### PR TITLE
Deprecate INTL_IDNA_VARIANT_2003

### DIFF
--- a/ext/intl/idn/idn.c
+++ b/ext/intl/idn/idn.c
@@ -291,6 +291,10 @@ static void php_intl_idn_handoff(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	}
 	/* don't check options; it wasn't checked before */
 
+	if (variant == INTL_IDN_VARIANT_2003) {
+		php_error_docref(NULL, E_DEPRECATED, "INTL_IDNA_VARIANT_2003 is deprecated");
+	}
+
 	if (idna_info != NULL) {
 		if (variant == INTL_IDN_VARIANT_2003) {
 			php_error_docref0(NULL, E_NOTICE,

--- a/ext/intl/tests/idn.phpt
+++ b/ext/intl/tests/idn.phpt
@@ -13,6 +13,9 @@ echo idn_to_ascii("t\xC3\xA4st.de")."\n";
 echo urlencode(idn_to_utf8('xn--tst-qla.de'))."\n";
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated in %s on line %d
 xn--tst-qla.de
+
+Deprecated: idn_to_utf8(): INTL_IDNA_VARIANT_2003 is deprecated in %s on line %d
 t%C3%A4st.de

--- a/ext/intl/tests/idn_uts46_errors.phpt
+++ b/ext/intl/tests/idn_uts46_errors.phpt
@@ -62,6 +62,8 @@ Warning: idn_to_ascii(): idn_to_ascii: empty domain name in %s on line %d
 bool(false)
 fourth arg for 2003 variant (only notice raised):
 
+Deprecated: idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated in %s on line %d
+
 Notice: idn_to_ascii(): 4 arguments were provided, but INTL_IDNA_VARIANT_2003 only takes 3 - extra argument ignored in %s on line %d
 string(7) "foo.com"
 with error, but no details arg:


### PR DESCRIPTION
As of ICU 55.1 the IDNA2003 APIs are deprecated, so we're deprecating
INTL_IDNA_VARIANT_2003 as well, according to
https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003.