### PR TITLE
base64_decode: Fail on invalid padding and truncated input ("V" and "V=") in strict mode

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5410,7 +5410,7 @@ PHP_FUNCTION(openssl_decrypt)
 	}
 
 	if (!(options & OPENSSL_RAW_DATA)) {
-		base64_str = php_base64_decode((unsigned char*)data, (int)data_len);
+		base64_str = php_base64_decode_ex((unsigned char*)data, (int)data_len, 1);
 		if (!base64_str) {
 			php_error_docref(NULL, E_WARNING, "Failed to base64 decode the input");
 			RETURN_FALSE;

--- a/ext/openssl/tests/openssl_decrypt_error.phpt
+++ b/ext/openssl/tests/openssl_decrypt_error.phpt
@@ -7,7 +7,7 @@ openssl_decrypt() error tests
 $data = "openssl_decrypt() tests";
 $method = "AES-128-CBC";
 $password = "openssl";
-$wrong = "wrong";
+$wrong = base64_encode("wrong");
 $iv = str_repeat("\0", openssl_cipher_iv_length($method));
 
 $encrypted = openssl_encrypt($data, $method, $password);

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -152,8 +152,7 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 			/* fail if the padding character is second in a group (like V===) */
 			/* FIXME: why do we still allow invalid padding in other places in the middle of the string? */
 			if (i % 4 == 1) {
-				zend_string_free(result);
-				return NULL;
+				goto fail;
 			}
 			padding++;
 			continue;
@@ -172,8 +171,7 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 			}
 			/* fail on bad characters or if any data follows padding */
 			if (ch == -2 || padding) {
-				zend_string_free(result);
-				return NULL;
+				goto fail;
 			}
 		}
 
@@ -200,6 +198,10 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 	ZSTR_VAL(result)[ZSTR_LEN(result)] = '\0';
 
 	return result;
+
+fail:
+	zend_string_free(result);
+	return NULL;
 }
 /* }}} */
 

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -193,6 +193,10 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 		}
 		i++;
 	}
+	/* fail if the input is truncated (only one char in last group) */
+	if (strict && i % 4 == 1) {
+		goto fail;
+	}
 
 	ZSTR_LEN(result) = j;
 	ZSTR_VAL(result)[ZSTR_LEN(result)] = '\0';

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -197,6 +197,11 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 	if (strict && i % 4 == 1) {
 		goto fail;
 	}
+	/* fail if the padding length is wrong (not VV==, VVV=), but accept zero padding
+	 * RFC 4648: "In some circumstances, the use of padding [--] is not required" */
+	if (strict && padding && (padding > 2 || (i + padding) % 4 != 0)) {
+		goto fail;
+	}
 
 	ZSTR_LEN(result) = j;
 	ZSTR_VAL(result)[ZSTR_LEN(result)] = '\0';

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -149,11 +149,6 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 			break;
 		}
 		if (ch == base64_pad) {
-			/* fail if the padding character is second in a group (like V===) */
-			/* FIXME: why do we still allow invalid padding in other places in the middle of the string? */
-			if (i % 4 == 1) {
-				goto fail;
-			}
 			padding++;
 			continue;
 		}

--- a/ext/standard/tests/file/stream_rfc2397_006.phpt
+++ b/ext/standard/tests/file/stream_rfc2397_006.phpt
@@ -26,7 +26,9 @@ NULL
 
 Warning: file_get_contents() expects parameter 1 to be a valid path, string given in %s line %d
 NULL
