### PR TITLE
Fix #70842: Streams related segfault

### DIFF
--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -84,6 +84,7 @@ fprintf(stderr, "forget_persistent: %s:%p\n", stream->ops->label, stream);
 
 	if (stream->ctx) {
 		zend_list_delete(stream->ctx);
+		stream->ctx = NULL;
 	}
 
 	return 0;


### PR DESCRIPTION
Make sure stream context is set to null to prevent use after free