### PR TITLE
Remove obj handlers ptr value from spl_object_hash() value generation

### DIFF
--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -777,7 +777,7 @@ PHPAPI zend_string *php_spl_object_hash(zval *obj) /* {{{*/
 	}
 
 	hash_handle   = SPL_G(hash_mask_handle)^(intptr_t)Z_OBJ_HANDLE_P(obj);
-	hash_handlers = SPL_G(hash_mask_handlers)^(intptr_t)Z_OBJ_HT_P(obj);
+	hash_handlers = SPL_G(hash_mask_handlers);
 
 	return strpprintf(32, "%016lx%016lx", hash_handle, hash_handlers);
 }


### PR DESCRIPTION
During [implementing weak references](https://github.com/pinepain/php-weak) I faced with a problem that after replacing object handlers spl_object_hash() value changes while it uses object handlers pointer to generate last 16 characters. While first part is a has from object handle which is unique during object lifetime and while mostly all objects handlers points to `std_object_handlers`, so dropping handlers pointer from hash will still produce hash string of the same length with the same guarantee that this generated value will during object lifetime.