### PR TITLE
[php7.0] bugfix for #68406 #74940

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2363,6 +2363,11 @@ static HashTable *date_object_get_properties_timezone(zval *object) /* {{{ */
 	return props;
 } /* }}} */
 
+static inline void date_object_update_properties_timezone(zval *object) /* {{{ */
+{
+	date_object_get_properties_timezone(object);
+} /* }}} */
+
 static inline zend_object *date_object_new_interval_ex(zend_class_entry *class_type, int init_props) /* {{{ */
 {
 	php_interval_obj *intern;
@@ -3310,6 +3315,7 @@ PHP_FUNCTION(date_timezone_get)
 		php_date_instantiate(date_ce_timezone, return_value);
 		tzobj = Z_PHPTIMEZONE_P(return_value);
 		set_timezone_from_timelib_time(tzobj, dateobj->time);
+		date_object_update_properties_timezone(return_value);
 	} else {
 		RETURN_FALSE;
 	}
@@ -3707,6 +3713,7 @@ PHP_FUNCTION(timezone_open)
 		zval_ptr_dtor(return_value);
 		RETURN_FALSE;
 	}
+	date_object_update_properties_timezone(return_value);
 }
 /* }}} */
 
@@ -3727,6 +3734,7 @@ PHP_METHOD(DateTimeZone, __construct)
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling);
 	tzobj = Z_PHPTIMEZONE_P(getThis());
 	timezone_initialize(tzobj, tz, tz_len);
+	date_object_update_properties_timezone(getThis());
 	zend_restore_error_handling(&error_handling);
 }
 /* }}} */
@@ -3745,6 +3753,7 @@ static int php_date_timezone_initialize_from_hash(zval **return_value, php_timez
 				return FAILURE;
 			}
 			if (SUCCESS == timezone_initialize(*tzobj, Z_STRVAL_P(z_timezone), Z_STRLEN_P(z_timezone))) {
+				date_object_update_properties_timezone(*return_value);
 				return SUCCESS;
 			}
 		}
@@ -3786,7 +3795,7 @@ PHP_METHOD(DateTimeZone, __wakeup)
 
 	myht = Z_OBJPROP_P(object);
 
-	if(php_date_timezone_initialize_from_hash(&return_value, &tzobj, myht) != SUCCESS) {
+	if(php_date_timezone_initialize_from_hash(&object, &tzobj, myht) != SUCCESS) {
 		php_error_docref(NULL, E_ERROR, "Timezone initialization failed");
 	}
 }

--- a/ext/date/tests/bug68406.phpt
+++ b/ext/date/tests/bug68406.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Bug #68406 calling var_dump on a DateTimeZone object modifies it
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+
+$tz1 = new DateTimeZone('Europe/Berlin');
+$tz2 = new DateTimeZone('Europe/Berlin');
+
+$d = new DateTime('2014-12-24 13:00:00', $tz1);
+var_dump($d->getTimezone(), $tz2);
+
+if($tz2 == $d->getTimezone()) {
+    echo "yes";
+}
+else {
+    echo "no";
+}
+
+--EXPECT--
+object(DateTimeZone)#4 (2) {
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(13) "Europe/Berlin"
+}
+object(DateTimeZone)#2 (2) {
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(13) "Europe/Berlin"
+}
+yes

--- a/ext/date/tests/bug74940.phpt
+++ b/ext/date/tests/bug74940.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bug #74940 DateTimeZone loose comparison always true until properties are initialized
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+
+$tz1 = new DateTimeZone('Europe/Amsterdam');
+$tz2 = new DateTimeZone('UTC');
+
+var_dump($tz1 == $tz2);
+var_dump($tz1 === $tz2);
+
+$tz3 = clone($tz1);
+$tz4 = clone($tz2);
+
+var_dump($tz1 == $tz3);
+var_dump($tz4 == $tz3);
+
+$tz5 = unserialize(serialize($tz1));
+var_dump($tz1 == $tz5);
+var_dump($tz2 == $tz5);
+--EXPECT--
+bool(false)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+


### PR DESCRIPTION
this PR update the properties of DateTimeZone immediately after the object created. this should solve [#68406](https://bugs.php.net/bug.php?id=68406) and [#74940](https://bugs.php.net/bug.php?id=74940)


btw, I found this patch cannot apply to php 7.1 or above and master, since `php_error_docref` has been replaced with `zend_throw_error` in those branches. I'm not sure if I need to open a new PR targeting php 7.1 for this problem.