### PR TITLE
soap #69137 - Fix SSL verify when using a proxy

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -161,7 +161,7 @@ void http_context_headers(php_stream_context* context,
 static php_stream* http_connect(zval* this_ptr, php_url *phpurl, int use_ssl, php_stream_context *context, int *use_proxy)
 {
 	php_stream *stream;
-	zval *proxy_host, *proxy_port, *tmp;
+	zval *proxy_host, *proxy_port, *tmp, ssl_proxy_peer_name;
 	char *host;
 	char *name;
 	char *protocol;
@@ -240,6 +240,13 @@ static php_stream* http_connect(zval* this_ptr, php_url *phpurl, int use_ssl, ph
 	/* SSL & proxy */
 	if (stream && *use_proxy && use_ssl) {
 		smart_str soap_headers = {0};
+
+		/* Set peer_name or name verification will try to use the proxy server name */
+		if (context && (tmp = php_stream_context_get_option(context, "ssl", "peer_name")) != NULL) {
+			ZVAL_STRING(&ssl_proxy_peer_name, phpurl->host);
+			php_stream_context_set_option(PHP_STREAM_CONTEXT(stream), "ssl", "peer_name", &ssl_proxy_peer_name);
+			zval_ptr_dtor(&ssl_proxy_peer_name);
+		}
 
 		smart_str_append_const(&soap_headers, "CONNECT ");
 		smart_str_appends(&soap_headers, phpurl->host);

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -242,7 +242,7 @@ static php_stream* http_connect(zval* this_ptr, php_url *phpurl, int use_ssl, ph
 		smart_str soap_headers = {0};
 
 		/* Set peer_name or name verification will try to use the proxy server name */
-		if (context && (tmp = php_stream_context_get_option(context, "ssl", "peer_name")) != NULL) {
+		if (!context || (tmp = php_stream_context_get_option(context, "ssl", "peer_name")) == NULL) {
 			ZVAL_STRING(&ssl_proxy_peer_name, phpurl->host);
 			php_stream_context_set_option(PHP_STREAM_CONTEXT(stream), "ssl", "peer_name", &ssl_proxy_peer_name);
 			zval_ptr_dtor(&ssl_proxy_peer_name);

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2368,6 +2368,8 @@ PHP_METHOD(SoapClient, SoapClient)
 				Z_TYPE_P(tmp) == IS_RESOURCE) {
 			context = php_stream_context_from_zval(tmp, 1);
 			Z_ADDREF_P(tmp);
+		} else {
+			context = php_stream_context_alloc(); 
 		}
 
 		if ((tmp = zend_hash_str_find(ht, "location", sizeof("location")-1)) != NULL &&

--- a/ext/soap/tests/bug69137.phpt
+++ b/ext/soap/tests/bug69137.phpt
@@ -1,0 +1,41 @@
+--TEST--
+SOAP Bug #69137 - Peer verification fails when using a proxy with SoapClient
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (getenv("SKIP_ONLINE_TESTS")) { die("skip test requiring internet connection"); }
+if (!getenv('http_proxy')) { die("skip test unless an HTTP/HTTPS proxy server is specified in http_proxy environment variable"); }
+?>
+--INI--
+soap.wsdl_cache_enabled=0
+--FILE--
+<?php
+
+class IpLookup
+{
+    public $licenseKey;
+    public $ipAddress;
+}
+
+list ($proxyHost, $proxyPort) = explode(':', str_replace('http://', '', $_ENV['http_proxy']));
+
+$testServiceWsdl = 'https://ws.cdyne.com/ip2geo/ip2geo.asmx?wsdl';
+$parameters = [
+	'proxy_host' => $proxyHost,
+	'proxy_port' => $proxyPort,
+	'trace' => 1,
+];
+$client = new SoapClient($testServiceWsdl, $parameters);
+
+$lookup = new IpLookup();
+$lookup->licenseKey = 0;
+$lookup->ipAddress = '72.52.91.14';
+
+$result = $client->ResolveIP($lookup);
+
+if ($result && is_object($result) && $result->ResolveIPResult && is_object($result->ResolveIPResult)) {
+	print "successful lookup";
+}
+?>
+--EXPECT--
+successful lookup

--- a/ext/soap/tests/bug69137.phpt
+++ b/ext/soap/tests/bug69137.phpt
@@ -7,7 +7,7 @@ if (getenv("SKIP_ONLINE_TESTS")) { die("skip test requiring internet connection"
 if (!getenv('http_proxy')) { die("skip test unless an HTTP/HTTPS proxy server is specified in http_proxy environment variable"); }
 ?>
 --INI--
-soap.wsdl_cache_enabled=0
+soap.wsdl_cache_enabled=1
 --FILE--
 <?php
 
@@ -19,7 +19,12 @@ class IpLookup
 
 list ($proxyHost, $proxyPort) = explode(':', str_replace('http://', '', $_ENV['http_proxy']));
 
+// Prime the WSDL cache because that request sets peer_name on the HTTP context
+// and masks the SOAP bug.
 $testServiceWsdl = 'https://ws.cdyne.com/ip2geo/ip2geo.asmx?wsdl';
+$client = new SoapClient($testServiceWsdl);
+unset($client);
+
 $parameters = [
 	'proxy_host' => $proxyHost,
 	'proxy_port' => $proxyPort,


### PR DESCRIPTION
Name verification was failing because the OpenSSL extension was picking the proxy server's address when guessing which name to compare to the SSL certificate. This scenario is already handled for stream wrappers in http_fopen_wrapper.c. This patch applies the same fix to the SOAP extension: when a proxy is used, set peer_name explicitly on the stream context.

https://bugs.php.net/bug.php?id=69137

Thanks to @arrisray for helping debug and fix a segfault in an earlier version of this patch.