### PR TITLE
Skip tests rely on Zend MM turned on

### DIFF
--- a/ext/oci8/tests/pecl_bug10194_blob.phpt
+++ b/ext/oci8/tests/pecl_bug10194_blob.phpt
@@ -6,6 +6,9 @@ $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on t
 require(dirname(__FILE__).'/skipif.inc');
 if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platforms only");
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
+if (getenv("USE_ZEND_ALLOC") === "0") {
+    die("skip Zend MM disabled");
+}
 ?> 
 --INI--
 memory_limit=3M

--- a/ext/standard/tests/strings/str_pad_variation5.phpt
+++ b/ext/standard/tests/strings/str_pad_variation5.phpt
@@ -5,6 +5,9 @@ memory_limit=128M
 --SKIPIF--
 <?php
 if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only");
+if (getenv("USE_ZEND_ALLOC") === "0") {
+    die("skip Zend MM disabled");
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Those two tests have expect memory exhausted fatal error.

These two tests will failed when in memory check mode in 32bit system.
