### PR TITLE
fd can be zero in random_* fd caching

### DIFF
--- a/ext/standard/random.c
+++ b/ext/standard/random.c
@@ -43,7 +43,7 @@ static void random_globals_ctor(php_random_globals *random_globals_p)
 
 static void random_globals_dtor(php_random_globals *random_globals_p)
 {
-	if (random_globals_p->fd > 0) {
+	if (random_globals_p->fd >= 0) {
 		close(random_globals_p->fd);
 		random_globals_p->fd = -1;
 	}


### PR DESCRIPTION
An issue identified in bug #69833 - Errors from `open()` are negative, so the fd can be zero.

This applies to 7.0 only