### PR TITLE
Use RtlGenRandom instead of CryptGenRandom

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -2012,10 +2012,6 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 	(void)ts_resource(0);
 #endif
 
-#ifdef PHP_WIN32
-	php_win32_init_rng_lock();
-#endif
-
 	module_shutdown = 0;
 	module_startup = 1;
 	sapi_initialize_empty_request();

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -20,7 +20,10 @@
 /* $Id$ */
 
 #include "php.h"
-#include <wincrypt.h>
+// See notes http://msdn.microsoft.com/en-us/library/aa387694(v=vs.85).aspx
+#define SystemFunction036 NTAPI SystemFunction036
+#include <NTSecAPI.h>
+#undef SystemFunction036
 
 PHPAPI char *php_win32_error_to_msg(HRESULT error)
 {
@@ -49,71 +52,12 @@ int php_win32_check_trailing_space(const char * path, const int path_len) {
 	}
 }
 
-HCRYPTPROV   hCryptProv;
-unsigned int has_crypto_ctx = 0;
-
-#ifdef ZTS
-MUTEX_T php_lock_win32_cryptoctx;
-void php_win32_init_rng_lock()
-{
-	php_lock_win32_cryptoctx = tsrm_mutex_alloc();
-}
-
-void php_win32_free_rng_lock()
-{
-	tsrm_mutex_lock(php_lock_win32_cryptoctx);
-	if (has_crypto_ctx == 1) {
-		CryptReleaseContext(hCryptProv, 0);
-		has_crypto_ctx = 0;
-	}
-	tsrm_mutex_unlock(php_lock_win32_cryptoctx);
-	tsrm_mutex_free(php_lock_win32_cryptoctx);
-
-}
-#else
-#define php_win32_init_rng_lock();
-#define php_win32_free_rng_lock();
-#endif
-
-
-
 PHPAPI int php_win32_get_random_bytes(unsigned char *buf, size_t size) {  /* {{{ */
 
 	BOOL ret;
 
-#ifdef ZTS
-	tsrm_mutex_lock(php_lock_win32_cryptoctx);
-#endif
-
-	if (has_crypto_ctx == 0) {
-		/* CRYPT_VERIFYCONTEXT > only hashing&co-like use, no need to acces prv keys */
-		if (!CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL, CRYPT_MACHINE_KEYSET|CRYPT_VERIFYCONTEXT )) {
-			/* Could mean that the key container does not exist, let try
-			   again by asking for a new one. If it fails here, it surely means that the user running
-               this process does not have the permission(s) to use this container.
-             */
-			if (GetLastError() == NTE_BAD_KEYSET) {
-				if (CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL, CRYPT_NEWKEYSET | CRYPT_MACHINE_KEYSET | CRYPT_VERIFYCONTEXT )) {
-					has_crypto_ctx = 1;
-				} else {
-					has_crypto_ctx = 0;
-				}
-			}
-		} else {
-			has_crypto_ctx = 1;
-		}
-	}
-
-#ifdef ZTS
-	tsrm_mutex_unlock(php_lock_win32_cryptoctx);
-#endif
-
-	if (has_crypto_ctx == 0) {
-		return FAILURE;
-	}
-
 	/* XXX should go in the loop if size exceeds UINT_MAX */
-	ret = CryptGenRandom(hCryptProv, (DWORD)size, buf);
+	ret = RtlGenRandom(buf, (DWORD)size);
 
 	if (ret) {
 		return SUCCESS;


### PR DESCRIPTION
Use RtlGenRandom instead of CryptGenRandom as the usage is much simpler. While the function is marked as deprecated a Microsoft developer recommended the following:
http://blogs.msdn.com/b/michael_howard/archive/2005/01/14/353379.aspx

The CRT (rand_s) as well as Windows itself (shell, WRL) use this function.

The proposed change removes the global lock and the dependency to CryptoAPI.
