### PR TITLE
Fix bug #54379 PDO_OCI: UTF-8 output gets truncated

### DIFF
--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -694,6 +694,13 @@ static int pdo_oci_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_DC
 		goto cleanup;
 	}
 
+	/* Get max character width */
+	H->last_err = OCINlsNumericInfoGet(H->env, H->err, &H->max_char_width, OCI_NLS_CHARSET_MAXBYTESZ);
+	if (H->last_err) {
+		oci_drv_error("OCINlsNumericInfoGet: OCI_NLS_CHARSET_MAXBYTESZ");
+		goto cleanup;
+	}
+
 	dbh->methods = &oci_methods;
 	dbh->alloc_own_columns = 1;
 	dbh->native_case = PDO_CASE_UPPER;

--- a/ext/pdo_oci/oci_statement.c
+++ b/ext/pdo_oci/oci_statement.c
@@ -582,11 +582,12 @@ static int oci_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC) /* {{{ */
 			} else {
 				S->cols[colno].datalen = col->maxlen;
 			}
-			if (dtype == SQLT_BIN) {
-				S->cols[colno].datalen *= 3;
+			dtype = SQLT_CHR;
+			if (dtype == SQLT_CHR) {
+				S->cols[colno].datalen *= S->H->max_char_width;
 			}
 			S->cols[colno].data = emalloc(S->cols[colno].datalen + 1);
-			dtype = SQLT_CHR;
+
 
 			/* returning data as a string */
 			col->param_type = PDO_PARAM_STR;

--- a/ext/pdo_oci/php_pdo_oci_int.h
+++ b/ext/pdo_oci/php_pdo_oci_int.h
@@ -37,6 +37,7 @@ typedef struct {
 	/* OCI9; 0 == use NLS_LANG */
 	ub2			charset;
 	sword		last_err;
+	sb4		max_char_width;
 
 	unsigned	attached:1;
 	unsigned	_reserved:31;

--- a/ext/pdo_oci/tests/bug54379.phpt
+++ b/ext/pdo_oci/tests/bug54379.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Bug #54379 (PDO_OCI: UTF-8 output gets truncated)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_oci')) 
+die('skip not loaded');
+require dirname(__FILE__).'/../../pdo/tests/pdo_test.inc';
+if (!preg_match('/charset=.*utf8/i', getenv('PDOTEST_DSN')))
+die('skip not UTF8 DSN');
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require 'ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+try {
+        $db->exec("DROP TABLE test");
+} catch (Exception $e) {
+}
+
+$db->exec("CREATE TABLE test (col1 NVARCHAR2(100))");
+$db->exec("INSERT INTO test VALUES('12345678901234567890')");
+$db->exec("INSERT INTO test VALUES('Русские символы по три байта')");
+
+$stmt = $db->prepare("SELECT * FROM test");
+
+$stmt->execute();
+var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
+
+$db->exec("DROP TABLE test");
+
+?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  array(1) {
+    ["col1"]=>
+    string(20) "12345678901234567890"
+  }
+  [1]=>
+  array(1) {
+    ["col1"]=>
+    string(52) "Русские символы по три байта"
+  }
+}


### PR DESCRIPTION
Oracle docs defines three versions of utf8 encoding.
- AL32UTF8 and UTFE character can occupy up to 4 bytes.
- UTF8 character can occupy up to 6 bytes.
  Details here: http://docs.oracle.com/cd/B19306_01/server.102/b14225/ch6unicode.htm#i1006998 
  We can obtain maximum character size in bytes by calling OCINlsNumericInfoGet() and get current max character width. 
  Details here: http://docs.oracle.com/cd/B10501_01/server.920/a96529/ch8.htm#14288
