### PR TITLE
RFC: Counting of non-countable objects

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -108,6 +108,8 @@ PHP 7.2 UPGRADE NOTES
       'Multiple' => ['One header', 'Another header'],
       'Multiline' = "FirstLine\r\n SecondLine",
     ];
+  . count() now raises a warning when an invalid parameter is passed.
+    Only arrays and objects implementing the Countable interface should be passed.
 
 - XML:
   . utf8_encode() and utf8_decode() have been moved to the Standard extension

--- a/Zend/tests/generators/errors/count_error.phpt
+++ b/Zend/tests/generators/errors/count_error.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Generators can't be counted
+--FILE--
+<?php
+
+function gen() { yield; }
+
+$gen = gen();
+
+try {
+    count($gen);
+} catch (Exception $e) {
+    echo $e;
+}
+
+?>
+--EXPECTF--
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d

--- a/ext/date/tests/timezone_transitions_get_variation2.phpt
+++ b/ext/date/tests/timezone_transitions_get_variation2.phpt
@@ -145,24 +145,32 @@ int(8)
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, array given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- int indexed array --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, array given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- associative array --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, array given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- nested arrays --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, array given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- uppercase NULL --
@@ -193,48 +201,64 @@ int(8)
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- empty string SQ --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- string DQ --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- string SQ --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- mixed case string --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- heredoc --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- instance of classWithToString --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, object given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- instance of classWithoutToString --
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, object given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- undefined var --
@@ -249,5 +273,7 @@ int(8)
 
 Warning: timezone_transitions_get() expects parameter 2 to be integer, resource given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 ===DONE===

--- a/ext/date/tests/timezone_transitions_get_variation3.phpt
+++ b/ext/date/tests/timezone_transitions_get_variation3.phpt
@@ -145,24 +145,32 @@ int(1)
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, array given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- int indexed array --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, array given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- associative array --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, array given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- nested arrays --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, array given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- uppercase NULL --
@@ -193,48 +201,64 @@ int(1)
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- empty string SQ --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- string DQ --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- string SQ --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- mixed case string --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- heredoc --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, string given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- instance of classWithToString --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, object given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- instance of classWithoutToString --
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, object given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- undefined var --
@@ -249,5 +273,7 @@ int(1)
 
 Warning: timezone_transitions_get() expects parameter 3 to be integer, resource given in %s on line %d
 string(7) "boolean"
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 ===DONE===

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -790,6 +790,7 @@ PHP_FUNCTION(count)
 
 	switch (Z_TYPE_P(array)) {
 		case IS_NULL:
+			php_error_docref(NULL, E_WARNING, "Parameter must be an array or an object that implements Countable");
 			RETURN_LONG(0);
 			break;
 		case IS_ARRAY:
@@ -820,8 +821,14 @@ PHP_FUNCTION(count)
 				}
 				return;
 			}
+
+			/* If There's no handler and it doesn't implement Countable then add a warning */
+			php_error_docref(NULL, E_WARNING, "Parameter must be an array or an object that implements Countable");
+			RETURN_LONG(1);
+			break;
 		}
 		default:
+			php_error_docref(NULL, E_WARNING, "Parameter must be an array or an object that implements Countable");
 			RETURN_LONG(1);
 			break;
 	}

--- a/ext/standard/tests/array/count_invalid.phpt
+++ b/ext/standard/tests/array/count_invalid.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Only arrays and countable objects can be counted
+--FILE--
+<?php
+
+$result = count(null);
+var_dump($result);
+
+$result = count("string");
+var_dump($result);
+
+$result = count(123);
+var_dump($result);
+
+$result = count(true);
+var_dump($result);
+
+$result = count(false);
+var_dump($result);
+
+$result = count((object) []);
+var_dump($result);
+
+?>
+--EXPECTF--
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)

--- a/ext/standard/tests/array/count_recursive.phpt
+++ b/ext/standard/tests/array/count_recursive.phpt
@@ -132,7 +132,11 @@ closedir( $resource2 );
 --EXPECTF--
 *** Testing basic functionality of count() function ***
 -- Testing NULL --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 COUNT_NORMAL: should be 0, is 0
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 COUNT_RECURSIVE: should be 0, is 0
 -- Testing arrays --
 COUNT_NORMAL: should be 2, is 2
@@ -141,9 +145,15 @@ COUNT_RECURSIVE: should be 8, is 8
 COUNT_NORMAL: should be 3, is 3
 COUNT_RECURSIVE: should be 6, is 6
 -- Testing strings --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 COUNT_NORMAL: should be 1, is 1
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 COUNT_RECURSIVE: should be 1, is 1
 -- Testing various types with no second argument --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 COUNT_NORMAL: should be 1, is 1
 COUNT_NORMAL: should be 2, is 2
 -- Testing really cool arrays --
@@ -184,11 +194,19 @@ COUNT_NORMAL is 4
 COUNT_RECURSIVE is 7
 
 -- Testing count() on constants with no second argument --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 COUNT_NORMAL: should be 1, is 1
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 COUNT_NORMAL: should be 1, is 1
 
 -- Testing count() on NULL and Unset variables --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 COUNT_NORMAL: should be 0, is 0
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 COUNT_NORMAL: should be 1, is 1
 COUNT_NORMAL: should be 0, is 0
 

