### PR TITLE
Implement array_search for all values (return array of keys)

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -328,6 +328,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_array_search, 0, 0, 2)
 	ZEND_ARG_INFO(0, needle)
 	ZEND_ARG_INFO(0, haystack) /* ARRAY_INFO(0, haystack, 0) */
 	ZEND_ARG_INFO(0, strict)
+	ZEND_ARG_INFO(0, all)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_extract, 0, 0, 1)

--- a/ext/standard/tests/array/array_search_all.phpt
+++ b/ext/standard/tests/array/array_search_all.phpt
@@ -1,0 +1,36 @@
+--TEST--
+array_search() tests
+--FILE--
+<?php
+
+$a = array(1=>0, 2=>1, 4=>3, 5=>3, "a"=>"b", "c"=>"d", "e"=>"3");
+
+var_dump(array_search(9, $a, true, true));
+var_dump(array_search(3, $a, true, true));
+var_dump(array_search(3, $a, false, true));
+var_dump(array_search("d", $a, true, true));
+
+?>
+Done
+--EXPECTF--
+array(0) {
+}
+array(2) {
+  [0]=>
+  int(4)
+  [1]=>
+  int(5)
+}
+array(3) {
+  [0]=>
+  int(4)
+  [1]=>
+  int(5)
+  [2]=>
+  string(1) "e"
+}
+array(1) {
+  [0]=>
+  string(1) "c"
+}
+Done

--- a/ext/standard/tests/array/array_search_errors.phpt
+++ b/ext/standard/tests/array/array_search_errors.phpt
@@ -14,7 +14,7 @@ var_dump( array_search() );
 
 /* unexpected no.of arguments in array_search() */
 $var = array("mon", "tues", "wed", "thurs");
-var_dump( array_search(1, $var, 0, "test") );
+var_dump( array_search(1, $var, 0, "test", "foo") );
 var_dump( array_search("test") );
 
 /* unexpected second argument in array_search() */
@@ -30,7 +30,7 @@ echo "Done\n";
 Warning: array_search() expects at least 2 parameters, 0 given in %s on line %d
 NULL
 
-Warning: array_search() expects at most 3 parameters, 4 given in %s on line %d
+Warning: array_search() expects at most 4 parameters, 5 given in %s on line %d
 NULL
 
 Warning: array_search() expects at least 2 parameters, 1 given in %s on line %d


### PR DESCRIPTION
I notice there is no simple way to search all values in an array (to retrieve all the keys)

Here is a simple implementation.

I also add a ZVAL_STR_OR_LONG which can perhaps be moved in Zend, as probably used in lot of places.

7.1 seems a good candidate for a very minor self-contained change (else 7.2/master is fine)