### PR TITLE
PHP bug 67130: nextRowset should work with unfetched rows

### DIFF
--- a/ext/pdo_dblib/dblib_stmt.c
+++ b/ext/pdo_dblib/dblib_stmt.c
@@ -119,7 +119,7 @@ static int pdo_dblib_stmt_dtor(pdo_stmt_t *stmt)
 	return 1;
 }
 
-static int pdo_dblib_stmt_next_rowset(pdo_stmt_t *stmt)
+static int pdo_dblib_stmt_next_rowset_no_cancel(pdo_stmt_t *stmt)
 {
 	pdo_dblib_stmt *S = (pdo_dblib_stmt*)stmt->driver_data;
 	pdo_dblib_db_handle *H = S->H;
@@ -142,6 +142,26 @@ static int pdo_dblib_stmt_next_rowset(pdo_stmt_t *stmt)
 	return 1;
 }
 
+static int pdo_dblib_stmt_next_rowset(pdo_stmt_t *stmt)
+{
+	pdo_dblib_stmt *S = (pdo_dblib_stmt*)stmt->driver_data;
+	pdo_dblib_db_handle *H = S->H;
+	RETCODE ret = SUCCESS;
+
+	// Ideally use dbcanquery here, but there is a bug in freetds's implementation of dbcanquery
+	// It has been resolved but is currently only available in nightly builds
+	while (NO_MORE_ROWS != ret) {
+		ret = dbnextrow(H->link);
+
+		if (FAIL == ret) {
+			pdo_raise_impl_error(stmt->dbh, stmt, "HY000", "PDO_DBLIB: dbnextrow() returned FAIL");
+			return 0;
+		}
+	}
+
+	return pdo_dblib_stmt_next_rowset_no_cancel(stmt);
+}
+
 static int pdo_dblib_stmt_execute(pdo_stmt_t *stmt)
 {
 	pdo_dblib_stmt *S = (pdo_dblib_stmt*)stmt->driver_data;
@@ -160,7 +180,7 @@ static int pdo_dblib_stmt_execute(pdo_stmt_t *stmt)
 		return 0;
 	}
 
-	ret = pdo_dblib_stmt_next_rowset(stmt);
+	ret = pdo_dblib_stmt_next_rowset_no_cancel(stmt);
 
 	stmt->row_count = DBCOUNT(H->link);
 	stmt->column_count = dbnumcols(H->link);

--- a/ext/pdo_dblib/tests/bug_67130.phpt
+++ b/ext/pdo_dblib/tests/bug_67130.phpt
@@ -1,0 +1,36 @@
+--TEST--
+PDO_DBLIB: \PDOStatement::nextRowset() should succeed when all rows in current rowset haven't been fetched
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+$stmt = $db->query('SELECT 1; SELECT 2; SELECT 3;');
+var_dump($stmt->fetch());
+var_dump($stmt->fetch());
+var_dump($stmt->nextRowset());
+var_dump($stmt->nextRowset());
+var_dump($stmt->fetch());
+var_dump($stmt->nextRowset());
+?>
+--EXPECT--
+array(2) {
+  ["computed"]=>
+  int(1)
+  [0]=>
+  int(1)
+}
+bool(false)
+bool(true)
+bool(true)
+array(2) {
+  ["computed"]=>
+  int(3)
+  [0]=>
+  int(3)
+}
+bool(false)


### PR DESCRIPTION
Bug 67130: Calling nextRowset() with unfetched rows causes a segfault.

I have fixed this by fetching any unfetched rows before advancing the rowset.  Attached is a test case.