### PR TITLE
Fix compile failure introduced by the fix for bug #46408.

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -584,7 +584,7 @@ ZEND_API void _convert_to_cstring(zval *op ZEND_FILE_LINE_DC) /* {{{ */
 			break;
 		}
 		default:
-			return _convert_to_string(op);
+			_convert_to_string(op ZEND_FILE_LINE_CC);
 	}
 	Z_TYPE_P(op) = IS_STRING;
 }


### PR DESCRIPTION
Commit 92965b033afa098945d18080203de1595084d1ac broke compilation in zend_operators.c on gcc 4.7.2 (and probably other versions). This fixes it.
