### PR TITLE
Fix issue with password_verify exposing the underlying crypt wrapper …

### DIFF
--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -260,7 +260,7 @@ PHP_FUNCTION(password_verify)
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &password, &password_len, &hash, &hash_len) == FAILURE) {
 		RETURN_FALSE;
 	}
-	if ((ret = php_crypt(password, (int)password_len, hash, (int)hash_len)) == NULL) {
+	if ((ret = php_crypt(password, (int)password_len, hash, (int)hash_len, 1)) == NULL) {
 		RETURN_FALSE;
 	}
 
@@ -415,7 +415,7 @@ PHP_FUNCTION(password_hash)
 	/* This cast is safe, since both values are defined here in code and cannot overflow */
 	hash_len = (int) (hash_format_len + salt_len);
 
-	if ((result = php_crypt(password, (int)password_len, hash, hash_len)) == NULL) {
+	if ((result = php_crypt(password, (int)password_len, hash, hash_len, 1)) == NULL) {
 		efree(hash);
 		RETURN_FALSE;
 	}

--- a/ext/standard/php_crypt.h
+++ b/ext/standard/php_crypt.h
@@ -23,7 +23,7 @@
 #ifndef PHP_CRYPT_H
 #define PHP_CRYPT_H
 
-PHPAPI zend_string *php_crypt(const char *password, const int pass_len, const char *salt, int salt_len);
+PHPAPI zend_string *php_crypt(const char *password, const int pass_len, const char *salt, int salt_len, zend_bool quiet);
 PHP_FUNCTION(crypt);
 #if HAVE_CRYPT
 PHP_MINIT_FUNCTION(crypt);

--- a/ext/standard/tests/password/password_verify.phpt
+++ b/ext/standard/tests/password/password_verify.phpt
@@ -11,6 +11,13 @@ var_dump(password_verify("foo", '$2a$07$usesomesillystringforsalt$'));
 var_dump(password_verify('rasmusler', '$2a$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi'));
 
 var_dump(password_verify('rasmuslerdorf', '$2a$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi'));
+
+var_dump(password_verify("foo", null));
+
+var_dump(password_verify("rasmuslerdorf", "rl.3StKT.4T8M"));
+
+var_dump(password_verify("foo", "$1"));
+
 echo "OK!";
 ?>
 --EXPECT--
@@ -18,4 +25,7 @@ bool(false)
 bool(false)
 bool(false)
 bool(true)
+bool(false)
+bool(true)
+bool(false)
 OK!


### PR DESCRIPTION
…by warning when verifying DES hashes

 - By preventing the warning from being shown

Fixes #69686: https://bugs.php.net/bug.php?id=69686