### PR TITLE
Fixed bug #60285 (setting REPORT_EXIT_STATUS for make test won't work)

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -101,8 +101,7 @@ test: all
 		TEST_PHP_EXECUTABLE=$(PHP_EXECUTABLE) \
 		TEST_PHP_SRCDIR=$(top_srcdir) \
 		CC="$(CC)" \
-			$(PHP_EXECUTABLE) -n -c $(top_builddir)/tmp-php.ini $(PHP_TEST_SETTINGS) $(top_srcdir)/run-tests.php -n -c $(top_builddir)/tmp-php.ini -d extension_dir=$(top_builddir)/modules/ $(PHP_TEST_SHARED_EXTENSIONS) $(TESTS); \
-		rm $(top_builddir)/tmp-php.ini; \
+			$(PHP_EXECUTABLE) -n -c $(top_builddir)/tmp-php.ini $(PHP_TEST_SETTINGS) $(top_srcdir)/run-tests.php -n -c $(top_builddir)/tmp-php.ini -d extension_dir=$(top_builddir)/modules/ $(PHP_TEST_SHARED_EXTENSIONS) $(TESTS) && rm $(top_builddir)/tmp-php.ini; \
 	else \
 		echo "ERROR: Cannot run tests without CLI sapi."; \
 	fi


### PR DESCRIPTION
See https://bugs.php.net/bug.php?id=60285

This is related to PR #232

after the patch:
`REPORT_EXIT_STATUS=1 make test` will works as expected`

this makes ci like travis easier

BTW  @lstrojny #232 was merged to master only,  I thought both #232 and this PR could apply
to all branches,  or at least 5.5, what do you think?
