### PR TITLE
Crypt error-condition fixes

### DIFF
--- a/ext/standard/crypt.c
+++ b/ext/standard/crypt.c
@@ -216,6 +216,8 @@ PHPAPI zend_string *php_crypt(const char *password, const int pass_len, const ch
 				ZEND_SECURE_ZERO(output, PHP_MAX_SALT_LEN + 1);
 				return result;
 			}
+        } else if (salt[0] == '*' && (salt[1] == '0' || salt[1] == '1')) {
+            return NULL;
 		} else {
 			/* DES Fallback */
 

--- a/ext/standard/crypt.c
+++ b/ext/standard/crypt.c
@@ -100,6 +100,12 @@
 
 #define PHP_CRYPT_RAND php_rand()
 
+/* Used to check DES salts to ensure that they contain only valid characters */
+#define IS_VALID_SALT_CHARACTER(c) (((c) >= '.' && (c) <= '9') || ((c) >= 'A' && (c) <= 'Z') || ((c) >= 'a' && (c) <= 'z'))
+
+#define DES_INVALID_SALT_ERROR "Supplied salt is not valid for DES. Possible bug in provided salt format."
+
+
 PHP_MINIT_FUNCTION(crypt) /* {{{ */
 {
 	REGISTER_LONG_CONSTANT("CRYPT_SALT_LENGTH", PHP_MAX_SALT_LEN, CONST_CS | CONST_PERSISTENT);
@@ -196,10 +202,7 @@ PHPAPI zend_string *php_crypt(const char *password, const int pass_len, const ch
 		} else if (
 				salt[0] == '$' &&
 				salt[1] == '2' &&
-				salt[3] == '$' &&
-				salt[4] >= '0' && salt[4] <= '3' &&
-				salt[5] >= '0' && salt[5] <= '9' &&
-				salt[6] == '$') {
+				salt[3] == '$') {
 			char output[PHP_MAX_SALT_LEN + 1];
 
 			memset(output, 0, PHP_MAX_SALT_LEN + 1);
@@ -214,6 +217,16 @@ PHPAPI zend_string *php_crypt(const char *password, const int pass_len, const ch
 				return result;
 			}
 		} else {
+            /* DES Fallback */
+
+            /* Only check the salt if it's not EXT_DES */
+            if (salt[0] != '_') {
+                /* DES style hashes */
+                if (!IS_VALID_SALT_CHARACTER(salt[0]) || !IS_VALID_SALT_CHARACTER(salt[1])) {
+                    php_error_docref(NULL, E_DEPRECATED, DES_INVALID_SALT_ERROR);
+                }
+            }
+
 			memset(&buffer, 0, sizeof(buffer));
 			_crypt_extended_init_r();
 
@@ -238,6 +251,10 @@ PHPAPI zend_string *php_crypt(const char *password, const int pass_len, const ch
 #  else
 #    error Data struct used by crypt_r() is unknown. Please report.
 #  endif
+        if (salt[0] != '$' && salt[0] != '_' && (!IS_VALID_SALT_CHARACTER(salt[0]) || !IS_VALID_SALT_CHARACTER(salt[1]))) {
+            /* error consistently about invalid DES fallbacks */
+            php_error_docref(NULL, E_DEPRECATED, DES_INVALID_SALT_ERROR);
+        }
 		crypt_res = crypt_r(password, salt, &buffer);
 		if (!crypt_res || (salt[0] == '*' && salt[1] == '0')) {
 			return NULL;

--- a/ext/standard/crypt.c
+++ b/ext/standard/crypt.c
@@ -217,15 +217,15 @@ PHPAPI zend_string *php_crypt(const char *password, const int pass_len, const ch
 				return result;
 			}
 		} else {
-            /* DES Fallback */
+			/* DES Fallback */
 
-            /* Only check the salt if it's not EXT_DES */
-            if (salt[0] != '_') {
-                /* DES style hashes */
-                if (!IS_VALID_SALT_CHARACTER(salt[0]) || !IS_VALID_SALT_CHARACTER(salt[1])) {
-                    php_error_docref(NULL, E_DEPRECATED, DES_INVALID_SALT_ERROR);
-                }
-            }
+			/* Only check the salt if it's not EXT_DES */
+			if (salt[0] != '_') {
+				/* DES style hashes */
+				if (!IS_VALID_SALT_CHARACTER(salt[0]) || !IS_VALID_SALT_CHARACTER(salt[1])) {
+					php_error_docref(NULL, E_DEPRECATED, DES_INVALID_SALT_ERROR);
+				}
+			}
 
 			memset(&buffer, 0, sizeof(buffer));
 			_crypt_extended_init_r();
@@ -251,10 +251,10 @@ PHPAPI zend_string *php_crypt(const char *password, const int pass_len, const ch
 #  else
 #    error Data struct used by crypt_r() is unknown. Please report.
 #  endif
-        if (salt[0] != '$' && salt[0] != '_' && (!IS_VALID_SALT_CHARACTER(salt[0]) || !IS_VALID_SALT_CHARACTER(salt[1]))) {
-            /* error consistently about invalid DES fallbacks */
-            php_error_docref(NULL, E_DEPRECATED, DES_INVALID_SALT_ERROR);
-        }
+		if (salt[0] != '$' && salt[0] != '_' && (!IS_VALID_SALT_CHARACTER(salt[0]) || !IS_VALID_SALT_CHARACTER(salt[1]))) {
+			/* error consistently about invalid DES fallbacks */
+			php_error_docref(NULL, E_DEPRECATED, DES_INVALID_SALT_ERROR);
+		}
 		crypt_res = crypt_r(password, salt, &buffer);
 		if (!crypt_res || (salt[0] == '*' && salt[1] == '0')) {
 			return NULL;

--- a/ext/standard/tests/crypt/bcrypt_invalid_algorithm.phpt
+++ b/ext/standard/tests/crypt/bcrypt_invalid_algorithm.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test BCRYPT with invalid algorithm
+--FILE--
+<?php
+var_dump(crypt("test", "$23$04$1234567890123456789012345"));
+var_dump(crypt("test", "$20$04$1234567890123456789012345"));
+var_dump(crypt("test", "$2g$04$1234567890123456789012345"));
+?>
+--EXPECTF--
+string(2) "*0"
+string(2) "*0"
+string(2) "*0"

--- a/ext/standard/tests/crypt/bcrypt_invalid_cost.phpt
+++ b/ext/standard/tests/crypt/bcrypt_invalid_cost.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test BCRYPT with invalid cost
+--FILE--
+<?php
+var_dump(crypt("test", "$2a$4$1234567891234567891234567"));
+var_dump(crypt("test", "$2a$00$1234567891234567891234567"));
+var_dump(crypt("test", "$2a$01$1234567891234567891234567"));
+var_dump(crypt("test", "$2a$02$1234567891234567891234567"));
+var_dump(crypt("test", "$2a$03$1234567891234567891234567"));
+var_dump(crypt("test", "$2a$32$1234567891234567891234567"));
+var_dump(crypt("test", "$2a$40$1234567891234567891234567"));
+?>
+--EXPECTF--
+string(2) "*0"
+string(2) "*0"
+string(2) "*0"
+string(2) "*0"
+string(2) "*0"
+string(2) "*0"
+string(2) "*0"

--- a/ext/standard/tests/crypt/des_fallback_invalid_salt.phpt
+++ b/ext/standard/tests/crypt/des_fallback_invalid_salt.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test DES with invalid fallback
+--FILE--
+<?php
+
+var_dump(crypt("test", "$#"));
+var_dump(crypt("test", "$5zd$01"));
+
+?>
+--EXPECTF--
+Deprecated: crypt(): Supplied salt is not valid for DES. Possible bug in provided salt format. in %s on line %d
+string(13) "$#8MWASl5pGIk"
+
+Deprecated: crypt(): Supplied salt is not valid for DES. Possible bug in provided salt format. in %s on line %d
+string(13) "$54mkQyGCLvHs"

--- a/ext/standard/tests/strings/crypt_blowfish_variation2.phpt
+++ b/ext/standard/tests/strings/crypt_blowfish_variation2.phpt
@@ -1,10 +1,10 @@
 --TEST--
-Test Blowfish crypt() falls back to DES when rounds are not specified,
+Test Blowfish crypt() does not fall back to DES when rounds are not specified,
 or Blowfish is not available.
 --FILE--
 <?php
 $crypt = crypt(b'U*U', b'$2a$CCCCCCCCCCCCCCCCCCCCC.E5YPO9kmyuRGyh0XouQYb4YMJKvyOeW');
-if ($crypt===b'$2SHYF.wPGyfE') {
+if ($crypt==='*0') {
     echo "OK\n";
 } else {
     echo "Not OK\n";


### PR DESCRIPTION
Crypt is currently documented to fail if provided invalid salts for STD_DES. The current implementation does not do so.

This can cause `crypt` to become silently insecure by falling back to STD_DES if there is a mistake in the salt format for another algorithm. For example:

    $2y$40$10241354902359023523523

Will cause the output to be STD_DES rather than bcrypt in current PHP. This is because `40` is an invalid cost. Rather than erroring, a silent downgrade is occurring.

Since many codebases may be relying on this legacy behavior without realizing it, this PR adds an `E_DEPRECATED` error when an invalid DES salt is used.

This means the fallback behavior still will work today (so it won't break sites) but it will emit an error. In a future release this should be made a hard error (not falling back to DES but returning the `*0` error condition).