### PR TITLE
Fixed #68024 #68171 #60387

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -541,17 +541,16 @@ static char *fpm_conf_set_pm(zval *value, void **config, intptr_t offset) /* {{{
 static char *fpm_conf_set_array(zval *key, zval *value, void **config, int convert_to_bool) /* {{{ */
 {
 	struct key_value_s *kv;
-	struct key_value_s ***parent = (struct key_value_s ***) config;
+	key_value_list *parent = *(key_value_list **)config;
 	int b;
 	void *subconf = &b;
 
-	kv = malloc(sizeof(*kv));
+	kv = calloc(1, sizeof(*kv));
 
 	if (!kv) {
 		return "malloc() failed";
 	}
 
-	memset(kv, 0, sizeof(*kv));
 	kv->key = strdup(Z_STRVAL_P(key));
 
 	if (!kv->key) {
@@ -580,8 +579,12 @@ static char *fpm_conf_set_array(zval *key, zval *value, void **config, int conve
 		return "fpm_conf_set_array: strdup(value) failed";
 	}
 
-	kv->next = **parent;
-	**parent = kv;
+	if (parent->head) {
+		parent->tail->next = kv;
+	} else {
+		parent->head = kv;
+	}
+	parent->tail = kv;
 	return NULL;
 }
 /* }}} */
@@ -596,18 +599,20 @@ static void *fpm_worker_pool_config_alloc() /* {{{ */
 		return 0;
 	}
 
-	wp->config = malloc(sizeof(struct fpm_worker_pool_config_s));
+	wp->config = calloc(1, sizeof(struct fpm_worker_pool_config_s));
 
 	if (!wp->config) { 
 		fpm_worker_pool_free(wp);
 		return 0;
 	}
 
-	memset(wp->config, 0, sizeof(struct fpm_worker_pool_config_s));
 	wp->config->listen_backlog = FPM_BACKLOG_DEFAULT;
 	wp->config->pm_process_idle_timeout = 10; /* 10s by default */
 	wp->config->process_priority = 64; /* 64 means unset */
 	wp->config->clear_env = 1;
