### PR TITLE
Adds deprecation-message for ldap_sort

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -2019,6 +2019,8 @@ PHP_FUNCTION(ldap_sort)
 	size_t sflen;
 	zend_resource *le;
 
+    php_error_docref(NULL, E_DEPRECATED, "Usage of ldap_sort is deprecated and will be removed in one of the next PHP-versions");
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rrs", &link, &result, &sortfilter, &sflen) != SUCCESS) {
 		RETURN_FALSE;
 	}

--- a/ext/ldap/tests/ldap_sort_basic.phpt
+++ b/ext/ldap/tests/ldap_sort_basic.phpt
@@ -51,6 +51,7 @@ ldap_delete($link, "cn=userE,$base");
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
+Deprecated: ldap_sort(): Usage of ldap_sort is deprecated and will be removed in one of the next PHP-versions in %s.php on line %d
 bool(true)
 array(7) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_sort_error.phpt
+++ b/ext/ldap/tests/ldap_sort_error.phpt
@@ -18,17 +18,27 @@ var_dump(ldap_sort($link, $link, "sn"));
 ?>
 ===DONE===
 --EXPECTF--
+Deprecated: ldap_sort(): Usage of ldap_sort is deprecated and will be removed in one of the next PHP-versions in %s.php on line %d
+
 Warning: ldap_sort() expects exactly 3 parameters, 1 given in %s on line %d
 bool(false)
+
+Deprecated: ldap_sort(): Usage of ldap_sort is deprecated and will be removed in one of the next PHP-versions in %s.php on line %d
 
 Warning: ldap_sort() expects exactly 3 parameters, 2 given in %s on line %d
 bool(false)
 
+Deprecated: ldap_sort(): Usage of ldap_sort is deprecated and will be removed in one of the next PHP-versions in %s.php on line %d
+
 Warning: ldap_sort() expects exactly 3 parameters, 4 given in %s on line %d
 bool(false)
 
+Deprecated: ldap_sort(): Usage of ldap_sort is deprecated and will be removed in one of the next PHP-versions in %s.php on line %d
+
 Warning: ldap_sort() expects parameter 3 to be %binary_string_optional%, resource given in %s on line %d
 bool(false)
+
+Deprecated: ldap_sort(): Usage of ldap_sort is deprecated and will be removed in one of the next PHP-versions in %s.php on line %d
 
 Warning: ldap_sort(): Supplied resource is not a valid ldap result resource in %s on line %d
 bool(false)

--- a/ext/ldap/tests/ldap_sort_variation.phpt
+++ b/ext/ldap/tests/ldap_sort_variation.phpt
@@ -51,6 +51,7 @@ ldap_delete($link, "cn=userE,$base");
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
+Deprecated: ldap_sort(): Usage of ldap_sort is deprecated and will be removed in one of the next PHP-versions in %s.php on line %d
 bool(true)
 array(7) {
   ["count"]=>


### PR DESCRIPTION
As already described on the Mailinglist (http://news.php.net/php.internals/86877 and others) we try to remove ```ldap_sort``` ASAP as the underlying C-library (OpenLDAP >= 2.4) has that call already deprecated for numerous years.

Therefore this commit simply adds raising *E_DEPRECATED* on calling ```ldap_sort```.