### PR TITLE
ext/sodium: Update ZPP to ZPP throw

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -542,7 +542,7 @@ PHP_FUNCTION(sodium_memzero)
 {
 	zval      *buf_zv;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(),
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(),
 							  "z", &buf_zv) == FAILURE) {
 		return;
 	}
@@ -567,7 +567,7 @@ PHP_FUNCTION(sodium_increment)
 	unsigned char *val;
 	size_t         val_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(),
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(),
 							  "z", &val_zv) == FAILURE) {
 		return;
 	}
@@ -591,7 +591,7 @@ PHP_FUNCTION(sodium_add)
 	size_t         val_len;
 	size_t         addv_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(),
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(),
 							  "zs", &val_zv, &addv, &addv_len) == FAILURE) {
 		return;
 	}
@@ -618,7 +618,7 @@ PHP_FUNCTION(sodium_memcmp)
 	size_t     len1;
 	size_t     len2;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &buf1, &len1,
 							  &buf2, &len2) == FAILURE) {
 		return;
@@ -638,7 +638,7 @@ PHP_FUNCTION(sodium_crypto_shorthash)
 	size_t         key_len;
 	size_t         msg_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &key, &key_len) == FAILURE) {
 		return;
@@ -671,7 +671,7 @@ PHP_FUNCTION(sodium_crypto_secretbox)
 	size_t         msg_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
 							  &msg, &msg_len,
 							  &nonce, &nonce_len,
 							  &key, &key_len) == FAILURE) {
@@ -716,7 +716,7 @@ PHP_FUNCTION(sodium_crypto_secretbox_open)
 	size_t         ciphertext_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
 							  &ciphertext, &ciphertext_len,
 							  &nonce, &nonce_len,
 							  &key, &key_len) == FAILURE) {
@@ -759,7 +759,7 @@ PHP_FUNCTION(sodium_crypto_generichash)
 	size_t         key_len = 0;
 	size_t         msg_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|sl",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|sl",
 							  &msg, &msg_len,
 							  &key, &key_len,
 							  &hash_len) == FAILURE) {
@@ -798,7 +798,7 @@ PHP_FUNCTION(sodium_crypto_generichash_init)
 	zend_long                 hash_len = crypto_generichash_BYTES;
 	size_t                    key_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|sl",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|sl",
 							  &key, &key_len,
 							  &hash_len) == FAILURE) {
 		return;
@@ -836,7 +836,7 @@ PHP_FUNCTION(sodium_crypto_generichash_update)
 	size_t                    msg_len;
 	size_t                    state_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zs",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zs",
 							  &state_zv, &msg, &msg_len) == FAILURE) {
 		return;
 	}
@@ -874,7 +874,7 @@ PHP_FUNCTION(sodium_crypto_generichash_final)
 	size_t                    state_len;
 	zend_long                 hash_len = crypto_generichash_BYTES;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|l",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z|l",
 							  &state_zv, &hash_len) == FAILURE) {
 		return;
 	}
@@ -942,7 +942,7 @@ PHP_FUNCTION(sodium_crypto_box_seed_keypair)
 	size_t         keypair_len;
 	size_t         seed_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &seed, &seed_len) == FAILURE) {
 		return;
 	}
@@ -976,7 +976,7 @@ PHP_FUNCTION(sodium_crypto_box_keypair_from_secretkey_and_publickey)
 	size_t       publickey_len;
 	size_t       secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &secretkey, &secretkey_len,
 							  &publickey, &publickey_len) == FAILURE) {
 		return;
@@ -1009,7 +1009,7 @@ PHP_FUNCTION(sodium_crypto_box_secretkey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
 		return;
 	}
@@ -1033,7 +1033,7 @@ PHP_FUNCTION(sodium_crypto_box_publickey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
 		return;
 	}
@@ -1058,7 +1058,7 @@ PHP_FUNCTION(sodium_crypto_box_publickey_from_secretkey)
 	unsigned char *secretkey;
 	size_t         secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &secretkey, &secretkey_len) == FAILURE) {
 		return;
 	}
