### PR TITLE
Fix bug #64346 - Invalidation for NS_FCALL cache

### DIFF
--- a/Zend/tests/bug64346.phpt
+++ b/Zend/tests/bug64346.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #64346: Function name resolution and eval
+--FILE--
+<?php
+
+namespace NS;
+
+function getLen($s) {
+    return strlen($s);
+}
+
+var_dump(getLen("foo"));
+eval("namespace NS_unrelated; function strlen() { return 42; }");
+var_dump(getLen("foo"));
+eval("namespace NS; function strlen() { return 42; }");
+var_dump(getLen("foo"));
+
+?>
+--EXPECT--
+int(3)
+int(3)
+int(42)

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -357,6 +357,7 @@ struct _zend_op_array {
 	zend_function *prototype;
 	uint32_t num_args;
 	uint32_t required_num_args;
+	uint32_t cache_gen;
 	zend_arg_info *arg_info;
 	/* END of common elements */
 
@@ -406,6 +407,7 @@ typedef struct _zend_internal_function {
 	zend_function *prototype;
 	uint32_t num_args;
 	uint32_t required_num_args;
+	uint32_t cache_gen;
 	zend_internal_arg_info *arg_info;
 	/* END of common elements */
 
@@ -429,6 +431,7 @@ union _zend_function {
 		union _zend_function *prototype;
 		uint32_t num_args;
 		uint32_t required_num_args;
+		uint32_t cache_gen; /* For invalidation of INIT_NS_FCALL cache entries */
 		zend_arg_info *arg_info;
 	} common;
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -84,6 +84,7 @@ ZEND_API const zend_internal_function zend_pass_function = {
 	NULL,                   /* prototype         */
 	0,                      /* num_args          */
 	0,                      /* required_num_args */
+	0,                      /* cache_gen         */
 	NULL,                   /* arg_info          */
 	ZEND_FN(pass),          /* handler           */
 	NULL,                   /* module            */

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3358,10 +3358,14 @@ ZEND_VM_HANDLER(69, ZEND_INIT_NS_FCALL_BY_NAME, ANY, CONST, NUM)
 	zval *func;
 	zend_function *fbc;
 	zend_execute_data *call;
+	void **cache_slot;
+	uint32_t gen;
 
 	func_name = EX_CONSTANT(opline->op2) + 1;
-	fbc = CACHED_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(opline->op2)));
-	if (UNEXPECTED(fbc == NULL)) {
+	cache_slot = CACHE_ADDR(Z_CACHE_SLOT_P(EX_CONSTANT(opline->op2)));
+	fbc = CACHED_PTR_EX(cache_slot);
+	gen = (uintptr_t) CACHED_PTR_EX(cache_slot + 1);
+	if (UNEXPECTED(fbc == NULL || gen < fbc->common.cache_gen)) {
 		func = zend_hash_find(EG(function_table), Z_STR_P(func_name));
 		if (func == NULL) {
 			func_name++;
@@ -3373,7 +3377,8 @@ ZEND_VM_HANDLER(69, ZEND_INIT_NS_FCALL_BY_NAME, ANY, CONST, NUM)
 			}
 		}
 		fbc = Z_FUNC_P(func);
-		CACHE_PTR(Z_CACHE_SLOT_P(EX_CONSTANT(opline->op2)), fbc);
+		CACHE_PTR_EX(cache_slot, fbc);
+		CACHE_PTR_EX(cache_slot + 1, (void *) (uintptr_t) fbc->common.cache_gen);
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!fbc->op_array.run_time_cache)) {
 			init_func_run_time_cache(&fbc->op_array);
 		}

--- a/ext/opcache/Optimizer/compact_literals.c
+++ b/ext/opcache/Optimizer/compact_literals.c
@@ -144,7 +144,7 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 					LITERAL_INFO(opline->op2.constant, LITERAL_FUNC, 1, 1, 2);
 					break;
 				case ZEND_INIT_NS_FCALL_BY_NAME:
-					LITERAL_INFO(opline->op2.constant, LITERAL_FUNC, 1, 1, 3);
+					LITERAL_INFO(opline->op2.constant, LITERAL_FUNC, 1, 2, 3);
 					break;
 				case ZEND_INIT_METHOD_CALL:
 					if (ZEND_OP2_TYPE(opline) == IS_CONST) {


### PR DESCRIPTION
The basic premise here is that actually invalidating all the relevant runtime cache entries is too complicated. Instead we tag the global fallback function with a "cache generation", which is incremented every time a namespaced function is defined that might invalidate an existing global namespace fallback. We then compare against this cache generation in INIT_NS_FCALL. If it was incremented in the meantime, we discard the cache state.

The overhead introduced by this implementation is...
 * An extra uint32_t (8 bytes with padding) in each function.
 * An extra comparison, only in INIT_NS_FCALL.

Bug: https://bugs.php.net/bug.php?id=64346