### PR TITLE
Validate CN if CURLOPT_SSL_VERIFYHOST is set to true

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2014,6 +2014,10 @@ static int _php_curl_setopt(php_curl *ch, long option, zval **zvalue, zval *retu
 
 	switch (option) {
 		/* Long options */
+		case CURLOPT_SSL_VERIFYHOST:
+			if(Z_TYPE_PP(zvalue)==IS_BOOL && Z_BVAL_PP(zvalue)) {
+				php_error_docref(NULL TSRMLS_CC, E_NOTICE, "CURLOPT_SSL_VERIFYHOST set to true which disables common name validation (setting CURLOPT_SSL_VERIFYHOST to 2 enables common name validation)");
+			}
 		case CURLOPT_AUTOREFERER:
 		case CURLOPT_BUFFERSIZE:
 		case CURLOPT_CLOSEPOLICY:
@@ -2048,7 +2052,6 @@ static int _php_curl_setopt(php_curl *ch, long option, zval **zvalue, zval *retu
 		case CURLOPT_PUT:
 		case CURLOPT_RESUME_FROM:
 		case CURLOPT_SSLVERSION:
-		case CURLOPT_SSL_VERIFYHOST:
 		case CURLOPT_SSL_VERIFYPEER:
 		case CURLOPT_TIMECONDITION:
 		case CURLOPT_TIMEOUT:

--- a/ext/curl/tests/bug63363.phpt
+++ b/ext/curl/tests/bug63363.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Bug #63363 (CURL silently accepts boolean value for SSL_VERIFYHOST)
+--SKIPIF--
+<?php
+if (!extension_loaded("curl")) {
+        exit("skip curl extension not loaded");
+}
+
+?>
+--FILE--
+<?php
+$ch = curl_init();
+var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false));
+/* Case that should throw an error */
+var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true));
+var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0));
+var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 1));
+var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2));
+
+curl_close($ch);
+?>
+--EXPECTF--
+bool(true)
+
+Notice: curl_setopt(): CURLOPT_SSL_VERIFYHOST set to true which disables common name validation (setting CURLOPT_SSL_VERIFYHOST to 2 enables common name validation) in %s on line %d
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Per https://crypto.stanford.edu/~dabo/pubs/abstracts/ssl-client-bugs.html - if CURLOPT_SSL_VERIFYHOST is set to "true", convert_to_long_ex sets the LVAL to 1.

libcurl handles the CURLOPT_SSL_VERIFYHOST=1 differently than the default value, 2. CURLOPT_SSL_VERIFYHOST=1 will not check the common name (essentially allowing a MITM attack). A long value of 2 will validate the common name.

http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTSSLVERIFYHOST

I realize this may have impact to code previously setting CURLOPT_SSL_VERIFYHOST to "true" and not worrying about the CN validation - which may now break because libcurl will execute the CN validation. Don't think this is a particularly negative thing - presuming peoples' code had it set to "true" to begin with for peer + host validation.

[amended] - after discussion on internals, setting CURLOPT_SSL_VERIFYHOST should trigger a warning but the lval should remain 1.

[amended] Stas recommends this should be a notice and not a warning, makes sense to me.
