### PR TITLE
[RFC] Trailing commas in group use lists

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,8 @@ PHP                                                                        NEWS
   . Fixed bug #74149 (static embed SAPI linkage error). (krakjoe)
   . Fixed bug #72359, bug #72451, bug #73706, bug #71115 and others related
     to interned strings handling in TS builds. (Anatol, Dmitry)
+  . Implemented "Trailing Commas In List Syntax" RFC for group use lists only.
+    (Sammy Kaye Powers)
 
 - BCMath:
   . Fixed bug #46564 (bcmod truncates fractionals). (liborm85)

--- a/Zend/tests/ns_088.phpt
+++ b/Zend/tests/ns_088.phpt
@@ -14,4 +14,4 @@ namespace Fiz\Biz\Buz {
 }
 ?>
 --EXPECTF--
-Parse error: syntax error, unexpected '{', expecting ',' or '}' in %sns_088.php on line 5
+Parse error: syntax error, unexpected '{', expecting '}' in %sns_088.php on line 5

--- a/Zend/tests/ns_094.phpt
+++ b/Zend/tests/ns_094.phpt
@@ -12,4 +12,4 @@ use const Foo\Bar\{
 };
 
 --EXPECTF--
-Parse error: syntax error, unexpected 'const' (T_CONST), expecting identifier (T_STRING) in %s on line 7
+Parse error: syntax error, unexpected 'const' (T_CONST), expecting '}' in %s on line 7

--- a/Zend/tests/ns_trailing_comma_01.phpt
+++ b/Zend/tests/ns_trailing_comma_01.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Mixed group use declaration can contain trailing comma
+--FILE--
+<?php
+namespace Foo {
+  const FOO_CONST = "Foo const\n";
+  function foo_func() {
+    echo "Foo func\n";
+  }
+  class FooClass {
+    function __construct() {
+      echo "Foo class\n";
+    }
+  }
+}
+namespace {
+  use Foo\{
+    const FOO_CONST,
+    function foo_func,
+    FooClass as BarClass,
+  };
+  echo FOO_CONST;
+  foo_func();
+  new BarClass;
+}
+?>
+--EXPECT--
+Foo const
+Foo func
+Foo class

--- a/Zend/tests/ns_trailing_comma_02.phpt
+++ b/Zend/tests/ns_trailing_comma_02.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Unmixed group use declaration can contain trailing comma
+--FILE--
+<?php
+namespace Foo {
+  const FOO_CONST_1 = "Foo const 1\n";
+  const FOO_CONST_2 = "Foo const 2\n";
+}
+namespace Bar {
+  function foo_func_1() {
+    echo "Bar func 1\n";
+  }
+  function foo_func_2() {
+    echo "Bar func 2\n";
+  }
+}
+namespace Baz {
+  class BazFooClass {
+    function __construct() { echo "BazFoo class\n"; }
+  }
+  class BazBarClass {
+    function __construct() { echo "BazBar class\n"; }
+  }
+}
+namespace {
+  use const Foo\{
+    FOO_CONST_1,
+    FOO_CONST_2,
+  };
+  use function Bar\{
+    foo_func_1,
+    foo_func_2,
+  };
+  use Baz\{
+    BazFooClass,
+    BazBarClass,
+  };
+  echo FOO_CONST_1;
+  echo FOO_CONST_2;
+  foo_func_1();
+  foo_func_2();
+  new BazFooClass;
+  new BazBarClass;
+}
+?>
+--EXPECT--
+Foo const 1
+Foo const 2
+Bar func 1
+Bar func 2
+BazFoo class
+BazBar class

--- a/Zend/tests/ns_trailing_comma_error_01.phpt
+++ b/Zend/tests/ns_trailing_comma_error_01.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Group use declarations mustn't be empty
+--FILE--
+<?php
+use Baz\{};
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected '}', expecting identifier (T_STRING) or function (T_FUNCTION) or const (T_CONST) in %s on line %d

