### PR TITLE
Don't overflow the buffer on bad DNS TXT records

### DIFF
--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -517,6 +517,10 @@ static u_char *php_parserr(u_char *cp, querybuf *answer, int type_to_fetch, int 
 				
 				while (ll < dlen) {
 					n = cp[ll];
+					if ((n + ll) > dlen) {
+						// bad record, don't set anything
+						break;
+					}
 					memcpy(tp + ll , cp + ll + 1, n);
 					add_next_index_stringl(entries, cp + ll + 1, n, 1);
 					ll = ll + n + 1;


### PR DESCRIPTION
`dlen` can be small but then the chunk length could exceed it and
overrun the buffer.

An example site with this bug is berlin.polemb.net running this code:

```
  $types = array('AAAA' => 1, 'A' => 1);
  $records = dns_get_record("berlin.polemb.net",
                            DNS_A | DNS_TXT | DNS_AAAA | DNS_CNAME,
                            );
  var_dump($records);
```
