### PR TITLE
Fixed bug #70469 SoapClient's fatal error in error_get_last()

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2167,11 +2167,6 @@ static void soap_error_handler(int error_num, const char *error_filename, const 
 			int buffer_len;
 #ifdef va_copy
 			va_list argcopy;
-#endif
-			zend_object **old_objects;
-			int old = PG(display_errors);
-
-#ifdef va_copy
 			va_copy(argcopy, args);
 			buffer_len = vslprintf(buffer, sizeof(buffer)-1, format, argcopy);
 			va_end(argcopy);
@@ -2189,24 +2184,6 @@ static void soap_error_handler(int error_num, const char *error_filename, const 
 			add_soap_fault_ex(&fault, &SOAP_GLOBAL(error_object), code, buffer, NULL, NULL);
 			Z_ADDREF(fault);
 			zend_throw_exception_object(&fault);
-
-			old_objects = EG(objects_store).object_buckets;
-			EG(objects_store).object_buckets = NULL;
-			PG(display_errors) = 0;
-			SG(sapi_headers).http_status_line = NULL;
-			zend_try {
-				call_old_error_handler(error_num, error_filename, error_lineno, format, args);
-			} zend_catch {
-				CG(in_compilation) = _old_in_compilation;
-				EG(current_execute_data) = _old_current_execute_data;
-				if (SG(sapi_headers).http_status_line) {
-					efree(SG(sapi_headers).http_status_line);
-				}
-				SG(sapi_headers).http_status_line = _old_http_status_line;
-				SG(sapi_headers).http_response_code = _old_http_response_code;
-			} zend_end_try();
-			EG(objects_store).object_buckets = old_objects;
-			PG(display_errors) = old;
 			zend_bailout();
 		} else if (!use_exceptions ||
 		           !SOAP_GLOBAL(error_code) ||

--- a/ext/soap/tests/bugs/bug70469.phpt
+++ b/ext/soap/tests/bugs/bug70469.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #70469 (SoapClient should not generate E_ERROR if exceptions enabled)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+try {
+    $x = new SoapClient('http://i_dont_exist.com/some.wsdl');
+} catch (SoapFault $e) {
+    echo "catched\n";
+}
+
+$error = error_get_last();
+if ($error === null) {
+    echo "ok\n";
+}
+?>
+--EXPECT--
+catched
+ok


### PR DESCRIPTION
Hello! Fixed bug https://bugs.php.net/bug.php?id=70469 when you can get fatal error from error_get_last() even if SoapClient is in exception mode.

This issue first appeared in commit https://github.com/php/php-src/commit/a830b0fc6b2c3651f0c8ed44b83708945efaca21 . The issue was about server side error logging but patch changed client side too. I think we don't want silent errors in SoapClient in exception mode. Please correct me if I'm wrong.