### PR TITLE
Fix LDFLAGS getting overwritten (ext/curl)

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -99,7 +99,7 @@ if test "$PHP_CURL" != "no"; then
    
     save_CFLAGS="$CFLAGS"
     CFLAGS=$CURL_INCL
-    save_LDFLAGS="$CFLAGS"
+    save_LDFLAGS="$LDFLAGS"
     LDFLAGS=$CURL_LIBS
    
     AC_PROG_CPP


### PR DESCRIPTION
bug was introduced in https://github.com/php/php-src/commit/b8c6ce91b24d314fe9f9996a17942b63ecec249b