### PR TITLE
Fixed memleak in alloc_globals_ctor

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -1950,6 +1950,9 @@ void zend_mm_shutdown(zend_mm_heap *heap, int full, int silent)
 
 #if ZEND_MM_CUSTOM
 	if (heap->use_custom_heap) {
+		if (full) {
+			free(heap);
+		}
 		return;
 	}
 #endif


### PR DESCRIPTION
This free operation is missed when new MM was introduced in master.