### PR TITLE
Fixes #66714: imageconvolution breakage in 5.5.9

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -4879,7 +4879,7 @@ PHP_FUNCTION(imageconvolution)
 				if (zend_hash_index_find(Z_ARRVAL_PP(var), (j), (void **) &var2) == SUCCESS) {
 					if (Z_TYPE_PP(var2) != IS_DOUBLE) {
 						zval dval;
-						dval = **var;
+						dval = **var2;
 						zval_copy_ctor(&dval);
 						convert_to_double(&dval);
 						matrix[i][j] = (float)Z_DVAL(dval);


### PR DESCRIPTION
[#66714](https://bugs.php.net/bug.php?id=66714)

5.5.9 included some GD fixes related to [#66356](https://bugs.php.net/bug.php?id=66356). One of those fixes changed the 
above section of imageconvolution, but the variable was mistyped.

EDIT: Have confirmed that this does indeed fix the issue after compiling my php-5.5 branch with this fix.
