### PR TITLE
Set XML_PARSE_HUGE by default when using XML_Parser

### DIFF
--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -474,7 +474,7 @@ XML_ParserCreate_MM(const XML_Char *encoding, const XML_Memory_Handling_Suite *m
 #endif
 
 #if LIBXML_VERSION >= 20703
-	xmlCtxtUseOptions(parser->parser, XML_PARSE_OLDSAX);
+	xmlCtxtUseOptions(parser->parser, XML_PARSE_OLDSAX | XML_PARSE_HUGE);
 #endif
 
 	parser->parser->replaceEntities = 1;


### PR DESCRIPTION
Default to letting the XML parser handle documents larger than 10 MB, which is a restriction set by libxml.

Addresses https://bugs.php.net/bug.php?id=65604
