### PR TITLE
Fix #67447: imagecrop() adds a black line when cropping

### DIFF
--- a/ext/gd/libgd/gd_crop.c
+++ b/ext/gd/libgd/gd_crop.c
@@ -80,14 +80,14 @@ printf("rect->x: %i\nrect->y: %i\nrect->width: %i\nrect->height: %i\n", crop->x,
 	y = crop->y;
 	if (src->trueColor) {
 		unsigned int dst_y = 0;
-		while (y < (crop->y + (crop->height - 1))) {
+		while (y < (crop->y + crop->height)) {
 			/* TODO: replace 4 w/byte per channel||pitch once available */
 			memcpy(dst->tpixels[dst_y++], src->tpixels[y++] + crop->x, crop->width * 4);
 		}
 	} else {
 		int x;
-		for (y = crop->y; y < (crop->y + (crop->height - 1)); y++) {
-			for (x = crop->x; x < (crop->x + (crop->width - 1)); x++) {
+		for (y = crop->y; y < (crop->y + crop->height); y++) {
+			for (x = crop->x; x < (crop->x + crop->width); x++) {
 				dst->pixels[y - crop->y][x - crop->x] = src->pixels[y][x];
 			}
 		}

--- a/ext/gd/tests/bug67447.phpt
+++ b/ext/gd/tests/bug67447.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #67447 (imagecrop() adds a black line when cropping)
+--FILE--
+<?php
+// true color
+$image = imagecreatetruecolor(500, 500);
+$red = imagecolorallocate($image, 255, 0, 0);
+imagefill($image, 0, 0, $red);
+$cropped = imagecrop($image, ['x' => 0, 'y' => 0, 'width' => 250, 'height' => 250]);
+var_dump(imagecolorat($cropped, 249, 249) === $red);
+imagedestroy($image);
+imagedestroy($cropped);
+
+// palette
+$image = imagecreate(500, 500);
+imagecolorallocate($image, 0, 0, 255); // first palette color = background
+$red = imagecolorallocate($image, 255, 0, 0);
+imagefill($image, 0, 0, $red);
+$cropped = imagecrop($image, ['x' => 0, 'y' => 0, 'width' => 250, 'height' => 250]);
+var_dump(imagecolorat($cropped, 249, 249) === $red);
+imagedestroy($image);
+imagedestroy($cropped);
+?>
+--EXPECT--
+bool(true)
+bool(true)


### PR DESCRIPTION
A simple one-off error: imagecrop)() copied only width-1 and height-1 pixels.

Apparently, the loops are running until `< -1` instead of `<= -1`, but perhaps I'm overlooking something. @pierrejoye @remicollet: okay to merge? PHP 5.6+?

BTW, the external libgd is not affected, because it's delegating to [gdImageCopy()](https://github.com/libgd/libgd/blob/master/src/gd_crop.c#L27).