### PR TITLE
Fix SEGV in crypt() configure tests

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -69,6 +69,14 @@ AC_CACHE_CHECK(for standard DES crypt, ac_cv_crypt_des,[
 #include <crypt.h>
 #endif
 
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
 int main(void)
 {
 #if HAVE_CRYPT
@@ -94,6 +102,14 @@ AC_CACHE_CHECK(for extended DES crypt, ac_cv_crypt_ext_des,[
 #include <crypt.h>
 #endif
 
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
 int main(void)
 {
 #if HAVE_CRYPT
@@ -117,6 +133,14 @@ AC_TRY_RUN([
 
 #if HAVE_CRYPT_H
 #include <crypt.h>
+#endif
+
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#ifdef HAVE_STRING_H
+#include <string.h>
 #endif
 
 int main(void)
@@ -153,6 +177,14 @@ AC_TRY_RUN([
 #include <crypt.h>
 #endif
 
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
 int main(void)
 {
 #if HAVE_CRYPT
@@ -184,6 +216,14 @@ AC_TRY_RUN([
 #include <crypt.h>
 #endif
 
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
 int main(void)
 {
 #if HAVE_CRYPT
@@ -212,6 +252,14 @@ AC_TRY_RUN([
 
 #if HAVE_CRYPT_H
 #include <crypt.h>
+#endif
+
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#ifdef HAVE_STRING_H
+#include <string.h>
 #endif
 
 int main(void)

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -80,7 +80,10 @@ AC_CACHE_CHECK(for standard DES crypt, ac_cv_crypt_des,[
 int main(void)
 {
 #if HAVE_CRYPT
-	exit(strcmp((char *)crypt("rasmuslerdorf","rl"),"rl.3StKT.4T8M"));
+	char *p = crypt("rasmuslerdorf", "rl");
+	if (!p)
+		exit(1);
+	exit(strcmp(p, "rl.3StKT.4T8M"));
 #else
 	exit(0);
 #endif
@@ -113,7 +116,10 @@ AC_CACHE_CHECK(for extended DES crypt, ac_cv_crypt_ext_des,[
 int main(void)
 {
 #if HAVE_CRYPT
-	exit(strcmp((char *)crypt("rasmuslerdorf","_J9..rasm"),"_J9..rasmBYk8r9AiWNc"));
+	char *p = crypt("rasmuslerdorf", "_J9..rasm");
+	if (!p)
+		exit(1);
+	exit(strcmp(p, "_J9..rasmBYk8r9AiWNc"));
 #else
 	exit(0);
 #endif
@@ -147,6 +153,7 @@ int main(void)
 {
 #if HAVE_CRYPT
 	char salt[15], answer[40];
+	char *p;
 
 	salt[0]='$'; salt[1]='1'; salt[2]='$';
 	salt[3]='r'; salt[4]='a'; salt[5]='s';
@@ -155,7 +162,10 @@ int main(void)
 	salt[12]='\0';
 	strcpy(answer, salt);
 	strcat(answer, "rISCgZzpwk3UhDidwXvin0");
-	exit(strcmp((char *)crypt("rasmuslerdorf",salt),answer));
+	p = crypt("rasmuslerdorf", salt);
+	if (!p)
+		exit(1);
+	exit(strcmp(p, answer));
 #else
 	exit(0);
 #endif
@@ -189,12 +199,16 @@ int main(void)
 {
 #if HAVE_CRYPT
 	char salt[30], answer[70];
+	char *p;
 
 	salt[0]='$'; salt[1]='2'; salt[2]='a'; salt[3]='$'; salt[4]='0'; salt[5]='7'; salt[6]='$'; salt[7]='\0';
 	strcat(salt, "rasmuslerd............");
 	strcpy(answer, salt);
 	strcpy(&answer[29], "nIdrcHdxcUxWomQX9j6kvERCFjTg7Ra");
-	exit(strcmp((char *)crypt("rasmuslerdorf",salt),answer));
+	p = crypt("rasmuslerdorf", salt);
+	if (!p)
+		exit(1);
+	exit(strcmp(p, answer));
 #else
 	exit(0);
 #endif
@@ -228,11 +242,15 @@ int main(void)
 {
 #if HAVE_CRYPT
 	char salt[21], answer[21+86];
+	char *p;
 
 	strcpy(salt, "\$6\$rasmuslerdorf\$");
 	strcpy(answer, salt);
 	strcat(answer, "EeHCRjm0bljalWuALHSTs1NB9ipEiLEXLhYeXdOpx22gmlmVejnVXFhd84cEKbYxCo.XuUTrW.RLraeEnsvWs/");
-	exit(strcmp((char *)crypt("rasmuslerdorf",salt),answer));
+	p = crypt("rasmuslerdorf", salt);
+	if (!p)
+		exit(1);
+	exit(strcmp(p, answer));
 #else
 	exit(0);
 #endif
@@ -266,11 +284,15 @@ int main(void)
 {
 #if HAVE_CRYPT
 	char salt[21], answer[21+43];
+	char *p;
 
 	strcpy(salt, "\$5\$rasmuslerdorf\$");
 	strcpy(answer, salt);
 	strcat(answer, "cFAm2puLCujQ9t.0CxiFIIvFi4JyQx5UncCt/xRIX23");
-	exit(strcmp((char *)crypt("rasmuslerdorf",salt),answer));
+	p = crypt("rasmuslerdorf", salt);
+	if (!p)
+		exit(1);
+	exit(strcmp(p, answer));
 #else
 	exit(0);
 #endif

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -69,9 +69,10 @@ AC_CACHE_CHECK(for standard DES crypt, ac_cv_crypt_des,[
 #include <crypt.h>
 #endif
 
-main() {
+int main(void)
+{
 #if HAVE_CRYPT
-    exit (strcmp((char *)crypt("rasmuslerdorf","rl"),"rl.3StKT.4T8M"));
+	exit(strcmp((char *)crypt("rasmuslerdorf","rl"),"rl.3StKT.4T8M"));
 #else
 	exit(0);
 #endif
@@ -93,11 +94,12 @@ AC_CACHE_CHECK(for extended DES crypt, ac_cv_crypt_ext_des,[
 #include <crypt.h>
 #endif
 
-main() {
+int main(void)
+{
 #if HAVE_CRYPT
-  exit (strcmp((char *)crypt("rasmuslerdorf","_J9..rasm"),"_J9..rasmBYk8r9AiWNc"));
+	exit(strcmp((char *)crypt("rasmuslerdorf","_J9..rasm"),"_J9..rasmBYk8r9AiWNc"));
 #else
-  exit(0);
+	exit(0);
 #endif
 }],[
   ac_cv_crypt_ext_des=yes
@@ -117,18 +119,19 @@ AC_TRY_RUN([
 #include <crypt.h>
 #endif
 
-main() {
+int main(void)
+{
 #if HAVE_CRYPT
-    char salt[15], answer[40];
+	char salt[15], answer[40];
 
-    salt[0]='$'; salt[1]='1'; salt[2]='$'; 
-    salt[3]='r'; salt[4]='a'; salt[5]='s';
-    salt[6]='m'; salt[7]='u'; salt[8]='s';
-    salt[9]='l'; salt[10]='e'; salt[11]='$';
-    salt[12]='\0';
-    strcpy(answer,salt);
-    strcat(answer,"rISCgZzpwk3UhDidwXvin0");
-    exit (strcmp((char *)crypt("rasmuslerdorf",salt),answer));
+	salt[0]='$'; salt[1]='1'; salt[2]='$';
+	salt[3]='r'; salt[4]='a'; salt[5]='s';
+	salt[6]='m'; salt[7]='u'; salt[8]='s';
+	salt[9]='l'; salt[10]='e'; salt[11]='$';
+	salt[12]='\0';
+	strcpy(answer, salt);
+	strcat(answer, "rISCgZzpwk3UhDidwXvin0");
+	exit(strcmp((char *)crypt("rasmuslerdorf",salt),answer));
 #else
 	exit(0);
 #endif
@@ -150,15 +153,16 @@ AC_TRY_RUN([
 #include <crypt.h>
 #endif
 
-main() {
+int main(void)
+{
 #if HAVE_CRYPT
-    char salt[30], answer[70];
-    
-    salt[0]='$'; salt[1]='2'; salt[2]='a'; salt[3]='$'; salt[4]='0'; salt[5]='7'; salt[6]='$'; salt[7]='\0';
-    strcat(salt,"rasmuslerd............");
-    strcpy(answer,salt);
-    strcpy(&answer[29],"nIdrcHdxcUxWomQX9j6kvERCFjTg7Ra");
-    exit (strcmp((char *)crypt("rasmuslerdorf",salt),answer));
+	char salt[30], answer[70];
+
+	salt[0]='$'; salt[1]='2'; salt[2]='a'; salt[3]='$'; salt[4]='0'; salt[5]='7'; salt[6]='$'; salt[7]='\0';
+	strcat(salt, "rasmuslerd............");
+	strcpy(answer, salt);
+	strcpy(&answer[29], "nIdrcHdxcUxWomQX9j6kvERCFjTg7Ra");
+	exit(strcmp((char *)crypt("rasmuslerdorf",salt),answer));
 #else
 	exit(0);
 #endif
@@ -180,14 +184,15 @@ AC_TRY_RUN([
 #include <crypt.h>
 #endif
 
-main() {
+int main(void)
+{
 #if HAVE_CRYPT
-    char salt[21], answer[21+86];
+	char salt[21], answer[21+86];
 
-    strcpy(salt,"\$6\$rasmuslerdorf\$");
-    strcpy(answer, salt);
-    strcat(answer, "EeHCRjm0bljalWuALHSTs1NB9ipEiLEXLhYeXdOpx22gmlmVejnVXFhd84cEKbYxCo.XuUTrW.RLraeEnsvWs/");
-    exit (strcmp((char *)crypt("rasmuslerdorf",salt),answer));
+	strcpy(salt, "\$6\$rasmuslerdorf\$");
+	strcpy(answer, salt);
+	strcat(answer, "EeHCRjm0bljalWuALHSTs1NB9ipEiLEXLhYeXdOpx22gmlmVejnVXFhd84cEKbYxCo.XuUTrW.RLraeEnsvWs/");
+	exit(strcmp((char *)crypt("rasmuslerdorf",salt),answer));
 #else
 	exit(0);
 #endif
@@ -209,15 +214,15 @@ AC_TRY_RUN([
 #include <crypt.h>
 #endif
 
-main() {
+int main(void)
+{
 #if HAVE_CRYPT
-    char salt[21], answer[21+43];
+	char salt[21], answer[21+43];
 
-    strcpy(salt,"\$5\$rasmuslerdorf\$");
-    strcpy(answer, salt);
-    strcat(answer, "cFAm2puLCujQ9t.0CxiFIIvFi4JyQx5UncCt/xRIX23");
-    exit (strcmp((char *)crypt("rasmuslerdorf",salt),answer));
-
+	strcpy(salt, "\$5\$rasmuslerdorf\$");
+	strcpy(answer, salt);
+	strcat(answer, "cFAm2puLCujQ9t.0CxiFIIvFi4JyQx5UncCt/xRIX23");
+	exit(strcmp((char *)crypt("rasmuslerdorf",salt),answer));
 #else
 	exit(0);
 #endif

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -85,7 +85,7 @@ int main(void)
 		exit(1);
 	exit(strcmp(p, "rl.3StKT.4T8M"));
 #else
-	exit(0);
+	exit(1);
 #endif
 }],[
   ac_cv_crypt_des=yes
@@ -121,7 +121,7 @@ int main(void)
 		exit(1);
 	exit(strcmp(p, "_J9..rasmBYk8r9AiWNc"));
 #else
-	exit(0);
+	exit(1);
 #endif
 }],[
   ac_cv_crypt_ext_des=yes
@@ -167,7 +167,7 @@ int main(void)
 		exit(1);
 	exit(strcmp(p, answer));
 #else
-	exit(0);
+	exit(1);
 #endif
 }],[
   ac_cv_crypt_md5=yes
@@ -210,7 +210,7 @@ int main(void)
 		exit(1);
 	exit(strcmp(p, answer));
 #else
-	exit(0);
+	exit(1);
 #endif
 }],[
   ac_cv_crypt_blowfish=yes
@@ -252,7 +252,7 @@ int main(void)
 		exit(1);
 	exit(strcmp(p, answer));
 #else
-	exit(0);
+	exit(1);
 #endif
 }],[
   ac_cv_crypt_sha512=yes
@@ -294,7 +294,7 @@ int main(void)
 		exit(1);
 	exit(strcmp(p, answer));
 #else
-	exit(0);
+	exit(1);
 #endif
 }],[
   ac_cv_crypt_sha256=yes


### PR DESCRIPTION
The crypt() configure tests can SEGV on failure. An example I see in the Linux kernel log buffer:

conftest[91314]: unhandled signal 11 at 0000000000000000 nip 00003fffafa485a4 lr 00000000100005b8 code 30001

While fixing this I took the opportunity to clean the tests up. One surprising thing I found was the tests return success if HAVE_CRYPT is not defined, which seems wrong.