### PR TITLE
Fix for Bug #74383 in PHP7.1 and above: Wrong reflection on Phar::run…

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -5134,7 +5134,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phar_webPhar, 0, 0, 0)
 	ZEND_ARG_INFO(0, rewrites)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_phar_running, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phar_running, 0, 0, 0)
 	ZEND_ARG_INFO(0, retphar)
 ZEND_END_ARG_INFO()
 

--- a/ext/phar/tests/bug74383.phpt
+++ b/ext/phar/tests/bug74383.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Phar: bug #74383: Wrong reflection on Phar::running
+--SKIPIF--
+<?php if (!extension_loaded("phar") || !extension_loaded('reflection')) die("skip"); ?>
+--FILE--
+<?php
+$rc = new ReflectionClass(Phar::class);
+$rm = $rc->getMethod("running");
+echo $rm->getNumberOfParameters();
+echo PHP_EOL;
+echo $rm->getNumberOfRequiredParameters();
+echo PHP_EOL;
+echo (int) $rm->getParameters()[0]->isOptional();
+
+?>
+
+--EXPECT--
+1
+0
+1


### PR DESCRIPTION
…ning

This is an identical fix to https://github.com/php/php-src/pull/2463 except the it doesn't have conflict with the branch PHP-7.1 and master. The merge conflicts happens because of the removal of the line `PHAR_ARG_INFO` in PHP 7.1.

Here it is PHP 7.0:
https://github.com/php/php-src/blob/PHP-7.0.18/ext/phar/phar_object.c#L5193

Here in PHP 7.1 `PHAR_ARG_INFO` is removed :
https://github.com/php/php-src/blob/PHP-7.1.4/ext/phar/phar_object.c#L5137

Also if there is a merge conflict between different version is opening another PR the correct thing to do?