### PR TITLE
parse_url is inconsistent with specified port (#64604)

### DIFF
--- a/ext/standard/tests/url/bug64604.phpt
+++ b/ext/standard/tests/url/bug64604.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Bug #64604 parse_url is inconsistent with specified port
+--FILE--
+<?php
+var_dump(parse_url('//localhost/path'));
+var_dump(parse_url('//localhost:80/path'));
+var_dump(parse_url('//localhost:/path'));
+var_dump(parse_url('http://localhost:80/path'));
+?>
+--EXPECT--
+array(2) {
+  ["host"]=>
+  string(9) "localhost"
+  ["path"]=>
+  string(5) "/path"
+}
+array(3) {
+  ["host"]=>
+  string(9) "localhost"
+  ["port"]=>
+  int(80)
+  ["path"]=>
+  string(5) "/path"
+}
+array(2) {
+  ["host"]=>
+  string(9) "localhost"
+  ["path"]=>
+  string(5) "/path"
+}
+array(4) {
+  ["scheme"]=>
+  string(4) "http"
+  ["host"]=>
+  string(9) "localhost"
+  ["port"]=>
+  int(80)
+  ["path"]=>
+  string(5) "/path"
+}

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -181,6 +181,10 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 		p = e + 1;
 		pp = p;
 
+		if (*s == '/' && *(s+1) == '/') { /* relative-scheme URL */
+			s += 2;
+		}
+
 		while (pp-p < 6 && isdigit(*pp)) {
 			pp++;
 		}
@@ -201,10 +205,6 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 			STR_FREE(ret->scheme);
 			efree(ret);
 			return NULL;
-		} else if (*s == '/' && *(s+1) == '/') { /* relative-scheme URL */
-			s += 2;
-		} else {
-			goto just_path;
 		}
 	} else if (*s == '/' && *(s+1) == '/') { /* relative-scheme URL */
 		s += 2;


### PR DESCRIPTION
This is a basic fix for https://bugs.php.net/bug.php?id=64604
As discussed with @yohgaki in #509 a separate ticket will be opened for the TLD issue (see comments in the ticket) to identify the hostname and I'm going to ask in the internals mailinglist soon for opinions about possible solutions.
