### PR TITLE
Bug #61660 bin2hex(hex2bin($data)) != $data

### DIFF
--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -162,6 +162,8 @@ PHPAPI char *php_strerror(int errnum);
 # endif
 #endif
 
+#define PHP_HEX2BIN_PARTIAL_OUTPUT_ON_ERROR	1<<1
+
 void register_string_constants(INIT_FUNC_ARGS);
 
 #endif /* PHP_STRING_H */

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -87,6 +87,7 @@ void register_string_constants(INIT_FUNC_ARGS)
 	REGISTER_LONG_CONSTANT("PATHINFO_BASENAME", PHP_PATHINFO_BASENAME, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("PATHINFO_EXTENSION", PHP_PATHINFO_EXTENSION, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("PATHINFO_FILENAME", PHP_PATHINFO_FILENAME, CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("HEX2BIN_PARTIAL_OUTPUT_ON_ERROR", PHP_HEX2BIN_PARTIAL_OUTPUT_ON_ERROR, CONST_CS | CONST_PERSISTENT);
 
 #ifdef HAVE_LOCALECONV
 	/* If last members of struct lconv equal CHAR_MAX, no grouping is done */
@@ -148,7 +149,7 @@ static char *php_bin2hex(const unsigned char *old, const size_t oldlen, size_t *
 
 /* {{{ php_hex2bin
  */
-static char *php_hex2bin(const unsigned char *old, const size_t oldlen, size_t *newlen)
+static char *php_hex2bin(const unsigned char *old, const size_t oldlen, size_t *newlen, int options TSRMLS_DC)
 {
 	size_t target_length = oldlen >> 1;
 	register unsigned char *str = (unsigned char *)safe_emalloc(target_length, sizeof(char), 1);
@@ -254,24 +255,24 @@ PHP_FUNCTION(bin2hex)
 }
 /* }}} */
 
-/* {{{ proto string hex2bin(string data)
+/* {{{ proto string hex2bin(string data, [int options])
    Converts the hex representation of data to binary */
 PHP_FUNCTION(hex2bin)
 {
 	char *result, *data;
 	size_t newlen;
-	int datalen;
+	int datalen, options = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &datalen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|l", &data, &datalen, &options) == FAILURE) {
 		return;
 	}
 
-	if (datalen % 2 != 0) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Hexadecimal input string must have an even length");
+	if ((datalen % 2 != 0 || datalen == 0) && options ^ PHP_HEX2BIN_PARTIAL_OUTPUT_ON_ERROR) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Hexadecimal input string must have an even length and cannot be empty");
 		RETURN_FALSE;
 	}
 
-	result = php_hex2bin((unsigned char *)data, datalen, &newlen);
+	result = php_hex2bin((unsigned char *)data, datalen, &newlen, options TSRMLS_CC);
 
 	if (!result) {
 		RETURN_FALSE;

--- a/ext/standard/tests/strings/bug61660.phpt
+++ b/ext/standard/tests/strings/bug61660.phpt
@@ -4,8 +4,10 @@ Bug #61660: bin2hex(hex2bin($data)) != $data
 <?php
 
 var_dump(hex2bin('123'));
+var_dump(hex2bin('123', HEX2BIN_PARTIAL_OUTPUT_ON_ERROR));
 
 ?>
 --EXPECTF--
-Warning: hex2bin(): Hexadecimal input string must have an even length in %s on line %d
+Warning: hex2bin(): Hexadecimal input string must have an even length and cannot be empty in %s on line %d
 bool(false)
+string(1) ""


### PR DESCRIPTION
This bug fix now introduces a second optional argument to hex2bin that will comply with BC.
Additionally, the patch prevents an empty string from being accepted (as the existing patch did not).
