### PR TITLE
Skip tests that rely on sessions if sessions aren't available

### DIFF
--- a/ext/standard/tests/general_functions/output_add_rewrite_var_basic1.phpt
+++ b/ext/standard/tests/general_functions/output_add_rewrite_var_basic1.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Test output_add_rewrite_var() function basic feature
 --SKIPIF--
+<?php if (!extension_loaded("session")) die("skip session support is not available"); ?>
 --INI--
 session.trans_sid_tags="a=href,area=href,frame=src,form="
 url_rewriter.tags="a=href,area=href,frame=src,form="

--- a/ext/standard/tests/general_functions/output_add_rewrite_var_basic2.phpt
+++ b/ext/standard/tests/general_functions/output_add_rewrite_var_basic2.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Test output_add_rewrite_var() function basic feature
 --SKIPIF--
+<?php if (!extension_loaded("session")) die("skip session support is not available"); ?>
 --INI--
 session.trans_sid_tags="a=href,area=href,frame=src,form="
 url_rewriter.tags="a=href,area=href,frame=src,form="

--- a/ext/standard/tests/general_functions/output_add_rewrite_var_basic3.phpt
+++ b/ext/standard/tests/general_functions/output_add_rewrite_var_basic3.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Test output_add_rewrite_var() function basic feature
 --SKIPIF--
+<?php if (!extension_loaded("session")) die("skip session support is not available"); ?>
 --INI--
 session.trans_sid_tags="a=href,area=href,frame=src,form="
 url_rewriter.tags="a=href,area=href,frame=src,form="

--- a/ext/standard/tests/general_functions/output_add_rewrite_var_basic4.phpt
+++ b/ext/standard/tests/general_functions/output_add_rewrite_var_basic4.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Test output_add_rewrite_var() function basic feature
 --SKIPIF--
+<?php if (!extension_loaded("session")) die("skip session support is not available"); ?>
 --INI--
 session.trans_sid_tags="a=href,area=href,frame=src,form="
 url_rewriter.tags="a=href,area=href,frame=src,form="


### PR DESCRIPTION
a53a6b3fb4060c9c71a84b0acaaa0211777f6e17 introduced some tests that depend on the session extension being enabled, but don't check if it is. This pr skips those tests if the extension isn't loaded