### PR TITLE
- addressed bug #65159, Misleading configure help text for --with-mysql-sock

### DIFF
--- a/ext/mysql/config.m4
+++ b/ext/mysql/config.m4
@@ -45,7 +45,7 @@ PHP_ARG_WITH(mysql, for MySQL support,
                           mysqlnd the MySQL native driver will be used])
 
 PHP_ARG_WITH(mysql-sock, for specified location of the MySQL UNIX socket,
-[  --with-mysql-sock[=DIR]   MySQL/MySQLi/PDO_MYSQL: Location of the MySQL unix socket pointer.
+[  --with-mysql-sock[=SOCKPATH]   MySQL/MySQLi/PDO_MYSQL: Location of the MySQL unix socket pointer.
                             If unspecified, the default locations are searched], no, no)
 
 if test -z "$PHP_ZLIB_DIR"; then


### PR DESCRIPTION
plz check out the following report. 
--with-mysql-sock configure option takes not a directory but a socket file path.

https://bugs.php.net/bug.php?id=65159
