### PR TITLE
Fix #66479: Wrong response to FCGI_GET_VALUES

### DIFF
--- a/sapi/cgi/fastcgi.c
+++ b/sapi/cgi/fastcgi.c
@@ -990,6 +990,7 @@ static int fcgi_read_request(fcgi_request *req)
 		q = req->env.list;
 		while (q != NULL) {
 			if (zend_hash_find(&fcgi_mgmt_vars, q->var, q->var_len, (void**) &value) != SUCCESS) {
+				q = q->list_next;
 				continue;
 			}
 			zlen = Z_STRLEN_PP(value);
@@ -1016,6 +1017,7 @@ static int fcgi_read_request(fcgi_request *req)
 			p += q->var_len;
 			memcpy(p, Z_STRVAL_PP(value), zlen);
 			p += zlen;
+			q = q->list_next;
 		}
 		len = p - buf - sizeof(fcgi_header);
 		len += fcgi_make_header((fcgi_header*)buf, FCGI_GET_VALUES_RESULT, 0, len);


### PR DESCRIPTION
Requesting Get-Values via FCGI caused an "endless" loop over the last requested parameter and ended with an invalid response. this patch solves this loop bug.
