### PR TITLE
Remove outdated README from ext/gmp

### DIFF
--- a/ext/gmp/README
+++ b/ext/gmp/README
@@ -1,5 +1,0 @@
-Arbitrary length number support with GNU MP library.
-Please see the PGP manual for more documentation.
-See also GNU MP home page at http://www.swox.com/gmp/.
-GNU MP library is available under the tems of GNU LGPL 
-license. Please see http://www.swox.com/gmp/lgpl.html


### PR DESCRIPTION
The PHP manual now includes better GMP introduction with updated links to GNU MP library homepage.