### PR TITLE
Fix: fold-maker `fpm_event_pre_init()'

### DIFF
--- a/sapi/fpm/fpm/fpm_events.c
+++ b/sapi/fpm/fpm/fpm_events.c
@@ -291,7 +291,7 @@ int fpm_event_pre_init(char *machanism) /* {{{ */
 	}
 	return -1;
 }
-/* }} */
+/* }}} */
 
 const char *fpm_event_machanism_name() /* {{{ */
 {
@@ -538,4 +538,3 @@ int fpm_event_del(struct fpm_event_s *ev) /* {{{ */
 }
 /* }}} */
 
-/* }}} */


### PR DESCRIPTION
And remove unwanted folding-marker on bottom row

```diff
$ git diff 49c7fe4 90d1e9d
diff --git a/sapi/fpm/fpm/fpm_events.c b/sapi/fpm/fpm/fpm_events.c
index ca45cb1..2b8e8cf 100644
--- a/sapi/fpm/fpm/fpm_events.c
+++ b/sapi/fpm/fpm/fpm_events.c
@@ -291,7 +291,7 @@ int fpm_event_pre_init(char *machanism) /* {{{ */
        }
        return -1;
 }
-/* }} */
+/* }}} */

 const char *fpm_event_machanism_name() /* {{{ */
 {
@@ -538,4 +538,3 @@ int fpm_event_del(struct fpm_event_s *ev) /* {{{ */
 }
 /* }}} */

-/* }}} */
```