### PR TITLE
Permit trailing whitespace in numeric strings

### DIFF
--- a/Zend/tests/trailing_whitespace_numeric_strings.phpt
+++ b/Zend/tests/trailing_whitespace_numeric_strings.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Acceptance of whitespace in numeric strings
+--FILE--
+<?php
+
+$strings = [
+    "123",
+    "123   ",
+    "123 \t\n\r\v\f",
+    "   123",
+    " \t\n\r\v\f123",
+    "   123   ",
+    " \t\n\r\v\f123 \t\n\r\v\f",
+    "123.0",
+    "123.0   ",
+    "123.0 \t\n\r\v\f",
+    "   123.0",
+    " \t\n\r\v\f123.0",
+    "   123.0   ",
+    " \t\n\r\v\f123 \t\n\r\v\f",
+    "123e0",
+    "123e0   ",
+    "123e0 \t\n\r\v\f",
+    "   123e0",
+    " \t\n\r\v\f123e0",
+    "   123e0   ",
+    " \t\n\r\v\f123e0 \t\n\r\v\f"
+];
+
+function takes_integer(int $i) {
+    \assert($i === 123);
+}
+function takes_float(float $f) {
+    \assert($f === 123.0);
+}
+
+foreach ($strings as $string) {
+    \assert($string == 123);
+    $num = +$string;
+    \assert($num == 123);
+    takes_integer($string);
+    takes_float($string);
+    \assert(\intdiv($string, 1) === 123);
+    \assert(\is_numeric($string));
+    $incremented = $string;
+    ++$incremented;
+    \assert(\is_int($incremented) || \is_float($incremented));
+    \assert($incremented == 124);
+    $decremented = $string;
+    --$decremented;
+    \assert(\is_int($decremented) || \is_float($decremented));
+    \assert($decremented == 122);
+}
+
+echo "OK!", PHP_EOL;
+
+?>
+--EXPECT--
+OK!

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -3077,11 +3077,19 @@ process_double:
 	}
 
 	if (ptr != str + length) {
-		if (!allow_errors) {
-			return 0;
+		const char *endptr = ptr;
+		while (*endptr == ' ' || *endptr == '\t' || *endptr == '\n' || *endptr == '\r' || *endptr == '\v' || *endptr == '\f') {
+			endptr++;
+			length--;
 		}
-		if (allow_errors == -1) {
-			zend_error(E_NOTICE, "A non well formed numeric value encountered");
+
+		if (ptr != str + length) {
+			if (!allow_errors) {
+				return 0;
+			}
+			if (allow_errors == -1) {
+				zend_error(E_NOTICE, "A non well formed numeric value encountered");
+			}
 		}
 	}
 

--- a/ext/standard/tests/general_functions/is_numeric.phpt
+++ b/ext/standard/tests/general_functions/is_numeric.phpt
@@ -78,6 +78,7 @@ $numerics = array(
   '-1',
   '1e2',
   ' 1',
+  "1 ",
   '2974394749328742328432',
   '-1e-2',
   "0123",
@@ -118,7 +119,6 @@ $not_numerics = array(
   array(),
   array("string"),
   "",
-  "1 ",
   "- 1",
   "1.2.4",
   "1e7.6",
@@ -313,6 +313,8 @@ bool(true)
 bool(true)
 -- Iteration 76 --
 bool(true)
+-- Iteration 77 --
+bool(true)
 
 *** Testing is_numeric() on non numeric types ***
 -- Iteration 1 --
@@ -370,8 +372,6 @@ bool(false)
 -- Iteration 27 --
 bool(false)
 -- Iteration 28 --
-bool(false)
--- Iteration 29 --
 bool(false)
 
 *** Testing error conditions ***


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/trailing_whitespace_numerics

This is a language change, if a tiny one.