### PR TITLE
openssl: add basic openssl_get_cert_locations test

### DIFF
--- a/ext/openssl/tests/openssl_get_cert_locations_basic.phpt
+++ b/ext/openssl/tests/openssl_get_cert_locations_basic.phpt
@@ -1,0 +1,28 @@
+--TEST--
+openssl_get_cert_locations() tests
+--SKIPIF--
+<?php if (!extension_loaded("openssl")) print "skip"; ?>
+--FILE--
+<?php
+// openssl locations differ per distro.
+var_dump(openssl_get_cert_locations());
+?>
+--EXPECTF--
+array(8) {
+  ["default_cert_file"]=>
+  string(%d) "%s"
+  ["default_cert_file_env"]=>
+  string(%d) "%s"
+  ["default_cert_dir"]=>
+  string(%d) "%s"
+  ["default_cert_dir_env"]=>
+  string(%d) "%s"
+  ["default_private_dir"]=>
+  string(%d) "%s"
+  ["default_default_cert_area"]=>
+  string(%d) "%s"
+  ["ini_cafile"]=>
+  string(%d) ""
+  ["ini_capath"]=>
+  string(%d) ""
+}


### PR DESCRIPTION
Add a simple test for openssl_get_cert_locations, exact locations can't
be hardcoded since they differ per distro.