### PR TITLE
Double variable assignment -> remove

### DIFF
--- a/ext/pdo_oci/config.w32
+++ b/ext/pdo_oci/config.w32
@@ -29,8 +29,6 @@ if (PHP_PDO_OCI != "no") {
 
 	if (pdo_oci_header && CHECK_LIB("oci.lib", "pdo_oci", pdo_oci_lib_paths)) {
 
-		pdo_oci_inc_dir = FSO.GetParentFolderName(pdo_oci_header);
-
 		EXTENSION('pdo_oci', 'pdo_oci.c oci_driver.c oci_statement.c');
 
 		/* probe for some functions not present in older versions */


### PR DESCRIPTION
Variable is set below

See after EXTENSION...
```
/* probe for some functions not present in older versions */
pdo_oci_inc_dir = FSO.GetFolder(pdo_oci_header);
```