### PR TITLE
Implement #32803: Add animated GIF support

### DIFF
--- a/ext/gd/libgd/gd.h
+++ b/ext/gd/libgd/gd.h
@@ -611,6 +611,38 @@ gdImagePtr gdImageCreateFromGif(FILE *fd);
 gdImagePtr gdImageCreateFromGifCtx(gdIOCtxPtr in);
 gdImagePtr gdImageCreateFromGifSource(gdSourcePtr in);
 
+/**
+ * Group: GifAnim
+ *
+ *   Legal values for Disposal. gdDisposalNone is always used by
+ *   the built-in optimizer if previm is passed.
+ *
+ * Constants: gdImageGifAnim
+ *
+ *   gdDisposalUnknown              - Not recommended
+ *   gdDisposalNone                 - Preserve previous frame
+ *   gdDisposalRestoreBackground    - First allocated color of palette
+ *   gdDisposalRestorePrevious      - Restore to before start of frame
+ *
+ * See also: <gdImageGifAnimAdd>
+ */
+enum {
+	gdDisposalUnknown,
+	gdDisposalNone,
+	gdDisposalRestoreBackground,
+	gdDisposalRestorePrevious
+};
+
+void gdImageGifAnimBegin(gdImagePtr im, FILE *outFile, int GlobalCM, int Loops);
+void gdImageGifAnimAdd(gdImagePtr im, FILE *outFile, int LocalCM, int LeftOfs, int TopOfs, int Delay, int Disposal, gdImagePtr previm);
+void gdImageGifAnimEnd(FILE *outFile);
+void gdImageGifAnimBeginCtx(gdImagePtr im, gdIOCtx *out, int GlobalCM, int Loops);
+void gdImageGifAnimAddCtx(gdImagePtr im, gdIOCtx *out, int LocalCM, int LeftOfs, int TopOfs, int Delay, int Disposal, gdImagePtr previm);
+void gdImageGifAnimEndCtx(gdIOCtx *out);
+void * gdImageGifAnimBeginPtr(gdImagePtr im, int *size, int GlobalCM, int Loops);
+void * gdImageGifAnimAddPtr(gdImagePtr im, int *size, int LocalCM, int LeftOfs, int TopOfs, int Delay, int Disposal, gdImagePtr previm);
+void * gdImageGifAnimEndPtr(int *size);
+
 /* A custom data sink. For backwards compatibility. Use
 	gdIOCtx instead. */
 /* The sink function must return -1 on error, otherwise the number

--- a/ext/gd/libgd/gd_gif_out.c
+++ b/ext/gd/libgd/gd_gif_out.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "gd.h"
+#include "gdhelpers.h"
 
 /* Code drawn from ppmtogif.c, from the pbmplus package
 **
@@ -90,6 +91,7 @@ static int colorstobpp(int colors);
 static void BumpPixel (GifCtx *ctx);
 static int GIFNextPixel (gdImagePtr im, GifCtx *ctx);
 static void GIFEncode (gdIOCtxPtr fp, int GWidth, int GHeight, int GInterlace, int Background, int Transparent, int BitsPerPixel, int *Red, int *Green, int *Blue, gdImagePtr im);
+static void GIFAnimEncode(gdIOCtxPtr fp, int IWidth, int IHeight, int LeftOfs, int TopOfs, int GInterlace, int Transparent, int Delay, int Disposal, int BitsPerPixel, int *Red, int *Green, int *Blue, gdImagePtr im);
 static void compress (int init_bits, gdIOCtx *outfile, gdImagePtr im, GifCtx *ctx);
 static void output (code_int code, GifCtx *ctx);
 static void cl_block (GifCtx *ctx);
@@ -138,6 +140,691 @@ void gdImageGifCtx(gdImagePtr im, gdIOCtxPtr out)
 		/* Destroy palette based temporary image. */
 		gdImageDestroy(	pim);
 	}
