### PR TITLE
Omit the removal of generated module files at installation

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -43,8 +43,7 @@ install-modules: build-modules
 	@test -d modules && \
 	$(mkinstalldirs) $(INSTALL_ROOT)$(EXTENSION_DIR)
 	@echo "Installing shared extensions:     $(INSTALL_ROOT)$(EXTENSION_DIR)/"
-	@rm -f modules/*.la >/dev/null 2>&1
-	@$(INSTALL) modules/* $(INSTALL_ROOT)$(EXTENSION_DIR)
+	@find ./modules -type f ! -name '*.la' | xargs -0 -I {} $(INSTALL) {} $(INSTALL_ROOT)$(EXTENSION_DIR)
 
 install-headers:
 	-@if test "$(INSTALL_HEADERS)"; then \


### PR DESCRIPTION
Hello, this is a `quickfix`. The removal of modules during the installation step is not required before doing `make distclean` otherwise the `make test` command fails after installation step (useful when doing development of php-src). The `make clean` and `make distclean` are probably better steps for removing files generated during the build.

Thanks.