### PR TITLE
Add macro php_error_docref_ex()

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -268,7 +268,7 @@ PHPAPI zend_long php_count_recursive(zval *array, zend_long mode) /* {{{ */
 
 	if (Z_TYPE_P(array) == IS_ARRAY) {
 		if (Z_ARRVAL_P(array)->u.v.nApplyCount > 1) {
-			php_error_docref(NULL, E_WARNING, "recursion detected");
+			php_error_docref_ex(E_WARNING, "recursion detected");
 			return 0;
 		}
 

--- a/main/php.h
+++ b/main/php.h
@@ -320,6 +320,7 @@ PHPAPI void php_win32_docref2_from_error(DWORD error, const char *param1, const 
 END_EXTERN_C()
 
 #define php_error_docref php_error_docref0
+#define php_error_docref_ex(...) php_error_docref0(NULL, __VA_ARGS__)
 
 #define zenderror phperror
 #define zendlex phplex


### PR DESCRIPTION
The first parameter of php_error_docref() are always NULL.

Most of the code in both php-src & external extension, the docref is NULL.

In php-src:
docref NULL: 2530
docref not NULL:  51

I will update rest of the code to use new macro if accepted
