### PR TITLE
Fix potential crash when setting invalid declare value

### DIFF
--- a/Zend/tests/declare_006.phpt
+++ b/Zend/tests/declare_006.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Use of non-literals in declare ticks values crashes compiler
+--FILE--
+<?php
+declare(ticks = UNKNOWN_CONST) {
+  echo 'Done';
+}
+--EXPECTF--
+
+Fatal error: declare(ticks) value must be a literal in %sdeclare_006.php on line 2

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4954,8 +4954,12 @@ void zend_compile_declare(zend_ast *ast) /* {{{ */
 		zend_ast *declare_ast = declares->child[i];
 		zend_ast *name_ast = declare_ast->child[0];
 		zend_ast *value_ast = declare_ast->child[1];
-
 		zend_string *name = zend_ast_get_str(name_ast);
+
+		if (value_ast->kind != ZEND_AST_ZVAL) {
+			zend_error_noreturn(E_COMPILE_ERROR, "declare(%s) value must be a literal", ZSTR_VAL(name));
+		}
+
 		if (zend_string_equals_literal_ci(name, "ticks")) {
 			zval value_zv;
 			zend_const_expr_to_zval(&value_zv, value_ast);


### PR DESCRIPTION
Using a non-literal expression in a declare value can cause the
compiler to crash trying to turn that AST node into a usable zval.

There was an existing test for such values using 'encoding',
but that didn't crash because it's handled by the lexer
rather than being compiled.

Trying to use a non-literal with ticks reproduces the crash.