### PR TITLE
ext/curl interface.c: modify curl_setopt_handler to allow resetting CURLOPT_HEADERFUNCTION callback

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2543,12 +2543,14 @@ string_copy:
 
 		case CURLOPT_HEADERFUNCTION:
 			/* check if we're setting to NULL = we're restoring php default handler */
-			if(Z_TYPE_PP(zvalue) == IS_NULL && ch->handlers->write_header->method != PHP_CURL_IGNORE) {
+			if(Z_TYPE_PP(zvalue) == IS_NULL) {
 				if(ch->handlers->write_header->method == PHP_CURL_USER) {
 					Z_DELREF_PP(zvalue);
 					ch->handlers->write_header->func_name = NULL;
 					ch->handlers->write_header->method = PHP_CURL_IGNORE;
 					break;
+				} else if(ch->handlers->write_header->method == PHP_CURL_IGNORE) {
+					break; //prevent the assign-code later on if user passed NULL and the handler was IGNORE already
 				} else {
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "set CURLOPT_HEADERFUNCTION to NULL after it was something other than a callable");
 				}

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2548,6 +2548,7 @@ string_copy:
 					Z_DELREF_PP(zvalue);
 					ch->handlers->write_header->func_name = NULL;
 					ch->handlers->write_header->method = PHP_CURL_IGNORE;
+					break;
 				} else {
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "set CURLOPT_HEADERFUNCTION to NULL after it was something other than a callable");
 				}

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2556,7 +2556,8 @@ string_copy:
 					/* prevent the assign-code later on if user passed NULL and the handler was IGNORE already */
 					break; 
 				} else {
-					php_error_docref(NULL TSRMLS_CC, E_WARNING, "set CURLOPT_HEADERFUNCTION to NULL after it was something other than a callable");
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "Tried to set CURLOPT_HEADERFUNCTION to NULL after it was something other than a callable");
+					break;
 				}
 			}
 			if (ch->handlers->write_header->func_name) {

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2542,6 +2542,16 @@ string_copy:
 			break;
 
 		case CURLOPT_HEADERFUNCTION:
+			/* check if we're setting to NULL = we're restoring php default handler */
+			if(Z_TYPE_PP(zvalue) == IS_NULL && ch->handlers->write_header->method != PHP_CURL_IGNORE) {
+				if(ch->handlers->write_header->method == PHP_CURL_USER) {
+					Z_DELREF_PP(zvalue);
+					ch->handlers->write_header->func_name = NULL;
+					ch->handlers->write_header->method = PHP_CURL_IGNORE;
+				} else {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "set CURLOPT_HEADERFUNCTION to NULL after it was something other than a callable");
+				}
+			}
 			if (ch->handlers->write_header->func_name) {
 				zval_ptr_dtor(&ch->handlers->write_header->func_name);
 				ch->handlers->write_header->fci_cache = empty_fcall_info_cache;

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2545,7 +2545,10 @@ string_copy:
 			/* check if we're setting to NULL = we're restoring php default handler */
 			if(Z_TYPE_PP(zvalue) == IS_NULL) {
 				if(ch->handlers->write_header->method == PHP_CURL_USER) {
-					Z_DELREF_PP(zvalue);
+					if(ch->handlers->write_header->func_name) {
+						zval_ptr_dtor(&ch->handlers->write_header->func_name);
+						ch->handlers->write_header->fci_cache = empty_fcall_info_cache;
+					}
 					ch->handlers->write_header->func_name = NULL;
 					ch->handlers->write_header->method = PHP_CURL_IGNORE;
 					break;

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2553,7 +2553,8 @@ string_copy:
 					ch->handlers->write_header->method = PHP_CURL_IGNORE;
 					break;
 				} else if(ch->handlers->write_header->method == PHP_CURL_IGNORE) {
-					break; //prevent the assign-code later on if user passed NULL and the handler was IGNORE already
+					/* prevent the assign-code later on if user passed NULL and the handler was IGNORE already */
+					break; 
 				} else {
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "set CURLOPT_HEADERFUNCTION to NULL after it was something other than a callable");
 				}


### PR DESCRIPTION
Sometimes it may be useful to remove a CURLOPT_HEADERFUNCTION callback (this
is supported in the cURL API by passing NULL as callback), e.g. when doing
cURL FTP with custom commands like MLST which need a CURLOPT_HEADERFUNCTION
to parse the server return, and then wanting to do other FTP commands which
would be irritated by the presence of a CURLOPT_HEADERFUNCTION callback.

This absolutely needs more work, especially checking if the
CURLOPT_HEADERFUNCTION handler was something other (like a stream redirect) -
the current implementation just checks if the previous handler was a user
callback and errors out otherwise.
