### PR TITLE
DateTimeZone::getOffset() now accepts a DateTimeInterface

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -325,12 +325,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_timezone_name_from_abbr, 0, 0, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_timezone_offset_get, 0, 0, 2)
-	ZEND_ARG_INFO(0, object)
-	ZEND_ARG_INFO(0, datetime)
+	ZEND_ARG_OBJ_INFO(0, object, DateTimeZone, 0)
+	ZEND_ARG_OBJ_INFO(0, datetime, DateTimeInterface, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_timezone_method_offset_get, 0, 0, 1)
-	ZEND_ARG_INFO(0, datetime)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_timezone_transitions_get, 0, 0, 1)
@@ -3799,7 +3799,7 @@ PHP_FUNCTION(timezone_name_from_abbr)
 }
 /* }}} */
 
-/* {{{ proto long timezone_offset_get(DateTimeZone object, DateTime object)
+/* {{{ proto long timezone_offset_get(DateTimeZone object, DateTimeInterface datetime)
    Returns the timezone offset.
 */
 PHP_FUNCTION(timezone_offset_get)
@@ -3809,13 +3809,13 @@ PHP_FUNCTION(timezone_offset_get)
 	php_date_obj        *dateobj;
 	timelib_time_offset *offset;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "OO", &object, date_ce_timezone, &dateobject, date_ce_date) == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "OO", &object, date_ce_timezone, &dateobject, date_ce_interface) == FAILURE) {
 		RETURN_FALSE;
 	}
 	tzobj = Z_PHPTIMEZONE_P(object);
 	DATE_CHECK_INITIALIZED(tzobj->initialized, DateTimeZone);
 	dateobj = Z_PHPDATE_P(dateobject);
