### PR TITLE
Make Opcache tests using the cli server more reliable

### DIFF
--- a/ext/opcache/tests/php_cli_server.inc
+++ b/ext/opcache/tests/php_cli_server.inc
@@ -20,28 +20,43 @@ function php_cli_server_start($ini = "") {
 		$cmd = "exec {$php_executable} -t {$doc_root} $ini -S " . PHP_CLI_SERVER_ADDRESS . " 2>/dev/null";
 		$handle = proc_open($cmd, $descriptorspec, $pipes, $doc_root);
 	}
-	
+
 	// note: even when server prints 'Listening on localhost:8964...Press Ctrl-C to quit.'
 	//       it might not be listening yet...need to wait until fsockopen() call returns
-    $i = 0;
-    while (($i++ < 30) && !($fp = @fsockopen(PHP_CLI_SERVER_HOSTNAME, PHP_CLI_SERVER_PORT))) {
-        usleep(10000);
-    }
+	$error = "Unable to connect to servers\n";
+	for ($i=0; $i < 60; $i++) {
+		usleep(25000); // 25ms per try
+		$status = proc_get_status($handle);
+		$fp = @fsockopen(PHP_CLI_SERVER_HOSTNAME, PHP_CLI_SERVER_PORT);
+		// Failure, the server is no longer running
+		if (!($status && $status['running'])) {
+			$error = "Server is not running\n";
+			break;
+		}
+		// Success, Connected to servers
+		if ($fp) {
+			$error = '';
+			break;
+		}
+	}
 
-    if ($fp) {
-        fclose($fp);
-    }
+	if ($fp) {
+		fclose($fp);
+	}
+
+	if ($error) {
+		echo $error;
+		proc_terminate($handle);
+		exit(1);
+	}
 
 	register_shutdown_function(
 		function($handle) {
 			proc_terminate($handle);
 		},
-			$handle
-		);
-	// don't bother sleeping, server is already up
-	// server can take a variable amount of time to be up, so just sleeping a guessed amount of time
-	// does not work. this is why tests sometimes pass and sometimes fail. to get a reliable pass
-	// sleeping doesn't work.
+		$handle
+	);
+
 }
 ?>
 


### PR DESCRIPTION
Same fix applied to ext/curl/tests/server.inc
and sapi/cli/tests/php_cli_server.inc

1. Increases the amount of time for the PHP built-in server to accept a connection
2. Outputs an error if the PHP built-in server fails