### PR TITLE
change functor to quote to pass in driver_params

### DIFF
--- a/ext/pdo/pdo_sql_parser.re
+++ b/ext/pdo/pdo_sql_parser.re
@@ -271,9 +271,11 @@ safe:
 
 						default:
 							buf = zval_get_string(parameter);
+                            zval* driver_params = emalloc( sizeof( zval ));
+                            ZVAL_COPY( driver_params, &( param->driver_params ));
 							if (!stmt->dbh->methods->quoter(stmt->dbh, ZSTR_VAL(buf),
 									ZSTR_LEN(buf), &plc->quoted, &plc->qlen,
-									param_type)) {
+									param_type, driver_params)) {
 								/* bork */
 								ret = -1;
 								strncpy(stmt->error_code, stmt->dbh->error_code, 6);
@@ -282,6 +284,7 @@ safe:
 								}
 								goto clean_up;
 							}
+                            efree( driver_params );
 							plc->freeq = 1;
 					}
 

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -257,7 +257,7 @@ typedef int (*pdo_dbh_prepare_func)(pdo_dbh_t *dbh, const char *sql, size_t sql_
 typedef zend_long (*pdo_dbh_do_func)(pdo_dbh_t *dbh, const char *sql, size_t sql_len);
 
 /* quote a string */
-typedef int (*pdo_dbh_quote_func)(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype);
+typedef int (*pdo_dbh_quote_func)(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype, zval* driver_params);
 
 /* transaction related */
 typedef int (*pdo_dbh_txn_func)(pdo_dbh_t *dbh);


### PR DESCRIPTION
When `stmt->supports_placeholders == PDO_PLACEHOLDER_NONE`,
`stmt->dbh->methods->quoter(stmt->dbh, Z_STRVAL(tmp_param), Z_STRLEN(tmp_param), &plc->quoted, &plc->qlen, param->param_type)` calls the quote function of a specific driver, which quotes a string and is ultimately placed into a placeholder of a prepared statement.

The problem I'm encountering is that when quote is called here, only the connection information is passed into the function. Once inside the quote function, there is no way to access statement or parameter level information.

In my case specifically, I store the encoding of a bound parameter in `pdo_bound_param_data->driver_params` and I need to change the behavior of the quote function depending on this encoding. For instance, if the encoding is CHAR I simply put quote around a given string (e.g., string to 'string'); however, if the encoding is UTF8, I need to put an N in front of the quote for the query to work in TSQL (e.g., 한국어 to N'한국어').