### PR TITLE
prohibit empty cookie names for setcookie()

### DIFF
--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -86,7 +86,10 @@ PHPAPI int php_setcookie(char *name, size_t name_len, char *value, size_t value_
 	int result;
 	zend_string *encoded_value = NULL;
 
-	if (name && strpbrk(name, "=,; \t\r\n\013\014") != NULL) {   /* man isspace for \013 and \014 */
+	if (!name_len) {
+		zend_error( E_WARNING, "Cookie names must not be empty" );
+		return FAILURE;
+	} else if (name && strpbrk(name, "=,; \t\r\n\013\014") != NULL) {   /* man isspace for \013 and \014 */
 		zend_error( E_WARNING, "Cookie names cannot contain any of the following '=,; \\t\\r\\n\\013\\014'" );
 		return FAILURE;
 	}

--- a/ext/standard/tests/network/bug69523.phpt
+++ b/ext/standard/tests/network/bug69523.phpt
@@ -1,0 +1,8 @@
+--TEST--
+setcookie() allows empty cookie name
+--FILE--
+<?php
+setcookie('', 'foo');
+?>
+--EXPECTF--
+Warning: Cookie names must not be empty in %s on line %d


### PR DESCRIPTION
Possible fix for [bug #69523](https://bugs.php.net/bug.php?id=69523). I've implemented requinix' suggestion, but that might constitute a BC break. An alternative might be to raise only an E_NOTICE, and to allow the header to be sent.