### PR TITLE
Fix 5.5.10 NEWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,10 @@ PHP                                                                        NEWS
   . Fix compilation on libcurl versions between 7.10.5 and 7.12.2, inclusive.
     (Adam)
 
+- FPM:
+  . Added clear_env configuration directive to disable clearenv() call.
+  (Github PR# 598, Paul Annesley)
+
 - GD:
   . Fixed bug #66714 (imageconvolution breakage). (Brad Daily)
   . Fixed bug #66869 (Invalid 2nd argument crashes imageaffinematrixget) (Pierre)
@@ -55,10 +59,6 @@ PHP                                                                        NEWS
   . Bug #66731 (file: infinite recursion) (CVE-2014-1943). (Remi)
   . Fixed bug #66820 (out-of-bounds memory access in fileinfo)
     (CVE-2014-2270). (Remi)
-
-- FPM:
-  . Added clear_env configuration directive to disable clearenv() call.
-  (Github PR# 598, Paul Annesley)
 
 - GD
   . Fixed Bug #66815 (imagecrop(): insufficient fix for NULL defer


### PR DESCRIPTION
The FPM change didn't make it into 5.5.10 but will instead be in 5.5.11; http://php.net/Changelog-5.php, the release and the NEWS file in the release accurately reflect this, but the 5.5 branch NEWS doesn't (as the release was made and tagged from the last RC, which didn't contain that change yet). Refs GitHub PR #598.
