### PR TITLE
Sqlite3 exception7

### DIFF
--- a/ext/sqlite3/tests/bug68760.phpt
+++ b/ext/sqlite3/tests/bug68760.phpt
@@ -1,9 +1,9 @@
 --TEST--
-Bug #68760 (Callback throws exception behaviour. Segfault in 5.6)
+Bug #68760 (Callback throws exception behaviour.)
 --FILE--
 <?php
 function oopsFunction($a, $b) {
-	echo "callback";
+	echo "callback".PHP_EOL;
 	throw new \Exception("oops");
 }
 
@@ -27,6 +27,5 @@ catch(\Exception $e) {
 ?>
 --EXPECTF--
 callback
-Warning: SQLite3::query(): An error occurred while invoking the compare callback in %a/bug68760.php on line %i
 Exception: oops
 


### PR DESCRIPTION
An exception in an callback function for a custom collator function should stop calling the callback function immediately. The change also suppresses the error message that duplicates the exception message. 

This is the 7 version of https://github.com/php/php-src/pull/1090 which addresses https://bugs.php.net/bug.php?id=68760