### PR TITLE
Fix FTP tests for Travis CI.

### DIFF
--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -7,7 +7,7 @@ $context = stream_context_create(array('ssl' => array('local_cert' => dirname(__
 for ($i=0; $i<10 && !$socket; ++$i) {
 	$port = rand(50000, 65535);
 	
-	$socket = stream_socket_server("tcp://127.0.0.1:$port", $errno, $errstr, STREAM_SERVER_BIND|STREAM_SERVER_LISTEN, $context);
+	@$socket = stream_socket_server("tcp://127.0.0.1:$port", $errno, $errstr, STREAM_SERVER_BIND|STREAM_SERVER_LISTEN, $context);
 }
 //set anther random port that is not the same as $port
 do{
@@ -15,6 +15,7 @@ do{
 }while($pasv_port == $port);
 
 if (!$socket) {
+	echo "$errstr ($errno)\n";
 	die("could not start/bind the ftp server\n");
 }
 


### PR DESCRIPTION
This suppresses the errors from stream_socket_server() until
server.inc will not make anymore attempts.

Here is an example:
https://travis-ci.org/php/php-src/jobs/189706040
```
========DIFF========
001+ Warning: stream_socket_server(): unable to connect to tcp://127.0.0.1:58558 (Address already in use) in /home/travis/build/php/php-src/ext/ftp/tests/server.inc on line 10
========DONE========
```

The test was successful but it output a warning after its first attempt at `stream_socket_server()` failed.