### PR TITLE
Fixes #66764 - configure doesn't define EXPANDED_DATADIR / PHP_DATADIR correctly

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1170,7 +1170,7 @@ case $libdir in
     libdir=$libdir/php
     ;;
 esac
-case $datadir in
+case `eval echo $datadir` in
   '${prefix}/share')
     datadir=$datadir/php
     ;;
@@ -1185,7 +1185,7 @@ old_libdir=$libdir
 old_datadir=$datadir
 exec_prefix=`eval echo $exec_prefix`
 libdir=`eval echo $libdir`
-datadir=`eval echo $datadir`
+datadir=`eval eval echo $datadir`
 
 dnl Build extension directory path
 


### PR DESCRIPTION
as the bugreport explains the value for EXPANDED_DATADIR doesn't gets properly expanded.
it is borked since 5.4 when we moved from autoconf 2.13 to 2.59: http://3v4l.org/IpcgT
the reason is that there are some autoconf default values which were changed in autoconf 2.59c(http://lists.gnu.org/archive/html/automake/2006-04/msg00065.html) and datadir is now defaults to '$datarootdir' which in turn defaults to '${prefix}/share'
previously(before autoconf 2.59 so up to php 5.3 there was no datarootdir and datadir was defaulting to '${prefix}/share' so a single eval was enough to expand the path.