### PR TITLE
PoC patch for bug #69111

### DIFF
--- a/ext/session/mod_user_class.c
+++ b/ext/session/mod_user_class.c
@@ -25,6 +25,10 @@
 	if (PS(default_mod) == NULL) {				\
 		php_error_docref(NULL, E_CORE_ERROR, "Cannot call default session handler"); \
 		RETURN_FALSE;						\
+	} \
+	if (!PS(mod_user_internal)) { \
+		php_error_docref(NULL, E_CORE_ERROR, "Cannot call session handler from user script"); \
+		RETURN_FALSE;						\
 	}
 
 #define PS_SANITY_CHECK_IS_OPEN				\

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -184,6 +184,7 @@ typedef struct _php_ps_globals {
 	} mod_user_names;
 	int mod_user_implemented;
 	int mod_user_is_open;
+	int mod_user_internal;
 	const struct ps_serializer_struct *serializer;
 	zval http_session_vars;
 	zend_bool auto_start;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -105,6 +105,7 @@ static inline void php_rinit_session_globals(void) /* {{{ */
 	PS(session_status) = php_session_none;
 	PS(mod_data) = NULL;
 	PS(mod_user_is_open) = 0;
+	PS(mod_user_internal) = 0;
 	PS(define_sid) = 1;
 	PS(session_vars) = NULL;
 	ZVAL_UNDEF(&PS(http_session_vars));
@@ -2236,15 +2237,18 @@ static PHP_FUNCTION(session_start)
 		} ZEND_HASH_FOREACH_END();
 	}
 
+	PS(mod_user_internal) = 1;
 	php_session_start();
 
 	if (PS(session_status) != php_session_active) {
+		PS(mod_user_internal) = 0;
 		RETURN_FALSE;
 	}
 
 	if (read_and_close) {
 		php_session_flush(0);
 	}
+	PS(mod_user_internal) = 0;
 
 	RETURN_TRUE;
 }
@@ -2258,7 +2262,10 @@ static PHP_FUNCTION(session_destroy)
 		return;
 	}
 
-	RETURN_BOOL(php_session_destroy() == SUCCESS);
+	PS(mod_user_internal) = 1;
+	ret = php_session_destroy();
+	PS(mod_user_internal) = 0;
+	RETVAL_BOOL(ret == SUCCESS);
 }
 /* }}} */
 
@@ -2283,7 +2290,9 @@ static PHP_FUNCTION(session_unset)
    Write session data and end session */
 static PHP_FUNCTION(session_write_close)
 {
+	PS(mod_user_internal) = 1;
 	php_session_flush(1);
+	PS(mod_user_internal) = 0;
 }
 /* }}} */
 
@@ -2291,7 +2300,9 @@ static PHP_FUNCTION(session_write_close)
    Abort session and end session. Session data will not be written */
 static PHP_FUNCTION(session_abort)
 {
+	PS(mod_user_internal) = 1;
 	php_session_abort();
+	PS(mod_user_internal) = 0;
 }
 /* }}} */
 
@@ -2299,7 +2310,9 @@ static PHP_FUNCTION(session_abort)
    Reset session data from saved session data */
 static PHP_FUNCTION(session_reset)
 {
+	PS(mod_user_internal) = 1;
 	php_session_reset();
+	PS(mod_user_internal) = 0;
 }
 /* }}} */
 


### PR DESCRIPTION
This PoC patch for bug #69111. I didn't even try to compile it because I think this is not needed.
https://bugs.php.net/bug.php?id=69111

I would rather deprecate use of previous save handler functions as "base" class method for SessionHandler. Session module has too many states already and inheriting previous save handler functions is not mandatory. (I'm going to implement "user serialize handler", so crypt/etc can be done with it for internal save handlers)
