### PR TITLE
Remove $this from incompatible context

### DIFF
--- a/Zend/tests/009.phpt
+++ b/Zend/tests/009.phpt
@@ -30,10 +30,10 @@ var_dump(get_class($f2));
 echo "Done\n";
 ?>
 --EXPECTF--	
-Strict Standards: Non-static method foo::bar() should not be called statically in %s on line %d
+Deprecated: Non-static method foo::bar() should not be called statically in %s on line %d
 string(3) "foo"
 
-Strict Standards: Non-static method foo::bar() should not be called statically in %s on line %d
+Deprecated: Non-static method foo::bar() should not be called statically in %s on line %d
 string(3) "foo"
 string(3) "foo"
 string(3) "foo"

--- a/Zend/tests/bug40621.phpt
+++ b/Zend/tests/bug40621.phpt
@@ -15,6 +15,6 @@ Foo::get();
 echo "Done\n";
 ?>
 --EXPECTF--	
-Strict Standards: Non-static method Foo::get() should not be called statically in %s on line %d
+Deprecated: Non-static method Foo::get() should not be called statically in %s on line %d
 
 Fatal error: Non-static method Foo::__construct() cannot be called statically in %s on line %d

--- a/Zend/tests/bug46381.phpt
+++ b/Zend/tests/bug46381.phpt
@@ -16,4 +16,4 @@ $test->test();
 echo "Done\n";
 ?>
 --EXPECTF--	
-Fatal error: Non-static method ArrayIterator::current() cannot be called statically, assuming $this from incompatible context in %s on line %d
+Fatal error: Non-static method ArrayIterator::current() cannot be called statically in %s on line %d

--- a/Zend/tests/bug47054.phpt
+++ b/Zend/tests/bug47054.phpt
@@ -34,6 +34,4 @@ Called class: C
 
 Warning: get_called_class() called from outside a class in %s on line %d
 
-Strict Standards: Non-static method D::m() should not be called statically in %s on line %d
-
-Fatal error: Using $this when not in object context in %s on line %d
+Fatal error: Non-static method D::m() cannot be called statically in %s on line %d

--- a/Zend/tests/bug48533.phpt
+++ b/Zend/tests/bug48533.phpt
@@ -36,6 +36,6 @@ int(2)
 %unicode|string%(9) "__call::c"
 %unicode|string%(15) "__callStatic::a"
 
-Strict Standards: Non-static method foo::b() should not be called statically in %s on line %d
+Deprecated: Non-static method foo::b() should not be called statically in %s on line %d
 int(2)
 %unicode|string%(15) "__callStatic::c"

--- a/Zend/tests/call_static_006.phpt
+++ b/Zend/tests/call_static_006.phpt
@@ -21,10 +21,10 @@ foo::__construct();
 
 ?>
 --EXPECTF--
-Strict Standards: Non-static method foo::aa() should not be called statically in %s on line %d
+Deprecated: Non-static method foo::aa() should not be called statically in %s on line %d
 ok
 
-Strict Standards: Non-static method foo::aa() should not be called statically in %s on line %d
+Deprecated: Non-static method foo::aa() should not be called statically in %s on line %d
 ok
 
 Fatal error: Cannot call constructor in %s on line %d

--- a/Zend/tests/call_user_func_004.phpt
+++ b/Zend/tests/call_user_func_004.phpt
@@ -13,6 +13,4 @@ call_user_func(array('foo', 'teste'));
 
 ?>
 --EXPECTF--
-Strict Standards: %son-static method foo::teste() should not be called statically in %s on line %d
-
-Fatal error: Using $this when not in object context in %s on line %d
+Warning: call_user_func() expects parameter 1 to be a valid callback, non-static method foo::teste() cannot be called statically in %s on line %d

--- a/Zend/tests/call_user_func_005.phpt
+++ b/Zend/tests/call_user_func_005.phpt
@@ -18,8 +18,8 @@ var_dump(call_user_func(array('foo', 'teste')));
 
 ?>
 --EXPECTF--
