### PR TITLE
Fix null pointer dereference(s)

### DIFF
--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -842,27 +842,27 @@ PHPAPI size_t vspprintf(char **pbuf, size_t max_len, const char *format, va_list
 
 	xbuf_format_converter(&buf, 1, format, ap);
 
+	/*
+	 * Test 'pbuf'(also known as 'error') against NULL,
+	 * since it is called multiple places without
+	 * checking against NULL, causing null pointer
+	 * dereferences.
+	 */
+	if(!pbuf) {
+		return 0;
+	}
+
 	if (max_len && buf.len > max_len) {
 		buf.len = max_len;
 	}
 
 	smart_string_0(&buf);
 
-	/*
-	 * Test 'pbuf'(also known as 'error') against NULL,
-	 * since it is called multiple places without
-	 * checking against NULL, causing null pointer
-	 *dereferences.
-	 */
 	if (buf.c) {
-		if(pbuf) {
-			*pbuf = buf.c;
-		}
+		*pbuf = buf.c;
 		result = buf.len;
 	} else {
-		if(pbuf) {
-			*pbuf = NULL;
-		}
+		*pbuf = NULL;
 		result = 0;
 	}
 

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -848,11 +848,16 @@ PHPAPI size_t vspprintf(char **pbuf, size_t max_len, const char *format, va_list
 
 	smart_string_0(&buf);
 
+	//Test 'pbuf'(also known as 'error') against NULL, since it is called multiple places without checking against, causing null pointer dereferences.
 	if (buf.c) {
-		*pbuf = buf.c;
+		if(pbuf) {
+			*pbuf = buf.c;
+		}
 		result = buf.len;
 	} else {
-		*pbuf = NULL;
+		if(pbuf) {
+			*pbuf = NULL;
+		}
 		result = 0;
 	}
 

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -848,7 +848,12 @@ PHPAPI size_t vspprintf(char **pbuf, size_t max_len, const char *format, va_list
 
 	smart_string_0(&buf);
 
-	//Test 'pbuf'(also known as 'error') against NULL, since it is called multiple places without checking against, causing null pointer dereferences.
+	/*
+	 * Test 'pbuf'(also known as 'error') against NULL,
+	 * since it is called multiple places without
+	 * checking against NULL, causing null pointer
+	 *dereferences.
+	 */
 	if (buf.c) {
 		if(pbuf) {
 			*pbuf = buf.c;


### PR DESCRIPTION
--

Multiple places 'spprintf' is called with a NULL 'pbuf', which
passes itself to vspprintf, which dereferences it.

Although most places check whether 'pbuf'(normally called 'error')
is null, it is smarter to check it inside the function that
requires a non-null value.

This will avoid future problems, too.


See bug #68839(https://bugs.php.net/bug.php?id=68839) for an example of NULL being passed to spprintf.