### PR TITLE
Add php_random_int internal API

### DIFF
--- a/ext/standard/php_random.h
+++ b/ext/standard/php_random.h
@@ -34,7 +34,13 @@ typedef struct {
 #define php_random_bytes_throw(b, s) php_random_bytes((b), (s), 1)
 #define php_random_bytes_silent(b, s) php_random_bytes((b), (s), 0)
 
+#define php_random_int_throw(min, max, result) \
+	php_random_int((min), (max), (result), 1)
+#define php_random_int_silent(min, max, result) \
+	php_random_int((min), (max), (result), 0)
+
 PHPAPI int php_random_bytes(void *bytes, size_t size, zend_bool should_throw);
+PHPAPI int php_random_int(zend_long min, zend_long max, zend_long *result, zend_bool should_throw);
 
 #ifdef ZTS
 # define RANDOM_G(v) ZEND_TSRMG(random_globals_id, php_random_globals *, v)


### PR DESCRIPTION
This is the internal API compliment to `php_random_bytes`

The purpose is to allow extensions and future enhancements that require high quality unbiased random numbers to fetch them without having to implement their own unbiasing algorithm.
