### PR TITLE
Add 'serialNumberHex' variable to openssl_x509_parse

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1948,6 +1948,7 @@ PHP_FUNCTION(openssl_x509_parse)
 	char *extname;
 	BIO  *bio_out;
 	BUF_MEM *bio_buf;
+	char * hexserial;
 	char buf[256];
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|b", &zcert, &useshortnames) == FAILURE) {
@@ -1976,6 +1977,18 @@ PHP_FUNCTION(openssl_x509_parse)
 	add_assoc_long(return_value, "version", 			X509_get_version(cert));
 
 	add_assoc_string(return_value, "serialNumber", i2s_ASN1_INTEGER(NULL, X509_get_serialNumber(cert)), 1); 
+
+	/* Return the hex representation of the serial number, as defined by OpenSSL */
+	hexserial = BN_bn2hex(ASN1_INTEGER_to_BN(X509_get_serialNumber(cert), NULL));
+
+	/* If we received null back from BN_bn2hex, there was a critical error in openssl,
+	 * and we should not continue.
+	 */
+	if (!hexserial) {
+		RETURN_FALSE;
+	}
+	add_assoc_string(return_value, "serialNumberHex", hexserial, 1); 
+	OPENSSL_free(hexserial);
 
 	add_assoc_asn1_string(return_value, "validFrom", 	X509_get_notBefore(cert));
 	add_assoc_asn1_string(return_value, "validTo", 		X509_get_notAfter(cert));


### PR DESCRIPTION
Currently, openssl_x509_parse returns an integer for the serialNumber
field. This can be unexpected, as the common way of handling serial 
numbers is with a hex string.

This is compounded as  php's dechex() function cannot handle >32
bit numbers which will leave people that are trying to handle large serial
numbers frustrated.

By adding this extra return variable to openssl_x509_parse, the
consumer of the variable is certain that the serialNumberHex that
is returned is exactly the same Hex Serial number as OpenSSL returns
everywhere else.