### PR TITLE
Fixed #74298 - IntlDateFormatter->format() doesn't return microseconds/fractions

### DIFF
--- a/ext/intl/common/common_date.cpp
+++ b/ext/intl/common/common_date.cpp
@@ -125,6 +125,8 @@ U_CFUNC int intl_datetime_decompose(zval *z, double *millis, TimeZone **tz,
 	}
 
 	if (millis) {
+		php_date_obj *datetime;
+
 		ZVAL_STRING(&zfuncname, "getTimestamp");
 		if (call_user_function(NULL, z, &zfuncname, &retval, 0, NULL)
 				!= SUCCESS || Z_TYPE(retval) != IS_LONG) {
@@ -137,7 +139,8 @@ U_CFUNC int intl_datetime_decompose(zval *z, double *millis, TimeZone **tz,
 			return FAILURE;
 		}
 
-		*millis = U_MILLIS_PER_SECOND * (double)Z_LVAL(retval);
+		datetime = Z_PHPDATE_P(z);
+		*millis = U_MILLIS_PER_SECOND * ((double)Z_LVAL(retval) + datetime->time->f);
 		zval_ptr_dtor(&zfuncname);
 	}
 

--- a/ext/intl/tests/bug74298.phpt
+++ b/ext/intl/tests/bug74298.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bug #74298 (IntlDateFormatter->format() doesn't return microseconds/fractions)
+--SKIPIF--
+<?php if (!extension_loaded('intl')) print 'skip'; ?>
+--FILE--
+<?php
+var_dump((new \DateTime('2017-01-01 01:02:03.123456'))->format('Y-m-d\TH:i:s.u'));
+
+var_dump((new \IntlDateFormatter(
+    'en-US',
+    \IntlDateFormatter::FULL,
+    \IntlDateFormatter::FULL,
+    'UTC',
+    \IntlDateFormatter::GREGORIAN,
+    'yyyy-MM-dd HH:mm:ss.SSSSSS'
+))->format(new \DateTime('2017-01-01 01:02:03.123456')));
+
+var_dump(datefmt_create(
+    'en-US',
+    \IntlDateFormatter::FULL,
+    \IntlDateFormatter::FULL,
+    'UTC',
+    \IntlDateFormatter::GREGORIAN,
+    'yyyy-MM-dd HH:mm:ss.SSSSSS'
+)->format(new \DateTime('2017-01-01 01:02:03.123456')));
+?>
+--EXPECTF--
+string(26) "2017-01-01T01:02:03.123456"
+string(26) "2017-01-01 01:02:03.123000"
+string(26) "2017-01-01 01:02:03.123000"


### PR DESCRIPTION
FIx for https://bugs.php.net/bug.php?id=74298

`udat_format` supports formatting only milliseconds (3 digits of fractions). 

Here is the statement from documentation:
`Appends zeros if more than 3 letters specified. Truncates at three significant digits when parsing.`