### PR TITLE
Fixed bug #62460 (php binaries installed as binary.dSYM)

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1335,10 +1335,10 @@ PHP_CONFIGURE_PART(Configuring libtool)
 
 LDFLAGS="$LDFLAGS $PHP_AIX_LDFLAGS"
 
-dnl Autoconf 2.13's libtool checks go slightly nuts on Mac OS X 10.5 and 10.6.
+dnl Autoconf 2.13's libtool checks go slightly nuts on Mac OS X 10.5, 10.6, 10.7 and 10.8.
 dnl This hack works around it. Ugly.
 case $host_alias in
-*darwin9*|*darwin10*)
+*darwin9*|*darwin10*|*darwin11*|*darwin12*)
   ac_cv_exeext=
   ;;
 esac


### PR DESCRIPTION
Hi,
See this fix for autoconf for Mac OS X 10.5 & 10.6: http://marc.info/?l=php-cvs&m=125961714419896
but Mac OS X 10.7&10.8 affected too, It affect PHP-5.3 only(5.3 requires autoconf 2.13, 5.4 didn't).

see also: 
https://bugs.php.net/bug.php?id=62460  (10.8)
http://news.php.net/php.internals/61261 (10.7)

Thanks
