### PR TITLE
Return types

### DIFF
--- a/Zend/tests/return_types/001.phpt
+++ b/Zend/tests/return_types/001.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Returned nothing, expected array
+
+--FILE--
+<?php
+function test1() : array {
+}
+
+test1();
+
+--EXPECTF--
+Catchable fatal error: The function test1 was expected to return an array and returned nothing in %s on line %d

--- a/Zend/tests/return_types/002.phpt
+++ b/Zend/tests/return_types/002.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Returned null, expected array
+
+--FILE--
+<?php
+function test1() : array {
+    return null;
+}
+
+test1();
+
+--EXPECTF--
+Catchable fatal error: The function test1 was expected to return an array and returned null in %s on line %d

--- a/Zend/tests/return_types/003.phpt
+++ b/Zend/tests/return_types/003.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Returned 1, expected array
+
+--FILE--
+<?php
+function test1() : array {
+    return 1;
+}
+test1();
+
+--EXPECTF--
+Catchable fatal error: The function test1 was expected to return an array and returned an integer in %s on line %d

--- a/Zend/tests/return_types/004.phpt
+++ b/Zend/tests/return_types/004.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Returned string, expected array
+
+--FILE--
+<?php
+function test1() : array {
+    return "hello";
+}
+
+test1();
+
+--EXPECTF--
+Catchable fatal error: The function test1 was expected to return an array and returned a string in %s on line %d

--- a/Zend/tests/return_types/005.phpt
+++ b/Zend/tests/return_types/005.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Return value fails inheritance check in method
+
+--FILE--
+<?php
+class foo {}
+
+class qux {
+    public function foo() : foo {
+        return $this;
+    }
+}
+
+$qux = new qux();
+$qux->foo();
+
+--EXPECTF--
+Catchable fatal error: The function qux::foo was expected to return an object of class foo and returned an object of class qux in %s on line %d

--- a/Zend/tests/return_types/006.phpt
+++ b/Zend/tests/return_types/006.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Return type allowed in child when parent does not have return type
+
+--FILE--
+<?php
+class Comment {}
+
+class CommentsIterator extends ArrayIterator implements Iterator {
+    function current() : Comment {
+        return parent::current();
+    }
+}
+
+$comments = new CommentsIterator([new Comment]);
+foreach ($comments as $comment) {
+    var_dump($comment);
+}
+
+--EXPECTF--
+object(Comment)#%d (%d) {
+}

--- a/Zend/tests/return_types/007.phpt
+++ b/Zend/tests/return_types/007.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Return value is subclass of return type
+
+--FILE--
+<?php
+class foo {}
+
+class qux extends foo {
+    public function foo() : foo {
+        return $this;
+    }
+}
+
+$qux = new qux();
+var_dump($qux->foo());
+
+--EXPECTF--
+object(qux)#%d (%d) {
+}

--- a/Zend/tests/return_types/008.phpt
+++ b/Zend/tests/return_types/008.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Return type covariance in interface implementation
+
+--FILE--
+<?php
+interface foo {
+    public function bar() : foo;
+}
+
+
+class qux implements foo {
+    public function bar() : qux {
+        return $this;
+    }
+}
+
+$qux = new qux();
+var_dump($qux->bar());
+
+--EXPECTF--
+object(qux)#%d (%d) {
+}

--- a/Zend/tests/return_types/009.phpt
+++ b/Zend/tests/return_types/009.phpt
@@ -16,4 +16,4 @@ class qux implements foo {
 }
 
 --EXPECTF--
-Fatal error: Declaration of qux::bar should be compatible with foo::bar(): foo, return type mismatch in %s on line %d
+Fatal error: Declaration of qux::bar() must be compatible with foo::bar(): foo in %s on line %d

--- a/Zend/tests/return_types/009.phpt
+++ b/Zend/tests/return_types/009.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Return type covariance error
+
+--FILE--
+<?php
+interface foo {
+    public function bar() : foo;
+}
+
+interface biz {}
+
+class qux implements foo {
+    public function bar() : biz {
+        return $this;
+    }
+}
+
+--EXPECTF--
+Fatal error: Declaration of qux::bar should be compatible with foo::bar(): foo, return type mismatch in %s on line %d

--- a/Zend/tests/return_types/010.phpt
+++ b/Zend/tests/return_types/010.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Returned null, expected array reference
+
+--FILE--
+<?php
+function &foo(array &$in) : array {
+    return null;
+}
+
+$array = [1, 2, 3];
+var_dump(foo($array));
+
+--EXPECTF--
+Catchable fatal error: The function foo was expected to return an array and returned null in %s on line %d

--- a/Zend/tests/return_types/011.phpt
+++ b/Zend/tests/return_types/011.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Function returned callable, expected callable
+
+--FILE--
+<?php
+function foo() : callable {
+    return function() {};
+}
+
+var_dump(foo());
+
+--EXPECTF--
+object(Closure)#%d (%d) {
+}

--- a/Zend/tests/return_types/012.phpt
+++ b/Zend/tests/return_types/012.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Method returned callable, expected callable
+
+--FILE--
+<?php
+class foo {
+    public function bar() : callable {
+        $test = "one";
+        return function() use($test) : array {
+            return array($test);
+        };
+    }
+}
+
+$baz = new foo();
+var_dump($baz->bar());
+
+--EXPECT--
+object(Closure)#2 (2) {
+  ["static"]=>
+  array(1) {
+    ["test"]=>
+    string(3) "one"
+  }
+  ["this"]=>
+  object(foo)#1 (0) {
+  }
+}

--- a/Zend/tests/return_types/013.phpt
+++ b/Zend/tests/return_types/013.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Closure inside method returned null, expected array
+
+--FILE--
+<?php
+class foo {
+    public function bar() : callable {
+        $test = "one";
+        return function() use($test) : array {
+            return null;
+        };
+    }
+}
+
+$baz = new foo();
+var_dump($func=$baz->bar(), $func());
+
+--EXPECTF--
+Catchable fatal error: The function %s was expected to return an array and returned null in %s on line %d

--- a/Zend/tests/return_types/014.phpt
+++ b/Zend/tests/return_types/014.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Constructors cannot declare a return type
+
+--FILE--
+<?php
+
+class Foo {
+	function __construct() : Foo {}
+}
+
+--EXPECTF--
+Fatal error: Constructor %s::%s() cannot declare a return type in %s on line %s

