### PR TITLE
Allow resetting error handler (#60738)

### DIFF
--- a/Zend/tests/bug60738.phpt
+++ b/Zend/tests/bug60738.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #60738 Allow 'set_error_handler' to handle NULL
+--FILE--
+<?php
+
+set_error_handler(function() { echo 'Intercepted error!', "\n"; });
+
+trigger_error('Error!');
+
+set_error_handler(null);
+
+trigger_error('Error!');
+?>
+--EXPECTF--
+Intercepted error!
+
+Notice: Error! in %s on line %d

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1520,13 +1520,15 @@ ZEND_FUNCTION(set_error_handler)
 		return;
 	}
 
-	if (!zend_is_callable(error_handler, 0, &error_handler_name TSRMLS_CC)) {
-		zend_error(E_WARNING, "%s() expects the argument (%s) to be a valid callback",
-				   get_active_function_name(TSRMLS_C), error_handler_name?error_handler_name:"unknown");
+	if (Z_TYPE_P(error_handler) != IS_NULL) { /* NULL == unset */
+		if (!zend_is_callable(error_handler, 0, &error_handler_name TSRMLS_CC)) {
+			zend_error(E_WARNING, "%s() expects the argument (%s) to be a valid callback",
+					   get_active_function_name(TSRMLS_C), error_handler_name?error_handler_name:"unknown");
+			efree(error_handler_name);
+			return;
+		}
 		efree(error_handler_name);
-		return;
 	}
-	efree(error_handler_name);
 
 	if (EG(user_error_handler)) {
 		had_orig_error_handler = 1;
@@ -1538,7 +1540,7 @@ ZEND_FUNCTION(set_error_handler)
 	}
 	ALLOC_ZVAL(EG(user_error_handler));
 
-	if (!zend_is_true(error_handler)) { /* unset user-defined handler */
+	if (Z_TYPE_P(error_handler) == IS_NULL) { /* unset user-defined handler */
 		FREE_ZVAL(EG(user_error_handler));
 		EG(user_error_handler) = NULL;
 		RETURN_TRUE;


### PR DESCRIPTION
This allows the error handler to be reset using `set_error_handler(null)`. As the code suggests this behavior was already previously intended, but the callback check was done too strictly.

See also bug https://bugs.php.net/bug.php?id=60738.

PS: I replaced the `!zend_is_true` with a strict null check to be consistent with the behavior of `set_exception_handler`.
