### PR TITLE
Improvement: get_class_constants and get_object_constants functions

### DIFF
--- a/Zend/tests/get_class_constants.phpt
+++ b/Zend/tests/get_class_constants.phpt
@@ -1,0 +1,25 @@
+--TEST--
+get_class_constants(): Simple test
+--FILE--
+<?php
+
+class test {
+	const val = "string";
+	const val2 = 1;
+}
+var_dump(get_class_constants('test'));
+var_dump(get_class_constants(new test()));
+?>
+--EXPECT--	
+array(2) {
+  ["val"]=>
+  string(6) "string"
+  ["val2"]=>
+  int(1)
+}
+array(2) {
+  ["val"]=>
+  string(6) "string"
+  ["val2"]=>
+  int(1)
+}

--- a/Zend/tests/get_object_constants.phpt
+++ b/Zend/tests/get_object_constants.phpt
@@ -1,0 +1,19 @@
+--TEST--
+get_object_constants(): Simple test
+--FILE--
+<?php
+
+class test {
+	const val = "string";
+	const val2 = 1;
+}
+$test = new test();
+var_dump(get_object_constants($test));
+?>
+--EXPECT--	
+array(2) {
+  ["val"]=>
+  string(6) "string"
+  ["val2"]=>
+  int(1)
+}


### PR DESCRIPTION
## Overview

Presently the only way to get class constants in a list is to go through the Reflection API: http://php.net/manual/en/reflectionclass.getconstants.php.  While the reflection class object is great; it is also far slower than doing this directly in a zend function.  Additionally it does not fit in with the current methods:
- get_class_methods
- get_class_vars
- get_object_vars

In my opinion this should be added for consistency as well as to provide a quick[er] and fast[er] way of accessing the constants of a class than having to utilize reflection for a simple call.

There was a previous ticket on this that recommended the ReflectionClass over providing methods: https://bugs.php.net/bug.php?id=43315  However, I still do believe that these functions are needed and are far more efficient.
## Speed Differences:
### Test Class

``` php
function get_reflection_constants($class)
{
    $rc = new ReflectionClass($class);
    return $rc->getConstants();
}

class MyClass {
    const CONST1 = "var";
    const CONST2 = "var";
}

echo "Reflection Class" . PHP_EOL;
$benchStart = microtime(true);
for ($c=0;$c<100000;$c++) {
    get_reflection_constants('MyClass');
}
$benchEnd = microtime(true);
$diff = $benchEnd - $benchStart;
var_dump($diff);

echo "Object Constants" . PHP_EOL;
$benchStart = microtime(true);
for($c=0;$c<100000;$c++) {
    get_object_constants(new MyClass());
}
$benchEnd = microtime(true);
$diff = $benchEnd - $benchStart;
var_dump($diff);

echo "Class Constants" . PHP_EOL;
$benchStart = microtime(true);
for($c=0;$c<100000;$c++) {
    get_class_constants('MyClass');
}
$benchEnd = microtime(true);
$diff = $benchEnd - $benchStart;
var_dump($diff);
```
### Output:

Reflection Class
float(0.079263210296631)
Object Constants
float(0.031561136245728)
Class Constants
float(0.028576850891113)
