### PR TITLE
Fix `is_callable` `$callable_name` for anon class methods

### DIFF
--- a/ext/standard/tests/general_functions/is_callable_anon.phpt
+++ b/ext/standard/tests/general_functions/is_callable_anon.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test is_callable() function : usage variations - anonymous class method
+--FILE--
+<?php
+
+new class {
+    function __construct() {
+        $fname = null;
+        if (is_callable([$this, 'f'], false, $fname)) {
+            call_user_func($fname);
+        } else {
+            echo "dang\n";
+        }
+    }
+    function f() {
+        echo "nice\n";
+    }
+};
+
+?>
+--EXPECT--
+nice

--- a/ext/standard/tests/general_functions/is_callable_variation1.phpt
+++ b/ext/standard/tests/general_functions/is_callable_variation1.phpt
@@ -21,10 +21,10 @@ function check_iscallable( $functions ) {
     var_dump( is_callable($func) );  //given only $var argument
     var_dump( is_callable($func, TRUE) );  //given $var and $syntax argument
     var_dump( is_callable($func, TRUE, $callable_name) );
-    echo $callable_name, "\n";
+    echo json_encode($callable_name) . "\n";
     var_dump( is_callable($func, FALSE) );  //given $var and $syntax argument
     var_dump( is_callable($func, FALSE, $callable_name) );
-    echo $callable_name, "\n";
+    echo json_encode($callable_name) . "\n";
     $counter++;
   }
 }
@@ -59,150 +59,149 @@ check_iscallable($undef_functions);
 
 ?>
 ===DONE===
---EXPECTF--
 *** Testing is_callable() on undefined functions ***
 -- Iteration  1 --
 bool(false)
 bool(true)
 bool(true)
-
+""
 bool(false)
 bool(false)
-
+""
 -- Iteration  2 --
 bool(false)
 bool(true)
 bool(true)
-
+""
 bool(false)
 bool(false)
-
+""
 -- Iteration  3 --
 bool(false)
 bool(true)
 bool(true)
- 
+" "
 bool(false)
 bool(false)
- 
+" "
 -- Iteration  4 --
 bool(false)
 bool(true)
 bool(true)
- 
+" "
 bool(false)
 bool(false)
- 
+" "
 -- Iteration  5 --
 bool(false)
 bool(true)
 bool(true)
-12356
+"12356"
 bool(false)
 bool(false)
-12356
+"12356"
 -- Iteration  6 --
 bool(false)
 bool(true)
 bool(true)
-
+"\u0000"
 bool(false)
 bool(false)
-
+"\u0000"
 -- Iteration  7 --
 bool(false)
 bool(true)
 bool(true)
-\0
+"\\0"
 bool(false)
 bool(false)
-\0
+"\\0"
 -- Iteration  8 --
 bool(false)
 bool(true)
 bool(true)
-hello world
+"hello world"
 bool(false)
 bool(false)
-hello world
+"hello world"
 -- Iteration  9 --
 bool(false)
 bool(true)
 bool(true)
-hello world
+"hello world"
 bool(false)
 bool(false)
-hello world
+"hello world"
 -- Iteration  10 --
 bool(false)
 bool(true)
 bool(true)
-welcome
+"welcome\u0000"
 bool(false)
 bool(false)
-welcome
+"welcome\u0000"
 -- Iteration  11 --
 bool(false)
 bool(true)
 bool(true)
-welcome\0
+"welcome\\0"
 bool(false)
 bool(false)
-welcome\0
+"welcome\\0"
 -- Iteration  12 --
 bool(false)
 bool(true)
 bool(true)
-==%%%***$$$@@@!!
+"==%%%***$$$@@@!!"
 bool(false)
 bool(false)
-==%%%***$$$@@@!!
+"==%%%***$$$@@@!!"
 -- Iteration  13 --
 bool(false)
 bool(true)
 bool(true)
-false
+"false"
 bool(false)
 bool(false)
-false
+"false"
 -- Iteration  14 --
 bool(false)
 bool(true)
 bool(true)
-8
+"8"
 bool(false)
 bool(false)
-8
+"8"
 -- Iteration  15 --
 bool(false)
 bool(true)
 bool(true)
-\t
+"\\t"
 bool(false)
 bool(false)
-\t
+"\\t"
 -- Iteration  16 --
 bool(false)
 bool(true)
 bool(true)
-\007
+"\\007"
 bool(false)
 bool(false)
-\007
+"\\007"
 -- Iteration  17 --
 bool(false)
 bool(true)
 bool(true)
-123
+"123"
 bool(false)
 bool(false)
-123
+"123"
 -- Iteration  18 --
 bool(false)
 bool(true)
 bool(true)
-echo()
+"echo()"
 bool(false)
 bool(false)
-echo()
+"echo()"
 ===DONE===

--- a/ext/standard/type.c
+++ b/ext/standard/type.c
@@ -409,8 +409,11 @@ PHP_FUNCTION(is_callable)
 	if (ZEND_NUM_ARGS() > 2) {
 		retval = zend_is_callable_ex(var, NULL, check_flags, &name, NULL, &error);
 		zval_dtor(callable_name);
-		//??? is it necessary to be consistent with old PHP ("\0" support)
-		if (UNEXPECTED(ZSTR_LEN(name) != strlen(ZSTR_VAL(name)))) {
+		if (retval && check_flags == 0) {
+			// `var` is callable and actually exists. Return `name` as-is (including
+			// any null-chars) so that `call_user_func($callable_name)` works.
+			ZVAL_STR(callable_name, name);
+		} else if (UNEXPECTED(ZSTR_LEN(name) != strlen(ZSTR_VAL(name)))) {
 			ZVAL_STRINGL(callable_name, ZSTR_VAL(name), strlen(ZSTR_VAL(name)));
 			zend_string_release(name);
 		} else {

--- a/ext/standard/type.c
+++ b/ext/standard/type.c
@@ -409,16 +409,7 @@ PHP_FUNCTION(is_callable)
 	if (ZEND_NUM_ARGS() > 2) {
 		retval = zend_is_callable_ex(var, NULL, check_flags, &name, NULL, &error);
 		zval_dtor(callable_name);
-		if (retval && check_flags == 0) {
-			// `var` is callable and actually exists. Return `name` as-is (including
-			// any null-chars) so that `call_user_func($callable_name)` works.
-			ZVAL_STR(callable_name, name);
-		} else if (UNEXPECTED(ZSTR_LEN(name) != strlen(ZSTR_VAL(name)))) {
-			ZVAL_STRINGL(callable_name, ZSTR_VAL(name), strlen(ZSTR_VAL(name)));
-			zend_string_release(name);
-		} else {
-			ZVAL_STR(callable_name, name);
-		}
+		ZVAL_STR(callable_name, name);
 	} else {
 		retval = zend_is_callable_ex(var, NULL, check_flags, NULL, NULL, &error);
 	}


### PR DESCRIPTION
Fixes bug https://bugs.php.net/bug.php?id=73118

This patch aims to make `is_callable` return a usable `$callable_name` for anonymous class methods. Anon class methods are formatted like...

    class@anonymous\x00/path/to/script.php0xdeadbeef::funcName

...where `\x00` is a null-char. The current behavior is to return just "class@anonymous" which is unusable as a function ref, e.g., as a parameter to `call_user_func`.

I attempt to preserve back-compat by only returning the full callable name (including null-char) when the function actually exists (retval is TRUE and `$syntax_only` is FALSE).

Open to suggestions if someone can think of a cleaner way.

**EDIT: See nikic's comment below and new commit.**