### PR TITLE
remove 'broken tar' detection by filename

### DIFF
--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -113,10 +113,7 @@ int phar_is_tar(char *buf, char *fname) /* {{{ */
 	memset(header->checksum, ' ', sizeof(header->checksum));
 	ret = (checksum == phar_tar_checksum(buf, 512));
 	memcpy(header->checksum, save, sizeof(header->checksum));
-	if (!ret && strstr(fname, ".tar")) {
-		/* probably a corrupted tar - so we will pretend it is one */
-		return 1;
-	}
+	
 	return ret;
 }
 /* }}} */


### PR DESCRIPTION
Really confuding place, that occure bugs like this
https://bugs.php.net/bug.php?id=67761
We can't handle file as tar just because it contain .tar
