### PR TITLE
Add spl_object_freeze function

### DIFF
--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -741,6 +741,43 @@ PHP_FUNCTION(spl_object_hash)
 }
 /* }}} */
 
+static zend_object_handlers immut_object_handlers = {};
+
+static void immut_write_property(zval *object, zval *member, zval *value, void **cache_slot) /* {{{ */
+{
+	zend_throw_exception(zend_ce_exception, "Attempt to modify property from immutable class instance", 0);
+}
+
+static zval *immut_read_property_by_ref(zval *object, zval *member, int type, void **cache_slot)
+{
+	zend_throw_exception(zend_ce_exception, "Attempt to get property by reference from immutable class instance", 0);
+
+	return NULL;
+}
+
+static void immut_unset_property(zval *object, zval *member, void **cache_slot) /* {{{ */
+{
+	zend_throw_exception(zend_ce_exception, "Attempt to unset property from immutable class instance", 0);
+}
+
+/* {{{ proto object obj spl_object_freeze(object obj)
+ Turn existing object instance to immutable */
+PHP_FUNCTION(spl_object_freeze)
+{
+	zval *zv = NULL;
+	zend_object *obj = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "o", &zv) == FAILURE) {
+		return;
+	}
+
+	obj = (zend_object *) Z_OBJ_P(zv);
+	obj->handlers = &immut_object_handlers;
+
+	RETVAL_ZVAL(zv, 1, 0);
+}
+/* }}} */
+
 PHPAPI zend_string *php_spl_object_hash(zval *obj) /* {{{*/
 {
 	intptr_t hash_handle, hash_handlers;
@@ -862,6 +899,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_object_hash, 0, 0, 1)
 	ZEND_ARG_INFO(0, obj)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_object_freeze, 0, 0, 1)
+	ZEND_ARG_INFO(0, object)
+ZEND_END_ARG_INFO()
 /* }}} */
 
 /* {{{ spl_functions
@@ -878,6 +919,7 @@ const zend_function_entry spl_functions[] = {
 	PHP_FE(class_implements,        arginfo_class_implements)
 	PHP_FE(class_uses,              arginfo_class_uses)
 	PHP_FE(spl_object_hash,         arginfo_spl_object_hash)
+	PHP_FE(spl_object_freeze,      arginfo_spl_object_freeze)
 #ifdef SPL_ITERATORS_H
 	PHP_FE(iterator_to_array,       arginfo_iterator_to_array)
 	PHP_FE(iterator_count,          arginfo_iterator)
@@ -899,6 +941,11 @@ PHP_MINIT_FUNCTION(spl)
 	PHP_MINIT(spl_heap)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(spl_fixedarray)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(spl_observer)(INIT_FUNC_ARGS_PASSTHRU);
+
+	memcpy(&immut_object_handlers, zend_get_std_object_handlers(), sizeof(immut_object_handlers));
+	immut_object_handlers.write_property = immut_write_property;
+	immut_object_handlers.unset_property = immut_unset_property;
+	immut_object_handlers.get_property_ptr_ptr = immut_read_property_by_ref;
 
 	return SUCCESS;
 }


### PR DESCRIPTION
This would allow to turn existing objects into immutable instances.:

```php
<?php
// Arbitrary immutability
$obj = spl_object_freeze(new SomeThirdParyClass);

// Immutability enforced on __construct
class SomeImmutableObject {
    public $name;

    function __construct($name) {
      $this->name = $name;

      spl_object_freeze($this); // nobody touches it from now on!
    }
}

$object = new SomeImmutableObject('foo');
$object->name = 'bar'; // Exception: Attempt to modify property from immutable class instance

// Optional immutability through named constructor 
class SomeObject {
    public $name;

    function __construct(string $name) {
      $this->name = $name;
    }

    static function new(string $name) : self {
        return new self($name);
    }

    static function newImmutable(string $name) : self {
        $instance = new self($name);

        spl_object_freeze($instance); // make this instance immutable!

        return $instance;
    }
}

$object = SomeObject::new('foo');
$object->name = 'bar'; // works

$object = SomeObject::newImmutable('foo');
$object->name = 'bar'; // Exception: Attempt to modify property from immutable class instance
```

Advantages:

- It's not necessary to declare an immutable and a mutable version of a class in order to have both behaviors;
- It's possible to make objects of third party classes immutable;
- It probably won't require any change to be compatible with typed properties;

No RFC yet.
