### PR TITLE
Bug #57702 :: Multiple BLOB fetch fails.

### DIFF
--- a/ext/pdo_oci/oci_statement.c
+++ b/ext/pdo_oci/oci_statement.c
@@ -99,7 +99,7 @@ static int oci_stmt_dtor(pdo_stmt_t *stmt TSRMLS_DC) /* {{{ */
 				switch (S->cols[i].dtype) {
 					case SQLT_BLOB:
 					case SQLT_CLOB:
-						/* do nothing */
+						OCIDescriptorFree(S->cols[i].data, OCI_DTYPE_LOB);
 						break;
 					default:
 						efree(S->cols[i].data);
@@ -654,7 +654,6 @@ static int oci_blob_close(php_stream *stream, int close_handle TSRMLS_DC)
 
 	if (close_handle) {
 		OCILobClose(self->S->H->svc, self->S->err, self->lob);
-		OCIDescriptorFree(self->lob, OCI_DTYPE_LOB);
 		efree(self);
 	}
 


### PR DESCRIPTION
Please refer to https://bugs.php.net/bug.php?id=57702 for more information.

P.S. May someone help to contribute the php-level test case for this issue? 

Sorry that since this bug will ALWAYS hit during installation when develop with Drupal 7.x pdo_oci driver, but very hard to reproduce its trigger with simple test cases...

Hope someone can give a hand for it ;-)
