### PR TITLE
Zend Rope String

### DIFF
--- a/Zend/zend_vm_opcodes.c
+++ b/Zend/zend_vm_opcodes.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <zend.h>
 
-const char *zend_vm_opcodes_map[171] = {
+const char *zend_vm_opcodes_map[175] = {
 	"ZEND_NOP",
 	"ZEND_ADD",
 	"ZEND_SUB",
@@ -193,6 +193,10 @@ const char *zend_vm_opcodes_map[171] = {
 	"ZEND_BIND_GLOBAL",
 	"ZEND_COALESCE",
 	"ZEND_SPACESHIP",
+	"ZEND_ROPE_INIT",
+	"ZEND_ROPE_ADD_STRING",
+	"ZEND_ROPE_ADD_VAR",
+	"ZEND_ROPE_END",
 };
 
 ZEND_API const char* zend_get_opcode_name(zend_uchar opcode) {

--- a/Zend/zend_vm_opcodes.h
+++ b/Zend/zend_vm_opcodes.h
@@ -199,5 +199,9 @@ END_EXTERN_C()
 #define ZEND_BIND_GLOBAL                     168
 #define ZEND_COALESCE                        169
 #define ZEND_SPACESHIP                       170
+#define ZEND_ROPE_INIT                       171
+#define ZEND_ROPE_ADD_STRING                 172
+#define ZEND_ROPE_ADD_VAR                    173
+#define ZEND_ROPE_END                        174
 
 #endif


### PR DESCRIPTION
This is a underworking further improvement based on  https://github.com/laruence/php-src/tree/encaps_list (which could be committed without questions, no new opcodes)

These two branches aims to improve performance for encaps_list (ZEND_ADD_(STRING|VAR|CHAR)).

but this branch(zend-rope) needs introduce series new opcodes, ZEND_ROPE_(INIT|ADD_STRING|ADD_VAR|END)

However, besides be a good addtion for encaps_list, this also could be a replacement for encaps_list completely.

furthermore, if rope list is introduced,  we could do the similar things to concat list. that is next move.

thanks