### PR TITLE
Request #73088: str_check_encoding and str_scrub

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2471,6 +2471,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_str_check_encoding, 0, 0, 1)
 	ZEND_ARG_INFO(0, encoding)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_str_scrub, 0, 0, 1)
+	ZEND_ARG_INFO(0, str)
+	ZEND_ARG_INFO(0, encoding)
+ZEND_END_ARG_INFO()
+
 /* }}} */
 /* {{{ syslog.c */
 #ifdef HAVE_SYSLOG_H
@@ -2771,6 +2776,7 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(strpbrk,															arginfo_strpbrk)
 	PHP_FE(substr_compare,													arginfo_substr_compare)
 	PHP_FE(str_check_encoding,													arginfo_str_check_encoding)
+	PHP_FE(str_scrub,													arginfo_str_scrub)
 #ifdef HAVE_STRCOLL
 	PHP_FE(strcoll,															arginfo_strcoll)
 #endif

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2465,6 +2465,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_substr_compare, 0, 0, 3)
 	ZEND_ARG_INFO(0, length)
 	ZEND_ARG_INFO(0, case_sensitivity)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_str_check_encoding, 0, 0, 1)
+	ZEND_ARG_INFO(0, str)
+	ZEND_ARG_INFO(0, encoding)
+ZEND_END_ARG_INFO()
+
 /* }}} */
 /* {{{ syslog.c */
 #ifdef HAVE_SYSLOG_H
@@ -2764,7 +2770,7 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(str_split,														arginfo_str_split)
 	PHP_FE(strpbrk,															arginfo_strpbrk)
 	PHP_FE(substr_compare,													arginfo_substr_compare)
-
+	PHP_FE(str_check_encoding,													arginfo_str_check_encoding)
 #ifdef HAVE_STRCOLL
 	PHP_FE(strcoll,															arginfo_strcoll)
 #endif
