### PR TITLE
working example of session garbage collection in subdirectories

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1480,7 +1480,7 @@ session.gc_maxlifetime = 1440
 ;       collection through a shell script, cron entry, or some other method.
 ;       For example, the following script would is the equivalent of
 ;       setting session.gc_maxlifetime to 1440 (1440 seconds = 24 minutes):
-;          find /path/to/sessions -cmin +24 | xargs rm
+;          find /path/to/sessions -cmin +24 -type f | xargs -r rm
 
 ; PHP 4.2 and less have an undocumented feature/bug that allows you to
 ; to initialize a session variable in the global scope.


### PR DESCRIPTION
without '-type f' find will output all subdirectories.
xargs '-r' option - not run the command if nothig found.
