### PR TITLE
Refactor ftp_append test to clean temporary files

### DIFF
--- a/ext/ftp/tests/ftp_append.phpt
+++ b/ext/ftp/tests/ftp_append.phpt
@@ -13,15 +13,19 @@ if (!$ftp) die("Couldn't connect to the server");
 
 var_dump(ftp_login($ftp, 'user', 'pass'));
 
-@unlink(__DIR__.'/ftp_append_foobar');
+$fooPath = __DIR__ . '/ftp_append_foo';
+file_put_contents($fooPath, 'foo');
+var_dump(ftp_append($ftp, 'ftp_append_foobar', $fooPath, FTP_BINARY));
+unlink($fooPath);
 
-file_put_contents(__DIR__.'/ftp_append_foo', 'foo');
-var_dump(ftp_append($ftp, 'ftp_append_foobar', __DIR__.'/ftp_append_foo', FTP_BINARY));
+$barPath = __DIR__ . '/ftp_append_bar';
+file_put_contents($barPath, 'bar');
+var_dump(ftp_append($ftp, 'ftp_append_foobar', $barPath, FTP_BINARY));
+unlink($barPath);
 
-file_put_contents(__DIR__.'/ftp_append_bar', 'bar');
-var_dump(ftp_append($ftp, 'ftp_append_foobar', __DIR__.'/ftp_append_bar', FTP_BINARY));
-
-var_dump(file_get_contents(__DIR__.'/ftp_append_foobar'));
+$fooBarPath = __DIR__ . '/ftp_append_foobar';
+var_dump(file_get_contents($fooBarPath));
+unlink($fooBarPath);
 
 ftp_close($ftp);
 ?>

--- a/ext/ftp/tests/ftp_append.phpt
+++ b/ext/ftp/tests/ftp_append.phpt
@@ -16,18 +16,24 @@ var_dump(ftp_login($ftp, 'user', 'pass'));
 $fooPath = __DIR__ . '/ftp_append_foo';
 file_put_contents($fooPath, 'foo');
 var_dump(ftp_append($ftp, 'ftp_append_foobar', $fooPath, FTP_BINARY));
-unlink($fooPath);
 
 $barPath = __DIR__ . '/ftp_append_bar';
 file_put_contents($barPath, 'bar');
 var_dump(ftp_append($ftp, 'ftp_append_foobar', $barPath, FTP_BINARY));
-unlink($barPath);
 
 $fooBarPath = __DIR__ . '/ftp_append_foobar';
 var_dump(file_get_contents($fooBarPath));
-unlink($fooBarPath);
 
 ftp_close($ftp);
+?>
+--CLEAN--
+<?php
+$fooPath = __DIR__ . '/ftp_append_foo';
+unlink($fooPath);
+$barPath = __DIR__ . '/ftp_append_bar';
+unlink($barPath);
+$fooBarPath = __DIR__ . '/ftp_append_foobar';
+unlink($fooBarPath);
 ?>
 --EXPECTF--
 bool(true)


### PR DESCRIPTION
The test ext/ftp/tests/ftp_append.phpt was leaving these files on the repo after each run:

ext/ftp/tests/ftp_append_bar
ext/ftp/tests/ftp_append_foo
ext/ftp/tests/ftp_append_foobar

This refactor removes theses files after their usage. 