### PR TITLE
Fix #68355: Inconsistency in example php.ini comments

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -674,7 +674,7 @@ auto_append_file =
 ; http://php.net/default-mimetype
 default_mimetype = "text/html"
 
-; PHP's default character set is set to UTF-8
+; PHP's default character set is set to UTF-8.
 ; http://php.net/default-charset
 default_charset = "UTF-8"
 
@@ -753,7 +753,7 @@ enable_dl = Off
 ; will look for to know it is OK to continue execution.  Setting this variable MAY
 ; cause security issues, KNOW WHAT YOU ARE DOING FIRST.
 ; http://php.net/cgi.redirect-status-env
-;cgi.redirect_status_env = 
+;cgi.redirect_status_env =
 
 ; cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
 ; previous behaviour was to set PATH_TRANSLATED to SCRIPT_FILENAME, and to not grok

--- a/php.ini-production
+++ b/php.ini-production
@@ -674,7 +674,7 @@ auto_append_file =
 ; http://php.net/default-mimetype
 default_mimetype = "text/html"
 
-; PHP's default character set is set to empty.
+; PHP's default character set is set to UTF-8.
 ; http://php.net/default-charset
 default_charset = "UTF-8"
 
@@ -684,10 +684,12 @@ default_charset = "UTF-8"
 ;internal_encoding =
 
 ; PHP input character encoding is set to empty.
+; If empty, default_charset is used.
 ; http://php.net/input-encoding
 ;input_encoding =
 
 ; PHP output character encoding is set to empty.
+; If empty, default_charset is used.
 ; mbstring or iconv output handler is used.
 ; See also output_buffer.
 ; http://php.net/output-encoding


### PR DESCRIPTION
There are some arbitrary differences between php.ini-production and
php.ini-development. This patch corrects the differences.
