### PR TITLE
Fix #72152: base64_decode should reject NUL in strict mode

### DIFF
--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -150,7 +150,8 @@ PHPAPI unsigned char *php_base64_decode_ex(const unsigned char *str, int length,
 	result = (unsigned char *)safe_emalloc(length, 1, 1);
 
 	/* run through the whole string, converting as we go */
-	while ((ch = *current++) != '\0' && length-- > 0) {
+	while (length-- > 0) {
+		ch = *current++;
 		if (ch == base64_pad) {
 			if (*current != '=' && ((i % 4) == 1 || (strict && length > 0))) {
 				if ((i % 4) != 1) {


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=72152

The documentation for `base64_decode` parameter `$strict` says, "Returns FALSE if input contains character from outside the base64 alphabet." This should apply to NUL bytes as well.