### PR TITLE
Implement Countable for DomNodeList and DOMNamedNodeMap (Request #74837)

### DIFF
--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -172,6 +172,7 @@ PHP_METHOD(domnode, getLineNo);
 
 /* domnodelist methods */
 PHP_FUNCTION(dom_nodelist_item);
+PHP_FUNCTION(dom_nodelist_count);
 
 /* domnamednodemap methods */
 PHP_FUNCTION(dom_namednodemap_get_named_item);
@@ -181,6 +182,7 @@ PHP_FUNCTION(dom_namednodemap_item);
 PHP_FUNCTION(dom_namednodemap_get_named_item_ns);
 PHP_FUNCTION(dom_namednodemap_set_named_item_ns);
 PHP_FUNCTION(dom_namednodemap_remove_named_item_ns);
+PHP_FUNCTION(dom_namednodemap_count);
 
 /* domcharacterdata methods */
 PHP_FUNCTION(dom_characterdata_substring_data);

--- a/ext/dom/namednodemap.c
+++ b/ext/dom/namednodemap.c
@@ -342,18 +342,15 @@ PHP_FUNCTION(dom_namednodemap_count)
 {
 	zval *id;
 	dom_object *intern;
-	zval *count;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &id, dom_namednodemap_class_entry) == FAILURE) {
 		return;
 	}
 
 	intern = Z_DOMOBJ_P(id);
-	if(dom_namednodemap_length_read(intern, &count)) {
+	if(dom_namednodemap_length_read(intern, return_value) == FAILURE) {
 		RETURN_FALSE;
 	}
-
-	RETURN_LONG(count);
 }
 /* }}} end dom_namednodemap_count */
 

--- a/ext/dom/namednodemap.c
+++ b/ext/dom/namednodemap.c
@@ -57,6 +57,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_namednodemap_remove_named_item_ns, 0, 0, 0)
 	ZEND_ARG_INFO(0, namespaceURI)
 	ZEND_ARG_INFO(0, localName)
 ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_namednodemap_count, 0, 0, 0)
+ZEND_END_ARG_INFO();
 /* }}} */
 
 /*
@@ -74,6 +77,7 @@ const zend_function_entry php_dom_namednodemap_class_functions[] = { /* {{{ */
 	PHP_FALIAS(getNamedItemNS, dom_namednodemap_get_named_item_ns, arginfo_dom_namednodemap_get_named_item_ns)
 	PHP_FALIAS(setNamedItemNS, dom_namednodemap_set_named_item_ns, arginfo_dom_namednodemap_set_named_item_ns)
 	PHP_FALIAS(removeNamedItemNS, dom_namednodemap_remove_named_item_ns, arginfo_dom_namednodemap_remove_named_item_ns)
+	PHP_FALIAS(count, dom_namednodemap_count, arginfo_dom_namednodemap_count)
 	PHP_FE_END
 };
 /* }}} */
@@ -331,6 +335,27 @@ PHP_FUNCTION(dom_namednodemap_remove_named_item_ns)
  DOM_NOT_IMPLEMENTED();
 }
 /* }}} end dom_namednodemap_remove_named_item_ns */
+
+/* {{{ proto int|bool dom_namednodemap_count();
+*/
+PHP_FUNCTION(dom_namednodemap_count)
+{
+	zval *id;
+	dom_object *intern;
+	zval *count;
+
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &id, dom_namednodemap_class_entry) == FAILURE) {
+		return;
+	}
+
+	intern = Z_DOMOBJ_P(id);
+	if(dom_namednodemap_length_read(intern, &count)) {
+		RETURN_FALSE;
+	}
+
+	RETURN_LONG(count);
+}
+/* }}} end dom_namednodemap_count */
 
 #endif
 

