### PR TITLE
Disable RTLD_DEEPBIND when compiling with AddressSanitizer

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -131,6 +131,12 @@
 
 #if defined(HAVE_LIBDL) && !defined(ZEND_WIN32)
 
+# if defined(__has_feature)
+#  if __has_feature(address_sanitizer)
+#   define __SANITIZE_ADDRESS__
+#  endif
+# endif
+
 # ifndef RTLD_LAZY
 #  define RTLD_LAZY 1    /* Solaris 1, FreeBSD's (2.1.7.1 and older) */
 # endif
@@ -141,7 +147,7 @@
 
 # if defined(RTLD_GROUP) && defined(RTLD_WORLD) && defined(RTLD_PARENT)
 #  define DL_LOAD(libname)			dlopen(libname, RTLD_LAZY | RTLD_GLOBAL | RTLD_GROUP | RTLD_WORLD | RTLD_PARENT)
-# elif defined(RTLD_DEEPBIND)
+# elif defined(RTLD_DEEPBIND) && !defined(__SANITIZE_ADDRESS__)
 #  define DL_LOAD(libname)			dlopen(libname, RTLD_LAZY | RTLD_GLOBAL | RTLD_DEEPBIND)
 # else
 #  define DL_LOAD(libname)			dlopen(libname, RTLD_LAZY | RTLD_GLOBAL)


### PR DESCRIPTION
The AddressSanitizer doesn't support RTLD_DEEPBIND resulting in
erratic errors when deinitializing phar module and possibly others.

Clang use __has_feature() macro to indicate compilation with
AddressSanitizer while gcc uses __SANITIZE_ADDRESS__ define.

See https://bugs.php.net/bug.php?id=73677 for more background.