### PR TITLE
add 'e' flag for fopen() to enable CLOEXEC

### DIFF
--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -94,6 +94,12 @@ PHPAPI int php_stream_parse_fopen_modes(const char *mode, int *open_flags)
 		flags |= O_RDONLY;
 	}
 
+#if defined(O_CLOEXEC)
+	if (strchr(mode, 'e')) {
+		flags |= O_CLOEXEC;
+	}
+#endif
+
 #if defined(O_NONBLOCK)
 	if (strchr(mode, 'n')) {
 		flags |= O_NONBLOCK;


### PR DESCRIPTION
introduces a new mode character 'e' for fopen to add O_CLOEXEC flag
useful for preventing leaking of file descriptors to child processes
