### PR TITLE
substr_compare: Ignore length parameter if NULL

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5700,14 +5700,15 @@ PHP_FUNCTION(substr_compare)
 {
 	zend_string *s1, *s2;
 	zend_long offset, len=0;
+	zend_bool len_is_default=1;
 	zend_bool cs=0;
 	size_t cmp_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SSl|lb", &s1, &s2, &offset, &len, &cs) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SSl|l!b", &s1, &s2, &offset, &len, &len_is_default, &cs) == FAILURE) {
 		RETURN_FALSE;
 	}
 
-	if (ZEND_NUM_ARGS() >= 4 && len <= 0) {
+	if (!len_is_default && len <= 0) {
 		if (len == 0) {
 			RETURN_LONG(0L);
 		} else {

--- a/ext/standard/tests/strings/bug55451.phpt
+++ b/ext/standard/tests/strings/bug55451.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #55451 (substr_compare with NULL as default length)
+--FILE--
+<?php
+var_dump(substr_compare("abcde", "ABCD", 0, NULL, false) != 0);
+var_dump(substr_compare("abcde", "ABCD", 0, NULL, true) != 0);
+var_dump(substr_compare("abcde", "ABCDE", 0, NULL, false) != 0);
+var_dump(substr_compare("abcde", "ABCDE", 0, NULL, true) == 0);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/standard/tests/strings/substr_compare.phpt
+++ b/ext/standard/tests/strings/substr_compare.phpt
@@ -39,7 +39,7 @@ Test
 
 Warning: substr_compare(): The length must be greater than or equal to zero in %s on line %d
 bool(false)
-int(0)
+int(4)
 
 Warning: substr_compare() expects parameter 4 to be integer, string given in %s on line %d
 bool(false)


### PR DESCRIPTION
Make substr_compare ignore the length if it's NULL. This allows to use the last parameter (case_insensitivity) with the default length. Fixes bug #55451.