### PR TITLE
Use ASCII delimiters for browscap regular expressions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug #67985 (Incorrect last used array index copied to new array after
     unset). (Tjerk)
+  . Fixed bug #68021 (get_browser() browser_name_regex returns non-utf-8 
+    characters). (Tjerk)
 
 ?? ??? 2014, PHP 5.4.33
 

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -91,7 +91,7 @@ static void convert_browscap_pattern(zval *pattern, int persistent) /* {{{ */
 
 	t = (char *) safe_pemalloc(Z_STRLEN_P(pattern), 2, 5, persistent);
 
-	t[j++] = '\xA7'; /* section sign */
+	t[j++] = '~';
 	t[j++] = '^';
 
 	for (i=0; i<Z_STRLEN_P(pattern); i++, j++) {
@@ -119,9 +119,9 @@ static void convert_browscap_pattern(zval *pattern, int persistent) /* {{{ */
 				t[j++] = '\\';
 				t[j] = ')';
 				break;
-			case '\xA7':
+			case '~':
 				t[j++] = '\\';
-				t[j] = '\xA7';
+				t[j] = '~';
 				break;
 			default:
 				t[j] = Z_STRVAL_P(pattern)[i];
@@ -130,7 +130,7 @@ static void convert_browscap_pattern(zval *pattern, int persistent) /* {{{ */
 	}
 
 	t[j++] = '$';
-	t[j++] = '\xA7';
+	t[j++] = '~';
 
 	t[j]=0;
 	Z_STRVAL_P(pattern) = t;

