### PR TITLE
fix typo in php.ini (Bug report: #69554)

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1636,7 +1636,7 @@ zend.assertions = 1
 
 [mbstring]
 ; language for internal character representation.
-; This affects mb_send_mail() and mbstrig.detect_order.
+; This affects mb_send_mail() and mbstring.detect_order.
 ; http://php.net/mbstring.language
 ;mbstring.language = Japanese
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -1636,7 +1636,7 @@ zend.assertions = -1
 
 [mbstring]
 ; language for internal character representation.
-; This affects mb_send_mail() and mbstrig.detect_order.
+; This affects mb_send_mail() and mbstring.detect_order.
 ; http://php.net/mbstring.language
 ;mbstring.language = Japanese
 


### PR DESCRIPTION
'mbstrig' for 'mbstring'.

Bug report reference: #69554