### PR TITLE
gmp_init(): Don't use leading 0x or 0b if different base specified

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -738,11 +738,9 @@ static int convert_to_gmp(mpz_t gmpnumber, zval *val, int base TSRMLS_DC)
 
 		if (Z_STRLEN_P(val) > 2) {
 			if (numstr[0] == '0') {
-				if (numstr[1] == 'x' || numstr[1] == 'X') {
-					base = 16;
+				if (base == 16 && (numstr[1] == 'x' || numstr[1] == 'X')) {
 					skip_lead = 1;
-				} else if (base != 16 && (numstr[1] == 'b' || numstr[1] == 'B')) {
-					base = 2;
+				} else if (base == 2 && (numstr[1] == 'b' || numstr[1] == 'B')) {
 					skip_lead = 1;
 				}
 			}

--- a/ext/gmp/tests/bug50175.phpt
+++ b/ext/gmp/tests/bug50175.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Bug #50175: gmp_init() results 0 on given base and number starting with 0x or 0b
+--SKIPIF--
+<?php if (!extension_loaded("gmp")) print "skip"; ?>
+--FILE--
+<?php
+for ($base = 2; $base <= 36; $base++) {
+	echo "$base:";
+	for ($i = 1; $i < $base; $i++) {
+		$c = $i <= 9 ? $i : chr($i - 10 + ord('a'));
+		echo ' ' . gmp_strval(gmp_init("0$c$c", $base), $base);
+	}
+	echo "\n";
+}
+?>
+--EXPECT--
+2: 11
+3: 11 22
+4: 11 22 33
+5: 11 22 33 44
+6: 11 22 33 44 55
+7: 11 22 33 44 55 66
+8: 11 22 33 44 55 66 77
+9: 11 22 33 44 55 66 77 88
+10: 11 22 33 44 55 66 77 88 99
+11: 11 22 33 44 55 66 77 88 99 aa
+12: 11 22 33 44 55 66 77 88 99 aa bb
+13: 11 22 33 44 55 66 77 88 99 aa bb cc
+14: 11 22 33 44 55 66 77 88 99 aa bb cc dd
+15: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee
+16: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+17: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg
+18: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh
+19: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii
+20: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj
+21: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk
+22: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll
+23: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm
+24: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn
+25: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo
+26: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp
+27: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq
+28: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr
+29: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
+30: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt
+31: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu
+32: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv
+33: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww
+34: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx
+35: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy
+36: 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz


### PR DESCRIPTION
Fixes bugs #50175 and #55398.

Made pull request against master; backport to older branches if you wish.

@smalyshev @TazeTSchnitzel @nikic
