### PR TITLE
Prefer isfinite to finite

### DIFF
--- a/Zend/configure.in
+++ b/Zend/configure.in
@@ -90,10 +90,10 @@ int zend_sprintf(char *buffer, const char *format, ...);
 #define zend_isinf(a) 0
 #endif
 
-#ifdef HAVE_FINITE
-#define zend_finite(a) finite(a)
-#elif defined(HAVE_ISFINITE) || defined(isfinite)
+#if defined(HAVE_ISFINITE) || defined(isfinite)
 #define zend_finite(a) isfinite(a)
+#elif defined(HAVE_FINITE)
+#define zend_finite(a) finite(a)
 #elif defined(fpclassify)
 #define zend_finite(a) ((fpclassify((a))!=FP_INFINITE&&fpclassify((a))!=FP_NAN)?1:0)
 #else


### PR DESCRIPTION
Since finite() is not part of ANSI C

@see http://bytes.com/topic/c/answers/217761-finite-ansi-c