### PR TITLE
Cleanup all SSLv2 code, whatever OpenSSL version is

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1275,9 +1275,6 @@ PHP_MINIT_FUNCTION(openssl)
 #ifndef OPENSSL_NO_SSL3
 	php_stream_xport_register("sslv3", php_openssl_ssl_socket_factory);
 #endif
-#ifndef OPENSSL_NO_SSL2
-	php_stream_xport_register("sslv2", php_openssl_ssl_socket_factory);
-#endif
 	php_stream_xport_register("tls", php_openssl_ssl_socket_factory);
 	php_stream_xport_register("tlsv1.0", php_openssl_ssl_socket_factory);
 #if OPENSSL_VERSION_NUMBER >= 0x10001001L
@@ -1325,9 +1322,6 @@ PHP_MSHUTDOWN_FUNCTION(openssl)
 	php_unregister_url_stream_wrapper("ftps");
 
 	php_stream_xport_unregister("ssl");
-#ifndef OPENSSL_NO_SSL2
-	php_stream_xport_unregister("sslv2");
-#endif
 #ifndef OPENSSL_NO_SSL3
 	php_stream_xport_unregister("sslv3");
 #endif

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -991,6 +991,9 @@ static int php_get_crypto_method_ctx_flags(int method_flags) /* {{{ */
 {
 	int ssl_ctx_options = SSL_OP_ALL;
 
+#ifdef SSL_OP_NO_SSLv2
+	ssl_ctx_options |= SSL_OP_NO_SSLv2;
+#endif
 #ifdef HAVE_SSL3
 	if (!(method_flags & STREAM_CRYPTO_METHOD_SSLv3)) {
 		ssl_ctx_options |= SSL_OP_NO_SSLv3;


### PR DESCRIPTION
SSLv2 is deprecated and unsecure

Recent OpenSSL version have drop it
Linux distributions have already disable (with older OpenSSL version)

So this is mostly a cleanup, which ensure SSLv2 is never available even when build with an old and unsecure OpenSSL version.