### PR TITLE
Add `optind` param to `getopt`

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -646,6 +646,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_getopt, 0, 0, 1)
 	ZEND_ARG_INFO(0, options)
 	ZEND_ARG_INFO(0, opts) /* ARRAY_INFO(0, opts, 1) */
+	ZEND_ARG_INFO(1, optind)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_flush, 0)
@@ -4239,7 +4240,7 @@ static int parse_opts(char * opts, opt_struct ** result)
 }
 /* }}} */
 
-/* {{{ proto array getopt(string options [, array longopts])
+/* {{{ proto array getopt(string options [, array longopts [, int &optind]])
    Get options from the command line argument list */
 PHP_FUNCTION(getopt)
 {
@@ -4251,11 +4252,18 @@ PHP_FUNCTION(getopt)
 	char *php_optarg = NULL;
 	int php_optind = 1;
 	zval val, *args = NULL, *p_longopts = NULL;
+	zval *zoptind = NULL;
 	int optname_len = 0;
 	opt_struct *opts, *orig_opts;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|a", &options, &options_len, &p_longopts) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|az/", &options, &options_len, &p_longopts, &zoptind) == FAILURE) {
 		RETURN_FALSE;
+	}
+
+	/* Init zoptind to 1 */
+	if (zoptind) {
+		zval_dtor(zoptind);
+		ZVAL_LONG(zoptind, 1);
 	}
 
 	/* Get argv from the global symbol table. We calculate argc ourselves
@@ -4397,6 +4405,11 @@ PHP_FUNCTION(getopt)
 		}
 
 		php_optarg = NULL;
+	}
+
+	/* Set zoptind to php_optind */
+	if (zoptind) {
+		ZVAL_LONG(zoptind, php_optind);
 	}
 
 	free_longopts(orig_opts);

--- a/ext/standard/tests/general_functions/getopt_006.phpt
+++ b/ext/standard/tests/general_functions/getopt_006.phpt
@@ -1,0 +1,15 @@
+--TEST--
+getopt#006 (optind #1)
+--ARGS--
+-a 1 -b 2 test
+--INI--
+register_argc_argv=On
+variables_order=GPS
+--FILE--
+<?php
+    $optind = null;
+    getopt('a:b:', [], $optind);
+    var_dump($optind);
+?>
+--EXPECT--
+int(5)

--- a/ext/standard/tests/general_functions/getopt_007.phpt
+++ b/ext/standard/tests/general_functions/getopt_007.phpt
@@ -1,7 +1,7 @@
 --TEST--
 getopt#007 (optind #2)
 --ARGS--
--a 1 -b 2 -- test
+-a 1 -b 2 -- -c nope test
 --INI--
 register_argc_argv=On
 variables_order=GPS

--- a/ext/standard/tests/general_functions/getopt_007.phpt
+++ b/ext/standard/tests/general_functions/getopt_007.phpt
@@ -1,0 +1,15 @@
+--TEST--
+getopt#007 (optind #2)
+--ARGS--
+-a 1 -b 2 -- test
+--INI--
+register_argc_argv=On
+variables_order=GPS
+--FILE--
+<?php
+    $optind = null;
+    getopt('a:b:', [], $optind);
+    var_dump($optind);
+?>
+--EXPECT--
+int(6)

--- a/ext/standard/tests/general_functions/getopt_008.phpt
+++ b/ext/standard/tests/general_functions/getopt_008.phpt
@@ -1,0 +1,15 @@
+--TEST--
+getopt#008 (optind #3)
+--ARGS--
+-a 1 -b 2
+--INI--
+register_argc_argv=On
+variables_order=GPS
+--FILE--
+<?php
+    $optind = null;
+    getopt('a:b:', [], $optind);
+    var_dump($optind);
+?>
+--EXPECT--
+int(5)

--- a/ext/standard/tests/general_functions/getopt_009.phpt
+++ b/ext/standard/tests/general_functions/getopt_009.phpt
@@ -1,0 +1,15 @@
+--TEST--
+getopt#009 (optind #4)
+--ARGS--
+messup -a 1 -b 2
+--INI--
+register_argc_argv=On
+variables_order=GPS
+--FILE--
+<?php
+    $optind = null;
+    getopt('a:b:', [], $optind);
+    var_dump($optind);
+?>
+--EXPECT--
+int(1)


### PR DESCRIPTION
This patch adds an `optind` parameter to `getopt`, making it easier for programs to access positional arguments when combined with flag arguments. This pattern is present in many getopt implementations.

I emailed[1] internals about this a while ago but didn't get any feedback, however I think @nikic liked the idea. I'm hoping to get some feedback here instead.

[1] http://news.php.net/php.internals/93627
