### PR TITLE
Fix DateInterval::format segfault (bug #71889)

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4359,6 +4359,10 @@ static char *date_interval_format(char *format, int format_len, timelib_rel_time
 
 	smart_str_0(&string);
 
+	if (string.c == NULL) {
+		return estrdup("");
+	}
+
 	return string.c;
 }
 /* }}} */

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4309,7 +4309,7 @@ static char *date_interval_format(char *format, int format_len, timelib_rel_time
 	char                 buffer[33];
 
 	if (!format_len) {
-		return estrdup("");
+		return STR_EMPTY_ALLOC();
 	}
 
 	for (i = 0; i < format_len; i++) {
@@ -4360,7 +4360,7 @@ static char *date_interval_format(char *format, int format_len, timelib_rel_time
 	smart_str_0(&string);
 
 	if (string.c == NULL) {
-		return estrdup("");
+		return STR_EMPTY_ALLOC();
 	}
 
 	return string.c;

--- a/ext/date/tests/bug71889.phpt
+++ b/ext/date/tests/bug71889.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #71889 (DateInterval::format segfault on '%' input)
+--INI--
+date.timezone=US/Eastern
+--FILE--
+<?php
+$di = new DateInterval('P1D');
+var_dump($di->format("%"));
+?>
+--EXPECT--
+string(0) ""


### PR DESCRIPTION
Fixes a segfault when using `DateInterval::format('%')`. This affects PHP 7 and master too.

/cc @derickr 