### PR TITLE
Fix Bug #66622: Closures do not correctly capture the late bound class (static::) in some cases

### DIFF
--- a/Zend/tests/closure_049.phpt
+++ b/Zend/tests/closure_049.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Closure 049: static::class in static closure in non-static method.
+
+--FILE--
+<?php
+
+class A {
+    function foo() {
+        $f = static function() {
+            return static::class;
+        };
+        return $f();
+    }
+}
+
+class B extends A {}
+
+$b = new B;
+
+var_dump($b->foo());
+--EXPECT--
+string(1) "B"

--- a/Zend/tests/closure_050.phpt
+++ b/Zend/tests/closure_050.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Closure 050: static::class in non-static closure in non-static method.
+
+--FILE--
+<?php
+
+class A {
+    function foo() {
+        $f = function() {
+            return static::class;
+        };
+        return $f();
+    }
+}
+
+class B extends A {}
+
+$b = new B;
+var_dump($b->foo());
+
+--EXPECT--
+string(1) "B"

--- a/Zend/tests/closure_051.phpt
+++ b/Zend/tests/closure_051.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Closure 051: static::class in static closure in static method.
+
+--FILE--
+<?php
+
+class A {
+    static function foo() {
+        $f = static function() {
+            return static::class;
+        };
+        return $f();
+    }
+}
+
+class B extends A {}
+
+var_dump(B::foo());
+
+--EXPECT--
+string(1) "B"

--- a/Zend/tests/closure_052.phpt
+++ b/Zend/tests/closure_052.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Closure 052: static::class in non-static closure in static method.
+
+--FILE--
+<?php
+
+class A {
+    static function foo() {
+        $f = function() {
+            return static::class;
+        };
+        return $f();
+    }
+}
+
+class B extends A {}
+
+var_dump(B::foo());
+
+--EXPECT--
+string(1) "B"

--- a/Zend/tests/closure_053.phpt
+++ b/Zend/tests/closure_053.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Closure 053: self::class in static closure in non-static method.
+
+--FILE--
+<?php
+
+class A {
+    function foo() {
+        $f = static function() {
+            return self::class;
+        };
+        return $f();
+    }
+}
+
+class B extends A {}
+
+$b = new B;
+var_dump($b->foo());
+
+--EXPECT--
+string(1) "A"

--- a/Zend/tests/closure_054.phpt
+++ b/Zend/tests/closure_054.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Closure 054: self::class in non-static closure in non-static method.
+
+--FILE--
+<?php
+
+class A {
+    function foo() {
+        $f = function() {
+            return self::class;
+        };
+        return $f();
+    }
+}
+
+class B extends A {}
+
+$b = new B;
+var_dump($b->foo());
+
+--EXPECT--
+string(1) "A"

--- a/Zend/tests/closure_055.phpt
+++ b/Zend/tests/closure_055.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Closure 055: self::class in static closure in static method.
+
+--FILE--
+<?php
+
+class A {
+    static function foo() {
+        $f = static function() {
+            return self::class;
+        };
+        return $f();
+    }
+}
+
+class B extends A {}
+
+var_dump(B::foo());
+
+--EXPECT--
+string(1) "A"

--- a/Zend/tests/closure_056.phpt
+++ b/Zend/tests/closure_056.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Closure 056: self::class in non-static closure in static method.
+
+--FILE--
+<?php
+
+class A {
+    static function foo() {
+        $f = function() {
+            return self::class;
+        };
+        return $f();
+    }
+}
+
+class B extends A {}
+
+var_dump(B::foo());
+
+--EXPECT--
+string(1) "A"

--- a/Zend/tests/closure_bug66622.phpt
+++ b/Zend/tests/closure_bug66622.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Bug 66622: Closures do not correctly capture the late bound class (static::) in some cases
+
+--FILE--
+<?php
+class A {
+    static function name() { return 'A'; }
+    function foo() {
+        $fn = function() { return static::name(); };
+        echo static::name() . ' vs ' . $fn() . "\n";
+    }
+    function bar() {
+        $fn = static function() { return static::name(); };
+        echo static::name() . ' vs ' . $fn() . "\n";
+    }
+    static function baz() {
+        $fn = function() { return static::name(); };
+        echo static::name() . ' vs ' . $fn() . "\n";
+    }
+}
+class B extends A {
+    static function name() { return 'B'; }
+}
+
+function test() {
+    (new B)->foo();
+    (new B)->bar();
+    (new B)->baz();
+    B::baz();
+}
+test();
+
+--EXPECT--
+B vs B
+B vs B
+B vs B
+B vs B

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -480,6 +480,7 @@ ZEND_API void zend_create_closure(zval *res, zend_function *func, zend_class_ent
 		}
 	}
 
