### PR TITLE
added test cases for bug 72969

### DIFF
--- a/ext/pdo_dblib/tests/batch_stmt_ins_exec.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_ins_exec.phpt
@@ -17,7 +17,8 @@ $db->query(
 "begin " .
 "  insert into #wf_pdo values(2), (3), (4); " .
 "  select * from #wf_pdo; " .
-"end; ");
+"end; "
+);
 
 // now lets get some results
 $stmt = $db->query(

--- a/ext/pdo_dblib/tests/batch_stmt_ins_exec.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_ins_exec.phpt
@@ -1,0 +1,60 @@
+--TEST--
+ PDO_DBLIB driver supports a batch of queries containing select, insert, update, exec statements
+ this test will fail when using the dblib driver that hasn't been patched
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+// creating a proc need to be a statement in it's own batch, so we need to do a little setup first
+$db->query("create table #wf_pdo(id int); ");
+$db->query(
+"create proc wf_exec_select_proc as " .
+"begin " .
+"  insert into #wf_pdo values(2), (3), (4); " .
+"  select * from #wf_pdo; " .
+"end; ");
+
+// now lets get some results
+$stmt = $db->query(
+"insert into #wf_pdo values(1); " .
+"exec wf_exec_select_proc; " .
+"drop table #wf_pdo; " .
+"drop procedure wf_exec_select_proc; ");
+
+// check results from the insert
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the exec
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the drop table
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the drop procedure
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check that there are no more results
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+?>
+--EXPECT--
+int(1)
+bool(true)
+int(-1)
+bool(true)
+int(-1)
+bool(true)
+int(-1)
+bool(false)
+int(-1)
+bool(false)

--- a/ext/pdo_dblib/tests/batch_stmt_ins_exec.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_ins_exec.phpt
@@ -1,6 +1,5 @@
 --TEST--
  PDO_DBLIB driver supports a batch of queries containing select, insert, update, exec statements
- this test will fail when using the dblib driver that hasn't been patched
 --SKIPIF--
 <?php
 if (!extension_loaded('pdo_dblib')) die('skip not loaded');
@@ -11,20 +10,20 @@ require dirname(__FILE__) . '/config.inc';
 require dirname(__FILE__) . '/config.inc';
 
 // creating a proc need to be a statement in it's own batch, so we need to do a little setup first
-$db->query("create table #wf_pdo(id int); ");
+$db->query("create table #php_pdo(id int); ");
 $db->query(
 "create proc wf_exec_select_proc as " .
 "begin " .
-"  insert into #wf_pdo values(2), (3), (4); " .
-"  select * from #wf_pdo; " .
+"  insert into #php_pdo values(2), (3), (4); " .
+"  select * from #php_pdo; " .
 "end; "
 );
 
 // now lets get some results
 $stmt = $db->query(
-"insert into #wf_pdo values(1); " .
+"insert into #php_pdo values(1); " .
 "exec wf_exec_select_proc; " .
-"drop table #wf_pdo; " .
+"drop table #php_pdo; " .
 "drop procedure wf_exec_select_proc; ");
 
 // check results from the insert
@@ -48,6 +47,8 @@ var_dump($stmt->rowCount());
 var_dump($stmt->nextRowset());
 
 ?>
+--XFAIL--
+ this test will fail when using the dblib driver that hasn't been patched
 --EXPECT--
 int(1)
 bool(true)

--- a/ext/pdo_dblib/tests/batch_stmt_ins_sel_up_del.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_ins_sel_up_del.phpt
@@ -1,0 +1,70 @@
+--TEST--
+ PDO_DBLIB driver supports a batch of queries containing select, insert, update statements
+ this test will fail when using the dblib driver that hasn't been patched
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+$stmt = $db->query("create table #wf_pdo(id int);" .
+"insert into #wf_pdo values(1), (2), (3);" .
+"select * from #wf_pdo;" .
+"update #wf_pdo set id = 4;" .
+"delete from #wf_pdo;" .
+"select * from #wf_pdo;" .
+"drop table #wf_pdo;");
+
+// check results from the create table
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the first insert
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the select
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the update
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the delete
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the select
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the drop
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check that there are no more results
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+?>
+--EXPECT--
+int(-1)
+bool(true)
+int(3)
+bool(true)
+int(-1)
+bool(true)
+int(3)
+bool(true)
+int(3)
+bool(true)
+int(-1)
+bool(true)
+int(-1)
+bool(false)
+int(-1)
+bool(false)

--- a/ext/pdo_dblib/tests/batch_stmt_ins_sel_up_del.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_ins_sel_up_del.phpt
@@ -10,13 +10,15 @@ require dirname(__FILE__) . '/config.inc';
 <?php
 require dirname(__FILE__) . '/config.inc';
 
-$stmt = $db->query("create table #wf_pdo(id int);" .
+$stmt = $db->query(
+"create table #wf_pdo(id int);" .
 "insert into #wf_pdo values(1), (2), (3);" .
 "select * from #wf_pdo;" .
 "update #wf_pdo set id = 4;" .
 "delete from #wf_pdo;" .
 "select * from #wf_pdo;" .
-"drop table #wf_pdo;");
+"drop table #wf_pdo;"
+);
 
 // check results from the create table
 var_dump($stmt->rowCount());

--- a/ext/pdo_dblib/tests/batch_stmt_ins_sel_up_del.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_ins_sel_up_del.phpt
@@ -1,6 +1,5 @@
 --TEST--
  PDO_DBLIB driver supports a batch of queries containing select, insert, update statements
- this test will fail when using the dblib driver that hasn't been patched
 --SKIPIF--
 <?php
 if (!extension_loaded('pdo_dblib')) die('skip not loaded');
@@ -11,13 +10,13 @@ require dirname(__FILE__) . '/config.inc';
 require dirname(__FILE__) . '/config.inc';
 
 $stmt = $db->query(
-"create table #wf_pdo(id int);" .
-"insert into #wf_pdo values(1), (2), (3);" .
-"select * from #wf_pdo;" .
-"update #wf_pdo set id = 4;" .
-"delete from #wf_pdo;" .
-"select * from #wf_pdo;" .
-"drop table #wf_pdo;"
+"create table #php_pdo(id int);" .
+"insert into #php_pdo values(1), (2), (3);" .
+"select * from #php_pdo;" .
+"update #php_pdo set id = 4;" .
+"delete from #php_pdo;" .
+"select * from #php_pdo;" .
+"drop table #php_pdo;"
 );
 
 // check results from the create table
@@ -53,6 +52,8 @@ var_dump($stmt->rowCount());
 var_dump($stmt->nextRowset());
 
 ?>
+--XFAIL--
+ this test will fail when using the dblib driver that hasn't been patched
 --EXPECT--
 int(-1)
 bool(true)
@@ -64,7 +65,7 @@ int(3)
 bool(true)
 int(3)
 bool(true)
-int(-1)
+int(0)
 bool(true)
 int(-1)
 bool(false)

--- a/ext/pdo_dblib/tests/batch_stmt_ins_up.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_ins_up.phpt
@@ -1,6 +1,5 @@
 --TEST--
  PDO_DBLIB driver supports multiple queries in a single query() call that don't return any row sets
- this test will fail when using the dblib driver that hasn't been patched
 --SKIPIF--
 <?php
 if (!extension_loaded('pdo_dblib')) die('skip not loaded');
@@ -11,11 +10,11 @@ require dirname(__FILE__) . '/config.inc';
 require dirname(__FILE__) . '/config.inc';
 
 $stmt = $db->query(
-"create table #wf_pdo(id int);" .
-"insert into #wf_pdo values(1), (2), (3);" .
-"update #wf_pdo set id = 1;" .
-"insert into #wf_pdo values(2);" .
-"drop table #wf_pdo;"
+"create table #php_pdo(id int);" .
+"insert into #php_pdo values(1), (2), (3);" .
+"update #php_pdo set id = 1;" .
+"insert into #php_pdo values(2);" .
+"drop table #php_pdo;"
 );
 
 // check results from the create table
@@ -43,6 +42,8 @@ var_dump($stmt->rowCount());
 var_dump($stmt->nextRowset());
 
 ?>
+--XFAIL--
+ this test will fail when using the dblib driver that hasn't been patched
 --EXPECT--
 int(-1)
 bool(true)

--- a/ext/pdo_dblib/tests/batch_stmt_ins_up.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_ins_up.phpt
@@ -10,11 +10,13 @@ require dirname(__FILE__) . '/config.inc';
 <?php
 require dirname(__FILE__) . '/config.inc';
 
-$stmt = $db->query("create table #wf_pdo(id int);" .
+$stmt = $db->query(
+"create table #wf_pdo(id int);" .
 "insert into #wf_pdo values(1), (2), (3);" .
 "update #wf_pdo set id = 1;" .
 "insert into #wf_pdo values(2);" .
-"drop table #wf_pdo;");
+"drop table #wf_pdo;"
+);
 
 // check results from the create table
 var_dump($stmt->rowCount());

--- a/ext/pdo_dblib/tests/batch_stmt_ins_up.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_ins_up.phpt
@@ -1,0 +1,56 @@
+--TEST--
+ PDO_DBLIB driver supports multiple queries in a single query() call that don't return any row sets
+ this test will fail when using the dblib driver that hasn't been patched
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+$stmt = $db->query("create table #wf_pdo(id int);" .
+"insert into #wf_pdo values(1), (2), (3);" .
+"update #wf_pdo set id = 1;" .
+"insert into #wf_pdo values(2);" .
+"drop table #wf_pdo;");
+
+// check results from the create table
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the first insert
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the update
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the second insert
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the drop
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check that there are no more results
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+?>
+--EXPECT--
+int(-1)
+bool(true)
+int(3)
+bool(true)
+int(3)
+bool(true)
+int(1)
+bool(true)
+int(-1)
+bool(false)
+int(-1)
+bool(false)

--- a/ext/pdo_dblib/tests/batch_stmt_rowcount.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_rowcount.phpt
@@ -10,7 +10,8 @@ require dirname(__FILE__) . '/config.inc';
 <?php
 require dirname(__FILE__) . '/config.inc';
 
-$stmt = $db->query("create table #wf_pdo(id int); " .
+$stmt = $db->query(
+"create table #wf_pdo(id int); " .
 "set rowcount 2; " .
 "insert into #wf_pdo values(1), (2), (3); " .
 "insert into #wf_pdo values(4), (5), (6); " .

--- a/ext/pdo_dblib/tests/batch_stmt_rowcount.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_rowcount.phpt
@@ -1,6 +1,5 @@
 --TEST--
  PDO_DBLIB driver supports set rowcount and select @@rowcount in batch statements
- this test will fail when using the dblib driver that hasn't been patched
 --SKIPIF--
 <?php
 if (!extension_loaded('pdo_dblib')) die('skip not loaded');
@@ -11,11 +10,11 @@ require dirname(__FILE__) . '/config.inc';
 require dirname(__FILE__) . '/config.inc';
 
 $stmt = $db->query(
-"create table #wf_pdo(id int); " .
+"create table #php_pdo(id int); " .
 "set rowcount 2; " .
-"insert into #wf_pdo values(1), (2), (3); " .
-"insert into #wf_pdo values(4), (5), (6); " .
-"update #wf_pdo set id = 4; " .
+"insert into #php_pdo values(1), (2), (3); " .
+"insert into #php_pdo values(4), (5), (6); " .
+"update #php_pdo set id = 4; " .
 "select @@rowcount; "
 );
 
@@ -50,9 +49,9 @@ var_dump($stmt->nextRowset());
 
 // now cleanup and check that the results are expected
 $stmt = $db->query("set rowcount 0;" .
-"select * from #wf_pdo;" .
-"delete from #wf_pdo;" .
-"drop table #wf_pdo;"
+"select * from #php_pdo;" .
+"delete from #php_pdo;" .
+"drop table #php_pdo;"
 );
 
 // check results from set rowcount
@@ -77,6 +76,8 @@ var_dump($stmt->rowCount());
 var_dump($stmt->nextRowset());
 
 ?>
+--XFAIL--
+ this test will fail when using the dblib driver that hasn't been patched
 --EXPECT--
 int(-1)
 bool(true)

--- a/ext/pdo_dblib/tests/batch_stmt_rowcount.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_rowcount.phpt
@@ -1,0 +1,142 @@
+--TEST--
+ PDO_DBLIB driver supports set rowcount and select @@rowcount in batch statements
+ this test will fail when using the dblib driver that hasn't been patched
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+$stmt = $db->query("create table #wf_pdo(id int); " .
+"set rowcount 2; " .
+"insert into #wf_pdo values(1), (2), (3); " .
+"insert into #wf_pdo values(4), (5), (6); " .
+"update #wf_pdo set id = 4; " .
+"select @@rowcount; "
+);
+
+// check results from the create table
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the set rowcount
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the first insert
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the second insert
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the update
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the select rowcount
+var_dump($stmt->fetchAll());
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check that there are no more results
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// now cleanup and check that the results are expected
+$stmt = $db->query("set rowcount 0;" .
+"select * from #wf_pdo;" .
+"delete from #wf_pdo;" .
+"drop table #wf_pdo;"
+);
+
+// check results from set rowcount
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the select
+var_dump($stmt->fetchAll());
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the delete
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the drop
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check that there are no more results
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+?>
+--EXPECT--
+int(-1)
+bool(true)
+int(-1)
+bool(true)
+int(2)
+bool(true)
+int(2)
+bool(true)
+int(2)
+bool(true)
+array(1) {
+  [0]=>
+  array(2) {
+    ["computed"]=>
+    int(2)
+    [0]=>
+    int(2)
+  }
+}
+int(-1)
+bool(false)
+int(-1)
+bool(false)
+int(-1)
+bool(true)
+array(4) {
+  [0]=>
+  array(2) {
+    ["id"]=>
+    int(4)
+    [0]=>
+    int(4)
+  }
+  [1]=>
+  array(2) {
+    ["id"]=>
+    int(4)
+    [0]=>
+    int(4)
+  }
+  [2]=>
+  array(2) {
+    ["id"]=>
+    int(4)
+    [0]=>
+    int(4)
+  }
+  [3]=>
+  array(2) {
+    ["id"]=>
+    int(5)
+    [0]=>
+    int(5)
+  }
+}
+int(-1)
+bool(true)
+int(4)
+bool(true)
+int(-1)
+bool(false)
+int(-1)
+bool(false)

--- a/ext/pdo_dblib/tests/batch_stmt_transaction.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_transaction.phpt
@@ -10,7 +10,8 @@ require dirname(__FILE__) . '/config.inc';
 <?php
 require dirname(__FILE__) . '/config.inc';
 
-$stmt = $db->query("create table #wf_pdo(id int);" .
+$stmt = $db->query(
+"create table #wf_pdo(id int);" .
 "insert into #wf_pdo values(1), (2), (3);" .
 "select * from #wf_pdo;" .
 "begin transaction;" .
@@ -18,7 +19,8 @@ $stmt = $db->query("create table #wf_pdo(id int);" .
 "rollback transaction;" .
 "select * from #wf_pdo;" .
 "delete from #wf_pdo;" .
-"drop table #wf_pdo;");
+"drop table #wf_pdo;"
+);
 
 // check results from the create table
 var_dump($stmt->rowCount());

--- a/ext/pdo_dblib/tests/batch_stmt_transaction.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_transaction.phpt
@@ -1,6 +1,5 @@
 --TEST--
  PDO_DBLIB driver supports a batch of queries containing select, insert, update statements
- this test will fail when using the dblib driver that hasn't been patched
 --SKIPIF--
 <?php
 if (!extension_loaded('pdo_dblib')) die('skip not loaded');
@@ -11,15 +10,15 @@ require dirname(__FILE__) . '/config.inc';
 require dirname(__FILE__) . '/config.inc';
 
 $stmt = $db->query(
-"create table #wf_pdo(id int);" .
-"insert into #wf_pdo values(1), (2), (3);" .
-"select * from #wf_pdo;" .
+"create table #php_pdo(id int);" .
+"insert into #php_pdo values(1), (2), (3);" .
+"select * from #php_pdo;" .
 "begin transaction;" .
-"update #wf_pdo set id = 4;" .
+"update #php_pdo set id = 4;" .
 "rollback transaction;" .
-"select * from #wf_pdo;" .
-"delete from #wf_pdo;" .
-"drop table #wf_pdo;"
+"select * from #php_pdo;" .
+"delete from #php_pdo;" .
+"drop table #php_pdo;"
 );
 
 // check results from the create table
@@ -64,6 +63,8 @@ var_dump($stmt->rowCount());
 var_dump($stmt->nextRowset());
 
 ?>
+--XFAIL--
+ this test will fail when using the dblib driver that hasn't been patched
 --EXPECT--
 int(-1)
 bool(true)

--- a/ext/pdo_dblib/tests/batch_stmt_transaction.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_transaction.phpt
@@ -1,0 +1,108 @@
+--TEST--
+ PDO_DBLIB driver supports a batch of queries containing select, insert, update statements
+ this test will fail when using the dblib driver that hasn't been patched
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+$stmt = $db->query("create table #wf_pdo(id int);" .
+"insert into #wf_pdo values(1), (2), (3);" .
+"select * from #wf_pdo;" .
+"begin transaction;" .
+"update #wf_pdo set id = 4;" .
+"rollback transaction;" .
+"select * from #wf_pdo;" .
+"delete from #wf_pdo;" .
+"drop table #wf_pdo;");
+
+// check results from the create table
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the first insert
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the select
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from begin transaction
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the update
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from rollback
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the select
+var_dump($stmt->fetchAll());
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the delete
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the drop
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check that there are no more results
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+?>
+--EXPECT--
+int(-1)
+bool(true)
+int(3)
+bool(true)
+int(-1)
+bool(true)
+int(-1)
+bool(true)
+int(3)
+bool(true)
+int(-1)
+bool(true)
+array(3) {
+  [0]=>
+  array(2) {
+    ["id"]=>
+    int(1)
+    [0]=>
+    int(1)
+  }
+  [1]=>
+  array(2) {
+    ["id"]=>
+    int(2)
+    [0]=>
+    int(2)
+  }
+  [2]=>
+  array(2) {
+    ["id"]=>
+    int(3)
+    [0]=>
+    int(3)
+  }
+}
+int(-1)
+bool(true)
+int(3)
+bool(true)
+int(-1)
+bool(false)
+int(-1)
+bool(false)

--- a/ext/pdo_dblib/tests/batch_stmt_try.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_try.phpt
@@ -1,0 +1,96 @@
+--TEST--
+ PDO_DBLIB driver supports using sql servers exceptions
+ this test will fail when using the dblib driver that hasn't been patched
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_dblib')) die('skip not loaded');
+require dirname(__FILE__) . '/config.inc';
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/config.inc';
+
+$stmt = $db->query("create table #wf_pdo(id int);" .
+"insert into #wf_pdo values(1), (2), (3);" .
+"select * from #wf_pdo;" .
+"begin try " .
+"  update #wf_pdo set id = 'f';" .
+"end try " .
+"begin catch " .
+"  throw;" .
+"end catch " .
+"select * from #wf_pdo;" .
+"delete from #wf_pdo;" .
+"drop table #wf_pdo;");
+
+// check results from the create table
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the first insert
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the select
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from try
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the update
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check that the update statement throws an error
+try {
+  var_dump($stmt->rowCount());
+  var_dump($stmt->nextRowset());
+} catch (PDOException $e) {
+  var_dump($e->getMessage());
+}
+
+// once an error is thrown, the batch is terminated.
+// there should no results from here on
+// check results from the select
+var_dump($stmt->fetchAll());
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the delete
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check results from the drop
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+// check that there are no more results
+var_dump($stmt->rowCount());
+var_dump($stmt->nextRowset());
+
+?>
+--EXPECT--
+int(-1)
+bool(true)
+int(3)
+bool(true)
+int(-1)
+bool(true)
+int(-1)
+bool(true)
+int(0)
+bool(true)
+int(-1)
+string(68) "SQLSTATE[HY000]: General error: PDO_DBLIB: dbresults() returned FAIL"
+array(0) {
+}
+int(-1)
+bool(false)
+int(-1)
+bool(false)
+int(-1)
+bool(false)
+int(-1)
+bool(false)

--- a/ext/pdo_dblib/tests/batch_stmt_try.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_try.phpt
@@ -10,7 +10,8 @@ require dirname(__FILE__) . '/config.inc';
 <?php
 require dirname(__FILE__) . '/config.inc';
 
-$stmt = $db->query("create table #wf_pdo(id int);" .
+$stmt = $db->query(
+"create table #wf_pdo(id int);" .
 "insert into #wf_pdo values(1), (2), (3);" .
 "select * from #wf_pdo;" .
 "begin try " .
@@ -21,7 +22,8 @@ $stmt = $db->query("create table #wf_pdo(id int);" .
 "end catch " .
 "select * from #wf_pdo;" .
 "delete from #wf_pdo;" .
-"drop table #wf_pdo;");
+"drop table #wf_pdo;"
+);
 
 // check results from the create table
 var_dump($stmt->rowCount());

--- a/ext/pdo_dblib/tests/batch_stmt_try.phpt
+++ b/ext/pdo_dblib/tests/batch_stmt_try.phpt
@@ -1,6 +1,5 @@
 --TEST--
  PDO_DBLIB driver supports using sql servers exceptions
- this test will fail when using the dblib driver that hasn't been patched
 --SKIPIF--
 <?php
 if (!extension_loaded('pdo_dblib')) die('skip not loaded');
@@ -11,18 +10,18 @@ require dirname(__FILE__) . '/config.inc';
 require dirname(__FILE__) . '/config.inc';
 
 $stmt = $db->query(
-"create table #wf_pdo(id int);" .
-"insert into #wf_pdo values(1), (2), (3);" .
-"select * from #wf_pdo;" .
+"create table #php_pdo(id int);" .
+"insert into #php_pdo values(1), (2), (3);" .
+"select * from #php_pdo;" .
 "begin try " .
-"  update #wf_pdo set id = 'f';" .
+"  update #php_pdo set id = 'f';" .
 "end try " .
 "begin catch " .
 "  throw;" .
 "end catch " .
-"select * from #wf_pdo;" .
-"delete from #wf_pdo;" .
-"drop table #wf_pdo;"
+"select * from #php_pdo;" .
+"delete from #php_pdo;" .
+"drop table #php_pdo;"
 );
 
 // check results from the create table
@@ -73,6 +72,8 @@ var_dump($stmt->rowCount());
 var_dump($stmt->nextRowset());
 
 ?>
+--XFAIL--
+ this test will fail when using the dblib driver that hasn't been patched
 --EXPECT--
 int(-1)
 bool(true)


### PR DESCRIPTION
The actual code fix belongs in the freetds library so these tests should be expected to fail when PHP isn't built against a patched version of that driver.   Each one of these tests is for a different combination of statements, including the SQL Server specific TRY CATCH.