### PR TITLE
Make the type hinting error message slightly clearer when a class is expected.

### DIFF
--- a/Zend/tests/bug33996.phpt
+++ b/Zend/tests/bug33996.phpt
@@ -26,4 +26,4 @@ FooTest(new Foo());
 --EXPECTF--
 Warning: Missing argument 1 for NormalTest(), called in %sbug33996.php on line %d and defined in %sbug33996.php on line %d
 Hi!
-Catchable fatal error: Argument 1 passed to FooTest() must be an instance of Foo, none given, called in %sbug33996.php on line %d and defined in %sbug33996.php on line %d
+Catchable fatal error: Argument 1 passed to FooTest() must be an instance of the class Foo, none given, called in %sbug33996.php on line %d and defined in %sbug33996.php on line %d

--- a/Zend/tests/bug39003.phpt
+++ b/Zend/tests/bug39003.phpt
@@ -21,4 +21,4 @@ test($obj);
 echo "Done\n";
 ?>
 --EXPECTF--	
-Catchable fatal error: Argument 1 passed to test() must be an instance of OtherClassName, instance of ClassName given, called in %s on line %d and defined in %s on line %d
+Catchable fatal error: Argument 1 passed to test() must be an instance of the class OtherClassName, instance of ClassName given, called in %s on line %d and defined in %s on line %d

--- a/Zend/tests/bug42802.phpt
+++ b/Zend/tests/bug42802.phpt
@@ -37,4 +37,4 @@ ok
 ok
 ok
 
-Catchable fatal error: Argument 1 passed to foo\test5() must be an instance of bar, instance of foo\bar given, called in %sbug42802.php on line %d and defined in %sbug42802.php on line %d
+Catchable fatal error: Argument 1 passed to foo\test5() must be an instance of the class bar, instance of foo\bar given, called in %sbug42802.php on line %d and defined in %sbug42802.php on line %d

--- a/Zend/tests/bug43332_1.phpt
+++ b/Zend/tests/bug43332_1.phpt
@@ -12,4 +12,4 @@ $foo = new foo;
 $foo->bar($foo); // Ok!
 $foo->bar(new \stdclass); // Error, ok!
 --EXPECTF--
-Catchable fatal error: Argument 1 passed to foobar\foo::bar() must be an instance of foobar\foo, instance of stdClass given, called in %sbug43332_1.php on line 10 and defined in %sbug43332_1.php on line 5
+Catchable fatal error: Argument 1 passed to foobar\foo::bar() must be an instance of the class foobar\foo, instance of stdClass given, called in %sbug43332_1.php on line 10 and defined in %sbug43332_1.php on line 5

--- a/Zend/tests/closure_027.phpt
+++ b/Zend/tests/closure_027.phpt
@@ -28,4 +28,4 @@ Notice: Undefined variable: y in %s on line %d
 Warning: Missing argument 1 for {closure}(), called in %s on line %d and defined in %s on line %d
 NULL
 
-Catchable fatal error: Argument 1 passed to test() must be an instance of Closure, instance of stdClass given, called in %s on line %d and defined in %s on line %d
+Catchable fatal error: Argument 1 passed to test() must be an instance of the class Closure, instance of stdClass given, called in %s on line %d and defined in %s on line %d

--- a/Zend/tests/objects_022.phpt
+++ b/Zend/tests/objects_022.phpt
@@ -36,4 +36,4 @@ object(bar)#%d (0) {
 object(baz)#%d (0) {
 }
 
-Catchable fatal error: Argument 1 passed to foo::testFoo() must be an instance of foo, instance of stdClass given, called in %s on line %d and defined in %s on line %d
+Catchable fatal error: Argument 1 passed to foo::testFoo() must be an instance of the class foo, instance of stdClass given, called in %s on line %d and defined in %s on line %d

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -583,7 +583,7 @@ ZEND_API char * zend_verify_arg_class_kind(const zend_arg_info *cur_arg_info, ul
 	if (*pce && (*pce)->ce_flags & ZEND_ACC_INTERFACE) {
 		return "implement interface ";
 	} else {
-		return "be an instance of ";
+		return "be an instance of the class ";
 	}
 }
 

--- a/ext/intl/tests/calendar_add_error.phpt
+++ b/ext/intl/tests/calendar_add_error.phpt
@@ -38,4 +38,4 @@ Warning: intlcal_add() expects exactly 3 parameters, 4 given in %s on line %d
 Warning: intlcal_add(): intlcal_add: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_add() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_add() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_before_after_error.phpt
