### PR TITLE
#70497: Drop Apache 1 style BLOCK_INTERRUPTIONS support

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -50,8 +50,6 @@ ZEND_API int (*zend_printf)(const char *format, ...);
 ZEND_API zend_write_func_t zend_write;
 ZEND_API FILE *(*zend_fopen)(const char *filename, char **opened_path TSRMLS_DC);
 ZEND_API int (*zend_stream_open_function)(const char *filename, zend_file_handle *handle TSRMLS_DC);
-ZEND_API void (*zend_block_interruptions)(void);
-ZEND_API void (*zend_unblock_interruptions)(void);
 ZEND_API void (*zend_ticks_function)(int ticks);
 ZEND_API void (*zend_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
 int (*zend_vspprintf)(char **pbuf, size_t max_len, const char *format, va_list ap);
@@ -669,10 +667,6 @@ int zend_startup(zend_utility_functions *utility_functions, char **extensions TS
 	}
 	zend_stream_open_function = utility_functions->stream_open_function;
 	zend_message_dispatcher_p = utility_functions->message_handler;
-#ifndef ZEND_SIGNALS
-	zend_block_interruptions = utility_functions->block_interruptions;
-	zend_unblock_interruptions = utility_functions->unblock_interruptions;
-#endif
 	zend_get_configuration_directive_p = utility_functions->get_configuration_directive;
 	zend_ticks_function = utility_functions->ticks_function;
 	zend_on_timeout = utility_functions->on_timeout;

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -548,8 +548,6 @@ typedef struct _zend_utility_functions {
 	int (*write_function)(const char *str, uint str_length);
 	FILE *(*fopen_function)(const char *filename, char **opened_path TSRMLS_DC);
 	void (*message_handler)(long message, const void *data TSRMLS_DC);
-	void (*block_interruptions)(void);
-	void (*unblock_interruptions)(void);
 	int (*get_configuration_directive)(const char *name, uint name_length, zval *contents);
 	void (*ticks_function)(int ticks);
 	void (*on_timeout)(int seconds TSRMLS_DC);
@@ -723,8 +721,8 @@ END_EXTERN_C()
 #define ZEND_UV(name) (zend_uv.name)
 
 #ifndef ZEND_SIGNALS
-#define HANDLE_BLOCK_INTERRUPTIONS()		if (zend_block_interruptions) { zend_block_interruptions(); }
-#define HANDLE_UNBLOCK_INTERRUPTIONS()		if (zend_unblock_interruptions) { zend_unblock_interruptions(); }
+#define HANDLE_BLOCK_INTERRUPTIONS()
+#define HANDLE_UNBLOCK_INTERRUPTIONS()
 #else
 #include "zend_signal.h"
 

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -248,9 +248,6 @@ struct _sapi_module_struct {
 
 	char *php_ini_path_override;
 
-	void (*block_interruptions)(void);
-	void (*unblock_interruptions)(void);
-
 	void (*default_post_reader)(TSRMLS_D);
 	void (*treat_data)(int arg, char *str, zval *destArray TSRMLS_DC);
 	char *executable_location;

--- a/main/main.c
+++ b/main/main.c
@@ -2121,8 +2121,6 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 	zuf.write_function = php_output_wrapper;
 	zuf.fopen_function = php_fopen_wrapper_for_zend;
 	zuf.message_handler = php_message_handler_for_zend;
-	zuf.block_interruptions = sapi_module.block_interruptions;
-	zuf.unblock_interruptions = sapi_module.unblock_interruptions;
 	zuf.get_configuration_directive = php_get_configuration_directive_for_zend;
 	zuf.ticks_function = php_run_ticks;
 	zuf.on_timeout = php_on_timeout;

--- a/sapi/apache/mod_php5.c
+++ b/sapi/apache/mod_php5.c
@@ -487,12 +487,8 @@ static sapi_module_struct apache_sapi_module = {
 
 	NULL,							/* php.ini path override */
 
-#ifdef PHP_WIN32
-	NULL,
-	NULL,
-#else
-	block_alarms,					/* Block interruptions */
-	unblock_alarms,					/* Unblock interruptions */
+#ifndef PHP_WIN32
+# warning "Support for block_alarms/unblock_alarms has been removed. Memory leaks may result."
 #endif
 
 	NULL,							/* default post reader */

--- a/sapi/apache_hooks/mod_php5.c
+++ b/sapi/apache_hooks/mod_php5.c
@@ -542,12 +542,8 @@ static sapi_module_struct apache_sapi_module = {
 
 	NULL,							/* php.ini path override */
 
-#ifdef PHP_WIN32
-	NULL,
-	NULL,
-#else
-	block_alarms,					/* Block interruptions */
-	unblock_alarms,					/* Unblock interruptions */
+#ifndef PHP_WIN32
+# warning "Support for block_alarms/unblock_alarms has been removed. Memory leaks may result."
 #endif
 
 	NULL,                           /* default post reader */

--- a/sapi/continuity/capi.c
+++ b/sapi/continuity/capi.c
@@ -380,9 +380,6 @@ sapi_module_struct capi_sapi_module = {
    NULL,			/* Get request time */
    NULL,			/* Child terminate */
 
-   NULL,			/* Block interruptions */
-   NULL,			/* Unblock interruptions */
-
    STANDARD_SAPI_MODULE_PROPERTIES
 };
 

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -476,8 +476,6 @@ static sapi_module_struct lsapi_sapi_module =
     sapi_lsapi_log_message,         /* Log message */
 
     NULL,                           /* php.ini path override */
-    NULL,                           /* block interruptions */
-    NULL,                           /* unblock interruptions */
     NULL,                           /* default post reader */
     NULL,                           /* treat data */
     NULL,                           /* executable location */

--- a/sapi/milter/php_milter.c
+++ b/sapi/milter/php_milter.c
@@ -928,9 +928,6 @@ static sapi_module_struct milter_sapi_module = {
 	NULL,							/* Get request time */
 	NULL,							/* Child terminate */
 
-	NULL,							/* Block interruptions */
-	NULL,							/* Unblock interruptions */
-
 	STANDARD_SAPI_MODULE_PROPERTIES
 };
 /* }}} */

--- a/sapi/nsapi/nsapi.c
+++ b/sapi/nsapi/nsapi.c
@@ -836,9 +836,6 @@ static sapi_module_struct nsapi_sapi_module = {
 	sapi_nsapi_get_request_time,			/* Get request time */
 	NULL,									/* Child terminate */
 
-	NULL,                                   /* Block interruptions */
-	NULL,                                   /* Unblock interruptions */
-
 	STANDARD_SAPI_MODULE_PROPERTIES
 };
 

--- a/sapi/thttpd/thttpd.c
+++ b/sapi/thttpd/thttpd.c
@@ -397,8 +397,6 @@ static sapi_module_struct thttpd_sapi_module = {
 	NULL,									/* Child terminate */
 
 	NULL,									/* php.ini path override */
-	NULL,									/* Block interruptions */
-	NULL,									/* Unblock interruptions */
 
 	NULL,
 	NULL,


### PR DESCRIPTION
This does the same thing as 127db5a37d17 ("HANDLE_BLOCK_INTERRUPTIONS()
is not used by SAPIs anymore. It may be useful only when PHP configured
with --enable-zend-signals.")

In the PHP7 version, the code could be dropped easily because no SAPI
used the hooks. However, in PHP5, the Apache 1 SAPIs use these hooks.
Some other SAPIs provided NULL pointers.

The Apache 1 SAPIs now throw a warning on build in case anyone still
uses them. The other SAPIs have had the relevant SAPI struct entries
dropped and so should still build.

This leads to a speed up on PHP5 code. I've measured the performance
impact on a PowerPC 64-bit little-endian system and on a x86_64 laptop
using the following script:

<?php
for ($i=1; $i < 100000000; $i++) {
        $genericObject = new stdClass();
        $a = (object) 8;
        $b = (object) 'abcde';
}
?>

I see a ~6% improvement in performance on POWER and a ~4% improvement
on x86_64.

I also see an improvement in a e-commerce web application on POWER
with this change.

Signed-off-by: Daniel Axtens <dja@axtens.net>