### PR TITLE
Fix #61345: fix install of CGI binary

### DIFF
--- a/sapi/cgi/Makefile.frag
+++ b/sapi/cgi/Makefile.frag
@@ -5,6 +5,7 @@ $(SAPI_CGI_PATH): $(PHP_GLOBAL_OBJS) $(PHP_BINARY_OBJS) $(PHP_CGI_OBJS)
 
 install-cgi: $(SAPI_CGI_PATH)
 	@echo "Installing PHP CGI binary:        $(INSTALL_ROOT)$(bindir)/"
+	@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
 	@$(INSTALL) -m 0755 $(SAPI_CGI_PATH) $(INSTALL_ROOT)$(bindir)/$(program_prefix)php-cgi$(program_suffix)$(EXEEXT)
 	@echo "Installing PHP CGI man page:      $(INSTALL_ROOT)$(mandir)/man1/"
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1


### PR DESCRIPTION
When CLI was not built but only CGI binary, then a sequence of

$ ./buildconf
$ ./configure  --prefix=/usr/local/phpcgi --disable-cli
$ make -j8
$ sudo rm -rf /usr/local/phpcgi
$ sudo make install

results in the following error:

/bin/bash /srv/smb/php-src.test/libtool --silent --preserve-dup-deps --mode=install cp ext/opcache/opcache.la /srv/smb/php-src.test/modules
Installing shared extensions:     /usr/local/phpcgi/lib/php/extensions/no-debug-non-zts-20121212/
Installing PHP CGI binary:        /usr/local/phpcgi/bin/
cp: cannot create regular file `/usr/local/phpcgi/bin/#INST@28245#': No such file or directory
make: **\* [install-cgi] Fehler 1

The solution is to create the binary directory before copying the
CGI binary as e.g. CLI does.

Signed-off-by: Oliver Metz oliver.metz@gmx.de

[extensive commit message]

Signed-off-by: Michael Heimpold mhei@heimpold.de
