### PR TITLE
Allow exceptions in __toString()

### DIFF
--- a/Zend/tests/bug26166.phpt
+++ b/Zend/tests/bug26166.phpt
@@ -31,20 +31,18 @@ echo $o;
 
 echo "===NONE===\n";
 
-function my_error_handler($errno, $errstr, $errfile, $errline) {
-	var_dump($errstr);
-}
-
-set_error_handler('my_error_handler');
-
 class NoneTest
 {
 	function __toString() {
 	}
 }
 
-$o = new NoneTest;
-echo $o;
+try {
+    $o = new NoneTest;
+    echo $o;
+} catch (Error $e) {
+    echo $e, "\n";
+}
 
 echo "===THROW===\n";
 
@@ -68,7 +66,9 @@ catch (Exception $e) {
 --EXPECTF--
 Hello World!
 ===NONE===
-string(56) "Method NoneTest::__toString() must return a string value"
+Error: Method NoneTest::__toString() must return a string value in %s:%d
+Stack trace:
+#0 {main}
 ===THROW===
-
-Fatal error: Method ErrorTest::__toString() must not throw an exception in %sbug26166.php on line %d
+Got the exception
+===DONE===

--- a/Zend/tests/bug28444.phpt
+++ b/Zend/tests/bug28444.phpt
@@ -3,20 +3,17 @@ Bug #28444 (Cannot access undefined property for object with overloaded property
 --FILE--
 <?php
 
-function my_error_handler($errno, $errstr, $errfile, $errline) {
-	var_dump($errstr);
-}
-
-set_error_handler('my_error_handler');
-
 class Object
 {
 	public $x;
 
-	function __construct($x)
-	{
+	function __construct($x) {
 		$this->x = $x;
 	}
+
+    function __toString() {
+        return "Object";
+    }
 }
 
 class Overloaded
@@ -66,8 +63,7 @@ Overloaded::__set(y,3)
 int(3)
 Overloaded::__get(y)
 int(3)
-string(55) "Object of class Object could not be converted to string"
-Overloaded::__set(z,)
+Overloaded::__set(z,Object)
 object(Object)#%d (1) {
   ["x"]=>
   int(4)

--- a/Zend/tests/bug30791.phpt
+++ b/Zend/tests/bug30791.phpt
@@ -11,24 +11,23 @@ set_error_handler('my_error_handler');
 
 class a
 {
-   public $a = 4;
-   function __call($a,$b) {
-       return "unknown method";
-   }
+    public $a = 4;
+    function __call($name, $args) {
+        echo __METHOD__, "\n";
+    }
 }
 
 $b = new a;
-echo $b,"\n";
+var_dump($b);
 $c = unserialize(serialize($b));
-echo $c,"\n";
 var_dump($c);
 
 ?>
 --EXPECT--
-string(50) "Object of class a could not be converted to string"
-
-string(50) "Object of class a could not be converted to string"
-
+object(a)#1 (1) {
+  ["a"]=>
+  int(4)
+}
 object(a)#2 (1) {
   ["a"]=>
   int(4)

--- a/Zend/tests/bug60909_2.phpt
+++ b/Zend/tests/bug60909_2.phpt
@@ -14,7 +14,11 @@ class Bad {
 $bad = new Bad();
 echo "$bad";
 --EXPECTF--
-Fatal error: Method Bad::__toString() must not throw an exception in %sbug60909_2.php on line 0
+Fatal error: Uncaught Exception: Oops, I cannot do this in %s:%d
+Stack trace:
+#0 %s(%d): Bad->__toString()
+#1 {main}
+  thrown in %s on line %d
 
 
 !!!shutdown!!!

--- a/Zend/tests/call_with_refs.phpt
+++ b/Zend/tests/call_with_refs.phpt
@@ -2,16 +2,17 @@
 Check call to non-ref function with call-time refs
 --FILE--
 <?php
-function my_errorhandler($errno,$errormsg) {
-  global $my_var;
-  $my_var=0x12345;
-  echo $errormsg."\n";
-  return true;
+class Test {
+    public function __toString() {
+        global $my_var;
+        $my_var=0x12345;
+        return "";
+    }
 }
-$oldhandler = set_error_handler("my_errorhandler");
+
 $my_var = str_repeat("A",64);
-$data = call_user_func_array("substr_replace",array(&$my_var, new StdClass(),1));
+$data = call_user_func_array("substr_replace", array(&$my_var, new Test, 1));
 echo "OK!";
+?>
 --EXPECT--	
-Object of class stdClass could not be converted to string
 OK!

--- a/Zend/tests/class_properties_const.phpt
+++ b/Zend/tests/class_properties_const.phpt
@@ -22,4 +22,7 @@ NULL
 Notice: Undefined property: A::$1 in %sclass_properties_const.php on line %d
 NULL
 
-Catchable fatal error: Object of class Closure could not be converted to string in %sclass_properties_const.php on line %d
+Fatal error: Uncaught Error: Object of class Closure could not be converted to string in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/closure_015.phpt
+++ b/Zend/tests/closure_015.phpt
@@ -2,18 +2,18 @@
 Closure 015: converting to string/unicode
 --FILE--
 <?php
-set_error_handler('myErrorHandler', E_RECOVERABLE_ERROR);
-function myErrorHandler($errno, $errstr, $errfile, $errline) {
-  echo "Error: $errstr at $errfile($errline)\n";
-  return true;
-}
 $x = function() { return 1; };
-print (string) $x;
-print "\n";
-print $x;
-print "\n";
+try {
+    print (string) $x;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    print $x;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
---EXPECTF--
-Error: Object of class Closure could not be converted to string at %sclosure_015.php(8)
-
-Error: Object of class Closure could not be converted to string at %sclosure_015.php(10)
+--EXPECT--
+Object of class Closure could not be converted to string
+Object of class Closure could not be converted to string

--- a/Zend/tests/exception_009.phpt
+++ b/Zend/tests/exception_009.phpt
@@ -25,4 +25,8 @@ throw new my_exception;
 
 ?>
 --EXPECT--
-Catchable fatal error: Object of class stdClass could not be converted to string in Unknown on line 0
+Fatal error: Uncaught Error: Object of class stdClass could not be converted to string in [no active file]:0
+Stack trace:
+#0 [internal function]: Exception->__toString()
+#1 {main}
+  thrown in [no active file] on line 0

--- a/Zend/tests/exception_from_toString.phpt
+++ b/Zend/tests/exception_from_toString.phpt
@@ -1,0 +1,115 @@
+--TEST--
+Test exceptions thrown from __toString() in various contexts
+--FILE--
+<?php
+
+class BadStr {
+    public function __toString() {
+        throw new Exception("Exception");
+    }
+}
+
+$str = "a";
+$num = 42;
+$badStr = new BadStr;
+
+try { $x = $str . $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = $badStr . $str; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = $str .= $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($str); 
+try { $x = $num . $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = $badStr . $num; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = $num .= $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($num);
+
+try { $x = $badStr .= $str; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($badStr);
+try { $x = $badStr .= $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($badStr);
+
+try { $x = "x$badStr"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "{$badStr}x"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "$str$badStr"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "$badStr$str"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { $x = "x$badStr$str"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "x$str$badStr"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "{$str}x$badStr"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "{$badStr}x$str"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { $x = (string) $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { $x = include $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { echo $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+${""} = 42;
+try { unset(${$badStr}); }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump(${""});
+
+unset(${""});
+try { $x = ${$badStr}; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { $x = isset(${$badStr}); }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+$obj = new stdClass;
+try { $x = $obj->{$badStr} = $str; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($obj);
+
+?>
+--EXPECT--
+Exception
+Exception
+Exception
+string(1) "a"
+Exception
+Exception
+Exception
+int(42)
+Exception
+object(BadStr)#1 (0) {
+}
+Exception
+object(BadStr)#1 (0) {
+}
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+int(42)
+Exception
+Exception
+Exception
+object(stdClass)#2 (0) {
+}

--- a/Zend/tests/instanceof_001.phpt
+++ b/Zend/tests/instanceof_001.phpt
@@ -16,7 +16,11 @@ var_dump($c[0] instanceof stdClass);
 
 var_dump(@$inexistent instanceof stdClass);
 
-var_dump("$a" instanceof stdClass);
+try {
+    var_dump("$a" instanceof stdClass);
+} catch (Error $e) {
+    echo $e, "\n";
+}
 
 ?>
 --EXPECTF--
@@ -25,5 +29,6 @@ bool(true)
 bool(true)
 bool(true)
 bool(false)
-
-Catchable fatal error: Object of class stdClass could not be converted to string in %s on line %d
+Error: Object of class stdClass could not be converted to string in %s:%d
+Stack trace:
+#0 {main}

--- a/Zend/tests/unexpected_ref_bug.phpt
+++ b/Zend/tests/unexpected_ref_bug.phpt
@@ -2,16 +2,18 @@
 Crash when function parameter modified via unexpected reference
 --FILE--
 <?php
-function my_errorhandler($errno,$errormsg) {
-  global $my_var;
-  $my_var = 0;
-  return true;
+class Test {
+    public function __toString() {
+        global $my_var;
+        $my_var = 0;
+        return ",";
+    }
 }
-set_error_handler("my_errorhandler");
+
 $my_var = str_repeat("A",64);
-$data = call_user_func_array("explode",array(new StdClass(), &$my_var));
+$data = call_user_func_array("explode",array(new Test(), &$my_var));
 $my_var=array(1,2,3);
-$data = call_user_func_array("implode",array(&$my_var, new StdClass()));
+$data = call_user_func_array("implode",array(&$my_var, new Test()));
 echo "Done.\n";
 ?>
 --EXPECTF--

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3635,6 +3635,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INCLUDE_OR_EVAL_SPEC_CONST_HAN
 		}
 		ZVAL_STR(&tmp_inc_filename, zval_get_string(inc_filename));
 		inc_filename = &tmp_inc_filename;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp_inc_filename));
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (opline->extended_value != ZEND_EVAL && strlen(Z_STRVAL_P(inc_filename)) != Z_STRLEN_P(inc_filename)) {
@@ -5009,6 +5014,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			GET_OP1_UNDEF_CV(varname, BP_VAR_R);
 		}
 		name = zval_get_string(varname);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(name);
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_CONST != IS_UNUSED) {
@@ -5499,6 +5509,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CONST_CONST_H
 			GET_OP1_UNDEF_CV(op1, BP_VAR_R);
 		}
 		op1_str = _zval_get_string_func(op1);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(op1_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	op2 = EX_CONSTANT(opline->op2);
 	if (IS_CONST == IS_CONST) {
@@ -5510,6 +5524,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CONST_CONST_H
 			GET_OP2_UNDEF_CV(op2, BP_VAR_R);
 		}
 		op2_str = _zval_get_string_func(op2);
+		if (UNEXPECTED(EG(exception))) {
+			if (IS_CONST != IS_CONST) {
+				zend_string_release(op1_str);
+			}
+			zend_string_release(op2_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	do {
 		if (IS_CONST != IS_CONST) {
@@ -6204,6 +6225,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_CONST_CONST_HAN
 		}
 		ZVAL_STR(&tmp, zval_get_string(varname));
 		varname = &tmp;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp));
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_CONST != IS_UNUSED) {
@@ -6978,6 +7004,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			GET_OP1_UNDEF_CV(varname, BP_VAR_R);
 		}
 		name = zval_get_string(varname);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(name);
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_VAR != IS_UNUSED) {
@@ -7182,6 +7213,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_CONST_VAR_HANDL
 		}
 		ZVAL_STR(&tmp, zval_get_string(varname));
 		varname = &tmp;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp));
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_VAR != IS_UNUSED) {
@@ -7493,6 +7529,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			GET_OP1_UNDEF_CV(varname, BP_VAR_R);
 		}
 		name = zval_get_string(varname);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(name);
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_UNUSED != IS_UNUSED) {
@@ -8053,6 +8094,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_CONST_UNUSED_HA
 		}
 		ZVAL_STR(&tmp, zval_get_string(varname));
 		varname = &tmp;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp));
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_UNUSED != IS_UNUSED) {
@@ -9290,6 +9336,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CONST_CV_HAND
 			GET_OP1_UNDEF_CV(op1, BP_VAR_R);
 		}
 		op1_str = _zval_get_string_func(op1);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(op1_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	op2 = _get_zval_ptr_cv_undef(execute_data, opline->op2.var);
 	if (IS_CV == IS_CONST) {
@@ -9301,6 +9351,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CONST_CV_HAND
 			GET_OP2_UNDEF_CV(op2, BP_VAR_R);
 		}
 		op2_str = _zval_get_string_func(op2);
+		if (UNEXPECTED(EG(exception))) {
+			if (IS_CONST != IS_CONST) {
+				zend_string_release(op1_str);
+			}
+			zend_string_release(op2_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	do {
 		if (IS_CONST != IS_CONST) {
@@ -11125,6 +11182,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CONST_TMPVAR_
 			GET_OP1_UNDEF_CV(op1, BP_VAR_R);
 		}
 		op1_str = _zval_get_string_func(op1);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(op1_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	op2 = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -11136,6 +11197,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CONST_TMPVAR_
 			GET_OP2_UNDEF_CV(op2, BP_VAR_R);
 		}
 		op2_str = _zval_get_string_func(op2);
+		if (UNEXPECTED(EG(exception))) {
+			if (IS_CONST != IS_CONST) {
+				zend_string_release(op1_str);
+			}
+			zend_string_release(op2_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	do {
 		if (IS_CONST != IS_CONST) {
@@ -12975,8 +13043,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ROPE_ADD_SPEC_TMP_CONST_HANDLE
 				GET_OP2_UNDEF_CV(var, BP_VAR_R);
 			}
 			rope[opline->extended_value] = _zval_get_string_func(var);
+			if (UNEXPECTED(EG(exception))) {
+				uint32_t i;
+				for (i = 0; i <= opline->extended_value; ++i) {
+					zend_string_release(rope[i]);
+				}
+				HANDLE_EXCEPTION();
+			}
 
-			CHECK_EXCEPTION();
 		}
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -13010,8 +13084,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ROPE_END_SPEC_TMP_CONST_HANDLE
 				GET_OP2_UNDEF_CV(var, BP_VAR_R);
 			}
 			rope[opline->extended_value] = _zval_get_string_func(var);
+			if (UNEXPECTED(EG(exception))) {
+				uint32_t i;
+				for (i = 0; i <= opline->extended_value; ++i) {
+					zend_string_release(rope[i]);
+				}
+				HANDLE_EXCEPTION();
+			}
 
-			CHECK_EXCEPTION();
 		}
 	}
 	for (i = 0; i <= opline->extended_value; i++) {
@@ -14259,8 +14339,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ROPE_ADD_SPEC_TMP_CV_HANDLER(Z
 				GET_OP2_UNDEF_CV(var, BP_VAR_R);
 			}
 			rope[opline->extended_value] = _zval_get_string_func(var);
+			if (UNEXPECTED(EG(exception))) {
+				uint32_t i;
+				for (i = 0; i <= opline->extended_value; ++i) {
+					zend_string_release(rope[i]);
+				}
+				HANDLE_EXCEPTION();
+			}
 
-			CHECK_EXCEPTION();
 		}
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -14294,8 +14380,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ROPE_END_SPEC_TMP_CV_HANDLER(Z
 				GET_OP2_UNDEF_CV(var, BP_VAR_R);
 			}
 			rope[opline->extended_value] = _zval_get_string_func(var);
+			if (UNEXPECTED(EG(exception))) {
+				uint32_t i;
+				for (i = 0; i <= opline->extended_value; ++i) {
+					zend_string_release(rope[i]);
+				}
+				HANDLE_EXCEPTION();
+			}
 
-			CHECK_EXCEPTION();
 		}
 	}
 	for (i = 0; i <= opline->extended_value; i++) {
@@ -14772,8 +14864,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ROPE_ADD_SPEC_TMP_TMPVAR_HANDL
 				GET_OP2_UNDEF_CV(var, BP_VAR_R);
 			}
 			rope[opline->extended_value] = _zval_get_string_func(var);
+			if (UNEXPECTED(EG(exception))) {
+				uint32_t i;
+				for (i = 0; i <= opline->extended_value; ++i) {
+					zend_string_release(rope[i]);
+				}
+				HANDLE_EXCEPTION();
+			}
 			zval_ptr_dtor_nogc(free_op2);
-			CHECK_EXCEPTION();
 		}
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -14807,8 +14905,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ROPE_END_SPEC_TMP_TMPVAR_HANDL
 				GET_OP2_UNDEF_CV(var, BP_VAR_R);
 			}
 			rope[opline->extended_value] = _zval_get_string_func(var);
+			if (UNEXPECTED(EG(exception))) {
+				uint32_t i;
+				for (i = 0; i <= opline->extended_value; ++i) {
+					zend_string_release(rope[i]);
+				}
+				HANDLE_EXCEPTION();
+			}
 			zval_ptr_dtor_nogc(free_op2);
-			CHECK_EXCEPTION();
 		}
 	}
 	for (i = 0; i <= opline->extended_value; i++) {
@@ -16684,7 +16788,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_obj_helper_SP
 			SEPARATE_ZVAL_NOREF(zptr);
 
 			binary_op(zptr, zptr, value);
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), zptr);
 			}
 		} else {
@@ -16762,7 +16866,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -16802,7 +16906,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_helper_SPEC_V
 
 		binary_op(var_ptr, var_ptr, value);
 
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+		if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 			ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 		}
 	}
