### PR TITLE
Dereferencing process-handles no longer waits on those processes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,4 +2,7 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? 201?, PHP 5.6.0
 
+- General improvements:
+  . Implemented FR #46487 (Dereferencing process-handles no longer waits on those processes). (Jille Timmermans)
+
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -159,6 +159,7 @@ static ZEND_RSRC_DTOR_FUNC(file_context_dtor)
 static void file_globals_ctor(php_file_globals *file_globals_p TSRMLS_DC)
 {
 	FG(pclose_ret) = 0;
+	FG(pclose_wait) = 0;
 	FG(user_stream_current_filename) = NULL;
 	FG(def_chunk_size) = PHP_SOCK_CHUNK_SIZE;
 	FG(wrapper_errors) = NULL;
@@ -960,7 +961,9 @@ PHP_FUNCTION(pclose)
 
 	PHP_STREAM_TO_ZVAL(stream, &arg1);
 
+	FG(pclose_wait) = 1;
 	zend_list_delete(stream->rsrc_id);
+	FG(pclose_wait) = 0;
 	RETURN_LONG(FG(pclose_ret));
 }
 /* }}} */

--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -115,7 +115,7 @@ typedef struct _php_meta_tags_data {
 php_meta_tags_token php_next_meta_token(php_meta_tags_data * TSRMLS_DC);
 
 typedef struct {
-  	int pclose_ret;
+	int pclose_ret;
 	size_t def_chunk_size;
 	long auto_detect_line_endings;
 	long default_socket_timeout;
@@ -126,6 +126,7 @@ typedef struct {
 	HashTable *stream_wrappers;			/* per-request copy of url_stream_wrappers_hash */
 	HashTable *stream_filters;			/* per-request copy of stream_filters_hash */
 	HashTable *wrapper_errors;			/* key: wrapper address; value: linked list of char* */
+	int pclose_wait;
 } php_file_globals;
 
 #ifdef ZTS

--- a/ext/standard/tests/general_functions/implicit_proc_close.phpt
+++ b/ext/standard/tests/general_functions/implicit_proc_close.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Implicit proc_close()s (by the GC) should not wait for the process to exit.
+--SKIPIF--
+<?php
+	if(!is_executable("/bin/sleep")) {
+		echo "skip";
+	}
+	if(!function_exists("proc_open")) {
+		echo "skip proc_open() is not available";
+	}
+?>
+--FILE--
+<?php
+	$descr = array(
+		0 => array("pipe", "r"),
+		1 => array("pipe", "w"),
+		2 => array("pipe", "w")
+	);
+
+	$ph = proc_open(
+		"/bin/sleep 2",
+		$descr,
+		$pipes
+	);
+	$t = microtime(true);
+	unset($ph);
+	$t = microtime(true) - $t;
+	if($t < 1) {
+		echo "Fast enough.\n";
+	} else {
+		var_dump($t);
+	}
+?>
+--EXPECT--
+Fast enough.


### PR DESCRIPTION
```
When handles created by proc_open() and popen() got destroyed they called waitpid() and waited for the process to exit. Now they only wait if they are explicitly closed with proc_close() or pclose().

Implements FR #46487
```

I will also send this over internals to be discussed.
