### PR TITLE
Disallow scope rebinding of functions and methods

### DIFF
--- a/Zend/tests/bug70630.phpt
+++ b/Zend/tests/bug70630.phpt
@@ -2,9 +2,26 @@
 Bug #70630 (Closure::call/bind() crash with ReflectionFunction->getClosure())
 --FILE--
 <?php
+
 class a {}
-$x = (new ReflectionFunction("substr"))->getClosure();
-$x->call(new a);
+function foo() { print "ok\n"; }
+
+foreach (["substr", "foo"] as $fn) {
+	$x = (new ReflectionFunction($fn))->getClosure();
+	$x->call(new a);
+	Closure::bind($x, new a)();
+	Closure::bind($x, new a, "a");
+}
+
 ?>
 --EXPECTF--
-Warning: a::substr() expects at least 2 parameters, 0 given in %s on line %d
+
+Warning: substr() expects at least 2 parameters, 0 given in %s on line %d
+
+Warning: substr() expects at least 2 parameters, 0 given in %s on line %d
+
+Warning: Cannot bind function substr to a class scope in %s on line %d
+ok
+ok
+
+Warning: Cannot bind function foo to a class scope in %s on line %d

--- a/Zend/tests/closure_041.phpt
+++ b/Zend/tests/closure_041.phpt
@@ -53,9 +53,9 @@ $d = $nonstaticScoped->bindTo(null); $d(); echo "\n";
 $d->bindTo($d);
 
 echo "After binding, with same-class instance for the bound ones", "\n";
-$d = $staticUnscoped->bindTo(new A); $d(); echo "\n";
+$d = $staticUnscoped->bindTo(new A); /* $d(); */ echo "\n";
 $d = $nonstaticUnscoped->bindTo(new A); $d(); echo " (should be scoped to dummy class)\n";
-$d = $staticScoped->bindTo(new A); $d(); echo "\n";
+$d = $staticScoped->bindTo(new A); /* $d(); */ echo "\n";
 $d = $nonstaticScoped->bindTo(new A); $d(); echo "\n";
 
 echo "After binding, with different instance for the bound ones", "\n";
@@ -64,6 +64,7 @@ $d = $nonstaticScoped->bindTo(new B); $d(); echo "\n";
 
 echo "Done.\n";
 
+?>
 --EXPECTF--
 Before binding
 scoped to A: bool(false)
@@ -86,14 +87,12 @@ bound: no
 After binding, with same-class instance for the bound ones
 
 Warning: Cannot bind an instance to a static closure in %s on line %d
-scoped to A: bool(false)
-bound: no
+
 scoped to A: bool(false)
 bound: A (should be scoped to dummy class)
 
 Warning: Cannot bind an instance to a static closure in %s on line %d
-scoped to A: bool(true)
-bound: no
+
 scoped to A: bool(true)
 bound: A
 After binding, with different instance for the bound ones

--- a/Zend/tests/closure_043.phpt
+++ b/Zend/tests/closure_043.phpt
@@ -26,19 +26,20 @@ $d = $staticUnscoped->bindTo(null, null); $d(); echo "\n";
 $d = $staticScoped->bindTo(null, null); $d(); echo "\n";
 
 echo "After binding, null scope, with instance", "\n";
-$d = $staticUnscoped->bindTo(new A, null); $d(); echo "\n";
-$d = $staticScoped->bindTo(new A, null); $d(); echo "\n";
+$d = $staticUnscoped->bindTo(new A, null); /* $d(); */ echo "\n";
+$d = $staticScoped->bindTo(new A, null); /* $d();n*/ echo "\n";
 
 echo "After binding, with scope, no instance", "\n";
 $d = $staticUnscoped->bindTo(null, 'A'); $d(); echo "\n";
 $d = $staticScoped->bindTo(null, 'A'); $d(); echo "\n";
 
 echo "After binding, with scope, with instance", "\n";
-$d = $staticUnscoped->bindTo(new A, 'A'); $d(); echo "\n";
-$d = $staticScoped->bindTo(new A, 'A'); $d(); echo "\n";
+$d = $staticUnscoped->bindTo(new A, 'A'); /* $d(); */ echo "\n";
+$d = $staticScoped->bindTo(new A, 'A'); /* $d(); */ echo "\n";
 
 echo "Done.\n";
 
