### PR TITLE
Use ZEND_STRL macro for builtin_types

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -190,10 +190,10 @@ typedef struct _builtin_type_info {
 } builtin_type_info;
 
 static const builtin_type_info builtin_types[] = {
-	{"int", sizeof("int") - 1, IS_LONG},
-	{"float", sizeof("float") - 1, IS_DOUBLE},
-	{"string", sizeof("string") - 1, IS_STRING},
-	{"bool", sizeof("bool") - 1, _IS_BOOL},
+	{ZEND_STRL("int"), IS_LONG},
+	{ZEND_STRL("float"), IS_DOUBLE},
+	{ZEND_STRL("string"), IS_STRING},
+	{ZEND_STRL("bool"), _IS_BOOL},
 	{NULL, 0, IS_UNDEF}
 };
 


### PR DESCRIPTION
A tiny little cleanup, using the macro rather than typing `"foo", sizeof("foo") - 1` manually.