### PR TITLE
Add php.ini option curl.capath

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -513,6 +513,7 @@ ZEND_GET_MODULE (curl)
 /* {{{ PHP_INI_BEGIN */
 PHP_INI_BEGIN()
 	PHP_INI_ENTRY("curl.cainfo", "", PHP_INI_SYSTEM, NULL)
+	PHP_INI_ENTRY("curl.capath", "", PHP_INI_SYSTEM, NULL)
 PHP_INI_END()
 /* }}} */
 
@@ -1928,6 +1929,7 @@ static void create_certinfo(struct curl_certinfo *ci, zval *listcode)
 static void _php_curl_set_default_options(php_curl *ch)
 {
 	char *cainfo;
+	char *capath;
 
 	curl_easy_setopt(ch->cp, CURLOPT_NOPROGRESS,        1);
 	curl_easy_setopt(ch->cp, CURLOPT_VERBOSE,           0);
@@ -1950,6 +1952,14 @@ static void _php_curl_set_default_options(php_curl *ch)
 	}
 	if (cainfo && cainfo[0] != '\0') {
 		curl_easy_setopt(ch->cp, CURLOPT_CAINFO, cainfo);
+	}
+
+	capath = INI_STR("openssl.capath");
+	if (!(capath && capath[0] != '\0')) {
+		capath = INI_STR("curl.capath");
+	}
+	if (capath && capath[0] != '\0') {
+		curl_easy_setopt(ch->cp, CURLOPT_CAPATH, capath);
 	}
 
 #if defined(ZTS)

--- a/php.ini-development
+++ b/php.ini-development
@@ -1889,6 +1889,10 @@ ldap.max_links = -1
 ; absolute path.
 ;curl.cainfo =
 
+; A default value for the CURLOPT_CAPATH option. This is required to be an
+; absolute path. This value must be a correctly hashed certificate directory. See https://www.openssl.org/docs/man1.1.0/apps/c_rehash.html
+;curl.capath =
+
 [openssl]
 ; The location of a Certificate Authority (CA) file on the local filesystem
 ; to use when verifying the identity of SSL/TLS peers. Most users should

--- a/php.ini-production
+++ b/php.ini-production
@@ -1895,6 +1895,10 @@ ldap.max_links = -1
 ; absolute path.
 ;curl.cainfo =
 
+; A default value for the CURLOPT_CAPATH option. This is required to be an
+; absolute path. This value must be a correctly hashed certificate directory. See https://www.openssl.org/docs/man1.1.0/apps/c_rehash.html
+;curl.capath =
+
 [openssl]
 ; The location of a Certificate Authority (CA) file on the local filesystem
 ; to use when verifying the identity of SSL/TLS peers. Most users should


### PR DESCRIPTION
There is no current way to configure an OpenSSL certs directory without calling `curl_setopt(CURLOPT_CAPATH,…)` for every use of cURL in PHP. This patch adds a php.ini option `curl.capath` that mirrors the `openssl.capath` option.

The attached patch is essentially a copy/replace/paste of the existing code for the `curl.cainfo` option.