### PR TITLE
str_[i]replace(): Add support for (string needle, array replace)

### DIFF
--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -24,6 +24,26 @@
 #ifndef PHP_STRING_H
 #define PHP_STRING_H
 
+/* php_xxx_to_xxx_ex() options */
+
+/* (string search, array replace) - behavior when replace array is exhausted */
+/* Bits 0-2 are reserved for these exclusive values */
+/* Other bits are free for future options */
+
+#define PHP_STR_ARRAY_REPLACE_STOP		0 /* Stop replace */
+#define PHP_STR_ARRAY_REPLACE_FIRST		1 /* Replace remaining matches with first elt */
+#define PHP_STR_ARRAY_REPLACE_LAST		2 /* Replace remaining matches with last elt */
+#define PHP_STR_ARRAY_REPLACE_LOOP		3 /* Loop */
+#define PHP_STR_ARRAY_REPLACE_EMPTY		4 /* Replace remaining matches with an empty string */
+
+#define PHP_STR_ARRAY_REPLACE_MASK		7 /* Bits 0-2 */
+#define PHP_STR_ARRAY_REPLACE_MAX		4 /* Max value */
+
+/* Nothing must be set outside of this mask */
+/* Will evolve when new flags will be defined */
+
+#define PHP_REPLACE_MASK				PHP_STR_ARRAY_REPLACE_MASK
+
 PHP_FUNCTION(strspn);
 PHP_FUNCTION(strcspn);
 PHP_FUNCTION(str_replace);
@@ -131,17 +151,17 @@ PHPAPI zend_string *php_basename(const char *s, size_t len, char *suffix, size_t
 PHPAPI size_t php_dirname(char *str, size_t len);
 PHPAPI char *php_stristr(char *s, char *t, size_t s_len, size_t t_len);
 PHPAPI zend_string *php_str_to_str_ex(char *haystack, size_t length, char *needle,
-		size_t needle_len, char *str, size_t str_len, int case_sensitivity, size_t *replace_count);
+		size_t needle_len, char *str, size_t str_len, int case_sensitivity, size_t *replace_count, zend_long options);
 PHPAPI zend_string *php_str_to_str(char *haystack, size_t length, char *needle,
 		size_t needle_len, char *str, size_t str_len);
 PHPAPI zend_string *php_str_to_array_ex(char *haystack, size_t length, char *needle,
-		size_t needle_len, HashTable *arr, int case_sensitivity, size_t *replace_count);
+		size_t needle_len, HashTable *arr, int case_sensitivity, size_t *replace_count, zend_long options);
 PHPAPI zend_string *php_str_to_array(char *haystack, size_t length, char *needle,
 		size_t needle_len, HashTable *arr);
 PHPAPI zend_string *php_trim(zend_string *str, char *what, size_t what_len, int mode);
 PHPAPI size_t php_strip_tags(char *rbuf, size_t len, int *state, char *allow, size_t allow_len);
 PHPAPI size_t php_strip_tags_ex(char *rbuf, size_t len, int *stateptr, char *allow, size_t allow_len, zend_bool allow_tag_spaces);
-PHPAPI size_t php_char_to_str_ex(char *str, size_t len, char from, char *to, size_t to_len, zval *result, int case_sensitivity, size_t *replace_count);
+PHPAPI size_t php_char_to_str_ex(char *str, size_t len, char from, char *to, size_t to_len, zval *result, int case_sensitivity, size_t *replace_count, zend_long options);
 PHPAPI size_t php_char_to_str(char *str, size_t len, char from, char *to, size_t to_len, zval *result);
 PHPAPI void php_implode(const zend_string *delim, zval *arr, zval *return_value);
 PHPAPI void php_explode(const zend_string *delim, zend_string *str, zval *return_value, zend_long limit);

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -134,6 +134,10 @@ PHPAPI zend_string *php_str_to_str_ex(char *haystack, size_t length, char *needl
 		size_t needle_len, char *str, size_t str_len, int case_sensitivity, size_t *replace_count);
 PHPAPI zend_string *php_str_to_str(char *haystack, size_t length, char *needle,
 		size_t needle_len, char *str, size_t str_len);
+PHPAPI zend_string *php_str_to_array_ex(char *haystack, size_t length, char *needle,
+		size_t needle_len, HashTable *arr, int case_sensitivity, size_t *replace_count);
+PHPAPI zend_string *php_str_to_array(char *haystack, size_t length, char *needle,
+		size_t needle_len, HashTable *arr);
 PHPAPI zend_string *php_trim(zend_string *str, char *what, size_t what_len, int mode);
 PHPAPI size_t php_strip_tags(char *rbuf, size_t len, int *state, char *allow, size_t allow_len);
 PHPAPI size_t php_strip_tags_ex(char *rbuf, size_t len, int *stateptr, char *allow, size_t allow_len, zend_bool allow_tag_spaces);

--- a/ext/standard/tests/strings/str_ireplace.phpt
+++ b/ext/standard/tests/strings/str_ireplace.phpt
@@ -117,10 +117,12 @@ string(143) "Change tracking and management software designed to watch
 Suggest features, report bugs, or ask
 	questions here."
 string(152) "Change tracking and management software designed to watch<br>	for abnormal system behavior.<br>Suggest features, report bugs, or ask<br>	questions here."
-string(30) "FgBnBrCVA10AabNBFjBCA10AabJzK?"
-Count: 11
-string(32) "FgBnBrCVB10CAbNBFjBC1010AabbJzK?"
+string(27) "FgBnBrCVA10AabNBFjAaaAaJzK?"
 Count: 6
-string(14) "FgnBrVNBFjJzK?"
-Count: 11
+string(29) "FgBnBrCVB10CAbNBFj10AabAaJzK?"
+Count: 6
+
+Warning: str_ireplace(): Replace array must not be empty in %s on line %d
+string(25) "FgAnBraVAAaNBaFjAaaAaJzK?"
+Count: 0
 Done

--- a/ext/standard/tests/strings/str_ireplace.phpt
+++ b/ext/standard/tests/strings/str_ireplace.phpt
@@ -2,6 +2,14 @@
 str_ireplace() tests
 --FILE--
 <?php
+function check_ireplace($search,$replace,&$subject)
+{
+$c=0;
+var_dump($subject=str_ireplace($search,$replace,$subject,$c));
+echo "Count: $c\n";
+}
+
+//------
 
 var_dump(str_ireplace());
 var_dump(str_ireplace(""));
@@ -44,6 +52,17 @@ $Data = "Change tracking and management software designed to watch
 var_dump($Data = str_ireplace("\r\n", "<br>", $Data));
 var_dump($Data = str_ireplace("\n", "<br>", $Data));
 
