### PR TITLE
base64_decode: Fail on invalid padding and truncated input ("V" and "V=")

### DIFF
--- a/ext/openssl/tests/openssl_decrypt_error.phpt
+++ b/ext/openssl/tests/openssl_decrypt_error.phpt
@@ -7,7 +7,7 @@ openssl_decrypt() error tests
 $data = "openssl_decrypt() tests";
 $method = "AES-128-CBC";
 $password = "openssl";
-$wrong = "wrong";
+$wrong = base64_encode("wrong");
 $iv = str_repeat("\0", openssl_cipher_iv_length($method));
 
 $encrypted = openssl_encrypt($data, $method, $password);

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -152,8 +152,7 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 			/* fail if the padding character is second in a group (like V===) */
 			/* FIXME: why do we still allow invalid padding in other places in the middle of the string? */
 			if (i % 4 == 1) {
-				zend_string_free(result);
-				return NULL;
+				goto fail;
 			}
 			padding++;
 			continue;
@@ -172,8 +171,7 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 			}
 			/* fail on bad characters or if any data follows padding */
 			if (ch == -2 || padding) {
-				zend_string_free(result);
-				return NULL;
+				goto fail;
 			}
 		}
 
@@ -200,6 +198,10 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 	ZSTR_VAL(result)[ZSTR_LEN(result)] = '\0';
 
 	return result;
+
+fail:
+	zend_string_free(result);
+	return NULL;
 }
 /* }}} */
 

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -154,20 +154,13 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 		}
 
 		ch = base64_reverse_table[ch];
-		if (!strict) {
-			/* skip unknown characters and whitespace */
-			if (ch < 0) {
-				continue;
-			}
-		} else {
-			/* skip whitespace */
-			if (ch == -1) {
-				continue;
-			}
-			/* fail on bad characters */
-			if (ch == -2) {
+		/* handle unknown characters and whitespace */
+		if (ch < 0) {
+			/* strict: fail on bad characters */
+			if (strict && ch == -2) {
 				goto fail;
 			}
+			continue;
 		}
 		/* fail on bad characters or if any data follows padding */
 		if (padding) {

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -164,10 +164,14 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 			if (ch == -1) {
 				continue;
 			}
-			/* fail on bad characters or if any data follows padding */
-			if (ch == -2 || padding) {
+			/* fail on bad characters */
+			if (ch == -2) {
 				goto fail;
 			}
+		}
+		/* fail on bad characters or if any data follows padding */
+		if (padding) {
+			goto fail;
 		}
 
 		switch(i % 4) {

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -189,6 +189,10 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 	if (i % 4 == 1) {
 		goto fail;
 	}
+	/* fail if there are more than 2 padding characters */
+	if (padding > 2) {
+		goto fail;
+	}
 
 	ZSTR_LEN(result) = j;
 	ZSTR_VAL(result)[ZSTR_LEN(result)] = '\0';

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -149,11 +149,6 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 			break;
 		}
 		if (ch == base64_pad) {
-			/* fail if the padding character is second in a group (like V===) */
-			/* FIXME: why do we still allow invalid padding in other places in the middle of the string? */
-			if (i % 4 == 1) {
-				goto fail;
-			}
 			padding++;
 			continue;
 		}
@@ -192,6 +187,10 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 			break;
 		}
 		i++;
+	}
+	/* fail if the input is truncated (only one char in last group) */
+	if (i % 4 == 1) {
+		goto fail;
 	}
 
 	ZSTR_LEN(result) = j;

--- a/ext/standard/tests/url/base64_decode_variation_001.phpt
+++ b/ext/standard/tests/url/base64_decode_variation_001.phpt
@@ -95,13 +95,13 @@ Error: 8 - Undefined variable: undefined_var, %s(%d)
 Error: 8 - Undefined variable: unset_var, %s(%d)
 
 -- Arg value 0 --
-string(0) ""
+bool(false)
 
 -- Arg value 1 --
-string(0) ""
+bool(false)
 
 -- Arg value 12345 --
-string(6) "d76df8"
+bool(false)
 
 -- Arg value -2345 --
 bool(false)
@@ -148,13 +148,13 @@ string(0) ""
 string(0) ""
 
 -- Arg value true --
-string(0) ""
+bool(false)
 
 -- Arg value false --
 string(0) ""
 
 -- Arg value TRUE --
-string(0) ""
+bool(false)
 
 -- Arg value FALSE --
 string(0) ""

--- a/ext/standard/tests/url/bug47174.phpt
+++ b/ext/standard/tests/url/bug47174.phpt
@@ -15,4 +15,4 @@ var_dump($in, base64_decode($in));
 --EXPECT--
 Invalid Signature
 string(10) "Zm9v==YmFy"
-string(6) "foobar"
+bool(false)

--- a/ext/standard/tests/url/bug52327.phpt
+++ b/ext/standard/tests/url/bug52327.phpt
@@ -8,5 +8,5 @@ var_dump(
 );
 ?>
 --EXPECT--
-string(51) "The '=' symbols aren't allowed where i put them o.O"
+bool(false)
 bool(false)


### PR DESCRIPTION
@nikic said in #1923 that invalid padding handling in Base64 should be fixed as well. So here we go:

- fail if the input is truncated (1 char in last group, like "V=" or only "V") regardless of the trailing padding character
- fail if there's too much padding (>2)
- fail if there's otherwise invalid padding (mixed with data)

Personally I'm not sure if adding new failures to non-strict mode is acceptable. Another option would be to implement the above only in strict mode and simply ignore any invalid padding in non-strict mode.