### PR TITLE
Fix #72641 Make phpize use PHP_PREFIX as the default location (windows)

### DIFF
--- a/win32/build/config.w32.phpize.in
+++ b/win32/build/config.w32.phpize.in
@@ -40,7 +40,7 @@ DEFINE("BASE_INCLUDES", "/I " + PHP_DIR + "/include /I " + PHP_DIR + "/include/m
 
 toolset_setup_common_cflags();
 
-ARG_WITH('prefix', 'PHP installation prefix', '');
+ARG_WITH('prefix', 'PHP installation prefix', PHP_PREFIX);
 ARG_WITH('mp', 'Tell Visual Studio use up to [n,auto,disable] processes for compilation', 'auto');
 var PHP_MP_DISABLED = true;
 if (VS_TOOLSET && PHP_MP != 'disable') {


### PR DESCRIPTION
The default path to where an extension is installed should be
PHP_PREFIX/ext on windows.