### PR TITLE
Allow traits to declare abstract private methods.

### DIFF
--- a/Zend/tests/traits/abstract_private_001.phpt
+++ b/Zend/tests/traits/abstract_private_001.phpt
@@ -1,0 +1,26 @@
+--TEST--
+abstract private functions in traits (normal case)
+--FILE--
+<?php
+
+trait T {
+    abstract private function f();
+}
+
+class C {
+    use T;
+
+    public function test() {
+        $this->f();
+    }
+
+    private function f() {
+        echo 'f() called';
+    }
+}
+
+(new C)->test();
+
+?>
+--EXPECT--
+f() called

--- a/Zend/tests/traits/abstract_private_002.phpt
+++ b/Zend/tests/traits/abstract_private_002.phpt
@@ -1,0 +1,16 @@
+--TEST--
+abstract private functions in traits (no concrete method error)
+--FILE--
+<?php
+
+trait T {
+    abstract private function f();
+}
+
+class C {
+    use T;
+}
+
+?>
+--EXPECTF--
+Fatal error: Class C contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (C::f) in %s on line %d

--- a/Zend/tests/traits/abstract_private_003.phpt
+++ b/Zend/tests/traits/abstract_private_003.phpt
@@ -1,0 +1,19 @@
+--TEST--
+abstract private functions in traits (no concrete method error)
+--FILE--
+<?php
+
+trait T {
+    abstract private function f();
+}
+
+abstract class C {
+    use T;
+}
+
+class D extends C {
+}
+
+?>
+--EXPECTF--
+Fatal error: Class D contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (C::f) in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -892,7 +892,12 @@ void zend_do_abstract_method(const znode *function_name, znode *modifiers, const
 
 	if (Z_LVAL(modifiers->u.constant) & ZEND_ACC_ABSTRACT) {
 		if(Z_LVAL(modifiers->u.constant) & ZEND_ACC_PRIVATE) {
-			zend_error_noreturn(E_COMPILE_ERROR, "%s function %s::%s() cannot be declared private", method_type, CG(active_class_entry)->name, Z_STRVAL(function_name->u.constant));
+			/* We don't want to error for traits, since an abstract private
+			 * method can be used there to require that a class using the trait
+			 * must implement a particular private method. */
+			if ((CG(active_class_entry)->ce_flags & ZEND_ACC_TRAIT) != ZEND_ACC_TRAIT) {
+				zend_error_noreturn(E_COMPILE_ERROR, "%s function %s::%s() cannot be declared private", method_type, CG(active_class_entry)->name, Z_STRVAL(function_name->u.constant));
+			}
 		}
 		if (Z_LVAL(body->u.constant) == ZEND_ACC_ABSTRACT) {
 			zend_op *opline = get_next_op(CG(active_op_array) TSRMLS_CC);


### PR DESCRIPTION
This implements request #67310 (Allow abstract private functions in traits),
which makes sense to me: you may want to require that a class using a trait
implements a particular private method for use in another trait method.
