### PR TITLE
adding barnaul timezone

### DIFF
--- a/ext/date/lib/timezonemap.h
+++ b/ext/date/lib/timezonemap.h
@@ -41,6 +41,7 @@
 	{ "adt",   1, -10800, "Atlantic/Bermuda"              },
 	{ "adt",   1, -10800, "Canada/Atlantic"               },
 	{ "adt",   1,  14400, "Asia/Baghdad"                  },
+	{ "krat",  0,  25200, "Asia/Barnaul"                  },
 	{ "aedt",  1,  39600, "Australia/Melbourne"           },
 	{ "aedt",  1,  39600, "Antarctica/Macquarie"          },
 	{ "aedt",  1,  39600, "Australia/ACT"                 },


### PR DESCRIPTION
I have problem, that described here: https://stackoverflow.com/questions/44815123/why-exist-difference-in-datetimezonelistabbreviations-output-and-supported-tim
For example here: http://php.net/manual/en/timezones.asia.php we have Asia/Barnaul timezone, but we can't get this timezone via using DateTimeZone::listAbbreviations. This pull request should fix this problem.