### PR TITLE
Pdosqlite bug

### DIFF
--- a/ext/pdo/tests/bug_63916.phpt
+++ b/ext/pdo/tests/bug_63916.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #63916 PDO::PARAM_INT casts to 32bit int internally even on 64bit builds in pdo_sqlite
+--SKIPIF--
+<?php 
+if (!extension_loaded('pdo')) die('skip');
+?>
+--FILE--
+<?php
+$num = 100004313234244; // notice this exceeds 32 bits
+$conn = new PDO('sqlite::memory:');
+$conn->query('CREATE TABLE users (id INTEGER NOT NULL, num INTEGER NOT NULL, PRIMARY KEY(id))');
+
+$stmt = $conn->prepare('insert into users (id, num) values (:id, :num)');
+$stmt->bindValue(':id', 1, PDO::PARAM_INT);
+$stmt->bindValue(':num', $num, PDO::PARAM_INT);
+$stmt->execute();
+
+$stmt = $conn->query('SELECT num FROM users');
+$result = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+var_dump($num,$result[0]);
+
+?>
+--EXPECT--
+int(100004313234244)
+string(15) "100004313234244"

--- a/ext/pdo_sqlite/sqlite_statement.c
+++ b/ext/pdo_sqlite/sqlite_statement.c
@@ -112,8 +112,14 @@ static int pdo_sqlite_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_d
 							}
 						} else {
 							convert_to_long(param->parameter);
-							if (SQLITE_OK == sqlite3_bind_int(S->stmt, param->paramno + 1, Z_LVAL_P(param->parameter))) {
-								return 1;
+							if (LONG_MAX > 2147483647) {
+								if (SQLITE_OK == sqlite3_bind_int64(S->stmt, param->paramno + 1, Z_LVAL_P(param->parameter))) {
+									return 1;
+								}
+							} else {
+								if (SQLITE_OK == sqlite3_bind_int(S->stmt, param->paramno + 1, Z_LVAL_P(param->parameter))) {
+									return 1;
+								}
 							}
 						}
 						pdo_sqlite_error_stmt(stmt);


### PR DESCRIPTION
Fixes Bug #63916 PDO::PARAM_INT casts to 32bit int internally even on 64bit builds in pdo_sqlite.
