### PR TITLE
Fixes setcookie to only send one Set-Cookie header per name

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -3740,6 +3740,10 @@ PHP_RINIT_FUNCTION(basic) /* {{{ */
 	/* Default to global filters only */
 	FG(stream_filters) = NULL;
 
+	/* setcookie */
+	ALLOC_HASHTABLE(SG(cookies));
+	zend_hash_init(SG(cookies), 0, NULL, NULL, 0);
+
 	return SUCCESS;
 }
 /* }}} */
@@ -3796,6 +3800,11 @@ PHP_RSHUTDOWN_FUNCTION(basic) /* {{{ */
 
  	BG(page_uid) = -1;
  	BG(page_gid) = -1;
+
+	/* setcookie */
+	zend_hash_destroy(SG(cookies));
+	FREE_HASHTABLE(SG(cookies));
+
 	return SUCCESS;
 }
 /* }}} */

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -81,6 +81,7 @@ PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, t
 	sapi_header_line ctr = {0};
 	int result;
 	zend_string *encoded_value = NULL;
+	zend_string *z_name = zend_string_init(name, name_len, 0);
 
 	if (name && strpbrk(name, "=,; \t\r\n\013\014") != NULL) {   /* man isspace for \013 and \014 */
 		zend_error( E_WARNING, "Cookie names cannot contain any of the following '=,; \\t\\r\\n\\013\\014'" );
@@ -91,6 +92,13 @@ PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, t
 		zend_error( E_WARNING, "Cookie values cannot contain any of the following ',; \\t\\r\\n\\013\\014'" );
 		return FAILURE;
 	}
