### PR TITLE
Support for HTTP PATCH in the built-in webserver

### DIFF
--- a/sapi/cli/php_http_parser.c
+++ b/sapi/cli/php_http_parser.c
@@ -81,6 +81,7 @@ static const char *method_strings[] =
   , "HEAD"
   , "POST"
   , "PUT"
+  , "PATCH"
   , "CONNECT"
   , "OPTIONS"
   , "TRACE"
@@ -626,6 +627,8 @@ size_t php_http_parser_execute (php_http_parser *parser,
           parser->method = PHP_HTTP_PROPFIND; /* or HTTP_PROPPATCH */
         } else if (index == 1 && parser->method == PHP_HTTP_POST && ch == 'U') {
           parser->method = PHP_HTTP_PUT;
+        } else if (index == 1 && parser->method == PHP_HTTP_POST && ch == 'A') {
+          parser->method = PHP_HTTP_PATCH;
         } else if (index == 2 && parser->method == PHP_HTTP_UNLOCK && ch == 'S') {
           parser->method = PHP_HTTP_UNSUBSCRIBE;
         } else if (index == 4 && parser->method == PHP_HTTP_PROPFIND && ch == 'P') {

--- a/sapi/cli/php_http_parser.h
+++ b/sapi/cli/php_http_parser.h
@@ -80,6 +80,7 @@ enum php_http_method
   , PHP_HTTP_HEAD
   , PHP_HTTP_POST
   , PHP_HTTP_PUT
+  , PHP_HTTP_PATCH
   /* pathological */
   , PHP_HTTP_CONNECT
   , PHP_HTTP_OPTIONS

--- a/sapi/cli/tests/php_cli_server_018.phpt
+++ b/sapi/cli/tests/php_cli_server_018.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Implement Req #61679 (Support HTTP PATCH method)
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+include "php_cli_server.inc";
+php_cli_server_start(<<<'PHP'
+var_dump($_SERVER['REQUEST_METHOD']);
+PHP
+);
+
+list($host, $port) = explode(':', PHP_CLI_SERVER_ADDRESS);
+$port = intval($port)?:80;
+
+$fp = fsockopen($host, $port, $errno, $errstr, 0.5);
+if (!$fp) {
+  die("connect failed");
+}
+
+if(fwrite($fp, <<<HEADER
+PATCH / HTTP/1.1
+Host: {$host}
+
+
+HEADER
+)) {
+    while (!feof($fp)) {
+        echo fgets($fp);
+    }
+}
+
+fclose($fp);
+?>
+--EXPECTF--
+HTTP/1.1 200 OK
+Host: %s
+Connection: close
+X-Powered-By: %s
+Content-type: text/html
+
+string(5) "PATCH"


### PR DESCRIPTION
I wanted to experiment using the HTTP PATCH method (http://tools.ietf.org/html/rfc5789), so I added it to the http parser for the built-in webserver. Perhaps someone else would benefit from this as well.

Somewhat related to Bug #61679 (https://bugs.php.net/bug.php?id=61679), but this PR does not add the behaviour of returning 405 for unsupported methods.
