### PR TITLE
Limit use to top of block

### DIFF
--- a/Zend/tests/bug42859.phpt
+++ b/Zend/tests/bug42859.phpt
@@ -3,10 +3,9 @@ Bug #42859 (import always conflicts with internal classes)
 --FILE--
 <?php
 namespace Foo;
-class Ex {}
-
 use Blah\Exception;
-use Blah\Ex;
+
+var_dump(Exception::class);
 ?>
 --EXPECTF--
-Fatal error: Cannot use Blah\Ex as Ex because the name is already in use in %sbug42859.php on line 6
+string(14) "Blah\Exception"

--- a/Zend/tests/bug43183.phpt
+++ b/Zend/tests/bug43183.phpt
@@ -2,11 +2,22 @@
 Bug #43183 ("use" of the same class in difference scripts results in a fatal error)
 --FILE--
 <?php
+$file1 = <<<'EOF'
 namespace Test;
-use Test\Foo;
-class Foo {}
-class Bar {}
-use Test\Bar;
-echo "ok\n";
---EXPECT--
-ok
+class Helper {}
+EOF;
+
+$file2 = <<<'EOF'
+namespace Test;
+use Test\Helper;
+class Other {}
+EOF;
+
+eval($file1);
+eval($file2);
+
+var_dump(new Test\Helper);
+
+--EXPECTF--
+object(Test\Helper)#%d (0) {
+}

--- a/Zend/tests/class_alias_021.phpt
+++ b/Zend/tests/class_alias_021.phpt
@@ -5,11 +5,11 @@ Overriding internal class with class alias
 
 namespace foo;
 
+use \baz as stdclass;
+
 class bar { }
 
 class_alias('foo\bar', 'baz');
-
-use \baz as stdClass;
 
 var_dump(new bar);
 var_dump(new stdClass);

--- a/Zend/tests/ns_002.phpt
+++ b/Zend/tests/ns_002.phpt
@@ -4,15 +4,16 @@
 <?php
 namespace test\ns1;
 
+use test\ns1\Foo as Bar;
+use test\ns1 as ns2;
+use test\ns1;
+
+
 class Foo {
   static function bar() {
     echo __CLASS__,"\n";
   }
 }
-
-use test\ns1\Foo as Bar;
-use test\ns1 as ns2;
-use test\ns1;
 
 Foo::bar();
 \test\ns1\Foo::bar();

--- a/Zend/tests/ns_012.phpt
+++ b/Zend/tests/ns_012.phpt
@@ -4,12 +4,12 @@
 <?php
 namespace test\ns1;
 
+use test\ns1 as ns2;
+use test as ns3;
+
 function foo() {
   echo __FUNCTION__,"\n";
 }
-
-use test\ns1 as ns2;
-use test as ns3;
 
 foo();
 bar();

--- a/Zend/tests/ns_030.phpt
+++ b/Zend/tests/ns_030.phpt
@@ -2,11 +2,11 @@
 030: Name ambiguity (import name & class name)
 --FILE--
 <?php
+use A\B as Foo;
+
 class Foo {
 }
 
-use A\B as Foo;
-
 new Foo();
 --EXPECTF--
-Fatal error: Cannot use A\B as Foo because the name is already in use in %sns_030.php on line 5
+Fatal error: Cannot declare class Foo because the name is already in use in %sns_030.php on line 4

--- a/Zend/tests/ns_042.phpt
+++ b/Zend/tests/ns_042.phpt
@@ -4,10 +4,11 @@
 <?php
 namespace test\ns1;
 
-const FOO = "ok\n";
-
 use test\ns1 as ns2;
 use test as ns3;
+
+const FOO = "ok\n";
+
 
 echo FOO;
 echo \test\ns1\FOO;

--- a/Zend/tests/ns_061.phpt
+++ b/Zend/tests/ns_061.phpt
@@ -2,8 +2,9 @@
 061: use in global scope
 --FILE--
 <?php
