### PR TITLE
These links to ~helly don't work anymore.

### DIFF
--- a/ext/spl/README
+++ b/ext/spl/README
@@ -4,4 +4,4 @@ code in the file spl.php or in the corresponding .inc file in the examples
 subdirectory. Based on the internal implementations or the files in the 
 examples subdirectory there are also some .php files to experiment with.
 
-For more information look at: http://php.net/~helly/php/ext/spl
+For more information look at: http://php.net/manual/en/book.spl.php

--- a/ext/spl/spl.php
+++ b/ext/spl/spl.php
@@ -145,9 +145,6 @@
  * - Debug session 2 <a href="http://talks.somabo.de/200509_toronto_iterator_debug_session_1.pps">[pps]</a>, <a href="http://talks.somabo.de/200509_toronto_iterator_debug_session_1.pdf">[pdf]</a>, <a href="http://taks.somabo.de/200411_php_conference_frankfrurt_iterator_debug_session.swf">[swf]</a>
  * - Debug session 3 <a href="http://talks.somabo.de/200509_toronto_iterator_debug_session_2.pps">[pps]</a>, <a href="http://talks.somabo.de/200509_toronto_iterator_debug_session_2.pdf">[pdf]</a>
  *
- * You can download this documentation as a chm file
- * <a href="http://php.net/~helly/php/ext/spl/spl.chm">here</a>.
- *
  * (c) Marcus Boerger, 2003 - 2007
  */
 


### PR DESCRIPTION
I couldn't find CHM information for the SPL so I just removed those links instead of updating them.
