### PR TITLE
Facilitate phpinfo integration using new HTML5 "scoped" attribute

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -272,7 +272,7 @@ static void php_print_gpcse_array(char *name, uint name_length)
  */
 void php_info_print_style(void)
 {
-	php_info_printf("<style type=\"text/css\">\n");
+	php_info_printf("<style type=\"text/css\" scoped=\"scoped\">\n");
 	php_info_print_css();
 	php_info_printf("</style>\n");
 }


### PR DESCRIPTION
Sometime for debug operation we need to integrate the phpinfo in a HTML container.
This commit will let you integrate the phpinfo without getting your page destroyed by additional CSS added by the phpinfo (XHTML compliant).
