### PR TITLE
Fixed bug #64938 libxml_disable_entity_loader setting is shared betwe…

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -848,7 +848,6 @@ static PHP_MINIT_FUNCTION(libxml)
 	if (sapi_module.name) {
 		static const char * const supported_sapis[] = {
 			"cgi-fcgi",
-			"fpm-fcgi",
 			"litespeed",
 			NULL
 		};


### PR DESCRIPTION
…en requests (FPM)
