### PR TITLE
Increase wait time in timeout_variation_9.phpt

### DIFF
--- a/tests/basic/timeout_variation_9.phpt
+++ b/tests/basic/timeout_variation_9.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Timeout within shutdown function
+--CREDITS--
+Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
 --SKIPIF--
 <?php 
 	if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
@@ -14,7 +16,7 @@ set_time_limit($t);
 function f()
 {
 	echo "call";
-	busy_wait(4);
+	busy_wait(5);
 }
 
 register_shutdown_function("f");

--- a/tests/basic/timeout_variation_9.phpt
+++ b/tests/basic/timeout_variation_9.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Timeout within shutdown function
---CREDITS--
-Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
 --SKIPIF--
 <?php 
 	if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");


### PR DESCRIPTION
TEST before change

```
=====================================================================
PHP         : /home/vagrant/php-src/sapi/cli/php 
PHP_SAPI    : cli
PHP_VERSION : 7.2.0-dev
ZEND_VERSION: 3.2.0-dev
PHP_OS      : Linux - Linux lubunut32 3.13.0-36-generic #63-Ubuntu SMP Wed Sep 3 21:30:45 UTC 2014 i686
INI actual  : /home/vagrant/php-src/tmp-php.ini
More .INIs  :   
---------------------------------------------------------------------
PHP         : /home/vagrant/php-src/sapi/phpdbg/phpdbg 
PHP_SAPI    : phpdbg
PHP_VERSION : 7.2.0-dev
ZEND_VERSION: 3.2.0-dev
PHP_OS      : Linux - Linux lubunut32 3.13.0-36-generic #63-Ubuntu SMP Wed Sep 3 21:30:45 UTC 2014 i686
INI actual  : /home/vagrant/php-src/tmp-php.ini
More .INIs  : 
---------------------------------------------------------------------
CWD         : /home/vagrant/php-src
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
Running selected tests.
TEST 1/1 [tests/basic/timeout_variation_9.phpt]
FAIL Timeout within shutdown function [tests/basic/timeout_variation_9.phpt] 
=====================================================================
Number of tests :    1                 1
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    1 (100.0%) (100.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :    0 (  0.0%) (  0.0%)
---------------------------------------------------------------------
Time taken      :    4 seconds
=====================================================================

=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Timeout within shutdown function [tests/basic/timeout_variation_9.phpt]
=====================================================================
```

TEST AFTER change

```
=====================================================================
PHP         : /home/vagrant/php-src/sapi/cli/php 
PHP_SAPI    : cli
PHP_VERSION : 7.2.0-dev
ZEND_VERSION: 3.2.0-dev
PHP_OS      : Linux - Linux lubunut32 3.13.0-36-generic #63-Ubuntu SMP Wed Sep 3 21:30:45 UTC 2014 i686
INI actual  : /home/vagrant/php-src/tmp-php.ini
More .INIs  :   
---------------------------------------------------------------------
PHP         : /home/vagrant/php-src/sapi/phpdbg/phpdbg 
PHP_SAPI    : phpdbg
PHP_VERSION : 7.2.0-dev
ZEND_VERSION: 3.2.0-dev
PHP_OS      : Linux - Linux lubunut32 3.13.0-36-generic #63-Ubuntu SMP Wed Sep 3 21:30:45 UTC 2014 i686
INI actual  : /home/vagrant/php-src/tmp-php.ini
More .INIs  : 
---------------------------------------------------------------------
CWD         : /home/vagrant/php-src
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
Running selected tests.
TEST 1/1 [tests/basic/timeout_variation_9.phpt]
PASS Timeout within shutdown function [tests/basic/timeout_variation_9.phpt] 
=====================================================================
Number of tests :    1                 1
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :    1 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    5 seconds
=====================================================================
```