### PR TITLE
Added Bison 2.5.1 to bison_version_list

### DIFF
--- a/Zend/acinclude.m4
+++ b/Zend/acinclude.m4
@@ -4,7 +4,7 @@ dnl This file contains local autoconf functions.
 
 AC_DEFUN([LIBZEND_BISON_CHECK],[
   # we only support certain bison versions
-  bison_version_list="1.28 1.35 1.75 1.875 2.0 2.1 2.2 2.3 2.4 2.4.1 2.4.2 2.4.3 2.5"
+  bison_version_list="1.28 1.35 1.75 1.875 2.0 2.1 2.2 2.3 2.4 2.4.1 2.4.2 2.4.3 2.5 2.5.1"
 
   # for standalone build of Zend Engine
   test -z "$SED" && SED=sed


### PR DESCRIPTION
The latest stable version of GNU Bison is 2.5.1. But we cannot run PHP's buildconf.sh using Bison 2.5.1.
