### PR TITLE
Update php_dns.h - fixes memory leak.

### DIFF
--- a/ext/standard/php_dns.h
+++ b/ext/standard/php_dns.h
@@ -33,7 +33,7 @@
 #define php_dns_search(res, dname, class, type, answer, anslen) \
 			res_nsearch(res, dname, class, type, answer, anslen);
 #define php_dns_free_handle(res) \
-			res_nclose(res); \
+			res_ndestroy(res); \
 			php_dns_free_res(res)
 
 #elif defined(HAVE_RES_SEARCH)


### PR DESCRIPTION
You need to call res_ndestroy() to free memory, otherwise you will leak a file descriptor on NetBSD or leak memory on FreeBSD and other operating systems. Please see the resolver man page at: http://man.netbsd.org/cgi-bin/man-cgi?resolver++NetBSD-current
"res_ndestroy() should be called to free memory allocated by res_ninit() after last use.".
I found the bug on NetBSD 7.0 with php 7.0.2, but it also affects php 5.6.14 and probably previous versions.
Here is a test-script to reproduce the memory leak:
<?php
for ($i = 0; $i < 50000; $i++) {
        echo $i . ": ";
        var_dump(checkdnsrr("www.netbsd.org", "A"));
}
While running this script, have a look how the php process grows because of the memory leak.
