### PR TITLE
zend_memnstr(): when needle is short, Sunday algorithm is slower than glibc memchr()

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -167,7 +167,7 @@ zend_memnstr(const char *haystack, const char *needle, size_t needle_len, const 
 		return NULL;
 	}
 
-	if (EXPECTED(off_s < 1024 || needle_len < 3)) {
+	if (EXPECTED(off_s < 1024 || needle_len < 9)) {	/* glibc memchr is faster when needle is too short */
 		end -= needle_len;
 
 		while (p <= end) {


### PR DESCRIPTION
On the below URL, it is discussed that PHP7's strpos() is slower than PHP5's one.

http://qiita.com/hnw/items/4f2467efea1e9c2e0b05

Because glibc memchr() is speeding up by [tricky code](https://sourceware.org/git/?p=glibc.git;a=blob;f=string/memchr.c;h=ca9fd99f2105003d0b56285ff3f41ba10dad8685;hb=HEAD#l100). 
glibc memchr() compare 4Byte(or 8Byte) at once, so "needle_len < 3" is too short.

needle is bigger enough, PHP7's strpos() is faster than PHP5's one.