### PR TITLE
Change default value for PDO_Mysql driver ATTR_EMULATE_PREPARES to off

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -50,6 +50,9 @@ PHP                                                                        NEWS
   . Deprecated the /e modifier
     (https://wiki.php.net/rfc/remove_preg_replace_eval_modifier). (Nikita Popov)
 
+- PDO_MySQL:
+  . Changed default value for ATTR_EMULATE_PREPARES to 0. (Anthony Ferrara)
+
 - pgsql
   . Added pg_escape_literal() and pg_escape_identifier() (Yasuo)
 

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -587,7 +587,8 @@ static int pdo_mysql_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_
 	H->max_buffer_size = 1024*1024;
 #endif
 
-	H->buffered = H->emulate_prepare = 1;
+	H->buffered = 1;
+	H->emulate_prepare = 0;
 
 	/* handle MySQL options */
 	if (driver_options) {


### PR DESCRIPTION
This pull request changes the default value for PDO_Mysql to disable prepared statement emulation. It can still be turned on with `$pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true)`.

This fixes issue https://bugs.php.net/bug.php?id=54638

Quoting:

The PDO_MySQL driver defaults emulate_prepare to 1, which forces all prepared 
queries to be emulated by the driver.  This means that even though the client 
library (mysqlnd or libmysql) may support prepared statements, PDO will never 
really use them.

You can set the attribute PDO::ATTR_EMULATE_PREPARES to 0, and it prepares and 
executes the prepared statements just fine using the native mode (rather than 
emulation).  However this is not documented at all on PHP.NET.

Since PDO_MYSQL will fallback to emulation automatically if the client library or 
server are too old for prepared statements, I would suggest that the default 
value for emulate_prepare should be set to 0 to allow for true prepared 
statements.
