### PR TITLE
Fix ZTS builds by adding a missing TSRMLS_FETCH().

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3637,6 +3637,7 @@ static zend_bool do_inherit_property_access_check(HashTable *target_ht, zend_pro
 {
 	zend_property_info *child_info;
 	zend_class_entry *parent_ce = ce->parent;
+	TSRMLS_FETCH();
 
 	if (parent_info->flags & (ZEND_ACC_PRIVATE|ZEND_ACC_SHADOW)) {
 		if (zend_hash_quick_find(&ce->properties_info, hash_key->arKey, hash_key->nKeyLength, hash_key->h, (void **) &child_info)==SUCCESS) {


### PR DESCRIPTION
ffc697ac27377df3f295c7dc7281b578759645cb added a call to `i_zval_ptr_dtor_nogc()` in `do_inherit_property_access_check()`. `i_zval_ptr_dtor_nogc()` requires `tsrm_ls` to be available in ZTS builds, but merge checker functions do not get the TSRM context.

As with `do_inherit_method_check()` (which has the same requirement), we'll use `TSRMLS_FETCH()` to get around it.