### PR TITLE
IDN support in streams

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -3,6 +3,7 @@ dnl $Id$ -*- autoconf -*-
 dnl
 dnl Check if flush should be called explicitly after buffered io
 dnl
+PHP_SETUP_ICU
 AC_CACHE_CHECK([whether flush should be called explicitly after a buffered io], ac_cv_flush_io,[
 AC_TRY_RUN( [
 #include <stdio.h>

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -155,7 +155,7 @@ static php_stream *php_ftp_fopen_connect(php_stream_wrapper *wrapper, const char
 	if (resource->port == 0)
 		resource->port = 21;
 	
-	transport_len = (int)spprintf(&transport, 0, "tcp://%s:%d", resource->host, resource->port);
+	transport_len = (int)spprintf(&transport, 0, "tcp://%s:%d", resource->ascii_domain, resource->port);
 	stream = php_stream_xport_create(transport, transport_len, REPORT_ERRORS, STREAM_XPORT_CLIENT | STREAM_XPORT_CONNECT, NULL, NULL, context, NULL, NULL);
 	efree(transport);
 	if (stream == NULL) {
@@ -552,7 +552,7 @@ php_stream * php_stream_url_wrap_ftp(php_stream_wrapper *wrapper, const char *pa
 	
 	/* open the data channel */
 	if (hoststart == NULL) {
-		hoststart = resource->host;
+		hoststart = resource->ascii_domain;
 	}
 	transport_len = (int)spprintf(&transport, 0, "tcp://%s:%d", hoststart, portno);
 	datastream = php_stream_xport_create(transport, transport_len, REPORT_ERRORS, STREAM_XPORT_CLIENT | STREAM_XPORT_CONNECT, NULL, NULL, context, NULL, NULL);
@@ -719,7 +719,7 @@ php_stream * php_stream_ftp_opendir(php_stream_wrapper *wrapper, const char *pat
 	
 	/* open the data channel */
 	if (hoststart == NULL) {
-		hoststart = resource->host;
+		hoststart = resource->ascii_domain;
 	}
 	datastream = php_stream_sock_open_host(hoststart, portno, SOCK_STREAM, 0, 0);
 	if (datastream == NULL) {

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -197,7 +197,7 @@ php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 			transport_len = Z_STRLEN_P(tmpzval);
 			transport_string = estrndup(Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval));
 		} else {
-			transport_len = spprintf(&transport_string, 0, "%s://%s:%d", use_ssl ? "ssl" : "tcp", resource->host, resource->port);
+			transport_len = spprintf(&transport_string, 0, "%s://%s:%d", use_ssl ? "ssl" : "tcp", resource->ascii_domain, resource->port);
 		}
 	}
 
@@ -240,12 +240,12 @@ php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 
 		/* Set peer_name or name verification will try to use the proxy server name */
 		if (!context || (tmpzval = php_stream_context_get_option(context, "ssl", "peer_name")) == NULL) {
-			ZVAL_STRING(&ssl_proxy_peer_name, resource->host);
+			ZVAL_STRING(&ssl_proxy_peer_name, resource->ascii_domain);
 			php_stream_context_set_option(PHP_STREAM_CONTEXT(stream), "ssl", "peer_name", &ssl_proxy_peer_name);
 		}
 
 		smart_str_appendl(&header, "CONNECT ", sizeof("CONNECT ")-1);
-		smart_str_appends(&header, resource->host);
+		smart_str_appends(&header, resource->ascii_domain);
 		smart_str_appendc(&header, ':');
 		smart_str_append_unsigned(&header, resource->port);
 		smart_str_appendl(&header, " HTTP/1.0\r\n", sizeof(" HTTP/1.0\r\n")-1);
@@ -561,10 +561,10 @@ finish:
 	if ((have_header & HTTP_HEADER_HOST) == 0) {
 		if ((use_ssl && resource->port != 443 && resource->port != 0) || 
 			(!use_ssl && resource->port != 80 && resource->port != 0)) {
-			if (snprintf(scratch, scratch_len, "Host: %s:%i\r\n", resource->host, resource->port) > 0)
+			if (snprintf(scratch, scratch_len, "Host: %s:%i\r\n", resource->ascii_domain, resource->port) > 0)
 				php_stream_write(stream, scratch, strlen(scratch));
 		} else {
-			if (snprintf(scratch, scratch_len, "Host: %s\r\n", resource->host) > 0) {
+			if (snprintf(scratch, scratch_len, "Host: %s\r\n", resource->ascii_domain) > 0) {
 				php_stream_write(stream, scratch, strlen(scratch));
 			}
 		}
@@ -836,9 +836,9 @@ finish:
 					strlcpy(loc_path, location, sizeof(loc_path));
 				}
 				if ((use_ssl && resource->port != 443) || (!use_ssl && resource->port != 80)) {
-					snprintf(new_path, sizeof(new_path) - 1, "%s://%s:%d%s", resource->scheme, resource->host, resource->port, loc_path);
+					snprintf(new_path, sizeof(new_path) - 1, "%s://%s:%d%s", resource->scheme, resource->ascii_domain, resource->port, loc_path);
 				} else {
-					snprintf(new_path, sizeof(new_path) - 1, "%s://%s%s", resource->scheme, resource->host, loc_path);
+					snprintf(new_path, sizeof(new_path) - 1, "%s://%s%s", resource->scheme, resource->ascii_domain, loc_path);
 				}
 			} else {
 				strlcpy(new_path, location, sizeof(new_path));

--- a/ext/standard/tests/http/idn.phpt
+++ b/ext/standard/tests/http/idn.phpt
@@ -1,0 +1,13 @@
+--TEST--
+IDN support
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+$fd = fopen('http://académie-française.fr', 'rb');
+$meta = stream_get_meta_data($fd);
+var_dump($meta['wrapper_data'][0]);
+fclose($fd);
+
+--EXPECT--
+string(15) "HTTP/1.1 200 OK"

--- a/ext/standard/url.h
+++ b/ext/standard/url.h
@@ -12,7 +12,8 @@
    | obtain it through the world-wide-web, please send a note to          |
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
-   | Author: Jim Winstead <jimw@php.net>                                  |
+   | Authors: Jim Winstead <jimw@php.net>                                 |
+   |          Kévin Dunglas <dunglas@gmail.com>                           |
    +----------------------------------------------------------------------+
  */
 /* $Id$ */
@@ -25,6 +26,7 @@ typedef struct php_url {
 	char *user;
 	char *pass;
 	char *host;
+	char *ascii_domain;
 	unsigned short port;
 	char *path;
 	char *query;


### PR DESCRIPTION
As discussed in this thread: http://marc.info/?l=php-internals&m=141107203812897, this PR add IDN support in streams. The way it is down (by adding a new internal field in the `php_url` struct) will allow adding easily IDN validation in `ext/filter`.

TODO:
- [ ] Write an RFC
- [ ] Add Windows support

Tests must be enhanced, it would be great if the PHP org can setup for test purpose:
- An HTTP, HTTPS and FTP enabled server with an IDN
