### PR TITLE
Fix issues with phpt and EXTENSIONS block on windows (BUG 75042)

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1575,15 +1575,16 @@ TEST $file
 
 	// Additional required extensions
 	if (array_key_exists('EXTENSIONS', $section_text)) {
-		$ext_dir=`$php -r 'echo ini_get("extension_dir");'`;
+		$ext_dir=`$php -r "echo ini_get('extension_dir');"`;
 		$extensions = preg_split("/[\n\r]+/", trim($section_text['EXTENSIONS']));
-		$loaded = explode(",", `$php -n -r 'echo implode(",", get_loaded_extensions());'`);
+		$loaded = explode(",", `$php -r "echo implode(',', get_loaded_extensions());"`);
+		$ext_prefix = substr(PHP_OS, 0, 3) === "WIN" ? "php_" : "";
 		foreach ($extensions as $req_ext) {
 			if (!in_array($req_ext, $loaded)) {
 				if ($req_ext == 'opcache') {
-					$ini_settings['zend_extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $req_ext . '.' . PHP_SHLIB_SUFFIX;
+					$ini_settings['zend_extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $ext_prefix . $req_ext . '.' . PHP_SHLIB_SUFFIX;
 				} else {
-					$ini_settings['extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $req_ext . '.' . PHP_SHLIB_SUFFIX;
+					$ini_settings['extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $ext_prefix . $req_ext . '.' . PHP_SHLIB_SUFFIX;
 				}
 			}
 		}

--- a/run-tests.php
+++ b/run-tests.php
@@ -1577,7 +1577,7 @@ TEST $file
 	if (array_key_exists('EXTENSIONS', $section_text)) {
 		$ext_dir=`$php -r "echo ini_get('extension_dir');"`;
 		$extensions = preg_split("/[\n\r]+/", trim($section_text['EXTENSIONS']));
-		$loaded = explode(",", `$php -r "echo implode(',', get_loaded_extensions());"`);
+		$loaded = explode(",", `$php -n -r "echo implode(',', get_loaded_extensions());"`);
 		$ext_prefix = substr(PHP_OS, 0, 3) === "WIN" ? "php_" : "";
 		foreach ($extensions as $req_ext) {
 			if (!in_array($req_ext, $loaded)) {

--- a/run-tests.php
+++ b/run-tests.php
@@ -1575,9 +1575,12 @@ TEST $file
 
 	// Additional required extensions
 	if (array_key_exists('EXTENSIONS', $section_text)) {
-		$ext_dir=`$php -r "echo ini_get('extension_dir');"`;
+		$ext_params = array();
+		settings2array($ini_overwrites, $ext_params);
+		settings2params($ext_params);
+		$ext_dir=`$php $pass_options $ext_params -d display_errors=0 -r "echo ini_get('extension_dir');"`;
 		$extensions = preg_split("/[\n\r]+/", trim($section_text['EXTENSIONS']));
-		$loaded = explode(",", `$php -n -r "echo implode(',', get_loaded_extensions());"`);
+		$loaded = explode(",", `$php $pass_options $ext_params -d display_errors=0 -r "echo implode(',', get_loaded_extensions());"`);
 		$ext_prefix = substr(PHP_OS, 0, 3) === "WIN" ? "php_" : "";
 		foreach ($extensions as $req_ext) {
 			if (!in_array($req_ext, $loaded)) {

--- a/tests/run-test/bug75042-2.phpt
+++ b/tests/run-test/bug75042-2.phpt
@@ -1,0 +1,18 @@
+--TEST--
+phpt EXTENSIONS directive with static module
+--SKIPIF--
+<?php
+if(empty($_ENV['TEST_PHP_EXECUTABLE'])) {
+	die('skip TEST_PHP_EXECUTABLE not set');
+}
+$php = $_ENV['TEST_PHP_EXECUTABLE'];
+if (false === stripos(`$php -n -m`, 'spl')) {
+	die('skip spl is NOT built static');
+}
+--EXTENSIONS--
+SPL
+--FILE--
+<?php
+var_dump(extension_loaded('spl'));
+--EXPECT--
+bool(true)

--- a/tests/run-test/bug75042-3.phpt
+++ b/tests/run-test/bug75042-3.phpt
@@ -1,0 +1,8 @@
+--TEST--
+phpt EXTENSIONS directive with nonexistent shared module
+--EXTENSIONS--
+nonexistentsharedmodule
+--FILE--
+<?php
+--EXPECTF--
+PHP Warning:  PHP Startup: Unable to load dynamic library '%snonexistentsharedmodule.%s' %A

--- a/tests/run-test/bug75042.phpt
+++ b/tests/run-test/bug75042.phpt
@@ -1,12 +1,13 @@
 --TEST--
-phpt EXTENSIONS directive - bug #75042
+phpt EXTENSIONS directive with shared module
 --SKIPIF--
 <?php
-if(!empty($_ENV['TEST_PHP_EXECUTABLE'])) {
-	$php = $_ENV['TEST_PHP_EXECUTABLE'];
-	if (false !== stripos(`$php -n -m`, 'openssl')) {
-		die('skip openssl is built static');
-	}
+if(empty($_ENV['TEST_PHP_EXECUTABLE'])) {
+	die('skip TEST_PHP_EXECUTABLE not set');
+}
+$php = $_ENV['TEST_PHP_EXECUTABLE'];
+if (false !== stripos(`$php -n -m`, 'openssl')) {
+	die('skip openssl is built static');
 }
 $ext_module = ini_get('extension_dir') . DIRECTORY_SEPARATOR . (substr(PHP_OS, 0, 3) === "WIN" ? "php_openssl." : "openssl.") . PHP_SHLIB_SUFFIX;
 if( !file_exists($ext_module) ) die('skip openssl shared extension not found');

--- a/tests/run-test/bug75042.phpt
+++ b/tests/run-test/bug75042.phpt
@@ -1,0 +1,19 @@
+--TEST--
+phpt EXTENSIONS directive - bug #75042
+--SKIPIF--
+<?php
+if(!empty($_ENV['TEST_PHP_EXECUTABLE'])) {
+	$php = $_ENV['TEST_PHP_EXECUTABLE'];
+	if (false !== stripos(`$php -n -m`, 'openssl')) {
+		die('skip openssl is built static');
+	}
+}
+$ext_module = ini_get('extension_dir') . DIRECTORY_SEPARATOR . (substr(PHP_OS, 0, 3) === "WIN" ? "php_openssl." : "openssl.") . PHP_SHLIB_SUFFIX;
+if( !file_exists($ext_module) ) die('skip openssl shared extension not found');
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+var_dump(extension_loaded('openssl'));
+--EXPECT--
+bool(true)


### PR DESCRIPTION
* Commands are not properly escaped for windows
* ~~Specifying "-n" to check loaded modules causes "Module already loaded"
warning~~
* Extensions to be loaded need the "php_" prefix on Windows

Bug: https://bugs.php.net/bug.php?id=75042