### PR TITLE
Add resource typehint and return type

### DIFF
--- a/Zend/tests/return_types/resource_allowed.phpt
+++ b/Zend/tests/return_types/resource_allowed.phpt
@@ -1,0 +1,15 @@
+--TEST--
+resource return type: acceptable cases
+--FILE--
+<?php
+
+function bar(): resource {
+    return fopen('php://memory', 'w'); // okay
+}
+
+bar();
+
+echo "OK!", PHP_EOL;
+--EXPECT--
+OK!
+

--- a/Zend/tests/return_types/resource_disallowed.phpt
+++ b/Zend/tests/return_types/resource_disallowed.phpt
@@ -1,0 +1,18 @@
+--TEST--
+resource return type: non-resource
+--FILE--
+<?php
+
+function bar(): resource {
+    return true;
+}
+
+try {
+	bar();
+} catch (TypeError $e) {
+	echo $e->getMessage();
+}
+
+--EXPECT--
+Return value of bar() must be of the type resource, boolean returned
+

--- a/Zend/tests/typehints/resource_allowed.phpt
+++ b/Zend/tests/typehints/resource_allowed.phpt
@@ -1,0 +1,15 @@
+--TEST--
+resource typehint: acceptable cases
+--FILE--
+<?php
+
+function foo(resource $foo) {
+    // okay
+}
+
+foo(fopen('php://memory', 'w'));
+
+echo "OK!", PHP_EOL;
+--EXPECT--
+OK!
+

--- a/Zend/tests/typehints/resource_disallowed.phpt
+++ b/Zend/tests/typehints/resource_disallowed.phpt
@@ -1,0 +1,18 @@
+--TEST--
+resource typehint: acceptable cases
+--FILE--
+<?php
+
+function foo(resource $foo) {
+    // okay
+}
+
+try {
+	foo(true);
+} catch (TypeError $e) {
+	echo $e->getMessage();
+}
+
+--EXPECTF--
+Argument 1 passed to foo() must be of the type resource, boolean given, called in %s on line %d
+

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -148,6 +148,7 @@ static const struct reserved_class_name reserved_class_names[] = {
 	{ZEND_STRL("static")},
 	{ZEND_STRL("string")},
 	{ZEND_STRL("true")},
+	{ZEND_STRL("resource")},
 	{NULL, 0}
 };
 
@@ -191,6 +192,7 @@ static const builtin_type_info builtin_types[] = {
 	{ZEND_STRL("float"), IS_DOUBLE},
 	{ZEND_STRL("string"), IS_STRING},
 	{ZEND_STRL("bool"), _IS_BOOL},
+	{ZEND_STRL("resource"), IS_RESOURCE},
 	{NULL, 0, IS_UNDEF}
 };
 


### PR DESCRIPTION
This PR adds a `resource` typehint and return type. Corresponding RFC:
https://wiki.php.net/rfc/resource_typehint
