### PR TITLE
remove hardcoded limit on number of pipes in proc_open()

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -240,6 +240,7 @@ static void proc_open_rsrc_dtor(zend_resource *rsrc TSRMLS_DC)
 	FG(pclose_ret) = -1;
 #endif
 	_php_free_envp(proc->env, proc->is_persistent);
+	pefree(proc->pipes, proc->is_persistent);
 	pefree(proc->command, proc->is_persistent);
 	pefree(proc, proc->is_persistent);
 
@@ -428,7 +429,8 @@ PHP_FUNCTION(proc_open)
 	zval *descitem = NULL;
 	zend_string *str_index;
 	zend_ulong nindex;
-	struct php_proc_open_descriptor_item descriptors[PHP_PROC_OPEN_MAX_DESCRIPTORS];
+	struct php_proc_open_descriptor_item *descriptors = NULL;
+	int ndescriptors_array;
 #ifdef PHP_WIN32
 	PROCESS_INFORMATION pi;
 	HANDLE childHandle;
@@ -493,7 +495,11 @@ PHP_FUNCTION(proc_open)
 		memset(&env, 0, sizeof(env));
 	}
 
-	memset(descriptors, 0, sizeof(descriptors));
+	ndescriptors_array = zend_hash_num_elements(Z_ARRVAL_P(descriptorspec));
+
+	descriptors = safe_emalloc(sizeof(struct php_proc_open_descriptor_item), ndescriptors_array, 0);
+
+	memset(descriptors, 0, sizeof(struct php_proc_open_descriptor_item) * ndescriptors_array);
 
 #ifdef PHP_WIN32
 	/* we use this to allow the child to inherit handles */
@@ -663,9 +669,7 @@ PHP_FUNCTION(proc_open)
 				goto exit_fail;
 			}
 		}
-
-		if (++ndesc == PHP_PROC_OPEN_MAX_DESCRIPTORS)
-			break;
+		ndesc++;
 	} ZEND_HASH_FOREACH_END();
 
 #ifdef PHP_WIN32
@@ -869,6 +873,7 @@ PHP_FUNCTION(proc_open)
 	proc = (struct php_process_handle*)pemalloc(sizeof(struct php_process_handle), is_persistent);
 	proc->is_persistent = is_persistent;
 	proc->command = command;
+	proc->pipes = pemalloc(sizeof(zend_resource *) * ndesc, is_persistent);
 	proc->npipes = ndesc;
 	proc->child = child;
 #ifdef PHP_WIN32
@@ -946,10 +951,12 @@ PHP_FUNCTION(proc_open)
 		}
 	}
 
+	efree(descriptors);
 	ZEND_REGISTER_RESOURCE(return_value, proc, le_proc_open);
 	return;
 
 exit_fail:
+	efree(descriptors);
 	_php_free_envp(env, is_persistent);
 	pefree(command, is_persistent);
 #if PHP_CAN_DO_PTS

--- a/ext/standard/proc_open.h
+++ b/ext/standard/proc_open.h
@@ -25,8 +25,6 @@ typedef int php_file_descriptor_t;
 typedef pid_t php_process_id_t;
 #endif
 
