### PR TITLE
Fixed bug #69174 (leaks when unused inner class use traits precedence)

### DIFF
--- a/Zend/tests/bug69174.phpt
+++ b/Zend/tests/bug69174.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #69174 (leaks when unused inner class use traits precedence)
+--FILE--
+<?php
+function test() {
+	class C1 {
+		use T1, T2 {
+			T1::foo insteadof T2;
+		}
+	}
+}
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4422,7 +4422,7 @@ ZEND_API void zend_do_bind_traits(zend_class_entry *ce TSRMLS_DC) /* {{{ */
 		ce->ce_flags -= ZEND_ACC_IMPLICIT_ABSTRACT_CLASS;
 	}
 
-	ce->ce_flags |=  ZEND_ACC_TRAITS_BINDED;
+	ce->ce_flags |=  ZEND_ACC_TRAITS_BOUND;
 }
 /* }}} */
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4421,6 +4421,8 @@ ZEND_API void zend_do_bind_traits(zend_class_entry *ce TSRMLS_DC) /* {{{ */
 	if (ce->ce_flags & ZEND_ACC_IMPLICIT_ABSTRACT_CLASS) {
 		ce->ce_flags -= ZEND_ACC_IMPLICIT_ABSTRACT_CLASS;
 	}
+
+	ce->ce_flags |=  ZEND_ACC_TRAITS_BINDED;
 }
 /* }}} */
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -213,6 +213,9 @@ typedef struct _zend_try_catch_element {
 #define ZEND_ACC_RETURN_REFERENCE		0x4000000
 #define ZEND_ACC_DONE_PASS_TWO			0x8000000
 
+/* class traits binded */
+#define ZEND_ACC_TRAITS_BINDED		    0x10000000
+
 char *zend_visibility_string(zend_uint fn_flags);
 
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -197,7 +197,6 @@ typedef struct _zend_try_catch_element {
 /* user class has methods with static variables */
 #define ZEND_HAS_STATIC_IN_METHODS    0x800000
 
-
 #define ZEND_ACC_CLOSURE              0x100000
 #define ZEND_ACC_GENERATOR            0x800000
 
@@ -213,7 +212,7 @@ typedef struct _zend_try_catch_element {
 #define ZEND_ACC_RETURN_REFERENCE		0x4000000
 #define ZEND_ACC_DONE_PASS_TWO			0x8000000
 
-/* class traits binded */
+/* class traits bound */
 #define ZEND_ACC_TRAITS_BOUND		    0x10000000
 
 char *zend_visibility_string(zend_uint fn_flags);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -214,7 +214,7 @@ typedef struct _zend_try_catch_element {
 #define ZEND_ACC_DONE_PASS_TWO			0x8000000
 
 /* class traits binded */
-#define ZEND_ACC_TRAITS_BINDED		    0x10000000
+#define ZEND_ACC_TRAITS_BOUND		    0x10000000
 
 char *zend_visibility_string(zend_uint fn_flags);
 

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -249,7 +249,7 @@ void _destroy_zend_class_traits_info(zend_class_entry *ce)
 
 	if (ce->trait_precedences) {
 		size_t i = 0;
-		zend_bool free_class_name = !(ce->ce_flags & ZEND_ACC_TRAITS_BINDED);
+		zend_bool free_class_name = !(ce->ce_flags & ZEND_ACC_TRAITS_BOUND);
 		
 		while (ce->trait_precedences[i]) {
 			efree((char*)ce->trait_precedences[i]->trait_method->method_name);

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -249,6 +249,7 @@ void _destroy_zend_class_traits_info(zend_class_entry *ce)
 
 	if (ce->trait_precedences) {
 		size_t i = 0;
+		zend_bool free_class_name = !(ce->ce_flags & ZEND_ACC_TRAITS_BINDED);
 		
 		while (ce->trait_precedences[i]) {
 			efree((char*)ce->trait_precedences[i]->trait_method->method_name);
@@ -256,6 +257,15 @@ void _destroy_zend_class_traits_info(zend_class_entry *ce)
 			efree(ce->trait_precedences[i]->trait_method);
 
 			if (ce->trait_precedences[i]->exclude_from_classes) {
+				if (free_class_name) {
+					int j = 0;
+					zend_trait_precedence *cur_precedence = ce->trait_precedences[j];
+					while (cur_precedence->exclude_from_classes[j]) {
+						efree(cur_precedence->exclude_from_classes[j]);
+						++j;
+					}
+				}
+
 				efree(ce->trait_precedences[i]->exclude_from_classes);
 			}
 


### PR DESCRIPTION
This was uncovered by master's new tests: Zend/tests/assert/expect_015.php

And fix the valgrind warning: https://gist.github.com/mbeccati/d4109974c5a82cf495a8