### PR TITLE
Pdo test fixes

### DIFF
--- a/ext/pdo/tests/bug_34630.phpt
+++ b/ext/pdo/tests/bug_34630.phpt
@@ -7,6 +7,9 @@ $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
+
+if (!strncasecmp(getenv('PDOTEST_DSN'), 'firebird', strlen('firebird'))) die('skip not implemented in firebird driver');
+
 ?>
 --FILE--
 <?php

--- a/ext/pdo/tests/bug_36798.phpt
+++ b/ext/pdo/tests/bug_36798.phpt
@@ -1,7 +1,7 @@
 --TEST--
 PDO Common: Bug #36798 (Error parsing named parameters with queries containing high-ascii chars)
 --SKIPIF--
-<?php  
+<?php
 if (!extension_loaded('pdo')) die('skip');
 $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
@@ -10,13 +10,11 @@ PDOTest::skip();
 
 if (!strncasecmp(getenv('PDOTEST_DSN'), 'oci', strlen('oci'))){
     if (!strpos(strtolower(getenv('PDOTEST_DSN')), 'charset=we8mswin1252')) die('skip expected output valid for Oracle with WE8MSWIN1252 character set');
-
 }
-
 ?>
 --FILE--
 <?php
-
+putenv('DB2CODEPAGE=850'); // needed for DB2
 if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE__) . '/../../pdo/tests/');
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
@@ -32,7 +30,7 @@ $row = $stmt->fetch(PDO::FETCH_NUM);
 var_dump( $row );
 
 ?>
---EXPECT--	
+--EXPECT--
 array(1) {
   [0]=>
   string(1) "Ã"

--- a/ext/pdo/tests/bug_36798.phpt
+++ b/ext/pdo/tests/bug_36798.phpt
@@ -14,7 +14,13 @@ if (!strncasecmp(getenv('PDOTEST_DSN'), 'oci', strlen('oci'))){
 ?>
 --FILE--
 <?php
-putenv('DB2CODEPAGE=850'); // needed for DB2
+if (!strncasecmp(getenv('PDOTEST_DSN'), 'dblib', strlen('dblib')) && !strpos(strtolower(getenv('PDOTEST_DSN')), ';charset=')){
+    putenv('PDOTEST_DSN='.getenv('PDOTEST_DSN').';charset=LATIN1'); // needed for MSSQL
+}
+if (!strncasecmp(getenv('PDOTEST_DSN'), 'odbc', strlen('odbc'))){
+    putenv('DB2CODEPAGE=850'); // needed for DB2
+}
+
 if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE__) . '/../../pdo/tests/');
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();

--- a/ext/pdo/tests/bug_38253.phpt
+++ b/ext/pdo/tests/bug_38253.phpt
@@ -14,7 +14,7 @@ if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE_
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $pdo = PDOTest::factory();
 
-$pdo->exec ("create table test (id integer primary key, n varchar(255))");
+$pdo->exec ("create table test (id integer not null primary key, n varchar(255))");
 $pdo->exec ("INSERT INTO test (id, n) VALUES (1, 'hi')");
 
 $pdo->setAttribute (PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_CLASS);
@@ -24,13 +24,13 @@ var_dump($stmt->fetchAll());
 
 $pdo = PDOTest::factory();
 
-if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) == 'oci') {
+if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) == 'oci' || $pdo->getAttribute(PDO::ATTR_DRIVER_NAME) == 'odbc') {
     $type = "clob";
 } else{
     $type = "text";
 }
 
-$pdo->exec ("create table test2 (id integer primary key, n $type)");
+$pdo->exec ("create table test2 (id integer not null primary key, n $type)");
 $pdo->exec ("INSERT INTO test2 (id, n) VALUES (1,'hi')");
 
 $pdo->setAttribute (PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_FUNC);

--- a/ext/pdo/tests/bug_38253.phpt
+++ b/ext/pdo/tests/bug_38253.phpt
@@ -20,13 +20,14 @@ $pdo->exec ("INSERT INTO test (id, n) VALUES (1, 'hi')");
 $pdo->setAttribute (PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_CLASS);
 $stmt = $pdo->prepare ("SELECT * FROM test");
 $stmt->execute();
-var_dump($stmt->fetchAll());
 
-$pdo = PDOTest::factory();
+var_dump($stmt->fetchAll());
 
 if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) == 'oci' || $pdo->getAttribute(PDO::ATTR_DRIVER_NAME) == 'odbc') {
     $type = "clob";
-} else{
+} else if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) == 'firebird') {
+    $type = 'BLOB SUB_TYPE TEXT';
+} else {
     $type = "text";
 }
 
