### PR TITLE
Forbid dynamic calls to scope introspection functions

### DIFF
--- a/Zend/tests/dynamic_call_005.phpt
+++ b/Zend/tests/dynamic_call_005.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Dynamic calls to scope introspection functions are forbidden
+--FILE--
+<?php
+
+function test_calls($func) {
+    $i = 1;
+
+    array_map($func, [['i' => new stdClass]]);
+    var_dump($i);
+
+    $func(['i' => new stdClass]);
+    var_dump($i);
+
+    call_user_func($func, ['i' => new stdClass]);
+    var_dump($i);
+}
+test_calls('extract');
+
+?>
+--EXPECTF--
+Warning: Cannot call extract() dynamically in %s on line %d
+int(1)
+
+Warning: Cannot call extract() dynamically in %s on line %d
+int(1)
+
+Warning: Cannot call extract() dynamically in %s on line %d
+int(1)

--- a/Zend/tests/dynamic_call_006.phpt
+++ b/Zend/tests/dynamic_call_006.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Dynamic calls to scope introspection functions are forbidden (function variations)
+--FILE--
+<?php
+function test() {
+    $func = 'extract';
+    $func(['a' => 'b']);
+
+    $func = 'compact';
+    $func(['a']);
+
+    $func = 'parse_str';
+    $func('a=b');
+
+    $func = 'get_defined_vars';
+    $func();
+
+    $func = 'func_get_args';
+    $func();
+
+    $func = 'func_get_arg';
+    $func(1);
+
+    $func = 'func_num_args';
+    $func();
+}
+test();
+
+?>
+--EXPECTF--
+Warning: Cannot call extract() dynamically in %s on line %d
+
+Warning: Cannot call compact() dynamically in %s on line %d
+
+Warning: Cannot call parse_str() with a single argument dynamically in %s on line %d
+
+Warning: Cannot call get_defined_vars() dynamically in %s on line %d
+
+Warning: Cannot call func_get_args() dynamically in %s on line %d
+
+Warning: Cannot call func_get_arg() dynamically in %s on line %d
+
+Warning: Cannot call func_num_args() dynamically in %s on line %d

--- a/Zend/tests/dynamic_call_007.phpt
+++ b/Zend/tests/dynamic_call_007.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Dynamic calls to scope introspection functions are forbidden (misoptimization)
+--FILE--
+<?php
+
+function test() {
+    $i = 1;
+    array_map('extract', [['i' => new stdClass]]);
+    $i += 1;
+    var_dump($i);
+}
+test();
+
+?>
+--EXPECTF--
+Warning: Cannot call extract() dynamically in %s on line %d
+int(2)

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -543,6 +543,7 @@ ZEND_API void zend_attach_symbol_table(zend_execute_data *execute_data);
 ZEND_API void zend_detach_symbol_table(zend_execute_data *execute_data);
 ZEND_API int zend_set_local_var(zend_string *name, zval *value, int force);
 ZEND_API int zend_set_local_var_str(const char *name, size_t len, zval *value, int force);
