### PR TITLE
Directly call a callable containing string with 'Class::func' (fixes #60687)

### DIFF
--- a/Zend/tests/call_static.phpt
+++ b/Zend/tests/call_static.phpt
@@ -12,9 +12,18 @@ class Test
 
 call_user_func("Test::Two", 'A', 'B');
 call_user_func(array("Test", "Three"), NULL, 0, false);
-Test::Four(5, 6, 7, 8);
+
+$b = 'Test::Four';
+$b(5, 6, 7, 8);
+
+$b = array('Test', 'Five');
+$b(6, 7, 8);
+
+Test::Six(7, 8);
 
 --EXPECT--
 Two() called with 2 arguments
 Three() called with 3 arguments
 Four() called with 4 arguments
+Five() called with 3 arguments
+Six() called with 2 arguments

--- a/Zend/tests/call_static_005.phpt
+++ b/Zend/tests/call_static_005.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Invalid method name in dynamic static call
+Empty method name in dynamic static call
 --FILE--
 <?php
 
@@ -12,6 +12,11 @@ class foo {
 $a = 'foo::';
 $a();
 
+$a = array('foo', '');
+$a();
+
 ?>
 --EXPECTF--
-Fatal error: Call to undefined function foo::() in %s on line %d
+string(0) ""
+string(0) ""
+

--- a/Zend/tests/call_static_006.phpt
+++ b/Zend/tests/call_static_006.phpt
@@ -17,10 +17,22 @@ foo::aa();
 $b = 'AA';
 foo::$b();
 
+$b = 'foo::AA';
+$b();
+
+$b = array('foo', 'AA');
+$b();
+
 foo::__construct();
 
 ?>
 --EXPECTF--
+Strict Standards: Non-static method foo::aa() should not be called statically in %s on line %d
+ok
+
+Strict Standards: Non-static method foo::aa() should not be called statically in %s on line %d
+ok
+
 Strict Standards: Non-static method foo::aa() should not be called statically in %s on line %d
 ok
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2672,11 +2672,8 @@ ZEND_VM_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST|TMP|VAR|CV)
 				zend_class_entry *ce;
 				function_name_strval += 2;
 				function_name_strlen = strlen(function_name_strval);
-				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
-				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
 
-				ce = zend_fetch_class_by_name(class_name_strval, class_name_strlen, NULL, 0 TSRMLS_CC);
-				free(class_name_strval);
+				ce = zend_fetch_class_by_name(Z_STRVAL_P(function_name), Z_STRLEN_P(function_name) - function_name_strlen - 2, NULL, 0 TSRMLS_CC);
 				if (UNEXPECTED(ce == NULL)) {
 					CHECK_EXCEPTION();
 					ZEND_VM_NEXT_OPCODE();

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2700,13 +2700,13 @@ ZEND_VM_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST|TMP|VAR|CV)
 			EX(call) = call;
 
 			FREE_OP2();
-                        CHECK_EXCEPTION();
-                        ZEND_VM_NEXT_OPCODE();
+			CHECK_EXCEPTION();
+			ZEND_VM_NEXT_OPCODE();
 
 		} else if (OP2_TYPE != IS_CONST && OP2_TYPE != IS_TMP_VAR &&
-		    EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
+				EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2628,7 +2628,7 @@ ZEND_VM_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST|TMP|VAR|CV)
 			call->fbc = CACHED_PTR(opline->op2.literal->cache_slot);
 		} else if (UNEXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL_P(function_name), Z_STRLEN_P(function_name)+1, Z_HASH_P(function_name), (void **) &call->fbc) == FAILURE)) {
 			SAVE_OPLINE();
-			zend_error_noreturn(E_ERROR, "1 Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
+			zend_error_noreturn(E_ERROR, "Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
 		} else {
 			CACHE_PTR(opline->op2.literal->cache_slot, call->fbc);
 		}
@@ -2662,7 +2662,7 @@ ZEND_VM_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST|TMP|VAR|CV)
 					lcname = zend_str_tolower_dup(function_name_strval, function_name_strlen);
 				}
 				if (UNEXPECTED(zend_hash_find(EG(function_table), lcname, function_name_strlen+1, (void **) &call->fbc) == FAILURE)) {
-					zend_error_noreturn(E_ERROR, "2 Call to undefined function %s()", function_name_strval);
+					zend_error_noreturn(E_ERROR, "Call to undefined function %s()", function_name_strval);
 				}
 				efree(lcname);
 
