### PR TITLE
Implement spl_object_id(object $x) : int

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,10 @@ PHP                                                                        NEWS
 - Sodium:
   . New cryptographic extension
 
+- SPL:
+  . Added spl_object_id() function returning an integer (the object handle) for an object.
+    (Tyson Andre)
+
 - SQLite3:
   . Fixed bug #74883 (SQLite3::__construct() produces "out of memory" exception
     with invalid flags). (Anatol)

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -794,6 +794,20 @@ PHP_FUNCTION(spl_object_hash)
 }
 /* }}} */
 
+/* {{{ proto int spl_object_id(object obj)
+ Returns the integer object handle for the given object */
+PHP_FUNCTION(spl_object_id)
+{
+	zval *obj;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJECT(obj)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_NULL());
+
+	RETURN_LONG((zend_long)Z_OBJ_HANDLE_P(obj));
+}
+/* }}} */
+
 PHPAPI zend_string *php_spl_object_hash(zval *obj) /* {{{*/
 {
 	intptr_t hash_handle, hash_handlers;
@@ -915,6 +929,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_object_hash, 0, 0, 1)
 	ZEND_ARG_INFO(0, obj)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_object_id, 0, 0, 1)
+	ZEND_ARG_INFO(0, obj)
+ZEND_END_ARG_INFO()
 /* }}} */
 
 /* {{{ spl_functions
@@ -931,6 +949,7 @@ const zend_function_entry spl_functions[] = {
 	PHP_FE(class_implements,        arginfo_class_implements)
 	PHP_FE(class_uses,              arginfo_class_uses)
 	PHP_FE(spl_object_hash,         arginfo_spl_object_hash)
+	PHP_FE(spl_object_id,           arginfo_spl_object_id)
 #ifdef SPL_ITERATORS_H
 	PHP_FE(iterator_to_array,       arginfo_iterator_to_array)
 	PHP_FE(iterator_count,          arginfo_iterator)

--- a/ext/spl/tests/spl_object_id.phpt
+++ b/ext/spl/tests/spl_object_id.phpt
@@ -1,0 +1,24 @@
+--TEST--
+SPL: spl_object_id()
+--FILE--
+<?php
+
+var_dump(spl_object_id(new stdClass));
+var_dump(spl_object_id(42));
+var_dump(spl_object_id());
+$a = new stdClass();
+var_dump(spl_object_id(new stdClass) === spl_object_id($a));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+int(%d)
+
+Warning: spl_object_id() expects parameter 1 to be object, integer given in %sspl_object_id.php on line %d
+NULL
+
+Warning: spl_object_id() expects exactly 1 parameter, 0 given in %sspl_object_id.php on line %d
+NULL
+bool(false)
+===DONE===


### PR DESCRIPTION
spl_object_id is a new function returning the object handle,
as a signed integer.

Discussion for this new function is ongoing on php-internals, see
https://marc.info/?t=143835274500003&r=1&w=2
(Subject: Exposing object handles to userland)

The object id is unique for the lifetime of the object.
When the object is garbage collected,
different objects may & will have the same object id.

- This is also the case for the string generated by spl_object_hash

It is always possible to cast the object handle to a **signed** zend_long
in php 7.2. _zend_object->handle is always of the type `uint32_t`.
(zend_long is 32 bits on 32 bit builds, 64 bits on 64 bit builds)

As of php 7.0, the object id uniquely identifies the object,
there can't be two objects with the same id but different handlers
(See the implementation of spl_object_hash)

Skip the pointless XORing, as discussed in internals.

- It was intended to avoid exposing in-memory addresses.
- The object handle is not a memory address.
- The output of var_dump() includes the object handle(id)

Commit a unit test of spl_object_id

Update NEWS

**EDIT: rebased for 7.2.0beta1**