### PR TITLE
Fix intdiv() argument names and description

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1763,7 +1763,7 @@ ZEND_BEGIN_ARG_INFO(arginfo_fmod, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_intdiv, 0)
-	ZEND_ARG_INFO(0, numerator)
+	ZEND_ARG_INFO(0, dividend)
 	ZEND_ARG_INFO(0, divisor)
 ZEND_END_ARG_INFO()
 /* }}} */

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1456,27 +1456,27 @@ PHP_FUNCTION(fmod)
 }
 /* }}} */
 
-/* {{{ proto int intdiv(int numerator, int divisor)
-   Returns the integer division of the numerator by the divisor */
+/* {{{ proto int intdiv(int dividend, int divisor)
+   Returns the integer quotient of the division of dividend by divisor */
 PHP_FUNCTION(intdiv)
 {
-	zend_long numerator, divisor;
+	zend_long dividend, divisor;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &numerator, &divisor) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &dividend, &divisor) == FAILURE) {
 		return;
 	}
 
 	if (divisor == 0) {
 		zend_throw_exception_ex(zend_ce_division_by_zero_error, 0, "Division by zero");
 		return;
-	} else if (divisor == -1 && numerator == ZEND_LONG_MIN) {
+	} else if (divisor == -1 && dividend == ZEND_LONG_MIN) {
 		/* Prevent overflow error/crash ... really should not happen:
 		   We don't return a float here as that violates function contract */
 		zend_throw_exception_ex(zend_ce_arithmetic_error, 0, "Division of PHP_INT_MIN by -1 is not an integer");
 		return;
 	}
 
-	RETURN_LONG(numerator / divisor);
+	RETURN_LONG(dividend / divisor);
 }
 /* }}} */
 


### PR DESCRIPTION
When I added `intdiv()`, I made the parameter names inconsistent. In mathematics, it's 'numerator and denominator' or 'dividend and divisor', not the weird hybrid I used, 'numerator and divisor'. This pull request corrects the parameter names to be 'dividend and divisor'. It also rewrites the description to be clearer, since 'integer division' is poorly defined.

I hope this can get in for 7.0 since it's a tiny documentation fix.