### PR TITLE
Additional validation for parse_url() for login/pass components

### DIFF
--- a/ext/standard/tests/strings/url_t.phpt
+++ b/ext/standard/tests/strings/url_t.phpt
@@ -575,22 +575,7 @@ $sample_urls = array (
   string(16) "some_page_ref123"
 }
 
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(7) {
-  ["scheme"]=>
-  string(4) "http"
-  ["host"]=>
-  string(11) "www.php.net"
-  ["port"]=>
-  int(80)
-  ["user"]=>
-  string(14) "secret@hideout"
-  ["path"]=>
-  string(10) "/index.php"
-  ["query"]=>
-  string(31) "test=1&test2=char&test3=mixesCI"
-  ["fragment"]=>
-  string(16) "some_page_ref123"
-}
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: bool(false)
 
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(8) {
   ["scheme"]=>
@@ -759,22 +744,7 @@ $sample_urls = array (
   string(7) "9130731"
 }
 
---> http://user:@pass@host/path?argument?value#etc: array(7) {
-  ["scheme"]=>
-  string(4) "http"
-  ["host"]=>
-  string(4) "host"
-  ["user"]=>
-  string(4) "user"
-  ["pass"]=>
-  string(5) "@pass"
-  ["path"]=>
-  string(5) "/path"
-  ["query"]=>
-  string(14) "argument?value"
-  ["fragment"]=>
-  string(3) "etc"
-}
+--> http://user:@pass@host/path?argument?value#etc: bool(false)
 string(4) "http"
 string(11) "www.php.net"
 int(80)

--- a/ext/standard/tests/url/parse_url_basic_001.phpt
+++ b/ext/standard/tests/url/parse_url_basic_001.phpt
@@ -507,23 +507,6 @@ echo "Done";
   string(16) "some_page_ref123"
 }
 
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(7) {
-  ["scheme"]=>
-  string(4) "http"
-  ["host"]=>
-  string(11) "www.php.net"
-  ["port"]=>
-  int(80)
-  ["user"]=>
-  string(14) "secret@hideout"
-  ["path"]=>
-  string(10) "/index.php"
-  ["query"]=>
-  string(31) "test=1&test2=char&test3=mixesCI"
-  ["fragment"]=>
-  string(16) "some_page_ref123"
-}
-
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: array(8) {
   ["scheme"]=>
   string(4) "http"
@@ -689,23 +672,6 @@ echo "Done";
   string(2) "gg"
   ["path"]=>
   string(7) "9130731"
-}
-
---> http://user:@pass@host/path?argument?value#etc: array(7) {
-  ["scheme"]=>
-  string(4) "http"
-  ["host"]=>
-  string(4) "host"
-  ["user"]=>
-  string(4) "user"
-  ["pass"]=>
-  string(5) "@pass"
-  ["path"]=>
-  string(5) "/path"
-  ["query"]=>
-  string(14) "argument?value"
-  ["fragment"]=>
-  string(3) "etc"
 }
 
 --> http://10.10.10.10/:80: array(3) {
@@ -883,4 +849,10 @@ echo "Done";
 --> http://blah.com:123456: bool(false)
 
 --> http://blah.com:abcdef: bool(false)
+
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123: bool(false)
+
+--> http://user:@pass@host/path?argument?value#etc: bool(false)
+
+--> http://foo.com\@bar.com: bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_002.phpt
+++ b/ext/standard/tests/url/parse_url_basic_002.phpt
@@ -69,7 +69,6 @@ echo "Done";
 --> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(4) "http"
 --> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(4) "http"
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(4) "http"
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(4) "http"
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(4) "http"
 --> nntp://news.php.net   : string(4) "nntp"
 --> ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz   : string(3) "ftp"
@@ -89,7 +88,6 @@ echo "Done";
 --> scheme:   : string(6) "scheme"
 --> foo+bar://baz@bang/bla   : string(7) "foo+bar"
 --> gg:9130731   : string(2) "gg"
---> http://user:@pass@host/path?argument?value#etc   : string(4) "http"
 --> http://10.10.10.10/:80   : string(4) "http"
 --> http://x:?   : string(4) "http"
 --> x:blah.com   : string(1) "x"
@@ -125,4 +123,7 @@ echo "Done";
 --> http://:?   : bool(false)
 --> http://blah.com:123456   : bool(false)
 --> http://blah.com:abcdef   : bool(false)
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : bool(false)
+--> http://user:@pass@host/path?argument?value#etc   : bool(false)
+--> http://foo.com\@bar.com   : bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_003.phpt
+++ b/ext/standard/tests/url/parse_url_basic_003.phpt
@@ -68,7 +68,6 @@ echo "Done";
 --> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(11) "www.php.net"
 --> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(11) "www.php.net"
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(11) "www.php.net"
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(11) "www.php.net"
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(11) "www.php.net"
 --> nntp://news.php.net   : string(12) "news.php.net"
 --> ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz   : string(11) "ftp.gnu.org"
