### PR TITLE
Mcryptecb deprecated fix

### DIFF
--- a/ext/mcrypt/mcrypt.c
+++ b/ext/mcrypt/mcrypt.c
@@ -1317,6 +1317,8 @@ PHP_FUNCTION(mcrypt_ecb)
 	convert_to_long_ex(mode);
 
 	php_mcrypt_do_crypt(cipher, key, key_len, data, data_len, "ecb", iv, iv_len, ZEND_NUM_ARGS(), Z_LVAL_PP(mode), return_value TSRMLS_CC);
+
+	php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "This function is deprecated; use mcrypt_generic() or mdecrypt_generic() instead");
 }
 /* }}} */
 


### PR DESCRIPTION
This function has been documented as deprecated for some time (before E_DEPRECATED level errors were thrown). I'm adding this so the function throws an E_DEPRECATED level error from now on and will update the documentation accordingly so that I can also close Bug #62374
