### PR TITLE
Add unary null coalescing operator

### DIFF
--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -961,6 +961,8 @@ expr_without_variable:
 			{ $$ = zend_ast_create(ZEND_AST_CONDITIONAL, $1, NULL, $4); }
 	|	expr T_COALESCE expr
 			{ $$ = zend_ast_create(ZEND_AST_COALESCE, $1, $3); }
+	|	expr T_COALESCE
+			{ zval z; ZVAL_NULL(&z); $$ = zend_ast_create(ZEND_AST_COALESCE, $1, zend_ast_create_zval_ex(&z, 0)); }
 	|	internal_functions_in_yacc { $$ = $1; }
 	|	T_INT_CAST expr		{ $$ = zend_ast_create_cast(IS_LONG, $2); }
 	|	T_DOUBLE_CAST expr	{ $$ = zend_ast_create_cast(IS_DOUBLE, $2); }

--- a/tests/lang/operators/coalesce_unary.phpt
+++ b/tests/lang/operators/coalesce_unary.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Test ?? operator (unary)
+--FILE--
+<?php
+
+$var = 7;
+$var2 = NULL;
+
+$obj = new StdClass;
+$obj->boo = 7;
+
+$arr = [
+	2 => 7,
+	"foo" => "bar",
+	"foobar" => NULL,
+	"qux" => $obj,
+	"bing" => [
+		"bang"
+	]
+];
+
+function foobar() {
+	echo "called\n";
+	return ['a'];
+}
+
+var_dump($nonexistent_variable??);
+echo PHP_EOL;
+var_dump($var??);
+var_dump($var2??);
+echo PHP_EOL;
+var_dump($obj->boo??);
+var_dump($obj->bing??);
+var_dump($arr["qux"]->boo??);
+var_dump($arr["qux"]->bing??);
+echo PHP_EOL;
+var_dump($arr[2]??);
+var_dump($arr["foo"]??);
+var_dump($arr["foobar"]??);
+var_dump($arr["qux"]??);
+var_dump($arr["bing"][0]??);
+var_dump($arr["bing"][1]??);
+echo PHP_EOL;
+var_dump(foobar()[0]??);
+echo PHP_EOL;
+function f($x)
+{
+    printf("%s(%d)\n", __FUNCTION__, $x);
+    return $x;
+}
+
+$a = f(null)??;
+?>
+--EXPECTF--
+NULL
+
+int(7)
+NULL
+
+int(7)
+NULL
+int(7)
+NULL
+
+int(7)
+string(3) "bar"
+NULL
+object(stdClass)#%d (%d) {
+  ["boo"]=>
+  int(7)
+}
+string(4) "bang"
+NULL
+
+called
+string(1) "a"
+
+f(0)


### PR DESCRIPTION
Corresponding php-langspec patch: https://github.com/php/php-langspec/pull/197

RFC: https://wiki.php.net/rfc/unary_null_coalescing_operator (Not yet accepted)