### PR TITLE
Fix use-after-free of ZCG(cwd) in Zend Optimizer (master)

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2284,6 +2284,11 @@ static void accel_deactivate(void)
 	 * the script is aborted abnormally, they may become messed up.
 	 */
 
+	if (ZCG(cwd)) {
+		zend_string_release(ZCG(cwd));
+		ZCG(cwd) = NULL;
+	}
+
 	if (!ZCG(enabled) || !accel_startup_ok) {
 		return;
 	}
@@ -2297,12 +2302,6 @@ static void accel_deactivate(void)
 		zend_accel_fast_shutdown();
 	}
 #endif
-
-	if (ZCG(cwd)) {
-		zend_string_release(ZCG(cwd));
-		ZCG(cwd) = NULL;
-	}
-
 }
 
 static int accelerator_remove_cb(zend_extension *element1, zend_extension *element2)


### PR DESCRIPTION
This pull request fixes bug [71584](https://bugs.php.net/bug.php?id=71584) for master by checking and freeing ZCG(cwd) even if Zend Opcache is disabled.