### PR TITLE
Fix bug #69679: DOMDocument::loadHTML refuses to accept NULL bytes

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1983,7 +1983,7 @@ static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 
 	id = getThis();
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p|l", &source, &source_len, &options) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), (mode == DOM_LOAD_FILE ? "p|l" : "s|l"), &source, &source_len, &options) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/tests/bug69679.phpt
+++ b/ext/dom/tests/bug69679.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #69679 (DOMDocument::loadHTML refuses to accept NULL bytes)
+--FILE--
+<?php
+$doc = new DOMDocument();
+$html = "<!DOCTYPE html><html><head><meta charset='UTF-8'></head><body>U+0000 <span>\x0</span></body></html>";
+$doc->loadHTML($html);
+print($doc->saveHTML());
+?>
+--EXPECT--
+<!DOCTYPE html>
+<html><head><meta charset="UTF-8"></head><body>U+0000 <span></span></body></html>


### PR DESCRIPTION
Maybe the test should be reduced to not check for the saved HTML for stability?