### PR TITLE
fix #74852 property_exists returns true on unknown DateInterval property

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1986,7 +1986,7 @@ static int date_interval_has_property(zval *object, zval *member, int type, void
 	zval *prop;
 	int retval = 0;
 
-	if (Z_TYPE_P(member) != IS_STRING) {
+	if (UNEXPECTED(Z_TYPE_P(member) != IS_STRING)) {
 		ZVAL_COPY(&tmp_member, member);
 		convert_to_string(&tmp_member);
 		member = &tmp_member;
@@ -2002,10 +2002,10 @@ static int date_interval_has_property(zval *object, zval *member, int type, void
 		}
 		return retval;
 	}
-
-	prop = date_interval_read_property(object, member, type, cache_slot, &rv);
-
-	if (prop != NULL) {
+	
+	prop = date_interval_read_property(object, member, BP_VAR_IS, cache_slot, &rv);
+	
+	if (prop != &EG(uninitialized_zval)) {
 		if (type == 2) {
 			retval = 1;
 		} else if (type == 1) {

--- a/ext/date/tests/bug74852.phpt
+++ b/ext/date/tests/bug74852.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #74852 property_exists returns true on unknown DateInterval property
+--FILE--
+<?php
+
+$interval = new DateInterval('P2D');
+var_dump(property_exists($interval,'abcde'));
+var_dump(isset($interval->abcde));
+var_dump($interval->abcde);
+
+?>
+--EXPECTF--
+bool(false)
+bool(false)
+
+Notice: Undefined property: DateInterval::$abcde in %s on line %d
+NULL


### PR DESCRIPTION
fix [bug #74852](https://bugs.php.net/bug.php?id=74852)