### PR TITLE
Fix wrong display in phpize.m4 when ZTS checking

### DIFF
--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -93,7 +93,7 @@ php_zts_is_enabled
   PHP_THREAD_SAFETY=no
 ])
 CPPFLAGS=$old_CPPFLAGS
-AC_MSG_RESULT([$PHP_DEBUG])
+AC_MSG_RESULT([$PHP_THREAD_SAFETY])
 
 dnl Support for building and testing Zend extensions
 ZEND_EXT_TYPE="zend_extension"


### PR DESCRIPTION
Little mistake.

```
checking if debug is enabled... yes
checking if zts is enabled... yes
```

It was using the wrong variable `$PHP_DEBUG`, so the output is always equals to debug's.