### PR TITLE
Change getimagesize associative return array

### DIFF
--- a/ext/gd/tests/imagecopyresampled_basic.phpt
+++ b/ext/gd/tests/imagecopyresampled_basic.phpt
@@ -35,20 +35,20 @@ imagepng($image_lge, $dest_lge);
 
 // Get new dimensions
 $percent = 0.5; // new image 50% of original
-list($width, $height) = getimagesize($dest_lge);
-echo "Size of original: width=". $width . " height=" . $height . "\n";
+$imageSize = getimagesize($dest_lge);
+echo "Size of original: width=". $imageSize['width'] . " height=" . $imageSize['height'] . "\n";
 
-$new_width = $width * $percent;
-$new_height = $height * $percent;
+$new_width = $imageSize['width'] * $percent;
+$new_height = $imageSize['height'] * $percent;
 
 // Resample
 $image_sml = imagecreatetruecolor($new_width, $new_height);
-imagecopyresampled($image_sml, $image_lge, 0, 0, 0, 0, $new_width, $new_height, $width, $height);
+imagecopyresampled($image_sml, $image_lge, 0, 0, 0, 0, $new_width, $new_height, $imageSize['width'], $imageSize['height']);
 
 imagepng($image_sml, $dest_sml);
 
-list($width, $height) = getimagesize($dest_sml);
-echo "Size of copy: width=". $width . " height=" . $height . "\n";
+$imageSize = getimagesize($dest_sml);
+echo "Size of copy: width=". $imageSize['width'] . " height=" . $imageSize['height'] . "\n";
 
 imagedestroy($image_lge); 
 imagedestroy($image_sml);

