### PR TITLE
php_url_parse_ex(): Respect length argument

### DIFF
--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -122,7 +122,7 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 		if (*(e + 1) == '\0') { /* only scheme is available */
 			ret->scheme = estrndup(s, (e - s));
 			php_replace_controlchars_ex(ret->scheme, (e - s));
-			goto end;
+			return ret;
 		}
 
 		/*
@@ -145,8 +145,7 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 			ret->scheme = estrndup(s, (e-s));
 			php_replace_controlchars_ex(ret->scheme, (e - s));
 
-			length -= ++e - s;
-			s = e;
+			s = e + 1;
 			goto just_path;
 		} else {
 			ret->scheme = estrndup(s, (e-s));
@@ -162,18 +161,12 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 						if (*(e + 5) == ':') {
 							s = e + 4;
 						}
-						goto nohost;
+						goto just_path;
 					}
 				}
 			} else {
-				if (!strncasecmp("file", ret->scheme, sizeof("file"))) {
-					s = e + 1;
-					goto nohost;
-				} else {
-					length -= ++e - s;
-					s = e;
-					goto just_path;
-				}
+				s = e + 1;
+				goto just_path;
 			}
 		}
 	} else if (e) { /* no scheme; starts with colon: look for port */
@@ -212,9 +205,7 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 	} else if (*s == '/' && *(s + 1) == '/') { /* relative-scheme URL */
 		s += 2;
 	} else {
-		just_path:
-		ue = s + length;
-		goto nohost;
+		goto just_path;
 	}
 
 	e = s + strcspn(s, "/?#");
@@ -296,7 +287,7 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 
 	s = e;
 
-	nohost:
+	just_path:
 
 	if ((p = memchr(s, '?', (ue - s)))) {
 		pp = memchr(s, '#', (ue - s));
@@ -343,7 +334,6 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 		ret->path = estrndup(s, (ue-s));
 		php_replace_controlchars_ex(ret->path, (ue - s));
 	}
-end:
 	return ret;
 }
 /* }}} */

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -289,51 +289,32 @@ PHPAPI php_url *php_url_parse_ex(char const *str, int length)
 
 	just_path:
 
-	if ((p = memchr(s, '?', (ue - s)))) {
-		pp = memchr(s, '#', (ue - s));
-
-		if (pp && pp < p) {
-			if (pp - s) {
-				ret->path = estrndup(s, (pp-s));
-				php_replace_controlchars_ex(ret->path, (pp - s));
-			}
-			p = pp;
-			goto label_parse;
-		}
-
-		if (p - s) {
-			ret->path = estrndup(s, (p-s));
-			php_replace_controlchars_ex(ret->path, (p - s));
-		}
-
-		if (pp) {
-			if (pp - ++p) {
-				ret->query = estrndup(p, (pp-p));
-				php_replace_controlchars_ex(ret->query, (pp - p));
-			}
-			p = pp;
-			goto label_parse;
-		} else if (++p - ue) {
-			ret->query = estrndup(p, (ue-p));
-			php_replace_controlchars_ex(ret->query, (ue - p));
-		}
-	} else if ((p = memchr(s, '#', (ue - s)))) {
-		if (p - s) {
-			ret->path = estrndup(s, (p-s));
-			php_replace_controlchars_ex(ret->path, (p - s));
-		}
-
-		label_parse:
+	e = ue;
+	p = memchr(s, '#', (e - s));
+	if (p) {
 		p++;
-
-		if (ue - p) {
-			ret->fragment = estrndup(p, (ue-p));
-			php_replace_controlchars_ex(ret->fragment, (ue - p));
+		if (p < e) {
+			ret->fragment = estrndup(p, (e - p));
+			php_replace_controlchars_ex(ret->fragment, (e - p));
 		}
-	} else {
-		ret->path = estrndup(s, (ue-s));
-		php_replace_controlchars_ex(ret->path, (ue - s));
+		e = p-1;
 	}
+
+	p = memchr(s, '?', (e - s));
+	if (p) {
+		p++;
+		if (p < e) {
+			ret->query = estrndup(p, (e - p));
+			php_replace_controlchars_ex(ret->query, (e - p));
+		}
+		e = p-1;
+	}
+
+	if (s < e || s == ue) {
+		ret->path = estrndup(s, (e - s));
+		php_replace_controlchars_ex(ret->path, (e - s));
+	}
+
 	return ret;
 }
 /* }}} */


### PR DESCRIPTION
The first two commits simplify the parse_url() implementation, the last one changes everything to respect the length argument -- previously this was somewhat hit and miss, depending on which branch was taken.