### PR TITLE
Remove "register_globals" support codes from php/php_binary serializer

### DIFF
--- a/ext/session/tests/session_encode_error2.phpt
+++ b/ext/session/tests/session_encode_error2.phpt
@@ -220,7 +220,7 @@ bool(true)
 
 -- Iteration 20 --
 bool(true)
-bool(false)
+string(33) "Hello World!|s:12:"Hello World!";"
 bool(true)
 
 -- Iteration 21 --


### PR DESCRIPTION
This patch removes "register_globals" support codes from php/php_binary serializer.
As a result, users may use PS_UNDEF_MAKER(=!) char for session variable name.

This patch is a code cleanup. However, there could be compatibility issue when user mixing old PHP (less than PHP 5.4.0) that supports "register_globals" (i.e. Variables that are registered by session_register()) When session_register()ed variables are undefined, it results in error. Since session_register() is removed in PHP 5.4.0, PHP 5.4.0 or later has no issues.

If there is no comment, I'll merge this in a few days.
