### PR TITLE
Support SEARCH HTTP verb in CLI HTTP server

### DIFF
--- a/sapi/cli/php_http_parser.c
+++ b/sapi/cli/php_http_parser.c
@@ -589,7 +589,7 @@ size_t php_http_parser_execute (php_http_parser *parser,
           case 'O': parser->method = PHP_HTTP_OPTIONS; break;
           case 'P': parser->method = PHP_HTTP_POST; /* or PROPFIND or PROPPATCH or PUT */ break;
           case 'R': parser->method = PHP_HTTP_REPORT; break;
-          case 'S': parser->method = PHP_HTTP_SUBSCRIBE; break;
+          case 'S': parser->method = PHP_HTTP_SUBSCRIBE; /* or SEARCH */ break;
           case 'T': parser->method = PHP_HTTP_TRACE; break;
           case 'U': parser->method = PHP_HTTP_UNLOCK; /* or UNSUBSCRIBE */ break;
           default: parser->method = PHP_HTTP_NOT_IMPLEMENTED; break;
@@ -597,7 +597,6 @@ size_t php_http_parser_execute (php_http_parser *parser,
         state = s_req_method;
         break;
       }
-
       case s_req_method:
       {
         const char *matcher;

--- a/sapi/cli/php_http_parser.c
+++ b/sapi/cli/php_http_parser.c
@@ -91,6 +91,7 @@ static const char *method_strings[] =
   , "MOVE"
   , "PROPFIND"
   , "PROPPATCH"
+  , "SEARCH"
   , "UNLOCK"
   , "REPORT"
   , "MKACTIVITY"
@@ -630,6 +631,8 @@ size_t php_http_parser_execute (php_http_parser *parser,
           parser->method = PHP_HTTP_PUT;
         } else if (index == 1 && parser->method == PHP_HTTP_POST && ch == 'A') {
           parser->method = PHP_HTTP_PATCH;
+        } else if (index == 1 && parser->method == PHP_HTTP_SUBSCRIBE && ch == 'E') {
+          parser->method = PHP_HTTP_SEARCH;
         } else if (index == 2 && parser->method == PHP_HTTP_UNLOCK && ch == 'S') {
           parser->method = PHP_HTTP_UNSUBSCRIBE;
         } else if (index == 4 && parser->method == PHP_HTTP_PROPFIND && ch == 'P') {

--- a/sapi/cli/php_http_parser.h
+++ b/sapi/cli/php_http_parser.h
@@ -90,6 +90,7 @@ enum php_http_method
   , PHP_HTTP_MOVE
   , PHP_HTTP_PROPFIND
   , PHP_HTTP_PROPPATCH
+  , PHP_HTTP_SEARCH
   , PHP_HTTP_UNLOCK
   /* subversion */
   , PHP_HTTP_REPORT

--- a/sapi/cli/tests/php_cli_server_020.phpt
+++ b/sapi/cli/tests/php_cli_server_020.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Use SEARCH as a HTTP verb
+--SKIPIF--
+<?php
+include "skipif.inc"; 
+?>
+--FILE--
+<?php
+include "php_cli_server.inc";
+php_cli_server_start('var_dump($_SERVER["REQUEST_METHOD"]);');
+
+list($host, $port) = explode(':', PHP_CLI_SERVER_ADDRESS);
+$port = intval($port) ?: 80;
+
+$fp = fsockopen($host, $port, $errno, $errstr, 0.5);
+if (!$fp) {
+  die("connect failed");
+}
+
+if(fwrite($fp, <<<HEADER
+SEARCH / HTTP/1.1
+Host: {$host}
+
+
+HEADER
+)) {
+	while (!feof($fp)) {
+		echo fgets($fp);
+	}
+}
+
+?>
+--EXPECTF--	
+HTTP/1.1 200 OK
+Host: %s
+Connection: close
+X-Powered-By: PHP/%s
+Content-type: text/html; charset=UTF-8
+
+string(6) "SEARCH"


### PR DESCRIPTION
This PR adds support for the "SEARCH" HTTP verb. The verb is described in RFC5323 (for WebDAV) and is meant to initiate a server side search for a resource.