### PR TITLE
Throwable

### DIFF
--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -32,7 +32,7 @@
 
 static zend_class_entry *base_exception_ce;
 static zend_class_entry *default_exception_ce;
-static zend_class_entry *error_exception_ce;
+static zend_class_entry *error_ce;
 static zend_class_entry *engine_exception_ce;
 static zend_class_entry *parse_exception_ce;
 static zend_class_entry *type_exception_ce;
@@ -740,6 +740,7 @@ void zend_register_default_exception(void) /* {{{ */
 	base_exception_ce->create_object = NULL;
 	memcpy(&default_exception_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 	default_exception_handlers.clone_obj = NULL;
+    zend_class_implements(base_exception_ce, 1, zend_ce_throwable);
 
 	zend_declare_property_string(base_exception_ce, "message", sizeof("message")-1, "", ZEND_ACC_PROTECTED);
 	zend_declare_property_string(base_exception_ce, "string", sizeof("string")-1, "", ZEND_ACC_PRIVATE);
@@ -752,7 +753,6 @@ void zend_register_default_exception(void) /* {{{ */
 	INIT_CLASS_ENTRY(ce, "Exception", NULL);
 	default_exception_ce = zend_register_internal_class_ex(&ce, base_exception_ce);
 	default_exception_ce->create_object = zend_default_exception_new;
-	zend_class_implements(default_exception_ce, 1, zend_ce_throwable);
 
 	/* A trick, to make visible private properties of BaseException */
 	ZEND_HASH_FOREACH_PTR(&default_exception_ce->properties_info, prop) {
@@ -773,21 +773,40 @@ void zend_register_default_exception(void) /* {{{ */
 		}
 	} ZEND_HASH_FOREACH_END();
 
-	INIT_CLASS_ENTRY(ce, "ErrorException", error_exception_functions);
-	error_exception_ce = zend_register_internal_class_ex(&ce, default_exception_ce);
-	error_exception_ce->create_object = zend_error_exception_new;
-	zend_declare_property_long(error_exception_ce, "severity", sizeof("severity")-1, E_ERROR, ZEND_ACC_PROTECTED);
+	INIT_CLASS_ENTRY(ce, "Error", NULL);
+	error_ce = zend_register_internal_class_ex(&ce, base_exception_ce);
+	error_ce->create_object = zend_default_exception_new;
+	zend_declare_property_long(error_ce, "severity", sizeof("severity")-1, E_ERROR, ZEND_ACC_PROTECTED);
 
-	INIT_CLASS_ENTRY(ce, "EngineException", NULL);
-	engine_exception_ce = zend_register_internal_class_ex(&ce, base_exception_ce);
+	/* A trick, to make visible private properties of BaseException */
+	ZEND_HASH_FOREACH_PTR(&error_ce->properties_info, prop) {
+		if (prop->flags & ZEND_ACC_SHADOW) {
+			if (prop->name->len == sizeof("\0BaseException\0string")-1) {
+				prop->flags &= ~ZEND_ACC_SHADOW;
+				prop->flags |= ZEND_ACC_PRIVATE;
+				prop->ce = error_ce;
+			} else if (prop->name->len == sizeof("\0BaseException\0trace")-1) {
+				prop->flags &= ~ZEND_ACC_SHADOW;
+				prop->flags |= ZEND_ACC_PRIVATE;
+				prop->ce = error_ce;
+			} else if (prop->name->len == sizeof("\0BaseException\0previous")-1) {
+				prop->flags &= ~ZEND_ACC_SHADOW;
+				prop->flags |= ZEND_ACC_PRIVATE;
+				prop->ce = error_ce;
+			}
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	INIT_CLASS_ENTRY(ce, "EngineError", NULL);
+	engine_exception_ce = zend_register_internal_class_ex(&ce, error_ce);
 	engine_exception_ce->create_object = zend_default_exception_new;
 
-	INIT_CLASS_ENTRY(ce, "ParseException", NULL);
-	parse_exception_ce = zend_register_internal_class_ex(&ce, base_exception_ce);
+	INIT_CLASS_ENTRY(ce, "ParseError", NULL);
+	parse_exception_ce = zend_register_internal_class_ex(&ce, error_ce);
 	parse_exception_ce->create_object = zend_default_exception_new;
 
-	INIT_CLASS_ENTRY(ce, "TypeException", NULL);
-	type_exception_ce = zend_register_internal_class_ex(&ce, engine_exception_ce);
+	INIT_CLASS_ENTRY(ce, "TypeError", NULL);
+	type_exception_ce = zend_register_internal_class_ex(&ce, error_ce);
 	type_exception_ce->create_object = zend_default_exception_new;
 }
 /* }}} */
@@ -804,9 +823,9 @@ ZEND_API zend_class_entry *zend_exception_get_default(void) /* {{{ */
 }
 /* }}} */
 
