### PR TITLE
Recover original meaning of SXE xpath test

### DIFF
--- a/ext/simplexml/tests/SimpleXMLElement_xpath.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_xpath.phpt
@@ -1,17 +1,15 @@
 --TEST--
 Testing xpath() with invalid XML
---SKIPIF--
-<?php PHP_INT_SIZE == 4 or die("skip - 32-bit only");
 --FILE--
 <?php
-$xml = simplexml_load_string("XXXXXXX^",$x,0x6000000000000001);
+// gracefully recover from parsing of invalid XML; not available in PHP
+const XML_PARSE_RECOVER = 1;
+
+// we're not interested in checking concrete warnings regarding invalid XML
+$xml = @simplexml_load_string("XXXXXXX^", 'SimpleXMLElement', XML_PARSE_RECOVER);
+
+// $xml is supposed to hold a SimpleXMLElement, but not FALSE/NULL
 var_dump($xml->xpath("BBBB"));
---EXPECTF--
-Notice: Undefined variable: x in %s on line %d
-
-Warning: simplexml_load_string() expects parameter 3 to be integer, float given in %s on line %d
-
-Fatal error: Uncaught EngineException: Call to a member function xpath() on null in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+?>
+--EXPECT--
+bool(false)

--- a/ext/simplexml/tests/SimpleXMLElement_xpath_1.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_xpath_1.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testing xpath() with invalid XML
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION != 5) die("skip this test is for PHP 5 only");
+if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platforms only");
+?>
+--FILE--
+<?php
+$xml = simplexml_load_string("XXXXXXX^",$x,0x6000000000000001);
+var_dump($xml->xpath("BBBB"));
+?>
+--EXPECTF--
+Notice: Undefined variable: x in %s on line %d
+
+Warning: simplexml_load_string(): Entity: line 1: parser error : Start tag expected, '<' not found in %s on line %d
+
+Warning: simplexml_load_string(): XXXXXXX^ in %s on line %d
+
+Warning: simplexml_load_string(): ^ in %s on line %d
+
+Fatal error: Call to a member function xpath() on boolean in %s on line %d

--- a/ext/simplexml/tests/SimpleXMLElement_xpath_2.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_xpath_2.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testing xpath() with invalid XML
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION != 5) die("skip this test is for PHP 5 only");
+if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platforms only");
+?>
+--FILE--
+<?php
+$xml = simplexml_load_string("XXXXXXX^",$x,0x6000000000000001);
+var_dump($xml->xpath("BBBB"));
+?>
+--EXPECTF--
+Notice: Undefined variable: x in %s on line %d
+
+Warning: simplexml_load_string(): Entity: line 1: parser error : Start tag expected, '<' not found in %s on line %d
+
+Warning: simplexml_load_string(): XXXXXXX^ in %s on line %d
+
+Warning: simplexml_load_string(): ^ in %s on line %d
+bool(false)
+

--- a/ext/simplexml/tests/SimpleXMLElement_xpath_3.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_xpath_3.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Testing xpath() with invalid XML
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) die("skip this test is for PHP 7+ only");
+if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platforms only");
+?>
+--FILE--
+<?php
+$xml = simplexml_load_string("XXXXXXX^",$x,0x6000000000000001);
+var_dump($xml->xpath("BBBB"));
+?>
+--EXPECTF--
+Notice: Undefined variable: x in %s on line %d
+
+Warning: simplexml_load_string() expects parameter 3 to be integer, float given in %s on line %d
+
+Fatal error: Uncaught EngineException: Call to a member function xpath() on null in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/simplexml/tests/SimpleXMLElement_xpath_4.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_xpath_4.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testing xpath() with invalid XML
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) die("skip this test is for PHP 7+ only");
+if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platforms only");
+?>
+--FILE--
+<?php
+$xml = simplexml_load_string("XXXXXXX^",$x,0x6000000000000001);
+var_dump($xml->xpath("BBBB"));
+?>
+--EXPECTF--
+Notice: Undefined variable: x in %s on line %d
+
+Warning: simplexml_load_string(): Entity: line 1: parser error : Start tag expected, '<' not found in %s on line %d
+
+Warning: simplexml_load_string(): XXXXXXX^ in %s on line %d
+
+Warning: simplexml_load_string(): ^ in %s on line %d
+bool(false)
+


### PR DESCRIPTION
While running the SimpleXML test suite, I've noticed that SimpleXMLElement_xpath.phpt fails for PHP 5 on 32bit systems, and is skipped for 64bit systems in master. I found that this test was [introduced to verify a bug fix](https://github.com/php/php-src/commit/345f6d90d5947c5cf380db79). Interestingly, the [PHP 5.5.26](https://github.com/php/php-src/blob/PHP-5.5.26/ext/simplexml/tests/SimpleXMLElement_xpath.phpt) and [PHP 5.6.10](https://github.com/php/php-src/blob/PHP-5.6.10/ext/simplexml/tests/SimpleXMLElement_xpath.phpt) branches still contain the original test, while the test has been [modified for master](https://github.com/php/php-src/blob/master/ext/simplexml/tests/SimpleXMLElement_xpath.phpt). However, these modifications have completely changed the meaning of the test. As it is now (in master), it doesn't check for regressions regarding the bug fix, but for general issues, such as rasing a notice regarding an undefined variable, overflow of integer literals to float, calling a method on a scalar, which are most likely covered elsewhere.

The strange thing about the original test is the usage of 0x6000000000000001 for the $options parameter of simplexml_load_string(). I have not been able to find out what both high flags (bit 63 and bit 62) are supposed to do; these are not documented for libxml, and it appears to me that they are simply ignored (perhaps @felipensp can shed some light on this issue). The low flag (bit 1), anyhow, is XML_PARSE_RECOVER, which forces the XML parser to accept even invalid XML. Using this flag is crucial here, because the test requires a SimpleXMLElement without underlying nodes (sxe->node). The actual warnings regarding invalid XML are irrelevant here, so using the @ operator is reasonable.

I've tested this patch on Windows 7 32bit (libxml 2.9.2) and Ubuntu 14.04 LTS 64bit (libxml 2.7.7, 2.7.8, 2.8.0, 2.9.1 and 2.9.2) and it works fine.

@weltling I have not been able to reproduce the failing of bug37565.phpt; not sure, why that is. The only non-passing test in the SimpleXML test suite is this one. 