### PR TITLE
Fix #73546: Logging for opcache has an empty file name

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1339,7 +1339,7 @@ static zend_persistent_script *cache_script_in_shared_memory(zend_persistent_scr
 	/* store script structure in the hash table */
 	bucket = zend_accel_hash_update(&ZCSG(hash), ZSTR_VAL(new_persistent_script->full_path), ZSTR_LEN(new_persistent_script->full_path), 0, new_persistent_script);
 	if (bucket) {
-		zend_accel_error(ACCEL_LOG_INFO, "Cached script '%s'", new_persistent_script->full_path);
+		zend_accel_error(ACCEL_LOG_INFO, "Cached script '%s'", ZSTR_VAL(new_persistent_script->full_path));
 		if (key &&
 		    /* key may contain non-persistent PHAR aliases (see issues #115 and #149) */
 		    memcmp(key, "phar://", sizeof("phar://") - 1) != 0 &&
@@ -1806,7 +1806,7 @@ zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type)
 		if (checksum != persistent_script->dynamic_members.checksum ) {
 			/* The checksum is wrong */
 			zend_accel_error(ACCEL_LOG_INFO, "Checksum failed for '%s':  expected=0x%0.8X, found=0x%0.8X",
-							 persistent_script->full_path, persistent_script->dynamic_members.checksum, checksum);
+							 ZSTR_VAL(persistent_script->full_path), persistent_script->dynamic_members.checksum, checksum);
 			zend_shared_alloc_lock();
 			if (!persistent_script->corrupted) {
 				persistent_script->corrupted = 1;

--- a/ext/opcache/tests/basic_logging.phpt
+++ b/ext/opcache/tests/basic_logging.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test basic logging for the Opcache
+--DESCRIPTION--
+This test runs a simple PHP script and ensures the Opcache 
+outputs the correct logging at the highest log_verbosity_level
+
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.log_verbosity_level=4
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+echo "Foo Bar\n";
+?>
+--EXPECTF--
+%s Message Cached script '%sbasic_logging%s'
+Foo Bar


### PR DESCRIPTION
This bug does not impact PHP 7.1. 