### PR TITLE
Segmentation fault on pdo_dblib::nextRowset (bug #69757)

### DIFF
--- a/ext/pdo_dblib/dblib_stmt.c
+++ b/ext/pdo_dblib/dblib_stmt.c
@@ -204,7 +204,14 @@ static int pdo_dblib_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC)
 	
 	struct pdo_column_data *col = &stmt->columns[colno];
 	
-	col->name = (char*)dbcolname(H->link, colno+1);
+	char *fname = (char*)dbcolname(H->link, colno+1);
+	char computed_buf[16];
+	if (*fname) {
+		col->name = estrdup(fname);
+	} else {
+		snprintf(computed_buf,16,"computed%d", colno);
+		col->name = estrdup(computed_buf);
+	}
 	col->maxlen = dbcollen(H->link, colno+1);
 	col->namelen = strlen(col->name);
 	col->param_type = PDO_PARAM_STR;


### PR DESCRIPTION
Workaround for handling "unnamed" fields in dblib's resultset. Code was copied from ext/mssql/php_mssql.c.