### PR TITLE
Added test for imagecopymergegray(), added color check to test for imagecopymerge()

### DIFF
--- a/ext/gd/tests/imagecopymerge_basic.phpt
+++ b/ext/gd/tests/imagecopymerge_basic.phpt
@@ -3,6 +3,9 @@ Testing imagecopymerge() of GD library
 --CREDITS--
 Cleston Viel Vieira de Sousa <cleston [dot] vs [at] gmail [dot] com>
 #testfest PHPSP on 2009-06-20
+
+Updated by Sean Fraaser <frasmage [at] gmail [dot] com>
+PHP[tek] 2017
 --SKIPIF--
 <?php 
 if (!extension_loaded("gd")) die("skip GD not present");
@@ -26,6 +29,6 @@ $rgb = imagecolorsforindex($des, $color);
 echo $rgb['red'], ", ", $rgb['green'], ", ", $rgb['blue'], "\n";
 
 ?>
---EXPECTF--
+--EXPECT--
 bool(true)
 203, 203, 241

--- a/ext/gd/tests/imagecopymergegray_basic.phpt
+++ b/ext/gd/tests/imagecopymergegray_basic.phpt
@@ -2,7 +2,7 @@
 Testing imagecopymergegray() of GD library
 --CREDITS--
 Sean Fraser <frasmage [at] gmail [dot] com>
-# PHP[tek] 2017
+PHP[tek] 2017
 --SKIPIF--
 <?php 
 if (!extension_loaded("gd")) die("skip GD not present");

--- a/ext/gd/tests/imagecopymergegray_basic.phpt
+++ b/ext/gd/tests/imagecopymergegray_basic.phpt
@@ -1,8 +1,8 @@
 --TEST--
-Testing imagecopymerge() of GD library
+Testing imagecopymergegray() of GD library
 --CREDITS--
-Cleston Viel Vieira de Sousa <cleston [dot] vs [at] gmail [dot] com>
-#testfest PHPSP on 2009-06-20
+Sean Fraser <frasmage [at] gmail [dot] com>
+# PHP[tek] 2017
 --SKIPIF--
 <?php 
 if (!extension_loaded("gd")) die("skip GD not present");
@@ -14,18 +14,18 @@ $des = imagecreate(120, 120);
 $src = imagecreate(100, 100);
 
 $color_des = imagecolorallocate($des, 50, 50, 200);
-$color_src = imagecolorallocate($src, 255, 255, 255);
+$color_src = imagecolorallocate($src, 255, 255, 0);
 
 imagefill($des, 0, 0, $color_des);
 imagefill($src, 0, 0, $color_src);
 
-var_dump(imagecopymerge($des, $src, 20, 20, 0, 0, 50, 50, 75));
+var_dump(imagecopymergegray($des, $src, 20, 20, 0, 0, 50, 50, 75));
 
 $color = imagecolorat($des, 30, 30);
 $rgb = imagecolorsforindex($des, $color);
 echo $rgb['red'], ", ", $rgb['green'], ", ", $rgb['blue'], "\n";
 
 ?>
---EXPECTF--
+--EXPECT--
 bool(true)
-203, 203, 241
+208, 208, 16


### PR DESCRIPTION
Adding test for uncovered function `imagecopymergegray()`.
Adding additional assertion to existing test for `imagecopymerge()` to verify that color merges as expected. Removed function calls that were unnecessary for the test.