### PR TITLE
emit error instead of warning when session persistence fails

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -568,7 +568,7 @@ static void php_session_save_current_state(int write) /* {{{ */
 			}
 
 			if ((ret == FAILURE) && !EG(exception)) {
-				php_error_docref(NULL, E_WARNING, "Failed to write session data (%s). Please "
+				php_error_docref(NULL, E_ERROR, "Failed to write session data (%s). Please "
 								 "verify that the current setting of session.save_path "
 								 "is correct (%s)",
 								 PS(mod)->s_name,


### PR DESCRIPTION
PHP creates empty files on NFS mounted directories but doesn't write session content into the files.

With E_ALL error reporting you get a warning "Warning: Unknown: Failed to write session data (files). Please verify that the current setting of session.save_path is correct (/XX..ZZ..YY/tmp/www/session/) in Unknown on line 0"

Even chmod the files (php itself created) to 777 doesnt make it work.
As the test-script in https://bugs.php.net/bug.php?id=69136 shows, php itself sees the directory as readable+writeable, but the write of php-src doesn't succeed nevertheless.

http sessions are such a basic part which makes me think that you need a hard error when they dont work. nearly no app will work when php behaves like the session did work but could not be persisted at the end of a request

its also hard to debug to find whats going on in the first place

refs parts of https://bugs.php.net/bug.php?id=69136