### PR TITLE
Always duplicate the method name in zend_get_call_trampoline_func().

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ PHP                                                                        NEWS
   . Fixed bug #69953 (Support MKCALENDAR request method). (Christoph)
 
 - Core:
+  . Fixed bug #71778 (zend_std_get_method() inconsistently increments the
+    method_name refcount). (Adam)
   . Fixed bug #71756 (Call-by-reference widens scope to uninvolved functions
     when used in switch). (Laruence)
   . Fixed bug #71729 (Possible crash in zend_bin_strtod, zend_oct_strtod,

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1065,7 +1065,7 @@ ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend
 	if (UNEXPECTED(strlen(ZSTR_VAL(method_name)) != ZSTR_LEN(method_name))) {
 		func->function_name = zend_string_init(ZSTR_VAL(method_name), strlen(ZSTR_VAL(method_name)), 0);
 	} else {
-		func->function_name = zend_string_copy(method_name);
+		func->function_name = zend_string_dup(method_name, 0);
 	}
 
 	return (zend_function*)func;


### PR DESCRIPTION
This fixes [bug #71778](https://bugs.php.net/bug.php?id=71778) (which has more detail), and ensures that there isn't inconsistent behaviour in `zend_get_call_trampoline_func()` (and, probably more importantly from an actual use perspective, `zend_std_get_method()` by extension).

This doesn't apply to 5.x, so the PR is against 7.0 for easy merging up to master.