--- a/Zend/tests/return_types/015.phpt
+++ b/Zend/tests/return_types/015.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Return types allowed in namespace
+
+--FILE--
+<?php
+
+namespace Collections;
+
+interface Collection {
+    function values(): Collection;
+}
+
+class Vector implements Collection {
+    function values(): Collection {
+        return $this;
+    }
+}
+
+$v = new Vector;
+var_dump($v->values());
+
+--EXPECTF--
+object(Collections\Vector)#%d (%d) {
+}

--- a/Zend/tests/return_types/016.phpt
+++ b/Zend/tests/return_types/016.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Fully qualified classes are allowed in return types
+
+--FILE--
+<?php
+
+namespace Collections;
+
+class Foo {
+    function foo(\Iterator $i): \Iterator {
+        return $i;
+    }
+}
+
+$foo = new Foo;
+var_dump($foo->foo(new \EmptyIterator()));
+
+--EXPECTF--
+object(EmptyIterator)#%d (0) {
+}

--- a/Zend/tests/return_types/017.phpt
+++ b/Zend/tests/return_types/017.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Fully qualified classes in trait return types
+
+--FILE--
+<?php
+
+namespace FooSpace;
+
+trait Fooable {
+    function foo(): \Iterator {
+        return new \EmptyIterator();
+    }
+}
+
+class Foo {
+    use Fooable;
+}
+
+$foo = new Foo;
+var_dump($foo->foo([]));
+
+--EXPECTF--
+object(EmptyIterator)#%d (%d) {
+}

--- a/Zend/tests/return_types/018.phpt
+++ b/Zend/tests/return_types/018.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Destructors cannot declare a return type
+
+--FILE--
+<?php
+
+class Foo {
+	function __destruct() : Foo {}
+}
+
+--EXPECTF--
+Fatal error: Destructor %s::%s() cannot declare a return type in %s on line %s

--- a/Zend/tests/return_types/019.phpt
+++ b/Zend/tests/return_types/019.phpt
@@ -1,0 +1,12 @@
+--TEST--
+__clone cannot declare a return type
+
+--FILE--
+<?php
+
+class Foo {
+	function __clone() : Foo {}
+}
+
+--EXPECTF--
+Fatal error: %s::%s() cannot declare a return type in %s on line %s

--- a/Zend/tests/return_types/020.phpt
+++ b/Zend/tests/return_types/020.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Exception thrown from function with return type
+
+--FILE--
+<?php
+function test() : array {
+    throw new Exception();
+}
+
+test();
+
+--EXPECTF--
+Fatal error: Uncaught exception 'Exception' in %s:%d
+Stack trace:
+#0 %s(%d): test()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/return_types/022.phpt
+++ b/Zend/tests/return_types/022.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Hint on closure with lexical vars
+
+--FILE--
+<?php
+$foo = "bar";
+$test = function() use($foo) : Closure {
+    return function() use ($foo) {
+        return $foo;
+    };
+};
+
+$callable = $test();
+var_dump($callable());
+
+--EXPECTF--
+string(3) "bar"

--- a/Zend/tests/return_types/023.phpt
+++ b/Zend/tests/return_types/023.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Return type allows self
+
+--FILE--
+<?php
+class Foo {
+    public static function getInstance() : self {
+        return new static();
+    }
+}
+
+class Bar extends Foo {}
+
+var_dump(Foo::getInstance());
+var_dump(Bar::getInstance());
+
+--EXPECTF--
+object(Foo)#%d (%d) {
+}
+object(Bar)#%d (%d) {
+}

--- a/Zend/tests/return_types/029.phpt
+++ b/Zend/tests/return_types/029.phpt
@@ -1,0 +1,12 @@
+--TEST--
+PHP 4 Constructors cannot declare a return type
+
+--FILE--
+<?php
+
+class Foo {
+	function foo() : Foo {}
+}
+
+--EXPECTF--
+Fatal error: Constructor %s::%s() cannot declare a return type in %s on line %s

--- a/Zend/tests/return_types/030.phpt
+++ b/Zend/tests/return_types/030.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Return type of self is not allowed in function
+
+--FILE--
+<?php
+
+function test(): self {}
+
+--EXPECTF--
+Fatal error: Cannot declare a return type of self outside of a class scope in %s on line 3

--- a/Zend/tests/return_types/031.phpt
+++ b/Zend/tests/return_types/031.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Return type of self is not allowed in closure
+
+--FILE--
+<?php
+
+$c = function(): self {};
+
+--EXPECTF--
+Fatal error: Cannot declare a return type of self outside of a class scope in %s on line 3

--- a/Zend/tests/return_types/classes.php
+++ b/Zend/tests/return_types/classes.php
@@ -1,0 +1,5 @@
+<?php
+
+class A {}
+class B extends A {}
+

--- a/Zend/tests/return_types/generators001.phpt
+++ b/Zend/tests/return_types/generators001.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Valid generator return types
+
+--FILE--
+<?php
+function test1() : Generator {
+    yield 1;
+}
+
+function test2() : Iterator {
+    yield 2;
+}
+
+function test3() : Traversable {
+    yield 3;
+}
+
+var_dump(
+    test1(),
+    test2(),
+    test3()
+);
+
+--EXPECTF--
+object(Generator)#%d (%d) {
+}
+object(Generator)#%d (%d) {
+}
+object(Generator)#%d (%d) {
+}

--- a/Zend/tests/return_types/generators002.phpt
+++ b/Zend/tests/return_types/generators002.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Generator return type must be Generator, Iterator or Traversable
+
+--FILE--
+<?php
+function test1() : StdClass {
+    yield 1;
+}
+
+--EXPECTF--
+Fatal error: Generators may only declare a return type of Generator, Iterator or Traversable, StdClass is not permitted in %s on line %d

--- a/Zend/tests/return_types/generators003.phpt
+++ b/Zend/tests/return_types/generators003.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Return type covariance works with generators
+
+--FILE--
+<?php
+interface Collection extends IteratorAggregate {
+    function getIterator(): Iterator;
+}
+
+class SomeCollection implements Collection {
+    function getIterator(): Generator {
+        foreach ($this->data as $key => $value) {
+            yield $key => $value;
+        }
+    }
+}
+
+$some = new SomeCollection();
+var_dump($some->getIterator());
+
+--EXPECTF--
+object(Generator)#%d (%d) {
+}

