### PR TITLE
asm goto is not supported by couple of systems. To make sure it does,

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -464,7 +464,7 @@ ZEND_API void zend_update_current_locale(void);
 
 static zend_always_inline void fast_long_increment_function(zval *op1)
 {
-#if defined(__GNUC__) && defined(__i386__)
+#if defined(HAVE_ASM_GOTO) && defined(__i386__)
 	__asm__ goto(
 		"incl (%0)\n\t"
 		"jo  %l1\n"
@@ -475,7 +475,7 @@ static zend_always_inline void fast_long_increment_function(zval *op1)
 	return;
 overflow: ZEND_ATTRIBUTE_COLD_LABEL
 	ZVAL_DOUBLE(op1, (double)ZEND_LONG_MAX + 1.0);
-#elif defined(__GNUC__) && defined(__x86_64__)
+#elif defined(HAVE_ASM_GOTO) && defined(__x86_64__)
 	__asm__ goto(
 		"incq (%0)\n\t"
 		"jo  %l1\n"
@@ -514,7 +514,7 @@ overflow: ZEND_ATTRIBUTE_COLD_LABEL
 
 static zend_always_inline void fast_long_decrement_function(zval *op1)
 {
-#if defined(__GNUC__) && defined(__i386__)
+#if defined(HAVE_ASM_GOTO) && defined(__i386__)
 	__asm__ goto(
 		"decl (%0)\n\t"
 		"jo  %l1\n"
@@ -525,7 +525,7 @@ static zend_always_inline void fast_long_decrement_function(zval *op1)
 	return;
 overflow: ZEND_ATTRIBUTE_COLD_LABEL
 	ZVAL_DOUBLE(op1, (double)ZEND_LONG_MIN - 1.0);
-#elif defined(__GNUC__) && defined(__x86_64__)
+#elif defined(HAVE_ASM_GOTO) && defined(__x86_64__)
 	__asm__ goto(
 		"decq (%0)\n\t"
 		"jo  %l1\n"
@@ -564,7 +564,7 @@ overflow: ZEND_ATTRIBUTE_COLD_LABEL
 
 static zend_always_inline void fast_long_add_function(zval *result, zval *op1, zval *op2)
 {
-#if defined(__GNUC__) && defined(__i386__)
+#if defined(HAVE_ASM_GOTO) && defined(__i386__)
 	__asm__ goto(
 		"movl	(%1), %%eax\n\t"
 		"addl   (%2), %%eax\n\t"
@@ -582,7 +582,7 @@ static zend_always_inline void fast_long_add_function(zval *result, zval *op1, z
 	return;
 overflow: ZEND_ATTRIBUTE_COLD_LABEL
 	ZVAL_DOUBLE(result, (double) Z_LVAL_P(op1) + (double) Z_LVAL_P(op2));
-#elif defined(__GNUC__) && defined(__x86_64__)
+#elif defined(HAVE_ASM_GOTO) && defined(__x86_64__)
 	__asm__ goto(
 		"movq	(%1), %%rax\n\t"
 		"addq   (%2), %%rax\n\t"
@@ -654,7 +654,7 @@ static zend_always_inline int fast_add_function(zval *result, zval *op1, zval *o
 
 static zend_always_inline void fast_long_sub_function(zval *result, zval *op1, zval *op2)
 {
-#if defined(__GNUC__) && defined(__i386__)
+#if defined(HAVE_ASM_GOTO) && defined(__i386__)
 	__asm__ goto(
 		"movl	(%1), %%eax\n\t"
 		"subl   (%2), %%eax\n\t"
@@ -672,7 +672,7 @@ static zend_always_inline void fast_long_sub_function(zval *result, zval *op1, z
 	return;
 overflow: ZEND_ATTRIBUTE_COLD_LABEL
 	ZVAL_DOUBLE(result, (double) Z_LVAL_P(op1) - (double) Z_LVAL_P(op2));
-#elif defined(__GNUC__) && defined(__x86_64__)
+#elif defined(HAVE_ASM_GOTO) && defined(__x86_64__)
 	__asm__ goto(
 		"movq	(%1), %%rax\n\t"
 		"subq   (%2), %%rax\n\t"

--- a/configure.ac
+++ b/configure.ac
@@ -753,6 +753,20 @@ if test "x$php_crypt_r" = "x1"; then
   PHP_CRYPT_R_STYLE
 fi
 
+dnl Check for asm goto support
+AC_CACHE_CHECK([for asm goto], ac_cv__asm_goto,
+[AC_TRY_RUN([
+int main(void) {
+    __asm__ goto("jmp %l0\n" :::: end);
+end:
+    return 0;
+}
+  ],ac_cv__asm_goto=yes, ac_cv__asm_goto=no, ac_cv__asm_goto=no)])
+
+if test "$ac_cv__asm_goto" = yes; then
+  AC_DEFINE(HAVE_ASM_GOTO,1,[Define if asm goto support])
+fi
+
 PHP_CHECK_VALGRIND
 
 dnl General settings.


### PR DESCRIPTION
we can check it at configure-time.

The https://github.com/php/php-src/commit/6acfade8a1084202229929ecb54c01f9ef1059d2 commit introduced a build break for FreeBSD 10.x (but works on FreeBSD 11.1) and OpenBSD due to lack of asm goto support. Might be the case for more "exotic" oses.