### PR TITLE
Fix bug #67587: Redirection loop on nginx with FPM

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -606,6 +606,7 @@ PHP_METHOD(Phar, webPhar)
 	}
 
 	if ((strlen(sapi_module.name) == sizeof("cgi-fcgi")-1 && !strncmp(sapi_module.name, "cgi-fcgi", sizeof("cgi-fcgi")-1))
+		|| (strlen(sapi_module.name) == sizeof("fpm-fcgi")-1 && !strncmp(sapi_module.name, "fpm-fcgi", sizeof("fpm-fcgi")-1))
 		|| (strlen(sapi_module.name) == sizeof("cgi")-1 && !strncmp(sapi_module.name, "cgi", sizeof("cgi")-1))) {
 
 		if (PG(http_globals)[TRACK_VARS_SERVER]) {


### PR DESCRIPTION
Redirection will work correctly as long as PATH_INFO is available,
e.g. via the following nginx configuration:

```
set $path_info $fastcgi_path_info;
fastcgi_param PATH_INFO $path_info;
```
