### PR TITLE
Enables GCC global register variables for ppc64le

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -427,6 +427,9 @@ if test "$ZEND_GCC_GLOBAL_REGS" != "no"; then
 #elif defined(__GNUC__) && defined(__x86_64__)
 # define ZEND_VM_FP_GLOBAL_REG "%r14"
 # define ZEND_VM_IP_GLOBAL_REG "%r15"
+#elif defined(__GNUC__) && defined(__powerpc64__)
+# define ZEND_VM_FP_GLOBAL_REG "r28"
+# define ZEND_VM_IP_GLOBAL_REG "r29"
 #else
 # error "global register variables are not supported"
 #endif

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2056,6 +2056,9 @@ static zend_always_inline void zend_vm_stack_extend_call_frame(zend_execute_data
 # elif defined(__GNUC__) && defined(__x86_64__)
 #  define ZEND_VM_FP_GLOBAL_REG "%r14"
 #  define ZEND_VM_IP_GLOBAL_REG "%r15"
+# elif defined(__GNUC__) && defined(__powerpc64__)
+#  define ZEND_VM_FP_GLOBAL_REG "r28"
+#  define ZEND_VM_IP_GLOBAL_REG "r29"
 # endif
 #endif
 


### PR DESCRIPTION
This patch adds support for global register
variables for ppc64le with GCC.