### PR TITLE
Remove PWS (Personal Web Server) references

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1819,7 +1819,7 @@ Installation
        set of HTTP headers. The headers it did return are:
    10. Windows:  I've  followed  all the instructions, but still can't get
        PHP and IIS to work together!
-   11. When  running  PHP as CGI with IIS, PWS, OmniHTTPD or Xitami, I get
+   11. When  running  PHP as CGI with IIS, OmniHTTPD or Xitami, I get
        the  following  error:  Security  Alert! PHP CGI cannot be accessed
        directly..
    12. How  do I know if my php.ini is being found and read? It seems like
@@ -2007,7 +2007,7 @@ cgi error:
           And  for  IIS4  you need to tell it that PHP is a script engine.
           Also, you will want to read this faq.
 
-   When running PHP as CGI with IIS, PWS, OmniHTTPD or Xitami, I get the
+   When running PHP as CGI with IIS, OmniHTTPD or Xitami, I get the
           following error: Security Alert! PHP CGI cannot be accessed
           directly..
           You  must set the cgi.force_redirect directive to 0. It defaults

--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -238,8 +238,6 @@ $text_files = array(
 	"php.ini-development" => "php.ini-development",
 	"php.ini-production" => "php.ini-production",
 	"win32/install.txt" => "install.txt",
-	"win32/pws-php5cgi.reg" => "pws-php5cgi.reg",
-	"win32/pws-php5isapi.reg" => "pws-php5isapi.reg",
 );
 
 foreach ($text_files as $src => $dest) {

--- a/win32/install.txt
+++ b/win32/install.txt
@@ -9,7 +9,7 @@ Installing PHP
         Windows Installer
         Manual Installation Steps
         ActiveScript
-        Microsoft IIS / PWS
+        Microsoft IIS
         Apache 1.3.x on Microsoft Windows
         Apache 2.0.x on Microsoft Windows
         Sun, iPlanet and Netscape servers on Microsoft Windows
@@ -211,7 +211,7 @@ Windows Installer (PHP 5.1.0 and earlier)
 
    The Windows PHP installer is available from the downloads page at
    http://www.php.net/downloads.php. This installs the CGI version of PHP
-   and for IIS, PWS, and Xitami, it configures the web server as well. The
+   and for IIS and Xitami, it configures the web server as well. The
    installer does not include any extra external PHP extensions
    (php_*.dll) as you'll only find those in the Windows Zip Package and
    PECL downloads.
@@ -433,7 +433,7 @@ c:\php
        follow the next step. Set the doc_root to point to your web servers
        document_root. For example:
 
-doc_root = c:\inetpub\wwwroot // for IIS/PWS
+doc_root = c:\inetpub\wwwroot // for IIS
 
 doc_root = c:\apache\htdocs // for Apache
 
@@ -442,11 +442,6 @@ doc_root = c:\apache\htdocs // for Apache
        what is already built in. Note that on a new installation it is
        advisable to first get PHP working and tested without any
        extensions before enabling them in php.ini.
-     * On PWS and IIS, you can set the browscap configuration setting to
-       point to: c:\windows\system\inetsrv\browscap.ini on Windows 9x/Me,
-       c:\winnt\system32\inetsrv\browscap.ini on NT/2000, and
-       c:\windows\system32\inetsrv\browscap.ini on XP. For an up-to-date
-       browscap.ini, read the following FAQ.
 
    PHP is now setup on your system. The next step is to choose a web
    server, and enable it to run PHP. Choose a web server from the table of
@@ -499,7 +494,7 @@ ActiveScript
      folder, if you wish to load extensions, etc.
      __________________________________________________________________
 
-Microsoft IIS / PWS
+Microsoft IIS
 
    This section contains notes and hints specific to IIS (Microsoft
    Internet Information Server).
@@ -511,7 +506,7 @@ Microsoft IIS / PWS
    yourself from those attacks.
      __________________________________________________________________
 
-General considerations for all installations of PHP with IIS or PWS
+General considerations for all installations of PHP with IIS
 
      * First, read the Manual Installation Instructions. Do not skip this
        step as it provides crucial information for installing PHP on
@@ -543,7 +538,7 @@ General considerations for all installations of PHP with IIS or PWS
        downloaded in the "Collection of PECL modules" package. Files such
        as php_zip.dll and php_ssh2.dll. Download PHP files here.
      * When defining the executable, the 'check that file exists' box may
-       also be checked. For a small performance penalty, the IIS (or PWS)
+       also be checked. For a small performance penalty, the IIS
        will check that the script file exists and sort out authentication
        before firing up PHP. This means that the web server will provide
        sensible 404 style error messages instead of CGI errors complaining
@@ -1579,7 +1574,7 @@ cgi error:
    11. Windows: I've followed all the instructions, but still can't get
           PHP and IIS to work together!
 
-   12. When running PHP as CGI with IIS, PWS, OmniHTTPD or Xitami, I get
+   12. When running PHP as CGI with IIS, OmniHTTPD or Xitami, I get
           the following error: Security Alert! PHP CGI cannot be accessed
           directly..
 
@@ -1824,7 +1819,7 @@ cgi error:
    tell it that PHP is a script engine. Also, you will want to read this
    faq.
 
-   12. When running PHP as CGI with IIS, PWS, OmniHTTPD or Xitami, I get
+   12. When running PHP as CGI with IIS, OmniHTTPD or Xitami, I get
    the following error: Security Alert! PHP CGI cannot be accessed
    directly..
 

--- a/win32/pws-php5cgi.reg
+++ b/win32/pws-php5cgi.reg
@@ -1,6 +1,0 @@
-REGEDIT4
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\w3svc\parameters\Script Map]
-".php"="[PUT PATH HERE]\\php.exe"
-
-

--- a/win32/pws-php5isapi.reg
+++ b/win32/pws-php5isapi.reg
@@ -1,5 +1,0 @@
-REGEDIT4
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\w3svc\parameters\Script Map]
-".php"="[PUT PATH HERE]\\php5isapi.dll"
-


### PR DESCRIPTION
Remove PWS references as windows XP and previous version are no longer supported
