### PR TITLE
Fix bug #64293	

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2342,8 +2342,10 @@ AC_DEFUN([PHP_SETUP_OPENSSL],[
       AC_MSG_ERROR([OpenSSL version 0.9.6 or greater required.])
     fi
 
-    if test -n "$OPENSSL_LIBS" && test -n "$OPENSSL_INCS"; then
+    if test -n "$OPENSSL_LIBS" ; then
       PHP_EVAL_LIBLINE($OPENSSL_LIBS, $1)
+    fi
+    if test -n "$OPENSSL_INCS" ; then
       PHP_EVAL_INCLINE($OPENSSL_INCS)
     fi
   fi


### PR DESCRIPTION
The problem is because of a change in pgkconfig 0.28 that trims the output of
pkg-config --cflags-only-I openssl.

This cause the 'if test -n "$OPENSSL_LIBS" && test -n "$OPENSSL_INCS"; then' to
fail and -lssl is no longer passed to the build.

Splitting the check in two resolves the issue.
