### PR TITLE
Fixed bug #62976 (Notice: could not be converted to int when comparing s...

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -1473,6 +1473,7 @@ ZEND_API int compare_function(zval *result, zval *op1, zval *op2 TSRMLS_DC) /* {
 						return ret;
 					}
 				}
+
 				if (Z_TYPE_P(op2) == IS_OBJECT) {
 					if (Z_OBJ_HT_P(op2)->get) {
 						op_free = Z_OBJ_HT_P(op2)->get(op2 TSRMLS_CC);
@@ -1491,6 +1492,12 @@ ZEND_API int compare_function(zval *result, zval *op1, zval *op2 TSRMLS_DC) /* {
 						return ret;
 					}
 				}
+
+				if (Z_TYPE_P(op1) == IS_OBJECT && Z_TYPE_P(op2) == IS_OBJECT) {
+					ZVAL_LONG(result, -1);
+					return SUCCESS;
+				}
+
 				if (!converted) {
 					if (Z_TYPE_P(op1) == IS_NULL) {
 						zendi_convert_to_boolean(op2, op2_copy, result);

--- a/ext/spl/tests/bug62976.phpt
+++ b/ext/spl/tests/bug62976.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #62976 (Notice: could not be converted to int when comparing some builtin classes)
+--FILE--
+<?php
+
+var_dump(new stdClass() == new ArrayObject());
+var_dump(new stdClass() == new Exception());
+var_dump(new ArrayObject() == new ArrayObject());
+var_dump(new ArrayObject(array(1, 2)) == new ArrayObject());
+?>
+--EXPECTF--
+bool(false)
+bool(false)
+bool(true)
+bool(false)

--- a/tests/lang/compare_objects_basic2.phpt
+++ b/tests/lang/compare_objects_basic2.phpt
@@ -20,9 +20,5 @@ var_dump($obj1 == $obj2);
 ===DONE===
 --EXPECTF--
 Simple test comparing two objects with different compare callback handler
-
-Notice: Object of class X could not be converted to int in %s on line %d
-
-Notice: Object of class DateTime could not be converted to int in %s on line %d
-bool(true)
+bool(false)
 ===DONE===


### PR DESCRIPTION
Hi, this is a proposal patch for bug #62976 https://bugs.php.net/bug.php?id=62976

It's really surprised to get a true when two different classes's instances was equal, 
even they can't be cast.

If both of the objects can't be casted to compare, they are not equal.

for your reference:
http://3v4l.org/f0qlB
