### PR TITLE
fixed Bug #68621

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1399,6 +1399,7 @@ static ZIPARCHIVE_METHOD(open)
 	zend_string *filename;
 	zval *self = getThis();
 	ze_zip_object *ze_obj = NULL;
+	char *php_spn = "php://";
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "P|l", &filename, &flags) == FAILURE) {
 		return;
@@ -1418,8 +1419,12 @@ static ZIPARCHIVE_METHOD(open)
 		RETURN_FALSE;
 	}
 
-	if (!(resolved_path = expand_filepath(filename->val, NULL))) {
-		RETURN_FALSE;
+	if (!strspn(filename->val,php_spn)) {
+		if (!(resolved_path = expand_filepath(filename->val, NULL))) {
+			RETURN_FALSE;
+		}
+	} else {
+		resolved_path = filename->val;
 	}
 
 	if (ze_obj->za) {

--- a/ext/zip/tests/bug68621.phpt
+++ b/ext/zip/tests/bug68621.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #68621	Filename appends the base url.
+The ZipArchive::open treats the filename not as defined per php manual on valid file wrappers. It appends the filename to the base url. Hence, creating/manipulating a zip file in memory space would be impossible.
+--SKIPIF--
+<?php
+/* $Id$ */
+if(!extension_loaded('zip')) die('skip');
+?>
+--FILE--
+<?php
+error_reporting(0);
+$zip = new \ZipArchive();
+if (!($err = $zip->open("php://memory", \ZipArchive::CREATE)))
+{
+	die(var_dump($err));
+}
+$zip->addFromString("test.txt", "sample text");
+
+if ($zip->filename == "php://memory") {
+	echo "done";
+} else {
+	echo "failed";
+}
+die;
+?>
+--EXPECTF--
+done


### PR DESCRIPTION
The ZipArchive::open treats the filename not as defined per php manual on valid file wrappers. It appends the filename to the base url. Hence, creating/manipulating a zip file in memory space would be impossible.

https://bugs.php.net/bug.php?id=68621