### PR TITLE
Fix the lchwon error test for Travis CI.

### DIFF
--- a/ext/standard/tests/file/lchown_error.phpt
+++ b/ext/standard/tests/file/lchown_error.phpt
@@ -73,6 +73,6 @@ bool(true)
 Warning: lchown() expects parameter 1 to be a valid path, array given in %s on line %d
 bool(true)
 
-Warning: lchown(): Operation not permitted in %s on line %d
+Warning: lchown(): %r(Operation not permitted|Invalid argument)%r in %s on line %d
 bool(false)
 ===DONE===


### PR DESCRIPTION
The E_WARNING message from the PHP function lchown is passed
from the system function lchown. The error message returned
from lchown can be filesystem dependent.

https://github.com/php/php-src/blob/6053987bc27e8dede37f437193a5cad448f99bce/ext/standard/filestat.c#L406