### PR TITLE
Travis: --enable-dba --with-gdbm --tcadb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ notifications:
 env:
     - REPORT_EXIT_STATUS=1 TEST_PHP_EXECUTABLE=./sapi/cli/php
 
+before_install:
+    # Required by dba-tcadb
+    - sudo apt-get install -qq libtokyocabinet-dev
+
 before_script:
     # Compile PHP
     - ./travis/compile.sh

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 ./buildconf
 ./configure \
+--without-pear \
 --with-pdo-mysql \
 --with-mysql \
 --with-mysqli \
 --with-pgsql \
 --with-pdo-pgsql \
 --with-pdo-sqlite \
+--enable-dba \
+--with-gdbm \
+--with-tcadb \
 --enable-intl \
---without-pear \
 --with-gd \
 --with-jpeg-dir=/usr \
 --with-png-dir=/usr \


### PR DESCRIPTION
This PR enables travis tests of ext/dba with the handlers inifile (buildin), flatfile (buildin), cdb (buildin), gdbm and tcadb.

I also would like to add --with-db4 but can't compile :( - see http://travis-ci.org/#!/marc-mabe/php-src/builds/2138877
