### PR TITLE
Fix Bug #67468  Segfault in highlight_file()/highlight_string() when pgsql.so module is loaded

### DIFF
--- a/Zend/zend_highlight.c
+++ b/Zend/zend_highlight.c
@@ -150,7 +150,7 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 				case T_DOC_COMMENT:
 					break;
 				default:
-					efree(token.value.str.val);
+					str_efree(token.value.str.val);
 					break;
 			}
 		}

--- a/Zend/zend_indent.c
+++ b/Zend/zend_indent.c
@@ -138,7 +138,7 @@ dflt_printout:
 			case T_WHITESPACE:
 				break;
 			default:
-				efree(token.value.str.val);
+				str_efree(token.value.str.val);
 				break;
 			}
 		}


### PR DESCRIPTION
str_efree() must be used in zend_highlight() and zend_indent() to free
string data assigned to a zval to account for interned strings.
