### PR TITLE
Fix #74750 - Look for user code before checking for strict_types

### DIFF
--- a/Zend/tests/type_declarations/bug74750.phpt
+++ b/Zend/tests/type_declarations/bug74750.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #74750 (strict_types not used for builtin callbacks)
+--FILE--
+<?php declare(strict_types=1);
+
+function print_str(string $foo) { var_dump($foo); }
+
+$input = ["1", "2", 3];
+array_map('print_str', $input);
+--EXPECTF--	
+string(1) "1"
+string(1) "2"
+
+Fatal error: Uncaught TypeError: Argument 1 passed to print_str() must be of the type string, integer given in %s
+Stack trace:
+#0 [internal function]: print_str(3)
+#1 %s array_map('print_str', Array)
+#2 {main}
+  thrown in %s

--- a/Zend/tests/type_declarations/bug75345.phpt
+++ b/Zend/tests/type_declarations/bug75345.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #75345 (Strict type declarations not enforced for Reflection API invocation)
+--FILE--
+<?php
+declare(strict_types=1);
+
+function f(bool $a)
+{
+    var_dump($a);
+}
+
+$f = new ReflectionFunction('f');
+$f->invoke(1);
+--EXPECTF--	
+Fatal error: Uncaught TypeError: Argument 1 passed to f() must be of the type boolean, integer given in %s
+Stack trace:
+#0 [internal function]: f(1)
+#1 %s ReflectionFunction->invoke(1)
+#2 {main}
+  thrown in %s

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -847,8 +847,15 @@ static zend_always_inline zend_bool zend_check_type(
 			   EXPECTED(Z_TYPE_P(arg) == IS_FALSE || Z_TYPE_P(arg) == IS_TRUE)) {
 		return 1;
 	} else {
+		zend_execute_data *caller_execute_data = EG(current_execute_data)->prev_execute_data;
+		while (caller_execute_data && 
+				caller_execute_data->func && 
+				!ZEND_USER_CODE(caller_execute_data->func->type)) {
+			caller_execute_data = caller_execute_data->prev_execute_data;
+		}
+
 		return zend_verify_scalar_type_hint(ZEND_TYPE_CODE(type), arg,
-			is_return_type ? ZEND_RET_USES_STRICT_TYPES() : ZEND_ARG_USES_STRICT_TYPES());
+			is_return_type ? ZEND_RET_USES_STRICT_TYPES() : ZEND_CALL_USES_STRICT_TYPES(caller_execute_data));
 	}
 
 	/* Special handling for IS_VOID is not necessary (for return types),


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=74750

This fix allows the indirect check of `strict_types` skipping calls that are not user code. This way, calls made via a callback or reflection will check the place where the code was actually called by the user instead of checking the internal function that delegates the call.

This also fixes https://bugs.php.net/bug.php?id=75345 which covers the case of Reflection.