### PR TITLE
Added mandatory Date: header to built-in webserver - bug #71276

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -96,6 +96,7 @@
 #include "ext/standard/html.h"
 #include "ext/standard/url.h" /* for php_raw_url_decode() */
 #include "ext/standard/php_string.h" /* for php_dirname() */
+#include "ext/date/php_date.h" /* for php_format_date() */
 #include "php_network.h"
 
 #include "php_http_parser.h"
@@ -348,6 +349,13 @@ static void append_essential_headers(smart_str* buffer, php_cli_server_client *c
 			smart_str_appendl_ex(buffer, "\r\n", 2, persistent);
 		}
 	}
+	time_t t;
+	time(&t);
+	zend_string *dt = php_format_date("r", 1, t, 1);
+	smart_str_appendl_ex(buffer, "Date: ", 6, persistent);
+	smart_str_appends_ex(buffer, dt->val, persistent);
+	smart_str_appendl_ex(buffer, "\r\n", 2, persistent);
+
 	smart_str_appendl_ex(buffer, "Connection: close\r\n", sizeof("Connection: close\r\n") - 1, persistent);
 } /* }}} */
 

--- a/sapi/cli/tests/bug43177.phpt
+++ b/sapi/cli/tests/bug43177.phpt
@@ -61,6 +61,7 @@ HEADER
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: localhost
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8
@@ -68,18 +69,21 @@ Content-type: text/html; charset=UTF-8
 OK
 HTTP/1.0 500 Internal Server Error
 Host: localhost
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8
 
 HTTP/1.0 500 Internal Server Error
 Host: localhost
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8
 
 HTTP/1.0 500 Internal Server Error
 Host: localhost
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/bug65066_100.phpt
+++ b/sapi/cli/tests/bug65066_100.phpt
@@ -34,6 +34,7 @@ HEADER
 --EXPECTF--
 HTTP/1.1 100 Continue
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/bug65066_422.phpt
+++ b/sapi/cli/tests/bug65066_422.phpt
@@ -34,6 +34,7 @@ HEADER
 --EXPECTF--
 HTTP/1.1 422 Unknown Status Code
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/bug65066_511.phpt
+++ b/sapi/cli/tests/bug65066_511.phpt
@@ -34,6 +34,7 @@ HEADER
 --EXPECTF--
 HTTP/1.1 511 Network Authentication Required
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/bug65633.phpt
+++ b/sapi/cli/tests/bug65633.phpt
@@ -37,6 +37,7 @@ fclose($fp);
 ?>
 --EXPECTF--
 HTTP/1.1 200 OK
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/bug66606_2.phpt
+++ b/sapi/cli/tests/bug66606_2.phpt
@@ -38,6 +38,7 @@ fclose($fp);
 --EXPECTF--	
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/bug66830.phpt
+++ b/sapi/cli/tests/bug66830.phpt
@@ -37,6 +37,7 @@ fclose($fp);
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/bug67429.phpt
+++ b/sapi/cli/tests/bug67429.phpt
@@ -38,11 +38,13 @@ HEADER
 ?>
 --EXPECTF--
 HTTP/1.1 308 Permanent Redirect
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8
 
 HTTP/1.1 426 Upgrade Required
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/bug68745.phpt
+++ b/sapi/cli/tests/bug68745.phpt
@@ -27,6 +27,7 @@ fclose($fp);
 ?>
 --EXPECTF--
 HTTP/1.1 200 OK
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/bug71005.phpt
+++ b/sapi/cli/tests/bug71005.phpt
@@ -39,6 +39,7 @@ HEADER
 --EXPECTF--	
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_004.phpt
+++ b/sapi/cli/tests/php_cli_server_004.phpt
@@ -38,6 +38,7 @@ HEADER
 --EXPECTF--	
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_005.phpt
+++ b/sapi/cli/tests/php_cli_server_005.phpt
@@ -50,6 +50,7 @@ HEADER
 --EXPECTF--	
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_006.phpt
+++ b/sapi/cli/tests/php_cli_server_006.phpt
@@ -34,6 +34,7 @@ HEADER
 --EXPECTF--	
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_007.phpt
+++ b/sapi/cli/tests/php_cli_server_007.phpt
@@ -34,6 +34,7 @@ HEADER
 --EXPECTF--	
 HTTP/1.1 401 Unauthorized
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 WWW-Authenticate: Digest realm="foo",qop="auth",nonce="XXXXX",opaque="acbd18db4cc2f85cedef654fccc4a4d8"

