### PR TITLE
Update php_network.h

### DIFF
--- a/main/php_network.h
+++ b/main/php_network.h
@@ -121,7 +121,7 @@ typedef int php_socket_t;
 /* #define PHP_USE_POLL_2_EMULATION 1 */
 
 #if defined(HAVE_SYS_POLL_H) && defined(HAVE_POLL)
-# include <sys/poll.h>
+# include <poll.h>
 typedef struct pollfd php_pollfd;
 #else
 typedef struct _php_pollfd {


### PR DESCRIPTION
```
In file included from /usr/local/include/php/main/php_network.h:124:0,
                 from /var/www/html/php-ext-handlersocketi-0.0.1/hs_response.c:3:
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
 #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
  ^
```