### PR TITLE
Fix bug #69767 - Default parameter value with wrong type segfaults

### DIFF
--- a/Zend/tests/bug69767.phpt
+++ b/Zend/tests/bug69767.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Bug #69767 - Default parameter value with wrong type segfaults
+--FILE--
+<?php
+function foo(string $bar = 0) {}
+?>
+--EXPECTF--
+Fatal error: Default value for parameters with a string type hint can only be string or NULL in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4373,8 +4373,10 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 						zend_error_noreturn(E_COMPILE_ERROR, "Default value for parameters "
 							"with a class type hint can only be NULL");
 					} else if (!ZEND_SAME_FAKE_TYPE(arg_info->type_hint, Z_TYPE(default_node.u.constant))) {
+						char *type_name = zend_ast_get_str(type_ast)->val;
+
 						zend_error_noreturn(E_COMPILE_ERROR, "Default value for parameters "
-							"with a %s type hint can only be %s or NULL", arg_info->class_name->val, arg_info->class_name->val);
+							"with a %s type hint can only be %s or NULL", type_name, type_name);
 					}
 				}
 			}


### PR DESCRIPTION
Tested on Windows 7 and Ubuntu 14.04.

This PR should be applied to master only (not PHP 5).