### PR TITLE
Support async pgsql connections and non-blocking queries

### DIFF
--- a/ext/pgsql/php_pgsql.h
+++ b/ext/pgsql/php_pgsql.h
@@ -67,6 +67,7 @@ PHP_MINFO_FUNCTION(pgsql);
 /* connection functions */
 PHP_FUNCTION(pg_connect);
 PHP_FUNCTION(pg_pconnect);
+PHP_FUNCTION(pg_connect_poll);
 PHP_FUNCTION(pg_close);
 PHP_FUNCTION(pg_connection_reset);
 PHP_FUNCTION(pg_connection_status);
@@ -134,6 +135,9 @@ PHP_FUNCTION(pg_field_is_null);
 PHP_FUNCTION(pg_field_table);
 /* async message functions */
 PHP_FUNCTION(pg_get_notify);
+PHP_FUNCTION(pg_socket);
+PHP_FUNCTION(pg_consume_input);
+PHP_FUNCTION(pg_flush);
 PHP_FUNCTION(pg_get_pid);
 /* error message functions */
 PHP_FUNCTION(pg_result_error);
@@ -191,6 +195,7 @@ PHP_FUNCTION(pg_select);
 
 /* connection options - ToDo: Add async connection option */
 #define PGSQL_CONNECT_FORCE_NEW     (1<<1)
+#define PGSQL_CONNECT_ASYNC         (1<<2)
 /* php_pgsql_convert options */
 #define PGSQL_CONV_IGNORE_DEFAULT   (1<<1)     /* Do not use DEAFULT value by removing field from returned array */
 #define PGSQL_CONV_FORCE_NULL       (1<<2)     /* Convert to NULL if string is null string */
@@ -221,6 +226,13 @@ static char *get_field_name(PGconn *pgsql, Oid oid, HashTable *list TSRMLS_DC);
 static void php_pgsql_get_field_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type);
 static void php_pgsql_data_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type);
 static void php_pgsql_do_async(INTERNAL_FUNCTION_PARAMETERS,int entry_type);
