### PR TITLE
Remove incorrect reference to Kathmandu in India

### DIFF
--- a/ext/date/lib/timezonemap.h
+++ b/ext/date/lib/timezonemap.h
@@ -1049,8 +1049,6 @@
 	{ "ist",   0,  19800, "Asia/Dacca"                    },
 	{ "ist",   0,  19800, "Asia/Dhaka"                    },
 	{ "ist",   0,  19800, "Asia/Karachi"                  },
-	{ "ist",   0,  19800, "Asia/Kathmandu"                },
-	{ "ist",   0,  19800, "Asia/Katmandu"                 },
 	{ "ist",   0,  19800, "Asia/Kolkata"                  },
 	{ "ist",   0,  19800, "Asia/Thimbu"                   },
 	{ "ist",   0,  19800, "Asia/Thimphu"                  },


### PR DESCRIPTION
Kathmandu (and alternative spelling Katmandu) is in Nepal, not in India. It is not part of Indian Standard Time "ist".
This should fix the problem in the output of DateTimeZone::listAbbreviations() reported in bug:
https://bugs.php.net/bug.php?id=70502

Note that Asia/Kathmandu and Asia/Katmandu are also correctly listed as "npt" and 20700 seconds = UTC+05:45 offset elsewhere in this array.