### PR TITLE
Fix bug #73887 by evicting realpath cache entries

### DIFF
--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -232,8 +232,8 @@ typedef struct _virtual_cwd_globals {
 	zend_long                   realpath_cache_size;
 	zend_long                   realpath_cache_size_limit;
 	zend_long                   realpath_cache_ttl;
+	realpath_cache_bucket      *realpath_cache[1024];
 	zend_ulong                  realpath_cache_clean_index;
-	realpath_cache_bucket *realpath_cache[1024];
 } virtual_cwd_globals;
 
 #ifdef ZTS

--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -232,6 +232,7 @@ typedef struct _virtual_cwd_globals {
 	zend_long                   realpath_cache_size;
 	zend_long                   realpath_cache_size_limit;
 	zend_long                   realpath_cache_ttl;
+	zend_ulong                  realpath_cache_clean_index;
 	realpath_cache_bucket *realpath_cache[1024];
 } virtual_cwd_globals;
 


### PR DESCRIPTION
The cache evicts buckets with round robin now instead of not caching new entries at all.

See https://bugs.php.net/bug.php?id=73887.

/cc @bwoebi @nikic @staabm @krakjoe 