### PR TITLE
Throwable: A different approach

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -323,22 +323,20 @@ Relevant RFCs:
 Changes to error handling
 -------------------------
 
-* The new base class of the exception hierarchy is BaseException, from which
+* The new base class of the exception hierarchy is Throwable, from which
   Exception extends. Typehints in exception handling code may need to be changed
-  to account for this.
 
-* Some fatal errors and recoverable fatal errors now throw an EngineException
-  instead. As EngineException extends BaseException but not Exception, these
-  exceptions will not caught by existing try/catch blocks.
+* Some fatal errors and recoverable fatal errors now throw an Error, a class
+  that also extends Throwable. As Error extends Throwable but not Exception,
+  these exceptions will not caught by existing try/catch blocks.
 
   For the recoverable fatal errors which have been converted into an exception,
   it is no longer possible to silently ignore the error from an error handler.
   In particular, it is no longer possible to ignore typehint failures.
 
-* Parser errors now generate a ParseException (extends BaseException). Error
-  handling for eval()s on potentially invalid code should be changed to catch
-  ParseException in addition to the previous return value / error_get_last()
-  based handling.
+* Parser errors now generate a ParseError (extends Error). Error handling for
+  eval()s on potentially invalid code should be changed to catch ParseError in
+  addition to the previous return value / error_get_last() based handling.
 
 * Constructors of internal classes will now always throw an exception on
   failure. Previously some constructors returned NULL or an unusable object.

--- a/Zend/tests/028.phpt
+++ b/Zend/tests/028.phpt
@@ -20,7 +20,7 @@ bool(true)
 
 Notice: Undefined offset: 2 in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Function name must be a string' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Function name must be a string' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/030.phpt
+++ b/Zend/tests/030.phpt
@@ -34,7 +34,7 @@ $test->bar();
 object(Exception)#%d (7) {
   ["message":protected]=>
   string(3) "foo"
-  ["string":"BaseException":private]=>
+  ["string":"Throwable":private]=>
   string(0) ""
   ["code":protected]=>
   int(0)
@@ -42,7 +42,7 @@ object(Exception)#%d (7) {
   string(%d) "%s030.php"
   ["line":protected]=>
   int(%d)
-  ["trace":"BaseException":private]=>
+  ["trace":"Throwable":private]=>
   array(1) {
     [0]=>
     array(6) {
@@ -61,7 +61,7 @@ object(Exception)#%d (7) {
       }
     }
   }
-  ["previous":"BaseException":private]=>
+  ["previous":"Throwable":private]=>
   NULL
 }
 'test' => '0'

--- a/Zend/tests/037.phpt
+++ b/Zend/tests/037.phpt
@@ -16,7 +16,7 @@ var_dump($x::$x);
 --EXPECTF--
 int(1)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: Closure::$x' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: Closure::$x' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/access_modifiers_010.phpt
+++ b/Zend/tests/access_modifiers_010.phpt
@@ -28,7 +28,7 @@ new c;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method d::test2() from context 'a'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method d::test2() from context 'a'' in %s:%d
 Stack trace:
 #0 %s(%d): a->test()
 #1 %s(%d): c->__construct()

--- a/Zend/tests/add_002.phpt
+++ b/Zend/tests/add_002.phpt
@@ -10,7 +10,7 @@ $o->prop = "value";
 
 try {
 	var_dump($a + $o);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . "\n";
 }
 
@@ -26,7 +26,7 @@ Exception: Unsupported operand types
 
 Notice: Object of class stdClass could not be converted to int in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Unsupported operand types' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Unsupported operand types' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/add_003.phpt
+++ b/Zend/tests/add_003.phpt
@@ -10,7 +10,7 @@ $o->prop = "value";
 
 try {
 	var_dump($o + $a);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . "\n";
 }
 
@@ -26,7 +26,7 @@ Exception: Unsupported operand types
 
 Notice: Object of class stdClass could not be converted to int in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Unsupported operand types' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Unsupported operand types' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/add_004.phpt
+++ b/Zend/tests/add_004.phpt
@@ -7,7 +7,7 @@ $a = array(1,2,3);
 
 try {
 	var_dump($a + 5);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . "\n";
 }
 
@@ -19,7 +19,7 @@ echo "Done\n";
 --EXPECTF--	
 Exception: Unsupported operand types
 
-Fatal error: Uncaught exception 'EngineException' with message 'Unsupported operand types' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Unsupported operand types' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/add_007.phpt
+++ b/Zend/tests/add_007.phpt
@@ -9,7 +9,7 @@ $s1 = "some string";
 
 try {
 	var_dump($a + $s1);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . "\n";
 }
 
@@ -21,7 +21,7 @@ echo "Done\n";
 --EXPECTF--	
 Exception: Unsupported operand types
 
