### PR TITLE
pcntl_signal_dispatch: Speed up by preventing system calls when unnecessary

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1224,6 +1224,7 @@ static void pcntl_signal_handler(int signo)
 		PCNTL_G(head) = psig;
 	}
 	PCNTL_G(tail) = psig;
+	PCNTL_G(pending_signals) = 1;
 }
 
 void pcntl_signal_dispatch()
@@ -1233,6 +1234,10 @@ void pcntl_signal_dispatch()
 	sigset_t mask;
 	sigset_t old_mask;
 	TSRMLS_FETCH();
+
+	if(!PCNTL_G(pending_signals)) {
+		return;
+	}
 		
 	/* Mask all signals */
 	sigfillset(&mask);
@@ -1271,6 +1276,8 @@ void pcntl_signal_dispatch()
 		PCNTL_G(spares) = queue;
 		queue = next;
 	}
+
+	PCNTL_G(pending_signals) = 0;
 
 	/* Re-enable queue */
 	PCNTL_G(processing_signal_queue) = 0;

--- a/ext/pcntl/php_pcntl.h
+++ b/ext/pcntl/php_pcntl.h
@@ -69,6 +69,7 @@ ZEND_BEGIN_MODULE_GLOBALS(pcntl)
 	int processing_signal_queue;
 	struct php_pcntl_pending_signal *head, *tail, *spares;
 	int last_error;
+	volatile char pending_signals;
 ZEND_END_MODULE_GLOBALS(pcntl)
 
 #ifdef ZTS


### PR DESCRIPTION
This should be a fairly cheap win to make pcntl_signal_dispatch() somewhat faster in the case there are no signals pending.
