### PR TITLE
Fix #69373 References to deleted XPath query results

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -337,6 +337,8 @@ int dom_node_node_value_write(dom_object *obj, zval *newval)
 		case XML_ATTRIBUTE_NODE:
 			if (nodep->children) {
 				node_list_unlink(nodep->children);
+				php_libxml_node_free_list((xmlNodePtr) nodep->children);
+				nodep->children = NULL;
 			}
 		case XML_TEXT_NODE:
 		case XML_COMMENT_NODE:

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -224,7 +224,7 @@ static void php_libxml_node_free(xmlNodePtr node)
 	}
 }
 
-static void php_libxml_node_free_list(xmlNodePtr node)
+PHP_LIBXML_API void php_libxml_node_free_list(xmlNodePtr node)
 {
 	xmlNodePtr curnode;
 

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -100,6 +100,7 @@ PHP_LIBXML_API int php_libxml_decrement_doc_ref(php_libxml_node_object *object);
 PHP_LIBXML_API xmlNodePtr php_libxml_import_node(zval *object);
 PHP_LIBXML_API zval *php_libxml_register_export(zend_class_entry *ce, php_libxml_export_node export_function);
 /* When an explicit freeing of node and children is required */
+PHP_LIBXML_API void php_libxml_node_free_list(xmlNodePtr node);
 PHP_LIBXML_API void php_libxml_node_free_resource(xmlNodePtr node);
 /* When object dtor is called as node may still be referenced */
 PHP_LIBXML_API void php_libxml_node_decrement_resource(php_libxml_node_object *object);


### PR DESCRIPTION
xmlNodeSetContentLen() calls xmlFreeNode() on node->children. This causes
problems if there are other references around to those children.