### PR TITLE
Fix #63174 - mt_rand() fails when given range exceeding PHP_INT_MAX

### DIFF
--- a/ext/standard/int_overflow.h
+++ b/ext/standard/int_overflow.h
@@ -1,0 +1,89 @@
+/**
+ * "How to detect integer overflow in C and C++ addition and subtraction"
+ * http://ptspts.blogspot.com/2014/01/how-to-detect-integer-overflow-in-c-and.html
+ */
+#ifndef _INT_OVERFLOW_H
+#define _INT_OVERFLOW_H 1
+
+#undef MAX_INT_SIZE
+#ifdef __cplusplus  /* g++-4.6 doesn't have __builtin_choose_expr. */
+static inline unsigned TO_UNSIGNED_LOW(int x) { return x; } 
+static inline unsigned TO_UNSIGNED_LOW(unsigned x) { return x; } 
+static inline unsigned long long TO_UNSIGNED_LOW(long long x) { return x; } 
+static inline unsigned long long TO_UNSIGNED_LOW(unsigned long long x) { return x; } 
+#endif
+#if __SIZEOF_INT128__ >= 16 || ((__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)) && __SIZEOF_SIZE_T__ >= 8)
+#ifdef __cplusplus  /* g++-4.6 doesn't have __builtin_choose_expr. */
+static inline __uint128_t TO_UNSIGNED_LOW(__int128_t x) { return x; } 
+static inline __uint128_t TO_UNSIGNED_LOW(__uint128_t x) { return x; } 
+#else
+#define TO_UNSIGNED_LOW(x) ( \
+    __builtin_choose_expr(sizeof(x) <= sizeof(int), (unsigned)(x), \
+    __builtin_choose_expr(sizeof(x) <= sizeof(long long), (unsigned long long)(x), \
+    __builtin_choose_expr(sizeof(x) <= sizeof(__int128_t), (__uint128_t)(x), \
+    (void)0))))  /* Compile-time error when assigned to something. */
+#endif
+#define MAX_INT_SIZE (sizeof(long long) > sizeof(__int128_t) ? sizeof(long long) : sizeof(__int128_t))
+#else
+#ifndef __cplusplus
+#define TO_UNSIGNED_LOW(x) ( \
+    __builtin_choose_expr(sizeof(x) <= sizeof(int), (unsigned)(x), \
+    __builtin_choose_expr(sizeof(x) <= sizeof(long long), (unsigned long long)(x), \
+    (void)0)))  /* Compile-time error when assigned to something. */
+#endif
+#define MAX_INT_SIZE (sizeof(long long))
+#endif
+/* Converts to the the corresponding (or a bit larger) unsigned type.
+ */
+#define to_unsigned(x) TO_UNSIGNED_LOW(x)
+
+/* Doesn't evaluate x. Returns (int)0 or (int)1 indicating whether the value or
+ * type x is unsigned.
+ */
+#define is_unsigned(a) (((__typeof__(a))-1) > 0)
+
+/* Detect signed addition overflow, without executing a single overflowing
+ * operation.
+ */
+#define _IS_ADD_OVERFLOW_S(x, y, c) ({ \
+    __typeof__(x) _x = (x), _y  = (y), _z = \
+        (_x ^ ~_y) & (1 << (sizeof(_x) * 8 - 1)); \
+    (int)(((_z & (((_x ^ _z) + _y + (c)) ^ ~_y)) >> \
+    (sizeof(_x) * 8 - 1)) & 1); })
+
+/* Detect signed subtraction overflow, without executing a single overflowing
+ * operation.
+ */
+#define _IS_SUBTRACT_OVERFLOW_S(x, y, c) ({ \
+    __typeof__(x) _x = (x), _y  = (y), _z = \
+        (_x ^ ~_y) & (1 << (sizeof(_x) * 8 - 1)); \
+    (int)(((_z & (((_x ^ _z) - _y - (c)) ^ _y)) >> \
+    (sizeof(_x) * 8 - 1)) & 1); })
+
+/* Returns (int)0 or (int)1 indicating whether the addition x + y + c would
+ * overflow or underflow. x and y must be of the same (signed or unsigned)
+ * integer type, and c must be 0 or 1, of any integer (or bool) type.
+ */
+#define is_add_overflow(x, y, c) ( \
+    sizeof(x) > MAX_INT_SIZE && !is_unsigned(x) ? \
+    _IS_ADD_OVERFLOW_S(x, y, c) : ({ \
+    __typeof__(x) _x = (x), _y = (y), _s = \
+        (__typeof__(x))(to_unsigned(_x) + _y + (c)); \
+    is_unsigned(_x) ? \
+    (int)((((_x & _y) | ((_x | _y) & ~_s)) >> (sizeof(_x) * 8 - 1))) : \
+    (int)((((_s ^ _x) & (_s ^ _y)) >> (sizeof(_x) * 8 - 1)) & 1); }))
+
+/* Returns (int)0 or (int)1 indicating whether the subtraction x - y - c would
+ * overflow or underflow. x and y must be of the same (signed or unsigned)
+ * integer type, and c must be 0 or 1, of any integer (or bool) type.
+ */
+#define is_subtract_overflow(x, y, c) ( \
+    sizeof(x) > MAX_INT_SIZE && !is_unsigned(x) ? \
+    _IS_SUBTRACT_OVERFLOW_S(x, y, c) : ({ \
+    __typeof__(x) _x = (x), _y = (y), _s = \
+        (__typeof__(x))(to_unsigned(_x) - _y - (c)); \
+    is_unsigned(_x) ? \
+    (int)((((~_x & _y) | ((~_x | _y) & _s)) >> (sizeof(_x) * 8 - 1))) : \
+    (int)((((_x ^ _y) & (_s ^ _x)) >> (sizeof(_x) * 8 - 1)) & 1); }))
+
+#endif  /* INT_OVERFLOW_H */