@@ -37,7 +38,6 @@ $pdo->setAttribute (PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_FUNC);
 $stmt = $pdo->prepare ("SELECT * FROM test2");
 $stmt->execute();
 var_dump($stmt->fetchAll());
-
 ?>
 --EXPECTF--
 Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error: No fetch class specified in %s on line %d

--- a/ext/pdo/tests/bug_40285.phpt
+++ b/ext/pdo/tests/bug_40285.phpt
@@ -1,12 +1,14 @@
 --TEST--
 PDO Common: Bug #40285 (The prepare parser goes into an infinite loop on ': or ":)
 --SKIPIF--
-<?php  
+<?php
 if (!extension_loaded('pdo')) die('skip');
 $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
+$db = PDOTest::factory();
+if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'dblib') die('skip DBLIB driver does not support PDO::ATTR_EMULATE_PREPARES');
 ?>
 --FILE--
 <?php
@@ -16,12 +18,10 @@ require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
 
 $db->exec('CREATE TABLE test (field1 VARCHAR(32), field2 VARCHAR(32), field3 VARCHAR(32), field4 INT)');
-
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 $s = $db->prepare("INSERT INTO test VALUES( ':id', 'name', 'section', 22)" );
 $s->execute();
-
 echo "Done\n";
 ?>
---EXPECT--	
+--EXPECT--
 Done

--- a/ext/pdo/tests/bug_43130.phpt
+++ b/ext/pdo/tests/bug_43130.phpt
@@ -34,7 +34,7 @@ $stmt->execute();
 var_dump($stmt->fetch(PDO::FETCH_COLUMN));
 ?>
 --EXPECTF--
-Warning: PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number: parameter was not defined in %s on line %d
+Warning: PDOStatement::%s(): SQLSTATE[HY093]: Invalid parameter number: parameter was not defined in %s on line %d
 
-Warning: PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number in %s on line %d
+Warning: PDOStatement::execute(): SQLSTATE[%s]: %s
 bool(false)

--- a/ext/pdo/tests/bug_43139.phpt
+++ b/ext/pdo/tests/bug_43139.phpt
@@ -22,9 +22,18 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'oci') {
 	$from = 'from dual';
 } else if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'firebird') {
 	$from = 'FROM RDB$DATABASE';
+} else if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'odbc') {
+  @$db->exec("DROP TABLE test");
+  $db->exec("CREATE TABLE test (a integer)");
+  $db->exec("INSERT INTO test VALUES (1)");
+  $from = 'from test';
 }
 
 var_dump($db->query("select 0 as abc, 1 as xyz, 2 as def $from")->fetchAll(PDO::FETCH_GROUP));
+
+if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'odbc') {
+  $db->exec("DROP TABLE test");
+}
 ?>
 --EXPECT--
 array(1) {

--- a/ext/pdo/tests/bug_61292.phpt
+++ b/ext/pdo/tests/bug_61292.phpt
@@ -7,6 +7,8 @@ $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
+$db = PDOTest::factory();
+if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'dblib') die('skip DBLIB driver does not support PDO::ATTR_PERSISTENT');
 ?>
 --FILE--
 <?php

--- a/ext/pdo/tests/bug_65946.phpt
+++ b/ext/pdo/tests/bug_65946.phpt
@@ -20,9 +20,15 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'firebird') {
     $limitStatement = ' ROWS :limit';
 } else if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'oci') {
     $limitStatement = ' where ROWNUM <= :limit';
+} else if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'dblib') {
+    $limitStatement = ' ORDER BY id OFFSET 0 ROWS FETCH NEXT :limit ROWS ONLY';
 }
 
-$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+// dblib does not support attributes.
+if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) != 'dblib') {
+    $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+}
+
 $db->exec('CREATE TABLE test(id int)');
 $db->exec('INSERT INTO test VALUES(1)');
 $stmt = $db->prepare('SELECT * FROM test' . $limitStatement);

--- a/ext/pdo/tests/bug_65946.phpt
+++ b/ext/pdo/tests/bug_65946.phpt
@@ -16,7 +16,9 @@ require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
 
 $limitStatement = ' LIMIT :limit';
-if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'oci') {
+if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'firebird') {
+    $limitStatement = ' ROWS :limit';
+} else if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'oci') {
     $limitStatement = ' where ROWNUM <= :limit';
 }
 

--- a/ext/pdo/tests/bug_65946.phpt
+++ b/ext/pdo/tests/bug_65946.phpt
@@ -12,11 +12,18 @@ PDOTest::skip();
 <?php
 if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE__) . '/../../pdo/tests/');
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+
 $db = PDOTest::factory();
+
+$limitStatement = ' LIMIT :limit';
+if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'oci') {
+    $limitStatement = ' where ROWNUM <= :limit';
+}
+
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 $db->exec('CREATE TABLE test(id int)');
 $db->exec('INSERT INTO test VALUES(1)');