@@ -18895,7 +18999,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -19889,7 +19993,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_obj_helper_SP
 			SEPARATE_ZVAL_NOREF(zptr);
 
 			binary_op(zptr, zptr, value);
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), zptr);
 			}
 		} else {
@@ -19967,7 +20071,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -20007,7 +20111,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_helper_SPEC_V
 
 		binary_op(var_ptr, var_ptr, value);
 
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+		if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 			ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 		}
 	}
@@ -21553,7 +21657,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_obj_helper_SP
 			SEPARATE_ZVAL_NOREF(zptr);
 
 			binary_op(zptr, zptr, value);
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), zptr);
 			}
 		} else {
@@ -21631,7 +21735,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -21672,7 +21776,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_helper_SPEC_V
 
 		binary_op(var_ptr, var_ptr, value);
 
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+		if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 			ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 		}
 	}
@@ -23105,7 +23209,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_obj_helper_SP
 			SEPARATE_ZVAL_NOREF(zptr);
 
 			binary_op(zptr, zptr, value);
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), zptr);
 			}
 		} else {
@@ -23183,7 +23287,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -24995,7 +25099,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -25499,7 +25603,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_obj_helper_SP
 			SEPARATE_ZVAL_NOREF(zptr);
 
 			binary_op(zptr, zptr, value);
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), zptr);
 			}
 		} else {
@@ -25577,7 +25681,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -26987,7 +27091,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_obj_helper_SP
 			SEPARATE_ZVAL_NOREF(zptr);
 
 			binary_op(zptr, zptr, value);
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), zptr);
 			}
 		} else {
@@ -27065,7 +27169,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -29367,6 +29471,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INCLUDE_OR_EVAL_SPEC_CV_HANDLE
 		}
 		ZVAL_STR(&tmp_inc_filename, zval_get_string(inc_filename));
 		inc_filename = &tmp_inc_filename;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp_inc_filename));
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (opline->extended_value != ZEND_EVAL && strlen(Z_STRVAL_P(inc_filename)) != Z_STRLEN_P(inc_filename)) {
@@ -30749,7 +30858,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_obj_helper_SP
 			SEPARATE_ZVAL_NOREF(zptr);
 
 			binary_op(zptr, zptr, value);
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), zptr);
 			}
 		} else {
@@ -30827,7 +30936,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -30867,7 +30976,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_helper_SPEC_C
 
 		binary_op(var_ptr, var_ptr, value);
 
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+		if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 			ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 		}
 	}
