### PR TITLE
Set FPM_BACKLOG_DEFAULT to 511

### DIFF
--- a/sapi/fpm/fpm/fpm_sockets.h
+++ b/sapi/fpm/fpm/fpm_sockets.h
@@ -19,7 +19,7 @@
 #if (__FreeBSD__) || (__OpenBSD__)
 #define FPM_BACKLOG_DEFAULT -1
 #else
-#define FPM_BACKLOG_DEFAULT 65535
+#define FPM_BACKLOG_DEFAULT 511 
 #endif
 
 enum fpm_address_domain fpm_sockets_domain_from_address(char *addr);


### PR DESCRIPTION
It is too large for php-fpm to set the listen backlog to 65535.
It is really **NOT** a good idea to clog the accept queue especially
when the client or nginx has a timeout for this connection.

Assume that the php-fpm qps is 5000. It will take 13s to completely
consume the 65535 backloged connections. The connection maybe already
have been closed cause of timeout of nginx or clients. So when we accept
the 65535th socket, we get a broken pipe.

Even worse, if hundreds of php-fpm processes get a closed connection
they are just wasting time and resouces to run a heavy task and finally
get error when writing to the closed connection(error: Broken Pipe).

The really max accept queue size will be backlog+1(ie, 512 here).
We take 511 which is the same as nginx and redis.