### PR TITLE
Changed error storage behavior

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -973,7 +973,7 @@ PHPAPI void php_html_puts(const char *str, size_t size)
 static ZEND_COLD void php_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args)
 {
 	char *buffer;
-	int buffer_len, display;
+	int buffer_len, display, store_only = 0;
 
 	buffer_len = (int)vspprintf(&buffer, PG(log_errors_max_len), format, args);
 
@@ -991,27 +991,6 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 		}
 	} else {
 		display = 1;
-	}
-
-	/* store the error if it has changed */
-	if (display) {
-		if (PG(last_error_message)) {
-			char *s = PG(last_error_message);
-			PG(last_error_message) = NULL;
-			free(s);
-		}
-		if (PG(last_error_file)) {
-			char *s = PG(last_error_file);
-			PG(last_error_file) = NULL;
-			free(s);
-		}
-		if (!error_filename) {
-			error_filename = "Unknown";
-		}
-		PG(last_error_type) = type;
-		PG(last_error_message) = strdup(buffer);
-		PG(last_error_file) = strdup(error_filename);
-		PG(last_error_lineno) = error_lineno;
 	}
 
 	/* according to error handling mode, suppress error, throw exception or show it */
@@ -1034,127 +1013,160 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 				/* notices are no errors and are not treated as such like E_WARNINGS */
 				break;
 			default:
-				/* throw an exception if we are in EH_THROW mode
-				 * but DO NOT overwrite a pending exception
-				 */
-				if (EG(error_handling) == EH_THROW && !EG(exception)) {
-					zend_throw_error_exception(EG(exception_class), buffer, 0, type);
+				/* throw an exception if we are in EH_THROW mode */
+				if (EG(error_handling) == EH_THROW) {
+					/* DO NOT overwrite a pending exception */
+					if (!EG(exception)) {
+						zend_throw_error_exception(EG(exception_class), buffer, 0, type);
+					}
+					goto done;
 				}
-				efree(buffer);
-				return;
+				store_only = 1;
 		}
 	}
 
