### PR TITLE
Fix phpdbg breakpoint restoring after execution completes

### DIFF
--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -136,7 +136,7 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 					switch (brake->type) {
 						case PHPDBG_BREAK_FILE: {
 							phpdbg_asprintf(&new_str,
-								"%sbreak %s:%lu\n", *str,
+								"%sbreak \"%s\":%lu\n", *str,
 								((phpdbg_breakfile_t*)brake)->filename,
 								((phpdbg_breakfile_t*)brake)->line);
 						} break;


### PR DESCRIPTION
The test `stdin_001.phpt ` for phpdbg was failing because the breakpoints were not restored after execution completed. This is because the new name for stdin "Standard input code" has spaces in it and the `phpdbg_export_breakpoints_to_string` did not quote the filename. 