### PR TITLE
modify for while nginx fastcgi keepalive ，fpm will result in 502 response 

### DIFF
--- a/sapi/fpm/fpm/fastcgi.c
+++ b/sapi/fpm/fpm/fastcgi.c
@@ -727,7 +727,7 @@ void fcgi_close(fcgi_request *req, int force, int destroy)
 	}
 #endif
 
-	if ((force || !req->keep) && req->fd >= 0) {
+	if (req->fd >= 0) {
 #ifdef _WIN32
 		if (!req->tcp) {
 			HANDLE pipe = (HANDLE)_get_osfhandle(req->fd);
@@ -737,7 +737,7 @@ void fcgi_close(fcgi_request *req, int force, int destroy)
 			}
 			DisconnectNamedPipe(pipe);
 		} else {
-			if (!force) {
+			if (!force || req->keep) {
 				char buf[8];
 
 				shutdown(req->fd, 1);


### PR DESCRIPTION
modify for while nginx fastcgi keepalive enabled ,when  the max requests (MAX_REQUEST in  ) counter reached , the last reponse to nginx will fail . because fpm will close(req->fd) directly ，with no shutdown() and wait for the packets that nginx returned .  and i think the if condition in line 730 is not as useful as  that written,so I changed it .



