### PR TITLE
Set default ftp mode to binary

### DIFF
--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -816,7 +816,7 @@ PHP_FUNCTION(ftp_systype)
 }
 /* }}} */
 
-/* {{{ proto bool ftp_fget(resource stream, resource fp, string remote_file, int mode[, int resumepos])
+/* {{{ proto bool ftp_fget(resource stream, resource fp, string remote_file, [, int mode [, int resumepos]])
    Retrieves a file from the FTP server and writes it to an open file */
 PHP_FUNCTION(ftp_fget)
 {
@@ -826,9 +826,9 @@ PHP_FUNCTION(ftp_fget)
 	php_stream	*stream;
 	char		*file;
 	size_t		file_len;
-	zend_long		mode, resumepos=0;
+	zend_long		mode=FTPTYPE_IMAGE, resumepos=0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rrsl|l", &z_ftp, &z_file, &file, &file_len, &mode, &resumepos) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rrs|ll", &z_ftp, &z_file, &file, &file_len, &mode, &resumepos) == FAILURE) {
 		return;
 	}
 
@@ -862,7 +862,7 @@ PHP_FUNCTION(ftp_fget)
 }
 /* }}} */
 
-/* {{{ proto int ftp_nb_fget(resource stream, resource fp, string remote_file, int mode[, int resumepos])
+/* {{{ proto int ftp_nb_fget(resource stream, resource fp, string remote_file [, int mode [, int resumepos]])
    Retrieves a file from the FTP server asynchronly and writes it to an open file */
 PHP_FUNCTION(ftp_nb_fget)
 {
@@ -872,9 +872,9 @@ PHP_FUNCTION(ftp_nb_fget)
 	php_stream	*stream;
 	char		*file;
 	size_t		file_len;
-	zend_long		mode, resumepos=0, ret;
+	zend_long		mode=FTPTYPE_IMAGE, resumepos=0, ret;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rrsl|l", &z_ftp, &z_file, &file, &file_len, &mode, &resumepos) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rrs|ll", &z_ftp, &z_file, &file, &file_len, &mode, &resumepos) == FAILURE) {
 		return;
 	}
 
@@ -936,7 +936,7 @@ PHP_FUNCTION(ftp_pasv)
 }
 /* }}} */
 
-/* {{{ proto bool ftp_get(resource stream, string local_file, string remote_file, int mode[, int resume_pos])
+/* {{{ proto bool ftp_get(resource stream, string local_file, string remote_file [, int mode [, int resume_pos]])
    Retrieves a file from the FTP server and writes it to a local file */
 PHP_FUNCTION(ftp_get)
 {
@@ -946,9 +946,9 @@ PHP_FUNCTION(ftp_get)
 	php_stream	*outstream;
 	char		*local, *remote;
 	size_t		local_len, remote_len;
-	zend_long		mode, resumepos=0;
+	zend_long		mode=FTPTYPE_IMAGE, resumepos=0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rppl|l", &z_ftp, &local, &local_len, &remote, &remote_len, &mode, &resumepos) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rpp|ll", &z_ftp, &local, &local_len, &remote, &remote_len, &mode, &resumepos) == FAILURE) {
 		return;
 	}
 
@@ -1001,7 +1001,7 @@ PHP_FUNCTION(ftp_get)
 }
 /* }}} */
 
-/* {{{ proto int ftp_nb_get(resource stream, string local_file, string remote_file, int mode[, int resume_pos])
+/* {{{ proto int ftp_nb_get(resource stream, string local_file, string remote_file, [, int mode [, int resume_pos]])
    Retrieves a file from the FTP server nbhronly and writes it to a local file */
 PHP_FUNCTION(ftp_nb_get)
 {
@@ -1012,9 +1012,9 @@ PHP_FUNCTION(ftp_nb_get)
 	char		*local, *remote;
 	size_t		local_len, remote_len;
 	int ret;
-	zend_long		mode, resumepos=0;
+	zend_long		mode=FTPTYPE_IMAGE, resumepos=0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rssl|l", &z_ftp, &local, &local_len, &remote, &remote_len, &mode, &resumepos) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss|ll", &z_ftp, &local, &local_len, &remote, &remote_len, &mode, &resumepos) == FAILURE) {
 		return;
 	}
 
@@ -1114,7 +1114,7 @@ PHP_FUNCTION(ftp_nb_continue)
 }
 /* }}} */
 
