### PR TITLE
Fix #69267 (partially): mb_strtolower fails on titlecase characters

### DIFF
--- a/ext/mbstring/php_unicode.c
+++ b/ext/mbstring/php_unicode.c
@@ -186,7 +186,7 @@ MBSTRING_API unsigned long php_unicode_toupper(unsigned long code, enum mbfl_no_
 		 */
 		field = 1;
 		l = _uccase_len[0] + _uccase_len[1];
-		r = _uccase_size - 3;
+		r = (_uccase_size * 3) - 3;
 	}
 	return case_lookup(code, l, r, field);
 }
@@ -217,7 +217,7 @@ MBSTRING_API unsigned long php_unicode_tolower(unsigned long code, enum mbfl_no_
 		 */
 		field = 2;
 		l = _uccase_len[0] + _uccase_len[1];
-		r = _uccase_size - 3;
+		r = (_uccase_size * 3) - 3;
 	}
 	return case_lookup(code, l, r, field);
 }

--- a/ext/mbstring/tests/bug69267.phpt
+++ b/ext/mbstring/tests/bug69267.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #69267 (mb_strtolower fails on titlecase characters)
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
+--FILE--
+<?php
+$str = "\u{01c5}";
+var_dump(
+    "\u{01c6}" === mb_strtolower($str)
+);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
This patch fixes a simple arithmetical error.

This is a partial fix. The characters ǅ, ǈ, ǋ, ǲ will now be converted appropriately. However, Greek characters with hypogegrammene still do not work. This is because they are not generated by ucgendat.c as title-case characters, but rather as upper-case characters. Since this file originates in OpenLDAP, I have submitted a [patch](http://www.openldap.org/its/index.cgi/Incoming?id=8508) there. I don't know what the proper way is to propagate that change here, however, assuming it is accepted.
