### PR TITLE
There's a fix for some of that pesky non-standard undefined behaviour in here!

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -1171,10 +1171,10 @@ static zend_always_inline int zend_mm_small_size_to_bit(int size)
 # define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
-static zend_always_inline int zend_mm_small_size_to_bin(size_t size)
+static zend_always_inline size_t zend_mm_small_size_to_bin(size_t size)
 {
-#if 0
-	int n;
+#if 0 // can we have a discussion about this `#if 0`?
+	size_t n;
                             /*0,  1,  2,  3,  4,  5,  6,  7,  8,  9  10, 11, 12*/
 	static const int f1[] = { 3,  3,  3,  3,  3,  3,  3,  4,  5,  6,  7,  8,  9};
 	static const int f2[] = { 0,  0,  0,  0,  0,  0,  0,  4,  8, 12, 16, 20, 24};
@@ -1183,7 +1183,7 @@ static zend_always_inline int zend_mm_small_size_to_bin(size_t size)
 	n = zend_mm_small_size_to_bit(size - 1);
 	return ((size-1) >> f1[n]) + f2[n];
 #else
-	unsigned int t1, t2;
+	size_t t1, t2;
 
 	if (size <= 64) {
 		/* we need to support size == 0 ... */
@@ -1194,7 +1194,7 @@ static zend_always_inline int zend_mm_small_size_to_bin(size_t size)
 		t1 = t1 >> t2;
 		t2 = t2 - 3;
 		t2 = t2 << 2;
-		return (int)(t1 + t2);
+		return t1 + t2;
 	}
 #endif
 }

--- a/sapi/phpdbg/phpdbg_rinit_hook.c
+++ b/sapi/phpdbg/phpdbg_rinit_hook.c
@@ -67,7 +67,7 @@ static PHP_RINIT_FUNCTION(phpdbg_webhelper) /* {{{ */
 		}
 
 		char *msg = NULL;
-        size_t msglen = 0;
+		size_t msglen = 0;
 		phpdbg_webdata_compress(&msg, &msglen);
 
 		send(s, (unsigned char[]){ msglen

--- a/sapi/phpdbg/phpdbg_rinit_hook.c
+++ b/sapi/phpdbg/phpdbg_rinit_hook.c
@@ -58,7 +58,7 @@ static PHP_RINIT_FUNCTION(phpdbg_webhelper) /* {{{ */
 		int s = socket(AF_UNIX, SOCK_STREAM, 0);
 		size_t len = strlen(PHPDBG_WG(path)) + sizeof(sock.sun_family);
 		char buf[(1 << 8) + 1];
-		size_t buflen;
+		ssize_t buflen;
 		sock.sun_family = AF_UNIX;
 		strcpy(sock.sun_path, PHPDBG_WG(path));
 
@@ -70,10 +70,11 @@ static PHP_RINIT_FUNCTION(phpdbg_webhelper) /* {{{ */
 		size_t msglen = 0;
 		phpdbg_webdata_compress(&msg, &msglen);
 
-		send(s, (unsigned char[]){ msglen
-			                     , msglen / 0x100
-			                     , msglen / 0x10000
-			                     , msglen / 0x1000000 }, 4, 0);
+		buf[buflen=0] = msglen;
+		buf[++buflen] = msglen / 0x100;
+		buf[++buflen] = msglen / 0x10000;
+		buf[++buflen] = msglen / 0x1000000;
+		send(s, buf, 4, 0);
 		send(s, msg, msglen, 0);
 
 		while ((buflen = recv(s, buf, sizeof(buf) - 1, 0)) > 0) {

--- a/sapi/phpdbg/phpdbg_webdata_transfer.c
+++ b/sapi/phpdbg/phpdbg_webdata_transfer.c
@@ -27,7 +27,7 @@ static int phpdbg_is_auto_global(char *name, int len) {
 	return ret;
 }
 
-PHPDBG_API void phpdbg_webdata_compress(char **msg, int *len) {
+PHPDBG_API void phpdbg_webdata_compress(char **msg, size_t *len) {
 	zval array;
 	HashTable *ht;
 	zval zv[9] = {{{0}}};

--- a/sapi/phpdbg/phpdbg_webdata_transfer.h
+++ b/sapi/phpdbg/phpdbg_webdata_transfer.h
@@ -22,6 +22,6 @@
 #include "zend.h"
 #include "phpdbg.h"
 
-PHPDBG_API void phpdbg_webdata_compress(char **msg, int *len);
+PHPDBG_API void phpdbg_webdata_compress(char **msg, size_t *len);
 
 #endif /* PHPDBG_WEBDATA_TRANSFER_H */


### PR DESCRIPTION
At <https://github.com/php/php-src/commit/a1ff07ac13551c6f120c76618a52d866214b28ca#diff-3c2982bb766210ce070c2eb9f6f7e3d6L73> there is no guarantee that `size_t` will occupy four bytes. This commit contains various refactoring to reduce type-related warnings and non-standard undefined behaviour.