### PR TITLE
fix language dependent Windows socket tests

### DIFF
--- a/ext/sockets/tests/socket_import_stream-4-win.phpt
+++ b/ext/sockets/tests/socket_import_stream-4-win.phpt
@@ -80,11 +80,11 @@ stream_set_blocking
 Warning: stream_set_blocking(): supplied resource is not a valid stream resource in %s on line %d
 
 socket_set_block 
-Warning: socket_set_block(): unable to set blocking mode [%d]: An operation was attempted on something that is not a socket.
+Warning: socket_set_block(): unable to set blocking mode [10038]: %s
  in %ssocket_import_stream-4-win.php on line %d
 
 socket_get_option 
-Warning: socket_get_option(): unable to retrieve socket option [%d]: An operation was attempted on something that is not a socket.
+Warning: socket_get_option(): unable to retrieve socket option [10038]: %s
  in %ssocket_import_stream-4-win.php on line %d
 
 

--- a/ext/sockets/tests/socket_sentto_recvfrom_ipv6_udp-win32.phpt
+++ b/ext/sockets/tests/socket_sentto_recvfrom_ipv6_udp-win32.phpt
@@ -48,7 +48,7 @@ require 'ipv6_skipif.inc';
 
     socket_close($socket);
 --EXPECTF--
-Warning: socket_recvfrom(): unable to recvfrom [10022]: An invalid argument was supplied.
+Warning: socket_recvfrom(): unable to recvfrom [10022]: %s
  in %s on line %d
 
 Warning: Wrong parameter count for socket_sendto() in %s on line %d


### PR DESCRIPTION
These tests will only pass on an English Windows (and only as long as the message texts will not change). I've modified the tests to check for the Windows error code, and to take an abritrary message.