### PR TITLE
Prevent branching timing leak in hash_equals()

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -860,7 +860,7 @@ PHP_FUNCTION(hash_equals)
 		result |= known_str[j] ^ user_str[j];
 	}
 
-	RETURN_BOOL(1 & ((result - 1) >> 8));
+	RETURN_BOOL(1 & ((result - 1) >> CHAR_BIT);
 }
 /* }}} */
 

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -860,7 +860,7 @@ PHP_FUNCTION(hash_equals)
 		result |= known_str[j] ^ user_str[j];
 	}
 
-	RETURN_BOOL(1 & ((result - 1) >> CHAR_BIT);
+	RETURN_BOOL(1 & ((result - 1) >> CHAR_BIT));
 }
 /* }}} */
 

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -830,7 +830,7 @@ PHP_FUNCTION(hash_equals)
 {
 	zval *known_zval, *user_zval;
 	char *known_str, *user_str;
-	int result = 0;
+	unsigned int result = 0;
 	size_t j;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &known_zval, &user_zval) == FAILURE) {
@@ -860,7 +860,7 @@ PHP_FUNCTION(hash_equals)
 		result |= known_str[j] ^ user_str[j];
 	}
 
-	RETURN_BOOL(0 == result);
+	RETURN_BOOL(1 & ((result - 1) >> 8));
 }
 /* }}} */
 


### PR DESCRIPTION
From Taylor "Riastradh" Campbell on ##crypto on Freenode:

> Conversion to unsigned char guarantees the eighth bit (zero-indexed) is clear.  If equal, result == 0 so result - 1 == -1 which is all bits set so shifting right by 8 and anding with 1 gives 1.  If unequal, result - 1 is nonzero but below 255 so the shift gives zero.

See: https://cryptocoding.net/index.php/Coding_rules#Avoid_branchings_controlled_by_secret_data