### PR TITLE
Add third param for strrchr function like strchr/strstr

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2207,8 +2207,9 @@ PHP_FUNCTION(strrchr)
 	zend_string *haystack;
 	const char *found = NULL;
 	zend_long found_offset;
+	zend_bool part = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sz", &haystack, &needle) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|b", &haystack, &needle, &part) == FAILURE) {
 		return;
 	}
 
@@ -2225,7 +2226,11 @@ PHP_FUNCTION(strrchr)
 
 	if (found) {
 		found_offset = found - haystack->val;
-		RETURN_STRINGL(found, haystack->len - found_offset);
+		if(part) {
+			RETURN_STRINGL(haystack->val, found_offset);
+		} else {
+			RETURN_STRINGL(found, haystack->len - found_offset);
+		}
 	} else {
 		RETURN_FALSE;
 	}

--- a/ext/standard/tests/strings/strrchr_error.phpt
+++ b/ext/standard/tests/strings/strrchr_error.phpt
@@ -19,7 +19,7 @@ echo "\n-- Testing strrchr() function with less than expected no. of arguments -
 var_dump( strrchr($haystack) );
 
 echo "\n-- Testing strrchr() function with more than expected no. of arguments --";
-var_dump( strrchr($haystack, $needle, $extra_arg) );
+var_dump( strrchr($haystack, $needle, true, $extra_arg) );
 
 echo "*** Done ***";
 ?>
@@ -35,6 +35,6 @@ Warning: strrchr() expects exactly 2 parameters, 1 given in %s on line %d
 NULL
 
 -- Testing strrchr() function with more than expected no. of arguments --
-Warning: strrchr() expects exactly 2 parameters, 3 given in %s on line %d
+Warning: strrchr() expects exactly 3 parameters, 4 given in %s on line %d
 NULL
 *** Done ***

--- a/tests/strings/001.phpt
+++ b/tests/strings/001.phpt
@@ -40,12 +40,14 @@ echo "Testing strrchr: ";
 $test = "fola fola blakken";
 $found1 = strrchr($test, "b");
 $found2 = strrchr($test, 102);
+$found3 = strrchr($test, "o", true);
 if ($found1 != "blakken") {
 	echo("failed 1\n");
 } elseif ($found2 != "fola blakken") {
 	echo("failed 2\n");
-}
-else {
+} elseif ($found3 != "fola f") {
+	echo("failed 3\n");
+} else {
 	echo("passed\n");
 }
 


### PR DESCRIPTION
The strchr() function description below:
```c
//strchr alias of strstr
string strstr ( string $haystack , mixed $needle [, bool $before_needle = false ] )
```

But the strrchr() function don't support `$before_needle` param, below:
```c
string strrchr ( string $haystack , mixed $needle )
```

Now supported in this commit.
