### PR TITLE
fix bug #67955

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -830,7 +830,7 @@ try_again:
 						      (zend_hash_index_find(Z_ARRVAL_PP(data), 2, (void**)&tmp) == FAILURE ||
 						       in_domain(phpurl->host,Z_STRVAL_PP(tmp))) &&
 						      (use_ssl || zend_hash_index_find(Z_ARRVAL_PP(data), 3, (void**)&tmp) == FAILURE)) {
-								smart_str_appendl(&soap_headers, key, key_len);
+								smart_str_appendl(&soap_headers, key, key_len-1);
 								smart_str_appendc(&soap_headers, '=');
 								smart_str_appendl(&soap_headers, Z_STRVAL_PP(value), Z_STRLEN_PP(value));
 								smart_str_appendc(&soap_headers, ';');


### PR DESCRIPTION
this fixes a regression from 6c2a8068207a02b3d7ae7416a9967dad0a81e61f 
which caused [bug 67955](https://bugs.php.net/bug.php?id=67955):

`smart_str_appendl` is expecting the length as the length of the string,
but key_length is the byte length of the key, including the 0
terminator.

As such, the cookie name appended to the header would now also include
the 0 terminator of the key name which then would be sent to the server.
