### PR TITLE
Fix #70103: ZipArchive::addGlob ignores remove_all_path option

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1691,8 +1691,8 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 					entry_name = entry_name_buf;
 					entry_name_len = strlen(entry_name);
 				} else {
-					entry_name = Z_STRVAL_P(zval_file);
-					entry_name_len = Z_STRLEN_P(zval_file);
+					entry_name = file_stripped;
+					entry_name_len = file_stripped_len;
 				}
 				if (basename) {
 					zend_string_release(basename);

--- a/ext/zip/tests/bug70103.phpt
+++ b/ext/zip/tests/bug70103.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Bug #70103 (ZipArchive::addGlob ignores remove_all_path option)
+--SKIPIF--
+<?php
+if (!extension_loaded('zip')) die('skip zip support not available');
+?>
+--FILE--
+<?php
+$dir = __DIR__ . '/bug70103';
+
+mkdir($dir); chmod($dir, 0777);
+file_put_contents($dir . '/foo.txt', 'foo');
+
+$zip = new ZipArchive();
+$zip->open($dir . '/test.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addGlob($dir . '/*.txt', GLOB_NOSORT, array('remove_all_path' => true));
+$zip->close();
+
+$zip = new ZipArchive();
+$zip->open($dir . '/test.zip');
+var_dump($zip->numFiles);
+var_dump($zip->getNameIndex(0));
+$zip->close();
+?>
+--CLEAN--
+<?php
+$dir = __DIR__ . '/bug70103';
+unlink($dir . '/foo.txt');
+unlink($dir . '/test.zip');
+rmdir($dir);
+?>
+--EXPECT--
+int(1)
+string(7) "foo.txt"


### PR DESCRIPTION
When the remove_all_path option is set, but no add_path option, remove_all_path
is simply ignored. This patch fixes this.

The PR is against master, but this should be merged to PHP 5.6 as well.
