### PR TITLE
Apply the division by 0 semantics to bcdiv() and bcmod()

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -350,7 +350,7 @@ PHP_FUNCTION(bcdiv)
 			RETVAL_STR(bc_num2str(result));
 			break;
 		case -1: /* division by zero */
-			php_error_docref(NULL, E_WARNING, "Division by zero");
+			zend_throw_exception_ex(NULL, 0, "Division by zero");
 			break;
 	}
 
@@ -384,7 +384,7 @@ PHP_FUNCTION(bcmod)
 			RETVAL_STR(bc_num2str(result));
 			break;
 		case -1:
-			php_error_docref(NULL, E_WARNING, "Division by zero");
+			zend_throw_exception_ex(NULL, 0, "Division by zero");
 			break;
 	}
 

--- a/ext/bcmath/tests/bcdiv_error1.phpt
+++ b/ext/bcmath/tests/bcdiv_error1.phpt
@@ -8,7 +8,11 @@ antoni@solucionsinternet.com
 <?php if(!extension_loaded("bcmath")) print "skip"; ?>
 --FILE--
 <?php
-echo bcdiv('10.99', '0');
+try {
+    var_dump(bcdiv('10.99', '0'));
+} catch (Exception $e) {
+    echo "\nException: " . $e->getMessage() . "\n";
+}
 ?>
 --EXPECTF--
-Warning: bcdiv(): Division by zero in %s.php on line %d
+Exception: Division by zero

--- a/ext/bcmath/tests/bcmod_error2.phpt
+++ b/ext/bcmath/tests/bcmod_error2.phpt
@@ -6,7 +6,11 @@ bcmod() - mod by 0
 bcmath.scale=0
 --FILE--
 <?php
-echo bcmod("10", "0");
+try {
+    var_dump(bcmod("10", "0"));
+} catch (Exception $e) {
+    echo "\nException: " . $e->getMessage() . "\n";
+}
 ?>
 --EXPECTF--
-Warning: bcmod(): Division by zero in %s on line %d
+Exception: Division by zero


### PR DESCRIPTION
This patch updates the old division by 0 semantics from the bcmath extension to the new behaviour as defined in commit: cae0147ed3ceb55fcb1bc059b8e8ea6a36ea69a8