### PR TITLE
[PHP7] adds support for named captures to `mb_ereg*` functions

### DIFF
--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -649,6 +649,50 @@ _php_mb_regex_init_options(const char *parg, int narg, OnigOptionType *option, O
 }
 /* }}} */
 
+
+/*
+ * Callbacks for named subpatterns
+ */
+
+/* {{{ struct mb_ereg_groups_iter_arg */
+typedef struct mb_regex_groups_iter_args {
+	zval		*groups;
+	char		*search_str;
+	int			search_len;
+	OnigRegion	*region;
+} mb_regex_groups_iter_args;
+/* }}} */
+
+/* {{{ mb_ereg_groups_iter */
+static int
+mb_regex_groups_iter(const OnigUChar* name, const OnigUChar* name_end, int ngroup_num, int* group_nums, regex_t* reg, void* parg)
+{
+	mb_regex_groups_iter_args *args = (mb_regex_groups_iter_args *) parg;
+	int i, gn, ref, beg, end;
+
+	for (i = 0; i < ngroup_num; i++) {
+		gn = group_nums[i];
+		ref = onig_name_to_backref_number(reg, name, name_end, args->region);
+		if (ref != gn) {
+			/*
+			 * In case of duplicate groups, keep only the last suceeding one
+			 * to be consistent with preg_match with the PCRE_DUPNAMES option.
+			 */
+			continue;
+		}
+		beg = args->region->beg[gn];
+		end = args->region->end[gn];
+		if (beg >= 0 && beg < end && end <= args->search_len) {
+			add_assoc_stringl_ex(args->groups, (char *)name, name_end - name, &args->search_str[beg], end - beg);
+		} else {
+			add_assoc_bool_ex(args->groups, (char *)name, name_end - name, 0);
+		}
+	}
+
+	return 0;
+}
+/* }}} */
+
 /*
  * php functions
  */
@@ -763,6 +807,11 @@ static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 			} else {
 				add_index_bool(array, i, 0);
 			}
+		}
+
+		if (onig_number_of_names(re) > 0) {
+			mb_regex_groups_iter_args args = {array, string, string_len, regs};
+			onig_foreach_name(re, mb_regex_groups_iter, &args);
 		}
 	}
 
@@ -1291,6 +1340,15 @@ _php_mb_regex_ereg_search_exec(INTERNAL_FUNCTION_PARAMETERS, int mode)
 					add_index_bool(return_value, i, 0);
 				}
 			}
+			if (onig_number_of_names(MBREX(search_re)) > 0) {
+				mb_regex_groups_iter_args args = {
+					return_value,
+					Z_STRVAL(MBREX(search_str)),
+					Z_STRLEN(MBREX(search_str)),
+					MBREX(search_regs)
+				};
+				onig_foreach_name(MBREX(search_re), mb_regex_groups_iter, &args);
+			}
 			break;
 		default:
 			RETVAL_TRUE;
@@ -1417,6 +1475,15 @@ PHP_FUNCTION(mb_ereg_search_getregs)
 				add_index_bool(return_value, i, 0);
 			}
 		}
+		if (onig_number_of_names(MBREX(search_re)) > 0) {
+			mb_regex_groups_iter_args args = {
+				return_value,
+				Z_STRVAL(MBREX(search_str)),
+				len,
+				MBREX(search_regs)
+			};
+			onig_foreach_name(MBREX(search_re), mb_regex_groups_iter, &args);
+		}
 	} else {
 		RETVAL_FALSE;
 	}
@@ -1445,7 +1512,7 @@ PHP_FUNCTION(mb_ereg_search_setpos)
 	if ((position < 0) && (!Z_ISUNDEF(MBREX(search_str))) && (Z_TYPE(MBREX(search_str)) == IS_STRING)) {
 		position += Z_STRLEN(MBREX(search_str));
 	}
