### PR TITLE
add security.level for php-fpm #65935

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -149,7 +149,7 @@ static struct ini_value_parser_s ini_fpm_pool_options[] = {
 	{ "chdir",                     &fpm_conf_set_string,      WPO(chdir) },
 	{ "catch_workers_output",      &fpm_conf_set_boolean,     WPO(catch_workers_output) },
 	{ "security.limit_extensions", &fpm_conf_set_string,      WPO(security_limit_extensions) },
-	{ "security.limit_guid",       &fpm_conf_set_boolean,     WPO(security_limit_guid) },
+	{ "security.level",            &fpm_conf_set_integer,     WPO(security_level) },
 	{ 0, 0, 0 }
 };
 
@@ -919,8 +919,8 @@ static int fpm_conf_process_all_pools() /* {{{ */
 			fpm_evaluate_full_path(&wp->config->slowlog, wp, NULL, 0);
 		}
 		
-		if (wp->config->security_limit_guid) {
-		    wp->limit_guid = wp->config->security_limit_guid;
+		if (wp->config->security_level) {
+		    wp->security_level = wp->config->security_level;
 		}
 
 		/* request_slowlog_timeout */
@@ -1606,7 +1606,7 @@ static void fpm_conf_dump() /* {{{ */
 		zlog(ZLOG_NOTICE, "\tchdir = %s",                      STR2STR(wp->config->chdir));
 		zlog(ZLOG_NOTICE, "\tcatch_workers_output = %s",       BOOL2STR(wp->config->catch_workers_output));
 		zlog(ZLOG_NOTICE, "\tsecurity.limit_extensions = %s",  wp->config->security_limit_extensions);
-		zlog(ZLOG_NOTICE, "\tsecurity.limit_guid = %s",        BOOL2STR(wp->config->security_limit_guid));
+		zlog(ZLOG_NOTICE, "\tsecurity.level = %d",             wp->config->security_level);
 
 		for (kv = wp->config->env; kv; kv = kv->next) {
 			zlog(ZLOG_NOTICE, "\tenv[%s] = %s", kv->key, kv->value);

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -84,7 +84,7 @@ struct fpm_worker_pool_config_s {
 	char *chdir;
 	int catch_workers_output;
 	char *security_limit_extensions;
-	int security_limit_guid;
+	int security_level;
 	struct key_value_s *env;
 	struct key_value_s *php_admin_values;
 	struct key_value_s *php_values;

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1909,8 +1909,8 @@ consult the installation file that came with this distribution, or visit \n\
 				goto fastcgi_request_done;
 			}
 
-			/* limit based on pool guid settings */
-			if (fpm_php_limit_guid(SG(request_info).path_translated, gid, uid TSRMLS_CC)) {
+			/* apply security settings */
+			if (fpm_php_security_apply(SG(request_info).path_translated, gid, uid TSRMLS_CC)) {
 				SG(sapi_headers).http_response_code = 403;
 				PUTS("Access denied.\n");
 				goto fastcgi_request_done;

--- a/sapi/fpm/fpm/fpm_php.h
+++ b/sapi/fpm/fpm/fpm_php.h
@@ -44,7 +44,7 @@ void fpm_php_soft_quit();
 int fpm_php_init_main();
 int fpm_php_apply_defines_ex(struct key_value_s *kv, int mode);
 int fpm_php_limit_extensions(char *path);
-int fpm_php_limit_guid(char *path, gid_t gid, uid_t uid TSRMLS_DC);
+int fpm_php_security_apply(char *path, gid_t gid, uid_t uid TSRMLS_DC);
 char* fpm_php_get_string_from_table(char *table, char *key TSRMLS_DC);
 
 #endif

--- a/sapi/fpm/fpm/fpm_worker_pool.h
+++ b/sapi/fpm/fpm/fpm_worker_pool.h
@@ -38,7 +38,7 @@ struct fpm_worker_pool_s {
 	struct fpm_scoreboard_s *scoreboard;
 	int log_fd;
 	char **limit_extensions;
-	int limit_guid;
+	int security_level;
 
 	/* for ondemand PM */
 	struct fpm_event_s *ondemand_event;

--- a/sapi/fpm/php-fpm.conf.in
+++ b/sapi/fpm/php-fpm.conf.in
@@ -483,11 +483,24 @@ pm.max_spare_servers = 3
 ; Default Value: .php
 ;security.limit_extensions = .php .php3 .php4 .php5
 
-; Forces FPM to verify *exact* file permissions before serving any script
-; The gid and uid of the requested script must match *exactly*
-; those of the current pool
-; Default Value: no
-security.limit_guid = no
+; Set the security level for FPM
+; Security level is on the scale of 0-8, where 0 means no security checks are performed
+; Setting the number to, for example 5, means level 5 and below security requirements are 
+; enforced for each request
+;
+; Default Value: 0
+; Values:
+;   1: do not allow any script to execute as root user
+;   2: do not allow any script to execute as root group
+;   3: do not allow access to paths with backreferences ".."
+;   4: do not allow access to anything not a regular file
+;   5: do not allow access to executable files
+;   6: do not allow access to paths that are readable or writable by any other group
+;   7: do not allow access to paths that are writable by the current user or group
+;   8: do not allow access to paths where the group and user do not match the current group and user *exactly*
+;
+; At level 8, only files owned by the current user and group, with permissions 400 may be executed.
+security.level = 8
  
 ; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
 ; the current environment.


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=65935

It went something like this:

  Someone asked for suexec like functionality, a gid/uid check, which I implemented.
  Some other people said can we do more.
  Remi pointed out that suexec is much more

http://httpd.apache.org/docs/2.2/suexec.html

  suexec is loads, and restrictive, all the time.

So for php-fpm _only_ I implemented a security level to give a bit of power to the user in configuring their security.

Lastly ... SECURE ALL THE THINGS !!!
