### PR TITLE
Fix #73886: Handle access log & error log on Docker

### DIFF
--- a/sapi/fpm/fpm/fpm_stdio.c
+++ b/sapi/fpm/fpm/fpm_stdio.c
@@ -32,7 +32,7 @@ int fpm_stdio_init_main() /* {{{ */
 		return -1;
 	}
 
-	if (0 > dup2(fd, STDIN_FILENO) || 0 > dup2(fd, STDOUT_FILENO)) {
+	if (0 > dup2(fd, STDIN_FILENO)) {
 		zlog(ZLOG_SYSERROR, "failed to init stdio: dup2()");
 		close(fd);
 		return -1;


### PR DESCRIPTION
Seems a bit odd to set the stdout to /dev/null making it unusable for logs.
I could not find any reason why it is like this other then the commit b172c7dc7c27032dc2b50c0f77ebb4bf54622941 and 4d005a8e65c2753565493f761fc3302d97f0e408 where @tony2001 added the FPM sapi.