### PR TITLE
Fix bug #67704: CURLOPT_POSTFIELDS modify the type of param base php-5.5

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2587,7 +2587,9 @@ static int _php_curl_setopt(php_curl *ch, long option, zval **zvalue TSRMLS_DC) 
 					uint   string_key_len;
 					ulong  num_key;
 					int    numeric_key;
-
+					zval tmp_current;
+					zval *tmp_current_ptr = NULL;
+					
 					zend_hash_get_current_key_ex(postfields, &string_key, &string_key_len, &num_key, 0, NULL);
 
 					/* Pretend we have a string_key here */
@@ -2636,9 +2638,14 @@ static int _php_curl_setopt(php_curl *ch, long option, zval **zvalue TSRMLS_DC) 
 						}
 						continue;
 					}
-
-					SEPARATE_ZVAL(current);
-					convert_to_string_ex(current);
+					
+					if (Z_TYPE_PP(current) != IS_STRING) {
+						tmp_current = **current;
+						zval_copy_ctor(&tmp_current);
+						convert_to_string(&tmp_current);
+						tmp_current_ptr = &tmp_current;
+						current = &tmp_current_ptr;
+					}
 
 					postval = Z_STRVAL_PP(current);
 
@@ -2685,6 +2692,9 @@ static int _php_curl_setopt(php_curl *ch, long option, zval **zvalue TSRMLS_DC) 
 
 					if (numeric_key) {
 						efree(string_key);
+					}
+					if (tmp_current_ptr) {
+						zval_dtor(tmp_current_ptr);
 					}
 				}
 

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2524,10 +2524,22 @@ static int _php_curl_setopt(php_curl *ch, long option, zval **zvalue TSRMLS_DC) 
 				 zend_hash_get_current_data(ph, (void **) &current) == SUCCESS;
 				 zend_hash_move_forward(ph)
 			) {
-				SEPARATE_ZVAL(current);
-				convert_to_string_ex(current);
+				zval tmp_current;
+				zval *tmp_current_ptr = NULL;
+
+				if (Z_TYPE_PP(current) != IS_STRING) {
+					tmp_current = **current;
+					zval_copy_ctor(&tmp_current);
+					convert_to_string(&tmp_current);
+					tmp_current_ptr = &tmp_current;
+					current = &tmp_current_ptr;
+				}
 
 				slist = curl_slist_append(slist, Z_STRVAL_PP(current));
+
+				if (tmp_current_ptr) {
+					zval_dtor(tmp_current_ptr);
+				}
 				if (!slist) {
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "Could not build curl_slist");
 					return 1;

--- a/ext/curl/tests/bug67704.phpt
+++ b/ext/curl/tests/bug67704.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Bug #67704 (CURLOPT_POSTFIELDS modify the type of param)
+--SKIPIF--
+<?php 
+if (!extension_loaded("curl")) {
+	exit("skip curl extension not loaded");
+}
+?>
+--FILE--
+<?php
+$ch = curl_init();
+$post_data = array('a' => 1, 'b' => '2'); 
+curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
+var_dump($post_data['a']);                                                                                                                                  
+curl_close($ch);              
+
+$ch = curl_init();            
+$one = 1;                     
+$post_data = array('a' => $one, 'b' => '2');
+curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
+var_dump($post_data['a']);                                                                                                                                  
+curl_close($ch);
+
+$ch = curl_init();
+$one_with_ref = 1;
+$post_data = array('a' => &$one_with_ref, 'b' => '2');
+curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
+var_dump($post_data['a']);                                                                                                                                  
+curl_close($ch);
+
+$ch = curl_init();            
+$post_data = array('a' => true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
+var_dump($post_data['a']);                                                                                                                                                                                    
+curl_close($ch);
+
+?>
+--EXPECTF--
+int(1)
+int(1)
+int(1)
+bool(true)

--- a/ext/curl/tests/bug67704.phpt
+++ b/ext/curl/tests/bug67704.phpt
@@ -31,7 +31,27 @@ curl_close($ch);
 $ch = curl_init();            
 $post_data = array('a' => true);
 curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
-var_dump($post_data['a']);                                                                                                                                                                                    
+var_dump($post_data['a']);
+curl_close($ch);
+
+$ch = curl_init();
+$header = array('a' => 1);
+curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
+var_dump($header['a']);
+curl_close($ch);
+
+$ch = curl_init();
+$one = 1;
+$header = array('a' => $one);
+curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
+var_dump($header['a']);
+curl_close($ch);
+
+$ch = curl_init();
+$two_with_ref = 2;
+$header = array('a' => &$two_with_ref);
+curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
+var_dump($header['a']);
 curl_close($ch);
 
 ?>
@@ -40,3 +60,6 @@ int(1)
 int(1)
 int(1)
 bool(true)
+int(1)
+int(1)
+int(2)


### PR DESCRIPTION
curl_setopt will modify the type of param
the bugs is here: https://bugs.php.net/bug.php?id=67704

when the type of param is not string, we use a temp variable， then convert it to string, free the memory of the variable at last

bug fix base php-5.4 is here: https://github.com/php/php-src/pull/924
