### PR TITLE
openssl_pkcs12_read: add missing BIO_free

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2989,6 +2989,7 @@ PHP_FUNCTION(openssl_pkcs12_read)
 				}
 
 				X509_free(aCA);
+				BIO_free(bio_out);
 			}
 
 			sk_X509_free(ca);


### PR DESCRIPTION
When filling the extracerts array with certificates bio_out is created
but not free'd leading to a small memory leak of 224 bytes (reported by
valgrind).