### PR TITLE
add php_create_socket/php_destroy_socket PHP_SOCKETS_API 

### DIFF
--- a/ext/sockets/php_sockets.h
+++ b/ext/sockets/php_sockets.h
@@ -70,6 +70,8 @@ struct	sockaddr_un {
 #endif
 
 PHP_SOCKETS_API int php_sockets_le_socket(void);
+PHP_SOCKETS_API php_socket *php_create_socket(void);
+PHP_SOCKETS_API void php_destroy_socket(zend_resource *rsrc TSRMLS_DC);
 
 #define php_sockets_le_socket_name "Socket"
 

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -384,7 +384,7 @@ PHP_SOCKETS_API int php_sockets_le_socket(void) /* {{{ */
 
 /* allocating function to make programming errors due to uninitialized fields
  * less likely */
-static php_socket *php_create_socket(void) /* {{{ */
+PHP_SOCKETS_API php_socket *php_create_socket(void) /* {{{ */
 {
 	php_socket *php_sock = emalloc(sizeof(php_socket));
 
@@ -398,7 +398,7 @@ static php_socket *php_create_socket(void) /* {{{ */
 }
 /* }}} */
 
-static void php_destroy_socket(zend_resource *rsrc TSRMLS_DC) /* {{{ */
+PHP_SOCKETS_API void php_destroy_socket(zend_resource *rsrc TSRMLS_DC) /* {{{ */
 {
 	php_socket *php_sock = rsrc->ptr;
 


### PR DESCRIPTION
This patch is to add php_create_socket/php_destroy_socket PHP_SOCKETS_API to abel to create socket ressource in other extension like php_sockets_le_socket permit to pecl-event to fetch socket ressource.

The first application while be to cast integer file descriptor used by eventlistenet and eventbufferevent in socket ressource:
https://bitbucket.org/osmanov/pecl-event/pull-request/9/add-eventutil-getsocketfromfd-method/diff
