### PR TITLE
Fix test for proc_nice: bsd ps command didn't support option -o "%p %n"

### DIFF
--- a/ext/standard/tests/general_functions/proc_nice_basic.phpt
+++ b/ext/standard/tests/general_functions/proc_nice_basic.phpt
@@ -13,7 +13,7 @@ if(!function_exists('proc_nice')) die("skip. proc_nice not available ");
 <?php
 	function getNice($id)
 	{
-		$res = shell_exec('ps -p ' . $id .' -o "%p %n"');
+		$res = shell_exec('ps -p ' . $id .' -o pid -o ni');
 		preg_match('/^\s*\w+\s+\w+\s*(\d+)\s+(\d+)/m', $res, $matches);
 		if (count($matches) > 2)
 			return $matches[2];


### PR DESCRIPTION
Hi, 
           In bsd based os, ps command didn't supprt option -o "%p %n":

ps: %p: keyword not found
ps: %n: keyword not found

but they all support -o pid -o ni.
