### PR TITLE
#68986 pointer returned by php_stream_fopen_temporary_file not validated in memory.c

### DIFF
--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -375,6 +375,10 @@ static size_t php_stream_temp_write(php_stream *stream, const char *buf, size_t 
 
 		if (memsize + count >= ts->smax) {
 			php_stream *file = php_stream_fopen_temporary_file(ts->tmpdir, "php", NULL);
+			if (file == NULL) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to create temporary file.  Check permissions in temporary files directory.");
+				return NULL;
+			}
 			php_stream_write(file, membuf, memsize);
 			php_stream_free_enclosed(ts->innerstream, PHP_STREAM_FREE_CLOSE);
 			ts->innerstream = file;

--- a/tests/basic/bug68986.phpt
+++ b/tests/basic/bug68986.phpt
@@ -8,6 +8,11 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 	die('skip.. only for unix');
 }
 
+$fp = fopen('php://temp', 'r+');
+$data = implode('', array_fill(0, (1024 * 1024 * 2), 'A'));
+var_dump(fwrite($fp, $data)); 
+fclose($fp);
+
 $tempDir = getenv("TMPDIR");
 mkdir($tempDir . '/php68986');
 system("chmod 444 " . $tempDir . '/php68986');
@@ -19,5 +24,7 @@ var_dump(fwrite($fp, $data));
 fclose($fp);
 rmdir($tempDir . '/php68986');
 
+?>
 --EXPECT--
+int(2097152)
 int(2088960)

--- a/tests/basic/bug68986.phpt
+++ b/tests/basic/bug68986.phpt
@@ -8,11 +8,6 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 	die('skip.. only for unix');
 }
 
-$fp = fopen('php://temp', 'r+');
-$data = implode('', array_fill(0, (1024 * 1024 * 2), 'A'));
-var_dump(fwrite($fp, $data)); 
-fclose($fp);
-
 $tempDir = getenv("TMPDIR");
 mkdir($tempDir . '/php68986');
 system("chmod 444 " . $tempDir . '/php68986');
@@ -25,5 +20,4 @@ fclose($fp);
 rmdir($tempDir . '/php68986');
 
 --EXPECT--
-int(2097152)
 int(2088960)

--- a/tests/basic/bug68986.phpt
+++ b/tests/basic/bug68986.phpt
@@ -24,7 +24,6 @@ var_dump(fwrite($fp, $data));
 fclose($fp);
 rmdir($tempDir . '/php68986');
 
-?>
 --EXPECT--
 int(2097152)
 int(2088960)

--- a/tests/basic/bug68986.phpt
+++ b/tests/basic/bug68986.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #68986 (pointer returned by php_stream_fopen_temporary_file not validated in memory.c)
+--INI--
+default_charset=UTF-8
+--FILE--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+	die('skip.. only for unix');
+}
+
+$tempDir = getenv("TMPDIR");
+mkdir($tempDir . '/php68986');
+system("chmod 444 " . $tempDir . '/php68986');
+putenv("TMPDIR=" . $tempDir . '/php68986');
+
+$fp = fopen('php://temp', 'r+');
+$data = implode('', array_fill(0, (1024 * 1024 * 2), 'A'));
+var_dump(fwrite($fp, $data)); 
+fclose($fp);
+rmdir($tempDir . '/php68986');
+
+--EXPECT--
+int(2088960)


### PR DESCRIPTION
it seems that the pointer returned by php_stream_fopen_temporary_file / php_stream_fopen_tmpfile is not validated prior to use in memory.c in the case where a script is executed in an environment  where the TMPDIR is not writable to the user, it will cause a SIGSEGV.

from the script side any code that utilize php://temp with 2MB+ buffer with the above condition will encounter this issue.

i have fixed the problem on all the calling code in memory.c using php_error_docref, i see that in phar they have handled the condition with zend_throw_exception_ex. i am not in a position to decide which one is best at this time. i think a friendly warning is better than a SIGSEGV at this point :)

i have validated this problem exists on github-master and releases 5.4.37, 5.4.17 

```php
#mkdir /tmp/x
#chmod 444 /tmp/x
#export TMPDIR=/tmp/x

$fp = fopen('php://temp', 'r+');
$data = implode('', array_fill(0, (1024 * 1024 * 2), 'A'));
fwrite($fp, $data);
```