### PR TITLE
Allow loading extensions by name

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 7.2.0alpha2
 
+- Core:
+  . Allow loading PHP/Zend extensions by name in ini files (extension=<name>).
+    (francois at tekwire dot net)
+
 - GD:
   . Fixed bug #74744 (gd.h: stdarg.h include missing for va_list use in
     gdErrorMethod). (rainer dot jung at kippdata dot de, cmb)
@@ -15,6 +19,8 @@ PHP                                                                        NEWS
 - Standard
   . Compatibility with libargon2 versions 20161029 and 20160821.
     (charlesportwoodii at erianna dot com)
+  . Add support for extension name as argument to dl().
+    (francois at tekwire dot net)
 
 - Streams
   . Default ssl/single_dh_use and ssl/honor_cipher_order to true.

--- a/ext/standard/dl.c
+++ b/ext/standard/dl.c
@@ -81,10 +81,10 @@ PHPAPI PHP_FUNCTION(dl)
 PHPAPI int php_load_extension(char *filename, int type, int start_now)
 {
 	void *handle;
-	char *libpath;
+	char *libpath, *orig_libpath;
 	zend_module_entry *module_entry;
 	zend_module_entry *(*get_module)(void);
-	int error_type;
+	int error_type, slash_suffix;
 	char *extension_dir;
 
 	if (type == MODULE_PERSISTENT) {
@@ -109,11 +109,36 @@ PHPAPI int php_load_extension(char *filename, int type, int start_now)
 		libpath = estrdup(filename);
 	} else if (extension_dir && extension_dir[0]) {
 		int extension_dir_len = (int)strlen(extension_dir);
-
-		if (IS_SLASH(extension_dir[extension_dir_len-1])) {
+		slash_suffix = IS_SLASH(extension_dir[extension_dir_len-1]);
+		/* Try as filename first */
+		if (slash_suffix) {
 			spprintf(&libpath, 0, "%s%s", extension_dir, filename); /* SAFE */
 		} else {
 			spprintf(&libpath, 0, "%s%c%s", extension_dir, DEFAULT_SLASH, filename); /* SAFE */
+		}
+		if (VCWD_ACCESS(libpath, F_OK)) {
+			/* If file does not exist, consider as extension name and build file name */
+			orig_libpath = libpath;
+#if PHP_WIN32
+			if (slash_suffix) {
+				spprintf(&libpath, 0, "%sphp_%s." PHP_SHLIB_SUFFIX, extension_dir, filename); /* SAFE */
+			} else {
+				spprintf(&libpath, 0, "%s%cphp_%s." PHP_SHLIB_SUFFIX, extension_dir, DEFAULT_SLASH, filename); /* SAFE */
+			}
+#else
+			if (slash_suffix) {
+				spprintf(&libpath, 0, "%s%s." PHP_SHLIB_SUFFIX, extension_dir, filename); /* SAFE */
+			} else {
+				spprintf(&libpath, 0, "%s%c%s." PHP_SHLIB_SUFFIX, extension_dir, DEFAULT_SLASH, filename); /* SAFE */
+			}
+#endif
+			if (VCWD_ACCESS(libpath, F_OK)) {
+				php_error_docref(NULL TSRMLS_CC, error_type, "Cannot access dynamic library '%s' (tried : %s, %s)", filename, orig_libpath, libpath);
+				efree(orig_libpath);
+				efree(libpath);
+				return FAILURE;
+			}
+			efree(orig_libpath);
 		}
 	} else {
 		return FAILURE; /* Not full path given or extension_dir is not set */

--- a/php.ini-development
+++ b/php.ini-development
@@ -860,64 +860,63 @@ default_socket_timeout = 60
 ; If you wish to have an extension loaded automatically, use the following
 ; syntax:
 ;
-;   extension=modulename.extension
+;   extension=modulename
 ;
-; For example, on Windows:
+; For example:
 ;
-;   extension=mysqli.dll
-;
-; ... or under UNIX:
-;
-;   extension=mysqli.so
-;
-; ... or with a path:
+;   extension=mysqli
+; 
+; When the extension library to load is not located in the default extension
+; directory, You may specify an absolute path to the library file:
 ;
 ;   extension=/path/to/extension/mysqli.so
 ;
-; If you only provide the name of the extension, PHP will look for it in its
-; default extension directory.
+; Note : The syntax used in previous PHP versions ('extension=<ext>.so' and
+; 'extension='php_<ext>.dll') is supported for legacy reasons and may be
+; deprecated in a future PHP major version. So, when it is possible, please
+; move to the new ('extension=<ext>) syntax.
 ;
-; Windows Extensions
-; Note that ODBC support is built in, so no dll is needed for it.
-; Note that many DLL files are located in the extensions/ (PHP 4) ext/ (PHP 5+)
-; extension folders as well as the separate PECL DLL download (PHP 5+).
-; Be sure to appropriately set the extension_dir directive.
+; Notes for Windows environments :
 ;
-;extension=php_bz2.dll
-;extension=php_curl.dll
-;extension=php_fileinfo.dll
-;extension=php_ftp.dll
-;extension=php_gd2.dll
-;extension=php_gettext.dll
-;extension=php_gmp.dll
-;extension=php_intl.dll
-;extension=php_imap.dll
-;extension=php_interbase.dll
-;extension=php_ldap.dll
-;extension=php_mbstring.dll
-;extension=php_exif.dll      ; Must be after mbstring as it depends on it
-;extension=php_mysqli.dll
-;extension=php_oci8_12c.dll  ; Use with Oracle Database 12c Instant Client
-;extension=php_openssl.dll
-;extension=php_pdo_firebird.dll
-;extension=php_pdo_mysql.dll
-;extension=php_pdo_oci.dll
-;extension=php_pdo_odbc.dll
-;extension=php_pdo_pgsql.dll
-;extension=php_pdo_sqlite.dll
-;extension=php_pgsql.dll
-;extension=php_shmop.dll
+; - ODBC support is built in, so no dll is needed for it.
+; - Many DLL files are located in the extensions/ (PHP 4) or ext/ (PHP 5+)
+;   extension folders as well as the separate PECL DLL download (PHP 5+).
+;   Be sure to appropriately set the extension_dir directive.
+;
+;extension=bz2
+;extension=curl
+;extension=fileinfo
+;extension=gd2
+;extension=gettext
+;extension=gmp
+;extension=intl
+;extension=imap
+;extension=interbase
+;extension=ldap
+;extension=mbstring
+;extension=exif      ; Must be after mbstring as it depends on it
+;extension=mysqli
+;extension=oci8_12c  ; Use with Oracle Database 12c Instant Client
+;extension=openssl
+;extension=pdo_firebird
+;extension=pdo_mysql
+;extension=pdo_oci
+;extension=pdo_odbc
+;extension=pdo_pgsql
+;extension=pdo_sqlite
+;extension=pgsql
+;extension=shmop
 
 ; The MIBS data available in the PHP distribution must be installed.
 ; See http://www.php.net/manual/en/snmp.installation.php
-;extension=php_snmp.dll
+;extension=snmp
 
-;extension=php_soap.dll
-;extension=php_sockets.dll
-;extension=php_sqlite3.dll
-;extension=php_tidy.dll
-;extension=php_xmlrpc.dll
-;extension=php_xsl.dll
+;extension=soap
+;extension=sockets
+;extension=sqlite3
+;extension=tidy
+;extension=xmlrpc
+;extension=xsl
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;

--- a/php.ini-production
+++ b/php.ini-production
@@ -867,64 +867,63 @@ default_socket_timeout = 60
 ; If you wish to have an extension loaded automatically, use the following
 ; syntax:
 ;
-;   extension=modulename.extension
+;   extension=modulename
 ;
-; For example, on Windows:
+; For example:
 ;
-;   extension=mysqli.dll
-;
-; ... or under UNIX:
-;
-;   extension=mysqli.so
-;
-; ... or with a path:
+;   extension=mysqli
+; 
+; When the extension library to load is not located in the default extension
+; directory, You may specify an absolute path to the library file:
 ;
 ;   extension=/path/to/extension/mysqli.so
 ;
-; If you only provide the name of the extension, PHP will look for it in its
-; default extension directory.
+; Note : The syntax used in previous PHP versions ('extension=<ext>.so' and
+; 'extension='php_<ext>.dll') is supported for legacy reasons and may be
+; deprecated in a future PHP major version. So, when it is possible, please
+; move to the new ('extension=<ext>) syntax.
 ;
-; Windows Extensions
-; Note that ODBC support is built in, so no dll is needed for it.
-; Note that many DLL files are located in the extensions/ (PHP 4) ext/ (PHP 5+)
-; extension folders as well as the separate PECL DLL download (PHP 5+).
-; Be sure to appropriately set the extension_dir directive.
+; Notes for Windows environments :
 ;
-;extension=php_bz2.dll
-;extension=php_curl.dll
-;extension=php_fileinfo.dll
-;extension=php_ftp.dll
-;extension=php_gd2.dll
-;extension=php_gettext.dll
-;extension=php_gmp.dll
-;extension=php_intl.dll
-;extension=php_imap.dll
-;extension=php_interbase.dll
-;extension=php_ldap.dll
-;extension=php_mbstring.dll
-;extension=php_exif.dll      ; Must be after mbstring as it depends on it
-;extension=php_mysqli.dll
-;extension=php_oci8_12c.dll  ; Use with Oracle Database 12c Instant Client
-;extension=php_openssl.dll
-;extension=php_pdo_firebird.dll
-;extension=php_pdo_mysql.dll
-;extension=php_pdo_oci.dll
-;extension=php_pdo_odbc.dll
-;extension=php_pdo_pgsql.dll
-;extension=php_pdo_sqlite.dll
-;extension=php_pgsql.dll
-;extension=php_shmop.dll
+; - ODBC support is built in, so no dll is needed for it.
+; - Many DLL files are located in the extensions/ (PHP 4) or ext/ (PHP 5+)
+;   extension folders as well as the separate PECL DLL download (PHP 5+).
+;   Be sure to appropriately set the extension_dir directive.
+;
+;extension=bz2
+;extension=curl
+;extension=fileinfo
+;extension=gd2
+;extension=gettext
+;extension=gmp
+;extension=intl
+;extension=imap
+;extension=interbase
+;extension=ldap
+;extension=mbstring
+;extension=exif      ; Must be after mbstring as it depends on it
+;extension=mysqli
+;extension=oci8_12c  ; Use with Oracle Database 12c Instant Client
+;extension=openssl
+;extension=pdo_firebird
+;extension=pdo_mysql
+;extension=pdo_oci
+;extension=pdo_odbc
+;extension=pdo_pgsql
+;extension=pdo_sqlite
+;extension=pgsql
+;extension=shmop
 
 ; The MIBS data available in the PHP distribution must be installed.
 ; See http://www.php.net/manual/en/snmp.installation.php
-;extension=php_snmp.dll
+;extension=snmp
 
-;extension=php_soap.dll
-;extension=php_sockets.dll
-;extension=php_sqlite3.dll
-;extension=php_tidy.dll
-;extension=php_xmlrpc.dll
-;extension=php_xsl.dll
+;extension=soap
+;extension=sockets
+;extension=sqlite3
+;extension=tidy
+;extension=xmlrpc
+;extension=xsl
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;


### PR DESCRIPTION
Status : RFC is approved for inclusion in 7.2

---

This PR provides a portable way to configure the list of PHP extensions to load.

Today, 'extension=' lines in php.ini must contain the extension's file name. Unfortunately, this file name depends on the platform PHP is running on. A 'php_' prefix must even be added on Windows.

While seasoned PHP administrators are used to this mechanism, this is a problem when writing documentation for beginners, or when writing platform-agnostic scripts. A typical example is the coexistence of a Windows development environment and a Linux production. In such cases, it is impossible to write a single configuration file that will work in both environments, forcing developers to manually maintain two separate versions of the file.

This PR allows to specify extensions (PHP and Zend) by their extension name.

Example : 

```
extension=bz2
zend_extension=xdebug
```

'extension=bz2', for example, will cause PHP to load a file named 'php_bz2.dll' on Windows, and a file named 'bz2.so' on LInux.

Note that filenames are still accepted and handled as before. So, this extension does not cause any BC break.

Example php.ini files are modified because loading extensions by name becomes the recommended way of configuring additional extensions to load.

Cases where the extension name is accepted : 
- 'extension=' INI setting
- 'zend_extension=' INI setting
- argument to the _dl()_ function

Cases where the extension name cannot be used : 
- The '-z' command line option still requires an absolute file path.
- When specifying an absolute path, a filename must be provided. A path like '/path/to/extensions/bz2' is invalid

---

References:
- [An article I wrote on the same subject](http://tekwire.net/joomla/projects/ideas/php-load-ext-by-name)
