### PR TITLE
removed unreachable code in the substr_replace function

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2501,9 +2501,7 @@ PHP_FUNCTION(substr_replace)
 				}
 			}
 
-			if (f > Z_STRLEN_P(str) || (f < 0 && -f > Z_STRLEN_P(str))) {
-				RETURN_FALSE;
-			} else if (l > Z_STRLEN_P(str) || (l < 0 && -l > Z_STRLEN_P(str))) {
+			if (l > Z_STRLEN_P(str) || (l < 0 && -l > Z_STRLEN_P(str))) {
 				l = Z_STRLEN_P(str);
 			}
 


### PR DESCRIPTION
Removal the if in line [#L2504](https://github.com/php/php-src/blob/master/ext/standard/string.c#L2504)

This line is unreachable because in line [#L2491](https://github.com/php/php-src/blob/master/ext/standard/string.c#L2491) if `f` is greather than `Z_STRLEN_P(str)` its value will be `Z_STRLEN_P(str)`

And even if the `f` is negative and `Z_STRLEN_P(str) = 0' then the line [#L2489](https://github.com/php/php-src/blob/master/ext/standard/string.c#L2489) will change the its value to 0