### PR TITLE
Bug #71667: have pdo_dblib emulate how mssql extension names "computed" columns (master)

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -101,6 +101,7 @@ static int dblib_handle_preparer(pdo_dbh_t *dbh, const char *sql, size_t sql_len
 	stmt->driver_data = S;
 	stmt->methods = &dblib_stmt_methods;
 	stmt->supports_placeholders = PDO_PLACEHOLDER_NONE;
+	S->computed_column_name_count = 0;
 	S->err.sqlstate = stmt->error_code;
 
 	return 1;

--- a/ext/pdo_dblib/dblib_stmt.c
+++ b/ext/pdo_dblib/dblib_stmt.c
@@ -198,17 +198,27 @@ static int pdo_dblib_stmt_describe(pdo_stmt_t *stmt, int colno)
 		return FAILURE;
 	}
 
+	if (colno == 0) {
+		S->computed_column_name_count = 0;
+	}
+
 	col = &stmt->columns[colno];
 	fname = (char*)dbcolname(H->link, colno+1);
 
 	if (fname && *fname) {
 		col->name =  zend_string_init(fname, strlen(fname), 0);
 	} else {
-		char buf[16];
-		int len;
-		
-		len = snprintf(buf, sizeof(buf), "computed%d", colno);
-		col->name = zend_string_init(buf, len, 0);
+		if (S->computed_column_name_count > 0) {
+			char buf[16];
+			int len;
+
+			len = snprintf(buf, sizeof(buf), "computed%d", S->computed_column_name_count);
+			col->name = zend_string_init(buf, len, 0);
+		} else {
+			col->name = zend_string_init("computed", strlen("computed"), 0);
+		}
+
+		S->computed_column_name_count++;
 	}
 
 	col->maxlen = dbcollen(H->link, colno+1);

--- a/ext/pdo_dblib/php_pdo_dblib_int.h
+++ b/ext/pdo_dblib/php_pdo_dblib_int.h
@@ -118,6 +118,7 @@ typedef struct {
 typedef struct {
 	pdo_dblib_db_handle *H;
 	pdo_dblib_err err;
+	unsigned int computed_column_name_count;
 } pdo_dblib_stmt;
 
 typedef struct {

--- a/ext/pdo_dblib/tests/bug_71667.phpt
+++ b/ext/pdo_dblib/tests/bug_71667.phpt
@@ -1,0 +1,34 @@
+--TEST--
+PDO_DBLIB: Emulate how mssql extension names "computed" columns
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+$stmt = $db->prepare("SELECT 1, 2 AS named, 3");
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(6) {
+    ["computed"]=>
+    string(1) "1"
+    [0]=>
+    string(1) "1"
+    ["named"]=>
+    string(1) "2"
+    [1]=>
+    string(1) "2"
+    ["computed1"]=>
+    string(1) "3"
+    [2]=>
+    string(1) "3"
+  }
+}


### PR DESCRIPTION
Full notes are in the bug report I created:
https://bugs.php.net/bug.php?id=71667