@@ -2819,7 +2819,7 @@ ZEND_VM_HANDLER(69, ZEND_INIT_NS_FCALL_BY_NAME, ANY, CONST)
 		func_name++;
 		if (UNEXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL(func_name->constant), Z_STRLEN(func_name->constant)+1, func_name->hash_value, (void **) &call->fbc)==FAILURE)) {
 			SAVE_OPLINE();
-			zend_error_noreturn(E_ERROR, "3 Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
+			zend_error_noreturn(E_ERROR, "Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
 		} else {
 			CACHE_PTR(opline->op2.literal->cache_slot, call->fbc);
 		}
@@ -2853,7 +2853,7 @@ ZEND_VM_HANDLER(60, ZEND_DO_FCALL, CONST, ANY)
 		EX(function_state).function = CACHED_PTR(opline->op1.literal->cache_slot);
 	} else if (UNEXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL_P(fname), Z_STRLEN_P(fname)+1, Z_HASH_P(fname), (void **) &EX(function_state).function)==FAILURE)) {
 	    SAVE_OPLINE();
-		zend_error_noreturn(E_ERROR, "4 Call to undefined function %s()", fname->value.str.val);
+		zend_error_noreturn(E_ERROR, "Call to undefined function %s()", fname->value.str.val);
 	} else {
 		CACHE_PTR(opline->op1.literal->cache_slot, EX(function_state).function);
 	}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1505,13 +1505,13 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPCODE
 			call->is_ctor_call = 0;
 			EX(call) = call;
 
