### PR TITLE
Proposal: Send CLIENT_SSL Only If Server Supports

### DIFF
--- a/ext/mysqlnd/mysqlnd.c
+++ b/ext/mysqlnd/mysqlnd.c
@@ -809,6 +809,12 @@ MYSQLND_METHOD(mysqlnd_conn_data, connect_handshake)(MYSQLND_CONN_DATA * conn,
 		SET_CLIENT_ERROR(*conn->error_info, CR_NOT_IMPLEMENTED, UNKNOWN_SQLSTATE,
 						 "Connecting to 3.22, 3.23 & 4.0 servers is not supported");
 		goto err;
+	} else if ((mysql_flags & CLIENT_SSL) && !(greet_packet->server_capabilities & CLIENT_SSL)) {
+		DBG_ERR("SSL connection requested, but server does not support SSL.");
+		php_error_docref(NULL, E_WARNING, "SSL connection requested, but server does not support SSL.");
+		SET_CLIENT_ERROR(*conn->error_info, CR_NOT_IMPLEMENTED, UNKNOWN_SQLSTATE,
+						 "SSL connection requested, but server does not support SSL");
+		goto err;
 	}
 
 	conn->thread_id			= greet_packet->thread_id;

--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -103,6 +103,11 @@ mysqlnd_auth_handshake(MYSQLND_CONN_DATA * conn,
 			auth_packet->connect_attr = conn->options->connect_attr;
 		}
 
+		/* Only send CLIENT_SSL flag if the server supports it. Otherwise, we get bad handshake errors. */
+		if ((auth_packet->client_flags & CLIENT_SSL) && !(conn->server_capabilities & CLIENT_SSL)) {
+			auth_packet->client_flags &= ~CLIENT_SSL;
+		}
+
 		if (!PACKET_WRITE(auth_packet, conn)) {
 			goto end;
 		}


### PR DESCRIPTION
Please test before merging. My goal is to point to an issue we ran into: If you tell PHP to use SSL if it is available and PHP tries to connect to MySQL that does not support SSL, it will still send the CLIENT_SSL capability. The MySQL handshake process sees the CLIENT_SSL capability and treats the bytes that follow as a TLS handshake. This fails with the message "Bad Handshake".
