### PR TITLE
Added method DateTime::createFromImmutable() [follow-up for #1145]

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -65,6 +65,8 @@ PHP                                                                        NEWS
   . Fixed bug #74404 (Wrong reflection on DateTimeZone::getTransitions).
     (krakjoe)
   . Fixed bug #74080 (add constant for RFC7231 format datetime). (duncan3dc)
+  . Implemented FR #74668: Add DateTime::createFromImmutable() method.
+    (bugs dot php dot net at majkl578 dot cz, Rican7)
 
 - Dba:
   . Fixed bug #72885 (flatfile: dba_fetch() fails to read replaced entry).

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -309,6 +309,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_date_method_timestamp_get, 0)
 ZEND_END_ARG_INFO()
 
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_date_method_create_from_immutable, 0, 0, 1)
+	ZEND_ARG_INFO(0, DateTimeImmutable)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_date_method_create_from_mutable, 0, 0, 1)
 	ZEND_ARG_INFO(0, DateTime)
 ZEND_END_ARG_INFO()
@@ -472,6 +477,7 @@ const zend_function_entry date_funcs_date[] = {
 	PHP_ME(DateTime,			__construct,		arginfo_date_create, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
 	PHP_ME(DateTime,			__wakeup,			NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(DateTime,			__set_state,		NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateTime,			createFromImmutable,	arginfo_date_method_create_from_immutable, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(createFromFormat, date_create_from_format,	arginfo_date_create_from_format, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(getLastErrors, date_get_last_errors,	arginfo_date_get_last_errors, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(format,		date_format,		arginfo_date_method_format, 0)
@@ -2816,7 +2822,28 @@ PHP_METHOD(DateTimeImmutable, __construct)
 }
 /* }}} */
 
-/* {{{ proto DateTimeImmutable::createFromMutable(DateTimeZone object)
+/* {{{ proto DateTime::createFromImmutable(DateTimeImmutable object)
+   Creates new DateTime object from an existing immutable DateTimeImmutable object.
+*/
+PHP_METHOD(DateTime, createFromImmutable)
+{
+	zval *datetimeimmutable_object = NULL;
+	php_date_obj *new_obj = NULL;
+	php_date_obj *old_obj = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJECT_OF_CLASS(datetimeimmutable_object, date_ce_immutable)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_date_instantiate(date_ce_date, return_value);
+	old_obj = Z_PHPDATE_P(datetimeimmutable_object);
+	new_obj = Z_PHPDATE_P(return_value);
+
+	new_obj->time = timelib_time_clone(old_obj->time);
+}
+/* }}} */
+
+/* {{{ proto DateTimeImmutable::createFromMutable(DateTime object)
    Creates new DateTimeImmutable object from an existing mutable DateTime object.
 */
 PHP_METHOD(DateTimeImmutable, createFromMutable)
@@ -2833,14 +2860,7 @@ PHP_METHOD(DateTimeImmutable, createFromMutable)
 	old_obj = Z_PHPDATE_P(datetime_object);
 	new_obj = Z_PHPDATE_P(return_value);
 
-	new_obj->time = timelib_time_ctor();
-	*new_obj->time = *old_obj->time;
-	if (old_obj->time->tz_abbr) {
-		new_obj->time->tz_abbr = timelib_strdup(old_obj->time->tz_abbr);
-	}
-	if (old_obj->time->tz_info) {
-		new_obj->time->tz_info = old_obj->time->tz_info;
-	}
+	new_obj->time = timelib_time_clone(old_obj->time);
 }
 /* }}} */
 

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -53,6 +53,7 @@ PHP_FUNCTION(getdate);
 PHP_METHOD(DateTime, __construct);
 PHP_METHOD(DateTime, __wakeup);
 PHP_METHOD(DateTime, __set_state);
+PHP_METHOD(DateTime, createFromImmutable);
 PHP_FUNCTION(date_create);
 PHP_FUNCTION(date_create_immutable);
 PHP_FUNCTION(date_create_from_format);

--- a/ext/date/tests/DateTime_createFromImmutable.phpt
+++ b/ext/date/tests/DateTime_createFromImmutable.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Tests for DateTime::createFromImmutable.
+--INI--
+date.timezone=Europe/London
+--FILE--
+<?php
+$current = "2014-03-02 16:24:08";
+$i = date_create_immutable( $current );
+
+$m = DateTime::createFromImmutable( $i );
+var_dump( $m );
+
+$m->modify('+ 1 hour');
+
+var_dump( $i->format('Y-m-d H:i:s') === $current );
+
+$m = DateTime::createFromImmutable( date_create( $current ) );
+var_dump( $m );
+?>
+--EXPECTF--
+object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "2014-03-02 16:24:08.000000"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(13) "Europe/London"
+}
+bool(true)
+
+Warning: DateTime::createFromImmutable() expects parameter 1 to be DateTimeImmutable, object given in %stests%eDateTime_createFromImmutable.php on line %d
+NULL

--- a/ext/date/tests/DateTime_verify.phpt
+++ b/ext/date/tests/DateTime_verify.phpt
@@ -27,7 +27,7 @@ object(ReflectionClass)#%d (1) {
   string(8) "DateTime"
 }
 ..and get names of all its methods
-array(18) {
+array(19) {
   [0]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
@@ -52,102 +52,109 @@ array(18) {
   [3]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(16) "createFromFormat"
+    string(19) "createFromImmutable"
     ["class"]=>
     string(8) "DateTime"
   }
   [4]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(13) "getLastErrors"
+    string(16) "createFromFormat"
     ["class"]=>
     string(8) "DateTime"
   }
   [5]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(6) "format"
+    string(13) "getLastErrors"
     ["class"]=>
     string(8) "DateTime"
   }
   [6]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(6) "modify"
+    string(6) "format"
     ["class"]=>
     string(8) "DateTime"
   }
   [7]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(3) "add"
+    string(6) "modify"
     ["class"]=>
     string(8) "DateTime"
   }
   [8]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(3) "sub"
