### PR TITLE
function getfilesystemtime: change the way to convert FILE struct to __int64 

### DIFF
--- a/win32/time.c
+++ b/win32/time.c
@@ -1,4 +1,3 @@
-
 /*****************************************************************************
  *                                                                           *
  * DH_TIME.C                                                                 *
@@ -37,10 +36,21 @@ int getfilesystemtime(struct timeval *time_Info)
 {
 FILETIME ft;
 __int64 ff;
+ULARGE_INTEGER convFromft;
 
     GetSystemTimeAsFileTime(&ft);   /* 100 ns blocks since 01-Jan-1641 */
                                     /* resolution seems to be 0.01 sec */ 
-    ff = *(__int64*)(&ft);
+    /* ff = *(__int64*)(&ft); */
+    /*
+            Do not cast a pointer to a FILETIME structure to either a 
+            ULARGE_INTEGER* or __int64* value because it can cause alignment faults on 64-bit Windows.
+            
+            via  http://technet.microsoft.com/en-us/library/ms724284(v=vs.85).aspx
+     */
+    convFromft.HighPart = ft.dwHighDateTime;
+    convFromft.LowPart = ft.dwLowDateTime;
+    ff = convFromft.QuadPart;
+    
     time_Info->tv_sec = (int)(ff/(__int64)10000000-(__int64)11644473600);
     time_Info->tv_usec = (int)(ff % 10000000)/10;
     return 0;


### PR DESCRIPTION
The direct convert from FILE struct to __int64 is unsafe.

via http://technet.microsoft.com/en-us/library/ms724284(v=vs.85).aspx

"Do not cast a pointer to a FILETIME structure to either a 
ULARGE_INTEGER\* or __int64\* value because it can cause alignment faults on 64-bit Windows."

In my computer(windows 7 32bit), either way works fine. but i just believe it's necessary to avoid the Possible problems .

long long getfilesystemtime_old() 
{
FILETIME ft;
__int64 ff;
ULARGE_INTEGER convFromft;
    GetSystemTimeAsFileTime(&ft);  
    ff = _(__int64_)(&ft); 
    return ff;
}

long long  getfilesystemtime() 
{
FILETIME ft;
__int64 ff;
ULARGE_INTEGER convFromft;
    GetSystemTimeAsFileTime(&ft);  
    convFromft.HighPart=ft.dwHighDateTime;
    convFromft.LowPart=ft.dwLowDateTime;
    ff=convFromft.QuadPart;

```
return ff;
```

}

int _tmain(int argc, _TCHAR\* argv[])
{
    if(getfilesystemtime()==getfilesystemtime_old())
    {
        printf("good");
    }

}
