### PR TITLE
Export php_date_get_interface_ce() for extension use

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,9 @@ PHP                                                                        NEWS
 	functions. (Pierrick)
   . Add support for HTTP/2 Server Push (davey)
 
+- Date:
+  . Export date_get_interface_ce for extension use (Jeremy Mikola)
+
 - PCRE:
   . Fixed bug #72476 (Memleak in jit_stack). (Laruence)
   . Fixed bug #72463 (mail fails with invalid argument). (Anatol)

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -585,6 +585,11 @@ PHPAPI zend_class_entry *php_date_get_immutable_ce(void)
 	return date_ce_immutable;
 }
 
+PHPAPI zend_class_entry *php_date_get_interface_ce(void)
+{
+	return date_ce_interface;
+}
+
 PHPAPI zend_class_entry *php_date_get_timezone_ce(void)
 {
 	return date_ce_timezone;

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -221,6 +221,7 @@ PHPAPI timelib_tzinfo *get_timezone_info(void);
 /* Grabbing CE's so that other exts can use the date objects too */
 PHPAPI zend_class_entry *php_date_get_date_ce(void);
 PHPAPI zend_class_entry *php_date_get_immutable_ce(void);
+PHPAPI zend_class_entry *php_date_get_interface_ce(void);
 PHPAPI zend_class_entry *php_date_get_timezone_ce(void);
 
 /* Functions for creating DateTime objects, and initializing them from a string */


### PR DESCRIPTION
@derickr: We spoke about this earlier in https://github.com/mongodb/mongo-php-driver/pull/336#issuecomment-228755315:

>> Alternatively, do we need to use zend_fetch_class() and resolve the interface name string to a class entry?
>
> That sounds kinda crappy... I'd rather export the interface in PHP (from PHP 7.1).