### PR TITLE
Remove old apache_hooks occurrence

### DIFF
--- a/main/php_main.h
+++ b/main/php_main.h
@@ -34,8 +34,6 @@ PHPAPI int php_module_startup(sapi_module_struct *sf, zend_module_entry *additio
 PHPAPI void php_module_shutdown(void);
 PHPAPI void php_module_shutdown_for_exec(void);
 PHPAPI int php_module_shutdown_wrapper(sapi_module_struct *sapi_globals);
-PHPAPI int php_request_startup_for_hook(void);
-PHPAPI void php_request_shutdown_for_hook(void *dummy);
 
 PHPAPI int php_register_extensions(zend_module_entry **ptr, int count);
 


### PR DESCRIPTION
The apache_hooks SAPI has been removed since PHP >= 7.0 and there is no need to have two different php_request_startup definitions.

As a reference: Support for apache_hooks in this file has been added via 99c7ddc3a8f9ecf1a3968f6e59dc9d95106bb0c7