+/* Check 'needle=string/replace=array' case */
+
+$search='a';
+$repl=array('B','C','A',10,'Aab', null);
+$subject='FgAnBraVAAaNBaFjAaaAaJzK?';
+check_ireplace($search,$repl,$subject);
+check_ireplace($search,$repl,$subject);
+
+$repl=array();
+$subject='FgAnBraVAAaNBaFjAaaAaJzK?';
+check_ireplace($search,$repl,$subject);
 
 echo "Done\n";
 ?>
@@ -98,4 +117,10 @@ string(143) "Change tracking and management software designed to watch
 Suggest features, report bugs, or ask
 	questions here."
 string(152) "Change tracking and management software designed to watch<br>	for abnormal system behavior.<br>Suggest features, report bugs, or ask<br>	questions here."
+string(30) "FgBnBrCVA10AabNBFjBCA10AabJzK?"
+Count: 11
+string(32) "FgBnBrCVB10CAbNBFjBC1010AabbJzK?"
+Count: 6
+string(14) "FgnBrVNBFjJzK?"
+Count: 11
 Done

--- a/ext/standard/tests/strings/str_replace.phpt
+++ b/ext/standard/tests/strings/str_replace.phpt
@@ -133,7 +133,7 @@ $obj_subject = new subject;
 class search 
 {
   function __toString() {
-    return "Hello, world";
+    return "world";
   }
 }
 $obj_search = new search;
@@ -141,14 +141,19 @@ $obj_search = new search;
 class replace 
 {
   function __toString() {
-    return "Hello, world";
+    return "everybody";
   }
 }
 $obj_replace = new replace;
 
-var_dump(str_replace("$obj_search", "$obj_replace", "$obj_subject", $count));
+var_dump(str_replace($obj_search, $obj_replace, $obj_subject, $count));
 var_dump($count);
 
+// Check that object vars are still objects
+
+var_dump($obj_subject);
+var_dump($obj_search);
+var_dump($obj_replace);
 
 echo "\n-- Testing arrays --\n";
 var_dump(str_replace(array("a", "a", "b"), "multi", "aaa", $count));
@@ -230,7 +235,7 @@ var_dump( str_replace() );
 var_dump( str_replace("") );
 var_dump( str_replace(NULL) );
 var_dump( str_replace(1, 2) );
-var_dump( str_replace(1,2,3,$var,5) );
+var_dump( str_replace(1,2,3,$var,5,6) );
 
 fclose($resource1);
 closedir($resource2);
@@ -869,8 +874,14 @@ array(3) {
 int(6)
 
 -- Testing objects --
-string(12) "Hello, world"
+string(16) "Hello, everybody"
 int(1)
+object(subject)#1 (0) {
+}
+object(search)#2 (0) {
+}
+object(replace)#3 (0) {
+}
 
 -- Testing arrays --
 string(15) "multimultimulti"
@@ -950,6 +961,6 @@ NULL
 Warning: str_replace() expects at least 3 parameters, 2 given in %s on line %d
 NULL
 
-Warning: str_replace() expects at most 4 parameters, 5 given in %s on line %d
+Warning: str_replace() expects at most 5 parameters, 6 given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/strings/str_replace.phpt
+++ b/ext/standard/tests/strings/str_replace.phpt
@@ -884,11 +884,9 @@ array(2) {
   string(3) "ccc"
 }
 int(6)
-
-Notice: Array to string conversion in %s on line %d
 array(2) {
   [0]=>
-  string(15) "ArrayArrayArray"
+  string(3) "qqc"
   [1]=>
   string(3) "bbb"
 }

--- a/ext/standard/tests/strings/str_replace_variation3.phpt
+++ b/ext/standard/tests/strings/str_replace_variation3.phpt
@@ -172,11 +172,9 @@ array(2) {
   string(3) "ccc"
 }
 int(6)
