### PR TITLE
Php 5.5 spl class extend https://bugs.php.net/bug.php?id=69275

### DIFF
--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -29,20 +29,16 @@ ZEND_API zend_class_entry *zend_ce_iterator;
 ZEND_API zend_class_entry *zend_ce_arrayaccess;
 ZEND_API zend_class_entry *zend_ce_serializable;
 
+
 /* {{{ zend_call_method
  Only returns the returned zval if retval_ptr != NULL */
-ZEND_API zval* zend_call_method(zval **object_pp, zend_class_entry *obj_ce, zend_function **fn_proxy, const char *function_name, int function_name_len, zval **retval_ptr_ptr, int param_count, zval* arg1, zval* arg2 TSRMLS_DC)
+ZEND_API zval* zend_call_method_params(zval **object_pp, zend_class_entry *obj_ce, zend_function **fn_proxy, const char *function_name, int function_name_len, zval **retval_ptr_ptr, int param_count, zval ***params TSRMLS_DC)
 {
 	int result;
 	zend_fcall_info fci;
 	zval z_fname;
 	zval *retval;
 	HashTable *function_table;
-
-	zval **params[2];
-
-	params[0] = &arg1;
-	params[1] = &arg2;
 
 	fci.size = sizeof(fci);
 	/*fci.function_table = NULL; will be read form zend_class_entry of object if needed */
@@ -112,6 +108,25 @@ ZEND_API zval* zend_call_method(zval **object_pp, zend_class_entry *obj_ce, zend
 		return NULL;
 	}
 	return *retval_ptr_ptr;
+}
+/* }}} */
+
+
+/* {{{ zend_call_method
+ Only returns the returned zval if retval_ptr != NULL */
+ZEND_API zval* zend_call_method(zval **object_pp, zend_class_entry *obj_ce, zend_function **fn_proxy, const char *function_name, int function_name_len, zval **retval_ptr_ptr, int param_count, zval* arg1, zval* arg2 TSRMLS_DC)
+{
+
+	zval **params[2];
+
+	params[0] = &arg1;
+	params[1] = &arg2;
+
+	return zend_call_method_params(
+		object_pp, obj_ce, fn_proxy, function_name, function_name_len,
+		retval_ptr_ptr, param_count, params TSRMLS_CC
+	);
+
 }
 /* }}} */
 

