### PR TITLE
makes `mb_ereg` clear the `$regs` argument on failure

### DIFF
--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -704,6 +704,11 @@ static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 		RETURN_FALSE;
 	}
 
+	if (array != NULL) {
+		zval_dtor(array);
+		array_init(array);
+	}
+
 	options = MBREX(regex_default_options);
 	if (icase) {
 		options |= ONIG_OPTION_IGNORECASE;
@@ -743,8 +748,6 @@ static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 	str = string;
 	if (array != NULL) {
 		match_len = regs->end[0] - regs->beg[0];
-		zval_dtor(array);
-		array_init(array);
 		for (i = 0; i < regs->num_regs; i++) {
 			beg = regs->beg[i];
 			end = regs->end[i];

--- a/ext/mbstring/tests/bug43994.phpt
+++ b/ext/mbstring/tests/bug43994.phpt
@@ -8,12 +8,12 @@ function_exists('mb_ereg') or die("skip mb_ereg() is not available in this build
 --FILE--
 <?php
 /* Prototype  : int mb_ereg(string $pattern, string $string [, array $registers])
- * Description: Regular expression match for multibyte string 
+ * Description: Regular expression match for multibyte string
  * Source code: ext/mbstring/php_mbregex.c
  */
 
 /*
- * mb_ereg 'successfully' matching incorrectly: 
+ * mb_ereg 'successfully' matching incorrectly:
  * Bug now seems to be fixed - error message is now generated when an 'empty'
  * pattern is supplied to mb_ereg. Similar error message to ereg().
  */
@@ -38,7 +38,7 @@ foreach($inputs as $input) {
 };
 ?>
 
---EXPECTF-- 
+--EXPECTF--
 
 -- Iteration 1 --
 Without $regs arg:
@@ -49,7 +49,8 @@ With $regs arg:
 
 Warning: mb_ereg(): empty pattern in %s on line %d
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 2 --
 Without $regs arg:
@@ -60,7 +61,8 @@ With $regs arg:
 
 Warning: mb_ereg(): empty pattern in %s on line %d
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 3 --
 Without $regs arg:
@@ -71,7 +73,8 @@ With $regs arg:
 
 Warning: mb_ereg(): empty pattern in %s on line %d
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 4 --
 Without $regs arg:
@@ -82,7 +85,8 @@ With $regs arg:
 
 Warning: mb_ereg(): empty pattern in %s on line %d
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 5 --
 Without $regs arg:
@@ -93,7 +97,8 @@ With $regs arg:
 
 Warning: mb_ereg(): empty pattern in %s on line %d
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 6 --
 Without $regs arg:
@@ -104,7 +109,8 @@ With $regs arg:
 
 Warning: mb_ereg(): empty pattern in %s on line %d
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 7 --
 Without $regs arg:
@@ -115,7 +121,8 @@ With $regs arg:
 
 Warning: mb_ereg(): empty pattern in %s on line %d
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 8 --
 Without $regs arg:
@@ -126,4 +133,5 @@ With $regs arg:
 
 Warning: mb_ereg(): empty pattern in %s on line %d
 bool(false)
-NULL
+array(0) {
+}

--- a/ext/mbstring/tests/mb_ereg1.phpt
+++ b/ext/mbstring/tests/mb_ereg1.phpt
@@ -19,7 +19,7 @@ foreach ($a as $args) {
 }
 ?>
 ===DONE===
---EXPECTF--	
+--EXPECTF--
 bool(false)
 array(3) {
   [0]=>
@@ -27,7 +27,8 @@ array(3) {
   [1]=>
   int(2)
   [2]=>
-  int(3)
+  array(0) {
+  }
 }
 
 Warning: mb_ereg(): empty pattern in %s on line %d
@@ -38,7 +39,8 @@ array(3) {
   [1]=>
   string(0) ""
   [2]=>
-  string(0) ""
+  array(0) {
+  }
 }
 
 Notice: Array to string conversion in %s on line %d
@@ -50,7 +52,8 @@ array(3) {
   [1]=>
   int(1)
   [2]=>
-  string(0) ""
+  array(0) {
+  }
 }
 
 Warning: mb_ereg() expects parameter 2 to be string, array given in %s on line %d

--- a/ext/mbstring/tests/mb_ereg_basic.phpt
+++ b/ext/mbstring/tests/mb_ereg_basic.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test mb_ereg() function : basic functionality 
+Test mb_ereg() function : basic functionality
 --SKIPIF--
 <?php
 extension_loaded('mbstring') or die('skip');
@@ -8,7 +8,7 @@ function_exists('mb_ereg') or die("skip mb_ereg() is not available in this build
 --FILE--
 <?php
 /* Prototype  : int mb_ereg(string $pattern, string $string [, array $registers])
- * Description: Regular expression match for multibyte string 
+ * Description: Regular expression match for multibyte string
  * Source code: ext/mbstring/php_mbregex.c
  */
 
@@ -113,5 +113,6 @@ array(3) {
   string(8) "MTIzNA=="
 }
 bool(false)
-NULL
+array(0) {
+}
 Done

--- a/ext/mbstring/tests/mb_ereg_variation1.phpt
+++ b/ext/mbstring/tests/mb_ereg_variation1.phpt
@@ -8,8 +8,8 @@ function_exists('mb_ereg') or die("skip mb_ereg() is not available in this build
 --FILE--
 <?php
 /* Prototype  : int mb_ereg(string $pattern, string $string [, array $registers])
- * Description: Regular expression match for multibyte string 
- * Source code: ext/mbstring/php_mbregex.c 
+ * Description: Regular expression match for multibyte string
+ * Source code: ext/mbstring/php_mbregex.c
  */
 
 /*
@@ -65,7 +65,7 @@ $inputs = array(
 /*12*/ "string",
        'string',
        $heredoc,
- 
+
 // object data
 /*15*/ new classA(),
 
@@ -95,47 +95,58 @@ echo "Done";
 
 -- Iteration 1 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 2 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 3 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 4 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 5 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 6 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 7 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 8 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 9 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 10 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 11 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 12 --
 int(6)
@@ -153,13 +164,16 @@ array(1) {
 
 -- Iteration 14 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 15 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 16 --
 bool(false)
-NULL
+array(0) {
+}
 Done

--- a/ext/mbstring/tests/mb_ereg_variation2.phpt
+++ b/ext/mbstring/tests/mb_ereg_variation2.phpt
@@ -8,7 +8,7 @@ function_exists('mb_ereg') or die("skip mb_ereg() is not available in this build
 --FILE--
 <?php
 /* Prototype  : int mb_ereg(string $pattern, string $string [, array $registers])
- * Description: Regular expression match for multibyte string 
+ * Description: Regular expression match for multibyte string
  * Source code: ext/mbstring/php_mbregex.c
  */
 
@@ -66,7 +66,7 @@ $inputs = array(
        false,
        TRUE,
        FALSE,
- 
+
 // empty data
 /*16*/ "",
        '',
@@ -75,7 +75,7 @@ $inputs = array(
 /*18*/ "string",
        'string',
        $heredoc,
- 
+
 // object data
 /*21*/ new classA(),
 
@@ -112,71 +112,88 @@ echo "Done";
 
 -- Iteration 1 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 2 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 3 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 4 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 5 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 6 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 7 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 8 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 9 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 10 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 11 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 12 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 13 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 14 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 15 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 16 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 17 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 18 --
 int(3)
@@ -194,19 +211,23 @@ array(1) {
 
 -- Iteration 20 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 21 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 22 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 23 --
 bool(false)
-NULL
+array(0) {
+}
 
 -- Iteration 24 --
 


### PR DESCRIPTION
When `mb_ereg` failed to match, it didn't update the `$regs` argument.
Now it will always set it to the empty array.

Fixes bug #72711