### PR TITLE
change the visibility of get_next_char

### DIFF
--- a/ext/standard/html.c
+++ b/ext/standard/html.c
@@ -98,7 +98,7 @@ static char *get_default_charset(void) {
 
 /* {{{ get_next_char
  */
-static inline unsigned int get_next_char(
+PHPAPI unsigned int get_next_char(
 		enum entity_charset charset,
 		const unsigned char *str,
 		size_t str_len,
@@ -373,7 +373,7 @@ static inline unsigned int get_next_char(
 /* {{{ entity_charset determine_charset
  * returns the charset identifier based on current locale or a hint.
  * defaults to UTF-8 */
-static enum entity_charset determine_charset(char *charset_hint)
+PHPAPI enum entity_charset determine_charset(char *charset_hint)
 {
 	size_t i;
 	enum entity_charset charset = cs_utf_8;

--- a/ext/standard/html.h
+++ b/ext/standard/html.h
@@ -54,9 +54,18 @@ PHP_FUNCTION(htmlspecialchars_decode);
 PHP_FUNCTION(html_entity_decode);
 PHP_FUNCTION(get_html_translation_table);
 
+enum entity_charset {
+  cs_utf_8, cs_8859_1, cs_cp1252, cs_8859_15, cs_cp1251,
+	cs_8859_5, cs_cp866, cs_macroman, cs_koi8r, cs_big5,
+	cs_gb2312, cs_big5hkscs, cs_sjis, cs_eucjp,
+	cs_numelems /* used to count the number of charsets */
+};
+
 PHPAPI zend_string *php_escape_html_entities(unsigned char *old, size_t oldlen, int all, int flags, char *hint_charset);
 PHPAPI zend_string *php_escape_html_entities_ex(unsigned char *old, size_t oldlen, int all, int flags, char *hint_charset, zend_bool double_encode);
 PHPAPI zend_string *php_unescape_html_entities(unsigned char *old, size_t oldlen, int all, int flags, char *hint_charset);
 PHPAPI unsigned int php_next_utf8_char(const unsigned char *str, size_t str_len, size_t *cursor, int *status);
+PHPAPI unsigned int get_next_char(enum entity_charset charset, const unsigned char *str, size_t str_len, size_t *cursor, int *status);
+PHPAPI enum entity_charset determine_charset(char *charset_hint);
 
 #endif /* HTML_H */

--- a/ext/standard/html_tables.h
+++ b/ext/standard/html_tables.h
@@ -28,11 +28,6 @@
 ***************************************************************************
 **************************************************************************/
 
-enum entity_charset { cs_utf_8, cs_8859_1, cs_cp1252, cs_8859_15, cs_cp1251,
-					  cs_8859_5, cs_cp866, cs_macroman, cs_koi8r, cs_big5,
-					  cs_gb2312, cs_big5hkscs, cs_sjis, cs_eucjp,
-					  cs_numelems /* used to count the number of charsets */
-					};
 #define CHARSET_UNICODE_COMPAT(cs)	((cs) <= cs_8859_1)
 #define CHARSET_SINGLE_BYTE(cs)		((cs) > cs_utf_8 && (cs) < cs_big5)
 #define CHARSET_PARTIAL_SUPPORT(cs)	((cs) >= cs_big5)

--- a/ext/standard/html_tables/html_table_gen.php
+++ b/ext/standard/html_tables/html_table_gen.php
@@ -51,11 +51,6 @@ $t = <<<CODE
 ***************************************************************************
 **************************************************************************/
 
-enum entity_charset { cs_utf_8, cs_8859_1, cs_cp1252, cs_8859_15, cs_cp1251,
-					  cs_8859_5, cs_cp866, cs_macroman, cs_koi8r, cs_big5,
-					  cs_gb2312, cs_big5hkscs, cs_sjis, cs_eucjp,
-					  cs_numelems /* used to count the number of charsets */
-					};
 #define CHARSET_UNICODE_COMPAT(cs)	((cs) <= cs_8859_1)
 #define CHARSET_SINGLE_BYTE(cs)		((cs) > cs_utf_8 && (cs) < cs_big5)
 #define CHARSET_PARTIAL_SUPPORT(cs)	((cs) >= cs_big5)
@@ -190,10 +185,10 @@ foreach ($encodings as $e) {
         if (preg_match("/^0x([0-9A-Z]{2})\t0x([0-9A-Z]{2,})/i", $l, $matches))
             $map[] = array($matches[1], $matches[2]);
     }
-    
+
     $mappy = array();
     foreach ($map as $v) { $mappy[hexdec($v[0])] = hexdec($v[1]); }
-    
+
     $mstable = array("ident" => $e['ident']);
     /* calculate two-stage tables */
     for ($i = 0; $i < 4; $i++) {
@@ -202,7 +197,7 @@ foreach ($encodings as $e) {
             $mstable[$i][$j] = isset($mappy[$cp]) ? $mappy[$cp] : NULL;
         }
     }
-    
+
     echo
 "/* {{{ Stage 2 tables for {$e['name']} */\n\n";
 
@@ -212,9 +207,9 @@ foreach ($encodings as $e) {
             $s2tables_idents[$i] = $encodings[$t[0]/5]["ident"];
             continue;
         }
-        
+
         $s2tables_idents[$i] = $e["ident"];
-        
+
         echo "static const enc_to_uni_stage2 enc_to_uni_s2_{$e['ident']}_".
             sprintf("%02X", $i << 6)." = { {\n";
         for ($j = 0; $j < 64; $j++) {
@@ -227,10 +222,10 @@ foreach ($encodings as $e) {
                 echo "0xFFFF,"; /* special value; indicates no mapping */
         }
         echo "\n} };\n\n";
-        
+
         $prevStage2[] = $mstable[$i];
     }
-    
+
     echo
 "/* end of stage 2 tables for {$e['name']} }}} */\n\n";
 
@@ -333,23 +328,23 @@ foreach ($encodings as $e) {
         if (preg_match("/^0x([0-9A-Z]{2})\t0x([0-9A-Z]{2,})\s+#\s*(.*)$/i", $l, $matches))
             $map[] = array($matches[1], $matches[2], rtrim($matches[3]));
     }
-    
+
     $mappy = array();
     foreach ($map as $v) {
         if (hexdec($v[0]) >= $e['range'][0] && hexdec($v[0]) <= $e['range'][1])
             $mappy[hexdec($v[1])] = array(hexdec($v[0]), strtolower($v[2]));
     }
     ksort($mappy);
-    
+
     echo
 "static const uni_to_enc unimap_{$e['ident']}[] = {\n";
-    
+
     foreach ($mappy as $k => $v) {
         echo "\t{ ", sprintf("0x%04X", $k), ", ", sprintf("0x%02X", $v[0]), " },\t/* ",
             $v[1], " */\n";
     }
     echo "};\n";
-    
+
     echo
 "/* {{{ end of mappings *from* Unicode for {$e['name']} */\n\n";
 }
@@ -476,7 +471,7 @@ foreach ($multicp_rows as $k => $v) {
             $v['default'] = "gt";
 		echo "\t{ {", sprintf("\"%-21s", $v["default"].'",'),
 			"\t", sprintf("%02d", (count($v) - 1)), ",\t\t",
-            sprintf("% 2d", strlen($v["default"])), '} },', "\n"; 
+            sprintf("% 2d", strlen($v["default"])), '} },', "\n";
 	} else {
 		echo "\t{ {", sprintf("%-22s", 'NULL,'),
 			"\t", sprintf("%02d", count($v)), ",\t\t0} },\n";
@@ -484,7 +479,7 @@ foreach ($multicp_rows as $k => $v) {
 	unset($v["default"]);
 	foreach ($v as $l => $w) {
 		echo "\t{ {", sprintf("\"%-21s", $w.'",'), "\t", sprintf("0x%05s", $l), ",\t",
-            sprintf("% 2d", strlen($w)), '} },', "\n"; 
+            sprintf("% 2d", strlen($w)), '} },', "\n";
 	}
 	echo "};\n";
 }
@@ -561,7 +556,7 @@ for ($i = 0; $i < 0x1E; $i++) {
 				else
 					echo "{1, { {(void *)", sprintf("multi_cp_{$ident}_%05X",
 						($i << 12) | ($k << 6) | $y ), ", 0} } },";
-				
+
 			}
 			echo "\n};\n\n";
 		}
@@ -685,7 +680,7 @@ echo
 //			die("violated assumption for traverse_for_entities");
 //		}
 //	}
-//	
+//
 //	$k++;
 //}
 //echo "\n};\n\n";


### PR DESCRIPTION
This proposal is about changing the visiblity of `get_next_char` and `entity_charset determine_charset`.

These functions are useful for the developers who want to propose standard functions for PHP.
The one of shortcut of `get_next_char` is `php_next_utf8_char` and is already used in json and xml modules.