+++ b/ext/intl/tests/calendar_before_after_error.phpt
@@ -35,11 +35,11 @@ bool(false)
 error: 2, IntlCalendar::before() expects exactly 1 parameter, 0 given
 error: 2, IntlCalendar::before(): intlcal_before/after: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to IntlCalendar::after() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to IntlCalendar::after() must be an instance of the class IntlCalendar, integer given
 error: 2, IntlCalendar::after() expects parameter 1 to be IntlCalendar, integer given
 error: 2, IntlCalendar::after(): intlcal_before/after: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to IntlCalendar::before() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to IntlCalendar::before() must be an instance of the class IntlCalendar, integer given
 error: 2, IntlCalendar::before() expects parameter 1 to be IntlCalendar, integer given
 error: 2, IntlCalendar::before(): intlcal_before/after: bad arguments
 bool(false)

--- a/ext/intl/tests/calendar_clear_error.phpt
+++ b/ext/intl/tests/calendar_clear_error.phpt
@@ -28,4 +28,4 @@ bool(false)
 Warning: intlcal_clear(): intlcal_clear: invalid field in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_clear() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_clear() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_equals_error.phpt
+++ b/ext/intl/tests/calendar_equals_error.phpt
@@ -28,19 +28,19 @@ var_dump(intlcal_equals(1, $c));
 error: 2, IntlCalendar::equals() expects exactly 1 parameter, 0 given
 error: 2, IntlCalendar::equals(): intlcal_equals: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to IntlCalendar::equals() must be an instance of IntlCalendar, instance of stdClass given
+error: 4096, Argument 1 passed to IntlCalendar::equals() must be an instance of the class IntlCalendar, instance of stdClass given
 error: 2, IntlCalendar::equals() expects parameter 1 to be IntlCalendar, object given
 error: 2, IntlCalendar::equals(): intlcal_equals: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to IntlCalendar::equals() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to IntlCalendar::equals() must be an instance of the class IntlCalendar, integer given
 error: 2, IntlCalendar::equals() expects exactly 1 parameter, 2 given
 error: 2, IntlCalendar::equals(): intlcal_equals: bad arguments
 bool(false)
-error: 4096, Argument 2 passed to intlcal_equals() must be an instance of IntlCalendar, array given
+error: 4096, Argument 2 passed to intlcal_equals() must be an instance of the class IntlCalendar, array given
 error: 2, intlcal_equals() expects parameter 2 to be IntlCalendar, array given
 error: 2, intlcal_equals(): intlcal_equals: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to intlcal_equals() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_equals() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_equals() expects parameter 1 to be IntlCalendar, integer given
 error: 2, intlcal_equals(): intlcal_equals: bad arguments
 bool(false)

--- a/ext/intl/tests/calendar_fieldDifference_error.phpt
+++ b/ext/intl/tests/calendar_fieldDifference_error.phpt
@@ -39,4 +39,4 @@ Warning: intlcal_field_difference() expects exactly 3 parameters, 4 given in %s 
 Warning: intlcal_field_difference(): intlcal_field_difference: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_field_difference() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_field_difference() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_getDayOfWeekType_error.phpt
+++ b/ext/intl/tests/calendar_getDayOfWeekType_error.phpt
@@ -41,4 +41,4 @@ Warning: intlcal_get_day_of_week_type() expects parameter 2 to be long, string g
 Warning: intlcal_get_day_of_week_type(): intlcal_get_day_of_week_type: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_day_of_week_type() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_day_of_week_type() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_getErrorCode_error.phpt
+++ b/ext/intl/tests/calendar_getErrorCode_error.phpt
@@ -23,4 +23,4 @@ Warning: IntlCalendar::getErrorCode() expects exactly 0 parameters, 1 given in %
 Warning: IntlCalendar::getErrorCode(): intlcal_get_error_code: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_error_code() must be an instance of IntlCalendar, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_error_code() must be an instance of the class IntlCalendar, null given in %s on line %d

--- a/ext/intl/tests/calendar_getErrorMessage_error.phpt
+++ b/ext/intl/tests/calendar_getErrorMessage_error.phpt
@@ -23,4 +23,4 @@ Warning: IntlCalendar::getErrorMessage() expects exactly 0 parameters, 1 given i
 Warning: IntlCalendar::getErrorMessage(): intlcal_get_error_message: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_error_message() must be an instance of IntlCalendar, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_error_message() must be an instance of the class IntlCalendar, null given in %s on line %d

--- a/ext/intl/tests/calendar_getFirstDayOfWeek_error.phpt
+++ b/ext/intl/tests/calendar_getFirstDayOfWeek_error.phpt
@@ -29,4 +29,4 @@ Warning: intlcal_get_first_day_of_week() expects exactly 1 parameter, 2 given in
 Warning: intlcal_get_first_day_of_week(): intlcal_get_first_day_of_week: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_first_day_of_week() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_first_day_of_week() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_getLocale_error.phpt
