### PR TITLE
Improve building the LDAP and OCI8 extensions statically.

### DIFF
--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -15,6 +15,10 @@ AC_DEFUN([PHP_LDAP_CHECKS], [
     LDAP_DIR=$1
     LDAP_INCDIR=$1/ldap/public
     LDAP_LIBDIR=$1/$PHP_LIBDIR
+  elif test -f $1/sdk/include/ldap.h; then
+    LDAP_DIR=$1
+    LDAP_INCDIR=$1/sdk/include
+    LDAP_LIBDIR=$1
   fi
 ])
 
@@ -148,6 +152,8 @@ if test "$PHP_LDAP" != "no"; then
     AC_DEFINE(HAVE_ORALDAP,1,[ ])
     if test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.10.1; then
       AC_DEFINE(HAVE_ORALDAP_10,1,[ ])
+    elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.11.1; then
+      AC_DEFINE(HAVE_ORALDAP_11,1,[ ])
     fi
   else
     AC_MSG_ERROR(Cannot find ldap libraries in $LDAP_LIBDIR.)

--- a/ext/ldap/php_ldap.h
+++ b/ext/ldap/php_ldap.h
@@ -23,7 +23,7 @@
 #ifndef PHP_LDAP_H
 #define PHP_LDAP_H
 
-#ifndef HAVE_ORALDAP
+#if !defined(HAVE_OCI8) && !defined(HAVE_ORALDAP)
 #include <lber.h>
 #endif
 


### PR DESCRIPTION
Allows the LDAP extension to link with the Oracle Instant Client ZIP
file library LDAP implementation, e.g. using
--with-ldap=/path/to/instantclient.  (Does not support building with
Instant Client RPMS.)

Allows the LDAP and OCI8 extensions to be statically built when not
passing a directory to --with-ldap.  However this uses Oracle ldap.h
headers but doesn't use Oracle's LDAP implementation.  A preferred
user build scenario is to build PHP without OCI8, and then build OCI8
as a shared extension.
