### PR TITLE
Fixed test case

### DIFF
--- a/ext/phar/tests/phar_get_supported_signatures_001.phpt
+++ b/ext/phar/tests/phar_get_supported_signatures_001.phpt
@@ -17,10 +17,14 @@ var_dump(Phar::getSupportedSignatures());
 ===DONE===
 ?>
 --EXPECT--
-array(2) {
+array(4) {
   [0]=>
   string(3) "MD5"
   [1]=>
   string(5) "SHA-1"
+  [2]=>
+  string(7) "SHA-256"
+  [3]=>
+  string(7) "SHA-512"
 }
 ===DONE===


### PR DESCRIPTION
This test case must running without the hash extension, so long time was not found the failure.
