### PR TITLE
Skip some shift tests with undefined behaviour for platforms different than x86

### DIFF
--- a/tests/lang/operators/bitwiseShiftLeft_basiclong_64bit.phpt
+++ b/tests/lang/operators/bitwiseShiftLeft_basiclong_64bit.phpt
@@ -3,6 +3,7 @@ Test << operator : 64bit long tests
 --SKIPIF--
 <?php
 if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
+if (strtolower(php_uname('m')) != 'x86_64') die("skip this test is for x86_64 platforms only");
 ?>
 --FILE--
 <?php

--- a/tests/lang/operators/bitwiseShiftLeft_variationStr_64bit.phpt
+++ b/tests/lang/operators/bitwiseShiftLeft_variationStr_64bit.phpt
@@ -3,6 +3,7 @@ Test << operator : various numbers as strings
 --SKIPIF--
 <?php
 if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
+if (strtolower(php_uname('m')) != 'x86_64') die("skip this test is for x86_64 platforms only");
 ?>
 --FILE--
 <?php

--- a/tests/lang/operators/bitwiseShiftRight_basiclong_64bit.phpt
+++ b/tests/lang/operators/bitwiseShiftRight_basiclong_64bit.phpt
@@ -3,6 +3,7 @@ Test >> operator : 64bit long tests
 --SKIPIF--
 <?php
 if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
+if (strtolower(php_uname('m')) != 'x86_64') die("skip this test is for x86_64 platforms only");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
The results for the following test files have undefined behaviour as stated by \[1\] (page 1185): "If the value of the right operand is negative or is greater than or equal to the width of the promoted left operand, the behavior is undefined".

    tests/lang/operators/bitwiseShiftLeft_basiclong_64bit.phpt
    tests/lang/operators/bitwiseShiftLeft_variationStr_64bit.phpt
    tests/lang/operators/bitwiseShiftRight_basiclong_64bit.phpt

The output expected by PHP is based on the implementation by x86, which takes into account only the 6 least-significant bits of the shift count \[2\] (page 4-340). In POWER, the behaviour is to shift the register by the number of bits specified by the shift count register \[3\] (page 99).

For example, when executed by PHP 5, the command

    echo 9223372036854775807 << -1;

will print `0` on POWER and `-9223372036854775808` on x86-64.

Use the following command to run these tests:

    ./run-tests.php \
    tests/lang/operators/bitwiseShiftLeft_basiclong_64bit.phpt \
    tests/lang/operators/bitwiseShiftLeft_variationStr_64bit.phpt \
    tests/lang/operators/bitwiseShiftRight_basiclong_64bit.phpt

An alternative to this PR would be the removal of the undefined parts of these tests.

[1] JONES, Derek M. The New C Standard http://www.coding-guidelines.com/cbook/cbook1_1.pdf 
[2] Intel® 64 and IA-32 Architectures Software Developer’s Manual Volume 2 (2A, 2B & 2C): Instruction Set Reference, A-Z http://www.intel.com.br/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
[3] Power ISA™ Version 2.07 < https://www.power.org/wp-content/uploads/2013/05/PowerISA_V2.07_PUBLIC.pdf>