### PR TITLE
GOTO: branch hinting for execute_ex() internal label table initialization.

### DIFF
--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -1189,7 +1189,7 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
 					  // Emit array of labels of opcode handlers and code for
 					  // zend_opcode_handlers initialization
 						$prolog = $m[1];
-						out($f,$prolog."if (execute_data == NULL) {\n");
+						out($f,$prolog."if (UNEXPECTED(execute_data == NULL)) {\n");
 						out($f,$prolog."\tstatic const void* labels[] = {\n");
 						gen_labels($f, $spec, $kind, $prolog."\t\t");
 						out($f,$prolog."\t};\n");


### PR DESCRIPTION
Minor performance improvement for GOTO VM kind.
The check for label table initialization shall be hinted as UNEXPECTED, as it is executed only once, at initialization time.