### PR TITLE
zend_compile_try: fix memory reallocation handling in multi-catch

### DIFF
--- a/Zend/tests/try/bug74444.phpt
+++ b/Zend/tests/try/bug74444.phpt
@@ -1,0 +1,77 @@
+--TEST--
+Bug #74444 (multiple catch freezes in some cases)
+--FILE--
+<?php
+function foo()
+{
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	echo '';
+	try {
+		throw new \RuntimeException();
+	} catch (\FooEx  | \RuntimeException $e) {
+		echo 1;
+	}
+	echo 2;
+}
+
+foo();
+
+--EXPECT--
+12

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4887,6 +4887,7 @@ void zend_compile_try(zend_ast *ast) /* {{{ */
 
 			if (!is_last_class) {
 				jmp_multicatch[j] = zend_emit_jump(0);
+				opline = &CG(active_op_array)->opcodes[opnum_catch];
 				opline->extended_value = get_next_op_number(CG(active_op_array));
 			}
 		}


### PR DESCRIPTION
fixes bug https://bugs.php.net/bug.php?id=74444

`zend_emit_jump(0);` may cause memory reallocation so we need to get opline again

this is my first php-src PR so I hope it is ok :)