-/* {{{ proto bool ftp_fput(resource stream, string remote_file, resource fp, int mode[, int startpos])
+/* {{{ proto bool ftp_fput(resource stream, string remote_file, resource fp [, int mode [, int startpos]])
    Stores a file from an open file to the FTP server */
 PHP_FUNCTION(ftp_fput)
 {
@@ -1122,11 +1122,11 @@ PHP_FUNCTION(ftp_fput)
 	ftpbuf_t	*ftp;
 	ftptype_t	xtype;
 	size_t		remote_len;
-	zend_long		mode, startpos=0;
+	zend_long		mode=FTPTYPE_IMAGE, startpos=0;
 	php_stream	*stream;
 	char		*remote;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsrl|l", &z_ftp, &remote, &remote_len, &z_file, &mode, &startpos) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsr|ll", &z_ftp, &remote, &remote_len, &z_file, &mode, &startpos) == FAILURE) {
 		return;
 	}
 
@@ -1163,7 +1163,7 @@ PHP_FUNCTION(ftp_fput)
 }
 /* }}} */
 
-/* {{{ proto int ftp_nb_fput(resource stream, string remote_file, resource fp, int mode[, int startpos])
+/* {{{ proto int ftp_nb_fput(resource stream, string remote_file, resource fp [, int mode [, int startpos]])
    Stores a file from an open file to the FTP server nbronly */
 PHP_FUNCTION(ftp_nb_fput)
 {
@@ -1172,11 +1172,11 @@ PHP_FUNCTION(ftp_nb_fput)
 	ftptype_t	xtype;
 	size_t		remote_len;
 	int             ret;
-	zend_long	mode, startpos=0;
+	zend_long	mode=FTPTYPE_IMAGE, startpos=0;
 	php_stream	*stream;
 	char		*remote;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsrl|l", &z_ftp, &remote, &remote_len, &z_file, &mode, &startpos) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsr|ll", &z_ftp, &remote, &remote_len, &z_file, &mode, &startpos) == FAILURE) {
 		return;
 	}
 
@@ -1218,7 +1218,7 @@ PHP_FUNCTION(ftp_nb_fput)
 /* }}} */
 
 
-/* {{{ proto bool ftp_put(resource stream, string remote_file, string local_file, int mode[, int startpos])
+/* {{{ proto bool ftp_put(resource stream, string remote_file, string local_file [, int mode [, int startpos]])
    Stores a file on the FTP server */
 PHP_FUNCTION(ftp_put)
 {
@@ -1227,10 +1227,10 @@ PHP_FUNCTION(ftp_put)
 	ftptype_t	xtype;
 	char		*remote, *local;
 	size_t		remote_len, local_len;
-	zend_long		mode, startpos=0;
+	zend_long		mode=FTPTYPE_IMAGE, startpos=0;
 	php_stream 	*instream;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rppl|l", &z_ftp, &remote, &remote_len, &local, &local_len, &mode, &startpos) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rpp|ll", &z_ftp, &remote, &remote_len, &local, &local_len, &mode, &startpos) == FAILURE) {
 		return;
 	}
 
@@ -1273,7 +1273,7 @@ PHP_FUNCTION(ftp_put)
 /* }}} */
 
 
-/* {{{ proto int ftp_nb_put(resource stream, string remote_file, string local_file, int mode[, int startpos])
+/* {{{ proto int ftp_nb_put(resource stream, string remote_file, string local_file [, int mode [, int startpos]])
    Stores a file on the FTP server */
 PHP_FUNCTION(ftp_nb_put)
 {
@@ -1282,10 +1282,10 @@ PHP_FUNCTION(ftp_nb_put)
 	ftptype_t	xtype;
 	char		*remote, *local;
 	size_t		remote_len, local_len;
-	zend_long		mode, startpos=0, ret;
+	zend_long		mode=FTPTYPE_IMAGE, startpos=0, ret;
 	php_stream 	*instream;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rppl|l", &z_ftp, &remote, &remote_len, &local, &local_len, &mode, &startpos) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rpp|ll", &z_ftp, &remote, &remote_len, &local, &local_len, &mode, &startpos) == FAILURE) {
 		return;
 	}
 

--- a/ext/ftp/tests/004.phpt
+++ b/ext/ftp/tests/004.phpt
@@ -20,7 +20,6 @@ var_dump(ftp_alloc($ftp, array()));
 var_dump(ftp_cdup($ftp, 0));
 var_dump(ftp_chdir($ftp, array()));
 var_dump(ftp_chmod($ftp, 0666));
-var_dump(ftp_get($ftp, 1234,12));
 var_dump(ftp_close());
 var_dump(ftp_connect('sfjkfjaksfjkasjf'));
 var_dump(ftp_delete($ftp, array()));
@@ -50,30 +49,27 @@ NULL
 Warning: ftp_chmod() expects exactly 3 parameters, 2 given in %s on line %d
 bool(false)
 
-Warning: ftp_get() expects at least 4 parameters, 3 given in %s on line %d
+Warning: ftp_close() expects exactly 1 parameter, 0 given in %s004.php on line 16
 NULL
 
