### PR TITLE
Fixed wrong parameter type of php_stream_mmap_range()

### DIFF
--- a/main/streams/mmap.c
+++ b/main/streams/mmap.c
@@ -22,7 +22,7 @@
 #include "php.h"
 #include "php_streams_int.h"
 
-PHPAPI char *_php_stream_mmap_range(php_stream *stream, size_t offset, size_t length, php_stream_mmap_operation_t mode, size_t *mapped_len)
+PHPAPI char *_php_stream_mmap_range(php_stream *stream, size_t offset, size_t length, php_stream_mmap_access_t mode, size_t *mapped_len)
 {
 	php_stream_mmap_range range;
 

--- a/main/streams/php_stream_mmap.h
+++ b/main/streams/php_stream_mmap.h
@@ -67,7 +67,7 @@ typedef struct {
 #define php_stream_mmap_possible(stream)			(!php_stream_is_filtered((stream)) && php_stream_mmap_supported((stream)))
 
 BEGIN_EXTERN_C()
-PHPAPI char *_php_stream_mmap_range(php_stream *stream, size_t offset, size_t length, php_stream_mmap_operation_t mode, size_t *mapped_len);
+PHPAPI char *_php_stream_mmap_range(php_stream *stream, size_t offset, size_t length, php_stream_mmap_access_t mode, size_t *mapped_len);
 #define php_stream_mmap_range(stream, offset, length, mode, mapped_len)	_php_stream_mmap_range((stream), (offset), (length), (mode), (mapped_len))
 
 /* un-maps the last mapped range */


### PR DESCRIPTION
There are several warings about this.
The mode type should be php_stream_mmap_access_t but not php_stream_mmap_operate_t