### PR TITLE
Skip exec() whitespace test on systems without echo -e

### DIFF
--- a/ext/standard/tests/general_functions/bug70018.phpt
+++ b/ext/standard/tests/general_functions/bug70018.phpt
@@ -5,6 +5,9 @@ Bug #70018 (exec does not strip all whitespace), var 1
 if (substr(PHP_OS, 0, 3) == "WIN") {
   die("skip.. not for Windows");
 }
+if (`echo -e test` == "-e test\n") {
+  die("skip.. /bin/echo does not support -e");
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
For example, OS X doesn't support this flag.

Should be merged into 5.5 and 5.6 too, I think.