### PR TITLE
Fixes bug #74708 reflection signatures for random_bytes+random_int

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1912,11 +1912,11 @@ ZEND_BEGIN_ARG_INFO(arginfo_mt_getrandmax, 0)
 ZEND_END_ARG_INFO()
 /* }}} */
 /* {{{ random.c */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_random_bytes, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_random_bytes, 0, 0, 1)
 	ZEND_ARG_INFO(0, length)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_random_int, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_random_int, 0, 0, 2)
 	ZEND_ARG_INFO(0, min)
 	ZEND_ARG_INFO(0, max)
 ZEND_END_ARG_INFO()

--- a/ext/standard/tests/random/reflection.phpt
+++ b/ext/standard/tests/random/reflection.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #74708 Wrong reflection on random_bytes and random_int
+--FILE--
+<?php
+$rf = new ReflectionFunction('random_bytes');
+var_dump($rf->getNumberOfParameters());
+var_dump($rf->getNumberOfRequiredParameters());
+
+$rf = new ReflectionFunction('random_int');
+var_dump($rf->getNumberOfParameters());
+var_dump($rf->getNumberOfRequiredParameters());
+?>
+===DONE===
+--EXPECT--
+int(1)
+int(1)
+int(2)
+int(2)
+===DONE===


### PR DESCRIPTION
They have 1 and 2 required parameters, respectively
See https://secure.php.net/manual/en/function.random-int.php