### PR TITLE
Fix #53156: imagerectangle problem with point ordering

### DIFF
--- a/ext/gd/libgd/gd.c
+++ b/ext/gd/libgd/gd.c
@@ -2044,7 +2044,9 @@ void gdImageRectangle (gdImagePtr im, int x1, int y1, int x2, int y2, int color)
 		t=y1;
 		y1 = y2;
 		y2 = t;
-
+	}
+	
+	if (x2 < x1) {
 		t = x1;
 		x1 = x2;
 		x2 = t;

--- a/ext/gd/tests/bug53156.phpt
+++ b/ext/gd/tests/bug53156.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Bug #53156 (imagerectangle problem with point ordering)
+--SKIPIF--
+<?php
+if (!extension_loaded('gd')) die('skip gd extension not available');
+?>
+--FILE--
+<?php
+function draw_and_check_pixel($x, $y)
+{
+    global $img, $black, $red;
+    
+    echo (imagecolorat($img, $x, $y) === $black) ? '+' : '-';
+    imagesetpixel($img, $x, $y, $red);
+}
+
+function draw_and_check_rectangle($x1, $y1, $x2, $y2)
+{
+    global $img, $black;
+    
+    echo 'Rectangle: ';
+    imagerectangle($img, $x1, $y1, $x2, $y2, $black);
+    draw_and_check_pixel(($x1 + $x2) / 2, $y1);
+    draw_and_check_pixel($x1, ($y1 + $y2) / 2);
+    draw_and_check_pixel(($x1 + $x2) / 2, $y2);
+    draw_and_check_pixel($x2, ($y1 + $y2) / 2);
+    echo PHP_EOL;
+}
+
+$img = imagecreate(110, 210);
+$bgnd  = imagecolorallocate($img, 255, 255, 255);
+$black = imagecolorallocate($img, 0, 0, 0);
+$red = imagecolorallocate($img, 255, 0, 0);
+
+draw_and_check_rectangle(10, 10, 50, 50);
+draw_and_check_rectangle(50, 60, 10, 100);
+draw_and_check_rectangle(50, 150, 10, 110);
+draw_and_check_rectangle(10, 200, 50, 160);
+imagesetthickness($img, 4);
+draw_and_check_rectangle(60, 10, 100, 50);
+draw_and_check_rectangle(100, 60, 60, 100);
+draw_and_check_rectangle(100, 150, 60, 110);
+draw_and_check_rectangle(60, 200, 100, 160);
+
+imagepng($img, __DIR__ . '/bug53156.png');
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/bug53156.png');
+?>
+--EXPECT--
+Rectangle: ++++
+Rectangle: ++++
+Rectangle: ++++
+Rectangle: ++++
+Rectangle: ++++
+Rectangle: ++++
+Rectangle: ++++
+Rectangle: ++++

--- a/ext/gd/tests/bug53156.phpt
+++ b/ext/gd/tests/bug53156.phpt
@@ -20,33 +20,31 @@ function draw_and_check_rectangle($x1, $y1, $x2, $y2)
     
     echo 'Rectangle: ';
     imagerectangle($img, $x1, $y1, $x2, $y2, $black);
-    draw_and_check_pixel(($x1 + $x2) / 2, $y1);
-    draw_and_check_pixel($x1, ($y1 + $y2) / 2);
-    draw_and_check_pixel(($x1 + $x2) / 2, $y2);
-    draw_and_check_pixel($x2, ($y1 + $y2) / 2);
+    $x = ($x1 + $x2) / 2;
+    $y = ($y1 + $y2) / 2;
+    draw_and_check_pixel($x,  $y1);
+    draw_and_check_pixel($x1, $y);
+    draw_and_check_pixel($x,  $y2);
+    draw_and_check_pixel($x2, $y);
     echo PHP_EOL;
 }
 
 $img = imagecreate(110, 210);
 $bgnd  = imagecolorallocate($img, 255, 255, 255);
-$black = imagecolorallocate($img, 0, 0, 0);
-$red = imagecolorallocate($img, 255, 0, 0);
+$black = imagecolorallocate($img,   0,   0,   0);
+$red   = imagecolorallocate($img, 255,   0,   0);
 
-draw_and_check_rectangle(10, 10, 50, 50);
-draw_and_check_rectangle(50, 60, 10, 100);
-draw_and_check_rectangle(50, 150, 10, 110);
-draw_and_check_rectangle(10, 200, 50, 160);
+draw_and_check_rectangle( 10,  10,  50,  50);
+draw_and_check_rectangle( 50,  60,  10, 100);
+draw_and_check_rectangle( 50, 150,  10, 110);
+draw_and_check_rectangle( 10, 200,  50, 160);
 imagesetthickness($img, 4);
-draw_and_check_rectangle(60, 10, 100, 50);
-draw_and_check_rectangle(100, 60, 60, 100);
-draw_and_check_rectangle(100, 150, 60, 110);
-draw_and_check_rectangle(60, 200, 100, 160);
+draw_and_check_rectangle( 60,  10, 100,  50);
+draw_and_check_rectangle(100,  60,  60, 100);
+draw_and_check_rectangle(100, 150,  60, 110);
+draw_and_check_rectangle( 60, 200, 100, 160);
 
-imagepng($img, __DIR__ . '/bug53156.png');
-?>
---CLEAN--
-<?php
-@unlink(__DIR__ . '/bug53156.png');
+//imagepng($img, __DIR__ . '/bug53156.png'); // debug
 ?>
 --EXPECT--
 Rectangle: ++++


### PR DESCRIPTION
Contrary to imagefilledrectangle(), imagerectangle() has the documented
limitation that the given points have to be the upper left and the lower right
corner, respectively. However, libgd already caters to upper right / lower left
pairs, and not catering to the other two combinations seems to be an oversight.

[Reported upstream](https://github.com/libgd/libgd/issues/177).

IMHO the patch should be applied to PHP 5.6, too. @pierrejoye @remicollet Any objections?