### PR TITLE
Remove extraneous parentheses in conditions

### DIFF
--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -62644,7 +62644,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 	uint32_t spec = zend_spec_handlers[opcode];
 	switch (opcode) {
 		case ZEND_ADD:
-			if ((res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			if (res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62652,7 +62652,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 				if (op->op1_type > op->op2_type) {
 					zend_swap_operands(op);
 				}
-			} else if ((op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			} else if (op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62660,7 +62660,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 				if (op->op1_type > op->op2_type) {
 					zend_swap_operands(op);
 				}
-			} else if ((op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE)) {
+			} else if (op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62671,17 +62671,17 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 			}
 			break;
 		case ZEND_SUB:
-			if ((res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			if (res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
 				spec = 3706 | SPEC_RULE_OP1 | SPEC_RULE_OP2;
-			} else if ((op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			} else if (op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
 				spec = 3731 | SPEC_RULE_OP1 | SPEC_RULE_OP2;
-			} else if ((op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE)) {
+			} else if (op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62689,7 +62689,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 			}
 			break;
 		case ZEND_MUL:
-			if ((res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			if (res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62697,7 +62697,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 				if (op->op1_type > op->op2_type) {
 					zend_swap_operands(op);
 				}
-			} else if ((op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			} else if (op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62705,7 +62705,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 				if (op->op1_type > op->op2_type) {
 					zend_swap_operands(op);
 				}
-			} else if ((op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE)) {
+			} else if (op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62716,7 +62716,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 			}
 			break;
 		case ZEND_IS_EQUAL:
-			if ((op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			if (op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62724,7 +62724,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 				if (op->op1_type > op->op2_type) {
 					zend_swap_operands(op);
 				}
-			} else if ((op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE)) {
+			} else if (op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62735,7 +62735,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 			}
 			break;
 		case ZEND_IS_NOT_EQUAL:
-			if ((op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			if (op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62743,7 +62743,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 				if (op->op1_type > op->op2_type) {
 					zend_swap_operands(op);
 				}
-			} else if ((op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE)) {
+			} else if (op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62754,12 +62754,12 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 			}
 			break;
 		case ZEND_IS_SMALLER:
-			if ((op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			if (op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
 				spec = 4156 | SPEC_RULE_OP1 | SPEC_RULE_OP2 | SPEC_RULE_SMART_BRANCH;
-			} else if ((op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE)) {
+			} else if (op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62767,12 +62767,12 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 			}
 			break;
 		case ZEND_IS_SMALLER_OR_EQUAL:
-			if ((op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG)) {
+			if (op1_info == MAY_BE_LONG && op2_info == MAY_BE_LONG) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
 				spec = 4306 | SPEC_RULE_OP1 | SPEC_RULE_OP2 | SPEC_RULE_SMART_BRANCH;
-			} else if ((op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE)) {
+			} else if (op1_info == MAY_BE_DOUBLE && op2_info == MAY_BE_DOUBLE) {
 				if (op->op1_type == IS_CONST && op->op2_type == IS_CONST) {
 					break;
 				}
@@ -62780,45 +62780,45 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 			}
 			break;
 		case ZEND_QM_ASSIGN:
-			if ((op1_info == MAY_BE_DOUBLE)) {
+			if (op1_info == MAY_BE_DOUBLE) {
 				spec = 4546 | SPEC_RULE_OP1;
-			} else if ((!(op1_info & ((MAY_BE_ANY|MAY_BE_UNDEF)-(MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG|MAY_BE_DOUBLE))))) {
+			} else if (!(op1_info & ((MAY_BE_ANY|MAY_BE_UNDEF)-(MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG|MAY_BE_DOUBLE)))) {
 				spec = 4551 | SPEC_RULE_OP1;
 			}
 			break;
 		case ZEND_PRE_INC:
-			if ((res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG)) {
+			if (res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG) {
 				spec = 4456 | SPEC_RULE_OP1 | SPEC_RULE_RETVAL;
-			} else if ((op1_info == MAY_BE_LONG)) {
+			} else if (op1_info == MAY_BE_LONG) {
 				spec = 4466 | SPEC_RULE_OP1 | SPEC_RULE_RETVAL;
-			} else if ((op1_info == (MAY_BE_LONG|MAY_BE_DOUBLE))) {
+			} else if (op1_info == (MAY_BE_LONG|MAY_BE_DOUBLE)) {
 				spec = 4476 | SPEC_RULE_OP1 | SPEC_RULE_RETVAL;
 			}
 			break;
 		case ZEND_PRE_DEC:
-			if ((res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG)) {
+			if (res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG) {
 				spec = 4486 | SPEC_RULE_OP1 | SPEC_RULE_RETVAL;
-			} else if ((op1_info == MAY_BE_LONG)) {
+			} else if (op1_info == MAY_BE_LONG) {
 				spec = 4496 | SPEC_RULE_OP1 | SPEC_RULE_RETVAL;
-			} else if ((op1_info == (MAY_BE_LONG|MAY_BE_DOUBLE))) {
+			} else if (op1_info == (MAY_BE_LONG|MAY_BE_DOUBLE)) {
 				spec = 4506 | SPEC_RULE_OP1 | SPEC_RULE_RETVAL;
 			}
 			break;
 		case ZEND_POST_INC:
-			if ((res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG)) {
+			if (res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG) {
 				spec = 4516 | SPEC_RULE_OP1;
-			} else if ((op1_info == MAY_BE_LONG)) {
+			} else if (op1_info == MAY_BE_LONG) {
 				spec = 4521 | SPEC_RULE_OP1;
-			} else if ((op1_info == (MAY_BE_LONG|MAY_BE_DOUBLE))) {
+			} else if (op1_info == (MAY_BE_LONG|MAY_BE_DOUBLE)) {
 				spec = 4526 | SPEC_RULE_OP1;
 			}
 			break;
 		case ZEND_POST_DEC:
-			if ((res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG)) {
+			if (res_info == MAY_BE_LONG && op1_info == MAY_BE_LONG) {
 				spec = 4531 | SPEC_RULE_OP1;
-			} else if ((op1_info == MAY_BE_LONG)) {
+			} else if (op1_info == MAY_BE_LONG) {
 				spec = 4536 | SPEC_RULE_OP1;
-			} else if ((op1_info == (MAY_BE_LONG|MAY_BE_DOUBLE))) {
+			} else if (op1_info == (MAY_BE_LONG|MAY_BE_DOUBLE)) {
 				spec = 4541 | SPEC_RULE_OP1;
 			}
 			break;
@@ -62828,7 +62828,7 @@ ZEND_API void zend_vm_set_opcode_handler_ex(zend_op* op, uint32_t op1_info, uint
 			}
 			break;
 		case ZEND_FETCH_DIM_R:
-			if ((!(op2_info & (MAY_BE_UNDEF|MAY_BE_NULL|MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE|MAY_BE_REF)))) {
+			if (!(op2_info & (MAY_BE_UNDEF|MAY_BE_NULL|MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE|MAY_BE_REF))) {
 				spec = 4556 | SPEC_RULE_OP1 | SPEC_RULE_OP2;
 			}
 			break;

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -659,6 +659,19 @@ function opcode_name($name, $spec, $op1, $op2) {
 	return $name.($spec?"_SPEC":"").$prefix[$op1].$prefix[$op2];
 }
 
+// Formats condition, protecting it by parentheses when needed.
+function format_condition($condition) {
+	if ($condition === "") {
+		throw new InvalidArgumentException("A non empty string condition was expected.");
+	}
+
+	if ($condition[0] === "(" && substr($condition, -1) === ")") {
+		return $condition;
+	}
+
+	return "(".$condition.")";
+}
+
 // Generates code for opcode handler or helper
 function gen_code($f, $spec, $kind, $export, $code, $op1, $op2, $name, $extra_spec=null) {
 	global $op1_type, $op2_type, $op1_get_zval_ptr, $op2_get_zval_ptr,
@@ -2347,11 +2360,12 @@ function gen_vm($def, $skel) {
 					out($f, "\t\tcase $orig_op:\n");
 					$first = true;
 					foreach($dsc['type_spec'] as $code => $condition) {
+						$condition = format_condition($condition);
 						if ($first) {
-							out($f, "\t\t\tif ($condition) {\n");
+							out($f, "\t\t\tif $condition {\n");
 							$first = false;
 						} else {
-							out($f, "\t\t\t} else if ($condition) {\n");
+							out($f, "\t\t\t} else if $condition {\n");
 						}
 						$spec_dsc = $opcodes[$code];
 						if (isset($spec_dsc["spec"]["NO_CONST_CONST"])) {


### PR DESCRIPTION
This fixes nine clang/llvm parentheses-equality warnings.

**Example of warning** 
```
Zend/zend_vm_execute.h:59845:25: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
                        } else if ((op1_info == MAY_BE_LONG)) {
                                    ~~~~~~~~~^~~~~~~~~~~~~~
Zend/zend_vm_execute.h:59845:25: note: remove extraneous parentheses around the comparison to silence this warning
                        } else if ((op1_info == MAY_BE_LONG)) {
                                   ~         ^             ~
Zend/zend_vm_execute.h:59845:25: note: use '=' to turn this equality comparison into an assignment
                        } else if ((op1_info == MAY_BE_LONG)) {
                                             ^~
                                             =
```