### PR TITLE
Add ZEND_ARG_CALLABLE_INFO to allow internal function to type hint against callable.

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -101,6 +101,7 @@ typedef struct _zend_fcall_info_cache {
 #define ZEND_ARG_INFO(pass_by_ref, name)							{ #name, sizeof(#name)-1, NULL, 0, 0, 0, pass_by_ref},
 #define ZEND_ARG_PASS_INFO(pass_by_ref)								{ NULL, 0, NULL, 0, 0, 0, pass_by_ref},
 #define ZEND_ARG_OBJ_INFO(pass_by_ref, name, classname, allow_null) { #name, sizeof(#name)-1, #classname, sizeof(#classname)-1, IS_OBJECT, allow_null, pass_by_ref},
+#define ZEND_ARG_CALLABLE_INFO(pass_by_ref, name, allow_null)       { #name, sizeof(#name)-1, NULL, 0, IS_CALLABLE, allow_null, pass_by_ref },
 #define ZEND_ARG_ARRAY_INFO(pass_by_ref, name, allow_null) { #name, sizeof(#name)-1, NULL, 0, IS_ARRAY, allow_null, pass_by_ref},
 #define ZEND_ARG_TYPE_INFO(pass_by_ref, name, type_hint, allow_null) { #name, sizeof(#name)-1, NULL, 0, type_hint, allow_null, pass_by_ref},
 #define ZEND_BEGIN_ARG_INFO_EX(name, pass_rest_by_reference, return_reference, required_num_args)	\


### PR DESCRIPTION
For some reason this macro is missing. Confirmed in local testing that it works but can't provide any unit tests since it's not used in PHP core.

Pull request is against 5.4 since that's the version callable was introduced.