### PR TITLE
Add a "strict_types" key to backtrace output

### DIFF
--- a/Zend/tests/bug50383.phpt
+++ b/Zend/tests/bug50383.phpt
@@ -55,6 +55,7 @@ Array
 
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -66,6 +67,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
 )
@@ -88,6 +90,7 @@ Array
 
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -99,6 +102,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
 )

--- a/Zend/tests/bug64239_2.phpt
+++ b/Zend/tests/bug64239_2.phpt
@@ -41,6 +41,7 @@ Array
             [function] => Bmethod
             [class] => B
             [type] => ->
+            [strict_types] => 0
         )
 
 )
@@ -53,6 +54,7 @@ Array
             [function] => Bmethod
             [class] => B
             [type] => ->
+            [strict_types] => 0
         )
 
 )

--- a/Zend/tests/bug73156.phpt
+++ b/Zend/tests/bug73156.phpt
@@ -24,7 +24,7 @@ array(2) {
     string(4) "eval"
   }
   [1]=>
-  array(7) {
+  array(8) {
     ["file"]=>
     string(%d) "%sbug73156.php"
     ["line"]=>
@@ -46,5 +46,7 @@ array(2) {
       array(0) {
       }
     }
+    ["strict_types"]=>
+    int(0)
   }
 }

--- a/Zend/tests/closure_032.phpt
+++ b/Zend/tests/closure_032.phpt
@@ -26,6 +26,7 @@ Array
                     [0] => 23
                 )
 
+            [strict_types] => 0
         )
 
 )
@@ -42,6 +43,7 @@ Array
                     [0] => 23
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -62,6 +64,7 @@ Array
 
                 )
 
+            [strict_types] => 0
         )
 
 )

--- a/Zend/tests/debug_backtrace_limit.phpt
+++ b/Zend/tests/debug_backtrace_limit.phpt
@@ -31,6 +31,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
 )
@@ -45,6 +46,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -56,6 +58,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
 )
@@ -70,6 +73,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -81,6 +85,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
     [2] => Array
@@ -92,6 +97,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
 )
@@ -106,6 +112,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -117,6 +124,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
     [2] => Array
@@ -128,6 +136,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
 )

--- a/Zend/tests/debug_backtrace_options.phpt
+++ b/Zend/tests/debug_backtrace_options.phpt
@@ -80,6 +80,7 @@ Array
                 (
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -94,6 +95,7 @@ Array
                     [2] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
     [2] => Array
@@ -113,6 +115,7 @@ Array
                     [1] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
     [3] => Array
@@ -128,6 +131,7 @@ Array
                     [1] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
 )
@@ -144,6 +148,7 @@ Array
                     [0] => 1
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -158,6 +163,7 @@ Array
                     [2] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
     [2] => Array
@@ -177,6 +183,7 @@ Array
                     [1] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
     [3] => Array
@@ -192,6 +199,7 @@ Array
                     [1] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
 )
@@ -208,6 +216,7 @@ Array
                     [0] => 
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -222,6 +231,7 @@ Array
                     [2] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
     [2] => Array
@@ -237,6 +247,7 @@ Array
                     [1] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
     [3] => Array
@@ -252,6 +263,7 @@ Array
                     [1] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
 )
@@ -268,6 +280,7 @@ Array
                     [0] => 1
                 )
 
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -282,6 +295,7 @@ Array
                     [2] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
     [2] => Array
@@ -301,6 +315,7 @@ Array
                     [1] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
     [3] => Array
@@ -316,6 +331,7 @@ Array
                     [1] => backtrace_print
                 )
 
+            [strict_types] => 0
         )
 
 )
@@ -327,6 +343,7 @@ Array
             [file] => %sdebug_backtrace_options.php
             [line] => 23
             [function] => backtrace_print
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -334,6 +351,7 @@ Array
             [file] => %sdebug_backtrace_options.php
             [line] => %d
             [function] => doit
