### PR TITLE
DateTimeZone::getOffset() now accepts a DateTimeInterface

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -326,11 +326,11 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_timezone_offset_get, 0, 0, 2)
 	ZEND_ARG_INFO(0, object)
-	ZEND_ARG_INFO(0, datetime)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_timezone_method_offset_get, 0, 0, 1)
-	ZEND_ARG_INFO(0, datetime)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_timezone_transitions_get, 0, 0, 1)
@@ -3809,13 +3809,13 @@ PHP_FUNCTION(timezone_offset_get)
 	php_date_obj        *dateobj;
 	timelib_time_offset *offset;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "OO", &object, date_ce_timezone, &dateobject, date_ce_date) == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "OO", &object, date_ce_timezone, &dateobject, date_ce_interface) == FAILURE) {
 		RETURN_FALSE;
 	}
 	tzobj = Z_PHPTIMEZONE_P(object);
 	DATE_CHECK_INITIALIZED(tzobj->initialized, DateTimeZone);
 	dateobj = Z_PHPDATE_P(dateobject);
-	DATE_CHECK_INITIALIZED(dateobj->time, DateTime);
+	DATE_CHECK_INITIALIZED(dateobj->time, DateTimeInterface);
 
 	switch (tzobj->type) {
 		case TIMELIB_ZONETYPE_ID:

--- a/ext/date/tests/68062.phpt
+++ b/ext/date/tests/68062.phpt
@@ -1,0 +1,13 @@
+--TEST--
+DateTimeZone::getOffset() accepts a DateTimeInterface object
+--FILE--
+<?php
+
+$tz = new DateTimeZone('Europe/London');
+$dt = new DateTimeImmutable('2014-09-20', $tz);
+
+echo $tz->getOffset($dt);
+echo $tz->getOffset(1);
+--EXPECTF--
+3600
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, integer given in %s


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=68062

Should be backported to PHP-5.6 and PHP-5.5.
