### PR TITLE
Allow arbitrary expressions for empty()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ PHP                                                                        NEWS
   . World domination
   . Improve set_exception_handler while doing reset.(Laruence)
   . Support constant array/string dereferencing. (Laruence)
+  . Add support for using empty() on the result of function calls and
+    other expressions (https://wiki.php.net/rfc/empty_isset_exprs).
+    (Nikita Popov)
 
 - Core:
   . Fixed bug #61681 (Malformed grammar). (Nikita Popov, Etienne, Laruence).

--- a/UPGRADING
+++ b/UPGRADING
@@ -28,6 +28,9 @@ PHP X.Y UPGRADE NOTES
 
 - Support constant array/string dereferencing. (Laruence)
   (https://wiki.php.net/rfc/constdereference)
+- Add support for using empty() on the result of function calls and
+  other expressions. Thus it is now possible to write empty(getArray()),
+  for example. (https://wiki.php.net/rfc/empty_isset_exprs)
 
 ========================================
 2. Changes in SAPI modules
@@ -51,7 +54,7 @@ PHP X.Y UPGRADE NOTES
   - Implemented format character "Z": NUL-padded string
   - "a" now does not remove trailing NUL characters on unpack() anymore
   - "A" will now strip all trailing ASCII whitespace on unpack() (it used to
-    remove only trailing spaces.
+    remove only trailing spaces)
 
 ========================================
 5. New Functions

--- a/Zend/tests/empty_with_expr.phpt
+++ b/Zend/tests/empty_with_expr.phpt
@@ -1,0 +1,32 @@
+--TEST--
+empty() with arbitrary expressions
+--FILE--
+<?php
+
+function getEmptyArray() { return []; }
+function getNonEmptyArray() { return [1, 2, 3]; }
+
+var_dump(empty([]));
+var_dump(empty([1, 2, 3]));
+
+var_dump(empty(getEmptyArray()));
+var_dump(empty(getNonEmptyArray()));
+
+var_dump(empty([] + []));
+var_dump(empty([1, 2, 3] + []));
+
+var_dump(empty("string"));
+var_dump(empty(""));
+var_dump(empty(true));
+var_dump(empty(false));
+--EXPECT--
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(false)
+bool(true)
+bool(false)
+bool(true)

--- a/Zend/tests/isset_expr_error.phpt
+++ b/Zend/tests/isset_expr_error.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Error message for isset(func())
+--FILE--
+<?php
+isset(1 + 1);
+?>
+--EXPECTF--
+Fatal error: Cannot use isset() on the result of an expression (you can use "null !== expression" instead) in %s on line %d

--- a/Zend/tests/isset_func_error.phpt
+++ b/Zend/tests/isset_func_error.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Error message for isset(func())
+--FILE--
+<?php
+isset(abc());
+?>
+--EXPECTF--
+Fatal error: Cannot use isset() on the result of a function call (you can use "null !== func()" instead) in %s on line %d


### PR DESCRIPTION
Patch for https://wiki.php.net/rfc/empty_isset_exprs.
