### PR TITLE
http_cookie_set and http_cookie_remove

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1437,6 +1437,16 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_setrawcookie, 0, 0, 1)
 	ZEND_ARG_INFO(0, httponly)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_http_cookie_set, 0, 0, 2)
+	ZEND_ARG_INFO(0, name)
+	ZEND_ARG_INFO(0, value)
+	ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_http_cookie_remove, 0)
+	ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_headers_sent, 0, 0, 0)
 	ZEND_ARG_INFO(1, file)
 	ZEND_ARG_INFO(1, line)
@@ -3034,6 +3044,8 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 
 	PHP_FE(setcookie,														arginfo_setcookie)
 	PHP_FE(setrawcookie,													arginfo_setrawcookie)
+	PHP_FE(http_cookie_set,													arginfo_http_cookie_set)
+	PHP_FE(http_cookie_remove,												arginfo_http_cookie_remove)
 	PHP_FE(header,															arginfo_header)
 	PHP_FE(header_remove,													arginfo_header_remove)
 	PHP_FE(headers_sent,													arginfo_headers_sent)
@@ -3619,6 +3631,10 @@ PHP_MINIT_FUNCTION(basic) /* {{{ */
 	REGISTER_LONG_CONSTANT("PHP_URL_FRAGMENT", PHP_URL_FRAGMENT, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("PHP_QUERY_RFC1738", PHP_QUERY_RFC1738, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("PHP_QUERY_RFC3986", PHP_QUERY_RFC3986, CONST_CS | CONST_PERSISTENT);
+
+	REGISTER_LONG_CONSTANT("HTTP_COOKIE_ENCODE_NONE", HTTP_COOKIE_ENCODE_NONE, CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("HTTP_COOKIE_ENCODE_RFC1738", HTTP_COOKIE_ENCODE_RFC1738, CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("HTTP_COOKIE_ENCODE_RFC3986", HTTP_COOKIE_ENCODE_RFC3986, CONST_CS | CONST_PERSISTENT);
 
 #define REGISTER_MATH_CONSTANT(x)  REGISTER_DOUBLE_CONSTANT(#x, x, CONST_CS | CONST_PERSISTENT)
 	REGISTER_MATH_CONSTANT(M_E);

--- a/ext/standard/head.h
+++ b/ext/standard/head.h
@@ -28,11 +28,17 @@
 #define COOKIE_SECURE     "; secure"
 #define COOKIE_HTTPONLY   "; HttpOnly"
 
+#define HTTP_COOKIE_ENCODE_NONE 0
+#define HTTP_COOKIE_ENCODE_RFC1738 1
+#define HTTP_COOKIE_ENCODE_RFC3986 2
+
 extern PHP_RINIT_FUNCTION(head);
 PHP_FUNCTION(header);
 PHP_FUNCTION(header_remove);
 PHP_FUNCTION(setcookie);
 PHP_FUNCTION(setrawcookie);
+PHP_FUNCTION(http_cookie_set);
+PHP_FUNCTION(http_cookie_remove);
 PHP_FUNCTION(headers_sent);
 PHP_FUNCTION(headers_list);
 PHP_FUNCTION(http_response_code);


### PR DESCRIPTION
bool http_cookie_set(string $name, string $value [, array $options])

expires: int, default: 0
path: string, default: ""
domain: string, default: ""
secure: bool, default: false
httponly: bool, default: false
encode: int, default: HTTP_COOKIE_ENCODE_RFC1738 

Contants for encode option:
    HTTP_COOKIE_ENCODE_NONE (same as setrawcookie)
    HTTP_COOKIE_ENCODE_RFC1738 (same encoding as setcookie)
    HTTP_COOKIE_ENCODE_RFC3986

If encoding is HTTP_COOKIE_ENCODE_NONE, then no encoding is performed. The caller is responsible for a correct encoding.

If encoding is HTTP_COOKIE_ENCODE_RFC1738, then encoding is performed per RFC 1738 and the application/x-www-form-urlencoded media type, which implies that spaces are encoded as plus (+) signs.

If encoding is HTTP_COOKIE_ENCODE_RFC3986, then encoding is performed according to RFC 3986, and spaces will be percent encoded (%20).

Set cookie with httponly without unnecessary pass the default values for $path, $domain or $secure like setcoookie() or setrawcookie()

    http_cookie_set('foo', 'bar', [
        'httponly' => true
    ]); 

Disable encoding and encode the value with another function:

    http_cookie_set('foo', base64_encode($value), [
        'httponly' => true,
        'encoding' => HTTP_COOKIE_ENCODE_NONE
    ]);

bool http_cookie_remove(string $name);
Remove a cookie. No more need to look into the manual if the correct value is "", NULL or 0 to remove cookies.