### PR TITLE
modify for while nginx fastcgi keepalive enabled ,when the max reques…

### DIFF
--- a/sapi/fpm/fpm/fastcgi.c
+++ b/sapi/fpm/fpm/fastcgi.c
@@ -737,7 +737,7 @@ void fcgi_close(fcgi_request *req, int force, int destroy)
 			}
 			DisconnectNamedPipe(pipe);
 		} else {
-			if (!force) {
+			if (!force || req->keep) {
 				char buf[8];
 
 				shutdown(req->fd, 1);
@@ -746,7 +746,7 @@ void fcgi_close(fcgi_request *req, int force, int destroy)
 			closesocket(req->fd);
 		}
 #else
-		if (!force) {
+		if (!force || req->keep) {
 			char buf[8];
 
 			shutdown(req->fd, 1);


### PR DESCRIPTION
…ts (MAX_REQUEST in php_fpm.conf) counter reached , fpm will close(req->fd) directly ，with no shutdown() and wait for the packets that nginx returned . the last reponse to nginx will fail because php-fpm will return "Reset" tcp packet.