### PR TITLE
Remove needless zeroing of anonymously mmap'd memory

### DIFF
--- a/sapi/fpm/fpm/fpm_shm.c
+++ b/sapi/fpm/fpm/fpm_shm.c
@@ -35,7 +35,6 @@ void *fpm_shm_alloc(size_t size) /* {{{ */
 		return NULL;
 	}
 
-	memset(mem, 0, size);
 	fpm_shm_size += size;
 	return mem;
 }

--- a/sapi/litespeed/lsapilib.c
+++ b/sapi/litespeed/lsapilib.c
@@ -2639,7 +2639,6 @@ static int lsapi_init_children_status()
         perror( "Anonymous mmap() failed" );
         return -1;
     }
-    memset( pBuf, 0, size );
     g_prefork_server->m_pChildrenStatus = (lsapi_child_status *)pBuf;
     g_prefork_server->m_pChildrenStatusCur = (lsapi_child_status *)pBuf;
     g_prefork_server->m_pChildrenStatusEnd = (lsapi_child_status *)pBuf + size / sizeof( lsapi_child_status );


### PR DESCRIPTION
All existing systems zero anonymously mmapped memory, and if I
understand correctly POSIX will be specifying this soon. Many projects
already rely on it, so no reasonable system would return memory of
unspecified value.