-
-Notice: Array to string conversion in %s on line %d
 array(1) {
   [0]=>
-  string(15) "ArrayArrayArray"
+  string(3) "qqc"
 }
 int(3)
 array(2) {

--- a/ext/standard/tests/strings/str_replace_variation4.phpt
+++ b/ext/standard/tests/strings/str_replace_variation4.phpt
@@ -18,11 +18,22 @@ precision=14
 	  replace arg was forced to a string.
 */
 
-function check_replace($search,$replace,&$subject)
+function check_replace2(&$result,$search,$replace,$subject,$opt_name)
 {
 $c=0;
-var_dump($subject=str_replace($search,$replace,$subject,$c));
-echo "Count: $c\n";
+$result[$opt_name]['value']=str_replace($search,$replace,$subject,$c,constant($opt_name));
+$result[$opt_name]['count']=$c;
+}
+
+function check_replace($search,$replace,$subject)
+{
+$result=array();
+check_replace2($result,$search,$replace,$subject,'STR_REPLACE_STOP');
+check_replace2($result,$search,$replace,$subject,'STR_REPLACE_LOOP');
+check_replace2($result,$search,$replace,$subject,'STR_REPLACE_FIRST');
+check_replace2($result,$search,$replace,$subject,'STR_REPLACE_LAST');
+check_replace2($result,$search,$replace,$subject,'STR_REPLACE_EMPTY');
+var_dump($result);
 }
 
 //----
@@ -51,28 +62,26 @@ msg("replace count, separate");
 $subject='Replace [?] repl/count [?] separate [?] elem[?]ents';
 check_replace($search,$repl,$subject);
 
-msg("replace loop, grouped");
+msg("multiple, grouped");
 
-$subject='Replace [?][?][?][?][?][?][?][?][?][?][?][?][?][?][?][?][?] a lot of grouped elements';
+$subject='Replace [?][?][?][?][?][?][?][?][?] grouped elements';
 check_replace($search,$repl,$subject);
 
-msg("replace loop, separate");
+msg("multiple, separate");
 
-$subject='[?]Rep[?]la[?]ce [?] ma[?]ny[?] [?] s[?]epa[?]rate [?] el[?]emen[?]ts[?]?';
+$subject='[?]Rep[?]la[?]ce [?] ma[?]ny[?] [?] s[?]epa[?]rate [?]';
 check_replace($search,$repl,$subject);
 
 msg("Empty replace array");
 
-$subject='[?]Rep[?]la[?]ce[?] wi[?]th[?][?][?][?] e[?]mp[?]ty [?]ar[?]ray[?][?]';
+$subject='[?]Rep[?]la[?]ce[?]';
 $repl=array();
 check_replace($search,$repl,$subject);
 
 msg("replace elements contain needle");
 
-$subject='[?]Rep[?]la[?]ce [?]ma[?]ny[?] [?]s[?]epa[?]rate[?] el[?]emen[?]ts[?]?';
+$subject='[?]Rep[?]la[?]ce[?] [?]ma[?]ny[?] ';
 $repl=array('al[?]pz[?]',"[?]b[?]v\n",null,37,"[?]\n[?]");
-check_replace($search,$repl,$subject);
-check_replace($search,$repl,$subject);
 check_replace($search,$repl,$subject);
 
 msg("subject == needle");
@@ -89,22 +98,19 @@ $search=$subject."\n";
 $repl=array(1,2,3);
 check_replace($search,$repl,$subject);
 
-msg("Level 2 cyclic - basic 1");
+msg("Multi-level array");
 
-$subject='[?](?)Rep[?]la[?(?)]ce [?]ma[?]n(?)y[?] (?)[?]s[?]epa[?]';
+$subject='[?](?)Rep[?]la[?(?)]ce [?]ma';
 $repl=array(
 	array('al[?]p(?)z[?]',"[?]b(?)v\n",null,37,"\n[?]"),
 	array('zk(?)j[?]', null, 'ab(?)c', 45)
 	);
 $search=array('[?]','(?)');
 check_replace($search,$repl,$subject);
-check_replace($search,$repl,$subject);
-check_replace($search,$repl,$subject);
 
+msg("Multi-level - empty array");
 
-msg("Level 2 cyclic - empty array (level 2)");
-
-$subject='[?](?)Rep[?]la[?(?)]c<a>e [?]ma[?]n(?)y[?<a>] (?)[?]s[?]epa';
+$subject='[?](?)Rep[?]la[?](?)c<a>e';
 $repl=array(
 	array('ap(?)z[?]',"b[?](?)v\n",null,37,"[?]\n[?]"),
 	array(),
@@ -112,143 +118,1063 @@ $repl=array(
 	);
 $search=array('[?]','(?)','<a>');
 check_replace($search,$repl,$subject);
+
+msg("Multi-level - deep 1");
+
+$search=array('[?]',array('(?)','d','e'),'a','R');
+$repl=array(
+	array('ap(?)z[?]',"b[?](?)v",null,37,"[?]n[?]"),
+	array('a',array('b',null)),
+	array('k(?)j[?]')
+	);
+$subject=array('[?](?)Re[?](?)c<a>e'
+	,'mykey' => array('[?]dabdee(?)ab[?][?]dd(?)ec(?)'
+		,array(null, 'key2' => $search, $repl, 10, 20)
+		),
+	$repl);
 check_replace($search,$repl,$subject);
-check_replace($search,$repl,$subject);
+
+msg('Invalid options value');
+
+$c=0;
+var_dump(str_replace('a','b','abc',$c,50));
+var_dump($c);
 
 ?>
 ===DONE===
 --EXPECTF--	
 --- 1 element ---
 
-string(23) "Replace 1 alpha element"
-Count: 1
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(23) "Replace 1 alpha element"
+    ["count"]=>
+    int(1)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(23) "Replace 1 alpha element"
+    ["count"]=>
+    int(1)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(23) "Replace 1 alpha element"
+    ["count"]=>
+    int(1)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(23) "Replace 1 alpha element"
+    ["count"]=>
+    int(1)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(23) "Replace 1 alpha element"
+    ["count"]=>
+    int(1)
+  }
+}
 
 --- replace count, grouped ---
 
-string(47) "Replace alphabeta10 repl/count grouped elements"
-Count: 4
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(47) "Replace alphabeta10 repl/count grouped elements"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(47) "Replace alphabeta10 repl/count grouped elements"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(47) "Replace alphabeta10 repl/count grouped elements"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(47) "Replace alphabeta10 repl/count grouped elements"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(47) "Replace alphabeta10 repl/count grouped elements"
+    ["count"]=>
+    int(4)
+  }
+}
 
 --- replace count, separate ---
 
-string(50) "Replace alpha repl/count beta separate 10 elements"
-Count: 4
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(50) "Replace alpha repl/count beta separate 10 elements"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(50) "Replace alpha repl/count beta separate 10 elements"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(50) "Replace alpha repl/count beta separate 10 elements"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(50) "Replace alpha repl/count beta separate 10 elements"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(50) "Replace alpha repl/count beta separate 10 elements"
+    ["count"]=>
+    int(4)
+  }
+}
 
---- replace loop, grouped ---
+--- multiple, grouped ---
 
-string(83) "Replace alphabeta10alphabeta10alphabeta10alphabeta10alpha a lot of grouped elements"
-Count: 17
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(51) "Replace alphabeta10[?][?][?][?][?] grouped elements"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(52) "Replace alphabeta10alphabeta10alpha grouped elements"
+    ["count"]=>
+    int(9)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(61) "Replace alphabeta10alphaalphaalphaalphaalpha grouped elements"
+    ["count"]=>
+    int(9)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(36) "Replace alphabeta10 grouped elements"
+    ["count"]=>
+    int(9)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(36) "Replace alphabeta10 grouped elements"
+    ["count"]=>
+    int(9)
+  }
+}
 
---- replace loop, separate ---
+--- multiple, separate ---
 
-string(72) "alphaRepbetala10ce  maalphanybeta 10 sepaalpharate beta el10ementsalpha?"
-Count: 13
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(53) "alphaRepbetala10ce  ma[?]ny[?] [?] s[?]epa[?]rate [?]"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(55) "alphaRepbetala10ce  maalphanybeta 10 sepaalpharate beta"
+    ["count"]=>
+    int(10)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(65) "alphaRepbetala10ce  maalphanyalpha alpha salphaepaalpharate alpha"
+    ["count"]=>
+    int(10)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(35) "alphaRepbetala10ce  many  separate "
+    ["count"]=>
+    int(10)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(35) "alphaRepbetala10ce  many  separate "
+    ["count"]=>
+    int(10)
+  }
+}
 
 --- Empty replace array ---
 
-string(24) "Replace with empty array"
-Count: 15
+
+Warning: str_replace(): Replace array must not be empty in %s on line %d
+
+Warning: str_replace(): Replace array must not be empty in %s on line %d
+
+Warning: str_replace(): Replace array must not be empty in %s on line %d
+
+Warning: str_replace(): Replace array must not be empty in %s on line %d
+
+Warning: str_replace(): Replace array must not be empty in %s on line %d
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(19) "[?]Rep[?]la[?]ce[?]"
+    ["count"]=>
+    int(0)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(19) "[?]Rep[?]la[?]ce[?]"
+    ["count"]=>
+    int(0)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(19) "[?]Rep[?]la[?]ce[?]"
+    ["count"]=>
+    int(0)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(19) "[?]Rep[?]la[?]ce[?]"
+    ["count"]=>
+    int(0)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(19) "[?]Rep[?]la[?]ce[?]"
+    ["count"]=>
+    int(0)
+  }
+}
 
 --- replace elements contain needle ---
 
