### PR TITLE
Copy dependencies of the core DLL in `nmake snap` for statically-comp…

### DIFF
--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -204,7 +204,8 @@ function extract_file_from_tarball($pkg, $filename, $dest_dir) /* {{{ */
 
 /* the core dll */
 copy("$build_dir/php.exe", "$dist_dir/php.exe");
-copy("$build_dir/$phpdll", "$dist_dir/$phpdll");
+/* copy dll and its dependencies */
+copy_file_list($build_dir, "$dist_dir", [$phpdll]);
 
 /* and the .lib goes into dev */
 $phplib = str_replace(".dll", ".lib", $phpdll);


### PR DESCRIPTION
…iled extensions when packaging builds (Windows)

Shared extension dependencies are already copied but static ones don't appear to be. This causes problems running packaged builds which have statically-compiled extensions with dependencies (for example YAML depends on `yaml.dll`).