### PR TITLE
[Bug] 73529 Add a failing test

### DIFF
--- a/ext/session/tests/bug73529.phpt
+++ b/ext/session/tests/bug73529.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Bug #73529 session_decode() silently fails on wrong input
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+
+ini_set("session.serialize_handler", "php_serialize");
+session_start();
+
+$result1 = session_decode(serialize(["foo" => "bar"]));
+$session1 = $_SESSION;
+session_destroy();
+
+ini_set("session.serialize_handler", "php");
+session_start();
+
+$result2 = session_decode(serialize(["foo" => "bar"]));
+$session2 = $_SESSION;
+session_destroy();
+
+var_dump($result1);
+var_dump($session1);
+var_dump($result2);
+var_dump($session2);
+
+?>
+--EXPECT--
+bool(true)
+array(1) {
+  ["foo"]=>
+  string(3) "bar"
+}
+bool(false)
+array(0) {
+}


### PR DESCRIPTION
I wrote the included test for [Bug 73529](https://bugs.php.net/bug.php?id=73529), and I attempted to fix it but couldn't quite figure it out.

I think the problem is around [this part](https://github.com/php/php-src/blob/a36dd1dfd8cf807d31aa9acc2f092b532a45bb15/ext/session/session.c#L1077) of the code. It reads like if it doesn't find the delimiter (separating the name from the value, eg `test|i:1;`) then it just returns true. But we can't set a failure here, as an empty session would also fail.

Any suggestions @yohgaki, or am I way off?
