### PR TITLE
Fix bugs 62561,62896 (Modifying DateTime::__construct,date_create adds an hour)

### DIFF
--- a/ext/date/lib/parse_date.re
+++ b/ext/date/lib/parse_date.re
@@ -1073,6 +1073,7 @@ weekdayof        = (reltextnumber|reltexttext) space (dayfull|dayabbr) space 'of
 		s->time->is_localtime = 1;
 		s->time->zone_type = TIMELIB_ZONETYPE_OFFSET;
 		s->time->z = 0;
+		s->time->dst = 0;
 
 		TIMELIB_DEINIT;
 		return TIMELIB_RELATIVE;
@@ -2077,6 +2078,7 @@ timelib_time *timelib_parse_from_format(char *format, char *string, int len, tim
 				s->time->is_localtime = 1;
 				s->time->zone_type = TIMELIB_ZONETYPE_OFFSET;
 				s->time->z = 0;
+				s->time->dst = 0;
 				break;
 
 			case 'e': /* timezone */

--- a/ext/date/tests/bug62561.phpt
+++ b/ext/date/tests/bug62561.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #62561 Unixtimestamp may take on local times DST flag (this test will only be valid during EDT)
+--FILE--
+<?php
+$tz = new DateTimeZone('America/New_York');
+$ts = new DateTime('@1341115200', $tz);
+$int = new DateInterval('P1D');
+$dayFromTs = new DateTime('@1341115200', new DateTimeZone('America/New_York'));
+$dayFromTs->add($int);
+
+echo 'ts: '.$ts->format('Y-m-d H:i:s')."\n";
+echo 'day from ts: '.$dayFromTs->format('Y-m-d H:i:s')."\n";
+?>
+--EXPECT--
+ts: 2012-07-01 04:00:00
+day from ts: 2012-07-02 04:00:00

--- a/ext/date/tests/bug62896.phpt
+++ b/ext/date/tests/bug62896.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Bug #62896 Unixtimestamp may take on local times DST flag (this test will only be valid during CEST)
+--FILE--
+<?php
+  $tz = new DateTimeZone('Europe/Berlin');
+
+  echo "FROM TIMESTAMP, NO TZ:\n";
+
+  $date = new DateTime('@'.strtotime('2012-08-22 00:00:00 CEST'));
+  echo $date->format('Y-m-d H:i:s T').' (offset '.$date->getOffset().")\n";
+
+  $date->modify('+0 days');
+  echo $date->format('Y-m-d H:i:s T').' (offset '.$date->getOffset().")\n";
+
+  echo "FROM TIMESTAMP, WITH TZ:\n";
+
+  $date = new DateTime('@'.strtotime('2012-08-22 00:00:00 CEST'));
+  $date->setTimezone($tz);
+  echo $date->format('Y-m-d H:i:s T').' (offset '.$date->getOffset().")\n";
+
+  $date->modify('+0 days');
+  echo $date->format('Y-m-d H:i:s T').' (offset '.$date->getOffset().")\n";
+
+  echo "FROM STRING:\n";
+
+  $date = new DateTime('2012-08-22 00:00:00 CEST', $tz);
+  echo $date->format('Y-m-d H:i:s T').' (offset '.$date->getOffset().")\n";
+
+  $date->modify('+0 days');
+  echo $date->format('Y-m-d H:i:s T').' (offset '.$date->getOffset().")\n";
+--EXPECT--
+FROM TIMESTAMP, NO TZ:
+2012-08-21 22:00:00 GMT+0000 (offset 0)
+2012-08-21 22:00:00 GMT+0000 (offset 0)
+FROM TIMESTAMP, WITH TZ:
+2012-08-22 00:00:00 CEST (offset 7200)
+2012-08-22 00:00:00 CEST (offset 7200)
+FROM STRING:
+2012-08-22 00:00:00 CEST (offset 7200)
+2012-08-22 00:00:00 CEST (offset 7200)


### PR DESCRIPTION
Prevent a unix timestamp, which is always GMT when being parsed, from taking on
the local timezones DST flag.
