### PR TITLE
Fixed bug #75448 - In case of failure, mysqli::prepare() returns NULL instead of FALSE

### DIFF
--- a/ext/mysqli/mysqli_prop.c
+++ b/ext/mysqli/mysqli_prop.c
@@ -32,7 +32,7 @@
 #define CHECK_STATUS(value) \
 	if (!obj->ptr || ((MYSQLI_RESOURCE *)obj->ptr)->status < value ) { \
 		php_error_docref(NULL, E_WARNING, "Property access is not allowed yet"); \
-		ZVAL_NULL(retval); \
+		ZVAL_FALSE(retval); \
 		return retval; \
 	} \
 
@@ -40,7 +40,7 @@
 MYSQL *p; \
 if (!obj->ptr || !(MY_MYSQL *)((MYSQLI_RESOURCE *)(obj->ptr))->ptr) { \
 	php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", ZSTR_VAL(obj->zo.ce->name));\
-	ZVAL_NULL(retval);\
+	ZVAL_FALSE(retval);\
 	return retval; \
 } else { \
 	CHECK_STATUS(statusval);\

--- a/ext/mysqli/php_mysqli_structs.h
+++ b/ext/mysqli/php_mysqli_structs.h
@@ -256,12 +256,12 @@ extern void php_mysqli_fetch_into_hash_aux(zval *return_value, MYSQL_RES * resul
 	mysqli_object *intern = Z_MYSQLI_P(__id); \
 	if (!(my_res = (MYSQLI_RESOURCE *)intern->ptr)) {\
   		php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", ZSTR_VAL(intern->zo.ce->name));\
-  		RETURN_NULL();\
+		RETURN_FALSE;\
   	}\
 	__ptr = (__type)my_res->ptr; \
 	if (__check && my_res->status < __check) { \
 		php_error_docref(NULL, E_WARNING, "invalid object or resource %s\n", ZSTR_VAL(intern->zo.ce->name)); \
-		RETURN_NULL();\
+		RETURN_FALSE;\
 	}\
 }
 

--- a/ext/mysqli/tests/bug28817.phpt
+++ b/ext/mysqli/tests/bug28817.phpt
@@ -38,5 +38,5 @@ array(2) {
   [1]=>
   %s(3) "bar"
 }
-NULL
+bool(false)
 bool(true)

--- a/ext/mysqli/tests/bug34810.phpt
+++ b/ext/mysqli/tests/bug34810.phpt
@@ -105,7 +105,7 @@ object(mysqli)#%d (%d) {
 }
 object(mysqli)#%d (%d) {
   ["affected_rows"]=>
-  NULL
+  bool(false)
   ["client_info"]=>
   string(%d) "%s"
   ["client_version"]=>
@@ -119,28 +119,28 @@ object(mysqli)#%d (%d) {
   ["error"]=>
   string(0) ""
   ["error_list"]=>
-  NULL
+  bool(false)
   ["field_count"]=>
-  NULL
+  bool(false)
   ["host_info"]=>
-  NULL
+  bool(false)
   ["info"]=>
-  NULL
+  bool(false)
   ["insert_id"]=>
-  NULL
+  bool(false)
   ["server_info"]=>
-  NULL
+  bool(false)
   ["server_version"]=>
-  NULL
+  bool(false)
   ["stat"]=>
   NULL
   ["sqlstate"]=>
-  NULL
+  bool(false)
   ["protocol_version"]=>
-  NULL
+  bool(false)
   ["thread_id"]=>
-  NULL
+  bool(false)
   ["warning_count"]=>
-  NULL
+  bool(false)
 }
 Done

--- a/ext/mysqli/tests/bug36802.phpt
+++ b/ext/mysqli/tests/bug36802.phpt
@@ -17,7 +17,7 @@ Bug #36802 (crashes with with mysqli_set_charset())
 	if (method_exists($mysql, 'set_charset')) {
 		$x[0] = @$mysql->set_charset('utf8');
 	} else {
-		$x[0] = NULL;
+		$x[0] = false;
 	}
 	$x[1] = @$mysql->query("SELECT 'foo' FROM DUAL");
 
@@ -31,9 +31,9 @@ Bug #36802 (crashes with with mysqli_set_charset())
 --EXPECT--
 array(4) {
   [0]=>
-  NULL
+  bool(false)
   [1]=>
-  NULL
+  bool(false)
   [2]=>
   bool(true)
   [3]=>

--- a/ext/mysqli/tests/bug75448.phpt
+++ b/ext/mysqli/tests/bug75448.phpt
@@ -1,0 +1,19 @@
+--TEST--
+mysqli_prepare() called on a closed connection should return FALSE (bug #75448)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifemb.inc');
+require_once('skipifconnectfailure.inc');
+?>
+--FILE--
+<?php
+require_once 'connect.inc';
+$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket);
+mysqli_close($link);
+$stmt = mysqli_prepare($link, 'SELECT VERSION()');
+var_dump($stmt);
+?>
+--EXPECTF--
+Warning: mysqli_prepare(): Couldn't fetch mysqli in %s on line %d
+bool(false)

--- a/ext/mysqli/tests/mysqli_affected_rows.phpt
+++ b/ext/mysqli/tests/mysqli_affected_rows.phpt
@@ -122,8 +122,8 @@ mysqli_affected_rows()
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = @mysqli_affected_rows($link)))
-		printf("[033] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_affected_rows($link)))
+		printf("[033] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_affected_rows_oo.phpt
+++ b/ext/mysqli/tests/mysqli_affected_rows_oo.phpt
@@ -11,8 +11,8 @@ mysqli->affected_rows
 	require_once("connect.inc");
 
 	$mysqli = new mysqli();
-	if (NULL !== ($tmp = @$mysqli->affected_rows))
-		printf("[000a] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$mysqli->affected_rows))
+		printf("[000a] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!$mysqli = new my_mysqli($host, $user, $passwd, $db, $port, $socket)) {
 		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -101,8 +101,8 @@ mysqli->affected_rows
 
 	$mysqli->close();
 
-	if (NULL !== ($tmp = @$mysqli->affected_rows))
-		printf("[026] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$mysqli->affected_rows))
+		printf("[026] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_autocommit.phpt
+++ b/ext/mysqli/tests/mysqli_autocommit.phpt
@@ -134,8 +134,8 @@ mysqli_autocommit()
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = @mysqli_autocommit($link, false)))
-		printf("[033] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_autocommit($link, false)))
+		printf("[033] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_autocommit_oo.phpt
+++ b/ext/mysqli/tests/mysqli_autocommit_oo.phpt
@@ -124,8 +124,8 @@ mysqli->autocommit()
 
 	$mysqli->close();
 
-	if (NULL !== ($tmp = @$mysqli->autocommit( false)))
-		printf("[030] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$mysqli->autocommit( false)))
+		printf("[030] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_change_user.phpt
+++ b/ext/mysqli/tests/mysqli_change_user.phpt
@@ -105,8 +105,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = @mysqli_change_user($link, $user, $passwd, $db)))
-		printf("[018] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_change_user($link, $user, $passwd, $db)))
+		printf("[018] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
 		printf("[019] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",

--- a/ext/mysqli/tests/mysqli_character_set_name.phpt
+++ b/ext/mysqli/tests/mysqli_character_set_name.phpt
@@ -62,8 +62,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = @mysqli_character_set_name($link)))
-		printf("[013] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_character_set_name($link)))
+		printf("[013] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	/* Make sure that the function alias exists */
 	if (!is_null($tmp = @mysqli_character_set_name()))

--- a/ext/mysqli/tests/mysqli_character_set_name_oo.phpt
+++ b/ext/mysqli/tests/mysqli_character_set_name_oo.phpt
@@ -57,12 +57,12 @@ mysqli_chararcter_set_name(), mysql_client_encoding() [alias]
 
 	$mysqli->close();
 
-	if (NULL !== ($tmp = @$mysqli->character_set_name()))
-		printf("[013] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$mysqli->character_set_name()))
+		printf("[013] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	/* Make sure that the function alias exists */
-	if (!is_null($tmp = @$mysqli->character_set_name()))
-		printf("[014] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$mysqli->character_set_name()))
+		printf("[014] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_class_mysqli_properties_no_conn.phpt
+++ b/ext/mysqli/tests/mysqli_class_mysqli_properties_no_conn.phpt
@@ -144,67 +144,67 @@ require_once('skipifconnectfailure.inc');
 Without RS
 
 Class variables:
-affected_rows = 'NULL'
-client_info = 'NULL'
+affected_rows = 'false'
+client_info = 'false'
 client_version = '%s'
 connect_errno = '%s'
 connect_error = ''%s'
-errno = 'NULL'
-error = 'NULL'
-error_list = 'NULL'
-field_count = 'NULL'
-host_info = 'NULL'
-info = 'NULL'
-insert_id = 'NULL'
-protocol_version = 'NULL'
-server_info = 'NULL'
-server_version = 'NULL'
-sqlstate = 'NULL'
-stat = 'NULL'
-thread_id = 'NULL'
-warning_count = 'NULL'
+errno = 'false'
+error = 'false'
+error_list = 'false'
+field_count = 'false'
+host_info = 'false'
+info = 'false'
+insert_id = 'false'
+protocol_version = 'false'
+server_info = 'false'
+server_version = 'false'
+sqlstate = 'false'
+stat = 'false'
+thread_id = 'false'
+warning_count = 'false'
 
 Object variables:
-affected_rows = 'NULL'
-client_info = 'NULL'
+affected_rows = 'false'
+client_info = 'false'
 client_version = '%s'
 connect_errno = '%s'
 connect_error = '%s'
-errno = 'NULL'
-error = 'NULL'
-error_list = 'NULL'
-field_count = 'NULL'
-host_info = 'NULL'
-info = 'NULL'
-insert_id = 'NULL'
-server_info = 'NULL'
-server_version = 'NULL'
-stat = 'NULL'
-sqlstate = 'NULL'
-protocol_version = 'NULL'
-thread_id = 'NULL'
-warning_count = 'NULL'
+errno = 'false'
+error = 'false'
+error_list = 'false'
+field_count = 'false'
+host_info = 'false'
+info = 'false'
+insert_id = 'false'
+server_info = 'false'
+server_version = 'false'
+stat = 'false'
+sqlstate = 'false'
+protocol_version = 'false'
+thread_id = 'false'
+warning_count = 'false'
 
 Magic, magic properties:
-mysqli->affected_rows = ''/NULL (''/NULL)
+mysqli->affected_rows = ''/boolean (''/boolean)
 
 Warning: assert(): assert(@mysqli_get_client_info() === @$mysqli->client_info) failed in %s on line %d
-mysqli->client_info = ''/NULL ('%s'/%s)
+mysqli->client_info = ''/boolean ('%s'/%s)
 mysqli->client_version =  '%s'/integer ('%s'/integer)
-mysqli->errno = ''/NULL (''/NULL)
-mysqli->error = ''/NULL (''/NULL)
-mysqli->field_count = ''/NULL (''/NULL)
-mysqli->insert_id = ''/NULL (''/NULL)
-mysqli->sqlstate = ''/NULL (''/NULL)
-mysqli->host_info = ''/NULL (''/NULL)
-mysqli->info = ''/NULL (''/NULL)
+mysqli->errno = ''/boolean (''/boolean)
+mysqli->error = ''/boolean (''/boolean)
+mysqli->field_count = ''/boolean (''/boolean)
+mysqli->insert_id = ''/boolean (''/boolean)
+mysqli->sqlstate = ''/boolean (''/boolean)
+mysqli->host_info = ''/boolean (''/boolean)
+mysqli->info = ''/boolean (''/boolean)
 
 Warning: assert(): assert(@mysqli_thread_id($mysqli) > @$mysqli->thread_id) failed in %s on line %d
-mysqli->thread_id = ''/NULL (''/NULL)
-mysqli->protocol_version = ''/NULL (''/NULL)
-mysqli->server_info = ''/NULL (''/NULL)
-mysqli->server_version = ''/NULL (''/NULL)
-mysqli->warning_count = ''/NULL (''/NULL)
+mysqli->thread_id = ''/boolean (''/boolean)
+mysqli->protocol_version = ''/boolean (''/boolean)
+mysqli->server_info = ''/boolean (''/boolean)
+mysqli->server_version = ''/boolean (''/boolean)
+mysqli->warning_count = ''/boolean (''/boolean)
 
 Access to undefined properties:
 mysqli->unknown = ''
@@ -217,67 +217,67 @@ mysqli->connect_errno = '%s'/integer ('%s'/integer)
 With RS
 
 Class variables:
-affected_rows = 'NULL'
-client_info = 'NULL'
+affected_rows = 'false'
+client_info = 'false'
 client_version = '%s'
 connect_errno = '%s'
 connect_error = '%s'
-errno = 'NULL'
-error = 'NULL'
-error_list = 'NULL'
-field_count = 'NULL'
-host_info = 'NULL'
-info = 'NULL'
-insert_id = 'NULL'
-protocol_version = 'NULL'
-server_info = 'NULL'
-server_version = 'NULL'
-sqlstate = 'NULL'
-stat = 'NULL'
-thread_id = 'NULL'
-warning_count = 'NULL'
+errno = 'false'
+error = 'false'
+error_list = 'false'
+field_count = 'false'
+host_info = 'false'
+info = 'false'
+insert_id = 'false'
+protocol_version = 'false'
+server_info = 'false'
+server_version = 'false'
+sqlstate = 'false'
+stat = 'false'
+thread_id = 'false'
+warning_count = 'false'
 
 Object variables:
-affected_rows = 'NULL'
-client_info = 'NULL'
+affected_rows = 'false'
+client_info = 'false'
 client_version = '%s'
 connect_errno = '%s'
 connect_error = '%s'
-errno = 'NULL'
-error = 'NULL'
-error_list = 'NULL'
-field_count = 'NULL'
-host_info = 'NULL'
-info = 'NULL'
-insert_id = 'NULL'
-server_info = 'NULL'
-server_version = 'NULL'
-stat = 'NULL'
-sqlstate = 'NULL'
-protocol_version = 'NULL'
-thread_id = 'NULL'
-warning_count = 'NULL'
+errno = 'false'
+error = 'false'
+error_list = 'false'
+field_count = 'false'
+host_info = 'false'
+info = 'false'
+insert_id = 'false'
+server_info = 'false'
+server_version = 'false'
+stat = 'false'
+sqlstate = 'false'
+protocol_version = 'false'
+thread_id = 'false'
+warning_count = 'false'
 
 Magic, magic properties:
-mysqli->affected_rows = ''/NULL (''/NULL)
+mysqli->affected_rows = ''/boolean (''/boolean)
 
 Warning: assert(): assert(@mysqli_get_client_info() === @$mysqli->client_info) failed in %s on line %d
-mysqli->client_info = ''/NULL ('%s'/%s)
+mysqli->client_info = ''/boolean ('%s'/%s)
 mysqli->client_version =  '%s'/integer ('%s'/integer)
-mysqli->errno = ''/NULL (''/NULL)
-mysqli->error = ''/NULL (''/NULL)
-mysqli->field_count = ''/NULL (''/NULL)
-mysqli->insert_id = ''/NULL (''/NULL)
-mysqli->sqlstate = ''/NULL (''/NULL)
-mysqli->host_info = ''/NULL (''/NULL)
-mysqli->info = ''/NULL (''/NULL)
+mysqli->errno = ''/boolean (''/boolean)
+mysqli->error = ''/boolean (''/boolean)
+mysqli->field_count = ''/boolean (''/boolean)
+mysqli->insert_id = ''/boolean (''/boolean)
+mysqli->sqlstate = ''/boolean (''/boolean)
+mysqli->host_info = ''/boolean (''/boolean)
+mysqli->info = ''/boolean (''/boolean)
 
 Warning: assert(): assert(@mysqli_thread_id($mysqli) > @$mysqli->thread_id) failed in %s on line %d
-mysqli->thread_id = ''/NULL (''/NULL)
-mysqli->protocol_version = ''/NULL (''/NULL)
-mysqli->server_info = ''/NULL (''/NULL)
-mysqli->server_version = ''/NULL (''/NULL)
-mysqli->warning_count = ''/NULL (''/NULL)
+mysqli->thread_id = ''/boolean (''/boolean)
+mysqli->protocol_version = ''/boolean (''/boolean)
+mysqli->server_info = ''/boolean (''/boolean)
+mysqli->server_version = ''/boolean (''/boolean)
+mysqli->warning_count = ''/boolean (''/boolean)
 
 Access to undefined properties:
 mysqli->unknown = ''

--- a/ext/mysqli/tests/mysqli_close.phpt
+++ b/ext/mysqli/tests/mysqli_close.phpt
@@ -31,8 +31,8 @@ require_once('skipifconnectfailure.inc');
 	if (true !== $tmp)
 		printf("[005] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
-	if (!is_null($tmp = @mysqli_query($link, "SELECT 1")))
-		printf("[006] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_query($link, "SELECT 1")))
+		printf("[006] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_close_oo.phpt
+++ b/ext/mysqli/tests/mysqli_close_oo.phpt
@@ -24,11 +24,11 @@ require_once('skipifconnectfailure.inc');
 	if (true !== $tmp)
 		printf("[003] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
-	if (!is_null($tmp = @$mysqli->close()))
-		printf("[004] Expecting NULL got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$mysqli->close()))
+		printf("[004] Expecting false got %s/%s\n", gettype($tmp), $tmp);
 
-	if (!is_null($tmp = @$mysqli->query("SELECT 1")))
-		printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$mysqli->query("SELECT 1")))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_commit.phpt
+++ b/ext/mysqli/tests/mysqli_commit.phpt
@@ -64,8 +64,8 @@ if (!have_innodb($link))
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = @mysqli_commit($link)))
-		printf("[014] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_commit($link)))
+		printf("[014] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_commit_oo.phpt
+++ b/ext/mysqli/tests/mysqli_commit_oo.phpt
@@ -21,8 +21,8 @@ if (!have_innodb($link))
 	$link   = NULL;
 
 	$mysqli = new mysqli();
-	if (!is_null($tmp = @$mysqli->commit())) {
-		printf("[013] Expecting NULL got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$mysqli->commit())) {
+		printf("[013] Expecting false got %s/%s\n", gettype($tmp), $tmp);
 	}
 
 	if (!$mysqli = new my_mysqli($host, $user, $passwd, $db, $port, $socket)) {
@@ -90,8 +90,8 @@ if (!have_innodb($link))
 
 	$mysqli->close();
 
-	if (NULL !== ($tmp = @$mysqli->commit())) {
-		printf("[017] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$mysqli->commit())) {
+		printf("[017] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 	}
 
 	print "done!";

--- a/ext/mysqli/tests/mysqli_connect_oo.phpt
+++ b/ext/mysqli/tests/mysqli_connect_oo.phpt
@@ -1,9 +1,9 @@
 --TEST--
 new mysqli()
 --SKIPIF--
-<?php 
+<?php
 require_once('skipif.inc');
-require_once('skipifemb.inc'); 
+require_once('skipifemb.inc');
 require_once('skipifconnectfailure.inc');
 ?>
 --FILE--
@@ -59,7 +59,7 @@ require_once('skipifconnectfailure.inc');
 			// We had long discussions on this and found that the ext/mysqli API as
 			// such is broken. As we can't fix it, we document how it has behaved from
 			// the first day on. And that's: no connection.
-			if (NULL !== ($tmp = @$mysqli->query('SELECT 1'))) {
+			if (false !== ($tmp = @$mysqli->query('SELECT 1'))) {
 				printf("[013] There shall be no connection!\n");
 				$mysqli->close();
 			}
@@ -75,7 +75,7 @@ require_once('skipifconnectfailure.inc');
 			// We had long discussions on this and found that the ext/mysqli API as
 			// such is broken. As we can't fix it, we document how it has behaved from
 			// the first day on. And that's: no connection.
-			if (NULL !== ($tmp = @$mysqli->query('SELECT 1'))) {
+			if (false !== ($tmp = @$mysqli->query('SELECT 1'))) {
 				printf("[011] There shall be no connection!\n");
 				$mysqli->close();
 			}

--- a/ext/mysqli/tests/mysqli_data_seek.phpt
+++ b/ext/mysqli/tests/mysqli_data_seek.phpt
@@ -56,8 +56,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_free_result($res);
 
-	if (NULL !== ($tmp = mysqli_data_seek($res, 1)))
-		printf("[013] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_data_seek($res, 1)))
+		printf("[013] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 

--- a/ext/mysqli/tests/mysqli_data_seek_oo.phpt
+++ b/ext/mysqli/tests/mysqli_data_seek_oo.phpt
@@ -20,8 +20,8 @@ require_once('skipifconnectfailure.inc');
 		$host, $user, $db, $port, $socket);
 
 	$res = new mysqli_result($mysqli);
-	if (NULL !== ($tmp = @$res->data_seek(0)))
-		printf("[002] Expecting NULL/NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$res->data_seek(0)))
+		printf("[002] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!$res = $mysqli->query('SELECT * FROM test ORDER BY id LIMIT 4', MYSQLI_STORE_RESULT))
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -65,8 +65,8 @@ require_once('skipifconnectfailure.inc');
 
 	$res->free_result();
 
-	if (NULL !== ($tmp = $res->data_seek(1)))
-		printf("[015] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = $res->data_seek(1)))
+		printf("[015] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	$mysqli->close();
 

--- a/ext/mysqli/tests/mysqli_dump_debug_info.phpt
+++ b/ext/mysqli/tests/mysqli_dump_debug_info.phpt
@@ -32,8 +32,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_dump_debug_info($link)))
-		printf("[005] Expecting NULL, got %s/%s\n",
+	if (false !== ($tmp = mysqli_dump_debug_info($link)))
+		printf("[005] Expecting NULL, got %s/%s, [%d] %s\n",
 			gettype($tmp), $tmp,
 			mysqli_errno($link), mysqli_error($link));
 

--- a/ext/mysqli/tests/mysqli_dump_debug_info_oo.phpt
+++ b/ext/mysqli/tests/mysqli_dump_debug_info_oo.phpt
@@ -26,8 +26,8 @@ require_once('skipifconnectfailure.inc');
 
 	$mysqli->close();
 
-	if (NULL !== ($tmp = $mysqli->dump_debug_info()))
-		printf("[004] Expecting NULL, got %s/%s, [%d] %s\n",
+	if (false !== ($tmp = $mysqli->dump_debug_info()))
+		printf("[004] Expecting false, got %s/%s, [%d] %s\n",
 			gettype($tmp), $tmp,
 			$mysqli->errno, $mysqli->error);
 

--- a/ext/mysqli/tests/mysqli_errno.phpt
+++ b/ext/mysqli/tests/mysqli_errno.phpt
@@ -48,5 +48,5 @@ int(0)
 int(%d)
 
 Warning: mysqli_errno(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_errno_oo.phpt
+++ b/ext/mysqli/tests/mysqli_errno_oo.phpt
@@ -45,5 +45,5 @@ int(0)
 int(%d)
 
 Warning: main(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_error.phpt
+++ b/ext/mysqli/tests/mysqli_error.phpt
@@ -45,5 +45,5 @@ require_once('skipifconnectfailure.inc');
 ?>
 --EXPECTF--
 Warning: mysqli_error(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_error_oo.phpt
+++ b/ext/mysqli/tests/mysqli_error_oo.phpt
@@ -42,5 +42,5 @@ require_once('skipifconnectfailure.inc');
 ?>
 --EXPECTF--
 Warning: main(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_error_unicode.phpt
+++ b/ext/mysqli/tests/mysqli_error_unicode.phpt
@@ -45,5 +45,5 @@ require_once('skipifconnectfailure.inc');
 string(%d) "Table 'няма_такава_таблица' doesn't exist"
 
 Warning: mysqli_error(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_fetch_all.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_all.phpt
@@ -296,8 +296,8 @@ if (!function_exists('mysqli_fetch_all'))
 
 	mysqli_close($link);
 
-	if (null !== ($tmp = mysqli_fetch_array($res, MYSQLI_ASSOC)))
-			printf("[015] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_fetch_array($res, MYSQLI_ASSOC)))
+		printf("[015] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 		printf("[016] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",

--- a/ext/mysqli/tests/mysqli_fetch_all_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_all_oo.phpt
@@ -298,8 +298,8 @@ if (!function_exists('mysqli_fetch_all'))
 
 	mysqli_close($link);
 
-	if (null !== ($tmp = $res->fetch_array(MYSQLI_ASSOC)))
-		printf("[015] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = $res->fetch_array(MYSQLI_ASSOC)))
+		printf("[015] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_fetch_array.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_array.phpt
@@ -287,8 +287,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (null !== ($tmp = mysqli_fetch_array($res, MYSQLI_ASSOC)))
-		printf("[015] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_fetch_array($res, MYSQLI_ASSOC)))
+		printf("[015] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_fetch_array_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_array_oo.phpt
@@ -271,8 +271,8 @@ require_once('skipifconnectfailure.inc');
 
 	$mysqli->close();
 
-	if (null !== ($tmp = $res->fetch_array(MYSQLI_ASSOC)))
-		printf("[015] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = $res->fetch_array(MYSQLI_ASSOC)))
+		printf("[015] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_fetch_assoc.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_assoc.phpt
@@ -60,8 +60,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_free_result($res);
 
-	if (NULL !== ($tmp = mysqli_fetch_assoc($res)))
-		printf("[008] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_fetch_assoc($res)))
+		printf("[008] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 

--- a/ext/mysqli/tests/mysqli_fetch_assoc_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_assoc_oo.phpt
@@ -16,8 +16,8 @@ require_once('skipifconnectfailure.inc');
 	// Note: no SQL type tests, internally the same function gets used as for mysqli_fetch_array() which does a lot of SQL type test
 	$mysqli = new mysqli();
 	$res = @new mysqli_result($mysqli);
-	if (!is_null($tmp = @$res->fetch_assoc()))
-		printf("[001] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$res->fetch_assoc()))
+		printf("[001] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	require('table.inc');
 	if (!$mysqli = new my_mysqli($host, $user, $passwd, $db, $port, $socket))
@@ -47,8 +47,8 @@ require_once('skipifconnectfailure.inc');
 
 	$res->free_result();
 
-	if (NULL !== ($tmp = $res->fetch_assoc()))
-		printf("[008] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = $res->fetch_assoc()))
+		printf("[008] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 

--- a/ext/mysqli/tests/mysqli_fetch_field.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_field.phpt
@@ -58,8 +58,8 @@ require_once('skipifconnectfailure.inc');
 	mysqli_free_result($res);
 
 	// Read http://bugs.php.net/bug.php?id=42344 on defaults!
-	if (NULL !== ($tmp = mysqli_fetch_field($res)))
-		printf("[006] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_fetch_field($res)))
+		printf("[006] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_query($link, "DROP TABLE IF EXISTS test"))
 		printf("[007] [%d] %s\n", mysqli_errno($link), mysqli_error($link));

--- a/ext/mysqli/tests/mysqli_fetch_field_direct.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_field_direct.phpt
@@ -34,8 +34,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_free_result($res);
 
-	if (NULL !== ($tmp = mysqli_fetch_field_direct($res, 0)))
-		printf("Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_fetch_field_direct($res, 0)))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_fetch_field_direct_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_field_direct_oo.phpt
@@ -43,8 +43,8 @@ require_once('skipifconnectfailure.inc');
 
 	$res->free_result();
 
-	if (NULL !== ($tmp = $res->fetch_field_direct(0)))
-		printf("[007] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = $res->fetch_field_direct(0)))
+		printf("[007] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	$mysqli->close();
 	print "done!";

--- a/ext/mysqli/tests/mysqli_fetch_field_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_field_oo.phpt
@@ -16,8 +16,8 @@ require_once('skipifconnectfailure.inc');
 	// Note: no SQL type tests, internally the same function gets used as for mysqli_fetch_array() which does a lot of SQL type test
 	$mysqli = new mysqli();
 	$res = @new mysqli_result($mysqli);
-	if (!is_null($tmp = @$res->fetch_field()))
-		printf("[001] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$res->fetch_field()))
+		printf("[001] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	require('table.inc');
 	if (!$mysqli = new mysqli($host, $user, $passwd, $db, $port, $socket))
@@ -59,8 +59,8 @@ require_once('skipifconnectfailure.inc');
 
 	$res->free_result();
 
-	if (NULL !== ($tmp = $res->fetch_field()))
-		printf("[007] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = $res->fetch_field()))
+		printf("[007] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	$mysqli->close();
 	print "done!";

--- a/ext/mysqli/tests/mysqli_fetch_fields.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_fields.phpt
@@ -55,8 +55,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_free_result($res);
 
-	if (NULL !== ($tmp = mysqli_fetch_fields($res)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_fetch_fields($res)))
+		printf("[006] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_fetch_lengths.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_lengths.phpt
@@ -53,5 +53,5 @@ array(2) {
 bool(false)
 
 Warning: mysqli_fetch_lengths(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_fetch_lengths_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_lengths_oo.phpt
@@ -46,5 +46,5 @@ array(2) {
 NULL
 
 Warning: main(): Property access is not allowed yet in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_fetch_object.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object.phpt
@@ -67,7 +67,7 @@ require_once('skipifconnectfailure.inc');
 		}
 	} catch (Throwable $e) {
 		echo "Exception: " . $e->getMessage() . "\n";
-	}	
+	}
 
 	try {
 		$obj = mysqli_fetch_object($res, 'mysqli_fetch_object_construct', array('a'));
@@ -77,7 +77,7 @@ require_once('skipifconnectfailure.inc');
 		}
 	} catch (Throwable $e) {
 		echo "Exception: " . $e->getMessage() . "\n";
-	}	
+	}
 
 	$obj = mysqli_fetch_object($res, 'mysqli_fetch_object_construct', array('a', 'b'));
 	if (($obj->ID !== "5") || ($obj->label !== "e") || ($obj->a !== 'a') || ($obj->b !== 'b') || (get_class($obj) != 'mysqli_fetch_object_construct')) {
@@ -152,7 +152,7 @@ Exception: Too few arguments to function mysqli_fetch_object_construct::__constr
 NULL
 NULL
 [E_WARNING] mysqli_fetch_object(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 [0] Argument 3 passed to mysqli_fetch_object() must be of the type array, string given in %s on line %d
 
 Fatal error: Class 'this_class_does_not_exist' not found in %s on line %d

--- a/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
@@ -16,8 +16,8 @@ require_once('skipifconnectfailure.inc');
 
 	$mysqli = new mysqli();
 	$res = @new mysqli_result($mysqli);
-	if (!is_null($tmp = @$res->fetch_object()))
-		printf("[001] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @$res->fetch_object()))
+		printf("[001] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	require('table.inc');
 	if (!$mysqli = new my_mysqli($host, $user, $passwd, $db, $port, $socket))
@@ -140,6 +140,6 @@ Exception: Too few arguments to function mysqli_fetch_object_construct::__constr
 NULL
 NULL
 [E_WARNING] mysqli_fetch_object(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 
 Fatal error: Class 'this_class_does_not_exist' not found in %s on line %d

--- a/ext/mysqli/tests/mysqli_fetch_row.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_row.phpt
@@ -55,5 +55,5 @@ array(3) {
 NULL
 
 Warning: mysqli_fetch_row(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_field_count.phpt
+++ b/ext/mysqli/tests/mysqli_field_count.phpt
@@ -59,5 +59,5 @@ int(0)
 int(3)
 
 Warning: mysqli_field_count(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_field_seek.phpt
+++ b/ext/mysqli/tests/mysqli_field_seek.phpt
@@ -251,5 +251,5 @@ object(stdClass)#%d (13) {
 }
 
 Warning: mysqli_field_seek(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_field_tell.phpt
+++ b/ext/mysqli/tests/mysqli_field_tell.phpt
@@ -106,5 +106,5 @@ bool(true)
 int(0)
 
 Warning: mysqli_field_tell(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_free_result.phpt
+++ b/ext/mysqli/tests/mysqli_free_result.phpt
@@ -60,7 +60,7 @@ NULL
 b
 
 Warning: mysqli_free_result(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 c
 bool(false)
 %s(0) ""

--- a/ext/mysqli/tests/mysqli_get_charset.phpt
+++ b/ext/mysqli/tests/mysqli_get_charset.phpt
@@ -101,8 +101,8 @@ if (!function_exists('mysqli_get_charset'))
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_get_charset($link)))
-		printf("[023] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_get_charset($link)))
+		printf("[023] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_insert_id.phpt
+++ b/ext/mysqli/tests/mysqli_insert_id.phpt
@@ -136,5 +136,5 @@ require_once('skipifconnectfailure.inc');
 ?>
 --EXPECTF--
 Warning: mysqli_insert_id(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_more_results.phpt
+++ b/ext/mysqli/tests/mysqli_more_results.phpt
@@ -82,5 +82,5 @@ Strict Standards: mysqli_next_result(): There is no next result set. Please, cal
 Strict Standards: mysqli_next_result(): There is no next result set. Please, call mysqli_more_results()/mysqli::more_results() to check whether to call this function/method in %s on line %d
 
 Warning: mysqli_more_results(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_multi_query.phpt
+++ b/ext/mysqli/tests/mysqli_multi_query.phpt
@@ -130,5 +130,5 @@ Strict Standards: mysqli_next_result(): There is no next result set. Please, cal
 [010] 7
 
 Warning: mysqli_multi_query(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_next_result.phpt
+++ b/ext/mysqli/tests/mysqli_next_result.phpt
@@ -84,5 +84,5 @@ Strict Standards: mysqli_next_result(): There is no next result set. Please, cal
 Strict Standards: mysqli_next_result(): There is no next result set. Please, call mysqli_more_results()/mysqli::more_results() to check whether to call this function/method in %s on line %d
 
 Warning: mysqli_next_result(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_num_fields.phpt
+++ b/ext/mysqli/tests/mysqli_num_fields.phpt
@@ -35,8 +35,8 @@ require_once('skipifconnectfailure.inc');
 
 		mysqli_free_result($res);
 
-		if ($test_free && (NULL !== ($tmp = mysqli_num_fields($res))))
-			printf("[%03d] Expecting NULL, got %s/%s\n", $offset + 2, gettype($tmp), $tmp);
+		if ($test_free && (false !== ($tmp = mysqli_num_fields($res))))
+			printf("[%03d] Expecting false, got %s/%s\n", $offset + 2, gettype($tmp), $tmp);
 	}
 
 	func_test_mysqli_num_fields($link, "SELECT 1 AS a", 1, 5);

--- a/ext/mysqli/tests/mysqli_num_rows.phpt
+++ b/ext/mysqli/tests/mysqli_num_rows.phpt
@@ -35,8 +35,8 @@ require_once('skipifconnectfailure.inc');
 
 		mysqli_free_result($res);
 
-		if ($test_free && (NULL !== ($tmp = mysqli_num_rows($res))))
-			printf("[%03d] Expecting NULL, got %s/%s\n", $offset + 2, gettype($tmp), $tmp);
+		if ($test_free && (false !== ($tmp = mysqli_num_rows($res))))
+			printf("[%03d] Expecting false, got %s/%s\n", $offset + 2, gettype($tmp), $tmp);
 
 	}
 

--- a/ext/mysqli/tests/mysqli_options.phpt
+++ b/ext/mysqli/tests/mysqli_options.phpt
@@ -58,7 +58,6 @@ require_once('skipifconnectfailure.inc');
 	var_dump("MYSQLI_OPT_LOCAL_INFILE",		mysqli_options($link, MYSQLI_OPT_LOCAL_INFILE, 1));
 	var_dump("MYSQLI_INIT_COMMAND",			mysqli_options($link, MYSQLI_INIT_COMMAND, array('SET AUTOCOMMIT=0', 'SET AUTOCOMMIT=1')));
 
-	
 	if (!$link2 = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
 		printf("[006] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
 			$host, $user, $db, $port, $socket);
@@ -104,7 +103,7 @@ require_once('skipifconnectfailure.inc');
 
 	/* mysqli_real_connect() */
 	var_dump("MYSQLI_CLIENT_SSL",			mysqli_options($link, MYSQLI_CLIENT_SSL, 'not a mysqli_option'));
-	
+
 	mysqli_close($link);
 
 	echo "Link closed";
@@ -139,5 +138,5 @@ bool(false)
 Link closed
 Warning: mysqli_options(): Couldn't fetch mysqli in %s line %d
 %s(19) "MYSQLI_INIT_COMMAND"
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_ping.phpt
+++ b/ext/mysqli/tests/mysqli_ping.phpt
@@ -34,8 +34,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (!is_null($tmp = mysqli_ping($link)))
-		printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_ping($link)))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_query.phpt
+++ b/ext/mysqli/tests/mysqli_query.phpt
@@ -107,8 +107,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_query($link, "SELECT id FROM test")))
-		printf("[011] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_query($link, "SELECT id FROM test")))
+		printf("[011] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_query_unicode.phpt
+++ b/ext/mysqli/tests/mysqli_query_unicode.phpt
@@ -87,8 +87,8 @@ mysqli_close($link);
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_query($link, "SELECT id FROM test")))
-		printf("[014] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_query($link, "SELECT id FROM test")))
+		printf("[014] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_real_connect.phpt
+++ b/ext/mysqli/tests/mysqli_real_connect.phpt
@@ -165,8 +165,8 @@ require_once('skipifconnectfailure.inc');
 		@mysqli_close($link);
 	}
 
-	if (NULL !== ($tmp = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, $socket)))
-		printf("[026] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, $socket)))
+		printf("[026] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_real_connect.phpt
+++ b/ext/mysqli/tests/mysqli_real_connect.phpt
@@ -178,7 +178,7 @@ require_once('skipifconnectfailure.inc');
 Warning: mysqli_real_connect(): (%s/%d): Access denied for user '%s'@'%s' (using password: YES) in %s on line %d
 object(mysqli)#%d (%d) {
   ["affected_rows"]=>
-  NULL
+  bool(false)
   ["client_info"]=>
   %s
   ["client_version"]=>
@@ -192,29 +192,29 @@ object(mysqli)#%d (%d) {
   ["error"]=>
   %s
   ["error_list"]=>
-  NULL
+  bool(false)
   ["field_count"]=>
-  NULL
+  bool(false)
   ["host_info"]=>
-  NULL
+  bool(false)
   ["info"]=>
-  NULL
+  bool(false)
   ["insert_id"]=>
-  NULL
+  bool(false)
   ["server_info"]=>
-  NULL
+  bool(false)
   ["server_version"]=>
-  NULL
+  bool(false)
   ["stat"]=>
-  NULL
+  bool(false)
   ["sqlstate"]=>
-  NULL
+  bool(false)
   ["protocol_version"]=>
-  NULL
+  bool(false)
   ["thread_id"]=>
-  NULL
+  bool(false)
   ["warning_count"]=>
-  NULL
+  bool(false)
 }
 
 Warning: mysqli_real_connect(): Couldn't fetch mysqli in %s on line %d

--- a/ext/mysqli/tests/mysqli_real_escape_string.phpt
+++ b/ext/mysqli/tests/mysqli_real_escape_string.phpt
@@ -44,8 +44,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_real_escape_string($link, 'foo')))
-		printf("[010] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_real_escape_string($link, 'foo')))
+		printf("[010] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	/* Make sure that the function alias exists */
 	if (NULL !== ($tmp = @mysqli_escape_string()))

--- a/ext/mysqli/tests/mysqli_real_escape_string_unicode.phpt
+++ b/ext/mysqli/tests/mysqli_real_escape_string_unicode.phpt
@@ -74,8 +74,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_real_escape_string($link, 'foo')))
-		printf("[018] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_real_escape_string($link, 'foo')))
+		printf("[018] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_real_query.phpt
+++ b/ext/mysqli/tests/mysqli_real_query.phpt
@@ -84,8 +84,8 @@ ver_param;')) {
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_real_query($link, "SELECT id FROM test")))
-		printf("[011] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_real_query($link, "SELECT id FROM test")))
+		printf("[011] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_result_references.phpt
+++ b/ext/mysqli/tests/mysqli_result_references.phpt
@@ -135,11 +135,11 @@ array(7) refcount(2){
     ["field_count"]=>
     NULL
     ["lengths"]=>
-    NULL
+    bool(false)
     ["num_rows"]=>
     NULL
     ["type"]=>
-    NULL
+    bool(false)
   }
 }
 array(1) refcount(2){

--- a/ext/mysqli/tests/mysqli_rollback.phpt
+++ b/ext/mysqli/tests/mysqli_rollback.phpt
@@ -63,8 +63,8 @@ mysqli_rollback()
 
 	mysqli_close($link);
 
-	if (!is_null($tmp = mysqli_rollback($link)))
-		printf("[014] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_rollback($link)))
+		printf("[014] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!\n";
 ?>

--- a/ext/mysqli/tests/mysqli_select_db.phpt
+++ b/ext/mysqli/tests/mysqli_select_db.phpt
@@ -67,7 +67,7 @@ require_once('skipifconnectfailure.inc');
 
 	$current_db = $row['dbname'];
 
-	mysqli_report(MYSQLI_REPORT_OFF);	  
+	mysqli_report(MYSQLI_REPORT_OFF);
 	mysqli_select_db($link, 'I can not imagine that this database exists');
 	mysqli_report(MYSQLI_REPORT_ERROR);
 
@@ -91,7 +91,7 @@ require_once('skipifconnectfailure.inc');
 	if (strtolower($row['dbname']) != strtolower($current_db))
 		printf("[017] Current DB should not change if set fails\n");
 
-	
+
 	if (!$res = $link->query("SELECT id FROM test WHERE id = 1"))
 		printf("[018] [%d] %s\n");
 
@@ -100,8 +100,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_select_db($link, $db)))
-		printf("[017] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_select_db($link, $db)))
+		printf("[019] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!\n";
 ?>

--- a/ext/mysqli/tests/mysqli_set_charset.phpt
+++ b/ext/mysqli/tests/mysqli_set_charset.phpt
@@ -116,8 +116,8 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_set_charset($link, $new_charset)))
-		printf("[016] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_set_charset($link, $new_charset)))
+		printf("[019] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_set_opt.phpt
+++ b/ext/mysqli/tests/mysqli_set_opt.phpt
@@ -65,5 +65,5 @@ bool(true)
 bool(false)
 
 Warning: mysqli_set_opt(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_sqlstate.phpt
+++ b/ext/mysqli/tests/mysqli_sqlstate.phpt
@@ -46,5 +46,5 @@ NULL
 %s(5) "00000"
 
 Warning: mysqli_sqlstate(): Couldn't fetch mysqli in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_stat.phpt
+++ b/ext/mysqli/tests/mysqli_stat.phpt
@@ -30,8 +30,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (!is_null($tmp = mysqli_stat($link)))
-		printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stat($link)))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_stmt_affected_rows.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_affected_rows.phpt
@@ -234,8 +234,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (!is_null($tmp = mysqli_stmt_affected_rows($stmt)))
-		printf("[047] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_affected_rows($stmt)))
+		printf("[047] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 

--- a/ext/mysqli/tests/mysqli_stmt_attr_get.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_attr_get.phpt
@@ -53,8 +53,8 @@ require_once('skipifconnectfailure.inc');
 	$stmt->close();
 
 	foreach ($valid_attr as $k => $attr) {
-		if (!is_null($tmp = @mysqli_stmt_attr_get($stmt, $attr))) {
-			printf("[007] Expecting NULL/NULL, got %s/%s for attribute %s/%s\n",
+		if (false !== ($tmp = @mysqli_stmt_attr_get($stmt, $attr))) {
+			printf("[007] Expecting false, got %s/%s for attribute %s/%s\n",
 				gettype($tmp), $tmp, $k, $attr);
 		}
 	}

--- a/ext/mysqli/tests/mysqli_stmt_attr_set.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_attr_set.phpt
@@ -41,8 +41,8 @@ require_once('skipifconnectfailure.inc');
 
 
 	$stmt = mysqli_stmt_init($link);
-	if (!is_null($tmp = @mysqli_stmt_attr_set($stmt, 0, 0)))
-		printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_stmt_attr_set($stmt, 0, 0)))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	$stmt->prepare("SELECT * FROM test");
 

--- a/ext/mysqli/tests/mysqli_stmt_bind_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_result.phpt
@@ -35,8 +35,8 @@ require_once('skipifconnectfailure.inc');
 	$label = null;
 	$foo = null;
 
-	if (!is_null($tmp = mysqli_stmt_bind_result($stmt, $id)))
-		printf("[003] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_bind_result($stmt, $id)))
+		printf("[003] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 1"))
 		printf("[004] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));

--- a/ext/mysqli/tests/mysqli_stmt_close.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_close.phpt
@@ -25,8 +25,8 @@ require_once('skipifconnectfailure.inc');
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 	// Yes, amazing, eh? AFAIK a work around of a constructor bug...
-	if (!is_null($tmp = mysqli_stmt_close($stmt)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_close($stmt)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test"))
 		printf("[005] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -34,8 +34,8 @@ require_once('skipifconnectfailure.inc');
 	if (true !== ($tmp = mysqli_stmt_close($stmt)))
 		printf("[006] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
-	if (!is_null($tmp = mysqli_stmt_close($stmt)))
-		printf("[007] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_close($stmt)))
+		printf("[007] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!$stmt = mysqli_stmt_init($link))
 		printf("[008] [%d] %s\n", mysqli_errno($link), mysqli_error($link));

--- a/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
@@ -24,8 +24,8 @@ require_once('skipifconnectfailure.inc');
 	if (!$stmt = mysqli_stmt_init($link))
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-	if (!is_null($tmp = mysqli_stmt_data_seek($stmt, 1)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_data_seek($stmt, 1)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id FROM test ORDER BY id"))
 		printf("[005] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -75,8 +75,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_data_seek($stmt, 0)))
-		printf("[017] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_data_seek($stmt, 0)))
+		printf("[017] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_stmt_errno.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_errno.phpt
@@ -53,8 +53,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_errno($stmt)))
-		printf("[011] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_errno($stmt)))
+		printf("[011] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_stmt_error.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_error.phpt
@@ -53,8 +53,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_error($stmt)))
-		printf("[011] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_error($stmt)))
+		printf("[011] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_stmt_execute.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute.phpt
@@ -31,15 +31,15 @@ if (mysqli_get_server_version($link) <= 40100) {
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 	// stmt object status test
-	if (NULL !== ($tmp = mysqli_stmt_execute($stmt)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_execute($stmt)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (mysqli_stmt_prepare($stmt, "SELECT i_do_not_exist_believe_me FROM test ORDER BY id"))
 		printf("[005] Statement should have failed!\n");
 
 	// stmt object status test
-	if (NULL !== ($tmp = mysqli_stmt_execute($stmt)))
-		printf("[006] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_execute($stmt)))
+		printf("[006] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id FROM test ORDER BY id LIMIT 1"))
 		printf("[007] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -126,8 +126,8 @@ if (mysqli_get_server_version($link) <= 40100) {
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_execute($stmt)))
-		printf("[028] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_execute($stmt)))
+		printf("[028] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_stmt_fetch.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_fetch.phpt
@@ -30,8 +30,8 @@ require_once('skipifconnectfailure.inc');
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 	// stmt object status test
-	if (NULL !== ($tmp = mysqli_stmt_fetch($stmt)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_fetch($stmt)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
 		printf("[005] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -73,8 +73,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_fetch($stmt)))
-		printf("[016] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_fetch($stmt)))
+		printf("[016] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 

--- a/ext/mysqli/tests/mysqli_stmt_field_count.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_field_count.phpt
@@ -22,13 +22,14 @@ require_once('skipifconnectfailure.inc');
 	require('table.inc');
 
 	$stmt = mysqli_stmt_init($link);
-	if (!is_null($tmp = mysqli_stmt_field_count($stmt)))
-		printf("[003] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_field_count($stmt)))
+		printf("[003] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (mysqli_stmt_prepare($stmt, ''))
 		printf("[004] Prepare should fail for an empty statement\n");
-	if (!is_null($tmp = mysqli_stmt_field_count($stmt)))
-		printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+
+	if (false !== ($tmp = mysqli_stmt_field_count($stmt)))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, 'SELECT 1'))
 		printf("[006] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -74,8 +75,9 @@ require_once('skipifconnectfailure.inc');
 
 	if (mysqli_stmt_prepare($stmt, 'SELECT id FROM test'))
 		printf("[020] Prepare should fail, statement has been closed\n");
-	if (!is_null($tmp = mysqli_stmt_field_count($stmt)))
-		printf("[011] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+
+	if (false !== ($tmp = mysqli_stmt_field_count($stmt)))
+		printf("[021] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 

--- a/ext/mysqli/tests/mysqli_stmt_free_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_free_result.phpt
@@ -30,8 +30,8 @@ require_once('skipifconnectfailure.inc');
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 	// stmt object status test
-	if (NULL !== ($tmp = mysqli_stmt_free_result($stmt)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_free_result($stmt)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id"))
 		printf("[005] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -67,8 +67,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_free_result($stmt)))
-		printf("[015] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_free_result($stmt)))
+		printf("[015] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 

--- a/ext/mysqli/tests/mysqli_stmt_get_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result.phpt
@@ -33,8 +33,8 @@ if (!function_exists('mysqli_stmt_get_result'))
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 	// stmt object status test
-	if (NULL !== ($tmp = mysqli_stmt_fetch($stmt)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
+	if (false !== ($tmp = mysqli_stmt_fetch($stmt)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
 		printf("[005] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -58,8 +58,8 @@ if (!function_exists('mysqli_stmt_get_result'))
 		printf("[010] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 	// stmt object status test
-	if (NULL !== ($tmp = mysqli_stmt_fetch($stmt)))
-		printf("[011] Expecting NULL, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
+	if (false !== ($tmp = mysqli_stmt_fetch($stmt)))
+		printf("[011] Expecting false, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
 		printf("[012] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -81,8 +81,8 @@ if (!function_exists('mysqli_stmt_get_result'))
 		printf("[017] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 	// stmt object status test
-	if (NULL !== ($tmp = mysqli_stmt_get_result($stmt)))
-		printf("[018] Expecting NULL, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
+	if (false !== ($tmp = mysqli_stmt_get_result($stmt)))
+		printf("[018] Expecting false, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
 		printf("[019] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -148,8 +148,8 @@ if (!function_exists('mysqli_stmt_get_result'))
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_fetch($stmt)))
-		printf("[042] Expecting NULL, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
+	if (false !== ($tmp = mysqli_stmt_fetch($stmt)))
+		printf("[042] Expecting false, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
 
 	mysqli_close($link);
 

--- a/ext/mysqli/tests/mysqli_stmt_get_result2.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result2.phpt
@@ -144,8 +144,8 @@ if (!function_exists('mysqli_stmt_get_result'))
 	mysqli_stmt_close($stmt);
 	mysqli_close($link);
 
-	if (NULL !== ($res = mysqli_stmt_get_result($stmt))) {
-		printf("[022] Expecting NULL got %s/%s\n",
+	if (false !== ($res = mysqli_stmt_get_result($stmt))) {
+		printf("[026] Expecting false got %s/%s\n",
 			gettype($res), $res);
 	}
 

--- a/ext/mysqli/tests/mysqli_stmt_get_result_metadata.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_metadata.phpt
@@ -227,11 +227,11 @@ _null
 _label_concat
 
 Warning: mysqli_fetch_field(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 
 Warning: mysqli_fetch_field(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 
 Warning: mysqli_fetch_field(): Couldn't fetch mysqli_result in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_stmt_get_result_seek.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_seek.phpt
@@ -97,19 +97,19 @@ if (!function_exists('mysqli_stmt_get_result'))
 
 	mysqli_free_result($res);
 
-	if (NULL !== ($tmp = mysqli_data_seek($res, 0)))
-		printf("[017] Expecting NULL got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_data_seek($res, 0)))
+		printf("[017] Expecting false got %s/%s\n", gettype($tmp), $tmp);
 
-	if (NULL !== ($row = $res->fetch_array(MYSQLI_NUM)))
-		printf("[018] Expecting NULL got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($row = $res->fetch_array(MYSQLI_NUM)))
+		printf("[018] Expecting false got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_data_seek($res, 0)))
-		printf("[019] Expecting NULL got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_data_seek($res, 0)))
+		printf("[019] Expecting false got %s/%s\n", gettype($tmp), $tmp);
 
-	if (NULL !== ($row = $res->fetch_array(MYSQLI_NUM)))
-		printf("[020] Expecting NULL got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($row = $res->fetch_array(MYSQLI_NUM)))
+		printf("[020] Expecting false got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_stmt_get_warnings.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_warnings.phpt
@@ -40,8 +40,8 @@ mysqli_query($link, "DROP TABLE IF EXISTS test");
 	if (!$stmt = mysqli_stmt_init($link))
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-	if (NULL !== ($tmp = mysqli_stmt_get_warnings($stmt)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_get_warnings($stmt)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SET sql_mode=''") || !mysqli_stmt_execute($stmt))
 		printf("[005] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -92,8 +92,8 @@ mysqli_query($link, "DROP TABLE IF EXISTS test");
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_get_warnings($stmt)))
-		printf("[018] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_get_warnings($stmt)))
+		printf("[018] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_stmt_init.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_init.phpt
@@ -39,8 +39,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_stmt_init($link)))
-		printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_init($link)))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_stmt_insert_id.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_insert_id.phpt
@@ -23,8 +23,8 @@ require_once('skipifconnectfailure.inc');
 	require('table.inc');
 
 	$stmt = mysqli_stmt_init($link);
-	if (NULL !== ($tmp = @mysqli_stmt_insert_id($stmt)))
-		printf("[003] Expecting NULL/NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_stmt_insert_id($stmt)))
+		printf("[003] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 1") ||
 		!mysqli_stmt_execute($stmt)) {
@@ -73,5 +73,5 @@ require_once('skipifconnectfailure.inc');
 ?>
 --EXPECTF--
 Warning: mysqli_stmt_insert_id(): Couldn't fetch mysqli_stmt in %s on line %d
-NULL
+bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_stmt_num_rows.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_num_rows.phpt
@@ -101,8 +101,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_num_rows($stmt)))
-		printf("[056] Expecting NULL, got %s/%s\n");
+	if (false !== ($tmp = mysqli_stmt_num_rows($stmt)))
+		printf("[056] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_stmt_param_count.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_param_count.phpt
@@ -24,8 +24,8 @@ require_once('skipifconnectfailure.inc');
 	if (!$stmt = mysqli_stmt_init($link))
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-	if (NULL !== ($tmp = mysqli_stmt_param_count($stmt)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_param_count($stmt)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	function func_test_mysqli_stmt_param_count($stmt, $query, $expected, $offset) {
 
@@ -48,8 +48,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_param_count($stmt)))
-		printf("[40] Expecting NULL, got %s/%s\n");
+	if (false !== ($tmp = mysqli_stmt_param_count($stmt)))
+		printf("[40] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 

--- a/ext/mysqli/tests/mysqli_stmt_prepare.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_prepare.phpt
@@ -41,8 +41,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_prepare($stmt, "SELECT id FROM test")))
-		printf("[007] Expecting NULL, got %s/%s\n");
+	if (false !== ($tmp = mysqli_stmt_prepare($stmt, "SELECT id FROM test")))
+		printf("[007] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_stmt_reset.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_reset.phpt
@@ -30,8 +30,8 @@ require_once('skipifconnectfailure.inc');
 	if (!$stmt = mysqli_stmt_init($link))
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-	if (NULL !== ($tmp = mysqli_stmt_reset($stmt)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_reset($stmt)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (true !== ($tmp = mysqli_stmt_prepare($stmt, 'SELECT id FROM test')))
 		printf("[005] Expecting boolean/true, got %s/%s, [%d] %s\n",
@@ -93,8 +93,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_reset($stmt)))
-		printf("[021] Expecting NULL, got %s/%s\n");
+	if (false !== ($tmp = mysqli_stmt_reset($stmt)))
+		printf("[021] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_stmt_result_metadata.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_result_metadata.phpt
@@ -24,8 +24,8 @@ require_once('skipifconnectfailure.inc');
 	if (!$stmt = mysqli_stmt_init($link))
 		printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-	if (NULL !== ($tmp = mysqli_stmt_result_metadata($stmt)))
-		printf("[004] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_result_metadata($stmt)))
+		printf("[004] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test"))
 		printf("[005] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -82,8 +82,8 @@ require_once('skipifconnectfailure.inc');
 	mysqli_free_result($res);
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_result_metadata($stmt)))
-		printf("[017] Expecting NULL, got %s/%s\n");
+	if (false !== ($tmp = mysqli_stmt_result_metadata($stmt)))
+		printf("[017] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
 
 	/* Check that the function alias exists. It's a deprecated function,
 	but we have not announce the removal so far, therefore we need to check for it */

--- a/ext/mysqli/tests/mysqli_stmt_sqlstate.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_sqlstate.phpt
@@ -27,8 +27,8 @@ require_once('skipifconnectfailure.inc');
 	if (!$stmt = mysqli_stmt_init($link))
 		printf("[004] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-	if (NULL !== ($tmp = mysqli_stmt_sqlstate($stmt)))
-		printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_stmt_sqlstate($stmt)))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "SELECT id FROM test"))
 		printf("[006] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
@@ -45,8 +45,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_stmt_close($stmt);
 
-	if (NULL !== ($tmp = mysqli_stmt_sqlstate($stmt)))
-		printf("[010] Expecting NULL, got %s/%s\n");
+	if (false !== ($tmp = mysqli_stmt_sqlstate($stmt)))
+		printf("[010] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	print "done!";

--- a/ext/mysqli/tests/mysqli_stmt_store_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_store_result.phpt
@@ -21,15 +21,15 @@ require_once('skipifconnectfailure.inc');
 
 	require('table.inc');
 
-	if (!is_null($tmp = @mysqli_stmt_store_result(new mysqli_stmt())))
-		printf("[003] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_stmt_store_result(new mysqli_stmt())))
+		printf("[003] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!$stmt = mysqli_stmt_init($link))
 		printf("[004] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 	// stmt object status test
-	if (NULL !== ($tmp = @mysqli_stmt_store_result($stmt)))
-		printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_stmt_store_result($stmt)))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	if (!mysqli_stmt_prepare($stmt, "INSERT INTO test(id, label) VALUES (100, 'z')") ||
 		!mysqli_stmt_execute($stmt))
@@ -75,8 +75,8 @@ require_once('skipifconnectfailure.inc');
 	mysqli_stmt_close($stmt);
 	mysqli_stmt_close($stmt_buf);
 
-	if (NULL !== ($tmp = @mysqli_stmt_store_result($stmt)))
-		printf("[017] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = @mysqli_stmt_store_result($stmt)))
+		printf("[017] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	mysqli_close($link);
 	mysqli_close($link_buf);

--- a/ext/mysqli/tests/mysqli_store_result.phpt
+++ b/ext/mysqli/tests/mysqli_store_result.phpt
@@ -50,8 +50,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_store_result($link)))
-		printf("[010] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_store_result($link)))
+		printf("[010] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_thread_id.phpt
+++ b/ext/mysqli/tests/mysqli_thread_id.phpt
@@ -30,8 +30,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_thread_id($link)))
-		printf("[005] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_thread_id($link)))
+		printf("[005] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_use_result.phpt
+++ b/ext/mysqli/tests/mysqli_use_result.phpt
@@ -50,8 +50,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_use_result($link)))
-		printf("[010] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_use_result($link)))
+		printf("[010] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_warning_count.phpt
+++ b/ext/mysqli/tests/mysqli_warning_count.phpt
@@ -38,8 +38,8 @@ require_once('skipifconnectfailure.inc');
 
 	mysqli_close($link);
 
-	if (NULL !== ($tmp = mysqli_warning_count($link)))
-		printf("[010] Expecting NULL, got %s/%s\n", gettype($tmp), $tmp);
+	if (false !== ($tmp = mysqli_warning_count($link)))
+		printf("[010] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
 
 	print "done!";
 ?>


### PR DESCRIPTION
The patch is way larger than initially expected due to the following:

1. The `MYSQLI_FETCH_RESOURCE` macro which handles the situation of a closed connection is used by many other `mysqli_*` functions, so the change in the macro affects those functions as well. I reviewed the documentation articles for some of them, and none claimed that the function was expected to return `NULL`.
2. The failures in `mysqli_class_mysqli_properties_no_conn.phpt` showed that the values of `mysqli` class properties should be consistent with the return values of the corresponding functions, so I modified `CHECK_STATUS` and `MYSQLI_GET_MYSQL` as well.