### PR TITLE
ext/dba/config.m4: Autodetect Berkeley DB v5.3.

### DIFF
--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -320,6 +320,10 @@ if test "$PHP_DB4" != "no"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/db4/db.h
       break
+    elif test -f "$i/include/db5.3/db.h"; then
+      THIS_PREFIX=$i
+      THIS_INCLUDE=$i/include/db5.3/db.h
+      break
     elif test -f "$i/include/db5.1/db.h"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/include/db5.1/db.h
@@ -362,7 +366,7 @@ if test "$PHP_DB4" != "no"; then
       break
     fi
   done
-  PHP_DBA_DB_CHECK(4, db-5.1 db-5.0 db-4.8 db-4.7 db-4.6 db-4.5 db-4.4 db-4.3 db-4.2 db-4.1 db-4.0 db-4 db4 db, [(void)db_create((DB**)0, (DB_ENV*)0, 0)])
+  PHP_DBA_DB_CHECK(4, db-5.3 db-5.1 db-5.0 db-4.8 db-4.7 db-4.6 db-4.5 db-4.4 db-4.3 db-4.2 db-4.1 db-4.0 db-4 db4 db, [(void)db_create((DB**)0, (DB_ENV*)0, 0)])
 fi
 PHP_DBA_STD_RESULT(db4,Berkeley DB4)
 


### PR DESCRIPTION
When the user passes --with-db4=DIR to ./configure, the directory DIR
is searched for a number of paths in order of preference. These paths
contain possible locations for Berkeley DB (BDB) to be installed, and
since PHP only supports BDB-4.x and BDB-5.x, it's important that (for
example) version 5.1 be autodetected before falling back to
/usr/include/db.h which can point to BDB-6.x.

The newer BDB-5.3 works with PHP, and if only BDB-5.3 is installed on
the user's system, the current ./configure script is fine. However, if
both BDB-5.3 and BDB-6.0 are installed, version 5.3 is not
autodetected, causing BDB-6.0 to be used. The ./configure step then fails.

This commit adds autodetection for BDB-5.3, and fixes a bug reported
on Gentoo at https://bugs.gentoo.org/show_bug.cgi?id=564824.