### PR TITLE
Fix Win32 SSPI initialization for digest authentication in cURL

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1239,7 +1239,7 @@ PHP_MINIT_FUNCTION(curl)
 	gcry_control(GCRYCTL_SET_THREAD_CBS, &php_curl_gnutls_tsl);
 #endif
 
-	if (curl_global_init(CURL_GLOBAL_SSL) != CURLE_OK) {
+	if (curl_global_init(CURL_GLOBAL_DEFAULT) != CURLE_OK) {
 		return FAILURE;
 	}
 


### PR DESCRIPTION
Since cURL 7.40.0, HTTP Digest Authentication support is now handled by Windows SSPI.

To initialize cURL, the php_curl module uses curl_global_init(CURL_GLOBAL_SSL); This call skips initializing any Win32 specific features (see curl_global_init in cURL lib/easy.c). 

As a result, the SSPI interface is not initialized and attempting to use HTTP Digest Authentication results in referencing a null pointer, s_pSecFn, in Curl_sasl_create_digest_http_message (lib/curl_sasl_sspi.c).

To fix, PHP_MINIT_FUNCTION should call curl_global_init with CURL_GLOBAL_DEFAULT. This will not affect non-Win32 platforms and is the cURL recommended default.

This was tested with the official Windows PHP binaries, 5.6.6 VC11 x86 Thread Safe, running on Windows 8.1 x64.

See bug #69088 https://bugs.php.net/bug.php?id=69088