### PR TITLE
Replace old references to SVN in buildcheck.sh with Git.

### DIFF
--- a/build/buildcheck.sh
+++ b/build/buildcheck.sh
@@ -33,14 +33,14 @@ ac_version=`$PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' 
 if test -z "$ac_version"; then
 echo "buildconf: autoconf not found."
 echo "           You need autoconf version 2.59 or newer installed"
-echo "           to build PHP from SVN."
+echo "           to build PHP from Git."
 exit 1
 fi
 IFS=.; set $ac_version; IFS=' '
 if test "$1" = "2" -a "$2" -lt "59" || test "$1" -lt "2"; then
 echo "buildconf: autoconf version $ac_version found."
 echo "           You need autoconf version 2.59 or newer installed"
-echo "           to build PHP from SVN."
+echo "           to build PHP from Git."
 exit 1
 else
 echo "buildconf: autoconf version $ac_version (ok)"


### PR DESCRIPTION
This patch changes two small references to the old SVN repository in the error message produced when trying to run buildconf without autoconf or with an older autoconf.
