### PR TITLE
Fixed #74099 - Memory leak with openssl_encrypt()

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -6309,8 +6309,7 @@ static int php_openssl_cipher_update(const EVP_CIPHER *cipher_type,
 
 	*poutbuf = zend_string_alloc((int)data_len + EVP_CIPHER_block_size(cipher_type), 0);
 
-	if ((!enc || data_len > 0) &&
-			!EVP_CipherUpdate(cipher_ctx, (unsigned char*)ZSTR_VAL(*poutbuf),
+	if (!EVP_CipherUpdate(cipher_ctx, (unsigned char*)ZSTR_VAL(*poutbuf),
 					&i, (unsigned char *)data, (int)data_len)) {
 		/* we don't show warning when we fail but if we ever do, then it should look like this:
 		if (mode->is_single_run_aead && !enc) {
@@ -6366,7 +6365,6 @@ PHP_FUNCTION(openssl_encrypt)
 		php_error_docref(NULL, E_WARNING, "Failed to create cipher context");
 		RETURN_FALSE;
 	}
-
 	php_openssl_load_cipher_mode(&mode, cipher_type);
 
 	if (php_openssl_cipher_init(cipher_type, cipher_ctx, &mode,

--- a/ext/openssl/tests/bug74099.phpt
+++ b/ext/openssl/tests/bug74099.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #74099 Memory leak with openssl_encrypt()
+--SKIPIF--
+<?php
+if (!extension_loaded("openssl")) die("skip");
+?>
+--FILE--
+<?php
+$aad = random_bytes(32);
+$iv = random_bytes(16);
+$key = random_bytes(32);
+
+$plaintext = '';
+$tag = null;
+
+$ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, \OPENSSL_RAW_DATA, $iv, $tag, $aad);
+var_dump($ciphertext);
+?>
+--EXPECTF--
+string(0) ""


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=74099

Actually changes are following:
1) `(!enc || data_len > 0)` was changed to `(!enc || data_len >= 0)`
2) but `data_len` is unsigned that's why `data_len >= 0` is always `true` and condition was removed.