### PR TITLE
zend_compile.c type cleanup

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -193,7 +193,8 @@ static const builtin_type_info builtin_types[] = {
 	{NULL, 0, IS_UNDEF}
 };
 
-static zend_always_inline const builtin_type_info* zend_find_builtin_type(const zend_string *name) /* {{{ */
+
+static zend_always_inline zend_uchar zend_lookup_builtin_type_by_name(const zend_string *name) /* {{{ */
 {
 	const builtin_type_info *info = &builtin_types[0];
 
@@ -201,23 +202,11 @@ static zend_always_inline const builtin_type_info* zend_find_builtin_type(const 
 		if (name->len == info->name_len
 			&& zend_binary_strcasecmp(name->val, name->len, info->name, info->name_len) == 0
 		) {
-			return info;
+			return info->type;
 		}
 	}
 
-	return NULL;
-}
-/* }}} */
-
-static zend_always_inline zend_uchar zend_lookup_builtin_type_by_name(const zend_string *const_name) /* {{{ */
-{
-	const builtin_type_info *info = zend_find_builtin_type(const_name);
-
-	if (info) {
-		return info->type;
-	} else {
-		return 0;
-	}
+	return 0;
 }
 /* }}} */
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -179,13 +179,13 @@ ZEND_API void zend_assert_valid_class_name(const zend_string *name) /* {{{ */
 }
 /* }}} */
 
-typedef struct _scalar_typehint_info {
+typedef struct _builtin_type_info {
 	const char* name;
 	const size_t name_len;
 	const zend_uchar type;
-} scalar_typehint_info;
+} builtin_type_info;
 
