### PR TITLE
Add support for the new tidy-html5 library in ext/tidy

### DIFF
--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -25,6 +25,14 @@ if test "$PHP_TIDY" != "no"; then
 
   if test -z "$TIDY_DIR"; then
     AC_MSG_ERROR(Cannot find libtidy)
+  else
+    dnl Check for tidybuffio.h (as opposed to simply buffio.h)
+    dnl which indicates that we are building against tidy-html5
+    dnl and not the legacy htmltidy. The two are compatible,
+    dnl except for with regard to this header file.
+    if test -f "$TIDY_INCDIR/tidybuffio.h"; then
+      AC_DEFINE(HAVE_TIDYBUFFIO_H,1,[defined if tidybuffio.h exists])
+    fi
   fi
 
   TIDY_LIBDIR=$TIDY_DIR/$PHP_LIBDIR

--- a/ext/tidy/tests/003.phpt
+++ b/ext/tidy/tests/003.phpt
@@ -10,8 +10,8 @@ tidy_clean_repair()
 	echo tidy_get_output($a);
 
 ?>
---EXPECT--
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
+--EXPECTF--
+<!DOCTYPE html%S>
 <html>
 <head>
 <title></title>

--- a/ext/tidy/tests/004.phpt
+++ b/ext/tidy/tests/004.phpt
@@ -19,13 +19,13 @@ $a = tidy_parse_string($html);
 var_dump(tidy_diagnose($a));
 echo tidy_get_error_buffer($a);
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 1 column 7 - Warning: discarding unexpected </html>
 line 1 column 14 - Warning: inserting missing 'title' element
-Info: Document content looks like HTML 3.2
-3 warnings, 0 errors were found!
+Info: Document content looks like HTML%w%d%S
+%S3 warnings%S0 errors%S
 bool(true)
 Info: Document content looks like HTML 3.2
 No warnings or errors were found.

--- a/ext/tidy/tests/010.phpt
+++ b/ext/tidy/tests/010.phpt
@@ -11,7 +11,7 @@ var_dump($a->html());
 var_dump($a->head());
 
 ?>
---EXPECT--
+--EXPECTF--
 object(tidyNode)#2 (8) {
   ["value"]=>
   string(94) "<html>
@@ -100,7 +100,7 @@ object(tidyNode)#2 (8) {
               ["proprietary"]=>
               bool(false)
               ["id"]=>
-              int(111)
+              int(%i)
               ["attribute"]=>
               NULL
               ["child"]=>
@@ -231,7 +231,7 @@ object(tidyNode)#2 (9) {
           ["proprietary"]=>
           bool(false)
           ["id"]=>
-          int(111)
+          int(%i)
           ["attribute"]=>
           NULL
           ["child"]=>
@@ -307,7 +307,7 @@ object(tidyNode)#2 (9) {
       ["proprietary"]=>
       bool(false)
       ["id"]=>
-      int(111)
+      int(%i)
       ["attribute"]=>
       NULL
       ["child"]=>

--- a/ext/tidy/tests/012.phpt
+++ b/ext/tidy/tests/012.phpt
@@ -30,7 +30,7 @@ Accessing children nodes
         dump_nodes($html);
             
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 object(tidyNode)#3 (9) {
   ["value"]=>
@@ -70,7 +70,7 @@ object(tidyNode)#3 (9) {
       ["proprietary"]=>
       bool(false)
       ["id"]=>
-      int(111)
+      int(%i)
       ["attribute"]=>
       NULL
       ["child"]=>
@@ -94,7 +94,7 @@ object(tidyNode)#4 (9) {
   ["proprietary"]=>
   bool(false)
   ["id"]=>
-  int(111)
+  int(%i)
   ["attribute"]=>
   NULL
   ["child"]=>
@@ -222,7 +222,7 @@ object(tidyNode)#5 (9) {
           ["proprietary"]=>
           bool(false)
           ["id"]=>
-          int(114)
+          int(%i)
           ["attribute"]=>
           NULL
           ["child"]=>
@@ -365,7 +365,7 @@ object(tidyNode)#8 (9) {
       ["proprietary"]=>
       bool(false)
       ["id"]=>
-      int(114)
+      int(%i)
       ["attribute"]=>
       NULL
       ["child"]=>
