### PR TITLE
Fix header_remove function, the name parameter is optional

### DIFF
--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -62,6 +62,7 @@ PHP_FUNCTION(header_remove)
 	size_t len = 0;
 
 	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
 		Z_PARAM_STRING(ctr.line, len)
 	ZEND_PARSE_PARAMETERS_END();
 


### PR DESCRIPTION
The name parameter in the header_remove function is optional.

This fixes the failing tests:
header_remove() [sapi/cgi/tests/011.phpt]
Bug #61605 (header_remove() does not remove all headers) [sapi/cgi/tests/bug61605.phpt]