+    string(3) "add"
     ["class"]=>
     string(8) "DateTime"
   }
   [9]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(11) "getTimezone"
+    string(3) "sub"
     ["class"]=>
     string(8) "DateTime"
   }
   [10]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(11) "setTimezone"
+    string(11) "getTimezone"
     ["class"]=>
     string(8) "DateTime"
   }
   [11]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(9) "getOffset"
+    string(11) "setTimezone"
     ["class"]=>
     string(8) "DateTime"
   }
   [12]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(7) "setTime"
+    string(9) "getOffset"
     ["class"]=>
     string(8) "DateTime"
   }
   [13]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(7) "setDate"
+    string(7) "setTime"
     ["class"]=>
     string(8) "DateTime"
   }
   [14]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(10) "setISODate"
+    string(7) "setDate"
     ["class"]=>
     string(8) "DateTime"
   }
   [15]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(12) "setTimestamp"
+    string(10) "setISODate"
     ["class"]=>
     string(8) "DateTime"
   }
   [16]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(12) "getTimestamp"
+    string(12) "setTimestamp"
     ["class"]=>
     string(8) "DateTime"
   }
   [17]=>
+  object(ReflectionMethod)#%d (2) {
+    ["name"]=>
+    string(12) "getTimestamp"
+    ["class"]=>
+    string(8) "DateTime"
+  }
+  [18]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
     string(4) "diff"


### PR DESCRIPTION
This basically resurrects PR #1145 which was initially merged, but then reverted because of some not really relevant objections.

The primary purpose of this method should be interoperability between DateTime and DateTimeImmutable. The further already has createFromMutable method, but the former has none. So if one wants to convert mutable to immutable, it's as easy as:
```
DateTime::createFromImmutable($dateTime)
```
but to convert immutable to mutable, it requires annoying boilerplate:
```
DateTime::createFromFormat(\DateTime::ISO8601, $dateTime->format(\DateTime::ISO8601), $dateTime->getTimezone())
```

There are still tons of libraries that rely only on DateTime class (looking at you, Doctrine). Of course, any new code should use the immutable variant, but it's not always feasible as such libraries wouldn't understand the immutable type - therefore it requires conversion.

I still believe it was a wrong decision to revert this before PHP 7, especially because the only arguments against were totally off topic / invalid.
Quoting @derickr's response from [the mailing list](markmail.org/message/3aesaaoqv6ihiw53#query:+page:1+mid:ukwizupev32ld5tg+state:results), which was the only objection as far as I know:
> When the factory method was added, we had this same discussion. And the 
> discussions lead to the conclusion that it does not make sense to have 
> this "createFromImmutable" factory method on DateTime. Basically with 
> the same reasons that people should type hint against the Interface 
> instead. To emulate that in PHP 5.5 and lower, users can just do:
> 
> class DateTimeInterface extends DateTime {}
> 
> I know, that's a bit of a hack.

These arguments are totally irrelevant. This is not a factory method, it's a method for interoperability and compatibility. Pretty much like it'd be `$mutable->toImmutable()` or `$immutable->toMutable()`.
Also the hack is totally meaningless and kind of funny, since the libraries that use DateTime are obviously doing it for purpose (i.e. backwards compatibility - semver anyone?).

I'd really like to see this resolved befrore PHP 7.2. It has already been blocked for two years and @derickr didn't even bother to reply to objections on the original PR...