-	/* display/log the error if necessary */
-	if (display && (EG(error_reporting) & type || (type & E_CORE))
-		&& (PG(log_errors) || PG(display_errors) || (!module_initialized))) {
-		char *error_type_str;
-		int syslog_type_int = LOG_NOTICE;
+	/* store the error if it has changed */
+	if (display) {
+		if (PG(last_error_message)) {
+			char *s = PG(last_error_message);
+			PG(last_error_message) = NULL;
+			free(s);
+		}
+		if (PG(last_error_file)) {
+			char *s = PG(last_error_file);
+			PG(last_error_file) = NULL;
+			free(s);
+		}
+		if (!error_filename) {
+			error_filename = "Unknown";
+		}
+		PG(last_error_type) = type;
+		PG(last_error_message) = strdup(buffer);
+		PG(last_error_file) = strdup(error_filename);
+		PG(last_error_lineno) = error_lineno;
 
-		switch (type) {
-			case E_ERROR:
-			case E_CORE_ERROR:
-			case E_COMPILE_ERROR:
-			case E_USER_ERROR:
-				error_type_str = "Fatal error";
-				syslog_type_int = LOG_ERR;
-				break;
-			case E_RECOVERABLE_ERROR:
-				error_type_str = "Catchable fatal error";
-				syslog_type_int = LOG_ERR;
-				break;
-			case E_WARNING:
-			case E_CORE_WARNING:
-			case E_COMPILE_WARNING:
-			case E_USER_WARNING:
-				error_type_str = "Warning";
-				syslog_type_int = LOG_WARNING;
-				break;
-			case E_PARSE:
-				error_type_str = "Parse error";
-				syslog_type_int = LOG_EMERG;
-				break;
-			case E_NOTICE:
-			case E_USER_NOTICE:
-				error_type_str = "Notice";
-				syslog_type_int = LOG_NOTICE;
-				break;
-			case E_STRICT:
-				error_type_str = "Strict Standards";
-				syslog_type_int = LOG_INFO;
-				break;
-			case E_DEPRECATED:
-			case E_USER_DEPRECATED:
-				error_type_str = "Deprecated";
-				syslog_type_int = LOG_INFO;
-				break;
-			default:
-				error_type_str = "Unknown error";
-				break;
+		if (store_only) {
+			goto done;
 		}
 
-		if (!module_initialized || PG(log_errors)) {
-			char *log_buffer;
-#ifdef PHP_WIN32
-			if (type == E_CORE_ERROR || type == E_CORE_WARNING) {
-				syslog(LOG_ALERT, "PHP %s: %s (%s)", error_type_str, buffer, GetCommandLine());
-			}
-#endif
-			spprintf(&log_buffer, 0, "PHP %s:  %s in %s on line %d", error_type_str, buffer, error_filename, error_lineno);
-			php_log_err_with_severity(log_buffer, syslog_type_int);
-			efree(log_buffer);
-		}
-
-		if (PG(display_errors) && ((module_initialized && !PG(during_request_startup)) || (PG(display_startup_errors)))) {
-			if (PG(xmlrpc_errors)) {
-				php_printf("<?xml version=\"1.0\"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><int>%pd</int></value></member><member><name>faultString</name><value><string>%s:%s in %s on line %d</string></value></member></struct></value></fault></methodResponse>", PG(xmlrpc_error_number), error_type_str, buffer, error_filename, error_lineno);
-			} else {
-				char *prepend_string = INI_STR("error_prepend_string");
-				char *append_string = INI_STR("error_append_string");
-
-				if (PG(html_errors)) {
-					if (type == E_ERROR || type == E_PARSE) {
-						zend_string *buf = php_escape_html_entities((unsigned char*)buffer, buffer_len, 0, ENT_COMPAT, NULL);
-						php_printf("%s<br />\n<b>%s</b>:  %s in <b>%s</b> on line <b>%d</b><br />\n%s", STR_PRINT(prepend_string), error_type_str, ZSTR_VAL(buf), error_filename, error_lineno, STR_PRINT(append_string));
-						zend_string_free(buf);
-					} else {
-						php_printf("%s<br />\n<b>%s</b>:  %s in <b>%s</b> on line <b>%d</b><br />\n%s", STR_PRINT(prepend_string), error_type_str, buffer, error_filename, error_lineno, STR_PRINT(append_string));
-					}
-				} else {
-					/* Write CLI/CGI errors to stderr if display_errors = "stderr" */
-					if ((!strcmp(sapi_module.name, "cli") || !strcmp(sapi_module.name, "cgi")) &&
-						PG(display_errors) == PHP_DISPLAY_ERRORS_STDERR
-					) {
-#ifdef PHP_WIN32
-						fprintf(stderr, "%s: %s in %s on line %u\n", error_type_str, buffer, error_filename, error_lineno);
-						fflush(stderr);
-#else
-						fprintf(stderr, "%s: %s in %s on line %u\n", error_type_str, buffer, error_filename, error_lineno);
-#endif
-					} else {
-						php_printf("%s\n%s: %s in %s on line %d\n%s", STR_PRINT(prepend_string), error_type_str, buffer, error_filename, error_lineno, STR_PRINT(append_string));
-					}
-				}
-			}
-		}
-#if ZEND_DEBUG
-		if (PG(report_zend_debug)) {
-			zend_bool trigger_break;
+		/* display/log the error if necessary */
+		if ((EG(error_reporting) & type || (type & E_CORE))
+			&& (PG(log_errors) || PG(display_errors) || (!module_initialized))) {
+			char *error_type_str;
+			int syslog_type_int = LOG_NOTICE;
 
 			switch (type) {
 				case E_ERROR:
 				case E_CORE_ERROR:
 				case E_COMPILE_ERROR:
 				case E_USER_ERROR:
-					trigger_break=1;
+					error_type_str = "Fatal error";
+					syslog_type_int = LOG_ERR;
+					break;
+				case E_RECOVERABLE_ERROR:
+					error_type_str = "Catchable fatal error";
+					syslog_type_int = LOG_ERR;
+					break;
+				case E_WARNING:
+				case E_CORE_WARNING:
+				case E_COMPILE_WARNING:
+				case E_USER_WARNING:
+					error_type_str = "Warning";
+					syslog_type_int = LOG_WARNING;
+					break;
+				case E_PARSE:
+					error_type_str = "Parse error";
+					syslog_type_int = LOG_EMERG;
+					break;
+				case E_NOTICE:
+				case E_USER_NOTICE:
+					error_type_str = "Notice";
+					syslog_type_int = LOG_NOTICE;
+					break;
+				case E_STRICT:
+					error_type_str = "Strict Standards";
+					syslog_type_int = LOG_INFO;
+					break;
+				case E_DEPRECATED:
+				case E_USER_DEPRECATED:
+					error_type_str = "Deprecated";
+					syslog_type_int = LOG_INFO;
 					break;
 				default:
-					trigger_break=0;
+					error_type_str = "Unknown error";
 					break;
 			}
-			zend_output_debug_string(trigger_break, "%s(%d) : %s - %s", error_filename, error_lineno, error_type_str, buffer);
-		}
+
+			if (!module_initialized || PG(log_errors)) {
+				char *log_buffer;
+#ifdef PHP_WIN32
+				if (type == E_CORE_ERROR || type == E_CORE_WARNING) {
+					syslog(LOG_ALERT, "PHP %s: %s (%s)", error_type_str, buffer, GetCommandLine());
+				}
 #endif
+				spprintf(&log_buffer, 0, "PHP %s:  %s in %s on line %d", error_type_str, buffer, error_filename, error_lineno);
+				php_log_err_with_severity(log_buffer, syslog_type_int);
+				efree(log_buffer);
+			}
+
+			if (PG(display_errors) && ((module_initialized && !PG(during_request_startup)) || (PG(display_startup_errors)))) {
+				if (PG(xmlrpc_errors)) {
+					php_printf("<?xml version=\"1.0\"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><int>%pd</int></value></member><member><name>faultString</name><value><string>%s:%s in %s on line %d</string></value></member></struct></value></fault></methodResponse>", PG(xmlrpc_error_number), error_type_str, buffer, error_filename, error_lineno);
+				}
+				else {
+					char *prepend_string = INI_STR("error_prepend_string");
+					char *append_string = INI_STR("error_append_string");
+
+					if (PG(html_errors)) {
+						if (type == E_ERROR || type == E_PARSE) {
+							zend_string *buf = php_escape_html_entities((unsigned char*)buffer, buffer_len, 0, ENT_COMPAT, NULL);
+							php_printf("%s<br />\n<b>%s</b>:  %s in <b>%s</b> on line <b>%d</b><br />\n%s", STR_PRINT(prepend_string), error_type_str, ZSTR_VAL(buf), error_filename, error_lineno, STR_PRINT(append_string));
+							zend_string_free(buf);
+						}
+						else {
+							php_printf("%s<br />\n<b>%s</b>:  %s in <b>%s</b> on line <b>%d</b><br />\n%s", STR_PRINT(prepend_string), error_type_str, buffer, error_filename, error_lineno, STR_PRINT(append_string));
+						}
+					}
+					else {
+						/* Write CLI/CGI errors to stderr if display_errors = "stderr" */
+						if ((!strcmp(sapi_module.name, "cli") || !strcmp(sapi_module.name, "cgi")) &&
+							PG(display_errors) == PHP_DISPLAY_ERRORS_STDERR
+							) {
+#ifdef PHP_WIN32
+							fprintf(stderr, "%s: %s in %s on line %u\n", error_type_str, buffer, error_filename, error_lineno);
+							fflush(stderr);
+#else
+							fprintf(stderr, "%s: %s in %s on line %u\n", error_type_str, buffer, error_filename, error_lineno);
+#endif
+						}
+						else {
+							php_printf("%s\n%s: %s in %s on line %d\n%s", STR_PRINT(prepend_string), error_type_str, buffer, error_filename, error_lineno, STR_PRINT(append_string));
+						}
+					}
+				}
+			}
+#if ZEND_DEBUG
+			if (PG(report_zend_debug)) {
+				zend_bool trigger_break;
+
+				switch (type) {
+					case E_ERROR:
+					case E_CORE_ERROR:
+					case E_COMPILE_ERROR:
+					case E_USER_ERROR:
+						trigger_break = 1;
+						break;
+					default:
+						trigger_break = 0;
+						break;
+				}
+				zend_output_debug_string(trigger_break, "%s(%d) : %s - %s", error_filename, error_lineno, error_type_str, buffer);
+			}
+#endif
+		}
+
+	} else if (store_only) {
+		goto done;
 	}
 
 	/* Bail out if we can't recover */
@@ -1188,22 +1200,16 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 				} else {
 					/* restore memory limit */
 					zend_set_memory_limit(PG(memory_limit));
-					efree(buffer);
 					zend_objects_store_mark_destructed(&EG(objects_store));
 					zend_bailout();
-					return;
+					goto done;
 				}
 			}
 			break;
 	}
 
 	/* Log if necessary */
