### PR TITLE
Add cgroups support to PHP-FPM pools

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -586,6 +586,9 @@ if test "$PHP_FPM" != "no"; then
   PHP_ARG_WITH(fpm-acl,,
   [  --with-fpm-acl          Use POSIX Access Control Lists], no, no)
 
+  PHP_ARG_WITH(fpm-cgroup,,
+  [  --with-fpm-cgroup       Use CGroups], no, no)
+
   if test "$PHP_FPM_SYSTEMD" != "no" ; then
     if test -z "$PKG_CONFIG"; then
       AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
@@ -637,6 +640,17 @@ if test "$PHP_FPM" != "no"; then
       AC_MSG_ERROR(libacl required not found)
     ])
   fi
+
+  if test "$PHP_FPM_CGROUP" != "no" ; then
+    AC_CHECK_HEADERS([libcgroup.h])
+    AC_CHECK_LIB(cgroup, cgroup_init, [
+      PHP_ADD_LIBRARY(cgroup)
+      AC_DEFINE(HAVE_FPM_CGROUP, 1, [ CGroups support ])
+    ],[
+      AC_MSG_ERROR(libcgroup required not found)
+    ])
+  fi
+
 
   PHP_SUBST_OLD(php_fpm_systemd)
   AC_DEFINE_UNQUOTED(PHP_FPM_SYSTEMD, "$php_fpm_systemd", [fpm systemd service type])

--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -157,6 +157,9 @@ static struct ini_value_parser_s ini_fpm_pool_options[] = {
 #ifdef HAVE_APPARMOR
 	{ "apparmor_hat",              &fpm_conf_set_string,      WPO(apparmor_hat) },
 #endif
+#ifdef HAVE_FPM_CGROUP
+	{ "cgroup",                    &fpm_conf_set_string,      WPO(cgroup) },
+#endif
 	{ 0, 0, 0 }
 };
 
@@ -657,6 +660,9 @@ int fpm_worker_pool_config_free(struct fpm_worker_pool_config_s *wpc) /* {{{ */
 	free(wpc->security_limit_extensions);
 #ifdef HAVE_APPARMOR
 	free(wpc->apparmor_hat);
+#endif
+#ifdef HAVE_FPM_CGROUP
+	free(wpc->cgroup);
 #endif
 
 	for (kv = wpc->php_values; kv; kv = kv_next) {
@@ -1606,6 +1612,9 @@ static void fpm_conf_dump() /* {{{ */
 		zlog(ZLOG_NOTICE, "\tprefix = %s",                     STR2STR(wp->config->prefix));
 		zlog(ZLOG_NOTICE, "\tuser = %s",                       STR2STR(wp->config->user));
 		zlog(ZLOG_NOTICE, "\tgroup = %s",                      STR2STR(wp->config->group));
+#ifdef HAVE_FPM_CGROUP
+		zlog(ZLOG_NOTICE, "\tcgroup = %s",                     STR2STR(wp->config->cgroup));
+#endif
 		zlog(ZLOG_NOTICE, "\tlisten = %s",                     STR2STR(wp->config->listen_address));
 		zlog(ZLOG_NOTICE, "\tlisten.backlog = %d",             wp->config->listen_backlog);
 #ifdef HAVE_FPM_ACL

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -97,6 +97,9 @@ struct fpm_worker_pool_config_s {
 	char *listen_acl_users;
 	char *listen_acl_groups;
 #endif
+#ifdef HAVE_FPM_CGROUP
+	char *cgroup;
+#endif
 };
 
 struct ini_value_parser_s {

--- a/sapi/fpm/fpm/fpm_worker_pool.c
+++ b/sapi/fpm/fpm/fpm_worker_pool.c
@@ -30,6 +30,9 @@ void fpm_worker_pool_free(struct fpm_worker_pool_s *wp) /* {{{ */
 	if (wp->home) {
 		free(wp->home);
 	}
+#ifdef HAVE_FPM_CGROUP
+	cgroup_free(&wp->cgroup);
+#endif
 	fpm_unix_free_socket_premissions(wp);
 	free(wp);
 }

--- a/sapi/fpm/fpm/fpm_worker_pool.h
+++ b/sapi/fpm/fpm/fpm_worker_pool.h
@@ -8,6 +8,10 @@
 #include "fpm_conf.h"
 #include "fpm_shm.h"
 
+#ifdef HAVE_FPM_CGROUP
+#include <libcgroup.h>
+#endif
+
 struct fpm_worker_pool_s;
 struct fpm_child_s;
 struct fpm_child_stat_s;
@@ -45,6 +49,9 @@ struct fpm_worker_pool_s {
 
 #ifdef HAVE_FPM_ACL
 	void *socket_acl;
+#endif
+#ifdef HAVE_FPM_CGROUP
+	struct cgroup *cgroup;
 #endif
 };
 

--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -23,6 +23,11 @@
 user = @php_fpm_user@
 group = @php_fpm_group@
 
+; When Cgroups are supported you can use this option to put worker processes to
+; specified cgroup.
+; Default Value: no set
+;cgroup = webserver/fpm
+
 ; The address on which to accept FastCGI requests.
 ; Valid syntaxes are:
 ;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on


### PR DESCRIPTION
This patch allows to configure cgroup where to put php-fpm pool worker processes, configured per pool separately.

Moving workers into cgroup by external applications is too inaccurate and unuseable in heavily-loaded envirnonments. Applying cgroup to worker at its start is correct solution for this, and can be widely used to pool resource control and limiting.

We use this solution since 5.6, with 7.0 too. But these branches are already closed for new features, so I made PR against 7.1.

Many Thanks to PHP Team.
