### PR TITLE
Fix php.ini opcache.max_accelerated_files documentation

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1776,7 +1776,7 @@ ldap.max_links = -1
 ;opcache.interned_strings_buffer=4
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
-; Only numbers between 200 and 100000 are allowed.
+; Only numbers between 200 and 1000000 are allowed.
 ;opcache.max_accelerated_files=2000
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.

--- a/php.ini-production
+++ b/php.ini-production
@@ -1776,7 +1776,7 @@ ldap.max_links = -1
 ;opcache.interned_strings_buffer=4
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
-; Only numbers between 200 and 100000 are allowed.
+; Only numbers between 200 and 1000000 are allowed.
 ;opcache.max_accelerated_files=2000
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.


### PR DESCRIPTION
As stated in [docs](https://secure.php.net/manual/en/opcache.configuration.php#ini.opcache.max-accelerated-files), the maximum is now 1000000.

> The maximum number of keys (and therefore scripts) in the OPcache hash table. The actual value used will be the first number in the set of prime numbers { 223, 463, 983, 1979, 3907, 7963, 16229, 32531, 65407, 130987 } that is greater than or equal to the configured value. The minimum value is 200. The maximum value is 100000 in PHP < 5.5.6, and 1000000 in later versions.

However, from the docs it is not clear what would happen if you use number greater than 130987.

*(The repository was taking ages to clone, so I edited the files through the Github web interface. Can you please squash the commits before eventually merging?)*