### PR TITLE
Implemented ReflectionFunction::isGenerator()

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3086,6 +3086,14 @@ ZEND_METHOD(reflection_function, isDeprecated)
 }
 /* }}} */
 
+/* {{{ proto public bool ReflectionFunction::isGenerator()
+   Returns whether this function is a generator */
+ZEND_METHOD(reflection_function, isGenerator)
+{
+	_function_check_flag(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_ACC_GENERATOR);
+}
+/* }}} */
+
 /* {{{ proto public bool ReflectionFunction::inNamespace()
    Returns whether this function is defined in namespace */
 ZEND_METHOD(reflection_function, inNamespace)
@@ -5696,6 +5704,7 @@ static const zend_function_entry reflection_function_abstract_functions[] = {
 	ZEND_ME(reflection_function, isDeprecated, arginfo_reflection__void, 0)
 	ZEND_ME(reflection_function, isInternal, arginfo_reflection__void, 0)
 	ZEND_ME(reflection_function, isUserDefined, arginfo_reflection__void, 0)
+	ZEND_ME(reflection_function, isGenerator, arginfo_reflection__void, 0)
 	ZEND_ME(reflection_function, getClosureThis, arginfo_reflection__void, 0)
 	ZEND_ME(reflection_function, getClosureScopeClass, arginfo_reflection__void, 0)
 	ZEND_ME(reflection_function, getDocComment, arginfo_reflection__void, 0)

--- a/ext/reflection/tests/ReflectionFunction_isGenerator_basic.phpt
+++ b/ext/reflection/tests/ReflectionFunction_isGenerator_basic.phpt
@@ -1,0 +1,52 @@
+--TEST--
+ReflectionFunction::isGenerator()
+--FILE--
+<?php
+
+$closure1 = function() {return "this is a closure"; };
+$closure2 = function($param) {
+	yield $param;
+};
+
+$rf1 = new ReflectionFunction($closure1);
+var_dump($rf1->isGenerator());
+
+$rf2 = new ReflectionFunction($closure2);
+var_dump($rf2->isGenerator());
+
+function func1() {
+	return 'func1';
+}
+
+function func2() {
+	yield 'func2';
+}
+
+$rf1 = new ReflectionFunction('func1');
+var_dump($rf1->isGenerator());
+
+$rf2 = new ReflectionFunction('func2');
+var_dump($rf2->isGenerator());
+
+
+class Foo {
+	public function f1() {
+	}
+
+	public function f2() {
+		yield;
+	}
+}
+
+$rc = new ReflectionClass('Foo');
+foreach($rc->getMethods() as $m) {
+	var_dump($m->isGenerator());
+}
+?>
+--EXPECTF--
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)


### PR DESCRIPTION
This patch implemented ReflectionFunction::isGenerator() to check whether a function is a generator.

It's quit straightforward :)  
