### PR TITLE
Logging to syslog with dynamic error levels (related to #49467 and #66413)

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4712,7 +4712,7 @@ PHPAPI int _php_error_log_ex(int opt_err, char *message, size_t message_len, cha
 			break;
 
 		default:
-			php_log_err(message);
+			php_log_err(message, LOG_NOTICE);
 			break;
 	}
 	return SUCCESS;

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4712,7 +4712,7 @@ PHPAPI int _php_error_log_ex(int opt_err, char *message, size_t message_len, cha
 			break;
 
 		default:
-			php_log_err(message, LOG_NOTICE);
+			php_log_err_with_severity(message, LOG_NOTICE);
 			break;
 	}
 	return SUCCESS;

--- a/main/main.c
+++ b/main/main.c
@@ -607,9 +607,9 @@ PHPAPI int php_get_module_initialized(void)
 }
 /* }}} */
 
-/* {{{ php_log_err
+/* {{{ php_log_err_with_severity
  */
-PHPAPI ZEND_COLD void php_log_err(char *log_message, int syslog_type_int)
+PHPAPI ZEND_COLD void php_log_err_with_severity(char *log_message, int syslog_type_int)
 {
 	int fd = -1;
 	time_t error_time;
@@ -1088,7 +1088,7 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 			}
 #endif
 			spprintf(&log_buffer, 0, "PHP %s:  %s in %s on line %d", error_type_str, buffer, error_filename, error_lineno);
-			php_log_err(log_buffer, syslog_type_int);
+			php_log_err_with_severity(log_buffer, syslog_type_int);
 			efree(log_buffer);
 		}
 

--- a/main/main.c
+++ b/main/main.c
@@ -609,7 +609,7 @@ PHPAPI int php_get_module_initialized(void)
 
 /* {{{ php_log_err
  */
-PHPAPI ZEND_COLD void php_log_err(char *log_message)
+PHPAPI ZEND_COLD void php_log_err(char *log_message, int syslog_type_int)
 {
 	int fd = -1;
 	time_t error_time;
@@ -624,7 +624,7 @@ PHPAPI ZEND_COLD void php_log_err(char *log_message)
 	if (PG(error_log) != NULL) {
 #ifdef HAVE_SYSLOG_H
 		if (!strcmp(PG(error_log), "syslog")) {
-			php_syslog(LOG_NOTICE, "%s", log_message);
+			php_syslog(syslog_type_int, "%s", log_message);
 			PG(in_error_log) = 0;
 			return;
 		}
@@ -1036,6 +1036,7 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 	if (display && (EG(error_reporting) & type || (type & E_CORE))
 		&& (PG(log_errors) || PG(display_errors) || (!module_initialized))) {
 		char *error_type_str;
+		int syslog_type_int = LOG_NOTICE;
 
 		switch (type) {
 			case E_ERROR:
@@ -1043,29 +1044,36 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 			case E_COMPILE_ERROR:
 			case E_USER_ERROR:
 				error_type_str = "Fatal error";
+				syslog_type_int = LOG_ERR;
 				break;
 			case E_RECOVERABLE_ERROR:
 				error_type_str = "Catchable fatal error";
+				syslog_type_int = LOG_ERR;
 				break;
 			case E_WARNING:
 			case E_CORE_WARNING:
 			case E_COMPILE_WARNING:
 			case E_USER_WARNING:
 				error_type_str = "Warning";
+				syslog_type_int = LOG_WARNING;
 				break;
 			case E_PARSE:
 				error_type_str = "Parse error";
+				syslog_type_int = LOG_EMERG;
 				break;
 			case E_NOTICE:
 			case E_USER_NOTICE:
 				error_type_str = "Notice";
+				syslog_type_int = LOG_NOTICE;
 				break;
 			case E_STRICT:
 				error_type_str = "Strict Standards";
+				syslog_type_int = LOG_INFO;
 				break;
 			case E_DEPRECATED:
 			case E_USER_DEPRECATED:
 				error_type_str = "Deprecated";
+				syslog_type_int = LOG_INFO;
 				break;
 			default:
 				error_type_str = "Unknown error";
@@ -1080,7 +1088,7 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 			}
 #endif
 			spprintf(&log_buffer, 0, "PHP %s:  %s in %s on line %d", error_type_str, buffer, error_filename, error_lineno);
-			php_log_err(log_buffer);
+			php_log_err(log_buffer, syslog_type_int);
 			efree(log_buffer);
 		}
 

--- a/main/php.h
+++ b/main/php.h
@@ -280,7 +280,7 @@ PHPAPI size_t php_write(void *buf, size_t size);
 PHPAPI size_t php_printf(const char *format, ...) PHP_ATTRIBUTE_FORMAT(printf, 1,
 		2);
 PHPAPI int php_get_module_initialized(void);
-PHPAPI ZEND_COLD void php_log_err(char *log_message);
+PHPAPI ZEND_COLD void php_log_err(char *log_message, int syslog_type_int);
 int Debug(char *format, ...) PHP_ATTRIBUTE_FORMAT(printf, 1, 2);
 int cfgparse(void);
 END_EXTERN_C()

--- a/main/php.h
+++ b/main/php.h
@@ -280,7 +280,8 @@ PHPAPI size_t php_write(void *buf, size_t size);
 PHPAPI size_t php_printf(const char *format, ...) PHP_ATTRIBUTE_FORMAT(printf, 1,
 		2);
 PHPAPI int php_get_module_initialized(void);
-PHPAPI ZEND_COLD void php_log_err(char *log_message, int syslog_type_int);
+#define php_log_err(msg) php_log_err_with_serevity(msg, LOG_NOTICE)
+PHPAPI ZEND_COLD void php_log_err_with_severity(char *log_message, int syslog_type_int);
 int Debug(char *format, ...) PHP_ATTRIBUTE_FORMAT(printf, 1, 2);
 int cfgparse(void);
 END_EXTERN_C()


### PR DESCRIPTION
Hi,

There are couple of requests in bugs.php.net:
https://bugs.php.net/bug.php?id=66413 (Setting for default syslog facility)
https://bugs.php.net/bug.php?id=49467 (Errors are logged to syslog using LOG_NOTICE instead of LOG_ERR)

Both which has good idea, but why would we log all the errors with the same level as we have errors, warnings, etc.

This adds ability to have different log levels in syslog when error_log = syslog is set, so that different errors can be handled differently in syslogs and logging management services as graylog.

