### PR TITLE
Fix correctness issues with type narrowing

### DIFF
--- a/Zend/tests/bug72335.phpt
+++ b/Zend/tests/bug72335.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Misoptimize due to type narrowing
+--FILE--
+<?php
+
+function test() {
+    $b = false;
+    $x = (1<<53)+1;
+    do {
+        $x = 1.0 * ($x - (1<<53));
+    } while ($b);
+    return $x;
+}
+var_dump(test());
+
+?>
+--EXPECT--
+float(1)

--- a/Zend/zend_bitset.h
+++ b/Zend/zend_bitset.h
@@ -221,7 +221,7 @@ static inline int zend_bitset_last(zend_bitset set, uint32_t len)
 #define ZEND_BITSET_FOREACH(set, len, bit) do { \
 	zend_bitset _set = (set); \
 	uint32_t _i, _len = (len); \
-	for (_i = 0; _i < len; _i++) { \
+	for (_i = 0; _i < _len; _i++) { \
 		zend_ulong _x = _set[_i]; \
 		if (_x) { \
 			(bit) = ZEND_BITSET_ELM_SIZE * 8 * _i; \


### PR DESCRIPTION
Fixes [bug #72335](https://bugs.php.net/bug.php?id=72335). I didn't find a great way to fix this. What I ended up with is starting at the assignment and trying to show that an early conversion to double produces identical results. This preserves the narrowing for mandel2...

@dstogov Can you take a look at this?