### PR TITLE
Fixed Bug #75212 php_value acts like php_admin_value

### DIFF
--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -38,7 +38,10 @@ static int fpm_php_zend_ini_alter_master(char *name, int name_length, char *new_
 			|| ini_entry->on_modify(ini_entry, duplicate,
 				ini_entry->mh_arg1, ini_entry->mh_arg2, ini_entry->mh_arg3, stage) == SUCCESS) {
 		ini_entry->value = duplicate;
-		ini_entry->modifiable = mode;
+		/* when mode == ZEND_INI_USER keep unchanged to allow ZEND_INI_PERDIR (.user.ini) */
+		if (mode == ZEND_INI_SYSTEM) {
+			ini_entry->modifiable = mode;
+		}
 	} else {
 		zend_string_release(duplicate);
 	}

--- a/sapi/fpm/tests/023-bug72212.phpt
+++ b/sapi/fpm/tests/023-bug72212.phpt
@@ -1,0 +1,82 @@
+--TEST--
+FPM: bug #75212 php_value acts like php_admin_value
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+include "include.inc";
+
+$logfile = __DIR__.'/php-fpm.log.tmp';
+$srcfile = __DIR__.'/bug75212.php';
+$inifile = __DIR__.'/.user.ini';
+$port = 9000+PHP_INT_SIZE;
+
+$cfg = <<<EOT
+[global]
+error_log = $logfile
+[unconfined]
+listen = 127.0.0.1:$port
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+php_admin_value[memory_limit]=32M
+php_value[date.timezone]=Europe/London
+EOT;
+
+$code = <<<EOT
+<?php
+echo "Test Start\n";
+var_dump(ini_get('memory_limit'), ini_get('date.timezone'));
+echo "Test End\n";
+EOT;
+file_put_contents($srcfile, $code);
+
+$ini = <<<EOT
+memory_limit=64M
+date.timezone=Europe/Paris
+
+EOT;
+file_put_contents($inifile, $ini);
+
+$fpm = run_fpm($cfg, $tail);
+if (is_resource($fpm)) {
+    fpm_display_log($tail, 2);
+    try {
+		$req = run_request('127.0.0.1', $port, $srcfile);
+		echo strstr($req, "Test Start");
+		echo "Request ok\n";
+	} catch (Exception $e) {
+		echo "Request error\n";
+	}
+    proc_terminate($fpm);
+    fpm_display_log($tail, -1);
+    fclose($tail);
+    proc_close($fpm);
+}
+
+?>
+Done
+--EXPECTF--
+[%s] NOTICE: fpm is running, pid %d
+[%s] NOTICE: ready to handle connections
+Test Start
+string(3) "32M"
+string(12) "Europe/Paris"
+Test End
+
+Request ok
+[%s] NOTICE: Terminating ...
+[%s] NOTICE: exiting, bye-bye!
+Done
+--CLEAN--
+<?php
+	$logfile = __DIR__.'/php-fpm.log.tmp';
+	$srcfile = __DIR__.'/bug75212.php';
+	$inifile = __DIR__.'/.user.ini';
+	@unlink($logfile);
+	@unlink($srcfile);
+	@unlink($inifile);
+?>

--- a/sapi/fpm/tests/include.inc
+++ b/sapi/fpm/tests/include.inc
@@ -124,6 +124,7 @@ function run_request($host, $port, $uri='/ping', $query='', $headers=array()) { 
 		'SERVER_NAME'       => php_uname('n'),
 		'SERVER_PROTOCOL'   => 'HTTP/1.1',
 		'CONTENT_TYPE'      => '',
+		'DOCUMENT_ROOT'     => __DIR__,
 		'CONTENT_LENGTH'    => 0
 	), $headers);
 	return $client->request($params, false)."\n";


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=75212

Open for discussion

I think that not being able to use .user.ini when a default value (php_value) is defined in the pool configuration is a bug.

But some may consider this as a breaking change (so perhaps only to be fixed in 7.2 only)
