### PR TITLE
Add timing to garbage collection when system supports gettimeofday().

### DIFF
--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -96,6 +96,7 @@ typedef struct _zend_gc_globals {
 
 	uint32_t gc_runs;
 	uint32_t collected;
+	long duration;
 
 #if GC_BENCH
 	uint32_t root_buf_length;


### PR DESCRIPTION
This allows Profilers that hook into the zend_execute stack to gather information about the total time of garbage collection, or depending on the implementation even time of GC in a single function call.

Currently Profilers cannot get this information and therefore the resulting data can be very misleading if the GC is triggered accidently during various function calls.

Sample usage in Qafoo's PHP Profiler extension: https://github.com/QafooLabs/php-profiler-extension/pull/6/files

The inclusion of this change is debatable, first its really only necessary for Profilers, adding overhead of the `gettimeofday` call in any case. However given that GC is triggered in very rare cases this might be considered OK. Composer for multi second long calls only triggers this cleanup 174 times (Reference: https://github.com/composer/composer/pull/3482#issuecomment-65252283)

The other approach could be to make `gc_collect_cycles` hookable by changing it to a function pointer.
