### PR TITLE
Fix #69374 IntlDateFormatter::formatObject returns wrong utf8 value

### DIFF
--- a/ext/intl/dateformat/dateformat_format_object.cpp
+++ b/ext/intl/dateformat/dateformat_format_object.cpp
@@ -146,7 +146,9 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 	}
 
 	//there's no support for relative time in ICU yet
-	timeStyle = (DateFormat::EStyle)(timeStyle & ~DateFormat::kRelative);
+	if (timeStyle != DateFormat::NONE) {
+		timeStyle = (DateFormat::EStyle)(timeStyle & ~DateFormat::kRelative);
+	}
 
 	zend_class_entry *instance_ce = Z_OBJCE_P(object);
 	if (instanceof_function(instance_ce, Calendar_ce_ptr)) {

--- a/ext/intl/dateformat/dateformat_format_object.cpp
+++ b/ext/intl/dateformat/dateformat_format_object.cpp
@@ -189,8 +189,8 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 
 	if (pattern) {
 		 df = new SimpleDateFormat(
-				UnicodeString(Z_STRVAL_P(format), Z_STRLEN_P(format),
-						UnicodeString::kInvariant),
+				UnicodeString(Z_STRVAL_PP(format)),
+				//UnicodeString::fromUTF8(Z_STRVAL_PP(format)), // ICU 4.02
 				Locale::createFromName(locale_str),
 				status);
 

--- a/ext/intl/tests/bug69374.phpt
+++ b/ext/intl/tests/bug69374.phpt
@@ -1,0 +1,24 @@
+--TEST--
+IntlDateFormatter::formatObject(): returns wrong utf8 value when $format param is utf8 string pattern.
+--SKIPIF--
+<?php
+if (!extension_loaded('intl')) die('skip intl extension not enabled'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '50.1.2') >=  0) die('skip for ICU < 50.1.2'); ?>
+--FILE--
+<?php
+$millitimestamp = 1428133423941.0; // 14:43:43 April 04 2015
+$pattern1 = '\'tháng\' MM, y'; // yMM format for Vietnamese
+$pattern2 = 'y년 MMM'; // yMM format for Korean
+$date = IntlCalendar::createInstance('Asia/Ho_Chi_Minh');
+$date->setTime($millitimestamp);
+echo IntlDateFormatter::formatObject($date, $pattern1, 'vi_VN'), "\n";
+echo IntlDateFormatter::formatObject ($date, $pattern2, 'ko_KR'), "\n";
+?>
+==DONE==
+
+--EXPECTF--
+tháng 04, 2015
+2015년 4월
+==DONE==
+
+

--- a/ext/intl/tests/bug69398.phpt
+++ b/ext/intl/tests/bug69398.phpt
@@ -1,0 +1,22 @@
+--TEST--
+IntlDateFormatter::formatObject(): returns wrong value when time style is NONE.
+--SKIPIF--
+<?php
+if (!extension_loaded('intl')) die('skip intl extension not enabled'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '50.1.2') >=  0) die('skip for ICU < 50.1.2'); ?>
+--FILE--
+<?php
+$millitimestamp = 1428133423941.0; // 14:43:43 April 04 2015
+$date = IntlCalendar::createInstance('Asia/Ho_Chi_Minh');
+$date->setTime($millitimestamp);
+echo IntlDateFormatter::formatObject($date, array(IntlDateFormatter::SHORT, IntlDateFormatter::NONE), 'vi_VN'), "\n";
+echo IntlDateFormatter::formatObject ($date, array(IntlDateFormatter::SHORT, IntlDateFormatter::NONE), 'ko_KR'), "\n";
+?>
+==DONE==
+
+--EXPECTF--
+04/04/2015
+15. 4. 4.
+==DONE==
+
+


### PR DESCRIPTION
We can use simple ICU UnicodeString constructor or UnicodeString::fromUTF8