### PR TITLE
#62489: dba_insert not working as expected

### DIFF
--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -88,15 +88,16 @@ DBA_UPDATE_FUNC(flatfile)
 	gval.dsize = vallen;
 	
 	switch(flatfile_store(dba, gkey, gval, mode==1 ? FLATFILE_INSERT : FLATFILE_REPLACE TSRMLS_CC)) {
-	case -1:
-		php_error_docref1(NULL TSRMLS_CC, key, E_WARNING, "Operation not possible");
-		return FAILURE;
-	default:
-	case 0:
-		return SUCCESS;
-	case 1:
-		php_error_docref1(NULL TSRMLS_CC, key, E_WARNING, "Key already exists");
-		return FAILURE;
+		case 0:
+			return SUCCESS;
+		case 1:
+			return FAILURE;
+		case -1:
+			php_error_docref1(NULL TSRMLS_CC, key, E_WARNING, "Operation not possible");
+			return FAILURE;
+		default:
+			php_error_docref2(NULL TSRMLS_CC, key, val, E_WARNING, "Unknown return value");
+			return FAILURE;
 	}
 }
 

--- a/ext/dba/dba_gdbm.c
+++ b/ext/dba/dba_gdbm.c
@@ -104,11 +104,18 @@ DBA_UPDATE_FUNC(gdbm)
 	gval.dptr = (char *) val;
 	gval.dsize = vallen;
 
-	if(gdbm_store(dba->dbf, gkey, gval, 
-				mode == 1 ? GDBM_INSERT : GDBM_REPLACE) == 0)
-		return SUCCESS;
-	php_error_docref2(NULL TSRMLS_CC, key, val, E_WARNING, "%s", gdbm_strerror(gdbm_errno));
-	return FAILURE;
+	switch (gdbm_store(dba->dbf, gkey, gval, mode == 1 ? GDBM_INSERT : GDBM_REPLACE)) {
+		case 0:
+			return SUCCESS;
+		case 1:
+			return FAILURE;
+		case -1:
+			php_error_docref2(NULL TSRMLS_CC, key, val, E_WARNING, "%s", gdbm_strerror(gdbm_errno));
+			return FAILURE;
+		default:
+			php_error_docref2(NULL TSRMLS_CC, key, val, E_WARNING, "Unknown return value");
+			return FAILURE;
+	}
 }
 
 DBA_EXISTS_FUNC(gdbm)

--- a/ext/dba/dba_inifile.c
+++ b/ext/dba/dba_inifile.c
@@ -101,7 +101,6 @@ DBA_UPDATE_FUNC(inifile)
 	case 0:
 		return SUCCESS;
 	case 1:
-		php_error_docref1(NULL TSRMLS_CC, key, E_WARNING, "Key already exists");
 		return FAILURE;
 	}
 }

--- a/ext/dba/dba_qdbm.c
+++ b/ext/dba/dba_qdbm.c
@@ -96,13 +96,15 @@ DBA_FETCH_FUNC(qdbm)
 DBA_UPDATE_FUNC(qdbm)
 {
 	QDBM_DATA;
-	int result;
-
-	result = dpput(dba->dbf, key, keylen, val, vallen, mode == 1 ? DP_DKEEP : DP_DOVER);
-	if (result)
+	
+	if (dpput(dba->dbf, key, keylen, val, vallen, mode == 1 ? DP_DKEEP : DP_DOVER)) {
 		return SUCCESS;
-
-	php_error_docref2(NULL TSRMLS_CC, key, val, E_WARNING, "%s", dperrmsg(dpecode));
+	}
+	
+	if (dpecode != DP_EKEEP) {
+		php_error_docref2(NULL TSRMLS_CC, key, val, E_WARNING, "%s", dperrmsg(dpecode));
+	}
+	
 	return FAILURE;
 }
 

--- a/ext/dba/tests/dba_db1.phpt
+++ b/ext/dba/tests/dba_db1.phpt
@@ -18,6 +18,8 @@ database handler: db1
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {
@@ -33,6 +35,8 @@ array(3) {
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_db2.phpt
+++ b/ext/dba/tests/dba_db2.phpt
@@ -18,6 +18,8 @@ database handler: db2
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {
@@ -33,6 +35,8 @@ array(3) {
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_db3.phpt
+++ b/ext/dba/tests/dba_db3.phpt
@@ -18,6 +18,8 @@ database handler: db3
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {
@@ -33,6 +35,8 @@ array(3) {
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_db4_000.phpt
+++ b/ext/dba/tests/dba_db4_000.phpt
@@ -22,6 +22,8 @@ database handler: db4
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {
@@ -37,6 +39,8 @@ array(3) {
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_dbm.phpt
+++ b/ext/dba/tests/dba_dbm.phpt
@@ -18,6 +18,8 @@ database handler: dbm
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {
@@ -33,6 +35,8 @@ array(3) {
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_flatfile.phpt
+++ b/ext/dba/tests/dba_flatfile.phpt
@@ -22,6 +22,8 @@ database handler: flatfile
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {
@@ -37,6 +39,8 @@ array(3) {
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_gdbm.phpt
+++ b/ext/dba/tests/dba_gdbm.phpt
@@ -21,6 +21,8 @@ database handler: gdbm
 Content String 2
 Content 2 replaced
 Read during write:%sallowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_handler.inc
+++ b/ext/dba/tests/dba_handler.inc
@@ -46,8 +46,16 @@ do {
 			echo "Read during write: allowed\n";
 		}
 		if ($db_writer!==FALSE) {
-			dba_insert("key number 6", "The 6th value", $db_writer);
-			@dba_insert("key number 6", "The 6th value inserted again would be an error", $db_writer);
+			if (dba_insert("key number 6", "The 6th value", $db_writer)) {
+				echo '"key number 6" written' . "\n";
+			} else {
+				echo 'Failed to write "key number 6"' . "\n";
+			}
+			if (dba_insert("key number 6", "The 6th value inserted again would be an error", $db_writer)) {
+				echo '"key number 6" written 2nd time' . "\n";
+			} else {
+				echo 'Failed to write "key number 6" 2nd time' . "\n";
+			}
 			dba_replace("key2", "Content 2 replaced 2nd time", $db_writer);
 			dba_delete("key4", $db_writer);
 			echo dba_fetch("key2", $db_writer)."\n";

--- a/ext/dba/tests/dba_inifile.phpt
+++ b/ext/dba/tests/dba_inifile.phpt
@@ -18,6 +18,8 @@ database handler: inifile
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {
@@ -33,6 +35,8 @@ array(3) {
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_ndbm.phpt
+++ b/ext/dba/tests/dba_ndbm.phpt
@@ -18,6 +18,8 @@ database handler: ndbm
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {
@@ -33,6 +35,8 @@ array(3) {
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_qdbm.phpt
+++ b/ext/dba/tests/dba_qdbm.phpt
@@ -19,6 +19,8 @@ database handler: qdbm
 Content String 2
 Content 2 replaced
 Read during write:%sallowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {

--- a/ext/dba/tests/dba_tcadb.phpt
+++ b/ext/dba/tests/dba_tcadb.phpt
@@ -22,6 +22,8 @@ database handler: tcadb
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {
@@ -37,6 +39,8 @@ array(3) {
 Content String 2
 Content 2 replaced
 Read during write: not allowed
+"key number 6" written
+Failed to write "key number 6" 2nd time
 Content 2 replaced 2nd time
 The 6th value
 array(3) {


### PR DESCRIPTION
removed warnings if dba_insert failed because of an already existing key.

fixed handlers are:
- flatfile
- gdbm
- inifile
- qdbm
