### PR TITLE
set variable register_argc_argv On on INI section

### DIFF
--- a/sapi/phpdbg/tests/run_001.phpt
+++ b/sapi/phpdbg/tests/run_001.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test argv passing
+--INI--
+register_argc_argv=On
 --PHPDBG--
 r
 r 1 2 3


### PR DESCRIPTION
Set the variable register_argc_argv On.
Without this parameter, the test suite freezes without alert the user.
Please try approve this PR faster, because is causing problems with phptestfests events.