### PR TITLE
Fix typo in PHP 7.2 changelog

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -161,7 +161,7 @@ All the deprecated functionality listed in the following will be removed in
 PHP 8.0.
 
 - Core:
-  . The trace_errors ini directive has been deprecated.
+  . The track_errors ini directive has been deprecated.
   . The __autoload() mechanism has been deprecated, use spl_autoload_register()
     instead.
   . The (unset) cast has been deprecated. This does not affect the unset($var)


### PR DESCRIPTION
See: https://github.com/php/php-src/commit/c61daf415d0207abda6041a3ed12c23b6a9d8ebf