### PR TITLE
Fixed bug #71972

### DIFF
--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -295,8 +295,9 @@ PHPAPI void php_session_reset_id(void);
 	zend_ulong num_key;													\
 	zval *struc;
 
-#define PS_ENCODE_LOOP(code) do {									\
+#define PS_ENCODE_LOOP_EX(once, code) do {							\
 	HashTable *_ht = Z_ARRVAL_P(Z_REFVAL(PS(http_session_vars)));	\
+	once;                                                           \
 	ZEND_HASH_FOREACH_KEY(_ht, num_key, key) {						\
 		if (key == NULL) {											\
 			php_error_docref(NULL, E_NOTICE,				\
@@ -308,6 +309,8 @@ PHPAPI void php_session_reset_id(void);
 		} 															\
 	} ZEND_HASH_FOREACH_END();										\
 } while(0)
+
+#define PS_ENCODE_LOOP(code)  PS_ENCODE_LOOP_EX(, code)
 
 PHPAPI ZEND_EXTERN_MODULE_GLOBALS(ps)
 

--- a/ext/session/tests/001.phpt
+++ b/ext/session/tests/001.phpt
@@ -32,5 +32,4 @@ print session_encode()."\n";
 
 session_destroy();
 --EXPECT--
-baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";s:4:"done";}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";s:4:"done";}}
-
+__SESS_N_VARS__|i:2;baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";s:4:"done";}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";s:4:"done";}}

--- a/ext/session/tests/004.phpt
+++ b/ext/session/tests/004.phpt
@@ -90,7 +90,7 @@ array(1) {
     int(2)
   }
 }
-WRITE: abtest, baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}}
+WRITE: abtest, __SESS_N_VARS__|i:2;baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}}
 OPEN: PHPSESSID
 READ: abtest
 object(foo)#3 (2) {

--- a/ext/session/tests/005.phpt
+++ b/ext/session/tests/005.phpt
@@ -92,7 +92,7 @@ session_destroy();
 --EXPECTF--
 OPEN: PHPSESSID
 READ: abtest
-object(foo)#4 (2) {
+object(foo)#%d (2) {
   ["bar"]=>
   string(2) "ok"
   ["yes"]=>
@@ -100,18 +100,18 @@ object(foo)#4 (2) {
 }
 array(1) {
   [3]=>
-  object(foo)#2 (2) {
+  object(foo)#%d (2) {
     ["bar"]=>
     string(2) "ok"
     ["yes"]=>
     int(2)
   }
 }
-WRITE: abtest, baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}}
+WRITE: abtest, __SESS_N_VARS__|i:2;baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}}
 CLOSE
 OPEN: PHPSESSID
 READ: abtest
-object(foo)#2 (2) {
+object(foo)#%d (2) {
   ["bar"]=>
   string(2) "ok"
   ["yes"]=>
@@ -119,7 +119,7 @@ object(foo)#2 (2) {
 }
 array(1) {
   [3]=>
-  object(foo)#4 (2) {
+  object(foo)#%d (2) {
     ["bar"]=>
     string(2) "ok"
     ["yes"]=>
@@ -127,11 +127,11 @@ array(1) {
   }
 }
 int(123)
-WRITE: abtest, baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:3;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:3;}}c|i:123;
+WRITE: abtest, __SESS_N_VARS__|i:3;baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:3;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:3;}}c|i:123;
 CLOSE
 OPEN: PHPSESSID
 READ: abtest
-object(foo)#4 (2) {
+object(foo)#%d (2) {
   ["bar"]=>
   string(2) "ok"
   ["yes"]=>
@@ -139,7 +139,7 @@ object(foo)#4 (2) {
 }
 array(1) {
   [3]=>
-  object(foo)#2 (2) {
+  object(foo)#%d (2) {
     ["bar"]=>
     string(2) "ok"
     ["yes"]=>
@@ -149,4 +149,3 @@ array(1) {
 int(123)
 DESTROY: abtest
 CLOSE
-

--- a/ext/session/tests/022.phpt
+++ b/ext/session/tests/022.phpt
@@ -29,4 +29,4 @@ var_dump(session_encode());
 session_destroy();
 ?>
 --EXPECT--
-string(126) "baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";s:4:"done";}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";s:4:"done";}}"
+string(146) "__SESS_N_VARS__|i:2;baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";s:4:"done";}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";s:4:"done";}}"