+ZEND_API int zend_forbid_dynamic_call(const char *func_name);
 
 ZEND_API zend_string *zend_find_alias_name(zend_class_entry *ce, zend_string *name);
 ZEND_API zend_string *zend_resolve_method_name(zend_class_entry *ce, zend_function *f);

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -491,12 +491,16 @@ ZEND_FUNCTION(func_num_args)
 {
 	zend_execute_data *ex = EX(prev_execute_data);
 
-	if (!(ZEND_CALL_INFO(ex) & ZEND_CALL_CODE)) {
-		RETURN_LONG(ZEND_CALL_NUM_ARGS(ex));
-	} else {
+	if (ZEND_CALL_INFO(ex) & ZEND_CALL_CODE) {
 		zend_error(E_WARNING, "func_num_args():  Called from the global scope - no function context");
 		RETURN_LONG(-1);
 	}
+
+	if (zend_forbid_dynamic_call("func_num_args()") == FAILURE) {
+		RETURN_LONG(-1);
+	}
+
+	RETURN_LONG(ZEND_CALL_NUM_ARGS(ex));
 }
 /* }}} */
 
@@ -521,6 +525,10 @@ ZEND_FUNCTION(func_get_arg)
 	ex = EX(prev_execute_data);
 	if (ZEND_CALL_INFO(ex) & ZEND_CALL_CODE) {
 		zend_error(E_WARNING, "func_get_arg():  Called from the global scope - no function context");
+		RETURN_FALSE;
+	}
+
+	if (zend_forbid_dynamic_call("func_get_arg()") == FAILURE) {
 		RETURN_FALSE;
 	}
 
@@ -555,6 +563,10 @@ ZEND_FUNCTION(func_get_args)
 
 	if (ZEND_CALL_INFO(ex) & ZEND_CALL_CODE) {
 		zend_error(E_WARNING, "func_get_args():  Called from the global scope - no function context");
+		RETURN_FALSE;
+	}
+
+	if (zend_forbid_dynamic_call("func_get_args()") == FAILURE) {
 		RETURN_FALSE;
 	}
 
@@ -2015,8 +2027,12 @@ ZEND_FUNCTION(get_defined_functions)
    Returns an associative array of names and values of all currently defined variable names (variables in the current scope) */
 ZEND_FUNCTION(get_defined_vars)
 {
-	zend_array *symbol_table = zend_rebuild_symbol_table();
+	zend_array *symbol_table;
+	if (zend_forbid_dynamic_call("get_defined_vars()") == FAILURE) {
+		return;
+	}
 
+	symbol_table = zend_rebuild_symbol_table();
 	if (UNEXPECTED(symbol_table == NULL)) {
 		return;
 	}

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -471,9 +471,12 @@ struct _zend_execute_data {
 #define ZEND_CALL_CLOSURE            (1 << 5)
 #define ZEND_CALL_RELEASE_THIS       (1 << 6)
 #define ZEND_CALL_ALLOCATED          (1 << 7)
+#define ZEND_CALL_DYNAMIC            (1 << 8)
+
+#define ZEND_CALL_INFO_SHIFT 16
 
 #define ZEND_CALL_INFO(call) \
-	(Z_TYPE_INFO((call)->This) >> 24)
+	(Z_TYPE_INFO((call)->This) >> ZEND_CALL_INFO_SHIFT)
 
 #define ZEND_CALL_KIND_EX(call_info) \
 	(call_info & (ZEND_CALL_CODE | ZEND_CALL_TOP))
@@ -482,11 +485,12 @@ struct _zend_execute_data {
 	ZEND_CALL_KIND_EX(ZEND_CALL_INFO(call))
 
 #define ZEND_SET_CALL_INFO(call, object, info) do { \
-		Z_TYPE_INFO((call)->This) = ((object) ? IS_OBJECT_EX : IS_UNDEF) | ((info) << 24); \
+		Z_TYPE_INFO((call)->This) = \
+			((object) ? IS_OBJECT_EX : IS_UNDEF) | ((info) << ZEND_CALL_INFO_SHIFT); \
 	} while (0)
 
 #define ZEND_ADD_CALL_FLAG_EX(call_info, flag) do { \
-		call_info |= ((flag) << 24); \
+		call_info |= ((flag) << ZEND_CALL_INFO_SHIFT); \
 	} while (0)
 
 #define ZEND_ADD_CALL_FLAG(call, flag) do { \

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2742,7 +2742,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_string(zend_s
 		init_func_run_time_cache(&fbc->op_array);
 	}
 
-	return zend_vm_stack_push_call_frame(ZEND_CALL_NESTED_FUNCTION,
+	return zend_vm_stack_push_call_frame(ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_DYNAMIC,
 		fbc, num_args, called_scope, NULL);
 }
 /* }}} */
@@ -2752,7 +2752,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_object(zval *
 	zend_function *fbc;
 	zend_class_entry *called_scope;
 	zend_object *object;
-	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION;
+	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_DYNAMIC;
 
 	if (EXPECTED(Z_OBJ_HANDLER_P(function, get_closure)) &&
 	    EXPECTED(Z_OBJ_HANDLER_P(function, get_closure)(function, &called_scope, &fbc, &object) == SUCCESS)) {
@@ -2785,7 +2785,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_array(zend_ar
 	zend_function *fbc;
 	zend_class_entry *called_scope;
 	zend_object *object;
-	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION;
+	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_DYNAMIC;
 
 	if (zend_hash_num_elements(function) == 2) {
 		zval *obj;

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3415,7 +3415,7 @@ ZEND_VM_HANDLER(118, ZEND_INIT_USER_CALL, CONST, CONST|TMPVAR|CV, NUM)
 	zend_class_entry *called_scope;
 	zend_object *object;
 	zend_execute_data *call;
-	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION;
+	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_DYNAMIC;
 
 	SAVE_OPLINE();
 	function_name = GET_OP2_ZVAL_PTR(BP_VAR_R);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5469,7 +5469,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_USER_CALL_SPEC_CONST_CONS
 	zend_class_entry *called_scope;
 	zend_object *object;
 	zend_execute_data *call;
-	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION;
+	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_DYNAMIC;
 
 	SAVE_OPLINE();
 	function_name = EX_CONSTANT(opline->op2);
@@ -9227,7 +9227,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_USER_CALL_SPEC_CONST_CV_H
 	zend_class_entry *called_scope;
 	zend_object *object;
 	zend_execute_data *call;
-	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION;
+	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_DYNAMIC;
 
 	SAVE_OPLINE();
 	function_name = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
@@ -11067,7 +11067,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_USER_CALL_SPEC_CONST_TMPV
 	zend_class_entry *called_scope;
 	zend_object *object;
 	zend_execute_data *call;
-	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION;
+	uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_DYNAMIC;
 
 	SAVE_OPLINE();
 	function_name = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2097,8 +2097,13 @@ PHP_FUNCTION(mb_parse_str)
 		detected = _php_mb_encoding_handler_ex(&info, track_vars_array, encstr);
 	} else {
 		zval tmp;
-		zend_array *symbol_table = zend_rebuild_symbol_table();
+		zend_array *symbol_table;
+		if (zend_forbid_dynamic_call("mb_parse_str() with a single argument") == FAILURE) {
+			efree(encstr);
+			return;
+		}
 
+		symbol_table = zend_rebuild_symbol_table();
 		ZVAL_ARR(&tmp, symbol_table);
 		detected = _php_mb_encoding_handler_ex(&info, &tmp, encstr);
 	}

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1805,6 +1805,10 @@ PHP_FUNCTION(extract)
 		}
 	}
 
+	if (zend_forbid_dynamic_call("extract()") == FAILURE) {
+		return;
+	}
+
 	symbol_table = zend_rebuild_symbol_table();
 #if 0
 	if (!symbol_table) {
@@ -1966,8 +1970,11 @@ PHP_FUNCTION(compact)
 		return;
 	}
 
-	symbol_table = zend_rebuild_symbol_table();
+	if (zend_forbid_dynamic_call("compact()") == FAILURE) {
+		return;
+	}
 
+	symbol_table = zend_rebuild_symbol_table();
 	if (UNEXPECTED(symbol_table == NULL)) {
 		return;
 	}

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4605,8 +4605,13 @@ PHP_FUNCTION(parse_str)
 
 	if (arrayArg == NULL) {
 		zval tmp;
-		zend_array *symbol_table = zend_rebuild_symbol_table();
+		zend_array *symbol_table;
+		if (zend_forbid_dynamic_call("parse_str() with a single argument") == FAILURE) {
+			efree(res);
+			return;
+		}
 
+		symbol_table = zend_rebuild_symbol_table();
 		ZVAL_ARR(&tmp, symbol_table);
 		sapi_module.treat_data(PARSE_STRING, res, &tmp);
 	} else 	{


### PR DESCRIPTION
Currently we allow performing dynamic calls to functions that introspect the parent stack frame. Apart from this being a source of segmentation faults previously and having wildly varying behavior between PHP5, PHP7 (namespaced and non-namespaced) and HHVM (for examples see bug #71220), this also causes issues for the data-flow optimizer, which is not able to detect these calls and abort optimization (see the dynamic_call_007.phpt test for a simple example of misoptimization).

Solve this by forbidding these dynamic calls.

Affects:
 * extract()
 * compact()
 * get_defined_vars()
 * parse_str() with one arg
 * mb_parse_str() with one arg
 * func_get_args()
 * func_get_arg()
 * func_num_args()