--- a/ext/standard/image.c
+++ b/ext/standard/image.c
@@ -1442,11 +1442,11 @@ static void php_getimagesize_from_stream(php_stream *stream, zval *info, INTERNA
 	if (result) {
 		char temp[MAX_LENGTH_OF_LONG * 2 + sizeof("width=\"\" height=\"\"")];
 		array_init(return_value);
-		add_index_long(return_value, 0, result->width);
-		add_index_long(return_value, 1, result->height);
-		add_index_long(return_value, 2, itype);
+		add_assoc_long(return_value, "width", result->width);
+		add_assoc_long(return_value, "height", result->height);
+		add_assoc_long(return_value, "type", itype);
 		snprintf(temp, sizeof(temp), "width=\"%d\" height=\"%d\"", result->width, result->height);
-		add_index_string(return_value, 3, temp);
+		add_assoc_string(return_value, "text", temp);
 
 		if (result->bits != 0) {
 			add_assoc_long(return_value, "bits", result->bits);

--- a/ext/standard/tests/image/bug13213.phpt
+++ b/ext/standard/tests/image/bug13213.phpt
@@ -7,13 +7,13 @@ var_dump(GetImageSize(dirname(__FILE__).'/bug13213.jpg'));
 --EXPECTF--
 Warning: getimagesize(): corrupt JPEG data: 2 extraneous bytes before marker in %s%ebug13213.php on line %d
 array(7) {
-  [0]=>
+  ["width"]=>
   int(1)
-  [1]=>
+  ["height"]=>
   int(1)
-  [2]=>
+  ["type"]=>
   int(2)
-  [3]=>
+  ["text"]=>
   string(20) "width="1" height="1""
   ["bits"]=>
   int(8)

--- a/ext/standard/tests/image/bug70052.phpt
+++ b/ext/standard/tests/image/bug70052.phpt
@@ -8,13 +8,13 @@ var_dump(getimagesize(__DIR__ . '/bug70052_2.wbmp'));
 --EXPECT--
 bool(false)
 array(5) {
-  [0]=>
+  ["width"]=>
   int(3)
-  [1]=>
+  ["height"]=>
   int(3)
-  [2]=>
+  ["type"]=>
   int(15)
-  [3]=>
+  ["text"]=>
   string(20) "width="3" height="3""
   ["mime"]=>
   string(18) "image/vnd.wap.wbmp"

--- a/ext/standard/tests/image/bug72278.phpt
+++ b/ext/standard/tests/image/bug72278.phpt
@@ -15,13 +15,13 @@ var_dump(getimagesize(FILENAME));
 
 Warning: getimagesize(): corrupt JPEG data: 3 extraneous bytes before marker in %s%ebug72278.php on line %d
 array(7) {
-  [0]=>
+  ["width"]=>
   int(300)
-  [1]=>
+  ["height"]=>
   int(300)
-  [2]=>
+  ["type"]=>
   int(2)
-  [3]=>
+  ["text"]=>
   string(24) "width="300" height="300""
   ["bits"]=>
   int(8)

--- a/ext/standard/tests/image/getimagesize.phpt
+++ b/ext/standard/tests/image/getimagesize.phpt
@@ -26,13 +26,13 @@ GetImageSize()
 array(16) {
   ["test-1pix.bmp"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(1)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(6)
-    [3]=>
+    ["text"]=>
     string(20) "width="1" height="1""
     ["bits"]=>
     int(24)
@@ -41,13 +41,13 @@ array(16) {
   }
   ["test12pix.webp"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(4)
-    [1]=>
+    ["height"]=>
     int(3)
-    [2]=>
+    ["type"]=>
     int(18)
-    [3]=>
+    ["text"]=>
     string(20) "width="4" height="3""
     ["bits"]=>
     int(8)
@@ -56,13 +56,13 @@ array(16) {
   }
   ["test1bpix.bmp"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(500)
-    [1]=>
+    ["height"]=>
     int(345)
-    [2]=>
+    ["type"]=>
     int(6)
-    [3]=>
+    ["text"]=>
     string(24) "width="500" height="345""
     ["bits"]=>
     int(32)
@@ -71,13 +71,13 @@ array(16) {
   }
   ["test1pix.bmp"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(1)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(6)
-    [3]=>
+    ["text"]=>
     string(20) "width="1" height="1""
     ["bits"]=>
     int(24)
@@ -86,13 +86,13 @@ array(16) {
   }
   ["test1pix.jp2"]=>
   array(7) {
-    [0]=>
+    ["width"]=>
     int(1)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(10)
-    [3]=>
+    ["text"]=>
     string(20) "width="1" height="1""
     ["bits"]=>
     int(8)
@@ -103,13 +103,13 @@ array(16) {
   }
   ["test1pix.jpc"]=>
   array(7) {
-    [0]=>
+    ["width"]=>
     int(1)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(9)
-    [3]=>
+    ["text"]=>
     string(20) "width="1" height="1""
     ["bits"]=>
     int(8)
@@ -120,13 +120,13 @@ array(16) {
   }
   ["test1pix.jpg"]=>
   array(7) {
-    [0]=>
+    ["width"]=>
     int(1)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(2)
-    [3]=>
+    ["text"]=>
     string(20) "width="1" height="1""
     ["bits"]=>
     int(8)
@@ -137,13 +137,13 @@ array(16) {
   }
   ["test2pix.gif"]=>
   array(7) {
-    [0]=>
+    ["width"]=>
     int(2)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(1)
-    [3]=>
+    ["text"]=>
     string(20) "width="2" height="1""
     ["bits"]=>
     int(1)
@@ -154,13 +154,13 @@ array(16) {
   }
   ["test3llpix.webp"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(1)
-    [1]=>
+    ["height"]=>
     int(3)
-    [2]=>
+    ["type"]=>
     int(18)
-    [3]=>
+    ["text"]=>
     string(20) "width="1" height="3""
     ["bits"]=>
     int(8)
@@ -169,13 +169,13 @@ array(16) {
   }
   ["test3pix.webp"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(1)
-    [1]=>
+    ["height"]=>
     int(3)
-    [2]=>
+    ["type"]=>
     int(18)
-    [3]=>
+    ["text"]=>
     string(20) "width="1" height="3""
     ["bits"]=>
     int(8)
@@ -184,13 +184,13 @@ array(16) {
   }
   ["test4pix.gif"]=>
   array(7) {
-    [0]=>
+    ["width"]=>
     int(4)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(1)
-    [3]=>
+    ["text"]=>
     string(20) "width="4" height="1""
     ["bits"]=>
     int(2)
@@ -201,13 +201,13 @@ array(16) {
   }
   ["test4pix.iff"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(4)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(14)
-    [3]=>
+    ["text"]=>
     string(20) "width="4" height="1""
     ["bits"]=>
     int(4)
@@ -216,13 +216,13 @@ array(16) {
   }
   ["test4pix.png"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(4)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(3)
-    [3]=>
+    ["text"]=>
     string(20) "width="4" height="1""
     ["bits"]=>
     int(4)
@@ -231,39 +231,39 @@ array(16) {
   }
   ["test4pix.psd"]=>
   array(5) {
-    [0]=>
+    ["width"]=>
     int(4)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(5)
-    [3]=>
+    ["text"]=>
     string(20) "width="4" height="1""
     ["mime"]=>
     string(9) "image/psd"
   }
   ["test4pix.swf"]=>
   array(5) {
-    [0]=>
+    ["width"]=>
     int(550)
-    [1]=>
+    ["height"]=>
     int(400)
-    [2]=>
+    ["type"]=>
     int(4)
-    [3]=>
+    ["text"]=>
     string(24) "width="550" height="400""
     ["mime"]=>
     string(29) "application/x-shockwave-flash"
   }
   ["test4pix.tif"]=>
   array(5) {
-    [0]=>
+    ["width"]=>
     int(4)
-    [1]=>
+    ["height"]=>
     int(1)
-    [2]=>
+    ["type"]=>
     int(7)
-    [3]=>
+    ["text"]=>
     string(20) "width="4" height="1""
     ["mime"]=>
     string(10) "image/tiff"

--- a/ext/standard/tests/image/getimagesize_246x247.phpt
+++ b/ext/standard/tests/image/getimagesize_246x247.phpt
@@ -26,13 +26,13 @@ GetImageSize() with 246x247 pixels
 array(1) {
   ["246x247.png"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(246)
-    [1]=>
+    ["height"]=>
     int(247)
-    [2]=>
+    ["type"]=>
     int(3)
-    [3]=>
+    ["text"]=>
     string(24) "width="246" height="247""
     ["bits"]=>
     int(4)

--- a/ext/standard/tests/image/getimagesize_384x385.phpt
+++ b/ext/standard/tests/image/getimagesize_384x385.phpt
@@ -26,13 +26,13 @@ GetImageSize() with 384x385 pixels
 array(1) {
   ["384x385.png"]=>
   array(6) {
-    [0]=>
+    ["width"]=>
     int(384)
-    [1]=>
+    ["height"]=>
     int(385)
-    [2]=>
+    ["type"]=>
     int(3)
-    [3]=>
+    ["text"]=>
     string(24) "width="384" height="385""
     ["bits"]=>
     int(1)

--- a/ext/standard/tests/image/getimagesize_basic.phpt
+++ b/ext/standard/tests/image/getimagesize_basic.phpt
@@ -51,13 +51,13 @@ foreach($imagetype_filenames as $key => $filename) {
 
 -- GIF image file (200x100.gif) --
 array(7) {
-  [0]=>
+  ["width"]=>
   int(200)
-  [1]=>
+  ["height"]=>
   int(100)
-  [2]=>
+  ["type"]=>
   int(1)
-  [3]=>
+  ["text"]=>
   string(24) "width="200" height="100""
   ["bits"]=>
   int(8)
@@ -71,13 +71,13 @@ array(0) {
 
 -- JPEG image file (200x100.jpg) --
 array(7) {
-  [0]=>
+  ["width"]=>
   int(200)
-  [1]=>
+  ["height"]=>
   int(100)
-  [2]=>
+  ["type"]=>
   int(2)
-  [3]=>
+  ["text"]=>
   string(24) "width="200" height="100""
   ["bits"]=>
   int(8)
@@ -93,13 +93,13 @@ array(1) {
 
 -- PNG image file (200x100.png) --
 array(6) {
-  [0]=>
+  ["width"]=>
   int(200)
-  [1]=>
+  ["height"]=>
   int(100)
-  [2]=>
+  ["type"]=>
   int(3)
-  [3]=>
+  ["text"]=>
   string(24) "width="200" height="100""
   ["bits"]=>
   int(8)
@@ -111,13 +111,13 @@ array(0) {
 
 -- SWF image file (200x100.swf) --
 array(5) {
-  [0]=>
+  ["width"]=>
   int(200)
-  [1]=>
+  ["height"]=>
   int(100)
-  [2]=>
+  ["type"]=>
   int(4)
-  [3]=>
+  ["text"]=>
   string(24) "width="200" height="100""
   ["mime"]=>
   string(29) "application/x-shockwave-flash"
@@ -127,13 +127,13 @@ array(0) {
 
 -- BMP image file (200x100.bmp) --
 array(6) {
-  [0]=>
+  ["width"]=>
   int(200)
-  [1]=>
+  ["height"]=>
   int(100)
-  [2]=>
+  ["type"]=>
   int(6)
-  [3]=>
+  ["text"]=>
   string(24) "width="200" height="100""
   ["bits"]=>
   int(24)
@@ -145,13 +145,13 @@ array(0) {
 
 -- TIFF intel byte order image file (200x100.tif) --
 array(5) {
-  [0]=>
+  ["width"]=>
   int(200)
-  [1]=>
+  ["height"]=>
   int(100)
-  [2]=>
+  ["type"]=>
   int(7)
-  [3]=>
+  ["text"]=>
   string(24) "width="200" height="100""
   ["mime"]=>
   string(10) "image/tiff"
@@ -161,13 +161,13 @@ array(0) {
 
 -- JPC image file (test1pix.jpc) --
 array(7) {
-  [0]=>
+  ["width"]=>
   int(1)
-  [1]=>
+  ["height"]=>
   int(1)
-  [2]=>
+  ["type"]=>
   int(9)
-  [3]=>
+  ["text"]=>
   string(20) "width="1" height="1""
   ["bits"]=>
   int(8)
@@ -181,13 +181,13 @@ array(0) {
 
 -- JP2 image file (test1pix.jp2) --
 array(7) {
-  [0]=>
+  ["width"]=>
   int(1)
-  [1]=>
+  ["height"]=>
   int(1)
-  [2]=>
+  ["type"]=>
   int(10)
-  [3]=>
+  ["text"]=>
   string(20) "width="1" height="1""
   ["bits"]=>
   int(8)
@@ -201,13 +201,13 @@ array(0) {
 
 -- IFF image file (test4pix.iff) --
 array(6) {
-  [0]=>
+  ["width"]=>
   int(4)
-  [1]=>
+  ["height"]=>
   int(1)
-  [2]=>
+  ["type"]=>
   int(14)
-  [3]=>
+  ["text"]=>
   string(20) "width="4" height="1""
   ["bits"]=>
   int(4)

--- a/ext/standard/tests/image/getimagesize_swc.phpt
+++ b/ext/standard/tests/image/getimagesize_swc.phpt
@@ -12,13 +12,13 @@ GetImageSize() for compressed swf files
 ?>
 --EXPECT--
 array(5) {
-  [0]=>
+  ["width"]=>
   int(550)
-  [1]=>
+  ["height"]=>
   int(400)
-  [2]=>
+  ["type"]=>
   int(13)
-  [3]=>
+  ["text"]=>
   string(24) "width="550" height="400""
   ["mime"]=>
   string(29) "application/x-shockwave-flash"

--- a/ext/standard/tests/image/getimagesize_tif_mm.phpt
+++ b/ext/standard/tests/image/getimagesize_tif_mm.phpt
@@ -23,13 +23,13 @@ var_dump($arr);
 --EXPECT--
 *** Testing getimagesize() : tiff_mm format ***
 array(5) {
-  [0]=>
+  ["width"]=>
   int(2)
-  [1]=>
+  ["height"]=>
   int(2)
-  [2]=>
+  ["type"]=>
   int(8)
-  [3]=>
+  ["text"]=>
   string(20) "width="2" height="2""
   ["mime"]=>
   string(10) "image/tiff"

--- a/ext/standard/tests/image/getimagesize_variation4.phpt
+++ b/ext/standard/tests/image/getimagesize_variation4.phpt
@@ -22,13 +22,13 @@ var_dump( $info );
 --EXPECTF--
 *** Testing getimagesize() : variation ***
 array(5) {
-  [0]=>
+  ["width"]=>
   int(550)
-  [1]=>
+  ["height"]=>
   int(400)
-  [2]=>
+  ["type"]=>
   int(13)
-  [3]=>
+  ["text"]=>
   string(24) "width="550" height="400""
   ["mime"]=>
   string(29) "application/x-shockwave-flash"

--- a/ext/standard/tests/image/getimagesize_variation_005.phpt
+++ b/ext/standard/tests/image/getimagesize_variation_005.phpt
@@ -22,13 +22,13 @@ var_dump( $info );
 --EXPECTF--
 *** Testing getimagesize() : basic functionality ***
 array(5) {
-  [0]=>
+  ["width"]=>
   int(550)
-  [1]=>
+  ["height"]=>
   int(400)
-  [2]=>
+  ["type"]=>
   int(13)
-  [3]=>
+  ["text"]=>
   string(24) "width="550" height="400""
   ["mime"]=>
   string(29) "application/x-shockwave-flash"

--- a/ext/standard/tests/image/getimagesize_wbmp.phpt
+++ b/ext/standard/tests/image/getimagesize_wbmp.phpt
@@ -23,13 +23,13 @@ var_dump($arr);
 --EXPECT--
 *** Testing getimagesize() : wbmp format ***
 array(5) {
-  [0]=>
+  ["width"]=>
   int(75)
-  [1]=>
+  ["height"]=>
   int(50)
-  [2]=>
+  ["type"]=>
   int(15)
-  [3]=>
+  ["text"]=>
   string(22) "width="75" height="50""
   ["mime"]=>
   string(18) "image/vnd.wap.wbmp"

--- a/ext/standard/tests/image/getimagesize_xbm.phpt
+++ b/ext/standard/tests/image/getimagesize_xbm.phpt
@@ -23,13 +23,13 @@ var_dump($arr);
 --EXPECT--
 *** Testing getimagesize() : xbm format ***
 array(5) {
-  [0]=>
+  ["width"]=>
   int(75)
-  [1]=>
+  ["height"]=>
   int(50)
-  [2]=>
+  ["type"]=>
   int(16)
-  [3]=>
+  ["text"]=>
   string(22) "width="75" height="50""
   ["mime"]=>
   string(9) "image/xbm"

--- a/ext/standard/tests/image/getimagesizefromstring1.phpt
+++ b/ext/standard/tests/image/getimagesizefromstring1.phpt
@@ -15,13 +15,13 @@ var_dump($i2);
 ?>
 --EXPECT--
 array(7) {
-  [0]=>
+  ["width"]=>
   int(120)
-  [1]=>
+  ["height"]=>
   int(67)
-  [2]=>
+  ["type"]=>
   int(1)
-  [3]=>
+  ["text"]=>
   string(23) "width="120" height="67""
   ["bits"]=>
   int(7)
@@ -31,13 +31,13 @@ array(7) {
   string(9) "image/gif"
 }
 array(7) {
-  [0]=>
+  ["width"]=>
   int(120)
-  [1]=>
+  ["height"]=>
   int(67)
-  [2]=>
+  ["type"]=>
   int(1)
-  [3]=>
+  ["text"]=>
   string(23) "width="120" height="67""
   ["bits"]=>
   int(7)

--- a/ext/standard/tests/image/image_type_to_mime_type.phpt
+++ b/ext/standard/tests/image/image_type_to_mime_type.phpt
@@ -20,7 +20,7 @@ image_type_to_mime_type()
 	sort($files);
 	foreach($files as $file) {
 		$result[$file] = getimagesize(dirname(__FILE__)."/$file");
-		$result[$file] = image_type_to_mime_type($result[$file][2]);
+		$result[$file] = image_type_to_mime_type($result[$file]["type"]);
 	}
 	var_dump($result);
 ?>


### PR DESCRIPTION
For some reason, the `getimagesize()` function returns a mixed associative array of integer keys and string keys. Looking back in the git history, this just looks like it was never considered. Anyhow, I would like to change this with this pull request.
This is probably a major BC issue that requires an RFC, but I first wanted to discus this issue here to make sure something like this could eventually be merged.