-	if (!display) {
-		efree(buffer);
-		return;
-	}
-
-	if (PG(track_errors) && module_initialized && EG(valid_symbol_table)) {
+	if (display && PG(track_errors) && module_initialized && EG(valid_symbol_table)) {
 		zval tmp;
 
 		ZVAL_STRINGL(&tmp, buffer, buffer_len);
@@ -1216,6 +1222,7 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 		}
 	}
 
+done:
 	efree(buffer);
 }
 /* }}} */

--- a/tests/lang/error/basic.phpt
+++ b/tests/lang/error/basic.phpt
@@ -3,10 +3,6 @@ Uncatched exceptions are properly stored.
 --FILE--
 <?php
 
-register_shutdown_function(function () {
-	var_dump(error_get_last());
-});
-
 new DateTime('1/1/11111');
 
 ?>
@@ -16,17 +12,3 @@ Stack trace:
 #0 %s: DateTime->__construct('1/1/11111')
 #1 {main}
   thrown in %s
-array(4) {
-  ["type"]=>
-  int(1)
-  ["message"]=>
-  string(327) "Uncaught Exception: DateTime::__construct(): Failed to parse time string (1/1/11111) at position 8 (1): Unexpected character in %s
-Stack trace:
-#0 %s: DateTime->__construct('1/1/11111')
-#1 {main}
-  thrown"
-  ["file"]=>
-  string(61) "%s"
-  ["line"]=>
-  int(%d)
-}

