### PR TITLE
Zstrict - Enforcing encapsulation/isolation

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -389,6 +389,38 @@ fi
 AC_MSG_CHECKING(whether to enable zend signal handling)
 AC_MSG_RESULT($ZEND_SIGNALS)
 
+AC_ARG_ENABLE(api-checks,
+[  --enable-api-checks     Perform API compliance checks],[
+  ZEND_CORE_CHECK_API=$enableval
+],[
+  ZEND_CORE_CHECK_API=no
+])  
+
+if test "$ZEND_CORE_CHECK_API" = "yes"; then
+	AC_DEFINE(ZEND_CORE_CHECK_API, 1, [Perform API compliance checks])
+else
+	AC_DEFINE(ZEND_CORE_CHECK_API, 0, [Perform API compliance checks])
+fi
+
+AC_MSG_CHECKING(whether to perform API compliance checks)
+AC_MSG_RESULT($ZEND_CORE_CHECK_API)
+
+AC_ARG_ENABLE(strict-api,
+[  --enable-strict-api     Enforce strict API compliance],[
+  ZEND_CORE_STRICT_API=$enableval
+],[
+  ZEND_CORE_STRICT_API=no
+])  
+
+if test "$ZEND_CORE_STRICT_API" = "yes"; then
+	AC_DEFINE(ZEND_CORE_STRICT_API, 1, [Enforce strict API compliance])
+else
+	AC_DEFINE(ZEND_CORE_STRICT_API, 0, [Enforce strict API compliance])
+fi
+
+AC_MSG_CHECKING(whether to enforce strict API compliance)
+AC_MSG_RESULT($ZEND_CORE_STRICT_API)
+
 ])
 
 AC_DEFUN([LIBZEND_CPLUSPLUS_CHECKS],[

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -28,6 +28,8 @@
 #include "zend_operators.h"
 #include "zend_variables.h"
 #include "zend_execute.h"
+#include "zend_types.h"
+#include "zend_string.h"
 
 
 BEGIN_EXTERN_C()
@@ -570,6 +572,18 @@ END_EXTERN_C()
 #define ZVAL_STRING(z, s) do {					\
 		const char *_s = (s);					\
 		ZVAL_STRINGL(z, _s, strlen(_s));		\
+	} while (0)
+
+#define ZVAL_STR_LEN(z, l) do {					\
+		zend_string_set_len(Z_STR_P(z), l);		\
+	} while (0)
+
+#define ZVAL_STR_DEC_LEN(z) do {					\
+		zend_string_dec_len(Z_STR_P(z));		\
+	} while (0)
+
+#define ZVAL_STR_INC_LEN(z) do {					\
+		zend_string_inc_len(Z_STR_P(z));		\
 	} while (0)
 
 #define ZVAL_EMPTY_STRING(z) do {				\
@@ -1126,8 +1140,8 @@ static zend_always_inline int zend_parse_arg_string(zval *arg, char **dest, size
 		*dest = NULL;
 		*dest_len = 0;
 	} else {
-		*dest = str->val;
-		*dest_len = str->len;
+		*dest = ZSTR_VAL(str);
+		*dest_len = ZSTR_LEN(str);
 	}
 	return 1;
 }