+	wp->config->env.head = NULL;
+	wp->config->php_values.head = NULL;
+	wp->config->php_admin_values.head = NULL;
 
 	if (!fpm_worker_all_pools) {
 		fpm_worker_all_pools = wp;
@@ -653,19 +658,19 @@ int fpm_worker_pool_config_free(struct fpm_worker_pool_config_s *wpc) /* {{{ */
 	free(wpc->apparmor_hat);
 #endif
 
-	for (kv = wpc->php_values; kv; kv = kv_next) {
+	for (kv = wpc->php_values.head; kv; kv = kv_next) {
 		kv_next = kv->next;
 		free(kv->key);
 		free(kv->value);
 		free(kv);
 	}
-	for (kv = wpc->php_admin_values; kv; kv = kv_next) {
+	for (kv = wpc->php_admin_values.head; kv; kv = kv_next) {
 		kv_next = kv->next;
 		free(kv->key);
 		free(kv->value);
 		free(kv);
 	}
-	for (kv = wpc->env; kv; kv = kv_next) {
+	for (kv = wpc->env.head; kv; kv = kv_next) {
 		kv_next = kv->next;
 		free(kv->key);
 		free(kv->value);
@@ -1067,14 +1072,14 @@ static int fpm_conf_process_all_pools() /* {{{ */
 			char *options[] = FPM_PHP_INI_TO_EXPAND;
 			char **p;
 
-			for (kv = wp->config->php_values; kv; kv = kv->next) {
+			for (kv = wp->config->php_values.head; kv; kv = kv->next) {
 				for (p = options; *p; p++) {
 					if (!strcasecmp(kv->key, *p)) {
 						fpm_evaluate_full_path(&kv->value, wp, NULL, 0);
 					}
 				}
 			}
-			for (kv = wp->config->php_admin_values; kv; kv = kv->next) {
+			for (kv = wp->config->php_admin_values.head; kv; kv = kv->next) {
 				if (!strcasecmp(kv->key, "error_log") && !strcasecmp(kv->value, "syslog")) {
 					continue;
 				}
@@ -1614,15 +1619,15 @@ static void fpm_conf_dump() /* {{{ */
 		zlog(ZLOG_NOTICE, "\tclear_env = %s",                  BOOL2STR(wp->config->clear_env));
 		zlog(ZLOG_NOTICE, "\tsecurity.limit_extensions = %s",  wp->config->security_limit_extensions);
 
-		for (kv = wp->config->env; kv; kv = kv->next) {
+		for (kv = wp->config->env.head; kv; kv = kv->next) {
 			zlog(ZLOG_NOTICE, "\tenv[%s] = %s", kv->key, kv->value);
 		}
 
-		for (kv = wp->config->php_values; kv; kv = kv->next) {
+		for (kv = wp->config->php_values.head; kv; kv = kv->next) {
 			zlog(ZLOG_NOTICE, "\tphp_value[%s] = %s", kv->key, kv->value);
 		}
 
-		for (kv = wp->config->php_admin_values; kv; kv = kv->next) {
+		for (kv = wp->config->php_admin_values.head; kv; kv = kv->next) {
 			zlog(ZLOG_NOTICE, "\tphp_admin_value[%s] = %s", kv->key, kv->value);
 		}
 		zlog(ZLOG_NOTICE, " ");

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -20,6 +20,11 @@ struct key_value_s {
 	char *value;
 };
 
+typedef struct _key_value_list {
+	struct key_value_s *head;
+	struct key_value_s *tail;
+} key_value_list;
+
 /*
  * Please keep the same order as in fpm_conf.c and in php-fpm.conf.in
  */
@@ -85,9 +90,9 @@ struct fpm_worker_pool_config_s {
 	int catch_workers_output;
 	int clear_env;
 	char *security_limit_extensions;
-	struct key_value_s *env;
-	struct key_value_s *php_admin_values;
-	struct key_value_s *php_values;
+	key_value_list env;
+	key_value_list php_admin_values;
+	key_value_list php_values;
 #ifdef HAVE_APPARMOR
 	char *apparmor_hat;
 #endif

--- a/sapi/fpm/fpm/fpm_env.c
+++ b/sapi/fpm/fpm/fpm_env.c
@@ -147,7 +147,7 @@ int fpm_env_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 		clearenv();
 	}
 
-	for (kv = wp->config->env; kv; kv = kv->next) {
+	for (kv = wp->config->env.head; kv; kv = kv->next) {
 		setenv(kv->key, kv->value, 1);
 	}
 
@@ -167,7 +167,7 @@ static int fpm_env_conf_wp(struct fpm_worker_pool_s *wp) /* {{{ */
 {
 	struct key_value_s *kv;
 
-	for (kv = wp->config->env; kv; kv = kv->next) {
+	for (kv = wp->config->env.head; kv; kv = kv->next) {
 		if (*kv->value == '$') {
 			char *value = getenv(kv->value + 1);
 

--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -118,13 +118,13 @@ static int fpm_php_apply_defines(struct fpm_worker_pool_s *wp) /* {{{ */
 {
 	struct key_value_s *kv;
 
-	for (kv = wp->config->php_values; kv; kv = kv->next) {
+	for (kv = wp->config->php_values.head; kv; kv = kv->next) {
 		if (fpm_php_apply_defines_ex(kv, ZEND_INI_USER) == -1) {
 			zlog(ZLOG_ERROR, "Unable to set php_value '%s'", kv->key);
 		}
 	}
 
-	for (kv = wp->config->php_admin_values; kv; kv = kv->next) {
+	for (kv = wp->config->php_admin_values.head; kv; kv = kv->next) {
 		if (fpm_php_apply_defines_ex(kv, ZEND_INI_SYSTEM) == -1) {
 			zlog(ZLOG_ERROR, "Unable to set php_admin_value '%s'", kv->key);
 		}


### PR DESCRIPTION
Bugs: [68024](https://bugs.php.net/bug.php?id=68024), [68171](https://bugs.php.net/bug.php?id=68171), [60387](https://bugs.php.net/bug.php?id=60387)

Instead of prepending key/value pairs into a linked list, we maintain
a head and tail for the three array config buckets so that operations
take place in the correct order _and_ existing values can be
overridden.
