### PR TITLE
phpdbg config.m4: make it detectable by old shells

### DIFF
--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -11,7 +11,7 @@ PHP_ARG_ENABLE(phpdbg-webhelper, for phpdbg web SAPI support,
 PHP_ARG_ENABLE(phpdbg-debug, for phpdbg debug build,
 [  --enable-phpdbg-debug      Build phpdbg in debug mode], no, no)
 
-if test "$BUILD_PHPDBG" == "" && test "$PHP_PHPDBG" != "no"; then
+if test "$BUILD_PHPDBG" = "" && test "$PHP_PHPDBG" != "no"; then
   AC_HEADER_TIOCGWINSZ
   AC_DEFINE(HAVE_PHPDBG, 1, [ ])
 


### PR DESCRIPTION
--enable-phpdbg is not detected on old systems (e.g.: stock FreeBSD 8), due to a PHPism in config.m4 (use of == operator).
Replacing == with the historic = makes it pass.