### PR TITLE
Add finfo::getMagicFile() and finfo_magic_file_get()

### DIFF
--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -158,6 +158,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_mime_content_type, 0, 0, 1)
 	ZEND_ARG_INFO(0, string)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_finfo_magic_file_get, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_finfo_method_magic_file_get, 0)
+ZEND_END_ARG_INFO()
 /* }}} */
 
 /* {{{ finfo_class_functions
@@ -167,6 +173,7 @@ zend_function_entry finfo_class_functions[] = {
 	ZEND_ME_MAPPING(set_flags,      finfo_set_flags,arginfo_finfo_method_set_flags, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(file,           finfo_file,     arginfo_finfo_method_file, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(buffer,         finfo_buffer,   arginfo_finfo_method_buffer, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(getMagicFile,   finfo_magic_file_get, arginfo_finfo_method_magic_file_get, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 /* }}} */
@@ -203,6 +210,7 @@ zend_function_entry fileinfo_functions[] = {
 	PHP_FE(finfo_file,		arginfo_finfo_file)
 	PHP_FE(finfo_buffer,	arginfo_finfo_buffer)
 	PHP_FE(mime_content_type, arginfo_mime_content_type)
+	PHP_FE(finfo_magic_file_get, arginfo_finfo_magic_file_get)
 	PHP_FE_END
 };
 /* }}} */
@@ -619,6 +627,36 @@ PHP_FUNCTION(finfo_buffer)
 PHP_FUNCTION(mime_content_type)
 {
 	_php_finfo_get_type(INTERNAL_FUNCTION_PARAM_PASSTHRU, -1, 1);
+}
+/* }}} */
+
+/* {{{ proto string finfo_magic_file_get()
+   Return path for the magic file */
+PHP_FUNCTION(finfo_magic_file_get)
+{
+	php_fileinfo *finfo;
+	zval *zfinfo;
+	char *ret_val = NULL;
+
+	FILEINFO_DECLARE_INIT_OBJECT(object)
+
+	if (object) {
+		ZEND_PARSE_PARAMETERS_START(0, 0)
+		ZEND_PARSE_PARAMETERS_END();
+
+		FILEINFO_FROM_OBJECT(finfo, object);
+	} else {
+		ZEND_PARSE_PARAMETERS_START(1, 1)
+			Z_PARAM_RESOURCE(zfinfo);
+		ZEND_PARSE_PARAMETERS_END();
+
+		if ((finfo = (php_fileinfo *)zend_fetch_resource(Z_RES_P(zfinfo), "file_info", le_fileinfo)) == NULL) {
+			RETURN_FALSE;
+		}
+	}
+
+	ret_val = (char *) file_magicfile(finfo->magic);
+	RETVAL_STRING(ret_val);
 }
 /* }}} */
 

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -655,7 +655,7 @@ PHP_FUNCTION(finfo_magic_file_get)
 		}
 	}
 
-	ret_val = (char *) file_magicfile(finfo->magic);
+	ret_val = (char *) magic_magic_file_get(finfo->magic);
 	RETVAL_STRING(ret_val);
 }
 /* }}} */

--- a/ext/fileinfo/libmagic/apprentice.c
+++ b/ext/fileinfo/libmagic/apprentice.c
@@ -3340,12 +3340,3 @@ file_magicfind(struct magic_set *ms, const char *name, struct mlist *v)
 	}
 	return -1;
 }
-
-public const char *
-file_magicfile(struct magic_set *ms)
-{
-	if(strncmp(ms->file, "unknown", strlen("unknown")) == 0) {
-		return "";
-	}
-	return ms->file;
-}

--- a/ext/fileinfo/libmagic/apprentice.c
+++ b/ext/fileinfo/libmagic/apprentice.c
@@ -632,8 +632,6 @@ file_apprentice(struct magic_set *ms, const char *fn, int action)
 		fn = p;
 	}
 
-	efree(mfn);
-
 	if (errs == -1) {
 		for (i = 0; i < MAGIC_SETS; i++) {
 			mlist_free(ms->mlist[i]);
@@ -3341,4 +3339,13 @@ file_magicfind(struct magic_set *ms, const char *name, struct mlist *v)
 		}
 	}
 	return -1;
