### PR TITLE
* double fastcgi_end_request on max_children limit

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1516,6 +1516,7 @@ PHP_FUNCTION(fastcgi_finish_request) /* {{{ */
 
 		fcgi_flush(request, 1);
 		fcgi_close(request, 0, 0);
+		request->closed = 1;
 		RETURN_TRUE;
 	}
 


### PR DESCRIPTION
Php sends 2 fastcgi FCGI_END_REQUEST records instead of one when `fastcgi_finish_request();` called and fpm param max_requests exceeded.

* one is sent on `fastcgi_finish_request();` call
* other is sent in block
`
fpm_main.c:1951
requests++;
if (max_requests && (requests == max_requests)) {
    fcgi_finish_request(&request, 1);
    break;
}
`

It confuses fastcgi client (i.e. nginx) receiving 2 FCGI_END_REQUEST records one after another.
So I have set `request->closed` flag to prevent second FastCGI record sending.