-Strict Standards: %son-static method foo::teste() should not be called statically in %s on line %d
-%string|unicode%(1) "x"
+Deprecated: %son-static method foo::teste() should not be called statically in %s on line %d
+string(1) "x"
 array(1) {
   [0]=>
   object(Closure)#%d (1) {

--- a/Zend/tests/callable_type_hint_001.phpt
+++ b/Zend/tests/callable_type_hint_001.phpt
@@ -21,7 +21,7 @@ foo($closure);
 string(6) "strpos"
 string(3) "foo"
 
-Strict Standards: Non-static method bar::baz() should not be called statically in %scallable_type_hint_001.php on line %d
+Deprecated: Non-static method bar::baz() should not be called statically in %scallable_type_hint_001.php on line %d
 array(2) {
   [0]=>
   string(3) "bar"

--- a/Zend/tests/fr47160.phpt
+++ b/Zend/tests/fr47160.phpt
@@ -5,7 +5,8 @@ Calling method from array
 
 class Hello {
 	public function world($x) {
-		echo "Hello, $x\n"; return $this;
+        $varName = 'this';
+		echo "Hello, $x\n"; return $$varName;
 	}
 }
 
@@ -99,13 +100,13 @@ var_dump(call_user_func($f, 'you'));
 
 ?>
 --EXPECTF--
-Strict Standards: Non-static method Hello::world() should not be called statically in %s on line %d
+Deprecated: Non-static method Hello::world() should not be called statically in %s on line %d
 Hello, you
 
 Notice: Undefined variable: this in %s on line %d
 NULL
 
-Strict Standards: %son-static method Hello::world() should not be called statically in %s on line %d
+Deprecated: %son-static method Hello::world() should not be called statically in %s on line %d
 Hello, you
 
 Notice: Undefined variable: this in %s on line %d

--- a/Zend/tests/incompat_ctx_user.phpt
+++ b/Zend/tests/incompat_ctx_user.phpt
@@ -16,5 +16,4 @@ $b->bar();
 
 ?>
 --EXPECTF--
-Deprecated: Non-static method A::foo() should not be called statically, assuming $this from incompatible context in %s on line %d
-string(1) "B"
+Fatal error: Non-static method A::foo() cannot be called statically in %s on line %d

--- a/Zend/tests/objects_027.phpt
+++ b/Zend/tests/objects_027.phpt
@@ -27,17 +27,17 @@ call_user_func(array('foo', 'test'));
 object(foo)#%d (0) {
 }
 
-Strict Standards: Non-static method foo::test() should not be called statically in %s on line %d
+Deprecated: Non-static method foo::test() should not be called statically in %s on line %d
 
-Strict Standards: Non-static method bar::show() should not be called statically in %s on line %d
+Deprecated: Non-static method bar::show() should not be called statically in %s on line %d
 object(foo)#%d (0) {
 }
 object(foo)#%d (0) {
 }
 
-Strict Standards: %son-static method foo::test() should not be called statically in %s on line %d
+Deprecated: Non-static method foo::test() should not be called statically in %s on line %d
 
-Strict Standards: Non-static method bar::show() should not be called statically in %s on line %d
+Deprecated: Non-static method bar::show() should not be called statically in %s on line %d
 object(foo)#%d (0) {
 }
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2885,7 +2885,7 @@ get_function_via_handler:
 				int severity;
 				char *verb;
 				if (fcc->function_handler->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-					severity = E_STRICT;
+					severity = E_DEPRECATED;
 					verb = "should not";
 				} else {
 					/* An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call. */

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1970,6 +1970,7 @@ static int zend_try_compile_cv(znode *result, zend_ast *ast) /* {{{ */
 
 		if (zend_string_equals_literal(name, "this")) {
 			CG(active_op_array)->this_var = result->u.op.var;
+			CG(active_op_array)->fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 		}
 		return SUCCESS;
 	}
