### PR TITLE
Adding method flag macros

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2938,7 +2938,7 @@ get_function_via_handler:
 			} else if (!fcc->object_ptr && !IS_STATIC_METHOD(fcc->function_handler)) {
 				int severity;
 				char *verb;
-				if (IS_PROTECTED_METHOD(fcc->function_handler)) {
+				if (fcc->function_handler->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
 					severity = E_STRICT;
 					verb = "should not";
 				} else {

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2226,69 +2226,69 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 		scope->__debugInfo = __debugInfo;
 		if (ctor) {
 			ctor->common.fn_flags |= ZEND_ACC_CTOR;
-			if (ctor->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(ctor)) {
 				zend_error(error_type, "Constructor %s::%s() cannot be static", scope->name, ctor->common.function_name);
 			}
 			ctor->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (dtor) {
 			dtor->common.fn_flags |= ZEND_ACC_DTOR;
-			if (dtor->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(dtor)) {
 				zend_error(error_type, "Destructor %s::%s() cannot be static", scope->name, dtor->common.function_name);
 			}
 			dtor->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (clone) {
 			clone->common.fn_flags |= ZEND_ACC_CLONE;
-			if (clone->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(clone)) {
 				zend_error(error_type, "Constructor %s::%s() cannot be static", scope->name, clone->common.function_name);
 			}
 			clone->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__call) {
-			if (__call->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(__call)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __call->common.function_name);
 			}
 			__call->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__callstatic) {
-			if (!(__callstatic->common.fn_flags & ZEND_ACC_STATIC)) {
+			if (!IS_STATIC_METHOD(__callstatic)) {
 				zend_error(error_type, "Method %s::%s() must be static", scope->name, __callstatic->common.function_name);
 			}
 			__callstatic->common.fn_flags |= ZEND_ACC_STATIC;
 		}
 		if (__tostring) {
-			if (__tostring->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(__tostring)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __tostring->common.function_name);
 			}
 			__tostring->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__get) {
-			if (__get->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(__get)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __get->common.function_name);
 			}
 			__get->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__set) {
-			if (__set->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(__set)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __set->common.function_name);
 			}
 			__set->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__unset) {
-			if (__unset->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(__unset)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __unset->common.function_name);
 			}
 			__unset->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__isset) {
-			if (__isset->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(__isset)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __isset->common.function_name);
 			}
 			__isset->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__debugInfo) {
-			if (__debugInfo->common.fn_flags & ZEND_ACC_STATIC) {
+			if (IS_STATIC_METHOD(__debugInfo)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __debugInfo->common.function_name);
 			}
 		}
