### PR TITLE
Give zend_vm_gen.php some TLC

### DIFF
--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -19,7 +19,7 @@
 	 $Id$
 */
 
-$header_text = <<< DATA
+const HEADER_TEXT = <<< DATA
 /*
    +----------------------------------------------------------------------+
    | Zend Engine                                                          |
@@ -50,9 +50,9 @@ DATA;
 
 error_reporting(E_ALL);
 
-define("ZEND_VM_KIND_CALL",   1);
-define("ZEND_VM_KIND_SWITCH", 2);
-define("ZEND_VM_KIND_GOTO",   3);
+const ZEND_VM_KIND_CALL   = 1;
+const ZEND_VM_KIND_SWITCH = 2;
+const ZEND_VM_KIND_GOTO   = 3;
 
 $vm_op_flags = array(
 	"ZEND_VM_OP_SPEC"         => 1<<0,
@@ -2136,7 +2136,7 @@ function gen_vm($def, $skel) {
 	$f = fopen(__DIR__ . "/zend_vm_opcodes.h", "w+") or die("ERROR: Cannot create zend_vm_opcodes.h\n");
 
 	// Insert header
-	out($f, $GLOBALS['header_text']);
+	out($f, HEADER_TEXT);
 	fputs($f, "#ifndef ZEND_VM_OPCODES_H\n#define ZEND_VM_OPCODES_H\n\n");
 	fputs($f, "#define ZEND_VM_SPEC\t\t" . ZEND_VM_SPEC . "\n");
 	fputs($f, "#define ZEND_VM_LINES\t\t" . ZEND_VM_LINES . "\n");
@@ -2176,7 +2176,7 @@ function gen_vm($def, $skel) {
 	$f = fopen(__DIR__ . "/zend_vm_opcodes.c", "w+") or die("ERROR: Cannot create zend_vm_opcodes.c\n");
 
 	// Insert header
-	out($f, $GLOBALS['header_text']);
+	out($f, HEADER_TEXT);
 	fputs($f,"#include <stdio.h>\n");
 	fputs($f,"#include <zend.h>\n\n");
 	
@@ -2208,7 +2208,7 @@ function gen_vm($def, $skel) {
 	$executor_file = realpath(__DIR__ . "/zend_vm_execute.h");
 
 	// Insert header
-	out($f, $GLOBALS['header_text']);
+	out($f, HEADER_TEXT);
 
 	out($f, "#ifdef ZEND_WIN32\n");
 	// Suppress free_op1 warnings on Windows
@@ -2497,7 +2497,7 @@ function usage() {
 }
 
 // Parse arguments
-for ($i = 1;  $i < $argc; $i++) {
+for ($i = 1; $i < $argc; $i++) {
 	if (strpos($argv[$i],"--with-vm-kind=") === 0) {
 		$kind = substr($argv[$i], strlen("--with-vm-kind="));
 		switch ($kind) {
@@ -2516,7 +2516,7 @@ for ($i = 1;  $i < $argc; $i++) {
 				die();
 		}
 	} else if ($argv[$i] == "--without-specializer") {
-	  // Disabling specialization
+		// Disabling specialization
 		define("ZEND_VM_SPEC", 0);
 	} else if ($argv[$i] == "--with-lines") {
 		// Enabling debugging using original zend_vm_def.h
@@ -2533,18 +2533,16 @@ for ($i = 1;  $i < $argc; $i++) {
 
 // Using defaults
 if (!defined("ZEND_VM_KIND")) {
-  // Using CALL threading by default
+	// Using CALL threading by default
 	define("ZEND_VM_KIND", ZEND_VM_KIND_CALL);
 }
 if (!defined("ZEND_VM_SPEC")) {
-  // Using specialized executor by default
+	// Using specialized executor by default
 	define("ZEND_VM_SPEC", 1);
 }
 if (!defined("ZEND_VM_LINES")) {
-  // Disabling #line directives
+	// Disabling #line directives
 	define("ZEND_VM_LINES", 0);
 }
 
 gen_vm(__DIR__ . "/zend_vm_def.h", __DIR__ . "/zend_vm_execute.skl");
-
-?>


### PR DESCRIPTION
I'm trying to wrap my head around the VM and opcodes and started studying the generator. I decided I might as well give it a little TLC; I removed most references to `$GLOBALS` and cleaned up a few other places. If you guys are OK with this kind of PR, I can commit a few more updates in a separate PR. :)