### PR TITLE
Fixed bug #69001: PHP crashed when calling zend_error during zend_startup

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -741,6 +741,14 @@ int zend_startup(zend_utility_functions *utility_functions, char **extensions TS
 	EG(user_exception_handler) = NULL;
 #endif
 
+	EG(bailout) = NULL;
+	EG(error_reporting) = E_ALL & ~E_NOTICE;
+	EG(active_symbol_table) = NULL;
+	EG(error_handling)  = EH_NORMAL;
+	EG(exception_class) = NULL;
+	EG(exception) = NULL;
+	EG(objects_store).object_buckets = NULL;
+
 	zend_interned_strings_init(TSRMLS_C);
 	zend_startup_builtin_functions(TSRMLS_C);
 	zend_register_standard_constants(TSRMLS_C);

--- a/main/main.c
+++ b/main/main.c
@@ -2038,22 +2038,6 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 
 	php_output_startup();
 
-	zuf.error_function = php_error_cb;
-	zuf.printf_function = php_printf;
-	zuf.write_function = php_output_wrapper;
-	zuf.fopen_function = php_fopen_wrapper_for_zend;
-	zuf.message_handler = php_message_handler_for_zend;
-	zuf.block_interruptions = sapi_module.block_interruptions;
-	zuf.unblock_interruptions = sapi_module.unblock_interruptions;
-	zuf.get_configuration_directive = php_get_configuration_directive_for_zend;
-	zuf.ticks_function = php_run_ticks;
-	zuf.on_timeout = php_on_timeout;
-	zuf.stream_open_function = php_stream_open_for_zend;
-	zuf.vspprintf_function = vspprintf;
-	zuf.getenv_function = sapi_getenv;
-	zuf.resolve_path_function = php_resolve_path_for_zend;
-	zend_startup(&zuf, NULL TSRMLS_CC);
-
 #ifdef ZTS
 	executor_globals = ts_resource(executor_globals_id);
 	ts_allocate_id(&core_globals_id, sizeof(php_core_globals), (ts_allocate_ctor) core_globals_ctor, (ts_allocate_dtor) core_globals_dtor);
@@ -2078,25 +2062,37 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 		}
 	}
 #endif
-	EG(bailout) = NULL;
-	EG(error_reporting) = E_ALL & ~E_NOTICE;
-	EG(active_symbol_table) = NULL;
-	PG(header_is_being_sent) = 0;
+
 	SG(request_info).headers_only = 0;
 	SG(request_info).argv0 = NULL;
 	SG(request_info).argc=0;
 	SG(request_info).argv=(char **)NULL;
+
+	PG(header_is_being_sent) = 0;
 	PG(connection_status) = PHP_CONNECTION_NORMAL;
 	PG(during_request_startup) = 0;
 	PG(last_error_message) = NULL;
 	PG(last_error_file) = NULL;
 	PG(last_error_lineno) = 0;
-	EG(error_handling)  = EH_NORMAL;
-	EG(exception_class) = NULL;
 	PG(disable_functions) = NULL;
 	PG(disable_classes) = NULL;
-	EG(exception) = NULL;
-	EG(objects_store).object_buckets = NULL;
+
+	zuf.error_function = php_error_cb;
+	zuf.printf_function = php_printf;
+	zuf.write_function = php_output_wrapper;
+	zuf.fopen_function = php_fopen_wrapper_for_zend;
+	zuf.message_handler = php_message_handler_for_zend;
+	zuf.block_interruptions = sapi_module.block_interruptions;
+	zuf.unblock_interruptions = sapi_module.unblock_interruptions;
+	zuf.get_configuration_directive = php_get_configuration_directive_for_zend;
+	zuf.ticks_function = php_run_ticks;
+	zuf.on_timeout = php_on_timeout;
+	zuf.stream_open_function = php_stream_open_for_zend;
+	zuf.vspprintf_function = vspprintf;
+	zuf.getenv_function = sapi_getenv;
+	zuf.resolve_path_function = php_resolve_path_for_zend;
+
+	zend_startup(&zuf, NULL TSRMLS_CC);
 
 #if HAVE_SETLOCALE
 	setlocale(LC_CTYPE, "");


### PR DESCRIPTION

https://bugs.php.net/bug.php?id=69001

When build with ZTS, if any function inside zend_startup() throws
any errors(invoke `zend_error()`) will crash PHP. such as: https://github.com/php/php-src/blob/master/Zend/zend_API.c#L1976 

This also move EG() fields's initialization from main.c to zend.c
or there will be a jmp depend on uninitialized value.

https://github.com/php/php-src/blob/594c220dea0a1f3bd5e5d7fa72f8e5d00d0d2e6a/Zend/zend.c#L985

This bugs seems exist from PHP4.0