### PR TITLE
Fix #74269 - Strict comparison of initial trait property values

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -39,6 +39,8 @@ PHP 7.2 UPGRADE NOTES
     of a notice. They will generate an Error in a future version of PHP.
     (https://wiki.php.net/rfc/deprecate-bareword-strings)
   . Minimum supported Windows versions are Windows 7/Server 2008 R2.
+  . Initial trait property value compatibility check will no longer perform
+    any casts. (Bug #74269)
 
 - BCMath:
   . The bcmod() function no longer truncates fractional numbers to integers. As

--- a/Zend/tests/bug74269.phpt
+++ b/Zend/tests/bug74269.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #74269: It's possible to override trait property with different loosely-equal value
+--FILE--
+<?php
+trait PropertiesTrait
+{
+    public $same = true;
+}
+
+class PropertiesExample
+{
+    use PropertiesTrait;
+    public $same = 2;
+}
+?>
+--EXPECTF--
+Fatal error: PropertiesExample and PropertiesTrait define the same property ($same) in the composition of PropertiesExample. However, the definition differs and is considered incompatible. Class was composed in %s

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -23,7 +23,7 @@
 #include "zend_execute.h"
 #include "zend_inheritance.h"
 #include "zend_smart_str.h"
-#include "zend_inheritance.h"
+#include "zend_operators.h"
 
 static void overriden_ptr_dtor(zval *zv) /* {{{ */
 {
@@ -1576,15 +1576,11 @@ static void zend_do_traits_property_binding(zend_class_entry *ce) /* {{{ */
 						== (flags & (ZEND_ACC_PPP_MASK | ZEND_ACC_STATIC))) {
 						/* flags are identical, now the value needs to be checked */
 						if (flags & ZEND_ACC_STATIC) {
-							not_compatible = (FAILURE == compare_function(&compare_result,
-											  &ce->default_static_members_table[coliding_prop->offset],
-											  &ce->traits[i]->default_static_members_table[property_info->offset]))
-								  || (Z_LVAL(compare_result) != 0);
+							not_compatible = fast_is_not_identical_function(&ce->default_static_members_table[coliding_prop->offset],
+											  &ce->traits[i]->default_static_members_table[property_info->offset]);
 						} else {
-							not_compatible = (FAILURE == compare_function(&compare_result,
-											  &ce->default_properties_table[OBJ_PROP_TO_NUM(coliding_prop->offset)],
-											  &ce->traits[i]->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)]))
-								  || (Z_LVAL(compare_result) != 0);
+							not_compatible = fast_is_not_identical_function(&ce->default_properties_table[OBJ_PROP_TO_NUM(coliding_prop->offset)],
+											  &ce->traits[i]->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)]);
 						}
 					} else {
 						/* the flags are not identical, thus, we assume properties are not compatible */


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=74269

Given the potential BC break, should probably be only for master.