### PR TITLE
Revert "Revert fix for bug #55407"

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -167,7 +167,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_date_create_from_format, 0, 0, 2)
 	ZEND_ARG_INFO(0, format)
 	ZEND_ARG_INFO(0, time)
-	ZEND_ARG_INFO(0, object)
+	ZEND_ARG_OBJ_INFO(0, object, DateTimeZone, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_date_parse, 0, 0, 1)

--- a/ext/date/tests/bug55407.phpt
+++ b/ext/date/tests/bug55407.phpt
@@ -6,7 +6,7 @@ error_reporting=-1
 <?php namespace melt\core;
 
 class DateTime extends \DateTime {
-    public static function createFromFormat($format, $time, DateTimeZone $timezone = null) {
+    public static function createFromFormat($format, $time, \DateTimeZone $timezone = null) {
         return new DateTime(parent::createFromFormat($format, $time, $timezone));
     }
 }

--- a/ext/date/tests/bug55407.phpt
+++ b/ext/date/tests/bug55407.phpt
@@ -2,8 +2,6 @@
 Bug #55407 (Impossible to prototype DateTime::createFromFormat)
 --INI--
 error_reporting=-1
---XFAIL--
-Bug #55407
 --FILE--
 <?php namespace melt\core;
 


### PR DESCRIPTION
This reverts commit b148c50f4864684aa9a6c6483cc309a7f2badbb5 and reintroduces the fix for bug #55407.

With https://wiki.php.net/rfc/parameter-no-type-variance being implemented now, it's no longer a BC break.