### PR TITLE
Minor: typo fix in filter_var comment

### DIFF
--- a/ext/filter/filter.c
+++ b/ext/filter/filter.c
@@ -760,7 +760,7 @@ PHP_FUNCTION(filter_input)
 /* }}} */
 
 /* {{{ proto mixed filter_var(mixed variable [, long filter [, mixed options]])
- * Returns the filtered version of the vriable.
+ * Returns the filtered version of the variable.
  */
 PHP_FUNCTION(filter_var)
 {


### PR DESCRIPTION
"vriable" instead of "variable".