+}
+
+/*
+  Function: gdImageGifAnimBeginPtr
+
+    Like <gdImageGifAnimBegin> except that it outputs to a memory
+    buffer.  See <gdImageGifAnimBegin>.
+
+    The returned memory must be freed by the caller when it is no
+    longer needed. **The caller must invoke <gdFree>(), not free()**,
+    unless the caller is absolutely certain that the same
+    implementations of malloc, free, etc. are used both at library
+    build time and at application build time (but don't; it could
+    always change).
+
+    The 'size' parameter receives the total size of the block of
+    memory.
+
+  Parameters:
+
+    im          - The reference image
+    size        - Output: the size in bytes of the result.
+    GlobalCM    - Global colormap flag: 1 -> yes, 0 -> no, -1 -> do default
+    Loops       - Loop count; 0 -> infinite, -1 means no loop
+
+  Returns:
+
+   A pointer to the resulting data (the contents of the start of the
+   GIF) or NULL if an error occurred.
+
+*/
+
+void * gdImageGifAnimBeginPtr(gdImagePtr im, int *size, int GlobalCM, int Loops)
+{
+	void *rv;
+	gdIOCtx *out = gdNewDynamicCtx(2048, NULL);
+	if (out == NULL) return NULL;
+	gdImageGifAnimBeginCtx(im, out, GlobalCM, Loops);
+	rv = gdDPExtractData(out, size);
+	out->gd_free(out);
+	return rv;
+}
+
+
+/*
+  Function: gdImageGifAnimBegin
+
+    This function must be called as the first function when creating a
+    GIF animation. It writes the correct GIF file headers to selected
+    file output, and prepares for frames to be added for the
+    animation. The image argument is not used to produce an image
+    frame to the file, it is only used to establish the GIF animation
+    frame size, interlacing options and the color
+    palette. <gdImageGifAnimAdd> is used to add the first and
+    subsequent frames to the animation, and the animation must be
+    terminated by writing a semicolon character (;) to it or by using
+    gdImageGifAnimEnd to do that.
+
+    The GlobalCM flag indicates if a global color map (or palette) is
+    used in the GIF89A header. A nonzero value specifies that a global
+    color map should be used to reduce the size of the animation. Of
+    course, if the color maps of individual frames differ greatly, a
+    global color map may not be a good idea. GlobalCM=1 means write
+    global color map, GlobalCM=0 means do not, and GlobalCM=-1 means
+    to do the default, which currently is to use a global color map.
+
+    If Loops is 0 or greater, the Netscape 2.0 extension for animation
+    loop count is written. 0 means infinite loop count. -1 means that
+    the extension is not added which results in no looping. -1 is the
+    default.
+
+  Variants:
+
+    <gdImageGifAnimBeginCtx> outputs the image via a <gdIOCtx> struct.
+
+    <gdImageGifAnimBeginPtr> stores the image in a large array of bytes.
+
+  Parameters:
+
+    im          - The reference image
+    outfile     - The output FILE*.
+    GlobalCM    - Global colormap flag: 1 -> yes, 0 -> no, -1 -> do default
+    Loops       - Loop count; 0 -> infinite, -1 means no loop
+
+  Returns:
+
+    Nothing.
+
+  Example:
+
+    See <gdImageGifAnimBegin>.
+
+*/
+
+void gdImageGifAnimBegin(gdImagePtr im, FILE *outFile, int GlobalCM, int Loops)
+{
+	gdIOCtx *out = gdNewFileCtx(outFile);
+	if (out == NULL) return;
+	gdImageGifAnimBeginCtx(im, out, GlobalCM, Loops);
+	out->gd_free(out);
+}
+
+
+
+/*
+  Function: gdImageGifAnimBeginCtx
+
+    Like <gdImageGifAnimBegin> except that it outputs to <gdIOCtx>.
+    See <gdImageGifAnimBegin>.
+
+  Parameters:
+
+    im          - The reference image
+    out         - Pointer to the output <gdIOCtx>.
+    GlobalCM    - Global colormap flag: 1 -> yes, 0 -> no, -1 -> do default
+    Loops       - Loop count; 0 -> infinite, -1 means no loop
+
+  Returns:
+
+    Nothing.
+
+*/
+void gdImageGifAnimBeginCtx(gdImagePtr im, gdIOCtxPtr out, int GlobalCM, int Loops)
+{
+	int B;
+	int RWidth, RHeight;
+	int Resolution;
+	int ColorMapSize;
+	int BitsPerPixel;
+	int Background = 0;
+	int i;
+
+	/* Default is to use global color map */
+	if (GlobalCM < 0) {
+		GlobalCM = 1;
+	}
+
+	BitsPerPixel = colorstobpp(im->colorsTotal);
+	ColorMapSize = 1 << BitsPerPixel;
+
+	RWidth = im->sx;
+	RHeight = im->sy;
+
+	Resolution = BitsPerPixel;
+
+	/* Write the Magic header */
+	gdPutBuf("GIF89a", 6, out);
+
+	/* Write out the screen width and height */
+	gifPutWord(RWidth, out);
+	gifPutWord(RHeight, out);
+
+	/* Indicate that there is a global colour map */
+	B = GlobalCM ? 0x80 : 0;
+
+	/* OR in the resolution */
+	B |= (Resolution - 1) << 4;
+
+	/* OR in the Bits per Pixel */
+	B |= (BitsPerPixel - 1);
+
+	/* Write it out */
+	gdPutC(B, out);
+
+	/* Write out the Background colour */
+	gdPutC(Background, out);
+
+	/* Byte of 0's (future expansion) */
+	gdPutC(0, out);
+
+	/* Write out the Global Colour Map */
+	if(GlobalCM) {
+		for(i = 0; i < ColorMapSize; ++i) {
+			gdPutC(im->red[i], out);
+			gdPutC(im->green[i], out);
+			gdPutC(im->blue[i], out);
+		}
+	}
+
+	if(Loops >= 0) {
+		gdPutBuf("!\377\13NETSCAPE2.0\3\1", 16, out);
+		gifPutWord(Loops, out);
+		gdPutC(0, out);
+	}
+}
+
+
+
+/*
+  Function: gdImageGifAnimAddPtr
+
+    Like <gdImageGifAnimAdd> (which contains more information) except
+    that it stores the data to write into memory and returns a pointer
+    to it.
+
+    This memory must be freed by the caller when it is no longer
+    needed. **The caller must invoke <gdFree>(), not free(),** unless
+    the caller is absolutely certain that the same implementations of
+    malloc, free, etc. are used both at library build time and at
+    application build time (but don't; it could always change).
+
+    The 'size' parameter receives the total size of the block of
+    memory.
+
+  Parameters:
+
+    im          - The image to add.
+    size        - Output: the size of the resulting buffer.
+    LocalCM     - Flag.  If 1, use a local color map for this frame.
+    LeftOfs     - Left offset of image in frame.
+    TopOfs      - Top offset of image in frame.
+    Delay       - Delay before next frame (in 1/100 seconds)
+    Disposal    - MODE: How to treat this frame when the next one loads.
+    previm      - NULL or a pointer to the previous image written.
+
+  Returns:
+
+    Pointer to the resulting data or NULL if an error occurred.
+
+*/
+void * gdImageGifAnimAddPtr(gdImagePtr im, int *size, int LocalCM,
+                                         int LeftOfs, int TopOfs, int Delay,
+                                         int Disposal, gdImagePtr previm)
+{
+	void *rv;
+	gdIOCtx *out = gdNewDynamicCtx(2048, NULL);
+	if (out == NULL) return NULL;
+	gdImageGifAnimAddCtx(im, out, LocalCM, LeftOfs, TopOfs, Delay, Disposal, previm);
+	rv = gdDPExtractData(out, size);
+	out->gd_free(out);
+	return rv;
+}
+
+
+/*
+  Function: gdImageGifAnimAdd
+
+    This function writes GIF animation frames to GIF animation, which
+    was initialized with <gdImageGifAnimBegin>. With _LeftOfs_ and
+    _TopOfs_ you can place this frame in different offset than (0,0)
+    inside the image screen as defined in <gdImageGifAnimBegin>. Delay
+    between the previous frame and this frame is in 1/100s
+    units. _Disposal_ is usually <gdDisposalNone>, meaning that the
+    pixels changed by this frame should remain on the display when the
+    next frame begins to render, but can also be <gdDisposalUnknown>
+    (not recommended), <gdDisposalRestoreBackground> (restores the
+    first allocated color of the global palette), or
+    <gdDisposalRestorePrevious> (restores the appearance of the
+    affected area before the frame was rendered). Only
+    <gdDisposalNone> is a sensible choice for the first frame. If
+    _previm_ is passed, the built-in GIF optimizer will always use
+    <gdDisposalNone> regardless of the Disposal parameter.
+
+    Setting the _LocalCM_ flag to 1 adds a local palette for this
+    image to the animation. Otherwise the global palette is assumed
+    and the user must make sure the palettes match. Use
+    <gdImagePaletteCopy> to do that.
+
+    Automatic optimization is activated by giving the previous image
+    as a parameter. This function then compares the images and only
+    writes the changed pixels to the new frame in animation. The
+    _Disposal_ parameter for optimized animations must be set to 1,
+    also for the first frame. _LeftOfs_ and _TopOfs_ parameters are
+    ignored for optimized frames. To achieve good optimization, it is
+    usually best to use a single global color map. To allow
+    <gdImageGifAnimAdd> to compress unchanged pixels via the use of a
+    transparent color, the image must include a transparent color.
+
+
+  Variants:
+
+    <gdImageGifAnimAddCtx> outputs its data via a <gdIOCtx> struct.
+
+    <gdImageGifAnimAddPtr> outputs its data to a memory buffer which
+    it returns.
+
+  Parameters:
+
+    im          - The image to add.
+    outfile     - The output FILE* being written.
+    LocalCM     - Flag.  If 1, use a local color map for this frame.
+    LeftOfs     - Left offset of image in frame.
+    TopOfs      - Top offset of image in frame.
+    Delay       - Delay before next frame (in 1/100 seconds)
+    Disposal    - MODE: How to treat this frame when the next one loads.
+    previm      - NULL or a pointer to the previous image written.
+
+  Returns:
+
+    Nothing.
+
+  Example:
+
+    > {
+    > gdImagePtr im, im2, im3;
+    > int black, white, trans;
+    > FILE *out;
+    >
+    > im = gdImageCreate(100, 100);     // Create the image
+    > white = gdImageColorAllocate(im, 255, 255, 255); // Allocate background
+    > black = gdImageColorAllocate(im, 0, 0, 0); // Allocate drawing color
+    > trans = gdImageColorAllocate(im, 1, 1, 1); // trans clr for compression
+    > gdImageRectangle(im, 0, 0, 10, 10, black); // Draw rectangle
+    >
+    > out = fopen("anim.gif", "wb");// Open output file in binary mode
+    > gdImageGifAnimBegin(im, out, 1, 3);// Write GIF hdr, global clr map,loops
+    > // Write the first frame.  No local color map.  Delay = 1s
+    > gdImageGifAnimAdd(im, out, 0, 0, 0, 100, 1, NULL);
+    >
+    > // construct the second frame
+    > im2 = gdImageCreate(100, 100);
+    > (void)gdImageColorAllocate(im2, 255, 255, 255); // White background
+    > gdImagePaletteCopy (im2, im);  // Make sure the palette is identical
+    > gdImageRectangle(im2, 0, 0, 15, 15, black);    // Draw something
+    > // Allow animation compression with transparent pixels
+    > gdImageColorTransparent (im2, trans);
+    > gdImageGifAnimAdd(im2, out, 0, 0, 0, 100, 1, im);  // Add second frame
+    >
+    > // construct the third frame
+    > im3 = gdImageCreate(100, 100);
+    > (void)gdImageColorAllocate(im3, 255, 255, 255); // white background
+    > gdImagePaletteCopy (im3, im); // Make sure the palette is identical
+    > gdImageRectangle(im3, 0, 0, 15, 20, black); // Draw something
+    > // Allow animation compression with transparent pixels
+    > gdImageColorTransparent (im3, trans);
+    > // Add the third frame, compressing against the second one
+    > gdImageGifAnimAdd(im3, out, 0, 0, 0, 100, 1, im2);
+    > gdImageGifAnimEnd(out);  // End marker, same as putc(';', out);
+    > fclose(out); // Close file
+    >
+    > // Destroy images
+    > gdImageDestroy(im);
+    > gdImageDestroy(im2);
+    > gdImageDestroy(im3);
+    > }
+
+*/
+
+void gdImageGifAnimAdd(gdImagePtr im, FILE *outFile, int LocalCM,
+                                    int LeftOfs, int TopOfs, int Delay,
+                                    int Disposal, gdImagePtr previm)
+{
+	gdIOCtx *out = gdNewFileCtx(outFile);
+	if (out == NULL) return;
+	gdImageGifAnimAddCtx(im, out, LocalCM, LeftOfs, TopOfs, Delay, Disposal, previm);
+	out->gd_free(out);
+}
+
+static int comparewithmap(gdImagePtr im1, gdImagePtr im2, int c1, int c2, int *colorMap)
+{
+	if(!colorMap) {
+		return c1 == c2;
+	}
+
+	if(-2 != colorMap[c1]) {
+		return colorMap[c1] == c2;
+	}
+
+	return (colorMap[c1] = gdImageColorExactAlpha(im2, im1->red[c1], im1->green[c1], im1->blue[c1], im1->alpha[c1])) == c2;
+}
+
+/*
+  Function: gdImageGifAnimAddCtx
+
+    Adds an animation frame via a <gdIOCtxPtr>.  See gdImageGifAnimAdd>.
+
+  Parameters:
+
+    im          - The image to add.
+    out         - The output <gdIOCtxPtr>.
+    LocalCM     - Flag.  If 1, use a local color map for this frame.
+    LeftOfs     - Left offset of image in frame.
+    TopOfs      - Top offset of image in frame.
+    Delay       - Delay before next frame (in 1/100 seconds)
+    Disposal    - MODE: How to treat this frame when the next one loads.
+    previm      - NULL or a pointer to the previous image written.
+
+  Returns:
+
+    Nothing.
+
+*/
+void gdImageGifAnimAddCtx(gdImagePtr im, gdIOCtxPtr out,
+                                       int LocalCM, int LeftOfs, int TopOfs,
+                                       int Delay, int Disposal,
+                                       gdImagePtr previm)
+{
+	gdImagePtr pim = NULL, tim = im;
+	int interlace, transparent, BitsPerPixel;
+	interlace = im->interlace;
+	transparent = im->transparent;
+
+	/* Default is no local color map */
+	if(LocalCM < 0) {
+		LocalCM = 0;
+	}
+
+	if(im->trueColor) {
+		/* Expensive, but the only way that produces an
+			acceptable result: mix down to a palette
+			based temporary image. */
+		pim = gdImageCreatePaletteFromTrueColor(im, 1, 256);
+		if (!pim) {
+			return;
+		}
+		tim = pim;
+	}
+
+	if (previm) {
+		/* create optimized animation.  Compare this image to
+		   the previous image and crop the temporary copy of
+		   current image to include only changed rectangular
+		   area.  Also replace unchanged pixels inside this
+		   area with transparent color.  Transparent color
+		   needs to be already allocated!
+		   Preconditions:
+		   TopOfs, LeftOfs are assumed 0
+
+		   Images should be of same size.  If not, a temporary
+		   copy is made with the same size as previous image.
+
+		*/
+		gdImagePtr prev_pim = 0, prev_tim = previm;
+		int x, y;
+		int min_x = 0;
+		int min_y = tim->sy;
+		int max_x = 0;
+		int max_y = 0;
+		int colorMap[256];
+
+		if (previm->trueColor) {
+			prev_pim = gdImageCreatePaletteFromTrueColor(previm, 1, 256);
+			if (!prev_pim) {
+				goto fail_end;
+			}
+			prev_tim = prev_pim;
+		}
+
+		for (x = 0; x < 256; ++x) {
+			colorMap[x] = -2;
+		}
+
+		/* First find bounding box of changed areas. */
+		/* first find the top changed row */
+		for (y = 0; y < tim->sy; ++y) {
+			for (x = 0; x < tim->sx; ++x) {
+				if (!comparewithmap(prev_tim, tim,
+				                    prev_tim->pixels[y][x],
+				                    tim->pixels[y][x],
+				                    colorMap)) {
+					min_y = max_y = y;
+					min_x = max_x = x;
+					goto break_top;
+				}
+			}
+		}
+
+break_top:
+		if (tim->sy == min_y) {
+			/* No changes in this frame!! Encode empty image. */
+			transparent = 0;
+			min_x = min_y = 1;
+			max_x = max_y = 0;
+		} else {
+			/* Then the bottom row */
+			for (y = tim->sy - 1; y > min_y; --y) {
+				for (x = 0; x < tim->sx; ++x) {
+					if (!comparewithmap
+					        (prev_tim, tim,
+					         prev_tim->pixels[y][x],
+					         tim->pixels[y][x],
+					         colorMap)) {
+						max_y = y;
+						if(x < min_x) {
+							min_x = x;
+						}
+						if(x > max_x) {
+							max_x = x;
+						}
+						goto break_bot;
+					}
+				}
+			}
+
+break_bot:
+			/* left side */
+			for (x = 0; x < min_x; ++x) {
+				for (y = min_y; y <= max_y; ++y) {
+					if (!comparewithmap
+					        (prev_tim, tim,
+					         prev_tim->pixels[y][x],
+					         tim->pixels[y][x],
+					         colorMap)) {
+						min_x = x;
+						goto break_left;
+					}
+				}
+			}
+
+break_left:
+			/* right side */
+			for (x = tim->sx - 1; x > max_x; --x) {
+				for (y = min_y; y <= max_y; ++y) {
+					if (!comparewithmap
+					        (prev_tim, tim,
+					         prev_tim->pixels[y][x],
+					         tim->pixels[y][x],
+					         colorMap)) {
+						max_x = x;
+						goto break_right;
+					}
+				}
+			}
+
+break_right:
+			;
+		}
+
+		LeftOfs = min_x;
+		TopOfs = min_y;
+		Disposal = 1;
+
+		/* Make a copy of the image with the new offsets.
+		   But only if necessary. */
+		if (min_x != 0 || max_x != tim->sx - 1
+		        || min_y != 0 || max_y != tim->sy - 1
+		        || transparent >= 0) {
+
+			gdImagePtr pim2 = gdImageCreate(max_x-min_x + 1, max_y-min_y + 1);
+
+			if (!pim2) {
+				if (prev_pim) {
+					gdImageDestroy(prev_pim);
+				}
+				goto fail_end;
+			}
+
+			gdImagePaletteCopy(pim2, LocalCM ? tim : prev_tim);
+			gdImageCopy(pim2, tim, 0, 0, min_x, min_y,
+			            max_x - min_x + 1, max_y - min_y + 1);
+
+			if (pim) {
+				gdImageDestroy(pim);
+			}
+
+			tim = pim = pim2;
+		}
+
+		/* now let's compare pixels for transparent
+		   optimization.  But only if transparent is set. */
+		if (transparent >= 0) {
+			for(y = 0; y < tim->sy; ++y) {
+				for (x = 0; x < tim->sx; ++x) {
+					if(comparewithmap
+					        (prev_tim, tim,
+					         prev_tim->pixels[min_y + y][min_x + x],
+					         tim->pixels[y][x], 0)) {
+						gdImageSetPixel(tim, x, y, transparent);
+						break;
+					}
+				}
+			}
+		}
+
+		if(prev_pim) {
+			gdImageDestroy(prev_pim);
+		}
+	}
+
+	BitsPerPixel = colorstobpp(tim->colorsTotal);
+
+	/* All set, let's do it. */
+	GIFAnimEncode(
+	    out, tim->sx, tim->sy, LeftOfs, TopOfs, interlace, transparent,
+	    Delay, Disposal, BitsPerPixel,
+	    LocalCM ? tim->red : 0, tim->green, tim->blue, tim);
+
+fail_end:
+	if(pim) {
+		/* Destroy palette based temporary image. */
+		gdImageDestroy(pim);
+	}
+}
+
+
+
+/*
+  Function: gdImageGifAnimEnd
+
+    Terminates the GIF file properly.
+
+    (Previous versions of this function's documentation suggested just
+    manually writing a semicolon (';') instead since that is all this
+    function does.  While that has no longer changed, we now suggest
+    that you do not do this and instead always call
+    <gdImageGifAnimEnd> (or equivalent) since later versions could
+    possibly do more or different things.)
+
+  Variants:
+
+    <gdImageGifAnimEndCtx> outputs its data via a <gdIOCtx> struct.
+
+    <gdImageGifAnimEndPtr> outputs its data to a memory buffer which
+    it returns.
+
+  Parameters:
+
+    outfile     - the destination FILE*.
+
+  Returns:
+
+    Nothing.
+
+*/
+
+void gdImageGifAnimEnd(FILE *outFile)
+{
+#if 1
+	putc(';', outFile);
+#else
+	gdIOCtx *out = gdNewFileCtx(outFile);
+	if (out == NULL) return;
+	gdImageGifAnimEndCtx(out);
+	out->gd_free(out);
+#endif
+}
+
+/*
+  Function: gdImageGifAnimEndPtr
+
+    Like <gdImageGifAnimEnd> (which contains more information) except
+    that it stores the data to write into memory and returns a pointer
+    to it.
+
+    This memory must be freed by the caller when it is no longer
+    needed. **The caller must invoke <gdFree>(), not free(),** unless
+    the caller is absolutely certain that the same implementations of
+    malloc, free, etc. are used both at library build time and at
+    application build time (but don't; it could always change).
+
+    The 'size' parameter receives the total size of the block of
+    memory.
+
+  Parameters:
+
+    size        - Output: the size of the resulting buffer.
+
+  Returns:
+
+    Pointer to the resulting data or NULL if an error occurred.
+
+*/
+
+void * gdImageGifAnimEndPtr(int *size)
+{
+	char *rv = (char *) gdMalloc(1);
+	if(!rv) {
+		return 0;
+	}
+	*rv = ';';
+	*size = 1;
+	return (void *)rv;
+}
+
+/*
+  Function: gdImageGifAnimEndCtx
+
+    Like <gdImageGifAnimEnd>, but writes its data via a <gdIOCtx>.
+
+  Parameters:
+
+    out         - the destination <gdIOCtx>.
+
+  Returns:
+
+    Nothing.
+
+*/
+
+void gdImageGifAnimEndCtx(gdIOCtx *out)
+{
+	/*
+	 * Write the GIF file terminator
+	 */
+	gdPutC(';', out);
 }
 
 static int
