### PR TITLE
Fix #70769: Fix boolean conversion warnings

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -445,7 +445,6 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 	}
 
 	/* Constants */
-	if (&ce->constants_table) {
 		string_printf(str, "\n");
 		count = zend_hash_num_elements(&ce->constants_table);
 		string_printf(str, "%s  - Constants [%d] {\n", indent, count);
@@ -459,10 +458,8 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			} ZEND_HASH_FOREACH_END();
 		}
 		string_printf(str, "%s  }\n", indent);
-	}
 
 	/* Static properties */
-	if (&ce->properties_info) {
 		/* counting static properties */
 		count = zend_hash_num_elements(&ce->properties_info);
 		if (count > 0) {
@@ -489,10 +486,8 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			} ZEND_HASH_FOREACH_END();
 		}
 		string_printf(str, "%s  }\n", indent);
-	}
 
 	/* Static methods */
-	if (&ce->function_table) {
 		/* counting static methods */
 		count = zend_hash_num_elements(&ce->function_table);
 		if (count > 0) {
@@ -524,10 +519,8 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			string_printf(str, "\n");
 		}
 		string_printf(str, "%s  }\n", indent);
-	}
 
 	/* Default/Implicit properties */
-	if (&ce->properties_info) {
 		count = zend_hash_num_elements(&ce->properties_info) - count_static_props - count_shadow_props;
 		string_printf(str, "\n%s  - Properties [%d] {\n", indent, count);
 		if (count > 0) {
@@ -540,7 +533,6 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			} ZEND_HASH_FOREACH_END();
 		}
 		string_printf(str, "%s  }\n", indent);
-	}
 
 	if (obj && Z_TYPE_P(obj) == IS_OBJECT && Z_OBJ_HT_P(obj)->get_properties) {
 		string       dyn;
@@ -568,7 +560,6 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 	}
 
 	/* Non static methods */
-	if (&ce->function_table) {
 		count = zend_hash_num_elements(&ce->function_table) - count_static_funcs;
 		if (count > 0) {
 			zend_function *mptr;
@@ -617,7 +608,6 @@ static void _class_string(string *str, zend_class_entry *ce, zval *obj, char *in
 			string_printf(str, "\n%s  - Methods [0] {\n", indent);
 		}
 		string_printf(str, "%s  }\n", indent);
-	}
 
 	string_printf(str, "%s}\n", indent);
 	string_free(&sub_indent);


### PR DESCRIPTION
Summary:

There are conditions like:

      if (&ce->function_table) {
      }

The compiler complains and raises some warnings about boolean
conversion:

    warning: address of 'ce->constants_table' will always evaluate to
    'true' [-Wpointer-bool-conversion]

However ce->function_table is a HashTable member, referencing HashTable will always evaluate to true. This is confusing.

Since the address of 'HashTable' will always evaluate to true. the
conditions should be removed to avoid confusion. The scope is kept for local variables.

Platform:

    OS X 10.11

Compiler:

    Apple LLVM version 7.0.0 (clang-700.0.72)
    Target: x86_64-apple-darwin15.0.0
    Thread model: posix