### PR TITLE
[JSON] Don't suppress warnings in tests

### DIFF
--- a/ext/json/tests/pass001.1.phpt
+++ b/ext/json/tests/pass001.1.phpt
@@ -14,8 +14,6 @@ if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only");
  * Modified to test empty string values.
  * Modified to test a mix of integers and strings as keys.
  */
-// Expect warnings about INF.
-ini_set("error_reporting", E_ALL & ~E_WARNING);
 
 $test = "
 [

--- a/ext/json/tests/pass001.1_64bit.phpt
+++ b/ext/json/tests/pass001.1_64bit.phpt
@@ -14,8 +14,6 @@ if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
  * Modified to test empty string values.
  * Modified to test a mix of integers and strings as keys.
  */
-// Expect warnings about INF.
-ini_set("error_reporting", E_ALL & ~E_WARNING);
 
 $test = "
 [

--- a/ext/json/tests/pass001.phpt
+++ b/ext/json/tests/pass001.phpt
@@ -8,8 +8,6 @@ if (!extension_loaded('json')) die('skip');
 ?>
 --FILE--
 <?php
-// Expect warnings about INF.
-ini_set("error_reporting", E_ALL & ~E_WARNING);
 
 $test = "
 [


### PR DESCRIPTION
It's a bad idea to suppress _all_ warnings in tests, as future changes that cause warnings will also be hidden. It's better to declare the expected warnings and when/where they occur.

These tests don't actually raise warnings so removing the `error_reporting` flag has no affect