### PR TITLE
Add print zend string function to gdbinit

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -554,6 +554,18 @@ document printzops
 	dump operands of the current opline
 end
 
+define print_zstr
+	set $zstr = (zend_string *)$arg0
+	printf "string(%d) ", $zstr->len
+	____print_str $zstr->val $zstr->len
+	printf "\n"
+end
+
+document print_zstr
+	print the length and contents of a zend string
+	usage: print_zstr [ptr]
+end
+
 define zbacktrace
 	____executor_globals
 	dump_bt $eg.current_execute_data


### PR DESCRIPTION
I have been digging around in a core dump and I found having a function to print zend_strings useful. 

Usage example:
```
(gdb) print_zstr 0x7ff967402a50
length (9): "microtime"
```