### PR TITLE
Fix #74872 - Disambiguate the source of a trait alias when possible

### DIFF
--- a/Zend/tests/traits/bug55554e.phpt
+++ b/Zend/tests/traits/bug55554e.phpt
@@ -25,4 +25,4 @@ class ReportCollision {
 echo "ReportCollision: ";
 $o = new ReportCollision;
 --EXPECTF--
-Fatal error: Trait method ReportCollision has not been applied, because there are collisions with other trait methods on ReportCollision in %s on line %d
+Fatal error: Trait method TC2::ReportCollision has not been applied as ReportCollision::ReportCollision, because of collision with TC1::ReportCollision in %s on line %d

--- a/Zend/tests/traits/bug74872.phpt
+++ b/Zend/tests/traits/bug74872.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Bug #74872 (First Trait wins on importing same methods with diff alias)
+--FILE--
+<?php
+
+trait Trait1
+{
+    public function init()
+    {
+        echo("Trait1 - init\n");
+    }
+}
+
+trait Trait2
+{
+    public function init()
+    {
+        echo("Trait2 - init\n");
+    }
+}
+
+class Test
+{
+    use Trait1 {
+        init as public method1trait1;
+    }
+
+    use Trait2 {
+        init as public method1trait2;
+    }
+
+    final public function __construct()
+    {
+        $this->init();
+        $this->method1trait1();
+        $this->method1trait2();
+    }
+
+    public function init()
+    {
+        echo("Test - init\n");
+    }
+}
+
+$test = new Test();
+
+$reflection = new ReflectionClass( $test );
+
+foreach($reflection->getTraitAliases() as $k => $v)
+{
+    echo $k.' => '.$v."\n";
+}
+?>
+--EXPECT--
+Test - init
+Trait1 - init
+Trait2 - init
+method1trait1 => Trait1::init
+method1trait2 => Trait2::init

--- a/Zend/tests/traits/bugs/case-sensitive.phpt
+++ b/Zend/tests/traits/bugs/case-sensitive.phpt
@@ -20,4 +20,4 @@ class MyClass {
 }
 ?>
 --EXPECTF--
-Fatal error: Trait method M1 has not been applied, because there are collisions with other trait methods on MyClass in %s on line %d
+Fatal error: Trait method B::M1 has not been applied as MyClass::M1, because of collision with A::M1 in %s

--- a/Zend/tests/traits/conflict001.phpt
+++ b/Zend/tests/traits/conflict001.phpt
@@ -22,4 +22,4 @@ class TraitsTest {
 }
 ?>
 --EXPECTF--
-Fatal error: Trait method hello has not been applied, because there are collisions with other trait methods on TraitsTest in %s on line %d
+Fatal error: Trait method THello2::hello has not been applied as TraitsTest::hello, because of collision with THello1::hello in %s on line %d

--- a/Zend/tests/traits/conflict003.phpt
+++ b/Zend/tests/traits/conflict003.phpt
@@ -28,4 +28,4 @@ class Talker {
 
 ?>
 --EXPECTF--
-Fatal error: Trait method smallTalk has not been applied, because there are collisions with other trait methods on Talker in %s on line %d
+Fatal error: Trait method B::smallTalk has not been applied as Talker::smallTalk, because of collision with A::smallTalk in %s on line %d

--- a/Zend/tests/traits/error_011.phpt
+++ b/Zend/tests/traits/error_011.phpt
@@ -23,4 +23,4 @@ var_dump($x->test());
 
 ?>
 --EXPECTF--
-Fatal error: Trait method test has not been applied, because there are collisions with other trait methods on bar in %s on line %d
+Fatal error: Trait method c::test has not been applied as bar::test, because of collision with foo::test in %s

--- a/Zend/tests/traits/error_015.phpt
+++ b/Zend/tests/traits/error_015.phpt
@@ -23,4 +23,4 @@ var_dump($x->test());
 
 ?>
 --EXPECTF--
-Fatal error: Trait method test has not been applied, because there are collisions with other trait methods on bar in %s on line %d
+Fatal error: Trait method baz::test has not been applied as bar::test, because of collision with foo::test in %s

--- a/Zend/tests/traits/language010.phpt
+++ b/Zend/tests/traits/language010.phpt
@@ -27,4 +27,4 @@ $o->world();
 
 ?>
 --EXPECTF--
-Fatal error: Trait method world has not been applied, because there are collisions with other trait methods on MyClass in %s on line %d
+Fatal error: Trait method World::world has not been applied as MyClass::world, because of collision with Hello::hello in %s on line %d

--- a/Zend/tests/traits/language011.phpt
+++ b/Zend/tests/traits/language011.phpt
@@ -27,4 +27,4 @@ $o->sayWorld();
 
 ?>
 --EXPECTF--
-Fatal error: Trait method sayHello has not been applied, because there are collisions with other trait methods on MyClass in %s on line %d
+Fatal error: Trait method World::sayHello has not been applied as MyClass::sayHello, because of collision with Hello::sayHello in %s on line %d

--- a/Zend/tests/traits/language014.phpt
+++ b/Zend/tests/traits/language014.phpt
@@ -27,4 +27,4 @@ $o->world();
 
 ?>
 --EXPECTF--
-Fatal error: Trait method hello has not been applied, because there are collisions with other trait methods on MyClass in %s on line %d
+Fatal error: Trait method World::world has not been applied as MyClass::hello, because of collision with Hello::hello in %s on line %d

--- a/Zend/tests/traits/methods_002.phpt
+++ b/Zend/tests/traits/methods_002.phpt
@@ -25,4 +25,4 @@ var_dump(clone $o);
 
 ?>
 --EXPECTF--
-Fatal error: Trait method __clone has not been applied, because there are collisions with other trait methods on bar in %s on line %d
+Fatal error: Trait method baz::__clone has not been applied as bar::__clone, because of collision with foo::__clone in %s

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -110,6 +110,11 @@ typedef struct _zend_trait_alias {
 	* modifiers to be set on trait method
 	*/
 	uint32_t modifiers;
+
+	/**
+	* names of the traits for this alias
+	*/
+	zend_string **trait_names;
 } zend_trait_alias;
 
 struct _zend_class_entry {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6150,7 +6150,7 @@ static void zend_compile_trait_precedence(zend_ast *ast) /* {{{ */
 }
 /* }}} */
 
-static void zend_compile_trait_alias(zend_ast *ast) /* {{{ */
+static void zend_compile_trait_alias(zend_ast *ast, zend_ast *traits_ast) /* {{{ */
 {
 	zend_ast *method_ref_ast = ast->child[0];
 	zend_ast *alias_ast = ast->child[1];
@@ -6169,6 +6169,11 @@ static void zend_compile_trait_alias(zend_ast *ast) /* {{{ */
 	alias = emalloc(sizeof(zend_trait_alias));
 	alias->trait_method = zend_compile_method_ref(method_ref_ast);
 	alias->modifiers = modifiers;
+	if (!alias->trait_method->class_name) {
+		alias->trait_names = zend_compile_name_list(traits_ast);
+	} else {
+		alias->trait_names = NULL;
+	}
 
 	if (alias_ast) {
 		alias->alias = zend_string_copy(zend_ast_get_str(alias_ast));
@@ -6227,7 +6232,7 @@ void zend_compile_use_trait(zend_ast *ast) /* {{{ */
 				zend_compile_trait_precedence(adaptation_ast);
 				break;
 			case ZEND_AST_TRAIT_ALIAS:
-				zend_compile_trait_alias(adaptation_ast);
+				zend_compile_trait_alias(adaptation_ast, ast->child[0]);
 				break;
 			EMPTY_SWITCH_DEFAULT_CASE()
 		}

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1192,15 +1192,10 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, zend_s
 			return;
 		} else if (UNEXPECTED(existing_fn->common.scope->ce_flags & ZEND_ACC_TRAIT)) {
 			/* two traits can't define the same non-abstract method */
-#if 1
-			zend_error_noreturn(E_COMPILE_ERROR, "Trait method %s has not been applied, because there are collisions with other trait methods on %s",
-				name, ZSTR_VAL(ce->name));
-#else		/* TODO: better error message */
 			zend_error_noreturn(E_COMPILE_ERROR, "Trait method %s::%s has not been applied as %s::%s, because of collision with %s::%s",
 				ZSTR_VAL(fn->common.scope->name), ZSTR_VAL(fn->common.function_name),
 				ZSTR_VAL(ce->name), name,
 				ZSTR_VAL(existing_fn->common.scope->name), ZSTR_VAL(existing_fn->common.function_name));
-#endif
 		} else {
 			/* inherited members are overridden by members inserted by traits */
 			/* check whether the trait method fulfills the inheritance requirements */

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -211,6 +211,16 @@ void _destroy_zend_class_traits_info(zend_class_entry *ce)
 				zend_string_release(ce->trait_aliases[i]->alias);
 			}
 
+			if (ce->trait_aliases[i]->trait_names) {
+				size_t j = 0;
+				while (ce->trait_aliases[i]->trait_names[j]) {
+					zend_string_release(ce->trait_aliases[i]->trait_names[j]);
+					j++;
+				}
+
+				efree(ce->trait_aliases[i]->trait_names);
+			}
+
 			efree(ce->trait_aliases[i]);
 			i++;
 		}

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -425,6 +425,7 @@ static void zend_class_copy_ctor(zend_class_entry **pce)
 			memcpy(trait_aliases[i], ce->trait_aliases[i], sizeof(zend_trait_alias));
 			trait_aliases[i]->trait_method = emalloc(sizeof(zend_trait_method_reference));
 			memcpy(trait_aliases[i]->trait_method, ce->trait_aliases[i]->trait_method, sizeof(zend_trait_method_reference));
+			trait_aliases[i]->trait_names = ce->trait_aliases[i]->trait_names;
 			i++;
 		}
 		trait_aliases[i] = NULL;

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -644,6 +644,19 @@ static void zend_file_cache_serialize_class(zval                     *zv,
 				}
 			}
 
