### PR TITLE
when registering a function, their arguments can be dynamically

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2458,6 +2458,8 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 ZEND_API void zend_unregister_functions(const zend_function_entry *functions, int count, HashTable *function_table) /* {{{ */
 {
 	const zend_function_entry *ptr = functions;
+	zend_function *reg_function;
+	zend_arg_info *arg_info;
 	int i=0;
 	HashTable *target_function_table = function_table;
 	zend_string *lowercase_name;
@@ -2473,6 +2475,12 @@ ZEND_API void zend_unregister_functions(const zend_function_entry *functions, in
 		fname_len = strlen(ptr->fname);
 		lowercase_name = zend_string_alloc(fname_len, 0);
 		zend_str_tolower_copy(ZSTR_VAL(lowercase_name), ptr->fname, fname_len);
+		reg_function = zend_hash_find_ptr(target_function_table, lowercase_name);
+		if (reg_function->common.arg_info &&
+			(reg_function->common.fn_flags & (ZEND_ACC_HAS_RETURN_TYPE|ZEND_ACC_HAS_TYPE_HINTS))) {
+			arg_info = reg_function->common.arg_info - 1;
+			free(arg_info);
+		}
 		zend_hash_del(target_function_table, lowercase_name);
 		zend_string_free(lowercase_name);
 		ptr++;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2476,7 +2476,7 @@ ZEND_API void zend_unregister_functions(const zend_function_entry *functions, in
 		lowercase_name = zend_string_alloc(fname_len, 0);
 		zend_str_tolower_copy(ZSTR_VAL(lowercase_name), ptr->fname, fname_len);
 		reg_function = zend_hash_find_ptr(target_function_table, lowercase_name);
-		if (reg_function->common.arg_info &&
+		if (reg_function && reg_function->common.arg_info &&
 			(reg_function->common.fn_flags & (ZEND_ACC_HAS_RETURN_TYPE|ZEND_ACC_HAS_TYPE_HINTS))) {
 			arg_info = reg_function->common.arg_info - 1;
 			free(arg_info);

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -935,6 +935,38 @@ PHP_MINFO_FUNCTION(dom)
 
 PHP_MSHUTDOWN_FUNCTION(dom) /* {{{ */
 {
+#if defined(LIBXML_XPATH_ENABLED)
+	zend_unregister_functions(dom_xpath_class_entry->info.internal.builtin_functions, -1, &dom_xpath_class_entry->function_table);
+#endif
+	zend_unregister_functions(dom_node_class_entry->info.internal.builtin_functions, -1, &dom_node_class_entry->function_table);
+	zend_unregister_functions(dom_domexception_class_entry->info.internal.builtin_functions, -1, &dom_domexception_class_entry->function_table);
+	zend_unregister_functions(dom_domstringlist_class_entry->info.internal.builtin_functions, -1, &dom_domstringlist_class_entry->function_table);
+	zend_unregister_functions(dom_namelist_class_entry->info.internal.builtin_functions, -1, &dom_namelist_class_entry->function_table);
+	zend_unregister_functions(dom_domimplementationlist_class_entry->info.internal.builtin_functions, -1, &dom_domimplementationlist_class_entry->function_table);
+	zend_unregister_functions(dom_domimplementationsource_class_entry->info.internal.builtin_functions, -1, &dom_domimplementationsource_class_entry->function_table);
+	zend_unregister_functions(dom_domimplementation_class_entry->info.internal.builtin_functions, -1, &dom_domimplementation_class_entry->function_table);
+	zend_unregister_functions(dom_documentfragment_class_entry->info.internal.builtin_functions, -1, &dom_documentfragment_class_entry->function_table);
+	zend_unregister_functions(dom_document_class_entry->info.internal.builtin_functions, -1, &dom_document_class_entry->function_table);
+	zend_unregister_functions(dom_nodelist_class_entry->info.internal.builtin_functions, -1, &dom_nodelist_class_entry->function_table);
+	zend_unregister_functions(dom_namednodemap_class_entry->info.internal.builtin_functions, -1, &dom_namednodemap_class_entry->function_table);
+	zend_unregister_functions(dom_characterdata_class_entry->info.internal.builtin_functions, -1, &dom_characterdata_class_entry->function_table);
+	zend_unregister_functions(dom_attr_class_entry->info.internal.builtin_functions, -1, &dom_attr_class_entry->function_table);
+	zend_unregister_functions(dom_element_class_entry->info.internal.builtin_functions, -1, &dom_element_class_entry->function_table);
+	zend_unregister_functions(dom_text_class_entry->info.internal.builtin_functions, -1, &dom_text_class_entry->function_table);
+	zend_unregister_functions(dom_comment_class_entry->info.internal.builtin_functions, -1, &dom_comment_class_entry->function_table);
+	zend_unregister_functions(dom_typeinfo_class_entry->info.internal.builtin_functions, -1, &dom_typeinfo_class_entry->function_table);
+	zend_unregister_functions(dom_userdatahandler_class_entry->info.internal.builtin_functions, -1, &dom_userdatahandler_class_entry->function_table);
+	zend_unregister_functions(dom_domerror_class_entry->info.internal.builtin_functions, -1, &dom_domerror_class_entry->function_table);
+	zend_unregister_functions(dom_domerrorhandler_class_entry->info.internal.builtin_functions, -1, &dom_domerrorhandler_class_entry->function_table);
+	zend_unregister_functions(dom_domlocator_class_entry->info.internal.builtin_functions, -1, &dom_domlocator_class_entry->function_table);
+	zend_unregister_functions(dom_domconfiguration_class_entry->info.internal.builtin_functions, -1, &dom_domconfiguration_class_entry->function_table);
+	zend_unregister_functions(dom_cdatasection_class_entry->info.internal.builtin_functions, -1, &dom_cdatasection_class_entry->function_table);
+	zend_unregister_functions(dom_documenttype_class_entry->info.internal.builtin_functions, -1, &dom_documenttype_class_entry->function_table);
+	zend_unregister_functions(dom_notation_class_entry->info.internal.builtin_functions, -1, &dom_notation_class_entry->function_table);
+	zend_unregister_functions(dom_entity_class_entry->info.internal.builtin_functions, -1, &dom_entity_class_entry->function_table);
+	zend_unregister_functions(dom_entityreference_class_entry->info.internal.builtin_functions, -1, &dom_entityreference_class_entry->function_table);
+	zend_unregister_functions(dom_processinginstruction_class_entry->info.internal.builtin_functions, -1, &dom_processinginstruction_class_entry->function_table);
+	zend_unregister_functions(dom_string_extend_class_entry->info.internal.builtin_functions, -1, &dom_string_extend_class_entry->function_table);
 	zend_hash_destroy(&dom_domstringlist_prop_handlers);
 	zend_hash_destroy(&dom_namelist_prop_handlers);
 	zend_hash_destroy(&dom_domimplementationlist_prop_handlers);


### PR DESCRIPTION
allocated when there is a typed return.