### PR TITLE
SIZEOF_SIZE_T doesn't exist on AIX, keep using SIZEOF_LONG

### DIFF
--- a/ext/mbstring/oniguruma/regint.h
+++ b/ext/mbstring/oniguruma/regint.h
@@ -227,7 +227,11 @@
 } while(0)
 
 /* sizeof(OnigCodePoint) */
-#define WORD_ALIGNMENT_SIZE     SIZEOF_SIZE_T
+#ifdef SIZEOF_SIZE_T
+# define WORD_ALIGNMENT_SIZE     SIZEOF_SIZE_T
+#else
+# define WORD_ALIGNMENT_SIZE     SIZEOF_LONG
+#endif
 
 #define GET_ALIGNMENT_PAD_SIZE(addr,pad_size) do {\
   (pad_size) = WORD_ALIGNMENT_SIZE \


### PR DESCRIPTION
Fixes build problem on AIX (due to 228eaf5b):

/php-7.0.0RC7/ext/mbstring/oniguruma/regcomp.c:49: error: `SIZEOF_SIZE_T' undeclared here (not in a function)
/php-7.0.0RC7/ext/mbstring/oniguruma/regcomp.c:49: error: storage size of `PadBuf' isn't known
make: *** [oniguruma/regcomp.lo] Error 1