### PR TITLE
Invalid free of CG(interned_empty_string)

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -4004,7 +4004,7 @@ static xmlDocPtr serialize_response_call(sdlFunctionPtr function, char *function
 				} else {	
 					xmlNodeSetContentLen(node, BAD_CAST(str), (int)new_len);
 				}
-				efree(str);
+				str_efree(str);
 			}
 			if (zend_hash_find(prop, "faultstring", sizeof("faultstring"), (void**)&tmp) == SUCCESS) {
 				xmlNodePtr node = master_to_xml(get_conversion(IS_STRING), *tmp, SOAP_LITERAL, param TSRMLS_CC);
@@ -4029,7 +4029,7 @@ static xmlDocPtr serialize_response_call(sdlFunctionPtr function, char *function
 				} else {	
 					xmlNodeSetContentLen(node, BAD_CAST(str), (int)new_len);
 				}
-				efree(str);
+				str_efree(str);
 			}
 			if (zend_hash_find(prop, "faultstring", sizeof("faultstring"), (void**)&tmp) == SUCCESS) {
 				xmlNodePtr node = xmlNewChild(param, ns, BAD_CAST("Reason"), NULL);

--- a/ext/wddx/wddx.c
+++ b/ext/wddx/wddx.c
@@ -409,7 +409,7 @@ static void php_wddx_serialize_string(wddx_packet *packet, zval *var TSRMLS_DC)
 
 		php_wddx_add_chunk_ex(packet, buf, buf_len);
 
-		efree(buf);
+		str_efree(buf);
 	}
 	php_wddx_add_chunk_static(packet, WDDX_STRING_E);
 }
@@ -635,7 +635,7 @@ void php_wddx_serialize_var(wddx_packet *packet, zval *var, char *name, int name
 		snprintf(tmp_buf, name_esc_len + sizeof(WDDX_VAR_S), WDDX_VAR_S, name_esc);
 		php_wddx_add_chunk(packet, tmp_buf);
 		efree(tmp_buf);
-		efree(name_esc);
+		str_efree(name_esc);
 	}
 	
 	switch(Z_TYPE_P(var)) {

--- a/main/main.c
+++ b/main/main.c
@@ -918,7 +918,7 @@ PHPAPI void php_verror(const char *docref, const char *params, int type, const c
 	} else {
 		spprintf(&message, 0, "%s: %s", origin, buffer);
 	}
-	efree(origin);
+	str_efree(origin);
 	if (docref_buf) {
 		efree(docref_buf);
 	}


### PR DESCRIPTION
On failure php_escape_html_entities returns STR_EMPTY_ALLOC which is an
alias of CG(interned_empty_string) if interned strings are enabled.
Make sure we don't free this.

Fixes #68996