### PR TITLE
Properly read any remaining data when closing FastCGI socket

### DIFF
--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -1287,11 +1287,11 @@ void fcgi_close(fcgi_request *req, int force, int destroy)
 		}
 #else
 		if (!force) {
-			fcgi_header buf;
+			char buf[8];
 
 			shutdown(req->fd, 1);
-			/* read the last FCGI_STDIN header (it may be omitted) */
-			recv(req->fd, (char *)(&buf), sizeof(buf), 0);
+			/* read any remaining data, it may be omitted */
+			while (recv(req->fd, buf, sizeof(buf), 0) > 0) {}
 		}
 		close(req->fd);
 #endif


### PR DESCRIPTION
Fixes a regression (https://bugs.php.net/bug.php?id=71466) introduced in PHP7 by 18cf4e0a8a574034f60f4d123407c173e57e54ec, where under certain conditions the connection would be closed before all data was processed.

Prior to the linked breaking commit, this is the code that was used during `fcgi_close()`, specifically looping over `recv()` until all data was consumed. Just doing one `recv()` doesn't work correctly.

Downstream report: owncloud/core#21935