### PR TITLE
added parentheses around ‘&&' following suggestion

### DIFF
--- a/ext/mbstring/libmbfl/filters/mbfilter_big5.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_big5.c
@@ -190,7 +190,7 @@ mbfl_filt_conv_big5_wchar(int c, mbfl_convert_filter *filter)
 
 			if (filter->from->no_encoding == mbfl_no_encoding_cp950) {
 				/* PUA for CP950 */
-				if (w <= 0 &&
+				if ((w <= 0) &&
 					(((c1 >= 0xfa && c1 <= 0xfe) || (c1 >= 0x8e && c1 <= 0xa0) ||
 					  (c1 >= 0x81 && c1 <= 0x8d) ||(c1 >= 0xc7 && c1 <= 0xc8))
 					 && ((c > 0x39 && c < 0x7f) || (c > 0xa0 && c < 0xff))) ||

--- a/ext/mbstring/libmbfl/filters/mbfilter_big5.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_big5.c
@@ -190,12 +190,25 @@ mbfl_filt_conv_big5_wchar(int c, mbfl_convert_filter *filter)
 
 			if (filter->from->no_encoding == mbfl_no_encoding_cp950) {
 				/* PUA for CP950 */
-				if ((w <= 0) &&
-					(((c1 >= 0xfa && c1 <= 0xfe) || (c1 >= 0x8e && c1 <= 0xa0) ||
-					  (c1 >= 0x81 && c1 <= 0x8d) ||(c1 >= 0xc7 && c1 <= 0xc8))
-					 && ((c > 0x39 && c < 0x7f) || (c > 0xa0 && c < 0xff))) ||
-					((c1 == 0xc6) && (c > 0xa0 && c < 0xff))) {
+				if  (
+						(w <= 0 &&
+							(
+								(
+									(c1 >= 0xfa && c1 <= 0xfe) || (c1 >= 0x8e && c1 <= 0xa0) ||
+									(c1 >= 0x81 && c1 <= 0x8d) || (c1 >= 0xc7 && c1 <= 0xc8)
+								) &&
+								(
+									(c > 0x39 && c < 0x7f) || (c > 0xa0 && c < 0xff)
+								)
+							)
+						) || 
+						(
+							(c1 == 0xc6) && (c > 0xa0 && c < 0xff)
+						)
+					) {			
+					
 					c2 = c1 << 8 | c;
+					
 					for (k = 0; k < sizeof(cp950_pua_tbl)/(sizeof(unsigned short)*4); k++) {
 						if (c2 >= cp950_pua_tbl[k][2] && c2 <= cp950_pua_tbl[k][3]) {
 							break;


### PR DESCRIPTION
I just added parentheses following the suggestion 
==> default: /vagrant/php-src/ext/mbstring/libmbfl/filters/mbfilter_big5.c:193:16: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]