### PR TITLE
Implemented request #71520 (Adding the DateTime constants to the DateTimeInterface interface)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,8 @@ PHP                                                                        NEWS
 
 - Date:
   . Fixed bug #69587 (DateInterval properties and isset). (jhdxr)
+  . Implemented request #71520 (Adding the DateTime constants to
+    the DateTimeInterface interface). (bugs dot php dot net at majkl578 dot cz)
   . Fixed bug #74404 (Wrong reflection on DateTimeZone::getTransitions).
     (krakjoe)
   . Fixed bug #74080 (add constant for RFC7231 format datetime). (duncan3dc)

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2064,6 +2064,23 @@ static void date_register_classes(void) /* {{{ */
 	date_ce_interface = zend_register_internal_interface(&ce_interface);
 	date_ce_interface->interface_gets_implemented = implement_date_interface_handler;
 
+#define REGISTER_DATE_INTERFACE_CONST_STRING(const_name, value) \
+	zend_declare_class_constant_stringl(date_ce_interface, const_name, sizeof(const_name)-1, value, sizeof(value)-1);
+
+	REGISTER_DATE_INTERFACE_CONST_STRING("ATOM",             DATE_FORMAT_RFC3339);
+	REGISTER_DATE_INTERFACE_CONST_STRING("COOKIE",           DATE_FORMAT_COOKIE);
+	REGISTER_DATE_INTERFACE_CONST_STRING("ISO8601",          DATE_FORMAT_ISO8601);
+	REGISTER_DATE_INTERFACE_CONST_STRING("RFC822",           DATE_FORMAT_RFC822);
+	REGISTER_DATE_INTERFACE_CONST_STRING("RFC850",           DATE_FORMAT_RFC850);
+	REGISTER_DATE_INTERFACE_CONST_STRING("RFC1036",          DATE_FORMAT_RFC1036);
+	REGISTER_DATE_INTERFACE_CONST_STRING("RFC1123",          DATE_FORMAT_RFC1123);
+	REGISTER_DATE_INTERFACE_CONST_STRING("RFC7231",          DATE_FORMAT_RFC7231);
+	REGISTER_DATE_INTERFACE_CONST_STRING("RFC2822",          DATE_FORMAT_RFC2822);
+	REGISTER_DATE_INTERFACE_CONST_STRING("RFC3339",          DATE_FORMAT_RFC3339);
+	REGISTER_DATE_INTERFACE_CONST_STRING("RFC3339_EXTENDED", DATE_FORMAT_RFC3339_EXTENDED);
+	REGISTER_DATE_INTERFACE_CONST_STRING("RSS",              DATE_FORMAT_RFC1123);
+	REGISTER_DATE_INTERFACE_CONST_STRING("W3C",              DATE_FORMAT_RFC3339);
+
 	INIT_CLASS_ENTRY(ce_date, "DateTime", date_funcs_date);
 	ce_date.create_object = date_object_new_date;
 	date_ce_date = zend_register_internal_class_ex(&ce_date, NULL);
@@ -2075,23 +2092,6 @@ static void date_register_classes(void) /* {{{ */
 	date_object_handlers_date.get_properties = date_object_get_properties;
 	date_object_handlers_date.get_gc = date_object_get_gc;
 	zend_class_implements(date_ce_date, 1, date_ce_interface);
