### PR TITLE
#70497: v2: Compile out HANDLE_BLOCK_INTERRUPTIONS when unused

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -722,14 +722,19 @@ END_EXTERN_C()
 
 #define ZEND_UV(name) (zend_uv.name)
 
-#ifndef ZEND_SIGNALS
-#define HANDLE_BLOCK_INTERRUPTIONS()		if (zend_block_interruptions) { zend_block_interruptions(); }
-#define HANDLE_UNBLOCK_INTERRUPTIONS()		if (zend_unblock_interruptions) { zend_unblock_interruptions(); }
-#else
+/* HANDLE_BLOCK_INTERRUPTIONS is only used for Apache 1 and signal support.
+ * If we have neither of those we can compile it out. */
+#if defined(ZEND_SIGNALS)
 #include "zend_signal.h"
 
 #define HANDLE_BLOCK_INTERRUPTIONS()		ZEND_SIGNAL_BLOCK_INTERRUPUTIONS()
 #define HANDLE_UNBLOCK_INTERRUPTIONS()		ZEND_SIGNAL_UNBLOCK_INTERRUPTIONS()
+#elif defined(HAVE_APACHE)
+#define HANDLE_BLOCK_INTERRUPTIONS()		if (zend_block_interruptions) { zend_block_interruptions(); }
+#define HANDLE_UNBLOCK_INTERRUPTIONS()		if (zend_unblock_interruptions) { zend_unblock_interruptions(); }
+#else
+#define HANDLE_BLOCK_INTERRUPTIONS()
+#define HANDLE_UNBLOCK_INTERRUPTIONS()
 #endif
 
 BEGIN_EXTERN_C()


### PR DESCRIPTION
This does the same thing as 127db5a ("HANDLE_BLOCK_INTERRUPTIONS()
is not used by SAPIs anymore. It may be useful only when PHP configured
with --enable-zend-signals.")

In the PHP7 version, the code could be dropped easily because no SAPI
used the hooks. However, in PHP5, the Apache 1 SAPIs use these hooks.
Some other SAPIs provided NULL pointers.

With this patch, when PHP is compiled we first check for the Apache 1
SAPI, and if it is present, preserve the old behaviour. (Both flavours
of the Apache 1 SAPI define HAVE_APACHE, so use that.) It also preserves
the behaviour in the ZEND_SIGNALS case. Only if neither of those are
present do we compile out the definitions.

This leads to a speed up on PHP5 code. I've measured the performance
impact on a PowerPC 64-bit little-endian system and on a x86_64 laptop
using the following script:

<?php
for ($i=1; $i < 100000000; $i++) {
        $genericObject = new stdClass();
        $a = (object) 8;
        $b = (object) 'abcde';
}
?>

I see a ~6% improvement in performance on POWER and a ~4% improvement
on x86_64.

I also see an improvement in a e-commerce web application on POWER
with this change.

Signed-off-by: Daniel Axtens <dja@axtens.net>

---

This is version 2.
Changes in this version from version 1 (https://github.com/php/php-src/pull/1520)
 - Do not change behaviour under Apache 1.