### PR TITLE
get_class() disallow null parameter RFC

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,5 +29,10 @@ PHP                                                                        NEWS
   . Implemented request #69086 (enhancement for mb_convert_encoding() that
     handles multibyte replacement char nicely) (Masakielastic, Yasuo)
 
+- Standard:
+  . Implemented RFC: get_class() disallow null parameter. Passing null to
+    get_class() now generates a warning, rather than returning the calling
+    class scope.
+
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>
 

--- a/Zend/tests/009.phpt
+++ b/Zend/tests/009.phpt
@@ -7,6 +7,10 @@ class foo {
 	function bar () {
 		var_dump(get_class());
 	}
+    function testNull ()
+    {
+        var_dump(get_class(null));
+    }
 }
 
 class foo2 extends foo {
@@ -27,6 +31,8 @@ var_dump(get_class("qwerty"));
 var_dump(get_class($f1));
 var_dump(get_class($f2));
 
+$f1->testNull();
+
 echo "Done\n";
 ?>
 --EXPECTF--	
@@ -45,4 +51,7 @@ Warning: get_class() expects parameter 1 to be object, string given in %s on lin
 bool(false)
 string(3) "foo"
 string(4) "foo2"
+
+Warning: get_class() expects parameter 1 to be object, null given in %s on line %d
+bool(false)
 Done

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1009,7 +1009,7 @@ ZEND_FUNCTION(get_class)
 {
 	zval *obj = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|o!", &obj) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|o", &obj) == FAILURE) {
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/tests/class_object/get_class_variation_001.phpt
+++ b/ext/standard/tests/class_object/get_class_variation_001.phpt
@@ -152,12 +152,12 @@ bool(false)
 
 Arg value:  (type: NULL)
 
-Warning: get_class() called without object from outside a class in %sget_class_variation_001.php on line %d
+Warning: get_class() expects parameter 1 to be object, null given in %s on line %d
 bool(false)
 
 Arg value:  (type: NULL)
 
-Warning: get_class() called without object from outside a class in %sget_class_variation_001.php on line %d
+Warning: get_class() expects parameter 1 to be object, null given in %s on line %d
 bool(false)
 
 Arg value: 1 (type: boolean)
@@ -202,11 +202,11 @@ bool(false)
 
 Arg value:  (type: NULL)
 
-Warning: get_class() called without object from outside a class in %sget_class_variation_001.php on line %d
+Warning: get_class() expects parameter 1 to be object, null given in %s on line %d
 bool(false)
 
 Arg value:  (type: NULL)
 
-Warning: get_class() called without object from outside a class in %sget_class_variation_001.php on line %d
+Warning: get_class() expects parameter 1 to be object, null given in %s on line %d
 bool(false)
 Done


### PR DESCRIPTION
Changes get_class() to disallow null being a valid parameter, as that behaviour is highly astonishing.

The ratio of the number of characters in the RFC to the actual code change, is too darn high.

https://wiki.php.net/rfc/get_class_disallow_null_parameter