### PR TITLE
Regression tests for SplFileInfo class setters

### DIFF
--- a/ext/spl/tests/SplFileInfo_setFileClass_basic.phpt
+++ b/ext/spl/tests/SplFileInfo_setFileClass_basic.phpt
@@ -1,0 +1,19 @@
+--TEST--
+SplFileInfo::setFileClass() expects SplFileObject or child class
+--FILE--
+<?php
+
+class MyFileObject extends SplFileObject {}
+
+$info = new SplFileInfo(__FILE__);
+
+$info->setFileClass('MyFileObject');
+echo get_class($info->openFile()), "\n";
+
+$info->setFileClass('SplFileObject');
+echo get_class($info->openFile()), "\n";
+
+?>
+--EXPECT--
+MyFileObject
+SplFileObject

--- a/ext/spl/tests/SplFileInfo_setFileClass_error.phpt
+++ b/ext/spl/tests/SplFileInfo_setFileClass_error.phpt
@@ -1,0 +1,16 @@
+--TEST--
+SplFileInfo::setFileClass() throws exception for invalid class
+--FILE--
+<?php
+
+$info = new SplFileInfo(__FILE__);
+
+try {
+    $info->setFileClass('stdClass');
+} catch (UnexpectedValueException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+SplFileInfo::setFileClass() expects parameter 1 to be a class name derived from SplFileObject, 'stdClass' given

--- a/ext/spl/tests/SplFileInfo_setInfoClass_basic.phpt
+++ b/ext/spl/tests/SplFileInfo_setInfoClass_basic.phpt
@@ -1,0 +1,23 @@
+--TEST--
+SplFileInfo::setInfoClass() expects SplFileInfo or child class
+--FILE--
+<?php
+
+class MyInfoObject extends SplFileInfo {}
+
+$info = new SplFileInfo(__FILE__);
+
+$info->setInfoClass('MyInfoObject');
+echo get_class($info->getFileInfo()), "\n";
+echo get_class($info->getPathInfo()), "\n";
+
+$info->setInfoClass('SplFileInfo');
+echo get_class($info->getFileInfo()), "\n";
+echo get_class($info->getPathInfo()), "\n";
+
+?>
+--EXPECT--
+MyInfoObject
+MyInfoObject
+SplFileInfo
+SplFileInfo

--- a/ext/spl/tests/SplFileInfo_setInfoClass_error.phpt
+++ b/ext/spl/tests/SplFileInfo_setInfoClass_error.phpt
@@ -1,0 +1,16 @@
+--TEST--
+SplFileInfo::setInfoClass() throws exception for invalid class
+--FILE--
+<?php
+
+$info = new SplFileInfo(__FILE__);
+
+try {
+    $info->setInfoClass('stdClass');
+} catch (UnexpectedValueException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECTF--
+SplFileInfo::setInfoClass() expects parameter 1 to be a class name derived from SplFileInfo, 'stdClass' given


### PR DESCRIPTION
Adds tests for SplFileInfo class setters accepting either the base and child classes, and throwing an exception for unexpected classes.

Related: http://svn.php.net/viewvc?view=revision&revision=336017 and https://github.com/facebook/hhvm/pull/4917