### PR TITLE
fix the bug of curl_setopt

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2747,7 +2747,7 @@ PHP_FUNCTION(curl_setopt)
 	zend_long        options;
 	php_curl   *ch;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rlz", &zid, &options, &zvalue) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rlz/", &zid, &options, &zvalue) == FAILURE) {
 		return;
 	}
 


### PR DESCRIPTION
curl_setopt will  modify the type of param
the bugs is here: https://bugs.php.net/bug.php?id=67704
