### PR TITLE
Openssl 1.1.0 support for 7.0

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2337,15 +2337,13 @@ AC_DEFUN([PHP_SETUP_OPENSSL],[
 
   dnl If pkg-config is found try using it
   if test "$PHP_OPENSSL_DIR" = "yes" && test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
-    if $PKG_CONFIG --atleast-version=1.1 openssl; then
-      AC_MSG_ERROR([OpenSSL version >= 1.1 is not supported.])
-    elif $PKG_CONFIG --atleast-version=0.9.8 openssl; then
+    if $PKG_CONFIG --atleast-version=0.9.8 openssl; then
       found_openssl=yes
       OPENSSL_LIBS=`$PKG_CONFIG --libs openssl`
       OPENSSL_INCS=`$PKG_CONFIG --cflags-only-I openssl`
       OPENSSL_INCDIR=`$PKG_CONFIG --variable=includedir openssl`
     else
-      AC_MSG_ERROR([OpenSSL version >= 0.9.8 and < 1.1 required.])
+      AC_MSG_ERROR([OpenSSL version 0.9.8 or greater required.])
     fi
 
     if test -n "$OPENSSL_LIBS"; then

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5674,6 +5674,12 @@ PHP_FUNCTION(openssl_encrypt)
 
 	PHP_OPENSSL_CHECK_SIZE_T_TO_INT(data_len, data);
 
+	cipher_ctx = EVP_CIPHER_CTX_new();
+	if (!cipher_ctx) {
+		php_error_docref(NULL, E_WARNING, "Failed to create cipher context");
+		RETURN_FALSE;
+	}
+
 	keylen = EVP_CIPHER_key_length(cipher_type);
 	if (keylen > password_len) {
 		key = emalloc(keylen);
@@ -5691,12 +5697,6 @@ PHP_FUNCTION(openssl_encrypt)
 
 	outlen = data_len + EVP_CIPHER_block_size(cipher_type);
 	outbuf = zend_string_alloc(outlen, 0);
-
-	cipher_ctx = EVP_CIPHER_CTX_new();
-	if (!cipher_ctx) {
-		php_error_docref(NULL, E_WARNING, "Failed to create cipher context");
-		RETURN_FALSE;
-	}
 
 	EVP_EncryptInit(cipher_ctx, cipher_type, NULL, NULL);
 	if (password_len > keylen) {

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3409,7 +3409,26 @@ PHP_FUNCTION(openssl_csr_get_public_key)
 		RETURN_FALSE;
 	}
 
-	tpubkey=X509_REQ_get_pubkey(csr);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+	/* Due to changes in OpenSSL 1.1 related to locking when decoding CSR,
+	 * the pub key is not changed after assigning. It means if we pass
+	 * a private key, it will be returned including the private part.
+	 * If we duplicate it, then we get just the public part which is
+	 * the same behavior as for OpenSSL 1.0 */
+	csr = X509_REQ_dup(csr);
+#endif
+	/* Retrieve the public key from the CSR */
+	tpubkey = X509_REQ_get_pubkey(csr);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+	/* We need to free the CSR as it was duplicated */
+	X509_REQ_free(csr);
+#endif
+
+	if (tpubkey == NULL) {
+		RETURN_FALSE;
+	}
+
 	RETURN_RES(zend_register_resource(tpubkey, le_key));
 }
 /* }}} */

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1356,7 +1356,9 @@ PHP_MINIT_FUNCTION(openssl)
 #ifdef HAVE_OPENSSL_MD2_H
 	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_MD2", OPENSSL_ALGO_MD2, CONST_CS|CONST_PERSISTENT);
 #endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER)
 	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_DSS1", OPENSSL_ALGO_DSS1, CONST_CS|CONST_PERSISTENT);
+#endif
 #if OPENSSL_VERSION_NUMBER >= 0x0090708fL
 	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA224", OPENSSL_ALGO_SHA224, CONST_CS|CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA256", OPENSSL_ALGO_SHA256, CONST_CS|CONST_PERSISTENT);
@@ -4073,7 +4075,7 @@ PHP_FUNCTION(openssl_pkey_export_to_file)
 			cipher = NULL;
 		}
 