+?>
 --EXPECTF--
 Before binding
 bool(false)
@@ -57,13 +58,9 @@ bool(false)
 After binding, null scope, with instance
 
 Warning: Cannot bind an instance to a static closure in %s on line %d
-bool(false)
-bool(false)
 
 
 Warning: Cannot bind an instance to a static closure in %s on line %d
-bool(false)
-bool(false)
 
 After binding, with scope, no instance
 bool(true)
@@ -75,12 +72,8 @@ bool(false)
 After binding, with scope, with instance
 
 Warning: Cannot bind an instance to a static closure in %s on line %d
-bool(true)
-bool(false)
 
 
 Warning: Cannot bind an instance to a static closure in %s on line %d
-bool(true)
-bool(false)
 
 Done.

--- a/Zend/tests/closure_061.phpt
+++ b/Zend/tests/closure_061.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Closure::call() or Closure::bind() to independent class
+--FILE--
+<?php
+
+class foo {
+	public $var;
+    
+	function initClass() {
+		$this->var = __CLASS__;
+	}
+}
+
+class bar {
+	public $var;
+    
+	function initClass() {
+		$this->var = __CLASS__;
+	}
+    
+	function getVar() {
+		assert($this->var !== null); // ensure initClass was called
+		return $this->var;
+	}
+}
+
+class baz extends bar {
+	public $var;
+    
+	function initClass() {
+		$this->var = __CLASS__;
+	}
+}
+
+function callMethodOn($class, $method, $object) {
+	$closure = (new ReflectionMethod($class, $method))->getClosure((new ReflectionClass($class))->newInstanceWithoutConstructor());
+	$closure = $closure->bindTo($object, $class);
+	return $closure();
+}
+
+$baz = new baz;
+
+callMethodOn("baz", "initClass", $baz);
+var_dump($baz->getVar());
+
+callMethodOn("bar", "initClass", $baz);
+var_dump($baz->getVar());
+
+callMethodOn("foo", "initClass", $baz);
+var_dump($baz->getVar());
+
+?>
+--EXPECTF--
+string(3) "baz"
+string(3) "bar"
+string(3) "foo"

--- a/Zend/tests/closure_062.phpt
+++ b/Zend/tests/closure_062.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test Closure binding to unknown scopes with Closure::call()
+--FILE--
+<?php
+
+function foo() { echo get_class($this), "\n"; }
+$x = (new ReflectionFunction("foo"))->getClosure();
+$x->call(new stdClass);
+
+class a { function foo() { echo get_class($this), "\n"; } }
+$x = (new ReflectionMethod("a", "foo"))->getClosure(new a);
+$x->call(new stdClass);
+
+class b extends a {}
+$x = (new ReflectionMethod("a", "foo"))->getClosure(new a);
+$x->call(new b);
+
+class c extends stdClass { function foo() { echo get_class($this), "\n"; } }
+$x = (new ReflectionMethod("c", "foo"))->getClosure(new c);
+$x->call(new stdClass);
+
+$x = (new ReflectionMethod("a", "foo"))->getClosure(new a);
+$x->call(new a);
+
+class d { function foo() { print "Success\n"; yield; } }
+$x = (new ReflectionMethod("d", "foo"))->getClosure(new d);
+$x->call(new d)->current();
+
+// internal functions with unknown scope must fail
+$x = (new ReflectionMethod("Closure", "bindTo"))->getClosure(function() {});
+$x->call(new a);
+
+?>
+--EXPECTF--
+stdClass
+stdClass
+b
+stdClass
+a
+Success
+
+Warning: Cannot bind closure of internal method Closure::bindTo to unrelated object of class a in %s on line %d