-	DATE_CHECK_INITIALIZED(dateobj->time, DateTime);
+	DATE_CHECK_INITIALIZED(dateobj->time, DateTimeInterface);
 
 	switch (tzobj->type) {
 		case TIMELIB_ZONETYPE_ID:

--- a/ext/date/tests/014.phpt
+++ b/ext/date/tests/014.phpt
@@ -37,6 +37,4 @@ Warning: timezone_offset_get() expects exactly 2 parameters, 0 given in %s on li
 bool(false)
 int(0)
 
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, object given in %s on line %d
-bool(false)
-Done
+Catchable fatal error: Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, instance of DateTime given in %s

--- a/ext/date/tests/68062.phpt
+++ b/ext/date/tests/68062.phpt
@@ -1,0 +1,13 @@
+--TEST--
+DateTimeZone::getOffset() accepts a DateTimeInterface object
+--FILE--
+<?php
+
+$tz = new DateTimeZone('Europe/London');
+$dt = new DateTimeImmutable('2014-09-20', $tz);
+
+echo $tz->getOffset($dt);
+echo $tz->getOffset(1);
+--EXPECTF--
+3600
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, integer given in %s

--- a/ext/date/tests/DateTimeZone_getOffset_variation1.phpt
+++ b/ext/date/tests/DateTimeZone_getOffset_variation1.phpt
@@ -112,141 +112,141 @@ fclose( $file_handle );
 
 -- int 0 --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, integer given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, integer given in %s on line %d
 bool(false)
 
 -- int 1 --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, integer given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, integer given in %s on line %d
 bool(false)
 
 -- int 12345 --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, integer given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, integer given in %s on line %d
 bool(false)
 
 -- int -12345 --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, integer given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, integer given in %s on line %d
 bool(false)
 
 -- float 10.5 --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, double given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, double given in %s on line %d
 bool(false)
 
 -- float -10.5 --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, double given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, double given in %s on line %d
 bool(false)
 
 -- float .5 --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, double given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, double given in %s on line %d
 bool(false)
 
 -- empty array --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, array given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, array given in %s on line %d
 bool(false)
 
 -- int indexed array --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, array given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, array given in %s on line %d
 bool(false)
 
 -- associative array --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, array given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, array given in %s on line %d
 bool(false)
 
 -- nested arrays --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, array given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, array given in %s on line %d
 bool(false)
 
 -- uppercase NULL --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, null given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, null given in %s on line %d
 bool(false)
 
 -- lowercase null --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, null given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, null given in %s on line %d
 bool(false)
 
 -- lowercase true --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, boolean given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, boolean given in %s on line %d
 bool(false)
 
 -- lowercase false --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, boolean given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, boolean given in %s on line %d
 bool(false)
 
 -- uppercase TRUE --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, boolean given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, boolean given in %s on line %d
 bool(false)
 
 -- uppercase FALSE --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, boolean given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, boolean given in %s on line %d
 bool(false)
 
 -- empty string DQ --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, string given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, string given in %s on line %d
 bool(false)
 
 -- empty string SQ --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, string given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, string given in %s on line %d
 bool(false)
 
 -- string DQ --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, string given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, string given in %s on line %d
 bool(false)
 
 -- string SQ --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, string given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, string given in %s on line %d
 bool(false)
 
 -- mixed case string --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, string given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, string given in %s on line %d
 bool(false)
 
 -- heredoc --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, string given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, string given in %s on line %d
 bool(false)
 
 -- instance of classWithToString --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, object given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, object given in %s on line %d
 bool(false)
 
 -- instance of classWithoutToString --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, object given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, object given in %s on line %d
 bool(false)
 
 -- undefined var --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, null given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, null given in %s on line %d
 bool(false)
 
 -- unset var --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, null given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, null given in %s on line %d
 bool(false)
 
 -- resource --
 
-Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTime, resource given in %s on line %d
+Warning: DateTimeZone::getOffset() expects parameter 1 to be DateTimeInterface, resource given in %s on line %d
 bool(false)
 ===DONE===

--- a/ext/date/tests/bug67118.phpt
+++ b/ext/date/tests/bug67118.phpt
@@ -23,4 +23,6 @@ class mydt extends datetime
 new mydt("Funktionsansvarig rådgivning och juridik", "UTC");
 ?>
 --EXPECTF--
-Fatal error: Call to a member function format() on null in %sbug67118.php on line %d
+
+Warning: DateTime::format(): The DateTime object has not been correctly initialized by its constructor in %s on line %d
+Bad date

--- a/ext/date/tests/bug67118_2.phpt
+++ b/ext/date/tests/bug67118_2.phpt
@@ -24,5 +24,12 @@ Done
 --EXPECTF--
 First try
 Second try
-NULL
+object(Foo)#1 (3) {
+  ["date"]=>
+  string(26) "2007-09-12 15:49:12.000000"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(3) "UTC"
+}
 Done

--- a/ext/date/tests/timezone_offset_get_error.phpt
+++ b/ext/date/tests/timezone_offset_get_error.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test timezone_offset_get() function : error conditions 
+Test timezone_offset_get() function : error conditions
 --FILE--
 <?php
 /* Prototype  : int timezone_offset_get  ( DateTimeZone $object  , DateTime $datetime  )
@@ -7,12 +7,20 @@ Test timezone_offset_get() function : error conditions
  * Source code: ext/date/php_date.c
  * Alias to functions: DateTimeZone::getOffset
  */
- 
-//Set the default time zone 
+
+//Set the default time zone
 date_default_timezone_set("GMT");
 $tz = timezone_open("Europe/London");
 $date = date_create("GMT");
- 
+
+set_error_handler('err');
+
+function err($errno, $errstr) {
+	if ($errno === E_RECOVERABLE_ERROR) {
+		var_dump($errstr);
+	}
+}
+
 echo "*** Testing timezone_offset_get() : error conditions ***\n";
 
 echo "\n-- Testing timezone_offset_get() function with zero arguments --\n";
@@ -27,7 +35,7 @@ var_dump( timezone_offset_get($tz, $date, $extra_arg) );
 
 echo "\n-- Testing timezone_offset_get() function with an invalid values for \$object argument --\n";
 $invalid_obj = new stdClass();
-var_dump( timezone_offset_get($invalid_obj, $date) );  
+var_dump( timezone_offset_get($invalid_obj, $date) );
 $invalid_obj = 10;
 var_dump( timezone_offset_get($invalid_obj, $date) );
 $invalid_obj = null;