--- a/Zend/tests/return_types/generators004.phpt
+++ b/Zend/tests/return_types/generators004.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Generator with return type does not fail with empty return
+
+--FILE--
+<?php
+
+$a = function(): \Iterator {
+    yield 1;
+    return;
+};
+
+foreach($a() as $value) {
+    echo $value;
+}
+
+--EXPECT--
+1

--- a/Zend/tests/return_types/inheritance001.phpt
+++ b/Zend/tests/return_types/inheritance001.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Return type covariance; extends class
+
+--FILE--
+<?php
+
+class A {
+    function foo(): A {}
+}
+
+class B extends A {
+    function foo(): StdClass {}
+}
+
+--EXPECTF--
+Fatal error: Declaration of B::foo should be compatible with A::foo(): A, return type mismatch in %s on line %d

--- a/Zend/tests/return_types/inheritance001.phpt
+++ b/Zend/tests/return_types/inheritance001.phpt
@@ -13,4 +13,4 @@ class B extends A {
 }
 
 --EXPECTF--
-Fatal error: Declaration of B::foo should be compatible with A::foo(): A, return type mismatch in %s on line %d
+Fatal error: Declaration of B::foo() must be compatible with A::foo(): A in %s on line %d

--- a/Zend/tests/return_types/inheritance002.phpt
+++ b/Zend/tests/return_types/inheritance002.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Return type covariance; extends abstract class
+
+--FILE--
+<?php
+
+abstract class A {
+    abstract function foo(): A;
+}
+
+class B extends A {
+    function foo(): StdClass {}
+}
+
+--EXPECTF--
+Fatal error: Declaration of B::foo should be compatible with A::foo(): A, return type mismatch in %s on line %d

--- a/Zend/tests/return_types/inheritance002.phpt
+++ b/Zend/tests/return_types/inheritance002.phpt
@@ -13,4 +13,4 @@ class B extends A {
 }
 
 --EXPECTF--
-Fatal error: Declaration of B::foo should be compatible with A::foo(): A, return type mismatch in %s on line %d
+Fatal error: Declaration of B::foo() must be compatible with A::foo(): A in %s on line %d

--- a/Zend/tests/return_types/inheritance003.phpt
+++ b/Zend/tests/return_types/inheritance003.phpt
@@ -13,4 +13,4 @@ class B implements A {
 }
 
 --EXPECTF--
-Fatal error: Declaration of B::foo should be compatible with A::foo(): A, return type mismatch in %s on line %d
+Fatal error: Declaration of B::foo() must be compatible with A::foo(): A in %s on line %d

--- a/Zend/tests/return_types/inheritance003.phpt
+++ b/Zend/tests/return_types/inheritance003.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Return type mismatch; implements interface
+
+--FILE--
+<?php
+
+interface A {
+    function foo(): A;
+}
+
+class B implements A {
+    function foo(): StdClass {}
+}
+
+--EXPECTF--
+Fatal error: Declaration of B::foo should be compatible with A::foo(): A, return type mismatch in %s on line %d

--- a/Zend/tests/return_types/inheritance004.phpt
+++ b/Zend/tests/return_types/inheritance004.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Compile-time return type invariance; self and parent
+
+--FILE--
+<?php
+
+class A {
+    function foo(): self {}
+}
+
+class B extends A {
+    function foo(): parent {}
+}
+
+--EXPECT--

--- a/Zend/tests/return_types/inheritance005.phpt
+++ b/Zend/tests/return_types/inheritance005.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Internal covariant return type of self
+
+--FILE--
+<?php
+class Foo {
+    public static function test() : self {
+        return new Foo;
+    }
+}
+
+class Bar extends Foo {
+    public static function test() : self {
+        return new Bar;
+    }
+}
+
+var_dump(Bar::test());
+var_dump(Foo::test());
+
+--EXPECTF--
+object(Bar)#%d (0) {
+}
+object(Foo)#%d (0) {
+}

--- a/Zend/tests/return_types/inheritance006.phpt
+++ b/Zend/tests/return_types/inheritance006.phpt
@@ -1,0 +1,30 @@
+--TEST--
+External covariant return type of self
+
+--INI--
+opcache.enable_cli=1
+
+--FILE--
+<?php
+require __DIR__ . "/classes.php";
+
+class Foo {
+    public static function test() : A {
+        return new A;
+    }
+}
+
+class Bar extends Foo {
+    public static function test() : B {
+        return new B;
+    }
+}
+
+var_dump(Bar::test());
+var_dump(Foo::test());
+
+--EXPECTF--
+object(B)#%d (0) {
+}
+object(A)#%d (0) {
+}

--- a/Zend/tests/return_types/inheritance007.phpt
+++ b/Zend/tests/return_types/inheritance007.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Inheritance Hinting Compile Checking Failure Internal Classes
+
+--INI--
+opcache.enable_cli=1
+
+--FILE--
+<?php
+class Foo {
+    public static function test() : Traversable {
+        return new ArrayIterator([1, 2]);
+    }
+}
+
+class Bar extends Foo {
+    public static function test() : ArrayObject {
+        return new ArrayObject([1, 2]);
+    }
+}
+
+var_dump(Bar::test());
+var_dump(Foo::test());
+
+--EXPECTF--
+object(ArrayObject)#%d (1) {
+  ["storage":"ArrayObject":private]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(2)
+  }
+}
+object(ArrayIterator)#%d (1) {
+  ["storage":"ArrayIterator":private]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(2)
+  }
+}

--- a/Zend/tests/return_types/inheritance008.phpt
+++ b/Zend/tests/return_types/inheritance008.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Compile-time return type covariance; extends class by name
+
+--FILE--
+<?php
+
+class A {
+    function foo(): A {}
+}
+
+class B extends A {
+    function foo(): B {}
+}
+
+--EXPECT--