--- a/ext/standard/tests/misc/get_browser_basic.phpt
+++ b/ext/standard/tests/misc/get_browser_basic.phpt
@@ -37,7 +37,7 @@ for( $x = 0; $x < 20; $x++) {
 *** Testing get_browser() : basic functionality ***
 array(35) {
   ["browser_name_regex"]=>
-  string(41) "§^opera/7\.1.* \(windows nt 5\.1; .\).*$§"
+  string(41) "~^opera/7\.1.* \(windows nt 5\.1; .\).*$~"
   ["browser_name_pattern"]=>
   string(31) "Opera/7.1* (Windows NT 5.1; ?)*"
   ["parent"]=>
@@ -109,7 +109,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(83) "§^mozilla/4\.0 \(compatible; msie 6\.0; msie 5\.5; windows nt 5\.0\) opera 7\.0.*$§"
+  string(83) "~^mozilla/4\.0 \(compatible; msie 6\.0; msie 5\.5; windows nt 5\.0\) opera 7\.0.*$~"
   ["browser_name_pattern"]=>
   string(71) "Mozilla/4.0 (compatible; MSIE 6.0; MSIE 5.5; Windows NT 5.0) Opera 7.0*"
   ["parent"]=>
@@ -181,7 +181,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(83) "§^mozilla/4\.0 \(compatible; msie 6\.0; msie 5\.5; windows nt 4\.0\) opera 7\.0.*$§"
+  string(83) "~^mozilla/4\.0 \(compatible; msie 6\.0; msie 5\.5; windows nt 4\.0\) opera 7\.0.*$~"
   ["browser_name_pattern"]=>
   string(71) "Mozilla/4.0 (compatible; MSIE 6.0; MSIE 5.5; Windows NT 4.0) Opera 7.0*"
   ["parent"]=>
@@ -253,7 +253,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(69) "§^mozilla/4\.0 \(compatible; msie 5\.0; windows 2000\) opera 6\.0.*$§"
+  string(69) "~^mozilla/4\.0 \(compatible; msie 5\.0; windows 2000\) opera 6\.0.*$~"
   ["browser_name_pattern"]=>
   string(59) "Mozilla/4.0 (compatible; MSIE 5.0; Windows 2000) Opera 6.0*"
   ["parent"]=>
@@ -325,7 +325,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(68) "§^mozilla/4\.0 \(compatible; msie 5\.0; mac_powerpc\) opera 5\.0.*$§"
+  string(68) "~^mozilla/4\.0 \(compatible; msie 5\.0; mac_powerpc\) opera 5\.0.*$~"
   ["browser_name_pattern"]=>
   string(58) "Mozilla/4.0 (compatible; MSIE 5.0; Mac_PowerPC) Opera 5.0*"
   ["parent"]=>
@@ -397,7 +397,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(65) "§^mozilla/4\.0 \(compatible; msie 6\.0; .*windows nt 5\.1.*\).*$§"
+  string(65) "~^mozilla/4\.0 \(compatible; msie 6\.0; .*windows nt 5\.1.*\).*$~"
   ["browser_name_pattern"]=>
   string(53) "Mozilla/4.0 (compatible; MSIE 6.0; *Windows NT 5.1*)*"
   ["parent"]=>
@@ -469,7 +469,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(40) "§^opera/9\.0.* \(windows nt 5\.1.*\).*$§"
+  string(40) "~^opera/9\.0.* \(windows nt 5\.1.*\).*$~"
   ["browser_name_pattern"]=>
   string(29) "Opera/9.0* (Windows NT 5.1*)*"
   ["parent"]=>
@@ -541,7 +541,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(47) "§^opera/9\.2.* \(macintosh; .*mac os x;.*\).*$§"
+  string(47) "~^opera/9\.2.* \(macintosh; .*mac os x;.*\).*$~"
   ["browser_name_pattern"]=>
   string(36) "Opera/9.2* (Macintosh; *Mac OS X;*)*"
   ["parent"]=>
@@ -613,7 +613,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(65) "§^mozilla/4\.0 \(compatible; msie 6\.0; .*windows nt 5\.1.*\).*$§"
+  string(65) "~^mozilla/4\.0 \(compatible; msie 6\.0; .*windows nt 5\.1.*\).*$~"
   ["browser_name_pattern"]=>
   string(53) "Mozilla/4.0 (compatible; MSIE 6.0; *Windows NT 5.1*)*"
   ["parent"]=>
@@ -685,7 +685,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(65) "§^mozilla/4\.0 \(compatible; msie 6\.0; .*windows nt 5\.1.*\).*$§"
+  string(65) "~^mozilla/4\.0 \(compatible; msie 6\.0; .*windows nt 5\.1.*\).*$~"
   ["browser_name_pattern"]=>
   string(53) "Mozilla/4.0 (compatible; MSIE 6.0; *Windows NT 5.1*)*"
   ["parent"]=>
@@ -757,7 +757,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(59) "§^mozilla/.\.. \(compatible; msie 5\.2.*; .*mac_powerpc.*$§"
+  string(59) "~^mozilla/.\.. \(compatible; msie 5\.2.*; .*mac_powerpc.*$~"
   ["browser_name_pattern"]=>
   string(49) "Mozilla/?.? (compatible; MSIE 5.2*; *Mac_PowerPC*"
   ["parent"]=>
@@ -829,7 +829,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(59) "§^mozilla/.\.. \(compatible; msie 5\.0.*; .*mac_powerpc.*$§"
+  string(59) "~^mozilla/.\.. \(compatible; msie 5\.0.*; .*mac_powerpc.*$~"
   ["browser_name_pattern"]=>
   string(49) "Mozilla/?.? (compatible; MSIE 5.0*; *Mac_PowerPC*"
   ["parent"]=>
@@ -901,7 +901,7 @@ array(35) {
 }
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>
@@ -971,7 +971,7 @@ array(34) {
 }
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>
@@ -1041,7 +1041,7 @@ array(34) {
 }
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>
@@ -1111,7 +1111,7 @@ array(34) {
 }
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>
@@ -1181,7 +1181,7 @@ array(34) {
 }
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>
@@ -1251,7 +1251,7 @@ array(34) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(99) "§^mozilla/5\.0 \(windows; .; windows nt 6\.0; .*\) applewebkit/.* \(.*\) version/3\.0.* safari/.*$§"
+  string(99) "~^mozilla/5\.0 \(windows; .; windows nt 6\.0; .*\) applewebkit/.* \(.*\) version/3\.0.* safari/.*$~"
   ["browser_name_pattern"]=>
   string(83) "Mozilla/5.0 (Windows; ?; Windows NT 6.0; *) AppleWebKit/* (*) Version/3.0* Safari/*"
   ["parent"]=>
@@ -1323,7 +1323,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(99) "§^mozilla/.* \(iphone; .; .*mac os x.*\) applewebkit/.* \(.*\) version/.*\..* mobile/.* safari/.*$§"
+  string(99) "~^mozilla/.* \(iphone; .; .*mac os x.*\) applewebkit/.* \(.*\) version/.*\..* mobile/.* safari/.*$~"
   ["browser_name_pattern"]=>
   string(81) "Mozilla/* (iPhone; ?; *Mac OS X*) AppleWebKit/* (*) Version/*.* Mobile/* Safari/*"
   ["parent"]=>
@@ -1395,7 +1395,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(99) "§^mozilla/5\.0 \(ipod; u; .*mac os x; en\) applewebkit/.* \(.*\) version/3\.0 mobile/.* safari/.*$§"
+  string(99) "~^mozilla/5\.0 \(ipod; u; .*mac os x; en\) applewebkit/.* \(.*\) version/3\.0 mobile/.* safari/.*$~"
   ["browser_name_pattern"]=>
   string(84) "Mozilla/5.0 (iPod; U; *Mac OS X; en) AppleWebKit/* (*) Version/3.0 Mobile/* Safari/*"
   ["parent"]=>

--- a/ext/standard/tests/misc/get_browser_error.phpt
+++ b/ext/standard/tests/misc/get_browser_error.phpt
@@ -42,7 +42,7 @@ var_dump( get_browser( null, 'foobar' ) );
 *** Testing get_browser() : error functionality ***
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>

--- a/ext/standard/tests/misc/get_browser_variation1.phpt
+++ b/ext/standard/tests/misc/get_browser_variation1.phpt
@@ -38,7 +38,7 @@ for( $x = 20; $x < $count; $x++) {
 *** Testing get_browser() : variation functionality: extra browser names ***
 array(35) {
   ["browser_name_regex"]=>
-  string(94) "§^mozilla/5\.0 \(macintosh; .; .*mac os x.*\) applewebkit/.* \(.*\) version/3\.1.* safari/.*$§"
+  string(94) "~^mozilla/5\.0 \(macintosh; .; .*mac os x.*\) applewebkit/.* \(.*\) version/3\.1.* safari/.*$~"
   ["browser_name_pattern"]=>
   string(78) "Mozilla/5.0 (Macintosh; ?; *Mac OS X*) AppleWebKit/* (*) Version/3.1* Safari/*"
   ["parent"]=>
@@ -110,7 +110,7 @@ array(35) {
 }
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>
@@ -180,7 +180,7 @@ array(34) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(67) "§^mozilla/5\.0 \(macintosh; .*mac os x.*\) gecko/.* camino/1\.5.*$§"
+  string(67) "~^mozilla/5\.0 \(macintosh; .*mac os x.*\) gecko/.* camino/1\.5.*$~"
   ["browser_name_pattern"]=>
   string(55) "Mozilla/5.0 (Macintosh; *Mac OS X*) Gecko/* Camino/1.5*"
   ["parent"]=>
@@ -252,7 +252,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(29) "§^.*konqueror/3\.1.*linux.*$§"
+  string(29) "~^.*konqueror/3\.1.*linux.*$~"
   ["browser_name_pattern"]=>
   string(21) "*Konqueror/3.1*Linux*"
   ["parent"]=>
@@ -324,7 +324,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(29) "§^.*konqueror/3\.1.*linux.*$§"
+  string(29) "~^.*konqueror/3\.1.*linux.*$~"
   ["browser_name_pattern"]=>
   string(21) "*Konqueror/3.1*Linux*"
   ["parent"]=>
@@ -396,7 +396,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(21) "§^.*konqueror/2\..*$§"
+  string(21) "~^.*konqueror/2\..*$~"
   ["browser_name_pattern"]=>
   string(14) "*Konqueror/2.*"
   ["parent"]=>
@@ -468,7 +468,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(70) "§^mozilla/5\.0 \(windows; .; windows nt 5\.1; .*rv:1\.4.*\) gecko/.*$§"
+  string(70) "~^mozilla/5\.0 \(windows; .; windows nt 5\.1; .*rv:1\.4.*\) gecko/.*$~"
   ["browser_name_pattern"]=>
   string(58) "Mozilla/5.0 (Windows; ?; Windows NT 5.1; *rv:1.4*) Gecko/*"
   ["parent"]=>
@@ -540,7 +540,7 @@ array(35) {
 }
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>
@@ -610,7 +610,7 @@ array(34) {
 }
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>
@@ -680,7 +680,7 @@ array(34) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(57) "§^mozilla/5\.0 \(x11; .*linux.*; .*rv:1\.7.*\) gecko/.*$§"
+  string(57) "~^mozilla/5\.0 \(x11; .*linux.*; .*rv:1\.7.*\) gecko/.*$~"
   ["browser_name_pattern"]=>
   string(44) "Mozilla/5.0 (X11; *Linux*; *rv:1.7*) Gecko/*"
   ["parent"]=>
@@ -752,7 +752,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(70) "§^mozilla/5\.0 \(windows; .; windows nt 5\.1; .*rv:1\.9.*\) gecko/.*$§"
+  string(70) "~^mozilla/5\.0 \(windows; .; windows nt 5\.1; .*rv:1\.9.*\) gecko/.*$~"
   ["browser_name_pattern"]=>
   string(58) "Mozilla/5.0 (Windows; ?; Windows NT 5.1; *rv:1.9*) Gecko/*"
   ["parent"]=>
@@ -824,7 +824,7 @@ array(35) {
 }
 array(34) {
   ["browser_name_regex"]=>
-  string(6) "§^.*$§"
+  string(6) "~^.*$~"
   ["browser_name_pattern"]=>
   string(1) "*"
   ["browser"]=>
@@ -894,7 +894,7 @@ array(34) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(75) "§^mozilla/5\.0 \(x11; .*; linux.*; .*; rv:1\..*\) gecko/.* firebird/0\..*$§"
+  string(75) "~^mozilla/5\.0 \(x11; .*; linux.*; .*; rv:1\..*\) gecko/.* firebird/0\..*$~"
   ["browser_name_pattern"]=>
   string(60) "Mozilla/5.0 (X11; *; Linux*; *; rv:1.*) Gecko/* Firebird/0.*"
   ["parent"]=>
@@ -966,7 +966,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(57) "§^mozilla/5\.0 \(x11; .*linux.*; .*rv:1\.4.*\) gecko/.*$§"
+  string(57) "~^mozilla/5\.0 \(x11; .*linux.*; .*rv:1\.4.*\) gecko/.*$~"
   ["browser_name_pattern"]=>
   string(44) "Mozilla/5.0 (X11; *Linux*; *rv:1.4*) Gecko/*"
   ["parent"]=>
@@ -1038,7 +1038,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(86) "§^mozilla/5\.0 \(windows; .*; windows nt 5\.1; .*; rv:1\..*\) gecko/.* firefox/0\..*$§"
+  string(86) "~^mozilla/5\.0 \(windows; .*; windows nt 5\.1; .*; rv:1\..*\) gecko/.* firefox/0\..*$~"
   ["browser_name_pattern"]=>
   string(71) "Mozilla/5.0 (Windows; *; Windows NT 5.1; *; rv:1.*) Gecko/* Firefox/0.*"
   ["parent"]=>
@@ -1110,7 +1110,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(41) "§^mozilla/5\.0 \(.*rv:1\.8.*\) gecko/.*$§"
+  string(41) "~^mozilla/5\.0 \(.*rv:1\.8.*\) gecko/.*$~"
   ["browser_name_pattern"]=>
   string(30) "Mozilla/5.0 (*rv:1.8*) Gecko/*"
   ["parent"]=>
@@ -1182,7 +1182,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(41) "§^mozilla/5\.0 \(.*rv:1\.8.*\) gecko/.*$§"
+  string(41) "~^mozilla/5\.0 \(.*rv:1\.8.*\) gecko/.*$~"
   ["browser_name_pattern"]=>
   string(30) "Mozilla/5.0 (*rv:1.8*) Gecko/*"
   ["parent"]=>
@@ -1254,7 +1254,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(76) "§^mozilla/5\.0 \(x11; .*; sunos.*; .*; rv:1\.8.*\) gecko/.* firefox/2\.0.*$§"
+  string(76) "~^mozilla/5\.0 \(x11; .*; sunos.*; .*; rv:1\.8.*\) gecko/.* firefox/2\.0.*$~"
   ["browser_name_pattern"]=>
   string(61) "Mozilla/5.0 (X11; *; SunOS*; *; rv:1.8*) Gecko/* Firefox/2.0*"
   ["parent"]=>
@@ -1326,7 +1326,7 @@ array(35) {
 }
 array(35) {
   ["browser_name_regex"]=>
-  string(78) "§^mozilla/5\.0 \(x11; .*; .*linux.*; .*; rv:1\.8.*\) gecko/.* firefox/2\.0.*$§"
+  string(78) "~^mozilla/5\.0 \(x11; .*; .*linux.*; .*; rv:1\.8.*\) gecko/.* firefox/2\.0.*$~"
   ["browser_name_pattern"]=>
   string(62) "Mozilla/5.0 (X11; *; *Linux*; *; rv:1.8*) Gecko/* Firefox/2.0*"
   ["parent"]=>


### PR DESCRIPTION
Fixes [bug 68012](https://bugs.php.net/bug.php?id=68021).

Uses the tilde as the expression delimiter to make them ASCII compatible instead of `\xA7`.