### PR TITLE
Fixed getElementsByTagNameNS not filtering on default namespace (bug #67474)

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1345,7 +1345,7 @@ xmlNode *dom_get_elements_by_tag_name_ns_raw(xmlNodePtr nodep, char *ns, char *l
 	while (nodep != NULL && (*cur <= index || index == -1)) {
 		if (nodep->type == XML_ELEMENT_NODE) {
 			if (xmlStrEqual(nodep->name, (xmlChar *)local) || xmlStrEqual((xmlChar *)"*", (xmlChar *)local)) {
-				if (ns == NULL || (nodep->ns != NULL && (xmlStrEqual(nodep->ns->href, (xmlChar *)ns) || xmlStrEqual((xmlChar *)"*", (xmlChar *)ns)))) {
+				if (ns == NULL || (!strcmp(ns, "") && nodep->ns == NULL) || (nodep->ns != NULL && (xmlStrEqual(nodep->ns->href, (xmlChar *)ns) || xmlStrEqual((xmlChar *)"*", (xmlChar *)ns)))) {
 					if (*cur == index) {
 						ret = nodep;
 						break;

--- a/ext/dom/tests/bug67474.phpt
+++ b/ext/dom/tests/bug67474.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #67474 getElementsByTagNameNS and default namespace
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$doc = new DOMDocument();
+$doc->loadXML('<root xmlns:x="x"><a/><x:a/></root>');
+$list = $doc->getElementsByTagNameNS('', 'a');
+var_dump($list->length);
+$list = $doc->getElementsByTagNameNS(null, 'a');
+var_dump($list->length);
+?>
+--EXPECT--
+int(1)
+int(1)


### PR DESCRIPTION
This bug was caused by the fact that `dom_get_elements_by_tag_name_ns_raw`
uses an empty string to filter on the default namespace (as `NULL` means
'no filter'), whereas in the node itself the default namespace is
signalled by `nodep->ns` being `NULL`.