### PR TITLE
Potential double line counter increment

### DIFF
--- a/ext/spl/internal/splfileobject.inc
+++ b/ext/spl/internal/splfileobject.inc
@@ -320,9 +320,6 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
 			$this->freeLine();
 			throw new RuntimeException("Cannot read from file " . $this->fname);
 		}
-		if ($this->line) {
-			$this->lnum++;
-		}
 		$this->freeLine();
 		$this->line = fgets($this->fp, $this->max_len);
 		return $this->line;


### PR DESCRIPTION
Line counter increment is already taken care of in fget* handlers, where the actual fget* functions are called.
This double increment only occurs after initial read, shifting phase between the line counter and the actual file pointer.