### PR TITLE
Remove tsrmls leftovers

### DIFF
--- a/CODING_STANDARDS
+++ b/CODING_STANDARDS
@@ -178,7 +178,7 @@ Internal Function Naming Convensions
     Unexposed module function should be static and should not be defined in
     'php_modulename.h'.
 
-    static int php_session_destroy(TSRMLS_D)
+    static int php_session_destroy()
 
 2.  Main module source file must be named 'modulename.c'.
 

--- a/README.EXT_SKEL
+++ b/README.EXT_SKEL
@@ -172,7 +172,7 @@ PHP_FUNCTION(module_name_drawtext)
     zval *image = NULL;
     zval *font = NULL;
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "rsrll|l", &image, &text, &text_len, &font, &x, &y, &color) == FAILURE)
+    if (zend_parse_parameters(argc, "rsrll|l", &image, &text, &text_len, &font, &x, &y, &color) == FAILURE)
         return;
 
     if (image) {

--- a/README.NEW-OUTPUT-API
+++ b/README.NEW-OUTPUT-API
@@ -8,98 +8,98 @@ API adjustment to the old output control code:
 
 	Checking output control layers status:
 		// Using OG()
-		php_output_get_status(TSRMLS_C);
+		php_output_get_status();
 
 	Starting the default output handler:
-		// php_start_ob_buffer(NULL, 0, 1 TSRMLS_CC);
-		php_output_start_default(TSRMLS_C);
+		// php_start_ob_buffer(NULL, 0, 1);
+		php_output_start_default();
 
 	Starting an user handler by zval:
-		// php_start_ob_buffer(zhandler, chunk_size, erase TSRMLS_CC);
-		php_output_start_user(zhandler, chunk_size, flags TSRMLS_CC);
+		// php_start_ob_buffer(zhandler, chunk_size, erase);
+		php_output_start_user(zhandler, chunk_size, flags);
 
 	Starting an internal handler whithout context:
-		// php_ob_set_internal_handler(my_php_output_handler_func_t, buffer_size, "output handler name", erase TSRMLS_CC);
-		php_output_start_internal(handler_name, handler_name_len, my_php_output_handler_func_t, chunk_size, flags TSRMLS_CC);
+		// php_ob_set_internal_handler(my_php_output_handler_func_t, buffer_size, "output handler name", erase);
+		php_output_start_internal(handler_name, handler_name_len, my_php_output_handler_func_t, chunk_size, flags);
 
 	Starting an internal handler with context:
 		// not possible with old API
 		php_output_handler *h;
-		h = php_output_handler_create_internal(handler_name, handler_name_len, my_php_output_handler_context_func_t, chunk_size, flags TSRMLS_CC);
+		h = php_output_handler_create_internal(handler_name, handler_name_len, my_php_output_handler_context_func_t, chunk_size, flags);
 		php_output_handler_set_context(h, my_context, my_context_dtor);
-		php_output_handler_start(h TSRMLS_CC);
+		php_output_handler_start(h);
 
 	Testing whether a certain output handler has already been started:
-		// php_ob_handler_used("output handler name" TSRMLS_CC);
-		php_output_handler_started(handler_name, handler_name_len TSRMLS_CC);
+		// php_ob_handler_used("output handler name");
+		php_output_handler_started(handler_name, handler_name_len);
 
 	Flushing one output buffer:
-		// php_end_ob_buffer(1, 1 TSRMLS_CC);
-		php_output_flush(TSRMLS_C);
+		// php_end_ob_buffer(1, 1);
+		php_output_flush();
 
 	Flushing all output buffers:
 		// not possible with old API
-		php_output_flush_all(TSRMLS_C);
+		php_output_flush_all();
 
 	Cleaning one output buffer:
-		// php_ob_end_buffer(0, 1 TSRMLS_CC);
-		php_output_clean(TSRMLS_C);
+		// php_ob_end_buffer(0, 1);
+		php_output_clean();
 
 	Cleaning all output buffers:
 		// not possible with old API
-		php_output_clean_all(TSRMLS_C);
+		php_output_clean_all();
 
 	Discarding one output buffer:
-		// php_ob_end_buffer(0, 0 TSRMLS_CC);
-		php_output_discard(TSRMLS_C);
+		// php_ob_end_buffer(0, 0);
+		php_output_discard();
 
 	Discarding all output buffers:
-		// php_ob_end_buffers(0 TSRMLS_CC);
-		php_output_discard_all(TSRMLS_C);
+		// php_ob_end_buffers(0);
+		php_output_discard_all();
 
 	Stopping (and dropping) one output buffer:
-		// php_ob_end_buffer(1, 0 TSRMLS_CC)
-		php_output_end(TSRMLS_C);
+		// php_ob_end_buffer(1, 0)
+		php_output_end();
 
 	Stopping (and dropping) all output buffers:
-		// php_ob_end_buffers(1, 0 TSRMLS_CC);
-		php_output_end_all(TSRMLS_C);
+		// php_ob_end_buffers(1, 0);
+		php_output_end_all();
 
 	Retrieving output buffers contents:
-		// php_ob_get_buffer(zstring TSRMLS_CC);
-		php_output_get_contents(zstring TSRMLS_CC);
+		// php_ob_get_buffer(zstring);
+		php_output_get_contents(zstring);
 
 	Retrieving output buffers length:
-		// php_ob_get_length(zlength TSRMLS_CC);
-		php_output_get_length(zlength TSRMLS_CC);
+		// php_ob_get_length(zlength);
+		php_output_get_length(zlength);
 
 	Retrieving output buffering level:
 		// OG(nesting_level);
-		php_output_get_level(TSRMLS_C);
+		php_output_get_level();
 
 	Issue a warning because of an output handler conflict:
-		// php_ob_init_conflict("to be started handler name", "to be tested if already started handler name" TSRMLS_CC);
-		php_output_handler_conflict(new_handler_name, new_handler_name_len, set_handler_name, set_handler_name_len TSRMLS_CC);
+		// php_ob_init_conflict("to be started handler name", "to be tested if already started handler name");
+		php_output_handler_conflict(new_handler_name, new_handler_name_len, set_handler_name, set_handler_name_len);
 
 	Registering a conflict checking function, which will be checked prior starting the handler:
 		// not possible with old API, unless hardcoding into output.c
-		php_output_handler_conflict_register(handler_name, handler_name_len, my_php_output_handler_conflict_check_t TSRMLS_CC);
+		php_output_handler_conflict_register(handler_name, handler_name_len, my_php_output_handler_conflict_check_t);
 
 	Registering a reverse conflict checking function, which will be checked prior starting the specified foreign handler:
 		// not possible with old API
-		php_output_handler_reverse_conflict_register(foreign_handler_name, foreign_handler_name_len, my_php_output_handler_conflict_check_t TSRMLS_CC);
+		php_output_handler_reverse_conflict_register(foreign_handler_name, foreign_handler_name_len, my_php_output_handler_conflict_check_t);
 
 	Facilitating a context from within an output handler callable with ob_start():
 		// not possible with old API
-		php_output_handler_hook(PHP_OUTPUT_HANDLER_HOOK_GET_OPAQ, (void *) &custom_ctx_ptr_ptr TSRMLS_CC);
+		php_output_handler_hook(PHP_OUTPUT_HANDLER_HOOK_GET_OPAQ, (void *) &custom_ctx_ptr_ptr);
 
 	Disabling of the output handler by itself:
 		//not possible with old API
-		php_output_handler_hook(PHP_OUTPUT_HANDLER_HOOK_DISABLE, NULL TSRMLS_CC);
+		php_output_handler_hook(PHP_OUTPUT_HANDLER_HOOK_DISABLE, NULL);
 
 	Marking an output handler immutable by itself because of irreversibility of its operation:
 		// not possible with old API
-		php_output_handler_hook(PHP_OUTPUT_HANDLER_HOOK_IMMUTABLE, NULL TSRMLS_CC);
+		php_output_handler_hook(PHP_OUTPUT_HANDLER_HOOK_IMMUTABLE, NULL);
 
 	Restarting the output handler because of a CLEAN operation:
 		// not possible with old API

--- a/README.PARAMETER_PARSING_API
+++ b/README.PARAMETER_PARSING_API
@@ -13,8 +13,8 @@ meaningful error messages.
 Prototypes
 ----------
 /* Implemented. */
-int zend_parse_parameters(int num_args TSRMLS_DC, char *type_spec, ...);
-int zend_parse_parameters_ex(int flags, int num_args TSRMLS_DC, char *type_spec, ...);
+int zend_parse_parameters(int num_args, char *type_spec, ...);
+int zend_parse_parameters_ex(int flags, int num_args, char *type_spec, ...);
 
 The zend_parse_parameters() function takes the number of parameters
 passed to the extension function, the type specifier string, and the
@@ -30,7 +30,7 @@ resources cannot be auto-converted.
 
 PHP 5.5 includes a new function:
 
-int zend_parse_parameter(int flags, int arg_num TSRMLS_DC, zval **arg, const char *spec, ...);
+int zend_parse_parameter(int flags, int arg_num, zval **arg, const char *spec, ...);
 
 This function behaves like zend_parse_parameters_ex() except that instead of
 reading the arguments from the stack, it receives a single zval to convert
@@ -97,11 +97,11 @@ Both mistakes might cause memory corruptions and segfaults:
 1)
   char *str;
   long str_len; /* XXX THIS IS WRONG!! Use size_t instead. */
