### PR TITLE
Fix #72764. ftps:// opendir - Negotiate data channel encryption after NLST command

### DIFF
--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -288,6 +288,10 @@ if ($pid) {
 			}
 
 
+			if ((!empty($ssl)) && (!stream_socket_enable_crypto($pasvs, true, STREAM_CRYPTO_METHOD_SSLv23_SERVER))) {
+				die("SSLv23 handshake failed.\n");
+			}
+
 			if (empty($m[1]) || $m[1] !== 'emptydir') {
 				fputs($fs, "file1\r\nfile1\r\nfile\nb0rk\r\n");
 			}
@@ -402,10 +406,6 @@ if ($pid) {
 			fputs($s, "227 Entering Passive Mode. (127,0,0,1,{$p1},{$p2})\r\n");
 
 			$pasvs = stream_socket_accept($soc,10);
-
-			if ((!empty($ssl)) && (!stream_socket_enable_crypto($pasvs, true, STREAM_CRYPTO_METHOD_SSLv23_SERVER))) {
-				die("SSLv23 handshake failed.\n");
-			}
 
 		}elseif (preg_match('/^EPSV/', $buf, $matches)) {
 			fputs($s, "550 Extended passsive mode not supported.\r\n");

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -737,17 +737,6 @@ php_stream * php_stream_ftp_opendir(php_stream_wrapper *wrapper, const char *pat
 		goto opendir_errexit;
 	}
 
-	php_stream_context_set(datastream, context);
-	if (use_ssl_on_data && (php_stream_xport_crypto_setup(datastream,
-			STREAM_CRYPTO_METHOD_SSLv23_CLIENT, NULL TSRMLS_CC) < 0 ||
-			php_stream_xport_crypto_enable(datastream, 1 TSRMLS_CC) < 0)) {
-
-		php_stream_wrapper_log_error(wrapper, options TSRMLS_CC, "Unable to activate SSL mode");
-		php_stream_close(datastream);
-		datastream = NULL;
-		goto opendir_errexit;
-	}
-
 
 	php_stream_printf(stream TSRMLS_CC, "NLST %s\r\n", (resource->path != NULL ? resource->path : "/"));
 
@@ -756,6 +745,17 @@ php_stream * php_stream_ftp_opendir(php_stream_wrapper *wrapper, const char *pat
 		/* Could not retrieve or send the file
 		 * this data will only be sent to us after connection on the data port was initiated.
 		 */
+		php_stream_close(datastream);
+		datastream = NULL;
+		goto opendir_errexit;
+	}
+
+	php_stream_context_set(datastream, context);
+	if (use_ssl_on_data && (php_stream_xport_crypto_setup(datastream,
+			STREAM_CRYPTO_METHOD_SSLv23_CLIENT, NULL TSRMLS_CC) < 0 ||
+			php_stream_xport_crypto_enable(datastream, 1 TSRMLS_CC) < 0)) {
+
+		php_stream_wrapper_log_error(wrapper, options TSRMLS_CC, "Unable to activate SSL mode");
 		php_stream_close(datastream);
 		datastream = NULL;
 		goto opendir_errexit;


### PR DESCRIPTION
This is to prevent FTPS issues with IIS, ProFTPD and essentially fixes the mistake I did on PR #2032.

Sorry about that. 