--- a/ext/dom/nodelist.c
+++ b/ext/dom/nodelist.c
@@ -110,17 +110,15 @@ PHP_FUNCTION(dom_nodelist_count)
 {
 	zval *id;
 	dom_object *intern;
-	zval *count;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &id, dom_nodelist_class_entry) == FAILURE) {
 		return;
 	}
 
 	intern = Z_DOMOBJ_P(id);
-	if(dom_nodelist_length_read(intern, &count)) {
+	if(dom_nodelist_length_read(intern, return_value) == FAILURE) {
 		RETURN_FALSE;
 	}
-	RETURN_LONG(count);
 }
 /* }}} end dom_nodelist_count */
 

--- a/ext/dom/nodelist.c
+++ b/ext/dom/nodelist.c
@@ -34,6 +34,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_nodelist_item, 0, 0, 1)
 ZEND_END_ARG_INFO();
 /* }}} */
 
+/* {{{ arginfo */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_nodelist_count, 0, 0, 0)
+ZEND_END_ARG_INFO();
+/* }}} */
+
 /*
 * class DOMNodeList
 *
@@ -43,8 +48,10 @@ ZEND_END_ARG_INFO();
 
 const zend_function_entry php_dom_nodelist_class_functions[] = {
 	PHP_FALIAS(item, dom_nodelist_item, arginfo_dom_nodelist_item)
+	PHP_FALIAS(count, dom_nodelist_count, arginfo_dom_nodelist_count)
 	PHP_FE_END
 };
+
 
 /* {{{ length	int
 readonly=yes
@@ -95,6 +102,27 @@ int dom_nodelist_length_read(dom_object *obj, zval *retval)
 	ZVAL_LONG(retval, count);
 	return SUCCESS;
 }
+
+
+/* {{{ proto int|bool dom_nodelist_count();
+*/
+PHP_FUNCTION(dom_nodelist_count)
+{
+	zval *id;
+	dom_object *intern;
+	zval *count;
+
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &id, dom_nodelist_class_entry) == FAILURE) {
+		return;
+	}
+
+	intern = Z_DOMOBJ_P(id);
+	if(dom_nodelist_length_read(intern, &count)) {
+		RETURN_FALSE;
+	}
+	RETURN_LONG(count);
+}
+/* }}} end dom_nodelist_count */
 
 /* }}} */
 
@@ -169,6 +197,7 @@ PHP_FUNCTION(dom_nodelist_item)
 	RETVAL_NULL();
 }
 /* }}} end dom_nodelist_item */
+
 
 #endif
 

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -706,8 +706,7 @@ PHP_MINIT_FUNCTION(dom)
 	ce.create_object = dom_nnodemap_objects_new;
 	dom_nodelist_class_entry = zend_register_internal_class_ex(&ce, NULL);
 	dom_nodelist_class_entry->get_iterator = php_dom_get_iterator;
