### PR TITLE
Fix some compilation warnings

### DIFF
--- a/ext/fileinfo/libmagic/funcs.c
+++ b/ext/fileinfo/libmagic/funcs.c
@@ -61,17 +61,15 @@ extern public void convert_libmagic_pattern(zval *pattern, char *val, int len, i
 protected int
 file_printf(struct magic_set *ms, const char *fmt, ...)
 {
-	int rv;
 	va_list ap;
-	int len;
 	char *buf = NULL, *newstr;
 
 	va_start(ap, fmt);
-	len = vspprintf(&buf, 0, fmt, ap);
+	vspprintf(&buf, 0, fmt, ap);
 	va_end(ap);
 
 	if (ms->o.buf != NULL) {
-		len = spprintf(&newstr, 0, "%s%s", ms->o.buf, (buf ? buf : ""));
+		spprintf(&newstr, 0, "%s%s", ms->o.buf, (buf ? buf : ""));
 		if (buf) {
 			efree(buf);
 		}

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -240,7 +240,6 @@ dnl PNG is required by GD library
 
 dnl Various checks for GD features
   PHP_GD_ZLIB
-  PHP_GD_TTSTR
   PHP_GD_WEBP
   PHP_GD_JPEG
   PHP_GD_PNG

--- a/ext/gd/libgd/gd_interpolation.c
+++ b/ext/gd/libgd/gd_interpolation.c
@@ -935,7 +935,6 @@ static inline LineContribType *_gdContributionsCalc(unsigned int line_size, unsi
 	int windows_size;
 	unsigned int u;
 	LineContribType *res;
-	int overflow_error = 0;
 
 	if (scale_d < 1.0) {
 		width_d = filter_width_d / scale_d;

--- a/ext/gd/libgd/gdhelpers.c
+++ b/ext/gd/libgd/gdhelpers.c
@@ -15,7 +15,6 @@ char *
 gd_strtok_r (char *s, char *sep, char **state)
 {
   char separators[256];
-  char *start;
   char *result = 0;
   memset (separators, 0, sizeof (separators));
   while (*sep)
@@ -28,7 +27,6 @@ gd_strtok_r (char *s, char *sep, char **state)
       /* Pick up where we left off */
       s = *state;
     }
-  start = s;
   /* 1. EOS */
   if (!(*s))
     {


### PR DESCRIPTION
I noticed when doing a minimal compile that there are some compilation warnings that can easily be fixed. I later realized that there are more when doing a larger compilation, but these are mostly under the lib* folders of the extensions.

Not sure if it's a good idea to fix these, so waiting for feedback first. But I think the PHP_GD_TTSTR is a valid cleanup anyway ...