### PR TITLE
Prevent "make install" clobbering configuration for pre-existing installations; remove error ignore

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -53,7 +53,7 @@ install-headers:
 			paths="$$paths $(INSTALL_ROOT)$(phpincludedir)/$$i"; \
 		done; \
 		$(mkinstalldirs) $$paths && \
-		echo "Installing header files:           $(INSTALL_ROOT)$(phpincludedir)/" && \
+		echo "Installing header files:          $(INSTALL_ROOT)$(phpincludedir)/" && \
 		for i in `echo $(INSTALL_HEADERS)`; do \
 			if test "$(PHP_PECL_EXTENSION)"; then \
 				src=`echo $$i | $(SED) -e "s#ext/$(PHP_PECL_EXTENSION)/##g"`; \

--- a/sapi/fpm/Makefile.frag
+++ b/sapi/fpm/Makefile.frag
@@ -10,10 +10,10 @@ install-fpm: $(SAPI_FPM_PATH)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)/run
 	@$(INSTALL) -m 0755 $(SAPI_FPM_PATH) $(INSTALL_ROOT)$(sbindir)/$(program_prefix)php-fpm$(program_suffix)$(EXEEXT)
 
-        @if test -f "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf"; then \
-		echo "Installing PHP FPM config:        skipping"; \
+	@if test -f "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf"; then \
+		echo "Installing PHP FPM defconfig:     skipping"; \
 	else \
-		echo "Installing PHP FPM config:        $(INSTALL_ROOT)$(sysconfdir)/" && \
+		echo "Installing PHP FPM defconfig:     $(INSTALL_ROOT)$(sysconfdir)/" && \
 		$(mkinstalldirs) $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d; \
 		@$(INSTALL_DATA) sapi/fpm/php-fpm.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf.default"; \
 		@$(INSTALL_DATA) sapi/fpm/www.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.d/www.conf.default"; \

--- a/sapi/fpm/Makefile.frag
+++ b/sapi/fpm/Makefile.frag
@@ -11,13 +11,13 @@ install-fpm: $(SAPI_FPM_PATH)
 	@$(INSTALL) -m 0755 $(SAPI_FPM_PATH) $(INSTALL_ROOT)$(sbindir)/$(program_prefix)php-fpm$(program_suffix)$(EXEEXT)
 
         @if test -f "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf"; then \
-                echo "Installing PHP FPM config:        skipping"; \
-        else \
-                echo "Installing PHP FPM config:        $(INSTALL_ROOT)$(sysconfdir)/" && \
-                $(mkinstalldirs) $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d; \
-                @$(INSTALL_DATA) sapi/fpm/php-fpm.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf.default"; \
-                @$(INSTALL_DATA) sapi/fpm/www.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.d/www.conf.default"; \
-        fi
+		echo "Installing PHP FPM config:        skipping"; \
+	else \
+		echo "Installing PHP FPM config:        $(INSTALL_ROOT)$(sysconfdir)/" && \
+		$(mkinstalldirs) $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d; \
+		@$(INSTALL_DATA) sapi/fpm/php-fpm.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf.default"; \
+		@$(INSTALL_DATA) sapi/fpm/www.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.d/www.conf.default"; \
+	fi
 	
 	@echo "Installing PHP FPM man page:      $(INSTALL_ROOT)$(mandir)/man8/"
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man8

--- a/sapi/fpm/Makefile.frag
+++ b/sapi/fpm/Makefile.frag
@@ -10,11 +10,15 @@ install-fpm: $(SAPI_FPM_PATH)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)/run
 	@$(INSTALL) -m 0755 $(SAPI_FPM_PATH) $(INSTALL_ROOT)$(sbindir)/$(program_prefix)php-fpm$(program_suffix)$(EXEEXT)
 
-	@echo "Installing PHP FPM config:        $(INSTALL_ROOT)$(sysconfdir)/" && \
-	$(mkinstalldirs) $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d || :
-	@$(INSTALL_DATA) sapi/fpm/php-fpm.conf $(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf.default || :
-	@$(INSTALL_DATA) sapi/fpm/www.conf $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d/www.conf.default || :
-
+        @if test -f "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf"; then \
+                echo "Installing PHP FPM config:        skipping"; \
+        else \
+                echo "Installing PHP FPM config:        $(INSTALL_ROOT)$(sysconfdir)/" && \
+                $(mkinstalldirs) $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d; \
+                @$(INSTALL_DATA) sapi/fpm/php-fpm.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf.default"; \
+                @$(INSTALL_DATA) sapi/fpm/www.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.d/www.conf.default"; \
+        fi
+	
 	@echo "Installing PHP FPM man page:      $(INSTALL_ROOT)$(mandir)/man8/"
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man8
 	@$(INSTALL_DATA) sapi/fpm/php-fpm.8 $(INSTALL_ROOT)$(mandir)/man8/php-fpm$(program_suffix).8

--- a/sapi/fpm/Makefile.frag
+++ b/sapi/fpm/Makefile.frag
@@ -15,8 +15,8 @@ install-fpm: $(SAPI_FPM_PATH)
 	else \
 		echo "Installing PHP FPM defconfig:     $(INSTALL_ROOT)$(sysconfdir)/" && \
 		$(mkinstalldirs) $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d; \
-		@$(INSTALL_DATA) sapi/fpm/php-fpm.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf.default"; \
-		@$(INSTALL_DATA) sapi/fpm/www.conf "$(INSTALL_ROOT)$(sysconfdir)/php-fpm.d/www.conf.default"; \
+		$(INSTALL_DATA) sapi/fpm/php-fpm.conf $(INSTALL_ROOT)$(sysconfdir)/php-fpm.conf.default; \
+		$(INSTALL_DATA) sapi/fpm/www.conf $(INSTALL_ROOT)$(sysconfdir)/php-fpm.d/www.conf.default; \
 	fi
 	
 	@echo "Installing PHP FPM man page:      $(INSTALL_ROOT)$(mandir)/man8/"


### PR DESCRIPTION
By default php-fpm.d/* is included in the config. Writing anything there will break most existing PHP applications, so it should be skipped if installing into an existing environment.

Package maintainers generally build in a clean environment, so shouldn't be affected.

Also, $(INSTALL_DATA) won't return unnecessary errors, so don't ignore them. If installation of something is part of make install, and it doesn't happen, it should fail. ( || : at the end removed)