### PR TITLE
Adding bug 63463 test

### DIFF
--- a/tests/classes/bug63463.phpt
+++ b/tests/classes/bug63463.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Verifies that ReflectionProperty does not cause magic methods to get called when properties are unset
+--FILE--
+<?php
+
+class Test
+{
+	public	$publicProperty;
+	protected $protectedProperty;
+	private   $privateProperty;
+
+	public function __construct() {
+		unset(
+			$this->publicProperty,
+			$this->protectedProperty,
+			$this->privateProperty
+		);
+	}
+
+	function __get($name) {
+		echo 'called __get ' . $name;
+	}
+
+	function __set($name, $value) {
+		echo 'called __set ' . $name . ' ' . $value;
+	}
+}
+
+$t = new Test();
+
+foreach (array('publicProperty', 'protectedProperty', 'privateProperty') as $propertyName) {
+	$prop = new ReflectionProperty('Test', $propertyName);
+	$prop->setAccessible(true);
+	echo var_export($prop->getValue($t), true) . "\n";
+	$prop->setValue($t, 'value');
+}
+
+?>
+--EXPECTF--
+NULL
+NULL
+NULL


### PR DESCRIPTION
This PR introduces a failing test for bug [63463](https://bugs.php.net/bug.php?id=63463).

`ReflectionProperty::setValue` or `ReflectionProperty::getValue` triggers `__get`, `__set` when accessing properties that were unset.
