### PR TITLE
Small improvement with zend_memnstr

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -288,7 +288,7 @@ zend_memnstr(const char *haystack, const char *needle, int needle_len, char *end
 
 	while (p <= end) {
 		if ((p = (char *)memchr(p, *needle, (end-p+1))) && ne == p[needle_len-1]) {
-			if (!memcmp(needle, p, needle_len-1)) {
+			if (!memcmp(needle+1, p+1, needle_len-2)) {
 				return p;
 			}
 		}


### PR DESCRIPTION
There is no need to compare the first character again.

I use `strpos` for testing, with the following code.

```
$a = 'ahcdeabhdeabcheabcdhahcdeabhdeabcheabcde';
$b = 'abcde';
$t1 = microtime(true);
for ($i=0; $i < 50000000; $i++) {
    $c = strpos($a, $b);
}
$t2 = microtime(true);
echo ($t2-$t1)."\n";
```

It speeds up about 2% on average.