+			if (q->trait_names) {
+				zend_string **r;
+
+				SERIALIZE_PTR(q->trait_names);
+				r = q->trait_names;
+				UNSERIALIZE_PTR(r);
+
+				while (*r) {
+					SERIALIZE_STR(*r);
+					r++;
+				}
+			}
+
 			if (q->alias) {
 				SERIALIZE_STR(q->alias);
 			}
@@ -1275,6 +1288,18 @@ static void zend_file_cache_unserialize_class(zval                    *zv,
 				}
 				if (m->class_name) {
 					UNSERIALIZE_STR(m->class_name);
+				}
+			}
+
+			if (q->trait_names) {
+				zend_string **r;
+
+				UNSERIALIZE_PTR(q->trait_names);
+				r = q->trait_names;
+
+				while (*r) {
+					UNSERIALIZE_STR(*r);
+					r++;
 				}
 			}
 

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -742,6 +742,14 @@ static void zend_persist_class_entry(zval *zv)
 						sizeof(zend_trait_method_reference));
 				}
 
+				if (ce->trait_aliases[i]->trait_names) {
+					int j = 0;
+					while (ce->trait_aliases[i]->trait_names[j]) {
+						zend_accel_store_interned_string(ce->trait_aliases[i]->trait_names[j]);
+						j++;
+					}
+				}
+
 				if (ce->trait_aliases[i]->alias) {
 					zend_accel_store_interned_string(ce->trait_aliases[i]->alias);
 				}

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -356,6 +356,14 @@ static void zend_persist_class_entry_calc(zval *zv)
 					ADD_SIZE(sizeof(zend_trait_method_reference));
 				}
 
+				if (ce->trait_aliases[i]->trait_names) {
+					int j = 0;
+					while (ce->trait_aliases[i]->trait_names[j]) {
+						ADD_INTERNED_STRING(ce->trait_aliases[i]->trait_names[j], 0);
+						j++;
+					}
+				}
+
 				if (ce->trait_aliases[i]->alias) {
 					ADD_INTERNED_STRING(ce->trait_aliases[i]->alias, 0);
 				}


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=74872

Cases where two traits with a duplicate method name are added in the same use block will still be ambiguous.