### PR TITLE
Update default_mimetype ini setting description

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -663,11 +663,10 @@ auto_prepend_file =
 ; http://php.net/auto-append-file
 auto_append_file =
 
-; By default, PHP will output a character encoding using
-; the Content-type: header.  To disable sending of the charset, simply
-; set it to be empty.
+; By default, PHP will output a media type using the Content-Type header. To
+; disable this, simply set it to be empty.
 ;
-; PHP's built-in default is text/html
+; PHP's built-in default media type is set to text/html.
 ; http://php.net/default-mimetype
 default_mimetype = "text/html"
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -663,11 +663,10 @@ auto_prepend_file =
 ; http://php.net/auto-append-file
 auto_append_file =
 
-; By default, PHP will output a character encoding using
-; the Content-type: header.  To disable sending of the charset, simply
-; set it to be empty.
+; By default, PHP will output a media type using the Content-Type header. To
+; disable this, simply set it to be empty.
 ;
-; PHP's built-in default is text/html
+; PHP's built-in default media type is set to text/html.
 ; http://php.net/default-mimetype
 default_mimetype = "text/html"
 


### PR DESCRIPTION
The `default_mimetype` ini setting description should be referring to media types, not talking about character encoding - that's for the `default_charset` ini setting.

This is in response to doc bug #70287.