### PR TITLE
Recognize TDS versions 7.3 and 7.4

### DIFF
--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -281,6 +281,12 @@ static int pdo_dblib_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_
 		,{"7.2",DBVERSION_72}
 		,{"8.0",DBVERSION_72}
 #endif
+#ifdef DBVERSION_73
+		,{"7.3",DBVERSION_73}
+#endif
+#ifdef DBVERSION_74
+		,{"7.4",DBVERSION_74}
+#endif
 		,{"10.0",DBVERSION_100}
 		,{"auto",0} /* Only works with FreeTDS. Other drivers will bork */
 		


### PR DESCRIPTION
This should prevent errors when using FreeTDS 0.95 and 1.00 with SQL Server 2008 and SQL Server 2012 / 2014. Also see http://www.freetds.org/userguide/tdshistory.htm