### PR TITLE
Fix bug #70781 (Extension tests fail on dynamic ext dependency)

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1501,18 +1501,6 @@ TEST $file
 
 	// Default ini settings
 	$ini_settings = array();
-	// additional ini overwrites
-	//$ini_overwrites[] = 'setting=value';
-	settings2array($ini_overwrites, $ini_settings);
-
-	// Any special ini settings
-	// these may overwrite the test defaults...
-	if (array_key_exists('INI', $section_text)) {
-		if (strpos($section_text['INI'], '{PWD}') !== false) {
-			$section_text['INI'] = str_replace('{PWD}', dirname($file), $section_text['INI']);
-		}
-		settings2array(preg_split( "/[\n\r]+/", $section_text['INI']), $ini_settings);
-	}
 
 	// Additional required extensions
 	if (array_key_exists('EXTENSIONS', $section_text)) {
@@ -1524,6 +1512,19 @@ TEST $file
 				$ini_settings['extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $req_ext . '.' . PHP_SHLIB_SUFFIX;
 			}
 		}
+	}
+
+	// additional ini overwrites
+	//$ini_overwrites[] = 'setting=value';
+	settings2array($ini_overwrites, $ini_settings);
+
+	// Any special ini settings
+	// these may overwrite the test defaults...
+	if (array_key_exists('INI', $section_text)) {
+		if (strpos($section_text['INI'], '{PWD}') !== false) {
+			$section_text['INI'] = str_replace('{PWD}', dirname($file), $section_text['INI']);
+		}
+		settings2array(preg_split( "/[\n\r]+/", $section_text['INI']), $ini_settings);
 	}
 
 	settings2params($ini_settings);


### PR DESCRIPTION
Please see bug report for more information.

This fix allows extension tests to run when the extension depends on another (dynamically loaded) one.

It could be improved because some warning messages are still displayed in informational messages but, the most important is that the tests run.
