### PR TITLE
Bug #69151 - mb_ereg should reject ill-formed byte sequence

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -4513,6 +4513,58 @@ PHP_FUNCTION(mb_get_info)
 }
 /* }}} */
 
+MBSTRING_API int php_mb_check_encoding(const char *input, size_t length, const char *enc)
+{
+	const mbfl_encoding *encoding = MBSTRG(current_internal_encoding);
+	mbfl_buffer_converter *convd;
+	mbfl_string string, result, *ret = NULL;
+	long illegalchars = 0;
+
+	if (input == NULL) {
+		return MBSTRG(illegalchars) == 0;
+	}
+
+	if (enc != NULL) {
+		encoding = mbfl_name2encoding(enc);
+		if (!encoding || encoding == &mbfl_encoding_pass) {
+			php_error_docref(NULL, E_WARNING, "Invalid encoding \"%s\"", enc);
+			return 0;
+		}
+	}
+
+	convd = mbfl_buffer_converter_new2(encoding, encoding, 0);
+
+	if (convd == NULL) {
+		php_error_docref(NULL, E_WARNING, "Unable to create converter");
+		return 0;
+	}
+
+	mbfl_buffer_converter_illegal_mode(convd, MBFL_OUTPUTFILTER_ILLEGAL_MODE_NONE);
+	mbfl_buffer_converter_illegal_substchar(convd, 0);
+
+	/* initialize string */
+	mbfl_string_init_set(&string, mbfl_no_language_neutral, encoding->no_encoding);
+	mbfl_string_init(&result);
+
+	string.val = (unsigned char *) input;
+	string.len = length;
+
+	ret = mbfl_buffer_converter_feed_result(convd, &string, &result);
+	illegalchars = mbfl_buffer_illegalchars(convd);
+	mbfl_buffer_converter_delete(convd);
+
+	if (ret != NULL) {
+		if (illegalchars == 0 && string.len == result.len && memcmp(string.val, result.val, string.len) == 0) {
+			mbfl_string_clear(&result);
+			return 1;
+		}
+
+		mbfl_string_clear(&result);
+	}
+
+	return 0;
+}
+
 /* {{{ proto bool mb_check_encoding([string var[, string encoding]])
    Check if the string is valid for the specified encoding */
 PHP_FUNCTION(mb_check_encoding)
@@ -4521,51 +4573,15 @@ PHP_FUNCTION(mb_check_encoding)
 	size_t var_len;
 	char *enc = NULL;
 	size_t enc_len;
-	mbfl_buffer_converter *convd;
-	const mbfl_encoding *encoding = MBSTRG(current_internal_encoding);
-	mbfl_string string, result, *ret = NULL;
-	long illegalchars = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|ss", &var, &var_len, &enc, &enc_len) == FAILURE) {
 		return;
-	}
-
-	if (var == NULL) {
-		RETURN_BOOL(MBSTRG(illegalchars) == 0);
-	}
-
-	if (enc != NULL) {
-		encoding = mbfl_name2encoding(enc);
-		if (!encoding || encoding == &mbfl_encoding_pass) {
-			php_error_docref(NULL, E_WARNING, "Invalid encoding \"%s\"", enc);
-			RETURN_FALSE;
-		}
-	}
-
-	convd = mbfl_buffer_converter_new2(encoding, encoding, 0);
-	if (convd == NULL) {
-		php_error_docref(NULL, E_WARNING, "Unable to create converter");
-		RETURN_FALSE;
-	}
-	mbfl_buffer_converter_illegal_mode(convd, MBFL_OUTPUTFILTER_ILLEGAL_MODE_NONE);
-	mbfl_buffer_converter_illegal_substchar(convd, 0);
-
-	/* initialize string */
-	mbfl_string_init_set(&string, mbfl_no_language_neutral, encoding->no_encoding);
-	mbfl_string_init(&result);
-
-	string.val = (unsigned char *)var;
-	string.len = var_len;
-	ret = mbfl_buffer_converter_feed_result(convd, &string, &result);
-	illegalchars = mbfl_buffer_illegalchars(convd);
-	mbfl_buffer_converter_delete(convd);
+    }
 
 	RETVAL_FALSE;