@@ -2114,6 +2115,7 @@ static zend_op *zend_delayed_compile_prop(znode *result, zend_ast *ast, uint32_t
 
 	if (is_this_fetch(obj_ast)) {
 		obj_node.op_type = IS_UNUSED;
+		CG(active_op_array)->fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 	} else {
 		zend_delayed_compile_var(&obj_node, obj_ast, type);
 		zend_separate_if_call_and_write(&obj_node, obj_ast, type);
@@ -2868,6 +2870,7 @@ void zend_compile_method_call(znode *result, zend_ast *ast, uint32_t type) /* {{
 
 	if (is_this_fetch(obj_ast)) {
 		obj_node.op_type = IS_UNUSED;
+		CG(active_op_array)->fn_flags &= ~ZEND_ACC_ALLOW_STATIC;
 	} else {
 		zend_compile_expr(&obj_node, obj_ast);
 	}

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -717,7 +717,7 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 			if (error[0] >= 'a' && error[0] <= 'z') {
 				error[0] += ('A' - 'a');
 			}
-			zend_error(E_STRICT, "%s", error);
+			zend_error(E_DEPRECATED, "%s", error);
 			efree(error);
 		}
 		zend_string_release(callable_name);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1640,12 +1640,11 @@ try_function_name:
 				}
 				if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
 					if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-						zend_error(E_STRICT,
+						zend_error(E_DEPRECATED,
 						"Non-static method %s::%s() should not be called statically",
 						fbc->common.scope->name->val, fbc->common.function_name->val);
 					} else {
-						zend_error_noreturn(
-							E_ERROR,
+						zend_error_noreturn(E_ERROR,
 							"Non-static method %s::%s() cannot be called statically",
 							fbc->common.scope->name->val, fbc->common.function_name->val);
 					}
@@ -2023,12 +2022,11 @@ try_function_name:
 				}
 				if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
 					if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-						zend_error(E_STRICT,
+						zend_error(E_DEPRECATED,
 						"Non-static method %s::%s() should not be called statically",
 						fbc->common.scope->name->val, fbc->common.function_name->val);
 					} else {
-						zend_error_noreturn(
-							E_ERROR,
+						zend_error_noreturn(E_ERROR,
 							"Non-static method %s::%s() cannot be called statically",
 							fbc->common.scope->name->val, fbc->common.function_name->val);
 					}
@@ -2213,12 +2211,11 @@ try_function_name:
 				}
 				if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
 					if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-						zend_error(E_STRICT,
+						zend_error(E_DEPRECATED,
 						"Non-static method %s::%s() should not be called statically",
 						fbc->common.scope->name->val, fbc->common.function_name->val);
 					} else {
-						zend_error_noreturn(
-							E_ERROR,
+						zend_error_noreturn(E_ERROR,
 							"Non-static method %s::%s() cannot be called statically",
 							fbc->common.scope->name->val, fbc->common.function_name->val);
 					}
@@ -4256,27 +4253,18 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_CONST_HANDLER(
 
 	object = NULL;
 	if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
-		if (Z_OBJ(EX(This))) {
+		if (Z_OBJ(EX(This)) && instanceof_function(Z_OBJCE(EX(This)), ce)) {
 			object = Z_OBJ(EX(This));
 			GC_REFCOUNT(object)++;
-		}
-		if (!object ||
-		    !instanceof_function(object->ce, ce)) {
-		    /* We are calling method of the other (incompatible) class,
-		       but passing $this. This is done for compatibility with php-4. */
+		} else {
 			if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(
-					object ? E_DEPRECATED : E_STRICT,
-					"Non-static method %s::%s() should not be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error(E_DEPRECATED,
+					"Non-static method %s::%s() should not be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			} else {
-				/* An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call. */
-				zend_error_noreturn(
-					E_ERROR,
-					"Non-static method %s::%s() cannot be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error_noreturn(E_ERROR,
+					"Non-static method %s::%s() cannot be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			}
 		}
 	}
@@ -4327,12 +4315,11 @@ static int ZEND_FASTCALL  ZEND_INIT_USER_CALL_SPEC_CONST_CONST_HANDLER(ZEND_OPCO
 		} else if (func->common.scope &&
 		           !(func->common.fn_flags & ZEND_ACC_STATIC)) {
 			if (func->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(E_STRICT,
+				zend_error(E_DEPRECATED,
 				"Non-static method %s::%s() should not be called statically",
 				func->common.scope->name->val, func->common.function_name->val);
 			} else {
-				zend_error_noreturn(
-					E_ERROR,
+				zend_error_noreturn(E_ERROR,
 					"Non-static method %s::%s() cannot be called statically",
 					func->common.scope->name->val, func->common.function_name->val);
 			}
@@ -6051,27 +6038,18 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_UNUSED_HANDLER
 
 	object = NULL;
 	if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
-		if (Z_OBJ(EX(This))) {
+		if (Z_OBJ(EX(This)) && instanceof_function(Z_OBJCE(EX(This)), ce)) {
 			object = Z_OBJ(EX(This));
 			GC_REFCOUNT(object)++;
-		}
-		if (!object ||
-		    !instanceof_function(object->ce, ce)) {
-		    /* We are calling method of the other (incompatible) class,
-		       but passing $this. This is done for compatibility with php-4. */
+		} else {
 			if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(
-					object ? E_DEPRECATED : E_STRICT,
-					"Non-static method %s::%s() should not be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error(E_DEPRECATED,
+					"Non-static method %s::%s() should not be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			} else {
-				/* An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call. */
-				zend_error_noreturn(
-					E_ERROR,
-					"Non-static method %s::%s() cannot be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error_noreturn(E_ERROR,
+					"Non-static method %s::%s() cannot be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			}
 		}
 	}
@@ -7126,27 +7104,18 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_CV_HANDLER(ZEN
 
 	object = NULL;
 	if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
-		if (Z_OBJ(EX(This))) {
+		if (Z_OBJ(EX(This)) && instanceof_function(Z_OBJCE(EX(This)), ce)) {
 			object = Z_OBJ(EX(This));
 			GC_REFCOUNT(object)++;
-		}
-		if (!object ||
-		    !instanceof_function(object->ce, ce)) {
-		    /* We are calling method of the other (incompatible) class,
-		       but passing $this. This is done for compatibility with php-4. */
+		} else {
 			if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(
-					object ? E_DEPRECATED : E_STRICT,
-					"Non-static method %s::%s() should not be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error(E_DEPRECATED,
+					"Non-static method %s::%s() should not be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			} else {
-				/* An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call. */
-				zend_error_noreturn(
-					E_ERROR,
-					"Non-static method %s::%s() cannot be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error_noreturn(E_ERROR,
+					"Non-static method %s::%s() cannot be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			}
 		}
 	}
@@ -7197,12 +7166,11 @@ static int ZEND_FASTCALL  ZEND_INIT_USER_CALL_SPEC_CONST_CV_HANDLER(ZEND_OPCODE_
 		} else if (func->common.scope &&
 		           !(func->common.fn_flags & ZEND_ACC_STATIC)) {
 			if (func->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(E_STRICT,
+				zend_error(E_DEPRECATED,
 				"Non-static method %s::%s() should not be called statically",
 				func->common.scope->name->val, func->common.function_name->val);
 			} else {
-				zend_error_noreturn(
-					E_ERROR,
+				zend_error_noreturn(E_ERROR,
 					"Non-static method %s::%s() cannot be called statically",
 					func->common.scope->name->val, func->common.function_name->val);
 			}
@@ -8264,27 +8232,18 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_CONST_TMPVAR_HANDLER
 
 	object = NULL;
 	if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
-		if (Z_OBJ(EX(This))) {
+		if (Z_OBJ(EX(This)) && instanceof_function(Z_OBJCE(EX(This)), ce)) {
 			object = Z_OBJ(EX(This));
 			GC_REFCOUNT(object)++;
-		}
-		if (!object ||
-		    !instanceof_function(object->ce, ce)) {
-		    /* We are calling method of the other (incompatible) class,
-		       but passing $this. This is done for compatibility with php-4. */
+		} else {
 			if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(
-					object ? E_DEPRECATED : E_STRICT,
-					"Non-static method %s::%s() should not be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error(E_DEPRECATED,
+					"Non-static method %s::%s() should not be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			} else {
-				/* An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call. */
-				zend_error_noreturn(
-					E_ERROR,
-					"Non-static method %s::%s() cannot be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error_noreturn(E_ERROR,
+					"Non-static method %s::%s() cannot be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			}
 		}
 	}
@@ -8335,12 +8294,11 @@ static int ZEND_FASTCALL  ZEND_INIT_USER_CALL_SPEC_CONST_TMPVAR_HANDLER(ZEND_OPC
 		} else if (func->common.scope &&
 		           !(func->common.fn_flags & ZEND_ACC_STATIC)) {
 			if (func->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(E_STRICT,
+				zend_error(E_DEPRECATED,
 				"Non-static method %s::%s() should not be called statically",
 				func->common.scope->name->val, func->common.function_name->val);
 			} else {
-				zend_error_noreturn(
-					E_ERROR,
+				zend_error_noreturn(E_ERROR,
 					"Non-static method %s::%s() cannot be called statically",
 					func->common.scope->name->val, func->common.function_name->val);
 			}
@@ -13393,27 +13351,18 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_CONST_HANDLER(ZE
 
 	object = NULL;
 	if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
-		if (Z_OBJ(EX(This))) {
+		if (Z_OBJ(EX(This)) && instanceof_function(Z_OBJCE(EX(This)), ce)) {
 			object = Z_OBJ(EX(This));
 			GC_REFCOUNT(object)++;
-		}
-		if (!object ||
-		    !instanceof_function(object->ce, ce)) {
-		    /* We are calling method of the other (incompatible) class,
-		       but passing $this. This is done for compatibility with php-4. */
+		} else {
 			if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(
-					object ? E_DEPRECATED : E_STRICT,
-					"Non-static method %s::%s() should not be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error(E_DEPRECATED,
+					"Non-static method %s::%s() should not be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			} else {
-				/* An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call. */
-				zend_error_noreturn(
-					E_ERROR,
-					"Non-static method %s::%s() cannot be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error_noreturn(E_ERROR,
+					"Non-static method %s::%s() cannot be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			}
 		}
 	}
@@ -14872,27 +14821,18 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_UNUSED_HANDLER(Z
 
 	object = NULL;
 	if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
-		if (Z_OBJ(EX(This))) {
+		if (Z_OBJ(EX(This)) && instanceof_function(Z_OBJCE(EX(This)), ce)) {
 			object = Z_OBJ(EX(This));
 			GC_REFCOUNT(object)++;
-		}
-		if (!object ||
-		    !instanceof_function(object->ce, ce)) {
-		    /* We are calling method of the other (incompatible) class,
-		       but passing $this. This is done for compatibility with php-4. */
+		} else {
 			if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(
-					object ? E_DEPRECATED : E_STRICT,
-					"Non-static method %s::%s() should not be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error(E_DEPRECATED,
+					"Non-static method %s::%s() should not be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			} else {
-				/* An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call. */
-				zend_error_noreturn(
-					E_ERROR,
-					"Non-static method %s::%s() cannot be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error_noreturn(E_ERROR,
+					"Non-static method %s::%s() cannot be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			}
 		}
 	}
@@ -16309,27 +16249,18 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_CV_HANDLER(ZEND_
 
 	object = NULL;
 	if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
-		if (Z_OBJ(EX(This))) {
+		if (Z_OBJ(EX(This)) && instanceof_function(Z_OBJCE(EX(This)), ce)) {
 			object = Z_OBJ(EX(This));
 			GC_REFCOUNT(object)++;
-		}
-		if (!object ||
-		    !instanceof_function(object->ce, ce)) {
-		    /* We are calling method of the other (incompatible) class,
-		       but passing $this. This is done for compatibility with php-4. */
+		} else {
 			if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(
-					object ? E_DEPRECATED : E_STRICT,
-					"Non-static method %s::%s() should not be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error(E_DEPRECATED,
+					"Non-static method %s::%s() should not be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			} else {
-				/* An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call. */
-				zend_error_noreturn(
-					E_ERROR,
-					"Non-static method %s::%s() cannot be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error_noreturn(E_ERROR,
+					"Non-static method %s::%s() cannot be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			}
 		}
 	}
@@ -17746,27 +17677,18 @@ static int ZEND_FASTCALL  ZEND_INIT_STATIC_METHOD_CALL_SPEC_VAR_TMPVAR_HANDLER(Z
 
 	object = NULL;
 	if (!(fbc->common.fn_flags & ZEND_ACC_STATIC)) {
-		if (Z_OBJ(EX(This))) {
+		if (Z_OBJ(EX(This)) && instanceof_function(Z_OBJCE(EX(This)), ce)) {
 			object = Z_OBJ(EX(This));
 			GC_REFCOUNT(object)++;
-		}
-		if (!object ||
-		    !instanceof_function(object->ce, ce)) {
-		    /* We are calling method of the other (incompatible) class,
-		       but passing $this. This is done for compatibility with php-4. */
+		} else {
 			if (fbc->common.fn_flags & ZEND_ACC_ALLOW_STATIC) {
-				zend_error(
-					object ? E_DEPRECATED : E_STRICT,
-					"Non-static method %s::%s() should not be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error(E_DEPRECATED,
+					"Non-static method %s::%s() should not be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			} else {
-				/* An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call. */
-				zend_error_noreturn(
-					E_ERROR,
-					"Non-static method %s::%s() cannot be called statically%s",
-					fbc->common.scope->name->val, fbc->common.function_name->val,
-					object ? ", assuming $this from incompatible context" : "");
+				zend_error_noreturn(E_ERROR,
+					"Non-static method %s::%s() cannot be called statically",
+					fbc->common.scope->name->val, fbc->common.function_name->val);
 			}
 		}
 	}

--- a/ext/standard/tests/assert/assert_variation.phpt
+++ b/ext/standard/tests/assert/assert_variation.phpt
@@ -107,7 +107,7 @@ array(2) {
 ini.get("assert.callback") => [f2]
 
 
-Strict Standards: Non-static method c1::assert() should not be called statically in %s on line 53
+Deprecated: Non-static method c1::assert() should not be called statically in %s on line 53
 Class assertion failed 53, "0 != 0"
 NULL
 

--- a/ext/standard/tests/general_functions/bug32647.phpt
+++ b/ext/standard/tests/general_functions/bug32647.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #32647 (Using register_shutdown_function() with invalid callback can crash PHP)
 --INI--
-error_reporting=4095
+error_reporting=E_ALL
 display_errors=1
 --FILE--
 <?php
@@ -49,13 +49,13 @@ Warning: register_shutdown_function(): Invalid shutdown callback 'Array' passed 
 
 Warning: register_shutdown_function(): Invalid shutdown callback 'bar' passed in %s on line %d
 
-Strict Standards: Non-static method bar::barfoo() should not be called statically in %sbug32647.php on line %d
+Deprecated: Non-static method bar::barfoo() should not be called statically in %sbug32647.php on line %d
 
 Warning: register_shutdown_function(): Invalid shutdown callback 'bar::foobar' passed in %sbug32647.php on line %d
 foo!
 
-Strict Standards: Non-static method bar::barfoo() should not be called statically in Unknown on line 0
+Deprecated: Non-static method bar::barfoo() should not be called statically in Unknown on line 0
 
-Strict Standards: Non-static method bar::barfoo() should not be called statically in Unknown on line 0
+Deprecated: Non-static method bar::barfoo() should not be called statically in Unknown on line 0
 bar!
 bar!

--- a/ext/standard/tests/general_functions/bug47857.phpt
+++ b/ext/standard/tests/general_functions/bug47857.phpt
@@ -15,7 +15,7 @@ Exception::getMessage();
 --EXPECTF--
 bool(true)
 
-Strict Standards: Non-static method foo::bar() should not be called statically in %sbug47857.php on line %d
+Deprecated: Non-static method foo::bar() should not be called statically in %sbug47857.php on line %d
 ok
 bool(false)
 

--- a/tests/lang/bug23384.phpt
+++ b/tests/lang/bug23384.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #23384 (use of class constants in statics)
 --INI--
-error_reporting=4095
+error_reporting=E_ALL
 --FILE--
 <?php
 define('TEN', 10);
@@ -21,7 +21,7 @@ Foo::test();
 echo Foo::HUN."\n";
 ?>
 --EXPECTF--
-Strict Standards: Non-static method Foo::test() should not be called statically in %sbug23384.php on line %d
+Deprecated: Non-static method Foo::test() should not be called statically in %sbug23384.php on line %d
 Array
 (
     [100] => ten

--- a/tests/lang/passByReference_005.phpt
+++ b/tests/lang/passByReference_005.phpt
@@ -179,17 +179,17 @@ string(12) "Ref2 changed"
 
  ---- Pass by ref / pass by val: static method calls ----
 
-Strict Standards: Non-static method C::v() should not be called statically in %s on line 95
+Deprecated: Non-static method C::v() should not be called statically in %s on line 95
 
 Notice: Undefined variable: u1 in %s on line 95
 
-Strict Standards: Non-static method C::r() should not be called statically in %s on line 96
+Deprecated: Non-static method C::r() should not be called statically in %s on line 96
 
 Notice: Undefined variable: u1 in %s on line 97
 NULL
 string(11) "Ref changed"
 
-Strict Standards: Non-static method C::vv() should not be called statically in %s on line 100
+Deprecated: Non-static method C::vv() should not be called statically in %s on line 100
 
 Notice: Undefined variable: u1 in %s on line 100
 
@@ -201,7 +201,7 @@ Notice: Undefined variable: u2 in %s on line 101
 NULL
 NULL
 
-Strict Standards: Non-static method C::vr() should not be called statically in %s on line 104
+Deprecated: Non-static method C::vr() should not be called statically in %s on line 104
 
 Notice: Undefined variable: u1 in %s on line 104
 
@@ -209,7 +209,7 @@ Notice: Undefined variable: u1 in %s on line 105
 NULL
 string(11) "Ref changed"
 
-Strict Standards: Non-static method C::rv() should not be called statically in %s on line 108
+Deprecated: Non-static method C::rv() should not be called statically in %s on line 108
 
 Notice: Undefined variable: u2 in %s on line 108
 
@@ -217,7 +217,7 @@ Notice: Undefined variable: u2 in %s on line 109
 string(11) "Ref changed"
 NULL
 
-Strict Standards: Non-static method C::rr() should not be called statically in %s on line 112
+Deprecated: Non-static method C::rr() should not be called statically in %s on line 112
 string(12) "Ref1 changed"
 string(12) "Ref2 changed"
 

--- a/tests/lang/passByReference_006.phpt
+++ b/tests/lang/passByReference_006.phpt
@@ -91,7 +91,7 @@ object(stdClass)#%d (1) {
 
  ---- Pass uninitialised arrays & objects by ref: static method call ---
 
-Strict Standards: Non-static method C::refs() should not be called statically in %s on line 39
+Deprecated: Non-static method C::refs() should not be called statically in %s on line 39
 array(1) {
   [0]=>
   string(12) "Ref1 changed"


### PR DESCRIPTION
 * If we can detect at compile-time that a function uses $this,
   then ZEND_ACC_ALLOW_STATIC flag will not be set.
 * A static call (either without object or object from an incompatible
   class) to a non-static method without ZEND_ACC_ALLOW_STATIC will
   generate a fatal error.
 * If static calls are allowed an E_DEPRECATED will be generated.
 * In this case $this will be NULL. This makes sure that even
   obscured (varvar) usages of $this will not be able to access an
   object from an incompatible context.