### PR TITLE
ext/sodium: Change SodiumException to TypeError for param type checks

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -548,7 +548,7 @@ PHP_FUNCTION(sodium_memzero)
 	}
 	ZVAL_DEREF(buf_zv);
 	if (Z_TYPE_P(buf_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "a PHP string is required", 0);
+		zend_wrong_parameter_type_error(ZEND_PARSE_PARAMS_THROW, 1, Z_EXPECTED_STRING, buf_zv);
 		return;
 	}
 	if (Z_REFCOUNTED_P(buf_zv) && Z_REFCOUNT_P(buf_zv) == 1) {
@@ -573,7 +573,7 @@ PHP_FUNCTION(sodium_increment)
 	}
 	ZVAL_DEREF(val_zv);
 	if (Z_TYPE_P(val_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "a PHP string is required", 0);
+		zend_wrong_parameter_type_error(ZEND_PARSE_PARAMS_THROW, 1, Z_EXPECTED_STRING, val_zv);
 		return;
 	}
 
@@ -597,7 +597,7 @@ PHP_FUNCTION(sodium_add)
 	}
 	ZVAL_DEREF(val_zv);
 	if (Z_TYPE_P(val_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "PHP strings are required", 0);
+		zend_wrong_parameter_type_error(ZEND_PARSE_PARAMS_THROW, 1, Z_EXPECTED_STRING, val_zv);
 		return;
 	}
 
@@ -842,7 +842,7 @@ PHP_FUNCTION(sodium_crypto_generichash_update)
 	}
 	ZVAL_DEREF(state_zv);
 	if (Z_TYPE_P(state_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "a reference to a state is required", 0);
+		zend_wrong_parameter_type_error(ZEND_PARSE_PARAMS_THROW, 1, Z_EXPECTED_STRING, state_zv);
 		return;
 	}
 	sodium_separate_string(state_zv);
@@ -880,7 +880,7 @@ PHP_FUNCTION(sodium_crypto_generichash_final)
 	}
 	ZVAL_DEREF(state_zv);
 	if (Z_TYPE_P(state_zv) != IS_STRING) {
-		zend_throw_exception(sodium_exception_ce, "a reference to a state is required", 0);
+		zend_wrong_parameter_type_error(ZEND_PARSE_PARAMS_THROW, 1, Z_EXPECTED_STRING, state_zv);
 		return;
 	}
 	sodium_separate_string(state_zv);

--- a/ext/sodium/tests/exception_trace_without_args.phpt
+++ b/ext/sodium/tests/exception_trace_without_args.phpt
@@ -1,7 +1,7 @@
 --TEST--
 SodiumException backtraces do not contain function arguments
 --SKIPIF--
-<?php if (!extension_loaded("sodium")) print "skip"; ?>
+<?php if (!extension_loaded("sodium")) die("skip"); ?>
 --FILE--
 <?php
 
@@ -14,7 +14,7 @@ do_memzero($x);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught SodiumException: a PHP string is required in %s:%d
+Fatal error: Uncaught TypeError: sodium_memzero() expects parameter 1 to be string, integer given in %s:%d
 Stack trace:
 #0 %s(%d): sodium_memzero()
 #1 %s(%d): do_memzero()

--- a/ext/sodium/tests/inc_add.phpt
+++ b/ext/sodium/tests/inc_add.phpt
@@ -1,14 +1,14 @@
 --TEST--
 increment and add edge cases
 --SKIPIF--
-<?php if (!extension_loaded("sodium")) print "skip"; ?>
+<?php if (!extension_loaded("sodium")) die("skip"); ?>
 --FILE--
 <?php
 
 $notStr = 123;
 try {
 	sodium_increment($notStr);
-} catch (SodiumException $e) {
+} catch (TypeError $e) {
 	echo $e->getMessage(), "\n";
 }
 
@@ -27,7 +27,7 @@ $addStr = "\2\0\0";
 $notStr = 123;
 try {
 	sodium_add($notStr, $addStr);
-} catch (SodiumException $e) {
+} catch (TypeError $e) {
 	echo $e->getMessage(), "\n";
 }
 
@@ -43,12 +43,12 @@ var_dump($str, $str2);
 
 ?>
 --EXPECT--
