### PR TITLE
Binary Search implementation In Array.c

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1376,7 +1376,7 @@ static inline void php_array_binary_search(INTERNAL_FUNCTION_PARAMETERS, int beh
 			entry = zend_hash_index_find(arr_hash, mid);
 
 			compare_function(&result, value, entry);
-  
+			php_printf("%d\n",Z_LVAL(result));
 			if (Z_LVAL(result) < 0) {
 				high = mid - 1;
 			} else if (Z_LVAL(result) > 0) {
@@ -1386,7 +1386,7 @@ static inline void php_array_binary_search(INTERNAL_FUNCTION_PARAMETERS, int beh
 				if (Z_TYPE(result) == IS_TRUE) {
 					RETURN_TRUE;
 				} else {
-					high = mid - 1;
+					low = mid + 1;
 				}	
 			}
 		}

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -83,9 +83,11 @@
 #define INTERSECT_COMP_KEY_USER      1
 
 #define DOUBLE_DRIFT_FIX	0.000000000000001
+
 /* }}} */
 
 ZEND_DECLARE_MODULE_GLOBALS(array)
+
 
 /* {{{ php_array_init_globals
 */
@@ -94,6 +96,7 @@ static void php_array_init_globals(zend_array_globals *array_globals)
 	memset(array_globals, 0, sizeof(zend_array_globals));
 }
 /* }}} */
+
 
 PHP_MINIT_FUNCTION(array) /* {{{ */
 {
@@ -1332,7 +1335,86 @@ static inline void php_search_array(INTERNAL_FUNCTION_PARAMETERS, int behavior) 
 
 	RETURN_FALSE;
 }
+
+
+
+
 /* }}} */
+
+/* void php_binary_search_array(INTERNAL_FUNCTION_PARAMETERS, int behavior)
+ *  * 0 = return boolean
+ *   * 1 = return key
+ *    */
+
+static inline void php_binary_search_array(INTERNAL_FUNCTION_PARAMETERS, int behavior) /* {{{ */
+{
+    zval *value,                /* value to check for */
+         *array,                /* array to check in */
+         *entry;                /* pointer to array entry*/
+    zend_bool strict = 0;       /* strict comparison or not */
+
+#ifndef FAST_ZPP
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "za|b", &value, &array, &strict) == FAILURE) {
+        return;
+    }
+#else
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_ZVAL(value)
+        Z_PARAM_ARRAY(array)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(strict)
+    ZEND_PARSE_PARAMETERS_END();
+#endif
+    HashTable *arr_hash;
+    arr_hash = Z_ARRVAL_P(array);
+ 
+	int low=0; 
+    int high=zend_hash_num_elements(arr_hash);
+	int mid;
+
+    zval result;
+    if(strict){
+		while(low<=high){
+             mid=(low+high)/2;
+
+             ZVAL_DEREF(entry);
+             entry = zend_hash_index_find(arr_hash, mid);
+
+			 is_larger_function("ass","ass","sa");
+			 if(Z_LVAL(result) > 0){
+                high=mid-1;
+             }
+             else if(Z_LVAL(result) < 0){
+                low=mid+1;
+             }else{
+                 RETURN_TRUE;
+             }
+		}		
+	}else{
+		while(low<=high){
+			 mid=(low+high)/2;
+		
+    		 ZVAL_DEREF(entry);
+	         entry = zend_hash_index_find(arr_hash, mid);	     
+    
+		     compare_function(&result,entry,value);
+         
+			 if(Z_LVAL(result) > 0){
+		   		high=mid-1;
+			 }
+		 	 else if(Z_LVAL(result) < 0){
+				low=mid+1;
+			 }else{
+				 RETURN_TRUE;
+	    	 }		
+		}
+    }
+    RETURN_FALSE;
+}
+/* }}} */
+
+
+
 
 /* {{{ proto bool in_array(mixed needle, array haystack [, bool strict])
    Checks if the given value exists in the array */
