### PR TITLE
Fixed bug #68371 PDO#getAttribute() cannot be called with platform-specific attribute names

### DIFF
--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -458,6 +458,7 @@ static int pdo_mysql_get_attribute(pdo_dbh_t *dbh, long attr, zval *return_value
 			ZVAL_LONG(return_value, H->buffered);
 			break;
 
+		case PDO_ATTR_EMULATE_PREPARES:
 		case PDO_MYSQL_ATTR_DIRECT_QUERY:
 			ZVAL_LONG(return_value, H->emulate_prepare);
 			break;

--- a/ext/pdo_mysql/tests/bug68371.phpt
+++ b/ext/pdo_mysql/tests/bug68371.phpt
@@ -1,0 +1,101 @@
+--TEST--
+PDO MySQL Bug #38671 (PDO#getAttribute() cannot be called with platform-specific attribute names)
+--SKIPIF--
+<?php
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'skipif.inc');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+MySQLPDOTest::skip();
+?>
+--FILE--
+<?php
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+$pdo = MySQLPDOTest::factory();
+$pdo->setAttribute (\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+$attrs = array(
+    // Extensive test: default value and set+get values
+	PDO::ATTR_EMULATE_PREPARES		=> array(null, 1, 0),
+	PDO::MYSQL_ATTR_DIRECT_QUERY	=> array(null, 0, 1),
+	PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => array(null, 0, 1),
+
+    // Just test the default
+	PDO::ATTR_AUTOCOMMIT			=> array(null),
+	PDO::ATTR_PREFETCH				=> array(null),
+	PDO::ATTR_TIMEOUT				=> array(null),
+	PDO::ATTR_ERRMODE				=> array(null),
+	PDO::ATTR_SERVER_VERSION		=> array(null),
+	PDO::ATTR_CLIENT_VERSION		=> array(null),
+	PDO::ATTR_SERVER_INFO			=> array(null),
+	PDO::ATTR_CONNECTION_STATUS		=> array(null),
+	PDO::ATTR_CASE					=> array(null),
+	PDO::ATTR_CURSOR_NAME			=> array(null),
+	PDO::ATTR_CURSOR				=> array(null),
+	PDO::ATTR_ORACLE_NULLS			=> array(null),
+	PDO::ATTR_PERSISTENT			=> array(null),
+	PDO::ATTR_STATEMENT_CLASS		=> array(null),
+	PDO::ATTR_FETCH_TABLE_NAMES		=> array(null),
+	PDO::ATTR_FETCH_CATALOG_NAMES	=> array(null),
+	PDO::ATTR_DRIVER_NAME			=> array(null),
+	PDO::ATTR_STRINGIFY_FETCHES		=> array(null),
+	PDO::ATTR_MAX_COLUMN_LEN		=> array(null),
+	PDO::ATTR_DEFAULT_FETCH_MODE	=> array(null),
+);
+
+foreach ($attrs as $a => $vals) {
+	foreach ($vals as $v) {
+		try {
+			if (!isset($v)) {
+				var_dump($pdo->getAttribute($a));
+			} else {
+				$pdo->setAttribute($a, $v);
+				if ($pdo->getAttribute($a) === $v) {
+					echo "OK\n";
+				} else {
+					throw new \Exception('KO');
+				}
+			}
+		} catch (\Exception $e) {
+			if ($e->getCode() == 'IM001') {
+				echo "ERR\n";
+			} else {
+				echo "ERR {$e->getMessage()}\n";
+			}
+		}
+	}
+}
+
+?>
+--EXPECTF--
+int(1)
+OK
+OK
+int(0)
+OK
+OK
+int(1)
+OK
+OK
+int(1)
+ERR
+ERR
+int(2)
+string(%d) "%s"
+string(%d) "%s"
+string(%d) "%s"
+string(%d) "%s"
+int(2)
+ERR
+ERR
+int(0)
+bool(false)
+array(1) {
+  [0]=>
+  string(12) "PDOStatement"
+}
+ERR
+ERR
+string(5) "mysql"
+ERR
+ERR
+int(4)
+

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -379,6 +379,14 @@ static int pdo_pgsql_get_attribute(pdo_dbh_t *dbh, long attr, zval *return_value
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 
 	switch (attr) {
+		case PDO_ATTR_EMULATE_PREPARES:
+			ZVAL_BOOL(return_value, H->emulate_prepares);
+			break;
+
+		case PDO_PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT:
+			ZVAL_BOOL(return_value, H->disable_native_prepares);
+			break;
+
 		case PDO_ATTR_CLIENT_VERSION:
 			ZVAL_STRING(return_value, PG_VERSION, 1);
 			break;

--- a/ext/pdo_pgsql/tests/bug68371.phpt
+++ b/ext/pdo_pgsql/tests/bug68371.phpt
@@ -1,0 +1,99 @@
+--TEST--
+PDO PgSQL Bug #38671 (PDO#getAttribute() cannot be called with platform-specific attribute names)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+require dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+
+require dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+$pdo->setAttribute (\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+$attrs = array(
+    // Extensive test: default value and set+get values
+	PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT => array(null, true, false),
+	PDO::ATTR_EMULATE_PREPARES		=> array(null, true, false),
+
+    // Just test the default
+	PDO::ATTR_AUTOCOMMIT			=> array(null),
+	PDO::ATTR_PREFETCH				=> array(null),
+	PDO::ATTR_TIMEOUT				=> array(null),
+	PDO::ATTR_ERRMODE				=> array(null),
+	PDO::ATTR_SERVER_VERSION		=> array(null),
+	PDO::ATTR_CLIENT_VERSION		=> array(null),
+	PDO::ATTR_SERVER_INFO			=> array(null),
+	PDO::ATTR_CONNECTION_STATUS		=> array(null),
+	PDO::ATTR_CASE					=> array(null),
+	PDO::ATTR_CURSOR_NAME			=> array(null),
+	PDO::ATTR_CURSOR				=> array(null),
+	PDO::ATTR_ORACLE_NULLS			=> array(null),
+	PDO::ATTR_PERSISTENT			=> array(null),
+	PDO::ATTR_STATEMENT_CLASS		=> array(null),
+	PDO::ATTR_FETCH_TABLE_NAMES		=> array(null),
+	PDO::ATTR_FETCH_CATALOG_NAMES	=> array(null),
+	PDO::ATTR_DRIVER_NAME			=> array(null),
+	PDO::ATTR_STRINGIFY_FETCHES		=> array(null),
+	PDO::ATTR_MAX_COLUMN_LEN		=> array(null),
+	PDO::ATTR_DEFAULT_FETCH_MODE	=> array(null),
+);
+
+foreach ($attrs as $a => $vals) {
+	foreach ($vals as $v) {
+		try {
+			if (!isset($v)) {
+				var_dump($pdo->getAttribute($a));
+			} else {
+				$pdo->setAttribute($a, $v);
+				if ($pdo->getAttribute($a) === $v) {
+					echo "OK\n";
+				} else {
+					throw new \Exception('KO');
+				}
+			}
+		} catch (\Exception $e) {
+			if ($e->getCode() == 'IM001') {
+				echo "ERR\n";
+			} else {
+				echo "ERR {$e->getMessage()}\n";
+			}
+		}
+	}
+}
+
+?>
+--EXPECTF--
+bool(false)
+OK
+OK
+bool(false)
+OK
+OK
+ERR
+ERR
+ERR
+int(2)
+string(%d) "%s"
+string(%d) "%s"
+string(%d) "%s"
+string(31) "%s"
+int(2)
+ERR
+ERR
+int(0)
+bool(false)
+array(1) {
+  [0]=>
+  string(12) "PDOStatement"
+}
+ERR
+ERR
+string(5) "pgsql"
+ERR
+ERR
+int(4)
+


### PR DESCRIPTION
The PR is for 5.5. Merging up to 5.6 and master requires more changes.

Please do not merge. I will take care of it once Travis is happy.