### PR TITLE
Fixed bug #71859 (crash in zend_objects_store_call_destructors)

### DIFF
--- a/Zend/tests/bug71859.phpt
+++ b/Zend/tests/bug71859.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Bug #71859 (Segmentation fault when calling destructors)
+--FILE--
+<?php
+class constructs_in_destructor {
+  public function __destruct() {
+    //We are now in zend_objects_store_call_destructors
+    //This causes a realloc in zend_objects_store_put
+    for ($i = 0; $i < 10000; ++$i) {
+      $GLOBALS["a$i"] = new stdClass;
+    }
+    //Returns to zend_objects_store_call_destructors, to access freed memory.
+  }
+}
+
+gc_disable();
+$a = new constructs_in_destructor;
+//Create cycle so destructors are ran only in zend_objects_store_call_destructors
+$a->a = $a;
+
+// Create some objects so zend_objects_store_call_destructors has something
+// to do after constructs_in_destructor is destroyed.
+for ($i = 0; $i < 200; ++$i) {
+  $GLOBALS["b$i"] = new stdClass;
+}
+echo "ok\n";
+?>
+--EXPECTF--
+ok


### PR DESCRIPTION
zend_objects_store_call_destructors operated on reallocated memory if
destructors allocated enough objects to cause object store realloc.
After each destructor, check that object pool still points to the same
memory, if not, iterate over it again.