### PR TITLE
[DOM] Don't suppress warnings in tests

### DIFF
--- a/ext/dom/tests/dom_set_attr_node.phpt
+++ b/ext/dom/tests/dom_set_attr_node.phpt
@@ -62,7 +62,7 @@ object(DOMException)#%d (7) {
       array(1) {
         [0]=>
         
-Warning: var_dump(): Not yet implemented in %s on line %d
+Warning: var_dump(): %s
 DOMAttr
       }
     }

--- a/ext/dom/tests/dom_set_attr_node.phpt
+++ b/ext/dom/tests/dom_set_attr_node.phpt
@@ -2,8 +2,6 @@
 Test: setAttributeNode()
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
---INI--
-error_reporting = E_ALL & ~E_WARNING
 --FILE--
 <?php
 
@@ -63,7 +61,9 @@ object(DOMException)#%d (7) {
       ["args"]=>
       array(1) {
         [0]=>
-        DOMAttr
+        
+Warning: var_dump(): Not yet implemented in %s on line %d
+DOMAttr
       }
     }
   }


### PR DESCRIPTION
It seems like a bad idea to hide all warnings. If we change functionality in the future to raise a warning, the more tests that highlight the scope of the change the better