### PR TITLE
- fix bug #61541, Segfault when using ob_* in output_callback

### DIFF
--- a/main/output.c
+++ b/main/output.c
@@ -225,6 +225,17 @@ PHPAPI void php_end_ob_buffer(zend_bool send_buffer, zend_bool just_flush TSRMLS
 		zval *orig_buffer;
 		zval *z_status;
 
+		if(OG(ob_lock)) {
+			if (SG(headers_sent) && !SG(request_info).headers_only) {
+				OG(php_body_write) = php_ub_body_write_no_header;
+			} else {
+				OG(php_body_write) = php_ub_body_write;
+			}
+			OG(ob_nesting_level) = 0;
+			php_error_docref("ref.outcontrol" TSRMLS_CC, E_ERROR, "Cannot use output buffering in output buffering display handlers");
+			return;
+		}
+
 		ALLOC_INIT_ZVAL(orig_buffer);
 		ZVAL_STRINGL(orig_buffer, OG(active_ob_buffer).buffer, OG(active_ob_buffer).text_length, 1);
 

--- a/tests/output/ob_011.phpt
+++ b/tests/output/ob_011.phpt
@@ -1,7 +1,5 @@
 --TEST--
 output buffering - fatalism
---XFAIL--
-This test will fail until the fix in revision r214155 is backported from php 6
 --FILE--
 <?php
 function obh($s)


### PR DESCRIPTION
@see tests/output/ob_011.phpt  there is a XFAIL

In PHP5.4 using ob_\* functions in output_callback will issue Fatal error, but in 5.3 only calling ob_start() function will raise Fatal error ,but calling ob_clean/flush\* functions will cause Segfault because of the endless recurse function call. 

maybe the patch isn't perfect, please don't hesitate to let me know.
