### PR TITLE
Explicitly set the Unix socket permission bits

### DIFF
--- a/sapi/fpm/fpm/fpm_unix.c
+++ b/sapi/fpm/fpm/fpm_unix.c
@@ -239,6 +239,10 @@ int fpm_unix_set_socket_premissions(struct fpm_worker_pool_s *wp, const char *pa
 			return -1;
 		}
 	}
+	if (0 > chmod(path, wp->socket_mode)) {
+			zlog(ZLOG_SYSERROR, "[pool %s] failed to chmod() the socket '%s'", wp->config->name, wp->config->listen_address);
+			return -1;
+	}	
 	return 0;
 }
 /* }}} */


### PR DESCRIPTION
Chmod the socket file to guarantee it matches the listen.mode of the configuration of the pool. 
On filesystems that extend the basic Unix permissions, e.g. POSIX acl,  setting a matching umask
on creation of the socket file is not enough to guarantee correctly realized permissions
as given in the listen.mode directive of the pool.