-Fatal error: Uncaught exception 'EngineException' with message 'Unsupported operand types' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Unsupported operand types' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/arg_unpack/string_keys.phpt
+++ b/Zend/tests/arg_unpack/string_keys.phpt
@@ -9,12 +9,12 @@ set_error_handler(function($errno, $errstr) {
 
 try {
 	var_dump(...[1, 2, "foo" => 3, 4]);
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 }
 try {
 	var_dump(...new ArrayIterator([1, 2, "foo" => 3, 4]));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 }
 

--- a/Zend/tests/bug24773.phpt
+++ b/Zend/tests/bug24773.phpt
@@ -6,7 +6,7 @@ Bug #24773 (unset() of integers treated as arrays causes a crash)
 	unset($array["lvl1"]["lvl2"]["b"]);
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use string offset as an array' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use string offset as an array' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug26166.phpt
+++ b/Zend/tests/bug26166.phpt
@@ -48,14 +48,14 @@ echo $o;
 
 echo "===THROW===\n";
 
-class Error 
+class Test
 {
 	function __toString() {
 		throw new Exception("This is an error!");
 	}
 }
 
-$o = new Error;
+$o = new Test;
 try {
 	echo $o;
 }
@@ -71,4 +71,4 @@ Hello World!
 string(52) "Method None::__toString() must return a string value"
 ===THROW===
 
-Fatal error: Method Error::__toString() must not throw an exception in %sbug26166.php on line %d
+Fatal error: Method Test::__toString() must not throw an exception in %sbug26166.php on line %d

--- a/Zend/tests/bug29015.phpt
+++ b/Zend/tests/bug29015.phpt
@@ -8,7 +8,7 @@ $a->$x = "string('')";
 var_dump($a);
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access empty property' in %sbug29015.php:4
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access empty property' in %sbug29015.php:4
 Stack trace:
 #0 {main}
   thrown in %sbug29015.php on line 4

--- a/Zend/tests/bug29674.phpt
+++ b/Zend/tests/bug29674.phpt
@@ -38,7 +38,7 @@ NULL
 ===CHILD===
 string(4) "Base"
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access private property ChildClass::$private_child' in %sbug29674.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access private property ChildClass::$private_child' in %sbug29674.php:%d
 Stack trace:
 #0 %s(%d): BaseClass->printVars()
 #1 {main}

--- a/Zend/tests/bug31102.phpt
+++ b/Zend/tests/bug31102.phpt
@@ -45,7 +45,7 @@ __autoload(Test2,2)
 Caught: __autoload
 __autoload(Test3,3)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'Test3' not found' in %sbug31102.php(%d) : eval()'d code:1
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'Test3' not found' in %sbug31102.php(%d) : eval()'d code:1
 Stack trace:
 #0 %s(%d): eval()
 #1 {main}

--- a/Zend/tests/bug32660.phpt
+++ b/Zend/tests/bug32660.phpt
@@ -36,7 +36,7 @@ A Object
 
 Notice: Indirect modification of overloaded property A::$whatever has no effect in %sbug32660.php on line 23
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot assign by reference to overloaded object' in %sbug32660.php:23
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot assign by reference to overloaded object' in %sbug32660.php:23
 Stack trace:
 #0 {main}
   thrown in %sbug32660.php on line 23

--- a/Zend/tests/bug33318.phpt
+++ b/Zend/tests/bug33318.phpt
@@ -5,7 +5,7 @@ Bug #33318 (throw 1; results in Invalid opcode 108/1/8)
 throw 1;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Can only throw objects' in %sbug33318.php:2
+Fatal error: Uncaught exception 'EngineError' with message 'Can only throw objects' in %sbug33318.php:2
 Stack trace:
 #0 {main}
   thrown in %sbug33318.php on line 2

--- a/Zend/tests/bug34064.phpt
+++ b/Zend/tests/bug34064.phpt
@@ -31,7 +31,7 @@ array(1) {
   string(2) "ok"
 }
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use [] for reading' in %sbug34064.php:18
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use [] for reading' in %sbug34064.php:18
 Stack trace:
 #0 %s(%d): XmlTest->run()
 #1 {main}

--- a/Zend/tests/bug36071.phpt
+++ b/Zend/tests/bug36071.phpt
@@ -8,7 +8,7 @@ $a = clone 0;
 $a[0]->b = 0;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message '__clone method called on non-object' in %sbug36071.php:2
+Fatal error: Uncaught exception 'EngineError' with message '__clone method called on non-object' in %sbug36071.php:2
 Stack trace:
 #0 {main}
   thrown in %sbug36071.php on line 2

--- a/Zend/tests/bug36268.phpt
+++ b/Zend/tests/bug36268.phpt
@@ -11,7 +11,7 @@ $x = new Foo();
 bar();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function bar()' in %sbug36268.php:8
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function bar()' in %sbug36268.php:8
 Stack trace:
 #0 {main}
   thrown in %sbug36268.php on line 8

--- a/Zend/tests/bug37251.phpt
+++ b/Zend/tests/bug37251.phpt
@@ -10,7 +10,7 @@ class Foo {
 try {
 	$foo = new Foo();
 	$foo->bar();
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo 'OK';
 }
 --EXPECT--

--- a/Zend/tests/bug37632.phpt
+++ b/Zend/tests/bug37632.phpt
@@ -132,7 +132,7 @@ B2::doTest
 C2::test
 B4::doTest
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected C4::__construct() from context 'B4'' in %sbug37632.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected C4::__construct() from context 'B4'' in %sbug37632.php:%d
 Stack trace:
 #0 %s(%d): B4::doTest()
 #1 {main}

--- a/Zend/tests/bug40621.phpt
+++ b/Zend/tests/bug40621.phpt
@@ -17,7 +17,7 @@ echo "Done\n";
 --EXPECTF--	
 Deprecated: Non-static method Foo::get() should not be called statically in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method Foo::__construct() cannot be called statically' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method Foo::__construct() cannot be called statically' in %s:%d
 Stack trace:
 #0 %s(%d): Foo::get()
 #1 {main}

--- a/Zend/tests/bug41633_2.phpt
+++ b/Zend/tests/bug41633_2.phpt
@@ -8,7 +8,7 @@ class Foo {
 echo Foo::A."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined class constant 'self::B'' in %sbug41633_2.php:5
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined class constant 'self::B'' in %sbug41633_2.php:5
 Stack trace:
 #0 {main}
   thrown in %sbug41633_2.php on line 5

--- a/Zend/tests/bug41633_3.phpt
+++ b/Zend/tests/bug41633_3.phpt
@@ -9,7 +9,7 @@ class Foo {
 echo Foo::A;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot declare self-referencing constant 'Foo::B'' in %sbug41633_3.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot declare self-referencing constant 'Foo::B'' in %sbug41633_3.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug41633_3.php on line %d

--- a/Zend/tests/bug41813.phpt
+++ b/Zend/tests/bug41813.phpt
@@ -9,7 +9,7 @@ $foo[0]->bar = "xyz";
 echo "Done\n";
 ?>
 --EXPECTF--	
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use string offset as an array' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use string offset as an array' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug41919.phpt
+++ b/Zend/tests/bug41919.phpt
@@ -8,7 +8,7 @@ $foo[3]->bar[1] = "bang";
 echo "ok\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use string offset as an object' in %sbug41919.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use string offset as an object' in %sbug41919.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug41919.php on line %d

--- a/Zend/tests/bug42817.phpt
+++ b/Zend/tests/bug42817.phpt
@@ -6,7 +6,7 @@ $a = clone(null);
 array_push($a->b, $c);
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message '__clone method called on non-object' in %sbug42817.php:2
+Fatal error: Uncaught exception 'EngineError' with message '__clone method called on non-object' in %sbug42817.php:2
 Stack trace:
 #0 {main}
   thrown in %sbug42817.php on line 2

--- a/Zend/tests/bug42818.phpt
+++ b/Zend/tests/bug42818.phpt
@@ -5,7 +5,7 @@ Bug #42818 ($foo = clone(array()); leaks memory)
 $foo = clone(array());
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message '__clone method called on non-object' in %sbug42818.php:2
+Fatal error: Uncaught exception 'EngineError' with message '__clone method called on non-object' in %sbug42818.php:2
 Stack trace:
 #0 {main}
   thrown in %sbug42818.php on line 2

--- a/Zend/tests/bug42819.phpt
+++ b/Zend/tests/bug42819.phpt
@@ -299,7 +299,7 @@ Array
     [1] => 1
 )
 
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'foo\foo\unknown'' in %sbug42819.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'foo\foo\unknown'' in %sbug42819.php:%d
 Stack trace:
 #0 %s(%d): foo\oops()
 #1 {main}

--- a/Zend/tests/bug42937.phpt
+++ b/Zend/tests/bug42937.phpt
@@ -39,7 +39,7 @@ test3
 test4
 test5
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method C::test6()' in %sbug42937.php:21
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method C::test6()' in %sbug42937.php:21
 Stack trace:
 #0 %s(%d): B->test()
 #1 {main}

--- a/Zend/tests/bug43344_10.phpt
+++ b/Zend/tests/bug43344_10.phpt
@@ -5,7 +5,7 @@ Bug #43344.10 (Wrong error message for undefined namespace constant)
 echo namespace\bar."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'bar'' in %sbug43344_10.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'bar'' in %sbug43344_10.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug43344_10.php on line %d

--- a/Zend/tests/bug43344_11.phpt
+++ b/Zend/tests/bug43344_11.phpt
@@ -8,7 +8,7 @@ function f($a=namespace\bar) {
 echo f()."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'bar'' in %sbug43344_11.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'bar'' in %sbug43344_11.php:%d
 Stack trace:
 #0 %s(%d): f()
 #1 {main}

--- a/Zend/tests/bug43344_12.phpt
+++ b/Zend/tests/bug43344_12.phpt
@@ -8,7 +8,7 @@ function f($a=array(namespace\bar)) {
 echo f()."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'bar'' in %sbug43344_12.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'bar'' in %sbug43344_12.php:%d
 Stack trace:
 #0 %s(%d): f()
 #1 {main}

--- a/Zend/tests/bug43344_13.phpt
+++ b/Zend/tests/bug43344_13.phpt
@@ -9,7 +9,7 @@ function f($a=array(namespace\bar=>0)) {
 echo f()."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'bar'' in %sbug43344_13.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'bar'' in %sbug43344_13.php:%d
 Stack trace:
 #0 %s(%d): f()
 #1 {main}

--- a/Zend/tests/bug43344_2.phpt
+++ b/Zend/tests/bug43344_2.phpt
@@ -6,7 +6,7 @@ namespace Foo;
 echo Foo::bar."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'Foo\Foo' not found' in %sbug43344_2.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'Foo\Foo' not found' in %sbug43344_2.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug43344_2.php on line %d

--- a/Zend/tests/bug43344_6.phpt
+++ b/Zend/tests/bug43344_6.phpt
@@ -6,7 +6,7 @@ namespace Foo;
 echo namespace\bar."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'Foo\bar'' in %sbug43344_6.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'Foo\bar'' in %sbug43344_6.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug43344_6.php on line %d

--- a/Zend/tests/bug43344_7.phpt
+++ b/Zend/tests/bug43344_7.phpt
@@ -9,7 +9,7 @@ function f($a=namespace\bar) {
 echo f()."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'Foo\bar'' in %sbug43344_7.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'Foo\bar'' in %sbug43344_7.php:%d
 Stack trace:
 #0 %s(%d): Foo\f()
 #1 {main}

--- a/Zend/tests/bug43344_8.phpt
+++ b/Zend/tests/bug43344_8.phpt
@@ -9,7 +9,7 @@ function f($a=array(namespace\bar)) {
 echo f()."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'Foo\bar'' in %sbug43344_8.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'Foo\bar'' in %sbug43344_8.php:%d
 Stack trace:
 #0 %s(%d): Foo\f()
 #1 {main}

--- a/Zend/tests/bug43344_9.phpt
+++ b/Zend/tests/bug43344_9.phpt
@@ -10,7 +10,7 @@ function f($a=array(namespace\bar=>0)) {
 echo f()."\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'Foo\bar'' in %sbug43344_9.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'Foo\bar'' in %sbug43344_9.php:%d
 Stack trace:
 #0 %s(%d): Foo\f()
 #1 {main}

--- a/Zend/tests/bug44141.phpt
+++ b/Zend/tests/bug44141.phpt
@@ -22,7 +22,7 @@ class Y extends X
 $y = Y::cheat(5);
 echo $y->x, PHP_EOL;
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private X::__construct() from context 'Y'' in %sbug44141.php:15
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private X::__construct() from context 'Y'' in %sbug44141.php:15
 Stack trace:
 #0 %s(%d): Y::cheat(5)
 #1 {main}

--- a/Zend/tests/bug46304.phpt
+++ b/Zend/tests/bug46304.phpt
@@ -62,7 +62,7 @@ value6
 value6
 value6
 
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'NS1\ns2\coNSt1'' in %sbug46304.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'NS1\ns2\coNSt1'' in %sbug46304.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug46304.php on line %d

--- a/Zend/tests/bug46381.phpt
+++ b/Zend/tests/bug46381.phpt
@@ -14,7 +14,7 @@ $test->method();
 echo "Done\n";
 ?>
 --EXPECTF--	
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method ArrayIterator::current() cannot be called statically' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method ArrayIterator::current() cannot be called statically' in %s:%d
 Stack trace:
 #0 %s(%d): test->method()
 #1 {main}

--- a/Zend/tests/bug47054.phpt
+++ b/Zend/tests/bug47054.phpt
@@ -36,7 +36,7 @@ Warning: get_called_class() called from outside a class in %s on line %d
 
 Deprecated: Non-static method D::m() should not be called statically in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Using $this when not in object context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Using $this when not in object context' in %s:%d
 Stack trace:
 #0 %s(%d): D::m()
 #1 {main}

--- a/Zend/tests/bug47699.phpt
+++ b/Zend/tests/bug47699.phpt
@@ -15,7 +15,7 @@ new X();
 ?>
 --EXPECTF--
 BB
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'X' not found' in %sbug47699.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'X' not found' in %sbug47699.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug47699.php on line %d

--- a/Zend/tests/bug47704.phpt
+++ b/Zend/tests/bug47704.phpt
@@ -6,7 +6,7 @@ $s = "abd";
 $s[0]->a += 1;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use string offset as an object' in %sbug47704.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use string offset as an object' in %sbug47704.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug47704.php on line %d

--- a/Zend/tests/bug48215_2.phpt
+++ b/Zend/tests/bug48215_2.phpt
@@ -16,7 +16,7 @@ $c = new c();
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method b::b()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method b::b()' in %s:%d
 Stack trace:
 #0 %s(%d): c->__construct()
 #1 {main}

--- a/Zend/tests/bug48693.phpt
+++ b/Zend/tests/bug48693.phpt
@@ -5,22 +5,22 @@ Bug #48693 (Double declaration of __lambda_func when lambda wrongly formatted)
 
 try {
 	$x = create_function('', 'return 1; }');
-} catch (ParseException $e) {
+} catch (ParseError $e) {
 	echo "$e\n\n";
 }
 try {
 	$y = create_function('', 'function a() { }; return 2;');
-} catch (ParseException $e) {
+} catch (ParseError $e) {
 	echo "$e\n\n";
 }
 try {
 	$z = create_function('', '{');
-} catch (ParseException $e) {
+} catch (ParseError $e) {
 	echo "$e\n\n";
 }
 try {
 	$w = create_function('', 'return 3;');
-} catch (ParseException $e) {
+} catch (ParseError $e) {
 	echo "$e\n\n";
 }
 
@@ -31,12 +31,12 @@ var_dump(
 
 ?>
 --EXPECTF--
-exception 'ParseException' with message 'syntax error, unexpected '}', expecting end of file' in %sbug48693.php(4) : runtime-created function:1
+exception 'ParseError' with message 'syntax error, unexpected '}', expecting end of file' in %sbug48693.php(4) : runtime-created function:1
 Stack trace:
 #0 %sbug48693.php(4): create_function('', 'return 1; }')
 #1 {main}
 
-exception 'ParseException' with message 'syntax error, unexpected end of file' in %sbug48693.php(14) : runtime-created function:1
+exception 'ParseError' with message 'syntax error, unexpected end of file' in %sbug48693.php(14) : runtime-created function:1
 Stack trace:
 #0 %sbug48693.php(14): create_function('', '{')
 #1 {main}

--- a/Zend/tests/bug49866.phpt
+++ b/Zend/tests/bug49866.phpt
@@ -7,7 +7,7 @@ $b = &$a[1];
 $b = "f";
 echo $a;
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot create references to/from string offsets nor overloaded objects' in %sbug49866.php:3
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot create references to/from string offsets nor overloaded objects' in %sbug49866.php:3
 Stack trace:
 #0 {main}
   thrown in %sbug49866.php on line 3

--- a/Zend/tests/bug50146.phpt
+++ b/Zend/tests/bug50146.phpt
@@ -17,7 +17,7 @@ var_dump(isset($obj->a));
 bool(false)
 bool(false)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Closure object cannot have properties' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Closure object cannot have properties' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug52484.phpt
+++ b/Zend/tests/bug52484.phpt
@@ -16,7 +16,7 @@ unset($a->$prop);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access empty property' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access empty property' in %s:%d
 Stack trace:
 #0 %s(%d): A->__unset('')
 #1 {main}

--- a/Zend/tests/bug52484_2.phpt
+++ b/Zend/tests/bug52484_2.phpt
@@ -16,7 +16,7 @@ $a->$prop = 2;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access empty property' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access empty property' in %s:%d
 Stack trace:
 #0 %s(%d): A->__set('', 2)
 #1 {main}

--- a/Zend/tests/bug52484_3.phpt
+++ b/Zend/tests/bug52484_3.phpt
@@ -16,7 +16,7 @@ var_dump($a->$prop);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access empty property' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access empty property' in %s:%d
 Stack trace:
 #0 %s(%d): A->__get('')
 #1 {main}

--- a/Zend/tests/bug61025.phpt
+++ b/Zend/tests/bug61025.phpt
@@ -24,7 +24,7 @@ Warning: The magic method __invoke() must have public visibility and cannot be s
 
 Warning: The magic method __invoke() must have public visibility and cannot be static in %sbug61025.php on line %d
 Bar
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method Bar::__invoke() from context ''' in %sbug61025.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method Bar::__invoke() from context ''' in %sbug61025.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug61025.php on line %d

--- a/Zend/tests/bug63111.phpt
+++ b/Zend/tests/bug63111.phpt
@@ -31,7 +31,7 @@ bool(true)
 bool(true)
 ok
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot call abstract method Foo::bar()' in %sbug63111.php:20
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot call abstract method Foo::bar()' in %sbug63111.php:20
 Stack trace:
 #0 {main}
   thrown in %sbug63111.php on line 20

--- a/Zend/tests/bug63173.phpt
+++ b/Zend/tests/bug63173.phpt
@@ -9,7 +9,7 @@ $callback();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Array callback has to contain indices 0 and 1' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Array callback has to contain indices 0 and 1' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug64135.phpt
+++ b/Zend/tests/bug64135.phpt
@@ -10,7 +10,7 @@ function exception_error_handler() {
 set_error_handler("exception_error_handler");
 try {
    $undefined->undefined();
-} catch(BaseException $e) {
+} catch(Throwable $e) {
     echo "Exception is thrown";
 }
 --EXPECT--

--- a/Zend/tests/bug64720.phpt
+++ b/Zend/tests/bug64720.phpt
@@ -22,7 +22,7 @@ class Foo {
     }
 }
 
-class Error {
+class ErrorTest {
     private $trace;
     public function __construct() {
         $this->trace = debug_backtrace(1);
@@ -32,11 +32,11 @@ class Error {
 class Bar {
     public function __destruct() {
         Stat::getInstance();
-        new Error();
+        new ErrorTest();
     }
 
     public function test() {
-        new Error();
+        new ErrorTest();
     }
 }
 
@@ -45,7 +45,7 @@ $bar = new Bar();
 $bar->test();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: Stat::$requests' in %sbug64720.php:12
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: Stat::$requests' in %sbug64720.php:12
 Stack trace:
 #0 [internal function]: Stat->__destruct()
 #1 {main}

--- a/Zend/tests/bug64966.phpt
+++ b/Zend/tests/bug64966.phpt
@@ -5,7 +5,7 @@ Bug #64966 (segfault in zend_do_fcall_common_helper_SPEC)
 function test($func) {
 	try {
 		$a = $func("");
-	} catch (EngineException $e) {
+	} catch (EngineError $e) {
 		throw new Exception();
 	}
 	return true;

--- a/Zend/tests/bug65784.phpt
+++ b/Zend/tests/bug65784.phpt
@@ -57,7 +57,7 @@ $bar = foo3();
 string(9) "not catch"
 NULL
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'NotExists' not found' in %sbug65784.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'NotExists' not found' in %sbug65784.php:%d
 Stack trace:
 #0 %s(%d): foo3()
 #1 {main}

--- a/Zend/tests/bug65911.phpt
+++ b/Zend/tests/bug65911.phpt
@@ -17,7 +17,7 @@ $obj = new B();
 $obj->go();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: A::$this' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: A::$this' in %s:%d
 Stack trace:
 #0 %s(%d): B->go()
 #1 {main}

--- a/Zend/tests/bug68475.phpt
+++ b/Zend/tests/bug68475.phpt
@@ -36,7 +36,7 @@ $callback(...$args);
 $callback = 'TestClass::undefinedMethod';
 try {
     $callback();
-} catch (EngineException $e) {
+} catch (EngineError $e) {
     echo $e->getMessage() . "\n";
 }
 
@@ -44,7 +44,7 @@ try {
 $callback = 'UndefinedClass::testMethod';
 try {
     $callback();
-} catch (EngineException $e) {
+} catch (EngineError $e) {
     echo $e->getMessage() . "\n";
 }
 ?>

--- a/Zend/tests/bug68652.phpt
+++ b/Zend/tests/bug68652.phpt
@@ -36,7 +36,7 @@ class Bar {
 $foo = new Foo();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: Bar::$instance' in %sbug68652.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: Bar::$instance' in %sbug68652.php:%d
 Stack trace:
 #0 %s(%d): Bar::getInstance()
 #1 [internal function]: Foo->__destruct()

--- a/Zend/tests/call_static_004.phpt
+++ b/Zend/tests/call_static_004.phpt
@@ -18,7 +18,7 @@ foo::$a();
 --EXPECTF--
 string(3) "AaA"
 
-Fatal error: Uncaught exception 'EngineException' with message 'Function name must be a string' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Function name must be a string' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/call_static_005.phpt
+++ b/Zend/tests/call_static_005.phpt
@@ -12,7 +12,7 @@ class foo {
 try {
 	$a = 'foo::';
 	$a();
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo $e->getMessage();
 }
 

--- a/Zend/tests/call_static_006.phpt
+++ b/Zend/tests/call_static_006.phpt
@@ -27,7 +27,7 @@ ok
 Deprecated: Non-static method foo::aa() should not be called statically in %s on line %d
 ok
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot call constructor' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot call constructor' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/call_user_func_004.phpt
+++ b/Zend/tests/call_user_func_004.phpt
@@ -15,7 +15,7 @@ call_user_func(array('foo', 'teste'));
 --EXPECTF--
 Deprecated: %son-static method foo::teste() should not be called statically in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Using $this when not in object context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Using $this when not in object context' in %s:%d
 Stack trace:
 #0 %s(%d): foo::teste()
 #1 {main}

--- a/Zend/tests/class_alias_008.phpt
+++ b/Zend/tests/class_alias_008.phpt
@@ -13,7 +13,7 @@ new $a;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot instantiate abstract class foo' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot instantiate abstract class foo' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/class_alias_016.phpt
+++ b/Zend/tests/class_alias_016.phpt
@@ -18,7 +18,7 @@ var_dump(new foo);
 object(foo\bar)#%d (0) {
 }
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'foo\foo' not found' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'foo\foo' not found' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/class_alias_020.phpt
+++ b/Zend/tests/class_alias_020.phpt
@@ -30,7 +30,7 @@ object(foo\foo)#1 (0) {
 object(foo\bar\foo)#2 (0) {
 }
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'foo\bar' not found' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'foo\bar' not found' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/class_constants_001.phpt
+++ b/Zend/tests/class_constants_001.phpt
@@ -19,7 +19,7 @@ echo "Done\n";
 string(6) "string"
 int(1)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined class constant 'val3'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined class constant 'val3'' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/class_name_as_scalar_error_005.phpt
+++ b/Zend/tests/class_name_as_scalar_error_005.phpt
@@ -7,7 +7,7 @@ $x = static::class;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use "static" when no class scope is active' in %s:3
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use "static" when no class scope is active' in %s:3
 Stack trace:
 #0 {main}
   thrown in %s on line 3

--- a/Zend/tests/class_name_as_scalar_error_006.phpt
+++ b/Zend/tests/class_name_as_scalar_error_006.phpt
@@ -7,7 +7,7 @@ $x = parent::class;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use "parent" when no class scope is active' in %s:3
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use "parent" when no class scope is active' in %s:3
 Stack trace:
 #0 {main}
   thrown in %s on line 3

--- a/Zend/tests/class_name_as_scalar_error_007.phpt
+++ b/Zend/tests/class_name_as_scalar_error_007.phpt
@@ -7,7 +7,7 @@ var_dump(self::class);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use "self" when no class scope is active' in %s:3
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use "self" when no class scope is active' in %s:3
 Stack trace:
 #0 {main}
   thrown in %s on line 3

--- a/Zend/tests/clone_001.phpt
+++ b/Zend/tests/clone_001.phpt
@@ -7,7 +7,7 @@ $a = clone array();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message '__clone method called on non-object' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message '__clone method called on non-object' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/clone_003.phpt
+++ b/Zend/tests/clone_003.phpt
@@ -9,7 +9,7 @@ $a = clone $b;
 --EXPECTF--
 Notice: Undefined variable: b in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message '__clone method called on non-object' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message '__clone method called on non-object' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/clone_004.phpt
+++ b/Zend/tests/clone_004.phpt
@@ -17,7 +17,7 @@ $a = clone $c->b[1];
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use object of type foo as array' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use object of type foo as array' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/closure_005.phpt
+++ b/Zend/tests/closure_005.phpt
@@ -71,7 +71,7 @@ echo "Done\n";
 7
 Destroyed
 
-Fatal error: Uncaught exception 'EngineException' with message 'Using $this when not in object context' in %sclosure_005.php:28
+Fatal error: Uncaught exception 'EngineError' with message 'Using $this when not in object context' in %sclosure_005.php:28
 Stack trace:
 #0 %s(%d): A::{closure}()
 #1 {main}

--- a/Zend/tests/closure_019.phpt
+++ b/Zend/tests/closure_019.phpt
@@ -26,7 +26,7 @@ int(9)
 Notice: Only variable references should be returned by reference in %sclosure_019.php on line 4
 int(81)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot pass parameter 1 by reference' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot pass parameter 1 by reference' in %s:%d
 Stack trace:
 #0 %s(%d): test()
 #1 {main}

--- a/Zend/tests/closure_020.phpt
+++ b/Zend/tests/closure_020.phpt
@@ -40,7 +40,7 @@ object(foo)#%d (2) {
 bool(true)
 bool(true)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access private property foo::$test' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access private property foo::$test' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/closure_022.phpt
+++ b/Zend/tests/closure_022.phpt
@@ -8,7 +8,7 @@ $foo = function() use ($a) {
 $foo->a = 1;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Closure object cannot have properties' in %sclosure_022.php:5
+Fatal error: Uncaught exception 'EngineError' with message 'Closure object cannot have properties' in %sclosure_022.php:5
 Stack trace:
 #0 {main}
   thrown in %sclosure_022.php on line 5

--- a/Zend/tests/closure_031.phpt
+++ b/Zend/tests/closure_031.phpt
@@ -10,7 +10,7 @@ $foo = function() {
 };
 try {
 	var_dump($foo->a);
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "Error: {$ex->getMessage()}\n";
 }
 ?>

--- a/Zend/tests/closure_033.phpt
+++ b/Zend/tests/closure_033.phpt
@@ -25,7 +25,7 @@ $o->func();
 --EXPECTF--
 Test::{closure}()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method Test::func() from context ''' in %sclosure_033.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method Test::func() from context ''' in %sclosure_033.php:%d
 Stack trace:
 #0 {main}
   thrown in %sclosure_033.php on line %d

--- a/Zend/tests/closure_038.phpt
+++ b/Zend/tests/closure_038.phpt
@@ -55,17 +55,17 @@ Testing with scope as string
 int(23)
 int(24)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access private property B::$x' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access private property B::$x' in %s:%d
 Stack trace:
 #0 %s(%d): Closure->{closure}()
 #1 {main}
 
-Next exception 'EngineException' with message 'Cannot access private property B::$x' in %s:%d
+Next exception 'EngineError' with message 'Cannot access private property B::$x' in %s:%d
 Stack trace:
 #0 %s(%d): Closure->{closure}()
 #1 {main}
 
-Next exception 'EngineException' with message 'Cannot access private property B::$x' in %s:%d
+Next exception 'EngineError' with message 'Cannot access private property B::$x' in %s:%d
 Stack trace:
 #0 %s(%d): Closure->{closure}()
 #1 {main}

--- a/Zend/tests/closure_039.phpt
+++ b/Zend/tests/closure_039.phpt
@@ -55,17 +55,17 @@ Testing with scope as string
 int(23)
 int(24)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access private property B::$x' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access private property B::$x' in %s:%d
 Stack trace:
 #0 %s(%d): Closure->{closure}()
 #1 {main}
 
-Next exception 'EngineException' with message 'Cannot access private property B::$x' in %s:%d
+Next exception 'EngineError' with message 'Cannot access private property B::$x' in %s:%d
 Stack trace:
 #0 %s(%d): Closure->{closure}()
 #1 {main}
 
-Next exception 'EngineException' with message 'Cannot access private property B::$x' in %s:%d
+Next exception 'EngineError' with message 'Cannot access private property B::$x' in %s:%d
 Stack trace:
 #0 %s(%d): Closure->{closure}()
 #1 {main}

--- a/Zend/tests/closure_059.phpt
+++ b/Zend/tests/closure_059.phpt
@@ -19,17 +19,17 @@ call_user_func(array($f,"__invoke"), $a);
 
 try {
 	$f($b);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "Exception: " . $e->getMessage() . "\n";
 }
 try {
 	$f->__invoke($b);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "Exception: " . $e->getMessage() . "\n";
 }
 try {
 	call_user_func(array($f,"__invoke"), $b);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "Exception: " . $e->getMessage() . "\n";
 }
 --EXPECTF--

--- a/Zend/tests/constant_expressions_exceptions_002.phpt
+++ b/Zend/tests/constant_expressions_exceptions_002.phpt
@@ -4,7 +4,7 @@ Constant Expressions with unsupported operands 002
 <?php
 try {
 	require("constant_expressions_exceptions.inc");
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . " in " , $e->getFile() . " on line " . $e->getLine() . "\n";
 }
 ?>

--- a/Zend/tests/constant_expressions_invalid_offset_type_error.phpt
+++ b/Zend/tests/constant_expressions_invalid_offset_type_error.phpt
@@ -8,7 +8,7 @@ const C2 = [C1, [] => 1];
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Illegal offset type' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Illegal offset type' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/constant_expressions_self_referencing_array.phpt
+++ b/Zend/tests/constant_expressions_self_referencing_array.phpt
@@ -9,7 +9,7 @@ class A {
 var_dump(A::FOO);
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot declare self-referencing constant 'self::FOO'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot declare self-referencing constant 'self::FOO'' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/dereference_002.phpt
+++ b/Zend/tests/dereference_002.phpt
@@ -76,7 +76,7 @@ NULL
 
 Notice: Undefined offset: 3 in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to a member function bar() on null' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to a member function bar() on null' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/dereference_010.phpt
+++ b/Zend/tests/dereference_010.phpt
@@ -24,7 +24,7 @@ var_dump(b()[1]);
 NULL
 NULL
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use object of type stdClass as array' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use object of type stdClass as array' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/div_002.phpt
+++ b/Zend/tests/div_002.phpt
@@ -8,7 +8,7 @@ $b = array(1);
 
 try {
 	var_dump($a / $b);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . "\n";
 }
 
@@ -20,7 +20,7 @@ echo "Done\n";
 --EXPECTF--	
 Exception: Unsupported operand types
 
-Fatal error: Uncaught exception 'EngineException' with message 'Unsupported operand types' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Unsupported operand types' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/dynamic_call_001.phpt
+++ b/Zend/tests/dynamic_call_001.phpt
@@ -16,7 +16,7 @@ $a::$a();
 --EXPECTF--
 Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; foo has a deprecated constructor in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method foo::foo() cannot be called statically' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method foo::foo() cannot be called statically' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/dynamic_call_002.phpt
+++ b/Zend/tests/dynamic_call_002.phpt
@@ -9,7 +9,7 @@ $a::$a();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Function name must be a string' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Function name must be a string' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/dynamic_call_003.phpt
+++ b/Zend/tests/dynamic_call_003.phpt
@@ -10,7 +10,7 @@ $a::$b();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Function name must be a string' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Function name must be a string' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/dynamic_call_004.phpt
+++ b/Zend/tests/dynamic_call_004.phpt
@@ -9,7 +9,7 @@ $a::$b();
 --EXPECTF--
 Notice: Undefined variable: a in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class name must be a valid object or a string' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class name must be a valid object or a string' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/errmsg_044.phpt
+++ b/Zend/tests/errmsg_044.phpt
@@ -8,7 +8,7 @@ $a[0][0] = new stdclass;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use object of type stdClass as array' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use object of type stdClass as array' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/exception_004.phpt
+++ b/Zend/tests/exception_004.phpt
@@ -15,7 +15,7 @@ try {
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Exceptions must be valid objects derived from the Exception base class' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Exceptions must be valid objects derived from the Exception base class' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/exception_005.phpt
+++ b/Zend/tests/exception_005.phpt
@@ -9,7 +9,7 @@ throw new a();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot instantiate interface a' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot instantiate interface a' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/exception_006.phpt
+++ b/Zend/tests/exception_006.phpt
@@ -7,7 +7,7 @@ throw 1;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Can only throw objects' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Can only throw objects' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/exception_010.phpt
+++ b/Zend/tests/exception_010.phpt
@@ -15,16 +15,16 @@ $x->getcode(1);
 
 ?>
 --EXPECTF--
-Warning: BaseException::getTraceAsString() expects exactly 0 parameters, 1 given in %s on line %d
+Warning: Throwable::getTraceAsString() expects exactly 0 parameters, 1 given in %s on line %d
 
-Warning: BaseException::__toString() expects exactly 0 parameters, 1 given in %s on line %d
+Warning: Throwable::__toString() expects exactly 0 parameters, 1 given in %s on line %d
 
-Warning: BaseException::getTrace() expects exactly 0 parameters, 1 given in %s on line %d
+Warning: Throwable::getTrace() expects exactly 0 parameters, 1 given in %s on line %d
 
-Warning: BaseException::getLine() expects exactly 0 parameters, 1 given in %s on line %d
+Warning: Throwable::getLine() expects exactly 0 parameters, 1 given in %s on line %d
 
-Warning: BaseException::getFile() expects exactly 0 parameters, 1 given in %s on line %d
+Warning: Throwable::getFile() expects exactly 0 parameters, 1 given in %s on line %d
 
-Warning: BaseException::getMessage() expects exactly 0 parameters, 1 given in %s on line %d
+Warning: Throwable::getMessage() expects exactly 0 parameters, 1 given in %s on line %d
 
-Warning: BaseException::getCode() expects exactly 0 parameters, 1 given in %s on line %d
+Warning: Throwable::getCode() expects exactly 0 parameters, 1 given in %s on line %d

--- a/Zend/tests/exception_013.phpt
+++ b/Zend/tests/exception_013.phpt
@@ -8,19 +8,19 @@ class C {
 
 try {
 	var_dump(C::$a);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . " in " , $e->getFile() . " on line " . $e->getLine() . "\n";
 }
 
 try {
 	var_dump(C::$p);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . " in " , $e->getFile() . " on line " . $e->getLine() . "\n";
 }
 
 try {
 	unset(C::$a);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . " in " , $e->getFile() . " on line " . $e->getLine() . "\n";
 }
 
@@ -33,7 +33,7 @@ Exception: Cannot access private property C::$p in %sexception_013.php on line 1
 
 Exception: Attempt to unset static property C::$a in %sexception_013.php on line 19
 
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: C::$a' in %sexception_013.php:24
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: C::$a' in %sexception_013.php:24
 Stack trace:
 #0 {main}
   thrown in %sexception_013.php on line 24

--- a/Zend/tests/exception_014.phpt
+++ b/Zend/tests/exception_014.phpt
@@ -9,7 +9,7 @@ class C {
 $x = new C;
 try {
 	var_dump($x->p);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . " in " , $e->getFile() . " on line " . $e->getLine() . "\n";
 }
 
@@ -18,7 +18,7 @@ var_dump($x->p);
 --EXPECTF--
 Exception: Cannot access private property C::$p in %sexception_014.php on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access private property C::$p' in %sexception_014.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access private property C::$p' in %sexception_014.php:%d
 Stack trace:
 #0 {main}
   thrown in %sexception_014.php on line %d

--- a/Zend/tests/exception_015.phpt
+++ b/Zend/tests/exception_015.phpt
@@ -5,7 +5,7 @@ Exceptions on improper access to string
 $s = "ABC";
 try {
 	$s[] = "D";
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . " in " , $e->getFile() . " on line " . $e->getLine() . "\n";
 }
 
@@ -14,7 +14,7 @@ $s[] = "D";
 --EXPECTF--
 Exception: [] operator not supported for strings in %sexception_015.php on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message '[] operator not supported for strings' in %sexception_015.php:%d
+Fatal error: Uncaught exception 'EngineError' with message '[] operator not supported for strings' in %sexception_015.php:%d
 Stack trace:
 #0 {main}
   thrown in %sexception_015.php on line %d

--- a/Zend/tests/exception_016.phpt
+++ b/Zend/tests/exception_016.phpt
@@ -4,7 +4,7 @@ Exceptions on improper usage of $this
 <?php
 try {
 	$this->foo();
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . " in " , $e->getFile() . " on line " . $e->getLine() . "\n";
 }
 
@@ -13,7 +13,7 @@ $this->foo();
 --EXPECTF--
 Exception: Using $this when not in object context in %sexception_016.php on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Using $this when not in object context' in %sexception_016.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Using $this when not in object context' in %sexception_016.php:%d
 Stack trace:
 #0 {main}
   thrown in %sexception_016.php on line %d

--- a/Zend/tests/exception_017.phpt
+++ b/Zend/tests/exception_017.phpt
@@ -11,18 +11,18 @@ function foo(callable $x) {
 
 try {
 	C::foo();
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . " in " , $e->getFile() . " on line " . $e->getLine() . "\n";
 }
 
 try {
 	foo("C::foo");
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\n";
 	do {
 		echo "Exception: " . $e->getMessage() . "\n";
 		$e = $e->getPrevious();
-	} while ($e instanceof EngineException);
+	} while ($e instanceof EngineError);
 }
 
 C::foo();
@@ -33,7 +33,7 @@ Exception: Cannot call abstract method C::foo() in %sexception_017.php on line %
 Exception: Argument 1 passed to foo() must be callable, string given, called in %sexception_017.php on line %d
 Exception: Cannot call abstract method C::foo()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot call abstract method C::foo()' in %sexception_017.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot call abstract method C::foo()' in %sexception_017.php:%d
 Stack trace:
 #0 {main}
   thrown in %sexception_017.php on line %d

--- a/Zend/tests/exception_before_fatal.phpt
+++ b/Zend/tests/exception_before_fatal.phpt
@@ -10,38 +10,38 @@ set_error_handler("exception_error_handler");
 
 try {
     $foo->a();
-} catch(BaseException $e) {
+} catch(Throwable $e) {
     var_dump($e->getMessage());
 }
 
 try {
     new $foo();
-} catch(BaseException $e) {
+} catch(Throwable $e) {
     var_dump($e->getMessage());
 }
 
 try {
     throw $foo;
-} catch(BaseException $e) {
+} catch(Throwable $e) {
     var_dump($e->getMessage());
 }
 
 try {
     $foo();
-} catch(BaseException $e) {
+} catch(Throwable $e) {
     var_dump($e->getMessage());
 }
 
 try {
     $foo::b();
-} catch(BaseException $e) {
+} catch(Throwable $e) {
     var_dump($e->getMessage());
 }
 
 
 try {
     $b = clone $foo;
-} catch(BaseException $e) {
+} catch(Throwable $e) {
     var_dump($e->getMessage());
 }
 
@@ -50,7 +50,7 @@ class b {
 
 try {
     b::$foo();
-} catch(BaseException $e) {
+} catch(Throwable $e) {
     var_dump($e->getMessage());
 }
 ?>

--- a/Zend/tests/generators/bug63066.phpt
+++ b/Zend/tests/generators/bug63066.phpt
@@ -13,7 +13,7 @@ foreach(gen(new stdClass()) as $value)
 --EXPECTF--
 foo
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method stdClass::fatalError()' in %sbug63066.php:5
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method stdClass::fatalError()' in %sbug63066.php:5
 Stack trace:
 #0 %s(%d): gen(Object(stdClass))
 #1 {main}

--- a/Zend/tests/generators/bug65161.phpt
+++ b/Zend/tests/generators/bug65161.phpt
@@ -17,7 +17,7 @@ foreach (testGenerator() as $i);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function foo()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function foo()' in %s:%d
 Stack trace:
 #0 [internal function]: autoload('SyntaxError')
 #1 %s(%d): spl_autoload_call('SyntaxError')

--- a/Zend/tests/generators/bug67497.phpt
+++ b/Zend/tests/generators/bug67497.phpt
@@ -10,7 +10,7 @@ function gen() {
 
 try {
 	eval('abc');
-} catch (ParseException $ex) {
+} catch (ParseError $ex) {
 }
 
 $values = gen();

--- a/Zend/tests/generators/clone.phpt
+++ b/Zend/tests/generators/clone.phpt
@@ -12,7 +12,7 @@ clone $gen;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Trying to clone an uncloneable object of class Generator' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Trying to clone an uncloneable object of class Generator' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/generators/errors/generator_instantiate_error.phpt
+++ b/Zend/tests/generators/errors/generator_instantiate_error.phpt
@@ -7,7 +7,7 @@ new Generator;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'The "Generator" class is reserved for internal use and cannot be manually instantiated' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'The "Generator" class is reserved for internal use and cannot be manually instantiated' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/generators/errors/resume_running_generator_error.phpt
+++ b/Zend/tests/generators/errors/resume_running_generator_error.phpt
@@ -7,7 +7,7 @@ function gen() {
     $gen = yield;
     try {
 	    $gen->next();
-	} catch (EngineException $e) {
+	} catch (EngineError $e) {
 		echo "\nException: " . $e->getMessage() . "\n";
 	}
 	$gen->next();
@@ -21,7 +21,7 @@ $gen->next();
 --EXPECTF--
 Exception: Cannot resume an already running generator
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot resume an already running generator' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot resume an already running generator' in %s:%d
 Stack trace:
 #0 %s(%d): Generator->next()
 #1 [internal function]: gen()

--- a/Zend/tests/generators/errors/yield_in_force_closed_finally_error.phpt
+++ b/Zend/tests/generators/errors/yield_in_force_closed_finally_error.phpt
@@ -26,7 +26,7 @@ unset($gen);
 before yield
 before yield in finally
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot yield from finally in a force-closed generator' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot yield from finally in a force-closed generator' in %s:%d
 Stack trace:
 #0 %s(%d): gen()
 #1 {main}

--- a/Zend/tests/generators/throw_not_an_exception.phpt
+++ b/Zend/tests/generators/throw_not_an_exception.phpt
@@ -12,7 +12,7 @@ $gen->throw(new stdClass);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Exceptions must be valid objects derived from the Exception base class' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Exceptions must be valid objects derived from the Exception base class' in %s:%d
 Stack trace:
 #0 [internal function]: gen()
 #1 %s(%d): Generator->throw(Object(stdClass))

--- a/Zend/tests/generators/yield_from_already_running.phpt
+++ b/Zend/tests/generators/yield_from_already_running.phpt
@@ -11,7 +11,7 @@ function gen() {
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Impossible to yield from the Generator being currently run' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Impossible to yield from the Generator being currently run' in %s:%d
 Stack trace:
 #0 [internal function]: gen()
 #1 %s(%d): Generator->send(Object(Generator))

--- a/Zend/tests/indirect_call_array_001.phpt
+++ b/Zend/tests/indirect_call_array_001.phpt
@@ -8,7 +8,7 @@ $arr();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'a' not found' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'a' not found' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/indirect_call_array_002.phpt
+++ b/Zend/tests/indirect_call_array_002.phpt
@@ -8,7 +8,7 @@ $arr();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method stdClass::b()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method stdClass::b()' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/indirect_method_call_002.phpt
+++ b/Zend/tests/indirect_method_call_002.phpt
@@ -29,7 +29,7 @@ string(7) "testing"
 string(3) "foo"
 NULL
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method foo::www()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method foo::www()' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/list_005.phpt
+++ b/Zend/tests/list_005.phpt
@@ -44,7 +44,7 @@ NULL
 NULL
 ----
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use object of type stdClass as array' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use object of type stdClass as array' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/list_007.phpt
+++ b/Zend/tests/list_007.phpt
@@ -9,7 +9,7 @@ var_dump($x, $y);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use object of type Closure as array' in %slist_007.php:3
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use object of type Closure as array' in %slist_007.php:3
 Stack trace:
 #0 {main}
   thrown in %slist_007.php on line 3

--- a/Zend/tests/methods-on-non-objects-catch.phpt
+++ b/Zend/tests/methods-on-non-objects-catch.phpt
@@ -9,7 +9,7 @@ set_error_handler(function($code, $message) {
 $x= null;
 try {
 	var_dump($x->method());
-} catch (EngineException $e) {
+} catch (EngineError $e) {
   var_dump($e->getCode(), $e->getMessage());
 }
 echo "Alive\n";

--- a/Zend/tests/methods-on-non-objects-usort.phpt
+++ b/Zend/tests/methods-on-non-objects-usort.phpt
@@ -11,7 +11,7 @@ $list= [1, 4, 2, 3, -1];
 usort($list, function($a, $b) use ($comparator) {
   try {
 	  return $comparator->compare($a, $b);
-  } catch (EngineException $e) {
+  } catch (EngineError $e) {
 	  var_dump($e->getCode(), $e->getMessage());
 	  return 0;
   }

--- a/Zend/tests/methods-on-non-objects.phpt
+++ b/Zend/tests/methods-on-non-objects.phpt
@@ -9,7 +9,7 @@ echo "Should not get here!\n";
 ?>
 --EXPECTF--
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to a member function method() on null' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to a member function method() on null' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d 

--- a/Zend/tests/mul_001.phpt
+++ b/Zend/tests/mul_001.phpt
@@ -8,7 +8,7 @@ $b = array(1);
 
 try {
 	var_dump($a * $b);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . "\n";
 }
 
@@ -20,7 +20,7 @@ echo "Done\n";
 --EXPECTF--	
 Exception: Unsupported operand types
 
-Fatal error: Uncaught exception 'EngineException' with message 'Unsupported operand types' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Unsupported operand types' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/not_002.phpt
+++ b/Zend/tests/not_002.phpt
@@ -8,7 +8,7 @@ $b = array(1,2);
 
 try {
 	var_dump(~$b);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . "\n";
 }
 
@@ -20,7 +20,7 @@ echo "Done\n";
 --EXPECTF--	
 Exception: Unsupported operand types
 
-Fatal error: Uncaught exception 'EngineException' with message 'Unsupported operand types' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Unsupported operand types' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/ns_004.phpt
+++ b/Zend/tests/ns_004.phpt
@@ -6,7 +6,7 @@ namespace test\ns1;
 
 echo get_class(new Exception()),"\n";
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'test\ns1\Exception' not found' in %sns_004.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'test\ns1\Exception' not found' in %sns_004.php:%d
 Stack trace:
 #0 {main}
   thrown in %sns_004.php on line %d

--- a/Zend/tests/ns_026.phpt
+++ b/Zend/tests/ns_026.phpt
@@ -32,7 +32,7 @@ Method - Foo\Foo::__construct
 Method - Foo\Foo::Bar
 Func   - Foo\Bar
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function Foo\Foo\Bar()' in %sns_026.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function Foo\Foo\Bar()' in %sns_026.php:%d
 Stack trace:
 #0 {main}
   thrown in %sns_026.php on line %d

--- a/Zend/tests/ns_038.phpt
+++ b/Zend/tests/ns_038.phpt
@@ -11,7 +11,7 @@ function foo() {
 --EXPECTF--
 ok
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method Exception::bar()' in %sns_038.php:7
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method Exception::bar()' in %sns_038.php:7
 Stack trace:
 #0 {main}
   thrown in %sns_038.php on line 7

--- a/Zend/tests/ns_057.phpt
+++ b/Zend/tests/ns_057.phpt
@@ -56,7 +56,7 @@ const ok
 class ok
 ok
 
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'Test\ns1\unknown'' in %sns_057.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'Test\ns1\unknown'' in %sns_057.php:%d
 Stack trace:
 #0 {main}
   thrown in %sns_057.php on line %d

--- a/Zend/tests/ns_058.phpt
+++ b/Zend/tests/ns_058.phpt
@@ -54,7 +54,7 @@ const ok
 class ok
 ok
 
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'unknown'' in %sns_058.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'unknown'' in %sns_058.php:%d
 Stack trace:
 #0 {main}
   thrown in %sns_058.php on line %d

--- a/Zend/tests/ns_076.phpt
+++ b/Zend/tests/ns_076.phpt
@@ -22,7 +22,7 @@ array(1) {
   %s(7) "unknown"
 }
 
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'unknown'' in %sns_076.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'unknown'' in %sns_076.php:%d
 Stack trace:
 #0 {main}
   thrown in %sns_076.php on line %d

--- a/Zend/tests/ns_077_1.phpt
+++ b/Zend/tests/ns_077_1.phpt
@@ -10,7 +10,7 @@ function foo($a = array(0 => \unknown))
 
 foo();
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
 Stack trace:
 #0 %s(%d): foo\foo()
 #1 {main}

--- a/Zend/tests/ns_077_2.phpt
+++ b/Zend/tests/ns_077_2.phpt
@@ -10,7 +10,7 @@ function foo($a = array(\unknown => unknown))
 
 foo();
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
 Stack trace:
 #0 %s(%d): foo\foo()
 #1 {main}

--- a/Zend/tests/ns_077_3.phpt
+++ b/Zend/tests/ns_077_3.phpt
@@ -10,7 +10,7 @@ function foo($a = array(namespace\unknown => unknown))
 
 foo();
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'foo\unknown'' in %sns_077_%d.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'foo\unknown'' in %sns_077_%d.php:%d
 Stack trace:
 #0 %s(%d): foo\foo()
 #1 {main}

--- a/Zend/tests/ns_077_4.phpt
+++ b/Zend/tests/ns_077_4.phpt
@@ -10,7 +10,7 @@ function foo($a = array(0 => namespace\unknown))
 
 foo();
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'foo\unknown'' in %sns_077_%d.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'foo\unknown'' in %sns_077_%d.php:%d
 Stack trace:
 #0 %s(%d): foo\foo()
 #1 {main}

--- a/Zend/tests/ns_077_5.phpt
+++ b/Zend/tests/ns_077_5.phpt
@@ -9,7 +9,7 @@ function foo($a = array(0 => \unknown))
 
 foo();
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
 Stack trace:
 #0 %s(%d): foo()
 #1 {main}

--- a/Zend/tests/ns_077_6.phpt
+++ b/Zend/tests/ns_077_6.phpt
@@ -9,7 +9,7 @@ function foo($a = array(0 => \unknown))
 
 foo();
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
 Stack trace:
 #0 %s(%d): foo()
 #1 {main}

--- a/Zend/tests/ns_077_7.phpt
+++ b/Zend/tests/ns_077_7.phpt
@@ -9,7 +9,7 @@ function foo($a = array(0 => namespace\unknown))
 
 foo();
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
 Stack trace:
 #0 %s(%d): foo()
 #1 {main}

--- a/Zend/tests/ns_077_8.phpt
+++ b/Zend/tests/ns_077_8.phpt
@@ -9,7 +9,7 @@ function foo($a = array(namespace\unknown => unknown))
 
 foo();
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'unknown'' in %sns_077_%d.php:%d
 Stack trace:
 #0 %s(%d): foo()
 #1 {main}

--- a/Zend/tests/ns_092.phpt
+++ b/Zend/tests/ns_092.phpt
@@ -64,7 +64,7 @@ Foo\Bar\fiz
 Foo\Bar\biz
 Foo\Bar\buz
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function Foo\Bar\A()' in %sns_092.php:45
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function Foo\Bar\A()' in %sns_092.php:45
 Stack trace:
 #0 {main}
   thrown in %sns_092.php on line 45

--- a/Zend/tests/objects_017.phpt
+++ b/Zend/tests/objects_017.phpt
@@ -15,7 +15,7 @@ test()->test = 2;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access private property foo::$test' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access private property foo::$test' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/objects_025.phpt
+++ b/Zend/tests/objects_025.phpt
@@ -43,7 +43,7 @@ static - ok
 non-static - ok
 static - ok
 
-Fatal error: Uncaught exception 'EngineException' with message 'Method name must be a string' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Method name must be a string' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/objects_026.phpt
+++ b/Zend/tests/objects_026.phpt
@@ -10,7 +10,7 @@ try {
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Using $this when not in object context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Using $this when not in object context' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/objects_029.phpt
+++ b/Zend/tests/objects_029.phpt
@@ -23,7 +23,7 @@ new foo;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: foo::$f' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: foo::$f' in %s:%d
 Stack trace:
 #0 %s(%d): foo->__construct()
 #1 {main}

--- a/Zend/tests/objects_030.phpt
+++ b/Zend/tests/objects_030.phpt
@@ -23,7 +23,7 @@ new foo;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: bar::$f' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: bar::$f' in %s:%d
 Stack trace:
 #0 %s(%d): foo->__construct()
 #1 {main}

--- a/Zend/tests/offset_assign.phpt
+++ b/Zend/tests/offset_assign.phpt
@@ -10,7 +10,7 @@ echo "Done\n";
 --EXPECTF--	
 Warning: Illegal string offset 'x' in %soffset_assign.php on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use string offset as an array' in %soffset_assign.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use string offset as an array' in %soffset_assign.php:%d
 Stack trace:
 #0 {main}
   thrown in %soffset_assign.php on line %d

--- a/Zend/tests/offset_object.phpt
+++ b/Zend/tests/offset_object.phpt
@@ -8,7 +8,7 @@ var_dump($object[1]);
 
 ?>
 --EXPECTF--	
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use object of type stdClass as array' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use object of type stdClass as array' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/parent_class_name_without_parent.phpt
+++ b/Zend/tests/parent_class_name_without_parent.phpt
@@ -17,7 +17,7 @@ class C {
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use "parent" when current class scope has no parent' in %s:5
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use "parent" when current class scope has no parent' in %s:5
 Stack trace:
 #0 %s(%d): C->f()
 #1 {main}

--- a/Zend/tests/require_parse_exception.phpt
+++ b/Zend/tests/require_parse_exception.phpt
@@ -8,7 +8,7 @@ allow_url_include=1
 function test_parse_error($code) {
     try {
         require 'data://text/plain;base64,' . base64_encode($code);
-    } catch (ParseException $e) {
+    } catch (ParseError $e) {
         echo $e->getMessage(), " on line ", $e->getLine(), "\n";
     }
 }

--- a/Zend/tests/str_offset_002.phpt
+++ b/Zend/tests/str_offset_002.phpt
@@ -6,7 +6,7 @@ $a = "aaa";
 $x = array(&$a[1]);
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot create references to/from string offsets' in %sstr_offset_002.php:3
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot create references to/from string offsets' in %sstr_offset_002.php:3
 Stack trace:
 #0 {main}
   thrown in %sstr_offset_002.php on line 3

--- a/Zend/tests/sub_001.phpt
+++ b/Zend/tests/sub_001.phpt
@@ -8,7 +8,7 @@ $b = array(1);
 
 try {
 	var_dump($a - $b);
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . "\n";
 }
 
@@ -20,7 +20,7 @@ echo "Done\n";
 --EXPECTF--	
 Exception: Unsupported operand types
 
-Fatal error: Uncaught exception 'EngineException' with message 'Unsupported operand types' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Unsupported operand types' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/traits/bug60173.phpt
+++ b/Zend/tests/traits/bug60173.phpt
@@ -9,7 +9,7 @@ $rc = new ReflectionClass('foo');
 $rc->newInstance();
 
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot instantiate trait foo' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot instantiate trait foo' in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->newInstance()
 #1 {main}

--- a/Zend/tests/traits/bugs/alias01.phpt
+++ b/Zend/tests/traits/bugs/alias01.phpt
@@ -23,7 +23,7 @@ T:m1
 T:m1
 T:m2
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method C1::a2()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method C1::a2()' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/traits/error_007.phpt
+++ b/Zend/tests/traits/error_007.phpt
@@ -10,7 +10,7 @@ new abc;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot instantiate trait abc' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot instantiate trait abc' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/traits/error_012.phpt
+++ b/Zend/tests/traits/error_012.phpt
@@ -16,7 +16,7 @@ var_dump($x->test());
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected method bar::test() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected method bar::test() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/traits/language008a.phpt
+++ b/Zend/tests/traits/language008a.phpt
@@ -20,7 +20,7 @@ $o->sayHello();
 
 ?>
 --EXPECTF--	
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected method MyClass::sayHello() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected method MyClass::sayHello() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/traits/language008b.phpt
+++ b/Zend/tests/traits/language008b.phpt
@@ -27,7 +27,7 @@ $o->sayHelloWorld();
 ?>
 --EXPECTF--	
 Hello World!Hello World!
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method MyClass::sayHelloWorld() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method MyClass::sayHelloWorld() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/typehints/internal_function_strict_mode.phpt
+++ b/Zend/tests/typehints/internal_function_strict_mode.phpt
@@ -7,21 +7,21 @@ declare(strict_types=1);
 echo "*** Trying Ord With Integer" . PHP_EOL;
 try {
 	var_dump(ord(1));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	echo "*** Caught " . $e->getMessage() . PHP_EOL;
 }
 
 echo "*** Trying Array Map With Invalid Callback" . PHP_EOL;
 try {
 	array_map([null, "bar"], []);
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	echo "*** Caught " . $e->getMessage() . PHP_EOL;
 }
 
 echo "*** Trying Strlen With Float" . PHP_EOL;
 try {
 	var_dump(strlen(1.5));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	echo "*** Caught " . $e->getMessage() . PHP_EOL;
 }
 

--- a/Zend/tests/typehints/scalar_basic.phpt
+++ b/Zend/tests/typehints/scalar_basic.phpt
@@ -51,7 +51,7 @@ foreach ($functions as $type => $function) {
         var_dump($value);
         try {
             var_dump($function($value));
-        } catch (\TypeException $e) {
+        } catch (\TypeError $e) {
             echo "*** Caught " . $e->getMessage() . PHP_EOL;
         }
     }

--- a/Zend/tests/typehints/scalar_none.phpt
+++ b/Zend/tests/typehints/scalar_none.phpt
@@ -28,7 +28,7 @@ foreach ($functions as $type => $function) {
     echo "Testing $type:", PHP_EOL;
     try {
         var_dump($function());
-    } catch (TypeException $e) {
+    } catch (TypeError $e) {
         echo "*** Caught " . $e->getMessage() . PHP_EOL;
     }
 }

--- a/Zend/tests/typehints/scalar_null.phpt
+++ b/Zend/tests/typehints/scalar_null.phpt
@@ -28,7 +28,7 @@ foreach ($functions as $type => $function) {
     echo "Testing $type:", PHP_EOL;
     try {
         var_dump($function(null));
-    } catch (TypeException $e) {
+    } catch (TypeError $e) {
         echo "*** Caught " . $e->getMessage() . PHP_EOL;
     }
 }

--- a/Zend/tests/typehints/scalar_return_basic.phpt
+++ b/Zend/tests/typehints/scalar_return_basic.phpt
@@ -54,7 +54,7 @@ foreach ($functions as $type => $function) {
         var_dump($value);
         try {
             var_dump($function($value));
-        } catch (TypeException $e) {
+        } catch (TypeError $e) {
             echo "*** Caught " . $e->getMessage() . PHP_EOL;
         }
     }

--- a/Zend/tests/typehints/scalar_return_basic_64bit.phpt
+++ b/Zend/tests/typehints/scalar_return_basic_64bit.phpt
@@ -54,7 +54,7 @@ foreach ($functions as $type => $function) {
         var_dump($value);
         try {
             var_dump($function($value));
-        } catch (TypeException $e) {
+        } catch (TypeError $e) {
             echo "*** Caught " . $e->getMessage() . PHP_EOL;
         }
     }

--- a/Zend/tests/typehints/scalar_strict.phpt
+++ b/Zend/tests/typehints/scalar_strict.phpt
@@ -55,7 +55,7 @@ foreach ($functions as $type => $function) {
         var_dump($value);
         try {
             var_dump($function($value));
-        } catch (TypeException $e) {
+        } catch (TypeError $e) {
             echo "*** Caught " . $e->getMessage() . PHP_EOL;
         }
     }

--- a/Zend/tests/typehints/scalar_strict_64bit.phpt
+++ b/Zend/tests/typehints/scalar_strict_64bit.phpt
@@ -55,7 +55,7 @@ foreach ($functions as $type => $function) {
         var_dump($value);
         try {
             var_dump($function($value));
-        } catch (TypeException $e) {
+        } catch (TypeError $e) {
             echo "*** Caught " . $e->getMessage() . PHP_EOL;
         }
     }

--- a/Zend/tests/typehints/scalar_strict_basic.phpt
+++ b/Zend/tests/typehints/scalar_strict_basic.phpt
@@ -54,7 +54,7 @@ foreach ($functions as $type => $function) {
         echo PHP_EOL . "*** Trying ", type($value), " value", PHP_EOL;
         try {
             var_dump($function($value));
-        } catch (TypeException $e) {
+        } catch (TypeError $e) {
             echo "*** Caught " . $e->getMessage() . PHP_EOL;
         }
     }

--- a/Zend/tests/use_const/no_global_fallback.phpt
+++ b/Zend/tests/use_const/no_global_fallback.phpt
@@ -10,7 +10,7 @@ var_dump(baz);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined constant 'foo\bar\baz'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined constant 'foo\bar\baz'' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/use_function/no_global_fallback.phpt
+++ b/Zend/tests/use_function/no_global_fallback.phpt
@@ -10,7 +10,7 @@ var_dump(baz());
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function foo\bar\baz()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function foo\bar\baz()' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/use_function/no_global_fallback2.phpt
+++ b/Zend/tests/use_function/no_global_fallback2.phpt
@@ -15,7 +15,7 @@ namespace foo {
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function bar\test()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function bar\test()' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/varSyntax/method_call_on_string_literal.phpt
+++ b/Zend/tests/varSyntax/method_call_on_string_literal.phpt
@@ -5,7 +5,7 @@ Method call on string literal
 "string"->length();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to a member function length() on string' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to a member function length() on string' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/varSyntax/tempDimFetchByRefError.phpt
+++ b/Zend/tests/varSyntax/tempDimFetchByRefError.phpt
@@ -8,7 +8,7 @@ $fn([0, 1][0]);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use temporary expression in write context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use temporary expression in write context' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/varSyntax/tempPropFetchByRefError.phpt
+++ b/Zend/tests/varSyntax/tempPropFetchByRefError.phpt
@@ -8,7 +8,7 @@ $fn([0, 1]->prop);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot use temporary expression in write context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot use temporary expression in write context' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/variadic/typehint_suppressed_error.phpt
+++ b/Zend/tests/variadic/typehint_suppressed_error.phpt
@@ -9,7 +9,7 @@ function test(array... $args) {
 
 try {
 	test([0], [1], 2);
-} catch(EngineException $e) {
+} catch(EngineError $e) {
 	var_dump($e->getMessage());
 }
 

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -882,7 +882,7 @@ void zenderror(const char *error) /* {{{ */
 		return;
 	}
 
-	zend_throw_exception(zend_get_parse_exception(), error, E_PARSE);
+	zend_throw_exception(zend_get_parse_error(), error, E_PARSE);
 }
 /* }}} */
 
@@ -1059,7 +1059,7 @@ static void zend_error_va_list(int type, const char *format, va_list args)
 			va_start(args, format);
 #endif
 			zend_vspprintf(&message, 0, format, args);
-			zend_throw_exception(zend_get_engine_exception(), message, type);
+			zend_throw_exception(zend_get_engine_error(), message, type);
 			efree(message);
 #if !defined(HAVE_NORETURN) || defined(HAVE_NORETURN_ALIAS)
 			va_end(args);
@@ -1318,7 +1318,7 @@ ZEND_API void zend_type_error(const char *format, ...) /* {{{ */
 
 	va_start(va, format);
 	zend_vspprintf(&message, 0, format, va);
-	zend_throw_exception(zend_get_type_exception(), message, E_ERROR);
+	zend_throw_exception(zend_get_type_error(), message, E_ERROR);
 	efree(message);
 	va_end(va);
 } /* }}} */
@@ -1331,7 +1331,7 @@ ZEND_API void zend_internal_type_error(zend_bool throw_exception, const char *fo
 	va_start(va, format);
 	zend_vspprintf(&message, 0, format, va);
 	if (throw_exception) {
-		zend_throw_exception(zend_get_type_exception(), message, E_ERROR);
+		zend_throw_exception(zend_get_type_error(), message, E_ERROR);
 	} else {
 		zend_error(E_WARNING, message);
 	}

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -34,12 +34,13 @@ ZEND_API void zend_throw_exception_internal(zval *exception);
 
 void zend_register_default_exception(void);
 
-ZEND_API zend_class_entry *zend_exception_get_base(void);
+ZEND_API zend_class_entry *zend_get_throwable(void);
 ZEND_API zend_class_entry *zend_exception_get_default(void);
 ZEND_API zend_class_entry *zend_get_error_exception(void);
-ZEND_API zend_class_entry *zend_get_engine_exception(void);
-ZEND_API zend_class_entry *zend_get_parse_exception(void);
-ZEND_API zend_class_entry *zend_get_type_exception(void);
+ZEND_API zend_class_entry *zend_get_error(void);
+ZEND_API zend_class_entry *zend_get_engine_error(void);
+ZEND_API zend_class_entry *zend_get_parse_error(void);
+ZEND_API zend_class_entry *zend_get_type_error(void);
 ZEND_API void zend_register_default_classes(void);
 
 /* exception_ce   NULL or zend_exception_get_default() or a derived class

--- a/Zend/zend_language_scanner.c
+++ b/Zend/zend_language_scanner.c
@@ -998,7 +998,7 @@ static int zend_scan_escape_string(zval *zendlval, char *str, int len, char quot
 						}
 
 						if (!valid) {
-							zend_throw_exception(zend_get_parse_exception(),
+							zend_throw_exception(zend_get_parse_error(),
 								"Invalid UTF-8 codepoint escape sequence", E_PARSE);
 							zval_ptr_dtor(zendlval);
 							return FAILURE;
@@ -1009,7 +1009,7 @@ static int zend_scan_escape_string(zval *zendlval, char *str, int len, char quot
 
 						/* per RFC 3629, UTF-8 can only represent 21 bits */
 						if (codepoint > 0x10FFFF || errno) {
-							zend_throw_exception(zend_get_parse_exception(),
+							zend_throw_exception(zend_get_parse_error(),
 								"Invalid UTF-8 codepoint escape sequence: Codepoint too large", E_PARSE);
 							zval_ptr_dtor(zendlval);
 							return FAILURE;
@@ -2720,7 +2720,7 @@ yy136:
 		 * Because the lexing itself doesn't do that for us
 		 */
 		if (end != yytext + yyleng) {
-			zend_throw_exception(zend_get_parse_exception(), "Invalid numeric literal", E_PARSE);
+			zend_throw_exception(zend_get_parse_error(), "Invalid numeric literal", E_PARSE);
 			return T_ERROR;
 		}
 	} else {
@@ -2736,7 +2736,7 @@ yy136:
 			}
 			/* Also not an assert for the same reason */
 			if (end != yytext + yyleng) {
-				zend_throw_exception(zend_get_parse_exception(),
+				zend_throw_exception(zend_get_parse_error(),
 					"Invalid numeric literal", E_PARSE);
 				return T_ERROR;
 			}
@@ -2745,7 +2745,7 @@ yy136:
 		}
 		/* Also not an assert for the same reason */
 		if (end != yytext + yyleng) {
-			zend_throw_exception(zend_get_parse_exception(), "Invalid numeric literal", E_PARSE);
+			zend_throw_exception(zend_get_parse_error(), "Invalid numeric literal", E_PARSE);
 			return T_ERROR;
 		}
 	}

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -996,7 +996,7 @@ static int zend_scan_escape_string(zval *zendlval, char *str, int len, char quot
 						}
 
 						if (!valid) {
-							zend_throw_exception(zend_get_parse_exception(),
+							zend_throw_exception(zend_get_parse_error(),
 								"Invalid UTF-8 codepoint escape sequence", E_PARSE);
 							zval_ptr_dtor(zendlval);
 							return FAILURE;
@@ -1007,7 +1007,7 @@ static int zend_scan_escape_string(zval *zendlval, char *str, int len, char quot
 
 						/* per RFC 3629, UTF-8 can only represent 21 bits */
 						if (codepoint > 0x10FFFF || errno) {
-							zend_throw_exception(zend_get_parse_exception(),
+							zend_throw_exception(zend_get_parse_error(),
 								"Invalid UTF-8 codepoint escape sequence: Codepoint too large", E_PARSE);
 							zval_ptr_dtor(zendlval);
 							return FAILURE;
@@ -1635,7 +1635,7 @@ NEWLINE ("\r"|"\n"|"\r\n")
 		 * Because the lexing itself doesn't do that for us
 		 */
 		if (end != yytext + yyleng) {
-			zend_throw_exception(zend_get_parse_exception(), "Invalid numeric literal", E_PARSE);
+			zend_throw_exception(zend_get_parse_error(), "Invalid numeric literal", E_PARSE);
 			return T_ERROR;
 		}
 	} else {
@@ -1651,7 +1651,7 @@ NEWLINE ("\r"|"\n"|"\r\n")
 			}
 			/* Also not an assert for the same reason */
 			if (end != yytext + yyleng) {
-				zend_throw_exception(zend_get_parse_exception(),
+				zend_throw_exception(zend_get_parse_error(),
 					"Invalid numeric literal", E_PARSE);
 				return T_ERROR;
 			}
@@ -1660,7 +1660,7 @@ NEWLINE ("\r"|"\n"|"\r\n")
 		}
 		/* Also not an assert for the same reason */
 		if (end != yytext + yyleng) {
-			zend_throw_exception(zend_get_parse_exception(), "Invalid numeric literal", E_PARSE);
+			zend_throw_exception(zend_get_parse_error(), "Invalid numeric literal", E_PARSE);
 			return T_ERROR;
 		}
 	}

--- a/ext/date/tests/DateTimeZone_construct_error.phpt
+++ b/ext/date/tests/DateTimeZone_construct_error.phpt
@@ -17,7 +17,7 @@ $timezone = "GMT";
 $extra_arg = 99;
 try {
     new DateTimeZone($timezone, $extra_arg);
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 

--- a/ext/date/tests/DateTimeZone_construct_variation1.phpt
+++ b/ext/date/tests/DateTimeZone_construct_variation1.phpt
@@ -97,7 +97,7 @@ foreach($inputs as $variation =>$timezone) {
       echo "\n-- $variation --\n";
       try {
       	var_dump( new DateTimezone($timezone) );
-      } catch (BaseException $e) {
+      } catch (Throwable $e) {
       	  $msg = $e->getMessage();
       	  echo "FAILED: " . $msg . "\n";
       }	

--- a/ext/date/tests/DateTime_construct_error.phpt
+++ b/ext/date/tests/DateTime_construct_error.phpt
@@ -18,7 +18,7 @@ $timezone  = timezone_open("GMT");
 $extra_arg = 99;
 try {
     var_dump( new DateTime($time, $timezone, $extra_arg) );
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 

--- a/ext/date/tests/DateTime_construct_variation1.phpt
+++ b/ext/date/tests/DateTime_construct_variation1.phpt
@@ -102,14 +102,14 @@ foreach($inputs as $variation =>$time) {
       
       try {
       	var_dump( new DateTime($time) );
-      } catch (BaseException $e) {
+      } catch (Throwable $e) {
       	  $msg = $e->getMessage();
       	  echo "FAILED: " . $msg . "\n";
       }	
       
       try {
       	var_dump( new DateTime($time, $timezone) );
-      } catch (BaseException$e) {
+      } catch (Throwable$e) {
       	 $msg = $e->getMessage();
       	 echo "FAILED: " . $msg . "\n";
       }	

--- a/ext/date/tests/DateTime_construct_variation2.phpt
+++ b/ext/date/tests/DateTime_construct_variation2.phpt
@@ -102,7 +102,7 @@ foreach($inputs as $variation =>$timezone) {
       
       try {
 			var_dump( new DateTime($time, $timezone) );
-      } catch (BaseException $e) {
+      } catch (Throwable $e) {
 			$msg = $e->getMessage();
 			echo "FAILED: " . $msg . "\n";
       }	

--- a/ext/date/tests/timezone_offset_get_error.phpt
+++ b/ext/date/tests/timezone_offset_get_error.phpt
@@ -26,7 +26,7 @@ echo "*** Testing timezone_offset_get() : error conditions ***\n";
 echo "\n-- Testing timezone_offset_get() function with zero arguments --\n";
 try {
 	var_dump( timezone_offset_get() );
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 	echo "\n";
 }
@@ -34,7 +34,7 @@ try {
 echo "\n-- Testing timezone_offset_get() function with less than expected no. of arguments --\n";
 try {
 	var_dump( timezone_offset_get($tz) );
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 	echo "\n";
 }
@@ -43,7 +43,7 @@ echo "\n-- Testing timezone_offset_get() function with more than expected no. of
 $extra_arg = 99;
 try {
 	var_dump( timezone_offset_get($tz, $date, $extra_arg) );
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 	echo "\n";
 }
@@ -52,21 +52,21 @@ echo "\n-- Testing timezone_offset_get() function with an invalid values for \$o
 $invalid_obj = new stdClass();
 try {
 	var_dump( timezone_offset_get($invalid_obj, $date) );
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 	echo "\n";
 }
 $invalid_obj = 10;
 try {
 	var_dump( timezone_offset_get($invalid_obj, $date) );
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 	echo "\n";
 }
 $invalid_obj = null;
 try {
 	var_dump( timezone_offset_get($invalid_obj, $date) );
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 	echo "\n";
 }
@@ -75,21 +75,21 @@ echo "\n-- Testing timezone_offset_get() function with an invalid values for \$d
 $invalid_obj = new stdClass();
 try {
 	var_dump( timezone_offset_get($tz, $invalid_obj) );
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 	echo "\n";
 }
 $invalid_obj = 10;
 try {
 	var_dump( timezone_offset_get($tz, $invalid_obj) );
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 	echo "\n";
 }
 $invalid_obj = null;
 try {
 	var_dump( timezone_offset_get($tz, $invalid_obj) );
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getMessage());
 	echo "\n";
 }

--- a/ext/date/tests/timezone_offset_get_variation1.phpt
+++ b/ext/date/tests/timezone_offset_get_variation1.phpt
@@ -109,7 +109,7 @@ foreach($inputs as $variation =>$object) {
     echo "\n-- $variation --\n";
 	try {
 		var_dump( timezone_offset_get($object, $datetime) );
-	} catch (EngineException $ex) {
+	} catch (EngineError $ex) {
 		echo $ex->getMessage()."\n";
 	}
 };

--- a/ext/date/tests/timezone_offset_get_variation2.phpt
+++ b/ext/date/tests/timezone_offset_get_variation2.phpt
@@ -109,7 +109,7 @@ foreach($inputs as $variation =>$datetime) {
     echo "\n-- $variation --\n";
     try {
 		var_dump( timezone_offset_get($object, $datetime) );
-	} catch (EngineException $ex) {
+	} catch (EngineError $ex) {
 		echo $ex->getMessage()."\n";
 	}
 };

--- a/ext/dom/tests/DOMAttr_construct_error_001.phpt
+++ b/ext/dom/tests/DOMAttr_construct_error_001.phpt
@@ -9,7 +9,7 @@ Josh Sweeney <jsweeney@alt-invest.net>
 <?php
 try {
     $attr = new DOMAttr();
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 ?>

--- a/ext/dom/tests/DOMCDATASection_construct_error_001.phpt
+++ b/ext/dom/tests/DOMCDATASection_construct_error_001.phpt
@@ -9,7 +9,7 @@ Nic Rosental nicrosental@gmail.com
 <?php
 	try {
 	    $section = new DOMCDataSection();
-	} catch (TypeException $e) {
+	} catch (TypeError $e) {
 	    echo $e->getMessage();
 	}
 ?>

--- a/ext/dom/tests/DOMComment_construct_error_001.phpt
+++ b/ext/dom/tests/DOMComment_construct_error_001.phpt
@@ -9,7 +9,7 @@ Eric Lee Stewart <ericleestewart@gmail.com>
 <?php
 try {
     $comment = new DOMComment("comment1", "comment2");
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 ?>

--- a/ext/dom/tests/DOMDocumentFragment_construct_error_001.phpt
+++ b/ext/dom/tests/DOMDocumentFragment_construct_error_001.phpt
@@ -9,7 +9,7 @@ Eric Lee Stewart <ericleestewart@gmail.com>
 <?php
 try {
     $fragment = new DOMDocumentFragment("root");
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 ?>

--- a/ext/dom/tests/DOMDocument_saveHTMLFile_error2.phpt
+++ b/ext/dom/tests/DOMDocument_saveHTMLFile_error2.phpt
@@ -12,7 +12,7 @@ require_once dirname(__FILE__) .'/skipif.inc';
 DOMDocument::saveHTMLFile();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method DOMDocument::saveHTMLFile() cannot be called statically' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method DOMDocument::saveHTMLFile() cannot be called statically' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/dom/tests/DOMDocument_saveHTML_error2.phpt
+++ b/ext/dom/tests/DOMDocument_saveHTML_error2.phpt
@@ -12,7 +12,7 @@ require_once dirname(__FILE__) .'/skipif.inc';
 DOMDocument::saveHTML(true);
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method DOMDocument::saveHTML() cannot be called statically' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method DOMDocument::saveHTML() cannot be called statically' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/dom/tests/DOMDocument_validate_error2.phpt
+++ b/ext/dom/tests/DOMDocument_validate_error2.phpt
@@ -12,7 +12,7 @@ require_once dirname(__FILE__) .'/skipif.inc';
 DOMDocument::validate();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method DOMDocument::validate() cannot be called statically' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method DOMDocument::validate() cannot be called statically' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/dom/tests/dom003.phpt
+++ b/ext/dom/tests/dom003.phpt
@@ -28,13 +28,13 @@ $rootNode->appendChild($rootNode);
 object(DOMException)#%d (%d) {
   ["message":protected]=>
   string(23) "Hierarchy Request Error"
-  ["string":"BaseException":private]=>
+  ["string":"Throwable":private]=>
   string(0) ""
   ["file":protected]=>
   string(%d) "%sdom003.php"
   ["line":protected]=>
   int(8)
-  ["trace":"BaseException":private]=>
+  ["trace":"Throwable":private]=>
   array(1) {
     [0]=>
     array(6) {
@@ -55,7 +55,7 @@ object(DOMException)#%d (%d) {
       }
     }
   }
-  ["previous":"BaseException":private]=>
+  ["previous":"Throwable":private]=>
   NULL
   ["code"]=>
   int(3)

--- a/ext/dom/tests/dom_set_attr_node.phpt
+++ b/ext/dom/tests/dom_set_attr_node.phpt
@@ -40,13 +40,13 @@ ob_start();
 object(DOMException)#%d (7) {
   ["message":protected]=>
   string(20) "Wrong Document Error"
-  ["string":"BaseException":private]=>
+  ["string":"Throwable":private]=>
   string(0) ""
   ["file":protected]=>
   string(%d) "%sdom_set_attr_node.php"
   ["line":protected]=>
   int(%d)
-  ["trace":"BaseException":private]=>
+  ["trace":"Throwable":private]=>
   array(1) {
     [0]=>
     array(6) {
@@ -67,7 +67,7 @@ object(DOMException)#%d (7) {
       }
     }
   }
-  ["previous":"BaseException":private]=>
+  ["previous":"Throwable":private]=>
   NULL
   ["code"]=>
   int(4)

--- a/ext/dom/tests/regsiter_node_class.phpt
+++ b/ext/dom/tests/regsiter_node_class.phpt
@@ -37,7 +37,7 @@ myAttribute
 HELLO Attribute
 DOMAttr
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method DOMAttr::testit()' in %s:25
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method DOMAttr::testit()' in %s:25
 Stack trace:
 #0 {main}
   thrown in %s on line 25

--- a/ext/fileinfo/tests/bug61173.phpt
+++ b/ext/fileinfo/tests/bug61173.phpt
@@ -10,7 +10,7 @@ if (!class_exists('finfo'))
 try {
     $finfo = new finfo(1, '', false);
     var_dump($finfo);
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 --EXPECTF--

--- a/ext/fileinfo/tests/finfo_open_error.phpt
+++ b/ext/fileinfo/tests/finfo_open_error.phpt
@@ -22,7 +22,7 @@ var_dump( finfo_open( 'foobar' ) );
 
 try {
     var_dump( new finfo('foobar') );
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 

--- a/ext/intl/tests/badargs.phpt
+++ b/ext/intl/tests/badargs.phpt
@@ -18,7 +18,7 @@ foreach($funcs as $func) {
 			$res = $func($arg);
 		} catch (Exception $e) {
 			continue;
-		} catch (EngineException $e) {
+		} catch (EngineError $e) {
 			continue;
 		}
         if($res != false) {

--- a/ext/intl/tests/breakiter___construct.phpt
+++ b/ext/intl/tests/breakiter___construct.phpt
@@ -11,7 +11,7 @@ ini_set("intl.error_level", E_WARNING);
 new IntlBreakIterator();
 --EXPECTF--
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private IntlBreakIterator::__construct() from invalid context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private IntlBreakIterator::__construct() from invalid context' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/intl/tests/breakiter___construct_error.phpt
+++ b/ext/intl/tests/breakiter___construct_error.phpt
@@ -19,17 +19,17 @@ try {
 }
 try {
 	var_dump(new IntlRuleBasedBreakIterator());
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 }
 try {
 	var_dump(new IntlRuleBasedBreakIterator(1,2,3));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 }
 try {
 	var_dump(new IntlRuleBasedBreakIterator('[\p{Letter}\uFFFD]+;[:number:]+;', array()));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 }
 try {

--- a/ext/intl/tests/calendar_before_after_error.phpt
+++ b/ext/intl/tests/calendar_before_after_error.phpt
@@ -19,45 +19,45 @@ set_error_handler('eh');
 
 try {
 	var_dump($c->after());
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump($c->before());
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 
 try {
 	var_dump($c->after(1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump($c->before(1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 
 try{
 	var_dump($c->after($c, 1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump($c->before($c, 1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 
 try {
 	var_dump(intlcal_after($c));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_before($c));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 --EXPECT--

--- a/ext/intl/tests/calendar_equals_error.phpt
+++ b/ext/intl/tests/calendar_equals_error.phpt
@@ -19,29 +19,29 @@ set_error_handler('eh');
 
 try {
 	var_dump($c->equals());
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump($c->equals(new stdclass));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump($c->equals(1, 2));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 
 
 try {
 	var_dump(intlcal_equals($c, array()));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_equals(1, $c));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 

--- a/ext/intl/tests/calendar_get_Least_Greatest_Minimum_Maximum_error.phpt
+++ b/ext/intl/tests/calendar_get_Least_Greatest_Minimum_Maximum_error.phpt
@@ -34,22 +34,22 @@ set_error_handler('eh');
 
 try {
 	var_dump(intlcal_get_least_maximum(1, 1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_maximum(1, 1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_greatest_minimum(1, -1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_minimum(1, -1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 

--- a/ext/intl/tests/calendar_get_getActualMaximum_Minumum_error2.phpt
+++ b/ext/intl/tests/calendar_get_getActualMaximum_Minumum_error2.phpt
@@ -19,65 +19,65 @@ set_error_handler('eh');
 
 try {
 	var_dump(intlcal_get($c));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_actual_maximum($c));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_actual_minimum($c));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 
 try {
 	var_dump(intlcal_get($c, -1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_actual_maximum($c, -1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_actual_minimum($c, -1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 
 try {
 	var_dump(intlcal_get($c, "s"));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_actual_maximum($c, "s"));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_actual_minimum($c, "s"));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 
 try {
 	var_dump(intlcal_get(1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_actual_maximum(1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_get_actual_minimum(1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 --EXPECT--

--- a/ext/intl/tests/calendar_isEquivalentTo_error.phpt
+++ b/ext/intl/tests/calendar_isEquivalentTo_error.phpt
@@ -19,33 +19,33 @@ set_error_handler('eh');
 
 try {
 	var_dump($c->isEquivalentTo(0));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump($c->isEquivalentTo($c, 1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump($c->isEquivalentTo(1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 
 try {
 	var_dump(intlcal_is_equivalent_to($c));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_is_equivalent_to($c, 1));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump(intlcal_is_equivalent_to(1, $c));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 

--- a/ext/intl/tests/calendar_setTimeZone_error.phpt
+++ b/ext/intl/tests/calendar_setTimeZone_error.phpt
@@ -21,23 +21,23 @@ set_error_handler('eh');
 
 try {
 	var_dump($c->setTimeZone($gmt, 2));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try {
 	var_dump($c->setTimeZone());
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 
 try{
 	var_dump(intlcal_set_time_zone($c, 1, 2));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 try{
 	var_dump(intlcal_set_time_zone(1, $gmt));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 

--- a/ext/intl/tests/formatter_fail.phpt
+++ b/ext/intl/tests/formatter_fail.phpt
@@ -21,7 +21,7 @@ function crt($t, $l, $s) {
 		case $t == "O":
 			try {
 				return new NumberFormatter($l, $s);
-			} catch (BaseException $e) {
+			} catch (Throwable $e) {
 				print_exception($e);
 				return null;
 			}
@@ -45,7 +45,7 @@ $args = array(
 
 try {
 	$fmt = new NumberFormatter();
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 	$fmt = null;
 }
@@ -66,7 +66,7 @@ foreach($args as $arg) {
 
 ?>
 --EXPECTF--
-TypeException: NumberFormatter::__construct() expects at least 2 parameters, 0 given in %s on line %d
+TypeError: NumberFormatter::__construct() expects at least 2 parameters, 0 given in %s on line %d
 'numfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
 Warning: numfmt_create() expects at least 2 parameters, 0 given in %s on line %d
@@ -80,7 +80,7 @@ IntlException: Constructor failed in %sformatter_fail.php on line %d
 'numfmt_create: number formatter creation failed: U_UNSUPPORTED_ERROR'
 'numfmt_create: number formatter creation failed: U_UNSUPPORTED_ERROR'
 
-TypeException: NumberFormatter::__construct() expects parameter 1 to be string, array given in %s on line %d
+TypeError: NumberFormatter::__construct() expects parameter 1 to be string, array given in %s on line %d
 'numfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
 Warning: NumberFormatter::create() expects parameter 1 to be string, array given in %s on line %d

--- a/ext/intl/tests/gregoriancalendar___construct_error.phpt
+++ b/ext/intl/tests/gregoriancalendar___construct_error.phpt
@@ -22,7 +22,7 @@ try {
 }
 try {
 	var_dump(new IntlGregorianCalendar(1,2,3,4,NULL,array()));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 }
 --EXPECTF--

--- a/ext/intl/tests/msgfmt_fail.phpt
+++ b/ext/intl/tests/msgfmt_fail.phpt
@@ -22,7 +22,7 @@ function crt($t, $l, $s) {
 		case $t == "O":
 			try {
 				return new MessageFormatter($l, $s);
-			} catch (BaseException $e) {
+			} catch (Throwable $e) {
 				print_exception($e);
 				return null;
 			}
@@ -47,7 +47,7 @@ $args = array(
 
 try {
 	$fmt = new MessageFormatter();
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 	$fmt = null;
 }
@@ -58,7 +58,7 @@ $fmt = MessageFormatter::create();
 err($fmt);
 try {
 	$fmt = new MessageFormatter('en');
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 	$fmt = null;
 }
@@ -79,7 +79,7 @@ foreach($args as $arg) {
 
 ?>
 --EXPECTF--
-TypeException: MessageFormatter::__construct() expects exactly 2 parameters, 0 given in %s on line %d
+TypeError: MessageFormatter::__construct() expects exactly 2 parameters, 0 given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
 Warning: msgfmt_create() expects exactly 2 parameters, 0 given in %s on line %d
@@ -88,7 +88,7 @@ Warning: msgfmt_create() expects exactly 2 parameters, 0 given in %s on line %d
 Warning: MessageFormatter::create() expects exactly 2 parameters, 0 given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
-TypeException: MessageFormatter::__construct() expects exactly 2 parameters, 1 given in %s on line %d
+TypeError: MessageFormatter::__construct() expects exactly 2 parameters, 1 given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
 Warning: msgfmt_create() expects exactly 2 parameters, 1 given in %s on line %d
@@ -107,7 +107,7 @@ IntlException: Constructor failed in %smsgfmt_fail2.php on line %d
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 
-TypeException: MessageFormatter::__construct() expects parameter 1 to be string, array given in %s on line %d
+TypeError: MessageFormatter::__construct() expects parameter 1 to be string, array given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
 Warning: MessageFormatter::create() expects parameter 1 to be string, array given in %s on line %d

--- a/ext/intl/tests/msgfmt_fail2.phpt
+++ b/ext/intl/tests/msgfmt_fail2.phpt
@@ -22,7 +22,7 @@ function crt($t, $l, $s) {
 		case $t == "O":
 			try {
 				return new MessageFormatter($l, $s);
-			} catch (BaseException $e) {
+			} catch (Throwable $e) {
 				print_exception($e);
 				return null;
 			}
@@ -47,7 +47,7 @@ $args = array(
 
 try {
 	$fmt = new MessageFormatter();
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 	$fmt = null;
 }
@@ -58,7 +58,7 @@ $fmt = MessageFormatter::create();
 err($fmt);
 try {
 	$fmt = new MessageFormatter('en');
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 	$fmt = null;
 }
@@ -79,7 +79,7 @@ foreach($args as $arg) {
 
 ?>
 --EXPECTF--
-TypeException: MessageFormatter::__construct() expects exactly 2 parameters, 0 given in %s on line %d
+TypeError: MessageFormatter::__construct() expects exactly 2 parameters, 0 given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
 Warning: msgfmt_create() expects exactly 2 parameters, 0 given in %s on line %d
@@ -88,7 +88,7 @@ Warning: msgfmt_create() expects exactly 2 parameters, 0 given in %s on line %d
 Warning: MessageFormatter::create() expects exactly 2 parameters, 0 given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
-TypeException: MessageFormatter::__construct() expects exactly 2 parameters, 1 given in %s on line %d
+TypeError: MessageFormatter::__construct() expects exactly 2 parameters, 1 given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
 Warning: msgfmt_create() expects exactly 2 parameters, 1 given in %s on line %d
@@ -107,7 +107,7 @@ IntlException: Constructor failed in %smsgfmt_fail2.php on line %d
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 
-TypeException: MessageFormatter::__construct() expects parameter 1 to be string, array given in %s on line %d
+TypeError: MessageFormatter::__construct() expects parameter 1 to be string, array given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
 Warning: MessageFormatter::create() expects parameter 1 to be string, array given in %s on line %d

--- a/ext/intl/tests/timezone_getCanonicalID_error.phpt
+++ b/ext/intl/tests/timezone_getCanonicalID_error.phpt
@@ -29,7 +29,7 @@ bool(false)
 Warning: IntlTimeZone::getCanonicalID(): intltz_get_canonical_id: could not convert time zone id to UTF-16 in %s on line %d
 bool(false)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot pass parameter 2 by reference' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot pass parameter 2 by reference' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/intl/tests/timezone_hasSameRules_error.phpt
+++ b/ext/intl/tests/timezone_hasSameRules_error.phpt
@@ -18,14 +18,14 @@ set_error_handler("error_handler");
 $tz = IntlTimeZone::createTimeZone('Europe/Lisbon');
 try {
 	var_dump($tz->hasSameRules('foo'));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getCode(), $ex->getMessage());
 	echo "\n";
 }
 
 try {
 	var_dump(intltz_has_same_rules(null, $tz));
-} catch (EngineException $ex) {
+} catch (EngineError $ex) {
 	var_dump($ex->getCode(), $ex->getMessage());
 	echo "\n";
 }

--- a/ext/mysqli/tests/bug33491.phpt
+++ b/ext/mysqli/tests/bug33491.phpt
@@ -26,7 +26,7 @@ $DB->query_single('SELECT DATE()');
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to a member function fetch_row() on boolean' in %sbug33491.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to a member function fetch_row() on boolean' in %sbug33491.php:%d
 Stack trace:
 #0 %s(%d): DB->query_single('SELECT DATE()')
 #1 {main}

--- a/ext/mysqli/tests/bug38003.phpt
+++ b/ext/mysqli/tests/bug38003.phpt
@@ -17,7 +17,7 @@ $DB = new DB();
 echo "Done\n";
 ?>
 --EXPECTF--	
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private DB::__construct() from invalid context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private DB::__construct() from invalid context' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/mysqli/tests/mysqli_driver_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_driver_unclonable.phpt
@@ -10,7 +10,7 @@ Trying to clone mysqli_driver object
 	print "done!";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Trying to clone an uncloneable object of class mysqli_driver' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Trying to clone an uncloneable object of class mysqli_driver' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/mysqli/tests/mysqli_fetch_object.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object.phpt
@@ -101,7 +101,7 @@ require_once('skipifconnectfailure.inc');
 	try {
 		if (false !== ($obj = @mysqli_fetch_object($res, 'mysqli_fetch_object_construct', 'a')))
 			printf("[011] Should have failed\n");
-	} catch (EngineException $e) {
+	} catch (EngineError $e) {
 		handle_catchable_fatal($e->getCode(), $e->getMessage(), $e->getFile(), $e->getLine());
 	}
 

--- a/ext/mysqli/tests/mysqli_fetch_object_no_constructor.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object_no_constructor.phpt
@@ -62,7 +62,7 @@ Exception: Class mysqli_fetch_object_test does not have a constructor hence you 
 
 Fatal error with PHP (but no exception!):
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method mysqli_fetch_object_test::mysqli_fetch_object_test()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method mysqli_fetch_object_test::mysqli_fetch_object_test()' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
@@ -34,7 +34,7 @@ require_once('skipifconnectfailure.inc');
 	try {
 		if (!is_null($tmp = @$res->fetch_object($link, $link)))
 			printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
-	} catch (EngineException $e) {
+	} catch (EngineError $e) {
 		handle_catchable_fatal($e->getCode(), $e->getMessage(), $e->getFile(), $e->getLine());
 	}
 
@@ -42,7 +42,7 @@ require_once('skipifconnectfailure.inc');
 	try {
 		if (!is_null($tmp = @$res->fetch_object($link, $link, $link)))
 			printf("[006] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
-	} catch (EngineException $e) {
+	} catch (EngineError $e) {
 		handle_catchable_fatal($e->getCode(), $e->getMessage(), $e->getFile(), $e->getLine());
 	}
 
@@ -84,7 +84,7 @@ require_once('skipifconnectfailure.inc');
 			printf("[009] Object seems wrong. [%d] %s\n", $mysqli->errno, $mysqli->error);
 			var_dump($obj);
 		}
-	} catch (EngineException $e) {
+	} catch (EngineError $e) {
 		handle_catchable_fatal($e->getCode(), $e->getMessage(), $e->getFile(), $e->getLine());
 		mysqli_fetch_object($res);
 	}

--- a/ext/mysqli/tests/mysqli_result_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_result_unclonable.phpt
@@ -21,7 +21,7 @@ require_once('skipifconnectfailure.inc');
 	print "done!";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Trying to clone an uncloneable object of class mysqli_result' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Trying to clone an uncloneable object of class mysqli_result' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/mysqli/tests/mysqli_stmt_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_unclonable.phpt
@@ -22,7 +22,7 @@ require_once('skipifconnectfailure.inc');
 	print "done!";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Trying to clone an uncloneable object of class mysqli_stmt' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Trying to clone an uncloneable object of class mysqli_stmt' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/mysqli/tests/mysqli_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_unclonable.phpt
@@ -20,7 +20,7 @@ require_once('skipifconnectfailure.inc');
 	print "done!";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Trying to clone an uncloneable object of class mysqli' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Trying to clone an uncloneable object of class mysqli' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo/tests/bug47769.phpt
+++ b/ext/pdo/tests/bug47769.phpt
@@ -34,7 +34,7 @@ this is a protected method.
 this is a private method.
 foo
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected method test::isProtected() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected method test::isProtected() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo/tests/pdo_025.phpt
+++ b/ext/pdo/tests/pdo_025.phpt
@@ -110,7 +110,7 @@ object(Test)#%d (3) {
 }
 ===FAIL===
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access protected property Fail::$id' in %spdo_025.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access protected property Fail::$id' in %spdo_025.php:%d
 Stack trace:
 #0 {main}
   thrown in %spdo_025.php on line %d

--- a/ext/pdo/tests/pdo_037.phpt
+++ b/ext/pdo/tests/pdo_037.phpt
@@ -16,7 +16,7 @@ var_dump($obj->foo());
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method MyStatement::foo()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method MyStatement::foo()' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo_mysql/tests/bug_37445.phpt
+++ b/ext/pdo_mysql/tests/bug_37445.phpt
@@ -17,7 +17,7 @@ $stmt = $db->prepare("SELECT 1");
 $stmt->bindParam(':a', 'b');
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot pass parameter 2 by reference' in %sbug_37445.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot pass parameter 2 by reference' in %sbug_37445.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug_37445.php on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql___construct.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql___construct.phpt
@@ -31,7 +31,7 @@ MySQLPDOTest::skip();
 	    try {
 			if (NULL !== ($db = @new PDO()))
 				printf("[001] Too few parameters\n");
-		} catch (TypeException $ex) {
+		} catch (TypeError $ex) {
 		}
 
 		print tryandcatch(2, '$db = new PDO(chr(0));');

--- a/ext/pdo_mysql/tests/pdo_mysql___construct_options.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql___construct_options.phpt
@@ -70,7 +70,7 @@ MySQLPDOTest::skip();
 		try {
 			if (NULL !== ($db = @new PDO($dsn, $user, $pass, 'wrong type')))
 				printf("[001] Expecting NULL got %s/%s\n", gettype($db), $db);
-		} catch (TypeException $e) {
+		} catch (TypeError $e) {
 		}
 
 		if (!is_object($db = new PDO($dsn, $user, $pass, array())))

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_statement_class.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_statement_class.phpt
@@ -152,7 +152,7 @@ array(1) {
   }
 }
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot instantiate abstract class mystatement6' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot instantiate abstract class mystatement6' in %s:%d
 Stack trace:
 #0 %s(%d): PDO->query('SELECT id, labe...')
 #1 {main}

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_clear_error.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_clear_error.phpt
@@ -93,7 +93,7 @@ array(1) {
 
 Warning: PDO::prepare(): SQLSTATE[42S22]: Column not found: 1054 Unknown column 'unknown_column' in 'field list' in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to a member function execute() on boolean' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to a member function execute() on boolean' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_mixed_style.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_mixed_style.phpt
@@ -36,7 +36,7 @@ Warning: PDO::prepare(): SQLSTATE[HY093]: Invalid parameter number: mixed named 
 
 Warning: PDO::prepare(): SQLSTATE[HY093]: Invalid parameter number in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to a member function execute() on boolean' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to a member function execute() on boolean' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_errorcode.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_errorcode.phpt
@@ -56,7 +56,7 @@ Testing native PS...
 
 Warning: PDO::prepare(): SQLSTATE[42S02]: Base table or view not found: 1146 Table '%s.ihopeitdoesnotexist' doesn't exist in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to a member function execute() on boolean' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to a member function execute() on boolean' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_multiquery.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_multiquery.phpt
@@ -99,7 +99,7 @@ Native Prepared Statements...
 
 Warning: PDO::query(): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near '%SSELECT label FROM test ORDER BY id ASC LIMIT 1' at line %d in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to a member function errorInfo() on boolean' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to a member function errorInfo() on boolean' in %s:%d
 Stack trace:
 #0 %s(%d): mysql_stmt_multiquery_wrong_usage(Object(PDO))
 #1 {main}

--- a/ext/phar/tests/badparameters.phpt
+++ b/ext/phar/tests/badparameters.phpt
@@ -18,7 +18,7 @@ Phar::loadPhar(array());
 Phar::canCompress('hi');
 try {
 	$a = new Phar(array());
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print_exception($e);
 }
 try {

--- a/ext/phar/tests/bug60261.phpt
+++ b/ext/phar/tests/bug60261.phpt
@@ -8,7 +8,7 @@ Bug #60261 (phar dos null pointer)
 try {
     $nx = new Phar();
 	$nx->getLinkTarget();
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	echo $e->getMessage(), "\n";
 }
 

--- a/ext/phar/tests/cache_list/frontcontroller29.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller29.phpt
@@ -14,7 +14,7 @@ files/frontcontroller8.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function oopsie_daisy()' in phar://%sfatalerror.phps:1
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function oopsie_daisy()' in phar://%sfatalerror.phps:1
 Stack trace:
 #0 [internal function]: unknown()
 #1 %s(%d): Phar::webPhar('whatever', 'index.php', '404.php', Array)

--- a/ext/phar/tests/frontcontroller29.phpt
+++ b/ext/phar/tests/frontcontroller29.phpt
@@ -13,7 +13,7 @@ files/frontcontroller8.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function oopsie_daisy()' in phar://%sfatalerror.phps:1
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function oopsie_daisy()' in phar://%sfatalerror.phps:1
 Stack trace:
 #0 [internal function]: unknown()
 #1 %s(%d): Phar::webPhar('whatever', 'index.php', '404.php', Array)

--- a/ext/phar/tests/pharfileinfo_construct.phpt
+++ b/ext/phar/tests/pharfileinfo_construct.phpt
@@ -19,7 +19,7 @@ unlink($fname);
 
 try {
 $a = new PharFileInfo(array());
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 echo $e->getMessage() . "\n";
 }
 

--- a/ext/reflection/tests/ReflectionClass_CannotClone_basic.phpt
+++ b/ext/reflection/tests/ReflectionClass_CannotClone_basic.phpt
@@ -12,7 +12,7 @@ if (!extension_loaded('reflection)) print 'skip';
 $rc = new ReflectionClass("stdClass");
 $rc2 = clone($rc);
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Trying to clone an uncloneable object of class ReflectionClass' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Trying to clone an uncloneable object of class ReflectionClass' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/reflection/tests/ReflectionClass_getName_error1.phpt
+++ b/ext/reflection/tests/ReflectionClass_getName_error1.phpt
@@ -5,7 +5,7 @@ ReflectionClass::getName - forbid static invocation
 ReflectionClass::getName();
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method ReflectionClass::getName() cannot be called statically' in %s:2
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method ReflectionClass::getName() cannot be called statically' in %s:2
 Stack trace:
 #0 {main}
   thrown in %s on line 2

--- a/ext/reflection/tests/ReflectionClass_isCloneable_001.phpt
+++ b/ext/reflection/tests/ReflectionClass_isCloneable_001.phpt
@@ -68,7 +68,7 @@ Internal class - XMLWriter
 bool(false)
 bool(false)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Trying to clone an uncloneable object of class XMLWriter' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Trying to clone an uncloneable object of class XMLWriter' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/reflection/tests/ReflectionClass_isIterateable_001.phpt
+++ b/ext/reflection/tests/ReflectionClass_isIterateable_001.phpt
@@ -86,7 +86,7 @@ NULL
 
 Test static invocation:
 
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method ReflectionClass::isIterateable() cannot be called statically' in %s:43
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method ReflectionClass::isIterateable() cannot be called statically' in %s:43
 Stack trace:
 #0 {main}
   thrown in %s on line 43

--- a/ext/reflection/tests/ReflectionExtension_constructor_error.phpt
+++ b/ext/reflection/tests/ReflectionExtension_constructor_error.phpt
@@ -7,19 +7,19 @@ Leon Luijkx <leon@phpgg.nl>
 <?php
 try {
 	$obj = new ReflectionExtension();
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 
 try {
 	$obj = new ReflectionExtension('foo', 'bar');
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 
 try {
 	$obj = new ReflectionExtension([]);
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 

--- a/ext/reflection/tests/ReflectionFunction_construct.001.phpt
+++ b/ext/reflection/tests/ReflectionFunction_construct.001.phpt
@@ -9,7 +9,7 @@ Steve Seear <stevseea@php.net>
 try {
 	$a = new ReflectionFunction(array(1, 2, 3));
 	echo "exception not thrown.".PHP_EOL;
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 try {
@@ -19,17 +19,17 @@ try {
 }
 try {
 	$a = new ReflectionFunction();
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 try {
 	$a = new ReflectionFunction(1, 2);
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 try {
 	$a = new ReflectionFunction([]);
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 

--- a/ext/reflection/tests/ReflectionMethod_006.phpt
+++ b/ext/reflection/tests/ReflectionMethod_006.phpt
@@ -8,12 +8,12 @@ Steve Seear <stevseea@php.net>
 
 try {
 	new ReflectionMethod();
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 try {
 	new ReflectionMethod('a', 'b', 'c');
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 

--- a/ext/reflection/tests/ReflectionMethod_constructor_error2.phpt
+++ b/ext/reflection/tests/ReflectionMethod_constructor_error2.phpt
@@ -16,13 +16,13 @@ class TestClass
 try {
 	echo "Too few arguments:\n";
 	$methodInfo = new ReflectionMethod();
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 try {
 	echo "\nToo many arguments:\n";
 	$methodInfo = new ReflectionMethod("TestClass", "foo", true);
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 
@@ -45,7 +45,7 @@ try {
 try{
 	//invalid 2nd param
 	$methodInfo = new ReflectionMethod("TestClass", []);
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 

--- a/ext/reflection/tests/ReflectionMethod_invokeArgs_error2.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invokeArgs_error2.phpt
@@ -18,7 +18,7 @@ $testClassInstance = new TestClass();
 
 try {
     var_dump($foo->invokeArgs($testClassInstance, true));
-} catch (EngineException $e) {
+} catch (EngineError $e) {
     var_dump($e->getMessage());
 }
 

--- a/ext/reflection/tests/ReflectionObject_getName_error1.phpt
+++ b/ext/reflection/tests/ReflectionObject_getName_error1.phpt
@@ -5,7 +5,7 @@ ReflectionObject::getName - forbid static invocation
 ReflectionObject::getName();
 ?> 
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method ReflectionClass::getName() cannot be called statically' in %s:2
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method ReflectionClass::getName() cannot be called statically' in %s:2
 Stack trace:
 #0 {main}
   thrown in %s on line 2

--- a/ext/reflection/tests/ReflectionParameter_invalidMethodInConstructor.phpt
+++ b/ext/reflection/tests/ReflectionParameter_invalidMethodInConstructor.phpt
@@ -25,7 +25,7 @@ class C {
 try {
 	new ReflectionParameter(array ('A', 'b'));
 }
-catch(TypeException $e) {
+catch(TypeError $e) {
 	printf( "Ok - %s\n", $e->getMessage());
 }
 

--- a/ext/reflection/tests/ReflectionProperty_error.phpt
+++ b/ext/reflection/tests/ReflectionProperty_error.phpt
@@ -9,18 +9,18 @@ class C {
 
 try {
 	new ReflectionProperty();
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 try {
 	new ReflectionProperty('C::p');
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 
 try {
 	new ReflectionProperty('C', 'p', 'x');
-} catch (TypeException $re) {
+} catch (TypeError $re) {
 	echo "Ok - ".$re->getMessage().PHP_EOL;
 }
 

--- a/ext/reflection/tests/bug64007.phpt
+++ b/ext/reflection/tests/bug64007.phpt
@@ -16,7 +16,7 @@ var_dump($generator);
 --EXPECTF--
 string(%d) "Class Generator is an internal class marked as final that cannot be instantiated without invoking its constructor"
 
-Fatal error: Uncaught exception 'EngineException' with message 'The "Generator" class is reserved for internal use and cannot be manually instantiated' in %sbug64007.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'The "Generator" class is reserved for internal use and cannot be manually instantiated' in %sbug64007.php:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->newInstance()
 #1 {main}

--- a/ext/session/tests/bug60634_error_1.phpt
+++ b/ext/session/tests/bug60634_error_1.phpt
@@ -45,7 +45,7 @@ echo "um, hi\n";
 --EXPECTF--
 write: goodbye cruel world
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function undefined_function()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function undefined_function()' in %s:%d
 Stack trace:
 #0 [internal function]: write(%s, '')
 #1 %s(%d): session_write_close()

--- a/ext/session/tests/bug60634_error_3.phpt
+++ b/ext/session/tests/bug60634_error_3.phpt
@@ -43,7 +43,7 @@ session_start();
 --EXPECTF--
 write: goodbye cruel world
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function undefined_function()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function undefined_function()' in %s:%d
 Stack trace:
 #0 [internal function]: write(%s, '')
 #1 {main}

--- a/ext/session/tests/bug60634_error_5.phpt
+++ b/ext/session/tests/bug60634_error_5.phpt
@@ -44,7 +44,7 @@ echo "um, hi\n";
 --EXPECTF--
 close: goodbye cruel world
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined function undefined_function()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined function undefined_function()' in %s:%d
 Stack trace:
 #0 [internal function]: close()
 #1 %s(%d): session_write_close()

--- a/ext/simplexml/tests/SimpleXMLElement_xpath.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_xpath.phpt
@@ -11,7 +11,7 @@ Notice: Undefined variable: x in %s on line %d
 
 Warning: simplexml_load_string() expects parameter 3 to be integer, float given in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to a member function xpath() on null' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to a member function xpath() on null' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/simplexml/tests/bug37565.phpt
+++ b/ext/simplexml/tests/bug37565.phpt
@@ -17,13 +17,13 @@ class Setting extends ReflectionObject
 
 try {
 	Reflection::export(simplexml_load_string('<test/>', 'Setting'));
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	my_error_handler($e->getCode(), $e->getMessage(), $e->getFile(), $e->getLine());
 }
 
 try {
 	Reflection::export(simplexml_load_file('data:,<test/>', 'Setting'));
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	my_error_handler($e->getCode(), $e->getMessage(), $e->getFile(), $e->getLine());
 }
 

--- a/ext/snmp/tests/snmp-object-error.phpt
+++ b/ext/snmp/tests/snmp-object-error.phpt
@@ -16,17 +16,17 @@ snmp_set_valueretrieval(SNMP_VALUE_PLAIN);
 
 try {
 	var_dump(new SNMP(SNMP::VERSION_1, $hostname));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print $e->getMessage() . "\n";
 }
 try {
 	var_dump(new SNMP(SNMP::VERSION_1, $hostname, $community, ''));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print $e->getMessage() . "\n";
 }
 try {
 	var_dump(new SNMP(SNMP::VERSION_1, $hostname, $community, $timeout, ''));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	print $e->getMessage() . "\n";
 }
 try {

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -1496,10 +1496,10 @@ static void _soap_server_exception(soapServicePtr service, sdlFunctionPtr functi
 	ZVAL_OBJ(&exception_object, EG(exception));
 	if (instanceof_function(Z_OBJCE(exception_object), soap_fault_class_entry)) {
 		soap_server_fault_ex(function, &exception_object, NULL);
-	} else if (instanceof_function(Z_OBJCE(exception_object), zend_get_engine_exception())) {
+	} else if (instanceof_function(Z_OBJCE(exception_object), zend_get_engine_error())) {
 		if (service->send_errors) {
 			zval rv;
-			zend_string *msg = zval_get_string(zend_read_property(zend_exception_get_base(), &exception_object, "message", sizeof("message")-1, 0, &rv));
+			zend_string *msg = zval_get_string(zend_read_property(zend_get_throwable(), &exception_object, "message", sizeof("message")-1, 0, &rv));
 			add_soap_fault_ex(&exception_object, this_ptr, "Server", msg->val, NULL, NULL);
 			zend_string_release(msg);
 		} else {
@@ -2596,13 +2596,13 @@ static int do_request(zval *this_ptr, xmlDoc *request, char *location, char *act
 			add_soap_fault(this_ptr, "Client", "SoapClient::__doRequest() failed", NULL, NULL);
 			ret = FALSE;
 		} else if (Z_TYPE_P(response) != IS_STRING) {
-			if (EG(exception) && instanceof_function(EG(exception)->ce, zend_get_engine_exception())) {
+			if (EG(exception) && instanceof_function(EG(exception)->ce, zend_get_engine_error())) {
 				zval rv;
 				zend_string *msg;
 				zval exception_object;
 
 				ZVAL_OBJ(&exception_object, EG(exception));
-				msg = zval_get_string(zend_read_property(zend_exception_get_base(), &exception_object, "message", sizeof("message")-1, 0, &rv));
+				msg = zval_get_string(zend_read_property(zend_get_throwable(), &exception_object, "message", sizeof("message")-1, 0, &rv));
 				/* change class */
 				EG(exception)->ce = soap_fault_class_entry;
 				set_soap_fault(&exception_object, NULL, "Client", msg->val, NULL, NULL, NULL);

--- a/ext/spl/tests/CallbackFilterIteratorTest-002.phpt
+++ b/ext/spl/tests/CallbackFilterIteratorTest-002.phpt
@@ -10,25 +10,25 @@ set_error_handler(function($errno, $errstr){
 
 try {
 	new CallbackFilterIterator();
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	echo $e->getMessage() . "\n";
 }
 
 try {
 	new CallbackFilterIterator(null);
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	echo $e->getMessage() . "\n";
 }
 
 try {
 	new CallbackFilterIterator(new ArrayIterator(array()), null);
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	echo $e->getMessage() . "\n";
 }
 
 try {
 	new CallbackFilterIterator(new ArrayIterator(array()), array());
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	echo $e->getMessage() . "\n";
 }
 

--- a/ext/spl/tests/SplFixedArray__construct_param_array.phpt
+++ b/ext/spl/tests/SplFixedArray__construct_param_array.phpt
@@ -7,7 +7,7 @@ PHPNW Test Fest 2009 - Jordan Hatch
 
 try {
 	$array = new SplFixedArray( array("string", 1) );
-} catch (TypeException $iae) {
+} catch (TypeError $iae) {
 	echo "Ok - ".$iae->getMessage().PHP_EOL;
 }
 

--- a/ext/spl/tests/SplFixedArray__construct_param_string.phpt
+++ b/ext/spl/tests/SplFixedArray__construct_param_string.phpt
@@ -6,7 +6,7 @@ PHPNW Test Fest 2009 - Jordan Hatch
 <?php
 try {
 	$array = new SplFixedArray( "string" );
-} catch (TypeException $iae) {
+} catch (TypeError $iae) {
 	echo "Ok - ".$iae->getMessage().PHP_EOL;
 }
 

--- a/ext/spl/tests/SplFixedArray_construct_param_SplFixedArray.phpt
+++ b/ext/spl/tests/SplFixedArray_construct_param_SplFixedArray.phpt
@@ -6,7 +6,7 @@ Philip Norton philipnorton42@gmail.com
 <?php
 try {
 	$array = new SplFixedArray(new SplFixedArray(3));
-} catch (TypeException $iae) {
+} catch (TypeError $iae) {
 	echo "Ok - ".$iae->getMessage().PHP_EOL;
 }
 

--- a/ext/spl/tests/SplTempFileObject_constructor_error.phpt
+++ b/ext/spl/tests/SplTempFileObject_constructor_error.phpt
@@ -4,7 +4,7 @@ SPL SplTempFileObject constructor sets correct defaults when pass 0 arguments
 <?php
 try {
     new SplTempFileObject('invalid');
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 ?>

--- a/ext/spl/tests/arrayObject___construct_error1.phpt
+++ b/ext/spl/tests/arrayObject___construct_error1.phpt
@@ -7,14 +7,14 @@ $a = new stdClass;
 $a->p = 1;
 try {
   var_dump(new ArrayObject($a, 0, "Exception"));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
   echo $e->getMessage() . "(" . $e->getLine() .  ")\n";
 }
 
 echo "Non-existent class:\n";
 try {
   var_dump(new ArrayObject(new stdClass, 0, "nonExistentClassName"));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
   echo $e->getMessage() . "(" . $e->getLine() .  ")\n";
 }
 ?>

--- a/ext/spl/tests/arrayObject___construct_error2.phpt
+++ b/ext/spl/tests/arrayObject___construct_error2.phpt
@@ -13,7 +13,7 @@ Class C implements Iterator {
 
 try {
   var_dump(new ArrayObject(new stdClass, 0, "C", "extra"));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
   echo $e->getMessage() . "(" . $e->getLine() .  ")\n";
 }
 ?>

--- a/ext/spl/tests/arrayObject_setFlags_basic2.phpt
+++ b/ext/spl/tests/arrayObject_setFlags_basic2.phpt
@@ -26,7 +26,7 @@ string(6) "secret"
 string(6) "public"
 string(6) "secret"
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access private property C::$x' in %s:19
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access private property C::$x' in %s:19
 Stack trace:
 #0 {main}
   thrown in %s on line 19

--- a/ext/spl/tests/arrayObject_setIteratorClass_error1.phpt
+++ b/ext/spl/tests/arrayObject_setIteratorClass_error1.phpt
@@ -28,7 +28,7 @@ try {
   foreach($ao as $key=>$value) {
     echo "  $key=>$value\n";
   }
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	var_dump($e->getMessage());
 }
 
@@ -37,7 +37,7 @@ try {
   foreach($ao as $key=>$value) {
     echo "  $key=>$value\n";
   }
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	var_dump($e->getMessage());
 }
 

--- a/ext/spl/tests/bug48023.phpt
+++ b/ext/spl/tests/bug48023.phpt
@@ -9,7 +9,7 @@ new Foo;
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'Foo' not found' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'Foo' not found' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/spl/tests/bug49972.phpt
+++ b/ext/spl/tests/bug49972.phpt
@@ -8,7 +8,7 @@ $iterator->undefined();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to undefined method AppendIterator::undefined()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to undefined method AppendIterator::undefined()' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/spl/tests/bug54292.phpt
+++ b/ext/spl/tests/bug54292.phpt
@@ -5,7 +5,7 @@ Bug #54292 (Wrong parameter causes crash in SplFileObject::__construct())
 
 try {
 	new SplFileObject('foo', array());
-} catch (TypeException $e) {
+} catch (TypeError $e) {
 	var_dump($e->getMessage());
 }
 

--- a/ext/spl/tests/fixedarray_005.phpt
+++ b/ext/spl/tests/fixedarray_005.phpt
@@ -5,19 +5,19 @@ SPL: FixedArray: Invalid arguments
 
 try {
 	$a = new SplFixedArray(new stdClass);
-} catch (TypeException $iae) {
+} catch (TypeError $iae) {
 	echo "Ok - ".$iae->getMessage().PHP_EOL;
 }
 
 try {
 	$a = new SplFixedArray('FOO');
-} catch (TypeException $iae) {
+} catch (TypeError $iae) {
 	echo "Ok - ".$iae->getMessage().PHP_EOL;
 }
 
 try {
 	$a = new SplFixedArray('');
-} catch (TypeException $iae) {
+} catch (TypeError $iae) {
 	echo "Ok - ".$iae->getMessage().PHP_EOL;
 }
 

--- a/ext/spl/tests/fixedarray_009.phpt
+++ b/ext/spl/tests/fixedarray_009.phpt
@@ -5,7 +5,7 @@ SPL: FixedArray: Trying to instantiate passing string to construtor parameter
 
 try {
 	$a = new SplFixedArray('FOO');
-} catch (TypeException $iae) {
+} catch (TypeError $iae) {
 	echo "Ok - ".$iae->getMessage().PHP_EOL;
 }
 ?>

--- a/ext/spl/tests/fixedarray_015.phpt
+++ b/ext/spl/tests/fixedarray_015.phpt
@@ -5,7 +5,7 @@ SPL: FixedArray: accessing uninitialized array
 
 try {
 	$a = new SplFixedArray('');
-} catch (TypeException $iae) {
+} catch (TypeError $iae) {
 	echo "Ok - ".$iae->getMessage().PHP_EOL;
 }
 

--- a/ext/spl/tests/iterator_035.phpt
+++ b/ext/spl/tests/iterator_035.phpt
@@ -14,7 +14,7 @@ echo "Done\n";
 --EXPECTF--	
 Notice: Indirect modification of overloaded element of ArrayIterator has no effect in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot assign by reference to overloaded object' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot assign by reference to overloaded object' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/spl/tests/iterator_042.phpt
+++ b/ext/spl/tests/iterator_042.phpt
@@ -15,7 +15,7 @@ $it = new AppendIterator;
 
 try {
 	$it->append(array());
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	test_error_handler($e->getCode(), $e->getMessage(), $e->getFile(), $e->getLine());
 }
 $it->append(new ArrayIterator(array(1)));

--- a/ext/spl/tests/iterator_056.phpt
+++ b/ext/spl/tests/iterator_056.phpt
@@ -21,36 +21,36 @@ class myNoRewindIterator extends NoRewindIterator  {}
 
 try {
 	$it = new myFilterIterator();	
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 
 try {
 	$it = new myCachingIterator();	
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 
 try {
 	$it = new myRecursiveCachingIterator();	
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 
 try {
 	$it = new myParentIterator();	
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 
 try {
 	$it = new myLimitIterator();
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 try {
 	$it = new myNoRewindIterator();
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 

--- a/ext/spl/tests/recursive_tree_iterator_003.phpt
+++ b/ext/spl/tests/recursive_tree_iterator_003.phpt
@@ -4,7 +4,7 @@ SPL: RecursiveTreeIterator(non-traversable)
 <?php
 try {
 	new RecursiveTreeIterator(new ArrayIterator(array()));
-} catch (TypeException $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 ?>

--- a/ext/spl/tests/spl_004.phpt
+++ b/ext/spl/tests/spl_004.phpt
@@ -44,7 +44,7 @@ var_dump(iterator_apply($it, 'test'));
 echo "===ERRORS===\n";
 try {
 	var_dump(iterator_apply($it, 'test', 1));
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	my_error_handler($e->getCode(), $e->getMessage(), $e->getFile(), $e->getLine());
 }
 var_dump(iterator_apply($it, 'non_existing_function'));

--- a/ext/spl/tests/spl_iterator_iterator_constructor.phpt
+++ b/ext/spl/tests/spl_iterator_iterator_constructor.phpt
@@ -15,7 +15,7 @@ try {
     $test = new IteratorIterator($arrayIterator, 1, 1);
     $test = new IteratorIterator($arrayIterator, 1, 1, 1);
     $test = new IteratorIterator($arrayIterator, 1, 1, 1, 1);
-} catch (TypeException $e){
+} catch (TypeError $e){
   echo $e->getMessage() . "\n";
 }
 

--- a/ext/spl/tests/spl_iterator_recursive_getiterator_error.phpt
+++ b/ext/spl/tests/spl_iterator_recursive_getiterator_error.phpt
@@ -13,7 +13,7 @@ function p ($i) {
 }
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'An iterator cannot be used with foreach by reference' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'An iterator cannot be used with foreach by reference' in %s:%d
 Stack trace:
 #0 %s(%d): p(Object(IteratorIterator))
 #1 {main}

--- a/ext/sqlite3/tests/sqlite3_02_open.phpt
+++ b/ext/sqlite3/tests/sqlite3_02_open.phpt
@@ -10,7 +10,7 @@ Felix De Vliegher
 
 try {
   $db = new SQLite3();
-} catch (TypeException $e) {
+} catch (TypeError $e) {
   var_dump($e->getMessage());
 }
 

--- a/ext/standard/tests/array/arsort_object1.phpt
+++ b/ext/standard/tests/array/arsort_object1.phpt
@@ -87,7 +87,7 @@ echo "Done\n";
 --EXPECTF--
 *** Testing arsort() : object functionality ***
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'for_integer_asort' not found' in %sarsort_object1.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'for_integer_asort' not found' in %sarsort_object1.php:%d
 Stack trace:
 #0 {main}
   thrown in %sarsort_object1.php on line %d

--- a/ext/standard/tests/array/arsort_object2.phpt
+++ b/ext/standard/tests/array/arsort_object2.phpt
@@ -91,7 +91,7 @@ echo "Done\n";
 --EXPECTF--
 *** Testing arsort() : object functionality ***
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'for_integer_asort' not found' in %sarsort_object2.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'for_integer_asort' not found' in %sarsort_object2.php:%d
 Stack trace:
 #0 {main}
   thrown in %sarsort_object2.php on line %d

--- a/ext/standard/tests/general_functions/010.phpt
+++ b/ext/standard/tests/general_functions/010.phpt
@@ -13,7 +13,7 @@ class test {
 
 try {
 	var_dump(register_shutdown_function(array("test","__call")));
-} catch (EngineException $e) {
+} catch (EngineError $e) {
 	echo "\nException: " . $e->getMessage() . "\n";
 }
 

--- a/ext/standard/tests/general_functions/bug47857.phpt
+++ b/ext/standard/tests/general_functions/bug47857.phpt
@@ -19,7 +19,7 @@ Deprecated: Non-static method foo::bar() should not be called statically in %sbu
 ok
 bool(false)
 
-Fatal error: Uncaught exception 'EngineException' with message 'Non-static method BaseException::getMessage() cannot be called statically' in %sbug47857.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Non-static method Throwable::getMessage() cannot be called statically' in %sbug47857.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug47857.php on line %d

--- a/ext/standard/tests/serialize/bug69152.phpt
+++ b/ext/standard/tests/serialize/bug69152.phpt
@@ -2,15 +2,9 @@
 Bug #69152: Type Confusion Infoleak Vulnerability in unserialize()
 --FILE--
 <?php
-$x = unserialize('O:9:"exception":1:{s:20:"'."\0".'BaseException'."\0".'trace";s:4:"ryat";}');
-echo $x;
 $x =  unserialize('O:4:"test":1:{s:27:"__PHP_Incomplete_Class_Name";R:1;}');
 $x->test();
 
 ?>
 --EXPECTF--
-exception 'Exception' in %s:%d
-Stack trace:
-#0 {main}
-
 Fatal error: main(): The script tried to execute a method or access a property of an incomplete object. Please ensure that the class definition "unknown" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide a __autoload() function to load the class definition  in %s on line %d

--- a/ext/tidy/tests/035.phpt
+++ b/ext/tidy/tests/035.phpt
@@ -9,7 +9,7 @@ tidyNode::__construct()
 new tidyNode;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private tidyNode::__construct() from invalid context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private tidyNode::__construct() from invalid context' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/tokenizer/tests/parse_errors.phpt
+++ b/ext/tokenizer/tests/parse_errors.phpt
@@ -8,7 +8,7 @@ Parse errors during token_get_all()
 function test_parse_error($code) {
     try {
         var_dump(token_get_all($code));
-    } catch (ParseException $e) {
+    } catch (ParseError $e) {
         echo $e->getMessage(), "\n";
     }
 }

--- a/ext/xmlreader/tests/bug51936.phpt
+++ b/ext/xmlreader/tests/bug51936.phpt
@@ -19,7 +19,7 @@ Done
 --EXPECTF--
 Test
 
-Fatal error: Uncaught exception 'EngineException' with message 'Trying to clone an uncloneable object of class XMLReader' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Trying to clone an uncloneable object of class XMLReader' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/sapi/cgi/tests/004.phpt
+++ b/sapi/cgi/tests/004.phpt
@@ -36,7 +36,7 @@ echo "Done\n";
 --EXPECTF--	
 string(%d) "
 <br />
-<b>Fatal error</b>:  Uncaught exception 'EngineException' with message 'Cannot access private property test::$pri' in %s004.test.php:8
+<b>Fatal error</b>:  Uncaught exception 'EngineError' with message 'Cannot access private property test::$pri' in %s004.test.php:8
 Stack trace:
 #0 {main}
   thrown in <b>%s004.test.php</b> on line <b>8</b><br />

--- a/sapi/cli/tests/005.phpt
+++ b/sapi/cli/tests/005.phpt
@@ -14,7 +14,7 @@ $php = getenv('TEST_PHP_EXECUTABLE');
 
 var_dump(`"$php" -n --rc unknown`);
 var_dump(`"$php" -n --rc stdclass`);
-var_dump(`"$php" -n --rc baseexception`);
+var_dump(`"$php" -n --rc Throwable`);
 
 echo "Done\n";
 ?>
@@ -40,7 +40,7 @@ string(183) "Class [ <internal:Core> class stdClass ] {
 }
 
 "
-string(1368) "Class [ <internal:Core> abstract class BaseException ] {
+string(1364) "Class [ <internal:Core> abstract class Throwable ] {
 
   - Constants [0] {
   }

--- a/sapi/cli/tests/008.phpt
+++ b/sapi/cli/tests/008.phpt
@@ -36,7 +36,7 @@ echo "Done\n";
 --EXPECTF--	
 string(%d) "
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access private property test::$pri' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access private property test::$pri' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/sapi/cli/tests/bug43177.phpt
+++ b/sapi/cli/tests/bug43177.phpt
@@ -13,7 +13,7 @@ php_cli_server_start(<<<'SCRIPT'
 	        case "/parse":
 	                try {
                         eval("this is a parse error");
-                    } catch (ParseException $e) {
+                    } catch (ParseError $e) {
                     }
 					echo "OK\n";
 	                break;

--- a/sapi/cli/tests/php_cli_server_015.phpt
+++ b/sapi/cli/tests/php_cli_server_015.phpt
@@ -46,7 +46,7 @@ X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8
 
 <br />
-<b>Fatal error</b>:  Uncaught exception 'EngineException' with message 'Call to undefined function non_exists_function()' in %ssyntax_error.php:%d
+<b>Fatal error</b>:  Uncaught exception 'EngineError' with message 'Call to undefined function non_exists_function()' in %ssyntax_error.php:%d
 Stack trace:
 #0 %sindex.php(%d): require()
 #1 {main}

--- a/tests/classes/abstract.phpt
+++ b/tests/classes/abstract.phpt
@@ -27,7 +27,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call to function show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot call abstract method fail::show()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot call abstract method fail::show()' in %s:%d
 Stack trace:
 #0 %s(%d): pass->error()
 #1 {main}

--- a/tests/classes/abstract_class.phpt
+++ b/tests/classes/abstract_class.phpt
@@ -26,7 +26,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call to function show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot instantiate abstract class fail' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot instantiate abstract class fail' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/abstract_inherit.phpt
+++ b/tests/classes/abstract_inherit.phpt
@@ -19,7 +19,7 @@ echo "Done\n"; // Shouldn't be displayed
 ?>
 --EXPECTF--
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot instantiate abstract class fail' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot instantiate abstract class fail' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d 

--- a/tests/classes/abstract_user_call.phpt
+++ b/tests/classes/abstract_user_call.phpt
@@ -27,7 +27,7 @@ call_user_func(array($o, 'test_base::func'));
 --EXPECTF--
 test::func()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot call abstract method test_base::func()' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot call abstract method test_base::func()' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/array_access_012.phpt
+++ b/tests/classes/array_access_012.phpt
@@ -33,7 +33,7 @@ $data['element'] = &$test;
 
 Notice: Indirect modification of overloaded element of ArrayAccessImpl has no effect in %sarray_access_012.php on line 24
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot assign by reference to overloaded object' in %sarray_access_012.php:24
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot assign by reference to overloaded object' in %sarray_access_012.php:24
 Stack trace:
 #0 {main}
   thrown in %sarray_access_012.php on line 24

--- a/tests/classes/autoload_021.phpt
+++ b/tests/classes/autoload_021.phpt
@@ -10,7 +10,7 @@ $x = new $a;
 echo "BUG\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Class '../BUG' not found' in %sautoload_021.php:6
+Fatal error: Uncaught exception 'EngineError' with message 'Class '../BUG' not found' in %sautoload_021.php:6
 Stack trace:
 #0 {main}
   thrown in %sautoload_021.php on line 6

--- a/tests/classes/bug27504.phpt
+++ b/tests/classes/bug27504.phpt
@@ -22,7 +22,7 @@ Called function foo:bar(1)
 
 Warning: call_user_func_array() expects parameter 1 to be a valid callback, cannot access private method foo::bar() in %s on line %d
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method foo::bar() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method foo::bar() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/class_abstract.phpt
+++ b/tests/classes/class_abstract.phpt
@@ -25,7 +25,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 base
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot instantiate abstract class base' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot instantiate abstract class base' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/constants_basic_001.phpt
+++ b/tests/classes/constants_basic_001.phpt
@@ -86,7 +86,7 @@ string(6) "hello2"
 
 Expecting fatal error:
 
-Fatal error: Uncaught exception 'EngineException' with message 'Undefined class constant 'c19'' in %s:53
+Fatal error: Uncaught exception 'EngineError' with message 'Undefined class constant 'c19'' in %s:53
 Stack trace:
 #0 {main}
   thrown in %s on line 53

--- a/tests/classes/ctor_visibility.phpt
+++ b/tests/classes/ctor_visibility.phpt
@@ -66,7 +66,7 @@ Test::__construct()
 TestPriv::__construct()
 DerivedPriv::__construct()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot call private TestPriv::__construct()' in %sctor_visibility.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot call private TestPriv::__construct()' in %sctor_visibility.php:%d
 Stack trace:
 #0 %s(%d): DerivedPriv->__construct()
 #1 %s(%d): DerivedPriv::f()

--- a/tests/classes/destructor_visibility_001.phpt
+++ b/tests/classes/destructor_visibility_001.phpt
@@ -21,7 +21,7 @@ unset($obj);
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private Derived::__destruct() from context ''' in %sdestructor_visibility_001.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private Derived::__destruct() from context ''' in %sdestructor_visibility_001.php:%d
 Stack trace:
 #0 {main}
   thrown in %sdestructor_visibility_001.php on line %d

--- a/tests/classes/factory_and_singleton_003.phpt
+++ b/tests/classes/factory_and_singleton_003.phpt
@@ -15,7 +15,7 @@ $obj = new test;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected test::__construct() from invalid context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected test::__construct() from invalid context' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/factory_and_singleton_004.phpt
+++ b/tests/classes/factory_and_singleton_004.phpt
@@ -15,7 +15,7 @@ $obj = new test;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private test::__construct() from invalid context' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private test::__construct() from invalid context' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/factory_and_singleton_005.phpt
+++ b/tests/classes/factory_and_singleton_005.phpt
@@ -16,7 +16,7 @@ $obj = NULL;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected test::__destruct() from context ''' in %sfactory_and_singleton_005.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected test::__destruct() from context ''' in %sfactory_and_singleton_005.php:%d
 Stack trace:
 #0 {main}
   thrown in %sfactory_and_singleton_005.php on line %d

--- a/tests/classes/factory_and_singleton_006.phpt
+++ b/tests/classes/factory_and_singleton_006.phpt
@@ -16,7 +16,7 @@ $obj = NULL;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private test::__destruct() from context ''' in %sfactory_and_singleton_006.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private test::__destruct() from context ''' in %sfactory_and_singleton_006.php:%d
 Stack trace:
 #0 {main}
   thrown in %sfactory_and_singleton_006.php on line %d

--- a/tests/classes/factory_and_singleton_007.phpt
+++ b/tests/classes/factory_and_singleton_007.phpt
@@ -17,7 +17,7 @@ $obj = NULL;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected test::__clone() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected test::__clone() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/factory_and_singleton_008.phpt
+++ b/tests/classes/factory_and_singleton_008.phpt
@@ -17,7 +17,7 @@ $obj = NULL;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private test::__clone() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private test::__clone() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/interface_instantiate.phpt
+++ b/tests/classes/interface_instantiate.phpt
@@ -13,7 +13,7 @@ $t = new if_a();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot instantiate interface if_a' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot instantiate interface if_a' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/interfaces_001.phpt
+++ b/tests/classes/interfaces_001.phpt
@@ -5,11 +5,11 @@ ZE2 interfaces
 --FILE--
 <?php
 
-interface Throwable {
+interface ThrowableInterface {
 	public function getMessage();
 }
 
-class Exception_foo implements Throwable {
+class Exception_foo implements ThrowableInterface {
 	public $foo = "foo";
 
 	public function getMessage() {

--- a/tests/classes/interfaces_002.phpt
+++ b/tests/classes/interfaces_002.phpt
@@ -5,12 +5,12 @@ ZE2 interface with an unimplemented method
 --FILE--
 <?php
 
-interface Throwable {
+interface ThrowableInterface {
 	public function getMessage();
 	public function getErrno();
 }
 
-class Exception_foo implements Throwable {
+class Exception_foo implements ThrowableInterface {
 	public $foo = "foo";
 
 	public function getMessage() {
@@ -26,4 +26,4 @@ echo "Message: " . $foo->getMessage() . "\n";
 ===DONE===
 --EXPECTF--
 
-Fatal error: Class Exception_foo contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Throwable::getErrno) in %s on line %d
+Fatal error: Class Exception_foo contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (ThrowableInterface::getErrno) in %s on line %d

--- a/tests/classes/private_001.phpt
+++ b/tests/classes/private_001.phpt
@@ -23,7 +23,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method pass::show() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method pass::show() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/private_002.phpt
+++ b/tests/classes/private_002.phpt
@@ -32,7 +32,7 @@ echo "Done\n"; // shouldn't be displayed
 Call pass::show()
 Call fail::show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
 Stack trace:
 #0 %s(%d): fail::show()
 #1 {main}

--- a/tests/classes/private_003.phpt
+++ b/tests/classes/private_003.phpt
@@ -33,7 +33,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
 Stack trace:
 #0 %s(%d): fail::not_ok()
 #1 {main}

--- a/tests/classes/private_003b.phpt
+++ b/tests/classes/private_003b.phpt
@@ -34,7 +34,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
 Stack trace:
 #0 %s(%d): fail->not_ok()
 #1 {main}

--- a/tests/classes/private_004.phpt
+++ b/tests/classes/private_004.phpt
@@ -29,7 +29,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
 Stack trace:
 #0 %s(%d): fail::do_show()
 #1 {main}

--- a/tests/classes/private_004b.phpt
+++ b/tests/classes/private_004b.phpt
@@ -32,7 +32,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
 Stack trace:
 #0 %s(%d): fail->do_show()
 #1 {main}

--- a/tests/classes/private_005.phpt
+++ b/tests/classes/private_005.phpt
@@ -29,7 +29,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
 Stack trace:
 #0 %s(%d): fail::do_show()
 #1 {main}

--- a/tests/classes/private_005b.phpt
+++ b/tests/classes/private_005b.phpt
@@ -32,7 +32,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method pass::show() from context 'fail'' in %s:%d
 Stack trace:
 #0 %s(%d): fail->do_show()
 #1 {main}

--- a/tests/classes/private_redeclare.phpt
+++ b/tests/classes/private_redeclare.phpt
@@ -35,7 +35,7 @@ test
 derived
 base
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to private method base::show() from context 'derived'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to private method base::show() from context 'derived'' in %s:%d
 Stack trace:
 #0 %s(%d): derived->test()
 #1 {main}

--- a/tests/classes/property_recreate_private.phpt
+++ b/tests/classes/property_recreate_private.phpt
@@ -78,7 +78,7 @@ object(C)#%d (1) {
 
 Unset a private property, and attempt to recreate at global scope (expecting failure):
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access private property C::$p' in %s:46
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access private property C::$p' in %s:46
 Stack trace:
 #0 {main}
   thrown in %s on line 46

--- a/tests/classes/property_recreate_protected.phpt
+++ b/tests/classes/property_recreate_protected.phpt
@@ -50,7 +50,7 @@ object(D)#%d (1) {
 
 Unset a protected property, and attempt to recreate it outside of scope (expected failure):
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access protected property %s::$p' in %s:32
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access protected property %s::$p' in %s:32
 Stack trace:
 #0 {main}
   thrown in %s on line 32

--- a/tests/classes/protected_001.phpt
+++ b/tests/classes/protected_001.phpt
@@ -23,7 +23,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call fail()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected method pass::fail() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected method pass::fail() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/protected_001b.phpt
+++ b/tests/classes/protected_001b.phpt
@@ -24,7 +24,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call fail()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected method pass::fail() from context ''' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected method pass::fail() from context ''' in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/protected_002.phpt
+++ b/tests/classes/protected_002.phpt
@@ -32,7 +32,7 @@ echo "Done\n"; // shouldn't be displayed
 Call pass::show()
 Call fail::show()
 
-Fatal error: Uncaught exception 'EngineException' with message 'Call to protected method pass::show() from context 'fail'' in %s:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Call to protected method pass::show() from context 'fail'' in %s:%d
 Stack trace:
 #0 %s(%d): fail::show()
 #1 {main}

--- a/tests/classes/static_properties_003_error1.phpt
+++ b/tests/classes/static_properties_003_error1.phpt
@@ -15,7 +15,7 @@ unset($c->y);
 
 --> Access non-visible static prop like instance prop:
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access protected property C::$y' in %s:8
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access protected property C::$y' in %s:8
 Stack trace:
 #0 {main}
   thrown in %s on line 8

--- a/tests/classes/static_properties_003_error2.phpt
+++ b/tests/classes/static_properties_003_error2.phpt
@@ -15,7 +15,7 @@ echo $c->y;
 
 --> Access non-visible static prop like instance prop:
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access protected property C::$y' in %s:8
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access protected property C::$y' in %s:8
 Stack trace:
 #0 {main}
   thrown in %s on line 8

--- a/tests/classes/static_properties_003_error3.phpt
+++ b/tests/classes/static_properties_003_error3.phpt
@@ -15,7 +15,7 @@ $c->y = 1;
 
 --> Access non-visible static prop like instance prop:
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access protected property C::$y' in %s:8
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access protected property C::$y' in %s:8
 Stack trace:
 #0 {main}
   thrown in %s on line 8

--- a/tests/classes/static_properties_003_error4.phpt
+++ b/tests/classes/static_properties_003_error4.phpt
@@ -15,11 +15,11 @@ $c->y =& $ref;
 
 --> Access non-visible static prop like instance prop:
 
-Fatal error: Uncaught exception 'EngineException' with message 'Cannot access protected property C::$y' in %s:8
+Fatal error: Uncaught exception 'EngineError' with message 'Cannot access protected property C::$y' in %s:8
 Stack trace:
 #0 {main}
 
-Next exception 'EngineException' with message 'Cannot access protected property C::$y' in %s:8
+Next exception 'EngineError' with message 'Cannot access protected property C::$y' in %s:8
 Stack trace:
 #0 {main}
   thrown in %s on line 8

--- a/tests/classes/static_properties_undeclared_assign.phpt
+++ b/tests/classes/static_properties_undeclared_assign.phpt
@@ -6,7 +6,7 @@ Class C {}
 C::$p = 1;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: C::$p' in %s:3
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: C::$p' in %s:3
 Stack trace:
 #0 {main}
   thrown in %s on line 3

--- a/tests/classes/static_properties_undeclared_assignInc.phpt
+++ b/tests/classes/static_properties_undeclared_assignInc.phpt
@@ -6,7 +6,7 @@ Class C {}
 C::$p += 1;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: C::$p' in %s:3
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: C::$p' in %s:3
 Stack trace:
 #0 {main}
   thrown in %s on line 3

--- a/tests/classes/static_properties_undeclared_assignRef.phpt
+++ b/tests/classes/static_properties_undeclared_assignRef.phpt
@@ -7,7 +7,7 @@ $a = 'foo';
 C::$p =& $a;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: C::$p' in %s:4
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: C::$p' in %s:4
 Stack trace:
 #0 {main}
   thrown in %s on line 4

--- a/tests/classes/static_properties_undeclared_inc.phpt
+++ b/tests/classes/static_properties_undeclared_inc.phpt
@@ -6,7 +6,7 @@ Class C {}
 C::$p++;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: C::$p' in %s:3
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: C::$p' in %s:3
 Stack trace:
 #0 {main}
   thrown in %s on line 3

--- a/tests/classes/static_properties_undeclared_read.phpt
+++ b/tests/classes/static_properties_undeclared_read.phpt
@@ -6,7 +6,7 @@ Class C {}
 echo C::$p;
 ?>
 --EXPECTF--
-Fatal error: Uncaught exception 'EngineException' with message 'Access to undeclared static property: C::$p' in %s:3
+Fatal error: Uncaught exception 'EngineError' with message 'Access to undeclared static property: C::$p' in %s:3
 Stack trace:
 #0 {main}
   thrown in %s on line 3

--- a/tests/classes/type_hinting_004.phpt
+++ b/tests/classes/type_hinting_004.phpt
@@ -18,32 +18,32 @@ Ensure type hints are enforced for functions invoked as callbacks.
   }
   try {
     call_user_func('f1', 1);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func('f1', new A);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func('f2', 1);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func('f2');
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func('f2', new A);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func('f2', null);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   
@@ -67,32 +67,32 @@ Ensure type hints are enforced for functions invoked as callbacks.
 
   try {
     call_user_func(array('C', 'f1'), 1);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array('C', 'f1'), new A);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array('C', 'f2'), 1);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array('C', 'f2'));
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array('C', 'f2'), new A);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array('C', 'f2'), null);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   
@@ -117,32 +117,32 @@ Ensure type hints are enforced for functions invoked as callbacks.
 
   try {
     call_user_func(array($d, 'f1'), 1);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array($d, 'f1'), new A);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array($d, 'f2'), 1);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array($d, 'f2'));
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array($d, 'f2'), new A);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   try {
     call_user_func(array($d, 'f2'), null);
-  } catch (EngineException $ex) {
+  } catch (EngineError $ex) {
     echo "{$ex->getCode()}: {$ex->getMessage()} - {$ex->getFile()}({$ex->getLine()})\n\n";
   }
   

--- a/tests/lang/041.phpt
+++ b/tests/lang/041.phpt
@@ -17,7 +17,7 @@ echo $wrongClassname::$b."\n";
 --EXPECTF--
 foo
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'B' not found' in %s041.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'B' not found' in %s041.php:%d
 Stack trace:
 #0 {main}
   thrown in %s041.php on line %d

--- a/tests/lang/042.phpt
+++ b/tests/lang/042.phpt
@@ -16,7 +16,7 @@ echo $wrongClassname::B."\n";
 --EXPECTF--
 foo
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'B' not found' in %s042.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'B' not found' in %s042.php:%d
 Stack trace:
 #0 {main}
   thrown in %s042.php on line %d

--- a/tests/lang/043.phpt
+++ b/tests/lang/043.phpt
@@ -16,7 +16,7 @@ echo $wrongClassname::foo()."\n";
 --EXPECTF--
 foo
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'B' not found' in %s043.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'B' not found' in %s043.php:%d
 Stack trace:
 #0 {main}
   thrown in %s043.php on line %d

--- a/tests/lang/044.phpt
+++ b/tests/lang/044.phpt
@@ -18,7 +18,7 @@ echo $wrongClassname::$methodname()."\n";
 --EXPECTF--
 foo
 
-Fatal error: Uncaught exception 'EngineException' with message 'Class 'B' not found' in %s044.php:%d
+Fatal error: Uncaught exception 'EngineError' with message 'Class 'B' not found' in %s044.php:%d
 Stack trace:
 #0 {main}
   thrown in %s044.php on line %d

--- a/tests/lang/catchable_error_002.phpt
+++ b/tests/lang/catchable_error_002.phpt
@@ -19,7 +19,7 @@ Catchable fatal error [2]
 
 	try {
 		blah (new StdClass);
-	} catch (engineException $ex) {
+	} catch (EngineError $ex) {
 	    echo $ex->getMessage(), "\n";
 	}
 	echo "ALIVE!\n";

--- a/tests/lang/foreachLoopIterator.002.phpt
+++ b/tests/lang/foreachLoopIterator.002.phpt
@@ -21,7 +21,7 @@ foreach ($f as $k=>&$v) {
 --EXPECTF--
 -----( Try to iterate with &$value: )-----
 
-Fatal error: Uncaught exception 'EngineException' with message 'An iterator cannot be used with foreach by reference' in %s:13
+Fatal error: Uncaught exception 'EngineError' with message 'An iterator cannot be used with foreach by reference' in %s:13
 Stack trace:
 #0 {main}
   thrown in %s on line 13


### PR DESCRIPTION
This pull request is based on the [Throwable](https://github.com/php/php-src/pull/1274) pull request by @sebastianbergmann, but it takes a slightly different approach. This is based on comments made in that pull request as well as some comments on the internals mailing list.

I'm proposing a modification to the exception hierarchy for PHP 7:

- Throwable (abstract class)
    - Exception
        - ErrorException
        - RuntimeException
        - LogicException
        - ...
    - Error *(class names up for discussion)*
        - EngineError
            - TypeError
        - ParseError

`BaseException` has been renamed to `Throwable` and a new class `Error` extending `Throwable` is used for issues that previously raised errors in PHP 5. This scheme is similar to the exception hierarchy in Java.

- `catch(Exception $e)` does not catch any previously uncaught exceptions.
- `catch(Error $e)` can be used to catch only interpreter errors.
- `catch(Throwable $e)` can catch any exception or error class.

Pros:
- Clear separation of thrown classes. `Error` is only thrown due to problems that previously raised errors.
- `Error` naming scheme chosen to avoid confusion. Example: why would `catch (Exception $e)` not catch an object named `EngineException`?

Cons:
- Objects can be thrown that do not have `Exception` in the name.
- BC: Existing `Error` classes in the global namespace would need to be renamed.

---

Edit: I would rather a distinction wasn't made between normal exceptions and errors, but unfortunately we probably should for BC. Exceptions thrown by the engine shouldn't directly extend `Exception` because they would cause BC issues, being unintentionally caught by `catch (Exception $e)`. Since this distinction must be made, I think it's better to make the distinction clearer rather than try and obfuscate it and cause confusion for users.