### PR TITLE
Fix of Bug #74383: Wrong reflection on Phar::running

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -5191,7 +5191,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phar_webPhar, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 PHAR_ARG_INFO
-ZEND_BEGIN_ARG_INFO_EX(arginfo_phar_running, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phar_running, 0, 0, 0)
 	ZEND_ARG_INFO(0, retphar)
 ZEND_END_ARG_INFO()
 

--- a/ext/phar/tests/bug74383.phpt
+++ b/ext/phar/tests/bug74383.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Phar: bug #74383: Wrong reflection on Phar::running
+--SKIPIF--
+<?php if (!extension_loaded("phar") || !extension_loaded('reflection')) die("skip"); ?>
+--FILE--
+<?php
+$rc = new ReflectionClass(Phar::class);
+$rm = $rc->getMethod("running");
+echo $rm->getNumberOfParameters();
+echo PHP_EOL;
+echo $rm->getNumberOfRequiredParameters();
+echo PHP_EOL;
+echo (int) $rm->getParameters()[0]->isOptional();
+
+?>
+
+--EXPECT--
+1
+0
+1


### PR DESCRIPTION
Here are docs showing the parameter is optional:
http://php.net/manual/en/phar.running.php

Also the parameter is optional in the function definition:
https://github.com/php/php-src/blob/PHP-7.0.18/ext/phar/phar_object.c#L424