-$stmt = $db->prepare('SELECT * FROM test LIMIT :limit');
+$stmt = $db->prepare('SELECT * FROM test' . $limitStatement);
 $stmt->bindValue('limit', 1, PDO::PARAM_INT);
 if(!($res = $stmt->execute())) var_dump($stmt->errorInfo());
 if(!($res = $stmt->execute())) var_dump($stmt->errorInfo());

--- a/ext/pdo/tests/pdo_017.phpt
+++ b/ext/pdo/tests/pdo_017.phpt
@@ -16,7 +16,7 @@ try {
 }
 
 if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
-	require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+	require_once(dirname(__FILE__) . '/../../pdo_mysql/tests/mysql_pdo_test.inc');
 	if (false === MySQLPDOTest::detect_transactional_mysql_engine($db)) {
 		die('skip your mysql configuration does not support working transactions');
 	}
@@ -29,7 +29,7 @@ require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
 
 if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
-	require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+	require_once(dirname(__FILE__) . '/../../pdo_mysql/tests/mysql_pdo_test.inc');
 	$suf = ' ENGINE=' . MySQLPDOTest::detect_transactional_mysql_engine($db);
 } else {
 	$suf = '';

--- a/ext/pdo/tests/pdo_018.phpt
+++ b/ext/pdo/tests/pdo_018.phpt
@@ -71,7 +71,13 @@ $db->exec('CREATE TABLE classtypes(id int NOT NULL PRIMARY KEY, name VARCHAR(20)
 $db->exec('INSERT INTO classtypes VALUES(0, \'stdClass\')');
 $db->exec('INSERT INTO classtypes VALUES(1, \'TestBase\')');
 $db->exec('INSERT INTO classtypes VALUES(2, \'TestDerived\')');
-$db->exec('CREATE TABLE test(id int NOT NULL PRIMARY KEY, classtype int, val VARCHAR(255))');
+
+$nullable = '';
+if (!strncasecmp(getenv('PDOTEST_DSN'), 'dblib', strlen('dblib'))){
+  $nullable = 'NULL';
+}
+
+$db->exec('CREATE TABLE test(id int NOT NULL PRIMARY KEY, classtype int ' . $nullable . ', val VARCHAR(255))');
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/ext/pdo/tests/pdo_018.phpt
+++ b/ext/pdo/tests/pdo_018.phpt
@@ -71,7 +71,7 @@ $db->exec('CREATE TABLE classtypes(id int NOT NULL PRIMARY KEY, name VARCHAR(20)
 $db->exec('INSERT INTO classtypes VALUES(0, \'stdClass\')');
 $db->exec('INSERT INTO classtypes VALUES(1, \'TestBase\')');
 $db->exec('INSERT INTO classtypes VALUES(2, \'TestDerived\')');
-$db->exec('CREATE TABLE test(id int NOT NULL PRIMARY KEY, classtype int NULL, val VARCHAR(255))');
+$db->exec('CREATE TABLE test(id int NOT NULL PRIMARY KEY, classtype int, val VARCHAR(255))');
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/ext/pdo/tests/pdo_018.phpt
+++ b/ext/pdo/tests/pdo_018.phpt
@@ -20,7 +20,7 @@ class TestBase implements Serializable
 	public    $BasePub = 'Public';
 	protected $BasePro = 'Protected';
 	private   $BasePri = 'Private';
-	
+
 	function serialize()
 	{
 		$serialized = array();
@@ -31,7 +31,7 @@ class TestBase implements Serializable
 		echo __METHOD__ . "() = '$serialized'\n";
 		return $serialized;
 	}
-	
+
 	function unserialize($serialized)
 	{
 		echo __METHOD__ . "($serialized)\n";
@@ -55,7 +55,7 @@ class TestDerived extends TestBase
 		echo __METHOD__ . "()\n";
 		return TestBase::serialize();
 	}
-	
+
 	function unserialize($serialized)
 	{
 		echo __METHOD__ . "()\n";
@@ -68,10 +68,10 @@ class TestLeaf extends TestDerived
 }
 
 $db->exec('CREATE TABLE classtypes(id int NOT NULL PRIMARY KEY, name VARCHAR(20) NOT NULL UNIQUE)');
-$db->exec('INSERT INTO classtypes VALUES(0, \'stdClass\')'); 
-$db->exec('INSERT INTO classtypes VALUES(1, \'TestBase\')'); 
-$db->exec('INSERT INTO classtypes VALUES(2, \'TestDerived\')'); 
-$db->exec('CREATE TABLE test(id int NOT NULL PRIMARY KEY, classtype int, val VARCHAR(255))');
+$db->exec('INSERT INTO classtypes VALUES(0, \'stdClass\')');
+$db->exec('INSERT INTO classtypes VALUES(1, \'TestBase\')');
+$db->exec('INSERT INTO classtypes VALUES(2, \'TestDerived\')');
+$db->exec('CREATE TABLE test(id int NOT NULL PRIMARY KEY, classtype int NULL, val VARCHAR(255))');
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
@@ -121,7 +121,7 @@ foreach($objs as $idx => $obj)
 	{
 		$val = '';
 	}
-	$stmt->execute();	
+	$stmt->execute();
 }
 
 unset($stmt);

--- a/ext/pdo/tests/pdo_024.phpt
+++ b/ext/pdo/tests/pdo_024.phpt
@@ -14,7 +14,7 @@ if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE_
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
 
-$db->exec('create table test (id int, name varchar(10))');
+$db->exec('create table test (id int, name varchar(10) NULL)');
 
 $stmt = $db->prepare('insert into test (id, name) values(0, :name)');
 $name = NULL;

--- a/ext/pdo/tests/pdo_024.phpt
+++ b/ext/pdo/tests/pdo_024.phpt
@@ -14,7 +14,12 @@ if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE_
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
 
-$db->exec('create table test (id int, name varchar(10) NULL)');
+$define_nullable = '';
+if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'dblib') {
+  $define_nullable = 'NULL';
+}
+
+$db->exec('create table test (id int, name varchar(10) ' . $define_nullable . ')');
 
 $stmt = $db->prepare('insert into test (id, name) values(0, :name)');
 $name = NULL;

--- a/ext/pdo_dblib/tests/bug_45876.phpt
+++ b/ext/pdo_dblib/tests/bug_45876.phpt
@@ -11,25 +11,26 @@ require dirname(__FILE__) . '/config.inc';
 
 $stmt = $db->prepare("select ic1.* from information_schema.columns ic1");
 $stmt->execute();
-var_dump($stmt->getColumnMeta(0));
+echo "native_type:\n";
+var_dump($stmt->getColumnMeta(0)["native_type"]);
+echo "name:\n";
+var_dump($stmt->getColumnMeta(0)["name"]);
+echo "len:\n";
+var_dump($stmt->getColumnMeta(0)["len"]);
+echo "precision:\n";
+var_dump($stmt->getColumnMeta(0)["precision"]);
+echo "pdo_type:\n";
+var_dump($stmt->getColumnMeta(0)["pdo_type"]);
 $stmt = null;
 ?>
---EXPECT--
-array(8) {
-  ["max_length"]=>
-  int(255)
-  ["precision"]=>
-  int(0)
-  ["scale"]=>
-  int(0)
-  ["column_source"]=>
-  string(13) "TABLE_CATALOG"
-  ["native_type"]=>
-  string(4) "char"
-  ["name"]=>
-  string(13) "TABLE_CATALOG"
-  ["len"]=>
-  int(255)
-  ["pdo_type"]=>
-  int(2)
-}
+--EXPECTF--
+native_type:
+string(%d) "%s"
+name:
+string(%d) "%s"
+len:
+int(%d)
+precision:
+int(%d)
+pdo_type:
+int(%d)

--- a/ext/pdo_mysql/tests/pdo_mysql_exec.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_exec.phpt
@@ -75,7 +75,7 @@ MySQLPDOTest::skip();
 			exec_and_count(19, $db, 'CREATE PROCEDURE p(OUT ver_param VARCHAR(255)) BEGIN SELECT VERSION() INTO ver_param; END;', 0);
 			// we got this far without problems. If there's an issue from now on, its a failure
 			$ignore_exception = false;
-			exec_and_count(20, $db, 'CALL p(@version)', 0);
+			exec_and_count(20, $db, 'CALL p(@version)', 1);
 			$stmt = $db->query('SELECT @version AS p_version');
 			$tmp = $stmt->fetchAll(PDO::FETCH_ASSOC);
 			if (count($tmp) > 1 || !isset($tmp[0]['p_version'])) {


### PR DESCRIPTION
Wanted to do some PDO work on the core PDO classes and I've setup a system with multiple databases to test all PDO implementations. During this work I found that many test classes didn't pass due to different requirements from the different databases. 

I've gone though and made small changes to the test cases and also added a quoter function for ODBC.

I want this pull request accepted mainly because future development is much easier when the test cases pass. So when you implement things you can run the test cases and see that you've not broken any old dependencies.

Tested with:
- DSN sqlite - sqlite memory database
- DSN mysql - mysql database locally
- DSN pgsql - postgresql database locally
- DSN odbc - db2 database locally
- DSN firebird - firebird database locally
- DSN oci - oracle database locally
- DSN dblib - mssql database Amazon EC2