-static const scalar_typehint_info scalar_typehints[] = {
+static const builtin_type_info builtin_types[] = {
 	{"int", sizeof("int") - 1, IS_LONG},
 	{"float", sizeof("float") - 1, IS_DOUBLE},
 	{"string", sizeof("string") - 1, IS_STRING},
@@ -193,9 +193,9 @@ static const scalar_typehint_info scalar_typehints[] = {
 	{NULL, 0, IS_UNDEF}
 };
 
-static zend_always_inline const scalar_typehint_info* zend_find_scalar_typehint(const zend_string *name) /* {{{ */
+static zend_always_inline const builtin_type_info* zend_find_builtin_type(const zend_string *name) /* {{{ */
 {
-	const scalar_typehint_info *info = &scalar_typehints[0];
+	const builtin_type_info *info = &builtin_types[0];
 
 	for (; info->name; ++info) {
 		if (name->len == info->name_len
@@ -209,9 +209,9 @@ static zend_always_inline const scalar_typehint_info* zend_find_scalar_typehint(
 }
 /* }}} */
 
-static zend_always_inline zend_uchar zend_lookup_scalar_typehint_by_name(const zend_string *const_name) /* {{{ */
+static zend_always_inline zend_uchar zend_lookup_builtin_type_by_name(const zend_string *const_name) /* {{{ */
 {
-	const scalar_typehint_info *info = zend_find_scalar_typehint(const_name);
+	const builtin_type_info *info = zend_find_builtin_type(const_name);
 
 	if (info) {
 		return info->type;
@@ -4219,7 +4219,7 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 			arg_infos->type_hint = return_type_ast->attr;
 		} else {
 			zend_string *class_name = zend_ast_get_str(return_type_ast);
-			zend_uchar type = zend_lookup_scalar_typehint_by_name(class_name);
+			zend_uchar type = zend_lookup_builtin_type_by_name(class_name);
 
 			if (type != 0) {
 				arg_infos->type_hint = type;
@@ -4347,7 +4347,7 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 				zend_string *class_name = zend_ast_get_str(type_ast);
 				zend_uchar type;
 
-				type = zend_lookup_scalar_typehint_by_name(class_name);
+				type = zend_lookup_builtin_type_by_name(class_name);
 				if (type != 0) {
 					arg_info->type_hint = type;
 				} else {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4198,6 +4198,35 @@ ZEND_API void zend_set_function_arg_flags(zend_function *func) /* {{{ */
 }
 /* }}} */
 
+
+static void zend_compile_typename(zend_ast *ast, zend_arg_info *arg_info) /* {{{ */
+{
+	if (ast->kind == ZEND_AST_TYPE) {
+		arg_info->type_hint = ast->attr;
+	} else {
+		zend_string *class_name = zend_ast_get_str(ast);
+		zend_uchar type = zend_lookup_builtin_type_by_name(class_name);
+
+		if (type != 0) {
+			arg_info->type_hint = type;
+		} else {
+			uint32_t fetch_type = zend_get_class_fetch_type_ast(ast);
+			if (fetch_type == ZEND_FETCH_CLASS_DEFAULT) {
+				class_name = zend_resolve_class_name_ast(ast);
+				zend_assert_valid_class_name(class_name);
+			} else {
+				zend_ensure_valid_class_fetch_type(fetch_type);
+				zend_string_addref(class_name);
+			}
+
+			arg_info->type_hint = IS_OBJECT;
+			arg_info->class_name = class_name;
+		}
+	}
+}
+/* }}} */
+
+
 void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 {
 	zend_ast_list *list = zend_ast_get_list(ast);
@@ -4215,28 +4244,7 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 		arg_infos->allow_null = 0;
 		arg_infos->class_name = NULL;
 
-		if (return_type_ast->kind == ZEND_AST_TYPE) {
-			arg_infos->type_hint = return_type_ast->attr;
-		} else {
-			zend_string *class_name = zend_ast_get_str(return_type_ast);
-			zend_uchar type = zend_lookup_builtin_type_by_name(class_name);
-
-			if (type != 0) {
-				arg_infos->type_hint = type;
-			} else {
-				uint32_t fetch_type = zend_get_class_fetch_type_ast(return_type_ast);
-				if (fetch_type == ZEND_FETCH_CLASS_DEFAULT) {
-					class_name = zend_resolve_class_name_ast(return_type_ast);
-					zend_assert_valid_class_name(class_name);
-				} else {
-					zend_ensure_valid_class_fetch_type(fetch_type);
-					zend_string_addref(class_name);
-				}
-
-				arg_infos->type_hint = IS_OBJECT;
-				arg_infos->class_name = class_name;
-			}
-		}
+		zend_compile_typename(return_type_ast, arg_infos);
 
 		arg_infos++;
 		op_array->fn_flags |= ZEND_ACC_HAS_RETURN_TYPE;
@@ -4327,8 +4335,9 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 			op_array->fn_flags |= ZEND_ACC_HAS_TYPE_HINTS;
 			arg_info->allow_null = has_null_default;
 
+			zend_compile_typename(type_ast, arg_info);
+
 			if (type_ast->kind == ZEND_AST_TYPE) {
-				arg_info->type_hint = type_ast->attr;
 				if (arg_info->type_hint == IS_ARRAY) {
 					if (default_ast && !has_null_default
 						&& Z_TYPE(default_node.u.constant) != IS_ARRAY
@@ -4344,32 +4353,13 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 					}
 				}
 			} else {
-				zend_string *class_name = zend_ast_get_str(type_ast);
-				zend_uchar type;
-
-				type = zend_lookup_builtin_type_by_name(class_name);
-				if (type != 0) {
-					arg_info->type_hint = type;
-				} else {
-					uint32_t fetch_type = zend_get_class_fetch_type_ast(type_ast);
-					if (fetch_type == ZEND_FETCH_CLASS_DEFAULT) {
-						class_name = zend_resolve_class_name_ast(type_ast);
-						zend_assert_valid_class_name(class_name);
-					} else {
-						zend_ensure_valid_class_fetch_type(fetch_type);
-						zend_string_addref(class_name);
-					}
-
-					arg_info->type_hint = IS_OBJECT;
-					arg_info->class_name = class_name;
-				}
 				if (default_ast && !has_null_default && !Z_CONSTANT(default_node.u.constant)) {
 					if (arg_info->class_name) {
 						zend_error_noreturn(E_COMPILE_ERROR, "Default value for parameters "
 							"with a class type hint can only be NULL");
 					} else if (!ZEND_SAME_FAKE_TYPE(arg_info->type_hint, Z_TYPE(default_node.u.constant))) {
 						zend_error_noreturn(E_COMPILE_ERROR, "Default value for parameters "
-							"with a %s type hint can only be %s or NULL", class_name->val, class_name->val);
+							"with a %s type hint can only be %s or NULL", arg_info->class_name->val, arg_info->class_name->val);
 					}
 				}
 			}


### PR DESCRIPTION
When implementing `void` or `null` return types I noticed this possible cleanup. I don't have `Zend/` karma, so I couldn't commit it myself.