### PR TITLE
Fix #72320: iconv_substr returns false for empty strings

### DIFF
--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -858,7 +858,7 @@ static php_iconv_err_t _php_iconv_substr(smart_str *pretval,
 	}
 
 
-	if ((size_t)offset >= total_len) {
+	if ((size_t)offset > total_len) {
 		return PHP_ICONV_ERR_SUCCESS;
 	}
 
@@ -2108,7 +2108,7 @@ PHP_FUNCTION(iconv_substr)
 	err = _php_iconv_substr(&retval, ZSTR_VAL(str), ZSTR_LEN(str), offset, length, charset);
 	_php_iconv_show_error(err, GENERIC_SUPERSET_NAME, charset);
 
-	if (err == PHP_ICONV_ERR_SUCCESS && ZSTR_LEN(str) > 0 && retval.s != NULL) {
+	if (err == PHP_ICONV_ERR_SUCCESS && ZSTR_LEN(str) >= 0 && retval.s != NULL) {
 		RETURN_NEW_STR(retval.s);
 	}
 	smart_str_free(&retval);

--- a/ext/iconv/tests/bug72320.phpt
+++ b/ext/iconv/tests/bug72320.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #72320 (iconv_substr returns false for empty strings)
+--SKIPIF--
+<?php
+if (!extension_loaded('iconv')) die('skip ext/iconv required');
+?>
+--FILE--
+<?php
+var_dump(iconv_substr('', 0, 10, 'UTF-8'));
+var_dump(iconv_substr('foo', 3, 10, 'UTF-8'));
+?>
+--EXPECT--
+string(0) ""
+string(0) ""


### PR DESCRIPTION
For consistency with substr() and mb_substr(), iconv_substr() should return
an empty string instead of FALSE, when $offset == iconv_strlen($str).

In my opinion, the question is not whether to apply this patch, but rather against which PHP version. According to the docs ("If str is shorter than offset characters long, FALSE will be returned.") this is a bug, and so should be applied against PHP 5.6+. However, this change causes a BC break, so it might best be applied to master only. Then again, the respective behavior of substr() has been changed as of PHP 7, so a reasonable compromise would be to apply the fix against PHP 7.0 or maybe PHP 7.1.

Thoughts?