### PR TITLE
CLI: Error handling changes for the option parser

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1267,7 +1267,7 @@ int main(int argc, char *argv[])
 	setmode(_fileno(stderr), O_BINARY);		/* make the stdio mode be binary */
 #endif
 
-	while ((c = php_getopt(argc, argv, OPTIONS, &php_optarg, &php_optind, 0, 2))!=-1) {
+	while ((c = php_getopt(argc, argv, OPTIONS, &php_optarg, &php_optind, 1, 2))!=-1) {
 		switch (c) {
 			case 'c':
 				if (ini_path_override) {
@@ -1315,8 +1315,10 @@ int main(int argc, char *argv[])
 				cli_server_sapi_module.additional_functions = server_additional_functions;
 				break;
 #endif
-			case 'h': /* help & quit */
 			case '?':
+				exit_status = 1;
+				/* fall-thru intentional */
+			case 'h': /* help & quit */
 				php_cli_usage(argv[0]);
 				goto out;
 			case 'i': case 'v': case 'm':


### PR DESCRIPTION
Currently, if you start `php-cli` with invalid options, the usage is shown; two things could be done better:
1. An error to be shown when an invalid option is used or in case of missing arguments
2. The process exit status should be non-zero to indicate an error

The latter in particular makes it easier to spot with `set -e`.
