### PR TITLE
Bug #71667: have pdo_dblib emulate how mssql extension names "computed" column (PHP-5.6)

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -100,6 +100,7 @@ static int dblib_handle_preparer(pdo_dbh_t *dbh, const char *sql, long sql_len, 
 	stmt->driver_data = S;
 	stmt->methods = &dblib_stmt_methods;
 	stmt->supports_placeholders = PDO_PLACEHOLDER_NONE;
+	S->computed_column_name_count = 0;
 	S->err.sqlstate = stmt->error_code;
 
 	return 1;

--- a/ext/pdo_dblib/dblib_stmt.c
+++ b/ext/pdo_dblib/dblib_stmt.c
@@ -197,6 +197,10 @@ static int pdo_dblib_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC)
 	if(colno >= stmt->column_count || colno < 0)  {
 		return FAILURE;
 	}
+
+	if (colno == 0) {
+		S->computed_column_name_count = 0;
+	}
 	
 	col = &stmt->columns[colno];
 	fname = (char*)dbcolname(H->link, colno+1);
@@ -205,7 +209,14 @@ static int pdo_dblib_stmt_describe(pdo_stmt_t *stmt, int colno TSRMLS_DC)
 		col->name = estrdup(fname);
 		col->namelen = strlen(col->name);
 	} else {
-		col->namelen = spprintf(&col->name, 0, "computed%d", colno);
+		if (S->computed_column_name_count > 0) {
+			col->namelen = spprintf(&col->name, 0, "computed%d", S->computed_column_name_count);
+		} else {
+			col->name = estrdup("computed");
+			col->namelen = strlen("computed");
+		}
+
+		S->computed_column_name_count++;
 	}
 	col->maxlen = dbcollen(H->link, colno+1);
 	col->param_type = PDO_PARAM_STR;

--- a/ext/pdo_dblib/php_pdo_dblib_int.h
+++ b/ext/pdo_dblib/php_pdo_dblib_int.h
@@ -118,6 +118,7 @@ typedef struct {
 typedef struct {
 	pdo_dblib_db_handle *H;
 	pdo_dblib_err err;
+	unsigned int computed_column_name_count;
 } pdo_dblib_stmt;
 
 typedef struct {

--- a/ext/pdo_dblib/tests/bug_71667.phpt
+++ b/ext/pdo_dblib/tests/bug_71667.phpt
@@ -1,0 +1,34 @@
+--TEST--
+PDO_DBLIB: Emulate how mssql extension names "computed" columns
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+$stmt = $db->prepare("SELECT 1, 2 AS named, 3");
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(6) {
+    ["computed"]=>
+    string(1) "1"
+    [0]=>
+    string(1) "1"
+    ["named"]=>
+    string(1) "2"
+    [1]=>
+    string(1) "2"
+    ["computed1"]=>
+    string(1) "3"
+    [2]=>
+    string(1) "3"
+  }
+}


### PR DESCRIPTION
Some notes are in the bug report I created:
https://bugs.php.net/bug.php?id=71667

A question was raised in a #1775 about whether this change should go into a stable branch. There have been a few different behaviors for these column names in 5.x releases:
- emulate mssql (start at computed, next column is computed1, computed2, etc.)
- don't do anything, causing only one of these columns to be sent back, with an empty string for a name
- give names that start with computed, but with an index based on the column number (see #1386)

The second two behaviors were added without test coverage or discussion around how they'd affect existing code. So I'd argue that this PR is a bug fix for these regressions. Also, having behavior that diverges from the mssql extension will make it difficult for people to migrate from 5.x to 7, which requires them to switch to pdo_dblib.