### PR TITLE
Improved addcslashes parameters charlist length control in 256 bytes

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1590,7 +1590,7 @@ PHP_FUNCTION(pathinfo)
 	if (opt == PHP_PATHINFO_ALL) {
 		RETURN_ZVAL(&tmp, 0, 1);
 	} else {
-		zval *element;
+		zval *element;t
 		if ((element = zend_hash_get_current_data(Z_ARRVAL(tmp))) != NULL) {
 			RETVAL_ZVAL(element, 1, 0);
 		} else {
@@ -3170,7 +3170,7 @@ PHP_FUNCTION(addcslashes)
 		RETURN_STRINGL(str->val, str->len);
 	}
 	
-	if (what_len >= 256 ) {
+	if (what->len >= 256 ) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "charlist more than 256 bytes");
         	RETURN_FALSE;
 	}

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1590,7 +1590,7 @@ PHP_FUNCTION(pathinfo)
 	if (opt == PHP_PATHINFO_ALL) {
 		RETURN_ZVAL(&tmp, 0, 1);
 	} else {
-		zval *element;t
+		zval *element;
 		if ((element = zend_hash_get_current_data(Z_ARRVAL(tmp))) != NULL) {
 			RETVAL_ZVAL(element, 1, 0);
 		} else {

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3169,7 +3169,12 @@ PHP_FUNCTION(addcslashes)
 	if (what->len == 0) {
 		RETURN_STRINGL(str->val, str->len);
 	}
-
+	
+	if (what_len >= 256 ) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "charlist more than 256 bytes");
+        	RETURN_FALSE;
+	}
+	
 	RETURN_STR(php_addcslashes(str->val, str->len, 0, what->val, what->len TSRMLS_CC));
 }
 /* }}} */


### PR DESCRIPTION
Strictly speaking, addcslashes charlist parameter 256-byte is enough.And in the php_charmask function is Fills a 256-byte bytemask with input