### PR TITLE
Treat relative symlink target paths on Windows like on Linux

### DIFF
--- a/ext/standard/link_win32.c
+++ b/ext/standard/link_win32.c
@@ -166,7 +166,7 @@ PHP_FUNCTION(symlink)
 		RETURN_FALSE;
 	}
 
-	if ((attr = GetFileAttributes(topath)) == INVALID_FILE_ATTRIBUTES) {
+	if ((attr = GetFileAttributes(dest_p)) == INVALID_FILE_ATTRIBUTES) {
 			php_error_docref(NULL, E_WARNING, "Could not fetch file information(error %d)", GetLastError());
 			RETURN_FALSE;
 	}


### PR DESCRIPTION
On Windows relative target paths refer to the CWD, while on Linux they refer to the link itself. This PR is supposed to adapt the Windows behavior to that of Linux, i.e. it fixes #69473.

I think this should be done for PHP 7; I'm not sure about PHP 5.5 and 5.6, as this constitutes a BC break.

Currently, no tests are included, because it seems that many tests using symlink() are skipped on Windows anyway. 