+++ b/ext/intl/tests/calendar_getLocale_error.phpt
@@ -39,4 +39,4 @@ Warning: intlcal_get_locale() expects exactly 2 parameters, 1 given in %s on lin
 Warning: intlcal_get_locale(): intlcal_get_locale: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_locale() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_locale() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_getMinimalDaysInFirstWeek_error.phpt
+++ b/ext/intl/tests/calendar_getMinimalDaysInFirstWeek_error.phpt
@@ -29,4 +29,4 @@ Warning: intlcal_get_minimal_days_in_first_week() expects exactly 1 parameter, 2
 Warning: intlcal_get_minimal_days_in_first_week(): intlcal_get_minimal_days_in_first_week: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_minimal_days_in_first_week() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_minimal_days_in_first_week() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_getSkipped_RepeatedWallTimeOption_error.phpt
+++ b/ext/intl/tests/calendar_getSkipped_RepeatedWallTimeOption_error.phpt
@@ -44,4 +44,4 @@ Warning: intlcal_get_repeated_wall_time_option() expects exactly 1 parameter, 2 
 Warning: intlcal_get_repeated_wall_time_option(): intlcal_get_repeated_wall_time_option: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_skipped_wall_time_option() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_skipped_wall_time_option() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_getTimeZone_error.phpt
+++ b/ext/intl/tests/calendar_getTimeZone_error.phpt
@@ -29,4 +29,4 @@ Warning: intlcal_get_time_zone() expects exactly 1 parameter, 2 given in %s on l
 Warning: intlcal_get_time_zone(): intlcal_get_time_zone: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_time_zone() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_time_zone() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_getTime_error.phpt
+++ b/ext/intl/tests/calendar_getTime_error.phpt
@@ -28,4 +28,4 @@ Warning: intlcal_get_time() expects exactly 1 parameter, 2 given in %s on line %
 Warning: intlcal_get_time(): intlcal_get_time: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_time() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_time() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_getType_error.phpt
+++ b/ext/intl/tests/calendar_getType_error.phpt
@@ -29,4 +29,4 @@ Warning: intlcal_get_type() expects exactly 1 parameter, 2 given in %s on line %
 Warning: intlcal_get_type(): intlcal_get_type: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_type() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_type() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_getWeekendTransition_error.phpt
+++ b/ext/intl/tests/calendar_getWeekendTransition_error.phpt
@@ -41,4 +41,4 @@ Warning: intlcal_get_weekend_transition() expects exactly 2 parameters, 1 given 
 Warning: intlcal_get_weekend_transition(): intlcal_get_weekend_transition: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_get_weekend_transition() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_get_weekend_transition() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_get_Least_Greatest_Minimum_Maximum_error.phpt
+++ b/ext/intl/tests/calendar_get_Least_Greatest_Minimum_Maximum_error.phpt
@@ -82,19 +82,19 @@ bool(false)
 
 Warning: intlcal_get_minimum(): intlcal_get_minimum: invalid field in %s on line %d
 bool(false)
-error: 4096, Argument 1 passed to intlcal_get_least_maximum() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_get_least_maximum() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_get_least_maximum() expects parameter 1 to be IntlCalendar, integer given
 error: 2, intlcal_get_least_maximum(): intlcal_get_least_maximum: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to intlcal_get_maximum() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_get_maximum() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_get_maximum() expects parameter 1 to be IntlCalendar, integer given
 error: 2, intlcal_get_maximum(): intlcal_get_maximum: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to intlcal_get_greatest_minimum() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_get_greatest_minimum() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_get_greatest_minimum() expects parameter 1 to be IntlCalendar, integer given
 error: 2, intlcal_get_greatest_minimum(): intlcal_get_greatest_minimum: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to intlcal_get_minimum() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_get_minimum() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_get_minimum() expects parameter 1 to be IntlCalendar, integer given
 error: 2, intlcal_get_minimum(): intlcal_get_minimum: bad arguments
 bool(false)

--- a/ext/intl/tests/calendar_get_getActualMaximum_Minumum_error2.phpt
+++ b/ext/intl/tests/calendar_get_getActualMaximum_Minumum_error2.phpt
@@ -57,15 +57,15 @@ bool(false)
 error: 2, intlcal_get_actual_minimum() expects parameter 2 to be long, string given
 error: 2, intlcal_get_actual_minimum(): intlcal_get_actual_minimum: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to intlcal_get() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_get() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_get() expects exactly 2 parameters, 1 given
 error: 2, intlcal_get(): intlcal_get: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to intlcal_get_actual_maximum() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_get_actual_maximum() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_get_actual_maximum() expects exactly 2 parameters, 1 given
 error: 2, intlcal_get_actual_maximum(): intlcal_get_actual_maximum: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to intlcal_get_actual_minimum() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_get_actual_minimum() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_get_actual_minimum() expects exactly 2 parameters, 1 given
 error: 2, intlcal_get_actual_minimum(): intlcal_get_actual_minimum: bad arguments
 bool(false)

