### PR TITLE
Fix bug #71624, PHP_MODE_PROCESS_STDIN (CLI SAPI called with '-R') did not properly set $argi and $argn

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1018,16 +1018,15 @@ static int do_cli(int argc, char **argv) /* {{{ */
 				if (exec_begin && zend_eval_string_ex(exec_begin, NULL, "Command line begin code", 1) == FAILURE) {
 					exit_status=254;
 				}
-				ZVAL_LONG(&argi, index);
-				zend_hash_str_update(&EG(symbol_table), "argi", sizeof("argi")-1, &argi);
 				while (exit_status == SUCCESS && (input=php_stream_gets(s_in_process, NULL, 0)) != NULL) {
 					len = strlen(input);
 					while (len > 0 && len-- && (input[len]=='\n' || input[len]=='\r')) {
 						input[len] = '\0';
 					}
-					ZVAL_STRINGL(&argn, input, len);
+					ZVAL_STRINGL(&argn, input, len + 1);
 					zend_hash_str_update(&EG(symbol_table), "argn", sizeof("argn")-1, &argn);
-					Z_LVAL(argi) = ++index;
+					ZVAL_LONG(&argi, ++index);
+					zend_hash_str_update(&EG(symbol_table), "argi", sizeof("argi")-1, &argi);
 					if (exec_run) {
 						if (zend_eval_string_ex(exec_run, NULL, "Command line run code", 1) == FAILURE) {
 							exit_status=254;

--- a/sapi/cli/tests/bug71624.phpt
+++ b/sapi/cli/tests/bug71624.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #61977 Test that -R properly sets argi and argn
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+$php = getenv('TEST_PHP_EXECUTABLE');
+
+$filename_txt = dirname(__FILE__) . DIRECTORY_SEPARATOR . "bug71624.test.txt";
+
+$txt = 'foo
+test
+hello
+';
+
+file_put_contents($filename_txt, $txt);
+
+$test_args = ['$argi', '$argn'];
+foreach ($test_args as $test_arg) {
+	if (substr(PHP_OS, 0, 3) == 'WIN') {
+		var_dump(`type "$filename_txt" | "$php" -n -R "echo $test_arg . PHP_EOL;"`);
+	} else {
+		var_dump(`cat "$filename_txt" | "$php" -n -R 'echo $test_arg . PHP_EOL;'`);
+	}
+}
+
+@unlink($filename_txt);
+
+echo "Done\n";
+?>
+--EXPECT--
+string(6) "1
+2
+3
+"
+string(15) "foo
+test
+hello
+"
+Done


### PR DESCRIPTION
This was filed in the bug tracker [here](https://bugs.php.net/bug.php?id=71624)