-class A {}
 use \A as B;
+
+class A {}
 echo get_class(new B)."\n";
 --EXPECT--
 A

--- a/Zend/tests/ns_064.phpt
+++ b/Zend/tests/ns_064.phpt
@@ -5,6 +5,8 @@ Magic methods in overrided stdClass inside namespace
 
 namespace test;
 
+use test\foo as stdClass;
+
 class foo {
 	public $e = array();
 	
@@ -20,8 +22,6 @@ class foo {
 		return $this;
 	}
 }
-
-use test\foo as stdClass;
 
 $x = new stdClass;
 $x->a = 1;

--- a/Zend/tests/ns_066.phpt
+++ b/Zend/tests/ns_066.phpt
@@ -2,8 +2,8 @@
 066: Name ambiguity (import name & internal class name)
 --FILE--
 <?php
-include __DIR__ . '/ns_027.inc';
 use Foo\Bar\Foo as stdClass;
+include __DIR__ . '/ns_027.inc';
 
 new stdClass();
 --EXPECT--

--- a/Zend/tests/ns_085.phpt
+++ b/Zend/tests/ns_085.phpt
@@ -3,21 +3,22 @@
 --FILE--
 <?php
 namespace foo {
-use \foo;
-class bar {
-	function __construct() {echo __METHOD__,"\n";}
-}
-new foo;
-new bar;
+    use \foo;
+    class bar {
+    	function __construct() {echo __METHOD__,"\n";}
+    }
+    new foo;
+    new bar;
 }
 namespace {
-class foo {
-	function __construct() {echo __METHOD__,"\n";}
-}
-use foo\bar as foo1;
-new foo1;
-new foo;
-echo "===DONE===\n";
+    use foo\bar as foo1;
+
+    class foo {
+    	function __construct() {echo __METHOD__,"\n";}
+    }
+    new foo1;
+    new foo;
+    echo "===DONE===\n";
 }
 --EXPECT--
 foo::__construct

--- a/Zend/tests/ns_086.phpt
+++ b/Zend/tests/ns_086.phpt
@@ -12,21 +12,22 @@ zend.multibyte=1
 <?php
 declare(encoding='utf-8');
 namespace foo {
-use \foo;
-class bar {
-	function __construct() {echo __METHOD__,"\n";}
-}
-new foo;
-new bar;
+	use \foo;
+	class bar {
+		function __construct() {echo __METHOD__,"\n";}
+	}
+	new foo;
+	new bar;
 }
 namespace {
-class foo {
-	function __construct() {echo __METHOD__,"\n";}
-}
-use foo\bar as foo1;
-new foo1;
-new foo;
-echo "===DONE===\n";
+	use foo\bar as foo1;
+
+	class foo {
+		function __construct() {echo __METHOD__,"\n";}
+	}
+	new foo1;
+	new foo;
+	echo "===DONE===\n";
 }
 --EXPECT--
 foo::__construct