@@ -2852,7 +2852,7 @@ static int zend_is_callable_check_func(int check_flags, zval *callable, zend_fca
 			zend_function *priv_fbc;
 
 			if (zend_hash_find(&EG(scope)->function_table, lmname, mlen+1, (void **) &priv_fbc)==SUCCESS
-				&& priv_fbc->common.fn_flags & ZEND_ACC_PRIVATE
+				&& IS_PRIVATE_METHOD(priv_fbc)
 				&& priv_fbc->common.scope == EG(scope)) {
 				fcc->function_handler = priv_fbc;
 			}
@@ -2867,7 +2867,7 @@ static int zend_is_callable_check_func(int check_flags, zval *callable, zend_fca
 					fcc->function_handler = NULL;
 					goto get_function_via_handler;
 				}
-			} else if (fcc->function_handler->common.fn_flags & ZEND_ACC_PROTECTED) {
+			} else if (IS_PROTECTED_METHOD(fcc->function_handler)) {
 				if (!zend_check_protected(fcc->function_handler->common.scope, EG(scope))) {
 					retval = 0;
 					fcc->function_handler = NULL;
@@ -2928,17 +2928,17 @@ get_function_via_handler:
 
 	if (retval) {
 		if (fcc->calling_scope && !call_via_handler) {
-			if (!fcc->object_ptr && (fcc->function_handler->common.fn_flags & ZEND_ACC_ABSTRACT)) {
+			if (!fcc->object_ptr && IS_ABSTRACT_METHOD(fcc->function_handler)) {
 				if (error) {
 					zend_spprintf(error, 0, "cannot call abstract method %s::%s()", fcc->calling_scope->name, fcc->function_handler->common.function_name);
 					retval = 0;
 				} else {
 					zend_error(E_ERROR, "Cannot call abstract method %s::%s()", fcc->calling_scope->name, fcc->function_handler->common.function_name);
 				}
-			} else if (!fcc->object_ptr && !(fcc->function_handler->common.fn_flags & ZEND_ACC_STATIC)) {
+			} else if (!fcc->object_ptr && !IS_STATIC_METHOD(fcc->function_handler)) {
 				int severity;
 				char *verb;
-				if (fcc->function_handler->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
+				if (IS_PROTECTED_METHOD(fcc->function_handler)) {
 					severity = E_STRICT;
 					verb = "should not";
 				} else {
@@ -2981,7 +2981,7 @@ get_function_via_handler:
 						}
 						retval = 0;
 					}
-				} else if ((fcc->function_handler->common.fn_flags & ZEND_ACC_PROTECTED)) {
+				} else if (IS_PROTECTED_METHOD(fcc->function_handler)) {
 					if (!zend_check_protected(fcc->function_handler->common.scope, EG(scope))) {
 						if (error) {
 							if (*error) {

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2226,69 +2226,69 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 		scope->__debugInfo = __debugInfo;
 		if (ctor) {
 			ctor->common.fn_flags |= ZEND_ACC_CTOR;
-			if (IS_STATIC_METHOD(ctor)) {
+			if (IS_STATIC_FUNCTION(*ctor)) {
 				zend_error(error_type, "Constructor %s::%s() cannot be static", scope->name, ctor->common.function_name);
 			}
 			ctor->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (dtor) {
 			dtor->common.fn_flags |= ZEND_ACC_DTOR;
-			if (IS_STATIC_METHOD(dtor)) {
+			if (IS_STATIC_FUNCTION(*dtor)) {
 				zend_error(error_type, "Destructor %s::%s() cannot be static", scope->name, dtor->common.function_name);
 			}
 			dtor->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (clone) {
 			clone->common.fn_flags |= ZEND_ACC_CLONE;
-			if (IS_STATIC_METHOD(clone)) {
+			if (IS_STATIC_FUNCTION(*clone)) {
 				zend_error(error_type, "Constructor %s::%s() cannot be static", scope->name, clone->common.function_name);
 			}
 			clone->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__call) {
-			if (IS_STATIC_METHOD(__call)) {
+			if (IS_STATIC_FUNCTION(*__call)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __call->common.function_name);
 			}
 			__call->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__callstatic) {
-			if (!IS_STATIC_METHOD(__callstatic)) {
+			if (!IS_STATIC_FUNCTION(*__callstatic)) {
 				zend_error(error_type, "Method %s::%s() must be static", scope->name, __callstatic->common.function_name);
 			}
 			__callstatic->common.fn_flags |= ZEND_ACC_STATIC;
 		}
 		if (__tostring) {
-			if (IS_STATIC_METHOD(__tostring)) {
+			if (IS_STATIC_FUNCTION(*__tostring)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __tostring->common.function_name);
 			}
 			__tostring->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__get) {
-			if (IS_STATIC_METHOD(__get)) {
+			if (IS_STATIC_FUNCTION(*__get)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __get->common.function_name);
 			}
 			__get->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__set) {
-			if (IS_STATIC_METHOD(__set)) {
+			if (IS_STATIC_FUNCTION(*__set)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __set->common.function_name);
 			}
 			__set->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__unset) {
-			if (IS_STATIC_METHOD(__unset)) {
+			if (IS_STATIC_FUNCTION(*__unset)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __unset->common.function_name);
 			}
 			__unset->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__isset) {
-			if (IS_STATIC_METHOD(__isset)) {
+			if (IS_STATIC_FUNCTION(*__isset)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __isset->common.function_name);
 			}
 			__isset->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__debugInfo) {
-			if (IS_STATIC_METHOD(__debugInfo)) {
+			if (IS_STATIC_FUNCTION(*__debugInfo)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __debugInfo->common.function_name);
 			}
 		}
@@ -2852,7 +2852,7 @@ static int zend_is_callable_check_func(int check_flags, zval *callable, zend_fca
 			zend_function *priv_fbc;
 
 			if (zend_hash_find(&EG(scope)->function_table, lmname, mlen+1, (void **) &priv_fbc)==SUCCESS
-				&& IS_PRIVATE_METHOD(priv_fbc)
+				&& IS_PRIVATE_FUNCTION(*priv_fbc)
 				&& priv_fbc->common.scope == EG(scope)) {
 				fcc->function_handler = priv_fbc;
 			}
@@ -2867,7 +2867,7 @@ static int zend_is_callable_check_func(int check_flags, zval *callable, zend_fca
 					fcc->function_handler = NULL;
 					goto get_function_via_handler;
 				}
-			} else if (IS_PROTECTED_METHOD(fcc->function_handler)) {
+			} else if (IS_PROTECTED_FUNCTION(*fcc->function_handler)) {
 				if (!zend_check_protected(fcc->function_handler->common.scope, EG(scope))) {
 					retval = 0;
 					fcc->function_handler = NULL;
@@ -2928,14 +2928,14 @@ get_function_via_handler:
 
 	if (retval) {
 		if (fcc->calling_scope && !call_via_handler) {
-			if (!fcc->object_ptr && IS_ABSTRACT_METHOD(fcc->function_handler)) {
+			if (!fcc->object_ptr && IS_ABSTRACT_FUNCTION(*fcc->function_handler)) {
 				if (error) {
 					zend_spprintf(error, 0, "cannot call abstract method %s::%s()", fcc->calling_scope->name, fcc->function_handler->common.function_name);
 					retval = 0;
 				} else {
 					zend_error(E_ERROR, "Cannot call abstract method %s::%s()", fcc->calling_scope->name, fcc->function_handler->common.function_name);
 				}
-			} else if (!fcc->object_ptr && !IS_STATIC_METHOD(fcc->function_handler)) {
+			} else if (!fcc->object_ptr && !IS_STATIC_FUNCTION(*fcc->function_handler)) {
 				int severity;
 				char *verb;
 				if (fcc->function_handler->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
@@ -2981,7 +2981,7 @@ get_function_via_handler:
 						}
 						retval = 0;
 					}
-				} else if (IS_PROTECTED_METHOD(fcc->function_handler)) {
+				} else if (IS_PROTECTED_FUNCTION(*fcc->function_handler)) {
 					if (!zend_check_protected(fcc->function_handler->common.scope, EG(scope))) {
 						if (error) {
 							if (*error) {

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2226,69 +2226,69 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 		scope->__debugInfo = __debugInfo;
 		if (ctor) {
 			ctor->common.fn_flags |= ZEND_ACC_CTOR;
-			if (IS_STATIC_FUNCTION(*ctor)) {
+			if (ZEND_IS_STATIC_FUNCTION(*ctor)) {
 				zend_error(error_type, "Constructor %s::%s() cannot be static", scope->name, ctor->common.function_name);
 			}
 			ctor->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (dtor) {
 			dtor->common.fn_flags |= ZEND_ACC_DTOR;
-			if (IS_STATIC_FUNCTION(*dtor)) {
+			if (ZEND_IS_STATIC_FUNCTION(*dtor)) {
 				zend_error(error_type, "Destructor %s::%s() cannot be static", scope->name, dtor->common.function_name);
 			}
 			dtor->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (clone) {
 			clone->common.fn_flags |= ZEND_ACC_CLONE;
-			if (IS_STATIC_FUNCTION(*clone)) {
+			if (ZEND_IS_STATIC_FUNCTION(*clone)) {
 				zend_error(error_type, "Constructor %s::%s() cannot be static", scope->name, clone->common.function_name);
 			}
 			clone->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__call) {
-			if (IS_STATIC_FUNCTION(*__call)) {
+			if (ZEND_IS_STATIC_FUNCTION(*__call)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __call->common.function_name);
 			}
 			__call->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__callstatic) {
-			if (!IS_STATIC_FUNCTION(*__callstatic)) {
+			if (!ZEND_IS_STATIC_FUNCTION(*__callstatic)) {
 				zend_error(error_type, "Method %s::%s() must be static", scope->name, __callstatic->common.function_name);
 			}
 			__callstatic->common.fn_flags |= ZEND_ACC_STATIC;
 		}
 		if (__tostring) {
-			if (IS_STATIC_FUNCTION(*__tostring)) {
+			if (ZEND_IS_STATIC_FUNCTION(*__tostring)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __tostring->common.function_name);
 			}
 			__tostring->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__get) {
-			if (IS_STATIC_FUNCTION(*__get)) {
+			if (ZEND_IS_STATIC_FUNCTION(*__get)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __get->common.function_name);
 			}
 			__get->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__set) {
-			if (IS_STATIC_FUNCTION(*__set)) {
+			if (ZEND_IS_STATIC_FUNCTION(*__set)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __set->common.function_name);
 			}
 			__set->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__unset) {
-			if (IS_STATIC_FUNCTION(*__unset)) {
+			if (ZEND_IS_STATIC_FUNCTION(*__unset)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __unset->common.function_name);
 			}
 			__unset->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__isset) {
-			if (IS_STATIC_FUNCTION(*__isset)) {
+			if (ZEND_IS_STATIC_FUNCTION(*__isset)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __isset->common.function_name);
 			}
 			__isset->common.fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		if (__debugInfo) {
-			if (IS_STATIC_FUNCTION(*__debugInfo)) {
+			if (ZEND_IS_STATIC_FUNCTION(*__debugInfo)) {
 				zend_error(error_type, "Method %s::%s() cannot be static", scope->name, __debugInfo->common.function_name);
 			}
 		}
@@ -2852,7 +2852,7 @@ static int zend_is_callable_check_func(int check_flags, zval *callable, zend_fca
 			zend_function *priv_fbc;
 
 			if (zend_hash_find(&EG(scope)->function_table, lmname, mlen+1, (void **) &priv_fbc)==SUCCESS
-				&& IS_PRIVATE_FUNCTION(*priv_fbc)
+				&& ZEND_IS_PRIVATE_FUNCTION(*priv_fbc)
 				&& priv_fbc->common.scope == EG(scope)) {
 				fcc->function_handler = priv_fbc;
 			}
@@ -2867,7 +2867,7 @@ static int zend_is_callable_check_func(int check_flags, zval *callable, zend_fca
 					fcc->function_handler = NULL;
 					goto get_function_via_handler;
 				}
-			} else if (IS_PROTECTED_FUNCTION(*fcc->function_handler)) {
+			} else if (ZEND_IS_PROTECTED_FUNCTION(*fcc->function_handler)) {
 				if (!zend_check_protected(fcc->function_handler->common.scope, EG(scope))) {
 					retval = 0;
 					fcc->function_handler = NULL;
@@ -2928,14 +2928,14 @@ get_function_via_handler:
 
 	if (retval) {
 		if (fcc->calling_scope && !call_via_handler) {
-			if (!fcc->object_ptr && IS_ABSTRACT_FUNCTION(*fcc->function_handler)) {
+			if (!fcc->object_ptr && ZEND_IS_ABSTRACT_FUNCTION(*fcc->function_handler)) {
 				if (error) {
 					zend_spprintf(error, 0, "cannot call abstract method %s::%s()", fcc->calling_scope->name, fcc->function_handler->common.function_name);
 					retval = 0;
 				} else {
 					zend_error(E_ERROR, "Cannot call abstract method %s::%s()", fcc->calling_scope->name, fcc->function_handler->common.function_name);
 				}
-			} else if (!fcc->object_ptr && !IS_STATIC_FUNCTION(*fcc->function_handler)) {
+			} else if (!fcc->object_ptr && !ZEND_IS_STATIC_FUNCTION(*fcc->function_handler)) {
 				int severity;
 				char *verb;
 				if (fcc->function_handler->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
@@ -2981,7 +2981,7 @@ get_function_via_handler:
 						}
 						retval = 0;
 					}
-				} else if (IS_PROTECTED_FUNCTION(*fcc->function_handler)) {
+				} else if (ZEND_IS_PROTECTED_FUNCTION(*fcc->function_handler)) {
 					if (!zend_check_protected(fcc->function_handler->common.scope, EG(scope))) {
 						if (error) {
 							if (*error) {

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1077,11 +1077,11 @@ ZEND_FUNCTION(get_class_methods)
 	zend_hash_internal_pointer_reset_ex(&ce->function_table, &pos);
 
 	while (zend_hash_get_current_data_ex(&ce->function_table, (void **) &mptr, &pos) == SUCCESS) {
-		if (IS_PUBLIC_FUNCTION(*mptr) 
+		if (ZEND_IS_PUBLIC_FUNCTION(*mptr) 
 		 || (EG(scope) &&
-		     ((IS_PROTECTED_FUNCTION(*mptr) &&
+		     ((ZEND_IS_PROTECTED_FUNCTION(*mptr) &&
 		       zend_check_protected(mptr->common.scope, EG(scope)))
-		   || (IS_PRIVATE_FUNCTION(*mptr) &&
+		   || (ZEND_IS_PRIVATE_FUNCTION(*mptr) &&
 		       EG(scope) == mptr->common.scope)))) {
 			char *key;
 			uint key_len;
@@ -1093,7 +1093,7 @@ ZEND_FUNCTION(get_class_methods)
 				MAKE_STD_ZVAL(method_name);
 				ZVAL_STRINGL(method_name, mptr->common.function_name, len, 1);
 				zend_hash_next_index_insert(return_value->value.ht, &method_name, sizeof(zval *), NULL);
-			} else if (!IS_CONSTRUCTOR(*mptr) ||
+			} else if (!ZEND_IS_CONSTRUCTOR(*mptr) ||
 			    mptr->common.scope == ce ||
 			    zend_binary_strcasecmp(key, key_len-1, mptr->common.function_name, len) == 0) {
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1077,11 +1077,11 @@ ZEND_FUNCTION(get_class_methods)
 	zend_hash_internal_pointer_reset_ex(&ce->function_table, &pos);
 
 	while (zend_hash_get_current_data_ex(&ce->function_table, (void **) &mptr, &pos) == SUCCESS) {
-		if ((mptr->common.fn_flags & ZEND_ACC_PUBLIC) 
+		if (IS_PUBLIC_FUNCTION(*mptr) 
 		 || (EG(scope) &&
-		     (((mptr->common.fn_flags & ZEND_ACC_PROTECTED) &&
+		     ((IS_PROTECTED_FUNCTION(*mptr) &&
 		       zend_check_protected(mptr->common.scope, EG(scope)))
-		   || ((mptr->common.fn_flags & ZEND_ACC_PRIVATE) &&
+		   || (IS_PRIVATE_FUNCTION(*mptr) &&
 		       EG(scope) == mptr->common.scope)))) {
 			char *key;
 			uint key_len;
@@ -1093,7 +1093,7 @@ ZEND_FUNCTION(get_class_methods)
 				MAKE_STD_ZVAL(method_name);
 				ZVAL_STRINGL(method_name, mptr->common.function_name, len, 1);
 				zend_hash_next_index_insert(return_value->value.ht, &method_name, sizeof(zval *), NULL);
-			} else if ((mptr->common.fn_flags & ZEND_ACC_CTOR) == 0 ||
+			} else if (!IS_CONSTRUCTOR(*mptr) ||
 			    mptr->common.scope == ce ||
 			    zend_binary_strcasecmp(key, key_len-1, mptr->common.function_name, len) == 0) {
 

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -84,7 +84,7 @@ ZEND_METHOD(Closure, bind)
 
 	closure = (zend_closure *)zend_object_store_get_object(zclosure TSRMLS_CC);
 
-	if ((newthis != NULL) && (closure->func.common.fn_flags & ZEND_ACC_STATIC)) {
+	if ((newthis != NULL) && IS_STATIC_FUNCTION(closure->func)) {
 		zend_error(E_WARNING, "Cannot bind an instance to a static closure");
 	}
 
@@ -467,7 +467,7 @@ ZEND_API void zend_create_closure(zval *res, zend_function *func, zend_class_ent
 				zend_error(E_WARNING, "Cannot bind function %s::%s to scope class %s", func->common.scope->name, func->common.function_name, scope->name);
 				scope = NULL;
 			}
-			if(scope && this_ptr && (func->common.fn_flags & ZEND_ACC_STATIC) == 0 &&
+			if(scope && this_ptr && !IS_STATIC_FUNCTION(*func) &&
 					!instanceof_function(Z_OBJCE_P(this_ptr), closure->func.common.scope TSRMLS_CC)) {
 				zend_error(E_WARNING, "Cannot bind function %s::%s to object of class %s", func->common.scope->name, func->common.function_name, Z_OBJCE_P(this_ptr)->name);
 				scope = NULL;
@@ -486,7 +486,7 @@ ZEND_API void zend_create_closure(zval *res, zend_function *func, zend_class_ent
 	closure->func.common.scope = scope;
 	if (scope) {
 		closure->func.common.fn_flags |= ZEND_ACC_PUBLIC;
-		if (this_ptr && (closure->func.common.fn_flags & ZEND_ACC_STATIC) == 0) {
+		if (this_ptr && !IS_STATIC_FUNCTION(closure->func)) {
 			closure->this_ptr = this_ptr;
 			Z_ADDREF_P(this_ptr);
 		} else {

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -84,7 +84,7 @@ ZEND_METHOD(Closure, bind)
 
 	closure = (zend_closure *)zend_object_store_get_object(zclosure TSRMLS_CC);
 
-	if ((newthis != NULL) && IS_STATIC_FUNCTION(closure->func)) {
+	if ((newthis != NULL) && ZEND_IS_STATIC_FUNCTION(closure->func)) {
 		zend_error(E_WARNING, "Cannot bind an instance to a static closure");
 	}
 
@@ -467,7 +467,7 @@ ZEND_API void zend_create_closure(zval *res, zend_function *func, zend_class_ent
 				zend_error(E_WARNING, "Cannot bind function %s::%s to scope class %s", func->common.scope->name, func->common.function_name, scope->name);
 				scope = NULL;
 			}
-			if(scope && this_ptr && !IS_STATIC_FUNCTION(*func) &&
+			if(scope && this_ptr && !ZEND_IS_STATIC_FUNCTION(*func) &&
 					!instanceof_function(Z_OBJCE_P(this_ptr), closure->func.common.scope TSRMLS_CC)) {
 				zend_error(E_WARNING, "Cannot bind function %s::%s to object of class %s", func->common.scope->name, func->common.function_name, Z_OBJCE_P(this_ptr)->name);
 				scope = NULL;
@@ -486,7 +486,7 @@ ZEND_API void zend_create_closure(zval *res, zend_function *func, zend_class_ent
 	closure->func.common.scope = scope;
 	if (scope) {
 		closure->func.common.fn_flags |= ZEND_ACC_PUBLIC;
-		if (this_ptr && !IS_STATIC_FUNCTION(closure->func)) {
+		if (this_ptr && !ZEND_IS_STATIC_FUNCTION(closure->func)) {
 			closure->this_ptr = this_ptr;
 			Z_ADDREF_P(this_ptr);
 		} else {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3148,7 +3148,7 @@ static void do_inherit_parent_constructor(zend_class_entry *ce) /* {{{ */
 		ce->__debugInfo = ce->parent->__debugInfo;
 	}
 	if (ce->constructor) {
-		if (ce->parent->constructor && ce->parent->constructor->common.fn_flags & ZEND_ACC_FINAL) {
+		if (ce->parent->constructor && IS_FINAL_FUNCTION(*(ce->parent->constructor))) {
 			zend_error(E_ERROR, "Cannot override final %s::%s() with %s::%s()",
 				ce->parent->name, ce->parent->constructor->common.function_name,
 				ce->name, ce->constructor->common.function_name
@@ -3171,7 +3171,7 @@ static void do_inherit_parent_constructor(zend_class_entry *ce) /* {{{ */
 			lc_parent_class_name = zend_str_tolower_dup(ce->parent->name, ce->parent->name_length);
 			if (!zend_hash_exists(&ce->function_table, lc_parent_class_name, ce->parent->name_length+1) &&
 					zend_hash_find(&ce->parent->function_table, lc_parent_class_name, ce->parent->name_length+1, (void **)&function)==SUCCESS) {
-				if (function->common.fn_flags & ZEND_ACC_CTOR) {
+				if (IS_CONSTRUCTOR(*function)) {
 					/* inherit parent's constructor */
 					zend_hash_update(&ce->function_table, lc_parent_class_name, ce->parent->name_length+1, function, sizeof(zend_function), (void**)&new_function);
 					function_add_ref(new_function);
@@ -3225,14 +3225,14 @@ static zend_bool zend_do_perform_implementation_check(const zend_function *fe, c
 	/* Checks for constructors only if they are declared in an interface,
 	 * or explicitly marked as abstract
 	 */
-	if ((fe->common.fn_flags & ZEND_ACC_CTOR)
+	if (IS_CONSTRUCTOR(*fe)
 		&& ((proto->common.scope->ce_flags & ZEND_ACC_INTERFACE) == 0
-			&& (proto->common.fn_flags & ZEND_ACC_ABSTRACT) == 0)) {
+			&& !IS_ABSTRACT_FUNCTION(*proto))) {
 		return 1;
 	}
 
 	/* If both methods are private do not enforce a signature */
-    if ((fe->common.fn_flags & ZEND_ACC_PRIVATE) && (proto->common.fn_flags & ZEND_ACC_PRIVATE)) {
+    if (IS_PRIVATE_FUNCTION(*fe) && IS_PRIVATE_FUNCTION(*proto)) {
 		return 1;
 	}
 
@@ -3525,7 +3525,7 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 	zend_uint parent_flags = parent->common.fn_flags;
 
 	if ((parent->common.scope->ce_flags & ZEND_ACC_INTERFACE) == 0
-		&& parent->common.fn_flags & ZEND_ACC_ABSTRACT
+		&& IS_ABSTRACT_FUNCTION(*parent)
 		&& parent->common.scope != (child->common.prototype ? child->common.prototype->common.scope : child->common.scope)
 		&& child->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_IMPLEMENTED_ABSTRACT)) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Can't inherit abstract function %s::%s() (previously declared abstract in %s)",
@@ -3542,7 +3542,7 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 	/* You cannot change from static to non static and vice versa.
 	 */
 	if ((child_flags & ZEND_ACC_STATIC) != (parent_flags & ZEND_ACC_STATIC)) {
-		if (child->common.fn_flags & ZEND_ACC_STATIC) {
+		if (IS_STATIC_FUNCTION(*child)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Cannot make non static method %s::%s() static in class %s", ZEND_FN_SCOPE_NAME(parent), child->common.function_name, ZEND_FN_SCOPE_NAME(child));
 		} else {
 			zend_error_noreturn(E_COMPILE_ERROR, "Cannot make static method %s::%s() non static in class %s", ZEND_FN_SCOPE_NAME(parent), child->common.function_name, ZEND_FN_SCOPE_NAME(child));
@@ -3572,12 +3572,12 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 	} else if (parent_flags & ZEND_ACC_ABSTRACT) {
 		child->common.fn_flags |= ZEND_ACC_IMPLEMENTED_ABSTRACT;
 		child->common.prototype = parent;
-	} else if (!(parent->common.fn_flags & ZEND_ACC_CTOR) || (parent->common.prototype && (parent->common.prototype->common.scope->ce_flags & ZEND_ACC_INTERFACE))) {
+	} else if (!IS_CONSTRUCTOR(*parent) || (parent->common.prototype && (parent->common.prototype->common.scope->ce_flags & ZEND_ACC_INTERFACE))) {
 		/* ctors only have a prototype if it comes from an interface */
 		child->common.prototype = parent->common.prototype ? parent->common.prototype : parent;
 	}
 
-	if (child->common.prototype && (child->common.prototype->common.fn_flags & ZEND_ACC_ABSTRACT)) {
+	if (child->common.prototype && IS_ABSTRACT_FUNCTION(*child->common.prototype)) {
 		if (!zend_do_perform_implementation_check(child, child->common.prototype TSRMLS_CC)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s::%s() must be compatible with %s", ZEND_FN_SCOPE_NAME(child), child->common.function_name, zend_get_function_declaration(child->common.prototype TSRMLS_CC));
 		}
@@ -4007,14 +4007,14 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, const 
 			/* use temporary *overriden HashTable to detect hidden conflict */
 			if (*overriden) {
 				if (zend_hash_quick_find(*overriden, arKey, nKeyLength, h, (void**) &existing_fn) == SUCCESS) {
-					if (existing_fn->common.fn_flags & ZEND_ACC_ABSTRACT) {
+					if (IS_ABSTRACT_FUNCTION(*existing_fn)) {
 						/* Make sure the trait method is compatible with previosly declared abstract method */
 						if (!zend_traits_method_compatibility_check(fn, existing_fn TSRMLS_CC)) {
 							zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
 								zend_get_function_declaration(fn TSRMLS_CC),
 								zend_get_function_declaration(existing_fn TSRMLS_CC));
 						}
-					} else if (fn->common.fn_flags & ZEND_ACC_ABSTRACT) {
+					} else if (IS_ABSTRACT_FUNCTION(*fn)) {
 						/* Make sure the abstract declaration is compatible with previous declaration */
 						if (!zend_traits_method_compatibility_check(existing_fn, fn TSRMLS_CC)) {
 							zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
@@ -4030,14 +4030,14 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, const 
 			}
 			zend_hash_quick_update(*overriden, arKey, nKeyLength, h, fn, sizeof(zend_function), (void**)&fn);
 			return;
-		} else if (existing_fn->common.fn_flags & ZEND_ACC_ABSTRACT) {
+		} else if (IS_ABSTRACT_FUNCTION(*existing_fn)) {
 			/* Make sure the trait method is compatible with previosly declared abstract method */
 			if (!zend_traits_method_compatibility_check(fn, existing_fn TSRMLS_CC)) {
 				zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
 					zend_get_function_declaration(fn TSRMLS_CC),
 					zend_get_function_declaration(existing_fn TSRMLS_CC));
 			}
-		} else if (fn->common.fn_flags & ZEND_ACC_ABSTRACT) {
+		} else if (IS_ABSTRACT_FUNCTION(*fn)) {
 			/* Make sure the abstract declaration is compatible with previous declaration */
 			if (!zend_traits_method_compatibility_check(existing_fn, fn TSRMLS_CC)) {
 				zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
@@ -4075,7 +4075,7 @@ static int zend_fixup_trait_method(zend_function *fn, zend_class_entry *ce TSRML
 
 		fn->common.scope = ce;
 
-		if (fn->common.fn_flags & ZEND_ACC_ABSTRACT) {
+		if (IS_ABSTRACT_FUNCTION(*fn)) {
 			ce->ce_flags |= ZEND_ACC_IMPLICIT_ABSTRACT_CLASS;
 		}
 		if (fn->op_array.static_variables) {
@@ -5208,19 +5208,19 @@ void zend_do_end_class_declaration(const znode *class_token, const znode *parent
 
 	if (ce->constructor) {
 		ce->constructor->common.fn_flags |= ZEND_ACC_CTOR;
-		if (ce->constructor->common.fn_flags & ZEND_ACC_STATIC) {
+		if (IS_STATIC_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Constructor %s::%s() cannot be static", ce->name, ce->constructor->common.function_name);
 		}
 	}
 	if (ce->destructor) {
 		ce->destructor->common.fn_flags |= ZEND_ACC_DTOR;
-		if (ce->destructor->common.fn_flags & ZEND_ACC_STATIC) {
+		if (IS_STATIC_FUNCTION(*ce->destructor)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Destructor %s::%s() cannot be static", ce->name, ce->destructor->common.function_name);
 		}
 	}
 	if (ce->clone) {
 		ce->clone->common.fn_flags |= ZEND_ACC_CLONE;
-		if (ce->clone->common.fn_flags & ZEND_ACC_STATIC) {
+		if (IS_STATIC_FUNCTION(*ce->clone)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Clone method %s::%s() cannot be static", ce->name, ce->clone->common.function_name);
 		}
 	}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3148,7 +3148,7 @@ static void do_inherit_parent_constructor(zend_class_entry *ce) /* {{{ */
 		ce->__debugInfo = ce->parent->__debugInfo;
 	}
 	if (ce->constructor) {
-		if (ce->parent->constructor && IS_FINAL_FUNCTION(*(ce->parent->constructor))) {
+		if (ce->parent->constructor && ZEND_IS_FINAL_FUNCTION(*(ce->parent->constructor))) {
 			zend_error(E_ERROR, "Cannot override final %s::%s() with %s::%s()",
 				ce->parent->name, ce->parent->constructor->common.function_name,
 				ce->name, ce->constructor->common.function_name
@@ -3171,7 +3171,7 @@ static void do_inherit_parent_constructor(zend_class_entry *ce) /* {{{ */
 			lc_parent_class_name = zend_str_tolower_dup(ce->parent->name, ce->parent->name_length);
 			if (!zend_hash_exists(&ce->function_table, lc_parent_class_name, ce->parent->name_length+1) &&
 					zend_hash_find(&ce->parent->function_table, lc_parent_class_name, ce->parent->name_length+1, (void **)&function)==SUCCESS) {
-				if (IS_CONSTRUCTOR(*function)) {
+				if (ZEND_IS_CONSTRUCTOR(*function)) {
 					/* inherit parent's constructor */
 					zend_hash_update(&ce->function_table, lc_parent_class_name, ce->parent->name_length+1, function, sizeof(zend_function), (void**)&new_function);
 					function_add_ref(new_function);
@@ -3225,14 +3225,14 @@ static zend_bool zend_do_perform_implementation_check(const zend_function *fe, c
 	/* Checks for constructors only if they are declared in an interface,
 	 * or explicitly marked as abstract
 	 */
-	if (IS_CONSTRUCTOR(*fe)
+	if (ZEND_IS_CONSTRUCTOR(*fe)
 		&& ((proto->common.scope->ce_flags & ZEND_ACC_INTERFACE) == 0
-			&& !IS_ABSTRACT_FUNCTION(*proto))) {
+			&& !ZEND_IS_ABSTRACT_FUNCTION(*proto))) {
 		return 1;
 	}
 
 	/* If both methods are private do not enforce a signature */
-    if (IS_PRIVATE_FUNCTION(*fe) && IS_PRIVATE_FUNCTION(*proto)) {
+    if (ZEND_IS_PRIVATE_FUNCTION(*fe) && ZEND_IS_PRIVATE_FUNCTION(*proto)) {
 		return 1;
 	}
 
@@ -3525,7 +3525,7 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 	zend_uint parent_flags = parent->common.fn_flags;
 
 	if ((parent->common.scope->ce_flags & ZEND_ACC_INTERFACE) == 0
-		&& IS_ABSTRACT_FUNCTION(*parent)
+		&& ZEND_IS_ABSTRACT_FUNCTION(*parent)
 		&& parent->common.scope != (child->common.prototype ? child->common.prototype->common.scope : child->common.scope)
 		&& child->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_IMPLEMENTED_ABSTRACT)) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Can't inherit abstract function %s::%s() (previously declared abstract in %s)",
@@ -3542,7 +3542,7 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 	/* You cannot change from static to non static and vice versa.
 	 */
 	if ((child_flags & ZEND_ACC_STATIC) != (parent_flags & ZEND_ACC_STATIC)) {
-		if (IS_STATIC_FUNCTION(*child)) {
+		if (ZEND_IS_STATIC_FUNCTION(*child)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Cannot make non static method %s::%s() static in class %s", ZEND_FN_SCOPE_NAME(parent), child->common.function_name, ZEND_FN_SCOPE_NAME(child));
 		} else {
 			zend_error_noreturn(E_COMPILE_ERROR, "Cannot make static method %s::%s() non static in class %s", ZEND_FN_SCOPE_NAME(parent), child->common.function_name, ZEND_FN_SCOPE_NAME(child));
@@ -3572,12 +3572,12 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 	} else if (parent_flags & ZEND_ACC_ABSTRACT) {
 		child->common.fn_flags |= ZEND_ACC_IMPLEMENTED_ABSTRACT;
 		child->common.prototype = parent;
-	} else if (!IS_CONSTRUCTOR(*parent) || (parent->common.prototype && (parent->common.prototype->common.scope->ce_flags & ZEND_ACC_INTERFACE))) {
+	} else if (!ZEND_IS_CONSTRUCTOR(*parent) || (parent->common.prototype && (parent->common.prototype->common.scope->ce_flags & ZEND_ACC_INTERFACE))) {
 		/* ctors only have a prototype if it comes from an interface */
 		child->common.prototype = parent->common.prototype ? parent->common.prototype : parent;
 	}
 
-	if (child->common.prototype && IS_ABSTRACT_FUNCTION(*child->common.prototype)) {
+	if (child->common.prototype && ZEND_IS_ABSTRACT_FUNCTION(*child->common.prototype)) {
 		if (!zend_do_perform_implementation_check(child, child->common.prototype TSRMLS_CC)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s::%s() must be compatible with %s", ZEND_FN_SCOPE_NAME(child), child->common.function_name, zend_get_function_declaration(child->common.prototype TSRMLS_CC));
 		}
@@ -4007,14 +4007,14 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, const 
 			/* use temporary *overriden HashTable to detect hidden conflict */
 			if (*overriden) {
 				if (zend_hash_quick_find(*overriden, arKey, nKeyLength, h, (void**) &existing_fn) == SUCCESS) {
-					if (IS_ABSTRACT_FUNCTION(*existing_fn)) {
+					if (ZEND_IS_ABSTRACT_FUNCTION(*existing_fn)) {
 						/* Make sure the trait method is compatible with previosly declared abstract method */
 						if (!zend_traits_method_compatibility_check(fn, existing_fn TSRMLS_CC)) {
 							zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
 								zend_get_function_declaration(fn TSRMLS_CC),
 								zend_get_function_declaration(existing_fn TSRMLS_CC));
 						}
-					} else if (IS_ABSTRACT_FUNCTION(*fn)) {
+					} else if (ZEND_IS_ABSTRACT_FUNCTION(*fn)) {
 						/* Make sure the abstract declaration is compatible with previous declaration */
 						if (!zend_traits_method_compatibility_check(existing_fn, fn TSRMLS_CC)) {
 							zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
@@ -4030,14 +4030,14 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, const 
 			}
 			zend_hash_quick_update(*overriden, arKey, nKeyLength, h, fn, sizeof(zend_function), (void**)&fn);
 			return;
-		} else if (IS_ABSTRACT_FUNCTION(*existing_fn)) {
+		} else if (ZEND_IS_ABSTRACT_FUNCTION(*existing_fn)) {
 			/* Make sure the trait method is compatible with previosly declared abstract method */
 			if (!zend_traits_method_compatibility_check(fn, existing_fn TSRMLS_CC)) {
 				zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
 					zend_get_function_declaration(fn TSRMLS_CC),
 					zend_get_function_declaration(existing_fn TSRMLS_CC));
 			}
-		} else if (IS_ABSTRACT_FUNCTION(*fn)) {
+		} else if (ZEND_IS_ABSTRACT_FUNCTION(*fn)) {
 			/* Make sure the abstract declaration is compatible with previous declaration */
 			if (!zend_traits_method_compatibility_check(existing_fn, fn TSRMLS_CC)) {
 				zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
@@ -4075,7 +4075,7 @@ static int zend_fixup_trait_method(zend_function *fn, zend_class_entry *ce TSRML
 
 		fn->common.scope = ce;
 
-		if (IS_ABSTRACT_FUNCTION(*fn)) {
+		if (ZEND_IS_ABSTRACT_FUNCTION(*fn)) {
 			ce->ce_flags |= ZEND_ACC_IMPLICIT_ABSTRACT_CLASS;
 		}
 		if (fn->op_array.static_variables) {
@@ -5208,19 +5208,19 @@ void zend_do_end_class_declaration(const znode *class_token, const znode *parent
 
 	if (ce->constructor) {
 		ce->constructor->common.fn_flags |= ZEND_ACC_CTOR;
-		if (IS_STATIC_FUNCTION(*ce->constructor)) {
+		if (ZEND_IS_STATIC_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Constructor %s::%s() cannot be static", ce->name, ce->constructor->common.function_name);
 		}
 	}
 	if (ce->destructor) {
 		ce->destructor->common.fn_flags |= ZEND_ACC_DTOR;
-		if (IS_STATIC_FUNCTION(*ce->destructor)) {
+		if (ZEND_IS_STATIC_FUNCTION(*ce->destructor)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Destructor %s::%s() cannot be static", ce->name, ce->destructor->common.function_name);
 		}
 	}
 	if (ce->clone) {
 		ce->clone->common.fn_flags |= ZEND_ACC_CLONE;
-		if (IS_STATIC_FUNCTION(*ce->clone)) {
+		if (ZEND_IS_STATIC_FUNCTION(*ce->clone)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Clone method %s::%s() cannot be static", ce->name, ce->clone->common.function_name);
 		}
 	}

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -204,37 +204,34 @@ typedef struct _zend_try_catch_element {
 #define ZEND_ACC_GENERATOR            0x800000
 
 /* method flag helpers */
-#define IS_STATIC_FUNCTION(f) ( \
+#define ZEND_IS_STATIC_FUNCTION(f) ( \
 	(f).common.fn_flags & ZEND_ACC_STATIC	\
 )
-#define IS_FINAL_FUNCTION(f) ( \
+#define ZEND_IS_FINAL_FUNCTION(f) ( \
 	(f).common.fn_flags & ZEND_ACC_FINAL	\
 )
-#define IS_ABSTRACT_FUNCTION(f) ( \
+#define ZEND_IS_ABSTRACT_FUNCTION(f) ( \
 	(f).common.fn_flags & ZEND_ACC_ABSTRACT	\
 )
-#define IS_PRIVATE_FUNCTION(f) ( \
+#define ZEND_IS_PRIVATE_FUNCTION(f) ( \
 	(f).common.fn_flags & ZEND_ACC_PRIVATE	\
 )
-#define IS_PROTECTED_FUNCTION(f) ( \
+#define ZEND_IS_PROTECTED_FUNCTION(f) ( \
 	(f).common.fn_flags & ZEND_ACC_PROTECTED	\
 )
-#define IS_PUBLIC_FUNCTION(f) ( \
+#define ZEND_IS_PUBLIC_FUNCTION(f) ( \
 	(f).common.fn_flags & ZEND_ACC_PUBLIC	\
 )
-#define IS_PUBLIC_FUNCTION(f) ( \
-	(f).common.fn_flags & ZEND_ACC_PUBLIC	\
-)
-#define IS_CONSTRUCTOR(f) ( \
+#define ZEND_IS_CONSTRUCTOR(f) ( \
 	(f).common.fn_flags & ZEND_ACC_CTOR	\
 )
-#define IS_DESTRUCTOR(f) ( \
+#define ZEND_IS_DESTRUCTOR(f) ( \
 	(f).common.fn_flags & ZEND_ACC_DTOR	\
 )
-#define IS_DEPRECATED_FUNCTION(f) ( \
+#define ZEND_IS_DEPRECATED_FUNCTION(f) ( \
 	(f).common.fn_flags & ZEND_ACC_DEPRECATED	\
 )
-#define IS_CLOSURE(f) ( \
+#define ZEND_IS_CLOSURE(f) ( \
 	(f).common.fn_flags & ZEND_ACC_CLOSURE	\
 )
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -203,6 +203,41 @@ typedef struct _zend_try_catch_element {
 #define ZEND_ACC_CLOSURE              0x100000
 #define ZEND_ACC_GENERATOR            0x800000
 
+/* method flag helpers */
+#define IS_STATIC_METHOD(f) ( \
+	f->common.fn_flags & ZEND_ACC_STATIC	\
+)
+#define IS_FINAL_METHOD(f) ( \
+	f->common.fn_flags & ZEND_ACC_STATIC	\
+)
+#define IS_ABSTRACT_METHOD(f) ( \
+	f->common.fn_flags & ZEND_ACC_ABSTRACT	\
+)
+#define IS_PRIVATE_METHOD(f) ( \
+	f->common.fn_flags & ZEND_ACC_PRIVATE	\
+)
+#define IS_PROTECTED_METHOD(f) ( \
+	f->common.fn_flags & ZEND_ACC_PROTECTED	\
+)
+#define IS_PUBLIC_METHOD(f) ( \
+	f->common.fn_flags & ZEND_ACC_PUBLIC	\
+)
+#define IS_PUBLIC_METHOD(f) ( \
+	f->common.fn_flags & ZEND_ACC_PUBLIC	\
+)
+#define IS_CONSTRUCTOR(f) ( \
+	f->common.fn_flags & ZEND_ACC_CTOR	\
+)
+#define IS_DESTRUCTOR(f) ( \
+	f->common.fn_flags & ZEND_ACC_DTOR	\
+)
+#define IS_DEPRECATED_FUNCTION(f) ( \
+	f->common.fn_flags & ZEND_ACC_DEPRECATED	\
+)
+#define IS_CLOSURE(f) ( \
+	f->common.fn_flags & ZEND_ACC_CLOSURE	\
+)
+
 /* function flag for internal user call handlers __call, __callstatic */
 #define ZEND_ACC_CALL_VIA_HANDLER     0x200000
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -204,38 +204,38 @@ typedef struct _zend_try_catch_element {
 #define ZEND_ACC_GENERATOR            0x800000
 
 /* method flag helpers */
-#define IS_STATIC_METHOD(f) ( \
-	f->common.fn_flags & ZEND_ACC_STATIC	\
+#define IS_STATIC_FUNCTION(f) ( \
+	(f).common.fn_flags & ZEND_ACC_STATIC	\
 )
-#define IS_FINAL_METHOD(f) ( \
-	f->common.fn_flags & ZEND_ACC_STATIC	\
+#define IS_FINAL_FUNCTION(f) ( \
+	(f).common.fn_flags & ZEND_ACC_STATIC	\
 )
-#define IS_ABSTRACT_METHOD(f) ( \
-	f->common.fn_flags & ZEND_ACC_ABSTRACT	\
+#define IS_ABSTRACT_FUNCTION(f) ( \
+	(f).common.fn_flags & ZEND_ACC_ABSTRACT	\
 )
-#define IS_PRIVATE_METHOD(f) ( \
-	f->common.fn_flags & ZEND_ACC_PRIVATE	\
+#define IS_PRIVATE_FUNCTION(f) ( \
+	(f).common.fn_flags & ZEND_ACC_PRIVATE	\
 )
-#define IS_PROTECTED_METHOD(f) ( \
-	f->common.fn_flags & ZEND_ACC_PROTECTED	\
+#define IS_PROTECTED_FUNCTION(f) ( \
+	(f).common.fn_flags & ZEND_ACC_PROTECTED	\
 )
-#define IS_PUBLIC_METHOD(f) ( \
-	f->common.fn_flags & ZEND_ACC_PUBLIC	\
+#define IS_PUBLIC_FUNCTION(f) ( \
+	(f).common.fn_flags & ZEND_ACC_PUBLIC	\
 )
-#define IS_PUBLIC_METHOD(f) ( \
-	f->common.fn_flags & ZEND_ACC_PUBLIC	\
+#define IS_PUBLIC_FUNCTION(f) ( \
+	(f).common.fn_flags & ZEND_ACC_PUBLIC	\
 )
 #define IS_CONSTRUCTOR(f) ( \
-	f->common.fn_flags & ZEND_ACC_CTOR	\
+	(f).common.fn_flags & ZEND_ACC_CTOR	\
 )
 #define IS_DESTRUCTOR(f) ( \
-	f->common.fn_flags & ZEND_ACC_DTOR	\
+	(f).common.fn_flags & ZEND_ACC_DTOR	\
 )
 #define IS_DEPRECATED_FUNCTION(f) ( \
-	f->common.fn_flags & ZEND_ACC_DEPRECATED	\
+	(f).common.fn_flags & ZEND_ACC_DEPRECATED	\
 )
 #define IS_CLOSURE(f) ( \
-	f->common.fn_flags & ZEND_ACC_CLOSURE	\
+	(f).common.fn_flags & ZEND_ACC_CLOSURE	\
 )
 
 /* function flag for internal user call handlers __call, __callstatic */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -208,7 +208,7 @@ typedef struct _zend_try_catch_element {
 	(f).common.fn_flags & ZEND_ACC_STATIC	\
 )
 #define IS_FINAL_FUNCTION(f) ( \
-	(f).common.fn_flags & ZEND_ACC_STATIC	\
+	(f).common.fn_flags & ZEND_ACC_FINAL	\
 )
 #define IS_ABSTRACT_FUNCTION(f) ( \
 	(f).common.fn_flags & ZEND_ACC_ABSTRACT	\

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -709,10 +709,10 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache TS
 	}
 
 	if (EX(function_state).function->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) {
-		if (EX(function_state).function->common.fn_flags & ZEND_ACC_ABSTRACT) {
+		if (IS_ABSTRACT_FUNCTION(*EX(function_state).function)) {
 			zend_error_noreturn(E_ERROR, "Cannot call abstract method %s::%s()", EX(function_state).function->common.scope->name, EX(function_state).function->common.function_name);
 		}
-		if (EX(function_state).function->common.fn_flags & ZEND_ACC_DEPRECATED) {
+		if (IS_DEPRECATED_FUNCTION(*EX(function_state).function)) {
  			zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
 				EX(function_state).function->common.scope ? EX(function_state).function->common.scope->name : "",
 				EX(function_state).function->common.scope ? "::" : "",
@@ -789,7 +789,7 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache TS
 	}
 
 	if (fci->object_ptr) {
-		if ((EX(function_state).function->common.fn_flags & ZEND_ACC_STATIC)) {
+		if (IS_STATIC_FUNCTION(*(EX(function_state).function))) {
 			EG(This) = NULL;
 		} else {
 			EG(This) = fci->object_ptr;
@@ -1521,11 +1521,11 @@ typedef struct _zend_abstract_info {
 
 static int zend_verify_abstract_class_function(zend_function *fn, zend_abstract_info *ai TSRMLS_DC) /* {{{ */
 {
-	if (fn->common.fn_flags & ZEND_ACC_ABSTRACT) {
+	if (IS_ABSTRACT_FUNCTION(*fn)) {
 		if (ai->cnt < MAX_ABSTRACT_INFO_CNT) {
 			ai->afn[ai->cnt] = fn;
 		}
-		if (fn->common.fn_flags & ZEND_ACC_CTOR) {
+		if (IS_CONSTRUCTOR(*fn)) {
 			if (!ai->ctor) {
 				ai->cnt++;
 				ai->ctor = 1;

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -709,10 +709,10 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache TS
 	}
 
 	if (EX(function_state).function->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) {
-		if (IS_ABSTRACT_FUNCTION(*EX(function_state).function)) {
+		if (ZEND_IS_ABSTRACT_FUNCTION(*EX(function_state).function)) {
 			zend_error_noreturn(E_ERROR, "Cannot call abstract method %s::%s()", EX(function_state).function->common.scope->name, EX(function_state).function->common.function_name);
 		}
-		if (IS_DEPRECATED_FUNCTION(*EX(function_state).function)) {
+		if (ZEND_IS_DEPRECATED_FUNCTION(*EX(function_state).function)) {
  			zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
 				EX(function_state).function->common.scope ? EX(function_state).function->common.scope->name : "",
 				EX(function_state).function->common.scope ? "::" : "",
@@ -789,7 +789,7 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache TS
 	}
 
 	if (fci->object_ptr) {
-		if (IS_STATIC_FUNCTION(*(EX(function_state).function))) {
+		if (ZEND_IS_STATIC_FUNCTION(*(EX(function_state).function))) {
 			EG(This) = NULL;
 		} else {
 			EG(This) = fci->object_ptr;
@@ -1521,11 +1521,11 @@ typedef struct _zend_abstract_info {
 
 static int zend_verify_abstract_class_function(zend_function *fn, zend_abstract_info *ai TSRMLS_DC) /* {{{ */
 {
-	if (IS_ABSTRACT_FUNCTION(*fn)) {
+	if (ZEND_IS_ABSTRACT_FUNCTION(*fn)) {
 		if (ai->cnt < MAX_ABSTRACT_INFO_CNT) {
 			ai->afn[ai->cnt] = fn;
 		}
-		if (IS_CONSTRUCTOR(*fn)) {
+		if (ZEND_IS_CONSTRUCTOR(*fn)) {
 			if (!ai->ctor) {
 				ai->cnt++;
 				ai->ctor = 1;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1089,12 +1089,12 @@ static union _zend_function *zend_std_get_method(zval **object_ptr, char *method
 			zend_function *priv_fbc;
 
 			if (zend_hash_quick_find(&EG(scope)->function_table, lc_method_name, method_len+1, hash_value, (void **) &priv_fbc)==SUCCESS
-				&& IS_PRIVATE_FUNCTION(*priv_fbc)
+				&& ZEND_IS_PRIVATE_FUNCTION(*priv_fbc)
 				&& priv_fbc->common.scope == EG(scope)) {
 				fbc = priv_fbc;
 			}
 		}
-		if (IS_PROTECTED_FUNCTION(*fbc)) {
+		if (ZEND_IS_PROTECTED_FUNCTION(*fbc)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 * If we're not and __call() handler exists, invoke it, otherwise error out.
 			 */
@@ -1222,7 +1222,7 @@ ZEND_API zend_function *zend_std_get_static_method(zend_class_entry *ce, const c
 #if MBO_0
 	/* right now this function is used for non static method lookup too */
 	/* Is the function static */
-	if (UNEXPECTED(!IS_STATIC_FUNCTION(*fbc))) {
+	if (UNEXPECTED(!ZEND_IS_STATIC_FUNCTION(*fbc))) {
 		zend_error_noreturn(E_ERROR, "Cannot call non static method %s::%s() without object", ZEND_FN_SCOPE_NAME(fbc), fbc->common.function_name);
 	}
 #endif
@@ -1243,7 +1243,7 @@ ZEND_API zend_function *zend_std_get_static_method(zend_class_entry *ce, const c
 				zend_error_noreturn(E_ERROR, "Call to %s method %s::%s() from context '%s'", zend_visibility_string(fbc->common.fn_flags), ZEND_FN_SCOPE_NAME(fbc), function_name_strval, EG(scope) ? EG(scope)->name : "");
 			}
 		}
-	} else if (IS_PROTECTED_FUNCTION(*fbc)) {
+	} else if (ZEND_IS_PROTECTED_FUNCTION(*fbc)) {
 		/* Ensure that if we're calling a protected function, we're allowed to do so.
 		 */
 		if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(fbc), EG(scope)))) {
@@ -1345,7 +1345,7 @@ ZEND_API union _zend_function *zend_std_get_constructor(zval *object TSRMLS_DC) 
 					zend_error_noreturn(E_ERROR, "Call to private %s::%s() from invalid context", constructor->common.scope->name, constructor->common.function_name);
 				}
 			}
-		} else if (IS_PROTECTED_FUNCTION(*constructor)) {
+		} else if (ZEND_IS_PROTECTED_FUNCTION(*constructor)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 * Constructors only have prototype if they are defined by an interface but
 			 * it is the compilers responsibility to take care of the prototype.
@@ -1633,7 +1633,7 @@ int zend_std_get_closure(zval *obj, zend_class_entry **ce_ptr, zend_function **f
 	}
 
 	*ce_ptr = ce;
-	if (IS_STATIC_FUNCTION(*(*fptr_ptr))) {
+	if (ZEND_IS_STATIC_FUNCTION(*(*fptr_ptr))) {
 		if (zobj_ptr) {
 			*zobj_ptr = NULL;
 		}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1089,12 +1089,12 @@ static union _zend_function *zend_std_get_method(zval **object_ptr, char *method
 			zend_function *priv_fbc;
 
 			if (zend_hash_quick_find(&EG(scope)->function_table, lc_method_name, method_len+1, hash_value, (void **) &priv_fbc)==SUCCESS
-				&& priv_fbc->common.fn_flags & ZEND_ACC_PRIVATE
+				&& IS_PRIVATE_FUNCTION(*priv_fbc)
 				&& priv_fbc->common.scope == EG(scope)) {
 				fbc = priv_fbc;
 			}
 		}
-		if ((fbc->common.fn_flags & ZEND_ACC_PROTECTED)) {
+		if (IS_PROTECTED_FUNCTION(*fbc)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 * If we're not and __call() handler exists, invoke it, otherwise error out.
 			 */
@@ -1222,7 +1222,7 @@ ZEND_API zend_function *zend_std_get_static_method(zend_class_entry *ce, const c
 #if MBO_0
 	/* right now this function is used for non static method lookup too */
 	/* Is the function static */
-	if (UNEXPECTED(!(fbc->common.fn_flags & ZEND_ACC_STATIC))) {
+	if (UNEXPECTED(!IS_STATIC_FUNCTION(*fbc))) {
 		zend_error_noreturn(E_ERROR, "Cannot call non static method %s::%s() without object", ZEND_FN_SCOPE_NAME(fbc), fbc->common.function_name);
 	}
 #endif
@@ -1243,7 +1243,7 @@ ZEND_API zend_function *zend_std_get_static_method(zend_class_entry *ce, const c
 				zend_error_noreturn(E_ERROR, "Call to %s method %s::%s() from context '%s'", zend_visibility_string(fbc->common.fn_flags), ZEND_FN_SCOPE_NAME(fbc), function_name_strval, EG(scope) ? EG(scope)->name : "");
 			}
 		}
-	} else if ((fbc->common.fn_flags & ZEND_ACC_PROTECTED)) {
+	} else if (IS_PROTECTED_FUNCTION(*fbc)) {
 		/* Ensure that if we're calling a protected function, we're allowed to do so.
 		 */
 		if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(fbc), EG(scope)))) {
@@ -1345,7 +1345,7 @@ ZEND_API union _zend_function *zend_std_get_constructor(zval *object TSRMLS_DC) 
 					zend_error_noreturn(E_ERROR, "Call to private %s::%s() from invalid context", constructor->common.scope->name, constructor->common.function_name);
 				}
 			}
-		} else if ((constructor->common.fn_flags & ZEND_ACC_PROTECTED)) {
+		} else if (IS_PROTECTED_FUNCTION(*constructor)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 * Constructors only have prototype if they are defined by an interface but
 			 * it is the compilers responsibility to take care of the prototype.
@@ -1633,7 +1633,7 @@ int zend_std_get_closure(zval *obj, zend_class_entry **ce_ptr, zend_function **f
 	}
 
 	*ce_ptr = ce;
-	if ((*fptr_ptr)->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*(*fptr_ptr))) {
 		if (zobj_ptr) {
 			*zobj_ptr = NULL;
 		}

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1906,10 +1906,10 @@ ZEND_VM_HELPER(zend_do_fcall_common_helper, ANY, ANY)
 	SAVE_OPLINE();
 	EX(object) = EX(call)->object;
 	if (UNEXPECTED((fbc->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) != 0)) {
-		if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_ABSTRACT) != 0)) {
+		if (UNEXPECTED(IS_ABSTRACT_FUNCTION(*fbc))) {
 			zend_error_noreturn(E_ERROR, "Cannot call abstract method %s::%s()", fbc->common.scope->name, fbc->common.function_name);
 		}
-		if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_DEPRECATED) != 0)) {
+		if (UNEXPECTED(IS_DEPRECATED_FUNCTION(*fbc))) {
 			zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
 				fbc->common.scope ? fbc->common.scope->name : "",
 				fbc->common.scope ? "::" : "",
@@ -1920,7 +1920,7 @@ ZEND_VM_HELPER(zend_do_fcall_common_helper, ANY, ANY)
 		}
 	}
 	if (fbc->common.scope &&
-		!(fbc->common.fn_flags & ZEND_ACC_STATIC) &&
+		!IS_STATIC_FUNCTION(*fbc) &&
 		!EX(object)) {
 
 		if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
@@ -2466,7 +2466,7 @@ ZEND_VM_HANDLER(112, ZEND_INIT_METHOD_CALL, TMP|VAR|UNUSED|CV, CONST|TMP|VAR|CV)
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -2581,13 +2581,13 @@ ZEND_VM_HANDLER(113, ZEND_INIT_STATIC_METHOD_CALL, CONST|VAR, CONST|TMP|VAR|UNUS
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -2679,8 +2679,7 @@ ZEND_VM_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST|TMP|VAR|CV)
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (OP2_TYPE == IS_VAR && OP2_FREE && Z_REFCOUNT_P(function_name) == 1 &&
-			    call->fbc->common.fn_flags & ZEND_ACC_CLOSURE) {
+			if (OP2_TYPE == IS_VAR && OP2_FREE && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -2738,7 +2737,7 @@ ZEND_VM_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST|TMP|VAR|CV)
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+				if (IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -3649,7 +3648,7 @@ ZEND_VM_HANDLER(110, ZEND_CLONE, CONST|TMP|VAR|UNUSED|CV, ANY)
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if ((clone->common.fn_flags & ZEND_ACC_PROTECTED)) {
+		} else if (IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1906,10 +1906,10 @@ ZEND_VM_HELPER(zend_do_fcall_common_helper, ANY, ANY)
 	SAVE_OPLINE();
 	EX(object) = EX(call)->object;
 	if (UNEXPECTED((fbc->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) != 0)) {
-		if (UNEXPECTED(IS_ABSTRACT_FUNCTION(*fbc))) {
+		if (UNEXPECTED(ZEND_IS_ABSTRACT_FUNCTION(*fbc))) {
 			zend_error_noreturn(E_ERROR, "Cannot call abstract method %s::%s()", fbc->common.scope->name, fbc->common.function_name);
 		}
-		if (UNEXPECTED(IS_DEPRECATED_FUNCTION(*fbc))) {
+		if (UNEXPECTED(ZEND_IS_DEPRECATED_FUNCTION(*fbc))) {
 			zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
 				fbc->common.scope ? fbc->common.scope->name : "",
 				fbc->common.scope ? "::" : "",
@@ -1920,7 +1920,7 @@ ZEND_VM_HELPER(zend_do_fcall_common_helper, ANY, ANY)
 		}
 	}
 	if (fbc->common.scope &&
-		!IS_STATIC_FUNCTION(*fbc) &&
+		!ZEND_IS_STATIC_FUNCTION(*fbc) &&
 		!EX(object)) {
 
 		if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
@@ -2466,7 +2466,7 @@ ZEND_VM_HANDLER(112, ZEND_INIT_METHOD_CALL, TMP|VAR|UNUSED|CV, CONST|TMP|VAR|CV)
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -2581,13 +2581,13 @@ ZEND_VM_HANDLER(113, ZEND_INIT_STATIC_METHOD_CALL, CONST|VAR, CONST|TMP|VAR|UNUS
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -2679,7 +2679,7 @@ ZEND_VM_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST|TMP|VAR|CV)
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (OP2_TYPE == IS_VAR && OP2_FREE && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
+			if (OP2_TYPE == IS_VAR && OP2_FREE && Z_REFCOUNT_P(function_name) == 1 && ZEND_IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -2737,7 +2737,7 @@ ZEND_VM_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST|TMP|VAR|CV)
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if (IS_STATIC_FUNCTION(*call->fbc)) {
+				if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -3648,7 +3648,7 @@ ZEND_VM_HANDLER(110, ZEND_CLONE, CONST|TMP|VAR|UNUSED|CV, ANY)
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if (IS_PROTECTED_FUNCTION(*clone)) {
+		} else if (ZEND_IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -486,10 +486,10 @@ static int ZEND_FASTCALL zend_do_fcall_common_helper_SPEC(ZEND_OPCODE_HANDLER_AR
 	SAVE_OPLINE();
 	EX(object) = EX(call)->object;
 	if (UNEXPECTED((fbc->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) != 0)) {
-		if (UNEXPECTED(IS_ABSTRACT_FUNCTION(*fbc))) {
+		if (UNEXPECTED(ZEND_IS_ABSTRACT_FUNCTION(*fbc))) {
 			zend_error_noreturn(E_ERROR, "Cannot call abstract method %s::%s()", fbc->common.scope->name, fbc->common.function_name);
 		}
-		if (UNEXPECTED(IS_DEPRECATED_FUNCTION(*fbc))) {
+		if (UNEXPECTED(ZEND_IS_DEPRECATED_FUNCTION(*fbc))) {
 			zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
 				fbc->common.scope ? fbc->common.scope->name : "",
 				fbc->common.scope ? "::" : "",
@@ -500,7 +500,7 @@ static int ZEND_FASTCALL zend_do_fcall_common_helper_SPEC(ZEND_OPCODE_HANDLER_AR
 		}
 	}
 	if (fbc->common.scope &&
-		!IS_STATIC_FUNCTION(*fbc) &&
+		!ZEND_IS_STATIC_FUNCTION(*fbc) &&
 		!EX(object)) {
 
 		if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
@@ -1484,7 +1484,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPCODE
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (IS_CONST == IS_VAR && 0 && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
+			if (IS_CONST == IS_VAR && 0 && Z_REFCOUNT_P(function_name) == 1 && ZEND_IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -1542,7 +1542,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPCODE
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if (IS_STATIC_FUNCTION(*call->fbc)) {
+				if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -1820,7 +1820,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_TMP_HANDLER(ZEND_OPCODE_H
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (IS_TMP_VAR == IS_VAR && 1 && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
+			if (IS_TMP_VAR == IS_VAR && 1 && Z_REFCOUNT_P(function_name) == 1 && ZEND_IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -1878,7 +1878,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_TMP_HANDLER(ZEND_OPCODE_H
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if (IS_STATIC_FUNCTION(*call->fbc)) {
+				if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -2018,7 +2018,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (IS_VAR == IS_VAR && (free_op2.var != NULL) && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
+			if (IS_VAR == IS_VAR && (free_op2.var != NULL) && Z_REFCOUNT_P(function_name) == 1 && ZEND_IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -2076,7 +2076,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if (IS_STATIC_FUNCTION(*call->fbc)) {
+				if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -2253,7 +2253,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CV_HANDLER(ZEND_OPCODE_HA
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (IS_CV == IS_VAR && 0 && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
+			if (IS_CV == IS_VAR && 0 && Z_REFCOUNT_P(function_name) == 1 && ZEND_IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -2311,7 +2311,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CV_HANDLER(ZEND_OPCODE_HA
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if (IS_STATIC_FUNCTION(*call->fbc)) {
+				if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -2808,7 +2808,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_CONST_HANDLER(ZEND_OPCODE_HANDLER_ARGS
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if (IS_PROTECTED_FUNCTION(*clone)) {
+		} else if (ZEND_IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -3885,13 +3885,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_CONST_HANDLER(
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -4881,13 +4881,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_TMP_HANDLER(ZE
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -5745,13 +5745,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_VAR_HANDLER(ZE
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -6480,13 +6480,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_UNUSED_HANDLER
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -7333,13 +7333,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_CV_HANDLER(ZEN
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -8162,7 +8162,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_TMP_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if (IS_PROTECTED_FUNCTION(*clone)) {
+		} else if (ZEND_IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -9305,7 +9305,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_TMP_CONST_HANDLER(ZEND_OPCO
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -10170,7 +10170,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_TMP_TMP_HANDLER(ZEND_OPCODE
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -11036,7 +11036,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_TMP_VAR_HANDLER(ZEND_OPCODE
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -12482,7 +12482,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_TMP_CV_HANDLER(ZEND_OPCODE_
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -13531,7 +13531,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_VAR_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if (IS_PROTECTED_FUNCTION(*clone)) {
+		} else if (ZEND_IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -15720,7 +15720,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_VAR_CONST_HANDLER(ZEND_OPCO
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -15834,13 +15834,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_CONST_HANDLER(ZE
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -18066,7 +18066,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_VAR_TMP_HANDLER(ZEND_OPCODE
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -18181,13 +18181,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_TMP_HANDLER(ZEND
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -20373,7 +20373,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_VAR_VAR_HANDLER(ZEND_OPCODE
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -20488,13 +20488,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_VAR_HANDLER(ZEND
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -21934,13 +21934,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_UNUSED_HANDLER(Z
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -23830,7 +23830,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_VAR_CV_HANDLER(ZEND_OPCODE_
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -23944,13 +23944,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_CV_HANDLER(ZEND_
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && ZEND_IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -24590,7 +24590,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_UNUSED_HANDLER(ZEND_OPCODE_HANDLER_ARG
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if (IS_PROTECTED_FUNCTION(*clone)) {
+		} else if (ZEND_IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -25472,7 +25472,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_UNUSED_CONST_HANDLER(ZEND_O
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -26880,7 +26880,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_UNUSED_TMP_HANDLER(ZEND_OPC
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -28194,7 +28194,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_UNUSED_VAR_HANDLER(ZEND_OPC
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -29936,7 +29936,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_UNUSED_CV_HANDLER(ZEND_OPCO
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -31128,7 +31128,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_CV_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if (IS_PROTECTED_FUNCTION(*clone)) {
+		} else if (ZEND_IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -33175,7 +33175,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_CV_CONST_HANDLER(ZEND_OPCOD
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -35287,7 +35287,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_CV_TMP_HANDLER(ZEND_OPCODE_
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -37454,7 +37454,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_CV_VAR_HANDLER(ZEND_OPCODE_
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -40622,7 +40622,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_CV_CV_HANDLER(ZEND_OPCODE_H
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if (IS_STATIC_FUNCTION(*call->fbc)) {
+	if (ZEND_IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -486,10 +486,10 @@ static int ZEND_FASTCALL zend_do_fcall_common_helper_SPEC(ZEND_OPCODE_HANDLER_AR
 	SAVE_OPLINE();
 	EX(object) = EX(call)->object;
 	if (UNEXPECTED((fbc->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) != 0)) {
-		if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_ABSTRACT) != 0)) {
+		if (UNEXPECTED(IS_ABSTRACT_FUNCTION(*fbc))) {
 			zend_error_noreturn(E_ERROR, "Cannot call abstract method %s::%s()", fbc->common.scope->name, fbc->common.function_name);
 		}
-		if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_DEPRECATED) != 0)) {
+		if (UNEXPECTED(IS_DEPRECATED_FUNCTION(*fbc))) {
 			zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
 				fbc->common.scope ? fbc->common.scope->name : "",
 				fbc->common.scope ? "::" : "",
@@ -500,7 +500,7 @@ static int ZEND_FASTCALL zend_do_fcall_common_helper_SPEC(ZEND_OPCODE_HANDLER_AR
 		}
 	}
 	if (fbc->common.scope &&
-		!(fbc->common.fn_flags & ZEND_ACC_STATIC) &&
+		!IS_STATIC_FUNCTION(*fbc) &&
 		!EX(object)) {
 
 		if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
@@ -1484,8 +1484,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPCODE
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (IS_CONST == IS_VAR && 0 && Z_REFCOUNT_P(function_name) == 1 &&
-			    call->fbc->common.fn_flags & ZEND_ACC_CLOSURE) {
+			if (IS_CONST == IS_VAR && 0 && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -1543,7 +1542,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CONST_HANDLER(ZEND_OPCODE
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+				if (IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -1821,8 +1820,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_TMP_HANDLER(ZEND_OPCODE_H
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (IS_TMP_VAR == IS_VAR && 1 && Z_REFCOUNT_P(function_name) == 1 &&
-			    call->fbc->common.fn_flags & ZEND_ACC_CLOSURE) {
+			if (IS_TMP_VAR == IS_VAR && 1 && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -1880,7 +1878,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_TMP_HANDLER(ZEND_OPCODE_H
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+				if (IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -2020,8 +2018,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (IS_VAR == IS_VAR && (free_op2.var != NULL) && Z_REFCOUNT_P(function_name) == 1 &&
-			    call->fbc->common.fn_flags & ZEND_ACC_CLOSURE) {
+			if (IS_VAR == IS_VAR && (free_op2.var != NULL) && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -2079,7 +2076,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+				if (IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -2256,8 +2253,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CV_HANDLER(ZEND_OPCODE_HA
 			if (call->object) {
 				Z_ADDREF_P(call->object);
 			}
-			if (IS_CV == IS_VAR && 0 && Z_REFCOUNT_P(function_name) == 1 &&
-			    call->fbc->common.fn_flags & ZEND_ACC_CLOSURE) {
+			if (IS_CV == IS_VAR && 0 && Z_REFCOUNT_P(function_name) == 1 && IS_CLOSURE(*call->fbc)) {
 				/* Delay closure destruction until its invocation */
 				call->fbc->common.prototype = (zend_function*)function_name;
 			} else {
@@ -2315,7 +2311,7 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_CV_HANDLER(ZEND_OPCODE_HA
 					zend_error_noreturn(E_ERROR, "Call to undefined method %s::%s()", Z_OBJ_CLASS_NAME_P(call->object), Z_STRVAL_PP(method));
 				}
 
-				if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+				if (IS_STATIC_FUNCTION(*call->fbc)) {
 					call->object = NULL;
 				} else {
 					if (!PZVAL_IS_REF(call->object)) {
@@ -2812,7 +2808,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_CONST_HANDLER(ZEND_OPCODE_HANDLER_ARGS
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if ((clone->common.fn_flags & ZEND_ACC_PROTECTED)) {
+		} else if (IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -3889,13 +3885,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_CONST_HANDLER(
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -4885,13 +4881,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_TMP_HANDLER(ZE
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -5749,13 +5745,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_VAR_HANDLER(ZE
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -6484,13 +6480,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_UNUSED_HANDLER
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -7337,13 +7333,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_CV_HANDLER(ZEN
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -8166,7 +8162,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_TMP_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if ((clone->common.fn_flags & ZEND_ACC_PROTECTED)) {
+		} else if (IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -9309,7 +9305,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_TMP_CONST_HANDLER(ZEND_OPCO
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -10174,7 +10170,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_TMP_TMP_HANDLER(ZEND_OPCODE
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -11040,7 +11036,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_TMP_VAR_HANDLER(ZEND_OPCODE
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -12486,7 +12482,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_TMP_CV_HANDLER(ZEND_OPCODE_
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -13535,7 +13531,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_VAR_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if ((clone->common.fn_flags & ZEND_ACC_PROTECTED)) {
+		} else if (IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -15724,7 +15720,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_VAR_CONST_HANDLER(ZEND_OPCO
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -15838,13 +15834,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_CONST_HANDLER(ZE
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -18070,7 +18066,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_VAR_TMP_HANDLER(ZEND_OPCODE
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -18185,13 +18181,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_TMP_HANDLER(ZEND
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -20377,7 +20373,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_VAR_VAR_HANDLER(ZEND_OPCODE
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -20492,13 +20488,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_VAR_HANDLER(ZEND
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -21938,13 +21934,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_UNUSED_HANDLER(Z
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -23834,7 +23830,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_VAR_CV_HANDLER(ZEND_OPCODE_
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -23948,13 +23944,13 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_CV_HANDLER(ZEND_
 		if (UNEXPECTED(ce->constructor == NULL)) {
 			zend_error_noreturn(E_ERROR, "Cannot call constructor");
 		}
-		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
+		if (EG(This) && Z_OBJCE_P(EG(This)) != ce->constructor->common.scope && IS_PRIVATE_FUNCTION(*ce->constructor)) {
 			zend_error_noreturn(E_ERROR, "Cannot call private %s::__construct()", ce->name);
 		}
 		call->fbc = ce->constructor;
 	}
 
-	if (call->fbc->common.fn_flags & ZEND_ACC_STATIC) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (EG(This) &&
@@ -24594,7 +24590,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_UNUSED_HANDLER(ZEND_OPCODE_HANDLER_ARG
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if ((clone->common.fn_flags & ZEND_ACC_PROTECTED)) {
+		} else if (IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -25476,7 +25472,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_UNUSED_CONST_HANDLER(ZEND_O
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -26884,7 +26880,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_UNUSED_TMP_HANDLER(ZEND_OPC
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -28198,7 +28194,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_UNUSED_VAR_HANDLER(ZEND_OPC
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -29940,7 +29936,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_UNUSED_CV_HANDLER(ZEND_OPCO
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -31132,7 +31128,7 @@ static int ZEND_FASTCALL  ZEND_CLONE_SPEC_CV_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
 			if (UNEXPECTED(ce != EG(scope))) {
 				zend_error_noreturn(E_ERROR, "Call to private %s::__clone() from context '%s'", ce->name, EG(scope) ? EG(scope)->name : "");
 			}
-		} else if ((clone->common.fn_flags & ZEND_ACC_PROTECTED)) {
+		} else if (IS_PROTECTED_FUNCTION(*clone)) {
 			/* Ensure that if we're calling a protected function, we're allowed to do so.
 			 */
 			if (UNEXPECTED(!zend_check_protected(zend_get_function_root_class(clone), EG(scope)))) {
@@ -33179,7 +33175,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_CV_CONST_HANDLER(ZEND_OPCOD
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -35291,7 +35287,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_CV_TMP_HANDLER(ZEND_OPCODE_
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -37458,7 +37454,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_CV_VAR_HANDLER(ZEND_OPCODE_
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {
@@ -40626,7 +40622,7 @@ static int ZEND_FASTCALL  ZEND_INIT_METHOD_CALL_SPEC_CV_CV_HANDLER(ZEND_OPCODE_H
 		zend_error_noreturn(E_ERROR, "Call to a member function %s() on a non-object", function_name_strval);
 	}
 
-	if ((call->fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+	if (IS_STATIC_FUNCTION(*call->fbc)) {
 		call->object = NULL;
 	} else {
 		if (!PZVAL_IS_REF(call->object)) {

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -500,7 +500,7 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			zend_hash_internal_pointer_reset_ex(&ce->function_table, &pos);
 
 			while (zend_hash_get_current_data_ex(&ce->function_table, (void **) &mptr, &pos) == SUCCESS) {
-				if (IS_STATIC_FUNCTION(*mptr) && (!IS_PRIVATE_FUNCTION(*mptr) || mptr->common.scope == ce))
+				if (ZEND_IS_STATIC_FUNCTION(*mptr) && (!ZEND_IS_PRIVATE_FUNCTION(*mptr) || mptr->common.scope == ce))
 				{
 					count_static_funcs++;
 				}
@@ -517,7 +517,7 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			zend_hash_internal_pointer_reset_ex(&ce->function_table, &pos);
 
 			while (zend_hash_get_current_data_ex(&ce->function_table, (void **) &mptr, &pos) == SUCCESS) {
-				if (IS_STATIC_FUNCTION(*mptr) && (!IS_PRIVATE_FUNCTION(*mptr) || mptr->common.scope == ce))
+				if (ZEND_IS_STATIC_FUNCTION(*mptr) && (!ZEND_IS_PRIVATE_FUNCTION(*mptr) || mptr->common.scope == ce))
 				{
 					string_printf(str, "\n");
 					_function_string(str, mptr, ce, sub_indent.string TSRMLS_CC);
@@ -599,14 +599,14 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			zend_hash_internal_pointer_reset_ex(&ce->function_table, &pos);
 
 			while (zend_hash_get_current_data_ex(&ce->function_table, (void **) &mptr, &pos) == SUCCESS) {
-				if (!IS_STATIC_FUNCTION(*mptr) && (!IS_PRIVATE_FUNCTION(*mptr) || mptr->common.scope == ce)) {
+				if (!ZEND_IS_STATIC_FUNCTION(*mptr) && (!ZEND_IS_PRIVATE_FUNCTION(*mptr) || mptr->common.scope == ce)) {
 					char *key;
 					uint key_len;
 					ulong num_index;
 					uint len = strlen(mptr->common.function_name);
 
 					/* Do not display old-style inherited constructors */
-					if (!IS_CONSTRUCTOR(*mptr)
+					if (!ZEND_IS_CONSTRUCTOR(*mptr)
 						|| mptr->common.scope == ce
 						|| zend_hash_get_current_key_ex(&ce->function_table, &key, &key_len, &num_index, 0, &pos) != HASH_KEY_IS_STRING
 						|| zend_binary_strcasecmp(key, key_len-1, mptr->common.function_name, len) == 0)
@@ -834,9 +834,9 @@ static void _function_string(string *str, zend_function *fptr, zend_class_entry 
 	}
 
 	string_write(str, indent, strlen(indent));
-	string_printf(str, IS_CLOSURE(*fptr) ? "Closure [ " : (fptr->common.scope ? "Method [ " : "Function [ "));
+	string_printf(str, ZEND_IS_CLOSURE(*fptr) ? "Closure [ " : (fptr->common.scope ? "Method [ " : "Function [ "));
 	string_printf(str, (fptr->type == ZEND_USER_FUNCTION) ? "<user" : "<internal");
-	if (IS_DEPRECATED_FUNCTION(*fptr)) {
+	if (ZEND_IS_DEPRECATED_FUNCTION(*fptr)) {
 		string_printf(str, ", deprecated");
 	}
 	if (fptr->type == ZEND_INTERNAL_FUNCTION && ((zend_internal_function*)fptr)->module) {
@@ -860,21 +860,21 @@ static void _function_string(string *str, zend_function *fptr, zend_class_entry 
 	if (fptr->common.prototype && fptr->common.prototype->common.scope) {
 		string_printf(str, ", prototype %s", fptr->common.prototype->common.scope->name);
 	}
-	if (IS_CONSTRUCTOR(*fptr)) {
+	if (ZEND_IS_CONSTRUCTOR(*fptr)) {
 		string_printf(str, ", ctor");
 	}
-	if (IS_DESTRUCTOR(*fptr)) {
+	if (ZEND_IS_DESTRUCTOR(*fptr)) {
 		string_printf(str, ", dtor");
 	}
 	string_printf(str, "> ");
 
-	if (IS_ABSTRACT_FUNCTION(*fptr)) {
+	if (ZEND_IS_ABSTRACT_FUNCTION(*fptr)) {
 		string_printf(str, "abstract ");
 	}
-	if (IS_FINAL_FUNCTION(*fptr)) {
+	if (ZEND_IS_FINAL_FUNCTION(*fptr)) {
 		string_printf(str, "final ");
 	}
-	if (IS_STATIC_FUNCTION(*fptr)) {
+	if (ZEND_IS_STATIC_FUNCTION(*fptr)) {
 		string_printf(str, "static ");
 	}
 
@@ -912,7 +912,7 @@ static void _function_string(string *str, zend_function *fptr, zend_class_entry 
 	}
 	string_init(&param_indent);
 	string_printf(&param_indent, "%s  ", indent);
-	if (IS_CLOSURE(*fptr)) {
+	if (ZEND_IS_CLOSURE(*fptr)) {
 		_function_closure_string(str, fptr, param_indent.string TSRMLS_CC);
 	}
 	_function_parameter_string(str, fptr, param_indent.string TSRMLS_CC);
@@ -1687,7 +1687,7 @@ ZEND_METHOD(reflection_function, isClosure)
 		return;
 	}
 	GET_REFLECTION_OBJECT_PTR(fptr);
-	RETURN_BOOL(IS_CLOSURE(*fptr));
+	RETURN_BOOL(ZEND_IS_CLOSURE(*fptr));
 }
 /* }}} */
 
@@ -2800,7 +2800,7 @@ ZEND_METHOD(reflection_method, getClosure)
 	METHOD_NOTSTATIC(reflection_method_ptr);
 	GET_REFLECTION_OBJECT_PTR(mptr);
 
-	if (IS_STATIC_FUNCTION(*mptr))  {
+	if (ZEND_IS_STATIC_FUNCTION(*mptr))  {
 		zend_create_closure(return_value, mptr, mptr->common.scope, NULL TSRMLS_CC);
 	} else {
 		if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "o", &obj) == FAILURE) {
@@ -2842,15 +2842,15 @@ ZEND_METHOD(reflection_method, invoke)
 
 	GET_REFLECTION_OBJECT_PTR(mptr);
 
-	if ((!IS_PUBLIC_FUNCTION(*mptr) || IS_ABSTRACT_FUNCTION(*mptr)) && intern->ignore_visibility == 0) {
-		if (IS_ABSTRACT_FUNCTION(*mptr)) {
+	if ((!ZEND_IS_PUBLIC_FUNCTION(*mptr) || ZEND_IS_ABSTRACT_FUNCTION(*mptr)) && intern->ignore_visibility == 0) {
+		if (ZEND_IS_ABSTRACT_FUNCTION(*mptr)) {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC,
 				"Trying to invoke abstract method %s::%s()",
 				mptr->common.scope->name, mptr->common.function_name);
 		} else {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC,
 				"Trying to invoke %s method %s::%s() from scope %s",
-				IS_PROTECTED_FUNCTION(*mptr) ? "protected" : "private",
+				ZEND_IS_PROTECTED_FUNCTION(*mptr) ? "protected" : "private",
 				mptr->common.scope->name, mptr->common.function_name,
 				Z_OBJCE_P(getThis())->name);
 		}
@@ -2867,7 +2867,7 @@ ZEND_METHOD(reflection_method, invoke)
 	 *
 	 * Else, we verify that the given object is an instance of the class.
 	 */
-	if (IS_STATIC_FUNCTION(*mptr)) {
+	if (ZEND_IS_STATIC_FUNCTION(*mptr)) {
 		object_ptr = NULL;
 		obj_ce = mptr->common.scope;
 	} else {
@@ -2948,15 +2948,15 @@ ZEND_METHOD(reflection_method, invokeArgs)
 		return;
 	}
 
-	if ((!IS_PUBLIC_FUNCTION(*mptr) || IS_ABSTRACT_FUNCTION(*mptr)) && intern->ignore_visibility == 0) {
-		if (IS_ABSTRACT_FUNCTION(*mptr)) {
+	if ((!ZEND_IS_PUBLIC_FUNCTION(*mptr) || ZEND_IS_ABSTRACT_FUNCTION(*mptr)) && intern->ignore_visibility == 0) {
+		if (ZEND_IS_ABSTRACT_FUNCTION(*mptr)) {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC,
 				"Trying to invoke abstract method %s::%s()",
 				mptr->common.scope->name, mptr->common.function_name);
 		} else {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC,
 				"Trying to invoke %s method %s::%s() from scope %s",
-				IS_PROTECTED_FUNCTION(*mptr) ? "protected" : "private",
+				ZEND_IS_PROTECTED_FUNCTION(*mptr) ? "protected" : "private",
 				mptr->common.scope->name, mptr->common.function_name,
 				Z_OBJCE_P(getThis())->name);
 		}
@@ -2975,7 +2975,7 @@ ZEND_METHOD(reflection_method, invokeArgs)
 	 *
 	 * Else, we verify that the given object is an instance of the class.
 	 */
-	if (IS_STATIC_FUNCTION(*mptr)) {
+	if (ZEND_IS_STATIC_FUNCTION(*mptr)) {
 		object = NULL;
 		obj_ce = mptr->common.scope;
 	} else {
@@ -3191,7 +3191,7 @@ ZEND_METHOD(reflection_method, isConstructor)
 	/* we need to check if the ctor is the ctor of the class level we we
 	 * looking at since we might be looking at an inherited old style ctor
 	 * defined in base class. */
-	RETURN_BOOL(IS_CONSTRUCTOR(*mptr) && intern->ce->constructor && intern->ce->constructor->common.scope == mptr->common.scope);
+	RETURN_BOOL(ZEND_IS_CONSTRUCTOR(*mptr) && intern->ce->constructor && intern->ce->constructor->common.scope == mptr->common.scope);
 }
 /* }}} */
 
@@ -3206,7 +3206,7 @@ ZEND_METHOD(reflection_method, isDestructor)
 		return;
 	}
 	GET_REFLECTION_OBJECT_PTR(mptr);
-	RETURN_BOOL(IS_DESTRUCTOR(*mptr));
+	RETURN_BOOL(ZEND_IS_DESTRUCTOR(*mptr));
 }
 /* }}} */
 
@@ -4098,7 +4098,7 @@ ZEND_METHOD(reflection_class, isInstantiable)
 		RETURN_TRUE;
 	}
 
-	RETURN_BOOL(IS_PUBLIC_FUNCTION(*ce->constructor));
+	RETURN_BOOL(ZEND_IS_PUBLIC_FUNCTION(*ce->constructor));
 }
 /* }}} */
 
@@ -4119,13 +4119,13 @@ ZEND_METHOD(reflection_class, isCloneable)
 	}
 	if (intern->obj) {
 		if (ce->clone) {
-			RETURN_BOOL(IS_PUBLIC_FUNCTION(*ce->clone));
+			RETURN_BOOL(ZEND_IS_PUBLIC_FUNCTION(*ce->clone));
 		} else {
 			RETURN_BOOL(Z_OBJ_HANDLER_P(intern->obj, clone_obj) != NULL);
 		}
 	} else {
 		if (ce->clone) {
-			RETURN_BOOL(IS_PUBLIC_FUNCTION(*ce->clone));
+			RETURN_BOOL(ZEND_IS_PUBLIC_FUNCTION(*ce->clone));
 		} else {
 			object_init_ex(&obj, ce);
 			RETVAL_BOOL(Z_OBJ_HANDLER(obj, clone_obj) != NULL);
@@ -4226,7 +4226,7 @@ ZEND_METHOD(reflection_class, newInstance)
 		zend_fcall_info fci;
 		zend_fcall_info_cache fcc;
 
-		if (!IS_PUBLIC_FUNCTION(*constructor)) {
+		if (!ZEND_IS_PUBLIC_FUNCTION(*constructor)) {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC, "Access to non-public constructor of class %s", ce->name);
 			zval_dtor(return_value);
 			RETURN_NULL();
@@ -4333,7 +4333,7 @@ ZEND_METHOD(reflection_class, newInstanceArgs)
 		zend_fcall_info fci;
 		zend_fcall_info_cache fcc;
 
-		if (!IS_PUBLIC_FUNCTION(*constructor)) {
+		if (!ZEND_IS_PUBLIC_FUNCTION(*constructor)) {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC, "Access to non-public constructor of class %s", ce->name);
 			zval_dtor(return_value);
 			RETURN_NULL();

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -500,7 +500,7 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			zend_hash_internal_pointer_reset_ex(&ce->function_table, &pos);
 
 			while (zend_hash_get_current_data_ex(&ce->function_table, (void **) &mptr, &pos) == SUCCESS) {
-				if (IS_STATIC_METHOD(mptr) && (!IS_PRIVATE_METHOD(mptr) || mptr->common.scope == ce))
+				if (IS_STATIC_FUNCTION(*mptr) && (!IS_PRIVATE_FUNCTION(*mptr) || mptr->common.scope == ce))
 				{
 					count_static_funcs++;
 				}
@@ -517,7 +517,7 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			zend_hash_internal_pointer_reset_ex(&ce->function_table, &pos);
 
 			while (zend_hash_get_current_data_ex(&ce->function_table, (void **) &mptr, &pos) == SUCCESS) {
-				if (IS_STATIC_METHOD(mptr) && (!IS_PRIVATE_METHOD(mptr) || mptr->common.scope == ce))
+				if (IS_STATIC_FUNCTION(*mptr) && (!IS_PRIVATE_FUNCTION(*mptr) || mptr->common.scope == ce))
 				{
 					string_printf(str, "\n");
 					_function_string(str, mptr, ce, sub_indent.string TSRMLS_CC);
@@ -599,14 +599,14 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			zend_hash_internal_pointer_reset_ex(&ce->function_table, &pos);
 
 			while (zend_hash_get_current_data_ex(&ce->function_table, (void **) &mptr, &pos) == SUCCESS) {
-				if (!IS_STATIC_METHOD(mptr) && (!IS_PRIVATE_METHOD(mptr) || mptr->common.scope == ce)) {
+				if (!IS_STATIC_FUNCTION(*mptr) && (!IS_PRIVATE_FUNCTION(*mptr) || mptr->common.scope == ce)) {
 					char *key;
 					uint key_len;
 					ulong num_index;
 					uint len = strlen(mptr->common.function_name);
 
 					/* Do not display old-style inherited constructors */
-					if (!IS_CONSTRUCTOR(mptr)
+					if (!IS_CONSTRUCTOR(*mptr)
 						|| mptr->common.scope == ce
 						|| zend_hash_get_current_key_ex(&ce->function_table, &key, &key_len, &num_index, 0, &pos) != HASH_KEY_IS_STRING
 						|| zend_binary_strcasecmp(key, key_len-1, mptr->common.function_name, len) == 0)
@@ -834,9 +834,9 @@ static void _function_string(string *str, zend_function *fptr, zend_class_entry 
 	}
 
 	string_write(str, indent, strlen(indent));
-	string_printf(str, IS_CLOSURE(fptr) ? "Closure [ " : (fptr->common.scope ? "Method [ " : "Function [ "));
+	string_printf(str, IS_CLOSURE(*fptr) ? "Closure [ " : (fptr->common.scope ? "Method [ " : "Function [ "));
 	string_printf(str, (fptr->type == ZEND_USER_FUNCTION) ? "<user" : "<internal");
-	if (IS_DEPRECATED_FUNCTION(fptr)) {
+	if (IS_DEPRECATED_FUNCTION(*fptr)) {
 		string_printf(str, ", deprecated");
 	}
 	if (fptr->type == ZEND_INTERNAL_FUNCTION && ((zend_internal_function*)fptr)->module) {
@@ -860,21 +860,21 @@ static void _function_string(string *str, zend_function *fptr, zend_class_entry 
 	if (fptr->common.prototype && fptr->common.prototype->common.scope) {
 		string_printf(str, ", prototype %s", fptr->common.prototype->common.scope->name);
 	}
-	if (IS_CONSTRUCTOR(fptr)) {
+	if (IS_CONSTRUCTOR(*fptr)) {
 		string_printf(str, ", ctor");
 	}
-	if (IS_DESTRUCTOR(fptr)) {
+	if (IS_DESTRUCTOR(*fptr)) {
 		string_printf(str, ", dtor");
 	}
 	string_printf(str, "> ");
 
-	if (IS_ABSTRACT_METHOD(fptr)) {
+	if (IS_ABSTRACT_FUNCTION(*fptr)) {
 		string_printf(str, "abstract ");
 	}
-	if (IS_FINAL_METHOD(fptr)) {
+	if (IS_FINAL_FUNCTION(*fptr)) {
 		string_printf(str, "final ");
 	}
-	if (IS_STATIC_METHOD(fptr)) {
+	if (IS_STATIC_FUNCTION(*fptr)) {
 		string_printf(str, "static ");
 	}
 
@@ -912,7 +912,7 @@ static void _function_string(string *str, zend_function *fptr, zend_class_entry 
 	}
 	string_init(&param_indent);
 	string_printf(&param_indent, "%s  ", indent);
-	if (IS_CLOSURE(fptr)) {
+	if (IS_CLOSURE(*fptr)) {
 		_function_closure_string(str, fptr, param_indent.string TSRMLS_CC);
 	}
 	_function_parameter_string(str, fptr, param_indent.string TSRMLS_CC);
@@ -1687,7 +1687,7 @@ ZEND_METHOD(reflection_function, isClosure)
 		return;
 	}
 	GET_REFLECTION_OBJECT_PTR(fptr);
-	RETURN_BOOL(IS_CLOSURE(fptr));
+	RETURN_BOOL(IS_CLOSURE(*fptr));
 }
 /* }}} */
 
@@ -2800,7 +2800,7 @@ ZEND_METHOD(reflection_method, getClosure)
 	METHOD_NOTSTATIC(reflection_method_ptr);
 	GET_REFLECTION_OBJECT_PTR(mptr);
 
-	if (IS_STATIC_METHOD(mptr))  {
+	if (IS_STATIC_FUNCTION(*mptr))  {
 		zend_create_closure(return_value, mptr, mptr->common.scope, NULL TSRMLS_CC);
 	} else {
 		if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "o", &obj) == FAILURE) {
@@ -2842,15 +2842,15 @@ ZEND_METHOD(reflection_method, invoke)
 
 	GET_REFLECTION_OBJECT_PTR(mptr);
 
-	if ((!IS_PUBLIC_METHOD(mptr) || IS_ABSTRACT_METHOD(mptr)) && intern->ignore_visibility == 0) {
-		if (IS_ABSTRACT_METHOD(mptr)) {
+	if ((!IS_PUBLIC_FUNCTION(*mptr) || IS_ABSTRACT_FUNCTION(*mptr)) && intern->ignore_visibility == 0) {
+		if (IS_ABSTRACT_FUNCTION(*mptr)) {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC,
 				"Trying to invoke abstract method %s::%s()",
 				mptr->common.scope->name, mptr->common.function_name);
 		} else {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC,
 				"Trying to invoke %s method %s::%s() from scope %s",
-				IS_PROTECTED_METHOD(mptr) ? "protected" : "private",
+				IS_PROTECTED_FUNCTION(*mptr) ? "protected" : "private",
 				mptr->common.scope->name, mptr->common.function_name,
 				Z_OBJCE_P(getThis())->name);
 		}
@@ -2867,7 +2867,7 @@ ZEND_METHOD(reflection_method, invoke)
 	 *
 	 * Else, we verify that the given object is an instance of the class.
 	 */
-	if (IS_STATIC_METHOD(mptr)) {
+	if (IS_STATIC_FUNCTION(*mptr)) {
 		object_ptr = NULL;
 		obj_ce = mptr->common.scope;
 	} else {
@@ -2948,15 +2948,15 @@ ZEND_METHOD(reflection_method, invokeArgs)
 		return;
 	}
 
-	if ((!IS_PUBLIC_METHOD(mptr) || IS_ABSTRACT_METHOD(mptr)) && intern->ignore_visibility == 0) {
-		if (IS_ABSTRACT_METHOD(mptr)) {
+	if ((!IS_PUBLIC_FUNCTION(*mptr) || IS_ABSTRACT_FUNCTION(*mptr)) && intern->ignore_visibility == 0) {
+		if (IS_ABSTRACT_FUNCTION(*mptr)) {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC,
 				"Trying to invoke abstract method %s::%s()",
 				mptr->common.scope->name, mptr->common.function_name);
 		} else {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC,
 				"Trying to invoke %s method %s::%s() from scope %s",
-				IS_PROTECTED_METHOD(mptr) ? "protected" : "private",
+				IS_PROTECTED_FUNCTION(*mptr) ? "protected" : "private",
 				mptr->common.scope->name, mptr->common.function_name,
 				Z_OBJCE_P(getThis())->name);
 		}
@@ -2975,7 +2975,7 @@ ZEND_METHOD(reflection_method, invokeArgs)
 	 *
 	 * Else, we verify that the given object is an instance of the class.
 	 */
-	if (IS_STATIC_METHOD(mptr)) {
+	if (IS_STATIC_FUNCTION(*mptr)) {
 		object = NULL;
 		obj_ce = mptr->common.scope;
 	} else {
@@ -3191,7 +3191,7 @@ ZEND_METHOD(reflection_method, isConstructor)
 	/* we need to check if the ctor is the ctor of the class level we we
 	 * looking at since we might be looking at an inherited old style ctor
 	 * defined in base class. */
-	RETURN_BOOL(IS_CONSTRUCTOR(mptr) && intern->ce->constructor && intern->ce->constructor->common.scope == mptr->common.scope);
+	RETURN_BOOL(IS_CONSTRUCTOR(*mptr) && intern->ce->constructor && intern->ce->constructor->common.scope == mptr->common.scope);
 }
 /* }}} */
 
@@ -3206,7 +3206,7 @@ ZEND_METHOD(reflection_method, isDestructor)
 		return;
 	}
 	GET_REFLECTION_OBJECT_PTR(mptr);
-	RETURN_BOOL(IS_DESTRUCTOR(mptr));
+	RETURN_BOOL(IS_DESTRUCTOR(*mptr));
 }
 /* }}} */
 
@@ -4098,7 +4098,7 @@ ZEND_METHOD(reflection_class, isInstantiable)
 		RETURN_TRUE;
 	}
 
-	RETURN_BOOL(IS_PUBLIC_METHOD(ce->constructor));
+	RETURN_BOOL(IS_PUBLIC_FUNCTION(*ce->constructor));
 }
 /* }}} */
 
@@ -4119,13 +4119,13 @@ ZEND_METHOD(reflection_class, isCloneable)
 	}
 	if (intern->obj) {
 		if (ce->clone) {
-			RETURN_BOOL(IS_PUBLIC_METHOD(ce->clone));
+			RETURN_BOOL(IS_PUBLIC_FUNCTION(*ce->clone));
 		} else {
 			RETURN_BOOL(Z_OBJ_HANDLER_P(intern->obj, clone_obj) != NULL);
 		}
 	} else {
 		if (ce->clone) {
-			RETURN_BOOL(IS_PUBLIC_METHOD(ce->clone));
+			RETURN_BOOL(IS_PUBLIC_FUNCTION(*ce->clone));
 		} else {
 			object_init_ex(&obj, ce);
 			RETVAL_BOOL(Z_OBJ_HANDLER(obj, clone_obj) != NULL);
@@ -4226,7 +4226,7 @@ ZEND_METHOD(reflection_class, newInstance)
 		zend_fcall_info fci;
 		zend_fcall_info_cache fcc;
 
-		if (!IS_PUBLIC_METHOD(constructor)) {
+		if (!IS_PUBLIC_FUNCTION(*constructor)) {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC, "Access to non-public constructor of class %s", ce->name);
 			zval_dtor(return_value);
 			RETURN_NULL();
@@ -4333,7 +4333,7 @@ ZEND_METHOD(reflection_class, newInstanceArgs)
 		zend_fcall_info fci;
 		zend_fcall_info_cache fcc;
 
-		if (!IS_PUBLIC_METHOD(constructor)) {
+		if (!IS_PUBLIC_FUNCTION(*constructor)) {
 			zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC, "Access to non-public constructor of class %s", ce->name);
 			zval_dtor(return_value);
 			RETURN_NULL();

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -497,7 +497,7 @@ PHP_FUNCTION(spl_autoload_register)
 			alfi.func_ptr = fcc.function_handler;
 			obj_ptr = fcc.object_ptr;
 			if (Z_TYPE_P(zcallable) == IS_ARRAY) {
-				if (!obj_ptr && alfi.func_ptr && !(alfi.func_ptr->common.fn_flags & ZEND_ACC_STATIC)) {
+				if (!obj_ptr && alfi.func_ptr && !IS_STATIC_METHOD(alfi.func_ptr)) {
 					if (do_throw) {
 						zend_throw_exception_ex(spl_ce_LogicException, 0 TSRMLS_CC, "Passed array specifies a non static method but no object (%s)", error);
 					}
@@ -565,7 +565,7 @@ PHP_FUNCTION(spl_autoload_register)
 			goto skip;
 		}
 
-		if (obj_ptr && !(alfi.func_ptr->common.fn_flags & ZEND_ACC_STATIC)) {
+		if (obj_ptr && !IS_STATIC_METHOD(alfi.func_ptr)) {
 			/* add object id to the hash to ensure uniqueness, for more reference look at bug #40091 */
 			lc_name = erealloc(lc_name, func_name_len + 2 + sizeof(zend_object_handle));
 			memcpy(lc_name + func_name_len, &Z_OBJ_HANDLE_P(obj_ptr), sizeof(zend_object_handle));
@@ -599,7 +599,7 @@ PHP_FUNCTION(spl_autoload_register)
 		}
 
 		if (zend_hash_add(SPL_G(autoload_functions), lc_name, func_name_len+1, &alfi.func_ptr, sizeof(autoload_func_info), NULL) == FAILURE) {
-			if (obj_ptr && !(alfi.func_ptr->common.fn_flags & ZEND_ACC_STATIC)) {
+			if (obj_ptr && !IS_STATIC_METHOD(alfi.func_ptr)) {
 				Z_DELREF_P(alfi.obj);
 			}				
 			if (alfi.closure) {

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -497,7 +497,7 @@ PHP_FUNCTION(spl_autoload_register)
 			alfi.func_ptr = fcc.function_handler;
 			obj_ptr = fcc.object_ptr;
 			if (Z_TYPE_P(zcallable) == IS_ARRAY) {
-				if (!obj_ptr && alfi.func_ptr && !IS_STATIC_METHOD(alfi.func_ptr)) {
+				if (!obj_ptr && alfi.func_ptr && !IS_STATIC_FUNCTION(*alfi.func_ptr)) {
 					if (do_throw) {
 						zend_throw_exception_ex(spl_ce_LogicException, 0 TSRMLS_CC, "Passed array specifies a non static method but no object (%s)", error);
 					}
@@ -565,7 +565,7 @@ PHP_FUNCTION(spl_autoload_register)
 			goto skip;
 		}
 
-		if (obj_ptr && !IS_STATIC_METHOD(alfi.func_ptr)) {
+		if (obj_ptr && !IS_STATIC_FUNCTION(*alfi.func_ptr)) {
 			/* add object id to the hash to ensure uniqueness, for more reference look at bug #40091 */
 			lc_name = erealloc(lc_name, func_name_len + 2 + sizeof(zend_object_handle));
 			memcpy(lc_name + func_name_len, &Z_OBJ_HANDLE_P(obj_ptr), sizeof(zend_object_handle));
@@ -599,7 +599,7 @@ PHP_FUNCTION(spl_autoload_register)
 		}
 
 		if (zend_hash_add(SPL_G(autoload_functions), lc_name, func_name_len+1, &alfi.func_ptr, sizeof(autoload_func_info), NULL) == FAILURE) {
-			if (obj_ptr && !IS_STATIC_METHOD(alfi.func_ptr)) {
+			if (obj_ptr && !IS_STATIC_FUNCTION(*alfi.func_ptr)) {
 				Z_DELREF_P(alfi.obj);
 			}				
 			if (alfi.closure) {

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -497,7 +497,7 @@ PHP_FUNCTION(spl_autoload_register)
 			alfi.func_ptr = fcc.function_handler;
 			obj_ptr = fcc.object_ptr;
 			if (Z_TYPE_P(zcallable) == IS_ARRAY) {
-				if (!obj_ptr && alfi.func_ptr && !IS_STATIC_FUNCTION(*alfi.func_ptr)) {
+				if (!obj_ptr && alfi.func_ptr && !ZEND_IS_STATIC_FUNCTION(*alfi.func_ptr)) {
 					if (do_throw) {
 						zend_throw_exception_ex(spl_ce_LogicException, 0 TSRMLS_CC, "Passed array specifies a non static method but no object (%s)", error);
 					}
@@ -565,7 +565,7 @@ PHP_FUNCTION(spl_autoload_register)
 			goto skip;
 		}
 
-		if (obj_ptr && !IS_STATIC_FUNCTION(*alfi.func_ptr)) {
+		if (obj_ptr && !ZEND_IS_STATIC_FUNCTION(*alfi.func_ptr)) {
 			/* add object id to the hash to ensure uniqueness, for more reference look at bug #40091 */
 			lc_name = erealloc(lc_name, func_name_len + 2 + sizeof(zend_object_handle));
 			memcpy(lc_name + func_name_len, &Z_OBJ_HANDLE_P(obj_ptr), sizeof(zend_object_handle));
@@ -599,7 +599,7 @@ PHP_FUNCTION(spl_autoload_register)
 		}
 
 		if (zend_hash_add(SPL_G(autoload_functions), lc_name, func_name_len+1, &alfi.func_ptr, sizeof(autoload_func_info), NULL) == FAILURE) {
-			if (obj_ptr && !IS_STATIC_FUNCTION(*alfi.func_ptr)) {
+			if (obj_ptr && !ZEND_IS_STATIC_FUNCTION(*alfi.func_ptr)) {
 				Z_DELREF_P(alfi.obj);
 			}				
 			if (alfi.closure) {


### PR DESCRIPTION
While investigating a bug report I noticed that it is really common to check various kinds of `common.fn_flags`. This PR adds macros to help with common checks such as `ZEND_ACC_STATIC`, `ZEND_ACC_PRIVATE`, `ZEND_ACC_DEPRECATED` and so on. It also converts roughly 160 instances to demonstrate how widespread the usage can be.