@@ -31277,6 +31386,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			GET_OP1_UNDEF_CV(varname, BP_VAR_R);
 		}
 		name = zval_get_string(varname);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(name);
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_CONST != IS_UNUSED) {
@@ -32101,6 +32215,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CV_CONST_HAND
 			GET_OP1_UNDEF_CV(op1, BP_VAR_R);
 		}
 		op1_str = _zval_get_string_func(op1);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(op1_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	op2 = EX_CONSTANT(opline->op2);
 	if (IS_CONST == IS_CONST) {
@@ -32112,6 +32230,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CV_CONST_HAND
 			GET_OP2_UNDEF_CV(op2, BP_VAR_R);
 		}
 		op2_str = _zval_get_string_func(op2);
+		if (UNEXPECTED(EG(exception))) {
+			if (IS_CV != IS_CONST) {
+				zend_string_release(op1_str);
+			}
+			zend_string_release(op2_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	do {
 		if (IS_CV != IS_CONST) {
@@ -32508,6 +32633,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_CV_CONST_HANDLE
 		}
 		ZVAL_STR(&tmp, zval_get_string(varname));
 		varname = &tmp;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp));
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_CONST != IS_UNUSED) {
@@ -33550,6 +33680,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			GET_OP1_UNDEF_CV(varname, BP_VAR_R);
 		}
 		name = zval_get_string(varname);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(name);
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_VAR != IS_UNUSED) {
@@ -33844,6 +33979,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_CV_VAR_HANDLER(
 		}
 		ZVAL_STR(&tmp, zval_get_string(varname));
 		varname = &tmp;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp));
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_VAR != IS_UNUSED) {
@@ -34241,7 +34381,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -34496,6 +34636,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			GET_OP1_UNDEF_CV(varname, BP_VAR_R);
 		}
 		name = zval_get_string(varname);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(name);
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_UNUSED != IS_UNUSED) {
@@ -35077,6 +35222,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_CV_UNUSED_HANDL
 		}
 		ZVAL_STR(&tmp, zval_get_string(varname));
 		varname = &tmp;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp));
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_UNUSED != IS_UNUSED) {
@@ -36061,7 +36211,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_obj_helper_SP
 			SEPARATE_ZVAL_NOREF(zptr);
 
 			binary_op(zptr, zptr, value);
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), zptr);
 			}
 		} else {
@@ -36139,7 +36289,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -36179,7 +36329,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_helper_SPEC_C
 
 		binary_op(var_ptr, var_ptr, value);
 
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+		if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 			ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 		}
 	}
