### PR TITLE
Improved addcslashes parameters charlist length control in 256 bytes

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3170,6 +3170,11 @@ PHP_FUNCTION(addcslashes)
 		RETURN_STRINGL(str->val, str->len);
 	}
 
+	if (what->len >= 256 ) {
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "charlist more than 256 bytes");
+		RETURN_FALSE;
+	}
+	
 	RETURN_STR(php_addcslashes(str->val, str->len, 0, what->val, what->len TSRMLS_CC));
 }
 /* }}} */


### PR DESCRIPTION
Strictly speaking, addcslashes charlist parameter 256-byte is enough.And in the php_charmask function is  Fills a 256-byte bytemask with input