### PR TITLE
Enhancement: php-fpm status page shows ip address of the client - backport to 5.6

### DIFF
--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -181,6 +181,13 @@ char *fpm_php_query_string(TSRMLS_D) /* {{{ */
 }
 /* }}} */
 
+char *fpm_php_client(TSRMLS_D) /* {{{ */
+{
+        fcgi_request *request = (fcgi_request*) SG(server_context);
+        return fcgi_getenv(request, "REMOTE_ADDR", sizeof("REMOTE_ADDR") - 1 TSRMLS_CC);
+}
+/* }}} */
+
 char *fpm_php_auth_user(TSRMLS_D) /* {{{ */
 {
 	return SG(request_info).auth_user;

--- a/sapi/fpm/fpm/fpm_php.h
+++ b/sapi/fpm/fpm/fpm_php.h
@@ -38,6 +38,7 @@ char *fpm_php_script_filename(TSRMLS_D);
 char *fpm_php_request_uri(TSRMLS_D);
 char *fpm_php_request_method(TSRMLS_D);
 char *fpm_php_query_string(TSRMLS_D);
+char *fpm_php_client(TSRMLS_D);
 char *fpm_php_auth_user(TSRMLS_D);
 size_t fpm_php_content_length(TSRMLS_D);
 void fpm_php_soft_quit();

--- a/sapi/fpm/fpm/fpm_request.c
+++ b/sapi/fpm/fpm/fpm_request.c
@@ -92,7 +92,7 @@ void fpm_request_reading_headers() /* {{{ */
 	proc->request_method[0] = '\0';
 	proc->script_filename[0] = '\0';
 	proc->query_string[0] = '\0';
-	proc->query_string[0] = '\0';
+	proc->client[0] = '\0';
 	proc->auth_user[0] = '\0';
 	proc->content_length = 0;
 	fpm_scoreboard_proc_release(proc);
@@ -110,6 +110,7 @@ void fpm_request_info() /* {{{ */
 	char *request_method = fpm_php_request_method(TSRMLS_C);
 	char *script_filename = fpm_php_script_filename(TSRMLS_C);
 	char *query_string = fpm_php_query_string(TSRMLS_C);
+	char *client = fpm_php_client(TSRMLS_C);
 	char *auth_user = fpm_php_auth_user(TSRMLS_C);
 	size_t content_length = fpm_php_content_length(TSRMLS_C);
 	struct timeval now;
@@ -136,6 +137,10 @@ void fpm_request_info() /* {{{ */
 	if (query_string) {
 		strlcpy(proc->query_string, query_string, sizeof(proc->query_string));
 	}
+
+        if (client) {
+                strlcpy(proc->client, client, sizeof(proc->client));
+        }
 
 	if (auth_user) {
 		strlcpy(proc->auth_user, auth_user, sizeof(proc->auth_user));

--- a/sapi/fpm/fpm/fpm_scoreboard.h
+++ b/sapi/fpm/fpm/fpm_scoreboard.h
@@ -36,6 +36,7 @@ struct fpm_scoreboard_proc_s {
 	char request_method[16];
 	size_t content_length; /* used with POST only */
 	char script_filename[256];
+	char client[40];
 	char auth_user[32];
 #ifdef HAVE_TIMES
 	struct tms cpu_accepted;

--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -168,6 +168,7 @@ int fpm_status_handle_request(TSRMLS_D) /* {{{ */
 					"<table border=\"1\">\n"
 					"<tr>"
 						"<th>pid</th>"
+						"<th>client</th>"
 						"<th>state</th>"
 						"<th>start time</th>"
 						"<th>start since</th>"
@@ -187,6 +188,7 @@ int fpm_status_handle_request(TSRMLS_D) /* {{{ */
 				full_syntax =
 					"<tr>"
 						"<td>%d</td>"
+						"<td>%s</td>"
 						"<td>%s</td>"
 						"<td>%s</td>"
 						"<td>%lu</td>"
@@ -239,6 +241,7 @@ int fpm_status_handle_request(TSRMLS_D) /* {{{ */
 					full_syntax = 
 						"<process>"
 							"<pid>%d</pid>"
+							"<client>%s</client>"
 							"<state>%s</state>"
 							"<start-time>%s</start-time>"
 							"<start-since>%lu</start-since>"
@@ -290,6 +293,7 @@ int fpm_status_handle_request(TSRMLS_D) /* {{{ */
 
 				full_syntax = "{"
 					"\"pid\":%d,"
+					"\"client\":\"%s\","
 					"\"state\":\"%s\","
 					"\"start time\":%s,"
 					"\"start since\":%lu,"
@@ -337,6 +341,7 @@ int fpm_status_handle_request(TSRMLS_D) /* {{{ */
 						"\n"
 						"************************\n"
 						"pid:                  %d\n"
+						"client:               %s\n"
 						"state:                %s\n"
 						"start time:           %s\n"
 						"start since:          %lu\n"
@@ -439,6 +444,7 @@ int fpm_status_handle_request(TSRMLS_D) /* {{{ */
 				strftime(time_buffer, sizeof(time_buffer) - 1, time_format, localtime(&proc.start_epoch));
 				spprintf(&buffer, 0, full_syntax,
 					proc.pid,
+					proc.client[0] != '\0' ? proc.client: "-",
 					fpm_request_get_stage_name(proc.request_stage),
 					time_buffer,
 					now_epoch - proc.start_epoch,

--- a/sapi/fpm/php-fpm.conf.in
+++ b/sapi/fpm/php-fpm.conf.in
@@ -313,6 +313,7 @@ pm.max_spare_servers = 3
 ;   http://www.foo.bar/status?xml&full
 ; The Full status returns for each process:
 ;   pid                  - the PID of the process;
+;   client               - client address (REMOTE_ADDR) (or '-' if not set);
 ;   state                - the state of the process (Idle, Running, ...);
 ;   start time           - the date and time the process has started;
 ;   start since          - the number of seconds since the process has started;
@@ -337,6 +338,7 @@ pm.max_spare_servers = 3
 ; Example output:
 ;   ************************
 ;   pid:                  31330
+;   client:               127.0.0.1
 ;   state:                Running
 ;   start time:           01/Jul/2011:17:53:49 +0200
 ;   start since:          63087

--- a/sapi/fpm/status.html.in
+++ b/sapi/fpm/status.html.in
@@ -64,11 +64,11 @@
 			</table>
 			<h1>Active Processes status</h1> 
 			<table border="0" cellpadding="3" width="95%" id="active">
-				<tr class="h"><th>PID&darr;</th><th>Start Time</th><th>Start Since</th><th>Requests Served</th><th>Request Duration</th><th>Request method</th><th>Request URI</th><th>Content Length</th><th>User</th><th>Script</th></tr>
+				<tr class="h"><th>PID&darr;</th><th>Client</th><th>Start Time</th><th>Start Since</th><th>Requests Served</th><th>Request Duration</th><th>Request method</th><th>Request URI</th><th>Content Length</th><th>User</th><th>Script</th></tr>
 			</table>
 			<h1>Idle Processes status</h1> 
 			<table border="0" cellpadding="3" width="95%" id="idle">
-				<tr class="h"><th>PID&darr;</th><th>Start Time</th><th>Start Since</th><th>Requests Served</th><th>Request Duration</th><th>Request method</th><th>Request URI</th><th>Content Length</th><th>User</th><th>Script</th><th>Last Request %CPU</th><th>Last Request Memory</th></tr>
+				<tr class="h"><th>PID&darr;</th><th>Client</th><th>Start Time</th><th>Start Since</th><th>Requests Served</th><th>Request Duration</th><th>Request method</th><th>Request URI</th><th>Content Length</th><th>User</th><th>Script</th><th>Last Request %CPU</th><th>Last Request Memory</th></tr>
 			</table>
 		</div>
 		<p>
@@ -328,6 +328,10 @@
 						row.className = c;
 						row.insertCell(-1).innerHTML = proc.pid;
 						row.cells[row.cells.length - 1].__search_v = proc.pid;
+						row.cells[row.cells.length - 1].__search_t = 0;
+
+						row.insertCell(-1).innerHTML = proc.client;
+						row.cells[row.cells.length - 1].__search_v = proc.client;
 						row.cells[row.cells.length - 1].__search_t = 0;
 
 						row.insertCell(-1).innerHTML = date(proc['start time'] * 1000);;

--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -185,6 +185,7 @@ pm.max_spare_servers = 3
 ;   http://www.foo.bar/status?xml&full
 ; The Full status returns for each process:
 ;   pid                  - the PID of the process;
+;   client               - client address (REMOTE_ADDR) (or '-' if not set);
 ;   state                - the state of the process (Idle, Running, ...);
 ;   start time           - the date and time the process has started;
 ;   start since          - the number of seconds since the process has started;
@@ -209,6 +210,7 @@ pm.max_spare_servers = 3
 ; Example output:
 ;   ************************
 ;   pid:                  31330
+;   client:               127.0.0.1
 ;   state:                Running
 ;   start time:           01/Jul/2011:17:53:49 +0200
 ;   start since:          63087


### PR DESCRIPTION
PHP-FPM is now aware of the IP address (REMOTE_ADDR) of the client
who initiated the request and shows it in status page.
Backported to 5.6 from 7.0 changes in PR #2713 

I have also found the duplicate line in fpm_request.c so I fixed it...