### PR TITLE
Fix bug #55138 PDO OCI cannot insert more than 1332 bytes

### DIFF
--- a/ext/pdo_oci/oci_statement.c
+++ b/ext/pdo_oci/oci_statement.c
@@ -333,11 +333,8 @@ static int oci_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *pa
 					case PDO_PARAM_STR:
 					default:
 						P->oci_type = SQLT_CHR;
-						value_sz = (sb4) param->max_value_len;
-						if (param->max_value_len == 0) {
-							value_sz = (sb4) 1332; /* maximum size before value is interpreted as a LONG value */
-						}
-
+						/* we can provide as much data as value_sz can fit */
+						value_sz = SB4MAXVAL;
 				}
 
 				if (param->name) {

--- a/ext/pdo_oci/tests/bug55138.phpt
+++ b/ext/pdo_oci/tests/bug55138.phpt
@@ -1,0 +1,27 @@
+--TEST--
+PDO OCI Bug #55138 (cannot insert more than 1332 one byte chars in al32utf8 varchar2 field)
+--SKIPIF--
+<?php
+/* $Id$ */
+if (!extension_loaded('pdo') || !extension_loaded('pdo_oci')) die('skip not loaded');
+require dirname(__FILE__).'/../../pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require 'ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+
+$db->exec("CREATE TABLE test(test VARCHAR2(2000))");
+$statement = $db->prepare("INSERT INTO test VALUES(:test)");
+$test = str_repeat("F", 2000);
+$statement->bindParam(":test", $test);
+$result = $statement->execute();
+var_dump($result);
+
+$data = $db->query('SELECT * FROM test')->fetchAll();
+$result = ($test === $data[0][0]);
+var_dump($result);
+--EXPECTF--
+bool(true)
+bool(true)


### PR DESCRIPTION
Replacement for issue #633 