### PR TITLE
Fixed #74445 - The PHP (mysqli) driver only connects with TLS 1.0 and…

### DIFF
--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -557,7 +557,7 @@ MYSQLND_METHOD(mysqlnd_vio, enable_ssl)(MYSQLND_VIO * const net)
 		}
 	}
 	php_stream_context_set(net_stream, context);
-	if (php_stream_xport_crypto_setup(net_stream, STREAM_CRYPTO_METHOD_TLS_CLIENT, NULL) < 0 ||
+	if (php_stream_xport_crypto_setup(net_stream, STREAM_CRYPTO_METHOD_TLS_ANY_CLIENT, NULL) < 0 ||
 	    php_stream_xport_crypto_enable(net_stream, 1) < 0)
 	{
 		DBG_ERR("Cannot connect to MySQL by using SSL");


### PR DESCRIPTION
… never TLS 1.2.  Updated PHP native MySQL driver to connect to MySQL with ANY version of TLS (v1,v1.1,v1.2) instead of just TLS v1 only.
