### PR TITLE
fix every worker call mmap in fpm_scoreboard_init_main

### DIFF
--- a/sapi/fpm/fpm/fpm_scoreboard.c
+++ b/sapi/fpm/fpm/fpm_scoreboard.c
@@ -52,16 +52,18 @@ int fpm_scoreboard_init_main() /* {{{ */
 			return -1;
 		}
 
-		wp->scoreboard = fpm_shm_alloc(sizeof(struct fpm_scoreboard_s) + (wp->config->pm_max_children - 1) * sizeof(struct fpm_scoreboard_proc_s *));
-		if (!wp->scoreboard) {
+		int scoreboard_size = sizeof(struct fpm_scoreboard_s) + (wp->config->pm_max_children) * sizeof(struct fpm_scoreboard_proc_s *);
+		int scoreboard_nprocs_size = sizeof(struct fpm_scoreboard_proc_s) * wp->config->pm_max_children;
+        void *shm_mem = fpm_shm_alloc(scoreboard_size + scoreboard_nprocs_size);
+		if (!shm_mem) {
 			return -1;
 		}
+		wp->scoreboard = shm_mem;
 		wp->scoreboard->nprocs = wp->config->pm_max_children;
+		shm_mem += scoreboard_size;
 		for (i = 0; i < wp->scoreboard->nprocs; i++) {
-			wp->scoreboard->procs[i] = fpm_shm_alloc(sizeof(struct fpm_scoreboard_proc_s));
-			if (!wp->scoreboard->procs[i]) {
-				return -1;
-			}
+			wp->scoreboard->procs[i] = shm_mem;
+			shm_mem += sizeof(struct fpm_scoreboard_proc_s);
 		}
 
 		wp->scoreboard->pm = wp->config->pm;

--- a/sapi/fpm/fpm/fpm_scoreboard.c
+++ b/sapi/fpm/fpm/fpm_scoreboard.c
@@ -241,13 +241,10 @@ void fpm_scoreboard_free(struct fpm_scoreboard_s *scoreboard) /* {{{ */
 		return;
 	}
 
-	for (i = 0; i < scoreboard->nprocs; i++) {
-		if (!scoreboard->procs[i]) {
-			continue;
-		}
-		fpm_shm_free(scoreboard->procs[i], sizeof(struct fpm_scoreboard_proc_s));
-	}
-	fpm_shm_free(scoreboard, sizeof(struct fpm_scoreboard_s));
+	int scoreboard_size = sizeof(struct fpm_scoreboard_s) + (scoreboard->nprocs) * sizeof(struct fpm_scoreboard_proc_s *);
+	int scoreboard_nprocs_size = sizeof(struct fpm_scoreboard_proc_s) * scoreboard->nprocs;
+	
+	fpm_shm_free(scoreboard, scoreboard_size + scoreboard_nprocs_size);
 }
 /* }}} */
 


### PR DESCRIPTION
Every mmap will cause lsof see a  /dev/zero (delete) , in fpm_scoreboard_init_main it call mmap pm_max_children + 1, so lsof every php-fpm worker process will see pm_max_children + 1 /dev/zero (delete) . so I think in fpm_scoreboard_init_main call fpm_shm_alloc only 1 every pool may be better.

In origin init wp->scoreboard->props use "(wp->config->pm_max_children - 1) * sizeof(struct fpm_scoreboard_proc_s *)" should be error , it should be "(wp->config->pm_max_children ) * sizeof(struct fpm_scoreboard_proc_s *)". The reason why origin no error when running is wp->scoreboard use a single page .

```
~$ ps -ef|grep php
root      6974     1  0 22:31 ?        00:00:00 php-fpm: master process (/usr/local/php-7.0.10/etc/php-fpm.conf)
nobody    6975  6974  0 22:31 ?        00:00:00 php-fpm: pool www
nobody    6976  6974  0 22:31 ?        00:00:00 php-fpm: pool www
nobody    6977  6974  0 22:31 ?        00:00:00 php-fpm: pool www
nobody    6978  6974  0 22:31 ?        00:00:00 php-fpm: pool www
nobody    6979  6974  0 22:31 ?        00:00:00 php-fpm: pool www
nobody    6980  6974  0 22:31 ?        00:00:00 php-fpm: pool www
nobody    6981  6974  0 22:31 ?        00:00:00 php-fpm: pool www
nobody    6982  6974  0 22:31 ?        00:00:00 php-fpm: pool www
nobody    6983  6974  0 22:31 ?        00:00:00 php-fpm: pool www
nobody    6984  6974  0 22:31 ?        00:00:00 php-fpm: pool www


~$ sudo lsof -np 6978 |grep /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088570 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088569 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088568 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088567 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088566 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088565 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088564 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088563 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088562 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088561 /dev/zero
php-fpm 6978 nobody  DEL    REG     0,5          1088560 /dev/zero
```