### PR TITLE
Fixed bug #60106 test bug by increasing log_errors_max_len

### DIFF
--- a/ext/standard/tests/streams/bug60106.phpt
+++ b/ext/standard/tests/streams/bug60106.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug#60106 (stream_socket_server silently truncates long unix socket paths)
+--INI--
+log_errors_max_len=4200
 --SKIPIF--
 <?php
 if( substr(PHP_OS, 0, 3) == "WIN" )


### PR DESCRIPTION
Hi, 
    This bugfix(#60106)'s test failed because the default log_erros's buffer length is log_errors_max_len=1024.
but this test output 4086+13 bytes. then some 'a's are missing. so the test failed.
    in this bug https://bugs.php.net/bug.php?id=61518 mattficken@php.net mention it too.

Thanks.
