### PR TITLE
Don't check CE for $this cache accesses

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1840,15 +1840,14 @@ ZEND_API void zend_fetch_dimension_by_zval_is(zval *result, zval *container, zva
 	zend_fetch_dimension_address_read(result, container, dim, dim_type, BP_VAR_IS, 1, 0);
 }
 
-static zend_always_inline zend_bool zend_is_obj_cache_valid(
-		zend_class_entry *obj_ce, zend_class_entry *cache_ce, zend_uchar op_type) {
-	/* Cache on $this access is always valid if it is populated at all. */
-	return op_type == IS_UNUSED
-		? cache_ce != NULL
-		: cache_ce == obj_ce;
+static zend_always_inline zend_bool zend_is_obj_cache_valid(zend_class_entry *obj_ce, zend_class_entry *cache_ce, zend_uchar op_type, zend_execute_data *execute_data) {
+	/* If a $this access has information cached for ce "self", then this information is also valid
+	 * for subclasses (and $this must be a subclass). */
+	return cache_ce == obj_ce
+		|| (op_type == IS_UNUSED && cache_ce == execute_data->func->common.scope);
 }
 
-static zend_always_inline void zend_fetch_property_address(zval *result, zval *container, uint32_t container_op_type, zval *prop_ptr, uint32_t prop_op_type, void **cache_slot, int type)
+static zend_always_inline void zend_fetch_property_address(zval *result, zval *container, uint32_t container_op_type, zval *prop_ptr, uint32_t prop_op_type, void **cache_slot, int type, zend_execute_data *execute_data)
 {
     if (container_op_type != IS_UNUSED && UNEXPECTED(Z_TYPE_P(container) != IS_OBJECT)) {
 		do {
@@ -1875,7 +1874,7 @@ static zend_always_inline void zend_fetch_property_address(zval *result, zval *c
 		} while (0);
 	}
 	if (prop_op_type == IS_CONST &&
-	    EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(container), CACHED_PTR_EX(cache_slot), container_op_type))) {
+	    EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(container), CACHED_PTR_EX(cache_slot), container_op_type, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR_EX(cache_slot + 1);
 		zend_object *zobj = Z_OBJ_P(container);
 		zval *retval;

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1840,6 +1840,13 @@ ZEND_API void zend_fetch_dimension_by_zval_is(zval *result, zval *container, zva
 	zend_fetch_dimension_address_read(result, container, dim, dim_type, BP_VAR_IS, 1, 0);
 }
 
+static zend_always_inline zend_bool zend_is_obj_cache_valid(
+		zend_class_entry *obj_ce, zend_class_entry *cache_ce, zend_uchar op_type) {
+	/* Cache on $this access is always valid if it is populated at all. */
+	return op_type == IS_UNUSED
+		? cache_ce != NULL
+		: cache_ce == obj_ce;
+}
 
 static zend_always_inline void zend_fetch_property_address(zval *result, zval *container, uint32_t container_op_type, zval *prop_ptr, uint32_t prop_op_type, void **cache_slot, int type)
 {
@@ -1868,7 +1875,7 @@ static zend_always_inline void zend_fetch_property_address(zval *result, zval *c
 		} while (0);
 	}
 	if (prop_op_type == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(container) == CACHED_PTR_EX(cache_slot))) {
+	    EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(container), CACHED_PTR_EX(cache_slot), container_op_type))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR_EX(cache_slot + 1);
 		zend_object *zobj = Z_OBJ_P(container);
 		zval *retval;

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2976,10 +2976,8 @@ ZEND_VM_HANDLER(112, ZEND_INIT_METHOD_CALL, CONST|TMPVAR|UNUSED|THIS|CV, CONST|T
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (OP2_TYPE == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), OP1_TYPE, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if (OP2_TYPE != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1778,7 +1778,7 @@ ZEND_VM_HANDLER(82, ZEND_FETCH_OBJ_R, CONST|TMP|VAR|UNUSED|THIS|CV, CONST|TMPVAR
 		zval *retval;
 
 		if (OP2_TYPE == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), OP1_TYPE))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), OP1_TYPE, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -1832,7 +1832,7 @@ ZEND_VM_HANDLER(85, ZEND_FETCH_OBJ_W, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV)
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 	FREE_OP2();
 	if (OP1_TYPE == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -1858,7 +1858,7 @@ ZEND_VM_HANDLER(88, ZEND_FETCH_OBJ_RW, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV)
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 	FREE_OP2();
 	if (OP1_TYPE == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -1905,7 +1905,7 @@ ZEND_VM_HANDLER(91, ZEND_FETCH_OBJ_IS, CONST|TMPVAR|UNUSED|THIS|CV, CONST|TMPVAR
 		zval *retval;
 
 		if (OP2_TYPE == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), OP1_TYPE))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), OP1_TYPE, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -1968,7 +1968,7 @@ ZEND_VM_HANDLER(94, ZEND_FETCH_OBJ_FUNC_ARG, CONST|TMP|VAR|UNUSED|THIS|CV, CONST
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 		FREE_OP2();
 		if (OP1_TYPE == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -1998,7 +1998,7 @@ ZEND_VM_HANDLER(97, ZEND_FETCH_OBJ_UNSET, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV)
 
 	property = GET_OP2_ZVAL_PTR(BP_VAR_R);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 	FREE_OP2();
 	if (OP1_TYPE == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -2081,7 +2081,7 @@ ZEND_VM_HANDLER(136, ZEND_ASSIGN_OBJ, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV, SPEC(
 	}
 
 	if (OP2_TYPE == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), OP1_TYPE))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), OP1_TYPE, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -2977,7 +2977,7 @@ ZEND_VM_HANDLER(112, ZEND_INIT_METHOD_CALL, CONST|TMPVAR|UNUSED|THIS|CV, CONST|T
 	called_scope = obj->ce;
 
 	if (OP2_TYPE == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), OP1_TYPE))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), OP1_TYPE, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5056,7 +5056,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CONST_CONST_H
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -5129,7 +5129,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CONST_CONST_
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -5355,8 +5355,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CO
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CONST != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if (IS_CONST == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -8840,7 +8842,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CONST_CV_HAND
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -8913,7 +8915,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CONST_CV_HAN
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -9139,8 +9141,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CV
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CV != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if (IS_CV == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -10829,7 +10833,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CONST_TMPVAR_
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -10903,7 +10907,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CONST_TMPVAR
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -11130,8 +11134,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_TM
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if ((IS_TMP_VAR|IS_VAR) != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -13339,7 +13345,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_TMP_CONST_HAN
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_TMP_VAR))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -14570,7 +14576,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_TMP_CV_HANDLE
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_TMP_VAR))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -15101,7 +15107,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_TMP_TMPVAR_HA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_TMP_VAR))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -18031,7 +18037,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_VAR_CONST_HAN
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_VAR))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -18246,7 +18252,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CONST_OP_D
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -18404,7 +18410,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CONST_OP_D
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -18562,7 +18568,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CONST_OP_D
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -18720,7 +18726,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CONST_OP_D
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -22260,7 +22266,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_VAR_CV_HANDLE
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_VAR))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -22475,7 +22481,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CV_OP_DATA
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -22633,7 +22639,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CV_OP_DATA
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -22791,7 +22797,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CV_OP_DATA
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -22949,7 +22955,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CV_OP_DATA
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -24788,7 +24794,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_VAR_TMPVAR_HA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_VAR))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -25004,7 +25010,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_TMPVAR_OP_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -25162,7 +25168,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_TMPVAR_OP_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -25320,7 +25326,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_TMPVAR_OP_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -25478,7 +25484,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_TMPVAR_OP_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -26872,7 +26878,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_UNUSED_CONST_
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -26998,7 +27004,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_UNUSED_CONST
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -27160,7 +27166,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CONST_O
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -27318,7 +27324,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CONST_O
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -27476,7 +27482,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CONST_O
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -27634,7 +27640,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CONST_O
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -27836,8 +27842,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CONST != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if (IS_CONST == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -29434,7 +29442,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_UNUSED_CV_HAN
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -29560,7 +29568,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_UNUSED_CV_HA
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -29722,7 +29730,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CV_OP_D
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -29880,7 +29888,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CV_OP_D
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -30038,7 +30046,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CV_OP_D
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -30196,7 +30204,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CV_OP_D
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -30398,8 +30406,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CV != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if (IS_CV == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -31196,7 +31206,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_UNUSED_TMPVAR
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -31323,7 +31333,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_UNUSED_TMPVA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -31486,7 +31496,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_TMPVAR_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -31644,7 +31654,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_TMPVAR_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -31802,7 +31812,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_TMPVAR_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -31960,7 +31970,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_TMPVAR_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -32162,8 +32172,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_T
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if ((IS_TMP_VAR|IS_VAR) != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -35832,7 +35844,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CV_CONST_HAND
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -35958,7 +35970,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CV_CONST_HAN
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -36133,7 +36145,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CONST_OP_DA
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -36291,7 +36303,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CONST_OP_DA
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -36449,7 +36461,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CONST_OP_DA
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -36607,7 +36619,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CONST_OP_DA
 	}
 
 	if (IS_CONST == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -37269,8 +37281,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CONST
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CONST != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if (IS_CONST == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -42056,7 +42070,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CV_CV_HANDLER
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -42182,7 +42196,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CV_CV_HANDLE
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -42357,7 +42371,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CV_OP_DATA_
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -42515,7 +42529,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CV_OP_DATA_
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -42673,7 +42687,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CV_OP_DATA_
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -42831,7 +42845,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CV_OP_DATA_
 	}
 
 	if (IS_CV == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -43549,8 +43563,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CV_HA
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CV != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if (IS_CV == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -45717,7 +45733,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CV_TMPVAR_HAN
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -45844,7 +45860,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CV_TMPVAR_HA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -46020,7 +46036,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_TMPVAR_OP_D
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -46178,7 +46194,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_TMPVAR_OP_D
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -46336,7 +46352,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_TMPVAR_OP_D
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -46494,7 +46510,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_TMPVAR_OP_D
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-	    EXPECTED(Z_OBJCE_P(object) == CACHED_PTR(Z_CACHE_SLOT_P(property_name)))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -47100,8 +47116,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_TMPVA
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if ((IS_TMP_VAR|IS_VAR) != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -49060,7 +49078,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_TMPVAR_CONST
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), (IS_TMP_VAR|IS_VAR)))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -49247,8 +49265,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CONST != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if (IS_CONST == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR)))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -51326,7 +51346,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_TMPVAR_CV_HA
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), (IS_TMP_VAR|IS_VAR)))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -51513,8 +51533,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CV != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if (IS_CV == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR)))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -52617,7 +52639,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_TMPVAR_TMPVA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zobj->ce == CACHED_PTR(Z_CACHE_SLOT_P(offset)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), (IS_TMP_VAR|IS_VAR)))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -52805,8 +52827,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_T
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if ((IS_TMP_VAR|IS_VAR) != IS_CONST ||
-	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
+	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR)))) {
+		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
+	} else {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5056,7 +5056,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CONST_CONST_H
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -5129,7 +5129,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CONST_CONST_
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -5191,7 +5191,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_CONST_
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CONST, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CONST, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_CONST == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -5356,7 +5356,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CO
 	called_scope = obj->ce;
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -8842,7 +8842,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CONST_CV_HAND
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -8915,7 +8915,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CONST_CV_HAN
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -8977,7 +8977,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_CONST_
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CONST, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CONST, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_CONST == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -9142,7 +9142,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CV
 	called_scope = obj->ce;
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -10833,7 +10833,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CONST_TMPVAR_
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -10907,7 +10907,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CONST_TMPVAR
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CONST, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -10970,7 +10970,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_CONST_
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CONST, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CONST, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 		zval_ptr_dtor_nogc(free_op2);
 		if (IS_CONST == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -11135,7 +11135,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_TM
 	called_scope = obj->ce;
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -13345,7 +13345,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_TMP_CONST_HAN
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_TMP_VAR))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_TMP_VAR, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -13407,7 +13407,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_TMP_CO
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_TMP_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_TMP_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_TMP_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -14576,7 +14576,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_TMP_CV_HANDLE
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_TMP_VAR))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_TMP_VAR, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -14638,7 +14638,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_TMP_CV
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_TMP_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_TMP_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_TMP_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -15107,7 +15107,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_TMP_TMPVAR_HA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_TMP_VAR))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_TMP_VAR, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -15170,7 +15170,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_TMP_TM
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_TMP_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_TMP_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 		zval_ptr_dtor_nogc(free_op2);
 		if (IS_TMP_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -18037,7 +18037,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_VAR_CONST_HAN
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_VAR))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_VAR, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -18090,7 +18090,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_W_SPEC_VAR_CONST_HAN
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 	if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -18116,7 +18116,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_RW_SPEC_VAR_CONST_HA
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 
 	if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -18152,7 +18152,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_VAR_CO
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -18182,7 +18182,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_UNSET_SPEC_VAR_CONST
 
 	property = EX_CONSTANT(opline->op2);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 
 	if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -18252,7 +18252,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CONST_OP_D
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -18410,7 +18410,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CONST_OP_D
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -18568,7 +18568,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CONST_OP_D
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -18726,7 +18726,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CONST_OP_D
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -22266,7 +22266,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_VAR_CV_HANDLE
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_VAR))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_VAR, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -22319,7 +22319,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_W_SPEC_VAR_CV_HANDLE
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 	if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -22345,7 +22345,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_RW_SPEC_VAR_CV_HANDL
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 
 	if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -22381,7 +22381,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_VAR_CV
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -22411,7 +22411,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_UNSET_SPEC_VAR_CV_HA
 
 	property = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 
 	if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -22481,7 +22481,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CV_OP_DATA
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -22639,7 +22639,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CV_OP_DATA
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -22797,7 +22797,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CV_OP_DATA
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -22955,7 +22955,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_CV_OP_DATA
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -24794,7 +24794,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_VAR_TMPVAR_HA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_VAR))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_VAR, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -24848,7 +24848,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_W_SPEC_VAR_TMPVAR_HA
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 	zval_ptr_dtor_nogc(free_op2);
 	if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -24874,7 +24874,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_RW_SPEC_VAR_TMPVAR_H
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 	zval_ptr_dtor_nogc(free_op2);
 	if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -24910,7 +24910,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_VAR_TM
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 		zval_ptr_dtor_nogc(free_op2);
 		if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -24940,7 +24940,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_UNSET_SPEC_VAR_TMPVA
 
 	property = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_VAR, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 	zval_ptr_dtor_nogc(free_op2);
 	if (IS_VAR == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -25010,7 +25010,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_TMPVAR_OP_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -25168,7 +25168,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_TMPVAR_OP_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -25326,7 +25326,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_TMPVAR_OP_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -25484,7 +25484,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_VAR_TMPVAR_OP_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_VAR, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -26878,7 +26878,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_UNUSED_CONST_
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -26931,7 +26931,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_W_SPEC_UNUSED_CONST_
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 	if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -26957,7 +26957,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_RW_SPEC_UNUSED_CONST
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 
 	if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -27004,7 +27004,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_UNUSED_CONST
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -27066,7 +27066,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_UNUSED
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -27096,7 +27096,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_UNSET_SPEC_UNUSED_CO
 
 	property = EX_CONSTANT(opline->op2);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 
 	if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -27166,7 +27166,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CONST_O
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -27324,7 +27324,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CONST_O
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -27482,7 +27482,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CONST_O
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -27640,7 +27640,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CONST_O
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -27843,7 +27843,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 	called_scope = obj->ce;
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -29442,7 +29442,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_UNUSED_CV_HAN
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -29495,7 +29495,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_W_SPEC_UNUSED_CV_HAN
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 	if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -29521,7 +29521,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_RW_SPEC_UNUSED_CV_HA
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 
 	if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -29568,7 +29568,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_UNUSED_CV_HA
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -29630,7 +29630,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_UNUSED
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -29660,7 +29660,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_UNSET_SPEC_UNUSED_CV
 
 	property = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 
 	if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -29730,7 +29730,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CV_OP_D
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -29888,7 +29888,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CV_OP_D
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -30046,7 +30046,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CV_OP_D
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -30204,7 +30204,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_CV_OP_D
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -30407,7 +30407,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 	called_scope = obj->ce;
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -31206,7 +31206,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_UNUSED_TMPVAR
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -31260,7 +31260,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_W_SPEC_UNUSED_TMPVAR
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 	zval_ptr_dtor_nogc(free_op2);
 	if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -31286,7 +31286,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_RW_SPEC_UNUSED_TMPVA
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 	zval_ptr_dtor_nogc(free_op2);
 	if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -31333,7 +31333,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_UNUSED_TMPVA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_UNUSED, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -31396,7 +31396,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_UNUSED
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 		zval_ptr_dtor_nogc(free_op2);
 		if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -31426,7 +31426,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_UNSET_SPEC_UNUSED_TM
 
 	property = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 	zval_ptr_dtor_nogc(free_op2);
 	if (IS_UNUSED == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -31496,7 +31496,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_TMPVAR_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -31654,7 +31654,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_TMPVAR_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -31812,7 +31812,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_TMPVAR_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -31970,7 +31970,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_UNUSED_TMPVAR_
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_UNUSED, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -32173,7 +32173,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_T
 	called_scope = obj->ce;
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -35844,7 +35844,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CV_CONST_HAND
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -35897,7 +35897,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_W_SPEC_CV_CONST_HAND
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 	if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -35923,7 +35923,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_RW_SPEC_CV_CONST_HAN
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 
 	if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -35970,7 +35970,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CV_CONST_HAN
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -36032,7 +36032,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_CV_CON
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -36062,7 +36062,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_UNSET_SPEC_CV_CONST_
 
 	property = EX_CONSTANT(opline->op2);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 
 	if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -36145,7 +36145,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CONST_OP_DA
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -36303,7 +36303,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CONST_OP_DA
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -36461,7 +36461,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CONST_OP_DA
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -36619,7 +36619,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CONST_OP_DA
 	}
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -37282,7 +37282,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CONST
 	called_scope = obj->ce;
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -42070,7 +42070,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CV_CV_HANDLER
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -42123,7 +42123,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_W_SPEC_CV_CV_HANDLER
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 	if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -42149,7 +42149,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_RW_SPEC_CV_CV_HANDLE
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 
 	if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -42196,7 +42196,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CV_CV_HANDLE
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -42258,7 +42258,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_CV_CV_
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 
 		if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -42288,7 +42288,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_UNSET_SPEC_CV_CV_HAN
 
 	property = _get_zval_ptr_cv_BP_VAR_R(execute_data, opline->op2.var);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 
 	if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -42371,7 +42371,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CV_OP_DATA_
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -42529,7 +42529,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CV_OP_DATA_
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -42687,7 +42687,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CV_OP_DATA_
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -42845,7 +42845,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_CV_OP_DATA_
 	}
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -43564,7 +43564,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CV_HA
 	called_scope = obj->ce;
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -45733,7 +45733,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_R_SPEC_CV_TMPVAR_HAN
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -45787,7 +45787,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_W_SPEC_CV_TMPVAR_HAN
 		HANDLE_EXCEPTION();
 	}
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 	zval_ptr_dtor_nogc(free_op2);
 	if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -45813,7 +45813,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_RW_SPEC_CV_TMPVAR_HA
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_RW, execute_data);
 	zval_ptr_dtor_nogc(free_op2);
 	if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -45860,7 +45860,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_CV_TMPVAR_HA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), IS_CV, execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -45923,7 +45923,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_FUNC_ARG_SPEC_CV_TMP
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
-		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W);
+		zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_W, execute_data);
 		zval_ptr_dtor_nogc(free_op2);
 		if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 			EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -45953,7 +45953,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_UNSET_SPEC_CV_TMPVAR
 
 	property = _get_zval_ptr_var(opline->op2.var, execute_data, &free_op2);
 
