### PR TITLE
Fix #70029: nodeValue of DOMElement list content of children nodes

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -297,7 +297,6 @@ int dom_node_node_value_read(dom_object *obj, zval *retval)
 	switch (nodep->type) {
 		case XML_ATTRIBUTE_NODE:
 		case XML_TEXT_NODE:
-		case XML_ELEMENT_NODE:
 		case XML_COMMENT_NODE:
 		case XML_CDATA_SECTION_NODE:
 		case XML_PI_NODE:

--- a/ext/dom/tests/bug28721.phpt
+++ b/ext/dom/tests/bug28721.phpt
@@ -119,66 +119,65 @@ print_node_r($p);
 
 ?>
 --EXPECT--
-
-name (value): p ( t1 X t2  xxx )
+name (value): p ()
 parent: NULL
 previousSibling: NULL
 nextSibling: NULL
 
   name (value): #text ( t1 )
-  parent: name (value): p ( t1 X t2  xxx )
+  parent: name (value): p ()
   previousSibling: NULL
-  nextSibling: name (value): b (X)
+  nextSibling: name (value): b ()
 
-  name (value): b (X)
-  parent: name (value): p ( t1 X t2  xxx )
+  name (value): b ()
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t1 )
   nextSibling: name (value): #text ( t2 )
 
     name (value): #text (X)
-    parent: name (value): b (X)
+    parent: name (value): b ()
     previousSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( t2 )
-  parent: name (value): p ( t1 X t2  xxx )
-  previousSibling: name (value): b (X)
+  parent: name (value): p ()
+  previousSibling: name (value): b ()
   nextSibling: name (value): #text ( xxx )
 
   name (value): #text ( xxx )
-  parent: name (value): p ( t1 X t2  xxx )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t2 )
   nextSibling: NULL
 
 Append t1 to p:
 
-name (value): p (X t2  xxx  t1 )
+name (value): p ()
 parent: NULL
 previousSibling: NULL
 nextSibling: NULL
 
-  name (value): b (X)
-  parent: name (value): p (X t2  xxx  t1 )
+  name (value): b ()
+  parent: name (value): p ()
   previousSibling: NULL
   nextSibling: name (value): #text ( t2 )
 
     name (value): #text (X)
-    parent: name (value): b (X)
+    parent: name (value): b ()
     previousSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( t2 )
-  parent: name (value): p (X t2  xxx  t1 )
-  previousSibling: name (value): b (X)
+  parent: name (value): p ()
+  previousSibling: name (value): b ()
   nextSibling: name (value): #text ( xxx )
 
   name (value): #text ( xxx )
-  parent: name (value): p (X t2  xxx  t1 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t2 )
   nextSibling: name (value): #text ( t1 )
 
   name (value): #text ( t1 )
-  parent: name (value): p (X t2  xxx  t1 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( xxx )
   nextSibling: NULL
 
@@ -186,18 +185,18 @@ t1 == ret: bool(true)
 
 div:
 
-name (value): div ( t3  t4  xxx )
+name (value): div ()
 parent: NULL
 previousSibling: NULL
 nextSibling: NULL
 
   name (value): #text ( t3 )
-  parent: name (value): div ( t3  t4  xxx )
+  parent: name (value): div ()
   previousSibling: NULL
   nextSibling: name (value): b ()
 
   name (value): b ()
-  parent: name (value): div ( t3  t4  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): #text ( t3 )
   nextSibling: name (value): #text ( t4 )
 
@@ -207,34 +206,34 @@ nextSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( t4 )
-  parent: name (value): div ( t3  t4  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): b ()
   nextSibling: name (value): #text ( xxx )
 
   name (value): #text ( xxx )
-  parent: name (value): div ( t3  t4  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): #text ( t4 )
   nextSibling: NULL
 
 Insert t4 before t3:
 
-name (value): div ( t4  t3  xxx )
+name (value): div ()
 parent: NULL
 previousSibling: NULL
 nextSibling: NULL
 
   name (value): #text ( t4 )
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: NULL
   nextSibling: name (value): #text ( t3 )
 
   name (value): #text ( t3 )
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): #text ( t4 )
   nextSibling: name (value): b ()
 
   name (value): b ()
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): #text ( t3 )
   nextSibling: name (value): #text ( xxx )
 
@@ -244,40 +243,40 @@ nextSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( xxx )
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): b ()
   nextSibling: NULL
 
 
 p:
 
-name (value): p (X t2  xxx  t1 )
+name (value): p ()
 parent: NULL
 previousSibling: NULL
 nextSibling: NULL
 
