### PR TITLE
Add mysqlnd.localhost_override option.

### DIFF
--- a/ext/mysqlnd/mysqlnd.h
+++ b/ext/mysqlnd/mysqlnd.h
@@ -282,6 +282,7 @@ ZEND_BEGIN_MODULE_GLOBALS(mysqlnd)
 	long			debug_calloc_fail_threshold;
 	long			debug_realloc_fail_threshold;
 	char *			sha256_server_public_key;
+	char *			localhost_override;
 ZEND_END_MODULE_GLOBALS(mysqlnd)
 
 PHPAPI ZEND_EXTERN_MODULE_GLOBALS(mysqlnd)

--- a/ext/mysqlnd/php_mysqlnd.c
+++ b/ext/mysqlnd/php_mysqlnd.c
@@ -209,6 +209,7 @@ static PHP_GINIT_FUNCTION(mysqlnd)
 	mysqlnd_globals->debug_calloc_fail_threshold = -1;
 	mysqlnd_globals->debug_realloc_fail_threshold = -1;
 	mysqlnd_globals->sha256_server_public_key = NULL;
+	mysqlnd_globals->localhost_override = NULL;
 }
 /* }}} */
 
@@ -237,6 +238,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("mysqlnd.log_mask",				"0", 	PHP_INI_ALL,	OnUpdateLong,	log_mask, zend_mysqlnd_globals, mysqlnd_globals)
 	STD_PHP_INI_ENTRY("mysqlnd.mempool_default_size","16000",   PHP_INI_ALL,	OnUpdateLong,	mempool_default_size,	zend_mysqlnd_globals,		mysqlnd_globals)
 	STD_PHP_INI_ENTRY("mysqlnd.sha256_server_public_key",NULL, 	PHP_INI_PERDIR, OnUpdateString,	sha256_server_public_key, zend_mysqlnd_globals, mysqlnd_globals)
+	STD_PHP_INI_ENTRY("mysqlnd.localhost_override", NULL, 	PHP_INI_ALL, OnUpdateString,	localhost_override, zend_mysqlnd_globals, mysqlnd_globals)
 
 #if PHP_DEBUG
 	STD_PHP_INI_ENTRY("mysqlnd.debug_emalloc_fail_threshold","-1",   PHP_INI_SYSTEM,	OnUpdateLong,	debug_emalloc_fail_threshold,	zend_mysqlnd_globals,		mysqlnd_globals)


### PR DESCRIPTION
When localhost is encoundtered in mysqlnd, it is overriden by /tmp/mysql.sock or socket_option.

Many distributions have their own custom patches to have a correct default for their distribution. This pull request adds mysqlnd.localhost_override ini option to configure it from their configuration options.

The implementation is straightforward and it is backward compatible, if you do not set it the behaviour is as it used to be.

A side effect is that you can use remote hosts as the override (tcp://ip:port). Many applications use localhost as the default host, and it would be nice if it was easier to configure it to use alternative hosts.

Another case that would also benefit is where a host goes from having mysql on the localhost to a seperate host.
