### PR TITLE
Fix hashtable inconsist when specify an invalid path to ini: phar.cache_...

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -3751,8 +3751,6 @@ PHP_RINIT_FUNCTION(basic) /* {{{ */
 	/* Default to global filters only */
 	FG(stream_filters) = NULL;
 
-	FG(wrapper_errors) = NULL;
-
 	return SUCCESS;
 }
 /* }}} */

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -162,6 +162,7 @@ static void file_globals_ctor(php_file_globals *file_globals_p TSRMLS_DC)
 	FG(pclose_ret) = 0;
 	FG(user_stream_current_filename) = NULL;
 	FG(def_chunk_size) = PHP_SOCK_CHUNK_SIZE;
+	FG(wrapper_errors) = NULL;
 }
 
 static void file_globals_dtor(php_file_globals *file_globals_p TSRMLS_DC)


### PR DESCRIPTION
when specify an invalide phar.cache_list in PHP5.3 will report hashtable inconsist. 

$php -d phar.cache_list=/invalid a.php

The reason and the fix is almost the same as @laruence ever fixed bug#62597 (segfault in php_stream_wrapper_log_error with ZTS build) in PHP-5.4 e7535e06e63104ccc0c90c4425b6c2541aa3c939 .
but crash in different place. so I didn't fill a bug.  
either merge or cherry-pick from 5.4 are fine for me :)

BT:

```
Breakpoint 1, _php_stream_open_wrapper_ex (path=0x100d36838 "/a", mode=0x1009dde00 "rb", options=18, opened_path=0x7fff5fbfe528, context=0x0, __php_stream_call_depth=0, __zend_filename=0x1009e5ba0 "/Users/reeze/Opensource/php-test/php-src-5.3/ext/phar/phar.c", __zend_lineno=1503, __zend_orig_filename=0x0, __zend_orig_lineno=0, tsrm_ls=0x100e03a20) at streams.c:1936
1936        php_stream *stream = NULL;
(gdb) c
Continuing.

Breakpoint 2, php_stream_tidy_wrapper_error_log (wrapper=0x100a9a0a0, tsrm_ls=0x100e03a20) at streams.c:230
230     if (wrapper && FG(wrapper_errors)) {
(gdb) c
Continuing.
/Users/reeze/Opensource/php-test/php-src-5.3/Zend/zend_hash.c(463) : ht=0x10050b050 is inconsistent
/Users/reeze/Opensource/php-test/php-src-5.3/Zend/zend_hash.c(70) : Bailed out without a bailout address!
```

And this fixed the following failed tests(PHP-5.3):

```
Phar: copy-on-write test 13 [cache_list] [ext/phar/tests/cache_list/copyonwrite13.phar.phpt]
Phar: copy-on-write test 14 [cache_list] [ext/phar/tests/cache_list/copyonwrite14.phar.phpt]
Phar: copy-on-write test 21 [cache_list] [ext/phar/tests/cache_list/copyonwrite21.phar.phpt]
Phar: copy-on-write test 22 [cache_list] [ext/phar/tests/cache_list/copyonwrite22.phar.phpt]
Phar: copy-on-write test 4a [cache_list] [ext/phar/tests/cache_list/copyonwrite4a.phpt]
Phar front controller other [ext/phar/tests/cache_list/frontcontroller1.phpt]
Phar front controller mime type extension is not a string [cache_list] [ext/phar/tests/cache_list/frontcontroller11.phpt]
Phar front controller PHP test [cache_list] [ext/phar/tests/cache_list/frontcontroller2.phpt]
Phar: phpinfo display 3 [ext/phar/tests/phpinfo_003.phpt]
```
