### PR TITLE
Implemented FR #45235 implement error_clear_last() function

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -685,6 +685,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_error_get_last, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_error_clear_last, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_call_user_func, 0, 0, 1)
 	ZEND_ARG_INFO(0, function_name)
 	ZEND_ARG_VARIADIC_INFO(0, parameters)
@@ -2942,6 +2945,7 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 
 	PHP_FE(error_log,														arginfo_error_log)
 	PHP_FE(error_get_last,													arginfo_error_get_last)
+	PHP_FE(error_clear_last,													arginfo_error_clear_last)
 	PHP_FE(call_user_func,													arginfo_call_user_func)
 	PHP_FE(call_user_func_array,											arginfo_call_user_func_array)
 	PHP_FE(forward_static_call,											arginfo_forward_static_call)
@@ -4697,6 +4701,33 @@ PHP_FUNCTION(error_get_last)
 		add_assoc_string_ex(return_value, "file", sizeof("file")-1, PG(last_error_file)?PG(last_error_file):"-");
 		add_assoc_long_ex(return_value, "line", sizeof("line")-1, PG(last_error_lineno));
 	}
+}
+/* }}} */
+
+/* {{{ proto bool error_clear_last()
+   Clear the last occurred error. Returns false if there hasn't been an error yet. */
+PHP_FUNCTION(error_clear_last)
+{
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
+		return;
+	}
+
+	if (PG(last_error_message)) {
+		PG(last_error_type) = 0;
+		PG(last_error_lineno) = 0;
+
+		free(PG(last_error_message));
+		PG(last_error_message) = NULL;
+
+		if (PG(last_error_file)) {
+			free(PG(last_error_file));
+			PG(last_error_file) = NULL;
+		}
+
+		RETURN_TRUE;
+	}
+
+	RETURN_FALSE;
 }
 /* }}} */
 

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4690,7 +4690,7 @@ PHPAPI int _php_error_log_ex(int opt_err, char *message, size_t message_len, cha
    Get the last occurred error as associative array. Returns NULL if there hasn't been an error yet. */
 PHP_FUNCTION(error_get_last)
 {
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
+	if (zend_parse_parameters_none() == FAILURE) {
 		return;
 	}
 
@@ -4708,7 +4708,7 @@ PHP_FUNCTION(error_get_last)
    Clear the last occurred error. Returns false if there hasn't been an error yet. */
 PHP_FUNCTION(error_clear_last)
 {
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
+	if (zend_parse_parameters_none() == FAILURE) {
 		return;
 	}
 

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4704,8 +4704,8 @@ PHP_FUNCTION(error_get_last)
 }
 /* }}} */
 
-/* {{{ proto bool error_clear_last()
-   Clear the last occurred error. Returns false if there hasn't been an error yet. */
+/* {{{ proto void error_clear_last(void)
+   Clear the last occurred error. */
 PHP_FUNCTION(error_clear_last)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -4723,11 +4723,7 @@ PHP_FUNCTION(error_clear_last)
 			free(PG(last_error_file));
 			PG(last_error_file) = NULL;
 		}
-
-		RETURN_TRUE;
 	}
-
-	RETURN_FALSE;
 }
 /* }}} */
 

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -81,6 +81,7 @@ PHP_FUNCTION(get_magic_quotes_gpc);
 
 PHP_FUNCTION(error_log);
 PHP_FUNCTION(error_get_last);
+PHP_FUNCTION(error_clear_last);
 
 PHP_FUNCTION(call_user_func);
 PHP_FUNCTION(call_user_func_array);

--- a/ext/standard/tests/general_functions/error_clear_last.phpt
+++ b/ext/standard/tests/general_functions/error_clear_last.phpt
@@ -1,0 +1,33 @@
+--TEST--
+error_clear_last() tests
+--FILE--
+<?php
+
+var_dump(error_get_last());
+
+var_dump(error_clear_last());
+
+@$a = $b;
+
+var_dump(error_get_last());
+var_dump(error_clear_last());
+var_dump(error_get_last());
+
+echo "Done\n";
+?>
+--EXPECTF--	
+NULL
+bool(false)
+array(4) {
+  ["type"]=>
+  int(8)
+  ["message"]=>
+  string(21) "Undefined variable: b"
+  ["file"]=>
+  string(%d) "%s"
+  ["line"]=>
+  int(%d)
+}
+bool(true)
+NULL
+Done

--- a/ext/standard/tests/general_functions/error_clear_last.phpt
+++ b/ext/standard/tests/general_functions/error_clear_last.phpt
@@ -4,20 +4,20 @@ error_clear_last() tests
 <?php
 
 var_dump(error_get_last());
-
-var_dump(error_clear_last());
+error_clear_last();
+var_dump(error_get_last());
 
 @$a = $b;
 
 var_dump(error_get_last());
-var_dump(error_clear_last());
+error_clear_last();
 var_dump(error_get_last());
 
 echo "Done\n";
 ?>
 --EXPECTF--	
 NULL
-bool(false)
+NULL
 array(4) {
   ["type"]=>
   int(8)
@@ -28,6 +28,5 @@ array(4) {
   ["line"]=>
   int(%d)
 }
-bool(true)
 NULL
 Done


### PR DESCRIPTION
In PHP a simple assign expression would raise error, if user use error_get_last() to check they can't guarantee the call site raise the error.  

This patch implement a function to clear the error state. There are similar functions like `socket_clear_error()`.

http://php.net/error_get_last
The top voted user contributed note are a tricky way to clear last error.

also there are a lot of apps use the similar hacks.

1. https://github.com/mathnerd3141/doeqs_new/blob/ba23c478a0c819dc6b2f8f96f9df35d16505eed2/errors.php#L20
2. https://github.com/benfinke/cargo_plane/blob/4911bc6a91d8345aa62c81fb52c8bed9d216c44e/Splunk/Util.php#L89

Request: https://bugs.php.net/bug.php?id=45235