-  zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &str_len)
+  zend_parse_parameters(ZEND_NUM_ARGS(), "s", &str, &str_len)
 
 2)
   int num; /* XXX THIS IS WRONG!! Use zend_long instead. */
-  zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &num)
+  zend_parse_parameters(ZEND_NUM_ARGS(), "l", &num)
 
 If you're in doubt, use check_parameters.php script to the parameters 
 and their types (it can be found in ./scripts/dev/ directory of PHP sources):
@@ -116,7 +116,7 @@ zend_long l;
 char *s;
 size_t s_len;
 zval *param;
-if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lsz",
+if (zend_parse_parameters(ZEND_NUM_ARGS(), "lsz",
                           &l, &s, &s_len, &param) == FAILURE) {
     return;
 }
@@ -126,7 +126,7 @@ if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lsz",
 zval *obj;
 double d = 0.5;
 zend_class_entry *my_ce;
-if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O|d",
+if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|d",
                           &obj, my_ce, &d) == FAILURE) {
     return;
 }
@@ -136,7 +136,7 @@ if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O|d",
    If null is passed for object, obj will be set to NULL. */
 zval *obj;
 zval *arr;
-if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "o!a",
+if (zend_parse_parameters(ZEND_NUM_ARGS(), "o!a",
                           &obj, &arr) == FAILURE) {
     return;
 }