--- a/ext/session/tests/024.phpt
+++ b/ext/session/tests/024.phpt
@@ -94,7 +94,7 @@ array(1) {
     int(2)
   }
 }
-WRITE: abtest, baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}}
+WRITE: abtest, __SESS_N_VARS__|i:2;baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}}
 OPEN: PHPSESSID
 READ: abtest
 object(foo)#%d (2) {

--- a/ext/session/tests/025.phpt
+++ b/ext/session/tests/025.phpt
@@ -116,7 +116,7 @@ array(1) {
     int(2)
   }
 }
-WRITE: abtest, baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}}
+WRITE: abtest, __SESS_N_VARS__|i:2;baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:2;}}
 CLOSE
 OPEN: PHPSESSID
 READ: abtest
@@ -136,7 +136,7 @@ array(1) {
   }
 }
 int(123)
-WRITE: abtest, baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:3;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:3;}}c|i:123;
+WRITE: abtest, __SESS_N_VARS__|i:3;baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:3;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:3;}}c|i:123;
 CLOSE
 OPEN: PHPSESSID
 READ: abtest

--- a/ext/session/tests/bug32330.phpt
+++ b/ext/session/tests/bug32330.phpt
@@ -71,7 +71,7 @@ $_SESSION['E'] = 'F';
 open: path = /tmp, name = sid
 read: id = %s
 gc: maxlifetime = %d
-write: id = %s, data = A|s:1:"B";
+write: id = %s, data = %s|i:1;A|s:1:"B";
 close
 open: path = /tmp, name = sid
 read: id = %s
@@ -81,5 +81,5 @@ close
 open: path = /tmp, name = sid
 read: id = %s
 gc: maxlifetime = %d
-write: id = %s, data = E|s:1:"F";
+write: id = %s, data = %s|i:1;E|s:1:"F";
 close

--- a/ext/session/tests/session_encode_basic.phpt
+++ b/ext/session/tests/session_encode_basic.phpt
@@ -101,76 +101,75 @@ ob_end_flush();
 bool(true)
 
 -- Iteration 1 --
-string(9) "data|i:0;"
+string(29) "__SESS_N_VARS__|i:1;data|i:0;"
 
 -- Iteration 2 --
-string(9) "data|i:1;"
+string(29) "__SESS_N_VARS__|i:1;data|i:1;"
 
 -- Iteration 3 --
-string(13) "data|i:12345;"
+string(33) "__SESS_N_VARS__|i:1;data|i:12345;"
 
 -- Iteration 4 --
-string(13) "data|i:-2345;"
+string(33) "__SESS_N_VARS__|i:1;data|i:-2345;"
 
 -- Iteration 5 --
-string(12) "data|d:10.5;"
+string(32) "__SESS_N_VARS__|i:1;data|d:10.5;"
 
 -- Iteration 6 --
-string(13) "data|d:-10.5;"
+string(33) "__SESS_N_VARS__|i:1;data|d:-10.5;"
 
 -- Iteration 7 --
-string(20) "data|d:123456789000;"
+string(40) "__SESS_N_VARS__|i:1;data|d:123456789000;"
 
 -- Iteration 8 --
-string(%d) "data|d:1.2345678899999999145113427164344339914681114578343112953007221221923828125E-9;"
+string(106) "__SESS_N_VARS__|i:1;data|d:1.2345678899999999145113427164344339914681114578343112953007221221923828125E-9;"
 
 -- Iteration 9 --
-string(11) "data|d:0.5;"
+string(31) "__SESS_N_VARS__|i:1;data|d:0.5;"
 
 -- Iteration 10 --
-string(7) "data|N;"
+string(27) "__SESS_N_VARS__|i:1;data|N;"
 
 -- Iteration 11 --
-string(7) "data|N;"
+string(27) "__SESS_N_VARS__|i:1;data|N;"
 
 -- Iteration 12 --
-string(9) "data|b:1;"
+string(29) "__SESS_N_VARS__|i:1;data|b:1;"
 
 -- Iteration 13 --
-string(9) "data|b:0;"
+string(29) "__SESS_N_VARS__|i:1;data|b:0;"
 
 -- Iteration 14 --
-string(9) "data|b:1;"
+string(29) "__SESS_N_VARS__|i:1;data|b:1;"
 
 -- Iteration 15 --
-string(9) "data|b:0;"
+string(29) "__SESS_N_VARS__|i:1;data|b:0;"
 
 -- Iteration 16 --
