### PR TITLE
Fix #67189: make IteratorIterator cloneable

### DIFF
--- a/ext/spl/tests/CallbackFilterIterator_Clone.phpt
+++ b/ext/spl/tests/CallbackFilterIterator_Clone.phpt
@@ -1,0 +1,17 @@
+--TEST--
+SPL: CallbackFilterIterator clone tests
+--FILE--
+<?php
+$filter_callback = function ($e) {
+  return true;
+};
+
+$arrayIterator = new ArrayIterator(array(1,2,3));
+$it1 = new CallbackFilterIterator($arrayIterator, $filter_callback);
+$it1->rewind();
+$it2 = clone $it1;
+$it2->next();
+var_dump($it1->current());
+?>
+--EXPECT--
+int(1)

--- a/ext/spl/tests/appenditerator_clone.phpt
+++ b/ext/spl/tests/appenditerator_clone.phpt
@@ -1,0 +1,29 @@
+--TEST--
+SPL: AppendIterator clone test
+--FILE--
+<?php
+$arrayIterator1 = new ArrayIterator(array(1, 2));
+$arrayIterator2 = new ArrayIterator(array(3, 4));
+$it1 = new AppendIterator();
+$it1->append($arrayIterator1);
+$it2 = clone $it1;
+$it2->append($arrayIterator2);
+
+$it1->rewind();
+$it1->next();
+$it2->rewind();
+
+echo "Original: ";
+foreach($it1 as $el) 
+  echo "$el, ";
+echo PHP_EOL;
+
+echo "Clone: ";
+foreach($it2 as $el) 
+  echo "$el, ";
+echo PHP_EOL;
+?>
+--EXPECT--
+Original: 1, 2, 
+Clone: 1, 2, 3, 4, 
+

--- a/ext/spl/tests/cachingiterator_clone.phpt
+++ b/ext/spl/tests/cachingiterator_clone.phpt
@@ -1,0 +1,16 @@
+--TEST--
+SPL: CachingIterator clone tests
+--FILE--
+<?php
+$arrayIterator = new ArrayIterator(array(1,2,3));
+$it1 = new CachingIterator($arrayIterator);
+$it1->rewind();
+$it2=clone $it1;
+$it2->next();
+var_dump($it1->current());
+$it1->next();
+var_dump($it1->current());
+?>
+--EXPECT--
+int(1)
+int(2)

--- a/ext/spl/tests/regexiterator_clone.phpt
+++ b/ext/spl/tests/regexiterator_clone.phpt
@@ -1,0 +1,17 @@
+--TEST--
+SPL: RegexIterator clone
+--FILE--
+<?php
+
+$testData = array("Test1", "something", "Test2");
+
+$it1 = new RegexIterator(new ArrayIterator($testData), '/Test.*/');
+$it1->rewind();
+$it2=clone $it1;
+$it2->next();
+print($it2->current().PHP_EOL);
+print($it2->getRegex().PHP_EOL);
+?>
+--EXPECT--
+Test2
+/Test.*/

--- a/ext/spl/tests/spl_iterator_iterator_clone.phpt
+++ b/ext/spl/tests/spl_iterator_iterator_clone.phpt
@@ -1,0 +1,15 @@
+--TEST--
+SPL: IteratorInterator clone tests
+--FILE--
+<?php
+$arrayIterator = new ArrayIterator(array(1,2,3));
+$it1 = new IteratorIterator($arrayIterator);
+$it1->rewind();
+
+$it2 = clone $it1;
+$it2->next();
+
+var_dump($it1->current());
+?>
+--EXPECT--
+int(1)


### PR DESCRIPTION
This PR fixes Bug [#67189](https://bugs.php.net/bug.php?id=67189).

It includes new TCs for cloning IteratorIterator, CallbackFilterIterator, AppendIterator and CachingIterator.
