### PR TITLE
Fix test failed ext/xmlrpc/tests/bug61264.phpt

### DIFF
--- a/ext/xmlrpc/tests/bug61264.phpt
+++ b/ext/xmlrpc/tests/bug61264.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #61264: xmlrpc_parse_method_descriptions leaks temporary variable
+--SKIPIF--
+<?php if (!extension_loaded("xmlrpc")) print "skip"; ?>
 --FILE--
 <?php
 $xml = <<<XML


### PR DESCRIPTION
This test failed because of it missing a skipif section 