@@ -144,7 +144,7 @@ if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "o!a",
 
 /* Gets a separated array which can also be null. */
 zval *arr;
-if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a/!",
+if (zend_parse_parameters(ZEND_NUM_ARGS(), "a/!",
                           &arr) == FAILURE) {
     return;
 }
@@ -161,10 +161,10 @@ char *s;
  */
 size_t length;
 
-if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC,
+if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(),
                              "lll", &l1, &l2, &l3) == SUCCESS) {
     /* manipulate longs */
-} else if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC,
+} else if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(),
                                     "s", &s, &length) == SUCCESS) {
     /* manipulate string */
 } else {
@@ -180,7 +180,7 @@ int i, num_varargs;
 zval *varargs = NULL;
 
 
-if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "*", &varargs, &num_varargs) == FAILURE) {
+if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &varargs, &num_varargs) == FAILURE) {
     return;
 }
 
@@ -200,7 +200,7 @@ size_t str_len;
 int i, num_varargs;
 zval *varargs = NULL;
 
-if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s+", &str, &str_len, &varargs, &num_varargs) == FAILURE) {
+if (zend_parse_parameters(ZEND_NUM_ARGS(), "s+", &str, &str_len, &varargs, &num_varargs) == FAILURE) {
     return;
 }
 
@@ -214,7 +214,7 @@ zval *array;
 int i, num_varargs;
 zval *varargs = NULL;
 
