### PR TITLE
Add ordering constants: CMP_LT, CMP_EQ, CMP_GT

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -2142,6 +2142,13 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 		REGISTER_MAIN_STRINGL_CONSTANT("PHP_BINARY", "", 0, CONST_PERSISTENT | CONST_CS);
 	}
 
+	/* Standard three-way comparison/ordering enumeration
+	 * Matches compare_function() (internal), strcmp(), <=> etc.
+	 */
+	REGISTER_MAIN_LONG_CONSTANT("CMP_LT", -1, CONST_PERSISTENT | CONST_CS);
+	REGISTER_MAIN_LONG_CONSTANT("CMP_EQ", 0, CONST_PERSISTENT | CONST_CS);
+	REGISTER_MAIN_LONG_CONSTANT("CMP_GT", 1, CONST_PERSISTENT | CONST_CS);
+
 	php_output_register_constants();
 	php_rfc1867_register_constants();
 

--- a/main/main.c
+++ b/main/main.c
@@ -2143,7 +2143,7 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 	}
 
 	/* Standard three-way comparison/ordering enumeration
-	 * Matches compare_function() (internal), strcmp(), <=> etc.
+	 * Matches <=>
 	 */
 	REGISTER_MAIN_LONG_CONSTANT("CMP_LT", -1, CONST_PERSISTENT | CONST_CS);
 	REGISTER_MAIN_LONG_CONSTANT("CMP_EQ", 0, CONST_PERSISTENT | CONST_CS);

--- a/tests/lang/constants/CMP.phpt
+++ b/tests/lang/constants/CMP.phpt
@@ -1,0 +1,38 @@
+--TEST--
+CMP_LT, CMP_EQ and CMP_GT ordering constants
+--FILE--
+<?php
+
+echo "Check values", PHP_EOL;
+var_dump(CMP_LT, CMP_EQ, CMP_GT);
+
+echo "Make sure they match <=> and strcmp() return values", PHP_EOL;
+var_dump((1 <=> 2) === CMP_LT);
+var_dump((1 <=> 1) === CMP_EQ);
+var_dump((2 <=> 1) === CMP_GT);
+var_dump(strcmp("a", "b") === CMP_LT);
+var_dump(strcmp("a", "a") === CMP_EQ);
+var_dump(strcmp("b", "a") === CMP_GT);
+
+echo "Make sure they're case-sensitive and lowercase variants aren't defined", PHP_EOL;
+var_dump(defined("cmp_lt"));
+var_dump(defined("cmp_eq"));
+var_dump(defined("cmp_gt"));
+
+?>
+--EXPECTF--
+Check values
+int(-1)
+int(0)
+int(1)
+Make sure they match <=> and strcmp() return values
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Make sure they're case-sensitive and lowercase variants aren't defined
+bool(false)
+bool(false)
+bool(false)

--- a/tests/lang/constants/CMP.phpt
+++ b/tests/lang/constants/CMP.phpt
@@ -6,13 +6,10 @@ CMP_LT, CMP_EQ and CMP_GT ordering constants
 echo "Check values", PHP_EOL;
 var_dump(CMP_LT, CMP_EQ, CMP_GT);
 
-echo "Make sure they match <=> and strcmp() return values", PHP_EOL;
+echo "Make sure they match <=> return values", PHP_EOL;
 var_dump((1 <=> 2) === CMP_LT);
 var_dump((1 <=> 1) === CMP_EQ);
 var_dump((2 <=> 1) === CMP_GT);
-var_dump(strcmp("a", "b") === CMP_LT);
-var_dump(strcmp("a", "a") === CMP_EQ);
-var_dump(strcmp("b", "a") === CMP_GT);
 
 echo "Make sure they're case-sensitive and lowercase variants aren't defined", PHP_EOL;
 var_dump(defined("cmp_lt"));
@@ -25,10 +22,7 @@ Check values
 int(-1)
 int(0)
 int(1)
-Make sure they match <=> and strcmp() return values
-bool(true)
-bool(true)
-bool(true)
+Make sure they match <=> return values
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
This adds three constants to PHP:

```php
const CMP_LT = -1;
const CMP_EQ = 0;
const CMP_GT = 1;
```

Why? Code readability. It means you can replace the magic numbers with more human-readable names, and prevent misunderstandings (particularly as to what `strcmp($a, $b) === 0` does).

For example:

```php
switch ($a <=> $b) {
    case CMP_LT:
        ...
    case CMP_EQ:
        ...
    case CMP_GT:
        ...
}
```

or

```php
if (CMP_EQ === strcmp($a, $b)) {
    ...
}
```