### PR TITLE
Update dblib_driver.c

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -315,7 +315,7 @@ static int pdo_dblib_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_
 	DBSETOPT(H->link, DBTEXTSIZE, "2147483647");
 
 	/* allow double quoted indentifiers */
-	DBSETOPT(H->link, DBQUOTEDIDENT, NULL);
+	DBSETOPT(H->link, DBQUOTEDIDENT, 1);
 
 	if (vars[3].optval && FAIL == dbuse(H->link, vars[3].optval)) {
 		goto cleanup;


### PR DESCRIPTION
Bugfix for issue 63638. The patch from 1 to NULL is reverted with this commit.

Please see: https://bugs.php.net/bug.php?id=63638

This pull request addresses that issue and should be merged.

NOTE: This pull request is for the php5.4.13 branch. The original (https://github.com/php/php-src/pull/306) was for the master branch.
