### PR TITLE
Throw an exception when attempting to count a generator

### DIFF
--- a/Zend/tests/generators/errors/count_error.phpt
+++ b/Zend/tests/generators/errors/count_error.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Generators can't be counted
+--FILE--
+<?php
+
+function gen() { yield; }
+
+$gen = gen();
+
+try {
+    count($gen);
+} catch (Exception $e) {
+    echo $e;
+}
+
+?>
+--EXPECTF--
+Exception: Counting of 'Generator' is not allowed in %s:%d
+Stack trace:
+#0 %s(%d): count(Object(Generator))
+#1 {main}

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -977,6 +977,13 @@ ZEND_METHOD(Generator, __wakeup)
 }
 /* }}} */
 
+/* count_elements implementation */
+static void zend_generator_count_elements(zval *object, zend_long *count) /* {{{ */
+{
+	zend_throw_exception(NULL, "Counting of 'Generator' is not allowed", 0);
+}
+/* }}} */
+
 /* get_iterator implementation */
 
 static void zend_generator_iterator_dtor(zend_object_iterator *iterator) /* {{{ */
@@ -1129,6 +1136,7 @@ void zend_register_generator_ce(void) /* {{{ */
 	zend_generator_handlers.dtor_obj = zend_generator_dtor_storage;
 	zend_generator_handlers.clone_obj = NULL;
 	zend_generator_handlers.get_constructor = zend_generator_get_constructor;
+	zend_generator_handlers.count_elements = zend_generator_count_elements;
 
 	INIT_CLASS_ENTRY(ce, "ClosedGeneratorException", NULL);
 	zend_ce_ClosedGeneratorException = zend_register_internal_class_ex(&ce, zend_ce_exception);


### PR DESCRIPTION
Generators are often looped around, and where you have code that accepts a traversable, it's logical to try and count it. At the moment counting a generator returns `int(1)`, so the unsupported behaviour can easily go unnoticed.

This pr proposes to change that by throwing an exception whenever code attempts to count a generator