### PR TITLE
zend_hash_do_resize: fix compacting condition

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -564,7 +564,7 @@ static void zend_hash_do_resize(HashTable *ht)
 
 	IS_CONSISTENT(ht);
 
-	if (ht->nNumUsed < ht->nNumOfElements) {
+	if (ht->nNumUsed > ht->nNumOfElements) {
 		HANDLE_BLOCK_INTERRUPTIONS();
 		zend_hash_rehash(ht);
 		HANDLE_UNBLOCK_INTERRUPTIONS();


### PR DESCRIPTION
nNumUsed should always be greater or equal to nNumOfElements so original condition is never true and arrays are always doubled in size and compaction is never triggered
