### PR TITLE
Ensure number_format() treats negative zero consistently

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -187,6 +187,7 @@ See also: https://wiki.php.net/rfc/deprecations_php_7_2
   . count() now raises a warning when an invalid parameter is passed.
     Only arrays and objects implementing the Countable interface should be passed.
   . pack() and unpack() now support float and double in both little and big endian.
+  . number_format() ensures zero values never contain a negative sign.
 
 - XML:
   . utf8_encode() and utf8_decode() have been moved to the Standard extension

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1143,6 +1143,11 @@ PHPAPI zend_string *_php_math_number_format_ex(double d, int dec, char *dec_poin
 		return tmpbuf;
 	}
 
+	/* Check if the number is no longer negative after rounding */
+	if (is_negative && d == 0) {
+		is_negative = 0;
+	}
+
 	/* find decimal point, if expected */
 	if (dec) {
 		dp = strpbrk(ZSTR_VAL(tmpbuf), ".,");

--- a/ext/standard/tests/math/number_format_negative_zero.phpt
+++ b/ext/standard/tests/math/number_format_negative_zero.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Prevent number_format from returning negative zero
+--FILE--
+<?php
+
+$number = -1.15E-15;
+
+var_dump($number);
+var_dump(number_format($number, 2));
+var_dump(number_format(-0.01, 2));
+
+?>
+--EXPECT--
+float(-1.15E-15)
+string(4) "0.00"
+string(5) "-0.01"


### PR DESCRIPTION
Following the acceptance vote of [the RFC](https://wiki.php.net/rfc/number_format_negative_zero) here's the implementation for making `number_format()` consistent when handling negative zero