### PR TITLE
Add comma to comment in php.ini

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -289,7 +289,7 @@ implicit_flush = Off
 ; callback-function.
 unserialize_callback_func =
 
-; When floats & doubles are serialized store serialize_precision significant
+; When floats & doubles are serialized, store serialize_precision significant
 ; digits after the floating point. The default value ensures that when floats
 ; are decoded with unserialize, the data will remain the same.
 ; The value is also used for json_encode when encoding double values.

--- a/php.ini-production
+++ b/php.ini-production
@@ -294,7 +294,7 @@ implicit_flush = Off
 ; callback-function.
 unserialize_callback_func =
 
-; When floats & doubles are serialized store serialize_precision significant
+; When floats & doubles are serialized, store serialize_precision significant
 ; digits after the floating point. The default value ensures that when floats
 ; are decoded with unserialize, the data will remain the same.
 ; The value is also used for json_encode when encoding double values.


### PR DESCRIPTION
I didn't find a way to include more than one file edit in the PR from the get go (using the web interface). I'll try to add the corresponding edit for `php.ini-development` after submission.