--- a/ext/intl/tests/calendar_inDaylightTime_error.phpt
+++ b/ext/intl/tests/calendar_inDaylightTime_error.phpt
@@ -29,4 +29,4 @@ Warning: intlcal_in_daylight_time() expects exactly 1 parameter, 2 given in %s o
 Warning: intlcal_in_daylight_time(): intlcal_in_daylight_time: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_in_daylight_time() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_in_daylight_time() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_isEquivalentTo_error.phpt
+++ b/ext/intl/tests/calendar_isEquivalentTo_error.phpt
@@ -26,25 +26,25 @@ var_dump(intlcal_is_equivalent_to($c, 1));
 var_dump(intlcal_is_equivalent_to(1, $c));
 
 --EXPECT--
-error: 4096, Argument 1 passed to IntlCalendar::isEquivalentTo() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to IntlCalendar::isEquivalentTo() must be an instance of the class IntlCalendar, integer given
 error: 2, IntlCalendar::isEquivalentTo() expects parameter 1 to be IntlCalendar, integer given
 error: 2, IntlCalendar::isEquivalentTo(): intlcal_is_equivalent_to: bad arguments
 bool(false)
 error: 2, IntlCalendar::isEquivalentTo() expects exactly 1 parameter, 2 given
 error: 2, IntlCalendar::isEquivalentTo(): intlcal_is_equivalent_to: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to IntlCalendar::isEquivalentTo() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to IntlCalendar::isEquivalentTo() must be an instance of the class IntlCalendar, integer given
 error: 2, IntlCalendar::isEquivalentTo() expects parameter 1 to be IntlCalendar, integer given
 error: 2, IntlCalendar::isEquivalentTo(): intlcal_is_equivalent_to: bad arguments
 bool(false)
 error: 2, intlcal_is_equivalent_to() expects exactly 2 parameters, 1 given
 error: 2, intlcal_is_equivalent_to(): intlcal_is_equivalent_to: bad arguments
 bool(false)
-error: 4096, Argument 2 passed to intlcal_is_equivalent_to() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 2 passed to intlcal_is_equivalent_to() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_is_equivalent_to() expects parameter 2 to be IntlCalendar, integer given
 error: 2, intlcal_is_equivalent_to(): intlcal_is_equivalent_to: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to intlcal_is_equivalent_to() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_is_equivalent_to() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_is_equivalent_to() expects parameter 1 to be IntlCalendar, integer given
 error: 2, intlcal_is_equivalent_to(): intlcal_is_equivalent_to: bad arguments
 bool(false)

--- a/ext/intl/tests/calendar_isLenient_error.phpt
+++ b/ext/intl/tests/calendar_isLenient_error.phpt
@@ -29,4 +29,4 @@ Warning: intlcal_is_lenient() expects exactly 1 parameter, 2 given in %s on line
 Warning: intlcal_is_lenient(): intlcal_is_lenient: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_is_lenient() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_is_lenient() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_isSet_error.phpt
+++ b/ext/intl/tests/calendar_isSet_error.phpt
@@ -39,4 +39,4 @@ Warning: intlcal_is_set() expects exactly 2 parameters, 1 given in %s on line %d
 Warning: intlcal_is_set(): intlcal_is_set: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_is_set() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_is_set() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_isWeekend_error.phpt
+++ b/ext/intl/tests/calendar_isWeekend_error.phpt
@@ -35,4 +35,4 @@ Warning: intlcal_is_weekend() expects parameter 2 to be double, string given in 
 Warning: intlcal_is_weekend(): intlcal_is_weekend: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_is_weekend() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_is_weekend() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_roll_error.phpt
+++ b/ext/intl/tests/calendar_roll_error.phpt
@@ -34,4 +34,4 @@ bool(false)
 Warning: intlcal_roll(): intlcal_set: too many arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_roll() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_roll() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_setFirstDayOfWeek_error.phpt
+++ b/ext/intl/tests/calendar_setFirstDayOfWeek_error.phpt
@@ -37,4 +37,4 @@ bool(false)
 Warning: intlcal_set_first_day_of_week(): intlcal_set_first_day_of_week: invalid day of week in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_set_first_day_of_week() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_set_first_day_of_week() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_setLenient_error.phpt
+++ b/ext/intl/tests/calendar_setLenient_error.phpt
@@ -41,4 +41,4 @@ Warning: intlcal_set_lenient() expects parameter 2 to be boolean, array given in
 Warning: intlcal_set_lenient(): intlcal_set_lenient: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_set_lenient() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_set_lenient() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_setMinimalDaysInFirstWeek_error.phpt
