### PR TITLE
Remove spurious `CG(context).in_finally` dingleberry

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -234,7 +234,6 @@ void zend_oparray_context_begin(zend_oparray_context *prev_context) /* {{{ */
 	CG(context).vars_size = 0;
 	CG(context).literals_size = 0;
 	CG(context).backpatch_count = 0;
-	CG(context).in_finally = 0;
 	CG(context).fast_call_var = -1;
 	CG(context).try_catch_offset = -1;
 	CG(context).current_brk_cont = -1;
@@ -4838,9 +4837,7 @@ void zend_compile_try(zend_ast *ast) /* {{{ */
 
 		zend_emit_op(NULL, ZEND_JMP, NULL, NULL);
 
-		CG(context).in_finally++;
 		zend_compile_stmt(finally_ast);
-		CG(context).in_finally--;
 
 		CG(active_op_array)->try_catch_array[try_catch_offset].finally_op = opnum_jmp + 1;
 		CG(active_op_array)->try_catch_array[try_catch_offset].finally_end

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -191,7 +191,6 @@ typedef struct _zend_oparray_context {
 	int        vars_size;
 	int        literals_size;
 	int        backpatch_count;
-	int        in_finally;
 	uint32_t   fast_call_var;
 	uint32_t   try_catch_offset;
 	int        current_brk_cont;


### PR DESCRIPTION
The `CG(context).in_finally` int seems to be a dingleberry from a past implementation of `finally`. I removed it and all the try/catch/finally tests still pass.

Also - my editor seems to have removed a bunch of random unneeded whitespace as well. Let me know if you want to keep all those in there and I'll add them back to the PR. :)