### PR TITLE
reset the heap's huge_list to NULL to avoid infinitely loop

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2152,6 +2152,7 @@ void zend_mm_shutdown(zend_mm_heap *heap, int full, int silent)
 		list = list->next;
 		zend_mm_chunk_free(heap, q->ptr, q->size);
 	}
+	heap->huge_list = NULL;
 
 	/* move all chunks except of the first one into the cache */
 	p = heap->main_chunk->next;


### PR DESCRIPTION
reset the heap's huge_list to NULL, otherwise would lead to infinitely loop by accessing some old memory address to construct a circular linked list