### PR TITLE
Fix bug #69625 php-fpm return http 200 response  without SCRIPT_FILENAME

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1837,7 +1837,7 @@ consult the installation file that came with this distribution, or visit \n\
 			 * if not, it's certainly not an HTTP over fcgi request */
 			if (!SG(request_info).request_method) {
 				zend_try {
-					zlog(ZLOG_DEBUG, "CRIPT_FILENAME env not found in cgi env");
+					zlog(ZLOG_ERROR, "SCRIPT_FILENAME env not found in cgi env");
 					SG(sapi_headers).http_response_code = 404;
 					PUTS("method not found.\n");
 				} zend_catch {

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1833,16 +1833,6 @@ consult the installation file that came with this distribution, or visit \n\
 				return FPM_EXIT_SOFTWARE;
 			}
 
-			/* check if request_method has been sent.
-			 * if not, it's certainly not an HTTP over fcgi request */
-			if (!SG(request_info).request_method) {
-				goto fastcgi_request_done;
-			}
-
-			if (fpm_status_handle_request()) {
-				goto fastcgi_request_done;
-			}
-
 			/* If path_translated is NULL, terminate here with a 404 */
 			if (!SG(request_info).path_translated) {
 				zend_try {
@@ -1851,6 +1841,16 @@ consult the installation file that came with this distribution, or visit \n\
 					PUTS("File not found.\n");
 				} zend_catch {
 				} zend_end_try();
+				goto fastcgi_request_done;
+			}
+
+			/* check if request_method has been sent.
+			 * if not, it's certainly not an HTTP over fcgi request */
+			if (!SG(request_info).request_method) {
+				goto fastcgi_request_done;
+			}
+
+			if (fpm_status_handle_request()) {
 				goto fastcgi_request_done;
 			}
 

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1833,20 +1833,15 @@ consult the installation file that came with this distribution, or visit \n\
 				return FPM_EXIT_SOFTWARE;
 			}
 
-			/* If path_translated is NULL, terminate here with a 404 */
-			if (!SG(request_info).path_translated) {
-				zend_try {
-					zlog(ZLOG_DEBUG, "Primary script unknown");
-					SG(sapi_headers).http_response_code = 404;
-					PUTS("File not found.\n");
-				} zend_catch {
-				} zend_end_try();
-				goto fastcgi_request_done;
-			}
-
 			/* check if request_method has been sent.
 			 * if not, it's certainly not an HTTP over fcgi request */
 			if (!SG(request_info).request_method) {
+				zend_try {
+					zlog(ZLOG_DEBUG, "CRIPT_FILENAME env not found in cgi env");
+					SG(sapi_headers).http_response_code = 404;
+					PUTS("method not found.\n");
+				} zend_catch {
+				} zend_end_try();
 				goto fastcgi_request_done;
 			}
 
@@ -1857,6 +1852,17 @@ consult the installation file that came with this distribution, or visit \n\
 			if (fpm_php_limit_extensions(SG(request_info).path_translated)) {
 				SG(sapi_headers).http_response_code = 403;
 				PUTS("Access denied.\n");
+				goto fastcgi_request_done;
+			}
+
+			/* If path_translated is NULL, terminate here with a 404 */
+			if (!SG(request_info).path_translated) {
+				zend_try {
+					zlog(ZLOG_DEBUG, "Primary script unknown");
+					SG(sapi_headers).http_response_code = 404;
+					PUTS("File not found.\n");
+				} zend_catch {
+				} zend_end_try();
 				goto fastcgi_request_done;
 			}
 


### PR DESCRIPTION
BUG report: https://bugs.php.net/bug.php?id=69625

In nginx config.conf file, configure info without fastcgi_param  SCRIPT_FILENAME default ,  http://trac.nginx.org/nginx/browser/nginx/conf/fastcgi_params  Any PHP files are returned blank response and  http 200 status.  

Because init_request_info function set default http response status 200, request_method is null in fpm_main.c near line 985. And if SCRIPT_FILENAME was not set in CGI protocol, SG(request_info).request_method \ SG(sapi_headers).http_response_code will not be reset . 

The program will terminate at "if (!SG(request_info).request_method)" near line 1838 in fpm_main.c , 

But http response status was 200 ,In fact it's a bug , The http response will be 404 , There is comment in fpm_main.c near line 1846 "/\* If path_translated is NULL, terminate here with a 404 */" .

So, I think the code of SG(request_info).path_translated determine should be placed in front of SG(request_info).request_method . Move line 1846-1855 into line 1835 .

more detail : http://www.cnxct.com/php-return-empty-result-on-nginx-without-script_filename/

当CGI包里没有SCRIPT_FILENAME时，php-fpm返回空白响应，http 200的问题。FPM日志中没记录，HTTP响应状态 200，很难排插原因。从fpm代码里可以看到，其实作者是有考虑到没有SCRIPT_FILENAME的问题的，只是判断顺序搞错了，故调整顺序。（英语不太好，我还是写中文吧 ,请@laruence  确认一下。）
