### PR TITLE
ZPP changes evaluation tool

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -249,6 +249,20 @@ ZEND_API void zend_wrong_paramers_count_error(int num_args, int min_num_args, in
 }
 /* }}} */
 
+ZEND_API void zend_deprecated_type_error(int num, zend_expected_type expected_type, zval *arg) /* {{{ */
+{
+	const char *space;
+	const char *class_name = get_active_class_name(&space);
+	static const char * const expected_error[] = {
+		Z_EXPECTED_TYPES(Z_EXPECTED_TYPE_STR)
+		NULL
+	};
+
+	zend_error(E_DEPRECATED, "%s%s%s() expects parameter %d to be %s, %s given",
+		class_name, space, get_active_function_name(), num, expected_error[expected_type], zend_zval_type_name(arg));
+}
+/* }}} */
+
 ZEND_API void zend_wrong_paramer_type_error(int num, zend_expected_type expected_type, zval *arg) /* {{{ */
 {
 	const char *space;
@@ -284,7 +298,7 @@ ZEND_API void zend_wrong_callback_error(int severity, int num, char *error) /* {
 }
 /* }}} */
 
-ZEND_API int zend_parse_arg_class(zval *arg, zend_class_entry **pce, int num, int check_null) /* {{{ */
+ZEND_API int zend_parse_arg_class(zval *arg, int _i, zend_expected_type _expected_type, zend_class_entry **pce, int num, int check_null) /* {{{ */
 {
 	zend_class_entry *ce_base = *pce;
 
@@ -520,7 +534,8 @@ static const char *zend_parse_arg_impl(int arg_num, zval *arg, va_list *va, cons
 			{
 				zend_fcall_info *fci = va_arg(*va, zend_fcall_info *);
 				zend_fcall_info_cache *fcc = va_arg(*va, zend_fcall_info_cache *);
-				char *is_callable_error = NULL;
+				char *is_callable_error = NULL;zend_wrong_callback_error
+				
 
 				if (check_null && Z_TYPE_P(arg) == IS_NULL) {
 					fci->size = 0;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -692,7 +692,8 @@ END_EXTERN_C()
 	_(Z_EXPECTED_RESOURCE,	"resource") \
 	_(Z_EXPECTED_PATH,		"a valid path") \
 	_(Z_EXPECTED_OBJECT,	"object") \
-	_(Z_EXPECTED_DOUBLE,	"float")
+	_(Z_EXPECTED_DOUBLE,	"float") \
+	_(Z_EXPECTED_NULL,		"null")
 
 #define Z_EXPECTED_TYPE_ENUM(id, str) id,
 #define Z_EXPECTED_TYPE_STR(id, str)  str,
@@ -808,6 +809,17 @@ ZEND_API void zend_wrong_callback_error(int severity, int num, char *error);
 
 #define Z_PARAM_ARRAY_OR_OBJECT(dest, check_null, separate) \
 	Z_PARAM_ARRAY_OR_OBJECT_EX(dest, 0, 0)
+
+#define Z_PARAM_NULL_EX(separate) \
+		Z_PARAM_PROLOGUE(separate); \
+		if (UNEXPECTED(!zend_parse_arg_null(_arg))) { \
+			_expected_type = Z_EXPECTED_NULL; \
+			error_code = ZPP_ERROR_WRONG_ARG; \
+			break; \
+		}
+
+#define Z_PARAM_NULL() \
+	Z_PARAM_NULL_EX(0)
 
 /* old "b" */
 #define Z_PARAM_BOOL_EX(dest, is_null, check_null, separate) \
@@ -1048,6 +1060,11 @@ ZEND_API void zend_wrong_callback_error(int severity, int num, char *error);
 
 ZEND_API int parse_arg_object_to_str(zval *arg, zend_string **str, int type);
 ZEND_API int zend_parse_arg_class(zval *arg, zend_class_entry **pce, int num, int check_null);
+
+static zend_always_inline int zend_parse_arg_null(zval *arg)
+{
+	return (EXPECTED(Z_TYPE_P(arg) == IS_NULL) ? 1 : 0);
+}
 
 static zend_always_inline int zend_parse_arg_bool(zval *arg, zend_bool *dest, zend_bool *is_null, int check_null)
 {

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -28,6 +28,7 @@
 #include "zend_operators.h"
 #include "zend_variables.h"
 #include "zend_execute.h"
+#include "zend_tmp_sth.h"
 
 
 BEGIN_EXTERN_C()

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -30,6 +30,7 @@
 #include "zend_strtod.h"
 #include "zend_exceptions.h"
 #include "zend_closures.h"
+#include "zend_tmp_sth.h"
 
 #if ZEND_USE_TOLOWER_L
 #include <locale.h>

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -149,6 +149,14 @@ static zend_always_inline zend_long zend_dval_to_lval(double d)
 #endif
 /* }}} */
 
+static zend_always_inline zend_bool zend_dval_is_integer(double d)
+{
+	double fractpart, intpart;
+	
+	fractpart = modf(d, &intpart);
+	return (zend_bool)(fractpart == (double)0.0);
+}
+
 #define ZEND_IS_DIGIT(c) ((c) >= '0' && (c) <= '9')
 #define ZEND_IS_XDIGIT(c) (((c) >= 'A' && (c) <= 'F') || ((c) >= 'a' && (c) <= 'f'))
 

--- a/Zend/zend_tmp_sth.h
+++ b/Zend/zend_tmp_sth.h
@@ -1,0 +1,19 @@
+
+/* This is a temporary file, created to test BC consequences of modifying
+the ZPP conversion rules */
+
+/* These options allow to modify the behavior of the ZPP layer.
+In order to customize the ruleset you want to test, just change values below
+and recompile. No need to run configure again.
+*/
+
+#ifndef ZEND_TMP_STH_H
+#define ZEND_TMP_STH_H
+
+
+
+
+
+
+/*-------------------------------------------------------------------------*/
+#endif

--- a/Zend/zend_tmp_sth.h
+++ b/Zend/zend_tmp_sth.h
@@ -1,19 +1,53 @@
+/*===========================================================================
 
-/* This is a temporary file, created to test BC consequences of modifying
-the ZPP conversion rules */
+This file is temporary and was created to help for testing BC consequences of
+potential modifications of ZPP conversion rules
 
-/* These options allow to modify the behavior of the ZPP layer.
-In order to customize the ruleset you want to test, just change values below
-and recompile. No need to run configure again.
-*/
+The flags below allow to modify the behavior of the ZPP layer.
+In order to customize the ruleset you want to test, just set/unset values
+and recompile. No need to run configure again if already done.
 
+As set in PR, the flag values below implement the ruleset proposed in
+https://wiki.php.net/rfc/coercive_sth, except the following points, which
+are not implemented yet :
+
+	- Changes in the way numeric strings are converted to int/float
+
+============================================================================*/
+   
 #ifndef ZEND_TMP_STH_H
 #define ZEND_TMP_STH_H
 
+/*---- Every flag below can be set/unset in an independent manner, unless
+*----- explicitely mentioned */
 
+/* Restrict conversions from IS_NULL */
 
+#define STH_DISABLE_NULL_TO_BOOL	0
+#define STH_DISABLE_NULL_TO_INT		0
+#define STH_DISABLE_NULL_TO_FLOAT	0
+#define STH_DISABLE_NULL_TO_STRING	0
 
+/* Restrict conversions from IS_FALSE/IS_TRUE */
 
+#define STH_DISABLE_BOOL_TO_INT		0
+#define STH_DISABLE_BOOL_TO_FLOAT	0
+#define STH_DISABLE_BOOL_TO_STRING	0
+
+/* Restrict conversions to bool */
+
+#define STH_DISABLE_INT_TO_BOOL		0
+#define STH_DISABLE_FLOAT_TO_BOOL	0
+#define STH_DISABLE_STRING_TO_BOOL	0
+
+/* Other restrictions */
+
+#define STH_DISABLE_FLOAT_TO_INT	0
+
+/* Accepts null fractional part only.
+   Ignored when STH_DISABLE_FLOAT_TO_INT is set */
+
+#define STH_RESTRICT_FLOAT_TO_INT	0
 
 /*-------------------------------------------------------------------------*/
 #endif

--- a/sth_run.sh
+++ b/sth_run.sh
@@ -1,0 +1,11 @@
+
+dir=$1
+
+make clean
+
+cp $dir/zend_tmp_sth.h Zend
+
+make $MAKEFLAGS
+
+make test 2>&1 | tee $dir/test.log
+

--- a/sth_run.sh
+++ b/sth_run.sh
@@ -1,11 +1,15 @@
 
 dir=$1
 
-make clean
-
+rsync -av --delete /K/work/Dev/_forked/php-src/ .
 cp $dir/zend_tmp_sth.h Zend
 
-make $MAKEFLAGS
+./buildconf
+../conf --disable-phar
+
+make clean
+make
 
 make test 2>&1 | tee $dir/test.log
+
 


### PR DESCRIPTION
This PR allows to test several potential changes in the ZPP ruleset, which is used when parsing internal function input arguments and will be potentially used for scalar type hinting.

Potential changes can be activated one by one or in any combination. Configuration is done by setting/unsetting values in Zend/zend_tmp_sth.h before compilation.

Please run configure with the '--disable-phar' option when testing this, as building phar.phar breaks when 'null to string' conversion is disabled (this is caused by a bug in phar code, and I don't have time to fix it).

The set of available flags will be extended when needed to propose additional restrictions or changes in behavior.

This conditional stuff is temporary and exists only as an addtional help for testing potential BC breaks before a final ruleset is voted upon. It will in no way be kept in the future released code.