### PR TITLE
Use size_t instead of int for loop counter

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -148,7 +148,7 @@ static int dblib_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unqu
 
 	int useBinaryEncoding = 0;
 	const char * hex = "0123456789abcdef";
-	int i;
+	size_t i;
 	char * q;
 	*quotedlen = 0;
 


### PR DESCRIPTION
This value is compared against a size_t value. There would only be issues in the event of very large quoted values, but better safe than sorry.