### PR TITLE
Fixed bug #62500 (Segfault in DateInterval class when extended)

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3511,6 +3511,11 @@ zval *date_interval_read_property(zval *object, zval *member, int type TSRMLS_DC
 
 	obj = (php_interval_obj *)zend_objects_get_address(object TSRMLS_CC);
 
+	if (!obj->initialized) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "The DateInterval object has not been correctly initialized by its constructor");
+		return EG(uninitialized_zval_ptr);
+	}
+
 #define GET_VALUE_FROM_STRUCT(n,m)            \
 	if (strcmp(Z_STRVAL_P(member), m) == 0) { \
 		value = obj->diff->n;                 \
@@ -3561,6 +3566,12 @@ void date_interval_write_property(zval *object, zval *member, zval *value TSRMLS
 		member = &tmp_member;
 	}
 	obj = (php_interval_obj *)zend_objects_get_address(object TSRMLS_CC);
+
+
+	if (!obj->initialized) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "The DateInterval object has not been correctly initialized by its constructor");
+		return;
+	}
 
 #define SET_VALUE_FROM_STRUCT(n,m)            \
 	if (strcmp(Z_STRVAL_P(member), m) == 0) { \

--- a/ext/date/tests/bug62500.phpt
+++ b/ext/date/tests/bug62500.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Bug #62500 (Segfault in DateInterval class when extended)
+--FILE--
+<?php
+class DateCrasher extends DateInterval {
+	public function __construct($time_spec) {
+		var_dump($this->y);
+		$this->y = 3;
+		var_dump($this->y);
+		parent::__construct($time_spec);
+	}
+}
+
+$c = new DateCrasher('P2Y4DT6H8M');
+var_dump($c);
+?>
+==DONE==
+--EXPECTF--
+Warning: DateCrasher::__construct(): The DateInterval object has not been correctly initialized by its constructor in %s on line %d
+NULL
+
+Warning: DateCrasher::__construct(): The DateInterval object has not been correctly initialized by its constructor in %s on line %d
+
+Warning: DateCrasher::__construct(): The DateInterval object has not been correctly initialized by its constructor in %s on line %d
+NULL
+object(DateCrasher)#1 (%d) {
+  ["y"]=>
+  int(2)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(4)
+  ["h"]=>
+  int(6)
+  ["i"]=>
+  int(8)
+  ["s"]=>
+  int(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+}
+==DONE==


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=62500

When accessing properties before DateIntervl initialized will cause segfault. 
other functions checked this situation but left property getter and setter function.
