### PR TITLE
Always consume meridian for correct error reporting

### DIFF
--- a/ext/date/lib/parse_date.c
+++ b/ext/date/lib/parse_date.c
@@ -24972,9 +24972,11 @@ timelib_time *timelib_parse_from_format(char *format, char *string, int len, tim
 				break;
 			case 'a': /* am/pm/a.m./p.m. */
 			case 'A': /* AM/PM/A.M./P.M. */
+				tmp = timelib_meridian_with_check((char **) &ptr, s->time->h);
+
 				if (s->time->h == TIMELIB_UNSET) {
 					add_pbf_error(s, "Meridian can only come after an hour has been found", string, begin);
-				} else if ((tmp = timelib_meridian_with_check((char **) &ptr, s->time->h)) == TIMELIB_UNSET) {
+				} else if (tmp == TIMELIB_UNSET) {
 					add_pbf_error(s, "A meridian could not be found", string, begin);
 				} else {
 					s->time->h += tmp;

--- a/ext/date/tests/bug64975.phpt
+++ b/ext/date/tests/bug64975.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test for bug #64975: Error parsing when AM PM not at the end
+--CREDITS--
+Chris Wright <daverandom@php.net>
+--FILE--
+<?php
+
+$date = DateTime::createFromFormat('d M Y A h:i', '11 Mar 2013 PM 3:34');
+$errors = date_get_last_errors();
+
+var_dump($date, $errors['errors'][12]);
+
+?>
+--EXPECT--
+bool(false)
+string(51) "Meridian can only come after an hour has been found"


### PR DESCRIPTION
Always consume meridian data from input string to ensure the correct error is reported in the errors array.

Fix for bug [#64975](https://bugs.php.net/bug.php?id=64975).