@@ -37241,6 +37391,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CV_CV_HANDLER
 			GET_OP1_UNDEF_CV(op1, BP_VAR_R);
 		}
 		op1_str = _zval_get_string_func(op1);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(op1_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	op2 = _get_zval_ptr_cv_undef(execute_data, opline->op2.var);
 	if (IS_CV == IS_CONST) {
@@ -37252,6 +37406,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CV_CV_HANDLER
 			GET_OP2_UNDEF_CV(op2, BP_VAR_R);
 		}
 		op2_str = _zval_get_string_func(op2);
+		if (UNEXPECTED(EG(exception))) {
+			if (IS_CV != IS_CONST) {
+				zend_string_release(op1_str);
+			}
+			zend_string_release(op2_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	do {
 		if (IS_CV != IS_CONST) {
@@ -38752,7 +38913,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_obj_helper_SP
 			SEPARATE_ZVAL_NOREF(zptr);
 
 			binary_op(zptr, zptr, value);
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), zptr);
 			}
 		} else {
@@ -38830,7 +38991,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_dim_helper_SP
 
 			binary_op(var_ptr, var_ptr, value);
 
-			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 			}
 		}
@@ -38871,7 +39032,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_binary_assign_op_helper_SPEC_C
 
 		binary_op(var_ptr, var_ptr, value);
 
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+		if (UNEXPECTED(RETURN_VALUE_USED(opline) && !EG(exception))) {
 			ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 		}
 	}
@@ -39849,6 +40010,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CV_TMPVAR_HAN
 			GET_OP1_UNDEF_CV(op1, BP_VAR_R);
 		}
 		op1_str = _zval_get_string_func(op1);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(op1_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	op2 = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -39860,6 +40025,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_CV_TMPVAR_HAN
 			GET_OP2_UNDEF_CV(op2, BP_VAR_R);
 		}
 		op2_str = _zval_get_string_func(op2);
+		if (UNEXPECTED(EG(exception))) {
+			if (IS_CV != IS_CONST) {
+				zend_string_release(op1_str);
+			}
+			zend_string_release(op2_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	do {
 		if (IS_CV != IS_CONST) {
@@ -40989,6 +41161,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INCLUDE_OR_EVAL_SPEC_TMPVAR_HA
 		}
 		ZVAL_STR(&tmp_inc_filename, zval_get_string(inc_filename));
 		inc_filename = &tmp_inc_filename;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp_inc_filename));
+			zval_ptr_dtor_nogc(free_op1);
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (opline->extended_value != ZEND_EVAL && strlen(Z_STRVAL_P(inc_filename)) != Z_STRLEN_P(inc_filename)) {
@@ -41799,6 +41976,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			GET_OP1_UNDEF_CV(varname, BP_VAR_R);
 		}
 		name = zval_get_string(varname);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(name);
+			zval_ptr_dtor_nogc(free_op1);
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_CONST != IS_UNUSED) {
@@ -42131,6 +42313,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_TMPVAR_CONST_
 			GET_OP1_UNDEF_CV(op1, BP_VAR_R);
 		}
 		op1_str = _zval_get_string_func(op1);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(op1_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	op2 = EX_CONSTANT(opline->op2);
 	if (IS_CONST == IS_CONST) {
@@ -42142,6 +42328,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_TMPVAR_CONST_
 			GET_OP2_UNDEF_CV(op2, BP_VAR_R);
 		}
 		op2_str = _zval_get_string_func(op2);
+		if (UNEXPECTED(EG(exception))) {
+			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
+				zend_string_release(op1_str);
+			}
+			zend_string_release(op2_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	do {
 		if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
@@ -42408,6 +42601,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_TMPVAR_CONST_HA
 		}
 		ZVAL_STR(&tmp, zval_get_string(varname));
 		varname = &tmp;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp));
+			zval_ptr_dtor_nogc(free_op1);
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_CONST != IS_UNUSED) {
@@ -42827,6 +43025,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			GET_OP1_UNDEF_CV(varname, BP_VAR_R);
 		}
 		name = zval_get_string(varname);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(name);
+			zval_ptr_dtor_nogc(free_op1);
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_VAR != IS_UNUSED) {
@@ -43032,6 +43235,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_TMPVAR_VAR_HAND
 		}
 		ZVAL_STR(&tmp, zval_get_string(varname));
 		varname = &tmp;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp));
+			zval_ptr_dtor_nogc(free_op1);
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_VAR != IS_UNUSED) {
@@ -43250,6 +43458,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			GET_OP1_UNDEF_CV(varname, BP_VAR_R);
 		}
 		name = zval_get_string(varname);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(name);
