### PR TITLE
Fixed #69017 Fail to push to array with constant value defined in class scope

### DIFF
--- a/Zend/tests/bug69017.phpt
+++ b/Zend/tests/bug69017.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug #bug69017 - Fail to push to the empty array with the constant value defined in class scope
+--FILE--
+<?php
+
+class c1
+{
+	const ZERO = 0;
+	const ONE = 1;
+	public static $a1 = array(self::ONE => 'one');
+	public static $a2 = array(self::ZERO => 'zero');
+}
+
+$v1 = c1::$a1;
+$v2 = c1::$a2;
+
+$v1[] = 1;
+$v2[] = 1;
+
+var_dump($v1);
+var_dump($v2);
+?>
+--EXPECT--
+array(2) {
+  [1]=>
+  string(3) "one"
+  [2]=>
+  int(1)
+}
+array(2) {
+  [0]=>
+  string(4) "zero"
+  [1]=>
+  int(1)
+}

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1415,6 +1415,9 @@ ZEND_API int zend_hash_update_current_key_ex(HashTable *ht, int key_type, const 
 
 		if (key_type == HASH_KEY_IS_LONG) {
 			p->h = num_index;
+			if (num_index >= ht->nNextFreeElement) {
+				ht->nNextFreeElement = num_index + 1;
+			}
 		} else {
 			p->h = h;
 			p->nKeyLength = str_length;


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=69017

When updating constant key we should update nNextElement too.