-	zend_class_implements(dom_nodelist_class_entry, 1, zend_ce_traversable);
-	zend_class_implements(dom_nodelist_class_entry, 1, zend_ce_countable);
+	zend_class_implements(dom_nodelist_class_entry, 2, zend_ce_traversable, zend_ce_countable);
 
 	zend_hash_init(&dom_nodelist_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
 	dom_register_prop_handler(&dom_nodelist_prop_handlers, "length", sizeof("length")-1, dom_nodelist_length_read, NULL);
@@ -717,8 +716,7 @@ PHP_MINIT_FUNCTION(dom)
 	ce.create_object = dom_nnodemap_objects_new;
 	dom_namednodemap_class_entry = zend_register_internal_class_ex(&ce, NULL);
 	dom_namednodemap_class_entry->get_iterator = php_dom_get_iterator;
-	zend_class_implements(dom_namednodemap_class_entry, 1, zend_ce_traversable);
-	zend_class_implements(dom_namednodemap_class_entry, 1, zend_ce_countable);
+	zend_class_implements(dom_namednodemap_class_entry, 2, zend_ce_traversable, zend_ce_countable);
 
 	zend_hash_init(&dom_namednodemap_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
 	dom_register_prop_handler(&dom_namednodemap_prop_handlers, "length", sizeof("length")-1, dom_namednodemap_length_read, NULL);

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -707,6 +707,7 @@ PHP_MINIT_FUNCTION(dom)
 	dom_nodelist_class_entry = zend_register_internal_class_ex(&ce, NULL);
 	dom_nodelist_class_entry->get_iterator = php_dom_get_iterator;
 	zend_class_implements(dom_nodelist_class_entry, 1, zend_ce_traversable);
+	zend_class_implements(dom_nodelist_class_entry, 1, zend_ce_countable);
 
 	zend_hash_init(&dom_nodelist_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
 	dom_register_prop_handler(&dom_nodelist_prop_handlers, "length", sizeof("length")-1, dom_nodelist_length_read, NULL);
@@ -717,6 +718,7 @@ PHP_MINIT_FUNCTION(dom)
 	dom_namednodemap_class_entry = zend_register_internal_class_ex(&ce, NULL);
 	dom_namednodemap_class_entry->get_iterator = php_dom_get_iterator;
 	zend_class_implements(dom_namednodemap_class_entry, 1, zend_ce_traversable);
+	zend_class_implements(dom_namednodemap_class_entry, 1, zend_ce_countable);
 
 	zend_hash_init(&dom_namednodemap_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
 	dom_register_prop_handler(&dom_namednodemap_prop_handlers, "length", sizeof("length")-1, dom_namednodemap_length_read, NULL);

--- a/ext/dom/tests/DOMNamedNodeMap_count.phpt
+++ b/ext/dom/tests/DOMNamedNodeMap_count.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test count nodes in DOMNamedNodeMap
+--CREDITS--
+Andreas Treichel <gmblar+github@gmail.com>
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$document = new DomDocument();
+$root = $document->createElement('root');
+$document->appendChild($root);
+for($i = 0; $i < 5; $i++) {
+    $root->setAttribute('attribute-' . $i, 'value-' . $i);
+}
+for($i = 0; $i < 7; $i++) {
+    $item = $document->createElement('item');
+    $root->appendChild($item);
+}
+var_dump($root->attributes->length);
+var_dump($root->attributes->count());
+var_dump(count($root->attributes));
+
+?>
+--EXPECTF--
+int(5)
+int(5)
+int(5)

--- a/ext/dom/tests/DomNodeList_count.phpt
+++ b/ext/dom/tests/DomNodeList_count.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test count nodes in DOMNodeList
+--CREDITS--
+Andreas Treichel <gmblar+github@gmail.com>
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$document = new DomDocument();
+$root = $document->createElement('root');
+$document->appendChild($root);
+for($i = 0; $i < 5; $i++) {
+    $root->setAttribute('attribute-' . $i, 'value-' . $i);
+}
+for($i = 0; $i < 7; $i++) {
+    $item = $document->createElement('item');
+    $root->appendChild($item);
+}
+var_dump($root->childNodes->length);
+var_dump($root->childNodes->count());
+var_dump(count($root->childNodes));
+
+?>
+--EXPECTF--
+int(7)
+int(7)
+int(7)


### PR DESCRIPTION
Implement the Interface Countable for DomNodeList and DOMNamedNodeMap (Request #74837)

    $document = new DomDocument();
    $root = $document->createElement('root');
    $document->appendChild($root);
    for($i = 0; $i < 5; $i++) {
        $root->setAttribute('attribute-' . $i, 'value-' . $i);
    }
    for($i = 0; $i < 7; $i++) {
        $item = $document->createElement('item');
        $root->appendChild($item);
    }

    // Count childnodes
    var_dump(count($root->childNodes));
    var_dump($root->childNodes->count());
    var_dump($root->childNodes->length);

    // Count attributes
    var_dump(count($root->attributes));
    var_dump($root->attributes->count());
    var_dump($root->attributes->length);

Does this require a RFC?