### PR TITLE
Correct two zlib tests to use a string, not a const

### DIFF
--- a/ext/zlib/tests/gzfile_variation4.phpt
+++ b/ext/zlib/tests/gzfile_variation4.phpt
@@ -2,7 +2,7 @@
 Test function gzfile() by substituting argument 1 with float values.
 --SKIPIF--
 <?php
-if (!extension_loaded(zlib)) die ('skip zlib extension not available in this build');
+if (!extension_loaded('zlib')) die ('skip zlib extension not available in this build');
 ?>
 --FILE--
 <?php

--- a/ext/zlib/tests/readgzfile_variation4.phpt
+++ b/ext/zlib/tests/readgzfile_variation4.phpt
@@ -2,7 +2,7 @@
 Test function readgzfile() by substituting argument 1 with float values.
 --SKIPIF--
 <?php
-if (!extension_loaded(zlib)) die ('skip zlib extension not available in this build');
+if (!extension_loaded('zlib')) die ('skip zlib extension not available in this build');
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
I don't want const to string conversions.
