### PR TITLE
Fix bug #75464 Wrong reflection on SoapClient::__setSoapHeaders

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -373,7 +373,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_soapclient___getcookies, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_soapclient___setsoapheaders, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_soapclient___setsoapheaders, 0, 0, 0)
 	ZEND_ARG_INFO(0, soapheaders)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
Fix for [bug 75464](https://bugs.php.net/bug.php?id=75464)