### PR TITLE
php_odbc_fetch_hash() Fixed a segfault when fetching certain SQL NULLs

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1765,7 +1765,7 @@ static void php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, int result_type)
 		if (result_type & ODBC_NUM) {
 			zend_hash_index_update(Z_ARRVAL_P(return_value), i, &tmp, sizeof(zval *), NULL);
 		} else {
-			if (!*(result->values[i].name) && Z_TYPE_P(tmp) != IS_NULL) {
+			if (!*(result->values[i].name) && Z_TYPE_P(tmp) == IS_STRING) {
 				zend_hash_update(Z_ARRVAL_P(return_value), Z_STRVAL_P(tmp),	Z_STRLEN_P(tmp)+1, &tmp, sizeof(zval *), NULL);
 			} else {
 				zend_hash_update(Z_ARRVAL_P(return_value), result->values[i].name, strlen(result->values[i].name)+1, &tmp, sizeof(zval *), NULL);


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=61387

Changed conditional @ php_odbc.c:1774 to include the check:

```
     && Z_TYPE_P(tmp) != IS_NULL
```

This prevents a potential segfault on 1775 when zend_hash_update is called with Z_STR*(tmp) args.

Example script ("fetch_array.php"):

<?php
$c = odbc_connect('Driver=SQL Server Native Client 11.0;server=xxx;uid=xxx;pwd=xxx;Database=xxx','','');
$e = odbc_exec($c, 'SELECT NULL'); // The result set contains an unamed column with a NULL value
$row = odbc_fetch_array($e); // segfault when retrieved
?>

Backtrace:

Program received signal SIGSEGV, Segmentation fault.
zend_inline_hash_func (nKeyLength=, arKey=0x0) at /usr/src/php_fix/php-src/Zend/zend_hash.h:283
283 case 1: hash = ((hash << 5) + hash) + *arKey++; break;
#0 zend_inline_hash_func (nKeyLength=, arKey=0x0) at /usr/src/php_fix/php-src/Zend/zend_hash.h:283
#1 _zend_hash_add_or_update (ht=0xfce7d0, arKey=0x0, nKeyLength=1, pData=0x7fffffffab80, nDataSize=8, pDest=0x0, flag=1) at /usr/src/php_fix/php-src/Zend/zend_hash.c:218
#2 0x00000000005752af in php_odbc_fetch_hash (ht=, return_value=0xfcd038, result_type=2, return_value_ptr=, this_ptr=,

return_value_used=) at /usr/src/php_fix/php-src/ext/odbc/php_odbc.c:1775
