### PR TITLE
handle non-NVT ASCII messages per the RFC's

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -53,6 +53,7 @@
 #include "php_ini.h"
 #include "php_globals.h"
 #include "php_main.h"
+#include "php_syslog.h"
 #include "fopen_wrappers.h"
 #include "ext/standard/php_standard.h"
 #include "ext/standard/php_string.h"
@@ -329,6 +330,28 @@ static PHP_INI_MH(OnChangeMemoryLimit)
 }
 /* }}} */
 
+/* {{{ PHP_INI_MH
+ */
+static PHP_INI_MH(OnSetLogFilter)
+{
+	const char *filter  = ZSTR_VAL(new_value);
+
+	if (!strcmp(filter, "none")) {
+		PG(syslog_filter) = PHP_SYSLOG_FILTER_NONE;
+		return SUCCESS;
+	}
+	if (!strcmp(filter, "no-ctrl")) {
+		PG(syslog_filter) = PHP_SYSLOG_FILTER_NO_CTRL;
+		return SUCCESS;
+	}
+	if (!strcmp(filter, "ascii")) {
+		PG(syslog_filter) = PHP_SYSLOG_FILTER_ASCII;
+		return SUCCESS;
+	}
+
+	return FAILURE;
+}
+/* }}} */
 
 /* {{{ php_disable_functions
  */
@@ -775,6 +798,7 @@ PHP_INI_BEGIN()
 #endif
 	STD_PHP_INI_ENTRY("syslog.facility",		"LOG_USER",		PHP_INI_SYSTEM,		OnSetFacility,		syslog_facility,	php_core_globals,		core_globals)
 	STD_PHP_INI_ENTRY("syslog.ident",		"php",			PHP_INI_SYSTEM,		OnUpdateString,		syslog_ident,		php_core_globals,		core_globals)
+	STD_PHP_INI_ENTRY("syslog.filter",		"no-ctrl",		PHP_INI_ALL,		OnSetLogFilter,		syslog_filter,		php_core_globals, 		core_globals)
 PHP_INI_END()
 /* }}} */
 

--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -170,6 +170,7 @@ struct _php_core_globals {
 	zend_long syslog_facility;
 	char *syslog_ident;
 	zend_bool have_called_openlog;
+	zend_long syslog_filter;
 };
 
 

--- a/main/php_syslog.h
+++ b/main/php_syslog.h
@@ -32,6 +32,11 @@
 #endif
 #endif
 
+/* Syslog filters */
+#define PHP_SYSLOG_FILTER_NONE		0
+#define PHP_SYSLOG_FILTER_NO_CTRL	1
+#define PHP_SYSLOG_FILTER_ASCII		2
+
 BEGIN_EXTERN_C()
 PHPAPI void php_syslog(int, const char *format, ...);
 PHPAPI void php_openlog(const char *, int, int);

--- a/php.ini-development
+++ b/php.ini-development
@@ -517,6 +517,14 @@ report_memleaks = On
 ; This setting is on by default.
 ;report_zend_debug = 0
 
+; Set this to disable filtering control characters (the default).
+; Some loggers only accept NVT-ASCII, others accept anything that's not
+; control characters.  If your logger accepts everything, then no filtering
+; is needed at all.
+; Values are: ascii (space-tilde), no_ctrl (all characters space and above),
+; and none (all characters)
+;syslog.filter = ascii
+
 ; Store the last error/warning message in $php_errormsg (boolean).
 ; This directive is DEPRECATED.
 ; Default Value: Off

--- a/php.ini-production
+++ b/php.ini-production
@@ -522,6 +522,14 @@ report_memleaks = On
 ; This setting is on by default.
 ;report_zend_debug = 0
 
+; Set this to disable filtering control characters (the default).
+; Some loggers only accept NVT-ASCII, others accept anything that's not
+; control characters.  If your logger accepts everything, then no filtering
+; is needed at all.
+; Values are: ascii (space-tilde), no_ctrl (all characters space and above),
+; and none (all characters)
+;syslog.filter = ascii
+
 ; Store the last error/warning message in $php_errormsg (boolean). Setting this value
 ; to On can assist in debugging and is appropriate for development servers. It should
 ; however be disabled on production servers.


### PR DESCRIPTION
Correct handling of non-NVT ASCII is not unambiguously defined by RFC-3164 nor by RFC-5424.

It is recommended that Unicode strings be formatted into UTF-8 shortest notation (compressed format) and prefixed by the BOM.

However, nothing unambiguous is defined for other code sets.

This is particularly a concern for cases where PHP applications are being run on hosted virtual servers, Docker containers, etc. where the owner of the application has no control over where the logging is being collected nor how the logger is configured.

In those cases, the decision has to be made to be (1) as conservative as possible in selecting what's sent (i.e., NVT-ASCII per Postel's Law), or (2) UTF-8 compressed strings with a BOM prefix.

This addresses [bug 75077](https://bugs.php.net/bug.php?id=75077).