### PR TITLE
Fix #74607 - Don't check for bi-directional compatibility in traits

### DIFF
--- a/Zend/tests/traits/bug60217b.phpt
+++ b/Zend/tests/traits/bug60217b.phpt
@@ -23,4 +23,4 @@ $o = new CBroken;
 $o->foo(1);
 
 --EXPECTF--
-Fatal error: Declaration of TBroken2::foo($a, $b = 0) must be compatible with TBroken1::foo($a) in %s on line %d
+Fatal error: Declaration of TBroken1::foo($a) must be compatible with TBroken2::foo($a, $b = 0) in %s

--- a/Zend/tests/traits/bug74607.phpt
+++ b/Zend/tests/traits/bug74607.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #74607 (Traits enforce different inheritance rules - return types)
+--FILE--
+<?php
+
+abstract class L1{ 
+abstract function m3($x);
+} 
+
+trait L2t{ 
+function m3($x): int{}
+} 
+
+class L2 extends L1{ 
+use L2t; 
+}
+
+echo "DONE";
+
+?>
+--EXPECT--
+DONE

--- a/Zend/tests/traits/bug74607a.phpt
+++ b/Zend/tests/traits/bug74607a.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #74607 (Traits enforce different inheritance rules - number of required parameters)
+--FILE--
+<?php
+
+abstract class L1{ 
+abstract function m3($x);
+} 
+
+trait L2t{ 
+function m3($x, $y = 0){}
+} 
+
+class L2 extends L1{ 
+use L2t; 
+}
+
+echo "DONE";
+
+?>
+--EXPECT--
+DONE

--- a/Zend/tests/traits/bugs/abstract-methods05.phpt
+++ b/Zend/tests/traits/bugs/abstract-methods05.phpt
@@ -22,4 +22,4 @@ class TraitsTest1 {
 
 ?>
 --EXPECTF--	
-Fatal error: Declaration of THelloA::hello($a) must be compatible with THelloB::hello() in %s on line %d
+Fatal error: Declaration of THelloB::hello() must be compatible with THelloA::hello($a) in %s on line %d

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1056,7 +1056,6 @@ static zend_bool zend_traits_method_compatibility_check(zend_function *fn, zend_
 	uint32_t other_flags = other_fn->common.scope->ce_flags;
 
 	return zend_do_perform_implementation_check(fn, other_fn)
-		&& ((other_fn->common.scope->ce_flags & ZEND_ACC_INTERFACE) || zend_do_perform_implementation_check(other_fn, fn))
 		&& ((fn_flags & (ZEND_ACC_FINAL|ZEND_ACC_STATIC)) ==
 		    (other_flags & (ZEND_ACC_FINAL|ZEND_ACC_STATIC))); /* equal final and static qualifier */
 }
@@ -1126,12 +1125,13 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, zend_s
 								ZSTR_VAL(zend_get_function_declaration(fn)),
 								ZSTR_VAL(zend_get_function_declaration(existing_fn)));
 						}
-					} else if (fn->common.fn_flags & ZEND_ACC_ABSTRACT) {
+					}
+					if (fn->common.fn_flags & ZEND_ACC_ABSTRACT) {
 						/* Make sure the abstract declaration is compatible with previous declaration */
 						if (UNEXPECTED(!zend_traits_method_compatibility_check(existing_fn, fn))) {
 							zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
-								ZSTR_VAL(zend_get_function_declaration(fn)),
-								ZSTR_VAL(zend_get_function_declaration(existing_fn)));
+								ZSTR_VAL(zend_get_function_declaration(existing_fn)),
+								ZSTR_VAL(zend_get_function_declaration(fn)));
 						}
 						return;
 					}
@@ -1154,8 +1154,8 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, zend_s
 			/* Make sure the abstract declaration is compatible with previous declaration */
 			if (UNEXPECTED(!zend_traits_method_compatibility_check(existing_fn, fn))) {
 				zend_error_noreturn(E_COMPILE_ERROR, "Declaration of %s must be compatible with %s",
-					ZSTR_VAL(zend_get_function_declaration(fn)),
-					ZSTR_VAL(zend_get_function_declaration(existing_fn)));
+					ZSTR_VAL(zend_get_function_declaration(existing_fn)),
+					ZSTR_VAL(zend_get_function_declaration(fn)));
 			}
 			return;
 		} else if (UNEXPECTED(existing_fn->common.scope->ce_flags & ZEND_ACC_TRAIT)) {


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=74607

Bi-directional checks are kept in case two abstract methods are being added. Additionally, some error messages now show the proper direction of the compatibility mismatch.

Given that this lifts a current restriction, no BC breaks should be introduced.