### PR TITLE
Fixed assumption that the temporary directory is located in /tmp

### DIFF
--- a/sapi/cli/tests/upload_2G.phpt
+++ b/sapi/cli/tests/upload_2G.phpt
@@ -89,7 +89,7 @@ array(1) {
     ["type"]=>
     string(10) "text/plain"
     ["tmp_name"]=>
-    string(14) "/tmp/php%s"
+    string(%d) "%s"
     ["error"]=>
     int(0)
     ["size"]=>


### PR DESCRIPTION
This is an issue for my system (I like all passing tests, don't you?)
