### PR TITLE
Fixed #74035 - ReflectionClass::newInstance param set as optional

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -4586,7 +4586,7 @@ ZEND_METHOD(reflection_class, isInstance)
 }
 /* }}} */
 
-/* {{{ proto public stdclass ReflectionClass::newInstance(mixed* args, ...)
+/* {{{ proto public stdclass ReflectionClass::newInstance([mixed* args], ...)
    Returns an instance of this class */
 ZEND_METHOD(reflection_class, newInstance)
 {
@@ -6273,8 +6273,8 @@ ZEND_BEGIN_ARG_INFO(arginfo_reflection_class_isInstance, 0)
 	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_reflection_class_newInstance, 0)
-	ZEND_ARG_INFO(0, args)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_reflection_class_newInstance, 0, 0, 0)
+	ZEND_ARG_VARIADIC_INFO(0, args)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_reflection_class_newInstanceWithoutConstructor, 0)

--- a/ext/reflection/tests/ReflectionClass_toString_001.phpt
+++ b/ext/reflection/tests/ReflectionClass_toString_001.phpt
@@ -252,7 +252,7 @@ Class [ <internal:Reflection> class ReflectionClass implements Reflector ] {
     Method [ <internal:Reflection> public method newInstance ] {
 
       - Parameters [1] {
-        Parameter #0 [ <required> $args ]
+        Parameter #0 [ <optional> ...$args ]
       }
     }
 

--- a/ext/reflection/tests/bug74035.phpt
+++ b/ext/reflection/tests/bug74035.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #74035: getNumberOfRequiredParameters wrong for ReflectionClass::newInstance
+--FILE--
+<?php
+$r = new ReflectionClass(ReflectionClass::class);
+$m = $r->getMethod('newInstance');
+
+echo $m->getNumberOfRequiredParameters();
+?>
+--EXPECT--
+0


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=74035