### PR TITLE
Added recursivetreeiterator::setPostfix() method

### DIFF
--- a/ext/spl/tests/recursive_tree_iterator_setpostfix.phpt
+++ b/ext/spl/tests/recursive_tree_iterator_setpostfix.phpt
@@ -1,0 +1,88 @@
+--TEST--
+SPL: RecursiveTreeIterator::setPostfix()
+--CREDITS--
+Joshua Thijssen (jthijssen@noxlogic.nl)
+--FILE--
+<?php
+
+$arr = array(
+	0 => array(
+		"a",
+		1,
+	),
+	"a" => array(
+		2,
+		"b",
+		3 => array(
+			4,
+			"c",
+		),
+		"3" => array(
+			4,
+			"c",
+		),
+	),
+);
+
+$it = new RecursiveArrayIterator($arr);
+$it = new RecursiveTreeIterator($it);
+
+echo "----\n";
+echo $it->getPostfix();
+echo "\n\n";
+
+echo "----\n";
+$it->setPostfix("POSTFIX");
+echo $it->getPostfix();
+echo "\n\n";
+
+echo "----\n";
+foreach($it as $k => $v) {
+	echo "[$k] => $v\n";
+}
+
+echo "----\n";
+$it->setPostfix("");
+echo $it->getPostfix();
+echo "\n\n";
+
+echo "----\n";
+foreach($it as $k => $v) {
+	echo "[$k] => $v\n";
+}
+
+
+
+?>
+===DONE===
+--EXPECTF--
+----
+
+
+----
+POSTFIX
+
+----
+[0] => |-ArrayPOSTFIX
+[0] => | |-aPOSTFIX
+[1] => | \-1POSTFIX
+[a] => \-ArrayPOSTFIX
+[0] =>   |-2POSTFIX
+[1] =>   |-bPOSTFIX
+[3] =>   \-ArrayPOSTFIX
+[0] =>     |-4POSTFIX
+[1] =>     \-cPOSTFIX
+----
+
+
+----
+[0] => |-Array
+[0] => | |-a
+[1] => | \-1
+[a] => \-Array
+[0] =>   |-2
+[1] =>   |-b
+[3] =>   \-Array
+[0] =>     |-4
+[1] =>     \-c
+===DONE===


### PR DESCRIPTION
Added a recursivetreeiterator::setPostfix method since it was not present. The getPostFix() method returns the string as set through this method, and the current() method will add the postfix to the actual current value (as stated in the documentation). 