--- a/Zend/zend_interfaces.h
+++ b/Zend/zend_interfaces.h
@@ -49,6 +49,9 @@ ZEND_API zval* zend_call_method(zval **object_pp, zend_class_entry *obj_ce, zend
 #define zend_call_method_with_2_params(obj, obj_ce, fn_proxy, function_name, retval, arg1, arg2) \
 	zend_call_method(obj, obj_ce, fn_proxy, function_name, sizeof(function_name)-1, retval, 2, arg1, arg2 TSRMLS_CC)
 
+#define zend_call_method_with_params(obj, obj_ce, fn_proxy, function_name, retval, num_params, params) \
+	zend_call_method_params(obj, obj_ce, fn_proxy, function_name, sizeof(function_name)-1, retval, num_params, params TSRMLS_CC)
+
 ZEND_API void zend_user_it_rewind(zend_object_iterator *_iter TSRMLS_DC);
 ZEND_API int zend_user_it_valid(zend_object_iterator *_iter TSRMLS_DC);
 ZEND_API void zend_user_it_get_current_key(zend_object_iterator *_iter, zval *key TSRMLS_DC);

--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -1039,17 +1039,23 @@ SPL_METHOD(SplHeap, rewind)
 SPL_METHOD(SplHeap, current)
 {
 	spl_heap_object *intern  = (spl_heap_object*)zend_object_store_get_object(getThis() TSRMLS_CC);
-	zval            *element = (zval *)intern->heap->elements[0];
-	
+	zval            *element;
+
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
 	}
 
-	if (!intern->heap->count || !element) {
+	if (!intern->heap->count) {
 		RETURN_NULL();
-	} else {
-		RETURN_ZVAL(element, 1, 0);
 	}
+
+	element = (zval *)intern->heap->elements[0];
+
+	if (!element) {
+		RETURN_NULL();
+	}
+
+	RETURN_ZVAL(element, 1, 0);
 }
 /* }}} */
 

--- a/ext/spl/tests/bug69275.phpt
+++ b/ext/spl/tests/bug69275.phpt
@@ -1,0 +1,63 @@
+--TEST--
+SPL: Inheritance of SplFileObject, SplFileInfo misses constructor code.
+--FILE--
+<?php
+
+class TestFileObject extends \SplFileObject {
+    public function __construct($file_name, $open_mode = 'r', $use_include_path = false, $context = null) {
+        if (is_resource($context)) {
+            parent::__construct($file_name, $open_mode, $use_include_path, $context);
+        }
+        else {
+            parent::__construct($file_name, $open_mode, $use_include_path);
+        }
+    }
+}
+
+class TestFileInfo extends \SplFileInfo {
+    function __construct($file_name) {
+        parent::__construct($file_name);
+    } 
+}
+
+$filename = dirname(__FILE__) . '/foo.temp';
+
+//Test that the fileInfo to fileObject works
+$fileInfo = new SplFileInfo($filename);
+$fileInfo->setFileClass('TestFileObject');
+$fileInstance = $fileInfo->openFile('w+');
+
+if (!($fileInstance instanceof TestFileObject)) {
+    echo "Incorrect type of fileInstance ".get_class($fileInstance).PHP_EOL;
+}
+
+
+$filename2 = dirname(__FILE__) . '/foo2.temp';
+//Test that the fileObject to fileInfo works
+$fileObject = new SplFileObject($filename2, 'w+');
+$fileObject->setInfoClass('TestFileInfo');
+$fileInfo = $fileObject->getFileInfo();
+
+if (!($fileInfo instanceof TestFileInfo)) {
+echo "Incorrect type of fileInfo ".get_class($fileInstance).PHP_EOL;
+}
+
+$fsIterator = new FilesystemIterator( dirname(__FILE__), FilesystemIterator::SKIP_DOTS);
+$fsIterator->setInfoClass('TestFileInfo');
+$fsIterator->setFileClass('TestFileObject');
+foreach ($fsIterator as $fsEntry) {
+    if (!($fsEntry instanceof TestFileInfo)) {
+        echo "Incorrect type of fileInfo ".get_class($fsEntry).PHP_EOL;
+    }
+}
+
+?>
+===DONE===
+--CLEAN--
+<?php
+unlink(dirname(__FILE__) . '/foo.temp');
+unlink(dirname(__FILE__) . '/foo2.temp');
+?>
+--EXPECT--
+
+===DONE===

--- a/ext/spl/tests/dit_004.phpt
+++ b/ext/spl/tests/dit_004.phpt
@@ -4,21 +4,36 @@ SPL: DirectoryIterator and clone
 <?php
 $a = new DirectoryIterator(__DIR__);
 $b = clone $a;
-var_dump((string)$b == (string)$a);
+
+$bValue = (string)$b;
+$aValue = (string)$a;
+if ($aValue != $bValue) {
+	echo "aValue and bValue should be the same".PHP_EOL;
+	echo $aValue.PHP_EOL;
+	echo $bValue.PHP_EOL;
+}
+
 var_dump($a->key(), $b->key());
 $a->next();
 $a->next();
 $a->next();
 $c = clone $a;
-var_dump((string)$c == (string)$a);
+
+$cValue = (string)$c;
+$aValue = (string)$a;
+if ($aValue != $cValue) {
+	echo "aValue and cValue should be the same".PHP_EOL;
+	echo $aValue.PHP_EOL;
+	echo $cValue.PHP_EOL;
+}
+
 var_dump($a->key(), $c->key());
+
 ?>
 ===DONE===
 --EXPECTF--
-bool(true)
 int(0)
 int(0)
-bool(true)
 int(3)
 int(3)
 ===DONE===

--- a/ext/spl/tests/dit_005.phpt
+++ b/ext/spl/tests/dit_005.phpt
@@ -4,19 +4,44 @@ SPL: FilesystemIterator and clone
 <?php
 $a = new FileSystemIterator(__DIR__);
 $b = clone $a;
-var_dump((string)$b == (string)$a);
-var_dump($a->key() == $b->key());
+$bValue = (string)$b;
+$aValue = (string)$a;
+if ($aValue != $bValue) {
+	echo "aValue and bValue should be the same".PHP_EOL;
+	echo $aValue.PHP_EOL;
+	echo $bValue.PHP_EOL;
+}
+
+$aKey = $a->key();
+$bKey = $b->key();
+if ($aKey != $bKey) {
+	echo "aKey and bKey should be the same".PHP_EOL;
+	echo $aKey.PHP_EOL;
+	echo $bKey.PHP_EOL;
+}
+
 $a->next();
 $a->next();
 $a->next();
+
 $c = clone $a;
-var_dump((string)$c == (string)$a);
-var_dump($a->key() == $c->key());
+
+$cValue = (string)$c;
+$aValue = (string)$a;
+if ($aValue != $cValue) {
+	echo "aValue and cValue should be the same".PHP_EOL;
+	echo $aValue.PHP_EOL;
+	echo $cValue.PHP_EOL;
+}
+
+$aKey = $a->key();
+$cKey = $c->key();
+if ($aKey != $cKey) {
+	echo "aKey and cKey should be the same".PHP_EOL;
+	echo $aKey.PHP_EOL;
+	echo $cKey.PHP_EOL;
+}
 ?>
 ===DONE===
 --EXPECTF--
-bool(true)
-bool(true)
-bool(true)
-bool(true)
 ===DONE===


### PR DESCRIPTION
Fix https://bugs.php.net/bug.php?id=69275 constructor not called correctly for extended class.

When a user specifies which class should be created for each 'file object' by having set `$fileInfo->setFileClass('TestFileObject');` the constructor was not being called correctly, with arguments 3 and 4 being missed entirely, and with argument 2 being hard-coded to 'r' aka read only. The change is to call the constructor properly. As the constructor has more than 2 args, I refactored zend_call_method to allow arbitrary number of params.

This PR probably needs discussion before merging. 