-	if (ret != NULL) {
-		if (illegalchars == 0 && string.len == result.len && memcmp(string.val, result.val, string.len) == 0) {
-			RETVAL_TRUE;
-		}
-		mbfl_string_clear(&result);
+
+	if (php_mb_check_encoding(var, var_len, enc)) {
+		RETVAL_TRUE;
 	}
 }
 /* }}} */

--- a/ext/mbstring/mbstring.h
+++ b/ext/mbstring/mbstring.h
@@ -149,6 +149,7 @@ MBSTRING_API int php_mb_encoding_detector_ex(const char *arg_string, int arg_len
 MBSTRING_API int php_mb_encoding_converter_ex(char **str, int *len, const char *encoding_to,
 											  const char *encoding_from);
 MBSTRING_API int php_mb_stripos(int mode, const char *old_haystack, unsigned int old_haystack_len, const char *old_needle, unsigned int old_needle_len, long offset, const char *from_encoding);
+MBSTRING_API int php_mb_check_encoding(const char *input, size_t length, const char *enc);
 
 /* internal use only */
 int _php_mb_ini_mbstring_internal_encoding_set(const char *new_value, uint new_value_length);

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -702,6 +702,16 @@ static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 		RETURN_FALSE;
 	}
 
+	if (!php_mb_check_encoding(
+	string,
+	string_len,
+	_php_mb_regex_mbctype2name(MBREX(current_mbctype))
+	)) {
+		zval_dtor(array);
+		array_init(array);
+		RETURN_FALSE;
+	}
+
 	options = MBREX(regex_default_options);
 	if (icase) {
 		options |= ONIG_OPTION_IGNORECASE;
@@ -844,6 +854,14 @@ static void _php_mb_regex_ereg_replace_exec(INTERNAL_FUNCTION_PARAMETERS, OnigOp
 						&option_str, &option_str_len) == FAILURE) {
 				RETURN_FALSE;
 			}
+		}
+
+		if (!php_mb_check_encoding(
+		string,
+		string_len,
+		_php_mb_regex_mbctype2name(MBREX(current_mbctype))
+		)) {
+			RETURN_NULL();
 		}
 
 		if (option_str != NULL) {
@@ -1347,14 +1365,22 @@ PHP_FUNCTION(mb_ereg_search_init)
 
 	ZVAL_DUP(&MBREX(search_str), arg_str);
 
-	MBREX(search_pos) = 0;
+	if (php_mb_check_encoding(
+	Z_STRVAL_P(arg_str),
+	Z_STRLEN_P(arg_str),
+	_php_mb_regex_mbctype2name(MBREX(current_mbctype))
+	)) {
+		MBREX(search_pos) = 0;
+		RETVAL_TRUE;
+	} else {
+		MBREX(search_pos) = Z_STRLEN_P(arg_str);
+		RETVAL_FALSE;
+	}
 
 	if (MBREX(search_regs) != NULL) {
 		onig_region_free(MBREX(search_regs), 1);
 		MBREX(search_regs) = NULL;
 	}
-
-	RETURN_TRUE;
 }
 /* }}} */
 

--- a/ext/mbstring/tests/bug69151.phpt
+++ b/ext/mbstring/tests/bug69151.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #69151 (mb_ereg should reject ill-formed byte sequence)
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
+--FILE--
+<?php
+$str = "\x80";
+var_dump(
+    false === mb_eregi('.', $str, $matches),
+    [] === $matches,
+    NULL === mb_ereg_replace('.', "\\0", $str),
+    false === mb_ereg_search_init("\x80", '.'),
+    false === mb_ereg_search()
+);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
This pull request add validation for encoding. Some of  ill-formed byte sequence can be converterted to dangerous ascii characters by legacy UTF-8 decoder without checking trailing bytes. `htmlspecharchars` and PCRE functions reject them. [Unicode Security Guide](http://websec.github.io/unicode-security-guide/character-transformations/#handling) shows example. "C2 22 3C" can be treated as "C2 22" + "3C". "3C" means "<".

```php

// http://websec.github.io/unicode-security-guide/character-transformations/#handling
//
// Code point	First byte	Second byte	Third byte	Fourth byte
// U+0000..U+007F	00..7F			
// U+0080..U+07FF	C2..DF	80..BF		
// U+0800..U+0FFF	E0	A0..BF	80..BF

$str = "\xC2\x22\x3C";
var_dump(
    "" === htmlspecialchars($str),
    false === preg_match('/./u', $str)
);
```