### PR TITLE
Fix PDO_OCI UTF-8 output truncated

### DIFF
--- a/ext/pdo_oci/oci_statement.c
+++ b/ext/pdo_oci/oci_statement.c
@@ -528,8 +528,8 @@ static int oci_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC) /* {{{ */
 	STMT_CALL_MSG(OCIAttrGet, "OCI_ATTR_NAME",
 			(param, OCI_DTYPE_PARAM, &colname, &namelen, OCI_ATTR_NAME, S->err));
 
-	col->precision = scale;
-	col->maxlen = data_size;
+	col->precision = scale;	
+	col->maxlen = ( data_size + 1 ) * sizeof(utext);
 	col->namelen = namelen;
 	col->name = estrndup((char *)colname, namelen);
 


### PR DESCRIPTION
Fix annoying "column 0 data was too large for buffer and was truncated to fit it" message with utf-8 in pdo_oci
