### PR TITLE
sodium extension: remove function names before exception messages

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -501,7 +501,7 @@ PHP_FUNCTION(sodium_memzero)
 	}
 	ZVAL_DEREF(buf_zv);
 	if (Z_TYPE_P(buf_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "memzero: a PHP string is required", 0);
+		zend_throw_exception(sodium_exception_ce, "a PHP string is required", 0);
 		return;
 	}
 	if (Z_REFCOUNTED_P(buf_zv) && Z_REFCOUNT_P(buf_zv) == 1) {
@@ -528,7 +528,7 @@ PHP_FUNCTION(sodium_increment)
 	}
 	ZVAL_DEREF(val_zv);
 	if (Z_TYPE_P(val_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "increment(): a PHP string is required", 0);
+		zend_throw_exception(sodium_exception_ce, "a PHP string is required", 0);
 		return;
 	}
 
@@ -559,7 +559,7 @@ PHP_FUNCTION(sodium_add)
 	}
 	ZVAL_DEREF(val_zv);
 	if (Z_TYPE_P(val_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "add(): PHP strings are required", 0);
+		zend_throw_exception(sodium_exception_ce, "PHP strings are required", 0);
 		return;
 	}
 
@@ -567,7 +567,7 @@ PHP_FUNCTION(sodium_add)
 	val = (unsigned char *) Z_STRVAL(*val_zv);
 	val_len = Z_STRLEN(*val_zv);
 	if (val_len != addv_len) {
-		zend_throw_exception(sodium_exception_ce, "add(): values must have the same length", 0);
+		zend_throw_exception(sodium_exception_ce, "values must have the same length", 0);
 		return;
 	}
 	c = 0U;
@@ -591,7 +591,7 @@ PHP_FUNCTION(sodium_memcmp)
 		return;
 	}
 	if (len1 != len2) {
-		zend_throw_exception(sodium_exception_ce, "memcmp(): arguments have different sizes", 0);
+		zend_throw_exception(sodium_exception_ce, "arguments have different sizes", 0);
 	} else {
 		RETURN_LONG(sodium_memcmp(buf1, buf2, len1));
 	}
@@ -612,8 +612,7 @@ PHP_FUNCTION(sodium_crypto_shorthash)
 	}
 	if (key_len != crypto_shorthash_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_shorthash(): key size should be "
-				   "CRYPTO_SHORTHASH_KEYBYTES bytes",
+				   "key size should be CRYPTO_SHORTHASH_KEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -621,7 +620,7 @@ PHP_FUNCTION(sodium_crypto_shorthash)
 	if (crypto_shorthash((unsigned char *) ZSTR_VAL(hash), msg,
 						 (unsigned long long) msg_len, key) != 0) {
 		zend_string_free(hash);
-		zend_throw_exception(sodium_exception_ce, "crypto_shorthash(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(hash)[crypto_shorthash_BYTES] = 0;
@@ -647,15 +646,13 @@ PHP_FUNCTION(sodium_crypto_secretbox)
 	}
 	if (nonce_len != crypto_secretbox_NONCEBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_secretbox(): nonce size should be "
-				   "CRYPTO_SECRETBOX_NONCEBYTES bytes",
+				   "nonce size should be CRYPTO_SECRETBOX_NONCEBYTES bytes",
 				   0);
 		return;
 	}
 	if (key_len != crypto_secretbox_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_secretbox(): key size should be "
-				   "CRYPTO_SECRETBOX_KEYBYTES bytes",
+				   "key size should be CRYPTO_SECRETBOX_KEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -668,7 +665,7 @@ PHP_FUNCTION(sodium_crypto_secretbox)
 							  msg, (unsigned long long) msg_len,
 							  nonce, key) != 0) {
 		zend_string_free(ciphertext);
-		zend_throw_exception(sodium_exception_ce, "crypto_secretbox(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(ciphertext)[msg_len + crypto_secretbox_MACBYTES] = 0;
@@ -694,15 +691,13 @@ PHP_FUNCTION(sodium_crypto_secretbox_open)
 	}
 	if (nonce_len != crypto_secretbox_NONCEBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_secretbox_open(): nonce size should be "
-				   "CRYPTO_SECRETBOX_NONCEBYTES bytes",
+				   "nonce size should be CRYPTO_SECRETBOX_NONCEBYTES bytes",
 				   0);
 		return;
 	}
 	if (key_len != crypto_secretbox_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_secretbox_open(): key size should be "
-				   "CRYPTO_SECRETBOX_KEYBYTES bytes",
+				   "key size should be CRYPTO_SECRETBOX_KEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -739,13 +734,13 @@ PHP_FUNCTION(sodium_crypto_generichash)
 	}
 	if (hash_len < crypto_generichash_BYTES_MIN ||
 		hash_len > crypto_generichash_BYTES_MAX) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash(): unsupported output length", 0);
+		zend_throw_exception(sodium_exception_ce, "unsupported output length", 0);
 		return;
 	}
 	if (key_len != 0 &&
 		(key_len < crypto_generichash_KEYBYTES_MIN ||
 		 key_len > crypto_generichash_KEYBYTES_MAX)) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash(): unsupported key length", 0);
