### PR TITLE
Improved code coverage of explode function

### DIFF
--- a/ext/standard/tests/strings/explode_variation7.phpt
+++ b/ext/standard/tests/strings/explode_variation7.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test explode() function : usage variations - when $string length is greater than
+EXPLODE_ALLOC_STEP (64) and the $limit is negative
+--CREDITS--
+edgarsandi - <edgar.r.sandi@gmail.com>
+--FILE--
+<?php
+
+/* Prototype  : array explode  ( string $delimiter  , string $string  [, int $limit  ] )
+ * Description: Split a string by string.
+ * Source code: ext/standard/string.c
+*/
+
+var_dump(count(explode('|', implode(range(1,65),'|'), -1)));
+
+--EXPECTF--
+int(64)


### PR DESCRIPTION
Improved code coverage of explode function when the length of parameter $string is greater than 64 (EXPLODE_ALLOC_STEP) and the $limit parameter is negative