### PR TITLE
Fix #68475 - Support $callable() syntax for all callable strings.

### DIFF
--- a/Zend/tests/bug68475.phpt
+++ b/Zend/tests/bug68475.phpt
@@ -8,6 +8,11 @@ class TestClass
     {
         echo "Static method called!\n";
     }
+
+    public static function staticMethodWithArgs($arg1, $arg2, $arg3)
+    {
+        printf("Static method called with args: %s, %s, %s\n", $arg1, $arg2, $arg3);
+    }
 }
 
 // Test basic call using Class::method syntax.
@@ -17,6 +22,15 @@ $callback();
 // Case should not matter.
 $callback = 'testclass::staticmethod';
 $callback();
+
+$args = ['arg1', 'arg2', 'arg3'];
+$callback = 'TestClass::staticMethodWithArgs';
+
+// Test call with args.
+$callback($args[0], $args[1], $args[2]);
+
+// Test call with splat operator.
+$callback(...$args);
 
 // Reference undefined method.
 $callback = 'TestClass::undefinedMethod';
@@ -34,8 +48,10 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECTF--
+--EXPECT--
 Static method called!
 Static method called!
+Static method called with args: arg1, arg2, arg3
+Static method called with args: arg1, arg2, arg3
 Call to undefined method TestClass::undefinedMethod()
 Class 'UndefinedClass' not found

--- a/Zend/tests/bug68475.phpt
+++ b/Zend/tests/bug68475.phpt
@@ -4,14 +4,6 @@ Bug #68475 Calling function using $callable() syntax with strings of form 'Class
 <?php
 class TestClass
 {
-    public $test;
-
-    public function instanceMethod()
-    {
-        $this->test = "Instance method called.\n";
-        echo $this->test;
-    }
-
     public static function staticMethod()
     {
         echo "Static method called!\n";
@@ -25,14 +17,6 @@ $callback();
 // Case should not matter.
 $callback = 'testclass::staticmethod';
 $callback();
-
-// Call non-static method.
-$callback = 'TestClass::instanceMethod';
-try {
-    $callback();
-} catch (EngineException $e) {
-    echo $e->getMessage() . "\n";
-}
 
 // Reference undefined method.
 $callback = 'TestClass::undefinedMethod';
@@ -53,8 +37,5 @@ try {
 --EXPECTF--
 Static method called!
 Static method called!
-
-Deprecated: Non-static method TestClass::instanceMethod() should not be called statically in %s on line %d
-Using $this when not in object context
 Call to undefined method TestClass::undefinedMethod()
 Class 'UndefinedClass' not found

--- a/Zend/tests/bug68475.phpt
+++ b/Zend/tests/bug68475.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Bug #68475 Calling function using $callable() syntax with strings of form 'Class::method'
+--FILE--
+<?php
+class TestClass
+{
+    public $test;
+
+    public function instanceMethod()
+    {
+        $this->test = "Instance method called.\n";
+        echo $this->test;
+    }
+
+    public static function staticMethod()
+    {
+        echo "Static method called!\n";
+    }
+}
+
+// Test basic call using Class::method syntax.
+$callback = 'TestClass::staticMethod';
+$callback();
+
+// Case should not matter.
+$callback = 'testclass::staticmethod';
+$callback();
+
+// Call non-static method.
+$callback = 'TestClass::instanceMethod';
+try {
+    $callback();
+} catch (EngineException $e) {
+    echo $e->getMessage() . "\n";
+}
+
+// Reference undefined method.
+$callback = 'TestClass::undefinedMethod';
+try {
+    $callback();
+} catch (EngineException $e) {
+    echo $e->getMessage() . "\n";
+}
+
+// Reference undefined class.
+$callback = 'UndefinedClass::testMethod';
+try {
+    $callback();
+} catch (EngineException $e) {
+    echo $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+Static method called!
+Static method called!
+Using $this when not in object context
+Call to undefined method TestClass::undefinedMethod()
+Class 'UndefinedClass' not found

--- a/Zend/tests/bug68475.phpt
+++ b/Zend/tests/bug68475.phpt
@@ -50,9 +50,11 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
 Static method called!
 Static method called!
+
+Deprecated: Non-static method TestClass::instanceMethod() should not be called statically in %s on line %d
 Using $this when not in object context
 Call to undefined method TestClass::undefinedMethod()
 Class 'UndefinedClass' not found


### PR DESCRIPTION
The `$callable()` syntax when used with a string of the form `'Class::method'` would error as an undefined function, even if the string returned `true` from `is_callable()` or the `callable` type-hint. This fix adds support for the `$callable()` syntax for any string accepted by `is_callable()` or the `callable` type-hint.

```php
class TestClass
{
    public static function staticMethod()
    {
        echo "Static method called!\n";
    }
}

function test(callable $callback)
{
    $callback();
}

$callable = 'TestClass::staticMethod';

var_dump(is_callable($callable));
test($callable);
```

Prior output:
```
bool(true)
PHP Fatal error: Call to undefined function TestClass::staticMethod() in ...
```

After patch:
```
bool(true)
Static method called!
```