### PR TITLE
Fixed bug #61964 (finfo_open with directory cause invalid free)

### DIFF
--- a/ext/fileinfo/tests/bug61964.phpt
+++ b/ext/fileinfo/tests/bug61964.phpt
@@ -1,0 +1,69 @@
+--TEST--
+Bug #61964 (finfo_open with directory cause invalid free)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$magic_file = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'magic';
+
+$ret = @finfo_open(FILEINFO_NONE, $magic_file . ".non-exits");
+var_dump($ret);
+
+$dir = __DIR__ . "/test-folder";
+@mkdir($dir);
+
+$magic_file_copy = $dir . "/magic.copy";
+$magic_file_copy2 = $magic_file_copy . "2";
+copy($magic_file, $magic_file_copy);
+copy($magic_file, $magic_file_copy2);
+
+$ret = finfo_open(FILEINFO_NONE, $dir);
+var_dump($ret);
+
+$ret = @finfo_open(FILEINFO_NONE, $dir);
+var_dump($ret);
+
+$ret = @finfo_open(FILEINFO_NONE, $dir. "/non-exits-dir");
+var_dump($ret);
+
+// write some test files to test folder
+file_put_contents($dir . "/test1.txt", "string\n> Core\n> Me");
+file_put_contents($dir . "/test2.txt", "a\nb\n");
+@mkdir($dir . "/test-inner-folder");
+
+finfo_open(FILEINFO_NONE, $dir);
+echo "DONE: testing dir with files\n";
+
+rmdir($dir . "/test-inner-folder");
+unlink($dir . "/test1.txt");
+unlink($dir . "/test2.txt");
+
+unlink($magic_file_copy);
+unlink($magic_file_copy2);
+rmdir($dir);
+?>
+===DONE===
+--EXPECTF--
+bool(false)
+resource(%d) of type (file_info)
+resource(%d) of type (file_info)
+bool(false)
+
+Notice: finfo_open(): Warning: offset `string' invalid in %sbug61964.php on line %d
+
+Notice: finfo_open(): Warning: offset ` Core' invalid in %sbug61964.php on line %d
+
+Notice: finfo_open(): Warning: type `Core' invalid in %sbug61964.php on line %d
+
+Notice: finfo_open(): Warning: offset `a' invalid in %sbug61964.php on line %d
+
+Notice: finfo_open(): Warning: type `a' invalid in %sbug61964.php on line %d
+
+Notice: finfo_open(): Warning: offset `b' invalid in %sbug61964.php on line %d
+
+Notice: finfo_open(): Warning: type `b' invalid in %sbug61964.php on line %d
+
+Warning: finfo_open(): Failed to load magic database at '%stest-folder'. in %sbug61964.php on line %d
+DONE: testing dir with files
+===DONE===


### PR DESCRIPTION
Hi, 
   we have been discuss this issue in irc, @laruence got some concern,  
then I sent a mail to the file lib author: Christos Zoulas christos@zoulas.com. 
he replied:

> > I got two question to ask:
> > 1. is _file_ intend to support dir?
> > 2. does the double free is bug?
> > Yes, yes, and I don't know what version you are using but the current version
> > does asprintf() not snprintf().

both 5.3&5.4 didn't use asprintf(), we use our memory management functions.

after got his reply  I think I can send this PR to ask you guys comment. 

Thanks.
