### PR TITLE
Assumed fix for several "Empty row packet body" bug tickets

### DIFF
--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -1516,6 +1516,7 @@ php_mysqlnd_read_row_ex(MYSQLND_PFC * pfc,
 		if (PASS != (ret = pfc->data->m.receive(pfc, vio, p, header.size, stats, error_info))) {
 			DBG_ERR("Empty row packet body");
 			php_error(E_WARNING, "Empty row packet body");
+			ret = FAIL;
 			break;
 		}
 


### PR DESCRIPTION
tickets that complain about this:

https://bugs.php.net/bug.php?id=66370
https://bugs.php.net/bug.php?id=64763
https://bugs.php.net/bug.php?id=65825

One is not reliably able to tell that a mysql response was successfully consumed completly without registering an error handler, that listens for the "Empty row packet body" warning. Not any of the examples does this. We were able to reproduce this by taking a long time in processing result rows, and forcing the mysql on the other end into a write timeout, leaving us with an incomplete result.
This points against master. Once there is a narrativ on what is the correct fix. I volunteer in backporting to the appropriate branches.

Best
