### PR TITLE
Fix 00version.phpt when commit message has multiple lines.

### DIFF
--- a/ext/pgsql/tests/00version.phpt
+++ b/ext/pgsql/tests/00version.phpt
@@ -46,5 +46,5 @@ array(13) {
   ["application_name"]=>
   string(%d) %s
 }
-string(%d) "%s"
+string(%d) "%a"
 OK


### PR DESCRIPTION
The environment variable "TRAVIS_COMMIT_MESSAGE" can contain multiple lines.

An example can be seen here https://travis-ci.org/php/php-src/jobs/195465293