### PR TITLE
Fix #70158: Building with static imap fails

### DIFF
--- a/ext/imap/config.w32
+++ b/ext/imap/config.w32
@@ -16,6 +16,7 @@ if (PHP_IMAP == "yes") {
 		CHECK_LIB("crypt32.lib", "imap");
 		EXTENSION("imap", "php_imap.c");
 
+		ADD_FLAG("LDFLAGS_IMAP", "/FORCE:MULTIPLE");
 		ADD_FLAG("CFLAGS_IMAP", "/D HAVE_IMAP2000=1 /D HAVE_IMAP2004=1 /D HAVE_IMAP2007a=1 /D HAVE_IMAP2007b=1 /D HAVE_IMAP_SSL=1");
 		AC_DEFINE('HAVE_IMAP', 1, 'Have IMAP support', true);
 		AC_DEFINE('HAVE_NEW_MIME2TEXT', 1, 'Have utf8_mime2text', true);


### PR DESCRIPTION
On Windows there are duplicate symbols defined by c-client's as well as PHP's
Unix compatibility layer, which cause static linking to fail. We turn on
/FORCE:MULTIPLE, so link ignores the second definitions from c-client
(producing a warning only instead of an error).