### PR TITLE
Fix bug #71269

### DIFF
--- a/sapi/fpm/fpm/fpm_signals.c
+++ b/sapi/fpm/fpm/fpm_signals.c
@@ -241,6 +241,10 @@ int fpm_signals_init_child() /* {{{ */
 		zlog(ZLOG_SYSERROR, "failed to init child signals: sigaction()");
 		return -1;
 	}
+
+#ifdef ZEND_SIGNALS
+	zend_signal_init();
+#endif
 	return 0;
 }
 /* }}} */


### PR DESCRIPTION
When an fpm child handles more than one request, zend_signal_startup() will override the saved signal handlers with the internal zend handlers set from the previous request, causing a SIGQUIT signal to result in a core dump rather than gracefully exiting (the expected behaviour).

This is fixed by adding a call to zend_signal_init() after setting the signal handlers in the child. The same technique is used in the apache SAPI module in commit fd5a756ad44124ffa7e9a5810a31ff49e91708cf which addresses bug #61083.