### PR TITLE
Avoid exact floating point comparison

### DIFF
--- a/ext/date/tests/timezone_location_get.phpt
+++ b/ext/date/tests/timezone_location_get.phpt
@@ -10,7 +10,7 @@ date.timezone=UTC
 $location = timezone_location_get(new DateTimeZone("Europe/Oslo"));
 var_dump($location);
 ?>
---EXPECT--
+--EXPECTF--
 array(4) {
   ["country_code"]=>
   string(2) "NO"

--- a/ext/date/tests/timezone_location_get.phpt
+++ b/ext/date/tests/timezone_location_get.phpt
@@ -15,7 +15,7 @@ array(4) {
   ["country_code"]=>
   string(2) "NO"
   ["latitude"]=>
-  float(59.91666)
+  float(59.9166%d)
   ["longitude"]=>
   float(10.75)
   ["comments"]=>


### PR DESCRIPTION
While working on an HHVM port for AARCH64 (ARMv8) it was discovered that
this regression test failed.  The test is comparing exact conversion of a floating
point value which is problematic.  This change is consistent with other tests in
this directory.
