### PR TITLE
Formatting fixes for git rules file

### DIFF
--- a/README.GIT-RULES
+++ b/README.GIT-RULES
@@ -114,9 +114,9 @@ If you fix some bugs, you should note the bug ID numbers in your
 commit message. Bug ID should be prefixed by "#" for easier access to
 bug report when developers are browsing CVS via LXR or Bonsai.
 
-Example::
+Example:
 
-  Fixed bug #14016 (pgsql notice handler double free crash bug.)
+Fixed bug #14016 (pgsql notice handler double free crash bug.)
 
 When you change the NEWS file for a bug fix, then please keep the bugs
 sorted in decreasing order under the fixed version.


### PR DESCRIPTION
Formatting fixes for git rules file

This commit fixes 2 issues with the git rules
file. First, a typo of "::" has been changed to
":". Second, an extraneous space has been
removed.
