### PR TITLE
Fix phar make paths

### DIFF
--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -1,5 +1,5 @@
 $(srcdir)/phar_path_check.c: $(srcdir)/phar_path_check.re
-	@(cd $(top_srcdir); $(RE2C) --no-generation-date -b -o phar_path_check.c phar_path_check.re)
+	@(cd $(top_srcdir); $(RE2C) --no-generation-date -b -o $(srcdir)/phar_path_check.c $(srcdir)/phar_path_check.re)
 
 pharcmd: $(builddir)/phar.php $(builddir)/phar.phar
 

--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -1,5 +1,5 @@
 $(srcdir)/phar_path_check.c: $(srcdir)/phar_path_check.re
-	@(cd $(top_srcdir); $(RE2C) --no-generation-date -b -o ext/phar/phar_path_check.c ext/phar/phar_path_check.re)
+	@(cd $(top_srcdir); $(RE2C) --no-generation-date -b -o phar_path_check.c phar_path_check.re)
 
 pharcmd: $(builddir)/phar.php $(builddir)/phar.phar
 


### PR DESCRIPTION
I guess no one noticed this error because the source `phar_path_check.c` normally never remade but if you get a different timestamp (older) than the target `phar_path_check.re` (as a result of source archive unpacking), you'll get this error:

```
re2c: error: cannot open source file: ext/phar/phar_path_check.re
make: *** [Makefile:193: /usr/src/php/ext/phar/phar_path_check.c] Error 1
```

Tries to look for `ext/phar/phar_path_check.re` from `/usr/src/php/ext/phar/`.

https://bugs.php.net/bug.php?id=75587