### PR TITLE
Switch from curl-config to pkg-config for curl extension

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -6,75 +6,97 @@ PHP_ARG_WITH(curl, for cURL support,
 [  --with-curl[=DIR]         Include cURL support])
 
 if test "$PHP_CURL" != "no"; then
-  if test -r $PHP_CURL/include/curl/easy.h; then
-    CURL_DIR=$PHP_CURL
+  if test -z "$PKG_CONFIG"; then
+    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+  fi
+
+  if test -x "$PKG_CONFIG"; then
+    dnl using pkg-config output
+
+    AC_MSG_CHECKING(for libcurl.pc)
+    if test "$PHP_CURL" == "yes"; then
+      PKNAME=libcurl
+      AC_MSG_RESULT(using default path)
+    elif test -r $PHP_CURL/$PHP_LIBDIR/pkgconfig/libcurl.pc; then
+      PKNAME=$PHP_CURL/$PHP_LIBDIR/pkgconfig/libcurl.pc
+      AC_MSG_RESULT(using $PKNAME)
+    elif test -r $PHP_CURL/lib/pkgconfig/libcurl.pc; then
+      PKNAME=$PHP_CURL/lib/pkgconfig/libcurl.pc
+      AC_MSG_RESULT(using $PKNAME)
+    else
+      AC_MSG_ERROR(Could not find libcurl.pc)
+    fi
+
+    AC_MSG_CHECKING(for cURL 7.10.5 or greater)
+    if $PKG_CONFIG --atleast-version 7.10.5 $PKNAME; then
+      curl_version_full=`$PKG_CONFIG --modversion $PKNAME`
+      AC_MSG_RESULT($curl_version_full)
+    else
+      AC_MSG_ERROR(cURL version 7.10.5 or later is required to compile php with cURL support)
+    fi
+
+    CURL_LIBS=`$PKG_CONFIG --libs   $PKNAME`
+    CURL_INCL=`$PKG_CONFIG --cflags $PKNAME`
+    CURL_SSL=`$PKG_CONFIG --variable=supported_features $PKNAME| $EGREP SSL`
   else
-    AC_MSG_CHECKING(for cURL in default path)
-    for i in /usr/local /usr; do
-      if test -r $i/include/curl/easy.h; then
-        CURL_DIR=$i
-        AC_MSG_RESULT(found in $i)
-        break
-      fi
-    done
+    dnl fallback to old vay, using curl-config
+
+    if test -r $PHP_CURL/include/curl/easy.h; then
+      CURL_DIR=$PHP_CURL
+    else
+      AC_MSG_CHECKING(for cURL in default path)
+      for i in /usr/local /usr; do
+        if test -r $i/include/curl/easy.h; then
+          CURL_DIR=$i
+          AC_MSG_RESULT(found in $i)
+          break
+        fi
+      done
+    fi
+
     if test -z "$CURL_DIR"; then
       AC_MSG_RESULT(not found)
-      if which dpkg-architecture>/dev/null; then
-        AC_MSG_CHECKING(for cURL in multiarch path)
-        CURL_MULTIARCH_INCLUDE=/usr/include/$(dpkg-architecture -qDEB_HOST_MULTIARCH)
-        if test -r $CURL_MULTIARCH_INCLUDE/curl/easy.h; then
-          CURL_DIR=/usr
-          AC_MSG_RESULT(found in $CURL_MULTIARCH_INCLUDE)
-        else
-          AC_MSG_RESULT(not found)
-        fi
+      AC_MSG_ERROR(Please reinstall the libcurl distribution -
+      easy.h should be in <curl-dir>/include/curl/)
+    fi
+
+    CURL_CONFIG="curl-config"
+    AC_MSG_CHECKING(for cURL 7.10.5 or greater)
+
+    if ${CURL_DIR}/bin/curl-config --libs > /dev/null 2>&1; then
+      CURL_CONFIG=${CURL_DIR}/bin/curl-config
+    else
+      if ${CURL_DIR}/curl-config --libs > /dev/null 2>&1; then
+        CURL_CONFIG=${CURL_DIR}/curl-config
       fi
     fi
-  fi
 
