### PR TITLE
Make array to string conversion a recoverable error

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -535,7 +535,7 @@ try_again:
 			break;
 		}
 		case IS_ARRAY:
-			zend_error(E_NOTICE, "Array to string conversion");
+			zend_error(E_RECOVERABLE_ERROR, "Array could not be converted to string");
 			zval_ptr_dtor(op);
 			ZVAL_NEW_STR(op, zend_string_init("Array", sizeof("Array")-1, 0));
 			break;
@@ -820,7 +820,7 @@ try_again:
 			return zend_strpprintf(0, "%.*G", (int) EG(precision), Z_DVAL_P(op));
 		}
 		case IS_ARRAY:
-			zend_error(E_NOTICE, "Array to string conversion");
+			zend_error(E_RECOVERABLE_ERROR, "Array could not be converted to string");
 			return zend_string_init("Array", sizeof("Array")-1, 0);
 		case IS_OBJECT: {
 			zval tmp;


### PR DESCRIPTION
Implements this RFC: https://wiki.php.net/rfc/array-to-string

Does not update any of the numerous tests it breaks. Also, given that engine exceptions passed, it might be better to make this throw an exception instead.

But by making this pull request, I might give the fact this RFC is unimplemented more attention.