### PR TITLE
Fix saving of -1 index from keys column in array_column function

### DIFF
--- a/ext/standard/tests/array/array_column_minus_one_index.phpt
+++ b/ext/standard/tests/array/array_column_minus_one_index.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test array_column() function: basic functionality (saving of -1 index)
+--FILE--
+<?php
+$records = array(
+    array(
+        'id' => 2135,
+        'first_name' => 'John',
+        'last_name' => 'Doe'
+    ),
+    array(
+        'id' => -1,
+        'first_name' => 'Sally',
+        'last_name' => 'Smith'
+    ),
+    array(
+        'id' => -2,
+        'first_name' => 'Jane',
+        'last_name' => 'Jones'
+    ),
+);
+ 
+$firstNames = array_column($records, 'first_name', 'id');
+print_r($firstNames);
+?>
+--EXPECTF--
+Array
+(
+    [2135] => John
+    [-1] => Sally
+    [-2] => Jane
+)
+


### PR DESCRIPTION
Current implementation of array_column function does not allow saving of -1 index as a key. See http://3v4l.org/fT1th (the next index is used in place of -1). This patch fixes the problem. I also added new test array_column_minus_one_index.phpt . All other tests for arrray_column passed as well.
