### PR TITLE
Fix configure errors for ODBC as standalone extension

### DIFF
--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -108,8 +108,8 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(adabas,,
 [  --with-adabas[=DIR]       Include Adabas D support [/usr/local]],no,no)
 
+  AC_MSG_CHECKING([for Adabas support])
   if test "$PHP_ADABAS" != "no"; then
-    AC_MSG_CHECKING([for Adabas support])
     if test "$PHP_ADABAS" = "yes"; then
       PHP_ADABAS=/usr/local
     fi
@@ -128,6 +128,8 @@ PHP_ARG_WITH(adabas,,
     PHP_ODBC_CHECK_HEADER(sqlext.h)
     AC_DEFINE(HAVE_ADABAS,1,[ ])
     AC_MSG_RESULT([$ext_output])
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -135,8 +137,8 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(sapdb,,
 [  --with-sapdb[=DIR]        Include SAP DB support [/usr/local]],no,no)
 
+  AC_MSG_CHECKING([for SAP DB support])
   if test "$PHP_SAPDB" != "no"; then
-    AC_MSG_CHECKING([for SAP DB support])
     if test "$PHP_SAPDB" = "yes"; then
       PHP_SAPDB=/usr/local
     fi
@@ -146,6 +148,8 @@ PHP_ARG_WITH(sapdb,,
     ODBC_TYPE=sapdb
     AC_DEFINE(HAVE_SAPDB,1,[ ])
     AC_MSG_RESULT([$ext_output])
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -153,8 +157,8 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(solid,,
 [  --with-solid[=DIR]        Include Solid support [/usr/local/solid]],no,no)
 
+  AC_MSG_CHECKING(for Solid support)
   if test "$PHP_SOLID" != "no"; then
-    AC_MSG_CHECKING(for Solid support)
     if test "$PHP_SOLID" = "yes"; then
       PHP_SOLID=/usr/local/solid
     fi
@@ -171,6 +175,8 @@ PHP_ARG_WITH(solid,,
     fi
     AC_MSG_RESULT([$ext_output])
     PHP_ODBC_FIND_SOLID_LIBS($ODBC_LIBDIR)
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -178,8 +184,8 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(ibm-db2,,
 [  --with-ibm-db2[=DIR]      Include IBM DB2 support [/home/db2inst1/sqllib]],no,no)
 
+  AC_MSG_CHECKING(for IBM DB2 support)
   if test "$PHP_IBM_DB2" != "no"; then
-    AC_MSG_CHECKING(for IBM DB2 support)
     if test "$PHP_IBM_DB2" = "yes"; then
       ODBC_INCDIR=/home/db2inst1/sqllib/include
       ODBC_LIBDIR=/home/db2inst1/sqllib/lib
@@ -208,6 +214,8 @@ You need to source your DB2 environment before running PHP configure:
     ], [
       $ODBC_LFLAGS $ODBC_LIBS
     ])
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -215,8 +223,8 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(ODBCRouter,,
 [  --with-ODBCRouter[=DIR]   Include ODBCRouter.com support [/usr]],no,no)
 
+  AC_MSG_CHECKING(for ODBCRouter.com support)
   if test "$PHP_ODBCROUTER" != "no"; then
-    AC_MSG_CHECKING(for ODBCRouter.com support)
     if test "$PHP_ODBCROUTER" = "yes"; then
       PHP_ODBCROUTER=/usr
     fi
@@ -228,6 +236,8 @@ PHP_ARG_WITH(ODBCRouter,,
     ODBC_TYPE=ODBCRouter
     AC_DEFINE(HAVE_ODBC_ROUTER,1,[ ])
     AC_MSG_RESULT([$ext_output])
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -236,8 +246,8 @@ PHP_ARG_WITH(empress,,
 [  --with-empress[=DIR]      Include Empress support [\$EMPRESSPATH]
                           (Empress Version >= 8.60 required)],no,no)
 
+  AC_MSG_CHECKING(for Empress support)
   if test "$PHP_EMPRESS" != "no"; then
-    AC_MSG_CHECKING(for Empress support)
     if test "$PHP_EMPRESS" = "yes"; then
       ODBC_INCDIR=$EMPRESSPATH/include/odbc
       ODBC_LIBDIR=$EMPRESSPATH/shlib
@@ -251,6 +261,8 @@ PHP_ARG_WITH(empress,,
     AC_DEFINE(HAVE_EMPRESS,1,[ ])
     AC_MSG_RESULT([$ext_output])
     PHP_ODBC_FIND_EMPRESS_LIBS($ODBC_LIBDIR)
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -260,8 +272,8 @@ PHP_ARG_WITH(empress-bcs,,
                           Include Empress Local Access support [\$EMPRESSPATH]
                           (Empress Version >= 8.60 required)],no,no)
 
+  AC_MSG_CHECKING(for Empress local access support)
   if test "$PHP_EMPRESS_BCS" != "no"; then
-    AC_MSG_CHECKING(for Empress local access support)
     if test "$PHP_EMPRESS_BCS" = "yes"; then
       ODBC_INCDIR=$EMPRESSPATH/include/odbc
       ODBC_LIBDIR=$EMPRESSPATH/shlib
@@ -291,6 +303,8 @@ PHP_ARG_WITH(empress-bcs,,
     AC_DEFINE(HAVE_EMPRESS,1,[ ])
     AC_MSG_RESULT([$ext_output])
     PHP_ODBC_FIND_EMPRESS_BCS_LIBS($ODBC_LIBDIR)
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -298,8 +312,8 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(birdstep,,
 [  --with-birdstep[=DIR]     Include Birdstep support [/usr/local/birdstep]],no,no)
   
+  AC_MSG_CHECKING(for Birdstep support)
   if test "$PHP_BIRDSTEP" != "no"; then
-    AC_MSG_CHECKING(for Birdstep support)
     if test "$PHP_BIRDSTEP" = "yes"; then
         ODBC_INCDIR=/usr/local/birdstep/include
         ODBC_LIBDIR=/usr/local/birdstep/lib
@@ -338,6 +352,8 @@ PHP_ARG_WITH(birdstep,,
 
     AC_DEFINE(HAVE_BIRDSTEP,1,[ ])
     AC_MSG_RESULT([$ext_output])
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -352,8 +368,8 @@ PHP_ARG_WITH(custom-odbc,,
                             LDFLAGS=-lunix
                             CUSTOM_ODBC_LIBS=\"-ldblib -lodbc\"],no,no)
 
+  AC_MSG_CHECKING(for a custom ODBC support)
   if test "$PHP_CUSTOM_ODBC" != "no"; then
-    AC_MSG_CHECKING(for a custom ODBC support)
     if test "$PHP_CUSTOM_ODBC" = "yes"; then
       PHP_CUSTOM_ODBC=/usr/local
     fi
@@ -365,6 +381,8 @@ PHP_ARG_WITH(custom-odbc,,
     ODBC_TYPE=custom-odbc
     AC_DEFINE(HAVE_CODBC,1,[ ])
     AC_MSG_RESULT([$ext_output])
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -372,8 +390,8 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(iodbc,,
 [  --with-iodbc[=DIR]        Include iODBC support [/usr/local]],no,no)
 
+  AC_MSG_CHECKING(for iODBC support)
   if test "$PHP_IODBC" != "no"; then
-    AC_MSG_CHECKING(for iODBC support)
     if test -z "$PKG_CONFIG"; then
       AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
     fi 
@@ -401,6 +419,8 @@ PHP_ARG_WITH(iodbc,,
       AC_DEFINE(HAVE_ODBC2,1,[ ])
       AC_MSG_RESULT([$ext_output])
     fi
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -408,8 +428,8 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(esoob,,
 [  --with-esoob[=DIR]        Include Easysoft OOB support [/usr/local/easysoft/oob/client]],no,no)
 
+  AC_MSG_CHECKING(for Easysoft ODBC-ODBC Bridge support)
   if test "$PHP_ESOOB" != "no"; then
-    AC_MSG_CHECKING(for Easysoft ODBC-ODBC Bridge support)
     if test "$PHP_ESOOB" = "yes"; then
       PHP_ESOOB=/usr/local/easysoft/oob/client
     fi
@@ -444,6 +464,8 @@ PHP_ARG_WITH(unixODBC,,
     PHP_ODBC_CHECK_HEADER(sqlext.h)
     AC_DEFINE(HAVE_UNIXODBC,1,[ ])
     AC_MSG_RESULT([$ext_output])
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
@@ -451,8 +473,8 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(dbmaker,,
 [  --with-dbmaker[=DIR]      Include DBMaker support],no,no)
 
+  AC_MSG_CHECKING(for DBMaker support)
   if test "$PHP_DBMAKER" != "no"; then
-    AC_MSG_CHECKING(for DBMaker support)
     if test "$PHP_DBMAKER" = "yes"; then
       # find dbmaker's home directory
       DBMAKER_HOME=`grep "^dbmaker:" /etc/passwd | $AWK -F: '{print $6}'`
@@ -494,6 +516,8 @@ PHP_ARG_WITH(dbmaker,,
       PHP_ADD_INCLUDE($ODBC_INCDIR)
       ODBC_STATIC="libphpext_odbc.la"
     fi
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -106,7 +106,7 @@ PHP_ARG_WITH(odbcver,,
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(adabas,,
-[  --with-adabas[=DIR]       Include Adabas D support [/usr/local]])
+[  --with-adabas[=DIR]       Include Adabas D support [/usr/local]],no,no)
 
   if test "$PHP_ADABAS" != "no"; then
     AC_MSG_CHECKING([for Adabas support])
@@ -133,7 +133,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(sapdb,,
-[  --with-sapdb[=DIR]        Include SAP DB support [/usr/local]])
+[  --with-sapdb[=DIR]        Include SAP DB support [/usr/local]],no,no)
 
   if test "$PHP_SAPDB" != "no"; then
     AC_MSG_CHECKING([for SAP DB support])
@@ -151,7 +151,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(solid,,
-[  --with-solid[=DIR]        Include Solid support [/usr/local/solid]])
+[  --with-solid[=DIR]        Include Solid support [/usr/local/solid]],no,no)
 
   if test "$PHP_SOLID" != "no"; then
     AC_MSG_CHECKING(for Solid support)
@@ -176,7 +176,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(ibm-db2,,
-[  --with-ibm-db2[=DIR]      Include IBM DB2 support [/home/db2inst1/sqllib]])
+[  --with-ibm-db2[=DIR]      Include IBM DB2 support [/home/db2inst1/sqllib]],no,no)
 
   if test "$PHP_IBM_DB2" != "no"; then
     AC_MSG_CHECKING(for IBM DB2 support)
@@ -213,7 +213,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(ODBCRouter,,
-[  --with-ODBCRouter[=DIR]   Include ODBCRouter.com support [/usr]])
+[  --with-ODBCRouter[=DIR]   Include ODBCRouter.com support [/usr]],no,no)
 
   if test "$PHP_ODBCROUTER" != "no"; then
     AC_MSG_CHECKING(for ODBCRouter.com support)
@@ -234,7 +234,7 @@ fi
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(empress,,
 [  --with-empress[=DIR]      Include Empress support [\$EMPRESSPATH]
-                          (Empress Version >= 8.60 required)])
+                          (Empress Version >= 8.60 required)],no,no)
 
   if test "$PHP_EMPRESS" != "no"; then
     AC_MSG_CHECKING(for Empress support)
@@ -258,7 +258,7 @@ if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(empress-bcs,,
 [  --with-empress-bcs[=DIR]
                           Include Empress Local Access support [\$EMPRESSPATH]
-                          (Empress Version >= 8.60 required)])
+                          (Empress Version >= 8.60 required)],no,no)
 
   if test "$PHP_EMPRESS_BCS" != "no"; then
     AC_MSG_CHECKING(for Empress local access support)
@@ -296,7 +296,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(birdstep,,
-[  --with-birdstep[=DIR]     Include Birdstep support [/usr/local/birdstep]])
+[  --with-birdstep[=DIR]     Include Birdstep support [/usr/local/birdstep]],no,no)
   
   if test "$PHP_BIRDSTEP" != "no"; then
     AC_MSG_CHECKING(for Birdstep support)
