### PR TITLE
Expose php_random_bytes as a first-class API within internals

### DIFF
--- a/ext/standard/php_random.h
+++ b/ext/standard/php_random.h
@@ -31,6 +31,11 @@ typedef struct {
 	int fd;
 } php_random_globals;
 
+#define php_random_bytes_throw(b, s) php_random_bytes((b), (s), 1)
+#define php_random_bytes_silent(b, s) php_random_bytes((b), (s), 0)
+
+PHPAPI int php_random_bytes(void *bytes, size_t size, zend_bool should_throw);
+
 #ifdef ZTS
 # define RANDOM_G(v) ZEND_TSRMG(random_globals_id, php_random_globals *, v)
 extern PHPAPI int random_globals_id;


### PR DESCRIPTION
This also defines two macros: php_random_bytes_throw and php_random_bytes_silent depending on use case which will throw exceptions or not respectively