### PR TITLE
Created sempty (Strict Empty) function which evaluates 0 and FALSE as no...

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2539,6 +2539,10 @@ ZEND_BEGIN_ARG_INFO(arginfo_is_scalar, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_sempty, 0)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_is_callable, 0, 0, 1)
 	ZEND_ARG_INFO(0, var)
 	ZEND_ARG_INFO(0, syntax_only)
@@ -3035,6 +3039,7 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(is_array,														arginfo_is_array)
 	PHP_FE(is_object,														arginfo_is_object)
 	PHP_FE(is_scalar,														arginfo_is_scalar)
+	PHP_FE(sempty,															arginfo_sempty)
 	PHP_FE(is_callable,														arginfo_is_callable)
 
 	/* functions from file.c */

--- a/ext/standard/php_type.h
+++ b/ext/standard/php_type.h
@@ -38,5 +38,6 @@ PHP_FUNCTION(is_array);
 PHP_FUNCTION(is_object);
 PHP_FUNCTION(is_scalar);
 PHP_FUNCTION(is_callable);
+PHP_FUNCTION(sempty);
 
 #endif

--- a/ext/standard/type.c
+++ b/ext/standard/type.c
@@ -365,6 +365,37 @@ PHP_FUNCTION(is_scalar)
 }
 /* }}} */
 
+/* {{{ proto bool sempty(mixed value)
+   Returns true if value is empty, in a strict fashion */
+PHP_FUNCTION(sempty)
+{
+	zval **arg;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z", &arg) == FAILURE) {
+		return;
+	}
+	
+	if(Z_STRLEN_PP(arg) == 0){
+		RETURN_TRUE;
+	}
+	
+	switch (Z_TYPE_PP(arg)) {
+		case IS_BOOL:
+		case IS_DOUBLE:
+		case IS_LONG:
+		case IS_STRING:
+			
+			RETURN_FALSE;
+			break;
+
+		default:
+			RETURN_TRUE;
+			break;
+	}
+}
+/* }}} */
+
+
 /* {{{ proto bool is_callable(mixed var [, bool syntax_only [, string callable_name]]) 
    Returns true if var is callable. */
 PHP_FUNCTION(is_callable)


### PR DESCRIPTION
Strict Empty (sempty) is a function that will evaluate empty with a stricter evaluation. Where empty will evaluate FALSE and 0 as empty values, sempty will see those as non-empty values.

An empty (zero-length) string is still considered null, and will evaluate as empty.

```
var_dump(sempty(null)) // true
var_dump(sempty("")) // true
var_dump(sempty(0)) // false
var_dump(sempty(false)) // false
```
