### PR TITLE
ReflectionType improvements

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3039,7 +3039,7 @@ ZEND_METHOD(reflection_type, __toString)
 	
 	if (param->arg_info->allow_null) {
 		str = zend_string_extend(str, ZSTR_LEN(str) + 1, 0);
-		memmove(ZSTR_VAL(str) + 1, ZSTR_VAL(str), ZSTR_LEN(str));
+		memmove(ZSTR_VAL(str) + 1, ZSTR_VAL(str), ZSTR_LEN(str) + 1);
 		ZSTR_VAL(str)[0] = '?';
 	}
 	

--- a/ext/reflection/php_reflection.h
+++ b/ext/reflection/php_reflection.h
@@ -38,6 +38,7 @@ extern PHPAPI zend_class_entry *reflection_function_abstract_ptr;
 extern PHPAPI zend_class_entry *reflection_function_ptr;
 extern PHPAPI zend_class_entry *reflection_parameter_ptr;
 extern PHPAPI zend_class_entry *reflection_type_ptr;
+extern PHPAPI zend_class_entry *reflection_named_type_ptr;
 extern PHPAPI zend_class_entry *reflection_class_ptr;
 extern PHPAPI zend_class_entry *reflection_object_ptr;
 extern PHPAPI zend_class_entry *reflection_method_ptr;

--- a/ext/reflection/tests/ReflectionExtension_getClasses_basic.phpt
+++ b/ext/reflection/tests/ReflectionExtension_getClasses_basic.phpt
@@ -9,7 +9,7 @@ var_dump($ext->getClasses());
 ?>
 ==DONE==
 --EXPECT--
-array(15) {
+array(16) {
   ["ReflectionException"]=>
   object(ReflectionClass)#2 (1) {
     ["name"]=>
@@ -50,38 +50,43 @@ array(15) {
     ["name"]=>
     string(14) "ReflectionType"
   }
-  ["ReflectionMethod"]=>
+  ["ReflectionNamedType"]=>
   object(ReflectionClass)#10 (1) {
+    ["name"]=>
+    string(19) "ReflectionNamedType"
+  }
+  ["ReflectionMethod"]=>
+  object(ReflectionClass)#11 (1) {
     ["name"]=>
     string(16) "ReflectionMethod"
   }
   ["ReflectionClass"]=>
-  object(ReflectionClass)#11 (1) {
+  object(ReflectionClass)#12 (1) {
     ["name"]=>
     string(15) "ReflectionClass"
   }
   ["ReflectionObject"]=>
-  object(ReflectionClass)#12 (1) {
+  object(ReflectionClass)#13 (1) {
     ["name"]=>
     string(16) "ReflectionObject"
   }
   ["ReflectionProperty"]=>
-  object(ReflectionClass)#13 (1) {
+  object(ReflectionClass)#14 (1) {
     ["name"]=>
     string(18) "ReflectionProperty"
   }
   ["ReflectionClassConstant"]=>
-  object(ReflectionClass)#14 (1) {
+  object(ReflectionClass)#15 (1) {
     ["name"]=>
     string(23) "ReflectionClassConstant"
   }
   ["ReflectionExtension"]=>
-  object(ReflectionClass)#15 (1) {
+  object(ReflectionClass)#16 (1) {
     ["name"]=>
     string(19) "ReflectionExtension"
   }
   ["ReflectionZendExtension"]=>
-  object(ReflectionClass)#16 (1) {
+  object(ReflectionClass)#17 (1) {
     ["name"]=>
     string(23) "ReflectionZendExtension"
   }

--- a/ext/reflection/tests/ReflectionNamedType.phpt
+++ b/ext/reflection/tests/ReflectionNamedType.phpt
@@ -1,0 +1,41 @@
+--TEST--
+ReflectionNamedType::getName() and ReflectionNamedType::__toString()
+--FILE--
+<?php
+
+function testInternalTypes(?Traversable $traversable): ?string {
+	return 'test';
+}
+
+function testUserDefinedTypes(?Test $traversable): ?Test {
+	return new Test;
+}
+
+$function = new ReflectionFunction('testInternalTypes');
+$type = $function->getParameters()[0]->getType();
+$return = $function->getReturnType();
+
+var_dump($type->getName());
+var_dump((string) $type);
+var_dump($return->getName());
+var_dump((string) $return);
+
+$function = new ReflectionFunction('testUserDefinedTypes');
+$type = $function->getParameters()[0]->getType();
+$return = $function->getReturnType();
+
+var_dump($type->getName());
+var_dump((string) $type);
+var_dump($return->getName());
+var_dump((string) $return);
+
+?>
+--EXPECTF--
+string(11) "Traversable"
+string(12) "?Traversable"
+string(6) "string"
+string(7) "?string"
+string(4) "Test"
+string(5) "?Test"
+string(4) "Test"
+string(5) "?Test"

--- a/ext/reflection/tests/ReflectionType_001.phpt
+++ b/ext/reflection/tests/ReflectionType_001.phpt
@@ -94,7 +94,7 @@ string(8) "callable"
 bool(true)
 bool(true)
 bool(false)
-string(8) "stdClass"
+string(9) "?stdClass"
 ** Function 0 - Parameter 4
 bool(false)
 ** Function 0 - Parameter 5


### PR DESCRIPTION
Implements a portion of @morrisonlevi's [ReflectionType Improvements RFC](https://wiki.php.net/rfc/reflectiontypeimprovements) that is necessary due to the [Nullable Types RFC](https://wiki.php.net/rfc/nullable_types).

`ReflectionParameter::getType()` and `ReflectionFunctionAbstract::getReturnType()` now return an instance of `ReflectionNamedType`. This class extends `ReflectionType`, adding a `getName()` method that returns the type name as a string. This method provides a means of retrieving the type name without casting the `ReflectionType` object to a string.

`ReflectionType::__toString()` was updated to prepend a `?` if the type is nullable, maintaining the string representation of `ReflectionType` as a syntax-valid representation of the type.

The BC impact of this PR should be minimal. In fact, *not* applying these changes may have a bigger impact to BC. Without the changes in this PR projects such as PHPUnit, PHPSpec, and Mockery fail to produce code compatible with function signatures including nullable types. These projects depend on the string representation of `ReflectionType` to generate code compatible with the parent class or interface. After the changes in this PR, these projects work as expected with nullable types.

@krakjoe @dshafik I'd like to merge this for 7.1. I think these changes to reflection are necessary and should not wait for 7.2.