### PR TITLE
merge ZEND_SIGNED_MULTIPLY_LONG for i386 and x86_64

### DIFF
--- a/Zend/zend_multiply.h
+++ b/Zend/zend_multiply.h
@@ -22,19 +22,7 @@
 #ifndef ZEND_MULTIPLY_H
 #define ZEND_MULTIPLY_H
 
-#if defined(__i386__) && defined(__GNUC__)
-
-#define ZEND_SIGNED_MULTIPLY_LONG(a, b, lval, dval, usedval) do {	\
-	zend_long __tmpvar; 													\
-	__asm__ ("imul %3,%0\n"											\
-		"adc $0,%1" 												\
-			: "=r"(__tmpvar),"=r"(usedval) 							\
-			: "0"(a), "r"(b), "1"(0));								\
-	if (usedval) (dval) = (double) (a) * (double) (b);				\
-	else (lval) = __tmpvar;											\
-} while (0)
-
-#elif defined(__x86_64__) && defined(__GNUC__)
+#if (defined(__i386__) || defined(__x86_64__)) && defined(__GNUC__)
 
 #define ZEND_SIGNED_MULTIPLY_LONG(a, b, lval, dval, usedval) do {	\
 	zend_long __tmpvar; 													\


### PR DESCRIPTION
merge ZEND_SIGNED_MULTIPLY_LONG for i386 and x86_64 as the definitions are identical

refs b7eb3c1c5a858e98985adc2335df9b4a021ade51

i noticed this when tried to backport x32 support for 5.3. 

i guess it could be merged to 5.4, 5.5 and 5.6 as well (should apply cleanly)