### PR TITLE
use c flag on shmop_open to allow multiple runs on linux

### DIFF
--- a/ext/shmop/tests/001.phpt
+++ b/ext/shmop/tests/001.phpt
@@ -13,7 +13,7 @@ shmop extension test
 	$write_d2 = "test #2 append data to shared memory segment";
 
 	echo "shm open for create: ";
-	$shm_id = shmop_open($hex_shm_id, "n", 0644, 1024);   
+	$shm_id = shmop_open($hex_shm_id, "c", 0644, 1024);
 	if (!$shm_id) {
 		die("failed\n");
 	} else {


### PR DESCRIPTION
I think you need to use the 'c' flag on the call to shmop_open().
Otherwise, this test will fail the next time it's run on a linux system.
The 'c' flag will reopen an existing shared memory block if it exists.