### PR TITLE
Fix use-after-free of ZCG(cwd) in Zend Optimizer (5.6)

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2370,6 +2370,11 @@ static void accel_deactivate(void)
 	 */
 	TSRMLS_FETCH();
 
+	if (ZCG(cwd)) {
+		efree(ZCG(cwd));
+		ZCG(cwd) = NULL;
+	}
+
 	if (!ZCG(enabled) || !accel_startup_ok) {
 		return;
 	}
@@ -2383,12 +2388,6 @@ static void accel_deactivate(void)
 		zend_accel_fast_shutdown(TSRMLS_C);
 	}
 #endif
-
-	if (ZCG(cwd)) {
-		efree(ZCG(cwd));
-		ZCG(cwd) = NULL;
-	}
-
 }
 
 static int accelerator_remove_cb(zend_extension *element1, zend_extension *element2)


### PR DESCRIPTION
This pull request fixes bug [71584](https://bugs.php.net/bug.php?id=71584) for PHP 5.6 by checking and freeing ZCG(cwd) even if Zend Opcache is disabled.