### PR TITLE
reformat & remove closing tag

### DIFF
--- a/ext/skeleton/skeleton.php
+++ b/ext/skeleton/skeleton.php
@@ -1,21 +1,28 @@
 <?php
-$br = (php_sapi_name() == "cli")? "":"<br>";
+
+$br = (php_sapi_name() == "cli") ? "" : "<br>";
 
 if(!extension_loaded('extname')) {
-	dl('extname.' . PHP_SHLIB_SUFFIX);
+    dl('extname.' . PHP_SHLIB_SUFFIX);
 }
+
 $module = 'extname';
 $functions = get_extension_funcs($module);
+
 echo "Functions available in the test extension:$br\n";
+
 foreach($functions as $func) {
-    echo $func."$br\n";
+    echo $func . "$br\n";
 }
+
 echo "$br\n";
+
 $function = 'confirm_' . $module . '_compiled';
+
 if (extension_loaded($module)) {
-	$str = $function($module);
+    $str = $function($module);
 } else {
-	$str = "Module $module is not compiled into PHP";
+    $str = "Module $module is not compiled into PHP";
 }
+
 echo "$str\n";
-?>


### PR DESCRIPTION
If a file is pure PHP code, it is preferable to omit the PHP closing tag at the end of the file.

Ref: http://php.net/manual/en/language.basic-syntax.phptags.php