### PR TITLE
Bug #61970 - Allow a child class to restrict access to ctor

### DIFF
--- a/Zend/tests/bug61970.phpt
+++ b/Zend/tests/bug61970.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #61970 (Restraining __construct() access level in subclass gives a fatal error)
+--FILE--
+<?php
+
+class Foo {
+    public function __construct(){}
+}
+
+class Bar extends Foo {
+    protected function __construct(){}
+}
+
+echo 'DONE';
+--EXPECT--
+DONE

--- a/Zend/tests/bug61970_1.phpt
+++ b/Zend/tests/bug61970_1.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #61970 (Restraining __construct() access level in subclass gives a fatal error - stays when implementing abstract)
+--FILE--
+<?php
+
+abstract class Foo {
+    abstract public function __construct();
+}
+
+class Bar extends Foo {
+    protected function __construct(){}
+}
+
+--EXPECTF--
+Fatal error: Access level to Bar::__construct() must be public (as in class Foo) in %s

--- a/Zend/tests/bug61970_2.phpt
+++ b/Zend/tests/bug61970_2.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #61970 (Restraining __construct() access level in subclass gives a fatal error - stays when inheriting implemented abstract)
+--FILE--
+<?php
+
+abstract class Foo {
+    abstract public function __construct();
+}
+
+class Bar extends Foo {
+    public function __construct(){}
+}
+
+class Baz extends Bar {
+    protected function __construct(){}
+}
+
+--EXPECTF--
+Fatal error: Access level to Baz::__construct() must be public (as in class Bar) in %s

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -578,8 +578,8 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot make non abstract method %s::%s() abstract in class %s", ZEND_FN_SCOPE_NAME(parent), ZSTR_VAL(child->common.function_name), ZEND_FN_SCOPE_NAME(child));
 	}
 
-	/* Prevent derived classes from restricting access that was available in parent classes */
-	if (UNEXPECTED((child_flags & ZEND_ACC_PPP_MASK) > (parent_flags & ZEND_ACC_PPP_MASK))) {
+	/* Prevent derived classes from restricting access that was available in parent classes (except deriving from non-abstract ctors) */
+	if (UNEXPECTED((!(child_flags & ZEND_ACC_CTOR) || (parent_flags & ZEND_ACC_ABSTRACT)) && (child_flags & ZEND_ACC_PPP_MASK) > (parent_flags & ZEND_ACC_PPP_MASK))) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Access level to %s::%s() must be %s (as in class %s)%s", ZEND_FN_SCOPE_NAME(child), ZSTR_VAL(child->common.function_name), zend_visibility_string(parent_flags), ZEND_FN_SCOPE_NAME(parent), (parent_flags&ZEND_ACC_PUBLIC) ? "" : " or weaker");
 	}
 

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -579,7 +579,8 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 	}
 
 	/* Prevent derived classes from restricting access that was available in parent classes (except deriving from non-abstract ctors) */
-	if (UNEXPECTED((!(child_flags & ZEND_ACC_CTOR) || (parent_flags & ZEND_ACC_ABSTRACT)) && (child_flags & ZEND_ACC_PPP_MASK) > (parent_flags & ZEND_ACC_PPP_MASK))) {
+	if (UNEXPECTED((!(child_flags & ZEND_ACC_CTOR) || (parent_flags & (ZEND_ACC_ABSTRACT | ZEND_ACC_IMPLEMENTED_ABSTRACT))) &&
+		(child_flags & ZEND_ACC_PPP_MASK) > (parent_flags & ZEND_ACC_PPP_MASK))) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Access level to %s::%s() must be %s (as in class %s)%s", ZEND_FN_SCOPE_NAME(child), ZSTR_VAL(child->common.function_name), zend_visibility_string(parent_flags), ZEND_FN_SCOPE_NAME(parent), (parent_flags&ZEND_ACC_PUBLIC) ? "" : " or weaker");
 	}
 

--- a/ext/mysqli/tests/bug38003.phpt
+++ b/ext/mysqli/tests/bug38003.phpt
@@ -17,5 +17,7 @@ $DB = new DB();
 echo "Done\n";
 ?>
 --EXPECTF--	
-Fatal error: Access level to DB::__construct() must be public (as in class mysqli) in %s%ebug38003.php on line %d
-
+Fatal error: Uncaught Error: Call to private DB::__construct() from invalid context in %s
+Stack trace:
+#0 {main}
+  thrown in %s


### PR DESCRIPTION
A child class should be able to restrict visibility on the constructor. Given that the number of required parameters is already not enforced, I believe the visibility should also not be enforced.

Link for bugsnet: https://bugs.php.net/bug.php?id=61970

This doesn't cause any BC break as it is lifting a current restriction.