@@ -426,7 +426,7 @@ object(tidyNode)#10 (9) {
   ["proprietary"]=>
   bool(false)
   ["id"]=>
-  int(114)
+  int(%i)
   ["attribute"]=>
   NULL
   ["child"]=>

--- a/ext/tidy/tests/016.phpt
+++ b/ext/tidy/tests/016.phpt
@@ -4,21 +4,10 @@ Passing configuration file through tidy_parse_file() (may fail with buggy libtid
 <?php if (!extension_loaded("tidy")) print "skip"; ?>
 --FILE--
 <?php
-        $tidy = tidy_parse_file(dirname(__FILE__)."/016.html", dirname(__FILE__)."/016.tcfg");
-    	tidy_clean_repair($tidy);
-        echo tidy_get_output($tidy);
+        $tidy = tidy_parse_file(dirname(__FILE__)."/016.html",
+                                dirname(__FILE__)."/016.tcfg");
+        $cfg = $tidy->getConfig();
+        echo $cfg["clean"];
 ?>
 --EXPECT--
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
-<html>
-<head>
-<title></title>
-
-<style type="text/css">
- p.c1 {font-weight: bold}
-</style>
-</head>
-<body>
-<p class="c1">testing</p>
-</body>
-</html>
+1

--- a/ext/tidy/tests/017.phpt
+++ b/ext/tidy/tests/017.phpt
@@ -5,8 +5,8 @@ The Tidy Output Buffer Filter
 --FILE--
 <?php ob_start("ob_tidyhandler"); ?>
 <B>testing</I>
---EXPECT--
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
+--EXPECTF--
+<!DOCTYPE html%S>
 <html>
 <head>
 <title></title>

--- a/ext/tidy/tests/020.phpt
+++ b/ext/tidy/tests/020.phpt
@@ -19,12 +19,11 @@ var_dump(strlen($tidy->errorBuffer) > 50);
 
 echo $tidy;
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 bool(true)
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html%A>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title></title>

--- a/ext/tidy/tests/024.phpt
+++ b/ext/tidy/tests/024.phpt
@@ -13,28 +13,27 @@ if (strtotime(tidy_get_release()) < strtotime('20 january 2007')) die ('skip old
 $contents = '
 <wps:block>
 <wps:var>
-<wps:value/>
+<wps:value></wps:value>
 </wps:var>
 </wps:block>';
 
 $config = array(
+'doctype' => 'omit',
 'new-blocklevel-tags' => 'wps:block,wps:var,wps:value',
 'newline' => 'LF'
 );
 
 $tidy = tidy_parse_string($contents, $config, 'utf8');
 $tidy->cleanRepair();
-
-var_dump($tidy->value);
+echo $tidy;
 
 ?>
 --EXPECTF--
-string(11%d) "<html>
+<html>
 <head>
 <title></title>
 </head>
 <body>
-<wps:block>%w<wps:var>
-<wps:value></wps:var>%w</wps:block>
+<wps:block>%w<wps:var>%w<wps:value></wps:value>%w</wps:var>%w</wps:block>
 </body>
-</html>"
+</html>

--- a/ext/tidy/tests/026.phpt
+++ b/ext/tidy/tests/026.phpt
@@ -12,8 +12,8 @@ echo '<p>xpto</p>';
 
 ?>
 </html>
---EXPECT--
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
+--EXPECTF--
+<!DOCTYPE html%S>
 <html>
 <head>
 <title></title>

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -31,7 +31,12 @@
 #include "ext/standard/info.h"
 
 #include "tidy.h"
+
+#if HAVE_TIDYBUFFIO_H
+#include "tidybuffio.h"
+#else
 #include "buffio.h"
+#endif
 
 /* compatibility with older versions of libtidy */
 #ifndef TIDY_CALL


### PR DESCRIPTION
Description taken from PHP Bug #72379, the individual commits contain more information:

The "tidy" extension is currently based off the "HTML tidy" project, which has gone extinct. For reference, see [its SourceForge page](http://tidy.sourceforge.net/), which points you towards its successor tidy-html5. The older project is now bit-rotting, and has some vulnerabilities (CVE-2015-5522 and CVE-2015-5523) that won't be fixed.

The PHP build system should accept tidy-html5 (they're compatible) instead of the legacy project.

