### PR TITLE
Bug #63000: MCAST_JOIN_GROUP on OSX is broken

### DIFF
--- a/ext/sockets/multicast.h
+++ b/ext/sockets/multicast.h
@@ -19,11 +19,12 @@
 /* $Id$ */
 
 #if defined(MCAST_JOIN_GROUP) && \
-	(!defined(PHP_WIN32) || (_WIN32_WINNT >= 0x600 && SOCKETS_ENABLE_VISTA_API))
+	(!defined(PHP_WIN32) || (_WIN32_WINNT >= 0x600 && SOCKETS_ENABLE_VISTA_API)) && \
+	!defined(__APPLE__)
 #define RFC3678_API 1
 /* has block/unblock and source membership, in this case for both IPv4 and IPv6 */
 #define HAS_MCAST_EXT 1
-#elif defined(IP_ADD_SOURCE_MEMBERSHIP)
+#elif defined(IP_ADD_SOURCE_MEMBERSHIP) && !defined(__APPLE__)
 /* has block/unblock and source membership, but only for IPv4 */
 #define HAS_MCAST_EXT 1
 #endif

--- a/ext/sockets/tests/mcast_osx.phpt
+++ b/ext/sockets/tests/mcast_osx.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #63000: Multicast on OSX
+--SKIPIF--
+<?php
+if (!extension_loaded('sockets')) {
+    die('skip sockets extension not available.');
+}
+if (PHP_OS !== 'Darwin') {
+    die('is not OSX.');
+}
+--FILE--
+<?php
+$socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+socket_bind($socket, '0.0.0.0', 31057);
+
+$so = socket_set_option($socket, IPPROTO_IP, MCAST_JOIN_GROUP, array(
+    "group" => '224.0.0.251',
+    "interface" => 0,
+));
+var_dump($so);
+--EXPECTF--
+bool(true)


### PR DESCRIPTION
Ticket: https://bugs.php.net/63000

The multicast support in PHP 5.4 makes use of MCAST_JOIN_GROUP if it is present.
The problem is that OSX 10.7 added the constant, but did not correctly implement
the feature. This causes the setsockopt call to fail.

The solution to the problem is to not use MCAST_JOIN_GROUP on OSX.

For reference, this was also done in VLC:
- http://trac.videolan.org/vlc/ticket/6104#comment:19
