### PR TITLE
Fixed bug #61828 Memleak when calling Directory(Recursive)Iterator/Spl(T...

### DIFF
--- a/ext/spl/tests/bug61828.phpt
+++ b/ext/spl/tests/bug61828.phpt
@@ -1,7 +1,8 @@
 --TEST--
-Testing Directory(Recursive)Iterator/Spl(Temp)FileObject ctor twice
+Bug #61828 Directory(Recursive)Iterator/Spl(Temp)FileObject ctor twice cause memleak&segfault
 --FILE--
 <?php
+/* Leak testing */
 $x = new DirectoryIterator(".");
 $x->__construct("..");
 
@@ -14,13 +15,55 @@ $x->__construct("..");
 $x = new GlobIterator(".");
 $x->__construct("..");
 
-$x = new SplFileObject('.');
-$x->__construct('..');
+$x = new SplFileObject(__FILE__);
+$x->__construct(__FILE__);
 
 $x = new SplTempFileObject(1);
 $x->__construct(1);
 
-echo "done!\n";
+echo "DONE testing normal double construct\n";
+
+/*
+ * When trying to get debug info by convert to string it will segfault.
+ * So here we simply trigger it by type convertion
+ */
+$y = new DirectoryIterator(".");
+try {
+	$y->__construct("bug-path");
+} catch (Exception $e)
+{}
+(string)$y;
+
+$y = new RecursiveDirectoryIterator(".");
+try {
+	$y->__construct("bug-path");
+} catch (Exception $e)
+{}
+(string)$y;
+
+$y = new FilesystemIterator(".");
+try {
+	$y->__construct("bug-path");
+} catch (Exception $e)
+{}
+(string)$y;
+
+$y = new SplFileObject(__FILE__);
+try {
+	$y->__construct('bug-path');
+} catch (Exception $e)
+{}
+(string)$y;
+
+$y = new SplTempFileObject(1);
+try {
+	$y->__construct('bug-param');
+} catch (Exception $e)
+{}
+(string)$y;
+
+echo "DONE testing double construct with later one thrown exception\n";
 ?>
 --EXPECT--
-done!
+DONE testing normal double construct
+DONE testing double construct with later one thrown exception


### PR DESCRIPTION
Hi, 
  This memory leak is the same as  felipe ever fixed one:

commit af2fc625df1e05f712211f7c23d00120cbac731f
Author: Felipe Pena felipe@php.net
Date:   Sun Mar 11 15:42:57 2012 +0000

```
- Fixed memory leak when calling SplFileInfo's constructor twice
```

The bug affect those SPL classes:
- DirectoryIterator(".");
- RecursiveDirectoryIterator(".");
- FilesystemIterator(".");
- GlobIterator(".");
- SplFileObject('.');
- SplTempFileObject(1);

Hi, @felipensp  will you take a look at this pull request?

Thank you.
