### PR TITLE
Fix references to removed timelib header file in build scripts

### DIFF
--- a/ext/date/config.w32
+++ b/ext/date/config.w32
@@ -19,5 +19,5 @@ tl_config.WriteLine("#define timelib_strdup  estrdup");
 tl_config.WriteLine("#define timelib_free    efree");
 tl_config.Close();
 
-PHP_INSTALL_HEADERS("ext/date/", "php_date.h lib/timelib.h lib/timelib_structs.h lib/timelib_config.h");
+PHP_INSTALL_HEADERS("ext/date/", "php_date.h lib/timelib.h lib/timelib_config.h");
 AC_DEFINE('HAVE_TIMELIB_CONFIG_H', 1, 'Have timelib_config.h')

--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -14,7 +14,7 @@ PHP_ADD_BUILD_DIR([$ext_builddir/lib], 1)
 PHP_ADD_INCLUDE([$ext_builddir/lib])
 PHP_ADD_INCLUDE([$ext_srcdir/lib])
 
-PHP_INSTALL_HEADERS([ext/date], [php_date.h lib/timelib.h lib/timelib_structs.h lib/timelib_config.h])
+PHP_INSTALL_HEADERS([ext/date], [php_date.h lib/timelib.h lib/timelib_config.h])
 AC_DEFINE([HAVE_TIMELIB_CONFIG_H], [1], [Have timelib_config.h])
 
 cat > $ext_builddir/lib/timelib_config.h <<EOF


### PR DESCRIPTION
This removes references to timelib_structs.h,
which was removed in bdd56f31078bf1f34341943603cf6aaa72e0db5c

Affects PHP 7.0, 7.1, 7.2, e.g. appveyor builds