### PR TITLE
Fixed bug #61605 header_remove() does not remove all headers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ PHP                                                                        NEWS
 (merge after 5.3.11 release)
 
 - Core:
+  . Fixed bug #61605 header_remove() does not remove all headers. (Reeze)
   . Fixed bug #61273 (call_user_func_array with more than 16333 arguments
     leaks / crashes). (Laruence)
   . Fixed bug #61165 (Segfault - strip_tags()). (Laruence)

--- a/sapi/cgi/tests/bug61605.phpt
+++ b/sapi/cgi/tests/bug61605.phpt
@@ -1,0 +1,61 @@
+--TEST--
+header_remove() should handle multiple same key headers
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+include "include.inc";
+
+$php = get_cgi_path();
+reset_env_vars();
+
+$f = tempnam(sys_get_temp_dir(), 'cgitest');
+
+function test($script) {
+	file_put_contents($GLOBALS['f'], $script);
+	$cmd = escapeshellcmd($GLOBALS['php']);
+	$cmd .= ' -n -dreport_zend_debug=0 -dhtml_errors=0 ' . escapeshellarg($GLOBALS['f']);
+	echo "----------\n";
+	echo rtrim($script) . "\n";
+	echo "----------\n";
+	passthru($cmd);
+}
+
+test('<?php
+header("X-Foo: Bar");
+header("X-Foo: Bar2", false);
+
+header_remove("X-Foo");
+?>');
+
+test('<?php
+header("X-Foo: Bar");
+header("X-Foo: Baz", false);
+header("X-Foo: Baz2");
+?>');
+
+@unlink($f);
+?>
+--EXPECTF--
+----------
+<?php
+header("X-Foo: Bar");
+header("X-Foo: Bar2", false);
+
+header_remove("X-Foo");
+?>
+----------
+X-Powered-By: PHP/%s
+Content-type: text/html
+
+----------
+<?php
+header("X-Foo: Bar");
+header("X-Foo: Baz", false);
+header("X-Foo: Baz2");
+?>
+----------
+X-Powered-By: PHP/%s
+X-Foo: Baz2
+Content-type: text/html


### PR DESCRIPTION
Hi, 
   after looking at the code,I found that SAPI it self did't handle multiple headers properly, apache2handler handles it for itself. so apache2handler can remove it correctly.

   SAPI headers are saved in zend_llist. when try to remove or replace it simply try to find the first one it found and stop searching. I've looked at sapi/cli&cgi they both didn't handle it itself.
   Sine header() doc says: "The optional replace parameter indicates whether the header should replace a previous similar header". but it did't behavior like this.
    So I made a patch for this. can someone review this pull request for me?

Thanks
