### PR TITLE
Bug 51363 var_export outputs an E_WARNING when recursion is detected

### DIFF
--- a/ext/standard/tests/general_functions/var_export_error2.phpt
+++ b/ext/standard/tests/general_functions/var_export_error2.phpt
@@ -15,4 +15,5 @@ var_export($obj, true);
 ===DONE===
 --EXPECTF--
 
-Fatal error: Nesting level too deep - recursive dependency? in %s on line 9
+Warning: var_export does not handle circular references in %s on line 9
+===DONE===

--- a/ext/standard/tests/general_functions/var_export_error3.phpt
+++ b/ext/standard/tests/general_functions/var_export_error3.phpt
@@ -15,4 +15,5 @@ var_export($a, true);
 ===DONE===
 --EXPECTF--
 
-Fatal error: Nesting level too deep - recursive dependency? in %s on line 9
+Warning: var_export does not handle circular references in %s on line 9
+===DONE===

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -453,6 +453,11 @@ PHPAPI void php_var_export_ex(zval **struc, int level, smart_str *buf TSRMLS_DC)
 		break;
 	case IS_ARRAY:
 		myht = Z_ARRVAL_PP(struc);
+		if(myht && myht->nApplyCount > 0){
+			smart_str_appendl(buf, "NULL", 4);
+			zend_error(E_WARNING, "var_export does not handle circular references");
+			return;
+		}
 		if (level > 1) {
 			smart_str_appendc(buf, '\n');
 			buffer_append_spaces(buf, level - 1);
@@ -469,6 +474,11 @@ PHPAPI void php_var_export_ex(zval **struc, int level, smart_str *buf TSRMLS_DC)
 
 	case IS_OBJECT:
 		myht = Z_OBJPROP_PP(struc);
+		if(myht && myht->nApplyCount > 0){
+			smart_str_appendl(buf, "NULL", 4);
+			zend_error(E_WARNING, "var_export does not handle circular references");
+			return;
+		}
 		if (level > 1) {
 			smart_str_appendc(buf, '\n');
 			buffer_append_spaces(buf, level - 1);


### PR DESCRIPTION
The documentation for var_export state that it does not handle circular references. However, var_export does not catch recursion. It leaves it to the zend hash functions to catch recursion. In here a E_ERROR is thrown when the recursive limit is hit.

This patch changes the var_export to detect recursion and throw a E_WARNING. E_WARNING was chosen b/c it is documented that var_export does not _handle_ recursion, but it does not say var_export will cause an E_ERROR. This also allows for user created error handlers to handle the situation.
