### PR TITLE
Fixed bug #61936  ____executor_globals fails when EG/CG symbol may not visible

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,8 +1,8 @@
 define ____executor_globals
 	if basic_functions_module.zts
 		set $tsrm_ls = ts_resource_ex(0, 0)
-		set $eg = ((zend_executor_globals*) (*((void ***) $tsrm_ls))[executor_globals_id-1])
-		set $cg = ((zend_compiler_globals*) (*((void ***) $tsrm_ls))[compiler_globals_id-1])
+		set $eg = ((struct _zend_executor_globals*) (*((void ***) $tsrm_ls))[executor_globals_id-1])
+		set $cg = ((struct _zend_compiler_globals*) (*((void ***) $tsrm_ls))[compiler_globals_id-1])
 	else
 		set $eg = executor_globals
 		set $cg = compiler_globals


### PR DESCRIPTION
Hi, 
  I've fill bug ticket #61936 since @pierre says we need a bug ticket to record.
see:  https://bugs.php.net/bug.php?id=61936.

since struct _zend_executor_globals is always available so use this struct is more portable.

This affect any command defined need $eg such as print_ht print_cvs printzv etc..

BTW: This happened only in ZTS build and if you didn't call backtrace command.

Thanks。 
