### PR TITLE
opcache config.m4: two HAVE_… defines not set

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -14,11 +14,11 @@ PHP_ARG_ENABLE(huge-code-pages, whether to enable copying PHP CODE pages into HU
 
 if test "$PHP_OPCACHE" != "no"; then
 
-  if test "$PHP_OPCACHE_FILE" == "yes"; then
+  if test "$PHP_OPCACHE_FILE" = "yes"; then
     AC_DEFINE(HAVE_OPCACHE_FILE_CACHE, 1, [Define to enable file based caching (experimental)])
   fi
 
-  if test "$PHP_HUGE_CODE_PAGES" == "yes"; then
+  if test "$PHP_HUGE_CODE_PAGES" = "yes"; then
     AC_DEFINE(HAVE_HUGE_CODE_PAGES, 1, [Define to enable copying PHP CODE pages into HUGE PAGES (experimental)])
   fi
 


### PR DESCRIPTION
HAVE_OPCACHE_FILE_CACHE and HAVE_HUGE_CODE_PAGES where not correctly set on old systems (e.g. FreeBSD 8), due to a PHPism in config.m4.
Using the standard shell operator = instead of == make the configure script produce the correct output.