### PR TITLE
Fix bug #70437 (disallow static access to traits)

### DIFF
--- a/Zend/tests/bug70437.phpt
+++ b/Zend/tests/bug70437.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #70437 (Changes to static properties in trait methods are not reflected in the class)
+--FILE--
+<?php
+
+trait foo {
+	static $bar = 1;
+
+	public static function baz() {
+		var_dump(++self::$bar);
+		var_dump(++static::$bar);
+	}
+}
+
+class bar {
+	use foo { baz as private foo; }
+
+	public static function baz() {
+		self::foo();
+		try {
+			foo::baz();
+		} catch (Error $e) {
+			print $e->getMessage()."\n";
+		}
+		++self::$bar;
+		var_dump(self::$bar);
+		try {
+			var_dump(foo::$bar);
+		} catch (Error $e) {
+			print $e->getMessage()."\n";
+		}
+	}
+}
+
+bar::baz();
+
+?>
+--EXPECT--
+int(2)
+int(3)
+Cannot call abstract method foo::baz()
+int(4)
+Cannot access abstract property foo::$bar

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4637,6 +4637,9 @@ void zend_begin_method_decl(zend_op_array *op_array, zend_string *name, zend_boo
 	} else if (!has_body) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Non-abstract method %s::%s() must contain body",
 			ZSTR_VAL(ce->name), ZSTR_VAL(name));
+	} else if (in_trait) {
+		/* force abstract in traits to prevent the_trait::static_method() from being allowed to be called */
+		op_array->fn_flags |= ZEND_ACC_ABSTRACT | ZEND_ACC_CHANGED;
 	}
 
 	op_array->scope = ce;
@@ -4912,6 +4915,10 @@ void zend_compile_prop_decl(zend_ast *ast) /* {{{ */
 
 	if (flags & ZEND_ACC_ABSTRACT) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Properties cannot be declared abstract");
+	}
+
+	if ((ce->ce_flags & ZEND_ACC_TRAIT) && !(flags & ZEND_ACC_PRIVATE)) {
+		flags |= ZEND_ACC_ABSTRACT;
 	}
 
 	/* Doc comment has been appended as last element in property list */

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -273,7 +273,9 @@ static void zend_std_call_issetter(zval *object, zval *member, zval *retval) /* 
 
 static zend_always_inline int zend_verify_property_access(zend_property_info *property_info, zend_class_entry *ce) /* {{{ */
 {
-	if (property_info->flags & ZEND_ACC_PUBLIC) {
+	if (UNEXPECTED(property_info->flags & ZEND_ACC_ABSTRACT)) {
+		return 0;
+	} else if (property_info->flags & ZEND_ACC_PUBLIC) {
 		return 1;
 	} else if (property_info->flags & ZEND_ACC_PRIVATE) {
 		return (ce == EG(scope) || property_info->ce == EG(scope));


### PR DESCRIPTION
See: https://bugs.php.net/70437

Achieved by making the methods and properties implicitly abstract and removing the abstract flag again upon copying to using class.

(Tests pending)