--- a/ext/standard/php_rand.h
+++ b/ext/standard/php_rand.h
@@ -41,6 +41,31 @@
 #define PHP_RAND_MAX RAND_MAX
 #endif
 
+/*
+ * A bit of tricky math here.  We want to avoid using a modulus because
+ * that simply tosses the high-order bits and might skew the distribution
+ * of random values over the range.  Instead we map the range directly.
+ *
+ * We need to map the range from 0...M evenly to the range a...b
+ * Let n = the random number and n' = the mapped random number
+ *
+ * Then we have: n' = a + n(b-a)/M
+ *
+ * We have a problem here in that only n==M will get mapped to b which
+ # means the chances of getting b is much much less than getting any of
+ # the other values in the range.  We can fix this by increasing our range
+ # artificially and using:
+ #
+ #               n' = a + n(b-a+1)/M
+ *
+ # Now we only have a problem if n==M which would cause us to produce a
+ # number of b+1 which would be bad.  So we bump M up by one to make sure
+ # this will never happen, and the final algorithm looks like this:
+ #
+ #               n' = a + n(b-a+1)/(M+1)
+ *
+ * -RL
+ */
 #define RAND_RANGE(__n, __min, __max, __tmax) \
     (__n) = (__min) + (zend_long) ((double) ( (double) (__max) - (__min) + 1.0) * ((__n) / ((__tmax) + 1.0)))
 

--- a/ext/standard/rand.c
+++ b/ext/standard/rand.c
@@ -258,7 +258,6 @@ PHP_FUNCTION(mt_srand)
 }
 /* }}} */
 
-
 /* {{{ proto int rand([int min, int max])
    Returns a random number */
 PHP_FUNCTION(rand)
@@ -295,10 +294,6 @@ PHP_FUNCTION(mt_rand)
 		} else if (max < min) {
 			php_error_docref(NULL, E_WARNING, "max(" ZEND_LONG_FMT ") is smaller than min(" ZEND_LONG_FMT ")", max, min);
 			RETURN_FALSE;
-		} else if (is_subtract_overflow(max, min, 0)) {
-			php_error_docref(NULL, E_WARNING, "range of max(" ZEND_LONG_FMT ") minus min(" ZEND_LONG_FMT ") would overflow", max, min);
-			RETURN_FALSE;
-
 		}
 	}
 

