### PR TITLE
Add tests for bug #75272 (WWW-Authenticate header forces 401 status)

### DIFF
--- a/ext/standard/tests/general_functions/bug75272_1.phpt
+++ b/ext/standard/tests/general_functions/bug75272_1.phpt
@@ -1,0 +1,14 @@
+--TEST--
+WWW-Authenticate: header does not override response code when response code set before header
+--XFAIL--
+Bug #75272 might still be open. This test asserts the expected behavior of WWW-Authenticate after the bug is resolved
+--CGI--
+--FILE--
+<?php
+header('HTTP/1.1 399 Choose Your Own Adventure');
+header('WWW-Authenticate: Basic realm="Foo"');
+?>
+--EXPECTHEADERS--
+Status: 399 Choose Your Own Adventure
+WWW-Authenticate: Basic realm="Foo"
+--EXPECT--

--- a/ext/standard/tests/general_functions/bug75272_2.phpt
+++ b/ext/standard/tests/general_functions/bug75272_2.phpt
@@ -1,0 +1,11 @@
+--TEST--
+WWW-Authenticate: header automatically sets 401 Unauthorized if no status codes previously set
+--CGI--
+--FILE--
+<?php
+header('WWW-Authenticate: Basic realm="Foo"');
+?>
+--EXPECTHEADERS--
+Status: 401 Unauthorized
+WWW-Authenticate: Basic realm="Foo"
+--EXPECT--

--- a/ext/standard/tests/general_functions/bug75272_3.phpt
+++ b/ext/standard/tests/general_functions/bug75272_3.phpt
@@ -1,0 +1,11 @@
+--TEST--
+WWW-Authenticate: header does not override the 399 response code when code passed as third argument
+--CGI--
+--FILE--
+<?php
+header('WWW-Authenticate: Basic realm="Foo"', true, 399);
+?>
+--EXPECTHEADERS--
+Status: 399
+WWW-Authenticate: Basic realm="Foo"
+--EXPECT--

--- a/ext/standard/tests/general_functions/bug75272_4.phpt
+++ b/ext/standard/tests/general_functions/bug75272_4.phpt
@@ -1,0 +1,13 @@
+--TEST--
+WWW-Authenticate: header does not override response code when response code set after header
+--CGI--
+--FILE--
+<?php
+header('WWW-Authenticate: Basic realm="Foo"');
+header('HTTP/1.1 399 Choose Your Own Adventure');
+?>
+--EXPECTHEADERS--
+Status: 399 Choose Your Own Adventure
+WWW-Authenticate: Basic realm="Foo"
+--EXPECT--
+


### PR DESCRIPTION
This contains four test files to assert expected behavior:

1. This test currently fails, as it is asserting the expected behavior [reported by the bug][75272]; it uses XFAIL for now
2. through 4. Asserts behavior that currently works as expected; added to ensure completeness of tests

[75272]: https://bugs.php.net/bug.php?id=75272