### PR TITLE
Bugfix for #71835 - failed json_encode recursion detection with get_object_vars in it.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,10 @@ PHP                                                                        NEWS
   . Fixed bug #69659 (ArrayAccess, isset() and the offsetExists method).
     (Nikita)
 
+- JSON:
+  . Fixed bug #71835 (json_encode sometimes incorrectly detects recursion
+    with JsonSerializable). (Jakub Zelenka)
+
 - ODBC:
   . Fixed bug #63171 (Script hangs after max_execution_time). (Remi)
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1183,7 +1183,7 @@ ZEND_FUNCTION(get_object_vars)
 
 	zobj = Z_OBJ_P(obj);
 
-	if (!zobj->ce->default_properties_count && properties == zobj->properties) {
+	if (!zobj->ce->default_properties_count && properties == zobj->properties && !ZEND_HASH_GET_APPLY_COUNT(properties)) {
 		/* fast copy */
 		if (EXPECTED(zobj->handlers == &std_object_handlers)) {
 			if (EXPECTED(!(GC_FLAGS(properties) & IS_ARRAY_IMMUTABLE))) {

--- a/ext/json/tests/bug71835.phpt
+++ b/ext/json/tests/bug71835.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #71835 (json_encode sometimes incorrectly detects recursion with JsonSerializable)
+--SKIPIF--
+<?php if (!extension_loaded("json")) print "skip"; ?>
+--FILE--
+<?php
+class SomeClass implements JsonSerializable {
+	public function jsonSerialize() {
+		return [get_object_vars($this)];
+	}
+}
+$class = new SomeClass;
+$arr = [$class];
+var_dump(json_encode($arr));
+?>
+--EXPECT--
+string(6) "[[[]]]"


### PR DESCRIPTION
Hi @laruence , I have been thinking about https://bugs.php.net/bug.php?id=71835 and the best fix that I can think of is checking hash apply count in get_object_vars. I don't think that it should have any impact on general perf as apply count is mainly used in encoders. In terms of json, this is a very special case but it makes sense to fall-back to the previous (PHP 5) logic (copying array). I haven't checked other encoders (e.g. php serialization) but if there is a similar logic, then it could be an issue there as well so this would fix it too...

If it's fine with you and no one else has got a better idea or see an issue in this, please could you merge  it - I don't think I have a Zend karma...