### PR TITLE
Removed XOR from php.ini

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -47,7 +47,6 @@
 
 ; Expressions in the INI file are limited to bitwise operators and parentheses:
 ; |  bitwise OR
-; ^  bitwise XOR
 ; &  bitwise AND
 ; ~  bitwise NOT
 ; !  boolean NOT

--- a/php.ini-production
+++ b/php.ini-production
@@ -47,7 +47,6 @@
 
 ; Expressions in the INI file are limited to bitwise operators and parentheses:
 ; |  bitwise OR
-; ^  bitwise XOR
 ; &  bitwise AND
 ; ~  bitwise NOT
 ; !  boolean NOT


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=64523

`parse_ini_*` does not support XOR operation. http://3v4l.org/6fYNg#v540

Commit where XOR is added:
https://github.com/php/php-src/commit/e0669bf1ab0892132bf6fe6f81587bfba45e7329#L0R50
