### PR TITLE
Fix #70831: Compile fails on system with 160 CPUs

### DIFF
--- a/ext/tokenizer/Makefile.frag
+++ b/ext/tokenizer/Makefile.frag
@@ -1,3 +1,4 @@
 $(top_srcdir)/Zend/zend_language_parser.c:
 $(top_srcdir)/Zend/zend_language_scanner.c:
+$(top_srcdir)/ext/tokenizer/tokenizer_data.c: $(top_srcdir)/Zend/zend_language_parser.h
 $(builddir)/tokenizer.lo: $(top_srcdir)/Zend/zend_language_parser.c $(top_srcdir)/Zend/zend_language_scanner.c


### PR DESCRIPTION
This fixes the following build issue on 160-CPU POWER8 machines

`ext/tokenizer/tokenizer_data.c:28:34: fatal error: zend_language_parser.h: No such file or directory
 #include <zend_language_parser.h>`

It is fixed by introducing an explicit dependency on the header file.

Signed-off-by: Daniel Axtens <dja@axtens.net>