### PR TITLE
Fix Apache 2.4.10+ SetHandler proxy:fcgi:// incompatibilities

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1142,19 +1142,6 @@ static void init_request_info(TSRMLS_D)
 				TRANSLATE_SLASHES(env_document_root);
 			}
 
-			if (env_path_translated != NULL && env_redirect_url != NULL &&
-			    env_path_translated != script_path_translated &&
-			    strcmp(env_path_translated, script_path_translated) != 0) {
-				/*
-				 * pretty much apache specific.  If we have a redirect_url
-				 * then our script_filename and script_name point to the
-				 * php executable
-				 */
-				script_path_translated = env_path_translated;
-				/* we correct SCRIPT_NAME now in case we don't have PATH_INFO */
-				env_script_name = env_redirect_url;
-			}
-
 #ifdef __riscos__
 			/* Convert path to unix format*/
 			__riscosify_control |= __RISCOSIFY_DONT_CHECK_DIR;
@@ -1323,7 +1310,7 @@ static void init_request_info(TSRMLS_D)
 					efree(pt);
 				}
 			} else {
-				/* make sure path_info/translated are empty */
+				/* make sure original values are remembered in ORIG_ copies if we've changed them */
 				if (!orig_script_filename ||
 					(script_path_translated != orig_script_filename &&
 					strcmp(script_path_translated, orig_script_filename) != 0)) {
@@ -1331,16 +1318,6 @@ static void init_request_info(TSRMLS_D)
 						_sapi_cgibin_putenv("ORIG_SCRIPT_FILENAME", orig_script_filename TSRMLS_CC);
 					}
 					script_path_translated = _sapi_cgibin_putenv("SCRIPT_FILENAME", script_path_translated TSRMLS_CC);
-				}
-				if (env_redirect_url) {
-					if (orig_path_info) {
-						_sapi_cgibin_putenv("ORIG_PATH_INFO", orig_path_info TSRMLS_CC);
-						_sapi_cgibin_putenv("PATH_INFO", NULL TSRMLS_CC);
-					}
-					if (orig_path_translated) {
-						_sapi_cgibin_putenv("ORIG_PATH_TRANSLATED", orig_path_translated TSRMLS_CC);
-						_sapi_cgibin_putenv("PATH_TRANSLATED", NULL TSRMLS_CC);
-					}
 				}
 				if (env_script_name != orig_script_name) {
 					if (orig_script_name) {


### PR DESCRIPTION
Apache 2.4.10+ will allow the following:

```
<FilesMatch \.php$>
SetHandler proxy:fcgi://localhost:9000
</FilesMatch>
```

This is much easier than using `ProxyPassMatch` (which prevents rewriting and other stuff) and rewrites (which are a bag of hurt because when combined with user-land `.htaccess` rewrites, there's always rewrite loops, prefix breakage etc (I've tried, for weeks).

It's basically the future of using Apache (via `mod_proxy_fcgi`) together with PHP-FPM. It's also available for older versions as a standalone module, very easy to install: https://gist.github.com/progandy/6ed4eeea60f6277c3e39

However, the two bits of code this commit deletes interfere with that. They both cover CGI-only mode and were copied from that SAPI into the FPM source. See e.g. https://bugs.php.net/bug.php?id=47042

The first deleted part mangled `SCRIPT_NAME` if something like

```
RewriteCond %{REQUEST_FILENAME} !-f
RewriteRule (.*) index.php/$1 [L]
```

is used (i.e. rewriting to `PATH_INFO`. The second part drops `PATH_INFO` if there was a `REDIRECT_URL` (with CGI mode, `SCRIPT_FILENAME` in Apache is the path to the PHP binary, and `PATH_INFO` contains the name of the script to run).

Clearly, neither applies in the case of FastCGI, so both are safe to delete.
