### PR TITLE
Fix #74039 is_infinite(-INF) broken when isinf not defined

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -100,7 +100,8 @@ AC_FUNC_ALLOCA
 AC_CHECK_FUNCS(memcpy strdup getpid kill strtod strtol finite fpclass sigsetjmp)
 AC_ZEND_BROKEN_SPRINTF
 
-AC_CHECK_FUNCS(finite isfinite isinf isnan)
+AC_CHECK_FUNCS(finite)
+AC_CHECK_DECLS([isfinite, isnan, isinf], [], [], [[#include <math.h>]])
 
 ZEND_FP_EXCEPT
 

--- a/Zend/configure.in
+++ b/Zend/configure.in
@@ -83,7 +83,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
 #define zend_isinf(a) isinf(a)
 #elif defined(INFINITY)
 /* Might not work, but is required by ISO C99 */
-#define zend_isinf(a) (((a)==INFINITY)?1:0)
+#define zend_isinf(a) (((a)==INFINITY || (a)==-INFINITY)?1:0)
 #elif defined(HAVE_FPCLASS)
 #define zend_isinf(a) ((fpclass(a) == FP_PINF) || (fpclass(a) == FP_NINF))
 #else

--- a/Zend/configure.in
+++ b/Zend/configure.in
@@ -64,13 +64,13 @@ int zend_sprintf(char *buffer, const char *format, ...);
 
 /* To enable the is_nan, is_infinite and is_finite PHP functions */
 #ifdef NETWARE
-	#define HAVE_ISNAN 1
-	#define HAVE_ISINF 1
-	#define HAVE_ISFINITE 1
+	#define HAVE_DECL_ISNAN 1
+	#define HAVE_DECL_ISINF 1
+	#define HAVE_DECL_ISINFINITE 1
 #endif
 
 #ifndef zend_isnan
-#ifdef HAVE_ISNAN
+#ifdef HAVE_DECL_ISNAN
 #define zend_isnan(a) isnan(a)
 #elif defined(HAVE_FPCLASS)
 #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
@@ -79,7 +79,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
 #endif
 #endif
 
-#ifdef HAVE_ISINF
+#ifdef HAVE_DECL_ISINF
 #define zend_isinf(a) isinf(a)
 #elif defined(INFINITY)
 /* Might not work, but is required by ISO C99 */
@@ -90,7 +90,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
 #define zend_isinf(a) 0
 #endif
 
-#if defined(HAVE_ISFINITE) || defined(isfinite)
+#if defined(HAVE_DECL_ISINFINITE) || defined(isfinite)
 #define zend_finite(a) isfinite(a)
 #elif defined(HAVE_FINITE)
 #define zend_finite(a) finite(a)

--- a/configure.in
+++ b/configure.in
@@ -88,7 +88,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
 #define zend_isinf(a) isinf(a)
 #elif defined(INFINITY)
 /* Might not work, but is required by ISO C99 */
-#define zend_isinf(a) (((a)==INFINITY)?1:0)
+#define zend_isinf(a) (((a)==INFINITY || (a)==-INFINITY)?1:0)
 #elif defined(HAVE_FPCLASS)
 #define zend_isinf(a) ((fpclass(a) == FP_PINF) || (fpclass(a) == FP_NINF))
 #else

--- a/configure.in
+++ b/configure.in
@@ -69,13 +69,13 @@ int zend_sprintf(char *buffer, const char *format, ...);
 
 /* To enable the is_nan, is_infinite and is_finite PHP functions */
 #ifdef NETWARE
-	#define HAVE_ISNAN 1
-	#define HAVE_ISINF 1
-	#define HAVE_ISFINITE 1
+	#define HAVE_DECL_ISNAN 1
+	#define HAVE_DECL_ISINF 1
+	#define HAVE_DECL_ISINFINITE 1
 #endif
 
 #ifndef zend_isnan
-#ifdef HAVE_ISNAN
+#ifdef HAVE_DECL_ISNAN
 #define zend_isnan(a) isnan(a)
 #elif defined(HAVE_FPCLASS)
 #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
@@ -84,7 +84,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
 #endif
 #endif
 
-#ifdef HAVE_ISINF
+#ifdef HAVE_DECL_ISINF
 #define zend_isinf(a) isinf(a)
 #elif defined(INFINITY)
 /* Might not work, but is required by ISO C99 */
@@ -95,7 +95,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
 #define zend_isinf(a) 0
 #endif
 
-#if defined(HAVE_ISFINITE) || defined(isfinite)
+#if defined(HAVE_DECL_ISINFINITE) || defined(isfinite)
 #define zend_finite(a) isfinite(a)
 #elif defined(HAVE_FINITE)
 #define zend_finite(a) finite(a)

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -420,7 +420,7 @@ AC_TRY_RUN([
 #include <math.h>
 #include <stdlib.h>
 
-#ifdef HAVE_ISNAN
+#ifdef HAVE_DECL_ISNAN
 #define zend_isnan(a) isnan(a)
 #elif defined(HAVE_FPCLASS)
 #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
@@ -451,7 +451,7 @@ AC_TRY_RUN([
 #include <math.h>
 #include <stdlib.h>
 
-#ifdef HAVE_ISINF
+#ifdef HAVE_DECL_ISINF
 #define zend_isinf(a) isinf(a)
 #elif defined(INFINITY)
 /* Might not work, but is required by ISO C99 */
@@ -485,7 +485,7 @@ AC_TRY_RUN([
 #include <math.h>
 #include <stdlib.h>
 
-#ifdef HAVE_ISINF
+#ifdef HAVE_DECL_ISINF
 #define zend_isinf(a) isinf(a)
 #elif defined(INFINITY)
 /* Might not work, but is required by ISO C99 */
@@ -520,7 +520,7 @@ AC_TRY_RUN([
 #include <math.h>
 #include <stdlib.h>
 
-#ifdef HAVE_ISNAN
+#ifdef HAVE_DECL_ISNAN
 #define zend_isnan(a) isnan(a)
 #elif defined(HAVE_FPCLASS)
 #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -455,7 +455,7 @@ AC_TRY_RUN([
 #define zend_isinf(a) isinf(a)
 #elif defined(INFINITY)
 /* Might not work, but is required by ISO C99 */
-#define zend_isinf(a) (((a)==INFINITY)?1:0)
+#define zend_isinf(a) (((a)==INFINITY || (a)==-INFINITY)?1:0)
 #elif defined(HAVE_FPCLASS)
 #define zend_isinf(a) ((fpclass(a) == FP_PINF) || (fpclass(a) == FP_NINF))
 #else
@@ -489,7 +489,7 @@ AC_TRY_RUN([
 #define zend_isinf(a) isinf(a)
 #elif defined(INFINITY)
 /* Might not work, but is required by ISO C99 */
-#define zend_isinf(a) (((a)==INFINITY)?1:0)
+#define zend_isinf(a) (((a)==INFINITY || (a)==-INFINITY)?1:0)
 #elif defined(HAVE_FPCLASS)
 #define zend_isinf(a) ((fpclass(a) == FP_PINF) || (fpclass(a) == FP_NINF))
 #else

--- a/ext/standard/tests/math/is_finite_variation1.phpt
+++ b/ext/standard/tests/math/is_finite_variation1.phpt
@@ -41,38 +41,41 @@ $inputs = array(
        12.3456789000e10,
        12.3456789000E-10,
        .5,
+       NAN,
+       INF,
+       -INF,
 
        // null data
-/*11*/ NULL,
+/*14*/ NULL,
        null,
 
        // boolean data
-/*13*/ true,
+/*16*/ true,
        false,
        TRUE,
        FALSE,
        
        // empty data
-/*17*/ "",
+/*20*/ "",
        '',
        array(),
 
        // string data
-/*20*/ "abcxyz",
+/*23*/ "abcxyz",
        'abcxyz',
        $heredoc,
        
        // object data
-/*23*/ new classA(),       
+/*26*/ new classA(),
        
        // undefined data
-/*24*/ @$undefined_var,
+/*27*/ @$undefined_var,
 
        // unset data
-/*25*/ @$unset_var,
+/*28*/ @$unset_var,
 
        // resource variable
-/*26*/ $fp
+/*29*/ $fp
 );
 
 // loop through each element of $inputs to check the behaviour of is_finite()
@@ -119,13 +122,13 @@ bool(true)
 bool(true)
 
 -- Iteration 11 --
-bool(true)
+bool(false)
 
 -- Iteration 12 --
-bool(true)
+bool(false)
 
 -- Iteration 13 --
-bool(true)
+bool(false)
 
 -- Iteration 14 --
 bool(true)
@@ -137,19 +140,13 @@ bool(true)
 bool(true)
 
 -- Iteration 17 --
-
-Warning: is_finite() expects parameter 1 to be float, string given in %s on line %d
-NULL
+bool(true)
 
 -- Iteration 18 --
-
-Warning: is_finite() expects parameter 1 to be float, string given in %s on line %d
-NULL
+bool(true)
 
 -- Iteration 19 --
-
-Warning: is_finite() expects parameter 1 to be float, array given in %s on line %d
-NULL
+bool(true)
 
 -- Iteration 20 --
 
@@ -163,21 +160,36 @@ NULL
 
 -- Iteration 22 --
 
-Warning: is_finite() expects parameter 1 to be float, string given in %s on line %d
+Warning: is_finite() expects parameter 1 to be float, array given in %s on line %d
 NULL
 
 -- Iteration 23 --
 
-Warning: is_finite() expects parameter 1 to be float, object given in %s on line %d
+Warning: is_finite() expects parameter 1 to be float, string given in %s on line %d
 NULL
 
 -- Iteration 24 --
-bool(true)
+
+Warning: is_finite() expects parameter 1 to be float, string given in %s on line %d
+NULL
 
 -- Iteration 25 --
-bool(true)
+
+Warning: is_finite() expects parameter 1 to be float, string given in %s on line %d
+NULL
 
 -- Iteration 26 --
+
+Warning: is_finite() expects parameter 1 to be float, object given in %s on line %d
+NULL
+
+-- Iteration 27 --
+bool(true)
+
+-- Iteration 28 --
+bool(true)
+
+-- Iteration 29 --
 
 Warning: is_finite() expects parameter 1 to be float, resource given in %s on line %d
 NULL

--- a/ext/standard/tests/math/is_infinite_variation1.phpt
+++ b/ext/standard/tests/math/is_infinite_variation1.phpt
@@ -41,38 +41,41 @@ $inputs = array(
        12.3456789000e10,
        12.3456789000E-10,
        .5,
+       NAN,
+       INF,
+       -INF,
 
        // null data
-/*11*/ NULL,
+/*14*/ NULL,
        null,
 
        // boolean data
-/*13*/ true,
+/*16*/ true,
        false,
        TRUE,
        FALSE,
        
        // empty data
-/*17*/ "",
+/*20*/ "",
        '',
        array(),
 
        // string data
-/*20*/ "abcxyz",
+/*23*/ "abcxyz",
        'abcxyz',
        $heredoc,
        
        // object data
-/*23*/ new classA(),       
+/*26*/ new classA(),       
        
        // undefined data
-/*24*/ @$undefined_var,
+/*27*/ @$undefined_var,
 
        // unset data
-/*25*/ @$unset_var,
+/*28*/ @$unset_var,
 
        // resource variable
-/*26*/ $fp
+/*29*/ $fp
 );
 
 // loop through each element of $inputs to check the behaviour of is_infinite()
@@ -122,10 +125,10 @@ bool(false)
 bool(false)
 
 -- Iteration 12 --
-bool(false)
+bool(true)
 
 -- Iteration 13 --
-bool(false)
+bool(true)
 
 -- Iteration 14 --
 bool(false)
@@ -137,19 +140,13 @@ bool(false)
 bool(false)
 
 -- Iteration 17 --
-
-Warning: is_infinite() expects parameter 1 to be float, string given in %s on line %d
-NULL
+bool(false)
 
 -- Iteration 18 --
-
-Warning: is_infinite() expects parameter 1 to be float, string given in %s on line %d
-NULL
+bool(false)
 
 -- Iteration 19 --
-
-Warning: is_infinite() expects parameter 1 to be float, array given in %s on line %d
-NULL
+bool(false)
 
 -- Iteration 20 --
 
@@ -163,21 +160,36 @@ NULL
 
 -- Iteration 22 --
 
-Warning: is_infinite() expects parameter 1 to be float, string given in %s on line %d
+Warning: is_infinite() expects parameter 1 to be float, array given in %s on line %d
 NULL
 
 -- Iteration 23 --
 
-Warning: is_infinite() expects parameter 1 to be float, object given in %s on line %d
+Warning: is_infinite() expects parameter 1 to be float, string given in %s on line %d
 NULL
 
 -- Iteration 24 --
-bool(false)
+
+Warning: is_infinite() expects parameter 1 to be float, string given in %s on line %d
+NULL
 
 -- Iteration 25 --
-bool(false)
+
+Warning: is_infinite() expects parameter 1 to be float, string given in %s on line %d
+NULL
 
 -- Iteration 26 --
+
+Warning: is_infinite() expects parameter 1 to be float, object given in %s on line %d
+NULL
+
+-- Iteration 27 --
+bool(false)
+
+-- Iteration 28 --
+bool(false)
+
+-- Iteration 29 --
 
 Warning: is_infinite() expects parameter 1 to be float, resource given in %s on line %d
 NULL


### PR DESCRIPTION
`is_infinite()` is broken in the PHP binary included in Alpine Linux. It returns TRUE for `is_infinite(INF)`, but FALSE for `is_infinite(-INF)`.

I believe to have fixed the problem, but I know virtually nothing about C or the PHP source, so bear with me :-)