### PR TITLE
Make static binding consistent and a little faster

### DIFF
--- a/Zend/tests/bug64979.phpt
+++ b/Zend/tests/bug64979.phpt
@@ -27,4 +27,4 @@ foreach (array($gen1, $gen2, $gen3) as $gen) {
 --EXPECT--
 int(1)
 int(2)
-int(1)
+int(3)

--- a/Zend/tests/call_user_func_003.phpt
+++ b/Zend/tests/call_user_func_003.phpt
@@ -25,7 +25,7 @@ object(Closure)#%d (1) {
   [%u|b%"static"]=>
   array(1) {
     [%u|b%"instance"]=>
-    object(Closure)#%d (0) {
+    &object(Closure)#%d (0) {
     }
   }
 }

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -2076,7 +2076,7 @@ ZEND_FUNCTION(create_function)
 
 	if (retval==SUCCESS) {
 		zend_op_array *func;
-		HashTable *static_variables;
+		void *static_variables;
 
 		func = zend_hash_str_find_ptr(EG(function_table), LAMBDA_TEMP_FUNCNAME, sizeof(LAMBDA_TEMP_FUNCNAME)-1);
 		if (!func) {

--- a/Zend/zend_closures.h
+++ b/Zend/zend_closures.h
@@ -25,7 +25,7 @@
 BEGIN_EXTERN_C()
 
 void zend_register_closure_ce(void);
-void zend_closure_bind_var(zval *closure_zv, zend_string *var_name, zval *var);
+void zend_closure_bind_var(zval *closure_zv, uint32_t num, zval *var);
 
 extern ZEND_API zend_class_entry *zend_ce_closure;
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -314,6 +314,11 @@ typedef struct _zend_class_constant {
 	zend_class_entry *ce;
 } zend_class_constant;
 
+typedef struct _zend_static_var {
+	zval val;
+	zend_string *name;
+} zend_static_var;
+
 /* arg_info for internal functions */
 typedef struct _zend_internal_arg_info {
 	const char *name;
@@ -361,8 +366,6 @@ struct _zend_op_array {
 	zend_arg_info *arg_info;
 	/* END of common elements */
 
-	uint32_t *refcount;
-
 	uint32_t this_var;
 
 	uint32_t last;
@@ -378,7 +381,12 @@ struct _zend_op_array {
 	zend_try_catch_element *try_catch_array;
 
 	/* static variables support */
-	HashTable *static_variables;
+	struct {
+		uint32_t count;
+		zend_static_var vars[1];
+	} *static_variables;
+
+	uint32_t *refcount;
 
 	zend_string *filename;
 	uint32_t line_start;

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -455,6 +455,9 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_OBJ_INC_APPLY_COUNT_P(zv) Z_OBJ_INC_APPLY_COUNT(*(zv))
 #define Z_OBJ_DEC_APPLY_COUNT_P(zv) Z_OBJ_DEC_APPLY_COUNT(*(zv))
 
+/* reference flags (static_variables, reference) */
+#define IS_REF_ARENA_ALLOCATED	(1<<0)
+
 /* All data types < IS_STRING have their constructor/destructors skipped */
 #define Z_CONSTANT(zval)			((Z_TYPE_FLAGS(zval) & IS_TYPE_CONSTANT) != 0)
 #define Z_CONSTANT_P(zval_p)		Z_CONSTANT(*(zval_p))

--- a/Zend/zend_vm_opcodes.c
+++ b/Zend/zend_vm_opcodes.c
@@ -392,7 +392,7 @@ static uint32_t zend_vm_opcodes_flags[184] = {
 	0x00027307,
 	0x00000373,
 	0x00100101,
-	0x00100301,
+	0x00100101,
 };
 
 ZEND_API const char* zend_get_opcode_name(zend_uchar opcode) {

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -853,7 +853,7 @@ int zend_optimize_script(zend_script *script, zend_long optimization_level, zend
 			} else if (op_array->type == ZEND_USER_FUNCTION) {
 				zend_op_array *orig_op_array;
 				if ((orig_op_array = zend_hash_find_ptr(&op_array->scope->function_table, name)) != NULL) {
-					HashTable *ht = op_array->static_variables;
+					void *ht = op_array->static_variables;
 					*op_array = *orig_op_array;
 					op_array->static_variables = ht;
 				}
@@ -938,7 +938,7 @@ int zend_optimize_script(zend_script *script, zend_long optimization_level, zend
 				} else if (op_array->type == ZEND_USER_FUNCTION) {
 					zend_op_array *orig_op_array;
 					if ((orig_op_array = zend_hash_find_ptr(&op_array->scope->function_table, name)) != NULL) {
-						HashTable *ht = op_array->static_variables;
+						void *ht = op_array->static_variables;
 						*op_array = *orig_op_array;
 						op_array->static_variables = ht;
 					}

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -147,6 +147,7 @@ typedef struct _zend_persistent_script {
 	size_t         size;                   /* size of used shared memory */
 	void          *arena_mem;              /* part that should be copied into process */
 	size_t         arena_size;
+	size_t         arena_offsets_size;     /* count of offsets into arena memory which need to be added process arena offset after copying */
 
 	/* All entries that shouldn't be counted in the ADLER32
 	 * checksum must be declared in this struct
@@ -237,6 +238,7 @@ typedef struct _zend_accel_globals {
 	/* preallocated shared-memory block to save current script */
 	void                   *mem;
 	void                   *arena_mem;
+	size_t                 *arena_offsets;
 	zend_persistent_script *current_persistent_script;
 	/* cache to save hash lookup on the same INCLUDE opcode */
 	const zend_op          *cache_opline;

--- a/ext/opcache/zend_shared_alloc.h
+++ b/ext/opcache/zend_shared_alloc.h
@@ -127,6 +127,8 @@ void *zend_shared_alloc(size_t size);
 /* copy into shared memory */
 void *_zend_shared_memdup(void *p, size_t size, zend_bool free_source);
 int  zend_shared_memdup_size(void *p, size_t size);
+/* copy into shared memory to be copied into non-shared process memory */
+void *zend_nonshared_memdup(void **source_ptr, size_t size);
 
 int zend_accel_in_shm(void *ptr);
 

--- a/ext/reflection/tests/009.phpt
+++ b/ext/reflection/tests/009.phpt
@@ -81,7 +81,7 @@ hoho
 --getStaticVariables--
 array(1) {
   ["var"]=>
-  int(1)
+  &int(1)
 }
 --invoke--
 NULL

--- a/ext/reflection/tests/025.phpt
+++ b/ext/reflection/tests/025.phpt
@@ -83,7 +83,7 @@ hoho
 --getStaticVariables--
 array(1) {
   ["var"]=>
-  int(1)
+  &int(1)
 }
 --invoke--
 NULL

--- a/ext/reflection/tests/ReflectionFunction_001.phpt
+++ b/ext/reflection/tests/ReflectionFunction_001.phpt
@@ -45,11 +45,11 @@ int(6)
 int(11)
 array(3) {
   ["c"]=>
-  NULL
+  &NULL
   ["a"]=>
-  int(1)
+  &int(1)
   ["b"]=>
-  string(5) "hello"
+  &string(5) "hello"
 }
 string(3) "bar"
 bool(false)

--- a/ext/reflection/tests/ReflectionMethod_getStaticVariables_basic.phpt
+++ b/ext/reflection/tests/ReflectionMethod_getStaticVariables_basic.phpt
@@ -41,17 +41,17 @@ var_dump($methodInfo->getStaticVariables());
 Public method:
 array(3) {
   ["c"]=>
-  NULL
+  &NULL
   ["a"]=>
-  int(1)
+  &int(1)
   ["b"]=>
-  string(5) "hello"
+  &string(5) "hello"
 }
 
 Private method:
 array(1) {
   ["a"]=>
-  int(1)
+  &int(1)
 }
 
 Method with no static variables:

--- a/ext/reflection/tests/bug32981.phpt
+++ b/ext/reflection/tests/bug32981.phpt
@@ -28,7 +28,7 @@ array(1) {
   [0]=>
   array(1) {
     ["enabled"]=>
-    bool(true)
+    &bool(true)
   }
 }
 ===DONE===


### PR DESCRIPTION
Previously cases like

``` php
class A { function foo() { static $a = 0; print $a++; } }
(new A)->foo();
class B extends A {}
(new B)->foo();
(new A)->foo();
(new B)->foo();
```

exposed different behavior depending on whether class B was early bound (add a surrounding `if (1) { }` statement) or the first call to the foo method happens after binding.
The reference was only installed at the first BIND_STATIC opcode, causing different behavior depending on whether statics were duplicated before or after BIND_STATIC.

This patch fixes that by always creating a reference for statics in functions, right at compile time.
The semantics are now that each function (with the exception of trait functions, which are expected to be literally copy-pasted) shares its statics with all instances of it.

The case above will now print 0123 in every case instead of 0011 or 0112 depending on binding times.

Also with Closures:

``` php
function getClosure() {
    return function () { static $a = 0; print $a++; };
}
$f = getClosure();
$f();
$g = getClosure();
$f();
$g();
$f();
```

will now print 0123 instead of 0101.

This makes behavior much more consistent.

To achieve this, it was needed to move to a zval+name array (instead of HashTable) for statics (as we cannot have mutable references in an immutable array in opcache).
Hence statics need to be copied directly into process memory upon each request instead of residing in shared memory. (That also removes the need for some run-time duplications.)
To support that, the patch adds a way to relocate pointers inside copied memory and arena allocates the copied parts.

Additionally, the better locality (statics now are typically closer to the op_array - side effect of arena allocation), one less fetch inside ZEND_BIND_STATIC (hello stalling cycles waiting for memory...) and much faster Closure binding account for (up to) 0.3% run-time improvement on real world applications (typical modern applications are relatively heavy on Closures nowadays).
