### PR TITLE
Fix #74922 - Try to resolve constants when importing trait properties

### DIFF
--- a/Zend/tests/traits/bug74922.phpt
+++ b/Zend/tests/traits/bug74922.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #74922 (Composed class has fatal error with duplicate, equal const properties)
+--FILE--
+<?php
+
+const VALUE = true;
+
+trait Foo {public $var = VALUE;}
+trait Bar {public $var = VALUE;}
+class Baz {use Foo, Bar;}
+
+echo "DONE";
+
+?>
+--EXPECT--
+DONE

--- a/Zend/tests/traits/bug74922a.phpt
+++ b/Zend/tests/traits/bug74922a.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #74922 (Composed class has fatal error with duplicate, equal const properties)
+--FILE--
+<?php
+
+const VALUE = true;
+
+trait Foo {public $var = VALUE;}
+trait Bar {public $var = true;}
+class Baz {use Foo, Bar;}
+
+echo "DONE";
+
+?>
+--EXPECT--
+DONE

--- a/Zend/tests/traits/bug74922b.inc
+++ b/Zend/tests/traits/bug74922b.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Bug74922;
+
+const FOO = 'foo';
+
+trait T1 {
+    public $var = FOO;
+}

--- a/Zend/tests/traits/bug74922b.phpt
+++ b/Zend/tests/traits/bug74922b.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #74922 (Composed class has fatal error with duplicate, equal const properties)
+--FILE--
+<?php
+
+require('bug74922b.inc');
+
+trait T2 {public $var = Bug74922\FOO;}
+class Baz {use Bug74922\T1, T2;}
+
+echo "DONE";
+
+?>
+--EXPECT--
+DONE

--- a/Zend/tests/traits/bug74922c.phpt
+++ b/Zend/tests/traits/bug74922c.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #74922 (Composed class has fatal error with duplicate, equal const properties)
+--FILE--
+<?php
+
+trait T {
+    public $x = self::X;
+}
+trait T2 {
+    public $x = self::X;
+}
+class C {
+    use T, T2;
+    const X = 42;
+}
+var_dump((new C)->x);
+
+?>
+--EXPECT--
+int(42)

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -24,6 +24,7 @@
 #include "zend_inheritance.h"
 #include "zend_smart_str.h"
 #include "zend_operators.h"
+#include "zend_types.h"
 
 static void overriden_ptr_dtor(zval *zv) /* {{{ */
 {
@@ -1568,19 +1569,30 @@ static void zend_do_traits_property_binding(zend_class_entry *ce) /* {{{ */
 					zend_hash_del(&ce->properties_info, prop_name);
 					flags |= ZEND_ACC_CHANGED;
 				} else {
+					not_compatible = 1;
+					
 					if ((coliding_prop->flags & (ZEND_ACC_PPP_MASK | ZEND_ACC_STATIC))
 						== (flags & (ZEND_ACC_PPP_MASK | ZEND_ACC_STATIC))) {
-						/* flags are identical, now the value needs to be checked */
+						/* the flags are identical, thus, the properties may be compatible */
+						zval op1, op2;
+
 						if (flags & ZEND_ACC_STATIC) {
-							not_compatible = fast_is_not_identical_function(&ce->default_static_members_table[coliding_prop->offset],
-											  &ce->traits[i]->default_static_members_table[property_info->offset]);
+							ZVAL_COPY(&op1, &ce->default_static_members_table[coliding_prop->offset]);
+							ZVAL_COPY(&op2, &ce->traits[i]->default_static_members_table[property_info->offset]);
 						} else {
-							not_compatible = fast_is_not_identical_function(&ce->default_properties_table[OBJ_PROP_TO_NUM(coliding_prop->offset)],
-											  &ce->traits[i]->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)]);
+							ZVAL_COPY(&op1, &ce->default_properties_table[OBJ_PROP_TO_NUM(coliding_prop->offset)]);
+							ZVAL_COPY(&op2, &ce->traits[i]->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)]);
 						}
-					} else {
-						/* the flags are not identical, thus, we assume properties are not compatible */
-						not_compatible = 1;
+
+						/* if any of the values is a constant, we try to resolve it */
+						if (UNEXPECTED(Z_TYPE(op1) == IS_CONSTANT_AST)) {
+							zval_update_constant_ex(&op1, ce);
+						}
+						if (UNEXPECTED(Z_TYPE(op2) == IS_CONSTANT_AST)) {
+							zval_update_constant_ex(&op2, ce);
+						}
+
+						not_compatible = fast_is_not_identical_function(&op1, &op2);
 					}
 
 					if (not_compatible) {


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=74922

It fixes [the reported issue](https://3v4l.org/kkHFe):
```
const VALUE = true;

trait Foo {public $var = VALUE;}
trait Bar {public $var = VALUE;}
class Baz {use Foo, Bar;}
```
And it also allows for values that are identical to the constant like:
```
const VALUE = true;

trait Foo {public $var = VALUE;}
trait Bar {public $var = true;}
class Baz {use Foo, Bar;}
```