### PR TITLE
Make use not clash and crash if the class is already defined

### DIFF
--- a/Zend/tests/bug42859.phpt
+++ b/Zend/tests/bug42859.phpt
@@ -6,7 +6,8 @@ namespace Foo;
 class Ex {}
 
 use Blah\Exception;
-use Blah\Ex;
+var_dump(new Ex);
 ?>
 --EXPECTF--
-Fatal error: Cannot use Blah\Ex as Ex because the name is already in use in %sbug42859.php on line 6
+object(Foo\Ex)#%d (0) {
+}

--- a/Zend/tests/ns_030.phpt
+++ b/Zend/tests/ns_030.phpt
@@ -9,4 +9,4 @@ use A\B as Foo;
 
 new Foo();
 --EXPECTF--
-Fatal error: Cannot use A\B as Foo because the name is already in use in %sns_030.php on line 5
+Fatal error: Class 'A\B' not found in %s on line %d

--- a/Zend/tests/use_const/define_imported_before.phpt
+++ b/Zend/tests/use_const/define_imported_before.phpt
@@ -7,12 +7,10 @@ namespace {
     const bar = 42;
 
     use const foo\bar;
-}
 
-namespace {
-    echo "Done";
+    echo bar;
 }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use const foo\bar as bar because the name is already in use in %s on line %d
+Fatal error: Undefined constant 'foo\bar' in %s on line %d

--- a/Zend/tests/use_function/define_imported_before.phpt
+++ b/Zend/tests/use_function/define_imported_before.phpt
@@ -7,12 +7,10 @@ namespace {
     function bar() {}
 
     use function foo\bar;
-}
 
-namespace {
-    echo "Done";
+    bar();
 }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use function foo\bar as bar because the name is already in use in %s on line %d
+Fatal error: Call to undefined function foo\bar() in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4924,17 +4924,6 @@ static char *zend_get_use_type_str(uint32_t type) /* {{{ */
 }
 /* }}} */
 
-static void zend_check_already_in_use(uint32_t type, zend_string *old_name, zend_string *new_name, zend_string *check_name) /* {{{ */
-{
-	if (zend_string_equals_ci(old_name, check_name)) {
-		return;
-	}
-
-	zend_error_noreturn(E_COMPILE_ERROR, "Cannot use%s %s as %s because the name "
-		"is already in use", zend_get_use_type_str(type), old_name->val, new_name->val);
-}
-/* }}} */
-
 void zend_compile_use(zend_ast *ast) /* {{{ */
 {
 	zend_ast_list *list = zend_ast_get_list(ast);
@@ -4985,51 +4974,6 @@ void zend_compile_use(zend_ast *ast) /* {{{ */
 		) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Cannot use %s as %s because '%s' "
 				"is a special class name", old_name->val, new_name->val, new_name->val);
-		}
-
-		if (current_ns) {
-			zend_string *ns_name = zend_string_alloc(current_ns->len + 1 + new_name->len, 0);
-			zend_str_tolower_copy(ns_name->val, current_ns->val, current_ns->len);
-			ns_name->val[current_ns->len] = '\\';
-			memcpy(ns_name->val + current_ns->len + 1, lookup_name->val, lookup_name->len);
-
-			if (zend_hash_exists(CG(class_table), ns_name)) {
-				zend_check_already_in_use(type, old_name, new_name, ns_name);
-			}
-
-			zend_string_free(ns_name);
-		} else {
-			switch (type) {
-				case T_CLASS:
-				{
-					zend_class_entry *ce = zend_hash_find_ptr(CG(class_table), lookup_name);
-					if (ce && ce->type == ZEND_USER_CLASS
-						&& ce->info.user.filename == CG(compiled_filename)
-					) {
-						zend_check_already_in_use(type, old_name, new_name, lookup_name);
-					}
-					break;
-				}
-				case T_FUNCTION:
-				{
-					zend_function *fn = zend_hash_find_ptr(CG(function_table), lookup_name);
-					if (fn && fn->type == ZEND_USER_FUNCTION
-						&& fn->op_array.filename == CG(compiled_filename)
-					) {
-						zend_check_already_in_use(type, old_name, new_name, lookup_name);
-					}
-					break;
-				}
-				case T_CONST:
-				{
-					zend_string *filename = zend_hash_find_ptr(&CG(const_filenames), lookup_name);
-					if (filename && filename == CG(compiled_filename)) {
-						zend_check_already_in_use(type, old_name, new_name, lookup_name);
-					}
-					break;
-				}
-				EMPTY_SWITCH_DEFAULT_CASE()
-			}
 		}
 
 		zend_string_addref(old_name);


### PR DESCRIPTION
Currently, use will crash with an error if there is already a symbol with the same name defined.

```
namespace Foo {
    class Bar {}
}
namespace Foo {
    use Biz\Bar;
}
```

That will generate a fatal error that "bar" already exists in scope:

> Fatal error: Cannot use Biz\Bar as Bar because the name is already in use.

This is because `use` does a symbol table lookup to see if there is a collision with any declared class.

However, this is a problematic check since inclusion order matters. If the first block is executed after the second one (different files) this will result in code working. If for some reason the inclusion order changes, the code will fail.

Additionally, opcache nulls out the symbol tables prior to compilation. So with opcache enabled, the code (assuming it lives in separate files) will never error, because the symbol table lookups will always fail.

This results in the check being inconsistent at best. It means that the same conceptual code will error if run one way, but not if run several others.

Therefore, I am proposing that we simply remove the error checks all together as the code is perfectly easy to understand and 100% predictable.

This has the side effect that the following code becomes possible:

```
<?php
class Test {}
use Bar\Test;
var_dump(new Test); // class(Bar\Test)
```
