### PR TITLE
fix  bug 63392

### DIFF
--- a/ext/date/lib/tm2unixtime.c
+++ b/ext/date/lib/tm2unixtime.c
@@ -150,7 +150,14 @@ static void do_adjust_for_weekday(timelib_time* time)
 	if (time->relative.weekday_behavior == 2)
 	{
 		if (time->relative.weekday == 0) {
-			time->relative.weekday = 7;
+                         /*
+			    这里不知道为什么 原始的代码是查看这个值等于0的情况，再把这个值赋值为7 。这个导致了
+			    Bug #63392	，5.13号  如果 加0的话 就不会产生bug,就是因为这个奇怪的赋值，导致了这个bug,不知道
+				原始的作者是怎么考虑的。
+
+
+			*/		
+			//time->relative.weekday = 7;
 		}
 		time->d -= current_dow;
 		time->d += time->relative.weekday;

--- a/ext/date/lib/tm2unixtime.c
+++ b/ext/date/lib/tm2unixtime.c
@@ -149,16 +149,6 @@ static void do_adjust_for_weekday(timelib_time* time)
 	current_dow = timelib_day_of_week(time->y, time->m, time->d);
 	if (time->relative.weekday_behavior == 2)
 	{
-		if (time->relative.weekday == 0) {
-                         /*
-			    这里不知道为什么 原始的代码是查看这个值等于0的情况，再把这个值赋值为7 。这个导致了
-			    Bug #63392	，5.13号  如果 加0的话 就不会产生bug,就是因为这个奇怪的赋值，导致了这个bug,不知道
-				原始的作者是怎么考虑的。
-
-
-			*/		
-			//time->relative.weekday = 7;
-		}
 		time->d -= current_dow;
 		time->d += time->relative.weekday;
 		return;

--- a/ext/date/tests/bug63392.phpt
+++ b/ext/date/tests/bug63392.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #63392 (DateTime::modify() start of week inconsistency)
+Description:
+------------
+Calling $dt->modify("Monday this week") for all dates 13¨C19 May 2012 (Sun¨CSat) 
+result in the same date (2012-05-14), suggesting that "this week" runs Sun¨CSat. 
+However, calling $dt->modify("Sunday this week") gives the "next" Sunday (2012-
+05-20) for the same range.
+
+On a related note, the documentation on relative date formats is lacking on the 
+behaviour of this and strtotime when used with locales; one might expect the 
+start of the week to be interpreted from LC_TIME.
+--FILE--
+<?php
+
+$dt = new DateTime("2012-05-13");
+$dt->modify("Sunday this week");
+var_dump($dt->format('r')
+?>
+--EXPECT--
+string(31) "Sun, 13 May 2012 00:00:00 +0000"

--- a/ext/date/tests/bug63392.phpt
+++ b/ext/date/tests/bug63392.phpt
@@ -3,6 +3,9 @@ Bug #63392 (DateTime::modify() start of week inconsistency)
 Description:
 ------------
 
+
+--INI--
+date.timezone=UTC
 --FILE--
 <?php
 

--- a/ext/date/tests/bug63392.phpt
+++ b/ext/date/tests/bug63392.phpt
@@ -2,20 +2,13 @@
 Bug #63392 (DateTime::modify() start of week inconsistency)
 Description:
 ------------
-Calling $dt->modify("Monday this week") for all dates 13¨C19 May 2012 (Sun¨CSat) 
-result in the same date (2012-05-14), suggesting that "this week" runs Sun¨CSat. 
-However, calling $dt->modify("Sunday this week") gives the "next" Sunday (2012-
-05-20) for the same range.
 
-On a related note, the documentation on relative date formats is lacking on the 
-behaviour of this and strtotime when used with locales; one might expect the 
-start of the week to be interpreted from LC_TIME.
 --FILE--
 <?php
 
 $dt = new DateTime("2012-05-13");
 $dt->modify("Sunday this week");
-var_dump($dt->format('r')
+var_dump($dt->format('r'));
 ?>
 --EXPECT--
 string(31) "Sun, 13 May 2012 00:00:00 +0000"


### PR DESCRIPTION
i delete these code if(time->relative.weekday == 0)time->relative.weekday == 7; these code cause bug 63392  , bug test  script blow
<?php

$dt = new DateTime("2012-05-13");
$dt->modify("Sunday this week");
var_dump($dt->format('r'));

Expected result:
----------------
string(31) "Sun, 13 May 2012 00:00:00 +0000"

Actual result:
--------------
string(31) "Sun, 20 May 2012 00:00:00 +0000"