### PR TITLE
Increase realpath_cache_size default value

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -601,7 +601,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("allow_url_include",	"0",		PHP_INI_SYSTEM,		OnUpdateBool,		allow_url_include,		php_core_globals,		core_globals)
 	STD_PHP_INI_BOOLEAN("enable_post_data_reading",	"1",	PHP_INI_SYSTEM|PHP_INI_PERDIR,	OnUpdateBool,	enable_post_data_reading,	php_core_globals,	core_globals)
 
-	STD_PHP_INI_ENTRY("realpath_cache_size",	"16K",		PHP_INI_SYSTEM,		OnUpdateLong,	realpath_cache_size_limit,	virtual_cwd_globals,	cwd_globals)
+	STD_PHP_INI_ENTRY("realpath_cache_size",	"128K",		PHP_INI_SYSTEM,		OnUpdateLong,	realpath_cache_size_limit,	virtual_cwd_globals,	cwd_globals)
 	STD_PHP_INI_ENTRY("realpath_cache_ttl",		"120",		PHP_INI_SYSTEM,		OnUpdateLong,	realpath_cache_ttl,			virtual_cwd_globals,	cwd_globals)
 
 	STD_PHP_INI_ENTRY("user_ini.filename",		".user.ini",	PHP_INI_SYSTEM,		OnUpdateString,		user_ini_filename,	php_core_globals,		core_globals)

--- a/main/main.c
+++ b/main/main.c
@@ -601,7 +601,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("allow_url_include",	"0",		PHP_INI_SYSTEM,		OnUpdateBool,		allow_url_include,		php_core_globals,		core_globals)
 	STD_PHP_INI_BOOLEAN("enable_post_data_reading",	"1",	PHP_INI_SYSTEM|PHP_INI_PERDIR,	OnUpdateBool,	enable_post_data_reading,	php_core_globals,	core_globals)
 
-	STD_PHP_INI_ENTRY("realpath_cache_size",	"128K",		PHP_INI_SYSTEM,		OnUpdateLong,	realpath_cache_size_limit,	virtual_cwd_globals,	cwd_globals)
+	STD_PHP_INI_ENTRY("realpath_cache_size",	"4096K",	PHP_INI_SYSTEM,		OnUpdateLong,	realpath_cache_size_limit,	virtual_cwd_globals,	cwd_globals)
 	STD_PHP_INI_ENTRY("realpath_cache_ttl",		"120",		PHP_INI_SYSTEM,		OnUpdateLong,	realpath_cache_ttl,			virtual_cwd_globals,	cwd_globals)
 
 	STD_PHP_INI_ENTRY("user_ini.filename",		".user.ini",	PHP_INI_SYSTEM,		OnUpdateString,		user_ini_filename,	php_core_globals,		core_globals)

--- a/php.ini-development
+++ b/php.ini-development
@@ -338,7 +338,7 @@ disable_classes =
 ; be increased on systems where PHP opens many files to reflect the quantity of
 ; the file operations performed.
 ; http://php.net/realpath-cache-size
-;realpath_cache_size = 16k
+;realpath_cache_size = 4096k
 
 ; Duration of time, in seconds for which to cache realpath information for a given
 ; file or directory. For systems with rarely changing files, consider increasing this

--- a/php.ini-production
+++ b/php.ini-production
@@ -338,7 +338,7 @@ disable_classes =
 ; be increased on systems where PHP opens many files to reflect the quantity of
 ; the file operations performed.
 ; http://php.net/realpath-cache-size
-;realpath_cache_size = 16k
+;realpath_cache_size = 4096k
 
 ; Duration of time, in seconds for which to cache realpath information for a given
 ; file or directory. For systems with rarely changing files, consider increasing this


### PR DESCRIPTION
the realpath_cache_size can have a strong impact on performance when the cache is full. in times where a lot of classes can be loaded via composer etc. the 16k realpath_cache_size which is the default until now can easily get too small.

-------

**Summary of all numbers collected within this Issue/Thread:**

|app/framework|req. real-path-cache in bytes|
| --- | --- |
|symfony 3.2.1 demo [1]|`600 000`|
|laravel 5.3 demo  [2]|`130 000`|
|wordpress 4.7 plain[3]|`50 000`|

I can easily get a real-path-cache size of `600 000` when clicking tru the symfony-demo app[1] (using symfony 3.2.1).

with the laravel demo app[2] which is a simple blog with 5 content pages the real-path-cache size is about `130 000` (using laravel5.3).

a plain WP4.7[3] - after the setup and surfing thru all the admin-backend pages the realpath-cachesize is ~`50 000`. No plugins involved, no real content inside WP added/created. just the very basic setup with the bare minimum you get after the installation process.

the values are calculated using `var_dump(realpath_cache_size());` after clicking thru a few pages.
the current default for php is `16 000`.. as you see already for this very simple examples you get way more then the default can hold.

tested on ubuntu14lts with php7.0.14

[1] http://symfony.com/blog/introducing-the-symfony-demo-application
[2] https://github.com/bestmomo/laravel5-3-example
[3] https://wordpress.org/download/

**Proposed new default**: 4096K