### PR TITLE
Improve internal function return types checking for parent

### DIFF
--- a/Zend/tests/return_types/026.phpt
+++ b/Zend/tests/return_types/026.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Return type of parent is not allowed in function
+--FILE--
+<?php
+
+function test(): parent {}
+
+--EXPECTF--
+Fatal error: Cannot declare a return type of parent outside of a class scope in %s on line 3

--- a/Zend/tests/return_types/027.phpt
+++ b/Zend/tests/return_types/027.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Return type of parent is not allowed in closure
+--FILE--
+<?php
+
+$c = function(): parent {};
+
+--EXPECTF--
+Fatal error: Cannot declare a return type of parent outside of a class scope in %s on line 3

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2003,6 +2003,7 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 			}
 			if (info->type_hint) {
 				if (info->class_name) {
+					ZEND_ASSERT(info->type_hint == IS_OBJECT);
 					if (!scope && (!strcasecmp(info->class_name, "self") || !strcasecmp(info->class_name, "parent"))) {
 						zend_error(E_CORE_ERROR, "Cannot declare a return type of %s outside of a class scope", info->class_name);
 					}

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2003,16 +2003,7 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 			}
 			if (info->type_hint) {
 				if (info->class_name) {
-					uint32_t fetch_type;
-					zend_string *class_name;
-					ALLOCA_FLAG(use_heap);
-
-					ZEND_ASSERT(info->type_hint == IS_OBJECT);
-					STR_ALLOCA_INIT(class_name, info->class_name, strlen(info->class_name), use_heap);
-					fetch_type = zend_get_class_fetch_type(class_name);
-					STR_ALLOCA_FREE(class_name, use_heap);
-
-					if (fetch_type != ZEND_FETCH_CLASS_DEFAULT && !scope) {
+					if (!scope && (!strcasecmp(info->class_name, "self") || !strcasecmp(info->class_name, "parent"))) {
 						zend_error(E_CORE_ERROR, "Cannot declare a return type of %s outside of a class scope", info->class_name);
 					}
 				}

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2003,9 +2003,17 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 			}
 			if (info->type_hint) {
 				if (info->class_name) {
+					uint32_t fetch_type;
+					zend_string *class_name;
+					ALLOCA_FLAG(use_heap);
+
 					ZEND_ASSERT(info->type_hint == IS_OBJECT);
-					if (!strcasecmp(info->class_name, "self") && !scope) {
-						zend_error(E_CORE_ERROR, "Cannot declare a return type of self outside of a class scope");
+					STR_ALLOCA_INIT(class_name, info->class_name, strlen(info->class_name), use_heap);
+					fetch_type = zend_get_class_fetch_type(class_name);
+					STR_ALLOCA_FREE(class_name, use_heap);
+
+					if (fetch_type != ZEND_FETCH_CLASS_DEFAULT && !scope) {
+						zend_error(E_CORE_ERROR, "Cannot declare a return type of %s outside of a class scope", info->class_name);
 					}
 				}
 


### PR DESCRIPTION
Previously the checking was against 'self', 'parent' need
to be checked as user land declearation as well.

This also add two missing test cases.