### PR TITLE
Feature - DateTime::createFromImmutable() method

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -183,6 +183,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_date_format, 0, 0, 2)
 	ZEND_ARG_INFO(0, format)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_date_method_create_from_immutable, 0, 0, 1)
+	ZEND_ARG_INFO(0, DateTimeImmutable)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_date_method_format, 0, 0, 1)
 	ZEND_ARG_INFO(0, format)
 ZEND_END_ARG_INFO()
@@ -463,9 +467,10 @@ static const zend_function_entry date_funcs_interface[] = {
 };
 
 const zend_function_entry date_funcs_date[] = {
-	PHP_ME(DateTime,			__construct,		arginfo_date_create, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
-	PHP_ME(DateTime,			__wakeup,			NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(DateTime,			__set_state,		NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateTime,			__construct,			arginfo_date_create, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
+	PHP_ME(DateTime,			__wakeup,				NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(DateTime,			__set_state,			NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateTime,			createFromImmutable,	arginfo_date_method_create_from_immutable, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(createFromFormat, date_create_from_format,	arginfo_date_create_from_format, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(getLastErrors, date_get_last_errors,	arginfo_date_get_last_errors, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(format,		date_format,		arginfo_date_method_format, 0)
@@ -2828,6 +2833,34 @@ PHP_METHOD(DateTime, __wakeup)
 
 	if (!php_date_initialize_from_hash(&dateobj, myht)) {
 		php_error(E_ERROR, "Invalid serialization data for DateTime object");
+	}
+}
+/* }}} */
+
+/* {{{ proto DateTime::createFromImmutable(DateTimeImmutable object)
+   Creates new DateTime object from an existing DateTimeImmutable object.
+*/
+PHP_METHOD(DateTime, createFromImmutable)
+{
+	zval *datetimeimmutable_object = NULL;
+	php_date_obj *new_obj = NULL;
+	php_date_obj *old_obj = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O!", &datetimeimmutable_object, date_ce_immutable) == FAILURE) {
+		return;
+	}
+
+	php_date_instantiate(date_ce_date, return_value);
+	old_obj = Z_PHPDATE_P(datetimeimmutable_object);
+	new_obj = Z_PHPDATE_P(return_value);
+
+	new_obj->time = timelib_time_ctor();
+	*new_obj->time = *old_obj->time;
+	if (old_obj->time->tz_abbr) {
+		new_obj->time->tz_abbr = strdup(old_obj->time->tz_abbr);
+	}
+	if (old_obj->time->tz_info) {
+		new_obj->time->tz_info = old_obj->time->tz_info;
 	}
 }
 /* }}} */

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -467,9 +467,9 @@ static const zend_function_entry date_funcs_interface[] = {
 };
 
 const zend_function_entry date_funcs_date[] = {
-	PHP_ME(DateTime,			__construct,			arginfo_date_create, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
-	PHP_ME(DateTime,			__wakeup,				NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(DateTime,			__set_state,			NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateTime,			__construct,		arginfo_date_create, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
+	PHP_ME(DateTime,			__wakeup,			NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(DateTime,			__set_state,		NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(DateTime,			createFromImmutable,	arginfo_date_method_create_from_immutable, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(createFromFormat, date_create_from_format,	arginfo_date_create_from_format, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(getLastErrors, date_get_last_errors,	arginfo_date_get_last_errors, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -50,6 +50,7 @@ PHP_FUNCTION(getdate);
 PHP_METHOD(DateTime, __construct);
 PHP_METHOD(DateTime, __wakeup);
 PHP_METHOD(DateTime, __set_state);
+PHP_METHOD(DateTime, createFromImmutable);
 PHP_FUNCTION(date_create);
 PHP_FUNCTION(date_create_immutable);
 PHP_FUNCTION(date_create_from_format);

--- a/ext/date/tests/DateTime_createFromImmutable.phpt
+++ b/ext/date/tests/DateTime_createFromImmutable.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Tests for DateTime::createFromImmutable.
+--INI--
+date.timezone=America/New_York
+--FILE--
+<?php
+$current = "2015-03-05 07:00:16";
+
+$i = DateTime::createFromImmutable(date_create_immutable($current));
+var_dump($i);
+
+$i = DateTime::createFromImmutable(date_create($current));
+var_dump($i);
+?>
+--EXPECTF--
+object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "2015-03-05 07:00:16.000000"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(13) "America/New_York"
+}
+
+Warning: DateTime::createFromImmutable() expects parameter 1 to be DateTimeImmutable, object given in %stests%eDateTime_createFromImmutable.php on line %d
+NULL

--- a/ext/date/tests/DateTime_createFromImmutable.phpt
+++ b/ext/date/tests/DateTime_createFromImmutable.phpt
@@ -19,7 +19,7 @@ object(DateTime)#%d (3) {
   ["timezone_type"]=>
   int(3)
   ["timezone"]=>
-  string(13) "America/New_York"
+  string(16) "America/New_York"
 }
 
 Warning: DateTime::createFromImmutable() expects parameter 1 to be DateTimeImmutable, object given in %stests%eDateTime_createFromImmutable.php on line %d

--- a/ext/date/tests/DateTime_verify.phpt
+++ b/ext/date/tests/DateTime_verify.phpt
@@ -27,7 +27,7 @@ object(ReflectionClass)#%d (1) {
   string(8) "DateTime"
 }
 ..and get names of all its methods
-array(18) {
+array(19) {
   [0]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
@@ -52,102 +52,109 @@ array(18) {
   [3]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(16) "createFromFormat"
+    string(19) "createFromImmutable"
     ["class"]=>
     string(8) "DateTime"
   }
   [4]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(13) "getLastErrors"
+    string(16) "createFromFormat"
     ["class"]=>
     string(8) "DateTime"
   }
   [5]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(6) "format"
+    string(13) "getLastErrors"
     ["class"]=>
     string(8) "DateTime"
   }
   [6]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(6) "modify"
+    string(6) "format"
     ["class"]=>
     string(8) "DateTime"
   }
   [7]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(3) "add"
+    string(6) "modify"
     ["class"]=>
     string(8) "DateTime"
   }
   [8]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(3) "sub"
+    string(3) "add"
     ["class"]=>
     string(8) "DateTime"
   }
   [9]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(11) "getTimezone"
+    string(3) "sub"
     ["class"]=>
     string(8) "DateTime"
   }
   [10]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(11) "setTimezone"
+    string(11) "getTimezone"
     ["class"]=>
     string(8) "DateTime"
   }
   [11]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(9) "getOffset"
+    string(11) "setTimezone"
     ["class"]=>
     string(8) "DateTime"
   }
   [12]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(7) "setTime"
+    string(9) "getOffset"
     ["class"]=>
     string(8) "DateTime"
   }
   [13]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(7) "setDate"
+    string(7) "setTime"
     ["class"]=>
     string(8) "DateTime"
   }
   [14]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(10) "setISODate"
+    string(7) "setDate"
     ["class"]=>
     string(8) "DateTime"
   }
   [15]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(12) "setTimestamp"
+    string(10) "setISODate"
     ["class"]=>
     string(8) "DateTime"
   }
   [16]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(12) "getTimestamp"
+    string(12) "setTimestamp"
     ["class"]=>
     string(8) "DateTime"
   }
   [17]=>
+  object(ReflectionMethod)#%d (2) {
+    ["name"]=>
+    string(12) "getTimestamp"
+    ["class"]=>
+    string(8) "DateTime"
+  }
+  [18]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
     string(4) "diff"


