### PR TITLE
Fix #36365: scandir duplicates file name at every 65535th file

### DIFF
--- a/win32/readdir.h
+++ b/win32/readdir.h
@@ -32,7 +32,7 @@ struct dirent {
 /* typedef DIR - not the same as Unix */
 typedef struct {
 	HANDLE handle;				/* _findfirst/_findnext handle */
-	short offset;				/* offset into directory */
+	int offset;					/* offset into directory */
 	short finished;				/* 1 if there are not more files */
 	WIN32_FIND_DATA fileinfo;	/* from _findfirst/_findnext */
 	char *dir;					/* the dir we are reading */


### PR DESCRIPTION
Due to DIR.offset being declared as short we have an overflow. This patch
changes the field to int.

unsigned int seems to be more logical, but as it was signed before, I didn't want to change that. The change from short to int increases the size of DIR on 32bit systems, but that seems to be neglectable (DIR is a large structure, anyway), so it seems a bitfield is unnecessary.

Anyhow, this patch is an ABI break, and as such is most likely unsuitable for PHP 5.6, unfortunately.

I have not added a regression test, because that would be a *very* slow test, and I consider it highly unlikely that somebody will revert the field to short in the future.

PS: the bug as well as this patch affects Windows only.