### PR TITLE
The RAND_RANGE() macro is immediately overwriting rnd_idx

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5479,7 +5479,6 @@ static void php_string_shuffle(char *str, zend_long len) /* {{{ */
 	n_left = n_elems;
 
 	while (--n_left) {
-		rnd_idx = php_rand();
 		RAND_RANGE(rnd_idx, 0, n_left, PHP_RAND_MAX);
 		if (rnd_idx != n_left) {
 			temp = str[n_left];


### PR DESCRIPTION
I removed the ```php_rand()``` and not the ```RAND_RANGE()``` because a code search showed that the first was not done anywhere else and the macro was in fact in use at many places.

Tests still pass, I think this is a good one. Also ```str_shuffle()``` gets noticeably faster.

Before:

```bash
$ time php -r 'for ($i=0; $i<10000000; $i++) str_shuffle("supercalifragilisticexpialidocious");'

real	0m13,330s
user	0m13,329s
sys	0m0,000s
```

After:

```bash
$ time ./sapi/cli/php -r 'for ($i=0; $i<10000000; $i++) str_shuffle("supercalifragilisticexpialidocious");'

real	0m9,884s
user	0m9,879s
sys	0m0,004s
```