-  name (value): b (X)
-  parent: name (value): p (X t2  xxx  t1 )
+  name (value): b ()
+  parent: name (value): p ()
   previousSibling: NULL
   nextSibling: name (value): #text ( t2 )
 
     name (value): #text (X)
-    parent: name (value): b (X)
+    parent: name (value): b ()
     previousSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( t2 )
-  parent: name (value): p (X t2  xxx  t1 )
-  previousSibling: name (value): b (X)
+  parent: name (value): p ()
+  previousSibling: name (value): b ()
   nextSibling: name (value): #text ( xxx )
 
   name (value): #text ( xxx )
-  parent: name (value): p (X t2  xxx  t1 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t2 )
   nextSibling: name (value): #text ( t1 )
 
   name (value): #text ( t1 )
-  parent: name (value): p (X t2  xxx  t1 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( xxx )
   nextSibling: NULL
 
@@ -291,73 +290,73 @@ nextSibling: NULL
   name (value): #text ( t5 )
   parent: name (value): #document-fragment ()
   previousSibling: NULL
-  nextSibling: name (value): i ( frob )
+  nextSibling: name (value): i ()
 
-  name (value): i ( frob )
+  name (value): i ()
   parent: name (value): #document-fragment ()
   previousSibling: name (value): #text ( t5 )
   nextSibling: name (value): #text ( t6 )
 
     name (value): #text ( frob )
-    parent: name (value): i ( frob )
+    parent: name (value): i ()
     previousSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( t6 )
   parent: name (value): #document-fragment ()
-  previousSibling: name (value): i ( frob )
+  previousSibling: name (value): i ()
   nextSibling: NULL
 
 Appending fragment to p:
 
-name (value): p (X t2  xxx  t1  t5  frob  t6 )
+name (value): p ()
 parent: NULL
 previousSibling: NULL
 nextSibling: NULL
 
-  name (value): b (X)
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  name (value): b ()
+  parent: name (value): p ()
   previousSibling: NULL
   nextSibling: name (value): #text ( t2 )
 
     name (value): #text (X)
-    parent: name (value): b (X)
+    parent: name (value): b ()
     previousSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( t2 )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
-  previousSibling: name (value): b (X)
+  parent: name (value): p ()
+  previousSibling: name (value): b ()
   nextSibling: name (value): #text ( xxx )
 
   name (value): #text ( xxx )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t2 )
   nextSibling: name (value): #text ( t1 )
 
   name (value): #text ( t1 )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( xxx )
   nextSibling: name (value): #text ( t5 )
 
   name (value): #text ( t5 )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t1 )
-  nextSibling: name (value): i ( frob )
+  nextSibling: name (value): i ()
 
-  name (value): i ( frob )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  name (value): i ()
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t5 )
   nextSibling: name (value): #text ( t6 )
 
     name (value): #text ( frob )
-    parent: name (value): i ( frob )
+    parent: name (value): i ()
     previousSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( t6 )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
-  previousSibling: name (value): i ( frob )
+  parent: name (value): p ()
+  previousSibling: name (value): i ()
   nextSibling: NULL
 
 Fragment:
@@ -369,23 +368,23 @@ nextSibling: NULL
 
 div:
 
-name (value): div ( t4  t3  xxx )
+name (value): div ()
 parent: NULL
 previousSibling: NULL
 nextSibling: NULL
 
   name (value): #text ( t4 )
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: NULL
   nextSibling: name (value): #text ( t3 )
 
   name (value): #text ( t3 )
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): #text ( t4 )
   nextSibling: name (value): b ()
 
   name (value): b ()
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): #text ( t3 )
   nextSibling: name (value): #text ( xxx )
 
@@ -395,30 +394,30 @@ nextSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( xxx )
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): b ()
   nextSibling: NULL
 
 Inserting fragment before t4
 Error (2) on line 109: DOMNode::insertBefore(): Document Fragment is empty
 
-name (value): div ( t4  t3  xxx )
+name (value): div ()
 parent: NULL
 previousSibling: NULL
 nextSibling: NULL
 
   name (value): #text ( t4 )
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: NULL
   nextSibling: name (value): #text ( t3 )
 
   name (value): #text ( t3 )
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): #text ( t4 )
   nextSibling: name (value): b ()
 
   name (value): b ()
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): #text ( t3 )
   nextSibling: name (value): #text ( xxx )
 
@@ -428,58 +427,58 @@ nextSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( xxx )
-  parent: name (value): div ( t4  t3  xxx )
+  parent: name (value): div ()
   previousSibling: name (value): b ()
   nextSibling: NULL
 
 p:
 
-name (value): p (X t2  xxx  t1  t5  frob  t6 )
+name (value): p ()
 parent: NULL
 previousSibling: NULL
 nextSibling: NULL
 
