### PR TITLE
php.ini-development/production: remove php_zip.dll

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -909,7 +909,6 @@ default_socket_timeout = 60
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;

--- a/php.ini-production
+++ b/php.ini-production
@@ -910,7 +910,6 @@ default_socket_timeout = 60
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;


### PR DESCRIPTION
Remove the reference to php_zip.dll in php.ini-production and
php.ini-development, because php_zip.dll does not exist anymore since
PHP 5.3
