### PR TITLE
Fix #70103: Fix bug 70103 when ZTS is enabled

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1699,18 +1699,18 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 						zval_ptr_dtor(return_value);
 						RETURN_FALSE;
 					}
-
 					snprintf(entry_name_buf, MAXPATHLEN, "%s%s", add_path, file_stripped);
-					entry_name = entry_name_buf;
-					entry_name_len = strlen(entry_name);
 				} else {
-					entry_name = file_stripped;
-					entry_name_len = file_stripped_len;
+					snprintf(entry_name_buf, MAXPATHLEN, "%s", file_stripped);
 				}
+
+				entry_name = entry_name_buf;
+				entry_name_len = strlen(entry_name);
 				if (basename) {
 					zend_string_release(basename);
 					basename = NULL;
 				}
+
 				if (php_zip_add_file(intern, Z_STRVAL_P(zval_file), Z_STRLEN_P(zval_file),
 					entry_name, entry_name_len, 0, 0) < 0) {
 					zval_dtor(return_value);


### PR DESCRIPTION
Used snprintf to copy the basename string before it is freed

```
========DIFF========
002+ string(6) "hp-src"
002- string(7) "foo.txt"
========DONE========
FAIL Bug #70103 (ZipArchive::addGlob ignores remove_all_path option) [ext/zip/tests/bug70103.phpt] 
```
https://travis-ci.org/php/php-src/jobs/189428235