--- a/Zend/tests/return_types/reflection001.phpt
+++ b/Zend/tests/return_types/reflection001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Reflection::hasReturnType true
+
+--SKIPIF--
+<?php
+if (!extension_loaded('reflection') || !defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70000) {
+    print 'skip';
+}
+
+--FILE--
+<?php
+
+$func = function(): array {
+    return [];
+};
+
+$rf = new ReflectionFunction($func);
+var_dump($rf->hasReturnType());
+
+--EXPECT--
+bool(true)

--- a/Zend/tests/return_types/reflection002.phpt
+++ b/Zend/tests/return_types/reflection002.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Reflection::hasReturnType false
+
+--SKIPIF--
+<?php
+if (!extension_loaded('reflection') || !defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70000) {
+    print 'skip';
+}
+
+--FILE--
+<?php
+
+$func = function() {
+    return [];
+};
+
+$rf = new ReflectionFunction($func);
+var_dump($rf->hasReturnType());
+
+--EXPECT--
+bool(false)

--- a/Zend/tests/return_types/reflection003.phpt
+++ b/Zend/tests/return_types/reflection003.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Reflection::getReturnType empty
+
+--SKIPIF--
+<?php
+if (!extension_loaded('reflection') || !defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70000) {
+    print 'skip';
+}
+
+--FILE--
+<?php
+
+$func = function() {
+    return [];
+};
+
+$rf = new ReflectionFunction($func);
+$rt = $rf->getReturnType();
+var_dump($rt->getKind() == $rt::IS_UNDECLARED);
+var_dump((string) $rt);
+var_dump((string) $rt === $rt->getName());
+
+--EXPECT--
+bool(true)
+string(0) ""
+bool(true)

--- a/Zend/tests/return_types/reflection004.phpt
+++ b/Zend/tests/return_types/reflection004.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Reflection::getReturnType array
+
+--SKIPIF--
+<?php
+if (!extension_loaded('reflection') || !defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70000) {
+    print 'skip';
+}
+
+--FILE--
+<?php
+
+$func = function(): array {
+    return [];
+};
+
+$rf = new ReflectionFunction($func);
+$rt = $rf->getReturnType();
+var_dump($rt->getKind() == $rt::IS_ARRAY);
+var_dump((string) $rt);
+var_dump((string) $rt === $rt->getName());
+
+--EXPECT--
+bool(true)
+string(5) "array"
+bool(true)

--- a/Zend/tests/return_types/reflection005.phpt
+++ b/Zend/tests/return_types/reflection005.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Reflection::getReturnType callable
+
+--SKIPIF--
+<?php
+if (!extension_loaded('reflection') || !defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70000) {
+    print 'skip';
+}
+
+--FILE--
+<?php
+
+$func = function(): callable {
+    return 'strlen';
+};
+
+$rf = new ReflectionFunction($func);
+$rt = $rf->getReturnType();
+var_dump($rt->getKind() == $rt::IS_CALLABLE);
+var_dump((string) $rt);
+var_dump((string) $rt === $rt->getName());
+
+--EXPECT--
+bool(true)
+string(8) "callable"
+bool(true)

--- a/Zend/tests/return_types/reflection006.phpt
+++ b/Zend/tests/return_types/reflection006.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Reflection::getReturnType object
+
+--SKIPIF--
+<?php
+if (!extension_loaded('reflection') || !defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70000) {
+    print 'skip';
+}
+
+--FILE--
+<?php
+
+$func = function(): StdClass {
+    return new StdClass;
+};
+
+$rf = new ReflectionFunction($func);
+$rt = $rf->getReturnType();
+var_dump($rt->getKind() == $rt::IS_OBJECT);
+var_dump((string) $rt);
+var_dump((string) $rt === $rt->getName());
+
+--EXPECT--
+bool(true)
+string(8) "StdClass"
+bool(true)

--- a/Zend/tests/return_types/reflection007.phpt
+++ b/Zend/tests/return_types/reflection007.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Reflection::getReturnType object
+
+--SKIPIF--
+<?php
+if (!extension_loaded('reflection') || !defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70000) {
+    print 'skip';
+}
+
+--FILE--
+<?php
+
+interface A {
+    function foo(): A;
+}
+
+$rc = new ReflectionClass("A");
+$rt = $rc->getMethod("foo")->getReturnType();
+var_dump($rt->getKind() == $rt::IS_OBJECT);
+var_dump((string) $rt);
+var_dump((string) $rt === $rt->getName());
+
+--EXPECT--
+bool(true)
+string(1) "A"
+bool(true)

--- a/Zend/tests/return_types/reflection008.phpt
+++ b/Zend/tests/return_types/reflection008.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Reflection::getReturnType object
+
+--SKIPIF--
+<?php
+if (!extension_loaded('reflection') || !defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70000) {
+    print 'skip';
+}
+
+--FILE--
+<?php
+
+class A {
+    function foo(): array {
+        return [];
+    }
+}
+
+$rc = new ReflectionClass("A");
+$rt = $rc->getMethod("foo")->getReturnType();
+var_dump($rt->getKind() == $rt::IS_ARRAY);
+var_dump((string) $rt);
+var_dump((string) $rt === $rt->getName());
+
+--EXPECT--
+bool(true)
+string(5) "array"
+bool(true)

--- a/Zend/tests/return_types/rfc001.phpt
+++ b/Zend/tests/return_types/rfc001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+RFC example: returned type does not match the type declaration
+
+--FILE--
+<?php
+
+function get_config(): array {
+    return 42;
+}
+
+get_config();
+
+--EXPECTF--
+Catchable fatal error: The function get_config was expected to return an array and returned an integer in %s on line %d

--- a/Zend/tests/return_types/rfc002.phpt
+++ b/Zend/tests/return_types/rfc002.phpt
@@ -1,0 +1,13 @@
+--TEST--
+RFC example: expected class int and returned integer
+
+--FILE--
+<?php
+function answer(): int {
+    return 42;
+}
+
+answer();
+
+--EXPECTF--
+Catchable fatal error: The function answer was expected to return an object of class int and returned an integer in %s on line %d

--- a/Zend/tests/return_types/rfc003.phpt
+++ b/Zend/tests/return_types/rfc003.phpt
@@ -1,0 +1,13 @@
+--TEST--
+RFC example: cannot return null with a return type declaration
+
+--FILE--
+<?php
+function foo(): DateTime {
+    return null;
+}
+
+foo();
+
+--EXPECTF--
+Catchable fatal error: The function foo was expected to return an object of class DateTime and returned null in %s on line %d

