### PR TITLE
Fixed Bug #61961 (file_get_content leaks when access empty file with max length

### DIFF
--- a/ext/standard/tests/file/bug61961.phpt
+++ b/ext/standard/tests/file/bug61961.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #61961 (file_get_contents() leaks when access empty file with max length)
+--FILE--
+<?php
+$tmp_empty_file = __FILE__ . ".tmp";
+file_put_contents($tmp_empty_file, "");
+
+var_dump(file_get_contents($tmp_empty_file, NULL, NULL, NULL, 10));
+unlink($tmp_empty_file);
+?>
+==DONE==
+--EXPECT--
+string(0) ""
+==DONE==

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1366,7 +1366,12 @@ PHPAPI size_t _php_stream_copy_to_mem(php_stream *src, char **buf, size_t maxlen
 			len += ret;
 			ptr += ret;
 		}
-		*ptr = '\0';
+		if (len) {
+			*ptr = '\0';
+		} else {
+			pefree(*buf, persistent);
+			*buf = NULL;
+		}
 		return len;
 	}
 


### PR DESCRIPTION
This fixed Bug https://bugs.php.net/bug.php?id=61961 

when using file_get_contents access an empty file with max length set will leak.

<?php
$tmp_empty_file = **FILE** . ".tmp";
file_put_contents($tmp_empty_file, "");

var_dump(file_get_contents($tmp_empty_file, NULL, NULL, NULL, 10));

[Sun May  6 18:11:17 2012]  Script:  '/Users/reeze/Opensource/php-src-
5.3/ext/standard/tests/file/bug61961.php'
/Users/reeze/Opensource/php-src-5.3/main/streams/streams.c(1360) :  Freeing 
0x10AB26F40 (11 bytes), script=/Users/reeze/Opensource/php-src-
5.3/ext/standard/tests/file/bug61961.php
/Users/reeze/Opensource/php-src-5.3/ext/standard/file.c(570) : Actual location 
(location was relayed)
=== Total 1 memory leaks detected ===
