### PR TITLE
Segfault fix for more than one modules

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -2207,7 +2207,7 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 			additional_modules_array[i] = &additional_modules[i];
 		}
 
-    		php_register_extensions(additional_modules_array, num_additional_modules TSRMLS_CC);
+		php_register_extensions(additional_modules_array, num_additional_modules TSRMLS_CC);
 		efree(additional_modules_array);
 	}
 


### PR DESCRIPTION
This bug has first reported on 2004 but was never fixed (http://marc.info/?l=php-internals&m=110257814320454&w=2). It has since then be raised several times (https://bugs.php.net/bug.php?id=63159 http://marc.info/?l=php-internals&m=110121150631159&w=2 http://marc.info/?l=php-internals&m=110332550012837&w=2). Let's see if we can fix it once and for all.
