### PR TITLE
Fixed #68110

### DIFF
--- a/Zend/tests/024.phpt
+++ b/Zend/tests/024.phpt
@@ -16,11 +16,15 @@ var_dump($a->$b->{$c[1]});
 ?>
 --EXPECTF--
 Notice: Undefined variable: a in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
 
 Notice: Undefined variable: %s in %s on line %d
 
 Notice: Undefined variable: %s in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
 
 Notice: Undefined variable: a in %s on line %d
@@ -44,6 +48,8 @@ Notice: Trying to get property of non-object in %s on line %d
 NULL
 
 Notice: Undefined variable: c in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
 
 Notice: Trying to get property of non-object in %s on line %d
 

--- a/Zend/tests/033.phpt
+++ b/Zend/tests/033.phpt
@@ -20,9 +20,39 @@ $arr[][]->bar = 2;
 
 Notice: Undefined variable: arr in %s on line %d
 
-Notice: Undefined variable: arr in %s on line %d
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
 
 Notice: Undefined variable: arr in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Notice: Undefined variable: arr in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
 
 Notice: Trying to get property of non-object in %s on line %d
 

--- a/Zend/tests/assign_to_var_003.phpt
+++ b/Zend/tests/assign_to_var_003.phpt
@@ -13,6 +13,7 @@ var_dump($var1);
 echo "Done\n";
 ?>
 --EXPECTF--	
+Warning: Attempt to use double as an array in %s on line %d
 NULL
 NULL
 Done

--- a/Zend/tests/bug24436.phpt
+++ b/Zend/tests/bug24436.phpt
@@ -17,8 +17,11 @@ class test {
 
 $test1 = new test();
 ?>
---EXPECT--
+--EXPECTF--
+Warning: Attempt to use null as an array in %s on line %d
 test1
+
+Warning: Attempt to use null as an array in %s on line %d
 test2
 test1
 test2

--- a/Zend/tests/dereference_002.phpt
+++ b/Zend/tests/dereference_002.phpt
@@ -69,6 +69,8 @@ array(2) {
   int(5)
 }
 int(1)
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
 
 Notice: Undefined offset: 4 in %s on line %d

--- a/Zend/tests/dereference_010.phpt
+++ b/Zend/tests/dereference_010.phpt
@@ -21,7 +21,10 @@ var_dump(b()[1]);
 
 ?>
 --EXPECTF--
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
 
 Fatal error: Cannot use object of type stdClass as array in %s on line %d

--- a/Zend/tests/dereference_014.phpt
+++ b/Zend/tests/dereference_014.phpt
@@ -27,8 +27,12 @@ var_dump($h);
 
 ?>
 --EXPECTF--
+Warning: Attempt to use null as an array in %s on line %d
+
 Notice: Trying to get property of non-object in %s on line %d
 NULL
+
+Warning: Attempt to use null as an array in %s on line %d
 
 Notice: Trying to get property of non-object in %s on line %d
 NULL

--- a/Zend/tests/isset_003.phpt
+++ b/Zend/tests/isset_003.phpt
@@ -27,11 +27,19 @@ var_dump(isset($GLOBALS[1]->$GLOBALS));
 bool(true)
 bool(true)
 bool(false)
+
+Warning: Attempt to use unknown as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
 bool(false)
 
 Notice: Undefined variable: c in %s on line %d
 
 Notice: Undefined variable: d in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
 
 Notice: Trying to get property of non-object in %s on line %d
 bool(false)

--- a/Zend/tests/isset_003_2_4.phpt
+++ b/Zend/tests/isset_003_2_4.phpt
@@ -29,11 +29,19 @@ var_dump(isset($GLOBALS[1]->$GLOBALS));
 bool(true)
 bool(true)
 bool(false)
+
+Warning: Attempt to use unknown as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
 bool(false)
 
 Notice: Undefined variable: c in %s on line %d
 
 Notice: Undefined variable: d in %s on line %d
+
+Warning: Attempt to use null as an array in %s on line %d
 
 Notice: Trying to get property of non-object in %s on line %d
 bool(false)

--- a/Zend/tests/offset_bool.phpt
+++ b/Zend/tests/offset_bool.phpt
@@ -25,13 +25,30 @@ var_dump($bool[$arr]);
 echo "Done\n";
 ?>
 --EXPECTF--	
+Warning: Attempt to use boolean as an array in %s on line %d
 NULL
+
+Warning: Attempt to use boolean as an array in %s on line %d
 NULL
+
+Warning: Attempt to use boolean as an array in %s on line %d
 NULL
+
+Warning: Attempt to use boolean as an array in %s on line %d
 NULL
+
+Warning: Attempt to use boolean as an array in %s on line %d
 NULL
+
+Warning: Attempt to use boolean as an array in %s on line %d
 NULL
+
+Warning: Attempt to use boolean as an array in %s on line %d
 NULL
+
+Warning: Attempt to use boolean as an array in %s on line %d
 NULL
+
+Warning: Attempt to use boolean as an array in %s on line %d
 NULL
 Done

--- a/Zend/tests/offset_long.phpt
+++ b/Zend/tests/offset_long.phpt
@@ -25,13 +25,31 @@ var_dump($long[$arr]);
 echo "Done\n";
 ?>
 --EXPECTF--	
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
+
+Warning: Attempt to use integer as an array in %s on line %d
 NULL
 Done

--- a/Zend/tests/offset_null.phpt
+++ b/Zend/tests/offset_null.phpt
@@ -25,13 +25,31 @@ var_dump($null[$arr]);
 echo "Done\n";
 ?>
 --EXPECTF--	
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
+
+Warning: Attempt to use null as an array in %s on line %d
 NULL
 Done

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1227,6 +1227,7 @@ static zend_always_inline void zend_fetch_dimension_address_read(zval *result, z
 			}
 		}
 	} else {
+		zend_error(E_WARNING, "Attempt to use %s as an array", zend_get_type_by_const(Z_TYPE_P(container)));
 		ZVAL_NULL(result);
 	}
 }


### PR DESCRIPTION
Addresses [bug 68110](https://bugs.php.net/bug.php?id=68110).

Raise a warning when a variable is dereferenced as an array but is neither a string, array or object.