### PR TITLE
Introduce zend_debug_backtrace_as_string()

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -2615,7 +2615,7 @@ static void _build_trace_string(smart_str *str, HashTable *ht, uint32_t num) /* 
 
 ZEND_API zend_string* zend_debug_backtrace_as_string(zval *trace)
 {
-	zval *frame, rv;
+	zval *frame;
 	zend_ulong index;
 	smart_str str = {0};
 	uint32_t num = 0;

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -2478,17 +2478,17 @@ static void smart_str_append_escaped(smart_str *str, const char *s, size_t l) {
 				case '\\': *res++ = '\\'; break;
 				case VK_ESCAPE: *res++ = 'e'; break;
 				default:
-								*res++ = 'x';
-								if ((c >> 4) < 10) {
-									*res++ = (c >> 4) + '0';
-								} else {
-									*res++ = (c >> 4) + 'A' - 10;
-								}
-								if ((c & 0xf) < 10) {
-									*res++ = (c & 0xf) + '0';
-								} else {
-									*res++ = (c & 0xf) + 'A' - 10;
-								}
+					*res++ = 'x';
+					if ((c >> 4) < 10) {
+						*res++ = (c >> 4) + '0';
+					} else {
+						*res++ = (c >> 4) + 'A' - 10;
+					}
+					if ((c & 0xf) < 10) {
+						*res++ = (c & 0xf) + '0';
+					} else {
+						*res++ = (c & 0xf) + 'A' - 10;
+					}
 			}
 		} else {
 			*res++ = c;

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -27,6 +27,7 @@
 #include "zend_exceptions.h"
 #include "zend_extensions.h"
 #include "zend_closures.h"
+#include "zend_smart_str.h"
 
 #undef ZEND_TEST_EXCEPTIONS
 
@@ -2423,6 +2424,217 @@ ZEND_FUNCTION(debug_print_backtrace)
 		ptr = skip->prev_execute_data;
 		++indent;
 	}
+}
+
+#define TRACE_APPEND_KEY(key) do {										\
+	tmp = zend_hash_str_find(ht, key, sizeof(key)-1);                   \
+	if (tmp) {                                                          \
+		if (Z_TYPE_P(tmp) != IS_STRING) {                               \
+			zend_error(E_WARNING, "Value for %s is no string", key);    \
+			smart_str_appends(str, "[unknown]");                        \
+		} else {                                                        \
+			smart_str_append(str, Z_STR_P(tmp));   \
+		}                                                               \
+	} \
+} while (0)
+
+/* Windows uses VK_ESCAPE instead of \e */
+#ifndef VK_ESCAPE
+#define VK_ESCAPE '\e'
+#endif
+
+static size_t compute_escaped_string_len(const char *s, size_t l) {
+	size_t i, len = l;
+	for (i = 0; i < l; ++i) {
+		char c = s[i];
+		if (c == '\n' || c == '\r' || c == '\t' ||
+				c == '\f' || c == '\v' || c == '\\' || c == VK_ESCAPE) {
+			len += 1;
+		} else if (c < 32 || c > 126) {
+			len += 3;
+		}
+	}
+	return len;
+}
+
+static void smart_str_append_escaped(smart_str *str, const char *s, size_t l) {
+	char *res;
+	size_t i, len = compute_escaped_string_len(s, l);
+
+	smart_str_alloc(str, len, 0);
+	res = &str->s->val[str->s->len];
+	str->s->len += len;
+
+	for (i = 0; i < l; ++i) {
+		char c = s[i];
+		if (c < 32 || c == '\\' || c > 126) {
+			*res++ = '\\';
+			switch (c) {
+				case '\n': *res++ = 'n'; break;
+				case '\r': *res++ = 'r'; break;
+				case '\t': *res++ = 't'; break;
+				case '\f': *res++ = 'f'; break;
+				case '\v': *res++ = 'v'; break;
+				case '\\': *res++ = '\\'; break;
+				case VK_ESCAPE: *res++ = 'e'; break;
+				default:
+								*res++ = 'x';
+								if ((c >> 4) < 10) {
+									*res++ = (c >> 4) + '0';
+								} else {
+									*res++ = (c >> 4) + 'A' - 10;
+								}
+								if ((c & 0xf) < 10) {
+									*res++ = (c & 0xf) + '0';
+								} else {
+									*res++ = (c & 0xf) + 'A' - 10;
+								}
+			}
+		} else {
+			*res++ = c;
+		}
+	}
+}
+
+static void _build_trace_args(zval *arg, smart_str *str) /* {{{ */
+{
+	/* the trivial way would be to do
+	 * convert_to_string_ex(arg);
+	 * append it and kill the now tmp arg.
+	 * but that could cause some E_NOTICE and also damn long lines.
+	 */
+
+	ZVAL_DEREF(arg);
+	switch (Z_TYPE_P(arg)) {
+		case IS_NULL:
+			smart_str_appends(str, "NULL, ");
+			break;
+		case IS_STRING:
+			smart_str_appendc(str, '\'');
+			smart_str_append_escaped(str, Z_STRVAL_P(arg), MIN(Z_STRLEN_P(arg), 15));
+			if (Z_STRLEN_P(arg) > 15) {
+				smart_str_appends(str, "...', ");
+			} else {
+				smart_str_appends(str, "', ");
+			}
+			break;
+		case IS_FALSE:
+			smart_str_appends(str, "false, ");
+			break;
+		case IS_TRUE:
+			smart_str_appends(str, "true, ");
+			break;
+		case IS_RESOURCE:
+			smart_str_appends(str, "Resource id #");
+			smart_str_append_long(str, Z_RES_HANDLE_P(arg));
+			smart_str_appends(str, ", ");
+			break;
+		case IS_LONG:
+			smart_str_append_long(str, Z_LVAL_P(arg));
+			smart_str_appends(str, ", ");
+			break;
+		case IS_DOUBLE: {
+			double dval = Z_DVAL_P(arg);
+			char *s_tmp = emalloc(MAX_LENGTH_OF_DOUBLE + EG(precision) + 1);
+			int l_tmp = zend_sprintf(s_tmp, "%.*G", (int) EG(precision), dval);  /* SAFE */
+			smart_str_appendl(str, s_tmp, l_tmp);
+			smart_str_appends(str, ", ");
+			efree(s_tmp);
+			break;
+		}
+		case IS_ARRAY:
+			smart_str_appends(str, "Array, ");
+			break;
+		case IS_OBJECT:
+			smart_str_appends(str, "Object(");
+			smart_str_append(str, Z_OBJCE_P(arg)->name);
+			smart_str_appends(str, "), ");
+			break;
+	}
+}
+/* }}} */
+
+static void _build_trace_string(smart_str *str, HashTable *ht, uint32_t num) /* {{{ */
+{
+	zval *file, *tmp;
+
+	smart_str_appendc(str, '#');
+	smart_str_append_long(str, num);
+	smart_str_appendc(str, ' ');
+
+	file = zend_hash_str_find(ht, "file", sizeof("file")-1);
+	if (file) {
+		if (Z_TYPE_P(file) != IS_STRING) {
+			zend_error(E_WARNING, "Function name is no string");
+			smart_str_appends(str, "[unknown function]");
+		} else{
+			zend_long line;
+			tmp = zend_hash_str_find(ht, "line", sizeof("line")-1);
+			if (tmp) {
+				if (Z_TYPE_P(tmp) == IS_LONG) {
+					line = Z_LVAL_P(tmp);
+				} else {
+					zend_error(E_WARNING, "Line is no long");
+					line = 0;
+				}
+			} else {
+				line = 0;
+			}
+			smart_str_append(str, Z_STR_P(file));
+			smart_str_appendc(str, '(');
+			smart_str_append_long(str, line);
+			smart_str_appends(str, "): ");
+		}
+	} else {
+		smart_str_appends(str, "[internal function]: ");
+	}
+	TRACE_APPEND_KEY("class");
+	TRACE_APPEND_KEY("type");
+	TRACE_APPEND_KEY("function");
+	smart_str_appendc(str, '(');
+	tmp = zend_hash_str_find(ht, "args", sizeof("args")-1);
+	if (tmp) {
+		if (Z_TYPE_P(tmp) == IS_ARRAY) {
+			size_t last_len = str->s->len;
+			zval *arg;
+
+			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(tmp), arg) {
+				_build_trace_args(arg, str);
+			} ZEND_HASH_FOREACH_END();
+
+			if (last_len != str->s->len) {
+				str->s->len -= 2; /* remove last ', ' */
+			}
+		} else {
+			zend_error(E_WARNING, "args element is no array");
+		}
+	}
+	smart_str_appends(str, ")\n");
+}
+/* }}} */
+
+ZEND_API zend_string* zend_debug_backtrace_as_string(zval *trace)
+{
+	zval *frame, rv;
+	zend_ulong index;
+	smart_str str = {0};
+	uint32_t num = 0;
+
+	ZEND_HASH_FOREACH_NUM_KEY_VAL(Z_ARRVAL_P(trace), index, frame) {
+		if (Z_TYPE_P(frame) != IS_ARRAY) {
+			zend_error(E_WARNING, "Expected array for frame %pu", index);
+			continue;
+		}
+
+		_build_trace_string(&str, Z_ARRVAL_P(frame), num++);
+	} ZEND_HASH_FOREACH_END();
+
+	smart_str_appendc(&str, '#');
+	smart_str_append_long(&str, num);
+	smart_str_appends(&str, " {main}");
+	smart_str_0(&str);
+
+	return str.s;
 }
 
 /* }}} */