@@ -35,50 +43,38 @@ var_dump( timezone_offset_get($invalid_obj, $date) );
 
 echo "\n-- Testing timezone_offset_get() function with an invalid values for \$datetime argument --\n";
 $invalid_obj = new stdClass();
-var_dump( timezone_offset_get($tz, $invalid_obj) );  
+var_dump( timezone_offset_get($tz, $invalid_obj) );
 $invalid_obj = 10;
 var_dump( timezone_offset_get($tz, $invalid_obj) );
 $invalid_obj = null;
-var_dump( timezone_offset_get($tz, $invalid_obj) );  
+var_dump( timezone_offset_get($tz, $invalid_obj) );
 ?>
 ===DONE===
 --EXPECTF--
 *** Testing timezone_offset_get() : error conditions ***
 
 -- Testing timezone_offset_get() function with zero arguments --
-
-Warning: timezone_offset_get() expects exactly 2 parameters, 0 given in %s on line %d
 bool(false)
 
 -- Testing timezone_offset_get() function with less than expected no. of arguments --
-
-Warning: timezone_offset_get() expects exactly 2 parameters, 1 given in %s on line %d
 bool(false)
 
 -- Testing timezone_offset_get() function with more than expected no. of arguments --
-
-Warning: timezone_offset_get() expects exactly 2 parameters, 3 given in %s on line %d
 bool(false)
 
 -- Testing timezone_offset_get() function with an invalid values for $object argument --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, object given in %s on line %d
+string(%d) "Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, instance of stdClass given"
 bool(false)
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, integer given in %s on line %d
+string(%d) "Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, integer given"
 bool(false)
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, null given in %s on line %d
+string(%d) "Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, null given"
 bool(false)
 
 -- Testing timezone_offset_get() function with an invalid values for $datetime argument --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, object given in %s on line %d
+string(%d) "Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, instance of stdClass given"
 bool(false)
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, integer given in %s on line %d
+string(%d) "Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, integer given"
 bool(false)
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, null given in %s on line %d
+string(%d) "Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, null given"
 bool(false)
 ===DONE===

--- a/ext/date/tests/timezone_offset_get_variation1.phpt
+++ b/ext/date/tests/timezone_offset_get_variation1.phpt
@@ -13,6 +13,14 @@ echo "*** Testing timezone_offset_get() : usage variation -  unexpected values t
 //Set the default time zone 
 date_default_timezone_set("Europe/London");
 
+set_error_handler('handler');
+
+function handler($errno, $errstr) {
+	if ($errno === E_RECOVERABLE_ERROR) {
+		echo $errstr . "\n";
+	}
+}
+
 //get an unset variable
 $unset_var = 10;
 unset ($unset_var);
@@ -111,142 +119,114 @@ fclose( $file_handle );
 *** Testing timezone_offset_get() : usage variation -  unexpected values to first argument $object***
 
 -- int 0 --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, integer given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, integer given
 bool(false)
 
 -- int 1 --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, integer given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, integer given
 bool(false)
 
 -- int 12345 --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, integer given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, integer given
 bool(false)
 
 -- int -12345 --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, integer given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, integer given
 bool(false)
 
 -- float 10.5 --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, double given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, double given
 bool(false)
 
 -- float -10.5 --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, double given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, double given
 bool(false)
 
 -- float .5 --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, double given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, double given
 bool(false)
 
 -- empty array --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, array given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, array given
 bool(false)
 
 -- int indexed array --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, array given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, array given
 bool(false)
 
 -- associative array --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, array given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, array given
 bool(false)
 
 -- nested arrays --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, array given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, array given
 bool(false)
 
 -- uppercase NULL --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, null given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, null given
 bool(false)
 
 -- lowercase null --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, null given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, null given
 bool(false)
 
 -- lowercase true --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, boolean given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, boolean given
 bool(false)
 
 -- lowercase false --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, boolean given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, boolean given
 bool(false)
 
 -- uppercase TRUE --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, boolean given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, boolean given
 bool(false)
 
 -- uppercase FALSE --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, boolean given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, boolean given
 bool(false)
 
 -- empty string DQ --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, string given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, string given
 bool(false)
 
 -- empty string SQ --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, string given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, string given
 bool(false)
 
 -- string DQ --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, string given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, string given
 bool(false)
 
 -- string SQ --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, string given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, string given
 bool(false)
 
 -- mixed case string --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, string given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, string given
 bool(false)
 
 -- heredoc --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, string given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, string given
 bool(false)
 
 -- instance of classWithToString --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, object given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, instance of classWithToString given
 bool(false)
 
 -- instance of classWithoutToString --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, object given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, instance of classWithoutToString given
 bool(false)
 
 -- undefined var --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, null given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, null given
 bool(false)
 
 -- unset var --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, null given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, null given
 bool(false)
 
 -- resource --
