### PR TITLE
Fixed FR #67915 - Improve strrchr()

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2245,9 +2245,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_strripos, 0, 0, 2)
 	ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_strrchr, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_strrchr, 0, 0, 2)
 	ZEND_ARG_INFO(0, haystack)
 	ZEND_ARG_INFO(0, needle)
+	ZEND_ARG_INFO(0, part)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_chunk_split, 0, 0, 1)

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2095,7 +2095,7 @@ PHP_FUNCTION(strripos)
 }
 /* }}} */
 
-/* {{{ proto string strrchr(string haystack, string needle)
+/* {{{ proto string strrchr(string haystack, string needle [, bool part])
    Finds the last occurrence of a character in a string within another */
 PHP_FUNCTION(strrchr)
 {
@@ -2103,8 +2103,9 @@ PHP_FUNCTION(strrchr)
 	zend_string *haystack;
 	const char *found = NULL;
 	zend_long found_offset;
+	zend_bool part = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sz", &haystack, &needle) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sz|b", &haystack, &needle, &part) == FAILURE) {
 		return;
 	}
 
@@ -2121,7 +2122,11 @@ PHP_FUNCTION(strrchr)
 
 	if (found) {
 		found_offset = found - haystack->val;
-		RETURN_STRINGL(found, haystack->len - found_offset);
+		if (part) {
+			RETURN_STRINGL(haystack->val, found_offset);
+		} else {
+			RETURN_STRINGL(found, haystack->len - found_offset);
+		}
 	} else {
 		RETURN_FALSE;
 	}

--- a/ext/standard/tests/strings/strrchr_basic.phpt
+++ b/ext/standard/tests/strings/strrchr_basic.phpt
@@ -35,6 +35,12 @@ var_dump( strrchr("Hello, World", "o") );
 var_dump( strrchr("Hello, World", "ooo") );
 
 var_dump( strrchr("Hello, World", "Zzzz") ); //non-existent needle in haystack
+
+echo "*** Testing part argument ***\n";
+
+var_dump( strrchr("Hello, World", "o", true) );
+var_dump( strrchr("Hello, World", "t", true) );
+
 echo "*** Done ***";
 ?>
 --EXPECTF--
@@ -53,5 +59,8 @@ string(12) "Hello, World"
 string(12) "Hello, World"
 string(4) "orld"
 string(4) "orld"
+bool(false)
+*** Testing part argument ***
+string(%d) "Hello, W"
 bool(false)
 *** Done ***

--- a/ext/standard/tests/strings/strrchr_error.phpt
+++ b/ext/standard/tests/strings/strrchr_error.phpt
@@ -19,7 +19,7 @@ echo "\n-- Testing strrchr() function with less than expected no. of arguments -
 var_dump( strrchr($haystack) );
 
 echo "\n-- Testing strrchr() function with more than expected no. of arguments --";
-var_dump( strrchr($haystack, $needle, $extra_arg) );
+var_dump( strrchr($haystack, $needle, false, $extra_arg) );
 
 echo "*** Done ***";
 ?>
@@ -27,14 +27,14 @@ echo "*** Done ***";
 *** Testing strrchr() function: error conditions ***
 
 -- Testing strrchr() function with Zero arguments --
-Warning: strrchr() expects exactly 2 parameters, 0 given in %s on line %d
+Warning: strrchr() expects at least 2 parameters, 0 given in %s on line %d
 NULL
 
 -- Testing strrchr() function with less than expected no. of arguments --
-Warning: strrchr() expects exactly 2 parameters, 1 given in %s on line %d
+Warning: strrchr() expects at least 2 parameters, 1 given in %s on line %d
 NULL
 
 -- Testing strrchr() function with more than expected no. of arguments --
-Warning: strrchr() expects exactly 2 parameters, 3 given in %s on line %d
+Warning: strrchr() expects at most 3 parameters, 4 given in %s on line %d
 NULL
 *** Done ***


### PR DESCRIPTION
This addresses [FR 67915](https://bugs.php.net/bug.php?id=67915).
- Added optional third argument to strrchr() to select the part before the match
- Updated error test cases
- Added test cases for new behaviour
