### PR TITLE
fix set_magic_quotes_runtime inconsistency with documentation

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4631,8 +4631,9 @@ PHP_FUNCTION(set_magic_quotes_runtime)
 	}
 	
 	if (new_setting) {
-		php_error_docref(NULL TSRMLS_CC, E_CORE_ERROR, "magic_quotes_runtime is not supported anymore");
-	}
+		php_error_docref(NULL TSRMLS_CC, E_CORE_ERROR, "magic quotes are not supported anymore");
+	} else php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "magic quotes are not supported anymore");
+	
 	RETURN_FALSE;
 }
 /* }}} */


### PR DESCRIPTION
http://www.php.net/manual/en/function.set-magic-quotes-runtime.php

This function should emit an E_DEPRECATED warning when disabling magic quotes, and E_CORE_ERROR on enabling ...

The documentation will be updated to reflect that is has not been removed, as this is misleading.
