### PR TITLE
enchant_broker_get_dict_path: fix segfault

### DIFF
--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -483,6 +483,11 @@ PHP_FUNCTION(enchant_broker_get_dict_path)
 			RETURN_FALSE;
 	}
 
+	if (value == NULL) {
+		php_error_docref(NULL, E_WARNING, "dict_path not set");
+		RETURN_FALSE;
+	}
+
 	RETURN_STRING(value);
 }
 /* }}} */

--- a/ext/enchant/tests/bug53070.phpt
+++ b/ext/enchant/tests/bug53070.phpt
@@ -1,0 +1,20 @@
+--TEST--
+bug #53070, calling enchant_broker_get_path without enchant_broker_set_path leads to a segfault
+--SKIPIF--
+<?php
+if(!extension_loaded('enchant')) die('skip, enchant not loader');
+if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+?>
+--FILE--
+<?php
+$broker = enchant_broker_init();
+var_dump(enchant_broker_get_dict_path($broker, ENCHANT_MYSPELL));
+var_dump(enchant_broker_get_dict_path($broker, ENCHANT_ISPELL));
+?>
+--EXPECTF--
+
+Warning: enchant_broker_get_dict_path(): dict_path not set in %s on line %d
+bool(false)
+
+Warning: enchant_broker_get_dict_path(): dict_path not set in %s on line %d
+bool(false)


### PR DESCRIPTION
enchant_broker_get_dict_path segfaults when the dict path is not setup,
instead of segfaulting return false instead. Also added a test for the segfault.