### PR TITLE
Enable compiler defenses against hostile memory-corruption exploitation for PHP/Windows

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -204,6 +204,8 @@ if (PHP_SNAPSHOT_TEMPLATE == "no") {
 	}
 }
 
+ARG_ENABLE("security-flags", "[Ignored] Disabling compiler security features no longer supported", "yes");
+
 DEFINE('SNAPSHOT_TEMPLATE', PHP_SNAPSHOT_TEMPLATE);
 
 /* XXX add and implement clang keyword for clang analyzer */

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -206,11 +206,6 @@ if (PHP_SNAPSHOT_TEMPLATE == "no") {
 
 DEFINE('SNAPSHOT_TEMPLATE', PHP_SNAPSHOT_TEMPLATE);
 
-ARG_ENABLE("security-flags", "Disable the compiler security flags", "yes");
-if (PHP_SECURITY_FLAGS == "yes") {
-	ADD_FLAG("LDFLAGS", "/NXCOMPAT /DYNAMICBASE ");
-}
-
 /* XXX add and implement clang keyword for clang analyzer */
 ARG_WITH("analyzer", "Enable static analyzer. Pass vs for Visual Studio, pvs for PVS-Studio", "no");
 if (PHP_ANALYZER == "vs") {

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -210,7 +210,6 @@ DEFINE('SNAPSHOT_TEMPLATE', PHP_SNAPSHOT_TEMPLATE);
 ARG_WITH("analyzer", "Enable static analyzer. Pass vs for Visual Studio, pvs for PVS-Studio", "no");
 if (PHP_ANALYZER == "vs") {
 	ADD_FLAG("CFLAGS", " /analyze ");
-	ADD_FLAG("CFLAGS", " /wd6308 ");
 } else if (PHP_ANALYZER == "pvs") {
 	var pvs_studio = false;
 

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2676,27 +2676,95 @@ function toolset_setup_common_libs()
 	DEFINE("LIBS", "kernel32.lib ole32.lib user32.lib advapi32.lib shell32.lib ws2_32.lib Dnsapi.lib psapi.lib");
 }
 
+function vs_warnings() {
+    var warnings = {};
+    warnings[4100] = "disable";	// Unreferenced formal parameter
+    warnings[4127] = "disable";	// Conditional expression is constant (usually a macro expansion, not an error)
+
+    warnings[4668] = "disable";	// Using #if UNDEFINED_MACRO instead of #ifdef UNDEFINED_MACRO
+    warnings[4710] = "disable";	// The compiler decided not to inline a function marked as INLINE
+    warnings[4711] = "disable";	// The compiler decided to inline a function
+
+    warnings[4820] = "disable";	// Message about padding bytes added to a structurenote
+
+    // By default, output all warnings but not as errors.
+    ADD_FLAG("CFLAGS", "/Wall /WX-");
+
+    // turn the warning array into compiler switches
+    for (var k in warnings) {
+        switch (warnings[k]) {
+            case "disable":
+                ADD_FLAG("CFLAGS", "/wd" + k);
+                break;
+            case "once":
+                ADD_FLAG("CFLAGS", "/wo" + k);
+                break;
+            case "error":
+                ADD_FLAG("CFLAGS", "/we" + k);
+                break;
+            default:
+                ERROR("Unknown warning type '" + warnings[k] + "' for warning " + k);
+                break;
+        }
+    }
+
+    // also perform static analysis of the code and output it to the build directory
+    ADD_FLAG("CFLAGS", "/analyze:log \"$(BUILD_DIR)\\codeanalysis.txt\" /analyze:quiet ");
+}
+
 function toolset_setup_build_mode()
 {
-	if (PHP_DEBUG == "yes") {
-		ADD_FLAG("CFLAGS", "/LDd /MDd /W3 /Gm /Od /D _DEBUG /D ZEND_DEBUG=1 " +
-			(X64?"/Zi":"/ZI"));
-		ADD_FLAG("LDFLAGS", "/debug");
-		// Avoid problems when linking to release libraries that use the release
-		// version of the libc
-		ADD_FLAG("PHP_LDFLAGS", "/nodefaultlib:msvcrt");
-	} else {
-		// Generate external debug files when --enable-debug-pack is specified
-		if (PHP_DEBUG_PACK == "yes") {
-			ADD_FLAG("CFLAGS", "/Zi");
-			ADD_FLAG("LDFLAGS", "/incremental:no /debug /opt:ref,icf");
-		}
-		// Equivalent to Release_TSInline build -> best optimization
-		ADD_FLAG("CFLAGS", "/LD /MD /W3 /Ox /D NDebug /D NDEBUG /D ZEND_WIN32_FORCE_INLINE /GF /D ZEND_DEBUG=0");
+    if (PHP_DEBUG == "yes") {
+        ADD_FLAG("CFLAGS", "/LDd /MDd /Gm /Od /D _DEBUG /D ZEND_DEBUG=1");
+        // Avoid problems when linking to release libraries that use the release
+        // version of the libc
+        ADD_FLAG("PHP_LDFLAGS", "/nodefaultlib:msvcrt");
 
-		// if you have VS.Net /GS hardens the binary against buffer overruns
-		// ADD_FLAG("CFLAGS", "/GS");
-	}
+        // Poison uninitialized locals, detect local variable stack buffer under/overruns and detect calling-convention errors
+        ADD_FLAG("CFLAGS", "/RTCs");
+
+        // Detect integer truncation errors
+        ADD_FLAG("CFLAGS", "/RTCc");
+
+        // Abort on uninitialized local use
+        ADD_FLAG("CFLAGS", "/RTCu");
+
+    } else {
+        ADD_FLAG("LDFLAGS", "/incremental:no /opt:ref,icf");
+        // Equivalent to Release_TSInline build -> best optimization
+        ADD_FLAG("CFLAGS", "/LD /MD /Ox /D NDebug /D NDEBUG /D ZEND_WIN32_FORCE_INLINE /GF /D ZEND_DEBUG=0");
+    }
+
+    //
+    // Security features for both Release and Debug builds:
+    //
+
+    // Enable PDBs by default.
+    ADD_FLAG("CFLAGS", "/Zi");
+    ADD_FLAG("LDFLAGS", "/debug");
+
+    // Set the compiler to output code-quality and possible errors to the console.
+    vs_warnings();
+
+    // Detects and prevents some stack buffer overruns that overwrite a function's return address. 
+    // This reduces the ability of hackers to cause exploit stack-overflow based memory corruptions in PHP deployed on Windows servers
+    ADD_FLAG("CFLAGS", "/GS");
+
+    // Detects and prevents function pointer corruptions caused by uninitialized local variables, use-after-free vulnerabilities, heap-overflows
+    // and some categories of stack-overflow vulnerabilities.
+    // This dramatically reduces the ability of hackers to cause exploit memory corruptions on PHP deployed on Windows Servers
+    // (Only available in Visual Studio 2015+)
+    if(VCVERS >= 1900)
+    {
+        ADD_FLAG("CFLAGS", "/guard:cf");
+        ADD_FLAG("LDFLAGS", "/guard:cf");
+    }
+
+    // Mark the binary as supporting Data Execution prevention to dramatically reduce exploitability of memory-corruption bugs
+    ADD_FLAG("LDFLAGS", "/NXCOMPAT");
+
+    // Mark the binary as supporting Address Space Layout Randomization to dramatically reduce exploitability of memory-corruption bugs
+    ADD_FLAG("LDFLAGS", "/DYNAMICBASE");
 }
 
 function object_out_dir_option_handle()

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2629,7 +2629,19 @@ function toolset_setup_common_cflags()
 	if (VS_TOOLSET) {
 		ADD_FLAG("CFLAGS", " /FD ");
 
-		ADD_FLAG('CFLAGS', '/D_USE_32BIT_TIME_T=1 ');
+		// fun stuff: MS deprecated ANSI stdio and similar functions
+		// disable annoying warnings.  In addition, time_t defaults
+		// to 64-bit.  Ask for 32-bit.
+		if (X64) {
+			ADD_FLAG('CFLAGS', ' /wd4996 ');
+		} else {
+			ADD_FLAG('CFLAGS', ' /wd4996 /D_USE_32BIT_TIME_T=1 ');
+		}
+
+		if (PHP_DEBUG == "yes") {
+			// Set some debug/release specific options
+			ADD_FLAG('CFLAGS', ' /RTC1 ');
+		}
 
 	} else if (CLANG_TOOLSET) {
 		if (X64) {
@@ -2668,10 +2680,12 @@ function vs_warnings() {
     var warnings = {};
     warnings[4100] = "disable";	// Unreferenced formal parameter
     warnings[4127] = "disable";	// Conditional expression is constant (usually a macro expansion, not an error)
+
     warnings[4668] = "disable";	// Using #if UNDEFINED_MACRO instead of #ifdef UNDEFINED_MACRO
     warnings[4710] = "disable";	// The compiler decided not to inline a function marked as INLINE
     warnings[4711] = "disable";	// The compiler decided to inline a function
-    warnings[4820] = "disable";	// Message about padding bytes added to a structure
+
+    warnings[4820] = "disable";	// Message about padding bytes added to a structurenote
 
     // By default, output all warnings but not as errors.
     ADD_FLAG("CFLAGS", "/Wall /WX-");
@@ -2729,7 +2743,6 @@ function toolset_setup_build_mode()
     ADD_FLAG("CFLAGS", "/Zi");
     ADD_FLAG("LDFLAGS", "/debug");
 
-
     // Set the compiler to output code-quality and possible errors to the console.
     vs_warnings();
 
@@ -2745,12 +2758,6 @@ function toolset_setup_build_mode()
     {
         ADD_FLAG("CFLAGS", "/guard:cf");
         ADD_FLAG("LDFLAGS", "/guard:cf");
-    }
-
-    // /SAFESEH protects against exception handler corruption within the process. We should enable it even if we don't use exception handlers, because
-    // Windows and other binaries do. /SAFESEH is x86 only; other platforms are automatically protected by this mitigation.
-    if (!X64) {
-        ADD_FLAG("LDFLAGS", "/SAFESEH");
     }
 
     // Mark the binary as supporting Data Execution prevention to dramatically reduce exploitability of memory-corruption bugs
@@ -2846,8 +2853,6 @@ function php_build_option_handle()
 					}
 				}
 			}
-			if (PHP_PHP_BUILD == "no")
-			    PHP_PHP_BUILD = ".";
 		}
 		PHP_PHP_BUILD = FSO.GetAbsolutePathName(PHP_PHP_BUILD);
 	}

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2750,6 +2750,12 @@ function toolset_setup_build_mode()
     // This reduces the ability of hackers to cause exploit stack-overflow based memory corruptions in PHP deployed on Windows servers
     ADD_FLAG("CFLAGS", "/GS");
 
