### PR TITLE
Safe timeout interrupt handling (max_execution_time).

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2284,15 +2284,11 @@ ZEND_API void* ZEND_FASTCALL _ecalloc(size_t nmemb, size_t size ZEND_FILE_LINE_D
 {
 	void *p;
 
-	HANDLE_BLOCK_INTERRUPTIONS();
-
 	p = _safe_emalloc(nmemb, size, 0 ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
 	if (UNEXPECTED(p == NULL)) {
-		HANDLE_UNBLOCK_INTERRUPTIONS();
 		return p;
 	}
 	memset(p, 0, size * nmemb);
-	HANDLE_UNBLOCK_INTERRUPTIONS();
 	return p;
 }
 
@@ -2301,16 +2297,12 @@ ZEND_API char* ZEND_FASTCALL _estrdup(const char *s ZEND_FILE_LINE_DC ZEND_FILE_
 	size_t length;
 	char *p;
 
-	HANDLE_BLOCK_INTERRUPTIONS();
-
 	length = strlen(s)+1;
 	p = (char *) _emalloc(length ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
 	if (UNEXPECTED(p == NULL)) {
-		HANDLE_UNBLOCK_INTERRUPTIONS();
 		return p;
 	}
 	memcpy(p, s, length);
-	HANDLE_UNBLOCK_INTERRUPTIONS();
 	return p;
 }
 
@@ -2318,16 +2310,12 @@ ZEND_API char* ZEND_FASTCALL _estrndup(const char *s, size_t length ZEND_FILE_LI
 {
 	char *p;
 
-	HANDLE_BLOCK_INTERRUPTIONS();
-
 	p = (char *) _emalloc(length+1 ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
 	if (UNEXPECTED(p == NULL)) {
-		HANDLE_UNBLOCK_INTERRUPTIONS();
 		return p;
 	}
 	memcpy(p, s, length);
 	p[length] = 0;
-	HANDLE_UNBLOCK_INTERRUPTIONS();
 	return p;
 }
 
@@ -2336,18 +2324,14 @@ ZEND_API char* ZEND_FASTCALL zend_strndup(const char *s, size_t length)
 {
 	char *p;
 
-	HANDLE_BLOCK_INTERRUPTIONS();
-
 	p = (char *) malloc(length+1);
 	if (UNEXPECTED(p == NULL)) {
-		HANDLE_UNBLOCK_INTERRUPTIONS();
 		return p;
 	}
 	if (length) {
 		memcpy(p, s, length);
 	}
 	p[length] = 0;
-	HANDLE_UNBLOCK_INTERRUPTIONS();
 	return p;
 }
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2035,13 +2035,25 @@ static zend_always_inline void zend_vm_stack_extend_call_frame(zend_execute_data
 }
 /* }}} */
 
+#define ZEND_VM_CHECK_INTERRUPT() do { \
+		if (UNEXPECTED(EG(vm_interrupt))) { \
+			ZEND_VM_INTERRUPT(); \
+		} \
+	} while (0)
+
 #define ZEND_VM_NEXT_OPCODE() \
 	CHECK_SYMBOL_TABLES() \
 	ZEND_VM_INC_OPCODE(); \
 	ZEND_VM_CONTINUE()
 
+#define ZEND_VM_NEXT_OPCODE_EX(new_op) \
+	CHECK_SYMBOL_TABLES() \
+	OPLINE = new_op; \
+	ZEND_VM_CONTINUE()
+
 #define ZEND_VM_SET_OPCODE(new_op) \
 	CHECK_SYMBOL_TABLES() \
+	ZEND_VM_CHECK_INTERRUPT(); \
 	OPLINE = new_op
 
 #define ZEND_VM_SET_RELATIVE_OPCODE(opline, offset) \
@@ -2050,6 +2062,7 @@ static zend_always_inline void zend_vm_stack_extend_call_frame(zend_execute_data
 #define ZEND_VM_JMP(new_op) \
 	if (EXPECTED(!EG(exception))) { \
 		ZEND_VM_SET_OPCODE(new_op); \
+		ZEND_VM_CHECK_INTERRUPT(); \
 	} else { \
 		LOAD_OPLINE(); \
 	} \

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -179,6 +179,9 @@ struct _zend_executor_globals {
 
 	zend_long precision;
 
+	zend_bool vm_interrupt;
+	zend_bool timed_out;
+
 	int ticks_count;
 
 	HashTable *in_autoload;

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -111,18 +111,14 @@ static zend_string *zend_new_interned_string_int(zend_string *str)
 			uint32_t *h = (uint32_t *) perealloc_recoverable(CG(interned_strings).arHash, (CG(interned_strings).nTableSize << 1) * sizeof(uint32_t), 1);
 
 			if (d && h) {
-				HANDLE_BLOCK_INTERRUPTIONS();
 				CG(interned_strings).arData = d;
 				CG(interned_strings).arHash = h;
 				CG(interned_strings).nTableSize = (CG(interned_strings).nTableSize << 1);
 				CG(interned_strings).nTableMask = CG(interned_strings).nTableSize - 1;
 				zend_hash_rehash(&CG(interned_strings));
-				HANDLE_UNBLOCK_INTERRUPTIONS();
 			}
 		}
 	}
-
-	HANDLE_BLOCK_INTERRUPTIONS();
 
 	idx = CG(interned_strings).nNumUsed++;
 	CG(interned_strings).nNumOfElements++;
@@ -134,8 +130,6 @@ static zend_string *zend_new_interned_string_int(zend_string *str)
 	nIndex = h & CG(interned_strings).nTableMask;
 	Z_NEXT(p->val) = CG(interned_strings).arHash[nIndex];
 	CG(interned_strings).arHash[nIndex] = idx;
-
-	HANDLE_UNBLOCK_INTERRUPTIONS();
 
 	return str;
 #else

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -12,12 +12,6 @@ ZEND_API void {%EXECUTOR_NAME%}_ex(zend_execute_data *execute_data)
 
 	while (1) {
     {%ZEND_VM_CONTINUE_LABEL%}
-#ifdef ZEND_WIN32
-		if (EG(timed_out)) {
-			zend_timeout(0);
-		}
-#endif
-
 		{%ZEND_VM_DISPATCH%} {
 			{%INTERNAL_EXECUTOR%}
 		}

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -979,9 +979,14 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name,
 							out($f,"#define ZEND_VM_RETURN()           return -1\n");
 							out($f,"#define ZEND_VM_ENTER()            return  1\n");
 							out($f,"#define ZEND_VM_LEAVE()            return  2\n");
-							out($f,"#define ZEND_VM_DISPATCH(opcode, opline) return zend_vm_get_opcode_handler(opcode, opline)(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n\n");
-							out($f,"#define ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_INTERNAL execute_data
-");
+							if (ZEND_VM_SPEC) {
+								out($f,"#define ZEND_VM_INTERRUPT()        return  zend_interrupt_helper_SPEC(execute_data)\n");
+							} else {
+								out($f,"#define ZEND_VM_INTERRUPT()        return  zend_interrupt_helper(execute_data)\n");
+							}
+							out($f,"#define ZEND_VM_DISPATCH(opcode, opline) return zend_vm_get_opcode_handler(opcode, opline)(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
+							out($f,"#define ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_INTERNAL execute_data\n");
+							out($f,"\n");
 							break;
 						case ZEND_VM_KIND_SWITCH:
 							out($f,"\n");
@@ -1005,9 +1010,14 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name,
 							out($f,"#define ZEND_VM_RETURN()   return\n");
 							out($f,"#define ZEND_VM_ENTER()    execute_data = EG(current_execute_data); LOAD_OPLINE(); ZEND_VM_CONTINUE()\n");
 							out($f,"#define ZEND_VM_LEAVE()    ZEND_VM_CONTINUE()\n");
-							out($f,"#define ZEND_VM_DISPATCH(opcode, opline) dispatch_handler = zend_vm_get_opcode_handler(opcode, opline); goto zend_vm_dispatch;\n\n");
-							out($f,"#define ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_INTERNAL execute_data
-");
+							if (ZEND_VM_SPEC) {
+								out($f,"#define ZEND_VM_INTERRUPT() goto zend_interrupt_helper_SPEC\n");
+							} else {
+								out($f,"#define ZEND_VM_INTERRUPT() goto zend_interrupt_helper\n");
+							}
+							out($f,"#define ZEND_VM_DISPATCH(opcode, opline) dispatch_handler = zend_vm_get_opcode_handler(opcode, opline); goto zend_vm_dispatch;\n");
+							out($f,"#define ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_INTERNAL execute_data\n");
+							out($f,"\n");
 							break;
 						case ZEND_VM_KIND_GOTO:
 							out($f,"\n");
@@ -1037,9 +1047,14 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name,
 							out($f,"#define ZEND_VM_RETURN()   return\n");
 							out($f,"#define ZEND_VM_ENTER()    execute_data = EG(current_execute_data); LOAD_OPLINE(); ZEND_VM_CONTINUE()\n");
 							out($f,"#define ZEND_VM_LEAVE()    ZEND_VM_CONTINUE()\n");
-							out($f,"#define ZEND_VM_DISPATCH(opcode, opline) goto *(void**)(zend_vm_get_opcode_handler(opcode, opline));\n\n");
-							out($f,"#define ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_INTERNAL execute_data
-");
+							if (ZEND_VM_SPEC) {
+								out($f,"#define ZEND_VM_INTERRUPT() goto zend_interrupt_helper_SPEC\n");
+							} else {
+								out($f,"#define ZEND_VM_INTERRUPT() goto zend_interrupt_helper\n");
+							}
+							out($f,"#define ZEND_VM_DISPATCH(opcode, opline) goto *(void**)(zend_vm_get_opcode_handler(opcode, opline));\n");
+							out($f,"#define ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_INTERNAL execute_data\n");
+							out($f,"\n");
 							break;
 					}
 					break;
@@ -1478,9 +1493,10 @@ function gen_vm($def, $skel) {
 		out($f,"#define ZEND_VM_RETURN()     return -1\n");
 		out($f,"#define ZEND_VM_ENTER()      return  1\n");
 		out($f,"#define ZEND_VM_LEAVE()      return  2\n");
-		out($f,"#define ZEND_VM_DISPATCH(opcode, opline) return zend_vm_get_opcode_handler(opcode, opline)(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n\n");
-		out($f,"#define ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_INTERNAL execute_data
-\n");
+		out($f,"#define ZEND_VM_INTERRUPT()  return  zend_interrupt_helper(execute_data)\n");
+		out($f,"#define ZEND_VM_DISPATCH(opcode, opline) return zend_vm_get_opcode_handler(opcode, opline)(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);\n");
+		out($f,"#define ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_INTERNAL execute_data\n");
+		out($f,"\n");
 	}
 	foreach ($export as $dsk) {
 		list($kind, $func, $name) = $dsk;

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1933,7 +1933,6 @@ static void php_array_data_shuffle(zval *array) /* {{{ */
 			}
 		}
 	}
-	HANDLE_BLOCK_INTERRUPTIONS();
 	hash->nNumUsed = n_elems;
 	hash->nInternalPointer = 0;
 
@@ -1949,7 +1948,6 @@ static void php_array_data_shuffle(zval *array) /* {{{ */
 	if (!(hash->u.flags & HASH_FLAG_PACKED)) {
 		zend_hash_to_packed(hash);
 	}
-	HANDLE_UNBLOCK_INTERRUPTIONS();
 }
 /* }}} */
 
@@ -4520,7 +4518,6 @@ PHP_FUNCTION(array_multisort)
 	zend_qsort(indirect, array_size, sizeof(Bucket *), php_multisort_compare, (swap_func_t)array_bucket_p_sawp);
 
 	/* Restructure the arrays based on sorted indirect - this is mostly taken from zend_hash_sort() function. */
-	HANDLE_BLOCK_INTERRUPTIONS();
 	for (i = 0; i < num_arrays; i++) {
 		int repack;
 
@@ -4542,7 +4539,6 @@ PHP_FUNCTION(array_multisort)
 			zend_hash_to_packed(hash);
 		}
 	}
-	HANDLE_UNBLOCK_INTERRUPTIONS();
 
 	/* Clean up. */
 	for (i = 0; i < array_size; i++) {

--- a/main/main.c
+++ b/main/main.c
@@ -1015,9 +1015,6 @@ static void php_error_cb(int type, const char *error_filename, const uint error_
 
 	/* store the error if it has changed */
 	if (display) {
-#ifdef ZEND_SIGNALS
-		HANDLE_BLOCK_INTERRUPTIONS();
-#endif
 		if (PG(last_error_message)) {
 			free(PG(last_error_message));
 			PG(last_error_message) = NULL;
@@ -1026,9 +1023,6 @@ static void php_error_cb(int type, const char *error_filename, const uint error_
 			free(PG(last_error_file));
 			PG(last_error_file) = NULL;
 		}
-#ifdef ZEND_SIGNALS
-		HANDLE_UNBLOCK_INTERRUPTIONS();
-#endif
 		if (!error_filename) {
 			error_filename = "Unknown";
 		}


### PR DESCRIPTION
Instead of throwing zend_error() from signal handler, now we just set EG(vm_interrupt) and EG(timed_out) flags. PHP VM checks EG(vm_interrupt) flag on each JMPx instruction (potential loop iteration) and then throws the same zend_error() from VM context. This is safe, and we don't need to wrap some critical code sections with HANDLE_BLOCK_INTERRUPTIONS/HANDLE_UNBLOCK_INTERRUPTIONS anymore (we will need them only in opcache). A small overhead of checking EG(vm_interrupt) on jumps is counterbanaced by improvement from HANDLE_BLOCK_INTERRUPTIONS/HANDLE_UNBLOCK_INTERRUPTIONS removal.

This mechanism is similar to timeout interrupt handling on Windows, but more efficient.
It doesn't allow interruption of internal functions.

In the future EG(vm_interrupt) may be reused for different purposes.