### PR TITLE
Don't append newline after X-PHP-Originating-Script

### DIFF
--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -286,7 +286,7 @@ PHPAPI int php_mail(char *to, char *subject, char *message, char *headers, char 
 		if (headers != NULL) {
 			spprintf(&hdr, 0, "X-PHP-Originating-Script: %ld:%s\n%s", php_getuid(TSRMLS_C), f, headers);
 		} else {
-			spprintf(&hdr, 0, "X-PHP-Originating-Script: %ld:%s\n", php_getuid(TSRMLS_C), f);
+			spprintf(&hdr, 0, "X-PHP-Originating-Script: %ld:%s", php_getuid(TSRMLS_C), f);
 		}
 		efree(f);
 	}


### PR DESCRIPTION
This fixes [bug 66535](https://bugs.php.net/bug.php?id=66535).

When the extra headers are empty, no newline should be appended after X-PHP-Originating-Script.

This is also discussed in [this question](http://stackoverflow.com/questions/20832339/php-mail-adds-leading-newline-when-no-additional-headers-present).
