### PR TITLE
Fix for bug66501 - key type not supported in this PHP build

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3454,6 +3454,15 @@ static int php_openssl_is_private_key(EVP_PKEY* pkey TSRMLS_DC)
 			}
 			break;
 #endif
+#ifdef EVP_PKEY_EC
+		case EVP_PKEY_EC:
+			assert(pkey->pkey.ec != NULL);
+
+			if ( NULL == EC_KEY_get0_private_key(pkey->pkey.ec)) {
+				return 0;
+			}
+			break;
+#endif
 		default:
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
 			break;

--- a/ext/openssl/tests/bug66501.phpt
+++ b/ext/openssl/tests/bug66501.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #66501: EC private key support in openssl_sign
+--SKIPIF--
+<?php 
+if (!extension_loaded("openssl")) die("skip");
+--FILE--
+<?php
+$pkey = 'ASN1 OID: prime256v1
+-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEILPkqoeyM7XgwYkuSj3077lrsrfWJK5LqMolv+m2oOjZoAoGCCqGSM49
+AwEHoUQDQgAEPq4hbIWHvB51rdWr8ejrjWo4qVNWVugYFtPg/xLQw0mHkIPZ4DvK
+sqOTOnMoezkbSmVVMuwz9flvnqHGmQvmug==
+-----END EC PRIVATE KEY-----';
+$key = openssl_pkey_get_private($pkey);
+$res = openssl_sign($data ='alpha', $sign, $key, 'ecdsa-with-SHA1');
+var_dump($res);
+--EXPECTF--
+bool(true)


### PR DESCRIPTION
Solving "key type not supported in this PHP build" error for bug 66501:
https://bugs.php.net/bug.php?id=66501
by adding EC support to php_openssl_is_private_key

also includes unit test that expects
PHP Warning: openssl_sign(): key type not supported in this PHP build!
not to be emitted
