### PR TITLE
Fix Bug # 72021 - Make LDAP_ESCAPE_DN compliant with RFC 4514

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -2823,7 +2823,7 @@ PHP_FUNCTION(ldap_set_rebind_proc)
 /* }}} */
 #endif
 
-static zend_string* php_ldap_do_escape(const zend_bool *map, const char *value, size_t valuelen)
+static zend_string* php_ldap_do_escape(const zend_bool *map, const char *value, size_t valuelen, zend_long flags)
 {
 	char hex[] = "0123456789abcdef";
 	size_t i, p = 0;
@@ -2833,13 +2833,20 @@ static zend_string* php_ldap_do_escape(const zend_bool *map, const char *value, 
 	for (i = 0; i < valuelen; i++) {
 		len += (map[(unsigned char) value[i]]) ? 3 : 1;
 	}
+	/* Per RFC 4514, a leading and trailing space must be escaped */
+	if (flags & PHP_LDAP_ESCAPE_DN && value[0] == ' ') {
+		len += 2;
+	}
+	if (flags & PHP_LDAP_ESCAPE_DN && valuelen && value[valuelen] == ' ') {
+		len += 2;
+	}
 
 	ret =  zend_string_alloc(len, 0);
 
 	for (i = 0; i < valuelen; i++) {
 		unsigned char v = (unsigned char) value[i];
 
-		if (map[v]) {
+		if (map[v] || (flags & PHP_LDAP_ESCAPE_DN && (i == 0 || i + 1 == valuelen ) && v == ' ')) {
 			ZSTR_VAL(ret)[p++] = '\\';
 			ZSTR_VAL(ret)[p++] = hex[v >> 4];
 			ZSTR_VAL(ret)[p++] = hex[v & 0x0f];
@@ -2884,7 +2891,7 @@ PHP_FUNCTION(ldap_escape)
 
 	if (flags & PHP_LDAP_ESCAPE_DN) {
 		havecharlist = 1;
-		php_ldap_escape_map_set_chars(map, "\\,=+<>;\"#", sizeof("\\,=+<>;\"#") - 1, 1);
+		php_ldap_escape_map_set_chars(map, "\\,=+<>;\"#\r", sizeof("\\,=+<>;\"#\r") - 1, 1);
 	}
 
 	if (!havecharlist) {
@@ -2897,7 +2904,7 @@ PHP_FUNCTION(ldap_escape)
 		php_ldap_escape_map_set_chars(map, ignores, ignoreslen, 0);
 	}
 
-	RETURN_NEW_STR(php_ldap_do_escape(map, value, valuelen));
+	RETURN_NEW_STR(php_ldap_do_escape(map, value, valuelen, flags));
 }
 
 #ifdef STR_TRANSLATION

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -2837,7 +2837,7 @@ static zend_string* php_ldap_do_escape(const zend_bool *map, const char *value, 
 	if (flags & PHP_LDAP_ESCAPE_DN && value[0] == ' ') {
 		len += 2;
 	}
-	if (flags & PHP_LDAP_ESCAPE_DN && valuelen && value[valuelen - 1] == ' ') {
+	if (flags & PHP_LDAP_ESCAPE_DN && valuelen > 1 && value[valuelen - 1] == ' ') {
 		len += 2;
 	}
 

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -2837,7 +2837,7 @@ static zend_string* php_ldap_do_escape(const zend_bool *map, const char *value, 
 	if (flags & PHP_LDAP_ESCAPE_DN && value[0] == ' ') {
 		len += 2;
 	}
-	if (flags & PHP_LDAP_ESCAPE_DN && valuelen && value[valuelen] == ' ') {
+	if (flags & PHP_LDAP_ESCAPE_DN && valuelen && value[valuelen - 1] == ' ') {
 		len += 2;
 	}
 

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -2834,10 +2834,10 @@ static zend_string* php_ldap_do_escape(const zend_bool *map, const char *value, 
 		len += (map[(unsigned char) value[i]]) ? 3 : 1;
 	}
 	/* Per RFC 4514, a leading and trailing space must be escaped */
-	if (flags & PHP_LDAP_ESCAPE_DN && value[0] == ' ') {
+	if ((flags & PHP_LDAP_ESCAPE_DN) && (value[0] == ' ')) {
 		len += 2;
 	}
-	if (flags & PHP_LDAP_ESCAPE_DN && valuelen > 1 && value[valuelen - 1] == ' ') {
+	if ((flags & PHP_LDAP_ESCAPE_DN) && ((valuelen > 1) && (value[valuelen - 1] == ' '))) {
 		len += 2;
 	}
 
@@ -2846,7 +2846,7 @@ static zend_string* php_ldap_do_escape(const zend_bool *map, const char *value, 
 	for (i = 0; i < valuelen; i++) {
 		unsigned char v = (unsigned char) value[i];
 
-		if (map[v] || (flags & PHP_LDAP_ESCAPE_DN && (i == 0 || i + 1 == valuelen) && v == ' ')) {
+		if (map[v] || ((flags & PHP_LDAP_ESCAPE_DN) && ((i == 0) || (i + 1 == valuelen)) && (v == ' '))) {
 			ZSTR_VAL(ret)[p++] = '\\';
 			ZSTR_VAL(ret)[p++] = hex[v >> 4];
 			ZSTR_VAL(ret)[p++] = hex[v & 0x0f];

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -2846,7 +2846,7 @@ static zend_string* php_ldap_do_escape(const zend_bool *map, const char *value, 
 	for (i = 0; i < valuelen; i++) {
 		unsigned char v = (unsigned char) value[i];
 
-		if (map[v] || (flags & PHP_LDAP_ESCAPE_DN && (i == 0 || i + 1 == valuelen ) && v == ' ')) {
+		if (map[v] || (flags & PHP_LDAP_ESCAPE_DN && (i == 0 || i + 1 == valuelen) && v == ' ')) {
 			ZSTR_VAL(ret)[p++] = '\\';
 			ZSTR_VAL(ret)[p++] = hex[v >> 4];
 			ZSTR_VAL(ret)[p++] = hex[v & 0x0f];

--- a/ext/ldap/tests/bug72021.phpt
+++ b/ext/ldap/tests/bug72021.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #72021 (ldap_escape() with DN flag is not RFC compliant)
+--CREDITS--
+Chad Sikorra <Chad.Sikorra@gmail.com>
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$subject = " Joe,= \rSmith ";
+
+var_dump(ldap_escape($subject, null, LDAP_ESCAPE_DN));
+?>
+--EXPECT--
+string(24) "\20Joe\2c\3d \0dSmith\20"


### PR DESCRIPTION
This fixes `ldap_escape` when used with `LDAP_ESCAPE_DN`. The current version does not escape carriage returns or leading/trailing spaces, which are both mentioned in RFC 4514:

https://www.ietf.org/rfc/rfc4514.txt

One caveat to this is that it will not ignore escaping the leading/trailing spaces even if specified by the second argument for `ldap_escape` (as the escaping is conditional depending on the position of the space character).

I also mentioned this to @DaveRandom who it seems wrote the original `ldap_escape` function, though I'm not sure if he is still active with PHP anymore.

http://stackoverflow.com/a/8561604/2242593

I also wasn't sure what branch to target this at, and I'm not really a C programmer, just interested in fixing some of the LDAP related bugs/features.