### PR TITLE
Remove remnants of TSMRLS_* macro calls

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1961,7 +1961,7 @@ static int php_cli_server_begin_send_static(php_cli_server *server, php_cli_serv
 	if (client->request.path_translated &&
 		('.' == client->request.path_translated[client->request.path_translated_len-1] ||
 		 ' ' == client->request.path_translated[client->request.path_translated_len-1])) {
-		return php_cli_server_send_error_page(server, client, 500 TSRMLS_CC);
+		return php_cli_server_send_error_page(server, client, 500);
 	}
 #endif
 

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -872,7 +872,7 @@ static int lsapi_activate_user_ini_finally(_lsapi_activate_user_ini_ctx *ctx,
     return rc;
 }
 
-static int lsapi_activate_user_ini(TSRMLS_D)
+static int lsapi_activate_user_ini( void )
 {
     _lsapi_activate_user_ini_ctx ctx;
     /**


### PR DESCRIPTION
@weltling Just confirming that the `TSRMLS_D` macro call in litespeed was simply missed, and not intentionally left.