### PR TITLE
Remove done TODO line from ext/date

### DIFF
--- a/ext/date/TODO
+++ b/ext/date/TODO
@@ -1,4 +1,3 @@
-- Port over my 200 test cases to .phpt format.
 - Write an error handler for unexpected characters while parsing dates.
 - Cache lookups for timezone information.
 - Make sure that date_default_timezone_set() validates the passed timezone


### PR DESCRIPTION
Tests for ext/date seem to be all in phpt format. The done line from the ext/date TODO file has been removed to have better overview.