### PR TITLE
Fixed #73124: php_ini_scanned_files()

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -1393,7 +1393,7 @@ PHP_FUNCTION(php_ini_scanned_files)
 		return;
 	}
 
-	if (strlen(PHP_CONFIG_FILE_SCAN_DIR) && php_ini_scanned_files) {
+	if (php_ini_scanned_files) {
 		RETURN_STRING(php_ini_scanned_files);
 	} else {
 		RETURN_FALSE;

--- a/ext/standard/tests/bug73124.phpt
+++ b/ext/standard/tests/bug73124.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #73124 (php_ini_scanned_files relied on PHP_CONFIG_FILE_SCAN_DIR)
+--SKIPIF--
+<?php
+if (!empty(PHP_CONFIG_FILE_SCAN_DIR)) die("Skip: PHP_CONFIG_FILE_SCAN_DIR must not be available");
+?>
+--FILE--
+<?php
+    $tempDir = sys_get_temp_dir();
+    putenv('PHP_INI_SCAN_DIR='.$tempDir);
+
+    $inifile = $tempDir.DIRECTORY_SEPARATOR.'scan-dir.ini';
+    @unlink($inifile);
+    file_put_contents($inifile, "\n");
+
+    $php = getenv('TEST_PHP_EXECUTABLE');
+    passthru('"'.$php.'" -r "print_r(php_ini_scanned_files());"');
+
+    putenv('PHP_INI_SCAN_DIR=');
+    @unlink($inifile);
+?>
+--EXPECTREGEX--
+.*[\/\\]scan-dir\.ini.*|.*[\/\\]scan-dir\.ini
+Done


### PR DESCRIPTION
Additional ini files are reported using the --ini option, but not by
`php_ini_scanned_files()`, which relied on PHP_CONFIG_FILE_SCAN_DIR.