### PR TITLE
fix integer overflow in wordwrap

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -972,6 +972,11 @@ PHP_FUNCTION(wordwrap)
 		RETURN_FALSE;
 	}
 
+	if (ZSTR_LEN(text) > ULONG_MAX / (breakchar_len + 1) - 1) {
+		p_error_docref(NULL, E_WARNING, "Integer overflow is occurred");
+		RETURN_FALSE;
+	}
+
 	/* Special case for a single-character break as it needs no
 	   additional storage space */
 	if (breakchar_len == 1 && !docut) {

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -973,7 +973,7 @@ PHP_FUNCTION(wordwrap)
 	}
 
 	if (ZSTR_LEN(text) > ULONG_MAX / (breakchar_len + 1) - 1) {
-		p_error_docref(NULL, E_WARNING, "Integer overflow is occurred");
+		p_error_docref(NULL, E_WARNING, "Integer overflow has occurred");
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -973,7 +973,7 @@ PHP_FUNCTION(wordwrap)
 	}
 
 	if (ZSTR_LEN(text) > ULONG_MAX / (breakchar_len + 1) - 1) {
-		p_error_docref(NULL, E_WARNING, "Integer overflow has occurred");
+		php_error_docref(NULL, E_WARNING, "Integer overflow has occurred");
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
Since integer overflow can be occurred in wordwrap,
input text length needs to be checked.

This is PoC code which cause SEGFAULT in 32bit Ubuntu

<?php
  $text1 = str_repeat("A", 65536);
  $text2 = str_repeat("B", 65536 - 1);
  $newtext = wordwrap($text1, -1, $text2);
?>

[ 4835.338030] php[32661]: segfault at 41414149 ip 082f6b6a sp bfd33de0
error 4 in php[8048000+837000]