### PR TITLE
Fix potential memory issue with USE_ZEND_ALLOC=0

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2726,9 +2726,9 @@ static void alloc_globals_ctor(zend_alloc_globals *alloc_globals TSRMLS_DC)
 		alloc_globals->mm_heap = malloc(sizeof(struct _zend_mm_heap));
 		memset(alloc_globals->mm_heap, 0, sizeof(struct _zend_mm_heap));
 		alloc_globals->mm_heap->use_zend_alloc = 0;
-		alloc_globals->mm_heap->_malloc = malloc;
+		alloc_globals->mm_heap->_malloc = __zend_malloc;
 		alloc_globals->mm_heap->_free = free;
-		alloc_globals->mm_heap->_realloc = realloc;
+		alloc_globals->mm_heap->_realloc = __zend_realloc;
 	} else {
 		alloc_globals->mm_heap = zend_mm_startup();
 	}


### PR DESCRIPTION
The PHP core and extensions are written with the assumption that memory
allocation either succeeds, or the allocator bails out (i.e. the allocator
is infallible). Therefore the result of emalloc() and friends are not checked
for NULL values.

However, with USE_ZEND_ALLOC=0, malloc() and friends are used as allocators,
but these are fallible, i.e. they return NULL instead of bailing out if they
fail. This easily leads to invalid memory accesses in the following, such as
in <https://bugs.php.net/73032>. Some of these cases may constitute
exploitable vulnerabilities.

Therefore we make the infallible __zend_alloc() and friends the default for
USE_ZEND_ALLOC=0.