### PR TITLE
Add methods to Collator for (Unicode) case insensitivity and more

### DIFF
--- a/ext/intl/collator/collator_class.c
+++ b/ext/intl/collator/collator_class.c
@@ -20,6 +20,7 @@
 #include "collator_attr.h"
 #include "collator_compare.h"
 #include "collator_sort.h"
+#include "collator_string.h"
 #include "collator_convert.h"
 #include "collator_locale.h"
 #include "collator_create.h"
@@ -88,6 +89,26 @@ ZEND_BEGIN_ARG_INFO_EX( collator_sort_args, 0, 0, 1 )
 	ZEND_ARG_INFO( 0, flags )
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX( collator_replace_args, 0, 0, 3 )
+	ZEND_ARG_INFO(0, string)
+	ZEND_ARG_INFO(0, search)
+	ZEND_ARG_INFO(0, replacement)
+	ZEND_ARG_INFO(1, count)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX( collator_index_args, 0, 0, 2 )
+	ZEND_ARG_INFO(0, haystack)
+	ZEND_ARG_INFO(0, needle)
+	ZEND_ARG_INFO(0, start)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX( collator_find_args, 0, 0, 2 )
+	ZEND_ARG_INFO(0, haystack)
+	ZEND_ARG_INFO(0, needle)
+	ZEND_ARG_INFO(0, start)
+	ZEND_ARG_INFO(0, before)
+ZEND_END_ARG_INFO()
+
 /* }}} */
 
 /* {{{ Collator_class_functions
@@ -109,6 +130,13 @@ zend_function_entry Collator_class_functions[] = {
 	PHP_NAMED_FE( getErrorCode, ZEND_FN( collator_get_error_code ), collator_0_args )
 	PHP_NAMED_FE( getErrorMessage, ZEND_FN( collator_get_error_message ), collator_0_args )
 	PHP_NAMED_FE( getSortKey, ZEND_FN( collator_get_sort_key ), collator_2_args )
+	PHP_NAMED_FE( replace, ZEND_FN( collator_replace ), collator_replace_args )
+	PHP_NAMED_FE( rindex, ZEND_FN( collator_rindex ), collator_index_args )
+	PHP_NAMED_FE( lindex, ZEND_FN( collator_lindex ), collator_index_args )
+	PHP_NAMED_FE( rfind, ZEND_FN( collator_rfind ), collator_find_args )
+	PHP_NAMED_FE( lfind, ZEND_FN( collator_lfind ), collator_find_args )
+	PHP_NAMED_FE( startsWith, ZEND_FN( collator_startswith ), collator_2_args )
+	PHP_NAMED_FE( endsWith, ZEND_FN( collator_endswith ), collator_2_args )
 	PHP_FE_END
 };
 /* }}} */

