### PR TITLE
Make README.md file more readable and useful

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,3 +1,0 @@
-For installation of PHP, please refer to the online documentation available at:
-
-   http://php.net/install

--- a/README.WIN32-BUILD-SYSTEM
+++ b/README.WIN32-BUILD-SYSTEM
@@ -1,6 +1,0 @@
-The Win32 Build System.
-
-See http://wiki.php.net/internals/windows/stepbystepbuild 
-
-vim:tw=78:sw=1:ts=1:et
-

--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
-The PHP Interpreter
-===================
-
-This is the github mirror of the official PHP repository located at
-http://git.php.net.
+# The PHP Interpreter
 
 [![Build Status](https://secure.travis-ci.org/php/php-src.svg?branch=master)](http://travis-ci.org/php/php-src)
 [![Build status](https://ci.appveyor.com/api/projects/status/meyur6fviaxgdwdy?svg=true)](https://ci.appveyor.com/project/php/php-src)
 
-Pull Requests
-=============
-PHP accepts pull requests via github. Discussions are done on github, but
-depending on the topic can also be relayed to the official PHP developer
-mailing list internals@lists.php.net.
+PHP is a popular general-purpose scripting language that is especially suited to
+web development.
 
-New features require an RFC and must be accepted by the developers.
-See https://wiki.php.net/rfc and https://wiki.php.net/rfc/voting for more
-information on the process.
+Official PHP Git repository is located at http://git.php.net. A repository mirror
+is available at https://github.com/php/php-src.
+
+## Installation
+
+For installation of PHP, please refer to the online documentation at
+http://php.net/install.
+
+## Pull requests
+
+PHP accepts pull requests via GitHub. Discussions are done on GitHub, but
+depending on the topic can also be relayed to the official PHP developer mailing
+list internals@lists.php.net.
+
+New features require an RFC and must be accepted by the developers. See
+https://wiki.php.net/rfc and https://wiki.php.net/rfc/voting for more information
+on the process.
 
 Bug fixes **do not** require an RFC, but require a bugtracker ticket. Always
 open a ticket at https://bugs.php.net and reference the bug id using #NNNNNN.
@@ -27,14 +34,12 @@ open a ticket at https://bugs.php.net and reference the bug id using #NNNNNN.
     the magic_quotes behavior and therefore should not raise a warning at any
     time. The patch removes this warning
 
-We do not merge pull requests directly on github. All PRs will be
-pulled and pushed through http://git.php.net.
+We do not merge pull requests directly on GitHub. All PRs will be pulled and
+pushed through http://git.php.net.
 
+## Guidelines for contributors
 
-Guidelines for contributors
-===========================
 - [CODING_STANDARDS](/CODING_STANDARDS)
 - [README.GIT-RULES](/README.GIT-RULES)
 - [README.MAILINGLIST_RULES](/README.MAILINGLIST_RULES)
 - [README.RELEASE_PROCESS](/README.RELEASE_PROCESS)
-

--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -68,13 +68,13 @@ function get_depends($module)
 		"api-ms-win-crt-.+\.dll",
 	);
 	global $build_dir, $extra_dll_deps, $ext_targets, $sapi_targets, $pecl_targets, $phpdll, $per_module_deps, $pecl_dll_deps;
-	
+
 	$bd = strtolower(realpath($build_dir));
 
 	$is_pecl = in_array($module, $pecl_targets);
-	
+
 	$cmd = "$GLOBALS[build_dir]\\deplister.exe \"$module\" \"$GLOBALS[build_dir]\"";
-	$proc = proc_open($cmd, 
+	$proc = proc_open($cmd,
 			array(1 => array("pipe", "w")),
 			$pipes);
 
@@ -106,7 +106,7 @@ function get_depends($module)
 				continue;
 			}
 		}
-		
+
 		if ($is_pecl) {
 			if (!in_array($dep, $pecl_dll_deps)) {
 				$pecl_dll_deps[] = $dep;
@@ -199,7 +199,7 @@ function extract_file_from_tarball($pkg, $filename, $dest_dir) /* {{{ */
 
 		$hdr['size'] = octdec(trim($hdr['size']));
 		echo "File: $hdr[filename] $hdr[size]\n";
-		
+
 		if ($filename == $hdr['filename']) {
 			echo "Found the file we want\n";
 			$dest = fopen($destfilename, 'wb');
@@ -208,14 +208,14 @@ function extract_file_from_tarball($pkg, $filename, $dest_dir) /* {{{ */
 			echo "Wrote $x bytes into $destfilename\n";
 			break;
 		}
-		
+
 		/* skip body of the file */
 		$size = 512 * ceil((int)$hdr['size'] / 512);
 		echo "Skipping $size bytes\n";
 		gzseek($fp, gztell($fp) + $size);
-		
+
 	} while (!$done);
-	
+
 } /* }}} */
 
 
@@ -247,7 +247,7 @@ if(sizeof($pecl_targets)) {
 $text_files = array(
 	"LICENSE" => "license.txt",
 	"NEWS" => "news.txt",
-	"INSTALL" => "install.txt", 
+	"README.md" => "README.md",
 	"README.REDIST.BINS" => "readme-redist-bins.txt",
 	"php.ini-development" => "php.ini-development",
 	"php.ini-production" => "php.ini-production"
@@ -323,9 +323,9 @@ foreach ($extra_dll_deps as $dll) {
 }
 
 /* TODO:
-add sanity check and test if all required DLLs are present, per version 
+add sanity check and test if all required DLLs are present, per version
 This version works at least for 3.6, 3.8 and 4.0 (5.3-vc6, 5.3-vc9 and HEAD).
-Add ADD_DLLS to add extra DLLs like dynamic dependencies for standard 
+Add ADD_DLLS to add extra DLLs like dynamic dependencies for standard
 deps. For example, libenchant.dll loads libenchant_myspell.dll or
 libenchant_ispell.dll
 */
@@ -451,7 +451,7 @@ function copy_test_dir($directory, $dest)
 		}
 	}
 
-	closedir($directory_list); 
+	closedir($directory_list);
 }
 
 function make_phar_dot_phar($dist_dir)
@@ -537,7 +537,7 @@ if (!$use_pear_template) {
 	extract_file_from_tarball('Archive_Tar', 'Archive/Tar.php', "$dist_dir/PEAR/go-pear-bundle");
 	extract_file_from_tarball('Console_Getopt', 'Console/Getopt.php', "$dist_dir/PEAR/go-pear-bundle");
 }
-	
+
 /* add extras from the template dir */
 if (file_exists($snapshot_template)) {
 	$items = glob("$snapshot_template/*");
@@ -567,7 +567,7 @@ if (file_exists($snapshot_template)) {
 			}
 		}
 	}
-	
+
 	/* copy c++ runtime */
 	$items = glob("$snapshot_template/dlls/*.CRT");
 


### PR DESCRIPTION
Hello, here are few more refactorings of the `README.md` file inspired from other open source projects and the [Art of README](https://github.com/noffle/art-of-readme):
- added a short description of the php-src repository
- links to Git repository and GitHub mirror are refactored to suit more use cases (when browsing the README.md file from download release archive)
- `INSTALL` and `README.WIN32-BUILD-SYSTEM` seem redundant and the [PHP manual installation chapter](http://php.net/install) has been mentioned in the `README.md` installation section instead.
- links have been put in the text without using Markdown links for now, to be more readable in text editors.