### PR TITLE
Update main.c

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -186,7 +186,7 @@ static PHP_INI_MH(OnChangeMemoryLimit)
 	if (new_value) {
 		PG(memory_limit) = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
 	} else {
-		PG(memory_limit) = 1<<30;		/* effectively, no limit */
+		PG(memory_limit) = 1UL<<30;		/* effectively, no limit */
 	}
 	return zend_set_memory_limit(PG(memory_limit));
 }


### PR DESCRIPTION
The constant `1` defaults to type `int`, which needn't necessarily contain thirty bits. In order to [avoid invoking undefined behaviour](https://port70.net/~nsz/c/c11/n1570.html#6.5p5) you must [ensure the right operand is less than the number of bits in the left operand](https://port70.net/~nsz/c/c11/n1570.html#6.5.7p3). I added a `UL` suffix to ensure that constant is treated as an `unsigned long`, which is required to be at least 32 bits in length.