### PR TITLE
Fixed bug #69221

### DIFF
--- a/Zend/tests/bug69221.phpt
+++ b/Zend/tests/bug69221.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #69221: Segmentation fault when using a generator in combination with an Iterator
+--FILE--
+<?php
+
+function gen() {
+	yield 1;
+};
+
+$gen1 = gen();
+$gen2 = (object) $gen1;
+
+foreach ($gen1 as $v1) {
+    foreach ($gen2 as $v2) {
+        break 2;
+    }
+}
+
+unset($gen1);
+foreach ($gen2 as $v) { var_dump($v); }
+
+?>
+--EXPECTF--
+int(1)

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -605,9 +605,9 @@ ZEND_METHOD(Generator, __wakeup)
 
 static void zend_generator_iterator_dtor(zend_object_iterator *iterator TSRMLS_DC) /* {{{ */
 {
-	zval *object = ((zend_generator_iterator *) iterator)->object;
+	zend_generator_iterator *iter = (zend_generator_iterator *) iterator;
 
-	zval_ptr_dtor(&object);
+	zend_objects_store_del_ref_by_handle(iter->handle TSRMLS_CC);
 }
 /* }}} */
 
@@ -699,8 +699,8 @@ zend_object_iterator *zend_generator_get_iterator(zend_class_entry *ce, zval *ob
 
 	/* We have to keep a reference to the generator object zval around,
 	 * otherwise the generator may be destroyed during iteration. */
-	Z_ADDREF_P(object);
-	iterator->object = object;
+	iterator->handle = Z_OBJ_HANDLE_P(object);
+	zend_objects_store_add_ref_by_handle(iterator->handle TSRMLS_CC);
 
 	return (zend_object_iterator *) iterator;
 }

--- a/Zend/zend_generators.h
+++ b/Zend/zend_generators.h
@@ -28,9 +28,9 @@ extern ZEND_API zend_class_entry *zend_ce_generator;
 typedef struct _zend_generator_iterator {
 	zend_object_iterator intern;
 
-	/* The generator object zval has to be stored, because the iterator is
-	 * holding a ref to it, which has to be dtored. */
-	zval *object;
+	/* The generator object handle has to be stored, because the
+	 * iterator is holding a ref to it, which has to be dtored. */
+	zend_object_handle handle;
 } zend_generator_iterator;
 
 typedef struct _zend_generator {


### PR DESCRIPTION
Bug: https://bugs.php.net/bug.php?id=69221

I am unsure whether this fix is okay for PHP 5.x due to the change to the `zend_generator_iterator` structure. The size should stay the same due to padding, but the meaning changes.