### PR TITLE
Fix #63343: Commit failure for repeated persistent connection

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2348,7 +2348,7 @@ PDO_API void php_pdo_free_statement(pdo_stmt_t *stmt)
 	do_fetch_opt_finish(stmt, 1);
 
 	if (!Z_ISUNDEF(stmt->database_object_handle)) {
-		zval_ptr_dtor(&stmt->database_object_handle);
+		Z_DELREF(stmt->database_object_handle);
 	}
 	zend_object_std_dtor(&stmt->std);
 }

--- a/ext/pdo/tests/bug_63343.phpt
+++ b/ext/pdo/tests/bug_63343.phpt
@@ -1,0 +1,34 @@
+--TEST--
+PDO Common: Bug #63343 (Commit failure for repeated persistent connection)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip');
+$dir = getenv('REDIR_TEST_DIR');
+if (false == $dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE__) . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+
+putenv("PDOTEST_ATTR=" . serialize(array(PDO::ATTR_PERSISTENT => true)));
+
+$db = PDOTest::factory('PDO', false);
+$db->beginTransaction();
+$st = $db->query('select 1');
+echo $st->fetchColumn(), PHP_EOL;
+$db->commit();
+
+$db = PDOTest::factory('PDO', false);
+$db->beginTransaction();
+$st = $db->query('select 2');
+echo $st->fetchColumn(), PHP_EOL;
+$db->commit();
+?>
+===DONE===
+--EXPECT--
+1
+2
+===DONE===


### PR DESCRIPTION
The `database_object_handle` may be shared, so we must not call its
destructor directly, but rather delete the reference.

The bug also exists in PHP-5.6, but I don't know how to resolve it there. :-(