### PR TITLE
Fix bad formatted "undefined offset" notice

### DIFF
--- a/Zend/tests/array_offset.phpt
+++ b/Zend/tests/array_offset.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Ensure "undefined offset" notice formats message corectly when undefined key is negative
+--FILE--
+<?php
+
+[][-1];
+[][-1.1];
+(new ArrayObject)[-1];
+(new ArrayObject)[-1.1];
+
+echo "Done\n";
+?>
+--EXPECTF--	
+Notice: Undefined offset: -1 in %s on line 3
+
+Notice: Undefined offset: -1 in %s on line 4
+
+Notice: Undefined offset: -1 in %s on line 5
+
+Notice: Undefined offset: -1 in %s on line 6
+Done

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1438,14 +1438,14 @@ num_index:
 		if (retval == NULL) {
 			switch (type) {
 				case BP_VAR_R:
-					zend_error(E_NOTICE,"Undefined offset: " ZEND_ULONG_FMT, hval);
+					zend_error(E_NOTICE,"Undefined offset: " ZEND_LONG_FMT, hval);
 					/* break missing intentionally */
 				case BP_VAR_UNSET:
 				case BP_VAR_IS:
 					retval = &EG(uninitialized_zval);
 					break;
 				case BP_VAR_RW:
-					zend_error(E_NOTICE,"Undefined offset: " ZEND_ULONG_FMT, hval);
+					zend_error(E_NOTICE,"Undefined offset: " ZEND_LONG_FMT, hval);
 					/* break missing intentionally */
 				case BP_VAR_W:
 					retval = zend_hash_index_add_new(ht, hval, &EG(uninitialized_zval));


### PR DESCRIPTION
Fix bad formatted "undefined offset" notice when array key is negative:

    php > [][-1];
    PHP Notice:  Undefined offset: 18446744073709551615 in php shell code on line 1

Expected:

    PHP Notice:  Undefined offset: -1 in php shell code on line 1

Only happens with master -  https://github.com/php/php-src/commit/8ee2a4a9b5de682c0b37670e1f4f86242b1650ce - branch: http://3v4l.org/cpvse.