### PR TITLE
Implement #72653: SQLite should allow opening with empty filename

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -100,6 +100,7 @@ PHP_METHOD(sqlite3, open)
 {
 	php_sqlite3_db_object *db_obj;
 	zval *object = getThis();
+	char empty_string[] = "";
 	char *filename, *encryption_key, *fullpath;
 	size_t filename_len, encryption_key_len = 0;
 	zend_long flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
@@ -118,8 +119,7 @@ PHP_METHOD(sqlite3, open)
 		return;
 	}
 	if (filename_len == 0) {
-		fullpath = emalloc(1);
-		*fullpath = '\0';
+		fullpath = empty_string;
 	} else if (filename_len != sizeof(":memory:")-1 ||
 			memcmp(filename, ":memory:", sizeof(":memory:")-1) != 0) {
 		if (!(fullpath = expand_filepath(filename, NULL))) {
@@ -142,7 +142,7 @@ PHP_METHOD(sqlite3, open)
 	if (sqlite3_open(fullpath, &(db_obj->db)) != SQLITE_OK) {
 #endif
 		zend_throw_exception_ex(zend_ce_exception, 0, "Unable to open database: %s", sqlite3_errmsg(db_obj->db));
-		if (fullpath) {
+		if (fullpath && fullpath != empty_string) {
 			efree(fullpath);
 		}
 		return;
@@ -163,7 +163,7 @@ PHP_METHOD(sqlite3, open)
 		sqlite3_set_authorizer(db_obj->db, php_sqlite3_authorizer, NULL);
 	}
 
-	if (fullpath) {
+	if (fullpath && fullpath != empty_string) {
 		efree(fullpath);
 	}
 }

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -117,7 +117,10 @@ PHP_METHOD(sqlite3, open)
 	if (strlen(filename) != filename_len) {
 		return;
 	}
-	if (filename_len != sizeof(":memory:")-1 ||
+	if (filename_len == 0) {
+		fullpath = emalloc(1);
+		*fullpath = '\0';
+	} else if (filename_len != sizeof(":memory:")-1 ||
 			memcmp(filename, ":memory:", sizeof(":memory:")-1) != 0) {
 		if (!(fullpath = expand_filepath(filename, NULL))) {
 			zend_throw_exception(zend_ce_exception, "Unable to expand filepath", 0);

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -114,9 +114,6 @@ PHP_METHOD(sqlite3, open)
 		zend_throw_exception(zend_ce_exception, "Already initialised DB Object", 0);
 	}
 
-	if (strlen(filename) != filename_len) {
-		return;
-	}
 	if (filename_len != 0 && (filename_len != sizeof(":memory:")-1 ||
 			memcmp(filename, ":memory:", sizeof(":memory:")-1) != 0)) {
 		if (!(fullpath = expand_filepath(filename, NULL))) {

--- a/ext/sqlite3/tests/sqlite3_open_empty_string.phpt
+++ b/ext/sqlite3/tests/sqlite3_open_empty_string.phpt
@@ -7,13 +7,8 @@ Thijs Feryn <thijs@feryn.eu>
 <?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
 --FILE--
 <?php
-try{
-    $db = new SQLite3('');
-} catch(Exception $e) {
-    echo $e->getMessage().PHP_EOL;
-}
+$db = new SQLite3('');
 echo "Done\n";
 ?>
---EXPECTF--
-Unable to expand filepath
+--EXPECT--
 Done


### PR DESCRIPTION
From the [sqlite3_open](https://www.sqlite.org/c3ref/open.html) docs:

| If the filename is an empty string, then a private, temporary on-disk
| database will be created. This private database will be automatically
| deleted as soon as the database connection is closed.

We make that facility available to userland.