### PR TITLE
*[Sessions]: Now session is accessible if process is ran by root.

### DIFF
--- a/ext/session/mod_files.c
+++ b/ext/session/mod_files.c
@@ -188,8 +188,13 @@ static void ps_files_open(ps_files *data, const char *key TSRMLS_DC)
 		if (data->fd != -1) {
 #ifndef PHP_WIN32
 			/* check that this session file was created by us or root – we
-			   don't want to end up accepting the sessions of another webapp */
-			if (fstat(data->fd, &sbuf) || (sbuf.st_uid != 0 && sbuf.st_uid != getuid() && sbuf.st_uid != geteuid())) {
+			   don't want to end up accepting the sessions of another webapp
+
+			   If the process is ran by root, we ignore session file ownership
+			   Use case: session is initiated by Apache under non-root and then
+			   accessed by backend with root permissions to execute some system tasks.
+			   */
+			if (fstat(data->fd, &sbuf) || (sbuf.st_uid != 0 && sbuf.st_uid != getuid() && sbuf.st_uid != geteuid() && getuid() != 0)) {
 				close(data->fd);
 				data->fd = -1;
 				return;


### PR DESCRIPTION
Fixing bug: https://bugs.php.net/bug.php?id=69582

Use case: session is initiated by Apache with non-root permissions. Later on, session could be accessed by backend process, which runs under root, but needs to communicate with same session data as Apache process.

Didn't work before this commit: session file is owned by non-root, process owner != file owner, so this triggered file handle closure.