### PR TITLE
Add clean and complete session save handler interface

### DIFF
--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -309,6 +309,9 @@ PHPAPI ZEND_EXTERN_MODULE_GLOBALS(ps)
 
 void php_session_auto_start(void *data);
 
+#define PS_SAVE_HANDLER_IFACE_NAME "SessionSaveHandlerInterface"
+extern zend_class_entry *php_session_save_handler_iface_entry;
+
 #define PS_CLASS_NAME "SessionHandler"
 extern zend_class_entry *php_session_class_entry;
 

--- a/ext/session/tests/session_save_handler_001.phpt
+++ b/ext/session/tests/session_save_handler_001.phpt
@@ -1,0 +1,106 @@
+--TEST--
+Test session_set_save_handler() : basic class wrapping existing handler
+--INI--
+session.use_strict_mode=1
+session.name=PHPSESSID
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+
+ob_start();
+
+/*
+ * Prototype : bool session_set_save_handler(SessionHandler $handler [, bool $register_shutdown_function = true])
+ * Description : Sets user-level session storage functions
+ * Source code : ext/session/session.c
+ */
+
+echo "*** Testing session_set_save_handler() : basic class wrapping existing handler ***\n";
+
+class MySession implements SessionSaveHandlerInterface {
+	public $i = 0;
+	public function open($path, $name) {
+		++$this->i;
+		echo 'Open ', session_id(), "\n";
+		return TRUE;
+	}
+	public function read($key) {
+		++$this->i;
+		echo 'Read ', session_id(), "\n";
+		return "";
+	}
+	public function write($key, $data) {
+		++$this->i;
+		echo 'Write ', session_id(), "\n";
+		return TRUE;
+	}
+	public function close() {
+		++$this->i;
+		echo 'Close ', session_id(), "\n";
+		return TRUE;
+	}
+	public function destroy($key) {
+		++$this->i;
+		return TRUE;
+	}
+	public function gc($key) {
+		return 0;
+	}
+	public function createId() {
+		++$this->i;
+		echo 'New Create ID ', session_id(), "\n";
+		return "1234567890";
+	}
+	public function validateId($key) {
+		++$this->i;
+		echo 'Validate ID ', session_id(), "\n";
+		return TRUE;
+	}
+	public function updateTimestamp($key, $data) {
+		++$this->i;
+		echo 'Update Timestamp ', session_id(), "\n";
+		return TRUE;
+	}
+}
+
+$oldHandler = ini_get('session.save_handler');
+$handler = new MySession;
+session_set_save_handler($handler);
+session_start();
+
+var_dump(session_id(), $oldHandler, ini_get('session.save_handler'), $handler->i, $_SESSION);
+
+$_SESSION['foo'] = "hello";
+
+session_write_close();
+session_unset();
+
+session_start();
+var_dump($_SESSION);
+
+session_write_close();
+session_unset();
+var_dump($handler->i);
+
+--EXPECTF--
+*** Testing session_set_save_handler() : basic class wrapping existing handler ***
+Open 
+New Create ID 
+Read 1234567890
+string(10) "1234567890"
+string(5) "files"
+string(4) "user"
+int(3)
+array(0) {
+}
+Write 1234567890
+Close 1234567890
+Open 1234567890
+Validate ID 1234567890
+Read 1234567890
+array(0) {
+}
+Write 1234567890
+Close 1234567890
+int(10)

