### PR TITLE
ext/exif/config.w32: mbstring is an optional dependency

### DIFF
--- a/ext/exif/config.w32
+++ b/ext/exif/config.w32
@@ -4,7 +4,7 @@
 ARG_ENABLE("exif", "exif", "no");
 
 if (PHP_EXIF == "yes") {
-	if (ADD_EXTENSION_DEP('exif', 'mbstring')) {
+	if (ADD_EXTENSION_DEP('exif', 'mbstring', true)) {
 		EXTENSION("exif", "exif.c");
 		AC_DEFINE('HAVE_EXIF', 1, 'Have exif');
 	} else {


### PR DESCRIPTION
It's optional in the zend_module_dep but the optional flag wasn't set in
config.w32, so configure.bat gave a fatal error if --enable-mbstring
wasn't used.
