### PR TITLE
Bug #71911: Make phpize set a proper build type (windows)

### DIFF
--- a/win32/build/config.w32.phpize.in
+++ b/win32/build/config.w32.phpize.in
@@ -23,7 +23,7 @@ toolset_setup_project_tools();
 ARG_ENABLE('object-out-dir', 'Alternate location for binary objects during build', '');
 object_out_dir_option_handle();
 
-ARG_ENABLE('debug', 'Compile with debugging symbols', "no");
+ARG_ENABLE('debug', 'Compile with debugging symbols', PHP_DEBUG);
 ARG_ENABLE('debug-pack', 'Release binaries with external debug symbols (--enable-debug must not be specified)', 'no');
 if (PHP_DEBUG == "yes" && PHP_DEBUG_PACK == "yes") {
 	ERROR("Use of both --enable-debug and --enable-debug-pack not allowed.");

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2042,6 +2042,7 @@ function generate_phpize()
 	CJ = FSO.CreateTextFile(dest + "/config.phpize.js");
 
 	CJ.WriteLine("var PHP_ZTS =" + '"' + PHP_ZTS + '"');
+	CJ.WriteLine("var PHP_DEBUG=" + '"' + PHP_DEBUG + '"');
 	CJ.WriteLine("var PHP_DLL_LIB =" + '"' + get_define('PHPLIB') + '"');
 	CJ.WriteLine("var PHP_DLL =" + '"' + get_define('PHPDLL') + '"');
 

--- a/win32/build/phpize.js.in
+++ b/win32/build/phpize.js.in
@@ -229,7 +229,7 @@ C.Write(file_get_contents(PHP_DIR + "/script/config.phpize.js"));
 // Pull in code for the base detection
 modules = file_get_contents(PHP_DIR + "/script/config.w32.phpize.in");
 
-C.WriteLine("ARG_ENABLE('debug', 'Compile with debugging symbols', \"no\");");
+C.WriteLine("ARG_ENABLE('debug', 'Compile with debugging symbols', PHP_DEBUG);");
 find_config_w32(".");
 
 // Now generate contents of module based on MODULES, chasing dependencies


### PR DESCRIPTION
The build type of an extension must correspond to that of PHP.
Phpize set a proper one automatically from PHP_DEBUG.

(This is a bugfix to https://github.com/php/php-src/pull/1841)
