### PR TITLE
Fix the case when an error or message occurs at BEGIN / COMMIT / ROLL…

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -173,6 +173,8 @@ static int pdo_dblib_transaction_cmd(const char *cmd, pdo_dbh_t *dbh TSRMLS_DC)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
 	RETCODE ret;
+
+	dbsetuserdata(H->link, (BYTE*)&H->err);
 	
 	if (FAIL == dbcmd(H->link, cmd)) {
 		return 0;


### PR DESCRIPTION
…BACK

Error causes segfault

At least with ROLLBACK, it is possible to have an error message
raised by the backend:
"
Server: Msg 3903, Level 16, State 1, Line 1
The ROLLBACK TRANSACTION request has no corresponding BEGIN TRANSACTION.
"
When this occurs, since the userdata is not set, the calls to
getuserdata() should return NULL.
Unfortunately, if an error was raised for a statement *before* the
ROLLBACK, the userdata will not be NULL because it was previously set ( and not reset..).
But since the data has already been freed, we will have a double free
error and a segfault.
This typically happens with erroneous code like this:
$pdo->beginTransaction();
$pdo->query('select 1 from table_which_does_not_exists');
$pdo->rollBack();
$pdo->rollBack(); // rollback raises an error
                  // stale userdata will be used => segfault