+		zend_throw_exception(sodium_exception_ce, "unsupported key length", 0);
 		return;
 	}
 	hash = zend_string_alloc(hash_len, 0);
@@ -753,7 +748,7 @@ PHP_FUNCTION(sodium_crypto_generichash)
 						   msg, (unsigned long long) msg_len,
 						   key, (size_t) key_len) != 0) {
 		zend_string_free(hash);
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(hash)[hash_len] = 0;
@@ -777,18 +772,18 @@ PHP_FUNCTION(sodium_crypto_generichash_init)
 	}
 	if (hash_len < crypto_generichash_BYTES_MIN ||
 		hash_len > crypto_generichash_BYTES_MAX) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_init(): unsupported output length", 0);
+		zend_throw_exception(sodium_exception_ce, "unsupported output length", 0);
 		return;
 	}
 	if (key_len != 0 &&
 		(key_len < crypto_generichash_KEYBYTES_MIN ||
 		 key_len > crypto_generichash_KEYBYTES_MAX)) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_init(): unsupported key length", 0);
+		zend_throw_exception(sodium_exception_ce, "unsupported key length", 0);
 		return;
 	}
 	if (crypto_generichash_init((void *) &state_tmp, key, (size_t) key_len,
 								(size_t) hash_len) != 0) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_init(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	state = zend_string_alloc(state_len, 0);
@@ -814,20 +809,20 @@ PHP_FUNCTION(sodium_crypto_generichash_update)
 	}
 	ZVAL_DEREF(state_zv);
 	if (Z_TYPE_P(state_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_update: a reference to a state is required", 0);
+		zend_throw_exception(sodium_exception_ce, "a reference to a state is required", 0);
 		return;
 	}
 	sodium_separate_string(state_zv);
 	state = (unsigned char *) Z_STRVAL(*state_zv);
 	state_len = Z_STRLEN(*state_zv);
 	if (state_len != sizeof (crypto_generichash_state)) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_update(): incorrect state length", 0);
+		zend_throw_exception(sodium_exception_ce, "incorrect state length", 0);
 		return;
 	}
 	memcpy(&state_tmp, state, sizeof state_tmp);
 	if (crypto_generichash_update((void *) &state_tmp, msg,
 								  (unsigned long long) msg_len) != 0) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_update(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	memcpy(state, &state_tmp, state_len);
@@ -851,19 +846,19 @@ PHP_FUNCTION(sodium_crypto_generichash_final)
 	}
 	ZVAL_DEREF(state_zv);
 	if (Z_TYPE_P(state_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_final: a reference to a state is required", 0);
+		zend_throw_exception(sodium_exception_ce, "a reference to a state is required", 0);
 		return;
 	}
 	sodium_separate_string(state_zv);
 	state = (unsigned char *) Z_STRVAL(*state_zv);
 	state_len = Z_STRLEN(*state_zv);
 	if (state_len != sizeof (crypto_generichash_state)) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_final(): incorrect state length", 0);
+		zend_throw_exception(sodium_exception_ce, "incorrect state length", 0);
 		return;
 	}
 	if (hash_len < crypto_generichash_BYTES_MIN ||
 		hash_len > crypto_generichash_BYTES_MAX) {
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_final(): unsupported output length", 0);
+		zend_throw_exception(sodium_exception_ce, "unsupported output length", 0);
 		return;
 	}
 	hash = zend_string_alloc(hash_len, 0);
@@ -872,7 +867,7 @@ PHP_FUNCTION(sodium_crypto_generichash_final)
 								 (unsigned char *) ZSTR_VAL(hash),
 								 (size_t) hash_len) != 0) {
 		zend_string_free(hash);
-		zend_throw_exception(sodium_exception_ce, "crypto_generichash_final(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	sodium_memzero(state, state_len);
@@ -893,7 +888,7 @@ PHP_FUNCTION(sodium_crypto_box_keypair)
 						   crypto_box_SECRETKEYBYTES,
 						   (unsigned char *) ZSTR_VAL(keypair)) != 0) {
 		zend_string_free(keypair);
-		zend_throw_exception(sodium_exception_ce, "crypto_box_keypair(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(keypair)[keypair_len] = 0;
@@ -914,7 +909,6 @@ PHP_FUNCTION(sodium_crypto_box_seed_keypair)
 	}
 	if (seed_len != crypto_box_SEEDBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_seed_keypair(): "
 				   "seed should be CRYPTO_BOX_SEEDBYTES bytes",
 				   0);
 		return;
@@ -926,7 +920,7 @@ PHP_FUNCTION(sodium_crypto_box_seed_keypair)
 								 (unsigned char *) ZSTR_VAL(keypair),
 								 seed) != 0) {
 		zend_string_free(keypair);
-		zend_throw_exception(sodium_exception_ce, "crypto_box_seed_keypair(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(keypair)[keypair_len] = 0;
@@ -950,14 +944,12 @@ PHP_FUNCTION(sodium_crypto_box_keypair_from_secretkey_and_publickey)
 	}
 	if (secretkey_len != crypto_box_SECRETKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_keypair_from_secretkey_and_publickey(): "
 				   "secretkey should be CRYPTO_BOX_SECRETKEYBYTES bytes",
 				   0);
 		return;
 	}
 	if (publickey_len != crypto_box_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_keypair_from_secretkey_and_publickey(): "
 				   "publickey should be CRYPTO_BOX_PUBLICKEYBYTES bytes",
 				   0);
 		return;
