### PR TITLE
Fix #70322: ZipArchive::close() doesn't indicate errors

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1616,6 +1616,7 @@ static ZIPARCHIVE_METHOD(close)
 	struct zip *intern;
 	zval *this = getThis();
 	ze_zip_object *ze_obj;
+	int err;
 
 	if (!this) {
 		RETURN_FALSE;
@@ -1625,7 +1626,8 @@ static ZIPARCHIVE_METHOD(close)
 
 	ze_obj = (ze_zip_object*) zend_object_store_get_object(this TSRMLS_CC);
 
-	if (zip_close(intern)) {
+	if (err = zip_close(intern)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, zip_strerror(intern));
 		zip_discard(intern);
 	}
 
@@ -1634,7 +1636,11 @@ static ZIPARCHIVE_METHOD(close)
 	ze_obj->filename_len = 0;
 	ze_obj->za = NULL;
 
-	RETURN_TRUE;
+	if (!err) {
+		RETURN_TRUE;
+	} else {
+		RETURN_FALSE;
+	}
 }
 /* }}} */
 

--- a/ext/zip/tests/bug70322.phpt
+++ b/ext/zip/tests/bug70322.phpt
@@ -1,13 +1,22 @@
 --TEST--
 Bug #70322 (ZipArchive::close() doesn't indicate errors)
+--DESCRIPTION--
+We want to test whether ZipArchive::close() returns FALSE and raises a warning
+on failure, so we force the failure by adding a file to the archive, which we
+delete before closing.
 --SKIPIF--
 <?php
 if (!extension_loaded('zip')) die('skip requires zip extension');
 ?>
 --FILE--
 <?php
+$zipfile = __DIR__ . '/bug70322.zip';
+$textfile = __DIR__ . '/bug70322.txt';
+touch($textfile);
 $zip = new ZipArchive();
-var_dump($zip->open(__DIR__ . '/bug70322.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE));
+$zip->open($zipfile, ZipArchive::CREATE);
+$zip->addFile($textfile);
+unlink($textfile);
 var_dump($zip->close());
 ?>
 --CLEAN--
@@ -16,7 +25,5 @@ var_dump($zip->close());
 @unlink(__DIR__ . '/bug70322.zip');
 ?>
 --EXPECTF--
-bool(true)
-
-Warning: ZipArchive::close(): Can't remove file: No such file or directory in %s%ebug70322.php on line %d
+Warning: ZipArchive::close(): Read error: No such file or directory in %s%ebug70322.php on line %d
 bool(false)

--- a/ext/zip/tests/bug70322.phpt
+++ b/ext/zip/tests/bug70322.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #70322 (ZipArchive::close() doesn't indicate errors)
+--SKIPIF--
+<?php
+if (!extension_loaded('zip')) die('skip requires zip extension');
+?>
+--FILE--
+<?php
+$zip = new ZipArchive();
+var_dump($zip->open(__DIR__ . '/bug70322.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE));
+var_dump($zip->close());
+?>
+--CLEAN--
+<?php
+// we don't expect the archive to be created, but clean up just in case...
+@unlink(__DIR__ . '/bug70322.zip');
+?>
+--EXPECTF--
+bool(true)
+
+Warning: ZipArchive::close(): Can't remove file: No such file or directory in %s%ebug70322.php on line %d
+bool(false)

--- a/ext/zip/tests/oo_delete.phpt
+++ b/ext/zip/tests/oo_delete.phpt
@@ -63,7 +63,8 @@ $sb = $zip->statIndex(1);
 var_dump($sb);
 $sb = $zip->statIndex(2);
 var_dump($sb);
-$zip->close();
+// suppress irrelevant error message:
+@$zip->close();
 unset($zip);
 
 if (file_exists($file)) {


### PR DESCRIPTION
If an archive can't be written, ZipArchive::close() nonetheless returns TRUE.
We fix the return value to properly return success, and additionally raise a
warning on failure.

@pierrejoye @remicollet Okay to merge? Or should this be applied to [pecl/zip](https://github.com/pierrejoye/php_zip/) first?