### PR TITLE
Fix #67594 - invisible colon should be stripped off header name

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1685,10 +1685,14 @@ static int php_cli_server_client_read_request_on_header_value(php_http_parser *p
 		return 1;
 	}
 	{
-		char *header_name = zend_str_tolower_dup(client->current_header_name, client->current_header_name_len);
-		zend_hash_add(&client->request.headers, header_name, client->current_header_name_len + 1, &value, sizeof(char *), NULL);
-		zend_hash_add(&client->request.headers_original_case, client->current_header_name, client->current_header_name_len + 1, &value, sizeof(char *), NULL);
-		efree(header_name);
+		/* strip off the colon */
+		char *orig_header_name = estrndup(client->current_header_name, client->current_header_name_len);
+		char *lc_header_name = zend_str_tolower_dup(client->current_header_name, client->current_header_name_len);
+
+		zend_hash_add(&client->request.headers, lc_header_name, client->current_header_name_len + 1, &value, sizeof(char *), NULL);
+		zend_hash_add(&client->request.headers_original_case, orig_header_name, client->current_header_name_len + 1, &value, sizeof(char *), NULL);
+		efree(lc_header_name);
+		efree(orig_header_name);
 	}
 
 	if (client->current_header_name_allocated) {


### PR DESCRIPTION
This fixes [#67594](https://bugs.php.net/bug.php?id=67594) by making sure that the string keys are properly null terminated before being added to the hash of header values; this was already done for the lower case names but not for the original case.