+	closure->this_ptr = NULL;
 	/* Invariants:
 	 * If the closure is unscoped, it has no bound object.
 	 * The the closure is scoped, it's either static or it's bound */
@@ -491,10 +492,7 @@ ZEND_API void zend_create_closure(zval *res, zend_function *func, zend_class_ent
 			Z_ADDREF_P(this_ptr);
 		} else {
 			closure->func.common.fn_flags |= ZEND_ACC_STATIC;
-			closure->this_ptr = NULL;
 		}
-	} else {
-		closure->this_ptr = NULL;
 	}
 }
 /* }}} */

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5400,6 +5400,7 @@ ZEND_VM_HANDLER(153, ZEND_DECLARE_LAMBDA_FUNCTION, CONST, UNUSED)
 {
 	USE_OPLINE
 	zend_function *op_array;
+	int closure_is_static, closure_is_being_defined_inside_static_context;
 
 	SAVE_OPLINE();
 
@@ -5408,7 +5409,13 @@ ZEND_VM_HANDLER(153, ZEND_DECLARE_LAMBDA_FUNCTION, CONST, UNUSED)
 		zend_error_noreturn(E_ERROR, "Base lambda function for closure not found");
 	}
 
-	zend_create_closure(&EX_T(opline->result.var).tmp_var, (zend_function *) op_array, EG(scope), EG(This) TSRMLS_CC);
+	closure_is_static = op_array->common.fn_flags & ZEND_ACC_STATIC;
+	closure_is_being_defined_inside_static_context = EX(prev_execute_data) && EX(prev_execute_data)->function_state.function->common.fn_flags & ZEND_ACC_STATIC;
+	if (closure_is_static || closure_is_being_defined_inside_static_context) {
+		zend_create_closure(&EX_T(opline->result.var).tmp_var, (zend_function *) op_array,  EG(called_scope), NULL TSRMLS_CC);
+	} else {
+		zend_create_closure(&EX_T(opline->result.var).tmp_var, (zend_function *) op_array,  EG(scope), EG(This) TSRMLS_CC);
+	}
 
 	CHECK_EXCEPTION();
 	ZEND_VM_NEXT_OPCODE();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6781,6 +6781,7 @@ static int ZEND_FASTCALL  ZEND_DECLARE_LAMBDA_FUNCTION_SPEC_CONST_UNUSED_HANDLER
 {
 	USE_OPLINE
 	zend_function *op_array;
+	int closure_is_static, closure_is_being_defined_inside_static_context;
 
 	SAVE_OPLINE();
 
@@ -6789,7 +6790,13 @@ static int ZEND_FASTCALL  ZEND_DECLARE_LAMBDA_FUNCTION_SPEC_CONST_UNUSED_HANDLER
 		zend_error_noreturn(E_ERROR, "Base lambda function for closure not found");
 	}
 
-	zend_create_closure(&EX_T(opline->result.var).tmp_var, (zend_function *) op_array, EG(scope), EG(This) TSRMLS_CC);
+	closure_is_static = op_array->common.fn_flags & ZEND_ACC_STATIC;
+	closure_is_being_defined_inside_static_context = EX(prev_execute_data) && EX(prev_execute_data)->function_state.function->common.fn_flags & ZEND_ACC_STATIC;
+	if (closure_is_static || closure_is_being_defined_inside_static_context) {
+		zend_create_closure(&EX_T(opline->result.var).tmp_var, (zend_function *) op_array,  EG(called_scope), NULL TSRMLS_CC);
+	} else {
+		zend_create_closure(&EX_T(opline->result.var).tmp_var, (zend_function *) op_array,  EG(scope), EG(This) TSRMLS_CC);
+	}
 
 	CHECK_EXCEPTION();
 	ZEND_VM_NEXT_OPCODE();


### PR DESCRIPTION
This PR fixes bug 66622. It does three things:
- Moves `Zend/tests/closure_*.phpt` to `Zend/tests/closure/*.phpt`. I was running these tests a lot and didn't have time to run the full `Zend/tests` suite. Some minor cleanup associated with the file renaming.
- Fixes static closures to use late static binding and adds tests for it.
- Automatically promotes non-static closures to be static when defined in a static method and adds tests for it.