-string(106) "al[?]pz[?]Rep[?]b[?]v
-lace 37ma[?]
-[?]nyal[?]pz[?] [?]b[?]v
-sepa37rate[?]
-[?] elal[?]pz[?]emen[?]b[?]v
-ts?"
-Count: 13
-string(152) "alal[?]pz[?]pz[?]b[?]v
-Repb37v
-lace 37ma[?]
-[?]
-al[?]pz[?]nyal[?]b[?]v
-pz 37b[?]
-[?]v
-sepa37rateal[?]pz[?]
-[?]b[?]v
- elalpz37emen[?]
-[?]bal[?]pz[?]v
-ts?"
-Count: 16
-string(204) "alalal[?]pz[?]pz[?]b[?]v
-pzb37v
-Repb37v
-lace 37ma[?]
-[?]
-al[?]pz[?]
-al[?]b[?]v
-pznyal37b[?]
-[?]v
-pz 37bal[?]pz[?]
-[?]b[?]v
-v
-sepa37ratealpz37
-[?]
-[?]bal[?]pz[?]v
- elalpz37emen[?]b[?]v
-
-bal37pz[?]
-[?]v
-ts?"
-Count: 20
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(47) "al[?]pz[?]Rep[?]b[?]v
+lace37 [?]
+[?]ma[?]ny[?] "
+    ["count"]=>
+    int(5)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(60) "al[?]pz[?]Rep[?]b[?]v
+lace37 [?]
+[?]maal[?]pz[?]ny[?]b[?]v
+ "
+    ["count"]=>
+    int(7)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(61) "al[?]pz[?]Rep[?]b[?]v
+lace37 [?]
+[?]maal[?]pz[?]nyal[?]pz[?] "
+    ["count"]=>
+    int(7)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(55) "al[?]pz[?]Rep[?]b[?]v
+lace37 [?]
+[?]ma[?]
+[?]ny[?]
+[?] "
+    ["count"]=>
+    int(7)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(41) "al[?]pz[?]Rep[?]b[?]v
+lace37 [?]
+[?]many "
+    ["count"]=>
+    int(7)
+  }
+}
 
 --- subject == needle ---
 
-string(1) "1"
-Count: 1
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(1) "1"
+    ["count"]=>
+    int(1)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(1) "1"
+    ["count"]=>
+    int(1)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(1) "1"
+    ["count"]=>
+    int(1)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(1) "1"
+    ["count"]=>
+    int(1)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(1) "1"
+    ["count"]=>
+    int(1)
+  }
+}
 
 --- length(subject) < length(needle) ---
 
-string(27) "FOOOOOOOOOOOOOOOOOOOOOOOOOO"
-Count: 0
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(27) "FOOOOOOOOOOOOOOOOOOOOOOOOOO"
+    ["count"]=>
+    int(0)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(27) "FOOOOOOOOOOOOOOOOOOOOOOOOOO"
+    ["count"]=>
+    int(0)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(27) "FOOOOOOOOOOOOOOOOOOOOOOOOOO"
+    ["count"]=>
+    int(0)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(27) "FOOOOOOOOOOOOOOOOOOOOOOOOOO"
+    ["count"]=>
+    int(0)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(27) "FOOOOOOOOOOOOOOOOOOOOOOOOOO"
+    ["count"]=>
+    int(0)
+  }
+}
 
---- Level 2 cyclic - basic 1 ---
+--- Multi-level array ---
 
-string(92) "al[?]pzk(?)j[?]z[?]Rep[?]bab(?)cv
-la[?45]ce ma37nzk(?)j[?]y
-[?] al[?]pab(?)cz[?]s[?]b45v
-epa"
-Count: 16
-string(127) "alal[?]pzk(?)j[?]z[?]pzkj[?]bab(?)cv
-zRep37bab45cv
-la[?45]ce ma37nzkzk(?)j[?]j
-[?]y
-al[?]pz[?] al[?]bab(?)cv
-pab45czs37b45v
-epa"
-Count: 17
-string(162) "alalal[?]pzk(?)j[?]z[?]pzkj[?]bab(?)cv
-zpzkj37bab45cv
-zRep37bab45cv
-la[?45]ce ma37nzkzkzk(?)j[?]j
-[?]j
-al[?]pz[?]y
-al[?]bab(?)cv
-pz al37bab45cv
-pab45czs37b45v
-epa"
-Count: 17
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(46) "al[?]pzk(?)j[?]z[?]Rep[?]bab(?)cv
+la[?45]ce ma"
+    ["count"]=>
+    int(7)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(46) "al[?]pzk(?)j[?]z[?]Rep[?]bab(?)cv
+la[?45]ce ma"
+    ["count"]=>
+    int(7)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(46) "al[?]pzk(?)j[?]z[?]Rep[?]bab(?)cv
+la[?45]ce ma"
+    ["count"]=>
+    int(7)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(46) "al[?]pzk(?)j[?]z[?]Rep[?]bab(?)cv
+la[?45]ce ma"
+    ["count"]=>
+    int(7)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(46) "al[?]pzk(?)j[?]z[?]Rep[?]bab(?)cv
+la[?45]ce ma"
+    ["count"]=>
+    int(7)
+  }
+}
 
---- Level 2 cyclic - empty array (level 2) ---
+--- Multi-level - empty array ---
 
