### PR TITLE
Add missing test for class constant access with deference

### DIFF
--- a/Zend/tests/varSyntax/constClassMemberAccess.phpt
+++ b/Zend/tests/varSyntax/constClassMemberAccess.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Const class member access with deference
+--FILE--
+<?php
+
+class A {
+    const A = ['a' => ['b' => 'c']];
+}
+
+var_dump(A::A);
+var_dump(A::A['a']);
+var_dump(A::A['a']['b']);
+
+?>
+--EXPECT--
+array(1) {
+  ["a"]=>
+  array(1) {
+    ["b"]=>
+    string(1) "c"
+  }
+}
+array(1) {
+  ["b"]=>
+  string(1) "c"
+}
+string(1) "c"


### PR DESCRIPTION
Relates to https://wiki.php.net/rfc/uniform_variable_syntax

I was experimenting with the lexer and noticed there is not test for this use case and this is likely to cause silent syntax BC breaks in the feature.