### PR TITLE
Constify str in add_assoc_string_ex and add_assoc_stringl_ex

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1407,7 +1407,7 @@ ZEND_API int add_assoc_str_ex(zval *arg, const char *key, size_t key_len, zend_s
 }
 /* }}} */
 
-ZEND_API int add_assoc_string_ex(zval *arg, const char *key, size_t key_len, char *str) /* {{{ */
+ZEND_API int add_assoc_string_ex(zval *arg, const char *key, size_t key_len, const char *str) /* {{{ */
 {
 	zval *ret, tmp;
 
@@ -1417,7 +1417,7 @@ ZEND_API int add_assoc_string_ex(zval *arg, const char *key, size_t key_len, cha
 }
 /* }}} */
 
-ZEND_API int add_assoc_stringl_ex(zval *arg, const char *key, size_t key_len, char *str, size_t length) /* {{{ */
+ZEND_API int add_assoc_stringl_ex(zval *arg, const char *key, size_t key_len, const char *str, size_t length) /* {{{ */
 {
 	zval *ret, tmp;
 

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -409,8 +409,8 @@ ZEND_API int add_assoc_bool_ex(zval *arg, const char *key, size_t key_len, int b
 ZEND_API int add_assoc_resource_ex(zval *arg, const char *key, size_t key_len, zend_resource *r);
 ZEND_API int add_assoc_double_ex(zval *arg, const char *key, size_t key_len, double d);
 ZEND_API int add_assoc_str_ex(zval *arg, const char *key, size_t key_len, zend_string *str);
-ZEND_API int add_assoc_string_ex(zval *arg, const char *key, size_t key_len, char *str);
-ZEND_API int add_assoc_stringl_ex(zval *arg, const char *key, size_t key_len, char *str, size_t length);
+ZEND_API int add_assoc_string_ex(zval *arg, const char *key, size_t key_len, const char *str);
+ZEND_API int add_assoc_stringl_ex(zval *arg, const char *key, size_t key_len, const char *str, size_t length);
 ZEND_API int add_assoc_zval_ex(zval *arg, const char *key, size_t key_len, zval *value);
 
 #define add_assoc_long(__arg, __key, __n) add_assoc_long_ex(__arg, __key, strlen(__key), __n)


### PR DESCRIPTION
I might be missing something but can't see any reason why `str` is not `const` in here. It's used in `ZVAL_STRINGL` which call `zend_string_init` that accepts `const`.

I could that drop unnecessary cast like this in openssl ext:

https://github.com/php/php-src/blob/8baf12b1615e8a89d984f8df8d9585d1e434f6c6/ext/openssl/openssl.c#L884