### PR TITLE
make failed tests fail the test target

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -86,7 +86,7 @@ PHP_TEST_SHARED_EXTENSIONS =  ` \
 PHP_DEPRECATED_DIRECTIVES_REGEX = '^(magic_quotes_(gpc|runtime|sybase)?|(zend_)?extension(_debug)?(_ts)?)[\t\ ]*='
 
 test: all
-	-@if test ! -z "$(PHP_EXECUTABLE)" && test -x "$(PHP_EXECUTABLE)"; then \
+	@if test ! -z "$(PHP_EXECUTABLE)" && test -x "$(PHP_EXECUTABLE)"; then \
 		INI_FILE=`$(PHP_EXECUTABLE) -d 'display_errors=stderr' -r 'echo php_ini_loaded_file();' 2> /dev/null`; \
 		if test "$$INI_FILE"; then \
 			$(EGREP) -h -v $(PHP_DEPRECATED_DIRECTIVES_REGEX) "$$INI_FILE" > $(top_builddir)/tmp-php.ini; \


### PR DESCRIPTION
I don't see any reason to ignore failed tests. This makes it unnecessarily difficult to use ci, also for module builds, since Makefile.global is copied by phpize.