@@ -1091,7 +1091,7 @@ PHP_FUNCTION(sodium_crypto_box)
 	size_t         msg_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
 							  &msg, &msg_len,
 							  &nonce, &nonce_len,
 							  &keypair, &keypair_len) == FAILURE) {
@@ -1140,7 +1140,7 @@ PHP_FUNCTION(sodium_crypto_box_open)
 	size_t         keypair_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
 							  &ciphertext, &ciphertext_len,
 							  &nonce, &nonce_len,
 							  &keypair, &keypair_len) == FAILURE) {
@@ -1184,7 +1184,7 @@ PHP_FUNCTION(sodium_crypto_box_seal)
 	size_t         msg_len;
 	size_t         publickey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &publickey, &publickey_len) == FAILURE) {
 		return;
@@ -1221,7 +1221,7 @@ PHP_FUNCTION(sodium_crypto_box_seal_open)
 	size_t         ciphertext_len;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &ciphertext, &ciphertext_len,
 							  &keypair, &keypair_len) == FAILURE) {
 		return;
@@ -1279,7 +1279,7 @@ PHP_FUNCTION(sodium_crypto_sign_seed_keypair)
 	size_t         keypair_len;
 	size_t         seed_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &seed, &seed_len) == FAILURE) {
 		return;
 	}
@@ -1313,7 +1313,7 @@ PHP_FUNCTION(sodium_crypto_sign_keypair_from_secretkey_and_publickey)
 	size_t       publickey_len;
 	size_t       secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &secretkey, &secretkey_len,
 							  &publickey, &publickey_len) == FAILURE) {
 		return;
@@ -1346,7 +1346,7 @@ PHP_FUNCTION(sodium_crypto_sign_publickey_from_secretkey)
 	char        *secretkey;
 	size_t       secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &secretkey, &secretkey_len) == FAILURE) {
 		return;
 	}
@@ -1375,7 +1375,7 @@ PHP_FUNCTION(sodium_crypto_sign_secretkey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
 		return;
 	}
@@ -1399,7 +1399,7 @@ PHP_FUNCTION(sodium_crypto_sign_publickey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
 		return;
 	}
@@ -1428,7 +1428,7 @@ PHP_FUNCTION(sodium_crypto_sign)
 	size_t              msg_signed_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
 		return;
@@ -1474,7 +1474,7 @@ PHP_FUNCTION(sodium_crypto_sign_open)
 	size_t              msg_signed_len;
 	size_t              publickey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg_signed, &msg_signed_len,
 							  &publickey, &publickey_len) == FAILURE) {
 		return;
@@ -1517,7 +1517,7 @@ PHP_FUNCTION(sodium_crypto_sign_detached)
 	size_t              msg_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
 		return;
@@ -1556,7 +1556,7 @@ PHP_FUNCTION(sodium_crypto_sign_verify_detached)
 	size_t         publickey_len;
 	size_t         signature_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
 							  &signature, &signature_len,
 							  &msg, &msg_len,
 							  &publickey, &publickey_len) == FAILURE) {
@@ -1591,7 +1591,7 @@ PHP_FUNCTION(sodium_crypto_stream)
 	size_t         key_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "lss",
 							  &ciphertext_len,
 							  &nonce, &nonce_len,
 							  &key, &key_len) == FAILURE) {
@@ -1632,7 +1632,7 @@ PHP_FUNCTION(sodium_crypto_stream_xor)
 	size_t         msg_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
 							  &msg, &msg_len,
 							  &nonce, &nonce_len,
 							  &key, &key_len) == FAILURE) {
@@ -1671,7 +1671,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256)
 	size_t         passwd_len;
 	size_t         salt_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lssll",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "lssll",
 							  &hash_len,
 							  &passwd, &passwd_len,
 							  &salt, &salt_len,
@@ -1720,7 +1720,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str)
 	zend_long    opslimit;
 	size_t       passwd_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sll",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sll",
 							  &passwd, &passwd_len,
 							  &opslimit, &memlimit) == FAILURE ||
 		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
