### PR TITLE
Fix #70315: imagecreatefromstring() returns Server Error but page is …

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -69,6 +69,9 @@ static void php_free_ps_enc(zend_rsrc_list_entry *rsrc TSRMLS_DC);
 #endif
 
 #include <gd.h>
+#ifndef HAVE_GD_BUNDLED
+# include <gd_errors.h>
+#endif
 #include <gdfontt.h>  /* 1 Tiny font */
 #include <gdfonts.h>  /* 2 Small font */
 #include <gdfontmb.h> /* 3 Medium bold font */
@@ -1099,6 +1102,18 @@ void php_gd_error_method(int type, const char *format, va_list args)
 {
 	TSRMLS_FETCH();
 
+	switch (type) {
+		case GD_DEBUG:
+		case GD_INFO:
+		case GD_NOTICE:
+			type = E_NOTICE;
+			break;
+		case GD_WARNING:
+			type = E_WARNING;
+			break;
+		default:
+			type = E_ERROR;
+	}
 	php_verror(NULL, "", type, format, args TSRMLS_CC);
 }
 /* }}} */


### PR DESCRIPTION
…rendered

That happens because the external libgd uses other error codes than PHP
(and the bundled libgd), but the libgd error codes are simply forwarded
to php_verror(). We fix that by properly mapping libgd errors to PHP errors.

As already mentioned in [the bug report](https://bugs.php.net/bug.php?id=70315), this doesn't necessarily mean that external and bundled libgd behave identically now, but at least we avoid inconsistencies like the one reported. Fixing the bundled libgd to match external libgd is probably best done for PHP 7.1.0 only.

Another issue is that most likely some PHPTs will fail after this change (when run again an external libgd PHP build), but there are already [plenty of failing tests](https://bugs.php.net/bug.php?id=72557) in this case now (I got 43 with and without the patch).