### PR TITLE
Bump Modules API number for 7.2 to distinguish from 7.1

### DIFF
--- a/Zend/zend_modules.h
+++ b/Zend/zend_modules.h
@@ -33,7 +33,7 @@
 #define ZEND_MODULE_INFO_FUNC_ARGS zend_module_entry *zend_module
 #define ZEND_MODULE_INFO_FUNC_ARGS_PASSTHRU zend_module
 
-#define ZEND_MODULE_API_NO 20160303
+#define ZEND_MODULE_API_NO 20160731
 #ifdef ZTS
 #define USING_ZTS 1
 #else


### PR DESCRIPTION
Commit 845f66ba64c8a51f5764df64ac99c9fc89efce3c bumped PHP API vesion and extensions API number, but not the modules API number. This breaks 7.1 when compiling and installing 7.2. See [bug report #74735](https://bugs.php.net/bug.php?id=74735).

```
Failed loading /usr/local/lib/php/20160303/opcache.so:  /usr/local/lib/php/20160303/opcache.so: undefined symbol: zend_known_strings
```