### PR TITLE
Fixes bug 74913 - redirecting incorrect include <sys/poll.h>

### DIFF
--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -43,7 +43,11 @@
 #	include <sys/select.h>
 #	include <sys/time.h>
 #	include <sys/types.h>
-#	include <sys/poll.h>
+#	if HAVE_POLL_H
+#		include <poll.h>
+#	elif HAVE_SYS_POLL_H
+#		include <sys/poll.h>
+#	endif
 #	include <netinet/in.h>
 #	include <unistd.h>
 #	include <arpa/inet.h>


### PR DESCRIPTION
This patch fixes compilation warning as noted in [74913](https://bugs.php.net/bug.php?id=74913).

Thank you for checking it out and considering merging it.