### PR TITLE
New test to identify session_start() regression in 7.1

### DIFF
--- a/ext/session/tests/session_start_after_headers.phpt
+++ b/ext/session/tests/session_start_after_headers.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test session_start() failure still populates $_SESSION
+--SKIPIF--
+<?php if (!function_exists("session_start")) die("skip session support is not available"); ?>
+--FILE--
+<?php
+
+echo "start\n";
+
+session_start();
+$_SESSION['blah'] = 'foo';
+var_dump($_SESSION);
+session_write_close();
+
+session_start();
+var_dump($_SESSION);
+
+?>
+--EXPECTF--
+start
+
+Warning: session_start(): Cannot send session cookie - headers already sent by (output started at %s:%d) in %s on line %d
+
+Warning: session_start(): Cannot send session cache limiter - headers already sent (output started at %s:%d) in %s on line %d
+array(1) {
+  ["blah"]=>
+  string(3) "foo"
+}
+
+Warning: session_start(): Cannot send session cookie - headers already sent by (output started at %s:%d) in %s on line %d
+
+Warning: session_start(): Cannot send session cache limiter - headers already sent (output started at %s:%d) in %s on line %d
+array(1) {
+  ["blah"]=>
+  string(3) "foo"
+}


### PR DESCRIPTION
In `7.0` and `5.6` calling `session_start()` even if headers have been sent still made `$_SESSION` usable, but `7.1` changes this behaviour.

The attached test passes on the `PHP-7.0` branch, but fails on the `PHP-7.1` branch