### PR TITLE
Fixed bug #69336 (Parsing error of strtotime)

### DIFF
--- a/ext/date/lib/tm2unixtime.c
+++ b/ext/date/lib/tm2unixtime.c
@@ -296,6 +296,16 @@ static void do_adjust_special_early(timelib_time* time)
 				break;
 		}
 	}
+
+	switch (time->relative.first_last_day_of) {
+                case 1: /* first */
+                        time->d = 1;
+                        break;
+                case 2: /* last */
+                        time->d = 0;
+                        time->m++;
+                        break;
+	}
 	timelib_do_normalize(time);
 }
 


### PR DESCRIPTION
I found this problem from: https://twitter.com/laruence/status/582766663705083904
This problem can be reproduced if the day num we are parsing is smaller than today's num.

Example:
Today is 31/03/2015, we want get the last day of April
Today is 29/05/2015, we want get the last day of Feb.

