### PR TITLE
Cleanup Safe Mode related comment in SG(request_info)

### DIFF
--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -105,7 +105,6 @@ typedef struct {
 	/* this is necessary for the CGI SAPI module */
 	char *argv0;
 
-	/* this is necessary for Safe Mode */
 	char *current_user;
 	int current_user_length;
 


### PR DESCRIPTION
Since Safe mode have been remove completely. then this comment is useless.