--- a/Zend/tests/return_types/rfc004.phpt
+++ b/Zend/tests/return_types/rfc004.phpt
@@ -1,0 +1,21 @@
+--TEST--
+RFC example: missing return type on override
+
+--FILE--
+<?php
+
+class User {}
+
+interface UserGateway {
+    function find($id) : User;
+}
+
+class UserGateway_MySql implements UserGateway {
+    // must return User or subtype of User
+    function find($id) {
+        return new User;
+    }
+}
+
+--EXPECTF--
+Fatal error: Declaration of UserGateway_MySql::find() must be compatible with UserGateway::find($id): User in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2211,6 +2211,11 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 			internal_function->num_args = 0;
 			internal_function->required_num_args = 0;
 		}
+
+		/* TODO: allow internal functions to declare return types somehow */
+		internal_function->return_type.name = NULL;
+		internal_function->return_type.kind = IS_UNDEF;
+
 		if (ptr->flags & ZEND_ACC_ABSTRACT) {
 			if (scope) {
 				/* This is a class that must be abstract itself. Here we set the check info. */

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -67,7 +67,7 @@ ZEND_API zend_ast *zend_ast_create_zval_ex(zval *zv, zend_ast_attr attr) {
 
 ZEND_API zend_ast *zend_ast_create_decl(
 	zend_ast_kind kind, uint32_t flags, uint32_t start_lineno, zend_string *doc_comment,
-	zend_string *name, zend_ast *child0, zend_ast *child1, zend_ast *child2
+	zend_string *name, zend_ast *child0, zend_ast *child1, zend_ast *child2, zend_ast *child3
 ) {
 	zend_ast_decl *ast;
 	TSRMLS_FETCH();
@@ -84,6 +84,7 @@ ZEND_API zend_ast *zend_ast_create_decl(
 	ast->child[0] = child0;
 	ast->child[1] = child1;
 	ast->child[2] = child2;
+	ast->child[3] = child3;
 
 	return (zend_ast *) ast;
 }
@@ -400,6 +401,7 @@ static void zend_ast_destroy_ex(zend_ast *ast, zend_bool free) {
 			zend_ast_destroy_ex(decl->child[0], free);
 			zend_ast_destroy_ex(decl->child[1], free);
 			zend_ast_destroy_ex(decl->child[2], free);
+			zend_ast_destroy_ex(decl->child[3], free);
 			break;
 		}
 		default:

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -183,7 +183,7 @@ typedef struct _zend_ast_decl {
 	unsigned char *lex_pos;
 	zend_string *doc_comment;
 	zend_string *name;
-	zend_ast *child[3];
+	zend_ast *child[4];
 } zend_ast_decl;
 
 ZEND_API zend_ast *zend_ast_create_zval_ex(zval *zv, zend_ast_attr attr);
@@ -193,7 +193,7 @@ ZEND_API zend_ast *zend_ast_create(zend_ast_kind kind, ...);
 
 ZEND_API zend_ast *zend_ast_create_decl(
 	zend_ast_kind kind, uint32_t flags, uint32_t start_lineno, zend_string *doc_comment,
-	zend_string *name, zend_ast *child0, zend_ast *child1, zend_ast *child2
+	zend_string *name, zend_ast *child0, zend_ast *child1, zend_ast *child2, zend_ast *child3
 );
 
 ZEND_API zend_ast *zend_ast_create_list(uint32_t init_children, zend_ast_kind kind, ...);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -35,6 +35,14 @@
 
 #define SET_UNUSED(op)  op ## _type = IS_UNUSED
 
+#define MAKE_NOP(opline) do { \
+	opline->opcode = ZEND_NOP; \
+	memset(&opline->result, 0, sizeof(opline->result)); \
+	memset(&opline->op1, 0, sizeof(opline->op1)); \
+	memset(&opline->op2, 0, sizeof(opline->op2)); \
+	opline->result_type = opline->op1_type = opline->op2_type = IS_UNUSED; \
+} while (0)
+
 #define RESET_DOC_COMMENT() do { \
 	if (CG(doc_comment)) { \
 		zend_string_release(CG(doc_comment)); \
@@ -223,6 +231,9 @@ typedef struct _zend_try_catch_element {
 /* internal function is allocated at arena */
 #define ZEND_ACC_ARENA_ALLOCATED		0x20000000
 
+/* Function has a return type hint (or class has such non-private function) */
+#define ZEND_ACC_HAS_RETURN_TYPE		0x40000000
+
 #define ZEND_CE_IS_TRAIT(ce) (((ce)->ce_flags & ZEND_ACC_TRAIT) == ZEND_ACC_TRAIT)
 
 char *zend_visibility_string(uint32_t fn_flags);
@@ -256,6 +267,16 @@ typedef struct _zend_arg_info {
 	zend_bool is_variadic;
 } zend_arg_info;
 
+/* TODO: (maybe) unify type information across the various places, such as
+ * return types, parameter types and exceptions */
+typedef struct _zend_type_decl {
+	zend_string *name;
+	zend_uchar kind;
+} zend_type_decl;
+
+void zend_type_decl_ctor(zend_type_decl*, zend_uchar, zend_string*);
+void zend_type_decl_dtor(zend_type_decl*);
+
 /* the following structure repeats the layout of zend_arg_info,
  * but its fields have different meaning. It's used as the first element of
  * arg_info array to define properties of internal functions.
@@ -281,6 +302,7 @@ struct _zend_op_array {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_arg_info *arg_info;
+	zend_type_decl return_type;
 	/* END of common elements */
 
 	uint32_t *refcount;
@@ -331,6 +353,7 @@ typedef struct _zend_internal_function {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_arg_info *arg_info;
+	zend_type_decl return_type;
 	/* END of common elements */
 
 	void (*handler)(INTERNAL_FUNCTION_PARAMETERS);
@@ -351,6 +374,7 @@ union _zend_function {
 		uint32_t num_args;
 		uint32_t required_num_args;
 		zend_arg_info *arg_info;
+		zend_type_decl return_type;
 	} common;
 
 	zend_op_array op_array;

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -774,7 +774,7 @@ static zend_bool zval_fits_type(const zval *variable, const zend_uchar type, con
 			return 1;
 
 		default:
-			assert (false && "Unknown type");
+			assert (0 && "Unknown type");
 	}
 }
 

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -48,6 +48,7 @@ ZEND_API int zend_eval_stringl(char *str, size_t str_len, zval *retval_ptr, char
 ZEND_API int zend_eval_string_ex(char *str, zval *retval_ptr, char *string_name, int handle_exceptions TSRMLS_DC);
 ZEND_API int zend_eval_stringl_ex(char *str, size_t str_len, zval *retval_ptr, char *string_name, int handle_exceptions TSRMLS_DC);
 
+ZEND_API void zend_return_type_error(int type, zend_function *function, zval *returned, const char *message TSRMLS_DC);
 ZEND_API char * zend_verify_arg_class_kind(const zend_arg_info *cur_arg_info, char **class_name, zend_class_entry **pce TSRMLS_DC);
 ZEND_API void zend_verify_arg_error(int error_type, const zend_function *zf, uint32_t arg_num, const char *need_msg, const char *need_kind, const char *given_msg, const char *given_kind, zval *arg TSRMLS_DC);
 

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -332,8 +332,17 @@ char *zend_visibility_string(uint32_t fn_flags) /* {{{ */
 /* }}} */
 
 
+/* TODO: move this elsewhere */
+static inline
+zend_bool zend_string_equals_ci(const zend_string *a, const zend_string *b) /* {{{ */
+{
+	return a->len == b->len && !zend_binary_strcasecmp(a->val, a->len, b->val, b->len);
+}
+/* }}} */
+
+
 static
-zend_bool zend_do_return_type_inheritance_check(const zend_function *fe, const zend_function *proto TSRMLS_DC)
+zend_bool zend_do_return_type_inheritance_check(const zend_function *fe, const zend_function *proto TSRMLS_DC) /* {{{ */
 {
 	zend_class_entry *child_ce;
 	zend_class_entry *parent_ce;
@@ -372,23 +381,23 @@ zend_bool zend_do_return_type_inheritance_check(const zend_function *fe, const z
 	}
 
 	/* 1b. If the type names are equal they are invariant */
-	if (zend_string_equals(child_name, parent_name)) {
+	if (zend_string_equals_ci(child_name, parent_name)) {
 		return 1;
 	}
 
 	/* 2a. Bind the type names to class entries; fetch the class if needed
 	 */
-	if (zend_string_equals(child_name, proto->common.scope->name)) {
+	if (zend_string_equals_ci(child_name, proto->common.scope->name)) {
 		child_ce = proto->common.scope;
-	} else if (zend_string_equals(child_name, fe->common.scope->name)) {
+	} else if (zend_string_equals_ci(child_name, fe->common.scope->name)) {
 		child_ce = fe->common.scope;
 	} else {
 		child_ce = zend_fetch_class_by_name(child_name, NULL, 0 TSRMLS_CC);
 	}
 
-	if (proto->common.scope->parent && zend_string_equals(parent_name, proto->common.scope->parent->name)) {
+	if (proto->common.scope->parent && zend_string_equals_ci(parent_name, proto->common.scope->parent->name)) {
 		parent_ce = proto->common.scope->parent;
-	} else if (zend_string_equals(parent_name, proto->common.scope->name)) {
+	} else if (zend_string_equals_ci(parent_name, proto->common.scope->name)) {
 		parent_ce = proto->common.scope;
 	} else {
 		parent_ce = zend_fetch_class_by_name(parent_name, NULL, 0 TSRMLS_CC);
@@ -398,6 +407,7 @@ zend_bool zend_do_return_type_inheritance_check(const zend_function *fe, const z
 	 *     the parent then they are not covariant */
 	return instanceof_function(child_ce, parent_ce TSRMLS_CC);
 }
+/* }}} */
 
 static zend_function *do_inherit_method(zend_function *old_function, zend_class_entry *ce TSRMLS_DC) /* {{{ */
 {

--- a/Zend/zend_inheritance.h
+++ b/Zend/zend_inheritance.h
@@ -33,6 +33,8 @@ ZEND_API void zend_do_bind_traits(zend_class_entry *ce TSRMLS_DC);
 ZEND_API void zend_do_inheritance(zend_class_entry *ce, zend_class_entry *parent_ce TSRMLS_DC);
 void zend_do_early_binding(TSRMLS_D);
 
+void zend_verify_class_return_type_variance(zend_class_entry *child_ce, zend_class_entry *parent_ce TSRMLS_DC);
+
 END_EXTERN_C()
 
 #endif

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -243,7 +243,6 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> variable_class_name dereferencable_scalar class_name_scalar constant dereferencable
 %type <ast> callable_expr callable_variable static_member new_variable
 %type <ast> assignment_list_element array_pair encaps_var encaps_var_offset isset_variables
-%type <ast> isset_variable
 %type <ast> top_statement_list use_declarations const_list inner_statement_list if_stmt
 %type <ast> alt_if_stmt for_exprs switch_case_list global_var_list static_var_list
 %type <ast> echo_expr_list unset_variables catch_list parameter_list class_statement_list
@@ -252,7 +251,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> class_const_list name_list trait_adaptations method_body non_empty_for_exprs
 %type <ast> ctor_arguments alt_if_stmt_without_else trait_adaptation_list lexical_vars
 %type <ast> lexical_var_list encaps_list array_pair_list non_empty_array_pair_list
-%type <ast> assignment_list
+%type <ast> assignment_list isset_variable type return_type
 
 %type <num> returns_ref function is_reference is_variadic class_type variable_modifiers
 %type <num> method_modifiers trait_modifiers non_empty_member_modifiers member_modifier
@@ -405,10 +404,10 @@ unset_variable:
 ;
 
 function_declaration_statement:
-	function returns_ref T_STRING '(' parameter_list ')' backup_doc_comment
-	'{' inner_statement_list '}'
-		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2, $1, $7,
-		      zend_ast_get_str($3), $5, NULL, $9); }
+	function returns_ref T_STRING '(' parameter_list ')' return_type
+	backup_doc_comment '{' inner_statement_list '}'
+		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2, $1, $8,
+		      zend_ast_get_str($3), $5, NULL, $10, $7); }
 ;
 
 is_reference:
@@ -425,11 +424,11 @@ class_declaration_statement:
 		class_type { $<num>$ = CG(zend_lineno); }
 		T_STRING extends_from implements_list backup_doc_comment '{' class_statement_list '}'
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, $1, $<num>2, $6,
-				  zend_ast_get_str($3), $4, $5, $8); }
+				  zend_ast_get_str($3), $4, $5, $8, NULL); }
 	|	T_INTERFACE { $<num>$ = CG(zend_lineno); }
 		T_STRING interface_extends_list backup_doc_comment '{' class_statement_list '}'
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_INTERFACE, $<num>2, $5,
-				  zend_ast_get_str($3), NULL, $4, $7); }
+				  zend_ast_get_str($3), NULL, $4, $7, NULL); }
 ;
 
 class_type:
