### PR TITLE
Fixed #75426 - "Cannot use empty array elements" reports wrong position

### DIFF
--- a/Zend/tests/bug75426.phpt
+++ b/Zend/tests/bug75426.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #75426 ("Cannot use empty array elements" reports wrong position)
+--FILE--
+<?php
+$a = [
+    1,
+    2,
+    ,
+    3
+];
+
+?>
+--EXPECTF--
+Fatal error: Cannot use empty array elements in arrays in %s on line 5

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -61,6 +61,7 @@ enum _zend_ast_kind {
 	/* 0 child nodes */
 	ZEND_AST_MAGIC_CONST = 0 << ZEND_AST_NUM_CHILDREN_SHIFT,
 	ZEND_AST_TYPE,
+	ZEND_AST_ARRAY_ELEM_EMPTY,
 
 	/* 1 child node */
 	ZEND_AST_VAR = 1 << ZEND_AST_NUM_CHILDREN_SHIFT,
@@ -269,7 +270,7 @@ static zend_always_inline zend_ast *zend_ast_create_cast(uint32_t type, zend_ast
 }
 static zend_always_inline zend_ast *zend_ast_list_rtrim(zend_ast *ast) {
 	zend_ast_list *list = zend_ast_get_list(ast);
-	if (list->children && list->child[list->children - 1] == NULL) {
+	if (list->children && list->child[list->children - 1]->kind == ZEND_AST_ARRAY_ELEM_EMPTY) {
 		list->children--;
 	}
 	return ast;

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1188,7 +1188,7 @@ array_pair_list:
 ;
 
 possible_array_pair:
-		/* empty */ { $$ = NULL; }
+		/* empty */ { $$ = zend_ast_create(ZEND_AST_ARRAY_ELEM_EMPTY); }
 	|	array_pair  { $$ = $1; }
 ;
 


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=75426

It introduces new `ZEND_AST_ARRAY_ELEM_EMPTY ` which used instead of `NULL` in array/list AST and helps keep track of position of such empty element.