### PR TITLE
Fixes mcrypt_ecb not issuing an E_DEPRECATED level notice

### DIFF
--- a/ext/mcrypt/mcrypt.c
+++ b/ext/mcrypt/mcrypt.c
@@ -238,7 +238,7 @@ ZEND_END_ARG_INFO()
 /* }}} */
 
 const zend_function_entry mcrypt_functions[] = { /* {{{ */
-	PHP_FE(mcrypt_ecb, 				arginfo_mcrypt_ecb)
+	PHP_DEP_FE(mcrypt_ecb, 				arginfo_mcrypt_ecb)
 	PHP_FE(mcrypt_cbc, 				arginfo_mcrypt_cbc)
 	PHP_FE(mcrypt_cfb, 				arginfo_mcrypt_cfb)
 	PHP_FE(mcrypt_ofb, 				arginfo_mcrypt_ofb)


### PR DESCRIPTION
Fixes mcrypt_ecb not issuing an E_DEPRECATED level notice, despite having been deprecated for some time. Please reference bug #62374 as well.
