### PR TITLE
Update comment, incorrect since 224aaf94

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -425,8 +425,7 @@ static void php_session_initialize(void) /* {{{ */
 	php_session_track_init();
 	if (PS(mod)->s_read(&PS(mod_data), PS(id), &val, PS(gc_maxlifetime)) == FAILURE) {
 		php_session_abort();
-		/* Some broken save handler implementation returns FAILURE for non-existent session ID */
-		/* It's better to raise error for this, but disabled error for better compatibility */
+		/* FYI: Some broken save handlers return FAILURE for non-existent session ID, this is incorrect */
 		php_error_docref(NULL, E_WARNING, "Failed to read session data: %s (path: %s)", PS(mod)->s_name, PS(save_path));
 		return;
 	}


### PR DESCRIPTION
In 224aaf94; the warning was enabled; making the comment above incorrect. I've updated the comment to reflect the current code