### PR TITLE
Fixed bug #70912 (Null ptr dereference instantiating class with inval…

### DIFF
--- a/Zend/tests/bug70912.phpt
+++ b/Zend/tests/bug70912.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #70912 Null ptr dereference instantiating class with invalid array property
+--FILE--
+<?php
+new class {
+    public $a = [][];
+};
+?>
+--EXPECTF--
+Fatal error: Cannot use [] for reading in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7386,7 +7386,12 @@ void zend_eval_const_expr(zend_ast **ast_ptr) /* {{{ */
 
 			zend_eval_const_expr(&ast->child[0]);
 			zend_eval_const_expr(&ast->child[1]);
-			if (!ast->child[0] || !ast->child[1] || ast->child[0]->kind != ZEND_AST_ZVAL || ast->child[1]->kind != ZEND_AST_ZVAL) {
+
+			if (!ast->child[1]) {
+				zend_error_noreturn(E_COMPILE_ERROR, "Cannot use [] for reading");
+			}
+
+			if (ast->child[0]->kind != ZEND_AST_ZVAL || ast->child[1]->kind != ZEND_AST_ZVAL) {
 				return;
 			}
 


### PR DESCRIPTION
The previous related fix is 2a1a8f9ea75d4c8c9c47c2a391113764b9d0639b for bug #70183
This check has to be done in compile time or it will be delayed to runtime and lead crash.

And ast->child[0] couldn't be null, so there is no need to check it.


@weltling  since you pulled that patch.