### PR TITLE
Revert "Test request47456.phpt for PR 1303" on PHP-7.0 and PHP-7.1

### DIFF
--- a/ext/pcre/tests/request47456.phpt
+++ b/ext/pcre/tests/request47456.phpt
@@ -34,11 +34,11 @@ array(3) {
     ["chr"]=>
     string(1) "b"
     [1]=>
-    NULL
+    string(0) ""
     ["num"]=>
-    NULL
+    string(0) ""
     [2]=>
-    NULL
+    string(0) ""
     [3]=>
     string(1) "b"
   }
@@ -77,11 +77,11 @@ array(3) {
     ["chr"]=>
     string(1) "b"
     [1]=>
-    NULL
+    string(0) ""
     ["num"]=>
-    NULL
+    string(0) ""
     [2]=>
-    NULL
+    string(0) ""
     [3]=>
     string(1) "b"
   }


### PR DESCRIPTION
This reverts commit e55e93a1e335bec39b7edb28f0b8470fa974f4e3.
This change should only apply to master. Not PHP-7.0 or PHP-7.1

https://github.com/php/php-src/pull/1303 was only applied to master. The test changes should be reverted from branches PHP-7.0 and PHP-7.1. 