### PR TITLE
Fixes #68948 related to a BC break introduced by #68532 fix.

### DIFF
--- a/ext/standard/tests/streams/bug68948.phpt
+++ b/ext/standard/tests/streams/bug68948.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bug #68948: feof() on temporary streams broken
+--FILE--
+<?php
+
+$testString = '0123456789';
+
+$stream = fopen("php://memory", "r+");
+fwrite($stream, $testString);
+rewind($stream);
+
+var_dump(fread($stream, 10));
+var_dump(ftell($stream));
+var_dump(feof($stream));
+
+rewind($stream);
+
+var_dump(fread($stream, 11));
+var_dump(ftell($stream));
+var_dump(feof($stream));
+
+?>
+--EXPECT--
+string(10) "0123456789"
+int(10)
+bool(false)
+string(10) "0123456789"
+int(10)
+bool(true)
+

--- a/ext/standard/tests/streams/stream_set_chunk_size.phpt
+++ b/ext/standard/tests/streams/stream_set_chunk_size.phpt
@@ -39,7 +39,7 @@ var_dump(fwrite($f, str_repeat('b', 3)));
 
 echo "should return previous chunk size (1)\n";
 var_dump(stream_set_chunk_size($f, 100));
-echo "should elicit one read of size 100 (chunk size)\n";
+echo "should elicit 3 reads of size 100 (chunk size)\n";
 var_dump(strlen(fread($f, 250)));
 echo "should elicit one read of size 100 (chunk size)\n";
 var_dump(strlen(fread($f, 50)));
@@ -67,13 +67,15 @@ write with size: 1
 int(3)
 should return previous chunk size (1)
 int(1)
-should elicit one read of size 100 (chunk size)
+should elicit 3 reads of size 100 (chunk size)
 read with size: 100
-int(100)
-should elicit one read of size 100 (chunk size)
 read with size: 100
+read with size: 100
+int(250)
+should elicit one read of size 100 (chunk size)
 int(50)
 should elicit no read because there is sufficient cached data
+read with size: 100
 int(50)
 should elicit 2 writes of size 100 and one of size 50
 write with size: 100

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -741,7 +741,7 @@ PHPAPI size_t _php_stream_read(php_stream *stream, char *buf, size_t size)
 		}
 
 		/* just break anyway, to avoid greedy read */
-		if (stream->wrapper != &php_plain_files_wrapper) {
+		if (!stream->wrapper || stream->wrapper->is_url) {
 			break;
 		}
 	}


### PR DESCRIPTION
This PR is an alternative to https://github.com/php/php-src/pull/1153 which is a attempt to address #68948 and #68481 without breaking #68532.

Right from start `feof()` on memory based streams didn't work the same way as on file based streams (although it works as expected on HHVM).

The [following PR](https://github.com/php/php-src/pull/936) changed the memory based streams behavior to solve an eof realted issue. However despite the BC Break, the new introduced behavior was still not consistent with file based streams behavior. And unfortunately there's no way to do so.

Indeed if the current behavior of file based streams is correct, the issue comes from the extrapolation of the eof state from [read()](https://github.com/php/php-src/blob/9d82a7dc9844281b17a4e20c744dd0271c657e51/main/streams/plain_wrapper.c#L398). Indeed eof can be safely set to `1` only when `read()` returns `0`.

So to make it works, this logic requires an extra read which is satisfied by the [following condition](https://github.com/php/php-src/blob/7aa7627172c11979ec45c2db85f99182812ee59d/main/streams/streams.c#L689). Indeed if the number of bytes actually read < size, the loop is executed once more. `read()` will return `0`, eof will be set to `1` and [we are done](https://github.com/php/php-src/blob/7aa7627172c11979ec45c2db85f99182812ee59d/main/streams/streams.c#L739)

But it's not possible to make other streams to work the same way because of [this specific check](https://github.com/php/php-src/blob/7aa7627172c11979ec45c2db85f99182812ee59d/main/streams/streams.c#L743). However due to the current eof logic this `break` is at least necessary for blocking streams (indeed an extra read will hang the whole process).

So either [php_stdiop_read](https://github.com/php/php-src/blob/9d82a7dc9844281b17a4e20c744dd0271c657e51/main/streams/plain_wrapper.c#L362) can rely on `fread()` and the whole `_php_stream_read` && `_php_stream_fill_read_buffer` will need to be refactored according to `feof()` behavior.

Or we can switch to greedy reads for all non blocking streams like in the following PR to the make the stream API consistent.

PS:
I noticed that `stream->wrapper` was `null` for some socket based streams but I have no idea if this "trick" can work for all other blocking streams.
