### PR TITLE
Bug fix 61038 - pack/unpack implementation fix

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -182,6 +182,10 @@ PHP 5.4 UPGRADE NOTES
 4. Changes to existing functions
 ================================
 
+- pack/unpack will now implement format character Z: NULL-padded string
+  Z: will strip everything after the first null on unpack, a: does not strip,
+  A: will strip any trailing whitespace on unpack.
+
 - array_combine now returns array() instead of FALSE when two empty arrays are
   provided as parameters.
 

--- a/ext/standard/tests/strings/bug61038.phpt
+++ b/ext/standard/tests/strings/bug61038.phpt
@@ -1,0 +1,37 @@
+--TEST--
+BugFix #61038
+--FILE--
+<?php
+	var_dump(unpack("Z4", pack("Z4", "foo")));
+	var_dump(unpack("a4", pack("a4", "foo")));
+	var_dump(unpack("A4", pack("A4", "foo")));
+	var_dump(unpack("a9", pack("a*", "foo\x00bar\x00 ")));
+	var_dump(unpack("A9", pack("a*", "foo\x00bar\x00 ")));
+	var_dump(unpack("Z9", pack("a*", "foo\x00bar\x00 ")));
+?>
+--EXPECTF--
+array(1) {
+  [1]=>
+  string(3) "foo"
+}
+array(1) {
+  [1]=>
+  string(4) "foo%c"
+}
+array(1) {
+  [1]=>
+  string(3) "foo"
+}
+array(1) {
+  [1]=>
+  string(9) "foo%cbar%c "
+}
+array(1) {
+  [1]=>
+  string(7) "foo%cbar"
+}
+array(1) {
+  [1]=>
+  string(3) "foo"
+}
+

--- a/ext/standard/tests/strings/unpack_error.phpt
+++ b/ext/standard/tests/strings/unpack_error.phpt
@@ -19,7 +19,7 @@ var_dump(unpack("I", pack("I", 65534), $extra_arg));
 
 echo "\n-- Testing unpack() function with invalid format character --\n";
 $extra_arg = 10;
-var_dump(unpack("Z", pack("I", 65534)));
+var_dump(unpack("G", pack("I", 65534)));
 ?>
 ===DONE===
 --EXPECTF--
@@ -37,6 +37,6 @@ NULL
 
 -- Testing unpack() function with invalid format character --
 
-Warning: unpack(): Invalid format type Z in %s on line %d
+Warning: unpack(): Invalid format type G in %s on line %d
 bool(false)
 ===DONE===


### PR DESCRIPTION
Added new "Z" argument to pack/unpack, now allowing "a" to return
data without stripping, and "A" strips all trailing white space,
while "Z" will strip everything after the first null.
This also fixes bug 61038