@@ -350,7 +350,7 @@ PHP_ARG_WITH(custom-odbc,,
                           running this configure script:
                             CPPFLAGS=\"-DODBC_QNX -DSQLANY_BUG\"
                             LDFLAGS=-lunix
-                            CUSTOM_ODBC_LIBS=\"-ldblib -lodbc\"])
+                            CUSTOM_ODBC_LIBS=\"-ldblib -lodbc\"],no,no)
 
   if test "$PHP_CUSTOM_ODBC" != "no"; then
     AC_MSG_CHECKING(for a custom ODBC support)
@@ -370,7 +370,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(iodbc,,
-[  --with-iodbc[=DIR]        Include iODBC support [/usr/local]])
+[  --with-iodbc[=DIR]        Include iODBC support [/usr/local]],no,no)
 
   if test "$PHP_IODBC" != "no"; then
     AC_MSG_CHECKING(for iODBC support)
@@ -406,7 +406,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(esoob,,
-[  --with-esoob[=DIR]        Include Easysoft OOB support [/usr/local/easysoft/oob/client]])
+[  --with-esoob[=DIR]        Include Easysoft OOB support [/usr/local/easysoft/oob/client]],no,no)
 
   if test "$PHP_ESOOB" != "no"; then
     AC_MSG_CHECKING(for Easysoft ODBC-ODBC Bridge support)
