### PR TITLE
Updated memcpy replace function by internal_function

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2246,7 +2246,7 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 		zend_str_tolower_copy(ZSTR_VAL(lowercase_name), ptr->fname, fname_len);
 		lowercase_name = zend_new_interned_string(lowercase_name);
 		reg_function = malloc(sizeof(zend_internal_function));
-		memcpy(reg_function, &function, sizeof(zend_internal_function));
+		memcpy(reg_function, internal_function, sizeof(zend_internal_function));
 		if (zend_hash_add_ptr(target_function_table, lowercase_name, reg_function) == NULL) {
 			unload=1;
 			free(reg_function);


### PR DESCRIPTION
@laruence Help look
System: Ubuntu 14.04
Error when compiling and installing:
```ouput
Generating phar.php
/bin/bash: line 1: 24160 Segmentation fault      (core dumped) ` if test -x "/home/zhuzx/work/php-src/sapi/cli/php"; then /home/zhuzx/work/php-src/build/shtool echo -n -- "/home/zhuzx/work/php-src/sapi/cli/php -n"; if test "x" != "x"; then /home/zhuzx/work/php-src/build/shtool echo -n -- " -d extension_dir=/home/zhuzx/work/php-src/modules"; for i in bz2 zlib phar; do if test -f "/home/zhuzx/work/php-src/modules/$i.la"; then . /home/zhuzx/work/php-src/modules/$i.la; /home/zhuzx/work/php-src/build/shtool echo -n -- " -d extension=$dlname"; fi; done; fi; else /home/zhuzx/work/php-src/build/shtool echo -n -- "/home/zhuzx/work/php-src/sapi/cli/php"; fi;` -n -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1' -d phar.readonly=0 -d 'safe_mode=0' /home/zhuzx/work/php-src/ext/phar/build_precommand.php > ext/phar/phar.php
make: *** [ext/phar/phar.php] Error 139
```
GDB Info:
```error
#0  0x00000000006e1e22 in zend_string_release (s=0x0) at /home/zhuzx/work/php-src/Zend/zend_string.h:271
#1  _zend_hash_del_el_ex (prev=<optimized out>, p=0x10, idx=0, ht=0x0) at /home/zhuzx/work/php-src/Zend/zend_hash.c:929
#2  _zend_hash_del_el (p=0x10, idx=0, ht=0x0) at /home/zhuzx/work/php-src/Zend/zend_hash.c:959
#3  zend_hash_reverse_apply (ht=0x0, apply_func=0x2b6717a01020) at /home/zhuzx/work/php-src/Zend/zend_hash.c:1532
#4  0x0000000000000000 in ?? ()
```