### PR TITLE
Optimize hash bucket data storage

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1776,14 +1776,14 @@ static void zend_sort_modules(void *base, size_t count, size_t siz, compare_func
 
 	while (b1 < end) {
 try_again:
-		m = (zend_module_entry*)(*b1)->pData;
+		m = (zend_module_entry*) zend_bucket_data(*b1);
 		if (!m->module_started && m->deps) {
 			const zend_module_dep *dep = m->deps;
 			while (dep->name) {
 				if (dep->type == MODULE_DEP_REQUIRED || dep->type == MODULE_DEP_OPTIONAL) {
 					b2 = b1 + 1;
 					while (b2 < end) {
-						r = (zend_module_entry*)(*b2)->pData;
+						r = (zend_module_entry*) zend_bucket_data(*b2);
 						if (strcasecmp(dep->name, r->name) == 0) {
 							tmp = *b1;
 							*b1 = *b2;

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -640,17 +640,17 @@ ZEND_API int zval_update_constant_ex(zval **pp, void *arg, zend_class_entry *sco
 
 			switch (Z_TYPE(const_value)) {
 				case IS_STRING:
-					ret = zend_symtable_update_current_key(Z_ARRVAL_P(p), Z_STRVAL(const_value), Z_STRLEN(const_value) + 1, HASH_UPDATE_KEY_IF_BEFORE);
+					ret = zend_symtable_update_current_key(Z_ARRVAL_P(p), Z_STRVAL(const_value), Z_STRLEN(const_value) + 1, sizeof(zval *), HASH_UPDATE_KEY_IF_BEFORE);
 					break;
 				case IS_BOOL:
 				case IS_LONG:
-					ret = zend_hash_update_current_key_ex(Z_ARRVAL_P(p), HASH_KEY_IS_LONG, NULL, 0, Z_LVAL(const_value), HASH_UPDATE_KEY_IF_BEFORE, NULL);
+					ret = zend_hash_update_current_key_ex(Z_ARRVAL_P(p), HASH_KEY_IS_LONG, NULL, 0, Z_LVAL(const_value), sizeof(zval *), HASH_UPDATE_KEY_IF_BEFORE, NULL);
 					break;
 				case IS_DOUBLE:
-					ret = zend_hash_update_current_key_ex(Z_ARRVAL_P(p), HASH_KEY_IS_LONG, NULL, 0, zend_dval_to_lval(Z_DVAL(const_value)), HASH_UPDATE_KEY_IF_BEFORE, NULL);
+					ret = zend_hash_update_current_key_ex(Z_ARRVAL_P(p), HASH_KEY_IS_LONG, NULL, 0, zend_dval_to_lval(Z_DVAL(const_value)), sizeof(zval *), HASH_UPDATE_KEY_IF_BEFORE, NULL);
 					break;
 				case IS_NULL:
-					ret = zend_hash_update_current_key_ex(Z_ARRVAL_P(p), HASH_KEY_IS_STRING, "", 1, 0, HASH_UPDATE_KEY_IF_BEFORE, NULL);
+					ret = zend_hash_update_current_key_ex(Z_ARRVAL_P(p), HASH_KEY_IS_STRING, "", 1, 0, sizeof(zval *), HASH_UPDATE_KEY_IF_BEFORE, NULL);
 					break;
 				default:
 					ret = SUCCESS;

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -315,7 +315,7 @@ tail_call:
 		}
 	}
 	while (p != NULL) {
-		pz = *(zval**)p->pData;
+		pz = *(zval**) zend_bucket_data(p);
 		if (Z_TYPE_P(pz) != IS_ARRAY || Z_ARRVAL_P(pz) != &EG(symbol_table)) {
 			pz->refcount__gc++;
 		}
@@ -358,7 +358,7 @@ static void zobj_scan_black(struct _store_object *obj, zval *pz TSRMLS_DC)
 		}
 		p = props->pListHead;
 		while (p != NULL) {
-			pz = *(zval**)p->pData;
+			pz = *(zval**) zend_bucket_data(p);
 			if (Z_TYPE_P(pz) != IS_ARRAY || Z_ARRVAL_P(pz) != &EG(symbol_table)) {
 				pz->refcount__gc++;
 			}
@@ -422,7 +422,7 @@ tail_call:
 			}
 		}
 		while (p != NULL) {
-			pz = *(zval**)p->pData;
+			pz = *(zval**) zend_bucket_data(p);
 			if (Z_TYPE_P(pz) != IS_ARRAY || Z_ARRVAL_P(pz) != &EG(symbol_table)) {
 				pz->refcount__gc--;
 			}
@@ -464,7 +464,7 @@ static void zobj_mark_grey(struct _store_object *obj, zval *pz TSRMLS_DC)
 			}
 			p = props->pListHead;
 			while (p != NULL) {
-				pz = *(zval**)p->pData;
+				pz = *(zval**) zend_bucket_data(p);
 				if (Z_TYPE_P(pz) != IS_ARRAY || Z_ARRVAL_P(pz) != &EG(symbol_table)) {
 					pz->refcount__gc--;
 				}
@@ -562,10 +562,10 @@ tail_call:
 		}
 		while (p != NULL) {
 			if (p->pListNext == NULL) {
-				pz = *(zval**)p->pData;
+				pz = *(zval**) zend_bucket_data(p);
 				goto tail_call;
 			} else {
-				zval_scan(*(zval**)p->pData TSRMLS_CC);
+				zval_scan(*(zval**) zend_bucket_data(p) TSRMLS_CC);
 			}
 			p = p->pListNext;
 		}
@@ -602,7 +602,7 @@ static void zobj_scan(zval *pz TSRMLS_DC)
 					}
 					p = props->pListHead;
 					while (p != NULL) {
-						zval_scan(*(zval**)p->pData TSRMLS_CC);
+						zval_scan(*(zval**) zend_bucket_data(p) TSRMLS_CC);
 						p = p->pListNext;
 					}
 				}
@@ -693,7 +693,7 @@ tail_call:
 		GC_G(zval_to_free) = (zval_gc_info*)pz;
 
 		while (p != NULL) {
-			pz = *(zval**)p->pData;
+			pz = *(zval**) zend_bucket_data(p);
 			if (Z_TYPE_P(pz) != IS_ARRAY || Z_ARRVAL_P(pz) != &EG(symbol_table)) {
 				pz->refcount__gc++;
 			}
@@ -739,7 +739,7 @@ static void zobj_collect_white(zval *pz TSRMLS_DC)
 				}
 				p = props->pListHead;
 				while (p != NULL) {
-					pz = *(zval**)p->pData;
+					pz = *(zval**) zend_bucket_data(p);
 					if (Z_TYPE_P(pz) != IS_ARRAY || Z_ARRVAL_P(pz) != &EG(symbol_table)) {
 						pz->refcount__gc++;
 					}

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -127,8 +127,6 @@ static const char *zend_new_interned_string_int(const char *arKey, int nKeyLengt
 	}
 	p->nKeyLength = nKeyLength;
 	p->h = h;
-	p->pData = &p->pDataPtr;
-	p->pDataPtr = p;
 	
 	p->pNext = CG(interned_strings).arBuckets[nIndex];
 	p->pLast = NULL;

--- a/ext/ereg/ereg.c
+++ b/ext/ereg/ereg.c
@@ -105,14 +105,12 @@ ZEND_GET_MODULE(ereg)
 /* {{{ ereg_lru_cmp */
 static int ereg_lru_cmp(const void *a, const void *b TSRMLS_DC)
 {
-	Bucket *f = *((Bucket **) a);
-	Bucket *s = *((Bucket **) b);
+	reg_cache *f = zend_bucket_data(*(Bucket **) a);
+	reg_cache *s = zend_bucket_data(*(Bucket **) b);
 
-	if (((reg_cache *)f->pData)->lastuse <
-				((reg_cache *)s->pData)->lastuse) {
+	if (f->lastuse < s->lastuse) {
 		return -1;
-	} else if (((reg_cache *)f->pData)->lastuse ==
-				((reg_cache *)s->pData)->lastuse) {
+	} else if (f->lastuse == s->lastuse) {
 		return 0;
 	} else {
 		return 1;

--- a/ext/intl/collator/collator_sort.c
+++ b/ext/intl/collator/collator_sort.c
@@ -209,17 +209,9 @@ static int collator_icu_compare_function(zval *result, zval *op1, zval *op2 TSRM
  */
 static int collator_compare_func( const void* a, const void* b TSRMLS_DC )
 {
-	Bucket *f;
-	Bucket *s;
 	zval result;
-	zval *first;
-	zval *second;
-
-	f = *((Bucket **) a);
-	s = *((Bucket **) b);
-
-	first = *((zval **) f->pData);
-	second = *((zval **) s->pData);
+	zval *first = *(zval **) zend_bucket_data(*(Bucket **) a);
+	zval *second = *(zval **) zend_bucket_data(*(Bucket **) b);
 
 	if( INTL_G(compare_func)( &result, first, second TSRMLS_CC) == FAILURE )
 		return 0;

--- a/ext/mysql/php_mysql.c
+++ b/ext/mysql/php_mysql.c
@@ -2173,19 +2173,12 @@ static void php_mysql_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, long result_type,
 			fci.symbol_table = NULL;
 			fci.object_ptr = return_value;
 			fci.retval_ptr_ptr = &retval_ptr;
-			if (ctor_params && Z_TYPE_P(ctor_params) != IS_NULL) {
-				if (Z_TYPE_P(ctor_params) == IS_ARRAY) {
-					HashTable *htl = Z_ARRVAL_P(ctor_params);
-					Bucket *p;
+			fci.params = NULL;
+			fci.param_count = 0;
+			fci.no_separation = 1;
 
-					fci.param_count = 0;
-					fci.params = safe_emalloc(sizeof(zval*), htl->nNumOfElements, 0);
-					p = htl->pListHead;
-					while (p != NULL) {
-						fci.params[fci.param_count++] = (zval**)p->pData;
-						p = p->pListNext;
-					}
-				} else {
+			if (ctor_params && Z_TYPE_P(ctor_params) != IS_NULL) {
+				if (zend_fcall_info_args(&fci, ctor_params TSRMLS_CC) == FAILURE) {
 					/* Two problems why we throw exceptions here: PHP is typeless
 					 * and hence passing one argument that's not an array could be
 					 * by mistake and the other way round is possible, too. The
@@ -2195,11 +2188,7 @@ static void php_mysql_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, long result_type,
 					zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Parameter ctor_params must be an array", 0 TSRMLS_CC);
 					return;
 				}
-			} else {
-				fci.param_count = 0;
-				fci.params = NULL;
 			}
-			fci.no_separation = 1;
 
 			fcc.initialized = 1;
 			fcc.function_handler = ce->constructor;

--- a/ext/mysqlnd/mysqlnd_plugin.c
+++ b/ext/mysqlnd/mysqlnd_plugin.c
@@ -177,7 +177,7 @@ PHPAPI void _mysqlnd_plugin_apply_with_argument(apply_func_arg_t apply_func, voi
 
 	p = mysqlnd_registered_plugins.pListHead;
 	while (p != NULL) {
-		int result = apply_func(p->pData, argument TSRMLS_CC);
+		int result = apply_func(zend_bucket_data(p), argument TSRMLS_CC);
 
 		if (result & ZEND_HASH_APPLY_REMOVE) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "mysqlnd_plugin_apply_with_argument must not remove table entries");

--- a/ext/mysqlnd/mysqlnd_reverse_api.c
+++ b/ext/mysqlnd/mysqlnd_reverse_api.c
@@ -61,7 +61,7 @@ PHPAPI void
 mysqlnd_reverse_api_register_api(MYSQLND_REVERSE_API * apiext TSRMLS_DC)
 {
 	zend_hash_add(&mysqlnd_api_ext_ht, apiext->module->name, strlen(apiext->module->name) + 1, &apiext,
-				  sizeof(MYSQLND_REVERSE_API), NULL);
+				  sizeof(MYSQLND_REVERSE_API *), NULL);
 }
 /* }}} */
 

--- a/ext/mysqlnd/php_mysqlnd.c
+++ b/ext/mysqlnd/php_mysqlnd.c
@@ -107,17 +107,17 @@ static void
 mysqlnd_minfo_dump_api_plugins(smart_str * buffer TSRMLS_DC)
 {
 	HashTable *ht = mysqlnd_reverse_api_get_api_list(TSRMLS_C);
-	Bucket *p;
+	HashPosition pos;
+	MYSQLND_REVERSE_API **ext;
 
-	p = ht->pListHead;
-	while(p != NULL) {
-		MYSQLND_REVERSE_API * ext = *(MYSQLND_REVERSE_API **) p->pData;
+	for (zend_hash_internal_pointer_reset_ex(ht, &pos);
+	     zend_hash_get_current_data_ex(ht, (void **) &ext, &pos);
+	     zend_hash_move_forward_ex(ht, &pos)
+	) {
 		if (buffer->len) {
 			smart_str_appendc(buffer, ',');
 		}
-		smart_str_appends(buffer, ext->module->name);
-
-		p = p->pListNext;
+		smart_str_appends(buffer, (*ext)->module->name);
 	}
 }
 /* }}} */

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -551,17 +551,17 @@ int zend_accel_script_optimize(zend_persistent_script *script TSRMLS_DC)
 
 	p = script->function_table.pListHead;
 	while (p) {
-		zend_op_array *op_array = (zend_op_array*)p->pData;
+		zend_op_array *op_array = (zend_op_array*) zend_bucket_data(p);
 		zend_accel_optimize(op_array, script, &constants TSRMLS_CC);
 		p = p->pListNext;
 	}
 
 	p = script->class_table.pListHead;
 	while (p) {
-		zend_class_entry *ce = (zend_class_entry*)p->pDataPtr;
+		zend_class_entry *ce = *(zend_class_entry**) zend_bucket_data(p);
 		q = ce->function_table.pListHead;
 		while (q) {
-			zend_op_array *op_array = (zend_op_array*)q->pData;
+			zend_op_array *op_array = (zend_op_array*) zend_bucket_data(q);
 			if (op_array->scope == ce) {
 				zend_accel_optimize(op_array, script, &constants TSRMLS_CC);
 			} else if (op_array->type == ZEND_USER_FUNCTION) {

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -397,4 +397,8 @@ const char *accel_new_interned_string(const char *arKey, int nKeyLength, int fre
 # define ZEND_CE_DOC_COMMENT_LEN(ce)	(ce)->doc_comment_len
 #endif
 
+#if ZEND_EXTENSION_API_NO <= PHP_5_5_X_API_NO
+# define zend_bucket_data(bucket) (bucket->pData)
+#endif
+
 #endif /* ZEND_ACCELERATOR_H */

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -468,22 +468,10 @@ static void pdo_stmt_construct(pdo_stmt_t *stmt, zval *object, zend_class_entry 
 		fci.object_ptr = object;
 		fci.symbol_table = NULL;
 		fci.retval_ptr_ptr = &retval;
-		if (ctor_args) {
-			HashTable *ht = Z_ARRVAL_P(ctor_args);
-			Bucket *p;
-
-			fci.param_count = 0;
-			fci.params = safe_emalloc(sizeof(zval*), ht->nNumOfElements, 0);
-			p = ht->pListHead;
-			while (p != NULL) {
-				fci.params[fci.param_count++] = (zval**)p->pData;
-				p = p->pListNext;
-			}
-		} else {
-			fci.param_count = 0;
-			fci.params = NULL;
-		}
+		fci.params = NULL;
 		fci.no_separation = 1;
+
+		zend_fcall_info_args(&fci, ctor_args TSRMLS_CC);
 
 		fcc.initialized = 1;
 		fcc.function_handler = dbstmt_ce->constructor;

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -757,22 +757,10 @@ static int do_fetch_class_prepare(pdo_stmt_t *stmt TSRMLS_DC) /* {{{ */
 		fci->function_name = NULL;
 		fci->symbol_table = NULL;
 		fci->retval_ptr_ptr = &stmt->fetch.cls.retval_ptr;
-		if (stmt->fetch.cls.ctor_args) {
-			HashTable *ht = Z_ARRVAL_P(stmt->fetch.cls.ctor_args);
-			Bucket *p;
-
-			fci->param_count = 0;
-			fci->params = safe_emalloc(sizeof(zval**), ht->nNumOfElements, 0);
-			p = ht->pListHead;
-			while (p != NULL) {
-				fci->params[fci->param_count++] = (zval**)p->pData;
-				p = p->pListNext;
-			}
-		} else {
-			fci->param_count = 0;
-			fci->params = NULL;
-		}
+		fci->params = NULL;
 		fci->no_separation = 1;
+
+		zend_fcall_info_args(fci, stmt->fetch.cls.ctor_args TSRMLS_CC);
 
 		fcc->initialized = 1;
 		fcc->function_handler = ce->constructor;

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -2793,33 +2793,22 @@ static void php_pgsql_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, long result_type,
 			fci.symbol_table = NULL;
 			fci.object_ptr = return_value;
 			fci.retval_ptr_ptr = &retval_ptr;
-			if (ctor_params && Z_TYPE_P(ctor_params) != IS_NULL) {
-				if (Z_TYPE_P(ctor_params) == IS_ARRAY) {
-					HashTable *ht = Z_ARRVAL_P(ctor_params);
-					Bucket *p;
+			fci.params = NULL;
+			fci.param_count = 0;
+			fci.no_separation = 1;
 
-					fci.param_count = 0;
-					fci.params = safe_emalloc(sizeof(zval***), ht->nNumOfElements, 0);
-					p = ht->pListHead;
-					while (p != NULL) {
-						fci.params[fci.param_count++] = (zval**)p->pData;
-						p = p->pListNext;
-					}
-				} else {
+			if (ctor_params && Z_TYPE_P(ctor_params) != IS_NULL) {
+				if (zend_fcall_info_args(&fci, ctor_params TSRMLS_CC) == FAILURE) {
 					/* Two problems why we throw exceptions here: PHP is typeless
 					 * and hence passing one argument that's not an array could be
-					 * by mistake and the other way round is possible, too. The 
+					 * by mistake and the other way round is possible, too. The
 					 * single value is an array. Also we'd have to make that one
 					 * argument passed by reference.
 					 */
 					zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Parameter ctor_params must be an array", 0 TSRMLS_CC);
 					return;
 				}
-			} else {
-				fci.param_count = 0;
-				fci.params = NULL;
 			}
-			fci.no_separation = 1;
 
 			fcc.initialized = 1;
 			fcc.function_handler = ce->constructor;

--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -930,7 +930,7 @@ static int phar_wrapper_rename(php_stream_wrapper *wrapper, const char *url_from
 				entry->filename = new_str_key;
 				entry->filename_len = new_key_len;
 
-				zend_hash_update_current_key_ex(&phar->manifest, key_type, new_str_key, new_key_len, 0, HASH_UPDATE_KEY_ANYWAY, NULL);
+				zend_hash_update_current_key_ex(&phar->manifest, key_type, new_str_key, new_key_len, 0, sizeof(phar_entry_info), HASH_UPDATE_KEY_ANYWAY, NULL);
 			}
 		}
 
@@ -948,7 +948,7 @@ static int phar_wrapper_rename(php_stream_wrapper *wrapper, const char *url_from
 				memcpy(new_str_key + to_len, str_key + from_len, key_len - from_len);
 				new_str_key[new_key_len] = 0;
 
-				zend_hash_update_current_key_ex(&phar->virtual_dirs, key_type, new_str_key, new_key_len, 0, HASH_UPDATE_KEY_ANYWAY, NULL);
+				zend_hash_update_current_key_ex(&phar->virtual_dirs, key_type, new_str_key, new_key_len, sizeof(void *), 0, HASH_UPDATE_KEY_ANYWAY, NULL);
 				efree(new_str_key);
 			}
 		}
@@ -968,7 +968,7 @@ static int phar_wrapper_rename(php_stream_wrapper *wrapper, const char *url_from
 				memcpy(new_str_key + to_len, str_key + from_len, key_len - from_len);
 				new_str_key[new_key_len] = 0;
 
-				zend_hash_update_current_key_ex(&phar->mounted_dirs, key_type, new_str_key, new_key_len, 0, HASH_UPDATE_KEY_ANYWAY, NULL);
+				zend_hash_update_current_key_ex(&phar->mounted_dirs, key_type, new_str_key, new_key_len, 0, sizeof(void *), HASH_UPDATE_KEY_ANYWAY, NULL);
 				efree(new_str_key);
 			}
 		}

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2232,7 +2232,7 @@ static int spl_filesystem_file_is_empty_line(spl_filesystem_object *intern TSRML
 		case IS_ARRAY:
 			if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_READ_CSV)
 			&& zend_hash_num_elements(Z_ARRVAL_P(intern->u.file.current_zval)) == 1) {
-				zval ** first = Z_ARRVAL_P(intern->u.file.current_zval)->pListHead->pData;
+				zval ** first = zend_bucket_data(Z_ARRVAL_P(intern->u.file.current_zval)->pListHead);
 					
 				return Z_TYPE_PP(first) == IS_STRING && Z_STRLEN_PP(first) == 0;
 			}

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -648,11 +648,10 @@ PHPAPI void php_print_info_htmlhead(TSRMLS_D)
 /* {{{ module_name_cmp */
 static int module_name_cmp(const void *a, const void *b TSRMLS_DC)
 {
-	Bucket *f = *((Bucket **) a);
-	Bucket *s = *((Bucket **) b);
+	zend_module_entry *f = zend_bucket_data(*(Bucket **) a);
+	zend_module_entry *s = zend_bucket_data(*(Bucket **) b);
 
-	return strcasecmp(((zend_module_entry *)f->pData)->name,
-				  ((zend_module_entry *)s->pData)->name);
+	return strcasecmp(f->name, s->name);
 }
 /* }}} */
 

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -223,11 +223,10 @@ static int print_module_info(zend_module_entry *module, void *arg TSRMLS_DC)
 
 static int module_name_cmp(const void *a, const void *b TSRMLS_DC)
 {
-	Bucket *f = *((Bucket **) a);
-	Bucket *s = *((Bucket **) b);
+	zend_module_entry *f = zend_bucket_data(*(Bucket **) a);
+	zend_module_entry *s = zend_bucket_data(*(Bucket **) b);
 
-	return strcasecmp(	((zend_module_entry *)f->pData)->name,
-						((zend_module_entry *)s->pData)->name);
+	return strcasecmp(f->name, s->name);
 }
 
 static void print_modules(TSRMLS_D)

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -182,11 +182,10 @@ static int print_module_info(zend_module_entry *module TSRMLS_DC) /* {{{ */
 
 static int module_name_cmp(const void *a, const void *b TSRMLS_DC) /* {{{ */
 {
-	Bucket *f = *((Bucket **) a);
-	Bucket *s = *((Bucket **) b);
+	zend_module_entry *f = zend_bucket_data(*(Bucket **) a);
+	zend_module_entry *s = zend_bucket_data(*(Bucket **) b);
 
-	return strcasecmp(((zend_module_entry *)f->pData)->name,
-				  ((zend_module_entry *)s->pData)->name);
+	return strcasecmp(f->name, s->name);
 }
 /* }}} */
 


### PR DESCRIPTION
Old behavior: Hash bucket data pointer is stored in pData and the
actual data is stored either in pDataPtr (for pointer types) or
a separate allocation.

New behavior: Hash bucket data is appended to the bucket struct.
The bucket data pointer thus implicitly becomes
(void *) ((char *) Bucket + sizeof(Bucket)).

Memory impact: In every case the memory needed for the pData poitner
is saved. For non-pointer types the pDataPtr and allocation overhead
is saved additionally. In numbers:
- 32bit / ptr :  4 bytes (per bucket)
- 32bit / data: 16 bytes (per bucket)
- 64bit / ptr :  8 bytes (per bucket)
- 64bit / data: 32 bytes (per bucket)

Limitations: It is no longer possible to store variable length data
in a hashtable. This feature was never actually used in PHP.

API changes:
- zend_(hash|symtable)_update_current_key(_ex) now take an
  additional nDataSize element. This is necessary because the
  potential bucket reallocation needs to know the data size.
- External code making direct use of the Bucket structure must use
  zend_bucket_data(Bucket *) instead of directly accessing the
  pData member of the bucket. This mostly impacts custom comparison
  functions for zend_hash_sort, as that is the only place where
  well-behaving code is forced to directly operate on buckets.
