### PR TITLE
maintainer-strict-api - A tool to check and enforce encapsulation

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -389,20 +389,20 @@ fi
 AC_MSG_CHECKING(whether to enable zend signal handling)
 AC_MSG_RESULT($ZEND_SIGNALS)
 
-AC_ARG_ENABLE(strict-api,
-[  --enable-strict-api     Enforce strict API compliance],[
+AC_ARG_ENABLE(maintainer-strict-api,
+[  --enable-maintainer-strict-api     Check strict API compliance - for code maintainers only!!],[
   ZEND_CORE_STRICT_API=$enableval
 ],[
   ZEND_CORE_STRICT_API=no
 ])  
 
 if test "$ZEND_CORE_STRICT_API" = "yes"; then
-	AC_DEFINE(ZEND_CORE_STRICT_API, 1, [Enforce strict API compliance])
+	AC_DEFINE(ZEND_CORE_STRICT_API, 1, [Check strict API compliance])
 else
-	AC_DEFINE(ZEND_CORE_STRICT_API, 0, [Enforce strict API compliance])
+	AC_DEFINE(ZEND_CORE_STRICT_API, 0, [Check strict API compliance])
 fi
 
-AC_MSG_CHECKING(whether to enforce strict API compliance)
+AC_MSG_CHECKING(whether to check strict API compliance)
 AC_MSG_RESULT($ZEND_CORE_STRICT_API)
 
 ])

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -389,6 +389,22 @@ fi
 AC_MSG_CHECKING(whether to enable zend signal handling)
 AC_MSG_RESULT($ZEND_SIGNALS)
 
