### PR TITLE
7.0.4 exec command cant work 

### DIFF
--- a/ext/wddx/wddx.c
+++ b/ext/wddx/wddx.c
@@ -877,7 +877,7 @@ static void php_wddx_pop_element(void *user_data, const XML_Char *name)
 		!strcmp((char *)name, EL_DATETIME)) {
 		wddx_stack_top(stack, (void**)&ent1);
 
-		if (!ent1->data) {
+		if (Z_TYPE(ent1->data) == IS_UNDEF) {
 			if (stack->top > 1) {
 				stack->top--;
 			} else {
@@ -1020,7 +1020,7 @@ static void php_wddx_process_data(void *user_data, const XML_Char *s, int len)
 					if (ent->varname) {
 						efree(ent->varname);
 					}
-					ent->data = NULL;
+					ZVAL_UNDEF(&ent->data);
 				}
 				break;
 


### PR DESCRIPTION
 I use

    exec("`fmpeg -i /var/www/ad-1/www/uploads/ad/v/5e/8f/98/88/5e8f98881c4da88fb31a1fe1b93c45d6.mp4 -y -f mjpeg -ss 3 -t 0.001 -s 640x1136 /var/www/ad-1/www/uploads/ad/v/5e/8f/98/88/5e8f98881c4da88fb31a1fe1b93c45d6.jpg")

in php file, it doesn't work. But I use `exec("whoami")`, it work well. When I use

    fmpeg -i /var/www/ad-1/www/uploads/ad/v/5e/8f/98/88/5e8f98881c4da88fb31a1fe1b93c45d6.mp4 -y -f mjpeg -ss 3 -t 0.001 -s 640x1136 /var/www/ad-1/www/uploads/ad/v/5e/8f/98/88/5e8f98881c4da88fb31a1fe1b93c45d6.jpg

in command line it work well. But when I use

    exec("`fmpeg -i /var/www/ad-1/www/uploads/ad/v/5e/8f/98/88/5e8f98881c4da88fb31a1fe1b93c45d6.mp4 -y -f mjpeg -ss 3 -t 0.001 -s 640x1136 /var/www/ad-1/www/uploads/ad/v/5e/8f/98/88/5e8f98881c4da88fb31a1fe1b93c45d6.jpg")

in php it doesn't work.