@@ -1761,7 +1761,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str_verify)
 	size_t     hash_str_len;
 	size_t     passwd_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &hash_str, &hash_str_len,
 							  &passwd, &passwd_len) == FAILURE) {
 		zend_throw_exception(sodium_exception_ce,
@@ -1798,7 +1798,7 @@ PHP_FUNCTION(sodium_crypto_pwhash)
 	size_t         salt_len;
 
 	alg = (zend_long) crypto_pwhash_ALG_DEFAULT;
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lssll|l",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "lssll|l",
 							  &hash_len,
 							  &passwd, &passwd_len,
 							  &salt, &salt_len,
@@ -1855,7 +1855,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str)
 	size_t       passwd_len;
 	size_t       len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sll",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sll",
 							  &passwd, &passwd_len,
 							  &opslimit, &memlimit) == FAILURE ||
 		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX ||
@@ -1898,7 +1898,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str_verify)
 	size_t     hash_str_len;
 	size_t     passwd_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &hash_str, &hash_str_len,
 							  &passwd, &passwd_len) == FAILURE) {
 		zend_throw_exception(sodium_exception_ce,
@@ -1948,7 +1948,7 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_encrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
 							  &msg, &msg_len,
 							  &ad, &ad_len,
 							  &npub, &npub_len,
@@ -2013,7 +2013,7 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_decrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
 							  &ciphertext, &ciphertext_len,
 							  &ad, &ad_len,
 							  &npub, &npub_len,
@@ -2080,7 +2080,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_encrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
 							  &msg, &msg_len,
 							  &ad, &ad_len,
 							  &npub, &npub_len,
@@ -2141,7 +2141,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_decrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
 							  &ciphertext, &ciphertext_len,
 							  &ad, &ad_len,
 							  &npub, &npub_len,
@@ -2203,7 +2203,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_encrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
 							  &msg, &msg_len,
 							  &ad, &ad_len,
 							  &npub, &npub_len,
@@ -2268,7 +2268,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_decrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
 							  &ciphertext, &ciphertext_len,
 							  &ad, &ad_len,
 							  &npub, &npub_len,
@@ -2336,7 +2336,7 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_encrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
 							  &msg, &msg_len,
 							  &ad, &ad_len,
 							  &npub, &npub_len,
@@ -2397,7 +2397,7 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_decrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
 							  &ciphertext, &ciphertext_len,
 							  &ad, &ad_len,
 							  &npub, &npub_len,
@@ -2458,7 +2458,7 @@ PHP_FUNCTION(sodium_bin2hex)
 	size_t         bin_len;
 	size_t         hex_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &bin, &bin_len) == FAILURE) {
 		return;
 	}
@@ -2484,7 +2484,7 @@ PHP_FUNCTION(sodium_hex2bin)
 	size_t         hex_len;
 	size_t         ignore_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|s",
 							  &hex, &hex_len,
 							  &ignore, &ignore_len) == FAILURE) {
 		return;
@@ -2512,7 +2512,7 @@ PHP_FUNCTION(sodium_crypto_scalarmult)
 	size_t         n_len;
 	size_t         p_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &n, &n_len, &p, &p_len) == FAILURE) {
 		return;
 	}
@@ -2542,7 +2542,7 @@ PHP_FUNCTION(sodium_crypto_kx_seed_keypair)
 	size_t       seed_len;
 	zend_string   *keypair;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &seed, &seed_len) == FAILURE) {
 		return;
 	}
@@ -2591,7 +2591,7 @@ PHP_FUNCTION(sodium_crypto_kx_secretkey)
 	unsigned char *keypair;
 	size_t       keypair_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
 		return;
 	}
@@ -2615,7 +2615,7 @@ PHP_FUNCTION(sodium_crypto_kx_publickey)
 	unsigned char *keypair;
 	size_t       keypair_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
 		return;
 	}
