### PR TITLE
Fix bug #64938: libxml_disable_entity_loader setting is shared between threads

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -861,8 +861,8 @@ static PHP_RINIT_FUNCTION(libxml)
 		xmlParserInputBufferCreateFilenameDefault(php_libxml_input_buffer_create_filename);
 		xmlOutputBufferCreateFilenameDefault(php_libxml_output_buffer_create_filename);
 
-		/* Enable the entity loader by default. This ensure that
-		 * other threads/requests that might have disable the loader
+		/* Enable the entity loader by default. This ensures that
+		 * other threads/requests that might have disabled the loader
 		 * do not affect the current request.
 		 */
 		LIBXML(entity_loader_disabled) = 0;

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -860,6 +860,12 @@ static PHP_RINIT_FUNCTION(libxml)
 		xmlSetGenericErrorFunc(NULL, php_libxml_error_handler);
 		xmlParserInputBufferCreateFilenameDefault(php_libxml_input_buffer_create_filename);
 		xmlOutputBufferCreateFilenameDefault(php_libxml_output_buffer_create_filename);
+
+		/* Enable the entity loader by default. This ensure that
+		 * other threads/requests that might have disable the loader
+		 * do not affect the current request.
+		 */
+		LIBXML(entity_loader_disabled) = 0;
 	}
 	return SUCCESS;
 }


### PR DESCRIPTION
The availability of entity loading is stored in a module global which previously was only initialized in the GINIT constructor. This had the effect that disabling the entity loader in one request caused subsequent requests hitting the same Apache child process to  also have the loader disabled.

With this change the loader is explicitely enabled in the request init phase.