### PR TITLE
Fix 37676: Add E_NOTICE when using array-index on non array/object/string container

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1899,8 +1899,13 @@ try_string_offset:
 		if (type != BP_VAR_IS && UNEXPECTED(Z_TYPE_P(container) == IS_UNDEF)) {
 			zval_undefined_cv(EG(current_execute_data)->opline->op1.var, EG(current_execute_data));
 		}
-		if (/*dim_type == IS_CV &&*/ UNEXPECTED(Z_TYPE_P(dim) == IS_UNDEF)) {
+		if (UNEXPECTED(Z_TYPE_P(dim) == IS_UNDEF)) {
 			zval_undefined_cv(EG(current_execute_data)->opline->op2.var, EG(current_execute_data));
+		}
+
+		if (EG(current_execute_data)->opline->op1_type != IS_VAR ||
+			(EG(current_execute_data)->opline->op1_type == IS_VAR && Z_TYPE_P(container) != IS_NULL)) {
+			zend_error(E_NOTICE, "Illegal offset type");
 		}
 		ZVAL_NULL(result);
 	}


### PR DESCRIPTION
This fix addresses bugs [37676](https://bugs.php.net/bug.php?id=37676) and [72636](https://bugs.php.net/bug.php?id=37676)

Before I changed all the tests, I wanted to see if this would be an acceptable means to remedy the reported issues.