### PR TITLE
Fix bug #69737 - Segfault when SplMinHeap::compare produces fatal error

### DIFF
--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -249,9 +249,10 @@ static void spl_ptr_heap_insert(spl_ptr_heap *heap, spl_ptr_heap_element elem, v
 	heap->ctor(elem TSRMLS_CC);
 
 	/* sifting up */
-	for(i = heap->count++; i > 0 && heap->cmp(heap->elements[(i-1)/2], elem, cmp_userdata TSRMLS_CC) < 0; i = (i-1)/2) {
+	for(i = heap->count; i > 0 && heap->cmp(heap->elements[(i-1)/2], elem, cmp_userdata TSRMLS_CC) < 0; i = (i-1)/2) {
 		heap->elements[i] = heap->elements[(i-1)/2];
 	}
+	heap->count++;
 
 	if (EG(exception)) {
 		/* exception thrown during comparison */


### PR DESCRIPTION
Fix bug #69737 - Segfault when SplMinHeap::compare produces fatal error
see http://git.php.net/?p=php-src.git;a=commit;h=1cbd25ca15383394ffa9ee8601c5de4c0f2f90e1

解决了PHP 'spl_heap_object_free_storage()' 释放后重利用本地利用代码执行漏洞
参考 http://git.php.net/?p=php-src.git;a=commit;h=1cbd25ca15383394ffa9ee8601c5de4c0f2f90e1