-Warning: ftp_close() expects exactly 1 parameter, 0 given in %s004.php on line 17
-NULL
-
-Warning: ftp_connect(): php_network_getaddresses: getaddrinfo failed: %s in %s004.php on line 18
+Warning: ftp_connect(): php_network_getaddresses: getaddrinfo failed: %s in %s004.php on line 17
 bool(false)
 
-Warning: ftp_delete() expects parameter 2 to be string, array given in %s004.php on line 19
+Warning: ftp_delete() expects parameter 2 to be string, array given in %s004.php on line 18
 NULL
 
-Warning: ftp_exec() expects parameter 2 to be string, array given in %s004.php on line 20
+Warning: ftp_exec() expects parameter 2 to be string, array given in %s004.php on line 19
 NULL
 
-Warning: ftp_systype() expects exactly 1 parameter, 2 given in %s004.php on line 22
+Warning: ftp_systype() expects exactly 1 parameter, 2 given in %s004.php on line 21
 NULL
 
-Warning: ftp_pwd() expects exactly 1 parameter, 2 given in %s004.php on line 23
+Warning: ftp_pwd() expects exactly 1 parameter, 2 given in %s004.php on line 22
 NULL
 
-Warning: ftp_login() expects exactly 3 parameters, 1 given in %s004.php on line 25
+Warning: ftp_login() expects exactly 3 parameters, 1 given in %s004.php on line 24
 NULL
 
-Warning: ftp_login(): Not logged in. in %s004.php on line 26
+Warning: ftp_login(): Not logged in. in %s004.php on line 25
 bool(false)
 bool(true)

--- a/ext/ftp/tests/006.phpt
+++ b/ext/ftp/tests/006.phpt
@@ -55,13 +55,13 @@ NULL
 Warning: ftp_rawlist() expects at least 2 parameters, 1 given in %s006.php on line 10
 NULL
 
-Warning: ftp_fget() expects at least 4 parameters, 1 given in %s006.php on line 11
+Warning: ftp_fget() expects at least 3 parameters, 1 given in %s006.php on line 11
 NULL
 
-Warning: ftp_nb_fget() expects at least 4 parameters, 1 given in %s006.php on line 12
+Warning: ftp_nb_fget() expects at least 3 parameters, 1 given in %s006.php on line 12
 NULL
 
-Warning: ftp_nb_get() expects at least 4 parameters, 1 given in %s006.php on line 13
+Warning: ftp_nb_get() expects at least 3 parameters, 1 given in %s006.php on line 13
 NULL
 
 Warning: ftp_pasv() expects exactly 2 parameters, 1 given in %s006.php on line 14
@@ -70,16 +70,16 @@ NULL
 Warning: ftp_nb_continue() expects exactly 1 parameter, 0 given in %s006.php on line 15
 NULL
 
-Warning: ftp_fput() expects at least 4 parameters, 0 given in %s006.php on line 16
+Warning: ftp_fput() expects at least 3 parameters, 0 given in %s006.php on line 16
 NULL
 
-Warning: ftp_nb_fput() expects at least 4 parameters, 1 given in %s006.php on line 17
+Warning: ftp_nb_fput() expects at least 3 parameters, 1 given in %s006.php on line 17
 NULL
 
-Warning: ftp_put() expects at least 4 parameters, 1 given in %s006.php on line 18
+Warning: ftp_put() expects at least 3 parameters, 1 given in %s006.php on line 18
 NULL
 
-Warning: ftp_nb_put() expects at least 4 parameters, 1 given in %s006.php on line 19
+Warning: ftp_nb_put() expects at least 3 parameters, 1 given in %s006.php on line 19
 NULL
 
 Warning: ftp_size() expects exactly 2 parameters, 1 given in %s006.php on line 20


### PR DESCRIPTION
Set default $mode to binary (FTP_BINARY or FTP_IMAGE) because unmodified contents of a transfered file is a sane default behavior. This change set the $mode argument of following functions to optional:

* bool ftp_get(resource stream, string local_file, string remote_file [, int mode [, int resume_pos]])
* bool ftp_put(resource stream, string remote_file, string local_file [, int mode [, int startpos]])
* bool ftp_fget(resource stream, resource fp, string remote_file, [, int mode [, int resumepos]])
* bool ftp_fput(resource stream, string remote_file, resource fp [, int mode [, int startpos]])
* int ftp_nb_get(resource stream, string local_file, string remote_file, [, int mode [, int resume_pos]])
* int ftp_nb_put(resource stream, string remote_file, string local_file [, int mode [, int startpos]])
* int ftp_nb_fget(resource stream, resource fp, string remote_file [, int mode [, int resumepos]])
* int ftp_nb_fput(resource stream, string remote_file, resource fp [, int mode [, int startpos]])

The change should have no impact on existing code.