### PR TITLE
Fix naming of global section in fpm_conf_dump()

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -1573,7 +1573,7 @@ static void fpm_conf_dump() /* {{{ */
 	/*
 	 * Please keep the same order as in fpm_conf.h and in php-fpm.conf.in
 	 */
-	zlog(ZLOG_NOTICE, "[General]");
+	zlog(ZLOG_NOTICE, "[global]");
 	zlog(ZLOG_NOTICE, "\tpid = %s",                         STR2STR(fpm_global_config.pid_file));
 	zlog(ZLOG_NOTICE, "\terror_log = %s",                   STR2STR(fpm_global_config.error_log));
 #ifdef HAVE_SYSLOG_H


### PR DESCRIPTION
The global section in the dump is named "General", but the correct section name is "global". See line #1313 and https://github.com/php/php-src/blob/master/sapi/fpm/php-fpm.conf.in. The commit fixes the naming. However, the proposed change might break any tooling that relies on finding "General" in the output.