-                        CHECK_EXCEPTION();
-                        ZEND_VM_NEXT_OPCODE();
+			CHECK_EXCEPTION();
+			ZEND_VM_NEXT_OPCODE();
 
 		} else if (IS_CONST != IS_CONST && IS_CONST != IS_TMP_VAR &&
-		    EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
+				EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
@@ -1873,13 +1873,13 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_TMP_HANDLER(ZEND_OPCODE_H
 			EX(call) = call;
 
 			zval_dtor(free_op2.var);
-                        CHECK_EXCEPTION();
-                        ZEND_VM_NEXT_OPCODE();
+			CHECK_EXCEPTION();
+			ZEND_VM_NEXT_OPCODE();
 
 		} else if (IS_TMP_VAR != IS_CONST && IS_TMP_VAR != IS_TMP_VAR &&
-		    EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
+				EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
@@ -2103,13 +2103,13 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 			EX(call) = call;
 
 			zval_ptr_dtor_nogc(&free_op2.var);
-                        CHECK_EXCEPTION();
-                        ZEND_VM_NEXT_OPCODE();
+			CHECK_EXCEPTION();
+			ZEND_VM_NEXT_OPCODE();
 
 		} else if (IS_VAR != IS_CONST && IS_VAR != IS_TMP_VAR &&
-		    EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
+				EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
@@ -2370,13 +2370,13 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CV_HANDLER(ZEND_OPCODE_HA
 			call->is_ctor_call = 0;
 			EX(call) = call;
 
-                        CHECK_EXCEPTION();
-                        ZEND_VM_NEXT_OPCODE();
+			CHECK_EXCEPTION();
+			ZEND_VM_NEXT_OPCODE();
 
 		} else if (IS_CV != IS_CONST && IS_CV != IS_TMP_VAR &&
-		    EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure) &&
-			Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
+				EXPECTED(Z_TYPE_P(function_name) == IS_OBJECT) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure) &&
+				Z_OBJ_HANDLER_P(function_name, get_closure)(function_name, &call->called_scope, &call->fbc, &call->object TSRMLS_CC) == SUCCESS) {
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1434,7 +1434,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPCODE
 			call->fbc = CACHED_PTR(opline->op2.literal->cache_slot);
 		} else if (UNEXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL_P(function_name), Z_STRLEN_P(function_name)+1, Z_HASH_P(function_name), (void **) &call->fbc) == FAILURE)) {
 			SAVE_OPLINE();
-			zend_error_noreturn(E_ERROR, "1 Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
+			zend_error_noreturn(E_ERROR, "Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
 		} else {
 			CACHE_PTR(opline->op2.literal->cache_slot, call->fbc);
 		}
@@ -1468,7 +1468,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPCODE
 					lcname = zend_str_tolower_dup(function_name_strval, function_name_strlen);
 				}
 				if (UNEXPECTED(zend_hash_find(EG(function_table), lcname, function_name_strlen+1, (void **) &call->fbc) == FAILURE)) {
-					zend_error_noreturn(E_ERROR, "2 Call to undefined function %s()", function_name_strval);
+					zend_error_noreturn(E_ERROR, "Call to undefined function %s()", function_name_strval);
 				}
 				efree(lcname);
 
@@ -1623,7 +1623,7 @@ static int ZEND_FASTCALL  ZEND_INIT_NS_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPC
 		func_name++;
 		if (UNEXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL(func_name->constant), Z_STRLEN(func_name->constant)+1, func_name->hash_value, (void **) &call->fbc)==FAILURE)) {
 			SAVE_OPLINE();
-			zend_error_noreturn(E_ERROR, "3 Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
+			zend_error_noreturn(E_ERROR, "Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
 		} else {
 			CACHE_PTR(opline->op2.literal->cache_slot, call->fbc);
 		}
@@ -1801,7 +1801,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_TMP_HANDLER(ZEND_OPCODE_H
 			call->fbc = CACHED_PTR(opline->op2.literal->cache_slot);
 		} else if (UNEXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL_P(function_name), Z_STRLEN_P(function_name)+1, Z_HASH_P(function_name), (void **) &call->fbc) == FAILURE)) {
 			SAVE_OPLINE();
-			zend_error_noreturn(E_ERROR, "1 Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
+			zend_error_noreturn(E_ERROR, "Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
 		} else {
 			CACHE_PTR(opline->op2.literal->cache_slot, call->fbc);
 		}
@@ -1835,7 +1835,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_TMP_HANDLER(ZEND_OPCODE_H
 					lcname = zend_str_tolower_dup(function_name_strval, function_name_strlen);
 				}
 				if (UNEXPECTED(zend_hash_find(EG(function_table), lcname, function_name_strlen+1, (void **) &call->fbc) == FAILURE)) {
-					zend_error_noreturn(E_ERROR, "2 Call to undefined function %s()", function_name_strval);
+					zend_error_noreturn(E_ERROR, "Call to undefined function %s()", function_name_strval);
 				}
 				efree(lcname);
 
@@ -2031,7 +2031,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 			call->fbc = CACHED_PTR(opline->op2.literal->cache_slot);
 		} else if (UNEXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL_P(function_name), Z_STRLEN_P(function_name)+1, Z_HASH_P(function_name), (void **) &call->fbc) == FAILURE)) {
 			SAVE_OPLINE();
-			zend_error_noreturn(E_ERROR, "1 Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
+			zend_error_noreturn(E_ERROR, "Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
 		} else {
 			CACHE_PTR(opline->op2.literal->cache_slot, call->fbc);
 		}
@@ -2065,7 +2065,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 					lcname = zend_str_tolower_dup(function_name_strval, function_name_strlen);
 				}
 				if (UNEXPECTED(zend_hash_find(EG(function_table), lcname, function_name_strlen+1, (void **) &call->fbc) == FAILURE)) {
-					zend_error_noreturn(E_ERROR, "2 Call to undefined function %s()", function_name_strval);
+					zend_error_noreturn(E_ERROR, "Call to undefined function %s()", function_name_strval);
 				}
 				efree(lcname);
 
@@ -2299,7 +2299,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CV_HANDLER(ZEND_OPCODE_HA
 			call->fbc = CACHED_PTR(opline->op2.literal->cache_slot);
 		} else if (UNEXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL_P(function_name), Z_STRLEN_P(function_name)+1, Z_HASH_P(function_name), (void **) &call->fbc) == FAILURE)) {
 			SAVE_OPLINE();
-			zend_error_noreturn(E_ERROR, "1 Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
+			zend_error_noreturn(E_ERROR, "Call to undefined function %s()", Z_STRVAL_P(opline->op2.zv));
 		} else {
 			CACHE_PTR(opline->op2.literal->cache_slot, call->fbc);
 		}
@@ -2333,7 +2333,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CV_HANDLER(ZEND_OPCODE_HA
 					lcname = zend_str_tolower_dup(function_name_strval, function_name_strlen);
 				}
 				if (UNEXPECTED(zend_hash_find(EG(function_table), lcname, function_name_strlen+1, (void **) &call->fbc) == FAILURE)) {
-					zend_error_noreturn(E_ERROR, "2 Call to undefined function %s()", function_name_strval);
+					zend_error_noreturn(E_ERROR, "Call to undefined function %s()", function_name_strval);
 				}
 				efree(lcname);
 
@@ -2694,7 +2694,7 @@ static int ZEND_FASTCALL  ZEND_DO_FCALL_SPEC_CONST_HANDLER(ZEND_OPCODE_HANDLER_A
 		EX(function_state).function = CACHED_PTR(opline->op1.literal->cache_slot);
 	} else if (UNEXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL_P(fname), Z_STRLEN_P(fname)+1, Z_HASH_P(fname), (void **) &EX(function_state).function)==FAILURE)) {
 	    SAVE_OPLINE();
-		zend_error_noreturn(E_ERROR, "4 Call to undefined function %s()", fname->value.str.val);
+		zend_error_noreturn(E_ERROR, "Call to undefined function %s()", fname->value.str.val);
 	} else {
 		CACHE_PTR(opline->op1.literal->cache_slot, EX(function_state).function);
 	}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1478,11 +1478,11 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPCODE
 				zend_class_entry *ce;
 				function_name_strval += 2;
 				function_name_strlen = strlen(function_name_strval);
