### PR TITLE
Bug Fix for bug#61537 json_encode() incorrectly truncates/discards infor...

### DIFF
--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -571,9 +571,14 @@ static PHP_FUNCTION(json_encode)
 
 	php_json_encode(&buf, parameter, options TSRMLS_CC);
 
-	ZVAL_STRINGL(return_value, buf.c, buf.len, 1);
-
-	smart_str_free(&buf);
+	/* If an error is still present we must return false as per the documented behavior */
+	if (JSON_G(error_code) != PHP_JSON_ERROR_NONE) {
+		smart_str_free(&buf);
+		RETURN_FALSE;
+	} else { /* Otherwise we can safely return the json */
+		RETVAL_STRINGL(buf.c, buf.len, 1);
+		smart_str_free(&buf);
+	}
 }
 /* }}} */
 

--- a/ext/json/tests/bug61537.phpt
+++ b/ext/json/tests/bug61537.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #61537 (json_encode() incorrectly truncates/discards information)
+--SKIPIF--
+<?php if (!extension_loaded("json")) print "skip"; ?>
+--FILE--
+<?php
+$a = null;
+$b = "\xff";
+
+var_dump(json_encode($a), json_last_error(), json_encode($b), json_last_error());
+?>
+--EXPECT--
+string(4) "null"
+int(0)
+bool(false)
+int(5)


### PR DESCRIPTION
...mation

json_encode() will now always return bool(false) if an error is present
