### PR TITLE
#66389 XMLRPC decoding 64bit integers

### DIFF
--- a/ext/xmlrpc/libxmlrpc/xml_to_dandarpc.c
+++ b/ext/xmlrpc/libxmlrpc/xml_to_dandarpc.c
@@ -91,7 +91,7 @@ XMLRPC_VALUE xml_element_to_DANDARPC_REQUEST_worker(XMLRPC_REQUEST request, XMLR
             XMLRPC_SetValueString(xCurrent, el->text.str, el->text.len);
          }
          else if(!strcmp(type, ATTR_INT)) {
-            XMLRPC_SetValueInt(xCurrent, atoi(el->text.str));
+            XMLRPC_SetValueInt(xCurrent, atol(el->text.str));
          }
          else if(!strcmp(type, ATTR_BOOLEAN)) {
             XMLRPC_SetValueBoolean(xCurrent, atoi(el->text.str));
@@ -206,7 +206,7 @@ xml_element* DANDARPC_to_xml_element_worker(XMLRPC_REQUEST request, XMLRPC_VALUE
             break;
          case xmlrpc_int:
             pAttrType = ATTR_INT;
-            snprintf(buf, BUF_SIZE, "%i", XMLRPC_GetValueInt(node));
+            snprintf(buf, BUF_SIZE, "%ld", XMLRPC_GetValueInt(node));
             simplestring_add(&elem_val->text, buf);
             break;
          case xmlrpc_boolean:

--- a/ext/xmlrpc/libxmlrpc/xml_to_soap.c
+++ b/ext/xmlrpc/libxmlrpc/xml_to_soap.c
@@ -346,7 +346,7 @@ XMLRPC_VALUE xml_element_to_SOAP_REQUEST_worker(XMLRPC_REQUEST request,
 				XMLRPC_SetValueString(xCurrent, el->text.str, el->text.len);
 			}
 			else if (!strcmp(type, TOKEN_INT)) {
-				XMLRPC_SetValueInt(xCurrent, atoi(el->text.str));
+				XMLRPC_SetValueInt(xCurrent, atol(el->text.str));
 			}
 			else if (!strcmp(type, TOKEN_BOOLEAN)) {
 				XMLRPC_SetValueBoolean(xCurrent, atoi(el->text.str));
@@ -502,7 +502,7 @@ xml_element* SOAP_to_xml_element_worker(XMLRPC_REQUEST request, XMLRPC_VALUE nod
 			break;
 		case xmlrpc_type_int:
 			pAttrType = TOKEN_INT;
-			snprintf(buf, BUF_SIZE, "%i", XMLRPC_GetValueInt(node));
+			snprintf(buf, BUF_SIZE, "%ld", XMLRPC_GetValueInt(node));
 			simplestring_add(&elem_val->text, buf);
 			break;
 		case xmlrpc_type_boolean:

--- a/ext/xmlrpc/libxmlrpc/xml_to_xmlrpc.c
+++ b/ext/xmlrpc/libxmlrpc/xml_to_xmlrpc.c
@@ -54,6 +54,7 @@ static const char rcsid[] = "#(@) $Id$";
 #define ELEM_FAULTCODE      "faultCode"
 #define ELEM_FAULTSTRING    "faultString"
 #define ELEM_I4             "i4"
+#define ELEM_I8             "i8"
 #define ELEM_INT            "int"
 #define ELEM_MEMBER         "member"
 #define ELEM_METHODCALL     "methodCall"
@@ -125,8 +126,8 @@ XMLRPC_VALUE xml_element_to_XMLRPC_REQUEST_worker(XMLRPC_REQUEST request, XMLRPC
 		else if (!strcmp(el->name, ELEM_NAME)) {
          XMLRPC_SetValueID_Case(current_val, el->text.str, 0, xmlrpc_case_exact);
 		}
-		else if (!strcmp(el->name, ELEM_INT) || !strcmp(el->name, ELEM_I4)) {
-         XMLRPC_SetValueInt(current_val, atoi(el->text.str));
+		else if (!strcmp(el->name, ELEM_INT) || !strcmp(el->name, ELEM_I4) || !strcmp(el->name, ELEM_I8)) {
+         XMLRPC_SetValueInt(current_val, atol(el->text.str));
 		}
 		else if (!strcmp(el->name, ELEM_BOOLEAN)) {
          XMLRPC_SetValueBoolean(current_val, atoi(el->text.str));
@@ -218,7 +219,7 @@ xml_element* XMLRPC_to_xml_element_worker(XMLRPC_VALUE current_vector, XMLRPC_VA
             break;
          case xmlrpc_int:
             elem_val->name = strdup(ELEM_INT);
-            snprintf(buf, BUF_SIZE, "%i", XMLRPC_GetValueInt(node));
+            snprintf(buf, BUF_SIZE, "%ld", XMLRPC_GetValueInt(node));
             simplestring_add(&elem_val->text, buf);
             break;
          case xmlrpc_boolean:

--- a/ext/xmlrpc/libxmlrpc/xmlrpc.c
+++ b/ext/xmlrpc/libxmlrpc/xmlrpc.c
@@ -962,7 +962,7 @@ const char *XMLRPC_SetValueString(XMLRPC_VALUE value, const char* val, int len) 
  * NAME
  *   XMLRPC_SetValueInt
  * SYNOPSIS
- *   void XMLRPC_SetValueInt(XMLRPC_VALUE value, int val)
+ *   void XMLRPC_SetValueInt(XMLRPC_VALUE value, long val)
  * FUNCTION
  *   Assign an int value to an XMLRPC_VALUE, and set it to type xmlrpc_int
  * INPUTS
@@ -975,7 +975,7 @@ const char *XMLRPC_SetValueString(XMLRPC_VALUE value, const char* val, int len) 
  *   XMLRPC_VALUE_TYPE
  * SOURCE
  */
-void XMLRPC_SetValueInt(XMLRPC_VALUE value, int val) {
+void XMLRPC_SetValueInt(XMLRPC_VALUE value, long val) {
    if(value) {
       value->type = xmlrpc_int;
       value->i = val;
@@ -1347,7 +1347,7 @@ XMLRPC_VALUE XMLRPC_CreateValueString(const char* id, const char* val, int len) 
  * NAME
  *   XMLRPC_CreateValueInt
  * SYNOPSIS
- *   XMLRPC_VALUE XMLRPC_CreateValueInt(const char* id, int i)
+ *   XMLRPC_VALUE XMLRPC_CreateValueInt(const char* id, long i)
  * FUNCTION
  *   Create an XMLRPC_VALUE, and assign an int to it
  * INPUTS
@@ -1362,7 +1362,7 @@ XMLRPC_VALUE XMLRPC_CreateValueString(const char* id, const char* val, int len) 
  *   XMLRPC_VALUE_TYPE
  * SOURCE
  */
-XMLRPC_VALUE XMLRPC_CreateValueInt(const char* id, int i) {
+XMLRPC_VALUE XMLRPC_CreateValueInt(const char* id, long i) {
    XMLRPC_VALUE val = XMLRPC_CreateValueEmpty();
    if(val) {
       XMLRPC_SetValueInt(val, i);
@@ -1943,7 +1943,7 @@ int XMLRPC_GetValueStringLen(XMLRPC_VALUE value) {
  * NAME
  *   XMLRPC_GetValueInt
  * SYNOPSIS
- *   int XMLRPC_GetValueInt(XMLRPC_VALUE value)
+ *   long XMLRPC_GetValueInt(XMLRPC_VALUE value)
  * FUNCTION
  *   retrieve integer value.
  * INPUTS
@@ -1957,7 +1957,7 @@ int XMLRPC_GetValueStringLen(XMLRPC_VALUE value) {
  *   XMLRPC_CreateValueInt ()
  * SOURCE
  */
-int XMLRPC_GetValueInt(XMLRPC_VALUE value) {
+long XMLRPC_GetValueInt(XMLRPC_VALUE value) {
     return ((value && value->type == xmlrpc_int) ? value->i : 0);
 }
 

--- a/ext/xmlrpc/libxmlrpc/xmlrpc.h
+++ b/ext/xmlrpc/libxmlrpc/xmlrpc.h
@@ -326,7 +326,7 @@ XMLRPC_VALUE XMLRPC_CreateValueBase64(const char* id, const char* s, int len);
 XMLRPC_VALUE XMLRPC_CreateValueDateTime(const char* id, time_t time);
 XMLRPC_VALUE XMLRPC_CreateValueDateTime_ISO8601(const char* id, const char *s);
 XMLRPC_VALUE XMLRPC_CreateValueDouble(const char* id, double f);
-XMLRPC_VALUE XMLRPC_CreateValueInt(const char* id, int i);
+XMLRPC_VALUE XMLRPC_CreateValueInt(const char* id, long i);
 XMLRPC_VALUE XMLRPC_CreateValueString(const char* id, const char* s, int len);
 XMLRPC_VALUE XMLRPC_CreateValueEmpty(void);
 XMLRPC_VALUE XMLRPC_CreateVector(const char* id, XMLRPC_VECTOR_TYPE type);
@@ -346,7 +346,7 @@ XMLRPC_VALUE XMLRPC_DupValueNew(XMLRPC_VALUE xSource);
 void XMLRPC_SetValueDateTime(XMLRPC_VALUE value, time_t time);
 void XMLRPC_SetValueDateTime_ISO8601(XMLRPC_VALUE value, const char* s);
 void XMLRPC_SetValueDouble(XMLRPC_VALUE value, double val);
-void XMLRPC_SetValueInt(XMLRPC_VALUE value, int val);
+void XMLRPC_SetValueInt(XMLRPC_VALUE value, long val);
 void XMLRPC_SetValueBoolean(XMLRPC_VALUE value, int val);
 const char *XMLRPC_SetValueString(XMLRPC_VALUE value, const char* s, int len);
 void XMLRPC_SetValueBase64(XMLRPC_VALUE value, const char* s, int len);
@@ -356,7 +356,7 @@ const char *XMLRPC_SetValueID_Case(XMLRPC_VALUE value, const char* id, int len, 
 /* Get Values */
 const char* XMLRPC_GetValueString(XMLRPC_VALUE value);
 int XMLRPC_GetValueStringLen(XMLRPC_VALUE value);
-int XMLRPC_GetValueInt(XMLRPC_VALUE value);
+long XMLRPC_GetValueInt(XMLRPC_VALUE value);
 int XMLRPC_GetValueBoolean(XMLRPC_VALUE value);
 double XMLRPC_GetValueDouble(XMLRPC_VALUE value);
 const char* XMLRPC_GetValueBase64(XMLRPC_VALUE value);

--- a/ext/xmlrpc/libxmlrpc/xmlrpc_private.h
+++ b/ext/xmlrpc/libxmlrpc/xmlrpc_private.h
@@ -90,7 +90,7 @@ typedef struct _xmlrpc_value {
    XMLRPC_VECTOR v;        /* vector type specific info                      */
    simplestring str;       /* string value buffer                            */
    simplestring id;        /* id of this value.  possibly empty.             */
-   int i;                  /* integer value.                                 */
+   long i;                 /* integer value.                                 */
    double d;               /* double value                                   */
    int iRefCount;          /* So we know when we can delete the value      . */
 } STRUCT_XMLRPC_VALUE;

--- a/ext/xmlrpc/tests/008.phpt
+++ b/ext/xmlrpc/tests/008.phpt
@@ -1,0 +1,27 @@
+--TEST--
+xmlrpc_decode() Simple test decode type i8
+
+--SKIPIF--
+<?php
+if (!extension_loaded("xmlrpc")) die("skip");
+?>
+
+--FILE--
+<?php
+
+$xml = <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<params>
+<param>
+ <value>
+  <i8>1</i8>
+ </value>
+</param>
+</params>
+XML;
+
+$response = xmlrpc_decode($xml);
+echo $response;
+
+--EXPECT--
+1

--- a/ext/xmlrpc/tests/009.phpt
+++ b/ext/xmlrpc/tests/009.phpt
@@ -1,0 +1,26 @@
+--TEST--
+xmlrpc_decode() 64bit integer decode type i8
+
+--SKIPIF--
+<?php
+if (!extension_loaded("xmlrpc")) die("skip");
+if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
+?>
+
+--FILE--
+<?php
+
+$xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+<params>
+<param><value><i8>8182349955</i8></value></param>
+</params>
+</methodResponse>
+XML;
+
+$response = xmlrpc_decode($xml);
+echo $response;
+
+--EXPECT--
+8182349955

--- a/ext/xmlrpc/tests/010.phpt
+++ b/ext/xmlrpc/tests/010.phpt
@@ -1,0 +1,26 @@
+--TEST--
+xmlrpc_decode() 64bit integer decode type i8
+
+--SKIPIF--
+<?php
+if (!extension_loaded("xmlrpc")) die("skip");
+if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
+?>
+
+--FILE--
+<?php
+
+$xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+<params>
+<param><value><i8>-128182349955</i8></value></param>
+</params>
+</methodResponse>
+XML;
+
+$response = xmlrpc_decode($xml);
+echo $response;
+
+--EXPECT--
+-128182349955


### PR DESCRIPTION
**This is not yet ready to merge.**

As stated in bug [#66389](https://bugs.php.net/bug.php?id=66389), php's included xmlrpc extension fails to properly decode 64bit integers even when compiled on a 64bit system.

This pull request:
- Fixes decoding 64bit integers
- Encodes 64bit integers into an <int> tag.
  - This breaks [bug40576_64bit.phpt](https://github.com/php/php-src/blob/master/ext/xmlrpc/tests/bug40576_64bit.phpt) because it tests for a failure to encode a 64bit integer properly.
  - This breaks the XML-RPC spec which says <int> & <i4> should only contain 32 bit integers. 64bit integers should be encoded with an <i8> tag.

There are 4 possible resolutions before this can be merged. I have ordered them in based on my approval of each solution.
#### Break the spec and put 64bit integers into <int>

**Advantages:** PHP can encode 64bit integers.
**Disadvantages:** Any parser that strictly adheres to the spec may fail to handle <int> exceeding it's specified limits.
#### Output <i8> in place of <int> in all encoding

**Advantages:** PHP can encode 64bit integers.
**Disadvantages:** The output of this extension will change, and parsers that do not support  <int>, <i4> & <i8> properly may break (although such parsers would have been relying on a bug in the first place).
#### Add an opt-in to enable proper 64bit integer handling

**Advantages:** PHP can encode 64bit integers.
**Disadvantages:** Requires people who expect this sensible behavior to know that they need to enable it manually. Many will observe the current buggy behavior and never realize there is a way to opt into the expected behavior.
#### Output <int> for all 32bit integers, and <i8> for all 64bit integers.

**Advantages:** Everyone who relies on the current behavior is using 32bit integers only, so no existing functionality will be broken.
**Disadvantages:** Complicates the xmlrpc extension code in exchange for being aware of how big an integer is and adjusting how it is represented accordingly. Based on my observations this doesn't fit in will with the design of the extension.
#### xmlrpc_encode should convert everything to a 32bit integer

**Advantages:** Output will remain exactly the same
**Disadvantages:** This introduces a permanent limitation in exchange for backwards compatibility, and will cause `$x != xmlrpc_decode(xmlrpc_encode($x))` when handling large integers.

---

I look forward to input on how this should be addressed.
