### PR TITLE
Bcscale return old value

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -577,7 +577,7 @@ PHP_FUNCTION(bccomp)
 }
 /* }}} */
 
-/* {{{ proto bool bcscale(int scale)
+/* {{{ proto int bcscale([int scale])
    Sets default scale parameter for all bc math functions */
 PHP_FUNCTION(bcscale)
 {
@@ -591,7 +591,7 @@ PHP_FUNCTION(bcscale)
 	old_scale = BCG(bc_precision);
 
 	if (ZEND_NUM_ARGS() == 1) {
-	BCG(bc_precision) = ((int)new_scale < 0) ? 0 : new_scale;
+		BCG(bc_precision) = ((int)new_scale < 0) ? 0 : new_scale;
 	}
 
 	RETURN_LONG(old_scale);

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -89,7 +89,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_bccomp, 0, 0, 2)
 	ZEND_ARG_INFO(0, scale)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_bcscale, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_bcscale, 0, 0, 0)
 	ZEND_ARG_INFO(0, scale)
 ZEND_END_ARG_INFO()
 

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -581,15 +581,20 @@ PHP_FUNCTION(bccomp)
    Sets default scale parameter for all bc math functions */
 PHP_FUNCTION(bcscale)
 {
-	zend_long new_scale;
+	zend_long old_scale, new_scale;
 
-	ZEND_PARSE_PARAMETERS_START(1, 1)
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(new_scale)
 	ZEND_PARSE_PARAMETERS_END();
 
-	BCG(bc_precision) = ((int)new_scale < 0) ? 0 : new_scale;
+	old_scale = BCG(bc_precision);
 
-	RETURN_TRUE;
+	if (ZEND_NUM_ARGS() == 1) {
+	BCG(bc_precision) = ((int)new_scale < 0) ? 0 : new_scale;
+	}
+
+	RETURN_LONG(old_scale);
 }
 /* }}} */
 

--- a/ext/bcmath/tests/bcscale_variation003.phpt
+++ b/ext/bcmath/tests/bcscale_variation003.phpt
@@ -1,0 +1,18 @@
+--TEST--
+bcscale() return value
+--SKIPIF--
+<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--INI--
+bcmath.scale=0
+--FILE--
+<?php
+var_dump(bcscale(1));
+var_dump(bcscale(4));
+var_dump(bcscale());
+var_dump(bcscale());
+?>
+--EXPECT--
+int(0)
+int(1)
+int(4)
+int(4)


### PR DESCRIPTION
This implements https://bugs.php.net/bug.php?id=67855 based on PR #778.

TL;DR: `bcsale()` now can be called without a parameter to get the current scale value, and returns the old scale value if called as setter.

Note that this would need an entry in UPGRADING.