### PR TITLE
Sync upstream patches we carry in Debian

### DIFF
--- a/ext/gd/gd_compat.c
+++ b/ext/gd/gd_compat.c
@@ -1,4 +1,6 @@
-#include "php_config.h"
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #ifdef HAVE_GD_PNG
 /* needs to be first */


### PR DESCRIPTION
Hi,

this pull request sync several patches we carry in Debian packages and that can be applied upstream.

44ed932, 50f18cc and f5ff12a fixes build issues on less common architectures (armel and m68k).

e29b9cb fixes example paths in default php-fpm.conf

Stuff with patches but forgotten in bugs.php.net:

9046085 adds getallheaders() function to FPM SAPI
1705b96 fixes PHP on 32-bit platform compiled with LARGE_FILE
