### PR TITLE
[PHP 7.2] Remove ident gitattribute for Zend/RFCs/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,8 +17,6 @@ ext/dba/libcdb/cdb.c            ident
 ext/filter/filter.c             ident
 README.input_filter             ident
 run-tests.php                   ident
-Zend/RFCs/002.txt               ident
-Zend/RFCs/003.txt               ident
 ext/exif/exif.c                 ident
 ext/ldap/ldap.c                 ident
 ext/pdo_pgsql/pdo_pgsql.c       ident


### PR DESCRIPTION
The ident attribute for `Zend/RFCs` is not used and can be removed in the .gitattributes. This is a minor patch for PHP 7.2 and master branches.