### PR TITLE
Removing misleading unused DEFAULT_KEY_LENGTH const

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -60,7 +60,7 @@
 #define timezone _timezone	/* timezone is called _timezone in LibC */
 #endif
 
-#define DEFAULT_KEY_LENGTH	512
+#define DEFAULT_KEY_LENGTH	2048
 #define MIN_KEY_LENGTH		384
 
 #define OPENSSL_ALGO_SHA1 	1

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -60,7 +60,6 @@
 #define timezone _timezone	/* timezone is called _timezone in LibC */
 #endif
 
-#define DEFAULT_KEY_LENGTH	2048
 #define MIN_KEY_LENGTH		384
 
 #define OPENSSL_ALGO_SHA1 	1


### PR DESCRIPTION
Switching default RSA keysize from 512 to 2048, new NIST security guidelines recommend minimum keysize of 2048 until year 2030 see https://wiki.mozilla.org/CA:MD5and1024
This would be great to add to PHP 5.6