+++ b/ext/intl/tests/calendar_setMinimalDaysInFirstWeek_error.phpt
@@ -36,5 +36,5 @@ bool(false)
 Warning: intlcal_set_minimal_days_in_first_week(): intlcal_set_minimal_days_in_first_week: invalid number of days; must be between 1 and 7 in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_set_minimal_days_in_first_week() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_set_minimal_days_in_first_week() must be an instance of the class IntlCalendar, integer given in %s on line %d
 

--- a/ext/intl/tests/calendar_setSkipped_RepeatedWallTimeOption_error.phpt
+++ b/ext/intl/tests/calendar_setSkipped_RepeatedWallTimeOption_error.phpt
@@ -79,4 +79,4 @@ Warning: intlcal_set_repeated_wall_time_option() expects exactly 2 parameters, 1
 Warning: intlcal_set_repeated_wall_time_option(): intlcal_set_repeated_wall_time_option: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_set_repeated_wall_time_option() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_set_repeated_wall_time_option() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_setTimeZone_error.phpt
+++ b/ext/intl/tests/calendar_setTimeZone_error.phpt
@@ -35,7 +35,7 @@ bool(false)
 error: 2, intlcal_set_time_zone() expects exactly 2 parameters, 3 given
 error: 2, intlcal_set_time_zone(): intlcal_set_time_zone: bad arguments
 bool(false)
-error: 4096, Argument 1 passed to intlcal_set_time_zone() must be an instance of IntlCalendar, integer given
+error: 4096, Argument 1 passed to intlcal_set_time_zone() must be an instance of the class IntlCalendar, integer given
 error: 2, intlcal_set_time_zone() expects parameter 1 to be IntlCalendar, integer given
 error: 2, intlcal_set_time_zone(): intlcal_set_time_zone: bad arguments
 bool(false)

--- a/ext/intl/tests/calendar_setTime_error.phpt
+++ b/ext/intl/tests/calendar_setTime_error.phpt
@@ -34,4 +34,4 @@ Warning: intlcal_set_time() expects exactly 2 parameters, 3 given in %s on line 
 Warning: intlcal_set_time(): intlcal_set_time: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_set_time() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_set_time() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_set_error.phpt
+++ b/ext/intl/tests/calendar_set_error.phpt
@@ -38,4 +38,4 @@ bool(false)
 Warning: intlcal_set(): intlcal_set: invalid field in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlcal_set() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_set() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/calendar_toDateTime_error.phpt
+++ b/ext/intl/tests/calendar_toDateTime_error.phpt
@@ -38,4 +38,4 @@ bool(false)
 Warning: IntlCalendar::toDateTime(): intlcal_to_date_time: DateTimeZone constructor threw exception in %s on line %d
 string(77) "exception: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)"
 
-Catchable fatal error: Argument 1 passed to intlcal_to_date_time() must be an instance of IntlCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlcal_to_date_time() must be an instance of the class IntlCalendar, integer given in %s on line %d

--- a/ext/intl/tests/gregoriancalendar_getGregorianChange_error.phpt
+++ b/ext/intl/tests/gregoriancalendar_getGregorianChange_error.phpt
@@ -27,4 +27,4 @@ Warning: intlgregcal_get_gregorian_change() expects exactly 1 parameter, 2 given
 Warning: intlgregcal_get_gregorian_change(): intlgregcal_get_gregorian_change: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlgregcal_get_gregorian_change() must be an instance of IntlGregorianCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlgregcal_get_gregorian_change() must be an instance of the class IntlGregorianCalendar, integer given in %s on line %d

--- a/ext/intl/tests/gregoriancalendar_isLeapYear_error.phpt
+++ b/ext/intl/tests/gregoriancalendar_isLeapYear_error.phpt
@@ -45,4 +45,4 @@ Warning: intlgregcal_is_leap_year() expects exactly 2 parameters, 1 given in %s 
 Warning: intlgregcal_is_leap_year(): intlgregcal_is_leap_year: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlgregcal_is_leap_year() must be an instance of IntlGregorianCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlgregcal_is_leap_year() must be an instance of the class IntlGregorianCalendar, integer given in %s on line %d

--- a/ext/intl/tests/gregoriancalendar_setGregorianChange_error.phpt
+++ b/ext/intl/tests/gregoriancalendar_setGregorianChange_error.phpt
@@ -39,4 +39,4 @@ Warning: intlgregcal_set_gregorian_change() expects exactly 2 parameters, 1 give
 Warning: intlgregcal_set_gregorian_change(): intlgregcal_set_gregorian_change: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intlgregcal_set_gregorian_change() must be an instance of IntlGregorianCalendar, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intlgregcal_set_gregorian_change() must be an instance of the class IntlGregorianCalendar, integer given in %s on line %d

