### PR TITLE
getfilesystemtime might  cause alignment faults on 64-bit Windows.

### DIFF
--- a/win32/time.c
+++ b/win32/time.c
@@ -46,7 +46,7 @@ ULARGE_INTEGER convFromft;
             
             via  http://technet.microsoft.com/zh-cn/library/ms724284%28v=vs.85%29.aspx
         */
-    //ff = *(__int64*)(&ft);
+
 	convFromft.HighPart=ft.dwHighDateTime;
 	convFromft.LowPart=ft.dwLowDateTime;
 	ff=convFromft.QuadPart;


### PR DESCRIPTION
http://technet.microsoft.com/en-us/library/ms724284%28v=vs.85%29.aspx

Do not cast a pointer to a FILETIME structure to either a ULARGE_INTEGER\* or __int64\* value because it can cause alignment faults on 64-bit Windows.
