### PR TITLE
limit size of result set so unit test runs reliably (master)

### DIFF
--- a/ext/pdo_dblib/tests/bug_69757.phpt
+++ b/ext/pdo_dblib/tests/bug_69757.phpt
@@ -11,8 +11,8 @@ require __DIR__ . '/config.inc';
 
 $sql = "
     exec dbo.sp_executesql N'
-        SELECT * FROM sysobjects
-        SELECT * FROM syscolumns
+        SELECT TOP 1 * FROM sysobjects
+        SELECT TOP 1 * FROM syscolumns
     '
 ";
 $stmt = $db->query($sql);


### PR DESCRIPTION
If you have a very big database, this query can cause the test to fail. One row is all that's needed for the purposes of the test.