### PR TITLE
Make the phar symlink point to the binary directory

### DIFF
--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -39,7 +39,7 @@ install-pharcmd: pharcmd
 	-@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
 	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)
 	-@rm -f $(INSTALL_ROOT)$(bindir)/phar
-	$(LN_S) -f $(INSTALL_ROOT)$(bindir)/phar.phar $(INSTALL_ROOT)$(bindir)/phar
+	$(LN_S) -f $(bindir)/phar.phar $(INSTALL_ROOT)$(bindir)/phar
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1
 	@$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.1
 	@$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.phar.1


### PR DESCRIPTION
slackware current, php-5.6.8: spotted wrong link /usr/bin/phar.
seems an oversight present also in master.