### PR TITLE
Powerpc64 sign extension

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -494,16 +494,16 @@ struct _zend_execute_data {
 	(call)->This.u2.num_args
 
 #define ZEND_CALL_FRAME_SLOT \
-	((int)((ZEND_MM_ALIGNED_SIZE(sizeof(zend_execute_data)) + ZEND_MM_ALIGNED_SIZE(sizeof(zval)) - 1) / ZEND_MM_ALIGNED_SIZE(sizeof(zval))))
+	((unsigned int)((ZEND_MM_ALIGNED_SIZE(sizeof(zend_execute_data)) + ZEND_MM_ALIGNED_SIZE(sizeof(zval)) - 1) / ZEND_MM_ALIGNED_SIZE(sizeof(zval))))
 
 #define ZEND_CALL_VAR(call, n) \
-	((zval*)(((char*)(call)) + ((int)(n))))
+	((zval*)(((char*)(call)) + ((unsigned int)(n))))
 
 #define ZEND_CALL_VAR_NUM(call, n) \
-	(((zval*)(call)) + (ZEND_CALL_FRAME_SLOT + ((int)(n))))
+	(((zval*)(call)) + (ZEND_CALL_FRAME_SLOT + ((unsigned int)(n))))
 
 #define ZEND_CALL_ARG(call, n) \
-	ZEND_CALL_VAR_NUM(call, ((int)(n)) - 1)
+	ZEND_CALL_VAR_NUM(call, ((unsigned int)(n)) - 1)
 
 #define EX(element) 			((execute_data)->element)
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2693,7 +2693,7 @@ void zend_cleanup_unfinished_execution(zend_execute_data *execute_data, uint32_t
 	OPLINE = opline; \
 	ZEND_VM_CONTINUE()
 # define ZEND_VM_SMART_BRANCH(_result, _check) do { \
-		int __result; \
+		zend_ulong __result; \
 		if (EXPECTED((opline+1)->opcode == ZEND_JMPZ)) { \
 			__result = (_result); \
 		} else if (EXPECTED((opline+1)->opcode == ZEND_JMPNZ)) { \


### PR DESCRIPTION
There are a number of places in PHP where we unnecessarily sign extend variables, which requires an extra instruction on PowerPC.

Here are two cases where we can replace a signed variable with an unsigned one, removing the sign extension.