--- a/Zend/tests/use_const/define_imported_before.phpt
+++ b/Zend/tests/use_const/define_imported_before.phpt
@@ -4,9 +4,9 @@ using const with same name as defined should fail
 <?php
 
 namespace {
+    use const foo\bar;
     const bar = 42;
 
-    use const foo\bar;
 }
 
 namespace {
@@ -15,4 +15,4 @@ namespace {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use const foo\bar as bar because the name is already in use in %s on line %d
+Fatal error: Cannot declare const bar because the name is already in use in %s on line %d

--- a/Zend/tests/use_const/no_global_fallback.phpt
+++ b/Zend/tests/use_const/no_global_fallback.phpt
@@ -2,10 +2,10 @@
 non-existent imported constants should not be looked up in the global table
 --FILE--
 <?php
+use const foo\bar\baz;
 
 require 'includes/global_baz.php';
 
-use const foo\bar\baz;
 var_dump(baz);
 
 ?>

--- a/Zend/tests/use_const/shadow_core.phpt
+++ b/Zend/tests/use_const/shadow_core.phpt
@@ -2,10 +2,10 @@
 shadowing a global core constant with a local version
 --FILE--
 <?php
+use const foo\PHP_VERSION;
 
 require 'includes/foo_php_version.php';
 
-use const foo\PHP_VERSION;
 
 var_dump(PHP_VERSION);
 echo "Done\n";

--- a/Zend/tests/use_function/conditional_function_declaration.phpt
+++ b/Zend/tests/use_function/conditional_function_declaration.phpt
@@ -3,15 +3,15 @@ function that is conditionally defined at runtime should not cause compiler erro
 --FILE--
 <?php
 
+use function bar\foo;
+
 if (0) {
     function foo() {
     }
 }
 
-use function bar\foo;
-
 echo "Done";
 
 ?>
---EXPECT--
-Done
+--EXPECTF--
+Fatal error: Cannot declare function foo because the name is already in use in %s on line %d

--- a/Zend/tests/use_function/define_imported_before.phpt
+++ b/Zend/tests/use_function/define_imported_before.phpt
@@ -4,9 +4,10 @@ using function with same name as defined should fail
 <?php
 
 namespace {
+    use function foo\bar;
+
     function bar() {}
 
-    use function foo\bar;
 }
 
 namespace {
@@ -15,4 +16,4 @@ namespace {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use function foo\bar as bar because the name is already in use in %s on line %d
+Fatal error: Cannot declare function bar because the name is already in use in %s on line %d

--- a/Zend/tests/use_function/no_global_fallback.phpt
+++ b/Zend/tests/use_function/no_global_fallback.phpt
@@ -2,10 +2,10 @@
 non-existent imported functions should not be looked up in the global table
 --FILE--
 <?php
+use function foo\bar\baz;
 
 require 'includes/global_baz.php';
 
-use function foo\bar\baz;
 var_dump(baz());
 
 ?>

--- a/Zend/tests/use_function/shadow_core.phpt
+++ b/Zend/tests/use_function/shadow_core.phpt
@@ -3,9 +3,9 @@ shadowing a global core function with a local version
 --FILE--
 <?php
 
-require 'includes/foo_strlen.php';
-
 use function foo\strlen;
+
+require 'includes/foo_strlen.php';
 
 var_dump(strlen('foo bar baz'));
 echo "Done\n";

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -454,7 +454,7 @@ static void compiler_globals_ctor(zend_compiler_globals *compiler_globals) /* {{
 		compiler_globals->static_members_table = NULL;
 	}
 	compiler_globals->script_encoding_list = NULL;
-    compiler_globals->current_namespace_ast = NULL;
+	compiler_globals->current_namespace_ast = NULL;
 
 #ifdef ZTS
 	zend_interned_empty_string_init(&compiler_globals->empty_string);

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -454,6 +454,7 @@ static void compiler_globals_ctor(zend_compiler_globals *compiler_globals) /* {{
 		compiler_globals->static_members_table = NULL;
 	}
 	compiler_globals->script_encoding_list = NULL;
+    compiler_globals->current_namespace_ast = NULL;
 
 #ifdef ZTS
 	zend_interned_empty_string_init(&compiler_globals->empty_string);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1556,7 +1556,7 @@ static void zend_end_namespace(void) /* {{{ */ {
 		zend_string_release(CG(current_namespace));
 		CG(current_namespace) = NULL;
 	}
-    CG(current_namespace_ast) = NULL;
+	CG(current_namespace_ast) = NULL;
 }
 /* }}} */
 
@@ -4938,37 +4938,37 @@ static void zend_check_already_in_use(uint32_t type, zend_string *old_name, zend
 
 static int zend_verify_namespace_use_position(zend_ast *ast) /* {{{ */
 {
-    zend_ast *stmt;
-    zend_ast_list *top_list;
-    uint32_t i, failcount = 0;
-    
-    
-    if (CG(current_namespace_ast) != NULL) {
-        top_list = zend_ast_get_list(CG(current_namespace_ast));
-    } else {
-        top_list = zend_ast_get_list(CG(ast));
-    }
-    
-    for (i = 0; i < top_list->children; i++) {
-        stmt = top_list->child[i];
-        if (stmt == ast) {
-            if (failcount == 0) {
-                return SUCCESS;
-            }
-            return FAILURE;
-        } else if (stmt != NULL && stmt->kind == ZEND_AST_NAMESPACE) {
-            /* non-block-mode, so we need to reset the fail count */
-            failcount = 0;
-        } else if (
-            stmt != NULL
-            && stmt->kind != ZEND_AST_USE
-            && stmt->kind != ZEND_AST_DECLARE
-        ) {
-            failcount++;
-        }
-    }
+	zend_ast *stmt;
+	zend_ast_list *top_list;
+	uint32_t i, failcount = 0;
 
-    return FAILURE;
+
+	if (CG(current_namespace_ast) != NULL) {
+		top_list = zend_ast_get_list(CG(current_namespace_ast));
+	} else {
+		top_list = zend_ast_get_list(CG(ast));
+	}
+
+	for (i = 0; i < top_list->children; i++) {
+		stmt = top_list->child[i];
+		if (stmt == ast) {
+			if (failcount == 0) {
+				return SUCCESS;
+			}
+			return FAILURE;
+		} else if (stmt != NULL && stmt->kind == ZEND_AST_NAMESPACE) {
+			/* non-block-mode, so we need to reset the fail count */
+			failcount = 0;
+		} else if (
+			stmt != NULL
+			&& stmt->kind != ZEND_AST_USE
+			&& stmt->kind != ZEND_AST_DECLARE
+		) {
+			failcount++;
+		}
+	}
+
+	return FAILURE;
 }
 /* }}} */
 
@@ -4981,10 +4981,10 @@ void zend_compile_use(zend_ast *ast) /* {{{ */
 	HashTable *current_import = zend_get_import_ht(type);
 	zend_bool case_sensitive = type == T_CONST;
 
-    if (FAILURE == zend_verify_namespace_use_position(ast)) {
-        zend_error_noreturn(E_COMPILE_ERROR, "Use statements must come before actual "
-            "code in the file");
-    }
+	if (FAILURE == zend_verify_namespace_use_position(ast)) {
+		zend_error_noreturn(E_COMPILE_ERROR, "Use statements must come before actual "
+			"code in the file");
+	}
 
 	for (i = 0; i < list->children; ++i) {
 		zend_ast *use_ast = list->child[i];
@@ -5170,9 +5170,9 @@ void zend_compile_namespace(zend_ast *ast) /* {{{ */
 				"the very first statement in the script");
 		}
 	}
-    
-    zend_end_namespace();
-    CG(in_namespace) = 1;
+	
+	zend_end_namespace();
+	CG(in_namespace) = 1;
 	if (with_bracket) {
 		CG(has_bracketed_namespaces) = 1;
 	}
@@ -5188,7 +5188,7 @@ void zend_compile_namespace(zend_ast *ast) /* {{{ */
 	}
 
 	if (stmt_ast) {
-        CG(current_namespace_ast) = stmt_ast;
+		CG(current_namespace_ast) = stmt_ast;
 		zend_compile_top_stmt(stmt_ast);
 		zend_end_namespace();
 	}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1556,6 +1556,7 @@ static void zend_end_namespace(void) /* {{{ */ {
 		zend_string_release(CG(current_namespace));
 		CG(current_namespace) = NULL;
 	}
+    CG(current_namespace_ast) = NULL;
 }
 /* }}} */
 
