### PR TITLE
Fix build break when building with Google native client tool chain.

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -664,7 +664,7 @@ static void *_zend_mm_realloc_int(zend_mm_heap *heap, void *p, size_t size ZEND_
 
 static inline unsigned int zend_mm_high_bit(size_t _size)
 {
-#if defined(__GNUC__) && defined(i386)
+#if defined(__GNUC__) && (defined(__native_client__) || defined(i386))
 	unsigned int n;
 
 	__asm__("bsrl %1,%0\n\t" : "=r" (n) : "rm"  (_size));
@@ -690,7 +690,7 @@ static inline unsigned int zend_mm_high_bit(size_t _size)
 
 static inline unsigned int zend_mm_low_bit(size_t _size)
 {
-#if defined(__GNUC__) && defined(i386)
+#if defined(__GNUC__) && (defined(__native_client__) || defined(i386))
 	unsigned int n;
 
 	__asm__("bsfl %1,%0\n\t" : "=r" (n) : "rm"  (_size));
@@ -2454,7 +2454,7 @@ ZEND_API size_t _zend_mem_block_size(void *ptr TSRMLS_DC ZEND_FILE_LINE_DC ZEND_
 	return _zend_mm_block_size(AG(mm_heap), ptr ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
 }
 
-#if defined(__GNUC__) && defined(i386)
+#if defined(__GNUC__) && (defined(__native_client__) || defined(i386))
 
 static inline size_t safe_address(size_t nmemb, size_t size, size_t offset)
 {


### PR DESCRIPTION
This is a small patch to ensure that the correct asm is built when cross compiling to native client. (https://developers.google.com/native-client/).

Description of the issue being corrected is here -> http://code.google.com/p/nativeclient/issues/detail?id=2255
