### PR TITLE
Configure --without-sendmail (fixes #63891)

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2062,9 +2062,14 @@ dnl
 dnl Search for the sendmail binary
 dnl
 AC_DEFUN([PHP_PROG_SENDMAIL], [
-  PHP_ALT_PATH=/usr/bin:/usr/sbin:/usr/etc:/etc:/usr/ucblib:/usr/lib
-  AC_PATH_PROG(PROG_SENDMAIL, sendmail,[], $PATH:$PHP_ALT_PATH)
-  PHP_SUBST(PROG_SENDMAIL)
+  PHP_ARG_WITH(sendmail, whether to enable sendmail funcitonality,
+  [  --without-sendmail      Build PHP without sendmail functionality.], yes)
+
+  if test "$PHP_SENDMAIL" != "no"; then
+    PHP_ALT_PATH=/usr/bin:/usr/sbin:/usr/etc:/etc:/usr/ucblib:/usr/lib
+    AC_PATH_PROG(PROG_SENDMAIL, sendmail,[], $PATH:$PHP_ALT_PATH)
+    PHP_SUBST(PROG_SENDMAIL)
+  fi
 ])
 
 dnl


### PR DESCRIPTION
Pull request for [issue #63891](https://bugs.php.net/bug.php?id=63891)

Adds`--with[out]-sendmail` although `--with-sendmail` will still
exclude sendmail functionality silently if the executable is not
found in the path. This is to maintain backwards compatibility.

I personally feel we should make sendmail required unless
`--without-sendmail` is used, but making an optional dependency
mandatory with configuration defaults is not my decision to make.
