### PR TITLE
[Bug] 73498 Incorrect SQL generated for pg_copy_to()

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -4096,7 +4096,7 @@ PHP_FUNCTION(pg_copy_to)
 		free_pg_null = 1;
 	}
 
-	spprintf(&query, 0, "COPY %s TO STDOUT DELIMITERS E'%c' WITH NULL AS E'%s'", table_name, *pg_delim, pg_null_as);
+	spprintf(&query, 0, "COPY %s TO STDOUT DELIMITER E'%c' NULL AS E'%s'", table_name, *pg_delim, pg_null_as);
 
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
@@ -4229,7 +4229,7 @@ PHP_FUNCTION(pg_copy_from)
 		pg_null_as_free = 1;
 	}
 
-	spprintf(&query, 0, "COPY %s FROM STDIN DELIMITERS E'%c' WITH NULL AS E'%s'", table_name, *pg_delim, pg_null_as);
+	spprintf(&query, 0, "COPY %s FROM STDIN DELIMITER E'%c' NULL AS E'%s'", table_name, *pg_delim, pg_null_as);
 	while ((pgsql_result = PQgetResult(pgsql))) {
 		PQclear(pgsql_result);
 	}

--- a/ext/pgsql/tests/01createdb.phpt
+++ b/ext/pgsql/tests/01createdb.phpt
@@ -29,6 +29,9 @@ else {
 	echo pg_last_error()."\n";
 }
 
+// Create view here
+pg_query($db,$view_def);
+
 pg_close($db);
 
 echo "OK";

--- a/ext/pgsql/tests/06_bug73498.phpt
+++ b/ext/pgsql/tests/06_bug73498.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug 73498 Incorrect DELIMITER syntax for pg_copy_to()
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+include('config.inc');
+
+$db = pg_connect($conn_str);
+
+$rows = pg_copy_to($db, "(select * from {$view_name})");
+
+var_dump(gettype($rows));
+var_dump(count($rows) > 0);
+
+?>
+--EXPECT--
+string(5) "array"
+bool(true)

--- a/ext/pgsql/tests/9999dropdb.phpt
+++ b/ext/pgsql/tests/9999dropdb.phpt
@@ -9,6 +9,7 @@ PostgreSQL drop db
 include('config.inc');
 
 $db = pg_connect($conn_str);
+pg_query($db, "DROP VIEW {$view_name}");
 pg_query($db, "DROP TABLE ".$table_name);
 @pg_query($db, "DROP TABLE ".$table_name_92);
 

--- a/ext/pgsql/tests/config.inc
+++ b/ext/pgsql/tests/config.inc
@@ -11,6 +11,10 @@ $table_name      = "php_pgsql_test";          // test table that will be created
 $table_name_92   = "php_pgsql_test_92";       // test table that will be created
 $num_test_record = 1000;                      // Number of records to create
 
+// Test view
+$view_name   = "php_pgsql_viewtest";
+$view_def    = "CREATE VIEW {$view_name} AS SELECT * FROM {$table_name};";
+
 // Test table
 $table_def    = "CREATE TABLE ${table_name} (num int, str text, bin bytea);";
 $table_def_92 = "CREATE TABLE ${table_name_92} (textary text[],  jsn json);";


### PR DESCRIPTION
Postgres uses the `DELIMITER` keyword since 7.3 (released in 2002).

All currently supported versions of postgres support `DELIMITER` so I don't think there's any reason to still use `DELIMITERS`

> The following syntax was used before PostgreSQL version 7.3 and is still supported
https://www.postgresql.org/docs/current/static/sql-copy.html#AEN77789