### PR TITLE
Remove unneded space from fn declaration

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1295,7 +1295,7 @@ PHP_METHOD(domdocument, __construct)
 }
 /* }}} end DOMDocument::__construct */
 
-char *_dom_get_valid_file_path(char *source, char *resolved_path, int resolved_path_len ) /* {{{ */
+char *_dom_get_valid_file_path(char *source, char *resolved_path, int resolved_path_len) /* {{{ */
 {
 	xmlURI *uri;
 	xmlChar *escsource;


### PR DESCRIPTION
refs https://github.com/php/php-src/commit/545b364d560b9550f853bd8dd5ab1641225a03c2