### PR TITLE
Make DateInterval::createFromDateString() throw an exception on invalid date strings

### DIFF
--- a/ext/date/tests/bug50020.phpt
+++ b/ext/date/tests/bug50020.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #50020
+--INI--
+date.timezone=GMT
+--FILE--
+<?php
+
+try {
+	$i = DateInterval::createFromDateString('P1D');
+} catch (Exception $e) {
+	var_dump($e->getMessage());
+}
+?>
+--EXPECTF--
+string(%d) "DateInterval::createFromDateString(): Failed to parse time string (P1D) at position 1 (1): Unexpected character"


### PR DESCRIPTION
This addresses [feature request 50020](https://bugs.php.net/bug.php?id=50020).

It throws an exception if `DateInterval::createFromDateString()` is given an invalid time string.
