### PR TITLE
[Bug] 73538 - Fix __setSoapHeaders() with array

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -3212,9 +3212,7 @@ PHP_METHOD(SoapClient, __setSoapHeaders)
 		zval *default_headers;
 
 		verify_soap_headers_array(Z_ARRVAL_P(headers));
-		if ((default_headers = zend_hash_str_find(Z_OBJPROP_P(this_ptr), "__default_headers", sizeof("__default_headers")-1)) == NULL) {
-			add_property_zval(this_ptr, "__default_headers", headers);
-		}
+		add_property_zval(this_ptr, "__default_headers", headers);
 	} else if (Z_TYPE_P(headers) == IS_OBJECT &&
 	           instanceof_function(Z_OBJCE_P(headers), soap_header_class_entry)) {
 		zval default_headers;

--- a/ext/soap/tests/bugs/bug73538.phpt
+++ b/ext/soap/tests/bugs/bug73538.phpt
@@ -1,0 +1,35 @@
+--TEST--
+SOAP: SoapClient::__setHeaders array overrides previous headers
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$client = new SoapClient(null, [
+    "location"      =>  "test://",
+    "uri"           =>  "test://",
+    "exceptions"    =>  false,
+    "trace"         =>  true,
+]);
+$client->__setSoapHeaders(new \SoapHeader('ns', 'Header', ['something' => 1]));
+$client->__setSoapHeaders(new \SoapHeader('ns', 'Header', ['something' => 2]));
+$client->test();
+echo $client->__getLastRequest();
+
+$client = new SoapClient(null, [
+    "location"      =>  "test://",
+    "uri"           =>  "test://",
+    "exceptions"    =>  false,
+    "trace"         =>  true,
+]);
+$client->__setSoapHeaders([new \SoapHeader('ns', 'Header', ['something' => 1])]);
+$client->__setSoapHeaders([new \SoapHeader('ns', 'Header', ['something' => 2])]);
+$client->test();
+echo $client->__getLastRequest();
+
+?>
+--EXPECT--
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="test://" xmlns:ns2="ns" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Header><ns2:Header><item><key>something</key><value>2</value></item></ns2:Header></SOAP-ENV:Header><SOAP-ENV:Body><ns1:test/></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="test://" xmlns:ns2="ns" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Header><ns2:Header><item><key>something</key><value>2</value></item></ns2:Header></SOAP-ENV:Header><SOAP-ENV:Body><ns1:test/></SOAP-ENV:Body></SOAP-ENV:Envelope>


### PR DESCRIPTION
Added a test for the bug [73538](https://bugs.php.net/bug.php?id=73538) and also attempted a fix.

The [docs](http://php.net/manual/en/soapclient.setsoapheaders.php) say that any call to `__setSoapHeaders()` will _"replace any previous values"_, so I changed the code to remove the headers, and then add the passed in ones