### PR TITLE
Fix bug #70015 - Compilation failure on aarch64

### DIFF
--- a/Zend/zend_multiply.h
+++ b/Zend/zend_multiply.h
@@ -75,8 +75,8 @@
 	__asm__("mul %0, %2, %3\n"										\
 		"smulh %1, %2, %3\n"										\
 		"sub %1, %1, %0, asr #63\n"									\
-			: "=X"(__tmpvar), "=X"(usedval)							\
-			: "X"(a), "X"(b));										\
+			: "=&r"(__tmpvar), "=&r"(usedval)						\
+			: "r"(a), "r"(b));										\
 	if (usedval) (dval) = (double) (a) * (double) (b);				\
 	else (lval) = __tmpvar;											\
 } while (0)


### PR DESCRIPTION
Faced at https://github.com/alpinelinux/aports/pull/587#issuecomment-265750816

Build fails with following
```
/tmp/ccbaoFgl.s: Assembler messages:
/tmp/ccbaoFgl.s:570: Error: operand 3 should be an integer register -- `mul x0,x0,1048576'
/tmp/ccbaoFgl.s:571: Error: operand 3 should be an integer register -- `smulh x1,x0,1048576'
```

Related docs
* https://developer.arm.com/docs/dui0801/latest/a64-general-instructions/mul
* https://developer.arm.com/docs/dui0801/latest/a64-general-instructions/smulh

Used patch from https://bugs.php.net/bug.php?id=70015