### PR TITLE
Fix for mysqlnd error handling bug on BSD platforms.

### DIFF
--- a/ext/mysqlnd/mysqlnd_priv.h
+++ b/ext/mysqlnd/mysqlnd_priv.h
@@ -105,7 +105,7 @@
 	} else { \
 		(error_info).error_no = (a); \
 		strlcpy((error_info).sqlstate, (b), sizeof((error_info).sqlstate)); \
-		if (&(error_info).error != (c)) { \
+		if ((error_info).error != (c)) { \
 			strlcpy((error_info).error, (c), sizeof((error_info).error)); \
 		} \
 		if ((error_info).error_list) {\

--- a/ext/mysqlnd/mysqlnd_priv.h
+++ b/ext/mysqlnd/mysqlnd_priv.h
@@ -105,7 +105,9 @@
 	} else { \
 		(error_info).error_no = (a); \
 		strlcpy((error_info).sqlstate, (b), sizeof((error_info).sqlstate)); \
-		strlcpy((error_info).error, (c), sizeof((error_info).error)); \
+		if (&(error_info).error != (c)) { \
+			strlcpy((error_info).error, (c), sizeof((error_info).error)); \
+		} \
 		if ((error_info).error_list) {\
 			MYSQLND_ERROR_LIST_ELEMENT error_for_the_list = {0}; \
 																	\


### PR DESCRIPTION
When SET_CLIENT_ERROR is called from mysqlnd_conn_data::connect,
error_info->error may already be populated with the same string that is
passed in as error, in essence copying the value from a string to itself.

This behavior is undefined in strlcpy on BSD (see BSD manfiles for
strlcpy(3)), and causes a segfault on (at least) Mac OS X 10.12.5.

(N.B. for a patch that works on master, see the [mysqlnd-error-handling branch on magnusnordlander/php-src](https://github.com/magnusnordlander/php-src/tree/mysqlnd-error-handling))