--- a/ext/intl/tests/timezone_getDSTSavings_error.phpt
+++ b/ext/intl/tests/timezone_getDSTSavings_error.phpt
@@ -20,4 +20,4 @@ Warning: IntlTimeZone::getDSTSavings() expects exactly 0 parameters, 1 given in 
 Warning: IntlTimeZone::getDSTSavings(): intltz_get_dst_savings: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intltz_get_dst_savings() must be an instance of IntlTimeZone, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intltz_get_dst_savings() must be an instance of the class IntlTimeZone, null given in %s on line %d

--- a/ext/intl/tests/timezone_getDisplayName_error.phpt
+++ b/ext/intl/tests/timezone_getDisplayName_error.phpt
@@ -42,4 +42,4 @@ Warning: IntlTimeZone::getDisplayName() expects at most 3 parameters, 4 given in
 Warning: IntlTimeZone::getDisplayName(): intltz_get_display_name: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intltz_get_display_name() must be an instance of IntlTimeZone, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intltz_get_display_name() must be an instance of the class IntlTimeZone, null given in %s on line %d

--- a/ext/intl/tests/timezone_getErrorCode_error.phpt
+++ b/ext/intl/tests/timezone_getErrorCode_error.phpt
@@ -20,4 +20,4 @@ Warning: IntlTimeZone::getErrorCode() expects exactly 0 parameters, 1 given in %
 Warning: IntlTimeZone::getErrorCode(): intltz_get_error_code: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intltz_get_error_code() must be an instance of IntlTimeZone, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intltz_get_error_code() must be an instance of the class IntlTimeZone, null given in %s on line %d

--- a/ext/intl/tests/timezone_getErrorMessage_error.phpt
+++ b/ext/intl/tests/timezone_getErrorMessage_error.phpt
@@ -20,4 +20,4 @@ Warning: IntlTimeZone::getErrorMessage() expects exactly 0 parameters, 1 given i
 Warning: IntlTimeZone::getErrorMessage(): intltz_get_error_message: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intltz_get_error_message() must be an instance of IntlTimeZone, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intltz_get_error_message() must be an instance of the class IntlTimeZone, null given in %s on line %d

--- a/ext/intl/tests/timezone_getID_error.phpt
+++ b/ext/intl/tests/timezone_getID_error.phpt
@@ -20,4 +20,4 @@ Warning: IntlTimeZone::getID() expects exactly 0 parameters, 1 given in %s on li
 Warning: IntlTimeZone::getID(): intltz_get_id: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intltz_get_id() must be an instance of IntlTimeZone, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intltz_get_id() must be an instance of the class IntlTimeZone, null given in %s on line %d

--- a/ext/intl/tests/timezone_getOffset_error.phpt
+++ b/ext/intl/tests/timezone_getOffset_error.phpt
@@ -30,4 +30,4 @@ Warning: IntlTimeZone::getOffset() expects exactly 4 parameters, 5 given in %s o
 Warning: IntlTimeZone::getOffset(): intltz_get_offset: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intltz_get_offset() must be an instance of IntlTimeZone, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intltz_get_offset() must be an instance of the class IntlTimeZone, null given in %s on line %d

--- a/ext/intl/tests/timezone_getRawOffset_error.phpt
+++ b/ext/intl/tests/timezone_getRawOffset_error.phpt
@@ -20,4 +20,4 @@ Warning: IntlTimeZone::getRawOffset() expects exactly 0 parameters, 1 given in %
 Warning: IntlTimeZone::getRawOffset(): intltz_get_raw_offset: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intltz_get_raw_offset() must be an instance of IntlTimeZone, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intltz_get_raw_offset() must be an instance of the class IntlTimeZone, null given in %s on line %d

--- a/ext/intl/tests/timezone_hasSameRules_error.phpt
+++ b/ext/intl/tests/timezone_hasSameRules_error.phpt
@@ -22,14 +22,14 @@ var_dump(intltz_has_same_rules(null, $tz));
 
 --EXPECT--
 int(4096)
-string(99) "Argument 1 passed to IntlTimeZone::hasSameRules() must be an instance of IntlTimeZone, string given"
+string(109) "Argument 1 passed to IntlTimeZone::hasSameRules() must be an instance of the class IntlTimeZone, string given"
 int(2)
 string(81) "IntlTimeZone::hasSameRules() expects parameter 1 to be IntlTimeZone, string given"
 int(2)
 string(66) "IntlTimeZone::hasSameRules(): intltz_has_same_rules: bad arguments"
 bool(false)
 int(4096)
