### PR TITLE
Increase wait time for tests involving sockets to improve Travis reliability

### DIFF
--- a/ext/curl/tests/bug64267.phpt
+++ b/ext/curl/tests/bug64267.phpt
@@ -17,8 +17,8 @@ var_dump(curl_setopt_array($c, [
 	CURLOPT_UPLOAD => true,
 	CURLOPT_INFILE => $f,
 	CURLOPT_INFILESIZE => filesize(__FILE__),
-	CURLOPT_CONNECTTIMEOUT => 1,
-	CURLOPT_TIMEOUT => 1,
+	CURLOPT_CONNECTTIMEOUT => 3,
+	CURLOPT_TIMEOUT => 3,
 ]));
 fclose($f);
 var_dump(curl_setopt_array($c, [

--- a/ext/curl/tests/server.inc
+++ b/ext/curl/tests/server.inc
@@ -33,9 +33,9 @@ function curl_cli_server_start() {
 	
     // note: even when server prints 'Listening on localhost:8964...Press Ctrl-C to quit.'
     //       it might not be listening yet...need to wait until fsockopen() call returns
-    $error = "Unable to connect to servers\n";
+    $error = "Unable to connect to server\n";
     for ($i=0; $i < 60; $i++) {
-        usleep(25000); // 25ms per try
+        usleep(50000); // 50ms per try
         $status = proc_get_status($handle);
         $fp = @fsockopen(PHP_CURL_SERVER_HOSTNAME, PHP_CURL_SERVER_PORT);
         // Failure, the server is no longer running
@@ -63,6 +63,14 @@ function curl_cli_server_start() {
     register_shutdown_function(
         function($handle) use($router) {
             proc_terminate($handle);
+            /* Wait for server to shutdown */
+            for ($i = 0; $i < 60; $i++) {
+                $status = proc_get_status($handle);
+                if (!($status && $status['running'])) {
+                    break;
+                }
+                usleep(50000);
+            }
         },
         $handle
     );

--- a/ext/opcache/tests/php_cli_server.inc
+++ b/ext/opcache/tests/php_cli_server.inc
@@ -23,9 +23,9 @@ function php_cli_server_start($ini = "") {
 
 	// note: even when server prints 'Listening on localhost:8964...Press Ctrl-C to quit.'
 	//       it might not be listening yet...need to wait until fsockopen() call returns
-	$error = "Unable to connect to servers\n";
+	$error = "Unable to connect to server\n";
 	for ($i=0; $i < 60; $i++) {
-		usleep(25000); // 25ms per try
+		usleep(50000); // 50ms per try
 		$status = proc_get_status($handle);
 		$fp = @fsockopen(PHP_CLI_SERVER_HOSTNAME, PHP_CLI_SERVER_PORT);
 		// Failure, the server is no longer running
@@ -53,6 +53,14 @@ function php_cli_server_start($ini = "") {
 	register_shutdown_function(
 		function($handle) {
 			proc_terminate($handle);
+			/* Wait for server to shutdown */
+			for ($i = 0; $i < 60; $i++) {
+				$status = proc_get_status($handle);
+				if (!($status && $status['running'])) {
+					break;
+				}
+			usleep(50000);
+			}
 		},
 		$handle
 	);

--- a/sapi/cli/tests/php_cli_server.inc
+++ b/sapi/cli/tests/php_cli_server.inc
@@ -36,9 +36,9 @@ function php_cli_server_start($code = 'echo "Hello world";', $router = 'index.ph
 
     // note: even when server prints 'Listening on localhost:8964...Press Ctrl-C to quit.'
     //       it might not be listening yet...need to wait until fsockopen() call returns
-    $error = "Unable to connect to servers\n";
+    $error = "Unable to connect to server\n";
     for ($i=0; $i < 60; $i++) {
-        usleep(25000); // 25ms per try
+        usleep(50000); // 50ms per try
         $status = proc_get_status($handle);
         $fp = @fsockopen(PHP_CLI_SERVER_HOSTNAME, PHP_CLI_SERVER_PORT);
         // Failure, the server is no longer running
@@ -85,7 +85,7 @@ function php_cli_server_stop($handle) {
                 $success = TRUE;
                 break;
             }
-            usleep(25000);
+            usleep(50000);
         }
     }
     return $success;

--- a/sapi/fpm/tests/002.phpt
+++ b/sapi/fpm/tests/002.phpt
@@ -27,7 +27,7 @@ if (is_resource($fpm)) {
     fpm_display_log($tail, 2);
     $i = 0;
     while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port))) {
-        usleep(25000);
+        usleep(50000);
     }
     if ($fp) {
         echo "Done\n";

--- a/sapi/fpm/tests/003.phpt
+++ b/sapi/fpm/tests/003.phpt
@@ -30,7 +30,7 @@ if (is_resource($fpm)) {
     fpm_display_log($tail, 2);
     $i = 0;
     while (($i++ < 60) && !($fp = fsockopen('[::1]', $port))) {
-        usleep(25000);
+        usleep(50000);
     }
     if ($fp) {
         echo "Done\n";

--- a/sapi/fpm/tests/004.phpt
+++ b/sapi/fpm/tests/004.phpt
@@ -30,14 +30,14 @@ if (is_resource($fpm)) {
     fpm_display_log($tail, 2);
     $i = 0;
     while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port))) {
-        usleep(25000);
+        usleep(50000);
     }
     if ($fp) {
         echo "Done IPv4\n";
         fclose($fp);
     }
     while (($i++ < 60) && !($fp = @fsockopen('[::1]', $port))) {
-        usleep(25000);
+        usleep(50000);
     }
     if ($fp) {
         echo "Done IPv6\n";

--- a/sapi/fpm/tests/013.phpt
+++ b/sapi/fpm/tests/013.phpt
@@ -28,7 +28,7 @@ $fpm = run_fpm($cfg, $tail);
 if (is_resource($fpm)) {
     $i = 0;
 	while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port))) {
-		usleep(25000);
+		usleep(50000);
 	}
 	if ($fp) {
 		echo "Started\n";

--- a/sapi/fpm/tests/014.phpt
+++ b/sapi/fpm/tests/014.phpt
@@ -28,7 +28,7 @@ $fpm = run_fpm($cfg, $tail);
 if (is_resource($fpm)) {
     $i = 0;
 	while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port))) {
-		usleep(25000);
+		usleep(50000);
 	}
 	if ($fp) {
 		echo "Started\n";

--- a/sapi/fpm/tests/015.phpt
+++ b/sapi/fpm/tests/015.phpt
@@ -43,7 +43,7 @@ $fpm = run_fpm($cfg, $tail);
 if (is_resource($fpm)) {
     $i = 0;
 	while (($i++ < 60) && !($fp = @fsockopen('127.0.0.1', $port1))) {
-		usleep(25000);
+		usleep(50000);
 	}
 	if ($fp) {
 		echo "Started\n";


### PR DESCRIPTION
1. Increased sleep time from 25ms to 50ms
2. Added sleep to shutdown handlers

The previous changes to these tests made them much more reliable in Travis. Hopefully
these changes make them very reliable. 