### PR TITLE
Correct and test none/null return types distinction

### DIFF
--- a/Zend/tests/return_types/001.phpt
+++ b/Zend/tests/return_types/001.phpt
@@ -9,4 +9,4 @@ function test1() : array {
 test1();
 
 --EXPECTF--
-Catchable fatal error: Return value of test1() must be of the type array, none returned in %s on line %d
+Catchable fatal error: Return value of test1() must be of the type array, no value returned in %s on line %d

--- a/Zend/tests/return_types/null_and_none1.phpt
+++ b/Zend/tests/return_types/null_and_none1.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Return types none/null distinction: Empty function
+--FILE--
+<?php
+
+function lacks_return(): array {
+}
+
+lacks_return();
+
+--EXPECTF--
+Catchable fatal error: Return value of lacks_return() must be of the type array, none returned in %snull_and_none1.php on line 3

--- a/Zend/tests/return_types/null_and_none1.phpt
+++ b/Zend/tests/return_types/null_and_none1.phpt
@@ -9,4 +9,4 @@ function lacks_return(): array {
 lacks_return();
 
 --EXPECTF--
-Catchable fatal error: Return value of lacks_return() must be of the type array, none returned in %snull_and_none1.php on line 3
+Catchable fatal error: Return value of lacks_return() must be of the type array, no value returned in %snull_and_none1.php on line 3

--- a/Zend/tests/return_types/null_and_none2.phpt
+++ b/Zend/tests/return_types/null_and_none2.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Return types none/null distinction: return;
+--FILE--
+<?php
+
+function returns_none(): array {
+    return;
+}
+
+returns_none();
+--EXPECTF--
+Catchable fatal error: Return value of returns_none() must be of the type array, none returned in %snull_and_none2.php on line 4

--- a/Zend/tests/return_types/null_and_none2.phpt
+++ b/Zend/tests/return_types/null_and_none2.phpt
@@ -9,4 +9,4 @@ function returns_none(): array {
 
 returns_none();
 --EXPECTF--
-Catchable fatal error: Return value of returns_none() must be of the type array, none returned in %snull_and_none2.php on line 4
+Catchable fatal error: Return value of returns_none() must be of the type array, no value returned in %snull_and_none2.php on line 4

--- a/Zend/tests/return_types/null_and_none3.phpt
+++ b/Zend/tests/return_types/null_and_none3.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Return types none/null distinction: return null;
+--FILE--
+<?php
+
+function returns_null(): array {
+    return null;
+}
+
+returns_null();
+--EXPECTF--
+Catchable fatal error: Return value of returns_null() must be of the type array, null returned in %snull_and_none3.php on line 4

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3194,7 +3194,12 @@ void zend_compile_return(zend_ast *ast) /* {{{ */
 	}
 
 	if (CG(active_op_array)->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
-		zend_emit_return_type_check(&expr_node, CG(active_op_array)->arg_info - 1);
+		/* maintains empty return/NULL return distinction */
+		if (!expr_ast) {
+			zend_emit_return_type_check(NULL, CG(active_op_array)->arg_info - 1);
+		} else {
+			zend_emit_return_type_check(&expr_node, CG(active_op_array)->arg_info - 1);
+		}
 		if (expr_node.op_type == IS_CONST) {
 			zval_copy_ctor(&expr_node.u.constant);
 		}

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -859,13 +859,13 @@ static inline int zend_verify_missing_return_type(zend_function *zf)
 		char *class_name;
 
 		need_msg = zend_verify_arg_class_kind(ret_info, &class_name, &ce);
-		zend_verify_return_error(E_RECOVERABLE_ERROR, zf, need_msg, class_name, "none", "");
+		zend_verify_return_error(E_RECOVERABLE_ERROR, zf, need_msg, class_name, "no value", "");
 		return 0;
 	} else if (ret_info->type_hint) {
 		if (ret_info->type_hint == IS_ARRAY) {
-			zend_verify_return_error(E_RECOVERABLE_ERROR, zf, "be of the type array", "", "none", "");
+			zend_verify_return_error(E_RECOVERABLE_ERROR, zf, "be of the type array", "", "no value", "");
 		} else if (ret_info->type_hint == IS_CALLABLE) {
-			zend_verify_return_error(E_RECOVERABLE_ERROR, zf, "be callable", "", "none", "");
+			zend_verify_return_error(E_RECOVERABLE_ERROR, zf, "be callable", "", "no value", "");
 #if ZEND_DEBUG
 		} else {
 			zend_error(E_ERROR, "Unknown typehint");


### PR DESCRIPTION
Currently:

1. `function foo(): array {}` produces the "must be an instance of int, **none** returned" error
2. `function foo(): array { return; }` produces the "must be an instance of int, **null** returned" error
3. `function foo(): array { return null; }` produces the "must be an instance of int, **null** returned" error

I think the 2nd case is wrong. `return;` doesn't return an explicit value, neither does omitting a return statement altogether, so it should say "none" and not "null" for that case.

This patch fixes the 2nd case to produce "none", and adds tests.