### PR TITLE
Fix bug #67704: CURLOPT_POSTFIELDS modify the type of param

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2070,14 +2070,16 @@ string_copy:
 					uint  string_key_len;
 					ulong num_key;
 					int numeric_key;
-					zval *current_tmp = NULL; 
+					zval tmp_current;
+					zval *tmp_current_ptr = NULL;
 					
 					if (Z_TYPE_PP(current) != IS_STRING) {
-                          			ALLOC_INIT_ZVAL(current_tmp);  
-                          			MAKE_COPY_ZVAL(current, current_tmp);
-                          			current = &current_tmp;        
-                          			convert_to_string_ex(current);                                                                                                                                                      
-                      			}
+						tmp_current = **current;
+						zval_copy_ctor(&tmp_current);
+						convert_to_string(&tmp_current);
+						tmp_current_ptr = &tmp_current;
+						current = &tmp_current_ptr;
+					}
 
 					zend_hash_get_current_key_ex(postfields, &string_key, &string_key_len, &num_key, 0, NULL);
 
@@ -2135,10 +2137,9 @@ string_copy:
 					if (numeric_key) {
 						efree(string_key);
 					}
-					if (current_tmp) {
-                          			zval_dtor(current_tmp);
-                          			FREE_ZVAL(current_tmp);
-                      			}
+					if (tmp_current_ptr) {
+						zval_dtor(tmp_current_ptr);
+					}
 				}
 
 				SAVE_CURL_ERROR(ch, error);

--- a/ext/curl/tests/bug67704.phpt
+++ b/ext/curl/tests/bug67704.phpt
@@ -28,8 +28,15 @@ curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
 var_dump($post_data['a']);                                                                                                                                  
 curl_close($ch);
 
+$ch = curl_init();            
+$post_data = array('a' => true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
+var_dump($post_data['a']);                                                                                                                                                                                    
+curl_close($ch);
+
 ?>
 --EXPECTF--
 int(1)
 int(1)
 int(1)
+bool(true)


### PR DESCRIPTION
curl_setopt will modify the type of param
the bugs is here: https://bugs.php.net/bug.php?id=67704

when the type of param is not string, we use a temp variable(current_tmp in the code)， then convert it to string, free the memory of the variable at last
