### PR TITLE
Expose more information about the zlib inflate stream to userspace

### DIFF
--- a/ext/zlib/php_zlib.h
+++ b/ext/zlib/php_zlib.h
@@ -48,6 +48,7 @@ typedef struct _php_zlib_buffer {
 typedef struct _php_zlib_context {
 	z_stream Z;
 	char *inflateDict;
+    size_t status;
 	size_t inflateDictlen;
 	php_zlib_buffer buffer;
 } php_zlib_context;

--- a/ext/zlib/php_zlib.h
+++ b/ext/zlib/php_zlib.h
@@ -48,7 +48,7 @@ typedef struct _php_zlib_buffer {
 typedef struct _php_zlib_context {
 	z_stream Z;
 	char *inflateDict;
-    size_t status;
+	size_t status;
 	size_t inflateDictlen;
 	php_zlib_buffer buffer;
 } php_zlib_context;

--- a/ext/zlib/tests/inflate_get_read_len.phpt
+++ b/ext/zlib/tests/inflate_get_read_len.phpt
@@ -1,0 +1,29 @@
+--TEST--
+inflate_get_read_len()
+--SKIPIF--
+<?php if (!extension_loaded("zlib")) print "skip"; ?>
+--FILE--
+<?php
+
+$uncompressed = "Hello world.";
+$random_junk = str_repeat("qebsouesl", 128);;
+
+$compressed = zlib_encode($uncompressed, ZLIB_ENCODING_DEFLATE);
+$compressed_len = strlen($compressed);
+$compressed .= $random_junk;
+
+$ctx = inflate_init(ZLIB_ENCODING_DEFLATE);
+$buf = inflate_add($ctx, $compressed);
+$detected_compressed_len = inflate_get_read_len($ctx);
+
+echo 'Status: ' . inflate_get_status($ctx) . "\n";
+echo 'Original compressed length: ' . $compressed_len . "\n";
+echo 'Detected compressed length: ' . $detected_compressed_len . "\n";
+
+echo ($compressed_len == $detected_compressed_len) ? 'The lengths are equal.' : 'The lengths are unequal.';
+?>
+--EXPECT--
+Status: 1
+Original compressed length: 20
+Detected compressed length: 20
+The lengths are equal.

--- a/ext/zlib/tests/inflate_get_status.phpt
+++ b/ext/zlib/tests/inflate_get_status.phpt
@@ -1,0 +1,60 @@
+--TEST--
+inflate_get_status()
+--SKIPIF--
+<?php if (!extension_loaded("zlib")) print "skip"; ?>
+--FILE--
+<?php
+
+$uncompressed = "Hello world.";
+$random_junk = str_repeat("qebsouesl", 128);;
+
+$compressed = zlib_encode($uncompressed, ZLIB_ENCODING_DEFLATE);
+$compressed_len = strlen($compressed);
+$compressed .= $random_junk;
+
+$ctx = inflate_init(ZLIB_ENCODING_DEFLATE);
+$status = inflate_get_status($ctx);
+$buf = '';
+
+for ($i = 0; $status == ZLIB_OK; ++$i)
+{
+    $buf .= inflate_add($ctx, substr($compressed, $i, 1));
+    echo '$i = ' . $i . ', ';
+    $status = inflate_get_status($ctx);
+    echo 'Status: ' . $status;
+    echo "\n";
+}
+
+echo '$buf = ' . $buf;
+echo "\n\n";
+
+echo "Adding more data should reset the stream and result in a Z_OK (ZLIB_OK) status.\n";
+inflate_add($ctx, substr($compressed, 0, 12));
+echo 'Status: ' . inflate_get_status($ctx);
+
+?>
+--EXPECT--
+$i = 0, Status: 0
+$i = 1, Status: 0
+$i = 2, Status: 0
+$i = 3, Status: 0
+$i = 4, Status: 0
+$i = 5, Status: 0
+$i = 6, Status: 0
+$i = 7, Status: 0
+$i = 8, Status: 0
+$i = 9, Status: 0
+$i = 10, Status: 0
+$i = 11, Status: 0
+$i = 12, Status: 0
+$i = 13, Status: 0
+$i = 14, Status: 0
+$i = 15, Status: 0
+$i = 16, Status: 0
+$i = 17, Status: 0
+$i = 18, Status: 0
+$i = 19, Status: 1
+$buf = Hello world.
+
+Adding more data should reset the stream and result in a Z_OK (ZLIB_OK) status.
+Status: 0

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -940,7 +940,7 @@ PHP_FUNCTION(inflate_add)
 			RETURN_FALSE;
 	}
 	
-	// Lazy-resetting the zlib stream so ctx->total_in remains available until the next inflate_add() call.
+	/* Lazy-resetting the zlib stream so ctx->total_in remains available until the next inflate_add() call. */
 	if (((php_zlib_context *) ctx)->status == Z_STREAM_END)
 	{
 		((php_zlib_context *) ctx)->status = Z_OK;
@@ -961,7 +961,7 @@ PHP_FUNCTION(inflate_add)
 		status = inflate(ctx, flush_type);
 		buffer_used = ZSTR_LEN(out) - ctx->avail_out;
 
-		((php_zlib_context *) ctx)->status = status; // Save status for exposing to userspace
+		((php_zlib_context *) ctx)->status = status; /* Save status for exposing to userspace */
 
 		switch (status) {
 			case Z_OK:

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -940,7 +940,7 @@ PHP_FUNCTION(inflate_add)
 			RETURN_FALSE;
 	}
 	
-	// Lazy-resetting the zlib stream so user can check whether the stream end has been reached with inflate.
+	// Lazy-resetting the zlib stream so ctx->total_in remains available until the next inflate_add() call.
 	if (((php_zlib_context *) ctx)->status == Z_STREAM_END)
 	{
 		((php_zlib_context *) ctx)->status = Z_OK;
@@ -1024,7 +1024,7 @@ PHP_FUNCTION(inflate_add)
 /* }}} */
 
 /* {{{ proto bool inflate_get_status(resource context)
-   Get decompression status, usually returns either ZLIB_OK, ZLIB_STREAM_END, or ZLIB_NEED_DICT. */
+   Get decompression status, usually returns either ZLIB_OK or ZLIB_STREAM_END. */
 PHP_FUNCTION(inflate_get_status)
 {
 	zval *res;
@@ -1538,6 +1538,12 @@ static PHP_MINIT_FUNCTION(zlib)
 	REGISTER_LONG_CONSTANT("ZLIB_OK", Z_OK, CONST_CS|CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("ZLIB_STREAM_END", Z_STREAM_END, CONST_CS|CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("ZLIB_NEED_DICT", Z_NEED_DICT, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("ZLIB_ERRNO", Z_ERRNO, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("ZLIB_STREAM_ERROR", Z_STREAM_ERROR, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("ZLIB_DATA_ERROR", Z_DATA_ERROR, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("ZLIB_MEM_ERROR", Z_MEM_ERROR, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("ZLIB_BUF_ERROR", Z_BUF_ERROR, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("ZLIB_VERSION_ERROR", Z_VERSION_ERROR, CONST_CS|CONST_PERSISTENT);
 
 	REGISTER_INI_ENTRIES();
 	return SUCCESS;


### PR DESCRIPTION
This adds the functions `inflate_get_status(resource context)` and `inflate_get_read_len(resource context)`. These expose the return value of `inflate()` and the `total_in` member of the `z_stream` structure. This patch does ***not*** break API compatibility; `inflate_init()` and `inflate_add()` work exactly the same.

Implementation
------------------
This patch defines the following userspace constants:
```
ZLIB_OK
ZLIB_STREAM_END
ZLIB_NEED_DICT
ZLIB_ERRNO
ZLIB_STREAM_ERROR
ZLIB_DATA_ERROR
ZLIB_MEM_ERROR
ZLIB_BUF_ERROR
ZLIB_VERSION_ERROR
```
They are equivalent to zlib's Z_* return codes documented [here](http://www.zlib.net/manual.html).

To store the inflate status, I extended the php_zlib_context struct to store the status from the previous `inflate_add()` call. In order to keep the `total_in` member of the zlib stream available, when a `Z_STREAM_END` occurs inflateReset() is not immediately called but is instead called the next time `inflate_add()` is called on the stream.

Use-case
------------
With access to the inflate status and number of  bytes processed, one can find the length of compressed data. In my case, this is because I wish to parse Git packfiles with PHP, and without knowing where the deflate-compressed data ends, it is impossible to find the next entry in the packfile.

`inflate_get_status()` could be used if one is reading a series of zlib-compressed data chunks and needs to know whether to fetch the next chunk (for example).

Semi-official Documentation
----------------------------------
```
int inflate_get_status( resource $context )
```
#### Parameters
- context: A context created with `inflate_init()`

#### Return values
- Returns an int corresponding to one of the above constants. These correspond to the zlib return codes documented in the [zlib Manual](http://www.zlib.net/manual.html).

____________________________________

```
int inflate_get_read_len( resource $context )
```
#### Parameters
- context: A context created with `inflate_init()`

#### Return values
- Returns the number of bytes **processed**. This is not the same as the length of all the input data, if zlib reaches the end of the zlib data before the end of the input string. (see `Z_STREAM_END`)

Examples/Test cases
-----------------------
I wrote two simple test cases for the functions; they are inflate_get_status.phpt and inflate_get_read_len.phpt in ext/zlib/tests.