### PR TITLE
Retry write in php_stdiop_write on EINTR

### DIFF
--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -337,14 +337,18 @@ static size_t php_stdiop_write(php_stream *stream, const char *buf, size_t count
 	assert(data != NULL);
 
 	if (data->fd >= 0) {
-#ifdef PHP_WIN32
 		int bytes_written;
+#ifdef PHP_WIN32
 		if (ZEND_SIZE_T_UINT_OVFL(count)) {
 			count = UINT_MAX;
 		}
 		bytes_written = _write(data->fd, buf, (unsigned int)count);
 #else
-		int bytes_written = write(data->fd, buf, count);
+		bytes_written = write(data->fd, buf, count);
+		if (bytes_written < 0 && errno == EINTR) {
+			/* Write was interrupted, retry once */
+			bytes_written = write(data->fd, buf, count);
+		}
 #endif
 		if (bytes_written < 0) return 0;
 		return (size_t) bytes_written;


### PR DESCRIPTION
Noticed while looking into a potential silent failure of `error_log`. This achieves parity with php_stdiop_read. See c3935671.