-if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a*l", &array, &varargs, &num_varargs, &num) == FAILURE) {
+if (zend_parse_parameters(ZEND_NUM_ARGS(), "a*l", &array, &varargs, &num_varargs, &num) == FAILURE) {
     return;
 }
 

--- a/README.STREAMS
+++ b/README.STREAMS
@@ -28,7 +28,7 @@ The main functions are:
 PHPAPI size_t php_stream_read(php_stream * stream, char * buf, size_t count);
 PHPAPI size_t php_stream_write(php_stream * stream, const char * buf, size_t
         count);
-PHPAPI size_t php_stream_printf(php_stream * stream TSRMLS_DC, 
+PHPAPI size_t php_stream_printf(php_stream * stream, 
         const char * fmt, ...);
 PHPAPI int php_stream_eof(php_stream * stream);
 PHPAPI int php_stream_getc(php_stream * stream);
@@ -47,7 +47,7 @@ Opening Streams
 In most cases, you should use this API:
 
 PHPAPI php_stream *php_stream_open_wrapper(const char *path, const char *mode,
-    int options, char **opened_path TSRMLS_DC);
+    int options, char **opened_path);
 
 Where:
     path is the file or resource to open.
@@ -80,7 +80,7 @@ PHPAPI php_stream *php_stream_fopen_tmpfile(void);
     Open a FILE * with tmpfile() and convert into a stream.
 
 PHPAPI php_stream *php_stream_fopen_temporary_file(const char *dir,
-    const char *pfx, char **opened_path TSRMLS_DC);
+    const char *pfx, char **opened_path);
     Generate a temporary file name and open it.
 
 There are some network enabled relatives in php_network.h:

--- a/README.input_filter
+++ b/README.input_filter
@@ -138,7 +138,7 @@ SAPI_INPUT_FILTER_FUNC(my_sapi_input_filter)
     strcpy(raw_var, "RAW_");
     strlcat(raw_var,var,var_len+5);
 
-    php_register_variable_ex(raw_var, &new_var, array_ptr TSRMLS_DC);
+    php_register_variable_ex(raw_var, &new_var, array_ptr);
 
     php_strip_tags(*val, val_len, NULL, NULL, 0);
 
@@ -154,7 +154,7 @@ PHP_FUNCTION(my_get_raw)
     zval **tmp;
     zval *array_ptr = NULL;
 
-    if(zend_parse_parameters(2 TSRMLS_CC, "ls", &arg, &var, &var_len) == FAILURE) {
+    if(zend_parse_parameters(2, "ls", &arg, &var, &var_len) == FAILURE) {
         return;
     }
 

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2187,7 +2187,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 #endif
 # if defined(ZTS)
 			if (option == CURLOPT_DNS_USE_GLOBAL_CACHE) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "CURLOPT_DNS_USE_GLOBAL_CACHE cannot be activated when thread safety is enabled");
+				php_error_docref(NULL, E_WARNING, "CURLOPT_DNS_USE_GLOBAL_CACHE cannot be activated when thread safety is enabled");
 				return 1;
 			}
 # endif

--- a/ext/intl/ERROR.CONVENTIONS
+++ b/ext/intl/ERROR.CONVENTIONS
@@ -21,9 +21,9 @@ intl.use_exceptions you get more fine-grained information about where the
 error occurred).
 
 The internal PHP code can set the global last error with:
