### PR TITLE
Bug #52861 unset failes with ArrayObject and deep arrays

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -408,7 +408,7 @@ static zval *spl_array_read_dimension_ex(int check_inherited, zval *object, zval
 	/* When in a write context,
 	 * ZE has to be fooled into thinking this is in a reference set
 	 * by separating (if necessary) and returning as an is_ref=1 zval (even if refcount == 1) */
-	if ((type == BP_VAR_W || type == BP_VAR_RW) && !Z_ISREF_PP(ret)) {
+	if ((type == BP_VAR_W || type == BP_VAR_RW || type == BP_VAR_UNSET) && !Z_ISREF_PP(ret)) {
 		if (Z_REFCOUNT_PP(ret) > 1) {
 			zval *newval;
 

--- a/ext/spl/tests/bug52861.phpt
+++ b/ext/spl/tests/bug52861.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #52861 (unset failes with ArrayObject and deep arrays)
+--FILE--
+<?php
+$arrayObject = new ArrayObject(array('foo' => array('bar' => array('baz' => 'boo'))));
+
+unset($arrayObject['foo']['bar']['baz']);
+print_r($arrayObject->getArrayCopy());
+?>
+--EXPECT--
+Array
+(
+    [foo] => Array
+        (
+            [bar] => Array
+                (
+                )
+
+        )
+
+)
+


### PR DESCRIPTION
ArrayObject fails to unset multi-dimensional arrays.  This is due to the code that fools ZE to believe we have a reference check.  In this case it is missing BP_VAR_UNSET whereas BP_VAR_W and BP_VAR_RW are handled.  Changing this resolves the overall issue.  This does not cause a break in BC other than the obvious fixing of the bug. Thanks to @auroraeosrose for helping me locate and did it!

Example:

``` php
$arrayObject(array('foo' => array('bar' => array('baz' => 'boo'))));
unset($arrayObject['foo']['bar']['baz']);
// will not work: PHP Notice:  Indirect modification of overloaded element of ArrayObject.
```

The patch resolves this behavior which has been broken since 5.3.4.  
