### PR TITLE
Move check for __builtin_expect to configure

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -257,9 +257,9 @@ char *alloca();
 # endif
 #endif /* ZEND_DEBUG */
 
-#if (defined (__GNUC__) && __GNUC__ > 2 ) && !defined(DARWIN) && !defined(__hpux) && !defined(_AIX)
-# define EXPECTED(condition)   __builtin_expect(!(!(condition)), 1)
-# define UNEXPECTED(condition) __builtin_expect(!(!(condition)), 0)
+#if PHP_HAVE_BUILTIN_EXPECT
+# define EXPECTED(condition)   __builtin_expect(!!(condition), 1)
+# define UNEXPECTED(condition) __builtin_expect(!!(condition), 0)
 #else
 # define EXPECTED(condition)   (condition)
 # define UNEXPECTED(condition) (condition)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -3031,3 +3031,21 @@ AC_DEFUN([PHP_CHECK_STDINT_TYPES], [
   ])
   AC_DEFINE([PHP_HAVE_STDINT_TYPES], [1], [Checked for stdint types])
 ])
+
+dnl PHP_CHECK_BUILTIN_EXPECT
+AC_DEFUN([PHP_CHECK_BUILTIN_EXPECT], [
+  AC_MSG_CHECKING([for __builtin_expect])
+
+  AC_TRY_LINK(, [
+    return __builtin_expect(1,1) ? 1 : 0;
+  ], [
+    have_builtin_expect=1
+    AC_MSG_RESULT([yes])
+  ], [
+    have_builtin_expect=0
+    AC_MSG_RESULT([no])
+  ])
+
+  AC_DEFINE([PHP_HAVE_BUILTIN_EXPECT], [$have_builtin_expect], [Whether the compiler supports __builtin_expect])
+
+])

--- a/configure.in
+++ b/configure.in
@@ -575,6 +575,9 @@ PHP_CHECK_SIZEOF(ptrdiff_t, 8)
 dnl Check stdint types (must be after header check)
 PHP_CHECK_STDINT_TYPES
 
+dnl Check __builtin_expect
+PHP_CHECK_BUILTIN_EXPECT
+
 dnl Check for members of the stat structure
 AC_STRUCT_ST_BLKSIZE
 dnl AC_STRUCT_ST_BLOCKS will screw QNX because fileblocks.o does not exists


### PR DESCRIPTION
This allows `__builtin_expect` to be used more accurately.

I've checked on a Mac and a Linux machine that it works correctly. Later I am going to test the Intel C Compiler on Linux.

We probably need to test this on a few other setups which I don't have access to:
  - Whatever Visual Studio versions we support
  - AIX
  - HPUX

… and maybe more.