### PR TITLE
Fixed memory leak of strripos() when empty needle or haystack

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2121,6 +2121,7 @@ PHP_FUNCTION(strripos)
 	}
 
 	if ((haystack->len == 0) || (needle->len == 0)) {
+		STR_ALLOCA_FREE(ord_needle, use_heap);
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2114,6 +2114,7 @@ PHP_FUNCTION(strripos)
 		needle = Z_STR_P(zneedle);
 	} else {
 		if (php_needle_char(zneedle, ord_needle->val) != SUCCESS) {
+			STR_ALLOCA_FREE(ord_needle, use_heap);
 			RETURN_FALSE;
 		}
 		ord_needle->val[1] = '\0';

--- a/ext/standard/tests/strings/strripos.phpt
+++ b/ext/standard/tests/strings/strripos.phpt
@@ -15,6 +15,9 @@ strripos() function
 	var_dump(@strripos("a", ""));
 	var_dump(@strripos("", "a"));
 	var_dump(@strripos("\\\\a", "\\a"));
+
+	$fp = fopen(__FILE__, "r");
+	var_dump(@strripos("", $fp));
 ?>
 --EXPECT--
 int(5)
@@ -30,4 +33,5 @@ bool(false)
 bool(false)
 bool(false)
 int(1)
+bool(false)
 


### PR DESCRIPTION
@laruence will you take a look at this? this seems been introduced during refactor.

Those tests affected.

```
strripos() function [ext/standard/tests/strings/strripos.phpt]
Test strripos() function : usage variations - double quoted strings for 'haystack' & 'needle' arguments [ext/standard/tests/strings/strripos_variation1.phpt]
Test strripos() function : usage variations - single quoted strings for 'haystack' & 'needle' arguments [ext/standard/tests/strings/strripos_variation2.phpt]
Test strripos() function : usage variations - multi line heredoc string for 'haystack' argument [ext/standard/tests/strings/strripos_variation3.phpt]
```