+
+static size_t php_pgsql_fd_write(php_stream *stream, const char *buf, size_t count TSRMLS_DC);
+static size_t php_pgsql_fd_read(php_stream *stream, char *buf, size_t count TSRMLS_DC);
+static int php_pgsql_fd_close(php_stream *stream, int close_handle TSRMLS_DC);
+static int php_pgsql_fd_flush(php_stream *stream TSRMLS_DC);
+static int php_pgsql_fd_set_option(php_stream *stream, int option, int value, void *ptrparam TSRMLS_DC);
+static int php_pgsql_fd_cast(php_stream *stream, int cast_as, void **ret TSRMLS_DC);
 
 typedef enum _php_pgsql_data_type {
 	/* boolean */
@@ -283,6 +295,18 @@ typedef struct _php_pgsql_notice {
 	char *message;
 	size_t len;
 } php_pgsql_notice;
+
+static php_stream_ops php_stream_pgsql_fd_ops = {
+	php_pgsql_fd_write,
+	php_pgsql_fd_read,
+	php_pgsql_fd_close,
+	php_pgsql_fd_flush,
+	"PostgreSQL link",
+	NULL, /* seek */
+	php_pgsql_fd_cast, /* cast */
+	NULL, /* stat */
+	php_pgsql_fd_set_option
+};
 
 ZEND_BEGIN_MODULE_GLOBALS(pgsql)
 	long default_link; /* default link when connection is omitted */

--- a/ext/pgsql/tests/29nb_async_connect.phpt
+++ b/ext/pgsql/tests/29nb_async_connect.phpt
@@ -1,0 +1,44 @@
+--TEST--
+PostgreSQL non-blocking async connect
+--SKIPIF--
+<?php
+include("skipif.inc");
+?>
+--FILE--
+<?php
+
+include('config.inc');
+include('nonblocking.inc');
+
+if (!$db = pg_connect($conn_str, PGSQL_CONNECT_ASYNC)) {
+	die("pg_connect() error");
+} elseif (pg_connection_status($db) === PGSQL_CONNECTION_BAD) {
+	die("pg_connect() error");
+} elseif ($db_socket = pg_socket($db)) {
+	stream_set_blocking($db_socket, FALSE);
+} else {
+	die("pg_socket() error");
+}
+
+while (TRUE) {
+	switch ($status = pg_connect_poll($db)) {
+		case PGSQL_POLLING_READING:
+			if (nb_is_readable($db_socket)) { break 2; }
+			break;
+		case PGSQL_POLLING_WRITING:
+			if (nb_is_writable($db_socket)) { break 2; }
+			break;
+		case PGSQL_POLLING_FAILED:
+			die("async connection failed");
+		case PGSQL_POLLING_OK:
+			break 2;
+	}
+}
+assert(pg_connection_status($db) === PGSQL_CONNECTION_MADE);
+echo "OK";
+
+pg_close($db);
+
+?>
+--EXPECT--
+OK

--- a/ext/pgsql/tests/30nb_async_query_params.phpt
+++ b/ext/pgsql/tests/30nb_async_query_params.phpt
@@ -1,0 +1,78 @@
+--TEST--
+PostgreSQL non-blocking async query params
+--SKIPIF--
+<?php
+include("skipif.inc");
+if (!function_exists('pg_send_query_params')) die('skip function pg_send_query_params() does not exist');
+?>
+--FILE--
+<?php
+
+include('config.inc');
+include('nonblocking.inc');
+
+$db = pg_connect($conn_str);
+
+$version = pg_version($db);
+if ($version['protocol'] < 3) {
+	echo "OK";
+	exit(0);
+}
+
+$db_socket = pg_socket($db);
+stream_set_blocking($db_socket, false);
+
+$sent = pg_send_query_params($db, "SELECT * FROM ".$table_name." WHERE num > \$1;", array(100));
+if ($sent === FALSE) {
+	echo "pg_send_query_params() error\n";
+} elseif ($sent === 0) {
+	nb_flush($db, $db_socket);
+}
+
+nb_consume($db, $db_socket);
+
+if (!($result = pg_get_result($db))) {
+	echo "pg_get_result() error\n";
+}
+if (!($rows = pg_num_rows($result))) {
+	echo "pg_num_rows() error\n";
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_array($result, $i, PGSQL_NUM);
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_object($result);
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_row($result, $i);
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_result($result, $i, 0);
+}
+
+pg_num_rows(pg_query_params($db, "SELECT * FROM ".$table_name." WHERE num > \$1;", array(100)));
+pg_num_fields(pg_query_params($db, "SELECT * FROM ".$table_name." WHERE num > \$1;", array(100)));
+pg_field_name($result, 0);
+pg_field_num($result, $field_name);
+pg_field_size($result, 0);
+pg_field_type($result, 0);
+pg_field_prtlen($result, 0);
+pg_field_is_null($result, 0);
+
+$sent = pg_send_query_params($db, "INSERT INTO ".$table_name." VALUES (\$1, \$2);", array(9999, "A'BC"));
+
+if ($sent === FALSE) {
+	echo "pg_send_query_params() error\n";
+} elseif ($sent === 0) {
+	nb_flush($db, $db_socket);
+}
+
+pg_last_oid($result);
+pg_free_result($result);
+
+pg_close($db);
+
+echo "OK";
+?>
+--EXPECT--
+OK

--- a/ext/pgsql/tests/31nb_async_query_prepared.phpt
+++ b/ext/pgsql/tests/31nb_async_query_prepared.phpt
@@ -1,0 +1,112 @@
+--TEST--
+PostgreSQL non-blocking async prepared queries
+--SKIPIF--
+<?php
+include("skipif.inc");
+if (!function_exists('pg_send_prepare')) die('skip function pg_send_prepare() does not exist');
+?>
+--FILE--
+<?php
+
+include('config.inc');
+include('nonblocking.inc');
+
+$db = pg_connect($conn_str);
+
+$version = pg_version($db);
+if ($version['protocol'] < 3) {
+	echo "OK";
+	exit(0);
+}
+
+$db_socket = pg_socket($db);
+stream_set_blocking($db_socket, false);
+
+$nb_send =  pg_send_prepare($db, 'php_test', "SELECT * FROM ".$table_name." WHERE num > \$1;");
+if ($nb_send === FALSE) {
+	echo "pg_send_prepare() error\n";
+} elseif ($nb_send === 0) {
+	nb_flush($db, $db_socket);
+}
+
+nb_consume($db, $db_socket);
+
+if (!($result = pg_get_result($db))) {
+	echo "pg_get_result() error\n";
+}
+pg_free_result($result);
+
+$nb_send = pg_send_execute($db, 'php_test', array(100));
+if ($nb_send === FALSE) {
+	echo "pg_send_execute() error\n";
+} elseif ($nb_send === 0) {
+	nb_flush($db, $db_socket);
+}
+
+nb_consume($db, $db_socket);
+
+if (!($result = pg_get_result($db))) {
+	echo "pg_get_result() error\n";
+}
+
+if (!($rows = pg_num_rows($result))) {
+	echo "pg_num_rows() error\n";
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_array($result, $i, PGSQL_NUM);
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_object($result);
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_row($result, $i);
+}
+for ($i=0; $i < $rows; $i++)  {
+	pg_fetch_result($result, $i, 0);
+}
+
+pg_num_rows(pg_query_params($db, "SELECT * FROM ".$table_name." WHERE num > \$1;", array(100)));
+pg_num_fields(pg_query_params($db, "SELECT * FROM ".$table_name." WHERE num > \$1;", array(100)));
+pg_field_name($result, 0);
+pg_field_num($result, $field_name);
+pg_field_size($result, 0);
+pg_field_type($result, 0);
+pg_field_prtlen($result, 0);
+pg_field_is_null($result, 0);
+
+$nb_send = pg_send_prepare($db, "php_test2", "INSERT INTO ".$table_name." VALUES (\$1, \$2);");
+if ($nb_send === FALSE) {
+	echo "pg_send_prepare() error\n";
+} elseif ($nb_send === 0) {
+	nb_flush($db, $db_socket);
+}
+
+nb_consume($db, $db_socket);
+
+if (!($result = pg_get_result($db))) {
+	echo "pg_get_result() error\n";
+}
+pg_free_result($result);
+
+$nb_send = pg_send_execute($db, "php_test2", array(9999, "A'BC"));
+if ($nb_send === FALSE) {
+	echo "pg_send_execute() error\n";
+} elseif ($nb_send === 0) {
+	nb_flush($db, $db_socket);
+}
+
+nb_consume($db, $db_socket);
+
+if (!($result = pg_get_result($db))) {
+	echo "pg_get_result() error\n";
+}
+
+pg_last_oid($result);
+pg_free_result($result);
+pg_close($db);
+
+echo "OK";
+?>
+--EXPECT--
+OK
+

--- a/ext/pgsql/tests/32nb_async_query.phpt
+++ b/ext/pgsql/tests/32nb_async_query.phpt
@@ -1,0 +1,84 @@
+--TEST--
+PostgreSQL non-blocking async queries
+--SKIPIF--
+<?php
+include("skipif.inc");
+if (!function_exists('pg_send_prepare')) die('skip function pg_send_prepare() does not exist');
+?>
+--FILE--
+<?php
+
+include('config.inc');
+include('nonblocking.inc');
+
+$db = pg_connect($conn_str);
+
+$version = pg_version($db);
+if ($version['protocol'] < 3) {
+	echo "OK";
+	exit(0);
+}
+
+$db_socket = pg_socket($db);
+stream_set_blocking($db_socket, false);
+
+$nb_send =  pg_send_query($db, "SELECT * FROM ".$table_name.";");
+if ($nb_send === FALSE) {
+	echo "pg_send_query() error\n";
+} elseif ($nb_send === 0) {
+	nb_flush($db, $db_socket);
+}
+
+nb_consume($db, $db_socket);
+
+if (!($result = pg_get_result($db))) {
+	echo "pg_get_result() error\n";
+}
+
+if (!($rows = pg_num_rows($result))) {
+	echo "pg_num_rows() error\n";
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_array($result, $i, PGSQL_NUM);
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_object($result);
+}
+for ($i=0; $i < $rows; $i++) {
+	pg_fetch_row($result, $i);
+}
+for ($i=0; $i < $rows; $i++)  {
+	pg_fetch_result($result, $i, 0);
+}
+
+pg_num_rows(pg_query($db, "SELECT * FROM ".$table_name.";"));
+pg_num_fields(pg_query($db, "SELECT * FROM ".$table_name.";"));
+pg_field_name($result, 0);
+pg_field_num($result, $field_name);
+pg_field_size($result, 0);
+pg_field_type($result, 0);
+pg_field_prtlen($result, 0);
+pg_field_is_null($result, 0);
+
+$nb_send = pg_send_query($db, "INSERT INTO ".$table_name." VALUES (8888, 'GGG');");
+if ($nb_send === FALSE) {
+	echo "pg_send_query() error\n";
+} elseif ($nb_send === 0) {
+	nb_flush($db, $db_socket);
+}
+
+nb_consume($db, $db_socket);
+
+if (!($result = pg_get_result($db))) {
+	echo "pg_get_result() error\n";
+}
+
+pg_last_oid($result);
+pg_free_result($result);
+pg_close($db);
+
+echo "OK";
+?>
+--EXPECT--
+OK
+

--- a/ext/pgsql/tests/nonblocking.inc
+++ b/ext/pgsql/tests/nonblocking.inc
@@ -1,0 +1,38 @@
+<?php
+
+function nb_is_readable($stream, $timeout = 1) {
+    $r = [$stream]; $w = []; $e = [];
+    return (bool) stream_select($r, $w, $e, $timeout, 0);
+};
+function nb_is_writable($stream, $timeout = 1) {
+    $r = []; $w = [$stream]; $e = [];
+    return (bool) stream_select($r, $w, $e, $timeout, 0);
+};
+function nb_flush($db, $db_socket) {
+    while (TRUE) {
+        if (! nb_is_writable($db_socket)) {
+            continue;
+        }
+        $flush = pg_flush($db);
+        if ($flush === TRUE) {
+            break; // All data flushed
+        } elseif ($flush === FALSE) {
+            echo "pg_flush() error\n";
+            break;
+        }
+    }
+};
+function nb_consume($db, $db_socket) {
+    while (TRUE) {
+        if (!nb_is_readable($db_socket)) {
+            continue;
+        } elseif (!pg_consume_input($db)) {
+            echo "pg_consume_input() error\n";
+            break;
+        } elseif (!pg_connection_busy($db)) {
+            break; // All data consumed
+        }
+
+    }
+};
+


### PR DESCRIPTION
### New functions

Each of the new functions accepts a single `$connection` resource paramter.
- `int pg_connect_poll(resource $connection)`
- `resource pg_socket(resource $connection)`
- `bool pg_consume_input(resource $connection)`
- `mixed pg_flush(resource $connection)`
### Modified functions

The following functions now additionally return zero if the  underlying socket is set to non-blocking mode and the send operation does not complete immediately. Previously these functions returned only boolean values and blocked execution while polling until all data was sent:
- `pg_send_execute`
- `pg_send_prepare`
- `pg_send_query`
- `pg_send_query_params`
### New constants

Used with `pg_connect()` to initiate an asynchronous connection attempt:
- `PGSQL_CONNECT_ASYNC`

Used with `pg_connection_status()` to determine the current state of an async connection attempt:
- `PGSQL_CONNECTION_STARTED`
- `PGSQL_CONNECTION_MADE`
- `PGSQL_CONNECTION_AWAITING_RESPONSE`
- `PGSQL_CONNECTION_AUTH_OK`
- `PGSQL_CONNECTION_SSL_STARTUP`
- `PGSQL_CONNECTION_SETENV`

Used with `pg_connect_poll()` to determine the result of an async connection attempt:
- `PGSQL_POLLING_FAILED`
- `PGSQL_POLLING_READING`
- `PGSQL_POLLING_WRITING`
- `PGSQL_POLLING_OK`
- `PGSQL_POLLING_ACTIVE`
### Polling via returned `pg_socket()` stream

`pg_socket()` returns a read-only socket stream that may be cast to a file descriptor for select (and similar) polling operations. Blocking behavior of the pgsql connection socket can be controlled by calling `stream_set_blocking()` on the stream returned by `pg_socket()`.
### Backwards Compatibility

These changes have no BC ramifications. All existing code continues to work as before.
### Example Async Connect

``` php
<?php
// Initiate async connect
if (!$db = pg_connect($conn_str, PGSQL_CONNECT_ASYNC)) {
    echo "pg_connect() error\n";
} elseif (pg_connection_status($db) === PGSQL_CONNECTION_BAD) {
    echo "pg_connect() error\n";
} elseif ($db_sock = pg_socket($db)) {
    stream_set_blocking($db_sock, FALSE);
} else {
    echo "pg_socket() error\n";
}

// Convenience methods for detecting readability/writability on the connection
$isReadable = function($stream, $timeout = 1) {
    $r = [$stream]; $w = []; $e = [];
    return (bool) stream_select($r, $w, $e, $timeout, 0);
};

$isWritable = function($stream, $timeout = 1) {
    $r = []; $w = [$stream]; $e = [];
    return (bool) stream_select($r, $w, $e, $timeout, 0);
};

// Poll until async connection is established
while (TRUE) {
    switch (pg_connect_poll($db)) {
        case PGSQL_POLLING_READING:
            if ($isReadable($db_sock)) { break 2; }
            break;
        case PGSQL_POLLING_WRITING:
            if ($isWritable($db_sock)) { break 2; }
            break;
        case PGSQL_POLLING_FAILED:
            die("Async connection failed\n");
        case PGSQL_POLLING_OK:
            echo "Async connection established\n";
            break 2;
    }
}
```
### Example Non-Blocking Query + Result

``` php
<?php
// Connect; get pollable socket; set socket to non-blocking.
$db = pg_connect($conn_str);
$db_sock = pg_socket($db);
stream_set_blocking($db_sock, FALSE);

// Send query
$sendCompleted = pg_send_query($db, "SELECT * FROM ".$table_name.";");

// Manually flush send buffer if necessary.
if ($sendCompleted === TRUE) {
    echo "pg_send_query() complete\n";
} elseif ($sendCompleted === FALSE) {
    die("pg_send_query() error");
} elseif ($sendCompleted === 0) {
    // flush all remaining data
    while (TRUE) {
        $r = []; $w = [$db_sock]; $e = [];
        if (!stream_select($r, $w, $e, $sec=42, $usec=0)) {
            continue;
        }
        $flushCompleted = pg_flush($db);
        if ($flushCompleted === TRUE) {
            echo "All outbound data flushed\n";
            break;
        } elseif ($flushCompleted === 0) {
            echo "More data to send\n";
        } elseif ($flushCompleted === FALSE) {
            die("Flush failed");
        }
    }
}

// Poll for readability and consume the result
while (TRUE) {
    $r = [$db_sock]; $w = []; $e = [];
    if (!stream_select($r, $w, $e, $sec=42, $usec=0)) {
        continue;
    } elseif (!pg_consume_input($db)) {
        die("pg_consume_input() error");
    } elseif (!pg_connection_busy($db)) {
        echo "All inbound data consumed!\n";
        break;
    }
}

// We've now consumed the full result
$result = pg_get_result($db);
```
