### PR TITLE
Better exception messages

### DIFF
--- a/Zend/tests/assert/expect_002.phpt
+++ b/Zend/tests/assert/expect_002.phpt
@@ -9,8 +9,7 @@ assert(false);
 var_dump(true);
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'AssertionException' with message 'assert(false)' in %sexpect_002.php:%d
+AssertionException: assert(false) in %sexpect_002.php on line %d
 Stack trace:
 #0 %sexpect_002.php(%d): assert(false, 'assert(false)')
 #1 {main}
-  thrown in %sexpect_002.php on line %d

--- a/Zend/tests/assert/expect_007.phpt
+++ b/Zend/tests/assert/expect_007.phpt
@@ -16,7 +16,6 @@ class HeaderMalfunctionException extends AssertionException {}
 assert (preg_match("~^([a-zA-Z0-9-]+)$~", $data["key"]), new HeaderMalfunctionException("malformed key found at {$next} \"{$data["key"]}\""));
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'HeaderMalfunctionException' with message 'malformed key found at 1 "X-HTTP "' in %sexpect_007.php:10
+HeaderMalfunctionException: malformed key found at 1 "X-HTTP " in %sexpect_007.php on line 10
 Stack trace:
 #0 {main}
-  thrown in %sexpect_007.php on line 10