@@ -1135,7 +1149,7 @@ static zend_always_inline int zend_parse_arg_string(zval *arg, char **dest, size
 static zend_always_inline int zend_parse_arg_path_str(zval *arg, zend_string **dest, int check_null)
 {
 	if (!zend_parse_arg_str(arg, dest, check_null) ||
-	    (*dest && UNEXPECTED(CHECK_NULL_PATH((*dest)->val, (*dest)->len)))) {
+	    (*dest && UNEXPECTED(CHECK_NULL_PATH(ZSTR_VAL(*dest), ZSTR_LEN(*dest))))) {
 		return 0;
 	}
 	return 1;
@@ -1152,8 +1166,8 @@ static zend_always_inline int zend_parse_arg_path(zval *arg, char **dest, size_t
 		*dest = NULL;
 		*dest_len = 0;
 	} else {
-		*dest = str->val;
-		*dest_len = str->len;
+		*dest = ZSTR_VAL(str);
+		*dest_len = ZSTR_LEN(str);
 	}
 	return 1;
 }

--- a/Zend/zend_strict.h
+++ b/Zend/zend_strict.h
@@ -1,0 +1,86 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend Engine                                                          |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1998-2015 Zend Technologies Ltd. (http://www.zend.com) |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+   | Author: Francois Laupretre <francois@php.net>                        |
+   +----------------------------------------------------------------------+
+*/
+/* $Id$ */
+/*============================================================================
+ This file implements '--enable-api-checks' and '--enable-strict-api'
+ configure otpions.
+
+ In 'api-check' mode the names of the protected structure elements are modified,
+ causing compilation to fail when some code attempts a direct access to the
+ element using its 'normal' name. This allows to detect and fixes places where
+ code does not respect the published API.
+
+ In 'strict-api' mode, the API becommes more restrictive, allowing developers
+ to check their code against future restrictions of the API.
+ 
+ -------------------------------- WARNING ------------------------------------
+ Including this file is reserved to source files located in the Zend
+ subdirectory (outside the Zend directory, it can be included indirectly,
+ through another zend_xxx include, but not directly). The macros defined below
+ should never be used in any piece of code outside the Zend subdirectory.
+============================================================================*/
+
+#ifndef ZEND_STRICT_H
+#define ZEND_STRICT_H
+
+#include "php_config.h"
+
+#ifdef ZEND_EXT_CHECK_API
+#	define __ZEND_CHECK_API ZEND_EXT_CHECK_API
+#else
+#	ifdef ZEND_CORE_CHECK_API
+#		define __ZEND_CHECK_API ZEND_CORE_CHECK_API
+#	else
+#		define __ZEND_CHECK_API 0
+#	endif
+#endif
+#if __ZEND_CHECK_API
+#	define _ZEND_PROTECTED(_prefix,_elt) _z_check_ ## _prefix ## _ ## _elt
+#	define ZEND_CHECK_API
+#else
+#	define _ZEND_PROTECTED(_prefix,_elt) _elt
+#endif
+#undef __ZEND_CHECK_API
+
+#ifdef ZEND_EXT_STRICT_API
+#	define __ZEND_STRICT_API ZEND_EXT_STRICT_API
+#else
+#	ifdef ZEND_CORE_STRICT_API
+#		define __ZEND_STRICT_API ZEND_CORE_STRICT_API
+#	else
+#		define __ZEND_STRICT_API 0
+#	endif
+#endif
+#if __ZEND_STRICT_API
+#	define _ZEND_PROTECTED_STRICT(_prefix,_elt) _ZEND_PROTECTED(_prefix ## _strict,_elt)
+#	define ZEND_STRICT_API
+#else
+#	define _ZEND_PROTECTED_STRICT(_prefix,_elt) _elt
+#endif
+#undef __ZEND_STRICT_API
+
+/*-------------------------------------------------------------------------*/
+#endif /* ZEND_STRICT_H */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * indent-tabs-mode: t
+ * End:
+ */

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -22,6 +22,7 @@
 #define ZEND_STRING_H
 
 #include "zend.h"
+#include "zend_strict.h"
 
 BEGIN_EXTERN_C()
 
@@ -35,41 +36,91 @@ void zend_interned_strings_dtor(void);
 
 END_EXTERN_C()
 
+/* Shortcuts */
+
+#ifdef ZEND_STRICT_API
+#	define ZSTR_VAL(zstr)  zend_string_get_val(zstr)
+#	define ZSTR_LEN(zstr)  zend_string_get_len(zstr)
+#	define ZSTR_HASH(zstr) zend_string_get_hash_val(zstr)
+#else
+#	define ZSTR_VAL(zstr)  (zstr)->_ZEND_PROTECTED_STRICT(zend_string, val)
+#	define ZSTR_LEN(zstr)  (zstr)->_ZEND_PROTECTED_STRICT(zend_string, len)
+#	define ZSTR_HASH(zstr) (zstr)->_ZEND_PROTECTED_STRICT(zend_string, h)
+#endif
+
 #define IS_INTERNED(s)					(GC_FLAGS(s) & IS_STR_INTERNED)
 
 #define STR_EMPTY_ALLOC()				CG(empty_string)
 
-#define _STR_HEADER_SIZE XtOffsetOf(zend_string, val)
+#define _STR_HEADER_SIZE XtOffsetOf(zend_string, _ZEND_PROTECTED_STRICT(zend_string, val))
+
+#define _ZSTR_STRUCT_SIZE(len) ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1)
 
 #define STR_ALLOCA_ALLOC(str, _len, use_heap) do { \
-	(str) = (zend_string *)do_alloca(ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + (_len) + 1), (use_heap)); \
+	(str) = (zend_string *)do_alloca(_ZSTR_STRUCT_SIZE(_len), (use_heap)); \
 	GC_REFCOUNT(str) = 1; \
 	GC_TYPE_INFO(str) = IS_STRING; \
-	(str)->h = 0; \
-	(str)->len = (_len); \
+	zend_string_forget_hash_val(str); \
+	zend_string_set_len(str, _len); \
 } while (0)
 #define STR_ALLOCA_INIT(str, s, len, use_heap) do { \
 	STR_ALLOCA_ALLOC(str, len, use_heap); \