@@ -4037,7 +4043,7 @@ PHP_FUNCTION(long2ip)
  ********************/
 
 /* {{{ proto string getenv(string varname[, bool local_only]
-   Get the value of an environment variable or every available environment variable 
+   Get the value of an environment variable or every available environment variable
    if no varname is present  */
 PHP_FUNCTION(getenv)
 {

--- a/ext/standard/html.c
+++ b/ext/standard/html.c
@@ -98,7 +98,7 @@ static char *get_default_charset(void) {
 
 /* {{{ get_next_char
  */
-static inline unsigned int get_next_char(
+PHPAPI unsigned int get_next_char(
 		enum entity_charset charset,
 		const unsigned char *str,
 		size_t str_len,
@@ -373,7 +373,7 @@ static inline unsigned int get_next_char(
 /* {{{ entity_charset determine_charset
  * returns the charset identifier based on current locale or a hint.
  * defaults to UTF-8 */
-static enum entity_charset determine_charset(char *charset_hint)
+PHPAPI enum entity_charset determine_charset(char *charset_hint)
 {
 	size_t i;
 	enum entity_charset charset = cs_utf_8;

--- a/ext/standard/html.h
+++ b/ext/standard/html.h
@@ -54,9 +54,18 @@ PHP_FUNCTION(htmlspecialchars_decode);
 PHP_FUNCTION(html_entity_decode);
 PHP_FUNCTION(get_html_translation_table);
 
+enum entity_charset {
+  cs_utf_8, cs_8859_1, cs_cp1252, cs_8859_15, cs_cp1251,
+	cs_8859_5, cs_cp866, cs_macroman, cs_koi8r, cs_big5,
+	cs_gb2312, cs_big5hkscs, cs_sjis, cs_eucjp,
+	cs_numelems /* used to count the number of charsets */
+};
+
 PHPAPI zend_string *php_escape_html_entities(unsigned char *old, size_t oldlen, int all, int flags, char *hint_charset);
 PHPAPI zend_string *php_escape_html_entities_ex(unsigned char *old, size_t oldlen, int all, int flags, char *hint_charset, zend_bool double_encode);
 PHPAPI zend_string *php_unescape_html_entities(unsigned char *old, size_t oldlen, int all, int flags, char *hint_charset);
 PHPAPI unsigned int php_next_utf8_char(const unsigned char *str, size_t str_len, size_t *cursor, int *status);
+PHPAPI unsigned int get_next_char(enum entity_charset charset, const unsigned char *str, size_t str_len, size_t *cursor, int *status);
+PHPAPI enum entity_charset determine_charset(char *charset_hint);
 
 #endif /* HTML_H */

--- a/ext/standard/html_tables.h
+++ b/ext/standard/html_tables.h
@@ -28,11 +28,6 @@
 ***************************************************************************
 **************************************************************************/
 
-enum entity_charset { cs_utf_8, cs_8859_1, cs_cp1252, cs_8859_15, cs_cp1251,
-					  cs_8859_5, cs_cp866, cs_macroman, cs_koi8r, cs_big5,
-					  cs_gb2312, cs_big5hkscs, cs_sjis, cs_eucjp,
-					  cs_numelems /* used to count the number of charsets */
-					};
 #define CHARSET_UNICODE_COMPAT(cs)	((cs) <= cs_8859_1)
 #define CHARSET_SINGLE_BYTE(cs)		((cs) > cs_utf_8 && (cs) < cs_big5)
 #define CHARSET_PARTIAL_SUPPORT(cs)	((cs) >= cs_big5)

--- a/ext/standard/html_tables/html_table_gen.php
+++ b/ext/standard/html_tables/html_table_gen.php
@@ -51,11 +51,6 @@ $t = <<<CODE
 ***************************************************************************
 **************************************************************************/
 
-enum entity_charset { cs_utf_8, cs_8859_1, cs_cp1252, cs_8859_15, cs_cp1251,
-					  cs_8859_5, cs_cp866, cs_macroman, cs_koi8r, cs_big5,
-					  cs_gb2312, cs_big5hkscs, cs_sjis, cs_eucjp,
-					  cs_numelems /* used to count the number of charsets */
-					};
 #define CHARSET_UNICODE_COMPAT(cs)	((cs) <= cs_8859_1)
 #define CHARSET_SINGLE_BYTE(cs)		((cs) > cs_utf_8 && (cs) < cs_big5)
 #define CHARSET_PARTIAL_SUPPORT(cs)	((cs) >= cs_big5)
@@ -190,10 +185,10 @@ foreach ($encodings as $e) {
         if (preg_match("/^0x([0-9A-Z]{2})\t0x([0-9A-Z]{2,})/i", $l, $matches))
             $map[] = array($matches[1], $matches[2]);
     }
-    
+
     $mappy = array();
     foreach ($map as $v) { $mappy[hexdec($v[0])] = hexdec($v[1]); }
-    
+
     $mstable = array("ident" => $e['ident']);
     /* calculate two-stage tables */
     for ($i = 0; $i < 4; $i++) {
@@ -202,7 +197,7 @@ foreach ($encodings as $e) {
             $mstable[$i][$j] = isset($mappy[$cp]) ? $mappy[$cp] : NULL;
         }
     }
-    
+
     echo
 "/* {{{ Stage 2 tables for {$e['name']} */\n\n";
 
@@ -212,9 +207,9 @@ foreach ($encodings as $e) {
             $s2tables_idents[$i] = $encodings[$t[0]/5]["ident"];
             continue;
         }
-        
+
         $s2tables_idents[$i] = $e["ident"];
-        
+
         echo "static const enc_to_uni_stage2 enc_to_uni_s2_{$e['ident']}_".
             sprintf("%02X", $i << 6)." = { {\n";
         for ($j = 0; $j < 64; $j++) {
@@ -227,10 +222,10 @@ foreach ($encodings as $e) {
                 echo "0xFFFF,"; /* special value; indicates no mapping */
         }
         echo "\n} };\n\n";
-        
+
         $prevStage2[] = $mstable[$i];
     }
-    
+
     echo
 "/* end of stage 2 tables for {$e['name']} }}} */\n\n";
 
@@ -333,23 +328,23 @@ foreach ($encodings as $e) {
         if (preg_match("/^0x([0-9A-Z]{2})\t0x([0-9A-Z]{2,})\s+#\s*(.*)$/i", $l, $matches))
             $map[] = array($matches[1], $matches[2], rtrim($matches[3]));
     }
-    
+
     $mappy = array();
     foreach ($map as $v) {
         if (hexdec($v[0]) >= $e['range'][0] && hexdec($v[0]) <= $e['range'][1])
             $mappy[hexdec($v[1])] = array(hexdec($v[0]), strtolower($v[2]));
     }
     ksort($mappy);
-    
+
     echo
 "static const uni_to_enc unimap_{$e['ident']}[] = {\n";
-    
+
     foreach ($mappy as $k => $v) {
         echo "\t{ ", sprintf("0x%04X", $k), ", ", sprintf("0x%02X", $v[0]), " },\t/* ",
             $v[1], " */\n";
     }
     echo "};\n";
-    
+
     echo
 "/* {{{ end of mappings *from* Unicode for {$e['name']} */\n\n";
 }
@@ -476,7 +471,7 @@ foreach ($multicp_rows as $k => $v) {
             $v['default'] = "gt";
 		echo "\t{ {", sprintf("\"%-21s", $v["default"].'",'),
 			"\t", sprintf("%02d", (count($v) - 1)), ",\t\t",
-            sprintf("% 2d", strlen($v["default"])), '} },', "\n"; 
+            sprintf("% 2d", strlen($v["default"])), '} },', "\n";
 	} else {
 		echo "\t{ {", sprintf("%-22s", 'NULL,'),
 			"\t", sprintf("%02d", count($v)), ",\t\t0} },\n";
@@ -484,7 +479,7 @@ foreach ($multicp_rows as $k => $v) {
 	unset($v["default"]);
 	foreach ($v as $l => $w) {
 		echo "\t{ {", sprintf("\"%-21s", $w.'",'), "\t", sprintf("0x%05s", $l), ",\t",
-            sprintf("% 2d", strlen($w)), '} },', "\n"; 
+            sprintf("% 2d", strlen($w)), '} },', "\n";
 	}
 	echo "};\n";
 }
@@ -561,7 +556,7 @@ for ($i = 0; $i < 0x1E; $i++) {
 				else
 					echo "{1, { {(void *)", sprintf("multi_cp_{$ident}_%05X",
 						($i << 12) | ($k << 6) | $y ), ", 0} } },";
-				
+
 			}
 			echo "\n};\n\n";
 		}
@@ -685,7 +680,7 @@ echo
 //			die("violated assumption for traverse_for_entities");
 //		}
 //	}
-//	
+//
 //	$k++;
 //}
 //echo "\n};\n\n";

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -1,4 +1,4 @@
-/* 
+/*
    +----------------------------------------------------------------------+
    | PHP Version 7                                                        |
    +----------------------------------------------------------------------+
@@ -13,7 +13,7 @@
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
    | Authors: Rasmus Lerdorf <rasmus@php.net>                             |
-   |          Stig Sæther Bakken <ssb@php.net>                            |
+   |          Stig Sï¿½ther Bakken <ssb@php.net>                            |
    +----------------------------------------------------------------------+
 */
 
@@ -93,6 +93,7 @@ PHP_FUNCTION(str_word_count);
 PHP_FUNCTION(str_split);
 PHP_FUNCTION(strpbrk);
 PHP_FUNCTION(substr_compare);
+PHP_FUNCTION(str_check_encoding);
 #ifdef HAVE_STRCOLL
 PHP_FUNCTION(strcoll);
 #endif
@@ -138,8 +139,8 @@ PHPAPI size_t php_strip_tags_ex(char *rbuf, size_t len, int *stateptr, const cha
 PHPAPI void php_implode(const zend_string *delim, zval *arr, zval *return_value);
 PHPAPI void php_explode(const zend_string *delim, zend_string *str, zval *return_value, zend_long limit);
 
-PHPAPI size_t php_strspn(char *s1, char *s2, char *s1_end, char *s2_end); 
-PHPAPI size_t php_strcspn(char *s1, char *s2, char *s1_end, char *s2_end); 
+PHPAPI size_t php_strspn(char *s1, char *s2, char *s1_end, char *s2_end);
+PHPAPI size_t php_strcspn(char *s1, char *s2, char *s1_end, char *s2_end);
 
 PHPAPI int string_natural_compare_function_ex(zval *result, zval *op1, zval *op2, zend_bool case_insensitive);
 PHPAPI int string_natural_compare_function(zval *result, zval *op1, zval *op2);

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -94,6 +94,7 @@ PHP_FUNCTION(str_split);
 PHP_FUNCTION(strpbrk);
 PHP_FUNCTION(substr_compare);
 PHP_FUNCTION(str_check_encoding);
+PHP_FUNCTION(str_scrub);
 #ifdef HAVE_STRCOLL
 PHP_FUNCTION(strcoll);
 #endif


### PR DESCRIPTION
Both `str_check_encoding` and `str_scrub` have same feature as `mb_check_encoding` and `mb_scrub`:

``` php
bool str_check_encoding ([ string $str[,string $encoding = ini_get("default_charset") ]] )
string str_scrub ([ string $str[,string $encoding = ini_get("default_charset") ]] )
```

fallback functions can be implemented by `htmlspecialchars` and `htmlspecialchars_decode` since PHP 5.4.0.

``` php
var_dump(
  // str_check_encoding
  "" === htmlspecialchars_decode(htmlspecialchars("a\x80b")),
  // str_scrub
  "a\u{fffd}b" === htmlspecialchars_decode(htmlspecialchars("a\x80b", ENT_SUBSTITUTE))
);
```