-
-Warning: timezone_offset_get() expects parameter 1 to be DateTimeZone, resource given in %s on line %d
+Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, resource given
 bool(false)
 ===DONE===

--- a/ext/date/tests/timezone_offset_get_variation2.phpt
+++ b/ext/date/tests/timezone_offset_get_variation2.phpt
@@ -13,6 +13,14 @@ echo "*** Testing timezone_offset_get() : usage variation -  unexpected values t
 //Set the default time zone 
 date_default_timezone_set("Europe/London");
 
+set_error_handler('handler');
+
+function handler($errno, $errstr) {
+	if ($errno === E_RECOVERABLE_ERROR) {
+		echo $errstr . "\n";
+	}
+}
+
 //get an unset variable
 $unset_var = 10;
 unset ($unset_var);
@@ -111,142 +119,114 @@ fclose( $file_handle );
 *** Testing timezone_offset_get() : usage variation -  unexpected values to second argument $datetime***
 
 -- int 0 --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, integer given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, integer given
 bool(false)
 
 -- int 1 --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, integer given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, integer given
 bool(false)
 
 -- int 12345 --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, integer given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, integer given
 bool(false)
 
 -- int -12345 --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, integer given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, integer given
 bool(false)
 
 -- float 10.5 --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, double given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, double given
 bool(false)
 
 -- float -10.5 --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, double given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, double given
 bool(false)
 
 -- float .5 --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, double given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, double given
 bool(false)
 
 -- empty array --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, array given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, array given
 bool(false)
 
 -- int indexed array --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, array given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, array given
 bool(false)
 
 -- associative array --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, array given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, array given
 bool(false)
 
 -- nested arrays --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, array given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, array given
 bool(false)
 
 -- uppercase NULL --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, null given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, null given
 bool(false)
 
 -- lowercase null --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, null given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, null given
 bool(false)
 
 -- lowercase true --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, boolean given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, boolean given
 bool(false)
 
 -- lowercase false --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, boolean given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, boolean given
 bool(false)
 
 -- uppercase TRUE --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, boolean given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, boolean given
 bool(false)
 
 -- uppercase FALSE --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, boolean given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, boolean given
 bool(false)
 
 -- empty string DQ --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, string given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, string given
 bool(false)
 
 -- empty string SQ --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, string given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, string given
 bool(false)
 
 -- string DQ --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, string given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, string given
 bool(false)
 
 -- string SQ --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, string given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, string given
 bool(false)
 
 -- mixed case string --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, string given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, string given
 bool(false)
 
 -- heredoc --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, string given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, string given
 bool(false)
 
 -- instance of classWithToString --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, object given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, instance of classWithToString given
 bool(false)
 
 -- instance of classWithoutToString --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, object given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, instance of classWithoutToString given
 bool(false)
 
 -- undefined var --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, null given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, null given
 bool(false)
 
 -- unset var --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, null given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, null given
 bool(false)
 
 -- resource --
-
-Warning: timezone_offset_get() expects parameter 2 to be DateTime, resource given in %s on line %d
+Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, resource given
 bool(false)
 ===DONE===


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=68062

This is a BC break, since the arguments are now declared using OBJ_ARG_INFO instead of plain ARG_INFO.

Should it be backported to 5.*, it would have to be kept with ARG_INFO.
