### PR TITLE
Fix #72575: using --allow-to-run-as-root should ignore missing user directive

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -763,8 +763,8 @@ static int fpm_conf_process_all_pools() /* {{{ */
 			}
 		}
 
-		/* alert if user is not set only if we are not root*/
-		if (!wp->config->user && !geteuid()) {
+		/* alert if user is not set; only if we are root and fpm is not running with --allow-to-run-as-root */
+		if (!wp->config->user && !geteuid() && !fpm_globals.run_as_root) {
 			zlog(ZLOG_ALERT, "[pool %s] user has not been defined", wp->config->name);
 			return -1;
 		}


### PR DESCRIPTION
Trying to start PHP-FPM with the --allow-to-run-as-root flag will not
work when the user directive is not given in the FPM worker pool
configuration. Parsing the config will fail. Consequently, FPM cannot
start.

The check is in place to prevent FPM from getting started with root
privileges by accident. Prior to #61295 the check would also prevent
any non-root user to start PHP-FPM without a user directive present.

This patch adds an additional check to the config parser, checking for
the --allow-to-run-as-root flag to be present. If so, parsing will no
longer abort for root users even if the user directive is missing.

I will also update the PHP docs since they still state the user
directive is a mandatory setting which it is not since #61295.