### PR TITLE
Example test for Dutch PHP Conference 2012 TestFest

### DIFF
--- a/ext/posix/tests/posix_getegid_basic.phpt
+++ b/ext/posix/tests/posix_getegid_basic.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test function posix_getegid() by calling it with its expected arguments
+--CREDITS--
+Michelangelo van Dam dragonbe@gmail.com
+#PHPTestFest Dutch PHP Conference 2012
+--SKIPIF--
+<?php 
+        if(!extension_loaded("posix")) print "skip - POSIX extension not loaded"; 
+?>
+--FILE--
+<?php
+var_dump(posix_getegid());
+?>
+--EXPECTF--
+int(%d)


### PR DESCRIPTION
Today at the [Dutch PHP Conference 2012](http://phpconference.nl) Rasmus mentioned to test some more PHP core elements, so we suggested to run a PHP TestFest at the conference.

As an example I tested untested function posix_getegid and added the test to ext/posix/tests/posix_getegid_basic.phpt
