### PR TITLE
Fix `nmake install` fails when there are no shared extensions in the build (Windows)

### DIFF
--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -246,8 +246,8 @@ really-install:
 	@if not exist $(PHP_PREFIX)\ext mkdir $(PHP_PREFIX)\ext
 	@echo Installing files under $(PHP_PREFIX)
 	@copy $(BUILD_DIR)\*.exe $(PHP_PREFIX) /y >nul
-	-@copy $(BUILD_DIR)\php_*.dll $(PHP_PREFIX)\ext /y >nul
-	-dir /b $(BUILD_DIR)\php_*.dll > $(BUILD_DIR)\extension_dlls.txt
+	@touch $(BUILD_DIR)\extension_dlls.txt
+	@if exist $(BUILD_DIR)\php_*.dll copy $(BUILD_DIR)\php_*.dll $(PHP_PREFIX)\ext /y >nul & dir /b $(BUILD_DIR)\php_*.dll > $(BUILD_DIR)\extension_dlls.txt
 	@xcopy $(BUILD_DIR)\*.dll /exclude:$(BUILD_DIR)\extension_dlls.txt $(PHP_PREFIX) /y >nul
 	@echo Registering event source with syslog (requires admin rights)
 	@echo It's okay for this step to fail:

--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -245,7 +245,7 @@ really-install:
 	@if not exist $(PHP_PREFIX) mkdir $(PHP_PREFIX)
 	@if not exist $(PHP_PREFIX)\ext mkdir $(PHP_PREFIX)\ext
 	@echo Installing files under $(PHP_PREFIX)
-	@copy $(BUILD_DIR)\*.exe $(PHP_PREFIX) /y >nul
+	@if exist $(BUILD_DIR)\*.exe copy $(BUILD_DIR)\*.exe $(PHP_PREFIX) /y >nul
 	@touch $(BUILD_DIR)\extension_dlls.txt
 	@if exist $(BUILD_DIR)\php_*.dll copy $(BUILD_DIR)\php_*.dll $(PHP_PREFIX)\ext /y >nul & dir /b $(BUILD_DIR)\php_*.dll > $(BUILD_DIR)\extension_dlls.txt
 	@xcopy $(BUILD_DIR)\*.dll /exclude:$(BUILD_DIR)\extension_dlls.txt $(PHP_PREFIX) /y >nul

--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -246,8 +246,8 @@ really-install:
 	@if not exist $(PHP_PREFIX)\ext mkdir $(PHP_PREFIX)\ext
 	@echo Installing files under $(PHP_PREFIX)
 	@copy $(BUILD_DIR)\*.exe $(PHP_PREFIX) /y >nul
-	@copy $(BUILD_DIR)\php_*.dll $(PHP_PREFIX)\ext /y >nul
-	dir /b $(BUILD_DIR)\php_*.dll > $(BUILD_DIR)\extension_dlls.txt
+	-@copy $(BUILD_DIR)\php_*.dll $(PHP_PREFIX)\ext /y >nul
+	-dir /b $(BUILD_DIR)\php_*.dll > $(BUILD_DIR)\extension_dlls.txt
 	@xcopy $(BUILD_DIR)\*.dll /exclude:$(BUILD_DIR)\extension_dlls.txt $(PHP_PREFIX) /y >nul
 	@echo Registering event source with syslog (requires admin rights)
 	@echo It's okay for this step to fail:


### PR DESCRIPTION
When there are no shared extensions in the build, these steps will fail. This instructs nmake to ignore these two steps failing.