### PR TITLE
get_token_type_name -  return NULL for unknown id

### DIFF
--- a/ext/tokenizer/tokenizer_data.c
+++ b/ext/tokenizer/tokenizer_data.c
@@ -304,6 +304,6 @@ char *get_token_type_name(int token_type)
 		case T_ELLIPSIS: return "T_ELLIPSIS";
 
 	}
-	return "UNKNOWN";
+	return NULL;
 }
 


### PR DESCRIPTION
Hi all,

Currently `get_token_type_name` returns "UNKNOWN" when an id is passed that is not known.
This is less idea because;
- its a magic value (it is also not a predefined constant)
- is less flexible, as who knows maybe we've a (pseudo) type/class 'unknown' in the future

Technically this PR is a BC break so not sure how to proceed.