### PR TITLE
Replace @*dir@ vars with 'expanded' versions

### DIFF
--- a/sapi/fpm/php-fpm.service.in
+++ b/sapi/fpm/php-fpm.service.in
@@ -8,8 +8,8 @@ After=syslog.target network.target
 
 [Service]
 Type=@php_fpm_systemd@
-PIDFile=@localstatedir@/run/php-fpm.pid
-ExecStart=@sbindir@/php-fpm --nodaemonize --fpm-config @sysconfdir@/php-fpm.conf
+PIDFile=@EXPANDED_LOCALSTATEDIR@/run/php-fpm.pid
+ExecStart=@EXPANDED_SBINDIR@/php-fpm --nodaemonize --fpm-config @EXPANDED_SYSCONFDIR@/php-fpm.conf
 ExecReload=/bin/kill -USR2 $MAINPID
 PrivateTmp=true
 


### PR DESCRIPTION
if not expanded it may compile into something like this:

    ...
    PIDFile=${prefix}/var/run/php-fpm.pid
    ExecStart=${exec_prefix}/sbin/php-fpm --nodaemonize --fpm-config ${prefix}/etc/php-fpm.conf
    ...