### PR TITLE
Fix for bug #18556

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -1907,7 +1907,8 @@ ZEND_API char *zend_str_tolower_copy(char *dest, const char *source, unsigned in
 	register unsigned char *end = str + length;
 
 	while (str < end) {
-		*result++ = zend_tolower((int)*str++);
+		*result++ = (*str == 'I') ? 'i' : zend_tolower((int)*str);
+		str++;
 	}
 	*result = '\0';
 
@@ -1927,7 +1928,7 @@ ZEND_API void zend_str_tolower(char *str, unsigned int length) /* {{{ */
 	register unsigned char *end = p + length;
 
 	while (p < end) {
-		*p = zend_tolower((int)*p);
+		*p = (*p == 'I') ? 'i' : zend_tolower((int)*p);
 		p++;
 	}
 }


### PR DESCRIPTION
Patch to avoid locale-aware lowercasing for letter 'I' in zend_str_tolower() and friends.