-string(92) "Argument 1 passed to intltz_has_same_rules() must be an instance of IntlTimeZone, null given"
+string(102) "Argument 1 passed to intltz_has_same_rules() must be an instance of the class IntlTimeZone, null given"
 int(2)
 string(74) "intltz_has_same_rules() expects parameter 1 to be IntlTimeZone, null given"
 int(2)

--- a/ext/intl/tests/timezone_toDateTimeZone_error.phpt
+++ b/ext/intl/tests/timezone_toDateTimeZone_error.phpt
@@ -35,4 +35,4 @@ Warning: intltz_to_date_time_zone() expects exactly 1 parameter, 0 given in %s o
 Warning: intltz_to_date_time_zone(): intltz_to_date_time_zone: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intltz_to_date_time_zone() must be an instance of IntlTimeZone, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to intltz_to_date_time_zone() must be an instance of the class IntlTimeZone, integer given in %s on line %d

--- a/ext/intl/tests/timezone_useDaylightTime_error.phpt
+++ b/ext/intl/tests/timezone_useDaylightTime_error.phpt
@@ -19,4 +19,4 @@ Warning: IntlTimeZone::useDaylightTime() expects exactly 0 parameters, 1 given i
 Warning: IntlTimeZone::useDaylightTime(): intltz_use_daylight_time: bad arguments in %s on line %d
 bool(false)
 
-Catchable fatal error: Argument 1 passed to intltz_use_daylight_time() must be an instance of IntlTimeZone, null given in %s on line %d
+Catchable fatal error: Argument 1 passed to intltz_use_daylight_time() must be an instance of the class IntlTimeZone, null given in %s on line %d

--- a/ext/intl/tests/transliterator_create_inverse_error.phpt
+++ b/ext/intl/tests/transliterator_create_inverse_error.phpt
@@ -18,4 +18,4 @@ Warning: Transliterator::createInverse() expects exactly 0 parameters, 1 given i
 
 Warning: Transliterator::createInverse(): transliterator_create_inverse: bad arguments in %s on line %d
 
-Catchable fatal error: Argument 1 passed to transliterator_create_inverse() must be an instance of Transliterator, string given in %s on line %d
+Catchable fatal error: Argument 1 passed to transliterator_create_inverse() must be an instance of the class Transliterator, string given in %s on line %d

--- a/ext/intl/tests/transliterator_get_error_code_error.phpt
+++ b/ext/intl/tests/transliterator_get_error_code_error.phpt
@@ -21,4 +21,4 @@ Warning: Transliterator::getErrorCode() expects exactly 0 parameters, 1 given in
 Warning: Transliterator::getErrorCode(): transliterator_get_error_code: unable to parse input params in %s on line %d
 
 
-Catchable fatal error: Argument 1 passed to transliterator_get_error_code() must be an instance of Transliterator, array given in %s on line %d
+Catchable fatal error: Argument 1 passed to transliterator_get_error_code() must be an instance of the class Transliterator, array given in %s on line %d

--- a/ext/intl/tests/transliterator_get_error_message_error.phpt
+++ b/ext/intl/tests/transliterator_get_error_message_error.phpt
@@ -21,4 +21,4 @@ Warning: Transliterator::getErrorMessage() expects exactly 0 parameters, 1 given
 Warning: Transliterator::getErrorMessage(): transliterator_get_error_message: unable to parse input params in %s on line %d
 
 
-Catchable fatal error: Argument 1 passed to transliterator_get_error_message() must be an instance of Transliterator, array given in %s on line %d
+Catchable fatal error: Argument 1 passed to transliterator_get_error_message() must be an instance of the class Transliterator, array given in %s on line %d

--- a/tests/classes/autoload_009.phpt
+++ b/tests/classes/autoload_009.phpt
@@ -15,6 +15,6 @@ Ensure type hints for unknown types do not trigger autoload.
 ?>
 --EXPECTF--
 
-Catchable fatal error: Argument 1 passed to f() must be an instance of UndefClass, instance of stdClass given, called in %s
+Catchable fatal error: Argument 1 passed to f() must be an instance of the class UndefClass, instance of stdClass given, called in %s
 
 

--- a/tests/classes/interfaces_003.phpt
+++ b/tests/classes/interfaces_003.phpt
@@ -23,4 +23,4 @@ $obj = new MyTestClass;
 ===DONE===
 --EXPECTF--
 
-Catchable fatal error: Argument 1 passed to MyTestClass::__construct() must be an instance of MyObject, none given, called in %sinterfaces_003.php on line %d
+Catchable fatal error: Argument 1 passed to MyTestClass::__construct() must be an instance of the class MyObject, none given, called in %sinterfaces_003.php on line %d

