### PR TITLE
Fix bug #72221 (segfault, past-the-end access)

### DIFF
--- a/Zend/tests/bug72221.phpt
+++ b/Zend/tests/bug72221.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #72221 (Segmentation fault in stream_get_line / zend_memnstr_ex)
+--FILE--
+<?php
+$fp = fopen("php://memory", "r+");
+fwrite($fp, str_repeat("baad", 1024*1024));
+rewind($fp);
+stream_get_line($fp, 1024*1024*2, "aaaa");
+echo "Done\n";
+--EXPECT--
+Done

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2965,6 +2965,9 @@ ZEND_API const char* ZEND_FASTCALL zend_memnstr_ex(const char *haystack, const c
 		if (i == needle_len) {
 			return p;
 		}
+		if (UNEXPECTED(p == end)) {
+			return NULL;
+		}
 		p += td[(unsigned char)(p[needle_len])];
 	}
 


### PR DESCRIPTION
There's a past-the-end access in `zend_memnstr_ex`. This may cause segfaults, as seen in bug #72221.