-string(58) "apz[?]Repb[?]v
-la[?]ck(?)j[?]e ma37ny[?] [?]
-[?]sapz[?]epa"
-Count: 15
-string(64) "apzapz[?]Repbb[?]v
-v
-lackj37e ma37ny[?]
-[?] apz[?]
-b[?]v
-sapzepa"
-Count: 13
-string(73) "apzapzapz[?]Repbbb[?]v
-v
-v
-lackj37e ma37ny
-37 apz[?]
-[?]
-bapz[?]v
-sapzepa"
-Count: 9
+
+Warning: str_replace(): Replace array must not be empty in %s on line 19
+
+Warning: str_replace(): Replace array must not be empty in %s on line 19
+
+Warning: str_replace(): Replace array must not be empty in %s on line 19
+
+Warning: str_replace(): Replace array must not be empty in %s on line 19
+
+Warning: str_replace(): Replace array must not be empty in %s on line 19
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    string(39) "ap(?)z[?](?)Repb[?](?)v
+la(?)ck(?)j[?]e"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    string(39) "ap(?)z[?](?)Repb[?](?)v
+la(?)ck(?)j[?]e"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    string(39) "ap(?)z[?](?)Repb[?](?)v
+la(?)ck(?)j[?]e"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    string(39) "ap(?)z[?](?)Repb[?](?)v
+la(?)ck(?)j[?]e"
+    ["count"]=>
+    int(4)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    string(39) "ap(?)z[?](?)Repb[?](?)v
+la(?)ck(?)j[?]e"
+    ["count"]=>
+    int(4)
+  }
+}
+
+--- Multi-level - deep 1 ---
+
+array(5) {
+  ["STR_REPLACE_STOP"]=>
+  array(2) {
+    ["value"]=>
+    array(3) {
+      [0]=>
+      string(26) "k(?)j[?]paz[?]ab[?]avac<a>"
+      ["mykey"]=>
+      array(2) {
+        [0]=>
+        string(31) "k(?)j[?]paz[?]babaabb[?]avddaca"
+        [1]=>
+        array(5) {
+          [0]=>
+          string(0) ""
+          ["key2"]=>
+          array(4) {
+            [0]=>
+            string(14) "k(?)j[?]paz[?]"
+            [1]=>
+            array(3) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              string(1) "b"
+              [2]=>
+              string(0) ""
+            }
+            [2]=>
+            string(8) "k(?)j[?]"
+            [3]=>
+            string(0) ""
+          }
+          [1]=>
+          array(3) {
+            [0]=>
+            array(5) {
+              [0]=>
+              string(18) "k(?)j[?]pazapaz[?]"
+              [1]=>
+              string(17) "bk(?)j[?]paz[?]av"
+              [2]=>
+              string(0) ""
+              [3]=>
+              string(2) "37"
+              [4]=>
+              string(21) "k(?)j[?]paz[?]nb[?]av"
+            }
+            [1]=>
+            array(2) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              array(2) {
+                [0]=>
+                string(1) "b"
+                [1]=>
+                string(0) ""
+              }
+            }
+            [2]=>
+            array(1) {
+              [0]=>
+              string(17) "kk(?)j[?]japaz[?]"
+            }
+          }
+          [2]=>
+          string(2) "10"
+          [3]=>
+          string(2) "20"
+        }
+      }
+      [1]=>
+      array(3) {
+        [0]=>
+        array(5) {
+          [0]=>
+          string(18) "k(?)j[?]pazapaz[?]"
+          [1]=>
+          string(17) "bk(?)j[?]paz[?]av"
+          [2]=>
+          string(0) ""
+          [3]=>
+          string(2) "37"
+          [4]=>
+          string(21) "k(?)j[?]paz[?]nb[?]av"
+        }
+        [1]=>
+        array(2) {
+          [0]=>
+          string(8) "k(?)j[?]"
+          [1]=>
+          array(2) {
+            [0]=>
+            string(1) "b"
+            [1]=>
+            string(0) ""
+          }
+        }
+        [2]=>
+        array(1) {
+          [0]=>
+          string(17) "kk(?)j[?]japaz[?]"
+        }
+      }
+    }
+    ["count"]=>
+    int(69)
+  }
+  ["STR_REPLACE_LOOP"]=>
+  array(2) {
+    ["value"]=>
+    array(3) {
+      [0]=>
+      string(61) "k(?)j[?]pk(?)j[?]z[?]k(?)j[?]b[?]k(?)j[?]vk(?)j[?]c<k(?)j[?]>"
+      ["mykey"]=>
+      array(2) {
+        [0]=>
+        string(79) "k(?)j[?]pk(?)j[?]z[?]bk(?)j[?]bk(?)j[?]k(?)j[?]bb[?]k(?)j[?]vbk(?)j[?]ck(?)j[?]"
+        [1]=>
+        array(5) {
+          [0]=>
+          string(0) ""
+          ["key2"]=>
+          array(4) {
+            [0]=>
+            string(21) "k(?)j[?]pk(?)j[?]z[?]"
+            [1]=>
+            array(3) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              string(1) "b"
+              [2]=>
+              string(0) ""
+            }
+            [2]=>
+            string(8) "k(?)j[?]"
+            [3]=>
+            string(0) ""
+          }
+          [1]=>
+          array(3) {
+            [0]=>
+            array(5) {
+              [0]=>
+              string(39) "k(?)j[?]pk(?)j[?]zk(?)j[?]pk(?)j[?]z[?]"
+              [1]=>
+              string(31) "bk(?)j[?]pk(?)j[?]z[?]k(?)j[?]v"
+              [2]=>
+              string(0) ""
+              [3]=>
+              string(2) "37"
+              [4]=>
+              string(35) "k(?)j[?]pk(?)j[?]z[?]nb[?]k(?)j[?]v"
+            }
+            [1]=>
+            array(2) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              array(2) {
+                [0]=>
+                string(1) "b"
+                [1]=>
+                string(0) ""
+              }
+            }
+            [2]=>
+            array(1) {
+              [0]=>
+              string(31) "kk(?)j[?]jk(?)j[?]pk(?)j[?]z[?]"
+            }
+          }
+          [2]=>
+          string(2) "10"
+          [3]=>
+          string(2) "20"
+        }
+      }
+      [1]=>
+      array(3) {
+        [0]=>
+        array(5) {
+          [0]=>
+          string(39) "k(?)j[?]pk(?)j[?]zk(?)j[?]pk(?)j[?]z[?]"
+          [1]=>
+          string(31) "bk(?)j[?]pk(?)j[?]z[?]k(?)j[?]v"
+          [2]=>
+          string(0) ""
+          [3]=>
+          string(2) "37"
+          [4]=>
+          string(35) "k(?)j[?]pk(?)j[?]z[?]nb[?]k(?)j[?]v"
+        }
+        [1]=>
+        array(2) {
+          [0]=>
+          string(8) "k(?)j[?]"
+          [1]=>
+          array(2) {
+            [0]=>
+            string(1) "b"
+            [1]=>
+            string(0) ""
+          }
+        }
+        [2]=>
+        array(1) {
+          [0]=>
+          string(31) "kk(?)j[?]jk(?)j[?]pk(?)j[?]z[?]"
+        }
+      }
+    }
+    ["count"]=>
+    int(102)
+  }
+  ["STR_REPLACE_FIRST"]=>
+  array(2) {
+    ["value"]=>
+    array(3) {
+      [0]=>
+      string(61) "k(?)j[?]pk(?)j[?]z[?]k(?)j[?]b[?]k(?)j[?]vk(?)j[?]c<k(?)j[?]>"
+      ["mykey"]=>
+      array(2) {
+        [0]=>
+        string(80) "k(?)j[?]pk(?)j[?]z[?]bk(?)j[?]bk(?)j[?]k(?)j[?]bb[?]k(?)j[?]vbbk(?)j[?]ck(?)j[?]"
+        [1]=>
+        array(5) {
+          [0]=>
+          string(0) ""
+          ["key2"]=>
+          array(4) {
+            [0]=>
+            string(21) "k(?)j[?]pk(?)j[?]z[?]"
+            [1]=>
+            array(3) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              string(1) "b"
+              [2]=>
+              string(0) ""
+            }
+            [2]=>
+            string(8) "k(?)j[?]"
+            [3]=>
+            string(0) ""
+          }
+          [1]=>
+          array(3) {
+            [0]=>
+            array(5) {
+              [0]=>
+              string(39) "k(?)j[?]pk(?)j[?]zk(?)j[?]pk(?)j[?]z[?]"
+              [1]=>
+              string(31) "bk(?)j[?]pk(?)j[?]z[?]k(?)j[?]v"
+              [2]=>
+              string(0) ""
+              [3]=>
+              string(2) "37"
+              [4]=>
+              string(35) "k(?)j[?]pk(?)j[?]z[?]nb[?]k(?)j[?]v"
+            }
+            [1]=>
+            array(2) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              array(2) {
+                [0]=>
+                string(1) "b"
+                [1]=>
+                string(0) ""
+              }
+            }
+            [2]=>
+            array(1) {
+              [0]=>
+              string(31) "kk(?)j[?]jk(?)j[?]pk(?)j[?]z[?]"
+            }
+          }
+          [2]=>
+          string(2) "10"
+          [3]=>
+          string(2) "20"
+        }
+      }
+      [1]=>
+      array(3) {
+        [0]=>
+        array(5) {
+          [0]=>
+          string(39) "k(?)j[?]pk(?)j[?]zk(?)j[?]pk(?)j[?]z[?]"
+          [1]=>
+          string(31) "bk(?)j[?]pk(?)j[?]z[?]k(?)j[?]v"
+          [2]=>
+          string(0) ""
+          [3]=>
+          string(2) "37"
+          [4]=>
+          string(35) "k(?)j[?]pk(?)j[?]z[?]nb[?]k(?)j[?]v"
+        }
+        [1]=>
+        array(2) {
+          [0]=>
+          string(8) "k(?)j[?]"
+          [1]=>
+          array(2) {
+            [0]=>
+            string(1) "b"
+            [1]=>
+            string(0) ""
+          }
+        }
+        [2]=>
+        array(1) {
+          [0]=>
+          string(31) "kk(?)j[?]jk(?)j[?]pk(?)j[?]z[?]"
+        }
+      }
+    }
+    ["count"]=>
+    int(102)
+  }
+  ["STR_REPLACE_LAST"]=>
+  array(2) {
+    ["value"]=>
+    array(3) {
+      [0]=>
+      string(61) "k(?)j[?]pk(?)j[?]z[?]k(?)j[?]b[?]k(?)j[?]vk(?)j[?]c<k(?)j[?]>"
+      ["mykey"]=>
+      array(2) {
+        [0]=>
+        string(78) "k(?)j[?]pk(?)j[?]z[?]bk(?)j[?]bk(?)j[?]k(?)j[?]bb[?]k(?)j[?]vk(?)j[?]ck(?)j[?]"
+        [1]=>
+        array(5) {
+          [0]=>
+          string(0) ""
+          ["key2"]=>
+          array(4) {
+            [0]=>
+            string(21) "k(?)j[?]pk(?)j[?]z[?]"
+            [1]=>
+            array(3) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              string(1) "b"
+              [2]=>
+              string(0) ""
+            }
+            [2]=>
+            string(8) "k(?)j[?]"
+            [3]=>
+            string(0) ""
+          }
+          [1]=>
+          array(3) {
+            [0]=>
+            array(5) {
+              [0]=>
+              string(39) "k(?)j[?]pk(?)j[?]zk(?)j[?]pk(?)j[?]z[?]"
+              [1]=>
+              string(31) "bk(?)j[?]pk(?)j[?]z[?]k(?)j[?]v"
+              [2]=>
+              string(0) ""
+              [3]=>
+              string(2) "37"
+              [4]=>
+              string(35) "k(?)j[?]pk(?)j[?]z[?]nb[?]k(?)j[?]v"
+            }
+            [1]=>
+            array(2) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              array(2) {
+                [0]=>
+                string(1) "b"
+                [1]=>
+                string(0) ""
+              }
+            }
+            [2]=>
+            array(1) {
+              [0]=>
+              string(31) "kk(?)j[?]jk(?)j[?]pk(?)j[?]z[?]"
+            }
+          }
+          [2]=>
+          string(2) "10"
+          [3]=>
+          string(2) "20"
+        }
+      }
+      [1]=>
+      array(3) {
+        [0]=>
+        array(5) {
+          [0]=>
+          string(39) "k(?)j[?]pk(?)j[?]zk(?)j[?]pk(?)j[?]z[?]"
+          [1]=>
+          string(31) "bk(?)j[?]pk(?)j[?]z[?]k(?)j[?]v"
+          [2]=>
+          string(0) ""
+          [3]=>
+          string(2) "37"
+          [4]=>
+          string(35) "k(?)j[?]pk(?)j[?]z[?]nb[?]k(?)j[?]v"
+        }
+        [1]=>
+        array(2) {
+          [0]=>
+          string(8) "k(?)j[?]"
+          [1]=>
+          array(2) {
+            [0]=>
+            string(1) "b"
+            [1]=>
+            string(0) ""
+          }
+        }
+        [2]=>
+        array(1) {
+          [0]=>
+          string(31) "kk(?)j[?]jk(?)j[?]pk(?)j[?]z[?]"
+        }
+      }
+    }
+    ["count"]=>
+    int(102)
+  }
+  ["STR_REPLACE_EMPTY"]=>
+  array(2) {
+    ["value"]=>
+    array(3) {
+      [0]=>
+      string(21) "k(?)j[?]pz[?]b[?]vc<>"
+      ["mykey"]=>
+      array(2) {
+        [0]=>
+        string(22) "k(?)j[?]pz[?]bbbb[?]vc"
+        [1]=>
+        array(5) {
+          [0]=>
+          string(0) ""
+          ["key2"]=>
+          array(4) {
+            [0]=>
+            string(13) "k(?)j[?]pz[?]"
+            [1]=>
+            array(3) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              string(1) "b"
+              [2]=>
+              string(0) ""
+            }
+            [2]=>
+            string(8) "k(?)j[?]"
+            [3]=>
+            string(0) ""
+          }
+          [1]=>
+          array(3) {
+            [0]=>
+            array(5) {
+              [0]=>
+              string(15) "k(?)j[?]pzpz[?]"
+              [1]=>
+              string(15) "bk(?)j[?]pz[?]v"
+              [2]=>
+              string(0) ""
+              [3]=>
+              string(2) "37"
+              [4]=>
+              string(19) "k(?)j[?]pz[?]nb[?]v"
+            }
+            [1]=>
+            array(2) {
+              [0]=>
+              string(8) "k(?)j[?]"
+              [1]=>
+              array(2) {
+                [0]=>
+                string(1) "b"
+                [1]=>
+                string(0) ""
+              }
+            }
+            [2]=>
+            array(1) {
+              [0]=>
+              string(15) "kk(?)j[?]jpz[?]"
+            }
+          }
+          [2]=>
+          string(2) "10"
+          [3]=>
+          string(2) "20"
+        }
+      }
+      [1]=>
+      array(3) {
+        [0]=>
+        array(5) {
+          [0]=>
+          string(15) "k(?)j[?]pzpz[?]"
+          [1]=>
+          string(15) "bk(?)j[?]pz[?]v"
+          [2]=>
+          string(0) ""
+          [3]=>
+          string(2) "37"
+          [4]=>
+          string(19) "k(?)j[?]pz[?]nb[?]v"
+        }
+        [1]=>
+        array(2) {
+          [0]=>
+          string(8) "k(?)j[?]"
+          [1]=>
+          array(2) {
+            [0]=>
+            string(1) "b"
+            [1]=>
+            string(0) ""
+          }
+        }
+        [2]=>
+        array(1) {
+          [0]=>
+          string(15) "kk(?)j[?]jpz[?]"
+        }
+      }
+    }
+    ["count"]=>
+    int(102)
+  }
+}
+
+--- Invalid options value ---
+
+
+Warning: str_replace(): Invalid options value (50) in %s on line %d
+string(3) "bbc"
+int(1)
 ===DONE===

