### PR TITLE
Add tests for setrawcookie() standard and error cases

### DIFF
--- a/ext/standard/tests/network/setrawcookie001.phpt
+++ b/ext/standard/tests/network/setrawcookie001.phpt
@@ -1,0 +1,80 @@
+--TEST--
+setrawcookie() tests
+--DESCRIPTION--
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+setrawcookie('name');
+setrawcookie('name', '');
+setrawcookie('name', 'value');
+setrawcookie('name', 'space+value');
+setrawcookie('name', 'value', 0);
+setrawcookie('name', 'value', $tsp = time() + 5);
+setrawcookie('name', 'value', $tsn = time() - 6);
+setrawcookie('name', 'value', $tsc = time());
+setrawcookie('name', 'value', 0, '/path/');
+setrawcookie('name', 'value', 0, '', 'domain.tld');
+setrawcookie('name', 'value', 0, '', '', TRUE);
+setrawcookie('name', 'value', 0, '', '', FALSE, TRUE);
+
+
+$expected = array(
+	'Set-Cookie: name=deleted; expires='.date('D, d-M-Y H:i:s', 1).' GMT; Max-Age=0',
+	'Set-Cookie: name=deleted; expires='.date('D, d-M-Y H:i:s', 1).' GMT; Max-Age=0',
+	'Set-Cookie: name=value',
+	'Set-Cookie: name=space+value',
+	'Set-Cookie: name=value',
+	'Set-Cookie: name=value; expires='.date('D, d-M-Y H:i:s', $tsp).' GMT; Max-Age=5',
+	'Set-Cookie: name=value; expires='.date('D, d-M-Y H:i:s', $tsn).' GMT; Max-Age=0',
+	'Set-Cookie: name=value; expires='.date('D, d-M-Y H:i:s', $tsc).' GMT; Max-Age=0',
+	'Set-Cookie: name=value; path=/path/',
+	'Set-Cookie: name=value; domain=domain.tld',
+	'Set-Cookie: name=value; secure',
+	'Set-Cookie: name=value; HttpOnly'
+);
+
+$headers = headers_list();
+if (($i = count($expected)) > count($headers))
+{
+	echo "Fewer headers are being sent than expected - aborting";
+	return;
+}
+
+do
+{
+	if (strncmp(current($headers), 'Set-Cookie:', 11) !== 0)
+	{
+		continue;
+	}
+
+	if (current($headers) === current($expected))
+	{
+		$i--;
+	}
+	else
+	{
+		echo "Header mismatch:\n\tExpected: "
+			.current($expected)
+			."\n\tReceived: ".current($headers)."\n";
+	}
+
+	next($expected);
+}
+while (next($headers) !== FALSE);
+
+echo ($i === 0)
+	? 'OK'
+	: 'A total of '.$i.' errors found.';
+?>
+--EXPECTHEADERS--
+
+--EXPECT--
+OK
+--CREDITS--
+Bill Condo bill@billcondo.com
+Matthew Radcliffe mradcliffe@kosada.com
+Peter Barney peter@peterbarney.com
+Michael Cordingley michael.cordingley@gmail.com
+Taylor Howard samueltaylorhoward@gmail.com
+# TestFest Columbus PHP UG 2017-10-11

--- a/ext/standard/tests/network/setrawcookie002.phpt
+++ b/ext/standard/tests/network/setrawcookie002.phpt
@@ -1,0 +1,45 @@
+--TEST--
+setrawcookie() cookie name negative tests
+--DESCRIPTION--
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+setrawcookie('=');
+setrawcookie(',');
+setrawcookie(';');
+setrawcookie(' ');
+setrawcookie("\t");
+setrawcookie("\r");
+setrawcookie("\n");
+setrawcookie("\013");
+setrawcookie("\014");
+?>
+--EXPECTHEADERS--
+
+--EXPECTF--
+Warning: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' in %s on line %d
+
+--CREDITS--
+Bill Condo bill@billcondo.com
+Matthew Radcliffe mradcliffe@kosada.com
+Peter Barney peter@peterbarney.com
+Michael Cordingley michael.cordingley@gmail.com
+Taylor Howard samueltaylorhoward@gmail.com
+# TestFest Columbus PHP UG 2017-10-11

--- a/ext/standard/tests/network/setrawcookie003.phpt
+++ b/ext/standard/tests/network/setrawcookie003.phpt
@@ -1,0 +1,42 @@
+--TEST--
+setrawcookie() cookie value negative tests
+--DESCRIPTION--
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+setrawcookie('value', ',');
+setrawcookie('value', ';');
+setrawcookie('value', ' ');
+setrawcookie('value', "\t");
+setrawcookie('value', "\r");
+setrawcookie('value', "\n");
+setrawcookie('value', "\013");
+setrawcookie('value', "\014");
+?>
+--EXPECTHEADERS--
+
+--EXPECTF--
+Warning: Cookie values cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie values cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie values cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie values cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie values cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie values cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie values cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie values cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+
+--CREDITS--
+Bill Condo bill@billcondo.com
+Matthew Radcliffe mradcliffe@kosada.com
+Peter Barney peter@peterbarney.com
+Michael Cordingley michael.cordingley@gmail.com
+Taylor Howard samueltaylorhoward@gmail.com
+# TestFest Columbus PHP UG 2017-10-11


### PR DESCRIPTION
Covers the errors and standard use cases of setrawcookie().

This is the ColumbusPHP user group's first attempt at writing PHP tests. It was a good group experience, we all contributed and learned something new.