### PR TITLE
Add ifdef on ecdh for single_ecdh_use

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1164,12 +1164,14 @@ static int set_server_specific_opts(php_stream *stream, SSL_CTX *ctx TSRMLS_DC) 
 		ssl_ctx_options |= SSL_OP_SINGLE_DH_USE;
 	}
 
+#ifdef HAVE_ECDH
 	if (SUCCESS == php_stream_context_get_option(
 				stream->context, "ssl", "single_ecdh_use", &val) &&
 			zend_is_true(*val)
 	) {
 		ssl_ctx_options |= SSL_OP_SINGLE_ECDH_USE;
 	}
+#endif
 
 	SSL_CTX_set_options(ctx, ssl_ctx_options);
 


### PR DESCRIPTION
Allows build with OpenSSL < 0.9.8

It looks to be under ecdh ifdef at d0c9207cff83a1055767e86e8d2aa9661513224f but changed in the refactor done at 27849c998a77a093449dec4b051dfc266d5123ec 
