### PR TITLE
fixed Bug #68621

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1528,6 +1528,7 @@ static ZIPARCHIVE_METHOD(open)
 
 	zval *this = getThis();
 	ze_zip_object *ze_obj = NULL;
+	char *php_spn = "php://";
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, ARG_PATH "|l", &filename, &filename_len, &flags) == FAILURE) {
 		return;
@@ -1547,8 +1548,12 @@ static ZIPARCHIVE_METHOD(open)
 		RETURN_FALSE;
 	}
 
-	if (!(resolved_path = expand_filepath(filename, NULL TSRMLS_CC))) {
-		RETURN_FALSE;
+	if (!strspn(filename,php_spn)) {
+		if (!(resolved_path = expand_filepath(filename, NULL TSRMLS_CC))) {
+			RETURN_FALSE;
+		}
+	} else {
+		resolved_path = filename;
 	}
 
 	if (ze_obj->za) {

--- a/ext/zip/tests/bug68621.phpt
+++ b/ext/zip/tests/bug68621.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #68621	Filename appends the base url.
+The ZipArchive::open treats the filename not as defined per php manual on valid file wrappers. It appends the filename to the base url. Hence, creating/manipulating a zip file in memory space would be impossible.
+--SKIPIF--
+<?php
+/* $Id$ */
+if(!extension_loaded('zip')) die('skip');
+?>
+--FILE--
+<?php
+
+$zip = new \ZipArchive();
+if (!($err = $zip->open("php://memory", \ZipArchive::CREATE)))
+{
+	die(var_dump($err));
+}
+$zip->addFromString("test.txt", "sample text");
+die(var_dump($zip));
+
+?>
+--EXPECTF--
+object(ZipArchive)[206]
+  public 'status' => int 0
+  public 'statusSys' => int 0
+  public 'numFiles' => int 1
+  public 'filename' => string 'php://memory' (length=12)
+  public 'comment' => string '' (length=0)


### PR DESCRIPTION
The ZipArchive::open treats the filename not as defined per php manual on valid file wrappers. It appends the filename to the base url. Hence, creating/manipulating a zip file in memory space would be impossible.

https://bugs.php.net/bug.php?id=68621