### PR TITLE
Fix bug #68571 : core dump when webserver close the socket

### DIFF
--- a/sapi/fpm/fpm/fastcgi.c
+++ b/sapi/fpm/fpm/fastcgi.c
@@ -977,6 +977,7 @@ int fcgi_flush(fcgi_request *req, int close)
 
 	if (safe_write(req, req->out_buf, len) != len) {
 		req->keep = 0;
+	        req->out_pos = req->out_buf;
 		return 0;
 	}
 

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -672,8 +672,11 @@ void sapi_cgi_log_fastcgi(int level, char *message, size_t len)
 		char *buf = malloc(len + 2);
 		memcpy(buf, message, len);
 		memcpy(buf + len, "\n", sizeof("\n"));
-		fcgi_write(request, FCGI_STDERR, buf, len+1);
+		ssize_t ret = fcgi_write(request, FCGI_STDERR, buf, len+1);
 		free(buf);
+	        if (ret <= 0) {
+                    php_handle_aborted_connection();
+	        }
 	}
 }
 /* }}} */

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -670,9 +670,10 @@ void sapi_cgi_log_fastcgi(int level, char *message, size_t len)
 	 */
 	if (CGIG(fcgi_logging) && request && message && len > 0) {
 		char *buf = malloc(len + 2);
+		ssize_t ret = 0;
 		memcpy(buf, message, len);
 		memcpy(buf + len, "\n", sizeof("\n"));
-		ssize_t ret = fcgi_write(request, FCGI_STDERR, buf, len+1);
+		ret = fcgi_write(request, FCGI_STDERR, buf, len+1);
 		free(buf);
 	        if (ret <= 0) {
                     php_handle_aborted_connection();


### PR DESCRIPTION
the bug is here: https://bugs.php.net/bug.php?id=68571

There is several conditions when core dump
1 don't use error_log in php.ini.
2 a lot of stderr log generate
3 webserver close the socket after send the request(request timeout will lead the action)

from the  code of php, we know that 
1 output is base a buffer(out_buf)
2 out_pos point to the last address, out_pos - out_buf <= 8192 (the buffer's length)
3 if out_hdr is NULL, we let out_pos add sizeof(fcgi_header)
4 before write data to client, we will reset out_hdr to NULL(in function close_packet)

but when write stderr to client failed, there are two mistake
1 we don't reset the pos of out_pos
2 we don't check the return value of fcgi_write

so out_pos  add more and more sizeof(fcgi_header) until address out of bounds and core dump

I rest the pos of out_pos and check the return value of fcgi_write in my PR