### PR TITLE
Patch for bug #61660

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -154,7 +154,7 @@ static char *php_hex2bin(const unsigned char *old, const size_t oldlen, size_t *
 	register unsigned char *str = (unsigned char *)safe_emalloc(target_length, sizeof(char), 1);
 	size_t i, j;
 	/* if we have an odd length, point to the end of the string to distinguish the special case */
-	j = oldlen & 1 ? oldlen + 1: 0;
+	j = oldlen & 1 ? oldlen : 0;
 	for (i = 0; i < target_length; i++) {
 		char c = old[j++];
 		if (c >= '0' && c <= '9') {


### PR DESCRIPTION
This is a patch for : https://bugs.php.net/bug.php?id=61660

I'm the one who reported the bug and I tested the patch in the particular case which led to his discovery.

Their can still be a problem with bin2hex. The reverse function is not aware of left padded values and thus return '012345' for example which can lead to some problems like stated by laruence in the bug comments.

I think bin2hex should also be patched to remove any leading 0s in the binary representation before converting it, but this is out of the scope of my patch and needs discussion.
