### PR TITLE
hash_equals: Don't leak length difference. (Bug 67939)

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -729,13 +729,12 @@ PHP_FUNCTION(hash_pbkdf2)
 /* }}} */
 
 /* {{{ proto bool hash_equals(string known_string, string user_string)
-   Compares two strings using the same time whether they're equal or not.
-   A difference in length will leak */
+   Compares two strings using the same time whether they're equal or not. */
 PHP_FUNCTION(hash_equals)
 {
 	zval *known_zval, *user_zval;
 	char *known_str, *user_str;
-	int result = 0, j;
+	int known_len, user_len, result, j;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zz", &known_zval, &user_zval) == FAILURE) {
 		return;
@@ -752,16 +751,19 @@ PHP_FUNCTION(hash_equals)
 		RETURN_FALSE;
 	}
 
-	if (Z_STRLEN_P(known_zval) != Z_STRLEN_P(user_zval)) {
-		RETURN_FALSE;
-	}
+	known_len = Z_STRLEN_P(known_zval);
+	user_len = Z_STRLEN_P(user_zval);
 
 	known_str = Z_STRVAL_P(known_zval);
 	user_str = Z_STRVAL_P(user_zval);
 
-	/* This is security sensitive code. Do not optimize this for speed. */
-	for (j = 0; j < Z_STRLEN_P(known_zval); j++) {
-		result |= known_str[j] ^ user_str[j];
+	/* Set result as different of 0 if strings have a different length. */
+	result = known_len - user_len;
+
+	/* This is security sensitive code. Do not optimize this for speed.
+           Always iterate on \0 to avoid issues with empty strings. */
+	for (j = 0; j < user_len + 1; j++) {
+		result |= known_str[j % (known_len + 1)] ^ user_str[j];
 	}
 
 	RETURN_BOOL(0 == result);


### PR DESCRIPTION
Reopened against 5.6 branch: https://github.com/php/php-src/pull/792

`hash_equals` leaks difference in length of compared strings (this is a documented behavior).
This implementation ported from Symfony don't.

The discussion started in a try to use `hash_equals` in Symfony: https://github.com/symfony/symfony/pull/11797
