### PR TITLE
Bug fix for wrong regex in mail

### DIFF
--- a/win32/sendmail.c
+++ b/win32/sendmail.c
@@ -165,7 +165,7 @@ static zend_string *php_win32_mail_trim_header(char *header)
 	}
 
 	ZVAL_STRINGL(&replace, PHP_WIN32_MAIL_UNIFY_REPLACE, strlen(PHP_WIN32_MAIL_UNIFY_REPLACE));
-	regex = zend_string_init(PHP_WIN32_MAIL_UNIFY_REPLACE, sizeof(PHP_WIN32_MAIL_UNIFY_REPLACE)-1, 0);
+	regex = zend_string_init(PHP_WIN32_MAIL_UNIFY_PATTERN, sizeof(PHP_WIN32_MAIL_UNIFY_PATTERN)-1, 0);
 
 //zend_string *php_pcre_replace(zend_string *regex, char *subject, int subject_len, zval *replace_val, int is_callable_replace, int limit, int *replace_count);
 


### PR DESCRIPTION
Problem:
mail function always fails on Windows

Reproduce:
To reproduce the bug call the mail function on Windows. The generated warnings in the log:
PHP Warning:  mail(): Empty regular expression in x.php on line 197
PHP Warning:  mail(): Error while trimming mail header with PCRE, please file a bug report at http://bugs.php.net/ in x.php on line 197

Cause:
The wrong string PHP_WIN32_MAIL_UNIFY_REPLACE instead of PHP_WIN32_MAIL_UNIFY_PATTERN is used for the regex.