### PR TITLE
Adjust logic in sanity checks.

### DIFF
--- a/ext/filter/filter.c
+++ b/ext/filter/filter.c
@@ -800,7 +800,7 @@ PHP_FUNCTION(filter_input_array)
 		return;
 	}
 
-	if (op && (Z_TYPE_P(op) != IS_ARRAY) && (Z_TYPE_P(op) == IS_LONG && !PHP_FILTER_ID_EXISTS(Z_LVAL_P(op)))) {
+	if (op && (Z_TYPE_P(op) != IS_ARRAY) && !(Z_TYPE_P(op) == IS_LONG && PHP_FILTER_ID_EXISTS(Z_LVAL_P(op)))) {
 		RETURN_FALSE;
 	}
 
@@ -845,7 +845,7 @@ PHP_FUNCTION(filter_var_array)
 		return;
 	}
 
-	if (op && (Z_TYPE_P(op) != IS_ARRAY) && (Z_TYPE_P(op) == IS_LONG && !PHP_FILTER_ID_EXISTS(Z_LVAL_P(op)))) {
+	if (op && (Z_TYPE_P(op) != IS_ARRAY) && !(Z_TYPE_P(op) == IS_LONG && PHP_FILTER_ID_EXISTS(Z_LVAL_P(op)))) {
 		RETURN_FALSE;
 	}
 

--- a/ext/filter/tests/057.phpt
+++ b/ext/filter/tests/057.phpt
@@ -1,0 +1,23 @@
+--TEST--
+filter_input_array() and filter_var_array() with invalid $definition arguments
+--SKIPIF--
+<?php if (!extension_loaded("filter")) die("skip"); ?>
+--FILE--
+<?php
+foreach (array(null, true, false, 1, "", new stdClass) as $invalid) {
+    var_dump(filter_input_array(INPUT_POST, $invalid));
+    var_dump(filter_var_array(array(), $invalid));
+}
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)


### PR DESCRIPTION
The code should return false when the provided options argument is neither an
array nor a valid filter.