### PR TITLE
LDAP cleaning - Stop using deprecated OpenLDAP functions

### DIFF
--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -92,7 +92,7 @@ PHP_ARG_WITH(ldap-sasl,for LDAP Cyrus SASL support,
 
 if test "$PHP_LDAP" != "no"; then
 
-  PHP_NEW_EXTENSION(ldap, ldap.c, $ext_shared,,)
+  PHP_NEW_EXTENSION(ldap, ldap.c, $ext_shared,,-DLDAP_DEPRECATED=1)
 
   if test "$PHP_LDAP" = "yes"; then
     for i in /usr/local /usr; do

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -58,7 +58,7 @@ AC_DEFUN([PHP_LDAP_SASL_CHECKS], [
       break
     fi
   done
-  
+
   if test "$LDAP_SASL_DIR"; then
     LDAP_SASL_INCDIR=$LDAP_SASL_DIR/include
     LDAP_SASL_LIBDIR=$LDAP_SASL_DIR/$PHP_LIBDIR
@@ -71,7 +71,7 @@ AC_DEFUN([PHP_LDAP_SASL_CHECKS], [
   else
     SASL_LIB="-L$LDAP_SASL_LIBDIR -lsasl2"
   fi
-  
+
   PHP_CHECK_LIBRARY(sasl2, sasl_version,
   [
     PHP_ADD_INCLUDE($LDAP_SASL_INCDIR)
@@ -92,7 +92,7 @@ PHP_ARG_WITH(ldap-sasl,for LDAP Cyrus SASL support,
 
 if test "$PHP_LDAP" != "no"; then
 
-  PHP_NEW_EXTENSION(ldap, ldap.c, $ext_shared,,-DLDAP_DEPRECATED=1)
+  PHP_NEW_EXTENSION(ldap, ldap.c, $ext_shared,,)
 
   if test "$PHP_LDAP" = "yes"; then
     for i in /usr/local /usr; do
@@ -125,7 +125,7 @@ if test "$PHP_LDAP" != "no"; then
     PHP_ADD_LIBRARY_WITH_PATH(ldap, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
 
   elif test -f $LDAP_LIBDIR/libssldap50.$SHLIB_SUFFIX_NAME; then
-    if test -n "$LDAP_PTHREAD"; then 
+    if test -n "$LDAP_PTHREAD"; then
       PHP_ADD_LIBRARY($LDAP_PTHREAD)
     fi
     PHP_ADD_LIBRARY_WITH_PATH(nspr4, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
@@ -138,7 +138,7 @@ if test "$PHP_LDAP" != "no"; then
     AC_DEFINE(HAVE_NSLDAP,1,[ ])
 
   elif test -f $LDAP_LIBDIR/libldapssl41.$SHLIB_SUFFIX_NAME; then
-    if test -n "$LDAP_PTHREAD"; then 
+    if test -n "$LDAP_PTHREAD"; then
       PHP_ADD_LIBRARY($LDAP_PTHREAD)
     fi
     PHP_ADD_LIBRARY_WITH_PATH(nspr3, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
@@ -148,14 +148,14 @@ if test "$PHP_LDAP" != "no"; then
     AC_DEFINE(HAVE_NSLDAP,1,[ ])
 
   elif test -f $LDAP_LIBDIR/libldapssl30.$SHLIB_SUFFIX_NAME; then
-    if test -n "$LDAP_PTHREAD"; then 
+    if test -n "$LDAP_PTHREAD"; then
       PHP_ADD_LIBRARY($LDAP_PTHREAD)
     fi
     PHP_ADD_LIBRARY_WITH_PATH(ldapssl30, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
     AC_DEFINE(HAVE_NSLDAP,1,[ ])
 
   elif test -f $LDAP_LIBDIR/libldap30.$SHLIB_SUFFIX_NAME; then
-    if test -n "$LDAP_PTHREAD"; then 
+    if test -n "$LDAP_PTHREAD"; then
       PHP_ADD_LIBRARY($LDAP_PTHREAD)
     fi
     PHP_ADD_LIBRARY_WITH_PATH(ldap30, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
@@ -187,7 +187,7 @@ if test "$PHP_LDAP" != "no"; then
   PHP_ADD_INCLUDE($LDAP_INCDIR)
   PHP_SUBST(LDAP_SHARED_LIBADD)
   AC_DEFINE(HAVE_LDAP,1,[ ])
-  
+
   dnl Save original values
   _SAVE_CPPFLAGS=$CPPFLAGS
   _SAVE_LIBS=$LIBS
@@ -205,7 +205,7 @@ if test "$PHP_LDAP" != "no"; then
   dnl Solaris 2.8 claims to be 2004 API, but doesn't have
   dnl ldap_parse_reference() nor ldap_start_tls_s()
   AC_CHECK_FUNCS([ldap_parse_result ldap_parse_reference ldap_start_tls_s])
-  
+
   dnl
   dnl SASL check
   dnl
@@ -215,12 +215,12 @@ if test "$PHP_LDAP" != "no"; then
 
   dnl
   dnl Sanity check
-  dnl 
+  dnl
   AC_CHECK_FUNC(ldap_bind_s, [], [
-    AC_MSG_ERROR([LDAP build check failed. Please check config.log for more information.]) 
+    AC_MSG_ERROR([LDAP build check failed. Please check config.log for more information.])
   ])
-  
+
   dnl Restore original values
   CPPFLAGS=$_SAVE_CPPFLAGS
   LIBS=$_SAVE_LIBS
-fi 
+fi

--- a/ext/ldap/config.w32
+++ b/ext/ldap/config.w32
@@ -21,7 +21,6 @@ if (PHP_LDAP != "no") {
 		AC_DEFINE('HAVE_LDAP', 1);
 		AC_DEFINE('HAVE_LDAP_SASL', 1);
 		AC_DEFINE('HAVE_LDAP_SASL_SASL_H', 1);
-		AC_DEFINE('LDAP_DEPRECATED', 1);
 
 	} else {
 		WARNING("ldap not enabled; libraries and headers not found");

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -72,7 +72,7 @@
 
 typedef struct {
 	LDAP *link;
-#if defined(LDAP_API_FEATURE_X_OPENLDAP) && defined(HAVE_3ARG_SETREBINDPROC)
+#if defined(HAVE_3ARG_SETREBINDPROC)
 	zval *rebindproc;
 #endif
 } ldap_linkdata;
@@ -98,7 +98,6 @@ static void _close_ldap_link(zend_rsrc_list_entry *rsrc TSRMLS_DC) /* {{{ */
 
 	/* ldap_unbind_s() is deprecated;
 	 * the distinction between ldap_unbind() and ldap_unbind_s() is moot */
-#ifdef LDAP_API_FEATURE_X_OPENLDAP
 	ldap_unbind_ext(ld->link, NULL, NULL);
 #ifdef HAVE_3ARG_SETREBINDPROC
 
@@ -107,9 +106,6 @@ static void _close_ldap_link(zend_rsrc_list_entry *rsrc TSRMLS_DC) /* {{{ */
 		FREE_ZVAL(ld->rebindproc);
 	}
 #endif
-#else /* ! LDAP_API_FEATURE_X_OPENLDAP */
-	ldap_unbind_s(ld->link);
-#endif /* ! LDAP_API_FEATURE_X_OPENLDAP */
 
 	efree(ld);
 	LDAPG(num_links)--;
@@ -310,13 +306,7 @@ PHP_FUNCTION(ldap_connect)
 {
 	char *host = NULL;
 	int hostlen;
-	long port =
-#ifdef LDAP_API_FEATURE_X_OPENLDAP
-	LDAP_PORT
-#else /* ! LDAP_API_FEATURE_X_OPENLDAP */
-	389 /* Default port */
-#endif /* ! LDAP_API_FEATURE_X_OPENLDAP */
-	;
+	long port = LDAP_PORT;
 #ifdef HAVE_ORALDAP
 	char *wallet = NULL, *walletpasswd = NULL;
 	int walletlen = 0, walletpasswdlen = 0;
@@ -351,7 +341,6 @@ PHP_FUNCTION(ldap_connect)
 
 	ld = ecalloc(1, sizeof(ldap_linkdata));
 
-#ifdef LDAP_API_FEATURE_X_OPENLDAP
 	/* OpenLDAP provides a specific call to detect valid LDAP URIs;
 	 * ldap_init()/ldap_open() is deprecated, use ldap_initialize() instead.
 	 */
@@ -380,9 +369,6 @@ PHP_FUNCTION(ldap_connect)
 			RETURN_FALSE;
 		}
 	}
-#else /* ! LDAP_API_FEATURE_X_OPENLDAP */
-	ldap = ldap_open(host, port);
-#endif /* ! LDAP_API_FEATURE_X_OPENLDAP */
 
 	if (ldap == NULL) {
 		efree(ld);
@@ -470,7 +456,6 @@ PHP_FUNCTION(ldap_bind)
 		RETURN_FALSE;
 	}
 
-#ifdef LDAP_API_FEATURE_X_OPENLDAP
 	{
 		struct berval   cred;
 
@@ -481,9 +466,6 @@ PHP_FUNCTION(ldap_bind)
 				NULL, NULL,     /* no controls right now */
 				NULL);	  /* we don't care about the server's credentials */
 	}
-#else
-	rc = ldap_bind_s(ld->link, ldap_bind_dn, ldap_bind_pw, LDAP_AUTH_SIMPLE);
-#endif
 	if ( rc != LDAP_SUCCESS) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to bind to server: %s", ldap_err2string(rc));
 		RETURN_FALSE;
@@ -1314,12 +1296,8 @@ PHP_FUNCTION(ldap_explode_dn)
 		add_index_string(return_value, i, ldap_value[i], 1);
 	}
 
-#ifdef LDAP_API_FEATURE_X_OPENLDAP
 	/* ldap_value_free() is deprecated */
 	ber_memvfree((void **)ldap_value);
-#else /* ! LDAP_API_FEATURE_X_OPENLDAP */
-	ldap_value_free(ldap_value);
-#endif /* ! LDAP_API_FEATURE_X_OPENLDAP */
 }
 /* }}} */
 
@@ -2495,7 +2473,7 @@ PHP_FUNCTION(ldap_start_tls)
 #endif
 #endif /* (LDAP_API_VERSION > 2000) || HAVE_NSLDAP || HAVE_ORALDAP */
 
-#if defined(LDAP_API_FEATURE_X_OPENLDAP) && defined(HAVE_3ARG_SETREBINDPROC)
+#if defined(HAVE_3ARG_SETREBINDPROC)
 /* {{{ _ldap_rebind_proc()
 */
 int _ldap_rebind_proc(LDAP *ldap, const char *url, ber_tag_t req, ber_int_t msgid, void *params)
@@ -2847,7 +2825,7 @@ PHP_FUNCTION(ldap_control_paged_result_response)
 		RETURN_FALSE;
 	}
 
-	lctrl = ldap_find_control(LDAP_CONTROL_PAGEDRESULTS, lserverctrls);
+	lctrl = ldap_control_find(LDAP_CONTROL_PAGEDRESULTS, lserverctrls, NULL);
 	if (lctrl == NULL) {
 		ldap_controls_free(lserverctrls);
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No paged results control response in result");
@@ -3148,7 +3126,7 @@ ZEND_END_ARG_INFO()
 #endif
 #endif
 
-#if defined(LDAP_API_FEATURE_X_OPENLDAP) && defined(HAVE_3ARG_SETREBINDPROC)
+#if defined(HAVE_3ARG_SETREBINDPROC)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ldap_set_rebind_proc, 0, 0, 2)
 	ZEND_ARG_INFO(0, link)
 	ZEND_ARG_INFO(0, callback)
@@ -3236,7 +3214,7 @@ const zend_function_entry ldap_functions[] = {
 #endif
 #endif
 
-#if defined(LDAP_API_FEATURE_X_OPENLDAP) && defined(HAVE_3ARG_SETREBINDPROC)
+#if defined(HAVE_3ARG_SETREBINDPROC)
 	PHP_FE(ldap_set_rebind_proc,						arginfo_ldap_set_rebind_proc)
 #endif
 

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -783,7 +783,7 @@ static void php_ldap_do_search(INTERNAL_FUNCTION_PARAMETERS, int scope)
 			php_set_opts(ld->link, ldap_sizelimit, ldap_timelimit, ldap_deref, &old_ldap_sizelimit, &old_ldap_timelimit, &old_ldap_deref);
 
 			/* Run the actual search */
-			rcs[i] = ldap_search(ld->link, ldap_base_dn, scope, ldap_filter, ldap_attrs, ldap_attrsonly);
+			ldap_search_ext(ld->link, ldap_base_dn, scope, ldap_filter, ldap_attrs, ldap_attrsonly, NULL, NULL, NULL, ldap_sizelimit, &rcs[i]);
 			lds[i] = ld;
 			zend_hash_move_forward(Z_ARRVAL_P(link));
 		}
@@ -825,7 +825,7 @@ cleanup_parallel:
 		php_set_opts(ld->link, ldap_sizelimit, ldap_timelimit, ldap_deref, &old_ldap_sizelimit, &old_ldap_timelimit, &old_ldap_deref);
 
 		/* Run the actual search */
-		errno = ldap_search_s(ld->link, ldap_base_dn, scope, ldap_filter, ldap_attrs, ldap_attrsonly, &ldap_res);
+		errno = ldap_search_ext_s(ld->link, ldap_base_dn, scope, ldap_filter, ldap_attrs, ldap_attrsonly, NULL, NULL, NULL, ldap_sizelimit, &ldap_res);
 
 		if (errno != LDAP_SUCCESS
 			&& errno != LDAP_SIZELIMIT_EXCEEDED
@@ -1297,7 +1297,7 @@ PHP_FUNCTION(ldap_explode_dn)
 	}
 
 	/* ldap_value_free() is deprecated */
-	ber_memvfree((void **)ldap_value);
+	ldap_memvfree((void **)ldap_value);
 }
 /* }}} */
 
@@ -1421,7 +1421,7 @@ static void php_ldap_do_modify(INTERNAL_FUNCTION_PARAMETERS, int oper)
 
 /* check flag to see if do_mod was called to perform full add , gerrit thomson */
 	if (is_full_add == 1) {
-		if ((i = ldap_add_s(ld->link, dn, ldap_mods)) != LDAP_SUCCESS) {
+		if ((i = ldap_add_ext_s(ld->link, dn, ldap_mods, NULL, NULL)) != LDAP_SUCCESS) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Add: %s", ldap_err2string(i));
 			RETVAL_FALSE;
 		} else RETVAL_TRUE;
@@ -1498,7 +1498,7 @@ PHP_FUNCTION(ldap_delete)
 
 	ZEND_FETCH_RESOURCE(ld, ldap_linkdata *, &link, -1, "ldap link", le_link);
 
-	if ((rc = ldap_delete_s(ld->link, dn)) != LDAP_SUCCESS) {
+	if ((rc = ldap_delete_ext_s(ld->link, dn, NULL, NULL)) != LDAP_SUCCESS) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Delete: %s", ldap_err2string(rc));
 		RETURN_FALSE;
 	}
@@ -1921,9 +1921,13 @@ PHP_FUNCTION(ldap_compare)
 		return;
 	}
 
+	struct berval lvalue;
+	lvalue.bv_val = value;
+	lvalue.bv_len = value_len;
+
 	ZEND_FETCH_RESOURCE(ld, ldap_linkdata *, &link, -1, "ldap link", le_link);
 
-	errno = ldap_compare_s(ld->link, dn, attr, value);
+	errno = ldap_compare_ext_s(ld->link, dn, attr, &lvalue, NULL, NULL);
 
 	switch (errno) {
 		case LDAP_COMPARE_TRUE:
@@ -2288,7 +2292,7 @@ PHP_FUNCTION(ldap_parse_result)
 					add_next_index_string(referrals, *refp, 1);
 					refp++;
 				}
-				ldap_value_free(lreferrals);
+				ldap_memvfree((void**)lreferrals);
 			}
 		case 5:
 			zval_dtor(errmsg);
@@ -2399,7 +2403,7 @@ PHP_FUNCTION(ldap_parse_reference)
 			add_next_index_string(referrals, *refp, 1);
 			refp++;
 		}
-		ldap_value_free(lreferrals);
+		ldap_memvfree((void**)lreferrals);
 	}
 	RETURN_TRUE;
 }


### PR DESCRIPTION
Hello,

I tried removing the -DLDAP_DEPRECATED=1 option of the build system and fix all warnings.
I also removed ifdefs as OpenLDAP >= 2.4 is the only implementation supported now.

The only warning left is about ldap_sort_entries which is deprecated, so if we want to keep ldap_sort in the PHP API we’ll have to implement that ourselves.