### PR TITLE
Fix #75031: Support append mode in `php://temp` streams

### DIFF
--- a/ext/standard/php_fopen_wrapper.c
+++ b/ext/standard/php_fopen_wrapper.c
@@ -28,6 +28,7 @@
 #include "php.h"
 #include "php_globals.h"
 #include "php_standard.h"
+#include "php_memory_streams.h"
 #include "php_fopen_wrappers.h"
 #include "SAPI.h"
 
@@ -203,20 +204,12 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
 				return NULL;
 			}
 		}
-		if (strpbrk(mode, "wa+")) {
-			mode_rw = TEMP_STREAM_DEFAULT;
-		} else {
-			mode_rw = TEMP_STREAM_READONLY;
-		}
+		mode_rw = php_stream_mode_from_str(mode);
 		return php_stream_temp_create(mode_rw, max_memory);
 	}
 
 	if (!strcasecmp(path, "memory")) {
-		if (strpbrk(mode, "wa+")) {
-			mode_rw = TEMP_STREAM_DEFAULT;
-		} else {
-			mode_rw = TEMP_STREAM_READONLY;
-		}
+		mode_rw = php_stream_mode_from_str(mode);
 		return php_stream_memory_create(mode_rw);
 	}
 

--- a/ext/standard/tests/streams/bug75031.phpt
+++ b/ext/standard/tests/streams/bug75031.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug #75031: Append mode in php://temp and php://memory 
+--FILE--
+<?php
+
+function test_75031($type, $mode) {
+    $fp = fopen($type, $mode);
+    fwrite($fp, "hello");
+    fseek($fp, 0, SEEK_SET);
+    fwrite($fp, "world");
+    var_dump(stream_get_contents($fp, -1, 0));
+    fclose($fp);
+}
+
+test_75031("php://temp", "w+");
+test_75031("php://memory", "w+");
+test_75031("php://temp", "a+");
+test_75031("php://memory", "a+");
+
+?>
+--EXPECT--
+string(5) "world"
+string(5) "world"
+string(10) "helloworld"
+string(10) "helloworld"

--- a/main/php_memory_streams.h
+++ b/main/php_memory_streams.h
@@ -25,9 +25,10 @@
 
 #define PHP_STREAM_MAX_MEM	2 * 1024 * 1024
 
-#define TEMP_STREAM_DEFAULT  0
-#define TEMP_STREAM_READONLY 1
-#define TEMP_STREAM_TAKE_BUFFER 2
+#define TEMP_STREAM_DEFAULT     0x0
+#define TEMP_STREAM_READONLY    0x1
+#define TEMP_STREAM_TAKE_BUFFER 0x2
+#define TEMP_STREAM_APPEND      0x4
 
 #define php_stream_memory_create(mode) _php_stream_memory_create((mode) STREAMS_CC)
 #define php_stream_memory_create_rel(mode) _php_stream_memory_create((mode) STREAMS_REL_CC)
@@ -41,6 +42,7 @@
 #define php_stream_temp_open(mode, max_memory_usage, buf, length) _php_stream_temp_open((mode), (max_memory_usage), (buf), (length) STREAMS_CC)
 
 BEGIN_EXTERN_C()
+
 PHPAPI php_stream *_php_stream_memory_create(int mode STREAMS_DC);
 PHPAPI php_stream *_php_stream_memory_open(int mode, char *buf, size_t length STREAMS_DC);
 PHPAPI char *_php_stream_memory_get_buffer(php_stream *stream, size_t *length STREAMS_DC);
@@ -48,6 +50,10 @@ PHPAPI char *_php_stream_memory_get_buffer(php_stream *stream, size_t *length ST
 PHPAPI php_stream *_php_stream_temp_create(int mode, size_t max_memory_usage STREAMS_DC);
 PHPAPI php_stream *_php_stream_temp_create_ex(int mode, size_t max_memory_usage, const char *tmpdir STREAMS_DC);
 PHPAPI php_stream *_php_stream_temp_open(int mode, size_t max_memory_usage, char *buf, size_t length STREAMS_DC);
+
+PHPAPI int php_stream_mode_from_str(const char *mode);
+PHPAPI const char *_php_stream_mode_to_str(int mode);
+
 END_EXTERN_C()
 
 extern PHPAPI php_stream_ops php_stream_memory_ops;


### PR DESCRIPTION
This patch introduces a distinction between write mode and append
mode in `php://temp` and `php://memory` streams, achieving parity
with C stdio.

https://bugs.php.net/bug.php?id=75031