### PR TITLE
Output encoding empty defaults

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -689,7 +689,6 @@ default_charset = "UTF-8"
 
 ; PHP output character encoding is set to empty.
 ; If empty, default_charset is used.
-; mbstring or iconv output handler is used.
 ; See also output_buffer.
 ; http://php.net/output-encoding
 ;output_encoding =

--- a/php.ini-production
+++ b/php.ini-production
@@ -689,7 +689,6 @@ default_charset = "UTF-8"
 
 ; PHP output character encoding is set to empty.
 ; If empty, default_charset is used.
-; mbstring or iconv output handler is used.
 ; See also output_buffer.
 ; http://php.net/output-encoding
 ;output_encoding =


### PR DESCRIPTION
It looks like there was some left over sentence in the ini's that don't belong there about `mbstring or iconv output handler is used` when leaving the `output_encoding` empty.

The correct behavior was already in the comment above it as per https://wiki.php.net/rfc/default_encoding