+            [strict_types] => 0
         )
 
     [2] => Array
@@ -343,6 +361,7 @@ Array
             [function] => doCall
             [class] => foo
             [type] => ->
+            [strict_types] => 0
         )
 
     [3] => Array
@@ -352,6 +371,7 @@ Array
             [function] => statCall
             [class] => foo
             [type] => ::
+            [strict_types] => 0
         )
 
 )
@@ -363,6 +383,7 @@ Array
             [file] => %sdebug_backtrace_options.php
             [line] => 25
             [function] => backtrace_print
+            [strict_types] => 0
         )
 
     [1] => Array
@@ -370,6 +391,7 @@ Array
             [file] => %sdebug_backtrace_options.php
             [line] => %d
             [function] => doit
+            [strict_types] => 0
         )
 
     [2] => Array
@@ -383,6 +405,7 @@ Array
                 )
 
             [type] => ->
+            [strict_types] => 0
         )
 
     [3] => Array
@@ -392,6 +415,7 @@ Array
             [function] => statCall
             [class] => foo
             [type] => ::
+            [strict_types] => 0
         )
 
 )

--- a/Zend/tests/strict_types_debug_backtrace.phpt
+++ b/Zend/tests/strict_types_debug_backtrace.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Strict types reported in debug backtrace
+--FILE--
+<?php declare(strict_types=0);
+
+require 'strict_types_debug_backtrace_helper.inc';
+
+function test_strict_types_debug_backtrace1()
+{
+	return debug_backtrace();
+}
+
+$bt1 = test_strict_types_debug_backtrace1();
+$bt2 = test_strict_types_debug_backtrace2();
+
+var_dump($bt1[0]['strict_types']);
+var_dump($bt2[0]['strict_types'], $bt2[1]['strict_types']);
+
+echo "Done\n";
+?>
+--EXPECTF--	
+int(0)
+int(0)
+int(1)
+Done

--- a/Zend/tests/strict_types_debug_backtrace_helper.inc
+++ b/Zend/tests/strict_types_debug_backtrace_helper.inc
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+// Separate file with strict_types enabled
+
+function test_strict_types_debug_backtrace2()
+{
+	return test_strict_types_debug_backtrace1();
+}

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -2711,6 +2711,9 @@ ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int 
 				debug_backtrace_get_args(call, &tmp);
 				zend_hash_add_new(Z_ARRVAL(stack_frame), CG(known_strings)[ZEND_STR_ARGS], &tmp);
 			}
