### PR TITLE
Added support for CSS/JavaScript source maps

### DIFF
--- a/sapi/cli/mime_type_map.h
+++ b/sapi/cli/mime_type_map.h
@@ -71,6 +71,7 @@ static php_cli_server_ext_mime_type_pair mime_type_map[] = {
 	{ "ma", "application/mathematica" },
 	{ "nb", "application/mathematica" },
 	{ "mb", "application/mathematica" },
+	{ "map", "application/json" },
 	{ "mathml", "application/mathml+xml" },
 	{ "mbox", "application/mbox" },
 	{ "mscml", "application/mediaservercontrol+xml" },


### PR DESCRIPTION
Source maps (http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) are basically a way to map a combined/minified file back to an unbuilt state. To avoid error messages in Browser DevTools, source map files should be served with the MIME type "application/json"