### PR TITLE
Fix PHP_GD_TTSTR: command not found warning in ext/gd

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -309,7 +309,6 @@ else
 
 dnl Various checks for GD features
   PHP_GD_ZLIB
-  PHP_GD_TTSTR
   PHP_GD_WEBP
   PHP_GD_JPEG
   PHP_GD_PNG
@@ -348,7 +347,7 @@ dnl
 if test "$PHP_GD" != "no"; then
   PHP_NEW_EXTENSION(gd, gd.c $extra_sources, $ext_shared,, \\$(GDLIB_CFLAGS))
 
-  if test "$GD_MODULE_TYPE" = "builtin"; then 
+  if test "$GD_MODULE_TYPE" = "builtin"; then
     PHP_ADD_BUILD_DIR($ext_builddir/libgd)
     GDLIB_CFLAGS="-I$ext_srcdir/libgd $GDLIB_CFLAGS"
     GD_HEADER_DIRS="ext/gd/ ext/gd/libgd/"


### PR DESCRIPTION
This is related to https://github.com/php/php-src/commit/494c5dc77ae92d21db915abada2ecefaca620543#diff-e8c8bd2d95fb24262f201d554c10ef59

and used by the `--enable-gd-native-ttf` option that has been removed since PHP 5.5.0.

When using system GD library, `PHP_GD_TTSTR: command not found` warning appears at `./configure` step.

Patch is for 7.2 and master branches.