### PR TITLE
Fix function proto comment typo for  ZEND_API void zend_user_it_invalidate_curren

### DIFF
--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -127,7 +127,7 @@ ZEND_API zval *zend_user_it_new_iterator(zend_class_entry *ce, zval *object TSRM
 }
 /* }}} */
 
-/* {{{ zend_user_it_dtor */
+/* {{{ zend_user_it_invalidate_current */
 ZEND_API void zend_user_it_invalidate_current(zend_object_iterator *_iter TSRMLS_DC)
 {
 	zend_user_iterator *iter = (zend_user_iterator*)_iter;


### PR DESCRIPTION
Hi, 

  it's not intentional for alias, am I right? since zend_user_it_invalidate_current marked
as ZEND_API.

/\* {{{ **zend_user_it_dtor** _/
ZEND_API void *_zend_user_it_invalidate_current*\* (zend_object_iterator *_iter TSRMLS_DC)

```
/* {{{ zend_user_it_dtor */
ZEND_API void zend_user_it_invalidate_current(zend_object_iterator *_iter TSRMLS_DC)
{
}
/* }}} */

/* {{{ zend_user_it_dtor */
static void zend_user_it_dtor(zend_object_iterator *_iter TSRMLS_DC)
{
}
/* }}} */
```
