### PR TITLE
json_encode(): added option to turn only empty arrays into object

### DIFF
--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -98,6 +98,7 @@ static PHP_MINIT_FUNCTION(json)
 	REGISTER_LONG_CONSTANT("JSON_HEX_APOS", PHP_JSON_HEX_APOS, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("JSON_HEX_QUOT", PHP_JSON_HEX_QUOT, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("JSON_FORCE_OBJECT", PHP_JSON_FORCE_OBJECT, CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("JSON_FORCE_EMPTY_OBJECT", PHP_JSON_FORCE_EMPTY_OBJECT, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("JSON_NUMERIC_CHECK", PHP_JSON_NUMERIC_CHECK, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("JSON_UNESCAPED_SLASHES", PHP_JSON_UNESCAPED_SLASHES, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("JSON_PRETTY_PRINT", PHP_JSON_PRETTY_PRINT, CONST_CS | CONST_PERSISTENT);
@@ -247,6 +248,12 @@ static void json_encode_array(smart_str *buf, zval **val, int options TSRMLS_DC)
 		return;
 	}
 
+	i = myht ? zend_hash_num_elements(myht) : 0;
+
+	if (i == 0 && (options & PHP_JSON_FORCE_EMPTY_OBJECT)) {
+		r = PHP_JSON_OUTPUT_OBJECT;
+	}
+
 	if (r == PHP_JSON_OUTPUT_ARRAY) {
 		smart_str_appendc(buf, '[');
 	} else {
@@ -255,8 +262,6 @@ static void json_encode_array(smart_str *buf, zval **val, int options TSRMLS_DC)
 
 	json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
 	++JSON_G(encoder_depth);
-
-	i = myht ? zend_hash_num_elements(myht) : 0;
 
 	if (i > 0)
 	{

--- a/ext/json/php_json.h
+++ b/ext/json/php_json.h
@@ -65,6 +65,7 @@ extern zend_class_entry *php_json_serializable_ce;
 #define PHP_JSON_PRETTY_PRINT	(1<<7)
 #define PHP_JSON_UNESCAPED_UNICODE	(1<<8)
 #define PHP_JSON_PARTIAL_OUTPUT_ON_ERROR (1<<9)
+#define PHP_JSON_FORCE_EMPTY_OBJECT (1<<10)
 
 /* Internal flags */
 #define PHP_JSON_OUTPUT_ARRAY	0

--- a/ext/json/tests/json_encode_empty_object.phpt
+++ b/ext/json/tests/json_encode_empty_object.phpt
@@ -1,0 +1,12 @@
+--TEST--
+json_encode() with JSON_FORCE_EMPTY_OBJECT
+--SKIPIF--
+<?php if (!extension_loaded("json")) print "skip"; ?>
+--FILE--
+<?php
+var_dump(json_encode(array(), JSON_FORCE_EMPTY_OBJECT));
+var_dump(json_encode(array(1,2,3), JSON_FORCE_EMPTY_OBJECT));
+?>
+--EXPECT--
+string(2) "{}"
+string(7) "[1,2,3]"


### PR DESCRIPTION
This PR supersedes https://github.com/php/php-src/pull/454 in the sense that I've fixed up my repo :)

I ran into a situation whereby empty php arrays should be sent as objects but are serialized into JSON as an Array type, i.e. `[]`.

The `JSON_FORCE_OBJECT` option will solve that, but that also affects numerically indexed arrays; in my case, I wanted a bit of both, so I'm proposing `JSON_FORCE_EMPTY_OBJECT` that will serialize only empty arrays as objects, but filled arrays will be serialized according to their keys or other flags.

A specific use-case is when the encoded value is passed to JavaScript; if an array is passed, you can add properties to it, but when you later do `JSON.stringify()` it returns an empty array. This is quite unlike PHP of course, because arrays can be both things, depending on whether it contains only numeric keys or not.

I readily admit that this use-case is fairly uncommon :)
