### PR TITLE
Fix bug #65785 (mbstring.func_overload should be deprecated)

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -1621,6 +1621,10 @@ PHP_RINIT_FUNCTION(mbstring)
 	if (MBSTRG(func_overload)){
 		p = &(mb_ovld[0]);
 
+		if (p > 0) {
+			php_error_docref("ref.mbstring", E_DEPRECATED, "Use of mbstring.func_overload is deprecated");
+		}
+
 		CG(compiler_options) |= ZEND_COMPILE_NO_BUILTIN_STRLEN;
 		while (p->type > 0) {
 			if ((MBSTRG(func_overload) & p->type) == p->type &&

--- a/ext/mbstring/tests/bug52931.phpt
+++ b/ext/mbstring/tests/bug52931.phpt
@@ -3,6 +3,7 @@ Bug #52931 (strripos not overloaded with function overloading enabled)
 --SKIPIF--
 <?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
 --INI--
+error_reporting=E_ALL ^ E_DEPRECATED
 mbstring.func_overload = 7
 mbstring.internal_encoding = utf-8
 --FILE--

--- a/ext/mbstring/tests/bug65785.phpt
+++ b/ext/mbstring/tests/bug65785.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #65785 (mbstring.func_overload should be depreciated)
+--INI--
+mbstring.func_overload=2
+--FILE--
+<?php
+echo ini_get('mbstring.func_overload');?>
+--EXPECTF--
+Deprecated: Unknown: Use of mbstring.func_overload is deprecated in Unknown on line 0
+2

--- a/ext/mbstring/tests/mb_get_info.phpt
+++ b/ext/mbstring/tests/mb_get_info.phpt
@@ -3,6 +3,7 @@ Test mb_get_info() function
 --SKIPIF--
 <?php extension_loaded('mbstring') or die('skip'); ?>
 --INI--
+error_reporting=E_ALL ^ E_DEPRECATED
 mbstring.encoding_translation=1
 mbstring.language=Korean
 mbstring.internal_encoding=UTF-8

--- a/ext/mbstring/tests/overload01.phpt
+++ b/ext/mbstring/tests/overload01.phpt
@@ -8,6 +8,7 @@ Function overloading test 1
 	}
 ?>
 --INI--
+error_reporting=E_ALL ^ E_DEPRECATED
 output_handler=
 mbstring.func_overload=7
 mbstring.internal_encoding=EUC-JP

--- a/ext/mbstring/tests/overload02.phpt
+++ b/ext/mbstring/tests/overload02.phpt
@@ -11,6 +11,7 @@ Function overloading test 2
 	}
 ?>
 --INI--
+error_reporting=E_ALL ^ E_DEPRECATED
 output_handler=
 mbstring.func_overload=7
 mbstring.internal_encoding=EUC-JP


### PR DESCRIPTION
Show deprecated message for mbstring.func_overload

https://bugs.php.net/bug.php?id=65785
