### PR TITLE
Fix 5.4.26 NEWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,10 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug #60602 (proc_open() changes environment array) (Tjerk)
 
+- FPM:
+  . Added clear_env configuration directive to disable clearenv() call.
+  (Github PR# 598, Paul Annesley)
+
 - GMP
   . fixed bug#66872 (invalid argument crashes gmp_testbit) (Pierre)
 
@@ -24,10 +28,6 @@ PHP                                                                        NEWS
 - Fileinfo:
   . Fixed bug #66731 (file: infinite recursion). (CVE-2014-1943) (Remi)
   . Fixed bug #66820 (out-of-bounds memory access in fileinfo). (Remi)
-
-- FPM:
-  . Added clear_env configuration directive to disable clearenv() call.
-  (Github PR# 598, Paul Annesley)
 
 - LDAP:
   . Implemented ldap_modify_batch (https://wiki.php.net/rfc/ldap_modify_batch).


### PR DESCRIPTION
The FPM change didn't make it into 5.4.26 but will instead be in 5.4.27; http://php.net/Changelog-5.php, the release and the NEWS file in the release accurately reflect this, but the 5.4 branch NEWS doesn't (as the release was made and tagged from the last RC, which didn't contain that change yet). Refs GitHub PR #598.
