### PR TITLE
Fixed bug #63428 (The behavior of execute() changed)

### DIFF
--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -459,7 +459,13 @@ ZEND_API void execute_ex(zend_execute_data *execute_data TSRMLS_DC)
 
 ZEND_API void execute(zend_op_array *op_array TSRMLS_DC)
 {
-	zend_execute_data *execute_data = zend_create_execute_data_from_op_array(op_array, 0 TSRMLS_CC);
+	zend_execute_data *execute_data;
+
+	if (EG(exception)) {
+		return;
+	}
+
+	execute_data = zend_create_execute_data_from_op_array(op_array, 0 TSRMLS_CC);
 
 	execute_ex(execute_data TSRMLS_CC);
 }

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -110,7 +110,13 @@ ZEND_API void {%EXECUTOR_NAME%}_ex(zend_execute_data *execute_data TSRMLS_DC)
 
 ZEND_API void {%EXECUTOR_NAME%}(zend_op_array *op_array TSRMLS_DC)
 {
-	zend_execute_data *execute_data = zend_create_execute_data_from_op_array(op_array, 0 TSRMLS_CC);
+	zend_execute_data *execute_data;
+
+	if (EG(exception)) {
+		return;
+	}
+
+	execute_data = zend_create_execute_data_from_op_array(op_array, 0 TSRMLS_CC);
 
 	{%EXECUTOR_NAME%}_ex(execute_data TSRMLS_CC);
 }


### PR DESCRIPTION
After the patch: f627be52540738e124da7cb1566d7f60a2b6a48b

Test Zend/tests/bug35437.phpt failed when zend_execute
wasn't function execute, such as dtrace or xdebug enabled.

execute() will call zend_vm_stack_alloc even EG(exception) is not null (that was changed), 
which will case segfault when testing bug35437.phpt
