### PR TITLE
Fix for nowait.phpt failing intermittently

### DIFF
--- a/ext/sysvsem/tests/nowait.phpt
+++ b/ext/sysvsem/tests/nowait.phpt
@@ -67,12 +67,16 @@ if ($pid) {
 		exit;
 	}
 
+	/* Release the child semahpore before releasing
+	   the releasing the parent semaphore and letting
+	   the child continue execution */
+	sem_release($c_sem_id);
+
 	echo "P: releasing semaphore $p_sem_id.\n";
 	if (!sem_release($p_sem_id)) {
 		echo "P: failed to release semaphore\n";
 	}
 
-	sem_release($c_sem_id);
 	$status = null;
 	pcntl_waitpid($pid, $status);
 


### PR DESCRIPTION
The parent process was releasing the child semaphore
after the child process continued execution. Now
the child semaphore is released before the child
process continues execution.