### PR TITLE
Tweak CSPRNG error conditions & add exceptions

### DIFF
--- a/ext/standard/random.c
+++ b/ext/standard/random.c
@@ -24,6 +24,7 @@
 #include <math.h>
 
 #include "php.h"
+#include "zend_exceptions.h"
 #include "php_random.h"
 
 #if PHP_WIN32

--- a/ext/standard/random.c
+++ b/ext/standard/random.c
@@ -133,8 +133,8 @@ PHP_FUNCTION(random_bytes)
 	}
 
 	if (size < 1) {
-		php_error_docref(NULL, E_WARNING, "Length must be greater than 0");
-		RETURN_FALSE;
+		zend_throw_exception(NULL, "Length must be greater than 0", 0);
+		return;
 	}
 
 	bytes = zend_string_alloc(size, 0);

--- a/ext/standard/random.c
+++ b/ext/standard/random.c
@@ -163,9 +163,13 @@ PHP_FUNCTION(random_int)
 		return;
 	}
 
-	if (min >= max) {
-		php_error_docref(NULL, E_WARNING, "Minimum value must be less than the maximum value");
-		RETURN_FALSE;
+	if (min > max) {
+		zend_throw_exception(NULL, "Minimum value must be less than or equal to the maximum value", 0);
+		return;
+	}
+
+	if (min == max) {
+		RETURN_LONG(min);
 	}
 
 	umax = max - min;

--- a/ext/standard/tests/random/random_bytes_error.phpt
+++ b/ext/standard/tests/random/random_bytes_error.phpt
@@ -6,12 +6,18 @@ Test error operation of random_bytes()
 
 var_dump(random_bytes());
 
-var_dump(random_bytes(-1));
+$bytes = null;
+try {
+    $bytes = random_bytes(0);
+} catch (Exception $e) {
+    var_dump($e->getMessage());
+}
+var_dump($bytes);
 
 ?>
 --EXPECTF--
+
 Warning: random_bytes() expects exactly 1 parameter, 0 given in %s on line %d
 NULL
-
-Warning: random_bytes(): Length must be greater than 0 in %s on line %d
-bool(false)
+string(29) "Length must be greater than 0"
+NULL

--- a/ext/standard/tests/random/random_int.phpt
+++ b/ext/standard/tests/random/random_int.phpt
@@ -11,8 +11,11 @@ var_dump($x >= 10 && $x <= 100);
 
 var_dump(random_int(-1000, -1) < 0);
 
+var_dump(random_int(42, 42));
+
 ?>
 --EXPECT--
 bool(true)
 bool(true)
 bool(true)
+int(42)

--- a/ext/standard/tests/random/random_int_error.phpt
+++ b/ext/standard/tests/random/random_int_error.phpt
@@ -8,7 +8,13 @@ var_dump(random_int());
 
 var_dump(random_int(10));
 
-var_dump(random_int(10, 0));
+$randomInt = null;
+try {
+    $randomInt = random_int(10, 0);
+} catch (Exception $e) {
+    var_dump($e->getMessage());
+}
+var_dump($randomInt);
 
 ?>
 --EXPECTF--
@@ -17,6 +23,5 @@ NULL
 
 Warning: random_int() expects exactly 2 parameters, 1 given in %s on line %d
 NULL
-
-Warning: random_int(): Minimum value must be less than the maximum value in %s on line %d
-bool(false)
+string(61) "Minimum value must be less than or equal to the maximum value"
+NULL


### PR DESCRIPTION
This PR is part 2 of #1397 and [this discussion](https://github.com/php/php-src/pull/1119#issuecomment-119108894). It tweaks the behavior of `random_bytes()` and `random_int()` in the following ways:

1. `random_bytes()` will throw an `Exception` if `length < 1` instead of issuing an `E_WARNING` and returning `false`.
2. `random_int()` now allows for `min` & `max` to be the same value for cases that need it (i.e. [when picking the last card in a shuffling algorithm](https://github.com/php/php-src/pull/1119#issuecomment-119226670))
3. `random_int()` will throw an `Exception` if `min > max` instead of issuing an `E_WARNING` and returning `false`.

There was some discussion of throwing the exceptions as an `InvalidArgumentException`, but the consensus seems to be "[keep it general](http://chat.stackoverflow.com/transcript/message/24298487#24298487)" for BC friendliness.

CC: @weltling, @KalleZ, @lt 