### PR TITLE
Revert ReflectionType::__toString() behavior + deprecate

### DIFF
--- a/Zend/tests/bug69802.phpt
+++ b/Zend/tests/bug69802.phpt
@@ -7,7 +7,7 @@ $r = new ReflectionMethod($f, '__invoke');
 var_dump($r->getParameters()[0]->getName());
 var_dump($r->getParameters()[0]->getClass());
 echo $r->getParameters()[0], "\n";
-echo $r->getReturnType(),"\n";
+echo $r->getReturnType()->getName(), "\n";
 echo $r,"\n";
 ?>
 --EXPECT--

--- a/Zend/tests/closures/closure_from_callable_reflection.phpt
+++ b/Zend/tests/closures/closure_from_callable_reflection.phpt
@@ -29,7 +29,7 @@ foreach ($callables as $callable) {
 	foreach ($refl->getParameters() as $param) {
 		if ($param->hasType()) {
 			$type = $param->getType();
-			echo $type->__toString() . "\n";
+			echo $type->getName() . "\n";
 		}
 	}
 }

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2158,7 +2158,7 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 		internal_function->prototype = NULL;
 		if (ptr->flags) {
 			if (!(ptr->flags & ZEND_ACC_PPP_MASK)) {
-				if (ptr->flags != ZEND_ACC_DEPRECATED || scope) {
+				if (ptr->flags != ZEND_ACC_DEPRECATED && scope) {
 					zend_error(error_type, "Invalid access level for %s%s%s() - access must be exactly one of public, protected or private", scope ? ZSTR_VAL(scope->name) : "", scope ? "::" : "", ptr->fname);
 				}
 				internal_function->fn_flags = ZEND_ACC_PUBLIC | ptr->flags;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6701,7 +6701,10 @@ static const zend_function_entry reflection_type_functions[] = {
 	ZEND_ME(reflection, __clone, arginfo_reflection__void, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
 	ZEND_ME(reflection_type, allowsNull, arginfo_reflection__void, 0)
 	ZEND_ME(reflection_type, isBuiltin, arginfo_reflection__void, 0)
-	ZEND_ME(reflection_type, __toString, arginfo_reflection__void, ZEND_ACC_DEPRECATED)
+	/* ReflectionType::__toString() is deprecated, but we currently do not mark it as such
+	 * due to bad interaction with the PHPUnit error handler and exceptions in __toString().
+	 * See PR2137. */
+	ZEND_ME(reflection_type, __toString, arginfo_reflection__void, 0)
 	PHP_FE_END
 };
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3022,23 +3022,13 @@ ZEND_METHOD(reflection_type, __toString)
 {
 	reflection_object *intern;
 	type_reference *param;
-	zend_string *str;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
 	}
 	GET_REFLECTION_OBJECT_PTR(param);
 	
-	str = reflection_type_name(param);
-	
-	if (param->arg_info->allow_null) {
-		size_t orig_len = ZSTR_LEN(str);
-		str = zend_string_extend(str, orig_len + 1, 0);
-		memmove(ZSTR_VAL(str) + 1, ZSTR_VAL(str), orig_len + 1);
-		ZSTR_VAL(str)[0] = '?';
-	}
-	
-	RETURN_STR(str);
+	RETURN_STR(reflection_type_name(param));
 }
 /* }}} */
 
@@ -6711,7 +6701,7 @@ static const zend_function_entry reflection_type_functions[] = {
 	ZEND_ME(reflection, __clone, arginfo_reflection__void, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
 	ZEND_ME(reflection_type, allowsNull, arginfo_reflection__void, 0)
 	ZEND_ME(reflection_type, isBuiltin, arginfo_reflection__void, 0)
-	ZEND_ME(reflection_type, __toString, arginfo_reflection__void, 0)
+	ZEND_ME(reflection_type, __toString, arginfo_reflection__void, ZEND_ACC_DEPRECATED)
 	PHP_FE_END
 };
 

--- a/ext/reflection/tests/ReflectionNamedType.phpt
+++ b/ext/reflection/tests/ReflectionNamedType.phpt
@@ -32,10 +32,18 @@ var_dump((string) $return);
 ?>
 --EXPECTF--
 string(11) "Traversable"
-string(12) "?Traversable"
+
+Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
+string(11) "Traversable"
 string(6) "string"
-string(7) "?string"
+
+Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
+string(6) "string"
 string(4) "Test"
-string(5) "?Test"
+
+Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
 string(4) "Test"
-string(5) "?Test"
+string(4) "Test"
+
+Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
+string(4) "Test"

--- a/ext/reflection/tests/ReflectionNamedType.phpt
+++ b/ext/reflection/tests/ReflectionNamedType.phpt
@@ -30,20 +30,12 @@ var_dump($return->getName());
 var_dump((string) $return);
 
 ?>
---EXPECTF--
+--EXPECT--
 string(11) "Traversable"
-
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
 string(11) "Traversable"
 string(6) "string"
-
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
 string(6) "string"
 string(4) "Test"
-
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
 string(4) "Test"
 string(4) "Test"
-
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
 string(4) "Test"

--- a/ext/reflection/tests/ReflectionType_001.phpt
+++ b/ext/reflection/tests/ReflectionType_001.phpt
@@ -28,7 +28,7 @@ foreach ([
     if ($ra) {
       var_dump($ra->allowsNull());
       var_dump($ra->isBuiltin());
-      var_dump((string)$ra);
+      var_dump($ra->getName());
     }
   }
 }
@@ -48,7 +48,7 @@ foreach ([
     if ($ra) {
       var_dump($ra->allowsNull());
       var_dump($ra->isBuiltin());
-      var_dump((string)$ra);
+      var_dump($ra->getName());
     }
   }
 }
@@ -70,7 +70,7 @@ foreach ([
   if ($ra) {
     var_dump($ra->allowsNull());
     var_dump($ra->isBuiltin());
-    var_dump((string)$ra);
+    var_dump($ra->getName());
   }
 }
 
@@ -96,7 +96,7 @@ string(8) "callable"
 bool(true)
 bool(true)
 bool(false)
-string(9) "?stdClass"
+string(8) "stdClass"
 ** Function 0 - Parameter 4
 bool(false)
 ** Function 0 - Parameter 5

--- a/ext/reflection/tests/ReflectionType_002.phpt
+++ b/ext/reflection/tests/ReflectionType_002.phpt
@@ -9,7 +9,7 @@ $rp = $rm->getParameters()[0];
 $rt = $rp->getType();
 $rrt = $rm->getReturnType();
 unset($rm, $rp);
-var_dump((string) $rt, (string) $rrt);
+var_dump($rt->getName(), $rrt->getName());
 
 --EXPECT--
 string(4) "Test"

--- a/ext/reflection/tests/ReflectionType_possible_types.phpt
+++ b/ext/reflection/tests/ReflectionType_possible_types.phpt
@@ -17,7 +17,7 @@ $functions = [
 foreach ($functions as $function) {
     $reflectionFunc = new ReflectionFunction($function);
     $returnType = $reflectionFunc->getReturnType();
-    var_dump($returnType->__toString());
+    var_dump($returnType->getName());
 }
 ?>
 --EXPECTF--

--- a/ext/reflection/tests/bug72661.phpt
+++ b/ext/reflection/tests/bug72661.phpt
@@ -6,5 +6,6 @@ function test(iterable $arg) { }
 
 var_dump((string)(new ReflectionParameter("test", 0))->getType());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
 string(8) "iterable"

--- a/ext/reflection/tests/bug72661.phpt
+++ b/ext/reflection/tests/bug72661.phpt
@@ -6,6 +6,5 @@ function test(iterable $arg) { }
 
 var_dump((string)(new ReflectionParameter("test", 0))->getType());
 ?>
---EXPECTF--
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
+--EXPECT--
 string(8) "iterable"


### PR DESCRIPTION
This restored the behavior of `ReflectionType::__toString()` from PHP 7.0. No `?` will be prepended for nullable types.

Additionally, the `ReflectionType::__toString()` method is deprecated in favor of `ReflectionNamedType::getName()`.