### PR TITLE
fix #75222 DateInterval microseconds property always 0

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4165,7 +4165,7 @@ zval *date_interval_read_property(zval *object, zval *member, int type, void **c
 		GET_VALUE_FROM_STRUCT(i, "i");
 		GET_VALUE_FROM_STRUCT(s, "s");
 		if (strcmp(Z_STRVAL_P(member), "f") == 0) {
-			fvalue = obj->diff->us / 1000000;
+			fvalue = obj->diff->us / 1000000.0;
 			break;
 		}
 		GET_VALUE_FROM_STRUCT(invert, "invert");

--- a/ext/date/tests/bug75222.phpt
+++ b/ext/date/tests/bug75222.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #75222 DateInterval microseconds property always 0
+--FILE--
+<?php
+
+$dt1 = new \DateTimeImmutable('2017-01-01T00:00:00.000000Z');
+$dt2 = new \DateTimeImmutable('2017-01-01T00:00:00.123456Z');
+$diff = $dt1->diff($dt2);
+//var_dump($diff);
+var_dump($diff->f);
+var_dump(get_object_vars($diff)['f']);
+var_dump($diff->f === get_object_vars($diff)['f']);
+?>
+--EXPECTF--
+float(0.123456)
+float(0.123456)
+bool(true)


### PR DESCRIPTION
fix [#75222](https://bugs.php.net/bug.php?id=75222).

I guess this is caused by a small mistake when @derickr did the manually meging (https://github.com/php/php-src/commit/584db6f38fcac3e5e1ca4c770d3aacfff09ee371)
