### PR TITLE
Remove duplicate check in substr()

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2426,10 +2426,6 @@ PHP_FUNCTION(substr)
 		}
 	}
 
-	if (f > (zend_long)ZSTR_LEN(str)) {
-		RETURN_FALSE;
-	}
-
 	if ((f + l) > (zend_long)ZSTR_LEN(str)) {
 		l = ZSTR_LEN(str) - f;
 	}


### PR DESCRIPTION
This check (if the start position is greater than the string length) is already performed on line 2399.