### PR TITLE
Fixed bug #71868:  Environment variables with no value are filtered out by proc_open()

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -108,11 +108,6 @@ static php_process_env_t _php_array_to_envp(zval *environment, int is_persistent
 	ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(environment), key, element) {
 		str = zval_get_string(element);
 
-		if (ZSTR_LEN(str) == 0) {
-			zend_string_release(str);
-			continue;
-		}
-
 		sizeenv += ZSTR_LEN(str) + 1;
 
 		if (key && ZSTR_LEN(key)) {

--- a/ext/standard/tests/general_functions/proc_open03.inc
+++ b/ext/standard/tests/general_functions/proc_open03.inc
@@ -1,0 +1,4 @@
+<?php
+
+var_dump($_SERVER['foo']);
+var_dump($_SERVER['bar']);

--- a/ext/standard/tests/general_functions/proc_open03.phpt
+++ b/ext/standard/tests/general_functions/proc_open03.phpt
@@ -1,0 +1,21 @@
+--TEST--
+proc_open
+--SKIPIF--
+<?php
+if (!function_exists("proc_open")) echo "skip proc_open() is not available";
+?>
+--FILE--
+<?php
+$php = PHP_BINARY;
+$callee = dirname(__FILE__) . DIRECTORY_SEPARATOR . "proc_open03.inc";
+$cmd = "$php $callee";
+$descriptor = array();
+$pipes = array();
+$cwd = dirname(__FILE__);
+$env = array('foo' => 'abc', 'bar' => '');
+$process = proc_open($cmd, $descriptor, $pipes, $cwd, $env);
+proc_close($process);
+?>
+--EXPECT--
+string(3) "abc"
+string(0) ""


### PR DESCRIPTION
By removing the code that skips empty array values.