@@ -4935,6 +4936,42 @@ static void zend_check_already_in_use(uint32_t type, zend_string *old_name, zend
 }
 /* }}} */
 
+static int zend_verify_namespace_use_position(zend_ast *ast) /* {{{ */
+{
+    zend_ast *stmt;
+    zend_ast_list *top_list;
+    uint32_t i, failcount = 0;
+    
+    
+    if (CG(current_namespace_ast) != NULL) {
+        top_list = zend_ast_get_list(CG(current_namespace_ast));
+    } else {
+        top_list = zend_ast_get_list(CG(ast));
+    }
+    
+    for (i = 0; i < top_list->children; i++) {
+        stmt = top_list->child[i];
+        if (stmt == ast) {
+            if (failcount == 0) {
+                return SUCCESS;
+            }
+            return FAILURE;
+        } else if (stmt != NULL && stmt->kind == ZEND_AST_NAMESPACE) {
+            /* non-block-mode, so we need to reset the fail count */
+            failcount = 0;
+        } else if (
+            stmt != NULL
+            && stmt->kind != ZEND_AST_USE
+            && stmt->kind != ZEND_AST_DECLARE
+        ) {
+            failcount++;
+        }
+    }
+
+    return FAILURE;
+}
+/* }}} */
+
 void zend_compile_use(zend_ast *ast) /* {{{ */
 {
 	zend_ast_list *list = zend_ast_get_list(ast);
@@ -4943,6 +4980,11 @@ void zend_compile_use(zend_ast *ast) /* {{{ */
 	uint32_t type = ast->attr;
 	HashTable *current_import = zend_get_import_ht(type);
 	zend_bool case_sensitive = type == T_CONST;
+
+    if (FAILURE == zend_verify_namespace_use_position(ast)) {
+        zend_error_noreturn(E_COMPILE_ERROR, "Use statements must come before actual "
+            "code in the file");
+    }
 
 	for (i = 0; i < list->children; ++i) {
 		zend_ast *use_ast = list->child[i];
@@ -5128,9 +5170,11 @@ void zend_compile_namespace(zend_ast *ast) /* {{{ */
 				"the very first statement in the script");
 		}
 	}
