### PR TITLE
Fixed bug #54821 (Add support for SPF records to dns_get_record)

### DIFF
--- a/ext/standard/tests/network/dns_get_record_basic.phpt
+++ b/ext/standard/tests/network/dns_get_record_basic.phpt
@@ -1,0 +1,27 @@
+--TEST--
+dns_get_record() tests
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--FILE--
+<?php
+/* This must be a domain that publishes an RFC4408 SPF-type DNS record, */
+/* not to be confused with a domain that publishes an SPF record in a TXT record type */
+$domain = 'github.com';
+$match = false;
+$dns = dns_get_record( $domain, DNS_SPF );
+if (count($dns) > 0) {
+    if (array_key_exists('type', $dns[0]) and $dns[0]['type'] == 'SPF' and
+        array_key_exists('spf', $dns[0]) and !empty($dns[0]['spf'])) {
+        $match = true;
+    }
+}
+if ($match) {
+    echo "SPF Match\n";
+} else {
+    echo "SPF Lookup failed\n";
+}
+?>
+--EXPECT--
+SPF Match

--- a/ext/standard/tests/network/dns_get_record_basic.phpt
+++ b/ext/standard/tests/network/dns_get_record_basic.phpt
@@ -3,6 +3,7 @@ dns_get_record() tests
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+if (getenv("SKIP_ONLINE_TESTS")) die("skip online test");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
This patch adds support for the SPF record type defined in RFC4408. The patch duplicates most of what the TXT record handling does, but it uses the correct DNS record type. I used a spare bit in the bitfield for the new type.

Strictly speaking this functionality will be deprecated in a forthcoming [update to RFC4498](http://tools.ietf.org/html/draft-ietf-spfbis-4408bis-21#page-13), but the SPF type remains a valid RR type which PHP cannot currently query without this patch.

While writing this I spotted an inconsistency in the windows version: it uses the `DNS_TYPE_TEXT` constant instead of `DNS_TYPE_TXT` (which matches the actual type name). It uses it consistently, but it's asking for trouble when all the other constants match across platforms.
