### PR TITLE
Include config.h instead of php_config.h in gd_compat.c

### DIFF
--- a/ext/gd/gd_compat.c
+++ b/ext/gd/gd_compat.c
@@ -1,4 +1,6 @@
-#include "php_config.h"
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #ifdef HAVE_GD_PNG
 /* needs to be first */


### PR DESCRIPTION
This fixes broken phpinfo() (among others) as it uses correct symbols, see the bugreport here: https://github.com/oerdnj/deb.sury.org/issues/111