-a PHP string is required
+sodium_increment() expects parameter 1 to be string, integer given
 string(3) "bbc"
 string(3) "abc"
 string(3) "bbc"
 string(3) "abc"
-PHP strings are required
+sodium_add() expects parameter 1 to be string, integer given
 string(3) "cbc"
 string(3) "abc"
 string(3) "cbc"


### PR DESCRIPTION
Hey @jedisct1, @paragonie-scott, @nikic!

The ext/sodium extension does type checks in an unconventional way by throwing a `SodiumException` instead of the expected `TypeError` exception. This PR aims at making ext/sodium act more like ZPP throw and give better error messages for param type checking.

There's probably a better way to implement this (I'm hard-coding the param position for example) but wanted to at least get a conversation started about this. :)

The main issue is that `TypeError` contains the argument values in the stacktrace whereas `SodiumException` removes them so `ext/sodium/tests/exception_trace_without_args.phpt` fails currently as I don't know how to remove them from the `TypeError` stacktrace so I'll need a little help on that one. :)

Anyway, here are the main changes:

## sodium_memzero()

```php
$bar = 12;
sodium_memzero($bar);

# Old error:
# Fatal error: Uncaught SodiumException: a PHP string is required in %s:%d

# New error:
# Fatal error: Uncaught TypeError: sodium_memzero() expects parameter 1 to be string, integer given in %s:%d
```

## sodium_increment()

```php
$bar = 4;
sodium_increment($bar);

# Old error:
# Fatal error: Uncaught SodiumException: a PHP string is required in %s:%d

# New error:
# Fatal error: Uncaught TypeError: sodium_increment() expects parameter 1 to be string, integer given in %s:%d
```

## sodium_add()

For `sodium_add()`, the second param is parsed as a `s` instead of `z`. I'm wondering if we could change that to `z` so we can do a `IS_STRING` check and then just use `Z_STRVAL_P()` and `Z_STRLEN_P()` to get `unsigned char *addv` and `size_t addv_len`. Thoughts?

```php
$a = 12;
$b = "";
sodium_add($a, $b);

# Old error:
# Fatal error: Uncaught SodiumException: PHP strings are required in %s:%d

# New error:
# Fatal error: Uncaught TypeError: sodium_add() expects parameter 1 to be string, integer given in %s:%d
```

## sodium_crypto_generichash_update()

Same issue as `sodium_add()` for the second param.

```php
$a = 42;
sodium_crypto_generichash_update($a, 'foo message');
var_dump($a);

# Old error:
# Fatal error: Uncaught SodiumException: a reference to a state is required in %s:%d

# New error:
# Fatal error: Uncaught TypeError: sodium_crypto_generichash_update() expects parameter 1 to be string, integer given in %s:%d
```

## sodium_crypto_generichash_final()

The second param is an optional long that we could type check as well.

```php
$a = 16;
sodium_crypto_generichash_final($a);

# Old error:
# Fatal error: Uncaught SodiumException: a reference to a state is required in %s:%d

# New error:
# Fatal error: Uncaught TypeError: sodium_crypto_generichash_final() expects parameter 1 to be string, integer given in %s:%d
```

## "invalid parameters" error message

Tangentially related (for a separate PR), there are 6 functions that return a very generic and unhelpful "invalid parameters" exception message. I recommend we examine each of these and break them up into individual error messages. For example, check out ZPP for `sodium_crypto_pwhash()`:

```c
	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lssll|l",
							  &hash_len,
							  &passwd, &passwd_len,
							  &salt, &salt_len,
							  &opslimit, &memlimit, &alg) == FAILURE ||
		hash_len <= 0 || hash_len >= 0xffffffff ||
		passwd_len >= 0xffffffff ||
		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
		zend_throw_exception(sodium_exception_ce, "invalid parameters", 0);
		return;
	}
```

1. I would assume we would want to fail closed anywhere we can so anywhere we have `zend_parse_parameters` I think it should be `zend_parse_parameters_throw`.
2. We should have a separate error message for each condition. E.g. `hash_len <= 0 || hash_len >= 0xffffffff` would have its own error: "$hash_length should be between '0' and '0xffffffff' inclusive" or something like that, etc.

Thoughts on any of this? :)