### PR TITLE
Fixed #75539 and #74183 - preg_last_error not returning error code after error

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -356,6 +356,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 #endif
 		php_error_docref(NULL, E_WARNING,
 						 p < ZSTR_VAL(regex) + ZSTR_LEN(regex) ? "Null byte in regex" : "Empty regular expression");
+		pcre_handle_exec_error(PCRE_ERROR_INTERNAL);
 		return NULL;
 	}
 
@@ -369,6 +370,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 		}
 #endif
 		php_error_docref(NULL,E_WARNING, "Delimiter must not be alphanumeric or backslash");
+		pcre_handle_exec_error(PCRE_ERROR_INTERNAL);
 		return NULL;
 	}
 
@@ -419,6 +421,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 		} else {
 			php_error_docref(NULL,E_WARNING, "No ending matching delimiter '%c' found", delimiter);
 		}
+		pcre_handle_exec_error(PCRE_ERROR_INTERNAL);
 		return NULL;
 	}
 
@@ -467,6 +470,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 				} else {
 					php_error_docref(NULL,E_WARNING, "Null byte in regex");
 				}
+				pcre_handle_exec_error(PCRE_ERROR_INTERNAL);
 				efree(pattern);
 #if HAVE_SETLOCALE
 				if (key != regex) {
@@ -497,6 +501,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 		}
 #endif
 		php_error_docref(NULL,E_WARNING, "Compilation failed: %s at offset %d", error, erroffset);
+		pcre_handle_exec_error(PCRE_ERROR_INTERNAL);
 		efree(pattern);
 		if (tables) {
 			pefree((void*)tables, 1);
@@ -528,6 +533,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 		}
 		if (error != NULL) {
 			php_error_docref(NULL, E_WARNING, "Error while studying pattern");
+			pcre_handle_exec_error(PCRE_ERROR_INTERNAL);
 		}
 	} else {
 		extra = NULL;
@@ -564,6 +570,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 		}
 #endif
 		php_error_docref(NULL, E_WARNING, "Internal pcre_fullinfo() error %d", rc);
+		pcre_handle_exec_error(PCRE_ERROR_INTERNAL);
 		return NULL;
 	}
 
@@ -575,6 +582,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 		}
 #endif
 		php_error_docref(NULL, E_WARNING, "Internal pcre_fullinfo() error %d", rc);
+		pcre_handle_exec_error(PCRE_ERROR_INTERNAL);
 		return NULL;
 	}
 

--- a/ext/pcre/tests/bug74183.phpt
+++ b/ext/pcre/tests/bug74183.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #74183 - preg_last_error not returning error code after error
+--FILE--
+<?php
+
+$sRegex = "/([A-Z]|[a-z]|[0-9]| |Ñ|ñ|!|&quot;|%|&amp;|'|´|-|:|;|>|=|&lt;|@|_|,|\{|\}|`|~|á|é|í|ó|ú|Á|É|Í|Ó|Ú|ü|Ü){1,300}/";
+$sTest = "Hello world";
+
+var_dump(preg_match($sRegex, $sTest));
+var_dump(preg_last_error() === \PREG_INTERNAL_ERROR);
+?>
+--EXPECTF--
+Warning: preg_match(): Compilation failed: regular expression is too large at offset %s in %s on line %s
+bool(false)
+bool(true)

--- a/ext/pcre/tests/bug75539.phpt
+++ b/ext/pcre/tests/bug75539.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #75539 - Recursive call errors are not reported by preg_last_error()
+--FILE--
+<?php
+
+var_dump(preg_match('/((?1)?z)/', ''));
+var_dump(preg_last_error() === \PREG_INTERNAL_ERROR);
+
+?>
+--EXPECTF--
+Warning: preg_match(): Compilation failed: recursive call could loop indefinitely at offset %s in %s on line %s
+bool(false)
+bool(true)


### PR DESCRIPTION
Fixes for https://bugs.php.net/bug.php?id=74183 and https://bugs.php.net/bug.php?id=75539