### PR TITLE
Fix C proto documents for new global functions

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -5109,7 +5109,7 @@ static inline zend_long php_mb_ord(const char* str, size_t str_len, const char* 
 }
 
 
-/* {{{ proto bool mb_ord([string str[, string encoding]]) */
+/* {{{ proto int|false mb_ord([string str[, string encoding]]) */
 PHP_FUNCTION(mb_ord)
 {
 	char* str;
@@ -5233,7 +5233,7 @@ static inline char* php_mb_chr(zend_long cp, const char* enc, size_t *output_len
 }
 
 
-/* {{{ proto bool mb_ord([int cp[, string encoding]]) */
+/* {{{ proto string|false mb_chr([int cp[, string encoding]]) */
 PHP_FUNCTION(mb_chr)
 {
 	zend_long cp;
@@ -5268,7 +5268,7 @@ static inline char* php_mb_scrub(const char* str, size_t str_len, const char* en
 }
 
 
-/* {{{ proto bool mb_scrub([string str[, string encoding]]) */
+/* {{{ proto string|false mb_scrub([string str[, string encoding]]) */
 PHP_FUNCTION(mb_scrub)
 {
 	char* str;

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -1620,7 +1620,7 @@ PHP_FUNCTION(stream_supports_lock)
 	RETURN_TRUE;
 }
 
-/* {{{ proto proto stream_isatty(resource stream)
+/* {{{ proto bool stream_isatty(resource stream)
 Check if a stream is a TTY.
 */
 PHP_FUNCTION(stream_isatty)
@@ -1658,7 +1658,7 @@ PHP_FUNCTION(stream_isatty)
 }
 
 #ifdef PHP_WIN32
-/* {{{ proto proto sapi_windows_vt100_support(resource stream[, bool enable])
+/* {{{ proto bool sapi_windows_vt100_support(resource stream[, bool enable])
    Get or set VT100 support for the specified stream associated to an
    output buffer of a Windows console.
 */


### PR DESCRIPTION
See NEWS and UPGRADING (or arginfo/implementation) for details.

ord converts multibyte character to codepoint, chr converts codepoint to multibyte character.