### PR TITLE
Let MessageFormatter and IntlDateFormatter accept DateTimeImmutable as well

### DIFF
--- a/ext/intl/common/common_date.cpp
+++ b/ext/intl/common/common_date.cpp
@@ -139,8 +139,8 @@ U_CFUNC int intl_datetime_decompose(zval *z, double *millis, TimeZone **tz,
 		php_date_obj *datetime;
 		datetime = Z_PHPDATE_P(z);
 		if (!datetime->time) {
-			spprintf(&message, 0, "%s: the DateTime object is not properly "
-					"initialized", func);
+			spprintf(&message, 0, "%s: the %s object is not properly "
+					"initialized", func, ZSTR_VAL(Z_OBJCE_P(z)->name));
 			intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR,
 				message, 1);
 			efree(message);
@@ -199,7 +199,7 @@ U_CFUNC double intl_zval_to_millis(zval *z, intl_error *err, const char *func)
 		rv = U_MILLIS_PER_SECOND * Z_DVAL_P(z);
 		break;
 	case IS_OBJECT:
-		if (instanceof_function(Z_OBJCE_P(z), php_date_get_date_ce())) {
+		if (instanceof_function(Z_OBJCE_P(z), php_date_get_interface_ce())) {
 			intl_datetime_decompose(z, &rv, NULL, err, func);
 		} else if (instanceof_function(Z_OBJCE_P(z), Calendar_ce_ptr)) {
 			Calendar_object *co = Z_INTL_CALENDAR_P(z);
@@ -222,7 +222,7 @@ U_CFUNC double intl_zval_to_millis(zval *z, intl_error *err, const char *func)
 		} else {
 			/* TODO: try with cast(), get() to obtain a number */
 			spprintf(&message, 0, "%s: invalid object type for date/time "
-					"(only IntlCalendar and DateTime permitted)", func);
+					"(only IntlCalendar and DateTimeInterface permitted)", func);
 			intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR,
 				message, 1);
 			efree(message);

--- a/ext/intl/tests/dateformat_bug65683.phpt
+++ b/ext/intl/tests/dateformat_bug65683.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #65683 IntlDateFormatter accepts DateTimeImmutable
+--SKIPIF--
+<?php
+if (!extension_loaded('intl')) die('skip intl extension not enabled'); ?>
+--FILE--
+<?php
+
+$formatter = new IntlDateFormatter('en-US', IntlDateFormatter::FULL, IntlDateFormatter::NONE, new DateTimeZone("UTC"));
+var_dump($formatter->format(new DateTimeImmutable('2017-03-27 00:00:00 UTC'))) . "\n";
+
+?>
+==DONE==
+--EXPECTF--
+string(%s) "Monday, March %d, 2017"
+==DONE==

--- a/ext/intl/tests/dateformat_format.phpt
+++ b/ext/intl/tests/dateformat_format.phpt
@@ -400,24 +400,24 @@ Formatted DateTime is : 20001230 05:04 PM
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'

--- a/ext/intl/tests/dateformat_format_variant2.phpt
+++ b/ext/intl/tests/dateformat_format_variant2.phpt
@@ -400,24 +400,24 @@ Formatted DateTime is : 20001230 05:04 PM
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'

--- a/ext/intl/tests/dateformat_format_variant3.phpt
+++ b/ext/intl/tests/dateformat_format_variant3.phpt
@@ -400,24 +400,24 @@ Formatted DateTime is : 20001230 05:04 PM
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'
 ------------
 Date is: stdClass::__set_state(array(
 ))
 ------------
-Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted): U_ILLEGAL_ARGUMENT_ERROR'
+Error while formatting as: 'datefmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted): U_ILLEGAL_ARGUMENT_ERROR'

--- a/ext/intl/tests/msgfmt_format_datetime.phpt
+++ b/ext/intl/tests/msgfmt_format_datetime.phpt
@@ -16,13 +16,16 @@ $fmt = <<<EOD
 EOD;
 
 $dt = new DateTime("2012-05-06 18:00:42", new DateTimeZone("Europe/Lisbon"));
+$dti = new DateTimeImmutable("2012-05-06 18:00:42", new DateTimeZone("Europe/Lisbon"));
 
 $mf = new MessageFormatter('en_US', $fmt);
 
 var_dump($mf->format(array($dt)));
+var_dump($mf->format(array($dti)));
 
 ?>
 ==DONE==
 --EXPECTF--
+string(%s) "May %d, 2012 %d:%d:42 %s"
 string(%s) "May %d, 2012 %d:%d:42 %s"
 ==DONE==

--- a/ext/intl/tests/msgfmt_format_error5.phpt
+++ b/ext/intl/tests/msgfmt_format_error5.phpt
@@ -20,7 +20,7 @@ $mf = new MessageFormatter('en_US', $fmt);
 var_dump($mf->format(array("foo" => new stdclass())));
 
 --EXPECTF--
-Warning: MessageFormatter::format(): msgfmt_format: invalid object type for date/time (only IntlCalendar and DateTime permitted) in %s on line %d
+Warning: MessageFormatter::format(): msgfmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted) in %s on line %d
 
 Warning: MessageFormatter::format(): The argument for key 'foo' cannot be used as a date or time in %s on line %d
 bool(false)


### PR DESCRIPTION
This commit fixes https://bugs.php.net/bug.php?id=65683 and possibly other similar reportings.

So far, both `MessageFormatter` and `IntlDateFormatter` only accepted `DateTime` values. This commit updates the code so that any object implementing the `DateTimeInterface` is accepted. Tests have been extended accordingly.