### PR TITLE
EmptyIterator now implements Countable; fixes bug 60577

### DIFF
--- a/ext/spl/internal/emptyiterator.inc
+++ b/ext/spl/internal/emptyiterator.inc
@@ -15,7 +15,7 @@
  * @version 1.0
  * @since PHP 5.1
  */
-class EmptyIterator implements Iterator
+class EmptyIterator implements Iterator, Countable
 {
 	/** No operation.
 	 * @return void
@@ -57,6 +57,15 @@ class EmptyIterator implements Iterator
 	{
 		// nothing to do
 	}
+
+	/** 
+	 * @return int
+	 */
+	function count()
+	{
+		return 0;
+	}
+
 }
 
 ?>

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -3241,12 +3241,23 @@ SPL_METHOD(EmptyIterator, next)
 	}
 } /* }}} */
 
+/* {{{ proto int EmptyIterator::count()
+   Does nothing */
+SPL_METHOD(EmptyIterator, count)
+{
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+	RETURN_LONG(0);
+} /* }}} */
+
 static const zend_function_entry spl_funcs_EmptyIterator[] = {
 	SPL_ME(EmptyIterator, rewind,           arginfo_recursive_it_void, ZEND_ACC_PUBLIC)
 	SPL_ME(EmptyIterator, valid,            arginfo_recursive_it_void, ZEND_ACC_PUBLIC)
 	SPL_ME(EmptyIterator, key,              arginfo_recursive_it_void, ZEND_ACC_PUBLIC)
 	SPL_ME(EmptyIterator, current,          arginfo_recursive_it_void, ZEND_ACC_PUBLIC)
 	SPL_ME(EmptyIterator, next,             arginfo_recursive_it_void, ZEND_ACC_PUBLIC)
+	SPL_ME(EmptyIterator, count,            arginfo_recursive_it_void, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -3707,6 +3718,7 @@ PHP_MINIT_FUNCTION(spl_iterators)
 
 	REGISTER_SPL_STD_CLASS_EX(EmptyIterator, NULL, spl_funcs_EmptyIterator);
 	REGISTER_SPL_ITERATOR(EmptyIterator);
+	REGISTER_SPL_IMPLEMENTS(EmptyIterator, Countable);
 
 	REGISTER_SPL_SUB_CLASS_EX(RecursiveTreeIterator, RecursiveIteratorIterator, spl_RecursiveTreeIterator_new, spl_funcs_RecursiveTreeIterator);
 	REGISTER_SPL_CLASS_CONST_LONG(RecursiveTreeIterator, "BYPASS_CURRENT",      RTIT_BYPASS_CURRENT);

--- a/ext/spl/tests/bug60577.phpt
+++ b/ext/spl/tests/bug60577.phpt
@@ -1,0 +1,8 @@
+--TEST--
+count(new EmptyIterator) should return zero
+--FILE--
+<?php
+$it = new EmptyIterator;
+var_dump(count($it));
+--EXPECT--
+int(0)


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=60577

This a feature request, not a bug. It seemed a logical change given that many iterators do implement `Countable`.
