### PR TITLE
Add $before_needle param for strrchr() like strchr()/strstr()

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2207,8 +2207,9 @@ PHP_FUNCTION(strrchr)
 	zend_string *haystack;
 	const char *found = NULL;
 	zend_long found_offset;
+	zend_bool part = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sz", &haystack, &needle) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|b", &haystack, &needle, &part) == FAILURE) {
 		return;
 	}
 
@@ -2225,7 +2226,11 @@ PHP_FUNCTION(strrchr)
 
 	if (found) {
 		found_offset = found - haystack->val;
-		RETURN_STRINGL(found, haystack->len - found_offset);
+		if(part) {
+			RETURN_STRINGL(haystack->val, found_offset);
+		} else {
+			RETURN_STRINGL(found, haystack->len - found_offset);
+		}	
 	} else {
 		RETURN_FALSE;
 	}

--- a/tests/strings/001.phpt
+++ b/tests/strings/001.phpt
@@ -28,14 +28,11 @@ echo "Testing strstr: ";
 $test = "This is a test";
 $found1 = strstr($test, 32);
 $found2 = strstr($test, "a ");
-$found3 = strrchr($test, "o", true);
 if ($found1 != " is a test") {
 	echo("failed 1\n");
 } elseif ($found2 != "a test") {
 	echo("failed 2\n");
-} elseif ($found3 != "fola f") {
-	echo("failed 3\n");
-} else {
+}  else {
 	echo("passed\n");
 }
 
@@ -43,12 +40,14 @@ echo "Testing strrchr: ";
 $test = "fola fola blakken";
 $found1 = strrchr($test, "b");
 $found2 = strrchr($test, 102);
+$found3 = strrchr($test, "o", true);
 if ($found1 != "blakken") {
 	echo("failed 1\n");
 } elseif ($found2 != "fola blakken") {
 	echo("failed 2\n");
-}
-else {
+} elseif ($found3 != "fola f") {
+	echo("failed 3\n");
+} else {
 	echo("passed\n");
 }
 

--- a/tests/strings/001.phpt
+++ b/tests/strings/001.phpt
@@ -28,10 +28,13 @@ echo "Testing strstr: ";
 $test = "This is a test";
 $found1 = strstr($test, 32);
 $found2 = strstr($test, "a ");
+$found3 = strrchr($test, "o", true);
 if ($found1 != " is a test") {
 	echo("failed 1\n");
 } elseif ($found2 != "a test") {
 	echo("failed 2\n");
+} elseif ($found3 != "fola f") {
+	echo("failed 3\n");
 } else {
 	echo("passed\n");
 }


### PR DESCRIPTION
The strchr() function description below:
```c
//strchr alias of strstr
string strstr ( string $haystack , mixed $needle [, bool $before_needle = false ] )
```

But the strrchr() function don't support `$before_needle` param, below:
```c
string strrchr ( string $haystack , mixed $needle )
```

Now supported in the commit.
