### PR TITLE
Fix Bug #69865

### DIFF
--- a/sapi/fpm/fpm/fpm_stdio.c
+++ b/sapi/fpm/fpm/fpm_stdio.c
@@ -73,6 +73,12 @@ int fpm_stdio_init_final() /* {{{ */
 				return -1;
 			}
 		}
+#ifdef HAVE_SYSLOG_H
+		else if (fpm_globals.error_log_fd == ZLOG_SYSLOG) {
+			/* dup to /dev/null when using syslog */
+			dup2(STDOUT_FILENO, STDERR_FILENO);
+		}
+#endif
 	}
 	zlog_set_launched();
 	return 0;


### PR DESCRIPTION
php-fpm does not close stderr when using syslog

Someone with FPM knowledge should have another look.
