### PR TITLE
Replace invalid code with a proper #error

### DIFF
--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -267,8 +267,7 @@ BEGIN_EXTERN_C()
 
 #if defined(IEEE_LITTLE_ENDIAN) + defined(IEEE_BIG_ENDIAN) + defined(VAX) + \
 		    defined(IBM) != 1
-	Exactly one of IEEE_LITTLE_ENDIAN IEEE_BIG_ENDIAN, VAX, or
-	IBM should be defined.
+#error "Exactly one of IEEE_LITTLE_ENDIAN IEEE_BIG_ENDIAN, VAX, or IBM should be defined."
 #endif
 
 	typedef union {


### PR DESCRIPTION
This code creates a nasty error as mentioned in bugs #31131, #37062
Patch taken from Debian's PHP package: 044-strtod_arm_fix