@@ -985,8 +977,7 @@ PHP_FUNCTION(sodium_crypto_box_secretkey)
 	if (keypair_len !=
 		crypto_box_SECRETKEYBYTES + crypto_box_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_secretkey(): keypair should be "
-				   "CRYPTO_BOX_KEYPAIRBYTES bytes",
+				   "keypair should be CRYPTO_BOX_KEYPAIRBYTES bytes",
 				   0);
 		return;
 	}
@@ -1010,8 +1001,7 @@ PHP_FUNCTION(sodium_crypto_box_publickey)
 	if (keypair_len !=
 		crypto_box_SECRETKEYBYTES + crypto_box_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_publickey(): keypair should be "
-				   "CRYPTO_BOX_KEYPAIRBYTES bytes",
+				   "keypair should be CRYPTO_BOX_KEYPAIRBYTES bytes",
 				   0);
 		return;
 	}
@@ -1035,8 +1025,7 @@ PHP_FUNCTION(sodium_crypto_box_publickey_from_secretkey)
 	}
 	if (secretkey_len != crypto_box_SECRETKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_publickey_from_secretkey(): key should be "
-				   "CRYPTO_BOX_SECRETKEYBYTES bytes",
+				   "key should be CRYPTO_BOX_SECRETKEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -1071,15 +1060,13 @@ PHP_FUNCTION(sodium_crypto_box)
 	}
 	if (nonce_len != crypto_box_NONCEBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box(): nonce size should be "
-				   "CRYPTO_BOX_NONCEBYTES bytes",
+				   "nonce size should be CRYPTO_BOX_NONCEBYTES bytes",
 				   0);
 		return;
 	}
 	if (keypair_len != crypto_box_SECRETKEYBYTES + crypto_box_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box(): keypair size should be "
-				   "CRYPTO_BOX_KEYPAIRBYTES bytes",
+				   "keypair size should be CRYPTO_BOX_KEYPAIRBYTES bytes",
 				   0);
 		return;
 	}
@@ -1094,7 +1081,7 @@ PHP_FUNCTION(sodium_crypto_box)
 						(unsigned long long) msg_len,
 						nonce, publickey, secretkey) != 0) {
 		zend_string_free(ciphertext);
-		zend_throw_exception(sodium_exception_ce, "crypto_box(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(ciphertext)[msg_len + crypto_box_MACBYTES] = 0;
@@ -1122,15 +1109,13 @@ PHP_FUNCTION(sodium_crypto_box_open)
 	}
 	if (nonce_len != crypto_box_NONCEBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_open(): nonce size should be "
-				   "CRYPTO_BOX_NONCEBYTES bytes",
+				   "nonce size should be CRYPTO_BOX_NONCEBYTES bytes",
 				   0);
 		return;
 	}
 	if (keypair_len != crypto_box_SECRETKEYBYTES + crypto_box_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_open(): keypair size should be "
-				   "CRYPTO_BOX_KEYBYTES bytes",
+				   "keypair size should be CRYPTO_BOX_KEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -1167,8 +1152,7 @@ PHP_FUNCTION(sodium_crypto_box_seal)
 	}
 	if (publickey_len != crypto_box_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_seal(): public key size should be "
-				   "CRYPTO_BOX_PUBLICKEYBYTES bytes",
+				   "public key size should be CRYPTO_BOX_PUBLICKEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -1180,7 +1164,7 @@ PHP_FUNCTION(sodium_crypto_box_seal)
 	if (crypto_box_seal((unsigned char *) ZSTR_VAL(ciphertext), msg,
 						(unsigned long long) msg_len, publickey) != 0) {
 		zend_string_free(ciphertext);
-		zend_throw_exception(sodium_exception_ce, "crypto_box_seal(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(ciphertext)[msg_len + crypto_box_SEALBYTES] = 0;
@@ -1205,8 +1189,7 @@ PHP_FUNCTION(sodium_crypto_box_seal_open)
 	}
 	if (keypair_len != crypto_box_SECRETKEYBYTES + crypto_box_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_box_seal_open(): keypair size should be "
-				   "CRYPTO_BOX_KEYBYTES bytes",
+				   "keypair size should be CRYPTO_BOX_KEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -1239,7 +1222,7 @@ PHP_FUNCTION(sodium_crypto_sign_keypair)
 							crypto_sign_SECRETKEYBYTES,
 							(unsigned char *) ZSTR_VAL(keypair)) != 0) {
 		zend_string_free(keypair);
-		zend_throw_exception(sodium_exception_ce, "crypto_sign_keypair(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(keypair)[keypair_len] = 0;
@@ -1260,7 +1243,6 @@ PHP_FUNCTION(sodium_crypto_sign_seed_keypair)
 	}
 	if (seed_len != crypto_sign_SEEDBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_seed_keypair(): "
 				   "seed should be CRYPTO_SIGN_SEEDBYTES bytes",
 				   0);
 		return;
@@ -1272,7 +1254,7 @@ PHP_FUNCTION(sodium_crypto_sign_seed_keypair)
 								 (unsigned char *) ZSTR_VAL(keypair),
 								 seed) != 0) {
 		zend_string_free(keypair);
-		zend_throw_exception(sodium_exception_ce, "crypto_sign_seed_keypair(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(keypair)[keypair_len] = 0;
@@ -1296,14 +1278,12 @@ PHP_FUNCTION(sodium_crypto_sign_keypair_from_secretkey_and_publickey)
 	}
 	if (secretkey_len != crypto_sign_SECRETKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_keypair_from_secretkey_and_publickey(): "
 				   "secretkey should be CRYPTO_SIGN_SECRETKEYBYTES bytes",
 				   0);
 		return;
 	}
 	if (publickey_len != crypto_sign_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_keypair_from_secretkey_and_publickey(): "
 				   "publickey should be CRYPTO_SIGN_PUBLICKEYBYTES bytes",
 				   0);
 		return;
