### PR TITLE
Fix bug #54382 (getAttributeNodeNS doesn't get xmlns* attributes)

### DIFF
--- a/ext/dom/tests/bug54382.phpt
+++ b/ext/dom/tests/bug54382.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #54382 DOMNode::getAttributeNodeNS doesn't get xmlns* attributes
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$xmlString = '<?xml version="1.0" encoding="utf-8" ?>
+<root xmlns="http://ns" xmlns:ns2="http://ns2">
+    <ns2:child />
+</root>';
+
+$xml=new DOMDocument();
+$xml->loadXML($xmlString);
+$de = $xml->documentElement;
+
+$ns2 = $de->getAttributeNodeNS("http://www.w3.org/2000/xmlns/", "ns2");
+if ($ns2 == NULL) {
+  echo 'namespace node does not exist.' . "\n";
+} else {
+  echo 'namespace node prefix=' . $ns2->prefix . "\n";
+  echo 'namespace node namespaceURI=' . $ns2->namespaceURI . "\n";
+}
+--EXPECT--
+namespace node prefix=ns2
+namespace node namespaceURI=http://ns2


### PR DESCRIPTION
The fix is based on the same strategy for handling namespace
declarations as used by getAttributeNode. Note that this strategy makes
these methods not return a DOMAttr for xmlns* attributes, but an
instance of the (undocumented) class DOMNameSpaceNode. This is not
really ideal, but at least this fix makes the behavior of
getAttributeNode and getAttributeNodeNS consistent.

A follow-up action would be to investigate whether DOMNameSpaceNode can
be made into a subclass of DOMAttr (which may be hard due to the way
libxml treats namespace declarations) or document this deviating return
value for xmlns* attributes.