### PR TITLE
Fixed bug #68129

### DIFF
--- a/ext/standard/tests/strings/url_t.phpt
+++ b/ext/standard/tests/strings/url_t.phpt
@@ -75,6 +75,7 @@ $sample_urls = array (
 );
 
     foreach ($sample_urls as $url) {
+        echo "\n--> $url: ";
         var_dump(@parse_url($url));
     }
 
@@ -84,21 +85,24 @@ $sample_urls = array (
     }
 ?>
 --EXPECT--
-array(1) {
+--> : array(1) {
   ["path"]=>
   string(0) ""
 }
-array(1) {
+
+--> 64.246.30.37: array(1) {
   ["path"]=>
   string(12) "64.246.30.37"
 }
-array(2) {
+
+--> http://64.246.30.37: array(2) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
   string(12) "64.246.30.37"
 }
-array(3) {
+
+--> http://64.246.30.37/: array(3) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -106,11 +110,13 @@ array(3) {
   ["path"]=>
   string(1) "/"
 }
-array(1) {
+
+--> 64.246.30.37/: array(1) {
   ["path"]=>
   string(13) "64.246.30.37/"
 }
-array(3) {
+
+--> 64.246.30.37:80/: array(3) {
   ["host"]=>
   string(12) "64.246.30.37"
   ["port"]=>
@@ -118,21 +124,25 @@ array(3) {
   ["path"]=>
   string(1) "/"
 }
-array(1) {
+
+--> php.net: array(1) {
   ["path"]=>
   string(7) "php.net"
 }
-array(1) {
+
+--> php.net/: array(1) {
   ["path"]=>
   string(8) "php.net/"
 }
-array(2) {
+
+--> http://php.net: array(2) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
   string(7) "php.net"
 }
-array(3) {
+
+--> http://php.net/: array(3) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -140,21 +150,25 @@ array(3) {
   ["path"]=>
   string(1) "/"
 }
-array(1) {
+
+--> www.php.net: array(1) {
   ["path"]=>
   string(11) "www.php.net"
 }
-array(1) {
+
+--> www.php.net/: array(1) {
   ["path"]=>
   string(12) "www.php.net/"
 }
-array(2) {
+
+--> http://www.php.net: array(2) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
   string(11) "www.php.net"
 }
-array(3) {
+
+--> http://www.php.net/: array(3) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -162,13 +176,15 @@ array(3) {
   ["path"]=>
   string(1) "/"
 }
-array(2) {
+
+--> www.php.net:80: array(2) {
   ["host"]=>
   string(11) "www.php.net"
   ["port"]=>
   int(80)
 }
-array(3) {
+
+--> http://www.php.net:80: array(3) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -176,7 +192,8 @@ array(3) {
   ["port"]=>
   int(80)
 }
-array(4) {
+
+--> http://www.php.net:80/: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -186,7 +203,8 @@ array(4) {
   ["path"]=>
   string(1) "/"
 }
-array(3) {
+
+--> http://www.php.net/index.php: array(3) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -194,11 +212,13 @@ array(3) {
   ["path"]=>
   string(10) "/index.php"
 }
-array(1) {
+
+--> www.php.net/?: array(1) {
   ["path"]=>
   string(12) "www.php.net/"
 }
-array(3) {
+
+--> www.php.net:80/?: array(3) {
   ["host"]=>
   string(11) "www.php.net"
   ["port"]=>
@@ -206,7 +226,8 @@ array(3) {
   ["path"]=>
   string(1) "/"
 }
-array(3) {
+
+--> http://www.php.net/?: array(3) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -214,7 +235,8 @@ array(3) {
   ["path"]=>
   string(1) "/"
 }
-array(4) {
+
+--> http://www.php.net:80/?: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -224,7 +246,8 @@ array(4) {
   ["path"]=>
   string(1) "/"
 }
-array(4) {
+
+--> http://www.php.net:80/index.php: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -234,7 +257,8 @@ array(4) {
   ["path"]=>
   string(10) "/index.php"
 }
-array(4) {
+
+--> http://www.php.net:80/foo/bar/index.php: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -244,7 +268,8 @@ array(4) {
   ["path"]=>
   string(18) "/foo/bar/index.php"
 }
-array(4) {
+
+--> http://www.php.net:80/this/is/a/very/deep/directory/structure/and/file.php: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -254,7 +279,8 @@ array(4) {
   ["path"]=>
   string(53) "/this/is/a/very/deep/directory/structure/and/file.php"
 }
-array(5) {
+
+--> http://www.php.net:80/this/is/a/very/deep/directory/structure/and/file.php?lots=1&of=2&parameters=3&too=4&here=5: array(5) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -266,7 +292,8 @@ array(5) {
   ["query"]=>
   string(37) "lots=1&of=2&parameters=3&too=4&here=5"
 }
-array(4) {
+
+--> http://www.php.net:80/this/is/a/very/deep/directory/structure/and/: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -276,7 +303,8 @@ array(4) {
   ["path"]=>
   string(45) "/this/is/a/very/deep/directory/structure/and/"
 }
-array(4) {
+
+--> http://www.php.net:80/this/is/a/very/deep/directory/structure/and/file.php: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -286,7 +314,8 @@ array(4) {
   ["path"]=>
   string(53) "/this/is/a/very/deep/directory/structure/and/file.php"
 }
-array(4) {
+
+--> http://www.php.net:80/this/../a/../deep/directory: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -296,7 +325,8 @@ array(4) {
   ["path"]=>
   string(28) "/this/../a/../deep/directory"
 }
-array(4) {
+
+--> http://www.php.net:80/this/../a/../deep/directory/: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -306,7 +336,8 @@ array(4) {
   ["path"]=>
   string(29) "/this/../a/../deep/directory/"
 }
-array(4) {
+
+--> http://www.php.net:80/this/is/a/very/deep/directory/../file.php: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -316,7 +347,8 @@ array(4) {
   ["path"]=>
   string(42) "/this/is/a/very/deep/directory/../file.php"
 }
-array(4) {
+
+--> http://www.php.net:80/index.php: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -326,7 +358,8 @@ array(4) {
   ["path"]=>
   string(10) "/index.php"
 }
-array(4) {
+
+--> http://www.php.net:80/index.php?: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -336,7 +369,8 @@ array(4) {
   ["path"]=>
   string(10) "/index.php"
 }
-array(5) {
+
+--> http://www.php.net:80/#foo: array(5) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -348,7 +382,8 @@ array(5) {
   ["fragment"]=>
   string(3) "foo"
 }
-array(4) {
+
+--> http://www.php.net:80/?#: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -358,7 +393,8 @@ array(4) {
   ["path"]=>
   string(1) "/"
 }
-array(5) {
+
+--> http://www.php.net:80/?test=1: array(5) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -370,7 +406,8 @@ array(5) {
   ["query"]=>
   string(6) "test=1"
 }
-array(4) {
+
+--> http://www.php.net/?test=1&: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -380,7 +417,8 @@ array(4) {
   ["query"]=>
   string(7) "test=1&"
 }
-array(5) {
+
+--> http://www.php.net:80/?&: array(5) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -392,7 +430,8 @@ array(5) {
   ["query"]=>
   string(1) "&"
 }
-array(5) {
+
+--> http://www.php.net:80/index.php?test=1&: array(5) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -404,7 +443,8 @@ array(5) {
   ["query"]=>
   string(7) "test=1&"
 }
-array(4) {
+
+--> http://www.php.net/index.php?&: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -414,7 +454,8 @@ array(4) {
   ["query"]=>
   string(1) "&"
 }
-array(5) {
+
+--> http://www.php.net:80/index.php?foo&: array(5) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -426,7 +467,8 @@ array(5) {
   ["query"]=>
   string(4) "foo&"
 }
-array(4) {
+
+--> http://www.php.net/index.php?&foo: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -436,7 +478,8 @@ array(4) {
   ["query"]=>
   string(4) "&foo"
 }
-array(5) {
+
+--> http://www.php.net:80/index.php?test=1&test2=char&test3=mixesCI: array(5) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -448,7 +491,8 @@ array(5) {
   ["query"]=>
   string(31) "test=1&test2=char&test3=mixesCI"
 }
-array(5) {
+
+--> www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(5) {
   ["host"]=>
   string(11) "www.php.net"
   ["port"]=>
@@ -460,7 +504,8 @@ array(5) {
   ["fragment"]=>
   string(16) "some_page_ref123"
 }
-array(7) {
+
+--> http://secret@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(7) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -476,13 +521,16 @@ array(7) {
   ["fragment"]=>
   string(16) "some_page_ref123"
 }
-array(6) {
+
+--> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(7) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
   string(11) "www.php.net"
   ["user"]=>
   string(6) "secret"
+  ["pass"]=>
+  string(0) ""
   ["path"]=>
   string(10) "/index.php"
   ["query"]=>
@@ -490,13 +538,16 @@ array(6) {
   ["fragment"]=>
   string(16) "some_page_ref123"
 }
-array(7) {
+
+--> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(8) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
   string(11) "www.php.net"
   ["port"]=>
   int(80)
+  ["user"]=>
+  string(0) ""
   ["pass"]=>
   string(7) "hideout"
   ["path"]=>
@@ -506,7 +557,8 @@ array(7) {
   ["fragment"]=>
   string(16) "some_page_ref123"
 }
-array(7) {
+
+--> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(7) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -522,7 +574,8 @@ array(7) {
   ["fragment"]=>
   string(16) "some_page_ref123"
 }
-array(7) {
+
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(7) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -538,7 +591,8 @@ array(7) {
   ["fragment"]=>
   string(16) "some_page_ref123"
 }
-array(8) {
+
+--> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(8) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -556,13 +610,15 @@ array(8) {
   ["fragment"]=>
   string(16) "some_page_ref123"
 }
-array(2) {
+
+--> nntp://news.php.net: array(2) {
   ["scheme"]=>
   string(4) "nntp"
   ["host"]=>
   string(12) "news.php.net"
 }
-array(3) {
+
+--> ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz: array(3) {
   ["scheme"]=>
   string(3) "ftp"
   ["host"]=>
@@ -570,25 +626,29 @@ array(3) {
   ["path"]=>
   string(22) "/gnu/glic/glibc.tar.gz"
 }
-array(2) {
+
+--> zlib:http://foo@bar: array(2) {
   ["scheme"]=>
   string(4) "zlib"
   ["path"]=>
   string(14) "http://foo@bar"
 }
-array(2) {
+
+--> zlib:filename.txt: array(2) {
   ["scheme"]=>
   string(4) "zlib"
   ["path"]=>
   string(12) "filename.txt"
 }
-array(2) {
+
+--> zlib:/path/to/my/file/file.txt: array(2) {
   ["scheme"]=>
   string(4) "zlib"
   ["path"]=>
   string(25) "/path/to/my/file/file.txt"
 }
-array(3) {
+
+--> foo://foo@bar: array(3) {
   ["scheme"]=>
   string(3) "foo"
   ["host"]=>
@@ -596,25 +656,29 @@ array(3) {
   ["user"]=>
   string(3) "foo"
 }
-array(2) {
+
+--> mailto:me@mydomain.com: array(2) {
   ["scheme"]=>
   string(6) "mailto"
   ["path"]=>
   string(15) "me@mydomain.com"
 }
-array(2) {
+
+--> /foo.php?a=b&c=d: array(2) {
   ["path"]=>
   string(8) "/foo.php"
   ["query"]=>
   string(7) "a=b&c=d"
 }
-array(2) {
+
+--> foo.php?a=b&c=d: array(2) {
   ["path"]=>
   string(7) "foo.php"
   ["query"]=>
   string(7) "a=b&c=d"
 }
-array(6) {
+
+--> http://user:passwd@www.example.com:8080?bar=1&boom=0: array(6) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -628,13 +692,15 @@ array(6) {
   ["query"]=>
   string(12) "bar=1&boom=0"
 }
-array(2) {
+
+--> file:///path/to/file: array(2) {
   ["scheme"]=>
   string(4) "file"
   ["path"]=>
   string(13) "/path/to/file"
 }
-array(3) {
+
+--> file://path/to/file: array(3) {
   ["scheme"]=>
   string(4) "file"
   ["host"]=>
@@ -642,13 +708,15 @@ array(3) {
   ["path"]=>
   string(8) "/to/file"
 }
-array(2) {
+
+--> file:/path/to/file: array(2) {
   ["scheme"]=>
   string(4) "file"
   ["path"]=>
   string(13) "/path/to/file"
 }
-array(4) {
+
+--> http://1.2.3.4:/abc.asp?a=1&b=2: array(4) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -658,7 +726,8 @@ array(4) {
   ["query"]=>
   string(7) "a=1&b=2"
 }
-array(3) {
+
+--> http://foo.com#bar: array(3) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -666,11 +735,13 @@ array(3) {
   ["fragment"]=>
   string(3) "bar"
 }
-array(1) {
+
+--> scheme:: array(1) {
   ["scheme"]=>
   string(6) "scheme"
 }
-array(4) {
+
+--> foo+bar://baz@bang/bla: array(4) {
   ["scheme"]=>
   string(7) "foo+bar"
   ["host"]=>
@@ -680,13 +751,15 @@ array(4) {
   ["path"]=>
   string(4) "/bla"
 }
-array(2) {
+
+--> gg:9130731: array(2) {
   ["scheme"]=>
   string(2) "gg"
   ["path"]=>
   string(7) "9130731"
 }
-array(7) {
+
+--> http://user:@pass@host/path?argument?value#etc: array(7) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
@@ -710,3 +783,4 @@ string(7) "hideout"
 string(10) "/index.php"
 string(31) "test=1&test2=char&test3=mixesCI"
 string(16) "some_page_ref123"
+

--- a/ext/standard/tests/url/parse_url_basic_001.phpt
+++ b/ext/standard/tests/url/parse_url_basic_001.phpt
@@ -454,13 +454,15 @@ echo "Done";
   string(16) "some_page_ref123"
 }
 
---> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(6) {
+--> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(7) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
   string(11) "www.php.net"
   ["user"]=>
   string(6) "secret"
+  ["pass"]=>
+  string(0) ""
   ["path"]=>
   string(10) "/index.php"
   ["query"]=>
@@ -469,13 +471,15 @@ echo "Done";
   string(16) "some_page_ref123"
 }
 
---> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(7) {
+--> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(8) {
   ["scheme"]=>
   string(4) "http"
   ["host"]=>
   string(11) "www.php.net"
   ["port"]=>
   int(80)
+  ["user"]=>
+  string(0) ""
   ["pass"]=>
   string(7) "hideout"
   ["path"]=>

--- a/ext/standard/tests/url/parse_url_basic_005.phpt
+++ b/ext/standard/tests/url/parse_url_basic_005.phpt
@@ -66,7 +66,7 @@ echo "Done";
 --> www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : NULL
 --> http://secret@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(6) "secret"
 --> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(6) "secret"
---> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : NULL
+--> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(0) ""
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(6) "secret"
 --> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(14) "secret@hideout"
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(6) "secret"

--- a/ext/standard/tests/url/parse_url_basic_006.phpt
+++ b/ext/standard/tests/url/parse_url_basic_006.phpt
@@ -65,7 +65,7 @@ echo "Done";
 --> http://www.php.net:80/index.php?test=1&test2=char&test3=mixesCI   : NULL
 --> www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : NULL
 --> http://secret@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : NULL
---> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : NULL
+--> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(0) ""
 --> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(7) "hideout"
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(7) "hideout"
 --> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : NULL

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -240,16 +240,12 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 	/* check for login and password */
 	if ((p = zend_memrchr(s, '@', (e-s)))) {
 		if ((pp = memchr(s, ':', (p-s)))) {
-			if ((pp-s) > 0) {
-				ret->user = estrndup(s, (pp-s));
-				php_replace_controlchars_ex(ret->user, (pp - s));
-			}	
+			ret->user = estrndup(s, (pp-s));
+			php_replace_controlchars_ex(ret->user, (pp - s));
 		
 			pp++;
-			if (p-pp > 0) {
-				ret->pass = estrndup(pp, (p-pp));
-				php_replace_controlchars_ex(ret->pass, (p-pp));
-			}	
+			ret->pass = estrndup(pp, (p-pp));
+			php_replace_controlchars_ex(ret->pass, (p-pp));
 		} else {
 			ret->user = estrndup(s, (p-s));
 			php_replace_controlchars_ex(ret->user, (p-s));


### PR DESCRIPTION
Empty usernames and passwords are now treated differently from no username or password

For example, empty password:

```
ftp://user:@example.org
```

Empty username:

```
ftp://:password@example.org
```

Empty username and empty password

```
ftp://:@example.org
```
