### PR TITLE
Fixed tests that fail with non-default `serialize_precision` configurations.

### DIFF
--- a/ext/standard/tests/general_functions/var_export-locale.phpt
+++ b/ext/standard/tests/general_functions/var_export-locale.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test var_export() function with locale
 --INI--
-precision=14
+serialize_precision=17
 --SKIPIF--
 <?php
 if (!setlocale(LC_ALL, "german", "de","de_DE","de_DE.ISO8859-1","de_DE.ISO_8859-1","de_DE.UTF-8")) {

--- a/ext/standard/tests/general_functions/var_export_basic3.phpt
+++ b/ext/standard/tests/general_functions/var_export_basic3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test var_export() function with valid float values
 --INI--
-precision=14
+serialize_precision=17
 --FILE--
 <?php
 /* Prototype  : mixed var_export(mixed var [, bool return])

--- a/ext/standard/tests/general_functions/var_export_basic5.phpt
+++ b/ext/standard/tests/general_functions/var_export_basic5.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test var_export() function with valid arrays
+--INI--
+serialize_precision=17
 --FILE--
 <?php
 /* Prototype  : mixed var_export(mixed var [, bool return])

--- a/tests/lang/bug24640.phpt
+++ b/tests/lang/bug24640.phpt
@@ -2,6 +2,7 @@
 Bug #24640 (var_export and var_dump can't output large float)
 --INI--
 precision=12
+serialize_precision=17
 --FILE--
 <?php
 function test($v)


### PR DESCRIPTION
See:
- https://bugs.php.net/bug.php?id=64760
- 4dc4302
