### PR TITLE
Bug #34380: preserve errno for stream_select and stream_socket_pair

### DIFF
--- a/ext/posix/php_posix.h
+++ b/ext/posix/php_posix.h
@@ -114,6 +114,7 @@ PHP_FUNCTION(posix_getrlimit);
 PHP_FUNCTION(posix_initgroups);
 #endif
 
+void php_posix_set_last_error(int);
 PHP_FUNCTION(posix_get_last_error);
 PHP_FUNCTION(posix_strerror);
 

--- a/ext/posix/php_posix.h
+++ b/ext/posix/php_posix.h
@@ -114,7 +114,7 @@ PHP_FUNCTION(posix_getrlimit);
 PHP_FUNCTION(posix_initgroups);
 #endif
 
-void php_posix_set_last_error(int);
+void php_posix_set_last_error(int TSRMLS_DC);
 PHP_FUNCTION(posix_get_last_error);
 PHP_FUNCTION(posix_strerror);
 

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -1322,7 +1322,7 @@ PHP_FUNCTION(posix_getrlimit)
 
 #endif /* HAVE_GETRLIMIT */
 
-void php_posix_set_last_error(int error) /* {{{ */
+void php_posix_set_last_error(int error TSRMLS_DC) /* {{{ */
 {
 	POSIX_G(last_error) = error;
 }

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -1322,6 +1322,12 @@ PHP_FUNCTION(posix_getrlimit)
 
 #endif /* HAVE_GETRLIMIT */
 
+void php_posix_set_last_error(int error) /* {{{ */
+{
+	POSIX_G(last_error) = error;
+}
+/* }}} */
+
 /* {{{ proto int posix_get_last_error(void)
    Retrieve the error number set by the last posix function which failed. */
 PHP_FUNCTION(posix_get_last_error)

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -67,7 +67,7 @@ PHP_FUNCTION(stream_socket_pair)
 	if (0 != socketpair((int)domain, (int)type, (int)protocol, pair)) {
 		char errbuf[256];
 		if (zend_hash_str_exists(&module_registry, "posix", sizeof("posix")-1))
-			php_posix_set_last_error(php_socket_errno());
+			php_posix_set_last_error(php_socket_errno() TSRMLS_CC);
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "failed to create sockets: [%d]: %s",
 			php_socket_errno(), php_socket_strerror(php_socket_errno(), errbuf, sizeof(errbuf)));
 		RETURN_FALSE;
@@ -816,7 +816,7 @@ PHP_FUNCTION(stream_select)
 
 	if (retval == -1) {
 		if (zend_hash_str_exists(&module_registry, "posix", sizeof("posix")-1))
-			php_posix_set_last_error(errno);
+			php_posix_set_last_error(errno TSRMLS_CC);
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to select [%d]: %s (max_fd=%d)",
 				errno, strerror(errno), max_fd);
 		RETURN_FALSE;

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -30,6 +30,9 @@
 #include "streamsfuncs.h"
 #include "php_network.h"
 #include "php_string.h"
+#include "ext/posix/php_posix.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(posix)
 
 #ifndef PHP_WIN32
 #define php_select(m, r, w, e, t)	select(m, r, w, e, t)
@@ -62,6 +65,7 @@ PHP_FUNCTION(stream_socket_pair)
 
 	if (0 != socketpair((int)domain, (int)type, (int)protocol, pair)) {
 		char errbuf[256];
+		POSIX_G(last_error) = php_socket_errno();
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "failed to create sockets: [%d]: %s",
 			php_socket_errno(), php_socket_strerror(php_socket_errno(), errbuf, sizeof(errbuf)));
 		RETURN_FALSE;
@@ -809,6 +813,7 @@ PHP_FUNCTION(stream_select)
 	retval = php_select(max_fd+1, &rfds, &wfds, &efds, tv_p);
 
 	if (retval == -1) {
+		POSIX_G(last_error) = errno;
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to select [%d]: %s (max_fd=%d)",
 				errno, strerror(errno), max_fd);
 		RETURN_FALSE;

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -30,9 +30,10 @@
 #include "streamsfuncs.h"
 #include "php_network.h"
 #include "php_string.h"
-#include "ext/posix/php_posix.h"
 
-ZEND_EXTERN_MODULE_GLOBALS(posix)
+#if HAVE_POSIX
+#include "ext/posix/php_posix.h"
+#endif
 
 #ifndef PHP_WIN32
 #define php_select(m, r, w, e, t)	select(m, r, w, e, t)
