### PR TITLE
Interpretation of curl_setopt values for boolean parameters

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2315,8 +2315,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 			error = curl_easy_setopt(ch->cp, option, lval);
 			break;
 		case CURLOPT_SAFE_UPLOAD:
-			lval = zval_get_long(zvalue);
-			if (lval == 0) {
+			if (!zend_is_true(zvalue)) {
 				php_error_docref(NULL, E_WARNING, "Disabling safe uploads is no longer supported");
 				return FAILURE;
 			}
@@ -2652,13 +2651,11 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 			break;
 
 		case CURLOPT_FOLLOWLOCATION:
-			lval = zval_get_long(zvalue);
+			lval = zend_is_true(zvalue);
 #if LIBCURL_VERSION_NUM < 0x071304
-			if (PG(open_basedir) && *PG(open_basedir)) {
-				if (lval != 0) {
-					php_error_docref(NULL, E_WARNING, "CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set");
-					return FAILURE;
-				}
+			if (lval && PG(open_basedir) && *PG(open_basedir)) {
+				php_error_docref(NULL, E_WARNING, "CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set");
+				return FAILURE;
 			}
 #endif
 			error = curl_easy_setopt(ch->cp, option, lval);
@@ -2814,8 +2811,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 			break;
 
 		case CURLOPT_RETURNTRANSFER:
-			lval = zval_get_long(zvalue);
-			if (lval) {
+			if (zend_is_true(zvalue)) {
 				ch->handlers->write->method = PHP_CURL_RETURN;
 			} else {
 				ch->handlers->write->method = PHP_CURL_STDOUT;
@@ -2891,8 +2887,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 		}
 
 		case CURLINFO_HEADER_OUT:
-			lval = zval_get_long(zvalue);
-			if (lval == 1) {
+			if (zend_is_true(zvalue)) {
 				curl_easy_setopt(ch->cp, CURLOPT_DEBUGFUNCTION, curl_debug);
 				curl_easy_setopt(ch->cp, CURLOPT_DEBUGDATA, (void *)ch);
 				curl_easy_setopt(ch->cp, CURLOPT_VERBOSE, 1);


### PR DESCRIPTION
In curl_setopt value should be converted to a boolean correctly when non-empty string is passed to it for following options:

* CURLOPT_SAFE_UPLOAD
* CURLOPT_FOLLOWLOCATION
* CURLOPT_RETURNTRANSFER
* CURLINFO_HEADER_OUT

So, in this example you expect that CURLOPT_RETURNTRANSFER option is set, but actually it wasn't:


    $ch = curl_init('.....');
    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 'foo');


This was because convertation to long is used to process this value.
Which is not logical, behaviour should be identical to one that's used to convert a string to boolean.