### PR TITLE
Fix #49510: boolean validation fails with FILTER_NULL_ON_FAILURE

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -241,6 +241,9 @@ void php_filter_boolean(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 	 * returns false for "0", "false", "off", "no", and ""
 	 * null otherwise. */
 	switch (len) {
+		case 0:
+			ret = 0;
+			break;
 		case 1:
 			if (*str == '1') {
 				ret = 1;


### PR DESCRIPTION
Fix #49510: Fix empty strings validation (treat it as correct false value).
