### PR TITLE
Use hash_ops->is_crypto in hash_init()

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -350,6 +350,11 @@ PHP_FUNCTION(hash_init)
 		RETURN_FALSE;
 	}
 
+	if (options & PHP_HASH_HMAC && !ops->is_crypto) {
+		php_error_docref(NULL, E_WARNING, "HMAC requested with a non-cryptographic hashing algorithm: %s", algo);
+		RETURN_FALSE;
+	}
+
 	if (options & PHP_HASH_HMAC &&
 		key_len <= 0) {
 		/* Note: a zero length key is no key at all */

--- a/ext/hash/tests/bug52240.phpt
+++ b/ext/hash/tests/bug52240.phpt
@@ -5,7 +5,7 @@ Bug #52240 (hash_copy() does not copy the HMAC key, causes wrong results and PHP
 --FILE--
 <?php
 
-$h = hash_init('crc32b', HASH_HMAC, '123456' );
+$h = hash_init('md5', HASH_HMAC, '123456');
 $h2 = hash_copy($h);
 var_dump(hash_final($h));
 $h3 = hash_copy($h2);
@@ -14,6 +14,6 @@ var_dump(hash_final($h3));
 
 ?>
 --EXPECT--
-string(8) "278af264"
-string(8) "278af264"
-string(8) "278af264"
+string(32) "cab1380ea86d8acc9aa62390a58406aa"
+string(32) "cab1380ea86d8acc9aa62390a58406aa"
+string(32) "cab1380ea86d8acc9aa62390a58406aa"

--- a/ext/hash/tests/hash_init_error.phpt
+++ b/ext/hash/tests/hash_init_error.phpt
@@ -1,0 +1,44 @@
+--TEST--
+hash_init() function - errors test
+--SKIPIF--
+<?php
+if (!extension_loaded('hash')) die('skip hash extension not available');
+?>
+--FILE--
+<?php
+echo "*** Testing hash_init(): error conditions ***\n";
+
+echo "-- Testing hash_init() function with no parameters --\n";
+var_dump(hash_init());
+
+echo "-- Testing hash_init() function with unknown algorithms --\n";
+var_dump(hash_init('dummy'));
+
+echo "-- Testing hash_init() function with HASH_HMAC and non-cryptographic algorithms --\n";
+var_dump(hash_init('crc32', HASH_HMAC));
+
+echo "-- Testing hash_init() function with HASH_HMAC and no key --\n";
+var_dump(hash_init('md5', HASH_HMAC));
+var_dump(hash_init('md5', HASH_HMAC, null));
+?>
+--EXPECTF--
+*** Testing hash_init(): error conditions ***
+-- Testing hash_init() function with no parameters --
+
+Warning: hash_init() expects at least 1 parameter, 0 given in %s on line %d
+NULL
+-- Testing hash_init() function with unknown algorithms --
+
+Warning: hash_init(): Unknown hashing algorithm: dummy in %s on line %d
+bool(false)
+-- Testing hash_init() function with HASH_HMAC and non-cryptographic algorithms --
+
+Warning: hash_init(): HMAC requested with a non-cryptographic hashing algorithm: crc32 in %s on line %d
+bool(false)
+-- Testing hash_init() function with HASH_HMAC and no key --
+
+Warning: hash_init(): HMAC requested without a key %s on line %d
+bool(false)
+
+Warning: hash_init(): HMAC requested without a key %s on line %d
+bool(false)


### PR DESCRIPTION
We've missed this in #2312.
Also added more tests.