### PR TITLE
Prevent quoted_printable_encode from corrupting multibyte characters by splitting them between lines

### DIFF
--- a/ext/standard/quot_print.c
+++ b/ext/standard/quot_print.c
@@ -162,7 +162,10 @@ PHPAPI unsigned char *php_quot_print_encode(const unsigned char *str, size_t len
 			lp = 0;
 		} else {
 			if (iscntrl (c) || (c == 0x7f) || (c & 0x80) || (c == '=') || ((c == ' ') && (*str == '\015'))) {
-				if ((lp += 3) > PHP_QPRINT_MAXL) {
+				if ((((lp+= 3) > PHP_QPRINT_MAXL) && (c <= 0x7f)) 
+            || ((c > 0x7f) && (c <= 0xdf) && ((lp + 3) > PHP_QPRINT_MAXL)) 
+            || ((c > 0xdf) && (c <= 0xef) && ((lp + 6) > PHP_QPRINT_MAXL)) 
+            || ((c > 0xef) && (c <= 0xf4) && ((lp + 9) > PHP_QPRINT_MAXL))) {
 					*d++ = '=';
 					*d++ = '\015';
 					*d++ = '\012';


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=62462

`quoted_printable_encode` ignores multibyte characters when adding soft line breaks. If such break is inserted in the middle of multibyte char it corrupts the encoded string - this pull request fixes that.
