### PR TITLE
session.hash_bits_per_character = 6 results in urlencoded value

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -229,7 +229,7 @@ static void php_session_decode(const char *val, int vallen TSRMLS_DC) /* {{{ */
  * into URLs.
  */
 
-static char hexconvtab[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,-";
+static char hexconvtab[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-";
 
 enum {
 	PS_HASH_FUNC_MD5,


### PR DESCRIPTION
When using session.hash_bits_per_character = 6, the default charset contains a character (comma) that will always be urlencoded. This results in cookie values having unpredictable lengths by default. Also %2C in your session id is ugly.