+}
+
+public const char *
+file_magicfile(struct magic_set *ms)
+{
+	if(strncmp(ms->file, "unknown", strlen("unknown")) == 0) {
+		return "";
+	}
+	return ms->file;
 }

--- a/ext/fileinfo/libmagic/magic.c
+++ b/ext/fileinfo/libmagic/magic.c
@@ -403,3 +403,12 @@ magic_getparam(struct magic_set *ms, int param, void *val)
 		return -1;
 	}
 }
+
+public const char *
+magic_magic_file_get(struct magic_set *ms)
+{
+	if(strncmp(ms->file, "unknown", strlen("unknown")) == 0) {
+		return "";
+	}
+	return ms->file;
+}

--- a/ext/fileinfo/libmagic/magic.c
+++ b/ext/fileinfo/libmagic/magic.c
@@ -407,7 +407,7 @@ magic_getparam(struct magic_set *ms, int param, void *val)
 public const char *
 magic_magic_file_get(struct magic_set *ms)
 {
-	if(strncmp(ms->file, "unknown", strlen("unknown")) == 0) {
+	if(strncmp(ms->file, "unknown", sizeof("unknown")-1) == 0) {
 		return "";
 	}
 	return ms->file;

--- a/ext/fileinfo/libmagic/magic.h
+++ b/ext/fileinfo/libmagic/magic.h
@@ -96,6 +96,7 @@ const char *magic_file(magic_t, const char *);
 const char *magic_stream(magic_t, php_stream *);
 const char *magic_descriptor(magic_t, int);
 const char *magic_buffer(magic_t, const void *, size_t);
+const char *magic_magic_file_get(struct magic_set *ms);
 
 const char *magic_error(magic_t);
 int magic_setflags(magic_t, int);

--- a/ext/fileinfo/php_fileinfo.h
+++ b/ext/fileinfo/php_fileinfo.h
@@ -44,6 +44,7 @@ PHP_FUNCTION(finfo_set_flags);
 PHP_FUNCTION(finfo_file);
 PHP_FUNCTION(finfo_buffer);
 PHP_FUNCTION(mime_content_type);
+PHP_FUNCTION(finfo_magic_file_get);
 
 #ifdef ZTS
 #define FILEINFO_G(v) TSRMG(fileinfo_globals_id, zend_fileinfo_globals *, v)

--- a/ext/fileinfo/tests/finfo_magic_file_get_env.phpt
+++ b/ext/fileinfo/tests/finfo_magic_file_get_env.phpt
@@ -7,7 +7,7 @@ if (!class_exists('finfo'))
 --FILE--
 <?php
 
-putenv('MAGIC=' . __DIR__ .'/magic');
+putenv('MAGIC=' . __DIR__ . DIRECTORY_SEPARATOR . 'magic');
 
 $finfo = new finfo(FILEINFO_NONE);
 $path = $finfo->getMagicFile();

--- a/ext/fileinfo/tests/finfo_magic_file_get_env.phpt
+++ b/ext/fileinfo/tests/finfo_magic_file_get_env.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test the external magic file path from env
+--SKIPIF--
+<?php
+if (!class_exists('finfo'))
+	die('skip no fileinfo extension');
+--FILE--
+<?php
+
+putenv('MAGIC=' . __DIR__ .'/magic');
+
+$finfo = new finfo(FILEINFO_NONE);
+$path = $finfo->getMagicFile();
+var_dump(substr($path, strlen(dirname(__DIR__, 3))));
+
+$finfo = finfo_open(FILEINFO_NONE);
+$path = finfo_magic_file_get($finfo);
+var_dump(substr($path, strlen(dirname(__DIR__, 3))));
+
+?>
+===DONE===
+--EXPECT--
+string(25) "/ext/fileinfo/tests/magic"
+string(25) "/ext/fileinfo/tests/magic"
+===DONE===
+

--- a/ext/fileinfo/tests/finfo_magic_file_get_env.phpt
+++ b/ext/fileinfo/tests/finfo_magic_file_get_env.phpt
@@ -19,8 +19,8 @@ var_dump(substr($path, strlen(dirname(__DIR__, 3))));
 
 ?>
 ===DONE===
---EXPECT--
-string(25) "/ext/fileinfo/tests/magic"
-string(25) "/ext/fileinfo/tests/magic"
+--EXPECTF--
+string(25) "%eext%efileinfo%etests%emagic"
+string(25) "%eext%efileinfo%etests%emagic"
 ===DONE===
 

--- a/ext/fileinfo/tests/finfo_magic_file_get_external.phpt
+++ b/ext/fileinfo/tests/finfo_magic_file_get_external.phpt
@@ -7,11 +7,11 @@ if (!class_exists('finfo'))
 --FILE--
 <?php
 
-$finfo = new finfo(FILEINFO_NONE, __DIR__.'/magic');
+$finfo = new finfo(FILEINFO_NONE,  __DIR__ . DIRECTORY_SEPARATOR . 'magic');
 $path = $finfo->getMagicFile();
 var_dump(substr($path, strlen(dirname(__DIR__, 3))));
 
-$finfo = finfo_open(FILEINFO_NONE, __DIR__.'/magic');
+$finfo = finfo_open(FILEINFO_NONE,  __DIR__ . DIRECTORY_SEPARATOR . 'magic');
 $path = finfo_magic_file_get($finfo);
 var_dump(substr($path, strlen(dirname(__DIR__, 3))));
 

--- a/ext/fileinfo/tests/finfo_magic_file_get_external.phpt
+++ b/ext/fileinfo/tests/finfo_magic_file_get_external.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test the external magic file path
+--SKIPIF--
+<?php
+if (!class_exists('finfo'))
+	die('skip no fileinfo extension');
+--FILE--
+<?php
+
+$finfo = new finfo(FILEINFO_NONE, __DIR__.'/magic');
+$path = $finfo->getMagicFile();
+var_dump(substr($path, strlen(dirname(__DIR__, 3))));
+
+$finfo = finfo_open(FILEINFO_NONE, __DIR__.'/magic');
+$path = finfo_magic_file_get($finfo);
+var_dump(substr($path, strlen(dirname(__DIR__, 3))));
+
+?>
+===DONE===
+--EXPECT--
+string(25) "/ext/fileinfo/tests/magic"
+string(25) "/ext/fileinfo/tests/magic"
+===DONE===
+

--- a/ext/fileinfo/tests/finfo_magic_file_get_external.phpt
+++ b/ext/fileinfo/tests/finfo_magic_file_get_external.phpt
@@ -17,8 +17,8 @@ var_dump(substr($path, strlen(dirname(__DIR__, 3))));
 
 ?>
 ===DONE===
---EXPECT--
-string(25) "/ext/fileinfo/tests/magic"
-string(25) "/ext/fileinfo/tests/magic"
+--EXPECTF--
+string(25) "%eext%efileinfo%etests%emagic"
+string(25) "%eext%efileinfo%etests%emagic"
 ===DONE===
 

--- a/ext/fileinfo/tests/finfo_magic_file_get_internal.phpt
+++ b/ext/fileinfo/tests/finfo_magic_file_get_internal.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test the internal magic file path
+--SKIPIF--
+<?php
+if (!class_exists('finfo'))
+	die('skip no fileinfo extension');
+--FILE--
+<?php
+
+$finfo = new finfo();
+var_dump($finfo->getMagicFile());
+
+$finfo = finfo_open();
+var_dump(finfo_magic_file_get($finfo));
+
+?>
+===DONE===
+--EXPECT--
+string(0) ""
+string(0) ""
+===DONE===
+


### PR DESCRIPTION
If the magic file is not set in finfo_open() or in the finfo::__construct() or pass NULL in the $magic_file parameter, the internal function search in the environment variables MAGIC for a magic file path. This functions return the path to the used magic file or an empty string if the internal magic data is used.

string finfo::getMagicFile()
string finfo_magic_file_get(resource $finfo)
