### PR TITLE
SPL: Add an SplFileObject::getStream() method

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2741,6 +2741,20 @@ SPL_METHOD(SplFileObject, fflush)
 	RETURN_BOOL(!php_stream_flush(intern->u.file.stream));
 } /* }}} */
 
+/* {{{ proto resource SplFileObject::getStream()
+   Get the internal stream resource for the file */
+SPL_METHOD(SplFileObject, getStream)
+{
+	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(getThis());
+
+	if(!intern->u.file.stream) {
+		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
+		return;
+	}
+
+	php_stream_to_zval(intern->u.file.stream, return_value);
+} /* }}} */
+
 /* {{{ proto int SplFileObject::ftell()
    Return current file position */
 SPL_METHOD(SplFileObject, ftell)
@@ -3062,6 +3076,7 @@ static const zend_function_entry spl_SplFileObject_functions[] = {
 	SPL_ME(SplFileObject, getCsvControl,  arginfo_splfileinfo_void,          ZEND_ACC_PUBLIC)
 	SPL_ME(SplFileObject, flock,          arginfo_file_object_flock,         ZEND_ACC_PUBLIC)
 	SPL_ME(SplFileObject, fflush,         arginfo_splfileinfo_void,          ZEND_ACC_PUBLIC)
+	SPL_ME(SplFileObject, getStream,      arginfo_splfileinfo_void,          ZEND_ACC_PUBLIC)
 	SPL_ME(SplFileObject, ftell,          arginfo_splfileinfo_void,          ZEND_ACC_PUBLIC)
 	SPL_ME(SplFileObject, fseek,          arginfo_file_object_fseek,         ZEND_ACC_PUBLIC)
 	SPL_ME(SplFileObject, fgetc,          arginfo_splfileinfo_void,          ZEND_ACC_PUBLIC)

--- a/ext/spl/tests/SplFileObject_getStream_basic.phpt
+++ b/ext/spl/tests/SplFileObject_getStream_basic.phpt
@@ -1,0 +1,17 @@
+--TEST--
+SplFileObject::getStream function - basic test
+--FILE--
+<?php
+/*
+ * test a successful read from an SplFileObject's stream
+*/
+$obj = new SplTempFileObject;
+$obj->fwrite("test content");
+
+$fh = $obj->getStream();
+fseek($fh, 0);
+var_dump(fread($fh, 20));
+
+?>
+--EXPECTF--
+string(12) "test content"


### PR DESCRIPTION
As `SplFileObject` is a wrapper around stream resources, it should be possible to access the underlying stream.

This PR adds that ability via a `getStream()` method, along with a test for it
