### PR TITLE
By default any TLS method should be used, not TLSv1.0 only

### DIFF
--- a/ext/openssl/tests/tls_wrapper.phpt
+++ b/ext/openssl/tests/tls_wrapper.phpt
@@ -1,0 +1,59 @@
+--TEST--
+tls stream wrapper
+--SKIPIF--
+<?php
+if (!extension_loaded("openssl")) die("skip openssl not loaded");
+if (!function_exists("proc_open")) die("skip no proc_open");
+--FILE--
+<?php
+$serverCode = <<<'CODE'
+    $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+    $ctx = stream_context_create(['ssl' => [
+        'local_cert' => __DIR__ . '/streams_crypto_method.pem',
+    ]]);
+
+    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
+    phpt_notify();
+
+    for ($i=0; $i < 6; $i++) {
+        @stream_socket_accept($server, 3);
+    }
+CODE;
+
+$clientCode = <<<'CODE'
+    $flags = STREAM_CLIENT_CONNECT;
+    $ctx = stream_context_create(['ssl' => [
+        'verify_peer' => false,
+        'verify_peer_name' => false,
+    ]]);
+
+    phpt_wait();
+
+    $client = stream_socket_client("tlsv1.0://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    var_dump($client);
+
+    $client = @stream_socket_client("sslv3://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    var_dump($client);
+
+    $client = @stream_socket_client("tlsv1.1://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    var_dump($client);
+
+    $client = @stream_socket_client("tlsv1.2://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    var_dump($client);
+
+    $client = @stream_socket_client("ssl://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    var_dump($client);
+
+    $client = @stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    var_dump($client);
+CODE;
+
+include 'ServerClientTestCase.inc';
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+--EXPECTF--
+resource(%d) of type (stream)
+bool(false)
+resource(%d) of type (stream)
+resource(%d) of type (stream)
+resource(%d) of type (stream)
+resource(%d) of type (stream)

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2573,8 +2573,7 @@ php_stream *php_openssl_ssl_socket_factory(const char *proto, size_t protolen,
 #endif
 	} else if (strncmp(proto, "tls", protolen) == 0) {
 		sslsock->enable_on_connect = 1;
-		/* STREAM_CRYPTO_METHOD_TLS_CLIENT is just TLSv1 for BC reasons with pre-5.6 */
-		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_SSLv23_CLIENT);
+		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_TLS_ANY_CLIENT);
 	} else if (strncmp(proto, "tlsv1.0", protolen) == 0) {
 		sslsock->enable_on_connect = 1;
 		sslsock->method = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2573,7 +2573,8 @@ php_stream *php_openssl_ssl_socket_factory(const char *proto, size_t protolen,
 #endif
 	} else if (strncmp(proto, "tls", protolen) == 0) {
 		sslsock->enable_on_connect = 1;
-		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+		/* STREAM_CRYPTO_METHOD_TLS_CLIENT is just TLSv1 for BC reasons with pre-5.6 */
+		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_SSLv23_CLIENT);
 	} else if (strncmp(proto, "tlsv1.0", protolen) == 0) {
 		sslsock->enable_on_connect = 1;
 		sslsock->method = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2557,7 +2557,7 @@ php_stream *php_openssl_ssl_socket_factory(const char *proto, size_t protolen,
 
 	if (strncmp(proto, "ssl", protolen) == 0) {
 		sslsock->enable_on_connect = 1;
-		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_ANY_CLIENT);
+		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_TLS_ANY_CLIENT);
 	} else if (strncmp(proto, "sslv2", protolen) == 0) {
 		php_error_docref(NULL, E_WARNING, "SSLv2 unavailable in this PHP version");
 		php_stream_close(stream);

--- a/main/streams/php_stream_transport.h
+++ b/main/streams/php_stream_transport.h
@@ -172,8 +172,8 @@ typedef enum {
 	STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT = (1 << 3 | 1),
 	STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT = (1 << 4 | 1),
 	STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT = (1 << 5 | 1),
-	/* tls now equates only to the specific TLSv1 method for BC with pre-5.6 */
-	STREAM_CRYPTO_METHOD_TLS_CLIENT = (1 << 3 | 1),
+	/* TLS equates to TLS_ANY as of PHP 7.2 */
+	STREAM_CRYPTO_METHOD_TLS_CLIENT = ((1 << 3) | (1 << 4) | (1 << 5) | 1),
 	STREAM_CRYPTO_METHOD_TLS_ANY_CLIENT = ((1 << 3) | (1 << 4) | (1 << 5) | 1),
 	STREAM_CRYPTO_METHOD_ANY_CLIENT = ((1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5) | 1),
 	STREAM_CRYPTO_METHOD_SSLv2_SERVER = (1 << 1),
@@ -183,8 +183,8 @@ typedef enum {
 	STREAM_CRYPTO_METHOD_TLSv1_0_SERVER = (1 << 3),
 	STREAM_CRYPTO_METHOD_TLSv1_1_SERVER = (1 << 4),
 	STREAM_CRYPTO_METHOD_TLSv1_2_SERVER = (1 << 5),
-	/* tls equates only to the specific TLSv1 method for BC with pre-5.6 */
-	STREAM_CRYPTO_METHOD_TLS_SERVER = (1 << 3),
+	/* TLS equates to TLS_ANY as of PHP 7.2 */
+	STREAM_CRYPTO_METHOD_TLS_SERVER = ((1 << 3) | (1 << 4) | (1 << 5)),
 	STREAM_CRYPTO_METHOD_TLS_ANY_SERVER = ((1 << 3) | (1 << 4) | (1 << 5)),
 	STREAM_CRYPTO_METHOD_ANY_SERVER = ((1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5))
 } php_stream_xport_crypt_method_t;


### PR DESCRIPTION
Not only does this default harm security as it disables the newer standard, it is also unexpected.

See also https://externals.io/thread/864.

I think this fix should also be backported to any supported version as it harms security.