### PR TITLE
Normalize compact('this') behavior

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1976,6 +1976,14 @@ static void php_compact_var(HashTable *eg_active_symbol_table, zval *return_valu
 			ZVAL_COPY(&data, value_ptr);
 			zend_hash_update(Z_ARRVAL_P(return_value), Z_STR_P(entry), &data);
 		}
+		if (ZSTR_LEN(Z_STR_P(entry)) == sizeof("this")-1  && !strcmp(ZSTR_VAL(Z_STR_P(entry)), "this")) {
+			zend_object *object = zend_get_this_object(EG(current_execute_data));
+			if (object) {
+				GC_REFCOUNT(object)++;
+				ZVAL_OBJ(&data, object);
+				zend_hash_update(Z_ARRVAL_P(return_value), Z_STR_P(entry), &data);
+			}
+		}
 	} else if (Z_TYPE_P(entry) == IS_ARRAY) {
 		if ((Z_ARRVAL_P(entry)->u.v.nApplyCount > 1)) {
 			php_error_docref(NULL, E_WARNING, "recursion detected");

--- a/ext/standard/tests/array/compact_no_this.phpt
+++ b/ext/standard/tests/array/compact_no_this.phpt
@@ -1,0 +1,25 @@
+--TEST--
+compact() without object context
+--FILE--
+<?php
+
+var_dump(
+    (new class {
+        function test(){
+            return (static function(){ return compact('this'); })();
+        }
+    })->test()
+);
+
+var_dump(compact('this'));
+
+var_dump((function(){ return compact('this'); })());
+
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}
+array(0) {
+}

--- a/ext/standard/tests/array/compact_order.phpt
+++ b/ext/standard/tests/array/compact_order.phpt
@@ -1,0 +1,25 @@
+--TEST--
+compact() and hashmap order
+--FILE--
+<?php
+
+$foo = null;
+$bar = null;
+
+var_dump(compact('foo', 'bar'));
+var_dump(compact('bar', 'foo'));
+
+?>
+--EXPECT--
+array(2) {
+  ["foo"]=>
+  NULL
+  ["bar"]=>
+  NULL
+}
+array(2) {
+  ["bar"]=>
+  NULL
+  ["foo"]=>
+  NULL
+}

--- a/ext/standard/tests/array/compact_this.phpt
+++ b/ext/standard/tests/array/compact_this.phpt
@@ -1,0 +1,46 @@
+--TEST--
+compact() with object context
+--FILE--
+<?php
+
+var_dump(
+    (new class {
+        function test(){
+            return compact('this');
+        }
+    })->test()
+);
+
+var_dump(
+    (new class {
+        function test(){
+            return compact([['this']]);
+        }
+    })->test()
+);
+
+var_dump(
+    (new class {
+        function test(){
+            return (function(){ return compact('this'); })();
+        }
+    })->test()
+);
+
+?>
+--EXPECT--
+array(1) {
+  ["this"]=>
+  object(class@anonymous)#1 (0) {
+  }
+}
+array(1) {
+  ["this"]=>
+  object(class@anonymous)#1 (0) {
+  }
+}
+array(1) {
+  ["this"]=>
+  object(class@anonymous)#1 (0) {
+  }
+}


### PR DESCRIPTION
`compact('this')` used to work https://3v4l.org/bmHr2 when a statement like `$this;` was emitted. After the RFC to [Fix inconsistent behavior of $this variable](https://wiki.php.net/rfc/this_var), this behavior changed subtly.

The old behavior was also fragile, to say the least, imagine a future engine optimization wiping "dead code" before compiling. So this PR also attempts to normalize `compact('this')` in a way it will always work, regardless of the presence of a dead `$this;` statement, while respecting the called scope - [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).

A quick search revealed this can be a source of confusion: http://stackoverflow.com/questions/4994711/this-keyword-and-compact-function