### PR TITLE
Wasted Shared Memory aboce 2Gb fix

### DIFF
--- a/ext/opcache/zend_accelerator_hash.c
+++ b/ext/opcache/zend_accelerator_hash.c
@@ -26,7 +26,7 @@
 
 /* Generated on an Octa-ALPHA 300MHz CPU & 2.5GB RAM monster */
 static uint prime_numbers[] =
-	{5, 11, 19, 53, 107, 223, 463, 983, 1979, 3907, 7963, 16229, 32531, 65407, 130987, 262237, 524521, 1048793 };
+	{5, 11, 19, 53, 97, 193, 389, 769, 1543, 3079, 6151, 12289, 24593, 49157, 98317, 196613, 393241, 786433, 1572869, 3145739, 6291469, 12582917, 25165843, 50331653, 100663319, 201326611, 402653189, 805306457, 1610612741 };
 static uint num_prime_numbers = sizeof(prime_numbers) / sizeof(uint);
 
 void zend_accel_hash_clean(zend_accel_hash *accel_hash)

--- a/ext/opcache/zend_accelerator_hash.c
+++ b/ext/opcache/zend_accelerator_hash.c
@@ -26,7 +26,7 @@
 
 /* Generated on an Octa-ALPHA 300MHz CPU & 2.5GB RAM monster */
 static uint prime_numbers[] =
-	{5, 11, 19, 53, 97, 193, 389, 769, 1543, 3079, 6151, 12289, 24593, 49157, 98317, 196613, 393241, 786433, 1572869, 3145739, 6291469, 12582917, 25165843, 50331653, 100663319, 201326611, 402653189, 805306457, 1610612741 };
+	{5, 11, 19, 53, 107, 223, 463, 983, 1979, 3907, 7963, 16229, 32531, 65407, 130987, 262237, 524521, 1048793 };
 static uint num_prime_numbers = sizeof(prime_numbers) / sizeof(uint);
 
 void zend_accel_hash_clean(zend_accel_hash *accel_hash)

--- a/ext/opcache/zend_shared_alloc.h
+++ b/ext/opcache/zend_shared_alloc.h
@@ -102,7 +102,7 @@ typedef struct _zend_smm_shared_globals {
     /* Amount of free shared memory */
     size_t                     shared_free;
     /* Amount of shared memory allocated by garbage */
-    int                        wasted_shared_memory;
+    size_t                     wasted_shared_memory;
     /* No more shared memory flag */
     zend_bool                  memory_exhausted;
     /* Saved Shared Allocator State */


### PR DESCRIPTION
When I set opcache.memory_consumption to 10240 (10Gb), it is possible to have more than 2Gb of wasted memory.

The Wasted memory variable in code is stored in signed int instead of size_t.

In fact I end up with negative value of wasted memory and wasted memory percentage, which is less than default 5% for scheduling the reload.

To replicate the problem set the opcache.memory_consumption to high value (3Gb)
Use opcache_compile_file and opcache_invalidate in loop with the same file until wasted memory rises above 2Gb

php.ini settings:

opcache.enable=1
opcache.enable_cli=0
opcache.memory_consumption=10240
opcache.interned_strings_buffer=16
opcache.max_accelerated_files=1048793
opcache.max_wasted_percentage=5
opcache.use_cwd=1
opcache.validate_timestamps=0
opcache.revalidate_freq=2
opcache.revalidate_path=1
opcache.save_comments=1
opcache.load_comments=1
opcache.error_log=/var/log/php-fpm.opcache.log
opcache.log_verbosity_level=1