### PR TITLE
Consistent use of fixed size integer types

### DIFF
--- a/ext/hash/hash_adler32.c
+++ b/ext/hash/hash_adler32.c
@@ -29,7 +29,7 @@ PHP_HASH_API void PHP_ADLER32Init(PHP_ADLER32_CTX *context)
 
 PHP_HASH_API void PHP_ADLER32Update(PHP_ADLER32_CTX *context, const unsigned char *input, size_t len)
 {
-	php_hash_uint32 i, s[2];
+	uint32_t i, s[2];
 
 	s[0] = context->state & 0xffff;
 	s[1] = (context->state >> 16) & 0xffff;

--- a/ext/hash/hash_fnv.c
+++ b/ext/hash/hash_fnv.c
@@ -147,8 +147,8 @@ PHP_HASH_API void PHP_FNV164Final(unsigned char digest[8], PHP_FNV164_CTX * cont
  * returns:
  *  32 bit hash as a static hash type
  */
-static php_hash_uint32
-fnv_32_buf(void *buf, size_t len, php_hash_uint32 hval, int alternate)
+static uint32_t
+fnv_32_buf(void *buf, size_t len, uint32_t hval, int alternate)
 {
 	unsigned char *bp = (unsigned char *)buf;   /* start of buffer */
 	unsigned char *be = bp + len;	   /* beyond end of buffer */
@@ -163,10 +163,10 @@ fnv_32_buf(void *buf, size_t len, php_hash_uint32 hval, int alternate)
 			hval *= PHP_FNV_32_PRIME;
 
 			/* xor the bottom with the current octet */
-			hval ^= (php_hash_uint32)*bp++;
+			hval ^= (uint32_t)*bp++;
 		} else {
 			/* xor the bottom with the current octet */
-			hval ^= (php_hash_uint32)*bp++;
+			hval ^= (uint32_t)*bp++;
 
 			/* multiply by the 32 bit FNV magic prime mod 2^32 */
 			hval *= PHP_FNV_32_PRIME;
@@ -189,8 +189,8 @@ fnv_32_buf(void *buf, size_t len, php_hash_uint32 hval, int alternate)
  * returns:
  *  64 bit hash as a static hash type
  */
-static php_hash_uint64
-fnv_64_buf(void *buf, size_t len, php_hash_uint64 hval, int alternate)
+static uint64_t
+fnv_64_buf(void *buf, size_t len, uint64_t hval, int alternate)
 {
 	unsigned char *bp = (unsigned char *)buf;   /* start of buffer */
 	unsigned char *be = bp + len;	   /* beyond end of buffer */
@@ -205,10 +205,10 @@ fnv_64_buf(void *buf, size_t len, php_hash_uint64 hval, int alternate)
 			hval *= PHP_FNV_64_PRIME;
 
 			/* xor the bottom with the current octet */
-			hval ^= (php_hash_uint64)*bp++;
+			hval ^= (uint64_t)*bp++;
 		 } else {
 			/* xor the bottom with the current octet */
-			hval ^= (php_hash_uint64)*bp++;
+			hval ^= (uint64_t)*bp++;
 
 			/* multiply by the 64 bit FNV magic prime mod 2^64 */
 			hval *= PHP_FNV_64_PRIME;

--- a/ext/hash/hash_gost.c
+++ b/ext/hash/hash_gost.c
@@ -207,10 +207,10 @@
 		AA(v, l, r); \
 	}
 
-static inline void Gost(PHP_GOST_CTX *context, php_hash_uint32 data[8])
+static inline void Gost(PHP_GOST_CTX *context, uint32_t data[8])
 {
 	int i;
-	php_hash_uint32 l, r, t, key[8], u[8], v[8], w[8], s[8], *h = context->state, *m = data;
+	uint32_t l, r, t, key[8], u[8], v[8], w[8], s[8], *h = context->state, *m = data;
 
 	memcpy(u, context->state, sizeof(u));
 	memcpy(v, data, sizeof(v));
@@ -227,11 +227,11 @@ static inline void Gost(PHP_GOST_CTX *context, php_hash_uint32 data[8])
 static inline void GostTransform(PHP_GOST_CTX *context, const unsigned char input[32])
 {
 	int i, j;
-	php_hash_uint32 data[8], temp = 0, save = 0;
+	uint32_t data[8], temp = 0, save = 0;
 
 	for (i = 0, j = 0; i < 8; ++i, j += 4) {
-		data[i] =	((php_hash_uint32) input[j]) | (((php_hash_uint32) input[j + 1]) << 8) |
-					(((php_hash_uint32) input[j + 2]) << 16) | (((php_hash_uint32) input[j + 3]) << 24);
+		data[i] =	((uint32_t) input[j]) | (((uint32_t) input[j + 1]) << 8) |
+					(((uint32_t) input[j + 2]) << 16) | (((uint32_t) input[j + 3]) << 24);
 		save = context->state[i + 8];
 		context->state[i + 8] += data[i] + temp;
 		temp = ((context->state[i + 8] < data[i]) || (context->state[i + 8] < save)) ? 1 : 0;
@@ -252,7 +252,7 @@ PHP_HASH_API void PHP_GOSTInitCrypto(PHP_GOST_CTX *context)
 	context->tables = &tables_crypto;
 }
 
-static const php_hash_uint32 MAX32 = 0xffffffffLU;
+static const uint32_t MAX32 = 0xffffffffLU;
 
 PHP_HASH_API void PHP_GOSTUpdate(PHP_GOST_CTX *context, const unsigned char *input, size_t len)
 {
@@ -288,7 +288,7 @@ PHP_HASH_API void PHP_GOSTUpdate(PHP_GOST_CTX *context, const unsigned char *inp
 
 PHP_HASH_API void PHP_GOSTFinal(unsigned char digest[32], PHP_GOST_CTX *context)
 {
-	php_hash_uint32 i, j, l[8] = {0};
+	uint32_t i, j, l[8] = {0};
 
 	if (context->length) {
 		GostTransform(context, context->buffer);

--- a/ext/hash/hash_haval.c
+++ b/ext/hash/hash_haval.c
@@ -31,28 +31,28 @@ static const unsigned char PADDING[128] ={
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-static const php_hash_uint32 D0[8] = {
+static const uint32_t D0[8] = {
 	0x243F6A88, 0x85A308D3, 0x13198A2E, 0x03707344, 0xA4093822, 0x299F31D0, 0x082EFA98, 0xEC4E6C89 };
 
-static const php_hash_uint32 K2[32] = {
+static const uint32_t K2[32] = {
 	0x452821E6, 0x38D01377, 0xBE5466CF, 0x34E90C6C, 0xC0AC29B7, 0xC97C50DD, 0x3F84D5B5, 0xB5470917,
 	0x9216D5D9, 0x8979FB1B, 0xD1310BA6, 0x98DFB5AC, 0x2FFD72DB, 0xD01ADFB7, 0xB8E1AFED, 0x6A267E96,
 	0xBA7C9045, 0xF12C7F99, 0x24A19947, 0xB3916CF7, 0x0801F2E2, 0x858EFC16, 0x636920D8, 0x71574E69,
 	0xA458FEA3, 0xF4933D7E, 0x0D95748F, 0x728EB658, 0x718BCD58, 0x82154AEE, 0x7B54A41D, 0xC25A59B5 };
 
-static const php_hash_uint32 K3[32] = {
+static const uint32_t K3[32] = {
 	0x9C30D539, 0x2AF26013, 0xC5D1B023, 0x286085F0, 0xCA417918, 0xB8DB38EF, 0x8E79DCB0, 0x603A180E,
 	0x6C9E0E8B, 0xB01E8A3E, 0xD71577C1, 0xBD314B27, 0x78AF2FDA, 0x55605C60, 0xE65525F3, 0xAA55AB94,
 	0x57489862, 0x63E81440, 0x55CA396A, 0x2AAB10B6, 0xB4CC5C34, 0x1141E8CE, 0xA15486AF, 0x7C72E993,
 	0xB3EE1411, 0x636FBC2A, 0x2BA9C55D, 0x741831F6, 0xCE5C3E16, 0x9B87931E, 0xAFD6BA33, 0x6C24CF5C };
 
-static const php_hash_uint32 K4[32] = {
+static const uint32_t K4[32] = {
 	0x7A325381, 0x28958677, 0x3B8F4898, 0x6B4BB9AF, 0xC4BFE81B, 0x66282193, 0x61D809CC, 0xFB21A991,
 	0x487CAC60, 0x5DEC8032, 0xEF845D5D, 0xE98575B1, 0xDC262302, 0xEB651B88, 0x23893E81, 0xD396ACC5,
 	0x0F6D6FF3, 0x83F44239, 0x2E0B4482, 0xA4842004, 0x69C8F04A, 0x9E1F9B5E, 0x21C66842, 0xF6E96C9A,
 	0x670C9C61, 0xABD388F0, 0x6A51A0D2, 0xD8542F68, 0x960FA728, 0xAB5133A3, 0x6EEF0B6C, 0x137A3BE4 };
 
-static const php_hash_uint32 K5[32] = {
+static const uint32_t K5[32] = {
 	0xBA3BF050, 0x7EFB2A98, 0xA1F1651D, 0x39AF0176, 0x66CA593E, 0x82430E88, 0x8CEE8619, 0x456F9FB4,
 	0x7D84A5C3, 0x3B8B5EBE, 0xE06F75D8, 0x85C12073, 0x401A449F, 0x56C16AA6, 0x4ED3AA62, 0x363F7706,
 	0x1BFEDF72, 0x429B023D, 0x37D0D724, 0xD00A1248, 0xDB0FEAD3, 0x49F1C09B, 0x075372C9, 0x80991B7B,
@@ -95,10 +95,10 @@ static const short M7[32] = {	7, 6, 5, 4, 3, 2, 1, 0, 7, 6, 5, 4, 3, 2, 1, 0,
 						7, 6, 5, 4, 3, 2, 1, 0, 7, 6, 5, 4, 3, 2, 1, 0 };
 
 /* {{{ Encode
-   Encodes input (php_hash_uint32) into output (unsigned char). Assumes len is
+   Encodes input (uint32_t) into output (unsigned char). Assumes len is
    a multiple of 4.
  */
-static void Encode(unsigned char *output, php_hash_uint32 *input, unsigned int len)
+static void Encode(unsigned char *output, uint32_t *input, unsigned int len)
 {
 	unsigned int i, j;
 
@@ -112,16 +112,16 @@ static void Encode(unsigned char *output, php_hash_uint32 *input, unsigned int l
 /* }}} */
 
 /* {{{ Decode
-   Decodes input (unsigned char) into output (php_hash_uint32). Assumes len is
+   Decodes input (unsigned char) into output (uint32_t). Assumes len is
    a multiple of 4.
  */
-static void Decode(php_hash_uint32 *output, const unsigned char *input, unsigned int len)
+static void Decode(uint32_t *output, const unsigned char *input, unsigned int len)
 {
 	unsigned int i, j;
 
 	for (i = 0, j = 0; j < len; i++, j += 4) {
-		output[i] = ((php_hash_uint32) input[j]) | (((php_hash_uint32) input[j + 1]) << 8) |
-			(((php_hash_uint32) input[j + 2]) << 16) | (((php_hash_uint32) input[j + 3]) << 24);
+		output[i] = ((uint32_t) input[j]) | (((uint32_t) input[j + 1]) << 8) |
+			(((uint32_t) input[j + 2]) << 16) | (((uint32_t) input[j + 3]) << 24);
 	}
 }
 /* }}} */
@@ -141,10 +141,10 @@ static void Decode(php_hash_uint32 *output, const unsigned char *input, unsigned
 
 /* {{{ PHP_3HAVALTransform
  */
-static void PHP_3HAVALTransform(php_hash_uint32 state[8], const unsigned char block[128])
+static void PHP_3HAVALTransform(uint32_t state[8], const unsigned char block[128])
 {
-	php_hash_uint32 E[8];
-	php_hash_uint32 x[32];
+	uint32_t E[8];
+	uint32_t x[32];
 	int i;
 
 	Decode(x, block, 128);
@@ -175,10 +175,10 @@ static void PHP_3HAVALTransform(php_hash_uint32 state[8], const unsigned char bl
 
 /* {{{ PHP_4HAVALTransform
  */
-static void PHP_4HAVALTransform(php_hash_uint32 state[8], const unsigned char block[128])
+static void PHP_4HAVALTransform(uint32_t state[8], const unsigned char block[128])
 {
-	php_hash_uint32 E[8];
-	php_hash_uint32 x[32];
+	uint32_t E[8];
+	uint32_t x[32];
 	int i;
 
 	Decode(x, block, 128);
@@ -212,10 +212,10 @@ static void PHP_4HAVALTransform(php_hash_uint32 state[8], const unsigned char bl
 
 /* {{{ PHP_5HAVALTransform
  */
-static void PHP_5HAVALTransform(php_hash_uint32 state[8], const unsigned char block[128])
+static void PHP_5HAVALTransform(uint32_t state[8], const unsigned char block[128])
 {
-	php_hash_uint32 E[8];
-	php_hash_uint32 x[32];
+	uint32_t E[8];
+	uint32_t x[32];
 	int i;
 
 	Decode(x, block, 128);
@@ -289,10 +289,10 @@ PHP_HASH_API void PHP_HAVALUpdate(PHP_HAVAL_CTX *context, const unsigned char *i
 	/* Compute number of bytes mod 128 */
 	index = (unsigned int) ((context->count[0] >> 3) & 0x7F);
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3)) < ((php_hash_uint32) inputLen << 3)) {
+	if ((context->count[0] += ((uint32_t) inputLen << 3)) < ((uint32_t) inputLen << 3)) {
 		context->count[1]++;
 	}
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 128 - index;
 

--- a/ext/hash/hash_joaat.c
+++ b/ext/hash/hash_joaat.c
@@ -70,8 +70,8 @@ PHP_HASH_API void PHP_JOAATFinal(unsigned char digest[4], PHP_JOAAT_CTX * contex
  * returns:
  *  32 bit hash as a static hash type
  */
-static php_hash_uint32
-joaat_buf(void *buf, size_t len, php_hash_uint32 hval)
+static uint32_t
+joaat_buf(void *buf, size_t len, uint32_t hval)
 {
     size_t i;
     unsigned char *input = (unsigned char *)buf;

--- a/ext/hash/hash_md.c
+++ b/ext/hash/hash_md.c
@@ -61,10 +61,10 @@ static const unsigned char PADDING[64] =
 };
 
 /* {{{ Encode
-   Encodes input (php_hash_uint32) into output (unsigned char). Assumes len is
+   Encodes input (uint32_t) into output (unsigned char). Assumes len is
    a multiple of 4.
  */
-static void Encode(unsigned char *output, php_hash_uint32 *input, unsigned int len)
+static void Encode(unsigned char *output, uint32_t *input, unsigned int len)
 {
 	unsigned int i, j;
 
@@ -78,16 +78,16 @@ static void Encode(unsigned char *output, php_hash_uint32 *input, unsigned int l
 /* }}} */
 
 /* {{{ Decode
-   Decodes input (unsigned char) into output (php_hash_uint32). Assumes len is
+   Decodes input (unsigned char) into output (uint32_t). Assumes len is
    a multiple of 4.
  */
-static void Decode(php_hash_uint32 *output, const unsigned char *input, unsigned int len)
+static void Decode(uint32_t *output, const unsigned char *input, unsigned int len)
 {
 	unsigned int i, j;
 
 	for (i = 0, j = 0; j < len; i++, j += 4)
-		output[i] = ((php_hash_uint32) input[j]) | (((php_hash_uint32) input[j + 1]) << 8) |
-			(((php_hash_uint32) input[j + 2]) << 16) | (((php_hash_uint32) input[j + 3]) << 24);
+		output[i] = ((uint32_t) input[j]) | (((uint32_t) input[j + 1]) << 8) |
+			(((uint32_t) input[j + 2]) << 16) | (((uint32_t) input[j + 3]) << 24);
 }
 /* }}} */
 
@@ -224,7 +224,7 @@ PHP_NAMED_FUNCTION(php_if_md5_file)
 #define S43 15
 #define S44 21
 
-static void MD5Transform(php_hash_uint32[4], const unsigned char[64]);
+static void MD5Transform(uint32_t[4], const unsigned char[64]);
 
 /* F, G, H and I are basic MD5 functions.
  */
@@ -241,22 +241,22 @@ static void MD5Transform(php_hash_uint32[4], const unsigned char[64]);
    Rotation is separate from addition to prevent recomputation.
  */
 #define FF(a, b, c, d, x, s, ac) { \
- (a) += F ((b), (c), (d)) + (x) + (php_hash_uint32)(ac); \
+ (a) += F ((b), (c), (d)) + (x) + (uint32_t)(ac); \
  (a) = ROTATE_LEFT ((a), (s)); \
  (a) += (b); \
   }
 #define GG(a, b, c, d, x, s, ac) { \
- (a) += G ((b), (c), (d)) + (x) + (php_hash_uint32)(ac); \
+ (a) += G ((b), (c), (d)) + (x) + (uint32_t)(ac); \
  (a) = ROTATE_LEFT ((a), (s)); \
  (a) += (b); \
   }
 #define HH(a, b, c, d, x, s, ac) { \
- (a) += H ((b), (c), (d)) + (x) + (php_hash_uint32)(ac); \
+ (a) += H ((b), (c), (d)) + (x) + (uint32_t)(ac); \
  (a) = ROTATE_LEFT ((a), (s)); \
  (a) += (b); \
   }
 #define II(a, b, c, d, x, s, ac) { \
- (a) += I ((b), (c), (d)) + (x) + (php_hash_uint32)(ac); \
+ (a) += I ((b), (c), (d)) + (x) + (uint32_t)(ac); \
  (a) = ROTATE_LEFT ((a), (s)); \
  (a) += (b); \
   }
@@ -290,10 +290,10 @@ PHP_HASH_API void PHP_MD5Update(PHP_MD5_CTX * context, const unsigned char *inpu
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3))
-		< ((php_hash_uint32) inputLen << 3))
+	if ((context->count[0] += ((uint32_t) inputLen << 3))
+		< ((uint32_t) inputLen << 3))
 		context->count[1]++;
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -352,10 +352,10 @@ PHP_HASH_API void PHP_MD5Final(unsigned char digest[16], PHP_MD5_CTX * context)
  * MD5 basic transformation. Transforms state based on block.
  */
 static void MD5Transform(state, block)
-php_hash_uint32 state[4];
+uint32_t state[4];
 const unsigned char block[64];
 {
-	php_hash_uint32 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+	uint32_t a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 
 	Decode(x, block, 64);
 
@@ -455,9 +455,9 @@ const unsigned char block[64];
 #define MD4_R2(a,b,c,d,k,s)		a = ROTL32(s, a + MD4_G(b,c,d) + x[k] + 0x5A827999)
 #define MD4_R3(a,b,c,d,k,s)		a = ROTL32(s, a + MD4_H(b,c,d) + x[k] + 0x6ED9EBA1)
 
-static void MD4Transform(php_hash_uint32 state[4], const unsigned char block[64])
+static void MD4Transform(uint32_t state[4], const unsigned char block[64])
 {
-	php_hash_uint32 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+	uint32_t a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 
 	Decode(x, block, 64);
 
@@ -549,10 +549,10 @@ PHP_HASH_API void PHP_MD4Update(PHP_MD4_CTX * context, const unsigned char *inpu
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3))
-		< ((php_hash_uint32) inputLen << 3))
+	if ((context->count[0] += ((uint32_t) inputLen << 3))
+		< ((uint32_t) inputLen << 3))
 		context->count[1]++;
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 

--- a/ext/hash/hash_ripemd.c
+++ b/ext/hash/hash_ripemd.c
@@ -143,9 +143,9 @@ PHP_HASH_API void PHP_RIPEMD320Init(PHP_RIPEMD320_CTX * context)
 #define F3(x,y,z)		(((x) & (z)) | ((y) & (~(z))))
 #define F4(x,y,z)		((x) ^ ((y) | (~(z))))
 
-static const php_hash_uint32 K_values[5]  = { 0x00000000, 0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xA953FD4E };    /* 128, 256, 160, 320 */
-static const php_hash_uint32 KK_values[4] = { 0x50A28BE6, 0x5C4DD124, 0x6D703EF3, 0x00000000 };                /* 128 & 256 */
-static const php_hash_uint32 KK160_values[5] = { 0x50A28BE6, 0x5C4DD124, 0x6D703EF3, 0x7A6D76E9, 0x00000000 }; /* 160 & 320 */
+static const uint32_t K_values[5]  = { 0x00000000, 0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xA953FD4E };    /* 128, 256, 160, 320 */
+static const uint32_t KK_values[4] = { 0x50A28BE6, 0x5C4DD124, 0x6D703EF3, 0x00000000 };                /* 128 & 256 */
+static const uint32_t KK160_values[5] = { 0x50A28BE6, 0x5C4DD124, 0x6D703EF3, 0x7A6D76E9, 0x00000000 }; /* 160 & 320 */
 
 #define K(n)  K_values[ (n) >> 4]
 #define KK(n) KK_values[(n) >> 4]
@@ -184,27 +184,27 @@ static const unsigned char SS[80] = {
 #define ROL(n, x)	(((x) << n) | ((x) >> (32 - n)))
 
 /* {{{ RIPEMDDecode
-   Decodes input (unsigned char) into output (php_hash_uint32). Assumes len is
+   Decodes input (unsigned char) into output (uint32_t). Assumes len is
    a multiple of 4.
  */
-static void RIPEMDDecode(php_hash_uint32 *output, const unsigned char *input, unsigned int len)
+static void RIPEMDDecode(uint32_t *output, const unsigned char *input, unsigned int len)
 {
 	unsigned int i, j;
 
 	for (i = 0, j = 0; j < len; i++, j += 4)
-		output[i] = ((php_hash_uint32) input[j + 0]) | (((php_hash_uint32) input[j + 1]) << 8) |
-			(((php_hash_uint32) input[j + 2]) << 16) | (((php_hash_uint32) input[j + 3]) << 24);
+		output[i] = ((uint32_t) input[j + 0]) | (((uint32_t) input[j + 1]) << 8) |
+			(((uint32_t) input[j + 2]) << 16) | (((uint32_t) input[j + 3]) << 24);
 }
 /* }}} */
 
 /* {{{ RIPEMD128Transform
  * ripemd128 basic transformation. Transforms state based on block.
  */
-static void RIPEMD128Transform(php_hash_uint32 state[4], const unsigned char block[64])
+static void RIPEMD128Transform(uint32_t state[4], const unsigned char block[64])
 {
-	php_hash_uint32 a  = state[0], b  = state[1], c  = state[2], d  = state[3];
-	php_hash_uint32 aa = state[0], bb = state[1], cc = state[2], dd = state[3];
-	php_hash_uint32 tmp, x[16];
+	uint32_t a  = state[0], b  = state[1], c  = state[2], d  = state[3];
+	uint32_t aa = state[0], bb = state[1], cc = state[2], dd = state[3];
+	uint32_t tmp, x[16];
 	int j;
 
 	RIPEMDDecode(x, block, 64);
@@ -261,10 +261,10 @@ PHP_HASH_API void PHP_RIPEMD128Update(PHP_RIPEMD128_CTX * context, const unsigne
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3)) < ((php_hash_uint32) inputLen << 3)) {
+	if ((context->count[0] += ((uint32_t) inputLen << 3)) < ((uint32_t) inputLen << 3)) {
 		context->count[1]++;
 	}
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -291,11 +291,11 @@ PHP_HASH_API void PHP_RIPEMD128Update(PHP_RIPEMD128_CTX * context, const unsigne
 /* {{{ RIPEMD256Transform
  * ripemd256 basic transformation. Transforms state based on block.
  */
-static void RIPEMD256Transform(php_hash_uint32 state[8], const unsigned char block[64])
+static void RIPEMD256Transform(uint32_t state[8], const unsigned char block[64])
 {
-	php_hash_uint32 a  = state[0], b  = state[1], c  = state[2], d  = state[3];
-	php_hash_uint32 aa = state[4], bb = state[5], cc = state[6], dd = state[7];
-	php_hash_uint32 tmp, x[16];
+	uint32_t a  = state[0], b  = state[1], c  = state[2], d  = state[3];
+	uint32_t aa = state[4], bb = state[5], cc = state[6], dd = state[7];
+	uint32_t tmp, x[16];
 	int j;
 
 	RIPEMDDecode(x, block, 64);
@@ -359,10 +359,10 @@ PHP_HASH_API void PHP_RIPEMD256Update(PHP_RIPEMD256_CTX * context, const unsigne
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3)) < ((php_hash_uint32) inputLen << 3)) {
+	if ((context->count[0] += ((uint32_t) inputLen << 3)) < ((uint32_t) inputLen << 3)) {
 		context->count[1]++;
 	}
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -389,11 +389,11 @@ PHP_HASH_API void PHP_RIPEMD256Update(PHP_RIPEMD256_CTX * context, const unsigne
 /* {{{ RIPEMD160Transform
  * ripemd160 basic transformation. Transforms state based on block.
  */
-static void RIPEMD160Transform(php_hash_uint32 state[5], const unsigned char block[64])
+static void RIPEMD160Transform(uint32_t state[5], const unsigned char block[64])
 {
-	php_hash_uint32 a  = state[0], b  = state[1], c  = state[2], d  = state[3], e  = state[4];
-	php_hash_uint32 aa = state[0], bb = state[1], cc = state[2], dd = state[3], ee = state[4];
-	php_hash_uint32 tmp, x[16];
+	uint32_t a  = state[0], b  = state[1], c  = state[2], d  = state[3], e  = state[4];
+	uint32_t aa = state[0], bb = state[1], cc = state[2], dd = state[3], ee = state[4];
+	uint32_t tmp, x[16];
 	int j;
 
 	RIPEMDDecode(x, block, 64);
@@ -458,10 +458,10 @@ PHP_HASH_API void PHP_RIPEMD160Update(PHP_RIPEMD160_CTX * context, const unsigne
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3)) < ((php_hash_uint32) inputLen << 3)) {
+	if ((context->count[0] += ((uint32_t) inputLen << 3)) < ((uint32_t) inputLen << 3)) {
 		context->count[1]++;
 	}
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -488,11 +488,11 @@ PHP_HASH_API void PHP_RIPEMD160Update(PHP_RIPEMD160_CTX * context, const unsigne
 /* {{{ RIPEMD320Transform
  * ripemd320 basic transformation. Transforms state based on block.
  */
-static void RIPEMD320Transform(php_hash_uint32 state[10], const unsigned char block[64])
+static void RIPEMD320Transform(uint32_t state[10], const unsigned char block[64])
 {
-	php_hash_uint32 a  = state[0], b  = state[1], c  = state[2], d  = state[3], e  = state[4];
-	php_hash_uint32 aa = state[5], bb = state[6], cc = state[7], dd = state[8], ee = state[9];
-	php_hash_uint32 tmp, x[16];
+	uint32_t a  = state[0], b  = state[1], c  = state[2], d  = state[3], e  = state[4];
+	uint32_t aa = state[5], bb = state[6], cc = state[7], dd = state[8], ee = state[9];
+	uint32_t tmp, x[16];
 	int j;
 
 	RIPEMDDecode(x, block, 64);
@@ -566,10 +566,10 @@ PHP_HASH_API void PHP_RIPEMD320Update(PHP_RIPEMD320_CTX * context, const unsigne
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3)) < ((php_hash_uint32) inputLen << 3)) {
+	if ((context->count[0] += ((uint32_t) inputLen << 3)) < ((uint32_t) inputLen << 3)) {
 		context->count[1]++;
 	}
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -601,10 +601,10 @@ static const unsigned char PADDING[64] =
 };
 
 /* {{{ RIPEMDEncode
-   Encodes input (php_hash_uint32) into output (unsigned char). Assumes len is
+   Encodes input (uint32_t) into output (unsigned char). Assumes len is
    a multiple of 4.
  */
-static void RIPEMDEncode(unsigned char *output, php_hash_uint32 *input, unsigned int len)
+static void RIPEMDEncode(unsigned char *output, uint32_t *input, unsigned int len)
 {
 	unsigned int i, j;
 

--- a/ext/hash/hash_sha.c
+++ b/ext/hash/hash_sha.c
@@ -35,10 +35,10 @@ static const unsigned char PADDING[128] =
 };
 
 /* {{{ SHAEncode32
-   Encodes input (php_hash_uint32) into output (unsigned char). Assumes len is
+   Encodes input (uint32_t) into output (unsigned char). Assumes len is
    a multiple of 4.
  */
-static void SHAEncode32(unsigned char *output, php_hash_uint32 *input, unsigned int len)
+static void SHAEncode32(unsigned char *output, uint32_t *input, unsigned int len)
 {
 	unsigned int i, j;
 
@@ -53,16 +53,16 @@ static void SHAEncode32(unsigned char *output, php_hash_uint32 *input, unsigned 
 
 
 /* {{{ SHADecode32
-   Decodes input (unsigned char) into output (php_hash_uint32). Assumes len is
+   Decodes input (unsigned char) into output (uint32_t). Assumes len is
    a multiple of 4.
  */
-static void SHADecode32(php_hash_uint32 *output, const unsigned char *input, unsigned int len)
+static void SHADecode32(uint32_t *output, const unsigned char *input, unsigned int len)
 {
 	unsigned int i, j;
 
 	for (i = 0, j = 0; j < len; i++, j += 4)
-		output[i] = ((php_hash_uint32) input[j + 3]) | (((php_hash_uint32) input[j + 2]) << 8) |
-			(((php_hash_uint32) input[j + 1]) << 16) | (((php_hash_uint32) input[j]) << 24);
+		output[i] = ((uint32_t) input[j + 3]) | (((uint32_t) input[j + 2]) << 8) |
+			(((uint32_t) input[j + 1]) << 16) | (((uint32_t) input[j]) << 24);
 }
 /* }}} */
 
@@ -179,22 +179,22 @@ PHP_FUNCTION(sha1_file)
 /* FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
  */
 #define FF(a, b, c, d, e, w) { \
- (e) += F ((b), (c), (d)) + (w) + (php_hash_uint32)(0x5A827999); \
+ (e) += F ((b), (c), (d)) + (w) + (uint32_t)(0x5A827999); \
  (e) += ROTATE_LEFT ((a), 5); \
  (b) = ROTATE_LEFT((b), 30); \
   }
 #define GG(a, b, c, d, e, w) { \
- (e) += G ((b), (c), (d)) + (w) + (php_hash_uint32)(0x6ED9EBA1); \
+ (e) += G ((b), (c), (d)) + (w) + (uint32_t)(0x6ED9EBA1); \
  (e) += ROTATE_LEFT ((a), 5); \
  (b) = ROTATE_LEFT((b), 30); \
   }
 #define HH(a, b, c, d, e, w) { \
- (e) += H ((b), (c), (d)) + (w) + (php_hash_uint32)(0x8F1BBCDC); \
+ (e) += H ((b), (c), (d)) + (w) + (uint32_t)(0x8F1BBCDC); \
  (e) += ROTATE_LEFT ((a), 5); \
  (b) = ROTATE_LEFT((b), 30); \
   }
 #define II(a, b, c, d, e, w) { \
- (e) += I ((b), (c), (d)) + (w) + (php_hash_uint32)(0xCA62C1D6); \
+ (e) += I ((b), (c), (d)) + (w) + (uint32_t)(0xCA62C1D6); \
  (e) += ROTATE_LEFT ((a), 5); \
  (b) = ROTATE_LEFT((b), 30); \
   }
@@ -219,10 +219,10 @@ PHP_HASH_API void PHP_SHA1Init(PHP_SHA1_CTX * context)
 /* {{{ SHA1Transform
  * SHA1 basic transformation. Transforms state based on block.
  */
-static void SHA1Transform(php_hash_uint32 state[5], const unsigned char block[64])
+static void SHA1Transform(uint32_t state[5], const unsigned char block[64])
 {
-	php_hash_uint32 a = state[0], b = state[1], c = state[2];
-	php_hash_uint32 d = state[3], e = state[4], x[16], tmp;
+	uint32_t a = state[0], b = state[1], c = state[2];
+	uint32_t d = state[3], e = state[4], x[16], tmp;
 
 	SHADecode32(x, block, 64);
 
@@ -339,10 +339,10 @@ PHP_HASH_API void PHP_SHA1Update(PHP_SHA1_CTX * context, const unsigned char *in
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3))
-		< ((php_hash_uint32) inputLen << 3))
+	if ((context->count[0] += ((uint32_t) inputLen << 3))
+		< ((uint32_t) inputLen << 3))
 		context->count[1]++;
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -445,7 +445,7 @@ const php_hash_ops php_hash_sha224_ops = {
 /* OM1 */
 #define SHA256_F5(x)		(ROTR32(17,(x)) ^ ROTR32(19,(x)) ^ SHR(10,(x)))
 
-static const php_hash_uint32 SHA256_K[64] = {
+static const uint32_t SHA256_K[64] = {
 	0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
 	0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
 	0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
@@ -477,11 +477,11 @@ PHP_HASH_API void PHP_SHA256Init(PHP_SHA256_CTX * context)
 /* {{{ SHA256Transform
  * SHA256 basic transformation. Transforms state based on block.
  */
-static void SHA256Transform(php_hash_uint32 state[8], const unsigned char block[64])
+static void SHA256Transform(uint32_t state[8], const unsigned char block[64])
 {
-	php_hash_uint32 a = state[0], b = state[1], c = state[2], d = state[3];
-	php_hash_uint32 e = state[4], f = state[5], g = state[6], h = state[7];
-	php_hash_uint32 x[16], T1, T2, W[64];
+	uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
+	uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+	uint32_t x[16], T1, T2, W[64];
 	int i;
 
 	SHADecode32(x, block, 64);
@@ -547,10 +547,10 @@ PHP_HASH_API void PHP_SHA224Update(PHP_SHA224_CTX * context, const unsigned char
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3)) < ((php_hash_uint32) inputLen << 3)) {
+	if ((context->count[0] += ((uint32_t) inputLen << 3)) < ((uint32_t) inputLen << 3)) {
 		context->count[1]++;
 	}
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -624,10 +624,10 @@ PHP_HASH_API void PHP_SHA256Update(PHP_SHA256_CTX * context, const unsigned char
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint32) inputLen << 3)) < ((php_hash_uint32) inputLen << 3)) {
+	if ((context->count[0] += ((uint32_t) inputLen << 3)) < ((uint32_t) inputLen << 3)) {
 		context->count[1]++;
 	}
-	context->count[1] += ((php_hash_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -703,7 +703,7 @@ PHP_HASH_API void PHP_SHA256Final(unsigned char digest[32], PHP_SHA256_CTX * con
 /* OM1 */
 #define SHA512_F5(x)			(ROTR64(19, x) ^ ROTR64(61, x) ^ SHR(6, x))
 
-static const php_hash_uint64 SHA512_K[128] = {
+static const uint64_t SHA512_K[128] = {
 	L64(0x428a2f98d728ae22), L64(0x7137449123ef65cd), L64(0xb5c0fbcfec4d3b2f), L64(0xe9b5dba58189dbbc),
 	L64(0x3956c25bf348b538), L64(0x59f111f1b605d019), L64(0x923f82a4af194f9b), L64(0xab1c5ed5da6d8118),
 	L64(0xd807aa98a3030242), L64(0x12835b0145706fbe), L64(0x243185be4ee4b28c), L64(0x550c7dc3d5ffb4e2),
@@ -726,10 +726,10 @@ static const php_hash_uint64 SHA512_K[128] = {
 	L64(0x4cc5d4becb3e42b6), L64(0x597f299cfc657e2a), L64(0x5fcb6fab3ad6faec), L64(0x6c44198c4a475817) };
 
 /* {{{ SHAEncode64
-   Encodes input (php_hash_uint64) into output (unsigned char). Assumes len is
+   Encodes input (uint64_t) into output (unsigned char). Assumes len is
    a multiple of 8.
  */
-static void SHAEncode64(unsigned char *output, php_hash_uint64 *input, unsigned int len)
+static void SHAEncode64(unsigned char *output, uint64_t *input, unsigned int len)
 {
 	unsigned int i, j;
 
@@ -748,19 +748,19 @@ static void SHAEncode64(unsigned char *output, php_hash_uint64 *input, unsigned 
 
 
 /* {{{ SHADecode64
-   Decodes input (unsigned char) into output (php_hash_uint64). Assumes len is
+   Decodes input (unsigned char) into output (uint64_t). Assumes len is
    a multiple of 8.
  */
-static void SHADecode64(php_hash_uint64 *output, const unsigned char *input, unsigned int len)
+static void SHADecode64(uint64_t *output, const unsigned char *input, unsigned int len)
 {
 	unsigned int i, j;
 
 	for (i = 0, j = 0; j < len; i++, j += 8)
 		output[i] =
-			((php_hash_uint64) input[j + 7]) | (((php_hash_uint64) input[j + 6]) << 8) |
-			(((php_hash_uint64) input[j + 5]) << 16) | (((php_hash_uint64) input[j + 4]) << 24) |
-			(((php_hash_uint64) input[j + 3]) << 32) | (((php_hash_uint64) input[j + 2]) << 40) |
-			(((php_hash_uint64) input[j + 1]) << 48) | (((php_hash_uint64) input[j]) << 56);
+			((uint64_t) input[j + 7]) | (((uint64_t) input[j + 6]) << 8) |
+			(((uint64_t) input[j + 5]) << 16) | (((uint64_t) input[j + 4]) << 24) |
+			(((uint64_t) input[j + 3]) << 32) | (((uint64_t) input[j + 2]) << 40) |
+			(((uint64_t) input[j + 1]) << 48) | (((uint64_t) input[j]) << 56);
 }
 /* }}} */
 
@@ -787,11 +787,11 @@ PHP_HASH_API void PHP_SHA384Init(PHP_SHA384_CTX * context)
  * SHA512 basic transformation. Transforms state based on block.
  * SHA384 uses the exact same algorithm
  */
-static void SHA512Transform(php_hash_uint64 state[8], const unsigned char block[128])
+static void SHA512Transform(uint64_t state[8], const unsigned char block[128])
 {
-	php_hash_uint64 a = state[0], b = state[1], c = state[2], d = state[3];
-	php_hash_uint64 e = state[4], f = state[5], g = state[6], h = state[7];
-	php_hash_uint64 x[16], T1, T2, W[80];
+	uint64_t a = state[0], b = state[1], c = state[2], d = state[3];
+	uint64_t e = state[4], f = state[5], g = state[6], h = state[7];
+	uint64_t x[16], T1, T2, W[80];
 	int i;
 
 	SHADecode64(x, block, 128);
@@ -838,10 +838,10 @@ PHP_HASH_API void PHP_SHA384Update(PHP_SHA384_CTX * context, const unsigned char
 	index = (unsigned int) ((context->count[0] >> 3) & 0x7F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint64) inputLen << 3)) < ((php_hash_uint64) inputLen << 3)) {
+	if ((context->count[0] += ((uint64_t) inputLen << 3)) < ((uint64_t) inputLen << 3)) {
 		context->count[1]++;
 	}
-	context->count[1] += ((php_hash_uint64) inputLen >> 61);
+	context->count[1] += ((uint64_t) inputLen >> 61);
 
 	partLen = 128 - index;
 
@@ -952,10 +952,10 @@ PHP_HASH_API void PHP_SHA512Update(PHP_SHA512_CTX * context, const unsigned char
 	index = (unsigned int) ((context->count[0] >> 3) & 0x7F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_hash_uint64) inputLen << 3)) < ((php_hash_uint64) inputLen << 3)) {
+	if ((context->count[0] += ((uint64_t) inputLen << 3)) < ((uint64_t) inputLen << 3)) {
 		context->count[1]++;
 	}
-	context->count[1] += ((php_hash_uint64) inputLen >> 61);
+	context->count[1] += ((uint64_t) inputLen >> 61);
 
 	partLen = 128 - index;
 

--- a/ext/hash/hash_sha3.c
+++ b/ext/hash/hash_sha3.c
@@ -29,7 +29,7 @@
 # endif
 #endif
 
-static inline php_hash_uint64 rol64(php_hash_uint64 v, unsigned char b) {
+static inline uint64_t rol64(uint64_t v, unsigned char b) {
 	return (v << b) | (v >> (64 - b));
 }
 static inline unsigned char idx(unsigned char x, unsigned char y) {
@@ -37,36 +37,36 @@ static inline unsigned char idx(unsigned char x, unsigned char y) {
 }
 
 #ifdef WORDS_BIGENDIAN
-static inline php_hash_uint64 load64(const unsigned char* x) {
+static inline uint64_t load64(const unsigned char* x) {
 	unsigned char i;
-	php_hash_uint64 ret = 0;
+	uint64_t ret = 0;
 	for (i = 7; i >= 0; --i) {
 		ret <<= 8;
 		ret |= x[i];
 	}
 	return ret;
 }
-static inline void store64(unsigned char* x, php_hash_uint64 val) {
+static inline void store64(unsigned char* x, uint64_t val) {
 	unsigned char i;
 	for (i = 0; i < 8; ++i) {
 		x[i] = val & 0xFF;
 		val >>= 8;
 	}
 }
-static inline void xor64(unsigned char* x, php_hash_uint64 val) {
+static inline void xor64(unsigned char* x, uint64_t val) {
 	unsigned char i;
 	for (i = 0; i < 8; ++i) {
 		x[i] ^= val & 0xFF;
 		val >>= 8;
 	}
 }
-# define readLane(x, y)     load64(ctx->state+sizeof(php_hash_uint64)*idx(x, y))
-# define writeLane(x, y, v) store64(ctx->state+sizeof(php_hash_uint64)*idx(x, y), v)
-# define XORLane(x, y, v)   xor64(ctx->state+sizeof(php_hash_uint64)*idx(x, y), v)
+# define readLane(x, y)     load64(ctx->state+sizeof(uint64_t)*idx(x, y))
+# define writeLane(x, y, v) store64(ctx->state+sizeof(uint64_t)*idx(x, y), v)
+# define XORLane(x, y, v)   xor64(ctx->state+sizeof(uint64_t)*idx(x, y), v)
 #else
-# define readLane(x, y)     (((php_hash_uint64*)ctx->state)[idx(x,y)])
-# define writeLane(x, y, v) (((php_hash_uint64*)ctx->state)[idx(x,y)] = v)
-# define XORLane(x, y, v)   (((php_hash_uint64*)ctx->state)[idx(x,y)] ^= v)
+# define readLane(x, y)     (((uint64_t*)ctx->state)[idx(x,y)])
+# define writeLane(x, y, v) (((uint64_t*)ctx->state)[idx(x,y)] = v)
+# define XORLane(x, y, v)   (((uint64_t*)ctx->state)[idx(x,y)] ^= v)
 #endif
 
 static inline char LFSR86540(unsigned char* pLFSR)
@@ -89,7 +89,7 @@ static void permute(PHP_SHA3_CTX* ctx) {
 
 	for (round = 0; round < 24; ++round) {
 		{ // Theta step (see [Keccak Reference, Section 2.3.2])
-			php_hash_uint64 C[5], D;
+			uint64_t C[5], D;
 			unsigned char x, y;
 			for (x = 0; x < 5; ++x) {
 				C[x] = readLane(x, 0) ^ readLane(x, 1) ^
@@ -105,11 +105,11 @@ static void permute(PHP_SHA3_CTX* ctx) {
 
 		{ // p and Pi steps (see [Keccak Reference, Sections 2.3.3 and 2.3.4])
 			unsigned char x = 1, y = 0, t;
-			php_hash_uint64 current = readLane(x, y);
+			uint64_t current = readLane(x, y);
 			for (t = 0; t < 24; ++t) {
 				unsigned char r = ((t + 1) * (t + 2) / 2) % 64;
 				unsigned char Y = (2*x + 3*y) % 5;
-				php_hash_uint64 temp;
+				uint64_t temp;
 				x = y;
 				y = Y;
 				temp = readLane(x, y);
@@ -121,7 +121,7 @@ static void permute(PHP_SHA3_CTX* ctx) {
 		{ // X step (see [Keccak Reference, Section 2.3.1])
 			unsigned char x, y;
 			for (y = 0; y < 5; ++y) {
-				php_hash_uint64 temp[5];
+				uint64_t temp[5];
 				for (x = 0; x < 5; ++x) {
 					temp[x] = readLane(x, y);
 				}
@@ -135,8 +135,8 @@ static void permute(PHP_SHA3_CTX* ctx) {
 			unsigned char j;
 			for (j = 0; j < 7; ++j) {
 				if (LFSR86540(&LFSRstate)) {
-					php_hash_uint64 bitPos = (1<<j) - 1;
-					XORLane(0, 0, (php_hash_uint64)1 << bitPos);
+					uint64_t bitPos = (1<<j) - 1;
+					XORLane(0, 0, (uint64_t)1 << bitPos);
 				}
 			}
 		}

--- a/ext/hash/hash_snefru.c
+++ b/ext/hash/hash_snefru.c
@@ -33,7 +33,7 @@
 #endif
 
 #if DBG_SNEFRU
-void ph(php_hash_uint32 h[16])
+void ph(uint32_t h[16])
 {
 	int i;
 	for (i = 0; i < 16; i++)
@@ -41,12 +41,12 @@ void ph(php_hash_uint32 h[16])
 }
 #endif
 
-static inline void Snefru(php_hash_uint32 input[16])
+static inline void Snefru(uint32_t input[16])
 {
 	static int shifts[4] = {16, 8, 16, 24};
 	int b, index, rshift, lshift;
-	const php_hash_uint32 *t0,*t1;
-	php_hash_uint32 SBE,B00,B01,B02,B03,B04,B05,B06,B07,B08,B09,B10,B11,B12,B13,B14,B15;
+	const uint32_t *t0,*t1;
+	uint32_t SBE,B00,B01,B02,B03,B04,B05,B06,B07,B08,B09,B10,B11,B12,B13,B14,B15;
 
 	B00 = input[0];
 	B01 = input[1];
@@ -129,7 +129,7 @@ static inline void SnefruTransform(PHP_SNEFRU_CTX *context, const unsigned char 
 								((input[i+2] & 0xff) << 8) | (input[i+3] & 0xff);
 	}
 	Snefru(context->state);
-	memset(&context->state[8], 0, sizeof(php_hash_uint32) * 8);
+	memset(&context->state[8], 0, sizeof(uint32_t) * 8);
 }
 
 PHP_HASH_API void PHP_SNEFRUInit(PHP_SNEFRU_CTX *context)
@@ -137,7 +137,7 @@ PHP_HASH_API void PHP_SNEFRUInit(PHP_SNEFRU_CTX *context)
 	memset(context, 0, sizeof(*context));
 }
 
-static const php_hash_uint32 MAX32 = 0xffffffffLU;
+static const uint32_t MAX32 = 0xffffffffLU;
 
 PHP_HASH_API void PHP_SNEFRUUpdate(PHP_SNEFRU_CTX *context, const unsigned char *input, size_t len)
 {
@@ -173,7 +173,7 @@ PHP_HASH_API void PHP_SNEFRUUpdate(PHP_SNEFRU_CTX *context, const unsigned char 
 
 PHP_HASH_API void PHP_SNEFRUFinal(unsigned char digest[32], PHP_SNEFRU_CTX *context)
 {
-	php_hash_uint32 i, j;
+	uint32_t i, j;
 
 	if (context->length) {
 		SnefruTransform(context, context->buffer);

--- a/ext/hash/hash_tiger.c
+++ b/ext/hash/hash_tiger.c
@@ -42,13 +42,13 @@
 #define round(a,b,c,x,mul) \
 	c ^= x; \
 	a -= t1[(unsigned char)(c)] ^ \
-		t2[(unsigned char)(((php_hash_uint32)(c))>>(2*8))] ^ \
+		t2[(unsigned char)(((uint32_t)(c))>>(2*8))] ^ \
 		t3[(unsigned char)((c)>>(4*8))] ^ \
-		t4[(unsigned char)(((php_hash_uint32)((c)>>(4*8)))>>(2*8))] ; \
-	b += t4[(unsigned char)(((php_hash_uint32)(c))>>(1*8))] ^ \
-		t3[(unsigned char)(((php_hash_uint32)(c))>>(3*8))] ^ \
-		t2[(unsigned char)(((php_hash_uint32)((c)>>(4*8)))>>(1*8))] ^ \
-		t1[(unsigned char)(((php_hash_uint32)((c)>>(4*8)))>>(3*8))]; \
+		t4[(unsigned char)(((uint32_t)((c)>>(4*8)))>>(2*8))] ; \
+	b += t4[(unsigned char)(((uint32_t)(c))>>(1*8))] ^ \
+		t3[(unsigned char)(((uint32_t)(c))>>(3*8))] ^ \
+		t2[(unsigned char)(((uint32_t)((c)>>(4*8)))>>(1*8))] ^ \
+		t1[(unsigned char)(((uint32_t)((c)>>(4*8)))>>(3*8))]; \
 	b *= mul;
 
 #define pass(a,b,c,mul) \
@@ -105,7 +105,7 @@
 #	define split(str) \
 	{ \
 		int i; \
-		php_hash_uint64 tmp[8]; \
+		uint64_t tmp[8]; \
 		 \
 		for (i = 0; i < 64; ++i) { \
 			((unsigned char *) tmp)[i^7] = ((unsigned char *) str)[i]; \
@@ -118,8 +118,8 @@
 
 #define tiger_compress(passes, str, state) \
 { \
-	register php_hash_uint64 a, b, c, tmpa, x0, x1, x2, x3, x4, x5, x6, x7; \
-	php_hash_uint64 aa, bb, cc; \
+	register uint64_t a, b, c, tmpa, x0, x1, x2, x3, x4, x5, x6, x7; \
+	uint64_t aa, bb, cc; \
 	unsigned int pass_no; \
 	\
 	a = state[0]; \
@@ -138,7 +138,7 @@
 
 static inline void TigerFinalize(PHP_TIGER_CTX *context)
 {
-	context->passed += (php_hash_uint64) context->length << 3;
+	context->passed += (uint64_t) context->length << 3;
 
 	context->buffer[context->length++] = 0x1;
 	if (context->length % 8) {
@@ -148,14 +148,14 @@ static inline void TigerFinalize(PHP_TIGER_CTX *context)
 
 	if (context->length > 56) {
 		memset(&context->buffer[context->length], 0, 64 - context->length);
-		tiger_compress(context->passes, ((php_hash_uint64 *) context->buffer), context->state);
+		tiger_compress(context->passes, ((uint64_t *) context->buffer), context->state);
 		memset(context->buffer, 0, 56);
 	} else {
 		memset(&context->buffer[context->length], 0, 56 - context->length);
 	}
 
 #ifndef WORDS_BIGENDIAN
-	memcpy(&context->buffer[56], &context->passed, sizeof(php_hash_uint64));
+	memcpy(&context->buffer[56], &context->passed, sizeof(uint64_t));
 #else
 	context->buffer[56] = (unsigned char) (context->passed & 0xff);
 	context->buffer[57] = (unsigned char) ((context->passed >> 8) & 0xff);
@@ -166,7 +166,7 @@ static inline void TigerFinalize(PHP_TIGER_CTX *context)
 	context->buffer[62] = (unsigned char) ((context->passed >> 48) & 0xff);
 	context->buffer[63] = (unsigned char) ((context->passed >> 56) & 0xff);
 #endif
-	tiger_compress(context->passes, ((php_hash_uint64 *) context->buffer), context->state);
+	tiger_compress(context->passes, ((uint64_t *) context->buffer), context->state);
 }
 
 static inline void TigerDigest(unsigned char *digest_str, unsigned int digest_len, PHP_TIGER_CTX *context)
@@ -206,14 +206,14 @@ PHP_HASH_API void PHP_TIGERUpdate(PHP_TIGER_CTX *context, const unsigned char *i
 		if (context->length) {
 			i = 64 - context->length;
 			memcpy(&context->buffer[context->length], input, i);
-			tiger_compress(context->passes, ((const php_hash_uint64 *) context->buffer), context->state);
+			tiger_compress(context->passes, ((const uint64_t *) context->buffer), context->state);
 			ZEND_SECURE_ZERO(context->buffer, 64);
 			context->passed += 512;
 		}
 
 		for (; i + 64 <= len; i += 64) {
 			memcpy(context->buffer, &input[i], 64);
-			tiger_compress(context->passes, ((const php_hash_uint64 *) context->buffer), context->state);
+			tiger_compress(context->passes, ((const uint64_t *) context->buffer), context->state);
 			context->passed += 512;
 		}
 		ZEND_SECURE_ZERO(&context->buffer[r], 64-r);

--- a/ext/hash/hash_whirlpool.c
+++ b/ext/hash/hash_whirlpool.c
@@ -41,10 +41,10 @@
 static void WhirlpoolTransform(PHP_WHIRLPOOL_CTX *context)
 {
     int i, r;
-    php_hash_uint64 K[8];        /* the round key */
-    php_hash_uint64 block[8];    /* mu(buffer) */
-    php_hash_uint64 state[8];    /* the cipher state */
-    php_hash_uint64 L[8];
+    uint64_t K[8];        /* the round key */
+    uint64_t block[8];    /* mu(buffer) */
+    uint64_t state[8];    /* the cipher state */
+    uint64_t L[8];
     unsigned char *buffer = context->buffer.data;
 
     /*
@@ -52,14 +52,14 @@ static void WhirlpoolTransform(PHP_WHIRLPOOL_CTX *context)
      */
     for (i = 0; i < 8; i++, buffer += 8) {
         block[i] =
-            (((php_hash_uint64)buffer[0]        ) << 56) ^
-            (((php_hash_uint64)buffer[1] & 0xffL) << 48) ^
-            (((php_hash_uint64)buffer[2] & 0xffL) << 40) ^
-            (((php_hash_uint64)buffer[3] & 0xffL) << 32) ^
-            (((php_hash_uint64)buffer[4] & 0xffL) << 24) ^
-            (((php_hash_uint64)buffer[5] & 0xffL) << 16) ^
-            (((php_hash_uint64)buffer[6] & 0xffL) <<  8) ^
-            (((php_hash_uint64)buffer[7] & 0xffL)      );
+            (((uint64_t)buffer[0]        ) << 56) ^
+            (((uint64_t)buffer[1] & 0xffL) << 48) ^
+            (((uint64_t)buffer[2] & 0xffL) << 40) ^
+            (((uint64_t)buffer[3] & 0xffL) << 32) ^
+            (((uint64_t)buffer[4] & 0xffL) << 24) ^
+            (((uint64_t)buffer[5] & 0xffL) << 16) ^
+            (((uint64_t)buffer[6] & 0xffL) <<  8) ^
+            (((uint64_t)buffer[7] & 0xffL)      );
     }
     /*
      * compute and apply K^0 to the cipher state:
@@ -274,7 +274,7 @@ PHP_HASH_API void PHP_WHIRLPOOLInit(PHP_WHIRLPOOL_CTX *context)
 
 PHP_HASH_API void PHP_WHIRLPOOLUpdate(PHP_WHIRLPOOL_CTX *context, const unsigned char *input, size_t len)
 {
-    php_hash_uint64 sourceBits = len * 8;
+    uint64_t sourceBits = len * 8;
     int sourcePos    = 0; /* index of leftmost source unsigned char containing data (1 to 8 bits). */
     int sourceGap    = (8 - ((int)sourceBits & 7)) & 7; /* space on source[sourcePos]. */
     int bufferRem    = context->buffer.bits & 7; /* occupied bits on buffer[bufferPos]. */
@@ -283,15 +283,15 @@ PHP_HASH_API void PHP_WHIRLPOOLUpdate(PHP_WHIRLPOOL_CTX *context, const unsigned
     unsigned char *bitLength    = context->bitlength;
     int bufferBits   = context->buffer.bits;
     int bufferPos    = context->buffer.pos;
-    php_hash_uint32 b, carry;
+    uint32_t b, carry;
     int i;
 
     /*
      * tally the length of the added data:
      */
-    php_hash_uint64 value = sourceBits;
+    uint64_t value = sourceBits;
     for (i = 31, carry = 0; i >= 0 && (carry != 0 || value != L64(0)); i--) {
-        carry += bitLength[i] + ((php_hash_uint32)value & 0xff);
+        carry += bitLength[i] + ((uint32_t)value & 0xff);
         bitLength[i] = (unsigned char)carry;
         carry >>= 8;
         value >>= 8;

--- a/ext/hash/php_hash.h
+++ b/ext/hash/php_hash.h
@@ -31,10 +31,6 @@
 #define PHP_HASH_HMAC		0x0001
 
 #define L64 INT64_C
-#define php_hash_int32  int32_t
-#define php_hash_uint32 uint32_t
-#define php_hash_int64  int64_t
-#define php_hash_uint64 uint64_t
 
 typedef void (*php_hash_init_func_t)(void *context);
 typedef void (*php_hash_update_func_t)(void *context, const unsigned char *buf, unsigned int count);

--- a/ext/hash/php_hash_adler32.h
+++ b/ext/hash/php_hash_adler32.h
@@ -24,7 +24,7 @@
 #include "ext/standard/basic_functions.h"
 
 typedef struct {
-	php_hash_uint32 state;
+	uint32_t state;
 } PHP_ADLER32_CTX;
 
 PHP_HASH_API void PHP_ADLER32Init(PHP_ADLER32_CTX *context);

--- a/ext/hash/php_hash_crc32.h
+++ b/ext/hash/php_hash_crc32.h
@@ -24,7 +24,7 @@
 #include "ext/standard/basic_functions.h"
 
 typedef struct {
-	php_hash_uint32 state;
+	uint32_t state;
 } PHP_CRC32_CTX;
 
 PHP_HASH_API void PHP_CRC32Init(PHP_CRC32_CTX *context);

--- a/ext/hash/php_hash_crc32_tables.h
+++ b/ext/hash/php_hash_crc32_tables.h
@@ -18,7 +18,7 @@
 
 /* $Id$ */
 
-static const php_hash_uint32 crc32_table[] = {  0x0,
+static const uint32_t crc32_table[] = {  0x0,
 	0x04c11db7, 0x09823b6e, 0x0d4326d9, 0x130476dc, 0x17c56b6b,
 	0x1a864db2, 0x1e475005, 0x2608edb8, 0x22c9f00f, 0x2f8ad6d6,
 	0x2b4bcb61, 0x350c9b64, 0x31cd86d3, 0x3c8ea00a, 0x384fbdbd,
@@ -72,7 +72,7 @@ static const php_hash_uint32 crc32_table[] = {  0x0,
 	0xa2f33668, 0xbcb4666d, 0xb8757bda, 0xb5365d03, 0xb1f740b4
 };
 
-static const php_hash_uint32 crc32b_table[] = {
+static const uint32_t crc32b_table[] = {
 	0x00000000, 0x77073096, 0xee0e612c, 0x990951ba,
 	0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
 	0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,

--- a/ext/hash/php_hash_fnv.h
+++ b/ext/hash/php_hash_fnv.h
@@ -21,15 +21,15 @@
 #ifndef PHP_HASH_FNV_H
 #define PHP_HASH_FNV_H
 
-#define PHP_FNV1_32_INIT ((php_hash_uint32)0x811c9dc5)
+#define PHP_FNV1_32_INIT ((uint32_t)0x811c9dc5)
 #define PHP_FNV1_32A_INIT PHP_FNV1_32_INIT
 
-#define PHP_FNV_32_PRIME ((php_hash_uint32)0x01000193)
+#define PHP_FNV_32_PRIME ((uint32_t)0x01000193)
 
-#define PHP_FNV1_64_INIT ((php_hash_uint64)0xcbf29ce484222325ULL)
+#define PHP_FNV1_64_INIT ((uint64_t)0xcbf29ce484222325ULL)
 #define PHP_FNV1A_64_INIT FNV1_64_INIT
 
-#define PHP_FNV_64_PRIME ((php_hash_uint64)0x100000001b3ULL)
+#define PHP_FNV_64_PRIME ((uint64_t)0x100000001b3ULL)
 
 
 /*
@@ -46,11 +46,11 @@ enum php_fnv_type {
 };
 
 typedef struct {
-	php_hash_uint32 state;
+	uint32_t state;
 } PHP_FNV132_CTX;
 
 typedef struct {
-	php_hash_uint64 state;
+	uint64_t state;
 } PHP_FNV164_CTX;
 
 
@@ -64,8 +64,8 @@ PHP_HASH_API void PHP_FNV164Update(PHP_FNV164_CTX *context, const unsigned char 
 PHP_HASH_API void PHP_FNV1a64Update(PHP_FNV164_CTX *context, const unsigned char *input, unsigned int inputLen);
 PHP_HASH_API void PHP_FNV164Final(unsigned char digest[16], PHP_FNV164_CTX * context);
 
-static php_hash_uint32 fnv_32_buf(void *buf, size_t len, php_hash_uint32 hval, int alternate);
-static php_hash_uint64 fnv_64_buf(void *buf, size_t len, php_hash_uint64 hval, int alternate);
+static uint32_t fnv_32_buf(void *buf, size_t len, uint32_t hval, int alternate);
+static uint64_t fnv_64_buf(void *buf, size_t len, uint64_t hval, int alternate);
 
 #endif
 

--- a/ext/hash/php_hash_gost.h
+++ b/ext/hash/php_hash_gost.h
@@ -25,11 +25,11 @@
 
 /* GOST context */
 typedef struct {
-	php_hash_uint32 state[16];
-	php_hash_uint32 count[2];
+	uint32_t state[16];
+	uint32_t count[2];
 	unsigned char length;
 	unsigned char buffer[32];
-	const php_hash_uint32 (*tables)[4][256];
+	const uint32_t (*tables)[4][256];
 } PHP_GOST_CTX;
 
 PHP_HASH_API void PHP_GOSTInit(PHP_GOST_CTX *);

--- a/ext/hash/php_hash_gost_tables.h
+++ b/ext/hash/php_hash_gost_tables.h
@@ -1,4 +1,4 @@
-static const php_hash_uint32 tables_test[4][256] = {
+static const uint32_t tables_test[4][256] = {
 	{ /* table 1 */
 		0x00072000LU, 0x00075000LU, 0x00074800LU, 0x00071000LU, 0x00076800LU, 0x00074000LU, 0x00070000LU, 0x00077000LU,
 		0x00073000LU, 0x00075800LU, 0x00070800LU, 0x00076000LU, 0x00073800LU, 0x00077800LU, 0x00072800LU, 0x00071800LU,
@@ -137,7 +137,7 @@ static const php_hash_uint32 tables_test[4][256] = {
 	},
 };
 
-static const php_hash_uint32 tables_crypto[4][256] = {
+static const uint32_t tables_crypto[4][256] = {
 	{ /* table 1 */
 		0x0002d000LU, 0x0002a000LU, 0x0002a800LU, 0x0002b000LU, 0x0002c000LU, 0x00028800LU, 0x00029800LU, 0x0002b800LU,
 		0x0002e800LU, 0x0002e000LU, 0x0002f000LU, 0x00028000LU, 0x0002c800LU, 0x00029000LU, 0x0002d800LU, 0x0002f800LU,

--- a/ext/hash/php_hash_haval.h
+++ b/ext/hash/php_hash_haval.h
@@ -24,13 +24,13 @@
 #include "ext/standard/basic_functions.h"
 /* HAVAL context. */
 typedef struct {
-	php_hash_uint32 state[8];
-	php_hash_uint32 count[2];
+	uint32_t state[8];
+	uint32_t count[2];
 	unsigned char buffer[128];
 
 	char passes;
 	short output;
-	void (*Transform)(php_hash_uint32 state[8], const unsigned char block[128]);
+	void (*Transform)(uint32_t state[8], const unsigned char block[128]);
 } PHP_HAVAL_CTX;
 
 #define PHP_HASH_HAVAL_INIT_DECL(p,b)	PHP_HASH_API void PHP_##p##HAVAL##b##Init(PHP_HAVAL_CTX *); \

--- a/ext/hash/php_hash_joaat.h
+++ b/ext/hash/php_hash_joaat.h
@@ -22,14 +22,14 @@
 #define PHP_HASH_JOAAT_H
 
 typedef struct {
-	php_hash_uint32 state;
+	uint32_t state;
 } PHP_JOAAT_CTX;
 
 PHP_HASH_API void PHP_JOAATInit(PHP_JOAAT_CTX *context);
 PHP_HASH_API void PHP_JOAATUpdate(PHP_JOAAT_CTX *context, const unsigned char *input, unsigned int inputLen);
 PHP_HASH_API void PHP_JOAATFinal(unsigned char digest[16], PHP_JOAAT_CTX * context);
 
-static php_hash_uint32 joaat_buf(void *buf, size_t len, php_hash_uint32 hval);
+static uint32_t joaat_buf(void *buf, size_t len, uint32_t hval);
 
 #endif
 

--- a/ext/hash/php_hash_md.h
+++ b/ext/hash/php_hash_md.h
@@ -60,8 +60,8 @@
 
 /* MD5 context. */
 typedef struct {
-	php_hash_uint32 state[4];				/* state (ABCD) */
-	php_hash_uint32 count[2];				/* number of bits, modulo 2^64 (lsb first) */
+	uint32_t state[4];				/* state (ABCD) */
+	uint32_t count[2];				/* number of bits, modulo 2^64 (lsb first) */
 	unsigned char buffer[64];	/* input buffer */
 } PHP_MD5_CTX;
 
@@ -76,8 +76,8 @@ PHP_NAMED_FUNCTION(php_if_md5_file);
 
 /* MD4 context */
 typedef struct {
-	php_hash_uint32 state[4];
-	php_hash_uint32 count[2];
+	uint32_t state[4];
+	uint32_t count[2];
 	unsigned char buffer[64];
 } PHP_MD4_CTX;
 

--- a/ext/hash/php_hash_ripemd.h
+++ b/ext/hash/php_hash_ripemd.h
@@ -24,26 +24,26 @@
 
 /* RIPEMD context. */
 typedef struct {
-	php_hash_uint32 state[4];		/* state (ABCD) */
-	php_hash_uint32 count[2];		/* number of bits, modulo 2^64 (lsb first) */
+	uint32_t state[4];		/* state (ABCD) */
+	uint32_t count[2];		/* number of bits, modulo 2^64 (lsb first) */
 	unsigned char buffer[64];	/* input buffer */
 } PHP_RIPEMD128_CTX;
 
 typedef struct {
-	php_hash_uint32 state[5];		/* state (ABCD) */
-	php_hash_uint32 count[2];		/* number of bits, modulo 2^64 (lsb first) */
+	uint32_t state[5];		/* state (ABCD) */
+	uint32_t count[2];		/* number of bits, modulo 2^64 (lsb first) */
 	unsigned char buffer[64];	/* input buffer */
 } PHP_RIPEMD160_CTX;
 
 typedef struct {
-	php_hash_uint32 state[8];		/* state (ABCD) */
-	php_hash_uint32 count[2];		/* number of bits, modulo 2^64 (lsb first) */
+	uint32_t state[8];		/* state (ABCD) */
+	uint32_t count[2];		/* number of bits, modulo 2^64 (lsb first) */
 	unsigned char buffer[64];	/* input buffer */
 } PHP_RIPEMD256_CTX;
 
 typedef struct {
-	php_hash_uint32 state[10];		/* state (ABCD) */
-	php_hash_uint32 count[2];		/* number of bits, modulo 2^64 (lsb first) */
+	uint32_t state[10];		/* state (ABCD) */
+	uint32_t count[2];		/* number of bits, modulo 2^64 (lsb first) */
 	unsigned char buffer[64];	/* input buffer */
 } PHP_RIPEMD320_CTX;
 

--- a/ext/hash/php_hash_sha.h
+++ b/ext/hash/php_hash_sha.h
@@ -36,8 +36,8 @@
 
 /* SHA1 context. */
 typedef struct {
-	php_hash_uint32 state[5];		/* state (ABCD) */
-	php_hash_uint32 count[2];		/* number of bits, modulo 2^64 */
+	uint32_t state[5];		/* state (ABCD) */
+	uint32_t count[2];		/* number of bits, modulo 2^64 */
 	unsigned char buffer[64];	/* input buffer */
 } PHP_SHA1_CTX;
 
@@ -52,8 +52,8 @@ PHP_FUNCTION(sha1_file);
 
 /* SHA224 context. */
 typedef struct {
-	php_hash_uint32 state[8];		/* state */
-	php_hash_uint32 count[2];		/* number of bits, modulo 2^64 */
+	uint32_t state[8];		/* state */
+	uint32_t count[2];		/* number of bits, modulo 2^64 */
 	unsigned char buffer[64];	/* input buffer */
 } PHP_SHA224_CTX;
 
@@ -63,8 +63,8 @@ PHP_HASH_API void PHP_SHA224Final(unsigned char[28], PHP_SHA224_CTX *);
 
 /* SHA256 context. */
 typedef struct {
-	php_hash_uint32 state[8];		/* state */
-	php_hash_uint32 count[2];		/* number of bits, modulo 2^64 */
+	uint32_t state[8];		/* state */
+	uint32_t count[2];		/* number of bits, modulo 2^64 */
 	unsigned char buffer[64];	/* input buffer */
 } PHP_SHA256_CTX;
 
@@ -74,8 +74,8 @@ PHP_HASH_API void PHP_SHA256Final(unsigned char[32], PHP_SHA256_CTX *);
 
 /* SHA384 context */
 typedef struct {
-	php_hash_uint64 state[8];	/* state */
-	php_hash_uint64 count[2];	/* number of bits, modulo 2^128 */
+	uint64_t state[8];	/* state */
+	uint64_t count[2];	/* number of bits, modulo 2^128 */
 	unsigned char buffer[128];	/* input buffer */
 } PHP_SHA384_CTX;
 
@@ -85,8 +85,8 @@ PHP_HASH_API void PHP_SHA384Final(unsigned char[48], PHP_SHA384_CTX *);
 
 /* SHA512 context */
 typedef struct {
-	php_hash_uint64 state[8];	/* state */
-	php_hash_uint64 count[2];	/* number of bits, modulo 2^128 */
+	uint64_t state[8];	/* state */
+	uint64_t count[2];	/* number of bits, modulo 2^128 */
 	unsigned char buffer[128];	/* input buffer */
 } PHP_SHA512_CTX;
 

--- a/ext/hash/php_hash_sha3.h
+++ b/ext/hash/php_hash_sha3.h
@@ -24,7 +24,7 @@
 
 typedef struct {
 	unsigned char state[200]; // 5 * 5 * sizeof(uint64)
-	php_hash_uint32 pos;
+	uint32_t pos;
 } PHP_SHA3_CTX;
 
 typedef PHP_SHA3_CTX PHP_SHA3_224_CTX;

--- a/ext/hash/php_hash_snefru.h
+++ b/ext/hash/php_hash_snefru.h
@@ -29,8 +29,8 @@
 
 /* SNEFRU context */
 typedef struct {
-	php_hash_uint32 state[16];
-	php_hash_uint32 count[2];
+	uint32_t state[16];
+	uint32_t count[2];
 	unsigned char length;
 	unsigned char buffer[32];
 } PHP_SNEFRU_CTX;

--- a/ext/hash/php_hash_snefru_tables.h
+++ b/ext/hash/php_hash_snefru_tables.h
@@ -18,7 +18,7 @@
 
 /* $Id$ */
 
-static const php_hash_uint32 tables[16][256]= {
+static const uint32_t tables[16][256]= {
 
  {  /* Start of S Box 0  */
 

--- a/ext/hash/php_hash_tiger.h
+++ b/ext/hash/php_hash_tiger.h
@@ -23,8 +23,8 @@
 
 /* TIGER context */
 typedef struct {
-	php_hash_uint64 state[3];
-	php_hash_uint64 passed;
+	uint64_t state[3];
+	uint64_t passed;
 	unsigned char buffer[64];
 	unsigned int passes:1;
 	unsigned int length:7;

--- a/ext/hash/php_hash_tiger_tables.h
+++ b/ext/hash/php_hash_tiger_tables.h
@@ -24,7 +24,7 @@
 #define t3 (table+256*2)
 #define t4 (table+256*3)
 
-static const php_hash_uint64 table[4*256] = {
+static const uint64_t table[4*256] = {
 	L64(0x02AAB17CF7E90C5E)   /*    0 */,    L64(0xAC424B03E243A8EC)   /*    1 */,
 	L64(0x72CD5BE30DD5FCD3)   /*    2 */,    L64(0x6D019B93F6F97F3A)   /*    3 */,
 	L64(0xCD9978FFD21F9193)   /*    4 */,    L64(0x7573A1C9708029E2)   /*    5 */,

--- a/ext/hash/php_hash_whirlpool.h
+++ b/ext/hash/php_hash_whirlpool.h
@@ -23,7 +23,7 @@
 
 /* WHIRLPOOL context */
 typedef struct {
-	php_hash_uint64 state[8];
+	uint64_t state[8];
 	unsigned char bitlength[32];
 	struct {
 		int pos;

--- a/ext/hash/php_hash_whirlpool_tables.h
+++ b/ext/hash/php_hash_whirlpool_tables.h
@@ -23,7 +23,7 @@
 
 #define R 10
 
-static const php_hash_uint64 rc[R + 1] = {
+static const uint64_t rc[R + 1] = {
     L64(0x0000000000000000),
     L64(0x1823c6e887b8014f),
     L64(0x36a6d2f5796f9152),
@@ -37,7 +37,7 @@ static const php_hash_uint64 rc[R + 1] = {
     L64(0xca2dbf07ad5a8333),
 };
 
-static const php_hash_uint64 C0[256] = {
+static const uint64_t C0[256] = {
     L64(0x18186018c07830d8), L64(0x23238c2305af4626), L64(0xc6c63fc67ef991b8), L64(0xe8e887e8136fcdfb),
     L64(0x878726874ca113cb), L64(0xb8b8dab8a9626d11), L64(0x0101040108050209), L64(0x4f4f214f426e9e0d),
     L64(0x3636d836adee6c9b), L64(0xa6a6a2a6590451ff), L64(0xd2d26fd2debdb90c), L64(0xf5f5f3f5fb06f70e),
@@ -104,7 +104,7 @@ static const php_hash_uint64 C0[256] = {
     L64(0x2828a0285d885075), L64(0x5c5c6d5cda31b886), L64(0xf8f8c7f8933fed6b), L64(0x8686228644a411c2),
 };
 
-static const php_hash_uint64 C1[256] = {
+static const uint64_t C1[256] = {
     L64(0xd818186018c07830), L64(0x2623238c2305af46), L64(0xb8c6c63fc67ef991), L64(0xfbe8e887e8136fcd),
     L64(0xcb878726874ca113), L64(0x11b8b8dab8a9626d), L64(0x0901010401080502), L64(0x0d4f4f214f426e9e),
     L64(0x9b3636d836adee6c), L64(0xffa6a6a2a6590451), L64(0x0cd2d26fd2debdb9), L64(0x0ef5f5f3f5fb06f7),
@@ -171,7 +171,7 @@ static const php_hash_uint64 C1[256] = {
     L64(0x752828a0285d8850), L64(0x865c5c6d5cda31b8), L64(0x6bf8f8c7f8933fed), L64(0xc28686228644a411),
 };
 
-static const php_hash_uint64 C2[256] = {
+static const uint64_t C2[256] = {
     L64(0x30d818186018c078), L64(0x462623238c2305af), L64(0x91b8c6c63fc67ef9), L64(0xcdfbe8e887e8136f),
     L64(0x13cb878726874ca1), L64(0x6d11b8b8dab8a962), L64(0x0209010104010805), L64(0x9e0d4f4f214f426e),
     L64(0x6c9b3636d836adee), L64(0x51ffa6a6a2a65904), L64(0xb90cd2d26fd2debd), L64(0xf70ef5f5f3f5fb06),
@@ -238,7 +238,7 @@ static const php_hash_uint64 C2[256] = {
     L64(0x50752828a0285d88), L64(0xb8865c5c6d5cda31), L64(0xed6bf8f8c7f8933f), L64(0x11c28686228644a4),
 };
 
-static const php_hash_uint64 C3[256] = {
+static const uint64_t C3[256] = {
     L64(0x7830d818186018c0), L64(0xaf462623238c2305), L64(0xf991b8c6c63fc67e), L64(0x6fcdfbe8e887e813),
     L64(0xa113cb878726874c), L64(0x626d11b8b8dab8a9), L64(0x0502090101040108), L64(0x6e9e0d4f4f214f42),
     L64(0xee6c9b3636d836ad), L64(0x0451ffa6a6a2a659), L64(0xbdb90cd2d26fd2de), L64(0x06f70ef5f5f3f5fb),
@@ -305,7 +305,7 @@ static const php_hash_uint64 C3[256] = {
     L64(0x8850752828a0285d), L64(0x31b8865c5c6d5cda), L64(0x3fed6bf8f8c7f893), L64(0xa411c28686228644),
 };
 
-static const php_hash_uint64 C4[256] = {
+static const uint64_t C4[256] = {
     L64(0xc07830d818186018), L64(0x05af462623238c23), L64(0x7ef991b8c6c63fc6), L64(0x136fcdfbe8e887e8),
     L64(0x4ca113cb87872687), L64(0xa9626d11b8b8dab8), L64(0x0805020901010401), L64(0x426e9e0d4f4f214f),
     L64(0xadee6c9b3636d836), L64(0x590451ffa6a6a2a6), L64(0xdebdb90cd2d26fd2), L64(0xfb06f70ef5f5f3f5),
@@ -372,7 +372,7 @@ static const php_hash_uint64 C4[256] = {
     L64(0x5d8850752828a028), L64(0xda31b8865c5c6d5c), L64(0x933fed6bf8f8c7f8), L64(0x44a411c286862286),
 };
 
-static const php_hash_uint64 C5[256] = {
+static const uint64_t C5[256] = {
     L64(0x18c07830d8181860), L64(0x2305af462623238c), L64(0xc67ef991b8c6c63f), L64(0xe8136fcdfbe8e887),
     L64(0x874ca113cb878726), L64(0xb8a9626d11b8b8da), L64(0x0108050209010104), L64(0x4f426e9e0d4f4f21),
     L64(0x36adee6c9b3636d8), L64(0xa6590451ffa6a6a2), L64(0xd2debdb90cd2d26f), L64(0xf5fb06f70ef5f5f3),
@@ -439,7 +439,7 @@ static const php_hash_uint64 C5[256] = {
     L64(0x285d8850752828a0), L64(0x5cda31b8865c5c6d), L64(0xf8933fed6bf8f8c7), L64(0x8644a411c2868622),
 };
 
-static const php_hash_uint64 C6[256] = {
+static const uint64_t C6[256] = {
     L64(0x6018c07830d81818), L64(0x8c2305af46262323), L64(0x3fc67ef991b8c6c6), L64(0x87e8136fcdfbe8e8),
     L64(0x26874ca113cb8787), L64(0xdab8a9626d11b8b8), L64(0x0401080502090101), L64(0x214f426e9e0d4f4f),
     L64(0xd836adee6c9b3636), L64(0xa2a6590451ffa6a6), L64(0x6fd2debdb90cd2d2), L64(0xf3f5fb06f70ef5f5),
@@ -506,7 +506,7 @@ static const php_hash_uint64 C6[256] = {
     L64(0xa0285d8850752828), L64(0x6d5cda31b8865c5c), L64(0xc7f8933fed6bf8f8), L64(0x228644a411c28686),
 };
 
-static const php_hash_uint64 C7[256] = {
+static const uint64_t C7[256] = {
     L64(0x186018c07830d818), L64(0x238c2305af462623), L64(0xc63fc67ef991b8c6), L64(0xe887e8136fcdfbe8),
     L64(0x8726874ca113cb87), L64(0xb8dab8a9626d11b8), L64(0x0104010805020901), L64(0x4f214f426e9e0d4f),
     L64(0x36d836adee6c9b36), L64(0xa6a2a6590451ffa6), L64(0xd26fd2debdb90cd2), L64(0xf5f3f5fb06f70ef5),

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -521,10 +521,10 @@ void phar_entry_remove(phar_entry_data *idata, char **error) /* {{{ */
 #endif
 #define PHAR_ZIP_16(var) ((php_uint16)((((php_uint16)var[0]) & 0xff) | \
 	(((php_uint16)var[1]) & 0xff) << 8))
-#define PHAR_ZIP_32(var) ((php_uint32)((((php_uint32)var[0]) & 0xff) | \
-	(((php_uint32)var[1]) & 0xff) << 8 | \
-	(((php_uint32)var[2]) & 0xff) << 16 | \
-	(((php_uint32)var[3]) & 0xff) << 24))
+#define PHAR_ZIP_32(var) ((uint32_t)((((uint32_t)var[0]) & 0xff) | \
+	(((uint32_t)var[1]) & 0xff) << 8 | \
+	(((uint32_t)var[2]) & 0xff) << 16 | \
+	(((uint32_t)var[3]) & 0xff) << 24))
 
 /**
  * Open an already loaded phar
@@ -604,7 +604,7 @@ int phar_open_parsed_phar(char *fname, int fname_len, char *alias, int alias_len
  *
  * data is the serialized zval
  */
-int phar_parse_metadata(char **buffer, zval *metadata, php_uint32 zip_metadata_len) /* {{{ */
+int phar_parse_metadata(char **buffer, zval *metadata, uint32_t zip_metadata_len) /* {{{ */
 {
 	php_unserialize_data_t var_hash;
 
@@ -649,14 +649,14 @@ int phar_parse_metadata(char **buffer, zval *metadata, php_uint32 zip_metadata_l
  * This is used by phar_open_from_filename to process the manifest, but can be called
  * directly.
  */
-static int phar_parse_pharfile(php_stream *fp, char *fname, int fname_len, char *alias, int alias_len, zend_long halt_offset, phar_archive_data** pphar, php_uint32 compression, char **error) /* {{{ */
+static int phar_parse_pharfile(php_stream *fp, char *fname, int fname_len, char *alias, int alias_len, zend_long halt_offset, phar_archive_data** pphar, uint32_t compression, char **error) /* {{{ */
 {
 	char b32[4], *buffer, *endbuffer, *savebuf;
 	phar_archive_data *mydata = NULL;
 	phar_entry_info entry;
-	php_uint32 manifest_len, manifest_count, manifest_flags, manifest_index, tmp_len, sig_flags;
+	uint32_t manifest_len, manifest_count, manifest_flags, manifest_index, tmp_len, sig_flags;
 	php_uint16 manifest_ver;
-	php_uint32 len;
+	uint32_t len;
 	zend_long offset;
 	int sig_len, register_alias = 0, temp_alias = 0;
 	char *signature = NULL;
@@ -778,7 +778,7 @@ static int phar_parse_pharfile(php_stream *fp, char *fname, int fname_len, char 
 
 		switch(sig_flags) {
 			case PHAR_SIG_OPENSSL: {
-				php_uint32 signature_len;
+				uint32_t signature_len;
 				char *sig;
 				zend_off_t whence;
 
@@ -1565,7 +1565,7 @@ static int phar_open_from_fp(php_stream* fp, char *fname, int fname_len, char *a
 	const zend_long tokenlen = sizeof(token) - 1;
 	zend_long halt_offset;
 	size_t got;
-	php_uint32 compression = PHAR_FILE_COMPRESSED_NONE;
+	uint32_t compression = PHAR_FILE_COMPRESSED_NONE;
 
 	if (error) {
 		*error = NULL;
@@ -2309,9 +2309,9 @@ int phar_open_executed_filename(char *alias, int alias_len, char **error) /* {{{
 /**
  * Validate the CRC32 of a file opened from within the phar
  */
-int phar_postprocess_file(phar_entry_data *idata, php_uint32 crc32, char **error, int process_zip) /* {{{ */
+int phar_postprocess_file(phar_entry_data *idata, uint32_t crc32, char **error, int process_zip) /* {{{ */
 {
-	php_uint32 crc = ~0;
+	uint32_t crc = ~0;
 	int len = idata->internal_file->uncompressed_filesize;
 	php_stream *fp = idata->fp;
 	phar_entry_info *entry = idata->internal_file;
@@ -2476,8 +2476,8 @@ int phar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int conv
 	zend_off_t manifest_ftell;
 	zend_long offset;
 	size_t wrote;
-	php_uint32 manifest_len, mytime, loc, new_manifest_count;
-	php_uint32 newcrc32;
+	uint32_t manifest_len, mytime, loc, new_manifest_count;
+	uint32_t newcrc32;
 	php_stream *file, *oldfile, *newfile, *stubfile;
 	php_stream_filter *filter;
 	php_serialize_data_t metadata_hash;
@@ -2809,7 +2809,7 @@ int phar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int conv
 		php_stream_flush(entry->cfp);
 		php_stream_filter_remove(filter, 1);
 		php_stream_seek(entry->cfp, 0, SEEK_END);
-		entry->compressed_filesize = (php_uint32) php_stream_tell(entry->cfp);
+		entry->compressed_filesize = (uint32_t) php_stream_tell(entry->cfp);
 		/* generate crc on compressed file */
 		php_stream_rewind(entry->cfp);
 		entry->old_flags = entry->flags;

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -516,11 +516,11 @@ void phar_entry_remove(phar_entry_data *idata, char **error) /* {{{ */
 	memcpy(&var, buffer, sizeof(var)); \
 	buffer += 4
 # define PHAR_GET_16(buffer, var) \
-	var = *(php_uint16*)(buffer); \
+	var = *(uint16_t*)(buffer); \
 	buffer += 2
 #endif
-#define PHAR_ZIP_16(var) ((php_uint16)((((php_uint16)var[0]) & 0xff) | \
-	(((php_uint16)var[1]) & 0xff) << 8))
+#define PHAR_ZIP_16(var) ((uint16_t)((((uint16_t)var[0]) & 0xff) | \
+	(((uint16_t)var[1]) & 0xff) << 8))
 #define PHAR_ZIP_32(var) ((uint32_t)((((uint32_t)var[0]) & 0xff) | \
 	(((uint32_t)var[1]) & 0xff) << 8 | \
 	(((uint32_t)var[2]) & 0xff) << 16 | \
@@ -655,7 +655,7 @@ static int phar_parse_pharfile(php_stream *fp, char *fname, int fname_len, char 
 	phar_archive_data *mydata = NULL;
 	phar_entry_info entry;
 	uint32_t manifest_len, manifest_count, manifest_flags, manifest_index, tmp_len, sig_flags;
-	php_uint16 manifest_ver;
+	uint16_t manifest_ver;
 	uint32_t len;
 	zend_long offset;
 	int sig_len, register_alias = 0, temp_alias = 0;

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -199,13 +199,6 @@ ZEND_EXTERN_MODULE_GLOBALS(phar)
 ZEND_TSRMLS_CACHE_EXTERN();
 #endif
 
-#ifndef php_uint16
-# if SIZEOF_SHORT == 2
-#  define php_uint16 unsigned short
-# else
-#  define php_uint16 uint16_t
-# endif
-#endif
 #include "pharzip.h"
 
 typedef union _phar_archive_object  phar_archive_object;

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -229,17 +229,17 @@ enum phar_fp_type {
 /* entry for one file in a phar file */
 typedef struct _phar_entry_info {
 	/* first bytes are exactly as in file */
-	php_uint32               uncompressed_filesize;
-	php_uint32               timestamp;
-	php_uint32               compressed_filesize;
-	php_uint32               crc32;
-	php_uint32               flags;
+	uint32_t                 uncompressed_filesize;
+	uint32_t                 timestamp;
+	uint32_t                 compressed_filesize;
+	uint32_t                 crc32;
+	uint32_t                 flags;
 	/* remainder */
 	/* when changing compression, save old flags in case fp is NULL */
-	php_uint32               old_flags;
+	uint32_t                 old_flags;
 	zval                     metadata;
 	int                      metadata_len; /* only used for cached manifests */
-	php_uint32               filename_len;
+	uint32_t                 filename_len;
 	char                     *filename;
 	enum phar_fp_type        fp_type;
 	/* offset within original phar file of the file contents */
@@ -295,14 +295,14 @@ struct _phar_archive_data {
 	HashTable                virtual_dirs;
 	/* hash of mounted directory paths */
 	HashTable                mounted_dirs;
-	php_uint32               flags;
-	php_uint32               min_timestamp;
-	php_uint32               max_timestamp;
+	uint32_t                 flags;
+	uint32_t                 min_timestamp;
+	uint32_t                 max_timestamp;
 	php_stream               *fp;
 	/* decompressed file contents are stored here */
 	php_stream               *ufp;
 	int                      refcount;
-	php_uint32               sig_flags;
+	uint32_t                 sig_flags;
 	int                      sig_len;
 	char                     *signature;
 	zval                     metadata;
@@ -536,7 +536,7 @@ void phar_object_init(void);
 void phar_destroy_phar_data(phar_archive_data *phar);
 
 int phar_open_entry_file(phar_archive_data *phar, phar_entry_info *entry, char **error);
-int phar_postprocess_file(phar_entry_data *idata, php_uint32 crc32, char **error, int process_zip);
+int phar_postprocess_file(phar_entry_data *idata, uint32_t crc32, char **error, int process_zip);
 int phar_open_from_filename(char *fname, int fname_len, char *alias, int alias_len, int options, phar_archive_data** pphar, char **error);
 int phar_open_or_create_filename(char *fname, int fname_len, char *alias, int alias_len, int is_data, int options, phar_archive_data** pphar, char **error);
 int phar_create_or_parse_filename(char *fname, int fname_len, char *alias, int alias_len, int is_data, int options, phar_archive_data** pphar, char **error);
@@ -544,7 +544,7 @@ int phar_open_executed_filename(char *alias, int alias_len, char **error);
 int phar_free_alias(phar_archive_data *phar, char *alias, int alias_len);
 int phar_get_archive(phar_archive_data **archive, char *fname, int fname_len, char *alias, int alias_len, char **error);
 int phar_open_parsed_phar(char *fname, int fname_len, char *alias, int alias_len, int is_data, int options, phar_archive_data** pphar, char **error);
-int phar_verify_signature(php_stream *fp, size_t end_of_phar, php_uint32 sig_type, char *sig, int sig_len, char *fname, char **signature, int *signature_len, char **error);
+int phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t sig_type, char *sig, int sig_len, char *fname, char **signature, int *signature_len, char **error);
 int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signature, int *signature_length, char **error);
 
 /* utility functions */
@@ -558,7 +558,7 @@ int phar_mount_entry(phar_archive_data *phar, char *filename, int filename_len, 
 zend_string *phar_find_in_include_path(char *file, int file_len, phar_archive_data **pphar);
 char *phar_fix_filepath(char *path, int *new_len, int use_cwd);
 phar_entry_info * phar_open_jit(phar_archive_data *phar, phar_entry_info *entry, char **error);
-int phar_parse_metadata(char **buffer, zval *metadata, php_uint32 zip_metadata_len);
+int phar_parse_metadata(char **buffer, zval *metadata, uint32_t zip_metadata_len);
 void destroy_phar_manifest_entry(zval *zv);
 int phar_seek_efp(phar_entry_info *entry, zend_off_t offset, int whence, zend_off_t position, int follow_links);
 php_stream *phar_get_efp(phar_entry_info *entry, int follow_links);
@@ -572,7 +572,7 @@ int phar_copy_on_write(phar_archive_data **pphar);
 
 /* tar functions in tar.c */
 int phar_is_tar(char *buf, char *fname);
-int phar_parse_tarfile(php_stream* fp, char *fname, int fname_len, char *alias, int alias_len, phar_archive_data** pphar, int is_data, php_uint32 compression, char **error);
+int phar_parse_tarfile(php_stream* fp, char *fname, int fname_len, char *alias, int alias_len, phar_archive_data** pphar, int is_data, uint32_t compression, char **error);
 int phar_open_or_create_tar(char *fname, int fname_len, char *alias, int alias_len, int is_data, int options, phar_archive_data** pphar, char **error);
 int phar_tar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int defaultstub, char **error);
 

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -2164,7 +2164,7 @@ its_ok:
 }
 /* }}} */
 
-static zend_object *phar_convert_to_other(phar_archive_data *source, int convert, char *ext, php_uint32 flags) /* {{{ */
+static zend_object *phar_convert_to_other(phar_archive_data *source, int convert, char *ext, uint32_t flags) /* {{{ */
 {
 	phar_archive_data *phar;
 	phar_entry_info *entry, newentry;
@@ -2288,7 +2288,7 @@ PHP_METHOD(Phar, convertToExecutable)
 	char *ext = NULL;
 	int is_data;
 	size_t ext_len = 0;
-	php_uint32 flags;
+	uint32_t flags;
 	zend_object *ret;
 	/* a number that is not 0, 1 or 2 (Which is also Greg's birthday, so there) */
 	zend_long format = 9021976, method = 9021976;
@@ -2392,7 +2392,7 @@ PHP_METHOD(Phar, convertToData)
 	char *ext = NULL;
 	int is_data;
 	size_t ext_len = 0;
-	php_uint32 flags;
+	uint32_t flags;
 	zend_object *ret;
 	/* a number that is not 0, 1 or 2 (Which is also Greg's birthday so there) */
 	zend_long format = 9021976, method = 9021976;
@@ -3066,7 +3066,7 @@ PHP_METHOD(Phar, getModified)
 static int phar_set_compression(zval *zv, void *argument) /* {{{ */
 {
 	phar_entry_info *entry = (phar_entry_info *)Z_PTR_P(zv);
-	php_uint32 compress = *(php_uint32 *)argument;
+	uint32_t compress = *(uint32_t *)argument;
 
 	if (entry->is_deleted) {
 		return ZEND_HASH_APPLY_KEEP;
@@ -3104,7 +3104,7 @@ static int phar_test_compression(zval *zv, void *argument) /* {{{ */
 }
 /* }}} */
 
-static void pharobj_set_compression(HashTable *manifest, php_uint32 compress) /* {{{ */
+static void pharobj_set_compression(HashTable *manifest, uint32_t compress) /* {{{ */
 {
 	zend_hash_apply_with_argument(manifest, phar_set_compression, &compress);
 }
@@ -3130,7 +3130,7 @@ PHP_METHOD(Phar, compress)
 	zend_long method;
 	char *ext = NULL;
 	size_t ext_len = 0;
-	php_uint32 flags;
+	uint32_t flags;
 	zend_object *ret;
 	PHAR_ARCHIVE_OBJECT();
 
@@ -3239,7 +3239,7 @@ PHP_METHOD(Phar, decompress)
 PHP_METHOD(Phar, compressFiles)
 {
 	char *error;
-	php_uint32 flags;
+	uint32_t flags;
 	zend_long method;
 	PHAR_ARCHIVE_OBJECT();
 

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -19,9 +19,9 @@
 
 #include "phar_internal.h"
 
-static php_uint32 phar_tar_number(char *buf, int len) /* {{{ */
+static uint32_t phar_tar_number(char *buf, int len) /* {{{ */
 {
-	php_uint32 num = 0;
+	uint32_t num = 0;
 	int i = 0;
 
 	while (i < len && buf[i] == ' ') {
@@ -62,7 +62,7 @@ static php_uint32 phar_tar_number(char *buf, int len) /* {{{ */
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-static int phar_tar_octal(char *buf, php_uint32 val, int len) /* {{{ */
+static int phar_tar_octal(char *buf, uint32_t val, int len) /* {{{ */
 {
 	char *p = buf;
 	int s = len;
@@ -84,9 +84,9 @@ static int phar_tar_octal(char *buf, php_uint32 val, int len) /* {{{ */
 }
 /* }}} */
 
-static php_uint32 phar_tar_checksum(char *buf, int len) /* {{{ */
+static uint32_t phar_tar_checksum(char *buf, int len) /* {{{ */
 {
-	php_uint32 sum = 0;
+	uint32_t sum = 0;
 	char *end = buf + len;
 
 	while (buf != end) {
@@ -100,8 +100,8 @@ static php_uint32 phar_tar_checksum(char *buf, int len) /* {{{ */
 int phar_is_tar(char *buf, char *fname) /* {{{ */
 {
 	tar_header *header = (tar_header *) buf;
-	php_uint32 checksum = phar_tar_number(header->checksum, sizeof(header->checksum));
-	php_uint32 ret;
+	uint32_t checksum = phar_tar_number(header->checksum, sizeof(header->checksum));
+	uint32_t ret;
 	char save[sizeof(header->checksum)], *bname;
 
 	/* assume that the first filename in a tar won't begin with <?php */
@@ -195,13 +195,13 @@ static int phar_tar_process_metadata(phar_entry_info *entry, php_stream *fp) /* 
 }
 /* }}} */
 
-int phar_parse_tarfile(php_stream* fp, char *fname, int fname_len, char *alias, int alias_len, phar_archive_data** pphar, int is_data, php_uint32 compression, char **error) /* {{{ */
+int phar_parse_tarfile(php_stream* fp, char *fname, int fname_len, char *alias, int alias_len, phar_archive_data** pphar, int is_data, uint32_t compression, char **error) /* {{{ */
 {
 	char buf[512], *actual_alias = NULL, *p;
 	phar_entry_info entry = {0};
 	size_t pos = 0, read, totalsize;
 	tar_header *hdr;
-	php_uint32 sum1, sum2, size, old;
+	uint32_t sum1, sum2, size, old;
 	phar_archive_data *myphar, *actual;
 	int last_was_longlink = 0;
 
@@ -291,7 +291,7 @@ bail:
 		| ((((unsigned char*)(buffer))[1]) <<  8) \
 		| (((unsigned char*)(buffer))[0]))
 #else
-# define PHAR_GET_32(buffer) (php_uint32) *(buffer)
+# define PHAR_GET_32(buffer) (uint32_t) *(buffer)
 #endif
 			myphar->sig_flags = PHAR_GET_32(buf);
 			if (FAILURE == phar_verify_signature(fp, php_stream_tell(fp) - size - 512, myphar->sig_flags, buf + 8, size - 8, fname, &myphar->signature, &myphar->sig_len, error)) {
@@ -1225,12 +1225,12 @@ nostub:
 		}
 #ifdef WORDS_BIGENDIAN
 # define PHAR_SET_32(var, buffer) \
-	*(php_uint32 *)(var) = (((((unsigned char*)&(buffer))[3]) << 24) \
+	*(uint32_t *)(var) = (((((unsigned char*)&(buffer))[3]) << 24) \
 		| ((((unsigned char*)&(buffer))[2]) << 16) \
 		| ((((unsigned char*)&(buffer))[1]) << 8) \
 		| (((unsigned char*)&(buffer))[0]))
 #else
-# define PHAR_SET_32(var, buffer) *(php_uint32 *)(var) = (php_uint32) (buffer)
+# define PHAR_SET_32(var, buffer) *(uint32_t *)(var) = (uint32_t) (buffer)
 #endif
 		PHAR_SET_32(sigbuf, phar->sig_flags);
 		PHAR_SET_32(sigbuf + 4, signature_length);

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1177,7 +1177,7 @@ char * phar_compress_filter(phar_entry_info * entry, int return_unknown) /* {{{ 
  */
 char * phar_decompress_filter(phar_entry_info * entry, int return_unknown) /* {{{ */
 {
-	php_uint32 flags;
+	uint32_t flags;
 
 	if (entry->is_modified) {
 		flags = entry->old_flags;
@@ -1473,7 +1473,7 @@ static int phar_call_openssl_signverify(int is_sign, php_stream *fp, zend_off_t 
 /* }}} */
 #endif /* #ifndef PHAR_HAVE_OPENSSL */
 
-int phar_verify_signature(php_stream *fp, size_t end_of_phar, php_uint32 sig_type, char *sig, int sig_len, char *fname, char **signature, int *signature_len, char **error) /* {{{ */
+int phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t sig_type, char *sig, int sig_len, char *fname, char **signature, int *signature_len, char **error) /* {{{ */
 {
 	int read_size, len;
 	zend_off_t read_len;

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -18,8 +18,8 @@
 
 #include "phar_internal.h"
 
-#define PHAR_GET_16(var) ((php_uint16)((((php_uint16)var[0]) & 0xff) | \
-	(((php_uint16)var[1]) & 0xff) << 8))
+#define PHAR_GET_16(var) ((uint16_t)((((uint16_t)var[0]) & 0xff) | \
+	(((uint16_t)var[1]) & 0xff) << 8))
 #define PHAR_GET_32(var) ((uint32_t)((((uint32_t)var[0]) & 0xff) | \
 	(((uint32_t)var[1]) & 0xff) << 8 | \
 	(((uint32_t)var[2]) & 0xff) << 16 | \
@@ -37,9 +37,9 @@ static inline void phar_write_16(char buffer[2], uint32_t value)
 	buffer[0] = (unsigned char) (value & 0xff);
 }
 # define PHAR_SET_32(var, value) phar_write_32(var, (uint32_t) (value));
-# define PHAR_SET_16(var, value) phar_write_16(var, (php_uint16) (value));
+# define PHAR_SET_16(var, value) phar_write_16(var, (uint16_t) (value));
 
-static int phar_zip_process_extra(php_stream *fp, phar_entry_info *entry, php_uint16 len) /* {{{ */
+static int phar_zip_process_extra(php_stream *fp, phar_entry_info *entry, uint16_t len) /* {{{ */
 {
 	union {
 		phar_zip_extra_field_header header;
@@ -143,7 +143,7 @@ static time_t phar_zip_d2u_time(char *cdtime, char *cddate) /* {{{ */
 
 static void phar_zip_u2d_time(time_t time, char *dtime, char *ddate) /* {{{ */
 {
-	php_uint16 ctime, cdate;
+	uint16_t ctime, cdate;
 	struct tm *tm, tmbuf;
 
 	tm = php_localtime_r(&time, &tmbuf);
@@ -168,7 +168,7 @@ int phar_parse_zipfile(php_stream *fp, char *fname, int fname_len, char *alias, 
 	phar_zip_dir_end locator;
 	char buf[sizeof(locator) + 65536];
 	zend_long size;
-	php_uint16 i;
+	uint16_t i;
 	phar_archive_data *mydata = NULL;
 	phar_entry_info entry = {0};
 	char *p = buf, *ext, *actual_alias = NULL;

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -20,23 +20,23 @@
 
 #define PHAR_GET_16(var) ((php_uint16)((((php_uint16)var[0]) & 0xff) | \
 	(((php_uint16)var[1]) & 0xff) << 8))
-#define PHAR_GET_32(var) ((php_uint32)((((php_uint32)var[0]) & 0xff) | \
-	(((php_uint32)var[1]) & 0xff) << 8 | \
-	(((php_uint32)var[2]) & 0xff) << 16 | \
-	(((php_uint32)var[3]) & 0xff) << 24))
-static inline void phar_write_32(char buffer[4], php_uint32 value)
+#define PHAR_GET_32(var) ((uint32_t)((((uint32_t)var[0]) & 0xff) | \
+	(((uint32_t)var[1]) & 0xff) << 8 | \
+	(((uint32_t)var[2]) & 0xff) << 16 | \
+	(((uint32_t)var[3]) & 0xff) << 24))
+static inline void phar_write_32(char buffer[4], uint32_t value)
 {
 	buffer[3] = (unsigned char) ((value & 0xff000000) >> 24);
 	buffer[2] = (unsigned char) ((value & 0xff0000) >> 16);
 	buffer[1] = (unsigned char) ((value & 0xff00) >> 8);
 	buffer[0] = (unsigned char) (value & 0xff);
 }
-static inline void phar_write_16(char buffer[2], php_uint32 value)
+static inline void phar_write_16(char buffer[2], uint32_t value)
 {
 	buffer[1] = (unsigned char) ((value & 0xff00) >> 8);
 	buffer[0] = (unsigned char) (value & 0xff);
 }
-# define PHAR_SET_32(var, value) phar_write_32(var, (php_uint32) (value));
+# define PHAR_SET_32(var, value) phar_write_32(var, (uint32_t) (value));
 # define PHAR_SET_16(var, value) phar_write_16(var, (php_uint16) (value));
 
 static int phar_zip_process_extra(php_stream *fp, phar_entry_info *entry, php_uint16 len) /* {{{ */
@@ -791,7 +791,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 	phar_zip_unix3 perms;
 	phar_zip_central_dir_file central;
 	struct _phar_zip_pass *p;
-	php_uint32 newcrc32;
+	uint32_t newcrc32;
 	zend_off_t offset;
 	int not_really_modified = 0;
 	p = (struct _phar_zip_pass*) arg;
@@ -822,7 +822,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 	PHAR_SET_16(perms.size, sizeof(perms) - 4);
 	PHAR_SET_16(perms.perms, entry->flags & PHAR_ENT_PERM_MASK);
 	{
-		php_uint32 crc = (php_uint32) ~0;
+		uint32_t crc = (uint32_t) ~0;
 		CRC32(crc, perms.perms[0]);
 		CRC32(crc, perms.perms[1]);
 		PHAR_SET_32(perms.crc32, ~crc);
@@ -848,7 +848,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 
 	/* do extra field for perms later */
 	if (entry->is_modified) {
-		php_uint32 loc;
+		uint32_t loc;
 		php_stream_filter *filter;
 		php_stream *efp;
 
@@ -936,7 +936,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 		php_stream_flush(entry->cfp);
 		php_stream_filter_remove(filter, 1);
 		php_stream_seek(entry->cfp, 0, SEEK_END);
-		entry->compressed_filesize = (php_uint32) php_stream_tell(entry->cfp);
+		entry->compressed_filesize = (uint32_t) php_stream_tell(entry->cfp);
 		PHAR_SET_32(central.compsize, entry->compressed_filesize);
 		PHAR_SET_32(local.compsize, entry->compressed_filesize);
 		/* generate crc on compressed file */
@@ -1194,7 +1194,7 @@ int phar_zip_flush(phar_archive_data *phar, char *user_stub, zend_long len, int 
 	char *temperr = NULL;
 	struct _phar_zip_pass pass;
 	phar_zip_dir_end eocd;
-	php_uint32 cdir_size, cdir_offset;
+	uint32_t cdir_size, cdir_offset;
 
 	pass.error = &temperr;
 	entry.flags = PHAR_ENT_PERM_DEF_FILE;

--- a/ext/session/mod_mm.c
+++ b/ext/session/mod_mm.c
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 
+#include "php_stdint.h"
 #include "php_session.h"
 #include "mod_mm.h"
 #include "SAPI.h"
@@ -39,14 +40,11 @@
 
 #define PS_MM_FILE "session_mm_"
 
-/* For php_uint32 */
-#include "ext/standard/basic_functions.h"
-
 /* This list holds all data associated with one session. */
 
 typedef struct ps_sd {
 	struct ps_sd *next;
-	php_uint32 hv;		/* hash value of key */
+	uint32_t hv;		/* hash value of key */
 	time_t ctime;		/* time of last change */
 	void *data;
 	size_t datalen;		/* amount of valid data */
@@ -57,8 +55,8 @@ typedef struct ps_sd {
 typedef struct {
 	MM *mm;
 	ps_sd **hash;
-	php_uint32 hash_max;
-	php_uint32 hash_cnt;
+	uint32_t hash_max;
+	uint32_t hash_cnt;
 	pid_t owner;
 } ps_mm;
 
@@ -70,9 +68,9 @@ static ps_mm *ps_mm_instance = NULL;
 # define ps_mm_debug(a)
 #endif
 
-static inline php_uint32 ps_sd_hash(const char *data, int len)
+static inline uint32_t ps_sd_hash(const char *data, int len)
 {
-	php_uint32 h;
+	uint32_t h;
 	const char *e = data + len;
 
 	for (h = 2166136261U; data < e; ) {
@@ -85,7 +83,7 @@ static inline php_uint32 ps_sd_hash(const char *data, int len)
 
 static void hash_split(ps_mm *data)
 {
-	php_uint32 nmax;
+	uint32_t nmax;
 	ps_sd **nhash;
 	ps_sd **ohash, **ehash;
 	ps_sd *ps, *next;
@@ -114,7 +112,7 @@ static void hash_split(ps_mm *data)
 
 static ps_sd *ps_sd_new(ps_mm *data, const char *key)
 {
-	php_uint32 hv, slot;
+	uint32_t hv, slot;
 	ps_sd *sd;
 	int keylen;
 
@@ -155,7 +153,7 @@ static ps_sd *ps_sd_new(ps_mm *data, const char *key)
 
 static void ps_sd_destroy(ps_mm *data, ps_sd *sd)
 {
-	php_uint32 slot;
+	uint32_t slot;
 
 	slot = ps_sd_hash(sd->key, strlen(sd->key)) & data->hash_max;
 
@@ -180,7 +178,7 @@ static void ps_sd_destroy(ps_mm *data, ps_sd *sd)
 
 static ps_sd *ps_sd_lookup(ps_mm *data, const char *key, int rw)
 {
-	php_uint32 hv, slot;
+	uint32_t hv, slot;
 	ps_sd *ret, *prev;
 
 	hv = ps_sd_hash(key, strlen(key));

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -3493,8 +3493,8 @@ PHPAPI double php_get_nan(void) /* {{{ */
 	return HUGE_VAL + -HUGE_VAL;
 #elif defined(__i386__) || defined(_X86_) || defined(ALPHA) || defined(_ALPHA) || defined(__alpha)
 	double val = 0.0;
-	((php_uint32*)&val)[1] = PHP_DOUBLE_QUIET_NAN_HIGH;
-	((php_uint32*)&val)[0] = 0;
+	((uint32_t*)&val)[1] = PHP_DOUBLE_QUIET_NAN_HIGH;
+	((uint32_t*)&val)[0] = 0;
 	return val;
 #elif HAVE_ATOF_ACCEPTS_NAN
 	return atof("NAN");
@@ -3510,8 +3510,8 @@ PHPAPI double php_get_inf(void) /* {{{ */
 	return HUGE_VAL;
 #elif defined(__i386__) || defined(_X86_) || defined(ALPHA) || defined(_ALPHA) || defined(__alpha)
 	double val = 0.0;
-	((php_uint32*)&val)[1] = PHP_DOUBLE_INFINITY_HIGH;
-	((php_uint32*)&val)[0] = 0;
+	((uint32_t*)&val)[1] = PHP_DOUBLE_INFINITY_HIGH;
+	((uint32_t*)&val)[0] = 0;
 	return val;
 #elif HAVE_ATOF_ACCEPTS_INF
 	return atof("INF");

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -149,18 +149,6 @@ PHPAPI int _php_error_log(int opt_err, char *message, char *opt, char *headers);
 PHPAPI int _php_error_log_ex(int opt_err, char *message, size_t message_len, char *opt, char *headers);
 PHPAPI int php_prefix_varname(zval *result, zval *prefix, char *var_name, size_t var_name_len, zend_bool add_underscore);
 
-#if SIZEOF_INT == 4
-/* Most 32-bit and 64-bit systems have 32-bit ints */
-typedef unsigned int php_uint32;
-typedef signed int php_int32;
-#elif SIZEOF_LONG == 4
-/* 16-bit systems? */
-typedef unsigned long php_uint32;
-typedef signed long php_int32;
-#else
-#error Need type which holds 32 bits
-#endif
-
 #define MT_N (624)
 
 typedef struct _php_basic_globals {
@@ -193,8 +181,8 @@ typedef struct _php_basic_globals {
 	php_stream_statbuf ssb, lssb;
 
 	/* rand.c */
-	php_uint32   state[MT_N+1];  /* state vector + 1 extra to not violate ANSI C */
-	php_uint32   *next;       /* next random value is computed from here */
+	uint32_t state[MT_N+1];  /* state vector + 1 extra to not violate ANSI C */
+	uint32_t *next;       /* next random value is computed from here */
 	int      left;        /* can *next++ this many times before reloading */
 
 	unsigned int rand_seed; /* Seed for rand(), in ts version */

--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -28,8 +28,8 @@ PHP_NAMED_FUNCTION(php_if_crc32)
 {
 	char *p;
 	size_t nr;
-	php_uint32 crcinit = 0;
-	register php_uint32 crc;
+	uint32_t crcinit = 0;
+	register uint32_t crc;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &p, &nr) == FAILURE) {
 		return;

--- a/ext/standard/lcg.c
+++ b/ext/standard/lcg.c
@@ -54,8 +54,8 @@ static void lcg_seed(void);
 
 PHPAPI double php_combined_lcg(void) /* {{{ */
 {
-	php_int32 q;
-	php_int32 z;
+	int32_t q;
+	int32_t z;
 
 	if (!LCG(seeded)) {
 		lcg_seed();

--- a/ext/standard/md5.c
+++ b/ext/standard/md5.c
@@ -169,16 +169,16 @@ PHP_NAMED_FUNCTION(php_if_md5_file)
  */
 #if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
 # define SET(n) \
-	(*(php_uint32 *)&ptr[(n) * 4])
+	(*(uint32_t *)&ptr[(n) * 4])
 # define GET(n) \
 	SET(n)
 #else
 # define SET(n) \
 	(ctx->block[(n)] = \
-	(php_uint32)ptr[(n) * 4] | \
-	((php_uint32)ptr[(n) * 4 + 1] << 8) | \
-	((php_uint32)ptr[(n) * 4 + 2] << 16) | \
-	((php_uint32)ptr[(n) * 4 + 3] << 24))
+	(uint32_t)ptr[(n) * 4] | \
+	((uint32_t)ptr[(n) * 4 + 1] << 8) | \
+	((uint32_t)ptr[(n) * 4 + 2] << 16) | \
+	((uint32_t)ptr[(n) * 4 + 3] << 24))
 # define GET(n) \
 	(ctx->block[(n)])
 #endif
@@ -190,8 +190,8 @@ PHP_NAMED_FUNCTION(php_if_md5_file)
 static const void *body(PHP_MD5_CTX *ctx, const void *data, size_t size)
 {
 	const unsigned char *ptr;
-	php_uint32 a, b, c, d;
-	php_uint32 saved_a, saved_b, saved_c, saved_d;
+	uint32_t a, b, c, d;
+	uint32_t saved_a, saved_b, saved_c, saved_d;
 
 	ptr = data;
 
@@ -307,8 +307,8 @@ PHPAPI void PHP_MD5Init(PHP_MD5_CTX *ctx)
 
 PHPAPI void PHP_MD5Update(PHP_MD5_CTX *ctx, const void *data, size_t size)
 {
-	php_uint32 saved_lo;
-	php_uint32 used, free;
+	uint32_t saved_lo;
+	uint32_t used, free;
 
 	saved_lo = ctx->lo;
 	if ((ctx->lo = (saved_lo + size) & 0x1fffffff) < saved_lo) {
@@ -342,7 +342,7 @@ PHPAPI void PHP_MD5Update(PHP_MD5_CTX *ctx, const void *data, size_t size)
 
 PHPAPI void PHP_MD5Final(unsigned char *result, PHP_MD5_CTX *ctx)
 {
-	php_uint32 used, free;
+	uint32_t used, free;
 
 	used = ctx->lo & 0x3f;
 

--- a/ext/standard/md5.h
+++ b/ext/standard/md5.h
@@ -42,10 +42,10 @@ PHP_NAMED_FUNCTION(php_if_md5_file);
 
 /* MD5 context. */
 typedef struct {
-	php_uint32 lo, hi;
-	php_uint32 a, b, c, d;
+	uint32_t lo, hi;
+	uint32_t a, b, c, d;
 	unsigned char buffer[64];
-	php_uint32 block[16];
+	uint32_t block[16];
 } PHP_MD5_CTX;
 
 PHPAPI void PHP_MD5Init(PHP_MD5_CTX *ctx);

--- a/ext/standard/php_crypt_r.c
+++ b/ext/standard/php_crypt_r.c
@@ -323,7 +323,7 @@ char * php_md5_crypt_r(const char *pw, const char *salt, char *out)
 	unsigned char final[16];
 	unsigned int i, sl, pwl;
 	PHP_MD5_CTX	ctx, ctx1;
-	php_uint32 l;
+	uint32_t l;
 	int pl;
 
 	pwl = strlen(pw);

--- a/ext/standard/php_lcg.h
+++ b/ext/standard/php_lcg.h
@@ -24,8 +24,8 @@
 #include "ext/standard/basic_functions.h"
 
 typedef struct {
-	php_int32 s1;
-	php_int32 s2;
+	int32_t s1;
+	int32_t s2;
 	int seeded;
 } php_lcg_globals;
 

--- a/ext/standard/php_rand.h
+++ b/ext/standard/php_rand.h
@@ -55,7 +55,7 @@
 
 PHPAPI void php_srand(zend_long seed);
 PHPAPI zend_long php_rand(void);
-PHPAPI void php_mt_srand(php_uint32 seed);
-PHPAPI php_uint32 php_mt_rand(void);
+PHPAPI void php_mt_srand(uint32_t seed);
+PHPAPI uint32_t php_mt_rand(void);
 
 #endif	/* PHP_RAND_H */

--- a/ext/standard/rand.c
+++ b/ext/standard/rand.c
@@ -146,19 +146,19 @@ PHPAPI zend_long php_rand(void)
 #define loBits(u)     ((u) & 0x7FFFFFFFU)  /* mask     the highest   bit of u */
 #define mixBits(u, v) (hiBit(u)|loBits(v)) /* move hi bit of u to hi bit of v */
 
-#define twist(m,u,v)  (m ^ (mixBits(u,v)>>1) ^ ((php_uint32)(-(php_int32)(loBit(u))) & 0x9908b0dfU))
+#define twist(m,u,v)  (m ^ (mixBits(u,v)>>1) ^ ((uint32_t)(-(int32_t)(loBit(u))) & 0x9908b0dfU))
 
 /* {{{ php_mt_initialize
  */
-static inline void php_mt_initialize(php_uint32 seed, php_uint32 *state)
+static inline void php_mt_initialize(uint32_t seed, uint32_t *state)
 {
 	/* Initialize generator state with seed
 	   See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
 	   In previous versions, most significant bits (MSBs) of the seed affect
 	   only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto. */
 
-	register php_uint32 *s = state;
-	register php_uint32 *r = state;
+	register uint32_t *s = state;
+	register uint32_t *r = state;
 	register int i = 1;
 
 	*s++ = seed & 0xffffffffU;
@@ -176,8 +176,8 @@ static inline void php_mt_reload(void)
 	/* Generate N new values in state
 	   Made clearer and faster by Matthew Bellew (matthew.bellew@home.com) */
 
-	register php_uint32 *state = BG(state);
-	register php_uint32 *p = state;
+	register uint32_t *state = BG(state);
+	register uint32_t *p = state;
 	register int i;
 
 	for (i = N - M; i--; ++p)
@@ -192,7 +192,7 @@ static inline void php_mt_reload(void)
 
 /* {{{ php_mt_srand
  */
-PHPAPI void php_mt_srand(php_uint32 seed)
+PHPAPI void php_mt_srand(uint32_t seed)
 {
 	/* Seed the generator with a simple uint32 */
 	php_mt_initialize(seed, BG(state));
@@ -205,12 +205,12 @@ PHPAPI void php_mt_srand(php_uint32 seed)
 
 /* {{{ php_mt_rand
  */
-PHPAPI php_uint32 php_mt_rand(void)
+PHPAPI uint32_t php_mt_rand(void)
 {
 	/* Pull a 32-bit integer from the generator state
 	   Every other access function simply transforms the numbers extracted here */
 
-	register php_uint32 s1;
+	register uint32_t s1;
 
 	if (BG(left) == 0) {
 		php_mt_reload();

--- a/ext/standard/sha1.c
+++ b/ext/standard/sha1.c
@@ -103,9 +103,9 @@ PHP_FUNCTION(sha1_file)
 /* }}} */
 
 
-static void SHA1Transform(php_uint32[5], const unsigned char[64]);
-static void SHA1Encode(unsigned char *, php_uint32 *, unsigned int);
-static void SHA1Decode(php_uint32 *, const unsigned char *, unsigned int);
+static void SHA1Transform(uint32_t[5], const unsigned char[64]);
+static void SHA1Encode(unsigned char *, uint32_t *, unsigned int);
+static void SHA1Decode(uint32_t *, const unsigned char *, unsigned int);
 
 static unsigned char PADDING[64] =
 {
@@ -133,22 +133,22 @@ static unsigned char PADDING[64] =
 /* FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
  */
 #define FF(a, b, c, d, e, w) { \
- (e) += F ((b), (c), (d)) + (w) + (php_uint32)(0x5A827999); \
+ (e) += F ((b), (c), (d)) + (w) + (uint32_t)(0x5A827999); \
  (e) += ROTATE_LEFT ((a), 5); \
  (b) = ROTATE_LEFT((b), 30); \
   }
 #define GG(a, b, c, d, e, w) { \
- (e) += G ((b), (c), (d)) + (w) + (php_uint32)(0x6ED9EBA1); \
+ (e) += G ((b), (c), (d)) + (w) + (uint32_t)(0x6ED9EBA1); \
  (e) += ROTATE_LEFT ((a), 5); \
  (b) = ROTATE_LEFT((b), 30); \
   }
 #define HH(a, b, c, d, e, w) { \
- (e) += H ((b), (c), (d)) + (w) + (php_uint32)(0x8F1BBCDC); \
+ (e) += H ((b), (c), (d)) + (w) + (uint32_t)(0x8F1BBCDC); \
  (e) += ROTATE_LEFT ((a), 5); \
  (b) = ROTATE_LEFT((b), 30); \
   }
 #define II(a, b, c, d, e, w) { \
- (e) += I ((b), (c), (d)) + (w) + (php_uint32)(0xCA62C1D6); \
+ (e) += I ((b), (c), (d)) + (w) + (uint32_t)(0xCA62C1D6); \
  (e) += ROTATE_LEFT ((a), 5); \
  (b) = ROTATE_LEFT((b), 30); \
   }
@@ -184,10 +184,10 @@ PHPAPI void PHP_SHA1Update(PHP_SHA1_CTX * context, const unsigned char *input,
 	index = (unsigned int) ((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((php_uint32) inputLen << 3))
-		< ((php_uint32) inputLen << 3))
+	if ((context->count[0] += ((uint32_t) inputLen << 3))
+		< ((uint32_t) inputLen << 3))
 		context->count[1]++;
-	context->count[1] += ((php_uint32) inputLen >> 29);
+	context->count[1] += ((uint32_t) inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -253,11 +253,11 @@ PHPAPI void PHP_SHA1Final(unsigned char digest[20], PHP_SHA1_CTX * context)
  * SHA1 basic transformation. Transforms state based on block.
  */
 static void SHA1Transform(state, block)
-php_uint32 state[5];
+uint32_t state[5];
 const unsigned char block[64];
 {
-	php_uint32 a = state[0], b = state[1], c = state[2];
-	php_uint32 d = state[3], e = state[4], x[16], tmp;
+	uint32_t a = state[0], b = state[1], c = state[2];
+	uint32_t d = state[3], e = state[4], x[16], tmp;
 
 	SHA1Decode(x, block, 64);
 
@@ -361,12 +361,12 @@ const unsigned char block[64];
 /* }}} */
 
 /* {{{ SHA1Encode
-   Encodes input (php_uint32) into output (unsigned char). Assumes len is
+   Encodes input (uint32_t) into output (unsigned char). Assumes len is
    a multiple of 4.
  */
 static void SHA1Encode(output, input, len)
 unsigned char *output;
-php_uint32 *input;
+uint32_t *input;
 unsigned int len;
 {
 	unsigned int i, j;
@@ -381,19 +381,19 @@ unsigned int len;
 /* }}} */
 
 /* {{{ SHA1Decode
-   Decodes input (unsigned char) into output (php_uint32). Assumes len is
+   Decodes input (unsigned char) into output (uint32_t). Assumes len is
    a multiple of 4.
  */
 static void SHA1Decode(output, input, len)
-php_uint32 *output;
+uint32_t *output;
 const unsigned char *input;
 unsigned int len;
 {
 	unsigned int i, j;
 
 	for (i = 0, j = 0; j < len; i++, j += 4)
-		output[i] = ((php_uint32) input[j + 3]) | (((php_uint32) input[j + 2]) << 8) |
-			(((php_uint32) input[j + 1]) << 16) | (((php_uint32) input[j]) << 24);
+		output[i] = ((uint32_t) input[j + 3]) | (((uint32_t) input[j + 2]) << 8) |
+			(((uint32_t) input[j + 1]) << 16) | (((uint32_t) input[j]) << 24);
 }
 /* }}} */
 

--- a/ext/standard/sha1.h
+++ b/ext/standard/sha1.h
@@ -25,8 +25,8 @@
 
 /* SHA1 context. */
 typedef struct {
-	php_uint32 state[5];		/* state (ABCD) */
-	php_uint32 count[2];		/* number of bits, modulo 2^64 (lsb first) */
+	uint32_t state[5];		/* state (ABCD) */
+	uint32_t count[2];		/* number of bits, modulo 2^64 (lsb first) */
 	unsigned char buffer[64];	/* input buffer */
 } PHP_SHA1_CTX;
 

--- a/sapi/litespeed/lsapilib.c
+++ b/sapi/litespeed/lsapilib.c
@@ -87,13 +87,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #include <inttypes.h>
-#ifndef uint32
-#define uint32 uint32_t
-#endif
 
 struct lsapi_MD5Context {
-    uint32 buf[4];
-    uint32 bits[2];
+    uint32_t buf[4];
+    uint32_t bits[2];
     unsigned char in[64];
 };
 
@@ -3339,18 +3336,18 @@ int LSAPI_ErrResponse_r( LSAPI_Request * pReq, int code, const char ** pRespHead
 }
 
 
-static void lsapi_MD5Transform(uint32 buf[4], uint32 const in[16]);
+static void lsapi_MD5Transform(uint32_t buf[4], uint32_t const in[16]);
 
 /*
  * Note: this code is harmless on little-endian machines.
  */
 static void byteReverse(unsigned char *buf, unsigned longs)
 {
-    uint32 t;
+    uint32_t t;
     do {
-        t = (uint32) ((unsigned) buf[3] << 8 | buf[2]) << 16 |
+        t = (uint32_t) ((unsigned) buf[3] << 8 | buf[2]) << 16 |
             ((unsigned) buf[1] << 8 | buf[0]);
-        *(uint32 *) buf = t;
+        *(uint32_t *) buf = t;
         buf += 4;
     } while (--longs);
 }
@@ -3376,12 +3373,12 @@ void lsapi_MD5Init(struct lsapi_MD5Context *ctx)
  */
 void lsapi_MD5Update(struct lsapi_MD5Context *ctx, unsigned char const *buf, unsigned len)
 {
-    register uint32 t;
+    register uint32_t t;
 
     /* Update bitcount */
 
     t = ctx->bits[0];
-    if ((ctx->bits[0] = t + ((uint32) len << 3)) < t)
+    if ((ctx->bits[0] = t + ((uint32_t) len << 3)) < t)
         ctx->bits[1]++;                /* Carry from low to high */
     ctx->bits[1] += len >> 29;
 
@@ -3399,7 +3396,7 @@ void lsapi_MD5Update(struct lsapi_MD5Context *ctx, unsigned char const *buf, uns
         }
         memmove(p, buf, t);
         byteReverse(ctx->in, 16);
-        lsapi_MD5Transform(ctx->buf, (uint32 *) ctx->in);
+        lsapi_MD5Transform(ctx->buf, (uint32_t *) ctx->in);
         buf += t;
         len -= t;
     }
@@ -3408,7 +3405,7 @@ void lsapi_MD5Update(struct lsapi_MD5Context *ctx, unsigned char const *buf, uns
     while (len >= 64) {
         memmove(ctx->in, buf, 64);
         byteReverse(ctx->in, 16);
-        lsapi_MD5Transform(ctx->buf, (uint32 *) ctx->in);
+        lsapi_MD5Transform(ctx->buf, (uint32_t *) ctx->in);
         buf += 64;
         len -= 64;
     }
@@ -3443,7 +3440,7 @@ void lsapi_MD5Final(unsigned char digest[16], struct lsapi_MD5Context *ctx)
         /* Two lots of padding:  Pad the first block to 64 bytes */
         memset(p, 0, count);
         byteReverse(ctx->in, 16);
-        lsapi_MD5Transform(ctx->buf, (uint32 *) ctx->in);
+        lsapi_MD5Transform(ctx->buf, (uint32_t *) ctx->in);
 
         /* Now fill the next block with 56 bytes */
         memset(ctx->in, 0, 56);
@@ -3454,10 +3451,10 @@ void lsapi_MD5Final(unsigned char digest[16], struct lsapi_MD5Context *ctx)
     byteReverse(ctx->in, 14);
 
     /* Append length in bits and transform */
-    ((uint32 *) ctx->in)[14] = ctx->bits[0];
-    ((uint32 *) ctx->in)[15] = ctx->bits[1];
+    ((uint32_t *) ctx->in)[14] = ctx->bits[0];
+    ((uint32_t *) ctx->in)[15] = ctx->bits[1];
 
-    lsapi_MD5Transform(ctx->buf, (uint32 *) ctx->in);
+    lsapi_MD5Transform(ctx->buf, (uint32_t *) ctx->in);
     byteReverse((unsigned char *) ctx->buf, 4);
     memmove(digest, ctx->buf, 16);
     memset(ctx, 0, sizeof(*ctx));        /* In case it's sensitive */
@@ -3480,9 +3477,9 @@ void lsapi_MD5Final(unsigned char digest[16], struct lsapi_MD5Context *ctx)
  * reflect the addition of 16 longwords of new data.  MD5Update blocks
  * the data and converts bytes into longwords for this routine.
  */
-static void lsapi_MD5Transform(uint32 buf[4], uint32 const in[16])
+static void lsapi_MD5Transform(uint32_t buf[4], uint32_t const in[16])
 {
-    register uint32 a, b, c, d;
+    register uint32_t a, b, c, d;
 
     a = buf[0];
     b = buf[1];


### PR DESCRIPTION
Remove various defines for fixed size integers, instead the standard intXX_t and uintXX_t types are used. These are already used in other parts of the code so this won't impact platform support.