### PR TITLE
Implement RFC "Deprecate mb_ereg_replace eval option"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,9 @@ PHP                                                                        NEWS
   . Fixed bug #71745 (FILTER_FLAG_NO_RES_RANGE does not cover whole 127.0.0.0/8
     range). (bugs dot php dot net at majkl578 dot cz)
 
+- Mbstring:
+  . Deprecated mb_ereg_replace() eval option. (Rouven Weßling, cmb)
+
 - PDO_pgsql:
   . Fixed bug #70313 (PDO statement fails to throw exception). (Matteo)
   . Fixed bug #72570 (Segmentation fault when binding parameters on a query

--- a/UPGRADING
+++ b/UPGRADING
@@ -93,6 +93,8 @@ PHP 7.1 UPGRADE NOTES
 4. Deprecated Functionality
 ========================================
 
+- 'e' option of mb_ereg_replace() and mb_eregi_replace().
+
 ========================================
 5. Changed Functions
 ========================================

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -855,6 +855,9 @@ static void _php_mb_regex_ereg_replace_exec(INTERNAL_FUNCTION_PARAMETERS, OnigOp
 			syntax = MBREX(regex_default_syntax);
 		}
 	}
+	if (eval && !is_callable) {
+		php_error_docref(NULL, E_DEPRECATED, "The 'e' option is deprecated, use mb_ereg_replace_callback instead");
+	}
 	if (Z_TYPE_P(arg_pattern_zval) == IS_STRING) {
 		arg_pattern = Z_STRVAL_P(arg_pattern_zval);
 		arg_pattern_len = Z_STRLEN_P(arg_pattern_zval);

--- a/ext/mbstring/tests/bug43301.phpt
+++ b/ext/mbstring/tests/bug43301.phpt
@@ -15,6 +15,8 @@ echo mb_ereg_replace($ptr,'$1',$txt,'e');
 
 ?>
 --EXPECTF--
+Deprecated: mb_ereg_replace(): The 'e' option is deprecated, use mb_ereg_replace_callback instead in %s%ebug43301.php on line %d
+
 Fatal error: Uncaught ParseError: syntax error, unexpected '1' (T_LNUMBER), expecting variable (T_VARIABLE) or '{' or '$' in %sbug43301.php(%d) : mbregex replace:1
 Stack trace:
 #0 %sbug43301.php(%d): mb_ereg_replace('hello', '$1', 'hello, I have g...', 'e')

--- a/ext/mbstring/tests/bug72164.phpt
+++ b/ext/mbstring/tests/bug72164.phpt
@@ -10,5 +10,6 @@ $var3 = NULL;
 $var8 = mbereg_replace($var2,$var3,$var3,$var0);
 var_dump($var8);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: mbereg_replace(): The 'e' option is deprecated, use mb_ereg_replace_callback instead in %s%ebug72164.php on line %d
 string(0) ""


### PR DESCRIPTION
<https://wiki.php.net/rfc/deprecate_mb_ereg_replace_eval_option> has been
accepted, so we implement it.

@realityking Please review. :)
