### PR TITLE
Fix for #68846

### DIFF
--- a/ext/mbstring/libmbfl/filters/mbfilter_gb18030.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_gb18030.c
@@ -239,9 +239,9 @@ mbfl_filt_conv_gb18030_wchar(int c, mbfl_convert_filter *filter)
 		if (((c1 >= 0x81 && c1 <= 0x84) || (c1 >= 0x90 && c1 <= 0xe3)) &&
 			c2 >= 0x30 && c2 <= 0x39 && c3 >= 0x81 && c3 <= 0xfe && c >= 0x30 && c <= 0x39) {
 			if (c1 >= 0x90 && c1 <= 0xe3) {
-				w = (((c1 - 0x90) * 10 + (c2 - 0x30) * 126 + (c3 - 0x81))) * 10 + (c - 0x30) + 0x10000;
+				w = ((((c1 - 0x90)*10 + (c2 - 0x30))*126 + (c3 - 0x81)))*10 + (c - 0x30) + 0x10000;
 			} else { /* Unicode BMP */
-				w = (((c1 - 0x81) * 10 + (c2 - 0x30)) * 126 + (c3 - 0x81)) * 10 + (c - 0x30);
+				w = (((c1 - 0x81)*10 + (c2 - 0x30))*126 + (c3 - 0x81))*10 + (c - 0x30);
 				if (w >= 0 && w <= 39419) {
 					k = mbfl_bisec_srch(w, mbfl_gb2uni_tbl, mbfl_gb_uni_max);
 					if (k<0) {

--- a/ext/mbstring/libmbfl/filters/mbfilter_gb18030.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_gb18030.c
@@ -239,9 +239,9 @@ mbfl_filt_conv_gb18030_wchar(int c, mbfl_convert_filter *filter)
 		if (((c1 >= 0x81 && c1 <= 0x84) || (c1 >= 0x90 && c1 <= 0xe3)) &&
 			c2 >= 0x30 && c2 <= 0x39 && c3 >= 0x81 && c3 <= 0xfe && c >= 0x30 && c <= 0x39) {
 			if (c1 >= 0x90 && c1 <= 0xe3) {
-				w = ((c1 - 0x90)*10 + (c2 - 0x30)*126 + (c3 - 0x81))*10 + (c - 0x30) + 0x10000;
+				w = (((c1 - 0x90) * 10 + (c2 - 0x30) * 126 + (c3 - 0x81))) * 10 + (c - 0x30) + 0x10000;
 			} else { /* Unicode BMP */
-				w = (((c1 - 0x81)*10 + (c2 - 0x30))*126 + (c3 - 0x81))*10 + (c - 0x30);
+				w = (((c1 - 0x81) * 10 + (c2 - 0x30)) * 126 + (c3 - 0x81)) * 10 + (c - 0x30);
 				if (w >= 0 && w <= 39419) {
 					k = mbfl_bisec_srch(w, mbfl_gb2uni_tbl, mbfl_gb_uni_max);
 					if (k<0) {

--- a/ext/mbstring/tests/bug68846.phpt
+++ b/ext/mbstring/tests/bug68846.phpt
@@ -5,7 +5,7 @@ Bug #68846	False detection of CJK Unified Ideographs Extension E
 --FILE--
 <?php
 var_dump(
-	"\x00\x02\x0b\xb7" === mb_convert_encoding("\x95\x34\xb2\x35", 'UTF-32', 'GB18030')
+    "\x00\x02\x0b\xb7" === mb_convert_encoding("\x95\x34\xb2\x35", 'UTF-32', 'GB18030')
 );
 ?>
 --EXPECT--

--- a/ext/mbstring/tests/bug68846.phpt
+++ b/ext/mbstring/tests/bug68846.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #68846	False detection of CJK Unified Ideographs Extension E
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
+--FILE--
+<?php
+var_dump(
+	"\x00\x02\x0b\xb7" === mb_convert_encoding("\x95\x34\xb2\x35", 'UTF-32', 'GB18030')
+);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
mbstring miscaliculate the codepoint when converting string from GB18030 to UTF-32. This pull request add missing missing parentheses.

```c
// http://icu-project.org/docs/papers/gb18030.html#h7
// uFirst = 0x10000;
// bFirst = [0x90, 0x30, 0x81, 0x30];

int linear(byte bytes[4]) {
    return ((bytes[0]*10+bytes[1])*126+bytes[2])*10+bytes[3];
}

 int mapToUnicode(byte bytes[4]) {
    int lin=linear(bytes);
    for each range {
        if(linear(bFirst)&lt;=lin&lt=linear(bLast)) {
            // range found
            return uFirst+(lin-linear(bFirst));
        }
    }
    // the byte sequence is not in any known range
    return error;
}
```