### PR TITLE
Fix #53823 - empty matches could result in garbled UTF-8 despite u modifier

### DIFF
--- a/ext/pcre/tests/bug53823.phpt
+++ b/ext/pcre/tests/bug53823.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Bug #53823 - preg_replace: * qualifier on unicode replace garbles the string
+--FILE--
+<?php
+var_dump(preg_replace('/[^\pL\pM]*/iu', '', 'áéíóú'));
+?>
+--EXPECT--
+string(10) "áéíóú"

--- a/ext/pcre/tests/bug53823.phpt
+++ b/ext/pcre/tests/bug53823.phpt
@@ -3,6 +3,11 @@ Bug #53823 - preg_replace: * qualifier on unicode replace garbles the string
 --FILE--
 <?php
 var_dump(preg_replace('/[^\pL\pM]*/iu', '', 'áéíóú'));
+// invalid UTF-8
+var_dump(preg_replace('/[^\pL\pM]*/iu', '', "\xFCáéíóú"));
+var_dump(preg_replace('/[^\pL\pM]*/iu', '', "áéíóú\xFC"));
 ?>
 --EXPECT--
 string(10) "áéíóú"
+NULL
+NULL

--- a/ext/pcre/tests/bug66121.phpt
+++ b/ext/pcre/tests/bug66121.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Bug #66121 - UTF-8 lookbehinds match bytes instead of characters
+--FILE--
+<?php
+// Sinhala characters
+var_dump(preg_replace('/(?<!ක)/u', '*', 'ක'));
+var_dump(preg_replace('/(?<!ක)/u', '*', 'ම'));
+// English characters
+var_dump(preg_replace('/(?<!k)/u', '*', 'k'));
+var_dump(preg_replace('/(?<!k)/u', '*', 'm'));
+// Sinhala characters
+preg_match_all('/(?<!ක)/u', 'ම', $matches, PREG_OFFSET_CAPTURE);
+var_dump($matches);
+?>
+--EXPECT--
+string(4) "*ක"
+string(5) "*ම*"
+string(2) "*k"
+string(3) "*m*"
+array(1) {
+  [0]=>
+  array(2) {
+    [0]=>
+    array(2) {
+      [0]=>
+      string(0) ""
+      [1]=>
+      int(0)
+    }
+    [1]=>
+    array(2) {
+      [0]=>
+      string(0) ""
+      [1]=>
+      int(3)
+    }
+  }
+}

--- a/ext/pcre/tests/bug66121.phpt
+++ b/ext/pcre/tests/bug66121.phpt
@@ -11,6 +11,11 @@ var_dump(preg_replace('/(?<!k)/u', '*', 'm'));
 // Sinhala characters
 preg_match_all('/(?<!ක)/u', 'ම', $matches, PREG_OFFSET_CAPTURE);
 var_dump($matches);
+// invalid UTF-8
+var_dump(preg_replace('/(?<!ක)/u', '*', "\xFCක"));
+var_dump(preg_replace('/(?<!ක)/u', '*', "ක\xFC"));
+var_dump(preg_match_all('/(?<!ක)/u', "\xFCම", $matches, PREG_OFFSET_CAPTURE));
+var_dump(preg_match_all('/(?<!ක)/u', "\xFCම", $matches, PREG_OFFSET_CAPTURE));
 ?>
 --EXPECT--
 string(4) "*ක"
@@ -36,3 +41,7 @@ array(1) {
     }
   }
 }
+NULL
+NULL
+bool(false)
+bool(false)


### PR DESCRIPTION
When advancing after empty matches, `php_pcre_match_impl()` as well as `php_pcre_replace_impl()` always advance to the next byte instead of the next code point when the `u` modifier is given. This may result in garbled UTF-8 results, and maybe in match errors. This PR fixes that.

Note that this issue has been fixed for `php_pcre_split_impl()` [long ago](https://github.com/php/php-src/commit/0330fb2cbf5b8d2f96aaa6f1de114e86d3dbbcfc). I've noticed that, only after having already implemented another solution: instead of using an additional PCRE, the string is iterated over looking for UTF-8 start sequences. The latter solution is more lightweight than the former, so it seems approrpiate to do it this way. The already implemented solution for `php_pcre_split_impl()` could be replaced, but as it is not broken, it seems reasonable to keep it – at least for PHP 5.

I've tested the patches on Windows 7 and Ubuntu 14.04 (bundled PCRE lib only).