### PR TITLE
Fixed bug #68638 pg_update() fails to store infinite values.

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -5591,15 +5591,13 @@ PHP_PGSQL_API int php_pgsql_convert(PGconn *pg_link, const char *table_name, con
 						else {
 							/* FIXME: better regex must be used */
 							if (php_pgsql_convert_match(Z_STRVAL_PP(val), Z_STRLEN_PP(val), "^([+-]{0,1}[0-9]+)|([+-]{0,1}[0-9]*[\\.][0-9]+)|([+-]{0,1}[0-9]+[\\.][0-9]*)|([+-]{0,1}(inf)(inity){0,1})$", 1 TSRMLS_CC) == FAILURE) {
-								err = 1;
+									err = 1;
 							}
 							else {
-
 								ZVAL_STRING(new_val, Z_STRVAL_PP(val), 1);
-								if(php_pgsql_convert_match(Z_STRVAL_PP(val), Z_STRLEN_PP(val), "^([+-]{0,1}(inf)(inity){0,1})$", 1 TSRMLS_CC) == SUCCESS) {
+								if(strcasestr(Z_STRVAL_PP(val),"inf")!=0){
 									php_pgsql_add_quotes(new_val, 1 TSRMLS_CC);
 								}
-
 							}
 						}
 						break;

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -5591,7 +5591,7 @@ PHP_PGSQL_API int php_pgsql_convert(PGconn *pg_link, const char *table_name, con
 						else {
 							/* FIXME: better regex must be used */
 							if (php_pgsql_convert_match(Z_STRVAL_PP(val), Z_STRLEN_PP(val), "^([+-]{0,1}[0-9]+)|([+-]{0,1}[0-9]*[\\.][0-9]+)|([+-]{0,1}[0-9]+[\\.][0-9]*)|([+-]{0,1}(inf)(inity){0,1})$", 1 TSRMLS_CC) == FAILURE) {
-									err = 1;
+								err = 1;
 							}
 							else {
 								ZVAL_STRING(new_val, Z_STRVAL_PP(val), 1);

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -5590,12 +5590,16 @@ PHP_PGSQL_API int php_pgsql_convert(PGconn *pg_link, const char *table_name, con
 						}
 						else {
 							/* FIXME: better regex must be used */
-							if (php_pgsql_convert_match(Z_STRVAL_PP(val), Z_STRLEN_PP(val), "^([+-]{0,1}[0-9]+)|([+-]{0,1}[0-9]*[\\.][0-9]+)|([+-]{0,1}[0-9]+[\\.][0-9]*)|([+-]{0,1}(INF)(inity){0,1})$", 1 TSRMLS_CC) == FAILURE) {
+							if (php_pgsql_convert_match(Z_STRVAL_PP(val), Z_STRLEN_PP(val), "^([+-]{0,1}[0-9]+)|([+-]{0,1}[0-9]*[\\.][0-9]+)|([+-]{0,1}[0-9]+[\\.][0-9]*)|([+-]{0,1}(inf)(inity){0,1})$", 1 TSRMLS_CC) == FAILURE) {
 								err = 1;
 							}
 							else {
+
 								ZVAL_STRING(new_val, Z_STRVAL_PP(val), 1);
-								php_pgsql_add_quotes(new_val, 1 TSRMLS_CC);
+								if(php_pgsql_convert_match(Z_STRVAL_PP(val), Z_STRLEN_PP(val), "^([+-]{0,1}(inf)(inity){0,1})$", 1 TSRMLS_CC) == SUCCESS) {
+									php_pgsql_add_quotes(new_val, 1 TSRMLS_CC);
+								}
+
 							}
 						}
 						break;

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -5590,11 +5590,12 @@ PHP_PGSQL_API int php_pgsql_convert(PGconn *pg_link, const char *table_name, con
 						}
 						else {
 							/* FIXME: better regex must be used */
-							if (php_pgsql_convert_match(Z_STRVAL_PP(val), Z_STRLEN_PP(val), "^([+-]{0,1}[0-9]+)|([+-]{0,1}[0-9]*[\\.][0-9]+)|([+-]{0,1}[0-9]+[\\.][0-9]*)$", 0 TSRMLS_CC) == FAILURE) {
+							if (php_pgsql_convert_match(Z_STRVAL_PP(val), Z_STRLEN_PP(val), "^([+-]{0,1}[0-9]+)|([+-]{0,1}[0-9]*[\\.][0-9]+)|([+-]{0,1}[0-9]+[\\.][0-9]*)|([+-]{0,1}(INF)(inity){0,1})$", 1 TSRMLS_CC) == FAILURE) {
 								err = 1;
 							}
 							else {
 								ZVAL_STRING(new_val, Z_STRVAL_PP(val), 1);
+								php_pgsql_add_quotes(new_val, 1 TSRMLS_CC);
 							}
 						}
 						break;

--- a/ext/pgsql/tests/bug68638.phpt
+++ b/ext/pgsql/tests/bug68638.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Bug #68638 pg_update() fails to store infinite values
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+include('config.inc');
+
+$conn = pg_connect($conn_str);
+
+$table='test_68638';
+
+pg_query("CREATE TABLE $table (id INT, value FLOAT)");
+
+pg_insert($conn,$table, array('id' => 1, 'value' => 1.2));
+pg_insert($conn,$table, array('id' => 2, 'value' => 10));
+pg_insert($conn,$table, array('id' => 3, 'value' => 15));
+
+var_dump(pg_update($conn,$table, array('value' => 'inf'), array('id' => 1), PGSQL_DML_STRING));
+
+pg_update($conn,$table, array('value' => 'inf'), array('id' => 1));
+pg_update($conn,$table, array('value' => '-inf'), array('id' => 2));
+pg_update($conn,$table, array('value' => '+inf'), array('id' => 3));
+
+$rs = pg_query("SELECT * FROM $table");
+while ($row = pg_fetch_assoc($rs)) {
+        var_dump($row);
+}
+
+pg_query("DROP TABLE $table");
+
+?>
+--EXPECT--
+string(52) "UPDATE "test_68638" SET "value"=E'inf' WHERE "id"=1;"
+array(2) {
+  ["id"]=>
+  string(1) "1"
+  ["value"]=>
+  string(8) "Infinity"
+}
+array(2) {
+  ["id"]=>
+  string(1) "2"
+  ["value"]=>
+  string(9) "-Infinity"
+}
+array(2) {
+  ["id"]=>
+  string(1) "3"
+  ["value"]=>
+  string(8) "Infinity"
+}


### PR DESCRIPTION
Regex to check float values changed to accept "infinity" values and ignore case. 
Quotes are added to prevent syntax error on PostgreSQL.