### PR TITLE
Optimize strtolower()/strtoupper()

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1439,7 +1439,7 @@ PHPAPI zend_string *php_string_toupper(zend_string *s)
 	e = c + ZSTR_LEN(s);
 
 	while (c < e) {
-		if (!isupper(*c)) {
+		if (islower(*c)) {
 			register unsigned char *r;
 			zend_string *res = zend_string_alloc(ZSTR_LEN(s), 0);
 
@@ -1508,7 +1508,7 @@ PHPAPI zend_string *php_string_tolower(zend_string *s)
 	e = c + ZSTR_LEN(s);
 
 	while (c < e) {
-		if (!islower(*c)) {
+		if (isupper(*c)) {
 			register unsigned char *r;
 			zend_string *res = zend_string_alloc(ZSTR_LEN(s), 0);
 


### PR DESCRIPTION
In PHP 7, unnecessary string copy is decreased from PHP 5 because of reference counting in `zend_string`. For example, return value of `strtolower("abc")` points the original `zend_string` and never duplicate the string.

However, `strtolower("abc1")` causes memory allocation. The current implementation of `strtolower` requires that all characters satisfy `islower(c)` for avoiding the string duplication. It seems too strict and inaccurate.