### PR TITLE
fix wrong check of definition_phi->constraint.range.max_ssa_var

### DIFF
--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -1585,7 +1585,7 @@ static void zend_infer_ranges_warmup(const zend_op_array *op_array, zend_ssa *ss
 					ssa->vars[j].definition_phi->has_range_constraint &&
 				    ssa->vars[j].definition_phi->constraint.range.negative &&
 				    ssa->vars[j].definition_phi->constraint.range.min_ssa_var < 0 &&
-				    ssa->vars[j].definition_phi->constraint.range.min_ssa_var < 0) {
+				    ssa->vars[j].definition_phi->constraint.range.max_ssa_var < 0) {
 					zend_ssa_range_constraint *constraint =
 						&ssa->vars[j].definition_phi->constraint.range;
 					if (tmp.min == ssa->var_info[j].range.min &&


### PR DESCRIPTION
`ssa->vars[j].definition_phi->constraint.range.min_ssa_var < 0` is twice checked.
Is `max_ssa_var` correct?