### PR TITLE
Fix tests/basic/timeout_variation_*.phpt

### DIFF
--- a/tests/basic/timeout_config.inc
+++ b/tests/basic/timeout_config.inc
@@ -4,8 +4,8 @@ $t = 3;
 
 function busy_wait($how_long)
 {
-	$until = time() + $how_long;
+	$until = microtime(TRUE) + $how_long;
 
-	while ($until > time());
+	while ($until > microtime(TRUE));
 }
 


### PR DESCRIPTION
In 042dd86 / fd51bd4, a new function `busy_wait($how_long)` was created for use in various unit tests which previously used `sleep()` to test the behaviour of `set_time_limit()`. The function accepts an integer, denoting the number of seconds to wait before returning.

However, unless the fractional part of the current timestamp is used when calculating elapsed time, the function typically returns early -- just because the integral part of the current timestamp has rolled over to the next value; this doesn't necessarily mean that an entire second has elapsed.

**Verification on 3v4l.org**
Using `time()`: https://3v4l.org/Fomhb
Using `microtime(TRUE)`: https://3v4l.org/BM9pZ