### PR TITLE
New handler for retrieving properties when object is serialized

### DIFF
--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -142,6 +142,12 @@ ZEND_API HashTable *zend_std_get_debug_info(zval *object, int *is_temp TSRMLS_DC
 }
 /* }}} */
 
+ZEND_API HashTable *zend_std_get_serialize_info(zval *object TSRMLS_DC) /* {{{ */
+{
+	return zend_std_get_properties(object TSRMLS_CC);
+}
+/* }}} */
+
 static zval *zend_std_call_getter(zval *object, zval *member TSRMLS_DC) /* {{{ */
 {
 	zval *retval = NULL;
@@ -1649,6 +1655,7 @@ ZEND_API zend_object_handlers std_object_handlers = {
 	zend_std_cast_object_tostring,			/* cast_object */
 	NULL,									/* count_elements */
 	NULL,									/* get_debug_info */
+	NULL,									/* get_serialize_info */
 	zend_std_get_closure,					/* get_closure */
 	zend_std_get_gc,						/* get_gc */
 	NULL,									/* do_operation */

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -82,6 +82,7 @@ typedef void (*zend_object_unset_dimension_t)(zval *object, zval *offset TSRMLS_
 typedef HashTable *(*zend_object_get_properties_t)(zval *object TSRMLS_DC);
 
 typedef HashTable *(*zend_object_get_debug_info_t)(zval *object, int *is_temp TSRMLS_DC);
+typedef HashTable *(*zend_object_get_serialize_info_t)(zval *objectp TSRMLS_DC);
 
 /* Used to call methods */
 /* args on stack! */
@@ -143,6 +144,7 @@ struct _zend_object_handlers {
 	zend_object_cast_t						cast_object;
 	zend_object_count_elements_t			count_elements;
 	zend_object_get_debug_info_t			get_debug_info;
+	zend_object_get_serialize_info_t		get_serialize_info;
 	zend_object_get_closure_t				get_closure;
 	zend_object_get_gc_t					get_gc;
 	zend_object_do_operation_t				do_operation;
@@ -162,6 +164,7 @@ ZEND_API union _zend_function *zend_std_get_constructor(zval *object TSRMLS_DC);
 ZEND_API struct _zend_property_info *zend_get_property_info(zend_class_entry *ce, zval *member, int silent TSRMLS_DC);
 ZEND_API HashTable *zend_std_get_properties(zval *object TSRMLS_DC);
 ZEND_API HashTable *zend_std_get_debug_info(zval *object, int *is_temp TSRMLS_DC);
+ZEND_API HashTable *zend_std_get_serialize_info(zval *object TSRMLS_DC);
 ZEND_API int zend_std_cast_object_tostring(zval *readobj, zval *writeobj, int type TSRMLS_DC);
 ZEND_API void zend_std_write_property(zval *object, zval *member, zval *value, const struct _zend_literal *key TSRMLS_DC);
 ZEND_API void rebuild_object_properties(zend_object *zobj);

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -451,6 +451,7 @@ END_EXTERN_C()
 #define Z_OBJ_HANDLER(zval, hf) Z_OBJ_HT((zval))->hf
 #define Z_RESVAL(zval)			(zval).value.lval
 #define Z_OBJDEBUG(zval,is_tmp)	(Z_OBJ_HANDLER((zval),get_debug_info)?Z_OBJ_HANDLER((zval),get_debug_info)(&(zval),&is_tmp TSRMLS_CC):(is_tmp=0,Z_OBJ_HANDLER((zval),get_properties)?Z_OBJPROP(zval):NULL))
+#define Z_OBJSERIALIZE(zval)	(Z_OBJ_HANDLER((zval),get_serialize_info)?Z_OBJ_HANDLER((zval),get_serialize_info)(&(zval) TSRMLS_CC):(Z_OBJ_HANDLER((zval),get_properties)?Z_OBJPROP(zval):NULL))
 
 #define Z_LVAL_P(zval_p)		Z_LVAL(*zval_p)
 #define Z_BVAL_P(zval_p)		Z_BVAL(*zval_p)
@@ -466,6 +467,7 @@ END_EXTERN_C()
 #define Z_OBJ_HT_P(zval_p)		Z_OBJ_HT(*zval_p)
 #define Z_OBJ_HANDLER_P(zval_p, h)	Z_OBJ_HANDLER(*zval_p, h)
 #define Z_OBJDEBUG_P(zval_p,is_tmp)	Z_OBJDEBUG(*zval_p,is_tmp)
+#define Z_OBJSERIALIZE_P(zval)	Z_OBJSERIALIZE(*zval)
 
 #define Z_LVAL_PP(zval_pp)		Z_LVAL(**zval_pp)
 #define Z_BVAL_PP(zval_pp)		Z_BVAL(**zval_pp)
@@ -481,6 +483,7 @@ END_EXTERN_C()
 #define Z_OBJ_HT_PP(zval_p)		Z_OBJ_HT(**zval_p)
 #define Z_OBJ_HANDLER_PP(zval_p, h)		Z_OBJ_HANDLER(**zval_p, h)
 #define Z_OBJDEBUG_PP(zval_pp,is_tmp)	Z_OBJDEBUG(**zval_pp,is_tmp)
+#define Z_OBJSERIALIZE_PP(zval)	Z_OBJSERIALIZE(**zval)
 
 #define Z_TYPE(zval)		(zval).type
 #define Z_TYPE_P(zval_p)	Z_TYPE(*zval_p)


### PR DESCRIPTION
This handler is used in var.c for getting properties from object. If not available, standard get_properties is used. It works similar way as get_debug_info.
