### PR TITLE
Fix #44643: PDO-ODBC: bound parameters ignore explicit type definitions

### DIFF
--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -323,7 +323,11 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 							(Z_STRLEN_P(param->parameter) < 4000 ||
 								Z_TYPE_P(param->parameter) != IS_STRING)) {
 						sqltype = SQL_VARCHAR;
-						precision = sizeof(param->parameter);
+						if(Z_TYPE_P(param->parameter) == IS_STRING) {
+							precision = Z_STRLEN_P(param->parameter);
+						} else {
+							precision = 10;
+						}
 						scale = 0;
 					} else {
 						/* MS Access, for instance, doesn't support SQLDescribeParam,

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -279,7 +279,7 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 	pdo_odbc_stmt *S = (pdo_odbc_stmt*)stmt->driver_data;
 	RETCODE rc;
 	SWORD sqltype = 0, ctype = 0, scale = 0, nullable = 0;
-	UDWORD precision = 0;
+	SQLULEN precision = 0;
 	pdo_odbc_param *P;
 	
 	/* we're only interested in parameters for prepared SQL right now */
@@ -315,17 +315,29 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 
 				rc = SQLDescribeParam(S->stmt, (SQLUSMALLINT) param->paramno+1, &sqltype, &precision, &scale, &nullable);
 				if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
-					/* MS Access, for instance, doesn't support SQLDescribeParam,
-					 * so we need to guess */
-					sqltype = PDO_PARAM_TYPE(param->param_type) == PDO_PARAM_LOB ?
-									SQL_LONGVARBINARY :
-									SQL_LONGVARCHAR;
-					precision = 4000;
-					scale = 5;
-					nullable = 1;
-
-					if (param->max_value_len > 0) {
-						precision = param->max_value_len;
+					/* if the PDO_PARAM_TYPE is string, lets see if we can fit it in a varchar. */
+					if ((Z_TYPE_P(param->parameter) != IS_ARRAY && 
+							Z_TYPE_P(param->parameter) != IS_OBJECT &&
+							Z_TYPE_P(param->parameter) != IS_RESOURCE) &&
+							param->max_value_len <= 0 && 
+							(Z_STRLEN_P(param->parameter) < 4000 ||
+								Z_TYPE_P(param->parameter) != IS_STRING)) {
+						sqltype = SQL_VARCHAR;
+						precision = sizeof(param->parameter);
+						scale = 0;
+					} else {
+						/* MS Access, for instance, doesn't support SQLDescribeParam,
+						 * so we need to guess */
+						sqltype = PDO_PARAM_TYPE(param->param_type) == PDO_PARAM_LOB ?
+										SQL_LONGVARBINARY :
+										SQL_LONGVARCHAR;
+						precision = 4000;
+						scale = 5;
+						nullable = 1;
+	
+						if (param->max_value_len > 0) {
+							precision = param->max_value_len;
+						}
 					}
 				}
 				if (sqltype == SQL_BINARY || sqltype == SQL_VARBINARY || sqltype == SQL_LONGVARBINARY) {


### PR DESCRIPTION
This bug is also referenced in
[#44643](https://bugs.php.net/bug.php?id=44643)
pdo_odbc has had well-documented issues with parameterised queries accessing SQL Server for a long time. The issue is that when SQLDescribeParam does not return information about an input query parameter, pdo_odbc treats the parameter as a LONGVARCHAR or LONGVARBINARY. This patch modifies pdo_odbc to treat input parameters of less than 4000 characters in length as VARCHAR when the server does not return useful parameter information in response to the SQLDescribeParam call. This fixes behavior on SQL server, and shouldn't adversely affect behavior on other DBMS's, because the others for the most part return valid parameter info.
