### PR TITLE
Fixed bug #61858 (DOMAttr debug info generates E_WARNING)

### DIFF
--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -213,7 +213,7 @@ Since: DOM Level 3
 */
 int dom_attr_schema_type_info_read(dom_object *obj, zval *retval)
 {
-	php_error_docref(NULL, E_WARNING, "Not yet implemented");
+	/* TODO */
 	ZVAL_NULL(retval);
 	return SUCCESS;
 }

--- a/ext/dom/tests/bug61858.phpt
+++ b/ext/dom/tests/bug61858.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #61858 DOMAttr debug info generates E_WARNING
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$doc = new DOMDocument();
+$doc->loadXML('<example a="b">Test</example>');
+
+$example = $doc->getElementsByTagName('example')->item(0);
+$attr    = $example->getAttributeNode('a');
+
+var_dump($attr);
+print_r($attr);
+--EXPECTF--
+object(DOMAttr)#%d (%d) {
+%A
+}
+DOMAttr Object
+(
+%A
+)


### PR DESCRIPTION
It seems fair to remove this warning, given that:

* it is not documented in the official documentation
* the $specified property, which has a similar 'not implemented' status,
  also does not trigger a warning
* it apparently hinders quite a lot of people during debugging, judging by
  the number of votes on the bug