### PR TITLE
Fix minor build problem in C++11

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -60,7 +60,7 @@ typedef struct _zend_fcall_info_cache {
 	zval *object_ptr;
 } zend_fcall_info_cache;
 
-#define ZEND_NS_NAME(ns, name)			ns"\\"name
+#define ZEND_NS_NAME(ns, name)			ns "\\" name
 
 #define ZEND_FN(name) zif_##name
 #define ZEND_MN(name) zim_##name


### PR DESCRIPTION
Clang++ 3.3 (and presumably other C++11 compilers) chokes on the definition of ZEND_NS_NAME in Zend/zend_API.h, because it's interpreted as a user-defined literal.

I've verified that Clang++ parses the headers correctly with this patch, and PHP itself (I tested master and 5.4.12) still builds correctly using gcc 4.2.1 and clang 4.1 on Mac OS X.

I'd like to have this patch go into master as well as the 5.4 and 5.5 branches.
