### PR TITLE
fix openssl_spki_new memory leak

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1851,20 +1851,18 @@ PHP_FUNCTION(openssl_spki_new)
 	s = zend_string_alloc(strlen(spkac) + strlen(spkstr), 0);
 	sprintf(ZSTR_VAL(s), "%s%s", spkac, spkstr);
 	ZSTR_LEN(s) = strlen(ZSTR_VAL(s));
+	OPENSSL_free(spkstr);
 
 	RETVAL_STR(s);
 	goto cleanup;
 
 cleanup:
 
-	if (keyresource == NULL && spki != NULL) {
+	if (spki != NULL) {
 		NETSCAPE_SPKI_free(spki);
 	}
 	if (keyresource == NULL && pkey != NULL) {
 		EVP_PKEY_free(pkey);
-	}
-	if (keyresource == NULL && spkstr != NULL) {
-		efree(spkstr);
 	}
 
 	if (s && ZSTR_LEN(s) <= 0) {


### PR DESCRIPTION
There are two memory leaks in openssl_spki_new reported by valgrind when running:
```
USE_ZEND_ALLOC=0 valgrind --leak-check=full ./sapi/cli/php ext/openssl/tests/openssl_spki_export_basic.phpt 
```

This PR fixes both of the leaks.