### PR TITLE
Removing XFAIL from bug69958.phpt

### DIFF
--- a/ext/phar/tests/bug69958.phpt
+++ b/ext/phar/tests/bug69958.phpt
@@ -1,6 +1,6 @@
 --TEST--
 Phar: bug #69958: Segfault in Phar::convertToData on invalid file
---XFAIL--
+--DESCRIPTION--
 Still has memory leaks, see https://bugs.php.net/bug.php?id=70005
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
@@ -9,7 +9,7 @@ Still has memory leaks, see https://bugs.php.net/bug.php?id=70005
 $tarphar = new PharData(__DIR__.'/bug69958.tar');
 $phar = $tarphar->convertToData(Phar::TAR); 
 --EXPECTF--
-Fatal error: Uncaught exception 'BadMethodCallException' with message 'phar "%s/bug69958.tar" exists and must be unlinked prior to conversion' in %s/bug69958.php:%d
+Fatal error: Uncaught BadMethodCallException: phar "%s/bug69958.tar" exists and must be unlinked prior to conversion in %s/bug69958.php:%d
 Stack trace:
 #0 %s/bug69958.php(%d): PharData->convertToData(%d)
 #1 {main}


### PR DESCRIPTION
The memory leak does not impact the test passing