### PR TITLE
Issue 23955: setcookie() to send Max-Age attribute

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1153,11 +1153,11 @@ static int php_session_cache_limiter(TSRMLS_D) /* {{{ */
    ********************* */
 
 #define COOKIE_SET_COOKIE "Set-Cookie: "
-#define COOKIE_EXPIRES	"; Expires="
+#define COOKIE_EXPIRES	"; expires="
 #define COOKIE_MAX_AGE	"; Max-Age="
-#define COOKIE_PATH		"; Path="
-#define COOKIE_DOMAIN	"; Domain="
-#define COOKIE_SECURE	"; Secure"
+#define COOKIE_PATH		"; path="
+#define COOKIE_DOMAIN	"; domain="
+#define COOKIE_SECURE	"; secure"
 #define COOKIE_HTTPONLY	"; HttpOnly"
 
 static void php_session_send_cookie(TSRMLS_D) /* {{{ */

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -117,14 +117,14 @@ PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, t
 		 * pick an expiry date in the past
 		 */
 		dt = php_format_date("D, d-M-Y H:i:s T", sizeof("D, d-M-Y H:i:s T")-1, 1, 0 TSRMLS_CC);
-		snprintf(cookie, len + 100, "Set-Cookie: %s=deleted; Expires=%s; Max-Age=0", name, dt);
+		snprintf(cookie, len + 100, "Set-Cookie: %s=deleted; expires=%s; Max-Age=0", name, dt);
 		efree(dt);
 	} else {
 		snprintf(cookie, len + 100, "Set-Cookie: %s=%s", name, value ? encoded_value : "");
 		if (expires > 0) {
 			const char *p;
 			char tsdelta[13];
-			strlcat(cookie, "; Expires=", len + 100);
+			strlcat(cookie, "; expires=", len + 100);
 			dt = php_format_date("D, d-M-Y H:i:s T", sizeof("D, d-M-Y H:i:s T")-1, expires, 0 TSRMLS_CC);
 			/* check to make sure that the year does not exceed 4 digits in length */
 			p = zend_memrchr(dt, '-', strlen(dt));
@@ -149,18 +149,18 @@ PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, t
 	}
 
 	if (path && path_len > 0) {
-		strlcat(cookie, "; Path=", len + 100);
+		strlcat(cookie, "; path=", len + 100);
 		strlcat(cookie, path, len + 100);
 	}
 	if (domain && domain_len > 0) {
-		strlcat(cookie, "; Domain=", len + 100);
+		strlcat(cookie, "; domain=", len + 100);
 		strlcat(cookie, domain, len + 100);
 	}
 	if (secure) {
-		strlcat(cookie, "; Secure", len + 100);
+		strlcat(cookie, "; secure", len + 100);
 	}
 	if (httponly) {
-		strlcat(cookie, "; HttpOnly", len + 100);
+		strlcat(cookie, "; httponly", len + 100);
 	}
 
 	ctr.line = cookie;

--- a/ext/standard/tests/network/setcookie.phpt
+++ b/ext/standard/tests/network/setcookie.phpt
@@ -23,13 +23,13 @@ $expected = array(
 	'Set-Cookie: name=value',
 	'Set-Cookie: name=space+value',
 	'Set-Cookie: name=value',
-	'Set-Cookie: name=value; Expires='.date('D, d-M-Y H:i:s', $tsp).' GMT; Max-Age=5',
-	'Set-Cookie: name=value; Expires='.date('D, d-M-Y H:i:s', $tsn).' GMT; Max-Age=-6',
-	'Set-Cookie: name=value; Expires='.date('D, d-M-Y H:i:s', $tsc).' GMT; Max-Age=0',
-	'Set-Cookie: name=value; Path=/path/',
-	'Set-Cookie: name=value; Domain=domain.tld',
-	'Set-Cookie: name=value; Secure',
-	'Set-Cookie: name=value; HttpOnly'
+	'Set-Cookie: name=value; expires='.date('D, d-M-Y H:i:s', $tsp).' GMT; Max-Age=5',
+	'Set-Cookie: name=value; expires='.date('D, d-M-Y H:i:s', $tsn).' GMT; Max-Age=-6',
+	'Set-Cookie: name=value; expires='.date('D, d-M-Y H:i:s', $tsc).' GMT; Max-Age=0',
+	'Set-Cookie: name=value; path=/path/',
+	'Set-Cookie: name=value; domain=domain.tld',
+	'Set-Cookie: name=value; secure',
+	'Set-Cookie: name=value; httponly'
 );
 
 $headers = headers_list();


### PR DESCRIPTION
`setcookie()` should send not only the _Expires_, but also the _Max-Age_ attribute.
Changed the session extension to send the Max-Age attribute as well.

As described in [#23955](https://bugs.php.net/bug.php?id=23955), a user agent having an erroneously configured timezone would have issues when calculating when to expire the cookie.

As described in [RFC6265](http://www.faqs.org/rfcs/rfc6265.html), Max-Age must be implemented by user agents in the following manner:
- Specifies delta time in seconds and when present.
- Has precedence over Expires, when both are present.
- User agents that don't support it should simply ignore it.

Given those characteristics, it only makes sense that both Expires and Max-Age are sent together.

This MIGHT also fix [#43439](https://bugs.php.net/bug.php?id=43439), but I'm not really sure about it - should be checked.

Edit:

https://wiki.php.net/rfc/cookie_max-age
