### PR TITLE
add test for strptime(): return false on failure

### DIFF
--- a/ext/standard/tests/time/strptime_error.phpt
+++ b/ext/standard/tests/time/strptime_error.phpt
@@ -32,6 +32,9 @@ echo "\n-- Testing strptime() function with more than expected no. of arguments 
 $extra_arg = 10;
 var_dump( strptime($date, $format, $extra_arg) );
 
+echo "\n-- Testing strptime() function on failure --\n";
+var_dump( strptime('foo', $format) );
+
 ?>
 ===DONE===
 --EXPECTF--
@@ -51,5 +54,8 @@ NULL
 
 Warning: strptime() expects exactly 2 parameters, 3 given in %s on line %d
 NULL
+
+-- Testing strptime() function on failure --
+bool(false)
 ===DONE===
 


### PR DESCRIPTION
I don't know how to run coverage but I'm attempting to cover the return false on failure portion for strptime from

http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/datetime.c.gcov.php

![screen shot 2017-06-18 at 12 40 07 pm](https://user-images.githubusercontent.com/348263/27262413-5a13978a-5424-11e7-9b42-badfbedc4933.png)