-	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET);
+	zend_fetch_property_address(EX_VAR(opline->result.var), container, IS_CV, property, (IS_TMP_VAR|IS_VAR), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(Z_CACHE_SLOT_P(property)) : NULL), BP_VAR_UNSET, execute_data);
 	zval_ptr_dtor_nogc(free_op2);
 	if (IS_CV == IS_VAR && READY_TO_DESTROY(free_op1)) {
 		EXTRACT_ZVAL_PTR(EX_VAR(opline->result.var));
@@ -46036,7 +46036,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_TMPVAR_OP_D
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -46194,7 +46194,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_TMPVAR_OP_D
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -46352,7 +46352,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_TMPVAR_OP_D
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -46510,7 +46510,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_OBJ_SPEC_CV_TMPVAR_OP_D
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(Z_OBJCE_P(object), CACHED_PTR(Z_CACHE_SLOT_P(property_name)), IS_CV, execute_data))) {
 		uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(property_name) + sizeof(void*));
 		zend_object *zobj = Z_OBJ_P(object);
 		zval *property;
@@ -47117,7 +47117,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_TMPVA
 	called_scope = obj->ce;
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV, execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -49078,7 +49078,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_TMPVAR_CONST
 		zval *retval;
 
 		if (IS_CONST == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), (IS_TMP_VAR|IS_VAR)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), (IS_TMP_VAR|IS_VAR), execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -49266,7 +49266,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 	called_scope = obj->ce;
 
 	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR)))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR), execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -51346,7 +51346,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_TMPVAR_CV_HA
 		zval *retval;
 
 		if (IS_CV == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), (IS_TMP_VAR|IS_VAR)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), (IS_TMP_VAR|IS_VAR), execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -51534,7 +51534,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 	called_scope = obj->ce;
 
 	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR)))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR), execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;
