### PR TITLE
Add support for "xfailif" to phpt SKIPIF sections

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1609,6 +1609,11 @@ TEST $file
 					$info = " (warn: $m[1])";
 				}
 			}
+
+			if (!strncasecmp('xfail', ltrim($output), 5)) {
+				// Pretend we have an XFAIL section
+				$section_text['XFAIL'] = trim(substr(ltrim($output), 5));
+			}
 		}
 	}
 


### PR DESCRIPTION
If SKIPIF output starts with "xfail" instead of "skip", the test
will be marked as XFAIL with the following message. Example:

    --TEST--
    Test xfailif feature
    --SKIPIF--
    <?php
    if (some_cond()) die('xfail Expected to fail!');
    ?>
    --FILE--
    ...