--- a/ext/intl/collator/collator_class.c
+++ b/ext/intl/collator/collator_class.c
@@ -131,6 +131,7 @@ zend_function_entry Collator_class_functions[] = {
 	PHP_NAMED_FE( getErrorMessage, ZEND_FN( collator_get_error_message ), collator_0_args )
 	PHP_NAMED_FE( getSortKey, ZEND_FN( collator_get_sort_key ), collator_2_args )
 	PHP_NAMED_FE( replace, ZEND_FN( collator_replace ), collator_replace_args )
+	PHP_NAMED_FE( replaceCallback, ZEND_FN( collator_replace_callback ), collator_replace_args )
 	PHP_NAMED_FE( rindex, ZEND_FN( collator_rindex ), collator_index_args )
 	PHP_NAMED_FE( lindex, ZEND_FN( collator_lindex ), collator_index_args )
 	PHP_NAMED_FE( rfind, ZEND_FN( collator_rfind ), collator_find_args )

--- a/ext/intl/collator/collator_string.c
+++ b/ext/intl/collator/collator_string.c
@@ -1,0 +1,385 @@
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include "php_intl.h"
+#include "collator.h"
+#include "collator_class.h"
+#include "collator_string.h"
+#include "intl_convert.h"
+#include "grapheme/grapheme_util.h"
+
+#include <unicode/usearch.h>
+
+#undef COLLATOR_CHECK_STATUS
+#define COLLATOR_CHECK_STATUS(ro, msg)                                \
+	do {                                                              \
+		intl_error_set_code(NULL, COLLATOR_ERROR_CODE(ro));           \
+		if (U_FAILURE(COLLATOR_ERROR_CODE(ro))) {                     \
+			intl_errors_set_custom_msg(COLLATOR_ERROR_P(ro), msg, 0); \
+			goto end;                                                 \
+		}                                                             \
+	} while (0);
+
+#define UTF8_TO_UTF16(ro, to, to_len, from, from_len)                                        \
+	do {                                                                                     \
+		to = NULL;                                                                           \
+		to_len = 0;                                                                          \
+		intl_convert_utf8_to_utf16(&to, &to_len, from, from_len, COLLATOR_ERROR_CODE_P(ro)); \
+		COLLATOR_CHECK_STATUS(ro, "string conversion of " #from " to UTF-16 failed");        \
+	} while (0);
+
+#define UTF16_TO_UTF8(ro, to, from, from_len)                                        \
+	do {                                                                             \
+		to = intl_convert_utf16_to_utf8(from, from_len, COLLATOR_ERROR_CODE_P(ro));  \
+		COLLATOR_CHECK_STATUS(ro, "string conversion of " #from " to UTF-8 failed"); \
+	} while (0);
+
+static void starts_or_ends_with(INTERNAL_FUNCTION_PARAMETERS, int first)
+{
+	UChar *uneedle = NULL;
+	int32_t uneedle_len = 0;
+	UChar *uhaystack = NULL;
+	int32_t uhaystack_len = 0;
+	UStringSearch *uss = NULL;
+	UBreakIterator *ubrk = NULL;
+	zend_string *haystack, *needle;
+
+	COLLATOR_METHOD_INIT_VARS
+	if ( FAILURE == zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "OSS", &object, Collator_ce_ptr, &haystack, &needle )) {
+		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "collator_replace: unable to parse input params", 0 );
+
+		RETURN_FALSE;
+	}
+	COLLATOR_METHOD_FETCH_OBJECT;
+	if (!co || !co->ucoll) {
+		intl_error_set_code( NULL, COLLATOR_ERROR_CODE( co ) );
+		intl_errors_set_custom_msg( COLLATOR_ERROR_P( co ), "Object not initialized", 0 );
+		php_error_docref(NULL, E_RECOVERABLE_ERROR, "Object not initialized");
+
+		RETURN_FALSE;
+	}
+
+	UTF8_TO_UTF16(co, uhaystack, uhaystack_len, ZSTR_VAL(haystack), ZSTR_LEN(haystack));
+	UTF8_TO_UTF16(co, uneedle, uneedle_len, ZSTR_VAL(needle), ZSTR_LEN(needle));
+	uss = usearch_openFromCollator(uneedle, uneedle_len, uhaystack, uhaystack_len, co->ucoll, NULL, COLLATOR_ERROR_CODE_P( co ));
+	COLLATOR_CHECK_STATUS(co, "failed creating UStringSearch");
+
+	if (first) {
+		RETVAL_BOOL(0 == usearch_first(uss, COLLATOR_ERROR_CODE_P( co )));
+		COLLATOR_CHECK_STATUS(co, "failed while searching");
+	} else {
+		int32_t lastMatch;
+
+		lastMatch = usearch_last(uss, COLLATOR_ERROR_CODE_P( co ));
+		COLLATOR_CHECK_STATUS(co, "failed while searching");
+		RETVAL_BOOL(uhaystack_len == lastMatch + usearch_getMatchedLength(uss));
+	}
+	if (FALSE) {
+end:
+		RETVAL_FALSE;
+	}
+	if (NULL != ubrk) {
+		ubrk_close(ubrk);
+	}
+	if (NULL != uneedle) {
+		efree(uneedle);
+	}
+	if (NULL != uhaystack) {
+		efree(uhaystack);
+	}
+	if (NULL != uss) {
+		usearch_close(uss);
+	}
+}
+
+/* {{{ proto bool Collator::startsWith( Collator $coll, string $string, string $prefix )
+ * Does string begins with prefix? }}} */
+/* {{{ proto bool collator_startswith( Collator $coll, string $string, string $prefix )
+ * Does string begins with prefix?
+ */
+PHP_FUNCTION(collator_startswith)
+{
+	starts_or_ends_with(INTERNAL_FUNCTION_PARAM_PASSTHRU, TRUE);
+}
+/* }}} */
+
+/* {{{ proto bool Collator::startsWith( Collator $coll, string $string, string $suffix )
+ * Does string ends with suffix? }}} */
+/* {{{ proto bool collator_startswith( Collator $coll, string $string, string $suffix )
+ * Does string ends with suffix?
+ */
+PHP_FUNCTION(collator_endswith)
+{
+	starts_or_ends_with(INTERNAL_FUNCTION_PARAM_PASSTHRU, FALSE);
+}
+/* }}} */
+
+static void collator_index(INTERNAL_FUNCTION_PARAMETERS, int search_first, int want_only_pos)
+{
+	int ret;
+	int32_t cuoffset; /* Unit: UTF-16 CU */
+	long startoffset = 0; /* Unit: grapheme */
+	UChar *uneedle = NULL;
+	int32_t uneedle_len = 0;
+	UChar *uhaystack = NULL;
+	int32_t uhaystack_len = 0;
+	UStringSearch *uss = NULL;
+	int32_t match_start = -1; /* Unit: UTF-16 CU */
+	zend_bool before = FALSE;
+	UBreakIterator *ubrk = NULL;
+	zend_string *haystack, *needle;
+	unsigned char u_break_iterator_buffer[U_BRK_SAFECLONE_BUFFERSIZE];
+
+	COLLATOR_METHOD_INIT_VARS
+	if (want_only_pos) {
+		ret = zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OSS|l", &object, Collator_ce_ptr, &haystack, &needle, &startoffset);
+	} else {
+		ret = zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OSS|lb", &object, Collator_ce_ptr, &haystack, &needle, &startoffset, &before);
+	}
+	if (FAILURE == ret) {
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "unable to parse input params", 0);
+
+		RETURN_FALSE;
+	}
+	COLLATOR_METHOD_FETCH_OBJECT;
+	if (!co || !co->ucoll) {
+		intl_error_set_code( NULL, COLLATOR_ERROR_CODE( co ) );
+		intl_errors_set_custom_msg( COLLATOR_ERROR_P( co ), "Object not initialized", 0 );
+		php_error_docref(NULL, E_RECOVERABLE_ERROR, "Object not initialized");
+
+		RETURN_FALSE;
+	}
+
+	UTF8_TO_UTF16(co, uhaystack, uhaystack_len, ZSTR_VAL(haystack), ZSTR_LEN(haystack));
+	UTF8_TO_UTF16(co, uneedle, uneedle_len, ZSTR_VAL(needle), ZSTR_LEN(needle));
+	ubrk = grapheme_get_break_iterator((void*) u_break_iterator_buffer, COLLATOR_ERROR_CODE_P( co ));
+	COLLATOR_CHECK_STATUS(co, "failed cloning UBreakIterator");
+	ubrk_setText(ubrk, uhaystack, uhaystack_len, COLLATOR_ERROR_CODE_P( co ));
+	COLLATOR_CHECK_STATUS(co, "failed binding text to UBreakIterator");
+	if (0 != startoffset) {
+		if (UBRK_DONE == (cuoffset = utf16_grapheme_to_cu(ubrk, startoffset))) {
+			intl_error_set(NULL, U_INDEX_OUTOFBOUNDS_ERROR, "offset is out of bounds", 0);
+			goto end;
+		}
+	} else {
+		if (search_first) {
+			cuoffset = 0;
+		} else {
+			cuoffset = uhaystack_len;
+		}
+	}
+	uss = usearch_openFromCollator(uneedle, uneedle_len, uhaystack, uhaystack_len, co->ucoll, ubrk, COLLATOR_ERROR_CODE_P( co ));
+	COLLATOR_CHECK_STATUS(co, "failed creating UStringSearch");
+
+	if (search_first) {
+		match_start = usearch_following(uss, cuoffset, COLLATOR_ERROR_CODE_P( co ));
+	} else {
+		usearch_setAttribute(uss, USEARCH_OVERLAP, USEARCH_ON, COLLATOR_ERROR_CODE_P( co ));
+		COLLATOR_CHECK_STATUS(co, "failed switching overlap attribute to on");
+		match_start = usearch_preceding(uss, cuoffset, COLLATOR_ERROR_CODE_P( co ));
+	}
+	COLLATOR_CHECK_STATUS(co, "failed while searching");
+	if (USEARCH_DONE != match_start) {
+		if (want_only_pos) {
+			RETVAL_LONG((long) utf16_cu_to_grapheme(ubrk, match_start));
+		} else {
+			zend_string *result;
+
+			if (before) {
+				UTF16_TO_UTF8(co, result, uhaystack, match_start);
+			} else {
+				UTF16_TO_UTF8(co, result, uhaystack + match_start, uhaystack_len - match_start);
+			}
+			RETVAL_STR(result);
+		}
+	} else {
+		if (want_only_pos) {
+			RETVAL_LONG((long) -1);
+		} else {
+			RETVAL_FALSE;
+		}
+	}
+
+	if (FALSE) {
+end:
+		RETVAL_FALSE;
+	}
+	if (NULL != ubrk) {
+		ubrk_close(ubrk);
+	}
+	if (NULL != uneedle) {
+		efree(uneedle);
+	}
+	if (NULL != uhaystack) {
+		efree(uhaystack);
+	}
+	if (NULL != uss) {
+		usearch_close(uss);
+	}
+}
+
+/* {{{ proto string Collator::rindex( Collator $coll, string $haystack, string $needle [, int $start ] )
+ * Returns the index of the rightmost occurrence of the given substring }}} */
+/* {{{ proto string collator_rindex( Collator $coll, string $haystack, string $needle [, int $start ] )
+ * Returns the index of the rightmost occurrence of the given substring
+ */
+PHP_FUNCTION(collator_rindex)
+{
+	collator_index(INTERNAL_FUNCTION_PARAM_PASSTHRU, FALSE, TRUE);
+}
+/* }}} */
+
+/* {{{ proto string Collator::lindex( Collator $coll, string $haystack, string $needle [, int $start ] )
+ * Returns the index of the leftmost occurrence of the given substring }}} */
+/* {{{ proto string collator_lindex( Collator $coll, string $haystack, string $needle [, int $start ] )
+ * Returns the index of the leftmost occurrence of the given substring
+ */
+PHP_FUNCTION(collator_lindex)
+{
+	collator_index(INTERNAL_FUNCTION_PARAM_PASSTHRU, TRUE, TRUE);
+}
+/* }}} */
+
+/* {{{ proto string Collator::rfind( Collator $coll, string $haystack, string $needle [, int $start [, bool $before ] ] )
+ * Returns part of haystack string starting from and including the rightmost occurrence of needle to the end of haystack }}} */
+/* {{{ proto string collator_rfind( Collator $coll, string $haystack, string $needle [, int $start [, bool $before ] ] )
+ * Returns part of haystack string starting from and including the rightmost occurrence of needle to the end of haystack
+ */
+PHP_FUNCTION(collator_rfind)
+{
+	collator_index(INTERNAL_FUNCTION_PARAM_PASSTHRU, FALSE, FALSE);
+}
+/* }}} */
+
+/* {{{ proto string Collator::lfind( Collator $coll, string $haystack, string $needle [, int $start [, bool $before ] ] )
+ * Returns part of haystack string starting from and including the leftmost occurrence of needle to the end of haystack }}} */
+/* {{{ proto string collator_lfind( Collator $coll, string $haystack, string $needle [, int $start [, bool $before ] ] )
+ * Returns part of haystack string starting from and including the leftmost occurrence of needle to the end of haystack
+ */
+PHP_FUNCTION(collator_lfind)
+{
+	collator_index(INTERNAL_FUNCTION_PARAM_PASSTHRU, TRUE, FALSE);
+}
+/* }}} */
+
+typedef enum {
+	REPLACE_FORWARD,
+	REPLACE_REVERSE
+} ReplacementDirection;
+
+static void utf16_replace_len(
+    UChar **ucopy, int32_t *ucopy_len,
+    UChar *ureplacement, int32_t ureplacement_len,
+    UChar *ustring /* UNUSED */, int32_t ustring_len, /* Used by ICU, don't alter it ! So, we work on a copy. */
+    int32_t start_match_offset, int32_t match_cu_length,
+    ReplacementDirection direction
+) {
+	int32_t diff_len;
+	int32_t real_offset;
+
+	if (REPLACE_REVERSE == direction) {
+		real_offset = start_match_offset;
+	} else {
+		real_offset = *ucopy_len - (ustring_len - start_match_offset);
+	}
+	diff_len = ureplacement_len - match_cu_length;
+	if (diff_len > 0) {
+		*ucopy = safe_erealloc(*ucopy, *ucopy_len + diff_len, sizeof(**ucopy), 1 * sizeof(**ucopy)); // reference may no longer be valid from this point
+	}
+	if (ureplacement_len != match_cu_length) {
+		u_memmove(*ucopy + real_offset + match_cu_length + diff_len, *ucopy + real_offset + match_cu_length, *ucopy_len - real_offset - match_cu_length);
+	}
+	u_memcpy(*ucopy + real_offset, ureplacement, ureplacement_len);
+	*ucopy_len += diff_len;
+}
+
+/* {{{ proto string Collator::replace( Collator $coll, string $subject, string $search, string $replacement [, int &$count ] )
+ * Replace all matches of search, according to collation, by replacement in subject. }}} */
+/* {{{ proto string collator_replace(  Collator $coll, string $subject, string $search, string $replacement [, int &$count ] )
+ * Replace all matches of search, according to collation, by replacement in subject.
+ */
+PHP_FUNCTION(collator_replace)
+{
+	int32_t l;
+	zval *zcount = NULL;
+	long count = 0;
+	UChar *usearch = NULL;
+	int32_t usearch_len = 0;
+	UChar *usubject = NULL;
+	int32_t usubject_len = 0;
+	UStringSearch *uss = NULL;
+	UChar *ureplace = NULL;
+	int32_t ureplace_len = 0;
+	UChar *uresult = NULL;
+	int32_t uresult_len = 0;
+	zend_string *search, *replace, *subject, *result = NULL;
+
+	COLLATOR_METHOD_INIT_VARS
+	if ( FAILURE == zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "OSSS|z/", &object, Collator_ce_ptr, &subject, &search, &replace, &zcount )) {
+		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "collator_replace: unable to parse input params", 0 );
+
+		RETURN_FALSE;
+	}
+	COLLATOR_METHOD_FETCH_OBJECT;
+	if (!co || !co->ucoll) {
+		intl_error_set_code( NULL, COLLATOR_ERROR_CODE( co ) );
+		intl_errors_set_custom_msg( COLLATOR_ERROR_P( co ), "Object not initialized", 0 );
+		php_error_docref(NULL, E_RECOVERABLE_ERROR, "Object not initialized");
+
+		RETURN_FALSE;
+	}
+
+	UTF8_TO_UTF16(co, usearch, usearch_len, ZSTR_VAL(search), ZSTR_LEN(search));
+	UTF8_TO_UTF16(co, usubject, usubject_len, ZSTR_VAL(subject), ZSTR_LEN(subject));
+	uss = usearch_openFromCollator(usearch, usearch_len, usubject, usubject_len, co->ucoll, NULL, COLLATOR_ERROR_CODE_P( co ));
+	COLLATOR_CHECK_STATUS(co, "failed creating UStringSearch");
+	UTF8_TO_UTF16(co, ureplace, ureplace_len, ZSTR_VAL(replace), ZSTR_LEN(replace));
+	uresult_len = usubject_len;
+	uresult = safe_emalloc(usubject_len, sizeof(*usubject), 1 * sizeof(*usubject));
+	u_memcpy(uresult, usubject, usubject_len);
+	uresult[uresult_len] = 0;
+	for (l = usearch_first(uss, COLLATOR_ERROR_CODE_P( co )); U_SUCCESS(COLLATOR_ERROR_CODE( co )) && USEARCH_DONE != l; l = usearch_next(uss, COLLATOR_ERROR_CODE_P( co )), count++) {
+		utf16_replace_len(&uresult, &uresult_len, ureplace, ureplace_len, usubject, usubject_len, l, usearch_getMatchedLength(uss), REPLACE_FORWARD);
+	}
+	COLLATOR_CHECK_STATUS(co, "failed while searching");
+	UTF16_TO_UTF8(co, result, uresult, uresult_len);
+	RETVAL_STR(result);
+
+	if (FALSE) {
+end:
+		if (NULL != result) {
+			zend_string_release(result);
+		}
+		RETVAL_FALSE;
+	}
+	if (NULL != uss) {
+		usearch_close(uss);
+	}
+	if (NULL != uresult) {
+		efree(uresult);
+	}
+	if (NULL != ureplace) {
+		efree(ureplace);
+	}
+	if (NULL != usearch) {
+		efree(usearch);
+	}
+	if (NULL != usubject) {
+		efree(usubject);
+	}
+	if (ZEND_NUM_ARGS() > 3) {
+		zval_dtor(zcount);
+		ZVAL_LONG(zcount, count);
+	}
+}
+/* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/ext/intl/collator/collator_string.h
+++ b/ext/intl/collator/collator_string.h
@@ -5,6 +5,7 @@
 # include <php.h>
 
 PHP_FUNCTION( collator_replace );
+PHP_FUNCTION( collator_replace_callback );
 
 PHP_FUNCTION( collator_rfind );
 PHP_FUNCTION( collator_lfind );

--- a/ext/intl/collator/collator_string.h
+++ b/ext/intl/collator/collator_string.h
@@ -1,0 +1,16 @@
+#ifndef COLLATOR_STRING_H
+
+# define COLLATOR_STRING_H
+
+# include <php.h>
+
+PHP_FUNCTION( collator_replace );
+
+PHP_FUNCTION( collator_rfind );
+PHP_FUNCTION( collator_lfind );
+PHP_FUNCTION( collator_rindex );
+PHP_FUNCTION( collator_lindex );
+PHP_FUNCTION( collator_startswith );
+PHP_FUNCTION( collator_endswith );
+
+#endif /* !COLLATOR_STRING_H */

