### PR TITLE
Improved logarithm of base 2 and 10 of standard math functions

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -337,7 +337,7 @@ fi
 dnl
 dnl Check for available functions
 dnl
-AC_CHECK_FUNCS(getcwd getwd asinh acosh atanh log1p hypot glob strfmon nice fpclass isinf isnan mempcpy strpncpy)
+AC_CHECK_FUNCS(getcwd getwd asinh acosh atanh log1p log2 hypot glob strfmon nice fpclass isinf isnan mempcpy strpncpy)
 AC_FUNC_FNMATCH	
 
 dnl

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -697,22 +697,35 @@ PHP_FUNCTION(log1p)
 PHP_FUNCTION(log)
 {
 	double num, base = 0;
-	
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d|d", &num, &base) == FAILURE) {
 		return;
 	}
+
 	if (ZEND_NUM_ARGS() == 1) {
 		RETURN_DOUBLE(log(num));
 	}
+
+#ifdef HAVE_LOG2
+	if (base == 2.0) {
+		RETURN_DOUBLE(log2(num));
+	}
+#endif
+
+	if (base == 10.0) {
+		RETURN_DOUBLE(log10(num));
+	}
+
+	if (base == 1.0) {
+		RETURN_DOUBLE(php_get_nan());
+	}
+
 	if (base <= 0.0) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "base must be greater than 0");				
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "base must be greater than 0");
 		RETURN_FALSE;
 	}
-	if (base == 1) {
-		RETURN_DOUBLE(php_get_nan());
-	} else {
-		RETURN_DOUBLE(log(num) / log(base));
-	}
+
+	RETURN_DOUBLE(log(num) / log(base));
 }
 /* }}} */
 


### PR DESCRIPTION
... to reduce rounding errors.

Internally on `log(x, 2)` the native `C` function `log2(x)` and on `log(x, 10)` the native `C` function `log10(x)` will be called.

Because of after this PR the following will be the same in PHP `log10(x)` === `log10(x)` the function `log10` is needless and could be deprecated/removed. I will create an RFC if this PR was merged.

This PR is against PHP-5.4 as there is no BC break.
Please merge into PHP-5.4 up to master.
Please tell me if I did something wrong.
