### PR TITLE
Add time to the RAND pool before each RAND_bytes call

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -971,7 +971,6 @@ static void php_openssl_dispose_config(struct php_x509_request * req TSRMLS_DC) 
 #define PHP_OPENSSL_RAND_ADD_TIME() ((void) 0)
 #else
 #define PHP_OPENSSL_RAND_ADD_TIME() php_openssl_rand_add_timeval()
-#endif
 
 static inline void php_openssl_rand_add_timeval()  /* {{{ */
 {
@@ -981,6 +980,8 @@ static inline void php_openssl_rand_add_timeval()  /* {{{ */
 	RAND_add(&tv, sizeof(tv), 0.0);
 }
 /* }}} */
+
+#endif
 
 static int php_openssl_load_rand_file(const char * file, int *egdsocket, int *seeded TSRMLS_DC) /* {{{ */
 {

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -967,6 +967,21 @@ static void php_openssl_dispose_config(struct php_x509_request * req TSRMLS_DC) 
 }
 /* }}} */
 
+#ifdef PHP_WIN32
+#define PHP_OPENSSL_RAND_ADD_TIME() ((void) 0)
+#else
+#define PHP_OPENSSL_RAND_ADD_TIME() php_openssl_rand_add_timeval()
+#endif
+
+static inline void php_openssl_rand_add_timeval()  /* {{{ */
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+	RAND_add(&tv, sizeof(tv), 0.0);
+}
+/* }}} */
+
 static int php_openssl_load_rand_file(const char * file, int *egdsocket, int *seeded TSRMLS_DC) /* {{{ */
 {
 	char buffer[MAXPATHLEN];
@@ -1010,6 +1025,7 @@ static int php_openssl_write_rand_file(const char * file, int egdsocket, int see
 	if (file == NULL) {
 		file = RAND_file_name(buffer, sizeof(buffer));
 	}
+	PHP_OPENSSL_RAND_ADD_TIME();
 	if (file == NULL || !RAND_write_file(file)) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to write random state");
 		return FAILURE;
@@ -3396,12 +3412,14 @@ static EVP_PKEY * php_openssl_generate_private_key(struct php_x509_request * req
 	if ((req->priv_key = EVP_PKEY_new()) != NULL) {
 		switch(req->priv_key_type) {
 			case OPENSSL_KEYTYPE_RSA:
+				PHP_OPENSSL_RAND_ADD_TIME();
 				if (EVP_PKEY_assign_RSA(req->priv_key, RSA_generate_key(req->priv_key_bits, 0x10001, NULL, NULL))) {
 					return_val = req->priv_key;
 				}
 				break;
 #if !defined(NO_DSA) && defined(HAVE_DSA_DEFAULT_METHOD)
 			case OPENSSL_KEYTYPE_DSA:
+				PHP_OPENSSL_RAND_ADD_TIME();
 				{
 					DSA *dsapar = DSA_generate_parameters(req->priv_key_bits, NULL, 0, NULL, NULL, NULL, NULL);
 					if (dsapar) {
@@ -3419,6 +3437,7 @@ static EVP_PKEY * php_openssl_generate_private_key(struct php_x509_request * req
 #endif
 #if !defined(NO_DH)
 			case OPENSSL_KEYTYPE_DH:
+				PHP_OPENSSL_RAND_ADD_TIME();
 				{
 					DH *dhpar = DH_generate_parameters(req->priv_key_bits, 2, NULL, NULL);
 					int codes = 0;
@@ -3582,6 +3601,7 @@ PHP_FUNCTION(openssl_pkey_new)
 					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dsa, pub_key);
 					if (dsa->p && dsa->q && dsa->g) {
 						if (!dsa->priv_key && !dsa->pub_key) {
+							PHP_OPENSSL_RAND_ADD_TIME();
 							DSA_generate_key(dsa);
 						}
 						if (EVP_PKEY_assign_DSA(pkey, dsa)) {
@@ -3603,6 +3623,7 @@ PHP_FUNCTION(openssl_pkey_new)
 					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dh, g);
 					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dh, priv_key);
 					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dh, pub_key);
+					PHP_OPENSSL_RAND_ADD_TIME();
 					if (dh->p && dh->g &&
 							(dh->pub_key || DH_generate_key(dh)) &&
 							EVP_PKEY_assign_DH(pkey, dh)) {
@@ -5423,6 +5444,7 @@ PHP_FUNCTION(openssl_random_pseudo_bytes)
 		RETURN_FALSE;
 	}
 #else
+	PHP_OPENSSL_RAND_ADD_TIME();
 	if (RAND_bytes(buffer, buffer_length) <= 0) {
 		efree(buffer);
 		if (zstrong_result_returned) {


### PR DESCRIPTION
This is an another variant of the fix for [bug 1844](https://bugs.php.net/bug.php?id=71915). The idea is to sort of back-port what OpenSSL 1.1 does and add a time to the entropy pool before each RAND_bytes call. It means also before each OpenSSL function that calls it internally. It is replaced by noop on Windows where it's not needed and it will be also noop if compiled with OpenSSL 1.1 (once I merge it's support to master).