### PR TITLE
Fixed a few formatting things in README.TESTING and CODING_STANDARDS

### DIFF
--- a/CODING_STANDARDS
+++ b/CODING_STANDARDS
@@ -18,6 +18,7 @@ Code Implementation
 
 For instance, ``function int mail(char *to, char *from)`` should NOT free
 to and/or from.
+
 Exceptions:
 
 - The function's designated behavior is freeing that resource.  E.g. efree()
@@ -112,6 +113,7 @@ User Functions/Methods Naming Conventions
     of ``parent_*``::
 
     A family of 'foo' functions, for example:
+    
     Good:
     'foo_select_bar'
     'foo_insert_baz'

--- a/README.TESTING
+++ b/README.TESTING
@@ -104,7 +104,8 @@ The php file will be generated always.
 NOTE: You can set environment variable TEST_PHP_DETAILED to enable
 detailed test information.
 
-[Automated testing]
+[Automated Testing]
+--------------
  If you like to keep up to speed, with latest developments and quality
 assurance, setting the environment variable NO_INTERACTION to 1, will not
 prompt the tester for any user input.
@@ -142,7 +143,7 @@ then
 fi
 ========== end of qa-test.sh =============
 
-NOTE: the exit status of run-tests.php will be 1 when
+NOTE: The exit status of run-tests.php will be 1 when
 REPORT_EXIT_STATUS is set. The result of "make test" may be higher
 than that. At present, gmake 3.79.1 returns 2, so it is
 advised to test for non-zero, rather then a specific value.


### PR DESCRIPTION
A few formatting fixes. Mostly to help with readability. 