--- a/ext/standard/rand.c
+++ b/ext/standard/rand.c
@@ -30,6 +30,7 @@
 #include "php.h"
 #include "php_math.h"
 #include "php_rand.h"
+#include "int_overflow.h"
 
 #include "basic_functions.h"
 
@@ -294,10 +295,7 @@ PHP_FUNCTION(mt_rand)
 		} else if (max < min) {
 			php_error_docref(NULL, E_WARNING, "max(" ZEND_LONG_FMT ") is smaller than min(" ZEND_LONG_FMT ")", max, min);
 			RETURN_FALSE;
-		} else if (
-			(min > 0 && max < (ZEND_LONG_MAX - min)) ||
-			(min < 0 && max > (ZEND_LONG_MAX + min))
-		) {
+		} else if (is_subtract_overflow(max, min, 0)) {
 			php_error_docref(NULL, E_WARNING, "range of max(" ZEND_LONG_FMT ") minus min(" ZEND_LONG_FMT ") would overflow", max, min);
 			RETURN_FALSE;
 

--- a/ext/standard/rand.c
+++ b/ext/standard/rand.c
@@ -320,6 +320,13 @@ PHP_FUNCTION(mt_rand)
 		} else if (max < min) {
 			php_error_docref(NULL, E_WARNING, "max(" ZEND_LONG_FMT ") is smaller than min(" ZEND_LONG_FMT ")", max, min);
 			RETURN_FALSE;
+		} else if (
+			(min > 0 && max < (PHP_MT_RAND_MAX - min)) ||
+			(min < 0 && max > (PHP_MT_RAND_MAX + min))
+		) {
+			php_error_docref(NULL, E_WARNING, "range of max(" ZEND_LONG_FMT ") minus min(" ZEND_LONG_FMT ") exceeds getrandmax()", max, min);
+			RETURN_FALSE;
+
 		}
 	}
 

--- a/ext/standard/rand.c
+++ b/ext/standard/rand.c
@@ -258,32 +258,6 @@ PHP_FUNCTION(mt_srand)
 /* }}} */
 
 
-/*
- * A bit of tricky math here.  We want to avoid using a modulus because
- * that simply tosses the high-order bits and might skew the distribution
- * of random values over the range.  Instead we map the range directly.
- *
- * We need to map the range from 0...M evenly to the range a...b
- * Let n = the random number and n' = the mapped random number
- *
- * Then we have: n' = a + n(b-a)/M
- *
- * We have a problem here in that only n==M will get mapped to b which
- # means the chances of getting b is much much less than getting any of
- # the other values in the range.  We can fix this by increasing our range
- # artificially and using:
- #
- #               n' = a + n(b-a+1)/M
- *
- # Now we only have a problem if n==M which would cause us to produce a
- # number of b+1 which would be bad.  So we bump M up by one to make sure
- # this will never happen, and the final algorithm looks like this:
- #
- #               n' = a + n(b-a+1)/(M+1)
- *
- * -RL
- */
-
 /* {{{ proto int rand([int min, int max])
    Returns a random number */
 PHP_FUNCTION(rand)

--- a/ext/standard/rand.c
+++ b/ext/standard/rand.c
@@ -313,7 +313,7 @@ PHP_FUNCTION(mt_rand)
 	zend_long max;
 	zend_long number;
 	int  argc = ZEND_NUM_ARGS();
