### PR TITLE
Fix long messages to stdout/stderr getting truncated

### DIFF
--- a/sapi/fpm/fpm/fpm_stdio.c
+++ b/sapi/fpm/fpm/fpm_stdio.c
@@ -119,6 +119,8 @@ static void fpm_stdio_child_said(struct fpm_event_s *ev, short which, void *arg)
 	int is_last_message = 0;
 	int in_buf = 0;
 	int res;
+	char fmt_buf[max_buf_size];
+	int fmt_len = 0;
 
 	if (!arg) {
 		return;
@@ -130,10 +132,15 @@ static void fpm_stdio_child_said(struct fpm_event_s *ev, short which, void *arg)
 	} else {
 		event = &child->ev_stderr;
 	}
+	
+	/* calculate how long the "child 123 said into ..." prefix is so we can subtract its length from max_buf_size */
+	fmt_len = snprintf(fmt_buf, max_buf_size, "[pool %s] child %d said into %s: \"%%s\"%%s", child->wp->config->name, (int) child->pid, is_stdout ? "stdout" : "stderr");
+	/* subtract two characters each for the two "%s", then add character counts for "WARNING: " added by zlog and "[11-Feb-2015 15:58:20] " added by zlog; we're ignoring the potential extra length in log_level=DEBUG */
+	fmt_len = fmt_len - 2 - 2 + 9 + 23; 
 
 	while (fifo_in || fifo_out) {
 		if (fifo_in) {
-			res = read(fd, buf + in_buf, max_buf_size - 1 - in_buf);
+			res = read(fd, buf + in_buf, max_buf_size - fmt_len - 1 - in_buf);
 			if (res <= 0) { /* no data */
 				fifo_in = 0;
 				if (res < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
@@ -171,7 +178,7 @@ static void fpm_stdio_child_said(struct fpm_event_s *ev, short which, void *arg)
 				/* FIXME: there might be binary data */
 
 				/* we should print if no more space in the buffer */
-				if (in_buf == max_buf_size - 1) {
+				if (in_buf == max_buf_size - fmt_len - 1) {
 					should_print = 1;
 				}
 
@@ -187,8 +194,7 @@ static void fpm_stdio_child_said(struct fpm_event_s *ev, short which, void *arg)
 						*nl = '\0';
 					}
 
-					zlog(ZLOG_WARNING, "[pool %s] child %d said into %s: \"%s\"%s", child->wp->config->name,
-					  (int) child->pid, is_stdout ? "stdout" : "stderr", buf, is_last_message ? ", pipe is closed" : "");
+					zlog(ZLOG_WARNING, fmt_buf, buf, is_last_message ? ", pipe is closed" : "");
 
 					if (nl) {
 						int out_buf = 1 + nl - buf;


### PR DESCRIPTION
The maximum zlog message length is 1024 including timestamp et cetera.

With very long messages over 1024 characters, these get wrapped into multiple chunks correctly, but then the "WARNING: child blah said into blah" gets added and the zlog call truncates the messages using "..." at the end, resulting in a couple dozen bytes getting lost.

This change calculates the length at which wrapping needs to occur correctly.

To reproduce, log a long message to `stderr`, e.g. a bit of Shakespeare:

```
file_put_contents('php://stderr', "If it were done when 'tis done, then 'twere well // It were done quickly. If the assassination // Could trammel up the consequence, and catch, // With his surcease, success; that but this blow // Might be the be-all and the end-all--here, // But here, upon this bank and shoal of time,-- // We'd jump the life to come. But in these cases // We still have judgement here; that we but teach // Bloody instructions, which being taught, return // To plague the inventor: this even-handed justice // Commends the ingredients of our poison'd chalice // To our own lips. He's here in double trust: // First, as I am his kinsman and his subject, // Strong both against the deed: then, as his host, // Who should against his murderer shut the door, // Not bear the knife myself. Besides, this Duncan // Hath borne his faculties so meek, hath been // So clear in his great office, that his virtues // Will plead like angels, trumpet-tongued, against // The deep damnation of his taking-off: // And pity, like a naked new-born babe, // Striding the blast, or heaven's cherubin, hors'd // Upon the sightless couriers of the air, // Shall blow the horrid deed in every eye, // That tears shall drown the wind.--I have no spur // To prick the sides of my intent, but only // Vaulting ambition, which o'erleaps itself, // And falls on the other. // Is this a dagger which I see before me, // The handle toward my hand? Come, let me clutch thee:-- // I have thee not, and yet I see thee still. // Art thou not, fatal vision, sensible // To feeling as to sight? or art thou but // A dagger of the mind, a false creation, // Proceeding from the heat-oppressed brain? // I see thee yet, in form as palpable // As this which now I draw. // Thou marshall'st me the way that I was going; // And such an instrument I was to use. // Mine eyes are made the fools o' the other senses, // Or else worth all the rest: I see thee still; // And on thy blade and dudgeon gouts of blood, // Which was not so before.--There's no such thing: // It is the bloody business which informs // Thus to mine eyes.--Now o'er the one half-world // Nature seems dead, and wicked dreams abuse // The curtain'd sleep; now witchcraft celebrates // Pale Hecate's offerings; and wither'd murder, // Alarum'd by his sentinel, the wolf, // Whose howl's his watch, thus with his stealthy pace, // With Tarquin's ravishing strides, towards his design // Moves like a ghost.--Thou sure and firm-set earth, // Hear not my steps, which way they walk, for fear // Thy very stones prate of my whereabout, // And take the present horror from the time, // Which now suits with it.--Whiles I threat, he lives; // Words to the heat of deeds too cold breath gives. // ");
```
