### PR TITLE
implement php://fdraw stream wrapper

### DIFF
--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -24,6 +24,7 @@
 #include "ext/standard/flock_compat.h"
 #include "ext/standard/file.h"
 #include "ext/standard/php_filestat.h"
+#include "ext/standard/php_fopen_wrappers.h"
 #include "php_open_temporary_file.h"
 #include "ext/standard/basic_functions.h"
 #include "php_ini.h"
@@ -476,6 +477,7 @@ PHP_FUNCTION(stream_get_meta_data)
 {
 	zval *arg1;
 	php_stream *stream;
+	int tmp_fd;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &arg1) == FAILURE) {
 		return;
@@ -492,6 +494,10 @@ PHP_FUNCTION(stream_get_meta_data)
 		add_assoc_string(return_value, "wrapper_type", (char *)stream->wrapper->wops->label);
 	}
 	add_assoc_string(return_value, "stream_type", (char *)stream->ops->label);
+
+	if (SUCCESS == php_stream_cast(stream, PHP_STREAM_AS_FD_FOR_SELECT | PHP_STREAM_CAST_INTERNAL, (void*)&tmp_fd, 0) && tmp_fd != -1) {
+		add_assoc_long(return_value, "fd", tmp_fd);
+	}
 
 	add_assoc_string(return_value, "mode", stream->mode);
 

