### PR TITLE
Fixed #73959 - pgsql - lastInsertId fails to throw an exception for wrong sequence name

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -391,7 +391,6 @@ static char *pdo_pgsql_last_insert_id(pdo_dbh_t *dbh, const char *name, size_t *
 			(void)PQexec(H->server, "ROLLBACK TO SAVEPOINT _php_lastid_savepoint");
 		}
 		pdo_pgsql_error(dbh, status, pdo_pgsql_sqlstate(res));
-		*len = spprintf(&id, 0, ZEND_LONG_FMT, (zend_long) H->pgoid);
 	}
 
 	if (savepoint) {

--- a/ext/pdo_pgsql/tests/bug73959.phpt
+++ b/ext/pdo_pgsql/tests/bug73959.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #73959 (lastInsertId fails to throw an exception)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
+require dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+require dirname(__FILE__) . '/config.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+require dirname(__FILE__) . '/config.inc';
+$db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+$db->setAttribute(PDO::ATTR_PERSISTENT, false);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->setAttribute(PDO::PGSQL_ATTR_DISABLE_PREPARES, true);
+
+try {
+    $db->lastInsertId('nonexistent_seq');
+    echo "Error: No exception thrown";
+} catch (PDOException $e) {
+    echo "Success: Exception thrown";
+}
+?>
+--EXPECT--
+Success: Exception thrown


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=73959
Caused by https://github.com/php/php-src/commit/90c6cbd09baa8802cd0d92ad13d9d791a3e4025d#diff-b62143c40851ff103819b192f4225110R378