### PR TITLE
Support SOURCE_DATE_EPOCH for Build Date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1282,7 +1282,8 @@ fi
 EXTRA_LDFLAGS="$EXTRA_LDFLAGS $PHP_LDFLAGS"
 EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $PHP_LDFLAGS"
 
-PHP_BUILD_DATE=`date '+%Y-%m-%d'`
+# SOURCE_DATE_EPOCH for reproducible builds https://reproducible-builds.org/specs/source-date-epoch/
+PHP_BUILD_DATE=`date --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d`
 AC_DEFINE_UNQUOTED(PHP_BUILD_DATE,"$PHP_BUILD_DATE",[PHP build date])
 
 PHP_UNAME=`uname -a | xargs`


### PR DESCRIPTION
When checking for reproducible builds php is build twice, once with the
current date and once with a date in the future. To keep the build date
supported and reproducible builds possible, SOURCE_DATE_EPOCH is
introduced which can be set to the same epoch value for both builds.

Fixes Bug #69727