--- a/sapi/cli/tests/php_cli_server_008.phpt
+++ b/sapi/cli/tests/php_cli_server_008.phpt
@@ -54,6 +54,7 @@ fclose($fp);
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8
@@ -61,6 +62,7 @@ Content-type: text/html; charset=UTF-8
 string(8) "HTTP/1.1"
 HTTP/1.0 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_009.phpt
+++ b/sapi/cli/tests/php_cli_server_009.phpt
@@ -78,6 +78,7 @@ fclose($fp);
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8
@@ -85,6 +86,7 @@ Content-type: text/html; charset=UTF-8
 string(8) "/foo/bar"
 HTTP/1.0 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_010.phpt
+++ b/sapi/cli/tests/php_cli_server_010.phpt
@@ -55,6 +55,7 @@ fclose($fp);
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8
@@ -65,6 +66,7 @@ string(8) "/foo/bar"
 string(7) "foo=bar"
 HTTP/1.0 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_012.phpt
+++ b/sapi/cli/tests/php_cli_server_012.phpt
@@ -40,6 +40,7 @@ fclose($fp);
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_013.phpt
+++ b/sapi/cli/tests/php_cli_server_013.phpt
@@ -83,6 +83,7 @@ fclose($fp);
 
 HTTP/1.1 404 Not Found
 Host: %s
+Date: %s
 Connection: close
 Content-Type: text/html; charset=UTF-8
 Content-Length: %d
@@ -91,6 +92,7 @@ Content-Length: %d
 </head><body><h1>Not Found</h1><p>The requested resource <code class="url">/</code> was not found on this server.</p></body></html>
 HTTP/1.1 404 Not Found
 Host: %s
+Date: %s
 Connection: close
 Content-Type: text/html; charset=UTF-8
 Content-Length: %d
@@ -99,6 +101,7 @@ Content-Length: %d
 </head><body><h1>Not Found</h1><p>The requested resource <code class="url">/main/style.css</code> was not found on this server.</p></body></html>
 HTTP/1.1 404 Not Found
 Host: %s
+Date: %s
 Connection: close
 Content-Type: text/html; charset=UTF-8
 Content-Length: %d

--- a/sapi/cli/tests/php_cli_server_014.phpt
+++ b/sapi/cli/tests/php_cli_server_014.phpt
@@ -65,6 +65,7 @@ fclose($fp);
 
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: %s
@@ -72,6 +73,7 @@ Content-type: %s
 done
 HTTP/1.1 404 Not Found
 Host: %s
+Date: %s
 Connection: close
 Content-Type: %s
 Content-Length: %d

--- a/sapi/cli/tests/php_cli_server_015.phpt
+++ b/sapi/cli/tests/php_cli_server_015.phpt
@@ -41,6 +41,7 @@ fclose($fp);
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_017.phpt
+++ b/sapi/cli/tests/php_cli_server_017.phpt
@@ -37,6 +37,7 @@ fclose($fp);
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_018.phpt
+++ b/sapi/cli/tests/php_cli_server_018.phpt
@@ -37,6 +37,7 @@ fclose($fp);
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: %s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/php_cli_server_019.phpt
+++ b/sapi/cli/tests/php_cli_server_019.phpt
@@ -41,6 +41,7 @@ fclose($fp);
 --EXPECTF--
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: %s
 Bar-Foo: Foo

--- a/sapi/cli/tests/php_cli_server_020.phpt
+++ b/sapi/cli/tests/php_cli_server_020.phpt
@@ -33,6 +33,7 @@ HEADER
 --EXPECTF--	
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8

--- a/sapi/cli/tests/upload_2G.phpt
+++ b/sapi/cli/tests/upload_2G.phpt
@@ -77,6 +77,7 @@ Test
 
 HTTP/1.1 200 OK
 Host: %s
+Date: %s
 Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8


### PR DESCRIPTION
As explained here: https://bugs.php.net/bug.php?id=71276

The Date: header is mandatory in a HTTP response.
This pull-requests adds it and fixes the various tests that were impacted as well.

Also, this doesn't touch the Host: header but this one should be removed in the future, as well.