### PR TITLE
PostgreSQL's PDOStatement::getColumnMeta() fills in table's name.

### DIFF
--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -574,7 +574,7 @@ static char * pdo_pgsql_translate_oid_to_table(Oid oid, PGconn *conn)
 	PGresult *tmp_res;
 	char *querystr = NULL;
 
-	spprintf(&querystr, 0, "select relname from pg_class where oid=%ud", oid);
+	spprintf(&querystr, 0, "select relname from pg_class where oid=%u", oid);
 
 	if ((tmp_res = PQexec(conn, querystr)) == NULL || PQresultStatus(tmp_res) != PGRES_TUPLES_OK) {
 		if (tmp_res) {

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -574,7 +574,7 @@ static char * pdo_pgsql_translate_oid_to_table(Oid oid, PGconn *conn)
 	PGresult *tmp_res;
 	char *querystr = NULL;
 
-	spprintf(&querystr, 0, "select relname from pg_class where oid=%d", oid);
+	spprintf(&querystr, 0, "select relname from pg_class where oid=%ud", oid);
 
 	if ((tmp_res = PQexec(conn, querystr)) == NULL || PQresultStatus(tmp_res) != PGRES_TUPLES_OK) {
 		if (tmp_res) {

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -568,12 +568,40 @@ static int pgsql_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr, unsigned 
 	return 1;
 }
 
+static char * pdo_pgsql_translate_oid_to_table(Oid oid, PGconn *conn)
+{
+	char *table_name = NULL;
+	PGresult *tmp_res;
+	char *querystr = NULL;
+
+	spprintf(&querystr, 0, "select relname from pg_class where oid=%d", oid);
+
+	if ((tmp_res = PQexec(conn, querystr)) == NULL || PQresultStatus(tmp_res) != PGRES_TUPLES_OK) {
+		if (tmp_res) {
+			PQclear(tmp_res);
+		}
+		efree(querystr);
+		return 0;
+	}
+	efree(querystr);
+
+	if ((table_name = PQgetvalue(tmp_res, 0, 0)) == NULL) {
+		PQclear(tmp_res);
+		return 0;
+	}
+
+	PQclear(tmp_res);
+	return table_name;
+}
+
 static int pgsql_stmt_get_column_meta(pdo_stmt_t *stmt, long colno, zval *return_value TSRMLS_DC)
 {
 	pdo_pgsql_stmt *S = (pdo_pgsql_stmt*)stmt->driver_data;
 	PGresult *res;
 	char *q=NULL;
 	ExecStatusType status;
+	Oid table_oid;
+	char *table_name=NULL;
 	
 	if (!S->result) {
 		return FAILURE;
@@ -585,6 +613,15 @@ static int pgsql_stmt_get_column_meta(pdo_stmt_t *stmt, long colno, zval *return
 	
 	array_init(return_value);
 	add_assoc_long(return_value, "pgsql:oid", S->cols[colno].pgsql_type);
+
+	table_oid = PQftable(S->result, colno);
+	add_assoc_long(return_value, "pgsql:table_oid", table_oid);
+	table_name = pdo_pgsql_translate_oid_to_table(table_oid, S->H->server);
+	if (table_name) {
+		add_assoc_string(return_value, "table", table_name, 1);
+	}
+
+
 
 	/* Fetch metadata from Postgres system catalogue */
 	spprintf(&q, 0, "SELECT TYPNAME FROM PG_TYPE WHERE OID=%d", S->cols[colno].pgsql_type);


### PR DESCRIPTION
http://www.php.net/manual/en/pdostatement.getcolumnmeta.php states that there should be column 'table' in returned array. That is not true in current implementation of pgsql_stmt_get_column_meta(). This patch gets table's oid and tries to translate it to table's name.