### PR TITLE
sapi: fpm: Add security.exec_basedir per-pool configuration option

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -153,6 +153,7 @@ static struct ini_value_parser_s ini_fpm_pool_options[] = {
 	{ "chdir",                     &fpm_conf_set_string,      WPO(chdir) },
 	{ "catch_workers_output",      &fpm_conf_set_boolean,     WPO(catch_workers_output) },
 	{ "clear_env",                 &fpm_conf_set_boolean,     WPO(clear_env) },
+	{ "security.exec_basedir",     &fpm_conf_set_string,      WPO(security_exec_basedir) },
 	{ "security.limit_extensions", &fpm_conf_set_string,      WPO(security_limit_extensions) },
 #ifdef HAVE_APPARMOR
 	{ "apparmor_hat",              &fpm_conf_set_string,      WPO(apparmor_hat) },
@@ -654,6 +655,7 @@ int fpm_worker_pool_config_free(struct fpm_worker_pool_config_s *wpc) /* {{{ */
 	free(wpc->slowlog);
 	free(wpc->chroot);
 	free(wpc->chdir);
+	free(wpc->security_exec_basedir);
 	free(wpc->security_limit_extensions);
 #ifdef HAVE_APPARMOR
 	free(wpc->apparmor_hat);
@@ -1013,6 +1015,20 @@ static int fpm_conf_process_all_pools() /* {{{ */
 					zlog(ZLOG_ERROR, "[pool %s] the chdir path '%s' does not exist or is not a directory", wp->config->name, wp->config->chdir);
 					return -1;
 				}
+			}
+		}
+
+		/* security.exec_basedir */
+		if (wp->config->security_exec_basedir) {
+			size_t path_len;
+
+			fpm_evaluate_full_path(&wp->config->security_exec_basedir, wp, NULL, 0);
+
+			path_len = strlen(wp->config->security_exec_basedir);
+
+			if (!path_len || wp->config->security_exec_basedir[path_len - 1] != '/') {
+				zlog(ZLOG_ERROR, "[pool %s] the security.exec_basedir path '%s' must end with a '/'", wp->config->name, wp->config->security_exec_basedir);
+				return -1;
 			}
 		}
 
@@ -1642,6 +1658,7 @@ static void fpm_conf_dump() /* {{{ */
 		zlog(ZLOG_NOTICE, "\tchdir = %s",                      STR2STR(wp->config->chdir));
 		zlog(ZLOG_NOTICE, "\tcatch_workers_output = %s",       BOOL2STR(wp->config->catch_workers_output));
 		zlog(ZLOG_NOTICE, "\tclear_env = %s",                  BOOL2STR(wp->config->clear_env));
+		zlog(ZLOG_NOTICE, "\tsecurity.exec_basedir = %s",      wp->config->security_exec_basedir);
 		zlog(ZLOG_NOTICE, "\tsecurity.limit_extensions = %s",  wp->config->security_limit_extensions);
 
 		for (kv = wp->config->env; kv; kv = kv->next) {

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -85,6 +85,7 @@ struct fpm_worker_pool_config_s {
 	char *chdir;
 	int catch_workers_output;
 	int clear_env;
+	char *security_exec_basedir;
 	char *security_limit_extensions;
 	struct key_value_s *env;
 	struct key_value_s *php_admin_values;

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1931,6 +1931,12 @@ consult the installation file that came with this distribution, or visit \n\
 				goto fastcgi_request_done;
 			}
 
+			if (UNEXPECTED(fpm_php_check_exec_basedir(SG(request_info).path_translated))) {
+				SG(sapi_headers).http_response_code = 403;
+				PUTS("Access denied.\n");
+				goto fastcgi_request_done;
+			}
+
 			if (UNEXPECTED(fpm_php_limit_extensions(SG(request_info).path_translated))) {
 				SG(sapi_headers).http_response_code = 403;
 				PUTS("Access denied.\n");

--- a/sapi/fpm/fpm/fpm_php.h
+++ b/sapi/fpm/fpm/fpm_php.h
@@ -43,6 +43,7 @@ size_t fpm_php_content_length(void);
 void fpm_php_soft_quit();
 int fpm_php_init_main();
 int fpm_php_apply_defines_ex(struct key_value_s *kv, int mode);
+int fpm_php_check_exec_basedir(char *path);
 int fpm_php_limit_extensions(char *path);
 char* fpm_php_get_string_from_table(zend_string *table, char *key);
 

--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -12,6 +12,7 @@
 ; - 'chdir'
 ; - 'php_values'
 ; - 'php_admin_values'
+; - 'security.exec_basedir'
 ; When not set, the global prefix (or @php_fpm_prefix@) applies instead.
 ; Note: This directive can also be relative to the global prefix.
 ; Default Value: none
@@ -369,6 +370,13 @@ pm.max_spare_servers = 3
 ; via getenv(), $_ENV and $_SERVER.
 ; Default Value: yes
 ;clear_env = no
+
+; Limits the directory which can be used to execute the request script.
+; This can be used to ensure that pools defined for specific users can
+; only be used to execute scripts under the control of those users.
+; This value must be defined as an absolute path and end with a '/'.
+; Default Value: not set
+;security.exec_basedir =
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit


### PR DESCRIPTION
When a single webserver is used to access multiple FPM pools (one per user), it can become possible for one vhost to execute scripts using the pool of another vhost (e.g. Apache SetHandler in .htaccess).

To prevent this, it is necessary to restrict which files a pool can execute for a request (it doesn't matter what that file then does as long as it is under control of the correct user).

While chroot does achieve this it then becomes inconvenient to allow access to any external resources (e.g. database sockets, libraries, applications) without inadvertently allowing third party users to make files available within the chroot.

This adds a per-pool configuration option "security.exec_basedir":
  Limits the directory which can be used to execute the request script.
  This can be used to ensure that pools defined for specific users can
  only be used to execute scripts under the control of those users.
  This value must be defined as an absolute path and end with a '/'.
