### PR TITLE
Enable JSON1 for bundled libsqlite

### DIFF
--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -83,7 +83,7 @@ if test "$PHP_PDO_SQLITE" != "no"; then
       fi
 
       AC_DEFINE(HAVE_SQLITE3_CLOSE_V2, 1, [have sqlite3_close_v2])
-      other_flags="-DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS5=1 -DSQLITE_CORE=1 -DSQLITE_ENABLE_COLUMN_METADATA=1"
+      other_flags="-DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS5=1 -DSQLITE_ENABLE_JSON1=1 -DSQLITE_CORE=1 -DSQLITE_ENABLE_COLUMN_METADATA=1"
 
 	  dnl As long as intl is not shared we can have ICU support
       if test "$PHP_INTL" = "yes" && test "$PHP_INTL_SHARED" != "yes"; then

--- a/ext/pdo_sqlite/config.w32
+++ b/ext/pdo_sqlite/config.w32
@@ -4,7 +4,7 @@
 ARG_WITH("pdo-sqlite", "for pdo_sqlite support", "no");
 
 if (PHP_PDO_SQLITE != "no") {
-	EXTENSION("pdo_sqlite", "pdo_sqlite.c sqlite_driver.c sqlite_statement.c", null, "/DSQLITE_THREADSAFE=" + (PHP_ZTS == "yes" ? "1" : "0") + " /D SQLITE_ENABLE_FTS3=1 /D SQLITE_ENABLE_FTS4=1 /D SQLITE_ENABLE_FTS5=1 /D SQLITE_ENABLE_COLUMN_METADATA=1 /D SQLITE_CORE=1 /I" + configure_module_dirname + "/../sqlite3/libsqlite /I" + configure_module_dirname);
+	EXTENSION("pdo_sqlite", "pdo_sqlite.c sqlite_driver.c sqlite_statement.c", null, "/DSQLITE_THREADSAFE=" + (PHP_ZTS == "yes" ? "1" : "0") + " /D SQLITE_ENABLE_FTS3=1 /D SQLITE_ENABLE_FTS4=1 /D SQLITE_ENABLE_FTS5=1 /D SQLITE_ENABLE_JSON1=1 /D SQLITE_ENABLE_COLUMN_METADATA=1 /D SQLITE_CORE=1 /I" + configure_module_dirname + "/../sqlite3/libsqlite /I" + configure_module_dirname);
 	
 	ADD_EXTENSION_DEP('pdo_sqlite', 'pdo');
 	// If pdo_sqlite is static, and sqlite3 is also static, then we don't add a second copy of the sqlite3 libs

--- a/ext/sqlite3/config.w32
+++ b/ext/sqlite3/config.w32
@@ -4,7 +4,7 @@
 ARG_WITH("sqlite3", "SQLite 3 support", "no");
 
 if (PHP_SQLITE3 != "no") {
-	ADD_FLAG("CFLAGS_SQLITE3", "/D SQLITE_THREADSAFE=" + (PHP_ZTS == "yes" ? "1" : "0") + " /D SQLITE_ENABLE_FTS3=1 /D SQLITE_ENABLE_FTS4=1 /D SQLITE_ENABLE_FTS5=1 /D SQLITE_ENABLE_COLUMN_METADATA=1 /D SQLITE_CORE=1 /D SQLITE_API=__declspec(dllexport) ");
+	ADD_FLAG("CFLAGS_SQLITE3", "/D SQLITE_THREADSAFE=" + (PHP_ZTS == "yes" ? "1" : "0") + " /D SQLITE_ENABLE_FTS3=1 /D SQLITE_ENABLE_FTS4=1 /D SQLITE_ENABLE_FTS5=1 /D SQLITE_ENABLE_JSON1=1 /D SQLITE_ENABLE_COLUMN_METADATA=1 /D SQLITE_CORE=1 /D SQLITE_API=__declspec(dllexport) ");
 	EXTENSION("sqlite3", "sqlite3.c", null, "/I" + configure_module_dirname + "/libsqlite /I" + configure_module_dirname + " /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
 	ADD_SOURCES(configure_module_dirname + "/libsqlite", "sqlite3.c", "sqlite3");

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -78,7 +78,7 @@ if test $PHP_SQLITE3 != "no"; then
       debug_flags="-DSQLITE_DEBUG=1"
     fi
 
-    other_flags="-DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS5=1 -DSQLITE_CORE=1 -DSQLITE_ENABLE_COLUMN_METADATA=1"
+    other_flags="-DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS5=1 -DSQLITE_ENABLE_JSON1=1 -DSQLITE_CORE=1 -DSQLITE_ENABLE_COLUMN_METADATA=1"
 
 	dnl As long as intl is not shared we can have ICU support
     if test "$PHP_INTL" = "yes" && test "$PHP_INTL_SHARED" != "yes"; then


### PR DESCRIPTION
As JSON spreads very fast as a configuration-file and general communication format, in the past few years almost every SQL language has developed their own JSON support: MySQL, PostgreSQL, MariaDB, and even SQLite. However, while these can be used in all other drivers out-of-the-box, SQLite is a weak exception regarding this: JSON is supplied with an external plug-in. It'd be great if this extremely useful feature would be part of the core bundle. The code base is quite small compared to the FTS plug-ins, so it would not cause unnecessary overhead. It also does not introduce new types or operators - only a few `JSON_*` functions.

@weltling @remicollet do you think it's viable?