### PR TITLE
Enable extension loading from .user.ini when run as CGI.

### DIFF
--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -709,8 +709,8 @@ void php_ini_register_extensions(TSRMLS_D)
 	zend_llist_apply(&extension_lists.engine, php_load_zend_extension_cb TSRMLS_CC);
 	zend_llist_apply(&extension_lists.functions, php_load_php_extension_cb TSRMLS_CC);
 
-	zend_llist_destroy(&extension_lists.engine);
-	zend_llist_destroy(&extension_lists.functions);
+	zend_llist_clean(&extension_lists.engine);
+	zend_llist_clean(&extension_lists.functions);
 }
 /* }}} */
 

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -818,6 +818,7 @@ static void php_cgi_ini_activate_user_config(char *path, int path_len, const cha
 
 	/* Activate ini entries with values from the user config hash */
 	php_ini_activate_config(entry->user_config, PHP_INI_PERDIR, PHP_INI_STAGE_HTACCESS TSRMLS_CC);
+	php_ini_register_extensions(TSRMLS_CC);
 }
 /* }}} */
 


### PR DESCRIPTION
Functionality is not included for other SAPIs because they either do not
support .user.ini (e.g. CLI) or they serve multiple requests and thus
do not support dl() (e.g. FastCGI).

There is also a bugfix to invoke zlist_clean, to ensure extension_lists can be
reused for the second round of extension appliations (since the head and tail
pointers have garbage in them).

Signed-off-by: Edward Z. Yang ezyang@mit.edu

(Available for PHP 5.3 too on request.)
