### PR TITLE
access to dynamic array  GC_G(buf) out of bound

### DIFF
--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -210,7 +210,7 @@ ZEND_API void gc_init(void)
 {
 	if (GC_G(buf) == NULL && GC_G(gc_enabled)) {
 		GC_G(buf) = (gc_root_buffer*) malloc(sizeof(gc_root_buffer) * GC_ROOT_BUFFER_MAX_ENTRIES);
-		GC_G(last_unused) = &GC_G(buf)[GC_ROOT_BUFFER_MAX_ENTRIES];
+		GC_G(last_unused) = &GC_G(buf)[GC_ROOT_BUFFER_MAX_ENTRIES-1];
 		gc_reset();
 	}
 }


### PR DESCRIPTION
Here:
GC_G(last_unused) = &GC_G(buf)[GC_ROOT_BUFFER_MAX_ENTRIES];
the access for GC_G(buf)[GC_ROOT_BUFFER_MAX_ENTRIES] is out of the malloc size bound.
though it may not be easily triggered