### PR TITLE
Make SUCCESS & FAILURE result codes strongly typed to avoid conflicts

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -276,10 +276,10 @@ static const char long_min_digits[] = "9223372036854775808";
 
 #define MAX_LENGTH_OF_DOUBLE 32
 
-#undef SUCCESS
-#undef FAILURE
-#define SUCCESS 0
-#define FAILURE -1				/* this MUST stay a negative number, or it may affect functions! */
+typedef enum {
+  SUCCESS =  0,
+  FAILURE = -1,		/* this MUST stay a negative number, or it may affect functions! */
+} RESULT_CODE;
 
 #include "zend_hash.h"
 #include "zend_ts_hash.h"


### PR DESCRIPTION
Currently SUCCESS & FAILURE codes are macros. These are reasonably common symbol names, and when integrating PHP with a large code base then conflicts can occur when the macros leak out of the local scope.
