### PR TITLE
Fix bug #71635 (DatePeriod::getEndDate() segfault)

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4536,6 +4536,10 @@ PHP_METHOD(DatePeriod, getEndDate)
 
         dpobj = (php_period_obj *)zend_object_store_get_object(getThis() TSRMLS_CC);
 
+        if (!dpobj->end) {
+                return;
+        }
+
         php_date_instantiate(dpobj->start_ce, return_value TSRMLS_CC);
         dateobj = (php_date_obj *)zend_object_store_get_object(return_value TSRMLS_CC);
         dateobj->time = timelib_time_ctor();

--- a/ext/date/tests/bug71635.phpt
+++ b/ext/date/tests/bug71635.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #71635 (segfault in DatePeriod::getEndDate() when no end date has been set)
+--FILE--
+<?php
+date_default_timezone_set('UTC');
+$period = new DatePeriod(new DateTimeImmutable("now"), new DateInterval("P2Y4DT6H8M"), 2);
+
+var_dump($period->getEndDate());
+?>
+--EXPECT--
+NULL


### PR DESCRIPTION
This fixes a segfault in `DatePeriod::getEndDate()` when no end date has been set. This is also reproducible in PHP 7 and master.

Bug report: https://bugs.php.net/bug.php?id=71635

@derickr can you take a look please?