### PR TITLE
add meaningful error message in zip extension

### DIFF
--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -85,7 +85,7 @@ if test "$PHP_ZIP" != "no"; then
 
     if test -z "$LIBZIP_LIBDIR"; then
       AC_MSG_RESULT(not found)
-      AC_MSG_ERROR(Please reinstall the libzip distribution)
+      AC_MSG_ERROR(Please install the required header files for libzip, this may be libzip-dev)
     fi
 
     dnl Could not think of a simple way to check libzip for overwrite support


### PR DESCRIPTION
while I was compiling the zip extension, I got the fuzzy message `Please reinstall the libzip distribution`

after looking around for the extension, it was installed, while the required package to be installed was `libzip-dev` to install the required header file.