--- a/ext/standard/tests/array/count_variation1.phpt
+++ b/ext/standard/tests/array/count_variation1.phpt
@@ -97,74 +97,122 @@ echo "Done";
 *** Testing count() : usage variations ***
 
 -- Iteration 1 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 2 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 3 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 4 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 5 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 6 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 7 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 8 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 9 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 10 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 11 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 12 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 13 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 14 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 15 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 16 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 17 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 18 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 19 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 20 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 21 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 
 -- Iteration 22 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 23 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 24 --
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(1)
 Done

--- a/ext/standard/tests/array/sizeof_basic1.phpt
+++ b/ext/standard/tests/array/sizeof_basic1.phpt
@@ -45,16 +45,28 @@ echo "Done";
 --EXPECTF--
 *** Testing sizeof() : basic functionality ***
 -- Testing sizeof() for integer type in default, COUNT_NORMAL and COUNT_RECURSIVE modes --
-default mode: int(1)
+default mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL mode: int(1)
+COUNT_NORMAL mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE mode: int(1)
+COUNT_RECURSIVE mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Testing sizeof() for float  type in default, COUNT_NORMAL and COUNT_RECURSIVE modes --
-default mode: int(1)
+default mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL mode: int(1)
+COUNT_NORMAL mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE mode: int(1)
+COUNT_RECURSIVE mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 Done

--- a/ext/standard/tests/array/sizeof_object2.phpt
+++ b/ext/standard/tests/array/sizeof_object2.phpt
@@ -101,38 +101,68 @@ echo "Done";
 *** Testing sizeof() : object functionality ***
 --- Testing sizeof() with objects which doesn't implement Countable interface ---
 -- Iteration 1 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 2 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 3 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 4 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 5 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 Done

--- a/ext/standard/tests/array/sizeof_variation1.phpt
+++ b/ext/standard/tests/array/sizeof_variation1.phpt
@@ -66,150 +66,264 @@ for($i = 0; $i < count($values); $i++)
   echo "COUNT_NORMAL Mode: ";
   var_dump( sizeof($var, COUNT_NORMAL) );
   echo "\n";
-     
+
   echo "COUNT_RECURSIVE Mode: ";
   var_dump( sizeof($var, COUNT_RECURSIVE) );
   echo "\n";
-  
+
   $counter++;
 }
-      
+
 echo "Done";
 ?>
 --EXPECTF--
 *** Testing sizeof() : usage variations ***
 --- Testing sizeof() for all scalar types in default,COUNT_NORMAL and COUNT_RECURSIVE mode ---
 -- Iteration 1 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 2 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 3 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 4 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 5 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 6 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 7 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 8 --
-Default Mode: int(0)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
 
-COUNT_NORMAL Mode: int(0)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
 
-COUNT_RECURSIVE Mode: int(0)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
 
 -- Iteration 9 --
-Default Mode: int(0)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
 
-COUNT_NORMAL Mode: int(0)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
 
-COUNT_RECURSIVE Mode: int(0)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
 
 -- Iteration 10 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 11 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 12 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 13 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 14 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 15 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 16 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 17 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 -- Iteration 18 --
-Default Mode: int(0)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
 
-COUNT_NORMAL Mode: int(0)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
 
-COUNT_RECURSIVE Mode: int(0)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(0)
 
 -- Iteration 19 --
-Default Mode: int(1)
+Default Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_NORMAL Mode: int(1)
+COUNT_NORMAL Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
-COUNT_RECURSIVE Mode: int(1)
+COUNT_RECURSIVE Mode: 
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
+int(1)
 
 Done

--- a/ext/standard/tests/array/sizeof_variation4.phpt
+++ b/ext/standard/tests/array/sizeof_variation4.phpt
@@ -90,261 +90,381 @@ echo "Done";
 -- Iteration 1 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 2 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 3 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 4 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 5 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 6 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 7 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 8 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 9 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 10 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 11 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 12 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 13 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 14 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 15 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 16 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 17 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 18 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 19 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 -- Iteration 20 --
 Default Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_NORMAL Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 COUNT_RECURSIVE Mode: 
 Notice: Undefined variable: value in %s on line %d
+
+Warning: sizeof(): Parameter must be an array or an object that implements Countable in %s on line %d
 int(0)
 
 Done

--- a/run-tests.php
+++ b/run-tests.php
@@ -1637,7 +1637,7 @@ TEST $file
 		$IN_REDIRECT['dir'] = realpath(dirname($file));
 		$IN_REDIRECT['prefix'] = trim($section_text['TEST']);
 
-		if (count($IN_REDIRECT['TESTS']) == 1) {
+		if (!empty($IN_REDIRECT['TESTS'])) {
 
 			if (is_array($org_file)) {
 				$test_files[] = $org_file[1];


### PR DESCRIPTION
Implementation for the recently accepted rfc: https://wiki.php.net/rfc/counting_non_countables

I've added new tests (`count_invalid.phpt`) to ensure all non-countables issue a warning.

For existing tests I've either hidden warnings (because there were too many) or added expectations where warnings were already in use. I'm not sure of the usual approach here?