### PR TITLE
arc4random_buf on OpenBSD for random bytes instead of opening /dev/arandom

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -386,7 +386,7 @@ PHPAPI zend_string *php_session_create_id(PS_CREATE_SID_ARGS) /* {{{ */
 # endif /* HAVE_HASH_EXT */
 			}
 		}
-#elif HAVE_DECL_ARC4RANDOM_BUF && ((defined(__OpenBSD__) && OpenBSD >= 201405)
+#elif HAVE_DECL_ARC4RANDOM_BUF && (defined(__OpenBSD__) && OpenBSD >= 201405)
 		unsigned char rbuf[2048];
 		int n;
 		int to_read = PS(entropy_length);
@@ -409,6 +409,7 @@ PHPAPI zend_string *php_session_create_id(PS_CREATE_SID_ARGS) /* {{{ */
 					break;
 # endif /* HAVE_HASH_EXT */
 			}
+
 			to_read -= n;
 		}
 #else

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -386,6 +386,31 @@ PHPAPI zend_string *php_session_create_id(PS_CREATE_SID_ARGS) /* {{{ */
 # endif /* HAVE_HASH_EXT */
 			}
 		}
+#elif HAVE_DECL_ARC4RANDOM_BUF && ((defined(__OpenBSD__) && OpenBSD >= 201405)
+		unsigned char rbuf[2048];
+		int n;
+		int to_read = PS(entropy_length);
+		unsigned char *outmsg;
+
+		while (to_read > 0) {
+			n = MIN(to_read, sizeof(rbuf));
+			arc4random_buf(rbuf, n);
+
+			switch (PS(hash_func)) {
+				case PS_HASH_FUNC_MD5:
+					PHP_MD5Update(&md5_context, rbuf, n);
+					break;
+				case PS_HASH_FUNC_SHA1:
+					PHP_SHA1Update(&sha1_context, rbuf, n);
+					break;
+# if defined(HAVE_HASH_EXT) && !defined(COMPILE_DL_HASH)
+				case PS_HASH_FUNC_OTHER:
+					PS(hash_ops)->hash_update(hash_context, rbuf, n);
+					break;
+# endif /* HAVE_HASH_EXT */
+			}
+			to_read -= n;
+		}
 #else
 		int fd;
 


### PR DESCRIPTION
In the php_session_create_id function a file descriptor is opened to the configured session.entropy_file by default, on non-Windows OSs and OSs that don't have an entropy_file available at compile time.
This is effectively described in the comments above session.entropy_file:
> ; On systems that don't have /dev/urandom but do have /dev/arandom, this will default to /dev/arandom
> ; If neither are found at compile time, the default is no entropy file.
> ; On windows, setting the entropy_length setting will activate the
> ; Windows random source (using the CryptoAPI)

In OpenBSD however, there is no need for this, as the arc4random functions are available as a fast random source, generating high quality pseudo-random number streams.
This eliminates the usage of a file descriptor on these systems.

The idea herein is to extend the comments with an extra line:
> ; On OpenBSD, setting the entropy_length setting will use arc4random instead