### PR TITLE
Fix a compiler warning in php_rand.h

### DIFF
--- a/ext/standard/php_rand.h
+++ b/ext/standard/php_rand.h
@@ -27,6 +27,7 @@
 
 #include <stdlib.h>
 #include "basic_functions.h"
+#include "php_lcg.h"
 
 /* System Rand functions */
 #ifndef RAND_MAX

--- a/ext/standard/rand.c
+++ b/ext/standard/rand.c
@@ -30,7 +30,6 @@
 #include "php.h"
 #include "php_math.h"
 #include "php_rand.h"
-#include "php_lcg.h"
 
 #include "basic_functions.h"
 


### PR DESCRIPTION
php_rand.h uses php_combined_lcg() which may cause a compiler warning when the header defining it, isn't included.
