### PR TITLE
bug#72057 Fix RECV opcode to handle all kinds of exceptions

### DIFF
--- a/Zend/tests/bug72057.phpt
+++ b/Zend/tests/bug72057.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #72057 (PHP hangs when user error handler throws exception after Notice from type coercion)
+--FILE--
+<?php
+
+set_error_handler(
+    function() {
+        throw new Exception("My custom error");
+    }
+);
+
+(function (int $i) { bar(); })("7as");
+
+--EXPECTF--
+
+Fatal error: Uncaught Exception: My custom error in %s:%d
+Stack trace:
+#0 %s(%d): {closure}(8, 'A non well form...', '%s', %d, Array)
+#1 %s(%d): {closure}('7as')
+#2 {main}
+  thrown in %s on line %d

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4704,7 +4704,7 @@ ZEND_VM_HANDLER(63, ZEND_RECV, ANY, ANY)
 		zval *param = _get_zval_ptr_cv_undef_BP_VAR_W(execute_data, opline->result.var);
 
 		SAVE_OPLINE();
-		if (UNEXPECTED(!zend_verify_arg_type(EX(func), arg_num, param, NULL, CACHE_ADDR(opline->op2.num)))) {
+		if (UNEXPECTED(!zend_verify_arg_type(EX(func), arg_num, param, NULL, CACHE_ADDR(opline->op2.num)) || EG(exception))) {
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -4742,7 +4742,7 @@ ZEND_VM_HANDLER(64, ZEND_RECV_INIT, ANY, CONST)
 		zval *default_value = EX_CONSTANT(opline->op2);
 
 		SAVE_OPLINE();
-		if (UNEXPECTED(!zend_verify_arg_type(EX(func), arg_num, param, default_value, CACHE_ADDR(Z_CACHE_SLOT_P(default_value))))) {
+		if (UNEXPECTED(!zend_verify_arg_type(EX(func), arg_num, param, default_value, CACHE_ADDR(Z_CACHE_SLOT_P(default_value))) || EG(exception))) {
 			HANDLE_EXCEPTION();
 		}
 	}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1188,7 +1188,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RECV_SPEC_HANDLER(ZEND_OPCODE_
 		zval *param = _get_zval_ptr_cv_undef_BP_VAR_W(execute_data, opline->result.var);
 
 		SAVE_OPLINE();
-		if (UNEXPECTED(!zend_verify_arg_type(EX(func), arg_num, param, NULL, CACHE_ADDR(opline->op2.num)))) {
+		if (UNEXPECTED(!zend_verify_arg_type(EX(func), arg_num, param, NULL, CACHE_ADDR(opline->op2.num)) || EG(exception))) {
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -2208,7 +2208,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RECV_INIT_SPEC_CONST_HANDLER(Z
 		zval *default_value = EX_CONSTANT(opline->op2);
 
 		SAVE_OPLINE();
-		if (UNEXPECTED(!zend_verify_arg_type(EX(func), arg_num, param, default_value, CACHE_ADDR(Z_CACHE_SLOT_P(default_value))))) {
+		if (UNEXPECTED(!zend_verify_arg_type(EX(func), arg_num, param, default_value, CACHE_ADDR(Z_CACHE_SLOT_P(default_value))) || EG(exception))) {
 			HANDLE_EXCEPTION();
 		}
 	}


### PR DESCRIPTION
fix RECV opcode to handle exceptions thrown from user-defined error handler
as a result of Notice error from failed type coercion