### PR TITLE
Fix bug #25215: max_input_time timeout misreported

### DIFF
--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -224,6 +224,7 @@ ZEND_API uint zend_get_executed_lineno(void);
 ZEND_API zend_bool zend_is_executing(void);
 
 ZEND_API void zend_set_timeout(zend_long seconds, int reset_signals);
+ZEND_API void zend_set_input_timeout(long seconds);
 ZEND_API void zend_unset_timeout(void);
 ZEND_API void zend_timeout(int dummy);
 ZEND_API zend_class_entry *zend_fetch_class(zend_string *class_name, int fetch_type);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1143,7 +1143,11 @@ ZEND_API void zend_timeout(int dummy) /* {{{ */
 		zend_on_timeout(EG(timeout_seconds));
 	}
 
-	zend_error(E_ERROR, "Maximum execution time of %pd second%s exceeded", EG(timeout_seconds), EG(timeout_seconds) == 1 ? "" : "s");
+	zend_error(E_ERROR, "Maximum %s time of %d second%s exceeded",
+	        EG(timeout_type) == ZEND_TIMEOUT_TYPE_INPUT ? "input" : "execution",
+	        EG(timeout_seconds),
+	        EG(timeout_seconds) == 1 ? "" : "s"
+        );
 }
 /* }}} */
 
@@ -1172,6 +1176,7 @@ void zend_set_timeout(zend_long seconds, int reset_signals) /* {{{ */
 {
 
 	EG(timeout_seconds) = seconds;
+	EG(timeout_type) = ZEND_TIMEOUT_TYPE_DEFAULT;
 
 #ifdef ZEND_WIN32
 	if(!seconds) {
@@ -1234,6 +1239,13 @@ void zend_set_timeout(zend_long seconds, int reset_signals) /* {{{ */
 	}
 #	endif /* HAVE_SETITIMER */
 #endif
+}
+/* }}} */
+
+void zend_set_input_timeout(long seconds) /* {{{ */
+{
+        zend_set_timeout(seconds, 1);
+        EG(timeout_type) = ZEND_TIMEOUT_TYPE_INPUT;
 }
 /* }}} */
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -211,7 +211,7 @@ struct _zend_executor_globals {
 
 	/* timeout support */
 	zend_long timeout_seconds;
-	int timeout_type;
+	unsigned char timeout_type;
 
 	int lambda_count;
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -62,6 +62,9 @@ END_EXTERN_C()
 #define ZEND_EARLY_BINDING_DELAYED      1
 #define ZEND_EARLY_BINDING_DELAYED_ALL  2
 
+#define ZEND_TIMEOUT_TYPE_DEFAULT       1
+#define ZEND_TIMEOUT_TYPE_INPUT         2
+
 typedef struct _zend_declarables {
 	zval ticks;
 } zend_declarables;
@@ -208,6 +211,7 @@ struct _zend_executor_globals {
 
 	/* timeout support */
 	zend_long timeout_seconds;
+	int timeout_type;
 
 	int lambda_count;
 

--- a/main/main.c
+++ b/main/main.c
@@ -1621,7 +1621,7 @@ int php_request_startup(void)
 		if (PG(max_input_time) == -1) {
 			zend_set_timeout(EG(timeout_seconds), 1);
 		} else {
-			zend_set_timeout(PG(max_input_time), 1);
+		        zend_set_input_timeout(PG(max_input_time));
 		}
 
 		/* Disable realpath cache if an open_basedir is set */


### PR DESCRIPTION
With this change PHP uses a different error message upon running into a timeout when it relates to max_input_type instead of max_execution_time.

I'm having a hard time coming with a test case for this, unfortunately.