--- a/ext/intl/config.m4
+++ b/ext/intl/config.m4
@@ -24,6 +24,7 @@ if test "$PHP_INTL" != "no"; then
     collator/collator.c \
     collator/collator_class.c \
     collator/collator_sort.c \
+    collator/collator_string.c \
     collator/collator_convert.c \
     collator/collator_locale.c \
     collator/collator_compare.c \

--- a/ext/intl/config.w32
+++ b/ext/intl/config.w32
@@ -20,6 +20,7 @@ if (PHP_INTL != "no") {
 				collator_is_numeric.c \
 				collator_locale.c \
 				collator_sort.c \
+				collator_string.c \
 				", "intl");
 		ADD_SOURCES(configure_module_dirname + "/common", "\
 				common_error.c \

--- a/ext/intl/grapheme/grapheme_util.h
+++ b/ext/intl/grapheme/grapheme_util.h
@@ -36,7 +36,8 @@ int32_t grapheme_count_graphemes(UBreakIterator *bi, UChar *string, int32_t stri
 
 int32_t grapheme_get_haystack_offset(UBreakIterator* bi, int32_t offset);
 
-UBreakIterator* grapheme_get_break_iterator(void *stack_buffer, UErrorCode *status );
+int32_t utf16_cu_to_grapheme(UBreakIterator *ubrk, int32_t pos);
+int32_t utf16_grapheme_to_cu(UBreakIterator *ubrk, int32_t offset);
 
 /* OUTSIDE_STRING: check if (possibly negative) long offset is outside the string with int32_t length */
 #define OUTSIDE_STRING(offset, max_len) ( offset <= INT32_MIN || offset > INT32_MAX || (offset < 0 ? -offset > (zend_long) max_len : offset >= (zend_long) max_len) )

--- a/ext/intl/php_intl.c
+++ b/ext/intl/php_intl.c
@@ -29,6 +29,7 @@
 #include "collator/collator_attr.h"
 #include "collator/collator_compare.h"
 #include "collator/collator_sort.h"
+#include "collator/collator_string.h"
 #include "collator/collator_convert.h"
 #include "collator/collator_locale.h"
 #include "collator/collator_create.h"
@@ -152,6 +153,29 @@ ZEND_BEGIN_ARG_INFO_EX(collator_sort_args, 0, 0, 2)
 	ZEND_ARG_OBJ_INFO(0, object, Collator, 0)
 	ZEND_ARG_ARRAY_INFO(1, arr, 0)
 	ZEND_ARG_INFO(0, sort_flags)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(collator_replace_args, 0, 0, 4)
+	ZEND_ARG_OBJ_INFO(0, object, Collator, 0)
+	ZEND_ARG_INFO(0, string)
+	ZEND_ARG_INFO(0, search)
+	ZEND_ARG_INFO(0, replacement)
+	ZEND_ARG_INFO(1, count)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(collator_index_args, 0, 0, 3)
+	ZEND_ARG_OBJ_INFO(0, object, Collator, 0)
+	ZEND_ARG_INFO(0, haystack)
+	ZEND_ARG_INFO(0, needle)
+	ZEND_ARG_INFO(0, start)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(collator_find_args, 0, 0, 3)
+	ZEND_ARG_OBJ_INFO(0, object, Collator, 0)
+	ZEND_ARG_INFO(0, haystack)
+	ZEND_ARG_INFO(0, needle)
+	ZEND_ARG_INFO(0, start)
+	ZEND_ARG_INFO(0, before)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(numfmt_parse_arginfo, 0, 0, 2)
@@ -635,6 +659,13 @@ zend_function_entry intl_functions[] = {
 	PHP_FE( collator_get_error_code, collator_0_args )
 	PHP_FE( collator_get_error_message, collator_0_args )
 	PHP_FE( collator_get_sort_key, collator_2_args )
+	PHP_FE( collator_replace, collator_replace_args )
+	PHP_FE( collator_rindex, collator_index_args )
+	PHP_FE( collator_lindex, collator_index_args )
+	PHP_FE( collator_rfind, collator_find_args )
+	PHP_FE( collator_lfind, collator_find_args )
+	PHP_FE( collator_startswith, collator_2_args )
+	PHP_FE( collator_endswith, collator_2_args )
 
 	/* formatter functions */
 	PHP_FE( numfmt_create, arginfo_numfmt_create )

--- a/ext/intl/tests/collator_string_endswith.phpt
+++ b/ext/intl/tests/collator_string_endswith.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Collator::endswith()
+--SKIPIF--
+<?php if (!extension_loaded('intl')) echo 'skip'; ?>
+--INI--
+intl.error_level=0
+intl.use_exceptions=0
+--FILE--
+<?php
+$grave = "\u{300}";
+$acute = "\u{301}";
+
+$e_acute_nfc = "é"; // U+E9
+$e_acute_nfd = "e${acute}";
+
+$e_grave_nfc = "è"; // U+E8
+$e_grave_nfd = "e${grave}";
+
+$fr = new Collator('fr');
+$tr = new Collator('tr');
+$fr->setStrength(Collator::PRIMARY);
+
+var_dump($fr->endswith('eSSSS', 'ßß'));
+var_dump($fr->endswith('eßß', 'SSSS'));
+
+foreach ([$fr, $tr] as $coll) {
+	$coll->setStrength(Collator::SECONDARY);
+}
+
+echo "\n", 'Grapheme consistency', "\n";
+var_dump($fr->endswith($e_acute_nfd, $acute));
+
+echo "\n", 'Turkish dotted I', "\n";
+foreach ([$fr, $tr] as $coll) {
+	echo $coll->getLocale(Locale::VALID_LOCALE), PHP_EOL;
+	var_dump($coll->endswith('İYİ', 'i'));
+	var_dump($coll->endswith('IYI', 'i'));
+}
+
+echo "\n", 'Turkish non dotted I', "\n";
+foreach ([$fr, $tr] as $coll) {
+	echo $coll->getLocale(Locale::VALID_LOCALE), PHP_EOL;
+	var_dump($coll->endswith('Hayır', 'YIR'));
+	var_dump($coll->endswith('Hayir', 'YIR'));
+}
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+
+Grapheme consistency
+bool(false)
+
+Turkish dotted I
+fr
+bool(false)
+bool(true)
+tr
+bool(true)
+bool(false)
+
+Turkish non dotted I
+fr
+bool(false)
+bool(true)
+tr
+bool(true)
+bool(false)

--- a/ext/intl/tests/collator_string_lfind.phpt
+++ b/ext/intl/tests/collator_string_lfind.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Collator::lfind()
+--SKIPIF--
+<?php if (!extension_loaded('intl')) echo 'skip'; ?>
+--INI--
+intl.use_exceptions=0
+--FILE--
+<?php
+$grave = "\u{300}";
+$acute = "\u{301}";
+
+$e_acute_nfc = "é";
+$e_acute_nfd = "e${acute}";
+
+$e_grave_nfc = "è";
+$e_grave_nfd = "e${grave}";
+
+$coll = new Collator('fr_FR');
+$coll->setAttribute(Collator::NORMALIZATION_MODE, Collator::OFF);
+
+$haystack1 = "Ce verre est {$e_acute_nfd}br{$e_acute_nfd}ch{$e_acute_nfd}.";
+$haystack2 = str_replace($e_acute_nfd, $e_acute_nfc, $haystack1);
+
+var_dump(
+	$coll->lfind($haystack1, $e_acute_nfc) === "{$e_acute_nfd}br{$e_acute_nfd}ch{$e_acute_nfd}.",
+	$coll->lfind($haystack2, $e_acute_nfd) === "{$e_acute_nfc}br{$e_acute_nfc}ch{$e_acute_nfc}.",
+
+	$coll->lfind($haystack1, $e_acute_nfc, 0, TRUE) === "Ce verre est ",
+	$coll->lfind($haystack2, $e_acute_nfd, 0, TRUE) === "Ce verre est ",
+
+	$coll->lfind($haystack1, $e_acute_nfc, 14) === "{$e_acute_nfd}ch{$e_acute_nfd}.",
+	$coll->lfind($haystack2, $e_acute_nfd, 14) === "{$e_acute_nfc}ch{$e_acute_nfc}."
+);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/intl/tests/collator_string_lindex.phpt
+++ b/ext/intl/tests/collator_string_lindex.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Collator::lindex()
+--SKIPIF--
+<?php if (!extension_loaded('intl')) echo 'skip'; ?>
+--INI--
+intl.use_exceptions=0
+--FILE--
+<?php
+$grave = "\u{300}";
+$acute = "\u{301}";
+
+$e_acute_nfc = "é";
+$e_acute_nfd = "e${acute}";
+
+$e_grave_nfc = "è";
+$e_grave_nfd = "e${grave}";
+
+$coll = new Collator('fr_FR');
+$coll->setAttribute(Collator::NORMALIZATION_MODE, Collator::OFF);
+
+$haystack1 = "Ce verre est {$e_acute_nfd}br{$e_acute_nfd}ch{$e_acute_nfd}.";
+$haystack2 = str_replace($e_acute_nfd, $e_acute_nfc, $haystack1);
+
+var_dump(
+	$coll->lindex($haystack1, $e_acute_nfc, 14) === 16,
+	$coll->lindex($haystack2, $e_acute_nfd, 14) === 16,
+	$coll->lindex($haystack1, $e_acute_nfc, -6) === 16,
+	$coll->lindex($haystack2, $e_acute_nfd, -6) === 16
+);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/intl/tests/collator_string_replace_basic.phpt
+++ b/ext/intl/tests/collator_string_replace_basic.phpt
@@ -1,0 +1,100 @@
+--TEST--
+Collator::replace (basic)
+--SKIPIF--
+<?php if (!extension_loaded('intl') || !extension_loaded('mbstring')) echo 'skip'; ?>
+--INI--
+intl.error_level=0
+intl.use_exceptions=0
+intl.default_locale=fr
+--FILE--
+<?php
+define('TIMES', 30);
+
+$coll = new Collator(NULL);
+$coll->setStrength(Collator::PRIMARY);
+
+function assert_single($subject, $search, $replacement, $expected) {
+    global $coll;
+
+    return $coll->replace($subject, $search, $replacement) === $expected;
+}
+
+function assert_multiple($subject, $search, $replacement, $expected) {
+    global $coll;
+
+    return $coll->replace(str_repeat($subject, TIMES), $search, $replacement) === str_repeat($expected, TIMES);
+}
+
+echo 'Check count parameter', "\n";
+$coll->replace('oui', 'non', 'maybe', $c1);
+var_dump($c1);
+$coll->replace('la valeur a déjà été modifiée', 'É', 'x', $c2);
+var_dump($c2);
+
+echo 'Delete (replace by empty string)', "\n";
+var_dump(assert_single("Vous eûtes 23 ÉlèVes", ' élèves', '', "Vous eûtes 23"));
+var_dump(assert_multiple("Vous eûtes 23 ÉlèVes", ' élèves', '', "Vous eûtes 23"));
+
+echo 'Replace by a shorter string', "\n";
+var_dump(assert_single("Vous eûtes 23 ÉlèVes", 'élèves', 'cats', "Vous eûtes 23 cats"));
+var_dump(assert_multiple("Vous eûtes 23 ÉlèVes", 'élèves', 'cats', "Vous eûtes 23 cats"));
+
+echo 'ß <=> SS', "\n";
+var_dump(assert_single('Petersburger Straße', 'SS', '<eszett>', 'Petersburger Stra<eszett>e'));
+var_dump(assert_multiple('Petersburger Straße', 'SS', '<eszett>', 'Petersburger Stra<eszett>e'));
+
+echo 'DZ digraph', "\n";
+var_dump(assert_single('ǲwon hráǳa', 'Ǳ', '<DZ>', '<DZ>won hrá<DZ>a'));
+var_dump(assert_multiple('ǲwon hráǳa', 'Ǳ', '<DZ>', '<DZ>won hrá<DZ>a'));
+
+
+$coll = new Collator('tr');
+$coll->setStrength(Collator::PRIMARY);
+
+echo 'Turkish dotted I', "\n";
+var_dump(assert_single('İyi akşamlar', 'İ', '<dotted i>', '<dotted i>y<dotted i> akşamlar'));
+var_dump(assert_multiple('İyi akşamlar', 'İ', '<dotted i>', '<dotted i>y<dotted i> akşamlar'));
+
+echo 'Turkish non dotted I', "\n";
+var_dump(assert_single('Hayır', 'I', '<non dotted i>', 'Hay<non dotted i>r'));
+var_dump(assert_multiple('Hayır', 'I', '<non dotted i>', 'Hay<non dotted i>r'));
+
+$grave = "\u{300}";
+$acute = "\u{301}";
+
+$e_acute_nfc = "é"; // U+E9
+$e_acute_nfd = "e${acute}";
+
+$e_grave_nfc = "è"; // U+E8
+$e_grave_nfd = "e${grave}";
+
+$input = "${e_acute_nfd}e${e_grave_nfd}";
+
+$coll->setStrength(Collator::SECONDARY);
+echo 'Grapheme consistency', "\n";
+var_dump(mb_convert_encoding($coll->replace($input, 'E', '<replaced>'), 'HTML-ENTITIES', 'UTF-8') === "e&#769;<replaced>e&#768;");
+?>
+--EXPECT--
+Check count parameter
+int(0)
+int(6)
+Delete (replace by empty string)
+bool(true)
+bool(true)
+Replace by a shorter string
+bool(true)
+bool(true)
+ß <=> SS
+bool(true)
+bool(true)
+DZ digraph
+bool(true)
+bool(true)
+Turkish dotted I
+bool(true)
+bool(true)
+Turkish non dotted I
+bool(true)
+bool(true)
+Grapheme consistency
+bool(true)

--- a/ext/intl/tests/collator_string_replace_callback.phpt
+++ b/ext/intl/tests/collator_string_replace_callback.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Collator::replaceCallback
+--SKIPIF--
+<?php if (!extension_loaded('intl')) echo 'skip'; ?>
+--FILE--
+<?php
+const STRING = 'élève';
+
+$coll = new Collator(NULL);
+$coll->setStrength(Collator::PRIMARY);
+
+var_dump(
+	$coll->replaceCallback(STRING, 'e', 'htmlentities'),
+	$coll->replaceCallback(STRING, 'e', function () {}),
+	$coll->replaceCallback(STRING, 'e', function () { return 3; }),
+	$coll->replaceCallback(STRING, 'e', function ($m) { return '<mark>' . $m . '</mark>'; })
+);
+try {
+	$coll->replaceCallback(STRING, 'e', function ($m, $n) {});
+} catch (Error $e) {
+	echo $e->getMessage();
+}
+?>
+--EXPECT--
+string(19) "&eacute;l&egrave;ve"
+string(2) "lv"
+string(5) "3l3v3"
+string(46) "<mark>é</mark>l<mark>è</mark>v<mark>e</mark>"
+Too few arguments to function {closure}(), 1 passed and exactly 2 expected

--- a/ext/intl/tests/collator_string_replace_error.phpt
+++ b/ext/intl/tests/collator_string_replace_error.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Collator::replace (error)
+--SKIPIF--
+<?php if (!extension_loaded('intl')) echo 'skip'; ?>
+--INI--
+intl.error_level=0
+intl.use_exceptions=0
+--FILE--
+<?php
+$coll = new Collator(NULL);
+
+var_dump($coll->replace('subject', 'search'));
+var_dump($coll->replace('subject', 'search', 'replacement', $count, 'FAIL'));
+?>
+--EXPECTF--
+
+Warning: Collator::replace() expects at least 3 parameters, 2 given in %s on line %d
+bool(false)
+
+Warning: Collator::replace() expects at most 4 parameters, 5 given in %s on line %d
+bool(false)

--- a/ext/intl/tests/collator_string_rfind.phpt
+++ b/ext/intl/tests/collator_string_rfind.phpt
@@ -1,0 +1,96 @@
+--TEST--
+Collator::rfind()
+--SKIPIF--
+<?php if (!extension_loaded('intl')) echo 'skip'; ?>
+--INI--
+intl.use_exceptions=0
+--FILE--
+<?php
+$grave = "\u{300}";
+$acute = "\u{301}";
+
+$e_acute_nfc = "é";
+$e_acute_nfd = "e${acute}";
+
+$e_grave_nfc = "è";
+$e_grave_nfd = "e${grave}";
+
+$coll = new Collator('fr_FR');
+$coll->setAttribute(Collator::NORMALIZATION_MODE, Collator::OFF);
+
+$haystack1 = "Ce verre est {$e_acute_nfd}br{$e_acute_nfd}ch{$e_acute_nfd}.";
+$haystack2 = str_replace($e_acute_nfd, $e_acute_nfc, $haystack1);
+
+echo 'Same string in NFC and NFD forms:', "\n";
+var_dump(
+	$coll->rfind($haystack1, $e_acute_nfc) === "{$e_acute_nfd}.",
+	$coll->rfind($haystack2, $e_acute_nfd) === "{$e_acute_nfc}.",
+
+	$coll->rfind($haystack1, $e_acute_nfc, 0, TRUE) === "Ce verre est {$e_acute_nfd}br{$e_acute_nfd}ch",
+	$coll->rfind($haystack2, $e_acute_nfd, 0, TRUE) === "Ce verre est {$e_acute_nfc}br{$e_acute_nfc}ch",
+
+	$coll->rfind($haystack1, $e_acute_nfc, 14) === "{$e_acute_nfd}br{$e_acute_nfd}ch{$e_acute_nfd}.",
+	$coll->rfind($haystack2, $e_acute_nfd, 14) === "{$e_acute_nfc}br{$e_acute_nfc}ch{$e_acute_nfc}."
+);
+
+/*
++---+---+---+---+---+
+| a | a | a | a | a |
++---+---+---+---+---+
+| 0 | 1 | 2 | 3 | 4 |
++---+---+---+---+---+
+              # ^     => search on left to offset 4 (represented by ^), match is at offset 3 (represented by #)
+  # ^                 => search on left to offset 1 (represented by ^), match is at offset 0 (represented by #)
+*/
+
+echo 'Simple offset checks:', "\n";
+var_dump(
+	$coll->rfind('aaaaa', 'a', 1, FALSE) === 'aaaaa',
+	$coll->rfind('aaaaa', 'a', 1, TRUE) === '',
+
+	$coll->rfind('aaaaa', 'a', 4, FALSE) === 'aa',
+	$coll->rfind('aaaaa', 'a', 4, TRUE) === 'aaa'
+);
+
+$X307 = "\u{307}"; # 307 (COMBINING DOT ABOVE)
+$X323 = "\u{323}"; # 323 (COMBINING DOT BELOW)
+$S = "S{$X307}{$X323}";
+$string = str_repeat($S, 5);
+echo 'String of repeted substrings:', "\n";
+var_dump(
+	$coll->rfind($string, $S, 1, FALSE) === str_repeat($S, 5),
+	$coll->rfind($string, $S, 1, TRUE) === '',
+
+	$coll->rfind($string, $S, 4, FALSE) === str_repeat($S, 2),
+	$coll->rfind($string, $S, 4, TRUE) === str_repeat($S, 3)
+);
+
+/*
+var_dump($coll->rindex($string, $S, 4));
+var_dump($coll->rindex($string, $S, 4));
+var_dump($coll->rfind($string, $S, 4, FALSE));
+var_dump($coll->rfind($string, $S, 4, TRUE));
+var_dump($coll->rfind('aaaaa', 'a', 1, FALSE)); // string (5) "aaaaa" match on [0;1[
+var_dump($coll->rfind('aaaaa', 'a', 1, TRUE)); // string (0) "" match on [0;1[
+var_dump($coll->rfind('aaaaa', 'a', 4, FALSE)); // string (2) "aa" match on [3;4[
+var_dump($coll->rfind('aaaaa', 'a', 4, TRUE)); // string (3) "aaa" match on [3;4[
+*/
+?>
+--EXPECT--
+Same string in NFC and NFD forms:
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Simple offset checks:
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+String of repeted substrings:
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/intl/tests/collator_string_rindex.phpt
+++ b/ext/intl/tests/collator_string_rindex.phpt
@@ -1,0 +1,83 @@
+--TEST--
+Collator::rindex()
+--SKIPIF--
+<?php if (!extension_loaded('intl')) echo 'skip'; ?>
+--INI--
+intl.use_exceptions=0
+--FILE--
+<?php
+$grave = "\u{300}";
+$acute = "\u{301}";
+
+$e_acute_nfc = "é";
+$e_acute_nfd = "e${acute}";
+
+$e_grave_nfc = "è";
+$e_grave_nfd = "e${grave}";
+
+$coll = new Collator('fr_FR');
+$coll->setAttribute(Collator::NORMALIZATION_MODE, Collator::OFF);
+
+$haystack1 = "Ce verre est {$e_acute_nfd}br{$e_acute_nfd}ch{$e_acute_nfd}.";
+$haystack2 = str_replace($e_acute_nfd, $e_acute_nfc, $haystack1);
+
+echo 'Same string in NFC and NFD forms (positive offset):', "\n";
+var_dump(
+	$coll->rindex($haystack1, $e_acute_nfc, 14) === 13,
+	$coll->rindex($haystack2, $e_acute_nfd, 14) === 13
+);
+
+/*
+
+NFD ($haystack1):
++---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+| C | e | - | v | e | r | r | e | - | e | s | t | - | e | ' | b | r | ...
++---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | 1 | 2 |   3   | 4 | 5 | Grapheme offsets
++---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | CU offsets
++---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+                                                            ^ (search offset)
+
+NFC ($haystack2):
++---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+| C | e | - | v | e | r | r | e | - | e | s | t | - | é | b | r | é | c | h | é | . | ...
++---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | Grapheme offsets
++---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+| 1 | 0 | 9 | 8 | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 | 9 | 8 | 7 | 6 | 5 | 4 | 3 | 2 | 1 | Negative grapheme offsets (without minus sign)
++---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | CU offsets
++---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+                                                        ^ (search offset)
+*/
+
+echo 'Same string in NFC and NFD forms (negative offset):', "\n";
+var_dump(
+	$coll->rindex($haystack1, $e_acute_nfc, -7) === 13,
+	$coll->rindex($haystack2, $e_acute_nfd, -7) === 13
+);
+
+echo 'Grapheme consistency:', "\n";
+var_dump($coll->rindex($haystack1, 'e') === 9);
+
+echo 'Overlap test (r[find|index] only):', "\n";
+var_dump(
+	$coll->rindex($haystack1, $e_acute_nfc, 13) === -1,
+	$coll->rindex($haystack2, $e_acute_nfd, 13) === -1
+);
+
+exit;
+?>
+--EXPECT--
+Same string in NFC and NFD forms (positive offset):
+bool(true)
+bool(true)
+Same string in NFC and NFD forms (negative offset):
+bool(true)
+bool(true)
+Grapheme consistency:
+bool(true)
+Overlap test (r[find|index] only):
+bool(true)
+bool(true)

--- a/ext/intl/tests/collator_string_startswith.phpt
+++ b/ext/intl/tests/collator_string_startswith.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Collator::startswith()
+--SKIPIF--
+<?php if (!extension_loaded('intl')) echo 'skip'; ?>
+--INI--
+intl.error_level=0
+intl.use_exceptions=0
+--FILE--
+<?php
+$grave = "\u{300}";
+$acute = "\u{301}";
+
+$e_acute_nfc = "é"; // U+E9
+$e_acute_nfd = "e${acute}";
+
+$e_grave_nfc = "è"; // U+E8
+$e_grave_nfd = "e${grave}";
+
+$fr = new Collator('fr');
+$tr = new Collator('tr');
+$fr->setStrength(Collator::PRIMARY);
+
+var_dump($fr->startswith('SSSSe', 'ßß'));
+var_dump($fr->startswith('ßße', 'SSSS'));
+
+foreach ([$fr, $tr] as $coll) {
+	$coll->setStrength(Collator::SECONDARY);
+}
+
+echo "\n", 'Grapheme consistency', "\n";
+var_dump($fr->startswith($e_acute_nfd, 'e'));
+
+echo "\n", 'Turkish dotted I', "\n";
+foreach ([$fr, $tr] as $coll) {
+	echo $coll->getLocale(Locale::VALID_LOCALE), PHP_EOL;
+	var_dump($coll->startswith('İyi', 'i'));
+	var_dump($coll->startswith('Iyi', 'i'));
+}
+
+echo "\n", 'Turkish non dotted I', "\n";
+foreach ([$fr, $tr] as $coll) {
+	echo $coll->getLocale(Locale::VALID_LOCALE), PHP_EOL;
+	var_dump($coll->startswith('Hayır', 'HAYI'));
+	var_dump($coll->startswith('Hayir', 'HAYI'));
+}
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+
+Grapheme consistency
+bool(false)
+
+Turkish dotted I
+fr
+bool(false)
+bool(true)
+tr
+bool(true)
+bool(false)
+
+Turkish non dotted I
+fr
+bool(false)
+bool(true)
+tr
+bool(true)
+bool(false)


### PR DESCRIPTION
This PR add the following methods (and an equivalent procedural function) to Collator (intl extension):
* replace (an Unicode substitute to str_ireplace)
  + `string Collator::replace(string $string, string $search, string $replacement [, int &count ])`
  + `string collator_replace(Collator $coll, string $string, string $search, string $replacement [, int &count ])`
* replaceCallback
  + `string Collator::replaceCallback(string $string, string $search, callable $replacement [, int &count ])`
  + `string collator_replace_callback(Collator $coll, string $string, string $search, callable $replacement [, int &count ])`
* lfind (an Unicode substitute to str(i)str)
  + `mixed Collator::lfind(string $haystack, string $needle [, int $startOffset = 0 [, bool $before ]])`
  + `mixed collator_lfind(Collator $coll, string $haystack, string $needle [, int $startOffset = 0 [, bool $before ]])`
* rfind (an Unicode substitute to strr(i)str with a different behavior)
  + `mixed Collator::rfind(string $haystack, string $needle [, int $startOffset = 0 [, bool $before ]])`
  + `mixed collator_rfind(Collator $coll, string $haystack, string $needle [, int $startOffset = 0 [, bool $before ]])`
* lindex (an Unicode substitute to str(i)pos)
  + `int Collator::lindex(string $haystack, string $needle [, int $startOffset = 0 ])`
  + `int collator_lindex(Collator $coll, string $haystack, string $needle [, int $startOffset = 0 ])`
* rindex (an Unicode substitute to strr(i)pos with a different behavior)
  + `int Collator::rindex(string $haystack, string $needle [, int $startOffset = 0 ])`
  + `int collator_rindex(Collator $coll, string $haystack, string $needle [, int $startOffset = 0 ])`
* startswith
  + `boolean Collator::startsWith(string $haystack, string $needle)`
  + `boolean collator_startswith(Collator $coll, string $haystack, string $needle)`
* endswith
  + `boolean Collator::endsWith(string $haystack, string $needle)`
  + `boolean collator_endswith(Collator $coll, string $haystack, string $needle)`

Goal: be able to search and/or replace in an Unicode string based on a collation (and in a grapheme consistent way), mostly to ignore case and/or accents. Also supports turkic languages (i = İ + ı = I vs i = I).

Note: for locale independant case insensitivity (turkic languages excluded), UCA rules can be used by creating a "root" Collator (`$coll = new Collator('root');`) and a secondary-level strength (`$coll->setStrength(Collator::SECONDARY);`)