### PR TITLE
Adding another testing scenario without coverage in setlocale function

### DIFF
--- a/ext/standard/tests/strings/setlocale_error.phpt
+++ b/ext/standard/tests/strings/setlocale_error.phpt
@@ -11,8 +11,8 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 --FILE--
 <?php
 /* Prototype  : string setlocale (int $category , string $locale [,string $..] )
-              : string setlocale(int $category , array $locale);  
- * Description: Sets locale information.Returns the new current locale , or FALSE if locale functionality is not implemented in this platform. 
+              : string setlocale(int $category , array $locale);
+ * Description: Sets locale information.Returns the new current locale , or FALSE if locale functionality is not implemented in this platform.
  * Source code: ext/standard/string.c
 */
 
@@ -35,6 +35,10 @@ echo "\n-- Testing setlocale() function with invalid multiple locales, 'category
 //Invalid array of locales
 var_dump( setlocale(LC_ALL,"en_US.invalid", "en_AU.invalid", "ko_KR.invalid") );
 
+echo "\n-- Testing setlocale() function with locale name too long, 'category' = LC_ALL --";
+//Invalid locale - locale name too long
+var_dump(setlocale(LC_ALL,str_pad('',255,'A')));
+
 echo "\nDone";
 ?>
 --EXPECTF--
@@ -52,6 +56,10 @@ NULL
 bool(false)
 
 -- Testing setlocale() function with invalid multiple locales, 'category' = LC_ALL --
+bool(false)
+
+-- Testing setlocale() function with locale name too long, 'category' = LC_ALL --
+Warning: setlocale(): Specified locale name is too long in %s on line %d
 bool(false)
 
 Done


### PR DESCRIPTION
The warning message "Specified locale name is too long in %s on line %d" of setlocale function is not covered

This commit adds the coverage the warning message too