### PR TITLE
Fix CGI m4 config message when CGI is disabled

### DIFF
--- a/sapi/cgi/config9.m4
+++ b/sapi/cgi/config9.m4
@@ -27,9 +27,9 @@ if test "$PHP_CGI" != "no"; then
 
     AC_MSG_CHECKING([whether cross-process locking is required by accept()])
     case "`uname -sr`" in
-      IRIX\ 5.* | SunOS\ 5.* | UNIX_System_V\ 4.0)	
+      IRIX\ 5.* | SunOS\ 5.* | UNIX_System_V\ 4.0)
         AC_MSG_RESULT([yes])
-        AC_DEFINE([USE_LOCKING], [1], 
+        AC_DEFINE([USE_LOCKING], [1],
           [Define if cross-process locking is required by accept()])
       ;;
       *)
@@ -74,5 +74,5 @@ if test "$PHP_CGI" != "no"; then
 
     PHP_OUTPUT(sapi/cgi/php-cgi.1)
 else
-  AC_MSG_RESULT(yes)
+  AC_MSG_RESULT(no)
 fi


### PR DESCRIPTION
When doing `./configure --disable-cgi`, this is the output line:
```
checking for CGI build... yes
```

This patch fixes the output message when building PHP with `--disable-cgi` from currently always set `yes` to `no`. It targets PHP 7 branches up to master.


