### PR TITLE
Fix #72409 - return previous handler

### DIFF
--- a/ext/pcntl/tests/pcntl_signal.phpt
+++ b/ext/pcntl/tests/pcntl_signal.phpt
@@ -5,12 +5,15 @@ pcntl_signal()
 <?php if (!extension_loaded("posix")) die("skip posix extension not available"); ?>
 --FILE--
 <?php
-pcntl_signal(SIGTERM, function($signo){
+function pcntl_test($signo) {}
+pcntl_signal(SIGTERM, 'pcntl_test');
+$prev = pcntl_signal(SIGTERM, function($signo){
 	echo "signal dispatched\n";
 });
 posix_kill(posix_getpid(), SIGTERM);
 pcntl_signal_dispatch();
 
+var_dump($prev);
 var_dump(pcntl_signal());
 var_dump(pcntl_signal(SIGALRM, SIG_IGN));
 var_dump(pcntl_signal(-1, -1));
@@ -24,6 +27,7 @@ echo "ok\n";
 ?>
 --EXPECTF--
 signal dispatched
+string(10) "pcntl_test"
 
 Warning: pcntl_signal() expects at least 2 parameters, 0 given in %s
 NULL


### PR DESCRIPTION
This patch addresses https://bugs.php.net/bug.php?id=72409
It does alter default behavior in a potentially BC-incompatable
means.  In the event someone was === true, the return value
of pcntl_signal().  However, this change could be applied to
master with small changes.