### PR TITLE
Fixes mcrypt_ecb not issuing an E_DEPRECATED level notice

### DIFF
--- a/ext/mcrypt/mcrypt.c
+++ b/ext/mcrypt/mcrypt.c
@@ -1317,6 +1317,8 @@ PHP_FUNCTION(mcrypt_ecb)
 	convert_to_long_ex(mode);
 
 	php_mcrypt_do_crypt(cipher, key, key_len, data, data_len, "ecb", iv, iv_len, ZEND_NUM_ARGS(), Z_LVAL_PP(mode), return_value TSRMLS_CC);
+
+	php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "This function is deprecated; use mcrypt_generic() or mdecrypt_generic() instead");
 }
 /* }}} */
 


### PR DESCRIPTION
Fixes mcrypt_ecb not issuing an E_DEPRECATED level notice, despite having been deprecated for some time. Please reference bug #62374 as well.
