### PR TITLE
Implement #51103: a warning should be displayed if there is a pcre error

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -100,6 +100,7 @@ static void pcre_handle_exec_error(int pcre_code) /* {{{ */
 			break;
 	}
 
+	php_error_docref(NULL, E_NOTICE, "PCRE error %d", preg_code);
 	PCRE_G(error_code) = preg_code;
 }
 /* }}} */

--- a/ext/pcre/tests/006.phpt
+++ b/ext/pcre/tests/006.phpt
@@ -18,8 +18,11 @@ var_dump($result);
 echo "Done\n";
 ?>
 --EXPECTF--	
+Notice: preg_replace(): PCRE error 2 in %s%e006.php on line %d
 string(58) "[CODE]&lt;td align=&quot;$stylevar[right]&quot;&gt;[/CODE]"
 NULL
+
+Notice: preg_replace(): PCRE error 2 in %s%e006.php on line %d
 string(58) "[CODE]&lt;td align=&quot;$stylevar[right]&quot;&gt;[/CODE]"
 NULL
 Done

--- a/ext/pcre/tests/007.phpt
+++ b/ext/pcre/tests/007.phpt
@@ -26,7 +26,7 @@ var_dump(preg_last_error() == PREG_BAD_UTF8_ERROR);
 
 echo "Done!\n";
 ?>
---EXPECT--
+--EXPECTF--
 array(1) {
   [0]=>
   string(1) "o"
@@ -54,6 +54,8 @@ array(1) {
 string(6) "ola123"
 string(6) "olaÿ23"
 bool(true)
+
+Notice: preg_replace_callback(): PCRE error 4 in %s%e007.php on line %d
 NULL
 bool(true)
 Done!

--- a/ext/pcre/tests/backtrack_limit.phpt
+++ b/ext/pcre/tests/backtrack_limit.phpt
@@ -19,7 +19,8 @@ var_dump(preg_match_all('/\p{Nd}/', '0123456789', $dummy));
 var_dump(preg_last_error() === PREG_NO_ERROR);
 
 ?>
---EXPECT--
+--EXPECTF--
+Notice: preg_match_all(): PCRE error 2 in %s%ebacktrack_limit.php on line %d
 bool(false)
 bool(true)
 int(10)

--- a/ext/pcre/tests/bug52732.phpt
+++ b/ext/pcre/tests/bug52732.phpt
@@ -9,5 +9,6 @@ $ret = preg_match('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar');
 var_dump($ret);
 
 ?>
---EXPECT--
+--EXPECTF--
+Notice: preg_match(): PCRE error 2 in %s%ebug52732.php on line %d
 bool(false)

--- a/ext/pcre/tests/bug53823.phpt
+++ b/ext/pcre/tests/bug53823.phpt
@@ -7,7 +7,11 @@ var_dump(preg_replace('/[^\pL\pM]*/iu', '', 'áéíóú'));
 var_dump(preg_replace('/[^\pL\pM]*/iu', '', "\xFCáéíóú"));
 var_dump(preg_replace('/[^\pL\pM]*/iu', '', "áéíóú\xFC"));
 ?>
---EXPECT--
+--EXPECTF--
 string(10) "áéíóú"
+
+Notice: preg_replace(): PCRE error 4 in %s%ebug53823.php on line %d
 NULL
+
+Notice: preg_replace(): PCRE error 4 in %s%ebug53823.php on line %d
 NULL

--- a/ext/pcre/tests/bug66121.phpt
+++ b/ext/pcre/tests/bug66121.phpt
@@ -17,7 +17,7 @@ var_dump(preg_replace('/(?<!ක)/u', '*', "ක\xFC"));
 var_dump(preg_match_all('/(?<!ක)/u', "\xFCම", $matches, PREG_OFFSET_CAPTURE));
 var_dump(preg_match_all('/(?<!ක)/u', "\xFCම", $matches, PREG_OFFSET_CAPTURE));
 ?>
---EXPECT--
+--EXPECTF--
 string(4) "*ක"
 string(5) "*ම*"
 string(2) "*k"
@@ -41,7 +41,15 @@ array(1) {
     }
   }
 }
