### PR TITLE
New function: stream_socket_listen()

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1981,6 +1981,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_stream_socket_server, 0, 0, 1)
 	ZEND_ARG_INFO(0, context)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_stream_socket_listen, 0)
+    ZEND_ARG_INFO(0, serverstream)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_stream_socket_accept, 0, 0, 1)
 	ZEND_ARG_INFO(0, serverstream)
 	ZEND_ARG_INFO(0, timeout)
@@ -3125,6 +3129,7 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(stream_filter_remove,											arginfo_stream_filter_remove)
 	PHP_FE(stream_socket_client,											arginfo_stream_socket_client)
 	PHP_FE(stream_socket_server,											arginfo_stream_socket_server)
+	PHP_FE(stream_socket_listen,											arginfo_stream_socket_listen)
 	PHP_FE(stream_socket_accept,											arginfo_stream_socket_accept)
 	PHP_FE(stream_socket_get_name,											arginfo_stream_socket_get_name)
 	PHP_FE(stream_socket_recvfrom,											arginfo_stream_socket_recvfrom)

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -235,6 +235,40 @@ PHP_FUNCTION(stream_socket_server)
 }
 /* }}} */
 
+/* {{{ proto bool stream_socket_listen(resource serverstream)
+   Listen for client connections on a socket previously bound via stream_socket_server() */
+PHP_FUNCTION(stream_socket_listen)
+{
+	php_stream *stream = NULL;
+	zval *zstream = NULL, **zbacklog = NULL;
+	int backlog = 32;
+	char *error_text = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zstream) == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	php_stream_from_zval(stream, &zstream);
+
+	if (stream->context && php_stream_context_get_option(stream->context, "socket", "backlog", &zbacklog) == SUCCESS) {
+		zval *ztmp = *zbacklog;			
+		convert_to_long_ex(&ztmp);
+		backlog = Z_LVAL_P(ztmp);
+		if (ztmp != *zbacklog) {
+			zval_ptr_dtor(&ztmp);
+		}
+	}
+	
+	if (0 != php_stream_xport_listen(stream, backlog, &error_text TSRMLS_CC)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, error_text == NULL ? "Unknown error" : error_text);
+		RETURN_FALSE;
+	} else {
+		php_stream_to_zval(stream, return_value);
+		RETURN_TRUE;
+	}
+}
+/* }}} */
+
 /* {{{ proto resource stream_socket_accept(resource serverstream, [ double timeout [, string &peername ]])
    Accept a client connection from a server socket */
 PHP_FUNCTION(stream_socket_accept)

--- a/ext/standard/streamsfuncs.h
+++ b/ext/standard/streamsfuncs.h
@@ -25,6 +25,7 @@
 
 PHP_FUNCTION(stream_socket_client);
 PHP_FUNCTION(stream_socket_server);
+PHP_FUNCTION(stream_socket_listen);
 PHP_FUNCTION(stream_socket_accept);
 PHP_FUNCTION(stream_socket_get_name);
 PHP_FUNCTION(stream_socket_recvfrom);

--- a/ext/standard/tests/streams/stream_socket_listen.phpt
+++ b/ext/standard/tests/streams/stream_socket_listen.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Tests that stream_socket_listen() listens on a previously bound socket
+--FILE--
+<?php
+$server = stream_socket_server('tcp://0.0.0.0:0', $errno, $errstr, STREAM_SERVER_BIND);
+var_dump(stream_socket_listen($server));
+
+$port = explode(':', stream_socket_get_name($server, FALSE), 2)[1];
+
+$clientAddr = "tcp://127.0.0.1:{$port}";
+$clientFlags = STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT;
+$client = stream_socket_client($clientAddr, $errno, $errstr, $timeout = 0, $clientFlags);
+
+while (TRUE) {
+    $r = [$server];
+    $w = $e = NULL;
+    if (stream_select($r, $w, $e, $timeout = 1)) {
+        $serverClient = stream_socket_accept($server, 1);
+        break;
+    }
+}
+
+fwrite($serverClient, "foo\n");
+$sockData = trim(fgets($client));
+
+var_dump($server, $client, $serverClient, $sockData);
+
+fclose($server);
+fclose($client);
+fclose($serverClient);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+bool(true)
+resource(%d) of type (stream)
+resource(%d) of type (stream)
+resource(%d) of type (stream)
+string(3) "foo"
+===DONE===

--- a/main/streams/transports.c
+++ b/main/streams/transports.c
@@ -275,6 +275,9 @@ PHPAPI int php_stream_xport_listen(php_stream *stream, int backlog, char **error
 		}
 
 		return param.outputs.returncode;
+
+	} else if (ret == PHP_STREAM_OPTION_RETURN_NOTIMPL) {
+		*error_text = "listening not supported on this stream";
 	}
 
 	return ret;


### PR DESCRIPTION
The stream socket functions are incredibly useful and obviate the need for the sockets extension for the vast majority of potential use-cases. However, it's currently not possible to bind a socket and listen for connections in separate steps using `stream_socket_server()`.

This _can_ be done with the aid of ext/sockets like so:

``` php
<?php
$stream = stream_socket_server(
    'tcp://0.0.0.0:0',
    $errno,
    $errstr,
    STREAM_SERVER_BIND
);
$sock = socket_import_stream($stream);
socket_listen($sock);
```

Why is this useful? Well, for example, binding to a port in the main process and then listening individually in child forks/threads trivializes scaling socket servers. By listening on the same bound socket in multiple processes you get the advantage of the OS distributing new client connections to the individual workers instead of routing them in userland. Additionally, newer linux kernel versions (3.9x) now support the SO_REUSEPORT socket option which only makes this functionality more attractive. Admittedly you still need ext/sockets to reap the benefits of SO_REUSEPORT, but this may not always be the case.

My proposed patch adds a very simple function so that listening may be decoupled from binding without the need for ext/sockets:

``` php
<?php
$stream = stream_socket_server(
    'tcp://0.0.0.0:0',
    $errno,
    $errstr,
    STREAM_SERVER_BIND
);
// do stuff, fork, etc. Then in the child process:
stream_socket_listen($stream);
```

Existing functionality is not modified and there are no BC breaks. I.E. you can still bind + listen in a single step like before.
