### PR TITLE
Add basic test for posix_setegid function

### DIFF
--- a/ext/posix/tests/posix_setegid_basic.phpt
+++ b/ext/posix/tests/posix_setegid_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test function posix_setegid() by calling it with its expected arguments
+--SKIPIF--
+<?php 
+    if(!extension_loaded("posix")) die("skip - POSIX extension not loaded"); 
+?>
+--FILE--
+<?php
+var_dump(posix_setegid(posix_getegid()));
+?>
+--EXPECTF--
+bool(true)


### PR DESCRIPTION
:tada: Added basic test for [posix_setegid](http://php.net/manual/en/function.posix-setegid.php) :sunglasses: 

This wasn't covered in [gcov test coverage report for posix.c](http://gcov.php.net/PHP_7_1/lcov_html/ext/posix/posix.c.gcov.php)

![gcov coverage](https://github.com/shaikhul/screenshots/raw/master/posix_setegid_coverage.png)

Thanks @SammyK for your inspiring presentation at [#phptek 2017](https://joind.in/event/phptek-2017/writing-tests-for-php-source) :clap: :clap: :clap: 