### PR TITLE
Fixes #67960 - Long/short day names reversed in jddayofweek()

### DIFF
--- a/ext/calendar/calendar.c
+++ b/ext/calendar/calendar.c
@@ -208,7 +208,7 @@ static struct cal_entry_t cal_conversion_table[CAL_NUM_CALS] = {
 #define JEWISH_HEB_MONTH_NAME(year) ((monthsPerYear[((year)-1) % 19] == 13)?JewishMonthHebNameLeap:JewishMonthHebName)
 
 /* For jddayofweek */
-enum { CAL_DOW_DAYNO, CAL_DOW_SHORT, CAL_DOW_LONG };
+enum { CAL_DOW_DAYNO, CAL_DOW_LONG, CAL_DOW_SHORT };
 
 /* For jdmonthname */
 enum { CAL_MONTH_GREGORIAN_SHORT, CAL_MONTH_GREGORIAN_LONG,
@@ -694,10 +694,10 @@ PHP_FUNCTION(jddayofweek)
 	daynames = DayNameShort[day];
 
 	switch (mode) {
-	case CAL_DOW_SHORT:
+	case CAL_DOW_LONG:
 		RETURN_STRING(daynamel);
 		break;
-	case CAL_DOW_LONG:
+	case CAL_DOW_SHORT:
 		RETURN_STRING(daynames);
 		break;
 	case CAL_DOW_DAYNO:

--- a/ext/calendar/tests/jddayofweek.phpt
+++ b/ext/calendar/tests/jddayofweek.phpt
@@ -6,7 +6,7 @@ jddayofweek()
 <?php
 foreach (array(2440588, 2452162, 2453926, -1000) as $jd) {
   echo "### JD $jd ###\n";
-  for ($mode = 0; $mode <= 2; $mode++) {
+  foreach (array(CAL_DOW_DAYNO, CAL_DOW_LONG, CAL_DOW_SHORT) as $mode) {
     echo "--- mode $mode ---\n";
     for ($offset = 0; $offset <= 7; $offset++) {
       echo jddayofweek($jd + $offset, $mode). "\n";


### PR DESCRIPTION
See https://bugs.php.net/bug.php?id=67960

We reverse the definitions of the constants, so that `CAL_DOW_LONG` is now `1` and `CAL_DOW_SHORT` is now `2` so that they correspond with the definitions given in the documentation at http://www.php.net/function.jddayofweek

This means we need to reverse their usage in the code.  Note here that previously, `CAL_DOW_LONG` selected the short names `daynames` and `CAL_DOW_SHORT` selected the long names `daynamel`!

The test script is now driven from the constants - and since we test their numeric values in the expected output, we are checking that they are set consistently.