### PR TITLE
Fix memory leak(null coalescing operator with Spl hash)

### DIFF
--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -736,9 +736,11 @@ zval *zend_std_read_dimension(zval *object, zval *offset, int type, zval *rv) /*
 		if (type == BP_VAR_IS) {
 			zend_call_method_with_1_params(object, ce, NULL, "offsetexists", rv, offset);
 			if (UNEXPECTED(Z_ISUNDEF_P(rv))) {
+				zval_ptr_dtor(offset);
 				return NULL;
 			}
 			if (!i_zend_is_true(rv)) {
+				zval_ptr_dtor(offset);
 				zval_ptr_dtor(rv);
 				return &EG(uninitialized_zval);
 			}

--- a/ext/spl/tests/observer_010.phpt
+++ b/ext/spl/tests/observer_010.phpt
@@ -1,0 +1,15 @@
+--TEST--
+SPL: SplObjectStorage null coalescing operator memory leak
+--FILE--
+<?php
+// In maintainer zts mode, this should no longer
+// detect memory leaks for the objects
+$a = new stdClass();
+$b = new stdClass();
+$map = new SplObjectStorage();
+$map[$a] = 'foo';
+var_dump($map[$b] ?? null);
+var_dump($map[$a] ?? null);
+--EXPECTF--
+NULL
+string(3) "foo"


### PR DESCRIPTION
The SEPARATE_ARG_IF_REF macro increased the refcount of the object passed as a
key.
However, when the key did not exist in the ArrayAccess implementation,
the code returned early without trying to decrement the refcount.

Add a test of `??` succeeding+failing on a SplObjectStorage instance.