### PR TITLE
Pass error severity to SAPI modules and raise corresponding error level in Apache

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4727,7 +4727,7 @@ PHPAPI int _php_error_log_ex(int opt_err, char *message, size_t message_len, cha
 
 		case 4: /* send to SAPI */
 			if (sapi_module.log_message) {
-				sapi_module.log_message(message);
+				sapi_module.log_message(message, -1);
 			} else {
 				return FAILURE;
 			}

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -242,7 +242,7 @@ struct _sapi_module_struct {
 	char *(*read_cookies)(void);
 
 	void (*register_server_variables)(zval *track_vars_array);
-	void (*log_message)(char *message);
+	void (*log_message)(char *message, int syslog_type_int);
 	double (*get_request_time)(void);
 	void (*terminate_process)(void);
 

--- a/main/main.c
+++ b/main/main.c
@@ -698,7 +698,7 @@ PHPAPI ZEND_COLD void php_log_err_with_severity(char *log_message, int syslog_ty
 	/* Otherwise fall back to the default logging location, if we have one */
 
 	if (sapi_module.log_message) {
-		sapi_module.log_message(log_message);
+		sapi_module.log_message(log_message, syslog_type_int);
 	}
 	PG(in_error_log) = 0;
 }

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -314,16 +314,44 @@ php_apache_sapi_flush(void *server_context)
 	}
 }
 
-static void php_apache_sapi_log_message(char *msg)
+static void php_apache_sapi_log_message(char *msg, int syslog_type_int)
 {
 	php_struct *ctx;
+	int aplog_type = APLOG_ERR;
 
 	ctx = SG(server_context);
+
+	switch (syslog_type_int) {
+		case LOG_EMERG:
+			aplog_type = APLOG_EMERG;
+			break;
+		case LOG_ALERT:
+			aplog_type = APLOG_ALERT;
+			break;
+		case LOG_CRIT:
+			aplog_type = APLOG_CRIT;
+			break;
+		case LOG_ERR:
+			aplog_type = APLOG_ERR;
+			break;
+		case LOG_WARNING:
+			aplog_type = APLOG_WARNING;
+			break;
+		case LOG_NOTICE:
+			aplog_type = APLOG_NOTICE;
+			break;
+		case LOG_INFO:
+			aplog_type = APLOG_INFO;
+			break;
+		case LOG_DEBUG:
+			aplog_type = APLOG_DEBUG;
+			break;
+	}
 
 	if (ctx == NULL) { /* we haven't initialized our ctx yet, oh well */
 		ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_STARTUP, 0, NULL, "%s", msg);
 	} else {
-		ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, ctx->r, "%s", msg);
+		ap_log_rerror(APLOG_MARK, aplog_type, 0, ctx->r, "%s", msg);
 	}
 }
 
@@ -332,7 +360,7 @@ static void php_apache_sapi_log_message_ex(char *msg, request_rec *r)
 	if (r) {
 		ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, msg, r->filename);
 	} else {
-		php_apache_sapi_log_message(msg);
+		php_apache_sapi_log_message(msg, -1);
 	}
 }
 

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -711,7 +711,7 @@ static void sapi_cgi_register_variables(zval *track_vars_array)
 	}
 }
 
-static void sapi_cgi_log_message(char *message)
+static void sapi_cgi_log_message(char *message, int syslog_type_int)
 {
 	if (fcgi_is_fastcgi() && CGIG(fcgi_logging)) {
 		fcgi_request *request;

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -377,7 +377,7 @@ static void sapi_cli_register_variables(zval *track_vars_array) /* {{{ */
 }
 /* }}} */
 
-static void sapi_cli_log_message(char *message) /* {{{ */
+static void sapi_cli_log_message(char *message, int syslog_type_int) /* {{{ */
 {
 	fprintf(stderr, "%s\n", message);
 }

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -689,7 +689,7 @@ static void sapi_cli_server_register_variables(zval *track_vars_array) /* {{{ */
 	zend_hash_apply_with_arguments(&client->request.headers, (apply_func_args_t)sapi_cli_server_register_entry_cb, 1, track_vars_array);
 } /* }}} */
 
-static void sapi_cli_server_log_message(char *msg) /* {{{ */
+static void sapi_cli_server_log_message(char *msg, int syslog_type_int) /* {{{ */
 {
 	char buf[52];
 
@@ -1184,7 +1184,7 @@ static void php_cli_server_logf(const char *format, ...) /* {{{ */
 	}
 
 	if (sapi_module.log_message) {
-		sapi_module.log_message(buf);
+		sapi_module.log_message(buf, -1);
 	}
 
 	efree(buf);

--- a/sapi/embed/php_embed.c
+++ b/sapi/embed/php_embed.c
@@ -94,7 +94,7 @@ static void php_embed_send_header(sapi_header_struct *sapi_header, void *server_
 {
 }
 
-static void php_embed_log_message(char *message)
+static void php_embed_log_message(char *message, int syslog_type_int)
 {
 	fprintf (stderr, "%s\n", message);
 }

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -660,7 +660,7 @@ void sapi_cgi_log_fastcgi(int level, char *message, size_t len)
 
 /* {{{ sapi_cgi_log_message
  */
-static void sapi_cgi_log_message(char *message)
+static void sapi_cgi_log_message(char *message, int syslog_type_int)
 {
 	zlog(ZLOG_NOTICE, "PHP message: %s", message);
 }

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -398,7 +398,7 @@ static int sapi_lsapi_send_headers(sapi_headers_struct *sapi_headers)
 
 /* {{{ sapi_lsapi_send_headers
  */
-static void sapi_lsapi_log_message(char *message)
+static void sapi_lsapi_log_message(char *message, int syslog_type_int)
 {
     char buf[8192];
     int len = strlen( message );

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -795,7 +795,7 @@ static void php_sapi_phpdbg_send_header(sapi_header_struct *sapi_header, void *s
 }
 /* }}} */
 
-static void php_sapi_phpdbg_log_message(char *message) /* {{{ */
+static void php_sapi_phpdbg_log_message(char *message, int syslog_type_int) /* {{{ */
 {
 	/*
 	* We must not request TSRM before being booted


### PR DESCRIPTION
As mentioned in [Enable per-module logging in Apache 2.4+](https://github.com/php/php-src/pull/1921#issuecomment-223347127) all logged messages in Apache are errors. So current log file may look like this:

```
[php7:error] [pid 25023] [client 127.0.0.1:52378] PHP Notice:  Undefined variable: ...
[php7:error] [pid 25023] [client 127.0.0.1:52418] PHP Warning:  Cannot divide by zero in ...
[php7:error] [pid 25027] [client 127.0.0.1:52388] PHP Fatal error:  Uncaught Error: Call to undefined function...
```

Messages are with corresponding error level after this change:

```
[php7:notice] [pid 25023] [client 127.0.0.1:52378] PHP Notice:  Undefined variable: ...
[php7:warn] [pid 25023] [client 127.0.0.1:52418] PHP Warning:  Cannot divide by zero in ...
[php7:error] [pid 25027] [client 127.0.0.1:52388] PHP Fatal error:  Uncaught Error: Call to undefined function...
```