@@ -1330,7 +1310,6 @@ PHP_FUNCTION(sodium_crypto_sign_publickey_from_secretkey)
 	}
 	if (secretkey_len != crypto_sign_SECRETKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_publickey_from_secretkey(): "
 				   "secretkey should be CRYPTO_SIGN_SECRETKEYBYTES bytes",
 				   0);
 		return;
@@ -1340,7 +1319,7 @@ PHP_FUNCTION(sodium_crypto_sign_publickey_from_secretkey)
 	if (crypto_sign_ed25519_sk_to_pk((unsigned char *) ZSTR_VAL(publickey),
 									 (const unsigned char *) secretkey) != 0) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_publickey_from_secretkey(): internal error", 0);
+				   "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(publickey)[crypto_sign_PUBLICKEYBYTES] = 0;
@@ -1361,8 +1340,7 @@ PHP_FUNCTION(sodium_crypto_sign_secretkey)
 	if (keypair_len !=
 		crypto_sign_SECRETKEYBYTES + crypto_sign_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_secretkey(): keypair should be "
-				   "CRYPTO_SIGN_KEYPAIRBYTES bytes",
+				   "keypair should be CRYPTO_SIGN_KEYPAIRBYTES bytes",
 				   0);
 		return;
 	}
@@ -1386,8 +1364,7 @@ PHP_FUNCTION(sodium_crypto_sign_publickey)
 	if (keypair_len !=
 		crypto_sign_SECRETKEYBYTES + crypto_sign_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_publickey(): keypair should be "
-				   "CRYPTO_SIGN_KEYPAIRBYTES bytes",
+				   "keypair should be CRYPTO_SIGN_KEYPAIRBYTES bytes",
 				   0);
 		return;
 	}
@@ -1416,8 +1393,7 @@ PHP_FUNCTION(sodium_crypto_sign)
 	}
 	if (secretkey_len != crypto_sign_SECRETKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign(): secret key size should be "
-				   "CRYPTO_SIGN_SECRETKEYBYTES bytes",
+				   "secret key size should be CRYPTO_SIGN_SECRETKEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -1431,7 +1407,7 @@ PHP_FUNCTION(sodium_crypto_sign)
 					&msg_signed_real_len, msg,
 					(unsigned long long) msg_len, secretkey) != 0) {
 		zend_string_free(msg_signed);
-		zend_throw_exception(sodium_exception_ce, "crypto_sign(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	if (msg_signed_real_len <= 0U || msg_signed_real_len >= SIZE_MAX ||
@@ -1463,8 +1439,7 @@ PHP_FUNCTION(sodium_crypto_sign_open)
 	}
 	if (publickey_len != crypto_sign_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_open(): public key size should be "
-				   "CRYPTO_SIGN_PUBLICKEYBYTES bytes",
+				   "public key size should be CRYPTO_SIGN_PUBLICKEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -1507,8 +1482,7 @@ PHP_FUNCTION(sodium_crypto_sign_detached)
 	}
 	if (secretkey_len != crypto_sign_SECRETKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_detached(): secret key size should be "
-				   "CRYPTO_SIGN_SECRETKEYBYTES bytes",
+				   "secret key size should be CRYPTO_SIGN_SECRETKEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -1518,7 +1492,7 @@ PHP_FUNCTION(sodium_crypto_sign_detached)
 							 &signature_real_len, msg,
 							 (unsigned long long) msg_len, secretkey) != 0) {
 		zend_string_free(signature);
-		zend_throw_exception(sodium_exception_ce, "crypto_sign_detached()", 0);
+		zend_throw_exception(sodium_exception_ce, "signature creation failed", 0);
 		return;
 	}
 	if (signature_real_len <= 0U || signature_real_len > crypto_sign_BYTES) {
@@ -1548,15 +1522,13 @@ PHP_FUNCTION(sodium_crypto_sign_verify_detached)
 	}
 	if (signature_len != crypto_sign_BYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_verify_detached(): signature size should be "
-				   "CRYPTO_SIGN_BYTES bytes",
+				   "signature size should be CRYPTO_SIGN_BYTES bytes",
 				   0);
 		return;
 	}
 	if (publickey_len != crypto_sign_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_verify_detached(): public key size should be "
-				   "CRYPTO_SIGN_PUBLICKEYBYTES bytes",
+				   "public key size should be CRYPTO_SIGN_PUBLICKEYBYTES bytes",
 				   0);
 		return;
 	}
