### PR TITLE
Implement writing to BLOBs in SQLite3

### DIFF
--- a/ext/sqlite3/tests/sqlite3_30_blobopen.phpt
+++ b/ext/sqlite3/tests/sqlite3_30_blobopen.phpt
@@ -27,6 +27,16 @@ echo "Stream Contents\n";
 var_dump(stream_get_contents($stream));
 echo "Closing Stream\n";
 var_dump(fclose($stream));
+echo "Opening stream in write mode\n";
+$stream = $db->openBlob('test', 'data', 1, 'main', 1);
+var_dump($stream);
+echo "Writing to blob\n";
+var_dump(fwrite($stream, 'ABCD'));
+echo "Stream Contents\n";
+fseek($stream, 0);
+var_dump(stream_get_contents($stream));
+echo "Closing Stream\n";
+var_dump(fclose($stream));
 echo "Closing database\n";
 var_dump($db->close());
 echo "Done\n";
@@ -43,6 +53,14 @@ bool(true)
 resource(%d) of type (stream)
 Stream Contents
 string(9) "TEST TEST"
+Closing Stream
+bool(true)
+Opening stream in write mode
+resource(%d) of type (stream)
+Writing to blob
+int(4)
+Stream Contents
+string(9) "ABCD TEST"
 Closing Stream
 bool(true)
 Closing database

--- a/ext/sqlite3/tests/sqlite3_30_blobopen.phpt
+++ b/ext/sqlite3/tests/sqlite3_30_blobopen.phpt
@@ -25,16 +25,20 @@ $stream = $db->openBlob('test', 'data', 1);
 var_dump($stream);
 echo "Stream Contents\n";
 var_dump(stream_get_contents($stream));
+echo "Writing to read-only stream\n";
+var_dump(fwrite($stream, 'ABCD'));
 echo "Closing Stream\n";
 var_dump(fclose($stream));
 echo "Opening stream in write mode\n";
-$stream = $db->openBlob('test', 'data', 1, 'main', 1);
+$stream = $db->openBlob('test', 'data', 1, 'main', SQLITE3_OPEN_READWRITE);
 var_dump($stream);
 echo "Writing to blob\n";
 var_dump(fwrite($stream, 'ABCD'));
 echo "Stream Contents\n";
 fseek($stream, 0);
 var_dump(stream_get_contents($stream));
+echo "Expanding blob size\n";
+var_dump(fwrite($stream, 'ABCD ABCD ABCD'));
 echo "Closing Stream\n";
 var_dump(fclose($stream));
 echo "Closing database\n";
@@ -53,6 +57,10 @@ bool(true)
 resource(%d) of type (stream)
 Stream Contents
 string(9) "TEST TEST"
+Writing to read-only stream
+
+Warning: fwrite(): Can't write to blob stream: is open as read only in %s on line %d
+int(0)
 Closing Stream
 bool(true)
 Opening stream in write mode
@@ -61,6 +69,10 @@ Writing to blob
 int(4)
 Stream Contents
 string(9) "ABCD TEST"
+Expanding blob size
+
+Warning: fwrite(): It is not possible to increase the size of a BLOB in %s on line %d
+int(0)
 Closing Stream
 bool(true)
 Closing database


### PR DESCRIPTION
This patch implements writing to BLOB streams.

Due to limitations in SQLite API itself, it's not possible to change the stream size though. So you can only replace content.

It is recommended to use the SQLite zeroblob(n) function to initialize a blob to the right size before writing to it.