### PR TITLE
Error on multiple default blocks in a switch

### DIFF
--- a/Zend/tests/034.phpt
+++ b/Zend/tests/034.phpt
@@ -22,5 +22,5 @@ switch (1) {
 }
 
 ?>
---EXPECT--
-3
+--EXPECTF--
+Fatal error: Switch statements may only contain one default clause in %s on line 13

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5091,6 +5091,11 @@ void zend_compile_switch(zend_ast *ast TSRMLS_DC) /* {{{ */
 		znode cond_node;
 
 		if (!cond_ast) {
+			if (has_default_case) {
+				CG(zend_lineno) = case_ast->lineno;
+				zend_error_noreturn(E_COMPILE_ERROR,
+					"Switch statements may only contain one default clause");
+			}
 			has_default_case = 1;
 			continue;
 		}


### PR DESCRIPTION
Part of RFC: https://wiki.php.net/rfc/switch.default.multiple
