### PR TITLE
Use non-deprecated %pure-parser directive

### DIFF
--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -260,7 +260,7 @@ ZEND_API int zend_parse_ini_string(char *str, zend_bool unbuffered_errors, int s
 %}
 
 %expect 0
-%pure_parser
+%pure-parser
 
 %token TC_SECTION
 %token TC_RAW

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -43,7 +43,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 
 %}
 
-%pure_parser
+%pure-parser
 %expect 0
 
 %code requires {


### PR DESCRIPTION
Should solve these two deprecation notices when compiling:

```
/php-src/Zend/zend_language_parser.y:46.1-12: warning: deprecated directive, use '%pure-parser' [-Wdeprecated]
 %pure_parser
 ^^^^^^^^^^^^
/php-src/Zend/zend_ini_parser.y:263.1-12: warning: deprecated directive, use '%pure-parser' [-Wdeprecated]
 %pure_parser
 ^^^^^^^^^^^^
```