### PR TITLE
Fix bug #68532: convert.base64-encode omits padding bytes

### DIFF
--- a/ext/standard/tests/file/bug68532.phpt
+++ b/ext/standard/tests/file/bug68532.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug #68532: convert.base64-encode omits padding bytes
+--FILE--
+<?php
+$testString = 'test';
+$stream = fopen('php://memory','r+');
+fwrite($stream, $testString);
+rewind($stream);
+$filter = stream_filter_append($stream, 'convert.base64-encode');
+echo "memoryStream = " . stream_get_contents($stream).PHP_EOL;
+
+
+$fileStream = fopen(__DIR__ . '/base64test.txt','w+');
+fwrite($fileStream , $testString);
+rewind($fileStream );
+$filter = stream_filter_append($fileStream , 'convert.base64-encode');
+echo "fileStream = " . stream_get_contents($fileStream ).PHP_EOL;
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/base64test.txt');
+?>
+--EXPECT--
+memoryStream = dGVzdA==
+fileStream = dGVzdA==

--- a/ext/standard/tests/file/stream_rfc2397_007.phpt
+++ b/ext/standard/tests/file/stream_rfc2397_007.phpt
@@ -27,6 +27,7 @@ foreach($streams as $stream)
 	var_dump(feof($fp));
 	echo "===GETC===\n";
 	var_dump(fgetc($fp));
+	var_dump(fgetc($fp));
 	var_dump(ftell($fp));
 	var_dump(feof($fp));
 	echo "===REWIND===\n";
@@ -94,6 +95,7 @@ int(5)
 bool(false)
 ===GETC===
 string(1) "5"
+bool(false)
 int(6)
 bool(true)
 ===REWIND===

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -87,15 +87,19 @@ static size_t php_stream_memory_read(php_stream *stream, char *buf, size_t count
 	php_stream_memory_data *ms = (php_stream_memory_data*)stream->abstract;
 	assert(ms != NULL);
 
-	if (ms->fpos + count >= ms->fsize) {
-		count = ms->fsize - ms->fpos;
+	if (ms->fpos == ms->fsize) {
 		stream->eof = 1;
-	}
-	if (count) {
-		assert(ms->data!= NULL);
-		assert(buf!= NULL);
-		memcpy(buf, ms->data+ms->fpos, count);
-		ms->fpos += count;
+		count = 0;
+	} else {
+		if (ms->fpos + count >= ms->fsize) {
+			count = ms->fsize - ms->fpos;
+		}
+		if (count) {
+			assert(ms->data!= NULL);
+			assert(buf!= NULL);
+			memcpy(buf, ms->data+ms->fpos, count);
+			ms->fpos += count;
+		}
 	}
 	return count;
 }


### PR DESCRIPTION
The memory stream will now read as much as possible and only set the EOF when you try to read when there is nothing left.
This is the way file streams do it and apparently some filter algorithms as convert.base64-encode depend on it.
