### PR TITLE
Fixed bug #64235 (Insteadof not work for class method in 5.4.11)

### DIFF
--- a/Zend/tests/traits/bug64235.phpt
+++ b/Zend/tests/traits/bug64235.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Bug #64235 (Insteadof not work for class method in 5.4.11)
+--SKIPIF--
+<?php
+if (!version_compare(zend_version(), '2.5.0', '<')) die('skip ZendEngine 2.4 only'); ?>
+?>
+--FILE--
+<?php
+
+class TestParentClass
+{
+    public function method()
+    {
+        print_r('Parent method');
+        print "\n";
+    }
+
+	public function bar()
+	{
+		print "bar\n";
+	}
+}
+
+trait TestTrait
+{
+    public function method()
+    {
+        print_r('Trait method');
+        print "\n";
+    }
+
+	public function bar()
+	{
+		print "bar trait";
+	}
+}
+
+class TestChildClass extends TestParentClass
+{
+    use TestTrait
+    {
+        TestTrait::method as methodAlias;
+
+		/* They should be traits but not classes */
+        TestTrait::bar insteadof TestParentClass;
+		TestParentClass::bar as newbar;
+        TestParentClass::method insteadof TestTrait;
+    }
+}
+
+(new TestChildClass)->method();
+(new TestChildClass)->methodAlias();
+echo "==DONE=="
+?>
+--EXPECTF--
+Deprecated: Using class as trait is deprecated, class: TestParentClass is not a trait in %sbug64235.php on line %d
+
+Deprecated: Using class as trait is deprecated, class: TestParentClass is not a trait in %sbug64235.php on line %d
+
+Deprecated: Using class as trait is deprecated, class: TestParentClass is not a trait in %sbug64235.php on line %d
+Parent method
+Trait method
+==DONE==

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3859,6 +3859,12 @@ static void zend_check_trait_usage(zend_class_entry *ce, zend_class_entry *trait
 {
 	zend_uint i;
 
+	/* Trait checking for 5.4 only which keep for BC, only trait is allowed 5.5+ */
+	if (!(trait->ce_flags & ZEND_ACC_TRAIT)) {
+		zend_error(E_DEPRECATED, "Using class as trait is deprecated, class: %s is not a trait", trait->name);
+		return;
+	}
+
 	for (i = 0; i < ce->num_traits; i++) {
 		if (ce->traits[i] == trait) {
 			return;


### PR DESCRIPTION
After the traits refactor, it "fixed" the traits precedence which could use class but not trait that was not intend from the design and manual.

this PR fixes the BC, and the same time deprecate the behavior.

This is a 5.4 only patch.
