### PR TITLE
Fix #69579: Invalid free with internal trait (2)

### DIFF
--- a/Zend/tests/traits/bug69579.phpt
+++ b/Zend/tests/traits/bug69579.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #69579 (Internal trait double-free)
+--SKIPIF--
+<?php
+if (!PHP_DEBUG) die("skip only run in debug version");
+?>
+--FILE--
+<?php
+
+class Bar{
+  use _ZendTestTrait;
+}
+
+$bar = new Bar();
+var_dump($bar->testMethod());
+// destruction causes a double-free and explodes
+
+?>
+--EXPECT--
+bool(true)

--- a/Zend/tests/traits/get_declared_traits_001.phpt
+++ b/Zend/tests/traits/get_declared_traits_001.phpt
@@ -12,8 +12,8 @@ final class e { }
 var_dump(get_declared_traits());
 
 ?>
---EXPECT--
-array(1) {
-  [0]=>
+--EXPECTF--
+array(%d) {%A
+  [%d]=>
   string(1) "c"
 }

--- a/Zend/tests/traits/get_declared_traits_002.phpt
+++ b/Zend/tests/traits/get_declared_traits_002.phpt
@@ -13,8 +13,8 @@ namespace test {
 }
 
 ?>
---EXPECT--
-array(1) {
-  [0]=>
+--EXPECTF--
+array(%d) {%A
+  [%d]=>
   string(6) "test\c"
 }

--- a/Zend/tests/traits/get_declared_traits_003.phpt
+++ b/Zend/tests/traits/get_declared_traits_003.phpt
@@ -13,13 +13,15 @@ var_dump(get_declared_traits());
 
 ?>
 --EXPECTF--
-%astring(1) "a"
+array(%d) {%A
+  [%d]=>
+  string(1) "a"
   [%d]=>
   string(1) "d"
   [%d]=>
   string(1) "e"
 }
-array(1) {
-  [0]=>
+array(%d) {%A
+  [%d]=>
   string(1) "c"
 }

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -34,6 +34,7 @@
 #if ZEND_DEBUG
 static zend_class_entry *zend_test_interface;
 static zend_class_entry *zend_test_class;
+static zend_class_entry *zend_test_trait;
 static zend_object_handlers zend_test_class_handlers;
 #endif
 
@@ -308,6 +309,18 @@ static int zend_test_class_call_method(zend_string *method, zend_object *object,
 /* }}} */
 #endif
 
+#if ZEND_DEBUG
+static ZEND_METHOD(_ZendTestTrait, testMethod) /* {{{ */ {
+	RETURN_TRUE;
+}
+/* }}} */
+
+static zend_function_entry zend_test_trait_methods[] = {
+    ZEND_ME(_ZendTestTrait, testMethod, arginfo_zend__void, ZEND_ACC_PUBLIC)
+    ZEND_FE_END
+};
+#endif
+
 static const zend_function_entry builtin_functions[] = { /* {{{ */
 	ZEND_FE(zend_version,		arginfo_zend__void)
 	ZEND_FE(func_num_args,		arginfo_zend__void)
@@ -403,6 +416,13 @@ ZEND_MINIT_FUNCTION(core) { /* {{{ */
 	memcpy(&zend_test_class_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 	zend_test_class_handlers.get_method = zend_test_class_method_get;
 	zend_test_class_handlers.call_method = zend_test_class_call_method;
+#endif
+
+#if ZEND_DEBUG
+	INIT_CLASS_ENTRY(class_entry, "_ZendTestTrait", zend_test_trait_methods);
+	zend_test_trait = zend_register_internal_class(&class_entry);
+	zend_test_trait->ce_flags |= ZEND_ACC_TRAIT;
+	zend_declare_property_null(zend_test_trait, "testProp", sizeof("testProp")-1, ZEND_ACC_PUBLIC);
 #endif
 
 	return SUCCESS;

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1227,6 +1227,7 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, zend_s
 	function_add_ref(fn);
 	new_fn = zend_arena_alloc(&CG(arena), sizeof(zend_op_array));
 	memcpy(new_fn, fn, sizeof(zend_op_array));
+	new_fn->common.fn_flags |= ZEND_ACC_ARENA_ALLOCATED;
 	fn = zend_hash_update_ptr(&ce->function_table, key, new_fn);
 	zend_add_magic_methods(ce, key, fn);
 }


### PR DESCRIPTION
> If you are fixing a bug, then please submit your PR against the lowest branch of PHP that the bug affects

787377b works in 7.0, but f9b7bd0 is modeled after 2ee73ee

This PR includes the change from #1262, plus a test case and an internal test trait. I set up a Travis build to demonstrate what happens:
https://travis-ci.org/jbboehr/php-psr/jobs/161807370#L956
https://travis-ci.org/jbboehr/php-psr/jobs/161807373#L954