### PR TITLE
SSLv3 and “Stream Socket Transports”

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1250,7 +1250,9 @@ PHP_MINIT_FUNCTION(openssl)
 	}
 
 	php_stream_xport_register("ssl", php_openssl_ssl_socket_factory);
+#ifndef OPENSSL_NO_SSL3
 	php_stream_xport_register("sslv3", php_openssl_ssl_socket_factory);
+#endif
 #ifndef OPENSSL_NO_SSL2
 	php_stream_xport_register("sslv2", php_openssl_ssl_socket_factory);
 #endif
@@ -1299,7 +1301,9 @@ PHP_MSHUTDOWN_FUNCTION(openssl)
 #ifndef OPENSSL_NO_SSL2
 	php_stream_xport_unregister("sslv2");
 #endif
+#ifndef OPENSSL_NO_SSL3
 	php_stream_xport_unregister("sslv3");
+#endif
 	php_stream_xport_unregister("tls");
 	php_stream_xport_unregister("tlsv1.0");
 #if OPENSSL_VERSION_NUMBER >= 0x10001001L


### PR DESCRIPTION
When OpenSSL is compiled with `no-ssl3` it still shows up under “Stream Socket Transports”. In the file [`xp_ssl.c`](https://github.com/php/php-src/blob/master/ext/openssl/xp_ssl.c#L966-980) there are checks for both sslv2/3 and will throw an error when they're used and not present. I think it's good to remove both if we know they won't work. And it's kind of misleading, to register something that isn't there.

*(Asked Wez about this and he suggested me to do a PR)*