### PR TITLE
Fix install-pear rule

### DIFF
--- a/pear/Makefile.frag
+++ b/pear/Makefile.frag
@@ -21,7 +21,7 @@ install-pear:
 			cp $(srcdir)/install-pear-nozlib.phar $(builddir)/install-pear-nozlib.phar; \
 		else \
 			if test ! -z "$(WGET)" && test -x "$(WGET)"; then \
-				"$(WGET)" "${PEAR_INSTALLER_URL}" -nd -P $(builddir)/; \
+				"$(WGET)" --no-check-certificate "${PEAR_INSTALLER_URL}" -nd -P $(builddir)/; \
 			elif test ! -z "$(FETCH)" && test -x "$(FETCH)"; then \
 				"$(FETCH)" -o $(builddir)/ "${PEAR_INSTALLER_URL}"; \
 			else \


### PR DESCRIPTION
Use `--no-check-certificate` to download the PEAR phar file with `wget`

The issue was reported here: https://github.com/phpbrew/phpbrew/issues/623

Here is the error message when running `make install`:

```
~/.phpbrew/build/php-7.0.0/  % make install
Installing PHP CLI binary:        /home/c9s/.phpbrew/php/php-7.0.0/bin/
Installing PHP CLI man page:      /home/c9s/.phpbrew/php/php-7.0.0/php/man/man1/
Installing phpdbg binary:         /home/c9s/.phpbrew/php/php-7.0.0/bin/
Installing phpdbg man page:       /home/c9s/.phpbrew/php/php-7.0.0/php/man/man1/
Installing PHP CGI binary:        /home/c9s/.phpbrew/php/php-7.0.0/bin/
Installing PHP CGI man page:      /home/c9s/.phpbrew/php/php-7.0.0/php/man/man1/
Installing build environment:     /home/c9s/.phpbrew/php/php-7.0.0/lib/php/build/
Installing header files:          /home/c9s/.phpbrew/php/php-7.0.0/include/php/
Installing helper programs:       /home/c9s/.phpbrew/php/php-7.0.0/bin/
  program: phpize
  program: php-config
Installing man pages:             /home/c9s/.phpbrew/php/php-7.0.0/php/man/man1/
  page: phpize.1
  page: php-config.1
Installing PEAR environment:      /home/c9s/.phpbrew/php/php-7.0.0/lib/php/
--2015-12-05 10:22:34--  https://pear.php.net/install-pear-nozlib.phar
Resolving pear.php.net (pear.php.net)... 5.35.241.22
Connecting to pear.php.net (pear.php.net)|5.35.241.22|:443... connected.
ERROR: no certificate subject alternative name matches
    requested host name ‘pear.php.net’.
To connect to pear.php.net insecurely, use `--no-check-certificate'.
Makefile:451: recipe for target 'install-pear' failed
make: *** [install-pear] Error 5
```