### PR TITLE
Fixed ZEND_STRL and ZEND_STRS macro

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -473,8 +473,8 @@ static zend_always_inline double _zend_get_nan(void) /* {{{ */
 } /* }}} */
 #define ZEND_NAN (_zend_get_nan())
 
-#define ZEND_STRL(str)		(str), (sizeof(str)-1)
-#define ZEND_STRS(str)		(str), (sizeof(str))
+#define ZEND_STRL(str)		(str), (strlen(str))
+#define ZEND_STRS(str)		(str), (strlen(str) + 1)
 #define ZEND_NORMALIZE_BOOL(n)			\
 	((n) ? (((n)>0) ? 1 : -1) : 0)
 #define ZEND_TRUTH(x)		((x) ? 1 : 0)


### PR DESCRIPTION
The use of these two macros in the source code are as follows:
```
zend_hash_str_add(ht, ZEND_STRL("modules"), &zv[7]);
zend_declare_class_constant_null(Locale_ce_ptr, ZEND_STRS("DEFAULT_LOCALE") - 1);
```

Let's take a look at the prototypes that use these two macros:
```
#define zend_hash_str_add(ht, key, len, pData) \
		_zend_hash_str_add(ht, key, len, pData ZEND_FILE_LINE_CC)
ZEND_API int zend_declare_class_constant_null(zend_class_entry *ce, const char *name, size_t name_length);
```

So we can see that sizeof(str) is to get the length of the string through the character pointer.
But that's wrong. sizeof(str) is the size of the character pointer.

This is based on the source:
https://www.gnu.org/software/libc/manual/html_node/String-Length.html

According to the description:

> "But beware, this will not work unless string is the array itself, not a pointer to it. For example:
char string[32] = "hello, world";
char *ptr = string;
sizeof (string)
    ⇒ 32
sizeof (ptr)
    ⇒ 4  /* (on a machine with 4 byte pointers) */
This is an easy mistake to make when you are working with functions that take string arguments; those arguments are always pointers, not arrays.
"

