### PR TITLE
Bug #70861: Fix binding of empty string resource as a parameter.

### DIFF
--- a/ext/pdo/pdo_sql_parser.c
+++ b/ext/pdo/pdo_sql_parser.c
@@ -576,8 +576,7 @@ safe:
 
 						buf = php_stream_copy_to_mem(stm, PHP_STREAM_COPY_ALL, 0);
 						if (!buf) {
-							ret = -1;
-							goto clean_up;
+							buf = ZSTR_EMPTY_ALLOC();
 						}
 						if (!stmt->dbh->methods->quoter(stmt->dbh, ZSTR_VAL(buf), ZSTR_LEN(buf), &plc->quoted, &plc->qlen,
 								param->param_type)) {

--- a/ext/pdo/pdo_sql_parser.re
+++ b/ext/pdo/pdo_sql_parser.re
@@ -218,8 +218,7 @@ safe:
 
 						buf = php_stream_copy_to_mem(stm, PHP_STREAM_COPY_ALL, 0);
 						if (!buf) {
-							ret = -1;
-							goto clean_up;
+							buf = ZSTR_EMPTY_ALLOC();
 						}
 						if (!stmt->dbh->methods->quoter(stmt->dbh, ZSTR_VAL(buf), ZSTR_LEN(buf), &plc->quoted, &plc->qlen,
 								param->param_type)) {


### PR DESCRIPTION
See: https://bugs.php.net/bug.php?id=70861

The original fix for https://bugs.php.net/bug.php?id=70861 unfortunately did fix the crash, but not the issue.

The problem is given a PG SQL PDO stmt $stmt when doing:

```php
         $value = '';

          $blob = fopen('php://memory', 'a');
          fwrite($blob, $value);
          rewind($blob);

          $stmt->bindParam(':db_insert_placeholder_0' , $blob, \PDO::PARAM_LOB);
```

That then php_stream_copy_to_mem() returns NULL, but if we don't bind the placeholder than the query fails.

The attached patch uses an empty ZSTR to remove the problem, which probably makes sense that an empty resource is mapped to an empty string instead of NULL.

There might be a better fix available, but this fixes the test for me.