### PR TITLE
Update pdo_odbc to use SQLLEN where appropriate

### DIFF
--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -279,7 +279,7 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 	pdo_odbc_stmt *S = (pdo_odbc_stmt*)stmt->driver_data;
 	RETCODE rc;
 	SWORD sqltype = 0, ctype = 0, scale = 0, nullable = 0;
-	UDWORD precision = 0;
+	SQLULEN precision = 0;
 	pdo_odbc_param *P;
 	
 	/* we're only interested in parameters for prepared SQL right now */
@@ -551,7 +551,7 @@ static int odbc_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC)
 	struct pdo_column_data *col = &stmt->columns[colno];
 	RETCODE rc;
 	SWORD	colnamelen;
-	SDWORD	colsize;
+	SQLULEN	colsize;
 	SQLLEN displaysize;
 
 	rc = SQLDescribeCol(S->stmt, colno+1, S->cols[colno].colname,

--- a/ext/pdo_odbc/php_pdo_odbc_int.h
+++ b/ext/pdo_odbc/php_pdo_odbc_int.h
@@ -135,7 +135,7 @@ typedef struct {
 
 typedef struct {
 	char *data;
-	unsigned long datalen;
+	SQLLEN datalen;
 	SQLLEN fetched_len;
 	SWORD	coltype;
 	char colname[128];
@@ -157,7 +157,7 @@ typedef struct {
 } pdo_odbc_stmt;
 
 typedef struct {
-	SQLINTEGER len;
+	SQLLEN len;
 	SQLSMALLINT paramtype;
 	char *outbuf;
 	unsigned is_unicode:1;


### PR DESCRIPTION
Many ODBC APIs were changed to use SQLLEN instead of SQLINTEGER. This
has the benefit of allowing 64-bit parameters on 64-bit platforms, but
causes problems if your application is not updated to use these 64-bit
types. If you pass a pointer to the wrong size variable, you will get
unpredictible results.as the driver will read or write to random memory.

For more information, see
http://msdn.microsoft.com/en-us/library/windows/desktop/ms716287%28v=vs.85%29.aspx

This was changed in Windows Server 2003 on Windows and in unixODBC
2.2.14, which was released in November 2008. It's about time it was
fixed in pdo_odbc.