### PR TITLE
pdo_dblib: Use integer placeholders in test, since values can vary with the TDS version

### DIFF
--- a/ext/pdo_dblib/tests/bug_45876.phpt
+++ b/ext/pdo_dblib/tests/bug_45876.phpt
@@ -17,7 +17,7 @@ $stmt = null;
 --EXPECTF--
 array(10) {
   ["max_length"]=>
-  int(255)
+  int(%d)
   ["precision"]=>
   int(0)
   ["scale"]=>
@@ -35,5 +35,5 @@ array(10) {
   ["name"]=>
   string(13) "TABLE_CATALOG"
   ["len"]=>
-  int(255)
+  int(%d)
 }


### PR DESCRIPTION
I'm starting to look at behavior differences with different versions of the TDS protocol. I'm hoping to push the test suite in a direction where the version is taken into account, to make it possible to run the tests in a broader range of environments and to catch those differences when they matter. This straightforward change came out of that testing.