### PR TITLE
Fixed typo - inconsistent notice for undefined property (introduced by fix for #49348)

### DIFF
--- a/Zend/tests/bug52041.phpt
+++ b/Zend/tests/bug52041.phpt
@@ -35,29 +35,29 @@ Notice: Undefined variable: x in %sbug52041.php on line 3
 
 Warning: Creating default object from empty value in %sbug52041.php on line 8
 
-Notice: Undefined property: a in %sbug52041.php on line 8
+Notice: Undefined property: stdClass::$a in %sbug52041.php on line 8
 
 Notice: Undefined variable: x in %sbug52041.php on line 3
 
-Notice: Undefined property: a in %sbug52041.php on line 9
+Notice: Undefined property: stdClass::$a in %sbug52041.php on line 9
 
 Warning: Creating default object from empty value in %sbug52041.php on line 9
 
-Notice: Undefined property: b in %sbug52041.php on line 9
+Notice: Undefined property: stdClass::$b in %sbug52041.php on line 9
 
 Notice: Undefined variable: x in %sbug52041.php on line 3
 
 Warning: Creating default object from empty value in %sbug52041.php on line 10
 
-Notice: Undefined property: a in %sbug52041.php on line 10
+Notice: Undefined property: stdClass::$a in %sbug52041.php on line 10
 
 Notice: Undefined variable: x in %sbug52041.php on line 3
 
-Notice: Undefined property: a in %sbug52041.php on line 11
+Notice: Undefined property: stdClass::$a in %sbug52041.php on line 11
 
 Warning: Creating default object from empty value in %sbug52041.php on line 11
 
-Notice: Undefined property: b in %sbug52041.php on line 11
+Notice: Undefined property: stdClass::$b in %sbug52041.php on line 11
 
 Notice: Undefined variable: x in %sbug52041.php on line 3
 

--- a/Zend/tests/bug60536_001.phpt
+++ b/Zend/tests/bug60536_001.phpt
@@ -23,5 +23,5 @@ echo "DONE";
 ?>
 --EXPECTF--
 
-Notice: Undefined property: x in %s on line 14
+Notice: Undefined property: Z::$x in %s on line 14
 DONE

--- a/Zend/tests/bug62005.phpt
+++ b/Zend/tests/bug62005.phpt
@@ -10,7 +10,7 @@ add_points(NULL, 2);
 --EXPECTF--
 Warning: Creating default object from empty value in %sbug62005.php on line %d
 
-Notice: Undefined property: energy in %sbug62005.php on line 3
+Notice: Undefined property: stdClass::$energy in %sbug62005.php on line 3
 stdClass Object
 (
     [energy] => 2

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -755,7 +755,7 @@ static zval **zend_std_get_property_ptr_ptr(zval *object, zval *member, int type
 			new_zval = &EG(uninitialized_zval);
 
 			if(UNEXPECTED(type == BP_VAR_RW || type == BP_VAR_R)) {
-				zend_error(E_NOTICE, "Undefined property: %s", Z_STRVAL_P(member));
+				zend_error(E_NOTICE, "Undefined property: %s::$%s", zobj->ce->name, Z_STRVAL_P(member));
 			}
 			Z_ADDREF_P(new_zval);
 			if (EXPECTED((property_info->flags & ZEND_ACC_STATIC) == 0) &&

--- a/tests/classes/implicit_instantiation_001.phpt
+++ b/tests/classes/implicit_instantiation_001.phpt
@@ -41,7 +41,7 @@ var_dump($c);
 
 Warning: Creating default object from empty value in %s on line 18
 
-Notice: Undefined property: prop in %s on line 18
+Notice: Undefined property: stdClass::$prop in %s on line 18
 
   --> Attempting implicit conversion to object using assignment...
 
@@ -51,7 +51,7 @@ Warning: Creating default object from empty value in %s on line 22
 
 Warning: Creating default object from empty value in %s on line 26
 
-Notice: Undefined property: prop in %s on line 26
+Notice: Undefined property: stdClass::$prop in %s on line 26
 
 
 ---( $c->emptyString )---
@@ -59,7 +59,7 @@ Notice: Undefined property: prop in %s on line 26
 
 Warning: Creating default object from empty value in %s on line 18
 
-Notice: Undefined property: prop in %s on line 18
+Notice: Undefined property: stdClass::$prop in %s on line 18
 
   --> Attempting implicit conversion to object using assignment...
 
@@ -69,7 +69,7 @@ Warning: Creating default object from empty value in %s on line 22
 
 Warning: Creating default object from empty value in %s on line 26
 
-Notice: Undefined property: prop in %s on line 26
+Notice: Undefined property: stdClass::$prop in %s on line 26
 
 
 ---( $c->null )---
@@ -77,7 +77,7 @@ Notice: Undefined property: prop in %s on line 26
 
 Warning: Creating default object from empty value in %s on line 18
 
-Notice: Undefined property: prop in %s on line 18
+Notice: Undefined property: stdClass::$prop in %s on line 18
 
   --> Attempting implicit conversion to object using assignment...
 
@@ -87,7 +87,7 @@ Warning: Creating default object from empty value in %s on line 22
 
 Warning: Creating default object from empty value in %s on line 26
 
-Notice: Undefined property: prop in %s on line 26
+Notice: Undefined property: stdClass::$prop in %s on line 26
 
 
 ---( $c->boolTrue )---


### PR DESCRIPTION
The message added as a fix for #49348 (0c6d903ce7615a7197cb997d67d98058c3ec5d6a) is not consistent with the other one triggered in similar case.

Consider the following code:

``` php
$x = new stdClass();
echo $x->foo++;
echo $x->bar;
```

Currently, it triggers two notices:
Notice: Undefined property: foo
Notice: Undefined property: stdClass::$bar

The first one was added by the fix for #49348 and is inconsistent with other notices related to property access. It should be same as the other one (should contain classname, :: and dollar).

(I already [commented](https://bugs.php.net/bug.php?id=49348#1364587653) on bugs.php.net and here in #281, but noone cared.)
