### PR TITLE
Fix bug #71241: array_replace_recursive mutates ref params

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3045,6 +3045,25 @@ PHP_FUNCTION(array_slice)
 }
 /* }}} */
 
+static zend_always_inline zval * zval_dup_ref_or_separate(zval *zv) /* {{{ */
+{
+	zval *tmp = zv;
+	ZVAL_DEREF(tmp);
+	if (Z_ISREF_P(zv)) {
+		if (Z_REFCOUNT_P(zv) == 1) {
+			ZVAL_UNREF(zv);
+		} else {
+			Z_DELREF_P(zv);
+			ZVAL_DUP(zv, tmp);
+		}
+		tmp = zv;
+	} else {
+		SEPARATE_ZVAL(tmp);
+	}
+	return tmp;
+}
+/* }}} */
+
 PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 {
 	zval *src_entry, *dest_entry;
@@ -3067,17 +3086,8 @@ PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 					return 0;
 				}
 
-				if (Z_ISREF_P(dest_entry)) {
-					if (Z_REFCOUNT_P(dest_entry) == 1) {
-						ZVAL_UNREF(dest_entry);
-					} else {
-						Z_DELREF_P(dest_entry);
-						ZVAL_DUP(dest_entry, dest_zval);
-					}
-					dest_zval = dest_entry;
-				} else {
-					SEPARATE_ZVAL(dest_zval);
-				}
+				dest_zval = zval_dup_ref_or_separate(dest_entry);
+
 				if (Z_TYPE_P(dest_zval) == IS_NULL) {
 					convert_to_array_ex(dest_zval);
 					add_next_index_null(dest_zval);
@@ -3200,7 +3210,8 @@ PHPAPI int php_array_replace_recursive(HashTable *dest, HashTable *src) /* {{{ *
 			php_error_docref(NULL, E_WARNING, "recursion detected");
 			return 0;
 		}
-		SEPARATE_ZVAL(dest_zval);
+
+		dest_zval = zval_dup_ref_or_separate(dest_entry);
 
 		if (ZEND_HASH_APPLY_PROTECTION(Z_ARRVAL_P(dest_zval))) {
 			Z_ARRVAL_P(dest_zval)->u.v.nApplyCount++;

--- a/ext/standard/tests/array/array_replace_merge_recursive_ref.phpt
+++ b/ext/standard/tests/array/array_replace_merge_recursive_ref.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test array_(replace|merge)_recursive with references
+--FILE--
+<?php
+
+$one = [1];
+$two = [42];
+$arr1 = ['k' => &$one];
+$arr2 = ['k' => &$two];
+var_dump(current($one), current($two));
+array_replace_recursive($arr1, $arr2);
+var_dump(current($one), current($two));
+
+$one = [1];
+$two = [42];
+$arr1 = ['k' => &$one];
+$arr2 = ['k' => &$two];
+var_dump(current($one), current($two));
+array_merge_recursive($arr1, $arr2);
+var_dump(current($one), current($two));
+
+?>
+--EXPECT--
+int(1)
+int(42)
+int(1)
+int(42)
+int(1)
+int(42)
+int(1)
+int(42)


### PR DESCRIPTION
`array_replace_recursive` can sometimes mutate its params if references are nested within. This is new behavior in PHP 7: https://3v4l.org/0sdbm. If the new behavior is desirable, then `array_merge_recursive`, which does not do this, should be modified to be consistent.