### PR TITLE
Fixes for ZPP string arguments (and stuff)

### DIFF
--- a/README.EXT_SKEL
+++ b/README.EXT_SKEL
@@ -164,7 +164,7 @@ PHP_FUNCTION(module_name_drawtext)
     char *text = NULL;
     int argc = ZEND_NUM_ARGS();
     int image_id = -1;
-    int text_len;
+    size_t text_len;
     int font_id = -1;
     long x;
     long y;

--- a/README.PARAMETER_PARSING_API
+++ b/README.PARAMETER_PARSING_API
@@ -64,7 +64,8 @@ Type specifiers
  O  - object of specific type given by class entry (zval*, zend_class_entry)
  p  - valid path (string without null bytes in the middle) and its length (char*, int)
  r  - resource (zval*)
- s  - string (with possible null bytes) and its length (char*, int)
+ s  - string (with possible null bytes) and its length (char*, size_t)
+ S  - string (zend_string*)
  z  - the actual zval (zval*)
  Z  - the actual zval (zval**)
  *  - variable arguments list (0 or more)
@@ -97,7 +98,7 @@ it's "l", not "i" btw).
 Both mistakes cause memory corruptions and segfaults on 64bit OSes:
 1)
   char *str;
-  long str_len; /* XXX THIS IS WRONG!! Use int instead. */
+  long str_len; /* XXX THIS IS WRONG!! Use size_t instead. */
   zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len)
 
 2)
@@ -115,7 +116,7 @@ Examples
 /* Gets a long, a string and its length, and a zval */
 long l;
 char *s;
