### PR TITLE
Test that readline respects open_basedir

### DIFF
--- a/ext/readline/tests/readline_read_history_open_basedir_001.phpt
+++ b/ext/readline/tests/readline_read_history_open_basedir_001.phpt
@@ -1,0 +1,17 @@
+--TEST--
+readline_read_history(): Test that open_basedir is respected
+--SKIPIF--
+<?php if (!extension_loaded("readline") || !function_exists('readline_read_history')) die("skip"); ?>
+--INI--
+open_basedir=/tmp/some-sandbox
+--FILE--
+<?php
+
+$name = '/tmp/out-of-sandbox';
+
+var_dump(readline_read_history($name));
+
+?>
+--EXPECTF--
+Warning: readline_read_history(): open_basedir restriction in effect. File(/tmp/out-of-sandbox) is not within the allowed path(s): (/tmp/some-sandbox) in %s on line %d
+bool(false)

--- a/ext/readline/tests/readline_write_history_open_basedir_001.phpt
+++ b/ext/readline/tests/readline_write_history_open_basedir_001.phpt
@@ -1,0 +1,17 @@
+--TEST--
+readline_write_history(): Test that open_basedir is respected
+--SKIPIF--
+<?php if (!extension_loaded("readline") || !function_exists('readline_write_history')) die("skip"); ?>
+--INI--
+open_basedir=/tmp/some-sandbox
+--FILE--
+<?php
+
+$name = '/tmp/out-of-sandbox';
+
+var_dump(readline_write_history($name));
+
+?>
+--EXPECTF--
+Warning: readline_write_history(): open_basedir restriction in effect. File(/tmp/out-of-sandbox) is not within the allowed path(s): (/tmp/some-sandbox) in %s on line %d
+bool(false)


### PR DESCRIPTION
Hi,
this PR extends the test coverage in ext/readline/readline.c and asserts that open_basedir is respected (line 416 and 441) 