### PR TITLE
Fix typo in UPGRADING, should be oci_unregister_taf_callback

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -261,7 +261,7 @@ See also: https://wiki.php.net/rfc/deprecations_php_7_2
   . Added mb_scrub() that scrubs broken multibyte strings.
 
 - OCI8:
-  . Added oci_register_taf_callback() and oci_disable_taf_callback() for
+  . Added oci_register_taf_callback() and oci_unregister_taf_callback() for
     Oracle Database TAF callback support.
 
 - Sockets:


### PR DESCRIPTION
See de65a2243f5e52ccafc69889ab0b64f4481c5358 which exposes
the unregister functionality. (The correct function name was used in NEWS)