### PR TITLE
Invalid free of CG(interned_empty_string)

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -4004,7 +4004,7 @@ static xmlDocPtr serialize_response_call(sdlFunctionPtr function, char *function
 				} else {	
 					xmlNodeSetContentLen(node, BAD_CAST(str), (int)new_len);
 				}
-				efree(str);
+				str_efree(str);
 			}
 			if (zend_hash_find(prop, "faultstring", sizeof("faultstring"), (void**)&tmp) == SUCCESS) {
 				xmlNodePtr node = master_to_xml(get_conversion(IS_STRING), *tmp, SOAP_LITERAL, param TSRMLS_CC);
@@ -4029,7 +4029,7 @@ static xmlDocPtr serialize_response_call(sdlFunctionPtr function, char *function
 				} else {	
 					xmlNodeSetContentLen(node, BAD_CAST(str), (int)new_len);
 				}
-				efree(str);
+				str_efree(str);
 			}
 			if (zend_hash_find(prop, "faultstring", sizeof("faultstring"), (void**)&tmp) == SUCCESS) {
 				xmlNodePtr node = xmlNewChild(param, ns, BAD_CAST("Reason"), NULL);

--- a/ext/soap/tests/bug68996.phpt
+++ b/ext/soap/tests/bug68996.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Bug #68996 (Invalid free of CG(interned_empty_string))
+--SKIPIF--
+<?php
+if (getenv("USE_ZEND_ALLOC") !== "0")
+    print "skip Need Zend MM disabled";
+?>
+--FILE--
+<?php
+$s = new SoapServer(NULL, [
+    'uri' => 'http://foo',
+]);
+
+function foo() {
+  return new SoapFault("\xfc\x63", "some msg");
+}
+$s->addFunction("foo");
+
+// soap 1.1
+$HTTP_RAW_POST_DATA = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <SOAP-ENV:foo />
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+EOF;
+$s->handle($HTTP_RAW_POST_DATA);
+
+// soap 1.2
+$HTTP_RAW_POST_DATA = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+  <env:Body>
+    <env:foo />
+  </env:Body>
+</env:Envelope>
+EOF;
+$s->handle($HTTP_RAW_POST_DATA);
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode></faultcode><faultstring>some msg</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><env:Fault><env:Code><env:Value></env:Value></env:Code><env:Reason><env:Text>some msg</env:Text></env:Reason></env:Fault></env:Body></env:Envelope>

--- a/ext/standard/tests/strings/bug68996.phpt
+++ b/ext/standard/tests/strings/bug68996.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #68996 (Invalid free of CG(interned_empty_string))
+--SKIPIF--
+<?php
+if (getenv("USE_ZEND_ALLOC") !== "0")
+    print "skip Need Zend MM disabled";
+?>
+--INI--
+html_errors=1
+--FILE--
+<?php
+fopen("\xfc\x63", "r");
+?>
+--EXPECTF--
+<br />
+<b>Warning</b>:  : failed to open stream: No such file or directory in <b>%sbug68996.php</b> on line <b>2</b><br />

--- a/ext/standard/tests/strings/bug68996.phpt
+++ b/ext/standard/tests/strings/bug68996.phpt
@@ -10,7 +10,14 @@ html_errors=1
 --FILE--
 <?php
 fopen("\xfc\x63", "r");
+finfo_open(FILEINFO_MIME_TYPE, "\xfc\x63");
 ?>
 --EXPECTF--
 <br />
 <b>Warning</b>:  : failed to open stream: No such file or directory in <b>%sbug68996.php</b> on line <b>2</b><br />
+<br />
+<b>Warning</b>:  : failed to open stream: No such file or directory in <b>%sbug68996.php</b> on line <b>3</b><br />
+<br />
+<b>Warning</b>:  : failed to open stream: No such file or directory in <b>%sbug68996.php</b> on line <b>3</b><br />
+<br />
+<b>Warning</b>:  finfo_open():  in <b>/%sbug68996.php</b> on line <b>3</b><br />

--- a/ext/wddx/tests/bug68996.phpt
+++ b/ext/wddx/tests/bug68996.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #68996 (Invalid free of CG(interned_empty_string))
+--SKIPIF--
+<?php
+if (getenv("USE_ZEND_ALLOC") !== "0")
+    print "skip Need Zend MM disabled";
+?>
+--FILE--
+<?php
+echo wddx_serialize_value("\xfc\x63") . "\n";
+echo wddx_serialize_value([ "\xfc\x63" => "foo" ]) . "\n";
+?>
+--EXPECTF--
+<wddxPacket version='1.0'><header/><data><string></string></data></wddxPacket>
+<wddxPacket version='1.0'><header/><data><struct><var name=''><string>foo</string></var></struct></data></wddxPacket>

--- a/ext/wddx/wddx.c
+++ b/ext/wddx/wddx.c
@@ -409,7 +409,7 @@ static void php_wddx_serialize_string(wddx_packet *packet, zval *var TSRMLS_DC)
 
 		php_wddx_add_chunk_ex(packet, buf, buf_len);
 
-		efree(buf);
+		str_efree(buf);
 	}
 	php_wddx_add_chunk_static(packet, WDDX_STRING_E);
 }
@@ -635,7 +635,7 @@ void php_wddx_serialize_var(wddx_packet *packet, zval *var, char *name, int name
 		snprintf(tmp_buf, name_esc_len + sizeof(WDDX_VAR_S), WDDX_VAR_S, name_esc);
 		php_wddx_add_chunk(packet, tmp_buf);
 		efree(tmp_buf);
-		efree(name_esc);
+		str_efree(name_esc);
 	}
 	
 	switch(Z_TYPE_P(var)) {

--- a/main/main.c
+++ b/main/main.c
@@ -918,7 +918,7 @@ PHPAPI void php_verror(const char *docref, const char *params, int type, const c
 	} else {
 		spprintf(&message, 0, "%s: %s", origin, buffer);
 	}
-	efree(origin);
+	str_efree(origin);
 	if (docref_buf) {
 		efree(docref_buf);
 	}

--- a/main/main.c
+++ b/main/main.c
@@ -935,7 +935,7 @@ PHPAPI void php_verror(const char *docref, const char *params, int type, const c
 			zend_hash_update(EG(active_symbol_table), "php_errormsg", sizeof("php_errormsg"), (void **) &tmp, sizeof(zval *), NULL);
 		}
 	}
-	efree(buffer);
+	str_efree(buffer);
 
 	php_error(type, "%s", message);
 	efree(message);


### PR DESCRIPTION
On failure php_escape_html_entities returns STR_EMPTY_ALLOC which is an
alias of CG(interned_empty_string) if interned strings are enabled.
Make sure we don't free this.

Fixes #68996