### PR TITLE
[WIP] accessor optimization

### DIFF
--- a/Zend/tests/bug52614.phpt
+++ b/Zend/tests/bug52614.phpt
@@ -60,11 +60,11 @@ var_dump($foo->o2);
 
 $foo->a1[0] = 1;
 $foo->f7($foo->f6()[0]);
-var_dump($foo->a1[0]);
+var_dump($foo->a1[0]); // 2
 $foo->f1()[0]++;
-var_dump($foo->a1[0]);
+var_dump($foo->a1[0]); // 2
 $foo->f6()[0]++;
-var_dump($foo->a1[0]);
+var_dump($foo->a1[0]); // 3
 --EXPECTF--
 NULL
 array(0) {

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -365,8 +365,14 @@ struct _zend_op_array {
 	zend_arg_info *arg_info;
 	/* END of common elements */
 
-	zend_uchar accessor_type; // the accessor type (getter, setter, const returniing)
-	uint32_t property_offset;
+
+	/* the accessor info */
+	union {
+		uint32_t property_offset;
+	} accessor_info;
+
+	/* the accessor type (getter, setter, const) */
+	zend_uchar accessor_type;
 
 	uint32_t *refcount;
 
@@ -598,6 +604,8 @@ struct _zend_execute_data {
 
 # define CT_CONSTANT(node) \
 	CT_CONSTANT_EX(CG(active_op_array), (node).constant)
+
+
 
 #if ZEND_USE_ABS_CONST_ADDR
 
@@ -1037,4 +1045,6 @@ ZEND_API zend_bool zend_binary_op_produces_numeric_string_error(uint32_t opcode,
  * c-basic-offset: 4
  * indent-tabs-mode: t
  * End:
+ *
+ * vim:noet:
  */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -197,6 +197,10 @@ typedef struct _zend_oparray_context {
 	HashTable *labels;
 } zend_oparray_context;
 
+#define ZEND_ACCESSOR_GETTER 0x01
+#define ZEND_ACCESSOR_SETTER 0x02
+#define ZEND_ACCESSOR_CONST  0x04
+
 /* method flags (types) */
 #define ZEND_ACC_STATIC			0x01
 #define ZEND_ACC_ABSTRACT		0x02
@@ -361,6 +365,9 @@ struct _zend_op_array {
 	zend_arg_info *arg_info;
 	/* END of common elements */
 
+	zend_uchar accessor_type; // the accessor type (getter, setter, const returniing)
+	uint32_t property_offset;
+
 	uint32_t *refcount;
 
 	uint32_t this_var;
@@ -421,7 +428,6 @@ typedef struct _zend_internal_function {
 
 union _zend_function {
 	zend_uchar type;	/* MUST be the first element of this struct! */
-
 	struct {
 		zend_uchar type;  /* never used */
 		zend_uchar arg_flags[3]; /* bitset of arg_info.pass_by_reference */
@@ -433,7 +439,6 @@ union _zend_function {
 		uint32_t required_num_args;
 		zend_arg_info *arg_info;
 	} common;
-
 	zend_op_array op_array;
 	zend_internal_function internal_function;
 };

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -537,10 +537,17 @@ zval *zend_std_read_property(zval *object, zval *member, int type, void **cache_
 	/* make zend_get_property_info silent if we have getter - we may want to use it */
 	property_offset = zend_get_property_offset(zobj->ce, Z_STR_P(member), (type == BP_VAR_IS) || (zobj->ce->__get != NULL), cache_slot);
 
+
 	if (EXPECTED(property_offset != ZEND_WRONG_PROPERTY_OFFSET)) {
 		if (EXPECTED(property_offset != ZEND_DYNAMIC_PROPERTY_OFFSET)) {
 			retval = OBJ_PROP(zobj, property_offset);
 			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				if (EXPECTED(EG(current_execute_data) != NULL)
+					&& EXPECTED(EG(current_execute_data)->func != NULL)
+					&& EXPECTED(EG(current_execute_data)->func->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+				) {
+					EG(current_execute_data)->func->op_array.property_offset = property_offset;
+				}
 				goto exit;
 			}
 		} else if (EXPECTED(zobj->properties != NULL)) {

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -546,7 +546,8 @@ zval *zend_std_read_property(zval *object, zval *member, int type, void **cache_
 					&& EXPECTED(EG(current_execute_data)->func != NULL)
 					&& EXPECTED(EG(current_execute_data)->func->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
 				) {
-					EG(current_execute_data)->func->op_array.property_offset = property_offset;
+					// Cache the property offset
+					EG(current_execute_data)->func->op_array.accessor_info.property_offset = property_offset;
 				}
 				goto exit;
 			}

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -97,7 +97,7 @@ void init_op_array(zend_op_array *op_array, zend_uchar type, int initial_ops_siz
 	op_array->run_time_cache = NULL;
 	op_array->cache_size = 0;
 	op_array->accessor_type = 0;
-	op_array->accessor_info.constant = 0;
+	op_array->accessor_info.property_offset = 0;
 
 	memset(op_array->reserved, 0, ZEND_MAX_RESERVED_RESOURCES * sizeof(void*));
 

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -96,6 +96,8 @@ void init_op_array(zend_op_array *op_array, zend_uchar type, int initial_ops_siz
 
 	op_array->run_time_cache = NULL;
 	op_array->cache_size = 0;
+	op_array->accessor_type = 0;
+	op_array->property_offset = 0;
 
 	memset(op_array->reserved, 0, ZEND_MAX_RESERVED_RESOURCES * sizeof(void*));
 
@@ -629,6 +631,42 @@ ZEND_API int pass_two(zend_op_array *op_array)
 		CG(context).literals_size = op_array->last_literal;
 	}
 	opline = op_array->opcodes;
+
+	/* If the op_array is a method without arguments and return one property,
+	 * we mark the op_array as an accessor.
+	 *
+	 * The condition below doesn't check op_array->type because the op_array is
+	 * already initialized with ZEND_USER_FUNCTION.
+	 *
+	 * When zend_extension is enabled, the compiler_option "ZEND_COMPILE_EXTENDED_INFO" will 
+	 * extend the op array with zend extension only op. The accessor info will be ignored.
+	 *
+	 * The expected op codes here are:
+	 *
+	 *  - FETCH_OBJ_R (IS_UNUSED, IS_CONST -> IS_VAR)
+	 *  - RETURN (IS_VAR)
+	 *  - RETURN (IS_CONST)
+	 * */
+	if (op_array->last == 3
+		&& (op_array->num_args == 0)
+		&& (op_array->scope != NULL)
+		&& (op_array->scope->type & ZEND_ACC_IMPLICIT_ABSTRACT_CLASS) == 0
+		&& (op_array->scope->type == ZEND_USER_CLASS)
+		&& (op_array->fn_flags & ZEND_ACC_PUBLIC) != 0
+		&& (op_array->fn_flags & ZEND_ACC_ABSTRACT) == 0
+	) {
+		// Verify the oplines
+		zend_op * returnop = opline + 1;
+		if (opline->opcode == ZEND_FETCH_OBJ_R
+			&& opline->op1_type == IS_UNUSED
+			&& opline->op2_type == IS_CONST
+			&& returnop->opcode == ZEND_RETURN
+			&& returnop->op1_type == IS_VAR
+		) {
+			op_array->accessor_type = ZEND_ACCESSOR_GETTER;
+		}
+	}
+
 	end = opline + op_array->last;
 	while (opline < end) {
 		switch (opline->opcode) {
@@ -827,4 +865,6 @@ ZEND_API binary_op_type get_binary_op(int opcode)
  * c-basic-offset: 4
  * indent-tabs-mode: t
  * End:
+ *
+ * vim:noet:
  */

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3148,61 +3148,55 @@ ZEND_VM_HANDLER(112, ZEND_INIT_METHOD_CALL, CONST|TMPVAR|UNUSED|THIS|CV, CONST|T
 			FREE_OP1();
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if (OP2_TYPE == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (OP1_TYPE == IS_CV
-		&& OP2_TYPE == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& EXPECTED(object != NULL)
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				/*
-				TODO: verify return type
-				if (fbc->op_array->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
-					zend_verify_return_type(fbc, retval, CACHE_ADDR(opline->op2.num));
-				}
-				*/
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6048,6 +6048,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CO
 		}
 	}
 
+	if (IS_CONST == IS_CV && IS_CONST == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
+		}
+	}
+
 	call_info = ZEND_CALL_NESTED_FUNCTION;
 	if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0)) {
 		obj = NULL;
@@ -9889,6 +9938,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CV
 		}
 	}
 
+	if (IS_CONST == IS_CV && IS_CV == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
+		}
+	}
+
 	call_info = ZEND_CALL_NESTED_FUNCTION;
 	if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0)) {
 		obj = NULL;
@@ -11807,6 +11905,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_TM
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
+		}
+	}
+
+	if (IS_CONST == IS_CV && (IS_TMP_VAR|IS_VAR) == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
 		}
 	}
 
@@ -28703,6 +28850,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 		}
 	}
 
+	if (IS_UNUSED == IS_CV && IS_CONST == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
+		}
+	}
+
 	call_info = ZEND_CALL_NESTED_FUNCTION;
 	if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0)) {
 		obj = NULL;
@@ -32038,6 +32234,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 		}
 	}
 
