### PR TITLE
Fix phpcredits() BC after remove Logo GUIDs

### DIFF
--- a/ext/standard/credits.c
+++ b/ext/standard/credits.c
@@ -27,6 +27,10 @@
 
 PHPAPI void php_print_credits(int flag TSRMLS_DC) /* {{{ */
 {
+	if (!sapi_module.phpinfo_as_text && flag & PHP_CREDITS_FULLPAGE) {
+		php_print_info_htmlhead(TSRMLS_C);
+	}
+
 	if (!sapi_module.phpinfo_as_text) {
 		PUTS("<h1>PHP Credits</h1>\n");
 	} else {
@@ -118,6 +122,10 @@ PHPAPI void php_print_credits(int flag TSRMLS_DC) /* {{{ */
 		/* Windows build boxes and such things */
 		CREDIT_LINE("Windows Infrastructure", "Alex Schoenmaker");
 		php_info_print_table_end();
+	}
+
+	if (!sapi_module.phpinfo_as_text && flag & PHP_CREDITS_FULLPAGE) {
+		PUTS("</div></body></html>\n");
 	}
 }
 /* }}} */

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -881,7 +881,7 @@ PHPAPI void php_print_info(int flag TSRMLS_DC)
 
 	if ((flag & PHP_INFO_CREDITS) && !sapi_module.phpinfo_as_text) {	
 		php_info_print_hr();
-		php_print_credits(PHP_CREDITS_ALL TSRMLS_CC);
+		php_print_credits(PHP_CREDITS_ALL & ~PHP_CREDITS_FULLPAGE TSRMLS_CC);
 	}
 
 	if (flag & PHP_INFO_LICENSE) {


### PR DESCRIPTION
This test was affected: ext/standard/tests/general_functions/phpcredits2.phpt

https://github.com/php/php-src/pull/132/files#diff-3
This makes constant PHP_CREDITS_FULLPAGE didn't functional anymore.
see: http://php.net/phpcredits

Hi, @TazeTSchnitzel   you might want to take a look at this :)
