### PR TITLE
Bug 65502

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -480,7 +480,7 @@ const zend_function_entry date_funcs_immutable[] = {
 	PHP_ME(DateTimeImmutable, __construct,   arginfo_date_create, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
 	PHP_ME(DateTime, __wakeup,       NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(DateTimeImmutable, __set_state,   NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	PHP_ME_MAPPING(createFromFormat, date_create_from_format, arginfo_date_create_from_format, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME_MAPPING(createFromFormat, date_create_immutable_from_format, arginfo_date_create_from_format, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(getLastErrors,    date_get_last_errors,    arginfo_date_get_last_errors, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(format,           date_format,             arginfo_date_method_format, 0)
 	PHP_ME_MAPPING(getTimezone, date_timezone_get,	arginfo_date_method_timezone_get, 0)

--- a/ext/date/tests/bug65502.phpt
+++ b/ext/date/tests/bug65502.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test for bug #65502: DateTimeImmutable::createFromFormat returns DateTime
+--CREDITS--
+Boro Sitnikovski <buritomath@yahoo.com>
+--INI--
+date.timezone = UTC
+--FILE--
+<?php
+echo get_class(DateTimeImmutable::createFromFormat('j-M-Y', '12-Sep-2013'));
+?>
+--EXPECT--
+DateTimeImmutable


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=65502

DateTimeImmutable::createFromFormat should call date_create_immutable_from_format instead of date_create_from_format