+	if (IS_UNUSED == IS_CV && IS_CV == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
+		}
+	}
+
 	call_info = ZEND_CALL_NESTED_FUNCTION;
 	if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0)) {
 		obj = NULL;
@@ -34304,6 +34549,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_T
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
+		}
+	}
+
+	if (IS_UNUSED == IS_CV && (IS_TMP_VAR|IS_VAR) == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
 		}
 	}
 
@@ -39719,6 +40013,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CONST
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
+		}
+	}
+
+	if (IS_CV == IS_CV && IS_CONST == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
 		}
 	}
 
@@ -46213,6 +46556,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CV_HA
 		}
 	}
 
+	if (IS_CV == IS_CV && IS_CV == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
+		}
+	}
+
 	call_info = ZEND_CALL_NESTED_FUNCTION;
 	if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0)) {
 		obj = NULL;
@@ -49756,6 +50148,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_TMPVA
 		}
 	}
 
+	if (IS_CV == IS_CV && (IS_TMP_VAR|IS_VAR) == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
+		}
+	}
+
 	call_info = ZEND_CALL_NESTED_FUNCTION;
 	if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0)) {
 		obj = NULL;
@@ -51982,6 +52423,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
+		}
+	}
+
+	if ((IS_TMP_VAR|IS_VAR) == IS_CV && IS_CONST == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
 		}
 	}
 
