### PR TITLE
Added support for setting a group for SysV Shared Memory

### DIFF
--- a/ext/sysvshm/php_sysvshm.h
+++ b/ext/sysvshm/php_sysvshm.h
@@ -26,9 +26,11 @@
 extern zend_module_entry sysvshm_module_entry;
 #define sysvshm_module_ptr &sysvshm_module_entry
 
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
+#include <grp.h>
 
 #define PHP_SHM_RSRC_NAME "sysvshm"
 
@@ -57,6 +59,13 @@ typedef struct {
 	long id;                 /* returned by shmget */
 	sysvshm_chunk_head *ptr; /* memory address of shared memory */
 } sysvshm_shm;
+
+typedef struct {
+	char *gr_name;			/* group name */
+	char *gr_passwd;		/* group password */
+	gid_t gr_gid;			/* group ID */
+	char **gr_mem;			/* group members */
+} group;
 
 PHP_MINIT_FUNCTION(sysvshm);
 PHP_FUNCTION(shm_attach);

--- a/ext/sysvshm/tests/002.phpt
+++ b/ext/sysvshm/tests/002.phpt
@@ -8,7 +8,7 @@ shm_attach() tests
 $key = ftok(__FILE__, 't');
 
 var_dump(shm_attach());
-var_dump(shm_attach(1,2,3,4));
+var_dump(shm_attach(1,2,3,4,5));
 
 var_dump(shm_attach(-1, 0));
 var_dump(shm_attach(0, -1));
@@ -36,7 +36,7 @@ echo "Done\n";
 Warning: shm_attach() expects at least 1 parameter, 0 given in %s on line %d
 NULL
 
-Warning: shm_attach() expects at most 3 parameters, 4 given in %s on line %d
+Warning: shm_attach() expects at most 4 parameters, 5 given in %s on line %d
 NULL
 
 Warning: shm_attach(): Segment size must be greater than zero in %s on line %d


### PR DESCRIPTION
I have added support for setting a valid group when attaching to the shared memory.

This allows you to create SHM and share it with users in a group which is not your default GID.

This is something that is missing in PHP since the addition of SysV SHM.
