### PR TITLE
Use zend_execute_internal always to call internal functions

### DIFF
--- a/Zend/zend_dtrace.c
+++ b/Zend/zend_dtrace.c
@@ -83,7 +83,7 @@ ZEND_API void dtrace_execute(zend_op_array *op_array TSRMLS_DC)
 	}
 }
 
-ZEND_API void dtrace_execute_internal(zend_execute_data *execute_data_ptr, int return_value_used TSRMLS_DC)
+ZEND_API void dtrace_execute_internal(zend_execute_data *execute_data_ptr, zend_fcall_info *fci, int return_value_used TSRMLS_DC)
 {
 	int lineno;
 	char *filename;
@@ -96,7 +96,7 @@ ZEND_API void dtrace_execute_internal(zend_execute_data *execute_data_ptr, int r
 		DTRACE_EXECUTE_ENTRY(filename, lineno);
 	}
 
-	execute_internal(execute_data_ptr, return_value_used TSRMLS_CC);
+	execute_internal(execute_data_ptr, fci, return_value_used TSRMLS_CC);
 
 	if (DTRACE_EXECUTE_RETURN_ENABLED()) {
 		DTRACE_EXECUTE_RETURN(filename, lineno);

--- a/Zend/zend_dtrace.h
+++ b/Zend/zend_dtrace.h
@@ -32,11 +32,11 @@ extern "C" {
 #ifdef HAVE_DTRACE
 ZEND_API zend_op_array *(*zend_dtrace_compile_file)(zend_file_handle *file_handle, int type TSRMLS_DC);
 ZEND_API void (*zend_dtrace_execute)(zend_op_array *op_array TSRMLS_DC);
-ZEND_API void (*zend_dtrace_execute_internal)(zend_execute_data *execute_data_ptr, int return_value_used TSRMLS_DC);
+ZEND_API void (*zend_dtrace_execute_internal)(zend_execute_data *execute_data_ptr, zend_fcall_info *fci, int return_value_used TSRMLS_DC);
 
 ZEND_API zend_op_array *dtrace_compile_file(zend_file_handle *file_handle, int type TSRMLS_DC);
 ZEND_API void dtrace_execute(zend_op_array *op_array TSRMLS_DC);
-ZEND_API void dtrace_execute_internal(zend_execute_data *execute_data_ptr, int return_value_used TSRMLS_DC);
+ZEND_API void dtrace_execute_internal(zend_execute_data *execute_data_ptr, zend_fcall_info *fci, int return_value_used TSRMLS_DC);
 #include <zend_dtrace_gen.h>
 
 #endif /* HAVE_DTRACE */

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -5,7 +5,7 @@
    | Copyright (c) 1998-2012 Zend Technologies Ltd. (http://www.zend.com) |
    +----------------------------------------------------------------------+
    | This source file is subject to version 2.00 of the Zend license,     |
-   | that is bundled with this package in the file LICENSE, and is        | 
+   | that is bundled with this package in the file LICENSE, and is        |
    | available through the world-wide-web at the following url:           |
    | http://www.zend.com/license/2_00.txt.                                |
    | If you did not receive a copy of the Zend license and are unable to  |
@@ -49,14 +49,15 @@ typedef union _temp_variable {
 
 
 BEGIN_EXTERN_C()
+struct _zend_fcall_info;
 ZEND_API extern void (*zend_execute)(zend_op_array *op_array TSRMLS_DC);
-ZEND_API extern void (*zend_execute_internal)(zend_execute_data *execute_data_ptr, int return_value_used TSRMLS_DC);
+ZEND_API extern void (*zend_execute_internal)(zend_execute_data *execute_data_ptr, struct _zend_fcall_info *fci, int return_value_used TSRMLS_DC);
 
 void init_executor(TSRMLS_D);
 void shutdown_executor(TSRMLS_D);
 void shutdown_destructors(TSRMLS_D);
 ZEND_API void execute(zend_op_array *op_array TSRMLS_DC);
-ZEND_API void execute_internal(zend_execute_data *execute_data_ptr, int return_value_used TSRMLS_DC);
+ZEND_API void execute_internal(zend_execute_data *execute_data_ptr, struct _zend_fcall_info *fci, int return_value_used TSRMLS_DC);
 ZEND_API int zend_is_true(zval *op);
 #define safe_free_zval_ptr(p) safe_free_zval_ptr_rel(p ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
 static zend_always_inline void safe_free_zval_ptr_rel(zval *p ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
@@ -270,7 +271,7 @@ static zend_always_inline void *zend_vm_stack_alloc(size_t size TSRMLS_DC)
 }
 
 static zend_always_inline void zend_vm_stack_free_int(void *ptr TSRMLS_DC)
-{	
+{
 	if (UNEXPECTED(ZEND_VM_STACK_ELEMETS(EG(argument_stack)) == (void**)ptr)) {
 		zend_vm_stack p = EG(argument_stack);
 
@@ -282,7 +283,7 @@ static zend_always_inline void zend_vm_stack_free_int(void *ptr TSRMLS_DC)
 }
 
 static zend_always_inline void zend_vm_stack_free(void *ptr TSRMLS_DC)
-{	
+{
 	if (UNEXPECTED(ZEND_VM_STACK_ELEMETS(EG(argument_stack)) == (void**)ptr)) {
 		zend_vm_stack p = EG(argument_stack);
 
@@ -302,7 +303,7 @@ static zend_always_inline void zend_vm_stack_free(void *ptr TSRMLS_DC)
 static zend_always_inline void** zend_vm_stack_push_args(int count TSRMLS_DC)
 {
 
-	if (UNEXPECTED(EG(argument_stack)->top - ZEND_VM_STACK_ELEMETS(EG(argument_stack)) < count)  || 
+	if (UNEXPECTED(EG(argument_stack)->top - ZEND_VM_STACK_ELEMETS(EG(argument_stack)) < count)  ||
 		UNEXPECTED(EG(argument_stack)->top == EG(argument_stack)->end)) {
 		zend_vm_stack p = EG(argument_stack);
 

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -38,7 +38,7 @@
 #endif
 
 ZEND_API void (*zend_execute)(zend_op_array *op_array TSRMLS_DC);
-ZEND_API void (*zend_execute_internal)(zend_execute_data *execute_data_ptr, int return_value_used TSRMLS_DC);
+ZEND_API void (*zend_execute_internal)(zend_execute_data *execute_data_ptr, zend_fcall_info *fci, int return_value_used TSRMLS_DC);
 
 /* true globals */
 ZEND_API const zend_fcall_info empty_fcall_info = { 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, 0 };
@@ -977,15 +977,12 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache TS
 		if (EX(function_state).function->common.scope) {
 			EG(scope) = EX(function_state).function->common.scope;
 		}
-
-		if (!zend_execute_internal) {
+		if(EXPECTED(zend_execute_internal == NULL)) {
 			/* saves one function call if zend_execute_internal is not used */
 			((zend_internal_function *) EX(function_state).function)->handler(fci->param_count, *fci->retval_ptr_ptr, fci->retval_ptr_ptr, fci->object_ptr, 1 TSRMLS_CC);
 		} else {
-			zend_execute_internal(&execute_data, 1 TSRMLS_CC);
+			zend_execute_internal(&execute_data, fci, 1 TSRMLS_CC);
 		}
-
-
 		/*  We shouldn't fix bad extensions here,
 			because it can break proper ones (Bug #34045)
 		if (!EX(function_state).function->common.return_reference)

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2028,7 +2028,7 @@ ZEND_VM_HELPER(zend_do_fcall_common_helper, ANY, ANY)
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(opline->extended_value, ret->var.ptr, (fbc->common.fn_flags & ZEND_ACC_RETURN_REFERENCE) ? &ret->var.ptr : NULL, EX(object), RETURN_VALUE_USED(opline) TSRMLS_CC);
 		} else {
-			zend_execute_internal(EXECUTE_DATA, RETURN_VALUE_USED(opline) TSRMLS_CC);
+			zend_execute_internal(EXECUTE_DATA, NULL, RETURN_VALUE_USED(opline) TSRMLS_CC);
 		}
 
 		if (!RETURN_VALUE_USED(opline)) {
@@ -2151,7 +2151,7 @@ ZEND_VM_HELPER_EX(zend_finally_handler_leaving, ANY, ANY, int type)
 					for (i=0; i<EX(op_array)->last_try_catch; i++) {
 						if (EX(op_array)->try_catch_array[i].try_op > op_num) {
 							break;
-						} 
+						}
 						if (op_num < EX(op_array)->try_catch_array[i].finally_op) {
 							finally_op_num = EX(op_array)->try_catch_array[i].finally_op;
 						}
@@ -2163,7 +2163,7 @@ ZEND_VM_HELPER_EX(zend_finally_handler_leaving, ANY, ANY, int type)
 					for (i=0; i<EX(op_array)->last_try_catch; i++) {
 						if (EX(op_array)->try_catch_array[i].try_op > op_num) {
 							break;
-						} 
+						}
 						if (op_num < EX(op_array)->try_catch_array[i].finally_op) {
 							finally_op_num = EX(op_array)->try_catch_array[i].finally_op;
 						}
@@ -2207,8 +2207,8 @@ ZEND_VM_HELPER_EX(zend_finally_handler_leaving, ANY, ANY, int type)
 		  for (i=0; i<EG(active_op_array)->last_try_catch; i++) {
 			  if (EG(active_op_array)->try_catch_array[i].try_op > op_num) {
 				  break;
-			  } 
-			  if (op_num < EG(active_op_array)->try_catch_array[i].finally_op 
+			  }
+			  if (op_num < EG(active_op_array)->try_catch_array[i].finally_op
 					  && (EX(leaving_dest) < EG(active_op_array)->try_catch_array[i].try_op
 						  || EX(leaving_dest) >= EG(active_op_array)->try_catch_array[i].finally_end)) {
 				  finally_op_num = EG(active_op_array)->try_catch_array[i].finally_op;
@@ -5145,7 +5145,7 @@ ZEND_VM_HANDLER(149, ZEND_HANDLE_EXCEPTION, ANY, ANY)
 		if (EG(active_op_array)->try_catch_array[i].try_op > op_num) {
 			/* further blocks will not be relevant... */
 			break;
-		} 
+		}
 		if (op_num < EG(active_op_array)->try_catch_array[i].catch_op) {
 			catch_op_num = EX(op_array)->try_catch_array[i].catch_op;
 			catched = i + 1;
@@ -5221,7 +5221,7 @@ ZEND_VM_HANDLER(149, ZEND_HANDLE_EXCEPTION, ANY, ANY)
 			ZEND_VM_SET_OPCODE(&EX(op_array)->opcodes[finally_op_num]);
 			ZEND_VM_CONTINUE();
 		}
-	} else if (catched) { 
+	} else if (catched) {
 		EX(leaving) = 0;
 		ZEND_VM_SET_OPCODE(&EX(op_array)->opcodes[catch_op_num]);
 		ZEND_VM_CONTINUE();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -615,7 +615,7 @@ static int ZEND_FASTCALL zend_do_fcall_common_helper_SPEC(ZEND_OPCODE_HANDLER_AR
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(opline->extended_value, ret->var.ptr, (fbc->common.fn_flags & ZEND_ACC_RETURN_REFERENCE) ? &ret->var.ptr : NULL, EX(object), RETURN_VALUE_USED(opline) TSRMLS_CC);
 		} else {
-			zend_execute_internal(execute_data, RETURN_VALUE_USED(opline) TSRMLS_CC);
+			zend_execute_internal(execute_data, NULL, RETURN_VALUE_USED(opline) TSRMLS_CC);
 		}
 
 		if (!RETURN_VALUE_USED(opline)) {


### PR DESCRIPTION
This patch restores the use of zend_execute_internal to call internal functions when they are called from another internal function via zend_call_function. This will allow modules to intercept it more efficiently. Unfortunately, this also requires slight API change and may require to fix the overriding function code since new way of calling was added. If the function does anything with execute data, it also would have to consider that some of these data can be wrong for current function if fci parameter is set and take it as overriding authority. 
