### PR TITLE
Fixed Bug #71038 session_start() returns TRUE on failure

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -87,6 +87,7 @@ zend_class_entry *php_session_id_iface_entry;
 	}
 
 static void php_session_send_cookie(TSRMLS_D);
+static void php_session_abort(TSRMLS_D);
 
 /* Dispatched by RINIT and by php_session_destroy */
 static inline void php_rinit_session_globals(TSRMLS_D) /* {{{ */
@@ -495,13 +496,17 @@ static void php_session_initialize(TSRMLS_D) /* {{{ */
 	char *val = NULL;
 	int vallen;
 
+	PS(session_status) = php_session_active;
+
 	if (!PS(mod)) {
+		PS(session_status) = php_session_disabled;
 		php_error_docref(NULL TSRMLS_CC, E_ERROR, "No storage module chosen - failed to initialize session");
 		return;
 	}
 
 	/* Open session handler first */
 	if (PS(mod)->s_open(&PS(mod_data), PS(save_path), PS(session_name) TSRMLS_CC) == FAILURE) {
+		php_session_abort(TSRMLS_C);
 		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Failed to initialize storage module: %s (path: %s)", PS(mod)->s_name, PS(save_path));
 		return;
 	}
@@ -510,6 +515,7 @@ static void php_session_initialize(TSRMLS_D) /* {{{ */
 	if (!PS(id)) {
 		PS(id) = PS(mod)->s_create_sid(&PS(mod_data), NULL TSRMLS_CC);
 		if (!PS(id)) {
+			php_session_abort(TSRMLS_C);
 			php_error_docref(NULL TSRMLS_CC, E_ERROR, "Failed to create session ID: %s (path: %s)", PS(mod)->s_name, PS(save_path));
 			return;
 		}
@@ -521,7 +527,6 @@ static void php_session_initialize(TSRMLS_D) /* {{{ */
 	/* Set session ID for compatibility for older/3rd party save handlers */
 	if (!PS(use_strict_mode)) {
 		php_session_reset_id(TSRMLS_C);
-		PS(session_status) = php_session_active;
 	}
 
 	/* GC must be done before read */
@@ -530,14 +535,14 @@ static void php_session_initialize(TSRMLS_D) /* {{{ */
 	/* Read data */
 	php_session_track_init(TSRMLS_C);
 	if (PS(mod)->s_read(&PS(mod_data), PS(id), &val, &vallen TSRMLS_CC) == FAILURE) {
+		php_session_abort(TSRMLS_C);
 		/* Some broken save handler implementation returns FAILURE for non-existent session ID */
 		/* It's better to raise error for this, but disabled error for better compatibility */
-		/*
-		php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Failed to read session data: %s (path: %s)", PS(mod)->s_name, PS(save_path));
-		*/
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to read session data: %s (path: %s)", PS(mod)->s_name, PS(save_path));
+		return;
 	}
 	/* Set session ID if session read didn't activated session */
-	if (PS(use_strict_mode) && PS(session_status) != php_session_active) {
+	if (PS(use_strict_mode) && PS(session_status) == php_session_none) {
 		php_session_reset_id(TSRMLS_C);
 		PS(session_status) = php_session_active;
 	}
@@ -1280,11 +1285,13 @@ static int php_session_cache_limiter(TSRMLS_D) /* {{{ */
 	php_session_cache_limiter_t *lim;
 
 	if (PS(cache_limiter)[0] == '\0') return 0;
+	if (PS(session_status) != php_session_active) return -1;
 
 	if (SG(headers_sent)) {
 		const char *output_start_filename = php_output_get_start_filename(TSRMLS_C);
 		int output_start_lineno = php_output_get_start_lineno(TSRMLS_C);
 
+		PS(session_status) = php_session_none;
 		if (output_start_filename) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot send session cache limiter - headers already sent (output started at %s:%d)", output_start_filename, output_start_lineno);
 		} else {

--- a/ext/session/tests/016.phpt
+++ b/ext/session/tests/016.phpt
@@ -16,11 +16,12 @@ session.serialize_handler=php
 <?php
 error_reporting(E_ALL);
 
-session_start();
+var_dump(session_start());
 $HTTP_SESSION_VARS["test"] = 1;
 session_write_close();
 print "I live\n";
 ?>
 --EXPECTF--
-Warning: session_write_close(): Failed to write session data (files). Please verify that the current setting of session.save_path is correct (123;:/really%scompletely:::/invalid;;,23123;213) in %s on line %d
+Warning: session_start(): Failed to read session data: files (path: 123;:/really\completely:::/invalid;;,23123;213) in %s on line 4
+bool(false)
 I live

--- a/ext/session/tests/bug61728.phpt
+++ b/ext/session/tests/bug61728.phpt
@@ -8,32 +8,34 @@ function output_html($ext) {
     return strlen($ext);
 }
 
-function open ($save_path, $session_name) { 
+function open ($save_path, $session_name) {
     return true;
-} 
+}
 
-function close() { 
+function close() {
     return true;
-} 
+}
 
-function read ($id) { 
-} 
+function read ($id) {
+    return '';
+}
 
-function write ($id, $sess_data) { 
+function write ($id, $sess_data) {
     ob_start("output_html");
     echo "laruence";
     ob_end_flush();
     return true;
-} 
+}
 
-function destroy ($id) { 
-} 
+function destroy ($id) {
+    return true;
+}
 
-function gc ($maxlifetime) { 
-    return true; 
-} 
+function gc ($maxlifetime) {
+    return true;
+}
 
-session_set_save_handler ("open", "close", "read", "write", "destroy", "gc"); 
+session_set_save_handler ("open", "close", "read", "write", "destroy", "gc");
 session_start();
 --EXPECTF--
 8

--- a/ext/session/tests/rfc1867_sid_invalid.phpt
+++ b/ext/session/tests/rfc1867_sid_invalid.phpt
@@ -47,13 +47,13 @@ session_destroy();
 --EXPECTF--
 Warning: Unknown: The session id is too long or contains illegal characters, valid characters are a-z, A-Z, 0-9 and '-,' in Unknown on line 0
 
-Warning: Unknown: The session id is too long or contains illegal characters, valid characters are a-z, A-Z, 0-9 and '-,' in Unknown on line 0
+Warning: Unknown: Failed to read session data: files (%s) in Unknown on line 0
 
 Warning: Unknown: Failed to write session data (files). Please verify that the current setting of session.save_path is correct () in Unknown on line 0
 
 Warning: Unknown: The session id is too long or contains illegal characters, valid characters are a-z, A-Z, 0-9 and '-,' in Unknown on line 0
 
-Warning: Unknown: The session id is too long or contains illegal characters, valid characters are a-z, A-Z, 0-9 and '-,' in Unknown on line 0
+Warning: Unknown: Failed to read session data: files (%s) in Unknown on line 0
 
 Warning: Unknown: Failed to write session data (files). Please verify that the current setting of session.save_path is correct () in Unknown on line 0
 string(%d) "%s"

--- a/ext/session/tests/session_module_name_variation3.phpt
+++ b/ext/session/tests/session_module_name_variation3.phpt
@@ -21,11 +21,11 @@ function open($save_path, $session_name) {
     throw new Exception("Stop...!");
 }
 
-function close() { }
-function read($id) { }
-function write($id, $session_data) { }
-function destroy($id) { }
-function gc($maxlifetime) { }
+function close() { return true; }
+function read($id) { return ''; }
+function write($id, $session_data) { return true; }
+function destroy($id) { return true; }
+function gc($maxlifetime) { return 0; }
 
 var_dump(session_module_name("files"));
 session_set_save_handler("open", "close", "read", "write", "destroy", "gc");
@@ -40,6 +40,8 @@ ob_end_flush();
 *** Testing session_module_name() : variation ***
 string(%d) "%s"
 string(4) "user"
+
+Warning: session_start(): Failed to read session data: user (%s) in %s on line %d
 
 Fatal error: Uncaught exception 'Exception' with message 'Stop...!' in %s:%d
 Stack trace:

--- a/ext/session/tests/session_save_path_variation2.phpt
+++ b/ext/session/tests/session_save_path_variation2.phpt
@@ -33,8 +33,12 @@ ob_end_flush();
 string(5) "/blah"
 
 Warning: session_start(): open(%sblah%e%s, O_RDWR) failed: No such file or directory (2) in %s on line %d
-bool(true)
+
+Warning: session_start(): Failed to read session data: files (path: %sblah) in %s on line %d
+bool(false)
 string(5) "/blah"
-bool(true)
+
+Warning: session_destroy(): Trying to destroy uninitialized session in %s on line %d
+bool(false)
 string(5) "/blah"
 Done

--- a/ext/session/tests/session_save_path_variation3.phpt
+++ b/ext/session/tests/session_save_path_variation3.phpt
@@ -33,8 +33,12 @@ ob_end_flush();
 string(5) "/blah"
 
 Warning: session_start(): open(%s, O_RDWR) failed: No such file or directory (2) in %s on line %d
-bool(true)
+
+Warning: session_start(): Failed to read session data: files (path: %sblah) in %s on line %d
+bool(false)
 string(5) "/blah"
-bool(true)
+
+Warning: session_destroy(): Trying to destroy uninitialized session in %s on line %d
+bool(false)
 string(5) "/blah"
 Done

--- a/ext/session/tests/session_set_save_handler_class_002.phpt
+++ b/ext/session/tests/session_set_save_handler_class_002.phpt
@@ -34,7 +34,7 @@ class MySession2 extends SessionHandler {
 	}
 
 	public function read($id) {
-		return @file_get_contents($this->path . $id);
+		return (string)@file_get_contents($this->path . $id);
 	}
 
 	public function write($id, $data) {

--- a/ext/session/tests/session_set_save_handler_class_005.phpt
+++ b/ext/session/tests/session_set_save_handler_class_005.phpt
@@ -33,7 +33,7 @@ class MySession6 extends SessionHandler {
 
 $handler = new MySession6;
 session_set_save_handler($handler);
-session_start();
+var_dump(session_start());
 
 var_dump(session_id(), ini_get('session.save_handler'), $_SESSION);
 
@@ -45,11 +45,12 @@ session_unset();
 *** Testing session_set_save_handler() : incomplete implementation ***
 
 Warning: SessionHandler::read(): Parent session handler is not open in %ssession_set_save_handler_class_005.php on line %d
+
+Warning: SessionHandler::close(): Parent session handler is not open in %ssession_set_save_handler_class_005.php on line %d
+
+Warning: session_start(): Failed to read session data: user (%s) in %ssession_set_save_handler_class_005.php on line %d
+bool(false)
 string(%d) "%s"
 string(4) "user"
 array(0) {
 }
-
-Warning: SessionHandler::write(): Parent session handler is not open in %ssession_set_save_handler_class_005.php on line %d
-
-Warning: SessionHandler::close(): Parent session handler is not open in %ssession_set_save_handler_class_005.php on line %d

--- a/ext/session/tests/session_set_save_handler_class_012.phpt
+++ b/ext/session/tests/session_set_save_handler_class_012.phpt
@@ -36,7 +36,7 @@ class MySession extends SessionHandler {
 $oldHandler = ini_get('session.save_handler');
 $handler = new MySession;
 session_set_save_handler($handler);
-session_start();
+var_dump(session_start());
 
 var_dump(session_id(), $oldHandler, ini_get('session.save_handler'), $handler->i, $_SESSION);
 
@@ -48,13 +48,14 @@ Warning: SessionHandler::open() expects exactly 2 parameters, 0 given in %s on l
 Read %s
 
 Warning: SessionHandler::read(): Parent session handler is not open in %s on line %d
+
+Warning: SessionHandler::close(): Parent session handler is not open in %s on line %d
+
+Warning: session_start(): Failed to read session data: user (%s) in %s on line %d
+bool(false)
 string(%d) "%s"
 string(5) "files"
 string(4) "user"
 int(2)
 array(0) {
 }
-
-Warning: Unknown: Parent session handler is not open in Unknown on line 0
-
-Warning: Unknown: Parent session handler is not open in Unknown on line 0

--- a/ext/session/tests/session_set_save_handler_class_016.phpt
+++ b/ext/session/tests/session_set_save_handler_class_016.phpt
@@ -10,10 +10,10 @@ session.name=PHPSESSID
 
 ob_start();
 
-/* 
+/*
  * Prototype : bool session_set_save_handler(SessionHandlerInterface $handler [, bool $register_shutdown_function = true])
  * Description : Sets user-level session storage functions
- * Source code : ext/session/session.c 
+ * Source code : ext/session/session.c
  */
 
 echo "*** Testing session_set_save_handler() function: class with create_sid ***\n";
@@ -34,7 +34,7 @@ class MySession2 extends SessionHandler {
 	}
 
 	public function read($id) {
-		return @file_get_contents($this->path . $id);
+		return (string)@file_get_contents($this->path . $id);
 	}
 
 	public function write($id, $data) {

--- a/ext/session/tests/session_set_save_handler_class_017.phpt
+++ b/ext/session/tests/session_set_save_handler_class_017.phpt
@@ -34,7 +34,7 @@ class MySession2 extends SessionHandler {
 	}
 
 	public function read($id) {
-		return @file_get_contents($this->path . $id);
+		return (string)@file_get_contents($this->path . $id);
 	}
 
 	public function write($id, $data) {

--- a/ext/session/tests/session_set_save_handler_error3.phpt
+++ b/ext/session/tests/session_set_save_handler_error3.phpt
@@ -34,6 +34,8 @@ ob_end_flush();
 --EXPECTF--
 *** Testing session_set_save_handler() : error functionality ***
 
+Warning: session_start(): Failed to read session data: user (%s) in %s on line %d
+
 Fatal error: Uncaught exception 'Exception' with message 'Do something bad..!' in %s:%d
 Stack trace:
 #0 [internal function]: open('', 'PHPSESSID')

--- a/ext/session/tests/session_set_save_handler_error4.phpt
+++ b/ext/session/tests/session_set_save_handler_error4.phpt
@@ -24,7 +24,7 @@ session_set_save_handler("callback", "callback", "callback", "echo", "callback",
 session_set_save_handler("callback", "callback", "callback", "callback", "echo", "callback");
 session_set_save_handler("callback", "callback", "callback", "callback", "callback", "echo");
 session_set_save_handler("callback", "callback", "callback", "callback", "callback", "callback");
-session_start();
+var_dump(session_start());
 ob_end_flush();
 ?>
 --EXPECTF--
@@ -39,3 +39,6 @@ Warning: session_set_save_handler(): Argument 4 is not a valid callback in %s on
 Warning: session_set_save_handler(): Argument 5 is not a valid callback in %s on line %d
 
 Warning: session_set_save_handler(): Argument 6 is not a valid callback in %s on line %d
+
+Warning: session_start(): Failed to read session data: user (%s) in %s on line %d
+bool(false)

--- a/ext/session/tests/session_set_save_handler_iface_001.phpt
+++ b/ext/session/tests/session_set_save_handler_iface_001.phpt
@@ -34,7 +34,7 @@ class MySession2 implements SessionHandlerInterface {
 	}
 
 	public function read($id) {
-		return @file_get_contents($this->path . $id);
+		return (string)@file_get_contents($this->path . $id);
 	}
 
 	public function write($id, $data) {

--- a/ext/session/tests/session_set_save_handler_iface_002.phpt
+++ b/ext/session/tests/session_set_save_handler_iface_002.phpt
@@ -43,7 +43,7 @@ class MySession2 implements MySessionHandlerInterface {
 	}
 
 	public function read($id) {
-		return @file_get_contents($this->path . $id);
+		return (string)@file_get_contents($this->path . $id);
 	}
 
 	public function write($id, $data) {


### PR DESCRIPTION
Although I prefer maintaining FAILURE/SUCCESS status by return values, it's possible to use PS(session_status) to return proper status from session_start(). 

This patch fixes
https://bugs.php.net/bug.php?id=71038

The destructive part is 

```
@@ -530,14 +535,14 @@ static void php_session_initialize(TSRMLS_D) /* {{{ */
        /* Read data */
        php_session_track_init(TSRMLS_C);
        if (PS(mod)->s_read(&PS(mod_data), PS(id), &val, &vallen TSRMLS_CC) == FAILURE) {
+               php_session_abort(TSRMLS_C);
                /* Some broken save handler implementation returns FAILURE for non-existent session ID */
                /* It's better to raise error for this, but disabled error for better compatibility */
-               /*
-               php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Failed to read session data: %s (path: %s)", PS(mod)->s_name, PS(save_path));
-               */
+               php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to read session data: %s (path: %s)", PS(mod)->s_name, PS(save_path));
+               return;
        }
```

This breaks save handlers returns broken return value (false/FAILURE) for successful read. 
Note: Reading non-existing session data (new session ID data) must be SUCCESS because there is no error at all and must return true/SUCCESS.

This change is BC for PHP 5.6, but not for PHP7 since it does not allow broken return value from PS(mod)->s_read.

For user save handlers using file_get_contents(), the only required change is cast to string like test files.

```
diff --git a/ext/session/tests/session_set_save_handler_class_002.phpt b/ext/session/tests/session_set_save_handler_class_002.phpt
index 6fb831f..faf0adf 100644
--- a/ext/session/tests/session_set_save_handler_class_002.phpt
+++ b/ext/session/tests/session_set_save_handler_class_002.phpt
@@ -34,7 +34,7 @@ class MySession2 extends SessionHandler {
        }
 
        public function read($id) {
-               return @file_get_contents($this->path . $id);
+               return (string)@file_get_contents($this->path . $id);
        }
 
        public function write($id, $data) {
```

Question is if we should fix this bug in PHP 5.6 or not. 
Other possible option is ignore s_read() error at all in PHP 5.6 to be compatible.
If nobody cares, I would like to choose 2nd (ignore read errors) option for PHP 5.6.
Any comments?

Note: One fpm test fails, but it should be irrelevant.