### PR TITLE
http parser code assumes char is signed

### DIFF
--- a/sapi/cli/php_http_parser.c
+++ b/sapi/cli/php_http_parser.c
@@ -326,7 +326,8 @@ size_t php_http_parser_execute (php_http_parser *parser,
                             const char *data,
                             size_t len)
 {
-  char c, ch;
+  char ch;
+  signed char c;
   const char *p = data, *pe;
   size_t to_read;
 


### PR DESCRIPTION
A char can be either signed or unsigned, and on PowerPC and ARM it is
unsigned. The following code will always be false on these architectures:

        if (c == -1) goto error;