### PR TITLE
Fixed #74699 - Missing range for FILTER_FLAG_NO_RES_RANGE

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -789,6 +789,7 @@ void php_filter_validate_ip(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 			if (flags & FILTER_FLAG_NO_RES_RANGE) {
 				if (
 					(ip[0] == 0) ||
+					(ip[0] == 224 && ip[1] == 0 && ip[2] == 0) ||
 					(ip[0] >= 240) ||
 					(ip[0] == 127) ||
 					(ip[0] == 169 && ip[1] == 254)

--- a/ext/filter/tests/bug74699.phpt
+++ b/ext/filter/tests/bug74699.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Bug #74699 (Missing range for FILTER_FLAG_NO_RES_RANGE)
+--SKIPIF--
+<?php
+if (!extension_loaded('filter')) die('skip filter extension not available');
+?>
+--FILE--
+<?php
+$return = filter_var("223.255.255.255", FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE);
+var_dump($return);
+
+$return = filter_var("224.0.0.0", FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE);
+var_dump($return);
+
+$return = filter_var("224.0.0.2", FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE);
+var_dump($return);
+
+$return = filter_var("224.0.0.255", FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE);
+var_dump($return);
+
+$return = filter_var("224.0.1.0", FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE);
+var_dump($return);
+
+$return = filter_var("224.1.0.0", FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE);
+var_dump($return);
+
+$return = filter_var("225.0.0.0", FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE);
+var_dump($return);
+?>
+--EXPECT--
+string(15) "223.255.255.255"
+bool(false)
+bool(false)
+bool(false)
+string(9) "224.0.1.0"
+string(9) "224.1.0.0"
+string(9) "225.0.0.0"


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=74699

According to IPv4 Multicast Address Space Registry (https://www.iana.org/assignments/multicast-addresses/multicast-addresses.xhtml) IP addresses `224.0.0.0 – 224.0.0.255` are reserved