### PR TITLE
Add missing fields to expected output for pdo_dblib test

### DIFF
--- a/ext/pdo_dblib/tests/bug_45876.phpt
+++ b/ext/pdo_dblib/tests/bug_45876.phpt
@@ -15,7 +15,7 @@ var_dump($stmt->getColumnMeta(0));
 $stmt = null;
 ?>
 --EXPECT--
-array(8) {
+array(10) {
   ["max_length"]=>
   int(255)
   ["precision"]=>
@@ -26,6 +26,10 @@ array(8) {
   string(13) "TABLE_CATALOG"
   ["native_type"]=>
   string(4) "char"
+  ["native_type_id"]=>
+  int(47)
+  ["native_usertype_id"]=>
+  int(2)
   ["name"]=>
   string(13) "TABLE_CATALOG"
   ["len"]=>


### PR DESCRIPTION
This test got out of sync at some point. You can see these fields in [pdo_dblib_stmt_get_column_meta()](https://github.com/php/php-src/blob/master/ext/pdo_dblib/dblib_stmt.c#L294).