### PR TITLE
Fixed list evaluation order been changed after AST patch merged

### DIFF
--- a/Zend/tests/list_008.phpt
+++ b/Zend/tests/list_008.phpt
@@ -1,0 +1,20 @@
+--TEST--
+List evaluation order should be reversed
+--FILE--
+<?php
+
+$list = array('first', 'second', 'third');
+list($a[0], $a[1], $a[2]) = $list;
+
+var_dump($a);
+
+?>
+--EXPECTF--
+array(3) {
+  [2]=>
+  string(5) "third"
+  [1]=>
+  string(6) "second"
+  [0]=>
+  string(5) "first"
+}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2237,10 +2237,11 @@ void zend_compile_static_prop(znode *result, zend_ast *ast, uint32_t type, int d
 static void zend_compile_list_assign(znode *result, zend_ast *ast, znode *expr_node) /* {{{ */
 {
 	zend_ast_list *list = zend_ast_get_list(ast);
-	uint32_t i;
+	int32_t i;
 	zend_bool has_elems = 0;
 
-	for (i = 0; i < list->children; ++i) {
+	/* list was evaluated from right to left */
+	for (i = list->children - 1; i >= 0; --i) {
 		zend_ast *var_ast = list->child[i];
 		znode fetch_result, dim_node;
 


### PR DESCRIPTION
Hi @nikic,

Before AST patch, the evaluation is from right to left, it prepend new node list, now we use ast array, 
this patch changed the evaluation order back by loop reversely.
