### PR TITLE
Add notification about DateTime and microseconds support

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -280,6 +280,9 @@ PHP 7.1 UPGRADE NOTES
   . Timezone initialization failure from serialized data will now throw an
     instance of Error from __wakeup() or __set_state() instead of resulting in
     a fatal error.
+  . DateTime instances now support microseconds. Please note this can have impact
+    when comparing; eg. this would previously return TRUE, but now returns FALSE:
+     (new DateTime('first day of next month') == new DateTime('first day of next month'));
 
 - DBA:
   . Data modification functions (e.g.: dba_insert()) now throw an instance of


### PR DESCRIPTION
The addition of microseconds to DateTime are great; but looking at [the 3v4l.org bughunt output](https://3v4l.org/bughunt/7.1.0RC5/7.1.0RC3+7.1.0RC1) I see hundreds of scripts unexpectedly 'failing' because two variables are no longer equal due to non-obvious microsecond differences (eg. https://3v4l.org/7rdeS ).

Hopefully this notice will prevent some bogus bugreports