### PR TITLE
report about OpenSSL 1.1 not supported during configure

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2337,13 +2337,15 @@ AC_DEFUN([PHP_SETUP_OPENSSL],[
 
   dnl If pkg-config is found try using it
   if test "$PHP_OPENSSL_DIR" = "yes" && test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
-    if $PKG_CONFIG --atleast-version=0.9.8 openssl; then
+    if $PKG_CONFIG --atleast-version=1.1 openssl; then
+      AC_MSG_ERROR([OpenSSL version >= 1.1 is not supported.])
+    elif $PKG_CONFIG --atleast-version=0.9.8 openssl; then
       found_openssl=yes
       OPENSSL_LIBS=`$PKG_CONFIG --libs openssl`
       OPENSSL_INCS=`$PKG_CONFIG --cflags-only-I openssl`
       OPENSSL_INCDIR=`$PKG_CONFIG --variable=includedir openssl`
     else
-      AC_MSG_ERROR([OpenSSL version 0.9.8 or greater required.])
+      AC_MSG_ERROR([OpenSSL version >= 0.9.8 and < 1.1 required.])
     fi
 
     if test -n "$OPENSSL_LIBS"; then


### PR DESCRIPTION
As only PHP 7.1+ supports OpenSSL 1.1 new API.

Other way, is to fix 7.0 to support it ;)