--- a/Zend/tests/assert/expect_009.phpt
+++ b/Zend/tests/assert/expect_009.phpt
@@ -17,9 +17,8 @@ class Two extends One {
 new Two();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'AssertionException' with message 'assert(false)' in %sexpect_009.php:%d
+AssertionException: assert(false) in %sexpect_009.php on line %d
 Stack trace:
 #0 %sexpect_009.php(%d): assert(false, 'assert(false)')
 #1 %sexpect_009.php(%d): Two->__construct()
 #2 {main}
-  thrown in %sexpect_009.php on line %d

--- a/Zend/tests/assert/expect_010.phpt
+++ b/Zend/tests/assert/expect_010.phpt
@@ -15,9 +15,8 @@ class Two extends One {}
 new Two();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'AssertionException' with message 'assert(false)' in %sexpect_010.php:%d
+AssertionException: assert(false) in %sexpect_010.php on line %d
 Stack trace:
 #0 %sexpect_010.php(%d): assert(false, 'assert(false)')
 #1 %sexpect_010.php(%d): One->__construct()
 #2 {main}
-  thrown in %sexpect_010.php on line %d

--- a/Zend/tests/assert/expect_011.phpt
+++ b/Zend/tests/assert/expect_011.phpt
@@ -22,9 +22,8 @@ class Two extends One {}
 new Two();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'AssertionException' with message '[Message]: MyExpectations' in %sexpect_011.php:%d
+AssertionException: [Message]: MyExpectations in %sexpect_011.php on line %d
 Stack trace:
 #0 %sexpect_011.php(%d): assert(false, '[Message]: MyEx...')
 #1 %sexpect_011.php(%d): One->__construct()
 #2 {main}
-  thrown in %sexpect_011.php on line %d

--- a/Zend/tests/bug38624.phpt
+++ b/Zend/tests/bug38624.phpt
@@ -26,9 +26,8 @@ $impl = new impl();
 echo "Done\n";
 ?>
 --EXPECTF--	
-Fatal error: Uncaught exception 'Exception' with message 'doesn't work' in %s:%d
+Exception: doesn't work in %s on line %d
 Stack trace:
 #0 %s(%d): impl->__get('counter')
 #1 %s(%d): impl->__construct()
 #2 {main}
-  thrown in %s on line %d

--- a/Zend/tests/bug41209.phpt
+++ b/Zend/tests/bug41209.phpt
@@ -39,8 +39,7 @@ var_dump(isset($cache[$id]));
 echo "Done\n";
 ?>
 --EXPECTF--	
-Fatal error: Uncaught exception 'ErrorException' with message 'Undefined variable: id' in %s:%d
+ErrorException: Undefined variable: id in %s on line %d
 Stack trace:
 #0 %s(%d): env::errorHandler(8, '%s', '%s', 34, Array)
 #1 {main}
-  thrown in %s on line %d

--- a/Zend/tests/bug41421.phpt
+++ b/Zend/tests/bug41421.phpt
@@ -21,9 +21,8 @@ echo "Done\n";
 --EXPECTF--	
 Warning: feof(): wrapper::stream_eof is not implemented! Assuming EOF in %s on line %d
 
-Fatal error: Uncaught exception 'Exception' in %s:%d
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 [internal function]: wrapper->stream_eof()
 #1 %s(%d): feof(Resource id #%d)
 #2 {main}
-  thrown in %s on line %d

--- a/Zend/tests/bug45805.phpt
+++ b/Zend/tests/bug45805.phpt
@@ -38,11 +38,10 @@ $o = new B;
 $o->bar();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'RuntimeException' in %sbug45805.php:%d
+RuntimeException: (empty message) in %sbug45805.php on line %d
 Stack trace:
 #0 %sbug45805.php(%d): PHPUnit_Util_ErrorHandler::handleError(8, 'Only variables ...', '%s', %d, Array)
 #1 [internal function]: B->foo()
 #2 %sbug45805.php(%d): ReflectionMethod->invoke(Object(B))
 #3 %sbug45805.php(%d): B->bar()
 #4 {main}
-  thrown in %sbug45805.php on line %d

--- a/Zend/tests/bug48228.phpt
+++ b/Zend/tests/bug48228.phpt
@@ -24,9 +24,8 @@ $l_aa->dosome();
 ?>
 --EXPECTF--
 
-Fatal error: Uncaught exception 'Exception' in %s
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 %s(%d): do_throw()
 #1 %s(%d): aa->dosome()
 #2 {main}
-  thrown in %s

--- a/Zend/tests/bug48408.phpt
+++ b/Zend/tests/bug48408.phpt
@@ -23,8 +23,7 @@ catch(Exception $e){
 ?>
 --EXPECTF--
 
-Fatal error: Uncaught exception 'Exception' in %s
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 %s(%d): C->generate(0)
 #1 {main}
-  thrown in %s

--- a/Zend/tests/bug49908.phpt
+++ b/Zend/tests/bug49908.phpt
@@ -20,9 +20,8 @@ new Foo;
 %unicode|string%(3) "Foo"
 %unicode|string%(3) "Bar"
 
-Fatal error: Uncaught exception 'Exception' with message 'Bar' in %s:%d
+Exception: Bar in %s on line %d
 Stack trace:
 #0 %s(7): __autoload('Bar')
 #1 %s(13): __autoload('Foo')
 #2 {main}
-  thrown in %s on line %d

--- a/Zend/tests/bug50005.phpt
+++ b/Zend/tests/bug50005.phpt
@@ -13,7 +13,6 @@ throw new a;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'a' in :%d
+a: (empty message) in Unknown on line %d
 Stack trace:
 #0 {main}
-  thrown in Unknown on line %d

--- a/Zend/tests/bug51394.phpt
+++ b/Zend/tests/bug51394.phpt
@@ -13,8 +13,7 @@ function eh()
 set_error_handler("eh");
 $a = $empty($b);
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'error!' in %sbug51394.php:%d
+Exception: error! in %sbug51394.php on line %d
 Stack trace:
 #0 %sbug51394.php(%d): eh(8, 'Undefined varia%s', '%s', %d, Array)
 #1 {main}
-  thrown in %sbug51394.php on line %d

--- a/Zend/tests/bug53511.phpt
+++ b/Zend/tests/bug53511.phpt
@@ -20,14 +20,13 @@ function test() {
 test();
 echo "bug\n";
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'ops 2' in %sbug53511.php:11
+Exception: ops 2 in %sbug53511.php on line 11
 Stack trace:
 #0 %sbug53511.php(17): test()
 #1 {main}
 
-Next exception 'Exception' with message 'ops 1' in %sbug53511.php:4
+Next Exception: ops 1 in %sbug53511.php on line 4
 Stack trace:
 #0 %sbug53511.php(12): Foo->__destruct()
 #1 %sbug53511.php(17): test()
 #2 {main}
-  thrown in %sbug53511.php on line 4

--- a/Zend/tests/bug60738_variation.phpt
+++ b/Zend/tests/bug60738_variation.phpt
@@ -16,8 +16,7 @@ NULL
 object(Closure)#1 (0) {
 }
 
-Fatal error: Uncaught exception 'Exception' with message 'Exception!' in %s:%d
+Exception: Exception! in %s on line %d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d
 

--- a/Zend/tests/bug60909_1.phpt
+++ b/Zend/tests/bug60909_1.phpt
@@ -11,12 +11,11 @@ set_error_handler(function($errno, $errstr, $errfile, $errline){
 require 'notfound.php';
 --EXPECTF--
 error(require(notfound.php): failed to open stream: %s)
-Warning: Uncaught exception 'Exception' with message 'Foo' in %sbug60909_1.php:5
+Exception: Foo in %sbug60909_1.php on line 5
 Stack trace:
 #0 %sbug60909_1.php(8): {closure}(2, 'require(notfoun...', '%s', 8, Array)
 #1 %sbug60909_1.php(8): require()
 #2 {main}
-  thrown in %sbug60909_1.php on line 5
 
 Fatal error: main(): Failed opening required 'notfound.php' (include_path='%s') in %sbug60909_1.php on line 8
 

--- a/Zend/tests/bug61767.phpt
+++ b/Zend/tests/bug61767.phpt
@@ -17,11 +17,10 @@ $undefined->foo();
 --EXPECTF--
 Error handler called (Undefined variable: undefined)
 
-Fatal error: Uncaught exception 'ErrorException' with message 'Undefined variable: undefined' in %sbug61767.php:%d
+ErrorException: Undefined variable: undefined in %sbug61767.php on line %d
 Stack trace:
 #0 %sbug61767.php(%d): {closure}(%s, 'Undefined varia...', '%s', %d, Array)
 #1 {main}
-  thrown in %sbug61767.php on line %d
 Shutting down
 Array
 (

--- a/Zend/tests/bug64821.1.phpt
+++ b/Zend/tests/bug64821.1.phpt
@@ -16,7 +16,6 @@ throw new a;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'a' in %s:0
+a: (empty message) in %s on line 0
 Stack trace:
 #0 {main}
-  thrown in %s on line %d

--- a/Zend/tests/bug64821.2.phpt
+++ b/Zend/tests/bug64821.2.phpt
@@ -13,7 +13,6 @@ throw new a;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'a' in %s:0
+a: (empty message) in %s on line 0
 Stack trace:
 #0 {main}
-  thrown in %s on line %d

--- a/Zend/tests/bug64821.3.phpt
+++ b/Zend/tests/bug64821.3.phpt
@@ -14,7 +14,6 @@ throw new a;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'a' in :0
+a: (empty message) in Unknown on line 0
 Stack trace:
 #0 {main}
-  thrown in Unknown on line %d

--- a/Zend/tests/bug64960.phpt
+++ b/Zend/tests/bug64960.phpt
@@ -31,10 +31,9 @@ $a['waa'];
 --EXPECTF--
 Notice: ob_end_flush(): failed to delete and flush buffer. No buffer to delete or flush in %sbug64960.php on line 3
 
-Fatal error: Uncaught exception 'Exception' in %sbug64960.php:19
+Exception: (empty message) in %sbug64960.php on line 19
 Stack trace:
 #0 [internal function]: {closure}(8, 'ob_end_clean():...', '%s', 9, Array)
 #1 %sbug64960.php(9): ob_end_clean()
 #2 [internal function]: ExceptionHandler->__invoke(Object(Exception))
 #3 {main}
-  thrown in %sbug64960.php on line 19

--- a/Zend/tests/bug64966.phpt
+++ b/Zend/tests/bug64966.phpt
@@ -21,9 +21,8 @@ $a = new A();
 $a->b();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' in %sbug64966.php:6
+Exception: (empty message) in %sbug64966.php on line 6
 Stack trace:
 #0 %sbug64966.php(13): test('iterator_apply')
 #1 %sbug64966.php(18): A->b()
 #2 {main}
-  thrown in %sbug64966.php on line 6

--- a/Zend/tests/debug_backtrace_with_include_and_this.phpt
+++ b/Zend/tests/debug_backtrace_with_include_and_this.phpt
@@ -31,9 +31,8 @@ try {
 ERR#2: include(class://non.existent.Class): failed to open stream: "CLWrapper::stream_open" call failed @ include
 ERR#2: include(): Failed opening 'class://non.existent.Class' for inclusion (include_path='%s') @ include
 
-Fatal error: Uncaught exception 'Exception' with message 'Failed loading class://non.existent.Class' in %s
+Exception: Failed loading class://non.existent.Class in %s on line %d
 Stack trace:
 #0 %s(%d): CL->load('class://non.exi...')
 #1 {main}
-  thrown in %s on line %d
 

--- a/Zend/tests/exception_001.phpt
+++ b/Zend/tests/exception_001.phpt
@@ -32,7 +32,6 @@ string(0) ""
 string(0) ""
 string(0) ""
 
-Fatal error: Uncaught exception 'Exception' in %s:%d
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d

--- a/Zend/tests/exception_003.phpt
+++ b/Zend/tests/exception_003.phpt
@@ -8,7 +8,6 @@ throw new Exception(1);
 ?>
 --EXPECTF--
 
-Fatal error: Uncaught exception 'Exception' with message '1' in %s:%d
+Exception: 1 in %s on line %d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d

--- a/Zend/tests/exception_007.phpt
+++ b/Zend/tests/exception_007.phpt
@@ -18,19 +18,18 @@ catch (Exception $e) {
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'Another' in %sexception_007.php:%d
+Exception: Another in %sexception_007.php on line %d
 Stack trace:
 #0 {main}
 
-Next exception 'Exception' with message 'First' in %sexception_007.php:%d
+Next Exception: First in %sexception_007.php on line %d
 Stack trace:
 #0 {main}
 
-Next exception 'Exception' with message 'Second' in %sexception_007.php:%d
+Next Exception: Second in %sexception_007.php on line %d
 Stack trace:
 #0 {main}
 
-Next exception 'Exception' with message 'Third' in %sexception_007.php:%d
+Next Exception: Third in %sexception_007.php on line %d
 Stack trace:
 #0 {main}
-  thrown in %sexception_007.php on line %d

--- a/Zend/tests/exception_008.phpt
+++ b/Zend/tests/exception_008.phpt
@@ -24,13 +24,12 @@ unset($ar);
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'First' in %sexception_008.php:%d
+Exception: First in %sexception_008.php on line %d
 Stack trace:
 #0 %sexception_008.php(%d): TestFirst->__destruct()
 #1 {main}
 
-Next exception 'Exception' with message 'Second' in %sexception_008.php:%d
+Next Exception: Second in %sexception_008.php on line %d
 Stack trace:
 #0 %sexception_008.php(%d): TestSecond->__destruct()
 #1 {main}
-  thrown in %sexception_008.php on line %d

--- a/Zend/tests/exception_011.phpt
+++ b/Zend/tests/exception_011.phpt
@@ -13,8 +13,7 @@ assert(false);
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'AssertionException' with message 'assert(false)' in %sexception_011.php:%d
+AssertionException: assert(false) in %sexception_011.php on line %d
 Stack trace:
 #0 %sexception_011.php(%d): assert(false, 'assert(false)')
 #1 {main}
-  thrown in %sexception_011.php on line %d

--- a/Zend/tests/exception_012.phpt
+++ b/Zend/tests/exception_012.phpt
@@ -13,9 +13,8 @@ $func();
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'AssertionException' with message 'assert(false)' in %sexception_012.php(%d) : runtime-created function:%d
+AssertionException: assert(false) in %sexception_012.php(%d) : runtime-created function on line %d
 Stack trace:
 #0 %sexception_012.php(%d) : runtime-created function(%d): assert(false, 'assert(false)')
 #1 %sexception_012.php(%d): __lambda_func()
 #2 {main}
-  thrown in %sexception_012.php(%d) : runtime-created function on line %d

--- a/Zend/tests/exception_handler_002.phpt
+++ b/Zend/tests/exception_handler_002.phpt
@@ -20,8 +20,7 @@ echo "Done\n";
 --EXPECTF--	
 string(12) "test thrown!"
 
-Fatal error: Uncaught exception 'Exception' in %sexception_handler_002.php:7
+Exception: (empty message) in %sexception_handler_002.php on line 7
 Stack trace:
 #0 [internal function]: foo(Object(test))
 #1 {main}
-  thrown in %sexception_handler_002.php on line %d

--- a/Zend/tests/exception_with_by_ref_message.phpt
+++ b/Zend/tests/exception_with_by_ref_message.phpt
@@ -15,7 +15,6 @@ throw new MyException($msg);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'MyException' with message 'Message' in %s:%d
+MyException: Message in %s on line %d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d

--- a/Zend/tests/gc_030.phpt
+++ b/Zend/tests/gc_030.phpt
@@ -20,15 +20,14 @@ unset($f1, $f2);
 gc_collect_cycles();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'foobar' in %sgc_030.php:%d
+Exception: foobar in %sgc_030.php on line %d
 Stack trace:
 #0 [internal function]: foo->__destruct()
 #1 %sgc_030.php(%d): gc_collect_cycles()
 #2 {main}
 
-Next exception 'Exception' with message 'foobar' in %sgc_030.php:%d
+Next Exception: foobar in %sgc_030.php on line %d
 Stack trace:
 #0 [internal function]: foo->__destruct()
 #1 %sgc_030.php(%d): gc_collect_cycles()
 #2 {main}
-  thrown in %sgc_030.php on line %d

--- a/Zend/tests/generators/errors/non_ref_generator_iterated_by_ref_error.phpt
+++ b/Zend/tests/generators/errors/non_ref_generator_iterated_by_ref_error.phpt
@@ -10,8 +10,7 @@ foreach ($gen as &$value) { }
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'You can only iterate a generator by-reference if it declared that it yields by-reference' in %s:%d
+Exception: You can only iterate a generator by-reference if it declared that it yields by-reference in %s on line %d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d
 

--- a/Zend/tests/generators/finally/throw_yield.phpt
+++ b/Zend/tests/generators/finally/throw_yield.phpt
@@ -17,8 +17,7 @@ foreach (foo(1, 5) as $x) {
 --EXPECTF--
 1
 
-Fatal error: Uncaught exception 'Exception' in %s:%d
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 %s(%d): foo(1, 5)
 #1 {main}
-  thrown in %s on line %d

--- a/Zend/tests/generators/finally/yield_throw.phpt
+++ b/Zend/tests/generators/finally/yield_throw.phpt
@@ -17,8 +17,7 @@ foreach (foo(1, 5) as $x) {
 --EXPECTF--
 1
 
-Fatal error: Uncaught exception 'Exception' in %s:%d
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 %s(%d): foo(1, 5)
 #1 {main}
-  thrown in %s on line %d

--- a/Zend/tests/generators/generator_throwing_in_foreach.phpt
+++ b/Zend/tests/generators/generator_throwing_in_foreach.phpt
@@ -12,9 +12,8 @@ foreach (gen() as $value) { }
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'foo' in %s:%d
+Exception: foo in %s on line %d
 Stack trace:
 #0 %s(%d): gen()
 #1 {main}
-  thrown in %s on line %d
 

--- a/Zend/tests/generators/throw_already_closed.phpt
+++ b/Zend/tests/generators/throw_already_closed.phpt
@@ -17,7 +17,6 @@ $gen->throw(new Exception('test'));
 --EXPECTF--
 bool(false)
 
-Fatal error: Uncaught exception 'Exception' with message 'test' in %s:%d
+Exception: test in %s on line %d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d

--- a/Zend/tests/generators/throw_rethrow.phpt
+++ b/Zend/tests/generators/throw_rethrow.phpt
@@ -25,10 +25,9 @@ Stack trace:
 #0 {main}
 
 
-Fatal error: Uncaught exception 'LogicException' with message 'new throw' in %s:%d
+LogicException: new throw in %s on line %d
 Stack trace:
 #0 [internal function]: gen()
 #1 %s(%d): Generator->throw(Object(RuntimeException))
 #2 {main}
-  thrown in %s on line %d
 

--- a/Zend/tests/generators/throw_uncaught.phpt
+++ b/Zend/tests/generators/throw_uncaught.phpt
@@ -13,7 +13,6 @@ var_dump($gen->throw(new RuntimeException('test')));
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'RuntimeException' with message 'test' in %s:%d
+RuntimeException: test in %s on line %d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d

--- a/Zend/tests/return_types/020.phpt
+++ b/Zend/tests/return_types/020.phpt
@@ -10,8 +10,7 @@ function test() : array {
 test();
 
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' in %s:%d
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 %s(%d): test()
 #1 {main}
-  thrown in %s on line %d

--- a/Zend/tests/throw_reference.phpt
+++ b/Zend/tests/throw_reference.phpt
@@ -9,7 +9,6 @@ throw $e;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' in %s:%d
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d

--- a/Zend/tests/try_finally_001.phpt
+++ b/Zend/tests/try_finally_001.phpt
@@ -15,8 +15,7 @@ foo("finally");
 --EXPECTF--
 string(7) "finally"
 
-Fatal error: Uncaught exception 'Exception' with message 'ex' %s
+Exception: ex in %s on line %d
 Stack trace:
 #0 %stry_finally_001.php(%d): foo('finally')
 #1 {main}
-  thrown in %stry_finally_001.php on line %d

--- a/Zend/tests/try_finally_003.phpt
+++ b/Zend/tests/try_finally_003.phpt
@@ -20,8 +20,7 @@ foo();
 ?>
 --EXPECTF--
 1234
-Fatal error: Uncaught exception 'Exception' with message 'ex' %s
+Exception: ex in %s on line %d
 Stack trace:
 #0 %stry_finally_003.php(%d): foo()
 #1 {main}
-  thrown in %stry_finally_003.php on line %d

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -53,7 +53,7 @@ ZEND_API int (*zend_stream_open_function)(const char *filename, zend_file_handle
 ZEND_API void (*zend_block_interruptions)(void);
 ZEND_API void (*zend_unblock_interruptions)(void);
 ZEND_API void (*zend_ticks_function)(int ticks);
-ZEND_API void (*zend_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
+ZEND_API zend_error_cb_type zend_error_cb;
 size_t (*zend_vspprintf)(char **pbuf, size_t max_len, const char *format, va_list ap);
 zend_string *(*zend_vstrpprintf)(size_t max_len, const char *format, va_list ap);
 ZEND_API char *(*zend_getenv)(char *name, size_t name_len);
@@ -998,6 +998,37 @@ ZEND_API zval *zend_get_configuration_directive(zend_string *name) /* {{{ */
 }
 /* }}} */
 
+static const char *zend_get_error_type_str(int type) /* {{{ */
+{
+	switch (type) {
+		case E_ERROR:
+		case E_CORE_ERROR:
+		case E_COMPILE_ERROR:
+		case E_USER_ERROR:
+			return "Fatal error";
+		case E_RECOVERABLE_ERROR:
+			return "Catchable fatal error";
+		case E_WARNING:
+		case E_CORE_WARNING:
+		case E_COMPILE_WARNING:
+		case E_USER_WARNING:
+			return "Warning";
+		case E_PARSE:
+			return "Parse error";
+		case E_NOTICE:
+		case E_USER_NOTICE:
+			return "Notice";
+		case E_STRICT:
+			return "Strict Standards";
+		case E_DEPRECATED:
+		case E_USER_DEPRECATED:
+			return "Deprecated";
+		default:
+			return "Unknown error";
+	}
+}
+/* }}} */
+
 #define SAVE_STACK(stack) do { \
 		if (CG(stack).top) { \
 			memcpy(&stack, &CG(stack), sizeof(zend_stack)); \
@@ -1030,6 +1061,7 @@ static void zend_error_va_list(int type, const char *format, va_list args)
 	zval params[5];
 	zval retval;
 	const char *error_filename;
+	const char *error_type_str;
 	uint error_lineno = 0;
 	zval orig_user_error_handler;
 	zend_bool in_compilation;
@@ -1154,11 +1186,13 @@ static void zend_error_va_list(int type, const char *format, va_list args)
 	va_start(args, format);
 #endif
 
+	error_type_str = zend_get_error_type_str(type);
+
 	/* if we don't have a user defined error handler */
 	if (Z_TYPE(EG(user_error_handler)) == IS_UNDEF
 		|| !(EG(user_error_handler_error_reporting) & type)
 		|| EG(error_handling) != EH_NORMAL) {
-		zend_error_cb(type, error_filename, error_lineno, format, args);
+		zend_error_cb(type, error_type_str, error_filename, error_lineno, "", format, args);
 	} else switch (type) {
 		case E_ERROR:
 		case E_PARSE:
@@ -1167,7 +1201,7 @@ static void zend_error_va_list(int type, const char *format, va_list args)
 		case E_COMPILE_ERROR:
 		case E_COMPILE_WARNING:
 			/* The error may not be safe to handle in user-space */
-			zend_error_cb(type, error_filename, error_lineno, format, args);
+			zend_error_cb(type, error_type_str, error_filename, error_lineno, "", format, args);
 			break;
 		default:
 			/* Handle the error in user space */
@@ -1231,13 +1265,14 @@ static void zend_error_va_list(int type, const char *format, va_list args)
 			if (call_user_function_ex(CG(function_table), NULL, &orig_user_error_handler, &retval, 5, params, 1, NULL) == SUCCESS) {
 				if (Z_TYPE(retval) != IS_UNDEF) {
 					if (Z_TYPE(retval) == IS_FALSE) {
-						zend_error_cb(type, error_filename, error_lineno, format, args);
+						zend_error_cb(type, error_type_str,
+							error_filename, error_lineno, "", format, args);
 					}
 					zval_ptr_dtor(&retval);
 				}
 			} else if (!EG(exception)) {
 				/* The user error handler failed, use built-in error handler */
-				zend_error_cb(type, error_filename, error_lineno, format, args);
+				zend_error_cb(type, error_type_str, error_filename, error_lineno, "", format, args);
 			}
 
 			if (in_compilation) {

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -189,8 +189,13 @@ struct _zend_class_entry {
 	} info;
 };
 
+typedef void (*zend_error_cb_type)(int type, const char *type_str,
+	const char *error_filename, const uint error_lineno,
+	const char *additional_info, const char *format, va_list args)
+	ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
+
 typedef struct _zend_utility_functions {
-	void (*error_function)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
+	zend_error_cb_type error_function;
 	size_t (*printf_function)(const char *format, ...) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 1, 2);
 	size_t (*write_function)(const char *str, size_t str_length);
 	FILE *(*fopen_function)(const char *filename, zend_string **opened_path);
@@ -276,7 +281,7 @@ extern ZEND_API FILE *(*zend_fopen)(const char *filename, zend_string **opened_p
 extern ZEND_API void (*zend_block_interruptions)(void);
 extern ZEND_API void (*zend_unblock_interruptions)(void);
 extern ZEND_API void (*zend_ticks_function)(int ticks);
-extern ZEND_API void (*zend_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
+extern ZEND_API zend_error_cb_type zend_error_cb;
 extern ZEND_API void (*zend_on_timeout)(int seconds);
 extern ZEND_API int (*zend_stream_open_function)(const char *filename, zend_file_handle *handle);
 extern size_t (*zend_vspprintf)(char **pbuf, size_t max_len, const char *format, va_list ap);

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -877,24 +877,88 @@ ZEND_API zend_object *zend_throw_error_exception(zend_class_entry *exception_ce,
 }
 /* }}} */
 
-static void zend_error_va(int type, const char *file, uint lineno, const char *format, ...) /* {{{ */
+static void zend_error_va(int type, const char *type_str, const char *file, uint lineno,
+	const char *additional_info, const char *format, ...) /* {{{ */
 {
 	va_list args;
 
 	va_start(args, format);
-	zend_error_cb(type, file, lineno, format, args);
+	zend_error_cb(type, type_str, file, lineno, additional_info, format, args);
 	va_end(args);
 }
 /* }}} */
 
-static void zend_error_helper(int type, const char *filename, const uint lineno, const char *format, ...)
+static zval *zend_exception_get_innermost(zval *exception) /* {{{ */
 {
-	va_list va;
-
-	va_start(va, format);
-	zend_error_cb(type, filename, lineno, format, va);
-	va_end(va);
+	for (;;) {
+		zval rv, *prev_exception = GET_PROPERTY(exception, "previous");
+		if (!prev_exception || Z_TYPE_P(prev_exception) != IS_OBJECT) {
+			return exception;
+		}
+		exception = prev_exception;
+	}
 }
+/* }}} */
+
+static zend_string *zend_exception_get_additional_info(zval *exception) /* {{{ */
+{
+	zend_string *str = STR_EMPTY_ALLOC();
+	zend_fcall_info fci;
+	zval trace, fname, rv;
+	zend_bool has_prev_exception;
+	ZVAL_STRINGL(&fname, "gettraceasstring", sizeof("gettraceasstring")-1);
+
+	do {
+		zend_string *prev_str = str;
+		zval *prev_exception = GET_PROPERTY(exception, "previous");
+		has_prev_exception = prev_exception && Z_TYPE_P(prev_exception) == IS_OBJECT;
+
+		fci.size = sizeof(fci);
+		fci.function_table = &Z_OBJCE_P(exception)->function_table;
+		ZVAL_COPY_VALUE(&fci.function_name, &fname);
+		fci.symbol_table = NULL;
+		fci.object = Z_OBJ_P(exception);
+		fci.retval = &trace;
+		fci.param_count = 0;
+		fci.params = NULL;
+		fci.no_separation = 1;
+
+		zend_call_function(&fci, NULL);
+
+		if (Z_TYPE(trace) != IS_STRING) {
+			zval_ptr_dtor(&trace);
+			ZVAL_UNDEF(&trace);
+		}
+
+		if (has_prev_exception) {
+			zend_string *message = zval_get_string(GET_PROPERTY_SILENT(exception, "message"));
+			zend_string *file = zval_get_string(GET_PROPERTY_SILENT(exception, "file"));
+			zend_long line = zval_get_long(GET_PROPERTY_SILENT(exception, "line"));
+			str = zend_strpprintf(0,
+				"\n\nNext %s: %s in %s on line " ZEND_LONG_FMT "\nStack trace:\n%s%s",
+				Z_OBJCE_P(exception)->name->val,
+				message->len ? message->val : "(empty message)",
+				file->len ? file->val : "Unknown", line,
+				(Z_TYPE(trace) == IS_STRING && Z_STRLEN(trace)) ? Z_STRVAL(trace) : "#0 {main}\n",
+				prev_str->val);
+			zend_string_release(message);
+			zend_string_release(file);
+		} else {
+			str = zend_strpprintf(0, "\nStack trace:\n%s%s",
+				(Z_TYPE(trace) == IS_STRING && Z_STRLEN(trace)) ? Z_STRVAL(trace) : "#0 {main}\n",
+				prev_str->val);
+		}
+
+		zend_string_release(prev_str);
+		zval_ptr_dtor(&trace);
+
+		exception = prev_exception;
+	} while (has_prev_exception);
+	zval_dtor(&fname);
+
+	return str;
+}
+/* }}} */
 
 /* This function doesn't return if it uses E_ERROR */
 ZEND_API void zend_exception_error(zend_object *ex, int severity) /* {{{ */
@@ -910,59 +974,32 @@ ZEND_API void zend_exception_error(zend_object *ex, int severity) /* {{{ */
 		zend_string *file = zval_get_string(GET_PROPERTY_SILENT(&exception, "file"));
 		zend_long line = zval_get_long(GET_PROPERTY_SILENT(&exception, "line"));
 		zend_long code = zval_get_long(GET_PROPERTY_SILENT(&exception, "code"));
+		const char *type_str = code == E_ERROR ? "Fatal error" : "Parse error";
 
 		if (ce_exception == type_exception_ce && strstr(message->val, ", called in ")) {
-			zend_error_helper(code, file->val, line, "%s and defined", message->val);
+			zend_error_va(code, type_str, file->val, line, "", "%s and defined", message->val);
 		} else {
-			zend_error_helper(code, file->val, line, "%s", message->val);
+			zend_error_va(code, type_str, file->val, line, "", "%s", message->val);
 		}
 
 		zend_string_release(file);
 		zend_string_release(message);
 		OBJ_RELEASE(ex);
 	} else if (instanceof_function(ce_exception, base_exception_ce)) {
-		zval tmp, rv;
-		zend_string *str, *file = NULL;
-		zend_long line = 0;
+		zval rv;
+		zval *inner_exception = zend_exception_get_innermost(&exception);
+		zend_string *message = zval_get_string(GET_PROPERTY_SILENT(inner_exception, "message"));
+		zend_string *file = zval_get_string(GET_PROPERTY_SILENT(inner_exception, "file"));
+		zend_long line = zval_get_long(GET_PROPERTY_SILENT(inner_exception, "line"));
+		zend_string *additional_info = zend_exception_get_additional_info(&exception);
 
-		zend_call_method_with_0_params(&exception, ce_exception, NULL, "__tostring", &tmp);
-		if (!EG(exception)) {
-			if (Z_TYPE(tmp) != IS_STRING) {
-				zend_error(E_WARNING, "%s::__toString() must return a string", ce_exception->name->val);
-			} else {
-				zend_update_property_string(base_exception_ce, &exception, "string", sizeof("string")-1, EG(exception) ? ce_exception->name->val : Z_STRVAL(tmp));
-			}
-		}
-		zval_ptr_dtor(&tmp);
+		zend_error_va(severity, Z_OBJCE_P(inner_exception)->name->val,
+			file->len ? file->val : NULL, line, additional_info->val,
+			"%s", message->len ? message->val : "(empty message)");
 
-		if (EG(exception)) {
-			zval zv;
-
-			ZVAL_OBJ(&zv, EG(exception));
-			/* do the best we can to inform about the inner exception */
-			if (instanceof_function(ce_exception, base_exception_ce)) {
-				file = zval_get_string(GET_PROPERTY_SILENT(&zv, "file"));
-				line = zval_get_long(GET_PROPERTY_SILENT(&zv, "line"));
-			}
-
-			zend_error_va(E_WARNING, (file && file->len > 0) ? file->val : NULL, line,
-				"Uncaught %s in exception handling during call to %s::__tostring()",
-				Z_OBJCE(zv)->name->val, ce_exception->name->val);
-
-			if (file) {
-				zend_string_release(file);
-			}
-		}
-
-		str = zval_get_string(GET_PROPERTY_SILENT(&exception, "string"));
-		file = zval_get_string(GET_PROPERTY_SILENT(&exception, "file"));
-		line = zval_get_long(GET_PROPERTY_SILENT(&exception, "line"));
-
-		zend_error_va(severity, (file && file->len > 0) ? file->val : NULL, line,
-			"Uncaught %s\n  thrown", str->val);
-
-		zend_string_release(str);
+		zend_string_release(message);
 		zend_string_release(file);
+		zend_string_release(additional_info);
 	} else {
 		zend_error(severity, "Uncaught exception '%s'", ce_exception->name->val);
 	}

--- a/ext/curl/tests/curl_file_serialize.phpt
+++ b/ext/curl/tests/curl_file_serialize.phpt
@@ -12,10 +12,9 @@ $data = 'a:2:{s:4:"file";O:8:"CURLFile":3:{s:4:"name";s:13:"testdata1.txt";s:4:"
 var_dump(unserialize($data));
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'Unserialization of CURLFile instances is not allowed' in %s
+Exception: Unserialization of CURLFile instances is not allowed in %s on line %d
 Stack trace:
 #0 [internal function]: CURLFile->__wakeup()
 #1 %s
 #2 {main}
-  thrown in %s on line %d
 

--- a/ext/date/tests/DatePeriod_wrong_constructor.phpt
+++ b/ext/date/tests/DatePeriod_wrong_constructor.phpt
@@ -10,8 +10,7 @@ date.timezone=UTC
 new DatePeriod();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'DatePeriod::__construct(): This constructor accepts either (DateTimeInterface, DateInterval, int) OR (DateTimeInterface, DateInterval, DateTime) OR (string) as arguments.' in %s:%d
+Exception: DatePeriod::__construct(): This constructor accepts either (DateTimeInterface, DateInterval, int) OR (DateTimeInterface, DateInterval, DateTime) OR (string) as arguments. in %s on line %d
 Stack trace:
 #0 %s(%d): DatePeriod->__construct()
 #1 {main}
-  thrown in %s on line %d

--- a/ext/dom/tests/DOMCharacterData_deleteData_error_002.phpt
+++ b/ext/dom/tests/DOMCharacterData_deleteData_error_002.phpt
@@ -16,8 +16,7 @@ $root->appendChild($cdata);
 $cdata->deleteData(5, 1);
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'DOMException' with message 'Index Size Error' in %s:%d
+DOMException: Index Size Error in %s on line %d
 Stack trace:
 #0 %s(%d): DOMCharacterData->deleteData(5, 1)
 #1 {main}
-  thrown in %s on line %d

--- a/ext/dom/tests/DOMDocumentFragment_appendXML_error_002.phpt
+++ b/ext/dom/tests/DOMDocumentFragment_appendXML_error_002.phpt
@@ -12,8 +12,7 @@ $fragment->appendXML('<bait>crankbait</bait>');
 $document->appendChild($fragment);
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'DOMException' with message 'No Modification Allowed Error' in %s:%d
+DOMException: No Modification Allowed Error in %s on line %d
 Stack trace:
 #0 %s(%d): DOMDocumentFragment->appendXML('<bait>crankbait...')
 #1 {main}
-  thrown in %s on line %d

--- a/ext/dom/tests/dom003.phpt
+++ b/ext/dom/tests/dom003.phpt
@@ -62,8 +62,7 @@ object(DOMException)#%d (%d) {
 }
 --- Don't catch exception with try/catch
 
-Fatal error: Uncaught exception 'DOMException' with message 'Hierarchy Request Error' in %sdom003.php:%d
+DOMException: Hierarchy Request Error in %sdom003.php on line %d
 Stack trace:
 #0 %sdom003.php(%d): DOMNode->appendChild(Object(DOMElement))
 #1 {main}
-  thrown in %sdom003.php on line %d

--- a/ext/intl/tests/bug62081.phpt
+++ b/ext/intl/tests/bug62081.phpt
@@ -12,8 +12,7 @@ ini_set('intl.error_level', E_WARNING);
 $x = new IntlDateFormatter('en', 1, 1);
 var_dump($x->__construct('en', 1, 1));
 --EXPECTF--
-Fatal error: Uncaught exception 'IntlException' with message 'IntlDateFormatter::__construct(): datefmt_create: cannot call constructor twice' in %sbug62081.php:4
+IntlException: IntlDateFormatter::__construct(): datefmt_create: cannot call constructor twice in %sbug62081.php on line 4
 Stack trace:
 #0 %sbug62081.php(4): IntlDateFormatter->__construct('en', 1, 1)
 #1 {main}
-  thrown in %sbug62081.php on line 4

--- a/ext/intl/tests/dateformat_calendars.phpt
+++ b/ext/intl/tests/dateformat_calendars.phpt
@@ -41,8 +41,7 @@ string(44) "Sunday, January 1, 2012 5:12:00 AM GMT+05:12"
 string(44) "Sunday, January 1, 2012 5:12:00 AM GMT+05:12"
 string(42) "Sunday, Tevet 6, 5772 5:12:00 AM GMT+05:12"
 
-Fatal error: Uncaught exception 'IntlException' with message 'IntlDateFormatter::__construct(): datefmt_create: invalid value for calendar type; it must be one of IntlDateFormatter::TRADITIONAL (locale's default calendar) or IntlDateFormatter::GREGORIAN. Alternatively, it can be an IntlCalendar object' in %sdateformat_calendars.php:%d
+IntlException: IntlDateFormatter::__construct(): datefmt_create: invalid value for calendar type; it must be one of IntlDateFormatter::TRADITIONAL (locale's default calendar) or IntlDateFormatter::GREGORIAN. Alternatively, it can be an IntlCalendar object in %sdateformat_calendars.php on line %d
 Stack trace:
 #0 %sdateformat_calendars.php(%d): IntlDateFormatter->__construct('en_US@calendar=...', 0, 0, 'GMT+05:12', -1)
 #1 {main}
-  thrown in %sdateformat_calendars.php on line %d

--- a/ext/intl/tests/dateformat_calendars_variant2.phpt
+++ b/ext/intl/tests/dateformat_calendars_variant2.phpt
@@ -42,8 +42,7 @@ string(47) "Sunday, January 1, 2012 at 5:12:00 AM GMT+05:12"
 string(47) "Sunday, January 1, 2012 at 5:12:00 AM GMT+05:12"
 string(48) "Sunday, Tevet 6, 5772 AM at 5:12:00 AM GMT+05:12"
 
-Fatal error: Uncaught exception 'IntlException' with message 'IntlDateFormatter::__construct(): datefmt_create: invalid value for calendar type; it must be one of IntlDateFormatter::TRADITIONAL (locale's default calendar) or IntlDateFormatter::GREGORIAN. Alternatively, it can be an IntlCalendar object' in %sdateformat_calendars_variant2.php:27
+IntlException: IntlDateFormatter::__construct(): datefmt_create: invalid value for calendar type; it must be one of IntlDateFormatter::TRADITIONAL (locale's default calendar) or IntlDateFormatter::GREGORIAN. Alternatively, it can be an IntlCalendar object in %sdateformat_calendars_variant2.php on line 27
 Stack trace:
 #0 %sdateformat_calendars_variant2.php(27): IntlDateFormatter->__construct('en_US@calendar=...', 0, 0, 'GMT+05:12', -1)
 #1 {main}
-  thrown in %sdateformat_calendars_variant2.php on line 27

--- a/ext/pdo/tests/pdo_036.phpt
+++ b/ext/pdo/tests/pdo_036.phpt
@@ -20,9 +20,8 @@ object(PDOStatement)#%d (1) {
   NULL
 }
 
-Fatal error: Uncaught exception 'PDOException' with message 'You may not create a PDORow manually' in %spdo_036.php:8
+PDOException: You may not create a PDORow manually in %spdo_036.php on line 8
 Stack trace:
 #0 [internal function]: PDORow->__construct()
 #1 %spdo_036.php(8): ReflectionClass->newInstance()
 #2 {main}
-  thrown in %spdo_036.php on line 8

--- a/ext/pdo/tests/pdorow.phpt
+++ b/ext/pdo/tests/pdorow.phpt
@@ -9,8 +9,7 @@ new PDORow;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'PDOException' with message 'You may not create a PDORow manually' in %spdorow.php:3
+PDOException: You may not create a PDORow manually in %spdorow.php on line 3
 Stack trace:
 #0 %spdorow.php(3): PDORow->__construct()
 #1 {main}
-  thrown in %spdorow.php on line 3

--- a/ext/phar/tests/bug46032.phpt
+++ b/ext/phar/tests/bug46032.phpt
@@ -27,8 +27,7 @@ new phardata('0000000000000000000');
 %string|unicode%(%d) "%smytest"
 %string|unicode%(%d) "%smytest"
 
-Fatal error: Uncaught exception 'UnexpectedValueException' with message 'Cannot create phar '0000000000000000000', file extension (or combination) not recognised or the directory does not exist' in %sbug46032.php:%d
+UnexpectedValueException: Cannot create phar '0000000000000000000', file extension (or combination) not recognised or the directory does not exist in %sbug46032.php on line %d
 Stack trace:
 #0 %sbug46032.php(%d): PharData->__construct('000000000000000...')
 #1 {main}
-  thrown in %sbug46032.php on line %d

--- a/ext/phar/tests/cache_list/frontcontroller11.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller11.phpt
@@ -15,8 +15,7 @@ files/frontcontroller5.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Key of MIME type overrides array must be a file extension, was "0"' in %sfrontcontroller11.php:2
+PharException: Key of MIME type overrides array must be a file extension, was "0" in %sfrontcontroller11.php on line 2
 Stack trace:
 #0 %sfrontcontroller11.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller11.php on line 2

--- a/ext/phar/tests/cache_list/frontcontroller12.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller12.phpt
@@ -14,8 +14,7 @@ files/frontcontroller6.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Unknown mime type specifier used, only Phar::PHP, Phar::PHPS and a mime type string are allowed' in %sfrontcontroller12.php:2
+PharException: Unknown mime type specifier used, only Phar::PHP, Phar::PHPS and a mime type string are allowed in %sfrontcontroller12.php on line 2
 Stack trace:
 #0 %sfrontcontroller12.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller12.php on line 2

--- a/ext/phar/tests/cache_list/frontcontroller13.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller13.phpt
@@ -14,8 +14,7 @@ files/frontcontroller7.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Unknown mime type specifier used (not a string or int), only Phar::PHP, Phar::PHPS and a mime type string are allowed' in %sfrontcontroller13.php:2
+PharException: Unknown mime type specifier used (not a string or int), only Phar::PHP, Phar::PHPS and a mime type string are allowed in %sfrontcontroller13.php on line 2
 Stack trace:
 #0 %sfrontcontroller13.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller13.php on line 2

--- a/ext/phar/tests/cache_list/frontcontroller18.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller18.phpt
@@ -11,8 +11,7 @@ PATH_INFO=/fronk.gronk
 --FILE_EXTERNAL--
 files/frontcontroller9.phar
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'No values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller18.php:2
+PharException: No values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller18.php on line 2
 Stack trace:
 #0 %sfrontcontroller18.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller18.php on line 2

--- a/ext/phar/tests/cache_list/frontcontroller19.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller19.phpt
@@ -11,8 +11,7 @@ PATH_INFO=/
 --FILE_EXTERNAL--
 files/frontcontroller10.phar
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Too many values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller19.php:2
+PharException: Too many values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller19.php on line 2
 Stack trace:
 #0 %sfrontcontroller19.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller19.php on line 2

--- a/ext/phar/tests/cache_list/frontcontroller20.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller20.phpt
@@ -11,8 +11,7 @@ PATH_INFO=/
 --FILE_EXTERNAL--
 files/frontcontroller11.phar
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Non-string value passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller20.php:2
+PharException: Non-string value passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller20.php on line 2
 Stack trace:
 #0 %sfrontcontroller20.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller20.php on line 2

--- a/ext/phar/tests/frontcontroller11.phpt
+++ b/ext/phar/tests/frontcontroller11.phpt
@@ -14,8 +14,7 @@ files/frontcontroller5.phar
 --EXPECTHEADERS--
 Content-type: text/html
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Key of MIME type overrides array must be a file extension, was "0"' in %sfrontcontroller11.php:2
+PharException: Key of MIME type overrides array must be a file extension, was "0" in %sfrontcontroller11.php on line 2
 Stack trace:
 #0 %sfrontcontroller11.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller11.php on line 2

--- a/ext/phar/tests/frontcontroller12.phpt
+++ b/ext/phar/tests/frontcontroller12.phpt
@@ -13,8 +13,7 @@ files/frontcontroller6.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Unknown mime type specifier used, only Phar::PHP, Phar::PHPS and a mime type string are allowed' in %sfrontcontroller12.php:2
+PharException: Unknown mime type specifier used, only Phar::PHP, Phar::PHPS and a mime type string are allowed in %sfrontcontroller12.php on line 2
 Stack trace:
 #0 %sfrontcontroller12.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller12.php on line 2

--- a/ext/phar/tests/frontcontroller13.phpt
+++ b/ext/phar/tests/frontcontroller13.phpt
@@ -13,8 +13,7 @@ files/frontcontroller7.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Unknown mime type specifier used (not a string or int), only Phar::PHP, Phar::PHPS and a mime type string are allowed' in %sfrontcontroller13.php:2
+PharException: Unknown mime type specifier used (not a string or int), only Phar::PHP, Phar::PHPS and a mime type string are allowed in %sfrontcontroller13.php on line 2
 Stack trace:
 #0 %sfrontcontroller13.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller13.php on line 2

--- a/ext/phar/tests/frontcontroller18.phpt
+++ b/ext/phar/tests/frontcontroller18.phpt
@@ -9,8 +9,7 @@ PATH_INFO=/fronk.gronk
 --FILE_EXTERNAL--
 files/frontcontroller9.phar
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'No values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller18.php:2
+PharException: No values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller18.php on line 2
 Stack trace:
 #0 %sfrontcontroller18.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller18.php on line 2

--- a/ext/phar/tests/frontcontroller19.phpt
+++ b/ext/phar/tests/frontcontroller19.phpt
@@ -9,8 +9,7 @@ PATH_INFO=/
 --FILE_EXTERNAL--
 files/frontcontroller10.phar
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Too many values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller19.php:2
+PharException: Too many values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller19.php on line 2
 Stack trace:
 #0 %sfrontcontroller19.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller19.php on line 2

--- a/ext/phar/tests/frontcontroller20.phpt
+++ b/ext/phar/tests/frontcontroller20.phpt
@@ -9,8 +9,7 @@ PATH_INFO=/
 --FILE_EXTERNAL--
 files/frontcontroller11.phar
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Non-string value passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller20.php:2
+PharException: Non-string value passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller20.php on line 2
 Stack trace:
 #0 %sfrontcontroller20.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller20.php on line 2

--- a/ext/phar/tests/tar/frontcontroller11.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller11.phar.phpt
@@ -14,8 +14,7 @@ files/frontcontroller5.phar.tar
 --EXPECTHEADERS--
 Content-type: text/html
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Key of MIME type overrides array must be a file extension, was "0"' in %sfrontcontroller11.phar.php:2
+PharException: Key of MIME type overrides array must be a file extension, was "0" in %sfrontcontroller11.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller11.phar.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller11.phar.php on line 2

--- a/ext/phar/tests/tar/frontcontroller12.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller12.phar.phpt
@@ -13,8 +13,7 @@ files/frontcontroller6.phar.tar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Unknown mime type specifier used, only Phar::PHP, Phar::PHPS and a mime type string are allowed' in %sfrontcontroller12.phar.php:2
+PharException: Unknown mime type specifier used, only Phar::PHP, Phar::PHPS and a mime type string are allowed in %sfrontcontroller12.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller12.phar.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller12.phar.php on line 2

--- a/ext/phar/tests/tar/frontcontroller13.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller13.phar.phpt
@@ -13,8 +13,7 @@ files/frontcontroller7.phar.tar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Unknown mime type specifier used (not a string or int), only Phar::PHP, Phar::PHPS and a mime type string are allowed' in %sfrontcontroller13.phar.php:2
+PharException: Unknown mime type specifier used (not a string or int), only Phar::PHP, Phar::PHPS and a mime type string are allowed in %sfrontcontroller13.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller13.phar.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller13.phar.php on line 2

--- a/ext/phar/tests/tar/frontcontroller18.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller18.phar.phpt
@@ -9,8 +9,7 @@ PATH_INFO=/fronk.gronk
 --FILE_EXTERNAL--
 files/frontcontroller9.phar.tar
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'No values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller18.phar.php:2
+PharException: No values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller18.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller18.phar.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller18.phar.php on line 2

--- a/ext/phar/tests/tar/frontcontroller19.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller19.phar.phpt
@@ -9,8 +9,7 @@ PATH_INFO=/
 --FILE_EXTERNAL--
 files/frontcontroller10.phar.tar
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Too many values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller19.phar.php:2
+PharException: Too many values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller19.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller19.phar.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller19.phar.php on line 2

--- a/ext/phar/tests/tar/frontcontroller20.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller20.phar.phpt
@@ -9,8 +9,7 @@ PATH_INFO=/
 --FILE_EXTERNAL--
 files/frontcontroller11.phar.tar
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Non-string value passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller20.phar.php:2
+PharException: Non-string value passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller20.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller20.phar.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller20.phar.php on line 2

--- a/ext/phar/tests/zip/frontcontroller11.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller11.phar.phpt
@@ -15,8 +15,7 @@ files/frontcontroller5.phar.zip
 --EXPECTHEADERS--
 Content-type: text/html
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Key of MIME type overrides array must be a file extension, was "0"' in %sfrontcontroller11.phar.php:2
+PharException: Key of MIME type overrides array must be a file extension, was "0" in %sfrontcontroller11.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller11.phar.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller11.phar.php on line 2

--- a/ext/phar/tests/zip/frontcontroller12.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller12.phar.phpt
@@ -14,8 +14,7 @@ files/frontcontroller6.phar.zip
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Unknown mime type specifier used, only Phar::PHP, Phar::PHPS and a mime type string are allowed' in %sfrontcontroller12.phar.php:2
+PharException: Unknown mime type specifier used, only Phar::PHP, Phar::PHPS and a mime type string are allowed in %sfrontcontroller12.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller12.phar.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller12.phar.php on line 2

--- a/ext/phar/tests/zip/frontcontroller13.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller13.phar.phpt
@@ -14,8 +14,7 @@ files/frontcontroller7.phar.zip
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Unknown mime type specifier used (not a string or int), only Phar::PHP, Phar::PHPS and a mime type string are allowed' in %sfrontcontroller13.phar.php:2
+PharException: Unknown mime type specifier used (not a string or int), only Phar::PHP, Phar::PHPS and a mime type string are allowed in %sfrontcontroller13.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller13.phar.php(2): Phar::webPhar('whatever', 'index.php', '', Array)
 #1 {main}
-  thrown in %sfrontcontroller13.phar.php on line 2

--- a/ext/phar/tests/zip/frontcontroller18.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller18.phar.phpt
@@ -10,8 +10,7 @@ PATH_INFO=/fronk.gronk
 --FILE_EXTERNAL--
 files/frontcontroller9.phar.zip
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'No values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller18.phar.php:2
+PharException: No values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller18.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller18.phar.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller18.phar.php on line 2

--- a/ext/phar/tests/zip/frontcontroller19.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller19.phar.phpt
@@ -10,8 +10,7 @@ PATH_INFO=/
 --FILE_EXTERNAL--
 files/frontcontroller10.phar.zip
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Too many values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller19.phar.php:2
+PharException: Too many values passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller19.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller19.phar.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller19.phar.php on line 2

--- a/ext/phar/tests/zip/frontcontroller20.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller20.phar.phpt
@@ -10,8 +10,7 @@ PATH_INFO=/
 --FILE_EXTERNAL--
 files/frontcontroller11.phar.zip
 --EXPECTF--
-Fatal error: Uncaught exception 'PharException' with message 'Non-string value passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME' in %sfrontcontroller20.phar.php:2
+PharException: Non-string value passed to Phar::mungServer(), expecting an array of any of these strings: PHP_SELF, REQUEST_URI, SCRIPT_FILENAME, SCRIPT_NAME in %sfrontcontroller20.phar.php on line 2
 Stack trace:
 #0 %sfrontcontroller20.phar.php(2): Phar::mungServer(Array)
 #1 {main}
-  thrown in %sfrontcontroller20.phar.php on line 2

--- a/ext/reflection/tests/ReflectionClass_getStaticPropertyValue_001_2_4.phpt
+++ b/ext/reflection/tests/ReflectionClass_getStaticPropertyValue_001_2_4.phpt
@@ -54,8 +54,7 @@ try {
 Retrieving static values from A:
 string(13) "default value"
 
-Fatal error: Uncaught exception 'ReflectionException' with message 'Class A does not have a property named ' in %sReflectionClass_getStaticPropertyValue_001_2_4.php:%d
+ReflectionException: Class A does not have a property named  in %sReflectionClass_getStaticPropertyValue_001_2_4.php on line %d
 Stack trace:
 #0 %sReflectionClass_getStaticPropertyValue_001_2_4.php(%d): ReflectionClass->getStaticPropertyValue('\x00A\x00privateOverr...')
 #1 {main}
-  thrown in %sReflectionClass_getStaticPropertyValue_001_2_4.php on line %d

--- a/ext/reflection/tests/ReflectionClass_isSubclassOf_error1.phpt
+++ b/ext/reflection/tests/ReflectionClass_isSubclassOf_error1.phpt
@@ -9,8 +9,7 @@ var_dump($rc->isSubclassOf('X'));
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'ReflectionException' with message 'Class X does not exist' in %s:5
+ReflectionException: Class X does not exist in %s on line 5
 Stack trace:
 #0 %s(5): ReflectionClass->isSubclassOf('X')
 #1 {main}
-  thrown in %s on line 5

--- a/ext/reflection/tests/ReflectionClass_newInstanceWithoutConstructor.phpt
+++ b/ext/reflection/tests/ReflectionClass_newInstanceWithoutConstructor.phpt
@@ -31,8 +31,7 @@ object(stdClass)#%d (0) {
 object(DateTime)#%d (0) {
 }
 
-Fatal error: Uncaught exception 'ReflectionException' with message 'Class Generator is an internal class marked as final that cannot be instantiated without invoking its constructor' in %sReflectionClass_newInstanceWithoutConstructor.php:%d
+ReflectionException: Class Generator is an internal class marked as final that cannot be instantiated without invoking its constructor in %sReflectionClass_newInstanceWithoutConstructor.php on line %d
 Stack trace:
 #0 %sReflectionClass_newInstanceWithoutConstructor.php(%d): ReflectionClass->newInstanceWithoutConstructor()
 #1 {main}
-  thrown in %sReflectionClass_newInstanceWithoutConstructor.php on line %d

--- a/ext/reflection/tests/ReflectionClass_setStaticPropertyValue_001_2_4.phpt
+++ b/ext/reflection/tests/ReflectionClass_setStaticPropertyValue_001_2_4.phpt
@@ -54,8 +54,7 @@ try {
 --EXPECTF--
 Set static values in A:
 
-Fatal error: Uncaught exception 'ReflectionException' with message 'Class A does not have a property named ' in %sReflectionClass_setStaticPropertyValue_001_2_4.php:%d
+ReflectionException: Class A does not have a property named  in %sReflectionClass_setStaticPropertyValue_001_2_4.php on line %d
 Stack trace:
 #0 %sReflectionClass_setStaticPropertyValue_001_2_4.php(%d): ReflectionClass->setStaticPropertyValue('\x00A\x00privateOverr...', 'new value 1')
 #1 {main}
-  thrown in %sReflectionClass_setStaticPropertyValue_001_2_4.php on line %d

--- a/ext/reflection/tests/ReflectionObject_isSubclassOf_error.phpt
+++ b/ext/reflection/tests/ReflectionObject_isSubclassOf_error.phpt
@@ -17,8 +17,7 @@ NULL
 Warning: ReflectionClass::isSubclassOf() expects exactly 1 parameter, 2 given in %s on line 6
 NULL
 
-Fatal error: Uncaught exception 'ReflectionException' with message 'Class X does not exist' in %s:7
+ReflectionException: Class X does not exist in %s on line 7
 Stack trace:
 #0 %s(7): ReflectionClass->isSubclassOf('X')
 #1 {main}
-  thrown in %s on line 7

--- a/ext/reflection/tests/ReflectionParameter_export_error3.phpt
+++ b/ext/reflection/tests/ReflectionParameter_export_error3.phpt
@@ -14,9 +14,8 @@ foreach($params as $key => $value) {
 }
 --EXPECTF--
 
-Fatal error: Uncaught exception 'ReflectionException' with message 'The parameter specified by its name could not be found' in %s.php:%d
+ReflectionException: The parameter specified by its name could not be found in %s.php on line %d
 Stack trace:
 #0 [internal function]: ReflectionParameter->__construct('ReflectionParam...', 'incorrect_param...')
 #1 %s.php(%d): ReflectionParameter::export('ReflectionParam...', 'incorrect_param...')
 #2 {main}
-  thrown in %s.php on line %d

--- a/ext/session/tests/bug60634_error_2.phpt
+++ b/ext/session/tests/bug60634_error_2.phpt
@@ -45,9 +45,8 @@ echo "um, hi\n";
 --EXPECTF--
 write: goodbye cruel world
 
-Fatal error: Uncaught exception 'Exception' in %s
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 [internal function]: write('%s', '')
 #1 %s(%d): session_write_close()
 #2 {main}
-  thrown in %s on line %d

--- a/ext/session/tests/bug60634_error_4.phpt
+++ b/ext/session/tests/bug60634_error_4.phpt
@@ -43,10 +43,9 @@ session_start();
 --EXPECTF--
 write: goodbye cruel world
 
-Fatal error: Uncaught exception 'Exception' in %s
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 [internal function]: write('%s', '')
 #1 {main}
-  thrown in %s on line %d
 close: goodbye cruel world
 

--- a/ext/session/tests/session_module_name_variation3.phpt
+++ b/ext/session/tests/session_module_name_variation3.phpt
@@ -41,11 +41,10 @@ ob_end_flush();
 string(%d) "%s"
 string(4) "user"
 
-Warning: Uncaught exception 'Exception' with message 'Stop...!' in %s:%d
+Exception: Stop...! in %s on line %d
 Stack trace:
 #0 [internal function]: open('', 'PHPSESSID')
 #1 %s(%d): session_start()
 #2 {main}
-  thrown in %s on line %d
 
 Fatal error: session_start(): Failed to initialize storage module: %s in %s%esession_module_name_variation3.php on line %d

--- a/ext/session/tests/session_set_save_handler_error3.phpt
+++ b/ext/session/tests/session_set_save_handler_error3.phpt
@@ -34,11 +34,10 @@ ob_end_flush();
 --EXPECTF--
 *** Testing session_set_save_handler() : error functionality ***
 
-Warning: Uncaught exception 'Exception' with message 'Do something bad..!' in %s:%d
+Exception: Do something bad..! in %s on line %d
 Stack trace:
 #0 [internal function]: open('', 'PHPSESSID')
 #1 %s(%d): session_start()
 #2 {main}
-  thrown in %s on line %d
 
 Fatal error: session_start(): Failed to initialize storage module: %s in %ssession_set_save_handler_error3.php on line %d

--- a/ext/soap/tests/bugs/bug42151.phpt
+++ b/ext/soap/tests/bugs/bug42151.phpt
@@ -26,7 +26,7 @@ try {
 echo "ok\n";
 ?>
 --EXPECT--
-SOAP-ERROR: Parsing WSDL: Couldn't load from 'httpx://' : failed to load external entity "httpx://"
+[WSDL] SOAP-ERROR: Parsing WSDL: Couldn't load from 'httpx://' : failed to load external entity "httpx://"
 
 ok
 I don't get executed either.

--- a/ext/soap/tests/bugs/bug44811.phpt
+++ b/ext/soap/tests/bugs/bug44811.phpt
@@ -14,6 +14,6 @@ try {
 die('ok');
 ?>
 --EXPECTF--
-SOAP-ERROR: Parsing WSDL: Couldn't load from 'http://slashdot.org' : %s
+[WSDL] SOAP-ERROR: Parsing WSDL: Couldn't load from 'http://slashdot.org' : %s
 
 ok

--- a/ext/soap/tests/bugs/bug54911.phpt
+++ b/ext/soap/tests/bugs/bug54911.phpt
@@ -13,7 +13,7 @@ Bug #54911 (Access to a undefined member in inherit SoapClient may cause Segment
     $client->__soapCall('', array());
 ?>
 --EXPECTF--
-SoapFault exception: [Client] Access to undeclared static property: XSoapClient::$crash in %sbug54911.php:4
+SoapFault: [Client] Access to undeclared static property: XSoapClient::$crash in %sbug54911.php on line 4
 Stack trace:
 #0 [internal function]: XSoapClient->__doRequest('<?xml version="...', '', '#', 1, 0)
 #1 %sbug54911.php(8): SoapClient->__soapCall('', Array)

--- a/ext/soap/tests/bugs/bug54911.phpt
+++ b/ext/soap/tests/bugs/bug54911.phpt
@@ -13,9 +13,8 @@ Bug #54911 (Access to a undefined member in inherit SoapClient may cause Segment
     $client->__soapCall('', array());
 ?>
 --EXPECTF--
-Fatal error: Uncaught SoapFault exception: [Client] Access to undeclared static property: XSoapClient::$crash in %sbug54911.php:4
+SoapFault exception: [Client] Access to undeclared static property: XSoapClient::$crash in %sbug54911.php:4
 Stack trace:
 #0 [internal function]: XSoapClient->__doRequest('<?xml version="...', '', '#', 1, 0)
 #1 %sbug54911.php(8): SoapClient->__soapCall('', Array)
 #2 {main}
-  thrown in %sbug54911.php on line 4

--- a/ext/spl/tests/DirectoryIterator_empty_constructor.phpt
+++ b/ext/spl/tests/DirectoryIterator_empty_constructor.phpt
@@ -8,8 +8,7 @@ Havard Eide <nucleuz@gmail.com>
 $it = new DirectoryIterator("");
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'RuntimeException' with message 'Directory name must not be empty.' in %s:%d
+RuntimeException: Directory name must not be empty. in %s on line %d
 Stack trace:
 #0 %s(%d): DirectoryIterator->__construct('')
 #1 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/DirectoryIterator_getInode_error.phpt
+++ b/ext/spl/tests/DirectoryIterator_getInode_error.phpt
@@ -21,8 +21,7 @@ var_dump($fileInfo->getInode());
 ?>
 
 --EXPECTF--
-Fatal error: Uncaught exception 'RuntimeException' with message 'SplFileInfo::getInode(): stat failed for %s' in %s
+RuntimeException: SplFileInfo::getInode(): stat failed for %s in %s on line %d
 Stack trace:
 #0 %s: SplFileInfo->getInode()
 #1 {main}
-  thrown in %s

--- a/ext/spl/tests/SplDoublyLinkedList_offsetGet_param_array.phpt
+++ b/ext/spl/tests/SplDoublyLinkedList_offsetGet_param_array.phpt
@@ -11,8 +11,7 @@ $get = $array->offsetGet( array( 'fail' ) );
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'OutOfRangeException' with message 'Offset invalid or out of range' in %s
+OutOfRangeException: Offset invalid or out of range in %s on line %d
 Stack trace:
 #0 %s
 #1 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/SplDoublyLinkedList_offsetGet_param_string.phpt
+++ b/ext/spl/tests/SplDoublyLinkedList_offsetGet_param_string.phpt
@@ -11,8 +11,7 @@ $get = $array->offsetGet( 'fail' );
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'OutOfRangeException' with message 'Offset invalid or out of range' in %s
+OutOfRangeException: Offset invalid or out of range in %s on line %d
 Stack trace:
 #0 %s
 #1 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/SplFileInfo_getGroup_error.phpt
+++ b/ext/spl/tests/SplFileInfo_getGroup_error.phpt
@@ -21,8 +21,7 @@ var_dump($fileInfo->getGroup());
 ?>
 
 --EXPECTF--
-Fatal error: Uncaught exception 'RuntimeException' with message 'SplFileInfo::getGroup(): stat failed for not_existing' in %s
+RuntimeException: SplFileInfo::getGroup(): stat failed for not_existing in %s on line %d
 Stack trace:
 #0 %s: SplFileInfo->getGroup()
 #1 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/SplFileInfo_getInode_error.phpt
+++ b/ext/spl/tests/SplFileInfo_getInode_error.phpt
@@ -21,8 +21,7 @@ var_dump($fileInfo->getInode());
 ?>
 
 --EXPECTF--
-Fatal error: Uncaught exception 'RuntimeException' with message 'SplFileInfo::getInode(): stat failed for not_existing' in %s
+RuntimeException: SplFileInfo::getInode(): stat failed for not_existing in %s on line %d
 Stack trace:
 #0 %s: SplFileInfo->getInode()
 #1 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/SplFileInfo_getOwner_error.phpt
+++ b/ext/spl/tests/SplFileInfo_getOwner_error.phpt
@@ -21,8 +21,7 @@ var_dump($fileInfo->getOwner());
 ?>
 
 --EXPECTF--
-Fatal error: Uncaught exception 'RuntimeException' with message 'SplFileInfo::getOwner(): stat failed for not_existing' in %s
+RuntimeException: SplFileInfo::getOwner(): stat failed for not_existing in %s on line %d
 Stack trace:
 #0 %s: SplFileInfo->getOwner()
 #1 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/SplFileInfo_getPerms_error.phpt
+++ b/ext/spl/tests/SplFileInfo_getPerms_error.phpt
@@ -21,8 +21,7 @@ var_dump($fileInfo->getPerms() == 0100557);
 ?>
 
 --EXPECTF--
-Fatal error: Uncaught exception 'RuntimeException' with message 'SplFileInfo::getPerms(): stat failed for %s' in %s
+RuntimeException: SplFileInfo::getPerms(): stat failed for %s in %s on line %d
 Stack trace:
 #0 %s: SplFileInfo->getPerms()
 #1 {main}
-  thrown in %s

--- a/ext/spl/tests/bug52238.phpt
+++ b/ext/spl/tests/bug52238.phpt
@@ -15,10 +15,9 @@ class Foo implements IteratorAggregate
 var_dump(iterator_to_array(new Foo));
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' in %s
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 %s: Foo->bar()
 #1 [internal function]: Foo->getIterator()
 #2 %s: iterator_to_array(Object(Foo))
 #3 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/bug54281.phpt
+++ b/ext/spl/tests/bug54281.phpt
@@ -12,8 +12,7 @@ foreach($it as $k=>$v) { }
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'LogicException' with message 'The object is in an invalid state as the parent constructor was not called' in %s:%d
+LogicException: The object is in an invalid state as the parent constructor was not called in %s on line %d
 Stack trace:
 #0 %s%ebug54281.php(8): RecursiveIteratorIterator->rewind()
 #1 {main}
-  thrown in %s%ebug54281.php on line 8

--- a/ext/spl/tests/bug54291.phpt
+++ b/ext/spl/tests/bug54291.phpt
@@ -5,9 +5,8 @@ Bug #54291 (Crash iterating DirectoryIterator for dir name starting with \0)
 $dir = new DirectoryIterator("\x00/abc");
 $dir->isFile();
 --EXPECTF--
-Fatal error: Uncaught exception 'UnexpectedValueException' with message 'Failed to open directory ""' in %s:%d
+UnexpectedValueException: Failed to open directory "" in %s on line %d
 Stack trace:
 #0 %s(%d): DirectoryIterator->__construct('\x00/abc')
 #1 {main}
-  thrown in %s on line %d
 

--- a/ext/spl/tests/recursiveIteratorIterator_beginchildren_error.phpt
+++ b/ext/spl/tests/recursiveIteratorIterator_beginchildren_error.phpt
@@ -28,9 +28,8 @@ var_dump($recItIt2->next());
 --EXPECTF--
 NULL
 
-Fatal error: Uncaught exception 'Exception' in %s
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 [internal function]: MyRecursiveIteratorIterator->beginchildren()
 #1 %s: RecursiveIteratorIterator->next()
 #2 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/recursiveIteratorIterator_callHasChildren_error.phpt
+++ b/ext/spl/tests/recursiveIteratorIterator_callHasChildren_error.phpt
@@ -28,9 +28,8 @@ var_dump($recItIt2->next());
 --EXPECTF--
 NULL
 
-Fatal error: Uncaught exception 'Exception' in %s
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 [internal function]: MyRecursiveIteratorIterator->callHasChildren()
 #1 %s: RecursiveIteratorIterator->next()
 #2 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/recursiveIteratorIterator_endchildren_error.phpt
+++ b/ext/spl/tests/recursiveIteratorIterator_endchildren_error.phpt
@@ -34,9 +34,8 @@ foreach ($recItIt2 as $val) echo "$val\n";
 1
 2
 
-Fatal error: Uncaught exception 'Exception' in %s
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 [internal function]: MyRecursiveIteratorIterator->endchildren()
 #1 %s: RecursiveIteratorIterator->next()
 #2 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/recursiveIteratorIterator_nextelement_error.phpt
+++ b/ext/spl/tests/recursiveIteratorIterator_nextelement_error.phpt
@@ -28,9 +28,8 @@ var_dump($recItIt->next());
 --EXPECTF--
 NULL
 
-Fatal error: Uncaught exception 'Exception' in %s
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 [internal function]: MyRecursiveIteratorIterator->nextelement()
 #1 %s: RecursiveIteratorIterator->next()
 #2 {main}
-  thrown in %s on line %d

--- a/ext/spl/tests/spl_autoload_012.phpt
+++ b/ext/spl/tests/spl_autoload_012.phpt
@@ -49,17 +49,16 @@ first
 autoload_first
 autoload_second
 
-Fatal error: Uncaught exception 'Exception' with message 'first' in %sspl_autoload_012.php:%d
+Exception: first in %sspl_autoload_012.php on line %d
 Stack trace:
 #0 [internal function]: autoload_first('ThisClassDoesNo...')
 #1 [internal function]: spl_autoload_call('ThisClassDoesNo...')
 #2 %sspl_autoload_012.php(%d): class_exists('ThisClassDoesNo...')
 #3 {main}
 
-Next exception 'Exception' with message 'second' in %sspl_autoload_012.php:%d
+Next Exception: second in %sspl_autoload_012.php on line %d
 Stack trace:
 #0 [internal function]: autoload_second('ThisClassDoesNo...')
 #1 [internal function]: spl_autoload_call('ThisClassDoesNo...')
 #2 %sspl_autoload_012.php(%d): class_exists('ThisClassDoesNo...')
 #3 {main}
-  thrown in %sspl_autoload_012.php on line %d

--- a/ext/spl/tests/spl_heap_count_basic.phpt
+++ b/ext/spl/tests/spl_heap_count_basic.phpt
@@ -27,9 +27,8 @@ count($heap);// refers to MyHeap->count() method
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'Exception' with message 'Cause count to fail' in %s
+Exception: Cause count to fail in %s on line %d
 Stack trace:
 #0 [internal function]: MyHeap->count()
 #1 %s count(Object(MyHeap))
 #2 {main}
-  thrown in %s on line %d

--- a/ext/standard/tests/array/bug35821.phpt
+++ b/ext/standard/tests/array/bug35821.phpt
@@ -23,10 +23,9 @@ echo "Done\n";
 ?>
 --EXPECTF--	
 
-Fatal error: Uncaught exception 'Exception' in %s:%d
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 %s(%d): Element->ThrowException()
 #1 [internal function]: Element::CallBack(Object(Element))
 #2 %s(%d): array_map(Array, Array)
 #3 {main}
-  thrown in %s on line %d

--- a/ext/standard/tests/file/bug38450_2.phpt
+++ b/ext/standard/tests/file/bug38450_2.phpt
@@ -106,9 +106,8 @@ Warning: Missing argument 1 for VariableStream::__construct() in %s on line %d
 
 Warning: fopen(var://myvar): failed to open stream: "VariableStream::stream_open" call failed in %s on line %d
 
-Fatal error: Uncaught exception 'Exception' with message 'constructor' in %s:%d
+Exception: constructor in %s on line %d
 Stack trace:
 #0 [internal function]: VariableStream->__construct()
 #1 %s(%d): fopen('var://myvar', 'r+')
 #2 {main}
-  thrown in %s on line %d

--- a/tests/basic/timeout_variation_6.phpt
+++ b/tests/basic/timeout_variation_6.phpt
@@ -22,8 +22,7 @@ f($t);
 never reached here
 --EXPECTF--
 call
-Fatal error: Uncaught exception 'Exception' with message 'exception before timeout' in %s:%d
+Exception: exception before timeout in %s on line %d
 Stack trace:
 #0 %s(%d): f(%d)
 #1 {main}
-  thrown in %s on line %d

--- a/tests/lang/bug32828.phpt
+++ b/tests/lang/bug32828.phpt
@@ -13,9 +13,8 @@ ob_start('output_handler');
 ob_end_clean();
 ?>
 --EXPECTF--	
-Fatal error: Uncaught exception 'Exception' in %s:%d
+Exception: (empty message) in %s on line %d
 Stack trace:
 #0 [internal function]: output_handler('', %d)
 #1 %s(%d): ob_end_clean()
 #2 {main}
-  thrown in %s on line %d


### PR DESCRIPTION
The fact that engine exceptions currently display as normal fatal errors is causing a lot of confusion, we will need to switch this to proper exception messages before the release. This PR cleans up the current exception messages to make it feasible to use them for engine exceptions as well.

Old message:

```
Fatal error: Uncaught exception 'UnexpectedValueException' with message 'Failed to open directory ""' in %s:%d
Stack trace:
#0 %s(%d): DirectoryIterator->__construct('\x00/abc')
#1 {main}
  thrown in %s on line %d
```

New message:

```
UnexpectedValueException: Failed to open directory "" in %s on line %d
Stack trace:
#0 %s(%d): DirectoryIterator->__construct('\x00/abc')
#1 {main}
```

Fallout: The error message for an "uncaught exception" is no longer based on `__toString`. Instead a canonical representation is always used.

Internal changes: The error callback now accepts two additional arguments: Firstly, the error type string (like `Fatal error` or `UnexpectedValueException`), which can now be changed independently of the error type. Secondly "additional information" which is to be displayed after the message, file and line information. This is used for exceptions to display the stack trace and "next" exceptions.