### PR TITLE
Prevent warning when printing arrays in gdb

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -181,7 +181,7 @@ define ____printzv_contents
 		printf "array: "
 		if ! $arg1
 			set $ind = $ind + 1
-			____print_ht $zvalue->value.arr
+			____print_ht $zvalue->value.arr 1
 			set $ind = $ind - 1
 			set $i = $ind
 			while $i > 0


### PR DESCRIPTION
`____print_ht` expects `$arg1`. Patch fixes the following error:

```
(gdb) printzv &z_multi_result                                        
[0x7fffffff8fe0] (refcount=1) array:     Packed(1)[0x7fffef4abf50]: {
      [0] 0 => Missing argument 1 in user function.                  
```