-  if test -z "$CURL_DIR"; then
-    AC_MSG_ERROR(Could not find cURL, please reinstall the libcurl distribution -
-    easy.h should be in <curl-dir>/include/curl/)
-  fi
-
-  CURL_CONFIG="curl-config"
-  AC_MSG_CHECKING(for cURL 7.10.5 or greater)
-
-  if ${CURL_DIR}/bin/curl-config --libs > /dev/null 2>&1; then
-    CURL_CONFIG=${CURL_DIR}/bin/curl-config
-  else
-    if ${CURL_DIR}/curl-config --libs > /dev/null 2>&1; then
-      CURL_CONFIG=${CURL_DIR}/curl-config
+    curl_version_full=`$CURL_CONFIG --version`
+    curl_version=`echo ${curl_version_full} | sed -e 's/libcurl //' | $AWK 'BEGIN { FS = "."; } { printf "%d", ($1 * 1000 + $2) * 1000 + $3;}'`
+    if test "$curl_version" -ge 7010005; then
+      AC_MSG_RESULT($curl_version_full)
+      CURL_LIBS=`$CURL_CONFIG --libs`
+      CURL_INCL=`$CURL_CONFIG --cflags`
+      CURL_SSL=`$CURL_CONFIG --feature | $EGREP SSL`
+    else
+      AC_MSG_ERROR(cURL version 7.10.5 or later is required to compile php with cURL support)
     fi
   fi
 
-  curl_version_full=`$CURL_CONFIG --version`
-  curl_version=`echo ${curl_version_full} | sed -e 's/libcurl //' | $AWK 'BEGIN { FS = "."; } { printf "%d", ($1 * 1000 + $2) * 1000 + $3;}'`
-  if test "$curl_version" -ge 7010005; then
-    AC_MSG_RESULT($curl_version_full)
-    CURL_LIBS=`$CURL_CONFIG --libs`
-  else
-    AC_MSG_ERROR(cURL version 7.10.5 or later is required to compile php with cURL support)
-  fi
+  dnl common stuff (pkg-config / curl-config)
 
-  if test -z "$CURL_MULTIARCH_INCLUDE"; then
-    PHP_ADD_INCLUDE($CURL_DIR/include)
-  else
-    PHP_ADD_INCLUDE($CURL_MULTIARCH_INCLUDE)
-  fi
   PHP_EVAL_LIBLINE($CURL_LIBS, CURL_SHARED_LIBADD)
-  PHP_ADD_LIBRARY_WITH_PATH(curl, $CURL_DIR/$PHP_LIBDIR, CURL_SHARED_LIBADD)
+  PHP_EVAL_INCLINE($CURL_INCL, CURL_SHARED_LIBADD)
   
   AC_MSG_CHECKING([for SSL support in libcurl])
-  CURL_SSL=`$CURL_CONFIG --feature | $EGREP SSL`
-  if test "$CURL_SSL" = "SSL"; then
+  if test -n "$CURL_SSL"; then
     AC_MSG_RESULT([yes])
     AC_DEFINE([HAVE_CURL_SSL], [1], [Have cURL with  SSL support])
    
     save_CFLAGS="$CFLAGS"
-    CFLAGS="`$CURL_CONFIG --cflags`"
-    save_LDFLAGS="$LDFLAGS"
-    LDFLAGS="`$CURL_CONFIG --libs`"
+    CFLAGS=$CURL_INCL
+    save_LDFLAGS="$CFLAGS"
+    LDFLAGS=$CURL_LIBS
    
     AC_PROG_CPP
     AC_MSG_CHECKING([for openssl support in libcurl])
@@ -145,21 +167,21 @@ int main(int argc, char *argv[])
   ],[
     AC_MSG_ERROR(There is something wrong. Please check config.log for more information.)
   ],[
-    $CURL_LIBS -L$CURL_DIR/$PHP_LIBDIR
+    $CURL_LIBS
   ])
 
   PHP_CHECK_LIBRARY(curl,curl_easy_strerror,
   [
     AC_DEFINE(HAVE_CURL_EASY_STRERROR,1,[ ])
   ],[],[
-    $CURL_LIBS -L$CURL_DIR/$PHP_LIBDIR
+    $CURL_LIBS
   ])
 
   PHP_CHECK_LIBRARY(curl,curl_multi_strerror,
   [
     AC_DEFINE(HAVE_CURL_MULTI_STRERROR,1,[ ])
   ],[],[
-    $CURL_LIBS -L$CURL_DIR/$PHP_LIBDIR
+    $CURL_LIBS
   ])
 
   PHP_NEW_EXTENSION(curl, interface.c multi.c share.c curl_file.c, $ext_shared)


### PR DESCRIPTION
First attemp to fix multiarch support (#74125) for curl
introduce some debian specificity (dpkg command)
so is not suitable for other environmant.

This is mostly related to a broken "curl-config" config on debian
which doesn't provide the correct build options, while pkg-config
works as expected.

This new attemp rely on pkg-config output instead.
