### PR TITLE
Fix for #71745: FILTER_FLAG_NO_RES_RANGE does not cover whole 127.0.0.0/8

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -789,10 +789,10 @@ void php_filter_validate_ip(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 			if (flags & FILTER_FLAG_NO_RES_RANGE) {
 				if (
 					(ip[0] == 0) ||
+					(ip[0] == 127) ||
 					(ip[0] == 100 && (ip[1] >= 64 && ip[1] <= 127)) ||
 					(ip[0] == 169 && ip[1] == 254) ||
 					(ip[0] == 192 && ip[1] == 0 && ip[2] == 2) ||
-					(ip[0] == 127 && ip[1] == 0 && ip[2] == 0 && ip[3] == 1) ||
 					(ip[0] >= 224 && ip[0] <= 255)
 				) {
 					RETURN_VALIDATION_FAILED

--- a/ext/filter/tests/bug71745.phpt
+++ b/ext/filter/tests/bug71745.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #71745 (FILTER_FLAG_NO_RES_RANGE does not cover whole 127.0.0.0/8 range)
+--SKIPIF--
+<?php if (!extension_loaded("filter")) die("skip"); ?>
+--FILE--
+<?php
+foreach (['127.0.0.1', '127.0.0.2', '127.0.1.1', '127.127.127.127'] as $ip) {
+    var_dump(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_RES_RANGE));
+}
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+bool(false)


### PR DESCRIPTION
This fixes filter_var to recognize whole 127.0.0.0/8 range as reserved.

Note that there is more of the reserved ranges missing as per [1] & [2], but it's rather a feature request. (I'll send another separate PR for those later if needed.)

[1] https://en.wikipedia.org/wiki/Reserved_IP_addresses#IPv4
[2] https://www.wikiwand.com/en/Reserved_IP_addresses