### PR TITLE
Fix Bug #67763 OPCache core dump, add checking for loaded state

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2488,6 +2488,13 @@ static int accel_startup(zend_extension *extension)
 	zend_function *func;
 	zend_ini_entry *ini_entry;
 
+	/* check loaded state here to prevent double accel_globals_ctor()
+	 * zend won't do this for zend_extension */
+	if (accel_startup_ok) {
+		zend_error(E_WARNING, ACCELERATOR_PRODUCT_NAME " already loaded");
+		return FAILURE;
+	}
+
 #ifdef ZTS
 	accel_globals_id = ts_allocate_id(&accel_globals_id, sizeof(zend_accel_globals), (ts_allocate_ctor) accel_globals_ctor, (ts_allocate_dtor) accel_globals_dtor);
 #else


### PR DESCRIPTION
Bug https://bugs.php.net/bug.php?id=67763&thanks=7

**Description**
The function `accel_globals_ctor()` in `accel_startup()` of opcache will be called twice If you run PHP with duplicated directives of `zend_extension=opcache.so`.

And this will cause opcache startup failed and segment fault when PHP exit.

**Reproduce**
```
php -d opcache.enable_cli -d zend_extension=opcache.so -d zend_extension=opcache.so -r 'time();'
```

**Log**
```
 ./php-5.6.8/sbin/php-fpm -dzend_extension=opcache.so -F

 webcore-test02v /usr/local # ./php-5.6.8/sbin/php-fpm -dzend_extension=opcache.so -F
[20-May-2015 14:32:36] NOTICE: PHP message: PHP Warning:  Module 'Zend OPcache' already loaded in Unknown on line 0
[20-May-2015 14:32:36] NOTICE: PHP message: PHP Warning:  Zend OPcache: module registration failed! in Unknown on line 0
[20-May-2015 14:32:36] NOTICE: fpm is running, pid 15497
[20-May-2015 14:32:36] NOTICE: ready to handle connections
^C[20-May-2015 14:32:37] NOTICE: Terminating ...
[20-May-2015 14:32:37] NOTICE: exiting, bye-bye!

glibc detected *** php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf): free(): invalid pointer: 0x00007fe373f633b8 ***
======= Backtrace: =========
/lib64/libc.so.6[0x3f74a76126]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)(php_module_shutdown+0x2a)[0x64ef1a]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x75efb9]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x756202]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x75fae5]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x760514]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x755efc]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x75aa5e]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x766383]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x75a6bf]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x755527]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x75d000]
/lib64/libc.so.6(__libc_start_main+0xfd)[0x3f74a1ecdd]
php-fpm: master process (/usr/local/php-5.6.8/etc/php-fpm.conf)[0x423c99]
======= Memory map: ========
00400000-00b3f000 r-xp 00000000 ca:41 5472258                            /usr/local/php-5.6.8/sbin/php-fpm
00d3f000-00ddd000 rw-p 0073f000 ca:41 5472258                            /usr/local/php-5.6.8/sbin/php-fpm
00ddd000-00dfb000 rw-p 00000000 00:00 0 
01cb2000-01f89000 rw-p 00000000 00:00 0                                  [heap]
32df200000-32df215000 r-xp 00000000 ca:41 12910992                       /lib64/libz.so.1.2.3
32df215000-32df414000 ---p 00015000 ca:41 12910992                       /lib64/libz.so.1.2.3
32df414000-32df415000 r--p 00014000 ca:41 12910992                       /lib64/libz.so.1.2.3
32df415000-32df416000 rw-p 00015000 ca:41 12910992                       /lib64/libz.so.1.2.3
32df600000-32df616000 r-xp 00000000 ca:41 12910993                       /lib64/libnsl-2.12.so
32df616000-32df815000 ---p 00016000 ca:41 12910993                       /lib64/libnsl-2.12.so
32df815000-32df816000 r--p 00015000 ca:41 12910993                       /lib64/libnsl-2.12.so
32df816000-32df817000 rw-p 00016000 ca:41 12910993                       /lib64/libnsl-2.12.so
32df817000-32df819000 rw-p 00000000 00:00 0 
33ace00000-33acf48000 r-xp 00000000 ca:41 4739600                        /usr/lib64/libxml2.so.2.7.6
33acf48000-33ad147000 ---p 00148000 ca:41 4739600                        /usr/lib64/libxml2.so.2.7.6
33ad147000-33ad151000 rw-p 00147000 ca:41 4739600                        /usr/lib64/libxml2.so.2.7.6
33ad151000-33ad152000 rw-p 00000000 00:00 0 
36a8c00000-36a8c1d000 r-xp 00000000 ca:41 12910919                       /lib64/libselinux.so.1
36a8c1d000-36a8e1c000 ---p 0001d000 ca:41 12910919                       /lib64/libselinux.so.1
36a8e1c000-36a8e1d000 r--p 0001c000 ca:41 12910919                       /lib64/libselinux.so.1
36a8e1d000-36a8e1e000 rw-p 0001d000 ca:41 12910919                       /lib64/libselinux.so.1
36a8e1e000-36a8e1f000 rw-p 00000000 00:00 0 
36a9000000-36a9003000 r-xp 00000000 ca:41 12911008                       /lib64/libcom_err.so.2.1
36a9003000-36a9202000 ---p 00003000 ca:41 12911008                       /lib64/libcom_err.so.2.1
36a9202000-36a9203000 r--p 00002000 ca:41 12911008                       /lib64/libcom_err.so.2.1
36a9203000-36a9204000 rw-p 00003000 ca:41 12911008                       /lib64/libcom_err.so.2.1
36a9400000-36a9574000 r-xp 00000000 ca:41 4739175                        /usr/lib64/libcrypto.so.1.0.0
36a9574000-36a9773000 ---p 00174000 ca:41 4739175                        /usr/lib64/libcrypto.so.1.0.0
36a9773000-36a978c000 r--p 00173000 ca:41 4739175                        /usr/lib64/libcrypto.so.1.0.0
36a978c000-36a9796000 rw-p 0018c000 ca:41 4739175                        /usr/lib64/libcrypto.so.1.0.0
36a9796000-36a979a000 rw-p 00000000 00:00 0 
36a9800000-36a9841000 r-xp 00000000 ca:41 12911010                       /lib64/libgssapi_krb5.so.2.2
36a9841000-36a9a41000 ---p 00041000 ca:41 12911010                       /lib64/libgssapi_krb5.so.2.2
36a9a41000-36a9a42000 r--p 00041000 ca:41 12911010                       /lib64/libgssapi_krb5.so.2.2
36a9a42000-36a9a44000 rw-p 00042000 ca:41 12911010                       /lib64/libgssapi_krb5.so.2.2
36a9c00000-36a9c02000 r-xp 00000000 ca:41 12910870                       /lib64/libkeyutils.so.1.3
36a9c02000-36a9e01000 ---p 00002000 ca:41 12910870                       /lib64/libkeyutils.so.1.3
36a9e01000-36a9e02000 r--p 00001000 ca:41 12910870                       /lib64/libkeyutils.so.1.3
36a9e02000-36a9e03000 rw-p 00002000 ca:41 12910870                       /lib64/libkeyutils.so.1.3
36aa000000-36aa00a000 r-xp 00000000 ca:41 12911006                       /lib64/libkrb5support.so.0.1
36aa00a000-36aa209000 ---p 0000a000 ca:41 12911006                       /lib64/libkrb5support.so.0.1
36aa209000-36aa20a000 r--p 00009000 ca:41 12911006                       /lib64/libkrb5support.so.0.1
36aa20a000-36aa20b000 rw-p 0000a000 ca:41 12911006                       /lib64/libkrb5support.so.0.1
36aa400000-36aa4db000 r-xp 00000000 ca:41 12911009                       /lib64/libkrb5.so.3.3
36aa4db000-36aa6da000 ---p 000db000 ca:41 12911009                       /lib64/libkrb5.so.3.3
36aa6da000-36aa6e4000 r--p 000da000 ca:41 12911009                       /lib64/libkrb5.so.3.3
36aa6e4000-36aa6e6000 rw-p 000e4000 ca:41 12911009                       /lib64/libkrb5.so.3.3
36aa800000-36aa829000 r-xp 00000000 ca:41 12911007                       /lib64/libk5crypto.so.3.1
36aa829000-36aaa29000 ---p 00029000 ca:41 12911007                       /lib64/libk5crypto.so.3.1
36aaa29000-36aaa2a000 r--p 00029000 ca:41 12911007                       /lib64/libk5crypto.so.3.1
36aaa2a000-36aaa2b000 rw-p 0002a000 ca:41 12911007                       /lib64/libk5crypto.so.3.1
36aaa2b000-36aaa2c000 rw-p 00000000 00:00 0 
36aac00000-36aac55000 r-xp 00000000 ca:41 4739732                        /usr/lib64/libssl.so.1.0.0
36aac55000-36aae55000 ---p 00055000 ca:41 4739732                        /usr/lib64/libssl.so.1.0.0
36aae55000-36aae58000 r--p 00055000 ca:41 4739732                        /usr/lib64/libssl.so.1.0.0
36aae58000-36aae5d000 rw-p 00058000 ca:41 4739732                        /usr/lib64/libssl.so.1.0.0
3f74600000-3f74620000 r-xp 00000000 ca:41 12910892                       /lib64/ld-2.12.so
3f7481f000-3f74820000 r--p 0001f000 ca:41 12910892                       /lib64/ld-2.12.so
3f74820000-3f74821000 rw-p 00020000 ca:41 12910892                       /lib64/ld-2.12.so
3f74821000-3f74822000 rw-p 00000000 00:00 0 
3f74a00000-3f74b8a000 r-xp 00000000 ca:41 12910718                       /lib64/libc-2.12.so
3f74b8a000-3f74d89000 ---p 0018a000 ca:41 12910718                       /lib64/libc-2.12.so
3f74d89000-3f74d8d000 r--p 00189000 ca:41 12910718                       /lib64/libc-2.12.so
3f74d8d000-3f74d8e000 rw-p 0018d000 ca:41 12910718                       /lib64/libc-2.12.so
3f74d8e000-3f74d93000 rw-p 00000000 00:00 0 
3f74e00000-3f74e02000 r-xp 00000000 ca:41 12910642                       /lib64/libdl-2.12.so
3f74e02000-3f75002000 ---p 00002000 ca:41 12910642                       /lib64/libdl-2.12.so
3f75002000-3f75003000 r--p 00002000 ca:41 12910642                       /lib64/libdl-2.12.so
3f75003000-3f75004000 rw-p 00003000 ca:41 12910642                       /lib64/libdl-2.12.so
3f75200000-3f75217000 r-xp 00000000 ca:41 12910850                       /lib64/libpthread-2.12.so
Aborted (core dumped)
```