### PR TITLE
Remove timestamps from build to make it reproducible

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -863,7 +863,6 @@ PHPAPI void php_print_info(int flag)
 		php_info_print_box_end();
 		php_info_print_table_start();
 		php_info_print_table_row(2, "System", ZSTR_VAL(php_uname));
-		php_info_print_table_row(2, "Build Date", __DATE__ " " __TIME__);
 #ifdef COMPILER
 		php_info_print_table_row(2, "Compiler", COMPILER);
 #endif

--- a/ext/standard/tests/general_functions/phpinfo.phpt
+++ b/ext/standard/tests/general_functions/phpinfo.phpt
@@ -19,7 +19,6 @@ phpinfo()
 PHP Version => %s
 
 System => %s
-Build Date => %s%a
 Configure Command => %s
 Server API => Command Line Interface
 Virtual Directory Support => %s

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -2213,9 +2213,9 @@ consult the installation file that came with this distribution, or visit \n\
 								SG(request_info).no_headers = 1;
 							}
 #if ZEND_DEBUG
-							php_printf("PHP %s (%s) (built: %s %s) (DEBUG)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
+							php_printf("PHP %s (%s) (DEBUG)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, get_zend_version());
 #else
-							php_printf("PHP %s (%s) (built: %s %s)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
+							php_printf("PHP %s (%s)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, get_zend_version());
 #endif
 							php_request_shutdown((void *) 0);
 							fcgi_shutdown();

--- a/sapi/cgi/tests/001.phpt
+++ b/sapi/cgi/tests/001.phpt
@@ -15,7 +15,7 @@ var_dump(`$php -n -v`);
 echo "Done\n";
 ?>
 --EXPECTF--
-string(%d) "PHP %s (cgi%s (built: %s
+string(%d) "PHP %s (cgi%s
 Copyright (c) 1997-20%s The PHP Group
 Zend Engine v%s, Copyright (c) 1998-20%s Zend Technologies
 "

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -682,8 +682,8 @@ static int do_cli(int argc, char **argv) /* {{{ */
 				goto out;
 
 			case 'v': /* show php version & quit */
-				php_printf("PHP %s (%s) (built: %s %s) %s\nCopyright (c) 1997-2015 The PHP Group\n%s",
-					PHP_VERSION, cli_sapi_module.name, __DATE__, __TIME__,
+				php_printf("PHP %s (%s) %s\nCopyright (c) 1997-2015 The PHP Group\n%s",
+					PHP_VERSION, cli_sapi_module.name,
 #if ZEND_DEBUG && defined(HAVE_GCOV)
 					"(DEBUG GCOV)",
 #elif ZEND_DEBUG

--- a/sapi/cli/tests/001.phpt
+++ b/sapi/cli/tests/001.phpt
@@ -12,7 +12,7 @@ var_dump(`$php -n -v`);
 echo "Done\n";
 ?>
 --EXPECTF--	
-string(%d) "PHP %s (cli) (built: %s)%s
+string(%d) "PHP %s (cli)%s
 Copyright (c) 1997-20%d The PHP Group
 Zend Engine v%s, Copyright (c) 1998-20%d Zend Technologies
 "

--- a/sapi/cli/tests/015.phpt
+++ b/sapi/cli/tests/015.phpt
@@ -13,15 +13,15 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 $php = getenv('TEST_PHP_EXECUTABLE');
 
 
-echo `"$php" -n --version | grep built:`;
+echo `"$php" -n --version | grep ^PHP`;
 echo `echo "<?php print_r(\\\$argv);" | "$php" -n -- foo bar baz`, "\n";
-echo `"$php" -n --version foo bar baz | grep built:`;
+echo `"$php" -n --version foo bar baz | grep ^PHP`;
 echo `"$php" -n --notexisting foo bar baz | grep Usage:`;
 
 echo "Done\n";
 ?>
 --EXPECTF--     
-PHP %d.%d.%d%s(cli) (built: %s)%s
+PHP %d.%d.%d%s(cli)%s
 Array
 (
     [0] => -
@@ -30,6 +30,6 @@ Array
     [3] => baz
 )
 
-PHP %d.%d.%d%s(cli) (built: %s)%s
+PHP %d.%d.%d%s(cli)%s
 Usage: %s [options] [-f] <file> [--] [args...]
 Done

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1730,9 +1730,9 @@ int main(int argc, char *argv[])
 				SG(request_info).no_headers = 1;
 
 #if ZEND_DEBUG
-				php_printf("PHP %s (%s) (built: %s %s) (DEBUG)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__,        __TIME__, get_zend_version());
+				php_printf("PHP %s (%s) (DEBUG)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, get_zend_version());
 #else
-				php_printf("PHP %s (%s) (built: %s %s)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__,      get_zend_version());
+				php_printf("PHP %s (%s)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, get_zend_version());
 #endif
 				php_request_shutdown((void *) 0);
 				fcgi_shutdown();

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -807,9 +807,9 @@ static int cli_main( int argc, char * argv[] )
             case 'v':
                 if (php_request_startup() != FAILURE) {
 #if ZEND_DEBUG
-                    php_printf("PHP %s (%s) (built: %s %s) (DEBUG)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
+                    php_printf("PHP %s (%s) (DEBUG)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, get_zend_version());
 #else
-                    php_printf("PHP %s (%s) (built: %s %s)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
+                    php_printf("PHP %s (%s)\nCopyright (c) 1997-2015 The PHP Group\n%s", PHP_VERSION, sapi_module.name, get_zend_version());
 #endif
 #ifdef PHP_OUTPUT_NEWAPI
                     php_output_end_all();

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1373,10 +1373,8 @@ phpdbg_main:
 				sapi_startup(phpdbg);
 				phpdbg->startup(phpdbg);
 				printf(
-					"phpdbg %s (built: %s %s)\nPHP %s, Copyright (c) 1997-2015 The PHP Group\n%s",
+					"phpdbg %s\nPHP %s, Copyright (c) 1997-2015 The PHP Group\n%s",
 					PHPDBG_VERSION,
-					__DATE__,
-					__TIME__,
 					PHP_VERSION,
 					get_zend_version()
 				);


### PR DESCRIPTION
The PHP build embeds timestamps into the generated binaries at build time. This
makes the build not reproducible, as in that the same source code will not
generate the bitwise exact same binaries.

Reproducible builds are important amongst others to verify the integrity of
distributions. See: https://wiki.debian.org/ReproducibleBuilds

We believe the value of the embedded timestamps is very limited. They do not
indicate which release, commit or git branch has been built, only a date which
in itself does not really say something. Therefore it seems safe to remove
them.
