### PR TITLE
Fix #66021 (Blank line inside empty JSON array/object)

### DIFF
--- a/ext/json/tests/bug66021.phpt
+++ b/ext/json/tests/bug66021.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #66021 (Blank line inside empty array/object when JSON_PRETTY_PRINT is set)
+--SKIPIF--
+<?php if (!extension_loaded("json")) print "skip"; ?>
+--FILE--
+<?php
+
+class Foo {
+	private $bar = 'baz';
+}
+
+echo json_encode([[], (object)[], new Foo], JSON_PRETTY_PRINT), "\n";
+
+?>
+--EXPECT--
+[
+    [],
+    {},
+    {}
+]


### PR DESCRIPTION
Changed json_encode() so that when the JSON_PRETTY_PRINT option is specified, the pair of linefeeds immediately after an opening bracket and before the corresponding closing bracket is omitted when the array or object contains no elements or accessible properties (and hence would have a blank line between the brackets).