+			zval_ptr_dtor_nogc(free_op1);
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_UNUSED != IS_UNUSED) {
@@ -43455,6 +43668,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_TMPVAR_UNUSED_H
 		}
 		ZVAL_STR(&tmp, zval_get_string(varname));
 		varname = &tmp;
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(Z_STR(tmp));
+			zval_ptr_dtor_nogc(free_op1);
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	if (IS_UNUSED != IS_UNUSED) {
@@ -44328,6 +44546,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_TMPVAR_CV_HAN
 			GET_OP1_UNDEF_CV(op1, BP_VAR_R);
 		}
 		op1_str = _zval_get_string_func(op1);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(op1_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	op2 = _get_zval_ptr_cv_undef(execute_data, opline->op2.var);
 	if (IS_CV == IS_CONST) {
@@ -44339,6 +44561,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_TMPVAR_CV_HAN
 			GET_OP2_UNDEF_CV(op2, BP_VAR_R);
 		}
 		op2_str = _zval_get_string_func(op2);
+		if (UNEXPECTED(EG(exception))) {
+			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
+				zend_string_release(op1_str);
+			}
+			zend_string_release(op2_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	do {
 		if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
@@ -45492,6 +45721,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_TMPVAR_TMPVAR
 			GET_OP1_UNDEF_CV(op1, BP_VAR_R);
 		}
 		op1_str = _zval_get_string_func(op1);
+		if (UNEXPECTED(EG(exception))) {
+			zend_string_release(op1_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	op2 = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -45503,6 +45736,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CONCAT_SPEC_TMPVAR_TMPVAR
 			GET_OP2_UNDEF_CV(op2, BP_VAR_R);
 		}
 		op2_str = _zval_get_string_func(op2);
+		if (UNEXPECTED(EG(exception))) {
+			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
+				zend_string_release(op1_str);
+			}
+			zend_string_release(op2_str);
+			HANDLE_EXCEPTION();
+		}
 	}
 	do {
 		if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {

--- a/ext/openssl/tests/003.phpt
+++ b/ext/openssl/tests/003.phpt
@@ -15,7 +15,11 @@ $b = 1;
 $c = new stdclass; 
 $d = new stdclass; 
 
-var_dump(openssl_pkcs7_decrypt($a, $b, $c, $d));
+try {
+    var_dump(openssl_pkcs7_decrypt($a, $b, $c, $d));
+} catch (Error $e) {
+    var_dump($e->getMessage());
+}
 var_dump($c);
 
 var_dump(openssl_pkcs7_decrypt($b, $b, $b, $b));
@@ -27,8 +31,6 @@ echo "Done\n";
 ?>
 --EXPECTF--	
 string(57) "Object of class stdClass could not be converted to string"
-string(66) "openssl_pkcs7_decrypt(): unable to coerce parameter 3 to x509 cert"
-bool(false)
 object(stdClass)#1 (0) {
 }
 string(66) "openssl_pkcs7_decrypt(): unable to coerce parameter 3 to x509 cert"

--- a/ext/openssl/tests/bug38261.phpt
+++ b/ext/openssl/tests/bug38261.phpt
@@ -31,4 +31,8 @@ Warning: openssl_x509_parse() expects at least 1 parameter, 0 given in %sbug3826
 NULL
 bool(false)
 
-Catchable fatal error: Object of class stdClass could not be converted to string in %sbug38261.php on line %d 
+Fatal error: Uncaught Error: Object of class stdClass could not be converted to string in %s:%d
+Stack trace:
+#0 %s(%d): openssl_x509_parse(Object(stdClass))
+#1 {main}
+  thrown in %s on line %d

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -1432,6 +1432,11 @@ static int preg_replace_impl(zval *return_value, zval *regex, zval *replace, zva
 		convert_to_string_ex(regex);
 	}
 
+	/* Exception during to string conversion, abort */
+	if (UNEXPECTED(EG(exception))) {
+		return 0;
+	}
+
 	/* if subject is an array */
 	if (Z_TYPE_P(subject) == IS_ARRAY) {
 		array_init_size(return_value, zend_hash_num_elements(Z_ARRVAL_P(subject)));

--- a/ext/pcre/tests/preg_replace_error1.phpt
+++ b/ext/pcre/tests/preg_replace_error1.phpt
@@ -55,5 +55,9 @@ string(1) "a"
 Arg value is /[a-zA-Z]/
 string(1) "1"
 
-Catchable fatal error: Object of class stdClass could not be converted to string in %spreg_replace_error1.php on line %d
+Fatal error: Uncaught Error: Object of class stdClass could not be converted to string in %s:%d
+Stack trace:
+#0 %s(%d): preg_replace(Object(stdClass), '1', 'a')
+#1 {main}
+  thrown in %s on line %d
 

--- a/ext/pcre/tests/preg_replace_error2.phpt
+++ b/ext/pcre/tests/preg_replace_error2.phpt
@@ -33,5 +33,8 @@ Arg value is: Array
 Warning: preg_replace(): Parameter mismatch, pattern is a string while replacement is an array in %spreg_replace_error2.php on line %d
 bool(false)
 
-Catchable fatal error: Object of class stdClass could not be converted to string in %spreg_replace_error2.php on line %d
-
+Fatal error: Uncaught Error: Object of class stdClass could not be converted to string in %s:%d
+Stack trace:
+#0 %s(%d): preg_replace('/[a-zA-Z]/', Object(stdClass), 'test')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/posix/tests/posix_getgrgid_variation.phpt
+++ b/ext/posix/tests/posix_getgrgid_variation.phpt
@@ -61,9 +61,6 @@ $values = array(
 
       // unset data
       $unset_var,
-
-      // object data
-      new stdclass(),
 );
 
 // loop through each element of the array for gid
@@ -184,5 +181,4 @@ valid output
 
 Arg value  
 valid output
-
-Catchable fatal error: Object of class stdClass could not be converted to string in %s on line %d
+Done

--- a/ext/posix/tests/posix_getpgid_variation.phpt
+++ b/ext/posix/tests/posix_getpgid_variation.phpt
@@ -63,9 +63,6 @@ $values = array(
 
       // unset data
       $unset_var,
-      
-      // object data
-      new stdclass(),
 );
 
 // loop through each element of the array for gid
@@ -184,5 +181,4 @@ valid output
 
 Arg value  
 valid output
-
-Catchable fatal error: Object of class stdClass could not be converted to string in %s on line %d
+Done

--- a/ext/posix/tests/posix_getpwuid_variation.phpt
+++ b/ext/posix/tests/posix_getpwuid_variation.phpt
@@ -61,9 +61,6 @@ $values = array(
 
       // unset data
       $unset_var,
-      
-      // object data
-      new stdclass(),
 );
 
 // loop through each element of the array for uid
@@ -184,5 +181,4 @@ valid output
 
 Arg value  
 valid output
-
-Catchable fatal error: Object of class stdClass could not be converted to string in %s on line %d
+Done

--- a/ext/posix/tests/posix_kill_variation1.phpt
+++ b/ext/posix/tests/posix_kill_variation1.phpt
@@ -62,9 +62,6 @@ $values = array(
 
       // unset data
       $unset_var,
-      
-      // object data
-      new stdclass(),
 );
 
 // loop through each element of the array for pid
@@ -178,5 +175,4 @@ bool(false)
 
 Arg value  
 bool(false)
-
-Catchable fatal error: Object of class stdClass could not be converted to string in %s on line %d
+Done

--- a/ext/posix/tests/posix_kill_variation2.phpt
+++ b/ext/posix/tests/posix_kill_variation2.phpt
@@ -62,9 +62,6 @@ $values = array(
 
       // unset data
       $unset_var,
-      
-      // object data
-      new stdclass(),
 );
 
 // loop through each element of the array for sig
@@ -178,5 +175,4 @@ bool(false)
 
 Arg value  
 bool(false)
-
-Catchable fatal error: Object of class stdClass could not be converted to string in %s on line %d
+Done

--- a/ext/posix/tests/posix_strerror_variation1.phpt
+++ b/ext/posix/tests/posix_strerror_variation1.phpt
@@ -61,9 +61,6 @@ $values = array(
 
       // unset data
       $unset_var,
-      
-      // object data
-      new stdclass(),
 );
 
 // loop through each element of the array for errno
@@ -177,5 +174,4 @@ string
 
 Arg value  
 string
-
-Catchable fatal error: Object of class stdClass could not be converted to string in %s on line %d
+Done

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -1057,13 +1057,9 @@ static void spl_recursive_tree_iterator_get_entry(spl_recursive_it_object *objec
 {
 	zend_object_iterator      *iterator = object->iterators[object->level].iterator;
 	zval                      *data;
-	zend_error_handling        error_handling;
 
 	data = iterator->funcs->get_current_data(iterator);
 
-	/* Replace exception handling so the catchable fatal error that is thrown when a class
-	 * without __toString is converted to string is converted into an exception. */
-	zend_replace_error_handling(EH_THROW, spl_ce_UnexpectedValueException, &error_handling);
 	if (data) {
 		ZVAL_DEREF(data);
 		if (Z_TYPE_P(data) == IS_ARRAY) {
@@ -1073,7 +1069,6 @@ static void spl_recursive_tree_iterator_get_entry(spl_recursive_it_object *objec
 			convert_to_string(return_value);
 		}
 	}
-	zend_restore_error_handling(&error_handling);
 }
 
 static void spl_recursive_tree_iterator_get_postfix(spl_recursive_it_object *object, zval *return_value)

--- a/ext/spl/tests/iterator_036.phpt
+++ b/ext/spl/tests/iterator_036.phpt
@@ -19,4 +19,9 @@ test(new CachingIterator($ar, 0));
 ===DONE===
 --EXPECTF--	
 
-Fatal error: Method CachingIterator::__toString() must not throw an exception in %siterator_036.php on line %d
+Fatal error: Uncaught BadMethodCallException: CachingIterator does not fetch string value (see CachingIterator::__construct) in %s:%d
+Stack trace:
+#0 %s(%d): CachingIterator->__toString()
+#1 %s(%d): test(Object(CachingIterator))
+#2 {main}
+  thrown in %s on line %d

--- a/ext/spl/tests/recursive_tree_iterator_007.phpt
+++ b/ext/spl/tests/recursive_tree_iterator_007.phpt
@@ -22,12 +22,12 @@ try {
 	foreach(new RecursiveTreeIterator($it) as $k => $v) {
 		echo "[$k] => $v\n";
 	}
-} catch (UnexpectedValueException $e) {
-	echo "UnexpectedValueException thrown\n";
+} catch (Throwable $e) {
+	echo get_class($e) . " thrown\n";
 }
 
 ?>
 ===DONE===
 --EXPECTF--
-UnexpectedValueException thrown
+Error thrown
 ===DONE===

--- a/ext/standard/tests/array/array_multisort_variation8.phpt
+++ b/ext/standard/tests/array/array_multisort_variation8.phpt
@@ -34,7 +34,6 @@ $inputs = array(
       'empty string DQ' => "",
       'string DQ' => "string",
       'instance of classWithToString' => new classWithToString(),
-      'instance of classWithoutToString' => new classWithoutToString(),
       'undefined var' => @$undefined_var,
 );
 
@@ -46,16 +45,13 @@ var_dump($inputs);
 --EXPECTF--
 *** Testing array_multisort() : usage variation  - test sort order of all types***
 bool(true)
-array(10) {
-  ["empty string DQ"]=>
-  string(0) ""
+array(9) {
   ["uppercase NULL"]=>
   NULL
+  ["empty string DQ"]=>
+  string(0) ""
   ["undefined var"]=>
   NULL
-  ["instance of classWithoutToString"]=>
-  object(classWithoutToString)#2 (0) {
-  }
   ["float -10.5"]=>
   float(-10.5)
   ["int 0"]=>

--- a/ext/standard/tests/class_object/class_exists_variation_001.phpt
+++ b/ext/standard/tests/class_object/class_exists_variation_001.phpt
@@ -76,7 +76,7 @@ $values = array(
 // loop through each element of the array for classname
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( class_exists($value, $autoload) );
 };
 
@@ -168,9 +168,8 @@ bool(false)
 
 Arg value  
 bool(false)
-Error: 4096 - Object of class stdClass could not be converted to string, %s(76)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - class_exists() expects parameter 1 to be string, object given, %s(77)
 NULL
 

--- a/ext/standard/tests/class_object/class_exists_variation_002.phpt
+++ b/ext/standard/tests/class_object/class_exists_variation_002.phpt
@@ -80,7 +80,7 @@ $values = array(
 // loop through each element of the array for autoload
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( class_exists($classname, $value) );
 };
 
@@ -184,9 +184,8 @@ bool(false)
 Arg value string 
 In __autoload(string_val)
 bool(false)
-Error: 4096 - Object of class stdClass could not be converted to string, %s(80)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - class_exists() expects parameter 2 to be boolean, object given, %s(81)
 NULL
 

--- a/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
+++ b/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
@@ -76,7 +76,7 @@ $values = array(
 // loop through each element of the array for class
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( get_class_methods($value) );
 };
 
@@ -163,9 +163,8 @@ NULL
 
 Arg value string 
 NULL
-Error: 4096 - Object of class stdClass could not be converted to string, %s(76)
 
-Arg value  
+Arg value stdClass 
 array(0) {
 }
 

--- a/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
+++ b/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
@@ -77,7 +77,7 @@ $values = array(
 // loop through each element of the array for object
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( get_parent_class($value) );
 };
 
@@ -166,9 +166,8 @@ bool(false)
 Arg value String 
 In __autoload(String)
 bool(false)
-Error: 4096 - Object of class stdClass could not be converted to string, %s(77)
 
-Arg value  
+Arg value stdClass 
 bool(false)
 
 Arg value  

--- a/ext/standard/tests/class_object/is_subclass_of_variation_002.phpt
+++ b/ext/standard/tests/class_object/is_subclass_of_variation_002.phpt
@@ -76,7 +76,7 @@ $values = array(
 // loop through each element of the array for class_name
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( is_subclass_of($object, $value) );
 };
 
@@ -162,9 +162,8 @@ bool(false)
 
 Arg value  
 bool(false)
-Error: 4096 - Object of class stdClass could not be converted to string, %s(%d)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - is_subclass_of() expects parameter 2 to be string, object given, %s(%d)
 NULL
 

--- a/ext/standard/tests/class_object/method_exists_variation_002.phpt
+++ b/ext/standard/tests/class_object/method_exists_variation_002.phpt
@@ -76,7 +76,7 @@ $values = array(
 // loop through each element of the array for method
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( method_exists($object, $value) );
 };
 
@@ -162,9 +162,8 @@ bool(false)
 
 Arg value  
 bool(false)
-Error: 4096 - Object of class stdClass could not be converted to string, %s(76)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - method_exists() expects parameter 2 to be string, object given, %s(77)
 NULL
 

--- a/ext/standard/tests/class_object/trait_exists_variation_001.phpt
+++ b/ext/standard/tests/class_object/trait_exists_variation_001.phpt
@@ -76,7 +76,7 @@ $values = array(
 // loop through each element of the array for traitname
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( trait_exists($value, $autoload) );
 };
 
@@ -168,9 +168,8 @@ bool(false)
 
 Arg value  
 bool(false)
-Error: 4096 - Object of class stdClass could not be converted to string, %s(76)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - trait_exists() expects parameter 1 to be string, object given, %s(77)
 NULL
 

--- a/ext/standard/tests/class_object/trait_exists_variation_002.phpt
+++ b/ext/standard/tests/class_object/trait_exists_variation_002.phpt
@@ -80,7 +80,7 @@ $values = array(
 // loop through each element of the array for autoload
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( trait_exists($traitname, $value) );
 };
 
@@ -184,9 +184,8 @@ bool(false)
 Arg value string 
 In __autoload(string_val)
 bool(false)
-Error: 4096 - Object of class stdClass could not be converted to string, %s(80)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - trait_exists() expects parameter 2 to be boolean, object given, %s(81)
 NULL
 

--- a/ext/standard/tests/general_functions/type.phpt
+++ b/ext/standard/tests/general_functions/type.phpt
@@ -47,7 +47,11 @@ foreach ($array as $var) {
 
 foreach ($types as $type) {
 	foreach ($array as $var) {
-		var_dump(settype($var, $type));
+        try {
+            var_dump(settype($var, $type));
+        } catch (Error $e) {
+            echo "Error: ", $e->getMessage(), "\n";
+        }
 		var_dump($var);
 	}
 }
@@ -344,7 +348,6 @@ bool(true)
 string(14) "Resource id #%d"
 bool(true)
 string(14) "Resource id #%d"
-string(57) "Object of class stdClass could not be converted to string"
-bool(true)
-string(6) "Object"
+Error: Object of class stdClass could not be converted to string
+string(0) ""
 Done

--- a/ext/standard/tests/math/base_convert_error.phpt
+++ b/ext/standard/tests/math/base_convert_error.phpt
@@ -22,7 +22,11 @@ base_convert(1234, 1, 10);
 base_convert(1234, 10, 37);
 
 echo "Incorrect input\n";
-base_convert(new classA(), 8, 10);
+try {
+    base_convert(new classA(), 8, 10);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
 --EXPECTF--
@@ -39,5 +43,4 @@ Warning: base_convert(): Invalid `from base' (1) in %s on line %d
 
 Warning: base_convert(): Invalid `to base' (37) in %s on line %s
 Incorrect input
-
-Catchable fatal error: Object of class classA could not be converted to string in %s on line %d
+Object of class classA could not be converted to string

--- a/ext/standard/tests/math/bindec_error.phpt
+++ b/ext/standard/tests/math/bindec_error.phpt
@@ -23,7 +23,11 @@ bindec();
 bindec('01010101111',true);
 
 echo "Incorrect input\n";
-bindec(new classA());
+try {
+    bindec(new classA());
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECTF--
 *** Testing bindec() : error conditions ***
@@ -33,5 +37,4 @@ Warning: bindec() expects exactly 1 parameter, 0 given in %s on line %d
 
 Warning: bindec() expects exactly 1 parameter, 2 given in %s on line %d
 Incorrect input
-
-Catchable fatal error: Object of class classA could not be converted to string in %s on line %d
+Object of class classA could not be converted to string

--- a/ext/standard/tests/math/hexdec_error.phpt
+++ b/ext/standard/tests/math/hexdec_error.phpt
@@ -19,7 +19,11 @@ hexdec();
 hexdec('0x123abc',true);
 
 echo "\n-- Incorrect input --\n";
-hexdec(new classA());
+try {
+    hexdec(new classA());
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
 --EXPECTF--
@@ -32,5 +36,4 @@ Warning: hexdec() expects exactly 1 parameter, 0 given in %s on line %d
 Warning: hexdec() expects exactly 1 parameter, 2 given in %s on line %d
 
 -- Incorrect input --
-
-Catchable fatal error: Object of class classA could not be converted to string in %s on line %d
+Object of class classA could not be converted to string

--- a/ext/standard/tests/math/octdec_error.phpt
+++ b/ext/standard/tests/math/octdec_error.phpt
@@ -19,8 +19,11 @@ octdec();
 octdec('0123567',true);
 
 echo "\n-- Incorrect input --\n";
-octdec(new classA());
-
+try {
+    octdec(new classA());
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
 --EXPECTF--
@@ -33,5 +36,4 @@ Warning: octdec() expects exactly 1 parameter, 0 given in %s on line %d
 Warning: octdec() expects exactly 1 parameter, 2 given in %s on line %d
 
 -- Incorrect input --
-
-Catchable fatal error: Object of class classA could not be converted to string in %s on line %d
+Object of class classA could not be converted to string

--- a/ext/standard/tests/streams/bug61115.phpt
+++ b/ext/standard/tests/streams/bug61115.phpt
@@ -7,7 +7,11 @@ $arrayLarge = array_fill(0, 113663, '*');
 
 $resourceFileTemp = fopen('php://temp', 'r+');
 stream_context_set_params($resourceFileTemp, array());
-preg_replace('', function() {}, $resourceFileTemp);
+try {
+    preg_replace('', function() {}, $resourceFileTemp);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECTF--
-Catchable fatal error: Object of class Closure could not be converted to string in %s on line %d
+Object of class Closure could not be converted to string

--- a/ext/standard/tests/strings/strval_error.phpt
+++ b/ext/standard/tests/strings/strval_error.phpt
@@ -29,7 +29,9 @@ var_dump( strval() );
 
 // Testing strval with a object which has no toString() method
 echo "\n-- Testing strval() function with object which has not toString() method  --\n";
-var_dump( strval(new MyClass()) );
+try {
+    var_dump( strval(new MyClass()) );
+} catch (Error $e) { echo $e->getMessage(), "\n"; }
 
 ?>
 ===DONE===
@@ -47,5 +49,5 @@ Warning: strval() expects exactly 1 parameter, 0 given in %s on line %d
 NULL
 
 -- Testing strval() function with object which has not toString() method  --
-
-Catchable fatal error: Object of class MyClass could not be converted to string in %s on line %d
+Object of class MyClass could not be converted to string
+===DONE===

--- a/ext/standard/tests/url/base64_encode_variation_001.phpt
+++ b/ext/standard/tests/url/base64_encode_variation_001.phpt
@@ -72,7 +72,7 @@ $values = array(
 // loop through each element of the array for str
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( base64_encode($value) );
 };
 
@@ -158,9 +158,8 @@ string(0) ""
 
 Arg value  
 string(0) ""
-Error: 4096 - Object of class stdClass could not be converted to string, %s(72)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - base64_encode() expects parameter 1 to be string, object given, %s(73)
 NULL
 

--- a/ext/standard/tests/url/parse_url_variation_001.phpt
+++ b/ext/standard/tests/url/parse_url_variation_001.phpt
@@ -69,7 +69,7 @@ $values = array(
 // loop through each element of the array for url
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( parse_url($value) );
 };
 
@@ -206,9 +206,8 @@ array(1) {
   ["path"]=>
   string(0) ""
 }
-Error: 4096 - Object of class stdClass could not be converted to string, %s(69)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - parse_url() expects parameter 1 to be string, object given, %s(70)
 NULL
 

--- a/ext/standard/tests/url/parse_url_variation_002_32bit.phpt
+++ b/ext/standard/tests/url/parse_url_variation_002_32bit.phpt
@@ -72,7 +72,7 @@ $values = array(
 // loop through each element of the array for url_component
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( parse_url($url, $value) );
 };
 
@@ -175,9 +175,8 @@ NULL
 Arg value string 
 Error: 2 - parse_url() expects parameter 2 to be integer, string given, %s(%d)
 NULL
-Error: 4096 - Object of class stdClass could not be converted to string, %s(%d)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - parse_url() expects parameter 2 to be integer, object given, %s(%d)
 NULL
 

--- a/ext/standard/tests/url/parse_url_variation_002_64bit.phpt
+++ b/ext/standard/tests/url/parse_url_variation_002_64bit.phpt
@@ -72,7 +72,7 @@ $values = array(
 // loop through each element of the array for url_component
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( parse_url($url, $value) );
 };
 
@@ -175,9 +175,8 @@ NULL
 Arg value string 
 Error: 2 - parse_url() expects parameter 2 to be integer, string given, %s(71)
 NULL
-Error: 4096 - Object of class stdClass could not be converted to string, %s(70)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - parse_url() expects parameter 2 to be integer, object given, %s(71)
 NULL
 

--- a/ext/standard/tests/url/rawurldecode_variation_001.phpt
+++ b/ext/standard/tests/url/rawurldecode_variation_001.phpt
@@ -73,7 +73,7 @@ $values = array(
 // loop through each element of the array for str
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( rawurldecode($value) );
 };
 
@@ -159,9 +159,8 @@ string(0) ""
 
 Arg value  
 string(0) ""
-Error: 4096 - Object of class stdClass could not be converted to string, %s(73)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - rawurldecode() expects parameter 1 to be string, object given, %s(74)
 NULL
 

--- a/ext/standard/tests/url/rawurlencode_variation_001.phpt
+++ b/ext/standard/tests/url/rawurlencode_variation_001.phpt
@@ -73,7 +73,7 @@ $values = array(
 // loop through each element of the array for str
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( rawurlencode($value) );
 };
 
@@ -159,9 +159,8 @@ string(0) ""
 
 Arg value  
 string(0) ""
-Error: 4096 - Object of class stdClass could not be converted to string, %s(73)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - rawurlencode() expects parameter 1 to be string, object given, %s(74)
 NULL
 

--- a/ext/standard/tests/url/urldecode_variation_001.phpt
+++ b/ext/standard/tests/url/urldecode_variation_001.phpt
@@ -73,7 +73,7 @@ $values = array(
 // loop through each element of the array for str
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( urldecode($value) );
 };
 
@@ -159,9 +159,8 @@ string(0) ""
 
 Arg value  
 string(0) ""
-Error: 4096 - Object of class stdClass could not be converted to string, %s(73)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - urldecode() expects parameter 1 to be string, object given, %s(74)
 NULL
 

--- a/ext/standard/tests/url/urlencode_variation_001.phpt
+++ b/ext/standard/tests/url/urlencode_variation_001.phpt
@@ -73,7 +73,7 @@ $values = array(
 // loop through each element of the array for str
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( urlencode($value) );
 };
 
@@ -159,9 +159,8 @@ string(0) ""
 
 Arg value  
 string(0) ""
-Error: 4096 - Object of class stdClass could not be converted to string, %s(73)
 
-Arg value  
+Arg value stdClass 
 Error: 2 - urlencode() expects parameter 1 to be string, object given, %s(74)
 NULL
 

--- a/tests/classes/tostring_001.phpt
+++ b/tests/classes/tostring_001.phpt
@@ -3,12 +3,6 @@ ZE2 __toString()
 --FILE--
 <?php
 
-function my_error_handler($errno, $errstr, $errfile, $errline) {
-	var_dump($errstr);
-}
-
-set_error_handler('my_error_handler');
-
 class test1
 {
 }
@@ -33,7 +27,11 @@ class test3
 echo "====test1====\n";
 $o = new test1;
 print_r($o);
-var_dump((string)$o);
+try {
+    var_dump((string)$o);
+} catch (Error $e) {
+    var_dump($e->getMessage());
+}
 var_dump($o);
 
 echo "====test2====\n";
@@ -70,7 +68,11 @@ echo sprintf("%s", $o);
 echo "====test10====\n";
 $o = new test3;
 var_dump($o);
-echo $o;
+try {
+    echo $o;
+} catch (Error $e) {
+    var_dump($e->getMessage());
+}
 
 ?>
 ====DONE====
@@ -80,7 +82,6 @@ test1 Object
 (
 )
 string(54) "Object of class test1 could not be converted to string"
-string(0) ""
 object(test1)#%d (0) {
 }
 ====test2====
@@ -113,7 +114,8 @@ test2::__toString()
 Converted
 ====test7====
 test2::__toString()
-string(19) "Illegal offset type"
+
+Warning: Illegal offset type in %s on line %d
 ====test8====
 test2::__toString()
 string(9) "Converted"

--- a/tests/classes/tostring_003.phpt
+++ b/tests/classes/tostring_003.phpt
@@ -30,4 +30,5 @@ catch(Exception $e)
 ?>
 ====DONE====
 --EXPECTF--
-Fatal error: Method Test::__toString() must not throw an exception in %stostring_003.php on line %d
+string(5) "Damn!"
+====DONE====

--- a/tests/classes/tostring_004.phpt
+++ b/tests/classes/tostring_004.phpt
@@ -2,24 +2,24 @@
 Object to string conversion: error cases and behaviour variations.
 --FILE--
 <?php
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
-        echo "Error: $err_no - $err_msg\n";
-}
-set_error_handler('test_error_handler');
-error_reporting(8191);
-
 
 echo "Object with no __toString():\n";
 $obj = new stdClass;
 echo "Try 1:\n";
-printf($obj);
-printf("\n");
+try {
+    printf($obj);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 echo "\nTry 2:\n";
-printf($obj . "\n");
+try {
+    printf($obj . "\n");
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
-
-echo "\n\nObject with bad __toString():\n";
+echo "\nObject with bad __toString():\n";
 class badToString {
 	function __toString() {
 		return 0;
@@ -27,29 +27,31 @@ class badToString {
 }
 $obj = new badToString;
 echo "Try 1:\n";
-printf($obj);
-printf("\n");
+try {
+    printf($obj);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 echo "\nTry 2:\n";
-printf($obj . "\n");
+try {
+    printf($obj . "\n");
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
 --EXPECTF--
 Object with no __toString():
 Try 1:
-Error: 4096 - Object of class stdClass could not be converted to string
-Object
+Object of class stdClass could not be converted to string
 
 Try 2:
-Error: 4096 - Object of class stdClass could not be converted to string
-
-
+Object of class stdClass could not be converted to string
 
 Object with bad __toString():
 Try 1:
-Error: 4096 - Method badToString::__toString() must return a string value
-
+Method badToString::__toString() must return a string value
 
 Try 2:
-Error: 4096 - Method badToString::__toString() must return a string value
-
+Method badToString::__toString() must return a string value


### PR DESCRIPTION
 * Allow exceptions to be thrown from `__toString()`. Currently a fatal error is generated instead.
 * Switch two recoverable errors that `__toString()` previously generated to `Error`s.
 * Make sure that the VM can deal with exceptions from `__toString()` without leaking. `zend_parse_parameters()` also deals with this correctly.

This does little to no adjustment of string conversions in the standard library. I think this is okay, as these are rarely occurring cases and not aborting immediately makes little difference (worst case is an extra warning gets thrown or similar). Furthermore it was already possible to throw exceptions on string conversion by hijacking the recoverable fatal errors, so any issues that still exist already existed previously as well.