### PR TITLE
Update interface.c

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2179,6 +2179,9 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 #endif
 #if LIBCURL_VERSION_NUM >= 0x070b02 /* Available since 7.11.2 */
 		case CURLOPT_TCP_NODELAY:
+		/* Why this function not implemented ? */
+		case CURLOPT_SSL_CTX_FUNCTION:
+		case CURLOPT_SSL_CTX_DATA:	
 #endif
 #if LIBCURL_VERSION_NUM >= 0x070c02 /* Available since 7.12.2 */
 		case CURLOPT_FTPSSLAUTH:


### PR DESCRIPTION
When try use curl with ssl from memory, i can see curl have this example to implementations it:

https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_DATA.html

Somebody can explain me why this is not implemented ?