### PR TITLE
New SSL stream context option to prevent CRIME attack vector

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -395,6 +395,18 @@ static inline int php_openssl_setup_crypto(php_stream *stream,
 	}
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	{
+		zval **val;
+		
+		if (stream->context && SUCCESS == php_stream_context_get_option(
+					stream->context, "ssl", "disable_compression", &val) &&
+				zval_is_true(*val)) {
+			SSL_CTX_set_options(sslsock->ctx, SSL_OP_NO_COMPRESSION);
+		}
+	}
+#endif
+
 	sslsock->ssl_handle = php_SSL_new_from_context(sslsock->ctx, stream TSRMLS_CC);
 	if (sslsock->ssl_handle == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "failed to create an SSL handle");


### PR DESCRIPTION
The CRIME attack vector exploits TLS compression. This patch adds a stream context option allowing servers to disable TLS compression for versions of OpenSSL >= 1.0.0 (which first introduced the SSL_OP_NO_COMPRESSION option). A summary rundown of the CRIME attack can be found here:
https://community.qualys.com/blogs/securitylabs/2012/09/14/crime-information-leakage-attack-against-ssltls

Thanks to @DaveRandom for locating the relevant section of code and for his sage input on the subject.
