### PR TITLE
Fixed bug #62852 (Unserialize invalid DateTime causes crash)

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2544,6 +2544,9 @@ static int php_date_initialize_from_hash(zval **return_value, php_date_obj **dat
 		if (zend_hash_find(myht, "timezone_type", 14, (void**) &z_timezone_type) == SUCCESS) {
 			convert_to_long(*z_timezone_type);
 			if (zend_hash_find(myht, "timezone", 9, (void**) &z_timezone) == SUCCESS) {
+				zend_error_handling error_handling;
+
+				zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 				convert_to_string(*z_timezone);
 
 				switch (Z_LVAL_PP(z_timezone_type)) {
@@ -2551,9 +2554,9 @@ static int php_date_initialize_from_hash(zval **return_value, php_date_obj **dat
 					case TIMELIB_ZONETYPE_ABBR: {
 						char *tmp = emalloc(Z_STRLEN_PP(z_date) + Z_STRLEN_PP(z_timezone) + 2);
 						snprintf(tmp, Z_STRLEN_PP(z_date) + Z_STRLEN_PP(z_timezone) + 2, "%s %s", Z_STRVAL_PP(z_date), Z_STRVAL_PP(z_timezone));
-						php_date_initialize(*dateobj, tmp, Z_STRLEN_PP(z_date) + Z_STRLEN_PP(z_timezone) + 1, NULL, NULL, 0 TSRMLS_CC);
+						php_date_initialize(*dateobj, tmp, Z_STRLEN_PP(z_date) + Z_STRLEN_PP(z_timezone) + 1, NULL, NULL, 1 TSRMLS_CC);
 						efree(tmp);
-						return 1;
+						break;
 					}
 
 					case TIMELIB_ZONETYPE_ID:
@@ -2567,10 +2570,15 @@ static int php_date_initialize_from_hash(zval **return_value, php_date_obj **dat
 						tzobj->tzi.tz = tzi;
 						tzobj->initialized = 1;
 
-						php_date_initialize(*dateobj, Z_STRVAL_PP(z_date), Z_STRLEN_PP(z_date), NULL, tmp_obj, 0 TSRMLS_CC);
+						php_date_initialize(*dateobj, Z_STRVAL_PP(z_date), Z_STRLEN_PP(z_date), NULL, tmp_obj, 1 TSRMLS_CC);
 						zval_ptr_dtor(&tmp_obj);
-						return 1;
+						break;
+					default:
+						zend_restore_error_handling(&error_handling TSRMLS_CC);
+						return 0;
 				}
+				zend_restore_error_handling(&error_handling TSRMLS_CC);
+				return 1;
 			}
 		}
 	}

--- a/ext/date/tests/bug62852.phpt
+++ b/ext/date/tests/bug62852.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #62852 (Unserialize invalid DateTime causes crash)
+--INI--
+date.timezone=GMT
+--FILE--
+<?php
+try {
+	$datetime = unserialize('O:8:"DateTime":3:{s:4:"date";s:20:"10007-06-07 03:51:49";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}');
+	var_dump($datetime);	
+} catch (Exception $e) {
+    var_dump($e->getMessage());
+}
+?>
+--EXPECTF--
+string(%d) "DateTime::__wakeup(): Failed to parse time string (%s) at position 12 (0): Double time specification"


### PR DESCRIPTION
See bug #62852 https://bugs.php.net/bug.php?id=62852

When wakeup from an invalid datetime it didn't complain but in inconsistant status. 
This causes crash when access.

Thanks
