### PR TITLE
Fix segfault on mysqlnd result set error

### DIFF
--- a/ext/mysqli/tests/bug71863.phpt
+++ b/ext/mysqli/tests/bug71863.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Bug #71863 Segfault when EXPLAIN with "Unknown Column" Error
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnectfailure.inc');
+require_once("connect.inc");
+?>
+--FILE--
+<?php
+require_once("connect.inc");
+
+$req = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
+
+// create db and table for test
+mysqli_query($req, "DROP TABLE IF EXISTS test_bug_71863") or die(mysqli_error($req));
+mysqli_query($req, "CREATE TABLE test_bug_71863 (id INT UNSIGNED NOT NULL DEFAULT 0)") or die(mysqli_error($req));
+    
+// segfault if EXPLAIN + "Unknown column" error
+mysqli_query($req, "EXPLAIN SELECT `id` FROM `test_bug_71863` WHERE `owner_id` = '2' AND `object_id` = '1' AND type = '0'") or die(mysqli_error($req));
+
+?>
+--CLEAN--
+<?php
+require_once("connect.inc");
+if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
+if (!mysqli_query($link, "DROP TABLE IF EXISTS test_bug_71863"))
+    printf("[c002] Cannot drop table, [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+mysqli_close($link);
+?>
+--EXPECTF--
+Warning: mysqli_query(): (42S22/1054): Unknown column 'owner_id' in 'where clause' in %sbug71863.php on line %d
+Unknown column 'owner_id' in 'where clause'

--- a/ext/mysqlnd/mysqlnd_result.c
+++ b/ext/mysqlnd/mysqlnd_result.c
@@ -1391,7 +1391,7 @@ MYSQLND_METHOD(mysqlnd_res, store_result_fetch_data)(MYSQLND_CONN_DATA * const c
 	}
 
 	if (ret == FAIL) {
-		COPY_CLIENT_ERROR(&set->error_info, row_packet->error_info);
+		memcpy(&set->error_info, &row_packet->error_info, sizeof(MYSQLND_ERROR_INFO));
 	} else {
 		/* libmysql's documentation says it should be so for SELECT statements */
 		UPSERT_STATUS_SET_AFFECTED_ROWS(conn->upsert_status, set->row_count);


### PR DESCRIPTION
This patch fixes bug# 71863 which caused a segfault when the result set
contained an error. This occurs becuase the buffered result set does
not contain callbacks in its mysqlnd error_info struct and would fail
on a null pointer when called with the macro COPY_CLIENT_ERROR.

The fix simply copies the error info struct from the row_packet into
the buffered result set, as was done before.