### PR TITLE
ext/gettext: respect passed in library directory for all checks

### DIFF
--- a/ext/gettext/config.m4
+++ b/ext/gettext/config.m4
@@ -30,7 +30,6 @@ if test "$PHP_GETTEXT" != "no"; then
 		AC_MSG_ERROR(Unable to find required gettext library)
 	])
   )
-  LDFLAGS=$O_LDFLAGS
 
   AC_DEFINE(HAVE_LIBINTL,1,[ ])
   PHP_NEW_EXTENSION(gettext, gettext.c, $ext_shared)
@@ -46,5 +45,6 @@ if test "$PHP_GETTEXT" != "no"; then
   AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, dngettext,  [AC_DEFINE(HAVE_DNGETTEXT, 1, [ ])])
   AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, dcngettext,  [AC_DEFINE(HAVE_DCNGETTEXT, 1, [ ])])
   AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, bind_textdomain_codeset,  [AC_DEFINE(HAVE_BIND_TEXTDOMAIN_CODESET, 1, [ ])])
+  LDFLAGS=$O_LDFLAGS
   
 fi


### PR DESCRIPTION
A directory given to configure by --with-gettext=dir is only
used within the very first AC_CHECK_LIB. This is because the
temporary modified LDFLAGS variable is reset too early.

This results in functions not detected properly.

The original issue and patch was reported for OpenWrt/LEDE
distribution by @Dimazhan at:
https://github.com/openwrt/packages/issues/4250

Signed-off-by: Michael Heimpold <mhei@heimpold.de>