### PR TITLE
Fix bug 69291

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -880,8 +880,8 @@ static inline int do_validate_timestamps(zend_persistent_script *persistent_scri
 
 int validate_timestamp_and_record(zend_persistent_script *persistent_script, zend_file_handle *file_handle TSRMLS_DC)
 {
-	if (ZCG(accel_directives).revalidate_freq &&
-	    persistent_script->dynamic_members.revalidate >= ZCG(request_time)) {
+	if ((!ZCG(accel_directives).validate_timestamps) || (ZCG(accel_directives).revalidate_freq &&
+		persistent_script->dynamic_members.revalidate >= ZCG(request_time))) {
 		return SUCCESS;
 	} else if (do_validate_timestamps(persistent_script, file_handle TSRMLS_CC) == FAILURE) {
 		return FAILURE;

--- a/ext/opcache/tests/bug69281.phpt
+++ b/ext/opcache/tests/bug69281.phpt
@@ -1,10 +1,10 @@
 --TEST--
-Test that script cached info is correct
+Test that script cached info is correct with validate_timestamps disabled
 --INI--
 opcache.enable=1
 opcache.enable_cli=1
 opcache.file_update_protection=0
-opcache.validate_timestamps=1
+opcache.validate_timestamps=0
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
 --FILE--


### PR DESCRIPTION
Fix bug testing whether timestamp. When validate_timestamps is set to 0, the timestamp field is not set, and so should not be used for testing whether the script is valid or not.

https://bugs.php.net/bug.php?id=69281

Probably needs to be applied to all versions.