### PR TITLE
Failing test with array_walk() and references

### DIFF
--- a/ext/standard/tests/array/array_walk_variation10.phpt
+++ b/ext/standard/tests/array/array_walk_variation10.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test array_walk() with callback using same subject array by reference
+--FILE--
+<?php
+
+$parts = array (
+  'foo',
+  'bar',
+  'baz',
+);
+
+array_walk($parts, function ($value, $key) use (&$parts) {
+    $parts = array_values($parts);
+});
+
+echo "Done\n";
+?>
+--EXPECTF--
+Done


### PR DESCRIPTION
This PR contains a failing test with `array_walk()` applying a callback that uses the same subject array by reference. Possibly relates to one of the following changes:

* 703c1bc570d1fc9a379fa38b298d6759a4b1a687
* df1a1c84412b28323a3818f1a5bed931491bddb3
* 37d7df72a62e9d63be6fb7eb83805a59f819bbf7
* 7bf4090efbbafda2e3113a03def9602a0e0b62ec
* and a few older commits

Since we already had many issues related to references and `array_walk` I won't pull request a fix as it would probably solve just another isolated case and create more problems further.

This crash is only reproducible on master so no need for a bug report :) this affects a few zend framework components and was isolated from this [snippet](
https://github.com/zendframework/zf2/blob/master/library/Zend/Loader/ClassMapAutoloader.php#L210-L215).