### PR TITLE
Change default gd.jpeg_ignore_warning = 1

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -989,7 +989,7 @@ ZEND_GET_MODULE(gd)
 
 /* {{{ PHP_INI_BEGIN */
 PHP_INI_BEGIN()
-	PHP_INI_ENTRY("gd.jpeg_ignore_warning", "0", PHP_INI_ALL, NULL)
+	PHP_INI_ENTRY("gd.jpeg_ignore_warning", "1", PHP_INI_ALL, NULL)
 PHP_INI_END()
 /* }}} */
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -1653,7 +1653,7 @@ zend.assertions = 1
 ; a gd image. The warning will then be displayed as notices
 ; disabled by default
 ; http://php.net/gd.jpeg-ignore-warning
-;gd.jpeg_ignore_warning = 0
+;gd.jpeg_ignore_warning = 1
 
 [exif]
 ; Exif UNICODE user comments are handled as UCS-2BE/UCS-2LE and JIS as JIS.

--- a/php.ini-production
+++ b/php.ini-production
@@ -1653,7 +1653,7 @@ zend.assertions = -1
 ; a gd image. The warning will then be displayed as notices
 ; disabled by default
 ; http://php.net/gd.jpeg-ignore-warning
-;gd.jpeg_ignore_warning = 0
+;gd.jpeg_ignore_warning = 1
 
 [exif]
 ; Exif UNICODE user comments are handled as UCS-2BE/UCS-2LE and JIS as JIS.


### PR DESCRIPTION
Ignoring these warnings apparently works fine (libgd does so in
gdImageCreateJpeg()), but not ignoring them may cause imagecreatefromjpeg()
to fail completely, so it seems reasonable to ignore warnings by default.

Note that this change most likely doesn't constitute a BC break; we're
simply being more resilient with regard to slightly broken JPEGs.

See also the related [bug #72404](https://bugs.php.net/bug.php?id=72404).

I don't think this change requires an RFC, but if others feel otherwise I can make one.

If the PR will be accepted, I'll change the documentation accordingly.