### PR TITLE
Feature/class name as scalar

### DIFF
--- a/Zend/tests/class_name_as_scalar.phpt
+++ b/Zend/tests/class_name_as_scalar.phpt
@@ -1,0 +1,77 @@
+--TEST--
+class name as scalar from ::class keyword
+--FILE--
+<?php
+
+namespace Foo\Bar {
+    class One {
+        // compile time constants
+        const A = self::class;
+        const B = Two::class;
+    }
+    class Two extends One {
+        public static function run() {
+            var_dump(self::class); // self compile time lookup
+            var_dump(static::class); // runtime lookup
+            var_dump(parent::class); // runtime lookup
+            var_dump(Baz::class); // default compile time lookup
+        }
+    }
+    class Three extends Two {
+        // compile time static lookups
+        public static function checkCompileTime(
+            $one = self::class,
+            $two = Baz::class,
+            $three = One::A,
+            $four = self::B
+        ) {
+            var_dump($one, $two, $three, $four);
+        }
+    }
+    echo "In NS\n";
+    var_dump(Moo::CLASS); // resolve in namespace
+}
+
+namespace {
+    use Bee\Bop as Moo,
+        Foo\Bar\One;
+    echo "Top\n";
+    var_dump(One::class); // resolve from use
+    var_dump(Boo::class); // resolve in global namespace
+    var_dump(Moo::CLASS); // resolve from use as
+    var_dump(\Moo::Class); // resolve fully qualified
+    $class = One::class; // assign class as scalar to var
+    $x = new $class; // create new class from original scalar assignment
+    var_dump($x);
+    Foo\Bar\Two::run(); // resolve runtime lookups
+    echo "Parent\n";
+    Foo\Bar\Three::run(); // resolve runtime lookups with inheritance
+    echo "Compile Check\n";
+    Foo\Bar\Three::checkCompileTime();
+}
+
+?>
+--EXPECTF--
+In NS
+string(11) "Foo\Bar\Moo"
+Top
+string(11) "Foo\Bar\One"
+string(3) "Boo"
+string(7) "Bee\Bop"
+string(3) "Moo"
+object(Foo\Bar\One)#1 (0) {
+}
+string(11) "Foo\Bar\Two"
+string(11) "Foo\Bar\Two"
+string(11) "Foo\Bar\One"
+string(11) "Foo\Bar\Baz"
+Parent
+string(11) "Foo\Bar\Two"
+string(13) "Foo\Bar\Three"
+string(11) "Foo\Bar\One"
+string(11) "Foo\Bar\Baz"
+Compile Check
+string(13) "Foo\Bar\Three"
+string(11) "Foo\Bar\Baz"
+string(11) "Foo\Bar\One"
+string(11) "Foo\Bar\Two"

--- a/Zend/tests/class_name_as_scalar_error_001.phpt
+++ b/Zend/tests/class_name_as_scalar_error_001.phpt
@@ -1,0 +1,13 @@
+--TEST--
+class name as scalar from ::class keyword error using static in class constant
+--FILE--
+<?php
+
+namespace Foo\Bar {
+    class One {
+    	const Baz = static::class;
+    }
+}
+?>
+--EXPECTF--
+Fatal error: static::class cannot be used for compile-time class name resolution in %s on line %d

--- a/Zend/tests/class_name_as_scalar_error_002.phpt
+++ b/Zend/tests/class_name_as_scalar_error_002.phpt
@@ -1,0 +1,13 @@
+--TEST--
+class name as scalar from ::class keyword error using parent in class constant
+--FILE--
+<?php
+
+namespace Foo\Bar {
+    class One {
+    	const Baz = parent::class;
+    }
+}
+?>
+--EXPECTF--
+Fatal error: parent::class cannot be used for compile-time class name resolution in %s on line %d

--- a/Zend/tests/class_name_as_scalar_error_003.phpt
+++ b/Zend/tests/class_name_as_scalar_error_003.phpt
@@ -1,0 +1,13 @@
+--TEST--
+class name as scalar from ::class keyword error using static in method signature
+--FILE--
+<?php
+
+namespace Foo\Bar {
+    class One {
+    	public function baz($x = static::class) {}
+    }
+}
+?>
+--EXPECTF--
+Fatal error: static::class cannot be used for compile-time class name resolution in %s on line %d

