### PR TITLE
Replace `Z_LVAL_PP` with `Z_LVAL_P`

### DIFF
--- a/ext/odbc/birdstep.c
+++ b/ext/odbc/birdstep.c
@@ -441,13 +441,13 @@ PHP_FUNCTION(birdstep_fetch)
 	stat = SQLExtendedFetch(res->hstmt,SQL_FETCH_NEXT,1,&row,RowStat);
 	if ( stat == SQL_NO_DATA_FOUND ) {
 		SQLFreeStmt(res->hstmt,SQL_DROP);
-		birdstep_del_result(list,Z_LVAL_PP(ind));
+		birdstep_del_result(list,Z_LVAL_P(*ind));
 		RETURN_FALSE;
 	}
 	if ( stat != SQL_SUCCESS && stat != SQL_SUCCESS_WITH_INFO ) {
 		php_error_docref(NULL, E_WARNING, "Birdstep: SQLFetch return error");
 		SQLFreeStmt(res->hstmt,SQL_DROP);
-		birdstep_del_result(list,Z_LVAL_PP(ind));
+		birdstep_del_result(list,Z_LVAL_P(*ind));
 		RETURN_FALSE;
 	}
 	res->fetched = 1;
@@ -479,7 +479,7 @@ PHP_FUNCTION(birdstep_result)
 		field = Z_STRVAL_PP(col);
 	} else {
 		convert_to_long_ex(col);
-		indx = Z_LVAL_PP(col);
+		indx = Z_LVAL_P(*col);
 	}
 	if ( field ) {
 		for ( i = 0; i < res->numcols; i++ ) {
@@ -502,13 +502,13 @@ PHP_FUNCTION(birdstep_result)
 		stat = SQLExtendedFetch(res->hstmt,SQL_FETCH_NEXT,1,&row,RowStat);
 		if ( stat == SQL_NO_DATA_FOUND ) {
 			SQLFreeStmt(res->hstmt,SQL_DROP);
-			birdstep_del_result(list,Z_LVAL_PP(ind));
+			birdstep_del_result(list,Z_LVAL_P(*ind));
 			RETURN_FALSE;
 		}
 		if ( stat != SQL_SUCCESS && stat != SQL_SUCCESS_WITH_INFO ) {
 			php_error_docref(NULL, E_WARNING, "Birdstep: SQLFetch return error");
 			SQLFreeStmt(res->hstmt,SQL_DROP);
-			birdstep_del_result(list,Z_LVAL_PP(ind));
+			birdstep_del_result(list,Z_LVAL_P(*ind));
 			RETURN_FALSE;
 		}
 		res->fetched = 1;
@@ -527,13 +527,13 @@ l1:
 				res->values[indx].value,4095,&res->values[indx].vallen);
 			if ( stat == SQL_NO_DATA_FOUND ) {
 				SQLFreeStmt(res->hstmt,SQL_DROP);
-				birdstep_del_result(list,Z_LVAL_PP(ind));
+				birdstep_del_result(list,Z_LVAL_P(*ind));
 				RETURN_FALSE;
 			}
 			if ( stat != SQL_SUCCESS && stat != SQL_SUCCESS_WITH_INFO ) {
 				php_error_docref(NULL, E_WARNING, "Birdstep: SQLGetData return error");
 				SQLFreeStmt(res->hstmt,SQL_DROP);
-				birdstep_del_result(list,Z_LVAL_PP(ind));
+				birdstep_del_result(list,Z_LVAL_P(*ind));
 				RETURN_FALSE;
 			}
 			if ( res->values[indx].valtype == SQL_LONGVARCHAR ) {

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -305,7 +305,7 @@ PHP_FUNCTION(readline_info)
 			oldval = rl_erase_empty_line;
 			if (value) {
 				convert_to_long_ex(value);
-				rl_erase_empty_line = Z_LVAL_PP(value);
+				rl_erase_empty_line = Z_LVAL_P(*value);
 			}
 			RETVAL_LONG(oldval);
 #endif


### PR DESCRIPTION
`Z_LVAL_PP` is removed by f4cfaf36e23ca47da3e352e1c60909104c059647.
In the commit, `Z_LVAL_P` was moved to `Zend/zend_types.h` but
`Z_LVAL_PP` was only deleted from `Zend/zend_operators.h` .