-void intl_error_set_code(intl_error* err, UErrorCode err_code TSRMLS_DC);
-void intl_error_set_custom_msg(intl_error* err, char* msg, int copyMsg TSRMLS_DC);
-void intl_error_set(intl_error* err, UErrorCode code, char* msg, int copyMsg TSRMLS_DC);
+void intl_error_set_code(intl_error* err, UErrorCode err_code);
+void intl_error_set_custom_msg(intl_error* err, char* msg, int copyMsg);
+void intl_error_set(intl_error* err, UErrorCode code, char* msg, int copyMsg);
 
 and by passing NULL as the first parameter. The last function is a combination
 of the first two. If the message is not a static buffer, copyMsg should be 1.
@@ -44,9 +44,9 @@ typedef struct {
 
 The global error and the object error can be SIMULTANEOUSLY set with these
 functions:
-void intl_errors_set_custom_msg(intl_error* err, char* msg, int copyMsg TSRMLS_DC);
-void intl_errors_set_code(intl_error* err, UErrorCode err_code TSRMLS_DC);
-void intl_errors_set(intl_error* err, UErrorCode code, char* msg, int copyMsg TSRMLS_DC);
+void intl_errors_set_custom_msg(intl_error* err, char* msg, int copyMsg);
+void intl_errors_set_code(intl_error* err, UErrorCode err_code);
+void intl_errors_set(intl_error* err, UErrorCode code, char* msg, int copyMsg);
 
 by passing a pointer to the object's intl_error structed as the first parameter.
 Node the extra 's' in the functions' names ('errors', not 'error').
@@ -79,8 +79,8 @@ Errors should be lost after a function call. This is different from the way
 ICU operates, where functions return immediately if an error is set.
 
 Error resetting can be done with:
-void intl_error_reset(NULL TSRMLS_DC);				/* reset global error */
-void intl_errors_reset(intl_error* err TSRMLS_DC );	/* reset global and object error */
+void intl_error_reset(NULL);				/* reset global error */
+void intl_errors_reset(intl_error* err);	/* reset global and object error */
 
 In practice, intl_errors_reset() is not used because most classes have also
 plain functions mapped to the same internal functions as their instance methods.
@@ -97,10 +97,10 @@ U_CFUNC PHP_FUNCTION(breakiter_set_text)
 	BREAKITER_METHOD_INIT_VARS;			/* macro also resets global error */
 	object = getThis();
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 			&text, &text_len) == FAILURE) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			"breakiter_set_text: bad arguments", 0 TSRMLS_CC);
+			"breakiter_set_text: bad arguments", 0);
 		RETURN_FALSE;
 	}
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -4927,7 +4927,7 @@ PHP_FUNCTION(openssl_seal)
 
 	iv_len = EVP_CIPHER_iv_length(cipher);
 	if (!iv && iv_len > 0) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+		php_error_docref(NULL, E_WARNING,
 				"Cipher algorithm requires an IV to be supplied as a sixth parameter");
 		RETURN_FALSE;
 	}

--- a/ext/pdo_odbc/php_pdo_odbc.h
+++ b/ext/pdo_odbc/php_pdo_odbc.h
@@ -47,16 +47,6 @@ ZEND_BEGIN_MODULE_GLOBALS(pdo_odbc)
 ZEND_END_MODULE_GLOBALS(pdo_odbc)
 */
 
-/* In every utility function you add that needs to use variables
-   in php_pdo_odbc_globals, call TSRMLS_FETCH(); after declaring other
-   variables used by that function, or better yet, pass in
-   after the last function argument and declare your utility function
-   with after the last declared argument.  Always refer to
-   the globals in your function as PDO_ODBC_G(variable).  You are
-   encouraged to rename these macros something shorter, see
-   examples in any other php module directory.
-*/
-
 #ifdef ZTS
 #define PDO_ODBC_G(v) TSRMG(pdo_odbc_globals_id, zend_pdo_odbc_globals *, v)
 #else

--- a/ext/pdo_sqlite/php_pdo_sqlite.h
+++ b/ext/pdo_sqlite/php_pdo_sqlite.h
@@ -48,16 +48,6 @@ ZEND_BEGIN_MODULE_GLOBALS(pdo_sqlite)
 ZEND_END_MODULE_GLOBALS(pdo_sqlite)
 */
 
