### PR TITLE
zend_call_function should consider exception a failure.

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -916,6 +916,7 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 
 	if (EG(exception)) {
 		zend_throw_exception_internal(NULL);
+		return FAILURE;
 	}
 	return SUCCESS;
 }


### PR DESCRIPTION
If a function has thrown an exception, it has not been called successfully and shouldn't return SUCCESS. This was found to be an issue in https://bugs.php.net/bug.php?id=68760

The scenario is:

i) Setup a callback function to be used by an external library, in this case SQLite.
ii) Call a userland function through that callback.
iii) The userland function throws an exception.

When the callback function throws an exception, the sorting should stop immediately rather than on the next loop. Currently it is not possible for the calling code to detect that the function has failed due to it throwing an exception, as zend_call_function returns SUCCESS on the function call that threw the exception, instead it is subsequent calls to the callback function that return FAILURE.

This change allows immediate detection that the callback has failed, within the loop that has failed, rather than the next one.

This change should only be done for 7.

fyi The place where the callback is being called is here:
https://github.com/php/php-src/blob/master/ext/sqlite3/sqlite3.c#L746-L748

