### PR TITLE
RFC: Deprecate png2wbmp() and jpegwbmp()

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -4085,6 +4085,8 @@ static void _php_image_convert(INTERNAL_FUNCTION_PARAMETERS, int image_type )
     zend_long ignore_warning;
 #endif
 
+	php_error_docref(NULL, E_DEPRECATED, "This function is deprecated");
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "pplll", &f_org, &f_org_len, &f_dest, &f_dest_len, &height, &width, &threshold) == FAILURE) {
 		return;
 	}

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -958,10 +958,10 @@ const zend_function_entry gd_functions[] = {
 	PHP_FE(imagetypes,								arginfo_imagetypes)
 
 #if defined(HAVE_GD_JPG)
-	PHP_FE(jpeg2wbmp,								arginfo_jpeg2wbmp)
+	PHP_DEP_FE(jpeg2wbmp,							arginfo_jpeg2wbmp)
 #endif
 #if defined(HAVE_GD_PNG)
-	PHP_FE(png2wbmp,								arginfo_png2wbmp)
+	PHP_DEP_FE(png2wbmp,							arginfo_png2wbmp)
 #endif
 	PHP_FE(image2wbmp,								arginfo_image2wbmp)
 	PHP_FE(imagelayereffect,						arginfo_imagelayereffect)
@@ -4084,8 +4084,6 @@ static void _php_image_convert(INTERNAL_FUNCTION_PARAMETERS, int image_type )
 #ifdef HAVE_GD_JPG
     zend_long ignore_warning;
 #endif
-
-	php_error_docref(NULL, E_DEPRECATED, "This function is deprecated");
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "pplll", &f_org, &f_org_len, &f_dest, &f_dest_len, &height, &width, &threshold) == FAILURE) {
 		return;

--- a/ext/gd/tests/jpeg2wbmp_error1.phpt
+++ b/ext/gd/tests/jpeg2wbmp_error1.phpt
@@ -32,7 +32,11 @@ jpeg2wbmp($file, $file2, 20, 120, 9);
 jpeg2wbmp($file, $file2, 20, 120, -1);
 ?>
 --EXPECTF--
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+
 Warning: jpeg2wbmp(): Invalid threshold value '9' in %s on line %d
+
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Invalid threshold value '-1' in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/jpeg2wbmp_error1.phpt
+++ b/ext/gd/tests/jpeg2wbmp_error1.phpt
@@ -32,11 +32,11 @@ jpeg2wbmp($file, $file2, 20, 120, 9);
 jpeg2wbmp($file, $file2, 20, 120, -1);
 ?>
 --EXPECTF--
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Invalid threshold value '9' in %s on line %d
 
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Invalid threshold value '-1' in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/jpeg2wbmp_error2-mb.phpt
+++ b/ext/gd/tests/jpeg2wbmp_error2-mb.phpt
@@ -20,15 +20,15 @@ jpeg2wbmp(null, $file, 20, 120, 8);
 jpeg2wbmp(false, $file, 20, 120, 8);
 ?>
 --EXPECTF--
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
 
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
 
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/jpeg2wbmp_error2-mb.phpt
+++ b/ext/gd/tests/jpeg2wbmp_error2-mb.phpt
@@ -20,9 +20,15 @@ jpeg2wbmp(null, $file, 20, 120, 8);
 jpeg2wbmp(false, $file, 20, 120, 8);
 ?>
 --EXPECTF--
-Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
+
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+
+Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
+
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/jpeg2wbmp_error2.phpt
+++ b/ext/gd/tests/jpeg2wbmp_error2.phpt
@@ -20,15 +20,15 @@ jpeg2wbmp(null, $file, 20, 120, 8);
 jpeg2wbmp(false, $file, 20, 120, 8);
 ?>
 --EXPECTF--
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
 
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
 
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/jpeg2wbmp_error2.phpt
+++ b/ext/gd/tests/jpeg2wbmp_error2.phpt
@@ -20,9 +20,15 @@ jpeg2wbmp(null, $file, 20, 120, 8);
 jpeg2wbmp(false, $file, 20, 120, 8);
 ?>
 --EXPECTF--
-Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
+
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+
+Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
+
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for reading in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/jpeg2wbmp_error3.phpt
+++ b/ext/gd/tests/jpeg2wbmp_error3.phpt
@@ -32,9 +32,15 @@ jpeg2wbmp($file, null, 20, 120, 8);
 jpeg2wbmp($file, false, 20, 120, 8);
 ?>
 --EXPECTF--
-Warning: jpeg2wbmp(): Unable to open '' for writing in %s on line %d
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for writing in %s on line %d
+
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+
+Warning: jpeg2wbmp(): Unable to open '' for writing in %s on line %d
+
+Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for writing in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/jpeg2wbmp_error3.phpt
+++ b/ext/gd/tests/jpeg2wbmp_error3.phpt
@@ -32,15 +32,15 @@ jpeg2wbmp($file, null, 20, 120, 8);
 jpeg2wbmp($file, false, 20, 120, 8);
 ?>
 --EXPECTF--
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for writing in %s on line %d
 
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for writing in %s on line %d
 
-Deprecated: jpeg2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function jpeg2wbmp() is deprecated in %s on line %d
 
 Warning: jpeg2wbmp(): Unable to open '' for writing in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/png2wbmp_error1-mb.phpt
+++ b/ext/gd/tests/png2wbmp_error1-mb.phpt
@@ -32,7 +32,11 @@ png2wbmp($file, $file2, 20, 120, 9);
 png2wbmp($file, $file2, 20, 120, -1);
 ?>
 --EXPECTF--
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+
 Warning: png2wbmp(): Invalid threshold value '9' in %s on line %d
+
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
 
 Warning: png2wbmp(): Invalid threshold value '-1' in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/png2wbmp_error1-mb.phpt
+++ b/ext/gd/tests/png2wbmp_error1-mb.phpt
@@ -32,11 +32,11 @@ png2wbmp($file, $file2, 20, 120, 9);
 png2wbmp($file, $file2, 20, 120, -1);
 ?>
 --EXPECTF--
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Invalid threshold value '9' in %s on line %d
 
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Invalid threshold value '-1' in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/png2wbmp_error1.phpt
+++ b/ext/gd/tests/png2wbmp_error1.phpt
@@ -32,7 +32,11 @@ png2wbmp($file, $file2, 20, 120, 9);
 png2wbmp($file, $file2, 20, 120, -1);
 ?>
 --EXPECTF--
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+
 Warning: png2wbmp(): Invalid threshold value '9' in %s on line %d
+
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
 
 Warning: png2wbmp(): Invalid threshold value '-1' in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/png2wbmp_error1.phpt
+++ b/ext/gd/tests/png2wbmp_error1.phpt
@@ -32,11 +32,11 @@ png2wbmp($file, $file2, 20, 120, 9);
 png2wbmp($file, $file2, 20, 120, -1);
 ?>
 --EXPECTF--
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Invalid threshold value '9' in %s on line %d
 
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Invalid threshold value '-1' in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/png2wbmp_error2.phpt
+++ b/ext/gd/tests/png2wbmp_error2.phpt
@@ -20,15 +20,15 @@ png2wbmp(null, $file, 20, 120, 8);
 png2wbmp(false, $file, 20, 120, 8);
 ?>
 --EXPECTF--
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for reading in %s on line %d
 
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for reading in %s on line %d
 
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for reading in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/png2wbmp_error2.phpt
+++ b/ext/gd/tests/png2wbmp_error2.phpt
@@ -20,9 +20,15 @@ png2wbmp(null, $file, 20, 120, 8);
 png2wbmp(false, $file, 20, 120, 8);
 ?>
 --EXPECTF--
-Warning: png2wbmp(): Unable to open '' for reading in %s on line %d
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for reading in %s on line %d
+
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+
+Warning: png2wbmp(): Unable to open '' for reading in %s on line %d
+
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for reading in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/png2wbmp_error3.phpt
+++ b/ext/gd/tests/png2wbmp_error3.phpt
@@ -32,9 +32,15 @@ png2wbmp($file, null, 20, 120, 8);
 png2wbmp($file, false, 20, 120, 8);
 ?>
 --EXPECTF--
-Warning: png2wbmp(): Unable to open '' for writing in %s on line %d
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for writing in %s on line %d
+
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+
+Warning: png2wbmp(): Unable to open '' for writing in %s on line %d
+
+Deprecated: png2wbmp(): This function is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for writing in %s on line %d
 --CLEAN--

--- a/ext/gd/tests/png2wbmp_error3.phpt
+++ b/ext/gd/tests/png2wbmp_error3.phpt
@@ -32,15 +32,15 @@ png2wbmp($file, null, 20, 120, 8);
 png2wbmp($file, false, 20, 120, 8);
 ?>
 --EXPECTF--
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for writing in %s on line %d
 
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for writing in %s on line %d
 
-Deprecated: png2wbmp(): This function is deprecated in %s on line %d
+Deprecated: Function png2wbmp() is deprecated in %s on line %d
 
 Warning: png2wbmp(): Unable to open '' for writing in %s on line %d
 --CLEAN--


### PR DESCRIPTION
See https://wiki.php.net/rfc/deprecate-png-jpeg-2wbmp.
