### PR TITLE
resetting to DEFAULT_SLASH instead of '/' (unixoid slash)

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -776,7 +776,7 @@ static void php_cgi_ini_activate_user_config(char *path, size_t path_len, const 
 			while ((ptr = strchr(ptr, DEFAULT_SLASH)) != NULL) {
 				*ptr = 0;
 				php_parse_user_ini_file(path, PG(user_ini_filename), entry->user_config);
-				*ptr = '/';
+				*ptr = DEFAULT_SLASH;
 				ptr++;
 			}
 		} else {

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -784,23 +784,23 @@ static void php_cgi_ini_activate_user_config(char *path, size_t path_len, const 
 			 */
 			for(;;)  {
 				
-				/* strchr may return NULL and so destroy our ptr, so we use tmp_ptr to store the result;
-				 * if tmp_ptr is not NULL, it points to the position of the next slash
+				/* strchr may return NULL and so destroy our ptr, so we use slash_pt to store the result;
+				 * if slash_ptr is not NULL, it points to the position of the next slash
 				 */
-				char *tmp_ptr = strchr(ptr, DEFAULT_SLASH);
+				char *slash_ptr = strchr(ptr, DEFAULT_SLASH);
 				
 				/* only zero out the char if it is a slash */
-				if (tmp_ptr != NULL) {  *tmp_ptr = 0; }
+				if (slash_ptr != NULL) {  *slash_ptr = 0; }
 				php_parse_user_ini_file(path, PG(user_ini_filename), entry->user_config TSRMLS_CC);
 				
 				/* reset to slash, if it was one before */
-				if (tmp_ptr != NULL) { *tmp_ptr = DEFAULT_SLASH; }
+				if (slash_ptr != NULL) { *slash_ptr = DEFAULT_SLASH; }
 				
 				/* no, there was no slash, so there is also no further subdirectory; exit the loop */
 				else                 { break; }
 				
 				/* jump behind the previously found slash and enter the next iteration */
-				ptr = tmp_ptr + 1;
+				ptr = slash_ptr + 1;
 				
 				/*
 			    printf(">>> searching for '%c' in '%s'+%d\n", DEFAULT_SLASH, s2, (ptr-s2));

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -772,19 +772,21 @@ static void php_cgi_ini_activate_user_config(char *path, size_t path_len, const 
 #else
 		if (strncmp(s1, s2, s_len) == 0) {
 #endif
+			int has_subfolder = 1;
 			ptr = s2 + start;  /* start is the point where doc_root ends! */
-			/*
+			
+			#ifdef teeshop_0
 			printf(">>> searching for '%c' in '%s'+%d\n", DEFAULT_SLASH, s2, (ptr-s2));
 			printf(">>>                       ");for (idx=0; idx<(ptr-s2); ++idx) { printf(" "); }printf("^\n");
 			printf(">>> ----------------------");for (idx=0; idx<(ptr-s2); ++idx) { printf("-"); }printf("+\n");
-			*/
+			#endif /* teeshop_0 */
 			
 			/* loop until no more slash can be found. if there is no more slash,
 			 * then search for .user.ini in the current directory and exit the loop
 			 */
-			for(;;)  {
+			while(has_subfolder)  {
 				
-				/* strchr may return NULL and so destroy our ptr, so we use slash_pt to store the result;
+				/* strchr may return NULL and so destroy our ptr, so we use slash_ptr to store the result;
 				 * if slash_ptr is not NULL, it points to the position of the next slash
 				 */
 				char *slash_ptr = strchr(ptr, DEFAULT_SLASH);
@@ -797,16 +799,16 @@ static void php_cgi_ini_activate_user_config(char *path, size_t path_len, const 
 				if (slash_ptr != NULL) { *slash_ptr = DEFAULT_SLASH; }
 				
 				/* no, there was no slash, so there is also no further subdirectory; exit the loop */
-				else                 { break; }
+				else                   { has_subfolder = 0; continue; }
 				
 				/* jump behind the previously found slash and enter the next iteration */
 				ptr = slash_ptr + 1;
 				
-				/*
+				#ifdef teeshop_0
 			    printf(">>> searching for '%c' in '%s'+%d\n", DEFAULT_SLASH, s2, (ptr-s2));
 				printf(">>>                       ");for (idx=0; idx<(ptr-s2); ++idx) { printf(" "); }printf("^\n");
 				printf(">>> ----------------------");for (idx=0; idx<(ptr-s2); ++idx) { printf("-"); }printf("+\n");
-			    */
+			    #endif /* teeshop_0 */
 			}
 		} else {
 			php_parse_user_ini_file(path, PG(user_ini_filename), entry->user_config);


### PR DESCRIPTION
Hi,

is there any reason why you replace the `DEFAULT_SLASH` to which `ptr` points to, by `'/'`? If you do so, you may make the directory name unreadable for the current system :-/