@@ -2646,7 +2646,7 @@ PHP_FUNCTION(sodium_crypto_kx_client_session_keys)
 	size_t       keypair_len;
 	size_t       server_pk_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &keypair, &keypair_len,
 							  &server_pk, &server_pk_len) == FAILURE) {
 		return;
@@ -2695,7 +2695,7 @@ PHP_FUNCTION(sodium_crypto_kx_server_session_keys)
 	size_t       keypair_len;
 	size_t       client_pk_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &keypair, &keypair_len,
 							  &client_pk, &client_pk_len) == FAILURE) {
 		return;
@@ -2740,7 +2740,7 @@ PHP_FUNCTION(sodium_crypto_auth)
 	size_t       msg_len;
 	size_t       key_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &key, &key_len) == FAILURE) {
 		return;
@@ -2770,7 +2770,7 @@ PHP_FUNCTION(sodium_crypto_auth_verify)
 	size_t     msg_len;
 	size_t     key_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
 							  &mac, &mac_len,
 							  &msg, &msg_len,
 							  &key, &key_len) == FAILURE) {
@@ -2798,7 +2798,7 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_sk_to_curve25519)
 	char        *eddsakey;
 	size_t       eddsakey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &eddsakey, &eddsakey_len) == FAILURE) {
 		return;
 	}
@@ -2826,7 +2826,7 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_pk_to_curve25519)
 	char        *eddsakey;
 	size_t       eddsakey_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &eddsakey, &eddsakey_len) == FAILURE) {
 		return;
 	}
