### PR TITLE
Fix #72374: ZipArchive::addGlob remove_path option strips first char of filename

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1652,6 +1652,7 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 		size_t real_len = strlen(remove_path);
 		if ((real_len > 1) && ((remove_path[real_len - 1] == '/') || (remove_path[real_len - 1] == '\\'))) {
 			remove_path[real_len - 1] = '\0';
+			remove_path_len -= 1;
 		}
 	}
 
@@ -1677,8 +1678,8 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 					file_stripped = ZSTR_VAL(basename);
 					file_stripped_len = ZSTR_LEN(basename);
 				} else if (remove_path && strstr(Z_STRVAL_P(zval_file), remove_path) != NULL) {
-					file_stripped = Z_STRVAL_P(zval_file) + remove_path_len + 1;
-					file_stripped_len = Z_STRLEN_P(zval_file) - remove_path_len - 1;
+					file_stripped = Z_STRVAL_P(zval_file) + remove_path_len;
+					file_stripped_len = Z_STRLEN_P(zval_file) - remove_path_len;
 				} else {
 					file_stripped = Z_STRVAL_P(zval_file);
 					file_stripped_len = Z_STRLEN_P(zval_file);

--- a/ext/zip/tests/bug72374.phpt
+++ b/ext/zip/tests/bug72374.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Bug #72374 (ZipArchive::addGlob remove_path option strips first char of filename)
+--SKIPIF--
+<?php
+if(!extension_loaded('zip')) die('skip');
+?>
+--FILE--
+<?php
+$dirname = dirname(__FILE__) . '/';
+include $dirname . 'utils.inc';
+
+$dirname = $dirname . 'bug72374/';
+mkdir($dirname);
+$file = $dirname . 'some-foo.txt';
+touch($file);
+
+$zip = new ZipArchive();
+$zip->open($dirname . 'test.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addGlob($file, 0, array('add_path' => 'prefix-', 'remove_path' => $dirname . 'some-'));
+$zip->addGlob($file, 0, array('add_path' => 'dir-prefix', 'remove_path' => $dirname));
+dump_entries_name($zip);
+$zip->close();
+?>
+--CLEAN--
+<?php
+$dirname = dirname(__FILE__) . '/';
+include $dirname . 'utils.inc';
+
+$dirname = $dirname . 'bug72374/';
+rmdir_rf($dirname);
+?>
+--EXPECTF--
+0 prefix-foo.txt
+1 dir-prefix/some-foo.txt

--- a/ext/zip/tests/oo_addpattern.phpt
+++ b/ext/zip/tests/oo_addpattern.phpt
@@ -24,7 +24,7 @@ if (!$zip->open($file)) {
         exit('failed');
 }
 $dir = realpath($dirname);
-$options = array('add_path' => 'baz/', 'remove_path' => $dir);
+$options = array('add_path' => 'baz', 'remove_path' => $dir);
 if (!$zip->addPattern('/\.txt$/', $dir, $options)) {
         echo "failed\n";
 }


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=72374

After adding a file by addGlob using add_path and remove_path options, the first character of the filename is stripped in the archive.
This patch fixed the issue.
