### PR TITLE
timezone_transitions_get is very slow

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3992,7 +3992,9 @@ PHP_FUNCTION(timezone_transitions_get)
 	zval                *object, element;
 	php_timezone_obj    *tzobj;
 	unsigned int         i, begin = 0, found;
-	zend_long            timestamp_begin = ZEND_LONG_MIN, timestamp_end = ZEND_LONG_MAX;
+	/* We use INT32_MIN instead of ZEND_LONG_MIN here, because php_format_date took very long in add_nominal and
+	   no transition exists now (2017-08-16) before the timestamp -2147483648 (1901-12-13) */
+	zend_long            timestamp_begin = INT32_MIN, timestamp_end = ZEND_LONG_MAX;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|ll", &object, date_ce_timezone, &timestamp_begin, &timestamp_end) == FAILURE) {
 		RETURN_FALSE;
@@ -4025,7 +4027,7 @@ PHP_FUNCTION(timezone_transitions_get)
 
 	array_init(return_value);
 
-	if (timestamp_begin == ZEND_LONG_MIN) {
+	if (timestamp_begin == INT32_MIN) {
 		add_nominal();
 		begin = 0;
 		found = 1;


### PR DESCRIPTION
timezone_transitions_get is very slow, because php_format_date in add_nominal with the default value ZEND_LONG_MIN took very long to iterate from ZEND_LONG_MIN to ZEND_LONG_MAX on 64 bit systems. No transitions exists at this time before the timestamp -2147483648 (INT32_MIN).

## With this patch:

Default Value
Duration: 0.000201

Timestamp for 1970-01-01 00:00:00
Duration: 0.000092

Timestamp for 0001-01-01 00:00:00
Duration: 0.000087


## PHP 7.1.6:

Default Value
Duration: 0.045996

Timestamp for 1970-01-01 00:00:00
Duration: 0.000082

Timestamp for 0001-01-01 00:00:00
Duration: 0.000097


## Benchmark

    function measure_duration(callable $callback) {
        $start = microtime(true);
        call_user_func($callback);
        $duration = microtime(true) - $start;
        printf("Duration: %s\n\n", number_format($duration, 6));
    }

    $timezone = new DateTimeZone('Europe/Berlin');

    measure_duration(function() use($timezone) {
        printf("Default Value\n");
        $timezone->getTransitions();
    });

    measure_duration(function() use($timezone) {
        $timestamp = 0;
        printf("Timestamp for %s\n", date('Y-m-d H:i:s', $timestamp));
        $timezone->getTransitions($timestamp);
    });

    measure_duration(function() use($timezone) {
        $timestamp = -62135596800;
        printf("Timestamp for %s\n", date('Y-m-d H:i:s', $timestamp));
        $timezone->getTransitions($timestamp);
    });

https://3v4l.org/MhkR8