### PR TITLE
Test ftp_ssl_connect() function : error conditions

### DIFF
--- a/ext/ftp/tests/ftp_ssl_connect_error.phpt
+++ b/ext/ftp/tests/ftp_ssl_connect_error.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Test ftp_ssl_connect() function : error conditions
+--SKIPIF--
+<?php
+$ssl = 1;
+require 'skipif.inc';
+if (!function_exists("ftp_ssl_connect")) die("skip ftp_ssl is disabled");
+?>
+--FILE--
+<?php
+echo "*** Testing ftp_ssl_connect() function : error conditions ***\n";
+echo "\n-- Testing ftp_ssl_connect() function on failure --\n";
+var_dump(ftp_ssl_connect('totes.invalid'));
+
+echo "\n-- Testing ftp_ssl_connect() function invalid argument type --\n";
+ftp_ssl_connect([]);
+ftp_ssl_connect('totes.invalid', []);
+ftp_ssl_connect('totes.invalid', 21, []);
+
+echo "\n-- Testing ftp_ssl_connect() function with more than expected no. of arguments --\n";
+ftp_ssl_connect('totes.invalid', 21, 1, []);
+
+echo "\n-- Testing ftp_ssl_connect() function timeout warning for value 0 --\n";
+ftp_ssl_connect('totes.invalid', 21, 0);
+
+?>
+===DONE===
+--EXPECTF--
+*** Testing ftp_ssl_connect() function : error conditions ***
+
+-- Testing ftp_ssl_connect() function on failure --
+
+Warning: ftp_ssl_connect(): php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %d
+bool(false)
+
+-- Testing ftp_ssl_connect() function invalid argument type --
+
+Warning: ftp_ssl_connect() expects parameter 1 to be string, array given in %s on line %d
+
+Warning: ftp_ssl_connect() expects parameter 2 to be integer, array given in %s on line %d
+
+Warning: ftp_ssl_connect() expects parameter 3 to be integer, array given in %s on line %d
+
+-- Testing ftp_ssl_connect() function with more than expected no. of arguments --
+
+Warning: ftp_ssl_connect() expects at most 3 parameters, 4 given in %s on line %d
+
+-- Testing ftp_ssl_connect() function timeout warning for value 0 --
+
+Warning: ftp_ssl_connect(): Timeout has to be greater than 0 in %s on line %d
+===DONE===


### PR DESCRIPTION
I don't know how to run coverage but I'm attempting to cover the return false on failure portion for ftp_ssl_connect and the timeout value warning from

http://gcov.php.net/PHP_HEAD/lcov_html/ext/ftp/php_ftp.c.gcov.php

![screen shot 2017-06-18 at 8 23 57 pm](https://user-images.githubusercontent.com/348263/27265463-68f19122-5464-11e7-8f5a-2faec0cc4d93.png)
