### PR TITLE
Add apparmor change hat functionality to fpm

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -536,6 +536,22 @@ AC_DEFUN([AC_FPM_SELECT],
 ])
 dnl }}}
 
+AC_DEFUN([AC_FPM_APPARMOR],
+[
+        AC_MSG_CHECKING([for apparmor])
+
+        SAVED_LIBS="$LIBS"
+        LIBS="$LIBS -lapparmor"
+
+        AC_TRY_LINK([ #include <sys/apparmor.h> ], [change_hat("test", 0);], [
+	  AC_DEFINE([HAVE_APPARMOR], 1, [do we have apparmor support?])
+          AC_MSG_RESULT([yes])
+        ], [
+          LIBS="$SAVED_LIBS"
+          AC_MSG_RESULT([no])
+        ])
+])
+
 
 AC_MSG_CHECKING(for FPM build)
 if test "$PHP_FPM" != "no"; then
@@ -555,6 +571,7 @@ if test "$PHP_FPM" != "no"; then
 	AC_FPM_EPOLL
 	AC_FPM_POLL
 	AC_FPM_SELECT
+        AC_FPM_APPARMOR
 
   PHP_ARG_WITH(fpm-user,,
   [  --with-fpm-user[=USER]  Set the user for php-fpm to run as. (default: nobody)], nobody, no)

--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -138,6 +138,9 @@ static struct ini_value_parser_s ini_fpm_pool_options[] = {
 	{ "chdir",                     &fpm_conf_set_string,      WPO(chdir) },
 	{ "catch_workers_output",      &fpm_conf_set_boolean,     WPO(catch_workers_output) },
 	{ "security.limit_extensions", &fpm_conf_set_string,      WPO(security_limit_extensions) },
+#ifdef HAVE_APPARMOR
+        { "apparmor_hat",              &fpm_conf_set_string,      WPO(apparmor_hat) },
+#endif
 	{ 0, 0, 0 }
 };
 
@@ -633,6 +636,9 @@ int fpm_worker_pool_config_free(struct fpm_worker_pool_config_s *wpc) /* {{{ */
 	free(wpc->chroot);
 	free(wpc->chdir);
 	free(wpc->security_limit_extensions);
+#ifdef HAVE_APPARMOR
+        free(wpc->apparmor_hat);
+#endif
 
 	for (kv = wpc->php_values; kv; kv = kv_next) {
 		kv_next = kv->next;

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -83,6 +83,9 @@ struct fpm_worker_pool_config_s {
 	struct key_value_s *env;
 	struct key_value_s *php_admin_values;
 	struct key_value_s *php_values;
+#ifdef HAVE_APPARMOR
+        char *apparmor_hat;
+#endif
 };
 
 struct ini_value_parser_s {

--- a/sapi/fpm/fpm/fpm_unix.c
+++ b/sapi/fpm/fpm/fpm_unix.c
@@ -17,6 +17,10 @@
 #include <sys/prctl.h>
 #endif
 
+#ifdef HAVE_APPARMOR
+#include <sys/apparmor.h>
+#endif
+
 #include "fpm.h"
 #include "fpm_conf.h"
 #include "fpm_cleanup.h"
@@ -212,6 +216,14 @@ int fpm_unix_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 			}
 		}
 	}
+
+#ifdef HAVE_APPARMOR
+        if (wp->config->apparmor_hat) {
+            if (0 > change_hat(wp->config->apparmor_hat, 0)) {
+                zlog(ZLOG_SYSERROR, "[pool %s] failed to change_hat(%s)", wp->config->name, wp->config->apparmor_hat);
+            }
+        }
+#endif
 
 #ifdef HAVE_PRCTL
 	if (0 > prctl(PR_SET_DUMPABLE, 1, 0, 0, 0)) {

--- a/sapi/fpm/php-fpm.conf.in
+++ b/sapi/fpm/php-fpm.conf.in
@@ -508,3 +508,6 @@ pm.max_spare_servers = 3
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+
+;App Armor hat to change to
+;apparmor_hat = hat


### PR DESCRIPTION
With this patch the pool config gets the additional parameter `apparmor_hat`.
Workers of this pool change their app armor hat to the configured one during spawn.
