### PR TITLE
Implemented FR #55716 - Add an option to pass a custom stream context

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2583,6 +2583,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_get_headers, 0, 0, 1)
 	ZEND_ARG_INFO(0, url)
 	ZEND_ARG_INFO(0, format)
+	ZEND_ARG_INFO(0, context)
 ZEND_END_ARG_INFO()
 /* }}} */
 /* {{{ user_filters.c */

--- a/ext/standard/tests/url/get_headers_error_001.phpt
+++ b/ext/standard/tests/url/get_headers_error_001.phpt
@@ -5,7 +5,7 @@ June Henriksen <juneih@redpill-linpro.com>
 #PHPTestFest2009 Norway 2009-06-09 \o/
 --FILE--
 <?php
-/* Prototype  : proto array get_headers(string url[, int format])
+/* Prototype  : proto array get_headers(string url[, int format[, resource $context]])
  * Description: Fetches all the headers sent by the server in response to a HTTP request
  * Source code: ext/standard/url.c
  * Alias to functions:
@@ -21,8 +21,9 @@ var_dump( get_headers() );
 echo "\n-- Testing get_headers() function with more than expected no. of arguments --\n";
 $url       = 'string_val';
 $format    = 1;
+$context   = stream_context_get_default();
 $extra_arg = 10;
-var_dump( get_headers($url, $format, $extra_arg) );
+var_dump( get_headers($url, $format, $context, $extra_arg) );
 
 echo "Done";
 ?>
@@ -36,7 +37,7 @@ NULL
 
 -- Testing get_headers() function with more than expected no. of arguments --
 
-Warning: get_headers() expects at most 2 parameters, 3 given in %s on line 19
+Warning: get_headers() expects at most 3 parameters, 4 given in %s on line 20
 NULL
 Done
 

--- a/ext/standard/tests/url/get_headers_error_003.phpt
+++ b/ext/standard/tests/url/get_headers_error_003.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test get_headers() function : test with context
+--FILE--
+<?php
+
+include dirname(__FILE__)."/../../../../sapi/cli/tests/php_cli_server.inc";
+php_cli_server_start('header("X-Request-Method: ".$_SERVER["REQUEST_METHOD"]);');
+
+$opts = array(
+  'http' => array(
+    'method' => 'HEAD'
+  )
+);
+
+$context = stream_context_create($opts);
+$headers = get_headers("http://".PHP_CLI_SERVER_ADDRESS, 1, $context);
+echo $headers["X-Request-Method"]."\n";
+
+stream_context_set_default($opts);
+$headers = get_headers("http://".PHP_CLI_SERVER_ADDRESS, 1);
+echo $headers["X-Request-Method"]."\n";
+
+echo "Done";
+?>
+--EXPECTF--
+HEAD
+HEAD
+Done
+
+
+

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -719,7 +719,7 @@ PHP_FUNCTION(get_headers)
 	HashTable *hashT;
 	zend_long format = 0;
 	zval *zcontext = NULL;
-	php_stream_context *context = NULL;
+	php_stream_context *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|lr!", &url, &url_len, &format, &zcontext) == FAILURE) {
 		return;

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -721,7 +721,7 @@ PHP_FUNCTION(get_headers)
 	zval *zcontext = NULL;
 	php_stream_context *context = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|lr", &url, &url_len, &format, &zcontext) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|lr!", &url, &url_len, &format, &zcontext) == FAILURE) {
 		return;
 	}
 

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -708,22 +708,24 @@ PHPAPI size_t php_raw_url_decode(char *str, size_t len)
 }
 /* }}} */
 
-/* {{{ proto array get_headers(string url[, int format])
+/* {{{ proto array get_headers(string url[, int format[, resource context]])
    fetches all the headers sent by the server in response to a HTTP request */
 PHP_FUNCTION(get_headers)
 {
 	char *url;
 	size_t url_len;
-	php_stream_context *context;
 	php_stream *stream;
 	zval *prev_val, *hdr = NULL, *h;
 	HashTable *hashT;
 	zend_long format = 0;
+	zval *zcontext = NULL;
+	php_stream_context *context = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &url, &url_len, &format) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|lr", &url, &url_len, &format, &zcontext) == FAILURE) {
 		return;
 	}
-	context = FG(default_context) ? FG(default_context) : (FG(default_context) = php_stream_context_alloc());
+
+	context = php_stream_context_from_zval(zcontext, 0);
 
 	if (!(stream = php_stream_open_wrapper_ex(url, "r", REPORT_ERRORS | STREAM_USE_URL | STREAM_ONLY_GET_HEADERS, NULL, context))) {
 		RETURN_FALSE;


### PR DESCRIPTION
the current way of setting the context options through stream_context_set_default is really clunky (and can cause side-effects as it modifies the global context options obviously).