### PR TITLE
Avoid triggering SIGPIPE after stream_socket_shutdown(SHUT_WR) of a SSL stream

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2467,6 +2467,16 @@ static int php_openssl_sockop_set_option(php_stream *stream, int option, int val
 					/* fall through */
 					break;
 			}
+			break;
+
+		case STREAM_XPORT_OP_SHUTDOWN:
+			if (sslsock->ssl_active && (xparam->how == STREAM_SHUT_WR || xparam->how == STREAM_SHUT_RDWR)) {
+				if (SSL_shutdown(sslsock->ssl_handle) == -1) {
+					php_stream_socket_ops.set_option(stream, option, value, ptrparam); /* ensure socket shutdown either way, but report failure */
+					return PHP_STREAM_OPTION_RETURN_ERR;
+				}
+			}
+			break;
 	}
 
 	return php_stream_socket_ops.set_option(stream, option, value, ptrparam);


### PR DESCRIPTION
Let $sock be a SSL stream, then
```php
stream_socket_shutdown($sock, STREAM_SHUT_WR);
fclose($sock);
```
shall not trigger a SIGPIPE.

SSL_shutdown() is called from within fclose() currently and will try to write to the socket, thus that function must be called before SHUT_WR.

I am not sure about the correct behavior within non-blocking I/O streams when the buffer is full. … What will happen then? Will it try to dispatch the SSL alert a second time inside the SSL_shutdown() within fclose() then?

Do I need to set `sslsock->ssl_active = 0;` here? (but won't that then break the read pipe?!)

please review - ping @bukka @DaveRandom