### PR TITLE
Bug65872 pass hash key to array reduce cb

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4684,7 +4684,10 @@ PHP_FUNCTION(array_reduce)
 	zend_fcall_info_cache fci_cache = empty_fcall_info_cache;
 	zval *initial = NULL;
 	HashTable *htbl;
-	Bucket *operand;
+
+	zend_ulong arr_num_key;
+	zend_string *arr_str_key;
+	zval *arr_val;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "af|z", &input, &fci, &fci_cache, &initial) == FAILURE) {
 		return;
@@ -4710,13 +4713,13 @@ PHP_FUNCTION(array_reduce)
 	fci.param_count = 3;
 	fci.no_separation = 0;
 
-	ZEND_HASH_FOREACH_BUCKET(htbl, operand) {
+	ZEND_HASH_FOREACH_KEY_VAL(htbl, arr_num_key, arr_str_key, arr_val) {
 		ZVAL_COPY(&args[0], &result);
-		ZVAL_COPY(&args[1], &(operand->val));
-		if (operand->key == NULL) {
-			ZVAL_LONG(&args[2], operand->h);
+		ZVAL_COPY(&args[1], arr_val);
+		if (arr_str_key == NULL) {
+			ZVAL_LONG(&args[2], arr_num_key);
 		} else {
-			ZVAL_STRINGL(&args[2], operand->key->val, operand->key->len);
+			ZVAL_STRINGL(&args[2], arr_str_key->val, arr_str_key->len);
 		}
 
 		fci.params = args;

--- a/ext/standard/tests/array/array_reduce.phpt
+++ b/ext/standard/tests/array/array_reduce.phpt
@@ -35,6 +35,16 @@ function reduce_null($w, $v) { return $w . $v; }
 $initial = null;
 var_dump(array_reduce($array, 'reduce_null', $initial), $initial);
 
+echo "\n*** Testing array_reduce() to integer with integer array keys ***\n";
+function reduce_integer_keys($w, $v, $k) { return $w * ($k + 1); }
+$initial = 1;
+var_dump(array_reduce($array, 'reduce_integer_keys', $initial), $initial);
+
+echo "\n*** Testing array_reduce() to string with string array keys ***\n";
+$stringKeyedArray = ['foo' => 1, 'bar' => 2, 'bas' => 3];
+$initial = 'quux';
+var_dump(array_reduce($stringKeyedArray, function ($w, $v, $k) { return $w . $k; }, $initial), $initial);
+
 echo "\nDone";
 ?> 
 --EXPECTF--
@@ -75,5 +85,13 @@ array(4) {
 *** Testing array_reduce() to null ***
 string(19) "foofoobarquxquxquux"
 NULL
+
+*** Testing array_reduce() to integer with integer array keys ***
+int(720)
+int(1)
+
+*** Testing array_reduce() to string with string array keys ***
+string(13) "quuxfoobarbas"
+string(4) "quux"
 
 Done

--- a/ext/standard/tests/array/array_reduce_variation1.phpt
+++ b/ext/standard/tests/array/array_reduce_variation1.phpt
@@ -1,11 +1,11 @@
 --TEST--
-Test array_reduce() function : variation 
+Test array_reduce() function : variation
 --FILE--
 <?php
 /* Prototype  : mixed array_reduce(array input, mixed callback [, int initial])
- * Description: Iteratively reduce the array to a single value via the callback. 
+ * Description: Iteratively reduce the array to a single value via the callback.
  * Source code: ext/standard/array.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing array_reduce() : variation ***\n";
@@ -15,30 +15,40 @@ function oneArg($v) {
   return $v;
 }
 
-function threeArgs($v, $w, $x) {
-  return $v + $w + $x;
+function twoArgs($v, $w) {
+  return $v + $w;
+}
+
+function fourArgs($v, $w, $x, $y) {
+  return $v + $w + $x + $y;
 }
 
 $array = array(1);
 
-echo "\n--- Testing with a callback with too few parameters ---\n";
+echo "\n--- Testing with a callback with one parameter ---\n";
 var_dump(array_reduce($array, "oneArg", 2));
 
+echo "\n--- Testing with a callback with two parameters ---\n";
+var_dump(array_reduce($array, "twoArgs", 2));
+
 echo "\n--- Testing with a callback with too many parameters ---\n";
-var_dump(array_reduce($array, "threeArgs", 2));
+var_dump(array_reduce($array, "fourArgs", 2));
 
 ?>
 ===DONE===
 --EXPECTF--
 *** Testing array_reduce() : variation ***
 
---- Testing with a callback with too few parameters ---
+--- Testing with a callback with one parameter ---
 int(2)
+
+--- Testing with a callback with two parameters ---
+int(3)
 
 --- Testing with a callback with too many parameters ---
 
-Warning: Missing argument 3 for threeArgs() in %sarray_reduce_variation1.php on line %d
+Warning: Missing argument 4 for fourArgs() in %sarray_reduce_variation1.php on line %d
 
-Notice: Undefined variable: x in %sarray_reduce_variation1.php on line %d
+Notice: Undefined variable: y in %sarray_reduce_variation1.php on line %d
 int(3)
 ===DONE===


### PR DESCRIPTION
This merge request passes the array key as a third parameter to an array_reduce callback.