--- a/Zend/tests/closure_063.phpt
+++ b/Zend/tests/closure_063.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Force failure with Closure binding to unknown scopes/$this with Closure::bind()
+--FILE--
+<?php
+
+function foo() { echo get_class($this), "\n"; }
+$x = (new ReflectionFunction("foo"))->getClosure();
+$x->bindTo(new stdClass)();
+$x->bindTo(new stdClass, "stdClass");
+
+class a { function foo() { echo get_class($this), "\n"; } }
+$x = (new ReflectionMethod("a", "foo"))->getClosure(new a);
+$x->bindTo(new stdClass)();
+
+class c extends stdClass { function foo() { echo get_class($this), "\n"; } }
+$x = (new ReflectionMethod("c", "foo"))->getClosure(new c);
+$x->bindTo(new stdClass)();
+
+class b extends a {}
+$x = (new ReflectionMethod("a", "foo"))->getClosure(new a);
+$x->bindTo(new b)();
+$x->bindTo(new b, "a")();
+$x->bindTo(new b, "c");
+
+$x = (new ReflectionMethod("a", "foo"))->getClosure(new a);
+$x->bindTo(new a)();
+
+class z extends SplStack {}
+$x = (new ReflectionMethod("SplStack", "pop"))->getClosure(new SplStack);
+$z = new z; $z->push(20);
+var_dump($x->bindTo($z)());
+$x->bindTo($z, "z");
+
+class d { function foo() { print "Success\n"; yield; } }
+class e extends d {}
+$x = (new ReflectionMethod("d", "foo"))->getClosure(new d);
+$x->bindTo(new d)()->current();
+$x->bindTo(new e)()->current();
+$x->bindTo(new e, "d")()->current();
+$x->bindTo(new e, "e");
+
+?>
+--EXPECTF--
+stdClass
+
+Warning: Cannot bind closure to scope of internal class stdClass in %s on line %d
+stdClass
+stdClass
+b
+b
+
+Warning: Cannot bind function a::foo to scope class c in %s on line %d
+a
+int(20)
+
+Warning: Cannot bind function SplDoublyLinkedList::pop to scope class z in %s on line %d
+Success
+Success
+Success
+
+Warning: Cannot bind function d::foo to scope class e in %s on line %d
+

--- a/Zend/tests/closure_call.phpt
+++ b/Zend/tests/closure_call.phpt
@@ -36,7 +36,6 @@ $elePHPant->x = 7;
 // Try on a StdClass
 var_dump($bar->call($elePHPant));
 
-
 $beta = function ($z) {
     return $this->x * $z;
 };
@@ -60,8 +59,6 @@ $foo->call(new FooBar);
 int(0)
 int(0)
 int(3)
-
-Warning: Cannot bind closure to object of internal class stdClass in %s line %d
-NULL
+int(7)
 int(21)
 int(3)

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -95,21 +95,11 @@ ZEND_METHOD(Closure, call)
 		return;
 	}
 
-	if (closure->func.type == ZEND_INTERNAL_FUNCTION) {
-		/* verify that we aren't binding internal function to a wrong object */
-		if ((closure->func.common.fn_flags & ZEND_ACC_STATIC) == 0 &&
-				closure->func.common.scope &&
-				!instanceof_function(Z_OBJCE_P(newthis), closure->func.common.scope)) {
-			zend_error(E_WARNING, "Cannot bind function %s::%s to object of class %s", ZSTR_VAL(closure->func.common.scope->name), ZSTR_VAL(closure->func.common.function_name), ZSTR_VAL(Z_OBJCE_P(newthis)->name));
-			return;
-		}
-	}
-
 	newobj = Z_OBJ_P(newthis);
 
