### PR TITLE
Fix test fails: ext/standard/tests/general_functions/bug27678.phpt

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1120,6 +1120,10 @@ static char *_php_math_number_format_ex_len(double d, int dec, char *dec_point,
 	tmplen = spprintf(&tmpbuf, 0, "%.*F", dec, d);
 
 	if (tmpbuf == NULL || !isdigit((int)tmpbuf[0])) {
+		if (result_len) {
+			*result_len = tmplen;
+		}
+
 		return tmpbuf;
 	}
 

--- a/ext/standard/tests/general_functions/bug27678.phpt
+++ b/ext/standard/tests/general_functions/bug27678.phpt
@@ -6,9 +6,11 @@ Bug #27678 (number_format() crashes with large numbers)
 number_format(1e80, 0, '', ' ');
 number_format(1e300, 0, '', ' ');
 number_format(1e320, 0, '', ' ');
-number_format(1e1000, 0, '', ' ');
+$num = number_format(1e1000, 0, '', ' ');
+var_dump(strlen($num) == 3); // $num == 'inf'
 
 echo "Done\n";
 ?>
 --EXPECT--	
+bool(true)
 Done


### PR DESCRIPTION
Hi, 
     After commit 3e62aae1, number_format()  set return string by length,
but _php_math_number_format_ex_len() didn't set the string length
on nan or inf. 
    https://github.com/php/php-src/commit/3e62aae1b456440328af4153524e22679b84f68a#L1R1258
when function _php_math_number_format_ex_len() return without set the length.  
the return value's string length is wild bits.   This _may_ cause segfault when destruct the return value.

@cataphract will you take a look? 

Thanks :)

```
Program received signal EXC_BAD_ACCESS, Could not access memory.
Reason: KERN_INVALID_ADDRESS at address: 0x000000015b278d8a
0x00000001004eef51 in _zval_dtor_func (zvalue=0x100cd2ea8, __zend_filename=0x1009ad298 "Zend//zend_execute.h", __zend_lineno=87)
    at zend_variables.c:35
35              CHECK_ZVAL_STRING_REL(zvalue);
(gdb) bt
#0  0x00000001004eef51 in _zval_dtor_func (zvalue=0x100cd2ea8, __zend_filename=0x1009ad298 "Zend//zend_execute.h", 
    __zend_lineno=87) at zend_variables.c:35
```
