### PR TITLE
Fix Win32 SSPI initialization for digest authentication in cURL

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1232,7 +1232,7 @@ PHP_MINIT_FUNCTION(curl)
 	gcry_control(GCRYCTL_SET_THREAD_CBS, &php_curl_gnutls_tsl);
 #endif
 
-	if (curl_global_init(CURL_GLOBAL_SSL) != CURLE_OK) {
+	if (curl_global_init(CURL_GLOBAL_DEFAULT) != CURLE_OK) {
 		return FAILURE;
 	}
 


### PR DESCRIPTION
See bug #69088 https://bugs.php.net/bug.php?id=69088