### PR TITLE
Fix various base64_decode bugs.

### DIFF
--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -145,12 +145,13 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 	/* run through the whole string, converting as we go */
 	while (length-- > 0 && (ch = *current++) != '\0') {
 		if (ch == base64_pad) {
+			/* fail if the padding character is second in a group (like V===) */
+			/* FIXME: why do we still allow invalid padding in other places in the middle of the string? */
 			if (i % 4 == 1) {
-				if (length == 0 || *current != '=') {
-					zend_string_free(result);
-					return NULL;
-				}
-			} else if (length > 0 && *current != '=' && strict) {
+				zend_string_free(result);
+				return NULL;
+			}
+			if (length > 0 && *current != '=' && strict) {
 				while (--length > 0 && isspace(*++current)) {
 					continue;
 				}

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -143,7 +143,12 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 	result = zend_string_alloc(length, 0);
 
 	/* run through the whole string, converting as we go */
-	while (length-- > 0 && (ch = *current++) != '\0') {
+	while (length-- > 0) {
+		ch = *current++;
+		/* stop on null byte in non-strict mode (FIXME: is this really desired?) */
+		if (ch == 0 && !strict) {
+			break;
+		}
 		if (ch == base64_pad) {
 			/* fail if the padding character is second in a group (like V===) */
 			/* FIXME: why do we still allow invalid padding in other places in the middle of the string? */

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -136,8 +136,7 @@ PHPAPI zend_string *php_base64_decode(const unsigned char *str, size_t length) /
 PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length, zend_bool strict) /* {{{ */
 {
 	const unsigned char *current = str;
-	int ch, i = 0, j = 0, k;
-	/* this sucks for threaded environments */
+	int ch, i = 0, j = 0;
 	zend_string *result;
 
 	result = zend_string_alloc(length, 0);
@@ -197,19 +196,6 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 		i++;
 	}
 
-	k = j;
-	/* mop things up if we ended on a boundary */
-	if (ch == base64_pad) {
-		switch(i % 4) {
-		case 1:
-			zend_string_free(result);
-			return NULL;
-		case 2:
-			k++;
-		case 3:
-			ZSTR_VAL(result)[k] = 0;
-		}
-	}
 	ZSTR_LEN(result) = j;
 	ZSTR_VAL(result)[ZSTR_LEN(result)] = '\0';
 

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -157,8 +157,9 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 				return NULL;
 			}
 			if (length > 0 && *current != '=' && strict) {
-				while (--length > 0 && isspace(*++current)) {
-					continue;
+				while (length > 0 && isspace(*current)) {
+					current++;
+					length--;
 				}
 				if (length == 0 || *current == '\0') {
 					continue;

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -143,16 +143,19 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 	result = zend_string_alloc(length, 0);
 
 	/* run through the whole string, converting as we go */
-	while ((ch = *current++) != '\0' && length-- > 0) {
+	while (length-- > 0 && (ch = *current++) != '\0') {
 		if (ch == base64_pad) {
-			if (*current != '=' && ((i % 4) == 1 || (strict && length > 0))) {
-				if ((i % 4) != 1) {
-					while (isspace(*(++current))) {
-						continue;
-					}
-					if (*current == '\0') {
-						continue;
-					}
+			if (i % 4 == 1) {
+				if (length == 0 || *current != '=') {
+					zend_string_free(result);
+					return NULL;
+				}
+			} else if (length > 0 && *current != '=' && strict) {
+				while (--length > 0 && isspace(*++current)) {
+					continue;
+				}
+				if (length == 0 || *current == '\0') {
+					continue;
 				}
 				zend_string_free(result);
 				return NULL;

--- a/ext/standard/tests/strings/bug72152.phpt
+++ b/ext/standard/tests/strings/bug72152.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #72152 (base64_decode $strict fails to detect null byte)
+--FILE--
+<?php
+var_dump(base64_decode("\x00", true));
+var_dump(base64_decode("\x00VVVV", true));
+var_dump(base64_decode("VVVV\x00", true));
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)

--- a/ext/standard/tests/strings/bug72263.phpt
+++ b/ext/standard/tests/strings/bug72263.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #72263 (base64_decode skips a character after padding in strict mode)
+--FILE--
+<?php
+var_dump(base64_decode("*", true));
+var_dump(base64_decode("=*", true));
+var_dump(base64_decode("VVV=", true));
+var_dump(base64_decode("VVV=*", true));
+--EXPECT--
+bool(false)
+bool(false)
+string(2) "UU"
+bool(false)

--- a/ext/standard/tests/strings/bug72264.phpt
+++ b/ext/standard/tests/strings/bug72264.phpt
@@ -1,0 +1,7 @@
+--TEST--
+Bug #72264 (base64_decode $strict fails with whitespace between padding)
+--FILE--
+<?php
+var_dump(base64_decode("VV= =", true));
+--EXPECT--
+string(1) "U"


### PR DESCRIPTION
Fix base64_decode bugs 72264, 72263, 72152, with tests.

This is for PHP-7.0, because the patches don't cleanly apply to PHP-5.6 (which uses char* instead of zend_string).