### PR TITLE
fix bug #72254 - get_object_vars with numerical properties

### DIFF
--- a/Zend/tests/bug72254_1.phpt
+++ b/Zend/tests/bug72254_1.phpt
@@ -1,0 +1,26 @@
+--TEST--
+bug #72254 - simple test
+--FILE--
+<?php
+$a = new stdClass();
+$a->{1} = 5;
+var_dump($a);
+$b =get_object_vars($a);
+var_dump($b, $b[1], $b["1"], reset($b), key($b));
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+object(stdClass)#1 (1) {
+  ["1"]=>
+  int(5)
+}
+array(1) {
+  [1]=>
+  int(5)
+}
+int(5)
+int(5)
+int(5)
+int(1)
+===DONE===

--- a/Zend/tests/bug72254_2.phpt
+++ b/Zend/tests/bug72254_2.phpt
@@ -1,0 +1,27 @@
+--TEST--
+bug #72254 - test with inaccessible properties
+--FILE--
+<?php
+class A {
+	public $x = 1;
+	protected $y = 2;
+	private $z = 3;
+};
+$a = new A();
+$a->{1} = 5;
+$b =get_object_vars($a);
+var_dump($b, $b[1], $b["1"], $b["x"]);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(2) {
+  ["x"]=>
+  int(1)
+  [1]=>
+  int(5)
+}
+int(5)
+int(5)
+int(1)
+===DONE===

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1184,39 +1184,28 @@ ZEND_FUNCTION(get_object_vars)
 
 	zobj = Z_OBJ_P(obj);
 
-	if (!zobj->ce->default_properties_count && properties == zobj->properties && !ZEND_HASH_GET_APPLY_COUNT(properties)) {
-		/* fast copy */
-		if (EXPECTED(zobj->handlers == &std_object_handlers)) {
-			if (EXPECTED(!(GC_FLAGS(properties) & IS_ARRAY_IMMUTABLE))) {
-				GC_REFCOUNT(properties)++;
-			}
-			RETURN_ARR(properties);
-		}
-		RETURN_ARR(zend_array_dup(properties));
-	} else {
-		array_init_size(return_value, zend_hash_num_elements(properties));
+	array_init_size(return_value, zend_hash_num_elements(properties));
 
-		ZEND_HASH_FOREACH_STR_KEY_VAL_IND(properties, key, value) {
-			if (key) {
-				if (zend_check_property_access(zobj, key) == SUCCESS) {
-					if (Z_ISREF_P(value) && Z_REFCOUNT_P(value) == 1) {
-						value = Z_REFVAL_P(value);
-					}
-					if (Z_REFCOUNTED_P(value)) {
-						Z_ADDREF_P(value);
-					}
-					if (ZSTR_VAL(key)[0] == 0) {
-						const char *prop_name, *class_name;
-						size_t prop_len;
-						zend_unmangle_property_name_ex(key, &class_name, &prop_name, &prop_len);
-						zend_hash_str_add_new(Z_ARRVAL_P(return_value), prop_name, prop_len, value);
-					} else {
-						zend_hash_add_new(Z_ARRVAL_P(return_value), key, value);
-					}
+	ZEND_HASH_FOREACH_STR_KEY_VAL_IND(properties, key, value) {
+		if (key) {
+			if (zend_check_property_access(zobj, key) == SUCCESS) {
+				if (Z_ISREF_P(value) && Z_REFCOUNT_P(value) == 1) {
+					value = Z_REFVAL_P(value);
+				}
+				if (Z_REFCOUNTED_P(value)) {
+					Z_ADDREF_P(value);
+				}
+				if (ZSTR_VAL(key)[0] == 0) {
+					const char *prop_name, *class_name;
+					size_t prop_len;
+					zend_unmangle_property_name_ex(key, &class_name, &prop_name, &prop_len);
+					add_assoc_zval_ex(return_value, prop_name, prop_len, value);
+				} else {
+					add_assoc_zval_ex(return_value, ZSTR_VAL(key), ZSTR_LEN(key), value);
 				}
 			}
-		} ZEND_HASH_FOREACH_END();
-	}
+		}
+	} ZEND_HASH_FOREACH_END();
 }
 /* }}} */
 


### PR DESCRIPTION
The problem is that PHP 5.6 uses `add_assoc_zval_ex` function to add properties to returned array, which handles numerical keys separately, whereas PHP 7.0 either returns the properties hashtable directly (in which case I guess that numerical keys are not handled separately) or adds properties to returned array using `zend_hash_str_add_new`/`zend_has_add_new` functions which again don't handle numerical keys separately.

I suspect that the reason why numerical keys are not accessible using the PHP 7 code is that when accessing an array, numerical keys are always handled separately and because they are stored as ordinary string keys, they cannot be accessed.

I therefore switched back to `add_assoc_zval_ex` function and removed the code that just returned properties hashtable, since it can contain numerical keys stored as strings and would need to be duplicated anyway.
