### PR TITLE
call_user_func(_array): Don't abort on reference warning

### DIFF
--- a/Zend/tests/call_user_func_008.phpt
+++ b/Zend/tests/call_user_func_008.phpt
@@ -1,0 +1,68 @@
+--TEST--
+call_user_func() behavior with references
+--FILE--
+<?php
+
+function test(&$ref1, &$ref2) {
+    $ref1 += 42;
+    $ref2 -= 42;
+    return true;
+}
+
+$i = $j = 0;
+var_dump(call_user_func('test', $i, $j));
+var_dump($i, $j);
+
+var_dump(call_user_func_array('test', [$i, $j]));
+var_dump($i, $j);
+
+$x =& $i; $y =& $j;
+var_dump(call_user_func('test', $i, $j));
+var_dump($i, $j);
+
+var_dump(call_user_func_array('test', [$i, $j]));
+var_dump($i, $j);
+
+$arr = [0, 0];
+$x =& $arr[0];
+$y =& $arr[1];
+unset($x, $y);
+var_dump(call_user_func_array('test', $arr));
+var_dump($arr[0], $arr[1]);
+
+?>
+--EXPECTF--
+Warning: Parameter 1 to test() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 2 to test() expected to be a reference, value given in %s on line %d
+bool(true)
+int(0)
+int(0)
+
+Warning: Parameter 1 to test() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 2 to test() expected to be a reference, value given in %s on line %d
+bool(true)
+int(0)
+int(0)
+
+Warning: Parameter 1 to test() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 2 to test() expected to be a reference, value given in %s on line %d
+bool(true)
+int(0)
+int(0)
+
+Warning: Parameter 1 to test() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 2 to test() expected to be a reference, value given in %s on line %d
+bool(true)
+int(0)
+int(0)
+
+Warning: Parameter 1 to test() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 2 to test() expected to be a reference, value given in %s on line %d
+bool(true)
+int(0)
+int(0)

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -787,42 +787,35 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 		zval *arg = &fci->params[i];
 
 		if (ARG_SHOULD_BE_SENT_BY_REF(func, i + 1)) {
-			if (UNEXPECTED(!Z_ISREF_P(arg))) {
-				if (fci->no_separation &&
-					!ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
-					if (i) {
-						/* hack to clean up the stack */
-						ZEND_CALL_NUM_ARGS(call) = i;
-						zend_vm_stack_free_args(call);
-					}
-					zend_vm_stack_free_call_frame(call);
-
-					zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
-						i+1,
+			/* References with refcount=1 are treated as non-references */
+			if (UNEXPECTED(!Z_ISREF_P(arg) || Z_REFCOUNT_P(arg) == 1)) {
+				if (ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
+					/* Send by-value */
+					ZVAL_DEREF(arg);
+				} else if (!fci->no_separation) {
+					/* Separation is enabled -- create a ref */
+					ZVAL_MAKE_REF(arg);
+				} else {
+					/* By-value send is not allowed -- emit a warning,
+					 * but still perform the call with a by-value send. */
+					ZVAL_DEREF(arg);
+					zend_error(E_WARNING,
+						"Parameter %d to %s%s%s() expected to be a reference, value given", i+1,
 						func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
 						func->common.scope ? "::" : "",
 						ZSTR_VAL(func->common.function_name));
-					if (EG(current_execute_data) == &dummy_execute_data) {
-						EG(current_execute_data) = dummy_execute_data.prev_execute_data;
-					}
-					return FAILURE;
 				}
-
-				ZVAL_NEW_REF(arg, arg);
 			}
-			Z_ADDREF_P(arg);
 		} else {
 			if (Z_ISREF_P(arg) &&
 			    !(func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
 				/* don't separate references for __call */
 				arg = Z_REFVAL_P(arg);
 			}
-			if (Z_OPT_REFCOUNTED_P(arg)) {
-				Z_ADDREF_P(arg);
-			}
 		}
+
 		param = ZEND_CALL_ARG(call, i+1);
-		ZVAL_COPY_VALUE(param, arg);
+		ZVAL_COPY(param, arg);
 	}
 
 	if (UNEXPECTED(func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4624,25 +4624,18 @@ ZEND_VM_C_LABEL(send_array):
 		param = ZEND_CALL_ARG(EX(call), 1);
 		ZEND_HASH_FOREACH_VAL(ht, arg) {
 			if (ARG_SHOULD_BE_SENT_BY_REF(EX(call)->func, arg_num)) {
-				if (UNEXPECTED(!Z_ISREF_P(arg))) {
+				if (UNEXPECTED(!Z_ISREF_P(arg) || Z_REFCOUNT_P(arg) == 1)) {
+					ZVAL_DEREF(arg);
 					if (!ARG_MAY_BE_SENT_BY_REF(EX(call)->func, arg_num)) {
-
-						zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
+						/* By-value send is not allowed -- emit a warning,
+						 * but still perform the call. */
+						zend_error(E_WARNING,
+							"Parameter %d to %s%s%s() expected to be a reference, value given",
 							arg_num,
 							EX(call)->func->common.scope ? ZSTR_VAL(EX(call)->func->common.scope->name) : "",
 							EX(call)->func->common.scope ? "::" : "",
 							ZSTR_VAL(EX(call)->func->common.function_name));
 
-						if (ZEND_CALL_INFO(EX(call)) & ZEND_CALL_CLOSURE) {
-							OBJ_RELEASE((zend_object*)EX(call)->func->common.prototype);
-						}
-						if (Z_TYPE(EX(call)->This) == IS_OBJECT) {
-							OBJ_RELEASE(Z_OBJ(EX(call)->This));
-						}
-						EX(call)->func = (zend_function*)&zend_pass_function;
-						Z_OBJ(EX(call)->This) = NULL;
-						ZEND_SET_CALL_INFO(EX(call), 0, ZEND_CALL_INFO(EX(call)) & ~ZEND_CALL_RELEASE_THIS);
-						break;
 					}
 				}
 			} else {
@@ -4673,25 +4666,12 @@ ZEND_VM_HANDLER(120, ZEND_SEND_USER, VAR|CV, NUM)
 	param = ZEND_CALL_VAR(EX(call), opline->result.var);
 
 	if (UNEXPECTED(ARG_MUST_BE_SENT_BY_REF(EX(call)->func, opline->op2.num))) {
+		ZVAL_DEREF(arg);
 		zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
 			opline->op2.num,
 			EX(call)->func->common.scope ? ZSTR_VAL(EX(call)->func->common.scope->name) : "",
 			EX(call)->func->common.scope ? "::" : "",
 			ZSTR_VAL(EX(call)->func->common.function_name));
-
-		if (ZEND_CALL_INFO(EX(call)) & ZEND_CALL_CLOSURE) {
-			OBJ_RELEASE((zend_object*)EX(call)->func->common.prototype);
-		}
-		if (Z_TYPE(EX(call)->This) == IS_OBJECT) {
-			OBJ_RELEASE(Z_OBJ(EX(call)->This));
-		}
-		ZVAL_UNDEF(param);
-		EX(call)->func = (zend_function*)&zend_pass_function;
-		Z_OBJ(EX(call)->This) = NULL;
-		ZEND_SET_CALL_INFO(EX(call), 0, ZEND_CALL_INFO(EX(call)) & ~ZEND_CALL_RELEASE_THIS);
-
-		FREE_OP1();
-		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	} else {
 		if (Z_ISREF_P(arg) &&
 		    !(EX(call)->func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1421,25 +1421,18 @@ send_array:
 		param = ZEND_CALL_ARG(EX(call), 1);
 		ZEND_HASH_FOREACH_VAL(ht, arg) {
 			if (ARG_SHOULD_BE_SENT_BY_REF(EX(call)->func, arg_num)) {
-				if (UNEXPECTED(!Z_ISREF_P(arg))) {
+				if (UNEXPECTED(!Z_ISREF_P(arg) || Z_REFCOUNT_P(arg) == 1)) {
+					ZVAL_DEREF(arg);
 					if (!ARG_MAY_BE_SENT_BY_REF(EX(call)->func, arg_num)) {
-
-						zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
+						/* By-value send is not allowed -- emit a warning,
+						 * but still perform the call. */
+						zend_error(E_WARNING,
+							"Parameter %d to %s%s%s() expected to be a reference, value given",
 							arg_num,
 							EX(call)->func->common.scope ? ZSTR_VAL(EX(call)->func->common.scope->name) : "",
 							EX(call)->func->common.scope ? "::" : "",
 							ZSTR_VAL(EX(call)->func->common.function_name));
 
-						if (ZEND_CALL_INFO(EX(call)) & ZEND_CALL_CLOSURE) {
-							OBJ_RELEASE((zend_object*)EX(call)->func->common.prototype);
-						}
-						if (Z_TYPE(EX(call)->This) == IS_OBJECT) {
-							OBJ_RELEASE(Z_OBJ(EX(call)->This));
-						}
-						EX(call)->func = (zend_function*)&zend_pass_function;
-						Z_OBJ(EX(call)->This) = NULL;
-						ZEND_SET_CALL_INFO(EX(call), 0, ZEND_CALL_INFO(EX(call)) & ~ZEND_CALL_RELEASE_THIS);
-						break;
 					}
 				}
 			} else {
@@ -15904,25 +15897,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_SEND_USER_SPEC_VAR_HANDLER(ZEN
 	param = ZEND_CALL_VAR(EX(call), opline->result.var);
 
 	if (UNEXPECTED(ARG_MUST_BE_SENT_BY_REF(EX(call)->func, opline->op2.num))) {
+		ZVAL_DEREF(arg);
 		zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
 			opline->op2.num,
 			EX(call)->func->common.scope ? ZSTR_VAL(EX(call)->func->common.scope->name) : "",
 			EX(call)->func->common.scope ? "::" : "",
 			ZSTR_VAL(EX(call)->func->common.function_name));
-
-		if (ZEND_CALL_INFO(EX(call)) & ZEND_CALL_CLOSURE) {
-			OBJ_RELEASE((zend_object*)EX(call)->func->common.prototype);
-		}
-		if (Z_TYPE(EX(call)->This) == IS_OBJECT) {
-			OBJ_RELEASE(Z_OBJ(EX(call)->This));
-		}
-		ZVAL_UNDEF(param);
-		EX(call)->func = (zend_function*)&zend_pass_function;
-		Z_OBJ(EX(call)->This) = NULL;
-		ZEND_SET_CALL_INFO(EX(call), 0, ZEND_CALL_INFO(EX(call)) & ~ZEND_CALL_RELEASE_THIS);
-
-		zval_ptr_dtor_nogc(free_op1);
-		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	} else {
 		if (Z_ISREF_P(arg) &&
 		    !(EX(call)->func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
@@ -34925,24 +34905,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_SEND_USER_SPEC_CV_HANDLER(ZEND
 	param = ZEND_CALL_VAR(EX(call), opline->result.var);
 
 	if (UNEXPECTED(ARG_MUST_BE_SENT_BY_REF(EX(call)->func, opline->op2.num))) {
+		ZVAL_DEREF(arg);
 		zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
 			opline->op2.num,
 			EX(call)->func->common.scope ? ZSTR_VAL(EX(call)->func->common.scope->name) : "",
 			EX(call)->func->common.scope ? "::" : "",
 			ZSTR_VAL(EX(call)->func->common.function_name));
-
-		if (ZEND_CALL_INFO(EX(call)) & ZEND_CALL_CLOSURE) {
-			OBJ_RELEASE((zend_object*)EX(call)->func->common.prototype);
-		}
-		if (Z_TYPE(EX(call)->This) == IS_OBJECT) {
-			OBJ_RELEASE(Z_OBJ(EX(call)->This));
-		}
-		ZVAL_UNDEF(param);
-		EX(call)->func = (zend_function*)&zend_pass_function;
-		Z_OBJ(EX(call)->This) = NULL;
-		ZEND_SET_CALL_INFO(EX(call), 0, ZEND_CALL_INFO(EX(call)) & ~ZEND_CALL_RELEASE_THIS);
-
-		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	} else {
 		if (Z_ISREF_P(arg) &&
 		    !(EX(call)->func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {

--- a/ext/reflection/tests/bug42976.phpt
+++ b/ext/reflection/tests/bug42976.phpt
@@ -27,12 +27,8 @@ echo "Done\n";
 string(9) "x.changed"
 
 Warning: Parameter 1 to C::__construct() expected to be a reference, value given in %sbug42976.php on line 15
-
-Warning: ReflectionClass::newInstance(): Invocation of C's constructor failed in %sbug42976.php on line 15
 string(10) "x.original"
 
 Warning: Parameter 1 to C::__construct() expected to be a reference, value given in %sbug42976.php on line 18
-
-Warning: ReflectionClass::newInstanceArgs(): Invocation of C's constructor failed in %sbug42976.php on line 18
 string(10) "x.original"
 Done

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1453,6 +1453,9 @@ static void spl_array_method(INTERNAL_FUNCTION_PARAMETERS, char *fname, int fnam
 	ZVAL_ARR(Z_REFVAL(params[0]), aht);
 	GC_REFCOUNT(aht)++;
 
+	/* Reference should have refcount>1 so it is a "real" reference */
+	Z_ADDREF(params[0]);
+
 	if (!use_arg) {
 		intern->nApplyCount++;
 		call_user_function_ex(EG(function_table), NULL, &function_name, return_value, 1, params, 1, NULL);

--- a/ext/standard/tests/general_functions/bug41970.phpt
+++ b/ext/standard/tests/general_functions/bug41970.phpt
@@ -14,13 +14,13 @@ echo "Done\n";
 ?>
 --EXPECTF--
 Warning: Parameter 1 to sort() expected to be a reference, value given in %sbug41970.php on line 5
-NULL
+bool(true)
 
 Warning: strlen() expects parameter 1 to be string, array given in %sbug41970.php on line 6
 NULL
 
 Warning: Parameter 1 to sort() expected to be a reference, value given in %sbug41970.php on line 7
-NULL
+bool(true)
 
 Warning: strlen() expects parameter 1 to be string, array given in %sbug41970.php on line 8
 NULL


### PR DESCRIPTION
This commit implements two changes:
a) zend_call_function() will treat reference zvals with refcount=1
   as if they were non-reference zvals.
b) zend_call_function() will allow performing calls where a
   reference argument is passed by-value. The usual warning is
   still emitted, but the call is no longer aborted.

The motivation for these changes is that currently the interaction
of references and call_user_func_array() is very fragile and
harmless internal changes can break calls as a side-effect. The
reason is that due to internal optimizations (e.g. the recent
array_slice() change that breaks WordPress) reference zvals with
rc=1 may not be retained in an array (which is by itself perfectly
fine, because rc=1 references are not references). Currently this
will cause call_user_func_array() to fail.

This change tries to counteract this by a) making sure we don't
treat rc=1 zvals as references and thus make the behavior
independent from internal details and b) making sure we don't
introduce backwards-compatibility issues by no longer aborting
the function call on the warning.