-
+	
 	if (argc != 0) {
 		if (zend_parse_parameters(argc, "ll", &min, &max) == FAILURE) {
 			return;
@@ -321,8 +321,8 @@ PHP_FUNCTION(mt_rand)
 			php_error_docref(NULL, E_WARNING, "max(" ZEND_LONG_FMT ") is smaller than min(" ZEND_LONG_FMT ")", max, min);
 			RETURN_FALSE;
 		} else if (
-			(min > 0 && max < (INT_MAX - min)) ||
-			(min < 0 && max > (INT_MAX + min))
+			(min > 0 && max < (ZEND_LONG_MAX - min)) ||
+			(min < 0 && max > (ZEND_LONG_MAX + min))
 		) {
 			php_error_docref(NULL, E_WARNING, "range of max(" ZEND_LONG_FMT ") minus min(" ZEND_LONG_FMT ") would overflow", max, min);
 			RETURN_FALSE;

--- a/ext/standard/rand.c
+++ b/ext/standard/rand.c
@@ -313,7 +313,7 @@ PHP_FUNCTION(mt_rand)
 	zend_long max;
 	zend_long number;
 	int  argc = ZEND_NUM_ARGS();
-	
+
 	if (argc != 0) {
 		if (zend_parse_parameters(argc, "ll", &min, &max) == FAILURE) {
 			return;

--- a/ext/standard/rand.c
+++ b/ext/standard/rand.c
@@ -321,10 +321,10 @@ PHP_FUNCTION(mt_rand)
 			php_error_docref(NULL, E_WARNING, "max(" ZEND_LONG_FMT ") is smaller than min(" ZEND_LONG_FMT ")", max, min);
 			RETURN_FALSE;
 		} else if (
-			(min > 0 && max < (PHP_MT_RAND_MAX - min)) ||
-			(min < 0 && max > (PHP_MT_RAND_MAX + min))
+			(min > 0 && max < (INT_MAX - min)) ||
+			(min < 0 && max > (INT_MAX + min))
 		) {
-			php_error_docref(NULL, E_WARNING, "range of max(" ZEND_LONG_FMT ") minus min(" ZEND_LONG_FMT ") exceeds getrandmax()", max, min);
+			php_error_docref(NULL, E_WARNING, "range of max(" ZEND_LONG_FMT ") minus min(" ZEND_LONG_FMT ") would overflow", max, min);
 			RETURN_FALSE;
 
 		}

--- a/ext/standard/tests/general_functions/bug63174.phpt
+++ b/ext/standard/tests/general_functions/bug63174.phpt
@@ -2,15 +2,27 @@
 Random number generators should not accept a range that would lead to overflow
 --FILE--
 <?php
-mt_srand(123456);
-var_dump(mt_rand(-1,            getrandmax()));
-var_dump(mt_rand(-getrandmax(), getrandmax()));
-var_dump(mt_rand(-getrandmax(), getrandmax()));
-var_dump(mt_rand(PHP_INT_MIN,   PHP_INT_MAX));
+// the biggest range we can accommodate, based on RAND_RANGE scaling algo
+// 32bit: $upper == getrandmax()       // since we use 32-bit MT algo
+// 64bit: getrandmax() < PHP_INT_MAX   // since we allow scaling into 64-bit range
+$upper = PHP_INT_MAX;
+
+// now run some tests at the edge of that range, all should pass
+var_dump(mt_rand( 1, $upper));    // just inside range
+var_dump(mt_rand( 0, $upper));    // just at range
+var_dump(mt_rand(-1, $upper-1));  // just at range, different scale
+
+// now run some tests outside that range, we should get failures
+var_dump(mt_rand(-1,      $upper)); // one too big
+var_dump(mt_rand(-$upper, $upper)); // double your pleasure
+
+// common idioms that should also never work
+var_dump(mt_rand(PHP_INT_MIN, PHP_INT_MAX));
 
 --EXPECTF--
-Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
-bool(false)
+int(%i)
+int(%i)
+int(%i)
 
 Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
 bool(false)

--- a/ext/standard/tests/general_functions/bug63174.phpt
+++ b/ext/standard/tests/general_functions/bug63174.phpt
@@ -5,15 +5,19 @@ Random number generators should not accept a range that would lead to overflow
 // the biggest range we can accommodate, based on RAND_RANGE scaling algo
 // 32bit: $upper == getrandmax()       // since we use 32-bit MT algo
 // 64bit: getrandmax() < PHP_INT_MAX   // since we allow scaling into 64-bit range
+$lower = PHP_INT_MIN;
 $upper = PHP_INT_MAX;
 
 // now run some tests at the edge of that range, all should pass
-var_dump(mt_rand( 1, $upper));    // just inside range
-var_dump(mt_rand( 0, $upper));    // just at range
-var_dump(mt_rand(-1, $upper-1));  // just at range, different scale
+var_dump(mt_rand( 1,     $upper));    // just inside range
+var_dump(mt_rand( 0,     $upper));    // just at range
+var_dump(mt_rand(-1,     $upper-1));  // just at range, different scale
+var_dump(mt_rand($lower, -1));        // just inside range
 
 // now run some tests outside that range, we should get failures
 var_dump(mt_rand(-1,      $upper)); // one too big
+var_dump(mt_rand($lower,  1));      // also one too big
+var_dump(mt_rand($lower,  $upper)); // $upper - $lower > PHP_INT_MAX
 var_dump(mt_rand(-$upper, $upper)); // double your pleasure
 
 // common idioms that should also never work
@@ -23,6 +27,13 @@ var_dump(mt_rand(PHP_INT_MIN, PHP_INT_MAX));
 int(%i)
 int(%i)
 int(%i)
+int(%i)
+
+Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
+bool(false)
+
+Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
+bool(false)
 
 Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
 bool(false)

--- a/ext/standard/tests/general_functions/bug63174.phpt
+++ b/ext/standard/tests/general_functions/bug63174.phpt
@@ -2,6 +2,18 @@
 Random number generators should not accept a range that would lead to overflow
 --FILE--
 <?php
+// simple tests (these should all work)
+var_dump(mt_rand());
+var_dump(mt_rand(0, 242));
+var_dump(mt_rand(1, 242));
+var_dump(mt_rand(65, 90));
+var_dump(mt_rand(-242, -1));
+var_dump(mt_rand(-242, 0));
+var_dump(mt_rand(-242, 1));
+var_dump(mt_rand(-10000, 10000));
+var_dump(mt_rand(19781017, 20130513));
+var_dump(mt_rand(-19561018, -19551124));
+
 // the biggest range we can accommodate, based on RAND_RANGE scaling algo
 // 32bit: $upper == getrandmax()       // since we use 32-bit MT algo
 // 64bit: getrandmax() < PHP_INT_MAX   // since we allow scaling into 64-bit range
@@ -28,6 +40,16 @@ var_dump(mt_rand(-$upper, $upper)); // double your pleasure
 var_dump(mt_rand(PHP_INT_MIN, PHP_INT_MAX));
 
 --EXPECTF--
+int(%i)
+int(%i)
+int(%i)
+int(%i)
+int(%i)
+int(%i)
+int(%i)
+int(%i)
+int(%i)
+int(%i)
 int(%i)
 int(%i)
 int(%i)

--- a/ext/standard/tests/general_functions/bug63174.phpt
+++ b/ext/standard/tests/general_functions/bug63174.phpt
@@ -5,11 +5,18 @@ Random number generators should not accept a range that would lead to overflow
 mt_srand(123456);
 var_dump(mt_rand(-1,            getrandmax()));
 var_dump(mt_rand(-getrandmax(), getrandmax()));
+var_dump(mt_rand(-getrandmax(), getrandmax()));
+var_dump(mt_rand(PHP_INT_MIN,   PHP_INT_MAX));
 
 --EXPECTF--
-Warning: mt_rand(): range of max(2147483647) minus min(-1) exceeds getrandmax() in %s on line %d
+Warning: mt_rand(): range of max(%i) minus min(%i) exceeds getrandmax() in %s on line %d
 bool(false)
 
-Warning: mt_rand(): range of max(2147483647) minus min(-2147483647) exceeds getrandmax() in %s on line %d
+Warning: mt_rand(): range of max(%i) minus min(%i) exceeds getrandmax() in %s on line %d
 bool(false)
 
+Warning: mt_rand(): range of max(%i) minus min(%i) exceeds getrandmax() in %s on line %d
+bool(false)
+
+Warning: mt_rand(): range of max(%i) minus min(%i) exceeds getrandmax() in %s on line %d
+bool(false)

--- a/ext/standard/tests/general_functions/bug63174.phpt
+++ b/ext/standard/tests/general_functions/bug63174.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Random number generators should not accept a range that would lead to overflow
+--FILE--
+<?php
+mt_srand(123456);
+var_dump(mt_rand(-1,            getrandmax()));
+var_dump(mt_rand(-getrandmax(), getrandmax()));
+
+--EXPECTF--
+Warning: mt_rand(): range of max(2147483647) minus min(-1) exceeds getrandmax() in %s on line %d
+bool(false)
+
+Warning: mt_rand(): range of max(2147483647) minus min(-2147483647) exceeds getrandmax() in %s on line %d
+bool(false)
+

--- a/ext/standard/tests/general_functions/bug63174.phpt
+++ b/ext/standard/tests/general_functions/bug63174.phpt
@@ -1,72 +1,158 @@
 --TEST--
-Random number generators should not accept a range that would lead to overflow
+Random number generators should not overflow
 --FILE--
 <?php
-// simple tests (these should all work)
-var_dump(mt_rand());
-var_dump(mt_rand(0, 242));
-var_dump(mt_rand(1, 242));
-var_dump(mt_rand(65, 90));
-var_dump(mt_rand(-242, -1));
-var_dump(mt_rand(-242, 0));
-var_dump(mt_rand(-242, 1));
-var_dump(mt_rand(-10000, 10000));
-var_dump(mt_rand(19781017, 20130513));
-var_dump(mt_rand(-19561018, -19551124));
 
-// the biggest range we can accommodate, based on RAND_RANGE scaling algo
+// the biggest range we can accommodate, based on RAND_SCALE scaling algo
 // 32bit: $upper == getrandmax()       // since we use 32-bit MT algo
 // 64bit: getrandmax() < PHP_INT_MAX   // since we allow scaling into 64-bit range
+if (! defined('PHP_INT_MIN')) {
+    define('PHP_INT_MIN', (-PHP_INT_MAX-1));
+}
 $lower = PHP_INT_MIN;
 $upper = PHP_INT_MAX;
 
-// now run some tests at the edge of that range, all should pass
-var_dump(mt_rand( 1,     $upper));    // just inside range
-var_dump(mt_rand( 0,     $upper));    // just at range
-var_dump(mt_rand(-1,     $upper-1));  // just at range, different scale
-var_dump(mt_rand($lower, -1));        // just inside range
-var_dump(
-    mt_rand($lower, -1) +
-    mt_rand(0,      $upper)
+// define our test ranges
+$ranges = array (
+    // nowhere close to overflowing
+    array (0, 242),
+    array (1, 242),
+    array (65, 90),
+    array (-242, -1),
+    array (-242, 0),
+    array (-242, 1),
+    array (-10000, 10000),
+    array (19781017, 20130513),
+    array (-19561018, -19551124),
+
+    // teetering on the edge of overflow
+    array (1, $upper),    // barely inside range
+    array (1, $upper-1),  // also barely inside range
+    array (0, $upper),    // on the borders of our int size
+    array ($lower, -1),   // also on the borders of our int size
+
+    // range (max - min) exceeds PHP_INT_MAX
+    // notice these all cross 0
+    array (-1, $upper, true),               // one too big
+    array ($lower, 1, true),                // also one too big
+    array ($lower, $upper, true),           // $upper - $lower > PHP_INT_MAX
+    array (-$upper,$upper, true),           // double your pleasure
+    array ($lower, -($lower+1), true),      // double your pleasure, again
+    array (PHP_INT_MIN, PHP_INT_MAX, true), // whoa, as big as it gets
 );
 
-// now run some tests outside that range, we should get failures
-var_dump(mt_rand(-1,      $upper)); // one too big
-var_dump(mt_rand($lower,  1));      // also one too big
-var_dump(mt_rand($lower,  $upper)); // $upper - $lower > PHP_INT_MAX
-var_dump(mt_rand(-$upper, $upper)); // double your pleasure
+foreach (array ('mt_rand', 'rand') as $prng) {
+    var_dump($prng);
 
-// common idioms that should also never work
-var_dump(mt_rand(PHP_INT_MIN, PHP_INT_MAX));
+    // check that we produce random numbers in the given ranges
+    var_dump(count($ranges));
+    foreach ($ranges as $k => $range) {
+        $number = mt_rand($range[0], $range[1]);
+        var_dump($number);                                      // expect: integer
+        var_dump($range[0] <= $number && $number <= $range[1]); // expect: true
+    }
+
+    // quick check the uniformity of the distribution
+    // "each nonrandom sequence is nonrandom in its own way."
+    // Observed that zero popped up a lot when there was overflow
+    $n = 10000;
+    $t =  4000; // 40% is well more than would be expected in a uniform distribution
+    foreach ($ranges as $range) {
+        if (empty($range[2])) {
+            // not an overflow test, skip it
+            continue;
+        }
+        $zeroCnt = 0;
+        for ($i = 0; $i < $n; $i++) {
+            $point = mt_rand($range[0], $range[1]);
+            if (0 === $point) {
+                $zeroCnt++;
+            }
+        }
+        if ($t < $zeroCnt) {
+            var_dump("Zero popped up more than 40% of the time in range [${range[0]}, ${range[1]})");
+        }
+    }
+}
 
 --EXPECTF--
+string(7) "mt_rand"
+int(19)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
+bool(true)
 int(%i)
-
-Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
-bool(false)
-
-Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
-bool(false)
-
-Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
-bool(false)
-
-Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
-bool(false)
-
-Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
-bool(false)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+string(4) "rand"
+int(19)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)
+int(%i)
+bool(true)

--- a/ext/standard/tests/general_functions/bug63174.phpt
+++ b/ext/standard/tests/general_functions/bug63174.phpt
@@ -9,14 +9,14 @@ var_dump(mt_rand(-getrandmax(), getrandmax()));
 var_dump(mt_rand(PHP_INT_MIN,   PHP_INT_MAX));
 
 --EXPECTF--
-Warning: mt_rand(): range of max(%i) minus min(%i) exceeds getrandmax() in %s on line %d
+Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
 bool(false)
 
-Warning: mt_rand(): range of max(%i) minus min(%i) exceeds getrandmax() in %s on line %d
+Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
 bool(false)
 
-Warning: mt_rand(): range of max(%i) minus min(%i) exceeds getrandmax() in %s on line %d
+Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
 bool(false)
 
-Warning: mt_rand(): range of max(%i) minus min(%i) exceeds getrandmax() in %s on line %d
+Warning: mt_rand(): range of max(%i) minus min(%i) would overflow in %s on line %d
 bool(false)

--- a/ext/standard/tests/general_functions/bug63174.phpt
+++ b/ext/standard/tests/general_functions/bug63174.phpt
@@ -13,6 +13,10 @@ var_dump(mt_rand( 1,     $upper));    // just inside range
 var_dump(mt_rand( 0,     $upper));    // just at range
 var_dump(mt_rand(-1,     $upper-1));  // just at range, different scale
 var_dump(mt_rand($lower, -1));        // just inside range
+var_dump(
+    mt_rand($lower, -1) +
+    mt_rand(0,      $upper)
+);
 
 // now run some tests outside that range, we should get failures
 var_dump(mt_rand(-1,      $upper)); // one too big
@@ -24,6 +28,7 @@ var_dump(mt_rand(-$upper, $upper)); // double your pleasure
 var_dump(mt_rand(PHP_INT_MIN, PHP_INT_MAX));
 
 --EXPECTF--
+int(%i)
 int(%i)
 int(%i)
 int(%i)


### PR DESCRIPTION
Requesting a MT random number in a range that exceeds PHP_INT_MAX causes overflow, which then results in a non-uniform distribution of random numbers.  Examples:

```
$rand = mt_rand(PHP_INT_MIN, PHP_INT_MAX); // causes overflow $rand will be disproportionately 0
```

Fixed as follows. If overflow would not happen, proceed as before scaling into the desired range.  If overflow would happen, (a) scale the number into the negative range, (b) scale the number into the positive range, and (c) add them together.  While not technically a BC breakage, it's possible that someone was relying on the old behavior which produced disproportionately more zero values.  Advise if this should be back patched.

See: https://bugs.php.net/bug.php?id=63174