### PR TITLE
update filter_var filters for ipv4 addresses to reflect rfc6890 

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -704,6 +704,7 @@ void php_filter_validate_ip(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 			if (flags & FILTER_FLAG_NO_PRIV_RANGE) {
 				if (
 					(ip[0] == 10) ||
+					(ip[0] == 169 && ip[1] == 254) ||
 					(ip[0] == 172 && (ip[1] >= 16 && ip[1] <= 31)) ||
 					(ip[0] == 192 && ip[1] == 168)
 				) {
@@ -714,10 +715,18 @@ void php_filter_validate_ip(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 			if (flags & FILTER_FLAG_NO_RES_RANGE) {
 				if (
 					(ip[0] == 0) ||
+					(ip[0] == 10) ||
 					(ip[0] == 100 && (ip[1] >= 64 && ip[1] <= 127)) ||
+					(ip[0] == 127) ||
 					(ip[0] == 169 && ip[1] == 254) ||
+					(ip[0] == 172 && (ip[1] >= 16 && ip[1] <= 31)) ||
+					(ip[0] == 192 && ip[1] == 0 && ip[2] == 0) ||
 					(ip[0] == 192 && ip[1] == 0 && ip[2] == 2) ||
-					(ip[0] == 127 && ip[1] == 0 && ip[2] == 0 && ip[3] == 1) ||
+					(ip[0] == 192 && ip[1] == 88 && ip[2] == 99) ||
+					(ip[0] == 192 && ip[1] == 168) ||
+					(ip[0] == 198 && (ip[1] == 18 || ip[1] == 19)) ||
+					(ip[0] == 198 && ip[1] == 51 && ip[2] == 100) ||
+					(ip[0] == 203 && ip[1] == 0 && ip[2] == 113) ||
 					(ip[0] >= 224 && ip[0] <= 255)
 				) {
 					RETURN_VALIDATION_FAILED

--- a/ext/filter/tests/018.phpt
+++ b/ext/filter/tests/018.phpt
@@ -41,7 +41,7 @@ string(9) "127.0.0.1"
 bool(false)
 string(12) "192.0.34.166"
 bool(false)
-string(9) "192.0.0.1"
+bool(false)
 bool(false)
 bool(false)
 string(12) "192.0.34.166"

--- a/ext/filter/tests/filter_ipv4_rfc6890.phpt
+++ b/ext/filter/tests/filter_ipv4_rfc6890.phpt
@@ -1,0 +1,137 @@
+--TEST--
+Bug #71745 FILTER_FLAG_NO_RES_RANGE does not cover whole 127.0.0.0/8 range
+--FILE--
+<?php
+//https://tools.ietf.org/html/rfc6890#section-2.1
+
+$privateRanges = array();
+// 10.0.0.0/8
+$privateRanges['10.0.0.0/8'] = array('10.0.0.0', '10.255.255.255');
+
+// 169.254.0.0/16
+$privateRanges['168.254.0.0/16'] = array('169.254.0.0', '169.254.255.255');
+
+// 172.16.0.0/12
+$privateRanges['172.16.0.0/12'] = array('172.16.0.0', '172.31.0.0');
+
+// 192.168.0.0/16
+$privateRanges['192.168.0.0/16'] = array('192.168.0.0', '192.168.255.255');
+
+foreach ($privateRanges as $key => $range) {
+	list($min, $max) = $range;
+	var_dump($key);
+	var_dump(filter_var($min, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE));
+	var_dump(filter_var($max, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE));
+}
+
+$reservedRanges = array();
+
+// 0.0.0.0/8
+$reserverRanges['0.0.0.0/8'] = array('0.0.0.0', '0.255.255.255');
+
+// 10.0.0.0/8
+$reserverdRanges['10.0.0.0/8'] = array('10.0.0.0', '10.255.255.255');
+
+// 100.64.0.0/10
+$reserverdRanges['10.64.0.0/10'] = array('100.64.0.0', '100.127.255.255');
+
+// 127.0.0.0/8
+$reserverdRanges['127.0.0.0/8'] = array('127.0.0.0', '127.255.255.255');
+
+// 169.254.0.0/16
+$reserverdRanges['169.254.0.0/16'] = array('169.254.0.0', '169.254.255.255');
+
+// 172.16.0.0/12
+$reserverdRanges['172.16.0.0/12'] = array('172.16.0.0', '172.31.0.0');
+
+// 192.0.0.0/24
+$reserverdRanges['192.0.0.0/24'] = array('192.0.0.0', '192.0.0.255');
+
+// 192.0.0.0/29
+$reserverdRanges['192.0.0.0/29'] = array('192.0.0.0', '192.0.0.7');
+
+// 192.0.2.0/24
+$reserverdRanges['192.0.2.0/24'] = array('192.0.2.0', '192.0.2.255');
+
+// 198.18.0.0/15
+$reserverdRanges['198.18.0.0/15'] = array('198.18.0.0', '198.19.255.255');
+
+// 198.51.100.0/24
+$reserverdRanges['198.51.100.0/24'] = array('198.51.100.0', '198.51.100.255');
+
+// 192.88.99.0/24
+$reserverdRanges['192.88.99.0/24'] = array('192.88.99.0', '192.88.99.255');
+
+// 192.168.0.0/16
+$reserverdRanges['192.168.0.0/16'] = array('192.168.0.0', '192.168.255.255');
+
+// 203.0.113.0/24
+$reserverdRanges['203.0.113.0/24'] = array('203.0.113.0', '203.0.113.255');
+
+// 240.0.0.0/4 + 255.255.255.255/32
+$reserverdRanges['240.0.0.0/4'] = array('224.0.0.0', '255.255.255.255');
+
+foreach ($reserverdRanges as $key => $range) {
+	list($min, $max) = $range;
+	var_dump($key);
+	var_dump(filter_var($min, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_RES_RANGE));
+	var_dump(filter_var($max, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_RES_RANGE));
+}
+
+
+
+--EXPECT--
+string(10) "10.0.0.0/8"
+bool(false)
+bool(false)
+string(14) "168.254.0.0/16"
+bool(false)
+bool(false)
+string(13) "172.16.0.0/12"
+bool(false)
+bool(false)
+string(14) "192.168.0.0/16"
+bool(false)
+bool(false)
+string(10) "10.0.0.0/8"
+bool(false)
+bool(false)
+string(12) "10.64.0.0/10"
+bool(false)
+bool(false)
+string(11) "127.0.0.0/8"
+bool(false)
+bool(false)
+string(14) "169.254.0.0/16"
+bool(false)
+bool(false)
+string(13) "172.16.0.0/12"
+bool(false)
+bool(false)
+string(12) "192.0.0.0/24"
+bool(false)
+bool(false)
+string(12) "192.0.0.0/29"
+bool(false)
+bool(false)
+string(12) "192.0.2.0/24"
+bool(false)
+bool(false)
+string(13) "198.18.0.0/15"
+bool(false)
+bool(false)
+string(15) "198.51.100.0/24"
+bool(false)
+bool(false)
+string(14) "192.88.99.0/24"
+bool(false)
+bool(false)
+string(14) "192.168.0.0/16"
+bool(false)
+bool(false)
+string(14) "203.0.113.0/24"
+bool(false)
+bool(false)
+string(11) "240.0.0.0/4"
+bool(false)
+bool(false)


### PR DESCRIPTION
Looking into to bug#71745 reporting that the whole 127.0.0.0/8 should be caught by the FILTER_FLAG_NO_RES_RANGE filter I found the filter doesn't take all currently reserved ranges into account.
This pullrequest adds all the ranges defined in rfc6890 to the FILTER_FLAG_NO_RES_RANGE, this also means the private ranges have been added to the NO_RES_RANGE flag as they are technically also reserved.

In addition to this I added the 169.254 range to the FILTER_FLAG_NO_PRIV_RANGE flag as this is used for link_local in ipv4 effectively making it a private network.

I'm not sure it it should be added to 5.6 as it might introduce a bc break, but 7.1 or even 7.0 might be elligable.