### PR TITLE
Prevent recursion in ZF2 Parameters class

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -603,7 +603,7 @@ static int spl_array_has_dimension_ex(int check_inherited, zval *object, zval *o
 
 		if (rv && zend_is_true(rv)) {
 			zval_ptr_dtor(&rv);
-			if (check_empty == 2) {
+			if (check_empty != 1) {
 				return 1;
 			} else if (intern->fptr_offset_get) {
 				value = spl_array_read_dimension_ex(1, object, offset, BP_VAR_R TSRMLS_CC);
@@ -629,6 +629,7 @@ static int spl_array_has_dimension_ex(int check_inherited, zval *object, zval *o
 					return 0;
 				}
 				break;
+
 			case IS_DOUBLE:
 			case IS_RESOURCE:
 			case IS_BOOL: 
@@ -646,28 +647,20 @@ static int spl_array_has_dimension_ex(int check_inherited, zval *object, zval *o
 					return 0;
 				}
 				break;
+
 			default:
 				zend_error(E_WARNING, "Illegal offset type");
 				return 0;
 		}
 
-		if (check_inherited && intern->fptr_offset_get) {
+		if (check_empty && check_inherited && intern->fptr_offset_get) {
 			value = spl_array_read_dimension_ex(1, object, offset, BP_VAR_R TSRMLS_CC);
 		} else {
 			value = *tmp;
 		}
 	}
 
-	switch (check_empty) {
-		case 0:
-			return Z_TYPE_P(value) != IS_NULL;
-		case 2:
-			return 1;
-		case 1:
-			return zend_is_true(value);
-	}
-
-	return 0;
+	return check_empty ? zend_is_true(value) : Z_TYPE_P(value) != IS_NULL;
 } /* }}} */
 
 static int spl_array_has_dimension(zval *object, zval *offset, int check_empty TSRMLS_DC) /* {{{ */

--- a/ext/spl/tests/bug66834.phpt
+++ b/ext/spl/tests/bug66834.phpt
@@ -75,14 +75,13 @@ var_dump($object->offsetexists('qux'), isset($object['qux']), empty($object['qux
 echo "==== class with offsetGet() and offsetSet() ====\n";
 $object = new ArrayObjectGetSet;
 $object['foo'] = 42;
-var_dump($object->offsetExists('foo'), $object->offsetExists('sbb'), isset($object['foo']), isset($object['sbb']));
+var_dump($object->offsetExists('foo'), $object->offsetExists('sbb'), isset($object['foo']), isset($object['sbb']), empty($object['sbb']));
 
 ?>
 --EXPECTF--
 ==== class with offsetExists() and offsetGet() ====
 string(37) "Called: ArrayObjectBoth::offsetExists"
 string(37) "Called: ArrayObjectBoth::offsetExists"
-string(34) "Called: ArrayObjectBoth::offsetGet"
 string(37) "Called: ArrayObjectBoth::offsetExists"
 string(34) "Called: ArrayObjectBoth::offsetGet"
 bool(true)
@@ -90,15 +89,13 @@ bool(true)
 bool(true)
 string(37) "Called: ArrayObjectBoth::offsetExists"
 string(37) "Called: ArrayObjectBoth::offsetExists"
-string(34) "Called: ArrayObjectBoth::offsetGet"
 string(37) "Called: ArrayObjectBoth::offsetExists"
 string(34) "Called: ArrayObjectBoth::offsetGet"
 bool(true)
-bool(false)
+bool(true)
 bool(true)
 string(37) "Called: ArrayObjectBoth::offsetExists"
 string(37) "Called: ArrayObjectBoth::offsetExists"
-string(34) "Called: ArrayObjectBoth::offsetGet"
 string(37) "Called: ArrayObjectBoth::offsetExists"
 string(34) "Called: ArrayObjectBoth::offsetGet"
 bool(true)
@@ -121,7 +118,7 @@ string(39) "Called: ArrayObjectExists::offsetExists"
 string(39) "Called: ArrayObjectExists::offsetExists"
 string(39) "Called: ArrayObjectExists::offsetExists"
 bool(true)
-bool(false)
+bool(true)
 bool(true)
 string(39) "Called: ArrayObjectExists::offsetExists"
 string(39) "Called: ArrayObjectExists::offsetExists"
@@ -137,16 +134,13 @@ bool(false)
 bool(true)
 ==== class with offsetGet() ====
 string(33) "Called: ArrayObjectGet::offsetGet"
-string(33) "Called: ArrayObjectGet::offsetGet"
 bool(true)
 bool(true)
 bool(true)
-string(33) "Called: ArrayObjectGet::offsetGet"
 string(33) "Called: ArrayObjectGet::offsetGet"
 bool(true)
 bool(false)
 bool(true)
-string(33) "Called: ArrayObjectGet::offsetGet"
 string(33) "Called: ArrayObjectGet::offsetGet"
 bool(true)
 bool(true)
@@ -160,4 +154,5 @@ Notice: Undefined index: foo in %s on line %d
 bool(false)
 bool(true)
 bool(false)
-bool(false)
+bool(true)
+bool(true)


### PR DESCRIPTION
Don't call inherited `offsetGet()` when `isset()` is used, only do this for `empty()`.

Exception: when `offsetGet()` is not overridden, we can safely get the value to compare against `null` when `isset()` is used.
