### PR TITLE
#74337 pointer returned by php_stream_fopen_tmpfile not validated

### DIFF
--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -489,9 +489,14 @@ static int php_stream_temp_cast(php_stream *stream, int castas, void **ret)
 		return FAILURE;
 	}
 
+	file = php_stream_fopen_tmpfile();
+	if (file == NULL) {
+		php_error_docref(NULL, E_WARNING, "Unable to create temporary file.");
+		return FAILURE;
+	}
+
 	/* perform the conversion and then pass the request on to the innerstream */
 	membuf = php_stream_memory_get_buffer(ts->innerstream, &memsize);
-	file = php_stream_fopen_tmpfile();
 	php_stream_write(file, membuf, memsize);
 	pos = php_stream_tell(ts->innerstream);
 


### PR DESCRIPTION
The pointer returned by php_stream_fopen_tmpfile is not validated prior to use in memory.c.
In the case where a script is executed in an environment where the parent directory of system TMP directory is not readable to the user, it will cause a application crash with Access Violation.

The issue is similar to the https://bugs.php.net/bug.php?id=68986

Steps to reproduce:
1. Create C:\TEMP folder
2. Create system user
3. Add Deny Full control access rights for created user on C:\
4. Remove Deny Full control access rights for created user on C:\TEMP
5. Add Allow Full control access rights for created user on C:\TEMP
6. Set TEMP and TMP system environment variables value to C:\TEMP
7. Execute script by created user:
```
<?php
$fp = fopen('php://temp', 'w+b');
$ch = curl_init();
curl_setopt($ch, CURLOPT_FILE, $fp);
```