### PR TITLE
Fixed bug #75365 (Enchant still reports version 1.1.0)

### DIFF
--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -323,7 +323,6 @@ PHP_MINFO_FUNCTION(enchant)
 #elif defined(HAVE_ENCHANT_BROKER_SET_PARAM)
 	php_info_print_table_row(2, "Libenchant Version", "1.5.0 or later");
 #endif
-	php_info_print_table_row(2, "Revision", "$Id$");
 	php_info_print_table_end();
 
 	php_info_print_table_start();

--- a/ext/enchant/php_enchant.h
+++ b/ext/enchant/php_enchant.h
@@ -24,7 +24,7 @@
 extern zend_module_entry enchant_module_entry;
 #define phpext_enchant_ptr &enchant_module_entry
 
-#define PHP_ENCHANT_VERSION "1.1.0"
+#define PHP_ENCHANT_VERSION PHP_VERSION
 
 #ifdef PHP_WIN32
 #define PHP_ENCHANT_API __declspec(dllexport)


### PR DESCRIPTION
Since Enchant is bundled, we make `PHP_ENCHANT_VERSION` an alias of
`PHP_VERSION` and also drop the rather meaningless revision hash from
the PHP info.