### PR TITLE
Prevent fd leak in readdir_r that causes false negative on readdir_r

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1365,8 +1365,11 @@ main() {
   dir = opendir("/");
   if (!dir) 
     exit(1);
-  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0)
+  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0) {
+    close(dir);
     exit(0);
+  }
+  close(dir);
   exit(1);
 }
     ],[


### PR DESCRIPTION
When compiled with AddressSanitizer this check for readdir_r implementation fails because it leaks dir file descriptor:

```
=================================================================
==116155==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32816 byte(s) in 1 object(s) allocated from:
    #0 0x4d1648 in __interceptor_malloc (/home/ondrej/Projects/pkg-php/php-src/conftest+0x4d1648)
    #1 0x7f73f0639623  (/lib/x86_64-linux-gnu/libc.so.6+0xb3623)

SUMMARY: AddressSanitizer: 32816 byte(s) leaked in 1 allocation(s).
```

This causes false negative on POSIX readdir_r implementation causing a build failure later.