### PR TITLE
Fix #75607 - UNREF trait property values before comparing

### DIFF
--- a/Zend/tests/traits/bug75607.phpt
+++ b/Zend/tests/traits/bug75607.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug #75607 (Comparision of initial static properties failing)
+--FILE--
+<?php
+
+trait T1
+{
+	public static $prop1 = 1;
+}
+
+class Base
+{
+	public static $prop1 = 1;
+}
+
+class Child extends base
+{
+	use T1;
+}
+
+echo "DONE";
+
+?>
+--EXPECT--
+DONE

--- a/Zend/tests/traits/bug75607a.phpt
+++ b/Zend/tests/traits/bug75607a.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Bug #75607 (Comparision of initial static properties failing)
+--FILE--
+<?php
+
+trait T1
+{
+	public static $prop1 = 1;
+}
+
+trait T2
+{
+	public static $prop1 = 1;
+}
+
+class Base
+{
+	use T1;
+}
+
+class Child extends base
+{
+	
+}
+
+class Grand extends Child
+{
+	use T2;
+}
+
+$c = new Grand();
+var_dump($c::$prop1);
+
+?>
+--EXPECT--
+int(1)

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1569,8 +1569,13 @@ static void zend_do_traits_property_binding(zend_class_entry *ce) /* {{{ */
 						== (flags & (ZEND_ACC_PPP_MASK | ZEND_ACC_STATIC))) {
 						/* flags are identical, now the value needs to be checked */
 						if (flags & ZEND_ACC_STATIC) {
-							not_compatible = fast_is_not_identical_function(&ce->default_static_members_table[coliding_prop->offset],
-											  &ce->traits[i]->default_static_members_table[property_info->offset]);
+							if (Z_ISREF(ce->default_static_members_table[coliding_prop->offset])) {
+								not_compatible = fast_is_not_identical_function(Z_REFVAL(ce->default_static_members_table[coliding_prop->offset]),
+												  &ce->traits[i]->default_static_members_table[property_info->offset]);
+							} else {
+								not_compatible = fast_is_not_identical_function(&ce->default_static_members_table[coliding_prop->offset],
+												  &ce->traits[i]->default_static_members_table[property_info->offset]);
+							}
 						} else {
 							not_compatible = fast_is_not_identical_function(&ce->default_properties_table[OBJ_PROP_TO_NUM(coliding_prop->offset)],
 											  &ce->traits[i]->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)]);


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=75607

I've used the same logic that is already on master from #2779 and applied it to references for this fix.