### PR TITLE
fix mbstring extension failed to compile in archlinux system

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfilter.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.h
@@ -104,6 +104,8 @@
 #define ssize_t __int64
 #elif defined(_WIN32)
 #define ssize_t __int32
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#define ssize_t __int128
 #endif
 #endif
 


### PR DESCRIPTION
fix `ssize_t`  is not defined in archlinux