### PR TITLE
Bug #68161 - DateTime::setTimestamp doesn't clear relative data

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3059,6 +3059,7 @@ static int php_date_modify(zval *object, char *modify, int modify_len TSRMLS_DC)
 {
 	php_date_obj *dateobj;
 	timelib_time *tmp_time;
+	timelib_rel_time tmp_rel_time;
 	timelib_error_container *err = NULL;
 
 	dateobj = (php_date_obj *) zend_object_store_get_object(object TSRMLS_CC);
@@ -3080,6 +3081,7 @@ static int php_date_modify(zval *object, char *modify, int modify_len TSRMLS_DC)
 		return 0;
 	}
 
+	memcpy(&tmp_rel_time, &dateobj->time->relative, sizeof(struct timelib_rel_time));
 	memcpy(&dateobj->time->relative, &tmp_time->relative, sizeof(struct timelib_rel_time));
 	dateobj->time->have_relative = tmp_time->have_relative;
 	dateobj->time->sse_uptodate = 0;
@@ -3113,6 +3115,7 @@ static int php_date_modify(zval *object, char *modify, int modify_len TSRMLS_DC)
 	timelib_update_ts(dateobj->time, NULL);
 	timelib_update_from_sse(dateobj->time);
 	dateobj->time->have_relative = 0;
+	memcpy(&dateobj->time->relative, &tmp_rel_time, sizeof(struct timelib_rel_time));
 	
 	return 1;
 }

--- a/ext/date/tests/68161.phpt
+++ b/ext/date/tests/68161.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #68161 - Relative offsets not cleared when setting a timestamp
+--FILE--
+<?php
+ini_set('date.timezone', 'UTC');
+
+$time_start = new DateTime('2014-10-02');
+
+echo $time_start->format('d-m-Y') . "\n";
+
+$time_start->modify('first day of this month');
+
+echo $time_start->format('d') . "\n";
+
+$time_start->setTimestamp(1412745640);
+
+echo $time_start->format('d-m-Y') . "\n";
+--EXPECTF--
+02-10-2014
+01
+08-10-2014


### PR DESCRIPTION
Fixes [PHP bug #68161](https://bugs.php.net/bug.php?id=68161) - Explicitly setting a timestamp does not clear previously set relative data.
