### PR TITLE
Apostrophe modifier in *printf is broken Bug #61532

### DIFF
--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -469,7 +469,7 @@ php_formatted_print(int ht, int *len, int use_array, int format_offset TSRMLS_DC
 							  "sprintf: now looking at '%c', inpos=%d\n",
 							  format[inpos], inpos));
 				for (;; inpos++) {
-					if (format[inpos] == ' ' || format[inpos] == '0') {
+					if ((format[inpos] == ' ' || format[inpos] == '0') && padding = ' ') {
 						padding = format[inpos];
 					} else if (format[inpos] == '-') {
 						alignment = ALIGN_LEFT;

--- a/ext/standard/tests/strings/bug61532.phpt
+++ b/ext/standard/tests/strings/bug61532.phpt
@@ -1,0 +1,10 @@
+--TEST--
+printf custom padding modiffier bug #61532
+--FILE--
+<?php
+printf("%'.9s\n","foo");
+printf("%'.09s\n","foo");
+?>
+--EXPECT--
+......foo
+......foo


### PR DESCRIPTION
This is a fix for Bug #61532.

Expected result was that printf/sprint does not change the custom padding modifier after it has been clearly specified as '.' with a 0 in printf("%'.09"); // for example. The suggested fix is to prevent the padding modifier from being overwritten by doing an extra check that it is still not the default initialized value of ' '.
