### PR TITLE
Fixes bug #69181 (csv parsing drops newlines within fields with SplFileObject::DROP_NEW_LINE)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -213,6 +213,7 @@ PHP                                                                        NEWS
     statements option). (peter dot wolanin at acquia dot com)
 
 - SPL:
+  . Fixed bug #69181 (csv parsing drops newlines within fields with SplFileObject::DROP_NEW_LINE). (greg dot bowler at g105b dot com)
   . Fixed bug #66405 (RecursiveDirectoryIterator::CURRENT_AS_PATHNAME
     breaks the RecursiveIterator). (Paul Garvin)
   . Fixed bug #65213 (cannot cast SplFileInfo to boolean) (Tjerk)

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2082,7 +2082,8 @@ static int spl_filesystem_file_read(spl_filesystem_object *intern, int silent TS
 		intern->u.file.current_line = estrdup("");
 		intern->u.file.current_line_len = 0;
 	} else {
-		if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE)) {
+		if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE) && !SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_READ_CSV)) {
+			/* when SPL_FILE_OBJECT_READ_CSV is set, a newline does not necessarily mean the end of the row, so don't drop. CSV rows can contain multiple quoted newlines. */
 			line_len = strcspn(buf, "\r\n");
 			buf[line_len] = '\0';
 		}

--- a/ext/spl/tests/SplFileObject_fgetcsv_drop_new_line.phpt
+++ b/ext/spl/tests/SplFileObject_fgetcsv_drop_new_line.phpt
@@ -1,0 +1,69 @@
+--TEST--
+SplFileObject::fgetcsv default path
+--FILE--
+<?php
+$csv = <<<CSV
+"field1","field2","field3"
+"field
+4","field
+5","field6
+"
+
+CSV;
+file_put_contents('SplFileObject__fgetcsv_dropnewline.csv', $csv);
+
+// Read the CSV without DROP_NEW_LINES first
+$fo = new SplFileObject('SplFileObject__fgetcsv_dropnewline.csv');
+$fo->setFlags(SplFileObject::READ_CSV);
+var_dump($fo->fgetcsv());
+var_dump($fo->fgetcsv());
+
+// Read the CSV without DROP_NEW_LINES first
+$fo = new SplFileObject('SplFileObject__fgetcsv_dropnewline.csv');
+$fo->setFlags(SplFileObject::READ_CSV | SplFileObject::DROP_NEW_LINE);
+var_dump($fo->fgetcsv());
+var_dump($fo->fgetcsv());
+?>
+--CLEAN--
+<?php
+unlink('SplFileObject__fgetcsv_dropnewline.csv');
+?>
+--EXPECTF--
+array(3) {
+  [0]=>
+  string(6) "field1"
+  [1]=>
+  string(6) "field2"
+  [2]=>
+  string(6) "field3"
+}
+array(3) {
+  [0]=>
+  string(7) "field
+4"
+  [1]=>
+  string(7) "field
+5"
+  [2]=>
+  string(7) "field6
+"
+}
+array(3) {
+  [0]=>
+  string(6) "field1"
+  [1]=>
+  string(6) "field2"
+  [2]=>
+  string(6) "field3"
+}
+array(3) {
+  [0]=>
+  string(7) "field
+4"
+  [1]=>
+  string(7) "field
+5"
+  [2]=>
+  string(7) "field6
+"
+}


### PR DESCRIPTION
This pull request fixes buggy behaviour when using `SplFileObject` to work with CSV files.

According to the documentation, the `DROP_NEW_LINE` flag drops newlines at the end of a line. http://php.net/manual/en/class.splfileobject.php#splfileobject.constants.drop-new-line

However, even though CSV files are obviously stored with new lines at the end of each line, the _fields within the CSV can also contain any number of newline characters, as long as they are quoted_. In this case, the bug appears, as the DROP_NEW_LINE flag causes c function `strcspn` to remove the first, and only the first, newline from the entire row of fields.

My solution is to ignore the `strcspn` function when parsing CSV files, because if there _are_ any newlines within fields, the fields MUST be delimited, therefore no newlines should be dropped within the delimiters.
