### PR TITLE
Fix overrun in exif's "Illegal components" error message.

### DIFF
--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -3230,7 +3230,7 @@ static int exif_process_IFD_TAG(image_info_type *ImageInfo, char *dir_entry, cha
 	}
 
 	if (components <= 0) {
-		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal components(%ld)", tag, exif_get_tagname(tag, tagname, -12, tag_table), components);
+		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal components(%d)", tag, exif_get_tagname(tag, tagname, -12, tag_table), components);
 		return FALSE;
 	}
 

--- a/ext/exif/tests/bug73737.phpt
+++ b/ext/exif/tests/bug73737.phpt
@@ -8,7 +8,7 @@ Bug #73737 (Crash when parsing a tag format)
 	var_dump($exif);
 ?>
 --EXPECTF--
-Warning: exif_thumbnail(bug73737.tiff): Process tag(x0100=ImageWidth ): Illegal components(%i) in %s on line %d
+Warning: exif_thumbnail(bug73737.tiff): Process tag(x0100=ImageWidth ): Illegal components(0) in %s on line %d
 
 Warning: exif_thumbnail(bug73737.tiff): Error in TIFF: filesize(x0030) less than start of IFD dir(x10102) in %s line %d
 bool(false)


### PR DESCRIPTION
The variables "components" is an integer, but is being
output as long. As a result it is printing 8 bytes
instead of 4 bytes.

https://travis-ci.org/php/php-src/jobs/188590337
```
========DIFF========
001+ Warning: exif_thumbnail(bug73737.tiff): Process tag(x0100=ImageWidth ): Illegal components(-9223372019674906624) in /home/travis/build/php/php-src/ext/exif/tests/bug73737.php on line 2
001- Warning: exif_thumbnail(bug73737.tiff): Process tag(x0100=ImageWidth ): Illegal components(0) in %s on line %d
========DONE========
```
Above a 64bit integer (-9223372019674906624) is being displayed but the variable `components` is only 32bits.
