### PR TITLE
BUG #74737: Incorrect ReflectionFunction information for mysqli_get_c…

### DIFF
--- a/ext/mysqli/mysqli_fe.c
+++ b/ext/mysqli/mysqli_fe.c
@@ -453,7 +453,7 @@ const zend_function_entry mysqli_functions[] = {
 #ifdef HAVE_MYSQLI_GET_CHARSET
 	PHP_FE(mysqli_get_charset,							arginfo_mysqli_only_link)
 #endif
-	PHP_FE(mysqli_get_client_info,						arginfo_mysqli_only_link)
+	PHP_FE(mysqli_get_client_info,						arginfo_mysqli_no_options)
 	PHP_FE(mysqli_get_client_version,					arginfo_mysqli_only_link)
 	PHP_FE(mysqli_get_links_stats,						arginfo_mysqli_no_options)
 	PHP_FE(mysqli_get_host_info,						arginfo_mysqli_only_link)

--- a/ext/mysqli/tests/bug74737.phpt
+++ b/ext/mysqli/tests/bug74737.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #74737: Incorrect ReflectionFunction information for mysqli_get_client_info
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!extension_loaded('reflection')) { die("skip"); }
+?>
+--FILE--
+<?php
+$client_info = mysqli_get_client_info();
+$rf = new ReflectionFunction('mysqli_get_client_info');
+echo $rf->getNumberOfParameters();
+echo PHP_EOL;
+echo $rf->getNumberOfRequiredParameters();
+?>
+
+--EXPECT--
+0
+0


### PR DESCRIPTION
…lient_info

The $link parameter for `mysqli_get_client_info` was showing as required from reflection, but it is an optional parameter. 

https://bugs.php.net/bug.php?id=74737