### PR TITLE
Expand path names in php-fpm.service

### DIFF
--- a/sapi/fpm/php-fpm.service.in
+++ b/sapi/fpm/php-fpm.service.in
@@ -1,11 +1,11 @@
 [Unit]
 Description=The PHP FastCGI Process Manager
-After=syslog.target network.target
+After=network.target
 
 [Service]
 Type=@php_fpm_systemd@
-PIDFile=@localstatedir@/run/php-fpm.pid
-ExecStart=@sbindir@/php-fpm --nodaemonize --fpm-config @sysconfdir@/php-fpm.conf
+PIDFile=@EXPANDED_LOCALSTATEDIR@/run/php-fpm.pid
+ExecStart=@EXPANDED_SBINDIR@/php-fpm --nodaemonize --fpm-config @EXPANDED_SYSCONFDIR@/php-fpm.conf
 ExecReload=/bin/kill -USR2 $MAINPID
 
 [Install]


### PR DESCRIPTION
Currently the PHP build creates a non-working php-fpm.service systemd service file that looks like:

```
[Unit]
Description=The PHP FastCGI Process Manager
After=syslog.target network.target

[Service]
Type=simple
PIDFile=${prefix}/var/run/php-fpm.pid
ExecStart=${exec_prefix}/sbin/php-fpm --nodaemonize --fpm-config ${prefix}/etc/php-fpm.conf
ExecReload=/bin/kill -USR2 $MAINPID

[Install]
WantedBy=multi-user.target
```

Change this to use the expanded path names instead of ${prefix}