@@ -1584,7 +1556,7 @@ PHP_FUNCTION(sodium_crypto_stream)
 		return;
 	}
 	if (ciphertext_len <= 0 || ciphertext_len >= SIZE_MAX) {
-		zend_throw_exception(sodium_exception_ce, "crypto_stream(): invalid length", 0);
+		zend_throw_exception(sodium_exception_ce, "invalid length", 0);
 		return;
 	}
 	if (nonce_len != crypto_stream_NONCEBYTES) {
@@ -1599,7 +1571,7 @@ PHP_FUNCTION(sodium_crypto_stream)
 	if (crypto_stream((unsigned char *) ZSTR_VAL(ciphertext),
 					  (unsigned long long) ciphertext_len, nonce, key) != 0) {
 		zend_string_free(ciphertext);
-		zend_throw_exception(sodium_exception_ce, "crypto_stream(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(ciphertext)[ciphertext_len] = 0;
@@ -1637,7 +1609,7 @@ PHP_FUNCTION(sodium_crypto_stream_xor)
 	if (crypto_stream_xor((unsigned char *) ZSTR_VAL(ciphertext), msg,
 						  (unsigned long long) msg_len, nonce, key) != 0) {
 		zend_string_free(ciphertext);
-		zend_throw_exception(sodium_exception_ce, "crypto_stream_xor(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(ciphertext)[ciphertext_len] = 0;
@@ -1663,7 +1635,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256)
 							  &opslimit, &memlimit) == FAILURE ||
 		hash_len <= 0 || hash_len >= SIZE_MAX ||
 		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
-		zend_throw_exception(sodium_exception_ce, "crypto_pwhash_scryptsalsa208sha256(): invalid parameters", 0);
+		zend_throw_exception(sodium_exception_ce, "invalid parameters", 0);
 		return;
 	}
 	if (passwd_len <= 0) {
@@ -1689,7 +1661,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256)
 		 passwd, (unsigned long long) passwd_len, salt,
 		 (unsigned long long) opslimit, (size_t) memlimit) != 0) {
 		zend_string_free(hash);
-		zend_throw_exception(sodium_exception_ce, "crypto_pwhash_scryptsalsa208sha256(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(hash)[hash_len] = 0;
@@ -1710,7 +1682,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str)
 							  &opslimit, &memlimit) == FAILURE ||
 		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_pwhash_scryptsalsa208sha256_str(): invalid parameters",
+				   "invalid parameters",
 				   0);
 		return;
 	}
@@ -1731,7 +1703,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str)
 		(ZSTR_VAL(hash_str), passwd, (unsigned long long) passwd_len,
 		 (unsigned long long) opslimit, (size_t) memlimit) != 0) {
 		zend_string_free(hash_str);
-		zend_throw_exception(sodium_exception_ce, "crypto_pwhash_scryptsalsa208sha256_str(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(hash_str)[crypto_pwhash_scryptsalsa208sha256_STRBYTES - 1] = 0;
@@ -1750,7 +1722,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str_verify)
 							  &hash_str, &hash_str_len,
 							  &passwd, &passwd_len) == FAILURE) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_pwhash_scryptsalsa208sha256_str_verify(): invalid parameters",
+				   "invalid parameters",
 				   0);
 		return;
 	}
@@ -1787,7 +1759,7 @@ PHP_FUNCTION(sodium_crypto_pwhash)
 							  &opslimit, &memlimit) == FAILURE ||
 		hash_len <= 0 || hash_len >= SIZE_MAX ||
 		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
-		zend_throw_exception(sodium_exception_ce, "crypto_pwhash(): invalid parameters", 0);
+		zend_throw_exception(sodium_exception_ce, "invalid parameters", 0);
 		return;
 	}
 	if (passwd_len <= 0) {
@@ -1811,7 +1783,7 @@ PHP_FUNCTION(sodium_crypto_pwhash)
 		 (unsigned long long) opslimit, (size_t) memlimit,
 		 crypto_pwhash_alg_default()) != 0) {
 		zend_string_free(hash);
-		zend_throw_exception(sodium_exception_ce, "crypto_pwhash(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(hash)[hash_len] = 0;
@@ -1833,7 +1805,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str)
 							  &opslimit, &memlimit) == FAILURE ||
 		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_pwhash_str(): invalid parameters",
