### PR TITLE
zend_string changes and additions

### DIFF
--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -93,6 +93,11 @@ static zend_always_inline uint32_t zend_string_delref(zend_string *s)
 	return 1;
 }
 
+static zend_always_inline zend_uchar zend_string_is_persistent(zend_string *s)
+{
+	return (GC_FLAGS(s) & IS_STR_PERSISTENT);
+}
+
 static zend_always_inline zend_string *zend_string_alloc(size_t len, int persistent)
 {
 	zend_string *ret = (zend_string *)pemalloc(ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), persistent);
@@ -163,6 +168,7 @@ static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_
 		if (EXPECTED(GC_REFCOUNT(s) == 1)) {
 			ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), persistent);
 			ret->len = len;
+			ret->val[len] = '\0';
 			zend_string_forget_hash_val(ret);
 			return ret;
 		} else {
@@ -170,7 +176,8 @@ static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_
 		}
 	}
 	ret = zend_string_alloc(len, persistent);
-	memcpy(ret->val, s->val, (len > s->len ? s->len : len) + 1);
+	memcpy(ret->val, s->val, MIN(len, s->len) + 1);
+	ret->val[len] = '\0';
 	return ret;
 }
 
@@ -203,6 +210,7 @@ static zend_always_inline zend_string *zend_string_truncate(zend_string *s, size
 		if (EXPECTED(GC_REFCOUNT(s) == 1)) {
 			ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), persistent);
 			ret->len = len;
+			ret->val[len] = '\0';
 			zend_string_forget_hash_val(ret);
 			return ret;
 		} else {
@@ -210,9 +218,54 @@ static zend_always_inline zend_string *zend_string_truncate(zend_string *s, size
 		}
 	}
 	ret = zend_string_alloc(len, persistent);
-	memcpy(ret->val, s->val, len + 1);
+	memcpy(ret->val, s->val, len);
+	ret->val[len] = '\0';
 	return ret;
 }
+
+static zend_always_inline zend_string *zend_string_resize(zend_string *s, size_t len)
+{
+	zend_string *ret;
+
+	if (!IS_INTERNED(s)) {
+		if (EXPECTED(GC_REFCOUNT(s) == 1)) {
+			ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), zend_string_is_persistent(s));
+			ret->len = len;
+			s->val[len] = '\0';
+			zend_string_forget_hash_val(ret);
+			return ret;
+		} else {
+			GC_REFCOUNT(s)--;
+		}
+	}
+	ret = zend_string_alloc(len, zend_string_is_persistent(s));
+	memcpy(ret->val, s->val, MIN(len, s->len));
+	ret->val[len] = '\0';
+	return ret;
+}
+
+static zend_always_inline zend_string *zend_string_append_buf_len(zend_string *s1, char *s2, size_t len2)
+{
+	ZEND_ASSERT(s1);
+	ZEND_ASSERT(s2);
+	s1 = zend_string_resize(s1, s1->len + len2);
+	memcpy(s1->val + s1->len - len2, s2, len2 + 1);
+	return s1;
+}	
+	
+static zend_always_inline zend_string *zend_string_append(zend_string *s1, zend_string *s2)
+{
+	ZEND_ASSERT(s1 != s2); // zend_string_append(s, s) is not supported
+	return zend_string_append_buf_len(s1, s2->val, s2->len);
+}	
+	
+static zend_always_inline zend_string *zend_string_append_buf(zend_string *s1, char *s2)
+{
+	return zend_string_append_buf_len(s1, s2, strlen(s2));
+}	
+
+#define zend_string_append_literal(_s1, _c) \
+	zend_string_append_buf_len(_s1, _c, sizeof(c) - 1);
 
 static zend_always_inline zend_string *zend_string_safe_realloc(zend_string *s, size_t n, size_t m, size_t l, int persistent)
 {
@@ -237,7 +290,7 @@ static zend_always_inline void zend_string_free(zend_string *s)
 {
 	if (!IS_INTERNED(s)) {
 		ZEND_ASSERT(GC_REFCOUNT(s) <= 1);
-		pefree(s, GC_FLAGS(s) & IS_STR_PERSISTENT);
+		pefree(s, zend_string_is_persistent(s));
 	}
 }
 
@@ -245,7 +298,7 @@ static zend_always_inline void zend_string_release(zend_string *s)
 {
 	if (!IS_INTERNED(s)) {
 		if (--GC_REFCOUNT(s) == 0) {
-			pefree(s, GC_FLAGS(s) & IS_STR_PERSISTENT);
+			pefree(s, zend_string_is_persistent(s));
 		}
 	}
 }

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -168,7 +168,6 @@ static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_
 		if (EXPECTED(GC_REFCOUNT(s) == 1)) {
 			ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), persistent);
 			ret->len = len;
-			ret->val[len] = '\0';
 			zend_string_forget_hash_val(ret);
 			return ret;
 		} else {
@@ -177,7 +176,6 @@ static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_
 	}
 	ret = zend_string_alloc(len, persistent);
 	memcpy(ret->val, s->val, MIN(len, s->len) + 1);
-	ret->val[len] = '\0';
 	return ret;
 }
 
@@ -210,7 +208,6 @@ static zend_always_inline zend_string *zend_string_truncate(zend_string *s, size
 		if (EXPECTED(GC_REFCOUNT(s) == 1)) {
 			ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_STR_HEADER_SIZE + len + 1), persistent);
 			ret->len = len;
-			ret->val[len] = '\0';
 			zend_string_forget_hash_val(ret);
 			return ret;
 		} else {
@@ -219,7 +216,6 @@ static zend_always_inline zend_string *zend_string_truncate(zend_string *s, size
 	}
 	ret = zend_string_alloc(len, persistent);
 	memcpy(ret->val, s->val, len);
-	ret->val[len] = '\0';
 	return ret;
 }
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -637,6 +637,11 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 		}												\
 	} while (0)
 
+#define ZVAL_STR_RESIZE(z, l) do {						\
+		zval *__z = (z);								\
+		Z_STR_P(__z) = zend_string_resize(Z_STR_P(__z), l); \
+	} while (0)
+
 #define ZVAL_ARR(z, a) do {						\
 		zval *__z = (z);						\
 		Z_ARR_P(__z) = (a);						\


### PR DESCRIPTION
> This PR initially proposed to suppress the 'persistent' argument of zend_string realloc/extend/truncate functions. As this would break already-ported extensions, we now propose additions only.

# Add zend_string_resize() function

This function is similar to zend_string_realloc() but doesn't take the 'persistent' arg, as a zend_string is always re-allocated in the memory space it was created in.

# Add a collection of zend_string_append() functions

These function allow to append to a zend_string from : 

* another zend_string,
* a pair (char *, len),
* a literal string,
* or a null-terminated string (using strlen()).

The 'append' functions are all based on zend_string_resize().

> I also fixed what I consider as a bug, as long as none gives me a good reason to do so : when trucating a string via zend_string_realloc() or zend_string_truncate(), the resulting string is not null-terminated.