### PR TITLE
Added put, patch and delete request_methods plus tests.

### DIFF
--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -469,7 +469,12 @@ SAPI_API void sapi_activate(void)
 		if (PG(enable_post_data_reading)
 		&& 	SG(request_info).content_type
 		&&  SG(request_info).request_method
-		&& !strcmp(SG(request_info).request_method, "POST")) {
+		&&
+			(!strcmp(SG(request_info).request_method, "POST") ||
+			!strcmp(SG(request_info).request_method, "PUT") ||
+			!strcmp(SG(request_info).request_method, "PATCH") ||
+			!strcmp(SG(request_info).request_method, "DELETE"))
+		) {
 			/* HTTP POST may contain form data to be processed into variables
 			 * depending on given content type */
 			sapi_read_post_data();

--- a/main/php_content_types.c
+++ b/main/php_content_types.c
@@ -37,7 +37,13 @@ static sapi_post_entry php_post_entries[] = {
  */
 SAPI_API SAPI_POST_READER_FUNC(php_default_post_reader)
 {
-	if (!strcmp(SG(request_info).request_method, "POST")) {
+	if (
+        !strcmp(SG(request_info).request_method, "POST") ||
+        !strcmp(SG(request_info).request_method, "PUT") ||
+        !strcmp(SG(request_info).request_method, "PATCH") ||
+        !strcmp(SG(request_info).request_method, "DELETE")
+        ) {
+
 		if (NULL == SG(request_info).post_entry) {
 			/* no post handler registered, so we just swallow the data */
 			sapi_read_standard_form_data();

--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -690,7 +690,11 @@ static zend_bool php_auto_globals_create_post(zend_string *name)
 			(strchr(PG(variables_order),'P') || strchr(PG(variables_order),'p')) &&
 		!SG(headers_sent) &&
 		SG(request_info).request_method &&
-		!strcasecmp(SG(request_info).request_method, "POST")) {
+			(!strcasecmp(SG(request_info).request_method, "POST") ||
+			!strcasecmp(SG(request_info).request_method, "PUT") ||
+			!strcasecmp(SG(request_info).request_method, "PATCH") ||
+			!strcasecmp(SG(request_info).request_method, "DELETE"))
+		) {
 		sapi_module.treat_data(PARSE_POST, NULL, NULL);
 	} else {
 		zval_ptr_dtor(&PG(http_globals)[TRACK_VARS_POST]);

--- a/run-tests.php
+++ b/run-tests.php
@@ -1296,7 +1296,7 @@ TEST $file
 				unset($section_text['FILEEOF']);
 			}
 
-			foreach (array( 'FILE', 'EXPECT', 'EXPECTF', 'EXPECTREGEX' ) as $prefix) {            
+			foreach (array( 'FILE', 'EXPECT', 'EXPECTF', 'EXPECTREGEX' ) as $prefix) {
 				$key = $prefix . '_EXTERNAL';
 
 				if (@count($section_text[$key]) == 1) {
@@ -1340,8 +1340,8 @@ TEST $file
 
 	$tested = trim($section_text['TEST']);
 
-	/* For GET/POST/PUT tests, check if cgi sapi is available and if it is, use it. */
-	if (!empty($section_text['GET']) || !empty($section_text['POST']) || !empty($section_text['GZIP_POST']) || !empty($section_text['DEFLATE_POST']) || !empty($section_text['POST_RAW']) || !empty($section_text['PUT']) || !empty($section_text['COOKIE']) || !empty($section_text['EXPECTHEADERS'])) {
+	/* For GET/POST/PUT/PATCH/DELETE tests, check if cgi sapi is available and if it is, use it. */
+	if (!empty($section_text['GET']) || !empty($section_text['POST']) || !empty($section_text['GZIP_POST']) || !empty($section_text['DEFLATE_POST']) || !empty($section_text['POST_RAW']) || !empty($section_text['PUT']) || !empty($section_text['PATCH']) || !empty($section_text['DELETE']) || !empty($section_text['COOKIE']) || !empty($section_text['EXPECTHEADERS'])) {
 		if (isset($php_cgi)) {
 			$old_php = $php;
 			$php = $php_cgi . ' -C ';
@@ -1594,9 +1594,9 @@ TEST $file
 			}
 		}
 	}
-	
+
 	if (!extension_loaded("zlib")
-	&& (	array_key_exists("GZIP_POST", $section_text) 
+	&& (	array_key_exists("GZIP_POST", $section_text)
 		||	array_key_exists("DEFLATE_POST", $section_text))
 	) {
 		$message = "ext/zlib required";
@@ -1770,8 +1770,88 @@ TEST $file
 			$request .= $line;
 		}
 
+		if (empty($env['CONTENT_TYPE'])) {
+			$env['CONTENT_TYPE']   = 'application/x-www-form-urlencoded';
+		}
+
 		$env['CONTENT_LENGTH'] = strlen($request);
 		$env['REQUEST_METHOD'] = 'PUT';
+
+		if (empty($request)) {
+			junit_mark_test_as('BORK', $shortname, $tested, null, 'empty $request');
+			return 'BORKED';
+		}
+
+		save_text($tmp_post, $request);
+		$cmd = "$php $pass_options $ini_settings -f \"$test_file\" 2>&1 < \"$tmp_post\"";
+
+	} elseif (array_key_exists('PATCH', $section_text) && !empty($section_text['PATCH'])) {
+
+		$post = trim($section_text['PATCH']);
+		$raw_lines = explode("\n", $post);
+
+		$request = '';
+		$started = false;
+
+		foreach ($raw_lines as $line) {
+
+			if (empty($env['CONTENT_TYPE']) && preg_match('/^Content-Type:(.*)/i', $line, $res)) {
+				$env['CONTENT_TYPE'] = trim(str_replace("\r", '', $res[1]));
+				continue;
+			}
+
+			if ($started) {
+				$request .= "\n";
+			}
+
+			$started = true;
+			$request .= $line;
+		}
+
+		if (empty($env['CONTENT_TYPE'])) {
+			$env['CONTENT_TYPE']   = 'application/x-www-form-urlencoded';
+		}
+
+		$env['CONTENT_LENGTH'] = strlen($request);
+		$env['REQUEST_METHOD'] = 'PATCH';
+
+		if (empty($request)) {
+			junit_mark_test_as('BORK', $shortname, $tested, null, 'empty $request');
+			return 'BORKED';
+		}
+
+		save_text($tmp_post, $request);
+		$cmd = "$php $pass_options $ini_settings -f \"$test_file\" 2>&1 < \"$tmp_post\"";
+
+	} elseif (array_key_exists('DELETE', $section_text) && !empty($section_text['DELETE'])) {
+
+		$post = trim($section_text['DELETE']);
+		$raw_lines = explode("\n", $post);
+
+		$request = '';
+		$started = false;
+
+		foreach ($raw_lines as $line) {
+
+			if (empty($env['CONTENT_TYPE']) && preg_match('/^Content-Type:(.*)/i', $line, $res)) {
+				$env['CONTENT_TYPE'] = trim(str_replace("\r", '', $res[1]));
+				continue;
+			}
+
+			if ($started) {
+				$request .= "\n";
+			}
+
+			$started = true;
+			$request .= $line;
+		}
+
+		if (empty($env['CONTENT_TYPE'])) {
+			$env['CONTENT_TYPE']   = 'application/x-www-form-urlencoded';
+		}
+
+		$env['CONTENT_LENGTH'] = strlen($request);
+		$env['REQUEST_METHOD'] = 'DELETE';
 
 		if (empty($request)) {
 			junit_mark_test_as('BORK', $shortname, $tested, null, 'empty $request');
@@ -2185,7 +2265,7 @@ $output
 	if (isset($old_php)) {
 		$php = $old_php;
 	}
-	
+
 	$diff = empty($diff) ? '' : preg_replace('/\e/', '<esc>', $diff);
 
 	junit_mark_test_as($restype, str_replace($cwd . '/', '', $tested_file), $tested, null, $info, $diff);

--- a/tests/basic/033.phpt
+++ b/tests/basic/033.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Simple PUT Method test
+--PUT--
+a=Hello+World
+--FILE--
+<?php
+echo $_POST['a']; ?>
+--EXPECT--
+Hello World

--- a/tests/basic/034.phpt
+++ b/tests/basic/034.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Simple PATCH Method test
+--PATCH--
+a=Hello+World
+--FILE--
+<?php
+echo $_POST['a']; ?>
+--EXPECT--
+Hello World

--- a/tests/basic/035.phpt
+++ b/tests/basic/035.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Simple DELETE Method test
+--DELETE--
+a=Hello+World
+--FILE--
+<?php
+echo $_POST['a']; ?>
+--EXPECT--
+Hello World


### PR DESCRIPTION
#### Summary:

Added support for request methods with the smallest change possible.
#### History:

HTTP 1.0 had only support for GET, POST and HEAD.
In June of 1999 HTTP 1.1 added the verbs PUT and DELETE and later in 2010 RFC5789 (https://tools.ietf.org/html/rfc5789) added PATCH.
#### Pull request explaination:

In this pull request I try to add put, patch and delete with changing as few functions as possible. I simply handle the new verbs as POST. As defined in HTTP 1.1 they are similar in input data requirements and differ only in usage.
#### Known side effects

Because this PR tries to handle PUT, PATCH and DELETE exactly as POST the php://input stream will be read. So as POST one need to set the enable_post_data_reading to fetch the stream from these requests. 

---

After reading discussion linked by Tyrael where the suggestion below already has been discussed in length I'll remove the suggestion so we could focus on the main part of the PR.
~~More work I could do is add new globals for $_PUT, $_PATCH and $_DELETE but I think this might be more confusing. Or we could move from $_POST to a new global not tied to a verb. Example $_PARSED_INPUT~~
#### Mentioned in bugs

https://bugs.php.net/bug.php?id=55815
https://bugs.php.net/bug.php?id=70331
