### PR TITLE
Fix "undefined reference to zm_startup_password" compilation error

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1821,6 +1821,7 @@ ZEND_BEGIN_ARG_INFO(arginfo_getlastmod, 0)
 ZEND_END_ARG_INFO()
 /* }}} */
 /* {{{ password.c */
+#if HAVE_CRYPT
 ZEND_BEGIN_ARG_INFO_EX(arginfo_password_hash, 0, 0, 2)
 	ZEND_ARG_INFO(0, password)
 	ZEND_ARG_INFO(0, algo)
@@ -1838,6 +1839,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_password_verify, 0, 0, 2)
 	ZEND_ARG_INFO(0, password)
 	ZEND_ARG_INFO(0, hash)
 ZEND_END_ARG_INFO()
+#endif
 /* }}} */
 /* {{{ proc_open.c */
 #ifdef PHP_CAN_SUPPORT_PROC_OPEN
@@ -2846,10 +2848,12 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(base64_decode,													arginfo_base64_decode)
 	PHP_FE(base64_encode,													arginfo_base64_encode)
 
+#if HAVE_CRYPT
 	PHP_FE(password_hash,													arginfo_password_hash)
 	PHP_FE(password_get_info,												arginfo_password_get_info)
 	PHP_FE(password_needs_rehash,											arginfo_password_needs_rehash)
 	PHP_FE(password_verify,													arginfo_password_verify)
+#endif
 	PHP_FE(convert_uuencode,												arginfo_convert_uuencode)
 	PHP_FE(convert_uudecode,												arginfo_convert_uudecode)
 
@@ -3600,7 +3604,10 @@ PHP_MINIT_FUNCTION(basic) /* {{{ */
 	BASIC_MINIT_SUBMODULE(browscap)
 	BASIC_MINIT_SUBMODULE(standard_filters)
 	BASIC_MINIT_SUBMODULE(user_filters)
+
+#if HAVE_CRYPT
 	BASIC_MINIT_SUBMODULE(password)
+#endif
 
 #if defined(HAVE_LOCALECONV) && defined(ZTS)
 	BASIC_MINIT_SUBMODULE(localeconv)


### PR DESCRIPTION
The whole of password.c is inside a `#if HAVE_CRYPT` conditional, but `basic_functions.c` unconditionally initializes the password module and tries to declares its functions, leading to this error.

This fixes phpbrew/phpbrew#236
