### PR TITLE
Fix ReflectionType::__toString() BC break

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5102,7 +5102,7 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 		arg_infos->class_name = NULL;
 
 		if (return_type_ast->attr & ZEND_TYPE_NULLABLE) {
-			arg_infos->allow_null = 1;
+			arg_infos->allow_null = 2;
 			return_type_ast->attr &= ~ZEND_TYPE_NULLABLE;
 		}
 
@@ -5194,10 +5194,10 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 				&& (Z_TYPE(default_node.u.constant) == IS_NULL
 					|| (Z_TYPE(default_node.u.constant) == IS_CONSTANT
 						&& strcasecmp(Z_STRVAL(default_node.u.constant), "NULL") == 0));
-			zend_bool is_explicitly_nullable = (type_ast->attr & ZEND_TYPE_NULLABLE) == ZEND_TYPE_NULLABLE;
+			zend_bool is_explicitly_nullable = ((type_ast->attr & ZEND_TYPE_NULLABLE) == ZEND_TYPE_NULLABLE) << 1;
 
 			op_array->fn_flags |= ZEND_ACC_HAS_TYPE_HINTS;
-			arg_info->allow_null = has_null_default || is_explicitly_nullable;
+			arg_info->allow_null = has_null_default | is_explicitly_nullable;
 
 			type_ast->attr &= ~ZEND_TYPE_NULLABLE;
 			zend_compile_typename(type_ast, arg_info);

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3031,7 +3031,7 @@ ZEND_METHOD(reflection_type, __toString)
 	
 	str = reflection_type_name(param);
 	
-	if (param->arg_info->allow_null) {
+	if (param->arg_info->allow_null & 2) {
 		size_t orig_len = ZSTR_LEN(str);
 		str = zend_string_extend(str, orig_len + 1, 0);
 		memmove(ZSTR_VAL(str) + 1, ZSTR_VAL(str), orig_len + 1);

--- a/ext/reflection/tests/ReflectionType_001.phpt
+++ b/ext/reflection/tests/ReflectionType_001.phpt
@@ -2,7 +2,7 @@
 ReflectionParameter::get/hasType and ReflectionType tests
 --FILE--
 <?php
-function foo(stdClass $a, array $b, callable $c, stdClass $d = null, $e = null, string $f, bool $g, int $h, float $i, NotExisting $j) { }
+function foo(stdClass $a, array $b, ?callable $c, stdClass $d = null, $e = null, string $f, bool $g, int $h, float $i, NotExisting $j) { }
 
 function bar(): stdClass { return new stdClass; }
 
@@ -89,14 +89,14 @@ bool(true)
 string(5) "array"
 ** Function 0 - Parameter 2
 bool(true)
-bool(false)
 bool(true)
-string(8) "callable"
+bool(true)
+string(9) "?callable"
 ** Function 0 - Parameter 3
 bool(true)
 bool(true)
 bool(false)
-string(9) "?stdClass"
+string(8) "stdClass"
 ** Function 0 - Parameter 4
 bool(false)
 ** Function 0 - Parameter 5


### PR DESCRIPTION
PHP 7.1 has a BC break that is hitting us hard, that is: `ReflectionType::__toString()` now adds a `?` in front of type hints where `null` is allowed by their default values.
But since `zend_bool` is really an `unsigned char`, we have plenty of room to store and forward this semantic subtlety (nullable being set through `?Foo $arg` vs `Foo $arg = null`) so that `ReflectionType::__toString()` can be accurate again, thus BC.