### PR TITLE
Fix fast ZPP macro definition

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -832,7 +832,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(zend_bool throw_
 #define Z_PARAM_ARRAY_OR_OBJECT_EX(dest, check_null, separate) \
 	Z_PARAM_ARRAY_OR_OBJECT_EX2(dest, check_null, separate, separate)
 
-#define Z_PARAM_ARRAY_OR_OBJECT(dest, check_null, separate) \
+#define Z_PARAM_ARRAY_OR_OBJECT(dest) \
 	Z_PARAM_ARRAY_OR_OBJECT_EX(dest, 0, 0)
 
 /* old "b" */


### PR DESCRIPTION
This looks like a copy/paste error to me. I wasn't sure if it should go in the lower branches, due to the internal API breakage.