### PR TITLE
Define floorf if system doesn't have it (follow up for 22c48761)

### DIFF
--- a/ext/gd/libgd/gd_interpolation.c
+++ b/ext/gd/libgd/gd_interpolation.c
@@ -66,6 +66,16 @@ TODO:
 # include <emmintrin.h>
 #endif
 
+#ifndef HAVE_FLOORF
+# define HAVE_FLOORF 0
+#endif
+#if HAVE_FLOORF == 0
+# ifndef floorf
+/* float floorf(float x);*/
+#  define floorf(x) ((float)(floor(x)))
+# endif
+#endif
+
 #ifndef MIN
 #define MIN(a,b) ((a)<(b)?(a):(b))
 #endif


### PR DESCRIPTION
floorf is checked in config.m4