### PR TITLE
Fix #71943: dblib_handle_quoter needs to allocate an extra byte

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -170,7 +170,7 @@ static int dblib_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unqu
 		 *
 		 */
 		*quotedlen = (unquotedlen * 2) + 2; /* 2 chars per byte +2 for "0x" prefix */
-		q = *quoted = emalloc(*quotedlen);
+		q = *quoted = emalloc(*quotedlen+1); /* Add byte for terminal null */
 
 		*q++ = '0';
 		*q++ = 'x';
@@ -181,7 +181,7 @@ static int dblib_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unqu
 	} else {
 		/* Alpha/Numeric Quoting */
 		*quotedlen += 2; /* +2 for opening, closing quotes */
-		q  = *quoted = emalloc(*quotedlen);
+		q  = *quoted = emalloc(*quotedlen+1); /* Add byte for terminal null */
 		*q++ = '\'';
 
 		for (i=0;i<unquotedlen;i++) {

--- a/ext/pdo_dblib/tests/pdo_dblib_quote.phpt
+++ b/ext/pdo_dblib/tests/pdo_dblib_quote.phpt
@@ -1,0 +1,24 @@
+--TEST--
+PDO_DBLIB: Ensure quote function returns expected results
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+var_dump($db->quote(true, PDO::PARAM_BOOL));
+var_dump($db->quote(false, PDO::PARAM_BOOL));
+var_dump($db->quote(42, PDO::PARAM_INT));
+var_dump($db->quote(null, PDO::PARAM_NULL));
+var_dump($db->quote('\'', PDO::PARAM_STR));
+var_dump($db->quote('foo', PDO::PARAM_STR));
+?>
+--EXPECT--
+string(3) "'1'"
+string(2) "''"
+string(4) "'42'"
+string(2) "''"
+string(4) "''''"
+string(5) "'foo'"


### PR DESCRIPTION
The quoted versions of some of the values are inaccurate -- you don't need quotes around numbers, null should be NULL -- but I'll leave those for a separate fix.