### PR TITLE
Fix for #63911: Compare opcodes of the op_array to determine different functions

### DIFF
--- a/Zend/tests/traits/bug63911.phpt
+++ b/Zend/tests/traits/bug63911.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #63911 (Ignore conflicting trait methods originationg from identical sub traits)
+--FILE--
+<?php
+trait A
+{
+    public function a(){
+        echo 'Done';
+    }
+}
+trait B
+{
+    use A;
+}
+trait C
+{
+    use A;
+}
+class D
+{
+    use B, C;
+}
+
+(new D)->a();
+--EXPECT--
+Done

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1145,6 +1145,11 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, zend_s
 	zend_function *new_fn;
 
 	if ((existing_fn = zend_hash_find_ptr(&ce->function_table, key)) != NULL) {
+		/* if it is the same function regardless of where it is coming from, there is no conflict and we do not need to add it again */
+		if (existing_fn->op_array.opcodes == fn->op_array.opcodes) {
+			return;
+		}
+
 		if (existing_fn->common.scope == ce) {
 			/* members from the current class override trait methods */
 			/* use temporary *overriden HashTable to detect hidden conflict */


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=63911

Joint venture of @pmmaga and @DaveRandom at PHPNW17.