+    // /SAFESEH protects against exception handler corruption within the process. We should enable it even if we don't use exception handlers, because
+    // Windows and other binaries do. /SAFESEH is x86 only; other platforms are automatically protected by this mitigation.
+    if (!X64) {
+        ADD_FLAG("LDFLAGS", "/SAFESEH");
+    }
+
     // Detects and prevents function pointer corruptions caused by uninitialized local variables, use-after-free vulnerabilities, heap-overflows
     // and some categories of stack-overflow vulnerabilities.
     // This dramatically reduces the ability of hackers to cause exploit memory corruptions on PHP deployed on Windows Servers


### PR DESCRIPTION
Enable various compiler defenses against memory-corruption exploitation by hackers when compiling PHP for Windows.

Specifically, this commit adds the following:

== Memory Corruption Exploitation Mitigations ==
- Enabled /GS on the compiler, to allow many categories of stack-overflow to be detected by the compiler and aborted. This reduces the ability of hackers to exploit stack-overflow vulnerabilities in PHP.
- Enabled /NXCOMPAT, which informs Windows that data (such as allocations on the heap, the stack and data sections within the binary) are not executable code. This is a baseline security feature to protect against most categories of memory-corruption exploit.
- Enabled /DYNAMICBASE, which informs Windows that the binary supports Address Space Layout Randomization. This means that PHP's EXE and DLL modules will be located at different (randomized) addresses on each different server and after each server restart. This reduces the ability of hackers to know in advance where useful machine code sequences and library functions in the PHP process on the server are, and hence reduce the ability of hackers to overwrite function pointers and take control of the server using a memory corruption vulnerability. This is a baseline security feature to protect against most categories of memory-corruption exploit.
- Enabled /guard:cf, which informs Windows that the binary supports Control Flow Guard. This allows latest versions of Windows to protect against most instances where a hacker is able to overwrite a function pointer in the process (such as via an uninitialized local, heap-overflow, stack-overflow, double-free, underflow or use-after-free memory corruption vulnerability). This is a baseline security feature to protect against most categories of memory-corruption exploit on newer versions of Windows Server.
- On debug builds, /RTCs, /RTCu, /RTCc tries to detect memory-corruption issues associated with local-variables, such as using local variables before they are initialized and stack buffer overflow/underflows. This gives higher granularity than /GS, but is not compatible with optimized builds, and so is only enabled for debug builds.

== Symbols output by default ==
Enabled PDB symbol output by default to increase the ability to debug crashes.

This also means that when shipping binaries as packages to end-users, we can compile once and then separate the PDBs in the output directory into the "symbol package", rather than build twice and risk non-deterministic compiler behavior leading to corrupt symbols.

For x86 builds, we now only output debug symbols via /Zi (Program Database) rather than /ZI (Program Database for Edit and Continue) in order to avoid a collision with /guard:cf. If developers are currently using Visual Studio's "Edit and Continue" feature for x86 builds, I'm happy to revisit this.

== Automatic Code Analysis ==
- Enabled all(+) compiler warnings to print to STDOUT 
  -- (+) Some very noisy warnings that rarely correspond to real errors are disabled.
  -- These warnings only print to standard out during a build, so does not affect the build.
- Enabled PREFAST analysis during the build. PREFAST will perform static analysis of the code and place it into "codeanalysis.txt" in the output directory once the build is complete.
