### PR TITLE
Request #75550: Print PHP version in phpinfo() func html title

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -766,7 +766,7 @@ PHPAPI void php_print_info_htmlhead(void)
 	php_info_print("<html xmlns=\"http://www.w3.org/1999/xhtml\">");
 	php_info_print("<head>\n");
 	php_info_print_style();
-	php_info_print("<title>phpinfo()</title>");
+	php_info_print("<title>PHP %s - phpinfo()</title>", PHP_VERSION);
 	php_info_print("<meta name=\"ROBOTS\" content=\"NOINDEX,NOFOLLOW,NOARCHIVE\" />");
 	php_info_print("</head>\n");
 	php_info_print("<body><div class=\"center\">\n");


### PR DESCRIPTION
Filled request for https://bugs.php.net/bug.php?id=75550
Html title tag now shows php version.