-		
+
 	if (position < 0 || (!Z_ISUNDEF(MBREX(search_str)) && Z_TYPE(MBREX(search_str)) == IS_STRING && (size_t)position > Z_STRLEN(MBREX(search_str)))) {
 		php_error_docref(NULL, E_WARNING, "Position is out of range");
 		MBREX(search_pos) = 0;

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -694,6 +694,136 @@ mb_regex_groups_iter(const OnigUChar* name, const OnigUChar* name_end, int ngrou
 /* }}} */
 
 /*
+ * Helper for _php_mb_regex_ereg_replace_exec
+ */
+/* {{{ mb_regex_substitute */
+static inline void mb_regex_substitute(
+	smart_str *pbuf,
+	const char *subject,
+	size_t subject_len,
+	char *replace,
+	size_t replace_len,
+	php_mb_regex_t *regexp,
+	OnigRegion *regs,
+	const mbfl_encoding *enc
+) {
+	char *p, *sp, *eos;
+	int no; /* bakreference group number */
+	int clen; /* byte-length of the current character */
+
+	p = replace;
+	eos = replace + replace_len;
+
+	while (p < eos) {
+		clen = (int) php_mb_mbchar_bytes_ex(p, enc);
+		if (clen != 1 || p == eos || p[0] != '\\') {
+			/* skip anything that's not an ascii backslash */
+			smart_str_appendl(pbuf, p, clen);
+			p += clen;
+			continue;
+		}
+		sp = p; /* save position */
+		clen = (int) php_mb_mbchar_bytes_ex(++p, enc);
+		if (clen != 1 || p == eos) {
+			/* skip escaped multibyte char */
+			p += clen;
+			smart_str_appendl(pbuf, sp, p - sp);
+			continue;
+		}
+		no = -1;
+		switch (p[0]) {
+			case '0':
+				no = 0;
+				p++;
+				break;
+			case '1': case '2': case '3': case '4':
+			case '5': case '6': case '7': case '8': case '9':
+				if (!onig_noname_group_capture_is_active(regexp)) {
+					/*
+					 * FIXME:
+					 * Oniguruma throws a compile error if numbered backrefs are used with named groups in the pattern.
+					 * For now we just ignore them, but in the future we might want to raise a warning
+					 * and abort the whole replace operation.
+					 */
+					p++;
+					smart_str_appendl(pbuf, sp, p - sp);
+					continue;
+				}
+				no = p[0] - '0';
+				p++;
+				break;
+			case 'k':
+				clen = (int) php_mb_mbchar_bytes_ex(++p, enc);
+				if (clen != 1 || p == eos || (p[0] != '<' && p[0] != '\'')) {
+					/* not a backref delimiter */
+					p += clen;
+					smart_str_appendl(pbuf, sp, p - sp);
+					continue;
+				}
+				/* try to consume everything until next delimiter */
+				char delim = p[0] == '<' ? '>' : '\'';
+				char *name, *name_end;
+				char maybe_num = 1;
+				name_end = name = p + 1;
+				while (name_end < eos) {
+					clen = (int) php_mb_mbchar_bytes_ex(name_end, enc);
+					if (clen != 1) {
+						name_end += clen;
+						maybe_num = 0;
+						continue;
+					}
+					if (name_end[0] == delim) break;
+					if (maybe_num && !isdigit(name_end[0])) maybe_num = 0;
+					name_end++;
+				}
+				p = name_end + 1;
+				if (name_end - name < 1 || name_end >= eos) {
+					/* the backref was empty or we failed to find the end delimiter */
+					smart_str_appendl(pbuf, sp, p - sp);
+					continue;
+				}
+				/* we have either a name or a number */
+				if (maybe_num) {
+					if (!onig_noname_group_capture_is_active(regexp)) {
+						/* see above note on mixing numbered & named backrefs */
+						smart_str_appendl(pbuf, sp, p - sp);
+						continue;
+					}
+					if (name_end - name == 1) {
+						no = name[0] - '0';
+						break;
+					}
+					if (name[0] == '0') {
+						/* 01 is not a valid number */
+						break;
+					}
+					no = (int) strtoul(name, NULL, 10);
+					break;
+				}
+				no = onig_name_to_backref_number(regexp, (OnigUChar *)name, (OnigUChar *)name_end, regs);
+				break;
+			default:
+				p += clen;
+				smart_str_appendl(pbuf, sp, p - sp);
+				continue;
+		}
+		if (no < 0 || no >= regs->num_regs) {
+			/* invalid group number reference, keep the escape sequence in the output */
+			smart_str_appendl(pbuf, sp, p - sp);
+			continue;
+		}
+		if (regs->beg[no] >= 0 && regs->beg[no] < regs->end[no] && (size_t)regs->end[no] <= subject_len) {
+			smart_str_appendl(pbuf, subject + regs->beg[no], regs->end[no] - regs->beg[no]);
+		}
+	}
+
+	if (p < eos) {
+		smart_str_appendl(pbuf, p, eos - p);
+	}
+}
+/* }}} */
+
+/*
  * php functions
  */
 
@@ -859,14 +989,12 @@ static void _php_mb_regex_ereg_replace_exec(INTERNAL_FUNCTION_PARAMETERS, OnigOp
 	char *string;
 	size_t string_len;
 
-	char *p;
 	php_mb_regex_t *re;
 	OnigSyntaxType *syntax;
 	OnigRegion *regs = NULL;
 	smart_str out_buf = {0};
 	smart_str eval_buf = {0};
 	smart_str *pbuf;
-	size_t i;
 	int err, eval, n;
 	OnigUChar *pos;
 	OnigUChar *string_lim;
@@ -976,38 +1104,11 @@ static void _php_mb_regex_ereg_replace_exec(INTERNAL_FUNCTION_PARAMETERS, OnigOp
 			break;
 		}
 		if (err >= 0) {
-#if moriyoshi_0
-			if (regs->beg[0] == regs->end[0]) {
-				php_error_docref(NULL, E_WARNING, "Empty regular expression");
-				break;
-			}
-#endif
 			/* copy the part of the string before the match */
 			smart_str_appendl(&out_buf, (char *)pos, (size_t)((OnigUChar *)(string + regs->beg[0]) - pos));
 
 			if (!is_callable) {
-				/* copy replacement and backrefs */
-				i = 0;
-				p = replace;
-				while (i < replace_len) {
-					int fwd = (int) php_mb_mbchar_bytes_ex(p, enc);
-					n = -1;
-					if ((replace_len - i) >= 2 && fwd == 1 &&
-					p[0] == '\\' && p[1] >= '0' && p[1] <= '9') {
-						n = p[1] - '0';
-					}
-					if (n >= 0 && n < regs->num_regs) {
-						if (regs->beg[n] >= 0 && regs->beg[n] < regs->end[n] && (size_t)regs->end[n] <= string_len) {
-							smart_str_appendl(pbuf, string + regs->beg[n], regs->end[n] - regs->beg[n]);
-						}
-						p += 2;
-						i += 2;
-					} else {
-						smart_str_appendl(pbuf, p, fwd);
-						p += fwd;
-						i += fwd;
-					}
-				}
+				mb_regex_substitute(pbuf, string, string_len, replace, replace_len, re, regs, enc);
 			}
 
 			if (eval) {
@@ -1046,6 +1147,10 @@ static void _php_mb_regex_ereg_replace_exec(INTERNAL_FUNCTION_PARAMETERS, OnigOp
 				array_init(&subpats);
 				for (i = 0; i < regs->num_regs; i++) {
 					add_next_index_stringl(&subpats, string + regs->beg[i], regs->end[i] - regs->beg[i]);
+				}
+				if (onig_number_of_names(re) > 0) {
+					mb_regex_groups_iter_args args = {&subpats, string, string_len, regs};
+					onig_foreach_name(re, mb_regex_groups_iter, &args);
 				}
 
 				ZVAL_COPY_VALUE(&args[0], &subpats);

--- a/ext/mbstring/tests/mb_ereg_dupnames.phpt
+++ b/ext/mbstring/tests/mb_ereg_dupnames.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Testing mb_ereg() duplicate named groups
+--SKIPIF--
+<?php
+if (!extension_loaded('mbstring')) die('skip mbstring not enabled');
+function_exists('mb_ereg') or die("skip mb_ereg() is not available in this build");
+?>
+--FILE--
+<?php
+    mb_regex_encoding("UTF-8");
+    $pattern = '\w+((?<punct>？)|(?<punct>！))';
+    mb_ereg($pattern, '中？', $m);
+    var_dump($m);
+    mb_ereg($pattern, '中！', $m);
+    var_dump($m);
+?>
+--EXPECT--
+array(4) {
+  [0]=>
+  string(6) "中？"
+  [1]=>
+  string(3) "？"
+  [2]=>
+  bool(false)
+  ["punct"]=>
+  string(3) "？"
+}
+array(4) {
+  [0]=>
+  string(6) "中！"
+  [1]=>
+  bool(false)
+  [2]=>
+  string(3) "！"
+  ["punct"]=>
+  string(3) "！"
+}

--- a/ext/mbstring/tests/mb_ereg_named_subpatterns.phpt
+++ b/ext/mbstring/tests/mb_ereg_named_subpatterns.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Testing mb_ereg() named subpatterns
+--SKIPIF--
+<?php
+if (!extension_loaded('mbstring')) die('skip mbstring not enabled');
+function_exists('mb_ereg') or die("skip mb_ereg() is not available in this build");
+?>
+--FILE--
+<?php
+    mb_regex_encoding("UTF-8");
+    mb_ereg('(?<wsp>\s*)(?<word>\w+)', '  中国', $m);
+    var_dump($m);
+    mb_ereg('(?<wsp>\s*)(?<word>\w+)', '国', $m);
+    var_dump($m);
+    mb_ereg('(\s*)(?<word>\w+)', '  中国', $m);
+    var_dump($m);
+?>
+--EXPECT--
+array(5) {
+  [0]=>
+  string(8) "  中国"
+  [1]=>
+  string(2) "  "
+  [2]=>
+  string(6) "中国"
+  ["wsp"]=>
+  string(2) "  "
+  ["word"]=>
+  string(6) "中国"
+}
+array(5) {
+  [0]=>
+  string(3) "国"
+  [1]=>
+  bool(false)
+  [2]=>
+  string(3) "国"
+  ["wsp"]=>
+  bool(false)
+  ["word"]=>
+  string(3) "国"
+}
+array(3) {
+  [0]=>
+  string(8) "  中国"
+  [1]=>
+  string(6) "中国"
+  ["word"]=>
+  string(6) "中国"
+}

--- a/ext/mbstring/tests/mb_ereg_replace_callback.phpt
+++ b/ext/mbstring/tests/mb_ereg_replace_callback.phpt
@@ -8,8 +8,16 @@ function_exists('mb_ereg_replace_callback') or die("skip mb_ereg_replace_callbac
 --FILE--
 <?php
 $str = 'abc 123 #",; $foo';
-echo mb_ereg_replace_callback('(\S+)', function($m){return $m[1].'('.strlen($m[1]).')';}, $str);
+
+echo mb_ereg_replace_callback('(\S+)', function ($m) {
+    return $m[1].'('.strlen($m[1]).')';
+}, $str), "\n";
+
+echo mb_ereg_replace_callback('(?<word>\w+) (?<digit>\d+).*', function ($m) {
+    return sprintf("%s-%s", $m['digit'], $m['word']);
+}, $str), "\n";
 ?>
 --EXPECT--
 abc(3) 123(3) #",;(4) $foo(4)
+123-abc
 

--- a/ext/mbstring/tests/mb_ereg_replace_named_subpatterns.phpt
+++ b/ext/mbstring/tests/mb_ereg_replace_named_subpatterns.phpt
@@ -1,0 +1,37 @@
+--TEST--
+mb_ereg_replace() with named subpatterns
+--SKIPIF--
+<?php
+extension_loaded('mbstring') or die('skip mbstring not available');
+function_exists('mb_ereg_replace') or die("skip mb_ereg_replace() is not available in this build");
+?>
+--FILE--
+<?php
+    mb_regex_set_options('');
+    // \k<word> syntax
+    echo mb_ereg_replace('(?<a>\s*)(?<b>\w+)(?<c>\s*)', '\k<a>_\k<b>_\k<c>', 'a b c d e' ), "\n";
+    // \k'word' syntax
+    echo mb_ereg_replace('(?<word>[a-z]+)',"<\k'word'>", 'abc def ghi'), PHP_EOL;
+    // numbered captures with \k<n> syntax
+    echo mb_ereg_replace('(1)(2)(3)(4)(5)(6)(7)(8)(9)(a)(\10)', '\k<0>-\k<10>-', '123456789aa'), PHP_EOL;
+    // numbered captures with \k'n' syntax
+    echo mb_ereg_replace('(1)(2)(3)(4)(5)(6)(7)(8)(9)(a)(\10)', "\k'0'-\k'10'-", '123456789aa'), PHP_EOL;
+    // backref 0 works, but 01 is ignored
+    echo mb_ereg_replace('a', "\k'0'_\k<01>", 'a'), PHP_EOL;
+    // Numbered backref is ignored if named backrefs are present
+    echo mb_ereg_replace('(?<a>A)\k<a>', '-\1-', 'AA'), PHP_EOL;
+    // An empty backref is ignored
+    echo mb_ereg_replace('(\w)\1', '-\k<>-', 'AA'), PHP_EOL;
+    // An unclosed backref is ignored
+    echo mb_ereg_replace('(?<a>\w+)', '-\k<a', 'AA'), PHP_EOL;
+?>
+
+--EXPECT--
+_a_ _b_ _c_ _d_ _e_
+<abc> <def> <ghi>
+123456789aa-a-
+123456789aa-a-
+a_\k<01>
+-\1-
+-\k<>-
+-\k<a

--- a/ext/mbstring/tests/mb_ereg_search_named_subpatterns.phpt
+++ b/ext/mbstring/tests/mb_ereg_search_named_subpatterns.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Testing mb_ereg_search() named capture groups
+--SKIPIF--
+<?php
+if (!extension_loaded('mbstring')) die('skip mbstring not enabled');
+function_exists('mb_ereg_search') or die("skip mb_ereg_search() is not available in this build");
+?>
+--FILE--
+<?php
+    mb_regex_encoding("UTF-8");
+    mb_ereg_search_init('  中国？');
+    mb_ereg_search('(?<wsp>\s*)(?<word>\w+)(?<punct>[？！])');
+    var_dump(mb_ereg_search_getregs());
+?>
+--EXPECT--
+array(7) {
+  [0]=>
+  string(11) "  中国？"
+  [1]=>
+  string(2) "  "
+  [2]=>
+  string(6) "中国"
+  [3]=>
+  string(3) "？"
+  ["punct"]=>
+  string(3) "？"
+  ["wsp"]=>
+  string(2) "  "
+  ["word"]=>
+  string(6) "中国"
+}


### PR DESCRIPTION
Fixes Bug #72704.
## Changes to `mb_ereg`

The third parameters passed to `mb_ereg` now contains both numbered and named references to the capturing groups.

``` php
mb_ereg('(?<wsp>\s*)(?<word>\w+)', '  国', $m);
$m == [0 => "  国", 1 => "  ", 2 => "国", "wsp" => "  ", "word" => "国"];
```
## Changes to `mb_ereg_search_regs` and `mb_ereg_search_getregs`

The two functions now return both numbered and named references to the capturing groups. (see above)
## Changes to `mb_ereg_replace_callback`

Named references to the capturing groups are now passed to `mb_ereg_replace_callback`.

``` php
mb_ereg_replace_callback('(?<word>\w+)', function($m){ return $m['word']; }, '国国');
//=> "国国"
```
## Changes to `mb_ereg_replace`

This PR adds a subset of the [oniguruma back-reference syntax](https://github.com/kkos/oniguruma/blob/master/doc/RE#L234) for replacement strings in `mb_ereg_replace`:
- `\k<name>` and `\k'name'` for named subpatterns.
- `\k<n>` and `\k'n'` for numbered subpatterns

These last two notations allow referencing numbered groups where n > 9, which is not currently implemented with the `\n` notation (and isn't implemented by Ruby either).

Examples:

``` php
mb_ereg_replace('\s*(?<word>\w+)\s*', "_\k<word>_\k'word'_", '  foo  ' );
// => "_foo_foo_"
mb_ereg_replace('(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(\10)', "_\k<10>_\k'11'_", 'abcdefghijj');
// => "_j_j_"
```

Note that if the pattern contains named subpatterns, numbered references in the replacement string will be ignored (except the '\0' reference):

``` php
mb_ereg_replace('(?<a>A)\k<a>', '-\1-\0', 'AA');
//=> "-\1-AA"
```

This behavior is for consistency with Oniguruma, which does not allow numbered backreferences in a pattern using named subpatterns:

``` php
mb_ereg('(?<a>A)\1', 'AA');
//=> PHP warning:  mb_ereg(): mbregex compile err: numbered backref/call is not allowed. (use name) on line 1
```