-
-	if (CG(current_namespace)) {
-		zend_string_release(CG(current_namespace));
+    
+    zend_end_namespace();
+    CG(in_namespace) = 1;
+	if (with_bracket) {
+		CG(has_bracketed_namespaces) = 1;
 	}
 
 	if (name_ast) {
@@ -5141,18 +5185,10 @@ void zend_compile_namespace(zend_ast *ast) /* {{{ */
 		}
 
 		CG(current_namespace) = zend_string_copy(name);
-	} else {
-		CG(current_namespace) = NULL;
-	}
-
-	zend_reset_import_tables();
-
-	CG(in_namespace) = 1;
-	if (with_bracket) {
-		CG(has_bracketed_namespaces) = 1;
 	}
 
 	if (stmt_ast) {
+        CG(current_namespace_ast) = stmt_ast;
 		zend_compile_top_stmt(stmt_ast);
 		zend_end_namespace();
 	}

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -117,6 +117,7 @@ struct _zend_compiler_globals {
 	HashTable *current_import_const;
 	zend_bool  in_namespace;
 	zend_bool  has_bracketed_namespaces;
+    zend_ast *current_namespace_ast;
 
 	HashTable const_filenames;
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -117,7 +117,7 @@ struct _zend_compiler_globals {
 	HashTable *current_import_const;
 	zend_bool  in_namespace;
 	zend_bool  has_bracketed_namespaces;
-    zend_ast *current_namespace_ast;
+	zend_ast *current_namespace_ast;
 
 	HashTable const_filenames;
 


### PR DESCRIPTION
Currently, `use` declarations can happen in any top level code (top or inside of block-mode namespace declarations). This can result in weird situations like:

```
<?php
namespace Foo;
var_dump(new Test); // Foo\Test
use Bar\Test;
var_dump(new Test); // Bar\Test
```

This PR adds a compile time check to ensure that use statements occur at the top of the block (file, or immediately following a namespace declaration). The only other non-use symbols allowed before it are Namespace declarations and `declare` calls.
