### PR TITLE
Fix segfault when built with OpenSSL >= 1.0.1

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -4974,9 +4974,6 @@ SSL *php_SSL_new_from_context(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{
 
 	GET_VER_OPT_STRING("local_cert", certfile);
 	if (certfile) {
-		X509 *cert = NULL;
-		EVP_PKEY *key = NULL;
-		SSL *tmpssl;
 		char resolved_path_buff[MAXPATHLEN];
 		const char * private_key = NULL;
 
@@ -5003,7 +5000,11 @@ SSL *php_SSL_new_from_context(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{
 				}		
 			}
 
-			tmpssl = SSL_new(ctx);
+#if OPENSSL_VERSION_NUMBER < 0x10001001L
+			/* Unnecessary as of OpenSSLv1.0.1 (will segfault if used with >= 10001001 ) */
+			X509 *cert = NULL;
+			EVP_PKEY *key = NULL;
+			SSL *tmpssl = SSL_new(ctx);
 			cert = SSL_get_certificate(tmpssl);
 
 			if (cert) {
@@ -5012,7 +5013,7 @@ SSL *php_SSL_new_from_context(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{
 				EVP_PKEY_free(key);
 			}
 			SSL_free(tmpssl);
-
+#endif
 			if (!SSL_CTX_check_private_key(ctx)) {
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Private key does not match certificate!");
 			}


### PR DESCRIPTION
This commit fixes segfaults encountered when using `ext/openssl` built against OpenSSL >= 1.0.1. This newer version of OpenSSL is required for TLSv1.1 and TLSv1.2 support.

Note that this patch has no BC implications and should be safe to merge with 5.4 and 5.5 branches.
