### PR TITLE
Add syslog's ident and facility parameters to config

### DIFF
--- a/ext/standard/syslog.c
+++ b/ext/standard/syslog.c
@@ -125,6 +125,12 @@ PHP_MSHUTDOWN_FUNCTION(syslog)
 	return SUCCESS;
 }
 
+void php_openlog(const char *ident, int option, int facility)
+{
+	openlog(ident, option, facility);
+	PG(have_called_openlog) = 1;
+}
+
 /* {{{ proto bool openlog(string ident, int option, int facility)
    Open connection to system logger */
 /*
@@ -151,7 +157,7 @@ PHP_FUNCTION(openlog)
 	if(BG(syslog_device) == NULL) {
 		RETURN_FALSE;
 	}
-	openlog(BG(syslog_device), option, facility);
+	php_openlog(BG(syslog_device), option, facility);
 	RETURN_TRUE;
 }
 /* }}} */

--- a/main/main.c
+++ b/main/main.c
@@ -148,6 +148,143 @@ static char *get_safe_charset_hint(void) {
 
 /* {{{ PHP_INI_MH
  */
+static PHP_INI_MH(OnSetFacility)
+{
+	const char *facility = ZSTR_VAL(new_value);
+
+#ifdef LOG_AUTH
+	if (!strcmp(facility, "LOG_AUTH") || !strcmp(facility, "auth") || !strcmp(facility, "security")) {
+		PG(syslog_facility) = LOG_AUTH;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_AUTHPRIV
+	if (!strcmp(facility, "LOG_AUTHPRIV") || !strcmp(facility, "authpriv")) {
+		PG(syslog_facility) = LOG_AUTHPRIV;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_CRON
+	if (!strcmp(facility, "LOG_CRON") || !strcmp(facility, "cron")) {
+		PG(syslog_facility) = LOG_CRON;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_DAEMON
+	if (!strcmp(facility, "LOG_DAEMON") || !strcmp(facility, "daemon")) {
+		PG(syslog_facility) = LOG_DAEMON;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_FTP
+	if (!strcmp(facility, "LOG_FTP") || !strcmp(facility, "ftp")) {
+		PG(syslog_facility) = LOG_FTP;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_KERN
+	if (!strcmp(facility, "LOG_KERN") || !strcmp(facility, "kern")) {
+		PG(syslog_facility) = LOG_KERN;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_LPR
+	if (!strcmp(facility, "LOG_LPR") || !strcmp(facility, "lpr")) {
+		PG(syslog_facility) = LOG_LPR;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_MAIL
+	if (!strcmp(facility, "LOG_MAIL") || !strcmp(facility, "mail")) {
+		PG(syslog_facility) = LOG_MAIL;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_INTERNAL_MARK
+	if (!strcmp(facility, "LOG_INTERNAL_MARK") || !strcmp(facility, "mark")) {
+		PG(syslog_facility) = LOG_INTERNAL_MARK;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_NEWS
+	if (!strcmp(facility, "LOG_NEWS") || !strcmp(facility, "news")) {
+		PG(syslog_facility) = LOG_NEWS;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_SYSLOG
+	if (!strcmp(facility, "LOG_SYSLOG") || !strcmp(facility, "syslog")) {
+		PG(syslog_facility) = LOG_SYSLOG;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_USER
+	if (!strcmp(facility, "LOG_USER") || !strcmp(facility, "user")) {
+		PG(syslog_facility) = LOG_USER;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_UUCP
+	if (!strcmp(facility, "LOG_UUCP") || !strcmp(facility, "uucp")) {
+		PG(syslog_facility) = LOG_UUCP;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_LOCAL0
+	if (!strcmp(facility, "LOG_LOCAL0") || !strcmp(facility, "local0")) {
+		PG(syslog_facility) = LOG_LOCAL0;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_LOCAL1
+	if (!strcmp(facility, "LOG_LOCAL1") || !strcmp(facility, "local1")) {
+		PG(syslog_facility) = LOG_LOCAL1;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_LOCAL2
+	if (!strcmp(facility, "LOG_LOCAL2") || !strcmp(facility, "local2")) {
+		PG(syslog_facility) = LOG_LOCAL2;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_LOCAL3
+	if (!strcmp(facility, "LOG_LOCAL3") || !strcmp(facility, "local3")) {
+		PG(syslog_facility) = LOG_LOCAL3;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_LOCAL4
+	if (!strcmp(facility, "LOG_LOCAL4") || !strcmp(facility, "local4")) {
+		PG(syslog_facility) = LOG_LOCAL4;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_LOCAL5
+	if (!strcmp(facility, "LOG_LOCAL5") || !strcmp(facility, "local5")) {
+		PG(syslog_facility) = LOG_LOCAL5;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_LOCAL6
+	if (!strcmp(facility, "LOG_LOCAL6") || !strcmp(facility, "local6")) {
+		PG(syslog_facility) = LOG_LOCAL6;
+		return SUCCESS;
+	}
+#endif
+#ifdef LOG_LOCAL7
+	if (!strcmp(facility, "LOG_LOCAL7") || !strcmp(facility, "local7")) {
+		PG(syslog_facility) = LOG_LOCAL7;
+		return SUCCESS;
+	}
+#endif
+
+	return FAILURE;
+}
+/* }}} */
+
+/* {{{ PHP_INI_MH
+ */
 static PHP_INI_MH(OnSetPrecision)
 {
 	zend_long i;
@@ -636,6 +773,8 @@ PHP_INI_BEGIN()
 #ifdef PHP_WIN32
 	STD_PHP_INI_BOOLEAN("windows.show_crt_warning",		"0",		PHP_INI_ALL,		OnUpdateBool,			windows_show_crt_warning,			php_core_globals,	core_globals)
 #endif
+	STD_PHP_INI_ENTRY("syslog.facility",		"LOG_USER",		PHP_INI_SYSTEM,		OnSetFacility,		syslog_facility,	php_core_globals,		core_globals)
+	STD_PHP_INI_ENTRY("syslog.ident",		"php",			PHP_INI_SYSTEM,		OnUpdateString,		syslog_ident,		php_core_globals,		core_globals)
 PHP_INI_END()
 /* }}} */
 
@@ -2134,6 +2273,8 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 	if (PG(open_basedir) && *PG(open_basedir)) {
 		CWDG(realpath_cache_size_limit) = 0;
 	}
+
+	PG(have_called_openlog) = 0;
 
 	/* initialize stream wrappers registry
 	 * (this uses configuration parameters from php.ini)

--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -166,6 +166,10 @@ struct _php_core_globals {
 #ifdef PHP_WIN32
 	zend_bool windows_show_crt_warning;
 #endif
+
+	zend_long syslog_facility;
+	char *syslog_ident;
+	zend_bool have_called_openlog;
 };
 
 

--- a/main/php_syslog.c
+++ b/main/php_syslog.c
@@ -42,6 +42,15 @@ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
 {
 	va_list args;
 
+	/*
+	 * don't rely on openlog() being called by syslog() if it's
+	 * not already been done; call it ourselves and pass the
+	 * correct parameters!
+	 */
+	if (!PG(have_called_openlog)) {
+		php_openlog(PG(syslog_ident), 0, PG(syslog_facility));
+	}
+
 	va_start(args, format);
 	vsyslog(priority, format, args);
 	va_end(args);
@@ -55,6 +64,15 @@ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
 	smart_string fbuf = {0};
 	smart_string sbuf = {0};
 	va_list args;
+
+	/*
+	 * don't rely on openlog() being called by syslog() if it's
+	 * not already been done; call it ourselves and pass the
+	 * correct parameters!
+	 */
+	if (!PG(have_called_openlog)) {
+		php_openlog(PG(syslog_ident), 0, PG(syslog_facility));
+	}
 
 	va_start(args, format);
 	zend_printf_to_smart_string(&fbuf, format, args);

--- a/main/php_syslog.h
+++ b/main/php_syslog.h
@@ -34,6 +34,7 @@
 
 BEGIN_EXTERN_C()
 PHPAPI void php_syslog(int, const char *format, ...);
+PHPAPI void php_openlog(const char *, int, int);
 END_EXTERN_C()
 
 #endif

--- a/php.ini-development
+++ b/php.ini-development
@@ -577,6 +577,10 @@ html_errors = On
 ;error_log = php_errors.log
 ; Log errors to syslog (Event Log on Windows).
 ;error_log = syslog
+; the next two lines ony happen if the previous line sending errors to syslog
+; has been set as well.
+;syslog.ident = php
+;syslog.facility = user
 
 ;windows.show_crt_warning
 ; Default value: 0

--- a/php.ini-production
+++ b/php.ini-production
@@ -584,6 +584,12 @@ html_errors = On
 ;error_log = php_errors.log
 ; Log errors to syslog (Event Log on Windows).
 ;error_log = syslog
+; Log errors to syslog (Event Log on Windows).
+;error_log = syslog
+; the next two lines ony happen if the previous line sending errors to syslog
+; has been set as well.
+;syslog.ident = php
+;syslog.facility = user
 
 ;windows.show_crt_warning
 ; Default value: 0

--- a/sapi/fpm/fpm/fpm_stdio.c
+++ b/sapi/fpm/fpm/fpm_stdio.c
@@ -289,7 +289,7 @@ int fpm_stdio_open_error_log(int reopen) /* {{{ */
 
 #ifdef HAVE_SYSLOG_H
 	if (!strcasecmp(fpm_global_config.error_log, "syslog")) {
-		openlog(fpm_global_config.syslog_ident, LOG_PID | LOG_CONS, fpm_global_config.syslog_facility);
+		php_openlog(fpm_global_config.syslog_ident, LOG_PID | LOG_CONS, fpm_global_config.syslog_facility);
 		fpm_globals.error_log_fd = ZLOG_SYSLOG;
 		if (fpm_use_error_log()) {
 			zlog_set_fd(fpm_globals.error_log_fd);

--- a/win32/wsyslog.c
+++ b/win32/wsyslog.c
@@ -95,10 +95,6 @@ void vsyslog(int priority, const char *message, va_list args)
 	DWORD evid;
 	wchar_t *strsw[2];
 
-	/* default event source */
-	if (INVALID_HANDLE_VALUE == PW32G(log_source))
-		openlog("php", LOG_PID, LOG_SYSLOG);
-
 	switch (priority) {			/* translate UNIX type into NT type */
 		case LOG_ALERT:
 			etype = EVENTLOG_ERROR_TYPE;


### PR DESCRIPTION
You might want to be able to set the ident (`syslog.ident`) and facility (`syslog.facility`) before a single line of scripting gets executed... especially if you're debugging code and it might crash before it has a chance to call `openlog()`, etc.