+				   "invalid parameters",
 				   0);
 		return;
 	}
@@ -1853,7 +1825,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str)
 		(ZSTR_VAL(hash_str), passwd, (unsigned long long) passwd_len,
 		 (unsigned long long) opslimit, (size_t) memlimit) != 0) {
 		zend_string_free(hash_str);
-		zend_throw_exception(sodium_exception_ce, "crypto_pwhash_str(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(hash_str)[crypto_pwhash_STRBYTES - 1] = 0;
@@ -1875,7 +1847,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str_verify)
 							  &hash_str, &hash_str_len,
 							  &passwd, &passwd_len) == FAILURE) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_pwhash_str_verify(): invalid parameters",
+				   "invalid parameters",
 				   0);
 		return;
 	}
@@ -1923,7 +1895,6 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_encrypt)
 	}
 	if (npub_len != crypto_aead_aes256gcm_NPUBBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_aes256gcm_encrypt(): "
 				   "public nonce size should be "
 				   "CRYPTO_AEAD_AES256GCM_NPUBBYTES bytes",
 				   0);
@@ -1931,7 +1902,6 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_encrypt)
 	}
 	if (secretkey_len != crypto_aead_aes256gcm_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_aes256gcm_encrypt(): "
 				   "secret key size should be "
 				   "CRYPTO_AEAD_AES256GCM_KEYBYTES bytes",
 				   0);
@@ -1948,7 +1918,7 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_encrypt)
 		 (unsigned long long) msg_len,
 		 ad, (unsigned long long) ad_len, NULL, npub, secretkey) != 0) {
 		zend_string_free(ciphertext);
-		zend_throw_exception(sodium_exception_ce, "crypto_aead_aes256gcm_encrypt(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	if (ciphertext_real_len <= 0U || ciphertext_real_len >= SIZE_MAX ||
@@ -1986,7 +1956,6 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_decrypt)
 	}
 	if (npub_len != crypto_aead_aes256gcm_NPUBBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_aes256gcm_decrypt(): "
 				   "public nonce size should be "
 				   "CRYPTO_AEAD_AES256GCM_NPUBBYTES bytes",
 				   0);
@@ -1994,7 +1963,6 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_decrypt)
 	}
 	if (secretkey_len != crypto_aead_aes256gcm_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_aes256gcm_decrypt(): "
 				   "secret key size should be "
 				   "CRYPTO_AEAD_AES256GCM_KEYBYTES bytes",
 				   0);
@@ -2049,7 +2017,6 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_encrypt)
 	}
 	if (npub_len != crypto_aead_chacha20poly1305_NPUBBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_chacha20poly1305_encrypt(): "
 				   "public nonce size should be "
 				   "CRYPTO_AEAD_CHACHA20POLY1305_NPUBBYTES bytes",
 				   0);
@@ -2057,7 +2024,6 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_encrypt)
 	}
 	if (secretkey_len != crypto_aead_chacha20poly1305_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_chacha20poly1305_encrypt(): "
 				   "secret key size should be "
 				   "CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES bytes",
 				   0);
@@ -2074,7 +2040,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_encrypt)
 		 (unsigned long long) msg_len,
 		 ad, (unsigned long long) ad_len, NULL, npub, secretkey) != 0) {
 		zend_string_free(ciphertext);
-		zend_throw_exception(sodium_exception_ce, "crypto_aead_chacha20poly1305_encrypt(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	if (ciphertext_real_len <= 0U || ciphertext_real_len >= SIZE_MAX ||
@@ -2112,7 +2078,6 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_decrypt)
 	}
 	if (npub_len != crypto_aead_chacha20poly1305_NPUBBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_chacha20poly1305_decrypt(): "
 				   "public nonce size should be "
 				   "CRYPTO_AEAD_CHACHA20POLY1305_NPUBBYTES bytes",
 				   0);
@@ -2120,7 +2085,6 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_decrypt)
 	}
 	if (secretkey_len != crypto_aead_chacha20poly1305_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_chacha20poly1305_decrypt(): "
 				   "secret key size should be "
 				   "CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES bytes",
 				   0);
@@ -2175,7 +2139,6 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_encrypt)
 	}
 	if (npub_len != crypto_aead_chacha20poly1305_IETF_NPUBBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_chacha20poly1305_ietf_encrypt(): "
 				   "public nonce size should be "
 				   "CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES bytes",
 				   0);
@@ -2183,7 +2146,6 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_encrypt)
 	}
 	if (secretkey_len != crypto_aead_chacha20poly1305_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_chacha20poly1305_ietf_encrypt(): "
 				   "secret key size should be "
 				   "CRYPTO_AEAD_CHACHA20POLY1305_IETF_KEYBYTES bytes",
 				   0);
