### PR TITLE
Fixed bug #62202 (ReflectionParameter::getDefaultValue() leaks with constand

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2397,6 +2397,7 @@ ZEND_METHOD(reflection_parameter, getDefaultValue)
 	reflection_object *intern;
 	parameter_reference *param;
 	zend_op *precv;
+	int type;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -2420,7 +2421,8 @@ ZEND_METHOD(reflection_parameter, getDefaultValue)
 
 	*return_value = precv->op2.u.constant;
 	INIT_PZVAL(return_value);
-	if (Z_TYPE_P(return_value) != IS_CONSTANT && Z_TYPE_P(return_value) != IS_CONSTANT_ARRAY) {
+	type = Z_TYPE_P(return_value);
+	if (type != IS_CONSTANT && type != IS_CONSTANT_ARRAY && type != (IS_CONSTANT | IS_CONSTANT_UNQUALIFIED)) {
 		zval_copy_ctor(return_value);
 	}
 	zval_update_constant_ex(&return_value, (void*)0, param->fptr->common.scope TSRMLS_CC);

--- a/ext/reflection/tests/bug62202.phpt
+++ b/ext/reflection/tests/bug62202.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #62202 (ReflectionParameter::getDefaultValue() leaks with constant)
+--FILE--
+<?php
+
+define('TEST_CONST', '10');
+
+class Foo {
+	public function bar($param = TEST_CONST) {
+		return $param;
+	}
+}
+
+$refl_method = new ReflectionMethod('Foo::bar');
+
+foreach ($refl_method->getParameters() as $param) {
+	if ($param->isDefaultValueAvailable()) {
+		var_dump($param->getDefaultValue());
+	}
+}
+?>
+--EXPECT--
+string(2) "10"


### PR DESCRIPTION
Hi,
  I found this leaks when testing reflection related functions.

This happend because when compiling constant zval.type will add IS_CONSTANT_UNQUALIFIED.

Thank:)
