### PR TITLE
Fix #49649 - Handle property visibility changes on unserialization

### DIFF
--- a/ext/standard/tests/serialize/bug49649.phpt
+++ b/ext/standard/tests/serialize/bug49649.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Bug #49649 (unserialize() doesn't handle changes in property visibility) - to public
+--FILE--
+<?php
+
+/**
+ *class Foo
+ *{
+ *	private $private = 1;
+ *	
+ *	protected $protected = 2;
+ *	
+ *	public $public = 3;
+ *	
+ *	public $notThere = 'old';
+ * }
+ *
+ * echo base64_encode(serialize(new Foo()));
+ *
+ * The class above represents the serialized, base64_encoded string below.
+*/
+$serialized = 'TzozOiJGb28iOjQ6e3M6MTI6IgBGb28AcHJpdmF0ZSI7aToxO3M6MTI6IgAqAHByb3RlY3RlZCI7aToyO3M6NjoicHVibGljIjtpOjM7czo4OiJub3RUaGVyZSI7czozOiJvbGQiO30';
+
+class Foo
+{
+	public $public = null;
+
+	public $protected = null;
+
+	public $private = null;
+}
+
+$class = unserialize(base64_decode($serialized));
+var_dump($class);
+--EXPECT--
+object(Foo)#1 (4) {
+  ["public"]=>
+  int(3)
+  ["protected"]=>
+  int(2)
+  ["private"]=>
+  int(1)
+  ["notThere"]=>
+  string(3) "old"
+}

--- a/ext/standard/tests/serialize/bug49649_1.phpt
+++ b/ext/standard/tests/serialize/bug49649_1.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Bug #49649 (unserialize() doesn't handle changes in property visibility) - to protected
+--FILE--
+<?php
+
+/**
+ *class Foo
+ *{
+ *	private $private = 1;
+ *	
+ *	protected $protected = 2;
+ *	
+ *	public $public = 3;
+ *	
+ *	public $notThere = 'old';
+ * }
+ *
+ * echo base64_encode(serialize(new Foo()));
+ *
+ * The class above represents the serialized, base64_encoded string below.
+*/
+$serialized = 'TzozOiJGb28iOjQ6e3M6MTI6IgBGb28AcHJpdmF0ZSI7aToxO3M6MTI6IgAqAHByb3RlY3RlZCI7aToyO3M6NjoicHVibGljIjtpOjM7czo4OiJub3RUaGVyZSI7czozOiJvbGQiO30';
+
+class Foo
+{
+	protected $public = null;
+
+	protected $protected = null;
+
+	protected $private = null;
+}
+
+$class = unserialize(base64_decode($serialized));
+var_dump($class);
+--EXPECT--
+object(Foo)#1 (4) {
+  ["public":protected]=>
+  int(3)
+  ["protected":protected]=>
+  int(2)
+  ["private":protected]=>
+  int(1)
+  ["notThere"]=>
+  string(3) "old"
+}

--- a/ext/standard/tests/serialize/bug49649_2.phpt
+++ b/ext/standard/tests/serialize/bug49649_2.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Bug #49649 (unserialize() doesn't handle changes in property visibility) - to private
+--FILE--
+<?php
+
+/**
+ *class Foo
+ *{
+ *	private $private = 1;
+ *	
+ *	protected $protected = 2;
+ *	
+ *	public $public = 3;
+ *	
+ *	public $notThere = 'old';
+ * }
+ *
+ * echo base64_encode(serialize(new Foo()));
+ *
+ * The class above represents the serialized, base64_encoded string below.
+*/
+$serialized = 'TzozOiJGb28iOjQ6e3M6MTI6IgBGb28AcHJpdmF0ZSI7aToxO3M6MTI6IgAqAHByb3RlY3RlZCI7aToyO3M6NjoicHVibGljIjtpOjM7czo4OiJub3RUaGVyZSI7czozOiJvbGQiO30';
+
+class Foo
+{
+	private $public = null;
+
+	private $protected = null;
+
+	private $private = null;
+}
+
+$class = unserialize(base64_decode($serialized));
+var_dump($class);
+--EXPECT--
+object(Foo)#1 (4) {
+  ["public":"Foo":private]=>
+  int(3)
+  ["protected":"Foo":private]=>
+  int(2)
+  ["private":"Foo":private]=>
+  int(1)
+  ["notThere"]=>
+  string(3) "old"
+}


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=49649

It shouldn't have any BC breaking effects. Any feedback on the implementation is welcome.