### PR TITLE
Fix 72122 - don't use EH_THROW for calls to getIterator

### DIFF
--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -481,7 +481,9 @@ static void spl_recursive_it_it_construct(INTERNAL_FUNCTION_PARAMETERS, zend_cla
 			if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "o|lzl", &iterator, &flags, &user_caching_it_flags, &mode) == SUCCESS) {
 				if (instanceof_function(Z_OBJCE_P(iterator), zend_ce_aggregate TSRMLS_CC)) {
 					zval *aggregate = iterator;
+					zend_restore_error_handling(&error_handling TSRMLS_CC);
 					zend_call_method_with_0_params(&aggregate, Z_OBJCE_P(aggregate), &Z_OBJCE_P(aggregate)->iterator_funcs.zf_new_iterator, "getiterator", &iterator);
+					zend_replace_error_handling(EH_THROW, spl_ce_InvalidArgumentException, &error_handling TSRMLS_CC);
 					inc_refcount = 0;
 				}
 
@@ -511,7 +513,9 @@ static void spl_recursive_it_it_construct(INTERNAL_FUNCTION_PARAMETERS, zend_cla
 			if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "o|ll", &iterator, &mode, &flags) == SUCCESS) {
 				if (instanceof_function(Z_OBJCE_P(iterator), zend_ce_aggregate TSRMLS_CC)) {
 					zval *aggregate = iterator;
+					zend_restore_error_handling(&error_handling TSRMLS_CC);
 					zend_call_method_with_0_params(&aggregate, Z_OBJCE_P(aggregate), &Z_OBJCE_P(aggregate)->iterator_funcs.zf_new_iterator, "getiterator", &iterator);
+					zend_replace_error_handling(EH_THROW, spl_ce_InvalidArgumentException, &error_handling TSRMLS_CC);
 					inc_refcount = 0;
 				}
 			} else {
@@ -1514,7 +1518,9 @@ static spl_dual_it_object* spl_dual_it_construct(INTERNAL_FUNCTION_PARAMETERS, z
 					ce = *pce_cast;
 				}
 				if (instanceof_function(ce, zend_ce_aggregate TSRMLS_CC)) {
+					zend_restore_error_handling(&error_handling TSRMLS_CC);
 					zend_call_method_with_0_params(&zobject, ce, &ce->iterator_funcs.zf_new_iterator, "getiterator", &retval);
+					zend_replace_error_handling(EH_THROW, spl_ce_InvalidArgumentException, &error_handling TSRMLS_CC);
 					if (EG(exception)) {
 						if (retval) {
 							zval_ptr_dtor(&retval);

--- a/ext/spl/tests/bug72122.phpt
+++ b/ext/spl/tests/bug72122.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #72122 (IteratorIterator breaks '@' error suppression)
+--FILE--
+<?php
+class CustomIterator implements IteratorAggregate {
+	public function getIterator() {
+		@unlink('/missing/file.txt');
+		return new ArrayIterator(array('item'));
+	}
+}
+
+$obj = new CustomIterator;
+$iterator = new IteratorIterator($obj);
+echo get_class($iterator);
+?>
+--EXPECT--
+IteratorIterator


### PR DESCRIPTION
Looks like this has already undergone a larger refactor for PHP 7: https://github.com/php/php-src/commit/122d759618a42bff105971b923fbbb5be02e34b9.

Disclaimer: this is the first time I’ve dipped into PHP internals. Feel free to close this without comment if I’m way off the mark :)