+
+			ZVAL_LONG(&tmp, (func->common.fn_flags & ZEND_ACC_STRICT_TYPES) == ZEND_ACC_STRICT_TYPES);
+			zend_hash_add_new(Z_ARRVAL(stack_frame), CG(known_strings)[ZEND_STR_STRICT_TYPES], &tmp);
 		} else {
 			/* i know this is kinda ugly, but i'm trying to avoid extra cycles in the main execution loop */
 			zend_bool build_filename_arg = 1;

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -410,6 +410,7 @@ static zend_always_inline void zend_zts_interned_string_free(zend_string **s)
 	_(ZEND_STR_SEVERITY,               "severity") \
 	_(ZEND_STR_STRING,                 "string") \
 	_(ZEND_STR_TRACE,                  "trace") \
+	_(ZEND_STR_STRICT_TYPES,           "strict_types") \
 
 
 typedef enum _zend_known_string_id {

--- a/ext/dom/tests/dom003.phpt
+++ b/ext/dom/tests/dom003.phpt
@@ -37,7 +37,7 @@ object(DOMException)#%d (%d) {
   ["trace":"Exception":private]=>
   array(1) {
     [0]=>
-    array(6) {
+    array(7) {
       ["file"]=>
       string(%d) "%sdom003.php"
       ["line"]=>
@@ -53,6 +53,8 @@ object(DOMException)#%d (%d) {
         [0]=>
         DOMElement
       }
+      ["strict_types"]=>
+      int(0)
     }
   }
   ["previous":"Exception":private]=>

--- a/ext/dom/tests/dom_set_attr_node.phpt
+++ b/ext/dom/tests/dom_set_attr_node.phpt
@@ -49,7 +49,7 @@ object(DOMException)#%d (7) {
   ["trace":"Exception":private]=>
   array(1) {
     [0]=>
-    array(6) {
+    array(7) {
       ["file"]=>
       string(%d) "%sdom_set_attr_node.php"
       ["line"]=>
@@ -65,6 +65,8 @@ object(DOMException)#%d (7) {
         [0]=>
         DOMAttr
       }
+      ["strict_types"]=>
+      int(0)
     }
   }
   ["previous":"Exception":private]=>

--- a/ext/reflection/tests/ReflectionGenerator_basic.phpt
+++ b/ext/reflection/tests/ReflectionGenerator_basic.phpt
@@ -39,7 +39,7 @@ object(Generator)#2 (0) {
 }
 array(1) {
   [0]=>
-  array(4) {
+  array(5) {
     ["file"]=>
     string(%d) "%s"
     ["line"]=>
@@ -49,6 +49,8 @@ array(1) {
     ["args"]=>
     array(0) {
     }
+    ["strict_types"]=>
+    int(0)
   }
 }
 int(%d)

--- a/ext/reflection/tests/ReflectionGenerator_getTrace.phpt
+++ b/ext/reflection/tests/ReflectionGenerator_getTrace.phpt
@@ -27,7 +27,7 @@ var_dump((new ReflectionGenerator($gen))->getTrace());
 --EXPECTF--
 array(2) {
   [0]=>
-  array(4) {
+  array(5) {
     ["file"]=>
     string(%d) "%s"
     ["line"]=>
@@ -37,9 +37,11 @@ array(2) {
     ["args"]=>
     array(0) {
     }
+    ["strict_types"]=>
+    int(0)
   }
   [1]=>
-  array(4) {
+  array(5) {
     ["file"]=>
     string(%d) "%s"
     ["line"]=>
@@ -49,5 +51,7 @@ array(2) {
     ["args"]=>
     array(0) {
     }
+    ["strict_types"]=>
+    int(0)
   }
 }

--- a/ext/reflection/tests/ReflectionGenerator_in_Generator.phpt
+++ b/ext/reflection/tests/ReflectionGenerator_in_Generator.phpt
@@ -46,7 +46,7 @@ object(ReflectionFunction)#4 (1) {
 NULL
 array(1) {
   [0]=>
-  array(4) {
+  array(5) {
     ["file"]=>
     string(%d) "%s"
     ["line"]=>
@@ -56,6 +56,8 @@ array(1) {
     ["args"]=>
     array(0) {
     }
+    ["strict_types"]=>
+    int(0)
   }
 }
 int(%d)

--- a/ext/standard/tests/array/array_walk_closure.phpt
+++ b/ext/standard/tests/array/array_walk_closure.phpt
@@ -205,7 +205,7 @@ End result:int(42)
 closure and exception
 array(2) {
   [0]=>
-  array(2) {
+  array(3) {
     ["function"]=>
     string(9) "{closure}"
     ["args"]=>
@@ -215,9 +215,11 @@ array(2) {
       [1]=>
       string(3) "two"
     }
+    ["strict_types"]=>
+    int(0)
   }
   [1]=>
-  array(4) {
+  array(5) {
     ["file"]=>
     string(%d) "%s"
     ["line"]=>
@@ -246,6 +248,8 @@ array(2) {
         }
       }
     }
+    ["strict_types"]=>
+    int(0)
   }
 }
 Done


### PR DESCRIPTION
The idea here is to be able to see which functions were called with strict_types enabled or disabled, and where parameters may have had their types converted
