### PR TITLE
More robust handling of stringified column data

### DIFF
--- a/ext/pdo_dblib/php_pdo_dblib_int.h
+++ b/ext/pdo_dblib/php_pdo_dblib_int.h
@@ -90,6 +90,10 @@ typedef unsigned char *LPBYTE;
 typedef float			DBFLT4;
 #endif
 
+// hardcoded string length from FreeTDS
+// src/tds/convert.c:tds_convert_datetimeall()
+# define DATETIME_MAX_LEN   63
+
 int pdo_dblib_error_handler(DBPROCESS *dbproc, int severity, int dberr,
 	int oserr, char *dberrstr, char *oserrstr);
 


### PR DESCRIPTION
 - Use at least the FreeTDS maximum when converting datetime data
 - Use dbconvert() return value to set string lengths or handle errors