### PR TITLE
Fix Bug #68207

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1973,14 +1973,12 @@ fastcgi_request_done:
 			}
 			request_body_fd = -2;
 
-			if (EG(exit_status) == 255) {
-				if (CGIG(error_header) && *CGIG(error_header)) {
-					sapi_header_line ctr = {0};
+			if (EG(exit_status) == 255 && CGIG(error_header) && *CGIG(error_header) && !SG(headers_sent)) {
+				sapi_header_line ctr = {0};
 
-					ctr.line = CGIG(error_header);
-					ctr.line_len = strlen(CGIG(error_header));
-					sapi_header_op(SAPI_HEADER_REPLACE, &ctr TSRMLS_CC);
-				}
+				ctr.line = CGIG(error_header);
+				ctr.line_len = strlen(CGIG(error_header));
+				sapi_header_op(SAPI_HEADER_REPLACE, &ctr TSRMLS_CC);
 			}
 
 			fpm_request_end(TSRMLS_C);


### PR DESCRIPTION
Setting fastcgi.error_header can result in an E_WARNING being triggered

Add check for SG(headers_sent)