### PR TITLE
Update NEWS with Group Use Declarations

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,7 +56,8 @@
   . Added error_clear_last() function. (Reeze Xia)
   . Fixed bug #68797 (Number 2.2250738585072012e-308 converted incorrectly).
     (Anatol)
-  . Implemented the RFC `Scalar Type Decalarations v0.5` (Anthony) 
+  . Implemented the RFC `Scalar Type Decalarations v0.5`. (Anthony)
+  . Implemented the RFC `Group Use Declarations`. (Marcio)
 
 - Curl:
   . Fixed bug #68937 (Segfault in curl_multi_exec). (Laruence)


### PR DESCRIPTION
Sorry for the overly wee PR, but I just noticed we have a **NEWS** file that should have been updated when #1005 was merged.

Thanks.