### PR TITLE
Meaningful data type for _parameter_reference's "required" field 

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1980,7 +1980,7 @@ ZEND_METHOD(reflection_function, returnsReference)
 /* }}} */
 
 /* {{{ proto public bool ReflectionFunction::getNumberOfParameters()
-   Gets the number of required parameters */
+   Gets the total number of parameters */
 ZEND_METHOD(reflection_function, getNumberOfParameters)
 {
 	reflection_object *intern;


### PR DESCRIPTION
Hi.

The aim of this patch is to fix a problem related to the _parameter_reference
structure and its `required` field.

[The `required` field](http://lxr.php.net/opengrok/xref/PHP_5_4/ext/reflection/php_reflection.c#192), until now, stored how many required parameters the function, it belongs to, has. I think this is rather problematic because it's a feature of the function to know how many required parameters it has, not of the parameter itself. The parameter should only say if it's required or optional (among other unrelated things).

Also storing the function's number of required parameters in every parameter was redundant since the [_zend_function structure](http://lxr.php.net/xref/PHP_5_4/Zend/zend_compile.h#zend_function) already has that information. And storing the same value (number of required parameters) across multiple variables is inefficient and could lead to inconsistencies.

So I tried to solve this problem by declaring the `required` field as `zend_bool` (see 7fe93ca66dd806a197).

While working on this I noticed some inconsistency between a comment and the code, bb59a5f5256df4d2e6.

I also updated the related reflection tests and everything seems ok (59fa4989f2ebb8d0).

While updating the tests I noticed a duplicate so I deleted it, see f613f01157abfc495.

Finally I thought `var_dump()` calls on a `ReflectionParameter` must be consistent with `echo` and `print` so I came up with db3c26b4e62361a.

PS:
You can assign the above stated problem with the following analogy.
A vehicle must know about its number of required or optional (in case of flats) wheels (parameters), the wheel itself should not know how many of it it takes to assemble the vehicle(the function) in order to run.
It only says that it's required when it's assembled on the vehicle and optional when serving as a back up wheel.
