### PR TITLE
Call php_module_shutdown() for php-fpm child processes

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1982,8 +1982,9 @@ fastcgi_request_done:
 out:
 
 	SG(server_context) = NULL;
+	php_module_shutdown(TSRMLS_C);
+
 	if (parent) {
-		php_module_shutdown(TSRMLS_C);
 		sapi_shutdown();
 	}
 


### PR DESCRIPTION
The PHP_MSHUTDOWN_FUNCTION should execute when a php-fpm child process exits. It currently only runs for the master process.

We run into a problem with a custom extension which needs to release resources when a process exits and this fix solves the problem.
