### PR TITLE
Update .editorconfig with some more configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,16 +1,35 @@
-; http://editorconfig.org/
+# http://editorconfig.org/
 
 root = true
 
-[*.{c,h}]
-charset                  = UTF-8
-end_of_line              = LF
+[*.{c,h,awk,w32,bat,mk,frag}]
+charset                  = utf-8
+end_of_line              = lf
 indent_size              = 4
 indent_style             = tab
-insert_final_newline     = true
 tab_width                = 4
 trim_trailing_whitespace = true
+insert_final_newline     = true
 
-[*.yml]
+[*.{php,phpt}]
+charset                  = utf-8
+end_of_line              = lf
+indent_size              = 4
+indent_style             = space
+trim_trailing_whitespace = true
+insert_final_newline     = true
+
+[*.{yml,m4,sh}]
+charset                  = utf-8
+end_of_line              = lf
 indent_size              = 2
 indent_style             = space
+trim_trailing_whitespace = true
+insert_final_newline     = true
+
+[*.md]
+charset                  = utf-8
+end_of_line              = lf
+indent_style             = space
+trim_trailing_whitespace = false
+insert_final_newline     = true


### PR DESCRIPTION
Added support for .awk, .w32, .bat, .mk, .frag, .m4, .sh, .php, .phpt, and Markdown files based on the current most used coding style in the php-src repository for the [.editorconfig](http://editorconfig.org/).

This pull request supersedes the previous #2826 because it should target PHP-7.0 branch. Many times people checkout branches that tracks PHP-7.0 or above branches and still need the proper editor configurations there. That's why the target branch is set to PHP-7.0. Hope that's ok. Thanks for considering checking it our or merging it. It helps living with different coding styles across editors better.

Note: The *.php and *phpt files currently have mixed coding style and some minor different encodings and line endings are used in few. The one used in this .editorconfig file is the prevailing style based on current coding style direction.