### PR TITLE
Remove deadcode from BCMath extension

### DIFF
--- a/ext/bcmath/libbcmath/src/init.c
+++ b/ext/bcmath/libbcmath/src/init.c
@@ -38,10 +38,6 @@
 #include "bcmath.h"
 #include "private.h"
 
-#if SANDER_0
- bc_num _bc_Free_list = NULL;
-#endif
-
 /* new_num allocates a number and sets fields to known values. */
 
 bc_num
@@ -129,4 +125,3 @@ bc_init_num (bc_num *num)
 {
   *num = bc_copy_num (BCG(_zero_));
 }
-

--- a/ext/bcmath/libbcmath/src/private.h
+++ b/ext/bcmath/libbcmath/src/private.h
@@ -31,11 +31,6 @@
 
 /* "Private" routines to bcmath. */
 
-/* variables */
-#if SANDER_0
-extern bc_num _bc_Free_list;
-#endif
-
 /* routines */
 int _bc_do_compare (bc_num n1, bc_num n2, int use_sign, int ignore_last);
 bc_num _bc_do_add (bc_num n1, bc_num n2, int scale_min);

--- a/ext/bcmath/libbcmath/src/recmul.c
+++ b/ext/bcmath/libbcmath/src/recmul.c
@@ -57,17 +57,8 @@ new_sub_num (length, scale, value)
 {
   bc_num temp;
 
-#ifdef SANDER_0
-  if (_bc_Free_list != NULL) {
-    temp = _bc_Free_list;
-    _bc_Free_list = temp->n_next;
-  } else {
-#endif
-    temp = (bc_num) emalloc (sizeof(bc_struct));
-#ifdef SANDER_0
-    if (temp == NULL) bc_out_of_memory ();
-  }
-#endif
+  temp = (bc_num) emalloc (sizeof(bc_struct));
+
   temp->n_sign = PLUS;
   temp->n_len = length;
   temp->n_scale = scale;


### PR DESCRIPTION
It seems this macro was introduced (and named after) a past contributor ([see here](http://marc.info/?l=php-cvs&m=103859277304729&w=3)) to enclose code that wasn't used anymore. Given that this dates back to ~15 years ago, I think it's safe to assume the code definitely isn't needed anymore...