### PR TITLE
Resolve bug #72017

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2230,7 +2230,7 @@ double_str:
 			RANGE_CHECK_DOUBLE_INIT_ARRAY(low, high);
 
 			ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
-				for (i = 0; i < size && (element = low - (i * step)) <= low && element >= high; ++i) {
+				for (i = 0; i < size && (element = low - (i * step)) >= high; ++i) {
 					Z_DVAL(tmp) = element;
 					ZEND_HASH_FILL_ADD(&tmp);
 				}
@@ -2244,7 +2244,7 @@ double_str:
 			RANGE_CHECK_DOUBLE_INIT_ARRAY(high, low);
 
 			ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
-				for (i = 0; i < size && (element = low + (i * step)) <= high && element >= low; ++i) {
+				for (i = 0; i < size && (element = low + (i * step)) <= high; ++i) {
 					Z_DVAL(tmp) = element;
 					ZEND_HASH_FILL_ADD(&tmp);
 				}

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2230,7 +2230,7 @@ double_str:
 			RANGE_CHECK_DOUBLE_INIT_ARRAY(low, high);
 
 			ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
-				for (i = 0; i < size && (element = low - (i * step)) >= high; ++i) {
+				for (i = 0, element = low; i < size && element >= high; ++i, element = low - (i * step)) {
 					Z_DVAL(tmp) = element;
 					ZEND_HASH_FILL_ADD(&tmp);
 				}
@@ -2244,7 +2244,7 @@ double_str:
 			RANGE_CHECK_DOUBLE_INIT_ARRAY(high, low);
 
 			ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
-				for (i = 0; i < size && (element = low + (i * step)) <= high; ++i) {
+				for (i = 0, element = low; i < size && element <= high; ++i, element = low + (i * step)) {
 					Z_DVAL(tmp) = element;
 					ZEND_HASH_FILL_ADD(&tmp);
 				}

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2097,7 +2097,7 @@ PHP_FUNCTION(array_fill_keys)
 			php_error_docref(NULL, E_WARNING, "The supplied range exceeds the maximum array size: start=%0.0f end=%0.0f", end, start); \
 			RETURN_FALSE; \
 		} \
-		size = (uint32_t)__calc_size; \
+		size = (uint32_t)round(__calc_size); \
 		array_init_size(return_value, size); \
 		zend_hash_real_init(Z_ARRVAL_P(return_value), 1); \
 	} while (0)
@@ -2209,7 +2209,7 @@ PHP_FUNCTION(range)
 			zend_hash_next_index_insert_new(Z_ARRVAL_P(return_value), &tmp);
 		}
 	} else if (Z_TYPE_P(zlow) == IS_DOUBLE || Z_TYPE_P(zhigh) == IS_DOUBLE || is_step_double) {
-		double low, high;
+		double low, high, element;
 		uint32_t i, size;
 double_str:
 		low = zval_get_double(zlow);
@@ -2230,8 +2230,8 @@ double_str:
 			RANGE_CHECK_DOUBLE_INIT_ARRAY(low, high);
 
 			ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
-				for (i = 0; i < size; ++i) {
-					Z_DVAL(tmp) = low - (i * step);
+				for (i = 0; i < size && (element = low - (i * step)) <= low && element >= high; ++i) {
+					Z_DVAL(tmp) = element;
 					ZEND_HASH_FILL_ADD(&tmp);
 				}
 			} ZEND_HASH_FILL_END();
@@ -2244,8 +2244,8 @@ double_str:
 			RANGE_CHECK_DOUBLE_INIT_ARRAY(high, low);
 
 			ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
-				for (i = 0; i < size; ++i) {
-					Z_DVAL(tmp) = low + (i * step);
+				for (i = 0; i < size && (element = low + (i * step)) <= high && element >= low; ++i) {
+					Z_DVAL(tmp) = element;
 					ZEND_HASH_FILL_ADD(&tmp);
 				}
 			} ZEND_HASH_FILL_END();

--- a/ext/standard/tests/array/range_bug72017.phpt
+++ b/ext/standard/tests/array/range_bug72017.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #72017 (incorrect truncation due to floating point precision issue)
+--FILE--
+<?php
+var_dump(range(4.5, 4.2, 0.1));
+?>
+--EXPECT--
+array(4) {
+  [0]=>
+  float(4.5)
+  [1]=>
+  float(4.4)
+  [2]=>
+  float(4.3)
+  [3]=>
+  float(4.2)
+}


### PR DESCRIPTION
Resolves bug [#72017](https://bugs.php.net/bug.php?id=72017).

This is a little hacky, but it works. It should really be noted that `range()` does not work well with floats because of the precision problem.

There's still cases where `range()` will not work:
```
var_dump(range(90, 90.1, .1)); // bool(false)
```
([3v4l](https://3v4l.org/6O769).)

I can't see a fix to these, however.