### PR TITLE
Deprecate multiple default blocks in a switch

### DIFF
--- a/Zend/tests/034.phpt
+++ b/Zend/tests/034.phpt
@@ -22,5 +22,8 @@ switch (1) {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Switch statements may only contain one default clause in %s on line %d
+
+Deprecated: Switch statements may only contain one default clause in %s on line %d
 3

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5073,6 +5073,10 @@ void zend_do_default_before_statement(const znode *case_list, znode *default_tok
 	default_token->u.op.opline_num = next_op_number;
 
 	next_op_number = get_next_op_number(CG(active_op_array));
+	/* -1 indicates no default seen yet */
+	if (switch_entry_ptr->default_case >= 0) {
+		zend_error(E_DEPRECATED, "Switch statements may only contain one default clause");
+	}
 	switch_entry_ptr->default_case = next_op_number;
 
 	if (case_list->op_type==IS_UNUSED) {


### PR DESCRIPTION
Part of RFC: https://wiki.php.net/rfc/switch.default.multiple
This generates an E_DEPRECATED warning but continues to run the last default block. This change is intended for PHP 5.NEXT, not PHP 5.6.