### PR TITLE
Fix failing test for umask() in 5.3

### DIFF
--- a/ext/standard/tests/file/umask_variation3.phpt
+++ b/ext/standard/tests/file/umask_variation3.phpt
@@ -110,7 +110,7 @@ foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
       umask(0);
       var_dump(umask($value));
-      var_dump( umask());
+      var_dump(umask() & 0777);
 };
 
 ?>


### PR DESCRIPTION
Test ext/standard/tests/file/umask_variation3.phpt fails in 5.3

In branch 5.4 this get fixed umask_variation3.phpt
 in commit https://github.com/php/php-src/commit/9eb5cb6571698ca1c623ad3e02c8727c4b0c9a09
but 5.3 didn't.
