### PR TITLE
Mention spl_object_id in UPGRADING notes for PHP 7.2

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -268,6 +268,9 @@ See also: https://wiki.php.net/rfc/deprecations_php_7_2
   . Added socket_addrinfo_lookup(), socket_addrinfo_connect(),
     socket_addrinfo_bind() and socket_addrinfo_explain().
 
+- SPL:
+  . Added spl_object_id().
+
 ========================================
 7. New Classes and Interfaces
 ========================================


### PR DESCRIPTION
This was implemented in PR #2611 for the PHP 7.2 release