@@ -556,9 +555,18 @@ parameter:
 
 optional_type:
 		/* empty */	{ $$ = NULL; }
-	|	T_ARRAY		{ $$ = zend_ast_create_ex(ZEND_AST_TYPE, IS_ARRAY); }
+	|	type		{ $$ = $1; }
+;
+
+type:
+		T_ARRAY		{ $$ = zend_ast_create_ex(ZEND_AST_TYPE, IS_ARRAY); }
 	|	T_CALLABLE	{ $$ = zend_ast_create_ex(ZEND_AST_TYPE, IS_CALLABLE); }
 	|	name		{ $$ = $1; }
+;
+
+return_type:
+		/* empty */	{ $$ = NULL; }
+	|	':' type	{ $$ = $2; }
 ;
 
 argument_list:
@@ -615,10 +623,10 @@ class_statement:
 			{ $$ = $2; RESET_DOC_COMMENT(); }
 	|	T_USE name_list trait_adaptations
 			{ $$ = zend_ast_create(ZEND_AST_USE_TRAIT, $2, $3); }
-	|	method_modifiers function returns_ref T_STRING '(' parameter_list ')' backup_doc_comment
-		method_body
-			{ $$ = zend_ast_create_decl(ZEND_AST_METHOD, $3 | $1, $2, $8,
-				  zend_ast_get_str($4), $6, NULL, $9); }
+	|	method_modifiers function returns_ref T_STRING '(' parameter_list ')'
+		return_type backup_doc_comment method_body
+			{ $$ = zend_ast_create_decl(ZEND_AST_METHOD, $3 | $1, $2, $9,
+				  zend_ast_get_str($4), $6, NULL, $10, $8); }
 ;
 
 name_list:
