### PR TITLE
Fixed #73973 - debug_zval_dump() assertion error for resource consts with --enable-debug

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -808,9 +808,6 @@ static void copy_constant_array(zval *dst, zval *src) /* {{{ */
 			}
 		} else if (Z_REFCOUNTED_P(val)) {
 			Z_ADDREF_P(val);
-			if (UNEXPECTED(Z_TYPE_INFO_P(val) == IS_RESOURCE_EX)) {
-				Z_TYPE_INFO_P(new_val) &= ~(IS_TYPE_REFCOUNTED << Z_TYPE_FLAGS_SHIFT);
-			}
 		}
 	} ZEND_HASH_FOREACH_END();
 }
@@ -853,12 +850,7 @@ repeat:
 		case IS_FALSE:
 		case IS_TRUE:
 		case IS_NULL:
-			break;
 		case IS_RESOURCE:
-			ZVAL_COPY(&val_free, val);
-			/* TODO: better solution than this tricky disable dtor on resource? */
-			Z_TYPE_INFO(val_free) &= ~(IS_TYPE_REFCOUNTED << Z_TYPE_FLAGS_SHIFT);
-			val = &val_free;
 			break;
 		case IS_ARRAY:
 			if (!Z_IMMUTABLE_P(val)) {

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -344,6 +344,10 @@ void shutdown_executor(void) /* {{{ */
 	} zend_end_try();
 
 	zend_try {
+		clean_non_persistent_constants();
+    } zend_end_try();
+
+	zend_try {
 		zend_close_rsrc_list(&EG(regular_list));
 	} zend_end_try();
 
@@ -372,10 +376,6 @@ void shutdown_executor(void) /* {{{ */
 			FREE_HASHTABLE(*EG(symtable_cache_ptr));
 			EG(symtable_cache_ptr)--;
 		}
-	} zend_end_try();
-
-	zend_try {
-		clean_non_persistent_constants();
 	} zend_end_try();
 
 	zend_try {

--- a/ext/standard/tests/general_functions/bug73973.phpt
+++ b/ext/standard/tests/general_functions/bug73973.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug #73973 debug_zval_dump() assertion error for resource consts with --enable-debug
+--FILE--
+<?php
+define('myerr', fopen('php://stderr', 'w'));
+debug_zval_dump(myerr);
+?>
+--EXPECTF--
+resource(5) of type (stream) refcount(%d)


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=73973


I reverted changes in `zend_builtin_functions.c` done here - https://github.com/php/php-src/commit/6815c08e2939f49a2ac9087924d58448edb401ba 

Proper resource handling is done here https://github.com/php/php-src/commit/896814e139d8dead8193f0e44cdc4ba3d8a002c7 and here https://github.com/php/php-src/commit/ac58d21aa38ca00ab9698cecfa05c8e0ff1e8d4a

Segmentation fault mentioned in https://bugs.php.net/bug.php?id=70398 will not occur because of 
https://github.com/php/php-src/blob/c8aa6f3a9a3d2c114d0c5e0c9fdd0a465dbb54a5/Zend/zend_ast.c#L481

Corresponding to https://bugs.php.net/bug.php?id=70398 tests are passing successfully. 