### PR TITLE
[WIN] Warning Free Code: Select

### DIFF
--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -36,7 +36,7 @@
 static int
 mysqlnd_set_sock_no_delay(php_stream * stream)
 {
-	int socketd = ((php_netstream_data_t*)stream->abstract)->socket;
+	php_socket_t socketd = ((php_netstream_data_t*)stream->abstract)->socket;
 	int ret = SUCCESS;
 	int flag = 1;
 	int result = setsockopt(socketd, IPPROTO_TCP,  TCP_NODELAY, (char *) &flag, sizeof(int));
@@ -56,7 +56,7 @@ mysqlnd_set_sock_no_delay(php_stream * stream)
 static int
 mysqlnd_set_sock_keepalive(php_stream * stream)
 {
-	int socketd = ((php_netstream_data_t*)stream->abstract)->socket;
+	php_socket_t socketd = ((php_netstream_data_t*)stream->abstract)->socket;
 	int ret = SUCCESS;
 	int flag = 1;
 	int result = setsockopt(socketd, SOL_SOCKET, SO_KEEPALIVE, (char *) &flag, sizeof(int));

--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -36,7 +36,7 @@
 static int
 mysqlnd_set_sock_no_delay(php_stream * stream)
 {
-	php_socket_t socketd = ((php_netstream_data_t*)stream->abstract)->socket;
+	int socketd = ((php_netstream_data_t*)stream->abstract)->socket;
 	int ret = SUCCESS;
 	int flag = 1;
 	int result = setsockopt(socketd, IPPROTO_TCP,  TCP_NODELAY, (char *) &flag, sizeof(int));
@@ -56,7 +56,7 @@ mysqlnd_set_sock_no_delay(php_stream * stream)
 static int
 mysqlnd_set_sock_keepalive(php_stream * stream)
 {
-	php_socket_t socketd = ((php_netstream_data_t*)stream->abstract)->socket;
+	int socketd = ((php_netstream_data_t*)stream->abstract)->socket;
 	int ret = SUCCESS;
 	int flag = 1;
 	int result = setsockopt(socketd, SOL_SOCKET, SO_KEEPALIVE, (char *) &flag, sizeof(int));

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -248,7 +248,7 @@ static void print_extensions(void) /* {{{ */
 #define STDERR_FILENO 2
 #endif
 
-static inline int sapi_cli_select(int fd)
+static inline int sapi_cli_select(php_socket_t fd)
 {
 	fd_set wfd, dfd;
 	struct timeval tv;

--- a/win32/select.c
+++ b/win32/select.c
@@ -34,17 +34,21 @@
  * - Calling this with NULL sets as a portable way to sleep with sub-second
  *   accuracy is not supported.
  * */
-PHPAPI int php_select(SOCKET max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv)
+PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv)
 {
 	ULONGLONG ms_total, limit;
 	HANDLE handles[MAXIMUM_WAIT_OBJECTS];
-	int handle_slot_to_fd[MAXIMUM_WAIT_OBJECTS];
-	int n_handles = 0, i;
+	php_socket_t handle_slot_to_fd[MAXIMUM_WAIT_OBJECTS];
+	php_socket_t n_handles = 0, i;
 	fd_set sock_read, sock_write, sock_except;
 	fd_set aread, awrite, aexcept;
-	int sock_max_fd = -1;
+	php_socket_t sock_max_fd = -1;
 	struct timeval tvslice;
 	int retcode;
+
+	if (max_fd < 0) {
+		return FAILURE;
+	}
 
 #define SAFE_FD_ISSET(fd, set)	(set != NULL && FD_ISSET(fd, set))
 
@@ -136,13 +140,13 @@ PHPAPI int php_select(SOCKET max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, s
 				for (i = 0; i < n_handles; i++) {
 					if (WAIT_OBJECT_0 == WaitForSingleObject(handles[i], 0)) {
 						if (SAFE_FD_ISSET(handle_slot_to_fd[i], rfds)) {
-							FD_SET((uint32_t)handle_slot_to_fd[i], &aread);
+							FD_SET((php_socket_t) handle_slot_to_fd[i], &aread);
 						}
 						if (SAFE_FD_ISSET(handle_slot_to_fd[i], wfds)) {
-							FD_SET((uint32_t)handle_slot_to_fd[i], &awrite);
+							FD_SET((php_socket_t) handle_slot_to_fd[i], &awrite);
 						}
 						if (SAFE_FD_ISSET(handle_slot_to_fd[i], efds)) {
-							FD_SET((uint32_t)handle_slot_to_fd[i], &aexcept);
+							FD_SET((php_socket_t) handle_slot_to_fd[i], &aexcept);
 						}
 						retcode++;
 					}

--- a/win32/select.c
+++ b/win32/select.c
@@ -34,7 +34,7 @@
  * - Calling this with NULL sets as a portable way to sleep with sub-second
  *   accuracy is not supported.
  * */
-PHPAPI int php_select(SOCKET max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv)
+PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv)
 {
 	ULONGLONG ms_total, limit;
 	HANDLE handles[MAXIMUM_WAIT_OBJECTS];

--- a/win32/select.c
+++ b/win32/select.c
@@ -87,7 +87,7 @@ PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *e
 
 	if (n_handles == 0) {
 		/* plain sockets only - let winsock handle the whole thing */
-		return select(NULL, rfds, wfds, efds, tv);
+		return select(0, rfds, wfds, efds, tv);
 	}
 
 	/* mixture of handles and sockets; lets multiplex between
@@ -111,7 +111,7 @@ PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *e
 			tvslice.tv_sec = 0;
 			tvslice.tv_usec = 100000;
 
-			retcode = select(NULL, &aread, &awrite, &aexcept, &tvslice);
+			retcode = select(0, &aread, &awrite, &aexcept, &tvslice);
 		}
 		if (n_handles > 0) {
 			/* check handles */

--- a/win32/select.c
+++ b/win32/select.c
@@ -34,7 +34,7 @@
  * - Calling this with NULL sets as a portable way to sleep with sub-second
  *   accuracy is not supported.
  * */
-PHPAPI int php_select(int max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv)
+PHPAPI int php_select(SOCKET max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv)
 {
 	ULONGLONG ms_total, limit;
 	HANDLE handles[MAXIMUM_WAIT_OBJECTS];

--- a/win32/select.c
+++ b/win32/select.c
@@ -87,7 +87,7 @@ PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *e
 
 	if (n_handles == 0) {
 		/* plain sockets only - let winsock handle the whole thing */
-		return select(max_fd, rfds, wfds, efds, tv);
+		return select(NULL, rfds, wfds, efds, tv);
 	}
 
 	/* mixture of handles and sockets; lets multiplex between
@@ -111,7 +111,7 @@ PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *e
 			tvslice.tv_sec = 0;
 			tvslice.tv_usec = 100000;
 
-			retcode = select(sock_max_fd+1, &aread, &awrite, &aexcept, &tvslice);
+			retcode = select(NULL, &aread, &awrite, &aexcept, &tvslice);
 		}
 		if (n_handles > 0) {
 			/* check handles */

--- a/win32/select.c
+++ b/win32/select.c
@@ -61,7 +61,7 @@ PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *e
 	FD_ZERO(&sock_except);
 
 	/* build an array of handles for non-sockets */
-	for (i = 0; i < max_fd; i++) {
+	for (i = 0; i < INT_MAX && i < max_fd; i++) {
 		if (SAFE_FD_ISSET(i, rfds) || SAFE_FD_ISSET(i, wfds) || SAFE_FD_ISSET(i, efds)) {
 			handles[n_handles] = (HANDLE)(zend_uintptr_t)_get_osfhandle(i);
 			if (handles[n_handles] == INVALID_HANDLE_VALUE) {

--- a/win32/select.c
+++ b/win32/select.c
@@ -34,21 +34,17 @@
  * - Calling this with NULL sets as a portable way to sleep with sub-second
  *   accuracy is not supported.
  * */
-PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv)
+PHPAPI int php_select(SOCKET max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv)
 {
 	ULONGLONG ms_total, limit;
 	HANDLE handles[MAXIMUM_WAIT_OBJECTS];
-	php_socket_t handle_slot_to_fd[MAXIMUM_WAIT_OBJECTS];
-	php_socket_t n_handles = 0, i;
+	int handle_slot_to_fd[MAXIMUM_WAIT_OBJECTS];
+	int n_handles = 0, i;
 	fd_set sock_read, sock_write, sock_except;
 	fd_set aread, awrite, aexcept;
-	php_socket_t sock_max_fd = -1;
+	int sock_max_fd = -1;
 	struct timeval tvslice;
 	int retcode;
-
-	if (max_fd < 0) {
-		return FAILURE;
-	}
 
 #define SAFE_FD_ISSET(fd, set)	(set != NULL && FD_ISSET(fd, set))
 
@@ -140,13 +136,13 @@ PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *e
 				for (i = 0; i < n_handles; i++) {
 					if (WAIT_OBJECT_0 == WaitForSingleObject(handles[i], 0)) {
 						if (SAFE_FD_ISSET(handle_slot_to_fd[i], rfds)) {
-							FD_SET((php_socket_t) handle_slot_to_fd[i], &aread);
+							FD_SET((uint32_t)handle_slot_to_fd[i], &aread);
 						}
 						if (SAFE_FD_ISSET(handle_slot_to_fd[i], wfds)) {
-							FD_SET((php_socket_t) handle_slot_to_fd[i], &awrite);
+							FD_SET((uint32_t)handle_slot_to_fd[i], &awrite);
 						}
 						if (SAFE_FD_ISSET(handle_slot_to_fd[i], efds)) {
-							FD_SET((php_socket_t) handle_slot_to_fd[i], &aexcept);
+							FD_SET((uint32_t)handle_slot_to_fd[i], &aexcept);
 						}
 						retcode++;
 					}

--- a/win32/select.h
+++ b/win32/select.h
@@ -18,6 +18,6 @@
 
 /* $Id$ */
 
-#include "php_network.h"
+#include <WinSock2.h>
 
-PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv);
+PHPAPI int php_select(SOCKET max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv);

--- a/win32/select.h
+++ b/win32/select.h
@@ -18,5 +18,6 @@
 
 /* $Id$ */
 
-PHPAPI int php_select(int max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv);
+#include <WinSock2.h>
 
+PHPAPI int php_select(SOCKET max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv);

--- a/win32/select.h
+++ b/win32/select.h
@@ -18,6 +18,6 @@
 
 /* $Id$ */
 
-#include <WinSock2.h>
+#include "php_network.h"
 
-PHPAPI int php_select(SOCKET max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv);
+PHPAPI int php_select(php_socket_t max_fd, fd_set *rfds, fd_set *wfds, fd_set *efds, struct timeval *tv);


### PR DESCRIPTION
This warning was about a possible loss of data due to the downcast of `php_socket_t` to `int`. The former maps to a platform specific type, hence, it might downcast from a 64 bit integer to a 32 bit integer.

The original `nmake` warning for reference:

```
sapi\cli\php_cli_server.c(791): warning C4244: 'function': conversion from 'php_socket_t' to 'int', possible loss of data
```

I checked all callers of `sapi_cli_select`, and all of them are using `php_socket_t` properly. Hence, the change should be fine for all of internals code.

@weltling this one is for you. 🐱 