### PR TITLE
Fix #70001: Assigning to DOMNode::textContent does additional entity …

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -847,7 +847,6 @@ int dom_node_text_content_write(dom_object *obj, zval *newval)
 {
 	xmlNode *nodep = dom_object_get_node(obj);
 	zend_string *str;
-	xmlChar *enc_str;
 
 	if (nodep == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 0);
@@ -855,9 +854,9 @@ int dom_node_text_content_write(dom_object *obj, zval *newval)
 	}
 
 	str = zval_get_string(newval);
-	enc_str = xmlEncodeEntitiesReentrant(nodep->doc, (xmlChar *) ZSTR_VAL(str));
-	xmlNodeSetContent(nodep, enc_str);
-	xmlFree(enc_str);
+	/* we have to use xmlNodeAddContent() to get the same behavior as with xmlNewText() */
+	xmlNodeSetContent(nodep, (xmlChar *) "");
+	xmlNodeAddContent(nodep, (xmlChar *) ZSTR_VAL(str));
 	zend_string_release(str);
 
 	return SUCCESS;

--- a/ext/dom/tests/bug70001.phpt
+++ b/ext/dom/tests/bug70001.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #70001 (Assigning to DOMNode::textContent does additional entity encoding)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$element = new DOMText('<p>foo & bar</p>');
+var_dump($element->textContent);
+$element = (new DOMDocument())->createTextNode('<p>foo & bar</p>');
+var_dump($element->textContent);
+$element->textContent = ('<p>foo & bar</p>');
+var_dump($element->textContent);
+?>
+--EXPECT--
+string(16) "<p>foo & bar</p>"
+string(16) "<p>foo & bar</p>"
+string(16) "<p>foo & bar</p>"


### PR DESCRIPTION
…encoding

Assigning to DOMNode::textContent encodes entities, what does not match the
behavior of DOMText::__construct() and DOMDocument::createTextNode. This patch
changes the behavior of DOMNode::textContent in this regard.

IMO the former behavior is a bug, but changing the behavior would constitute a BC break (there may be code working around the issue), so perhaps it would be best to apply the patch for PHP 7 only.