### PR TITLE
LibreSSL compatibility fix

### DIFF
--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -18,6 +18,7 @@ if test "$PHP_OPENSSL" != "no"; then
 
   AC_CHECK_LIB(ssl, DSA_get_default_method, AC_DEFINE(HAVE_DSA_DEFAULT_METHOD, 1, [OpenSSL 0.9.7 or later]))
   AC_CHECK_LIB(crypto, X509_free, AC_DEFINE(HAVE_DSA_DEFAULT_METHOD, 1, [OpenSSL 0.9.7 or later]))
+  AC_CHECK_FUNCS([RAND_egd])
 
   PHP_SETUP_OPENSSL(OPENSSL_SHARED_LIBADD, 
   [

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -972,12 +972,15 @@ static int php_openssl_load_rand_file(const char * file, int *egdsocket, int *se
 
 	if (file == NULL) {
 		file = RAND_file_name(buffer, sizeof(buffer));
-	} else if (RAND_egd(file) > 0) {
+	}
+#ifdef HAVE_RAND_EGD
+	else if (RAND_egd(file) > 0) {
 		/* if the given filename is an EGD socket, don't
 		 * write anything back to it */
 		*egdsocket = 1;
 		return SUCCESS;
 	}
+#endif
 	if (file == NULL || !RAND_load_file(file, -1)) {
 		if (RAND_status() == 0) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to load random state; not enough random data!");


### PR DESCRIPTION
Test compiled on OpenBSD 5.6 current snapshot.

`./configure --disable-all --enable-debug --with-openssl=/usr`

```
$ sapi/cli/php -i | grep -A 3 OpenSSL
OpenSSL support => enabled
OpenSSL Library Version => LibreSSL 2.0
OpenSSL Header Version => LibreSSL 2.0
```

Test results

```
FAILED TEST SUMMARY
---------------------------------------------------------------------
Bug #55646: textual input in openssl_csr_new() is not expected in UTF-8 [ext/openssl/tests/bug55646.phpt]
Bug #65729: CN_match gives false positive when wildcard is used [ext/openssl/tests/bug65729.phpt]
```

First failure is platform specific (OpenBSD /etc/ssl/openssl.cnf does not contain a `v3_ca` section
Second failure is kind of XFAIL lately

Can probably go into current 5.x branches too.