### PR TITLE
calling getenv() without arguments should return the environment variables as an array

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4014,7 +4014,7 @@ PHP_FUNCTION(long2ip)
    if no varname is present  */
 PHP_FUNCTION(getenv)
 {
-	char *ptr, *str;
+	char *ptr, *str = NULL;
 	size_t str_len;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s", &str, &str_len) == FAILURE) {

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -23,6 +23,7 @@
 #include "php_streams.h"
 #include "php_main.h"
 #include "php_globals.h"
+#include "php_variables.h"
 #include "php_ini.h"
 #include "php_standard.h"
 #include "php_math.h"
@@ -631,7 +632,7 @@ ZEND_BEGIN_ARG_INFO(arginfo_long2ip, 0)
 	ZEND_ARG_INFO(0, proper_address)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_getenv, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_getenv, 0, 0, 0)
 	ZEND_ARG_INFO(0, varname)
 ZEND_END_ARG_INFO()
 
@@ -4008,15 +4009,22 @@ PHP_FUNCTION(long2ip)
  * System Functions *
  ********************/
 
-/* {{{ proto string getenv(string varname)
-   Get the value of an environment variable */
+/* {{{ proto string getenv([string varname])
+   Get the value of an environment variable or every available environment variable 
+   if no varname is present  */
 PHP_FUNCTION(getenv)
 {
 	char *ptr, *str;
 	size_t str_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &str, &str_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s", &str, &str_len) == FAILURE) {
 		RETURN_FALSE;
+	}
+
+	if (!str) {
+		array_init(return_value);
+		php_import_environment_variables(return_value);
+		return;
 	}
 
 	/* SAPI method returns an emalloc()'d string */

--- a/ext/standard/tests/general_functions/getenv.phpt
+++ b/ext/standard/tests/general_functions/getenv.phpt
@@ -1,0 +1,16 @@
+--TEST--
+getenv() basic tests
+--ENV--
+FOO=bar
+--FILE--
+<?php
+
+var_dump(getenv("FOO"));
+var_dump(getenv()["FOO"]);
+
+echo "Done\n";
+?>
+--EXPECTF--
+string(3) "bar"
+string(3) "bar"
+Done


### PR DESCRIPTION
see https://bugs.php.net/bug.php?id=69359 and #1214 for the past discussion which lead me to the current PR.