### PR TITLE
FR #72614: Enable 'nmake test' on building extensions

### DIFF
--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -195,6 +195,7 @@ build-lib: build-ext-libs
 build-devel: build-headers build-lib
 	@if not exist $(BUILD_DIR_DEV)\script mkdir $(BUILD_DIR_DEV)\script >nul
 	@if not exist $(BUILD_DIR_DEV)\build mkdir $(BUILD_DIR_DEV)\build >nul
+	@copy run-tests.php $(BUILD_DIR_DEV)\script\ /y >nul
 	@copy win32\build\confutils.js $(BUILD_DIR_DEV)\script\ /y >nul
 	@copy win32\build\configure.tail $(BUILD_DIR_DEV)\script\ /y >nul
 	@copy win32\build\config.w32.phpize.in $(BUILD_DIR_DEV)\script\ /y >nul

--- a/win32/build/Makefile.phpize
+++ b/win32/build/Makefile.phpize
@@ -28,6 +28,15 @@ clean: clean-pecl
 	@for %D in (_x $(BUILD_DIRS_SUB)) do @if exist %D @del /F /Q %D\*.* > NUL
 	-@del /F /Q $(BUILD_DIR)\*.res $(BUILD_DIR)\*.lib $(BUILD_DIR)\*.ilk $(BUILD_DIR)\*.pdb $(BUILD_DIR)\*.exp $(PHPDEF) $(BUILD_DIR)\php-$(PHP_VERSION_STRING)-Win32.zip $(BUILD_DIR)\pecl-$(PHP_VERSION_STRING)-Win32.zip > NUL
 
+!if "$(EXT_TARGETS)" == ""
+_EXTENSION_DLL=$(PECL_TARGETS)
+!else
+_EXTENSION_DLL=$(EXT_TARGETS)
+!endif
+
+test:
+	"$(PHP_PREFIX)\php.exe" -d open_basedir= -d output_buffering=0 run-tests.php $(TESTS) -p "$(PHP_PREFIX)\php.exe" -d extension=$(BUILD_DIR)\$(_EXTENSION_DLL)
+
 !if $(MT) == ""
 _VC_MANIFEST_EMBED_EXE=
 _VC_MANIFEST_EMBED_DLL=

--- a/win32/build/phpize.js.in
+++ b/win32/build/phpize.js.in
@@ -262,3 +262,5 @@ C.Write(file_get_contents(PHP_DIR + "\\script\\configure.tail"));
 
 B.WriteLine("@echo off");
 B.WriteLine("cscript /nologo configure.js %*");
+
+FSO.CopyFile(PHP_DIR + "\\script\\run-tests.php", "run-tests.php", true);


### PR DESCRIPTION
On Windows, Makefile generated by phpize doesn't have the 'test'
target rule. This commit fixes that and enables 'nmake test' on
Windows.