### PR TITLE
Fix RegexIterator::USE_KEY related bug

### DIFF
--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -2038,13 +2038,14 @@ SPL_METHOD(RegexIterator, accept)
 
 	if (Z_TYPE(intern->current.data) == IS_UNDEF) {
 		RETURN_FALSE;
-	} else if (Z_TYPE(intern->current.data) == IS_ARRAY) {
-		RETURN_FALSE;
 	}
 
 	if (intern->u.regex.flags & REGIT_USE_KEY) {
 		subject = zval_get_string(&intern->current.key);
 	} else {
+		if (Z_TYPE(intern->current.data) == IS_ARRAY) {
+			RETURN_FALSE;
+		}
 		subject = zval_get_string(&intern->current.data);
 	}
 

--- a/ext/spl/tests/bug68128-USE_KEY.phpt
+++ b/ext/spl/tests/bug68128-USE_KEY.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #68128 - RecursiveRegexIterator raises "Array to string conversion" notice
+--FILE--
+<?php
+
+$arrayIterator = new ArrayIterator(array('key 1' => 'value 1', 'key 2' => ['value 2']));
+$regexIterator = new RegexIterator($arrayIterator, '/^key/', RegexIterator::MATCH, RegexIterator::USE_KEY);
+
+foreach ($regexIterator as $key => $value) {
+    var_dump($key, $value);
+}
+
+?>
+--EXPECT--
+string(5) "key 1"
+string(7) "value 1"
+string(5) "key 2"
+array(1) {
+  [0]=>
+  string(7) "value 2"
+}

--- a/ext/spl/tests/iterator_053.phpt
+++ b/ext/spl/tests/iterator_053.phpt
@@ -50,7 +50,7 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
-bool(false)
+bool(true)
 bool(true)
 bool(true)
 bool(true)
@@ -124,7 +124,20 @@ array(2) {
     string(1) "4"
   }
 }
-bool(false)
+bool(true)
+int(5)
+array(2) {
+  [0]=>
+  array(1) {
+    [0]=>
+    string(1) "5"
+  }
+  [1]=>
+  array(1) {
+    [0]=>
+    string(1) "5"
+  }
+}
 bool(true)
 int(6)
 array(2) {


### PR DESCRIPTION
This is related to https://github.com/php/php-src/pull/865. Turns out in case `USE_KEY` flag is active RegexIterator->accept() should keep it's old behavior which is to accept keys mapping arrays:

https://3v4l.org/EmbIN

This broke after PHP 5.5 but was not noticed due to lack of tests for `USE_KEY` or maybe it was considered undefined behavior. Anyway, it seems that the new behavior is not as reasonable as what we had on v5.4?

Thoughts?