### PR TITLE
CSS syntax highlighting

### DIFF
--- a/Zend/tests/bug35655.phpt
+++ b/Zend/tests/bug35655.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Bug #35655 (whitespace following end of heredoc is lost)
 --INI--
+highlight.use_css = no
 highlight.string  = #DD0000
 highlight.comment = #FF8000
 highlight.keyword = #007700

--- a/Zend/tests/bug36513.phpt
+++ b/Zend/tests/bug36513.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #36513 (comment will be outputed in last line)
+--INI--
+highlight.use_css = no
 --FILE--
 <?php 
 function test($s) {

--- a/Zend/tests/bug42767.phpt
+++ b/Zend/tests/bug42767.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Bug #42767 (highlight_string() truncates trailing comments)
 --INI--
+highlight.use_css = no
 highlight.string  = #DD0000
 highlight.comment = #FF8000
 highlight.keyword = #007700

--- a/Zend/tests/nowdoc_013.phpt
+++ b/Zend/tests/nowdoc_013.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Test whitespace following end of nowdoc
 --INI--
+highlight.use_css = no
 highlight.string  = #DD0000
 highlight.comment = #FF8000
 highlight.keyword = #007700

--- a/Zend/tests/nowdoc_014.phpt
+++ b/Zend/tests/nowdoc_014.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Highlighting empty nowdoc
 --INI--
+highlight.use_css = no
 highlight.string  = #DD0000
 highlight.comment = #FF8000
 highlight.keyword = #007700

--- a/Zend/zend_highlight.c
+++ b/Zend/zend_highlight.c
@@ -86,21 +86,37 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 {
 	zval token;
 	int token_type;
-	char *last_color = syntax_highlighter_ini->highlight_html;
-	char *next_color;
+	zend_syntax_highlight_class last_class = HL_HTML;
+	zend_syntax_highlight_class next_class;
+	char **highlight_colors = (char**)syntax_highlighter_ini;
+
+	if (syntax_highlighter_ini->use_css) {
+		zend_syntax_highlight_class i;
+		zend_printf("<style>");
+		for (i = 0; i < zend_syntax_highlight_class_len; i++) {
+			zend_printf(".%s {", zend_syntax_highlight_class_names[i]);
+			zend_printf("color: %s;", highlight_colors[i]);
+			zend_printf("}");
+		}
+		zend_printf("</style>\n");
+	}
 
 	zend_printf("<code>");
-	zend_printf("<span style=\"color: %s\">\n", last_color);
+	if (syntax_highlighter_ini->use_css) {
+		zend_printf("<span class=\"%s\">\n", zend_syntax_highlight_class_names[last_class]);
+	} else {
+		zend_printf("<span style=\"color: %s\">\n", highlight_colors[last_class]);
+	}
 	/* highlight stuff coming back from zendlex() */
 	ZVAL_UNDEF(&token);
 	while ((token_type=lex_scan(&token))) {
 		switch (token_type) {
 			case T_INLINE_HTML:
-				next_color = syntax_highlighter_ini->highlight_html;
+				next_class = HL_HTML;
 				break;
 			case T_COMMENT:
 			case T_DOC_COMMENT:
-				next_color = syntax_highlighter_ini->highlight_comment;
+				next_class = HL_COMMENT;
 				break;
 			case T_OPEN_TAG:
 			case T_OPEN_TAG_WITH_ECHO:
@@ -113,12 +129,12 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 			case T_FUNC_C:
 			case T_NS_C:
 			case T_CLASS_C:
-				next_color = syntax_highlighter_ini->highlight_default;
+				next_class = HL_DEFAULT;
 				break;
 			case '"':
 			case T_ENCAPSED_AND_WHITESPACE:
 			case T_CONSTANT_ENCAPSED_STRING:
-				next_color = syntax_highlighter_ini->highlight_string;
+				next_class = HL_STRING;
 				break;
 			case T_WHITESPACE:
 				zend_html_puts((char*)LANG_SCNG(yy_text), LANG_SCNG(yy_leng));  /* no color needed */
@@ -127,20 +143,24 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 				break;
 			default:
 				if (Z_TYPE(token) == IS_UNDEF) {
-					next_color = syntax_highlighter_ini->highlight_keyword;
+					next_class = HL_KEYWORD;
 				} else {
-					next_color = syntax_highlighter_ini->highlight_default;
+					next_class = HL_DEFAULT;
 				}
 				break;
 		}
 
-		if (last_color != next_color) {
-			if (last_color != syntax_highlighter_ini->highlight_html) {
+		if (last_class != next_class) {
+			if (last_class != HL_HTML) {
 				zend_printf("</span>");
 			}
-			last_color = next_color;
-			if (last_color != syntax_highlighter_ini->highlight_html) {
-				zend_printf("<span style=\"color: %s\">", last_color);
+			last_class = next_class;
+			if (last_class != HL_HTML) {
+				if (syntax_highlighter_ini->use_css) {
+					zend_printf("<span class=\"%s\">", zend_syntax_highlight_class_names[last_class]);
+				} else {
+					zend_printf("<span style=\"color: %s\">", highlight_colors[last_class]);
+				}
 			}
 		}
 
@@ -163,7 +183,7 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 		ZVAL_UNDEF(&token);
 	}
 
-	if (last_color != syntax_highlighter_ini->highlight_html) {
+	if (last_class != HL_HTML) {
 		zend_printf("</span>\n");
 	}
 	zend_printf("</span>\n");

--- a/Zend/zend_highlight.h
+++ b/Zend/zend_highlight.h
@@ -22,19 +22,44 @@
 #ifndef ZEND_HIGHLIGHT_H
 #define ZEND_HIGHLIGHT_H
 
-#define HL_COMMENT_COLOR     "#FF8000"    /* orange */
-#define HL_DEFAULT_COLOR     "#0000BB"    /* blue */
-#define HL_HTML_COLOR        "#000000"    /* black */
-#define HL_STRING_COLOR      "#DD0000"    /* red */
-#define HL_KEYWORD_COLOR     "#007700"    /* green */
+#define HL_COMMENT_COLOR	"#FF8000"	/* orange */
+#define HL_DEFAULT_COLOR	"#0000BB"	/* blue */
+#define HL_HTML_COLOR		"#000000"	/* black */
+#define HL_STRING_COLOR		"#DD0000"	/* red */
+#define HL_KEYWORD_COLOR	"#007700"	/* green */
 
+typedef enum _zend_syntax_highlight_class {
+	HL_COMMENT = 0,
+	HL_DEFAULT,
+	HL_HTML,
+	HL_STRING,
+	HL_KEYWORD,
+	zend_syntax_highlight_class_len
+} zend_syntax_highlight_class;
+
+static const char *zend_syntax_highlight_class_names[zend_syntax_highlight_class_len] = {
+	"comment",
+	"default",
+	"html",
+	"string",
+	"keyword"
+};
+
+static const char *zend_syntax_highlight_class_colors[zend_syntax_highlight_class_len] = {
+	HL_COMMENT_COLOR,
+	HL_DEFAULT_COLOR,
+	HL_HTML_COLOR,
+	HL_STRING_COLOR,
+	HL_KEYWORD_COLOR
+};
 
 typedef struct _zend_syntax_highlighter_ini {
-	char *highlight_html;
 	char *highlight_comment;
 	char *highlight_default;
+	char *highlight_html;
 	char *highlight_string;
 	char *highlight_keyword;
+	zend_bool use_css;
 } zend_syntax_highlighter_ini;
 
 

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -5107,6 +5107,7 @@ PHPAPI zend_bool append_user_shutdown_function(php_shutdown_function_entry shutd
 
 ZEND_API void php_get_highlight_struct(zend_syntax_highlighter_ini *syntax_highlighter_ini) /* {{{ */
 {
+	syntax_highlighter_ini->use_css           = INI_BOOL("highlight.use_css");
 	syntax_highlighter_ini->highlight_comment = INI_STR("highlight.comment");
 	syntax_highlighter_ini->highlight_default = INI_STR("highlight.default");
 	syntax_highlighter_ini->highlight_html    = INI_STR("highlight.html");

--- a/ext/standard/tests/general_functions/highlight_heredoc.phpt
+++ b/ext/standard/tests/general_functions/highlight_heredoc.phpt
@@ -1,6 +1,7 @@
 --TEST--
 highlight_string() handling of heredoc
 --INI--
+highlight.use_css=no
 highlight.html=#000000
 --FILE--
 <?php

--- a/ext/standard/tests/strings/highlight_file.phpt
+++ b/ext/standard/tests/strings/highlight_file.phpt
@@ -1,6 +1,7 @@
 --TEST--
 highlight_file() tests
 --INI--
+highlight.use_css=no
 highlight.string=#DD0000
 highlight.comment=#FF9900
 highlight.keyword=#007700

--- a/ext/standard/tests/strings/show_source_basic.phpt
+++ b/ext/standard/tests/strings/show_source_basic.phpt
@@ -3,6 +3,8 @@ Test function show_source() by calling it with its expected arguments, more test
 --CREDITS--
 Francesco Fullone ff@ideato.it
 #PHPTestFest Cesena Italia on 2009-06-20
+--INI--
+highlight.use_css = no
 --FILE--
 <?php
 echo "*** Test by calling method or function with its expected arguments ***\n";

--- a/ext/standard/tests/strings/show_source_variation1.phpt
+++ b/ext/standard/tests/strings/show_source_variation1.phpt
@@ -3,6 +3,8 @@ Test function show_source() by calling it with its expected arguments and php ou
 --CREDITS--
 Francesco Fullone ff@ideato.it
 #PHPTestFest Cesena Italia on 2009-06-20
+--INI--
+highlight.use_css = no
 --FILE--
 <?php
 echo "*** Test by calling method or function with its expected arguments and php output ***\n";

--- a/ext/standard/tests/strings/show_source_variation2.phpt
+++ b/ext/standard/tests/strings/show_source_variation2.phpt
@@ -3,6 +3,8 @@ Test function show_source() by calling it with its expected arguments and output
 --CREDITS--
 Francesco Fullone ff@ideato.it
 #PHPTestFest Cesena Italia on 2009-06-20
+--INI--
+highlight.use_css = no
 --FILE--
 <?php
 echo "*** Test by calling method or function with its expected arguments and output to variable ***\n";

--- a/main/main.c
+++ b/main/main.c
@@ -483,6 +483,7 @@ PHP_INI_MH(OnChangeBrowscap);
 /* {{{ PHP_INI
  */
 PHP_INI_BEGIN()
+	PHP_INI_ENTRY_EX("highlight.use_css",		"1",		PHP_INI_ALL,	NULL,			php_ini_color_displayer_cb)
 	PHP_INI_ENTRY_EX("highlight.comment",		HL_COMMENT_COLOR,	PHP_INI_ALL,	NULL,			php_ini_color_displayer_cb)
 	PHP_INI_ENTRY_EX("highlight.default",		HL_DEFAULT_COLOR,	PHP_INI_ALL,	NULL,			php_ini_color_displayer_cb)
 	PHP_INI_ENTRY_EX("highlight.html",			HL_HTML_COLOR,		PHP_INI_ALL,	NULL,			php_ini_color_displayer_cb)

--- a/sapi/cgi/tests/008.phpt
+++ b/sapi/cgi/tests/008.phpt
@@ -30,8 +30,8 @@ $o = new test;
 
 file_put_contents($filename, $code);
 
-var_dump(`"$php" -n -s "$filename"`);
-var_dump(`"$php" -n -s "unknown"`);
+var_dump(`"$php" -d highlight.use_css=0 -n -s "$filename"`);
+var_dump(`"$php" -d highlight.use_css=0 -n -s "unknown"`);
 
 @unlink($filename);
 

--- a/sapi/cli/tests/014.phpt
+++ b/sapi/cli/tests/014.phpt
@@ -27,8 +27,8 @@ $o = new test;
 
 file_put_contents($filename, $code);
 
-var_dump(`"$php" -n -s $filename`);
-var_dump(`"$php" -n -s unknown`);
+var_dump(`"$php" -d highlight.use_css=0 -n -s $filename`);
+var_dump(`"$php" -d highlight.use_css=0 -n -s unknown`);
 
 @unlink($filename);
 

--- a/tests/strings/004.phpt
+++ b/tests/strings/004.phpt
@@ -1,6 +1,7 @@
 --TEST--
 highlight_string() buffering
 --INI--
+highlight.use_css=no
 highlight.string=#DD0000
 highlight.comment=#FF9900
 highlight.keyword=#007700

--- a/tests/strings/bug26703.phpt
+++ b/tests/strings/bug26703.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Bug #26703 (Certain characters inside strings incorrectly treated as keywords)
 --INI--
+highlight.use_css=no
 highlight.string=#DD0000
 highlight.comment=#FF9900
 highlight.keyword=#007700


### PR DESCRIPTION
Would be cool for 7.1, no?

This adds an INI option to use CSS classes, rather than inline styles, in syntax highlighter output. I guess this is technically misnamed since it already uses CSS, just inline CSS, hmm.

This would break applications which mess with the output, but they could flip `use_css` to `0`.

Lacks tests for now.
