### PR TITLE
#69161 Removing Signed Zeros - number_format

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -390,6 +390,7 @@ PHP_FUNCTION(round)
 		case IS_DOUBLE:
 			return_val = (Z_TYPE_P(value) == IS_LONG) ? (double)Z_LVAL_P(value) : Z_DVAL_P(value);
 			return_val = _php_math_round(return_val, (int)places, (int)mode);
+			return_val = (return_val == -0) ? 0 : return_val;
 			RETURN_DOUBLE(return_val);
 			break;
 

--- a/ext/standard/tests/math/round_signed_zeros.phpt
+++ b/ext/standard/tests/math/round_signed_zeros.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Simple math tests
+--FILE--
+<?php // $Id$
+
+echo round(-0.0021);
+--EXPECT--
+0
+


### PR DESCRIPTION
It's possible to get a signed zero:

<?php
echo round(-0.0001, 2); // -0
?>

This is valid according to IEEE 754 so probably shouldn't be changed internally. However, for display purposes, "-0" is needlessly confusing.

There's no simple way of removing it. I can call abs($num) but I need an if statement to only call abs($num); when $num is -0. 

My proposal is that number_format, which is used for display purposes, changes -0 into +0.

------

I saw some comments under the http://php.net/manual/en/function.round.php, and they can't understand why the return value is '-0'. 

What do you think?