### PR TITLE
support VM_RETURN vm_interrupt

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2092,7 +2092,7 @@ static zend_always_inline void i_free_compiled_variables(zend_execute_data *exec
 }
 /* }}} */
 
-void zend_free_compiled_variables(zend_execute_data *execute_data) /* {{{ */
+ZEND_API void zend_free_compiled_variables(zend_execute_data *execute_data) /* {{{ */
 {
 	i_free_compiled_variables(execute_data);
 }
@@ -2500,7 +2500,7 @@ static void cleanup_live_vars(zend_execute_data *execute_data, uint32_t op_num, 
 }
 /* }}} */
 
-void zend_cleanup_unfinished_execution(zend_execute_data *execute_data, uint32_t op_num, uint32_t catch_op_num) {
+ZEND_API void zend_cleanup_unfinished_execution(zend_execute_data *execute_data, uint32_t op_num, uint32_t catch_op_num) {
 	cleanup_unfinished_calls(execute_data, op_num);
 	cleanup_live_vars(execute_data, op_num, catch_op_num);
 }

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -184,7 +184,13 @@ static zend_always_inline zend_vm_stack zend_vm_stack_new_page(size_t size, zend
 
 ZEND_API void zend_vm_stack_init(void)
 {
-	EG(vm_stack) = zend_vm_stack_new_page(ZEND_VM_STACK_PAGE_SIZE, NULL);
+	zend_vm_stack_init_ex(ZEND_VM_STACK_PAGE_SIZE);
+}
+
+ZEND_API void zend_vm_stack_init_ex(size_t size)
+{
+	EG(vm_stack) = zend_vm_stack_new_page(ZEND_VM_STACK_PAGE_ALIGNED_SIZE(size), NULL);
+	EG(vm_stack)->frame_size = size;
 	EG(vm_stack)->top++;
 	EG(vm_stack_top) = EG(vm_stack)->top;
 	EG(vm_stack_end) = EG(vm_stack)->end;
@@ -209,8 +215,8 @@ ZEND_API void* zend_vm_stack_extend(size_t size)
 	stack = EG(vm_stack);
 	stack->top = EG(vm_stack_top);
 	EG(vm_stack) = stack = zend_vm_stack_new_page(
-		EXPECTED(size < ZEND_VM_STACK_FREE_PAGE_SIZE) ?
-			ZEND_VM_STACK_PAGE_SIZE : ZEND_VM_STACK_PAGE_ALIGNED_SIZE(size),
+		EXPECTED(size < stack->frame_size) ?
+			ZEND_VM_STACK_PAGE_ALIGNED_SIZE(stack->frame_size) : ZEND_VM_STACK_PAGE_ALIGNED_SIZE(size),
 		stack);
 	ptr = stack->top;
 	EG(vm_stack_top) = (void*)(((char*)ptr) + size);

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -322,8 +322,8 @@ typedef zval* zend_free_op;
 ZEND_API zval *zend_get_zval_ptr(const zend_op *opline, int op_type, const znode_op *node, const zend_execute_data *execute_data, zend_free_op *should_free, int type);
 
 ZEND_API void zend_clean_and_cache_symbol_table(zend_array *symbol_table);
-void zend_free_compiled_variables(zend_execute_data *execute_data);
-void zend_cleanup_unfinished_execution(zend_execute_data *execute_data, uint32_t op_num, uint32_t catch_op_num);
+ZEND_API void zend_free_compiled_variables(zend_execute_data *execute_data);
+ZEND_API void zend_cleanup_unfinished_execution(zend_execute_data *execute_data, uint32_t op_num, uint32_t catch_op_num);
 
 ZEND_API int ZEND_FASTCALL zend_do_fcall_overloaded(zend_execute_data *call, zval *ret);
 

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -138,6 +138,7 @@ struct _zend_vm_stack {
 	zval *top;
 	zval *end;
 	zend_vm_stack prev;
+	size_t frame_size;
 };
 
 #define ZEND_VM_STACK_HEADER_SLOTS \
@@ -162,6 +163,7 @@ struct _zend_vm_stack {
 #endif
 
 ZEND_API void zend_vm_stack_init(void);
+ZEND_API void zend_vm_stack_init_ex(size_t size);
 ZEND_API void zend_vm_stack_destroy(void);
 ZEND_API void* zend_vm_stack_extend(size_t size);
 


### PR DESCRIPTION
I wrote a [RFC](https://wiki.php.net/rfc/zend-vm-pause-api) for PR #2886. After published in the php-internal list, @dstogov pointed out that
> It should be possible do similar things using EG(vm_interrupt) and zend_interrupt_function() callback (introduced in php-7.1)
> ext/pcntl implements asynchronous signal handling using this.

I read the code of `EG(vm_interrupt)`, almost every thing I proposed in PR #2886 could be implemented by the `EG(vm_interrupt)`. However, the `EG(vm_interrupt)` can only pause-and-continue, but I propose to introduce a pause-and-return API.

So I propose to introduce another to make the minimum changes to php-src base.

And the [RFC](https://wiki.php.net/rfc/zend-vm-pause-api) has also been updated.