### PR TITLE
fpm: relax log permissions (bug #61435)

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -947,7 +947,7 @@ static int fpm_conf_process_all_pools() /* {{{ */
 			if (wp->config->slowlog && *wp->config->slowlog) {
 				int fd;
 
-				fd = open(wp->config->slowlog, O_WRONLY | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR);
+				fd = open(wp->config->slowlog, O_WRONLY | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 
 				if (0 > fd) {
 					zlog(ZLOG_SYSERROR, "Unable to create or open slowlog(%s)", wp->config->slowlog);

--- a/sapi/fpm/fpm/fpm_log.c
+++ b/sapi/fpm/fpm/fpm_log.c
@@ -42,7 +42,7 @@ int fpm_log_open(int reopen) /* {{{ */
 		}
 		ret = 0;
 		
-		fd = open(wp->config->access_log, O_WRONLY | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR);
+		fd = open(wp->config->access_log, O_WRONLY | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 		if (0 > fd) {
 			zlog(ZLOG_SYSERROR, "failed to open access log (%s)", wp->config->access_log);
 			return -1;

--- a/sapi/fpm/fpm/fpm_php_trace.c
+++ b/sapi/fpm/fpm/fpm_php_trace.c
@@ -17,6 +17,7 @@
 # include <stdint.h>
 #endif
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <errno.h>
@@ -140,10 +141,12 @@ void fpm_php_trace(struct fpm_child_s *child) /* {{{ */
 	TSRMLS_FETCH();
 	fpm_scoreboard_update(0, 0, 0, 0, 0, 0, 1, FPM_SCOREBOARD_ACTION_INC, child->wp->scoreboard);
 	FILE *slowlog;
+	int fd;
 
 	zlog(ZLOG_NOTICE, "about to trace %d", (int) child->pid);
 
-	slowlog = fopen(child->wp->config->slowlog, "a+");
+	fd = open(child->wp->config->slowlog, O_WRONLY | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	slowlog = fdopen(fd, "a");
 
 	if (!slowlog) {
 		zlog(ZLOG_SYSERROR, "unable to open slowlog (%s)", child->wp->config->slowlog);

--- a/sapi/fpm/fpm/fpm_stdio.c
+++ b/sapi/fpm/fpm/fpm_stdio.c
@@ -279,7 +279,7 @@ int fpm_stdio_open_error_log(int reopen) /* {{{ */
 	}
 #endif
 
-	fd = open(fpm_global_config.error_log, O_WRONLY | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR);
+	fd = open(fpm_global_config.error_log, O_WRONLY | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	if (0 > fd) {
 		zlog(ZLOG_SYSERROR, "failed to open error_log (%s)", fpm_global_config.error_log);
 		return -1;


### PR DESCRIPTION
Do not unconditionally set permissions for access_log, error_log and slow_log to
0600, instead default to 0644 and allow the administrator to set tightier
permissions as needed (using umask).

This makes the logs more accessible to developers which are unlikely to run as
the PHP server user.

---

[bug 61435](https://bugs.php.net/bug.php?id=61435) has been open for too long, let's try to carry it upstream in this way.