-string(12) "data|s:0:"";"
+string(32) "__SESS_N_VARS__|i:1;data|s:0:"";"
 
 -- Iteration 17 --
-string(12) "data|s:0:"";"
+string(32) "__SESS_N_VARS__|i:1;data|s:0:"";"
 
 -- Iteration 18 --
-string(19) "data|s:7:"Nothing";"
+string(39) "__SESS_N_VARS__|i:1;data|s:7:"Nothing";"
 
 -- Iteration 19 --
-string(19) "data|s:7:"Nothing";"
+string(39) "__SESS_N_VARS__|i:1;data|s:7:"Nothing";"
 
 -- Iteration 20 --
-string(25) "data|s:12:"Hello World!";"
+string(45) "__SESS_N_VARS__|i:1;data|s:12:"Hello World!";"
 
 -- Iteration 21 --
-string(22) "data|O:6:"classA":0:{}"
+string(42) "__SESS_N_VARS__|i:1;data|O:6:"classA":0:{}"
 
 -- Iteration 22 --
-string(7) "data|N;"
+string(27) "__SESS_N_VARS__|i:1;data|N;"
 
 -- Iteration 23 --
-string(7) "data|N;"
+string(27) "__SESS_N_VARS__|i:1;data|N;"
 
 -- Iteration 24 --
-string(9) "data|i:0;"
+string(29) "__SESS_N_VARS__|i:1;data|i:0;"
 bool(true)
 Done
-

--- a/ext/session/tests/session_encode_error2.phpt
+++ b/ext/session/tests/session_encode_error2.phpt
@@ -100,122 +100,122 @@ ob_end_flush();
 -- Iteration 1 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 0 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 0 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 2 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 1 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 1 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 3 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 12345 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 12345 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 4 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key -2345 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key -2345 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 5 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 10 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 10 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 6 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key -10 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key -10 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 7 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key %s in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 123456789000 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 8 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 0 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 0 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 9 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 0 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 0 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 10 --
 bool(true)
-string(21) "|s:12:"Hello World!";"
+string(41) "__SESS_N_VARS__|i:1;|s:12:"Hello World!";"
 bool(true)
 
 -- Iteration 11 --
 bool(true)
-string(21) "|s:12:"Hello World!";"
+string(41) "__SESS_N_VARS__|i:1;|s:12:"Hello World!";"
 bool(true)
 
 -- Iteration 12 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 1 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 1 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 13 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 0 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 0 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 14 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 1 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 1 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 15 --
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 0 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 0 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 
 -- Iteration 16 --
 bool(true)
-string(21) "|s:12:"Hello World!";"
+string(41) "__SESS_N_VARS__|i:1;|s:12:"Hello World!";"
 bool(true)
 
 -- Iteration 17 --
 bool(true)
-string(21) "|s:12:"Hello World!";"
+string(41) "__SESS_N_VARS__|i:1;|s:12:"Hello World!";"
 bool(true)
 
 -- Iteration 18 --
 bool(true)
-string(28) "Nothing|s:12:"Hello World!";"
+string(48) "__SESS_N_VARS__|i:1;Nothing|s:12:"Hello World!";"
 bool(true)
 
 -- Iteration 19 --
 bool(true)
-string(28) "Nothing|s:12:"Hello World!";"
+string(48) "__SESS_N_VARS__|i:1;Nothing|s:12:"Hello World!";"
 bool(true)
 
 -- Iteration 20 --
@@ -226,26 +226,26 @@ bool(true)
 -- Iteration 21 --
 bool(true)
 
-Warning: Illegal offset type in %s on line 82
+Warning: Illegal offset type in %ssession_encode_error2.php on line %d
 bool(false)
 bool(true)
 
 -- Iteration 22 --
 bool(true)
-string(21) "|s:12:"Hello World!";"
+string(41) "__SESS_N_VARS__|i:1;|s:12:"Hello World!";"
 bool(true)
 
 -- Iteration 23 --
 bool(true)
-string(21) "|s:12:"Hello World!";"
+string(41) "__SESS_N_VARS__|i:1;|s:12:"Hello World!";"
 bool(true)
 
 -- Iteration 24 --
 bool(true)
 
-Notice: Resource ID#%d used as offset, casting to integer (%d) in %s on line %d
+Notice: Resource ID#5 used as offset, casting to integer (5) in %ssession_encode_error2.php on line %d
 
-Notice: session_encode(): Skipping numeric key %d in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 5 in %ssession_encode_error2.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 Done