--- a/ext/standard/tests/strings/str_replace_variation4.phpt
+++ b/ext/standard/tests/strings/str_replace_variation4.phpt
@@ -1,0 +1,178 @@
+--TEST--
+Test str_replace() function for case (needle=string ; replace=array)
+--INI--
+precision=14
+--FILE--
+<?php
+/* 
+  Prototype: mixed str_replace(mixed $search, mixed $replace, 
+                               mixed $subject [, int &$count]);
+  Description: Replace all occurrences of the search string with 
+               the replacement string
+
+  This feature was requested in bug #38685: if needle is a string and replace
+      is an array, each  occurence of needle is replaced by an element of the
+	  replace array. If the replace array contains less elements than the
+	  count of needles found, loop to the first one and continue.
+	  Before this feature was implemented, when the needle was a string, the
+	  replace arg was forced to a string.
+*/
+
+function check_replace($search,$replace,&$subject)
+{
+$c=0;
+var_dump($subject=str_replace($search,$replace,$subject,$c));
+echo "Count: $c\n";
+}
+
+//----
+
+function msg($str)
+{
+echo "\n--- $str ---\n\n";
+}
+
+//----
+
+msg("1 element");
+
+$search='[?]';
+$repl=array('alpha','beta',10, null);
+$subject='Replace 1 [?] element';
+check_replace($search,$repl,$subject);
+
+msg("replace count, grouped");
+
+$subject='Replace [?][?][?][?] repl/count grouped elements';
+check_replace($search,$repl,$subject);
+
+msg("replace count, separate");
+
+$subject='Replace [?] repl/count [?] separate [?] elem[?]ents';
+check_replace($search,$repl,$subject);
+
+msg("replace loop, grouped");
+
+$subject='Replace [?][?][?][?][?][?][?][?][?][?][?][?][?][?][?][?][?] a lot of grouped elements';
+check_replace($search,$repl,$subject);
+
+msg("eplace loop, separate");
+
+$subject='[?]Rep[?]la[?]ce [?] ma[?]ny[?] [?] s[?]epa[?]rate [?] el[?]emen[?]ts[?]?';
+check_replace($search,$repl,$subject);
+
+msg("Empty replace array");
+
+$subject='[?]Rep[?]la[?]ce[?] wi[?]th[?][?][?][?] e[?]mp[?]ty [?]ar[?]ray[?][?]';
+$repl=array();
+check_replace($search,$repl,$subject);
+
+msg("replace elements contain needle");
+
+$subject='[?]Rep[?]la[?]ce [?]ma[?]ny[?] [?]s[?]epa[?]rate[?] el[?]emen[?]ts[?]?';
+$repl=array('al[?]pz[?]',"[?]b[?]v\n",null,37,"[?]\n[?]");
+check_replace($search,$repl,$subject);
+check_replace($search,$repl,$subject);
+check_replace($search,$repl,$subject);
+
+msg("subject == needle");
+
+$search='FOOOOOOOOOOOOOOOOOOOOOOOOOO';
+$subject=$search;
+$repl=array(1,2,3);
+check_replace($search,$repl,$subject);
+
+msg("length(subject) < length(needle)");
+
+$subject='FOOOOOOOOOOOOOOOOOOOOOOOOOO';
+$search=$subject."\n";
+$repl=array(1,2,3);
+check_replace($search,$repl,$subject);
+
+?>
+===DONE===
+--EXPECTF--	
+--- 1 element ---
+
+string(23) "Replace 1 alpha element"
+Count: 1
+
+--- replace count, grouped ---
+
+string(47) "Replace alphabeta10 repl/count grouped elements"
+Count: 4
+
+--- replace count, separate ---
+
+string(50) "Replace alpha repl/count beta separate 10 elements"
+Count: 4
+
+--- replace loop, grouped ---
+
+string(83) "Replace alphabeta10alphabeta10alphabeta10alphabeta10alpha a lot of grouped elements"
+Count: 17
+
+--- eplace loop, separate ---
+
+string(72) "alphaRepbetala10ce  maalphanybeta 10 sepaalpharate beta el10ementsalpha?"
+Count: 13
+
+--- Empty replace array ---
+
+string(24) "Replace with empty array"
+Count: 15
+
+--- replace elements contain needle ---
+
+string(106) "al[?]pz[?]Rep[?]b[?]v
+lace 37ma[?]
+[?]nyal[?]pz[?] [?]b[?]v
+sepa37rate[?]
+[?] elal[?]pz[?]emen[?]b[?]v
+ts?"
+Count: 13
+string(152) "alal[?]pz[?]pz[?]b[?]v
+Repb37v
+lace 37ma[?]
+[?]
+al[?]pz[?]nyal[?]b[?]v
+pz 37b[?]
+[?]v
+sepa37rateal[?]pz[?]
+[?]b[?]v
+ elalpz37emen[?]
+[?]bal[?]pz[?]v
+ts?"
+Count: 16
+string(204) "alalal[?]pz[?]pz[?]b[?]v
+pzb37v
+Repb37v
+lace 37ma[?]
+[?]
+al[?]pz[?]
+al[?]b[?]v
+pznyal37b[?]
+[?]v
+pz 37bal[?]pz[?]
+[?]b[?]v
+v
+sepa37ratealpz37
+[?]
+[?]bal[?]pz[?]v
+ elalpz37emen[?]b[?]v
+
+bal37pz[?]
+[?]v
+ts?"
+Count: 20
+
+--- subject == needle ---
+
+string(1) "1"
+Count: 1
+
+--- length(subject) < length(needle) ---
+
+string(27) "FOOOOOOOOOOOOOOOOOOOOOOOOOO"
+Count: 0
+===DONE===

