### PR TITLE
user-defined comparison callback can return floats (test included)

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -592,12 +592,12 @@ static int php_array_user_compare(const void *a, const void *b TSRMLS_DC) /* {{{
 	BG(user_compare_fci).retval_ptr_ptr = &retval_ptr;
 	BG(user_compare_fci).no_separation = 0;
 	if (zend_call_function(&BG(user_compare_fci), &BG(user_compare_fci_cache) TSRMLS_CC) == SUCCESS && retval_ptr) {
-		long retval;
+		double retval;
 
-		convert_to_long_ex(&retval_ptr);
-		retval = Z_LVAL_P(retval_ptr);
+		convert_to_double_ex(&retval_ptr);
+		retval = Z_DVAL_P(retval_ptr);
 		zval_ptr_dtor(&retval_ptr);
-		return retval < 0 ? -1 : retval > 0 ? 1 : 0;
+		return retval < 0.0 ? -1 : retval > 0.0 ? 1 : 0;
 	} else {
 		return 0;
 	}

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -592,18 +592,19 @@ static int php_array_user_compare(const void *a, const void *b TSRMLS_DC) /* {{{
 	BG(user_compare_fci).retval_ptr_ptr = &retval_ptr;
 	BG(user_compare_fci).no_separation = 0;
 	if (zend_call_function(&BG(user_compare_fci), &BG(user_compare_fci_cache) TSRMLS_CC) == SUCCESS && retval_ptr) {
-		long long_retval;
-		double double_retval;
-		
 		if (Z_TYPE_P(retval_ptr) == IS_DOUBLE) {
-			double_retval = Z_DVAL_P(retval_ptr);
+			double dretval;
+
+			dretval = Z_DVAL_P(retval_ptr);
 			zval_ptr_dtor(&retval_ptr);
-			return double_retval < 0.0 ? -1 : double_retval > 0.0 ? 1 : 0;
+			return dretval < 0.0 ? -1 : dretval > 0.0 ? 1 : 0;
 		} else {
+			long lretval;
+
 			convert_to_long_ex(&retval_ptr);
-			long_retval = Z_LVAL_P(retval_ptr);
+			lretval = Z_LVAL_P(retval_ptr);
 			zval_ptr_dtor(&retval_ptr);
-			return long_retval < 0 ? -1 : long_retval > 0 ? 1 : 0;
+			return lretval < 0 ? -1 : lretval > 0 ? 1 : 0;
 		}
 	} else {
 		return 0;

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -592,12 +592,19 @@ static int php_array_user_compare(const void *a, const void *b TSRMLS_DC) /* {{{
 	BG(user_compare_fci).retval_ptr_ptr = &retval_ptr;
 	BG(user_compare_fci).no_separation = 0;
 	if (zend_call_function(&BG(user_compare_fci), &BG(user_compare_fci_cache) TSRMLS_CC) == SUCCESS && retval_ptr) {
-		double retval;
-
-		convert_to_double_ex(&retval_ptr);
-		retval = Z_DVAL_P(retval_ptr);
-		zval_ptr_dtor(&retval_ptr);
-		return retval < 0.0 ? -1 : retval > 0.0 ? 1 : 0;
+		long long_retval;
+		double double_retval;
+		
+		if (Z_TYPE_P(retval_ptr) == IS_DOUBLE) {
+			double_retval = Z_DVAL_P(retval_ptr);
+			zval_ptr_dtor(&retval_ptr);
+			return double_retval < 0.0 ? -1 : double_retval > 0.0 ? 1 : 0;
+		} else {
+			convert_to_long_ex(&retval_ptr);
+			long_retval = Z_LVAL_P(retval_ptr);
+			zval_ptr_dtor(&retval_ptr);
+			return long_retval < 0 ? -1 : long_retval > 0 ? 1 : 0;
+		}
 	} else {
 		return 0;
 	}

--- a/tests/basic/usort_float.phpt
+++ b/tests/basic/usort_float.phpt
@@ -1,0 +1,52 @@
+--TEST--
+usort tests
+--FILE--
+<?php
+
+$a = [5, 8, 3, 6, 7, 32, 0];
+$cb = function ($a, $b) { return $a - $b; };
+
+usort($a, $cb);
+
+var_dump($a);
+
+$a = [.1, .5, .9, 1.0, 1, -1, -0.5];
+
+usort($a, $cb);
+
+var_dump($a);
+
+?>
+--EXPECT--
+array(7) {
+  [0]=>
+  int(0)
+  [1]=>
+  int(3)
+  [2]=>
+  int(5)
+  [3]=>
+  int(6)
+  [4]=>
+  int(7)
+  [5]=>
+  int(8)
+  [6]=>
+  int(32)
+}
+array(7) {
+  [0]=>
+  int(-1)
+  [1]=>
+  float(-0.5)
+  [2]=>
+  float(0.1)
+  [3]=>
+  float(0.5)
+  [4]=>
+  float(0.9)
+  [5]=>
+  float(1)
+  [6]=>
+  int(1)
+}


### PR DESCRIPTION
I think we could make it possible to return floats from user-defined comparison callbacks. Here's the PR which adds this feature.