### PR TITLE
Fix IS_UNDEF comparisons in opcache

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -585,7 +585,7 @@ static void accel_use_shm_interned_strings(void)
 
 		for (j = 0; j < ce->constants_table.nNumUsed; j++) {
 			q = ce->constants_table.arData + j;
-			if (!Z_TYPE(q->val) == IS_UNDEF) continue;
+			if (Z_TYPE(q->val) == IS_UNDEF) continue;
 			if (q->key) {
 				q->key = accel_new_interned_string(q->key);
 			}
@@ -595,7 +595,7 @@ static void accel_use_shm_interned_strings(void)
 	/* constant hash keys */
 	for (idx = 0; idx < EG(zend_constants)->nNumUsed; idx++) {
 		p = EG(zend_constants)->arData + idx;
-		if (!Z_TYPE(p->val) == IS_UNDEF) continue;
+		if (Z_TYPE(p->val) == IS_UNDEF) continue;
 		if (p->key) {
 			p->key = accel_new_interned_string(p->key);
 		}


### PR DESCRIPTION
Fixes `-Wlogical-not-parentheses` compiler warnings.

This is a follow-up for 5324f22f598c.

**Compiler used for issue detection:**

FreeBSD clang version 3.8.0 (tags/RELEASE_380/final 262564) (based on LLVM 3.8.0)

**Example of warning:**
```
/home/dereckson/dev/php/php-src/ext/opcache/ZendAccelerator.c:588:8: warning: logical not is only applied to the left hand side of this comparison
      [-Wlogical-not-parentheses]
                        if (!Z_TYPE(q->val) == IS_UNDEF) continue;
                            ^               ~~
/home/dereckson/dev/php/php-src/ext/opcache/ZendAccelerator.c:588:8: note: add parentheses after the '!' to evaluate the comparison first
                        if (!Z_TYPE(q->val) == IS_UNDEF) continue;
                            ^
                             (                         )
/home/dereckson/dev/php/php-src/ext/opcache/ZendAccelerator.c:588:8: note: add parentheses around left hand side expression to silence this warning
                        if (!Z_TYPE(q->val) == IS_UNDEF) continue;
                            ^
                            (              )
```