### PR TITLE
Issue 66085 - discussion

### DIFF
--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -161,6 +161,11 @@ typedef signed long php_int32;
 
 #define MT_N (624)
 
+typedef struct _zval_chain {
+    zval* value;
+    struct _zval_chain* next;
+} zval_chain;
+
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 	HashTable putenv_ht;
@@ -208,6 +213,7 @@ typedef struct _php_basic_globals {
 	struct {
 		void *var_hash;
 		unsigned level;
+		zval_chain* zval_refs;
 	} serialize;
 	struct {
 		void *var_hash;

--- a/ext/standard/php_var.h
+++ b/ext/standard/php_var.h
@@ -51,6 +51,7 @@ typedef struct php_unserialize_data* php_unserialize_data_t;
 
 PHPAPI void php_var_serialize(smart_str *buf, zval **struc, php_serialize_data_t *var_hash TSRMLS_DC);
 PHPAPI int php_var_unserialize(zval **rval, const unsigned char **p, const unsigned char *max, php_unserialize_data_t *var_hash TSRMLS_DC);
+void php_var_serialize_release_zval_chain(zval_chain* zval_refs);
 
 #define PHP_VAR_SERIALIZE_INIT(var_hash_ptr) \
 do  { \
@@ -61,6 +62,7 @@ do  { \
 		if (!BG(serialize_lock)) { \
 			BG(serialize).var_hash = (void *)(var_hash_ptr); \
 			BG(serialize).level = 1; \
+			BG(serialize).zval_refs = NULL; \
 		} \
 	} else { \
 		(var_hash_ptr) = (php_serialize_data_t)BG(serialize).var_hash; \
@@ -79,6 +81,7 @@ do { \
 			zend_hash_destroy((php_serialize_data_t)BG(serialize).var_hash); \
 			FREE_HASHTABLE((php_serialize_data_t)BG(serialize).var_hash); \
 			BG(serialize).var_hash = NULL; \
+			php_var_serialize_release_zval_chain(BG(serialize).zval_refs); \
 		} \
 	} \
 } while (0)

--- a/ext/standard/tests/serialize/serialization_reentrant.phpt
+++ b/ext/standard/tests/serialize/serialization_reentrant.phpt
@@ -1,0 +1,91 @@
+--TEST--
+--FILE--
+<?php
+class test implements Serializable {
+    public $a;
+
+    public function __construct( $_val ){
+        $this->a = $_val;
+    }
+
+    public function serialize() {
+        $tmp = (object) array();
+        $tmp->a = $this->a;
+        echo serialize( $tmp ) . "\n";
+        return serialize( $tmp );
+    }
+
+    public function unserialize($var) {}
+}
+
+$n = array();
+$n[] = new test("temp1");
+$n[] = new test("temp2");
+$n[] = new test("temp3");
+$n[] = new test("temp4");
+$n[] = new test("temp5");
+$n[] = new test("temp6");
+$n[] = new test("temp7");
+$n[] = new test("temp8");
+$n[] = new test("temp9");
+print_r( unserialize( serialize( $n ) ) );
+?>
+--EXPECTF--
+O:8:"stdClass":1:{s:1:"a";s:5:"temp1";}
+O:8:"stdClass":1:{s:1:"a";s:5:"temp2";}
+O:8:"stdClass":1:{s:1:"a";s:5:"temp3";}
+O:8:"stdClass":1:{s:1:"a";s:5:"temp4";}
+O:8:"stdClass":1:{s:1:"a";s:5:"temp5";}
+O:8:"stdClass":1:{s:1:"a";s:5:"temp6";}
+O:8:"stdClass":1:{s:1:"a";s:5:"temp7";}
+O:8:"stdClass":1:{s:1:"a";s:5:"temp8";}
+O:8:"stdClass":1:{s:1:"a";s:5:"temp9";}
+Array
+(
+    [0] => test Object
+        (
+            [a] => 
+        )
+
+    [1] => test Object
+        (
+            [a] => 
+        )
+
+    [2] => test Object
+        (
+            [a] => 
+        )
+
+    [3] => test Object
+        (
+            [a] => 
+        )
+
+    [4] => test Object
+        (
+            [a] => 
+        )
+
+    [5] => test Object
+        (
+            [a] => 
+        )
+
+    [6] => test Object
+        (
+            [a] => 
+        )
+
+    [7] => test Object
+        (
+            [a] => 
+        )
+
+    [8] => test Object
+        (
+            [a] => 
+        )
+
+)
+


### PR DESCRIPTION
Submitting pull request for discussion only (i.e. please don't merge this ;), see: https://bugs.php.net/bug.php?id=66085

When invoking a custom serializer which itself uses serialize, serialized temporary objects are unreferenced and garbage collected.  Their handles and zval memory locations can be reused which results in defeating the reference linking capability of serialize (the collected objects are viewed as having been visited and are candidates for reference linking).

I don't see any great solutions but here are a few:
1. Just don't support re-entrant serialize with reference linking.   Create a new serialization context for every serialize entrance.
2. It turns out (from what I can tell) zvals do not have unique ids over time.  Handles are just slots which are reused and memory locations are also reused exactly, so these conspire against being able to distinguish a previous dead object from a live object occupying the same memory location.  A solution could be to introduce a monotonic counter which is set on every zval produced in order to produce completely unique ids for the lifetime of the php process.  This presumably would entail modifying zval or other core structure so could affect (albiet innocuously) a large surface area.  With truly unique ids, a live zval could never be confused with a previous live or dead zval.
3. Forcibly prevent collection of zvals implicated in an object graph undergoing serialization.  This can be done by incrementing a reference count, and storing a list of visited zvals so their unreference/collection can be deferred until the end of the top level serialize call.

The last option is what this patch implements.

I do not vouch for this implementation - in specific, I found I needed to `Z_ADDREF_P` when capturing zvals but `zval_ptr_dtor` for cleanup, otherwise I would be warned about leaked objects.  I'm not clear why this would be, or if I'm not just lucky here.  Working around the GC in this way is at best a hack and at worst possibly really stupid, so I'm just curious for my own sake whether my understanding of the issues here are correct.

For what it is worth, I also investigated msgpack-php implementation, and it appears their impl shares (or is heavily inspired) by the PHP serialize impl (or vice versa), and I wouldn't be surprised if they run into the same issue.
