### PR TITLE
Join untracked files to root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ ext/mbstring/libmbfl/filters/Makefile.in
 ext/mbstring/libmbfl/mbfl/Makefile.in
 ext/mbstring/libmbfl/mbfl/EastAsianWidth.txt
 ext/mbstring/libmbfl/nls/Makefile.in
+ext/mbstring/oniguruma/oniguruma.h
 ext/mssql/#*#
 ext/mssql/Makefile.global
 ext/mssql/acinclude.m4
@@ -188,9 +189,15 @@ sapi/fpm/php-fpm.1
 sapi/fpm/init.d.php-fpm
 sapi/fpm/php-fpm.conf
 sapi/fpm/fpm/php-cgi
+sapi/fpm/php-fpm.8
+sapi/fpm/php-fpm.service
+sapi/fpm/status.html
+sapi/fpm/www.conf
 sapi/phpdbg/phpdbg_parser.c
 sapi/phpdbg/phpdbg_parser.h
 sapi/phpdbg/phpdbg
+sapi/phpdbg/build
+sapi/phpdbg/*.output
 scripts/php-config
 scripts/phpize
 scripts/man1/*.1
@@ -231,4 +238,3 @@ win32/wsyslog.h
 # special cases to invert previous ignore rules
 !ext/fileinfo/libmagic.patch
 !ext/mbstring/oniguruma.patch
-

--- a/ext/mbstring/.gitignore
+++ b/ext/mbstring/.gitignore
@@ -1,1 +1,0 @@
-oniguruma/oniguruma.h

--- a/sapi/fpm/.gitignore
+++ b/sapi/fpm/.gitignore
@@ -1,4 +1,0 @@
-php-fpm.8
-php-fpm.service
-status.html
-www.conf

--- a/sapi/phpdbg/.gitignore
+++ b/sapi/phpdbg/.gitignore
@@ -1,6 +1,0 @@
-.libs/
-phpdbg
-*.lo
-*.o
-*.output
-build


### PR DESCRIPTION
Currently there are several `.gitignore` files located in some folders. I think all of the removed .gitignore files in this patch could be joined into a single one located in root folder since phpdbg, fpm and mbstring aren't developed separately in their repositories.