### PR TITLE
variation of icu libraries causes failure

### DIFF
--- a/ext/intl/tests/timezone_getDisplayName_variant3-49+.phpt
+++ b/ext/intl/tests/timezone_getDisplayName_variant3-49+.phpt
@@ -19,8 +19,8 @@ var_dump($lsb->getDisplayName(false, IntlTimeZone::DISPLAY_LONG, 'pt_PT'));
 
 ?>
 ==DONE==
---EXPECT--
+--EXPECTF--
 string(30) "Western European Standard Time"
 string(30) "Western European Standard Time"
-string(32) "Hora Padrão da Europa Ocidental"
+string(32) "Hora %cadrão da Europa Ocidental"
 ==DONE==


### PR DESCRIPTION
This test is sensitive to the version of the unicode libraries used.
There is a 1-character difference in the pt_PT name

string(32)   "Hora padrão da Europa Ocidental"
string(32)   "Hora Padrão da Europa Ocidental"
-----------------^

This change relaxes the comparison slightly.
Otherwise, this test fails on Ubuntu 16.04 and
Fedora 25 when imported into the HHVM environment.
