### PR TITLE
mbstring tests

### DIFF
--- a/ext/mbstring/tests/mb_language.phpt
+++ b/ext/mbstring/tests/mb_language.phpt
@@ -1,0 +1,39 @@
+--TEST--
+mb_language()
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip');
+--INI--
+mbstring.language=
+--FILE--
+<?php
+echo "Checking default language:\n";
+var_dump(mb_language());
+
+echo "Checking default language after ini_set:\n";
+ini_set('mbstring.language', 'uni');
+var_dump(mb_language());
+
+echo "Changing language to English should be successful:\n";
+var_dump(mb_language('English'));
+
+echo "Confirm language was changed:\n";
+var_dump(mb_language());
+
+echo "Try changing to a non-existant language:\n";
+var_dump(mb_language('Pig Latin'));
+var_dump(mb_language());
+?>
+--EXPECTF--
+Checking default language:
+string(7) "neutral"
+Checking default language after ini_set:
+string(3) "uni"
+Changing language to English should be successful:
+bool(true)
+Confirm language was changed:
+string(7) "English"
+Try changing to a non-existant language:
+
+Warning: mb_language(): Unknown language "Pig Latin" in %s on line %d
+bool(false)
+string(7) "neutral"

--- a/ext/mbstring/tests/mb_strcut_negative_length.phpt
+++ b/ext/mbstring/tests/mb_strcut_negative_length.phpt
@@ -1,0 +1,18 @@
+--TEST--
+mb_strcut() negative length test
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip');
+--FILE--
+<?php
+var_dump(mb_strcut('Déjà vu', 1, -3));
+var_dump(mb_strcut('Déjà vu', 1, -4));
+var_dump(mb_strcut('Déjà vu', 1, -5));
+var_dump(mb_strcut('Déjà vu', 1, -6));
+var_dump(mb_strcut('Déjà vu', 1, -999));
+?>
+--EXPECT--
+string(5) "éjà"
+string(3) "éj"
+string(3) "éj"
+string(2) "é"
+string(0) ""


### PR DESCRIPTION
This adds tests for a couple of mbstring functions:

 - `mb_language()` is somewhat tested in `ext/mbstring/tests/mb_send_mail*.phpt`, but the behavior of specifying an unknown language is not
 - `mb_strcut()` had no tests for the usage of negative lengths