### PR TITLE
Fix PDO tests to match SQL standard syntax and pass Firebird tests.

### DIFF
--- a/ext/pdo/tests/pdo_018.phpt
+++ b/ext/pdo/tests/pdo_018.phpt
@@ -71,7 +71,7 @@ $db->exec('CREATE TABLE classtypes(id int NOT NULL PRIMARY KEY, name VARCHAR(20)
 $db->exec('INSERT INTO classtypes VALUES(0, \'stdClass\')'); 
 $db->exec('INSERT INTO classtypes VALUES(1, \'TestBase\')'); 
 $db->exec('INSERT INTO classtypes VALUES(2, \'TestDerived\')'); 
-$db->exec('CREATE TABLE test(id int NOT NULL PRIMARY KEY, classtype int NULL, val VARCHAR(255) NULL)');
+$db->exec('CREATE TABLE test(id int NOT NULL PRIMARY KEY, classtype int, val VARCHAR(255))');
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/ext/pdo_firebird/tests/bug_72931.phpt
+++ b/ext/pdo_firebird/tests/bug_72931.phpt
@@ -10,7 +10,7 @@ $C->exec('create table tablea (id integer)');
 $S = $C->prepare('insert into tablea (id) values (1) returning id');
 $S->execute();
 $D = $S->fetch(PDO::FETCH_NUM);
-echo $D[0][0];
+echo $D[0];
 unset($S);
 unset($C);
 ?>
@@ -18,7 +18,7 @@ unset($C);
 <?php
 require 'testdb.inc';
 $C = new PDO('firebird:dbname='.$test_base, $user, $password) or die;
-$C->exec('DROP table tablea');
+$C->exec('drop table tablea');
 ?>
 --EXPECT--
 1


### PR DESCRIPTION
By default SQL field definition allow nulls. Explicit specification is required for "NOT null".