### PR TITLE
Fix potential crash when setting invalid declare value

### DIFF
--- a/Zend/tests/declare_001.phpt
+++ b/Zend/tests/declare_001.phpt
@@ -24,4 +24,4 @@ Warning: Unsupported encoding [1] in %sdeclare_001.php on line %d
 
 Warning: Unsupported encoding [1.1231312321313E+20] in %sdeclare_001.php on line %d
 
-Fatal error: Encoding must be a literal in %s on line %d
+Parse error: syntax error, unexpected 'M_PI' (T_STRING), expecting integer number (T_LNUMBER) or floating-point number (T_DNUMBER) or quoted-string (T_CONSTANT_ENCAPSED_STRING) in %s/declare_001.php on line 6

--- a/Zend/tests/declare_002.phpt
+++ b/Zend/tests/declare_002.phpt
@@ -24,4 +24,4 @@ Warning: Unsupported encoding [%d] in %sdeclare_002.php on line 3
 
 Warning: Unsupported encoding [%f] in %sdeclare_002.php on line 4
 
-Fatal error: Encoding must be a literal in %sdeclare_002.php on line 6
+Parse error: syntax error, unexpected 'M_PI' (T_STRING), expecting integer number (T_LNUMBER) or floating-point number (T_DNUMBER) or quoted-string (T_CONSTANT_ENCAPSED_STRING) in %s/declare_002.php on line 6

--- a/Zend/tests/declare_003.phpt
+++ b/Zend/tests/declare_003.phpt
@@ -18,4 +18,4 @@ Warning: Unsupported encoding [1] in %sdeclare_003.php on line %d
 
 Warning: Unsupported encoding [11111111111111] in %sdeclare_003.php on line %d
 
-Fatal error: Encoding must be a literal in %s on line %d
+Parse error: syntax error, unexpected 'M_PI' (T_STRING), expecting integer number (T_LNUMBER) or floating-point number (T_DNUMBER) or quoted-string (T_CONSTANT_ENCAPSED_STRING) in %s/declare_003.php on line 5

--- a/Zend/tests/declare_004.phpt
+++ b/Zend/tests/declare_004.phpt
@@ -17,4 +17,4 @@ Warning: Unsupported encoding [%d] in %sdeclare_004.php on line 3
 
 Warning: Unsupported encoding [%f] in %sdeclare_004.php on line 4
 
-Fatal error: Encoding must be a literal in %sdeclare_004.php on line 5
+Parse error: syntax error, unexpected 'M_PI' (T_STRING), expecting integer number (T_LNUMBER) or floating-point number (T_DNUMBER) or quoted-string (T_CONSTANT_ENCAPSED_STRING) in %s/declare_004.php on line 5

--- a/Zend/tests/declare_006.phpt
+++ b/Zend/tests/declare_006.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Use of non-literals in declare ticks values crashes compiler
+--FILE--
+<?php
+
+declare(ticks = UNKNOWN_CONST) {
+  echo 'Done';
+}
+--EXPECTF--
+Parse error: syntax error, unexpected 'UNKNOWN_CONST' (T_STRING), expecting integer number (T_LNUMBER) or floating-point number (T_DNUMBER) or quoted-string (T_CONSTANT_ENCAPSED_STRING) in %s/declare_006.php on line 3

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -249,7 +249,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> non_empty_parameter_list argument_list non_empty_argument_list property_list
 %type <ast> class_const_list class_const_decl name_list trait_adaptations method_body non_empty_for_exprs
 %type <ast> ctor_arguments alt_if_stmt_without_else trait_adaptation_list lexical_vars
-%type <ast> lexical_var_list encaps_list
+%type <ast> lexical_var_list encaps_list declare_list declare_decl declare_scalar
 %type <ast> array_pair non_empty_array_pair_list array_pair_list possible_array_pair
 %type <ast> isset_variable type return_type type_expr
 %type <ast> identifier
@@ -394,6 +394,22 @@ const_list:
 	|	const_decl { $$ = zend_ast_create_list(1, ZEND_AST_CONST_DECL, $1); }
 ;
 
+declare_list:
+		declare_list ',' declare_decl { $$ = zend_ast_list_add($1, $3); }
+	|	declare_decl { $$ = zend_ast_create_list(1, ZEND_AST_CONST_DECL, $1); }
+;
+
+declare_decl:
+		T_STRING '=' declare_scalar
+			{ $$ = zend_ast_create(ZEND_AST_CONST_ELEM, $1, $3, NULL); }
+;
+
+declare_scalar:
+		T_LNUMBER { $$ = $1; }
+	|	T_DNUMBER { $$ = $1; }
+	|	T_CONSTANT_ENCAPSED_STRING { $$ = $1; }
+;
+
 inner_statement_list:
 		inner_statement_list inner_statement
 			{ $$ = zend_ast_list_add($1, $2); }
@@ -440,7 +456,7 @@ statement:
 	|	T_FOREACH '(' expr T_AS foreach_variable T_DOUBLE_ARROW foreach_variable ')'
 		foreach_statement
 			{ $$ = zend_ast_create(ZEND_AST_FOREACH, $3, $7, $5, $9); }
-	|	T_DECLARE '(' const_list ')'
+	|	T_DECLARE '(' declare_list ')'
 			{ zend_handle_encoding_declaration($3); }
 		declare_statement
 			{ $$ = zend_ast_create(ZEND_AST_DECLARE, $3, $6); }


### PR DESCRIPTION
Using a non-literal expression in a declare value can cause the
compiler to crash trying to turn that AST node into a usable zval.

There was an existing test for such values using 'encoding',
but that didn't crash because it's handled by the lexer
rather than being compiled.

Trying to use a non-literal with ticks reproduces the crash.