### PR TITLE
Fix #69203: FILTER_FLAG_STRIP_HIGH doesn't strip ASCII 127

### DIFF
--- a/ext/filter/sanitizing_filters.c
+++ b/ext/filter/sanitizing_filters.c
@@ -123,7 +123,7 @@ static void php_filter_strip(zval *value, zend_long flags)
 	buf = zend_string_alloc(Z_STRLEN_P(value) + 1, 0);
 	c = 0;
 	for (i = 0; i < Z_STRLEN_P(value); i++) {
-		if ((str[i] > 127) && (flags & FILTER_FLAG_STRIP_HIGH)) {
+		if ((str[i] >= 127) && (flags & FILTER_FLAG_STRIP_HIGH)) {
 		} else if ((str[i] < 32) && (flags & FILTER_FLAG_STRIP_LOW)) {
 		} else if ((str[i] == '`') && (flags & FILTER_FLAG_STRIP_BACKTICK)) {
 		} else {


### PR DESCRIPTION
FILTER_FLAG_STRIP_HIGH was inconsistent wit
FILTER_FLAG_ENCODE_HIGH: the second was encoding ASCII 12,
where the first was not.