### PR TITLE
Bug 64560

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4481,7 +4481,7 @@ PHP_FUNCTION(timezone_identifiers_list)
 	const timelib_tzdb             *tzdb;
 	const timelib_tzdb_index_entry *table;
 	int                             i, item_count;
-	long                            what = PHP_DATE_TIMEZONE_GROUP_ALL;
+	long                            what = PHP_DATE_TIMEZONE_GROUP_ALL_W_BC;
 	char                           *option = NULL;
 	int                             option_len = 0;
 

--- a/ext/date/tests/bug64560.phpt
+++ b/ext/date/tests/bug64560.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Test for bug #64560: timezones missing from DateTimeZone::listIdentifiers()
+--CREDITS--
+Boro Sitnikovski <buritomath@yahoo.com>
+--FILE--
+<?php
+var_dump(in_array('Australia/Canberra', DateTimeZone::listIdentifiers()));
+--EXPECT--
+bool(true)


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=64560

Include all timezones (with backwards compatibility) for default $what
