### PR TITLE
Fix #70277: new DateTimeZone($foo) is ignoring text after null byte

### DIFF
--- a/ext/date/tests/bug70277.phpt
+++ b/ext/date/tests/bug70277.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #70277 (new DateTimeZone($foo) is ignoring text after null byte)
+--FILE--
+<?php
+$timezone = "Europe/Zurich\0Foo";
+var_dump(timezone_open($timezone));
+var_dump(new DateTimeZone($timezone));
+?>
+--EXPECTF--
+Warning: timezone_open(): Timezone must not contain null bytes in %sbug70277.php on line %d
+bool(false)
+
+Fatal error: Uncaught exception 'Exception' with message 'DateTimeZone::__construct(): Timezone must not contain null bytes' in %sbug70277.php:%d
+Stack trace:
+#0 %sbug70277.php(%d): DateTimeZone->__construct('Europe/Zurich\x00F...')
+#1 {main}
+  thrown in %sbug70277.php on line %d


### PR DESCRIPTION
The DateTimeZone constructors are not binary safe. They're parsing the timezone
as string, but discard the length when calling timezone_initialize(). This
patch adds a tz_len parameter and a respective check to timezone_initialize().