### PR TITLE
Fixed bug #61546 functions related to current script failed when chdir() in cli sapi

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1073,7 +1073,7 @@ int main(int argc, char *argv[])
 		SG(request_info).argc=argc-php_optind+1;
 		arg_excp = argv+php_optind-1;
 		arg_free = argv[php_optind-1];
-		SG(request_info).path_translated = file_handle.filename;
+		SG(request_info).path_translated = tsrm_realpath(file_handle.filename, NULL TSRMLS_CC);
 		argv[php_optind-1] = file_handle.filename;
 		SG(request_info).argv=argv+php_optind-1;
 

--- a/sapi/cli/tests/bug61546.inc
+++ b/sapi/cli/tests/bug61546.inc
@@ -1,0 +1,10 @@
+<?php
+$func = $argv[1];
+
+var_dump(chdir(".."));
+
+if ($func == 'get_current_user') {
+	var_dump(get_current_user() !== "");
+} else {
+	var_dump($func() !== false);
+}

--- a/sapi/cli/tests/bug61546.phpt
+++ b/sapi/cli/tests/bug61546.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Bug #61546 (functions related to current script failed when chdir() in cli sapi)
+--FILE--
+<?php
+
+function test_func($func) {
+	$php = getenv("TEST_PHP_EXECUTABLE");
+	$test_file = pathinfo(__FILE__, PATHINFO_FILENAME) . '.inc';
+
+	$desc = array(
+		0 => STDIN,
+		1 => STDOUT,
+		2 => STDERR,
+	);
+
+	/*
+     * The auto test tool will pass absolute path of the current script to php,
+     * so use proc_open to execute script as relative filename.
+     */
+	proc_open("$php -n " . escapeshellarg($test_file) . " $func", $desc, $pipes, dirname(__FILE__));
+}
+
+test_func('get_current_user');
+test_func('getmyinode');
+test_func('getlastmod');
+
+/*
+ * getmyuid and getmygid will not be affected because those two functions have fallback
+ * when current script can't be found such as run as php -r. listed here just for testing
+ */
+test_func('getmyuid');
+test_func('getmygid');
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Hi, 
    in cli sapi  SG(request_info).path_translated is relative path. when chdir it will point to non-exists file.
in fastcgi and fpm they all point to absolute path. so I made this push request to fix this.

   this bug affect get_current_user(), getmyinode() and getlastmod().

thanks.
