### PR TITLE
php-fpm.conf clear_env = no prevents clearenv() in workers.

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -127,7 +127,6 @@ static struct ini_value_parser_s ini_fpm_pool_options[] = {
 	{ "listen.group",              &fpm_conf_set_string,      WPO(listen_group) },
 	{ "listen.mode",               &fpm_conf_set_string,      WPO(listen_mode) },
 	{ "listen.allowed_clients",    &fpm_conf_set_string,      WPO(listen_allowed_clients) },
-	{ "preserve_environment",      &fpm_conf_set_boolean,     WPO(preserve_environment) },
 	{ "process.priority",          &fpm_conf_set_integer,     WPO(process_priority) },
 	{ "pm",                        &fpm_conf_set_pm,          WPO(pm) },
 	{ "pm.max_children",           &fpm_conf_set_integer,     WPO(pm_max_children) },
@@ -149,6 +148,7 @@ static struct ini_value_parser_s ini_fpm_pool_options[] = {
 	{ "chroot",                    &fpm_conf_set_string,      WPO(chroot) },
 	{ "chdir",                     &fpm_conf_set_string,      WPO(chdir) },
 	{ "catch_workers_output",      &fpm_conf_set_boolean,     WPO(catch_workers_output) },
+	{ "clear_env",                 &fpm_conf_set_boolean,     WPO(clear_env) },
 	{ "security.limit_extensions", &fpm_conf_set_string,      WPO(security_limit_extensions) },
 #ifdef HAVE_APPARMOR
 	{ "apparmor_hat",              &fpm_conf_set_string,      WPO(apparmor_hat) },
@@ -607,6 +607,7 @@ static void *fpm_worker_pool_config_alloc() /* {{{ */
 	wp->config->listen_backlog = FPM_BACKLOG_DEFAULT;
 	wp->config->pm_process_idle_timeout = 10; /* 10s by default */
 	wp->config->process_priority = 64; /* 64 means unset */
+	wp->config->clear_env = 1;
 
 	if (!fpm_worker_all_pools) {
 		fpm_worker_all_pools = wp;
@@ -1582,7 +1583,6 @@ static void fpm_conf_dump() /* {{{ */
 		zlog(ZLOG_NOTICE, "\tlisten.group = %s",               STR2STR(wp->config->listen_group));
 		zlog(ZLOG_NOTICE, "\tlisten.mode = %s",                STR2STR(wp->config->listen_mode));
 		zlog(ZLOG_NOTICE, "\tlisten.allowed_clients = %s",     STR2STR(wp->config->listen_allowed_clients));
-		zlog(ZLOG_NOTICE, "\tpreserve_environment = %s",       BOOL2STR(wp->config->preserve_environment));
 		if (wp->config->process_priority == 64) {
 			zlog(ZLOG_NOTICE, "\tprocess.priority = undefined");
 		} else {
@@ -1608,6 +1608,7 @@ static void fpm_conf_dump() /* {{{ */
 		zlog(ZLOG_NOTICE, "\tchroot = %s",                     STR2STR(wp->config->chroot));
 		zlog(ZLOG_NOTICE, "\tchdir = %s",                      STR2STR(wp->config->chdir));
 		zlog(ZLOG_NOTICE, "\tcatch_workers_output = %s",       BOOL2STR(wp->config->catch_workers_output));
+		zlog(ZLOG_NOTICE, "\tclear_env = %s",                  BOOL2STR(wp->config->clear_env));
 		zlog(ZLOG_NOTICE, "\tsecurity.limit_extensions = %s",  wp->config->security_limit_extensions);
 
 		for (kv = wp->config->env; kv; kv = kv->next) {

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -62,7 +62,6 @@ struct fpm_worker_pool_config_s {
 	char *listen_group;
 	char *listen_mode;
 	char *listen_allowed_clients;
-	int preserve_environment;
 	int process_priority;
 	int pm;
 	int pm_max_children;
@@ -84,6 +83,7 @@ struct fpm_worker_pool_config_s {
 	char *chroot;
 	char *chdir;
 	int catch_workers_output;
+	int clear_env;
 	char *security_limit_extensions;
 	struct key_value_s *env;
 	struct key_value_s *php_admin_values;

--- a/sapi/fpm/fpm/fpm_env.c
+++ b/sapi/fpm/fpm/fpm_env.c
@@ -143,7 +143,7 @@ int fpm_env_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 	fpm_env_setproctitle(title);
 	efree(title);
 
-	if (!wp->config->preserve_environment) {
+	if (wp->config->clear_env) {
 		clearenv();
 	}
 

--- a/sapi/fpm/php-fpm.conf.in
+++ b/sapi/fpm/php-fpm.conf.in
@@ -142,14 +142,6 @@
 ; Default Value: none
 ;prefix = /path/to/pools/$pool
 
-; Preserve environment
-; By default, environment variables are not passed to workers.
-; This option prevents environment from being cleared when FPM workers spawn,
-; making environment variables available to PHP code running in the workers
-; via getenv(), $_ENV and $_SERVER.
-; Default Value: no
-;preserve_environment = yes
-
 ; Unix user/group of processes
 ; Note: The user is mandatory. If the group is not set, the default user's group
 ;       will be used.
@@ -482,6 +474,15 @@ pm.max_spare_servers = 3
 ; process time (several ms).
 ; Default Value: no
 ;catch_workers_output = yes
+
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+;clear_env = no
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit


### PR DESCRIPTION
## Summary

This patch adds a `clear_env` boolean option (default: yes) to `php-fpm.conf`, making it possible to pass standard environment variables to web apps running under PHP-FPM, by setting the option to `no`.
## Usage

Configure php-fpm.conf:

``` ini
[www]
clear_env = no
```

Run php-fpm with environment variables:

``` sh
export DATABASE_URL="mysql://john:c1t1z3n@127.0.0.1:3306/widgets"
php5-fpm
```

Access environment variables from PHP:

``` php
<?php
$db->connect(getenv("DATABASE_URL") ?: "mysql://user:pass@localhost/default");
```
## Background

Currently, FPM workers always clear their environment when they spawn. This makes it impossible to configure a web application by passing standard environment variables.

_(Environment variables can be whitelisted or statically set in [php-fpm's pool config](http://www.php.net/manual/en/install.fpm.configuration.php#example-60), but it should not be necessary, and is sometimes impossible, to edit configuration files to pass environment to a process)._

[The Twelve Factor App](http://12factor.net/config), and [Heroku](https://devcenter.heroku.com/articles/config-vars), and other modern platforms/practices, advocate passing arbitrary configuration to web applications using standard unix environment variables. [Docker containers](http://docs.docker.io/en/latest/reference/run/#env-environment-variables) are parametized by environment variables.

This patch does not change the default behavior, so is fully backwards compatible.

**Update**: this pull-request was originally for `preserve_environment` (default: no), but the config option name has been changed to `clear_env` (default: yes).
