### PR TITLE
Bug #66481 Segfaults on session_name()

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -681,6 +681,13 @@ static PHP_INI_MH(OnUpdateSaveDir) /* {{{ */
 
 static PHP_INI_MH(OnUpdateName) /* {{{ */
 {
+	/* Don't accept a blank session name from php.ini or -d session.name= */
+	if (!PG(modules_activated) && !new_value_length) {
+		/* Force the default value. */
+		new_value = "PHPSESSID";
+		new_value_length = 9;
+	}
+
 	/* Numeric session.name won't work at all */
 	if (PG(modules_activated) &&
 		(!new_value_length || is_numeric_string(new_value, new_value_length, NULL, NULL, 0))) {

--- a/ext/session/tests/bug66481.phpt
+++ b/ext/session/tests/bug66481.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #66481: Calls to session_name() segfault when session.name is null.
+--INI--
+session.name=
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+
+var_dump(session_name("foo"));
+var_dump(session_name("bar"));
+
+--EXPECTF--
+string(9) "PHPSESSID"
+string(3) "foo"
+


### PR DESCRIPTION
If the previous value of session.name was NULL then any call to
session_name($string) would result in a segmentation fault.

This changes the behaviour to set the value of session.name to
"PHPSESSID" if a blank value is given in php.ini or via -d on the
command line. There is already protection against setting it to NULL via
session_name() or ini_set().
