### PR TITLE
Fix for bug #65911

### DIFF
--- a/Zend/tests/bug65911.phpt
+++ b/Zend/tests/bug65911.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #65911 (scope resolution operator - strange behavior with $this)
+--FILE--
+<?php
+class A {}
+
+class B
+{
+	public function go()
+	{
+		$this->foo = 'bar';
+		echo A::$this->foo; // should not output 'bar'
+	}
+}
+
+$obj = new B();
+$obj->go();
+?>
+--EXPECTF--
+Fatal error: Access to undeclared static property: A::$this in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -901,6 +901,7 @@ static zend_bool opline_is_fetch_this(const zend_op *opline TSRMLS_DC) /* {{{ */
 {
 	if ((opline->opcode == ZEND_FETCH_W) && (opline->op1_type == IS_CONST)
 		&& (Z_TYPE(CONSTANT(opline->op1.constant)) == IS_STRING)
+		&& ((opline->extended_value & ZEND_FETCH_STATIC_MEMBER) != ZEND_FETCH_STATIC_MEMBER)
 		&& (Z_HASH_P(&CONSTANT(opline->op1.constant)) == THIS_HASHVAL)
 		&& (Z_STRLEN(CONSTANT(opline->op1.constant)) == (sizeof("this")-1))
 		&& !memcmp(Z_STRVAL(CONSTANT(opline->op1.constant)), "this", sizeof("this"))) {


### PR DESCRIPTION
In context of static accesses like `classname::$this`, the string `$this` should not be handled like a `$this` variable, but as an identifier for a static variable.

See https://bugs.php.net/bug.php?id=65911
