### PR TITLE
Fix #66479: Wrong response to FCGI_GET_VALUES

### DIFF
--- a/sapi/cgi/fastcgi.c
+++ b/sapi/cgi/fastcgi.c
@@ -989,6 +989,7 @@ static int fcgi_read_request(fcgi_request *req)
 		q = req->env.list;
 		while (q != NULL) {
 			if ((value = zend_hash_str_find(&fcgi_mgmt_vars, q->var, q->var_len)) == NULL) {
+				q = q->list_next;
 				continue;
 			}
 			zlen = Z_STRLEN_P(value);
@@ -1015,6 +1016,7 @@ static int fcgi_read_request(fcgi_request *req)
 			p += q->var_len;
 			memcpy(p, Z_STRVAL_P(value), zlen);
 			p += zlen;
+			q = q->list_next;
 		}
 		len = p - buf - sizeof(fcgi_header);
 		len += fcgi_make_header((fcgi_header*)buf, FCGI_GET_VALUES_RESULT, 0, len);


### PR DESCRIPTION
Requesting Get-Values via FCGI caused an "endless" loop over the last requested parameter and ended with an invalid response. this patch solves this loop bug.