### PR TITLE
Skip serialize test if ext/session is not loaded

### DIFF
--- a/ext/standard/tests/serialize/bug70219_1.phpt
+++ b/ext/standard/tests/serialize/bug70219_1.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #70219 Use after free vulnerability in session deserializer
+--SKIPIF--
+<?php include __DIR__ . '/../../../session/tests/skipif.inc'; ?>
 --FILE--
 <?php
 ini_set('session.serialize_handler', 'php_serialize');


### PR DESCRIPTION
The test for bug70219 in `ext/standard/tests/serialize/` is dependent on the session extension, so use `ext/session`'s `skipif.inc` file.