### PR TITLE
Bug #52958 :: Segfault in PDO_OCI on cleanup after running a long testsuite.

### DIFF
--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -227,8 +227,10 @@ static int oci_handle_closer(pdo_dbh_t *dbh TSRMLS_DC) /* {{{ */
 		H->server = NULL;
 	}
 
-	OCIHandleFree(H->err, OCI_HTYPE_ERROR);
-	H->err = NULL;
+	if (H->err) {
+		OCIHandleFree(H->err, OCI_HTYPE_ERROR);
+		H->err = NULL;
+	}
 
 	if (H->charset && H->env) {
 		OCIHandleFree(H->env, OCI_HTYPE_ENV);


### PR DESCRIPTION
Please refer to https://bugs.php.net/bug.php?id=52958 for more information.

P.S. May someone help to contribute the php-level test case for this issue?

Sorry that since this bug will ALWAYS hit during installation when develop with Drupal 7.x pdo_oci driver, but very hard to reproduce its trigger with simple test cases...

Hope someone can give a hand for it ;-)
