### PR TITLE
Failing test with array_walk() and references

### DIFF
--- a/ext/standard/tests/array/array_walk_variation10.phpt
+++ b/ext/standard/tests/array/array_walk_variation10.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test array_walk() with callback using same subject array by reference
+--XFAIL--
+Only fails when subject array has more than 2 itens
+--FILE--
+<?php
+
+$parts = array (
+  'foo',
+  'bar',
+  'baz',
+);
+
+array_walk($parts, function ($value, $key) use (&$parts) {
+    $parts = array_values($parts);
+});
+
+echo "Done\n";
+?>
+--EXPECTF--
+Done


### PR DESCRIPTION
After a long time, revisiting issue #1267, I still could not fix it :neutral_face: but it looks like the bug only happens when the subject array has more than 2 items. The following variation shows no failure https://3v4l.org/8DHT1 :

```php
$parts = array (
  'foo',
  'bar',
);

array_walk($parts, function ($value, $key) use (&$parts) {
    $parts = array_values($parts);
});

echo "Done\n";
```

I added an --XFAIL-- section to the pull requested test as @cmb69 asked, just in case we decide to merge it.