-	if (newobj->ce != closure->func.common.scope && newobj->ce->type == ZEND_INTERNAL_CLASS) {
+	if (closure->func.type == ZEND_INTERNAL_FUNCTION && closure->func.common.scope != NULL && !instanceof_function(newobj->ce, closure->func.common.scope)) {
 		/* rebinding to internal class is not allowed */
-		zend_error(E_WARNING, "Cannot bind closure to object of internal class %s", ZSTR_VAL(newobj->ce->name));
+		zend_error(E_WARNING, "Cannot bind closure of internal method %s::%s to unrelated object of class %s", ZSTR_VAL(closure->func.common.scope->name), ZSTR_VAL(closure->func.common.function_name), ZSTR_VAL(newobj->ce->name));
 		return;
 	}
 
@@ -126,17 +116,21 @@ ZEND_METHOD(Closure, call)
 
 	if (fci_cache.function_handler->common.fn_flags & ZEND_ACC_GENERATOR) {
 		zval new_closure;
-		zend_create_closure(&new_closure, fci_cache.function_handler, Z_OBJCE_P(newthis), closure->called_scope, newthis);
+		zend_create_closure(&new_closure, fci_cache.function_handler, closure->func.common.scope, closure->called_scope, newthis);
+		ZEND_ASSERT(Z_TYPE(new_closure) == IS_OBJECT);
 		closure = (zend_closure *) Z_OBJ(new_closure);
 		fci_cache.function_handler = &closure->func;
 	} else {
 		memcpy(&my_function, fci_cache.function_handler, fci_cache.function_handler->type == ZEND_USER_FUNCTION ? sizeof(zend_op_array) : sizeof(zend_internal_function));
-		/* use scope of passed object */
-		my_function.common.scope = Z_OBJCE_P(newthis);
 		fci_cache.function_handler = &my_function;
+	}
+
+	if (closure->func.type == ZEND_USER_FUNCTION && (closure->func.common.fn_flags & ZEND_ACC_REAL_CLOSURE)) {
+		/* use scope of passed object; we must not change scope of functions and methods, only true Closures */
+		fci_cache.function_handler->common.scope = Z_OBJCE_P(newthis);
 
 		/* Runtime cache relies on bound scope to be immutable, hence we need a separate rt cache in case scope changed */
-		if (ZEND_USER_CODE(my_function.type) && closure->func.common.scope != Z_OBJCE_P(newthis)) {
+		if (closure->func.common.scope != Z_OBJCE_P(newthis)) {
 			my_function.op_array.run_time_cache = emalloc(my_function.op_array.cache_size);
 			memset(my_function.op_array.run_time_cache, 0, my_function.op_array.cache_size);
 		}
@@ -149,7 +143,7 @@ ZEND_METHOD(Closure, call)
 	if (fci_cache.function_handler->common.fn_flags & ZEND_ACC_GENERATOR) {
 		/* copied upon generator creation */
 		--GC_REFCOUNT(&closure->std);
-	} else if (ZEND_USER_CODE(my_function.type) && closure->func.common.scope != Z_OBJCE_P(newthis)) {
+	} else if (ZEND_USER_CODE(my_function.type) && (closure->func.common.fn_flags & ZEND_ACC_REAL_CLOSURE) && closure->func.common.scope != Z_OBJCE_P(newthis)) {
 		efree(my_function.op_array.run_time_cache);
 	}
 }
@@ -167,10 +161,11 @@ ZEND_METHOD(Closure, bind)
 		RETURN_NULL();
 	}
 
-	closure = (zend_closure *)Z_OBJ_P(zclosure);
+	closure = (zend_closure *) Z_OBJ_P(zclosure);
 
 	if ((newthis != NULL) && (closure->func.common.fn_flags & ZEND_ACC_STATIC)) {
 		zend_error(E_WARNING, "Cannot bind an instance to a static closure");
+		RETURN_NULL();
 	}
 
 	if (scope_arg != NULL) { /* scope argument was given */
@@ -189,10 +184,10 @@ ZEND_METHOD(Closure, bind)
 			}
 			zend_string_release(class_name);
 		}
-		if(ce && ce != closure->func.common.scope && ce->type == ZEND_INTERNAL_CLASS) {
+		if (ce && ce != closure->func.common.scope && ce->type == ZEND_INTERNAL_CLASS) {
 			/* rebinding to internal class is not allowed */
 			zend_error(E_WARNING, "Cannot bind closure to scope of internal class %s", ZSTR_VAL(ce->name));
-			return;
+			RETURN_NULL();
 		}
 	} else { /* scope argument not given; do not change the scope by default */
 		ce = closure->func.common.scope;
@@ -205,14 +200,17 @@ ZEND_METHOD(Closure, bind)
 	}
 
 	zend_create_closure(return_value, &closure->func, ce, called_scope, newthis);
-	new_closure = (zend_closure *) Z_OBJ_P(return_value);
 
