### PR TITLE
Fixed Bug #69874 : Can't set empty additional_headers for mail()

### DIFF
--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -225,7 +225,7 @@ static int php_mail_detect_multiple_crlf(char *hdr) {
 	/* This function detects multiple/malformed multiple newlines. */
 	size_t len;
 
-	if (!hdr) {
+	if (!hdr || !strlen(hdr)) {
 		return 0;
 	}
 
@@ -320,7 +320,7 @@ PHPAPI int php_mail(char *to, char *subject, char *message, char *headers, char 
 		efree(f);
 	}
 
-	if (hdr && strlen(hdr) && php_mail_detect_multiple_crlf(hdr)) {
+	if (hdr && php_mail_detect_multiple_crlf(hdr)) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Multiple or malformed newlines found in additional_header");
 		MAIL_RET(0);
 	}

--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -320,7 +320,7 @@ PHPAPI int php_mail(char *to, char *subject, char *message, char *headers, char 
 		efree(f);
 	}
 
-	if (hdr && php_mail_detect_multiple_crlf(hdr)) {
+	if (hdr && strlen(hdr) && php_mail_detect_multiple_crlf(hdr)) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Multiple or malformed newlines found in additional_header");
 		MAIL_RET(0);
 	}

--- a/ext/standard/tests/mail/bug69874.phpt
+++ b/ext/standard/tests/mail/bug69874.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Bug #69874: Null addtional_headers does not send mail
+--INI--
+sendmail_path=tee mailBasic.out >/dev/null
+mail.add_x_header = Off
+--SKIPIF--
+<?php
+if(substr(PHP_OS, 0, 3) == "WIN")
+  die("skip Won't run on Windows");
+?>
+--FILE--
+<?php
+/* Prototype  : int mail(string to, string subject, string message [, string additional_headers [, string additional_parameters]])
+ * Description: Send an email message
+ * Source code: ext/standard/mail.c
+ * Alias to functions:
+ */
+
+echo "*** Testing mail() : send email without additional headers ***\n";
+
+// Initialise all required variables
+$to = 'user@company.com';
+$subject = 'Test Subject';
+$message = 'A Message';
+
+$outFile = "mailBasic.out";
+@unlink($outFile);
+
+var_dump( mail($to, $subject, $message) );
+echo file_get_contents($outFile);
+unlink($outFile);
+
+?>
+===DONE===
+--EXPECTF--
+*** Testing mail() : send email without additional headers ***
+bool(true)
+To: user@company.com
+Subject: Test Subject
+
+A Message
+===DONE===


### PR DESCRIPTION
There was a null additional header bug test, but it enables mail.add_x_header which adds additional headers.
This PR fixes the bug and add test case for true null additional headers.