### PR TITLE
Don't call unsafe functions in the signal handler

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1187,7 +1187,8 @@ static void zend_timeout_handler(int dummy) /* {{{ */
 		/* Die on hard timeout */
 		const char *error_filename = NULL;
 		uint error_lineno = 0;
-		char *log_buffer = NULL;
+		char log_buffer[2048];
+		int output_len = 0;
 
 		if (zend_is_compiling()) {
 			error_filename = ZSTR_VAL(zend_get_compiled_filename());
@@ -1205,8 +1206,10 @@ static void zend_timeout_handler(int dummy) /* {{{ */
 			error_filename = "Unknown";
 		}
 
-		zend_spprintf(&log_buffer, 0, "\nFatal error: Maximum execution time of " ZEND_LONG_FMT "+" ZEND_LONG_FMT " seconds exceeded (terminated) in %s on line %d\n", EG(timeout_seconds), EG(hard_timeout), error_filename, error_lineno);
-		write(2, log_buffer, strlen(log_buffer));
+		output_len = snprintf(log_buffer, sizeof(log_buffer), "\nFatal error: Maximum execution time of " ZEND_LONG_FMT "+" ZEND_LONG_FMT " seconds exceeded (terminated) in %s on line %d\n", EG(timeout_seconds), EG(hard_timeout), error_filename, error_lineno);
+		if (output_len > 0) {
+			write(2, log_buffer, MIN(output_len, sizeof(log_buffer)));
+		}
 		_exit(1);
     }
 #endif

--- a/ext/pcntl/tests/001.phpt
+++ b/ext/pcntl/tests/001.phpt
@@ -2,17 +2,16 @@
 Test pcntl wait functionality
 --SKIPIF--
 <?php
-	if (!extension_loaded("pcntl")) print "skip"; 
+	if (!extension_loaded("pcntl")) print "skip";
 	elseif (!function_exists("posix_kill")) print "skip posix_kill() not available";
 ?>
 --FILE--
-<?php 
+<?php
 function test_exit_waits(){
 	print "\n\nTesting pcntl_wifexited and wexitstatus....";
 
 	$pid=pcntl_fork();
 	if ($pid==0) {
-		sleep(1);
 		exit(-1);
 	} else {
 		$options=0;
@@ -25,13 +24,11 @@ function test_exit_signal(){
 	print "\n\nTesting pcntl_wifsignaled....";
 
 	$pid=pcntl_fork();
-    
+
 	if ($pid==0) {
-		sleep(10);
-		exit;
+		posix_kill(posix_getpid(), SIGTERM);
 	} else {
 		$options=0;
-		posix_kill($pid, SIGTERM);
 		pcntl_waitpid($pid, $status, $options);
 		if ( pcntl_wifsignaled($status) ) {
 			$signal_print=pcntl_wtermsig($status);
@@ -47,13 +44,12 @@ function test_stop_signal(){
 	print "\n\nTesting pcntl_wifstopped and pcntl_wstopsig....";
 
 	$pid=pcntl_fork();
-    
+
 	if ($pid==0) {
-		sleep(1);
+		posix_kill(posix_getpid(), SIGSTOP);
 		exit;
 	} else {
 		$options=WUNTRACED;
-		posix_kill($pid, SIGSTOP);
 		pcntl_waitpid($pid, $status, $options);
 		if ( pcntl_wifstopped($status) ) {
 			$signal_print=pcntl_wstopsig($status);

--- a/run-tests.php
+++ b/run-tests.php
@@ -1103,7 +1103,7 @@ function system_with_timeout($commandline, $env = null, $stdin = null)
 			break;
 		} else if ($n === 0) {
 			/* timed out */
-			$data .= "\n ** ERROR: process timed out **\n";
+			$data .= "\n ** ERROR: process timed out after $timeout second(s) **\n";
 			proc_terminate($proc, 9);
 			return $data;
 		} else if ($n > 0) {


### PR DESCRIPTION
Like zend_spprintf inside the signal handler. This can cause a deadlock on malloc like:
```
 #0  0x00007ffff68266ac in __lll_lock_wait_private () from /lib64/libc.so.6
 #1  0x00007ffff67a51c7 in _L_lock_14687 () from /lib64/libc.so.6
 #2  0x00007ffff67a22c3 in malloc () from /lib64/libc.so.6
 #3  0x000000000067accd in xbuf_format_converter ()
 #4  0x000000000067bc1a in vspprintf ()
 #5  0x00000000006f5726 in zend_spprintf ()
 #6  0x00000000006c6556 in zend_timeout_handler ()
 #7  0x00000000006fe04e in zend_signal_handler ()
 #8  0x00000000006fe18b in zend_signal_handler_defer ()
 #9  <signal handler called>
 #10 0x00007ffff67a05dc in _int_malloc () from /lib64/libc.so.6
 #11 0x00007ffff67a226c in malloc () from /lib64/libc.so.6
 #12 0x0000000000580bda in zif_some_extension ()
...
```

I agree that the above trace is contrived by setting USE_ZEND_ALLOC=0. 

But mmap (used by the new memory manager) is also not a "safe" function per http://man7.org/linux/man-pages/man7/signal.7.html so this fix seems worth doing.