@@ -2204,7 +2166,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_encrypt)
 		 (unsigned long long) msg_len,
 		 ad, (unsigned long long) ad_len, NULL, npub, secretkey) != 0) {
 		zend_string_free(ciphertext);
-		zend_throw_exception(sodium_exception_ce, "crypto_aead_chacha20poly1305_ietf_encrypt(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	if (ciphertext_real_len <= 0U || ciphertext_real_len >= SIZE_MAX ||
@@ -2242,7 +2204,6 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_decrypt)
 	}
 	if (npub_len != crypto_aead_chacha20poly1305_IETF_NPUBBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_chacha20poly1305_ietf_decrypt(): "
 				   "public nonce size should be "
 				   "CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES bytes",
 				   0);
@@ -2250,7 +2211,6 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_decrypt)
 	}
 	if (secretkey_len != crypto_aead_chacha20poly1305_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_chacha20poly1305_ietf_decrypt(): "
 				   "secret key size should be "
 				   "CRYPTO_AEAD_CHACHA20POLY1305_IETF_KEYBYTES bytes",
 				   0);
@@ -2311,7 +2271,6 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_encrypt)
 	}
 	if (npub_len != crypto_aead_xchacha20poly1305_IETF_NPUBBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_xchacha20poly1305_ietf_encrypt(): "
 				   "public nonce size should be "
 				   "CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES bytes",
 				   0);
@@ -2319,7 +2278,6 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_encrypt)
 	}
 	if (secretkey_len != crypto_aead_xchacha20poly1305_IETF_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_xchacha20poly1305_ietf_encrypt(): "
 				   "secret key size should be "
 				   "CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES bytes",
 				   0);
@@ -2340,7 +2298,7 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_encrypt)
 		 (unsigned long long) msg_len,
 		 ad, (unsigned long long) ad_len, NULL, npub, secretkey) != 0) {
 		zend_string_free(ciphertext);
-		zend_throw_exception(sodium_exception_ce, "crypto_aead_xchacha20poly1305_ietf_encrypt(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	if (ciphertext_real_len <= 0U || ciphertext_real_len >= SIZE_MAX ||
@@ -2378,7 +2336,6 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_decrypt)
 	}
 	if (npub_len != crypto_aead_xchacha20poly1305_IETF_NPUBBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_xchacha20poly1305_ietf_decrypt(): "
 				   "public nonce size should be "
 				   "CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES bytes",
 				   0);
@@ -2386,7 +2343,6 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_decrypt)
 	}
 	if (secretkey_len != crypto_aead_xchacha20poly1305_IETF_KEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_aead_xchacha20poly1305_ietf_decrypt(): "
 				   "secret key size should be "
 				   "CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES bytes",
 				   0);