### PR DESCRIPTION
## Introduction

The [DateTimeImmutable class][php-datetimeimmutable], added in version 5.5, was a very convenient addition to the bundled date/time extension. Unfortunately, when migrating legacy codebases or when using an application that needed to mix immutable/mutable instances, the `DateTimeImmutable` class fell short in convenience by not providing a clear/clean way to build an immutable instance from a mutable instance.

This problem was solved in version 5.6 with the addition of a convenient factory method: [`DateTimeImmutable::createFromMutable()`][php-datetimeimmutable-createfrommutable]. Unfortunately, however, this addition created a one-sided convenience where a similar problem has been unresolved: Its still just as difficult to create mutable `DateTime` instances from an immutable `DateTimeImmutable` instance.

Arguably, creating `DateTime` instances from the immutable representations is something that an application would actually do more often, as any current (or legacy) applications and libraries are more likely to have function/method API's that require `DateTime` instances as parameters. While ideally the parameter types of new libraries would be `DateTimeInterface` (or at least `DateTimeImmutable`), that option is only available to libraries and applications that support PHP 5.5 as a minimum version... which is currently not the majority.

Without this factory method available to the `DateTime` class, its quite cumbersome to translate back and forth between the types, and honestly is quite the deterrent to even using the `DateTimeImmutable` class because of this. For example, if I was using a new library or application that dealt with `DateTimeImmutable` objects, but still had to interact with current/older libraries, I'd need to do work like this quite often:

```php
// Use some cool new library that returns a `DateTimeImmutable`
$date_time_immutable = $new_cool_library->getStartTime();

// Use an existing library that accepts a `DateTime` concrete type
$date_time = new DateTime(null, $date_time_immutable->getTimeZone());
$date_time->setTimestamp($date_time_immutable->getTimestamp());
$existing_event_library->setTriggerAt($date_time);
```

As you can imagine, doing the above for multiple calls around an application/library is quite cumbersome, and often leads to potentially buggy user-land implementations to keep the code "DRY" or even worse: simply deters a library/application author from using the new `DateTimeImmutable` object despite its wonderful advantages.


## Proposal

This PR proposes to introduce a **single** new method on the `DateTime` class with the following signature:

```php
public static DateTime DateTime::createFromImmutable (DateTimeImmutable $datetime)
```

The resulting object would contain the same date/time value as the provided immutable parameter, however modifications to the resultant `DateTime` object would only modify that instance and not the immutable instance that was given as an argument. In other words, this simply copies state. It would be quite similar to a type-casted clone (if that were possible).

This proposal was designed to mirror the currently accepted and in-use [`DateTimeImmutable::createFromMutable()`][php-datetimeimmutable-createfrommutable] method. It contains a similar signature and would compliment the aforementioned method well.

## Backward Incompatible Changes

None. This is a new static method on the concrete `DateTime` class (not on the Interface), so no extending classes would have to worry about breaking here.

## Proposed PHP Version(s)

PHP 7

## Affected PHP Functionality

### To SAPIs

None

### To Existing Extensions

None

### To Opcache

None

[php-datetimeimmutable]: http://php.net/manual/en/class.datetimeimmutable.php
[php-datetimeimmutable-createfrommutable]: http://php.net/manual/en/datetimeimmutable.createfrommutable.php
[php-datetime]: http://php.net/manual/en/class.datetime.php