### PR TITLE
Fix freeing null segfault. Added test for behaviour.

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -906,16 +906,21 @@ static int php_sqlite3_callback_compare(void *coll, int a_len, const void *a, in
 	efree(zargs[1]);
 	efree(zargs);
 
-	//retval ought to contain a ZVAL_LONG by now
-	// (the result of a comparison, i.e. most likely -1, 0, or 1)
-	//I suppose we could accept any scalar return type, though.
-	if (Z_TYPE_P(retval) != IS_LONG){
+	if (!retval) {
+		//Exception was thrown by callback, default to 0 for compare
+		ret = 0;
+	} else if (Z_TYPE_P(retval) != IS_LONG) {
+		//retval ought to contain a ZVAL_LONG by now
+    	// (the result of a comparison, i.e. most likely -1, 0, or 1)
+    	//I suppose we could accept any scalar return type, though.
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "An error occurred while invoking the compare callback (invalid return type).  Collation behaviour is undefined.");
-	}else{
+	} else {
 		ret = Z_LVAL_P(retval);
 	}
 
-	zval_ptr_dtor(&retval);
+	if (retval) {
+		zval_ptr_dtor(&retval);
+	}
 
 	return ret;
 }

--- a/ext/sqlite3/tests/bug68760.phpt
+++ b/ext/sqlite3/tests/bug68760.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #68760 (Callback throws exception behaviour. Segfault in 5.6)
+--FILE--
+<?php
+function oopsFunction($a, $b) {
+	echo "callback";
+	throw new \Exception("oops");
+}
+
+$db = new SQLite3(":memory:");
+$db->exec("CREATE TABLE test (col1 string)");
+$db->exec("INSERT INTO test VALUES ('a1')");
+$db->exec("INSERT INTO test VALUES ('a10')");
+$db->exec("INSERT INTO test VALUES ('a2')");
+
+try {
+    $db->createCollation('NATURAL_CMP', 'oopsFunction');
+    $naturalSort = $db->query("SELECT col1 FROM test ORDER BY col1 COLLATE NATURAL_CMP");
+    while ($row = $naturalSort->fetchArray()) {
+        echo $row['col1'], "\n";
+    }
+    $db->close();
+}
+catch(\Exception $e) {
+    echo "Exception: ".$e->getMessage();
+}
+?>
+--EXPECTF--
+callback
+Warning: SQLite3::query(): An error occurred while invoking the compare callback in %a/bug68760.php on line %i
+Exception: oops
+


### PR DESCRIPTION
An exception in an callback function for a custom collator function caused a segfault in PHP5.x. https://bugs.php.net/bug.php?id=68760

There is a different PR incoming for the behaviour in 7.