@@ -2857,7 +2857,7 @@ PHP_FUNCTION(sodium_compare)
 	size_t     len1;
 	size_t     len2;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &buf1, &len1,
 							  &buf2, &len2) == FAILURE) {
 		return;
@@ -2998,7 +2998,7 @@ PHP_FUNCTION(sodium_crypto_kdf_derive_from_key)
 	size_t         ctx_len;
 	size_t         key_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llss",
+	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "llss",
 							  &subkey_len,
 							  &subkey_id,
 							  &ctx, &ctx_len,

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -308,7 +308,7 @@ static void sodium_remove_param_values_from_backtrace(zend_object *obj) {
 	zval obj_zv, rv, *trace;
 
 	ZVAL_OBJ(&obj_zv, obj);
-	trace = zend_read_property(zend_ce_exception, &obj_zv, "trace", sizeof("trace")-1, 0, &rv);
+	trace = zend_read_property(zend_get_exception_base(&obj), &obj_zv, "trace", sizeof("trace")-1, 0, &rv);
 	if (trace && Z_TYPE_P(trace) == IS_ARRAY) {
 		zval *frame;
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(trace), frame) {
@@ -547,6 +547,7 @@ PHP_FUNCTION(sodium_memzero)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(),
 							  "z", &buf_zv) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	ZVAL_DEREF(buf_zv);
@@ -572,6 +573,7 @@ PHP_FUNCTION(sodium_increment)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(),
 							  "z", &val_zv) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	ZVAL_DEREF(val_zv);
@@ -596,6 +598,7 @@ PHP_FUNCTION(sodium_add)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(),
 							  "zs", &val_zv, &addv, &addv_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	ZVAL_DEREF(val_zv);
@@ -624,6 +627,7 @@ PHP_FUNCTION(sodium_memcmp)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &buf1, &len1,
 							  &buf2, &len2) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (len1 != len2) {
@@ -644,6 +648,7 @@ PHP_FUNCTION(sodium_crypto_shorthash)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &key, &key_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (key_len != crypto_shorthash_KEYBYTES) {
@@ -678,6 +683,7 @@ PHP_FUNCTION(sodium_crypto_secretbox)
 							  &msg, &msg_len,
 							  &nonce, &nonce_len,
 							  &key, &key_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (nonce_len != crypto_secretbox_NONCEBYTES) {
@@ -723,6 +729,7 @@ PHP_FUNCTION(sodium_crypto_secretbox_open)
 							  &ciphertext, &ciphertext_len,
 							  &nonce, &nonce_len,
 							  &key, &key_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (nonce_len != crypto_secretbox_NONCEBYTES) {
@@ -766,6 +773,7 @@ PHP_FUNCTION(sodium_crypto_generichash)
 							  &msg, &msg_len,
 							  &key, &key_len,
 							  &hash_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (hash_len < crypto_generichash_BYTES_MIN ||
@@ -804,6 +812,7 @@ PHP_FUNCTION(sodium_crypto_generichash_init)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|sl",
 							  &key, &key_len,
 							  &hash_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (hash_len < crypto_generichash_BYTES_MIN ||
@@ -841,6 +850,7 @@ PHP_FUNCTION(sodium_crypto_generichash_update)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zs",
 							  &state_zv, &msg, &msg_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	ZVAL_DEREF(state_zv);
@@ -879,6 +889,7 @@ PHP_FUNCTION(sodium_crypto_generichash_final)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z|l",
 							  &state_zv, &hash_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	ZVAL_DEREF(state_zv);
@@ -947,6 +958,7 @@ PHP_FUNCTION(sodium_crypto_box_seed_keypair)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &seed, &seed_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (seed_len != crypto_box_SEEDBYTES) {
@@ -982,6 +994,7 @@ PHP_FUNCTION(sodium_crypto_box_keypair_from_secretkey_and_publickey)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &secretkey, &secretkey_len,
 							  &publickey, &publickey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (secretkey_len != crypto_box_SECRETKEYBYTES) {
@@ -1014,6 +1027,7 @@ PHP_FUNCTION(sodium_crypto_box_secretkey)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (keypair_len !=
@@ -1038,6 +1052,7 @@ PHP_FUNCTION(sodium_crypto_box_publickey)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (keypair_len !=
@@ -1063,6 +1078,7 @@ PHP_FUNCTION(sodium_crypto_box_publickey_from_secretkey)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (secretkey_len != crypto_box_SECRETKEYBYTES) {
@@ -1098,6 +1114,7 @@ PHP_FUNCTION(sodium_crypto_box)
 							  &msg, &msg_len,
 							  &nonce, &nonce_len,
 							  &keypair, &keypair_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (nonce_len != crypto_box_NONCEBYTES) {
@@ -1147,6 +1164,7 @@ PHP_FUNCTION(sodium_crypto_box_open)
 							  &ciphertext, &ciphertext_len,
 							  &nonce, &nonce_len,
 							  &keypair, &keypair_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (nonce_len != crypto_box_NONCEBYTES) {
@@ -1190,6 +1208,7 @@ PHP_FUNCTION(sodium_crypto_box_seal)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &publickey, &publickey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (publickey_len != crypto_box_PUBLICKEYBYTES) {
@@ -1227,6 +1246,7 @@ PHP_FUNCTION(sodium_crypto_box_seal_open)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &ciphertext, &ciphertext_len,
 							  &keypair, &keypair_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (keypair_len != crypto_box_SECRETKEYBYTES + crypto_box_PUBLICKEYBYTES) {
@@ -1284,6 +1304,7 @@ PHP_FUNCTION(sodium_crypto_sign_seed_keypair)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &seed, &seed_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (seed_len != crypto_sign_SEEDBYTES) {
@@ -1319,6 +1340,7 @@ PHP_FUNCTION(sodium_crypto_sign_keypair_from_secretkey_and_publickey)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &secretkey, &secretkey_len,
 							  &publickey, &publickey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (secretkey_len != crypto_sign_SECRETKEYBYTES) {
@@ -1351,6 +1373,7 @@ PHP_FUNCTION(sodium_crypto_sign_publickey_from_secretkey)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (secretkey_len != crypto_sign_SECRETKEYBYTES) {
@@ -1380,6 +1403,7 @@ PHP_FUNCTION(sodium_crypto_sign_secretkey)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (keypair_len !=
@@ -1404,6 +1428,7 @@ PHP_FUNCTION(sodium_crypto_sign_publickey)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (keypair_len !=
@@ -1434,6 +1459,7 @@ PHP_FUNCTION(sodium_crypto_sign)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (secretkey_len != crypto_sign_SECRETKEYBYTES) {
@@ -1480,6 +1506,7 @@ PHP_FUNCTION(sodium_crypto_sign_open)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg_signed, &msg_signed_len,
 							  &publickey, &publickey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (publickey_len != crypto_sign_PUBLICKEYBYTES) {
@@ -1523,6 +1550,7 @@ PHP_FUNCTION(sodium_crypto_sign_detached)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (secretkey_len != crypto_sign_SECRETKEYBYTES) {
@@ -1563,6 +1591,7 @@ PHP_FUNCTION(sodium_crypto_sign_verify_detached)
 							  &signature, &signature_len,
 							  &msg, &msg_len,
 							  &publickey, &publickey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (signature_len != crypto_sign_BYTES) {
@@ -1598,6 +1627,7 @@ PHP_FUNCTION(sodium_crypto_stream)
 							  &ciphertext_len,
 							  &nonce, &nonce_len,
 							  &key, &key_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (ciphertext_len <= 0 || ciphertext_len >= SIZE_MAX) {
@@ -1639,6 +1669,7 @@ PHP_FUNCTION(sodium_crypto_stream_xor)
 							  &msg, &msg_len,
 							  &nonce, &nonce_len,
 							  &key, &key_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (nonce_len != crypto_stream_NONCEBYTES) {
@@ -1678,8 +1709,11 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256)
 							  &hash_len,
 							  &passwd, &passwd_len,
 							  &salt, &salt_len,
-							  &opslimit, &memlimit) == FAILURE ||
-		hash_len <= 0 || hash_len >= SIZE_MAX || hash_len > 0x1fffffffe0ULL ||
+							  &opslimit, &memlimit) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
+		return;
+	}
+	if (hash_len <= 0 || hash_len >= SIZE_MAX || hash_len > 0x1fffffffe0ULL ||
 		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
 		zend_throw_exception(sodium_exception_ce, "invalid parameters", 0);
 		return;
@@ -1725,11 +1759,12 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sll",
 							  &passwd, &passwd_len,
-							  &opslimit, &memlimit) == FAILURE ||
-		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
-		zend_throw_exception(sodium_exception_ce,
-				   "invalid parameters",
-				   0);
+							  &opslimit, &memlimit) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
+		return;
+	}
+	if (opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
+		zend_throw_exception(sodium_exception_ce, "invalid parameters", 0);
 		return;
 	}
 	if (passwd_len <= 0) {
@@ -1767,9 +1802,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str_verify)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &hash_str, &hash_str_len,
 							  &passwd, &passwd_len) == FAILURE) {
-		zend_throw_exception(sodium_exception_ce,
-				   "invalid parameters",
-				   0);
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (passwd_len <= 0) {
@@ -1805,8 +1838,11 @@ PHP_FUNCTION(sodium_crypto_pwhash)
 							  &hash_len,
 							  &passwd, &passwd_len,
 							  &salt, &salt_len,
-							  &opslimit, &memlimit, &alg) == FAILURE ||
-		hash_len <= 0 || hash_len >= 0xffffffff ||
+							  &opslimit, &memlimit, &alg) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
+		return;
+	}
+	if (hash_len <= 0 || hash_len >= 0xffffffff ||
 		passwd_len >= 0xffffffff ||
 		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX) {
 		zend_throw_exception(sodium_exception_ce, "invalid parameters", 0);
@@ -1860,11 +1896,13 @@ PHP_FUNCTION(sodium_crypto_pwhash_str)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sll",
 							  &passwd, &passwd_len,
-							  &opslimit, &memlimit) == FAILURE ||
-		opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX ||
+							  &opslimit, &memlimit) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
+		return;
+	}
+	if (opslimit <= 0 || memlimit <= 0 || memlimit > SIZE_MAX ||
 		passwd_len >= 0xffffffff) {
-		zend_throw_exception(sodium_exception_ce,
-				   "invalid parameters", 0);
+		zend_throw_exception(sodium_exception_ce, "invalid parameters", 0);
 		return;
 	}
 	if (passwd_len <= 0) {
@@ -1904,8 +1942,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str_verify)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &hash_str, &hash_str_len,
 							  &passwd, &passwd_len) == FAILURE) {
-		zend_throw_exception(sodium_exception_ce,
-				   "invalid parameters", 0);
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (passwd_len >= 0xffffffff) {
@@ -1956,6 +1993,7 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_encrypt)
 							  &ad, &ad_len,
 							  &npub, &npub_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (npub_len != crypto_aead_aes256gcm_NPUBBYTES) {
@@ -2021,6 +2059,7 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_decrypt)
 							  &ad, &ad_len,
 							  &npub, &npub_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (npub_len != crypto_aead_aes256gcm_NPUBBYTES) {
@@ -2088,6 +2127,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_encrypt)
 							  &ad, &ad_len,
 							  &npub, &npub_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (npub_len != crypto_aead_chacha20poly1305_NPUBBYTES) {
@@ -2149,6 +2189,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_decrypt)
 							  &ad, &ad_len,
 							  &npub, &npub_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (npub_len != crypto_aead_chacha20poly1305_NPUBBYTES) {
@@ -2211,6 +2252,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_encrypt)
 							  &ad, &ad_len,
 							  &npub, &npub_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (npub_len != crypto_aead_chacha20poly1305_IETF_NPUBBYTES) {
@@ -2276,6 +2318,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_decrypt)
 							  &ad, &ad_len,
 							  &npub, &npub_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (npub_len != crypto_aead_chacha20poly1305_IETF_NPUBBYTES) {
@@ -2344,6 +2387,7 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_encrypt)
 							  &ad, &ad_len,
 							  &npub, &npub_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (npub_len != crypto_aead_xchacha20poly1305_IETF_NPUBBYTES) {
@@ -2405,6 +2449,7 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_decrypt)
 							  &ad, &ad_len,
 							  &npub, &npub_len,
 							  &secretkey, &secretkey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (npub_len != crypto_aead_xchacha20poly1305_IETF_NPUBBYTES) {
@@ -2463,6 +2508,7 @@ PHP_FUNCTION(sodium_bin2hex)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &bin, &bin_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (bin_len >= SIZE_MAX / 2U) {
@@ -2490,6 +2536,7 @@ PHP_FUNCTION(sodium_hex2bin)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|s",
 							  &hex, &hex_len,
 							  &ignore, &ignore_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	bin_len = hex_len / 2;
@@ -2517,6 +2564,7 @@ PHP_FUNCTION(sodium_crypto_scalarmult)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &n, &n_len, &p, &p_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (n_len != crypto_scalarmult_SCALARBYTES ||
@@ -2547,6 +2595,7 @@ PHP_FUNCTION(sodium_crypto_kx_seed_keypair)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &seed, &seed_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (seed_len != crypto_kx_SEEDBYTES) {
@@ -2596,6 +2645,7 @@ PHP_FUNCTION(sodium_crypto_kx_secretkey)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (keypair_len !=
@@ -2620,6 +2670,7 @@ PHP_FUNCTION(sodium_crypto_kx_publickey)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &keypair, &keypair_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (keypair_len !=
@@ -2652,6 +2703,7 @@ PHP_FUNCTION(sodium_crypto_kx_client_session_keys)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &keypair, &keypair_len,
 							  &server_pk, &server_pk_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (keypair_len != crypto_kx_SECRETKEYBYTES + crypto_kx_PUBLICKEYBYTES) {
@@ -2701,6 +2753,7 @@ PHP_FUNCTION(sodium_crypto_kx_server_session_keys)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &keypair, &keypair_len,
 							  &client_pk, &client_pk_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (keypair_len != crypto_kx_SECRETKEYBYTES + crypto_kx_PUBLICKEYBYTES) {
@@ -2746,6 +2799,7 @@ PHP_FUNCTION(sodium_crypto_auth)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &msg, &msg_len,
 							  &key, &key_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (key_len != crypto_auth_KEYBYTES) {
@@ -2777,6 +2831,7 @@ PHP_FUNCTION(sodium_crypto_auth_verify)
 							  &mac, &mac_len,
 							  &msg, &msg_len,
 							  &key, &key_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (key_len != crypto_auth_KEYBYTES) {
@@ -2803,6 +2858,7 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_sk_to_curve25519)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &eddsakey, &eddsakey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (eddsakey_len != crypto_sign_SECRETKEYBYTES) {
@@ -2831,6 +2887,7 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_pk_to_curve25519)
 
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
 							  &eddsakey, &eddsakey_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (eddsakey_len != crypto_sign_PUBLICKEYBYTES) {
@@ -2863,6 +2920,7 @@ PHP_FUNCTION(sodium_compare)
 	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
 							  &buf1, &len1,
 							  &buf2, &len2) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (len1 != len2) {
@@ -3006,6 +3064,7 @@ PHP_FUNCTION(sodium_crypto_kdf_derive_from_key)
 							  &subkey_id,
 							  &ctx, &ctx_len,
 							  &key, &key_len) == FAILURE) {
+		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}
 	if (subkey_len < crypto_kdf_BYTES_MIN) {

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -303,11 +303,10 @@ zend_module_entry sodium_module_entry = {
 ZEND_GET_MODULE(sodium)
 #endif
 
-static zend_object *sodium_exception_create_object(zend_class_entry *ce) {
-	zend_object *obj = zend_ce_exception->create_object(ce);
+/* Remove argument information from backtrace to prevent information leaks */
+static void sodium_remove_param_values_from_backtrace(zend_object *obj) {
 	zval obj_zv, rv, *trace;
 
-	/* Remove argument information from backtrace to prevent information leaks */
 	ZVAL_OBJ(&obj_zv, obj);
 	trace = zend_read_property(zend_ce_exception, &obj_zv, "trace", sizeof("trace")-1, 0, &rv);
 	if (trace && Z_TYPE_P(trace) == IS_ARRAY) {
@@ -321,7 +320,11 @@ static zend_object *sodium_exception_create_object(zend_class_entry *ce) {
 			}
 		} ZEND_HASH_FOREACH_END();
 	}
+}
 
+static zend_object *sodium_exception_create_object(zend_class_entry *ce) {
+	zend_object *obj = zend_ce_exception->create_object(ce);
+	sodium_remove_param_values_from_backtrace(obj);
 	return obj;
 }
 

--- a/ext/sodium/tests/sodium_error_001.phpt
+++ b/ext/sodium/tests/sodium_error_001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+TypeErrors will not contain param values in backtrace
+--SKIPIF--
+<?php if (!extension_loaded("sodium")) die("skip ext/sodium required"); ?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+function do_crypto_shorthash($message, $key) {
+  return sodium_crypto_shorthash($message, $key);
+}
+
+$m = 12;
+$key = random_bytes(SODIUM_CRYPTO_SHORTHASH_KEYBYTES);
+$hash = do_crypto_shorthash($m, $key);
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: sodium_crypto_shorthash() expects parameter 1 to be string, integer given in %s:%d
+Stack trace:
+#0 %s(%d): sodium_crypto_shorthash()
+#1 %s(%d): do_crypto_shorthash()
+#2 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
This is a complement PR to #2691 and accomplishes two main things:

1. Replace all references to `zend_parse_parameters()` with `zend_parse_parameters_throw()` to fail closed when strict types are enabled.
2. Remove param values from the `TypeError` backtrace that is thrown from `zend_parse_parameters_throw()`.

I have one test to show that the second point works for `TypeError`, but not sure if we want to add a few more functions in there to check. But there are a ton of them so... :)

Also - as a future consideration, we should extract `sodium_remove_param_values_from_backtrace()` in such a way that other functions can take advantage of that functionality. :)