--- a/ext/standard/tests/file/stream_rfc2397_002.phpt
+++ b/ext/standard/tests/file/stream_rfc2397_002.phpt
@@ -33,11 +33,13 @@ foreach($streams as $stream)
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-array(7) {
+array(8) {
   ["wrapper_type"]=>
   string(7) "RFC2397"
   ["stream_type"]=>
   string(7) "RFC2397"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "r"
   ["unread_bytes"]=>
@@ -54,11 +56,13 @@ NULL
 Warning: fopen(data://): failed to open stream: rfc2397: no comma in URL in %sstream_rfc2397_002.php on line %d
 NULL
 NULL
-array(7) {
+array(8) {
   ["wrapper_type"]=>
   string(7) "RFC2397"
   ["stream_type"]=>
   string(7) "RFC2397"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "r"
   ["unread_bytes"]=>
@@ -83,11 +87,13 @@ NULL
 Warning: fopen(data://foo=bar,): failed to open stream: rfc2397: illegal media type in %sstream_rfc2397_002.php on line %d
 NULL
 NULL
-array(8) {
+array(9) {
   ["wrapper_type"]=>
   string(7) "RFC2397"
   ["stream_type"]=>
   string(7) "RFC2397"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "r"
   ["unread_bytes"]=>
@@ -106,11 +112,13 @@ NULL
 Warning: fopen(data://text/plain;foo,): failed to open stream: rfc2397: illegal parameter in %sstream_rfc2397_002.php on line %d
 NULL
 NULL
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(7) "RFC2397"
   ["stream_type"]=>
   string(7) "RFC2397"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "r"
   ["unread_bytes"]=>
@@ -131,11 +139,13 @@ string(3) "bar"
 Warning: fopen(data://text/plain;foo=bar;bla,): failed to open stream: rfc2397: illegal parameter in %sstream_rfc2397_002.php on line %d
 NULL
 NULL
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(7) "RFC2397"
   ["stream_type"]=>
   string(7) "RFC2397"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "r"
   ["unread_bytes"]=>
@@ -156,11 +166,13 @@ string(3) "bar"
 Warning: fopen(data://text/plain;foo=bar;bar=baz): failed to open stream: rfc2397: no comma in URL in %sstream_rfc2397_002.php on line %d
 NULL
 NULL
-array(10) {
+array(11) {
   ["wrapper_type"]=>
   string(7) "RFC2397"
   ["stream_type"]=>
   string(7) "RFC2397"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "r"
   ["unread_bytes"]=>

--- a/ext/standard/tests/file/userstreams_002.phpt
+++ b/ext/standard/tests/file/userstreams_002.phpt
@@ -48,6 +48,8 @@ bool(true)
 
 ------ stream_cast not implemented: -------
 
+Warning: stream_get_meta_data(): test_wrapper_base::stream_cast is not implemented! in %s
+
 Warning: stream_select(): test_wrapper_base::stream_cast is not implemented! in %s
 
 Warning: stream_select(): cannot represent a stream of type user-space as a select()able descriptor in %s
@@ -75,6 +77,10 @@ bool(false)
 
 ------ return value is stream itself: -------
 
+Warning: stream_get_meta_data(): supplied argument is not a valid stream resource in %s
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast must return a stream resource in %s
+
 Warning: stream_select(): test_wrapper::stream_cast must not return itself in %s
 
 Warning: stream_select(): cannot represent a stream of type user-space as a select()able descriptor in %s
@@ -83,6 +89,8 @@ Warning: stream_select(): No stream arrays were passed in %s
 bool(false)
 
 ------ return value cannot be casted: -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast must not return itself in %s
 
 Warning: stream_select(): test_wrapper_base::stream_cast is not implemented! in %s
 

--- a/ext/standard/tests/file/userstreams_003.phpt
+++ b/ext/standard/tests/file/userstreams_003.phpt
@@ -60,6 +60,8 @@ bool(true)
 bool(true)
 
 ------ stream_set_blocking - 1: -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 value:
 int(0)
 ptrparam:
@@ -71,6 +73,8 @@ bool(true)
 bool(true)
 
 ------ stream_set_blocking - 2: -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 value:
 int(1)
 ptrparam:
@@ -82,6 +86,8 @@ bool(true)
 bool(false)
 
 ------ stream_set_blocking - 3: -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 value:
 int(0)
 ptrparam:
@@ -94,10 +100,14 @@ bool(true)
 
 ------ stream_set_blocking - 4: -------
 
+Warning: stream_get_meta_data(): test_wrapper_base::stream_cast is not implemented! in %s
+
 Warning: stream_set_blocking(): test_wrapper_base::stream_set_option is not implemented! in %s
 bool(false)
 
 ------ stream_set_write_buffer - 1: -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 value:
 int(0)
 ptrparam:
@@ -109,6 +119,8 @@ bool(true)
 int(0)
 
 ------ stream_set_write_buffer - 2: -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 value:
 int(2)
 ptrparam:
@@ -120,6 +132,8 @@ bool(true)
 int(0)
 
 ------ stream_set_write_buffer - 3: -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 value:
 int(2)
 ptrparam:
@@ -131,6 +145,8 @@ bool(true)
 int(-1)
 
 ------ stream_set_timeout - 1: -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 value:
 int(10)
 ptrparam:
@@ -142,6 +158,8 @@ bool(true)
 bool(true)
 
 ------ stream_set_timeout - 2: -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 value:
 int(11)
 ptrparam:

--- a/ext/standard/tests/file/userstreams_004.phpt
+++ b/ext/standard/tests/file/userstreams_004.phpt
@@ -43,16 +43,30 @@ bool(true)
 ------ stream_lock not implemented: -------
 
 Warning: flock(): test_wrapper_base::stream_lock is not implemented! in %s
+
+Warning: stream_get_meta_data(): test_wrapper_base::stream_cast is not implemented! in %s
 bool(false)
 ------ fclock(LOCK_SH): -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 bool(true)
 ------ fclock(LOCK_SH|LOCK_NB): -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 bool(true)
 ------ fclock(LOCK_EX): -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 bool(true)
 ------ fclock(LOCK_EX|LOCK_NB): -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 bool(true)
 ------ fclock(LOCK_UN): -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 bool(true)
 ------ fclock(LOCK_UN|LOCK_NB): -------
+
+Warning: stream_get_meta_data(): test_wrapper::stream_cast is not implemented! in %s
 bool(true)

--- a/ext/standard/tests/network/socket_get_status_basic.phpt
+++ b/ext/standard/tests/network/socket_get_status_basic.phpt
@@ -17,9 +17,11 @@ fclose($server);
 
 ?>
 --EXPECTF--
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socket%S"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_file_basic.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_file_basic.phpt
@@ -11,11 +11,13 @@ fclose($fp);
 
 ?>
 --EXPECTF--
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "r"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_file_variation1.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_file_variation1.phpt
@@ -28,11 +28,13 @@ unlink($filename);
 
 ?>
 --EXPECTF--
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "r"
   ["unread_bytes"]=>
@@ -48,11 +50,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -68,11 +72,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "w"
   ["unread_bytes"]=>
@@ -88,11 +94,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "w+"
   ["unread_bytes"]=>
@@ -108,11 +116,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "a"
   ["unread_bytes"]=>
@@ -128,11 +138,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "a+"
   ["unread_bytes"]=>
@@ -148,11 +160,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "x"
   ["unread_bytes"]=>
@@ -168,11 +182,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "x+"
   ["unread_bytes"]=>
@@ -188,11 +204,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "rb"
   ["unread_bytes"]=>
@@ -208,11 +226,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(3) "rb+"
   ["unread_bytes"]=>
@@ -228,11 +248,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "wb"
   ["unread_bytes"]=>
@@ -248,11 +270,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(3) "wb+"
   ["unread_bytes"]=>
@@ -268,11 +292,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "ab"
   ["unread_bytes"]=>
@@ -288,11 +314,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(3) "ab+"
   ["unread_bytes"]=>
@@ -308,11 +336,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "xb"
   ["unread_bytes"]=>
@@ -328,11 +358,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(3) "xb+"
   ["unread_bytes"]=>
@@ -348,11 +380,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "rt"
   ["unread_bytes"]=>
@@ -368,11 +402,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(3) "rt+"
   ["unread_bytes"]=>
@@ -388,11 +424,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "wt"
   ["unread_bytes"]=>
@@ -408,11 +446,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(3) "wt+"
   ["unread_bytes"]=>
@@ -428,11 +468,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "at"
   ["unread_bytes"]=>
@@ -448,11 +490,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(3) "at+"
   ["unread_bytes"]=>
@@ -468,11 +512,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "xt"
   ["unread_bytes"]=>
@@ -488,11 +534,13 @@ array(9) {
   ["eof"]=>
   bool(false)
 }
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(3) "xt+"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_file_variation2.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_file_variation2.phpt
@@ -42,11 +42,13 @@ unlink($filename);
 ?>
 --EXPECTF--
 Write some data to the file:
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "w+"
   ["unread_bytes"]=>
@@ -67,11 +69,13 @@ array(9) {
 Read a line of the file, causing data to be buffered:
 string(15) "a line of data
 "
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "w+"
   ["unread_bytes"]=>
@@ -90,11 +94,13 @@ array(9) {
 
 
 Read 20 bytes from the file:
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "w+"
   ["unread_bytes"]=>
@@ -113,11 +119,13 @@ array(9) {
 
 
 Read entire file:
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "w+"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_file_variation4.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_file_variation4.phpt
@@ -27,11 +27,13 @@ unlink($filename);
 ?>
 --EXPECTF--
 Create a file:
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "w+"
   ["unread_bytes"]=>
@@ -49,11 +51,13 @@ array(9) {
 }
 
 Change to file's directory and open with a relative path:
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(1) "r"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_file_variation5.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_file_variation5.phpt
@@ -32,11 +32,13 @@ unlink($filename);
 ?>
 --EXPECTF--
 Write some data to the file:
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "w+"
   ["unread_bytes"]=>
@@ -55,11 +57,13 @@ array(9) {
 
 
 Read entire file:
-array(9) {
+array(10) {
   ["wrapper_type"]=>
   string(9) "plainfile"
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "w+"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_process_basic.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_process_basic.phpt
@@ -16,7 +16,7 @@ pclose($handle);
 echo "Done";
 
 ?>
---EXPECT--
+--EXPECTF--
 array(8) {
   ["stream_type"]=>
   string(5) "STDIO"

--- a/ext/standard/tests/streams/stream_get_meta_data_process_basic.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_process_basic.phpt
@@ -17,9 +17,11 @@ echo "Done";
 
 ?>
 --EXPECT--
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(5) "STDIO"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "rb"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_basic.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_basic.phpt
@@ -9,9 +9,11 @@ fclose($tcp_socket);
 
 ?>
 --EXPECTF--
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_variation1.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_variation1.phpt
@@ -38,9 +38,11 @@ var_dump(stream_get_meta_data($client));
 ?>
 --EXPECTF--
 Write some data:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -57,9 +59,11 @@ array(7) {
 
 
 Read a line from the client, causing data to be buffered:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -76,9 +80,11 @@ array(7) {
 
 
 Read 3 bytes of data from the client:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -95,9 +101,11 @@ array(7) {
 
 
 Close the server side socket and read the remaining data from the client:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_variation2.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_variation2.phpt
@@ -36,9 +36,11 @@ fclose($server);
 
 ?>
 --EXPECTF--
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -55,9 +57,11 @@ array(7) {
 
 
 Set a timeout on the client and attempt a read:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -74,9 +78,11 @@ array(7) {
 
 
 Write some data from the server:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -93,9 +99,11 @@ array(7) {
 
 
 Read some data from the client:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_variation3.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_variation3.phpt
@@ -31,9 +31,11 @@ fclose($server);
 
 ?>
 --EXPECTF--
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -51,9 +53,11 @@ array(7) {
 
 Set blocking to false:
 bool(true)
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -71,9 +75,11 @@ array(7) {
 
 Set blocking to true:
 bool(true)
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_variation4.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_variation4.phpt
@@ -36,9 +36,11 @@ fclose($client);
 ?>
 --EXPECTF--
 Write some data:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -55,9 +57,11 @@ array(7) {
 
 
 Read a line from the client:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>
@@ -74,9 +78,11 @@ array(7) {
 
 
 Close the server side socket and read the remaining data from the client:
-array(7) {
+array(8) {
   ["stream_type"]=>
   string(%d) "tcp_socke%s"
+  ["fd"]=>
+  int(%d)
   ["mode"]=>
   string(2) "r+"
   ["unread_bytes"]=>


### PR DESCRIPTION
This wrapper differs from php://fd/ in one aspect: it doesn't call dup() on the descriptor, which means you fully control the original fd and can even close() it.
The patch also adds "fd" element to stream_get_meta_data() function, which contains fd number, if it's available.

Initially implemented by @YuriyNasretdinov.