-	memcpy((str)->val, (s), (len)); \
-	(str)->val[(len)] = '\0'; \
+	memcpy(ZSTR_VAL(str), (s), (len)); \
+	ZSTR_VAL(str)[(len)] = '\0'; \
 } while (0)
 
 #define STR_ALLOCA_FREE(str, use_heap) free_alloca(str, use_heap)
 
+static zend_always_inline char * zend_string_get_val(zend_string *s)
+{
+	return (s)->_ZEND_PROTECTED_STRICT(zend_string, val);
+}
+
+static zend_always_inline size_t zend_string_get_len(const zend_string *s)
+{
+	return (s)->_ZEND_PROTECTED_STRICT(zend_string, len);
+}
+
+static zend_always_inline void zend_string_set_len(zend_string *s, size_t len)
+{
+	(s)->_ZEND_PROTECTED_STRICT(zend_string, len)=len;
+}
+
+static zend_always_inline void zend_string_dec_len(zend_string *s)
+{
+	ZEND_ASSERT((s)->_ZEND_PROTECTED_STRICT(zend_string, len) > 0);
+	(s)->_ZEND_PROTECTED_STRICT(zend_string, len)--;
+}
+
+static zend_always_inline void zend_string_inc_len(zend_string *s)
+{
+	(s)->_ZEND_PROTECTED_STRICT(zend_string, len)++;
+}
+
+static zend_always_inline void _zend_string_set_hash_elt(zend_string *s, zend_ulong h)
+{
+	(s)->_ZEND_PROTECTED_STRICT(zend_string,h) = h;
+}
+
+static zend_always_inline zend_ulong _zend_string_get_hash_elt(const zend_string *s)
+{
+	return (s)->_ZEND_PROTECTED_STRICT(zend_string,h);
+}
+
 static zend_always_inline zend_ulong zend_string_hash_val(zend_string *s)
 {
-	if (!s->h) {
-		s->h = zend_hash_func(s->val, s->len);
+	if (!_zend_string_get_hash_elt(s)) {
+		_zend_string_set_hash_elt(s, zend_hash_func(ZSTR_VAL(s), ZSTR_LEN(s)));
 	}
-	return s->h;
+	return _zend_string_get_hash_elt(s);
 }
 
 static zend_always_inline void zend_string_forget_hash_val(zend_string *s)
 {
-	s->h = 0;
+	_zend_string_set_hash_elt(s, 0);
 }
 
-static zend_always_inline uint32_t zend_string_refcount(zend_string *s)
+static zend_always_inline uint32_t zend_string_refcount(const zend_string *s)
 {
 	if (!IS_INTERNED(s)) {
 		return GC_REFCOUNT(s);
@@ -95,7 +146,7 @@ static zend_always_inline uint32_t zend_string_delref(zend_string *s)
 
 static zend_always_inline zend_string *zend_string_alloc(size_t len, int persistent)
 {
-	zend_string *ret = (zend_string *)pemalloc(ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), persistent);
+	zend_string *ret = (zend_string *)pemalloc(_ZSTR_STRUCT_SIZE(len), persistent);
 
 	GC_REFCOUNT(ret) = 1;
 #if 1
@@ -106,14 +157,14 @@ static zend_always_inline zend_string *zend_string_alloc(size_t len, int persist
 	GC_FLAGS(ret) = (persistent ? IS_STR_PERSISTENT : 0);
 	GC_INFO(ret) = 0;
 #endif
-	ret->h = 0;
-	ret->len = len;
+	zend_string_forget_hash_val(ret);
+	zend_string_set_len(ret, len);
 	return ret;
 }
 
 static zend_always_inline zend_string *zend_string_safe_alloc(size_t n, size_t m, size_t l, int persistent)
 {
-	zend_string *ret = (zend_string *)safe_pemalloc(n, m, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + l + 1), persistent);
+	zend_string *ret = (zend_string *)safe_pemalloc(n, m, _ZSTR_STRUCT_SIZE(l), persistent);
 
 	GC_REFCOUNT(ret) = 1;
 #if 1
@@ -124,8 +175,8 @@ static zend_always_inline zend_string *zend_string_safe_alloc(size_t n, size_t m
 	GC_FLAGS(ret) = (persistent ? IS_STR_PERSISTENT : 0);
 	GC_INFO(ret) = 0;
 #endif
-	ret->h = 0;
-	ret->len = (n * m) + l;
+	zend_string_forget_hash_val(ret);
+	zend_string_set_len(ret, (n * m) + l);
 	return ret;
 }
 
@@ -133,8 +184,8 @@ static zend_always_inline zend_string *zend_string_init(const char *str, size_t 
 {
 	zend_string *ret = zend_string_alloc(len, persistent);
 
-	memcpy(ret->val, str, len);
-	ret->val[len] = '\0';
+	memcpy(ZSTR_VAL(ret), str, len);
+	ZSTR_VAL(ret)[len] = '\0';
 	return ret;
 }
 
@@ -151,7 +202,7 @@ static zend_always_inline zend_string *zend_string_dup(zend_string *s, int persi
 	if (IS_INTERNED(s)) {
 		return s;
 	} else {
-		return zend_string_init(s->val, s->len, persistent);
+		return zend_string_init(ZSTR_VAL(s), ZSTR_LEN(s), persistent);
 	}
 }
 
@@ -161,8 +212,8 @@ static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_
 
 	if (!IS_INTERNED(s)) {
 		if (EXPECTED(GC_REFCOUNT(s) == 1)) {
-			ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), persistent);
-			ret->len = len;
+			ret = (zend_string *)perealloc(s, _ZSTR_STRUCT_SIZE(len), persistent);
+			zend_string_set_len(ret, len);
 			zend_string_forget_hash_val(ret);
 			return ret;
 		} else {
@@ -170,7 +221,7 @@ static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_
 		}
 	}
 	ret = zend_string_alloc(len, persistent);
-	memcpy(ret->val, s->val, (len > s->len ? s->len : len) + 1);
+	memcpy(ZSTR_VAL(ret), ZSTR_VAL(s), MIN(len, ZSTR_LEN(s)) + 1);
 	return ret;
 }
 
@@ -178,11 +229,11 @@ static zend_always_inline zend_string *zend_string_extend(zend_string *s, size_t
 {
 	zend_string *ret;
 
-	ZEND_ASSERT(len >= s->len);
+	ZEND_ASSERT(len >= ZSTR_LEN(s));
 	if (!IS_INTERNED(s)) {
 		if (EXPECTED(GC_REFCOUNT(s) == 1)) {
-			ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), persistent);
-			ret->len = len;
+			ret = (zend_string *)perealloc(s, _ZSTR_STRUCT_SIZE(len), persistent);
+			zend_string_set_len(ret, len);
 			zend_string_forget_hash_val(ret);
 			return ret;
 		} else {
@@ -190,7 +241,7 @@ static zend_always_inline zend_string *zend_string_extend(zend_string *s, size_t
 		}
 	}
 	ret = zend_string_alloc(len, persistent);
-	memcpy(ret->val, s->val, s->len + 1);
+	memcpy(ZSTR_VAL(ret), ZSTR_VAL(s), ZSTR_LEN(s) + 1);
 	return ret;
 }
 
@@ -198,11 +249,11 @@ static zend_always_inline zend_string *zend_string_truncate(zend_string *s, size
 {
 	zend_string *ret;
 
-	ZEND_ASSERT(len <= s->len);
+	ZEND_ASSERT(len <= ZSTR_LEN(s));
 	if (!IS_INTERNED(s)) {
 		if (EXPECTED(GC_REFCOUNT(s) == 1)) {
-			ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), persistent);
-			ret->len = len;
+			ret = (zend_string *)perealloc(s, _ZSTR_STRUCT_SIZE(len), persistent);
+			zend_string_set_len(ret, len);
 			zend_string_forget_hash_val(ret);
 			return ret;
 		} else {
@@ -210,7 +261,7 @@ static zend_always_inline zend_string *zend_string_truncate(zend_string *s, size
 		}
 	}
 	ret = zend_string_alloc(len, persistent);
-	memcpy(ret->val, s->val, len + 1);
+	memcpy(ZSTR_VAL(ret), ZSTR_VAL(s), len + 1);
 	return ret;
 }
 
@@ -220,8 +271,8 @@ static zend_always_inline zend_string *zend_string_safe_realloc(zend_string *s, 
 
 	if (!IS_INTERNED(s)) {
 		if (GC_REFCOUNT(s) == 1) {
-			ret = (zend_string *)safe_perealloc(s, n, m, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + l + 1), persistent);
-			ret->len = (n * m) + l;
+			ret = (zend_string *)safe_perealloc(s, n, m, _ZSTR_STRUCT_SIZE(l), persistent);
+			zend_string_set_len(ret, (n * m) + l);
 			zend_string_forget_hash_val(ret);
 			return ret;
 		} else {
@@ -229,7 +280,7 @@ static zend_always_inline zend_string *zend_string_safe_realloc(zend_string *s, 
 		}
 	}
 	ret = zend_string_safe_alloc(n, m, l, persistent);
-	memcpy(ret->val, s->val, ((n * m) + l > s->len ? s->len : ((n * m) + l)) + 1);
+	memcpy(ZSTR_VAL(ret), ZSTR_VAL(s), MIN((n * m) + l, ZSTR_LEN(s)) + 1);
 	return ret;
 }
 
@@ -253,17 +304,17 @@ static zend_always_inline void zend_string_release(zend_string *s)
 
 static zend_always_inline zend_bool zend_string_equals(zend_string *s1, zend_string *s2)
 {
-	return s1 == s2 || (s1->len == s2->len && !memcmp(s1->val, s2->val, s1->len));
+	return s1 == s2 || (ZSTR_LEN(s1) == ZSTR_LEN(s2) && !memcmp(ZSTR_VAL(s1), ZSTR_VAL(s2), ZSTR_LEN(s1)));
 }
 
 #define zend_string_equals_ci(s1, s2) \
-	((s1)->len == (s2)->len && !zend_binary_strcasecmp((s1)->val, (s1)->len, (s2)->val, (s2)->len))
+	(ZSTR_LEN(s1) == ZSTR_LEN(s2) && !zend_binary_strcasecmp(ZSTR_VAL(s1), ZSTR_LEN(s1), ZSTR_VAL(s2), ZSTR_LEN(s2)))
 
 #define zend_string_equals_literal_ci(str, c) \
-	((str)->len == sizeof(c) - 1 && !zend_binary_strcasecmp((str)->val, (str)->len, (c), sizeof(c) - 1))
+	(ZSTR_LEN(str) == sizeof(c) - 1 && !zend_binary_strcasecmp(ZSTR_VAL(str), ZSTR_LEN(str), (c), sizeof(c) - 1))
 
 #define zend_string_equals_literal(str, literal) \
-	((str)->len == sizeof(literal)-1 && !memcmp((str)->val, literal, sizeof(literal) - 1))
+	(ZSTR_LEN(str) == sizeof(literal)-1 && !memcmp(ZSTR_VAL(str), literal, sizeof(literal) - 1))
 
 /*
  * DJBX33A (Daniel J. Bernstein, Times 33 with Addition)
@@ -340,13 +391,13 @@ static zend_always_inline void zend_interned_empty_string_init(zend_string **s)
 	zend_string *str;
 
 	str = zend_string_alloc(sizeof("")-1, 1);
-	str->val[0] = '\000';
+	ZSTR_VAL(str)[0] = '\000';
 
 #ifndef ZTS
 	*s = zend_new_interned_string(str);
 #else
 	zend_string_hash_val(str);
-	str->gc.u.v.flags |= IS_STR_INTERNED;
+	(str)->_ZEND_PROTECTED_STRICT(zend_string,gc).u.v.flags |= IS_STR_INTERNED;
 	*s = str;
 #endif
 }

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -23,6 +23,7 @@
 #ifndef ZEND_TYPES_H
 #define ZEND_TYPES_H
 
+#include "zend_strict.h"
 #include "zend_portability.h"
 #include "zend_long.h"
 
@@ -147,10 +148,10 @@ struct _zend_refcounted {
 };
 
 struct _zend_string {
-	zend_refcounted   gc;
-	zend_ulong        h;                /* hash value */
-	size_t            len;
-	char              val[1];
+	zend_refcounted   _ZEND_PROTECTED_STRICT(zend_string,gc);
+	zend_ulong        _ZEND_PROTECTED_STRICT(zend_string,h);                /* hash value */
+	size_t            _ZEND_PROTECTED_STRICT(zend_string,len);
+	char              _ZEND_PROTECTED_STRICT(zend_string,val)[1];
 };
 
 typedef struct _Bucket {
@@ -495,13 +496,13 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_STR(zval)					(zval).value.str
 #define Z_STR_P(zval_p)				Z_STR(*(zval_p))
 
-#define Z_STRVAL(zval)				Z_STR(zval)->val
+#define Z_STRVAL(zval)				ZSTR_VAL(Z_STR(zval))
 #define Z_STRVAL_P(zval_p)			Z_STRVAL(*(zval_p))
 
-#define Z_STRLEN(zval)				Z_STR(zval)->len
+#define Z_STRLEN(zval)				ZSTR_LEN(Z_STR(zval))
 #define Z_STRLEN_P(zval_p)			Z_STRLEN(*(zval_p))
 
-#define Z_STRHASH(zval)				Z_STR(zval)->h
+#define Z_STRHASH(zval)				ZSTR_HASH(Z_STR(zval))
 #define Z_STRHASH_P(zval_p)			Z_STRHASH(*(zval_p))
 
 #define Z_ARR(zval)					(zval).value.arr

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -135,7 +135,7 @@ struct _zval_struct {
 };
 
 struct _zend_refcounted {
-	uint32_t         refcount;			/* reference counter 32-bit */
+	uint32_t         _ZEND_PROTECTED_STRICT(zend_refcounted,refcount);	/* reference counter 32-bit */
 	union {
 		struct {
 			ZEND_ENDIAN_LOHI_3(
@@ -144,7 +144,7 @@ struct _zend_refcounted {
 				uint16_t      gc_info)  /* keeps GC root number (or 0) and color */
 		} v;
 		uint32_t type_info;
-	} u;
+	} _ZEND_PROTECTED_STRICT(zend_refcounted,u);
 };
 
 struct _zend_string {
@@ -355,11 +355,11 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_TYPE_FLAGS_SHIFT			8
 #define Z_CONST_FLAGS_SHIFT			16
 
-#define GC_REFCOUNT(p)				((zend_refcounted*)(p))->refcount
-#define GC_TYPE(p)					((zend_refcounted*)(p))->u.v.type
-#define GC_FLAGS(p)					((zend_refcounted*)(p))->u.v.flags
-#define GC_INFO(p)					((zend_refcounted*)(p))->u.v.gc_info
-#define GC_TYPE_INFO(p)				((zend_refcounted*)(p))->u.type_info
+#define GC_REFCOUNT(p)				((zend_refcounted*)(p))->_ZEND_PROTECTED_STRICT(zend_refcounted,refcount)
+#define GC_TYPE(p)					((zend_refcounted*)(p))->_ZEND_PROTECTED_STRICT(zend_refcounted,u).v.type
+#define GC_FLAGS(p)					((zend_refcounted*)(p))->_ZEND_PROTECTED_STRICT(zend_refcounted,u).v.flags
+#define GC_INFO(p)					((zend_refcounted*)(p))->_ZEND_PROTECTED_STRICT(zend_refcounted,u).v.gc_info
+#define GC_TYPE_INFO(p)				((zend_refcounted*)(p))->_ZEND_PROTECTED_STRICT(zend_refcounted,u).type_info
 
 #define Z_GC_TYPE(zval)				GC_TYPE(Z_COUNTED(zval))
 #define Z_GC_TYPE_P(zval_p)			Z_GC_TYPE(*(zval_p))

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -38,6 +38,22 @@ dnl Find php-config script
 PHP_ARG_WITH(php-config,,
 [  --with-php-config=PATH  Path to php-config [php-config]], php-config, no)
 
+PHP_ARG_ENABLE(api-checks, whether to perform API compliance checks,
+[  --enable-api-checks        Perform API compliance checks], no, no)
+if test "$PHP_API_CHECKS" = "yes"; then
+  AC_DEFINE(ZEND_EXT_CHECK_API,1,[Perform API compliance checks])
+else
+  AC_DEFINE(ZEND_EXT_CHECK_API,0,[Perform API compliance checks])
+fi
+
+PHP_ARG_ENABLE(strict-api, whether to enforce strict API compliance,
+[  --enable-strict-api        Enforce strict API compliance], no, no)
+if test "$PHP_STRICT_API" = "yes"; then
+  AC_DEFINE(ZEND_EXT_STRICT_API,1,[Enforce strict API compliance])
+else
+  AC_DEFINE(ZEND_EXT_STRICT_API,0,[Enforce strict API compliance])
+fi
+
 dnl For BC
 PHP_CONFIG=$PHP_PHP_CONFIG
 prefix=`$PHP_CONFIG --prefix 2>/dev/null`

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -10,9 +10,15 @@ else
 	DEBUG="";
 fi
 ./buildconf --force
+
+API_CHECK_OPT=''
+./configure --help | grep -- --enable-api-checks >/dev/null \
+	&& API_CHECK_OPT="--enable-api-checks"
+
 ./configure --quiet \
 $DEBUG \
 $TS \
+$API_CHECK_OPT \
 --enable-phpdbg \
 --enable-fpm \
 --with-pdo-mysql=mysqlnd \


### PR DESCRIPTION
> This branch is under discussion. It is not ready for merging yet. So, please read below and comment.

# Introduction - Why ?

Two months ago, [Anthony Ferrara expressed concerns](http://t110602.php-development.phptalks.info/concern-around-growing-complexity-in-engine-hash-table-specifically-t110602.html) about PHP 7 and zend_hash growing complexity, combined with a lack of strict encapsulation (tight coupling).

Some replied that the solution is just a mix of comments and documentation, but growing complexity quickly becomes unmanageable if any code can bypass official/published APIs. zend_hash is a critical examples, but not the only one.

While part of the solution lies in documentation, 'quick-and-dirty' is not just a question of knowledge. We also need tools to detect and fix API violations.

# 1. Protecting structure elements from direct access #

The first tool focuses on the question of direct access to structure elements. Even if the API provides macros and functions to access structure elements, it is still possible to access them directly, bypassing the API. This tool provides a way to 'protect' the elements you want, so that directly accessing them ouside of the official API causes a compile failure.

> As we code in C, it will always be possible to access any address in memory. So, we can only provide alert and detection tools to help developers improve their code. Those who willingly bypass everything and respect no rule will have to be stopped by other means.

From a user's point it view, it takes the form of an additional configure option. When PHP is configured with '--enable-api-checks', every direct access to protected structure elements causes a compilation error.

>When the 'enable-api-checks' configure option is not set, the code is not modified and direct access to structure element is still possible. That's why it is implemented as an option.

How does it work ? When the 'api-checks' mode is active, the name of protected structure elements is modified and the official API is modified accordingly. Then, every attempt to access the element using its 'usual' name generates a compile error.

This is a compile-time tool. As it generates long and complex names for protected elements, the generated code shouldn't be used for debugging. So, among others, this option must never be set when generating binary releases.

Protecting structure elements is simple : everywhere the protected element is to be used, it is replaced with '_ZEND_PROTECTED(&lt;prefix>,&lt;name>)', where &lt;prefix> is the name of the structure containing the element, and &lt;name> is the element name.

In general, only the first-level elements need to be protected, as they control access to the sub-elements.

# 2. Separating getters and setters #

Encapsulation is composed of different levels. Providing an abstraction layer, like a macro, is the first level. The second level requires a strict separation of getter and setter methods. This level cannot be achieved with a macro because a macro can be used as an lvalue in an assignment, and can be prefixed with '&' (giving the address of the struct element). So, using a macro, it is impossible to control get and set operations. And controlling get/set operations is the key to loose coupling.

PHP APIs generally provide setter methods, but they also often use macros as getters. In order to allow for a gradual improvement, another configure option, '--enable-strict-api' activates some API restrictions. These restrictions are typically changing some getters from macro to function, making them de-facto read-only. Other restrictions may also be activated by this flag. The idea is that this 'strict' mode will become the default mode in a future PHP version. So, extension developers can use it to check in advance that their code complies with an API stricter than the current one.

For an example of how this mode is used, please look at the declaration of ZSTR_VAL/ZSTR_LEN/ZSTR_HASH in zend_string.h. As you may see, in strict mode, these macros are aliased to functions, making them pure getters. An important side effect is that Z_STRLEN() becomes a pure getter too. So, the code using assignments to a Z_STRLEN() lvalue must be modified to use the new ZVAL_STR_LEN() macro. That's just an example but it illustrates how a developer can make his code compliant with a future version of the API.

Of course, the core also needs to be strict-compliant. It will take time but the most important is that we now have the tools to work on it. That's why I would like these tools included in the first 7.0 release, so that we can start working with them and prepare the next minor versions.

# What's in this branch ? #

1. Implementation of the 'api-checks' and 'strict-api' configuration flags.

2. Implement a 'clean' API for zend_string. zend_string is critical, in this regard, because no API existed to access the len and val elements. So, the first step is to create this API, then protect in strict mode, to help people fix their code.

3. As an example, I also protected the 'zend_refcounted' structure. Look how the structure was modified, along with the GC_xxx() macros. Remember that, once we decide that this behavior switches from 'strict' to 'general', we just need to rename the _ZEND_PROTECTED_STRICT macros to _ZEND_PROTECTED.

I am stopping now because doing more would be useless and confusing as long as the mechanisms are not officially approved and merged. The next steps, when it is done, would be probably to provide a complete encapsulated API for most zval elements. We'll also work on HashTables. HashTables are critical as there are a lot of places in the core which access directly the HashTable elements, and this must absolutely be cleaned before it becomes unmanageable.