### PR TITLE
Fix #49270: configure fails if PHP source folder path contains spaces

### DIFF
--- a/Zend/Makefile.am
+++ b/Zend/Makefile.am
@@ -33,24 +33,24 @@ zend_ini_scanner.lo: zend_ini_parser.h
 # Language parser/scanner rules
 
 zend_language_scanner.c: $(srcdir)/zend_language_scanner.l
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt $(srcdir)/zend_language_scanner_defs.h -o$@ $(srcdir)/zend_language_scanner.l
+	$(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt "$(srcdir)/zend_language_scanner_defs.h" -o$@ $(srcdir)/zend_language_scanner.l
 
 zend_language_parser.h: zend_language_parser.c
 zend_language_parser.c: $(srcdir)/zend_language_parser.y
-	$(YACC) -p zend -v -d $(srcdir)/zend_language_parser.y -o zend_language_parser.c
+	$(YACC) -p zend -v -d "$(srcdir)/zend_language_parser.y" -o zend_language_parser.c
 
 # INI parser/scanner rules
 
 zend_ini_parser.c: $(srcdir)/zend_ini_parser.y
-	$(YACC) -p ini_ -v -d $(srcdir)/zend_ini_parser.y -o zend_ini_parser.c
+	$(YACC) -p ini_ -v -d "$(srcdir)/zend_ini_parser.y" -o zend_ini_parser.c
 
 zend_ini_scanner.c: $(srcdir)/zend_ini_scanner.l
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt $(srcdir)/zend_ini_scanner_defs.h -o$@ $(srcdir)/zend_ini_scanner.l
+	$(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt "$(srcdir)/zend_ini_scanner_defs.h" -o$@ $(srcdir)/zend_ini_scanner.l
 
 zend_ini_parser.h: zend_ini_parser.c
 
 depend:
 
 zend_execute.lo: $(srcdir)/zend_execute.c
-	$(LIBTOOL) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(CPPFLAGS) $(INLINE_CFLAGS) -c $(srcdir)/zend_execute.c
+	$(LIBTOOL) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(CPPFLAGS) $(INLINE_CFLAGS) -c "$(srcdir)/zend_execute.c"
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -954,7 +954,7 @@ AC_DEFUN([PHP_NEW_EXTENSION],[
   ext_builddir=[]PHP_EXT_BUILDDIR($1)
   ext_srcdir=[]PHP_EXT_SRCDIR($1)
 
-  ifelse($5,,ac_extra=,[ac_extra=`echo "$5"| $SED 's#@ext_srcdir@#"$ext_srcdir"#g'|$SED s#@ext_builddir@#$ext_builddir#g`])
+  ifelse($5,,ac_extra=,[ac_extra=`echo "$5"|$SED "s#@ext_srcdir@#\"$ext_srcdir\"#g"|$SED s#@ext_builddir@#$ext_builddir#g`])
 
   if test "$3" != "shared" && test "$3" != "yes" && test "$4" != "cli"; then
 dnl ---------------------------------------------- Static module

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -162,7 +162,7 @@ EOF
     eval echo "$i = \$$i" >> Makefile
   done
 
-  cat $abs_srcdir/Makefile.global Makefile.fragments Makefile.objects >> Makefile
+  cat "$abs_srcdir/Makefile.global" Makefile.fragments Makefile.objects >> Makefile
 ])
 
 dnl
@@ -177,7 +177,7 @@ AC_DEFUN([PHP_ADD_MAKEFILE_FRAGMENT],[
   ifelse($1,,src=$ext_srcdir/Makefile.frag,src=$1)
   ifelse($2,,ac_srcdir=$ext_srcdir,ac_srcdir=$2)
   ifelse($3,,ac_builddir=$ext_builddir,ac_builddir=$3)
-  test -f "$src" && $SED -e "s#\$(srcdir)#$ac_srcdir#g" -e "s#\$(builddir)#$ac_builddir#g" $src  >> Makefile.fragments
+  test -f "$src" && $SED -e "s#\$(srcdir)#$ac_srcdir#g" -e "s#\$(builddir)#$ac_builddir#g" "$src"  >> Makefile.fragments
 ])
 
 dnl
@@ -914,7 +914,7 @@ AC_DEFUN([PHP_SELECT_SAPI],[
 
 dnl deprecated
 AC_DEFUN([PHP_EXTENSION],[
-  sources=`$AWK -f $abs_srcdir/build/scan_makefile_in.awk < []PHP_EXT_SRCDIR($1)[]/Makefile.in`
+  sources=`$AWK -f "$abs_srcdir/build/scan_makefile_in.awk" < []PHP_EXT_SRCDIR($1)[]/Makefile.in`
 
   PHP_NEW_EXTENSION($1, $sources, $2, $3)
 
@@ -954,7 +954,7 @@ AC_DEFUN([PHP_NEW_EXTENSION],[
   ext_builddir=[]PHP_EXT_BUILDDIR($1)
   ext_srcdir=[]PHP_EXT_SRCDIR($1)
 
-  ifelse($5,,ac_extra=,[ac_extra=`echo "$5"|$SED s#@ext_srcdir@#$ext_srcdir#g|$SED s#@ext_builddir@#$ext_builddir#g`])
+  ifelse($5,,ac_extra=,[ac_extra=`echo "$5"| $SED 's#@ext_srcdir@#"$ext_srcdir"#g'|$SED s#@ext_builddir@#$ext_builddir#g`])
 
   if test "$3" != "shared" && test "$3" != "yes" && test "$4" != "cli"; then
 dnl ---------------------------------------------- Static module
@@ -2767,9 +2767,9 @@ dnl
 AC_DEFUN([PHP_CHECK_PDO_INCLUDES],[
   AC_CACHE_CHECK([for PDO includes], pdo_cv_inc_path, [
     AC_MSG_CHECKING([for PDO includes])
-    if test -f $abs_srcdir/include/php/ext/pdo/php_pdo_driver.h; then
+    if test -f "$abs_srcdir/include/php/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
-    elif test -f $abs_srcdir/ext/pdo/php_pdo_driver.h; then
+    elif test -f "$abs_srcdir/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
     elif test -f $prefix/include/php/ext/pdo/php_pdo_driver.h; then
       pdo_cv_inc_path=$prefix/include/php/ext

--- a/build/genif.sh
+++ b/build/genif.sh
@@ -19,7 +19,7 @@ fi
 
 header_list=
 olddir=`pwd`
-cd $srcdir
+cd "$srcdir"
 
 module_ptrs="$extra_module_ptrs`echo $@ | $awk -f ./build/order_by_dep.awk`"
 
@@ -29,7 +29,7 @@ done
 
 includes=`$awk -f ./build/print_include.awk $header_list`
 
-cd $olddir
+cd "$olddir"
 
 cat $infile | \
 	sed \

--- a/configure.in
+++ b/configure.in
@@ -1563,11 +1563,11 @@ if test -n "\$REDO_ALL"; then
   echo "creating main/internal_functions.c"
   extensions="$EXT_STATIC"
 dnl mv -f main/internal_functions.c main/internal_functions.c.old 2>/dev/null
-  sh $srcdir/build/genif.sh $srcdir/main/internal_functions.c.in $srcdir "$EXTRA_MODULE_PTRS" $AWK \$extensions > main/internal_functions.c
+  sh "$srcdir/build/genif.sh" "$srcdir/main/internal_functions.c.in" "$srcdir" "$EXTRA_MODULE_PTRS" $AWK \$extensions > main/internal_functions.c
 
   echo "creating main/internal_functions_cli.c"
   cli_extensions="$EXT_CLI_STATIC"
-  sh $srcdir/build/genif.sh $srcdir/main/internal_functions.c.in $srcdir "$EXTRA_MODULE_PTRS" $AWK \$cli_extensions > main/internal_functions_cli.c
+  sh "$srcdir/build/genif.sh" "$srcdir/main/internal_functions.c.in" "$srcdir" "$EXTRA_MODULE_PTRS" $AWK \$cli_extensions > main/internal_functions_cli.c
 
   if test "$UNAME" = "FreeBSD" && test "$PHP_SAPI" = "apache2filter" && test "$TSRM_PTH" != "pth-config" ; then
     echo "+--------------------------------------------------------------------+"

--- a/ext/pdo_dblib/config.m4
+++ b/ext/pdo_dblib/config.m4
@@ -58,9 +58,9 @@ if test "$PHP_PDO_DBLIB" != "no"; then
     PHP_CHECK_PDO_INCLUDES
   ],[
     AC_MSG_CHECKING([for PDO includes])
-    if test -f $abs_srcdir/include/php/ext/pdo/php_pdo_driver.h; then
+    if test -f "$abs_srcdir/include/php/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
-    elif test -f $abs_srcdir/ext/pdo/php_pdo_driver.h; then
+    elif test -f "$abs_srcdir/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
     elif test -f $prefix/include/php/ext/pdo/php_pdo_driver.h; then
       pdo_cv_inc_path=$prefix/include/php/ext

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -126,9 +126,9 @@ if test "$PHP_PDO_MYSQL" != "no"; then
     PHP_CHECK_PDO_INCLUDES
   ],[
     AC_MSG_CHECKING([for PDO includes])
-    if test -f $abs_srcdir/include/php/ext/pdo/php_pdo_driver.h; then
+    if test -f "$abs_srcdir/include/php/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
-    elif test -f $abs_srcdir/ext/pdo/php_pdo_driver.h; then
+    elif test -f "$abs_srcdir/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
     elif test -f $prefix/include/php/ext/pdo/php_pdo_driver.h; then
       pdo_cv_inc_path=$prefix/include/php/ext

--- a/ext/pdo_oci/config.m4
+++ b/ext/pdo_oci/config.m4
@@ -213,9 +213,9 @@ You need to tell me where to find your Oracle Instant Client SDK, or set ORACLE_
     PHP_CHECK_PDO_INCLUDES
   ],[
     AC_MSG_CHECKING([for PDO includes])
-    if test -f $abs_srcdir/include/php/ext/pdo/php_pdo_driver.h; then
+    if test -f "$abs_srcdir/include/php/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
-    elif test -f $abs_srcdir/ext/pdo/php_pdo_driver.h; then
+    elif test -f "$abs_srcdir/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
     elif test -f $prefix/include/php/ext/pdo/php_pdo_driver.h; then
       pdo_cv_inc_path=$prefix/include/php/ext

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -46,9 +46,9 @@ if test "$PHP_PDO_ODBC" != "no"; then
     PHP_CHECK_PDO_INCLUDES
   ],[
     AC_MSG_CHECKING([for PDO includes])
-    if test -f $abs_srcdir/include/php/ext/pdo/php_pdo_driver.h; then
+    if test -f "$abs_srcdir/include/php/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
-    elif test -f $abs_srcdir/ext/pdo/php_pdo_driver.h; then
+    elif test -f "$abs_srcdir/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
     elif test -f $prefix/include/php/ext/pdo/php_pdo_driver.h; then
       pdo_cv_inc_path=$prefix/include/php/ext

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -103,9 +103,9 @@ if test "$PHP_PDO_PGSQL" != "no"; then
     PHP_CHECK_PDO_INCLUDES
   ],[
     AC_MSG_CHECKING([for PDO includes])
-    if test -f $abs_srcdir/include/php/ext/pdo/php_pdo_driver.h; then
+    if test -f "$abs_srcdir/include/php/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
-    elif test -f $abs_srcdir/ext/pdo/php_pdo_driver.h; then
+    elif test -f "$abs_srcdir/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
     elif test -f $prefix/include/php/ext/pdo/php_pdo_driver.h; then
       pdo_cv_inc_path=$prefix/include/php/ext

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -18,9 +18,9 @@ if test "$PHP_PDO_SQLITE" != "no"; then
     PHP_CHECK_PDO_INCLUDES
   ],[
     AC_MSG_CHECKING([for PDO includes])
-    if test -f $abs_srcdir/include/php/ext/pdo/php_pdo_driver.h; then
+    if test -f "$abs_srcdir/include/php/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
-    elif test -f $abs_srcdir/ext/pdo/php_pdo_driver.h; then
+    elif test -f "$abs_srcdir/ext/pdo/php_pdo_driver.h"; then
       pdo_cv_inc_path=$abs_srcdir/ext
     elif test -f $prefix/include/php/ext/pdo/php_pdo_driver.h; then
       pdo_cv_inc_path=$prefix/include/php/ext

--- a/sapi/phpdbg/Makefile.frag
+++ b/sapi/phpdbg/Makefile.frag
@@ -14,11 +14,11 @@ $(BUILD_BINARY): $(PHP_GLOBAL_OBJS) $(PHP_BINARY_OBJS) $(PHP_PHPDBG_OBJS)
 $(builddir)/phpdbg_lexer.lo: $(srcdir)/phpdbg_parser.h
 
 $(srcdir)/phpdbg_lexer.c: $(srcdir)/phpdbg_lexer.l
-	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date -cbdFo $(srcdir)/phpdbg_lexer.c $(srcdir)/phpdbg_lexer.l)
+	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date -cbdFo "$(srcdir)/phpdbg_lexer.c" "$(srcdir)/phpdbg_lexer.l")
 
 $(srcdir)/phpdbg_parser.h: $(srcdir)/phpdbg_parser.c
 $(srcdir)/phpdbg_parser.c: $(srcdir)/phpdbg_parser.y
-	@$(YACC) -p phpdbg_ -v -d $(srcdir)/phpdbg_parser.y -o $@
+	@$(YACC) -p phpdbg_ -v -d "$(srcdir)/phpdbg_parser.y" -o $@
 
 install-phpdbg: $(BUILD_BINARY)
 	@echo "Installing phpdbg binary:         $(INSTALL_ROOT)$(bindir)/"

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -22,8 +22,8 @@ if test "$BUILD_PHPDBG" == "" && test "$PHP_PHPDBG" != "no"; then
   fi
 
   if test "$PHP_PHPDBG_WEBHELPER" != "no"; then
-    if ! test -d $abs_srcdir/ext/phpdbg_webhelper; then
-      ln -s ../sapi/phpdbg $abs_srcdir/ext/phpdbg_webhelper
+    if ! test -d "$abs_srcdir/ext/phpdbg_webhelper"; then
+      ln -s ../sapi/phpdbg "$abs_srcdir/ext/phpdbg_webhelper"
     fi
     PHP_NEW_EXTENSION(phpdbg_webhelper, phpdbg_rinit_hook.c phpdbg_webdata_transfer.c, $ext_shared)
   fi

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo apt-get install re2c libgmp-dev libicu-dev libmcrypt-dev libtidy-dev
+sudo apt-get install re2c libgmp-dev libicu-dev libmcrypt-dev libtidy-dev libmagic-dev

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo apt-get install re2c libgmp-dev libicu-dev libmcrypt-dev libtidy-dev libmagic-dev
+sudo apt-get install re2c libgmp-dev libicu-dev libmcrypt-dev libtidy-dev


### PR DESCRIPTION
Hi,

I added some basic escaping to buildconf files, so I hope it fixes [#49270](https://bugs.php.net/bug.php?id=49270).

Is there a way to test these changes? I guess `phpt` files aren't able to test this, am I wrong?
