### PR TITLE
Better use of memcmp in zend_operators

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -230,7 +230,7 @@ zend_memnrstr(const char *haystack, const char *needle, size_t needle_len, char 
 
 		do {
 			if ((p = (const char *)zend_memrchr(haystack, *needle, (p - haystack) + 1)) && ne == p[needle_len-1]) {
-				if (!memcmp(needle, p, needle_len - 1)) {
+				if (!memcmp(needle + 1, p + 1, needle_len - 2)) {
 					return p;
 				}
 			}


### PR DESCRIPTION
This is the same situation as PR #2839 ,  but with `zend_memnrstr`.