### PR TITLE
Honor cipher order

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5162,7 +5162,7 @@ SSL *php_SSL_new_from_context(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to set cipher list `%s'", cipherlist);
 		return NULL;
 	}
-	if (GET_VER_OPT("honor_server_ciphers")) {
+	if (GET_VER_OPT("honor_cipher_order")) {
 		SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
 	}
 


### PR DESCRIPTION
#### Mitigating the BEAST TLS Vulnerability

The [BEAST](http://contextis.com/research/blog/server-technologies-https-beast-attack/) TLS attack vector was [first publicized in 2011](http://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack). Mitigating this attack is relatively simple: servers have only to [prioritize ciphers](https://community.qualys.com/blogs/securitylabs/2011/10/17/mitigating-the-beast-attack-on-tls) that aren't susceptible to the attack. However, unless instructed otherwise, OpenSSL uses the client's preferences when negotiating the cipher. To prevent nefarious (or naive) clients from prioritizing susceptible ciphers servers must configure SSL sessions using OpenSSL's `SSL_OP_CIPHER_SERVER_PREFERENCE` context option.
##### Proposed Solution

This patch adds a new boolean ssl context option, `"honor_cipher_order"`, to mitigate BEAST vulnerabilities in encrypted stream servers.
##### Suggested Usage

``` php
<?php
$bindTo = 'tls://127.0.0.1:12345';
$flags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
$ctx = stream_context_create(['ssl' => [
    'local_cert' => '/path/to/cert.pem',
    'ciphers' => '<place your ordered cipher list here>',
    'honor_cipher_order' => TRUE
]]);
$server = stream_socket_server($bindTo, $errNo, $errStr, $flags, $ctx);
```
##### How Problematic Is This Really?

> The 2011 BEAST attack8 targets a 2004 vulnerability in TLS 1.0 and earlier protocol versions, previously thought to be impractical to exploit. For a period of time, server-side mitigation of the BEAST attack was considered appropriate, even though the weakness is on the client side. Unfortunately, to mitigate server-side requires RC4, which we now recommend to disable. Because of that, and because the BEAST attack is by now largely mitigated client-side, we no longer recommend server-side mitigation.
> 
> The impact of a successful BEAST attack is similar to that of session hijacking.

-- [SSL Labs Best Practices Report](https://www.ssllabs.com/downloads/SSL_TLS_Deployment_Best_Practices_1.3.pdf) (September 2013)
##### Other Considerations

It's not really possible to include tests for this functionality without adding new functions to retrieve the negotiated cipher from an encrypted socket stream. I don't generally feel like creating functions solely for use in testing things is a good idea, so there are no .phpt tests included. I may PR a new function to get meta information about the SSL session in the future, though. In such a case I'll go ahead and add tests for this scenario.
