### PR TITLE
Fixes for session and fpm tests in PHP7.0 branch

### DIFF
--- a/ext/session/tests/save_handler.inc
+++ b/ext/session/tests/save_handler.inc
@@ -53,7 +53,7 @@ function gc($maxlifetime) {
     while (($file = readdir($directory)) !== FALSE) {
         $qualified = ($session_save_path."/".$file); 
         if (is_file($qualified) === TRUE) {
-            if (substr($file, 0, $length) === SESSION_FILE_PREFIX) {
+            if (substr($file, 0, $length) === SESSION_FILE_PREFIX && (filemtime($qualified) + $maxlifetime <= time() )) {
                 unlink($qualified);
             }
         }

--- a/ext/session/tests/session_set_save_handler_basic.phpt
+++ b/ext/session/tests/session_set_save_handler_basic.phpt
@@ -3,6 +3,7 @@ Test session_set_save_handler() function : basic functionality
 --INI--
 session.save_path=
 session.name=PHPSESSID
+session.gc_probability=0
 --SKIPIF--
 <?php include('skipif.inc'); ?>
 --FILE--

--- a/sapi/fpm/tests/002.phpt
+++ b/sapi/fpm/tests/002.phpt
@@ -26,8 +26,8 @@ $fpm = run_fpm($cfg, $tail);
 if (is_resource($fpm)) {
     fpm_display_log($tail, 2);
     $i = 0;
-    while (($i++ < 30) && !($fp = @fsockopen('127.0.0.1', $port))) {
-        usleep(10000);
+    while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port))) {
+        usleep(25000);
     }
     if ($fp) {
         echo "Done\n";

--- a/sapi/fpm/tests/003.phpt
+++ b/sapi/fpm/tests/003.phpt
@@ -29,8 +29,8 @@ $fpm = run_fpm($cfg, $tail);
 if (is_resource($fpm)) {
     fpm_display_log($tail, 2);
     $i = 0;
-    while (($i++ < 30) && !($fp = fsockopen('[::1]', $port))) {
-        usleep(10000);
+    while (($i++ < 60) && !($fp = fsockopen('[::1]', $port))) {
+        usleep(25000);
     }
     if ($fp) {
         echo "Done\n";

--- a/sapi/fpm/tests/004.phpt
+++ b/sapi/fpm/tests/004.phpt
@@ -29,15 +29,15 @@ $fpm = run_fpm($cfg, $tail);
 if (is_resource($fpm)) {
     fpm_display_log($tail, 2);
     $i = 0;
-    while (($i++ < 30) && !($fp = @fsockopen('127.0.0.1', $port))) {
-        usleep(10000);
+    while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port))) {
+        usleep(25000);
     }
     if ($fp) {
         echo "Done IPv4\n";
         fclose($fp);
     }
-    while (($i++ < 30) && !($fp = @fsockopen('[::1]', $port))) {
-        usleep(10000);
+    while (($i++ < 60) && !($fp = @fsockopen('[::1]', $port))) {
+        usleep(25000);
     }
     if ($fp) {
         echo "Done IPv6\n";

--- a/sapi/fpm/tests/013.phpt
+++ b/sapi/fpm/tests/013.phpt
@@ -27,8 +27,8 @@ EOT;
 $fpm = run_fpm($cfg, $tail);
 if (is_resource($fpm)) {
     $i = 0;
-	while (($i++ < 30) && !($fp = @fsockopen('127.0.0.1', $port))) {
-		usleep(10000);
+	while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port))) {
+		usleep(25000);
 	}
 	if ($fp) {
 		echo "Started\n";

--- a/sapi/fpm/tests/014.phpt
+++ b/sapi/fpm/tests/014.phpt
@@ -27,8 +27,8 @@ EOT;
 $fpm = run_fpm($cfg, $tail);
 if (is_resource($fpm)) {
     $i = 0;
-	while (($i++ < 30) && !($fp = @fsockopen('127.0.0.1', $port))) {
-		usleep(10000);
+	while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port))) {
+		usleep(25000);
 	}
 	if ($fp) {
 		echo "Started\n";

--- a/sapi/fpm/tests/015.phpt
+++ b/sapi/fpm/tests/015.phpt
@@ -42,8 +42,8 @@ EOT;
 $fpm = run_fpm($cfg, $tail);
 if (is_resource($fpm)) {
     $i = 0;
-	while (($i++ < 30) && !($fp = @fsockopen('127.0.0.1', $port1))) {
-		usleep(10000);
+	while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port1))) {
+		usleep(25000);
 	}
 	if ($fp) {
 		echo "Started\n";


### PR DESCRIPTION
1. Increased the timeout on sapi/fpm tests to match the cli server
2. Disabled session GC in session_set_save_handler_basic.phpt
3. Fixed GC in save_handler.inc to delete files based on age

This PR is for the PHP7.0 branch.