+
+Notice: preg_replace(): PCRE error 4 in %s%ebug66121.php on line %d
 NULL
+
+Notice: preg_replace(): PCRE error 4 in %s%ebug66121.php on line %d
 NULL
+
+Notice: preg_match_all(): PCRE error 4 in %s%ebug66121.php on line %d
 bool(false)
+
+Notice: preg_match_all(): PCRE error 4 in %s%ebug66121.php on line %d
 bool(false)

--- a/ext/pcre/tests/bug70345.phpt
+++ b/ext/pcre/tests/bug70345.phpt
@@ -14,6 +14,7 @@ preg_match($regex, $subject, $matches);
 
 var_dump($matches);
 --EXPECTF--
+Notice: preg_split(): PCRE error 1 in %s%ebug70345.php on line %d
 Array
 (
     [0] => aaaaxyzaaaa

--- a/ext/pcre/tests/invalid_utf8.phpt
+++ b/ext/pcre/tests/invalid_utf8.phpt
@@ -16,7 +16,8 @@ var_dump(preg_last_error());
 
 echo "Done\n";
 ?>
---EXPECT--	
+--EXPECTF--
+Notice: preg_replace(): PCRE error 4 in %s%einvalid_utf8.php on line %d
 NULL
 int(4)
 Done

--- a/ext/pcre/tests/invalid_utf8_offset.phpt
+++ b/ext/pcre/tests/invalid_utf8_offset.phpt
@@ -21,7 +21,8 @@ var_dump(preg_last_error() == PREG_NO_ERROR);
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
+Notice: preg_match(): PCRE error 5 in %s%einvalid_utf8_offset.php on line %d
 bool(false)
 array(0) {
 }

--- a/ext/pcre/tests/preg_match_error3.phpt
+++ b/ext/pcre/tests/preg_match_error3.phpt
@@ -5,6 +5,7 @@ Test preg_match() function : error conditions - jit stacklimit exhausted
 var_dump(preg_match('/^(foo)+$/', str_repeat('foo', 1024*8192)));
 var_dump(preg_last_error() === PREG_JIT_STACKLIMIT_ERROR);
 ?>
---EXPECT--
+--EXPECTF--
+Notice: preg_match(): PCRE error 6 in %s%epreg_match_error3.php on line %d
 bool(false)
 bool(true)

--- a/ext/pcre/tests/recursion_limit.phpt
+++ b/ext/pcre/tests/recursion_limit.phpt
@@ -19,7 +19,8 @@ var_dump(preg_match_all('/\p{Ll}\p{L}\p{Ll}\p{Ll}/', 'aeiou', $dummy));
 var_dump(preg_last_error() === PREG_NO_ERROR);
 
 ?>
---EXPECT--
+--EXPECTF--
+Notice: preg_match_all(): PCRE error 3 in %s%erecursion_limit.php on line %d
 bool(false)
 bool(true)
 int(1)

--- a/ext/pcre/tests/split2.phpt
+++ b/ext/pcre/tests/split2.phpt
@@ -310,6 +310,8 @@ array(6) {
 Warning: preg_last_error() expects exactly 0 parameters, 1 given in %s on line %d
 NULL
 bool(true)
+
+Notice: preg_split(): PCRE error 3 in %s%esplit2.php on line %d
 array(1) {
   [0]=>
   string(6) "ab2c3u"


### PR DESCRIPTION
As it's now, preg_*() may silently fail, and the developer would have to
explicitly check preg_last_error(). Raising a warning additionally appears
to be helpful for development and debugging.

As E_WARNING might be regarded too heavy a BC break, E_NOTICE appears to
be reasonable to mitigate BC concerns.