### PR TITLE
Patch for bug #61660 

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -13,7 +13,7 @@
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
    | Authors: Rasmus Lerdorf <rasmus@php.net>                             |
-   |          Stig S�ther Bakken <ssb@php.net>                            |
+   |          Stig Sæther Bakken <ssb@php.net>                            |
    |          Zeev Suraski <zeev@zend.com>                                |
    +----------------------------------------------------------------------+
  */
@@ -153,7 +153,7 @@ static char *php_hex2bin(const unsigned char *old, const size_t oldlen, size_t *
 	size_t target_length = oldlen >> 1;
 	register unsigned char *str = (unsigned char *)safe_emalloc(target_length, sizeof(char), 1);
 	size_t i, j;
-	// if we have an odd length, point to the end of the string to distinguish the special case
+	/* if we have an odd length, point to the end of the string to distinguish the special case */
 	j = oldlen & 1 == 0 ? 0 : oldlen + 1;
 	for (i = 0; i < target_length; i++) {
 		char c = old[j++];
@@ -164,7 +164,7 @@ static char *php_hex2bin(const unsigned char *old, const size_t oldlen, size_t *
 		} else if (c >= 'A' && c <= 'F') {
 			str[i] = (c - 'A' + 10) << 4;
 		} else if(c == '\0') {
-			// odd length, put the first 4 bits to 0 and restart at the beginning of the string
+			/* odd length, put the first 4 bits to 0 and restart at the beginning of the string */
 			str[i] = 0;
 			j = 0;
  		} else {


### PR DESCRIPTION
This is a patch for : https://bugs.php.net/bug.php?id=61660

I'm the one who reported the bug and I tested the patch in the particular case which led to his discovery.

Their can still be a problem with `bin2hex`. The reverse function is not aware of left padded values and thus return '01234' for example which can lead to some problems like stated by laruence in the bug comments.

I think `bin2hex` should also be patched to remove any leading 0s in the binary representation before converting it, but this is out of the scope of my patch and needs discussion.
