### PR TITLE
Fix #65600: SplFileObject->next() not move next without current()

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2501,16 +2501,21 @@ SPL_METHOD(SplFileObject, key)
 SPL_METHOD(SplFileObject, next)
 {
 	spl_filesystem_object *intern = (spl_filesystem_object*)zend_object_store_get_object(getThis() TSRMLS_CC);
+	zend_bool has_current_line;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
 	}
 
+	has_current_line = intern->u.file.current_line != NULL;
 	spl_filesystem_file_free_line(intern TSRMLS_CC);
 	if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_READ_AHEAD)) {
 		spl_filesystem_file_read_line(getThis(), intern, 1 TSRMLS_CC);
+		has_current_line = 1;
 	}
-	intern->u.file.current_line_num++;
+	if (has_current_line) {
+		intern->u.file.current_line_num++;
+	}
 } /* }}} */
 
 /* {{{ proto void SplFileObject::setFlags(int flags)

--- a/ext/spl/tests/SplFileObject_key_error002.phpt
+++ b/ext/spl/tests/SplFileObject_key_error002.phpt
@@ -18,5 +18,5 @@ var_dump($s->key());
 var_dump($s->valid());
 ?>
 --EXPECT--
-int(13)
+int(12)
 bool(false)

--- a/ext/spl/tests/bug65600.phpt
+++ b/ext/spl/tests/bug65600.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug #65600 (SplFileObject->next() not move next without current())
+--FILE--
+<?php
+$f = new SplFileObject('php://temp', 'w+');
+$f->fwrite("line 1\nline 2\nline 3");
+
+$f->rewind();
+var_dump($f->key());
+var_dump($f->current());
+
+$f->rewind();
+$f->next();
+$f->next();
+$f->next();
+var_dump($f->key());
+var_dump($f->current());
+?>
+--EXPECT--
+int(0)
+string(7) "line 1
+"
+int(0)
+string(7) "line 1
+"


### PR DESCRIPTION
Well, actually we don't fix next() to move to the next line, because that
is supposed to happen only when ::READ_AHEAD is set, but we're fixing the
inconsistency between ::key() and current() which occurs when next() is
called multiple times without calling current().

To cater to this change we have to adjust SplFileObject_key_error002.phpt,
which tests for an erroneous condition anyway.
