### PR TITLE
PowerPC64 support in long multiplication

### DIFF
--- a/Zend/zend_multiply.h
+++ b/Zend/zend_multiply.h
@@ -84,6 +84,24 @@
 	}																\
 } while (0)
 
+#elif defined(__powerpc64__) && defined(__GNUC__)
+
+#define ZEND_SIGNED_MULTIPLY_LONG(a, b, lval, dval, usedval) do {  \
+   long __tmpvar;                          \
+   __asm__("li 14, 0\n\t"                          \
+       "mtxer 14\n\t"                                          \
+       "mulldo. %0, %2,%3\n\t"                 \
+       "xor %1, %1, %1\n\t"                    \
+       "bns+ 0f\n\t"                       \
+        "li %1, 1\n\t"                     \
+        "0:\n"                         \
+           : "=r"(__tmpvar),"=r"(usedval)          \
+           : "r"(a), "r"(b)                \
+           : "r14", "cc");                 \
+   if (usedval) (dval) = (double) (a) * (double) (b);      \
+   else (lval) = __tmpvar;                     \
+} while (0)
+
 #elif SIZEOF_ZEND_LONG == 4
 
 #define ZEND_SIGNED_MULTIPLY_LONG(a, b, lval, dval, usedval) do {	\


### PR DESCRIPTION
In long integer multiplications, avoid casting
both operands to long double and use an inline
assembly-based overflow checking function instead.
