### PR TITLE
Remove ident gitattribute for ext/zip/php_zip.c

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,7 +15,6 @@ ext/dba/libflatfile/flatfile.c  ident
 ext/dba/libcdb/cdb_make.c       ident
 ext/dba/libcdb/cdb.c            ident
 ext/filter/filter.c             ident
-ext/zip/php_zip.c               ident
 README.input_filter             ident
 run-tests.php                   ident
 Zend/RFCs/002.txt               ident


### PR DESCRIPTION
The ident attribute for `ext/zip/php_zip.c` is not used and can be removed in the .gitattributes. This is a minor patch for PHP 7 branches up to master.