-				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
-				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
+//				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
+//				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
 
-				ce = zend_fetch_class_by_name(class_name_strval, class_name_strlen, NULL, 0 TSRMLS_CC);
-				free(class_name_strval);
+				ce = zend_fetch_class_by_name(Z_STRVAL_P(function_name), Z_STRLEN_P(function_name) - function_name_strlen - 2, NULL, 0 TSRMLS_CC);
+//				free(class_name_strval);
 				if (UNEXPECTED(ce == NULL)) {
 					CHECK_EXCEPTION();
 					ZEND_VM_NEXT_OPCODE();
@@ -1845,11 +1845,11 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_TMP_HANDLER(ZEND_OPCODE_H
 				zend_class_entry *ce;
 				function_name_strval += 2;
 				function_name_strlen = strlen(function_name_strval);
-				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
-				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
+//				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
+//				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
 
-				ce = zend_fetch_class_by_name(class_name_strval, class_name_strlen, NULL, 0 TSRMLS_CC);
-				free(class_name_strval);
+				ce = zend_fetch_class_by_name(Z_STRVAL_P(function_name), Z_STRLEN_P(function_name) - function_name_strlen - 2, NULL, 0 TSRMLS_CC);
+//				free(class_name_strval);
 				if (UNEXPECTED(ce == NULL)) {
 					CHECK_EXCEPTION();
 					ZEND_VM_NEXT_OPCODE();
@@ -2075,11 +2075,11 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 				zend_class_entry *ce;
 				function_name_strval += 2;
 				function_name_strlen = strlen(function_name_strval);
-				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
-				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
+//				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
+//				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
 
-				ce = zend_fetch_class_by_name(class_name_strval, class_name_strlen, NULL, 0 TSRMLS_CC);
-				free(class_name_strval);
+				ce = zend_fetch_class_by_name(Z_STRVAL_P(function_name), Z_STRLEN_P(function_name) - function_name_strlen - 2, NULL, 0 TSRMLS_CC);
+//				free(class_name_strval);
 				if (UNEXPECTED(ce == NULL)) {
 					CHECK_EXCEPTION();
 					ZEND_VM_NEXT_OPCODE();
@@ -2343,11 +2343,11 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CV_HANDLER(ZEND_OPCODE_HA
 				zend_class_entry *ce;
 				function_name_strval += 2;
 				function_name_strlen = strlen(function_name_strval);
-				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
-				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
+//				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
+//				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
 
-				ce = zend_fetch_class_by_name(class_name_strval, class_name_strlen, NULL, 0 TSRMLS_CC);
-				free(class_name_strval);
+				ce = zend_fetch_class_by_name(Z_STRVAL_P(function_name), Z_STRLEN_P(function_name) - function_name_strlen - 2, NULL, 0 TSRMLS_CC);
+//				free(class_name_strval);
 				if (UNEXPECTED(ce == NULL)) {
 					CHECK_EXCEPTION();
 					ZEND_VM_NEXT_OPCODE();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1478,11 +1478,8 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPCODE
 				zend_class_entry *ce;
 				function_name_strval += 2;
 				function_name_strlen = strlen(function_name_strval);
-//				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
-//				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
 
 				ce = zend_fetch_class_by_name(Z_STRVAL_P(function_name), Z_STRLEN_P(function_name) - function_name_strlen - 2, NULL, 0 TSRMLS_CC);
-//				free(class_name_strval);
 				if (UNEXPECTED(ce == NULL)) {
 					CHECK_EXCEPTION();
 					ZEND_VM_NEXT_OPCODE();
@@ -1845,11 +1842,8 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_TMP_HANDLER(ZEND_OPCODE_H
 				zend_class_entry *ce;
 				function_name_strval += 2;
 				function_name_strlen = strlen(function_name_strval);
-//				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
-//				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
 
 				ce = zend_fetch_class_by_name(Z_STRVAL_P(function_name), Z_STRLEN_P(function_name) - function_name_strlen - 2, NULL, 0 TSRMLS_CC);
-//				free(class_name_strval);
 				if (UNEXPECTED(ce == NULL)) {
 					CHECK_EXCEPTION();
 					ZEND_VM_NEXT_OPCODE();
@@ -2075,11 +2069,8 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 				zend_class_entry *ce;
 				function_name_strval += 2;
 				function_name_strlen = strlen(function_name_strval);
-//				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
-//				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
 
 				ce = zend_fetch_class_by_name(Z_STRVAL_P(function_name), Z_STRLEN_P(function_name) - function_name_strlen - 2, NULL, 0 TSRMLS_CC);
-//				free(class_name_strval);
 				if (UNEXPECTED(ce == NULL)) {
 					CHECK_EXCEPTION();
 					ZEND_VM_NEXT_OPCODE();
@@ -2343,11 +2334,8 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CV_HANDLER(ZEND_OPCODE_HA
 				zend_class_entry *ce;
 				function_name_strval += 2;
 				function_name_strlen = strlen(function_name_strval);
-//				class_name_strlen = Z_STRLEN_P(function_name) - function_name_strlen - 2;
-//				class_name_strval = zend_strndup(Z_STRVAL_P(function_name), class_name_strlen + 1);
 
 				ce = zend_fetch_class_by_name(Z_STRVAL_P(function_name), Z_STRLEN_P(function_name) - function_name_strlen - 2, NULL, 0 TSRMLS_CC);
-//				free(class_name_strval);
 				if (UNEXPECTED(ce == NULL)) {
 					CHECK_EXCEPTION();
 					ZEND_VM_NEXT_OPCODE();

--- a/run-tests.php
+++ b/run-tests.php
@@ -533,6 +533,9 @@ if (isset($argc) && $argc > 1) {
 			$repeat = false;
 
 			switch($switch) {
+				case 't':
+					$test_files[] = trim($argv[++$i]);
+					break;
 				case 'r':
 				case 'l':
 					$test_list = file($argv[++$i]);

--- a/run-tests.php
+++ b/run-tests.php
@@ -533,9 +533,6 @@ if (isset($argc) && $argc > 1) {
 			$repeat = false;
 
 			switch($switch) {
-				case 't':
-					$test_files[] = trim($argv[++$i]);
-					break;
 				case 'r':
 				case 'l':
 					$test_list = file($argv[++$i]);


### PR DESCRIPTION
```php
class MyClass {
    public static function myStaticFunc() {
        var_dump(__METHOD__);
    }
}

function call(callable $func) {
    $func();
}

$callFunction = 'call';
$callFunction('myclass::myStaticFunc');

$callFunction = 'myclass::myStaticFunc';
$callFunction();

$callFunction = 'myclass::unkownFunc';
$callFunction();
```

*BEFORE:*
The `callable` type-hint matches the given static method but it's not callable directly.
```
Fatal error: Call to undefined function myclass::myStaticFunc() in %s on line %d
```

*AFTER:*
```
string(21) "MyClass::myStaticFunc"
string(21) "MyClass::myStaticFunc"

Fatal error: Call to undefined method MyClass::unkownFunc() in %s on line %d
```

This should fix #60687, too.