-string(13) "foobar foobar"
+
+Warning: file_get_contents(data:;base64,#Zm9vYmFyIGZvb2Jhcg==): failed to open stream: rfc2397: unable to decode in %sstream_rfc2397_006.php on line %d
+bool(false)
 
 Warning: file_get_contents(data:;base64,#Zm9vYmFyIGZvb2Jhc=): failed to open stream: rfc2397: unable to decode in %sstream_rfc2397_006.php on line %d
 bool(false)

--- a/ext/standard/tests/url/base64_decode_basic_001.phpt
+++ b/ext/standard/tests/url/base64_decode_basic_001.phpt
@@ -9,7 +9,7 @@ Test base64_decode() function : basic functionality - ensure all base64 alphabet
  */
 
 echo "Decode an input string containing the whole base64 alphabet:\n";
-$allbase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+$allbase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/VV==";
 var_dump(bin2hex(base64_decode($allbase64)));
 var_dump(bin2hex(base64_decode($allbase64, false)));
 var_dump(bin2hex(base64_decode($allbase64, true)));
@@ -18,7 +18,7 @@ echo "Done";
 ?>
 --EXPECTF--
 Decode an input string containing the whole base64 alphabet:
-string(96) "00108310518720928b30d38f41149351559761969b71d79f8218a39259a7a29aabb2dbafc31cb3d35db7e39ebbf3dfbf"
-string(96) "00108310518720928b30d38f41149351559761969b71d79f8218a39259a7a29aabb2dbafc31cb3d35db7e39ebbf3dfbf"
-string(96) "00108310518720928b30d38f41149351559761969b71d79f8218a39259a7a29aabb2dbafc31cb3d35db7e39ebbf3dfbf"
+string(98) "00108310518720928b30d38f41149351559761969b71d79f8218a39259a7a29aabb2dbafc31cb3d35db7e39ebbf3dfbf55"
+string(98) "00108310518720928b30d38f41149351559761969b71d79f8218a39259a7a29aabb2dbafc31cb3d35db7e39ebbf3dfbf55"
+string(98) "00108310518720928b30d38f41149351559761969b71d79f8218a39259a7a29aabb2dbafc31cb3d35db7e39ebbf3dfbf55"
 Done

--- a/ext/standard/tests/url/base64_decode_basic_003.phpt
+++ b/ext/standard/tests/url/base64_decode_basic_003.phpt
@@ -1,0 +1,118 @@
+--TEST--
+Test base64_decode() function : basic functionality - padding and whitespace
+--FILE--
+<?php
+/* Prototype  : proto string base64_decode(string str[, bool strict])
+ * Description: Decodes string using MIME base64 algorithm
+ * Source code: ext/standard/base64.c
+ * Alias to functions:
+ */
+
+echo "Test base64_decode (output as JSON):\n";
+$data = [
+	"", "=", "==", "===", "====",
+	"V", "V=", "V==", "V===", "V====",
+	"VV", "VV=", "VV==", "VV===", "VV====",
+	"VVV", "VVV=", "VVV==", "VVV===", "VVV====",
+	"VVVV", "VVVV=", "VVVV==", "VVVV===", "VVVV====",
+	"=V", "=VV", "=VVV",
+	"==V", "==VV", "==VVV",
+	"===V", "===VV", "===VVV",
+	"====V", "====VV", "====VVV",
+	"=VVV", "V=VV", "VV=V", "VVV=",
+	"=VVVV", "V=VVV", "VV=VV", "VVV=V", "VVVV=",
+	"=VVV=", "V=VV=", "VV=V=", "VVV==",
+	"\nVV", "V\nV", "VV\n",
+	"\nVV==", "V\nV==", "VV\n==", "VV=\n=", "VV==\n",
+	"*VV", "V*V", "VV*",
+	"*VV==", "V*V==", "VV*==", "VV=*=", "VV==*",
+	"\0VV==", "V\0V==", "VV\0==", "VV=\0=", "VV==\0",
+	"\0VVV==", "V\0VV==", "VV\0V==", "VVV\0==", "VVV=\0=", "VVV==\0",
+];
+foreach ($data as $a) {
+	$b = base64_decode($a, false);
+	$c = base64_decode($a, true);
+	printf("base64 %-16s non-strict %-8s strict %s\n", json_encode($a), json_encode($b), json_encode($c));
+}
+echo "Done\n";
+?>
+--EXPECTF--
+Test base64_decode (output as JSON):
+base64 ""               non-strict ""       strict ""
+base64 "="              non-strict ""       strict false
+base64 "=="             non-strict ""       strict false
+base64 "==="            non-strict ""       strict false
+base64 "===="           non-strict ""       strict false
+base64 "V"              non-strict ""       strict false
+base64 "V="             non-strict ""       strict false
+base64 "V=="            non-strict ""       strict false
+base64 "V==="           non-strict ""       strict false
+base64 "V===="          non-strict ""       strict false
+base64 "VV"             non-strict "U"      strict "U"
+base64 "VV="            non-strict "U"      strict false
+base64 "VV=="           non-strict "U"      strict "U"
+base64 "VV==="          non-strict "U"      strict false
+base64 "VV===="         non-strict "U"      strict false
+base64 "VVV"            non-strict "UU"     strict "UU"
+base64 "VVV="           non-strict "UU"     strict "UU"
+base64 "VVV=="          non-strict "UU"     strict false
+base64 "VVV==="         non-strict "UU"     strict false
+base64 "VVV===="        non-strict "UU"     strict false
+base64 "VVVV"           non-strict "UUU"    strict "UUU"
+base64 "VVVV="          non-strict "UUU"    strict false
+base64 "VVVV=="         non-strict "UUU"    strict false
+base64 "VVVV==="        non-strict "UUU"    strict false
+base64 "VVVV===="       non-strict "UUU"    strict false
+base64 "=V"             non-strict ""       strict false
+base64 "=VV"            non-strict "U"      strict false
+base64 "=VVV"           non-strict "UU"     strict false
+base64 "==V"            non-strict ""       strict false
+base64 "==VV"           non-strict "U"      strict false
+base64 "==VVV"          non-strict "UU"     strict false
+base64 "===V"           non-strict ""       strict false
+base64 "===VV"          non-strict "U"      strict false
+base64 "===VVV"         non-strict "UU"     strict false
+base64 "====V"          non-strict ""       strict false
+base64 "====VV"         non-strict "U"      strict false
+base64 "====VVV"        non-strict "UU"     strict false
+base64 "=VVV"           non-strict "UU"     strict false
+base64 "V=VV"           non-strict "UU"     strict false
+base64 "VV=V"           non-strict "UU"     strict false
+base64 "VVV="           non-strict "UU"     strict "UU"
+base64 "=VVVV"          non-strict "UUU"    strict false
+base64 "V=VVV"          non-strict "UUU"    strict false
+base64 "VV=VV"          non-strict "UUU"    strict false
+base64 "VVV=V"          non-strict "UUU"    strict false
+base64 "VVVV="          non-strict "UUU"    strict false
+base64 "=VVV="          non-strict "UU"     strict false
+base64 "V=VV="          non-strict "UU"     strict false
+base64 "VV=V="          non-strict "UU"     strict false
+base64 "VVV=="          non-strict "UU"     strict false
+base64 "\nVV"           non-strict "U"      strict "U"
+base64 "V\nV"           non-strict "U"      strict "U"
+base64 "VV\n"           non-strict "U"      strict "U"
+base64 "\nVV=="         non-strict "U"      strict "U"
+base64 "V\nV=="         non-strict "U"      strict "U"
+base64 "VV\n=="         non-strict "U"      strict "U"
+base64 "VV=\n="         non-strict "U"      strict "U"
+base64 "VV==\n"         non-strict "U"      strict "U"
+base64 "*VV"            non-strict "U"      strict false
+base64 "V*V"            non-strict "U"      strict false
+base64 "VV*"            non-strict "U"      strict false
+base64 "*VV=="          non-strict "U"      strict false
+base64 "V*V=="          non-strict "U"      strict false
+base64 "VV*=="          non-strict "U"      strict false
+base64 "VV=*="          non-strict "U"      strict false
+base64 "VV==*"          non-strict "U"      strict false
+base64 "\u0000VV=="     non-strict ""       strict false
+base64 "V\u0000V=="     non-strict ""       strict false
+base64 "VV\u0000=="     non-strict "U"      strict false
+base64 "VV=\u0000="     non-strict "U"      strict false
+base64 "VV==\u0000"     non-strict "U"      strict false
+base64 "\u0000VVV=="    non-strict ""       strict false
+base64 "V\u0000VV=="    non-strict ""       strict false
+base64 "VV\u0000V=="    non-strict "U"      strict false
+base64 "VVV\u0000=="    non-strict "UU"     strict false
+base64 "VVV=\u0000="    non-strict "UU"     strict false
+base64 "VVV==\u0000"    non-strict "UU"     strict false
+Done

--- a/ext/standard/tests/url/base64_decode_variation_001.phpt
+++ b/ext/standard/tests/url/base64_decode_variation_001.phpt
@@ -95,13 +95,13 @@ Error: 8 - Undefined variable: undefined_var, %s(%d)
 Error: 8 - Undefined variable: unset_var, %s(%d)
 
 -- Arg value 0 --
-string(0) ""
+bool(false)
 
 -- Arg value 1 --
-string(0) ""
+bool(false)
 
 -- Arg value 12345 --
-string(6) "d76df8"
+bool(false)
 
 -- Arg value -2345 --
 bool(false)
@@ -148,13 +148,13 @@ string(0) ""
 string(0) ""
 
 -- Arg value true --
-string(0) ""
+bool(false)
 
 -- Arg value false --
 string(0) ""
 
 -- Arg value TRUE --
-string(0) ""
+bool(false)
 
 -- Arg value FALSE --
 string(0) ""

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -720,7 +720,7 @@ static php_stream * php_stream_url_wrap_rfc2397(php_stream_wrapper *wrapper, con
 	dlen--;
 
 	if (base64) {
-		base64_comma = php_base64_decode((const unsigned char *)comma, dlen);
+		base64_comma = php_base64_decode_ex((const unsigned char *)comma, dlen, 1);
 		if (!base64_comma) {
 			zval_ptr_dtor(&meta);
 			php_stream_wrapper_log_error(wrapper, options, "rfc2397: unable to decode");


### PR DESCRIPTION
This PR fixes remaining Base64 padding issues (as suggested by @nikic in #1923). This is a more conservative alternative to #1988:
- strict mode fails if the input is truncated (1 char in last group, like a single "V") regardless of the trailing padding character
- strict mode fails if there's too much padding (>2)
- non-strict mode becomes actually a bit more accepting, since all invalid padding is equally ignored