### PR TITLE
Issue #69442: Implemented fix for incorrect filedescriptor closing

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -854,6 +854,12 @@ PHP_FUNCTION(proc_open)
 		}
 #endif
 
+#if PHP_CAN_DO_PTS
+		if (dev_ptmx >= 0) {
+			close(dev_ptmx);
+			close(slave_pty);
+		}
+#endif
 		/* close those descriptors that we just opened for the parent stuff,
 		 * dup new descriptors into required descriptors and close the original
 		 * cruft */
@@ -868,13 +874,6 @@ PHP_FUNCTION(proc_open)
 			if (descriptors[i].childend != descriptors[i].index)
 				close(descriptors[i].childend);
 		}
-
-#if PHP_CAN_DO_PTS
-		if (dev_ptmx >= 0) {
-			close(dev_ptmx);
-			close(slave_pty);
-		}
-#endif
 
 		if (cwd) {
 			php_ignore_value(chdir(cwd));

--- a/ext/standard/tests/file/bug69442.phpt
+++ b/ext/standard/tests/file/bug69442.phpt
@@ -1,0 +1,46 @@
+--TEST--
+proc_open with PTY closes incorrect file descriptor
+--SKIPIF--
+<?php
+
+$code = <<< 'EOC'
+    <?php
+    $descriptors = array(array("pty"), array("pty"), array("pty"), array("pipe", "w"));
+    $pipes = array();
+    $process = proc_open('echo "foo";', $descriptors, $pipes);
+EOC;
+
+    $tmpFile = tempnam(sys_get_temp_dir(), "bug69442");
+    file_put_contents($tmpFile, $code);
+
+    exec($_SERVER['TEST_PHP_EXECUTABLE']." ".$tmpFile." 2>&1", $output);
+    $output = join("\n", $output);
+    unlink($tmpFile);
+
+    if (strstr($output, "pty pseudo terminal not supported on this system") !== false) {
+        die("skip PTY pseudo terminals are not supported");
+    }
+--FILE--
+<?php
+$cmd = '(echo "foo" ; exit 42;) 3>/dev/null; code=$?; echo $code >&3; exit $code';
+$descriptors = array(array("pty"), array("pty"), array("pty"), array("pipe", "w"));
+$pipes = array();
+
+$process = proc_open($cmd, $descriptors, $pipes);
+
+foreach ($pipes as $type => $pipe) {
+    $data = fread($pipe, 999);
+    echo 'type ' . $type . ' ';
+    var_dump($data);
+    fclose($pipe);
+}
+proc_close($process);
+--EXPECT--
+type 0 string(5) "foo
+"
+type 1 string(0) ""
+type 2 string(0) ""
+type 3 string(3) "42
+"
+
+


### PR DESCRIPTION
This PR fixes issue 69442, which was discovered through some functionality within the Symfony2 framework: https://github.com/symfony/symfony/issues/12643

Basically, it only manifests itself when PTS is enabled. This isn't the case in a standard PHP distribution, however, Ubuntu/Debian SRPM adds a patch to enabled this functionality (note that the patch itself does not include the functionality, it only ENABLES the already present functionality).

I've added a PHPT test, as created initially by @ewgRa (some additional effort has been taken to skip the test if PTY is not supported, i'm sure there are better ways to achieve the same goal in a less fragile way).
