### PR TITLE
Implement FR #55651: (Option to ignore the returned FTP PASV address)

### DIFF
--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -722,10 +722,11 @@ ftp_pasv(ftpbuf_t *ftp, int pasv)
 	memset(&ftp->pasvaddr, 0, n);
 	sa = (struct sockaddr *) &ftp->pasvaddr;
 
-#if HAVE_IPV6
 	if (getpeername(ftp->fd, sa, &n) < 0) {
 		return 0;
 	}
+
+#if HAVE_IPV6
 	if (sa->sa_family == AF_INET6) {
 		struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) sa;
 		char *endptr, delimiter;
@@ -778,8 +779,9 @@ ftp_pasv(ftpbuf_t *ftp, int pasv)
 		ipbox.c[n] = (unsigned char) b[n];
 	}
 	sin = (struct sockaddr_in *) sa;
-	sin->sin_family = AF_INET;
-	sin->sin_addr = ipbox.ia[0];
+	if (ftp->usepasvaddress) {
+		sin->sin_addr = ipbox.ia[0];
+	}
 	sin->sin_port = ipbox.s[2];
 
 	ftp->pasv = 2;

--- a/ext/ftp/ftp.h
+++ b/ext/ftp/ftp.h
@@ -31,6 +31,7 @@
 
 #define	FTP_DEFAULT_TIMEOUT	90
 #define FTP_DEFAULT_AUTOSEEK 1
+#define FTP_DEFAULT_USEPASVADDRESS	1
 #define PHP_FTP_FAILED			0
 #define PHP_FTP_FINISHED		1
 #define PHP_FTP_MOREDATA		2
@@ -71,6 +72,7 @@ typedef struct ftpbuf
 	php_sockaddr_storage	pasvaddr;	/* passive mode address */
 	long	timeout_sec;	/* User configurable timeout (seconds) */
 	int			autoseek;	/* User configurable autoseek flag */
+	int			usepasvaddress;	/* Use the address returned by the pasv command */
 
 	int				nb;		/* "nonblocking" transfer in progress */
 	databuf_t		*data;	/* Data connection for "nonblocking" transfers */

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -315,6 +315,7 @@ PHP_MINIT_FUNCTION(ftp)
 	REGISTER_LONG_CONSTANT("FTP_AUTORESUME", PHP_FTP_AUTORESUME, CONST_PERSISTENT | CONST_CS);
 	REGISTER_LONG_CONSTANT("FTP_TIMEOUT_SEC", PHP_FTP_OPT_TIMEOUT_SEC, CONST_PERSISTENT | CONST_CS);
 	REGISTER_LONG_CONSTANT("FTP_AUTOSEEK", PHP_FTP_OPT_AUTOSEEK, CONST_PERSISTENT | CONST_CS);
+	REGISTER_LONG_CONSTANT("FTP_USEPASVADDRESS", PHP_FTP_OPT_USEPASVADDRESS, CONST_PERSISTENT | CONST_CS);
 	REGISTER_LONG_CONSTANT("FTP_FAILED", PHP_FTP_FAILED, CONST_PERSISTENT | CONST_CS);
 	REGISTER_LONG_CONSTANT("FTP_FINISHED", PHP_FTP_FINISHED, CONST_PERSISTENT | CONST_CS);
 	REGISTER_LONG_CONSTANT("FTP_MOREDATA", PHP_FTP_MOREDATA, CONST_PERSISTENT | CONST_CS);
@@ -363,6 +364,7 @@ PHP_FUNCTION(ftp_connect)
 
 	/* autoseek for resuming */
 	ftp->autoseek = FTP_DEFAULT_AUTOSEEK;
+	ftp->usepasvaddress = FTP_DEFAULT_USEPASVADDRESS;
 #if HAVE_OPENSSL_EXT
 	/* disable ssl */
 	ftp->use_ssl = 0;
@@ -399,6 +401,7 @@ PHP_FUNCTION(ftp_ssl_connect)
 
 	/* autoseek for resuming */
 	ftp->autoseek = FTP_DEFAULT_AUTOSEEK;
+	ftp->usepasvaddress = FTP_DEFAULT_USEPASVADDRESS;
 	/* enable ssl */
 	ftp->use_ssl = 1;
 
@@ -1399,6 +1402,15 @@ PHP_FUNCTION(ftp_set_option)
 			ftp->autoseek = Z_LVAL_P(z_value);
 			RETURN_TRUE;
 			break;
+		case PHP_FTP_OPT_USEPASVADDRESS:
+			if (Z_TYPE_P(z_value) != IS_BOOL) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Option USEPASVADDRESS expects value of type boolean, %s given",
+					zend_zval_type_name(z_value));
+				RETURN_FALSE;
+			}
+			ftp->usepasvaddress = Z_LVAL_P(z_value);
+			RETURN_TRUE;
+			break;
 		default:
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown option '%ld'", option);
 			RETURN_FALSE;
@@ -1427,6 +1439,9 @@ PHP_FUNCTION(ftp_get_option)
 			break;
 		case PHP_FTP_OPT_AUTOSEEK:
 			RETURN_BOOL(ftp->autoseek);
+			break;
+		case PHP_FTP_OPT_USEPASVADDRESS:
+			RETURN_BOOL(ftp->usepasvaddress);
 			break;
 		default:
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown option '%ld'", option);

--- a/ext/ftp/php_ftp.h
+++ b/ext/ftp/php_ftp.h
@@ -29,6 +29,7 @@ extern zend_module_entry php_ftp_module_entry;
 
 #define PHP_FTP_OPT_TIMEOUT_SEC	0
 #define PHP_FTP_OPT_AUTOSEEK	1
+#define PHP_FTP_OPT_USEPASVADDRESS	2
 #define PHP_FTP_AUTORESUME		-1
 
 PHP_MINIT_FUNCTION(ftp);


### PR DESCRIPTION
This patch waits 4 years for review, while a lot of people complain (e.g. number of votes).

More info also at http://www.elitehosts.com/blog/php-ftp-passive-ftp-server-behind-nat-nightmare/