### PR TITLE
Various fixes to allow support for new VS2014 features

### DIFF
--- a/Zend/zend_config.w32.h
+++ b/Zend/zend_config.w32.h
@@ -47,7 +47,9 @@ typedef unsigned int uint;
 #define HAVE_CLASS_ISTDIOSTREAM
 #define istdiostream stdiostream
 
+#if _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #if _MSC_VER < 1500
 #define vsnprintf _vsnprintf
 #endif

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -49,6 +49,7 @@ VC_VERSIONS[1500] = 'MSVC9 (Visual C++ 2008)';
 VC_VERSIONS[1600] = 'MSVC10 (Visual C++ 2010)';
 VC_VERSIONS[1700] = 'MSVC11 (Visual C++ 2012)';
 VC_VERSIONS[1800] = 'MSVC12 (Visual C++ 2013)';
+VC_VERSIONS[1900] = 'MSVC14 (Visual C++ 2014)';
 
 var VC_VERSIONS_SHORT = new Array();
 VC_VERSIONS_SHORT[1200] = 'VC6';
@@ -59,6 +60,7 @@ VC_VERSIONS_SHORT[1500] = 'VC9';
 VC_VERSIONS_SHORT[1600] = 'VC10';
 VC_VERSIONS_SHORT[1700] = 'VC11';
 VC_VERSIONS_SHORT[1800] = 'VC12';
+VC_VERSIONS_SHORT[1900] = 'VC14';
 
 if (PROGRAM_FILES == null) {
 	PROGRAM_FILES = "C:\\Program Files";
@@ -1531,9 +1533,11 @@ function output_as_table(header, ar_out)
 		tmin = 0;
 		tmax = 0;
 		for (k = 0; k < ar_out.length; k++) {
-			var t = ar_out[k][j].length;
-			if (t > tmax) tmax = t;
-			else if (t < tmin) tmin = t;
+			if(typeof ar_out[k][j] != 'undefined') {
+				var t = ar_out[k][j].length;
+				if (t > tmax) tmax = t;
+				else if (t < tmin) tmin = t;
+			}
 		}
 		if (tmax > header[j].length) {
 			max[j] = tmax;
@@ -1574,8 +1578,10 @@ function output_as_table(header, ar_out)
 		line = ar_out[i];
 		for (j=0; j < l; j++) {
 			out += " " + line[j];
-			for (var k = 0; k < (max[j] - line[j].length); k++){
-				out += " ";
+			if(typeof line[j] != 'undefined') {
+				for (var k = 0; k < (max[j] - line[j].length); k++){
+					out += " ";
+				}
 			}
 			out += " |";
 		}
@@ -2052,7 +2058,7 @@ function AC_DEFINE(name, value, comment, quote)
 	}
 	if (quote && typeof(value) == "string") {
 		value = '"' + value.replace(new RegExp('(["\\\\])', "g"), '\\$1') + '"';
-	} else if (value.length == 0) {
+	} else if (typeof(value) != "undefined" && value.length == 0) {
 		value = '""';
 	}
 	var item = new Array(value, comment);

--- a/win32/php_stdint.h
+++ b/win32/php_stdint.h
@@ -33,6 +33,10 @@
 #error "Use this header only with Microsoft Visual C++ compilers!"
 #endif // _MSC_VER ]
 
+// Starting with VS2014, many of the C11 features are now included, so we only
+// need many of these typedefs and defines for older VS suites
+#if _MSC_VER < 1900
+
 #ifndef _MSC_STDINT_H_ // [
 #define _MSC_STDINT_H_
 
@@ -84,9 +88,6 @@ typedef __int64           int64_t;
 #endif
 #ifndef uint8_t
 typedef unsigned __int8   uint8_t;
-#endif
-#ifndef u_char
-typedef unsigned __int8   u_char;
 #endif
 typedef unsigned __int16  uint16_t;
 #ifndef uint32_t
@@ -254,3 +255,11 @@ static __inline int64_t llabs(int64_t i)
 
 
 #endif // _MSC_STDINT_H_ ]
+
+#else
+#include <stdint.h>
+#endif
+
+#ifndef u_char
+typedef unsigned __int8   u_char;
+#endif

--- a/win32/time.h
+++ b/win32/time.h
@@ -29,11 +29,13 @@ struct itimerval {
 };
 
 #ifndef timespec
+#if _MSC_VER < 1900
 struct timespec
 {
 	time_t   tv_sec;   /* seconds */
 	long     tv_nsec;  /* nanoseconds */
 };
+#endif
 #endif
 
 #define ITIMER_REAL    0		/*generates sigalrm */


### PR DESCRIPTION
- Added some typeof checks to handle JS errors introduced in Windows 10
- Added VS2014 to the list of compilers
- Changed to use stdint.h if we are using VS2014 or higher
- Skip defining timespec if we're using VS2014 or higher
- Moved u_char typedef out to always be defined regardless of VS version
