### PR TITLE
Fix #61557: CGI/FPM process could crash when using libxml

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -860,7 +860,6 @@ static PHP_MSHUTDOWN_FUNCTION(libxml)
 {
 	if (!_php_libxml_per_request_initialization) {
 		xmlSetGenericErrorFunc(NULL, NULL);
-		xmlSetStructuredErrorFunc(NULL, NULL);
 
 		xmlParserInputBufferCreateFilenameDefault(NULL);
 		xmlOutputBufferCreateFilenameDefault(NULL);
@@ -876,11 +875,11 @@ static int php_libxml_post_deactivate()
 	/* reset libxml generic error handling */
 	if (_php_libxml_per_request_initialization) {
 		xmlSetGenericErrorFunc(NULL, NULL);
-		xmlSetStructuredErrorFunc(NULL, NULL);
 
 		xmlParserInputBufferCreateFilenameDefault(NULL);
 		xmlOutputBufferCreateFilenameDefault(NULL);
 	}
+	xmlSetStructuredErrorFunc(NULL, NULL);
 
 	if (LIBXML(stream_context)) {
 		/* the steam_context resource will be released by resource list destructor */


### PR DESCRIPTION
Discussion @ https://bugs.php.net/bug.php?id=61557

Since d8bddb9665637d96f20dc4a2ae5668ba376f3b17 some SAPI would only
setup/reset callbacks to libxml once, instead of for each request
processed. However, this also included a callback for structured
errors, which should remain per request (as it can be defined through
PHP's libxml_use_internal_errors).

As a result, after the internal handler was set in a request,
processing another request would result in the handler being triggered
while the memory associated with it (LIBXML(error_list)) had been
free-d/reset, leading to the process segfaulting.

This reset the handler for structured errors after each request.

(Bug #61325 might possibly also be the same bug)
