### PR TITLE
Fixed #75396 - Exit inside generator finally results in fatal error

### DIFF
--- a/Zend/tests/generators/bug75396.phpt
+++ b/Zend/tests/generators/bug75396.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #75396 (Exit inside generator finally results in fatal error)
+--FILE--
+<?php
+
+$gen = (function () {
+
+    yield 42;
+
+    try {
+    } finally {
+        exit;
+    }
+})();
+
+$gen->send("x");
+
+?>
+--EXPECT--

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -223,6 +223,8 @@ static void zend_generator_dtor_storage(zend_object *object) /* {{{ */
 
 		ex->opline = &ex->func->op_array.opcodes[finally_op_num];
 		generator->flags |= ZEND_GENERATOR_FORCED_CLOSE;
+		generator->flags &= ~ZEND_GENERATOR_CURRENTLY_RUNNING;
+		
 		zend_generator_resume(generator);
 	}
 }


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=75396