### PR TITLE
Test for Bug #70783 Adding a trait to a class produces fatal error

### DIFF
--- a/tests/classes/bug70783.phpt
+++ b/tests/classes/bug70783.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #70783 (Adding a trait to a class produces fatal error)
+--FILE--
+<?php
+class B extends A {}
+trait wtf {}
+class A {
+  use wtf;
+}
+echo "OK";
+--EXPECTF--
+OK


### PR DESCRIPTION
This is a (currently failing) test for bug #70783
