### PR TITLE
Remove done TODO file from date extension

### DIFF
--- a/ext/date/TODO
+++ b/ext/date/TODO
@@ -1,4 +1,0 @@
-- Write an error handler for unexpected characters while parsing dates.
-- Cache lookups for timezone information.
-- Make sure that date_default_timezone_set() validates the passed timezone
-  identifier.


### PR DESCRIPTION
TODO file for date extension has been outdated:

- date_default_timezone_set_error.phpt includes checking that
  date_default_timezone_set() validates the passed timezone identifiers.

- ext/date/php_date.c includes timezone caching

- errors are included in date_parse() return value.