### PR TITLE
Add PHP bindings for setting and getting the image resolution

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -821,6 +821,12 @@ ZEND_BEGIN_ARG_INFO(arginfo_imagesetinterpolation, 0)
 	ZEND_ARG_INFO(0, method)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_imageresolution, 0, 0, 1)
+	ZEND_ARG_INFO(0, im)
+	ZEND_ARG_INFO(0, res_x)
+	ZEND_ARG_INFO(0, res_y)
+ZEND_END_ARG_INFO()
+
 /* }}} */
 
 /* {{{ gd_functions[]
@@ -964,6 +970,8 @@ const zend_function_entry gd_functions[] = {
 /* gd filters */
 	PHP_FE(imagefilter,     						arginfo_imagefilter)
 	PHP_FE(imageconvolution,						arginfo_imageconvolution)
+
+	PHP_FE(imageresolution,							arginfo_imageresolution)
 
 	PHP_FE_END
 };
@@ -4988,6 +4996,37 @@ PHP_FUNCTION(imagesetinterpolation)
 		 method = GD_BILINEAR_FIXED;
 	}
 	RETURN_BOOL(gdImageSetInterpolationMethod(im, (gdInterpolationMethod) method));
+}
+/* }}} */
+
+/* {{{ proto array imageresolution(resource im [, res_x, [res_y]])
+   Get or set the resolution of the image in DPI. */
+PHP_FUNCTION(imageresolution)
+{
+	zval *IM;
+	gdImagePtr im;
+	zend_long res_x = GD_RESOLUTION, res_y = GD_RESOLUTION;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|ll", &IM, &res_x, &res_y) == FAILURE)  {
+		return;
+	}
+
+	if ((im = (gdImagePtr)zend_fetch_resource(Z_RES_P(IM), "Image", le_gd)) == NULL) {
+		RETURN_FALSE;
+	}
+
+	switch (ZEND_NUM_ARGS()) {
+		case 3:
+			gdImageSetResolution(im, res_x, res_y);
+			RETURN_TRUE;
+		case 2:
+			gdImageSetResolution(im, res_x, res_x);
+			RETURN_TRUE;
+		default:
+			array_init(return_value);
+			add_next_index_long(return_value, gdImageResolutionX(im));
+			add_next_index_long(return_value, gdImageResolutionY(im));
+	}
 }
 /* }}} */
 

--- a/ext/gd/php_gd.h
+++ b/ext/gd/php_gd.h
@@ -198,6 +198,8 @@ PHP_FUNCTION(imagexbm);
 PHP_FUNCTION(imagefilter);
 PHP_FUNCTION(imageconvolution);
 
+PHP_FUNCTION(imageresolution);
+
 PHP_GD_API int phpi_get_le_gd(void);
 
 #else

--- a/ext/gd/tests/imageresolution_jpeg.phpt
+++ b/ext/gd/tests/imageresolution_jpeg.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Set and get image resolution of JPEG images
+--SKIPIF--
+<?php
+if (!extension_loaded('gd')) die('skip gd extension not available');
+if (!(imagetypes() & IMG_JPEG)) die('skip JPEG support not available');
+?>
+--FILE--
+<?php
+$filename = __DIR__ . DIRECTORY_SEPARATOR . 'imageresolution_jpeg.jpeg';
+
+$exp = imagecreate(100, 100);
+imagecolorallocate($exp, 255, 0, 0);
+
+imageresolution($exp, 71);
+imagejpeg($exp, $filename);
+$act = imagecreatefromjpeg($filename);
+var_dump(imageresolution($act));
+
+imageresolution($exp, 71, 299);
+imagejpeg($exp, $filename);
+$act = imagecreatefromjpeg($filename);
+var_dump(imageresolution($act));
+?>
+===DONE===
+--EXPECT--
+array(2) {
+  [0]=>
+  int(71)
+  [1]=>
+  int(71)
+}
+array(2) {
+  [0]=>
+  int(71)
+  [1]=>
+  int(299)
+}
+===DONE===
+--CLEAN--
+<?php
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'imageresolution_jpeg.jpeg');
+?>

--- a/ext/gd/tests/imageresolution_png.phpt
+++ b/ext/gd/tests/imageresolution_png.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Set and get image resolution of PNG images
+--SKIPIF--
+<?php
+if (!extension_loaded('gd')) die('skip gd extension not available');
+?>
+--FILE--
+<?php
+$filename = __DIR__ . DIRECTORY_SEPARATOR . 'imageresolution_png.png';
+
+$exp = imagecreate(100, 100);
+imagecolorallocate($exp, 255, 0, 0);
+
+imageresolution($exp, 71);
+imagepng($exp, $filename);
+$act = imagecreatefrompng($filename);
+var_dump(imageresolution($act));
+
+imageresolution($exp, 71, 299);
+imagepng($exp, $filename);
+$act = imagecreatefrompng($filename);
+var_dump(imageresolution($act));
+?>
+===DONE===
+--EXPECT--
+array(2) {
+  [0]=>
+  int(71)
+  [1]=>
+  int(71)
+}
+array(2) {
+  [0]=>
+  int(71)
+  [1]=>
+  int(299)
+}
+===DONE===
+--CLEAN--
+<?php
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'imageresolution_png.png');
+?>


### PR DESCRIPTION
We expose the image resolution related GD functionality to userland
by introducing `imagesetresolution()`, `imageresolutionx()` and
`imageresolutiony()` as simple wrappers.