### PR TITLE
Fix #73753 - Unpacked Arrays and Duplication

### DIFF
--- a/Zend/tests/bug73753.phpt
+++ b/Zend/tests/bug73753.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Bug #73753 Non packed arrays and duplication
+--FILE--
+<?php
+function iterate($current, $a, $result = null) {
+    if (!$current) {
+        return $result;
+    }
+
+    return iterate(getNext($a), $a, $current);
+}
+
+function getNext(&$a) {
+    return next($a);
+}
+
+function getCurrent($a) {
+    return current($a);
+}
+
+function traverse($a) {
+    return iterate(getCurrent($a), $a);
+}
+
+$arr = array(1 => 'foo', 'b' => 'bar', 'baz');
+var_dump(traverse($arr));
+?>
+--EXPECTF--
+string(3) "baz"

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1763,11 +1763,7 @@ static zend_always_inline uint32_t zend_array_dup_elements(HashTable *source, Ha
 	Bucket *end = p + source->nNumUsed;
 
 	do {
-		if (EXPECTED(zend_array_dup_element(source, target, idx, p, q, 0, static_keys, with_holes))) {
-			if (source->nInternalPointer == idx) {
-				target->nInternalPointer = idx;
-			}
-		} else {
+		if (!zend_array_dup_element(source, target, idx, p, q, 0, static_keys, with_holes)) {
 			uint32_t target_idx = idx;
 
 			idx++; p++;
@@ -1789,7 +1785,7 @@ static zend_always_inline uint32_t zend_array_dup_elements(HashTable *source, Ha
 
 ZEND_API HashTable* ZEND_FASTCALL zend_array_dup(HashTable *source)
 {
-    uint32_t idx;
+	uint32_t idx;
 	HashTable *target;
 
 	IS_CONSISTENT(source);
@@ -1853,7 +1849,8 @@ ZEND_API HashTable* ZEND_FASTCALL zend_array_dup(HashTable *source)
 		target->u.flags = (source->u.flags & ~(HASH_FLAG_PERSISTENT|ZEND_HASH_APPLY_COUNT_MASK)) | HASH_FLAG_APPLY_PROTECTION;
 		target->nTableMask = source->nTableMask;
 		target->nNextFreeElement = source->nNextFreeElement;
-		target->nInternalPointer = HT_INVALID_IDX;
+		target->nInternalPointer = source->nInternalPointer;
+
 		HT_SET_DATA_ADDR(target, emalloc(HT_SIZE(target)));
 		HT_HASH_RESET(target);
 

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1757,13 +1757,17 @@ static zend_always_inline void zend_array_dup_packed_elements(HashTable *source,
 
 static zend_always_inline uint32_t zend_array_dup_elements(HashTable *source, HashTable *target, int static_keys, int with_holes)
 {
-    uint32_t idx = 0;
+	uint32_t idx = 0;
 	Bucket *p = source->arData;
 	Bucket *q = target->arData;
 	Bucket *end = p + source->nNumUsed;
 
 	do {
-		if (!zend_array_dup_element(source, target, idx, p, q, 0, static_keys, with_holes)) {
+		if (EXPECTED(zend_array_dup_element(source, target, idx, p, q, 0, static_keys, with_holes))) {
+			if (source->nInternalPointer == idx) {
+				target->nInternalPointer = idx;
+			}
+		} else {
 			uint32_t target_idx = idx;
 
 			idx++; p++;


### PR DESCRIPTION
Bug was exposed in trying to call next() on an array that is not
packed.  What ends up happening is when separating a call to
zend_array_dup() is called and falls into the else case for type of
array.  This sets the nInternalPointer to invalid-idx, with the
expectation of being set during the zend_array_dup_elements() call.
However, there, we see that if we success duplicating the element,
we never check to see if the sources pointer is the current index.

This fix checks to see if we can dup the element, and if so, check
to see if the idx is the sources internal pointer, to set it.