### PR TITLE
Fix bug #74991 - include_path has a 4096 char (minus "__DIR__:") limit, in some PHAR cases

### DIFF
--- a/ext/phar/tests/bug74991.phpt
+++ b/ext/phar/tests/bug74991.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Phar: PHP bug #74991: include_path has a 4096 char (minus "__DIR__:") limit, in some PHAR cases
+--SKIPIF--
+<?php if (!extension_loaded("phar")) die("skip");
+--INI--
+phar.readonly=0
+--FILE--
+<?php
+// create a sample file in a custom include_path to lookup from the phar later:
+mkdir('path');
+touch('path/needle.php');
+$p = new Phar('sample.phar');
+// the use of a sub path is crucial, and make the include_path 1 byte larger (=OVERFLOW) than the MAXPATHLEN, the include_path will then be truncated to 4096 (MAXPATHLEN) into 'phar://..sample.phar/some:xx..xx:pat' so it will fail to find needle.php:
+$p['some/file'] = "<?php const MAXPATHLEN = 4096, OVERFLOW = 1, PATH = 'path'; set_include_path(str_repeat('x', MAXPATHLEN - strlen(__DIR__ . PATH_SEPARATOR . PATH_SEPARATOR . PATH) + OVERFLOW) . PATH_SEPARATOR . PATH); require('needle.php');";
+$p->setStub("<?php Phar::mapPhar('sample.phar'); __HALT_COMPILER();");
+// execute the phar code:
+require('phar://sample.phar/some/file');
+--CLEAN--
+<?php
+unlink('path/needle.php');
+unlink('sample.phar');
+rmdir('path');
+--EXPECT--

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -309,7 +309,7 @@ splitted:
 		efree(test);
 	}
 
-	spprintf(&path, MAXPATHLEN, "phar://%s/%s%c%s", arch, PHAR_G(cwd), DEFAULT_DIR_SEPARATOR, PG(include_path));
+	spprintf(&path, MAXPATHLEN + 1 + strlen(PG(include_path)), "phar://%s/%s%c%s", arch, PHAR_G(cwd), DEFAULT_DIR_SEPARATOR, PG(include_path));
 	efree(arch);
 	ret = php_resolve_path(filename, filename_len, path);
 	efree(path);


### PR DESCRIPTION
Fix for PHP bug [#74991](https://bugs.php.net/bug.php?id=74991), thereby fixing https://github.com/civicrm/cv/issues/23.