### PR TITLE
Segmentation fault on pdo_dblib::nextRowset (bug #69757)

### DIFF
--- a/ext/pdo_dblib/dblib_stmt.c
+++ b/ext/pdo_dblib/dblib_stmt.c
@@ -203,8 +203,15 @@ static int pdo_dblib_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC)
 	}
 	
 	struct pdo_column_data *col = &stmt->columns[colno];
-	
-	col->name = (char*)dbcolname(H->link, colno+1);
+
+	char *fname = (char*)dbcolname(H->link, colno+1);
+	char computed_buf[16];
+	if (*fname) {
+		col->name = estrdup(fname);
+	} else {
+		snprintf(computed_buf,16,"computed%d", colno);
+		col->name = estrdup(computed_buf);
+	}
 	col->maxlen = dbcollen(H->link, colno+1);
 	col->namelen = strlen(col->name);
 	col->param_type = PDO_PARAM_STR;

--- a/ext/pdo_dblib/dblib_stmt.c
+++ b/ext/pdo_dblib/dblib_stmt.c
@@ -206,7 +206,7 @@ static int pdo_dblib_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC)
 
 	char *fname = (char*)dbcolname(H->link, colno+1);
 	char computed_buf[16];
-	if (*fname) {
+	if (fname && *fname) {
 		col->name = estrdup(fname);
 	} else {
 		snprintf(computed_buf,16,"computed%d", colno);

--- a/ext/pdo_dblib/dblib_stmt.c
+++ b/ext/pdo_dblib/dblib_stmt.c
@@ -205,15 +205,14 @@ static int pdo_dblib_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC)
 	struct pdo_column_data *col = &stmt->columns[colno];
 
 	char *fname = (char*)dbcolname(H->link, colno+1);
-	char computed_buf[16];
+
 	if (fname && *fname) {
 		col->name = estrdup(fname);
+		col->namelen = strlen(col->name);
 	} else {
-		snprintf(computed_buf,16,"computed%d", colno);
-		col->name = estrdup(computed_buf);
+		col->namelen = spprintf(&col->name, NULL, "computed%d", colno);
 	}
 	col->maxlen = dbcollen(H->link, colno+1);
-	col->namelen = strlen(col->name);
 	col->param_type = PDO_PARAM_STR;
 		
 	return 1;

--- a/ext/pdo_dblib/tests/bug_69757.phpt
+++ b/ext/pdo_dblib/tests/bug_69757.phpt
@@ -1,0 +1,32 @@
+--TEST--
+PDO_DBLIB: Segmentation fault on pdo_dblib::nextRowset
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require __DIR__ . '/config.inc';
+?>
+--FILE--
+<?php
+require __DIR__ . '/config.inc';
+
+$sql = "
+    exec dbo.sp_executesql N'
+        SELECT * FROM sysobjects
+        SELECT * FROM syscolumns
+    '
+";
+$stmt = $db->query($sql);
+$resultset1 = $stmt->fetchAll(PDO::FETCH_ASSOC);
+if (true !== $stmt->nextRowset()) {
+    die('expect TRUE on nextRowset');
+}
+$resultset2 = $stmt->fetchAll(PDO::FETCH_ASSOC);
+if (false !== $stmt->nextRowset()) {
+    die('expect FALSE on nextRowset');
+}
+$stmt->closeCursor();
+
+echo "OK\n";
+?>
+--EXPECT--
+OK


### PR DESCRIPTION
Workaround for handling "unnamed" fields in dblib's resultset. Code was copied from ext/mssql/php_mssql.c.