### PR TITLE
Fix #61362: Exception::getTraceAsString and ::__toString scramble Unicode

### DIFF
--- a/Zend/tests/bug61362.phpt
+++ b/Zend/tests/bug61362.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #61362 (Exception::getTraceAsString, Exception::__toString not able to handle unicode)
+--FILE--
+<?php
+function test($arg){
+	throw new Exception();
+}
+
+try {
+	test('тест');
+}
+catch(Exception $e) {
+	echo $e->getTraceAsString();
+	echo (string)$e;
+}
+?>
+--EXPECTF--
+#0 %s(%d): test('\xD1\x82\xD0\xB5\xD1\x81\xD1\x82')
+#1 {main}Exception in %s:%d
+Stack trace:
+#0 %s(%d): test('\xD1\x82\xD0\xB5\xD1\x81\xD1\x82')
+#1 {main}

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -399,7 +399,7 @@ static void smart_str_append_escaped(smart_str *str, const char *s, size_t l) {
 	str->s->len += len;
 
 	for (i = 0; i < l; ++i) {
-		char c = s[i];
+		unsigned char c = s[i];
 		if (c < 32 || c == '\\' || c > 126) {
 			*res++ = '\\';
 			switch (c) {


### PR DESCRIPTION
The logic in smart_str_append_escaped() relies on unsigned values of c, so we
have to declare it as such.