-	/* Runtime cache relies on bound scope to be immutable, hence we need a separate rt cache in case scope changed */
-	if (ZEND_USER_CODE(closure->func.type) && (closure->func.common.scope != new_closure->func.common.scope || (closure->func.op_array.fn_flags & ZEND_ACC_NO_RT_ARENA))) {
-		new_closure->func.op_array.run_time_cache = emalloc(new_closure->func.op_array.cache_size);
-		memset(new_closure->func.op_array.run_time_cache, 0, new_closure->func.op_array.cache_size);
+	if (Z_TYPE_P(return_value) != IS_NULL) {
+		new_closure = (zend_closure *) Z_OBJ_P(return_value);
 
-		new_closure->func.op_array.fn_flags |= ZEND_ACC_NO_RT_ARENA;
+		/* Runtime cache relies on bound scope to be immutable, hence we need a separate rt cache in case scope changed */
+		if (ZEND_USER_CODE(closure->func.type) && (closure->func.common.scope != new_closure->func.common.scope || (closure->func.op_array.fn_flags & ZEND_ACC_NO_RT_ARENA))) {
+			new_closure->func.op_array.run_time_cache = emalloc(new_closure->func.op_array.cache_size);
+			memset(new_closure->func.op_array.run_time_cache, 0, new_closure->func.op_array.cache_size);
+
+			new_closure->func.op_array.fn_flags |= ZEND_ACC_NO_RT_ARENA;
+		}
 	}
 }
 /* }}} */
@@ -244,11 +242,9 @@ ZEND_API zend_function *zend_get_closure_invoke_method(zend_object *object) /* {
 	 * and we won't check arguments on internal function. We also set
 	 * ZEND_ACC_USER_ARG_INFO flag to prevent invalid usage by Reflection */
 	invoke->type = ZEND_INTERNAL_FUNCTION;
-	invoke->internal_function.fn_flags =
-		ZEND_ACC_PUBLIC | ZEND_ACC_CALL_VIA_HANDLER | (closure->func.common.fn_flags & keep_flags);
+	invoke->internal_function.fn_flags = ZEND_ACC_PUBLIC | ZEND_ACC_CALL_VIA_HANDLER | (closure->func.common.fn_flags & keep_flags);
 	if (closure->func.type != ZEND_INTERNAL_FUNCTION || (closure->func.common.fn_flags & ZEND_ACC_USER_ARG_INFO)) {
-		invoke->internal_function.fn_flags |=
-			ZEND_ACC_USER_ARG_INFO;
+		invoke->internal_function.fn_flags |= ZEND_ACC_USER_ARG_INFO;
 	}
 	invoke->internal_function.handler = ZEND_MN(Closure___invoke);
 	invoke->internal_function.module = 0;
@@ -360,8 +356,7 @@ static zend_object *zend_closure_clone(zval *zobject) /* {{{ */
 	zend_closure *closure = (zend_closure *)Z_OBJ_P(zobject);
 	zval result;
 
-	zend_create_closure(&result, &closure->func,
-		closure->func.common.scope, closure->called_scope, &closure->this_ptr);
+	zend_create_closure(&result, &closure->func, closure->func.common.scope, closure->called_scope, &closure->this_ptr);
 	return Z_OBJ(result);
 }
 /* }}} */
@@ -528,19 +523,46 @@ static void zend_closure_internal_handler(INTERNAL_FUNCTION_PARAMETERS) /* {{{ *
 }
 /* }}} */
 
