### PR TITLE
Escape newline on curl config.m4

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -33,8 +33,8 @@ if test "$PHP_CURL" != "no"; then
   fi
 
   if test -z "$CURL_DIR"; then
-    AC_MSG_ERROR(Could not find cURL, please reinstall the libcurl distribution -
-    easy.h should be in <curl-dir>/include/curl/)
+    AC_MSG_ERROR(Could not find cURL, please reinstall the libcurl distribution -dnl
+ easy.h should be in <curl-dir>/include/curl/)
   fi
 
   CURL_CONFIG="curl-config"


### PR DESCRIPTION
config.m4 contains a newline during an error message (presumably so the error message is split up), but this is messing up the generated configure file.  Adding dnl to the end of the line and reducing indentation to match desired spacing fixes the issue, but breaks indentation.

https://bugs.php.net/bug.php?id=75403