--- a/ext/standard/tests/strings/str_replace_variation4.phpt
+++ b/ext/standard/tests/strings/str_replace_variation4.phpt
@@ -56,7 +56,7 @@ msg("replace loop, grouped");
 $subject='Replace [?][?][?][?][?][?][?][?][?][?][?][?][?][?][?][?][?] a lot of grouped elements';
 check_replace($search,$repl,$subject);
 
-msg("eplace loop, separate");
+msg("replace loop, separate");
 
 $subject='[?]Rep[?]la[?]ce [?] ma[?]ny[?] [?] s[?]epa[?]rate [?] el[?]emen[?]ts[?]?';
 check_replace($search,$repl,$subject);
@@ -89,6 +89,32 @@ $search=$subject."\n";
 $repl=array(1,2,3);
 check_replace($search,$repl,$subject);
 
+msg("Level 2 cyclic - basic 1");
+
+$subject='[?](?)Rep[?]la[?(?)]ce [?]ma[?]n(?)y[?] (?)[?]s[?]epa[?]';
+$repl=array(
+	array('al[?]p(?)z[?]',"[?]b(?)v\n",null,37,"\n[?]"),
+	array('zk(?)j[?]', null, 'ab(?)c', 45)
+	);
+$search=array('[?]','(?)');
+check_replace($search,$repl,$subject);
+check_replace($search,$repl,$subject);
+check_replace($search,$repl,$subject);
+
+
+msg("Level 2 cyclic - empty array (level 2)");
+
+$subject='[?](?)Rep[?]la[?(?)]c<a>e [?]ma[?]n(?)y[?<a>] (?)[?]s[?]epa';
+$repl=array(
+	array('ap(?)z[?]',"b[?](?)v\n",null,37,"[?]\n[?]"),
+	array(),
+	array('k(?)j[?]', null, 'ab(?)c', 45)
+	);
+$search=array('[?]','(?)','<a>');
+check_replace($search,$repl,$subject);
+check_replace($search,$repl,$subject);
+check_replace($search,$repl,$subject);
+
 ?>
 ===DONE===
 --EXPECTF--	
