### PR TITLE
Remove done and old TODO file from ext/mysqli

### DIFF
--- a/ext/mysqli/TODO
+++ b/ext/mysqli/TODO
@@ -1,2 +1,0 @@
-- documentation
-- ini-settings


### PR DESCRIPTION
Since PHP documentation and ini settings should be updated for the mysqli extension, this patch removes an old and done TODO file from ext/mysqli folder.