### PR TITLE
Fix bug #61221 - imagegammacorrect function loses alpha channel

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -3019,10 +3019,11 @@ PHP_FUNCTION(imagegammacorrect)
 			for (x = 0; x < gdImageSX(im); x++)	{
 				c = gdImageGetPixel(im, x, y);
 				gdImageSetPixel(im, x, y,
-					gdTrueColor(
+					gdTrueColorAlpha(
 						(int) ((pow((pow((gdTrueColorGetRed(c)   / 255.0), input)), 1.0 / output) * 255) + .5),
 						(int) ((pow((pow((gdTrueColorGetGreen(c) / 255.0), input)), 1.0 / output) * 255) + .5),
-						(int) ((pow((pow((gdTrueColorGetBlue(c)  / 255.0), input)), 1.0 / output) * 255) + .5)
+						(int) ((pow((pow((gdTrueColorGetBlue(c)  / 255.0), input)), 1.0 / output) * 255) + .5),
+						gdTrueColorGetAlpha(c)
 					)
 				);
 			}

--- a/ext/gd/tests/bug61221.phpt
+++ b/ext/gd/tests/bug61221.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #61221 - imagegammacorrect function loses alpha channel
+--SKIPIF--
+<?php
+if (!extension_loaded('gd')) die('skip gd extension not available');
+?>
+--FILE--
+<?php
+$imagew = 50;
+$imageh = 50;
+$img = imagecreatetruecolor($imagew, $imageh);
+$blacktransparent = imagecolorallocatealpha($img, 0, 0, 0, 127);
+$redsolid = imagecolorallocate($img, 255, 0, 0);
+imagefill($img, 0, 0, $blacktransparent);
+imageline($img, $imagew / 2, 0, $imagew / 2, $imageh - 1, $redsolid);
+imageline($img, 0, $imageh / 2, $imagew - 1, $imageh / 2, $redsolid);
+imagegammacorrect($img, 1, 1);
+$color = imagecolorat($img, 0, 0);
+var_dump($color === $blacktransparent);
+imagedestroy($img);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
When applying imagegammacorrect() the alpha channel is now fully retained, instead of being completely lost.

I've tested this on Windows 7 and Ubuntu 14.04 (bundled GD lib only).

@pierrejoye @remicollet Please have a look at this PR. The patch seems to be straight forward, and I don't expect it to be a real BC break, because likely nobody used imagegammacorrect() on images with alpha channel (at least without [manual correction](http://stackoverflow.com/questions/3303639/php-gd2-how-to-maintain-alpha-channel-transparency-and-correct-gamma#3314151)). At least this might be merged into master for PHP 7.