### PR TITLE
Bug 67719

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -150,6 +150,12 @@ static inline zend_uchar is_numeric_string_ex(const char *str, int length, long 
 		str++;
 		length--;
 	}
+	ptr = str + length - 1;
+	while (*ptr == ' ' || *ptr == '\t' || *ptr == '\n' || *ptr == '\r' || *ptr == '\v' || *ptr == '\f') {
+		ptr--;
+		length--;
+	}
+
 	ptr = str;
 
 	if (*ptr == '-' || *ptr == '+') {

--- a/ext/standard/tests/bug67719.phpt
+++ b/ext/standard/tests/bug67719.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test for bug #67719: is_numeric treats leading and trailing spaces differently
+--CREDITS--
+Boro Sitnikovski <buritomath@yahoo.com>
+--FILE--
+<?php
+$str1 = " 1";
+$str2 = "1 ";
+var_dump(is_numeric($str1));
+var_dump(is_numeric($str2));
+var_dump($str1 == 1);
+var_dump($str2 == 1);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Make is_numeric() consistent. Since " 1" == 1 and "1 " == 1, is_numeric() should return true for both strings.
