### PR TITLE
Remove some old sapi/apache_hooks and sapi/apache leftovers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,8 +18,6 @@ ext/filter/filter.c             ident
 ext/zip/php_zip.c               ident
 README.input_filter             ident
 run-tests.php                   ident
-sapi/nsapi/nsapi.c              ident
-sapi/continuity/capi.c          ident
 Zend/RFCs/002.txt               ident
 Zend/RFCs/003.txt               ident
 ext/exif/exif.c                 ident
@@ -32,7 +30,6 @@ UPGRADING.INTERNALS             merge=NEWS
 /ext/bz2/tests/with_strings.phpt	-crlf
 /ext/dom/tests/bug40836.phpt	-crlf
 /ext/dom/tests/domelement.phpt	-crlf
-/ext/ereg/tests/eregi_basic_002.phpt	-crlf
 /ext/iconv/tests/iconv004.phpt	-crlf
 /ext/iconv/tests/iconv_basic.phpt	-crlf
 /ext/iconv/tests/iconv_strpos.phpt	-crlf

--- a/.gitignore
+++ b/.gitignore
@@ -262,9 +262,7 @@ pear/phpize
 pear/run-tests
 pear/php-config
 pear/scripts
-sapi/apache/libphp7.module
 sapi/apache2handler/libphp7.module
-sapi/apache_hooks/libphp7.module
 sapi/cgi/php-cgi
 sapi/cgi/php-cgi.1
 sapi/cli/php.1

--- a/Makefile.global
+++ b/Makefile.global
@@ -5,7 +5,7 @@ INSTALL_DATA = $(INSTALL) -m 644
 DEFS = -DPHP_ATOM_INC -I$(top_builddir)/include -I$(top_builddir)/main -I$(top_srcdir)
 COMMON_FLAGS = $(DEFS) $(INCLUDES) $(EXTRA_INCLUDES) $(CPPFLAGS) $(PHP_FRAMEWORKPATH)
 
-all: $(all_targets) 
+all: $(all_targets)
 	@echo
 	@echo "Build complete."
 	@echo "Don't forget to run 'make test'."
@@ -112,13 +112,13 @@ test: all
 clean:
 	find . -name \*.gcno -o -name \*.gcda | xargs rm -f
 	find . -name \*.lo -o -name \*.o | xargs rm -f
-	find . -name \*.la -o -name \*.a | xargs rm -f 
+	find . -name \*.la -o -name \*.a | xargs rm -f
 	find . -name \*.so | xargs rm -f
 	find . -name .libs -a -type d|xargs rm -rf
 	rm -f libphp$(PHP_MAJOR_VERSION).la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_MILTER_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(OVERALL_TARGET) modules/* libs/*
 
 distclean: clean
-	rm -f Makefile config.cache config.log config.status Makefile.objects Makefile.fragments libtool main/php_config.h main/internal_functions_cli.c main/internal_functions.c stamp-h sapi/apache/libphp$(PHP_MAJOR_VERSION).module sapi/apache_hooks/libphp$(PHP_MAJOR_VERSION).module buildmk.stamp Zend/zend_dtrace_gen.h Zend/zend_dtrace_gen.h.bak Zend/zend_config.h TSRM/tsrm_config.h
+	rm -f Makefile config.cache config.log config.status Makefile.objects Makefile.fragments libtool main/php_config.h main/internal_functions_cli.c main/internal_functions.c stamp-h buildmk.stamp Zend/zend_dtrace_gen.h Zend/zend_dtrace_gen.h.bak Zend/zend_config.h TSRM/tsrm_config.h
 	rm -f php7.spec main/build-defs.h scripts/phpize
 	rm -f ext/date/lib/timelib_config.h ext/mbstring/oniguruma/config.h ext/mbstring/libmbfl/config.h ext/oci8/oci8_dtrace_gen.h ext/oci8/oci8_dtrace_gen.h.bak
 	rm -f scripts/man1/phpize.1 scripts/php-config scripts/man1/php-config.1 sapi/cli/php.1 sapi/cgi/php-cgi.1 ext/phar/phar.1 ext/phar/phar.phar.1
@@ -135,7 +135,7 @@ prof-gen:
 
 prof-clean:
 	find . -name \*.lo -o -name \*.o | xargs rm -f
-	find . -name \*.la -o -name \*.a | xargs rm -f 
+	find . -name \*.la -o -name \*.a | xargs rm -f
 	find . -name \*.so | xargs rm -f
 	rm -f libphp$(PHP_MAJOR_VERSION).la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_MILTER_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(OVERALL_TARGET) modules/* libs/*
 


### PR DESCRIPTION
The `sapi/apache_hooks` and `sapi/apache` have been removed in PHP7. There are some minor occurrences in some files. This patch targets all PHP 7 branches up to master. In case there is a conflict with PHP-7.2 and master branches, I can open separate pull request for those.

Thanks.