-  name (value): b (X)
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  name (value): b ()
+  parent: name (value): p ()
   previousSibling: NULL
   nextSibling: name (value): #text ( t2 )
 
     name (value): #text (X)
-    parent: name (value): b (X)
+    parent: name (value): b ()
     previousSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( t2 )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
-  previousSibling: name (value): b (X)
+  parent: name (value): p ()
+  previousSibling: name (value): b ()
   nextSibling: name (value): #text ( xxx )
 
   name (value): #text ( xxx )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t2 )
   nextSibling: name (value): #text ( t1 )
 
   name (value): #text ( t1 )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( xxx )
   nextSibling: name (value): #text ( t5 )
 
   name (value): #text ( t5 )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t1 )
-  nextSibling: name (value): i ( frob )
+  nextSibling: name (value): i ()
 
-  name (value): i ( frob )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
+  name (value): i ()
+  parent: name (value): p ()
   previousSibling: name (value): #text ( t5 )
   nextSibling: name (value): #text ( t6 )
 
     name (value): #text ( frob )
-    parent: name (value): i ( frob )
+    parent: name (value): i ()
     previousSibling: NULL
     nextSibling: NULL
 
   name (value): #text ( t6 )
-  parent: name (value): p (X t2  xxx  t1  t5  frob  t6 )
-  previousSibling: name (value): i ( frob )
+  parent: name (value): p ()
+  previousSibling: name (value): i ()
   nextSibling: NULL

--- a/ext/dom/tests/bug42082.phpt
+++ b/ext/dom/tests/bug42082.phpt
@@ -22,9 +22,9 @@ DOMNodeList
 int(0)
 bool(true)
 bool(true)
-string(0) ""
+NULL
 bool(true)
-bool(true)
+bool(false)
 bool(false)
 bool(false)
 ===DONE===

--- a/ext/dom/tests/bug69846.phpt
+++ b/ext/dom/tests/bug69846.phpt
@@ -81,11 +81,7 @@ object(DOMElement)#%d (17) {
   ["nodeName"]=>
   string(5) "form1"
   ["nodeValue"]=>
-  string(39) "
-    Value A
-    Value B
-    Value C
-  "
+  NULL
   ["nodeType"]=>
   int(1)
   ["parentNode"]=>

--- a/ext/dom/tests/bug70029.phpt
+++ b/ext/dom/tests/bug70029.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #70029 (nodeValue of DOMElement list content of children nodes)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$doc = new DOMDocument();
+$doc->loadXml('<tag><childtag>myString</childtag></tag>');
+var_dump($doc->documentElement->nodeValue);
+?>
+--EXPECT--
+NULL

--- a/ext/dom/tests/dom001.phpt
+++ b/ext/dom/tests/dom001.phpt
@@ -108,7 +108,7 @@ Num Children: 4
 Node Name: title
 Node Type: 1
 Num Children: 1
-Node Content: Title
+Node Content: 
 
 Node Name: #text
 Node Type: 3
@@ -142,7 +142,7 @@ Num Children: 4
 Node Name: title
 Node Type: 1
 Num Children: 1
-Node Content: Title
+Node Content: 
 
 Node Name: #text
 Node Type: 3
@@ -186,7 +186,7 @@ Node Content: en
 Node Name: Silly
 Node Type: 1
 Num Children: 1
-Node Content: Symphony
+Node Content: 
 
 <?xml version="1.0" standalone="yes"?>
 <!DOCTYPE chapter SYSTEM "/share/sgml/Norman_Walsh/db3xml10/db3xml10.dtd" [
@@ -214,24 +214,24 @@ Node Content: Symphony
 Node Name: Silly
 Node Type: 1
 Num Children: 1
-Node Content: Symphony
+Node Content: 
 
     Using elem
 Node Name: Silly
 Node Type: 1
 Num Children: 1
-Node Content: Symphony
+Node Content: 
 
 --------- Unlink Node
 Node Name: Silly
 Node Type: 1
 Num Children: 1
-Node Content: Symphony
+Node Content: 
 
 Node Name: title
 Node Type: 1
 Num Children: 1
-Node Content: Title
+Node Content: 
 
 Node Name: #text
 Node Type: 3


### PR DESCRIPTION
According to the W3C DOM Core Level 3 specification [DOMElement::nodeValue is
supposed to yield null](http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-F68D080), but currently the DOM extension yield the result of
calling xmlNodeGetContent(), what is the concatenation of the values of the
children of the element. This patch fixes the non standard behavior.

Due to the obvious BC break it might be best to apply the patch only against master (i.e. PHP 7).