### PR TITLE
Fix php cli (-S option) inconsistent port parsing

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2209,7 +2209,7 @@ static int php_cli_server_ctor(php_cli_server *server, const char *addr, const c
 			*p++ = '\0';
 			if (*p == ':') {
 				port = strtol(p + 1, &p, 10);
-				if (port <= 0) {
+				if (port <= 0 || port > 65535) {
 					p = NULL;
 				}
 			} else if (*p != '\0') {
@@ -2225,7 +2225,7 @@ static int php_cli_server_ctor(php_cli_server *server, const char *addr, const c
 		if (p) {
 			*p++ = '\0';
 			port = strtol(p, &p, 10);
-			if (port <= 0) {
+			if (port <= 0 || port > 65535) {
 				p = NULL;
 			}
 		}


### PR DESCRIPTION
## Description

The php cli server (-S) option parser uses strtol(3) to retrieve the port
from address argument. Therefore, htons(3) is used to normalize the
address port, which leads to an unverified cast.

The issue may appear trivial, therefore, assuming that the "Listening on"
information line at [sapi/cli/php_cli_server.php:2536](on success) uses
argument string, it may lead to false information.
## Issue example:

```
    $ php -S 127.0.0.1:80808080
    PHP 5.5.14 Development Server started at Fri Jul 11 19:36:56 2014
    Listening on http://127.0.0.1:80808080
    Document root is /tmp
    Press Ctrl-C to quit.
```

In this example, the server succeeds, because 80808080 short cast from
htons(3) converts it to port 2192, indeed, the server listens at port 2192:

```
    $ lsof -P -i -n | grep php                                                      
    php     8424  nil    3u  IPv4 8323966      0t0  TCP 127.0.0.1:2192 (LISTEN)  
```

The proposed fix is lightweight, and only consists in port range
verification before htons(3) call.
