### PR TITLE
add php_create_socket/php_destroy_socket PHP_SOCKETS_API

### DIFF
--- a/ext/sockets/php_sockets.h
+++ b/ext/sockets/php_sockets.h
@@ -70,6 +70,9 @@ struct	sockaddr_un {
 #endif
 
 PHP_SOCKETS_API int php_sockets_le_socket(void);
+PHP_SOCKETS_API php_socket *php_create_socket(void);
+PHP_SOCKETS_API void php_destroy_socket(zend_rsrc_list_entry *rsrc TSRMLS_DC);
+
 
 #define php_sockets_le_socket_name "Socket"
 

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -384,7 +384,7 @@ PHP_SOCKETS_API int php_sockets_le_socket(void) /* {{{ */
 
 /* allocating function to make programming errors due to uninitialized fields
  * less likely */
-static php_socket *php_create_socket(void) /* {{{ */
+PHP_SOCKETS_API php_socket *php_create_socket(void) /* {{{ */
 {
 	php_socket *php_sock = emalloc(sizeof *php_sock);
 
@@ -398,7 +398,7 @@ static php_socket *php_create_socket(void) /* {{{ */
 }
 /* }}} */
 
-static void php_destroy_socket(zend_rsrc_list_entry *rsrc TSRMLS_DC) /* {{{ */
+PHP_SOCKETS_API void php_destroy_socket(zend_rsrc_list_entry *rsrc TSRMLS_DC) /* {{{ */
 {
 	php_socket *php_sock = rsrc->ptr;
 


### PR DESCRIPTION
add php_create_socket/php_destroy_socket PHP_SOCKETS_API to abel to create socket ressource in other extension.