--- a/Zend/tests/class_name_as_scalar_error_004.phpt
+++ b/Zend/tests/class_name_as_scalar_error_004.phpt
@@ -1,0 +1,13 @@
+--TEST--
+class name as scalar from ::class keyword error using parent in method signature
+--FILE--
+<?php
+
+namespace Foo\Bar {
+    class One {
+    	public function baz($x = parent::class) {}
+    }
+}
+?>
+--EXPECTF--
+Fatal error: parent::class cannot be used for compile-time class name resolution in %s on line %d

--- a/Zend/tests/class_name_as_scalar_error_005.phpt
+++ b/Zend/tests/class_name_as_scalar_error_005.phpt
@@ -1,0 +1,10 @@
+--TEST--
+class name as scalar from ::class keyword error using static non class context
+--FILE--
+<?php
+
+$x = static::class;
+
+?>
+--EXPECTF--
+Fatal error: Cannot access static::class when no class scope is active in %s on line %d

--- a/Zend/tests/class_name_as_scalar_error_006.phpt
+++ b/Zend/tests/class_name_as_scalar_error_006.phpt
@@ -1,0 +1,10 @@
+--TEST--
+class name as scalar from ::class keyword error using parent in non class context
+--FILE--
+<?php
+
+$x = parent::class;
+
+?>
+--EXPECTF--
+Fatal error: Cannot access parent::class when no class scope is active in %s on line %d

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -942,6 +942,7 @@ common_scalar:
 
 static_scalar: /* compile-time evaluated scalars */
 		common_scalar		{ $$ = $1; }
+	|	static_class_name_scalar	{ $$ = $1; }
 	|	namespace_name 		{ zend_do_fetch_constant(&$$, NULL, &$1, ZEND_CT, 1 TSRMLS_CC); }
 	|	T_NAMESPACE T_NS_SEPARATOR namespace_name { $$.op_type = IS_CONST; ZVAL_EMPTY_STRING(&$$.u.constant);  zend_do_build_namespace_name(&$$, &$$, &$3 TSRMLS_CC); $3 = $$; zend_do_fetch_constant(&$$, NULL, &$3, ZEND_CT, 0 TSRMLS_CC); }
 	|	T_NS_SEPARATOR namespace_name { char *tmp = estrndup(Z_STRVAL($2.u.constant), Z_STRLEN($2.u.constant)+1); memcpy(&(tmp[1]), Z_STRVAL($2.u.constant), Z_STRLEN($2.u.constant)+1); tmp[0] = '\\'; efree(Z_STRVAL($2.u.constant)); Z_STRVAL($2.u.constant) = tmp; ++Z_STRLEN($2.u.constant); zend_do_fetch_constant(&$$, NULL, &$2, ZEND_CT, 0 TSRMLS_CC); }
@@ -959,6 +960,7 @@ static_class_constant:
 
 scalar:
 		T_STRING_VARNAME		{ $$ = $1; }
+	|	class_name_scalar	{ $$ = $1; }
 	|	class_constant		{ $$ = $1; }
 	|	namespace_name	{ zend_do_fetch_constant(&$$, NULL, &$1, ZEND_RT, 1 TSRMLS_CC); }
 	|	T_NAMESPACE T_NS_SEPARATOR namespace_name { $$.op_type = IS_CONST; ZVAL_EMPTY_STRING(&$$.u.constant);  zend_do_build_namespace_name(&$$, &$$, &$3 TSRMLS_CC); $3 = $$; zend_do_fetch_constant(&$$, NULL, &$3, ZEND_RT, 0 TSRMLS_CC); }
@@ -1198,6 +1200,14 @@ isset_variable:
 class_constant:
 		class_name T_PAAMAYIM_NEKUDOTAYIM T_STRING { zend_do_fetch_constant(&$$, &$1, &$3, ZEND_RT, 0 TSRMLS_CC); }
 	|	variable_class_name T_PAAMAYIM_NEKUDOTAYIM T_STRING { zend_do_fetch_constant(&$$, &$1, &$3, ZEND_RT, 0 TSRMLS_CC); }
