### PR TITLE
Fix segfault on zend_vm_execute

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2835,7 +2835,7 @@ ZEND_VM_HANDLER(54, ZEND_ROPE_INIT, UNUSED, CONST|TMPVAR|CV, NUM)
 		var = GET_OP2_ZVAL_PTR(BP_VAR_R);
 		rope[0] = Z_STR_P(var);
 		if (UNEXPECTED(Z_REFCOUNTED_P(var))) {
-			Z_ADDREF_P(Z_STR_P(var));
+			Z_ADDREF_P(var);
 		}
 	} else {
 		var = GET_OP2_ZVAL_PTR_UNDEF(BP_VAR_R);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -28280,7 +28280,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ROPE_INIT_SPEC_UNUSED_CONST_HA
 		var = RT_CONSTANT(opline, opline->op2);
 		rope[0] = Z_STR_P(var);
 		if (UNEXPECTED(Z_REFCOUNTED_P(var))) {
-			Z_ADDREF_P(Z_STR_P(var));
+			Z_ADDREF_P(var);
 		}
 	} else {
 		var = RT_CONSTANT(opline, opline->op2);
@@ -30904,7 +30904,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ROPE_INIT_SPEC_UNUSED_CV_HANDL
 		var = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 		rope[0] = Z_STR_P(var);
 		if (UNEXPECTED(Z_REFCOUNTED_P(var))) {
-			Z_ADDREF_P(Z_STR_P(var));
+			Z_ADDREF_P(var);
 		}
 	} else {
 		var = _get_zval_ptr_cv_undef(opline->op2.var EXECUTE_DATA_CC);
@@ -32651,7 +32651,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ROPE_INIT_SPEC_UNUSED_TMPVAR_H
 		var = _get_zval_ptr_var(opline->op2.var, &free_op2 EXECUTE_DATA_CC);
 		rope[0] = Z_STR_P(var);
 		if (UNEXPECTED(Z_REFCOUNTED_P(var))) {
-			Z_ADDREF_P(Z_STR_P(var));
+			Z_ADDREF_P(var);
 		}
 	} else {
 		var = _get_zval_ptr_var(opline->op2.var, &free_op2 EXECUTE_DATA_CC);


### PR DESCRIPTION
Discovered executing token_get_all tests (in particular `ext/tokenizer/tests/token_get_all_variation19.phpt`) and introduced in https://github.com/php/php-src/commit/aa7bf415023c3d0de177be35242a01726d04a265