### PR TITLE
Enhanced array_column() to also work with object elements.

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3098,7 +3098,6 @@ PHP_FUNCTION(array_column)
 	zval *zcolumn = NULL, *zkey = NULL, *data;
 	HashTable *arr_hash;
 	zval *zcolval = NULL, *zkeyval = NULL, rvc, rvk;
-	HashTable *ht;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "hz!|z!", &arr_hash, &zcolumn, &zkey) == FAILURE) {
 		return;
@@ -3137,6 +3136,12 @@ PHP_FUNCTION(array_column)
 			zend_string_release(key);
 		} else {
 			add_next_index_zval(return_value, zcolval);
+		}
+		if (zcolval == &rvc) {
+			zval_ptr_dtor(&rvc);
+		}
+		if (zkeyval == &rvk) {
+			zval_ptr_dtor(&rvk);
 		}
 	} ZEND_HASH_FOREACH_END();
 }

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3068,16 +3068,15 @@ zend_bool array_column_param_helper(zval *param,
 }
 /* }}} */
 
-static inline zval *array_column_fetch_prop(zval *data, zval *name)
+static inline zval *array_column_fetch_prop(zval *data, zval *name, zval *rv)
 {
 	zval *prop = NULL;
 
 	if (Z_TYPE_P(data) == IS_OBJECT) {
 		zend_string *key = zval_get_string(name);
-		zval rv;
 
-		if (!Z_OBJ_HANDLER_P(data, has_property) || Z_OBJ_HANDLER_P(data, has_property)(data, name, 2, NULL)) {
-			prop = zend_read_property(Z_OBJCE_P(data), data, key->val, key->len, 1, &rv);
+		if (!Z_OBJ_HANDLER_P(data, has_property) || Z_OBJ_HANDLER_P(data, has_property)(data, name, 1, NULL)) {
+			prop = zend_read_property(Z_OBJCE_P(data), data, key->val, key->len, 1, rv);
 		}
 		zend_string_release(key);
 	} else if (Z_TYPE_P(data) == IS_ARRAY) {
@@ -3098,7 +3097,7 @@ PHP_FUNCTION(array_column)
 {
 	zval *zcolumn = NULL, *zkey = NULL, *data;
 	HashTable *arr_hash;
-	zval *zcolval = NULL, *zkeyval = NULL;
+	zval *zcolval = NULL, *zkeyval = NULL, rvc, rvk;
 	HashTable *ht;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "hz!|z!", &arr_hash, &zcolumn, &zkey) == FAILURE) {
@@ -3116,7 +3115,7 @@ PHP_FUNCTION(array_column)
 
 		if (!zcolumn) {
 			zcolval = data;
-		} else if ((zcolval = array_column_fetch_prop(data, zcolumn)) == NULL) {
+		} else if ((zcolval = array_column_fetch_prop(data, zcolumn, &rvc)) == NULL) {
 			continue;
 		}
 
@@ -3124,7 +3123,7 @@ PHP_FUNCTION(array_column)
 		 * which is to append the value as next_index
 		 */
 		if (zkey) {
-			zkeyval = array_column_fetch_prop(data, zkey);
+			zkeyval = array_column_fetch_prop(data, zkey, &rvk);
 		}
 
 		Z_TRY_ADDREF_P(zcolval);

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3123,7 +3123,7 @@ PHP_FUNCTION(array_column)
 				convert_to_string_ex(zkey);
 			}
 			if (Z_TYPE_P(zkey) == IS_STRING) {
-				zkeyval = zend_hash_find(ht, Z_STR_P(zkey));
+				zkeyval = zend_hash_find_ind(ht, Z_STR_P(zkey));
 			} else if (Z_TYPE_P(zkey) == IS_LONG) {
 				zkeyval = zend_hash_index_find(ht, Z_LVAL_P(zkey));
 			}

--- a/ext/standard/tests/array/array_column_variant_objects.phpt
+++ b/ext/standard/tests/array/array_column_variant_objects.phpt
@@ -25,6 +25,19 @@ function newUser($id, $first_name, $last_name)
     return $o;
 }
 
+class Something
+{
+	public function __isset($name)
+	{
+		return $name == 'id';
+	}
+
+	public function __get($name)
+	{
+		return "something";
+	}
+}
+
 $records = array(
     newUser(1, 'John', 'Doe'),
     newUser(2, 'Sally', 'Smith'),
@@ -32,6 +45,7 @@ $records = array(
     new User(1, 'John', 'Doe'),
     new User(2, 'Sally', 'Smith'),
     new User(3, 'Jane', 'Jones'),
+	new Something,
 );
 
 echo "*** Testing array_column() : object property fetching (numeric property names) ***\n";
@@ -113,13 +127,15 @@ array(3) {
   string(4) "Jane"
 }
 -- id column from recordset --
-array(3) {
+array(4) {
   [0]=>
   int(1)
   [1]=>
   int(2)
   [2]=>
   int(3)
+  [3]=>
+  string(9) "something"
 }
 -- last_name column from recordset, keyed by value from id column --
 array(3) {

--- a/ext/standard/tests/array/array_column_variant_objects.phpt
+++ b/ext/standard/tests/array/array_column_variant_objects.phpt
@@ -1,0 +1,142 @@
+--TEST--
+Test array_column() function: testing with objects
+--FILE--
+<?php
+
+class User
+{
+	public $id, $first_name, $last_name;
+
+	public function __construct($id, $first_name, $last_name)
+	{
+		$this->id = $id;
+		$this->first_name = $first_name;
+		$this->last_name = $last_name;
+	}
+}
+
+function newUser($id, $first_name, $last_name)
+{
+    $o = new stdClass;
+    $o->{0} = $id;
+    $o->{1} = $first_name;
+    $o->{2} = $last_name;
+
+    return $o;
+}
+
+$records = array(
+    newUser(1, 'John', 'Doe'),
+    newUser(2, 'Sally', 'Smith'),
+    newUser(3, 'Jane', 'Jones'),
+    new User(1, 'John', 'Doe'),
+    new User(2, 'Sally', 'Smith'),
+    new User(3, 'Jane', 'Jones'),
+);
+
+echo "*** Testing array_column() : object property fetching (numeric property names) ***\n";
+
+echo "-- first_name column from recordset --\n";
+var_dump(array_column($records, 1));
+
+echo "-- id column from recordset --\n";
+var_dump(array_column($records, 0));
+
+echo "-- last_name column from recordset, keyed by value from id column --\n";
+var_dump(array_column($records, 2, 0));
+
+echo "-- last_name column from recordset, keyed by value from first_name column --\n";
+var_dump(array_column($records, 2, 1));
+
+echo "*** Testing array_column() : object property fetching (string property names) ***\n";
+
+echo "-- first_name column from recordset --\n";
+var_dump(array_column($records, 'first_name'));
+
+echo "-- id column from recordset --\n";
+var_dump(array_column($records, 'id'));
+
+echo "-- last_name column from recordset, keyed by value from id column --\n";
+var_dump(array_column($records, 'last_name', 'id'));
+
+echo "-- last_name column from recordset, keyed by value from first_name column --\n";
+var_dump(array_column($records, 'last_name', 'first_name'));
+
+echo "Done\n";
+?>
+--EXPECTF--
+*** Testing array_column() : object property fetching (numeric property names) ***
+-- first_name column from recordset --
+array(3) {
+  [0]=>
+  string(4) "John"
+  [1]=>
+  string(5) "Sally"
+  [2]=>
+  string(4) "Jane"
+}
+-- id column from recordset --
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
+-- last_name column from recordset, keyed by value from id column --
+array(3) {
+  [1]=>
+  string(3) "Doe"
+  [2]=>
+  string(5) "Smith"
+  [3]=>
+  string(5) "Jones"
+}
+-- last_name column from recordset, keyed by value from first_name column --
+array(3) {
+  ["John"]=>
+  string(3) "Doe"
+  ["Sally"]=>
+  string(5) "Smith"
+  ["Jane"]=>
+  string(5) "Jones"
+}
+*** Testing array_column() : object property fetching (string property names) ***
+-- first_name column from recordset --
+array(3) {
+  [0]=>
+  string(4) "John"
+  [1]=>
+  string(5) "Sally"
+  [2]=>
+  string(4) "Jane"
+}
+-- id column from recordset --
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
+-- last_name column from recordset, keyed by value from id column --
+array(3) {
+  [1]=>
+  string(3) "Doe"
+  [2]=>
+  string(5) "Smith"
+  [3]=>
+  string(5) "Jones"
+}
+-- last_name column from recordset, keyed by value from first_name column --
+array(3) {
+  ["John"]=>
+  string(3) "Doe"
+  ["Sally"]=>
+  string(5) "Smith"
+  ["Jane"]=>
+  string(5) "Jones"
+}
+Done

--- a/ext/standard/tests/array/array_column_variant_objects.phpt
+++ b/ext/standard/tests/array/array_column_variant_objects.phpt
@@ -29,12 +29,12 @@ class Something
 {
 	public function __isset($name)
 	{
-		return $name == 'id';
+		return $name == 'first_name';
 	}
 
 	public function __get($name)
 	{
-		return "something";
+		return new User(4, 'Jack', 'Sparrow');
 	}
 }
 
@@ -118,24 +118,31 @@ array(3) {
 }
 *** Testing array_column() : object property fetching (string property names) ***
 -- first_name column from recordset --
-array(3) {
+array(4) {
   [0]=>
   string(4) "John"
   [1]=>
   string(5) "Sally"
   [2]=>
   string(4) "Jane"
+  [3]=>
+  object(User)#8 (3) {
+    ["id"]=>
+    int(4)
+    ["first_name"]=>
+    string(4) "Jack"
+    ["last_name"]=>
+    string(7) "Sparrow"
+  }
 }
 -- id column from recordset --
-array(4) {
+array(3) {
   [0]=>
   int(1)
   [1]=>
   int(2)
   [2]=>
   int(3)
-  [3]=>
-  string(9) "something"
 }
 -- last_name column from recordset, keyed by value from id column --
 array(3) {


### PR DESCRIPTION
While `array_column()` comes in handy for two-dimensional arrays, for the same reasons it would also come in handy if you have an array of objects.

This implementation behaves in the same manner as for arrays; if the property referenced by the `$column_key` argument doesn't exist, it will be skipped. If your class features dynamic properties by using `__get()`, you must implement `__isset()` as well.