### PR TITLE
sodium: check another symbol in build checks

### DIFF
--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -39,7 +39,7 @@ if test "$PHP_SODIUM" != "no"; then
   fi
 
   LIBNAME=sodium
-  LIBSYMBOL=crypto_pwhash_scryptsalsa208sha256
+  LIBSYMBOL=crypto_aead_chacha20poly1305_ietf_KEYBYTES
 
   if test -n "$LIBSODIUM_DIR"; then
     PHP_ADD_INCLUDE($LIBSODIUM_DIR/include)


### PR DESCRIPTION
libsodium 1.0.0 provides the currently checked symbol, but ext/sodium uses `crypto_aead_chacha20poly1305_ietf_KEYBYTES`, among others, which is only available starting 1.0.9.

Notably, this means that php 7.2 does not build on Debian Jessie ("oldstable" since a month ago) by default. (An updated libsodium is provided in jessie-backports, so that's not too hard to fix, but still.)

cc @jedisct1