### PR TITLE
Fixed phpdbg build broken when dtrace enabled

### DIFF
--- a/Zend/zend_dtrace.c
+++ b/Zend/zend_dtrace.c
@@ -23,6 +23,11 @@
 #include "zend_dtrace.h"
 
 #ifdef HAVE_DTRACE
+
+ZEND_API zend_op_array *(*zend_dtrace_compile_file)(zend_file_handle *file_handle, int type);
+ZEND_API void (*zend_dtrace_execute)(zend_op_array *op_array);
+ZEND_API void (*zend_dtrace_execute_internal)(zend_execute_data *execute_data, zval *return_value);
+
 /* PHP DTrace probes {{{ */
 static inline const char *dtrace_get_executed_filename(void)
 {
@@ -41,9 +46,9 @@ static inline const char *dtrace_get_executed_filename(void)
 ZEND_API zend_op_array *dtrace_compile_file(zend_file_handle *file_handle, int type)
 {
 	zend_op_array *res;
-	DTRACE_COMPILE_FILE_ENTRY(file_handle->opened_path, (char *)file_handle->filename);
+	DTRACE_COMPILE_FILE_ENTRY(file_handle->opened_path->val, (char *)file_handle->filename);
 	res = compile_file(file_handle, type);
-	DTRACE_COMPILE_FILE_RETURN(file_handle->opened_path, (char *)file_handle->filename);
+	DTRACE_COMPILE_FILE_RETURN(file_handle->opened_path->val, (char *)file_handle->filename);
 
 	return res;
 }

--- a/Zend/zend_dtrace.h
+++ b/Zend/zend_dtrace.h
@@ -30,9 +30,9 @@ extern "C" {
 #endif
 
 #ifdef HAVE_DTRACE
-ZEND_API zend_op_array *(*zend_dtrace_compile_file)(zend_file_handle *file_handle, int type);
-ZEND_API void (*zend_dtrace_execute)(zend_op_array *op_array);
-ZEND_API void (*zend_dtrace_execute_internal)(zend_execute_data *execute_data, zval *return_value);
+ZEND_API extern zend_op_array *(*zend_dtrace_compile_file)(zend_file_handle *file_handle, int type);
+ZEND_API extern void (*zend_dtrace_execute)(zend_op_array *op_array);
+ZEND_API extern void (*zend_dtrace_execute_internal)(zend_execute_data *execute_data, zval *return_value);
 
 ZEND_API zend_op_array *dtrace_compile_file(zend_file_handle *file_handle, int type);
 ZEND_API void dtrace_execute_ex(zend_execute_data *execute_data);


### PR DESCRIPTION
This also fixed a zend_string related warning.
