### PR TITLE
Revert unintentional docblock change

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -10,7 +10,7 @@
    | http://www.php.net/license/3_01.txt                                  |
    | If you did not receive a copy of the PHP license and are unable to   |
    | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you 6 copy immediately.               |
+   | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
    | Author: Sterling Hughes <sterling@php.net>                           |
    +----------------------------------------------------------------------+


### PR DESCRIPTION
Revert unintentional docblock change

It looks like commit dd8e59da8f5aafd9d77a0f1f17e5e272d09f643f
introduced an unintended docbloc change. I have reverted this
change in this commit.