-int s_len;
+size_t s_len;
 zval *param;
 if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lsz",
                           &l, &s, &s_len, &param) == FAILURE) {
@@ -154,13 +155,13 @@ if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a/!",
 long l1, l2, l3;
 char *s;
 /* 
- * The function expects a pointer to a integer in this case, not a long
+ * The function expects a pointer to a size_t (unsigned long) in this case, not a long
  * or any other type.  If you specify a type which is larger
- * than a 'int', the upper bits might not be initialized
+ * than a 'size_t', the upper bits might not be initialized
  * properly, leading to random crashes on platforms like
- * Tru64 or Linux/Alpha.
+ * Tru64 or Linux/Alpha/Darwin.
  */
-int length;
+size_t length;
 
 if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC,
                              "lll", &l1, &l2, &l3) == SUCCESS) {
@@ -197,7 +198,7 @@ if (varargs) {
 /* Function that accepts a string, followed by varargs (1 or more) */
 
 char *str;
-int str_len;
+size_t str_len;
 int i, num_varargs;
 zval ***varargs = NULL;
 

--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -288,7 +288,7 @@ PHP_FUNCTION(com_get_active_object)
 {
 	CLSID clsid;
 	char *module_name;
-	int module_name_len;
+	size_t module_name_len;
 	zend_long code_page = COMG(code_page);
 	IUnknown *unk = NULL;
 	IDispatch *obj = NULL;

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -3338,7 +3338,8 @@ PHP_FUNCTION(curl_escape)
 PHP_FUNCTION(curl_unescape)
 {
 	char       *str = NULL, *out = NULL;
-	int        str_len = 0, out_len;
+	size_t     str_len = 0;
+	int        out_len;
 	zval       *zid;
 	php_curl   *ch;
 

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -3915,7 +3915,8 @@ static void php_free_ps_enc(zend_resource *rsrc TSRMLS_DC)
 PHP_FUNCTION(imagepsloadfont)
 {
 	char *file;
-	int file_len, f_ind, *font;
+	size_t file_len;
+	int f_ind, *font;
 #ifdef PHP_WIN32
 	zend_stat_t st;
 #endif
@@ -4122,7 +4123,7 @@ PHP_FUNCTION(imagepstext)
 	T1_OUTLINE *char_path, *str_path;
 	T1_TMATRIX *transform = NULL;
 	char *str;
-	int str_len;
+	size_t str_len;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rsrlllll|lldl", &img, &str, &str_len, &fnt, &size, &_fg, &_bg, &x, &y, &space, &width, &angle, &aa_steps) == FAILURE) {
 		return;
@@ -4248,11 +4249,12 @@ PHP_FUNCTION(imagepsbbox)
 	zval *fnt;
 	zend_long sz = 0, sp = 0, wd = 0;
 	char *str;
+	size_t str_len;
 	int i, space = 0, add_width = 0, char_width, amount_kern;
 	int cur_x, cur_y, dx, dy;
 	int x1, y1, x2, y2, x3, y3, x4, y4;
 	int *f_ind;
-	int str_len, per_char = 0;
+	int per_char = 0;
 	int argc = ZEND_NUM_ARGS();
 	double angle = 0, sin_a = 0, cos_a = 0;
 	BBox char_bbox, str_bbox = {0, 0, 0, 0};

--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -1145,7 +1145,7 @@ PHP_MINFO_FUNCTION(imap)
 static void php_imap_do_open(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 {
 	char *mailbox, *user, *passwd;
-	int mailbox_len, user_len, passwd_len;
+	size_t mailbox_len, user_len, passwd_len;
 	long retries = 0, flags = NIL, cl_flags = NIL;
 	MAILSTREAM *imap_stream;
 	pils *imap_le_struct;
@@ -1266,7 +1266,7 @@ PHP_FUNCTION(imap_reopen)
 {
 	zval *streamind;
 	char *mailbox;
-	int mailbox_len;
+	size_t mailbox_len;
 	long options = 0, retries = 0;
 	pils *imap_le_struct;
 	long flags=NIL;
@@ -1312,7 +1312,7 @@ PHP_FUNCTION(imap_append)
 {
 	zval *streamind;
 	char *folder, *message, *internal_date = NULL, *flags = NULL;
-	int folder_len, message_len, internal_date_len = 0, flags_len = 0;
+	size_t folder_len, message_len, internal_date_len = 0, flags_len = 0;
 	pils *imap_le_struct;
 	STRING st;
 	zend_string* regex;
@@ -1415,7 +1415,7 @@ PHP_FUNCTION(imap_get_quota)
 {
 	zval *streamind;
 	char *qroot;
-	int qroot_len;
+	size_t qroot_len;
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &streamind, &qroot, &qroot_len) == FAILURE) {
@@ -1443,7 +1443,7 @@ PHP_FUNCTION(imap_get_quotaroot)
 {
 	zval *streamind;
 	char *mbox;
-	int mbox_len;
+	size_t mbox_len;
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &streamind, &mbox, &mbox_len) == FAILURE) {
@@ -1471,7 +1471,7 @@ PHP_FUNCTION(imap_set_quota)
 {
 	zval *streamind;
 	char *qroot;
-	int qroot_len;
+	size_t qroot_len;
 	long mailbox_size;
 	pils *imap_le_struct;
 	STRINGLIST	limits;
@@ -1496,7 +1496,7 @@ PHP_FUNCTION(imap_setacl)
 {
 	zval *streamind;
 	char *mailbox, *id, *rights;
-	int mailbox_len, id_len, rights_len;
+	size_t mailbox_len, id_len, rights_len;
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rsss", &streamind, &mailbox, &mailbox_len, &id, &id_len, &rights, &rights_len) == FAILURE) {
@@ -1515,7 +1515,7 @@ PHP_FUNCTION(imap_getacl)
 {
 	zval *streamind;
 	char *mailbox;
-	int mailbox_len;
+	size_t mailbox_len;
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &streamind, &mailbox, &mailbox_len) == FAILURE) {
@@ -1725,7 +1725,8 @@ PHP_FUNCTION(imap_mail_copy)
 	zval *streamind;
 	long options = 0;
 	char *seq, *folder;
-	int seq_len, folder_len, argc = ZEND_NUM_ARGS();
+	size_t seq_len, folder_len;
+	int argc = ZEND_NUM_ARGS();
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(argc TSRMLS_CC, "rss|l", &streamind, &seq, &seq_len, &folder, &folder_len, &options) == FAILURE) {
@@ -1748,7 +1749,7 @@ PHP_FUNCTION(imap_mail_move)
 {
 	zval *streamind;
 	char *seq, *folder;
-	int seq_len, folder_len;
+	size_t seq_len, folder_len;
 	long options = 0;
 	pils *imap_le_struct;
 	int argc = ZEND_NUM_ARGS();
@@ -1773,7 +1774,7 @@ PHP_FUNCTION(imap_createmailbox)
 {
 	zval *streamind;
 	char *folder;
-	int folder_len;
+	size_t folder_len;
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &streamind, &folder, &folder_len) == FAILURE) {
@@ -1796,7 +1797,7 @@ PHP_FUNCTION(imap_renamemailbox)
 {
 	zval *streamind;
 	char *old_mailbox, *new_mailbox;
-	int old_mailbox_len, new_mailbox_len;
+	size_t old_mailbox_len, new_mailbox_len;
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rss", &streamind, &old_mailbox, &old_mailbox_len, &new_mailbox, &new_mailbox_len) == FAILURE) {
@@ -1819,7 +1820,7 @@ PHP_FUNCTION(imap_deletemailbox)
 {
 	zval *streamind;
 	char *folder;
-	int folder_len;
+	size_t folder_len;
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &streamind, &folder, &folder_len) == FAILURE) {
@@ -1842,7 +1843,7 @@ PHP_FUNCTION(imap_list)
 {
 	zval *streamind;
 	char *ref, *pat;
-	int ref_len, pat_len;
+	size_t ref_len, pat_len;
 	pils *imap_le_struct;
 	STRINGLIST *cur=NIL;
 
@@ -1880,7 +1881,7 @@ PHP_FUNCTION(imap_list_full)
 {
 	zval *streamind, mboxob;
 	char *ref, *pat;
-	int ref_len, pat_len;
+	size_t ref_len, pat_len;
 	pils *imap_le_struct;
 	FOBJECTLIST *cur=NIL;
 	char *delim=NIL;
@@ -1929,7 +1930,7 @@ PHP_FUNCTION(imap_listscan)
 {
 	zval *streamind;
 	char *ref, *pat, *content;
-	int ref_len, pat_len, content_len;
+	size_t ref_len, pat_len, content_len;
 	pils *imap_le_struct;
 	STRINGLIST *cur=NIL;
 
@@ -2039,7 +2040,8 @@ PHP_FUNCTION(imap_headerinfo)
 {
 	zval *streamind;
 	char *defaulthost = NULL;
-	int defaulthost_len = 0, argc = ZEND_NUM_ARGS();
+	size_t defaulthost_len = 0;
+	int argc = ZEND_NUM_ARGS();
 	long msgno, fromlength, subjectlength;
 	pils *imap_le_struct;
 	MESSAGECACHE *cache;
@@ -2122,7 +2124,8 @@ PHP_FUNCTION(imap_rfc822_parse_headers)
 {
 	char *headers, *defaulthost = NULL;
 	ENVELOPE *en;
-	int headers_len, defaulthost_len = 0, argc = ZEND_NUM_ARGS();
+	size_t headers_len, defaulthost_len = 0;
+	int argc = ZEND_NUM_ARGS();
 
 	if (zend_parse_parameters(argc TSRMLS_CC, "s|s", &headers, &headers_len, &defaulthost, &defaulthost_len) == FAILURE) {
 		return;
@@ -2148,7 +2151,7 @@ PHP_FUNCTION(imap_lsub)
 {
 	zval *streamind;
 	char *ref, *pat;
-	int ref_len, pat_len;
+	size_t ref_len, pat_len;
 	pils *imap_le_struct;
 	STRINGLIST *cur=NIL;
 
@@ -2185,7 +2188,7 @@ PHP_FUNCTION(imap_lsub_full)
 {
 	zval *streamind, mboxob;
 	char *ref, *pat;
-	int ref_len, pat_len;
+	size_t ref_len, pat_len;
 	pils *imap_le_struct;
 	FOBJECTLIST *cur=NIL;
 	char *delim=NIL;
@@ -2234,7 +2237,7 @@ PHP_FUNCTION(imap_subscribe)
 {
 	zval *streamind;
 	char *folder;
-	int folder_len;
+	size_t folder_len;
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &streamind, &folder, &folder_len) == FAILURE) {
@@ -2257,7 +2260,7 @@ PHP_FUNCTION(imap_unsubscribe)
 {
 	zval *streamind;
 	char *folder;
-	int folder_len;
+	size_t folder_len;
 	pils *imap_le_struct;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &streamind, &folder, &folder_len) == FAILURE) {
@@ -2330,7 +2333,7 @@ PHP_FUNCTION(imap_fetchbody)
 	long msgno, flags = 0;
 	pils *imap_le_struct;
 	char *body, *sec;
-	int sec_len;
+	size_t sec_len;
 	unsigned long len;
 	int argc = ZEND_NUM_ARGS();
 
@@ -2370,7 +2373,7 @@ PHP_FUNCTION(imap_fetchmime)
 	long msgno, flags = 0;
 	pils *imap_le_struct;
 	char *body, *sec;
-	int sec_len;
+	size_t sec_len;
 	unsigned long len;
 	int argc = ZEND_NUM_ARGS();
 
@@ -2409,7 +2412,8 @@ PHP_FUNCTION(imap_savebody)
 	pils *imap_ptr = NULL;
 	php_stream *writer = NULL;
 	char *section = "";
-	int section_len = 0, close_stream = 1;
+	size_t section_len = 0;
+	int close_stream = 1;
 	long msgno, flags = 0;
 
 	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rzl|sl", &stream, &out, &msgno, &section, &section_len, &flags)) {
@@ -2459,7 +2463,7 @@ PHP_FUNCTION(imap_savebody)
 PHP_FUNCTION(imap_base64)
 {
 	char *text, *decode;
-	int text_len;
+	size_t text_len;
 	unsigned long newlength;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &text, &text_len) == FAILURE) {
@@ -2482,7 +2486,7 @@ PHP_FUNCTION(imap_base64)
 PHP_FUNCTION(imap_qprint)
 {
 	char *text, *decode;
-	int text_len;
+	size_t text_len;
 	unsigned long newlength;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &text, &text_len) == FAILURE) {
@@ -2505,7 +2509,7 @@ PHP_FUNCTION(imap_qprint)
 PHP_FUNCTION(imap_8bit)
 {
 	char *text, *decode;
-	int text_len;
+	size_t text_len;
 	unsigned long newlength;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &text, &text_len) == FAILURE) {
@@ -2528,7 +2532,7 @@ PHP_FUNCTION(imap_8bit)
 PHP_FUNCTION(imap_binary)
 {
 	char *text, *decode;
-	int text_len;
+	size_t text_len;
 	unsigned long newlength;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &text, &text_len) == FAILURE) {
@@ -2598,7 +2602,7 @@ PHP_FUNCTION(imap_mailboxmsginfo)
 PHP_FUNCTION(imap_rfc822_write_address)
 {
 	char *mailbox, *host, *personal;
-	int mailbox_len, host_len, personal_len;
+	size_t mailbox_len, host_len, personal_len;
 	ADDRESS *addr;
 	zend_string *string;
 
@@ -2639,7 +2643,7 @@ PHP_FUNCTION(imap_rfc822_parse_adrlist)
 {
 	zval tovals;
 	char *str, *defaulthost, *str_copy;
-	int str_len, defaulthost_len;
+	size_t str_len, defaulthost_len;
 	ADDRESS *addresstmp;
 	ENVELOPE *env;
 
@@ -2684,7 +2688,7 @@ PHP_FUNCTION(imap_rfc822_parse_adrlist)
 PHP_FUNCTION(imap_utf8)
 {
 	char *str;
-	int str_len;
+	size_t str_len;
 	SIZEDTEXT src, dest;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len) == FAILURE) {
@@ -2742,7 +2746,7 @@ PHP_FUNCTION(imap_utf7_decode)
 	const unsigned char *in, *inp, *endp;
 	unsigned char *out, *outp;
 	unsigned char c;
-	int arg_len, inlen, outlen;
+	size_t arg_len, inlen, outlen;
 	enum {
 		ST_NORMAL,	/* printable text */
 		ST_DECODE0,	/* encoded text rotation... */
@@ -2882,7 +2886,7 @@ PHP_FUNCTION(imap_utf7_encode)
 	zend_string *out;
 	unsigned char *outp;
 	unsigned char c;
-	int arg_len, inlen, outlen;
+	size_t arg_len, inlen, outlen;
 	enum {
 		ST_NORMAL,	/* printable text */
 		ST_ENCODE0,	/* encoded text rotation... */
@@ -2992,7 +2996,7 @@ PHP_FUNCTION(imap_utf7_encode)
 static void php_imap_mutf7(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 {
 	char *in;
-	int in_len;
+	size_t in_len;
 	unsigned char *out;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &in, &in_len) == FAILURE) {
@@ -3040,7 +3044,7 @@ PHP_FUNCTION(imap_setflag_full)
 {
 	zval *streamind;
 	char *sequence, *flag;
-	int sequence_len, flag_len;
+	size_t sequence_len, flag_len;
 	long flags = 0;
 	pils *imap_le_struct;
 
@@ -3061,7 +3065,7 @@ PHP_FUNCTION(imap_clearflag_full)
 {
 	zval *streamind;
 	char *sequence, *flag;
-	int sequence_len, flag_len;
+	size_t sequence_len, flag_len;
 	long flags = 0;
 	pils *imap_le_struct;
 	int argc = ZEND_NUM_ARGS();
@@ -3083,7 +3087,7 @@ PHP_FUNCTION(imap_sort)
 {
 	zval *streamind;
 	char *criteria = NULL, *charset = NULL;
-	int criteria_len, charset_len;
+	size_t criteria_len, charset_len;
 	long pgm, rev, flags = 0;
 	pils *imap_le_struct;
 	unsigned long *slst, *sl;
@@ -3221,7 +3225,7 @@ PHP_FUNCTION(imap_status)
 {
 	zval *streamind;
 	char *mbx;
-	int mbx_len;
+	size_t mbx_len;
 	long flags;
 	pils *imap_le_struct;
 
@@ -3263,7 +3267,7 @@ PHP_FUNCTION(imap_bodystruct)
 	zval *streamind;
 	long msg;
 	char *section;
-	int section_len;
+	size_t section_len;
 	pils *imap_le_struct;
 	zval parametres, param, dparametres, dparam;
 	PARAMETER *par, *dpar;
@@ -3374,7 +3378,7 @@ PHP_FUNCTION(imap_fetch_overview)
 {
 	zval *streamind;
 	char *sequence;
-	int sequence_len;
+	size_t sequence_len;
 	pils *imap_le_struct;
 	zval myoverview;
 	zend_string *address;
@@ -4027,7 +4031,8 @@ int _php_imap_mail(char *to, char *subject, char *message, char *headers, char *
 PHP_FUNCTION(imap_mail)
 {
 	char *to=NULL, *message=NULL, *headers=NULL, *subject=NULL, *cc=NULL, *bcc=NULL, *rpath=NULL;
-	int to_len, message_len, headers_len, subject_len, cc_len, bcc_len, rpath_len, argc = ZEND_NUM_ARGS();
+	size_t to_len, message_len, headers_len, subject_len, cc_len, bcc_len, rpath_len;
+	int argc = ZEND_NUM_ARGS();
 
 	if (zend_parse_parameters(argc TSRMLS_CC, "sss|ssss", &to, &to_len, &subject, &subject_len, &message, &message_len,
 		&headers, &headers_len, &cc, &cc_len, &bcc, &bcc_len, &rpath, &rpath_len) == FAILURE) {
@@ -4067,7 +4072,7 @@ PHP_FUNCTION(imap_search)
 {
 	zval *streamind;
 	char *criteria, *charset = NULL;
-	int criteria_len, charset_len = 0;
+	size_t criteria_len, charset_len = 0;
 	long flags = SE_FREE;
 	pils *imap_le_struct;
 	char *search_criteria;
@@ -4195,7 +4200,7 @@ PHP_FUNCTION(imap_mime_header_decode)
 	/* Author: Ted Parnefors <ted@mtv.se> */
 	zval myobject;
 	char *str, *string, *charset, encoding, *text, *decode;
-	int str_len;
+	size_t str_len;
 	long charset_token, encoding_token, end_token, end, offset=0, i;
 	unsigned long newlength;
 

--- a/ext/interbase/ibase_query.c
+++ b/ext/interbase/ibase_query.c
@@ -1062,7 +1062,8 @@ PHP_FUNCTION(ibase_query)
 {
 	zval *zlink, *ztrans, *bind_args = NULL;
 	char *query;
-	int bind_i, query_len, bind_num;
+	size_t query_len;
+	int bind_i, bind_num;
 	long trans_res_id = 0;
 	ibase_db_link *ib_link = NULL;
 	ibase_trans *trans = NULL;
@@ -1689,7 +1690,7 @@ PHP_FUNCTION(ibase_name_result)
 {
 	zval *result_arg;
 	char *name_arg;
-	int name_arg_len;
+	size_t name_arg_len;
 	ibase_result *ib_result;
 
 	RESET_ERRMSG;
@@ -1735,7 +1736,8 @@ PHP_FUNCTION(ibase_prepare)
 	zval *link_arg, *trans_arg;
 	ibase_db_link *ib_link;
 	ibase_trans *trans = NULL;
-	size_t query_len, trans_res_id = 0;
+	size_t query_len;
+	zend_long trans_res_id = 0;
 	ibase_query *ib_query;
 	char *query;
 

--- a/ext/interbase/ibase_service.c
+++ b/ext/interbase/ibase_service.c
@@ -208,7 +208,8 @@ PHP_FUNCTION(ibase_delete_user)
    Connect to the service manager */
 PHP_FUNCTION(ibase_service_attach)
 {
-	size_t hlen, ulen, plen, spb_len;
+	size_t hlen, ulen, plen;
+	int spb_len;
 	ibase_service *svm;
 	char buf[128], *host, *user, *pass, *loc;
 	isc_svc_handle handle = NULL;
@@ -425,7 +426,8 @@ static void _php_ibase_backup_restore(INTERNAL_FUNCTION_PARAMETERS, char operati
 	 */
 	zval *res;
 	char *db, *bk, buf[200];
-	size_t dblen, bklen, spb_len;
+	size_t dblen, bklen;
+	int spb_len;
 	long opts = 0;
 	zend_bool verbose = 0;
 	ibase_service *svm;
@@ -489,7 +491,8 @@ static void _php_ibase_service_action(INTERNAL_FUNCTION_PARAMETERS, char svc_act
 {
 	zval *res;
 	char buf[128], *db;
-	int dblen, spb_len;
+	size_t dblen;
+	int spb_len;
 	long action, argument = 0;
 	ibase_service *svm;
 

--- a/ext/interbase/interbase.c
+++ b/ext/interbase/interbase.c
@@ -883,7 +883,8 @@ int _php_ibase_attach_db(char **args, int *len, long *largs, isc_db_handle *db T
 static void _php_ibase_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent) /* {{{ */
 {
 	char *c, hash[16], *args[] = { NULL, NULL, NULL, NULL, NULL };
-	int i, len[] = { 0, 0, 0, 0, 0 };
+	size_t len[] = { 0, 0, 0, 0, 0 };
+	int i;
 	long largs[] = { 0, 0, 0 };
 	PHP_MD5_CTX hash_context;
 	zend_resource new_index_ptr, *le;

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -521,7 +521,8 @@ PHP_FUNCTION(ldap_sasl_bind)
 	char *sasl_authz_id = NULL;
 	char *sasl_authc_id = NULL;
 	char *props = NULL;
-	size_t rc, dn_len, passwd_len, mech_len, realm_len, authc_id_len, authz_id_len, props_len;
+	int rc;
+	size_t dn_len, passwd_len, mech_len, realm_len, authc_id_len, authz_id_len, props_len;
 	php_ldap_bictx *ctx;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|sssssss", &link, &binddn, &dn_len, &passwd, &passwd_len, &sasl_mech, &mech_len, &sasl_realm, &realm_len, &sasl_authc_id, &authc_id_len, &sasl_authz_id, &authz_id_len, &props, &props_len) != SUCCESS) {
@@ -2570,8 +2571,9 @@ PHP_FUNCTION(ldap_escape)
 static void php_ldap_do_translate(INTERNAL_FUNCTION_PARAMETERS, int way) 
 {
 	char *value;
-	int result, ldap_len;
-		
+	size_t value_len;
+	int result;
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &value, &value_len) != SUCCESS) {
 		return;
 	}

--- a/ext/mbstring/libmbfl/mbfl/mbfl_string.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_string.h
@@ -42,7 +42,7 @@ typedef struct _mbfl_string {
 	enum mbfl_no_language no_language;
 	enum mbfl_no_encoding no_encoding;
 	unsigned char *val;
-	unsigned int len;
+	size_t len;
 } mbfl_string;
 
 MBFLAPI extern void mbfl_string_init(mbfl_string *string);

--- a/ext/mbstring/libmbfl/mbfl/mbfl_string.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_string.h
@@ -42,7 +42,7 @@ typedef struct _mbfl_string {
 	enum mbfl_no_language no_language;
 	enum mbfl_no_encoding no_encoding;
 	unsigned char *val;
-	size_t len;
+	unsigned int len;
 } mbfl_string;
 
 MBFLAPI extern void mbfl_string_init(mbfl_string *string);

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -1879,7 +1879,7 @@ PHP_FUNCTION(mb_http_input)
 PHP_FUNCTION(mb_http_output)
 {
 	const char *name = NULL;
-	size_t name_len;
+	size_t name_len = 0;
 	const mbfl_encoding *encoding;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &name, &name_len) == FAILURE) {
@@ -2212,14 +2212,15 @@ PHP_FUNCTION(mb_strlen)
 	int n;
 	mbfl_string string;
 	char *enc_name = NULL;
-	size_t enc_name_len;
+	size_t enc_name_len, string_len;
 
 	mbfl_string_init(&string);
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", (char **)&string.val, &string.len, &enc_name, &enc_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", (char **)&string.val, &string_len, &enc_name, &enc_name_len) == FAILURE) {
 		return;
 	}
 
+	string.len = string_len;
 	string.no_language = MBSTRG(language);
 	if (enc_name == NULL) {
 		string.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
@@ -2248,7 +2249,7 @@ PHP_FUNCTION(mb_strpos)
 	zend_long offset;
 	mbfl_string haystack, needle;
 	char *enc_name = NULL;
-	size_t enc_name_len;
+	size_t enc_name_len, haystack_len, needle_len;
 
 	mbfl_string_init(&haystack);
 	mbfl_string_init(&needle);
@@ -2258,9 +2259,12 @@ PHP_FUNCTION(mb_strpos)
 	needle.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 	offset = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", (char **)&haystack.val, &haystack.len, (char **)&needle.val, &needle.len, &offset, &enc_name, &enc_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", (char **)&haystack.val, &haystack_len, (char **)&needle.val, &needle_len, &offset, &enc_name, &enc_name_len) == FAILURE) {
 		return;
 	}
+
+	haystack.len = haystack_len;
+	needle.len = needle_len;
 
 	if (enc_name != NULL) {
 		haystack.no_encoding = needle.no_encoding = mbfl_name2no_encoding(enc_name);
@@ -2311,7 +2315,7 @@ PHP_FUNCTION(mb_strrpos)
 	int n;
 	mbfl_string haystack, needle;
 	char *enc_name = NULL;
-	size_t enc_name_len;
+	size_t enc_name_len, haystack_len, needle_len;
 	zval *zoffset = NULL;
 	long offset = 0, str_flg;
 	char *enc_name2 = NULL;
@@ -2324,9 +2328,12 @@ PHP_FUNCTION(mb_strrpos)
 	needle.no_language = MBSTRG(language);
 	needle.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|zs", (char **)&haystack.val, &haystack.len, (char **)&needle.val, &needle.len, &zoffset, &enc_name, &enc_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|zs", (char **)&haystack.val, &haystack_len, (char **)&needle.val, &needle_len, &zoffset, &enc_name, &enc_name_len) == FAILURE) {
 		return;
 	}
+
+	haystack.len = haystack_len;
+	needle.len = needle_len;
 
 	if (zoffset) {
 		if (Z_TYPE_P(zoffset) == IS_STRING) {
@@ -2410,13 +2417,17 @@ PHP_FUNCTION(mb_stripos)
 	zend_long offset;
 	mbfl_string haystack, needle;
 	const char *from_encoding = MBSTRG(current_internal_encoding)->mime_name;
-	size_t from_encoding_len;
+	size_t from_encoding_len, haystack_len, needle_len;
 	n = -1;
 	offset = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", (char **)&haystack.val, (int *)&haystack.len, (char **)&needle.val, (int *)&needle.len, &offset, &from_encoding, &from_encoding_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", (char **)&haystack.val, &haystack_len, (char **)&needle.val, &needle_len, &offset, &from_encoding, &from_encoding_len) == FAILURE) {
 		return;
 	}
+
+	haystack.len = haystack_len;
+	needle.len = needle_len;
+
 	if (needle.len == 0) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Empty delimiter");
 		RETURN_FALSE;
@@ -2439,13 +2450,16 @@ PHP_FUNCTION(mb_strripos)
 	zend_long offset;
 	mbfl_string haystack, needle;
 	const char *from_encoding = MBSTRG(current_internal_encoding)->mime_name;
-	size_t from_encoding_len;
+	size_t from_encoding_len, haystack_len, needle_len;
 	n = -1;
 	offset = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", (char **)&haystack.val, (int *)&haystack.len, (char **)&needle.val, (int *)&needle.len, &offset, &from_encoding, &from_encoding_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", (char **)&haystack.val, &haystack_len, (char **)&needle.val, &needle_len, &offset, &from_encoding, &from_encoding_len) == FAILURE) {
 		return;
 	}
+
+	haystack.len = haystack_len;
+	needle.len = needle_len;
 
 	n = php_mb_stripos(1, (char *)haystack.val, haystack.len, (char *)needle.val, needle.len, offset, from_encoding TSRMLS_CC);
 
@@ -2464,7 +2478,7 @@ PHP_FUNCTION(mb_strstr)
 	int n, len, mblen;
 	mbfl_string haystack, needle, result, *ret = NULL;
 	char *enc_name = NULL;
-	size_t enc_name_len;
+	size_t enc_name_len, haystack_len, needle_len;
 	zend_bool part = 0;
 
 	mbfl_string_init(&haystack);
@@ -2474,9 +2488,12 @@ PHP_FUNCTION(mb_strstr)
 	needle.no_language = MBSTRG(language);
 	needle.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|bs", (char **)&haystack.val, (int *)&haystack.len, (char **)&needle.val, (int *)&needle.len, &part, &enc_name, &enc_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|bs", (char **)&haystack.val, &haystack_len, (char **)&needle.val, &needle_len, &part, &enc_name, &enc_name_len) == FAILURE) {
 		return;
 	}
+
+	haystack.len = haystack_len;
+	needle.len = needle_len;
 
 	if (enc_name != NULL) {
 		haystack.no_encoding = needle.no_encoding = mbfl_name2no_encoding(enc_name);
@@ -2526,7 +2543,7 @@ PHP_FUNCTION(mb_strrchr)
 	int n, len, mblen;
 	mbfl_string haystack, needle, result, *ret = NULL;
 	char *enc_name = NULL;
-	size_t enc_name_len;
+	size_t enc_name_len, haystack_len, needle_len;
 	zend_bool part = 0;
 
 	mbfl_string_init(&haystack);
@@ -2536,9 +2553,12 @@ PHP_FUNCTION(mb_strrchr)
 	needle.no_language = MBSTRG(language);
 	needle.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|bs", (char **)&haystack.val, &haystack.len, (char **)&needle.val, &needle.len, &part, &enc_name, &enc_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|bs", (char **)&haystack.val, &haystack_len, (char **)&needle.val, &needle_len, &part, &enc_name, &enc_name_len) == FAILURE) {
 		return;
 	}
+
+	haystack.len = haystack_len;
+	needle.len = needle_len;
 
 	if (enc_name != NULL) {
 		haystack.no_encoding = needle.no_encoding = mbfl_name2no_encoding(enc_name);
@@ -2588,8 +2608,8 @@ PHP_FUNCTION(mb_strrchr)
 PHP_FUNCTION(mb_stristr)
 {
 	zend_bool part = 0;
-	size_t from_encoding_len, len, mblen;
-	int n;
+	size_t from_encoding_len, haystack_len, needle_len;
+	int n, mblen, len;
 	mbfl_string haystack, needle, result, *ret = NULL;
 	const char *from_encoding = MBSTRG(current_internal_encoding)->mime_name;
 	mbfl_string_init(&haystack);
@@ -2600,9 +2620,12 @@ PHP_FUNCTION(mb_stristr)
 	needle.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|bs", (char **)&haystack.val, &haystack.len, (char **)&needle.val, &needle.len, &part, &from_encoding, &from_encoding_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|bs", (char **)&haystack.val, &haystack_len, (char **)&needle.val, &needle_len, &part, &from_encoding, &from_encoding_len) == FAILURE) {
 		return;
 	}
+
+	haystack.len = haystack_len;
+	needle.len = needle_len;
 
 	if (!needle.len) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Empty delimiter");
@@ -2652,7 +2675,7 @@ PHP_FUNCTION(mb_strrichr)
 {
 	zend_bool part = 0;
 	int n, len, mblen;
-	size_t from_encoding_len;
+	size_t from_encoding_len, haystack_len, needle_len;
 	mbfl_string haystack, needle, result, *ret = NULL;
 	const char *from_encoding = MBSTRG(current_internal_encoding)->name;
 	mbfl_string_init(&haystack);
@@ -2663,9 +2686,12 @@ PHP_FUNCTION(mb_strrichr)
 	needle.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|bs", (char **)&haystack.val, &haystack.len, (char **)&needle.val, &needle.len, &part, &from_encoding, &from_encoding_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|bs", (char **)&haystack.val, &haystack_len, (char **)&needle.val, &needle_len, &part, &from_encoding, &from_encoding_len) == FAILURE) {
 		return;
 	}
+
+	haystack.len = haystack_len;
+	needle.len = needle_len;
 
 	haystack.no_encoding = needle.no_encoding = mbfl_name2no_encoding(from_encoding);
 	if (haystack.no_encoding == mbfl_no_encoding_invalid) {
@@ -2711,7 +2737,7 @@ PHP_FUNCTION(mb_substr_count)
 	int n;
 	mbfl_string haystack, needle;
 	char *enc_name = NULL;
-	size_t enc_name_len;
+	size_t enc_name_len, haystack_len, needle_len;
 
 	mbfl_string_init(&haystack);
 	mbfl_string_init(&needle);
@@ -2720,9 +2746,12 @@ PHP_FUNCTION(mb_substr_count)
 	needle.no_language = MBSTRG(language);
 	needle.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|s", (char **)&haystack.val, &haystack.len, (char **)&needle.val, &needle.len, &enc_name, &enc_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|s", (char **)&haystack.val, &haystack_len, (char **)&needle.val, &needle_len, &enc_name, &enc_name_len) == FAILURE) {
 		return;
 	}
+
+	haystack.len = haystack_len;
+	needle.len = needle_len;
 
 	if (enc_name != NULL) {
 		haystack.no_encoding = needle.no_encoding = mbfl_name2no_encoding(enc_name);
@@ -2833,7 +2862,7 @@ PHP_FUNCTION(mb_strcut)
 	size_t argc = ZEND_NUM_ARGS();
 	char *encoding;
 	zend_long from, len;
-	size_t encoding_len;
+	size_t encoding_len, string_len;
 	zval *z_len = NULL;
 	mbfl_string string, result, *ret;
 
@@ -2841,9 +2870,11 @@ PHP_FUNCTION(mb_strcut)
 	string.no_language = MBSTRG(language);
 	string.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl|zs", (char **)&string.val, (int **)&string.len, &from, &z_len, &encoding, &encoding_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl|zs", (char **)&string.val, &string_len, &from, &z_len, &encoding, &encoding_len) == FAILURE) {
 		return;
 	}
+
+	string.len = string_len;
 
 	if (argc == 4) {
 		string.no_encoding = mbfl_name2no_encoding(encoding);
@@ -2902,16 +2933,18 @@ PHP_FUNCTION(mb_strwidth)
 	int n;
 	mbfl_string string;
 	char *enc_name = NULL;
-	size_t enc_name_len;
+	size_t enc_name_len, string_len;
 
 	mbfl_string_init(&string);
 
 	string.no_language = MBSTRG(language);
 	string.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", (char **)&string.val, &string.len, &enc_name, &enc_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", (char **)&string.val, &string_len, &enc_name, &enc_name_len) == FAILURE) {
 		return;
 	}
+
+	string.len = string_len;
 
 	if (enc_name != NULL) {
 		string.no_encoding = mbfl_name2no_encoding(enc_name);
@@ -3352,6 +3385,7 @@ PHP_FUNCTION(mb_encode_mimeheader)
 {
 	enum mbfl_no_encoding charset, transenc;
 	mbfl_string  string, result, *ret;
+	size_t string_len;
 	char *charset_name = NULL;
 	size_t charset_name_len;
 	char *trans_enc_name = NULL;
@@ -3364,9 +3398,11 @@ PHP_FUNCTION(mb_encode_mimeheader)
 	string.no_language = MBSTRG(language);
 	string.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|sssl", (char **)&string.val, &string.len, &charset_name, &charset_name_len, &trans_enc_name, &trans_enc_name_len, &linefeed, &linefeed_len, &indent) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|sssl", (char **)&string.val, &string_len, &charset_name, &charset_name_len, &trans_enc_name, &trans_enc_name_len, &linefeed, &linefeed_len, &indent) == FAILURE) {
 		return;
 	}
+
+	string.len = string_len;
 
 	charset = mbfl_no_encoding_pass;
 	transenc = mbfl_no_encoding_base64;
@@ -3410,14 +3446,17 @@ PHP_FUNCTION(mb_encode_mimeheader)
 PHP_FUNCTION(mb_decode_mimeheader)
 {
 	mbfl_string string, result, *ret;
+	size_t string_len;
 
 	mbfl_string_init(&string);
 	string.no_language = MBSTRG(language);
 	string.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", (char **)&string.val, &string.len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", (char **)&string.val, &string_len) == FAILURE) {
 		return;
 	}
+
+	string.len = string_len;
 
 	mbfl_string_init(&result);
 	ret = mbfl_mime_header_decode(&string, &result, MBSTRG(current_internal_encoding)->no_encoding);
@@ -3437,6 +3476,7 @@ PHP_FUNCTION(mb_convert_kana)
 {
 	int opt, i;
 	mbfl_string string, result, *ret;
+	size_t string_len;
 	char *optstr = NULL;
 	size_t optstr_len;
 	char *encname = NULL;
@@ -3446,9 +3486,11 @@ PHP_FUNCTION(mb_convert_kana)
 	string.no_language = MBSTRG(language);
 	string.no_encoding = MBSTRG(current_internal_encoding)->no_encoding;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ss", (char **)&string.val, &string.len, &optstr, &optstr_len, &encname, &encname_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ss", (char **)&string.val, &string_len, &optstr, &optstr_len, &encname, &encname_len) == FAILURE) {
 		return;
 	}
+
+	string.len = string_len;
 
 	/* option */
 	if (optstr != NULL) {

--- a/ext/mssql/php_mssql.c
+++ b/ext/mssql/php_mssql.c
@@ -544,7 +544,7 @@ PHP_MINFO_FUNCTION(mssql)
 static void php_mssql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 {
 	char *host = NULL, *user = NULL, *passwd = NULL;
-	int host_len = 0, user_len = 0, passwd_len = 0;
+	size_t host_len = 0, user_len = 0, passwd_len = 0;
 	zend_bool new_link = 0;
 	char *hashed_details;
 	int hashed_details_length;
@@ -904,7 +904,7 @@ PHP_FUNCTION(mssql_select_db)
 {
 	char *db;
 	zval *mssql_link_index = NULL;
-	int db_len;
+	size_t db_len;
 	int id = -1;
 	mssql_link  *mssql_ptr;
 
@@ -1325,7 +1325,8 @@ PHP_FUNCTION(mssql_query)
 {
 	char *query;
 	zval *mssql_link_index = NULL;
-	int query_len, retvalue, batchsize, num_fields;
+	size_t query_len;
+	int retvalue, batchsize, num_fields;
 	long zbatchsize = 0;
 	mssql_link *mssql_ptr;
 	mssql_result *result;
@@ -1973,7 +1974,7 @@ PHP_FUNCTION(mssql_min_message_severity)
 PHP_FUNCTION(mssql_init)
 {
 	char *sp_name;
-	int sp_name_len;
+	size_t sp_name_len;
 	zval *mssql_link_index = NULL;
 	mssql_link *mssql_ptr;
 	mssql_statement *statement;
@@ -2011,8 +2012,8 @@ PHP_FUNCTION(mssql_init)
 PHP_FUNCTION(mssql_bind)
 {
 	char *param_name;
-	int param_name_len, datalen;
-	int status = 0;
+	size_t param_name_len;
+	int datalen, status = 0;
 	long type = 0, maxlen = -1;
 	zval *stmt, **var;
 	zend_bool is_output = 0, is_null = 0;
@@ -2233,7 +2234,7 @@ PHP_FUNCTION(mssql_free_statement)
 PHP_FUNCTION(mssql_guid_string)
 {
 	char *binary;
-	int binary_len;
+	size_t binary_len;
 	zend_bool sf = 0;
 	char buffer[32+1];
 	char buffer2[36+1];

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -100,11 +100,7 @@ PHP_FUNCTION(oci_bind_by_name)
 {
 	ub2	bind_type = SQLT_CHR; /* unterminated string */
 	size_t name_len;
-<<<<<<< HEAD
 	zend_long maxlen = -1, type = 0;
-=======
-	long maxlen = -1, type = 0;
->>>>>>> mbstring, mssql and oci8
 	char *name;
 	zval *z_statement;
 	zval *bind_var = NULL;
@@ -132,15 +128,9 @@ PHP_FUNCTION(oci_bind_by_name)
 PHP_FUNCTION(oci_bind_array_by_name)
 {
 	size_t name_len;
-<<<<<<< HEAD
 	zend_long max_item_len = -1;
 	zend_long max_array_len = 0;
 	zend_long type = SQLT_AFC;
-=======
-	long max_item_len = -1;
-	long max_array_len = 0;
-	long type = SQLT_AFC;
->>>>>>> mbstring, mssql and oci8
 	char *name;
 	zval *z_statement;
 	zval *bind_var = NULL;
@@ -201,11 +191,7 @@ PHP_FUNCTION(oci_lob_save)
 	php_oci_descriptor *descriptor;
 	char *data;
 	size_t data_len;
-<<<<<<< HEAD
 	zend_long offset = 0;
-=======
-	long offset = 0;
->>>>>>> mbstring, mssql and oci8
 	ub4 bytes_written;
 
 	if (getThis()) {
@@ -534,11 +520,7 @@ PHP_FUNCTION(oci_lob_write)
 	zval *tmp, *z_descriptor = getThis();
 	php_oci_descriptor *descriptor;
 	size_t data_len;
-<<<<<<< HEAD
 	zend_long write_len = 0;
-=======
-	long write_len = 0;
->>>>>>> mbstring, mssql and oci8
 	ub4 bytes_written;
 	char *data;
 	
@@ -897,11 +879,7 @@ PHP_FUNCTION(oci_lob_export)
 	char *filename;
 	char *buffer;
 	size_t filename_len;
-<<<<<<< HEAD
 	zend_long start = -1, length = -1, block_length;
-=======
-	long start = -1, length = -1, block_length;
->>>>>>> mbstring, mssql and oci8
 	php_stream *stream;
 	ub4 lob_length;
 
@@ -1033,11 +1011,7 @@ PHP_FUNCTION(oci_lob_write_temporary)
 	php_oci_descriptor *descriptor;
 	char *data;
 	size_t data_len;
-<<<<<<< HEAD
 	zend_long type = OCI_TEMP_CLOB;
-=======
-	long type = OCI_TEMP_CLOB;
->>>>>>> mbstring, mssql and oci8
 
 	if (getThis()) {
 		if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|l", &data, &data_len, &type) == FAILURE) {
@@ -2322,11 +2296,7 @@ PHP_FUNCTION(oci_collection_element_assign)
 	zval *tmp, *z_collection = getThis();
 	php_oci_collection *collection;
 	size_t value_len;
-<<<<<<< HEAD
 	zend_long element_index;
-=======
-	long element_index;
->>>>>>> mbstring, mssql and oci8
 	char *value;
 
 	if (getThis()) {

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -100,7 +100,11 @@ PHP_FUNCTION(oci_bind_by_name)
 {
 	ub2	bind_type = SQLT_CHR; /* unterminated string */
 	size_t name_len;
+<<<<<<< HEAD
 	zend_long maxlen = -1, type = 0;
+=======
+	long maxlen = -1, type = 0;
+>>>>>>> mbstring, mssql and oci8
 	char *name;
 	zval *z_statement;
 	zval *bind_var = NULL;
@@ -128,9 +132,15 @@ PHP_FUNCTION(oci_bind_by_name)
 PHP_FUNCTION(oci_bind_array_by_name)
 {
 	size_t name_len;
+<<<<<<< HEAD
 	zend_long max_item_len = -1;
 	zend_long max_array_len = 0;
 	zend_long type = SQLT_AFC;
+=======
+	long max_item_len = -1;
+	long max_array_len = 0;
+	long type = SQLT_AFC;
+>>>>>>> mbstring, mssql and oci8
 	char *name;
 	zval *z_statement;
 	zval *bind_var = NULL;
@@ -191,7 +201,11 @@ PHP_FUNCTION(oci_lob_save)
 	php_oci_descriptor *descriptor;
 	char *data;
 	size_t data_len;
+<<<<<<< HEAD
 	zend_long offset = 0;
+=======
+	long offset = 0;
+>>>>>>> mbstring, mssql and oci8
 	ub4 bytes_written;
 
 	if (getThis()) {
@@ -520,7 +534,11 @@ PHP_FUNCTION(oci_lob_write)
 	zval *tmp, *z_descriptor = getThis();
 	php_oci_descriptor *descriptor;
 	size_t data_len;
+<<<<<<< HEAD
 	zend_long write_len = 0;
+=======
+	long write_len = 0;
+>>>>>>> mbstring, mssql and oci8
 	ub4 bytes_written;
 	char *data;
 	
@@ -879,7 +897,11 @@ PHP_FUNCTION(oci_lob_export)
 	char *filename;
 	char *buffer;
 	size_t filename_len;
+<<<<<<< HEAD
 	zend_long start = -1, length = -1, block_length;
+=======
+	long start = -1, length = -1, block_length;
+>>>>>>> mbstring, mssql and oci8
 	php_stream *stream;
 	ub4 lob_length;
 
@@ -1011,7 +1033,11 @@ PHP_FUNCTION(oci_lob_write_temporary)
 	php_oci_descriptor *descriptor;
 	char *data;
 	size_t data_len;
+<<<<<<< HEAD
 	zend_long type = OCI_TEMP_CLOB;
+=======
+	long type = OCI_TEMP_CLOB;
+>>>>>>> mbstring, mssql and oci8
 
 	if (getThis()) {
 		if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|l", &data, &data_len, &type) == FAILURE) {
@@ -2296,7 +2322,11 @@ PHP_FUNCTION(oci_collection_element_assign)
 	zval *tmp, *z_collection = getThis();
 	php_oci_collection *collection;
 	size_t value_len;
+<<<<<<< HEAD
 	zend_long element_index;
+=======
+	long element_index;
+>>>>>>> mbstring, mssql and oci8
 	char *value;
 
 	if (getThis()) {

--- a/ext/odbc/birdstep.c
+++ b/ext/odbc/birdstep.c
@@ -347,7 +347,8 @@ PHP_FUNCTION(birdstep_exec)
 {
 	char *query;
 	zend_long ind;
-	size_t query_len, indx;
+	size_t query_len;
+	int indx;
 	VConn *conn;
 	Vresult *res;
 	RETCODE stat;

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1575,7 +1575,8 @@ PHP_FUNCTION(odbc_exec)
 	zval *pv_conn;
 	zend_long pv_flags;
 	char *query;
-	int numArgs, query_len;
+	size_t query_len;
+	int numArgs;
 	odbc_result *result = NULL;
 	odbc_connection *conn;
 	RETCODE rc;
@@ -2868,7 +2869,8 @@ PHP_FUNCTION(odbc_field_scale)
 PHP_FUNCTION(odbc_field_num)
 {
 	char *fname;
-	size_t i, field_ind, fname_len;
+	size_t fname_len;
+	int field_ind, i;
 	odbc_result *result;
 	zval *pv_res;
 
@@ -3136,7 +3138,7 @@ PHP_FUNCTION(odbc_columns)
 	odbc_result *result = NULL;
 	odbc_connection *conn;
 	char *cat = NULL, *schema = NULL, *table = NULL, *column = NULL;
-	int cat_len = 0, schema_len = 0, table_len = 0, column_len = 0;
+	size_t cat_len = 0, schema_len = 0, table_len = 0, column_len = 0;
 	RETCODE rc;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|s!sss", &pv_conn, &cat, &cat_len, &schema, &schema_len,
@@ -3206,7 +3208,7 @@ PHP_FUNCTION(odbc_columnprivileges)
 	odbc_result *result = NULL;
 	odbc_connection *conn;
 	char *cat = NULL, *schema, *table, *column;
-	int cat_len = 0, schema_len, table_len, column_len;
+	size_t cat_len = 0, schema_len, table_len, column_len;
 	RETCODE rc;
 	
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs!sss", &pv_conn, &cat, &cat_len, &schema, &schema_len,
@@ -3406,7 +3408,7 @@ PHP_FUNCTION(odbc_primarykeys)
 	odbc_result   *result = NULL;
 	odbc_connection *conn;
 	char *cat = NULL, *schema = NULL, *table = NULL;
-	int cat_len = 0, schema_len, table_len;
+	size_t cat_len = 0, schema_len, table_len;
 	RETCODE rc;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs!ss", &pv_conn, &cat, &cat_len, &schema, &schema_len, &table, &table_len) == FAILURE) {
@@ -3535,7 +3537,7 @@ PHP_FUNCTION(odbc_procedures)
 	odbc_result   *result = NULL;
 	odbc_connection *conn;
 	char *cat = NULL, *schema = NULL, *proc = NULL;
-	int cat_len = 0, schema_len = 0, proc_len = 0;
+	size_t cat_len = 0, schema_len = 0, proc_len = 0;
 	RETCODE rc;
 
 	if (ZEND_NUM_ARGS() != 1 && ZEND_NUM_ARGS() != 4) {
@@ -3671,7 +3673,7 @@ PHP_FUNCTION(odbc_statistics)
 	odbc_result *result = NULL;
 	odbc_connection *conn;
 	char *cat = NULL, *schema, *name;
-	int cat_len = 0, schema_len, name_len;
+	size_t cat_len = 0, schema_len, name_len;
 	SQLUSMALLINT unique, reserved;
 	RETCODE rc;
 
@@ -3739,7 +3741,7 @@ PHP_FUNCTION(odbc_tableprivileges)
 	odbc_result   *result = NULL;
 	odbc_connection *conn;
 	char *cat = NULL, *schema = NULL, *table = NULL;
-	int cat_len = 0, schema_len, table_len;
+	size_t cat_len = 0, schema_len, table_len;
 	RETCODE rc;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs!ss", &pv_conn, &cat, &cat_len, &schema, &schema_len, &table, &table_len) == FAILURE) {

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3652,7 +3652,8 @@ PHP_FUNCTION(openssl_pkey_export)
 {
 	struct php_x509_request req;
 	zval * zpkey, * args = NULL, *out;
-	char * passphrase = NULL; size_t passphrase_len = 0;
+	char * passphrase = NULL;
+	size_t passphrase_len = 0;
 	zend_resource *key_resource = NULL;
 	EVP_PKEY * key;
 	BIO * bio_out = NULL;
@@ -3750,7 +3751,7 @@ PHP_FUNCTION(openssl_pkey_get_private)
 	zval *cert;
 	EVP_PKEY *pkey;
 	char * passphrase = "";
-	size_t passphrase_len = sizeof("")-1;
+	size_t passphrase_len = 0;
 	zend_resource *res;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z|s", &cert, &passphrase, &passphrase_len) == FAILURE) {

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -522,7 +522,7 @@ static PHP_METHOD(PDO, pgsqlCopyFromArray)
 	zval *pg_rows;
 
 	char *table_name, *pg_delim = NULL, *pg_null_as = NULL, *pg_fields = NULL;
-	size_t table_name_len, pg_delim_len = 0, pg_null_as_len = 0, pg_fields_len;
+	size_t table_name_len, pg_delim_len = 0, pg_null_as_len = 0, pg_fields_len = 0;
 	char *query;
 
 	PGresult *pgsql_result;
@@ -631,7 +631,7 @@ static PHP_METHOD(PDO, pgsqlCopyFromFile)
 	pdo_pgsql_db_handle *H;
 
 	char *table_name, *filename, *pg_delim = NULL, *pg_null_as = NULL, *pg_fields = NULL;
-	size_t  table_name_len, filename_len, pg_delim_len = 0, pg_null_as_len = 0, pg_fields_len;
+	size_t  table_name_len, filename_len, pg_delim_len = 0, pg_null_as_len = 0, pg_fields_len = 0;
 	char *query;
 	PGresult *pgsql_result;
 	ExecStatusType status;
@@ -730,7 +730,7 @@ static PHP_METHOD(PDO, pgsqlCopyToFile)
 	pdo_pgsql_db_handle *H;
 
 	char *table_name, *pg_delim = NULL, *pg_null_as = NULL, *pg_fields = NULL, *filename = NULL;
-	size_t table_name_len, pg_delim_len = 0, pg_null_as_len = 0, pg_fields_len, filename_len;
+	size_t table_name_len, pg_delim_len = 0, pg_null_as_len = 0, pg_fields_len = 0, filename_len;
 	char *query;
 
 	PGresult *pgsql_result;

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -3480,10 +3480,10 @@ PHP_FUNCTION(pg_lo_write)
   	zval *pgsql_id;
   	char *str;
   	zend_long z_len;
-	size_t str_len, nbytes;
+	size_t str_len;
 	size_t len;
 	pgLofp *pgsql;
-	int argc = ZEND_NUM_ARGS();
+	int argc = ZEND_NUM_ARGS(), nbytes;
 
 	if (zend_parse_parameters(argc TSRMLS_CC, "rs|l", &pgsql_id, &str, &str_len, &z_len) == FAILURE) {
 		return;
@@ -4001,9 +4001,9 @@ PHP_FUNCTION(pg_copy_to)
 {
 	zval *pgsql_link;
 	char *table_name, *pg_delim = NULL, *pg_null_as = NULL;
-	size_t table_name_len, pg_delim_len, pg_null_as_len, free_pg_null = 0;
+	size_t table_name_len, pg_delim_len, pg_null_as_len;
 	char *query;
-	int id = -1;
+	int free_pg_null = 0, id = -1;
 	PGconn *pgsql;
 	PGresult *pgsql_result;
 	ExecStatusType status;
@@ -4328,7 +4328,7 @@ PHP_FUNCTION(pg_escape_bytea)
 #ifdef HAVE_PQESCAPE_BYTEA_CONN
 	if (pgsql_link != NULL || id != -1) {
 		ZEND_FETCH_RESOURCE2(pgsql, PGconn *, pgsql_link, id, "PostgreSQL link", le_link, le_plink);
-		to = (char *)PQescapeByteaConn(pgsql, (unsigned char *)from, (size_t)from_len, &to_len);
+		to = (char *)PQescapeByteaConn(pgsql, (unsigned char *)from, from_len, &to_len);
 	} else
 #endif
 		to = (char *)PQescapeBytea((unsigned char*)from, from_len, &to_len);
@@ -4510,9 +4510,9 @@ static void php_pgsql_escape_internal(INTERNAL_FUNCTION_PARAMETERS, int escape_l
 	}
 
 	if (escape_literal) {
-		tmp = PGSQLescapeLiteral(pgsql, from, (size_t)from_len);
+		tmp = PGSQLescapeLiteral(pgsql, from, from_len);
 	} else {
-		tmp = PGSQLescapeIdentifier(pgsql, from, (size_t)from_len);
+		tmp = PGSQLescapeIdentifier(pgsql, from, from_len);
 	}
 	if (!tmp) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING,"Failed to escape");

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -948,7 +948,8 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
 PHP_FUNCTION(posix_access)
 {
 	zend_long mode = 0;
-	size_t filename_len, ret;
+	size_t filename_len;
+	int ret;
 	char *filename, *path;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "p|l", &filename, &filename_len, &mode) == FAILURE) {

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -675,7 +675,8 @@ void spl_filesystem_object_construct(INTERNAL_FUNCTION_PARAMETERS, zend_long cto
 {
 	spl_filesystem_object *intern;
 	char *path;
-	size_t parsed, len;
+	size_t len;
+	int parsed;
 	zend_long flags;
 	zend_error_handling error_handling;
 

--- a/ext/spl/spl_directory.h
+++ b/ext/spl/spl_directory.h
@@ -66,7 +66,7 @@ struct _spl_filesystem_object {
 	int                _path_len;
 	char               *orig_path;
 	char               *file_name;
-	int                file_name_len;
+	size_t             file_name_len;
 	SPL_FS_OBJ_TYPE    type;
 	zend_long               flags;
 	zend_class_entry   *file_class;
@@ -88,7 +88,7 @@ struct _spl_filesystem_object {
 			php_stream_context *context;
 			zval               *zcontext;
 			char               *open_mode;
-			int                open_mode_len;
+			size_t             open_mode_len;
 			zval               current_zval;
 			char               *current_line;
 			size_t             current_line_len;

--- a/ext/sybase_ct/php_sybase_ct.c
+++ b/ext/sybase_ct/php_sybase_ct.c
@@ -730,7 +730,7 @@ static void php_sybase_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 {
 	char *user = NULL, *passwd = NULL, *host = NULL, *charset = NULL, *appname = NULL;
 	char *hashed_details;
-	int hashed_details_length, len;
+	size_t hashed_details_length, len;
 	zend_bool new = 0;
 	sybase_link *sybase_ptr;
 
@@ -1061,7 +1061,8 @@ PHP_FUNCTION(sybase_select_db)
 {
 	zval *sybase_link_index = NULL;
 	char *db, *cmdbuf;
-	int id, len;
+	size_t len;
+	int id;
 	sybase_link *sybase_ptr;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|r", &db, &len, &sybase_link_index) == FAILURE) {
@@ -1426,7 +1427,8 @@ static void php_sybase_query (INTERNAL_FUNCTION_PARAMETERS, int buffered)
 	zval *sybase_link_index = NULL;
 	zend_bool store = 1;
 	char *query;
-	size_t len, id, deadlock_count;
+	size_t len, deadlock_count;
+	int id;
 	sybase_link *sybase_ptr;
 	sybase_result *result;
 	CS_INT restype;

--- a/ext/sybase_ct/php_sybase_ct.c
+++ b/ext/sybase_ct/php_sybase_ct.c
@@ -1427,8 +1427,8 @@ static void php_sybase_query (INTERNAL_FUNCTION_PARAMETERS, int buffered)
 	zval *sybase_link_index = NULL;
 	zend_bool store = 1;
 	char *query;
-	size_t len, deadlock_count;
-	int id;
+	size_t len;
+	int id, deadlock_count;
 	sybase_link *sybase_ptr;
 	sybase_result *result;
 	CS_INT restype;

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -855,7 +855,7 @@ PHP_METHOD(xmlreader, open)
 	xmlreader_object *intern = NULL;
 	char *source, *valid_file = NULL;
 	char *encoding = NULL;
-	char resolved_path[MAXPATHLEN + 1];
+	char resolved_path[MAXPATHLEN];
 	xmlTextReaderPtr reader = NULL;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "p|s!l", &source, &source_len, &encoding, &encoding_len, &options) == FAILURE) {

--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -695,7 +695,8 @@ static void php_xmlwriter_string_arg(INTERNAL_FUNCTION_PARAMETERS, xmlwriter_rea
 	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name;
-	size_t name_len, retval;
+	size_t name_len;
+	int retval;
 
 	zval *self = getThis();
 	
@@ -1548,7 +1549,8 @@ static PHP_FUNCTION(xmlwriter_start_dtd_entity)
 	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name;
-	size_t name_len, retval;
+	size_t name_len;
+	int retval;
 	zend_bool isparm;
 	zval *self = getThis();
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1097,7 +1097,7 @@ ZEND_GET_MODULE(zip)
 Create new zip using source uri for output */
 static PHP_NAMED_FUNCTION(zif_zip_open)
 {
-	char resolved_path[MAXPATHLEN + 1];
+	char resolved_path[MAXPATHLEN];
 	zip_rsrc *rsrc_int;
 	int err = 0;
 	zend_string *filename;


### PR DESCRIPTION
I stepped through all usages of `zend_parse_parameters()` in all core extensions except for `ext/standard` to make sure the correct type is used for the string length.

At the same time I've looked at overzealous replacements of `int` with `size_t`; some values work with negative numbers and as such should remain as `int`.

Finally, some minor inconsistencies were addressed.

This is a PR for two reasons:
1. Gather more feedback before submission
2. Let it run through Travis CI
