### PR TITLE
Add support for bitwise string assign ops

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1047,12 +1047,60 @@ ZEND_VM_HANDLER(31, ZEND_ASSIGN_BW_OR, VAR|UNUSED|CV, CONST|TMPVAR|UNUSED|CV)
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if !defined(ZEND_VM_SPEC) || (OP1_TYPE != IS_UNUSED && OP2_TYPE != IS_UNUSED)
+		zend_free_op free_op1, free_op2;
+		zval *container = GET_OP1_ZVAL_PTR_DEREF(BP_VAR_W);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = GET_OP2_ZVAL_PTR(BP_VAR_R);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			FREE_OP1();
+			FREE_OP2();
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		ZEND_VM_DISPATCH_TO_HELPER_EX(zend_binary_assign_op_dim_helper, binary_op, bitwise_or_function);
+
+#if !defined(ZEND_VM_SPEC) || (OP2_TYPE != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		ZEND_VM_DISPATCH_TO_HELPER_EX(zend_binary_assign_op_obj_helper, binary_op, bitwise_or_function);
 	}
-#else
-	ZEND_VM_DISPATCH_TO_HELPER_EX(zend_binary_assign_op_dim_helper, binary_op, bitwise_or_function);
 #endif
 }
 
@@ -1067,12 +1115,60 @@ ZEND_VM_HANDLER(32, ZEND_ASSIGN_BW_AND, VAR|UNUSED|CV, CONST|TMPVAR|UNUSED|CV)
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if !defined(ZEND_VM_SPEC) || (OP1_TYPE != IS_UNUSED && OP2_TYPE != IS_UNUSED)
+		zend_free_op free_op1, free_op2;
+		zval *container = GET_OP1_ZVAL_PTR_DEREF(BP_VAR_W);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = GET_OP2_ZVAL_PTR(BP_VAR_R);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			FREE_OP1();
+			FREE_OP2();
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		ZEND_VM_DISPATCH_TO_HELPER_EX(zend_binary_assign_op_dim_helper, binary_op, bitwise_and_function);
+
+#if !defined(ZEND_VM_SPEC) || (OP2_TYPE != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		ZEND_VM_DISPATCH_TO_HELPER_EX(zend_binary_assign_op_obj_helper, binary_op, bitwise_and_function);
 	}
-#else
-	ZEND_VM_DISPATCH_TO_HELPER_EX(zend_binary_assign_op_dim_helper, binary_op, bitwise_and_function);
 #endif
 }
 
@@ -1087,12 +1183,60 @@ ZEND_VM_HANDLER(33, ZEND_ASSIGN_BW_XOR, VAR|UNUSED|CV, CONST|TMPVAR|UNUSED|CV)
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if !defined(ZEND_VM_SPEC) || (OP1_TYPE != IS_UNUSED && OP2_TYPE != IS_UNUSED)
+		zend_free_op free_op1, free_op2;
+		zval *container = GET_OP1_ZVAL_PTR_DEREF(BP_VAR_W);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = GET_OP2_ZVAL_PTR(BP_VAR_R);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			FREE_OP1();
+			FREE_OP2();
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		ZEND_VM_DISPATCH_TO_HELPER_EX(zend_binary_assign_op_dim_helper, binary_op, bitwise_xor_function);
+
+#if !defined(ZEND_VM_SPEC) || (OP2_TYPE != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		ZEND_VM_DISPATCH_TO_HELPER_EX(zend_binary_assign_op_obj_helper, binary_op, bitwise_xor_function);
 	}
