### PR TITLE
openssl: Fix openssl_pkcs12_export extracerts test

### DIFF
--- a/ext/openssl/tests/openssl_pkcs12_export_basic.phpt
+++ b/ext/openssl/tests/openssl_pkcs12_export_basic.phpt
@@ -23,9 +23,9 @@ var_dump(openssl_pkcs12_export($cert_path, $output, $priv_path, $pass)); // read
 var_dump(openssl_pkcs12_read($output, $opts, $pass));
 var_dump(openssl_pkcs12_export($cert_res, $output, $priv_res, $pass)); // read certs from a resource
 var_dump(openssl_pkcs12_read($output, $opts, $pass));
-var_dump(openssl_pkcs12_export($cert, $output, $priv, $pass, array($cert))); // extra optional cert
+var_dump(openssl_pkcs12_export($cert, $output, $priv, $pass, array('extracerts' => $cert))); // extra optional cert
 var_dump(openssl_pkcs12_read($output, $opts, $pass));
-//var_dump(count($opts)); // should be 3 certificates, priv, pub, extra optional cert
+var_dump(count($opts)); // should be 3 certificates, priv, pub, extra optional cert
 
 
 var_dump(openssl_pkcs12_export($invalid, $output, $invalid, $pass));
@@ -42,6 +42,7 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
+int(3)
 
 Warning: openssl_pkcs12_export(): cannot get cert from parameter 1 in %s on line %d
 bool(false)


### PR DESCRIPTION
Fix the openssl_pkcs12_export testcase for extracerts, the 'extracerts'
option needs to be the key of the certificate value otherwise
openssl_pkcs12_export will ignore it.