### PR TITLE
Fix bug #71525 (Calls to date_modify will mutate timelib_rel_time, causing date_date_set issues)

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3054,6 +3054,7 @@ static int php_date_modify(zval *object, char *modify, size_t modify_len) /* {{{
 	timelib_update_ts(dateobj->time, NULL);
 	timelib_update_from_sse(dateobj->time);
 	dateobj->time->have_relative = 0;
+	memset(&dateobj->time->relative, 0, sizeof(dateobj->time->relative));
 
 	return 1;
 } /* }}} */

--- a/ext/date/tests/bug71525.phpt
+++ b/ext/date/tests/bug71525.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #71525 (Calls to date_modify will mutate timelib_rel_time, causing date_date_set issues)
+--FILE--
+<?php
+$date = new DateTime('2011-12-25 00:00:00');
+$date->modify('first day of next month');
+$date->setDate('2012', '1', '29');
+var_dump($date);
+
+--EXPECTF--
+object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "2012-01-29 00:00:00.000000"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(3) "UTC"
+}


### PR DESCRIPTION
timelib_time->timelib_rel_time is mutated by date_modify, and because it is never zero'ed out it latters causes other date operations to fail (like date_date_set)

https://bugs.php.net/bug.php?id=71525