@@ -852,16 +860,16 @@ expr_without_variable:
 	|	T_YIELD { $$ = zend_ast_create(ZEND_AST_YIELD, NULL, NULL); }
 	|	T_YIELD expr { $$ = zend_ast_create(ZEND_AST_YIELD, $2, NULL); }
 	|	T_YIELD expr T_DOUBLE_ARROW expr { $$ = zend_ast_create(ZEND_AST_YIELD, $4, $2); }
-	|	function returns_ref '(' parameter_list ')' lexical_vars backup_doc_comment
-		'{' inner_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $2, $1, $7,
+	|	function returns_ref '(' parameter_list ')' lexical_vars return_type
+		backup_doc_comment '{' inner_statement_list '}'
+			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $2, $1, $8,
 				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0),
-			      $4, $6, $9); }
-	|	T_STATIC function returns_ref '(' parameter_list ')' lexical_vars backup_doc_comment
-		'{' inner_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $3 | ZEND_ACC_STATIC, $2, $8,
+			      $4, $6, $10, $7); }
+	|	T_STATIC function returns_ref '(' parameter_list ')' lexical_vars
+		return_type backup_doc_comment '{' inner_statement_list '}'
+			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $3 | ZEND_ACC_STATIC, $2, $9,
 			      zend_string_init("{closure}", sizeof("{closure}") - 1, 0),
-			      $5, $7, $10); }
+			      $5, $7, $11, $8); }
 ;
 
 function:

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2808,6 +2808,31 @@ ZEND_VM_C_LABEL(fcall_end):
 	ZEND_VM_NEXT_OPCODE();
 }
 
+ZEND_VM_HANDLER(170, ZEND_VERIFY_RETURN_TYPE, ANY, VAR|UNUSED)
+{
+	USE_OPLINE
+	zval *retval_ptr;
+	zend_free_op free_op1, free_op2;
+	zend_type_decl *return_type = NULL;
+	zend_class_entry *ce = NULL;
+
+	SAVE_OPLINE();
+	retval_ptr = GET_OP1_ZVAL_PTR(BP_VAR_R);
+
+	if (OP1_TYPE == IS_UNUSED || Z_ISNULL_P(retval_ptr)) {
+		zend_return_type_error(E_RECOVERABLE_ERROR, EX(func), retval_ptr, NULL TSRMLS_CC);
+	} else {
+		return_type = &EX(func)->common.return_type;
+		ce = Z_CE_P(EX_VAR(opline->op2.var));
+
+		if (!zval_fits_type(retval_ptr, return_type->kind, ce TSRMLS_CC)) {
+			zend_return_type_error(E_RECOVERABLE_ERROR, EX(func), retval_ptr, NULL TSRMLS_CC);
+		}
+	}
+	CHECK_EXCEPTION();
+	ZEND_VM_NEXT_OPCODE();
+}
+
 ZEND_VM_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY)
 {
 	USE_OPLINE

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2125,6 +2125,31 @@ static int ZEND_FASTCALL  ZEND_INIT_FCALL_BY_NAME_SPEC_VAR_HANDLER(ZEND_OPCODE_H
 	}
 }
 
