### PR TITLE
Reduce downstream patches

### DIFF
--- a/ext/gd/libgd/gdcache.h
+++ b/ext/gd/libgd/gdcache.h
@@ -41,7 +41,7 @@
 /*********************************************************/
 
 #include <stdlib.h>
-#ifdef HAVE_MALLOC_H
+#if (!defined(__OpenBSD__)) && HAVE_MALLOC_H
  #include <malloc.h>
 #endif
 #ifndef NULL


### PR DESCRIPTION
As per http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/php/5.6/patches/patch-ext_gd_libgd_gdcache_h?rev=1.1&content-type=text/x-cvsweb-markup