### PR TITLE
[Date] Don't suppress warnings in tests

### DIFF
--- a/ext/date/tests/timestamp-in-dst.phpt
+++ b/ext/date/tests/timestamp-in-dst.phpt
@@ -4,8 +4,8 @@ Format timestamp in DST test
 date.timezone=CEST
 --FILE--
 <?php
-error_reporting(E_ALL & ~E_WARNING); // hide e_warning warning about timezones
 var_dump( date_create( '@1202996091' )->format( 'c' ) );
 ?>
---EXPECT--
+--EXPECTF--
+Warning: date_create(): Invalid date.timezone value 'CEST', we selected the timezone 'UTC' for now. in %s on line %d
 string(25) "2008-02-14T13:34:51+00:00"


### PR DESCRIPTION
It seems like a bad idea to hide all warnings. If we change functionality in the future to raise a warning, the more tests that highlight the scope of the change the better