### PR TITLE
Changed @*dir@ to @EXPANDED_*@ in sapi/fpm in PHP-7.0

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -655,11 +655,8 @@ if test "$PHP_FPM" != "no"; then
 
   PHP_SUBST_OLD(php_fpm_user)
   PHP_SUBST_OLD(php_fpm_group)
-  php_fpm_sysconfdir=`eval echo $sysconfdir`
-  PHP_SUBST_OLD(php_fpm_sysconfdir)
-  php_fpm_localstatedir=`eval echo $localstatedir`
-  PHP_SUBST_OLD(php_fpm_localstatedir)
   php_fpm_prefix=`eval echo $prefix`
+  test "$php_fpm_prefix" = "NONE" && php_fpm_prefix=/usr/local
   PHP_SUBST_OLD(php_fpm_prefix)
 
   AC_DEFINE_UNQUOTED(PHP_FPM_USER, "$php_fpm_user", [fpm user name])

--- a/sapi/fpm/php-fpm.8.in
+++ b/sapi/fpm/php-fpm.8.in
@@ -8,9 +8,9 @@ php-fpm \- PHP FastCGI Process Manager 'PHP-FPM'
 .LP
 .SH DESCRIPTION
 \fBPHP\fP is a widely\-used general\-purpose scripting language that is especially suited for 
-Web development and can be embedded into HTML. This is a variant of PHP that will run in the background as a daemon, listening for CGI requests. Output is logged to @php_fpm_localstatedir@/log/php-fpm.log.
+Web development and can be embedded into HTML. This is a variant of PHP that will run in the background as a daemon, listening for CGI requests. Output is logged to @EXPANDED_LOCALSTATEDIR@/log/php-fpm.log.
 .LP
-Most options are set in the configuration file. The configuration file is @php_fpm_sysconfdir@/php-fpm.conf. By default, php-fpm will respond to CGI requests listening on localhost http port 9000. Therefore php-fpm expects your webserver to forward all requests for '.php' files to port 9000 and you should edit your webserver configuration file appropriately.
+Most options are set in the configuration file. The configuration file is @EXPANDED_SYSCONFDIR@/php-fpm.conf. By default, php-fpm will respond to CGI requests listening on localhost http port 9000. Therefore php-fpm expects your webserver to forward all requests for '.php' files to port 9000 and you should edit your webserver configuration file appropriately.
 .SH OPTIONS
 .TP 15
 .B \-C
@@ -95,7 +95,7 @@ Specify the PID file location.
 .TP
 .PD 1
 .B \-y
-Specify alternative path to FastCGI process manager configuration file (the default is @php_fpm_sysconfdir@/php-fpm.conf)
+Specify alternative path to FastCGI process manager configuration file (the default is @EXPANDED_SYSCONFDIR@/php-fpm.conf)
 .TP
 .PD 0
 .B \-\-test
@@ -154,7 +154,7 @@ For any unix systems which use systemd for their main process manager, you shoul
 sudo systemctl start php-fpm.service
 .RE
 .TP
-If your installation has no appropriate init script, launch php-fpm with no arguments. It will launch as a daemon (background process) by default. The file @php_fpm_localstatedir@/run/php-fpm.pid determines whether php-fpm is already up and running. Once started, php-fpm then responds to several POSIX signals:
+If your installation has no appropriate init script, launch php-fpm with no arguments. It will launch as a daemon (background process) by default. The file @EXPANDED_LOCALSTATEDIR@/run/php-fpm.pid determines whether php-fpm is already up and running. Once started, php-fpm then responds to several POSIX signals:
 .P
 .PD 0
 .RS

--- a/sapi/fpm/php-fpm.conf.in
+++ b/sapi/fpm/php-fpm.conf.in
@@ -122,4 +122,4 @@
 ; Relative path can also be used. They will be prefixed by:
 ;  - the global prefix if it's been set (-p argument)
 ;  - @prefix@ otherwise
-include=@php_fpm_sysconfdir@/php-fpm.d/*.conf
+include=@EXPANDED_SYSCONFDIR@/php-fpm.d/*.conf

--- a/sapi/fpm/php-fpm.service.in
+++ b/sapi/fpm/php-fpm.service.in
@@ -4,8 +4,8 @@ After=syslog.target network.target
 
 [Service]
 Type=@php_fpm_systemd@
-PIDFile=@localstatedir@/run/php-fpm.pid
-ExecStart=@sbindir@/php-fpm --nodaemonize --fpm-config @sysconfdir@/php-fpm.conf
+PIDFile=@EXPANDED_LOCALSTATEDIR@/run/php-fpm.pid
+ExecStart=@EXPANDED_SBINDIR@/php-fpm --nodaemonize --fpm-config @EXPANDED_SYSCONFDIR@/php-fpm.conf
 ExecReload=/bin/kill -USR2 $MAINPID
 
 [Install]


### PR DESCRIPTION
if vars not expanded in php-fpm.service, it may compile into something like this:

```
...
PIDFile=${prefix}/var/run/php-fpm.pid
ExecStart=${exec_prefix}/sbin/php-fpm --nodaemonize --fpm-config ${prefix}/etc/php-fpm.conf
...
```

Is it only me, but when I run `./configure` without setting '--prefix' I get `NONE` as a prefix in php_fpm_sysconfdir, php_fpm_localstatedir and php_fpm_prefix, because

```
test "$prefix" = "NONE" && prefix=/usr/local
```

is done _after_

```
php_fpm_sysconfdir=`eval echo $sysconfdir`
PHP_SUBST_OLD(php_fpm_sysconfdir)
php_fpm_localstatedir=`eval echo $localstatedir`
PHP_SUBST_OLD(php_fpm_localstatedir)
```