@@ -1340,7 +1422,21 @@ PHP_FUNCTION(in_array)
 {
 	php_search_array(INTERNAL_FUNCTION_PARAM_PASSTHRU, 0);
 }
+
 /* }}} */
+
+
+/* {{{ proto bool binary_search(mixed needle, array haystack [, bool strict])
+ *    Checks if the given value exists in the array using binary search*/
+PHP_FUNCTION(binary_search)
+{
+	php_binary_search_array(INTERNAL_FUNCTION_PARAM_PASSTHRU, 0);
+}
+
+
+
+/* }}} */
+
 
 /* {{{ proto mixed array_search(mixed needle, array haystack [, bool strict])
    Searches the array for a given value and returns the corresponding key if successful */
@@ -1348,7 +1444,10 @@ PHP_FUNCTION(array_search)
 {
 	php_search_array(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1);
 }
+
 /* }}} */
+
+
 
 static int php_valid_var_name(char *var_name, size_t var_name_len) /* {{{ */
 {
@@ -1400,6 +1499,7 @@ PHPAPI int php_prefix_varname(zval *result, zval *prefix, char *var_name, size_t
 
 	return SUCCESS;
 }
+
 /* }}} */
 
 /* {{{ proto int extract(array var_array [, int extract_type [, string prefix]])
@@ -1655,6 +1755,10 @@ PHP_FUNCTION(array_fill)
 	}
 }
 /* }}} */
+
+
+
+
 
 /* {{{ proto array array_fill_keys(array keys, mixed val)
    Create an array using the elements of the first parameter as keys each initialized to val */

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1335,15 +1335,11 @@ static inline void php_search_array(INTERNAL_FUNCTION_PARAMETERS, int behavior) 
 
 	RETURN_FALSE;
 }
