### PR TITLE
Fix ext/mysql test failed

### DIFF
--- a/ext/mysql/tests/mysql_query_load_data_openbasedir.phpt
+++ b/ext/mysql/tests/mysql_query_load_data_openbasedir.phpt
@@ -2,13 +2,13 @@
 LOAD DATA INFILE - open_basedir
 --SKIPIF--
 <?php
+include_once('skipif.inc');
 @include_once("connect.inc");
 
 if (!isset($db)) {
   die("skip open_basedir setting prevents inclusing of required files");
 }
 
-include_once('skipif.inc');
 include_once('skipifconnectfailure.inc');
 
 


### PR DESCRIPTION
In ext/mysql/tests/mysql_query_load_data_openbasedir.phpt

skipif section:

connect.inc was include before skipif.inc. but if mysql wasn't enabled. connect will fatal
because of missing function:  mysql_get_client_info(). then skipif section output nothing.
this makes this tests didn't skip.

This is 5.3 only, since the patch could not directly been merged to 5.4/master.
I will send another PR.
