### PR TITLE
Fix for version string when connecting to a MariaDB server

### DIFF
--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -315,6 +315,7 @@ mysqlnd_read_header(MYSQLND_NET * net, MYSQLND_PACKET_HEADER * header,
 }
 /* }}} */
 
+#define MARIADB_RPL_VERSION_HACK "5.5.5-"
 
 /* {{{ php_mysqlnd_greet_read */
 static enum_func_status
@@ -361,6 +362,11 @@ php_mysqlnd_greet_read(void * _packet, MYSQLND_CONN_DATA * conn)
 		}
 		DBG_RETURN(PASS);
 	}
+
+        /* MariaDB always sends 5.5.5 before version string: 5.5.5 was never released,
+           so just ignore it */
+        if (!strncmp(p, MARIADB_RPL_VERSION_HACK, sizeof(MARIADB_RPL_VERSION_HACK) - 1))
+          p+= sizeof(MARIADB_RPL_VERSION_HACK) - 1;
 
 	packet->server_version = estrdup((char *)p);
 	p+= strlen(packet->server_version) + 1; /* eat the '\0' */


### PR DESCRIPTION
Since MariaDB hacked the version number and prefixes the MariaDB version with 5.5.5- the version string is not correct when connecting to MariaDB
server..
(For discussion see [Joomla discussion|https://github.com/joomla/joomla-cms/issues/9062#issuecomment-182969806])

This fix skips the first 7 bytes of version string, if the version string in greeting package is prefixed with
5.5.5- Neither MariaDB nor Oracle  released a 5.5.5 version, so it will not have any side affect with
older versions of MySQL, Percona or MariaDB.
