### PR TITLE
Fix #75310 - Use DBL_EPSILON to avoid rounding errors in the range function

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -30,6 +30,7 @@
 #include <math.h>
 #include <time.h>
 #include <stdio.h>
+#include <float.h>
 #if HAVE_STRING_H
 #include <string.h>
 #else
@@ -2211,7 +2212,7 @@ double_str:
 			RANGE_CHECK_DOUBLE_INIT_ARRAY(low, high);
 
 			ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
-				for (i = 0, element = low; i < size && element >= high; ++i, element = low - (i * step)) {
+				for (i = 0, element = low; i < size && (element > high || fabs(high - element) < DBL_EPSILON); ++i, element = low - (i * step)) {
 					Z_DVAL(tmp) = element;
 					ZEND_HASH_FILL_ADD(&tmp);
 				}
@@ -2225,7 +2226,7 @@ double_str:
 			RANGE_CHECK_DOUBLE_INIT_ARRAY(high, low);
 
 			ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
-				for (i = 0, element = low; i < size && element <= high; ++i, element = low + (i * step)) {
+				for (i = 0, element = low; i < size && (high > element || fabs(high - element) < DBL_EPSILON); ++i, element = low + (i * step)) {
 					Z_DVAL(tmp) = element;
 					ZEND_HASH_FILL_ADD(&tmp);
 				}

--- a/ext/standard/tests/array/range_bug75310_0.phpt
+++ b/ext/standard/tests/array/range_bug75310_0.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #75310 (another incorrect truncation due to floating point precision issue)
+--FILE--
+<?php
+var_dump(range(0.57, 0.49, -0.01));
+?>
+--EXPECT--
+array(9) {
+  [0]=>
+  float(0.57)
+  [1]=>
+  float(0.56)
+  [2]=>
+  float(0.55)
+  [3]=>
+  float(0.54)
+  [4]=>
+  float(0.53)
+  [5]=>
+  float(0.52)
+  [6]=>
+  float(0.51)
+  [7]=>
+  float(0.5)
+  [8]=>
+  float(0.49)
+}

--- a/ext/standard/tests/array/range_bug75310_1.phpt
+++ b/ext/standard/tests/array/range_bug75310_1.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #75310 (another incorrect truncation due to floating point precision issue)
+--FILE--
+<?php
+var_dump(range(-0.57, -0.49, 0.01));
+?>
+--EXPECT--
+array(9) {
+  [0]=>
+  float(-0.57)
+  [1]=>
+  float(-0.56)
+  [2]=>
+  float(-0.55)
+  [3]=>
+  float(-0.54)
+  [4]=>
+  float(-0.53)
+  [5]=>
+  float(-0.52)
+  [6]=>
+  float(-0.51)
+  [7]=>
+  float(-0.5)
+  [8]=>
+  float(-0.49)
+}


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=75310

In #1695, this constant was removed. However, in cases like the one described in the bug report, this _hack_ still makes a difference.
