### PR TITLE
Change our travis config to use the new container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: c
-
+sudo: false
+addons:
+  apt:
+    packages:
+      - locales
+      - language-pack-de
+      - re2c
+      - libgmp-dev
+      - libicu-dev
+      - libmcrypt-dev
+      - libtidy-dev
 notifications:
     email: 
        on_failure: change
@@ -26,11 +36,6 @@ env:
     matrix:
       - ENABLE_MAINTAINER_ZTS=0 ENABLE_DEBUG=0
       - ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
-
-before_install:
-    - sudo cp ./travis/de /var/lib/locales/supported.d/de
-    - sudo dpkg-reconfigure locales
-    - ./travis/install.sh
 
 before_script:
     # Compile PHP

--- a/ext/intl/tests/bug67052.phpt
+++ b/ext/intl/tests/bug67052.phpt
@@ -12,7 +12,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 
 function ut_main()
 {
-        setlocale(LC_ALL, 'de_DE');
+        setlocale(LC_ALL, 'de_DE.UTF-8');
         $fmt = new NumberFormatter( 'sl_SI.UTF-8', NumberFormatter::DECIMAL);
         $num = "1.234.567,891";
         $res_str =  $fmt->parse($num)."\n";
@@ -26,5 +26,5 @@ ut_run();
 ?>
 --EXPECT--
 1234567,891
-de_DE
+de_DE.UTF-8
 

--- a/ext/standard/tests/file/filetype_variation2.phpt
+++ b/ext/standard/tests/file/filetype_variation2.phpt
@@ -7,7 +7,7 @@ Dave Kelsey <d_kelsey@uk.ibm.com>
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip no /dev on Windows');
 }
-if (!file_exists("/dev/console")) {
+if (!file_exists("/dev/null")) {
     die('skip /dev/console not available');
 }    
 ?>
@@ -20,7 +20,7 @@ Description: Returns the type of the file. Possible values are fifo, char,
 */
 
 echo "-- Checking for char --\n";
-print( filetype("/dev/console") )."\n";
+print( filetype("/dev/null") )."\n";
 ?>
 ===DONE===
 --EXPECTF--

--- a/ext/standard/tests/file/filetype_variation2.phpt
+++ b/ext/standard/tests/file/filetype_variation2.phpt
@@ -8,7 +8,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip no /dev on Windows');
 }
 if (!file_exists("/dev/null")) {
-    die('skip /dev/console not available');
+    die('skip /dev/null not available');
 }    
 ?>
 --FILE--

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -10,7 +10,9 @@ else
 	DEBUG="";
 fi
 ./buildconf --force
-./configure --quiet \
+./configure \
+--prefix=$HOME"/php-install" \
+--quiet \
 $DEBUG \
 $TS \
 --enable-fpm \
@@ -50,4 +52,4 @@ $TS \
 --with-gmp \
 --enable-bcmath
 make -j2 --quiet
-sudo make install
+make install

--- a/travis/de
+++ b/travis/de
@@ -1,2 +1,0 @@
-de_DE.UTF-8 UTF-8
-de_DE ISO-8859-1

--- a/travis/ext/curl/setup.sh
+++ b/travis/ext/curl/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export PHP_CURL_HTTP_REMOTE_SERVER="http://localhost"
+export PHP_CURL_HTTP_REMOTE_SERVER="http://localhost:8080"
 cd ./ext/curl/tests/responder
-sudo php -S localhost:80 &
+php -S localhost:8080 &
 cd -

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-sudo apt-get install re2c libgmp-dev libicu-dev libmcrypt-dev libtidy-dev


### PR DESCRIPTION
See http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/ and http://docs.travis-ci.com/user/migrating-from-legacy/ for the reasons to migrate (tl;dr: faster builds).
The downside is that you can't use sudo in the container, but I was able to remove our sudo usages with little effort.
