### PR TITLE
Fix segfaults with string_replace and string_ireplace

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3958,7 +3958,8 @@ static zend_long php_str_replace_in_subject(zval *search, zval *replace, zval *s
 {
 	zval		*search_entry,
 				*replace_entry = NULL;
-	zend_string	*tmp_result;
+	zend_string	*tmp_result,
+				*replace_entry_str = NULL;
 	char		*replace_value = NULL;
 	size_t		 replace_len = 0;
 	zend_long	 replace_count = 0;
@@ -3990,7 +3991,8 @@ static zend_long php_str_replace_in_subject(zval *search, zval *replace, zval *s
 		/* For each entry in the search array, get the entry */
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(search), search_entry) {
 			/* Make sure we're dealing with strings. */
-			SEPARATE_ZVAL(search_entry);
+			ZVAL_DEREF(search_entry);
+			SEPARATE_ZVAL_NOREF(search_entry);
 			convert_to_string(search_entry);
 			if (Z_STRLEN_P(search_entry) == 0) {
 				if (Z_TYPE_P(replace) == IS_ARRAY) {
@@ -4004,11 +4006,11 @@ static zend_long php_str_replace_in_subject(zval *search, zval *replace, zval *s
 				/* Get current entry */
 				if ((replace_entry = zend_hash_get_current_data_ex(Z_ARRVAL_P(replace), &pos)) != NULL) {
 					/* Make sure we're dealing with strings. */
-					convert_to_string_ex(replace_entry);
+					replace_entry_str = zval_get_string(replace_entry);
 
 					/* Set replacement value to the one we got from array */
-					replace_value = Z_STRVAL_P(replace_entry);
-					replace_len = Z_STRLEN_P(replace_entry);
+					replace_value = replace_entry_str->val;
+					replace_len = replace_entry_str->len;
 
 					zend_hash_move_forward_ex(Z_ARRVAL_P(replace), &pos);
 				} else {
@@ -4051,6 +4053,9 @@ static zend_long php_str_replace_in_subject(zval *search, zval *replace, zval *s
 				}				
 			}
 
+			if(replace_entry_str) {
+				zend_string_release(replace_entry_str);
+			}
 			zend_string_release(Z_STR_P(result));
 			ZVAL_STR(result, tmp_result);
 

--- a/ext/standard/tests/strings/str_replace_array_refs.phpt
+++ b/ext/standard/tests/strings/str_replace_array_refs.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test str_replace() function and array refs
+--INI--
+precision=14
+--FILE--
+<?php
+$data = ['a' => 'b', 'numeric' => 1];
+$ref = &$data;
+$b = &$ref['a'];
+$numeric = &$ref['numeric'];
+var_dump(str_replace(array_keys($data), $data, "a numeric"));
+var_dump($numeric);
+var_dump($data['numeric']);
+--EXPECTF--
+string(3) "b 1"
+int(1)
+int(1)

--- a/ext/standard/tests/strings/str_replace_array_refs2.phpt
+++ b/ext/standard/tests/strings/str_replace_array_refs2.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test str_replace() function and array refs, more cases
+--FILE--
+<?php
+$closure = function (array $array, array $keys, $value)
+{
+    $current = &$array;
+    foreach ($keys as $key)
+        $current = &$current[$key];
+    $current = $value;
+    return $array;
+};
+
+class SomeClass { public $prop; }
+
+$obj = new SomeClass;
+$obj->prop = ['x' => 'property'];
+$obj->prop = $closure($obj->prop, ['x'], 'a');
+var_dump(str_replace(array_keys($obj->prop), $obj->prop, "x property"));
+
+$array = ['x' => 'property'];
+$array = $closure($array, ['x'], 'a');
+var_dump(str_replace(array_keys($array), $array, "x property"));
+
+--EXPECTF--
+string(10) "a property"
+string(10) "a property"


### PR DESCRIPTION
Like in `ext/standard/tests/strings/str_replace_array_refs.phpt`:
```php
<?php
$data = ['a' => 'b'];
$ref = &$data;
$b = &$ref['a'];
var_dump(str_replace(array_keys($data), $data, "a"));
// segfault :~
```

And other possible very obscure situations involving object properties (with array values) being passed to `str_replace`:

```php
<?php
$closure = function (array $array, array $keys, $value) {
    $current = &$array;
    foreach ($keys as $key) $current = &$current[$key];
    $current = $value;
    return $array;
};
class SomeClass { public $prop; }
$obj = new SomeClass;
$obj->prop = ['x' => 'property'];
$obj->prop = $closure($obj->prop, ['x'], 'a');
var_dump(str_replace(array_keys($obj->prop), $obj->prop, "x property"));
```

PS: Problem is not present on PHP-5 and before, bug is only on master AFAIK.