### PR TITLE
Fix bug #47517 (https://bugs.php.net/bug.php?id=47517)

### DIFF
--- a/win32/build/default.manifest
+++ b/win32/build/default.manifest
@@ -1,6 +1,13 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
-   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
+   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+        <security>
+            <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+                <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
        <application> 
            <!-- Windows Vista -->
            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 


### PR DESCRIPTION
Add a \<requestedExecutionLevel\> to the manifest so Windows doesn't use file and registry virtualization for backwards compatibility with pre-Vista versions.