@@ -52639,7 +52639,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_OBJ_IS_SPEC_TMPVAR_TMPVA
 		zval *retval;
 
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), (IS_TMP_VAR|IS_VAR)))) {
+			EXPECTED(zend_is_obj_cache_valid(zobj->ce, CACHED_PTR(Z_CACHE_SLOT_P(offset)), (IS_TMP_VAR|IS_VAR), execute_data))) {
 			uint32_t prop_offset = (uint32_t)(intptr_t)CACHED_PTR(Z_CACHE_SLOT_P(offset) + sizeof(void*));
 
 			if (EXPECTED(prop_offset != (uint32_t)ZEND_DYNAMIC_PROPERTY_OFFSET)) {
@@ -52828,7 +52828,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_T
 	called_scope = obj->ce;
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR)))) {
+		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR), execute_data))) {
 		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
 	} else {
 	    zend_object *orig_obj = obj;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5355,10 +5355,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CO
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if (IS_CONST != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -9141,10 +9139,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_CV
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if (IS_CV != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -11134,10 +11130,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CONST_TM
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CONST, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if ((IS_TMP_VAR|IS_VAR) != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -27842,10 +27836,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if (IS_CONST != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -30406,10 +30398,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if (IS_CV != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -32172,10 +32162,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_T
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_UNUSED, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if ((IS_TMP_VAR|IS_VAR) != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -37281,10 +37269,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CONST
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if (IS_CONST != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -43563,10 +43549,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CV_HA
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if (IS_CV != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -47116,10 +47100,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_TMPVA
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), IS_CV, execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if ((IS_TMP_VAR|IS_VAR) != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -49265,10 +49247,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CONST == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR), execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if (IS_CONST != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -51533,10 +51513,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if (IS_CV == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR), execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if (IS_CV != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {
@@ -52827,10 +52805,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_T
 	obj = Z_OBJ_P(object);
 	called_scope = obj->ce;
 
-	if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		EXPECTED(zend_is_obj_cache_valid(called_scope, CACHED_PTR(Z_CACHE_SLOT_P(function_name)), (IS_TMP_VAR|IS_VAR), execute_data))) {
-		fbc = CACHED_PTR(Z_CACHE_SLOT_P(function_name) + sizeof(void *));
-	} else {
+	if ((IS_TMP_VAR|IS_VAR) != IS_CONST ||
+	    UNEXPECTED((fbc = CACHED_POLYMORPHIC_PTR(Z_CACHE_SLOT_P(function_name), called_scope)) == NULL)) {
 	    zend_object *orig_obj = obj;
 
 		if (UNEXPECTED(obj->handlers->get_method == NULL)) {


### PR DESCRIPTION
Test script:

```php
<?php

class A {
    public $prop = 42;
    public function getProp() {
        return $this->prop;
    }
}

class B extends A {
}

$n = 10000000;

$a = new A;
$b = new B;

$t = microtime(true);
for ($i = 0; $i < $n; $i++) {
    $a->getProp();
    $b->getProp();
}
var_dump(microtime(true) - $t);
```

This runs in 0.8s before the change and 0.5s after.

The issue is that the `$this->prop` access currently toggles back and forth between caching `A::$prop` and `B::$prop`. However, for accesses on `$this` (UNUSED op1) specifically this is not necessary. As of PHP 7.1 we enforce that `$this instanceof self` (or null), as such these should always access the same property. (Unless I'm missing some edge case?)

This patch only adjusts the checking code -- we could also use a non-polymorphic cache for UNUSED op1, but I think the extra implementation complexity of handling the two cases isn't worth it.