### PR TITLE
[UPD] - lastInsertId using Postgres Lastval() function for PHP 5.6.*

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -358,31 +358,30 @@ static char *pdo_pgsql_last_insert_id(pdo_dbh_t *dbh, const char *name, unsigned
 {
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	char *id = NULL;
+	PGresult *res;
+	ExecStatusType status;
+	const char *q[1];
+	q[0] = name;
 
-	if (name == NULL) {
-		if (H->pgoid == InvalidOid) {
-			return NULL;
-		}
-		*len = spprintf(&id, 0, "%ld", (long) H->pgoid);
+	if (PHP_PDO_PGSQL_LASTVAL_PG_VERSION <= PQserverVersion(H->server) && name == NULL) {
+		res = PQexec(H->server, "SELECT LASTVAL()");
 	} else {
-		PGresult *res;
-		ExecStatusType status;
-		const char *q[1];
-		q[0] = name;
 		res = PQexecParams(H->server, "SELECT CURRVAL($1)", 1, NULL, q, NULL, NULL, 0);
-		status = PQresultStatus(res);
-
-		if (res && (status == PGRES_TUPLES_OK)) {
-			id = estrdup((char *)PQgetvalue(res, 0, 0));
-			*len = PQgetlength(res, 0, 0);
-		} else {
-			pdo_pgsql_error(dbh, status, pdo_pgsql_sqlstate(res));
-		}
-
-		if (res) {
-			PQclear(res);
-		}
 	}
+	status = PQresultStatus(res);
+
+	if (res && (status == PGRES_TUPLES_OK)) {
+		id = estrdup((char *)PQgetvalue(res, 0, 0));
+		*len = PQgetlength(res, 0, 0);
+	} else {
+		pdo_pgsql_error(dbh, status, pdo_pgsql_sqlstate(res));
+		*len = spprintf(&id, 0, "%ld", (long) H->pgoid);
+	}
+
+	if (res) {
+		PQclear(res);
+	}
+
 	return id;
 }
 

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -29,6 +29,8 @@
 
 #define PHP_PDO_PGSQL_CONNECTION_FAILURE_SQLSTATE "08006"
 
+#define PHP_PDO_PGSQL_LASTVAL_PG_VERSION 80100
+
 typedef struct {
 	const char *file;
 	int line;

--- a/ext/pdo_pgsql/tests/bug_last_insert_id.phpt
+++ b/ext/pdo_pgsql/tests/bug_last_insert_id.phpt
@@ -1,0 +1,36 @@
+--TEST--
+currval() vs lastval() - PDO PgSQL Bug #1134 [BUG] New record, PostgreSQL and the Primary key https://github.com/phalcon/cphalcon/issues/1134
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+require dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+
+require dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+
+$db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+
+@$db->query('CREATE TABLE test_last_id (id SERIAL NOT NULL, field1 VARCHAR(10))');
+
+$stmt = $db->prepare("INSERT INTO test_last_id (field1) VALUES ('test')");
+
+$stmt->execute();
+
+/**
+ * No sequence name informed
+ */
+var_dump($db->lastInsertId());
+/**
+ * Sequence name informed
+ */
+var_dump($db->lastInsertId('test_last_id_id_seq'));
+?>
+--EXPECTREGEX--
+string\([0-9]*\)\ \"[0-9]*\"
+string\([0-9]*\)\ \"[0-9]*\"


### PR DESCRIPTION
Same commit from PR 2014, but for the 5.6 series (only one line changed)