### PR TITLE
fix segfault when the statement is actually empty

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -783,6 +783,10 @@ static void zend_ast_export_var_list(smart_str *str, zend_ast_list *list, int in
 
 static void zend_ast_export_stmt(smart_str *str, zend_ast *ast, int indent)
 {
+	if (!ast) {
+		return;
+	}
+
 	if (ast->kind == ZEND_AST_STMT_LIST ||
 	    ast->kind == ZEND_AST_TRAIT_ADAPTATIONS) {
 		zend_ast_list *list = (zend_ast_list*)ast;

--- a/tests/assert/expect_empty_stmt_bug.phpt
+++ b/tests/assert/expect_empty_stmt_bug.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Empty statement in assert() shouldn't segfault
+--FILE--
+<?php
+
+assert((function () { return true;; })());
+echo "ok";
+
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
In `assert` it will segfault trying to generate code from this for example: `(function () { return true;; })()` (extra semicolon creates an empty stmt)