### PR TITLE
Optimize object construction and destruction

### DIFF
--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -36,17 +36,9 @@ ZEND_API void zend_object_std_init(zend_object *object, zend_class_entry *ce)
 	object->ce = ce;
 	object->properties = NULL;
 	zend_objects_store_put(object);
-	p = object->properties_table;
-	if (EXPECTED(ce->default_properties_count != 0)) {
-		end = p + ce->default_properties_count;
-		do {
-			ZVAL_UNDEF(p);
-			p++;
-		} while (p != end);
-	}
 	if (UNEXPECTED(ce->ce_flags & ZEND_ACC_USE_GUARDS)) {
 		GC_FLAGS(object) |= IS_OBJ_USE_GUARDS;
-		ZVAL_UNDEF(p);
+		ZVAL_UNDEF(object->properties_table + object->ce->default_properties_count);
 	}
 }
 
@@ -251,6 +243,16 @@ ZEND_API zend_object *zend_objects_clone_obj(zval *zobject)
 	 * overwritten one then it must itself be overwritten */
 	old_object = Z_OBJ_P(zobject);
 	new_object = zend_objects_new(old_object->ce);
+
+	/* zend_objects_clone_members() expect the properties to be initialized. */
+	if (new_object->ce->default_properties_count) {
+		zval *p = new_object->properties_table;
+		zval *end = p + new_object->ce->default_properties_count;
+		do {
+			ZVAL_UNDEF(p);
+			p++;
+		} while (p != end);
+	}
 
 	zend_objects_clone_members(new_object, old_object);
 

--- a/Zend/zend_objects_API.c
+++ b/Zend/zend_objects_API.c
@@ -152,8 +152,6 @@ ZEND_API void zend_objects_store_del(zend_object *object) /* {{{ */
 	if (EG(objects_store).object_buckets &&
 	    IS_OBJ_VALID(EG(objects_store).object_buckets[object->handle])) {
 		if (GC_REFCOUNT(object) == 0) {
-			int failure = 0;
-
 			if (!(GC_FLAGS(object) & IS_OBJ_DESTRUCTOR_CALLED)) {
 				GC_FLAGS(object) |= IS_OBJ_DESTRUCTOR_CALLED;
 
@@ -172,23 +170,15 @@ ZEND_API void zend_objects_store_del(zend_object *object) /* {{{ */
 				if (!(GC_FLAGS(object) & IS_OBJ_FREE_CALLED)) {
 					GC_FLAGS(object) |= IS_OBJ_FREE_CALLED;
 					if (object->handlers->free_obj) {
-						zend_try {
-							GC_REFCOUNT(object)++;
-							object->handlers->free_obj(object);
-							GC_REFCOUNT(object)--;
-						} zend_catch {
-							failure = 1;
-						} zend_end_try();
+						GC_REFCOUNT(object)++;
+						object->handlers->free_obj(object);
+						GC_REFCOUNT(object)--;
 					}
 				}
 				ptr = ((char*)object) - object->handlers->offset;
 				GC_REMOVE_FROM_BUFFER(object);
 				efree(ptr);
 				ZEND_OBJECTS_STORE_ADD_TO_FREE_LIST(handle);
-			}
-
-			if (failure) {
-				zend_bailout();
 			}
 		} else {
 			GC_REFCOUNT(object)--;

--- a/Zend/zend_objects_API.c
+++ b/Zend/zend_objects_API.c
@@ -159,11 +159,7 @@ ZEND_API void zend_objects_store_del(zend_object *object) /* {{{ */
 
 				if (object->handlers->dtor_obj) {
 					GC_REFCOUNT(object)++;
-					zend_try {
-						object->handlers->dtor_obj(object);
-					} zend_catch {
-						failure = 1;
-					} zend_end_try();
+					object->handlers->dtor_obj(object);
 					GC_REFCOUNT(object)--;
 				}
 			}


### PR DESCRIPTION
This implements two basic micro-optimization for object ctor/dtor:

 * Don't UNDEF properties in zend_object_std_init(). object_properties_init() will already initialize the properties to the default values, there is no need to set them to UNDEF first. This requires an adjustment in zend_objects_clone_obj(), which does not call object_properties_init() right now.
 * Don't use zend_try around dtor_obj() and free_obj() calls. Per my analysis this is safe, because:
   * For dtor_obj() a bailout will only leak the object (fine)
   * For free_obj() a bailout will leak the object (fine), not add it to the free list (thus leaking an object store bucket, also fine) and not remove it from the GC root buffer (as the GC explicitly checks for FREE_CALLED and invalid buckets, this is also fine).

For the benchmark

```php
class Test {
    public $a, $b, $c, $d;
}
$n = 30000000;
$t = microtime(true);
for ($i = 0; $i < $n; $i++) {
    $obj = new Test;
}
var_dump(microtime(true) - $t);
```

I'm seeing an improvement from 1.78s to 1.43s, which is a speedup of x1.25.