### PR TITLE
Correct for connection with PDO::ATTR_STRINGIFY_FETCHES set to false

### DIFF
--- a/ext/pdo_dblib/tests/bug_71667.phpt
+++ b/ext/pdo_dblib/tests/bug_71667.phpt
@@ -19,16 +19,16 @@ array(1) {
   [0]=>
   array(6) {
     ["computed"]=>
-    string(1) "1"
+    int(1)
     [0]=>
-    string(1) "1"
+    int(1)
     ["named"]=>
-    string(1) "2"
+    int(2)
     [1]=>
-    string(1) "2"
+    int(2)
     ["computed1"]=>
-    string(1) "3"
+    int(3)
     [2]=>
-    string(1) "3"
+    int(3)
   }
 }


### PR DESCRIPTION
Since 1e1500a2bc30e0f7b0846e16567ffb3728f57eef, the default for tests is to return unstringified column data. The test added with ed3edc2f05c7be9c498aee64de2ad5a796456135 should have come in like this.