### PR TITLE
session_regenerate_id malfunctions with certain session handlers

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2097,15 +2097,18 @@ static PHP_FUNCTION(session_regenerate_id)
 		PS(session_vars) = NULL;
 	}
 	zend_string_release(PS(id));
+	PS(id) = NULL;
+
+	if (PS(mod)->s_open(&PS(mod_data), PS(save_path), PS(session_name)) == FAILURE) {
+		PS(session_status) = php_session_none;
+		php_error_docref(NULL, E_RECOVERABLE_ERROR, "Failed to create(open) session ID: %s (path: %s)", PS(mod)->s_name, PS(save_path));
+		RETURN_FALSE;
+	}
+
 	PS(id) = PS(mod)->s_create_sid(&PS(mod_data));
 	if (!PS(id)) {
 		PS(session_status) = php_session_none;
 		php_error_docref(NULL, E_RECOVERABLE_ERROR, "Failed to create new session ID: %s (path: %s)", PS(mod)->s_name, PS(save_path));
-		RETURN_FALSE;
-	}
-	if (PS(mod)->s_open(&PS(mod_data), PS(save_path), PS(session_name)) == FAILURE) {
-		PS(session_status) = php_session_none;
-		php_error_docref(NULL, E_RECOVERABLE_ERROR, "Failed to create(open) session ID: %s (path: %s)", PS(mod)->s_name, PS(save_path));
 		RETURN_FALSE;
 	}
 	if (PS(use_strict_mode) && PS(mod)->s_validate_sid &&


### PR DESCRIPTION
The current order of session_regenerate_id seems to be:

   - PS(mod)->s_close
   - PS(mod)-> s_create_sid
   - PS(mod)->s_open

This causes PS_CREATE_SID_FUNC to receive NULL data and it completely circumvents the original intention of PS_CREATE_SID_FUNC. (for example mod_files.c skips collision checks if data is NULL).

This doesn't seem to cause visible problems with built-in session handlers and not sure how to test this either.

t.php
```
<?php
ob_start();
ini_set ('session.save_path', '/tmp');

var_dump(session_start());
var_dump(session_regenerate_id(true));
?>
```

Relevant run on lldb:

````
lldb --file php -- t.php
(lldb) target create "/opt/php7/bin/php"
Current executable set to '/opt/php7/bin/php' (x86_64).
(lldb) settings set -- target.run-args  "t.php"
(lldb) breakpoint set --file mod_files.c --line 677
Breakpoint 1: where = php`ps_create_sid_files + 100 at mod_files.c:677, address = 0x00000001001cdc34
(lldb) run
Process 95005 launched: '/opt/php7/bin/php' (x86_64)
Process 95005 stopped
* thread #1: tid = 0x5b95ab, 0x00000001001cdc34 php`ps_create_sid_files(mod_data=0x0000000100d5bfe8) + 100 at mod_files.c:677, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x00000001001cdc34 php`ps_create_sid_files(mod_data=0x0000000100d5bfe8) + 100 at mod_files.c:677
   674 			}
   675 			/* Check collision */
   676 			/* FIXME: mod_data(data) should not be NULL (User handler could be NULL) */
-> 677 			if (data && ps_files_key_exists(data, ZSTR_VAL(sid)) == SUCCESS) {
   678 				if (sid) {
   679 					zend_string_release(sid);
   680 					sid = NULL;
(lldb) p data
(ps_files *) $0 = 0x00000001020810f0
(lldb) p *data
(ps_files) $1 = (lastkey = 0x0000000000000000, basedir = "/tmp", basedir_len = 4, dirdepth = 0, st_size = 0, filemode = 384, fd = -1)
(lldb) cont
Process 95005 resuming
Process 95005 stopped
* thread #1: tid = 0x5b95ab, 0x00000001001cdc34 php`ps_create_sid_files(mod_data=0x0000000100d5bfe8) + 100 at mod_files.c:677, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x00000001001cdc34 php`ps_create_sid_files(mod_data=0x0000000100d5bfe8) + 100 at mod_files.c:677
   674 			}
   675 			/* Check collision */
   676 			/* FIXME: mod_data(data) should not be NULL (User handler could be NULL) */
-> 677 			if (data && ps_files_key_exists(data, ZSTR_VAL(sid)) == SUCCESS) {
   678 				if (sid) {
   679 					zend_string_release(sid);
   680 					sid = NULL;
(lldb) p *data
error: Couldn't apply expression side effects : Couldn't dematerialize a result variable: couldn't read its memory
(lldb) p data
(ps_files *) $3 = 0x0000000000000000
```
  