### PR TITLE
Reflection: use Zend API to retrieve type name (consistency) - FOR DISCUSSION

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2992,19 +2992,17 @@ ZEND_METHOD(reflection_type, __toString)
 	GET_REFLECTION_OBJECT_PTR(param);
 
 	switch (param->arg_info->type_hint) {
-		case IS_ARRAY:    RETURN_STRINGL("array", sizeof("array") - 1);
-		case IS_CALLABLE: RETURN_STRINGL("callable", sizeof("callable") - 1);
 		case IS_OBJECT:
 			if (param->fptr->type == ZEND_INTERNAL_FUNCTION &&
 			    !(param->fptr->common.fn_flags & ZEND_ACC_USER_ARG_INFO)) {
 				RETURN_STRING(((zend_internal_arg_info*)param->arg_info)->class_name);
 			}
 			RETURN_STR_COPY(param->arg_info->class_name);
-		case IS_STRING:   RETURN_STRINGL("string", sizeof("string") - 1);
+		/* keep this for BC, bool vs boolean, int vs integer */
 		case _IS_BOOL:    RETURN_STRINGL("bool", sizeof("bool") - 1);
 		case IS_LONG:     RETURN_STRINGL("int", sizeof("int") - 1);
-		case IS_DOUBLE:   RETURN_STRINGL("float", sizeof("float") - 1);
-		EMPTY_SWITCH_DEFAULT_CASE()
+		/* use zend API for other types */
+		default:          RETURN_STRING(zend_get_type_by_const(param->arg_info->type_hint));
 	}
 }
 /* }}} */


### PR DESCRIPTION
Context: see https://github.com/etsy/phan/issues/888

So ReflectionType::__toString fails for some type (IS_NULL, IS_RESOURCE)

Question, is following code acceptable ?
```
ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(AI(setContentDownload), 0, 1, IS_NULL, NULL, 0)
    ZEND_ARG_TYPE_INFO(0, fh, IS_RESOURCE, 0)
    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
    ZEND_ARG_TYPE_INFO(0, disposition, IS_STRING, 0)
    ZEND_ARG_TYPE_INFO(0, params, IS_ARRAY, 0)
ZEND_END_ARG_INFO()
```

Return type should be IS_VOID (7.1+ only)
Param type IS_RESOURCE seems ok

Notice: extension works and reflection (from CLI) is ok
```
        Method [ <internal:request> public method setContentDownload ] {

          - Parameters [4] {
            Parameter #0 [ <required> resource $fh ]
            Parameter #1 [ <optional> string $name ]
            Parameter #2 [ <optional> string $disposition ]
            Parameter #3 [ <optional> array $params ]
          }
          - Return [ null ]
        }
```

This proposal use **zend_get_type_by_const**
Notice, we have to handle BC, so have to keep specific case for
* bool bs boolean
* int vs integer

Of course, can be fixed on "request" side, see https://gitlab.com/remicollet/ext-request/commit/d4542bf4278386020f081c6a5ba8c3acfbe2c432  but this seems a workaround.
