### PR TITLE
fix bug #73471 PHP freezes with AppendIterator

### DIFF
--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -3383,7 +3383,12 @@ SPL_METHOD(AppendIterator, append)
 	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "O", &it, zend_ce_iterator) == FAILURE) {
 		return;
 	}
-	spl_array_iterator_append(&intern->u.append.zarrayit, it);
+	if (intern->u.append.iterator->funcs->valid(intern->u.append.iterator) == SUCCESS) {
+		spl_array_iterator_append(&intern->u.append.zarrayit, it);
+		intern->u.append.iterator->funcs->move_forward(intern->u.append.iterator);
+	}else{
+		spl_array_iterator_append(&intern->u.append.zarrayit, it);
+	}
 
 	if (!intern->inner.iterator || spl_dual_it_valid(intern) != SUCCESS) {
 		if (intern->u.append.iterator->funcs->valid(intern->u.append.iterator) != SUCCESS) {

--- a/ext/spl/tests/bug73471.phpt
+++ b/ext/spl/tests/bug73471.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #73471 PHP freezes with AppendIterator
+--FILE--
+<?php
+
+$iterator = new \AppendIterator();
+$events = new \ArrayIterator([1,2,3,4,5]);
+$events2 = new \ArrayIterator(['a', 'b', 'c']);
+$iterator->append($events);
+foreach($events as $event){}
+$iterator->append($events2);
+?>
+===DONE===
+--EXPECT--	
+===DONE===


### PR DESCRIPTION
fix [bug #73471](https://bugs.php.net/bug.php?id=73471) PHP freezes with AppendIterator


the `spl_append_it_next_iterator` call inside `AppendIterator::append(Iterator it)` copy the current data of `intern->u.append.iterator` to `intern->inner.zobject` (see [here](https://github.com/php/php-src/blob/PHP-7.0/ext/spl/spl_iterators.c#L3337)), which leads to an infinite loop [here](https://github.com/php/php-src/blob/PHP-7.0/ext/spl/spl_iterators.c#L3394)