### PR TITLE
Fix ext/sodium display in phpinfo()

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -520,8 +520,8 @@ PHP_MINFO_FUNCTION(sodium)
 {
 	php_info_print_table_start();
 	php_info_print_table_header(2, "sodium support", "enabled");
-	php_info_print_table_header(2, "libsodium headers version", SODIUM_VERSION_STRING);
-	php_info_print_table_header(2, "libsodium library version", sodium_version_string());
+	php_info_print_table_row(2, "libsodium headers version", SODIUM_VERSION_STRING);
+	php_info_print_table_row(2, "libsodium library version", sodium_version_string());
 	php_info_print_table_end();
 }
 


### PR DESCRIPTION
Changes the display of ext/sodium in `phpinfo()` from ugly:

<img width="954" alt="screen shot 2017-07-24 at 5 14 42 pm" src="https://user-images.githubusercontent.com/578780/28547336-08045484-7094-11e7-8e11-a79349a5d2e8.png">

To slightly less ugly. :)

<img width="953" alt="screen shot 2017-07-24 at 5 15 47 pm" src="https://user-images.githubusercontent.com/578780/28547342-108cd130-7094-11e7-81de-4289bd81c2f2.png">
