### PR TITLE
fd can be zero in MCrypt fd caching

### DIFF
--- a/ext/mcrypt/mcrypt.c
+++ b/ext/mcrypt/mcrypt.c
@@ -493,10 +493,12 @@ static PHP_MSHUTDOWN_FUNCTION(mcrypt) /* {{{ */
 
 	if (MCG(fd[RANDOM]) >= 0) {
 		close(MCG(fd[RANDOM]));
+		MCG(fd[RANDOM]) = -1;
 	}
 
 	if (MCG(fd[URANDOM]) >= 0) {
 		close(MCG(fd[URANDOM]));
+		MCG(fd[URANDOM]) = -1;
 	}
 
 	UNREGISTER_INI_ENTRIES();

--- a/ext/mcrypt/mcrypt.c
+++ b/ext/mcrypt/mcrypt.c
@@ -491,11 +491,11 @@ static PHP_MSHUTDOWN_FUNCTION(mcrypt) /* {{{ */
 	php_stream_filter_unregister_factory("mcrypt.*" TSRMLS_CC);
 	php_stream_filter_unregister_factory("mdecrypt.*" TSRMLS_CC);
 
-	if (MCG(fd[RANDOM]) > 0) {
+	if (MCG(fd[RANDOM]) >= 0) {
 		close(MCG(fd[RANDOM]));
 	}
 
-	if (MCG(fd[URANDOM]) > 0) {
+	if (MCG(fd[URANDOM]) >= 0) {
 		close(MCG(fd[URANDOM]));
 	}
 


### PR DESCRIPTION
An issue identified in bug #69833 - Errors from `open()` are negative, so the fd can be zero.

This applies to 5.5+