### PR TITLE
improve FPM tests (mostly for systemd build)

### DIFF
--- a/sapi/fpm/tests/008.phpt
+++ b/sapi/fpm/tests/008.phpt
@@ -6,6 +6,7 @@ include "skipif.inc";
 
 $cfg = <<<EOT
 [global]
+error_log = /dev/null
 [poold_ondemand]
 listen=127.0.0.1:9000
 pm = ondemand

--- a/sapi/fpm/tests/015.phpt
+++ b/sapi/fpm/tests/015.phpt
@@ -62,9 +62,7 @@ if (is_resource($fpm)) {
 		echo "Error 2\n";
 	}
 	proc_terminate($fpm);
-	if (!feof($tail)) {
-		echo stream_get_contents($tail);
-	}
+	fpm_display_log($tail, -1);
 	fclose($tail);
 	proc_close($fpm);
 }
@@ -79,7 +77,7 @@ Error 2
 [%s] NOTICE: fpm is running, pid %d
 [%s] NOTICE: ready to handle connections
 [%s] WARNING: [pool pool2] child %d said into stderr: "ERROR: Wrong IP address 'xxx' in listen.allowed_clients"
-[%s] WARNING: [pool pool2] child %d said into stderr: "ERROR: There are no allowed addresses for this pool"
+[%s] WARNING: [pool pool2] child %d said into stderr: "ERROR: There are no allowed %s"
 [%s] WARNING: [pool pool2] child %d said into stderr: "ERROR: Connection disallowed: IP address '127.0.0.1' has been dropped."
 [%s] NOTICE: Terminating ...
 [%s] NOTICE: exiting, bye-bye!

--- a/sapi/fpm/tests/016.phpt
+++ b/sapi/fpm/tests/016.phpt
@@ -6,6 +6,7 @@ include "skipif.inc";
 
 $cfg = <<<EOT
 [global]
+error_log = /dev/null
 [poold_ondemand]
 listen=127.0.0.1:9000
 pm = ondemand
@@ -65,9 +66,7 @@ if (is_resource($fpm)) {
 		}
 	}
 	proc_terminate($fpm);
-	if (!feof($tail)) {
-		echo stream_get_contents($tail);
-	}
+	fpm_display_log($tail, -1);
 	fclose($tail);
 	proc_close($fpm);
 }

--- a/sapi/fpm/tests/017.phpt
+++ b/sapi/fpm/tests/017.phpt
@@ -42,7 +42,7 @@ if (is_resource($fpm)) {
 		echo "Request error\n";
 	}
     proc_terminate($fpm);
-    echo stream_get_contents($tail);
+    fpm_display_log($tail, -1);
     fclose($tail);
     proc_close($fpm);
 }

--- a/sapi/fpm/tests/019.phpt
+++ b/sapi/fpm/tests/019.phpt
@@ -46,7 +46,7 @@ if (is_resource($fpm)) {
 	printf("File %s %s\n", $pidfile, (file_exists(__DIR__.'/'.$pidfile) ? "exists" : "missing"));
 
 	proc_terminate($fpm);
-	echo stream_get_contents($tail);
+    fpm_display_log($tail, -1);
     fclose($tail);
     proc_close($fpm);
 	printf("File %s %s\n", $pidfile, (file_exists(__DIR__.'/'.$pidfile) ? "still exists" : "removed"));

--- a/sapi/fpm/tests/020.phpt
+++ b/sapi/fpm/tests/020.phpt
@@ -46,7 +46,7 @@ if (is_resource($fpm)) {
 	printf("File %s %s\n", $slwfile, (file_exists(__DIR__.'/'.$slwfile) ? "exists" : "missing"));
 
 	proc_terminate($fpm);
-	echo stream_get_contents($tail);
+    fpm_display_log($tail, -1);
     fclose($tail);
     proc_close($fpm);
 	readfile(__DIR__.'/'.$accfile);

--- a/sapi/fpm/tests/021-uds-acl.phpt
+++ b/sapi/fpm/tests/021-uds-acl.phpt
@@ -6,11 +6,17 @@ include "skipif.inc";
 if (!(file_exists('/usr/bin/getfacl') && file_exists('/etc/passwd') && file_exists('/etc/group'))) die ("skip missing getfacl command");
 $cfg = <<<EOT
 [global]
+error_log = /dev/null
 [unconfined]
 listen = 127.0.0.1:9999
 listen.acl_users = nobody
 listen.acl_groups = nobody
 listen.mode = 0600
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
 EOT;
 if (test_fpm_conf($cfg, $msg) == false) { die("skip " .  $msg); }
 ?>
@@ -66,7 +72,7 @@ if (is_resource($fpm)) {
 	passthru("/usr/bin/getfacl -cp $socket");
 
 	proc_terminate($fpm);
-    echo stream_get_contents($tail);
+    fpm_display_log($tail, -1);
     fclose($tail);
     proc_close($fpm);
 }

--- a/sapi/fpm/tests/022-cve-2016-5385.phpt
+++ b/sapi/fpm/tests/022-cve-2016-5385.phpt
@@ -51,7 +51,7 @@ if (is_resource($fpm)) {
 		echo "Request error\n";
 	}
     proc_terminate($fpm);
-    echo stream_get_contents($tail);
+    fpm_display_log($tail, -1);
     fclose($tail);
     proc_close($fpm);
 }

--- a/sapi/fpm/tests/include.inc
+++ b/sapi/fpm/tests/include.inc
@@ -89,7 +89,8 @@ function run_fpm_till($needle, $config, $max = 10) /* {{{ */
 /* }}} */
 
 function fpm_display_log($tail, $n=1, $ignore='systemd') { /* {{{ */
-	while ($n) {
+	/* Read $n lines or until EOF */
+	while ($n>0 || ($n<0 && !feof($tail))) {
 		$a = fgets($tail);
 		if (empty($ignore) || !strpos($a, $ignore)) {
 			echo $a;


### PR DESCRIPTION
Mostly to ignore "systemd" line: replace stream_get_contents with fpm_display_log (improved to read n lines or until EOF)

Also fix bad config in SKIP section.

With this patch, and ./configure --enable-fpm --with-fpm-systemd --with-fpm-acl

```
=====================================================================
Number of tests :   22                21
Tests skipped   :    1 (  4.5%) --------
Tests warned    :    2 (  9.1%) (  9.5%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :   19 ( 86.4%) ( 90.5%)
---------------------------------------------------------------------
Time taken      :    1 seconds
=====================================================================

```

With  ./configure --enable-fpm  (no systemd and no acl)
```
=====================================================================
Number of tests :   22                20
Tests skipped   :    2 (  9.1%) --------
Tests warned    :    2 (  9.1%) ( 10.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :   18 ( 81.8%) ( 90.0%)
---------------------------------------------------------------------
Time taken      :    1 seconds
=====================================================================

```
