### PR TITLE
Bug #48389: Correct non posix code (fixing FTBFS on GNU/Hurd)

### DIFF
--- a/TSRM/tsrm_config_common.h
+++ b/TSRM/tsrm_config_common.h
@@ -1,6 +1,10 @@
 #ifndef TSRM_CONFIG_COMMON_H
 #define TSRM_CONFIG_COMMON_H
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #ifndef __CYGWIN__
 # if WINNT|WIN32
 #  define TSRM_WIN32

--- a/ext/date/lib/parse_tz.c
+++ b/ext/date/lib/parse_tz.c
@@ -18,6 +18,10 @@
 
 /* $Id$ */
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #include "timelib.h"
 
 #include <stdio.h>

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -24,6 +24,10 @@
 # define __EXTENSIONS__	1	/* Solaris: uint */
 #endif
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #include "php.h"
 #include <stdio.h>
 #include <ctype.h>

--- a/main/php.h
+++ b/main/php.h
@@ -246,6 +246,10 @@ END_EXTERN_C()
 /* macros */
 #define STR_PRINT(str)	((str)?(str):"")
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #ifndef MAXPATHLEN
 # ifdef PATH_MAX
 #  define MAXPATHLEN PATH_MAX


### PR DESCRIPTION
See http://www.gnu.org/software/hurd/hurd/porting/guidelines.html#PATH_MAX_tt_MAX_PATH_tt_MAXPATHL
