### PR TITLE
inappropriate warning log in FPM

### DIFF
--- a/sapi/fpm/fpm/fpm_children.c
+++ b/sapi/fpm/fpm/fpm_children.c
@@ -424,8 +424,10 @@ int fpm_children_make(struct fpm_worker_pool_s *wp, int in_event_loop, int nb_to
 	}
 
 	if (!warned && fpm_global_config.process_max > 0 && fpm_globals.running_children >= fpm_global_config.process_max) {
-		warned = 1;
-		zlog(ZLOG_WARNING, "The maximum number of processes has been reached. Please review your configuration and consider raising 'process.max'");
+               if (wp->running_children < max) {
+                       warned = 1;
+                       zlog(ZLOG_WARNING, "The maximum number of processes has been reached. Please review your configuration and consider raising 'process.max'");
+               }
 	}
 
 	return 1; /* we are done */


### PR DESCRIPTION
First, I don't think it is a bug, so I don't report a bug in bugs.php.net

In the log of fpm in our  production environment, I often find this log when a children process quit and master fork a new process :

```
[20-Mar-2015 15:15:52] WARNING: The maximum number of processes has been reached. Please review your configuration and consider raising 'process.max'
[20-Mar-2015 15:15:53] WARNING: The maximum number of processes has been reached. Please review your configuration and consider raising 'process.max'
[20-Mar-2015 15:16:04] WARNING: The maximum number of processes has been reached. Please review your configuration and consider raising 'process.max'
[20-Mar-2015 15:16:19] WARNING: The maximum number of processes has been reached. Please review your configuration and consider raising 'process.max'
[20-Mar-2015 15:16:37] WARNING: The maximum number of processes has been reached. Please review your configuration and consider raising 'process.max'
```

the configure of fpm is:
1 use one pool
2 pm = static
3 process.max (in global) == pm.max_children (in pool)

```
if (!warned && fpm_global_config.process_max > 0 && fpm_globals.running_children >= fpm_global_config.process_max) {
        warned = 1;
        zlog(ZLOG_WARNING, "The maximum number of processes has been reached. Please review your configuration and consider raising 'process.max'");
    }
```

I read the code of fpm, the warning log is not appropriate, so I add a limit for print the warning log 
If running_children of  a pool  reach the max , it doesn't need to  print the warning log 
More  related analysis base  Chinese is here: http://redfoxli.github.io/useless-warning-log-of-fpm.html
