### PR TITLE
Fixed bug #68128

### DIFF
--- a/ext/spl/spl_engine.h
+++ b/ext/spl/spl_engine.h
@@ -51,6 +51,36 @@ static inline int spl_instantiate_arg_ex2(zend_class_entry *pce, zval *retval, z
 }
 /* }}} */
 
+/* {{{ spl_instantiate_arg_n */
+static inline void spl_instantiate_arg_n(zend_class_entry *pce, zval *retval, int argc, zval *argv TSRMLS_DC)
+{
+	zend_function *func = pce->constructor;
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+	zval dummy;
+
+	spl_instantiate(pce, retval TSRMLS_CC);
+
+	fci.size = sizeof(zend_fcall_info);
+	fci.function_table = &pce->function_table;
+	ZVAL_STR(&fci.function_name, func->common.function_name);
+	fci.object = Z_OBJ_P(retval);
+	fci.symbol_table = NULL;
+	fci.retval = &dummy;
+	fci.param_count = argc;
+	fci.params = argv;
+	fci.no_separation = 1;
+
+	fcc.initialized = 1;
+	fcc.function_handler = func;
+	fcc.calling_scope = EG(scope);
+	fcc.called_scope = pce;
+	fcc.object = Z_OBJ_P(retval);
+
+	zend_call_function(&fci, &fcc TSRMLS_CC);
+}
+/* }}} */
+
 #endif /* SPL_ENGINE_H */
 
 /*

--- a/ext/spl/tests/bug68128.phpt
+++ b/ext/spl/tests/bug68128.phpt
@@ -1,0 +1,91 @@
+--TEST--
+Bug #68128 - RecursiveRegexIterator raises "Array to string conversion" notice
+--FILE--
+<?php
+
+$array = new ArrayIterator(array('a', array('b', 'c')));
+$regex = new RegexIterator($array, '/Array/');
+
+foreach ($regex as $match) {
+    var_dump($match);
+}
+
+$rArrayIterator = new RecursiveArrayIterator(array('test1', array('tet3', 'test4', 'test5')));
+$rRegexIterator = new RecursiveRegexIterator($rArrayIterator, '/^(t)est(\d*)/',
+    RecursiveRegexIterator::ALL_MATCHES, 0, PREG_PATTERN_ORDER);
+
+foreach ($rRegexIterator as $key1 => $value1) {
+
+    if ($rRegexIterator->hasChildren()) {
+
+        // print all children
+        echo "Children: ";
+        foreach ($rRegexIterator->getChildren() as $key => $value) {
+			print_r($value);
+        }
+        echo "\n";
+    } else {
+        echo "No children ";
+		print_r($value1);
+		echo "\n";
+    }
+}
+
+?>
+--EXPECT--
+No children Array
+(
+    [0] => Array
+        (
+            [0] => test1
+        )
+
+    [1] => Array
+        (
+            [0] => t
+        )
+
+    [2] => Array
+        (
+            [0] => 1
+        )
+
+)
+
+Children: Array
+(
+    [0] => Array
+        (
+            [0] => test4
+        )
+
+    [1] => Array
+        (
+            [0] => t
+        )
+
+    [2] => Array
+        (
+            [0] => 4
+        )
+
+)
+Array
+(
+    [0] => Array
+        (
+            [0] => test5
+        )
+
+    [1] => Array
+        (
+            [0] => t
+        )
+
+    [2] => Array
+        (
+            [0] => 5
+        )
+
+)
+

--- a/ext/spl/tests/iterator_048.phpt
+++ b/ext/spl/tests/iterator_048.phpt
@@ -13,11 +13,6 @@ class MyRecursiveRegexIterator extends RecursiveRegexIterator
 			var_dump($v);
 		}
 	}
-
-	function accept()
-	{
-		return $this->hasChildren() || parent::accept();
-	}
 }
 
 $ar = new RecursiveArrayIterator(array('Foo', array('Bar'), 'FooBar', array('Baz'), 'Biz'));

--- a/ext/spl/tests/iterator_050.phpt
+++ b/ext/spl/tests/iterator_050.phpt
@@ -46,8 +46,6 @@ array(3) {
   [2]=>
   %s(1) "2"
 }
-
-Notice: Array to string conversion in %siterator_050.php on line %d
 int(0)
 array(2) {
   [0]=>
@@ -69,8 +67,6 @@ array(2) {
   [1]=>
   %s(1) "1"
 }
-
-Notice: Array to string conversion in %siterator_050.php on line %d
 object(ArrayIterator)#%d (1) {
   %s"storage"%s"ArrayIterator":private]=>
   array(9) {

--- a/ext/spl/tests/iterator_052.phpt
+++ b/ext/spl/tests/iterator_052.phpt
@@ -46,18 +46,6 @@ var_dump($ar);
 <?php exit(0); ?>
 --EXPECTF--
 bool(true)
-int(0)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
 int(1)
 array(3) {
@@ -97,85 +85,11 @@ array(3) {
   }
 }
 bool(true)
-int(3)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
-int(4)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
-
-Notice: Array to string conversion in %siterator_052.php on line %d
+bool(false)
 bool(true)
-int(5)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
-int(6)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
-int(7)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
-bool(true)
-int(8)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
 int(0)
 array(2) {
@@ -231,67 +145,11 @@ array(2) {
   }
 }
 bool(true)
-int(3)
-array(2) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-}
 bool(true)
-int(4)
-array(2) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-}
-
-Notice: Array to string conversion in %siterator_052.php on line %d
+bool(false)
 bool(true)
-int(5)
-array(2) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-}
 bool(true)
-int(6)
-array(2) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-}
 bool(true)
-int(7)
-array(2) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-}
-bool(true)
-int(8)
-array(2) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-}
 object(ArrayIterator)#%d (1) {
   ["storage":"ArrayIterator":private]=>
   array(9) {

--- a/ext/spl/tests/iterator_053.phpt
+++ b/ext/spl/tests/iterator_053.phpt
@@ -46,122 +46,14 @@ var_dump($ar);
 <?php exit(0); ?>
 --EXPECTF--
 bool(true)
-int(0)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
-int(1)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
-int(2)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
-int(3)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
-int(4)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
+bool(false)
 bool(true)
-int(5)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
-int(6)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
-int(7)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
-bool(true)
-int(8)
-array(3) {
-  [0]=>
-  array(0) {
-  }
-  [1]=>
-  array(0) {
-  }
-  [2]=>
-  array(0) {
-  }
-}
 bool(true)
 int(0)
 array(2) {
@@ -232,20 +124,7 @@ array(2) {
     string(1) "4"
   }
 }
-bool(true)
-int(5)
-array(2) {
-  [0]=>
-  array(1) {
-    [0]=>
-    string(1) "5"
-  }
-  [1]=>
-  array(1) {
-    [0]=>
-    string(1) "5"
-  }
-}
+bool(false)
 bool(true)
 int(6)
 array(2) {

--- a/ext/spl/tests/iterator_054.phpt
+++ b/ext/spl/tests/iterator_054.phpt
@@ -42,8 +42,6 @@ array(3) {
   [2]=>
   string(1) "3"
 }
-
-Notice: Array to string conversion in %siterator_054.php on line %d
 int(7)
 array(2) {
   [0]=>


### PR DESCRIPTION
Fixes an [issue](https://bugs.php.net/bug.php?id=68128) that's been around since d81ea16ef14735b97f22702ca1a78c3674fd987e.

Three issues are addressed:
1. `RecursiveRegexIterator::accept()` should accept non-empty arrays without applying any regular expression and `RegexIterator::accept()` should not accept an array.
2. `RegexIterator::accept()` should not accept an atom that fails to match anything, even when `PREG_PATTERN_ORDER` is used (which would return an array of empty arrays).
3. `RecursiveRegexIterator::getChildren()` should pass all constructor arguments to its child iterator instead of just the regular expression.
