### PR TITLE
fix coding error of glob.c

### DIFF
--- a/win32/glob.c
+++ b/win32/glob.c
@@ -837,7 +837,7 @@ g_opendir(str, pglob)
 	char buf[MAXPATHLEN];
 
 	if (!*str)
-		strlcpy(buf, ".", sizeof buf);
+		strlcpy(buf, ".", sizeof(buf));
 	else {
 		if (g_Ctoc(str, buf, sizeof(buf)))
 			return(NULL);


### PR DESCRIPTION
I think there is a program bug in line 840. The original version is sizeof buf, I change it to sizeof(buf).