### PR TITLE
Improvement: Generate a SOAP cache per PHP API version

### DIFF
--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -3196,6 +3196,8 @@ sdlPtr get_sdl(zval *this_ptr, char *uri, zend_long cache_wsdl)
 		unsigned char digest[16];
 		int len = strlen(SOAP_GLOBAL(cache_dir));
 		time_t cached;
+		char php_api_version[11];
+		int php_api_version_len = 0;
 		char *user = php_get_current_user();
 		int user_len = user ? strlen(user) + 1 : 0;
 
@@ -3204,7 +3206,9 @@ sdlPtr get_sdl(zval *this_ptr, char *uri, zend_long cache_wsdl)
 		PHP_MD5Update(&context, (unsigned char*)uri, uri_len);
 		PHP_MD5Final(digest, &context);
 		make_digest(md5str, digest);
-		key = emalloc(len+sizeof("/wsdl-")-1+user_len+sizeof(md5str));
+		snprintf(php_api_version, sizeof(php_api_version), "%d-", PHP_API_VERSION);
+		php_api_version_len = strlen(php_api_version);
+		key = emalloc(len+sizeof("/wsdl-")-1+user_len+php_api_version_len+sizeof(md5str));
 		memcpy(key,SOAP_GLOBAL(cache_dir),len);
 		memcpy(key+len,"/wsdl-",sizeof("/wsdl-")-1);
 		len += sizeof("/wsdl-")-1;
@@ -3213,6 +3217,8 @@ sdlPtr get_sdl(zval *this_ptr, char *uri, zend_long cache_wsdl)
 			len += user_len-1;
 			key[len++] = '-';
 		}
+		memcpy(key+len,php_api_version,php_api_version_len);
+		len += php_api_version_len;
 		memcpy(key+len,md5str,sizeof(md5str));
 
 		if ((sdl = get_sdl_from_cache(key, uri, t-SOAP_GLOBAL(cache_ttl), &cached)) != NULL) {


### PR DESCRIPTION
The SOAP cache files are only compatible amongst the same PHP API version.
The internal data structure of the cache changed between PHP 5.6 and 7.0.
This makes the cache written by 5.6 unreadable by 7.0.
To bypass this issue the PHP API version appended as part of the cache file name.

E.g.:
```php
<?php
$client = new SoapClient('http://www.webservicex.com/globalweather.asmx?wsdl', array('cache_wsdl' => WSDL_CACHE_DISK) );

$params = array('CountryName' => 'Switzerland', 'CityName' => 'Neuchatel');
$response = $client->GetWeather($params);
```

Run this example with PHP 5.6 and afterwards with PHP 7.0/7.1. In general the default cache directory is the /tmp folder (on Linux or the equivalent on other systems).

PHP 5.6 will create the SOAP cache file 'wsdl--25973e3a4f1f264d79dcf66967109a98' (the username in the filename is omitted, due to running the example script in a container namespace). If PHP 7.0 runs it sees the cache file, but is unable to read the content.
A SoapFault exception is triggered:
```
Fatal error: Uncaught SoapFault exception: [Client] Function ("GetWeather") is not a valid method for this service in /tmp/test.php:5
Stack trace:
#0 /tmp/test.php(5): SoapClient->__call('GetWeather', Array)
#1 {main}
  thrown in /tmp/test.php on line 5
```

My simple solution to this problem is to add the PHP API version to the SOAP cache file name:
`PHP 5.6 without Patch: wsdl--25973e3a4f1f264d79dcf66967109a98`
`PHP 5.6: wsdl--20131106-25973e3a4f1f264d79dcf66967109a98`
`PHP 7.0: wsdl--20151012-25973e3a4f1f264d79dcf66967109a98`

This problem can occur when switching the PHP version of an application. We (working for a webhosting company) experience this issue multiple time when changing the current PHP version.
The same issue applies if multiple PHP versions are used on a machine and the CLI and FastCGI/PHP-FPM version differ. E.g.  a cron periodically prefetches some data from a SOAP server. The same SOAP endpoint is uses in a webapplication.

This issue is hard to reflect in a test case. Any advice in testing this case?

The issue could also resolved with the following alternative solutions:
- Define a different cache folder per PHP version => soap.wsdl_cache_dir
 - This implies to have different caching folders (one per version) setup on the target host. The folder creation is currently not handled by the SOAP code.
- Clear the SOAP cache files before a version switch