+;
+
+static_class_name_scalar:
+	class_name T_PAAMAYIM_NEKUDOTAYIM T_CLASS { zend_do_resolve_class_name(&$$, &$1, 1 TSRMLS_CC); }
+;
+
+class_name_scalar:
+	class_name T_PAAMAYIM_NEKUDOTAYIM T_CLASS { zend_do_resolve_class_name(&$$, &$1, 0 TSRMLS_CC); }
 ;
 
 %%

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3567,6 +3567,9 @@ ZEND_VM_HANDLER(99, ZEND_FETCH_CONSTANT, VAR|CONST|UNUSED, CONST)
 			}
 			ZVAL_COPY_VALUE(&EX_T(opline->result.var).tmp_var, *value);
 			zval_copy_ctor(&EX_T(opline->result.var).tmp_var);
+		} else if (Z_STRLEN_P(opline->op2.zv) == sizeof("class")-1 && strcmp(Z_STRVAL_P(opline->op2.zv), "class") == 0) {
+			/* "class" is assigned as a case-sensitive keyword from zend_do_resolve_class_name */ 
+			ZVAL_STRINGL(&EX_T(opline->result.var).tmp_var, ce->name, ce->name_length, 1);
 		} else {
 			zend_error_noreturn(E_ERROR, "Undefined class constant '%s'", Z_STRVAL_P(opline->op2.zv));
 		}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3735,6 +3735,9 @@ static int ZEND_FASTCALL  ZEND_FETCH_CONSTANT_SPEC_CONST_CONST_HANDLER(ZEND_OPCO
 			}
 			ZVAL_COPY_VALUE(&EX_T(opline->result.var).tmp_var, *value);
 			zval_copy_ctor(&EX_T(opline->result.var).tmp_var);
+		} else if (Z_STRLEN_P(opline->op2.zv) == sizeof("class")-1 && strcmp(Z_STRVAL_P(opline->op2.zv), "class") == 0) {
+			/* "class" is assigned as a case-sensitive keyword from zend_do_resolve_class_name */
+			ZVAL_STRINGL(&EX_T(opline->result.var).tmp_var, ce->name, ce->name_length, 1);
 		} else {
 			zend_error_noreturn(E_ERROR, "Undefined class constant '%s'", Z_STRVAL_P(opline->op2.zv));
 		}
@@ -15600,6 +15603,9 @@ static int ZEND_FASTCALL  ZEND_FETCH_CONSTANT_SPEC_VAR_CONST_HANDLER(ZEND_OPCODE
 			}
 			ZVAL_COPY_VALUE(&EX_T(opline->result.var).tmp_var, *value);
 			zval_copy_ctor(&EX_T(opline->result.var).tmp_var);
+		} else if (Z_STRLEN_P(opline->op2.zv) == sizeof("class")-1 && strcmp(Z_STRVAL_P(opline->op2.zv), "class") == 0) {
+			/* "class" is assigned as a case-sensitive keyword from zend_do_resolve_class_name */
+			ZVAL_STRINGL(&EX_T(opline->result.var).tmp_var, ce->name, ce->name_length, 1);
 		} else {
 			zend_error_noreturn(E_ERROR, "Undefined class constant '%s'", Z_STRVAL_P(opline->op2.zv));
 		}
@@ -25175,6 +25181,9 @@ static int ZEND_FASTCALL  ZEND_FETCH_CONSTANT_SPEC_UNUSED_CONST_HANDLER(ZEND_OPC
 			}
 			ZVAL_COPY_VALUE(&EX_T(opline->result.var).tmp_var, *value);
 			zval_copy_ctor(&EX_T(opline->result.var).tmp_var);
+		} else if (Z_STRLEN_P(opline->op2.zv) == sizeof("class")-1 && strcmp(Z_STRVAL_P(opline->op2.zv), "class") == 0) {
+			/* "class" is assigned as a case-sensitive keyword from zend_do_resolve_class_name */
+			ZVAL_STRINGL(&EX_T(opline->result.var).tmp_var, ce->name, ce->name_length, 1);
 		} else {
 			zend_error_noreturn(E_ERROR, "Undefined class constant '%s'", Z_STRVAL_P(opline->op2.zv));
 		}


### PR DESCRIPTION
FOR RFC: https://wiki.php.net/rfc/class_name_scalars

Patch addresses:
- Allows for Name::class, self::class, static::class, parent::class resolution to a scalar based on current use rules and current namespace.
- Reuses existing keyword "class"
