### PR TITLE
Remove MSIE 5-specific Cache-Control fields.

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1216,7 +1216,7 @@ CACHE_LIMITER_FUNC(private_no_expire) /* {{{ */
 {
 	char buf[MAX_STR + 1];
 
-	snprintf(buf, sizeof(buf), "Cache-Control: private, max-age=" ZEND_LONG_FMT ", pre-check=" ZEND_LONG_FMT, PS(cache_expire) * 60, PS(cache_expire) * 60); /* SAFE */
+	snprintf(buf, sizeof(buf), "Cache-Control: private, max-age=" ZEND_LONG_FMT, PS(cache_expire) * 60); /* SAFE */
 	ADD_HEADER(buf);
 
 	last_modified();
@@ -1234,8 +1234,8 @@ CACHE_LIMITER_FUNC(nocache) /* {{{ */
 {
 	ADD_HEADER("Expires: Thu, 19 Nov 1981 08:52:00 GMT");
 
-	/* For HTTP/1.1 conforming clients and the rest (MSIE 5) */
-	ADD_HEADER("Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0");
+	/* For HTTP/1.1 conforming clients */
+	ADD_HEADER("Cache-Control: no-store, no-cache, must-revalidate");
 
 	/* For HTTP/1.0 conforming clients */
 	ADD_HEADER("Pragma: no-cache");


### PR DESCRIPTION
As it was mentioned in https://github.com/rails/rails/pull/19556#issuecomment-92073248 by @matthewd (based on great "research"), it is useless to support MSIE 5 specific `pre-check` and `post-check` Cache-Control fields now.

This patch was tested via built-in web server, cURL calls and following script:

```php
<?php
session_cache_limiter("nocache"); // "private_no_expire" or "private"
session_start();
?>
```

And it works as expected.

There are no tests for `session_cache_limiter` function.
[Local `make test`](https://gist.github.com/simi/df19ae81a69a74c57f5b) is not passing, but I hope it is not related to this patch since it fails with same fails without this patch.

This is revert of 04daa55.