### PR TITLE
added a note to opache.fast_shutdown why its not enabled by default

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1805,6 +1805,7 @@ ldap.max_links = -1
 ;opcache.save_comments=1
 
 ; If enabled, a fast shutdown sequence is used for the accelerated code
+; Depending on the used Memory Manager this may cause some incompatibilities.
 ;opcache.fast_shutdown=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.

--- a/php.ini-production
+++ b/php.ini-production
@@ -1805,6 +1805,7 @@ ldap.max_links = -1
 ;opcache.save_comments=1
 
 ; If enabled, a fast shutdown sequence is used for the accelerated code
+; Depending on the used Memory Manager this may cause some incompatibilities.
 ;opcache.fast_shutdown=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.


### PR DESCRIPTION
fixes the last remaing part of php-bug 73726.

the other settings were already fix by PR
https://github.com/php/php-src/pull/2291

note taken from https://github.com/php/php-src/pull/2238#issuecomment-271219770