### PR TITLE
Fix #68476 - ext-enchant: configure does not recognise libenchant version

### DIFF
--- a/ext/enchant/config.m4
+++ b/ext/enchant/config.m4
@@ -37,6 +37,6 @@ if test "$PHP_ENCHANT" != "no"; then
 	[
 	  AC_DEFINE(HAVE_ENCHANT_BROKER_SET_PARAM,             1, [ ])
 	  AC_DEFINE(ENCHANT_VERSION_STRING,             "1.5.x", [ ])
-	], [], [ -L$ENCHANT_LIB $ENCHANT_SHARED_LIBADD])
+	], [], [ -L$ENCHANT_LIBDIR $ENCHANT_SHARED_LIBADD])
 
 fi


### PR DESCRIPTION
enchant includes two (still undocumented) functions since version 1.1.0:
* enchant_broker_set_dict_path
* enchant_broker_get_dict_path

Both of them only get activated if libenchant >= 1.5.0. Unfortunately there seems to be an error in the configure script that will fail the version detection, even if a newer libenchant version is installed.