+static int ZEND_FASTCALL  ZEND_VERIFY_RETURN_TYPE_SPEC_VAR_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
+{
+	USE_OPLINE
+	zval *retval_ptr;
+	zend_free_op free_op1;
+	zend_type_decl *return_type = NULL;
+	zend_class_entry *ce = NULL;
+
+	SAVE_OPLINE();
+	retval_ptr = get_zval_ptr(opline->op1_type, &opline->op1, execute_data, &free_op1, BP_VAR_R);
+
+	if (opline->op1_type == IS_UNUSED || Z_ISNULL_P(retval_ptr)) {
+		zend_return_type_error(E_RECOVERABLE_ERROR, EX(func), retval_ptr, NULL TSRMLS_CC);
+	} else {
+		return_type = &EX(func)->common.return_type;
+		ce = Z_CE_P(EX_VAR(opline->op2.var));
+
+		if (!zval_fits_type(retval_ptr, return_type->kind, ce TSRMLS_CC)) {
+			zend_return_type_error(E_RECOVERABLE_ERROR, EX(func), retval_ptr, NULL TSRMLS_CC);
+		}
+	}
+	CHECK_EXCEPTION();
+	ZEND_VM_NEXT_OPCODE();
+}
+
 static int ZEND_FASTCALL  ZEND_FETCH_CLASS_SPEC_UNUSED_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
 {
 	USE_OPLINE
@@ -2162,6 +2187,31 @@ static int ZEND_FASTCALL  ZEND_FETCH_CLASS_SPEC_UNUSED_HANDLER(ZEND_OPCODE_HANDL
 		CHECK_EXCEPTION();
 		ZEND_VM_NEXT_OPCODE();
 	}
+}
+
+static int ZEND_FASTCALL  ZEND_VERIFY_RETURN_TYPE_SPEC_UNUSED_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
+{
+	USE_OPLINE
+	zval *retval_ptr;
+	zend_free_op free_op1;
+	zend_type_decl *return_type = NULL;
+	zend_class_entry *ce = NULL;
+
+	SAVE_OPLINE();
+	retval_ptr = get_zval_ptr(opline->op1_type, &opline->op1, execute_data, &free_op1, BP_VAR_R);
+
+	if (opline->op1_type == IS_UNUSED || Z_ISNULL_P(retval_ptr)) {
+		zend_return_type_error(E_RECOVERABLE_ERROR, EX(func), retval_ptr, NULL TSRMLS_CC);
+	} else {
+		return_type = &EX(func)->common.return_type;
+		ce = Z_CE_P(EX_VAR(opline->op2.var));
+
+		if (!zval_fits_type(retval_ptr, return_type->kind, ce TSRMLS_CC)) {
+			zend_return_type_error(E_RECOVERABLE_ERROR, EX(func), retval_ptr, NULL TSRMLS_CC);
+		}
+	}
+	CHECK_EXCEPTION();
+	ZEND_VM_NEXT_OPCODE();
 }
 
 static int ZEND_FASTCALL  ZEND_FETCH_CLASS_SPEC_CV_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
@@ -48875,6 +48925,31 @@ void zend_init_opcodes_handlers(void)
   	ZEND_COALESCE_SPEC_CV_HANDLER,
   	ZEND_COALESCE_SPEC_CV_HANDLER,
   	ZEND_COALESCE_SPEC_CV_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_VAR_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_UNUSED_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_VAR_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_UNUSED_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_VAR_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_UNUSED_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_VAR_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_UNUSED_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_NULL_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_VAR_HANDLER,
+  	ZEND_VERIFY_RETURN_TYPE_SPEC_UNUSED_HANDLER,
+  	ZEND_NULL_HANDLER,
   	ZEND_NULL_HANDLER
   };
   zend_opcode_handlers = (opcode_handler_t*)labels;

--- a/Zend/zend_vm_opcodes.c
+++ b/Zend/zend_vm_opcodes.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <zend.h>
 
-const char *zend_vm_opcodes_map[170] = {
+const char *zend_vm_opcodes_map[171] = {
 	"ZEND_NOP",
 	"ZEND_ADD",
 	"ZEND_SUB",
@@ -192,6 +192,7 @@ const char *zend_vm_opcodes_map[170] = {
 	"ZEND_ASSIGN_POW",
 	"ZEND_BIND_GLOBAL",
 	"ZEND_COALESCE",
+	"ZEND_VERIFY_RETURN_TYPE",
 };
 
 ZEND_API const char* zend_get_opcode_name(zend_uchar opcode) {

--- a/Zend/zend_vm_opcodes.h
+++ b/Zend/zend_vm_opcodes.h
@@ -182,5 +182,6 @@ END_EXTERN_C()
 #define ZEND_ASSIGN_POW                      167
 #define ZEND_BIND_GLOBAL                     168
 #define ZEND_COALESCE                        169
+#define ZEND_VERIFY_RETURN_TYPE              170
 
 #endif

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -430,6 +430,14 @@ static void zend_persist_op_array_ex(zend_op_array *op_array, zend_persistent_sc
 		}
 	}
 
+	if (op_array->return_type.kind == IS_OBJECT) {
+		if (already_stored) {
+			op_array->return_type.name = zend_shared_alloc_get_xlat_entry(op_array->return_type.name);
+		} else {
+			zend_accel_store_string(op_array->return_type.name);
+		}
+	}
+
 	if (op_array->brk_cont_array) {
 		zend_accel_store(op_array->brk_cont_array, sizeof(zend_brk_cont_element) * op_array->last_brk_cont);
 	}

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -210,6 +210,10 @@ static void zend_persist_op_array_calc_ex(zend_op_array *op_array TSRMLS_DC)
 		}
 	}
 
+	if (op_array->return_type.kind == IS_OBJECT) {
+		ADD_STRING(op_array->return_type.name);
+	}
+
 	if (op_array->brk_cont_array) {
 		ADD_DUP_SIZE(op_array->brk_cont_array, sizeof(zend_brk_cont_element) * op_array->last_brk_cont);
 	}


### PR DESCRIPTION
This is a pull request to implement the return type RFC: https://wiki.php.net/rfc/returntypehinting

Notes about the implementation:

  - Adds a new opcode `ZEND_VERIFY_RETURN_TYPE`. When a function has a return type, this opcode will be emitted to check that the return value satisfies the return type.
  - When:
      - a child class inherits from a parent class
      - and the parent class has a method which uses a class or interface as a return type
      - and the method is overwritten
      - then the child class must use delayed binding. In some cases we could do string matching to avoid the delayed binding.
  - Internal classes cannot specify return types, at least not easily.
  - During `pass_two` if a `ZEND_VERIFY_RETURN_TYPE` opcode is found in a `Generator` then it will be made into a no-op. It would be nicer to not emit one for generators, but this is somewhat difficult to do because when you process the `return` expression you may not know if the function is a generator yet.