### PR TITLE
Fix inconsistency with group use and leading `\`

### DIFF
--- a/Zend/tests/ns_094.phpt
+++ b/Zend/tests/ns_094.phpt
@@ -3,7 +3,7 @@ Type group use declarations should not allow override on inner itens
 --FILE--
 <?php
 
-// should not throw syntax errors
+// should throw syntax errors
 
 use const Foo\Bar\{
     A,

--- a/Zend/tests/ns_095.phpt
+++ b/Zend/tests/ns_095.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Absolute namespaces should be allowed
+--FILE--
+<?php
+
+namespace Foo\Bar {
+    class ClassA{}
+    class ClassB{}
+    class ClassC{}
+
+    function fn_a(){ return __FUNCTION__; }
+    function fn_b(){ return __FUNCTION__; }
+    function fn_c(){ return __FUNCTION__; }
+
+    const CONST_A = 1;
+    const CONST_B = 2;
+    const CONST_C = 3;
+}
+
+namespace Baz {
+
+    use \Foo\Bar\{ClassA, ClassB, ClassC};
+    use function \Foo\Bar\{fn_a, fn_b, fn_c};
+    use const \Foo\Bar\{CONST_A, CONST_B, CONST_C};
+
+    var_dump(ClassA::class);
+    var_dump(ClassB::class);
+    var_dump(ClassC::class);
+    var_dump(fn_a());
+    var_dump(fn_b());
+    var_dump(fn_c());
+    var_dump(CONST_A);
+    var_dump(CONST_B);
+    var_dump(CONST_C);
+
+    echo "\nDone\n";
+}
+?>
+--EXPECTF--
+
+string(14) "Foo\Bar\ClassA"
+string(14) "Foo\Bar\ClassB"
+string(14) "Foo\Bar\ClassC"
+string(12) "Foo\Bar\fn_a"
+string(12) "Foo\Bar\fn_b"
+string(12) "Foo\Bar\fn_c"
+int(1)
+int(2)
+int(3)
+
+Done

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -335,13 +335,17 @@ use_type:
 ;
 
 group_use_declaration:
-	namespace_name T_NS_SEPARATOR '{' use_declarations '}'
-		{$$ = zend_ast_create(ZEND_AST_GROUP_USE, $1, $4); }
+		namespace_name T_NS_SEPARATOR '{' use_declarations '}'
+			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $1, $4); }
+	|	T_NS_SEPARATOR namespace_name T_NS_SEPARATOR '{' use_declarations '}'
+			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $2, $5); }
 ;
 
 mixed_group_use_declaration:
-	namespace_name T_NS_SEPARATOR '{' inline_use_declarations '}'
-		{$$ = zend_ast_create(ZEND_AST_GROUP_USE, $1, $4);}
+		namespace_name T_NS_SEPARATOR '{' inline_use_declarations '}'
+			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $1, $4);}
+	|	T_NS_SEPARATOR namespace_name T_NS_SEPARATOR '{' inline_use_declarations '}'
+			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $2, $5); }
 ;
 
 inline_use_declarations:


### PR DESCRIPTION
There's still an ongoing discussion at http://news.php.net/php.internals/87774