### PR TITLE
Fixed case part of bug #64874 ("json_decode handles whitespace and case-sensitivity incorrectly")

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,10 @@ PHP                                                                        NEWS
 - Hash:
   . Added gost-crypto (CryptoPro S-box) GOST hash algo. (Manuel Mausz)
 
+- JSON:
+  . Fixed case part of bug #64874 ("json_decode handles whitespace and
+    case-sensitivity incorrectly")
+
 - mysqlnd:
   . Disabled flag for SP OUT variables for 5.5+ servers as they are not natively
     supported by the overlying APIs. (Andrey)

--- a/UPGRADING
+++ b/UPGRADING
@@ -30,6 +30,14 @@ PHP X.Y UPGRADE NOTES
   }
   ?>
 
+- JSON:
+  json_decode() no longer accepts non-lowercase variants of lone JSON true,
+  false or null values. For example, True or FALSE will now cause json_decode to
+  return NULL and set an error value you can fetch with json_last_error().
+  This affects JSON texts consisting solely of true, false or null. Text
+  containing non-lowercase values inside JSON arrays or objects has never been
+  accepted.
+
 ========================================
 2. New Features
 ========================================

--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -712,14 +712,14 @@ PHP_JSON_API void php_json_decode_ex(zval *return_value, char *str, int str_len,
 
 		RETVAL_NULL();
 		if (trim_len == 4) {
-			if (!strncasecmp(trim, "null", trim_len)) {
+			if (!strncmp(trim, "null", trim_len)) {
 				/* We need to explicitly clear the error because its an actual NULL and not an error */
 				jp->error_code = PHP_JSON_ERROR_NONE;
 				RETVAL_NULL();
-			} else if (!strncasecmp(trim, "true", trim_len)) {
+			} else if (!strncmp(trim, "true", trim_len)) {
 				RETVAL_BOOL(1);
 			}
-		} else if (trim_len == 5 && !strncasecmp(trim, "false", trim_len)) {
+		} else if (trim_len == 5 && !strncmp(trim, "false", trim_len)) {
 			RETVAL_BOOL(0);
 		}
 

--- a/ext/json/tests/bug64874_part2.phpt
+++ b/ext/json/tests/bug64874_part2.phpt
@@ -1,0 +1,69 @@
+--TEST--
+Case-sensitivity part of bug #64874 ("json_decode handles whitespace and case-sensitivity incorrectly")
+--SKIPIF--
+<?php if (!extension_loaded("json")) print "skip"; ?>
+--FILE--
+<?php
+function decode($json) {
+    var_dump(json_decode($json));
+    echo ((json_last_error() !== 0) ? 'ERROR' : 'SUCCESS') . PHP_EOL;
+}
+
+// Only lowercase should work
+decode('true');
+decode('True');
+decode('[true]');
+decode('[True]');
+echo PHP_EOL;
+
+decode('false');
+decode('False');
+decode('[false]');
+decode('[False]');
+echo PHP_EOL;
+
+decode('null');
+decode('Null');
+decode('[null]');
+decode('[Null]');
+echo PHP_EOL;
+
+echo "Done\n";
+--EXPECT--
+bool(true)
+SUCCESS
+NULL
+ERROR
+array(1) {
+  [0]=>
+  bool(true)
+}
+SUCCESS
+NULL
+ERROR
+
+bool(false)
+SUCCESS
+NULL
+ERROR
+array(1) {
+  [0]=>
+  bool(false)
+}
+SUCCESS
+NULL
+ERROR
+
+NULL
+SUCCESS
+NULL
+ERROR
+array(1) {
+  [0]=>
+  NULL
+}
+SUCCESS
+NULL
+ERROR
+
+Done


### PR DESCRIPTION
This request fixes the JSON parser's handling of top-level true/false/null. By that I mean a lone true/false/null value, not one inside an array of object. Hence, `json_decode("True");` (currently valid) is affected but `json_decode("[True]");` (currently invalid) is not.

At present, there is a bug where non-lowercase forms (e.g. `True` or `tRUE`) of these top-level values are accepted by the parser without erroring. This behaviour is not compliant with the JSON.org standard, nor the IETF RFC, nor the ECMA standard. It is also inconsistent with other JSON implementations. Were I to try `JSON.parse('True');` in JavaScript or `json.loads('true')` in Python, I would be met with an error. The function is even inconsistent with itself in this respect, as `[True]` will fail but `True` will not. I suspect that this behaviour was not intended and simply came about because of someone failing to read the specification and assuming case-insensitivity.

Hence I propose this patch. It replaces `strcasecmp` with `strcmp` where the former was used incorrectly. It is a minor backwards-compatibility break, so I am targeting this at 5.6. However I believe that it is very unlikely that any code relied on this bug, since all JSON serialisers output lowercase literals, and any hand-written JSON is likely not a lone true, false or null value.

In the event that code relied on this bug, they could simply do something like this:

``` php
function json_decode_bad($json) {
    $json = trim($json, ' \t\n\r');
    $values = ['true' => true, 'false' => false, 'null' => null];
    foreach ($values as $key => $value) {
        if (strcasecmp($key, $json) === 0) {
            return $value;
        }
    }
    return json_decode($json);
}
```

So, I ask that this is merged, as a tiny backwards-compatibility break but bringing PHP into harmony with other JSON implementations and the specification.

**EDIT:** I should note that this is a literal 3-line change, replacing `strcasecmp` for `strcmp` on three different lines.

**EDIT 2:** dsp asked me where in the JSON standard it says that it must be lowercase. It's in [RFC 4627](http://tools.ietf.org/html/rfc4627), page 2:

> The literal names MUST be lowercase.  No other literal names are allowed.
