### PR TITLE
Set FPM log level earlier during init

### DIFF
--- a/sapi/fpm/fpm/fpm_unix.c
+++ b/sapi/fpm/fpm/fpm_unix.c
@@ -266,6 +266,8 @@ int fpm_unix_init_main() /* {{{ */
 	struct fpm_worker_pool_s *wp;
 	int is_root = !geteuid();
 
+	zlog_set_level(fpm_globals.log_level);
+
 	if (fpm_global_config.rlimit_files) {
 		struct rlimit r;
 
@@ -396,7 +398,6 @@ int fpm_unix_init_main() /* {{{ */
 		}
 	}
 
-	zlog_set_level(fpm_globals.log_level);
 	return 0;
 }
 /* }}} */


### PR DESCRIPTION
The log level will be ignored throughout log events in `fpm_unix_init_main`, until
the very end when `zlog_set_level` is finally called.

In particular, `fpm_unix_conf_wp` may throw notices like this:

> [08-Nov-2014 17:13:36] NOTICE: [pool www] 'user' directive is ignored when…

Which will still appear even if `log_level` in php-fpm.conf is set to `warning`+

To reproduce, set "log_level" in `php-fpm.conf` to warning. On startup as non-root, these two notices will still appear:

> [08-Nov-2014 17:13:36] NOTICE: [pool www] 'user' directive is ignored when FPM is not running as root
> [08-Nov-2014 17:13:36] NOTICE: [pool www] 'user' directive is ignored when FPM is not running as root

Adresses https://bugs.php.net/bug.php?id=68381
