### PR TITLE
Stabilize 73594 tests

### DIFF
--- a/ext/standard/tests/network/bug73594.phpt
+++ b/ext/standard/tests/network/bug73594.phpt
@@ -19,8 +19,9 @@ if (empty($out)) die("skip local resolver does not return additional records");
 <?php
 $auth = array();
 $additional = array();
-dns_get_record('php.net', DNS_MX, $auth, $additional);
-var_dump(empty($additional));
+$res = dns_get_record('php.net', DNS_MX, $auth, $additional);
+// only check $additional if dns_get_record is successful
+var_dump(!empty($res) && empty($additional));
 ?>
 --EXPECT--
 bool(false)

--- a/ext/standard/tests/network/bug73594a.phpt
+++ b/ext/standard/tests/network/bug73594a.phpt
@@ -18,8 +18,9 @@ if (empty($out)) die("skip local resolver does not return authority records");
 --FILE--
 <?php
 $auth = array();
-dns_get_record('php.net', DNS_MX, $auth);
-var_dump(empty($auth));
+$res = dns_get_record('php.net', DNS_MX, $auth);
+// only check $auth if dns_get_record is successful
+var_dump(!empty($res) && empty($auth));
 ?>
 --EXPECT--
 bool(false)


### PR DESCRIPTION
Currently, these tests fail if the extra parameters are not populated, however, it is never checked if the dns_get_record call was actually successful.

Unfortunately, doing the same check in the SKIP section won't guarantee that during the actual test the call will succeed.