### PR TITLE
Allow crypto_method context value in stream_socket_enable_crypto()

### DIFF
--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -40,6 +40,8 @@ typedef unsigned long long php_timeout_ull;
 typedef unsigned __int64 php_timeout_ull;
 #endif
 
+#define GET_CTX_OPT(stream, wrapper, name, val) (stream->context && SUCCESS == php_stream_context_get_option(stream->context, wrapper, name, &val))
+
 static php_stream_context *decode_context_param(zval *contextresource TSRMLS_DC);
 
 /* Streams based network functions */
@@ -1502,16 +1504,27 @@ PHP_FUNCTION(stream_socket_enable_crypto)
 	long cryptokind = 0;
 	zval *zstream, *zsessstream = NULL;
 	php_stream *stream, *sessstream = NULL;
-	zend_bool enable;
+	zend_bool enable, cryptokindnull;
 	int ret;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rb|lr", &zstream, &enable, &cryptokind, &zsessstream) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rb|l!r", &zstream, &enable, &cryptokind, &cryptokindnull, &zsessstream) == FAILURE) {
 		RETURN_FALSE;
 	}
 
 	php_stream_from_zval(stream, &zstream);
 
-	if (ZEND_NUM_ARGS() >= 3) {
+	if (enable) {
+		if (ZEND_NUM_ARGS() < 3 || cryptokindnull) {
+			zval **val;
+
+			if (!GET_CTX_OPT(stream, "ssl", "crypto_method", val)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "When enabling encryption you must specify the crypto type");
+				RETURN_FALSE;
+			}
+
+			cryptokind = Z_LVAL_PP(val);
+		}
+
 		if (zsessstream) {
 			php_stream_from_zval(sessstream, &zsessstream);
 		}
@@ -1519,9 +1532,6 @@ PHP_FUNCTION(stream_socket_enable_crypto)
 		if (php_stream_xport_crypto_setup(stream, cryptokind, sessstream TSRMLS_CC) < 0) {
 			RETURN_FALSE;
 		}
-	} else if (enable) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "When enabling encryption you must specify the crypto type");
-		RETURN_FALSE;
 	}
 
 	ret = php_stream_xport_crypto_enable(stream, enable TSRMLS_CC);


### PR DESCRIPTION
Don't require the 3rd argument to `stream_socket_enable_crypto()`, as it can now be specified in the `ssl` -> `crypto_method` context option.
