### PR TITLE
substr_compare(): Allow zero length comparison

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5585,14 +5585,13 @@ PHP_FUNCTION(substr_compare)
 	int s1_len, s2_len;
 	long offset, len=0;
 	zend_bool cs=0;
-	uint cmp_len;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssl|lb", &s1, &s1_len, &s2, &s2_len, &offset, &len, &cs) == FAILURE) {
 		RETURN_FALSE;
 	}
 
-	if (ZEND_NUM_ARGS() >= 4 && len <= 0) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "The length must be greater than zero");
+	if (ZEND_NUM_ARGS() >= 4 && len < 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "The length must be greater than or equal to zero");
 		RETURN_FALSE;
 	}
 
@@ -5606,12 +5605,10 @@ PHP_FUNCTION(substr_compare)
 		RETURN_FALSE;
 	}
 
-	cmp_len = (uint) (len ? len : MAX(s2_len, (s1_len - offset)));
-
 	if (!cs) {
-		RETURN_LONG(zend_binary_strncmp(s1 + offset, (s1_len - offset), s2, s2_len, cmp_len));
+		RETURN_LONG(zend_binary_strncmp(s1 + offset, (s1_len - offset), s2, s2_len, (uint)len));
 	} else {
-		RETURN_LONG(zend_binary_strncasecmp_l(s1 + offset, (s1_len - offset), s2, s2_len, cmp_len));
+		RETURN_LONG(zend_binary_strncasecmp_l(s1 + offset, (s1_len - offset), s2, s2_len, (uint)len));
 	}
 }
 /* }}} */

--- a/ext/standard/tests/strings/bug33605.phpt
+++ b/ext/standard/tests/strings/bug33605.phpt
@@ -2,10 +2,10 @@
 Bug #33605 (substr_compare crashes)
 --FILE--
 <?php
-$res = substr_compare("aa", "a", -99999999, 0, 0);
+$res = substr_compare("aa", "a", -99999999, -1, 0);
 var_dump($res);
 
 ?>
 --EXPECTF--
-Warning: substr_compare(): The length must be greater than zero in %s on line %d
+Warning: substr_compare(): The length must be greater than or equal to zero in %s on line %d
 bool(false)

--- a/ext/standard/tests/strings/substr_compare.phpt
+++ b/ext/standard/tests/strings/substr_compare.phpt
@@ -10,9 +10,10 @@ var_dump(substr_compare("abcde", "bc", 1, 3));
 var_dump(substr_compare("abcde", "cd", 1, 2));
 var_dump(substr_compare("abcde", "abc", 5, 1));
 var_dump(substr_compare("abcde", "abcdef", -10, 10));
-
+var_dump(substr_compare("abcde", "abc", 0, 0));
 var_dump(substr_compare("abcde", -1, 0, NULL, new stdClass));
 echo "Test\n";
+var_dump(substr_compare("abcde", "abc", 0, -1));
 var_dump(substr_compare("abcde", "abc", -1, NULL, -5));
 var_dump(substr_compare("abcde", -1, 0, "str", new stdClass));
 
@@ -28,13 +29,15 @@ int(-1)
 Warning: substr_compare(): The start position cannot exceed initial string length in %s on line %d
 bool(false)
 int(-1)
+int(0)
 
 Warning: substr_compare() expects parameter 5 to be boolean, object given in %s on line %d
 bool(false)
 Test
 
-Warning: substr_compare(): The length must be greater than zero in %s on line %d
+Warning: substr_compare(): The length must be greater than or equal to zero in %s on line %d
 bool(false)
+int(0)
 
 Warning: substr_compare() expects parameter 4 to be long, string given in %s on line %d
 bool(false)


### PR DESCRIPTION
Analogous to how `strncmp()` handles a zero length comparison, `substr_compare()` with a zero length should return `0` as well.

Example:

```
substr_compare("abc", "a", 0, 0); // 0
substr_compare("abc", "a", 0, -1); // false (with warning)
```

This patch also cleans up logic prior to bug #33605
