### PR TITLE
Fix null pointer dereferences

### DIFF
--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -840,6 +840,17 @@ PHPAPI size_t vspprintf(char **pbuf, size_t max_len, const char *format, va_list
 	smart_string buf = {0};
 	size_t result;
 
+
+	/*
+	 * Test 'pbuf'(also known as 'error') against NULL,
+	 * since it is called multiple places without
+	 * checking against NULL, causing null pointer
+	 * dereferences.
+	 */
+	if(!pbuf) {
+		return 0;
+	}
+
 	xbuf_format_converter(&buf, 1, format, ap);
 
 	if (max_len && buf.len > max_len) {


### PR DESCRIPTION
--

Multiple places 'spprintf' is called with a NULL 'pbuf', which
passes itself to vspprintf, which dereferences it.

Although most places check whether 'pbuf'(normally called 'error')
is null, it is smarter to check it inside the function that
requires a non-null value.

This will avoid future problems, too.

See bug #68839 [https://bugs.php.net/bug.php?id=68839] for an example of NULL being passed to spprintf.
There are multiple other places checks are not used to confirm error/pbuf is not null.