### PR TITLE
FIX #71831: CURLOPT_NOPROXY applied as long instead of string

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2226,7 +2226,6 @@ static int _php_curl_setopt(php_curl *ch, long option, zval **zvalue TSRMLS_DC) 
 		case CURLOPT_CERTINFO:
 #endif
 #if LIBCURL_VERSION_NUM >= 0x071304 /* Available since 7.19.4 */
-		case CURLOPT_NOPROXY:
 		case CURLOPT_PROTOCOLS:
 		case CURLOPT_REDIR_PROTOCOLS:
 		case CURLOPT_SOCKS5_GSSAPI_NEC:
@@ -2308,6 +2307,7 @@ static int _php_curl_setopt(php_curl *ch, long option, zval **zvalue TSRMLS_DC) 
 		case CURLOPT_USERNAME:
 #endif
 #if LIBCURL_VERSION_NUM >= 0x071304 /* Available since 7.19.4 */
+		case CURLOPT_NOPROXY:
 		case CURLOPT_SOCKS5_GSSAPI_SERVICE:
 #endif
 #if LIBCURL_VERSION_NUM >= 0x071400 /* Available since 7.20.0 */


### PR DESCRIPTION
The CURLOPT_NOPROXY option value is converted to a long before
being applied as a curl option. This causes the option to have
no effect. This patch changes this conversion to a string.