--- a/ext/session/tests/session_encode_variation3.phpt
+++ b/ext/session/tests/session_encode_variation3.phpt
@@ -28,6 +28,6 @@ ob_end_flush();
 --EXPECTF--
 *** Testing session_encode() : variation ***
 bool(true)
-string(34) "foo|a:3:{i:0;i:1;i:1;i:2;i:2;i:3;}"
+string(%d) "%s|i:1;foo|a:3:{i:0;i:1;i:1;i:2;i:2;i:3;}"
 bool(true)
 Done

--- a/ext/session/tests/session_encode_variation4.phpt
+++ b/ext/session/tests/session_encode_variation4.phpt
@@ -30,6 +30,6 @@ ob_end_flush();
 --EXPECTF--
 *** Testing session_encode() : variation ***
 bool(true)
-string(52) "foo|a:3:{i:0;i:1;i:1;i:2;i:2;i:3;}guff|R:1;blah|R:1;"
+string(%d) "%s|i:3;foo|a:3:{i:0;i:1;i:1;i:2;i:2;i:3;}guff|R:1;blah|R:1;"
 bool(true)
 Done

--- a/ext/session/tests/session_encode_variation5.phpt
+++ b/ext/session/tests/session_encode_variation5.phpt
@@ -30,6 +30,6 @@ ob_end_flush();
 --EXPECTF--
 *** Testing session_encode() : variation ***
 bool(true)
-string(64) "data|a:5:{i:0;i:1;i:1;i:2;i:2;i:3;s:3:"foo";R:1;s:4:"blah";R:1;}"
+string(%d) "%s|i:1;data|a:5:{i:0;i:1;i:1;i:2;i:2;i:3;s:3:"foo";R:1;s:4:"blah";R:1;}"
 bool(true)
 Done

--- a/ext/session/tests/session_encode_variation6.phpt
+++ b/ext/session/tests/session_encode_variation6.phpt
@@ -35,17 +35,17 @@ ob_end_flush();
 *** Testing session_encode() : variation ***
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 0 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 0 in %ssession_encode_variation6.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 bool(true)
 
-Notice: session_encode(): Skipping numeric key 1234567890 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key 1234567890 in %ssession_encode_variation6.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 bool(true)
 
-Notice: session_encode(): Skipping numeric key -1234567890 in %s on line %d
-bool(false)
+Notice: session_encode(): Skipping numeric key -1234567890 in %ssession_encode_variation6.php on line %d
+string(20) "__SESS_N_VARS__|i:1;"
 bool(true)
 Done

--- a/ext/session/tests/session_encode_variation7.phpt
+++ b/ext/session/tests/session_encode_variation7.phpt
@@ -20,15 +20,17 @@ echo "*** Testing session_encode() : variation ***\n";
 var_dump(session_start());
 $_SESSION["foo"] = 1234567890;
 $encoded = session_encode();
+var_dump($encoded);
 var_dump(base64_encode($encoded));
 var_dump(session_destroy());
 
 echo "Done";
 ob_end_flush();
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing session_encode() : variation ***
 bool(true)
-string(24) "A2Zvb2k6MTIzNDU2Nzg5MDs="
+string(37) "__SESS_N_VARS__i:1;fooi:1234567890;"
+string(52) "D19fU0VTU19OX1ZBUlNfX2k6MTsDZm9vaToxMjM0NTY3ODkwOw=="
 bool(true)
 Done

--- a/ext/session/tests/session_set_save_handler_basic.phpt
+++ b/ext/session/tests/session_set_save_handler_basic.phpt
@@ -77,7 +77,7 @@ array(3) {
   ["Guff"]=>
   int(1234567890)
 }
-Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;]
+Write [%s,%s,%sBlah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;]
 Close [%s,PHPSESSID]
 array(3) {
   ["Blah"]=>
@@ -98,7 +98,7 @@ array(3) {
   ["Guff"]=>
   int(1234567890)
 }
-Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;Bar|s:3:"Foo";]
+Write [%s,%s,%sBlah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;Bar|s:3:"Foo";]
 Close [%s,PHPSESSID]
 Cleanup..
 Open [%s,PHPSESSID]

