### PR TITLE
Fix Compiler Warning: Call fabs() instead of abs() since floor() returns double

### DIFF
--- a/ext/date/lib/interval.c
+++ b/ext/date/lib/interval.c
@@ -70,7 +70,7 @@ timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two)
 		rt->i += dst_m_corr;
 	}
 
-	rt->days = abs(floor((one->sse - two->sse - (dst_h_corr * 3600) - (dst_m_corr * 60)) / 86400));
+	rt->days = fabs(floor((one->sse - two->sse - (dst_h_corr * 3600) - (dst_m_corr * 60)) / 86400));
 
 	timelib_do_rel_normalize(rt->invert ? one : two, rt);
 


### PR DESCRIPTION
The compiler complains about using abs() on double value:

```
warning: using integer absolute value function
      'abs' when argument is of floating point type [-Wabsolute-value]
        rt->days = abs(floor((one->sse - two->sse - (dst_h_corr * 3600) - (dst_m_corr * 60)) / 86400));
```

This PR fixes the warning.