### PR TITLE
ext/imap/config.m4: fix ac_cv_u8t_decompose check

### DIFF
--- a/ext/imap/config.m4
+++ b/ext/imap/config.m4
@@ -147,7 +147,7 @@ if test "$PHP_IMAP" != "no"; then
 
     old_CFLAGS=$CFLAGS
     CFLAGS="-I$IMAP_INC_DIR"
-    AC_CACHE_CHECK(for U8T_DECOMPOSE, ac_cv_u8t_canonical,
+    AC_CACHE_CHECK(for U8T_DECOMPOSE, ac_cv_u8t_decompose,
       AC_TRY_COMPILE([
 #include <c-client.h>
       ],[


### PR DESCRIPTION
Once upon the time, commit c58f63a38ae19caaab339c61486fc3bd7e5894f9
changed the check from U8T_CANONICAL to U8T_DECOMPOSE. However,
the autoconf cache id was not renamed.

Sometimes it is desirable to preseed the autoconf variables, e.g. when
cross-compiling to avoid the tests running on the host system. In this
case it's confusing when the cache id does not match the variable to
set, so let's adjust it.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>