### PR TITLE
Fixed header file include in readline_cli.c

### DIFF
--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -19,6 +19,10 @@
 
 /* $Id$ */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "php.h"
 
 #ifndef HAVE_RL_COMPLETION_MATCHES


### PR DESCRIPTION
This file should include header file of ```config.h```, Because this macro ```HAVE_LIBEDIT``` are defined in it.
Otherwise ```HAVE_LIBEDIT``` will always equals ```0```, This cause several bugs, for example:
when I have libedit compiled, It still using ```append_histroy()``` in here: [append_histroy](https://github.com/RustJason/php-src/blob/74993ffb99ba8450d6feefcb8ecb9bf965a3fc54/ext/readline/readline_cli.c#L664-L667)

```
➜  readline  php -a
Interactive mode enabled

xhgui - either extension xhprof or uprofiler must be loaded
php > echo "a";
php: symbol lookup error: /usr/local/php/php7.0.0/lib/php/extensions/no-debug-non-zts-20151012/readline.so: undefined symbol: append_history
```

At least this patch fixed my problem. 
Thanks.
