### PR TITLE
Fix bug #69227 and #65967

### DIFF
--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -109,7 +109,7 @@ void spl_SplOjectStorage_free_storage(void *object TSRMLS_DC) /* {{{ */
 		efree(intern->debug_info);
 	}
 
-	if (intern->gcdata_len > 0) {
+	if (intern->gcdata != NULL) {
 		efree(intern->gcdata);
 	}
 
@@ -378,10 +378,6 @@ static HashTable *spl_object_storage_get_gc(zval *obj, zval ***table, int *n TSR
 	long requiredLength = intern->storage.nNumOfElements * 2;
 
 	if (requiredLength > intern->gcdata_len) {
-		if (intern->gcdata_len > 0) {
-			efree(intern->gcdata);
-		}
-
 		intern->gcdata = (zval**)erealloc(intern->gcdata, sizeof(zval*) * requiredLength);
 		intern->gcdata_len = requiredLength;
 	}
@@ -394,7 +390,7 @@ static HashTable *spl_object_storage_get_gc(zval *obj, zval ***table, int *n TSR
 	}
 
 	*table = intern->gcdata;
-	*n = intern->gcdata_len;
+	*n = i;
 
 	return std_object_handlers.get_properties(obj TSRMLS_CC);
 }

--- a/ext/spl/tests/bug53071.phpt
+++ b/ext/spl/tests/bug53071.phpt
@@ -23,5 +23,5 @@ echo "Done.\n";
 
 ?>
 --EXPECTF--
-int(5)
+int(4)
 Done.

--- a/ext/spl/tests/bug65967.phpt
+++ b/ext/spl/tests/bug65967.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #65967: SplObjectStorage contains corrupt member variables after garbage collection
+--INI--
+zend.enable_gc=1
+--FILE--
+<?php
+$objstore = new SplObjectStorage();
+gc_collect_cycles();
+
+var_export($objstore);
+?>
+--EXPECT--
+SplObjectStorage::__set_state(array(
+))


### PR DESCRIPTION
See https://bugs.php.net/bug.php?id=69227

**The old**:
SplObjectStorage had a get_gc method that returns SplObjectStorage->properties. A hidden `\x00gcdata` property is added as an array so the gc can iterate over the contents of the collection. This was added to address https://bugs.php.net/bug.php?id=53071. 

When a SplObjectStorage has a reference to itself in its collection (directly or indirectly) the gc will fetch a copy of gcdata, then going depth first into its children it hits itself a second time at which point it truncates the existing gcdata hash and fills it with the same data. This frees the pointer being held by the first pass of gcdata. Use after free ensues.

**The new**:
This patch removes the hidden `\x00gcdata` property from SplObjectStorage, replacing it with a list of zval*'s. Unlike a linked list updating the contents of a flat array does not invalidate the callers reference. Also the values never really change as the underlying collection does not change during gc

This fixes the free after use, and other bugs resulting from gcdata being a property (eg https://bugs.php.net/bug.php?id=65967)

This is broken in 5.* and master, but master will require a different patch as the gc has changed a little.