+AC_ARG_ENABLE(strict-api,
+[  --enable-strict-api     Enforce strict API compliance],[
+  ZEND_CORE_STRICT_API=$enableval
+],[
+  ZEND_CORE_STRICT_API=no
+])  
+
+if test "$ZEND_CORE_STRICT_API" = "yes"; then
+	AC_DEFINE(ZEND_CORE_STRICT_API, 1, [Enforce strict API compliance])
+else
+	AC_DEFINE(ZEND_CORE_STRICT_API, 0, [Enforce strict API compliance])
+fi
+
+AC_MSG_CHECKING(whether to enforce strict API compliance)
+AC_MSG_RESULT($ZEND_CORE_STRICT_API)
+
 ])
 
 AC_DEFUN([LIBZEND_CPLUSPLUS_CHECKS],[

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -64,7 +64,7 @@ ZEND_API zend_ast *zend_ast_create_zval_ex(zval *zv, zend_ast_attr attr) {
 	ast->kind = ZEND_AST_ZVAL;
 	ast->attr = attr;
 	ZVAL_COPY_VALUE(&ast->val, zv);
-	ast->val.u2.lineno = CG(zend_lineno);
+	Z_LINENO(ast->val) = CG(zend_lineno);
 	return (zend_ast *) ast;
 }
 

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -166,7 +166,7 @@ typedef struct _zend_ast_list {
 	zend_ast *child[1];
 } zend_ast_list;
 
-/* Lineno is stored in val.u2.lineno */
+/* Lineno is available using Z_LINENO(val) */
 typedef struct _zend_ast_zval {
 	zend_ast_kind kind;
 	zend_ast_attr attr;
@@ -237,7 +237,7 @@ static zend_always_inline uint32_t zend_ast_get_num_children(zend_ast *ast) {
 static zend_always_inline uint32_t zend_ast_get_lineno(zend_ast *ast) {
 	if (ast->kind == ZEND_AST_ZVAL) {
 		zval *zv = zend_ast_get_zval(ast);
-		return zv->u2.lineno;
+		return Z_LINENO_P(zv);
 	} else {
 		return ast->lineno;
 	}

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1969,7 +1969,7 @@ static int copy_function_name(zval *zv, int num_args, va_list args, zend_hash_ke
 		char *disable_functions = INI_STR("disable_functions");
 
 		if ((*exclude_disabled == 1) && (disable_functions != NULL)) {
-			if (strstr(disable_functions, func->common.function_name->val) == NULL) {
+			if (strstr(disable_functions, ZSTR_VAL(func->common.function_name)) == NULL) {
 				add_next_index_str(internal_ar, zend_string_copy(hash_key->key));
 			}
 		} else {

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -497,7 +497,7 @@ struct _zend_execute_data {
 	} while (0)
 
 #define ZEND_CALL_NUM_ARGS(call) \
-	(call)->This.u2.num_args
+	Z_NUM_ARGS((call)->This)
 
 #define ZEND_CALL_FRAME_SLOT \
 	((int)((ZEND_MM_ALIGNED_SIZE(sizeof(zend_execute_data)) + ZEND_MM_ALIGNED_SIZE(sizeof(zval)) - 1) / ZEND_MM_ALIGNED_SIZE(sizeof(zval))))

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -219,7 +219,7 @@ static void zend_generator_dtor_storage(zend_object *object) /* {{{ */
 		fast_call = ZEND_CALL_VAR(ex, ex->func->op_array.opcodes[finally_op_end].op1.var);
 		Z_OBJ_P(fast_call) = EG(exception);
 		EG(exception) = NULL;
-		fast_call->u2.lineno = (uint32_t)-1;
+		Z_LINENO_P(fast_call) = (uint32_t)-1;
 
 		ex->opline = &ex->func->op_array.opcodes[finally_op_num];
 		generator->flags |= ZEND_GENERATOR_FORCED_CLOSE;

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -112,7 +112,6 @@ static void zend_ini_add_string(zval *result, zval *op1, zval *op2)
 
 	if (Z_TYPE_P(op1) != IS_STRING) {
 		zend_string *str = zval_get_string(op1);
-<<<<<<< HEAD
 		/* ZEND_ASSERT(!Z_REFCOUNTED_P(op1)); */
 		if (ZEND_SYSTEM_INI) {
 			ZVAL_PSTRINGL(op1, ZSTR_VAL(str), ZSTR_LEN(str));
@@ -120,10 +119,6 @@ static void zend_ini_add_string(zval *result, zval *op1, zval *op2)
 		} else {
 			ZVAL_STR(op1, str);
 		}
-=======
-		ZVAL_PSTRINGL(op1, ZSTR_VAL(str), ZSTR_LEN(str));
-		zend_string_release(str);
->>>>>>> 2a0837b... Fix 'non-strict' zend_string access
 	}
 	op1_len = (int)Z_STRLEN_P(op1);
 	

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -112,6 +112,7 @@ static void zend_ini_add_string(zval *result, zval *op1, zval *op2)
 
 	if (Z_TYPE_P(op1) != IS_STRING) {
 		zend_string *str = zval_get_string(op1);
+<<<<<<< HEAD
 		/* ZEND_ASSERT(!Z_REFCOUNTED_P(op1)); */
 		if (ZEND_SYSTEM_INI) {
 			ZVAL_PSTRINGL(op1, ZSTR_VAL(str), ZSTR_LEN(str));
@@ -119,6 +120,10 @@ static void zend_ini_add_string(zval *result, zval *op1, zval *op2)
 		} else {
 			ZVAL_STR(op1, str);
 		}
+=======
+		ZVAL_PSTRINGL(op1, ZSTR_VAL(str), ZSTR_LEN(str));
+		zend_string_release(str);
+>>>>>>> 2a0837b... Fix 'non-strict' zend_string access
 	}
 	op1_len = (int)Z_STRLEN_P(op1);
 	

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -524,17 +524,17 @@ ZEND_API uint32_t *zend_get_property_guard(zend_object *zobj, zend_string *membe
 		    (EXPECTED(ZSTR_H(str) == ZSTR_H(member)) &&
 		     EXPECTED(ZSTR_LEN(str) == ZSTR_LEN(member)) &&
 		     EXPECTED(memcmp(ZSTR_VAL(str), ZSTR_VAL(member), ZSTR_LEN(member)) == 0))) {
-			return &zv->u2.property_guard;
-		} else if (EXPECTED(zv->u2.property_guard == 0)) {
+			return &zv->_ZSTRICT_FIELD(zval_struct,u2).property_guard;
+		} else if (EXPECTED(zv->_ZSTRICT_FIELD(zval_struct,u2).property_guard == 0)) {
 			zend_string_release(Z_STR_P(zv));
 			ZVAL_STR_COPY(zv, member);
-			return &zv->u2.property_guard;
+			return &zv->_ZSTRICT_FIELD(zval_struct,u2).property_guard;
 		} else {
 			ALLOC_HASHTABLE(guards);
 			zend_hash_init(guards, 8, NULL, zend_property_guard_dtor, 0);
 			/* mark pointer as "special" using low bit */
 			zend_hash_add_new_ptr(guards, member,
-				(void*)(((zend_uintptr_t)&zv->u2.property_guard) | 1));
+				(void*)(((zend_uintptr_t)&zv->_ZSTRICT_FIELD(zval_struct,u2).property_guard) | 1));
 			zend_string_release(Z_STR_P(zv));
 			ZVAL_ARR(zv, guards);
 		}
@@ -549,8 +549,8 @@ ZEND_API uint32_t *zend_get_property_guard(zend_object *zobj, zend_string *membe
 		ZEND_ASSERT(Z_TYPE_P(zv) == IS_UNDEF);
 		GC_FLAGS(zobj) |= IS_OBJ_HAS_GUARDS;
 		ZVAL_STR_COPY(zv, member);
-		zv->u2.property_guard = 0;
-		return &zv->u2.property_guard;
+		zv->_ZSTRICT_FIELD(zval_struct,u2).property_guard = 0;
+		return &zv->_ZSTRICT_FIELD(zval_struct,u2).property_guard;
 	}
 	/* we have to allocate uint32_t separately because ht->arData may be reallocated */
 	ptr = (uint32_t*)emalloc(sizeof(uint32_t));

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2793,8 +2793,8 @@ ZEND_API zend_long ZEND_FASTCALL zendi_smart_strcmp(zend_string *s1, zend_string
 	zend_long lval1 = 0, lval2 = 0;
 	double dval1 = 0.0, dval2 = 0.0;
 
-	if ((ret1 = is_numeric_string_ex(s1->val, s1->len, &lval1, &dval1, 0, &oflow1)) &&
-		(ret2 = is_numeric_string_ex(s2->val, s2->len, &lval2, &dval2, 0, &oflow2))) {
+	if ((ret1 = is_numeric_string_ex(ZSTR_VAL(s1), ZSTR_LEN(s1), &lval1, &dval1, 0, &oflow1)) &&
+		(ret2 = is_numeric_string_ex(ZSTR_VAL(s2), ZSTR_LEN(s2), &lval2, &dval2, 0, &oflow2))) {
 #if ZEND_ULONG_MAX == 0xFFFFFFFF
 		if (oflow1 != 0 && oflow1 == oflow2 && dval1 - dval2 == 0. &&
 			((oflow1 == 1 && dval1 > 9007199254740991. /*0x1FFFFFFFFFFFFF*/)
@@ -2831,7 +2831,7 @@ ZEND_API zend_long ZEND_FASTCALL zendi_smart_strcmp(zend_string *s1, zend_string
 	} else {
 		int strcmp_ret;
 string_cmp:
-		strcmp_ret = zend_binary_strcmp(s1->val, s1->len, s2->val, s2->len);
+		strcmp_ret = zend_binary_strcmp(ZSTR_VAL(s1), ZSTR_LEN(s1), ZSTR_VAL(s2), ZSTR_LEN(s2));
 		return ZEND_NORMALIZE_BOOL(strcmp_ret);
 	}
 }

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -435,10 +435,6 @@ ZEND_API void zend_update_current_locale(void);
 #define zend_update_current_locale()
 #endif
 
-/* The offset in bytes between the value and type fields of a zval */
-#define ZVAL_OFFSETOF_TYPE	\
-	(offsetof(zval, u1.type_info) - offsetof(zval, value))
-
 static zend_always_inline void fast_long_increment_function(zval *op1)
 {
 #if PHP_HAVE_BUILTIN_SADDL_OVERFLOW && SIZEOF_LONG == SIZEOF_ZEND_LONG
@@ -466,7 +462,7 @@ static zend_always_inline void fast_long_increment_function(zval *op1)
 		"movl %1, %c2(%0)\n"
 		"0:"
 		:
-		: "r"(&op1->value),
+		: "r"(&_Z_VALUE_P(op1)),
 		  "n"(IS_DOUBLE),
 		  "n"(ZVAL_OFFSETOF_TYPE)
 		: "cc", "memory");
@@ -479,7 +475,7 @@ static zend_always_inline void fast_long_increment_function(zval *op1)
 		"movl %1, %c2(%0)\n"
 		"0:"
 		:
-		: "r"(&op1->value),
+		: "r"(&_Z_VALUE_P(op1)),
 		  "n"(IS_DOUBLE),
 		  "n"(ZVAL_OFFSETOF_TYPE)
 		: "cc", "memory");
@@ -520,7 +516,7 @@ static zend_always_inline void fast_long_decrement_function(zval *op1)
 		"movl %1,%c2(%0)\n"
 		"0:"
 		:
-		: "r"(&op1->value),
+		: "r"(&_Z_VALUE_P(op1)),
 		  "n"(IS_DOUBLE),
 		  "n"(ZVAL_OFFSETOF_TYPE)
 		: "cc", "memory");
@@ -533,7 +529,7 @@ static zend_always_inline void fast_long_decrement_function(zval *op1)
 		"movl %1,%c2(%0)\n"
 		"0:"
 		:
-		: "r"(&op1->value),
+		: "r"(&_Z_VALUE_P(op1)),
 		  "n"(IS_DOUBLE),
 		  "n"(ZVAL_OFFSETOF_TYPE)
 		: "cc", "memory");
@@ -582,9 +578,9 @@ static zend_always_inline void fast_long_add_function(zval *result, zval *op1, z
 		"fstpl	(%0)\n"
 		"1:"
 		:
-		: "r"(&result->value),
-		  "r"(&op1->value),
-		  "r"(&op2->value),
+		: "r"(&_Z_VALUE_P(result)),
+		  "r"(&_Z_VALUE_P(op1)),
+		  "r"(&_Z_VALUE_P(op2)),
 		  "n"(IS_LONG),
 		  "n"(IS_DOUBLE),
 		  "n"(ZVAL_OFFSETOF_TYPE)
@@ -605,9 +601,9 @@ static zend_always_inline void fast_long_add_function(zval *result, zval *op1, z
 		"fstpl	(%0)\n"
 		"1:"
 		:
-		: "r"(&result->value),
-		  "r"(&op1->value),
-		  "r"(&op2->value),
+		: "r"(&_Z_VALUE_P(result)),
+		  "r"(&_Z_VALUE_P(op1)),
+		  "r"(&_Z_VALUE_P(op2)),
 		  "n"(IS_LONG),
 		  "n"(IS_DOUBLE),
 		  "n"(ZVAL_OFFSETOF_TYPE)
@@ -689,9 +685,9 @@ static zend_always_inline void fast_long_sub_function(zval *result, zval *op1, z
 		"fstpl	(%0)\n"
 		"1:"
 		:
-		: "r"(&result->value),
-		  "r"(&op1->value),
-		  "r"(&op2->value),
+		: "r"(&_Z_VALUE_P(result)),
+		  "r"(&_Z_VALUE_P(op1)),
+		  "r"(&_Z_VALUE_P(op2)),
 		  "n"(IS_LONG),
 		  "n"(IS_DOUBLE),
 		  "n"(ZVAL_OFFSETOF_TYPE)
@@ -716,9 +712,9 @@ static zend_always_inline void fast_long_sub_function(zval *result, zval *op1, z
 		"fstpl	(%0)\n"
 		"1:"
 		:
-		: "r"(&result->value),
-		  "r"(&op1->value),
-		  "r"(&op2->value),
+		: "r"(&_Z_VALUE_P(result)),
+		  "r"(&_Z_VALUE_P(op1)),
+		  "r"(&_Z_VALUE_P(op2)),
 		  "n"(IS_LONG),
 		  "n"(IS_DOUBLE),
 		  "n"(ZVAL_OFFSETOF_TYPE)

--- a/Zend/zend_strict.h
+++ b/Zend/zend_strict.h
@@ -2,7 +2,7 @@
    +----------------------------------------------------------------------+
    | Zend Engine                                                          |
    +----------------------------------------------------------------------+
-   | Copyright (c) 1998-2015 Zend Technologies Ltd. (http://www.zend.com) |
+   | Copyright (c) 1998-2017 Zend Technologies Ltd. (http://www.zend.com) |
    +----------------------------------------------------------------------+
    | This source file is subject to version 2.00 of the Zend license,     |
    | that is bundled with this package in the file LICENSE, and is        |
@@ -17,13 +17,12 @@
 */
 /* $Id$ */
 /*============================================================================
- This file implements the '--enable-strict-api' configure option.
+ This file implements the '--enable-maintainer-strict-api' configure option.
 
  When this option is set, the names of the protected structure fields (those
  defined using using the _ZSTRICT_FIELD() macro) are modified, causing
- compilation to fail when some code attempts a direct access to the structure
- field using its usual name. This allows to detect when code does not respect
- the published API.
+ a compile failure when code attempts a direct access to the structure
+ fields. This allows to detect violations of the published API.
 
  -------------------------------- WARNING ------------------------------------
  Including this file is reserved to source files located in the Zend

--- a/Zend/zend_strict.h
+++ b/Zend/zend_strict.h
@@ -1,0 +1,67 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend Engine                                                          |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1998-2015 Zend Technologies Ltd. (http://www.zend.com) |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+   | Author: Francois Laupretre <francois@php.net>                        |
+   +----------------------------------------------------------------------+
+*/
+/* $Id$ */
+/*============================================================================
+ This file implements the '--enable-strict-api' configure option.
+
+ When this option is set, the names of the protected structure fields (those
+ defined using using the _ZSTRICT_FIELD() macro) are modified, causing
+ compilation to fail when some code attempts a direct access to the structure
+ field using its usual name. This allows to detect when code does not respect
+ the published API.
+
+ -------------------------------- WARNING ------------------------------------
+ Including this file is reserved to source files located in the Zend
+ subdirectory. Outside the Zend directory, this file can be included indirectly,
+ through another zend_xxx include, but not directly. The macros defined below
+ should never be used in any piece of code outside the Zend subdirectory.
+============================================================================*/
+
+#ifndef ZEND_STRICT_H
+#define ZEND_STRICT_H
+
+#include "php_config.h"
+
+#ifdef ZEND_EXT_STRICT_API
+#	define __ZEND_STRICT_API ZEND_EXT_STRICT_API
+#else
+#	ifdef ZEND_CORE_STRICT_API
+#		define __ZEND_STRICT_API ZEND_CORE_STRICT_API
+#	else
+#		define __ZEND_STRICT_API 0
+#	endif
+#endif
+#if __ZEND_STRICT_API
+#	define _ZSTRICT_NAME(_type,_prefix,_elt) _zstrict_ ## _type ## _ ## _prefix ## _ ## _elt
+#	define _ZSTRICT_FIELD(_prefix,_elt) _ZSTRICT_NAME(field,_prefix,_elt)
+#	define ZEND_STRICT_API
+#else
+#	define _ZSTRICT_FIELD(_prefix,_elt) _elt
+#endif
+#undef __ZEND_STRICT_API
+
+/*-------------------------------------------------------------------------*/
+#endif /* ZEND_STRICT_H */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * indent-tabs-mode: t
+ * End:
+ */

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -22,6 +22,7 @@
 #define ZEND_STRING_H
 
 #include "zend.h"
+#include "zend_strict.h"
 
 BEGIN_EXTERN_C()
 
@@ -38,9 +39,9 @@ END_EXTERN_C()
 
 /* Shortcuts */
 
-#define ZSTR_VAL(zstr)  (zstr)->val
-#define ZSTR_LEN(zstr)  (zstr)->len
-#define ZSTR_H(zstr)    (zstr)->h
+#define ZSTR_VAL(zstr)  (zstr)->_ZSTRICT_FIELD(zend_string,val)
+#define ZSTR_LEN(zstr)  (zstr)->_ZSTRICT_FIELD(zend_string,len)
+#define ZSTR_H(zstr)    (zstr)->_ZSTRICT_FIELD(zend_string,h)
 #define ZSTR_HASH(zstr) zend_string_hash_val(zstr)
 
 /* Compatibility macros */
@@ -58,7 +59,7 @@ END_EXTERN_C()
 
 #define ZSTR_EMPTY_ALLOC()				CG(empty_string)
 
-#define _ZSTR_HEADER_SIZE XtOffsetOf(zend_string, val)
+#define _ZSTR_HEADER_SIZE XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,val))
 
 #define _ZSTR_STRUCT_SIZE(len) (_ZSTR_HEADER_SIZE + len + 1)
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -99,7 +99,6 @@ typedef void (*sort_func_t)(void *, size_t, size_t, compare_func_t, swap_func_t)
 typedef void (*dtor_func_t)(zval *pDest);
 typedef void (*copy_ctor_func_t)(zval *pElement);
 
-<<<<<<< HEAD
 /*
  * zend_type - is an abstraction layer to represent information about type hint.
  * It shouldn't be used directly. Only through ZEND_TYPE_* macros.
@@ -157,9 +156,6 @@ typedef uintptr_t zend_type;
 	ZEND_TYPE_ENCODE_CLASS_CONST_Q2(ZEND_TYPE_ENCODE_CLASS_CONST_ ##allow_null, class_name)
 #define ZEND_TYPE_ENCODE_CLASS_CONST(class_name, allow_null) \
 	ZEND_TYPE_ENCODE_CLASS_CONST_Q1(allow_null, class_name)
-=======
-/* Use Z_xxx() macros (defined below) to access zend_value and zval elements */
->>>>>>> b5b51df... Protect gc/refcount and zval fields
 
 typedef union _zend_value {
 	zend_long         lval;				/* long value */
@@ -200,14 +196,10 @@ struct _zval_struct {
 		uint32_t     num_args;             /* arguments number for EX(This) */
 		uint32_t     fe_pos;               /* foreach position */
 		uint32_t     fe_iter_idx;          /* foreach iterator index */
-<<<<<<< HEAD
 		uint32_t     access_flags;         /* class constant access flags */
 		uint32_t     property_guard;       /* single property guard */
 		uint32_t     extra;                /* not further specified */
-	} u2;
-=======
 	} _ZSTRICT_FIELD(zval_struct,u2);
->>>>>>> b5b51df... Protect gc/refcount and zval fields
 };
 
 /* Access struct elements via the GC_xxx() macros (defined below) */
@@ -422,11 +414,7 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_CONST_FLAGS(zval)			(zval)._ZSTRICT_FIELD(zval_struct,u1).v.const_flags
 #define Z_CONST_FLAGS_P(zval_p)		Z_CONST_FLAGS(*(zval_p))
 
-<<<<<<< HEAD
-#define Z_TYPE_INFO(zval)			(zval).u1.type_info
-=======
 #define Z_TYPE_INFO(zval)			(zval)._ZSTRICT_FIELD(zval_struct,u1).type_info
->>>>>>> b5b51df... Protect gc/refcount and zval fields
 #define Z_TYPE_INFO_P(zval_p)		Z_TYPE_INFO(*(zval_p))
 
 #define Z_VAR_FLAGS(zval)			(zval)._ZSTRICT_FIELD(zval_struct,u2).var_flags
@@ -450,20 +438,16 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_FE_ITER(zval)				(zval)._ZSTRICT_FIELD(zval_struct,u2).fe_iter_idx
 #define Z_FE_ITER_P(zval_p)			Z_FE_ITER(*(zval_p))
 
-<<<<<<< HEAD
-#define Z_ACCESS_FLAGS(zval)		(zval).u2.access_flags
+#define Z_ACCESS_FLAGS(zval)		(zval)._ZSTRICT_FIELD(zval_struct,u2).access_flags
 #define Z_ACCESS_FLAGS_P(zval_p)	Z_ACCESS_FLAGS(*(zval_p))
 
-#define Z_EXTRA(zval)				(zval).u2.extra
+#define Z_EXTRA(zval)				(zval)._ZSTRICT_FIELD(zval_struct,u2).extra
 #define Z_EXTRA_P(zval_p)			Z_EXTRA(*(zval_p))
 
-#define Z_COUNTED(zval)				(zval).value.counted
-=======
 #define _Z_VALUE(zval)				(zval)._ZSTRICT_FIELD(zval_struct,value)
 #define _Z_VALUE_P(zval_p)			_Z_VALUE(*(zval_p))
 
 #define Z_COUNTED(zval)				_Z_VALUE(zval).counted
->>>>>>> b5b51df... Protect gc/refcount and zval fields
 #define Z_COUNTED_P(zval_p)			Z_COUNTED(*(zval_p))
 
 #define Z_TYPE_MASK					0xff
@@ -533,13 +517,8 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define IS_STR_CONSTANT             (1<<3) /* constant index */
 #define IS_STR_CONSTANT_UNQUALIFIED (1<<4) /* the same as IS_CONSTANT_UNQUALIFIED */
 
-<<<<<<< HEAD
 /* array flags */
 #define IS_ARRAY_IMMUTABLE			(1<<1)
-=======
-/* array flags (zval.value.arr->gc.u.v.flags) */
-#define IS_ARRAY_IMMUTABLE			(1<<1) /* the same as IS_TYPE_IMMUTABLE */
->>>>>>> b5b51df... Protect gc/refcount and zval fields
 
 /* object flags (zval.value.obj->gc.u.v.flags) */
 #define IS_OBJ_APPLY_COUNT			0x07
@@ -602,14 +581,10 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_ISNULL(zval)				(Z_TYPE(zval) == IS_NULL)
 #define Z_ISNULL_P(zval_p)			Z_ISNULL(*(zval_p))
 
-<<<<<<< HEAD
 #define Z_ISERROR(zval)				(Z_TYPE(zval) == _IS_ERROR)
 #define Z_ISERROR_P(zval_p)			Z_ISERROR(*(zval_p))
 
-#define Z_LVAL(zval)				(zval).value.lval
-=======
 #define Z_LVAL(zval)				_Z_VALUE(zval).lval
->>>>>>> b5b51df... Protect gc/refcount and zval fields
 #define Z_LVAL_P(zval_p)			Z_LVAL(*(zval_p))
 
 #define Z_DVAL(zval)				_Z_VALUE(zval).dval

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -99,6 +99,7 @@ typedef void (*sort_func_t)(void *, size_t, size_t, compare_func_t, swap_func_t)
 typedef void (*dtor_func_t)(zval *pDest);
 typedef void (*copy_ctor_func_t)(zval *pElement);
 
+<<<<<<< HEAD
 /*
  * zend_type - is an abstraction layer to represent information about type hint.
  * It shouldn't be used directly. Only through ZEND_TYPE_* macros.
@@ -156,6 +157,9 @@ typedef uintptr_t zend_type;
 	ZEND_TYPE_ENCODE_CLASS_CONST_Q2(ZEND_TYPE_ENCODE_CLASS_CONST_ ##allow_null, class_name)
 #define ZEND_TYPE_ENCODE_CLASS_CONST(class_name, allow_null) \
 	ZEND_TYPE_ENCODE_CLASS_CONST_Q1(allow_null, class_name)
+=======
+/* Use Z_xxx() macros (defined below) to access zend_value and zval elements */
+>>>>>>> b5b51df... Protect gc/refcount and zval fields
 
 typedef union _zend_value {
 	zend_long         lval;				/* long value */
@@ -167,7 +171,7 @@ typedef union _zend_value {
 	zend_resource    *res;
 	zend_reference   *ref;
 	zend_ast_ref     *ast;
-	zval             *zv;
+	zval             *zv;				/* Access using Z_INDIRECT() */
 	void             *ptr;
 	zend_class_entry *ce;
 	zend_function    *func;
@@ -178,7 +182,7 @@ typedef union _zend_value {
 } zend_value;
 
 struct _zval_struct {
-	zend_value        value;			/* value */
+	zend_value        _ZSTRICT_FIELD(zval_struct,value);	/* value */
 	union {
 		struct {
 			ZEND_ENDIAN_LOHI_4(
@@ -187,8 +191,8 @@ struct _zval_struct {
 				zend_uchar    const_flags,
 				zend_uchar    reserved)	    /* call info for EX(This) */
 		} v;
-		uint32_t type_info;
-	} u1;
+		uint32_t type_info;					/* Access using Z_TYPE_INFO() */
+	} _ZSTRICT_FIELD(zval_struct,u1);
 	union {
 		uint32_t     next;                 /* hash collision chain */
 		uint32_t     cache_slot;           /* literal cache slot */
@@ -196,14 +200,20 @@ struct _zval_struct {
 		uint32_t     num_args;             /* arguments number for EX(This) */
 		uint32_t     fe_pos;               /* foreach position */
 		uint32_t     fe_iter_idx;          /* foreach iterator index */
+<<<<<<< HEAD
 		uint32_t     access_flags;         /* class constant access flags */
 		uint32_t     property_guard;       /* single property guard */
 		uint32_t     extra;                /* not further specified */
 	} u2;
+=======
+	} _ZSTRICT_FIELD(zval_struct,u2);
+>>>>>>> b5b51df... Protect gc/refcount and zval fields
 };
 
+/* Access struct elements via the GC_xxx() macros (defined below) */
+
 typedef struct _zend_refcounted_h {
-	uint32_t         refcount;			/* reference counter 32-bit */
+	uint32_t         _ZSTRICT_FIELD(refcounted,refcount); /* reference counter 32-bit */
 	union {
 		struct {
 			ZEND_ENDIAN_LOHI_3(
@@ -212,16 +222,18 @@ typedef struct _zend_refcounted_h {
 				uint16_t      gc_info)  /* keeps GC root number (or 0) and color */
 		} v;
 		uint32_t type_info;
-	} u;
+	} _ZSTRICT_FIELD(refcounted,u);
 } zend_refcounted_h;
 
 struct _zend_refcounted {
 	zend_refcounted_h gc;
 };
 
+/* Use ZSTR_xxx() (zend_string.h) macros to access zend_string fields */
+
 struct _zend_string {
 	zend_refcounted_h gc;
-	zend_ulong        _ZSTRICT_FIELD(zend_string,h);                /* hash value */
+	zend_ulong        _ZSTRICT_FIELD(zend_string,h);	/* hash value */
 	size_t            _ZSTRICT_FIELD(zend_string,len);
 	char              _ZSTRICT_FIELD(zend_string,val)[1];
 };
@@ -388,7 +400,7 @@ struct _zend_ast_ref {
 #define _IS_ERROR					20
 
 static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
-	return pz->u1.v.type;
+	return pz->_ZSTRICT_FIELD(zval_struct,u1).v.type;
 }
 
 #define ZEND_SAME_FAKE_TYPE(faketype, realtype) ( \
@@ -396,31 +408,49 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 	|| ((faketype) == _IS_BOOL && ((realtype) == IS_TRUE || (realtype) == IS_FALSE)) \
 )
 
+/* The offset in bytes between the value and type fields of a zval */
+#define ZVAL_OFFSETOF_TYPE	\
+	(offsetof(zval, _ZSTRICT_FIELD(zval_struct,u1).type_info) - offsetof(zval, _ZSTRICT_FIELD(zval_struct,value)))
+
 /* we should never set just Z_TYPE, we should set Z_TYPE_INFO */
 #define Z_TYPE(zval)				zval_get_type(&(zval))
 #define Z_TYPE_P(zval_p)			Z_TYPE(*(zval_p))
 
-#define Z_TYPE_FLAGS(zval)			(zval).u1.v.type_flags
+#define Z_TYPE_FLAGS(zval)			(zval)._ZSTRICT_FIELD(zval_struct,u1).v.type_flags
 #define Z_TYPE_FLAGS_P(zval_p)		Z_TYPE_FLAGS(*(zval_p))
 
-#define Z_CONST_FLAGS(zval)			(zval).u1.v.const_flags
+#define Z_CONST_FLAGS(zval)			(zval)._ZSTRICT_FIELD(zval_struct,u1).v.const_flags
 #define Z_CONST_FLAGS_P(zval_p)		Z_CONST_FLAGS(*(zval_p))
 
+<<<<<<< HEAD
 #define Z_TYPE_INFO(zval)			(zval).u1.type_info
+=======
+#define Z_TYPE_INFO(zval)			(zval)._ZSTRICT_FIELD(zval_struct,u1).type_info
+>>>>>>> b5b51df... Protect gc/refcount and zval fields
 #define Z_TYPE_INFO_P(zval_p)		Z_TYPE_INFO(*(zval_p))
 
-#define Z_NEXT(zval)				(zval).u2.next
+#define Z_VAR_FLAGS(zval)			(zval)._ZSTRICT_FIELD(zval_struct,u2).var_flags
+#define Z_VAR_FLAGS_P(zval_p)		Z_VAR_FLAGS(*(zval_p))
+
+#define Z_NEXT(zval)				(zval)._ZSTRICT_FIELD(zval_struct,u2).next
 #define Z_NEXT_P(zval_p)			Z_NEXT(*(zval_p))
 
-#define Z_CACHE_SLOT(zval)			(zval).u2.cache_slot
+#define Z_CACHE_SLOT(zval)			(zval)._ZSTRICT_FIELD(zval_struct,u2).cache_slot
 #define Z_CACHE_SLOT_P(zval_p)		Z_CACHE_SLOT(*(zval_p))
 
-#define Z_FE_POS(zval)				(zval).u2.fe_pos
+#define Z_LINENO(zval)				(zval)._ZSTRICT_FIELD(zval_struct,u2).lineno
+#define Z_LINENO_P(zval_p)			Z_LINENO(*(zval_p))
+
+#define Z_NUM_ARGS(zval)			(zval)._ZSTRICT_FIELD(zval_struct,u2).num_args
+#define Z_NUM_ARGS_P(zval_p)		Z_NUM_ARGS(*(zval_p))
+
+#define Z_FE_POS(zval)				(zval)._ZSTRICT_FIELD(zval_struct,u2).fe_pos
 #define Z_FE_POS_P(zval_p)			Z_FE_POS(*(zval_p))
 
-#define Z_FE_ITER(zval)				(zval).u2.fe_iter_idx
+#define Z_FE_ITER(zval)				(zval)._ZSTRICT_FIELD(zval_struct,u2).fe_iter_idx
 #define Z_FE_ITER_P(zval_p)			Z_FE_ITER(*(zval_p))
 
+<<<<<<< HEAD
 #define Z_ACCESS_FLAGS(zval)		(zval).u2.access_flags
 #define Z_ACCESS_FLAGS_P(zval_p)	Z_ACCESS_FLAGS(*(zval_p))
 
@@ -428,6 +458,12 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_EXTRA_P(zval_p)			Z_EXTRA(*(zval_p))
 
 #define Z_COUNTED(zval)				(zval).value.counted
+=======
+#define _Z_VALUE(zval)				(zval)._ZSTRICT_FIELD(zval_struct,value)
+#define _Z_VALUE_P(zval_p)			_Z_VALUE(*(zval_p))
+
+#define Z_COUNTED(zval)				_Z_VALUE(zval).counted
+>>>>>>> b5b51df... Protect gc/refcount and zval fields
 #define Z_COUNTED_P(zval_p)			Z_COUNTED(*(zval_p))
 
 #define Z_TYPE_MASK					0xff
@@ -435,11 +471,11 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_TYPE_FLAGS_SHIFT			8
 #define Z_CONST_FLAGS_SHIFT			16
 
-#define GC_REFCOUNT(p)				(p)->gc.refcount
-#define GC_TYPE(p)					(p)->gc.u.v.type
-#define GC_FLAGS(p)					(p)->gc.u.v.flags
-#define GC_INFO(p)					(p)->gc.u.v.gc_info
-#define GC_TYPE_INFO(p)				(p)->gc.u.type_info
+#define GC_REFCOUNT(p)				(p)->gc._ZSTRICT_FIELD(refcounted,refcount)
+#define GC_TYPE(p)					(p)->gc._ZSTRICT_FIELD(refcounted,u).v.type
+#define GC_FLAGS(p)					(p)->gc._ZSTRICT_FIELD(refcounted,u).v.flags
+#define GC_INFO(p)					(p)->gc._ZSTRICT_FIELD(refcounted,u).v.gc_info
+#define GC_TYPE_INFO(p)				(p)->gc._ZSTRICT_FIELD(refcounted,u).type_info
 
 #define Z_GC_TYPE(zval)				GC_TYPE(Z_COUNTED(zval))
 #define Z_GC_TYPE_P(zval_p)			Z_GC_TYPE(*(zval_p))
@@ -489,7 +525,7 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define MARK_CONSTANT_VISITED(p)	Z_CONST_FLAGS_P(p) |= IS_CONSTANT_VISITED_MARK
 #define RESET_CONSTANT_VISITED(p)	Z_CONST_FLAGS_P(p) &= ~IS_CONSTANT_VISITED_MARK
 
-/* string flags (zval.value->gc.u.flags) */
+/* string flags (zval.value.str->gc.u.v.flags) */
 #define IS_STR_PERSISTENT			(1<<0) /* allocated using malloc   */
 #define IS_STR_INTERNED				(1<<1) /* interned string          */
 #define IS_STR_PERMANENT        	(1<<2) /* relives request boundary */
@@ -497,10 +533,15 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define IS_STR_CONSTANT             (1<<3) /* constant index */
 #define IS_STR_CONSTANT_UNQUALIFIED (1<<4) /* the same as IS_CONSTANT_UNQUALIFIED */
 
+<<<<<<< HEAD
 /* array flags */
 #define IS_ARRAY_IMMUTABLE			(1<<1)
+=======
+/* array flags (zval.value.arr->gc.u.v.flags) */
+#define IS_ARRAY_IMMUTABLE			(1<<1) /* the same as IS_TYPE_IMMUTABLE */
+>>>>>>> b5b51df... Protect gc/refcount and zval fields
 
-/* object flags (zval.value->gc.u.flags) */
+/* object flags (zval.value.obj->gc.u.v.flags) */
 #define IS_OBJ_APPLY_COUNT			0x07
 #define IS_OBJ_DESTRUCTOR_CALLED	(1<<3)
 #define IS_OBJ_FREE_CALLED			(1<<4)
@@ -561,16 +602,20 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_ISNULL(zval)				(Z_TYPE(zval) == IS_NULL)
 #define Z_ISNULL_P(zval_p)			Z_ISNULL(*(zval_p))
 
+<<<<<<< HEAD
 #define Z_ISERROR(zval)				(Z_TYPE(zval) == _IS_ERROR)
 #define Z_ISERROR_P(zval_p)			Z_ISERROR(*(zval_p))
 
 #define Z_LVAL(zval)				(zval).value.lval
+=======
+#define Z_LVAL(zval)				_Z_VALUE(zval).lval
+>>>>>>> b5b51df... Protect gc/refcount and zval fields
 #define Z_LVAL_P(zval_p)			Z_LVAL(*(zval_p))
 
-#define Z_DVAL(zval)				(zval).value.dval
+#define Z_DVAL(zval)				_Z_VALUE(zval).dval
 #define Z_DVAL_P(zval_p)			Z_DVAL(*(zval_p))
 
-#define Z_STR(zval)					(zval).value.str
+#define Z_STR(zval)					_Z_VALUE(zval).str
 #define Z_STR_P(zval_p)				Z_STR(*(zval_p))
 
 #define Z_STRVAL(zval)				ZSTR_VAL(Z_STR(zval))
@@ -582,13 +627,13 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_STRHASH(zval)				ZSTR_HASH(Z_STR(zval))
 #define Z_STRHASH_P(zval_p)			Z_STRHASH(*(zval_p))
 
-#define Z_ARR(zval)					(zval).value.arr
+#define Z_ARR(zval)					_Z_VALUE(zval).arr
 #define Z_ARR_P(zval_p)				Z_ARR(*(zval_p))
 
 #define Z_ARRVAL(zval)				Z_ARR(zval)
 #define Z_ARRVAL_P(zval_p)			Z_ARRVAL(*(zval_p))
 
-#define Z_OBJ(zval)					(zval).value.obj
+#define Z_OBJ(zval)					_Z_VALUE(zval).obj
 #define Z_OBJ_P(zval_p)				Z_OBJ(*(zval_p))
 
 #define Z_OBJ_HT(zval)				Z_OBJ(zval)->handlers
@@ -609,7 +654,7 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_OBJDEBUG(zval,tmp)		(Z_OBJ_HANDLER((zval),get_debug_info)?Z_OBJ_HANDLER((zval),get_debug_info)(&(zval),&tmp):(tmp=0,Z_OBJ_HANDLER((zval),get_properties)?Z_OBJPROP(zval):NULL))
 #define Z_OBJDEBUG_P(zval_p,tmp)	Z_OBJDEBUG(*(zval_p), tmp)
 
-#define Z_RES(zval)					(zval).value.res
+#define Z_RES(zval)					_Z_VALUE(zval).res
 #define Z_RES_P(zval_p)				Z_RES(*zval_p)
 
 #define Z_RES_HANDLE(zval)			Z_RES(zval)->handle
@@ -621,28 +666,28 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_RES_VAL(zval)				Z_RES(zval)->ptr
 #define Z_RES_VAL_P(zval_p)			Z_RES_VAL(*zval_p)
 
-#define Z_REF(zval)					(zval).value.ref
+#define Z_REF(zval)					_Z_VALUE(zval).ref
 #define Z_REF_P(zval_p)				Z_REF(*(zval_p))
 
 #define Z_REFVAL(zval)				&Z_REF(zval)->val
 #define Z_REFVAL_P(zval_p)			Z_REFVAL(*(zval_p))
 
-#define Z_AST(zval)					(zval).value.ast
+#define Z_AST(zval)					_Z_VALUE(zval).ast
 #define Z_AST_P(zval_p)				Z_AST(*(zval_p))
 
-#define Z_ASTVAL(zval)				(zval).value.ast->ast
+#define Z_ASTVAL(zval)				_Z_VALUE(zval).ast->ast
 #define Z_ASTVAL_P(zval_p)			Z_ASTVAL(*(zval_p))
 
-#define Z_INDIRECT(zval)			(zval).value.zv
+#define Z_INDIRECT(zval)			_Z_VALUE(zval).zv
 #define Z_INDIRECT_P(zval_p)		Z_INDIRECT(*(zval_p))
 
-#define Z_CE(zval)					(zval).value.ce
+#define Z_CE(zval)					_Z_VALUE(zval).ce
 #define Z_CE_P(zval_p)				Z_CE(*(zval_p))
 
-#define Z_FUNC(zval)				(zval).value.func
+#define Z_FUNC(zval)				_Z_VALUE(zval).func
 #define Z_FUNC_P(zval_p)			Z_FUNC(*(zval_p))
 
-#define Z_PTR(zval)					(zval).value.ptr
+#define Z_PTR(zval)					_Z_VALUE(zval).ptr
 #define Z_PTR_P(zval_p)				Z_PTR(*(zval_p))
 
 #define ZVAL_UNDEF(z) do {				\
@@ -895,9 +940,9 @@ static zend_always_inline uint32_t zval_delref_p(zval* pz) {
 #if SIZEOF_SIZE_T == 4
 # define ZVAL_COPY_VALUE_EX(z, v, gc, t)				\
 	do {												\
-		uint32_t _w2 = v->value.ww.w2;					\
+		uint32_t _w2 = _Z_VALUE_P(v).ww.w2;					\
 		Z_COUNTED_P(z) = gc;							\
-		z->value.ww.w2 = _w2;							\
+		_Z_VALUE_P(z).ww.w2 = _w2;							\
 		Z_TYPE_INFO_P(z) = t;							\
 	} while (0)
 #elif SIZEOF_SIZE_T == 8

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -24,6 +24,7 @@
 #ifndef ZEND_TYPES_H
 #define ZEND_TYPES_H
 
+#include "zend_strict.h"
 #include "zend_portability.h"
 #include "zend_long.h"
 
@@ -220,9 +221,9 @@ struct _zend_refcounted {
 
 struct _zend_string {
 	zend_refcounted_h gc;
-	zend_ulong        h;                /* hash value */
-	size_t            len;
-	char              val[1];
+	zend_ulong        _ZSTRICT_FIELD(zend_string,h);                /* hash value */
+	size_t            _ZSTRICT_FIELD(zend_string,len);
+	char              _ZSTRICT_FIELD(zend_string,val)[1];
 };
 
 typedef struct _Bucket {

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7013,7 +7013,7 @@ ZEND_VM_HELPER(zend_dispatch_try_catch_finally_helper, ANY, ANY, uint32_t try_ca
 			cleanup_live_vars(execute_data, op_num, try_catch->finally_op);
 			Z_OBJ_P(fast_call) = EG(exception);
 			EG(exception) = NULL;
-			fast_call->u2.lineno = (uint32_t)-1;
+			fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno = (uint32_t)-1;
 			ZEND_VM_SET_OPCODE(&EX(func)->op_array.opcodes[try_catch->finally_op]);
 			ZEND_VM_CONTINUE();
 
@@ -7021,9 +7021,9 @@ ZEND_VM_HELPER(zend_dispatch_try_catch_finally_helper, ANY, ANY, uint32_t try_ca
 			zval *fast_call = EX_VAR(EX(func)->op_array.opcodes[try_catch->finally_end].op1.var);
 
 			/* cleanup incomplete RETURN statement */
-			if (fast_call->u2.lineno != (uint32_t)-1
-			 && (EX(func)->op_array.opcodes[fast_call->u2.lineno].op2_type & (IS_TMP_VAR | IS_VAR))) {
-				zval *return_value = EX_VAR(EX(func)->op_array.opcodes[fast_call->u2.lineno].op2.var);
+			if (fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno != (uint32_t)-1
+			 && (EX(func)->op_array.opcodes[fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno].op2_type & (IS_TMP_VAR | IS_VAR))) {
+				zval *return_value = EX_VAR(EX(func)->op_array.opcodes[fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno].op2.var);
 
 				zval_ptr_dtor(return_value);
 			}
@@ -7473,9 +7473,9 @@ ZEND_VM_HANDLER(159, ZEND_DISCARD_EXCEPTION, ANY, ANY)
 	SAVE_OPLINE();
 
 	/* cleanup incomplete RETURN statement */
-	if (fast_call->u2.lineno != (uint32_t)-1
-	 && (EX(func)->op_array.opcodes[fast_call->u2.lineno].op2_type & (IS_TMP_VAR | IS_VAR))) {
-		zval *return_value = EX_VAR(EX(func)->op_array.opcodes[fast_call->u2.lineno].op2.var);
+	if (fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno != (uint32_t)-1
+	 && (EX(func)->op_array.opcodes[fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno].op2_type & (IS_TMP_VAR | IS_VAR))) {
+		zval *return_value = EX_VAR(EX(func)->op_array.opcodes[fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno].op2.var);
 
 		zval_ptr_dtor(return_value);
 	}
@@ -7497,7 +7497,7 @@ ZEND_VM_HANDLER(162, ZEND_FAST_CALL, JMP_ADDR, ANY)
 
 	Z_OBJ_P(fast_call) = NULL;
 	/* set return address */
-	fast_call->u2.lineno = opline - EX(func)->op_array.opcodes;
+	fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno = opline - EX(func)->op_array.opcodes;
 	ZEND_VM_SET_OPCODE(OP_JMP_ADDR(opline, opline->op1));
 	ZEND_VM_CONTINUE();
 }
@@ -7508,8 +7508,8 @@ ZEND_VM_HANDLER(163, ZEND_FAST_RET, ANY, TRY_CATCH)
 	zval *fast_call = EX_VAR(opline->op1.var);
 	uint32_t current_try_catch_offset, current_op_num;
 
-	if (fast_call->u2.lineno != (uint32_t)-1) {
-		const zend_op *fast_ret = EX(func)->op_array.opcodes + fast_call->u2.lineno;
+	if (fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno != (uint32_t)-1) {
+		const zend_op *fast_ret = EX(func)->op_array.opcodes + fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno;
 
 		ZEND_VM_SET_OPCODE(fast_ret + 1);
 		ZEND_VM_CONTINUE();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1694,7 +1694,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try_catch_finally_hel
 			cleanup_live_vars(execute_data, op_num, try_catch->finally_op);
 			Z_OBJ_P(fast_call) = EG(exception);
 			EG(exception) = NULL;
-			fast_call->u2.lineno = (uint32_t)-1;
+			fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno = (uint32_t)-1;
 			ZEND_VM_SET_OPCODE(&EX(func)->op_array.opcodes[try_catch->finally_op]);
 			ZEND_VM_CONTINUE();
 
@@ -1702,9 +1702,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try_catch_finally_hel
 			zval *fast_call = EX_VAR(EX(func)->op_array.opcodes[try_catch->finally_end].op1.var);
 
 			/* cleanup incomplete RETURN statement */
-			if (fast_call->u2.lineno != (uint32_t)-1
-			 && (EX(func)->op_array.opcodes[fast_call->u2.lineno].op2_type & (IS_TMP_VAR | IS_VAR))) {
-				zval *return_value = EX_VAR(EX(func)->op_array.opcodes[fast_call->u2.lineno].op2.var);
+			if (fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno != (uint32_t)-1
+			 && (EX(func)->op_array.opcodes[fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno].op2_type & (IS_TMP_VAR | IS_VAR))) {
+				zval *return_value = EX_VAR(EX(func)->op_array.opcodes[fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno].op2.var);
 
 				zval_ptr_dtor(return_value);
 			}
@@ -1834,9 +1834,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DISCARD_EXCEPTION_SPEC_HANDLER
 	SAVE_OPLINE();
 
 	/* cleanup incomplete RETURN statement */
-	if (fast_call->u2.lineno != (uint32_t)-1
-	 && (EX(func)->op_array.opcodes[fast_call->u2.lineno].op2_type & (IS_TMP_VAR | IS_VAR))) {
-		zval *return_value = EX_VAR(EX(func)->op_array.opcodes[fast_call->u2.lineno].op2.var);
+	if (fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno != (uint32_t)-1
+	 && (EX(func)->op_array.opcodes[fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno].op2_type & (IS_TMP_VAR | IS_VAR))) {
+		zval *return_value = EX_VAR(EX(func)->op_array.opcodes[fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno].op2.var);
 
 		zval_ptr_dtor(return_value);
 	}
@@ -1858,7 +1858,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_CALL_SPEC_HANDLER(ZEND_OP
 
 	Z_OBJ_P(fast_call) = NULL;
 	/* set return address */
-	fast_call->u2.lineno = opline - EX(func)->op_array.opcodes;
+	fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno = opline - EX(func)->op_array.opcodes;
 	ZEND_VM_SET_OPCODE(OP_JMP_ADDR(opline, opline->op1));
 	ZEND_VM_CONTINUE();
 }
@@ -1869,8 +1869,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FAST_RET_SPEC_HANDLER(ZEND_OPC
 	zval *fast_call = EX_VAR(opline->op1.var);
 	uint32_t current_try_catch_offset, current_op_num;
 
-	if (fast_call->u2.lineno != (uint32_t)-1) {
-		const zend_op *fast_ret = EX(func)->op_array.opcodes + fast_call->u2.lineno;
+	if (fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno != (uint32_t)-1) {
+		const zend_op *fast_ret = EX(func)->op_array.opcodes + fast_call->_ZSTRICT_FIELD(zval_struct,u2).lineno;
 
 		ZEND_VM_SET_OPCODE(fast_ret + 1);
 		ZEND_VM_CONTINUE();

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -563,7 +563,7 @@ PHP_FUNCTION(enchant_broker_request_dict)
 		pbroker->dict[pos] = dict;
 
 		dict->rsrc = zend_register_resource(dict, le_enchant_dict);
-		pbroker->rsrc->gc.refcount++;
+		GC_REFCOUNT(pbroker->rsrc)++;
 		RETURN_RES(dict->rsrc);
 	} else {
 		RETURN_FALSE;
@@ -610,7 +610,7 @@ PHP_FUNCTION(enchant_broker_request_pwl_dict)
 		pbroker->dict[pos] = dict;
 
 		dict->rsrc = zend_register_resource(dict, le_enchant_dict);
-		pbroker->rsrc->gc.refcount++;
+		GC_REFCOUNT(pbroker->rsrc)++;
 		RETURN_RES(dict->rsrc);
 	} else {
 		RETURN_FALSE;

--- a/ext/opcache/Optimizer/zend_dump.c
+++ b/ext/opcache/Optimizer/zend_dump.c
@@ -113,7 +113,7 @@ static void zend_dump_unused_op(const zend_op *opline, znode_op op, uint32_t fla
 void zend_dump_var(const zend_op_array *op_array, zend_uchar var_type, int var_num)
 {
 	if (var_type == IS_CV && var_num < op_array->last_var) {
-		fprintf(stderr, "CV%d($%s)", var_num, op_array->vars[var_num]->val);
+		fprintf(stderr, "CV%d($%s)", var_num, ZSTR_VAL(op_array->vars[var_num]));
 	} else if (var_type == IS_VAR) {
 		fprintf(stderr, "V%d", var_num);
 	} else if (var_type == IS_TMP_VAR) {
@@ -169,9 +169,9 @@ static void zend_dump_type_info(uint32_t info, zend_class_entry *ce, int is_inst
 		fprintf(stderr, "class");
 		if (ce) {
 			if (is_instanceof) {
-				fprintf(stderr, " (instanceof %s)", ce->name->val);
+				fprintf(stderr, " (instanceof %s)", ZSTR_VAL(ce->name));
 			} else {
-				fprintf(stderr, " (%s)", ce->name->val);
+				fprintf(stderr, " (%s)", ZSTR_VAL(ce->name));
 			}
 		}
 	} else if ((info & MAY_BE_ANY) == MAY_BE_ANY) {
@@ -277,9 +277,9 @@ static void zend_dump_type_info(uint32_t info, zend_class_entry *ce, int is_inst
 			fprintf(stderr, "object");
 			if (ce) {
 				if (is_instanceof) {
-					fprintf(stderr, " (instanceof %s)", ce->name->val);
+					fprintf(stderr, " (instanceof %s)", ZSTR_VAL(ce->name));
 				} else {
-					fprintf(stderr, " (%s)", ce->name->val);
+					fprintf(stderr, " (%s)", ZSTR_VAL(ce->name));
 				}
 			}
 		}
@@ -792,9 +792,9 @@ static void zend_dump_op_array_name(const zend_op_array *op_array)
 	func_info = ZEND_FUNC_INFO(op_array);
 	if (op_array->function_name) {
 		if (op_array->scope && op_array->scope->name) {
-			fprintf(stderr, "%s::%s", op_array->scope->name->val, op_array->function_name->val);
+			fprintf(stderr, "%s::%s", ZSTR_VAL(op_array->scope->name), ZSTR_VAL(op_array->function_name));
 		} else {
-			fprintf(stderr, "%s", op_array->function_name->val);
+			fprintf(stderr, "%s", ZSTR_VAL(op_array->function_name));
 		}
 	} else {
 		fprintf(stderr, "%s", "$_main");
@@ -884,7 +884,7 @@ void zend_dump_op_array(const zend_op_array *op_array, uint32_t dump_flags, cons
 	if (msg) {
 		fprintf(stderr, "    ; (%s)\n", msg);
 	}
-	fprintf(stderr, "    ; %s:%u-%u\n", op_array->filename->val, op_array->line_start, op_array->line_end);
+	fprintf(stderr, "    ; %s:%u-%u\n", ZSTR_VAL(op_array->filename), op_array->line_start, op_array->line_end);
 
 	if (func_info && func_info->num_args > 0) {
 		uint32_t j;

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -634,7 +634,7 @@ try_again:
 			}
 		}
 		smart_str_append_const(&soap_headers,"Content-Length: ");
-		smart_str_append_long(&soap_headers, request->len);
+		smart_str_append_long(&soap_headers, ZSTR_LEN(request));
 		smart_str_append_const(&soap_headers, "\r\n");
 
 		/* HTTP Authentication */
@@ -861,7 +861,7 @@ try_again:
 		    (Z_TYPE_P(trace) == IS_TRUE || (Z_TYPE_P(trace) == IS_LONG && Z_LVAL_P(trace) != 0))) {
 			add_property_stringl(this_ptr, "__last_request_headers", ZSTR_VAL(soap_headers.s), ZSTR_LEN(soap_headers.s));
 		}
-		smart_str_appendl(&soap_headers, request->val, request->len);
+		smart_str_appendl(&soap_headers, ZSTR_VAL(request), ZSTR_LEN(request));
 		smart_str_0(&soap_headers);
 
 		err = php_stream_write(stream, ZSTR_VAL(soap_headers.s), ZSTR_LEN(soap_headers.s));
@@ -1263,7 +1263,7 @@ try_again:
 		     strcmp(content_encoding,"x-gzip") == 0) &&
 		     zend_hash_str_exists(EG(function_table), "gzinflate", sizeof("gzinflate")-1)) {
 			ZVAL_STRING(&func, "gzinflate");
-			ZVAL_STRINGL(&params[0], http_body->val+10, http_body->len-10);
+			ZVAL_STRINGL(&params[0], ZSTR_VAL(http_body)+10, ZSTR_LEN(http_body)-10);
 		} else if (strcmp(content_encoding,"deflate") == 0 &&
 		           zend_hash_str_exists(EG(function_table), "gzuncompress", sizeof("gzuncompress")-1)) {
 			ZVAL_STRING(&func, "gzuncompress");
@@ -1430,7 +1430,7 @@ static zend_string* get_http_body(php_stream *stream, int close, char *headers)
 					}
 
 					while (len_size < buf_size) {
-						int len_read = php_stream_read(stream, http_buf->val + http_buf_size, buf_size - len_size);
+						int len_read = php_stream_read(stream, ZSTR_VAL(http_buf) + http_buf_size, buf_size - len_size);
 						if (len_read <= 0) {
 							/* Error or EOF */
 							done = TRUE;
@@ -1488,7 +1488,7 @@ static zend_string* get_http_body(php_stream *stream, int close, char *headers)
 		}
 		http_buf = zend_string_alloc(header_length, 0);
 		while (http_buf_size < header_length) {
-			int len_read = php_stream_read(stream, http_buf->val + http_buf_size, header_length - http_buf_size);
+			int len_read = php_stream_read(stream, ZSTR_VAL(http_buf) + http_buf_size, header_length - http_buf_size);
 			if (len_read <= 0) {
 				break;
 			}
@@ -1502,7 +1502,7 @@ static zend_string* get_http_body(php_stream *stream, int close, char *headers)
 			} else {
 				http_buf = zend_string_alloc(4096, 0);
 			}
-			len_read = php_stream_read(stream, http_buf->val + http_buf_size, 4096);
+			len_read = php_stream_read(stream, ZSTR_VAL(http_buf) + http_buf_size, 4096);
 			if (len_read > 0) {
 				http_buf_size += len_read;
 			}
@@ -1511,8 +1511,8 @@ static zend_string* get_http_body(php_stream *stream, int close, char *headers)
 		return NULL;
 	}
 
-	http_buf->val[http_buf_size] = '\0';
-	http_buf->len = http_buf_size;
+	ZSTR_VAL(http_buf)[http_buf_size] = '\0';
+	ZSTR_LEN(http_buf) = http_buf_size;
 	return http_buf;
 }
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -152,7 +152,7 @@ static int php_array_key_compare(const void *a, const void *b) /* {{{ */
 			return (zend_long)f->h > (zend_long)s->h ? 1 : -1;
 		} else {
 			l1 = (zend_long)f->h;
-			t = is_numeric_string(s->key->val, s->key->len, &l2, &d, 1);
+			t = is_numeric_string(ZSTR_VAL(s->key), ZSTR_LEN(s->key), &l2, &d, 1);
 			if (t == IS_LONG) {
 				/* pass */
 			} else if (t == IS_DOUBLE) {
@@ -166,7 +166,7 @@ static int php_array_key_compare(const void *a, const void *b) /* {{{ */
 			return zendi_smart_strcmp(f->key, s->key);
 		} else {
 			l2 = (zend_long)s->h;
-			t = is_numeric_string(f->key->val, f->key->len, &l1, &d, 1);
+			t = is_numeric_string(ZSTR_VAL(f->key), ZSTR_LEN(f->key), &l1, &d, 1);
 			if (t == IS_LONG) {
 				/* pass */
 			} else if (t == IS_DOUBLE) {
@@ -196,12 +196,12 @@ static int php_array_key_compare_numeric(const void *a, const void *b) /* {{{ */
 	} else {
 		double d1, d2;
 		if (f->key) {
-			d1 = zend_strtod(f->key->val, NULL);
+			d1 = zend_strtod(ZSTR_VAL(f->key), NULL);
 		} else {
 			d1 = (double)(zend_long)f->h;
 		}
 		if (s->key) {
-			d2 = zend_strtod(s->key->val, NULL);
+			d2 = zend_strtod(ZSTR_VAL(s->key), NULL);
 		} else {
 			d2 = (double)(zend_long)s->h;
 		}
@@ -226,15 +226,15 @@ static int php_array_key_compare_string_case(const void *a, const void *b) /* {{
 	char buf2[MAX_LENGTH_OF_LONG + 1];
 
 	if (f->key) {
-		s1 = f->key->val;
-		l1 = f->key->len;
+		s1 = ZSTR_VAL(f->key);
+		l1 = ZSTR_LEN(f->key);
 	} else {
 		s1 = zend_print_long_to_buf(buf1 + sizeof(buf1) - 1, f->h);
 		l1 = buf1 + sizeof(buf1) - 1 - s1;
 	}
 	if (s->key) {
-		s2 = s->key->val;
-		l2 = s->key->len;
+		s2 = ZSTR_VAL(s->key);
+		l2 = ZSTR_LEN(s->key);
 	} else {
 		s2 = zend_print_long_to_buf(buf2 + sizeof(buf2) - 1, s->h);
 		l2 = buf2 + sizeof(buf2) - 1 - s1;
@@ -259,15 +259,15 @@ static int php_array_key_compare_string(const void *a, const void *b) /* {{{ */
 	char buf2[MAX_LENGTH_OF_LONG + 1];
 
 	if (f->key) {
-		s1 = f->key->val;
-		l1 = f->key->len;
+		s1 = ZSTR_VAL(f->key);
+		l1 = ZSTR_LEN(f->key);
 	} else {
 		s1 = zend_print_long_to_buf(buf1 + sizeof(buf1) - 1, f->h);
 		l1 = buf1 + sizeof(buf1) - 1 - s1;
 	}
 	if (s->key) {
-		s2 = s->key->val;
-		l2 = s->key->len;
+		s2 = ZSTR_VAL(s->key);
+		l2 = ZSTR_LEN(s->key);
 	} else {
 		s2 = zend_print_long_to_buf(buf2 + sizeof(buf2) - 1, s->h);
 		l2 = buf2 + sizeof(buf2) - 1 - s2;
@@ -292,15 +292,15 @@ static int php_array_key_compare_string_natural_general(const void *a, const voi
 	char buf2[MAX_LENGTH_OF_LONG + 1];
 
 	if (f->key) {
-		s1 = f->key->val;
-		l1 = f->key->len;
+		s1 = ZSTR_VAL(f->key);
+		l1 = ZSTR_LEN(f->key);
 	} else {
 		s1 = zend_print_long_to_buf(buf1 + sizeof(buf1) - 1, f->h);
 		l1 = buf1 + sizeof(buf1) - 1 - s1;
 	}
 	if (s->key) {
-		s2 = s->key->val;
-		l2 = s->key->len;
+		s2 = ZSTR_VAL(s->key);
+		l2 = ZSTR_LEN(s->key);
 	} else {
 		s2 = zend_print_long_to_buf(buf2 + sizeof(buf2) - 1, s->h);
 		l2 = buf2 + sizeof(buf2) - 1 - s1;
@@ -343,12 +343,12 @@ static int php_array_key_compare_string_locale(const void *a, const void *b) /* 
 	char buf2[MAX_LENGTH_OF_LONG + 1];
 
 	if (f->key) {
-		s1 = f->key->val;
+		s1 = ZSTR_VAL(f->key);
 	} else {
 		s1 = zend_print_long_to_buf(buf1 + sizeof(buf1) - 1, f->h);
 	}
 	if (s->key) {
-		s2 = s->key->val;
+		s2 = ZSTR_VAL(s->key);
 	} else {
 		s2 = zend_print_long_to_buf(buf2 + sizeof(buf2) - 1, s->h);
 	}

--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -100,17 +100,17 @@ static zend_bool php_mail_build_headers_check_field_value(zval *val)
 
 	/* https://tools.ietf.org/html/rfc2822#section-2.2.1 */
 	/* https://tools.ietf.org/html/rfc2822#section-2.2.3 */
-	while (len < value->len) {
-		if (*(value->val+len) == '\r') {
-			if (value->len - len >= 3
-				&&  *(value->val+len+1) == '\n'
-				&& (*(value->val+len+2) == ' '  || *(value->val+len+2) == '\t')) {
+	while (len < ZSTR_LEN(value)) {
+		if (*(ZSTR_VAL(value)+len) == '\r') {
+			if (ZSTR_LEN(value) - len >= 3
+				&&  *(ZSTR_VAL(value)+len+1) == '\n'
+				&& (*(ZSTR_VAL(value)+len+2) == ' '  || *(ZSTR_VAL(value)+len+2) == '\t')) {
 				len += 3;
 				continue;
 			}
 			return FAILURE;
 		}
-		if (*(value->val+len) == '\0') {
+		if (*(ZSTR_VAL(value)+len) == '\0') {
 			return FAILURE;
 		}
 		len++;
@@ -124,8 +124,8 @@ static zend_bool php_mail_build_headers_check_field_name(zend_string *key)
 	size_t len = 0;
 
 	/* https://tools.ietf.org/html/rfc2822#section-2.2 */
-	while (len < key->len) {
-		if (*(key->val+len) < 33 || *(key->val+len) > 126 || *(key->val+len) == ':') {
+	while (len < ZSTR_LEN(key)) {
+		if (*(ZSTR_VAL(key)+len) < 33 || *(ZSTR_VAL(key)+len) > 126 || *(ZSTR_VAL(key)+len) == ':') {
 			return FAILURE;
 		}
 		len++;
@@ -274,7 +274,7 @@ PHPAPI zend_string *php_mail_build_headers(zval *headers)
 	} ZEND_HASH_FOREACH_END();
 
 	/* Remove the last \r\n */
-	if (s.s) s.s->len -= 2;
+	if (s.s) ZSTR_LEN(s.s) -= 2;
 	smart_str_0(&s);
 
 	return s.s;
@@ -509,7 +509,7 @@ PHPAPI int php_mail(char *to, char *subject, char *message, char *headers, char 
 			
 			time(&curtime);
 			date_str = php_format_date("d-M-Y H:i:s e", 13, curtime, 1);
-			len = spprintf(&tmp, 0, "[%s] %s%s", date_str->val, logline, PHP_EOL);
+			len = spprintf(&tmp, 0, "[%s] %s%s", ZSTR_VAL(date_str), logline, PHP_EOL);
 			
 			php_mail_log_to_file(mail_log, tmp, len);
 			

--- a/ext/xmlrpc/xmlrpc-epi-php.c
+++ b/ext/xmlrpc/xmlrpc-epi-php.c
@@ -279,9 +279,9 @@ static void destroy_server_data(xmlrpc_server_data *server)
 static void xmlrpc_server_destructor(zend_resource *rsrc)
 {
 	if (rsrc && rsrc->ptr) {
-		rsrc->gc.refcount++;
+		GC_REFCOUNT(rsrc)++;
 		destroy_server_data((xmlrpc_server_data*) rsrc->ptr);
-		rsrc->gc.refcount--;
+		GC_REFCOUNT(rsrc)--;
 	}
 }
 

--- a/sapi/apache2handler/php_functions.c
+++ b/sapi/apache2handler/php_functions.c
@@ -389,10 +389,10 @@ PHP_MINFO_FUNCTION(apache)
 		smart_str_appendc(&tmp1, ' ');
 	}
 	if (tmp1.s) {
-		if (tmp1.s->len > 0) {
-			tmp1.s->val[tmp1.s->len - 1] = '\0';
+		if (ZSTR_LEN(tmp1.s) > 0) {
+			ZSTR_VAL(tmp1.s)[ZSTR_LEN(tmp1.s) - 1] = '\0';
 		} else {
-			tmp1.s->val[0] = '\0';
+			ZSTR_VAL(tmp1.s)[0] = '\0';
 		}
 	}
 
@@ -430,7 +430,7 @@ PHP_MINFO_FUNCTION(apache)
 
 	php_info_print_table_row(2, "Virtual Server", (serv->is_virtual ? "Yes" : "No"));
 	php_info_print_table_row(2, "Server Root", ap_server_root);
-	php_info_print_table_row(2, "Loaded Modules", tmp1.s->val);
+	php_info_print_table_row(2, "Loaded Modules", ZSTR_VAL(tmp1.s));
 
 	smart_str_free(&tmp1);
 	php_info_print_table_end();

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -353,7 +353,7 @@ static void append_essential_headers(smart_str* buffer, php_cli_server_client *c
 	if (!gettimeofday(&tv, NULL)) {
 		zend_string *dt = php_format_date("r", 1, tv.tv_sec, 1);
 		smart_str_appendl_ex(buffer, "Date: ", 6, persistent);
-		smart_str_appends_ex(buffer, dt->val, persistent);
+		smart_str_appends_ex(buffer, ZSTR_VAL(dt), persistent);
 		smart_str_appendl_ex(buffer, "\r\n", 2, persistent);
 		zend_string_release(dt);
 	}

--- a/sapi/fpm/fpm/fpm_php_trace.c
+++ b/sapi/fpm/fpm/fpm_php_trace.c
@@ -109,7 +109,7 @@ static int fpm_php_trace_dump(struct fpm_child_s *child, FILE *slowlog) /* {{{ *
 					ZEND_ASSERT(0);
 				}
 			} else {
-				if (0 > fpm_trace_get_strz(buf, buf_size, function_name + offsetof(zend_string, val))) {
+				if (0 > fpm_trace_get_strz(buf, buf_size, function_name + (long)ZSTR_VAL((zend_string *)NULL))) {
 					return -1;
 				}
 
@@ -155,7 +155,7 @@ static int fpm_php_trace_dump(struct fpm_child_s *child, FILE *slowlog) /* {{{ *
 
 				file_name = l;
 
-				if (0 > fpm_trace_get_strz(buf, buf_size, file_name + offsetof(zend_string, val))) {
+				if (0 > fpm_trace_get_strz(buf, buf_size, file_name + (long)ZSTR_VAL((zend_string *)NULL))) {
 					return -1;
 				}
 

--- a/sapi/fpm/fpm/fpm_php_trace.c
+++ b/sapi/fpm/fpm/fpm_php_trace.c
@@ -97,7 +97,7 @@ static int fpm_php_trace_dump(struct fpm_child_s *child, FILE *slowlog) /* {{{ *
 
 			if (function_name == 0) {
 				uint32_t *call_info = (uint32_t *)&l;
-				if (0 > fpm_trace_get_long(execute_data + offsetof(zend_execute_data, This.u1.type_info), &l)) {
+				if (0 > fpm_trace_get_long(execute_data + offsetof(zend_execute_data, This._ZSTRICT_FIELD(zval_struct,u1).type_info), &l)) {
 					return -1;
 				}
 

--- a/sapi/phpdbg/phpdbg_info.c
+++ b/sapi/phpdbg/phpdbg_info.c
@@ -212,7 +212,7 @@ static int phpdbg_print_symbols(zend_bool show_globals) {
 
 		if (ops->function_name) {
 			if (ops->scope) {
-				phpdbg_notice("variableinfo", "method=\"%s::%s\" num=\"%d\"", "Variables in %s::%s() (%d)", ops->scope->name->val, ops->function_name->val, zend_hash_num_elements(&vars));
+				phpdbg_notice("variableinfo", "method=\"%s::%s\" num=\"%d\"", "Variables in %s::%s() (%d)", ZSTR_VAL(ops->scope->name), ZSTR_VAL(ops->function_name), zend_hash_num_elements(&vars));
 			} else {
 				phpdbg_notice("variableinfo", "function=\"%s\" num=\"%d\"", "Variables in %s() (%d)", ZSTR_VAL(ops->function_name), zend_hash_num_elements(&vars));
 			}
@@ -313,9 +313,9 @@ PHPDBG_INFO(literal) /* {{{ */
 
 		if (ops->function_name) {
 			if (ops->scope) {
-				phpdbg_notice("literalinfo", "method=\"%s::%s\" num=\"%d\"", "Literal Constants in %s::%s() (%d)", ops->scope->name->val, ops->function_name->val, count);
+				phpdbg_notice("literalinfo", "method=\"%s::%s\" num=\"%d\"", "Literal Constants in %s::%s() (%d)", ZSTR_VAL(ops->scope->name), ZSTR_VAL(ops->function_name), count);
 			} else {
-				phpdbg_notice("literalinfo", "function=\"%s\" num=\"%d\"", "Literal Constants in %s() (%d)", ops->function_name->val, count);
+				phpdbg_notice("literalinfo", "function=\"%s\" num=\"%d\"", "Literal Constants in %s() (%d)", ZSTR_VAL(ops->function_name), count);
 			}
 		} else {
 			if (ops->filename) {

--- a/sapi/phpdbg/phpdbg_print.c
+++ b/sapi/phpdbg/phpdbg_print.c
@@ -270,9 +270,9 @@ void phpdbg_print_opcodes_function(const char *function, size_t len) {
 	if (!func) {
 		zend_string *rt_name;
 		ZEND_HASH_FOREACH_STR_KEY_PTR(EG(class_table), rt_name, func) {
-			if (func->type == ZEND_USER_FUNCTION && *rt_name->val == '\0') {
-				if (func->op_array.function_name->len == len && !zend_binary_strcasecmp(function, len, func->op_array.function_name->val, func->op_array.function_name->len)) {
-					phpdbg_print_opcodes_function(rt_name->val, rt_name->len);
+			if (func->type == ZEND_USER_FUNCTION && *ZSTR_VAL(rt_name) == '\0') {
+				if (ZSTR_LEN(func->op_array.function_name) == len && !zend_binary_strcasecmp(function, len, ZSTR_VAL(func->op_array.function_name), ZSTR_LEN(func->op_array.function_name))) {
+					phpdbg_print_opcodes_function(ZSTR_VAL(rt_name), ZSTR_LEN(rt_name));
 				}
 			}
 		} ZEND_HASH_FOREACH_END();
@@ -288,7 +288,7 @@ static void phpdbg_print_opcodes_method_ce(zend_class_entry *ce, const char *fun
 	zend_function *func;
 
 	if (ce->type != ZEND_USER_CLASS) {
-		phpdbg_out("function name: %s::%s (internal)\n", ce->name->val, function);
+		phpdbg_out("function name: %s::%s (internal)\n", ZSTR_VAL(ce->name), function);
 		return;
 	}
 
@@ -296,7 +296,7 @@ static void phpdbg_print_opcodes_method_ce(zend_class_entry *ce, const char *fun
 		return;
 	}
 
-	phpdbg_out("function name: %s::%s\n", ce->name->val, function);
+	phpdbg_out("function name: %s::%s\n", ZSTR_VAL(ce->name), function);
 	phpdbg_print_function_helper(func);
 }
 
@@ -306,8 +306,8 @@ void phpdbg_print_opcodes_method(const char *class, const char *function) {
 	if (phpdbg_safe_class_lookup(class, strlen(class), &ce) != SUCCESS) {
 		zend_string *rt_name;
 		ZEND_HASH_FOREACH_STR_KEY_PTR(EG(class_table), rt_name, ce) {
-			if (ce->type == ZEND_USER_CLASS && *rt_name->val == '\0') {
-				if (ce->name->len == strlen(class) && !zend_binary_strcasecmp(class, strlen(class), ce->name->val, ce->name->len)) {
+			if (ce->type == ZEND_USER_CLASS && *ZSTR_VAL(rt_name) == '\0') {
+				if (ZSTR_LEN(ce->name) == strlen(class) && !zend_binary_strcasecmp(class, strlen(class), ZSTR_VAL(ce->name), ZSTR_LEN(ce->name))) {
 					phpdbg_print_opcodes_method_ce(ce, function);
 				}
 			}
@@ -364,8 +364,8 @@ void phpdbg_print_opcodes_class(const char *class) {
 	if (phpdbg_safe_class_lookup(class, strlen(class), &ce) != SUCCESS) {
 		zend_string *rt_name;
 		ZEND_HASH_FOREACH_STR_KEY_PTR(EG(class_table), rt_name, ce) {
-			if (ce->type == ZEND_USER_CLASS && *rt_name->val == '\0') {
-				if (ce->name->len == strlen(class) && !zend_binary_strcasecmp(class, strlen(class), ce->name->val, ce->name->len)) {
+			if (ce->type == ZEND_USER_CLASS && *ZSTR_VAL(rt_name) == '\0') {
+				if (ZSTR_LEN(ce->name) == strlen(class) && !zend_binary_strcasecmp(class, strlen(class), ZSTR_VAL(ce->name), ZSTR_LEN(ce->name))) {
 					phpdbg_print_opcodes_ce(ce);
 				}
 			}

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -1922,9 +1922,9 @@ void phpdbg_force_interruption(void) /* {{{ */ {
 	if (data) {
 		if (data->func) {
 			if (ZEND_USER_CODE(data->func->type)) {
-				phpdbg_notice("hardinterrupt", "opline=\"%p\" num=\"%lu\" file=\"%s\" line=\"%u\"", "Current opline: %p (op #%lu) in %s:%u", data->opline, (data->opline - data->func->op_array.opcodes) / sizeof(data->opline), data->func->op_array.filename->val, data->opline->lineno);
+				phpdbg_notice("hardinterrupt", "opline=\"%p\" num=\"%lu\" file=\"%s\" line=\"%u\"", "Current opline: %p (op #%lu) in %s:%u", data->opline, (data->opline - data->func->op_array.opcodes) / sizeof(data->opline), ZSTR_VAL(data->func->op_array.filename), data->opline->lineno);
 			} else if (data->func->internal_function.function_name) {
-				phpdbg_notice("hardinterrupt", "func=\"%s\"", "Current opline: in internal function %s", data->func->internal_function.function_name->val);
+				phpdbg_notice("hardinterrupt", "func=\"%s\"", "Current opline: in internal function %s", ZSTR_VAL(data->func->internal_function.function_name));
 			} else {
 				phpdbg_notice("hardinterrupt", "", "Current opline: executing internal code");
 			}

--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -142,7 +142,7 @@ zend_bool phpdbg_check_watch_diff(phpdbg_watchtype type, void *oldPtr, void *new
 		case WATCH_ON_REFCOUNTED:
 			return memcmp(oldPtr, newPtr, sizeof(uint32_t) /* no zend_refcounted metadata info */) != 0;
 		case WATCH_ON_STR:
-			return memcmp(oldPtr, newPtr, *(size_t *) oldPtr + XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len)) != 0;
+			return memcmp(oldPtr, newPtr, *(size_t *) oldPtr + XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,val)) - XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,len))) != 0;
 		case WATCH_ON_HASHDATA:
 			ZEND_ASSERT(0);
 	}
@@ -200,13 +200,13 @@ void phpdbg_print_watch_diff(phpdbg_watchtype type, zend_string *name, void *old
 		case WATCH_ON_STR:
 			phpdbg_out("Old value: ");
 			phpdbg_xml("<watchvalue %r type=\"old\">");
-			zend_write((char *) oldPtr + XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len), *(size_t *) oldPtr);
+			zend_write((char *) oldPtr + XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,val)) - XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,len)), *(size_t *) oldPtr);
 			phpdbg_xml("</watchvalue>");
 			phpdbg_out("\n");
 
 			phpdbg_out("New value: ");
 			phpdbg_xml("<watchvalue %r type=\"new\">");
-			zend_write((char *) newPtr + XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len), *(size_t *) newPtr);
+			zend_write((char *) newPtr + XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,val)) - XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,len)), *(size_t *) newPtr);
 			phpdbg_xml("</watchvalue>");
 			phpdbg_out("\n");
 			break;
@@ -325,7 +325,7 @@ void phpdbg_watch_backup_data(phpdbg_watchpoint_t *watch) {
 			if (watch->backup.str) {
 				zend_string_release(watch->backup.str);
 			}
-			watch->backup.str = zend_string_init((char *) watch->addr.ptr + XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len), *(size_t *) watch->addr.ptr, 1);
+			watch->backup.str = zend_string_init((char *) watch->addr.ptr + XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,val)) - XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,len)), *(size_t *) watch->addr.ptr, 1);
 			break;
 		case WATCH_ON_HASHTABLE:
 			memcpy((char *) &watch->backup + HT_WATCH_OFFSET, watch->addr.ptr, watch->size);
@@ -395,7 +395,7 @@ void phpdbg_update_watch_ref(phpdbg_watchpoint_t *watch) {
 				phpdbg_watch_backup_data(&coll->reference);
 			} else if (Z_TYPE_P(watch->addr.zv) == IS_STRING) {
 				coll->reference.type = WATCH_ON_STR;
-				phpdbg_set_addr_watchpoint(&Z_STRLEN_P(watch->addr.zv), XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len) + Z_STRLEN_P(watch->addr.zv) + 1, &coll->reference);
+				phpdbg_set_addr_watchpoint(&Z_STRLEN_P(watch->addr.zv), XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,val)) - XtOffsetOf(zend_string, _ZSTRICT_FIELD(zend_string,len)) + Z_STRLEN_P(watch->addr.zv) + 1, &coll->reference);
 				coll->reference.coll = coll;
 				phpdbg_store_watchpoint_btree(&coll->reference);
 				phpdbg_activate_watchpoint(&coll->reference);

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -38,6 +38,14 @@ dnl Find php-config script
 PHP_ARG_WITH(php-config,,
 [  --with-php-config=PATH  Path to php-config [php-config]], php-config, no)
 
+PHP_ARG_ENABLE(strict-api, whether to enforce strict API compliance,
+[  --enable-strict-api        Enforce strict API compliance], no, no)
+if test "$PHP_STRICT_API" = "yes"; then
+  AC_DEFINE(ZEND_EXT_STRICT_API,1,[Enforce strict API compliance])
+else
+  AC_DEFINE(ZEND_EXT_STRICT_API,0,[Enforce strict API compliance])
+fi
+
 dnl For BC
 PHP_CONFIG=$PHP_PHP_CONFIG
 prefix=`$PHP_CONFIG --prefix 2>/dev/null`

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -38,12 +38,12 @@ dnl Find php-config script
 PHP_ARG_WITH(php-config,,
 [  --with-php-config=PATH  Path to php-config [php-config]], php-config, no)
 
-PHP_ARG_ENABLE(strict-api, whether to enforce strict API compliance,
-[  --enable-strict-api        Enforce strict API compliance], no, no)
+PHP_ARG_ENABLE(maintainer-strict-api, whether to enforce strict API compliance,
+[  --enable-maintainer-strict-api        Check strict API compliance - for code maintainers only!!], no, no)
 if test "$PHP_STRICT_API" = "yes"; then
-  AC_DEFINE(ZEND_EXT_STRICT_API,1,[Enforce strict API compliance])
+  AC_DEFINE(ZEND_EXT_STRICT_API,1,[Check strict API compliance])
 else
-  AC_DEFINE(ZEND_EXT_STRICT_API,0,[Enforce strict API compliance])
+  AC_DEFINE(ZEND_EXT_STRICT_API,0,[Check strict API compliance])
 fi
 
 dnl For BC

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -59,5 +59,10 @@ $TS \
 --with-xpm-dir=/usr \
 --with-kerberos \
 --enable-sysvmsg 
+<<<<<<< HEAD
 make -j2 --quiet
 make install
+=======
+make -j2 -k --quiet
+sudo make install
+>>>>>>> 633312d... Add '-k' option to the 'make' command to display *every* error

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -10,11 +10,18 @@ else
 	DEBUG="";
 fi
 ./buildconf --force
+
+# Enable 'maintainer-strict-api' option only if supported
+STRICT_API_OPT=''
+./configure --help | grep -- --enable-maintainer-strict-api >/dev/null \
+	&& STRICT_API_OPT="--enable-maintainer-strict-api"
+
 ./configure \
 --prefix=$HOME"/php-install" \
 --quiet \
 $DEBUG \
 $TS \
+$STRICT_API_OPT \
 --enable-phpdbg \
 --enable-fpm \
 --with-pdo-mysql=mysqlnd \
@@ -59,10 +66,5 @@ $TS \
 --with-xpm-dir=/usr \
 --with-kerberos \
 --enable-sysvmsg 
-<<<<<<< HEAD
-make -j2 --quiet
-make install
-=======
 make -j2 -k --quiet
-sudo make install
->>>>>>> 633312d... Add '-k' option to the 'make' command to display *every* error
+make install


### PR DESCRIPTION
This pull request is a follow-up to a [previous PR](https://github.com/php/php-src/pull/1348), which was probably going too far. The present one focuses on the mechanism I want to introduce, and limits its first application to a basic case.

Parts of the text below are taken from the previous PR.
# Why

Some months ago, [Anthony Ferrara expressed concerns](http://t110602.php-development.phptalks.info/concern-around-growing-complexity-in-engine-hash-table-specifically-t110602.html) about PHP 7 and zend_hash growing complexity, combined with a lack of strict encapsulation (tight coupling).

Some replied that the solution is just a mix of comments and documentation, but growing complexity quickly becomes unmanageable if any code can bypass official/published APIs. zend_hash is a critical examples, but not the only one.

While part of the solution lies in documentation, 'quick-and-dirty' behaviors are not exclusively triggered by a lack of information. We also need tools to detect API violations.

An API violation is the fact of accessing resources by a way not respecting the official/published API, for any reason, wanted or not. An obvious case is directly accessing structure elements by their name, without using the available macros. While this code works, it is an example of tight coupling which, going unnoticed, creates a lot of potential issues in the future. For this reason, these violations must be detected and fixed as soon as possible, especially in a huge piece of code shared by many developers.
# Protecting structure fields from direct access

The tool implemented here allows to detect direct access to structure fields, when an other mechanism (macro) is available.

From a user's point of view, activating this detection mechanism is very simple : 
- Configure your PHP tree or your extension using the '--enable-strict-api' option,
- Compile as usual,
- During the compilation, every direct access to a protected structure field causes a compile error. When such an error is issued, you must examine the code and replace this direct access with the appropriate macro.

How does it work ? The option just modifies the field name of explicitely-protected fields. When some code attempts to access these fields using their usual name, an error is issued as this field name does not exist.

> **Important** : this mechanism is to be enabled for compile-time checks only. The code compiled with the 'strict-api' option on will never be distributed nor used for debugging. The reason is that, in this code, structure field names are replaced by cryptic complex names. So, even if the code works exactly the same, debugging it is very impractical.

**In other terms, Including this in 7.0 won't cause any extension maintainer to modify his code.**

When the 'strict-api' configure option is not set (the default), the field names are unchanged and any code directly accessing such fields is valid. This way, extension writers can distribute 'non-strict' extensions and take their time to make them strict-compliant.
# An example

Just another example to show why such a tool is really needed : 
- On Jun 30, 2015, @dstogov added two macros to access the 'val' and 'len' fields of zend_strings. In order to be as complete as possible, he also modified every direct access to these fields in the whole PHP core, replacing them with the newly-defined macros.
- Today, about 2 months later, I detect 27 locations in the core, modified during these 2 months, where 'val' and 'len' are accessed directly.

I don't know the reason and it is not important. It just shows that we need a mechanism to detect these violations as soon as possible. Ideally, such commits shouldn't have gone through but, without a mechanism to enforce the rule, it's impossible to detect. In order to solve this, as you will see in the patch, I modified the travis configure command to include the 'strict-api' configure option. So, such API violations will now be checked and rejected by the travis validation.
# Protecting a structure field

Protecting a field is simple : everywhere it is legitimate to access the struct field by its name, replace the name with '_ZSTRICT_FIELD(&lt;prefix>,&lt;name>)', where &lt;prefix> is the name of the structure containing the element, and &lt;name> is the element name. For an example, check how we protected zend_string fields in this PR (zend_string.h/zend_types.h).

In general, only the first-level elements need to be protected, as they control access to the sub-elements.

Of course, protecting a struct field implies that an official API (macro/function) is available.
# Coming next

The next structure to protect and encapsulate is the HashTable structure. Actually, the combination of tight coupling with the complexity of PHP7 HashTables makes it a critical concern. This really needs to be addressed before it becomes unmanageable.
