### PR TITLE
Fix bug #75346: PEAR install fails with shared xml extension

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -43,7 +43,6 @@ install-modules: build-modules
 	@test -d modules && \
 	$(mkinstalldirs) $(INSTALL_ROOT)$(EXTENSION_DIR)
 	@echo "Installing shared extensions:     $(INSTALL_ROOT)$(EXTENSION_DIR)/"
-	@rm -f modules/*.la >/dev/null 2>&1
 	@$(INSTALL) modules/* $(INSTALL_ROOT)$(EXTENSION_DIR)
 
 install-headers:

--- a/pear/Makefile.frag
+++ b/pear/Makefile.frag
@@ -3,7 +3,7 @@
 peardir=$(PEAR_INSTALLDIR)
 
 # Skip all php.ini files altogether
-PEAR_INSTALL_FLAGS = -n -dshort_open_tag=0 -dopen_basedir= -derror_reporting=1803 -dmemory_limit=-1 -ddetect_unicode=0
+PEAR_INSTALL_FLAGS = -n -dshort_open_tag=0 -dopen_basedir= -derror_reporting=1803 -dmemory_limit=-1 -ddetect_unicode=0 -d extension_dir="$(top_builddir)/modules" $(PHP_TEST_SHARED_EXTENSIONS)
 
 WGET = `which wget 2>/dev/null`
 FETCH = `which fetch 2>/dev/null`
@@ -34,4 +34,3 @@ install-pear:
 	else \
 		cat $(srcdir)/install-pear.txt; \
 	fi
-


### PR DESCRIPTION
PEAR installation requires to have xml and libxml extensions enabled. However when the xml extension is installed as shared one (`--enable-xml=shared`) the installation fails. This patch fixes bug [#75346](https://bugs.php.net/bug.php?id=75346) with additional ini entries passed to php cli command for installing PEAR.

The removal of modules during installation step is also not required before doing `make distclean` otherwise the shared modules cannot be determined easily.