@@ -88,7 +87,6 @@ echo "Done";
 --> scheme:   : NULL
 --> foo+bar://baz@bang/bla   : string(4) "bang"
 --> gg:9130731   : NULL
---> http://user:@pass@host/path?argument?value#etc   : string(4) "host"
 --> http://10.10.10.10/:80   : string(11) "10.10.10.10"
 --> http://x:?   : string(1) "x"
 --> x:blah.com   : NULL
@@ -124,4 +122,7 @@ echo "Done";
 --> http://:?   : bool(false)
 --> http://blah.com:123456   : bool(false)
 --> http://blah.com:abcdef   : bool(false)
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : bool(false)
+--> http://user:@pass@host/path?argument?value#etc   : bool(false)
+--> http://foo.com\@bar.com   : bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_004.phpt
+++ b/ext/standard/tests/url/parse_url_basic_004.phpt
@@ -68,7 +68,6 @@ echo "Done";
 --> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : NULL
 --> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : int(80)
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : NULL
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : int(80)
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : int(80)
 --> nntp://news.php.net   : NULL
 --> ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz   : NULL
@@ -88,7 +87,6 @@ echo "Done";
 --> scheme:   : NULL
 --> foo+bar://baz@bang/bla   : NULL
 --> gg:9130731   : NULL
---> http://user:@pass@host/path?argument?value#etc   : NULL
 --> http://10.10.10.10/:80   : NULL
 --> http://x:?   : NULL
 --> x:blah.com   : NULL
@@ -124,4 +122,7 @@ echo "Done";
 --> http://:?   : bool(false)
 --> http://blah.com:123456   : bool(false)
 --> http://blah.com:abcdef   : bool(false)
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : bool(false)
+--> http://user:@pass@host/path?argument?value#etc   : bool(false)
+--> http://foo.com\@bar.com   : bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_005.phpt
+++ b/ext/standard/tests/url/parse_url_basic_005.phpt
@@ -68,7 +68,6 @@ echo "Done";
 --> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(6) "secret"
 --> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(0) ""
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(6) "secret"
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(14) "secret@hideout"
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(6) "secret"
 --> nntp://news.php.net   : NULL
 --> ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz   : NULL
@@ -88,7 +87,6 @@ echo "Done";
 --> scheme:   : NULL
 --> foo+bar://baz@bang/bla   : string(3) "baz"
 --> gg:9130731   : NULL
---> http://user:@pass@host/path?argument?value#etc   : string(4) "user"
 --> http://10.10.10.10/:80   : NULL
 --> http://x:?   : NULL
 --> x:blah.com   : NULL
@@ -124,4 +122,7 @@ echo "Done";
 --> http://:?   : bool(false)
 --> http://blah.com:123456   : bool(false)
 --> http://blah.com:abcdef   : bool(false)
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : bool(false)
+--> http://user:@pass@host/path?argument?value#etc   : bool(false)
+--> http://foo.com\@bar.com   : bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_006.phpt
+++ b/ext/standard/tests/url/parse_url_basic_006.phpt
@@ -68,7 +68,6 @@ echo "Done";
 --> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(0) ""
 --> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(7) "hideout"
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(7) "hideout"
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : NULL
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(7) "hid:out"
 --> nntp://news.php.net   : NULL
 --> ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz   : NULL
@@ -88,7 +87,6 @@ echo "Done";
 --> scheme:   : NULL
 --> foo+bar://baz@bang/bla   : NULL
 --> gg:9130731   : NULL
---> http://user:@pass@host/path?argument?value#etc   : string(5) "@pass"
 --> http://10.10.10.10/:80   : NULL
 --> http://x:?   : NULL
 --> x:blah.com   : NULL
@@ -124,4 +122,7 @@ echo "Done";
 --> http://:?   : bool(false)
 --> http://blah.com:123456   : bool(false)
 --> http://blah.com:abcdef   : bool(false)
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : bool(false)
+--> http://user:@pass@host/path?argument?value#etc   : bool(false)
+--> http://foo.com\@bar.com   : bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_007.phpt
+++ b/ext/standard/tests/url/parse_url_basic_007.phpt
@@ -68,7 +68,6 @@ echo "Done";
 --> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(10) "/index.php"
 --> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(10) "/index.php"
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(10) "/index.php"
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(10) "/index.php"
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(10) "/index.php"
 --> nntp://news.php.net   : NULL
 --> ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz   : string(22) "/gnu/glic/glibc.tar.gz"
@@ -88,7 +87,6 @@ echo "Done";
 --> scheme:   : NULL
 --> foo+bar://baz@bang/bla   : string(4) "/bla"
 --> gg:9130731   : string(7) "9130731"
---> http://user:@pass@host/path?argument?value#etc   : string(5) "/path"
 --> http://10.10.10.10/:80   : string(4) "/:80"
 --> http://x:?   : NULL
 --> x:blah.com   : string(8) "blah.com"
