### PR TITLE
Allow arrays with define(), to match const syntax support (for master)

### DIFF
--- a/Zend/tests/008.phpt
+++ b/Zend/tests/008.phpt
@@ -41,11 +41,9 @@ bool(true)
 
 Notice: Constant test const already defined in %s on line %d
 bool(false)
+bool(true)
 
-Warning: Constants may only evaluate to scalar values in %s on line %d
-bool(false)
-
-Warning: Constants may only evaluate to scalar values in %s on line %d
+Warning: Constants may only evaluate to scalar values or arrays in %s on line %d
 bool(false)
 int(1)
 int(2)

--- a/Zend/tests/bug37811.phpt
+++ b/Zend/tests/bug37811.phpt
@@ -21,7 +21,7 @@ var_dump(Baz);
 --EXPECTF--
 string(3) "Foo"
 
-Warning: Constants may only evaluate to scalar values in %sbug37811.php on line %d
+Warning: Constants may only evaluate to scalar values or arrays in %sbug37811.php on line %d
 
 Notice: Use of undefined constant Baz - assumed 'Baz' in %sbug37811.php on line %d
 string(3) "Baz"

--- a/Zend/tests/constant_arrays.phpt
+++ b/Zend/tests/constant_arrays.phpt
@@ -1,0 +1,99 @@
+--TEST--
+Constant arrays
+--FILE--
+<?php
+
+define('FOOBAR', [1, 2, 3, ['foo' => 'bar']]);
+const FOO_BAR = [1, 2, 3, ['foo' => 'bar']];
+
+$x = FOOBAR;
+$x[0] = 7;
+var_dump($x, FOOBAR);
+
+$x = FOO_BAR;
+$x[0] = 7;
+var_dump($x, FOO_BAR);
+
+// ensure references are removed
+$x = 7;
+$y = [&$x];
+define('QUX', $y);
+$y[0] = 3;
+var_dump($x, $y, QUX);
+
+// ensure objects not allowed in arrays
+var_dump(define('ELEPHPANT', [new StdClass]));
+
+// ensure recursion doesn't crash
+$recursive = [];
+$recursive[0] = &$recursive;
+var_dump(define('RECURSION', $recursive));
+
+--EXPECTF--
+array(4) {
+  [0]=>
+  int(7)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  array(1) {
+    ["foo"]=>
+    string(3) "bar"
+  }
+}
+array(4) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  array(1) {
+    ["foo"]=>
+    string(3) "bar"
+  }
+}
+array(4) {
+  [0]=>
+  int(7)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  array(1) {
+    ["foo"]=>
+    string(3) "bar"
+  }
+}
+array(4) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  array(1) {
+    ["foo"]=>
+    string(3) "bar"
+  }
+}
+int(3)
+array(1) {
+  [0]=>
+  int(3)
+}
+array(1) {
+  [0]=>
+  int(7)
+}
+
+Warning: Constants may only evaluate to scalar values or arrays in %s on line %d
+bool(false)
+
+Warning: Constants cannot be recursive arrays in %s on line %d
+bool(false)

--- a/Zend/tests/constants_002.phpt
+++ b/Zend/tests/constants_002.phpt
@@ -11,7 +11,7 @@ var_dump(foo);
 
 ?>
 --EXPECTF--
-Warning: Constants may only evaluate to scalar values in %s on line %d
+Warning: Constants may only evaluate to scalar values or arrays in %s on line %d
 
 Notice: Use of undefined constant foo - assumed 'foo' in %s on line %d
 string(%d) "foo"


### PR DESCRIPTION
Version of https://github.com/php/php-src/pull/951 targeted at master.
