### PR TITLE
Remove comments restriction

### DIFF
--- a/CODING_STANDARDS
+++ b/CODING_STANDARDS
@@ -188,16 +188,7 @@ Internal Function Naming Convensions
 Syntax and indentation
 ----------------------
 
-1.  Never use C++ style comments (i.e. // comment).  Always use C-style
-    comments instead.  PHP is written in C, and is aimed at compiling
-    under any ANSI-C compliant compiler.  Even though many compilers
-    accept C++-style comments in C code, you have to ensure that your
-    code would compile with other compilers as well.
-    The only exception to this rule is code that is Win32-specific,
-    because the Win32 port is MS-Visual C++ specific, and this compiler
-    is known to accept C++-style comments in C code.
-
-2.  Use K&R-style.  Of course, we can't and don't want to
+1.  Use K&R-style.  Of course, we can't and don't want to
     force anybody to use a style he or she is not used to, but,
     at the very least, when you write code that goes into the core
     of PHP or one of its standard modules, please maintain the K&R
@@ -207,7 +198,7 @@ Syntax and indentation
 
     Indentstyle: http://www.catb.org/~esr/jargon/html/I/indent-style.html
 
-3.  Be generous with whitespace and braces.  Keep one empty line between the
+2.  Be generous with whitespace and braces.  Keep one empty line between the
     variable declaration section and the statements in a block, as well as
     between logical statement groups in a block.  Maintain at least one empty
     line between two functions, preferably two.  Always prefer::
@@ -220,11 +211,11 @@ Syntax and indentation
 
     if(foo)bar;
 
-4.  When indenting, use the tab character.  A tab is expected to represent
+3.  When indenting, use the tab character.  A tab is expected to represent
     four spaces.  It is important to maintain consistency in indenture so
     that definitions, comments, and control structures line up correctly.
 
-5.  Preprocessor statements (#if and such) MUST start at column one. To
+4.  Preprocessor statements (#if and such) MUST start at column one. To
     indent preprocessor directives you should put the # at the beginning
     of a line, followed by any number of whitespace.
 


### PR DESCRIPTION
Why not just do this? It's allowed since C99 and this restriction was added to the standards before C99. I'm pretty new to C and this confused me. Is a specific reason to keep this as a standard?