### PR TITLE
Increased coverage tests and moved warning test to money_format_error.phpt file

### DIFF
--- a/ext/standard/tests/strings/money_format_error.phpt
+++ b/ext/standard/tests/strings/money_format_error.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test money_format() function : error conditions  
+Test money_format() function : error conditions
 --SKIPIF--
 <?php
 	if (!function_exists('money_format')) {
@@ -30,9 +30,10 @@ echo "\n-- Testing money_format() function with insufficient arguments --\n";
 var_dump( money_format($string) );
 
 echo "\n-- Testing money_format() function with more than expected no. of arguments --\n";
-
 var_dump( money_format($string, $value, $extra_arg) );
 
+echo "\n-- Testing money_format() function with more than one token --\n";
+var_dump( money_format($string . $string, $value) );
 ?>
 ===DONE===
 --EXPECTF--
@@ -52,4 +53,9 @@ NULL
 
 Warning: money_format() expects exactly 2 parameters, 3 given in %s on line %d
 NULL
+
+-- Testing money_format() function with more than one token --
+
+Warning: money_format(): Only a single %ci or %cn token can be used in %s on line %d
+bool(false)
 ===DONE===

--- a/ext/standard/tests/strings/moneyformat.phpt
+++ b/ext/standard/tests/strings/moneyformat.phpt
@@ -14,10 +14,6 @@ if (setlocale(LC_MONETARY, 'en_US') === false) {
 <?php
 setlocale(LC_MONETARY, 'en_US');
 var_dump( money_format("X%nY", 3.1415));
-var_dump(money_format("AAAAA%n%n%n%n", NULL));
 ?>
 --EXPECTF--
 string(7) "X$3.14Y"
-
-Warning: money_format(): Only a single %ci or %cn token can be used in %s on line %d
-bool(false)


### PR DESCRIPTION
A warning function test has been moved to money_format_error.phpt file and this also increased the string coverage tests.