### PR TITLE
Fix #66562: Consistency bug where curl_multi_getcontent behaves different from curl_exec

### DIFF
--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -248,6 +248,8 @@ PHP_FUNCTION(curl_multi_getcontent)
 		smart_str_0(&ch->handlers->write->buf);
 		RETURN_STRINGL(ch->handlers->write->buf.c, ch->handlers->write->buf.len, 1);
 	}
+
+        RETURN_EMPTY_STRING();
 }
 /* }}} */
 


### PR DESCRIPTION
I doubt this should be applied to master but I could not really figure out how to make a pull request to a tag only. Since there might be people depending on the inconsistent behaviour I understood it should probably be applied to the next major version.