-		switch (EVP_PKEY_type(key->type)) {
+		switch (EVP_PKEY_base_id(key)) {
 #ifdef HAVE_EVP_PKEY_EC
 			case EVP_PKEY_EC:
 				pem_write = PEM_write_bio_ECPrivateKey(bio_out, EVP_PKEY_get1_EC_KEY(key), cipher, (unsigned char *)passphrase, (int)passphrase_len, NULL, NULL);
@@ -4143,7 +4145,7 @@ PHP_FUNCTION(openssl_pkey_export)
 			cipher = NULL;
 		}
 
-		switch (EVP_PKEY_type(key->type)) {
+		switch (EVP_PKEY_base_id(key)) {
 #ifdef HAVE_EVP_PKEY_EC
 			case EVP_PKEY_EC:
 				pem_write = PEM_write_bio_ECPrivateKey(bio_out, EVP_PKEY_get1_EC_KEY(key), cipher, (unsigned char *)passphrase, (int)passphrase_len, NULL, NULL);

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -659,6 +659,20 @@ static int X509_get_signature_nid(const X509 *x)
 	return OBJ_obj2nid(x->sig_alg->algorithm);
 }
 
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
+
+int EVP_PKEY_id(const EVP_PKEY *pkey)
+{
+	return pkey->type;
+}
+
+int EVP_PKEY_base_id(const EVP_PKEY *pkey)
+{
+	return EVP_PKEY_type(pkey->type);
+}
+
+#endif
+
 #endif
 
 #endif

--- a/ext/openssl/tests/001.phpt
+++ b/ext/openssl/tests/001.phpt
@@ -18,7 +18,8 @@ for ($z = "", $i = 0; $i < 1024; $i++) {
 		usleep($i);
 }
 
-$privkey = openssl_pkey_new();
+$conf = array('config' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'openssl.cnf');
+$privkey = openssl_pkey_new($conf);
 
 if ($privkey === false)
 	die("failed to create private key");
@@ -30,7 +31,7 @@ if ($key_file_name === false)
 
 echo "Export key to file\n";
 
-openssl_pkey_export_to_file($privkey, $key_file_name, $passphrase) or die("failed to export to file $key_file_name");
+openssl_pkey_export_to_file($privkey, $key_file_name, $passphrase, $conf) or die("failed to export to file $key_file_name");
 
 echo "Load key from file - array syntax\n";
 

--- a/ext/openssl/tests/bug41033.phpt
+++ b/ext/openssl/tests/bug41033.phpt
@@ -13,11 +13,11 @@ $pub = 'file://' . dirname(__FILE__) . '/' . 'bug41033pub.pem';
 
 $prkeyid = openssl_get_privatekey($prv, "1234");
 $ct = "Hello I am some text!";
-openssl_sign($ct, $signature, $prkeyid, OPENSSL_ALGO_DSS1);
+openssl_sign($ct, $signature, $prkeyid, OPENSSL_ALGO_SHA1);
 echo "Signature: ".base64_encode($signature) . "\n";
 
 $pukeyid = openssl_get_publickey($pub);
-$valid = openssl_verify($ct, $signature, $pukeyid, OPENSSL_ALGO_DSS1);
+$valid = openssl_verify($ct, $signature, $pukeyid, OPENSSL_ALGO_SHA1);
 echo "Signature validity: " . $valid . "\n";
 
 

--- a/ext/openssl/tests/bug41033.phpt
+++ b/ext/openssl/tests/bug41033.phpt
@@ -10,14 +10,14 @@ if (OPENSSL_VERSION_NUMBER < 0x009070af) die("skip");
 $prv = 'file://' . dirname(__FILE__) . '/' . 'bug41033.pem';
 $pub = 'file://' . dirname(__FILE__) . '/' . 'bug41033pub.pem';
 
-
+$alg = (OPENSSL_VERSION_NUMBER < 0x10000000) ? OPENSSL_ALGO_DSS1 : OPENSSL_ALGO_SHA1;
 $prkeyid = openssl_get_privatekey($prv, "1234");
 $ct = "Hello I am some text!";
-openssl_sign($ct, $signature, $prkeyid, OPENSSL_ALGO_SHA1);
+openssl_sign($ct, $signature, $prkeyid, $alg);
 echo "Signature: ".base64_encode($signature) . "\n";
 
 $pukeyid = openssl_get_publickey($pub);
-$valid = openssl_verify($ct, $signature, $pukeyid, OPENSSL_ALGO_SHA1);
+$valid = openssl_verify($ct, $signature, $pukeyid, $alg);
 echo "Signature validity: " . $valid . "\n";
 
 

--- a/ext/openssl/tests/bug66501.phpt
+++ b/ext/openssl/tests/bug66501.phpt
@@ -16,7 +16,7 @@ AwEHoUQDQgAEPq4hbIWHvB51rdWr8ejrjWo4qVNWVugYFtPg/xLQw0mHkIPZ4DvK
 sqOTOnMoezkbSmVVMuwz9flvnqHGmQvmug==
 -----END EC PRIVATE KEY-----';
 $key = openssl_pkey_get_private($pkey);
-$res = openssl_sign($data ='alpha', $sign, $key, 'ecdsa-with-SHA1');
+$res = openssl_sign($data ='alpha', $sign, $key, 'SHA1');
 var_dump($res);
 --EXPECTF--
 bool(true)

--- a/ext/openssl/tests/bug66501.phpt
+++ b/ext/openssl/tests/bug66501.phpt
@@ -16,7 +16,8 @@ AwEHoUQDQgAEPq4hbIWHvB51rdWr8ejrjWo4qVNWVugYFtPg/xLQw0mHkIPZ4DvK
 sqOTOnMoezkbSmVVMuwz9flvnqHGmQvmug==
 -----END EC PRIVATE KEY-----';
 $key = openssl_pkey_get_private($pkey);
-$res = openssl_sign($data ='alpha', $sign, $key, 'SHA1');
+$sigalg = (OPENSSL_VERSION_NUMBER < 0x10000000) ? 'ecdsa-with-SHA1' : 'SHA1';
+$res = openssl_sign($data ='alpha', $sign, $key, $sigalg);
 var_dump($res);
 --EXPECTF--
 bool(true)

--- a/ext/openssl/tests/openssl_error_string_basic.phpt
+++ b/ext/openssl/tests/openssl_error_string_basic.phpt
@@ -105,7 +105,7 @@ expect_openssl_errors('openssl_private_decrypt', ['04065072']);
 // public encrypt and decrypt with failed padding check and padding
 @openssl_public_encrypt("data", $crypted, $public_key_file, 1000);
 @openssl_public_decrypt("data", $crypted, $public_key_file);
-expect_openssl_errors('openssl_private_(en|de)crypt padding', ['0906D06C', '04068076', '0407006A', '04067072']);
+expect_openssl_errors('openssl_private_(en|de)crypt padding', ['0906D06C', '04068076', '04067072']);
 
 // X509
 echo "X509 errors\n";

--- a/ext/openssl/tests/openssl_error_string_basic.phpt
+++ b/ext/openssl/tests/openssl_error_string_basic.phpt
@@ -89,7 +89,7 @@ expect_openssl_errors('openssl_pkey_export_to_file opening', ['02001002', '2006D
 expect_openssl_errors('openssl_pkey_export_to_file pem', ['0906D06C']);
 // file to export cannot be written
 @openssl_pkey_export_to_file($private_key_file, $invalid_file_for_write);
-expect_openssl_errors('openssl_pkey_export_to_file write', ['2006D002', '09072007']);
+expect_openssl_errors('openssl_pkey_export_to_file write', ['2006D002']);
 // succesful export
 @openssl_pkey_export($private_key_file_with_pass, $out, 'wrong pwd');
 expect_openssl_errors('openssl_pkey_export', ['06065064', '0906A065']);
@@ -126,7 +126,7 @@ expect_openssl_errors('openssl_x509_checkpurpose purpose', ['0B086079']);
 echo "CSR errors\n";
 // file for csr (file:///) fails when opennig (BIO_new_file)
 @openssl_csr_get_subject("file://" . $invalid_file_for_read);
-expect_openssl_errors('openssl_csr_get_subject open', ['02001002', '2006D080', '20068079', '0906D06C']);
+expect_openssl_errors('openssl_csr_get_subject open', ['02001002', '2006D080']);
 // file or str csr is not correct PEM - failing PEM_read_bio_X509_REQ
 @openssl_csr_get_subject($crt_file);
 expect_openssl_errors('openssl_csr_get_subjec pem', ['0906D06C']);

--- a/ext/openssl/tests/openssl_free_key.phpt
+++ b/ext/openssl/tests/openssl_free_key.phpt
@@ -22,7 +22,8 @@ for ($z = "", $i = 0; $i < 1024; $i++) {
         usleep($i);
 }
 
-$privkey = openssl_pkey_new();
+$conf = array('config' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'openssl.cnf');
+$privkey = openssl_pkey_new($conf);
 
 if ($privkey === false)
     die("failed to create private key");
@@ -34,7 +35,7 @@ if ($key_file_name === false)
 
 echo "Export key to file\n";
 
-openssl_pkey_export_to_file($privkey, $key_file_name, $passphrase) or die("failed to export to file $key_file_name");
+openssl_pkey_export_to_file($privkey, $key_file_name, $passphrase, $conf) or die("failed to export to file $key_file_name");
 
 echo "Load key from file - array syntax\n";
 

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -996,6 +996,21 @@ static const SSL_METHOD *php_select_crypto_method(zend_long method_value, int is
 }
 /* }}} */
 
+#define PHP_SSL_MAX_VERSION_LEN 32
+
+static char *php_ssl_cipher_get_version(const SSL_CIPHER *c, char *buffer, size_t max_len) /* {{{ */
+{
+	const char *version = SSL_CIPHER_get_version(c);
+
+	strncpy(buffer, version, max_len);
+	if (max_len <= strlen(version)) {
+		buffer[max_len - 1] = 0;
+	}
+
+	return buffer;
+}
+/* }}} */
+
 static int php_get_crypto_method_ctx_flags(int method_flags) /* {{{ */
 {
 	int ssl_ctx_options = SSL_OP_ALL;
@@ -1210,7 +1225,7 @@ static int set_server_dh_param(php_stream * stream, SSL_CTX *ctx) /* {{{ */
 /* }}} */
 #endif
 
-#ifdef HAVE_ECDH
+#if defined(HAVE_ECDH) && (OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER))
 static int set_server_ecdh_curve(php_stream *stream, SSL_CTX *ctx) /* {{{ */
 {
 	zval *zvcurve;
@@ -1253,7 +1268,7 @@ static int set_server_specific_opts(php_stream *stream, SSL_CTX *ctx) /* {{{ */
 	zval *zv;
 	long ssl_ctx_options = SSL_CTX_get_options(ctx);
 
-#ifdef HAVE_ECDH
+#if defined(HAVE_ECDH) && (OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER))
 	if (set_server_ecdh_curve(stream, ctx) == FAILURE) {
 		return FAILURE;
 	}
@@ -1684,6 +1699,7 @@ static zend_array *capture_session_meta(SSL *ssl_handle) /* {{{ */
 	char *proto_str;
 	long proto = SSL_version(ssl_handle);
 	const SSL_CIPHER *cipher = SSL_get_current_cipher(ssl_handle);
+	char version_str[PHP_SSL_MAX_VERSION_LEN];
 
 	switch (proto) {
 #ifdef HAVE_TLS12
@@ -1716,7 +1732,7 @@ static zend_array *capture_session_meta(SSL *ssl_handle) /* {{{ */
 	add_assoc_string(&meta_arr, "protocol", proto_str);
 	add_assoc_string(&meta_arr, "cipher_name", (char *) SSL_CIPHER_get_name(cipher));
 	add_assoc_long(&meta_arr, "cipher_bits", SSL_CIPHER_get_bits(cipher, NULL));
-	add_assoc_string(&meta_arr, "cipher_version", SSL_CIPHER_get_version(cipher));
+	add_assoc_string(&meta_arr, "cipher_version", php_ssl_cipher_get_version(cipher, version_str, PHP_SSL_MAX_VERSION_LEN));
 
 	return Z_ARR(meta_arr);
 }
@@ -2292,6 +2308,7 @@ static int php_openssl_sockop_set_option(php_stream *stream, int option, int val
 			if (sslsock->ssl_active) {
 				zval tmp;
 				char *proto_str;
+				char version_str[PHP_SSL_MAX_VERSION_LEN];
 				const SSL_CIPHER *cipher;
 
 				array_init(&tmp);
@@ -2318,7 +2335,7 @@ static int php_openssl_sockop_set_option(php_stream *stream, int option, int val
 				add_assoc_string(&tmp, "protocol", proto_str);
 				add_assoc_string(&tmp, "cipher_name", (char *) SSL_CIPHER_get_name(cipher));
 				add_assoc_long(&tmp, "cipher_bits", SSL_CIPHER_get_bits(cipher, NULL));
-				add_assoc_string(&tmp, "cipher_version", SSL_CIPHER_get_version(cipher));
+				add_assoc_string(&tmp, "cipher_version", php_ssl_cipher_get_version(cipher, version_str, PHP_SSL_MAX_VERSION_LEN));
 
 #ifdef HAVE_TLS_ALPN
 				{

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1494,7 +1494,7 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, php_uint32 sig_typ
 			BIO *in;
 			EVP_PKEY *key;
 			EVP_MD *mdtype = (EVP_MD *) EVP_sha1();
-			EVP_MD_CTX md_ctx;
+			EVP_MD_CTX *md_ctx;
 #else
 			int tempsig;
 #endif
@@ -1567,7 +1567,8 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, php_uint32 sig_typ
 				return FAILURE;
 			}
 
-			EVP_VerifyInit(&md_ctx, mdtype);
+			md_ctx = EVP_MD_CTX_create();
+			EVP_VerifyInit(md_ctx, mdtype);
 			read_len = end_of_phar;
 
 			if (read_len > sizeof(buf)) {
@@ -1579,7 +1580,7 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, php_uint32 sig_typ
 			php_stream_seek(fp, 0, SEEK_SET);
 
 			while (read_size && (len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
-				EVP_VerifyUpdate (&md_ctx, buf, len);
+				EVP_VerifyUpdate (md_ctx, buf, len);
 				read_len -= (zend_off_t)len;
 
 				if (read_len < read_size) {
@@ -1587,9 +1588,9 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, php_uint32 sig_typ
 				}
 			}
 
-			if (EVP_VerifyFinal(&md_ctx, (unsigned char *)sig, sig_len, key) != 1) {
+			if (EVP_VerifyFinal(md_ctx, (unsigned char *)sig, sig_len, key) != 1) {
 				/* 1: signature verified, 0: signature does not match, -1: failed signature operation */
-				EVP_MD_CTX_cleanup(&md_ctx);
+				EVP_MD_CTX_destroy(md_ctx);
 
 				if (error) {
 					spprintf(error, 0, "broken openssl signature");
@@ -1598,7 +1599,7 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, php_uint32 sig_typ
 				return FAILURE;
 			}
 
-			EVP_MD_CTX_cleanup(&md_ctx);
+			EVP_MD_CTX_destroy(md_ctx);
 #endif
 
 			*signature_len = phar_hex_str((const char*)sig, sig_len, signature);


### PR DESCRIPTION
This is a backport and some 7.0 specific ports for OpenSSL 1.1 support.

@weltling Are you ok with that for 7.0 branch? The reason for that is that some distros already applies their own patches just to support OpenSSL 1.1 so this will prevent further diversion. In addition it unifies the code base for openssl ext so it is easier to write fixes for some parts (mainly current pkey bugs) that diverged between 7.0 and 7.1 (I mean I don't have to write it twice if I want to fix it in 7.0...)