### PR TITLE
Handle SQLDECIMAL/SQLNUMERIC types, which are used by later TDS versions

### DIFF
--- a/ext/pdo_dblib/README
+++ b/ext/pdo_dblib/README
@@ -9,4 +9,14 @@ The following database products are free for testing:
 	- Microsoft SQL Server Express (Windows Only)
 	- Sybase Adaptive Server (Windows, Linux, *NIX)
 	- Microsoft SQL Server Azure (One Month Trial Cloud Service)
-	
+
+You must set the following environment variables to run the tests:
+	- PDO_DBLIB_TEST_DSN  - DSN (e.g., dblib:host=localhost;dbname=test)
+	- PDO_DBLIB_TEST_USER - database user
+	- PDO_DBLIB_TEST_PASS - database user password
+
+This extension supports multiple versions of the TDS protocol. There are
+behavioral differences between versions. When making changes, it's recommended
+to test across all supported versions. You can specify a version using a version
+parameter in the DSN. See dblib_driver.c:pdo_dblib_handle_factory() for valid
+values.

--- a/ext/pdo_dblib/dblib_stmt.c
+++ b/ext/pdo_dblib/dblib_stmt.c
@@ -266,6 +266,11 @@ static int pdo_dblib_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr,
 	if (data_len != 0 || data != NULL) {
 		if (stmt->dbh->stringify) {
 			switch (coltype) {
+				case SQLDECIMAL:
+				case SQLNUMERIC:
+				case SQLMONEY:
+				case SQLMONEY4:
+				case SQLMONEYN:
 				case SQLFLT4:
 				case SQLFLT8:
 				case SQLINT4:
@@ -361,18 +366,16 @@ static int pdo_dblib_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr,
 
 					break;
 				}
+				case SQLDECIMAL:
+				case SQLNUMERIC:
 				case SQLMONEY:
 				case SQLMONEY4:
 				case SQLMONEYN: {
-					DBFLT8 money_value;
-					dbconvert(NULL, coltype, data, 8, SQLFLT8, (LPBYTE)&money_value, -1);
+					DBFLT8 float_value;
+					dbconvert(NULL, coltype, data, 8, SQLFLT8, (LPBYTE)&float_value, -1);
 
 					zv = emalloc(sizeof(zval));
-					ZVAL_DOUBLE(zv, money_value);
-
-					if (stmt->dbh->stringify) {
-						convert_to_string(zv);
-					}
+					ZVAL_DOUBLE(zv, float_value);
 
 					break;
 				}

--- a/ext/pdo_dblib/tests/config.inc
+++ b/ext/pdo_dblib/tests/config.inc
@@ -1,5 +1,20 @@
 <?php
 
+function get_tds_version() {
+	global $dsn;
+
+	$dsn_parts = explode(':', $dsn, 2);
+	if ($dsn_parts[0] == 'dblib') { // uri is an option, which we'll ignore
+		foreach (explode(';', $dsn_parts[1]) as $arg) {
+			$arg = explode('=', $arg);
+			if ($arg[0] == 'version') {
+				return $arg[1];
+			}
+	}
+
+	return null;
+}
+
 if (false !== getenv('PDO_DBLIB_TEST_DSN')) 
 	$dsn = getenv('PDO_DBLIB_TEST_DSN');
 else

--- a/ext/pdo_dblib/tests/types.phpt
+++ b/ext/pdo_dblib/tests/types.phpt
@@ -9,14 +9,28 @@ require __DIR__ . '/config.inc';
 <?php
 require __DIR__ . '/config.inc';
 
+function get_expected_float_string() {
+	switch (get_tds_version()) {
+		case '5.0':
+		case '6.0':
+		case '7.0':
+		case '7.1':
+		case '7.2':
+		case '8.0':
+			return '10.500';
+		default:
+			return '10.5';
+	}
+}
+
 $sql = "
 	SELECT
 		'foo' AS [char],
 		CAST('2030-01-01 23:59:59' AS DATETIME) AS [datetime],
 		CAST(0 AS BIT) AS [false],
-		10.5 AS [float],
+		10.500 AS [float],
 		1000 AS [int],
-		CAST(10.5 AS MONEY) AS [money],
+		CAST(10.500 AS MONEY) AS [money],
 		CAST('1950-01-18 23:00:00' AS SMALLDATETIME) as [smalldatetime],
 		CAST(1 AS BIT) AS [true]
 ";
@@ -40,9 +54,9 @@ $row = $stmt->fetch(PDO::FETCH_ASSOC);
 var_dump($row['char'] === 'foo');
 var_dump($row['datetime'] === '2030-01-01 23:59:59');
 var_dump($row['false'] === '0');
-var_dump($row['float'] === '10.5');
+var_dump($row['float'] === get_expected_float_string());
 var_dump($row['int'] === '1000');
-var_dump($row['money'] === '10.5');
+var_dump($row['money'] === '10.50');
 var_dump($row['smalldatetime'] === '1950-01-18 23:00:00');
 var_dump($row['true'] === '1');
 


### PR DESCRIPTION
This patches up a test failure that affected recent TDS versions. My approach to getting the current TDS version is admittedly hacky, but it's simple and it works. Other approaches I considered:
- Expose the version through PDO::getAttribute(). A little awkward, since you can't ask DBLIB for the current version. You can only set. I didn't like the idea of that attribute not always being available. Especially since you're only going to get something out if you pass it in yourself.
- Build out a test class with a factory method, similar to other PDO drivers. Such a class could encapsulate this get/set operation. The existing classes are, unfortunately, a bit oddly designed. After playing with this approach a little, it seemed like it would've been more "different" than "better."
