### PR TITLE
Fix Bug #73462 - Persistent connections don't set $connect_errno

### DIFF
--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -185,6 +185,10 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_real_conne
 								mysqlnd_restart_psession(mysql->mysql);
 #endif
 								MyG(num_active_persistent)++;
+
+								/* clear error */
+								php_mysqli_set_error(mysql_errno(mysql->mysql), (char *) mysql_error(mysql->mysql) TSRMLS_CC);								
+
 								goto end;
 							} else {
 								mysqli_close(mysql->mysql, MYSQLI_CLOSE_IMPLICIT);

--- a/ext/mysqli/tests/bug73462.phpt
+++ b/ext/mysqli/tests/bug73462.phpt
@@ -10,17 +10,30 @@ require_once('skipifconnectfailure.inc');
 <?php
 	require_once("connect.inc");
 
+	/* Initial persistent connection */
 	$mysql_1 = new mysqli('p:'.$host, $user, $passwd, $db);
+	$result = $mysql_1->query("SHOW STATUS LIKE 'Connections'");
+	$c1 = $result->fetch_row();
+	$result->free();
 	$mysql_1->close();
 
-	$mysql_2 = @new mysqli('DOESNT-EXIST', $user, $passwd, $db);
+	/* Failed connection to invalid host */
+	$mysql_2 = @new mysqli(' !!! invalid !!! ', $user, $passwd, $db);
 	@$mysql_2->close();
 
+	/* Re-use persistent connection */
 	$mysql_3 = new mysqli('p:'.$host, $user, $passwd, $db);
 	$error = mysqli_connect_errno();
+	$result = $mysql_3->query("SHOW STATUS LIKE 'Connections'");
+	$c3 = $result->fetch_row();
+	$result->free();
 	$mysql_3->close();
 
-	if ($error !== 0) printf("[001] Expecting '0' got '%d'.\n", $error);
+	if (end($c1) !== end($c3))
+		printf("[001] Expected '%d' got '%d'.\n", end($c1), end($c3));
+
+	if ($error !== 0)
+		printf("[002] Expected '0' got '%d'.\n", $error);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/bug73462.phpt
+++ b/ext/mysqli/tests/bug73462.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug #73462 (Persistent connections don't set $connect_errno)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifemb.inc');
+require_once('skipifconnectfailure.inc');
+?>
+--FILE--
+<?php
+	require_once("connect.inc");
+
+	$mysql_1 = new mysqli('p:'.$host, $user, $passwd, $db);
+	$mysql_1->close();
+
+	$mysql_2 = @new mysqli('DOESNT-EXIST', $user, $passwd, $db);
+	@$mysql_2->close();
+
+	$mysql_3 = new mysqli('p:'.$host, $user, $passwd, $db);
+	$error = mysqli_connect_errno();
+	$mysql_3->close();
+
+	if ($error !== 0) printf("[001] Expecting '0' got '%d'.\n", $error);
+
+	print "done!";
+?>
+--EXPECTF--
+done!


### PR DESCRIPTION
Persistent connections skipped resetting $connect_error and $connect_errno values
This adds the "clear error" line to persistent connections for consistency