### PR TITLE
array_column: Changing integer in test output to use %d

### DIFF
--- a/ext/standard/tests/array/array_column_basic.phpt
+++ b/ext/standard/tests/array/array_column_basic.phpt
@@ -178,7 +178,7 @@ array(3) {
 *** Testing multiple data types ***
 array(8) {
   [0]=>
-  object(stdClass)#1 (0) {
+  object(stdClass)#%d (0) {
   }
   [1]=>
   float(34.2345)
@@ -197,7 +197,7 @@ array(8) {
 }
 array(8) {
   [1]=>
-  object(stdClass)#1 (0) {
+  object(stdClass)#%d (0) {
   }
   [2]=>
   float(34.2345)


### PR DESCRIPTION
I've noticed some cases where the integer referencing the stdClass object in the output can be different. This pull request ensures that we use a placeholder for the integer (%d), so that the tests will not fail unnecessarily.
