### PR TITLE
Bug #46408: Fix double formatting for PostgreSQL bound parameters

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -572,6 +572,24 @@ ZEND_API void convert_to_boolean(zval *op) /* {{{ */
 }
 /* }}} */
 
+ZEND_API void _convert_to_cstring(zval *op ZEND_FILE_LINE_DC) /* {{{ */
+{
+	double dval;
+	switch (Z_TYPE_P(op)) {
+		case IS_DOUBLE: {
+			TSRMLS_FETCH();
+			dval = Z_DVAL_P(op);
+			Z_STRLEN_P(op) = zend_spprintf(&Z_STRVAL_P(op), 0, "%.*H", (int) EG(precision), dval);
+			/* %H already handles removing trailing zeros from the fractional part, yay */
+			break;
+		}
+		default:
+			return _convert_to_string(op);
+	}
+	Z_TYPE_P(op) = IS_STRING;
+}
+/* }}} */
+
 ZEND_API void _convert_to_string(zval *op ZEND_FILE_LINE_DC) /* {{{ */
 {
 	long lval;

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -301,6 +301,7 @@ ZEND_API int increment_function(zval *op1);
 ZEND_API int decrement_function(zval *op2);
 
 ZEND_API void convert_scalar_to_number(zval *op TSRMLS_DC);
+ZEND_API void _convert_to_cstring(zval *op ZEND_FILE_LINE_DC);
 ZEND_API void _convert_to_string(zval *op ZEND_FILE_LINE_DC);
 ZEND_API void convert_to_long(zval *op);
 ZEND_API void convert_to_double(zval *op);
@@ -314,6 +315,7 @@ ZEND_API void multi_convert_to_double_ex(int argc, ...);
 ZEND_API void multi_convert_to_string_ex(int argc, ...);
 ZEND_API int add_char_to_string(zval *result, const zval *op1, const zval *op2);
 ZEND_API int add_string_to_string(zval *result, const zval *op1, const zval *op2);
+#define convert_to_cstring(op) if ((op)->type != IS_STRING) { _convert_to_cstring((op) ZEND_FILE_LINE_CC); }
 #define convert_to_string(op) if ((op)->type != IS_STRING) { _convert_to_string((op) ZEND_FILE_LINE_CC); }
 
 ZEND_API double zend_string_to_double(const char *number, zend_uint length);

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1736,7 +1736,7 @@ PHP_FUNCTION(pg_query_params)
 			} else {
 				zval tmp_val = **tmp;
 				zval_copy_ctor(&tmp_val);
-				convert_to_string(&tmp_val);
+				convert_to_cstring(&tmp_val);
 				if (Z_TYPE(tmp_val) != IS_STRING) {
 					php_error_docref(NULL TSRMLS_CC, E_WARNING,"Error converting parameter");
 					zval_dtor(&tmp_val);

--- a/ext/pgsql/tests/bug46408.phpt
+++ b/ext/pgsql/tests/bug46408.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #46408 (Locale number format settings can cause pg_query_params to break with numerics)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once('config.inc');
+
+$dbh = pg_connect($conn_str);
+setlocale(LC_ALL, 'hr_HR.utf-8', 'hr_HR');
+pg_query_params("SELECT $1::numeric", array(3.5));
+pg_close($dbh);
+
+echo "Done".PHP_EOL;
+
+?>
+--EXPECTF--
+Done


### PR DESCRIPTION
See https://bugs.php.net/bug.php?id=46408 for extensive discussion of this.
