### PR TITLE
check for NULL, resolves https://bugs.php.net/bug.php?id=74481

### DIFF
--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2188,6 +2188,10 @@ PHPAPI zval *php_stream_context_get_option(php_stream_context *context,
 {
 	zval *wrapperhash;
 
+	if(!context) {
+		return NULL;
+	}
+
 	if (NULL == (wrapperhash = zend_hash_str_find(Z_ARRVAL(context->options), wrappername, strlen(wrappername)))) {
 		return NULL;
 	}


### PR DESCRIPTION
here's gdb backtrace

```
[root@vm-95700201 public_html]# gdb --core core.10863 `which php`
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-94.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /usr/bin/php...Reading symbols from /usr/lib/debug/usr/bin/php.debug...done.
done.
[New LWP 10863]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `php index_dev.php'.
Program terminated with signal 11, Segmentation fault.
#0  0x00007fb3227471fe in php_stream_context_get_option (context=0x0, wrappername=0x7fb308ee8cf4 "zip", optionname=0x7fb308ee992a "password", 
    optionvalue=0x7ffdd9ced9a8) at /usr/src/debug/php-5.6.31/main/streams/streams.c:2227
2227		if (FAILURE == zend_hash_find(Z_ARRVAL_P(context->options), (char*)wrappername, strlen(wrappername)+1, (void**)&wrapperhash)) {
Missing separate debuginfos, use: debuginfo-install aspell-0.60.6.1-9.el7.x86_64 audit-libs-2.6.5-3.el7_3.1.x86_64 bzip2-libs-1.0.6-13.el7.x86_64 cyrus-sasl-lib-2.1.26-20.el7_2.x86_64 expat-2.1.0-10.el7_3.x86_64 fontconfig-2.10.95-10.el7.x86_64 freetype-2.4.11-12.el7.x86_64 gd-last-2.2.4-1.el7.remi.x86_64 gmp-6.0.0-12.el7_1.x86_64 jbigkit-libs-2.0-11.el7.x86_64 keyutils-libs-1.5.8-3.el7.x86_64 libX11-1.6.3-3.el7.x86_64 libXau-1.0.8-2.1.el7.x86_64 libXpm-3.5.11-3.el7.x86_64 libc-client-2007f-4.el7.1.x86_64 libcap-ng-0.7.5-4.el7.x86_64 libcurl-7.29.0-35.el7.centos.x86_64 libgcrypt-1.5.3-13.el7_3.1.x86_64 libgpg-error-1.12-3.el7.x86_64 libicu-50.1.2-15.el7.x86_64 libidn-1.28-4.el7.x86_64 libjpeg-turbo-1.2.90-5.el7.x86_64 libmcrypt-2.5.8-13.el7.x86_64 libpng-1.5.13-7.el7_2.x86_64 libselinux-2.5-6.el7.x86_64 libssh2-1.4.3-10.el7_2.1.x86_64 libtidy-5.4.0-1.el7.x86_64 libtiff-4.0.3-27.el7_3.x86_64 libtool-ltdl-2.4.2-22.el7_3.x86_64 libwebp-0.3.0-3.el7.x86_64 libxcb-1.11-4.el7.x86_64 libxslt-1.1.28-5.el7.x86_64 libzip5-1.2.0-1.el7.remi.x86_64 nspr-4.13.1-1.0.el7_3.x86_64 nss-3.28.4-1.0.el7_3.x86_64 nss-softokn-freebl-3.16.2.3-14.4.el7.x86_64 nss-util-3.28.4-1.0.el7_3.x86_64 openldap-2.4.40-13.el7.x86_64 pam-1.1.8-18.el7.x86_64 php-pecl-jsonc-1.3.10-2.el7.remi.5.6.x86_64 php-pecl-zip-1.14.0-1.el7.remi.5.6.x86_64 php56-php-pecl-apcu-4.0.11-1.el7.remi.x86_64 recode-3.6-38.el7.x86_64 sqlite-3.7.17-8.el7.x86_64 t1lib-5.1.2-14.el7.x86_64 xz-libs-5.2.2-1.el7.x86_64
(gdb) bt
#0  0x00007fb3227471fe in php_stream_context_get_option (context=0x0, wrappername=0x7fb308ee8cf4 "zip", optionname=0x7fb308ee992a "password", 
    optionvalue=0x7ffdd9ced9a8) at /usr/src/debug/php-5.6.31/main/streams/streams.c:2227
#1  0x00007fb308ee8a82 in php_stream_zip_opener () from /usr/lib64/php/modules/zip.so
#2  0x00007fb322746cec in _php_stream_open_wrapper_ex (
    path=0x7fb3086e3df8 "zip:///home/itpanda/web/a1208.clouditp.ru/web/uploads/ftp/order_template.xlsx#xl/media/image1.png", 
    mode=mode@entry=0x7fb32286e74c "rb", options=<optimized out>, options@entry=24, opened_path=opened_path@entry=0x0, 
    context=context@entry=0x0) at /usr/src/debug/php-5.6.31/main/streams/streams.c:2059
#3  0x00007fb3226e593b in php_getimagesize_from_any (ht=1, return_value=0x7fb308756988, mode=1, return_value_used=<optimized out>, 
    this_ptr=<optimized out>, return_value_ptr=<optimized out>) at /usr/src/debug/php-5.6.31/ext/standard/image.c:1408
#4  0x00007fb32283a021 in zend_do_fcall_common_helper_SPEC (execute_data=<optimized out>)
    at /usr/src/debug/php-5.6.31/Zend/zend_vm_execute.h:558
#5  0x00007fb3227ce0e8 in execute_ex (execute_data=0x7fb3224f92d8) at /usr/src/debug/php-5.6.31/Zend/zend_vm_execute.h:363
#6  0x00007fb3227929cb in zend_execute_scripts (type=type@entry=8, retval=retval@entry=0x0, file_count=file_count@entry=3)
    at /usr/src/debug/php-5.6.31/Zend/zend.c:1353
#7  0x00007fb32272d682 in php_execute_script (primary_file=primary_file@entry=0x7ffdd9cf1080) at /usr/src/debug/php-5.6.31/main/main.c:2613
#8  0x00007fb32283bcf8 in do_cli (argc=2, argv=0x7fb322cacd80) at /usr/src/debug/php-5.6.31/sapi/cli/php_cli.c:998
#9  0x00007fb3226081ba in main (argc=2, argv=0x7fb322cacd80) at /usr/src/debug/php-5.6.31/sapi/cli/php_cli.c:1382
(gdb) 
```