### PR TITLE
Bug #70561: Fix DirectoryIterator to throw OutOfBoundsException

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -845,7 +845,8 @@ SPL_METHOD(DirectoryIterator, seek)
 			retval = NULL;
 		}
 		if (!valid) {
-			break;
+			zend_throw_exception_ex(spl_ce_OutOfBoundsException, 0 TSRMLS_CC, "Seek position %ld is out of range", pos);
+			return;
 		}
 		zend_call_method_with_0_params(&this_ptr, Z_OBJCE_P(getThis()), &intern->u.dir.func_next, "next", &retval);
 		if (retval) {

--- a/ext/spl/tests/bug70561.phpt
+++ b/ext/spl/tests/bug70561.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #70561 (DirectoryIterator::seek should throw OutOfBoundsException)
+--FILE--
+<?php
+$di = new DirectoryIterator(__DIR__ . '/..');
+
+$cnt = 0;
+$di->rewind();
+while ($di->valid()) {
+    $cnt++;
+    $di->next();
+}
+
+try {
+    $di->seek($cnt+1);
+} catch (OutOfBoundsException $ex) {
+    echo $ex->getMessage() . PHP_EOL;
+}
+echo "Is valid? " . (int) $di->valid() . PHP_EOL;
+?>
+--EXPECTF--
+Seek position %d is out of range
+Is valid? 0

--- a/ext/spl/tests/dit_006.phpt
+++ b/ext/spl/tests/dit_006.phpt
@@ -30,11 +30,12 @@ while ($di->valid()) {
 
 echo "Without seek we get $o\n";
 
-$p = 0;
-$di->seek($o+1);
-while ($di->valid()) {
-    $p++;
-    $di->next();
+try {
+    $p = 0;
+    $di->seek($o+1);
+    $p = 1;
+} catch (\OutOfBoundsException $ex) {
+    echo $ex->getMessage() . PHP_EOL;
 }
 
 var_dump($n !== $m, $m === $o, $p === 0);
@@ -44,6 +45,7 @@ var_dump($n !== $m, $m === $o, $p === 0);
 With seek(2) we get %d
 With seek(0) we get %d
 Without seek we get %d
+Seek position %d is out of range
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
DirectoryIterator implements SeekableIterator, which "should throw an
OutOfBoundsException if the position is not seekable". As is, seek just returns
and one must call valid(). This approach is different than most (all?) other
SeekableIterator implementations and leads to developer confusion. See the
[bug report](https://bugs.php.net/bug.php?id=70561) for a specific example.