### PR TITLE
fix command not found warning in ext/gd

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -240,7 +240,6 @@ dnl PNG is required by GD library
 
 dnl Various checks for GD features
   PHP_GD_ZLIB
-  PHP_GD_TTSTR
   PHP_GD_WEBP
   PHP_GD_JPEG
   PHP_GD_PNG


### PR DESCRIPTION
./configure: line 32011: PHP_GD_TTSTR: command not found

Removed in 494c5dc77ae92d21db915abada2ecefaca620543
