### PR TITLE
ext/date - Remove decade-old commented-out code

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3424,7 +3424,7 @@ PHP_FUNCTION(date_timezone_get)
 	}
 	dateobj = Z_PHPDATE_P(object);
 	DATE_CHECK_INITIALIZED(dateobj->time, DateTime);
-	if (dateobj->time->is_localtime/* && dateobj->time->tz_info*/) {
+	if (dateobj->time->is_localtime) {
 		php_date_instantiate(date_ce_timezone, return_value);
 		tzobj = Z_PHPTIMEZONE_P(return_value);
 		set_timezone_from_timelib_time(tzobj, dateobj->time);
@@ -3508,7 +3508,7 @@ PHP_FUNCTION(date_offset_get)
 	}
 	dateobj = Z_PHPDATE_P(object);
 	DATE_CHECK_INITIALIZED(dateobj->time, DateTime);
-	if (dateobj->time->is_localtime/* && dateobj->time->tz_info*/) {
+	if (dateobj->time->is_localtime) {
 		switch (dateobj->time->zone_type) {
 			case TIMELIB_ZONETYPE_ID:
 				offset = timelib_get_time_zone_info(dateobj->time->sse, dateobj->time->tz_info);


### PR DESCRIPTION
If we haven't uncommented it in [about](https://github.com/php/php-src/blame/master/ext/date/php_date.c#L3427) a [decade](https://github.com/php/php-src/blame/master/ext/date/php_date.c#L3511), I'm gonna assume we can remove it. 😉 