### PR TITLE
Fixes bug #74761 Unary operator expected error on line 3472 when configuring

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2687,7 +2687,7 @@ EOF
   done
 
   echo "'[$]0' \\" >> $1
-  if test `expr -- [$]0 : "'.*"` = 0; then
+  if test `expr " [$]0" : " '.*"` = 0; then
     CONFIGURE_COMMAND="$CONFIGURE_COMMAND '[$]0'"
   else 
     CONFIGURE_COMMAND="$CONFIGURE_COMMAND [$]0"


### PR DESCRIPTION
This patch fixes configure error on some systems such as Alpine.

When doing `./configure`, this error happens:

```
 line 3472: test: =: unary operator expected
```

One of the fixes has been suggested also here already:
https://bugs.php.net/bug.php?id=39835

Thank you for considering merging this.