### PR TITLE
Cursor is not opened on singleton selects.

### DIFF
--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -152,8 +152,8 @@ static int firebird_stmt_execute(pdo_stmt_t *stmt) /* {{{ */
 		}
 
 		*S->name = 0;
-		S->cursor_open = (S->out_sqlda.sqln > 0);	/* A cursor is opened, when more than zero columns returned */
-		S->exhausted = !S->cursor_open;
+		S->cursor_open = S->out_sqlda.sqln && (S->statement_type != isc_info_sql_stmt_exec_procedure);
+		S->exhausted = !S->out_sqlda.sqln; /* There are data to fetch */
 
 		return 1;
 	} while (0);

--- a/ext/pdo_firebird/tests/bug_aaa.phpt
+++ b/ext/pdo_firebird/tests/bug_aaa.phpt
@@ -5,7 +5,7 @@ PDO_Firebird: cursor should not be marked as opened on singleton statements
 --FILE--
 <?php
 require 'testdb.inc';
-$C = new PDO('firebird:dbname='.$test_base, $user, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]) or die;
+$C = new PDO('firebird:dbname='.$test_base, $user, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_WARNING]) or die;
 @$C->exec('drop table ta_table');
 $C->exec('create table ta_table (id integer)');
 $S = $C->prepare('insert into ta_table (id) values (:id) returning id');

--- a/ext/pdo_firebird/tests/bug_aaa.phpt
+++ b/ext/pdo_firebird/tests/bug_aaa.phpt
@@ -1,0 +1,19 @@
+--TEST--
+PDO_Firebird: cursor should not be marked as opened on singleton statements
+--SKIPIF--
+<?php if (!extension_loaded('interbase') || !extension_loaded('pdo_firebird')) die('skip'); ?>
+--FILE--
+<?php
+require 'testdb.inc';
+$C = new PDO('firebird:dbname='.$test_base, $user, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]) or die;
+@$C->exec('drop table ta_table');
+$C->exec('create table ta_table (id integer)');
+$S = $C->prepare('insert into ta_table (id) values (:id) returning id');
+$S->execute(['id' => 1]);
+$S->execute(['id' => 2]);
+unset($S);
+unset($C);
+echo 'OK';
+?>
+--EXPECT--
+OK


### PR DESCRIPTION
In case if we execute twice a prepared singleton statements an error is thrown trying to close an unopened cursor.

Code sample:
$S = $D->prepare('insert into ta_test (id, name) values (next value for gs_id, :name) returning id');
$S->execute(['name' => 'One']);
$S->execute(['name' => 'Two']);

All current tests are passed with this commit change.