@@ -405,6 +1092,103 @@ GIFEncode(gdIOCtxPtr fp, int GWidth, int GHeight, int GInterlace, int Background
          * Write the GIF file terminator
          */
         gdPutC( ';', fp );
+}
+
+static void GIFAnimEncode(gdIOCtxPtr fp, int IWidth, int IHeight, int LeftOfs, int TopOfs, int GInterlace, int Transparent, int Delay, int Disposal, int BitsPerPixel, int *Red, int *Green, int *Blue, gdImagePtr im)
+{
+	int B;
+	int ColorMapSize;
+	int InitCodeSize;
+	int i;
+	GifCtx ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
+
+	ctx.Interlace = GInterlace;
+	ctx.in_count = 1;
+
+	ColorMapSize = 1 << BitsPerPixel;
+
+	if(LeftOfs < 0) {
+		LeftOfs = 0;
+	}
+	if(TopOfs < 0) {
+		TopOfs = 0;
+	}
+	if(Delay < 0) {
+		Delay = 100;
+	}
+	if(Disposal < 0) {
+		Disposal = 1;
+	}
+
+	ctx.Width = IWidth;
+	ctx.Height = IHeight;
+
+	/* Calculate number of bits we are expecting */
+	ctx.CountDown = (long)ctx.Width * (long)ctx.Height;
+
+	/* Indicate which pass we are on (if interlace) */
+	ctx.Pass = 0;
+
+	/* The initial code size */
+	if(BitsPerPixel <= 1) {
+		InitCodeSize = 2;
+	} else {
+		InitCodeSize = BitsPerPixel;
+	}
+
+	/* Set up the current x and y position */
+	ctx.curx = ctx.cury = 0;
+
+	/* Write out extension for image animation and looping */
+	gdPutC('!', fp);
+	gdPutC(0xf9, fp);
+	gdPutC(4, fp);
+	gdPutC((Transparent >= 0 ? 1 : 0) | (Disposal << 2), fp);
+	gdPutC((unsigned char)(Delay & 255), fp);
+	gdPutC((unsigned char)((Delay >> 8) & 255), fp);
+	gdPutC((unsigned char) Transparent, fp);
+	gdPutC(0, fp);
+
+	/* Write an Image separator */
+	gdPutC(',', fp);
+
+	/* Write out the Image header */
+	gifPutWord(LeftOfs, fp);
+	gifPutWord(TopOfs, fp);
+	gifPutWord(ctx.Width, fp);
+	gifPutWord(ctx.Height, fp);
+
+	/* Indicate that there is a local colour map */
+	B = (Red && Green && Blue) ? 0x80 : 0;
+
+	/* OR in the interlacing */
+	B |= ctx.Interlace ? 0x40 : 0;
+
+	/* OR in the Bits per Pixel */
+	B |= (Red && Green && Blue) ? (BitsPerPixel - 1) : 0;
+
+	/* Write it out */
+	gdPutC(B, fp);
+
+	/* Write out the Local Colour Map */
+	if(Red && Green && Blue) {
+		for(i = 0; i < ColorMapSize; ++i) {
+			gdPutC(Red[i], fp);
+			gdPutC(Green[i], fp);
+			gdPutC(Blue[i], fp);
+		}
+	}
+
+	/* Write out the initial code size */
+	gdPutC(InitCodeSize, fp);
+
+	/* Go and actually compress the data */
+	compress(InitCodeSize + 1, fp, im, &ctx);
+
+	/* Write out a Zero-length packet (to end the series) */
+	gdPutC(0, fp);
 }
 
 /***************************************************************************

--- a/ext/gd/php_gd.h
+++ b/ext/gd/php_gd.h
@@ -201,6 +201,10 @@ PHP_FUNCTION(imageconvolution);
 
 PHP_FUNCTION(imageresolution);
 
+PHP_FUNCTION(imagegifanimbegin);
+PHP_FUNCTION(imagegifanimadd);
+PHP_FUNCTION(imagegifanimend);
+
 PHP_GD_API int phpi_get_le_gd(void);
 
 #else

--- a/ext/gd/tests/imagegifanim_basic.phpt
+++ b/ext/gd/tests/imagegifanim_basic.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Create an animated GIF with the imagegifanim*() functions
+--SKIPIF--
+<?php
+if (!extension_loaded('gd')) die('skip ext/gd required');
+?>
+--FILE--
+<?php
+$im = imagecreate(100, 50);
+$out = fopen('php://memory', 'w+b');
+imagecolorallocate($im, 0, 0, 0);
+imagegifanimbegin($im, $out);
+imagedestroy($im);
+
+for ($i = -30; $i < 120; $i += 10) {
+    $im = imagecreate(100, 50);
+    imagecolorallocate($im, 0, 0, 0);
+    $color = imagecolorallocate($im, 255, 255, 0);
+    $angle = (abs($i/10) % 2) * 45;
+    imagefilledarc($im, $i+15,25, 30,30, $angle,360-$angle, $color, IMG_ARC_PIE);
+    imagegifanimadd($im, $out, true, 0, 0, 30);
+    imagedestroy($im);
+}
+
+imagegifanimend($out);
+
+//rewind($out);
+//file_put_contents(__FILE__ . '.gif', stream_get_contents($out));
+
+rewind($out);
+echo md5(stream_get_contents($out));
+fclose($out);
+?>
+--EXPECT--
+acffc98703c521fbe1983efb8a66768e


### PR DESCRIPTION
We add PHP bindings for libgd's features to write animated GIFs, supporting
only GD context output via PHP streams (for now).

As PHP's bundled libgd doesn't yet include the respective features of the
external libgd, we add these. For external libgd builds we assume that at
least GD_2_0_29 (released 2006-04-05) is available without further checks.