-#define PHP_PROC_OPEN_MAX_DESCRIPTORS	16
-
 /* Environment block under win32 is a NUL terminated sequence of NUL terminated
  * name=value strings.
  * Under unix, it is an argv style array.
@@ -44,7 +42,7 @@ struct php_process_handle {
 	HANDLE childHandle;
 #endif
 	int npipes;
-	zend_resource *pipes[PHP_PROC_OPEN_MAX_DESCRIPTORS];
+	zend_resource **pipes;
 	char *command;
 	int is_persistent;
 	php_process_env_t env;

--- a/ext/standard/tests/general_functions/proc_open_pipes1.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes1.phpt
@@ -1,0 +1,75 @@
+--TEST--
+proc_open() with > 16 pipes 
+--FILE--
+<?php
+
+for ($i = 3; $i<= 30; $i++) {
+	$spec[$i] = array('pipe', 'w');
+}
+
+proc_open('sleep 1', $spec, $pipes);
+
+var_dump(count($spec));
+var_dump($pipes);
+
+?>
+--EXPECTF--
+int(28)
+array(28) {
+  [3]=>
+  resource(4) of type (Unknown)
+  [4]=>
+  resource(5) of type (Unknown)
+  [5]=>
+  resource(6) of type (Unknown)
+  [6]=>
+  resource(7) of type (Unknown)
+  [7]=>
+  resource(8) of type (Unknown)
+  [8]=>
+  resource(9) of type (Unknown)
+  [9]=>
+  resource(10) of type (Unknown)
+  [10]=>
+  resource(11) of type (Unknown)
+  [11]=>
+  resource(12) of type (Unknown)
+  [12]=>
+  resource(13) of type (Unknown)
+  [13]=>
+  resource(14) of type (Unknown)
+  [14]=>
+  resource(15) of type (Unknown)
+  [15]=>
+  resource(16) of type (Unknown)
+  [16]=>
+  resource(17) of type (Unknown)
+  [17]=>
+  resource(18) of type (Unknown)
+  [18]=>
+  resource(19) of type (Unknown)
+  [19]=>
+  resource(20) of type (Unknown)
+  [20]=>
+  resource(21) of type (Unknown)
+  [21]=>
+  resource(22) of type (Unknown)
+  [22]=>
+  resource(23) of type (Unknown)
+  [23]=>
+  resource(24) of type (Unknown)
+  [24]=>
+  resource(25) of type (Unknown)
+  [25]=>
+  resource(26) of type (Unknown)
+  [26]=>
+  resource(27) of type (Unknown)
+  [27]=>
+  resource(28) of type (Unknown)
+  [28]=>
+  resource(29) of type (Unknown)
+  [29]=>
+  resource(30) of type (Unknown)
+  [30]=>
+  resource(31) of type (Unknown)
+}

--- a/ext/standard/tests/general_functions/proc_open_pipes2.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes2.phpt
@@ -1,0 +1,16 @@
+--TEST--
+proc_open() with no pipes 
+--FILE--
+<?php
+
+$spec = array();
+proc_open('sleep 1', $spec, $pipes);
+
+var_dump(count($spec));
+var_dump($pipes);
+
+?>
+--EXPECTF--
+int(0)
+array(0) {
+}

--- a/ext/standard/tests/general_functions/proc_open_pipes3.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes3.phpt
@@ -1,0 +1,52 @@
+--TEST--
+proc_open() with invalid pipes 
+--FILE--
+<?php
+
+for ($i = 3; $i<= 5; $i++) {
+	$spec[$i] = array('pipe', 'w');
+}
+
+$spec[$i] = array('pi');
+proc_open('sleep 1', $spec, $pipes);
+
+$spec[$i] = 1;
+proc_open('sleep 1', $spec, $pipes);
+
+$spec[$i] = array('pipe', "test");
+proc_open('sleep 1', $spec, $pipes);
+var_dump($pipes);
+
+$spec[$i] = array('file', "test", "z");
+proc_open('sleep 1', $spec, $pipes);
+var_dump($pipes);
+
+echo "END\n";
+?>
+--EXPECTF--
+Warning: proc_open(): pi is not a valid descriptor spec/mode in %s on line %d
+
+Warning: proc_open(): Descriptor item must be either an array or a File-Handle in %s on line %d
+array(4) {
+  [3]=>
+  resource(4) of type (Unknown)
+  [4]=>
+  resource(5) of type (Unknown)
+  [5]=>
+  resource(6) of type (Unknown)
+  [6]=>
+  resource(7) of type (Unknown)
+}
+
+Warning: proc_open(test): failed to open stream: Inappropriate ioctl for device in %s on line %d
+array(4) {
+  [3]=>
+  resource(4) of type (Unknown)
+  [4]=>
+  resource(5) of type (Unknown)
+  [5]=>
+  resource(6) of type (Unknown)
+  [6]=>
+  resource(7) of type (Unknown)
+}
+END


### PR DESCRIPTION
ATM the first test here stops on 16th pipe, no warning/error is produced.
The limit of 16 pipes is hardcoded and there seems to be no reason to have it at all.