--- a/ext/session/tests/session_save_handler_002.phpt
+++ b/ext/session/tests/session_save_handler_002.phpt
@@ -1,0 +1,115 @@
+--TEST--
+Test session_set_save_handler() : basic class wrapping existing handler
+--INI--
+session.use_strict_mode=1
+session.save_handler=files
+session.name=PHPSESSID
+session.save_path=
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+
+ob_start();
+
+/*
+ * Prototype : bool session_set_save_handler(SessionHandler $handler [, bool $register_shutdown_function = true])
+ * Description : Sets user-level session storage functions
+ * Source code : ext/session/session.c
+ */
+
+echo "*** Testing session_set_save_handler() : basic class wrapping existing handler ***\n";
+
+require 'save_handler.inc';
+
+session_save_path(__DIR__);
+
+class MySession implements SessionSaveHandlerInterface {
+	public $i = 0;
+	public function open($path, $name) {
+		++$this->i;
+		return open($path, $name);
+	}
+	public function read($key) {
+		++$this->i;
+		return read($key);
+	}
+	public function write($key, $data) {
+		++$this->i;
+		return write($key, $data);
+	}
+	public function close() {
+		++$this->i;
+		return close();
+	}
+	public function destroy($key) {
+		++$this->i;
+		return destroy($key);
+	}
+	public function gc($key) {
+		return gc($key);
+	}
+	public function createId() {
+		++$this->i;
+		return session_create_id();
+	}
+	public function validateId($key) {
+		++$this->i;
+		return validate_sid($key);
+	}
+	public function updateTimestamp($key, $data) {
+		++$this->i;
+		return update($key, $data);
+	}
+}
+
+$oldHandler = ini_get('session.save_handler');
+$handler = new MySession;
+session_set_save_handler($handler);
+session_start();
+
+var_dump(session_id(), $oldHandler, ini_get('session.save_handler'), $handler->i, $_SESSION);
+
+$_SESSION['foo'] = "hello";
+
+session_write_close();
+session_unset();
+
+session_start();
+var_dump($_SESSION);
+
+session_write_close();
+session_unset();
+var_dump($handler->i);
+
+session_start();
+session_destroy();
+
+--EXPECTF--
+*** Testing session_set_save_handler() : basic class wrapping existing handler ***
+
+Open [%s,PHPSESSID]
+Read [%s,%s]
+string(32) "%s"
+string(5) "files"
+string(4) "user"
+int(3)
+array(0) {
+}
+Write [%s,%s,foo|s:5:"hello";]
+Close [%s,PHPSESSID]
+Open [%s,PHPSESSID]
+ValidateID [%s,%s]
+Read [%s,%s]
+array(1) {
+  ["foo"]=>
+  string(5) "hello"
+}
+Update [%s,%s]
+Close [%s,PHPSESSID]
+int(10)
+Open [%s,PHPSESSID]
+ValidateID [%s,%s]
+Read [%s,%s]
+Destroy [%s,%s]
+Close [%s,PHPSESSID]

--- a/ext/session/tests/session_set_save_handler_iface_002.phpt
+++ b/ext/session/tests/session_set_save_handler_iface_002.phpt
@@ -85,6 +85,6 @@ session_start();
 *** Testing session_set_save_handler() function: interface wrong ***
 bool(true)
 
-Warning: session_set_save_handler() expects parameter 1 to be SessionHandlerInterface, object given in %s
+Warning: session_set_save_handler(): Session save handler object must implement SessionSaveHandlerInterface or SessionHandlerInter in %s on line %d
 bool(false)
 good handler writing


### PR DESCRIPTION
With "**User defined session serializer RFC**", OO session save handler does not have to be intrusive to C written save handlers.
https://wiki.php.net/rfc/user_defined_session_serializer

This PR adds **clean and complete session save handler interface** (SessionSaveHandlerInterface)  that does not use base class.  i.e. No C written save handler base class.

SessionSaveHandlerInterface requires all required handlers for users to implement proper/optimal session save handler.

```php
interface SessionSaveHandlerInterface {
  function bool open(string $save_path);
  function bool close(void);
  function string read(string $key);
  function bool write(string $key, string $data);
  function bool destroy(string $key);
  function int gc(int $maxlifetime);
  function string createId(void);
  function bool validateId($key);
  function bool updateTimestamp($key, $data);
}
```
 
Note: Older save handler has "create_sid" method that does not comply CODING_STANDARDS. It renamed to "createId".

When obsolete session save handler object/classes are removed, session module code could be cleaned up. i.e. State management codes to prevent session save handler misuse/abuse can be removed. 

