### PR TITLE
Compile-time error for optional before required parameters

### DIFF
--- a/Zend/tests/bug74251.phpt
+++ b/Zend/tests/bug74251.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #74251 Compile-time error for placing optional parameters before required parameters
+--FILE--
+<?php
+
+function test($a = true, $b){}
+
+?>
+--EXPECTF--
+Fatal error: Only the last parameters can be optional in %sbug74251.php on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5073,6 +5073,7 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 	uint32_t i;
 	zend_op_array *op_array = CG(active_op_array);
 	zend_arg_info *arg_infos;
+	zend_bool optional_before_required = 0;
 	
 	if (return_type_ast) {
 		zend_bool allow_null = 0;
@@ -5154,7 +5155,11 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 			default_node.op_type = IS_CONST;
 			zend_const_expr_to_zval(&default_node.u.constant, default_ast);
 			CG(compiler_options) = cops;
+			optional_before_required = 1;
 		} else {
+			if (optional_before_required) {
+				zend_error_noreturn(E_COMPILE_ERROR, "Only the last parameters can be optional");
+			}
 			opcode = ZEND_RECV;
 			default_node.op_type = IS_UNUSED;
 			op_array->required_num_args = i + 1;


### PR DESCRIPTION
This resolves [#74251](https://bugs.php.net/bug.php?id=74251). I think a compile-time error makes a lot of sense, particularly with PHP 7.1 introducing the `ArgumentCountError` exception for passing in too few arguments (see [this](https://3v4l.org/uOl0t) and [this](https://3v4l.org/o6NIC)).