### PR TITLE
Fix #65069: GlobIterator fails to access files inside an open_basedir restricted dir

### DIFF
--- a/ext/spl/tests/bug65069.phpt
+++ b/ext/spl/tests/bug65069.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #65069: GlobIterator fails to access files inside an open_basedir restricted dir
+--FILE--
+<?php
+ini_set('open_basedir', __DIR__);
+
+$path = (dirname(__DIR__) . '/*/*.php');
+$std_glob = glob($path);
+$spl_glob = array();
+try {
+	$spl_glob_it = new \GlobIterator($path);
+	foreach ($spl_glob_it as $file_info) {
+		$spl_glob[] = $file_info->getPathname();
+	}
+} catch (Exception $e) {
+	var_dump($e->getMessage());
+}
+
+echo $std_glob == $spl_glob ? "SUCCESS" : "FAILURE";
+?>
+--EXPECT--
+SUCCESS

--- a/ext/spl/tests/bug65069.phpt
+++ b/ext/spl/tests/bug65069.phpt
@@ -4,7 +4,7 @@ Bug #65069: GlobIterator fails to access files inside an open_basedir restricted
 <?php
 ini_set('open_basedir', __DIR__);
 
-$path = (dirname(__DIR__) . '/*/*.php');
+$path = (dirname(__DIR__) . '/*/*');
 $std_glob = glob($path);
 $spl_glob = array();
 try {
@@ -15,8 +15,8 @@ try {
 } catch (Exception $e) {
 	var_dump($e->getMessage());
 }
-
-echo $std_glob == $spl_glob ? "SUCCESS" : "FAILURE";
+if (!empty($std_glob))
+	echo $std_glob == $spl_glob ? "SUCCESS" : "FAILURE";
 ?>
 --EXPECT--
 SUCCESS

--- a/ext/spl/tests/bug65069.phpt
+++ b/ext/spl/tests/bug65069.phpt
@@ -2,21 +2,45 @@
 Bug #65069: GlobIterator fails to access files inside an open_basedir restricted dir
 --FILE--
 <?php
-ini_set('open_basedir', __DIR__);
+$file_path = dirname(__FILE__);
+ini_set('open_basedir', $file_path);
 
-$path = (dirname(__DIR__) . '/*/*');
-$std_glob = glob($path);
-$spl_glob = array();
+// temp dirname used here
+$dirname = "$file_path/bug65069";
+
+// temp dir created
+mkdir($dirname);
+
+// temp files created
+$fp = fopen("$dirname/wonder12345", "w");
+fclose($fp);
+$fp = fopen("$dirname/wonder.txt", "w");
+fclose($fp);
+$fp = fopen("$dirname/file.text", "w");
+fclose($fp);
+
+$pattern = "$dirname/*.txt";
+
 try {
-	$spl_glob_it = new \GlobIterator($path);
+	$spl_glob_it = new \GlobIterator($pattern);
 	foreach ($spl_glob_it as $file_info) {
-		$spl_glob[] = $file_info->getPathname();
+		$spl_glob[] = $file_info->getFilename();
 	}
 } catch (Exception $e) {
 	var_dump($e->getMessage());
 }
-if (!empty($std_glob))
-	echo $std_glob == $spl_glob ? "SUCCESS" : "FAILURE";
+
+if (count($spl_glob) == 1)
+	echo $spl_glob[0]
+?>
+--CLEAN--
+<?php
+$file_path = dirname(__FILE__);
+$dirname = "$file_path/bug65069";
+unlink("$dirname/wonder12345");
+unlink("$dirname/wonder.txt");
+unlink("$dirname/file.text");
+rmdir($dirname);
 ?>
 --EXPECT--
-SUCCESS
+wonder.txt

--- a/ext/spl/tests/bug65069.phpt
+++ b/ext/spl/tests/bug65069.phpt
@@ -3,13 +3,12 @@ Bug #65069: GlobIterator fails to access files inside an open_basedir restricted
 --FILE--
 <?php
 $file_path = dirname(__FILE__);
-ini_set('open_basedir', $file_path);
-
 // temp dirname used here
 $dirname = "$file_path/bug65069";
-
 // temp dir created
 mkdir($dirname);
+
+ini_set('open_basedir', $dirname);
 
 // temp files created
 $fp = fopen("$dirname/wonder12345", "w");
@@ -19,19 +18,35 @@ fclose($fp);
 $fp = fopen("$dirname/file.text", "w");
 fclose($fp);
 
-$pattern = "$dirname/*.txt";
-
-try {
-	$spl_glob_it = new \GlobIterator($pattern);
-	foreach ($spl_glob_it as $file_info) {
-		$spl_glob[] = $file_info->getFilename();
-	}
-} catch (Exception $e) {
-	var_dump($e->getMessage());
+$spl_glob_it = new \GlobIterator("$dirname/*.txt");
+foreach ($spl_glob_it as $file_info) {
+	echo $file_info->getFilename() . "\n";
 }
 
-if (count($spl_glob) == 1)
-	echo $spl_glob[0]
+$spl_glob_it = new \GlobIterator(dirname(dirname($dirname)) . "/*/*/*");
+foreach ($spl_glob_it as $file_info) {
+	echo $file_info->getFilename() . "\n";
+}
+
+$spl_glob_empty = new \GlobIterator("$dirname/*.php");
+try {
+	$spl_glob_empty->count();
+} catch (LogicException $e) {
+	echo "logic exception\n";
+}
+
+try {
+	$spl_glob_not_allowed = new \GlobIterator(dirname(dirname($dirname)));
+} catch (Exception $e) {
+	echo "exception1\n";
+}
+
+try {
+	$spl_glob_sec = new \GlobIterator("$file_path/bug65069-this-will-never-exists");
+} catch (Exception $e) {
+	echo "exception2\n";
+}
+
 ?>
 --CLEAN--
 <?php
@@ -44,3 +59,9 @@ rmdir($dirname);
 ?>
 --EXPECT--
 wonder.txt
+file.text
+wonder.txt
+wonder12345
+logic exception
+exception1
+exception2

--- a/main/streams/glob_wrapper.c
+++ b/main/streams/glob_wrapper.c
@@ -249,8 +249,9 @@ static php_stream *php_glob_stream_opener(php_stream_wrapper *wrapper, char *pat
 	if ((options & STREAM_DISABLE_OPEN_BASEDIR) == 0) {
 		for (i = 0; i < pglob->glob.gl_pathc; i++) {
 			if (!php_check_open_basedir_ex(pglob->glob.gl_pathv[i], 0 TSRMLS_CC)) {
-				if (!pglob->open_basedir_indexmap)
+				if (!pglob->open_basedir_indexmap) {
 					pglob->open_basedir_indexmap = (size_t *) emalloc(sizeof(size_t) * pglob->glob.gl_pathc);
+				}
 				pglob->open_basedir_indexmap[pglob->open_basedir_indexmap_size++] = i;
 			}
 		}

--- a/main/streams/glob_wrapper.c
+++ b/main/streams/glob_wrapper.c
@@ -45,7 +45,7 @@ typedef struct {
 	size_t   path_len;
 	char     *pattern;
 	size_t   pattern_len;
-	int      *open_basedir_indexmap;
+	size_t   *open_basedir_indexmap;
 	size_t   open_basedir_indexmap_size;
 } glob_s_t;
 
@@ -250,7 +250,7 @@ static php_stream *php_glob_stream_opener(php_stream_wrapper *wrapper, char *pat
 		for (i = 0; i < pglob->glob.gl_pathc; i++) {
 			if (!php_check_open_basedir_ex(pglob->glob.gl_pathv[i], 0 TSRMLS_CC)) {
 				if (!pglob->open_basedir_indexmap)
-					pglob->open_basedir_indexmap = (int *) emalloc(sizeof(int) * pglob->glob.gl_pathc);
+					pglob->open_basedir_indexmap = (size_t *) emalloc(sizeof(int) * pglob->glob.gl_pathc);
 				pglob->open_basedir_indexmap[pglob->open_basedir_indexmap_size++] = i;
 			}
 		}

--- a/main/streams/glob_wrapper.c
+++ b/main/streams/glob_wrapper.c
@@ -250,7 +250,7 @@ static php_stream *php_glob_stream_opener(php_stream_wrapper *wrapper, char *pat
 		for (i = 0; i < pglob->glob.gl_pathc; i++) {
 			if (!php_check_open_basedir_ex(pglob->glob.gl_pathv[i], 0 TSRMLS_CC)) {
 				if (!pglob->open_basedir_indexmap)
-					pglob->open_basedir_indexmap = (size_t *) emalloc(sizeof(int) * pglob->glob.gl_pathc);
+					pglob->open_basedir_indexmap = (size_t *) emalloc(sizeof(size_t) * pglob->glob.gl_pathc);
 				pglob->open_basedir_indexmap[pglob->open_basedir_indexmap_size++] = i;
 			}
 		}

--- a/main/streams/glob_wrapper.c
+++ b/main/streams/glob_wrapper.c
@@ -255,6 +255,7 @@ static php_stream *php_glob_stream_opener(php_stream_wrapper *wrapper, char *pat
 		}
 		if (!pglob->basedir_indexmap) {
 			globfree(&pglob->glob);
+			efree(pglob);
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "open_basedir restriction in effect. File(%s) is not within the allowed path(s): (%s)", path, PG(open_basedir));
 			return NULL;
 		}


### PR DESCRIPTION
Proper checking and filtering of glob stream paths when open_basedir set
