### PR TITLE
Fix ext/mysql test failed 5.4+

### DIFF
--- a/ext/mysql/tests/mysql_query_load_data_openbasedir.phpt
+++ b/ext/mysql/tests/mysql_query_load_data_openbasedir.phpt
@@ -2,8 +2,8 @@
 LOAD DATA INFILE - open_basedir
 --SKIPIF--
 <?php
-@include_once("connect.inc");
 include_once('skipif.inc');
+@include_once("connect.inc");
 include_once('skipifconnectfailure.inc');
 
 


### PR DESCRIPTION
The same as https://github.com/php/php-src/pull/174, it could been apply to 5.4&master