--- a/tests/classes/type_hinting_002.phpt
+++ b/tests/classes/type_hinting_002.phpt
@@ -13,4 +13,4 @@ $o = new Foo;
 $o->a($o);
 ?>
 --EXPECTF--
-Catchable fatal error: Argument 1 passed to Foo::a() must be an instance of NonExisting, instance of Foo given, called in %s on line %d and defined in %s on line %d
+Catchable fatal error: Argument 1 passed to Foo::a() must be an instance of the class NonExisting, instance of Foo given, called in %s on line %d and defined in %s on line %d

--- a/tests/classes/type_hinting_004.phpt
+++ b/tests/classes/type_hinting_004.phpt
@@ -77,10 +77,10 @@ Ensure type hints are enforced for functions invoked as callbacks.
 ?>
 --EXPECTF--
 ---> Type hints with callback function:
-4096: Argument 1 passed to f1() must be an instance of A, integer given%s(10)
+4096: Argument 1 passed to f1() must be an instance of the class A, integer given%s(10)
 in f1;
 in f1;
-4096: Argument 1 passed to f2() must be an instance of A, integer given%s(13)
+4096: Argument 1 passed to f2() must be an instance of the class A, integer given%s(13)
 in f2;
 in f2;
 in f2;
@@ -88,10 +88,10 @@ in f2;
 
 
 ---> Type hints with callback static method:
-4096: Argument 1 passed to C::f1() must be an instance of A, integer given%s(26)
+4096: Argument 1 passed to C::f1() must be an instance of the class A, integer given%s(26)
 in C::f1 (static);
 in C::f1 (static);
-4096: Argument 1 passed to C::f2() must be an instance of A, integer given%s(33)
+4096: Argument 1 passed to C::f2() must be an instance of the class A, integer given%s(33)
 in C::f2 (static);
 in C::f2 (static);
 in C::f2 (static);
@@ -99,10 +99,10 @@ in C::f2 (static);
 
 
 ---> Type hints with callback instance method:
-4096: Argument 1 passed to D::f1() must be an instance of A, integer given%s(51)
+4096: Argument 1 passed to D::f1() must be an instance of the class A, integer given%s(51)
 in C::f1 (instance);
 in C::f1 (instance);
-4096: Argument 1 passed to D::f2() must be an instance of A, integer given%s(58)
+4096: Argument 1 passed to D::f2() must be an instance of the class A, integer given%s(58)
 in C::f2 (instance);
 in C::f2 (instance);
 in C::f2 (instance);

--- a/tests/lang/bug24658.phpt
+++ b/tests/lang/bug24658.phpt
@@ -53,4 +53,4 @@ int(2)
 object(foo)#%d (0) {
 }
 
-Catchable fatal error: Argument 1 passed to typehint() must be an instance of foo, integer given in %s on line %d
+Catchable fatal error: Argument 1 passed to typehint() must be an instance of the class foo, integer given in %s on line %d

--- a/tests/lang/catchable_error_001.phpt
+++ b/tests/lang/catchable_error_001.phpt
@@ -19,4 +19,4 @@ Catchable fatal error [1]
 	echo "ALIVE!\n";
 ?>
 --EXPECTF--
-Catchable fatal error: Argument 1 passed to blah() must be an instance of Foo, instance of stdClass given, called in %scatchable_error_001.php on line 15 and defined in %scatchable_error_001.php on line 5
+Catchable fatal error: Argument 1 passed to blah() must be an instance of the class Foo, instance of stdClass given, called in %scatchable_error_001.php on line 15 and defined in %scatchable_error_001.php on line 5

--- a/tests/lang/catchable_error_002.phpt
+++ b/tests/lang/catchable_error_002.phpt
@@ -25,7 +25,7 @@ array(5) {
   [0]=>
   int(4096)
   [1]=>
-  string(%d) "Argument 1 passed to blah() must be an instance of Foo, instance of stdClass given, called in %scatchable_error_002.php on line %d and defined"
+  string(%d) "Argument 1 passed to blah() must be an instance of the class Foo, instance of stdClass given, called in %scatchable_error_002.php on line %d and defined"
   [2]=>
   string(%d) "%scatchable_error_002.php"
   [3]=>

--- a/tests/lang/type_hints_001.phpt
+++ b/tests/lang/type_hints_001.phpt
@@ -23,4 +23,4 @@ type_hint_foo($bar);
 ?>
 --EXPECTF--
 
-Catchable fatal error: Argument 1 passed to type_hint_foo() must be an instance of Foo, instance of Bar given, called in %s on line 16 and defined in %s on line 9
+Catchable fatal error: Argument 1 passed to type_hint_foo() must be an instance of the class Foo, instance of Bar given, called in %s on line 16 and defined in %s on line 9


### PR DESCRIPTION
Implements FR #65656 (Error message when type hinting is ambigious).