-
-#define REGISTER_DATE_CLASS_CONST_STRING(const_name, value) \
-	zend_declare_class_constant_stringl(date_ce_date, const_name, sizeof(const_name)-1, value, sizeof(value)-1);
-
-	REGISTER_DATE_CLASS_CONST_STRING("ATOM",             DATE_FORMAT_RFC3339);
-	REGISTER_DATE_CLASS_CONST_STRING("COOKIE",           DATE_FORMAT_COOKIE);
-	REGISTER_DATE_CLASS_CONST_STRING("ISO8601",          DATE_FORMAT_ISO8601);
-	REGISTER_DATE_CLASS_CONST_STRING("RFC822",           DATE_FORMAT_RFC822);
-	REGISTER_DATE_CLASS_CONST_STRING("RFC850",           DATE_FORMAT_RFC850);
-	REGISTER_DATE_CLASS_CONST_STRING("RFC1036",          DATE_FORMAT_RFC1036);
-	REGISTER_DATE_CLASS_CONST_STRING("RFC1123",          DATE_FORMAT_RFC1123);
-	REGISTER_DATE_CLASS_CONST_STRING("RFC7231",          DATE_FORMAT_RFC7231);
-	REGISTER_DATE_CLASS_CONST_STRING("RFC2822",          DATE_FORMAT_RFC2822);
-	REGISTER_DATE_CLASS_CONST_STRING("RFC3339",          DATE_FORMAT_RFC3339);
-	REGISTER_DATE_CLASS_CONST_STRING("RFC3339_EXTENDED", DATE_FORMAT_RFC3339_EXTENDED);
-	REGISTER_DATE_CLASS_CONST_STRING("RSS",              DATE_FORMAT_RFC1123);
-	REGISTER_DATE_CLASS_CONST_STRING("W3C",              DATE_FORMAT_RFC3339);
 
 	INIT_CLASS_ENTRY(ce_immutable, "DateTimeImmutable", date_funcs_immutable);
 	ce_immutable.create_object = date_object_new_date;

--- a/ext/date/tests/DateTimeImmutable_constants.phpt
+++ b/ext/date/tests/DateTimeImmutable_constants.phpt
@@ -1,0 +1,32 @@
+--TEST--
+DateTimeImmutable constants
+--FILE--
+<?php
+
+var_dump(
+    DATE_ATOM    === DateTimeImmutable::ATOM,
+    DATE_COOKIE  === DateTimeImmutable::COOKIE,
+    DATE_ISO8601 === DateTimeImmutable::ISO8601,
+    DATE_RFC822  === DateTimeImmutable::RFC822,
+    DATE_RFC850  === DateTimeImmutable::RFC850,
+    DATE_RFC1036 === DateTimeImmutable::RFC1036,
+    DATE_RFC1123 === DateTimeImmutable::RFC1123,
+    DATE_RFC2822 === DateTimeImmutable::RFC2822,
+    DATE_RFC3339 === DateTimeImmutable::RFC3339,
+    DATE_RSS     === DateTimeImmutable::RSS,
+    DATE_W3C     === DateTimeImmutable::W3C
+);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/date/tests/DateTimeInterface_constants.phpt
+++ b/ext/date/tests/DateTimeInterface_constants.phpt
@@ -1,0 +1,32 @@
+--TEST--
+DateTimeInterface constants
+--FILE--
+<?php
+
+var_dump(
+    DATE_ATOM    === DateTimeInterface::ATOM,
+    DATE_COOKIE  === DateTimeInterface::COOKIE,
+    DATE_ISO8601 === DateTimeInterface::ISO8601,
+    DATE_RFC822  === DateTimeInterface::RFC822,
+    DATE_RFC850  === DateTimeInterface::RFC850,
+    DATE_RFC1036 === DateTimeInterface::RFC1036,
+    DATE_RFC1123 === DateTimeInterface::RFC1123,
+    DATE_RFC2822 === DateTimeInterface::RFC2822,
+    DATE_RFC3339 === DateTimeInterface::RFC3339,
+    DATE_RSS     === DateTimeInterface::RSS,
+    DATE_W3C     === DateTimeInterface::W3C
+);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/date/tests/DateTime_constants.phpt
+++ b/ext/date/tests/DateTime_constants.phpt
@@ -1,0 +1,32 @@
+--TEST--
+DateTime constants
+--FILE--
+<?php
+
+var_dump(
+    DATE_ATOM    === DateTime::ATOM,
+    DATE_COOKIE  === DateTime::COOKIE,
+    DATE_ISO8601 === DateTime::ISO8601,
+    DATE_RFC822  === DateTime::RFC822,
+    DATE_RFC850  === DateTime::RFC850,
+    DATE_RFC1036 === DateTime::RFC1036,
+    DATE_RFC1123 === DateTime::RFC1123,
+    DATE_RFC2822 === DateTime::RFC2822,
+    DATE_RFC3339 === DateTime::RFC3339,
+    DATE_RSS     === DateTime::RSS,
+    DATE_W3C     === DateTime::W3C
+);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Implements [FR #71520](https://bugs.php.net/bug.php?id=71520).

The primary motivation should be obvious from the feature request. Currently it's not possible to properly use DateTimeImmutable formatting, because one needs to use DateTime anyway, since the constants are defined only on DateTime class.