### PR TITLE
Fix #72918: negative offset inside a quoted string leads to parse error

### DIFF
--- a/Zend/tests/bug72918.phpt
+++ b/Zend/tests/bug72918.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #72918 (negative offset inside a quoted string leads to parse error)
+--FILE--
+<?php
+$array = [-3 => 'foo'];
+$string = 'abcde';
+
+echo "$array[-3]\n";
+echo "$string[-3]\n";
+echo <<<EOT
+$array[-3]
+$string[-3]
+
+EOT;
+?>
+===DONE===
+--EXPECT--
+foo
+c
+foo
+c
+===DONE===

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1249,6 +1249,7 @@ encaps_var:
 encaps_var_offset:
 		T_STRING		{ $$ = $1; }
 	|	T_NUM_STRING	{ $$ = $1; }
+   |  '-' T_NUM_STRING { $$ = zend_ast_create(ZEND_AST_UNARY_MINUS, $2); }
 	|	T_VARIABLE		{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
 ;
 

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1249,7 +1249,7 @@ encaps_var:
 encaps_var_offset:
 		T_STRING		{ $$ = $1; }
 	|	T_NUM_STRING	{ $$ = $1; }
-   |  '-' T_NUM_STRING { $$ = zend_ast_create(ZEND_AST_UNARY_MINUS, $2); }
+	|	'-' T_NUM_STRING { $$ = zend_ast_create(ZEND_AST_UNARY_MINUS, $2); }
 	|	T_VARIABLE		{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
 ;
 

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1875,7 +1875,7 @@ inline_char_handler:
 }
 
 <ST_VAR_OFFSET>{TOKENS}|[{}"`] {
-	/* Only '[' can be valid, but returning other tokens will allow a more explicit parse error */
+	/* Only '[' or '-' can be valid, but returning other tokens will allow a more explicit parse error */
 	RETURN_TOKEN(yytext[0]);
 }
 


### PR DESCRIPTION
We allow negative numeric offsets for the simple syntax inside
double-quoted and heredoc strings.