-/* In every utility function you add that needs to use variables
-   in php_pdo_sqlite_globals, call TSRMLS_FETCH(); after declaring other
-   variables used by that function, or better yet, pass in
-   after the last function argument and declare your utility function
-   with after the last declared argument.  Always refer to
-   the globals in your function as PDO_SQLITE_G(variable).  You are
-   encouraged to rename these macros something shorter, see
-   examples in any other php module directory.
-*/
-
 #ifdef ZTS
 #define PDO_SQLITE_G(v) TSRMG(pdo_sqlite_globals_id, zend_pdo_sqlite_globals *, v)
 #else

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -4085,7 +4085,7 @@ static int phar_extract_file(zend_bool overwrite, phar_entry_info *entry, char *
 	new_state.cwd[0] = DEFAULT_SLASH;
 	new_state.cwd[1] = '\0';
 	new_state.cwd_length = 1;
-	if (virtual_file_ex(&new_state, entry->filename, NULL, CWD_EXPAND TSRMLS_CC) != 0 ||
+	if (virtual_file_ex(&new_state, entry->filename, NULL, CWD_EXPAND) != 0 ||
 			new_state.cwd_length <= 1) {
 		if (EINVAL == errno && entry->filename_len > 50) {
 			char *tmp = estrndup(entry->filename, 50);

--- a/ext/skeleton/create_stubs
+++ b/ext/skeleton/create_stubs
@@ -195,7 +195,7 @@ END {
 		if (maxargs[i]>0) {
 			fetchargs = "\tif (zend_parse_parameters("
 			ints = ints "\tint argc = ZEND_NUM_ARGS();\n"
-			fetchargs = fetchargs "argc TSRMLS_CC, " specs[i]
+			fetchargs = fetchargs "argc, " specs[i]
 		} else {
 			fetchargs = fetchargs "\tif (zend_parse_parameters_none() == FAILURE) {\n\t\treturn;\n\t}"
 	 		xmlparams = xmlparams "      <void/>\n"

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -834,7 +834,7 @@ SPL_METHOD(DirectoryIterator, seek)
 			zval_ptr_dtor(&retval);
 		}
 		if (!valid) {
-			zend_throw_exception_ex(spl_ce_OutOfBoundsException, 0 TSRMLS_CC, "Seek position %ld is out of range", pos);
+			zend_throw_exception_ex(spl_ce_OutOfBoundsException, 0, "Seek position %ld is out of range", pos);
 			return;
 		}
 		zend_call_method_with_0_params(&EX(This), Z_OBJCE(EX(This)), &intern->u.dir.func_next, "next", NULL);

--- a/ext/xsl/php_xsl.h
+++ b/ext/xsl/php_xsl.h
@@ -115,16 +115,6 @@ ZEND_BEGIN_MODULE_GLOBALS(xsl)
 ZEND_END_MODULE_GLOBALS(xsl)
 */
 
-/* In every utility function you add that needs to use variables
-   in php_xsl_globals, call TSRM_FETCH(); after declaring other
-   variables used by that function, or better yet, pass in
-   after the last function argument and declare your utility function
-   with after the last declared argument.  Always refer to
-   the globals in your function as XSL_G(variable).  You are
-   encouraged to rename these macros something shorter, see
-   examples in any other php module directory.
-*/
-
 #ifdef ZTS
 #define XSL_G(v) TSRMG(xsl_globals_id, zend_xsl_globals *, v)
 #else

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1506,7 +1506,7 @@ static ZIPARCHIVE_METHOD(close)
 	ze_obj = Z_ZIP_P(self);
 
 	if ((err = zip_close(intern))) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s", zip_strerror(intern));
+		php_error_docref(NULL, E_WARNING, "%s", zip_strerror(intern));
 		zip_discard(intern);
 	}
 


### PR DESCRIPTION
Cleanup TSRMLS_D, TSRMLS_DC, TSRMLS_C, TSRMLS_CC and TSRMLS_FETCH leftovers in docs and code. Only the defines in TSRM/TSRM.h are kept for BC.