### PR TITLE
Drop support for EOL'd PHP versions from run-tests

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -4,7 +4,7 @@
    +----------------------------------------------------------------------+
    | PHP Version 7                                                        |
    +----------------------------------------------------------------------+
-   | Copyright (c) 1997-2010 The PHP Group                                |
+   | Copyright (c) 1997-2015 The PHP Group                                |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |
@@ -59,27 +59,6 @@ NO_PROC_OPEN_ERROR;
 exit;
 }
 
-// Version constants only available as of 5.2.8
-if (!defined("PHP_VERSION_ID")) {
-	list($major, $minor, $bug) = explode(".", phpversion(), 3);
-	$bug = (int)$bug; // Many distros make up their own versions
-	if ($bug < 10) {
-		$bug = "0$bug";
-	}
-
-	define("PHP_VERSION_ID", "{$major}0{$minor}$bug");
-	define("PHP_MAJOR_VERSION", $major);
-}
-
-// __DIR__ is available from 5.3.0
-if (PHP_VERSION_ID < 50300) {
-	define('__DIR__', realpath(dirname(__FILE__)));
-	// FILE_BINARY is available from 5.2.7
-	if (PHP_VERSION_ID < 50207) {
-		define('FILE_BINARY', 0);
-	}
-}
-
 // If timezone is not set, use UTC.
 if (ini_get('date.timezone') == '') {
 	date_default_timezone_set('UTC');
@@ -113,22 +92,6 @@ while(@ob_end_clean());
 if (ob_get_level()) echo "Not all buffers were deleted.\n";
 
 error_reporting(E_ALL);
-if (PHP_MAJOR_VERSION < 6) {
-	if (ini_get('safe_mode')) {
-		echo <<< SAFE_MODE_WARNING
-
-+-----------------------------------------------------------+
-|                       ! WARNING !                         |
-| You are running the test-suite with "safe_mode" ENABLED ! |
-|                                                           |
-| Chances are high that no test will work at all,           |
-| depending on how you configured "safe_mode" !             |
-+-----------------------------------------------------------+
-
-
-SAFE_MODE_WARNING;
-	}
-}
 
 $environment = isset($_ENV) ? $_ENV : array();
 if ((substr(PHP_OS, 0, 3) == "WIN") && empty($environment["SystemRoot"])) {
@@ -240,7 +203,6 @@ $exts_to_test = array();
 $ini_overwrites = array(
 		'output_handler=',
 		'open_basedir=',
-		'safe_mode=0',
 		'disable_functions=',
 		'output_buffering=Off',
 		'error_reporting=' . (E_ALL | E_STRICT),

--- a/server-tests.php
+++ b/server-tests.php
@@ -3,7 +3,7 @@
    +----------------------------------------------------------------------+
    | PHP Version 7                                                        |
    +----------------------------------------------------------------------+
-   | Copyright (c) 1997-2010 The PHP Group                                |
+   | Copyright (c) 1997-2015 The PHP Group                                |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |
@@ -47,14 +47,6 @@ define('PCRE_MISSING_ERROR',
 | enabled. To enable this extension either compile your PHP |
 | with --with-pcre-regex or if you have compiled pcre as a  |
 | shared module load it via php.ini.                        |
-+-----------------------------------------------------------+');
-define('SAFE_MODE_WARNING',
-'+-----------------------------------------------------------+
-|                       ! WARNING !                         |
-| You are running the test-suite with "safe_mode" ENABLED ! |
-|                                                           |
-| Chances are high that no test will work at all,           |
-| depending on how you configured "safe_mode" !             |
 +-----------------------------------------------------------+');
 define('TMP_MISSING',
 '+-----------------------------------------------------------+
@@ -456,7 +448,6 @@ class testHarness {
 			'output_handler'=>'',
 			'zlib.output_compression'=>'Off',
 			'open_basedir'=>'',
-			'safe_mode'=>'0',
 			'disable_functions'=>'',
 			'output_buffering'=>'Off',
 			'error_reporting'=>'4095',
@@ -736,7 +727,7 @@ class testHarness {
 	}
 
 	function checkRequirements() {
-		if (version_compare(phpversion(), "5.0") < 0) {
+		if (version_compare(phpversion(), "5.4") < 0) {
 			$this->writemsg(REQ_PHP_VERSION);
 			exit;
 		}
@@ -752,9 +743,6 @@ class testHarness {
 		if (!extension_loaded("pcre")) {
 			$this->writemsg(PCRE_MISSING_ERROR);
 			exit;
-		}
-		if (ini_get('safe_mode')) {
-			$this->writemsg(SAFE_MODE_WARNING);
 		}
 	}
 	


### PR DESCRIPTION
This PR drops unneeded checks from `run-tests.php` (and `server-tests.php`)