### PR TITLE
Count collisions during HT insertion operations

### DIFF
--- a/Zend/tests/bug70644.phpt
+++ b/Zend/tests/bug70644.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #70644: trivial hash complexity DoS attack (plain array)
+--FILE--
+<?php
+
+$a = [];
+$s = 1 << 16;
+for ($i = 0; count($a) < $s; $i += $s) {
+    $a[$i] = 0;
+} 
+
+?>
+--EXPECTF--
+Fatal error: Too many collisions in hashtable in %s on line %d

--- a/Zend/tests/bug70644_2.phpt
+++ b/Zend/tests/bug70644_2.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #70644: trivial hash complexity DoS attack (json_decode)
+--FILE--
+<?php
+
+$s = 1 << 16;
+$a = [];
+for ($i = 0, $j = 0; $i < $s; $i++, $j += $s) {
+    $a[] = '"' . $j  . '": null';
+}
+$j = '{' . implode(', ', $a) . '}';
+var_dump(json_decode($j, true));
+
+?>
+--EXPECTF--
+Fatal error: Too many collisions in hashtable in %s on line %d

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -34,6 +34,7 @@
 #define HASH_UPDATE_INDIRECT	(1<<2)
 #define HASH_ADD_NEW			(1<<3)
 #define HASH_ADD_NEXT			(1<<4)
+#define HASH_ADD_OR_RETURN      (1<<5)
 
 #define HASH_FLAG_PERSISTENT       (1<<0)
 #define HASH_FLAG_APPLY_PROTECTION (1<<1)
