### PR TITLE
Reduce build time on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,11 @@ notifications:
       on_success: change
       on_failure: always
 
-cache: 
-    - apt
-
+cache:
+  apt: true
+  ccache: true
+  directories:
+  - "config.cache"
 env:
     global:
       - MYSQL_TEST_HOST=127.0.0.1
@@ -45,15 +47,23 @@ env:
       - ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
 
 before_script:
-    # Compile PHP
-    - ./travis/compile.sh
-    # Setup Extensions 
-    - . ./travis/ext/mysql/setup.sh
-    - . ./travis/ext/mysqli/setup.sh
-    - . ./travis/ext/pdo_mysql/setup.sh
-    - . ./travis/ext/pgsql/setup.sh
-    - . ./travis/ext/pdo_pgsql/setup.sh
+- ccache --version
+- ccache -z
+- export USE_CCACHE=1
+- export CACHE_LOGFILE=/tmp/ccache.cache
+# Compile PHP
+- ./travis/compile.sh
+# Setup Extensions 
+- . ./travis/ext/mysql/setup.sh
+- . ./travis/ext/mysqli/setup.sh
+- . ./travis/ext/pdo_mysql/setup.sh
+- . ./travis/ext/pgsql/setup.sh
+- . ./travis/ext/pdo_pgsql/setup.sh
 
 # Run PHPs run-tests.php 
 script:
-    - ./sapi/cli/php run-tests.php -p `pwd`/sapi/cli/php $(if [ $ENABLE_DEBUG == 1 ]; then echo "-d opcache.enable_cli=1 -d zend_extension=`pwd`/modules/opcache.so"; fi) -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --offline --show-diff --set-timeout 120
+- ./sapi/cli/php run-tests.php -p `pwd`/sapi/cli/php $(if [ $ENABLE_DEBUG == 1 ]; then echo "-d opcache.enable_cli=1 -d zend_extension=`pwd`/modules/opcache.so"; fi) -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --offline --show-diff --set-timeout 120
+
+after_success:
+- ccache -s
+- cat /tmp/ccache.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,12 +48,12 @@ env:
 
 before_script:
 - ccache --version
-- ccache -z
+- ccache --zero-stats
 - export USE_CCACHE=1
 - export CACHE_LOGFILE=/tmp/ccache.cache
 # Compile PHP
 - ./travis/compile.sh
-# Setup Extensions 
+# Setup Extensions
 - . ./travis/ext/mysql/setup.sh
 - . ./travis/ext/mysqli/setup.sh
 - . ./travis/ext/pdo_mysql/setup.sh
@@ -65,5 +65,4 @@ script:
 - ./sapi/cli/php run-tests.php -p `pwd`/sapi/cli/php $(if [ $ENABLE_DEBUG == 1 ]; then echo "-d opcache.enable_cli=1 -d zend_extension=`pwd`/modules/opcache.so"; fi) -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --offline --show-diff --set-timeout 120
 
 after_success:
-- ccache -s
-- cat /tmp/ccache.cache
+- ccache --show-stats

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ cache:
   apt: true
   ccache: true
   directories:
-  - "config.cache"
+  - ~/.ccache
 env:
     global:
       - MYSQL_TEST_HOST=127.0.0.1
@@ -50,7 +50,6 @@ before_script:
 - ccache --version
 - ccache --zero-stats
 - export USE_CCACHE=1
-- export CACHE_LOGFILE=/tmp/ccache.cache
 # Compile PHP
 - ./travis/compile.sh
 # Setup Extensions

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -14,7 +14,9 @@ else
 fi
 
 if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
-  for i in $PHP_READLINE /usr/local /usr; do
+  dnl /opt/local     macports prefix
+  dnl /usr/local/opt homebrew link prefix
+  for i in $PHP_READLINE /opt/local /usr/local/opt /usr/local /usr; do
     test -f $i/include/readline/readline.h && READLINE_DIR=$i && break
   done
 
@@ -71,7 +73,7 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
 
 elif test "$PHP_LIBEDIT" != "no"; then
 
-  for i in $PHP_LIBEDIT /usr/local /usr; do
+  for i in $PHP_LIBEDIT /opt/local /usr/local/opt /usr/local /usr; do
     test -f $i/include/editline/readline.h && LIBEDIT_DIR=$i && break
   done
 

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -9,8 +9,9 @@ if [[ "$ENABLE_DEBUG" == 1 ]]; then
 else
 	DEBUG="";
 fi
-./buildconf --force
+./buildconf
 ./configure \
+--config-cache \
 --prefix=$HOME"/php-install" \
 --quiet \
 $DEBUG \


### PR DESCRIPTION
This PR setup ccache and config.cache on Travis CI
### Summary
- The reason of why config.cache is enabled is, the system configurations are actually the same for each build, `-C` option to enable config.cache can reduce the running time of ./configure script.
- ccache is enabled for compiling object code.

This PR may reduce about 2-3 minutes for each build.
