### PR TITLE
Use call_map to avoid linear call lookup

### DIFF
--- a/ext/opcache/Optimizer/zend_call_graph.c
+++ b/ext/opcache/Optimizer/zend_call_graph.c
@@ -266,6 +266,24 @@ int zend_build_call_graph(zend_arena **arena, zend_script *script, uint32_t buil
 }
 /* }}} */
 
+zend_call_info **zend_build_call_map(zend_arena **arena, zend_func_info *info, zend_op_array *op_array) /* {{{ */
+{
+	zend_call_info **map = zend_arena_calloc(arena, sizeof(zend_call_info *), op_array->last);
+	zend_call_info *call;
+	for (call = info->callee_info; call; call = call->next_callee) {
+		int i;
+		map[call->caller_init_opline - op_array->opcodes] = call;
+		map[call->caller_call_opline - op_array->opcodes] = call;
+		for (i = 0; i < call->num_args; i++) {
+			if (call->arg_info[i].opline) {
+				map[call->arg_info[i].opline - op_array->opcodes] = call;
+			}
+		}
+	}
+	return map;
+}
+/* }}} */
+
 /*
  * Local variables:
  * tab-width: 4

--- a/ext/opcache/Optimizer/zend_call_graph.h
+++ b/ext/opcache/Optimizer/zend_call_graph.h
@@ -51,6 +51,7 @@ struct _zend_func_info {
 	zend_ssa                ssa;          /* Static Single Assignmnt Form  */
 	zend_call_info         *caller_info;  /* where this function is called from */
 	zend_call_info         *callee_info;  /* which functions are called from this one */
+	zend_call_info        **call_map;     /* Call info associated with init/call/send opnum */
 	int                     num_args;     /* (-1 - unknown) */
 	zend_recv_arg_info     *arg_info;
 	zend_ssa_var_info       return_info;
@@ -69,6 +70,7 @@ typedef struct _zend_call_graph {
 BEGIN_EXTERN_C()
 
 int zend_build_call_graph(zend_arena **arena, zend_script *script, uint32_t build_flags, zend_call_graph *call_graph);
+zend_call_info **zend_build_call_map(zend_arena **arena, zend_func_info *info, zend_op_array *op_array);
 int zend_analyze_calls(zend_arena **arena, zend_script *script, uint32_t build_flags, zend_op_array *op_array, zend_func_info *func_info);
 
 END_EXTERN_C()

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -978,9 +978,10 @@ int zend_optimize_script(zend_script *script, zend_long optimization_level, zend
 		}
 
 		for (i = 0; i < call_graph.op_arrays_count; i++) {
-			if (call_graph.op_arrays[i]->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
-				func_info = ZEND_FUNC_INFO(call_graph.op_arrays[i]);
-				if (func_info) {
+			func_info = ZEND_FUNC_INFO(call_graph.op_arrays[i]);
+			if (func_info) {
+				func_info->call_map = zend_build_call_map(&ctx.arena, func_info, call_graph.op_arrays[i]);
+				if (call_graph.op_arrays[i]->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
 					zend_init_func_return_info(call_graph.op_arrays[i], script, &func_info->return_info);
 				}
 			}


### PR DESCRIPTION
Partial fix for https://bugs.php.net/bug.php?id=74250, dropping optimization time for the provided file from 3.1s to 0.9s. The remainder is mostly spent in the CFG pass (60%), though identify_loops also takes up 10% and probably shouldn't.