### PR TITLE
Return FALSE if error_log fails to write all bytes

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4738,6 +4738,7 @@ PHPAPI int _php_error_log(int opt_err, char *message, char *opt, char *headers) 
 PHPAPI int _php_error_log_ex(int opt_err, char *message, size_t message_len, char *opt, char *headers) /* {{{ */
 {
 	php_stream *stream = NULL;
+	size_t nbytes;
 
 	switch (opt_err)
 	{
@@ -4757,8 +4758,11 @@ PHPAPI int _php_error_log_ex(int opt_err, char *message, size_t message_len, cha
 			if (!stream) {
 				return FAILURE;
 			}
-			php_stream_write(stream, message, message_len);
+			nbytes = php_stream_write(stream, message, message_len);
 			php_stream_close(stream);
+			if (nbytes != message_len) {
+				return FAILURE;
+			}
 			break;
 
 		case 4: /* send to SAPI */


### PR DESCRIPTION
Related to #2258. Return FALSE if `error_log` fails to write all bytes. Currently it silently fails.