### PR TITLE
Use reasonable SQLite3 module version

### DIFF
--- a/ext/sqlite3/php_sqlite3.h
+++ b/ext/sqlite3/php_sqlite3.h
@@ -21,7 +21,7 @@
 #ifndef PHP_SQLITE3_H
 #define PHP_SQLITE3_H
 
-#define PHP_SQLITE3_VERSION	 "0.7-dev"
+#define PHP_SQLITE3_VERSION	PHP_VERSION
 
 extern zend_module_entry sqlite3_module_entry;
 #define phpext_sqlite3_ptr &sqlite3_module_entry


### PR DESCRIPTION
Since PECL/sqlite3 has been moved to ext/sqlite3 in 2008, the SQLite3
module version is hardcoded to `0.7-dev`. It doesn't appear to make
much sense to have an own module version for a bundled extensions, but
as other code might rely on it, we don't remove the constant but rather
make it an alias of the PHP version.