### PR TITLE
Adds files for easier LDAP-Testing

### DIFF
--- a/ext/ldap/Vagrantfile
+++ b/ext/ldap/Vagrantfile
@@ -1,0 +1,7 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.provision "shell", path: "https://gist.githubusercontent.com/heiglandreas/10e1c7dd80d6e058faae/raw/ext-ldap-test-provisioner.sh"
+end

--- a/ext/ldap/testldap.sh
+++ b/ext/ldap/testldap.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+vagrant up
+export LDAP_TEST_PASSWD="password"
+export LDAP_TEST_BASE="ou=extldap,dc=nodomain"
+export LDAP_TEST_USER="dc=admin,dc=nodomain"
+export LDAP_TEST_HOST=192.168.33.10
+
+cd ../..
+make test TESTS=ext/ldap
+cd ext/ldap


### PR DESCRIPTION
This PR adds a Vagrant-file to create a box containing an LDAP-Setup
specifically for testing PHPs ldap-extension.

After a `vagrant up` the box can be used by setting the following
environment-variables:

```
export LDAP_TEST_PASSWD="password"
export LDAP_TEST_BASE="ou=extldap,dc=nodomain"
export LDAP_TEST_USER="dc=admin,dc=nodomain"
export LDAP_TEST_HOST=192.168.33.10
```

After that you can run the LDAP-related tests by calling

```
make test TESTS=ext/ldap
```

This comit also contains a shellscript that combines these commands into
a single script. Therefore you can then call

```
$ testldap.sh
```

and you are ready to go.
