### PR TITLE
Fixed allocator sizeof operand mismatch in zend_register_functions

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2237,8 +2237,8 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 		lowercase_name = zend_string_alloc(fname_len, 1);
 		zend_str_tolower_copy(ZSTR_VAL(lowercase_name), ptr->fname, fname_len);
 		lowercase_name = zend_new_interned_string(lowercase_name);
-		reg_function = malloc(sizeof(zend_internal_function));
-		memcpy(reg_function, &function, sizeof(zend_internal_function));
+		reg_function = malloc(sizeof(zend_function));
+		memcpy(reg_function, &function, sizeof(zend_function));
 		if (zend_hash_add_ptr(target_function_table, lowercase_name, reg_function) == NULL) {
 			unload=1;
 			free(reg_function);


### PR DESCRIPTION
Quick fix for allocator `sizeof` operand mismatch in `zend_register_functions`.

`reg_function` and `function` are both type of `zend_function` and that's why size of `zend_function` must be used