### PR TITLE
Fixes #63921 sqlite3::bindvalue and relative PHP functions aren't using ...

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -730,7 +730,11 @@ static int sqlite3_do_callback(struct php_sqlite3_fci *fc, zval *cb, int argc, s
 
 		switch (sqlite3_value_type(argv[i])) {
 			case SQLITE_INTEGER:
+#if LONG_MAX > 2147483647
+				ZVAL_LONG(*zargs[i + is_agg], sqlite3_value_int64(argv[i]));
+#else
 				ZVAL_LONG(*zargs[i + is_agg], sqlite3_value_int(argv[i]));
+#endif
 				break;
 
 			case SQLITE_FLOAT:
@@ -774,7 +778,11 @@ static int sqlite3_do_callback(struct php_sqlite3_fci *fc, zval *cb, int argc, s
 		if (retval) {
 			switch (Z_TYPE_P(retval)) {
 				case IS_LONG:
+#if LONG_MAX > 2147483647
+					sqlite3_result_int64(context, Z_LVAL_P(retval));
+#else
 					sqlite3_result_int(context, Z_LVAL_P(retval));
+#endif
 					break;
 
 				case IS_NULL:
@@ -1493,7 +1501,11 @@ PHP_METHOD(sqlite3stmt, execute)
 			switch (param->type) {
 				case SQLITE_INTEGER:
 					convert_to_long(param->parameter);
+#if LONG_MAX > 2147483647
+					sqlite3_bind_int64(stmt_obj->stmt, param->param_number, Z_LVAL_P(param->parameter));
+#else
 					sqlite3_bind_int(stmt_obj->stmt, param->param_number, Z_LVAL_P(param->parameter));
+#endif
 					break;
 
 				case SQLITE_FLOAT:

--- a/ext/sqlite3/tests/bug63921-32bit.phpt
+++ b/ext/sqlite3/tests/bug63921-32bit.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #63921 sqlite3::bindvalue and relative PHP functions aren't using sqlite3_*_int64 API
+--SKIPIF--
+<?php 
+if (!extension_loaded('sqlite3')) die('skip');
+if (PHP_INT_SIZE > 4) die('skip'); // skip for 64bit builds - there is another test for that
+?>
+--FILE--
+<?php
+$num = PHP_INT_MAX; // 32 bits
+$conn = new sqlite3(':memory:');
+$conn->query('CREATE TABLE users (id INTEGER NOT NULL, num INTEGER NOT NULL, PRIMARY KEY(id))');
+
+$stmt = $conn->prepare('insert into users (id, num) values (:id, :num)');
+$stmt->bindValue(':id', 1, SQLITE3_INTEGER);
+$stmt->bindValue(':num', $num, SQLITE3_INTEGER);
+$stmt->execute();
+
+$stmt = $conn->query('SELECT num FROM users');
+$result = $stmt->fetchArray();
+
+var_dump($num,$result[0]);
+
+?>
+--EXPECT--
+int(2147483647)
+string(10) "2147483647"

--- a/ext/sqlite3/tests/bug63921-64bit.phpt
+++ b/ext/sqlite3/tests/bug63921-64bit.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #63921 sqlite3::bindvalue and relative PHP functions aren't using sqlite3_*_int64 API
+--SKIPIF--
+<?php 
+if (!extension_loaded('sqlite3')) die('skip');
+if (PHP_INT_SIZE < 8) die('skip'); // skip for 32bit builds - there is another test for that
+?>
+--FILE--
+<?php
+$num = 100004313234244; // notice this exceeds 32 bits
+$conn = new sqlite3(':memory:');
+$conn->query('CREATE TABLE users (id INTEGER NOT NULL, num INTEGER NOT NULL, PRIMARY KEY(id))');
+
+$stmt = $conn->prepare('insert into users (id, num) values (:id, :num)');
+$stmt->bindValue(':id', 1, SQLITE3_INTEGER);
+$stmt->bindValue(':num', $num, SQLITE3_INTEGER);
+$stmt->execute();
+
+$stmt = $conn->query('SELECT num FROM users');
+$result = $stmt->fetchArray();
+
+var_dump($num,$result[0]);
+
+?>
+--EXPECT--
+int(100004313234244)
+string(15) "100004313234244"


### PR DESCRIPTION
...sqlite3_*_int64 API calls.