--- a/Zend/tests/ns_trailing_comma_error_02.phpt
+++ b/Zend/tests/ns_trailing_comma_error_02.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Group use declarations mustn't contain just a comma
+--FILE--
+<?php
+use Baz\{,};
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',', expecting identifier (T_STRING) or function (T_FUNCTION) or const (T_CONST) in %s on line %d

--- a/Zend/tests/ns_trailing_comma_error_03.phpt
+++ b/Zend/tests/ns_trailing_comma_error_03.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Group use declarations mustn't allow more than one comma
+--FILE--
+<?php
+use Baz\{Foo,,};
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',', expecting '}' in %s on line %d

--- a/Zend/tests/ns_trailing_comma_error_04.phpt
+++ b/Zend/tests/ns_trailing_comma_error_04.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Group use declarations mustn't begin with a comma
+--FILE--
+<?php
+use Baz\{,Foo};
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',', expecting identifier (T_STRING) or function (T_FUNCTION) or const (T_CONST) in %s on line %d

--- a/Zend/tests/ns_trailing_comma_error_05.phpt
+++ b/Zend/tests/ns_trailing_comma_error_05.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Group use declarations mustn't contain two commas mid-list
+--FILE--
+<?php
+use Baz\{Foo,,Bar};
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',', expecting '}' in %s on line %d

--- a/Zend/tests/ns_trailing_comma_error_06.phpt
+++ b/Zend/tests/ns_trailing_comma_error_06.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Unmixed group use declarations mustn't allow more than one comma
+--FILE--
+<?php
+use const Baz\{Foo,,};
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',', expecting '}' in %s on line %d

--- a/Zend/tests/ns_trailing_comma_error_07.phpt
+++ b/Zend/tests/ns_trailing_comma_error_07.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Unmixed group use declarations mustn't begin with a comma
+--FILE--
+<?php
+use function Baz\{,Foo};
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',', expecting identifier (T_STRING) in %s on line %d

--- a/Zend/tests/ns_trailing_comma_error_08.phpt
+++ b/Zend/tests/ns_trailing_comma_error_08.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Unmixed group use declarations mustn't contain two commas mid-list
+--FILE--
+<?php
+use const Baz\{Foo,,Bar};
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',', expecting '}' in %s on line %d

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -338,17 +338,22 @@ use_type:
 ;
 
 group_use_declaration:
-		namespace_name T_NS_SEPARATOR '{' unprefixed_use_declarations '}'
+		namespace_name T_NS_SEPARATOR '{' unprefixed_use_declarations possible_comma '}'
 			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $1, $4); }
-	|	T_NS_SEPARATOR namespace_name T_NS_SEPARATOR '{' unprefixed_use_declarations '}'
+	|	T_NS_SEPARATOR namespace_name T_NS_SEPARATOR '{' unprefixed_use_declarations possible_comma '}'
 			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $2, $5); }
 ;
 
 mixed_group_use_declaration:
-		namespace_name T_NS_SEPARATOR '{' inline_use_declarations '}'
+		namespace_name T_NS_SEPARATOR '{' inline_use_declarations possible_comma '}'
 			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $1, $4);}
-	|	T_NS_SEPARATOR namespace_name T_NS_SEPARATOR '{' inline_use_declarations '}'
+	|	T_NS_SEPARATOR namespace_name T_NS_SEPARATOR '{' inline_use_declarations possible_comma '}'
 			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $2, $5); }
+;
+
+possible_comma:
+		/* empty */
+	|	','
 ;
 
 inline_use_declarations:


### PR DESCRIPTION
This is the implementation to allow trailing commas in grouped `use` lists which is the [only list syntax that passed](https://wiki.php.net/rfc/list-syntax-trailing-commas#grouped_namepaces) from the RFC.

![trailing-commas-all-the-things](https://cloud.githubusercontent.com/assets/578780/25247372/40a6bf2a-25d0-11e7-8592-33446e3cd7c4.jpg)