### PR TITLE
ext/ldap: Allow default host from ldap.conf to work.

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -366,7 +366,7 @@ PHP_FUNCTION(ldap_connect)
 	{
 		int rc = LDAP_SUCCESS;
 		char	*url = host;
-		if (!ldap_is_ldap_url(url)) {
+		if (url && !ldap_is_ldap_url(url)) {
 			int	urllen = hostlen + sizeof( "ldap://:65535" );
 
 			if (port <= 0 || port > 65535) {
@@ -376,7 +376,7 @@ PHP_FUNCTION(ldap_connect)
 			}
 
 			url = emalloc(urllen);
-			snprintf( url, urllen, "ldap://%s:%ld", host ? host : "", port );
+			snprintf( url, urllen, "ldap://%s:%ld", host, port );
 		}
 
 #ifdef LDAP_API_FEATURE_X_OPENLDAP

--- a/ext/ldap/tests/ldap_connect_ldap_conf.phpt
+++ b/ext/ldap/tests/ldap_connect_ldap_conf.phpt
@@ -1,0 +1,26 @@
+--TEST--
+ldap_connect() - Connection using default host from openldap's ldap.conf
+--CREDITS--
+David Caldwell <david@galvanix.com>
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+ob_start();
+phpinfo();
+if (!preg_match("/vendor name => openldap/i", ob_get_clean()))
+    die("skip not openldap");
+?>
+--FILE--
+<?php
+$conf=tempnam("/tmp","ldap.conf");
+file_put_contents($conf, "uri ldaps://example.com:3141/");
+putenv("LDAPCONF=$conf");
+$link = ldap_connect();
+ldap_get_option($link, LDAP_OPT_HOST_NAME, $host);
+var_dump($host);
+unlink($conf);
+?>
+===DONE===
+--EXPECTF--
+string(16) "example.com:3141"
+===DONE===


### PR DESCRIPTION
This fixes an regression introduced in e7af0fe1eb89e40671e86a588aa1b78607b85461. Previously, calling `ldap_connect()` with no parameters would pass `NULL` to `ldap_init()`, which causes it to use the default host specified in `/etc/ldap/ldap.conf` (on Ubuntu).

When the code changed to use `ldap_initialize()`, it initialized a uri, even if there were no parameters passed to `ldap_connect()`. Because of this, there's no way to pass a `NULL` into `ldap_initialize()`, making it impossible to use the default uri from ldap.conf.

This commit bypasses the uri creation when there is no host argument, passing on a `NULL` to `ldap_initialize()` which restores the old PHP 5.5 behavior.