--- a/ext/session/tests/session_set_save_handler_class_007.phpt
+++ b/ext/session/tests/session_set_save_handler_class_007.phpt
@@ -65,11 +65,11 @@ ob_end_flush();
 *** Testing session_set_save_handler() : manual shutdown, reopen ***
 (#1) constructor called
 (#1) finish called %s
-(#1) writing %s = foo|s:3:"bar";
+(#1) writing %s = %sfoo|s:3:"bar";
 (#1) closing %s
 (#2) constructor called
 (#1) destructor called
 done
-(#2) writing %s = foo|s:3:"bar";abc|s:3:"xyz";
+(#2) writing %s = %sfoo|s:3:"bar";abc|s:3:"xyz";
 (#2) closing %s
 (#2) destructor called

--- a/ext/session/tests/session_set_save_handler_class_008.phpt
+++ b/ext/session/tests/session_set_save_handler_class_008.phpt
@@ -59,7 +59,7 @@ ob_end_flush();
 *** Testing session_set_save_handler() : manual shutdown ***
 (#1) constructor called
 (#1) finish called %s
-(#1) writing %s = foo|s:3:"bar";
+(#1) writing %s = %sfoo|s:3:"bar";
 (#1) closing %s
 done
 (#1) destructor called

--- a/ext/session/tests/session_set_save_handler_class_009.phpt
+++ b/ext/session/tests/session_set_save_handler_class_009.phpt
@@ -57,6 +57,6 @@ ob_end_flush();
 *** Testing session_set_save_handler() : implicit shutdown ***
 (#1) constructor called
 done
-(#1) writing %s = foo|s:3:"bar";
+(#1) writing %s = %sfoo|s:3:"bar";
 (#1) closing %s
 (#1) destructor called

--- a/ext/session/tests/session_set_save_handler_class_010.phpt
+++ b/ext/session/tests/session_set_save_handler_class_010.phpt
@@ -58,6 +58,6 @@ ob_end_flush();
 (#1) constructor called
 done
 (#1) finish called %s
-(#1) writing %s = foo|s:3:"bar";
+(#1) writing %s = %sfoo|s:3:"bar";
 (#1) closing %s
 (#1) destructor called

--- a/ext/session/tests/session_set_save_handler_closures.phpt
+++ b/ext/session/tests/session_set_save_handler_closures.phpt
@@ -71,7 +71,7 @@ array(3) {
   ["Guff"]=>
   int(1234567890)
 }
-Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;]
+Write [%s,%s,%sBlah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;]
 Close [%s,PHPSESSID]
 array(3) {
   ["Blah"]=>
@@ -94,5 +94,5 @@ array(4) {
   ["Bar"]=>
   string(3) "Foo"
 }
-Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;Bar|s:3:"Foo";]
+Write [%s,%s,%sBlah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;Bar|s:3:"Foo";]
 Close [%s,PHPSESSID]

--- a/ext/session/tests/session_set_save_handler_variation4.phpt
+++ b/ext/session/tests/session_set_save_handler_variation4.phpt
@@ -63,7 +63,7 @@ array(3) {
   ["Guff"]=>
   int(1234567890)
 }
-Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;]
+Write [%s,%s,%sBlah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;]
 Close [%s,PHPSESSID]
 NULL
 Open [%s,PHPSESSID]

--- a/ext/session/tests/session_set_save_handler_variation6.phpt
+++ b/ext/session/tests/session_set_save_handler_variation6.phpt
@@ -71,7 +71,7 @@ array(3) {
   ["Guff"]=>
   int(1234567890)
 }
-Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;]
+Write [%s,%s,%sBlah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;]
 Close [%s,PHPSESSID]
 array(3) {
   ["Blah"]=>
@@ -92,7 +92,7 @@ array(3) {
   ["Guff"]=>
   int(1234567890)
 }
-Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;Bar|s:3:"Foo";]
+Write [%s,%s,%sBlah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;Bar|s:3:"Foo";]
 Close [%s,PHPSESSID]
 Starting session again..!
 Open [%s,PHPSESSID]


### PR DESCRIPTION
The problem is:

````
if (has_value) {
    ZVAL_UNDEF(&current);
    if (php_var_unserialize(&current, (const unsigned char **) &p, (const unsigned char *) endptr, &var_hash)) {
        zval *zv = php_set_session_var(name, &current, &var_hash );
        var_replace(&var_hash, &current, zv);
````

php_set_session_var may cause http_session_vars resize, which will make the var in var_hash->data become invalid..

I propose to fix this by prepend a magic var "__SESS_N_VARS" to session serialized string, with this, we could know how many vars there before doing session decoding, and extend PS(http_session_vars) to the proper size, thus can avoding hash table resize, as this is a little tricky , so I make PR instead of pushing it directly.

  thanks