### PR TITLE
#68986 pointer returned by php_stream_fopen_temporary_file not validated in memory.c (fix for 5.4)

### DIFF
--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -370,6 +370,10 @@ static size_t php_stream_temp_write(php_stream *stream, const char *buf, size_t 
 
 		if (memsize + count >= ts->smax) {
 			php_stream *file = php_stream_fopen_tmpfile();
+			if (file == NULL) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to create temporary file.  Check permissions in temporary files directory.");
+				return NULL;
+			}
 			php_stream_write(file, membuf, memsize);
 			php_stream_free_enclosed(ts->innerstream, PHP_STREAM_FREE_CLOSE);
 			ts->innerstream = file;

--- a/tests/basic/bug68986.phpt
+++ b/tests/basic/bug68986.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #68986 (pointer returned by php_stream_fopen_temporary_file not validated in memory.c)
+--INI--
+default_charset=UTF-8
+--FILE--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+	die('skip.. only for unix');
+}
+
+$tempDir = getenv("TMPDIR");
+mkdir($tempDir . '/php68986');
+system("chmod 444 " . $tempDir . '/php68986');
+putenv("TMPDIR=" . $tempDir . '/php68986');
+
+$fp = fopen('php://temp', 'r+');
+$data = implode('', array_fill(0, (1024 * 1024 * 2), 'A'));
+var_dump(fwrite($fp, $data)); 
+fclose($fp);
+rmdir($tempDir . '/php68986');
+
+--EXPECT--
+int(2088960)


### PR DESCRIPTION
this is 5.4 fix for https://github.com/php/php-src/pull/1051