### PR TITLE
Show "Standard input code" instead of "-" in error messages

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -2434,7 +2434,7 @@ PHPAPI int php_execute_script(zend_file_handle *primary_file)
 		 *   otherwise it will get opened and added to the included_files list in zend_execute_scripts
 		 */
  		if (primary_file->filename &&
- 		    (primary_file->filename[0] != '-' || primary_file->filename[1] != 0) &&
+ 		    strcmp("php://stdin", primary_file->filename) &&
  			primary_file->opened_path == NULL &&
  			primary_file->type != ZEND_HANDLE_FILENAME
 		) {

--- a/main/main.c
+++ b/main/main.c
@@ -2434,7 +2434,7 @@ PHPAPI int php_execute_script(zend_file_handle *primary_file)
 		 *   otherwise it will get opened and added to the included_files list in zend_execute_scripts
 		 */
  		if (primary_file->filename &&
- 		    strcmp("php://stdin", primary_file->filename) &&
+ 		    strcmp("Standard input code", primary_file->filename) &&
  			primary_file->opened_path == NULL &&
  			primary_file->type != ZEND_HANDLE_FILENAME
 		) {

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -2430,7 +2430,7 @@ consult the installation file that came with this distribution, or visit \n\
 				file_handle.filename = SG(request_info).path_translated;
 				file_handle.handle.fp = NULL;
 			} else {
-				file_handle.filename = "-";
+				file_handle.filename = "php://stdin";
 				file_handle.type = ZEND_HANDLE_FP;
 				file_handle.handle.fp = stdin;
 			}

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -2430,7 +2430,7 @@ consult the installation file that came with this distribution, or visit \n\
 				file_handle.filename = SG(request_info).path_translated;
 				file_handle.handle.fp = NULL;
 			} else {
-				file_handle.filename = "php://stdin";
+				file_handle.filename = "Standard input code";
 				file_handle.type = ZEND_HANDLE_FP;
 				file_handle.handle.fp = stdin;
 			}

--- a/sapi/cgi/tests/007.phpt
+++ b/sapi/cgi/tests/007.phpt
@@ -17,6 +17,6 @@ var_dump(`"$php" -n -s -w -l`);
 --EXPECTF--	
 string(25) "No input file specified.
 "
-string(31) "No syntax errors detected in -
+string(41) "No syntax errors detected in php://stdin
 "
 ===DONE===

--- a/sapi/cgi/tests/007.phpt
+++ b/sapi/cgi/tests/007.phpt
@@ -17,6 +17,6 @@ var_dump(`"$php" -n -s -w -l`);
 --EXPECTF--	
 string(25) "No input file specified.
 "
-string(41) "No syntax errors detected in php://stdin
+string(49) "No syntax errors detected in Standard input code
 "
 ===DONE===

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -925,7 +925,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 			/* here but this would make things only more complicated. And it */
 			/* is consitent with the way -R works where the stdin file handle*/
 			/* is also accessible. */
-			file_handle.filename = "php://stdin";
+			file_handle.filename = "Standard input code";
 			file_handle.handle.fp = stdin;
 		}
 		file_handle.type = ZEND_HANDLE_FP;
@@ -964,7 +964,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 		PG(during_request_startup) = 0;
 		switch (behavior) {
 		case PHP_MODE_STANDARD:
-			if (strcmp(file_handle.filename, "php://stdin")) {
+			if (strcmp(file_handle.filename, "Standard input code")) {
 				cli_register_file_handles();
 			}
 

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -925,7 +925,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 			/* here but this would make things only more complicated. And it */
 			/* is consitent with the way -R works where the stdin file handle*/
 			/* is also accessible. */
-			file_handle.filename = "-";
+			file_handle.filename = "php://stdin";
 			file_handle.handle.fp = stdin;
 		}
 		file_handle.type = ZEND_HANDLE_FP;
@@ -964,7 +964,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 		PG(during_request_startup) = 0;
 		switch (behavior) {
 		case PHP_MODE_STANDARD:
-			if (strcmp(file_handle.filename, "-")) {
+			if (strcmp(file_handle.filename, "php://stdin")) {
 				cli_register_file_handles();
 			}
 

--- a/sapi/cli/tests/015.phpt
+++ b/sapi/cli/tests/015.phpt
@@ -24,7 +24,7 @@ echo "Done\n";
 PHP %d.%d.%d%s(cli) (built: %s)%s
 Array
 (
-    [0] => php://stdin
+    [0] => Standard input code
     [1] => foo
     [2] => bar
     [3] => baz

--- a/sapi/cli/tests/015.phpt
+++ b/sapi/cli/tests/015.phpt
@@ -24,7 +24,7 @@ echo "Done\n";
 PHP %d.%d.%d%s(cli) (built: %s)%s
 Array
 (
-    [0] => -
+    [0] => php://stdin
     [1] => foo
     [2] => bar
     [3] => baz


### PR DESCRIPTION
Say you have broken code, like this:

``` php
<?php
declare(strict_types=1);
function add(int $a, int $b): int {
    return $a + $b;
}
add(1.0, 2.0);
```

Currently, the error message looks like this:

```
Fatal error: Uncaught TypeException: Argument 1 passed to add() must be of the type integer, float given, called in - on line 6 and defined in -:3
Stack trace:
#0 -(6): add(1, 2)
#1 {main}
  thrown in - on line 3
```

What on earth is `-`? It may not be immediately obvious to the user.

So, this makes them look like this:

```
Fatal error: Uncaught TypeException: Argument 1 passed to add() must be of the type integer, float given, called in php://stdin on line 6 and defined in php://stdin:3
Stack trace:
#0 php://stdin(6): add(1, 2)
#1 {main}
  thrown in php://stdin on line 3
```

I think `php://stdin` is a lot more obvious. It's a real URL too, [at least in PHP](http://php.net/manual/en/wrappers.php.php).
