### PR TITLE
mysqlnd: detect mysql unix socket path with mysql_config

### DIFF
--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -3,8 +3,9 @@ dnl $Id$
 dnl config.m4 for mysqlnd driver
 
 PHP_ARG_ENABLE(mysqlnd, whether to enable mysqlnd,
-  [  --enable-mysqlnd        Enable mysqlnd explicitly, will be done implicitly
-                          when required by other extensions], no, yes)
+  [  --enable-mysqlnd=FILE Enable mysqlnd explicitly, will be done implicitly
+                           when required by other extensions. FILE is the path
+                           to mysql_config.], no, yes)
 
 PHP_ARG_ENABLE(mysqlnd_compression_support, whether to disable compressed protocol support in mysqlnd,
 [  --disable-mysqlnd-compression-support
@@ -17,6 +18,8 @@ fi
 
 dnl If some extension uses mysqlnd it will get compiled in PHP core
 if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
+  MYSQL_CONFIG=$PHP_MYSQLND
+
   mysqlnd_ps_sources="mysqlnd_ps.c mysqlnd_ps_codec.c"
   mysqlnd_base_sources="mysqlnd.c mysqlnd_alloc.c mysqlnd_bt.c mysqlnd_charset.c mysqlnd_wireprotocol.c \
                    mysqlnd_loaddata.c mysqlnd_reverse_api.c mysqlnd_net.c \
@@ -44,6 +47,11 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
   PHP_NEW_EXTENSION(mysqlnd, $mysqlnd_sources, $ext_shared)
   PHP_ADD_BUILD_DIR([ext/mysqlnd], 1)
   PHP_INSTALL_HEADERS([ext/mysqlnd/])
+
+  if test -x "$MYSQL_CONFIG"; then
+    MYSQLND_SOCKET=`$MYSQL_CONFIG --socket`
+    AC_DEFINE_UNQUOTED(MYSQLND_UNIX_SOCK_ADDR, "$MYSQLND_SOCKET", [ ])
+  fi
 fi
 
 if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes" || test "$PHP_MYSQLI" != "no"; then

--- a/ext/mysqlnd/mysqlnd.c
+++ b/ext/mysqlnd/mysqlnd.c
@@ -921,7 +921,11 @@ MYSQLND_METHOD(mysqlnd_conn_data, connect)(MYSQLND_CONN_DATA * conn,
 		if (host_len == sizeof("localhost") - 1 && !strncasecmp(host, "localhost", host_len)) {
 			DBG_INF_FMT("socket=%s", socket_or_pipe? socket_or_pipe:"n/a");
 			if (!socket_or_pipe) {
+#ifdef MYSQLND_UNIX_SOCK_ADDR
+				socket_or_pipe = MYSQLND_UNIX_SOCK_ADDR;
+#else
 				socket_or_pipe = "/tmp/mysql.sock";
+#endif
 			}
 			transport_len = mnd_sprintf(&transport, 0, "unix://%s", socket_or_pipe);
 			unix_socket = TRUE;

--- a/ext/pdo_mysql/pdo_mysql.c
+++ b/ext/pdo_mysql/pdo_mysql.c
@@ -49,10 +49,14 @@ ZEND_DECLARE_MODULE_GLOBALS(pdo_mysql)
 # ifdef PHP_MYSQL_UNIX_SOCK_ADDR
 #  define PDO_MYSQL_UNIX_ADDR PHP_MYSQL_UNIX_SOCK_ADDR
 # else
-#  if !PHP_WIN32
-#   define PDO_MYSQL_UNIX_ADDR "/tmp/mysql.sock"
+#  ifdef MYSQLND_UNIX_SOCK_ADDR
+#   define PDO_MYSQL_UNIX_ADDR MYSQLND_UNIX_SOCK_ADDR
 #  else
-#   define PDO_MYSQL_UNIX_ADDR NULL
+#   if !PHP_WIN32
+#    define PDO_MYSQL_UNIX_ADDR "/tmp/mysql.sock"
+#   else
+#    define PDO_MYSQL_UNIX_ADDR NULL
+#   endif
 #  endif
 # endif
 #endif


### PR DESCRIPTION
When the mysql extension is disabled, there is no automatic detection
of the mysql unix socket path.
The mysqli/mysqlnd/pdo_mysql use a hardcoded /tmp/mysql.sock path.

This adds automatic detection of the mysql unix socket path in mysqlnd
with mysql_config --socket, and makes pdo_mysql use it as well.
