### PR TITLE
Fixed bug #66364 (BCMath bcmul ignores scale parameter)

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -326,6 +326,13 @@ PHP_FUNCTION(bcmul)
 	if (result->n_scale > scale) {
 		result = split_bc_num(result);
 		result->n_scale = scale;
+	} else if (result->n_scale < scale) {
+		bc_num temp;
+
+		bc_init_num(&temp);
+		bc_divide(result, BCG(_one_), &temp, scale);
+		bc_free_num(&result);
+		result = temp;
 	}
 
 	RETVAL_STR(bc_num2str(result));

--- a/ext/bcmath/tests/bug66364.phpt
+++ b/ext/bcmath/tests/bug66364.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #66364 (BCMath bcmul ignores scale parameter)
+--SKIPIF--
+<?php
+if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
+?>
+--FILE--
+<?php
+var_dump(bcmul('0.3', '0.2', 4));
+?>
+===DONE===
+--EXPECT--
+string(6) "0.0600"
+===DONE===


### PR DESCRIPTION
For consistency with other BCMath functions, we heed the scale even if
the trailing zeroes are not strictly required.

Instead of fiddling around with the internals of libbcmath, we simply
divide the result by one to get the desired result, if the original
result has too few decimals.