### PR TITLE
Fix #50444: PDO-ODBC changes for 64-bit

### DIFF
--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -279,7 +279,7 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 	pdo_odbc_stmt *S = (pdo_odbc_stmt*)stmt->driver_data;
 	RETCODE rc;
 	SWORD sqltype = 0, ctype = 0, scale = 0, nullable = 0;
-	UDWORD precision = 0;
+	SQLULEN precision = 0;
 	pdo_odbc_param *P;
 	
 	/* we're only interested in parameters for prepared SQL right now */
@@ -551,7 +551,7 @@ static int odbc_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC)
 	struct pdo_column_data *col = &stmt->columns[colno];
 	RETCODE rc;
 	SWORD	colnamelen;
-	SDWORD	colsize;
+	SQLULEN	colsize;
 	SQLLEN displaysize;
 
 	rc = SQLDescribeCol(S->stmt, colno+1, S->cols[colno].colname,

--- a/ext/pdo_odbc/php_pdo_odbc_int.h
+++ b/ext/pdo_odbc/php_pdo_odbc_int.h
@@ -157,7 +157,7 @@ typedef struct {
 } pdo_odbc_stmt;
 
 typedef struct {
-	SQLINTEGER len;
+	SQLLEN len;
 	SQLSMALLINT paramtype;
 	char *outbuf;
 	unsigned is_unicode:1;


### PR DESCRIPTION
[This bug](https://bugs.php.net/bug.php?id=50444) is also referenced in [#61777](https://bugs.php.net/bug.php?id=61777) and is still present in the latest stable release of the 5.5 branch (it looks like it's existed since at least 5.2). I see two tickets exist for this problem already, and I'm just submitting these changes via github as a reminder that this is a serious problem for anyone using PDO_ODBC on the 64-bit builds (any query with bound parameters will segfault).

I built my [feature branch](https://github.com/Andrewpk/php-src/tree/pdo_odbc_x64_fix) and verified that this fixed the bound parameters problem when using 64bit php + pdo_odbc basing off of 5.5.9 release. All other tests passed as they did for the 5.5.9 release. Patches for this already exist in the reported bugs, but I'm just sending a PR to voice my concern and re-propose the already proposed changes in case they've been forgotten.

Currently, the only workaround solutions for 64-bit users who utilize pdo_odbc are:
- Maintain their own builds of php with this or similar patches applied
- Run a 32-bit install of both php and the odbc manager (either with 32bit compat libs or chroot environment)

Thank you very much for all of your hard work!
I really enjoy the 5.5 improvements.
