### PR TITLE
phar: Support DELETE, HEAD and PUT HTTP methods in Phar::webPhar

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -582,7 +582,18 @@ PHP_METHOD(Phar, webPhar)
 	}
 
 	/* retrieve requested file within phar */
-	if (!(SG(request_info).request_method && SG(request_info).request_uri && (!strcmp(SG(request_info).request_method, "GET") || !strcmp(SG(request_info).request_method, "POST")))) {
+	if (!(SG(request_info).request_method
+          && SG(request_info).request_uri
+          && (!strcmp(SG(request_info).request_method, "GET")
+           || !strcmp(SG(request_info).request_method, "POST")
+           || !strcmp(SG(request_info).request_method, "DELETE")
+           || !strcmp(SG(request_info).request_method, "HEAD")
+           || !strcmp(SG(request_info).request_method, "OPTIONS")
+           || !strcmp(SG(request_info).request_method, "PATCH")
+           || !strcmp(SG(request_info).request_method, "PUT")
+          )
+         )
+      ) {
 		return;
 	}
 


### PR DESCRIPTION
Up to now only GET and POST requests could be handled with Phar::webPhar(),
which is insufficient for today's REST APIs.
This patch expands the list of supported HTTP methods.

Resolves: https://bugs.php.net/bug.php?id=51918