### PR TITLE
Provide a specific error message if date.timezone value is invalid.

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -862,9 +862,14 @@ static char* guess_timezone(const timelib_tzdb *tzdb TSRMLS_DC)
 		}
 	} else if (*DATEG(default_timezone) && timelib_timezone_id_is_valid(DATEG(default_timezone), tzdb)) {
 		return DATEG(default_timezone);
+	} else if (*DATEG(default_timezone)) {
+		/* Invalid date.timezone value */
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "date.timezone value '%s' is invalid. We selected the timezone 'UTC' for now.", DATEG(default_timezone));
+	} else {
+		/* No date.timezone value */
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, DATE_TZ_ERRMSG "We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.");
 	}
 	/* Fallback to UTC */
-	php_error_docref(NULL TSRMLS_CC, E_WARNING, DATE_TZ_ERRMSG "We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.");
 	return "UTC";
 }
 

--- a/ext/date/tests/date_default_timezone_get-4.phpt
+++ b/ext/date/tests/date_default_timezone_get-4.phpt
@@ -1,0 +1,11 @@
+--TEST--
+date_default_timezone_get() function [4]
+--INI--
+date.timezone=Incorrect/Zone
+--FILE--
+<?php
+	echo date_default_timezone_get(), "\n";
+?>
+--EXPECTF--
+Warning: date_default_timezone_get(): date.timezone value 'Incorrect/Zone' is invalid. We selected the timezone 'UTC' for now. in %sdate_default_timezone_get-4.php on line %d
+UTC


### PR DESCRIPTION
Rather than failing with the generic "it's bad to use the system timezone value, set date.timezone" when date.timezone is set, but incorrectly, fail telling the user that.
