### PR TITLE
isset() and empty() don't invoke ArrayObject::offsetGet()

### DIFF
--- a/ext/spl/tests/bug66834.phpt
+++ b/ext/spl/tests/bug66834.phpt
@@ -3,44 +3,60 @@ SPL: Bug #66834
 --FILE--
 <?php
 
+// overrides both offsetExists and offsetGet
 class ArrayObjectBoth extends ArrayObject 
 {
-  public function offsetExists($offset) {
-    var_dump('Called: '.__METHOD__);
-    return parent::offsetExists($offset);
-  }
+	public function offsetExists($offset) {
+		var_dump('Called: '.__METHOD__);
+		return parent::offsetExists($offset);
+	}
 
-  public function offsetGet($offset) {
-    var_dump('Called: '.__METHOD__);
-    return parent::offsetGet($offset);
-  }
+	public function offsetGet($offset) {
+		var_dump('Called: '.__METHOD__);
+		return parent::offsetGet($offset);
+	}
 }
+
+// overrides only offsetExists
+class ArrayObjectExists extends ArrayObject 
+{
+	public function offsetExists($offset) {
+		var_dump('Called: '.__METHOD__);
+		return parent::offsetExists($offset);
+	}
+}
+
+// overrides only offsetGet
+class ArrayObjectGet extends ArrayObject 
+{
+	public function offsetGet($offset) {
+		var_dump('Called: '.__METHOD__);
+		return parent::offsetGet($offset);
+	}
+}
+
+$values = ['foo' => '', 'bar' => null, 'baz' => 42];
 
 echo "==== class with offsetExists() and offsetGet() ====\n";
-$object = new ArrayObjectBoth(array('foo' => ''));
+$object = new ArrayObjectBoth($values);
 var_dump($object->offsetExists('foo'), isset($object['foo']), empty($object['foo']));
-
-class ArrayObjectExists extends ArrayObject {
-  public function offsetExists($offset) {
-    var_dump('Called: '.__METHOD__);
-    return parent::offsetExists($offset);
-  }
-}
+var_dump($object->offsetExists('bar'), isset($object['bar']), empty($object['bar']));
+var_dump($object->offsetexists('baz'), isset($object['baz']), empty($object['baz']));
+var_dump($object->offsetexists('qux'), isset($object['qux']), empty($object['qux']));
 
 echo "==== class with offsetExists() ====\n";
-$object = new ArrayObjectExists(array('foo' => ''));
+$object = new ArrayObjectExists($values);
 var_dump($object->offsetExists('foo'), isset($object['foo']), empty($object['foo']));
-
-class ArrayObjectGet extends ArrayObject {
-  public function offsetGet($offset) {
-    var_dump('Called: '.__METHOD__);
-    return parent::offsetGet($offset);
-  }
-}
+var_dump($object->offsetExists('bar'), isset($object['bar']), empty($object['bar']));
+var_dump($object->offsetexists('baz'), isset($object['baz']), empty($object['baz']));
+var_dump($object->offsetexists('qux'), isset($object['qux']), empty($object['qux']));
 
 echo "==== class with offsetGet() ====\n";
-$object = new ArrayObjectGet(array('foo' => ''));
+$object = new ArrayObjectGet($values);
 var_dump($object->offsetExists('foo'), isset($object['foo']), empty($object['foo']));
+var_dump($object->offsetExists('bar'), isset($object['bar']), empty($object['bar']));
+var_dump($object->offsetexists('baz'), isset($object['baz']), empty($object['baz']));
+var_dump($object->offsetexists('qux'), isset($object['qux']), empty($object['qux']));
 
 ?>
 --EXPECT--
@@ -53,6 +69,28 @@ string(34) "Called: ArrayObjectBoth::offsetGet"
 bool(true)
 bool(true)
 bool(true)
+string(37) "Called: ArrayObjectBoth::offsetExists"
+string(37) "Called: ArrayObjectBoth::offsetExists"
+string(34) "Called: ArrayObjectBoth::offsetGet"
+string(37) "Called: ArrayObjectBoth::offsetExists"
+string(34) "Called: ArrayObjectBoth::offsetGet"
+bool(true)
+bool(false)
+bool(true)
+string(37) "Called: ArrayObjectBoth::offsetExists"
+string(37) "Called: ArrayObjectBoth::offsetExists"
+string(34) "Called: ArrayObjectBoth::offsetGet"
+string(37) "Called: ArrayObjectBoth::offsetExists"
+string(34) "Called: ArrayObjectBoth::offsetGet"
+bool(true)
+bool(true)
+bool(false)
+string(37) "Called: ArrayObjectBoth::offsetExists"
+string(37) "Called: ArrayObjectBoth::offsetExists"
+string(37) "Called: ArrayObjectBoth::offsetExists"
+bool(false)
+bool(false)
+bool(true)
 ==== class with offsetExists() ====
 string(39) "Called: ArrayObjectExists::offsetExists"
 string(39) "Called: ArrayObjectExists::offsetExists"
@@ -60,9 +98,40 @@ string(39) "Called: ArrayObjectExists::offsetExists"
 bool(true)
 bool(true)
 bool(true)
+string(39) "Called: ArrayObjectExists::offsetExists"
+string(39) "Called: ArrayObjectExists::offsetExists"
+string(39) "Called: ArrayObjectExists::offsetExists"
+bool(true)
+bool(false)
+bool(true)
+string(39) "Called: ArrayObjectExists::offsetExists"
+string(39) "Called: ArrayObjectExists::offsetExists"
+string(39) "Called: ArrayObjectExists::offsetExists"
+bool(true)
+bool(true)
+bool(false)
+string(39) "Called: ArrayObjectExists::offsetExists"
+string(39) "Called: ArrayObjectExists::offsetExists"
+string(39) "Called: ArrayObjectExists::offsetExists"
+bool(false)
+bool(false)
+bool(true)
 ==== class with offsetGet() ====
 string(33) "Called: ArrayObjectGet::offsetGet"
 string(33) "Called: ArrayObjectGet::offsetGet"
 bool(true)
 bool(true)
+bool(true)
+string(33) "Called: ArrayObjectGet::offsetGet"
+string(33) "Called: ArrayObjectGet::offsetGet"
+bool(true)
+bool(false)
+bool(true)
+string(33) "Called: ArrayObjectGet::offsetGet"
+string(33) "Called: ArrayObjectGet::offsetGet"
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+bool(false)
 bool(true)


### PR DESCRIPTION
This fixed [bug 66834](http://bugs.php.net/66834).

Both `isset()` and `empty()` should inspect the value after checking whether the offset exists (or by calling `offsetExists()`).
