### PR TITLE
Compatibility with libargon2 versions 20161029 and 20160821

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -433,11 +433,20 @@ if test "$PHP_PASSWORD_ARGON2" != "no"; then
   PHP_ADD_LIBRARY_WITH_PATH(argon2, $ARGON2_DIR/$PHP_LIBDIR)
   PHP_ADD_INCLUDE($ARGON2_DIR/include)
 
+  AC_MSG_CHECKING([for argon2_hash function])
   AC_CHECK_LIB(argon2, argon2_hash, [
     LIBS="$LIBS -largon2"
     AC_DEFINE(HAVE_ARGON2LIB, 1, [ Define to 1 if you have the <argon2.h> header file ])
   ], [
     AC_MSG_ERROR([Problem with libargon2.(a|so). Please verify that Argon2 header and libaries are installed])
+  ])
+
+  AC_MSG_CHECKING([for argon2id_hash_raw function])
+  AC_CHECK_LIB(argon2, argon2id_hash_raw, [
+    LIBS="$LIBS -largon2"
+    AC_DEFINE(HAVE_ARGON2ID, 1, [ Define to 1 if Argon2 library has support for Argon2ID])
+  ], [
+    AC_MSG_RESULT([not found])
   ])
 fi
 

--- a/ext/standard/config.w32
+++ b/ext/standard/config.w32
@@ -7,6 +7,9 @@ if (PHP_PASSWORD_ARGON2 != "no") {
 	if (CHECK_LIB("argon2_a.lib;argon2.lib", null, PHP_PASSWORD_ARGON2)
 	&& CHECK_HEADER_ADD_INCLUDE("argon2.h", "CFLAGS")) {
 		AC_DEFINE('HAVE_ARGON2LIB', 1);
+		if (CHECK_FUNC_IN_HEADER("argon2.h", "argon2id_hash_raw", PHP_PHP_BUILD + "\\include", "CFLAGS")) {
+			AC_DEFINE('HAVE_ARGON2ID', 1);
+		}
 	} else {
 		WARNING("Argon2 not enabled; libaries and headers not found");
 	}

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -545,6 +545,9 @@ PHP_FUNCTION(password_hash)
 					threads,
 					(uint32_t)salt_len,
 					out_len
+#if HAVE_ARGON2ID
+					, type
+#endif
 				);
 
 				out = emalloc(out_len + 1);


### PR DESCRIPTION
#### Information

libargon2 [20161029](https://github.com/P-H-C/phc-winner-argon2/releases/tag/20161029) introduces the `type` parameter to the`argon2_encodedlen` function that is not present in [20160821](https://github.com/P-H-C/phc-winner-argon2/releases/tag/20160821).

This change is a preemptive patch against the Argon2 functionality introduced in #1997 to ensure compatibility with both versions.

With the release of Debian Stretch today, it seems like 20160821 is what is being packaged (see https://packages.debian.org/stretch/mips/libs/libargon2-0), however other distributions may package 20161029. Additionally end users may download the latest libargon2 20161029 and compile against it directly instead of using the one provided by their OS.

This patch does not introduce any new functionality into PHP.

----

#### Technical Details

A check against the `argon2id_hash_raw` function is used as the `Argon2_version` enum in the lib wasn't bumped in https://github.com/P-H-C/phc-winner-argon2/compare/20160821...20161029#diff-7d1c36b407eae6a25b79dad261dd5c6eL212 and `libargon2` doesn't expose any way to detect the build versioning string.

On Linux, all tests pass against both 20161029 and 20160821 . I can verify the config.win32 updates work on Windows, however I'm seeing linkage issues against `zendparse` in VS2017 using the latest php-sdk and windows build instructions. As I'm seeing this issue against the base deps as well I don't think this is an issue with this patch.

If desired, the argon2 library in PHP-SDK deps can be bumped to 20161029 with this patch.

---

#### Discussion Topics

I don't believe this necessitates an RFC or a larger mailing list discussion, however I'll open one up if there are concerns. If I need to file a separate bug report to reference this against this let me know.

Please advise if the config.win32 feature check can be improved upon. 

Thanks