### PR TITLE
return FALSE instead of NULL from ZipArchive::getStream when php_stream_...

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -2689,6 +2689,8 @@ static ZIPARCHIVE_METHOD(getStream)
 	stream = php_stream_zip_open(obj->filename, filename->val, mode STREAMS_CC);
 	if (stream) {
 		php_stream_to_zval(stream, return_value);
+	} else {
+		RETURN_FALSE;
 	}
 }
 /* }}} */


### PR DESCRIPTION
...zip_open() fails (fixes #67161)