### PR TITLE
http_fopen_wrapper.c - Ignore "100 Continue" responses

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -699,6 +699,24 @@ finish:
 			if ((options & STREAM_ONLY_GET_HEADERS) || ignore_errors) {
 				reqok = 1;
 			}
+
+			/* status codes of 1xx are "informational", and will be followed by a real response
+			 * e.g "100 Continue". RFC 7231 states that unexpected 1xx status MUST be parsed,
+			 * and MAY be ignored. As such, we need to skip ahead to the "real" status*/
+			if (response_code >= 100 && response_code < 200) {
+				/* consume lines until we find a line starting 'HTTP/1' */
+				while (
+					!php_stream_eof(stream)
+					&& php_stream_get_line(stream, tmp_line, sizeof(tmp_line) - 1, &tmp_line_len) != NULL
+					&& ( tmp_line_len < 6 || strncasecmp(tmp_line, "HTTP/1", 6) )
+				);
+
+				if (tmp_line_len > 9) {
+					response_code = atoi(tmp_line + 9);
+				} else {
+					response_code = 0;
+				}
+			}
 			/* all status codes in the 2xx range are defined by the specification as successful;
 			 * all status codes in the 3xx range are for redirection, and so also should never
 			 * fail */

--- a/ext/standard/tests/http/bug73297.phpt
+++ b/ext/standard/tests/http/bug73297.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Bug #73297 (Ignore 100 Continue returned by HTTP/1.1 servers)
+--INI--
+allow_url_fopen=1
+--SKIPIF--
+<?php require 'server.inc'; http_server_skipif('tcp://127.0.0.1:12342'); ?>
+--FILE--
+<?php
+require 'server.inc';
+
+$ctx = stream_context_create();
+
+function do_test() {
+  $options = [
+    'http' => [
+      'protocol_version' => '1.1',
+      'header' => 'Connection: Close'
+    ],
+  ];
+
+  $ctx = stream_context_create($options);
+
+  $responses = [
+    "data://text/plain,HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\n\r\n"
+      . "Hello"
+  ];
+  $pid = http_server('tcp://127.0.0.1:12342', $responses);
+
+  echo file_get_contents('http://127.0.0.1:12342/', false, $ctx);
+  echo "\n";
+
+  http_server_kill($pid);
+}
+
+do_test();
+echo "\n";
+
+?>
+--EXPECT--
+Hello
+

--- a/ext/standard/tests/http/bug73297.phpt
+++ b/ext/standard/tests/http/bug73297.phpt
@@ -8,34 +8,26 @@ allow_url_fopen=1
 <?php
 require 'server.inc';
 
-$ctx = stream_context_create();
+$options = [
+  'http' => [
+    'protocol_version' => '1.1',
+    'header' => 'Connection: Close'
+  ],
+];
 
-function do_test() {
-  $options = [
-    'http' => [
-      'protocol_version' => '1.1',
-      'header' => 'Connection: Close'
-    ],
-  ];
+$ctx = stream_context_create($options);
 
-  $ctx = stream_context_create($options);
+$responses = [
+  "data://text/plain,HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\n\r\n"
+    . "Hello"
+];
+$pid = http_server('tcp://127.0.0.1:12342', $responses);
 
-  $responses = [
-    "data://text/plain,HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\n\r\n"
-      . "Hello"
-  ];
-  $pid = http_server('tcp://127.0.0.1:12342', $responses);
-
-  echo file_get_contents('http://127.0.0.1:12342/', false, $ctx);
-  echo "\n";
-
-  http_server_kill($pid);
-}
-
-do_test();
+echo file_get_contents('http://127.0.0.1:12342/', false, $ctx);
 echo "\n";
+
+http_server_kill($pid);
 
 ?>
 --EXPECT--
 Hello
-


### PR DESCRIPTION
Fixes bug #73297

Part of an effort to implement HTTP/1.1 properly in the stream wrapper, with a view to making it easier or default in a future version.