@@ -421,15 +421,17 @@ PHP_ARG_WITH(esoob,,
     ODBC_TYPE=esoob
     AC_DEFINE(HAVE_ESOOB,1,[ ])
     AC_MSG_RESULT([$ext_output])
+  else
+    AC_MSG_RESULT(no)
   fi
 fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(unixODBC,,
-[  --with-unixODBC[=DIR]     Include unixODBC support [/usr/local]])
+[  --with-unixODBC[=DIR]     Include unixODBC support [/usr/local]],no,no)
 
+  AC_MSG_CHECKING(for unixODBC support)
   if test "$PHP_UNIXODBC" != "no"; then
-    AC_MSG_CHECKING(for unixODBC support)
     if test "$PHP_UNIXODBC" = "yes"; then
       PHP_UNIXODBC=/usr/local
     fi
@@ -447,7 +449,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(dbmaker,,
-[  --with-dbmaker[=DIR]      Include DBMaker support])
+[  --with-dbmaker[=DIR]      Include DBMaker support],no,no)
 
   if test "$PHP_DBMAKER" != "no"; then
     AC_MSG_CHECKING(for DBMaker support)
@@ -525,4 +527,7 @@ if test -n "$ODBC_TYPE"; then
   PHP_SUBST_OLD(ODBC_TYPE)
 
   PHP_NEW_EXTENSION(odbc, php_odbc.c, $ext_shared,, $ODBC_INCLUDE)
+else
+  AC_MSG_CHECKING([for any ODBC driver support])
+  AC_MSG_RESULT(no)
 fi


### PR DESCRIPTION
When building ODBC extension as a standalone extension (phpize), each ODBC driver defaults to yes and thus all it's triggers are being executed. This results to errors as the required environment isn't there (e.g. adabas while building unixODBC).