### PR TITLE
Unmangle anonymous class property names

### DIFF
--- a/Zend/tests/anon/012.phpt
+++ b/Zend/tests/anon/012.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Ensure correct unmangling of private property names for anonymous class instances
+--FILE--
+<?php
+var_dump(new class { private $foo; });
+?>
+--EXPECT--
+object(class@anonymous)#1 (1) {
+  ["foo":"class@anonymous":private]=>
+  NULL
+}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1171,6 +1171,7 @@ static zend_always_inline size_t zend_strnlen(const char* s, size_t maxlen) /* {
 ZEND_API int zend_unmangle_property_name_ex(const zend_string *name, const char **class_name, const char **prop_name, size_t *prop_len) /* {{{ */
 {
 	size_t class_name_len;
+	size_t anonclass_src_len;
 
 	*class_name = NULL;
 
@@ -1201,6 +1202,10 @@ ZEND_API int zend_unmangle_property_name_ex(const zend_string *name, const char 
 	}
 
 	*class_name = ZSTR_VAL(name) + 1;
+	anonclass_src_len = zend_strnlen(*class_name + class_name_len + 1, ZSTR_LEN(name) - class_name_len - 2);
+	if (class_name_len + anonclass_src_len + 2 != ZSTR_LEN(name)) {
+		class_name_len += anonclass_src_len + 1;
+	}
 	*prop_name = ZSTR_VAL(name) + class_name_len + 2;
 	if (prop_len) {
 		*prop_len = ZSTR_LEN(name) - class_name_len - 2;


### PR DESCRIPTION
Any attempt to perform introspection (eg. using `print_r()`, `var_dump()` or `ReflectionClass`) on an **anonymous class instance** results in incorrectly-unmangled **private property names**.

The change introduced in this PR enables `zend_unmangle_property_name[_ex]()` to detect where a property originated from an anonymous class, and skip the middle component of the mangled name (/path/to/file, eval'd code or - for stdin).

Example:
```php
<?php
var_dump(new class { private $a; });
print_r(new class { private $b; });
echo new ReflectionClass(new class { private $c; });
```

Diff between output of unpatched and patched php:
```diff
<   ["/path/to/file.php0x7f8b38099024":"class@anonymous":private]=>
---
>   ["a":"class@anonymous":private]=>
7c7
<     [/path/to/file.php0x7f8b38099045b:class@anonymous:private] => 
---
>     [b:class@anonymous:private] => 
22c22
<     Property [ <default> private $/path/to/file.php0x7f8b38099077 ]
---
>     Property [ <default> private $c ]
```