### PR TITLE
Minor fix: Missing quotes in openssl test case for bug bug64802

### DIFF
--- a/ext/openssl/tests/bug64802.phpt
+++ b/ext/openssl/tests/bug64802.phpt
@@ -3,7 +3,7 @@ Bug #64802: openssl_x509_parse fails to parse subject properly in some cases
 --SKIPIF--
 <?php
 if (!extension_loaded("openssl")) die("skip");
-if (!defined(OPENSSL_KEYTYPE_EC)) die("skip no EC available);
+if (!defined('OPENSSL_KEYTYPE_EC')) die("skip no EC available");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Fixe syntax error in test
