### PR TITLE
Test for eval() not throwing a catchable ParseError

### DIFF
--- a/Zend/tests/eval_catchable_parse_error.phpt
+++ b/Zend/tests/eval_catchable_parse_error.phpt
@@ -1,0 +1,14 @@
+--TEST--
+eval() throws catchable parse error
+--FILE--
+<?php
+
+try {
+    eval("substr('foo', 1");
+} catch (ParseError $ex) {
+    var_dump(1);
+}
+
+?>
+--EXPECT--
+int(1)


### PR DESCRIPTION
The docs say that `eval()` should throw a catchable `ParseError` in PHP 7:

> __ParseError__ is thrown when an error occurs while parsing PHP code, such as when eval() is called.

http://php.net/manual/en/class.parseerror.php

But this is not the case. The following code crashes with a parse error:

```php
try {
    eval("substr('foo', 1");
} catch (ParseError $ex) {
}

echo "everything is fine";
```