### PR TITLE
Opcache: Fix segfault while pre-evaluating a disabled function

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2642,11 +2642,20 @@ static zend_function_entry disabled_function[] = {
 
 ZEND_API int zend_disable_function(char *function_name, uint function_name_length TSRMLS_DC) /* {{{ */
 {
-	if (zend_hash_del(CG(function_table), function_name, function_name_length+1)==FAILURE) {
+	zend_internal_function *func;
+	int retval;
+
+	if (zend_hash_find(CG(function_table), function_name, function_name_length+1, (void *)&func) == FAILURE) {
 		return FAILURE;
 	}
+
+	zend_hash_del(CG(function_table), function_name, function_name_length+1);
+
+	EG(current_module) = func->module;
 	disabled_function[0].fname = function_name;
-	return zend_register_functions(NULL, disabled_function, CG(function_table), MODULE_PERSISTENT TSRMLS_CC);
+	retval = zend_register_functions(NULL, disabled_function, CG(function_table), MODULE_PERSISTENT TSRMLS_CC);
+	EG(current_module) = NULL;
+	return retval;
 }
 /* }}} */
 

--- a/ext/opcache/tests/bug68104.phpt
+++ b/ext/opcache/tests/bug68104.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #68104 (Segfault while pre-evaluating a disabled function)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+disable_functions=dl
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+var_dump(is_callable("dl"));
+--EXPECT--
+bool(true)


### PR DESCRIPTION
Opcache pass 1 accesses func->module in the "pre-evaluate constant functions"-step. However if the function has been disabled func->module will be NULL.

I think this will fix https://bugs.php.net/bug.php?id=68104
