### PR TITLE
Allow arrays with define(), to match const syntax support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ PHP                                                                        NEWS
   . Fixed bug #65769 (localeconv() broken in TS builds). (Anatol)
   . Fixed bug #65230 (setting locale randomly broken). (Anatol)
   . Fixed bug #68545 (NULL pointer dereference in unserialize.c). (Anatol)
+  . Fixed oversight where define() did not support arrays yet const syntax did. (Andrea)
 
 - cURL:
   . Fixed bug #67643 (curl_multi_getcontent returns '' when

--- a/UPGRADING
+++ b/UPGRADING
@@ -68,6 +68,8 @@ PHP 5.6 UPGRADE NOTES
 - Added constant scalar expressions syntax.
   (https://wiki.php.net/rfc/const_scalar_exprs)
 
+- Arrays are now permitted as constant values.
+
 - Added dedicated syntax for variadic functions.
   (https://wiki.php.net/rfc/variadics)
 

--- a/Zend/tests/008.phpt
+++ b/Zend/tests/008.phpt
@@ -41,11 +41,9 @@ bool(true)
 
 Notice: Constant test const already defined in %s on line %d
 bool(false)
+bool(true)
 
-Warning: Constants may only evaluate to scalar values in %s on line %d
-bool(false)
-
-Warning: Constants may only evaluate to scalar values in %s on line %d
+Warning: Constants may only evaluate to scalar values or arrays in %s on line %d
 bool(false)
 int(1)
 int(2)

--- a/Zend/tests/bug37811.phpt
+++ b/Zend/tests/bug37811.phpt
@@ -21,7 +21,7 @@ var_dump(Baz);
 --EXPECTF--
 string(3) "Foo"
 
-Warning: Constants may only evaluate to scalar values in %sbug37811.php on line %d
+Warning: Constants may only evaluate to scalar values or arrays in %sbug37811.php on line %d
 
 Notice: Use of undefined constant Baz - assumed 'Baz' in %sbug37811.php on line %d
 string(3) "Baz"

--- a/Zend/tests/constant_arrays.phpt
+++ b/Zend/tests/constant_arrays.phpt
@@ -1,0 +1,99 @@
+--TEST--
+Constant arrays
+--FILE--
+<?php
+
+define('FOOBAR', [1, 2, 3, ['foo' => 'bar']]);
+const FOO_BAR = [1, 2, 3, ['foo' => 'bar']];
+
+$x = FOOBAR;
+$x[0] = 7;
+var_dump($x, FOOBAR);
+
+$x = FOO_BAR;
+$x[0] = 7;
+var_dump($x, FOO_BAR);
+
+// ensure references are removed
+$x = 7;
+$y = [&$x];
+define('QUX', $y);
+$y[0] = 3;
+var_dump($x, $y, QUX);
+
+// ensure objects not allowed in arrays
+var_dump(define('ELEPHPANT', [new StdClass]));
+
+// ensure recursion doesn't crash
+$recursive = [];
+$recursive[0] = &$recursive;
+var_dump(define('RECURSION', $recursive));
+
+--EXPECTF--
+array(4) {
+  [0]=>
+  int(7)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  array(1) {
+    ["foo"]=>
+    string(3) "bar"
+  }
+}
+array(4) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  array(1) {
+    ["foo"]=>
+    string(3) "bar"
+  }
+}
+array(4) {
+  [0]=>
+  int(7)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  array(1) {
+    ["foo"]=>
+    string(3) "bar"
+  }
+}
+array(4) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  array(1) {
+    ["foo"]=>
+    string(3) "bar"
+  }
+}
+int(3)
+array(1) {
+  [0]=>
+  int(3)
+}
+array(1) {
+  [0]=>
+  int(7)
+}
+
+Warning: Constants may only evaluate to scalar values or arrays in %s on line %d
+bool(false)
+
+Warning: Constants cannot be recursive arrays in %s on line %d
+bool(false)

--- a/Zend/tests/constants_002.phpt
+++ b/Zend/tests/constants_002.phpt
@@ -11,7 +11,7 @@ var_dump(foo);
 
 ?>
 --EXPECTF--
-Warning: Constants may only evaluate to scalar values in %s on line %d
+Warning: Constants may only evaluate to scalar values or arrays in %s on line %d
 
 Notice: Use of undefined constant foo - assumed 'foo' in %s on line %d
 string(%d) "foo"

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -646,6 +646,86 @@ ZEND_FUNCTION(error_reporting)
 /* }}} */
 
 
