### PR TITLE
Array keys strict refs

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -731,6 +731,8 @@ static zend_always_inline int fast_equal_check_string(zval *op1, zval *op2)
 
 static zend_always_inline int fast_is_identical_function(zval *op1, zval *op2)
 {
+	ZVAL_DEREF(op1);
+	ZVAL_DEREF(op2);
 	if (Z_TYPE_P(op1) != Z_TYPE_P(op2)) {
 		return 0;
 	} else if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -741,6 +743,8 @@ static zend_always_inline int fast_is_identical_function(zval *op1, zval *op2)
 
 static zend_always_inline int fast_is_not_identical_function(zval *op1, zval *op2)
 {
+	ZVAL_DEREF(op1);
+	ZVAL_DEREF(op2);
 	if (Z_TYPE_P(op1) != Z_TYPE_P(op2)) {
 		return 1;
 	} else if (Z_TYPE_P(op1) <= IS_TRUE) {

--- a/ext/standard/tests/array/array_keys_non_strict.phpt
+++ b/ext/standard/tests/array/array_keys_non_strict.phpt
@@ -1,0 +1,109 @@
+--TEST--
+array_keys() in non-strict mode 
+--FILE--
+<?php
+
+$arr = array(1, "1", "", NULL, 0, false, true, array());
+
+$s = 1;
+var_dump(array_keys($arr, $s));
+
+$s = "1";
+var_dump(array_keys($arr, $s));
+
+$s = "";
+var_dump(array_keys($arr, $s));
+
+$s = NULL;
+var_dump(array_keys($arr, $s));
+
+$s = 0;
+var_dump(array_keys($arr, $s));
+
+$s = false;
+var_dump(array_keys($arr, $s));
+
+$s = true;
+var_dump(array_keys($arr, $s));
+
+$s = array();
+var_dump(array_keys($arr, $s));
+
+?>
+--EXPECTF--
+array(3) {
+  [0]=>
+  int(0)
+  [1]=>
+  int(1)
+  [2]=>
+  int(6)
+}
+array(3) {
+  [0]=>
+  int(0)
+  [1]=>
+  int(1)
+  [2]=>
+  int(6)
+}
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(3)
+  [2]=>
+  int(4)
+  [3]=>
+  int(5)
+}
+array(5) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(3)
+  [2]=>
+  int(4)
+  [3]=>
+  int(5)
+  [4]=>
+  int(7)
+}
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(3)
+  [2]=>
+  int(4)
+  [3]=>
+  int(5)
+}
+array(5) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(3)
+  [2]=>
+  int(4)
+  [3]=>
+  int(5)
+  [4]=>
+  int(7)
+}
+array(3) {
+  [0]=>
+  int(0)
+  [1]=>
+  int(1)
+  [2]=>
+  int(6)
+}
+array(3) {
+  [0]=>
+  int(3)
+  [1]=>
+  int(5)
+  [2]=>
+  int(7)
+}

--- a/ext/standard/tests/array/array_keys_strict.phpt
+++ b/ext/standard/tests/array/array_keys_strict.phpt
@@ -1,0 +1,65 @@
+--TEST--
+array_keys() in strict mode 
+--FILE--
+<?php
+
+$arr = array(1, "1", "", NULL, 0, false, true, array());
+
+$s = 1;
+var_dump(array_keys($arr, $s, true));
+
+$s = "1";
+var_dump(array_keys($arr, $s, true));
+
+$s = "";
+var_dump(array_keys($arr, $s, true));
+
+$s = NULL;
+var_dump(array_keys($arr, $s, true));
+
+$s = 0;
+var_dump(array_keys($arr, $s, true));
+
+$s = false;
+var_dump(array_keys($arr, $s, true));
+
+$s = true;
+var_dump(array_keys($arr, $s, true));
+
+$s = array();
+var_dump(array_keys($arr, $s, true));
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  int(0)
+}
+array(1) {
+  [0]=>
+  int(1)
+}
+array(1) {
+  [0]=>
+  int(2)
+}
+array(1) {
+  [0]=>
+  int(3)
+}
+array(1) {
+  [0]=>
+  int(4)
+}
+array(1) {
+  [0]=>
+  int(5)
+}
+array(1) {
+  [0]=>
+  int(6)
+}
+array(1) {
+  [0]=>
+  int(7)
+}

--- a/ext/standard/tests/array/array_keys_strict_ref.phpt
+++ b/ext/standard/tests/array/array_keys_strict_ref.phpt
@@ -1,0 +1,65 @@
+--TEST--
+array_keys() in strict mode with references 
+--FILE--
+<?php
+
+$arr = array(1, "1", "", NULL, 0, false, true, array());
+
+$s = &$arr[0];
+var_dump(array_keys($arr, $s, true));
+
+$s = &$arr[1];
+var_dump(array_keys($arr, $s, true));
+
+$s = &$arr[2];
+var_dump(array_keys($arr, $s, true));
+
+$s = &$arr[3];
+var_dump(array_keys($arr, $s, true));
+
+$s = &$arr[4];
+var_dump(array_keys($arr, $s, true));
+
+$s = &$arr[5];
+var_dump(array_keys($arr, $s, true));
+
+$s = &$arr[6];
+var_dump(array_keys($arr, $s, true));
+
+$s = &$arr[7];
+var_dump(array_keys($arr, $s, true));
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  int(0)
+}
+array(1) {
+  [0]=>
+  int(1)
+}
+array(1) {
+  [0]=>
+  int(2)
+}
+array(1) {
+  [0]=>
+  int(3)
+}
+array(1) {
+  [0]=>
+  int(4)
+}
+array(1) {
+  [0]=>
+  int(5)
+}
+array(1) {
+  [0]=>
+  int(6)
+}
+array(1) {
+  [0]=>
+  int(7)
+}


### PR DESCRIPTION
The code below returns empty array in PHP7 (i.e. fails to find the item) and works fine in previous versions:
    $haystack = array();
    $needle = array();
    $haystack[] = &$array;
    $idx = array_keys($bucket, $array, true);
    var_dump($idx);

This happens because is fast_is_identical_function() doesn't dereference its arguments before comparing their types, which means that even though the values *are* identical, they're considered different because one of them is a reference.

I also went ahead and added the same fix to the fast_is_not_identical_function().

The change didn't affect any tests, except for the new ones, added with the patch.