### PR TITLE
Update to 5.4.2-dev

### DIFF
--- a/main/php_version.h
+++ b/main/php_version.h
@@ -2,7 +2,7 @@
 /* edit configure.in to change version number */
 #define PHP_MAJOR_VERSION 5
 #define PHP_MINOR_VERSION 4
-#define PHP_RELEASE_VERSION 1
-#define PHP_EXTRA_VERSION "RC1-dev"
-#define PHP_VERSION "5.4.1RC1-dev"
-#define PHP_VERSION_ID 50401
+#define PHP_RELEASE_VERSION 2
+#define PHP_EXTRA_VERSION "-dev"
+#define PHP_VERSION "5.4.2-dev"
+#define PHP_VERSION_ID 50402


### PR DESCRIPTION
After PHP-5.4.1 was branched, the PHP-5.4 branch should have been 5.4.2-dev.
