### PR TITLE
Fix #62479 Allow odd characters in passwords

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -1155,6 +1155,7 @@ static int pdo_pgsql_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_
 	pdo_pgsql_db_handle *H;
 	int ret = 0;
 	char *conn_str, *p, *e;
+	char *tmp_pass;
 	long connect_timeout = 30;
 
 	H = pecalloc(1, sizeof(pdo_pgsql_db_handle), dbh->is_persistent);
@@ -1176,18 +1177,44 @@ static int pdo_pgsql_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_
 		connect_timeout = pdo_attr_lval(driver_options, PDO_ATTR_TIMEOUT, 30 TSRMLS_CC);
 	}
 
+	if (dbh->password) {
+		if (dbh->password[0] != '\'' && dbh->password[strlen(dbh->password) - 1] != '\'') {
+			char *pwd = dbh->password;
+			int pos = 1;
+
+			tmp_pass = safe_emalloc(2, strlen(dbh->password), 3);
+			tmp_pass[0] = '\'';
+
+			while (*pwd != '\0') {
+				if (*pwd == '\\' || *pwd == '\'') {
+					tmp_pass[pos++] = '\\';
+				}
+
+				tmp_pass[pos++] = *pwd++;
+			}
+
+			tmp_pass[pos++] = '\'';
+			tmp_pass[pos] = '\0';
+		} else {
+			tmp_pass = dbh->password;
+		}
+	}
+
 	/* support both full connection string & connection string + login and/or password */
 	if (dbh->username && dbh->password) {
-		spprintf(&conn_str, 0, "%s user=%s password=%s connect_timeout=%ld", dbh->data_source, dbh->username, dbh->password, connect_timeout);
+		spprintf(&conn_str, 0, "%s user=%s password=%s connect_timeout=%ld", dbh->data_source, dbh->username, tmp_pass, connect_timeout);
 	} else if (dbh->username) {
 		spprintf(&conn_str, 0, "%s user=%s connect_timeout=%ld", dbh->data_source, dbh->username, connect_timeout);
 	} else if (dbh->password) {
-		spprintf(&conn_str, 0, "%s password=%s connect_timeout=%ld", dbh->data_source, dbh->password, connect_timeout);
+		spprintf(&conn_str, 0, "%s password=%s connect_timeout=%ld", dbh->data_source, tmp_pass, connect_timeout);
 	} else {
 		spprintf(&conn_str, 0, "%s connect_timeout=%ld", (char *) dbh->data_source, connect_timeout);
 	}
 
 	H->server = PQconnectdb(conn_str);
+	if (dbh->password && tmp_pass != dbh->password) {
+		efree(tmp_pass);
+	}
 
 	efree(conn_str);
 

--- a/ext/pdo_pgsql/tests/bug62479.phpt
+++ b/ext/pdo_pgsql/tests/bug62479.phpt
@@ -1,0 +1,55 @@
+--TEST--
+PDO PgSQL Bug #62479 (PDO-psql cannot connect if password contains spaces)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+require dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+if (!isset($config['ENV']['PDOTEST_DSN'])) die('no dsn found in env');
+$db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+$rand = rand(5, 5);
+
+// Assume that if we can't create a user, this test needs to be skipped
+$testQuery = "CREATE USER pdo_$rand WITH PASSWORD 'testpass'";
+$db->query($testQuery);
+$testQuery = "DROP USER pdo_$rand";
+$db->query($testQuery);
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+$pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+$rand = rand(5, 5);
+$user = "pdo_$rand";
+$template = "CREATE USER $user WITH PASSWORD '%s'";
+$dropUser = "DROP USER $user";
+$testQuery = 'SELECT 1 as verification';
+
+// Create temp user with space in password
+$sql = sprintf($template, 'my password');
+$pdo->query($sql);
+
+$testConn = new PDO($config['ENV']['PDOTEST_DSN'], $user, "my password");
+$result = $testConn->query($testQuery);
+var_dump($result->fetch()[0]);
+
+// Remove the user
+$pdo->query($dropUser);
+
+// Create a user with a space and single quote
+$sql = sprintf($template, "my pass\'word");
+$pdo->query($sql);
+
+$testConn = new PDO($config['ENV']['PDOTEST_DSN'], $user, "my pass'word");
+$result = $testConn->query($testQuery);
+var_dump($result->fetch()[0]);
+
+// Remove the user
+$pdo->query($dropUser);
+
+?>
+--EXPECTF--
+int(1)
+int(1)


### PR DESCRIPTION
Currently, spaces and backslashes aren't allowed in passwords.
This patch allows for both to be usable.
