### PR TITLE
Implement #52857: Access to gdImageSetClip() and gdImageGetClip()

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -685,6 +685,18 @@ ZEND_BEGIN_ARG_INFO(arginfo_imagesy, 0)
 	ZEND_ARG_INFO(0, im)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_imagesetclip, 0)
+	ZEND_ARG_INFO(0, im)
+	ZEND_ARG_INFO(0, x1)
+	ZEND_ARG_INFO(0, y1)
+	ZEND_ARG_INFO(0, x2)
+	ZEND_ARG_INFO(0, y2)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_imagegetclip, 0)
+	ZEND_ARG_INFO(0, im)
+ZEND_END_ARG_INFO()
+
 #ifdef ENABLE_GD_TTF
 #if HAVE_LIBFREETYPE
 ZEND_BEGIN_ARG_INFO_EX(arginfo_imageftbbox, 0, 0, 4)
@@ -936,6 +948,8 @@ const zend_function_entry gd_functions[] = {
 	PHP_FE(imagestringup,							arginfo_imagestringup)
 	PHP_FE(imagesx,									arginfo_imagesx)
 	PHP_FE(imagesy,									arginfo_imagesy)
+	PHP_FE(imagesetclip,							arginfo_imagesetclip)
+	PHP_FE(imagegetclip,							arginfo_imagegetclip)
 	PHP_FE(imagedashedline,							arginfo_imagedashedline)
 
 #ifdef ENABLE_GD_TTF
@@ -3794,6 +3808,53 @@ PHP_FUNCTION(imagesy)
 	}
 
 	RETURN_LONG(gdImageSY(im));
+}
+/* }}} */
+
+/* {{{ proto bool imagesetclip(resource im, int x1, int y1, int x2, int y2)
+   Set the clipping rectangle. */
+PHP_FUNCTION(imagesetclip)
+{
+	zval *im_zval;
+	gdImagePtr im;
+	zend_long x1, y1, x2, y2;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rllll", &im_zval, &x1, &y1, &x2, &y2) == FAILURE) {
+		return;
+	}
+
+	if ((im = (gdImagePtr)zend_fetch_resource(Z_RES_P(im_zval), "Image", le_gd)) == NULL) {
+		RETURN_FALSE;
+	}
+
+	gdImageSetClip(im, x1, y1, x2, y2);
+	RETURN_TRUE;
+}
+/* }}} */
+
+/* {{{ proto array imagegetclip(resource im)
+   Get the clipping rectangle. */
+PHP_FUNCTION(imagegetclip)
+{
+	zval *im_zval;
+	gdImagePtr im;
+	int x1, y1, x2, y2;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &im_zval) == FAILURE) {
+		return;
+	}
+
+	if ((im = (gdImagePtr)zend_fetch_resource(Z_RES_P(im_zval), "Image", le_gd)) == NULL) {
+		RETURN_FALSE;
+	}
+
+	gdImageGetClip(im, &x1, &y1, &x2, &y2);
+	
+	array_init(return_value);
+	add_next_index_long(return_value, x1);
+	add_next_index_long(return_value, y1);
+	add_next_index_long(return_value, x2);
+	add_next_index_long(return_value, y2);
 }
 /* }}} */
 

--- a/ext/gd/php_gd.h
+++ b/ext/gd/php_gd.h
@@ -182,6 +182,8 @@ PHP_FUNCTION(imagestring);
 PHP_FUNCTION(imagestringup);
 PHP_FUNCTION(imagesx);
 PHP_FUNCTION(imagesy);
+PHP_FUNCTION(imagesetclip);
+PHP_FUNCTION(imagegetclip);
 PHP_FUNCTION(imagedashedline);
 PHP_FUNCTION(imagettfbbox);
 PHP_FUNCTION(imagettftext);

--- a/ext/gd/tests/imagegetclip_basic.phpt
+++ b/ext/gd/tests/imagegetclip_basic.phpt
@@ -1,0 +1,38 @@
+--TEST--
+imagegetclip() - basic functionality
+--SKIP--
+<?php
+if (!extension_loaded('gd')) die('skip ext/gd required');
+?>
+--FILE--
+<?php
+$im = imagecreate(10, 10);
+echo '=== original ===', PHP_EOL;
+var_dump(imagegetclip($im));
+imagesetclip($im, 1,2, 3,4);
+echo '=== after imagesetclip() ===', PHP_EOL;
+var_dump(imagegetclip($im));
+?>
+--EXPECT--
+=== original ===
+array(4) {
+  [0]=>
+  int(0)
+  [1]=>
+  int(0)
+  [2]=>
+  int(9)
+  [3]=>
+  int(9)
+}
+=== after imagesetclip() ===
+array(4) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  int(4)
+}

--- a/ext/gd/tests/imagesetclip_basic.phpt
+++ b/ext/gd/tests/imagesetclip_basic.phpt
@@ -1,0 +1,26 @@
+--TEST--
+imagesetclip() - basic functionality
+--SKIP--
+<?php
+if (!extension_loaded('gd')) die('skip ext/gd required');
+?>
+--FILE--
+<?php
+// draw a clipped diagonal line
+$im = imagecreate(100, 100);
+imagecolorallocate($im, 0, 0, 0);
+$white = imagecolorallocate($im, 255, 255, 255);
+imagesetclip($im, 10,10, 89,89);
+imageline($im, 0,0, 99,99, $white);
+
+// save image for manual inspection
+// imagepng($im, __FILE__ . '.png');
+
+// verify that the clipping has been respected
+imagesetclip($im, 0,0, 99,99);
+var_dump(imagecolorat($im, 9,9) !== $white);
+var_dump(imagecolorat($im, 90,90) !== $white);
+?>
+--EXPECT--
+bool(true)
+bool(true)


### PR DESCRIPTION
We add the necessary PHP bindings for both functions which are available
as of GD_2_0_12 (released 2006-04-05). The API of imagegetclip() is modelled
according to imageftbbox().