### PR TITLE
Zend: support relative paths for extensions

### DIFF
--- a/Zend/zend_extensions.c
+++ b/Zend/zend_extensions.c
@@ -20,6 +20,7 @@
 /* $Id$ */
 
 #include "zend_extensions.h"
+#include "php.h"
 
 ZEND_API zend_llist zend_extensions;
 static int last_resource_number;
@@ -30,8 +31,28 @@ int zend_load_extension(const char *path)
 	DL_HANDLE handle;
 	zend_extension *new_extension;
 	zend_extension_version_info *extension_version_info;
+	char *normalized_path;
+	char *extension_dir = INI_STR("extension_dir");
+	int extension_dir_len = strlen(extension_dir);
 
-	handle = DL_LOAD(path);
+	if (strchr(path, '/') == NULL || strchr(path, DEFAULT_SLASH) == NULL) {
+		if (extension_dir && extension_dir[0]) {
+			if (IS_SLASH(extension_dir[extension_dir_len-1])) {
+				spprintf(&normalized_path, 0, "%s%s", extension_dir, path);
+			} else {
+				spprintf(&normalized_path, 0, "%s%c%s", extension_dir, DEFAULT_SLASH, path);
+			}
+		} else {
+			return FAILURE;
+		}
+	} else {
+		normalized_path = estrdup(path);
+	}
+
+	handle = DL_LOAD(normalized_path);
+
+	efree(normalized_path);
+
 	if (!handle) {
 #ifndef ZEND_WIN32
 		fprintf(stderr, "Failed loading %s:  %s\n", path, DL_ERROR());


### PR DESCRIPTION
This would simplify greatly puppetization of Zend modules such as xdebug
in heterogeneous environments.

For example:
zend_extension="/usr/lib/php5/20090626/xdebug.so"
can become:
zend_extension=xdebug.so
