### PR TITLE
Remove README from ext/tidy in favor of the PHP docs

### DIFF
--- a/ext/tidy/README
+++ b/ext/tidy/README
@@ -1,7 +1,0 @@
-
-README FOR ext/tidy by John Coggeshall <john@php.net>
-
-
-Tidy is an extension based on Libtidy (http://tidy.sf.net/) and allows a PHP developer
-to clean, repair, and traverse HTML, XHTML, and XML documents -- including ones with
-embedded scripting languages such as PHP or ASP within them using OO constructs.


### PR DESCRIPTION
The tidy introduction includes an outdated link to tidy HTML library homepage, and PHP documentation presents the tidy PHP extension better instead.

Patches to update the Tidy library new homepage and extension description has been sent via edit.php.net.