### PR TITLE
Fix bug #66482, replace wrong item name 'priority' with 'process.priority' in php-fpm.conf

### DIFF
--- a/sapi/fpm/php-fpm.conf.in
+++ b/sapi/fpm/php-fpm.conf.in
@@ -185,7 +185,7 @@ listen = 127.0.0.1:9000
 ;       - The pool processes will inherit the master process priority
 ;         unless it specified otherwise
 ; Default Value: no set
-; priority = -19
+; process.priority = -19
 
 ; Choose how the process manager will control the number of child processes.
 ; Possible Values:


### PR DESCRIPTION
Fix bug #66482, replace wrong item name 'priority' with 'process.priority' in php-fpm.conf
