### PR TITLE
Fix bug #75237 (jsonSerialize() - Returning new instance of self causes segfault)

### DIFF
--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -483,6 +483,14 @@ static int php_json_encode_serializable_object(smart_str *buf, zval *val, int op
 	}
 
 	if ((Z_TYPE(retval) == IS_OBJECT) &&
+		(Z_OBJ(retval) != Z_OBJ_P(val)) &&
+		ce->name == Z_OBJCE(retval)->name) {
+			zend_throw_exception_ex(NULL, 0, "%s::jsonSerialize() cannot return a new instance of itself", ZSTR_VAL(ce->name));
+			zval_ptr_dtor(&retval);
+			zval_ptr_dtor(&fname);
+			PHP_JSON_HASH_APPLY_PROTECTION_DEC(myht);
+			return FAILURE;
+	} else if ((Z_TYPE(retval) == IS_OBJECT) &&
 		(Z_OBJ(retval) == Z_OBJ_P(val))) {
 		/* Handle the case where jsonSerialize does: return $this; by going straight to encode array */
 		PHP_JSON_HASH_APPLY_PROTECTION_DEC(myht);

--- a/ext/json/tests/bug75237.phpt
+++ b/ext/json/tests/bug75237.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #75237 (jsonSerialize() - Returning new instance of self causes segfault)
+--SKIPIF--
+<?php if (!extension_loaded("json")) die("skip ext/json required"); ?>
+--FILE--
+<?php
+class Foo implements JsonSerializable {
+  public function jsonSerialize() {
+    return new self;
+  }
+}
+
+try {
+  var_dump(json_encode(new Foo));
+} catch (Exception $e) {
+  echo $e->getMessage();
+}
+?>
+--EXPECT--
+Foo::jsonSerialize() cannot return a new instance of itself


### PR DESCRIPTION
This patch fixes [bug 75237](https://bugs.php.net/bug.php?id=75237). I'm pretty sure the garbage collection is correct, but just need to have a second set of eyes on it to make sure I didn't inadvertently break anything.

Also - this just throws a generic `Exception`. If you think we need to throw a specific exception, let me know and I can update the PR. :)