@@ -65,7 +66,8 @@ PHP_FUNCTION(stream_socket_pair)
 
 	if (0 != socketpair((int)domain, (int)type, (int)protocol, pair)) {
 		char errbuf[256];
-		POSIX_G(last_error) = php_socket_errno();
+		if (zend_hash_str_exists(&module_registry, "posix", sizeof("posix")-1))
+			php_posix_set_last_error(php_socket_errno());
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "failed to create sockets: [%d]: %s",
 			php_socket_errno(), php_socket_strerror(php_socket_errno(), errbuf, sizeof(errbuf)));
 		RETURN_FALSE;
@@ -813,7 +815,8 @@ PHP_FUNCTION(stream_select)
 	retval = php_select(max_fd+1, &rfds, &wfds, &efds, tv_p);
 
 	if (retval == -1) {
-		POSIX_G(last_error) = errno;
+		if (zend_hash_str_exists(&module_registry, "posix", sizeof("posix")-1))
+			php_posix_set_last_error(errno);
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to select [%d]: %s (max_fd=%d)",
 				errno, strerror(errno), max_fd);
 		RETURN_FALSE;

--- a/ext/standard/tests/streams/bug34380_01.phpt
+++ b/ext/standard/tests/streams/bug34380_01.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #34380: stream_socket_pair should set posix_globals.last_error on failure
+--SKIPIF--
+<?php
+if( substr(PHP_OS, 0, 3) == "WIN" )
+	die("skip. Do not run on Windows");
+?>
+--FILE--
+<?php
+
+// invalid type to force EOPNOTSUPP (only STREAM_PF_UNIX is supported on *nix)
+$sockets = stream_socket_pair(STREAM_PF_INET, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+var_dump($sockets);
+var_dump(posix_get_last_error());
+?>
+--EXPECTF--
+
+Warning: stream_socket_pair(): failed to create sockets: [95]: Operation not supported in %s on line %d
+bool(false)
+int(95)

--- a/ext/standard/tests/streams/bug34380_01.phpt
+++ b/ext/standard/tests/streams/bug34380_01.phpt
@@ -2,8 +2,10 @@
 Bug #34380: stream_socket_pair should set posix_globals.last_error on failure
 --SKIPIF--
 <?php
-if( substr(PHP_OS, 0, 3) == "WIN" )
+if (substr(PHP_OS, 0, 3) == "WIN")
 	die("skip. Do not run on Windows");
+if (!extension_loaded("posix"))
+	die("skip. posix extension must be loaded");
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/streams/bug34380_02.phpt
+++ b/ext/standard/tests/streams/bug34380_02.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Bug #34380: stream_select should set posix_globals.last_error on failure
+--SKIPIF--
+<?php
+if( substr(PHP_OS, 0, 3) == "WIN" )
+	die("skip. Do not run on Windows");
+?>
+--FILE--
+<?php
+
+function handler($signo) {}
+pcntl_signal(SIGUSR2, "handler");
+
+$pid = pcntl_fork();
+if ($pid == -1) {
+	die('could not fork');
+} else if ($pid) {
+	$open_spec = array(
+		0 => array('pipe', 'r'),
+		1 => array('pipe', 'w'),
+		2 => array('pipe', 'w')
+	);
+	$proc = proc_open('/bin/sleep 60', $open_spec, $pipes, NULL, $_ENV);
+	$reads = array($pipes[1]);
+	$e = NULL;
+
+	// should get EINTR after child sends us a signal
+	$fds = stream_select($reads, $e, $e, 60);
+	var_dump($fds);
+	var_dump(posix_get_last_error());
+	proc_terminate($proc);
+} else {
+	// racy
+	sleep(2);
+	posix_kill(posix_getppid(), SIGUSR2);
+}
+?>
+--EXPECTF--
+
+Warning: stream_select(): unable to select [4]: Interrupted system call (max_fd=%d) in %s on line %d
+bool(false)
+int(4)

--- a/ext/standard/tests/streams/bug34380_02.phpt
+++ b/ext/standard/tests/streams/bug34380_02.phpt
@@ -2,8 +2,10 @@
 Bug #34380: stream_select should set posix_globals.last_error on failure
 --SKIPIF--
 <?php
-if( substr(PHP_OS, 0, 3) == "WIN" )
+if (substr(PHP_OS, 0, 3) == "WIN")
 	die("skip. Do not run on Windows");
+if (!extension_loaded("posix") || !extension_loaded('pcntl'))
+	die("skip. posix and pcntl extensions must be loaded");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
When the system calls underneath stream_select() and stream_socket_pair()
fail, errno is logged but is not preserved. This change preservers errno in
posix_globals to allow the caller to query posix_get_last_error() to determine
the cause of the failure.

Previously there wasn't any way to differentiate between a signal interrupt
(EINTR) and other errors, making proper error handling/recovery difficult or
impossible.
