### PR TITLE
PHPNG: Fixed issue with zend_hash_str_del()

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -675,6 +675,10 @@ ZEND_API int zend_hash_str_del(HashTable *ht, const char *str, int len)
 
 	IS_CONSISTENT(ht);
 
+	if (ht->u.flags & HASH_FLAG_PACKED) {
+		return FAILURE;
+	}
+
 	h = zend_inline_hash_func(str, len);
 	nIndex = h & ht->nTableMask;
 


### PR DESCRIPTION
This fixes an issue with code like this:

```
add_index_string(&extra, 1, "test");
zend_hash_str_del(Z_ARRVAL(extra), "oauth_signature", sizeof("oauth_signature") - 1); // hang
```

A packed array has no string keys, so a removal shouldn't even be attempted.
