### PR TITLE
Fix parse error

### DIFF
--- a/Zend/tests/bug43128.phpt
+++ b/Zend/tests/bug43128.phpt
@@ -15,5 +15,6 @@ eval("class $a {}");
 if ($a instanceof $a); // Segmentation fault
 new $a;                // Segmentation fault
 echo "ok\n";
+?>
 --EXPECT--
 ok


### PR DESCRIPTION
Adding close tag to avoid:

``` php
Parse error: syntax error, unexpected '--' (T_DEC), expecting '[' in bug43128.phpt on line 18
```
