### PR TITLE
Remove obsolete function names from CODING_STANDARDS file

### DIFF
--- a/CODING_STANDARDS
+++ b/CODING_STANDARDS
@@ -93,12 +93,12 @@ User Functions/Methods Naming Conventions
     readability of the function name itself::
 
     Good:
-    'mcrypt_enc_self_test'
-    'mysql_list_fields'
+    'str_word_count'
+    'array_key_exists'
 
     Ok:
-    'mcrypt_module_get_algo_supported_key_sizes'
-    (could be 'mcrypt_mod_get_algo_sup_key_sizes'?)
+    'date_interval_create_from_date_string'
+    (could be 'date_int_create_from_date_str'?)
     'get_html_translation_table'
     (could be 'html_get_trans_table'?)
 

--- a/CODING_STANDARDS
+++ b/CODING_STANDARDS
@@ -98,7 +98,7 @@ User Functions/Methods Naming Conventions
 
     Ok:
     'date_interval_create_from_date_string'
-    (could be 'date_int_create_from_date_str'?)
+    (could be 'date_intvl_create_from_date_str'?)
     'get_html_translation_table'
     (could be 'html_get_trans_table'?)
 


### PR DESCRIPTION
Deprecated and removed function names used as examples in coding standards file.

- Mcrypt is deprecated and will be removed in 7.2
- Mysql functions are deprecated in 5.4 and removed in 7.0.

According to those changes, CODING_STANDARDS file should be updated.