### PR TITLE
Fixed issue #60953

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -2003,7 +2003,7 @@ static zend_object *phar_rename_archive(phar_archive_data *phar, char *ext, zend
 	const char *oldname = NULL;
 	char *oldpath = NULL;
 	char *basename = NULL, *basepath = NULL;
-	char *newname = NULL, *newpath = NULL;
+	char *newbasename = NULL, *newname = NULL, *newpath = NULL;
 	char *oldname_ext = NULL;
 	zval *ret, arg1;
 	zend_class_entry *ce;
@@ -2095,8 +2095,8 @@ static zend_object *phar_rename_archive(phar_archive_data *phar, char *ext, zend
 		oldname_ext = strstr(basename, ".");
 	}
 
-	newname = strndup(basename, (oldname_ext - basename));
-	spprintf(&newname, 0, "%s.%s", newname, ext);
+	newbasename = estrndup(basename, (oldname_ext - basename));
+	spprintf(&newname, 0, "%s.%s", newbasename, ext);
 	efree(basename);
 
 	basepath = estrndup(oldpath, (strlen(oldpath) - oldname_len));
@@ -2104,6 +2104,7 @@ static zend_object *phar_rename_archive(phar_archive_data *phar, char *ext, zend
 	phar->fname = newpath;
 	phar->ext = newpath + phar->fname_len - strlen(ext) - 1;
 	efree(basepath);
+    efree(newbasename);
 	efree(newname);
 
 	if (PHAR_G(manifest_cached) && NULL != (pphar = zend_hash_str_find_ptr(&cached_phars, newpath, phar->fname_len))) {

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -2104,7 +2104,7 @@ static zend_object *phar_rename_archive(phar_archive_data *phar, char *ext, zend
 	phar->fname = newpath;
 	phar->ext = newpath + phar->fname_len - strlen(ext) - 1;
 	efree(basepath);
-    efree(newbasename);
+	efree(newbasename);
 	efree(newname);
 
 	if (PHAR_G(manifest_cached) && NULL != (pphar = zend_hash_str_find_ptr(&cached_phars, newpath, phar->fname_len))) {

--- a/ext/phar/tests/bug48377.2.phpt
+++ b/ext/phar/tests/bug48377.2.phpt
@@ -12,7 +12,7 @@ $fname = dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.zip';
 $phar = new PharData($fname);
 $phar['x'] = 'hi';
 try {
-	$phar->convertToData(Phar::ZIP, Phar::NONE, '.2.phar.zip');
+	$phar->convertToData(Phar::ZIP, Phar::NONE, 'zip');
 } catch (BadMethodCallException $e) {
 	echo $e->getMessage(),"\n";
 }
@@ -21,5 +21,5 @@ try {
 --CLEAN--
 <?php unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.zip');?>
 --EXPECTF--
-data phar "%sbug48377.2.phar.zip" has invalid extension 2.phar.zip
+Unable to add newly converted phar "%sbug48377.2.zip" to the list of phars, a phar with that name already exists
 ===DONE===

--- a/ext/phar/tests/bug60953.phpt
+++ b/ext/phar/tests/bug60953.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Phar: rename test
+--SKIPIF--
+<?php if (!extension_loaded("phar")) die("skip"); ?>
+--INI--
+phar.readonly=0
+phar.require_hash=0
+--FILE--
+<?php
+$phar = new Phar(__DIR__ . '/package-1.2.3.phar');
+$phar['hello.txt'] = 'Hello World';
+$phar->stopBuffering();
+unset($phar);
+$phar = new Phar(__DIR__ . '/package-1.2.3.phar');
+$phar->convertToExecutable(Phar::TAR, Phar::GZ);
+var_dump(file_exists(__DIR__ . '/package-1.2.3.phar'));
+var_dump(file_exists(__DIR__ . '/package-1.2.3.phar.tar.gz'));
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/package-1.2.3.phar');
+unlink(__DIR__ . '/package-1.2.3.phar.tar.gz');
+?>
+--EXPECTF--
+bool(true)
+bool(true)

--- a/ext/phar/tests/phar_convert_repeated.phpt
+++ b/ext/phar/tests/phar_convert_repeated.phpt
@@ -50,7 +50,7 @@ var_dump($phar->getAlias());
 
 echo "================= convertToPhar() ====================\n";
 
-$phar = $phar->convertToExecutable(Phar::PHAR, Phar::NONE, '.2.phar');
+$phar = $phar->convertToExecutable(Phar::PHAR, Phar::NONE, '.phar.pharfile');
 var_dump($phar->isFileFormat(Phar::PHAR));
 var_dump($phar->isFileFormat(Phar::TAR));
 var_dump($phar->isFileFormat(Phar::ZIP));
@@ -59,7 +59,7 @@ var_dump($phar->getAlias());
 
 echo "================= convertToZip() =====================\n";
 
-$phar = $phar->convertToExecutable(Phar::ZIP, Phar::NONE, '.2.phar.zip');
+$phar = $phar->convertToExecutable(Phar::ZIP, Phar::NONE, '.phar.zipfile');
 var_dump($phar->isFileFormat(Phar::PHAR));
 var_dump($phar->isFileFormat(Phar::TAR));
 var_dump($phar->isFileFormat(Phar::ZIP));
@@ -68,7 +68,7 @@ var_dump($phar->getAlias());
 
 echo "================= convertToTar() =====================\n";
 
-$phar = $phar->convertToExecutable(Phar::TAR, Phar::NONE, '2.phar.tar');
+$phar = $phar->convertToExecutable(Phar::TAR, Phar::NONE, '.phar.tarfile');
 var_dump($phar->isFileFormat(Phar::PHAR));
 var_dump($phar->isFileFormat(Phar::TAR));
 var_dump($phar->isFileFormat(Phar::ZIP));
@@ -77,7 +77,7 @@ var_dump($phar->getAlias());
 
 echo "================= convertToZip() =====================\n";
 
-$phar = $phar->convertToExecutable(Phar::ZIP, Phar::NONE, '3.phar.zip');
+$phar = $phar->convertToExecutable(Phar::ZIP, Phar::NONE, '.phar.zip2');
 var_dump($phar->isFileFormat(Phar::PHAR));
 var_dump($phar->isFileFormat(Phar::TAR));
 var_dump($phar->isFileFormat(Phar::ZIP));
@@ -91,12 +91,12 @@ var_dump($phar->getAlias());
 unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar.zip');
 unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar.tar');
 unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar');
-unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.2.phar.zip');
-unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.2.phar.tar');
-unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.2.phar');
-unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.3.phar.zip');
-unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.3.phar.tar');
-unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.3.phar');
+unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar.zipfile');
+unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar.tarfile');
+unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar.pharfile');
+unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar.zipfile');
+unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar.tarfile');
+unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar.zip2');
 ?>
 --EXPECTF--
 =================== new Phar() =======================

--- a/ext/phar/tests/phar_convert_repeated_b.phpt
+++ b/ext/phar/tests/phar_convert_repeated_b.phpt
@@ -82,9 +82,9 @@ try {
 unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.phar.gz');
 unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.tar.gz');
 unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.tar');
-unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.2.tar');
 unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.zip');
 unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.1.zip');
+unlink(dirname(__FILE__) . '/' . basename(__FILE__, '.clean.php') . '.1.2.tar');
 ?>
 --EXPECT--
 =================== new PharData() ==================

--- a/ext/phar/tests/stat2_5.3.phpt
+++ b/ext/phar/tests/stat2_5.3.phpt
@@ -14,7 +14,6 @@ is_link();
 var_dump(is_file(__FILE__));
 
 $fname2 = dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.tar';
-$fname3 = dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.phar.tar';
 copy(dirname(__FILE__) . '/tar/files/links.tar', $fname2);
 $a = new PharData($fname2);
 $b = $a->convertToExecutable(Phar::TAR, Phar::NONE);
@@ -33,7 +32,7 @@ $b->addEmptyDir('foo/bar/blah');
 $b->setStub('<?php
 include "phar://" . __FILE__ . "/foo/stat.php";
 __HALT_COMPILER();');
-include $fname3;
+include dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.phar.tar';
 ?>
 ===DONE===
 --CLEAN--

--- a/ext/phar/tests/stat2_5.3.phpt
+++ b/ext/phar/tests/stat2_5.3.phpt
@@ -17,7 +17,7 @@ $fname2 = dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.tar';
 $fname3 = dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.phar.tar';
 copy(dirname(__FILE__) . '/tar/files/links.tar', $fname2);
 $a = new PharData($fname2);
-$b = $a->convertToExecutable(Phar::TAR, Phar::NONE, '.3.phar.tar');
+$b = $a->convertToExecutable(Phar::TAR, Phar::NONE);
 unset($a);
 Phar::unlinkArchive($fname2);
 $b['foo/stat.php'] = '<?php


### PR DESCRIPTION
Altered phar_rename_archive() such that it will look for well known file extensions to strip off when attempting to rename.  Not BC safe with regards to PHP-5x.
https://bugs.php.net/bug.php?id=60953

A large part of the motivation here is to allow dotted versions in the name of a phar, and expect the convert*() functions to do minimal processing on the file name, and allow those dotted version names to persist as they should be.

This allows the following to be possible:

``` php
$phar = new Phar(__DIR__ . '/package-1.2.3.phar');
$phar['hello.txt'] = 'Hello World';
$phar->stopBuffering();
unset($phar);
$phar = new Phar(__DIR__ . '/package-1.2.3.phar');
$phar->convertToExecutable(Phar::TAR, Phar::GZ);
var_dump(file_exists(__DIR__ . '/package-1.2.3.phar'));
var_dump(file_exists(__DIR__ . '/package-1.2.3.phar.tar.gz'));
```
