### PR TITLE
add get_error_handler() and get_exception_handler()

### DIFF
--- a/Zend/tests/error_handler_001.phpt
+++ b/Zend/tests/error_handler_001.phpt
@@ -1,0 +1,32 @@
+--TEST--
+error handler tests - 1
+--FILE--
+<?php
+
+var_dump(get_error_handler());
+
+var_dump(set_error_handler("my_error_handler"));
+
+trigger_error("test", E_USER_WARNING);
+
+var_dump(restore_error_handler());
+
+var_dump(get_error_handler());
+
+function my_error_handler($errno, $errstr, $errfile, $errline) {
+        var_dump($errno, $errstr, $errfile, $errline);
+}
+
+echo "Done\n";
+?>
+--EXPECTF--
+NULL
+NULL
+int(512)
+string(4) "test"
+string(%d) "%s/Zend/tests/error_handler_001.php"
+int(7)
+bool(true)
+NULL
+Done
+

--- a/Zend/tests/exception_handler_007.phpt
+++ b/Zend/tests/exception_handler_007.phpt
@@ -1,0 +1,30 @@
+--TEST--
+exception handler tests - 1
+--FILE--
+<?php
+
+var_dump(get_exception_handler());
+
+var_dump(set_exception_handler("my_exception_handler"));
+
+throw new test();
+
+function my_exception_handler($e) {
+	var_dump(get_class($e)." thrown!");
+
+	var_dump(restore_exception_handler());
+
+	var_dump(get_exception_handler());
+}
+
+class test extends Exception {
+}
+
+echo "Done\n";
+?>
+--EXPECTF--
+NULL
+NULL
+string(12) "test thrown!"
+bool(true)
+NULL

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -68,8 +68,10 @@ static ZEND_FUNCTION(get_object_vars);
 static ZEND_FUNCTION(get_class_methods);
 static ZEND_FUNCTION(trigger_error);
 static ZEND_FUNCTION(set_error_handler);
+static ZEND_FUNCTION(get_error_handler);
 static ZEND_FUNCTION(restore_error_handler);
 static ZEND_FUNCTION(set_exception_handler);
+static ZEND_FUNCTION(get_exception_handler);
 static ZEND_FUNCTION(restore_exception_handler);
 static ZEND_FUNCTION(get_declared_classes);
 static ZEND_FUNCTION(get_declared_traits);
@@ -286,8 +288,10 @@ static const zend_function_entry builtin_functions[] = { /* {{{ */
 	ZEND_FE(trigger_error,		arginfo_trigger_error)
 	ZEND_FALIAS(user_error,		trigger_error,		arginfo_trigger_error)
 	ZEND_FE(set_error_handler,		arginfo_set_error_handler)
+	ZEND_FE(get_error_handler,		arginfo_zend__void)
 	ZEND_FE(restore_error_handler,		arginfo_zend__void)
 	ZEND_FE(set_exception_handler,		arginfo_set_exception_handler)
+	ZEND_FE(get_exception_handler,		arginfo_zend__void)
 	ZEND_FE(restore_exception_handler,	arginfo_zend__void)
 	ZEND_FE(get_declared_classes, 		arginfo_zend__void)
 	ZEND_FE(get_declared_traits, 		arginfo_zend__void)
@@ -1656,6 +1660,16 @@ ZEND_FUNCTION(set_error_handler)
 }
 /* }}} */
 
+/* {{{ proto string get_error_handler(void)
+   Returns the currently defined error handler, or null */
+ZEND_FUNCTION(get_error_handler)
+{
+        if (Z_TYPE(EG(user_error_handler)) != IS_UNDEF) {
+                RETVAL_ZVAL(&EG(user_error_handler), 1, 0);
+        }
+}
+/* }}} */
+
 /* {{{ proto void restore_error_handler(void)
    Restores the previously defined error handler function */
 ZEND_FUNCTION(restore_error_handler)
@@ -1715,6 +1729,16 @@ ZEND_FUNCTION(set_exception_handler)
 	}
 
 	ZVAL_DUP(&EG(user_exception_handler), exception_handler);
+}
+/* }}} */
+
+/* {{{ proto string get_exception_handler(void)
+   Returns the currently defined exception handler, or null */
+ZEND_FUNCTION(get_exception_handler)
+{
+        if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
+                RETVAL_ZVAL(&EG(user_exception_handler), 1, 0);
+        }
 }
 /* }}} */
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1664,6 +1664,10 @@ ZEND_FUNCTION(set_error_handler)
    Returns the currently defined error handler, or null */
 ZEND_FUNCTION(get_error_handler)
 {
+        if (zend_parse_parameters_none() == FAILURE) {
+                return;
+        }
+
 	if (Z_TYPE(EG(user_error_handler)) != IS_UNDEF) {
 		RETVAL_ZVAL(&EG(user_error_handler), 1, 0);
 	}
@@ -1736,6 +1740,10 @@ ZEND_FUNCTION(set_exception_handler)
    Returns the currently defined exception handler, or null */
 ZEND_FUNCTION(get_exception_handler)
 {
+        if (zend_parse_parameters_none() == FAILURE) {
+                return;
+        }
+
 	if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
 		RETVAL_ZVAL(&EG(user_exception_handler), 1, 0);
 	}

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1664,9 +1664,9 @@ ZEND_FUNCTION(set_error_handler)
    Returns the currently defined error handler, or null */
 ZEND_FUNCTION(get_error_handler)
 {
-        if (Z_TYPE(EG(user_error_handler)) != IS_UNDEF) {
-                RETVAL_ZVAL(&EG(user_error_handler), 1, 0);
-        }
+	if (Z_TYPE(EG(user_error_handler)) != IS_UNDEF) {
+		RETVAL_ZVAL(&EG(user_error_handler), 1, 0);
+	}
 }
 /* }}} */
 
@@ -1736,9 +1736,9 @@ ZEND_FUNCTION(set_exception_handler)
    Returns the currently defined exception handler, or null */
 ZEND_FUNCTION(get_exception_handler)
 {
-        if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
-                RETVAL_ZVAL(&EG(user_exception_handler), 1, 0);
-        }
+	if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
+		RETVAL_ZVAL(&EG(user_exception_handler), 1, 0);
+	}
 }
 /* }}} */
 


### PR DESCRIPTION
Sometimes it is useful to get the current error/exception handler without replacing it (which is already possible with set__handler and restore__handler albeit a a bit more work).
Merging this PR would also resolve https://bugs.php.net/bug.php?id=54033
