### PR TITLE
Fix issue with zend signals in php_request_startup

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1662,7 +1662,9 @@ int php_request_startup(void)
 		zend_activate();
 		sapi_activate();
 
+#ifdef ZEND_SIGNALS
 		zend_signal_activate();
+#endif
 
 		if (PG(max_input_time) == -1) {
 			zend_set_timeout(EG(timeout_seconds), 1);


### PR DESCRIPTION
The zend_signals_activate() function is called in php_request_startup()
even if `----disable-zend-signals` is used. This causes uninitialized
variables to be used on ZTS builds.

This was removed in 7.1 in c870633. Removing guards from the SAPIs
should be fine, but removing the guard from main/main.c prevents anyone
using the static embedded library to integrate PHP into their programs.

For more details, see the "Additional remark" section in
https://bugs.php.net/bug.php?id=74149