### PR TITLE
opcache config.m4: Use = for comparison

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -359,7 +359,7 @@ AC_TRY_RUN([
     AC_MSG_RESULT("yes")
 ], AC_MSG_RESULT("no") )
 
-if test "$flock_type" == "unknown"; then
+if test "$flock_type" = "unknown"; then
 	AC_MSG_ERROR([Don't know how to define struct flock on this system[,] set --enable-opcache=no])
 fi
 


### PR DESCRIPTION
Similar to d01566fe2f604757de4d5445c3ae1d436584fc61 in PHP-7.0.