### PR TITLE
loosen the restrictions on ReflectionClass::newInstanceWithoutConstructor()

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -4309,7 +4309,7 @@ ZEND_METHOD(reflection_class, newInstanceWithoutConstructor)
 	GET_REFLECTION_OBJECT_PTR(ce);
 
 	if (ce->create_object != NULL && ce->ce_flags & ZEND_ACC_FINAL_CLASS) {
-		zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC, "Class %s is an internal class with a final __construct thus cannot be instantiated without invoking its constructor", ce->name);
+		zend_throw_exception_ex(reflection_exception_ptr, 0 TSRMLS_CC, "Class %s is an internal class marked as final that cannot be instantiated without invoking its constructor", ce->name);
 	}
 
 	object_init_ex(return_value, ce);

--- a/ext/reflection/tests/ReflectionClass_newInstanceWithoutConstructor.phpt
+++ b/ext/reflection/tests/ReflectionClass_newInstanceWithoutConstructor.phpt
@@ -31,7 +31,7 @@ object(stdClass)#%d (0) {
 object(DateTime)#%d (0) {
 }
 
-Fatal error: Uncaught exception 'ReflectionException' with message 'Class Generator is an internal class with a final __construct thus cannot be instantiated without invoking its constructor' in %sReflectionClass_newInstanceWithoutConstructor.php:%d
+Fatal error: Uncaught exception 'ReflectionException' with message 'Class Generator is an internal class marked as final that cannot be instantiated without invoking its constructor' in %sReflectionClass_newInstanceWithoutConstructor.php:%d
 Stack trace:
 #0 %sReflectionClass_newInstanceWithoutConstructor.php(%d): ReflectionClass->newInstanceWithoutConstructor()
 #1 {main}

--- a/ext/reflection/tests/bug64007.phpt
+++ b/ext/reflection/tests/bug64007.phpt
@@ -14,6 +14,6 @@ $generator  = $reflection->newInstance();
 var_dump($generator);
 ?>
 --EXPECTF--
-string(%d) "Class Generator is an internal class with a final __construct thus cannot be instantiated without invoking its constructor"
+string(%d) "Class Generator is an internal class marked as final that cannot be instantiated without invoking its constructor"
 
 Catchable fatal error: The "Generator" class is reserved for internal use and cannot be manually instantiated in %sbug64007.php on line %d


### PR DESCRIPTION
allow instantiating any class except internal classes with a final __construct().
see http://www.serverphorums.com/read.php?7,959450,987654#msg-987654 (and the whole thread) for the full discussion, but basically with the removal of the unserialize O: trick which allowed the instantiation of internal classes with a custom serializer there is no way to do that from the userland, and that breaks a bunch of libs/apps out there.
the original restriction was in place, because there are internal classes with custom object storage, where the object initialization happens in the __construct instead of the create_object hook, but for non final constructors it is already a problem which can occur (a class which has it's own __construct method which doesn't call parent::__construct() extending an internal class), so it is ok to allow the same problems surfacing here also.
