### PR TITLE
expose IFF_* constant, and add filter to net_get_interfaces

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -36,6 +36,7 @@
 #include "ext/standard/php_dns.h"
 #include "ext/standard/php_uuencode.h"
 #include "ext/standard/php_mt_rand.h"
+#include "ext/standard/net.h"
 
 #ifdef PHP_WIN32
 #include "win32/php_win32_globals.h"
@@ -961,9 +962,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_gethostname, 0)
 ZEND_END_ARG_INFO()
 #endif
-
-ZEND_BEGIN_ARG_INFO(arginfo_net_get_interfaces, 0)
-ZEND_END_ARG_INFO()
 
 #if defined(PHP_WIN32) || HAVE_DNS_SEARCH_FUNC
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dns_check_record, 0, 0, 1)
@@ -3063,10 +3061,6 @@ const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(gethostname,													arginfo_gethostname)
 #endif
 
-#if defined(PHP_WIN32) || HAVE_GETIFADDRS
-	PHP_FE(net_get_interfaces,												arginfo_net_get_interfaces)
-#endif
-
 #if defined(PHP_WIN32) || HAVE_DNS_SEARCH_FUNC
 
 	PHP_FE(dns_check_record,												arginfo_dns_check_record)
@@ -3714,6 +3708,7 @@ PHP_MINIT_FUNCTION(basic) /* {{{ */
 #endif
 
 	BASIC_MINIT_SUBMODULE(random)
+	BASIC_MINIT_SUBMODULE(standard_net)
 
 	return SUCCESS;
 }

--- a/ext/standard/net.h
+++ b/ext/standard/net.h
@@ -1,0 +1,27 @@
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2017 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author: Rasmus Lerdorf <rasmus@lerdorf.on.ca>                        |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef STANDARD_NET_H
+#define STANDARD_NET_H
+
+#include "php_network.h"
+
+PHP_MINIT_FUNCTION(standard_net);
+
+#endif /* STANDARD_NET_H */
+


### PR DESCRIPTION
@sgolemon just a quickly written patch, to see if can make sense

I also move function arginfo and registration in net.c (and we should perhaps do the same for the other submodules...). I think having arginfo close to implementation is better ;)


P.S. and no idea about Windows... not tested...