### PR TITLE
Change ident gitattribute for ext/ext_skel.php

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@ ext/simplexml/simplexml.c       ident
 ext/iconv/php_iconv.h           ident
 ext/posix/posix.c               ident
 ext/recode/recode.c             ident
-ext/skeleton/create_stubs       ident
+ext/ext_skel.php                ident
 ext/phar/phar/pharcommand.inc   ident
 ext/phar/phar.c                 ident
 ext/sysvmsg/sysvmsg.c           ident


### PR DESCRIPTION
This patch adds the ident gitattribute for the new `ext/ext_skel.php` file in the master branch (PHP 7.3).