+/* res will be set to IS_NULL or contains a Closure object */
 ZEND_API void zend_create_closure(zval *res, zend_function *func, zend_class_entry *scope, zend_class_entry *called_scope, zval *this_ptr) /* {{{ */
 {
 	zend_closure *closure;
 
-	object_init_ex(res, zend_ce_closure);
+	if (func->type != ZEND_USER_FUNCTION || (func->common.fn_flags & ZEND_ACC_REAL_CLOSURE) == 0) {
+		/* verify that we aren't binding a function or method (non-Closure) to a wrong scope */
+		if (func->common.scope != NULL) {
+			if (scope != func->common.scope) {
+				if (scope) {
+					zend_error(E_WARNING, "Cannot bind function %s::%s to scope class %s", ZSTR_VAL(func->common.scope->name), ZSTR_VAL(func->common.function_name), ZSTR_VAL(scope->name));
+				} else {
+					zend_error(E_WARNING, "Cannot unbind function %s::%s from its scope", ZSTR_VAL(func->common.scope->name), ZSTR_VAL(func->common.function_name));
+				}
+				ZVAL_NULL(res);
+				return;
+			}
+			if (func->type == ZEND_INTERNAL_FUNCTION && this_ptr && (Z_TYPE_P(this_ptr) != IS_UNDEF) && !instanceof_function(Z_OBJCE_P(this_ptr), func->common.scope)) {
+				/* rebinding to internal class is not allowed */
+				zend_error(E_WARNING, "Cannot bind closure of internal method %s::%s to unrelated object of class %s", ZSTR_VAL(func->common.scope->name), ZSTR_VAL(func->common.function_name), ZSTR_VAL(Z_OBJCE_P(this_ptr)->name));
+				ZVAL_NULL(res);
+				return;
+			}
+		} else if (scope) {
+			zend_error(E_WARNING, "Cannot bind function %s to a class scope", ZSTR_VAL(func->common.function_name));
+			ZVAL_NULL(res);
+			return;
+		}
+	}
 
-	closure = (zend_closure *)Z_OBJ_P(res);
-
-	if ((scope == NULL) && this_ptr && (Z_TYPE_P(this_ptr) != IS_UNDEF)) {
+	if ((scope == NULL) && this_ptr && (Z_TYPE_P(this_ptr) != IS_UNDEF) && func->type != ZEND_INTERNAL_FUNCTION) {
 		/* use dummy scope if we're binding an object without specifying a scope */
 		/* maybe it would be better to create one for this purpose */
 		scope = zend_ce_closure;
 	}
+
+	object_init_ex(res, zend_ce_closure);
+
+	closure = (zend_closure *) Z_OBJ_P(res);
+
 
 	if (func->type == ZEND_USER_FUNCTION) {
 		memcpy(&closure->func, func, sizeof(zend_op_array));
@@ -574,23 +596,6 @@ ZEND_API void zend_create_closure(zval *res, zend_function *func, zend_class_ent
 			closure->orig_internal_handler = closure->func.internal_function.handler;
 		}
 		closure->func.internal_function.handler = zend_closure_internal_handler;
-		/* verify that we aren't binding internal function to a wrong scope */
-		if(func->common.scope != NULL) {
-			if(scope && !instanceof_function(scope, func->common.scope)) {
-				zend_error(E_WARNING, "Cannot bind function %s::%s to scope class %s", ZSTR_VAL(func->common.scope->name), ZSTR_VAL(func->common.function_name), ZSTR_VAL(scope->name));
-				scope = NULL;
-			}
-			if(scope && this_ptr && (func->common.fn_flags & ZEND_ACC_STATIC) == 0 &&
-					!instanceof_function(Z_OBJCE_P(this_ptr), closure->func.common.scope)) {
-				zend_error(E_WARNING, "Cannot bind function %s::%s to object of class %s", ZSTR_VAL(func->common.scope->name), ZSTR_VAL(func->common.function_name), ZSTR_VAL(Z_OBJCE_P(this_ptr)->name));
-				scope = NULL;
-				this_ptr = NULL;
-			}
-		} else {
-			/* if it's a free function, we won't set scope & this since they're meaningless */
-			this_ptr = NULL;
-			scope = NULL;
-		}
 	}
 
 	ZVAL_UNDEF(&closure->this_ptr);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4842,7 +4842,7 @@ void zend_compile_func_decl(znode *result, zend_ast *ast) /* {{{ */
 		op_array->doc_comment = zend_string_copy(decl->doc_comment);
 	}
 	if (decl->kind == ZEND_AST_CLOSURE) {
-		op_array->fn_flags |= ZEND_ACC_CLOSURE;
+		op_array->fn_flags |= ZEND_ACC_CLOSURE | ZEND_ACC_REAL_CLOSURE;
 	}
 
 	if (is_method) {

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -238,7 +238,7 @@ typedef struct _zend_try_catch_element {
 /* user class has methods with static variables */
 #define ZEND_HAS_STATIC_IN_METHODS    0x800000
 
-
+#define ZEND_ACC_REAL_CLOSURE         0x40
 #define ZEND_ACC_CLOSURE              0x100000
 #define ZEND_ACC_GENERATOR            0x800000
 


### PR DESCRIPTION
This fixes bug #70630 (Closure::call/bind() crash with ReflectionFunction->getClosure())

As requested, I'm doing a pull request for this change to allow for further discussion.