### PR TITLE
Fixbug: phpize --clean will delete include/*.h

### DIFF
--- a/scripts/phpize.in
+++ b/scripts/phpize.in
@@ -11,7 +11,7 @@ SED="@SED@"
 
 FILES_BUILD="mkdep.awk scan_makefile_in.awk shtool libtool.m4"
 FILES="acinclude.m4 Makefile.global config.sub config.guess ltmain.sh run-tests*.php"
-CLEAN_FILES="$FILES *.o *.lo *.la .deps .libs/ build/ include/ modules/ install-sh \
+CLEAN_FILES="$FILES *.o *.lo *.la .deps .libs/ build/ modules/ install-sh \
 	mkinstalldirs missing config.nice config.sub config.guess configure configure.in \
 	aclocal.m4 config.h config.h.in conftest* ltmain.sh libtool config.cache autom4te.cache/ \
 	config.log config.status Makefile Makefile.fragments Makefile.objects confdefs.h \


### PR DESCRIPTION
Command `phpize --clean` delete all head file in include directory. Fix the bug.
