### PR TITLE
fix bug 70279

### DIFF
--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -1050,6 +1050,7 @@ static int fcgi_read_request(fcgi_request *req)
 	req->out_hdr = NULL;
 	req->out_pos = req->out_buf;
 	req->has_env = 1;
+	fcgi_hash_clean(&req->env);
 
 	if (safe_read(req, &hdr, sizeof(fcgi_header)) != sizeof(fcgi_header) ||
 	    hdr.version < FCGI_VERSION_1) {


### PR DESCRIPTION
As I've said on the mailing list, I'm not 100% sure whether this is the correct usage of the fastcgi API, so I would really appreciate if somebody with fastcgi (and FPM) knowledge could give a review.

Furthermore, if somebody could give me some pointers in how to write tests for FPM, I will gladly provide tests for this too.

This fixes bug 70279:

in commit f20118aa669f9992fee8a64024e623805669391b the call to fcgi_hash_init() moved out of the actual request handling to the point where FPM was only calling it once when it spawns a subprocess.

Because the datastructure was not cleaned between handling multiple requests, headers and other data of previous requests were not cleaned correctly.

This patch now calls fcgi_hash_clean() before handling individual requests at the cost of a bit of the performance gains of the previous commit.