--- a/tests/lang/error/basic.phpt
+++ b/tests/lang/error/basic.phpt
@@ -3,6 +3,17 @@ Uncatched exceptions are properly stored.
 --FILE--
 <?php
 
+register_shutdown_function(function () {
+	$error = error_get_last();
+	assert($error['type'] === 1);
+	assert(preg_match(
+		'/^Uncaught Exception: DateTime::__construct\(\): Failed to parse time string \(1\/1\/11111\) at position 8 \(1\): Unexpected character in .*\nStack trace:\n#0 .*: DateTime->__construct\(\'1\/1\/11111\'\)\n#1 {main}\n  thrown$/D',
+		$error['message']
+	) === 1);
+	assert(!empty($error['file']));
+	assert(is_int($error['line']));
+});
+
 new DateTime('1/1/11111');
 
 ?>

--- a/tests/lang/error/basic.phpt
+++ b/tests/lang/error/basic.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Uncatched exceptions are properly stored.
+--FILE--
+<?php
+
+register_shutdown_function(function () {
+	var_dump(error_get_last());
+});
+
+new DateTime('1/1/11111');
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: DateTime::__construct(): Failed to parse time string (1/1/11111) at position 8 (1): Unexpected character in %s
+Stack trace:
+#0 %s: DateTime->__construct('1/1/11111')
+#1 {main}
+  thrown in %s
+array(4) {
+  ["type"]=>
+  int(1)
+  ["message"]=>
+  string(327) "Uncaught Exception: DateTime::__construct(): Failed to parse time string (1/1/11111) at position 8 (1): Unexpected character in %s
+Stack trace:
+#0 %s: DateTime->__construct('1/1/11111')
+#1 {main}
+  thrown"
+  ["file"]=>
+  string(61) "%s"
+  ["line"]=>
+  int(%d)
+}

--- a/tests/lang/error/variant_catched_exception.phpt
+++ b/tests/lang/error/variant_catched_exception.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Catched exceptions should NOT be stored.
+--FILE--
+<?php
+
+register_shutdown_function(function () {
+	var_dump(error_get_last());
+});
+
+try {
+	new DateTime('1/1/11111');
+}
+catch (Exception $e) {
+	// Intentionally left blank.
+}
+
+?>
+--EXPECTF--
+NULL

--- a/tests/lang/error/variant_catched_exception.phpt
+++ b/tests/lang/error/variant_catched_exception.phpt
@@ -15,5 +15,5 @@ catch (Exception $e) {
 }
 
 ?>
---EXPECTF--
+--EXPECT--
 NULL


### PR DESCRIPTION
Currently any kind of error is stored for retrieval by `errot_get_last()`,
however, this behavior is actually not desired if the exception was caught.
This change addresses exactly this situation.

Consumes, extends, and closes #365
- [x] Implementation
- [x] Tests
- [ ] RFC
- [x] [php-internals thread](http://news.php.net/php.internals/93903)
- [ ] Reddit
