### PR TITLE
Small improvement for explicit_bzero :

### DIFF
--- a/main/explicit_bzero.c
+++ b/main/explicit_bzero.c
@@ -30,15 +30,19 @@
 
 #include <string.h>
 
-__attribute__((weak)) void
-__explicit_bzero_hook(void *dst, size_t siz)
-{
-}
-
 PHPAPI void php_explicit_bzero(void *dst, size_t siz)
 {
+#ifdef __GNUC__
 	memset(dst, 0, siz);
 	__explicit_bzero_hook(dst, siz);
+	asm __volatile__("" :: "r"(dst) : "memory"); 
+#else
+	size_t i = 0;
+	volatile unsigned char *buf = (volatile unsigned char *)dst;
+
+	for (; i < siz; i ++)
+		buf[i] = 0;
+#endif
 }
 #endif
 /*


### PR DESCRIPTION
- In case weak symbols are not supported.
- In case the hook is optimized somehow, having a simple barrier.