### PR TITLE
Fix Bug #73462 - Persistent connections don't set $connect_errno

### DIFF
--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -185,6 +185,10 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_real_conne
 								mysqlnd_restart_psession(mysql->mysql);
 #endif
 								MyG(num_active_persistent)++;
+
+								/* clear error */
+								php_mysqli_set_error(mysql_errno(mysql->mysql), (char *) mysql_error(mysql->mysql));
+
 								goto end;
 							} else {
 								mysqli_close(mysql->mysql, MYSQLI_CLOSE_IMPLICIT);

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -187,7 +187,7 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_real_conne
 								MyG(num_active_persistent)++;
 
 								/* clear error */
-								php_mysqli_set_error(mysql_errno(mysql->mysql), (char *) mysql_error(mysql->mysql));
+								php_mysqli_set_error(mysql_errno(mysql->mysql), (char *) mysql_error(mysql->mysql) TSRMLS_CC);
 
 								goto end;
 							} else {


### PR DESCRIPTION
Persistent connections skipped resetting $connect_error and $connect_errno values
This adds the "clear error" line to persistent connections for consistency