+static zend_bool validate_constant_array(zval *val) {
+	switch (Z_TYPE_P(val)) {
+		case IS_LONG:
+		case IS_DOUBLE:
+		case IS_STRING:
+		case IS_BOOL:
+		case IS_RESOURCE:
+		case IS_NULL:
+			return 1;
+		case IS_ARRAY:
+			{
+				HashPosition pos;
+				zval **entry;
+
+				if (++Z_ARRVAL_P(val)->nApplyCount > 1) {
+					--Z_ARRVAL_P(val)->nApplyCount;
+					zend_error(E_WARNING, "Constants cannot be recursive arrays");
+					return 0;
+				}
+
+				zend_hash_internal_pointer_reset_ex(Z_ARRVAL_P(val), &pos);
+				while (zend_hash_get_current_data_ex(Z_ARRVAL_P(val), (void **)&entry, &pos) == SUCCESS) {
+					if (!validate_constant_array(*entry)) {
+						return 0;
+					}
+					zend_hash_move_forward_ex(Z_ARRVAL_P(val), &pos);
+				}
+
+				--Z_ARRVAL_P(val)->nApplyCount;
+				return 1;
+			}
+			break;
+		default:
+			zend_error(E_WARNING, "Constants may only evaluate to scalar values or arrays");
+			return 0;
+	}
+}
+
+static zval* copy_constant_array(zval *val) {
+	int orig_array_size = zend_hash_num_elements(Z_ARRVAL_P(val));
+	HashPosition pos;
+	zval **entry;
+	zval *retval;
+
+	MAKE_STD_ZVAL(retval);
+	array_init_size(retval, orig_array_size);
+
+	zend_hash_internal_pointer_reset_ex(Z_ARRVAL_P(val), &pos);
+	while (zend_hash_get_current_data_ex(Z_ARRVAL_P(val), (void **)&entry, &pos) == SUCCESS) {
+		ulong num_key;
+		char *string_key;
+		uint string_key_len;
+		int key_type = zend_hash_get_current_key_ex(Z_ARRVAL_P(val), &string_key, &string_key_len, &num_key, 0, &pos);
+		zval *newentry = *entry;
+
+		if (Z_TYPE_P(newentry) == IS_ARRAY) {
+			newentry = copy_constant_array(newentry);
+		/* constant arrays can't contain references */
+		} else if (Z_ISREF_P(newentry)) {
+			SEPARATE_ZVAL(&newentry);
+		} else {
+			Z_ADDREF_P(newentry);
+		}
+
+		switch (key_type) {
+			case HASH_KEY_IS_STRING:
+				zend_hash_update(Z_ARRVAL_P(retval), string_key, string_key_len, &newentry, sizeof(zval *), NULL);
+				break;
+
+			case HASH_KEY_IS_LONG:	
+				zend_hash_index_update(Z_ARRVAL_P(retval), num_key, &newentry, sizeof(zval *), NULL);
+				break;
+		}
+
+		zend_hash_move_forward_ex(Z_ARRVAL_P(val), &pos);
+	}
+
+	return retval;
+}
+
 /* {{{ proto bool define(string constant_name, mixed value, boolean case_insensitive=false)
    Define a new constant */
 ZEND_FUNCTION(define)
@@ -681,6 +761,13 @@ repeat:
 		case IS_RESOURCE:
 		case IS_NULL:
 			break;
+		case IS_ARRAY:
+			if (!validate_constant_array(val)) {
+				RETURN_FALSE;
+			} else {
+				val = val_free = copy_constant_array(val);
+			}
+			break;
 		case IS_OBJECT:
 			if (!val_free) {
 				if (Z_OBJ_HT_P(val)->get) {
@@ -696,7 +783,7 @@ repeat:
 			}
 			/* no break */
 		default:
-			zend_error(E_WARNING,"Constants may only evaluate to scalar values");
+			zend_error(E_WARNING, "Constants may only evaluate to scalar values or arrays");
 			if (val_free) {
 				zval_ptr_dtor(&val_free);
 			}


### PR DESCRIPTION
This fixes an oversight in PHP 5.6, where you can create constant arrays with `const` yet not with `define()`. The hope is it can go into a micro release, as it's basically just a bugfix.
