### PR TITLE
Fix #72409 - return previous handler

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -949,6 +949,7 @@ PHP_FUNCTION(pcntl_exec)
 PHP_FUNCTION(pcntl_signal)
 {
 	zval *handle;
+	zval *prev_handle;
 	zend_string *func_name;
 	zend_long signo;
 	zend_bool restart_syscalls = 1;
@@ -975,6 +976,12 @@ PHP_FUNCTION(pcntl_signal)
 		}
 	}
 
+	if ((prev_handle = zend_hash_index_find(&PCNTL_G(php_signal_table), signo)) != NULL) {
+		RETVAL_ZVAL(prev_handle, 1, 0);
+	} else {
+		RETVAL_TRUE;
+	}
+
 	/* Special long value case for SIG_DFL and SIG_IGN */
 	if (Z_TYPE_P(handle) == IS_LONG) {
 		if (Z_LVAL_P(handle) != (zend_long) SIG_DFL && Z_LVAL_P(handle) != (zend_long) SIG_IGN) {
@@ -987,7 +994,7 @@ PHP_FUNCTION(pcntl_signal)
 			RETURN_FALSE;
 		}
 		zend_hash_index_del(&PCNTL_G(php_signal_table), signo);
-		RETURN_TRUE;
+		return;
 	}
 
 	if (!zend_is_callable(handle, 0, &func_name)) {
@@ -1008,7 +1015,6 @@ PHP_FUNCTION(pcntl_signal)
 		php_error_docref(NULL, E_WARNING, "Error assigning signal");
 		RETURN_FALSE;
 	}
-	RETURN_TRUE;
 }
 /* }}} */
 

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -72,6 +72,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_pcntl_signal, 0, 0, 2)
 	ZEND_ARG_INFO(0, restart_syscalls)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_pcntl_signal_get_handler, 0, 0, 1)
+	ZEND_ARG_INFO(0, signo)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pcntl_sigprocmask, 0, 0, 2)
 	ZEND_ARG_INFO(0, how)
 	ZEND_ARG_INFO(0, set)
@@ -155,6 +159,7 @@ const zend_function_entry pcntl_functions[] = {
 	PHP_FE(pcntl_waitpid,		arginfo_pcntl_waitpid)
 	PHP_FE(pcntl_wait,			arginfo_pcntl_wait)
 	PHP_FE(pcntl_signal,		arginfo_pcntl_signal)
+	PHP_FE(pcntl_signal_get_handler,		arginfo_pcntl_signal_get_handler)
 	PHP_FE(pcntl_signal_dispatch,	arginfo_pcntl_void)
 	PHP_FE(pcntl_wifexited,		arginfo_pcntl_wifexited)
 	PHP_FE(pcntl_wifstopped,	arginfo_pcntl_wifstopped)
@@ -993,7 +998,7 @@ PHP_FUNCTION(pcntl_signal)
 			php_error_docref(NULL, E_WARNING, "Error assigning signal");
 			RETURN_FALSE;
 		}
-		zend_hash_index_del(&PCNTL_G(php_signal_table), signo);
+		zend_hash_index_update(&PCNTL_G(php_signal_table), signo, handle);
 		return;
 	}
 
@@ -1017,6 +1022,29 @@ PHP_FUNCTION(pcntl_signal)
 	}
 }
 /* }}} */
+
+/* {{{ proto bool pcntl_signal_get_handler(int signo)
+   Gets signal handler */
+PHP_FUNCTION(pcntl_signal_get_handler)
+{
+	zval *prev_handle;
+	zend_long signo;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &signo) == FAILURE) {
+		return;
+	}
+
+	if (signo < 1 || signo > 32) {
+		php_error_docref(NULL, E_WARNING, "Invalid signal");
+		RETURN_FALSE;
+	}
+
+	if ((prev_handle = zend_hash_index_find(&PCNTL_G(php_signal_table), signo)) != NULL) {
+		RETURN_ZVAL(prev_handle, 1, 0);
+	} else {
+		RETURN_LONG((long)SIG_DFL);
+	}
+}
 
 /* {{{ proto bool pcntl_signal_dispatch()
    Dispatch signals to signal handlers */

--- a/ext/pcntl/php_pcntl.h
+++ b/ext/pcntl/php_pcntl.h
@@ -51,6 +51,7 @@ PHP_FUNCTION(pcntl_wexitstatus);
 PHP_FUNCTION(pcntl_wtermsig);
 PHP_FUNCTION(pcntl_wstopsig);
 PHP_FUNCTION(pcntl_signal);
+PHP_FUNCTION(pcntl_signal_get_handler);
 PHP_FUNCTION(pcntl_signal_dispatch);
 PHP_FUNCTION(pcntl_get_last_error);
 PHP_FUNCTION(pcntl_strerror);

--- a/ext/pcntl/tests/pcntl_signal.phpt
+++ b/ext/pcntl/tests/pcntl_signal.phpt
@@ -5,11 +5,15 @@ pcntl_signal()
 <?php if (!extension_loaded("posix")) die("skip posix extension not available"); ?>
 --FILE--
 <?php
-pcntl_signal(SIGTERM, function($signo){
+function pcntl_test($signo) {}
+pcntl_signal(SIGTERM, 'pcntl_test');
+$prev = pcntl_signal(SIGTERM, function($signo){
 	echo "signal dispatched\n";
 });
 posix_kill(posix_getpid(), SIGTERM);
 pcntl_signal_dispatch();
+
+var_dump($prev);
 
 var_dump(pcntl_signal());
 var_dump(pcntl_signal(SIGALRM, SIG_IGN));
@@ -24,6 +28,7 @@ echo "ok\n";
 ?>
 --EXPECTF--
 signal dispatched
+string(10) "pcntl_test"
 
 Warning: pcntl_signal() expects at least 2 parameters, 0 given in %s
 NULL

--- a/ext/pcntl/tests/pcntl_signal_get_handler.phpt
+++ b/ext/pcntl/tests/pcntl_signal_get_handler.phpt
@@ -1,0 +1,32 @@
+--TEST--
+pcntl_signal()
+--SKIPIF--
+<?php if (!extension_loaded("pcntl")) print "skip"; ?>
+<?php if (!extension_loaded("posix")) die("skip posix extension not available"); ?>
+--FILE--
+<?php
+var_dump(pcntl_signal_get_handler(SIGUSR1));
+
+function pcntl_test($signo) {}
+pcntl_signal(SIGUSR1, 'pcntl_test');
+var_dump(pcntl_signal_get_handler(SIGUSR1));
+
+pcntl_signal(SIGUSR1, SIG_IGN);
+var_dump(pcntl_signal_get_handler(SIGUSR1));
+
+pcntl_signal(SIGUSR1, SIG_DFL);
+var_dump(pcntl_signal_get_handler(SIGUSR1));
+
+posix_kill(posix_getpid(), SIGUSR1);
+pcntl_signal_dispatch();
+
+echo "ok\n";
+?>
+--EXPECTF--
+int(0)
+string(10) "pcntl_test"
+int(1)
+int(0)
+User defined signal 1
+
+Termsig=10


### PR DESCRIPTION
This patch addresses https://bugs.php.net/bug.php?id=72409
It does alter default behavior in a potentially BC-incompatable
means.  In the event someone was === true, the return value
of pcntl_signal().  However, this change could be applied to
master with small changes.

This patch is applied to master compared to PR #1952 which was
patching 5.6.x branch of PHP