### PR TITLE
Add a test for yielding with an operator

### DIFF
--- a/Zend/tests/generators/yield_with_operator.phpt
+++ b/Zend/tests/generators/yield_with_operator.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Yield can be used with an operator on a sent value
+--FILE--
+<?php
+
+function a () {
+    echo yield * 3;
+    echo yield + 3;
+    echo yield - 3;
+    echo yield / 3;
+}
+
+$a = a();
+for ($i = 0; $i < 4; $i++) {
+    $a->send(42);
+    echo "\n";
+}
+
+?>
+--EXPECT--
+126
+45
+39
+14


### PR DESCRIPTION
As pointed out on [internals](http://news.php.net/php.internals/84136) there is a valid yield syntax that is not currently tested for.

I've attempted to add a test for this, let me know if there's anything that needs changing or doesn't make sense.