### PR TITLE
Fixes bug #74906 - redirecting incorrect include <sys/errno.h>

### DIFF
--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -41,9 +41,9 @@
 #if HAVE_SNMP
 
 #include <sys/types.h>
+#include <errno.h>
 #ifdef PHP_WIN32
 #include <winsock2.h>
-#include <errno.h>
 #include <process.h>
 #include "win32/time.h"
 #elif defined(NETWARE)
@@ -52,17 +52,11 @@
 #else
 #include <sys/socket.h>
 #endif
-#include <errno.h>
 #include <sys/timeval.h>
 #else
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#ifndef _OSD_POSIX
-#include <sys/errno.h>
-#else
-#include <errno.h>  /* BS2000/OSD uses <errno.h>, not <sys/errno.h> */
-#endif
 #include <netdb.h>
 #endif
 #ifdef HAVE_UNISTD_H


### PR DESCRIPTION
Hello, when compiling PHP on Alpine Linux, there appears a warning:

```
In file included from /build/main/php7.2/src/php-7.2.0alpha3/ext/snmp/snmp.c:51:0:
/usr/include/sys/errno.h:1:2: warning: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Wcpp]
 #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
  ^~~~~~~
/build/main/php7.2/src/php-7.2.0alpha3/ext/snmp/snmp.c: In function 'zm_startup_snmp':
/build/main/php7.2/src/php-7.2.0alpha3/ext/snmp/snmp.c:2328:34: warning: assignment from incompatible pointer type [-Wincompatible-pointer-types]
  php_snmp_object_handlers.get_gc = php_snmp_get_gc;
```

This patch fixes bug [74906](https://bugs.php.net/bug.php?id=74906) where more info is provided.