### PR TITLE
Update copyright year to 2017

### DIFF
--- a/ext/oci8/oci8_failover.c
+++ b/ext/oci8/oci8_failover.c
@@ -2,7 +2,7 @@
    +----------------------------------------------------------------------+
    | PHP Version 7                                                        |
    +----------------------------------------------------------------------+
-   | Copyright (c) 1997-2016 The PHP Group                                |
+   | Copyright (c) 1997-2017 The PHP Group                                |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/ext/phar/phar.1.in
+++ b/ext/phar/phar.1.in
@@ -1,4 +1,4 @@
-.TH PHAR 1 "2016" "The PHP Group" "User Commands"
+.TH PHAR 1 "2017" "The PHP Group" "User Commands"
 .SH NAME
 phar, phar.phar \- PHAR (PHP archive) command line tool
 .SH SYNOPSIS
@@ -507,7 +507,7 @@ contributors all around the world.
 .SH VERSION INFORMATION
 This manpage describes \fBphar\fP, version @PHP_VERSION@.
 .SH COPYRIGHT
-Copyright \(co 1997\-2016 The PHP Group
+Copyright \(co 1997\-2017 The PHP Group
 .LP
 This source file is subject to version 3.01 of the PHP license,
 that is bundled with this package in the file LICENSE, and is

--- a/sapi/cli/php.1.in
+++ b/sapi/cli/php.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@php 1 "2016" "The PHP Group" "Scripting Language"
+.TH @program_prefix@php 1 "2017" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@php \- PHP Command Line Interface 'CLI'
 .P
@@ -454,7 +454,7 @@ contributors all around the world.
 .SH VERSION INFORMATION
 This manpage describes \fBphp\fP, version @PHP_VERSION@.
 .SH COPYRIGHT
-Copyright \(co 1997\-2016 The PHP Group
+Copyright \(co 1997\-2017 The PHP Group
 .LP
 This source file is subject to version 3.01 of the PHP license,
 that is bundled with this package in the file LICENSE, and is

--- a/sapi/fpm/php-fpm.8.in
+++ b/sapi/fpm/php-fpm.8.in
@@ -1,4 +1,4 @@
-.TH PHP-FPM 8 "2016" "The PHP Group" "Scripting Language"
+.TH PHP-FPM 8 "2017" "The PHP Group" "Scripting Language"
 .SH NAME
 .TP 15
 php-fpm \- PHP FastCGI Process Manager 'PHP-FPM'
@@ -213,7 +213,7 @@ contributors all around the world.
 .SH VERSION INFORMATION
 This manpage describes \fBphp-fpm\fP, version @PHP_VERSION@.
 .SH COPYRIGHT
-Copyright \(co 1997\-2016 The PHP Group
+Copyright \(co 1997\-2017 The PHP Group
 .PD 0
 .P
 Copyright (c) 2007-2009, Andrei Nigmatulin

--- a/scripts/man1/php-config.1.in
+++ b/scripts/man1/php-config.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@php\-config 1 "2016" "The PHP Group" "Scripting Language"
+.TH @program_prefix@php\-config 1 "2017" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@php\-config \- get information about PHP configuration and compile options
 .SH SYNOPSIS
@@ -65,7 +65,7 @@ PHP version as integer
 .SH VERSION INFORMATION
 This manpage describes \fBphp\fP, version @PHP_VERSION@.
 .SH COPYRIGHT
-Copyright \(co 1997\-2016 The PHP Group
+Copyright \(co 1997\-2017 The PHP Group
 .LP
 This source file is subject to version 3.01 of the PHP license,
 that is bundled with this package in the file LICENSE, and is

--- a/scripts/man1/phpize.1.in
+++ b/scripts/man1/phpize.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@phpize 1 "2016" "The PHP Group" "Scripting Language"
+.TH @program_prefix@phpize 1 "2017" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@phpize \- prepare a PHP extension for compiling
 .SH SYNOPSIS
@@ -32,7 +32,7 @@ Prints API version information
 .SH VERSION INFORMATION
 This manpage describes \fBphp\fP, version @PHP_VERSION@.
 .SH COPYRIGHT
-Copyright \(co 1997\-2016 The PHP Group
+Copyright \(co 1997\-2017 The PHP Group
 .LP
 This source file is subject to version 3.01 of the PHP license,
 that is bundled with this package in the file LICENSE, and is


### PR DESCRIPTION
This is a minor patch that updates some missed copyright 2016 years to 2017. It targets PHP-7.0 branch and above to master. Thank you for considering merging it or checking it out.