@@ -124,4 +122,7 @@ echo "Done";
 --> http://:?   : bool(false)
 --> http://blah.com:123456   : bool(false)
 --> http://blah.com:abcdef   : bool(false)
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : bool(false)
+--> http://user:@pass@host/path?argument?value#etc   : bool(false)
+--> http://foo.com\@bar.com   : bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_008.phpt
+++ b/ext/standard/tests/url/parse_url_basic_008.phpt
@@ -68,7 +68,6 @@ echo "Done";
 --> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(31) "test=1&test2=char&test3=mixesCI"
 --> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(31) "test=1&test2=char&test3=mixesCI"
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(31) "test=1&test2=char&test3=mixesCI"
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(31) "test=1&test2=char&test3=mixesCI"
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(31) "test=1&test2=char&test3=mixesCI"
 --> nntp://news.php.net   : NULL
 --> ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz   : NULL
@@ -88,7 +87,6 @@ echo "Done";
 --> scheme:   : NULL
 --> foo+bar://baz@bang/bla   : NULL
 --> gg:9130731   : NULL
---> http://user:@pass@host/path?argument?value#etc   : string(14) "argument?value"
 --> http://10.10.10.10/:80   : NULL
 --> http://x:?   : NULL
 --> x:blah.com   : NULL
@@ -124,4 +122,7 @@ echo "Done";
 --> http://:?   : bool(false)
 --> http://blah.com:123456   : bool(false)
 --> http://blah.com:abcdef   : bool(false)
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : bool(false)
+--> http://user:@pass@host/path?argument?value#etc   : bool(false)
+--> http://foo.com\@bar.com   : bool(false)
 Done

--- a/ext/standard/tests/url/parse_url_basic_009.phpt
+++ b/ext/standard/tests/url/parse_url_basic_009.phpt
@@ -68,7 +68,6 @@ echo "Done";
 --> http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(16) "some_page_ref123"
 --> http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(16) "some_page_ref123"
 --> http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(16) "some_page_ref123"
---> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(16) "some_page_ref123"
 --> http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : string(16) "some_page_ref123"
 --> nntp://news.php.net   : NULL
 --> ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz   : NULL
@@ -88,7 +87,6 @@ echo "Done";
 --> scheme:   : NULL
 --> foo+bar://baz@bang/bla   : NULL
 --> gg:9130731   : NULL
---> http://user:@pass@host/path?argument?value#etc   : string(3) "etc"
 --> http://10.10.10.10/:80   : NULL
 --> http://x:?   : NULL
 --> x:blah.com   : NULL
@@ -124,4 +122,7 @@ echo "Done";
 --> http://:?   : bool(false)
 --> http://blah.com:123456   : bool(false)
 --> http://blah.com:abcdef   : bool(false)
+--> http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123   : bool(false)
+--> http://user:@pass@host/path?argument?value#etc   : bool(false)
+--> http://foo.com\@bar.com   : bool(false)
 Done

--- a/ext/standard/tests/url/urls.inc
+++ b/ext/standard/tests/url/urls.inc
@@ -48,7 +48,6 @@ $urls = array(
 'http://secret:@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123',
 'http://:hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123',
 'http://secret:hideout@www.php.net/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123',
-'http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123',
 'http://secret:hid:out@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123',
 'nntp://news.php.net',
 'ftp://ftp.gnu.org/gnu/glic/glibc.tar.gz',
@@ -68,7 +67,6 @@ $urls = array(
 'scheme:',
 'foo+bar://baz@bang/bla',
 'gg:9130731',
-'http://user:@pass@host/path?argument?value#etc',
 'http://10.10.10.10/:80',
 'http://x:?',
 'x:blah.com',
@@ -106,6 +104,9 @@ $urls = array(
 'http://:?',
 'http://blah.com:123456',
 'http://blah.com:abcdef',
+'http://secret@hideout@www.php.net:80/index.php?test=1&test2=char&test3=mixesCI#some_page_ref123',
+'http://user:@pass@host/path?argument?value#etc',
+'http://foo.com\\@bar.com'
 );
 
 

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -242,6 +242,19 @@ PHPAPI php_url *php_url_parse_ex(char const *str, size_t length)
 
 	/* check for login and password */
 	if ((p = zend_memrchr(s, '@', (e-s)))) {
+		/* check for invalid chars inside login/pass */
+		pp = s;
+		while (pp < p) {
+			if (!isalnum(*pp) && *pp != ':' && *pp != ';' && *pp != '=' && !(*pp >= '!' && *pp <= ',')) {
+				if (ret->scheme) {
+					efree(ret->scheme);
+				}
+				efree(ret);
+				return NULL;
+			}
+			pp++;
+		}
+
 		if ((pp = memchr(s, ':', (p-s)))) {
 			ret->user = estrndup(s, (pp-s));
 			php_replace_controlchars_ex(ret->user, (pp - s));


### PR DESCRIPTION
Added validation to parse_url() to prohibit restricted characters inside login/pass components based on RFC3986 
