### PR TITLE
fix apr_psprintf format string from e0df4e3dba7c4ab92442b9e82c1de01fdbaa...

### DIFF
--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -669,7 +669,7 @@ zend_first_try {
 		}
 
 		apr_table_set(r->notes, "mod_php_memory_usage",
-			apr_psprintf(ctx->r->pool, "%zu", zend_memory_peak_usage(1 TSRMLS_CC)));
+			apr_psprintf(ctx->r->pool, "%" APR_SIZE_T_FMT, zend_memory_peak_usage(1 TSRMLS_CC)));
 	}
 
 } zend_end_try();


### PR DESCRIPTION
...3cce

This resolves the issue first reported to APR in https://issues.apache.org/bugzilla/show_bug.cgi?id=56120.
(APR doesn't currently support the "z" prefix, though we are keeping that issue open as an enhancement request.)