@@ -72,6 +73,7 @@ ZEND_API zval* ZEND_FASTCALL _zend_hash_update(HashTable *ht, zend_string *key,z
 ZEND_API zval* ZEND_FASTCALL _zend_hash_update_ind(HashTable *ht, zend_string *key,zval *pData ZEND_FILE_LINE_DC);
 ZEND_API zval* ZEND_FASTCALL _zend_hash_add(HashTable *ht, zend_string *key,zval *pData ZEND_FILE_LINE_DC);
 ZEND_API zval* ZEND_FASTCALL _zend_hash_add_new(HashTable *ht, zend_string *key,zval *pData ZEND_FILE_LINE_DC);
+ZEND_API zval* ZEND_FASTCALL _zend_hash_add_or_return(HashTable *ht, zend_string *key, zval *pData ZEND_FILE_LINE_DC);
 
 #define zend_hash_update(ht, key, pData) \
 		_zend_hash_update(ht, key, pData ZEND_FILE_LINE_CC)
@@ -81,6 +83,8 @@ ZEND_API zval* ZEND_FASTCALL _zend_hash_add_new(HashTable *ht, zend_string *key,
 		_zend_hash_add(ht, key, pData ZEND_FILE_LINE_CC)
 #define zend_hash_add_new(ht, key, pData) \
 		_zend_hash_add_new(ht, key, pData ZEND_FILE_LINE_CC)
+#define zend_hash_add_or_return(ht, key, pData) \
+		_zend_hash_add_or_return(ht, key, pData ZEND_FILE_LINE_CC)
 
 ZEND_API zval* ZEND_FASTCALL _zend_hash_str_add_or_update(HashTable *ht, const char *key, size_t len, zval *pData, uint32_t flag ZEND_FILE_LINE_DC);
 ZEND_API zval* ZEND_FASTCALL _zend_hash_str_update(HashTable *ht, const char *key, size_t len, zval *pData ZEND_FILE_LINE_DC);
@@ -100,6 +104,7 @@ ZEND_API zval* ZEND_FASTCALL _zend_hash_str_add_new(HashTable *ht, const char *k
 ZEND_API zval* ZEND_FASTCALL _zend_hash_index_add_or_update(HashTable *ht, zend_ulong h, zval *pData, uint32_t flag ZEND_FILE_LINE_DC);
 ZEND_API zval* ZEND_FASTCALL _zend_hash_index_add(HashTable *ht, zend_ulong h, zval *pData ZEND_FILE_LINE_DC);
 ZEND_API zval* ZEND_FASTCALL _zend_hash_index_add_new(HashTable *ht, zend_ulong h, zval *pData ZEND_FILE_LINE_DC);
+ZEND_API zval* ZEND_FASTCALL _zend_hash_index_add_or_return(HashTable *ht, zend_ulong h, zval *pData ZEND_FILE_LINE_DC);
 ZEND_API zval* ZEND_FASTCALL _zend_hash_index_update(HashTable *ht, zend_ulong h, zval *pData ZEND_FILE_LINE_DC);
 ZEND_API zval* ZEND_FASTCALL _zend_hash_next_index_insert(HashTable *ht, zval *pData ZEND_FILE_LINE_DC);
 ZEND_API zval* ZEND_FASTCALL _zend_hash_next_index_insert_new(HashTable *ht, zval *pData ZEND_FILE_LINE_DC);
@@ -108,6 +113,8 @@ ZEND_API zval* ZEND_FASTCALL _zend_hash_next_index_insert_new(HashTable *ht, zva
 		_zend_hash_index_add(ht, h, pData ZEND_FILE_LINE_CC)
 #define zend_hash_index_add_new(ht, h, pData) \
 		_zend_hash_index_add_new(ht, h, pData ZEND_FILE_LINE_CC)
+#define zend_hash_index_add_or_return(ht, h, pData) \
+		_zend_hash_index_add_or_return(ht, h, pData ZEND_FILE_LINE_CC)
 #define zend_hash_index_update(ht, h, pData) \
 		_zend_hash_index_update(ht, h, pData ZEND_FILE_LINE_CC)
 #define zend_hash_next_index_insert(ht, pData) \
@@ -150,7 +157,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_str_del_ind(HashTable *ht, const char *key,
 ZEND_API int ZEND_FASTCALL zend_hash_index_del(HashTable *ht, zend_ulong h);
 ZEND_API void ZEND_FASTCALL zend_hash_del_bucket(HashTable *ht, Bucket *p);
 
-/* Data retreival */
+/* Data retrieval */
 ZEND_API zval* ZEND_FASTCALL zend_hash_find(const HashTable *ht, zend_string *key);
 ZEND_API zval* ZEND_FASTCALL zend_hash_str_find(const HashTable *ht, const char *key, size_t len);
 ZEND_API zval* ZEND_FASTCALL zend_hash_index_find(const HashTable *ht, zend_ulong h);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1495,29 +1495,17 @@ ZEND_VM_HELPER_EX(zend_fetch_var_address_helper, CONST|TMPVAR|CV, UNUSED, int ty
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(execute_data, opline->extended_value & ZEND_FETCH_TYPE_MASK);
-	retval = zend_hash_find(target_symbol_table, name);
-	if (retval == NULL) {
-		switch (type) {
-			case BP_VAR_R:
-			case BP_VAR_UNSET:
-				zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-				/* break missing intentionally */
-			case BP_VAR_IS:
-				retval = &EG(uninitialized_zval);
-				break;
-			case BP_VAR_RW:
-				zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
-				break;
-			case BP_VAR_W:
-				retval = zend_hash_add_new(target_symbol_table, name, &EG(uninitialized_zval));
-				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+	if (type == BP_VAR_W) {
+		retval = zend_hash_add_or_return(target_symbol_table, name, &EG(uninitialized_zval));
+		if (Z_TYPE_P(retval) == IS_INDIRECT) {
+			retval = Z_INDIRECT_P(retval);
+			if (Z_TYPE_P(retval) == IS_UNDEF) {
+				ZVAL_NULL(retval);
+			}
 		}
-	/* GLOBAL or $$name variable may be an INDIRECT pointer to CV */
-	} else if (Z_TYPE_P(retval) == IS_INDIRECT) {
-		retval = Z_INDIRECT_P(retval);
-		if (Z_TYPE_P(retval) == IS_UNDEF) {
+	} else {
+		retval = zend_hash_find(target_symbol_table, name);
+		if (retval == NULL) {
 			switch (type) {
 				case BP_VAR_R:
 				case BP_VAR_UNSET:
@@ -1528,11 +1516,28 @@ ZEND_VM_HELPER_EX(zend_fetch_var_address_helper, CONST|TMPVAR|CV, UNUSED, int ty
 					break;
 				case BP_VAR_RW:
 					zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-					/* break missing intentionally */
-				case BP_VAR_W:
-					ZVAL_NULL(retval);
+					retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
 					break;
 				EMPTY_SWITCH_DEFAULT_CASE()
+			}
+		/* GLOBAL or $$name variable may be an INDIRECT pointer to CV */
+		} else if (Z_TYPE_P(retval) == IS_INDIRECT) {
+			retval = Z_INDIRECT_P(retval);
+			if (Z_TYPE_P(retval) == IS_UNDEF) {
+				switch (type) {
+					case BP_VAR_R:
+					case BP_VAR_UNSET:
+						zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
+						/* break missing intentionally */
+					case BP_VAR_IS:
+						retval = &EG(uninitialized_zval);
+						break;
+					case BP_VAR_RW:
+						zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
+						ZVAL_NULL(retval);
+						break;
+					EMPTY_SWITCH_DEFAULT_CASE()
+				}
 			}
 		}
 	}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -7167,29 +7167,17 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(execute_data, opline->extended_value & ZEND_FETCH_TYPE_MASK);
-	retval = zend_hash_find(target_symbol_table, name);
-	if (retval == NULL) {
-		switch (type) {
-			case BP_VAR_R:
-			case BP_VAR_UNSET:
-				zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-				/* break missing intentionally */
-			case BP_VAR_IS:
-				retval = &EG(uninitialized_zval);
-				break;
-			case BP_VAR_RW:
-				zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
-				break;
-			case BP_VAR_W:
-				retval = zend_hash_add_new(target_symbol_table, name, &EG(uninitialized_zval));
-				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+	if (type == BP_VAR_W) {
+		retval = zend_hash_add_or_return(target_symbol_table, name, &EG(uninitialized_zval));
+		if (Z_TYPE_P(retval) == IS_INDIRECT) {
+			retval = Z_INDIRECT_P(retval);
+			if (Z_TYPE_P(retval) == IS_UNDEF) {
+				ZVAL_NULL(retval);
+			}
 		}
-	/* GLOBAL or $$name variable may be an INDIRECT pointer to CV */
-	} else if (Z_TYPE_P(retval) == IS_INDIRECT) {
-		retval = Z_INDIRECT_P(retval);
-		if (Z_TYPE_P(retval) == IS_UNDEF) {
+	} else {
+		retval = zend_hash_find(target_symbol_table, name);
+		if (retval == NULL) {
 			switch (type) {
 				case BP_VAR_R:
 				case BP_VAR_UNSET:
@@ -7200,11 +7188,28 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 					break;
 				case BP_VAR_RW:
 					zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-					/* break missing intentionally */
-				case BP_VAR_W:
-					ZVAL_NULL(retval);
+					retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
 					break;
 				EMPTY_SWITCH_DEFAULT_CASE()
+			}
+		/* GLOBAL or $$name variable may be an INDIRECT pointer to CV */
+		} else if (Z_TYPE_P(retval) == IS_INDIRECT) {
+			retval = Z_INDIRECT_P(retval);
+			if (Z_TYPE_P(retval) == IS_UNDEF) {
+				switch (type) {
+					case BP_VAR_R:
+					case BP_VAR_UNSET:
+						zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
+						/* break missing intentionally */
+					case BP_VAR_IS:
+						retval = &EG(uninitialized_zval);
+						break;
+					case BP_VAR_RW:
+						zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
+						ZVAL_NULL(retval);
+						break;
+					EMPTY_SWITCH_DEFAULT_CASE()
+				}
 			}
 		}
 	}
@@ -34518,29 +34523,17 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(execute_data, opline->extended_value & ZEND_FETCH_TYPE_MASK);
-	retval = zend_hash_find(target_symbol_table, name);
-	if (retval == NULL) {
-		switch (type) {
-			case BP_VAR_R:
-			case BP_VAR_UNSET:
-				zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-				/* break missing intentionally */
-			case BP_VAR_IS:
-				retval = &EG(uninitialized_zval);
-				break;
-			case BP_VAR_RW:
-				zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
-				break;
-			case BP_VAR_W:
-				retval = zend_hash_add_new(target_symbol_table, name, &EG(uninitialized_zval));
-				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+	if (type == BP_VAR_W) {
+		retval = zend_hash_add_or_return(target_symbol_table, name, &EG(uninitialized_zval));
+		if (Z_TYPE_P(retval) == IS_INDIRECT) {
+			retval = Z_INDIRECT_P(retval);
+			if (Z_TYPE_P(retval) == IS_UNDEF) {
+				ZVAL_NULL(retval);
+			}
 		}
-	/* GLOBAL or $$name variable may be an INDIRECT pointer to CV */
-	} else if (Z_TYPE_P(retval) == IS_INDIRECT) {
-		retval = Z_INDIRECT_P(retval);
-		if (Z_TYPE_P(retval) == IS_UNDEF) {
+	} else {
+		retval = zend_hash_find(target_symbol_table, name);
+		if (retval == NULL) {
 			switch (type) {
 				case BP_VAR_R:
 				case BP_VAR_UNSET:
@@ -34551,11 +34544,28 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 					break;
 				case BP_VAR_RW:
 					zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-					/* break missing intentionally */
-				case BP_VAR_W:
-					ZVAL_NULL(retval);
+					retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
 					break;
 				EMPTY_SWITCH_DEFAULT_CASE()
+			}
+		/* GLOBAL or $$name variable may be an INDIRECT pointer to CV */
+		} else if (Z_TYPE_P(retval) == IS_INDIRECT) {
+			retval = Z_INDIRECT_P(retval);
+			if (Z_TYPE_P(retval) == IS_UNDEF) {
+				switch (type) {
+					case BP_VAR_R:
+					case BP_VAR_UNSET:
+						zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
+						/* break missing intentionally */
+					case BP_VAR_IS:
+						retval = &EG(uninitialized_zval);
+						break;
+					case BP_VAR_RW:
+						zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
+						ZVAL_NULL(retval);
+						break;
+					EMPTY_SWITCH_DEFAULT_CASE()
+				}
 			}
 		}
 	}
@@ -43119,29 +43129,17 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(execute_data, opline->extended_value & ZEND_FETCH_TYPE_MASK);
-	retval = zend_hash_find(target_symbol_table, name);
-	if (retval == NULL) {
-		switch (type) {
-			case BP_VAR_R:
-			case BP_VAR_UNSET:
-				zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-				/* break missing intentionally */
-			case BP_VAR_IS:
-				retval = &EG(uninitialized_zval);
-				break;
-			case BP_VAR_RW:
-				zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
-				break;
-			case BP_VAR_W:
-				retval = zend_hash_add_new(target_symbol_table, name, &EG(uninitialized_zval));
-				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+	if (type == BP_VAR_W) {
+		retval = zend_hash_add_or_return(target_symbol_table, name, &EG(uninitialized_zval));
+		if (Z_TYPE_P(retval) == IS_INDIRECT) {
+			retval = Z_INDIRECT_P(retval);
+			if (Z_TYPE_P(retval) == IS_UNDEF) {
+				ZVAL_NULL(retval);
+			}
 		}
-	/* GLOBAL or $$name variable may be an INDIRECT pointer to CV */
-	} else if (Z_TYPE_P(retval) == IS_INDIRECT) {
-		retval = Z_INDIRECT_P(retval);
-		if (Z_TYPE_P(retval) == IS_UNDEF) {
+	} else {
+		retval = zend_hash_find(target_symbol_table, name);
+		if (retval == NULL) {
 			switch (type) {
 				case BP_VAR_R:
 				case BP_VAR_UNSET:
@@ -43152,11 +43150,28 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 					break;
 				case BP_VAR_RW:
 					zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
-					/* break missing intentionally */
-				case BP_VAR_W:
-					ZVAL_NULL(retval);
+					retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
 					break;
 				EMPTY_SWITCH_DEFAULT_CASE()
+			}
+		/* GLOBAL or $$name variable may be an INDIRECT pointer to CV */
+		} else if (Z_TYPE_P(retval) == IS_INDIRECT) {
+			retval = Z_INDIRECT_P(retval);
+			if (Z_TYPE_P(retval) == IS_UNDEF) {
+				switch (type) {
+					case BP_VAR_R:
+					case BP_VAR_UNSET:
+						zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
+						/* break missing intentionally */
+					case BP_VAR_IS:
+						retval = &EG(uninitialized_zval);
+						break;
+					case BP_VAR_RW:
+						zend_error(E_NOTICE,"Undefined variable: %s", ZSTR_VAL(name));
+						ZVAL_NULL(retval);
+						break;
+					EMPTY_SWITCH_DEFAULT_CASE()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
For HashDos protection. The limit of 1000 is arbitrary.