-#else
-	ZEND_VM_DISPATCH_TO_HELPER_EX(zend_binary_assign_op_dim_helper, binary_op, bitwise_xor_function);
 #endif
 }
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -16864,12 +16864,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_VAR_CONST_HA
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && IS_CONST != IS_UNUSED)
+		zend_free_op free_op1;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = EX_CONSTANT(opline->op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_CONST(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CONST != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_CONST(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_CONST(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -16884,12 +16932,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_VAR_CONST_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && IS_CONST != IS_UNUSED)
+		zend_free_op free_op1;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = EX_CONSTANT(opline->op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_CONST(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CONST != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_CONST(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_CONST(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -16904,12 +17000,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_VAR_CONST_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && IS_CONST != IS_UNUSED)
+		zend_free_op free_op1;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = EX_CONSTANT(opline->op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_CONST(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CONST != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_CONST(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_CONST(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -18951,12 +19095,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_VAR_UNUSED_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && IS_UNUSED != IS_UNUSED)
+		zend_free_op free_op1;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = NULL;
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_UNUSED(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_UNUSED != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_UNUSED(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_UNUSED(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -18971,12 +19163,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_VAR_UNUSED_
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && IS_UNUSED != IS_UNUSED)
+		zend_free_op free_op1;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = NULL;
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_UNUSED(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_UNUSED != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_UNUSED(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_UNUSED(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -18991,12 +19231,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_VAR_UNUSED_
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && IS_UNUSED != IS_UNUSED)
+		zend_free_op free_op1;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = NULL;
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_UNUSED(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_UNUSED != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_UNUSED(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_UNUSED(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -20065,12 +20353,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_VAR_CV_HANDL
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && IS_CV != IS_UNUSED)
+		zend_free_op free_op1;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_CV(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CV != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_CV(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_CV(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -20085,12 +20421,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_VAR_CV_HAND
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && IS_CV != IS_UNUSED)
+		zend_free_op free_op1;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_CV(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CV != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_CV(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_CV(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -20105,12 +20489,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_VAR_CV_HAND
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && IS_CV != IS_UNUSED)
+		zend_free_op free_op1;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_CV(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CV != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_CV(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_CV(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -21736,12 +22168,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_VAR_TMPVAR_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && (IS_TMP_VAR|IS_VAR) != IS_UNUSED)
+		zend_free_op free_op1, free_op2;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+			zval_ptr_dtor_nogc(free_op2);
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_TMPVAR(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || ((IS_TMP_VAR|IS_VAR) != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_TMPVAR(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_TMPVAR(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -21756,12 +22236,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_VAR_TMPVAR_
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && (IS_TMP_VAR|IS_VAR) != IS_UNUSED)
+		zend_free_op free_op1, free_op2;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+			zval_ptr_dtor_nogc(free_op2);
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_TMPVAR(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || ((IS_TMP_VAR|IS_VAR) != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_TMPVAR(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_TMPVAR(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -21776,12 +22304,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_VAR_TMPVAR_
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_VAR != IS_UNUSED && (IS_TMP_VAR|IS_VAR) != IS_UNUSED)
+		zend_free_op free_op1, free_op2;
+		zval *container = _get_zval_ptr_var_deref(opline->op1.var, execute_data, &free_op1);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+			zval_ptr_dtor_nogc(free_op1);
+			zval_ptr_dtor_nogc(free_op2);
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_VAR_TMPVAR(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || ((IS_TMP_VAR|IS_VAR) != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_VAR_TMPVAR(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_VAR_TMPVAR(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -23251,12 +23827,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_UNUSED_CONST
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && IS_CONST != IS_UNUSED)
+
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = EX_CONSTANT(opline->op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CONST(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CONST != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_CONST(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CONST(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -23271,12 +23895,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_UNUSED_CONS
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && IS_CONST != IS_UNUSED)
+
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = EX_CONSTANT(opline->op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CONST(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CONST != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_CONST(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CONST(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -23291,12 +23963,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_UNUSED_CONS
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && IS_CONST != IS_UNUSED)
+
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = EX_CONSTANT(opline->op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CONST(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CONST != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_CONST(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CONST(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -25028,12 +25748,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_UNUSED_UNUSE
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && IS_UNUSED != IS_UNUSED)
+
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = NULL;
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_UNUSED(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_UNUSED != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_UNUSED(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_UNUSED(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -25048,12 +25816,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_UNUSED_UNUS
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && IS_UNUSED != IS_UNUSED)
+
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = NULL;
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_UNUSED(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_UNUSED != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_UNUSED(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_UNUSED(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -25068,12 +25884,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_UNUSED_UNUS
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && IS_UNUSED != IS_UNUSED)
+
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = NULL;
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_UNUSED(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_UNUSED != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_UNUSED(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_UNUSED(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -25612,12 +26476,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_UNUSED_CV_HA
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && IS_CV != IS_UNUSED)
+
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CV(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CV != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_CV(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CV(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -25632,12 +26544,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_UNUSED_CV_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && IS_CV != IS_UNUSED)
+
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CV(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CV != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_CV(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CV(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -25652,12 +26612,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_UNUSED_CV_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && IS_CV != IS_UNUSED)
+
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CV(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CV != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_CV(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_CV(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -27075,12 +28083,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_UNUSED_TMPVA
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && (IS_TMP_VAR|IS_VAR) != IS_UNUSED)
+		zend_free_op free_op2;
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+			zval_ptr_dtor_nogc(free_op2);
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_TMPVAR(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || ((IS_TMP_VAR|IS_VAR) != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_TMPVAR(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_TMPVAR(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -27095,12 +28151,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_UNUSED_TMPV
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && (IS_TMP_VAR|IS_VAR) != IS_UNUSED)
+		zend_free_op free_op2;
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+			zval_ptr_dtor_nogc(free_op2);
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_TMPVAR(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || ((IS_TMP_VAR|IS_VAR) != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_TMPVAR(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_TMPVAR(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -27115,12 +28219,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_UNUSED_TMPV
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_UNUSED != IS_UNUSED && (IS_TMP_VAR|IS_VAR) != IS_UNUSED)
+		zend_free_op free_op2;
+		zval *container = NULL;
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+			zval_ptr_dtor_nogc(free_op2);
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_UNUSED_TMPVAR(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || ((IS_TMP_VAR|IS_VAR) != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_UNUSED_TMPVAR(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_UNUSED_TMPVAR(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -30829,12 +31981,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_CV_CONST_HAN
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && IS_CONST != IS_UNUSED)
+
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = EX_CONSTANT(opline->op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_CONST(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CONST != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_CONST(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_CONST(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -30849,12 +32049,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_CV_CONST_HA
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && IS_CONST != IS_UNUSED)
+
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = EX_CONSTANT(opline->op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_CONST(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CONST != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_CONST(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_CONST(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -30869,12 +32117,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_CV_CONST_HA
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && IS_CONST != IS_UNUSED)
+
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = EX_CONSTANT(opline->op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_CONST(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CONST != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_CONST(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_CONST(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -34156,12 +35452,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_CV_UNUSED_HA
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && IS_UNUSED != IS_UNUSED)
+
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = NULL;
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_UNUSED(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_UNUSED != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_UNUSED(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_UNUSED(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -34176,12 +35520,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_CV_UNUSED_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && IS_UNUSED != IS_UNUSED)
+
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = NULL;
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_UNUSED(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_UNUSED != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_UNUSED(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_UNUSED(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -34196,12 +35588,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_CV_UNUSED_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && IS_UNUSED != IS_UNUSED)
+
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = NULL;
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_UNUSED(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_UNUSED != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_UNUSED(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_UNUSED(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -36080,12 +37520,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_CV_CV_HANDLE
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && IS_CV != IS_UNUSED)
+
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_CV(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CV != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_CV(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_CV(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -36100,12 +37588,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_CV_CV_HANDL
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && IS_CV != IS_UNUSED)
+
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_CV(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CV != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_CV(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_CV(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -36120,12 +37656,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_CV_CV_HANDL
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && IS_CV != IS_UNUSED)
+
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_CV(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || (IS_CV != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_CV(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_CV(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -38745,12 +40329,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_OR_SPEC_CV_TMPVAR_HA
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && (IS_TMP_VAR|IS_VAR) != IS_UNUSED)
+		zend_free_op free_op2;
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] |= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) | lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+			zval_ptr_dtor_nogc(free_op2);
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_TMPVAR(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || ((IS_TMP_VAR|IS_VAR) != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_TMPVAR(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_TMPVAR(bitwise_or_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -38765,12 +40397,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_AND_SPEC_CV_TMPVAR_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && (IS_TMP_VAR|IS_VAR) != IS_UNUSED)
+		zend_free_op free_op2;
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] &= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) & lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+			zval_ptr_dtor_nogc(free_op2);
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_TMPVAR(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || ((IS_TMP_VAR|IS_VAR) != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_TMPVAR(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_TMPVAR(bitwise_and_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 
@@ -38785,12 +40465,60 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_BW_XOR_SPEC_CV_TMPVAR_H
 	}
 # endif
 	if (EXPECTED(opline->extended_value == ZEND_ASSIGN_DIM)) {
+#endif
+
+#if 0 || (IS_CV != IS_UNUSED && (IS_TMP_VAR|IS_VAR) != IS_UNUSED)
+		zend_free_op free_op2;
+		zval *container = _get_zval_ptr_cv_deref_BP_VAR_W(execute_data, opline->op1.var);
+		if (Z_TYPE_P(container) == IS_STRING && EXPECTED(Z_STRLEN_P(container) != 0)) {
+			zval *dim = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
+			zend_long off = zend_check_string_offset(dim, BP_VAR_W);
+
+			if (EXPECTED(off < Z_STRLEN_P(container))) {
+				zend_string *str;
+				zend_free_op free_op_data1;
+				zval *value = _get_zval_ptr((opline + 1)->op1_type, (opline + 1)->op1, execute_data, &free_op_data1, BP_VAR_R);
+				SEPARATE_STRING(container);
+
+				str = Z_STR_P(container);
+				if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
+					if (Z_STRLEN_P(value) > 0) {
+						str->val[off] ^= *Z_STRVAL_P(value);
+					}
+				} else {
+					zend_long lval;
+					char buf[2];
+					if (EXPECTED(Z_TYPE_P(value) == IS_LONG)) {
+						lval = Z_LVAL_P(value);
+					} else {
+						lval = zval_get_long(value);
+					}
+					snprintf(buf, 2, ZEND_LONG_FMT, (str->val[off] >= '0' && str->val[off] <= '9' ? str->val[off] - '0' : 0) ^ lval);
+					str->val[off] = *buf;
+				}
+
+				FREE_OP(free_op_data1);
+			} else {
+				zend_error(E_NOTICE, "Undefined offset: " ZEND_ULONG_FMT, off);
+			}
+
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), container);
+			}
+
+			zval_ptr_dtor_nogc(free_op2);
+			CHECK_EXCEPTION();
+			ZEND_VM_INC_OPCODE();
+			ZEND_VM_NEXT_OPCODE();
+		}
+#endif
+
 		return zend_binary_assign_op_dim_helper_SPEC_CV_TMPVAR(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
+
+#if 0 || ((IS_TMP_VAR|IS_VAR) != IS_UNUSED)
 	} else /* if (EXPECTED(opline->extended_value == ZEND_ASSIGN_OBJ)) */ {
 		return zend_binary_assign_op_obj_helper_SPEC_CV_TMPVAR(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 	}
-#else
-	return zend_binary_assign_op_dim_helper_SPEC_CV_TMPVAR(bitwise_xor_function ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC);
 #endif
 }
 


### PR DESCRIPTION
`$str[$off] OP= $x;` equivalent to `$str[$off] = $str[$off] OP $x;`

Fixes fatal error for |=, ^= and &= on string offsets. Other people may feel free to add support for other ops, but I don't see any real sense in it (at least as long as we require the equality above to hold).
Changing that would need a RFC, hence this PR is only strictly doing what it does on e.g. array access too.
