### PR TITLE
Bugfix 71519 - return serialNumberHex from openssl_x509_parse

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2023,7 +2023,7 @@ PHP_FUNCTION(openssl_x509_parse)
 	if (!hexserial) {
 		RETURN_FALSE;
 	}
-	add_assoc_string(return_value, "serialNumberHex", hexserial, 1); 
+	add_assoc_string(return_value, "serialNumberHex", hexserial); 
 	OPENSSL_free(hexserial);
 
 	add_assoc_asn1_string(return_value, "validFrom", 	X509_get_notBefore(cert));

--- a/ext/openssl/tests/openssl_x509_parse_basic.phpt
+++ b/ext/openssl/tests/openssl_x509_parse_basic.phpt
@@ -12,7 +12,7 @@ var_dump(openssl_x509_parse($cert));
 var_dump(openssl_x509_parse($cert, false));
 ?>
 --EXPECTF--
-array(15) {
+array(16) {
   ["name"]=>
   string(96) "/C=BR/ST=Rio Grande do Sul/L=Porto Alegre/CN=Henrique do N. Angelo/emailAddress=hnangelo@php.net"
   ["subject"]=>
@@ -47,6 +47,8 @@ array(15) {
   int(2)
   ["serialNumber"]=>
   string(20) "12593567369101004962"
+  ["serialNumberHex"]=>
+  string(16) "AEC556CC723750A2"
   ["validFrom"]=>
   string(13) "080630102843Z"
   ["validTo"]=>
@@ -158,7 +160,7 @@ serial:AE:C5:56:CC:72:37:50:A2
     string(7) "CA:TRUE"
   }
 }
-array(15) {
+array(16) {
   ["name"]=>
   string(96) "/C=BR/ST=Rio Grande do Sul/L=Porto Alegre/CN=Henrique do N. Angelo/emailAddress=hnangelo@php.net"
   ["subject"]=>
@@ -193,6 +195,8 @@ array(15) {
   int(2)
   ["serialNumber"]=>
   string(20) "12593567369101004962"
+  ["serialNumberHex"]=>
+  string(16) "AEC556CC723750A2"
   ["validFrom"]=>
   string(13) "080630102843Z"
   ["validTo"]=>


### PR DESCRIPTION
Currently, openssl_x509_parse only returns an integer as the Serial Number.

This can be unexpected, as the common way of handling serial numbers is by treating them as a hex string.

This is compounded by php's dechex() function being unable to handle >32 bit numbers which will leave people trying to handle large serial numbers frustrated.

By adding this extra return variable to openssl_x509_parse, the consumer of the variable is certain that the serialNumberHex that is returned is exactly the same Hex Serial number as OpenSSL returns everywhere else.
