### PR TITLE
PHP bug #74004

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -2038,15 +2038,15 @@ static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 		RETURN_FALSE;
 	}
 
-	if (options) {
-		htmlCtxtUseOptions(ctxt, (int)options);
-	}
-
+	
 	ctxt->vctxt.error = php_libxml_ctx_error;
 	ctxt->vctxt.warning = php_libxml_ctx_warning;
 	if (ctxt->sax != NULL) {
 		ctxt->sax->error = php_libxml_ctx_error;
 		ctxt->sax->warning = php_libxml_ctx_warning;
+	}
+	if (options) {
+		htmlCtxtUseOptions(ctxt, (int)options);
 	}
 	htmlParseDocument(ctxt);
 	newdoc = ctxt->myDoc;

--- a/ext/dom/tests/bug74004.phpt
+++ b/ext/dom/tests/bug74004.phpt
@@ -6,10 +6,8 @@ Bug #74004 (DOMDocument->loadHTML and ->loadHTMLFile do not heed LIBXML_NOWARNIN
 <?php
 
 $doc=new DOMDocument();
-libxml_use_internal_errors(true);
-$doc->loadHTML("<tag-throw-warning></tag-throw-warning>",LIBXML_NOWARNING|LIBXML_NOERROR);
-print count(libxml_get_errors());
+$doc->loadHTML("<tag-throw></tag-throw>",LIBXML_NOERROR);
 
 ?>
 --EXPECT--
-0
+No warnings output

--- a/ext/dom/tests/bug74004.phpt
+++ b/ext/dom/tests/bug74004.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #74004 (DOMDocument->loadHTML and ->loadHTMLFile do not heed LIBXML_NOWARNING and LIBXML_NOERROR options)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$doc=new DOMDocument();
+libxml_use_internal_errors(true);
+$doc->loadHTML("<tag-throw-warning></tag-throw-warning>",LIBXML_NOWARNING|LIBXML_NOERROR);
+print count(libxml_get_errors());
+
+?>
+--EXPECT--
+0


### PR DESCRIPTION
Fix for DOMDocument loadHTML and loadHTMLFile ignore LIBXML_NOWARNING
and LIBXML_NOERROR flags.