### PR TITLE
Fixed bug #53829 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,10 @@ PHP                                                                        NEWS
   . Fixed bug #68351 (PDO::PARAM_BOOL and ATTR_EMULATE_PREPARES misbehaving)
     (Matteo)
 
+- zlib:
+  . Fixed bug #53829 (Compiling PHP with large file support will replace
+    function gzopen by gzopen64) (Sascha Kettler, Matteo)
+
 13 Nov 2014, PHP 5.5.19
 
 - Core:

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -34,6 +34,18 @@
 #include "ext/standard/php_string.h"
 #include "php_zlib.h"
 
+/*
+ * zlib include files can define the following preprocessor defines which rename
+ * the corresponding PHP functions to gzopen64, gzseek64 and gztell64 and thereby
+ * breaking some software, most notably PEAR's Archive_Tar, which halts execution
+ * without error message on gzip compressed archivesa.
+ *
+ * This only seems to happen on 32bit systems with large file support.
+ */
+#undef gzopen
+#undef gzseek
+#undef gztell
+
 ZEND_DECLARE_MODULE_GLOBALS(zlib);
 
 /* {{{ Memory management wrappers */


### PR DESCRIPTION
Compiling PHP with large file support will replace function gzopen by gzopen64
