### PR TITLE
[RFC] Allow overriding abstract methods

### DIFF
--- a/Zend/tests/abstract_inheritance_001.phpt
+++ b/Zend/tests/abstract_inheritance_001.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Allow abstract function override
+--FILE--
+<?php
+
+abstract class A           { abstract function bar($x); }
+abstract class B extends A { abstract function bar($x); }
+
+echo "DONE";
+?>
+--EXPECT--	
+DONE

--- a/Zend/tests/abstract_inheritance_002.phpt
+++ b/Zend/tests/abstract_inheritance_002.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Allow abstract function override
+--FILE--
+<?php
+
+abstract class A           { abstract function bar($x); }
+abstract class B extends A { abstract function bar($x, $y = 0); }
+
+echo "DONE";
+?>
+--EXPECT--	
+DONE

--- a/Zend/tests/abstract_inheritance_003.phpt
+++ b/Zend/tests/abstract_inheritance_003.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Allow abstract function override
+--FILE--
+<?php
+
+abstract class A           { abstract function bar($x, $y = 0); }
+abstract class B extends A { abstract function bar($x); }
+
+echo "DONE";
+?>
+--EXPECTF--	
+Fatal error: Declaration of B::bar($x) must be compatible with A::bar($x, $y = 0) in %s

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -551,16 +551,6 @@ static void do_inheritance_check_on_method(zend_function *child, zend_function *
 	uint32_t child_flags;
 	uint32_t parent_flags = parent->common.fn_flags;
 
-	if ((parent->common.scope->ce_flags & ZEND_ACC_INTERFACE) == 0
-		&& parent->common.fn_flags & ZEND_ACC_ABSTRACT
-		&& parent->common.scope != (child->common.prototype ? child->common.prototype->common.scope : child->common.scope)
-		&& child->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_IMPLEMENTED_ABSTRACT)) {
-		zend_error_noreturn(E_COMPILE_ERROR, "Can't inherit abstract function %s::%s() (previously declared abstract in %s)",
-			ZSTR_VAL(parent->common.scope->name),
-			ZSTR_VAL(child->common.function_name),
-			child->common.prototype ? ZSTR_VAL(child->common.prototype->common.scope->name) : ZSTR_VAL(child->common.scope->name));
-	}
-
 	if (UNEXPECTED(parent_flags & ZEND_ACC_FINAL)) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot override final method %s::%s()", ZEND_FN_SCOPE_NAME(parent), ZSTR_VAL(child->common.function_name));
 	}


### PR DESCRIPTION
This PR implements the RFC: https://wiki.php.net/rfc/allow-abstract-function-override

It also closes [#63384](https://bugs.php.net/bug.php?id=63384)