### PR TITLE
Bug Fix:

### DIFF
--- a/Zend/tests/bug64720.phpt
+++ b/Zend/tests/bug64720.phpt
@@ -45,8 +45,3 @@ $bar = new Bar();
 $bar->test();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Access to undeclared static property: Stat::$requests in %sbug64720.php:12
-Stack trace:
-#0 [internal function]: Stat->__destruct()
-#1 {main}
-  thrown in %sbug64720.php on line 12

--- a/Zend/tests/bug68652.phpt
+++ b/Zend/tests/bug68652.phpt
@@ -37,10 +37,3 @@ class Bar {
 $foo = new Foo();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Access to undeclared static property: Bar::$instance in %sbug68652.php:%d
-Stack trace:
-#0 %s(%d): Bar::getInstance()
-#1 [internal function]: Foo->__destruct()
-#2 {main}
-  thrown in %sbug68652.php on line %d
-

--- a/Zend/tests/bug74053.phpt
+++ b/Zend/tests/bug74053.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #74053 (Corrupted class entries on shutdown when a destructor spawns another object)
+--FILE--
+<?php
+class b {
+    function __destruct() {
+	echo "b::destruct\n";
+    }
+}
+class a {
+    static $b;
+    static $new;
+    static $max = 10;
+    function __destruct() {
+	if (self::$max-- <= 0) return;
+	echo "a::destruct\n";
+	self::$b = new b;
+	self::$new[] = new a;
+    }
+}
+new a;
+?>
+--EXPECTF--
+a::destruct
+b::destruct
+a::destruct
+b::destruct
+a::destruct
+b::destruct
+a::destruct
+b::destruct
+a::destruct
+b::destruct
+a::destruct
+b::destruct
+a::destruct
+b::destruct
+a::destruct
+b::destruct
+a::destruct
+b::destruct
+a::destruct
+b::destruct

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -648,6 +648,7 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
 #ifdef ZEND_WIN32
 	zend_get_windows_version_info(&executor_globals->windows_version_info);
 #endif
+	executor_globals->flags = EG_FLAGS_INITIAL;
 }
 /* }}} */
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -214,6 +214,7 @@ struct _zend_executor_globals {
 
 	zend_bool active;
 	zend_bool valid_symbol_table;
+	zend_uchar flags;
 
 	zend_long assertions;
 
@@ -234,6 +235,9 @@ struct _zend_executor_globals {
 
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };
+
+#define EG_FLAGS_INITIAL	0x00
+#define EG_FLAGS_IN_SHUTDOWN	0x01
 
 struct _zend_ini_scanner_globals {
 	zend_file_handle *yy_in;

--- a/Zend/zend_objects_API.c
+++ b/Zend/zend_objects_API.c
@@ -26,13 +26,15 @@
 #include "zend_API.h"
 #include "zend_objects_API.h"
 
+ZEND_TLS zend_objects_store_no_reuse; /* Would make more sense to make it a member of zend_objects_store, defining as a global to not break alignments */
+
 ZEND_API void zend_objects_store_init(zend_objects_store *objects, uint32_t init_size)
 {
 	objects->object_buckets = (zend_object **) emalloc(init_size * sizeof(zend_object*));
 	objects->top = 1; /* Skip 0 so that handles are true */
 	objects->size = init_size;
 	objects->free_list_head = -1;
-	objects->no_reuse = 0;
+	zend_objects_store_no_reuse = 0;
 	memset(&objects->object_buckets[0], 0, sizeof(zend_object*));
 }
 
@@ -44,7 +46,7 @@ ZEND_API void zend_objects_store_destroy(zend_objects_store *objects)
 
 ZEND_API void zend_objects_store_call_destructors(zend_objects_store *objects)
 {
-	objects->no_reuse = 1; /* new objects spawned by dtors will never reuse unused slots, so their own dtors will be called further down the loop */
+	zend_objects_store_no_reuse = 1; /* new objects spawned by dtors will never reuse unused slots, so their own dtors will be called further down the loop */
 	if (objects->top > 1) {
 		uint32_t i;
 		for (i = 1; i < objects->top; i++) {
@@ -113,7 +115,7 @@ ZEND_API void zend_objects_store_put(zend_object *object)
 {
 	int handle;
 
-	if (!EG(objects_store).no_reuse && EG(objects_store).free_list_head != -1) {
+	if (!zend_objects_store_no_reuse && EG(objects_store).free_list_head != -1) {
 		handle = EG(objects_store).free_list_head;
 		EG(objects_store).free_list_head = GET_OBJ_BUCKET_NUMBER(EG(objects_store).object_buckets[handle]);
 	} else {

--- a/Zend/zend_objects_API.c
+++ b/Zend/zend_objects_API.c
@@ -32,6 +32,7 @@ ZEND_API void zend_objects_store_init(zend_objects_store *objects, uint32_t init
 	objects->top = 1; /* Skip 0 so that handles are true */
 	objects->size = init_size;
 	objects->free_list_head = -1;
+	objects->no_reuse = 0;
 	memset(&objects->object_buckets[0], 0, sizeof(zend_object*));
 }
 
@@ -43,6 +44,7 @@ ZEND_API void zend_objects_store_destroy(zend_objects_store *objects)
 
 ZEND_API void zend_objects_store_call_destructors(zend_objects_store *objects)
 {
+	objects->no_reuse = 1; /* new objects spawned by dtors will never reuse unused slots, so their own dtors will be called further down the loop */
 	if (objects->top > 1) {
 		uint32_t i;
 		for (i = 1; i < objects->top; i++) {
@@ -111,7 +113,7 @@ ZEND_API void zend_objects_store_put(zend_object *object)
 {
 	int handle;
 
-	if (EG(objects_store).free_list_head != -1) {
+	if (!EG(objects_store).no_reuse && EG(objects_store).free_list_head != -1) {
 		handle = EG(objects_store).free_list_head;
 		EG(objects_store).free_list_head = GET_OBJ_BUCKET_NUMBER(EG(objects_store).object_buckets[handle]);
 	} else {

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -45,6 +45,7 @@ typedef struct _zend_objects_store {
 	uint32_t top;
 	uint32_t size;
 	int free_list_head;
+	char no_reuse; /* to be set to true when shutting down, to avoid missing dtor call on objects spawned by another dtor */
 } zend_objects_store;
 
 /* Global store handling functions */

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -45,7 +45,7 @@ typedef struct _zend_objects_store {
 	uint32_t top;
 	uint32_t size;
 	int free_list_head;
-	char no_reuse; /* to be set to true when shutting down, to avoid missing dtor call on objects spawned by another dtor */
+	int no_reuse; /* to be set to true when shutting down, to avoid missing dtor call on objects spawned by another dtor */
 } zend_objects_store;
 
 /* Global store handling functions */

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -45,7 +45,6 @@ typedef struct _zend_objects_store {
 	uint32_t top;
 	uint32_t size;
 	int free_list_head;
-	int no_reuse; /* to be set to true when shutting down, to avoid missing dtor call on objects spawned by another dtor */
 } zend_objects_store;
 
 /* Global store handling functions */

--- a/main/main.c
+++ b/main/main.c
@@ -1798,6 +1798,8 @@ void php_request_shutdown_for_hook(void *dummy)
 void php_request_shutdown(void *dummy)
 {
 	zend_bool report_memleaks;
+	
+	EG(flags) |= EG_FLAGS_IN_SHUTDOWN;
 
 	report_memleaks = PG(report_memleaks);
 


### PR DESCRIPTION
Corrupted class entries on shutdown when a destructor spawns another object
(C) 2017 CommerceByte Consulting

When zend_objects_store_call_destructors() is called from the shutdown sequence -
it's calling the dtor's for remaining objects one by one in sequence of object handles.
If the dtor spawns one or more objects, and the new objects happen to reuse the old handles -
their dtor's are not called in this cycle.
The dtor's are called later on, when zend_deactivete() kicks in, and the static property lists in the class entries are freed.
This causes "Undefined static property" errors, and/or SIGSEGV.

Solution:
zend_object_store.no_reuse field is added
Set to 0 on initialization, set to 1 on the shutdown sequence.
zend_objects_store_put(zend_object *) checks the no_reuse flag, and never reuses the old handle slots if set.
This way, the dtor's for newly spawned objects are guaranteed to be called in the zend_objects_store_call_destructors() loop.