### PR TITLE
Skip win32 path tests on OS X

### DIFF
--- a/ext/standard/tests/dir/chdir_basic-win32-mb.phpt
+++ b/ext/standard/tests/dir/chdir_basic-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test chdir() function : basic functionality 
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : bool chdir(string $directory)

--- a/ext/standard/tests/dir/chdir_variation2-win32-mb.phpt
+++ b/ext/standard/tests/dir/chdir_variation2-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test chdir() function : usage variations - relative paths
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : bool chdir(string $directory)

--- a/ext/standard/tests/dir/getcwd_basic-win32-mb.phpt
+++ b/ext/standard/tests/dir/getcwd_basic-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test getcwd() function : basic functionality
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : mixed getcwd(void)

--- a/ext/standard/tests/dir/readdir_variation3-win32-mb.phpt
+++ b/ext/standard/tests/dir/readdir_variation3-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test readdir() function : usage variations - sub-directories 
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : string readdir([resource $dir_handle])

--- a/ext/standard/tests/dir/readdir_variation4-win32-mb.phpt
+++ b/ext/standard/tests/dir/readdir_variation4-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test readdir() function : usage variations - different file names
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : string readdir([resource $dir_handle])

--- a/ext/standard/tests/dir/readdir_variation6-win32-mb.phpt
+++ b/ext/standard/tests/dir/readdir_variation6-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test readdir() function : usage variations - operate on previously opened directory
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : string readdir([resource $dir_handle])

--- a/ext/standard/tests/dir/rewinddir_basic-win32-mb.phpt
+++ b/ext/standard/tests/dir/rewinddir_basic-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test rewinddir() function : basic functionality 
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : void rewinddir([resource $dir_handle])

--- a/ext/standard/tests/dir/scandir_basic-win32-mb.phpt
+++ b/ext/standard/tests/dir/scandir_basic-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test scandir() function : basic functionality 
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : array scandir(string $dir [, int $sorting_order [, resource $context]])

--- a/ext/standard/tests/dir/scandir_variation10-win32-mb.phpt
+++ b/ext/standard/tests/dir/scandir_variation10-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test scandir() function : usage variations - different sorting constants
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : array scandir(string $dir [, int $sorting_order [, resource $context]])

--- a/ext/standard/tests/dir/scandir_variation4-win32-mb.phpt
+++ b/ext/standard/tests/dir/scandir_variation4-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test scandir() function : usage variations - different relative paths
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : array scandir(string $dir [, int $sorting_order [, resource $context]])

--- a/ext/standard/tests/dir/scandir_variation8-win32-mb.phpt
+++ b/ext/standard/tests/dir/scandir_variation8-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test scandir() function : usage variations - different file names
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : array scandir(string $dir [, int $sorting_order [, resource $context]])

--- a/ext/standard/tests/dir/scandir_variation9-win32-mb.phpt
+++ b/ext/standard/tests/dir/scandir_variation9-win32-mb.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test scandir() function : usage variations - different ints as $sorting_order arg
+--SKIPIF--
+<?php if (stristr(PHP_OS, "Darwin")) { die("Skip Unsupported on OS X"); } ?> 
 --FILE--
 <?php
 /* Prototype  : array scandir(string $dir [, int $sorting_order [, resource $context]])


### PR DESCRIPTION
@weltling please review and merge/merge up

These tests all fail on OS X (El Capitan).