### PR TITLE
Fixed test case for 5328d42

### DIFF
--- a/Zend/tests/generators/errors/serialize_unserialize_error.phpt
+++ b/Zend/tests/generators/errors/serialize_unserialize_error.phpt
@@ -34,9 +34,8 @@ Stack trace:
 
 exception 'Exception' with message 'Unserialization of 'Generator' is not allowed' in %s:%d
 Stack trace:
-#0 [internal function]: Generator->__wakeup()
-#1 %s(%d): unserialize('O:9:"Generator"...')
-#2 {main}
+#0 %s(%d): unserialize('O:9:"Generator"...')
+#1 {main}
 
 exception 'Exception' with message 'Unserialization of 'Generator' is not allowed' in %s:%d
 Stack trace:


### PR DESCRIPTION
The fix for #67072 (5.4) caused a test case from 5.5 onwards to fail.

This PR aims to fix that by updating the respective test case.
