### PR TITLE
Bug #67403 Add signatureType to openssl_x509_parse

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1973,11 +1973,10 @@ PHP_FUNCTION(openssl_x509_parse)
 	if (tmpstr) {
 		add_assoc_string(return_value, "alias", tmpstr, 1);
 	}
-/*
-	add_assoc_long(return_value, "signaturetypeLONG", X509_get_signature_type(cert));
-	add_assoc_string(return_value, "signaturetype", OBJ_nid2sn(X509_get_signature_type(cert)), 1);
-	add_assoc_string(return_value, "signaturetypeLN", OBJ_nid2ln(X509_get_signature_type(cert)), 1);
-*/
+
+	i2t_ASN1_OBJECT(buf, sizeof(buf)-1, (cert)->sig_alg->algorithm);
+	add_assoc_string(return_value, "signatureType", buf, 1);
+
 	MAKE_STD_ZVAL(subitem);
 	array_init(subitem);
 

--- a/ext/openssl/tests/bug67403.phpt
+++ b/ext/openssl/tests/bug67403.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #67403: Add signatureType to openssl_x509_parse
+--SKIPIF--
+<?php 
+if (!extension_loaded("openssl")) die("skip");
+--FILE--
+<?php
+$r = openssl_x509_parse(file_get_contents(__DIR__.'/bug64802.pem'));
+var_dump($r['signatureType']);
+$r = openssl_x509_parse(file_get_contents(__DIR__.'/bug37820cert.pem'));
+var_dump($r['signatureType']);
+--EXPECTF--
+string(21) "sha1WithRSAEncryption"
+string(20) "md5WithRSAEncryption"


### PR DESCRIPTION
Adding openssl signature parsing to openssl_x509_parse, so for instance, a cert with a sha1 signature should say sha1WithRSAEncryption (and not SHA1-With-RSA like other openssl signature functions might produce).  There was some old commented out code, that didn't work.  This pull request replaces it with working code.

Also removed unused const, DEFAULT_KEY_LENGTH in openssl, it was copied from req.c in the openssl examples source code, and is not otherwise used in php code.  See how it was copied over from req.c (openssl source) when ext/openssl/openssl.c was first being written:
http://www.opensource.apple.com/source/OpenSSL098/OpenSSL098-32/src/apps/req.c?txt
(leaving it in is a bit misleading, because it appears to be a default key length, but actually defaults are controlled by openssl.cnf).

