### PR TITLE
Fixes PHP bug 66331

### DIFF
--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -320,7 +320,8 @@ static zend_bool zend_do_perform_implementation_check(const zend_function *fe, c
 		}
 
 		/* by-ref constraints on arguments are invariant */
-		if (fe_arg_info->pass_by_reference != proto_arg_info->pass_by_reference) {
+		if ((!fe_arg_info->pass_by_reference && proto_arg_info->pass_by_reference)
+			|| (fe_arg_info->pass_by_reference && !proto_arg_info->pass_by_reference)) {
 			return 0;
 		}
 	}


### PR DESCRIPTION
At the moment userland classes cannot inherit from an extension class that is using ZEND_SEND_PREFER_REF instead of ZEND_SEND_REF.

This bug manifests in for example php-memcached-dev/php-memcached#126

I cannot figure out a good test to write for this issue because it requires an internal class.
