### PR TITLE
Fix bug #68822 php-fpm - the result of access log is wrong when use fastcgi_finish_request

### DIFF
--- a/sapi/fpm/fpm/fpm_request.c
+++ b/sapi/fpm/fpm/fpm_request.c
@@ -221,8 +221,6 @@ void fpm_request_finished() /* {{{ */
 
 	proc->request_stage = FPM_REQUEST_FINISHED;
 	proc->tv = now;
-	memset(&proc->accepted, 0, sizeof(proc->accepted));
-	proc->accepted_epoch = 0;
 	fpm_scoreboard_proc_release(proc);
 }
 /* }}} */


### PR DESCRIPTION
the bug is here: https://bugs.php.net/bug.php?id=68822

When I use fastcgi_finish_request in php script,  I find the result of access log is wrong

I read the php-src, whe use fastcgi_finish_request, it will call fpm_request_finished(it will clean the value of  proc->accepted_epoch &&  proc->accepted ).
But, fpm_log_write need proc->accepted_epoch &&  proc->accepted to print the log
The process is like this：
````
main -> php_execute_script -> fastcgi_finish_request -> fcgi_close -> fpm_request_finished -> fpm_request_end -> fpm_log_write
````
So, I think it is a bug.
By the way,although my PR can solve the problem, but I think it is not very good. -_-||