### PR TITLE
fix chmod_basic test

### DIFF
--- a/ext/standard/tests/file/chmod_basic.phpt
+++ b/ext/standard/tests/file/chmod_basic.phpt
@@ -9,14 +9,14 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 --FILE--
 <?php
 
-define("MODE_MASK", 07777);
+define("MODE_MASK", 0777);
 
 $filename = __FILE__ . ".tmp";
 
 $fd = fopen($filename, "w+");
 fclose($fd);
 
-for ($perms_to_set = 07777; $perms_to_set >= 0; $perms_to_set--) {
+for ($perms_to_set = 0777; $perms_to_set >= 0; $perms_to_set--) {
 	chmod($filename, $perms_to_set);
 	$set_perms = (fileperms($filename) & MODE_MASK);
 	clearstatcache();


### PR DESCRIPTION
Updated test to be green by replacing out of bounce mode_mask and file permission of 07777 with permission level 0777
