### PR TITLE
Add schema default/fixed value support in DOM

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1973,14 +1973,15 @@ static void _dom_document_schema_validate(INTERNAL_FUNCTION_PARAMETERS, int type
 	xmlDoc *docp;
 	dom_object *intern;
 	char *source = NULL, *valid_file = NULL;
-	int source_len = 0;
+	int source_len = 0, valid_opts = 0;
+	long flags = 0;
 	xmlSchemaParserCtxtPtr  parser;
 	xmlSchemaPtr            sptr;
 	xmlSchemaValidCtxtPtr   vptr;
 	int                     is_valid;
 	char resolved_path[MAXPATHLEN + 1];
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Op", &id, dom_document_class_entry, &source, &source_len) == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Op|l", &id, dom_document_class_entry, &source, &source_len, &flags) == FAILURE) {
 		return;
 	}
 
@@ -2029,6 +2030,13 @@ static void _dom_document_schema_validate(INTERNAL_FUNCTION_PARAMETERS, int type
 		RETURN_FALSE;
 	}
 
+#if LIBXML_VERSION >= 20614
+	if (flags & XML_SCHEMA_VAL_VC_I_CREATE) {
+		valid_opts |= XML_SCHEMA_VAL_VC_I_CREATE;
+	}
+#endif
+
+	xmlSchemaSetValidOptions(vptr, valid_opts);
 	xmlSchemaSetValidErrors(vptr, php_libxml_error_handler, php_libxml_error_handler, vptr);
 	is_valid = xmlSchemaValidateDoc(vptr, docp);
 	xmlSchemaFree(sptr);
@@ -2042,14 +2050,14 @@ static void _dom_document_schema_validate(INTERNAL_FUNCTION_PARAMETERS, int type
 }
 /* }}} */
 
-/* {{{ proto boolean dom_document_schema_validate_file(string filename); */
+/* {{{ proto boolean dom_document_schema_validate_file(string filename, int flags); */
 PHP_FUNCTION(dom_document_schema_validate_file)
 {
 	_dom_document_schema_validate(INTERNAL_FUNCTION_PARAM_PASSTHRU, DOM_LOAD_FILE);
 }
 /* }}} end dom_document_schema_validate_file */
 
