### PR TITLE
var_export - provide 'null' instead of 'NULL'

### DIFF
--- a/ext/standard/tests/general_functions/var_dump.phpt
+++ b/ext/standard/tests/general_functions/var_dump.phpt
@@ -481,12 +481,12 @@ array(0) {
 -- Iteration 2 --
 array(1) {
   [0]=>
-  NULL
+  null
 }
 -- Iteration 3 --
 array(1) {
   [0]=>
-  NULL
+  null
 }
 -- Iteration 4 --
 array(1) {
@@ -803,7 +803,7 @@ object(object_class)#5 (7) {
   int(11)
 }
 -- Iteration 9 --
-NULL
+null
 
 ** Testing var_dump() on objects having circular reference **
 object(object_class)#13 (8) {
@@ -875,7 +875,7 @@ array(4) {
   [2]=>
   bool(true)
   [3]=>
-  NULL
+  null
 }
 -- Iteration 3 --
 array(4) {
@@ -915,7 +915,7 @@ array(6) {
 -- Iteration 5 --
 array(4) {
   [0]=>
-  NULL
+  null
   [1]=>
   float(20000000000)
   [2]=>
@@ -928,7 +928,7 @@ array(4) {
   [0]=>
   string(27) "array(1,2,3,4)1.0000002TRUE"
   [1]=>
-  NULL
+  null
   [2]=>
   float(4611333)
   [3]=>
@@ -937,13 +937,13 @@ array(4) {
 
 *** Testing var_dump() on miscelleneous input arguments ***
 -- Iteration 1 --
-NULL
+null
 -- Iteration 2 --
-NULL
+null
 -- Iteration 3 --
-NULL
+null
 -- Iteration 4 --
-NULL
+null
 
 *** Testing var_dump() on multiple arguments ***
 array(15) {
@@ -1125,12 +1125,12 @@ array(15) {
   [1]=>
   array(1) {
     [0]=>
-    NULL
+    null
   }
   [2]=>
   array(1) {
     [0]=>
-    NULL
+    null
   }
   [3]=>
   array(1) {
@@ -1463,17 +1463,17 @@ array(9) {
     int(11)
   }
   [8]=>
-  NULL
+  null
 }
 array(4) {
   [0]=>
-  NULL
+  null
   [1]=>
-  NULL
+  null
   [2]=>
-  NULL
+  null
   [3]=>
-  NULL
+  null
 }
 array(6) {
   [0]=>
@@ -1501,7 +1501,7 @@ array(6) {
     [2]=>
     bool(true)
     [3]=>
-    NULL
+    null
   }
   [2]=>
   array(4) {
@@ -1541,7 +1541,7 @@ array(6) {
   [4]=>
   array(4) {
     [0]=>
-    NULL
+    null
     [1]=>
     float(20000000000)
     [2]=>
@@ -1554,7 +1554,7 @@ array(6) {
     [0]=>
     string(27) "array(1,2,3,4)1.0000002TRUE"
     [1]=>
-    NULL
+    null
     [2]=>
     float(4611333)
     [3]=>

--- a/ext/standard/tests/general_functions/var_dump_64bit.phpt
+++ b/ext/standard/tests/general_functions/var_dump_64bit.phpt
@@ -481,12 +481,12 @@ array(0) {
 -- Iteration 2 --
 array(1) {
   [0]=>
-  NULL
+  null
 }
 -- Iteration 3 --
 array(1) {
   [0]=>
-  NULL
+  null
 }
 -- Iteration 4 --
 array(1) {
@@ -803,7 +803,7 @@ object(object_class)#5 (7) {
   int(11)
 }
 -- Iteration 9 --
-NULL
+null
 
 ** Testing var_dump() on objects having circular reference **
 object(object_class)#13 (8) {
@@ -875,7 +875,7 @@ array(4) {
   [2]=>
   bool(true)
   [3]=>
-  NULL
+  null
 }
 -- Iteration 3 --
 array(4) {
@@ -915,7 +915,7 @@ array(6) {
 -- Iteration 5 --
 array(4) {
   [0]=>
-  NULL
+  null
   [1]=>
   float(20000000000)
   [2]=>
@@ -928,7 +928,7 @@ array(4) {
   [0]=>
   string(27) "array(1,2,3,4)1.0000002TRUE"
   [1]=>
-  NULL
+  null
   [2]=>
   float(4611333)
   [3]=>
@@ -937,13 +937,13 @@ array(4) {
 
 *** Testing var_dump() on miscelleneous input arguments ***
 -- Iteration 1 --
-NULL
+null
 -- Iteration 2 --
-NULL
+null
 -- Iteration 3 --
-NULL
+null
 -- Iteration 4 --
-NULL
+null
 
 *** Testing var_dump() on multiple arguments ***
 array(15) {
@@ -1125,12 +1125,12 @@ array(15) {
   [1]=>
   array(1) {
     [0]=>
-    NULL
+    null
   }
   [2]=>
   array(1) {
     [0]=>
-    NULL
+    null
   }
   [3]=>
   array(1) {
@@ -1463,17 +1463,17 @@ array(9) {
     int(11)
   }
   [8]=>
-  NULL
+  null
 }
 array(4) {
   [0]=>
-  NULL
+  null
   [1]=>
-  NULL
+  null
   [2]=>
-  NULL
+  null
   [3]=>
-  NULL
+  null
 }
 array(6) {
   [0]=>
@@ -1501,7 +1501,7 @@ array(6) {
     [2]=>
     bool(true)
     [3]=>
-    NULL
+    null
   }
   [2]=>
   array(4) {
@@ -1541,7 +1541,7 @@ array(6) {
   [4]=>
   array(4) {
     [0]=>
-    NULL
+    null
     [1]=>
     float(20000000000)
     [2]=>
@@ -1554,7 +1554,7 @@ array(6) {
     [0]=>
     string(27) "array(1,2,3,4)1.0000002TRUE"
     [1]=>
-    NULL
+    null
     [2]=>
     float(4611333)
     [3]=>

--- a/ext/standard/tests/general_functions/var_export-locale.phpt
+++ b/ext/standard/tests/general_functions/var_export-locale.phpt
@@ -693,25 +693,25 @@ string(9) "array (
 
 Iteration 2
 array (
-  0 => NULL,
+  0 => null,
 )
 array (
-  0 => NULL,
+  0 => null,
 )
 string(22) "array (
-  0 => NULL,
+  0 => null,
 )"
 
 
 Iteration 3
 array (
-  0 => NULL,
+  0 => null,
 )
 array (
-  0 => NULL,
+  0 => null,
 )
 string(22) "array (
-  0 => NULL,
+  0 => null,
 )"
 
 
@@ -970,7 +970,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -986,7 +986,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -1002,7 +1002,7 @@ string(293) "myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -1021,7 +1021,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -1037,7 +1037,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -1053,7 +1053,7 @@ string(293) "myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -1118,28 +1118,28 @@ string(36) "concreteClass::__set_state(array(
 *** Output for null values ***
 
 Iteration 1
-NULL
-NULL
-string(4) "NULL"
+null
+null
+string(4) "null"
 
 
 Iteration 2
-NULL
-NULL
-string(4) "NULL"
+null
+null
+string(4) "null"
 
 
 Iteration 3
-NULL
-NULL
-string(4) "NULL"
+null
+null
+string(4) "null"
 
 
 *** Testing error conditions ***
 
 Warning: var_export() expects at least 1 parameter, 0 given in %s on line %d
-NULL
+null
 Warning: var_export() expects at most 2 parameters, 3 given in %s on line %d
-NULL
+null
 
 Done

--- a/ext/standard/tests/general_functions/var_export_basic5.phpt
+++ b/ext/standard/tests/general_functions/var_export_basic5.phpt
@@ -60,25 +60,25 @@ string(9) "array (
 
 --Iteration: array(NULL) --
 array (
-  0 => NULL,
+  0 => null,
 )
 array (
-  0 => NULL,
+  0 => null,
 )
 string(22) "array (
-  0 => NULL,
+  0 => null,
 )"
 
 
 --Iteration: array(null) --
 array (
-  0 => NULL,
+  0 => null,
 )
 array (
-  0 => NULL,
+  0 => null,
 )
 string(22) "array (
-  0 => NULL,
+  0 => null,
 )"
 
 

--- a/ext/standard/tests/general_functions/var_export_basic6.phpt
+++ b/ext/standard/tests/general_functions/var_export_basic6.phpt
@@ -164,7 +164,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -180,7 +180,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -196,7 +196,7 @@ string(293) "myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -215,7 +215,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -231,7 +231,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),
@@ -247,7 +247,7 @@ string(293) "myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
+   'protected_var' => null,
    'proected_var' => 
   foo::__set_state(array(
   )),

--- a/ext/standard/tests/general_functions/var_export_basic7.phpt
+++ b/ext/standard/tests/general_functions/var_export_basic7.phpt
@@ -16,7 +16,7 @@ unset ($unset_var); // now a null
 $null_var = NULL;
 
 $valid_nulls = array(
-                "NULL" =>  NULL,
+                "NULL" => NULL,
                 "null" => null,
                 "null_var" => $null_var,
 );
@@ -40,20 +40,20 @@ foreach($valid_nulls as $key => $null_value) {
 *** Output for null values ***
 
 -- Iteration: NULL --
-NULL
-NULL
-string(4) "NULL"
+null
+null
+string(4) "null"
 
 
 -- Iteration: null --
-NULL
-NULL
-string(4) "NULL"
+null
+null
+string(4) "null"
 
 
 -- Iteration: null_var --
-NULL
-NULL
-string(4) "NULL"
+null
+null
+string(4) "null"
 
 ===DONE===

--- a/ext/standard/tests/general_functions/var_export_error1.phpt
+++ b/ext/standard/tests/general_functions/var_export_error1.phpt
@@ -29,10 +29,10 @@ var_dump( var_export($var, $return, $extra_arg) );
 -- Testing var_export() function with Zero arguments --
 
 Warning: var_export() expects at least 1 parameter, 0 given in %s on line 12
-NULL
+null
 
 -- Testing var_export() function with more than expected no. of arguments --
 
 Warning: var_export() expects at most 2 parameters, 3 given in %s on line 19
-NULL
+null
 ===DONE===

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -104,7 +104,7 @@ again:
 			php_printf("%sbool(true)\n", COMMON);
 			break;
 		case IS_NULL:
-			php_printf("%sNULL\n", COMMON);
+			php_printf("%snull\n", COMMON);
 			break;
 		case IS_LONG:
 			php_printf("%sint(" ZEND_LONG_FMT ")\n", COMMON, Z_LVAL_P(struc));
@@ -274,7 +274,7 @@ again:
 		php_printf("%sbool(true)\n", COMMON);
 		break;
 	case IS_NULL:
-		php_printf("%sNULL\n", COMMON);
+		php_printf("%snull\n", COMMON);
 		break;
 	case IS_LONG:
 		php_printf("%sint(" ZEND_LONG_FMT ")\n", COMMON, Z_LVAL_P(struc));
@@ -456,7 +456,7 @@ again:
 			smart_str_appendl(buf, "true", 4);
 			break;
 		case IS_NULL:
-			smart_str_appendl(buf, "NULL", 4);
+			smart_str_appendl(buf, "null", 4);
 			break;
 		case IS_LONG:
 			smart_str_append_long(buf, Z_LVAL_P(struc));
@@ -489,7 +489,7 @@ again:
 			myht = Z_ARRVAL_P(struc);
 			if (ZEND_HASH_APPLY_PROTECTION(myht) && myht->u.v.nApplyCount++ > 0) {
 				myht->u.v.nApplyCount--;
-				smart_str_appendl(buf, "NULL", 4);
+				smart_str_appendl(buf, "null", 4);
 				zend_error(E_WARNING, "var_export does not handle circular references");
 				return;
 			}
@@ -515,7 +515,7 @@ again:
 			myht = Z_OBJPROP_P(struc);
 			if (myht) {
 				if (myht->u.v.nApplyCount > 0) {
-					smart_str_appendl(buf, "NULL", 4);
+					smart_str_appendl(buf, "null", 4);
 					zend_error(E_WARNING, "var_export does not handle circular references");
 					return;
 				} else {
@@ -547,7 +547,7 @@ again:
 			goto again;
 			break;
 		default:
-			smart_str_appendl(buf, "NULL", 4);
+			smart_str_appendl(buf, "null", 4);
 			break;
 	}
 }


### PR DESCRIPTION
`var_export` returns `true` and `false` but `NULL`.
Let us make it consistent and return `null` as well.
This approach is also encouraged by PSR-2.

I did update obvious places, if you like the idea I will make build passing (by adjusting non-obvious (at least for me) places as well).