### PR TITLE
Fix for bug #72496 - Child method with different signature from parent private method

### DIFF
--- a/Zend/tests/bug72496.phpt
+++ b/Zend/tests/bug72496.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #72496 (declare public method with signature incompatible with parent private method should not throw a warning)
+--FILE--
+<?php
+class Foo
+{
+    private function getFoo()
+    {
+        return 'Foo';
+    }
+
+    private function getBar()
+    {
+        return 'Bar';
+    }
+
+    private function getBaz()
+    {
+        return 'Baz';
+    }
+}
+
+class Bar extends Foo
+{
+    public function getFoo($extraArgument)
+    {
+        return $extraArgument;
+    }
+
+    protected function getBar($extraArgument)
+    {
+        return $extraArgument;
+    }
+
+    private function getBaz($extraArgument)
+    {
+        return $extraArgument;
+    }
+}
+
+echo "OK\n";
+--EXPECT--
+OK

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3252,8 +3252,8 @@ static zend_bool zend_do_perform_implementation_check(const zend_function *fe, c
 		return 1;
 	}
 
-	/* If both methods are private do not enforce a signature */
-    if ((fe->common.fn_flags & ZEND_ACC_PRIVATE) && (proto->common.fn_flags & ZEND_ACC_PRIVATE)) {
+    /* If the prototype method is private do not enforce a signature */
+    if (proto->common.fn_flags & ZEND_ACC_PRIVATE) {
 		return 1;
 	}
 


### PR DESCRIPTION
When an implementation of a child method has the same name as a private parent method, their signatures are checked for compatibility.

This shouldn't be the case as if the parent's method is private, the child's method is not overriding it.

Link for the bug: https://bugs.php.net/bug.php?id=72496

This PR replaces https://github.com/php/php-src/pull/1971 which was made against 5.5