### PR TITLE
Allow major versions of bison

### DIFF
--- a/Zend/acinclude.m4
+++ b/Zend/acinclude.m4
@@ -4,7 +4,7 @@ dnl This file contains local autoconf functions.
 
 AC_DEFUN([LIBZEND_BISON_CHECK],[
   # we only support certain bison versions
-  bison_version_list="1.28 1.35 1.75 1.875 2.0 2.1 2.2 2.3 2.4 2.4.1 2.4.2 2.4.3 2.5 2.5.1 2.6 2.6.1 2.6.2"
+  bison_version_list="1.28 1.35 1.75 1.875 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7"
 
   # for standalone build of Zend Engine
   test -z "$SED" && SED=sed
@@ -12,7 +12,7 @@ AC_DEFUN([LIBZEND_BISON_CHECK],[
   bison_version=none
   if test "$YACC"; then
     AC_CACHE_CHECK([for bison version], php_cv_bison_version, [
-      bison_version_vars=`bison --version 2> /dev/null | grep 'GNU Bison' | cut -d ' ' -f 4 | $SED -e 's/\./ /' | tr -d a-z`
+      bison_version_vars=`bison --version 2> /dev/null | grep 'GNU Bison' | cut -d ' ' -f 4 | $SED -e 's/\./ /g' | tr -d a-z`
       php_cv_bison_version=invalid
       if test -n "$bison_version_vars"; then
         set $bison_version_vars


### PR DESCRIPTION
Tested to work with bison (GNU Bison) 2.7.12-4996 on OSX, but should
work generically on more platforms.