-ZEND_API zend_class_entry *zend_get_error_exception(void) /* {{{ */
+ZEND_API zend_class_entry *zend_get_error(void) /* {{{ */
 {
-	return error_exception_ce;
+	return error_ce;
 }
 /* }}} */
 

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -752,6 +752,7 @@ void zend_register_default_exception(void) /* {{{ */
 	INIT_CLASS_ENTRY(ce, "Exception", NULL);
 	default_exception_ce = zend_register_internal_class_ex(&ce, base_exception_ce);
 	default_exception_ce->create_object = zend_default_exception_new;
+	zend_class_implements(default_exception_ce, 1, zend_ce_throwable);
 
 	/* A trick, to make visible private properties of BaseException */
 	ZEND_HASH_FOREACH_PTR(&default_exception_ce->properties_info, prop) {

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -36,7 +36,7 @@ void zend_register_default_exception(void);
 
 ZEND_API zend_class_entry *zend_exception_get_base(void);
 ZEND_API zend_class_entry *zend_exception_get_default(void);
-ZEND_API zend_class_entry *zend_get_error_exception(void);
+ZEND_API zend_class_entry *zend_get_error(void);
 ZEND_API zend_class_entry *zend_get_engine_exception(void);
 ZEND_API zend_class_entry *zend_get_parse_exception(void);
 ZEND_API zend_class_entry *zend_get_type_exception(void);

--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -28,6 +28,7 @@ ZEND_API zend_class_entry *zend_ce_aggregate;
 ZEND_API zend_class_entry *zend_ce_iterator;
 ZEND_API zend_class_entry *zend_ce_arrayaccess;
 ZEND_API zend_class_entry *zend_ce_serializable;
+ZEND_API zend_class_entry *zend_ce_throwable;
 
 /* {{{ zend_call_method
  Only returns the returned zval if retval_ptr != NULL */
@@ -502,6 +503,13 @@ static int zend_implement_serializable(zend_class_entry *interface, zend_class_e
 }
 /* }}}*/
 
+/* {{{ zend_implement_throwable */
+static int zend_implement_throwable(zend_class_entry *interface, zend_class_entry *class_type)
+{
+	return SUCCESS;
+}
+/* }}}*/
+
 /* {{{ function tables */
 const zend_function_entry zend_funcs_aggregate[] = {
 	ZEND_ABSTRACT_ME(iterator, getIterator, NULL)
@@ -549,6 +557,8 @@ const zend_function_entry zend_funcs_serializable[] = {
 	ZEND_FENTRY(unserialize, NULL, arginfo_serializable_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT|ZEND_ACC_CTOR)
 	ZEND_FE_END
 };
+
+const zend_function_entry *zend_funcs_throwable    = NULL;
 /* }}} */
 
 #define REGISTER_INTERFACE(class_name, class_name_str) \
@@ -576,6 +586,8 @@ ZEND_API void zend_register_interfaces(void)
 	REGISTER_INTERFACE(arrayaccess, ArrayAccess);
 
 	REGISTER_INTERFACE(serializable, Serializable)
+
+	REGISTER_INTERFACE(throwable, Throwable)
 }
 /* }}} */
 

--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -551,7 +551,7 @@ const zend_function_entry zend_funcs_serializable[] = {
 };
 /* }}} */
 
-#define REGISTER_ITERATOR_INTERFACE(class_name, class_name_str) \
+#define REGISTER_INTERFACE(class_name, class_name_str) \
 	{\
 		zend_class_entry ce;\
 		INIT_CLASS_ENTRY(ce, # class_name_str, zend_funcs_ ## class_name) \
@@ -565,17 +565,17 @@ const zend_function_entry zend_funcs_serializable[] = {
 /* {{{ zend_register_interfaces */
 ZEND_API void zend_register_interfaces(void)
 {
-	REGISTER_ITERATOR_INTERFACE(traversable, Traversable);
+	REGISTER_INTERFACE(traversable, Traversable);
 
-	REGISTER_ITERATOR_INTERFACE(aggregate, IteratorAggregate);
+	REGISTER_INTERFACE(aggregate, IteratorAggregate);
 	REGISTER_ITERATOR_IMPLEMENT(aggregate, traversable);
 
-	REGISTER_ITERATOR_INTERFACE(iterator, Iterator);
+	REGISTER_INTERFACE(iterator, Iterator);
 	REGISTER_ITERATOR_IMPLEMENT(iterator, traversable);
 
-	REGISTER_ITERATOR_INTERFACE(arrayaccess, ArrayAccess);
+	REGISTER_INTERFACE(arrayaccess, ArrayAccess);
 
-	REGISTER_ITERATOR_INTERFACE(serializable, Serializable)
+	REGISTER_INTERFACE(serializable, Serializable)
 }
 /* }}} */
 

--- a/Zend/zend_interfaces.h
+++ b/Zend/zend_interfaces.h
@@ -31,6 +31,7 @@ extern ZEND_API zend_class_entry *zend_ce_aggregate;
 extern ZEND_API zend_class_entry *zend_ce_iterator;
 extern ZEND_API zend_class_entry *zend_ce_arrayaccess;
 extern ZEND_API zend_class_entry *zend_ce_serializable;
+extern ZEND_API zend_class_entry *zend_ce_throwable;
 
 typedef struct _zend_user_iterator {
 	zend_object_iterator     it;


### PR DESCRIPTION
    Message-ID: <54F07FC7.8050901@php.net>
    Date: Fri, 27 Feb 2015 15:31:35 +0100
    From: Sebastian Bergmann <sebastian@php.net>
    To: internals@lists.php.net
    References: <CAF+90c8nqCBGWpsqdfy+EKekOm3Cw5_zzE_nKeyLK5pzROTueg@mail.gmail.com>
    In-Reply-To: <CAF+90c8nqCBGWpsqdfy+EKekOm3Cw5_zzE_nKeyLK5pzROTueg@mail.gmail.com>
    Subject: Re: [PHP-DEV] [VOTE] Exceptions in the engine
    
    Am 23.02.2015 um 19:15 schrieb Nikita Popov:
    > Voting on the engine exceptions RFC, which proposes to convert existing
    > fatal and recoverable fatal errors into exceptions, has opened:
    > 
    >     https://wiki.php.net/rfc/engine_exceptions_for_php7#vote
    > 
    > The primary vote requires a 2/3 majority, as this is a language change.
    > 
    > A second vote will decide whether to use a BaseException based inheritance
    > hierarchy. This vote uses a simple majority.
    
     I have voted yes on "Allow exceptions in the engine and conversion of
     existing fatals?" and no on "Introduce and use BaseException?" and
     would like to elaborate on the latter.
    
     I am sorry that I was unable to raise this concern earlier (did not
     really become aware of the RFC before it was put to the vote), but I
     would prefer the following:
    
       * Introduce a Throwable interface
       * Let Exception implement the Throwable interface
       * Introduce an Error class that implements the Throwable interface
       * Use Error class as base class for exceptions raised by the engine
    
     This would be along the lines of what Java does.
    
    -- 
    PHP Internals - PHP Runtime Development Mailing List
    To unsubscribe, visit: http://www.php.net/unsub.php
