### PR TITLE
Fix intl tests failed because of missing skipif section

### DIFF
--- a/ext/intl/tests/breakiter___construct.phpt
+++ b/ext/intl/tests/breakiter___construct.phpt
@@ -1,6 +1,7 @@
 --TEST--
 IntlBreakIterator::__construct() should not be callable
 --SKIPIF--
+<?php
 if (!extension_loaded('intl'))
 	die('skip intl extension not enabled');
 --FILE--

--- a/ext/intl/tests/breakiter_clone_basic.phpt
+++ b/ext/intl/tests/breakiter_clone_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator: clone handler
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_current_basic.phpt
+++ b/ext/intl/tests/breakiter_current_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::current(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_factories_basic.phpt
+++ b/ext/intl/tests/breakiter_factories_basic.phpt
@@ -1,6 +1,7 @@
 --TEST--
 IntlBreakIterator factories: basic tests
 --SKIPIF--
+<?php
 if (!extension_loaded('intl'))
 	die('skip intl extension not enabled');
 --FILE--

--- a/ext/intl/tests/breakiter_factories_error.phpt
+++ b/ext/intl/tests/breakiter_factories_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator factory methods: argument errors
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_first_basic.phpt
+++ b/ext/intl/tests/breakiter_first_basic.phpt
@@ -1,6 +1,7 @@
 --TEST--
 IntlBreakIterator::first(): basic test
 --SKIPIF--
+<?php
 if (!extension_loaded('intl'))
 	die('skip intl extension not enabled');
 --FILE--

--- a/ext/intl/tests/breakiter_first_last_previous_current_error.phpt
+++ b/ext/intl/tests/breakiter_first_last_previous_current_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::first()/last()/previous()/current(): arg errors
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_following_basic.phpt
+++ b/ext/intl/tests/breakiter_following_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::following(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_following_preceding_isBoundary_error.phpt
+++ b/ext/intl/tests/breakiter_following_preceding_isBoundary_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::following()/preceding()/isBoundary(): arg errors
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_getLocale_basic.phpt
+++ b/ext/intl/tests/breakiter_getLocale_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::getLocale(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_getLocale_error.phpt
+++ b/ext/intl/tests/breakiter_getLocale_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::getLocale(): arg errors
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_getPartsIterator_basic.phpt
+++ b/ext/intl/tests/breakiter_getPartsIterator_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::getPartsIterator(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_getText_basic.phpt
+++ b/ext/intl/tests/breakiter_getText_basic.phpt
@@ -1,6 +1,7 @@
 --TEST--
 IntlBreakIterator::getText(): basic test
 --SKIPIF--
+<?php
 if (!extension_loaded('intl'))
 	die('skip intl extension not enabled');
 --FILE--

--- a/ext/intl/tests/breakiter_getText_error.phpt
+++ b/ext/intl/tests/breakiter_getText_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::getText(): arg errors
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_isBoundary_basic.phpt
+++ b/ext/intl/tests/breakiter_isBoundary_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::isBoundary(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_last_basic.phpt
+++ b/ext/intl/tests/breakiter_last_basic.phpt
@@ -1,6 +1,7 @@
 --TEST--
 IntlBreakIterator::last(): basic test
 --SKIPIF--
+<?php
 if (!extension_loaded('intl'))
 	die('skip intl extension not enabled');
 --FILE--

--- a/ext/intl/tests/breakiter_next_basic.phpt
+++ b/ext/intl/tests/breakiter_next_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::next(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_next_error.phpt
+++ b/ext/intl/tests/breakiter_next_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::next(): arg errors
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_preceding_basic.phpt
+++ b/ext/intl/tests/breakiter_preceding_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::preceding(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_previous_basic.phpt
+++ b/ext/intl/tests/breakiter_previous_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::previous(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/breakiter_setText_basic.phpt
+++ b/ext/intl/tests/breakiter_setText_basic.phpt
@@ -1,6 +1,7 @@
 --TEST--
 IntlBreakIterator::setText(): basic test
 --SKIPIF--
+<?php
 if (!extension_loaded('intl'))
 	die('skip intl extension not enabled');
 --FILE--

--- a/ext/intl/tests/breakiter_setText_error.phpt
+++ b/ext/intl/tests/breakiter_setText_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlBreakIterator::setText(): arg errors
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat___construct_bad_tz_cal.phpt
+++ b/ext/intl/tests/dateformat___construct_bad_tz_cal.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlDateFormatter::__construct(): bad timezone or calendar
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_create_cal_arg.phpt
+++ b/ext/intl/tests/dateformat_create_cal_arg.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlDateFormatter: several forms of the calendar arg
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_getCalendarObject_error.phpt
+++ b/ext/intl/tests/dateformat_getCalendarObject_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlDateFormatter::getCalendarObject(): bad args
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_getTimeZone_error.phpt
+++ b/ext/intl/tests/dateformat_getTimeZone_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlDateFormatter::getTimeZone(): bad args
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_get_set_calendar.phpt
+++ b/ext/intl/tests/dateformat_get_set_calendar.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlDateFormatter: setCalendar()/getCalendar()/getCalendarObject()
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_get_set_timezone.phpt
+++ b/ext/intl/tests/dateformat_get_set_timezone.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlDateFormatter: get/setTimeZone()
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_setTimeZoneID_deprecation.phpt
+++ b/ext/intl/tests/dateformat_setTimeZoneID_deprecation.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlDateFormatter: setTimeZoneID() deprecation
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_setTimeZone_error.phpt
+++ b/ext/intl/tests/dateformat_setTimeZone_error.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlDateFormatter::setTimeZone() bad args
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_timezone_arg_variations.phpt
+++ b/ext/intl/tests/dateformat_timezone_arg_variations.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlDateFormatter: several forms of the timezone arg
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/rbbiter___construct_basic.phpt
+++ b/ext/intl/tests/rbbiter___construct_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlRuleBasedBreakIterator::__construct: basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/rbbiter_getRuleStatusVec_basic.phpt
+++ b/ext/intl/tests/rbbiter_getRuleStatusVec_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlRuleBasedBreakIterator::getRuleStatusVec(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/rbbiter_getRuleStatus_basic.phpt
+++ b/ext/intl/tests/rbbiter_getRuleStatus_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlRuleBasedBreakIterator::getRuleStatus(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/rbbiter_getRules_basic.phpt
+++ b/ext/intl/tests/rbbiter_getRules_basic.phpt
@@ -1,5 +1,9 @@
 --TEST--
 IntlRuleBasedBreakIterator::getRules(): basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);


### PR DESCRIPTION
Many intl test cases missing skipif section to detect if extension available. and some of them miss a '<?php'  see: https://github.com/reeze/php-src/pull/new/php:master...reeze:fix-intl-tests#diff-0

Those test cases are in master only :)

Thanks