@@ -112,7 +138,7 @@ Count: 4
 string(83) "Replace alphabeta10alphabeta10alphabeta10alphabeta10alpha a lot of grouped elements"
 Count: 17
 
---- eplace loop, separate ---
+--- replace loop, separate ---
 
 string(72) "alphaRepbetala10ce  maalphanybeta 10 sepaalpharate beta el10ementsalpha?"
 Count: 13
@@ -175,4 +201,54 @@ Count: 1
 
 string(27) "FOOOOOOOOOOOOOOOOOOOOOOOOOO"
 Count: 0
+
+--- Level 2 cyclic - basic 1 ---
+
+string(92) "al[?]pzk(?)j[?]z[?]Rep[?]bab(?)cv
+la[?45]ce ma37nzk(?)j[?]y
+[?] al[?]pab(?)cz[?]s[?]b45v
+epa"
+Count: 16
+string(127) "alal[?]pzk(?)j[?]z[?]pzkj[?]bab(?)cv
+zRep37bab45cv
+la[?45]ce ma37nzkzk(?)j[?]j
+[?]y
+al[?]pz[?] al[?]bab(?)cv
+pab45czs37b45v
+epa"
+Count: 17
+string(162) "alalal[?]pzk(?)j[?]z[?]pzkj[?]bab(?)cv
+zpzkj37bab45cv
+zRep37bab45cv
+la[?45]ce ma37nzkzkzk(?)j[?]j
+[?]j
+al[?]pz[?]y
+al[?]bab(?)cv
+pz al37bab45cv
+pab45czs37b45v
+epa"
+Count: 17
+
+--- Level 2 cyclic - empty array (level 2) ---
+
+string(58) "apz[?]Repb[?]v
+la[?]ck(?)j[?]e ma37ny[?] [?]
+[?]sapz[?]epa"
+Count: 15
+string(64) "apzapz[?]Repbb[?]v
+v
+lackj37e ma37ny[?]
+[?] apz[?]
+b[?]v
+sapzepa"
+Count: 13
+string(73) "apzapzapz[?]Repbbb[?]v
+v
+v
+lackj37e ma37ny
+37 apz[?]
+[?]
+bapz[?]v
+sapzepa"
+Count: 9
 ===DONE===

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -405,7 +405,7 @@ static void php_array_element_export(zval *zv, zend_ulong index, zend_string *ke
 	} else { /* string key */
 		zend_string *tmp_str;
 		zend_string *ckey = php_addcslashes(key->val, key->len, 0, "'\\", 2);
-		tmp_str = php_str_to_str_ex(ckey->val, ckey->len, "\0", 1, "' . \"\\0\" . '", 12, 0, NULL);
+		tmp_str = php_str_to_str_ex(ckey->val, ckey->len, "\0", 1, "' . \"\\0\" . '", 12, 0, NULL, 0);
 
 		buffer_append_spaces(buf, level + 1);
 
@@ -479,7 +479,7 @@ again:
 			break;
 		case IS_STRING:
 			ztmp = php_addcslashes(Z_STRVAL_P(struc), Z_STRLEN_P(struc), 0, "'\\", 2);
-			ztmp2 = php_str_to_str_ex(ztmp->val, ztmp->len, "\0", 1, "' . \"\\0\" . '", 12, 0, NULL);
+			ztmp2 = php_str_to_str_ex(ztmp->val, ztmp->len, "\0", 1, "' . \"\\0\" . '", 12, 0, NULL, 0);
 
 			smart_str_appendc(buf, '\'');
 			smart_str_append(buf, ztmp2);


### PR DESCRIPTION
Implements feature request #38685 (https://bugs.php.net/bug.php?id=38685).

For full details, read the RFC (https://wiki.php.net/rfc/cyclic-replace).

When str_replace() receives a string as 'needle' and an array as 'replace', each occurence of 'needle' is replaced with an element of 'replace', in array order, and looping if count(replace array) is lower than count of needles found in subject.

Defines new php_str_to_array_ex() and php_str_to_array() C functions.
