### PR TITLE
Fix zend_fetch_debug_backtrace() when EG(current_execute_data) == NULL.

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -2458,12 +2458,13 @@ ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int 
 
 	call = NULL;
 	ptr = EG(current_execute_data);
-	if (!ptr->func || !ZEND_USER_CODE(ptr->func->common.type)) {
-		call = ptr;
-		ptr = ptr->prev_execute_data;
-	}
 
 	if (ptr) {
+		if (!ptr->func || !ZEND_USER_CODE(ptr->func->common.type)) {
+			call = ptr;
+			ptr = ptr->prev_execute_data;
+		}
+
 		if (skip_last) {
 			/* skip debug_backtrace() */
 			call = ptr;
@@ -2475,10 +2476,11 @@ ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int 
 				ptr = ptr->prev_execute_data;
 			}
 		}
-	}
-	if (!call) {
-		call = ptr;
-		ptr = ptr->prev_execute_data;
+
+		if (!call) {
+			call = ptr;
+			ptr = ptr->prev_execute_data;
+		}
 	}
 
 	array_init(return_value);


### PR DESCRIPTION
This is a regression from PHP 5, which never attempted to dereference fields in the execute data without first checking if it was NULL.