### PR TITLE
Update TSRM/tsrm_win32.c

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -193,7 +193,7 @@ Finished:
 TSRM_API int tsrm_win32_access(const char *pathname, int mode TSRMLS_DC)
 {
 	time_t t;
-	HANDLE thread_token;
+	HANDLE thread_token = NULL;
 	PSID token_sid;
 	SECURITY_INFORMATION sec_info = OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION;
 	GENERIC_MAPPING gen_map = { FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_GENERIC_EXECUTE, FILE_ALL_ACCESS };
@@ -363,6 +363,10 @@ Finished_Impersonate:
 		}
 
 Finished:
+		if(thread_token != NULL) {
+			CloseHandle(thread_token);
+		}
+
 		if(real_path != NULL) {
 			free(real_path);
 			real_path = NULL;


### PR DESCRIPTION
This update fixes the handle leak described here - https://bugs.php.net/bug.php?id=62444

We have to initialize the local thread_token variable to prevent closing some 'random' handle. And at the end of the function we have to use CloseHandle to free the resources we might have obtained, to prevent the leak.
