### PR TITLE
oci8 - Implementation of Oracle TAF Callback (PHP5)

### DIFF
--- a/ext/oci8/config.w32
+++ b/ext/oci8/config.w32
@@ -116,7 +116,7 @@ if (PHP_OCI8_12C != "no") {
 	if (CHECK_HEADER_ADD_INCLUDE("oci.h", "CFLAGS_OCI8_12C", oci8_12c_inc_paths) &&
 			CHECK_LIB("oci.lib", "oci8_12c", oci8_12c_lib_paths))
 	{
-		EXTENSION('oci8_12c', 'oci8.c oci8_lob.c oci8_statement.c oci8_collection.c oci8_interface.c', null, null, null, "ext\\oci8_12c")
+		EXTENSION('oci8_12c', 'oci8.c oci8_lob.c oci8_statement.c oci8_collection.c oci8_interface.c oci8_failover.c', null, null, null, "ext\\oci8_12c")
 
 		AC_DEFINE('HAVE_OCI8', 1);
 		AC_DEFINE('HAVE_OCI_INSTANT_CLIENT', 1);

--- a/ext/oci8/examples/oci8_taf_extended.php
+++ b/ext/oci8/examples/oci8_taf_extended.php
@@ -1,0 +1,89 @@
+<?php
+
+// Create connection
+$conn = oci_pconnect('username', 'password', 'pool');
+if (!$conn) {
+    $e = oci_error();
+    trigger_error($e['message'], E_USER_ERROR);
+}
+
+// Register TAF callback
+oci_register_taf_callback($conn, 'tafCallback');
+
+// Do something, that requires TAF callbacks
+switchSchema($conn);
+
+// Do some stuff
+
+// For testing:
+//   Do a long SELECT statement and sleep between
+//   each fetch. Start the script and while it's
+//   running shutdown the server it is connected to.
+//   This way a failover is triggered and the
+//   callback function is being called.
+
+// Close connection
+oci_close($conn);
+
+
+
+
+/* Switches the schema on database
+ *
+ * Without TAF callback, the script would fail
+ * once a failover occurs, as the new server
+ * still has the default schema. Using TAF
+ * callback the necessary settings can be setup
+ * for the new server.
+ */
+function switchSchema($conn) {
+	$stid = oci_parse($conn, 'ALTER SESSION SET CURRENT_SCHEMA = foobar');
+	oci_execute($stid);
+	oci_free_statement($stid);
+}
+
+/* Userspace callback function
+ *
+ * This function is a modified version of
+ * cdemofo.c from the following package:
+ * "Oracle Database Examples (12.1.0.2.0)
+ *  for Microsoft Windows (x64)"
+ */
+function tafCallback($conn, $event, $type) {
+	switch ($event) {
+		case OCI_FO_BEGIN:
+			printf(" Failing Over ... Please stand by \n");
+			printf(" Failover type was found to be %s \n",
+					(($type==OCI_FO_NONE) ? "NONE"
+					:($type==OCI_FO_SESSION) ? "SESSION"
+					:($type==OCI_FO_SELECT) ? "SELECT"
+					: "UNKNOWN!"));
+			break;
+
+		case OCI_FO_ABORT:
+			printf(" Failover aborted. Failover will not take place.\n");
+			break;
+
+		case OCI_FO_END:
+			printf(" Failover ended ...switching schema");
+			switchSchema($conn);
+			printf(" ...resuming services\n");
+			break;
+
+		case OCI_FO_REAUTH:
+			printf(" Failed over user. Switching schema.");
+			switchSchema($conn);
+			printf(" Resuming services\n");
+			break;
+
+		case OCI_FO_ERROR:
+			printf(" Failover error gotten. Sleeping...\n");
+			sleep(3);
+			return OCI_FO_RETRY;
+			break;
+
+		default:
+			printf("Bad Failover Event: %d.\n", $event);
+			break;
+	}
+}

--- a/ext/oci8/examples/oci8_taf_simple.php
+++ b/ext/oci8/examples/oci8_taf_simple.php
@@ -1,0 +1,53 @@
+<?php
+
+// Create connection
+$conn = oci_pconnect('username', 'password', 'pool');
+if (!$conn) {
+    $e = oci_error();
+    trigger_error($e['message'], E_USER_ERROR);
+}
+
+// Register TAF callback
+oci_register_taf_callback($conn, 'tafCallback');
+
+// Do something, that requires TAF callbacks
+switchSchema($conn);
+
+// Do some stuff
+
+// For testing:
+//   Do a long SELECT statement and sleep between
+//   each fetch. Start the script and while it's
+//   running shutdown the server it is connected to.
+//   This way a failover is triggered and the
+//   callback function is being called.
+
+// Close connection
+oci_close($conn);
+
+
+
+
+/* Switches the schema on database
+ *
+ * Without TAF callback, the script would fail
+ * once a failover occurs, as the new server
+ * still has the default schema. Using TAF
+ * callback the necessary settings can be setup
+ * for the new server.
+ */
+function switchSchema($conn) {
+	$stid = oci_parse($conn, 'ALTER SESSION SET CURRENT_SCHEMA = foobar');
+	oci_execute($stid);
+	oci_free_statement($stid);
+}
+
+/* Userspace callback function */
+function tafCallback($conn, $event) {
+	// At the end of a successfull failover, the event
+    // will either be OCI_FO_END or OCI_FO_REAUTH
+	if($event == OCI_FO_END || $event == OCI_FO_REAUTH) {
+		// Do something, that requires TAF callbacks
+		switchSchema($conn);
+	}
+}

--- a/ext/oci8/oci8_failover.c
+++ b/ext/oci8/oci8_failover.c
@@ -1,0 +1,164 @@
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 5                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2016 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Stig Sæther Bakken <ssb@php.net>                            |
+   |          Thies C. Arntzen <thies@thieso.net>                         |
+   |                                                                      |
+   | Collection support by Andy Sautins <asautins@veripost.net>           |
+   | Temporary LOB support by David Benson <dbenson@mancala.com>          |
+   | ZTS per process OCIPLogon by Harald Radi <harald.radi@nme.at>        |
+   |                                                                      |
+   | Redesigned by: Antony Dovgal <antony@zend.com>                       |
+   |                Andi Gutmans <andi@zend.com>                          |
+   |                Wez Furlong <wez@omniti.com>                          |
+   +----------------------------------------------------------------------+
+*/
+
+/* $Id$ */
+
+
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "ext/standard/info.h"
+#include "php_ini.h"
+
+#if HAVE_OCI8
+
+#include "php_oci8.h"
+#include "php_oci8_int.h"
+
+/*typedef struct {
+	char *callback;
+} php_oci_failover_context;*/
+
+/* {{{ callback_fn() 
+   OCI TAF callback function, calling userspace function */
+sb4 callback_fn(OCISvcCtx *svchp, OCIEnv *envhp, php_oci_connection *fo_ctx, ub4 fo_type, ub4 fo_event)
+{
+	TSRMLS_FETCH();
+
+	/* Check if userspace callback function was disabled */
+	if (!fo_ctx->taf_callback || !strcmp(PHP_OCI_TAF_DISABLE_CALLBACK, fo_ctx->taf_callback)) {
+		return 0;
+	}
+
+	/* Create zval */
+	zval *retval, *callback, *params[3];
+	MAKE_STD_ZVAL(retval);
+	MAKE_STD_ZVAL(callback);
+	MAKE_STD_ZVAL(params[0]);
+	MAKE_STD_ZVAL(params[1]);
+	MAKE_STD_ZVAL(params[2]);
+
+	/* Initialize zval */
+	ZVAL_STRING(callback, fo_ctx->taf_callback, 1);
+	ZVAL_RESOURCE(params[0], fo_ctx->id);
+	ZVAL_LONG(params[1], fo_event);
+	ZVAL_LONG(params[2], fo_type);
+
+	/* Call user function (if possible) */
+	if (call_user_function(EG(function_table), NULL, callback, retval, 3, params TSRMLS_CC) == FAILURE) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to call taf callback function, is it defined?");
+	}
+
+	/* Return value */
+	int returnValue = (int) Z_LVAL_P(retval);
+
+	/* Setting params[0] to null so ressource isn't destroyed on zval_dtor */
+	ZVAL_NULL(params[0]);
+
+	/* Cleanup */
+	zval_dtor(callback);
+	zval_dtor(retval);
+	zval_dtor(params[0]);
+	zval_dtor(params[1]);
+	zval_dtor(params[2]);
+	return returnValue;
+}
+/* }}} */
+
+/* {{{ php_oci_disable_taf_callback()
+   Disables the userspace callback function for Oracle TAF,
+   while keeping the OCI callback alive */
+int php_oci_disable_taf_callback(php_oci_connection *connection TSRMLS_DC)
+{
+	return php_oci_register_taf_callback(connection, NULL TSRMLS_CC);
+}
+/* }}} */
+
+/* {{{ php_oci_register_taf_callback()
+   Register a callback function for Oracle TAF */
+int php_oci_register_taf_callback(php_oci_connection *connection, char *callback TSRMLS_DC)
+{
+	sword errstatus;
+	char *oldCallback = NULL;
+
+	if (!callback) {
+		/* Disable callback */
+		if (!connection->taf_callback || !strcmp(PHP_OCI_TAF_DISABLE_CALLBACK, connection->taf_callback)) {
+			return 0; // Nothing to disable
+		}
+
+		oldCallback = connection->taf_callback;
+		callback = PHP_OCI_TAF_DISABLE_CALLBACK;
+	} else if (connection->taf_callback) {
+		/* Overwriting old callback */
+		oldCallback = connection->taf_callback;
+	}
+
+	/* Set userspace callback function */
+	connection->taf_callback = pestrdup(callback, connection->is_persistent);
+
+	/* OCI callback function already registered */
+	if (oldCallback) {
+		pefree(oldCallback, connection->is_persistent);
+		return 0;
+	}
+
+	/* temporary failover callback structure */
+	OCIFocbkStruct failover;
+	/* set context */
+	failover.fo_ctx = connection;
+
+	/* set callback function */
+	failover.callback_function = &callback_fn;
+
+	/* do the registration */
+	PHP_OCI_CALL_RETURN(errstatus, OCIAttrSet, (connection->server, (ub4) OCI_HTYPE_SERVER, (void *) &failover, (ub4) 0, (ub4) OCI_ATTR_FOCBK, connection->err));
+
+	if (errstatus  != OCI_SUCCESS) {
+		pefree(connection->taf_callback, connection->is_persistent);
+		connection->errcode = php_oci_error(connection->err, errstatus TSRMLS_CC);
+		return 2;
+	}
+
+	/* successful conclusion */
+	return 0;
+}
+/* }}} */
+
+#endif /* HAVE_OCI8 */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -44,6 +44,29 @@
 #define OCI_STMT_CALL 10
 #endif
 
+/* {{{ proto bool oci_register_taf_callback( resource connection [, string callback] )
+   Register a callback function for Oracle Transparent Application Failover (TAF) */
+PHP_FUNCTION(oci_register_taf_callback)
+{
+	zval *z_connection;
+	php_oci_connection *connection;
+	char *callback = NULL;
+	int callback_len = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|s!", &z_connection, &callback, &callback_len) == FAILURE) {
+		return;
+	}
+
+	PHP_OCI_ZVAL_TO_CONNECTION(z_connection, connection);
+
+	if (php_oci_register_taf_callback(connection, callback TSRMLS_CC) == 0) {
+		RETURN_TRUE;
+	} else {
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
 /* {{{ proto bool oci_define_by_name(resource stmt, string name, mixed &var [, int type])
    Define a PHP variable to an Oracle column by name */
 /* if you want to define a LOB/CLOB etc make sure you allocate it via OCINewDescriptor BEFORE defining!!! */
@@ -1567,6 +1590,9 @@ PHP_FUNCTION(oci_close)
 
 	PHP_OCI_ZVAL_TO_CONNECTION(z_connection, connection);
 	zend_list_delete(connection->id);
+	
+	//Disable Oracle TAF
+	php_oci_disable_taf_callback(connection TSRMLS_CC);
 
 	ZVAL_NULL(z_connection);
 	

--- a/ext/oci8/php_oci8.h
+++ b/ext/oci8/php_oci8.h
@@ -50,7 +50,7 @@
 extern zend_module_entry oci8_module_entry;
 #define phpext_oci8_ptr &oci8_module_entry
 #define phpext_oci8_11g_ptr &oci8_module_entry
-
+#define phpext_oci8_12c_ptr &oci8_module_entry
 
 PHP_MINIT_FUNCTION(oci);
 PHP_RINIT_FUNCTION(oci);

--- a/ext/oci8/php_oci8_int.h
+++ b/ext/oci8/php_oci8_int.h
@@ -95,6 +95,8 @@ extern zend_class_entry *oci_coll_class_entry_ptr;
 #define PHP_OCI_LOB_BUFFER_ENABLED  1
 #define PHP_OCI_LOB_BUFFER_USED     2
 
+#define PHP_OCI_TAF_DISABLE_CALLBACK ":disableCallback:"
+
 /* The mode parameter for oci_connect() is overloaded and accepts both
  * privilege and external authentication flags OR'd together.
  * PHP_OCI_CRED_EXT must be distinct from the OCI_xxx privilege
@@ -159,6 +161,8 @@ typedef struct {
 #ifdef HAVE_OCI8_DTRACE
 	char		   *client_id;					/* The oci_set_client_identifier() value */
 #endif
+
+	char		   *taf_callback;				/* The Oracle TAF callback function in the userspace */
 } php_oci_connection;
 /* }}} */
 
@@ -489,6 +493,13 @@ php_oci_bind *php_oci_bind_array_helper_number(zval *var, long max_table_length 
 php_oci_bind *php_oci_bind_array_helper_double(zval *var, long max_table_length TSRMLS_DC);
 php_oci_bind *php_oci_bind_array_helper_string(zval *var, long max_table_length, long maxlength TSRMLS_DC);
 php_oci_bind *php_oci_bind_array_helper_date(zval *var, long max_table_length, php_oci_connection *connection TSRMLS_DC);
+
+/* }}} */
+
+/* {{{ transparent failover related prototypes */
+
+int php_oci_register_taf_callback(php_oci_connection *connection, char *callback TSRMLS_DC);
+int php_oci_disable_taf_callback(php_oci_connection *connection TSRMLS_DC);
 
 /* }}} */
 


### PR DESCRIPTION
Adds support for the [Transparent Application Failover Callback](https://docs.oracle.com/cd/B19306_01/java.102/b14355/ocitaf.htm).
The php_oci_connection struct got a char* added which will contain the callback function, it should be set to PHP_OCI_TAF_DISABLE_CALLBACK at the end of a php request for permanent connections so that, if a TAF callback occurs, no userspace function will be called.
Maybe add support for registering object functions (via array), currently the register function only accepts a string. I didn't know how to implement it correctly. As a failover occurs very rarely it might be better to not keep the cache when saving the zend_fcall_info.

**Things to do**
- [ ] config.m4 needs to compile oci8_failover.c
- [ ] Check if correctly implemented (especially for multithreading)
- [ ] Add support for object functions

**New pull request**
Created a new pull request for PHP 7: #2459 