### PR TITLE
Test request47456.phpt for PR 1303

### DIFF
--- a/ext/pcre/tests/request47456.phpt
+++ b/ext/pcre/tests/request47456.phpt
@@ -34,11 +34,11 @@ array(3) {
     ["chr"]=>
     string(1) "b"
     [1]=>
-    string(0) ""
+    NULL
     ["num"]=>
-    string(0) ""
+    NULL
     [2]=>
-    string(0) ""
+    NULL
     [3]=>
     string(1) "b"
   }
@@ -77,11 +77,11 @@ array(3) {
     ["chr"]=>
     string(1) "b"
     [1]=>
-    string(0) ""
+    NULL
     ["num"]=>
-    string(0) ""
+    NULL
     [2]=>
-    string(0) ""
+    NULL
     [3]=>
     string(1) "b"
   }


### PR DESCRIPTION
After merging https://github.com/php/php-src/pull/1303 unmatched subpatterns are set to NULL.

The test `ext/pcre/tests/request47456.phpt`  was created after the PR was created.



