### PR TITLE
fix #69628: complex GLOB_BRACE fails on Windows

### DIFF
--- a/ext/standard/tests/file/bug69628.phpt
+++ b/ext/standard/tests/file/bug69628.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #69628: GLOB_BRACE with multiple brackets within the braces fails
+--FILE--
+<?php
+
+$file_path = dirname(__FILE__);
+
+// temp dirname used here
+$dirname = "$file_path/bug69628";
+
+// temp dir created
+mkdir($dirname);
+
+// temp files created
+file_put_contents("$dirname/image.jPg", '');
+file_put_contents("$dirname/image.gIf", '');
+file_put_contents("$dirname/image.png", '');
+
+sort_var_dump(glob("$dirname/*.{[jJ][pP][gG],[gG][iI][fF]}", GLOB_BRACE));
+
+function sort_var_dump($results) {
+   sort($results);
+   var_dump($results);
+}
+
+?>
+--CLEAN--
+<?php
+
+$file_path = dirname(__FILE__);
+unlink("$file_path/bug69628/image.jPg");
+unlink("$file_path/bug69628/image.gIf");
+unlink("$file_path/bug69628/image.png");
+rmdir("$file_path/bug69628/");
+
+?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  string(%d) "%s/bug69628/image.gIf"
+  [1]=>
+  string(%d) "%s/bug69628/image.jPg"
+}

--- a/ext/standard/tests/file/bug69628.phpt
+++ b/ext/standard/tests/file/bug69628.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Bug #69628: GLOB_BRACE with multiple brackets within the braces fails
+--SKIPIF--
+<?php
+if (!defined('GLOB_BRACE')) {
+    die('skip this test requires GLOB_BRACE support');
+}
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/file/glob_variation.phpt
+++ b/ext/standard/tests/file/glob_variation.phpt
@@ -5,6 +5,9 @@ Test glob() function: usage variations
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip.. Not valid for Windows');
 }
+if (!defined('GLOB_BRACE')) {
+    die('skip this test requires GLOB_BRACE support');
+}
 ?>
 --FILE--
 <?php

--- a/win32/glob.c
+++ b/win32/glob.c
@@ -293,17 +293,19 @@ globexp2(ptr, pattern, pglob, rv)
 	}
 
 	for (i = 0, pl = pm = ptr; pm <= pe; pm++) {
+		const Char *pb;
+
 		switch (*pm) {
 		case LBRACKET:
 			/* Ignore everything between [] */
-			for (pl = pm++; *pm != RBRACKET && *pm != EOS; pm++)
+			for (pb = pm++; *pm != RBRACKET && *pm != EOS; pm++)
 				;
 			if (*pm == EOS) {
 				/*
 				 * We could not find a matching RBRACKET.
 				 * Ignore and just look for RBRACE
 				 */
-				pm = pl;
+				pm = pb;
 			}
 			break;
 


### PR DESCRIPTION
The problem is that `pl` is advanced to `pm` after an opening bracket has been encountered, so the characters before the last opening bracket are ignored. This might be a deliberate design decision (allow only one bracketed expression inside a braced alternative), but it looks more like a bug. Furthermore multiple bracketed expressions inside a braced alternative seem to be supported by *nix implementations.

The suggested patch solves this by using another temporary variable (`pb`) to mark the position of the most recent left bracket.

With regard to bug69628.phpt: I copied sort_var_dump() from glob_basic.phpt and used it, even though sorting should happen automatically unless GLOB_NOSORT is used.