### PR TITLE
Request #75053 - Added E_WARNING for integer array index overflow

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -52,6 +52,13 @@
 	 !ZEND_USER_CODE(EX(prev_execute_data)->func->common.type) || \
 	 (EX(prev_execute_data)->opline->result_type != IS_UNUSED))
 
+#define CHECK_LONG_INDEX_OVERFLOW(key)	\
+	if (Z_DVAL_P(key) > ZEND_LONG_MAX) {	\
+		zend_error(E_WARNING, "Array index overflows the maximum integer value");	\
+	} else if (Z_DVAL_P(key) < ZEND_LONG_MIN) { \
+		zend_error(E_WARNING, "Array index overflows the minimum integer value");	\
+	}
+
 #ifdef ZEND_ENABLE_STATIC_TSRMLS_CACHE
 #define ZEND_TSRMG TSRMG_STATIC
 #define ZEND_TSRMLS_CACHE_EXTERN() TSRMLS_CACHE_EXTERN()

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1682,6 +1682,7 @@ ZEND_API int array_set_zval_key(HashTable *ht, zval *key, zval *value) /* {{{ */
 			result = zend_hash_index_update(ht, Z_LVAL_P(key), value);
 			break;
 		case IS_DOUBLE:
+			CHECK_LONG_INDEX_OVERFLOW(key);
 			result = zend_hash_index_update(ht, zend_dval_to_lval(Z_DVAL_P(key)), value);
 			break;
 		default:

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6956,6 +6956,7 @@ static zend_bool zend_try_ct_eval_array(zval *result, zend_ast *ast) /* {{{ */
 					zend_symtable_update(Z_ARRVAL_P(result), Z_STR_P(key), value);
 					break;
 				case IS_DOUBLE:
+					CHECK_LONG_INDEX_OVERFLOW(key);
 					zend_hash_index_update(Z_ARRVAL_P(result),
 						zend_dval_to_lval(Z_DVAL_P(key)), value);
 					break;

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1570,6 +1570,7 @@ str_index:
 				offset_key = ZSTR_EMPTY_ALLOC();
 				goto str_index;
 			case IS_DOUBLE:
+				CHECK_LONG_INDEX_OVERFLOW(dim);
 				hval = zend_dval_to_lval(Z_DVAL_P(dim));
 				goto num_index;
 			case IS_RESOURCE:

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5181,6 +5181,7 @@ ZEND_VM_C_LABEL(num_index):
 			str = ZSTR_EMPTY_ALLOC();
 			ZEND_VM_C_GOTO(str_index);
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			ZEND_VM_C_GOTO(num_index);
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5848,6 +5848,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -7632,6 +7633,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -9867,6 +9869,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -11835,6 +11838,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -13782,6 +13786,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -14511,6 +14516,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -15134,6 +15140,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -15657,6 +15664,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -19747,6 +19755,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -21509,6 +21518,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -24057,6 +24067,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -26555,6 +26566,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -37748,6 +37760,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -40456,6 +40469,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -44254,6 +44268,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {
@@ -47823,6 +47838,7 @@ num_index:
 			str = ZSTR_EMPTY_ALLOC();
 			goto str_index;
 		} else if (Z_TYPE_P(offset) == IS_DOUBLE) {
+			CHECK_LONG_INDEX_OVERFLOW(offset);
 			hval = zend_dval_to_lval(Z_DVAL_P(offset));
 			goto num_index;
 		} else if (Z_TYPE_P(offset) == IS_FALSE) {

--- a/ext/standard/tests/array/bug75053.phpt
+++ b/ext/standard/tests/array/bug75053.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Bug #75053 (Integer array key limitations)
+--FILE--
+<?php
+$arr = [5076964154930102272 => 'some value'];
+$arr[999999999999999999999999999999] = 'another value';
+$arr[-999999999999999999999999999999] = 'another value 2';
+$arr[99.99] = 'another value 3';
+var_dump($arr);
+$arr = [
+    5076964154930102272 => 'some value',
+    999999999999999999999999999999 => 'another value',
+    -999999999999999999999999999999 => 'another value 2',
+    99.99 => 'another value 3'
+];
+var_dump($arr);
+
+?>
+--EXPECTF--
+Warning: Array index overflows the maximum integer value in %s on line %s
+
+Warning: Array index overflows the minimum integer value in %s on line %s
+
+Warning: Array index overflows the maximum integer value in %s on line %s
+
+Warning: Array index overflows the minimum integer value in %s on line %s
+array(%s) {
+  [5076964154930102272]=>
+  string(%s) "another value"
+  [-5076964154930102272]=>
+  string(%s) "another value 2"
+  [99]=>
+  string(%s) "another value 3"
+}
+array(%s) {
+  [5076964154930102272]=>
+  string(%s) "another value"
+  [-5076964154930102272]=>
+  string(%s) "another value 2"
+  [99]=>
+  string(%s) "another value 3"
+}


### PR DESCRIPTION
Here is alternative solution for https://bugs.php.net/bug.php?id=75053
Now when integer array index overflow happens `E_WARNING` raised.

Alternative solution here: https://github.com/php/php-src/pull/2676