--- a/Zend/zend_builtin_functions.h
+++ b/Zend/zend_builtin_functions.h
@@ -26,6 +26,7 @@ int zend_startup_builtin_functions(void);
 
 BEGIN_EXTERN_C()
 ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int options, int limit);
+ZEND_API zend_string* zend_debug_backtrace_as_string(zval *trace);
 END_EXTERN_C()
 
 #endif /* ZEND_BUILTIN_FUNCTIONS_H */

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -28,7 +28,6 @@
 #include "zend_exceptions.h"
 #include "zend_vm.h"
 #include "zend_dtrace.h"
-#include "zend_smart_str.h"
 
 static zend_class_entry *base_exception_ce;
 static zend_class_entry *default_exception_ce;
@@ -358,220 +357,20 @@ ZEND_METHOD(error_exception, getSeverity)
 }
 /* }}} */
 
-#define TRACE_APPEND_KEY(key) do {                                          \
-		tmp = zend_hash_str_find(ht, key, sizeof(key)-1);                   \
-		if (tmp) {                                                          \
-			if (Z_TYPE_P(tmp) != IS_STRING) {                               \
-				zend_error(E_WARNING, "Value for %s is no string", key);    \
-				smart_str_appends(str, "[unknown]");                        \
-			} else {                                                        \
-				smart_str_append(str, Z_STR_P(tmp));   \
-			}                                                               \
-		} \
-	} while (0)
-
-/* Windows uses VK_ESCAPE instead of \e */
-#ifndef VK_ESCAPE
-#define VK_ESCAPE '\e'
-#endif
-
-static size_t compute_escaped_string_len(const char *s, size_t l) {
-	size_t i, len = l;
-	for (i = 0; i < l; ++i) {
-		char c = s[i];
-		if (c == '\n' || c == '\r' || c == '\t' ||
-			c == '\f' || c == '\v' || c == '\\' || c == VK_ESCAPE) {
-			len += 1;
-		} else if (c < 32 || c > 126) {
-			len += 3;
-		}
-	}
-	return len;
-}
-
-static void smart_str_append_escaped(smart_str *str, const char *s, size_t l) {
-	char *res;
-	size_t i, len = compute_escaped_string_len(s, l);
-
-	smart_str_alloc(str, len, 0);
-	res = &str->s->val[str->s->len];
-	str->s->len += len;
-
-	for (i = 0; i < l; ++i) {
-		char c = s[i];
-		if (c < 32 || c == '\\' || c > 126) {
-			*res++ = '\\';
-			switch (c) {
-				case '\n': *res++ = 'n'; break;
-				case '\r': *res++ = 'r'; break;
-				case '\t': *res++ = 't'; break;
-				case '\f': *res++ = 'f'; break;
-				case '\v': *res++ = 'v'; break;
-				case '\\': *res++ = '\\'; break;
-				case VK_ESCAPE: *res++ = 'e'; break;
-				default:
-					*res++ = 'x';
-					if ((c >> 4) < 10) {
-						*res++ = (c >> 4) + '0';
-					} else {
-						*res++ = (c >> 4) + 'A' - 10;
-					}
-					if ((c & 0xf) < 10) {
-						*res++ = (c & 0xf) + '0';
-					} else {
-						*res++ = (c & 0xf) + 'A' - 10;
-					}
-			}
-		} else {
-			*res++ = c;
-		}
-	}
-}
-
-static void _build_trace_args(zval *arg, smart_str *str) /* {{{ */
-{
-	/* the trivial way would be to do
-	 * convert_to_string_ex(arg);
-	 * append it and kill the now tmp arg.
-	 * but that could cause some E_NOTICE and also damn long lines.
-	 */
-
-	ZVAL_DEREF(arg);
-	switch (Z_TYPE_P(arg)) {
-		case IS_NULL:
-			smart_str_appends(str, "NULL, ");
-			break;
-		case IS_STRING:
-			smart_str_appendc(str, '\'');
-			smart_str_append_escaped(str, Z_STRVAL_P(arg), MIN(Z_STRLEN_P(arg), 15));
-			if (Z_STRLEN_P(arg) > 15) {
-				smart_str_appends(str, "...', ");
-			} else {
-				smart_str_appends(str, "', ");
-			}
-			break;
-		case IS_FALSE:
-			smart_str_appends(str, "false, ");
-			break;
-		case IS_TRUE:
-			smart_str_appends(str, "true, ");
-			break;
-		case IS_RESOURCE:
-			smart_str_appends(str, "Resource id #");
-			smart_str_append_long(str, Z_RES_HANDLE_P(arg));
-			smart_str_appends(str, ", ");
-			break;
-		case IS_LONG:
-			smart_str_append_long(str, Z_LVAL_P(arg));
-			smart_str_appends(str, ", ");
-			break;
-		case IS_DOUBLE: {
-			double dval = Z_DVAL_P(arg);
-			char *s_tmp = emalloc(MAX_LENGTH_OF_DOUBLE + EG(precision) + 1);
-			int l_tmp = zend_sprintf(s_tmp, "%.*G", (int) EG(precision), dval);  /* SAFE */
-			smart_str_appendl(str, s_tmp, l_tmp);
-			smart_str_appends(str, ", ");
-			efree(s_tmp);
-			break;
-		}
-		case IS_ARRAY:
-			smart_str_appends(str, "Array, ");
-			break;
-		case IS_OBJECT:
-			smart_str_appends(str, "Object(");
-			smart_str_append(str, Z_OBJCE_P(arg)->name);
-			smart_str_appends(str, "), ");
-			break;
-	}
-}
-/* }}} */
-
-static void _build_trace_string(smart_str *str, HashTable *ht, uint32_t num) /* {{{ */
-{
-	zval *file, *tmp;
-
-	smart_str_appendc(str, '#');
-	smart_str_append_long(str, num);
-	smart_str_appendc(str, ' ');
-
-	file = zend_hash_str_find(ht, "file", sizeof("file")-1);
-	if (file) {
-		if (Z_TYPE_P(file) != IS_STRING) {
-			zend_error(E_WARNING, "Function name is no string");
-			smart_str_appends(str, "[unknown function]");
-		} else{
-			zend_long line;
-			tmp = zend_hash_str_find(ht, "line", sizeof("line")-1);
-			if (tmp) {
-				if (Z_TYPE_P(tmp) == IS_LONG) {
-					line = Z_LVAL_P(tmp);
-				} else {
-					zend_error(E_WARNING, "Line is no long");
-					line = 0;
-				}
-			} else {
-				line = 0;
-			}
-			smart_str_append(str, Z_STR_P(file));
-			smart_str_appendc(str, '(');
-			smart_str_append_long(str, line);
-			smart_str_appends(str, "): ");
-		}
-	} else {
-		smart_str_appends(str, "[internal function]: ");
-	}
-	TRACE_APPEND_KEY("class");
-	TRACE_APPEND_KEY("type");
-	TRACE_APPEND_KEY("function");
-	smart_str_appendc(str, '(');
-	tmp = zend_hash_str_find(ht, "args", sizeof("args")-1);
-	if (tmp) {
-		if (Z_TYPE_P(tmp) == IS_ARRAY) {
-			size_t last_len = str->s->len;
-			zval *arg;
-
-			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(tmp), arg) {
-				_build_trace_args(arg, str);
-			} ZEND_HASH_FOREACH_END();
-
-			if (last_len != str->s->len) {
-				str->s->len -= 2; /* remove last ', ' */
-			}
-		} else {
-			zend_error(E_WARNING, "args element is no array");
-		}
-	}
-	smart_str_appends(str, ")\n");
-}
-/* }}} */
-
 /* {{{ proto string Exception::getTraceAsString()
    Obtain the backtrace for the exception as a string (instead of an array) */
 ZEND_METHOD(exception, getTraceAsString)
 {
-	zval *trace, *frame, rv;
-	zend_ulong index;
-	smart_str str = {0};
-	uint32_t num = 0;
+	zval *trace, rv;
+	zend_string *trace_str;
 
 	DEFAULT_0_PARAMS;
 
 	trace = zend_read_property(base_exception_ce, getThis(), "trace", sizeof("trace")-1, 1, &rv);
-	ZEND_HASH_FOREACH_NUM_KEY_VAL(Z_ARRVAL_P(trace), index, frame) {
-		if (Z_TYPE_P(frame) != IS_ARRAY) {
-			zend_error(E_WARNING, "Expected array for frame %pu", index);
-			continue;
-		}
 
-		_build_trace_string(&str, Z_ARRVAL_P(frame), num++);
-	} ZEND_HASH_FOREACH_END();
+	trace_str = zend_debug_backtrace_as_string(trace);
 
-	smart_str_appendc(&str, '#');
-	smart_str_append_long(&str, num);
-	smart_str_appends(&str, " {main}");
-	smart_str_0(&str);
-
-	RETURN_NEW_STR(str.s);
+	RETURN_NEW_STR(trace_str);
 }
 /* }}} */
 


### PR DESCRIPTION
Refactor code from `Exception#getTraceAsString()` into Zend/zend_builtin_functions.c as PHP_API and
reuse from zend_exceptions.c

This is the first step towards a new PHP function `debug_backtrace_string();` which behaves the same as `Exception#getTraceAsString()`.

Additionally this is helpful for logging and for extensions that work with errors.
