### PR TITLE
Bug #68669	DateTime::createFromFormat() does not allow NULL $timezone

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2696,7 +2696,7 @@ PHP_FUNCTION(date_create_from_format)
 	int             time_str_len = 0, format_str_len = 0;
 	zval            datetime_object;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|O", &format_str, &format_str_len, &time_str, &time_str_len, &timezone_object, date_ce_timezone) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|O!", &format_str, &format_str_len, &time_str, &time_str_len, &timezone_object, date_ce_timezone) == FAILURE) {
 		RETURN_FALSE;
 	}
 
@@ -2721,7 +2721,7 @@ PHP_FUNCTION(date_create_immutable_from_format)
 	int             time_str_len = 0, format_str_len = 0;
 	zval            datetime_object;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|O", &format_str, &format_str_len, &time_str, &time_str_len, &timezone_object, date_ce_timezone) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|O!", &format_str, &format_str_len, &time_str, &time_str_len, &timezone_object, date_ce_timezone) == FAILURE) {
 		RETURN_FALSE;
 	}
 

--- a/ext/date/tests/bug68669.phpt
+++ b/ext/date/tests/bug68669.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #68669 (DateTime::createFromFormat() does not allow NULL $timezone)
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+
+$result = get_class(DateTime::createFromFormat('Y/m/d', '2015/1/1', null));
+if ($result == 'DateTime') {
+    echo 'Done';
+} else {
+    echo 'Faild';
+}
+?>
+--EXPECTF--
+Done


### PR DESCRIPTION
`DateTime::createFromFormat($format, $time, DateTimeZone $timezone = null)` has a default value for its third parameter `$timezone`, but it doesn't accept `null` as a value.

Running the following script will raise a warning:

DateTime::createFromFormat('Y/m/d', '2015/1/1', null);

// Warning: DateTime::createFromFormat() expects parameter 3 to be DateTimeZone, null given

While the documentation states that the default timezone is going to be used when no parameter is given, also the case where a `null` `$timezone` is given should be handled correctly.

This would align the API to the language semantics about default values.