@@ -54328,6 +54818,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 		}
 	}
 
+	if ((IS_TMP_VAR|IS_VAR) == IS_CV && IS_CV == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
+		}
+	}
+
 	call_info = ZEND_CALL_NESTED_FUNCTION;
 	if (UNEXPECTED((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0)) {
 		obj = NULL;
@@ -55572,6 +56111,55 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_T
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
+		}
+	}
+
+	if ((IS_TMP_VAR|IS_VAR) == IS_CV && (IS_TMP_VAR|IS_VAR) == IS_CONST
+			&& object != NULL
+			&& EXPECTED(fbc != NULL)
+			&& UNEXPECTED(fbc->op_array.accessor_type == ZEND_ACCESSOR_GETTER)
+			&& EXPECTED(fbc->type == ZEND_USER_FUNCTION)
+			&& EXPECTED(fbc->op_array.property_offset != 0)
+	) {
+		zval *retval = NULL;
+		zend_op *nextop = NULL;
+		zend_bool assigned_result = 0;
+
+		if (EXPECTED(Z_TYPE_P(object) != IS_UNDEF)) {
+			retval = OBJ_PROP(obj, fbc->op_array.property_offset);
+			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+				nextop = (zend_op*) opline;
+				nextop++;
+				if (UNEXPECTED(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_BEGIN)) {
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							assigned_result = 1;
+						}
+						nextop++;
+					}
+					if (EXPECTED(nextop->opcode == ZEND_EXT_FCALL_END)) {
+						nextop++;
+					}
+				} else if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)) {
+
+					if (EXPECTED(nextop->result_type == IS_VAR)) {
+						ZVAL_DEREF(retval);
+						ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+						assigned_result = 1;
+					}
+					nextop++;
+				}
+				// TODO: verify return type
+				// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
+				if (EXPECTED(assigned_result)) {
+					ZEND_VM_JMP(nextop);
+				}
+			}
 		}
 	}
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6037,55 +6037,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CO
 
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if (IS_CONST == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (IS_CONST == IS_CV
-		&& IS_CONST == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -9919,55 +9920,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CV
 
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if (IS_CV == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (IS_CONST == IS_CV
-		&& IS_CV == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -11881,55 +11883,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_TM
 
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (IS_CONST == IS_CV
-		&& (IS_TMP_VAR|IS_VAR) == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -28815,55 +28818,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if (IS_CONST == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (IS_UNUSED == IS_CV
-		&& IS_CONST == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -32191,55 +32195,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if (IS_CV == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (IS_UNUSED == IS_CV
-		&& IS_CV == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -34501,55 +34506,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_T
 
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (IS_UNUSED == IS_CV
-		&& (IS_TMP_VAR|IS_VAR) == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -39957,55 +39963,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CONST
 
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if (IS_CONST == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (IS_CV == IS_CV
-		&& IS_CONST == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -46489,55 +46496,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CV_HA
 
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if (IS_CV == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (IS_CV == IS_CV
-		&& IS_CV == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -50073,55 +50081,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_TMPVA
 
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if (IS_CV == IS_CV
-		&& (IS_TMP_VAR|IS_VAR) == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -52343,55 +52352,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 			zval_ptr_dtor_nogc(free_op1);
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if (IS_CONST == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if ((IS_TMP_VAR|IS_VAR) == IS_CV
-		&& IS_CONST == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -54727,55 +54737,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 			zval_ptr_dtor_nogc(free_op1);
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if (IS_CV == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if ((IS_TMP_VAR|IS_VAR) == IS_CV
-		&& IS_CV == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 
@@ -56015,55 +56026,56 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_T
 			zval_ptr_dtor_nogc(free_op1);
 			HANDLE_EXCEPTION();
 		}
+
+
+
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
 		    EXPECTED(fbc->type <= ZEND_USER_FUNCTION) &&
 		    EXPECTED(!(fbc->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE|ZEND_ACC_NEVER_CACHE))) &&
 		    EXPECTED(obj == orig_obj)) {
 			CACHE_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope, fbc);
+
+
+			if (UNEXPECTED(fbc->op_array.accessor_type != 0)
+				&& EXPECTED(object != NULL)
+				&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
+			) {
+				zend_op *nextop = (zend_op*) opline + 1;
+				zval *retval = NULL;
+
+				if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
+					&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
+				{
+
+					retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
+
+					if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
+						&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
+					{
+						if (EXPECTED(nextop->result_type == IS_VAR)) {
+							ZVAL_DEREF(retval);
+							ZVAL_COPY(EX_VAR(nextop->result.var), retval);
+							nextop++;
+							ZEND_VM_JMP(nextop);
+						}
+					}
+				} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
+					retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
+					if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
+						&& EXPECTED(nextop->result_type == IS_VAR)
+					) {
+						ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
+						if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
+							zval_copy_ctor_func(EX_VAR(nextop->result.var));
+						}
+						nextop++;
+						ZEND_VM_JMP(nextop);
+					}
+				}
+			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
-		}
-	}
-
-	if ((IS_TMP_VAR|IS_VAR) == IS_CV
-		&& (IS_TMP_VAR|IS_VAR) == IS_CONST
-		&& EXPECTED(fbc != NULL)
-		&& UNEXPECTED(fbc->op_array.accessor_type != 0)
-		&& object != NULL
-		&& EXPECTED(Z_TYPE_P(object) != IS_UNDEF)
-	) {
-		zend_op *nextop = (zend_op*) opline + 1;
-		zval *retval = NULL;
-
-		if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_GETTER)
-			&& EXPECTED(fbc->op_array.accessor_info.property_offset != 0))
-		{
-			retval = OBJ_PROP(obj, fbc->op_array.accessor_info.property_offset);
-			if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)
-				&& EXPECTED(nextop->opcode == ZEND_DO_FCALL))
-			{
-				if (EXPECTED(nextop->result_type == IS_VAR)) {
-					// TODO: verify return type
-					// zend_verify_return_type(EX(func), retval_ptr, CACHE_ADDR(opline->op2.num));
-					ZVAL_DEREF(retval);
-					ZVAL_COPY(EX_VAR(nextop->result.var), retval);
-					nextop++;
-					ZEND_VM_JMP(nextop);
-				}
-			}
-		} else if (EXPECTED(fbc->op_array.accessor_type & ZEND_ACCESSOR_CONST)) {
-			retval = fbc->op_array.literals + fbc->op_array.opcodes->op1.constant;
-			if (EXPECTED(nextop->opcode == ZEND_DO_FCALL)
-				&& EXPECTED(nextop->result_type == IS_VAR)
-			) {
-				ZVAL_COPY_VALUE(EX_VAR(nextop->result.var), retval);
-				if (UNEXPECTED(Z_OPT_COPYABLE_P(EX_VAR(nextop->result.var)))) {
-					zval_copy_ctor_func(EX_VAR(nextop->result.var));
-				}
-				nextop++;
-				ZEND_VM_JMP(nextop);
-			}
 		}
 	}
 


### PR DESCRIPTION
Implement property getter optimization to make getter methods 2 times faster

## Optimization Targets

Simple getters

```php
class Foo {
    protected $value;
    public function getValue() {
        return $this->value;
    }
}
```

Const accessor

```php
class Foo {
    public function getTemplate() {
        return "base.html";
    }
}
```

Simple setters

```php
class Foo {
    protected $template;
    public function setTemplate($template) {
        $this->template = $template;
    }
}
```


## Changes

- Added accessor struct to op_array struct for saving accessor
      information.
- Added accessor checking in pass_two() for getter functions.
- Added quick property getter in INIT_METHOD_CALL op handler

## Benchmark Result

### Getter Method Only

https://gist.github.com/8cd230a5601cbe38439661adf3caca0d

Without getter optimization (3 runs):
151.0169506073ms

With getter optimization (3 runs)
39.201021194458ms

## Affect
Other Microbench result: https://gist.github.com/c9s/0273ac21631562724cabf86c42e86e32

