### PR TITLE
Demote LSP violation to warning even if parent implements abstract

### DIFF
--- a/Zend/tests/bug62358.phpt
+++ b/Zend/tests/bug62358.phpt
@@ -23,4 +23,4 @@ class B extends A {
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of B::foo($var) must be compatible with A::foo() in %sbug62358.php on line 17
+Warning: Declaration of B::foo($var) should be compatible with A::foo() in %sbug62358.php on line 17

--- a/Zend/tests/bug73987.phpt
+++ b/Zend/tests/bug73987.phpt
@@ -15,4 +15,4 @@ class B extends A {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of B::example($a, $b, $c = NULL) must be compatible with A::example($a, $b = NULL, $c = NULL) in %s
+Warning: Declaration of B::example($a, $b, $c = NULL) should be compatible with A::example($a, $b = NULL, $c = NULL) in %s

--- a/Zend/tests/bug73987_2.phpt
+++ b/Zend/tests/bug73987_2.phpt
@@ -17,4 +17,4 @@ class C extends B {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of C::example($a, $b, $c = NULL) must be compatible with B::example($a, $b = NULL, $c = NULL) in %s
+Warning: Declaration of C::example($a, $b, $c = NULL) should be compatible with B::example($a, $b = NULL, $c = NULL) in %s

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -619,9 +619,7 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 		zend_string *method_prototype = zend_get_function_declaration(parent);
 		zend_string *child_prototype = zend_get_function_declaration(child);
 
-		if (child->common.prototype && (
-			child->common.prototype->common.fn_flags & ZEND_ACC_ABSTRACT
-		)) {
+		if (parent->common.fn_flags & ZEND_ACC_ABSTRACT) {
 			error_level = E_COMPILE_ERROR;
 			error_verb = "must";
 		} else if ((parent->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) &&


### PR DESCRIPTION
After #2342, an LSP violation over the number of required parameters was promoted to a Fatal Error if the parent implements an interface or abstract.

This PR fixes that behaviour.