### PR TITLE
Fix #70173: ZVAL_COPY_VALUE_EX broken for 32bit Solaris Sparc

### DIFF
--- a/Zend/tests/bug70173.phpt
+++ b/Zend/tests/bug70173.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #70173 (ZVAL_COPY_VALUE_EX broken for 32bit Solaris Sparc)
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platforms only");
+?>
+--FILE--
+<?php
+$var = 2900000000;
+var_dump($var);
+?>
+--EXPECT--
+float(2900000000)

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -822,13 +822,23 @@ static zend_always_inline uint32_t zval_delref_p(zval* pz) {
 }
 
 #if SIZEOF_SIZE_T == 4
-# define ZVAL_COPY_VALUE_EX(z, v, gc, t)				\
+# ifdef WORDS_BIGENDIAN
+#  define ZVAL_COPY_VALUE_EX(z, v, gc, t)				\
+	do {												\
+		uint32_t _w1 = v->value.ww.w1;					\
+		Z_COUNTED_P(z) = gc;							\
+		z->value.ww.w1 = _w1;							\
+		Z_TYPE_INFO_P(z) = t;							\
+	} while (0)
+# else
+#  define ZVAL_COPY_VALUE_EX(z, v, gc, t)				\
 	do {												\
 		uint32_t _w2 = v->value.ww.w2;					\
 		Z_COUNTED_P(z) = gc;							\
 		z->value.ww.w2 = _w2;							\
 		Z_TYPE_INFO_P(z) = t;							\
 	} while (0)
+# endif
 #elif SIZEOF_SIZE_T == 8
 # define ZVAL_COPY_VALUE_EX(z, v, gc, t)				\
 	do {												\


### PR DESCRIPTION
On 32bit big endian architectures the high word of a zend_value is copied
twice, instead of copying both words. Let's fix it.