### PR TITLE
Fixed #74529 - DateTime::diff seems to ignore $absolute = true

### DIFF
--- a/ext/date/lib/interval.c
+++ b/ext/date/lib/interval.c
@@ -25,7 +25,7 @@
 #include "timelib.h"
 #include <math.h>
 
-timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two)
+timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two, bool absolute)
 {
 	timelib_rel_time *rt;
 	timelib_time *swp;
@@ -33,7 +33,7 @@ timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two)
 	timelib_time one_backup, two_backup;
 
 	rt = timelib_rel_time_ctor();
-	rt->invert = 0;
+	rt->invert = absolute;
 	if (one->sse > two->sse) {
 		swp = two;
 		two = one;

--- a/ext/date/lib/timelib.h
+++ b/ext/date/lib/timelib.h
@@ -158,7 +158,7 @@ double timelib_ts_to_juliandate(timelib_sll ts);
 int timelib_astro_rise_set_altitude(timelib_time *time, double lon, double lat, double altit, int upper_limb, double *h_rise, double *h_set, timelib_sll *ts_rise, timelib_sll *ts_set, timelib_sll *ts_transit);
 
 /* from interval.c */
-timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two);
+timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two, bool absolute);
 timelib_time *timelib_add(timelib_time *t, timelib_rel_time *interval);
 timelib_time *timelib_sub(timelib_time *t, timelib_rel_time *interval);
 

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3696,7 +3696,7 @@ PHP_FUNCTION(date_diff)
 
 	php_date_instantiate(date_ce_interval, return_value);
 	interval = Z_PHPINTERVAL_P(return_value);
-	interval->diff = timelib_diff(dateobj1->time, dateobj2->time);
+	interval->diff = timelib_diff(dateobj1->time, dateobj2->time, absolute);
 	if (absolute) {
 		interval->diff->invert = 0;
 	}
@@ -4053,7 +4053,7 @@ static int date_interval_initialize(timelib_rel_time **rt, /*const*/ char *forma
 			if(b && e) {
 				timelib_update_ts(b, NULL);
 				timelib_update_ts(e, NULL);
-				*rt = timelib_diff(b, e);
+				*rt = timelib_diff(b, e, false);
 				retval = SUCCESS;
 			} else {
 				php_error_docref(NULL, E_WARNING, "Failed to parse interval (%s)", format);

--- a/ext/date/tests/bug74529.phpt
+++ b/ext/date/tests/bug74529.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #74529 DateTime::diff seems to ignore $absolute = true
+--FILE--
+<?php
+
+date_default_timezone_set('Europe/Amsterdam');
+
+$date1 = date_create("2014-11-01 00:00:00");
+$date2 = date_create("2017-05-01 04:00:00");
+
+$diff1 = $date2->diff($date1, true);
+$diff2 = $date1->diff($date2, true);
+
+echo sprintf('%s %s %s %s', $diff1->m, $diff1->d, $diff1->h, $diff1->i) . "\n";
+echo sprintf('%s %s %s %s', $diff2->m, $diff2->d, $diff2->h, $diff2->i);
+?>
+--EXPECT--
+6 0 4 0
+6 0 4 0


### PR DESCRIPTION
Fixed https://bugs.php.net/bug.php?id=74529