-
-
-
-
 /* }}} */
 
 /* void php_array_binary_search(INTERNAL_FUNCTION_PARAMETERS, int behavior)
- *  * 0 = return boolean
- *   * 1 = return key
+ * 0 = return boolean
+ * 1 = return key
  */
 static inline void php_array_binary_search(INTERNAL_FUNCTION_PARAMETERS, int behavior) /* {{{ */
 {
@@ -1364,61 +1360,57 @@ static inline void php_array_binary_search(INTERNAL_FUNCTION_PARAMETERS, int beh
         Z_PARAM_BOOL(strict)
     ZEND_PARSE_PARAMETERS_END();
 #endif
-    HashTable *arr_hash;
-    arr_hash = Z_ARRVAL_P(array);
+	HashTable *arr_hash;
+	arr_hash = Z_ARRVAL_P(array);
  
 	int low=0; 
-    int high=zend_hash_num_elements(arr_hash)-1;
+	int high=zend_hash_num_elements(arr_hash)-1;
 	int mid;
 
-    zval result;
-    if(strict){	
+	zval result;
+	if(strict){	
 		while(low<=high){
-             mid=(low+high)/2;
+			mid=(low+high)/2;
         
-             ZVAL_DEREF(entry);
-             entry = zend_hash_index_find(arr_hash, mid);
+			ZVAL_DEREF(entry);
+			entry = zend_hash_index_find(arr_hash, mid);
 
-			 compare_function(&result, value, entry);
+			compare_function(&result, value, entry);
   
-			 if(Z_LVAL(result) < 0){
-        	 	high=mid-1;
-			 }else if(Z_LVAL(result) > 0){
-	            low=mid+1;
-			 }else{
+			if(Z_LVAL(result) < 0){
+				high=mid-1;
+			}else if(Z_LVAL(result) > 0){
+				low=mid+1;
+			}else{
 				fast_is_identical_function(&result, value, entry);
-			 	if(Z_TYPE(result) == IS_TRUE){
-    		            RETURN_TRUE;
+				if(Z_TYPE(result) == IS_TRUE){
+					RETURN_TRUE;
 				}else{
-						high=mid-1;
+					high=mid-1;
 				}	
 			}
 		}
 	}else{
 		while(low<=high){
-		 	 mid=(low+high)/2;
+			mid=(low+high)/2;
 		
-    		 ZVAL_DEREF(entry);
-	         entry = zend_hash_index_find(arr_hash, mid);	     
+			ZVAL_DEREF(entry);
+			entry = zend_hash_index_find(arr_hash, mid);	     
     
-		     compare_function(&result,entry,value);
+			compare_function(&result,entry,value);
          
-			 if(Z_LVAL(result) < 0){
-		   	  	low=mid+1;
-			 }
-		 	 else if(Z_LVAL(result) > 0){
+			if(Z_LVAL(result) < 0){
+				low=mid+1;
+			}else if(Z_LVAL(result) > 0){
 				high=mid-1;
-			 }else{
+			}else{
 				RETURN_TRUE;
-	    	 }		
+			}		
 		}
-    }
-    RETURN_FALSE;
+	}
+	RETURN_FALSE;
 }
 /* }}} */
-
-
-
 
 /* {{{ proto bool in_array(mixed needle, array haystack [, bool strict])
    Checks if the given value exists in the array */
@@ -1429,16 +1421,14 @@ PHP_FUNCTION(in_array)
 
 /* }}} */
 
-
-/* {{{ proto bool binary_search(mixed needle, array haystack [, bool strict])
+/* {{{ proto bool array_binary_search(mixed needle, array haystack [, bool strict])
  *    Checks if the given value exists in the array using binary search*/
-PHP_FUNCTION(binary_search)
+PHP_FUNCTION(array_binary_search)
 {
 	php_array_binary_search(INTERNAL_FUNCTION_PARAM_PASSTHRU, 0);
 }
 
 /* }}} */
-
 
 /* {{{ proto mixed array_search(mixed needle, array haystack [, bool strict])
    Searches the array for a given value and returns the corresponding key if successful */
@@ -1448,8 +1438,6 @@ PHP_FUNCTION(array_search)
 }
 
 /* }}} */
-
-
 
 static int php_valid_var_name(char *var_name, size_t var_name_len) /* {{{ */
 {

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1376,7 +1376,7 @@ static inline void php_array_binary_search(INTERNAL_FUNCTION_PARAMETERS, int beh
 			entry = zend_hash_index_find(arr_hash, mid);
 
 			compare_function(&result, value, entry);
-			php_printf("%d\n",Z_LVAL(result));
+
 			if (Z_LVAL(result) < 0) {
 				high = mid - 1;
 			} else if (Z_LVAL(result) > 0) {

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1373,23 +1373,7 @@ static inline void php_binary_search_array(INTERNAL_FUNCTION_PARAMETERS, int beh
 	int mid;
 
     zval result;
-    if(strict){
-		while(low<=high){
-             mid=(low+high)/2;
-
-             ZVAL_DEREF(entry);
-             entry = zend_hash_index_find(arr_hash, mid);
-
-			 is_larger_function("ass","ass","sa");
-			 if(Z_LVAL(result) > 0){
-                high=mid-1;
-             }
-             else if(Z_LVAL(result) < 0){
-                low=mid+1;
-             }else{
-                 RETURN_TRUE;
-             }
-		}		
+    if(strict){		
 	}else{
 		while(low<=high){
 			 mid=(low+high)/2;

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1346,8 +1346,12 @@ static inline void php_array_binary_search(INTERNAL_FUNCTION_PARAMETERS, int beh
     zval *value,                /* value to check for */
          *array,                /* array to check in */
          *entry;                /* pointer to array entry*/
+	zval result;				/* comparision result */
     zend_bool strict = 0;       /* strict comparison or not */
-
+    HashTable *arr_hash;
+    int low = 0;
+    int mid; 
+    int high;        
 #ifndef FAST_ZPP
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "za|b", &value, &array, &strict) == FAILURE) {
         return;
@@ -1360,50 +1364,46 @@ static inline void php_array_binary_search(INTERNAL_FUNCTION_PARAMETERS, int beh
         Z_PARAM_BOOL(strict)
     ZEND_PARSE_PARAMETERS_END();
 #endif
-	HashTable *arr_hash;
 	arr_hash = Z_ARRVAL_P(array);
  
-	int low=0; 
-	int high=zend_hash_num_elements(arr_hash)-1;
-	int mid;
-
-	zval result;
-	if(strict){	
-		while(low<=high){
-			mid=(low+high)/2;
+	high = zend_hash_num_elements(arr_hash) - 1;
+	
+	if (strict) {	
+		while (low <= high) {
+			mid = (low + high) / 2;
         
 			ZVAL_DEREF(entry);
 			entry = zend_hash_index_find(arr_hash, mid);
 
 			compare_function(&result, value, entry);
   
-			if(Z_LVAL(result) < 0){
-				high=mid-1;
-			}else if(Z_LVAL(result) > 0){
-				low=mid+1;
-			}else{
+			if (Z_LVAL(result) < 0) {
+				high = mid - 1;
+			} else if (Z_LVAL(result) > 0) {
+				low = mid + 1;
+			} else {
 				fast_is_identical_function(&result, value, entry);
-				if(Z_TYPE(result) == IS_TRUE){
+				if (Z_TYPE(result) == IS_TRUE) {
 					RETURN_TRUE;
-				}else{
-					high=mid-1;
+				} else {
+					high = mid - 1;
 				}	
 			}
 		}
-	}else{
-		while(low<=high){
-			mid=(low+high)/2;
+	} else {
+		while (low <= high) {
+			mid = (low + high) / 2;
 		
 			ZVAL_DEREF(entry);
 			entry = zend_hash_index_find(arr_hash, mid);	     
     
 			compare_function(&result,entry,value);
          
-			if(Z_LVAL(result) < 0){
-				low=mid+1;
-			}else if(Z_LVAL(result) > 0){
-				high=mid-1;
-			}else{
+			if (Z_LVAL(result) < 0) {
+				low = mid + 1;
+			} else if (Z_LVAL(result) > 0) {
+				high = mid - 1;
+			} else {
 				RETURN_TRUE;
 			}		
 		}
@@ -1745,10 +1745,6 @@ PHP_FUNCTION(array_fill)
 	}
 }
 /* }}} */
-
-
-
-
 
 /* {{{ proto array array_fill_keys(array keys, mixed val)
    Create an array using the elements of the first parameter as keys each initialized to val */

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -329,7 +329,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_array_search, 0, 0, 2)
 	ZEND_ARG_INFO(0, strict)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_binary_search, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_array_binary_search, 0, 0, 2)
     ZEND_ARG_INFO(0, needle)
     ZEND_ARG_INFO(0, haystack) /* ARRAY_INFO(0, haystack, 0) */
     ZEND_ARG_INFO(0, strict)
@@ -3279,7 +3279,7 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(max,																arginfo_max)
 	PHP_FE(in_array,														arginfo_in_array)
 	PHP_FE(array_search,													arginfo_array_search)
-	PHP_FE(binary_search,                                                   arginfo_binary_search)
+	PHP_FE(array_binary_search,                                             arginfo_array_binary_search)
 	PHP_FE(extract,															arginfo_extract)
 	PHP_FE(compact,															arginfo_compact)
 	PHP_FE(array_fill,														arginfo_array_fill)

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -133,6 +133,7 @@ static HashTable basic_submodules;
 #undef sprintf
 
 /* {{{ arginfo */
+
 /* {{{ main/main.c */
 ZEND_BEGIN_ARG_INFO(arginfo_set_time_limit, 0)
 	ZEND_ARG_INFO(0, seconds)
@@ -327,6 +328,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_array_search, 0, 0, 2)
 	ZEND_ARG_INFO(0, haystack) /* ARRAY_INFO(0, haystack, 0) */
 	ZEND_ARG_INFO(0, strict)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_binary_search, 0, 0, 2)
+    ZEND_ARG_INFO(0, needle)
+    ZEND_ARG_INFO(0, haystack) /* ARRAY_INFO(0, haystack, 0) */
+    ZEND_ARG_INFO(0, strict)
+ZEND_END_ARG_INFO()
+
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_extract, 0, 0, 1)
 	ZEND_ARG_INFO(ZEND_SEND_PREFER_REF, arg) /* ARRAY_INFO(0, arg, 0) */
@@ -599,6 +607,7 @@ ZEND_BEGIN_ARG_INFO(arginfo_array_combine, 0)
 	ZEND_ARG_INFO(0, keys)   /* ARRAY_INFO(0, keys, 0) */
 	ZEND_ARG_INFO(0, values) /* ARRAY_INFO(0, values, 0) */
 ZEND_END_ARG_INFO()
+
 /* }}} */
 /* {{{ basic_functions.c */
 ZEND_BEGIN_ARG_INFO(arginfo_get_magic_quotes_gpc, 0)
@@ -3270,6 +3279,7 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(max,																arginfo_max)
 	PHP_FE(in_array,														arginfo_in_array)
 	PHP_FE(array_search,													arginfo_array_search)
+	PHP_FE(binary_search,                                                   arginfo_binary_search)
 	PHP_FE(extract,															arginfo_extract)
 	PHP_FE(compact,															arginfo_compact)
 	PHP_FE(array_fill,														arginfo_array_fill)

--- a/ext/standard/php_array.h
+++ b/ext/standard/php_array.h
@@ -51,6 +51,7 @@ PHP_FUNCTION(min);
 PHP_FUNCTION(max);
 PHP_FUNCTION(in_array);
 PHP_FUNCTION(array_search);
+PHP_FUNCTION(binary_search);
 PHP_FUNCTION(extract);
 PHP_FUNCTION(compact);
 PHP_FUNCTION(array_fill);

--- a/ext/standard/php_array.h
+++ b/ext/standard/php_array.h
@@ -51,7 +51,7 @@ PHP_FUNCTION(min);
 PHP_FUNCTION(max);
 PHP_FUNCTION(in_array);
 PHP_FUNCTION(array_search);
-PHP_FUNCTION(binary_search);
+PHP_FUNCTION(array_binary_search);
 PHP_FUNCTION(extract);
 PHP_FUNCTION(compact);
 PHP_FUNCTION(array_fill);

--- a/ext/standard/tests/array/array_binary_search_variation1.phpt
+++ b/ext/standard/tests/array/array_binary_search_variation1.phpt
@@ -12,65 +12,207 @@ Test array_binary_search() function : usage variations - different needdle value
 /* Test array_binary_search with different possible needle values */
 
 echo "*** Testing array_binary_search with different needle values ***\n";
-$arrays = array (
-  array("hello","world",6,"PHP","MYSQL","6","C","ZEND","binary","C++","perl","machine code",4),
-);
+$array1 = array(1,2,3,4,5,6,7,8,9,10);
 
-$array_compare = array (
-    4,
-  "4",
-  "6",
-    6,
-   10,
-"PHP",
-"asda"
-);
-/* loop to check if elements in $array_compare exist in $arrays
-   using array_binary_search() */
-$counter = 1;
-foreach($arrays as $array) {
-  foreach($array_compare as $compare) {
-    sort($array);
-    echo "-- Iteration $counter --\n";
-    //strict option OFF
-    var_dump(array_binary_search($compare,$array));  
-    //strict option ON
-    var_dump(array_binary_search($compare,$array,TRUE));  
-    //strict option OFF
-    var_dump(array_binary_search($compare,$array,FALSE));  
-    $counter++;
- }
-}
+$array2 = array(1,"2",3,"4","5",6,"7",8,"9",10);
+
+$array3 = array(1,"two",3,"four",5,"six",7,"eight",9,"ten");
+
+$array4 = array("and","ball","decimal","message","ontario","person","test","version","zone");
+
+$array5 = array(1,"1",2,"2",3,"3",4,"4",5,"5");
+
+sort($array1);
+//strict option OFF
+var_dump(array_binary_search(4,$array1));  
+//strict option ON
+var_dump(array_binary_search(4,$array1,TRUE));  
+//strict option OFF
+var_dump(array_binary_search(4,$array1,FALSE));  
 		
+//strict option OFF
+var_dump(array_binary_search(6,$array1));       
+//strict option ON
+var_dump(array_binary_search(6,$array1,TRUE));       
+//strict option OFF
+var_dump(array_binary_search(6,$array1,FALSE));  
+
+var_dump(array_binary_search("6",$array1));
+//strict option ON
+var_dump(array_binary_search("6",$array1,TRUE));
+//strict option OFF
+var_dump(array_binary_search("6",$array1,FALSE));
+
+var_dump(array_binary_search("16",$array1));
+//strict option ON
+var_dump(array_binary_search("16",$array1,TRUE));
+//strict option OFF
+var_dump(array_binary_search("16",$array1,FALSE));
+
+sort($array2);
+
+var_dump(array_binary_search(1,$array2));
+//strict option ON
+var_dump(array_binary_search(1,$array2,TRUE));
+//strict option OFF
+var_dump(array_binary_search(1,$array2,FALSE));
+
+var_dump(array_binary_search(10,$array2));
+//strict option ON
+var_dump(array_binary_search(10,$array2,TRUE));
+//strict option OFF
+var_dump(array_binary_search(10,$array2,FALSE));
+
+var_dump(array_binary_search("10",$array2));
+//strict option ON
+var_dump(array_binary_search("10",$array2,TRUE));
+//strict option OFF
+var_dump(array_binary_search("10",$array2,FALSE));
+
+var_dump(array_binary_search(5,$array2));
+//strict option ON
+var_dump(array_binary_search(5,$array2,TRUE));
+//strict option OFF
+var_dump(array_binary_search(5,$array2,FALSE));
+
+sort($array3);
+
+var_dump(array_binary_search("six",$array3));
+//strict option ON
+var_dump(array_binary_search("six",$array3,TRUE));
+//strict option OFF
+var_dump(array_binary_search("six",$array3,FALSE));
+
+var_dump(array_binary_search(9.00,$array3));
+//strict option ON
+var_dump(array_binary_search(9.00,$array3,TRUE));
+//strict option OFF
+var_dump(array_binary_search(9.00,$array3,FALSE));
+
+var_dump(array_binary_search("9.00",$array3));
+//strict option ON
+var_dump(array_binary_search("9.00",$array3,TRUE));
+//strict option OFF
+var_dump(array_binary_search("9.00",$array3,FALSE));
+
+var_dump(array_binary_search(7,$array3));
+//strict option ON
+var_dump(array_binary_search(7,$array3,TRUE));
+//strict option OFF
+var_dump(array_binary_search(7,$array3,FALSE));
+
+sort($array4);
+
+var_dump(array_binary_search('ontario',$array4));
+//strict option ON
+var_dump(array_binary_search('ontario',$array4,TRUE));
+//strict option OFF
+var_dump(array_binary_search('ontario',$array4,FALSE));
+
+var_dump(array_binary_search('ONTARIO',$array4));
+//strict option ON
+var_dump(array_binary_search('ONTARIO',$array4,TRUE));
+//strict option OFF
+var_dump(array_binary_search('ONTARIO',$array4,FALSE));
+
+var_dump(array_binary_search('zOne',$array4));
+//strict option ON
+var_dump(array_binary_search('zOne',$array4,TRUE));
+//strict option OFF
+var_dump(array_binary_search('zOne',$array4,FALSE));
+
+var_dump(array_binary_search('sadas',$array4));
+//strict option ON
+var_dump(array_binary_search('sadas',$array4,TRUE));
+//strict option OFF
+var_dump(array_binary_search('sadas',$array4,FALSE));
+
+sort($array5);
+
+var_dump(array_binary_search(3,$array5));
+//strict option ON
+var_dump(array_binary_search(3,$array5,TRUE));
+//strict option OFF
+var_dump(array_binary_search(3,$array5,FALSE));
+
+var_dump(array_binary_search("3",$array5));
+//strict option ON
+var_dump(array_binary_search("3",$array5,TRUE));
+//strict option OFF
+var_dump(array_binary_search("3",$array5,FALSE));
+
+var_dump(array_binary_search(3.20,$array5));
+//strict option ON
+var_dump(array_binary_search(3.20,$array5,TRUE));
+//strict option OFF
+var_dump(array_binary_search(3.20,$array5,FALSE));
+
+var_dump(array_binary_search(33,$array5));
+//strict option ON
+var_dump(array_binary_search(33,$array5,TRUE));
+//strict option OFF
+var_dump(array_binary_search(33,$array5,FALSE));
 echo "Done\n";
 ?>
 --EXPECTF--
 *** Testing array_binary_search with different needle values ***
--- Iteration 1 --
 bool(true)
 bool(true)
 bool(true)
--- Iteration 2 --
+bool(true)
+bool(true)
+bool(true)
 bool(true)
 bool(false)
 bool(true)
--- Iteration 3 --
-bool(true)
-bool(true)
-bool(true)
--- Iteration 4 --
-bool(true)
-bool(true)
-bool(true)
--- Iteration 5 --
 bool(false)
 bool(false)
 bool(false)
--- Iteration 6 --
 bool(true)
 bool(true)
 bool(true)
--- Iteration 7 --
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(false)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+bool(false)
 bool(false)
 bool(false)
 bool(false)

--- a/ext/standard/tests/array/array_binary_search_variation1.phpt
+++ b/ext/standard/tests/array/array_binary_search_variation1.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Test array_binary_search() function : usage variations - different needdle values
+--FILE--
+<?php
+/*
+ * Prototype  : bool array_binary_search ( mixed $needle, array $haystack [, bool $strict] )
+ * Description: Used binary search to search haystack for needle and returns TRUE  
+ *              if it is found in the array, FALSE otherwise.
+ * Source Code: ext/standard/array.c
+*/
+
+/* Test array_binary_search with different possible needle values */
+
+echo "*** Testing array_binary_search with different needle values ***\n";
+$arrays = array (
+  array("hello","world",6,"PHP","MYSQL","6","C","ZEND","binary","C++","perl","machine code",4),
+);
+
+$array_compare = array (
+    4,
+  "4",
+  "6",
+    6,
+   10,
+"PHP",
+"asda"
+);
+/* loop to check if elements in $array_compare exist in $arrays
+   using array_binary_search() */
+$counter = 1;
+foreach($arrays as $array) {
+  foreach($array_compare as $compare) {
+    sort($array);
+    echo "-- Iteration $counter --\n";
+    //strict option OFF
+    var_dump(array_binary_search($compare,$array));  
+    //strict option ON
+    var_dump(array_binary_search($compare,$array,TRUE));  
+    //strict option OFF
+    var_dump(array_binary_search($compare,$array,FALSE));  
+    $counter++;
+ }
+}
+		
+echo "Done\n";
+?>
+--EXPECTF--
+*** Testing array_binary_search with different needle values ***
+-- Iteration 1 --
+bool(true)
+bool(true)
+bool(true)
+-- Iteration 2 --
+bool(true)
+bool(false)
+bool(true)
+-- Iteration 3 --
+bool(true)
+bool(true)
+bool(true)
+-- Iteration 4 --
+bool(true)
+bool(true)
+bool(true)
+-- Iteration 5 --
+bool(false)
+bool(false)
+bool(false)
+-- Iteration 6 --
+bool(true)
+bool(true)
+bool(true)
+-- Iteration 7 --
+bool(false)
+bool(false)
+bool(false)
+Done
+


### PR DESCRIPTION
This pull request will add the php_array_binary_search function into Array.c along with the PHP function array_binary_search. After benchmarking the new php_array_binary_search function and the php_search_array function, the results favored php_array_binary_search. Both tests use a sorted array with 1000000 indexes. 

```
Linear Search, 
Found
Linear search time: 0.00079488754272461 seconds
Binary Search
Found
Binary search time: 1.0967254638672E-5 seconds
```

As seen in this output, the binary search outperformed the linear search, I believe this function may be useful in certain situations. 
