### PR TITLE
Enable configure without opcache-file and huge-code-pages

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -6,11 +6,11 @@ PHP_ARG_ENABLE(opcache, whether to enable Zend OPcache support,
 [  --disable-opcache       Disable Zend OPcache support], yes)
 
 PHP_ARG_ENABLE(opcache-file, whether to enable file based caching,
-[  --disable-opcache-file  Disable file based caching], yes)
+[  --disable-opcache-file  Disable file based caching], yes, no)
 
 PHP_ARG_ENABLE(huge-code-pages, whether to enable copying PHP CODE pages into HUGE PAGES,
 [  --disable-huge-code-pages
-                          Disable copying PHP CODE pages into HUGE PAGES], yes)
+                          Disable copying PHP CODE pages into HUGE PAGES], yes, no)
 
 if test "$PHP_OPCACHE" != "no"; then
 


### PR DESCRIPTION
This doesn't chagne the default (yes for both features), but respects
--disable-opcache-file and --disable-huge-code-pages configure flags if given.