### PR TITLE
 Bug #71667: have pdo_dblib emulate how mssql extension names "computed" columns, plug memory leak (PHP-5.6)

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -100,6 +100,7 @@ static int dblib_handle_preparer(pdo_dbh_t *dbh, const char *sql, long sql_len, 
 	stmt->driver_data = S;
 	stmt->methods = &dblib_stmt_methods;
 	stmt->supports_placeholders = PDO_PLACEHOLDER_NONE;
+	S->computed_column_name_count = 0;
 	S->err.sqlstate = stmt->error_code;
 
 	return 1;

--- a/ext/pdo_dblib/php_pdo_dblib_int.h
+++ b/ext/pdo_dblib/php_pdo_dblib_int.h
@@ -118,6 +118,7 @@ typedef struct {
 typedef struct {
 	pdo_dblib_db_handle *H;
 	pdo_dblib_err err;
+	unsigned int computed_column_name_count;
 } pdo_dblib_stmt;
 
 typedef struct {

--- a/ext/pdo_dblib/tests/bug_71667.phpt
+++ b/ext/pdo_dblib/tests/bug_71667.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PDO_DBLIB: Set query timeouts
+PDO_DBLIB: Emulate how mssql extension names "computed" columns
 --SKIPIF--
 <?php
 if (!extension_loaded('pdo_dblib')) die('skip not loaded');

--- a/ext/pdo_dblib/tests/bug_71667.phpt
+++ b/ext/pdo_dblib/tests/bug_71667.phpt
@@ -19,16 +19,16 @@ array(1) {
   [0]=>
   array(6) {
     ["computed"]=>
-    int(1)
+    string(1) "1"
     [0]=>
-    int(1)
+    string(1) "1"
     ["named"]=>
-    int(2)
+    string(1) "2"
     [1]=>
-    int(2)
+    string(1) "2"
     ["computed1"]=>
-    int(3)
+    string(1) "3"
     [2]=>
-    int(3)
+    string(1) "3"
   }
 }

--- a/ext/pdo_dblib/tests/computed_column_name.phpt
+++ b/ext/pdo_dblib/tests/computed_column_name.phpt
@@ -1,0 +1,34 @@
+--TEST--
+PDO_DBLIB: Set query timeouts
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+$stmt = $db->prepare("SELECT 1, 2 AS named, 3");
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(6) {
+    ["computed"]=>
+    int(1)
+    [0]=>
+    int(1)
+    ["named"]=>
+    int(2)
+    [1]=>
+    int(2)
+    ["computed1"]=>
+    int(3)
+    [2]=>
+    int(3)
+  }
+}


### PR DESCRIPTION
Full notes are in the bug report I created:
https://bugs.php.net/bug.php?id=71667

The efree() calls could be removed from dblib_stmt.c because free_statement(), which is part of the pdo extension, will do this cleanup before the functions in dblib_stmt.c get called.

I realize that README.GIT-RULES says PRs should be done against PHP-5.6, but that branch is missing changes that my changes are built on top of. I'm happy to update this PR if anyone has guidance there. I'm going to look at master separately and submit another bug/PR if needed.