### PR TITLE
Bug #74975: XMLRPC: Different serialization for classes

### DIFF
--- a/ext/xmlrpc/tests/bug74975.phpt
+++ b/ext/xmlrpc/tests/bug74975.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Bug #74975	Different serialization for classes
+--SKIPIF--
+<?php
+if (!extension_loaded("xmlrpc")) print "skip";
+?>
+--FILE--
+<?php
+
+class Foo {
+    
+}
+
+class Bar {
+    
+    public $xmlrpc_type;
+    public $scalar;
+    
+}
+
+$foo = new Foo();
+$foo->xmlrpc_type = 'base64';
+$foo->scalar = 'foobar';
+
+$bar = new Bar();
+$bar->xmlrpc_type = 'base64';
+$bar->scalar = 'foobar';
+
+echo xmlrpc_encode([
+    'foo' => $foo,
+    'bar' => $bar
+]);
+
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="utf-8"?>
+<params>
+<param>
+ <value>
+  <struct>
+   <member>
+    <name>foo</name>
+    <value>
+     <base64>Zm9vYmFy&#10;</base64>
+    </value>
+   </member>
+   <member>
+    <name>bar</name>
+    <value>
+     <base64>Zm9vYmFy&#10;</base64>
+    </value>
+   </member>
+  </struct>
+ </value>
+</param>
+</params>

--- a/ext/xmlrpc/xmlrpc-epi-php.c
+++ b/ext/xmlrpc/xmlrpc-epi-php.c
@@ -1355,6 +1355,9 @@ XMLRPC_VALUE_TYPE get_zval_xmlrpc_type(zval* value, zval* newvalue) /* {{{ */
 					type = xmlrpc_vector;
 
 					if ((attr = zend_hash_str_find(Z_OBJPROP_P(value), OBJECT_TYPE_ATTR, sizeof(OBJECT_TYPE_ATTR) - 1)) != NULL) {
+						if(Z_TYPE_P(attr) == IS_INDIRECT) {
+							attr = Z_INDIRECT_P(attr);
+						}
 						if (Z_TYPE_P(attr) == IS_STRING) {
 							type = xmlrpc_str_as_type(Z_STRVAL_P(attr));
 						}
@@ -1369,6 +1372,9 @@ XMLRPC_VALUE_TYPE get_zval_xmlrpc_type(zval* value, zval* newvalue) /* {{{ */
 
 			if ((type == xmlrpc_base64 && Z_TYPE_P(value) == IS_OBJECT) || type == xmlrpc_datetime) {
 				if ((val = zend_hash_str_find(Z_OBJPROP_P(value), OBJECT_VALUE_ATTR, sizeof(OBJECT_VALUE_ATTR) - 1)) != NULL) {
+					if(Z_TYPE_P(val) == IS_INDIRECT) {
+						val = Z_INDIRECT_P(val);
+					}
 					ZVAL_COPY_VALUE(newvalue, val);
 				}
 			} else {

--- a/ext/xmlrpc/xmlrpc-epi-php.c
+++ b/ext/xmlrpc/xmlrpc-epi-php.c
@@ -1354,10 +1354,7 @@ XMLRPC_VALUE_TYPE get_zval_xmlrpc_type(zval* value, zval* newvalue) /* {{{ */
 					zval* attr;
 					type = xmlrpc_vector;
 
-					if ((attr = zend_hash_str_find(Z_OBJPROP_P(value), OBJECT_TYPE_ATTR, sizeof(OBJECT_TYPE_ATTR) - 1)) != NULL) {
-						if(Z_TYPE_P(attr) == IS_INDIRECT) {
-							attr = Z_INDIRECT_P(attr);
-						}
+					if ((attr = zend_hash_str_find_ind(Z_OBJPROP_P(value), OBJECT_TYPE_ATTR, sizeof(OBJECT_TYPE_ATTR) - 1)) != NULL) {
 						if (Z_TYPE_P(attr) == IS_STRING) {
 							type = xmlrpc_str_as_type(Z_STRVAL_P(attr));
 						}
@@ -1371,10 +1368,7 @@ XMLRPC_VALUE_TYPE get_zval_xmlrpc_type(zval* value, zval* newvalue) /* {{{ */
 			zval* val;
 
 			if ((type == xmlrpc_base64 && Z_TYPE_P(value) == IS_OBJECT) || type == xmlrpc_datetime) {
-				if ((val = zend_hash_str_find(Z_OBJPROP_P(value), OBJECT_VALUE_ATTR, sizeof(OBJECT_VALUE_ATTR) - 1)) != NULL) {
-					if(Z_TYPE_P(val) == IS_INDIRECT) {
-						val = Z_INDIRECT_P(val);
-					}
+				if ((val = zend_hash_str_find_ind(Z_OBJPROP_P(value), OBJECT_VALUE_ATTR, sizeof(OBJECT_VALUE_ATTR) - 1)) != NULL) {
 					ZVAL_COPY_VALUE(newvalue, val);
 				}
 			} else {


### PR DESCRIPTION
xmlrpc_encode and xmlrpc_encode_request works different if the properties $xmlrpc_type and $scalar are defined before assigning values to an object.

If the properties $xmlrpc_type and $scalar are defined, xmlrpc_encode* don't use the values for serialization.

https://bugs.php.net/bug.php?id=74975