### PR TITLE
Add test for bug #62102 / RFC 2144

### DIFF
--- a/ext/mcrypt/tests/bug62102_rfc2144.phpt
+++ b/ext/mcrypt/tests/bug62102_rfc2144.phpt
@@ -1,0 +1,24 @@
+--TEST--
+RFC 2144 test vectors (CAST-128, ECB mode) https://bugs.php.net/bug.php?id=62102
+--SKIPIF--
+<?php extension_loaded('mcrypt') OR print 'skip'; ?>
+--FILE--
+<?php
+$plaintext = "\x01\x23\x45\x67\x89\xAB\xCD\xEF";
+
+echo
+
+"128-bit: ",
+bin2hex(mcrypt_encrypt('cast-128', "\x01\x23\x45\x67\x12\x34\x56\x78\x23\x45\x67\x89\x34\x56\x78\x9A", $plaintext, 'ecb')),
+"\n",
+"80-bit: ",
+bin2hex(mcrypt_encrypt('cast-128', "\x01\x23\x45\x67\x12\x34\x56\x78\x23\x45", $plaintext, 'ecb')),
+"\n",
+"40-bit: ",
+bin2hex(mcrypt_encrypt('cast-128', "\x01\x23\x45\x67\x12", $plaintext, 'ecb')),
+"\n";
+
+--EXPECTF--
+128-bit: 238b4fe5847e44b2
+80-bit: eb6a711a2c02271b
+40-bit: 7ac816d16e9b302e


### PR DESCRIPTION
Using test vectors from RFC 2144, section B.1 (http://tools.ietf.org/rfc/rfc2144.txt)

The bug itself has (apparently) been fixed some time ago.
