### PR TITLE
Fix #66590: imagewebp() sometimes returns broken image

### DIFF
--- a/ext/gd/libgd/webpimg.c
+++ b/ext/gd/libgd/webpimg.c
@@ -779,6 +779,19 @@ WebPResult WebPEncode(const uint8* Y,
 										(chunk_size >> 24) & 255 };
 	  memcpy(*p_out, kRiffHeader, kRiffHeaderSize);
 
+	  if (img_size_bytes & 1) {  /* write a padding byte */
+		const int new_size = *p_out_size_bytes + 1;
+		unsigned char* p = (unsigned char*)realloc(*p_out, new_size);
+		if (p == NULL) {
+			free(*p_out);
+			*p_out = NULL;
+			*p_out_size_bytes = 0;
+			return webp_failure;
+		}
+		p[new_size - 1] = 0;
+		*p_out_size_bytes = new_size;
+	  }
+
 	  if (psnr) {
 		*psnr = WebPGetPSNR(Y, U, V, *p_out, *p_out_size_bytes);
 	  }


### PR DESCRIPTION
This pull-request based on https://bugs.php.net/bug.php?id=66590#1390869798