### PR TITLE
Fixed bug #67594

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? 2014, PHP 5.5.16
 
+- CLI server:
+  . Fixed bug #67594 (Unable to access to apache_request_headers() elements).
+    (Yasuo)
 
 ?? ??? 2014, PHP 5.5.15
 

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -481,7 +481,7 @@ PHP_FUNCTION(apache_request_headers) /* {{{ */
 {
 	php_cli_server_client *client;
 	HashTable *headers;
-	char *key;
+	char *key, *tmp;
 	uint key_len;
 	char **value_pointer;
 	HashPosition pos;
@@ -498,7 +498,9 @@ PHP_FUNCTION(apache_request_headers) /* {{{ */
 	zend_hash_internal_pointer_reset_ex(headers, &pos);
 	while (zend_hash_get_current_data_ex(headers, (void **)&value_pointer, &pos) == SUCCESS) {
 		zend_hash_get_current_key_ex(headers, &key, &key_len, NULL, 0, &pos);
-		add_assoc_string_ex(return_value, key, key_len, *value_pointer, 1);
+		tmp = estrndup(key, key_len-1);
+		add_assoc_string_ex(return_value, tmp, key_len, *value_pointer, 1);
+		efree(tmp);
 		zend_hash_move_forward_ex(headers, &pos);
 	}
 }


### PR DESCRIPTION
Zend hash allows any key, but PHP assumes null terminated keys for array keys.
