### PR TITLE
fix duplicate typedef in mcrypt

### DIFF
--- a/ext/mcrypt/mcrypt.c
+++ b/ext/mcrypt/mcrypt.c
@@ -346,12 +346,6 @@ static void php_mcrypt_module_dtor(zend_resource *rsrc) /* {{{ */
 }
 /* }}} */
 
-typedef enum {
-	RANDOM = 0,
-	URANDOM,
-	RAND
-} iv_source;
-
 static PHP_MINIT_FUNCTION(mcrypt) /* {{{ */
 {
 	le_mcrypt = zend_register_list_destructors_ex(php_mcrypt_module_dtor, NULL, "mcrypt", module_number);


### PR DESCRIPTION
https://github.com/php/php-src/commit/c09fad97d68d07d6b528d56d5cef1f8cbb9fc5ec

Is there a mistake in merge?

Thank you.