### PR TITLE
Fix 73783 : pcntl_signal() not handling SIG_IGN correctly

### DIFF
--- a/ext/pcntl/tests/bug73783.phpt
+++ b/ext/pcntl/tests/bug73783.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug #73783: (SIG_IGN needs to be set to prevent syscals from returning early)
+--SKIPIF--
+<?php
+	if (!extension_loaded('pcntl')) die('skip pcntl extension not available');
+	elseif (!extension_loaded('posix')) die('skip posix extension not available');
+?>
+--FILE--
+<?php
+pcntl_signal(SIGCHLD, SIG_IGN);
+
+switch(pcntl_fork()) {
+    case 0:
+        exit;
+        break;
+}
+
+$before = time();
+sleep(3);
+
+if (time() - $before >= 2) {
+    echo "working\n";
+} else {
+    echo "failed\n";
+}
+?>
+--EXPECTF--
+working


### PR DESCRIPTION
Bug #73783 raises an issue with signal handling when using SIG_IGN.
With PHP7.1 ZEND_SIGNALS is defaulted to on, which will for all
signals set the handler as zend_signal_handler_defer.  This is
problematic for syscalls like sleep(), which will only return when the
requisite number of seconds have elapsed, or, a non-ignored signal is
raised.  In this case we want to SIG_IGN SIGCHLD, however, SIG_IGN is
only stored in the SIGG(handlers) array, and the actual system level
handler is defined.  This prevents proper signal ignoring when requeted.