### PR TITLE
Specifying MACRO for PowerPC64

### DIFF
--- a/ext/mbstring/oniguruma/regint.h
+++ b/ext/mbstring/oniguruma/regint.h
@@ -50,6 +50,7 @@
 #if defined(__i386) || defined(__i386__) || defined(_M_IX86) || \
     (defined(__ppc__) && defined(__APPLE__)) || \
     defined(__x86_64) || defined(__x86_64__) || \
+    defined(__powerpc64__) || \
     defined(__mc68020__)
 #define PLATFORM_UNALIGNED_WORD_ACCESS
 #endif


### PR DESCRIPTION
Add PowerPC64 too, which is capable to access unaligned words.