-/* {{{ proto boolean dom_document_schema_validate(string source); */
+/* {{{ proto boolean dom_document_schema_validate(string source, int flags); */
 PHP_FUNCTION(dom_document_schema_validate_xml)
 {
 	_dom_document_schema_validate(INTERNAL_FUNCTION_PARAM_PASSTHRU, DOM_LOAD_STRING);

--- a/ext/dom/tests/DOMDocument_schemaValidateSource_addAttrs.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidateSource_addAttrs.phpt
@@ -1,0 +1,25 @@
+--TEST--
+DomDocument::schemaValidateSource() - Add missing attribute default values from schema
+--CREDITS--
+Chris Wright <info@daverandom.com>
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+
+$doc->load(dirname(__FILE__)."/book-attr.xml");
+
+$xsd = file_get_contents(dirname(__FILE__)."/book.xsd");
+
+$doc->schemaValidateSource($xsd, LIBXML_SCHEMA_CREATE);
+
+foreach ($doc->getElementsByTagName('book') as $book) {
+    var_dump($book->getAttribute('is-hardback'));
+}
+
+?>
+--EXPECT--
+string(5) "false"
+string(4) "true"

--- a/ext/dom/tests/DOMDocument_schemaValidateSource_error4.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidateSource_error4.phpt
@@ -17,5 +17,5 @@ var_dump($result);
 
 ?>
 --EXPECTF--
-Warning: DOMDocument::schemaValidateSource() expects exactly 1 parameter, 0 given in %s.php on line %d
+Warning: DOMDocument::schemaValidateSource() expects at least 1 parameter, 0 given in %s.php on line %d
 NULL

--- a/ext/dom/tests/DOMDocument_schemaValidateSource_missingAttrs.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidateSource_missingAttrs.phpt
@@ -1,0 +1,25 @@
+--TEST--
+DomDocument::schemaValidateSource() - Don't add missing attribute default values from schema
+--CREDITS--
+Chris Wright <info@daverandom.com>
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+
+$doc->load(dirname(__FILE__)."/book-attr.xml");
+
+$xsd = file_get_contents(dirname(__FILE__)."/book.xsd");
+
+$doc->schemaValidateSource($xsd);
+
+foreach ($doc->getElementsByTagName('book') as $book) {
+    var_dump($book->getAttribute('is-hardback'));
+}
+
+?>
+--EXPECT--
+string(0) ""
+string(4) "true"

--- a/ext/dom/tests/DOMDocument_schemaValidate_addAttrs.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidate_addAttrs.phpt
@@ -1,0 +1,23 @@
+--TEST--
+DomDocument::schemaValidate() - Add missing attribute default values from schema
+--CREDITS--
+Chris Wright <info@daverandom.com>
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+
+$doc->load(dirname(__FILE__)."/book-attr.xml");
+
+$doc->schemaValidate(dirname(__FILE__)."/book.xsd", LIBXML_SCHEMA_CREATE);
+
+foreach ($doc->getElementsByTagName('book') as $book) {
+    var_dump($book->getAttribute('is-hardback'));
+}
+
+?>
+--EXPECT--
+string(5) "false"
+string(4) "true"

--- a/ext/dom/tests/DOMDocument_schemaValidate_error4.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidate_error4.phpt
@@ -17,5 +17,5 @@ var_dump($result);
 
 ?>
 --EXPECTF--
-Warning: DOMDocument::schemaValidate() expects exactly 1 parameter, 0 given in %s.php on line %d
+Warning: DOMDocument::schemaValidate() expects at least 1 parameter, 0 given in %s.php on line %d
 NULL

--- a/ext/dom/tests/DOMDocument_schemaValidate_error5.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidate_error5.phpt
@@ -1,5 +1,5 @@
 --TEST--
-DomDocument::schemaValidate() - non-existant schema file
+DomDocument::schemaValidate() - non-existent schema file
 --CREDITS--
 Daniel Convissor <danielc@php.net>
 # TestFest 2009 NYPHP
@@ -12,14 +12,14 @@ $doc = new DOMDocument;
 
 $doc->load(dirname(__FILE__)."/book.xml");
 
-$result = $doc->schemaValidate(dirname(__FILE__)."/non-existant-file");
+$result = $doc->schemaValidate(dirname(__FILE__)."/non-existent-file");
 var_dump($result);
 
 ?>
 --EXPECTF--
-Warning: DOMDocument::schemaValidate(): I/O warning : failed to load external entity "%snon-existant-file" in %s.php on line %d
+Warning: DOMDocument::schemaValidate(): I/O warning : failed to load external entity "%snon-existent-file" in %s.php on line %d
 
-Warning: DOMDocument::schemaValidate(): Failed to locate the main schema resource at '%s/non-existant-file'. in %s.php on line %d
+Warning: DOMDocument::schemaValidate(): Failed to locate the main schema resource at '%s/non-existent-file'. in %s.php on line %d
 
 Warning: DOMDocument::schemaValidate(): Invalid Schema in %s.php on line %d
 bool(false)

--- a/ext/dom/tests/DOMDocument_schemaValidate_missingAttrs.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidate_missingAttrs.phpt
@@ -1,0 +1,23 @@
+--TEST--
+DomDocument::schemaValidate() - Don't add missing attribute default values from schema
+--CREDITS--
+Chris Wright <info@daverandom.com>
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+
+$doc->load(dirname(__FILE__)."/book-attr.xml");
+
+$doc->schemaValidate(dirname(__FILE__)."/book.xsd");
+
+foreach ($doc->getElementsByTagName('book') as $book) {
+    var_dump($book->getAttribute('is-hardback'));
+}
+
+?>
+--EXPECT--
+string(0) ""
+string(4) "true"

--- a/ext/dom/tests/book-attr.xml
+++ b/ext/dom/tests/book-attr.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<books>
+ <book>
+  <title>The Grapes of Wrath</title>
+  <author>John Steinbeck</author>
+ </book>
+ <book is-hardback="true">
+  <title>The Pearl</title>
+  <author>John Steinbeck</author>
+ </book>
+</books>

--- a/ext/dom/tests/book.xsd
+++ b/ext/dom/tests/book.xsd
@@ -9,6 +9,7 @@
        <xs:element name="title" type="xs:string"/>
        <xs:element name="author" type="xs:string"/>
       </xs:sequence>
+      <xs:attribute name="is-hardback" type="xs:boolean" default="false" use="optional" />
      </xs:complexType>
     </xs:element>
    </xs:sequence>

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -44,6 +44,7 @@
 #include <libxml/xmlsave.h>
 #ifdef LIBXML_SCHEMAS_ENABLED
 #include <libxml/relaxng.h>
+#include <libxml/xmlschemas.h>
 #endif
 
 #include "php_libxml.h"
@@ -797,6 +798,11 @@ static PHP_MINIT_FUNCTION(libxml)
 	REGISTER_LONG_CONSTANT("LIBXML_PARSEHUGE",	XML_PARSE_HUGE,			CONST_CS | CONST_PERSISTENT);
 #endif
 	REGISTER_LONG_CONSTANT("LIBXML_NOEMPTYTAG",	LIBXML_SAVE_NOEMPTYTAG,	CONST_CS | CONST_PERSISTENT);
+
+	/* Schema validation options */
+#if defined(LIBXML_SCHEMAS_ENABLED) && LIBXML_VERSION >= 20614
+	REGISTER_LONG_CONSTANT("LIBXML_SCHEMA_CREATE",	XML_SCHEMA_VAL_VC_I_CREATE,	CONST_CS | CONST_PERSISTENT);
+#endif
 
 	/* Additional constants for use with loading html */
 #if LIBXML_VERSION >= 20707


### PR DESCRIPTION
Added support for adding fixed/default values during XSD validation in the DOM extension.

This patch adds a second (optional) `$flags` argument to `DOMDocument::schemaValidate()` and `DOMDocument::schemaValidateSource()`, which is a bitmask of libxml schema validation context options. It also defines an additional PHP constant, `LIBXML_SCHEMA_CREATE`, corresponding to libxml's [`XML_SCHEMA_VAL_VC_I_CREATE`](http://www.xmlsoft.org/html/libxml-xmlschemas.html#xmlSchemaValidOption), which is currently the only valid flag that can be passed. When passed, the schema validation procedure will add default values from the schema when they are unspecified in the document.

The default value for the optional `$flags` parameter is `0`, which results in the current behaviour - hence merging this feature does not cause a BC-break.

See http://stackoverflow.com/q/15948847/889949 for more information.
