### PR TITLE
Bugfix for #73987

### DIFF
--- a/Zend/tests/bug62358.phpt
+++ b/Zend/tests/bug62358.phpt
@@ -23,4 +23,4 @@ class B extends A {
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of B::foo($var) must be compatible with I::foo() in %sbug62358.php on line 17
+Fatal error: Declaration of B::foo($var) must be compatible with A::foo() in %sbug62358.php on line 17

--- a/Zend/tests/bug73987.phpt
+++ b/Zend/tests/bug73987.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #73987 (Method compatibility check looks to original definition and not parent)
+Bug #73987 (Method compatibility check looks to original definition and not parent - nullability interface)
 --FILE--
 <?php
 

--- a/Zend/tests/bug73987.phpt
+++ b/Zend/tests/bug73987.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #73987 (Method compatibility check looks to original definition and not parent)
+--FILE--
+<?php
+
+interface I {
+  public function example($a, $b, $c);
+}
+class A implements I {
+  public function example($a, $b = null, $c = null) { } // compatible with I::example
+}
+class B extends A {
+  public function example($a, $b, $c = null) { } // compatible with I::example
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of B::example($a, $b, $c = NULL) must be compatible with A::example($a, $b = NULL, $c = NULL) in %s

--- a/Zend/tests/bug73987_1.phpt
+++ b/Zend/tests/bug73987_1.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #73987 (Method compatibility check looks to original definition and not parent)
+Bug #73987 (Method compatibility check looks to original definition and not parent - return types interface)
 --FILE--
 <?php
 

--- a/Zend/tests/bug73987_1.phpt
+++ b/Zend/tests/bug73987_1.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #73987 (Method compatibility check looks to original definition and not parent)
+--FILE--
+<?php
+
+interface I {
+  public function example();
+}
+class A implements I {
+  public function example(): int { } // compatible with I::example
+}
+class B extends A {
+  public function example(): string { } // compatible with I::example
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of B::example(): string must be compatible with A::example(): int in %s

--- a/Zend/tests/bug73987_2.phpt
+++ b/Zend/tests/bug73987_2.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #73987 (Method compatibility check looks to original definition and not parent - nullabilty abstract)
+--FILE--
+<?php
+
+abstract class A {
+    abstract function example($a, $b, $c);
+}
+
+class B extends A {
+    function example($a, $b = null, $c = null) { }
+}
+
+class C extends B {
+    function example($a, $b, $c = null) { }
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of C::example($a, $b, $c = NULL) must be compatible with B::example($a, $b = NULL, $c = NULL) in %s

--- a/Zend/tests/bug73987_3.phpt
+++ b/Zend/tests/bug73987_3.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #73987 (Method compatibility check looks to original definition and not parent - return types abstract)
+--FILE--
+<?php
+
+abstract class A {
+    abstract function example();
+}
+
+class B extends A {
+    function example(): int  { }
+}
+
+class C extends B {
+    function example(): string { }
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of C::example(): string must be compatible with B::example(): int in %s

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -586,13 +586,12 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 	} else if (!(parent->common.fn_flags & ZEND_ACC_CTOR) || (parent->common.prototype && (parent->common.prototype->common.scope->ce_flags & ZEND_ACC_INTERFACE))) {
 		/* ctors only have a prototype if it comes from an interface */
 		child->common.prototype = parent->common.prototype ? parent->common.prototype : parent;
+		/* and if that is the case, we want to check inheritance against it */
+		if (parent->common.fn_flags & ZEND_ACC_CTOR) {
+			parent = child->common.prototype;
+		}
 	}
 
-	if (child->common.prototype && (
-		child->common.prototype->common.fn_flags & ZEND_ACC_ABSTRACT
-	)) {
-		parent = child->common.prototype;
-	}
 	if (UNEXPECTED(!zend_do_perform_implementation_check(child, parent))) {
 		int error_level;
 		const char *error_verb;


### PR DESCRIPTION
Inheritance checks should not ignore parents if these implement an interface or abstract.

Link for bugsnet: https://bugs.php.net/bug.php?id=73987