@@ -2490,7 +2446,7 @@ PHP_FUNCTION(sodium_crypto_scalarmult)
 	}
 	if (n_len != crypto_scalarmult_SCALARBYTES ||
 		p_len != crypto_scalarmult_SCALARBYTES) {
-		zend_throw_exception(sodium_exception_ce, "crypto_scalarmult(): scalar and point must be "
+		zend_throw_exception(sodium_exception_ce, "scalar and point must be "
 				   "CRYPTO_SCALARMULT_SCALARBYTES bytes",
 				   0);
 		return;
@@ -2498,7 +2454,7 @@ PHP_FUNCTION(sodium_crypto_scalarmult)
 	q = zend_string_alloc(crypto_scalarmult_BYTES, 0);
 	if (crypto_scalarmult((unsigned char *) ZSTR_VAL(q), n, p) != 0) {
 		zend_string_free(q);
-		zend_throw_exception(sodium_exception_ce, "crypto_scalarmult(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(q)[crypto_scalarmult_BYTES] = 0;
@@ -2713,14 +2669,14 @@ PHP_FUNCTION(sodium_crypto_auth)
 		return;
 	}
 	if (key_len != crypto_auth_KEYBYTES) {
-		zend_throw_exception(sodium_exception_ce, "crypto_auth(): key must be CRYPTO_AUTH_KEYBYTES bytes", 0);
+		zend_throw_exception(sodium_exception_ce, "key must be CRYPTO_AUTH_KEYBYTES bytes", 0);
 		return;
 	}
 	mac = zend_string_alloc(crypto_auth_BYTES, 0);
 	if (crypto_auth((unsigned char *) ZSTR_VAL(mac),
 					(const unsigned char *) msg, msg_len,
 					(const unsigned char *) key) != 0) {
-		zend_throw_exception(sodium_exception_ce, "crypto_auth(): internal error", 0);
+		zend_throw_exception(sodium_exception_ce, "internal error", 0);
 		return;
 	}
 	ZSTR_VAL(mac)[crypto_auth_BYTES] = 0;
@@ -2744,11 +2700,11 @@ PHP_FUNCTION(sodium_crypto_auth_verify)
 		return;
 	}
 	if (key_len != crypto_auth_KEYBYTES) {
-		zend_throw_exception(sodium_exception_ce, "crypto_auth_verify(): key must be CRYPTO_AUTH_KEYBYTES bytes", 0);
+		zend_throw_exception(sodium_exception_ce, "key must be CRYPTO_AUTH_KEYBYTES bytes", 0);
 		return;
 	}
 	if (mac_len != crypto_auth_BYTES) {
-		zend_throw_exception(sodium_exception_ce, "crypto_auth_verify(): authentication tag must be CRYPTO_AUTH_BYTES bytes", 0);
+		zend_throw_exception(sodium_exception_ce, "authentication tag must be CRYPTO_AUTH_BYTES bytes", 0);
 		return;
 	}
 	if (crypto_auth_verify((const unsigned char *) mac,
@@ -2771,7 +2727,6 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_sk_to_curve25519)
 	}
 	if (eddsakey_len != crypto_sign_SECRETKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_ed25519_sk_to_curve25519(): "
 				   "Ed25519 key should be CRYPTO_SIGN_SECRETKEYBYTES bytes",
 				   0);
 		return;
@@ -2780,7 +2735,7 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_sk_to_curve25519)
 
 	if (crypto_sign_ed25519_sk_to_curve25519((unsigned char *) ZSTR_VAL(ecdhkey),
 											 (const unsigned char *) eddsakey) != 0) {
-		zend_throw_exception(sodium_exception_ce, "crypto_sign_ed25519_sk_to_curve25519()", 0);
+		zend_throw_exception(sodium_exception_ce, "conversion failed", 0);
 		return;
 	}
 	ZSTR_VAL(ecdhkey)[crypto_box_SECRETKEYBYTES] = 0;
@@ -2800,7 +2755,6 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_pk_to_curve25519)
 	}
 	if (eddsakey_len != crypto_sign_PUBLICKEYBYTES) {
 		zend_throw_exception(sodium_exception_ce,
-				   "crypto_sign_ed25519_pk_to_curve25519(): "
 				   "Ed25519 key should be CRYPTO_SIGN_PUBLICKEYBYTES bytes",
 				   0);
 		return;
@@ -2809,7 +2763,7 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_pk_to_curve25519)
 
 	if (crypto_sign_ed25519_pk_to_curve25519((unsigned char *) ZSTR_VAL(ecdhkey),
 											 (const unsigned char *) eddsakey) != 0) {
-		zend_throw_exception(sodium_exception_ce, "crypto_sign_ed25519_pk_to_curve25519()", 0);
+		zend_throw_exception(sodium_exception_ce, "conversion failed", 0);
 		return;
 	}
 	ZSTR_VAL(ecdhkey)[crypto_box_PUBLICKEYBYTES] = 0;
@@ -2832,7 +2786,7 @@ PHP_FUNCTION(sodium_compare)
 		return;
 	}
 	if (len1 != len2) {
-		zend_throw_exception(sodium_exception_ce, "compare(): arguments have different sizes", 0);
+		zend_throw_exception(sodium_exception_ce, "arguments have different sizes", 0);
 	} else {
 		RETURN_LONG(sodium_compare((const unsigned char *) buf1,
 								   (const unsigned char *) buf2, (size_t) len1));

--- a/ext/sodium/tests/crypto_auth.phpt
+++ b/ext/sodium/tests/crypto_auth.phpt
@@ -41,7 +41,7 @@ var_dump(sodium_crypto_auth_verify($badmac, $msg, $key));
 ?>
 --EXPECT--
 bool(true)
-crypto_auth(): key must be CRYPTO_AUTH_KEYBYTES bytes
+key must be CRYPTO_AUTH_KEYBYTES bytes
 bool(false)
 bool(false)
 bool(false)

--- a/ext/sodium/tests/crypto_box.phpt
+++ b/ext/sodium/tests/crypto_box.phpt
@@ -142,7 +142,7 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
-crypto_box(): keypair size should be CRYPTO_BOX_KEYPAIRBYTES bytes
+keypair size should be CRYPTO_BOX_KEYPAIRBYTES bytes
 bool(true)
 string(17) "Hi, this is Alice"
 string(21) "Hi Alice! This is Bob"

--- a/ext/sodium/tests/exception_trace_without_args.phpt
+++ b/ext/sodium/tests/exception_trace_without_args.phpt
@@ -14,7 +14,7 @@ do_memzero($x);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught SodiumException: memzero: a PHP string is required in %s:%d
+Fatal error: Uncaught SodiumException: a PHP string is required in %s:%d
 Stack trace:
 #0 %s(%d): sodium_memzero()
 #1 %s(%d): do_memzero()

--- a/ext/sodium/tests/inc_add.phpt
+++ b/ext/sodium/tests/inc_add.phpt
@@ -43,12 +43,12 @@ var_dump($str, $str2);
 
 ?>
 --EXPECT--
-increment(): a PHP string is required
+a PHP string is required
 string(3) "bbc"
 string(3) "abc"
 string(3) "bbc"
 string(3) "abc"
-add(): PHP strings are required
+PHP strings are required
 string(3) "cbc"
 string(3) "abc"
 string(3) "cbc"


### PR DESCRIPTION
Exceptions already include this information.