### PR TITLE
Fixed bug #62987 (Assigning to ArrayObject[null][something] overrides al...

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -327,6 +327,10 @@ static zval **spl_array_get_dimension_ptr_ptr(int check_inherited, zval *object,
 	}
 
 	switch(Z_TYPE_P(offset)) {
+	case IS_NULL:
+		Z_STRVAL_P(offset) = "";
+		Z_STRLEN_P(offset) = 0;
+		/* Fall Through */
 	case IS_STRING:
 		if (zend_symtable_find(ht, Z_STRVAL_P(offset), Z_STRLEN_P(offset)+1, (void **) &retval) == FAILURE) {
 			if (type == BP_VAR_W || type == BP_VAR_RW) {
@@ -367,8 +371,8 @@ static zval **spl_array_get_dimension_ptr_ptr(int check_inherited, zval *object,
 		}
 		break;
 	default:
-		zend_error(E_WARNING, "Illegal offset type");
-		return &EG(uninitialized_zval_ptr);
+		return (type == BP_VAR_W || type == BP_VAR_RW) ?
+			&EG(error_zval_ptr) : &EG(uninitialized_zval_ptr);
 	}
 } /* }}} */
 

--- a/ext/spl/tests/bug62987.phpt
+++ b/ext/spl/tests/bug62987.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Bug #62987 (Assigning to ArrayObject[null][something] overrides all undefined variables)
+--FILE--
+<?php
+
+$a = new ArrayObject();
+
+$b = array();
+
+$a[null]['hurr'] = 'durr';
+
+$d = array();
+var_dump($d['non-exist-key']);
+
+$undefine = 'will null be overwrited?';
+
+var_dump($what_ever);
+var_dump($a['non-exist-key']);
+var_dump($d['non-exist-key']);
+
+var_dump($a);
+?>
+===DONE===
+--EXPECTF--
+Notice: Undefined index: non-exist-key in %sbug62987.php on line %d
+NULL
+
+Notice: Undefined variable: what_ever in %sbug62987.php on line %d
+NULL
+
+Notice: Undefined index:  non-exist-key in %sbug62987.php on line %d
+NULL
+
+Notice: Undefined index: non-exist-key in %sbug62987.php on line %d
+NULL
+object(ArrayObject)#%d (%d) {
+  ["storage":"ArrayObject":private]=>
+  array(1) {
+    [""]=>
+    array(1) {
+      ["hurr"]=>
+      string(4) "durr"
+    }
+  }
+}
+===DONE===


### PR DESCRIPTION
see https://bugs.php.net/bug.php?id=62987

when access in write context, return NULL ptr will lead NULL been overwrite

This makes null changed everywhere.
