### PR TITLE
Return old scale value from bcscale()

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -537,15 +537,19 @@ PHP_FUNCTION(bccomp)
    Sets default scale parameter for all bc math functions */
 PHP_FUNCTION(bcscale)
 {
-	long new_scale;
-	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &new_scale) == FAILURE) {
+	long old_scale, new_scale;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &new_scale) == FAILURE) {
 		return;
 	}
 
-	BCG(bc_precision) = ((int)new_scale < 0) ? 0 : new_scale;
+	old_scale = BCG(bc_precision);
 
-	RETURN_TRUE;
+	if (ZEND_NUM_ARGS() == 1) {
+		BCG(bc_precision) = ((int)new_scale < 0) ? 0 : new_scale;
+	}
+
+	RETURN_LONG(old_scale);
 }
 /* }}} */
 

--- a/ext/bcmath/tests/bcscale_variation003.phpt
+++ b/ext/bcmath/tests/bcscale_variation003.phpt
@@ -1,0 +1,18 @@
+--TEST--
+bcscale() return value
+--SKIPIF--
+<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--INI--
+bcmath.scale=0
+--FILE--
+<?php
+var_dump(bcscale(1));
+var_dump(bcscale(4));
+var_dump(bcscale());
+var_dump(bcscale());
+?>
+--EXPECT--
+int(0)
+int(1)
+int(4)
+int(4)


### PR DESCRIPTION
Fix for [#67855](https://bugs.php.net/bug.php?id=67855).

Make argument for `bcscale()` optional, only update scale when the argument is passed, and always return the old value.

As this is a (minor) backwards compatibility break, this patch targets master.
