### PR TITLE
Fixed bug #75221 (Argon2i always throws NUL at the end)

### DIFF
--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -526,7 +526,7 @@ PHP_FUNCTION(password_hash)
 #endif
 				);
 
-				encoded = zend_string_alloc(encoded_len, 0);
+				encoded = zend_string_alloc(encoded_len - 1, 0);
 				status = argon2_hash(
 					time_cost,
 					memory_cost,
@@ -538,7 +538,7 @@ PHP_FUNCTION(password_hash)
 					ZSTR_VAL(out),
 					ZSTR_LEN(out),
 					ZSTR_VAL(encoded),
-					ZSTR_LEN(encoded),
+					ZSTR_LEN(encoded) + 1,
 					type,
 					ARGON2_VERSION_NUMBER
 				);

--- a/ext/standard/tests/password/bug75221.phpt
+++ b/ext/standard/tests/password/bug75221.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #75221 (Argon2i always throws NUL at the end)
+--SKIPIF--
+<?php
+if (!defined('PASSWORD_ARGON2I')) die('skip password_hash not built with Argon2');
+?>
+--FILE--
+<?php
+$hash = password_hash(
+    "php",
+    PASSWORD_ARGON2I,
+    ['memory_cost' => 16384, 'time_cost' => 2, 'threads' => 4]
+);
+var_dump(substr($hash, -1, 1) !== "\0");
+?>
+===DONE===
+--EXPECT--
+bool(true)
+===DONE===


### PR DESCRIPTION
Apparently, `argon2_encodedlen()` also counts the terminating NUL byte;
that doesn't appear to be documented somewhere, but from looking at the
implementation[1] it is pretty obvious.  Therefore, the respective
`zend_string` has to be one byte shorter.

[1] <https://github.com/P-H-C/phc-winner-argon2/blob/20161029/src/argon2.c#L431-L436>