+
+	if (zend_hash_exists(SG(cookies), z_name) == 1) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "should not be used twice with the same name");
+	}
+
+	zend_hash_add_empty_element(SG(cookies), z_name);
+	zend_string_release(z_name);
 
 	len += name_len;
 	if (value && url_encode) {

--- a/ext/standard/tests/network/bug67736-display-errors-off.phpt
+++ b/ext/standard/tests/network/bug67736-display-errors-off.phpt
@@ -1,0 +1,48 @@
+--TEST--
+setcookie() emits 2 cookies with same name with display_error off
+--DESCRIPTION--
+--INI--
+display_errors=0
+--FILE--
+<?php
+setcookie('name', 'value');
+setcookie('name', 'value');
+
+$expected = array(
+	'Set-Cookie: name=value',
+	'Set-Cookie: name=value',
+);
+
+$headers = headers_list();
+
+// Filter to get only the Set-Cookie headers
+$cookie_headers = [];
+foreach ($headers as $header) {
+	if (strpos($header, 'Set-Cookie:') === 0) $cookie_headers[] = $header;
+}
+
+if (count($cookie_headers) !== count($expected)) {
+	echo "Less headers are being sent than expected - aborting";
+	return;
+}
+
+$bad = 0;
+
+foreach ($cookie_headers as $i => $header) {
+	if ($header !== $expected[$i]) {
+		$bad++;
+		echo "Header mismatch:\n\tExpected: "
+			. $expected[$i]
+			. "\n\tReceived: "
+			. $header
+			. "\n";
+	}
+}
+
+echo ($bad === 0)
+	? 'OK'
+	: 'A total of ' . $bad . ' errors found.';
+--EXPECTHEADERS--
+
+--EXPECT--
+OK

--- a/ext/standard/tests/network/bug67736-display-errors-on.phpt
+++ b/ext/standard/tests/network/bug67736-display-errors-on.phpt
@@ -1,0 +1,33 @@
+--TEST--
+setcookie() emits 1 cookie then adds a warning for 2nd with same name
+--DESCRIPTION--
+--INI--
+--FILE--
+<?php
+
+setcookie('name', 'value');
+setcookie('name', 'value');
+
+$expected = array(
+	'Set-Cookie: name=value',
+);
+
+$headers = headers_list();
+
+// Filter to get only the Set-Cookie headers
+$cookie_headers = [];
+foreach ($headers as $header) {
+	if (strpos($header, 'Set-Cookie:') === 0) $cookie_headers[] = $header;
+}
+
+if (count($cookie_headers) !== count($expected)) {
+	echo "Less headers are being sent than expected - aborting";
+	return;
+}
+--EXPECTHEADERS--
+
+--EXPECTF--
+
+Warning: setcookie(): should not be used twice with the same name in %s
+
+Warning: Cannot modify header information - headers already sent by %s

--- a/ext/standard/tests/network/setcookie.phpt
+++ b/ext/standard/tests/network/setcookie.phpt
@@ -5,31 +5,31 @@ setcookie() tests
 date.timezone=UTC
 --FILE--
 <?php
-setcookie('name');
-setcookie('name', 'value');
-setcookie('name', 'space value');
-setcookie('name', 'value', 0);
-setcookie('name', 'value', $tsp = time() + 5);
-setcookie('name', 'value', $tsn = time() - 6);
-setcookie('name', 'value', $tsc = time());
-setcookie('name', 'value', 0, '/path/');
-setcookie('name', 'value', 0, '', 'domain.tld');
-setcookie('name', 'value', 0, '', '', TRUE);
-setcookie('name', 'value', 0, '', '', FALSE, TRUE);
+setcookie('name0');
+setcookie('name1', 'value');
+setcookie('name2', 'space value');
+setcookie('name3', 'value', 0);
+setcookie('name4', 'value', $tsp = time() + 5);
+setcookie('name5', 'value', $tsn = time() - 6);
+setcookie('name6', 'value', $tsc = time());
+setcookie('name7', 'value', 0, '/path/');
+setcookie('name8', 'value', 0, '', 'domain.tld');
+setcookie('name9', 'value', 0, '', '', TRUE);
+setcookie('name10', 'value', 0, '', '', FALSE, TRUE);
 
 
 $expected = array(
-	'Set-Cookie: name=',
-	'Set-Cookie: name=value',
-	'Set-Cookie: name=space+value',
-	'Set-Cookie: name=value',
-	'Set-Cookie: name=value; expires='.date('D, d-M-Y H:i:s', $tsp).' GMT; Max-Age=5',
-	'Set-Cookie: name=value; expires='.date('D, d-M-Y H:i:s', $tsn).' GMT; Max-Age=-6',
-	'Set-Cookie: name=value; expires='.date('D, d-M-Y H:i:s', $tsc).' GMT; Max-Age=0',
-	'Set-Cookie: name=value; path=/path/',
-	'Set-Cookie: name=value; domain=domain.tld',
-	'Set-Cookie: name=value; secure',
-	'Set-Cookie: name=value; HttpOnly'
+	'Set-Cookie: name0=',
+	'Set-Cookie: name1=value',
+	'Set-Cookie: name2=space+value',
+	'Set-Cookie: name3=value',
+	'Set-Cookie: name4=value; expires='.date('D, d-M-Y H:i:s', $tsp).' GMT; Max-Age=5',
+	'Set-Cookie: name5=value; expires='.date('D, d-M-Y H:i:s', $tsn).' GMT; Max-Age=-6',
+	'Set-Cookie: name6=value; expires='.date('D, d-M-Y H:i:s', $tsc).' GMT; Max-Age=0',
+	'Set-Cookie: name7=value; path=/path/',
+	'Set-Cookie: name8=value; domain=domain.tld',
+	'Set-Cookie: name9=value; secure',
+	'Set-Cookie: name10=value; HttpOnly'
 );
 
 $headers = headers_list();

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -137,6 +137,7 @@ typedef struct _sapi_globals_struct {
 	zval callback_func;
 	zend_fcall_info_cache fci_cache;
 	zend_bool callback_run;
+	HashTable *cookies;
 } sapi_globals_struct;
 
 


### PR DESCRIPTION
According to the IETF RFC 6265, only one Set-Cookie header should be sent per cookie name.

Fixes https://bugs.php.net/bug.php?id=67736

Cherry-picks and adapts 208deda (#795) for master
