### PR TITLE
Special-case aliases, add warning comments to implementations

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -519,7 +519,8 @@ ZEND_FUNCTION(func_get_args)
 /* }}} */
 
 /* {{{ proto int strlen(string str)
-   Get string length */
+   Get string length
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 ZEND_FUNCTION(strlen)
 {
 	zend_string *s;
@@ -776,7 +777,8 @@ repeat:
 
 
 /* {{{ proto bool defined(string constant_name)
-   Check whether a constant exists */
+   Check whether a constant exists
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 ZEND_FUNCTION(defined)
 {
 	zend_string *name;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4274,9 +4274,9 @@ int zend_try_compile_special_func(
 		return zend_compile_func_typecheck(result, args, IS_NULL TSRMLS_CC);
 	} else if (zend_string_equals_literal(lcname, "is_bool")) {
 		return zend_compile_func_typecheck(result, args, _IS_BOOL TSRMLS_CC);
-	} else if (zend_string_equals_literal(lcname, "is_long")) {
+	} else if (zend_string_equals_literal(lcname, "is_long") || zend_string_equals_literal(lcname, "is_int") || zend_string_equals_literal(lcname, "is_integer")) {
 		return zend_compile_func_typecheck(result, args, IS_LONG TSRMLS_CC);
-	} else if (zend_string_equals_literal(lcname, "is_float")) {
+	} else if (zend_string_equals_literal(lcname, "is_float") || zend_string_equals_literal(lcname, "is_double") || zend_string_equals_literal(lcname, "is_real")) {
 		return zend_compile_func_typecheck(result, args, IS_DOUBLE TSRMLS_CC);
 	} else if (zend_string_equals_literal(lcname, "is_string")) {
 		return zend_compile_func_typecheck(result, args, IS_STRING TSRMLS_CC);

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4714,7 +4714,8 @@ PHP_FUNCTION(error_get_last)
 /* }}} */
 
 /* {{{ proto mixed call_user_func(mixed function_name [, mixed parmeter] [, mixed ...])
-   Call a user function which is the first parameter */
+   Call a user function which is the first parameter
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(call_user_func)
 {
 	zval retval;
@@ -4741,7 +4742,8 @@ PHP_FUNCTION(call_user_func)
 /* }}} */
 
 /* {{{ proto mixed call_user_func_array(string function_name, array parameters)
-   Call a user function which is the first parameter with the arguments contained in array */
+   Call a user function which is the first parameter with the arguments contained in array
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(call_user_func_array)
 {
 	zval *params, retval;

--- a/ext/standard/type.c
+++ b/ext/standard/type.c
@@ -243,7 +243,8 @@ static inline void php_is_type(INTERNAL_FUNCTION_PARAMETERS, int type)
 
 
 /* {{{ proto bool is_null(mixed var)
-   Returns true if variable is null */
+   Returns true if variable is null
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(is_null)
 {
 	php_is_type(INTERNAL_FUNCTION_PARAM_PASSTHRU, IS_NULL);
@@ -251,7 +252,8 @@ PHP_FUNCTION(is_null)
 /* }}} */
 
 /* {{{ proto bool is_resource(mixed var)
-   Returns true if variable is a resource */
+   Returns true if variable is a resource
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(is_resource)
 {
 	php_is_type(INTERNAL_FUNCTION_PARAM_PASSTHRU, IS_RESOURCE);
@@ -259,7 +261,8 @@ PHP_FUNCTION(is_resource)
 /* }}} */
 
 /* {{{ proto bool is_bool(mixed var)
-   Returns true if variable is a boolean */
+   Returns true if variable is a boolean
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(is_bool)
 {
 	zval *arg;
@@ -274,7 +277,8 @@ PHP_FUNCTION(is_bool)
 /* }}} */
 
 /* {{{ proto bool is_long(mixed var)
-   Returns true if variable is a long (integer) */
+   Returns true if variable is a long (integer)
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(is_long)
 {
 	php_is_type(INTERNAL_FUNCTION_PARAM_PASSTHRU, IS_LONG);
@@ -282,7 +286,8 @@ PHP_FUNCTION(is_long)
 /* }}} */
 
 /* {{{ proto bool is_float(mixed var)
-   Returns true if variable is float point*/
+   Returns true if variable is float point
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(is_float)
 {
 	php_is_type(INTERNAL_FUNCTION_PARAM_PASSTHRU, IS_DOUBLE);
@@ -290,7 +295,8 @@ PHP_FUNCTION(is_float)
 /* }}} */
 
 /* {{{ proto bool is_string(mixed var)
-   Returns true if variable is a string */
+   Returns true if variable is a string
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(is_string)
 {
 	php_is_type(INTERNAL_FUNCTION_PARAM_PASSTHRU, IS_STRING);
@@ -298,7 +304,8 @@ PHP_FUNCTION(is_string)
 /* }}} */
 
 /* {{{ proto bool is_array(mixed var)
-   Returns true if variable is an array */
+   Returns true if variable is an array
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(is_array)
 {
 	php_is_type(INTERNAL_FUNCTION_PARAM_PASSTHRU, IS_ARRAY);
@@ -306,7 +313,8 @@ PHP_FUNCTION(is_array)
 /* }}} */
 
 /* {{{ proto bool is_object(mixed var)
-   Returns true if variable is an object */
+   Returns true if variable is an object
+   Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(is_object)
 {
 	php_is_type(INTERNAL_FUNCTION_PARAM_PASSTHRU, IS_OBJECT);


### PR DESCRIPTION
This is me finishing what @dstogov started. I spent an hour trying to figure out how it was possible that `is_long` and `is_int`/`is_integer` were doing different things in my bigints branch despite being FALIASes.

This should prevent any future confusion :)
