### PR TITLE
Fix for bug 62159 (support larger port numbers in URL).

### DIFF
--- a/ext/standard/tests/url/bug62159.phpt
+++ b/ext/standard/tests/url/bug62159.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #62159 (All ports greater than 65535 in parse_url)
+--FILE--
+<?php
+$url = 'ctpp://ericsson:78325/?carrier=31003&address=2125551212';
+$parsedURL = parse_url($url);
+var_dump($parsedURL);
+--EXPECT--
+array(5) {
+  ["scheme"]=>
+  string(4) "ctpp"
+  ["host"]=>
+  string(8) "ericsson"
+  ["port"]=>
+  int(78325)
+  ["path"]=>
+  string(1) "/"
+  ["query"]=>
+  string(32) "carrier=31003&address=2125551212"
+}

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -190,8 +190,8 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 			memcpy(port_buf, p, (pp - p));
 			port_buf[pp - p] = '\0';
 			port = strtol(port_buf, NULL, 10);
-			if (port > 0 && port <= 65535) {
-				ret->port = (unsigned short) port;
+			if (port > 0 && port <= 4294967295) {
+				ret->port = (uint32_t) port;
 				if (*s == '/' && *(s + 1) == '/') { /* relative-scheme URL */
 				    s += 2;
 				}
@@ -283,8 +283,8 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 				memcpy(port_buf, p, (e - p));
 				port_buf[e - p] = '\0';
 				port = strtol(port_buf, NULL, 10);
-				if (port > 0 && port <= 65535) {
-					ret->port = (unsigned short)port;
+				if (port > 0 && port <= 4294967295) {
+					ret->port = (uint32_t) port;
 				} else {
 					STR_FREE(ret->scheme);
 					STR_FREE(ret->user);

--- a/ext/standard/url.h
+++ b/ext/standard/url.h
@@ -25,7 +25,7 @@ typedef struct php_url {
 	char *user;
 	char *pass;
 	char *host;
-	unsigned short port;
+	uint32_t port;
 	char *path;
 	char *query;
 	char *fragment;


### PR DESCRIPTION
Changes "port" in php_url struct from an unsigned short to a uin32_t so value can be stored. Given how the field is used this appears to be safe to change.

https://bugs.php.net/bug.php?id=62159
