### PR TITLE
Namespace-scoped declares

### DIFF
--- a/Zend/tests/namespace_declares/basic.phpt
+++ b/Zend/tests/namespace_declares/basic.phpt
@@ -1,0 +1,45 @@
+--TEST--
+namespace_declare(): Basic usage
+--FILE--
+<?php
+
+namespace_declare('Foo', ['strict_types' => 1]);
+namespace_declare('Foo\Bar', ['strict_types' => 0]);
+
+function test($namespace, $extra = '') {
+    echo $namespace, ": ";
+    eval(<<<PHP
+$extra
+namespace $namespace;
+
+try {
+    echo strlen(10), "\n";
+} catch (\Error \$e) {
+    echo \$e->getMessage(), "\n";
+}
+PHP
+    );
+}
+
+test('Foo');
+test('Foo\Bar');
+test('Foo\NotBar');
+test('Foo\Bar\Baz');
+test('Foobar');
+test('foo');
+test('foo\BAR');
+
+test('Foo', 'declare(strict_types=0);');
+test('Foo\Bar', 'declare(strict_types=1);');
+
+?>
+--EXPECT--
+Foo: strlen() expects parameter 1 to be string, integer given
+Foo\Bar: 2
+Foo\NotBar: strlen() expects parameter 1 to be string, integer given
+Foo\Bar\Baz: 2
+Foobar: 2
+foo: strlen() expects parameter 1 to be string, integer given
+foo\BAR: 2
+Foo: 2
+Foo\Bar: strlen() expects parameter 1 to be string, integer given

--- a/Zend/tests/namespace_declares/basic.phpt
+++ b/Zend/tests/namespace_declares/basic.phpt
@@ -34,12 +34,12 @@ test('Foo\Bar', 'declare(strict_types=1);');
 
 ?>
 --EXPECT--
-Foo: strlen() expects parameter 1 to be string, integer given
+Foo: strlen() expects parameter 1 to be string, int given
 Foo\Bar: 2
-Foo\NotBar: strlen() expects parameter 1 to be string, integer given
+Foo\NotBar: strlen() expects parameter 1 to be string, int given
 Foo\Bar\Baz: 2
 Foobar: 2
-foo: strlen() expects parameter 1 to be string, integer given
+foo: strlen() expects parameter 1 to be string, int given
 foo\BAR: 2
 Foo: 2
-Foo\Bar: strlen() expects parameter 1 to be string, integer given
+Foo\Bar: strlen() expects parameter 1 to be string, int given

--- a/Zend/tests/namespace_declares/declare_after_use_error.phpt
+++ b/Zend/tests/namespace_declares/declare_after_use_error.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Cannot use namespace_declare() after namespace was used
+--FILE--
+<?php
+
+eval(<<<'PHP'
+namespace Foo\Bar;
+PHP
+);
+
+try {
+    namespace_declare('Foo\Bar', ['strict_types' => 1]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    namespace_declare('Foo', ['strict_types' => 1]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Cannot add declares to namespace "Foo\Bar", as it is already in use
+Cannot add declares to namespace "Foo", as it is already in use

--- a/Zend/tests/namespace_declares/declare_after_use_error_same_file.phpt
+++ b/Zend/tests/namespace_declares/declare_after_use_error_same_file.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Cannot add namespace_declare()s to namespace in current file
+--FILE--
+<?php
+
+namespace Foo\Bar;
+use Error;
+
+try {
+    namespace_declare('Foo\Bar', ['strict_types' => 1]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Cannot add declares to namespace "Foo\Bar", as it is already in use

--- a/Zend/tests/namespace_declares/errors.phpt
+++ b/Zend/tests/namespace_declares/errors.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Errors thrown by namespace_declare()
+--FILE--
+<?php
+
+$args = [
+    ["", []],
+    ["\\Foo", []],
+    ["Foo\\", []],
+    ["Foo", ["abc"]],
+    ["Foo", ["encoding" => "utf-8"]],
+    ["Foo", ["ticks" => 12.7]],
+    ["Foo", ["ticks" => -1]],
+    ["Foo", ["strict_types" => "on"]],
+    ["Foo", ["strict_types" => -1]],
+];
+
+foreach ($args as [$namespace, $declares]) {
+    try {
+        namespace_declare($namespace, $declares);
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+namespace_declare("Foo", ["ticks" => 0]);
+try {
+    namespace_declare("Foo", ["ticks" => 0]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Namespace cannot be empty
+Namespace cannot start with "\"
+Namespace cannot end with "\"
+Declare directive array must have string keys
+Cannot use "encoding" in namespace declare
+Value of "ticks" must be a non-negative integer
+Value of "ticks" must be a non-negative integer
+Value of "strict_types" must be 0 or 1
+Value of "strict_types" must be 0 or 1
+Declares for namespace "Foo" already defined

--- a/Zend/tests/namespace_declares/inconsistent_declares_error.phpt
+++ b/Zend/tests/namespace_declares/inconsistent_declares_error.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Using inconsistent namespace declares in the same file
+--FILE--
+<?php
+
+namespace_declare('Foo', ['strict_types' => 1]);
+namespace_declare('Bar', ['strict_types' => 0]);
+
+eval(<<<'PHP'
+namespace Foo;
+namespace Bar;
+PHP
+);
+
+?>
+--EXPECTF--
+Fatal error: Namespaced declares for namespace "Bar" are inconsistent with other namespaces in this file in %s on line %d

--- a/Zend/tests/namespace_declares/inconsistent_declares_error_global.phpt
+++ b/Zend/tests/namespace_declares/inconsistent_declares_error_global.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Using inconsistent namespace declares in the same file (including global namespace first)
+--FILE--
+<?php
+
+namespace_declare('Foo', ['strict_types' => 1]);
+
+eval(<<<'PHP'
+namespace {}
+namespace Foo {}
+PHP
+);
+
+?>
+--EXPECTF--
+Fatal error: Namespaced declares for namespace "Foo" are inconsistent with other namespaces in this file in %s on line %d

--- a/Zend/tests/namespace_declares/inconsistent_declares_error_global2.phpt
+++ b/Zend/tests/namespace_declares/inconsistent_declares_error_global2.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Using inconsistent namespace declares in the same file (including global namespace last)
+--FILE--
+<?php
+
+namespace_declare('Foo', ['strict_types' => 1]);
+
+eval(<<<'PHP'
+namespace Foo {}
+namespace {}
+PHP
+);
+
+?>
+--EXPECTF--
+Fatal error: Namespaced declares for namespace "" are inconsistent with other namespaces in this file in %s on line %d

--- a/Zend/tests/namespace_declares/order_is_irrelevant.phpt
+++ b/Zend/tests/namespace_declares/order_is_irrelevant.phpt
@@ -1,0 +1,32 @@
+--TEST--
+It does not matter whether declares for child namespaces are added first
+--FILE--
+<?php
+
+namespace_declare('Foo\Bar\Baz', ['strict_types' => 1]);
+namespace_declare('Foo\Bar', ['strict_types' => 0]);
+namespace_declare('Foo', ['strict_types' => 1]);
+
+function test($namespace) {
+    echo $namespace, ": ";
+    eval(<<<PHP
+namespace $namespace;
+
+try {
+    echo strlen(10), "\n";
+} catch (\Error \$e) {
+    echo \$e->getMessage(), "\n";
+}
+PHP
+    );
+}
+
+test('Foo');
+test('Foo\Bar');
+test('Foo\Bar\Baz');
+
+?>
+--EXPECT--
+Foo: strlen() expects parameter 1 to be string, integer given
+Foo\Bar: 2
+Foo\Bar\Baz: strlen() expects parameter 1 to be string, integer given

--- a/Zend/tests/namespace_declares/order_is_irrelevant.phpt
+++ b/Zend/tests/namespace_declares/order_is_irrelevant.phpt
@@ -27,6 +27,6 @@ test('Foo\Bar\Baz');
 
 ?>
 --EXPECT--
-Foo: strlen() expects parameter 1 to be string, integer given
+Foo: strlen() expects parameter 1 to be string, int given
 Foo\Bar: 2
-Foo\Bar\Baz: strlen() expects parameter 1 to be string, integer given
+Foo\Bar\Baz: strlen() expects parameter 1 to be string, int given

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -88,11 +88,6 @@ static ZEND_FUNCTION(namespace_declare);
 
 #include "zend_builtin_functions_arginfo.h"
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_namespace_declare, 0, 0, 2)
-	ZEND_ARG_INFO(0, namespace)
-	ZEND_ARG_INFO(0, declares)
-ZEND_END_ARG_INFO()
-
 /* }}} */
 
 static const zend_function_entry builtin_functions[] = { /* {{{ */

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -114,3 +114,5 @@ function gc_enable(): void {}
 function gc_disable(): void {}
 
 function gc_status(): array {}
+
+function namespace_declare(string $namespace, array $declares): void {}

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -196,3 +196,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_gc_disable arginfo_gc_enable
 
 #define arginfo_gc_status arginfo_get_included_files
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_namespace_declare, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, declares, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -363,6 +363,7 @@ void zend_file_context_begin(zend_file_context *prev_context) /* {{{ */
 	FC(in_namespace) = 0;
 	FC(has_bracketed_namespaces) = 0;
 	FC(declarables).ticks = 0;
+	FC(declarables).strict_types = 0;
 	zend_hash_init(&FC(seen_symbols), 8, NULL, NULL, 0);
 }
 /* }}} */
@@ -5446,6 +5447,7 @@ void zend_compile_declare(zend_ast *ast) /* {{{ */
 				zend_error_noreturn(E_COMPILE_ERROR, "strict_types declaration must have 0 or 1 as its value");
 			}
 
+			FC(declarables).strict_types = Z_LVAL(value_zv);
 			if (Z_LVAL(value_zv) == 1) {
 				CG(active_op_array)->fn_flags |= ZEND_ACC_STRICT_TYPES;
 			}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -507,6 +507,9 @@ void zend_init_compiler_data_structures(void) /* {{{ */
 	CG(encoding_declared) = 0;
 	CG(memoized_exprs) = NULL;
 	CG(memoize_mode) = 0;
+	CG(last_ns_declares) = NULL;
+	CG(last_namespaces) = NULL;
+	CG(last_num_namespaces) = 0;
 }
 /* }}} */
 
@@ -565,6 +568,9 @@ void shutdown_compiler(void) /* {{{ */
 		zend_hash_destroy(CG(delayed_autoloads));
 		FREE_HASHTABLE(CG(delayed_autoloads));
 		CG(delayed_autoloads) = NULL;
+	}
+	if (CG(last_namespaces)) {
+		efree(CG(last_namespaces));
 	}
 }
 /* }}} */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -708,7 +708,7 @@ BEGIN_EXTERN_C()
 void init_compiler(void);
 void shutdown_compiler(void);
 void zend_init_compiler_data_structures(void);
-const zend_declarables *zend_get_namespace_declares(zend_string *namespace_lc);
+ZEND_API const zend_declarables *zend_get_namespace_declares(zend_string *namespace_lc);
 
 void zend_oparray_context_begin(zend_oparray_context *prev_context);
 void zend_oparray_context_end(zend_oparray_context *prev_context);
@@ -1095,6 +1095,9 @@ END_EXTERN_C()
 
 /* this flag is set when compiler invoked during preloading in separate process */
 #define ZEND_COMPILE_PRELOAD_IN_CHILD           (1<<17)
+
+/* collect last_ns_declares, last_namespaces, last_num_namespaces, for use by opcache */
+#define ZEND_COMPILE_COLLECT_NS_INFO			(1<<11)
 
 /* The default value for CG(compiler_options) */
 #define ZEND_COMPILE_DEFAULT					ZEND_COMPILE_HANDLE_OP_ARRAY

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -98,9 +98,15 @@ static zend_always_inline znode *zend_ast_get_znode(zend_ast *ast) {
 	return &((zend_ast_znode *) ast)->node;
 }
 
+/* Used in the declares_set field for declares that were explicitly specified, rather
+ * than just being defaults */
+#define ZEND_DECLARE_TICKS        (1 << 0)
+#define ZEND_DECLARE_STRICT_TYPES (1 << 1)
+
 typedef struct _zend_declarables {
 	zend_long ticks;
 	zend_bool strict_types;
+	uint32_t declares_set;
 } zend_declarables;
 
 /* Compilation context that is different for each file, but shared between op arrays. */
@@ -110,6 +116,7 @@ typedef struct _zend_file_context {
 	zend_string *current_namespace;
 	zend_bool in_namespace;
 	zend_bool has_bracketed_namespaces;
+	const zend_declarables *ns_declares;
 
 	HashTable *imports;
 	HashTable *imports_function;
@@ -701,6 +708,7 @@ BEGIN_EXTERN_C()
 void init_compiler(void);
 void shutdown_compiler(void);
 void zend_init_compiler_data_structures(void);
+const zend_declarables *zend_get_namespace_declares(zend_string *namespace_lc);
 
 void zend_oparray_context_begin(zend_oparray_context *prev_context);
 void zend_oparray_context_end(zend_oparray_context *prev_context);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1097,7 +1097,7 @@ END_EXTERN_C()
 #define ZEND_COMPILE_PRELOAD_IN_CHILD           (1<<17)
 
 /* collect last_ns_declares, last_namespaces, last_num_namespaces, for use by opcache */
-#define ZEND_COMPILE_COLLECT_NS_INFO			(1<<11)
+#define ZEND_COMPILE_COLLECT_NS_INFO			(1<<18)
 
 /* The default value for CG(compiler_options) */
 #define ZEND_COMPILE_DEFAULT					ZEND_COMPILE_HANDLE_OP_ARRAY

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -100,6 +100,7 @@ static zend_always_inline znode *zend_ast_get_znode(zend_ast *ast) {
 
 typedef struct _zend_declarables {
 	zend_long ticks;
+	zend_bool strict_types;
 } zend_declarables;
 
 /* Compilation context that is different for each file, but shared between op arrays. */

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -174,7 +174,9 @@ void init_executor(void) /* {{{ */
 
 	EG(fake_scope) = NULL;
 	EG(trampoline).common.function_name = NULL;
+
 	EG(namespace_declares) = NULL;
+	EG(computed_namespace_declares) = NULL;
 
 	EG(ht_iterators_count) = sizeof(EG(ht_iterators_slots)) / sizeof(HashTableIterator);
 	EG(ht_iterators_used) = 0;
@@ -418,6 +420,11 @@ void shutdown_executor(void) /* {{{ */
 		if (EG(namespace_declares)) {
 			zend_hash_destroy(EG(namespace_declares));
 			FREE_HASHTABLE(EG(namespace_declares));
+		}
+
+		if (EG(computed_namespace_declares)) {
+			zend_hash_destroy(EG(computed_namespace_declares));
+			FREE_HASHTABLE(EG(computed_namespace_declares));
 		}
 	}
 

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -174,6 +174,7 @@ void init_executor(void) /* {{{ */
 
 	EG(fake_scope) = NULL;
 	EG(trampoline).common.function_name = NULL;
+	EG(namespace_declares) = NULL;
 
 	EG(ht_iterators_count) = sizeof(EG(ht_iterators_slots)) / sizeof(HashTableIterator);
 	EG(ht_iterators_used) = 0;
@@ -412,6 +413,11 @@ void shutdown_executor(void) /* {{{ */
 
 		if (EG(ht_iterators) != EG(ht_iterators_slots)) {
 			efree(EG(ht_iterators));
+		}
+
+		if (EG(namespace_declares)) {
+			zend_hash_destroy(EG(namespace_declares));
+			FREE_HASHTABLE(EG(namespace_declares));
 		}
 	}
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -239,6 +239,7 @@ struct _zend_executor_globals {
 	zend_bool exception_ignore_args;
 
 	HashTable *namespace_declares;
+	HashTable *computed_namespace_declares;
 
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -121,6 +121,7 @@ struct _zend_compiler_globals {
 	HashTable *memoized_exprs;
 	int memoize_mode;
 
+<<<<<<< HEAD
 	void   *map_ptr_base;
 	size_t  map_ptr_size;
 	size_t  map_ptr_last;
@@ -129,6 +130,18 @@ struct _zend_compiler_globals {
 	HashTable *delayed_autoloads;
 
 	uint32_t rtd_key_counter;
+=======
+#ifdef ZTS
+	zval **static_members_table;
+	int last_static_member;
+#endif
+
+	/* Namespace information from last compilation, only collected if
+	 * ZEND_COMPILE_COLLECT_NS_INFO is enabled. */
+	const zend_declarables *last_ns_declares;
+	zend_string **last_namespaces;
+	uint32_t last_num_namespaces;
+>>>>>>> Add opcache support for namespaced declares
 };
 
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -121,7 +121,6 @@ struct _zend_compiler_globals {
 	HashTable *memoized_exprs;
 	int memoize_mode;
 
-<<<<<<< HEAD
 	void   *map_ptr_base;
 	size_t  map_ptr_size;
 	size_t  map_ptr_last;
@@ -130,18 +129,12 @@ struct _zend_compiler_globals {
 	HashTable *delayed_autoloads;
 
 	uint32_t rtd_key_counter;
-=======
-#ifdef ZTS
-	zval **static_members_table;
-	int last_static_member;
-#endif
 
 	/* Namespace information from last compilation, only collected if
 	 * ZEND_COMPILE_COLLECT_NS_INFO is enabled. */
 	const zend_declarables *last_ns_declares;
 	zend_string **last_namespaces;
 	uint32_t last_num_namespaces;
->>>>>>> Add opcache support for namespaced declares
 };
 
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -238,6 +238,8 @@ struct _zend_executor_globals {
 
 	zend_bool exception_ignore_args;
 
+	HashTable *namespace_declares;
+
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };
 

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1661,25 +1661,6 @@ static void zend_accel_init_auto_globals(void)
 	}
 }
 
-static inline zend_bool check_ns_declares_consistency(zend_persistent_script *script) {
-	uint32_t i;
-
-	if (!script->ns_declares) {
-		return 1;
-	}
-
-	/* Check that all namespace declares are identical */
-	for (i = 0; i < script->num_namespaces; i++) {
-		zend_string *ns = script->namespaces[i];
-		const zend_declarables *ns_declares = zend_get_namespace_declares(ns);
-		if (memcmp(script->ns_declares, ns_declares, sizeof(zend_declarables)) != 0) {
-			return 0;
-		}
-	}
-
-	return 1;
-}
-
 static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handle, int type, const char *key, zend_op_array **op_array_p)
 {
 	zend_persistent_script *new_persistent_script;
@@ -2126,7 +2107,7 @@ zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type)
 		}
 	}
 
-	if (persistent_script && !check_ns_declares_consistency(persistent_script)) {
+	if (persistent_script && !zend_accel_check_ns_declares_consistency(persistent_script)) {
 		/* The namespace declares for this script changed, invalidate it */
 		zend_shared_alloc_lock();
 		if (!persistent_script->corrupted) {

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1771,14 +1771,6 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 		return NULL;
 	}
 
-	/* Take ownership of namespace information */
-	new_persistent_script->ns_declares = CG(last_ns_declares);
-	new_persistent_script->namespaces = CG(last_namespaces);
-	new_persistent_script->num_namespaces = CG(last_num_namespaces);
-	CG(last_ns_declares) = NULL;
-	CG(last_namespaces) = NULL;
-	CG(last_num_namespaces) = 0;
-
 	/* Build the persistent_script structure.
 	   Here we aren't sure we would store it, but we will need it
 	   further anyway.
@@ -1793,6 +1785,14 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 			(uint32_t)-1;
 
 	efree(op_array); /* we have valid persistent_script, so it's safe to free op_array */
+
+	/* Take ownership of namespace information */
+	new_persistent_script->ns_declares = CG(last_ns_declares);
+	new_persistent_script->namespaces = CG(last_namespaces);
+	new_persistent_script->num_namespaces = CG(last_num_namespaces);
+	CG(last_ns_declares) = NULL;
+	CG(last_namespaces) = NULL;
+	CG(last_num_namespaces) = 0;
 
     /* Fill in the ping_auto_globals_mask for the new script. If jit for auto globals is enabled we
        will have to ping the used auto global variables before execution */

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1661,6 +1661,25 @@ static void zend_accel_init_auto_globals(void)
 	}
 }
 
+static inline zend_bool check_ns_declares_consistency(zend_persistent_script *script) {
+	uint32_t i;
+
+	if (!script->ns_declares) {
+		return 1;
+	}
+
+	/* Check that all namespace declares are identical */
+	for (i = 0; i < script->num_namespaces; i++) {
+		zend_string *ns = script->namespaces[i];
+		const zend_declarables *ns_declares = zend_get_namespace_declares(ns);
+		if (memcmp(script->ns_declares, ns_declares, sizeof(zend_declarables)) != 0) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
 static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handle, int type, const char *key, zend_op_array **op_array_p)
 {
 	zend_persistent_script *new_persistent_script;
@@ -1747,6 +1766,7 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 		CG(compiler_options) |= ZEND_COMPILE_DELAYED_BINDING;
 		CG(compiler_options) |= ZEND_COMPILE_NO_CONSTANT_SUBSTITUTION;
 		CG(compiler_options) |= ZEND_COMPILE_IGNORE_OTHER_FILES;
+		CG(compiler_options) |= ZEND_COMPILE_COLLECT_NS_INFO;
 		if (ZCG(accel_directives).file_cache) {
 			CG(compiler_options) |= ZEND_COMPILE_WITH_FILE_CACHE;
 		}
@@ -1769,6 +1789,14 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 		}
 		return NULL;
 	}
+
+	/* Take ownership of namespace information */
+	new_persistent_script->ns_declares = CG(last_ns_declares);
+	new_persistent_script->namespaces = CG(last_namespaces);
+	new_persistent_script->num_namespaces = CG(last_num_namespaces);
+	CG(last_ns_declares) = NULL;
+	CG(last_namespaces) = NULL;
+	CG(last_num_namespaces) = 0;
 
 	/* Build the persistent_script structure.
 	   Here we aren't sure we would store it, but we will need it
@@ -2096,6 +2124,23 @@ zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type)
 			zend_shared_alloc_unlock();
 			persistent_script = NULL;
 		}
+	}
+
+	if (persistent_script && !check_ns_declares_consistency(persistent_script)) {
+		/* The namespace declares for this script changed, invalidate it */
+		zend_shared_alloc_lock();
+		if (!persistent_script->corrupted) {
+			persistent_script->corrupted = 1;
+			persistent_script->timestamp = 0;
+			ZSMMG(wasted_shared_memory) += persistent_script->dynamic_members.memory_consumption;
+			if (ZSMMG(memory_exhausted)) {
+				zend_accel_restart_reason reason =
+					zend_accel_hash_is_full(&ZCSG(hash)) ? ACCEL_RESTART_HASH : ACCEL_RESTART_OOM;
+				zend_accel_schedule_restart_if_necessary(reason);
+			}
+		}
+		zend_shared_alloc_unlock();
+		persistent_script = NULL;
 	}
 
 	/* Check the second level cache */

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -118,6 +118,10 @@ typedef struct _zend_persistent_script {
 	zend_bool      is_phar;
 	zend_bool      empty;
 
+	const zend_declarables *ns_declares;
+	zend_string  **namespaces;
+	uint32_t       num_namespaces;
+
 	void          *mem;                    /* shared memory area used by script structures */
 	size_t         size;                   /* size of used shared memory */
 	void          *arena_mem;              /* part that should be copied into process */

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -921,3 +921,22 @@ unsigned int zend_accel_script_checksum(zend_persistent_script *persistent_scrip
 	}
 	return checksum;
 }
+
+zend_bool zend_accel_check_ns_declares_consistency(zend_persistent_script *script) {
+	uint32_t i;
+
+	if (!script->ns_declares) {
+		return 1;
+	}
+
+	/* Check that all namespace declares are identical */
+	for (i = 0; i < script->num_namespaces; i++) {
+		zend_string *ns = script->namespaces[i];
+		const zend_declarables *ns_declares = zend_get_namespace_declares(ns);
+		if (memcmp(script->ns_declares, ns_declares, sizeof(zend_declarables)) != 0) {
+			return 0;
+		}
+	}
+
+	return 1;
+}

--- a/ext/opcache/zend_accelerator_util_funcs.h
+++ b/ext/opcache/zend_accelerator_util_funcs.h
@@ -38,5 +38,6 @@ zend_op_array* zend_accel_load_script(zend_persistent_script *persistent_script,
 unsigned int zend_adler32(unsigned int checksum, unsigned char *buf, uint32_t len);
 
 unsigned int zend_accel_script_checksum(zend_persistent_script *persistent_script);
+zend_bool zend_accel_check_ns_declares_consistency(zend_persistent_script *script);
 
 #endif /* ZEND_ACCELERATOR_UTIL_FUNCS_H */

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -799,6 +799,25 @@ static void zend_file_cache_serialize_class(zval                     *zv,
 	ZEND_MAP_PTR_INIT(ce->static_members_table, &ce->default_static_members_table);
 }
 
+static void zend_file_cache_serialize_ns_info(
+	zend_persistent_script *script, zend_file_cache_metainfo *info, void *buf)
+{
+	SERIALIZE_PTR(script->ns_declares);
+
+	if (script->namespaces) {
+		uint32_t i;
+		zend_string **namespaces;
+
+		SERIALIZE_PTR(script->namespaces);
+		namespaces = script->namespaces;
+		UNSERIALIZE_PTR(namespaces);
+
+		for (i = 0; i < script->num_namespaces; i++) {
+			SERIALIZE_STR(namespaces[i]);
+		}
+	}
+}
+
 static void zend_file_cache_serialize(zend_persistent_script   *script,
                                       zend_file_cache_metainfo *info,
                                       void                     *buf)
@@ -820,6 +839,7 @@ static void zend_file_cache_serialize(zend_persistent_script   *script,
 	zend_file_cache_serialize_hash(&new_script->script.class_table, script, info, buf, zend_file_cache_serialize_class);
 	zend_file_cache_serialize_hash(&new_script->script.function_table, script, info, buf, zend_file_cache_serialize_func);
 	zend_file_cache_serialize_op_array(&new_script->script.main_op_array, script, info, buf);
+	zend_file_cache_serialize_ns_info(new_script, info, buf);
 
 	SERIALIZE_PTR(new_script->arena_mem);
 	new_script->mem = NULL;
@@ -1521,6 +1541,36 @@ static void zend_file_cache_unserialize(zend_persistent_script  *script,
 	UNSERIALIZE_PTR(script->arena_mem);
 }
 
+static void zend_file_cache_unserialize_ns_info(zend_persistent_script *script, void *buf)
+{
+	uint32_t i;
+
+	/* We're not unserializing into SHM right now */
+	script->mem = buf;
+	script->corrupted = 1;
+
+	UNSERIALIZE_PTR(script->ns_declares);
+	UNSERIALIZE_PTR(script->namespaces);
+	for (i = 0; i < script->num_namespaces; i++) {
+		UNSERIALIZE_STR(script->namespaces[i]);
+	}
+}
+
+static void zend_file_cache_migrate_ns_info_to_shm(
+	zend_persistent_script *script, void *old_mem, void *new_mem)
+{
+#define TO_SHM(ptr) \
+	if (ptr) (ptr) = (void *) ((char *) (ptr) - (char *) old_mem + (char *) new_mem)
+
+	uint32_t i;
+	TO_SHM(script->ns_declares);
+	TO_SHM(script->namespaces);
+	for (i = 0; i < script->num_namespaces; i++) {
+		script->namespaces[i] = accel_new_interned_string(script->namespaces[i]);
+	}
+#undef TO_SHM
+}
+
 zend_persistent_script *zend_file_cache_script_load(zend_file_handle *file_handle)
 {
 	zend_string *full_path = file_handle->opened_path;
@@ -1623,6 +1673,20 @@ zend_persistent_script *zend_file_cache_script_load(zend_file_handle *file_handl
 		return NULL;
 	}
 
+	{
+		/* Unserialize NS info only and check consistency */
+		zend_persistent_script *tmp_script
+			= (zend_persistent_script *) ((char *) mem + info.script_offset);
+		ZCG(mem) = (char *) mem + info.mem_size;
+		zend_file_cache_unserialize_ns_info(tmp_script, mem);
+		if (!zend_accel_check_ns_declares_consistency(tmp_script)) {
+			unlink(filename);
+			zend_arena_release(&CG(arena), checkpoint);
+			efree(filename);
+			return NULL;
+		}
+	}
+
 	if (!file_cache_only &&
 	    !ZCSG(restart_in_progress) &&
 		!ZSMMG(memory_exhausted) &&
@@ -1697,6 +1761,7 @@ use_process_mem:
 	script->corrupted = 0;
 
 	if (cache_it) {
+		zend_file_cache_migrate_ns_info_to_shm(script, mem, buf);
 		ZCSG(map_ptr_last) = CG(map_ptr_last);
 		script->dynamic_members.checksum = zend_accel_script_checksum(script);
 		script->dynamic_members.last_used = ZCG(request_time);

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1081,7 +1081,8 @@ static void zend_accel_persist_class_table(HashTable *class_table)
 static void zend_accel_persist_namespace_info(zend_persistent_script *script)
 {
 	if (script->ns_declares) {
-		script->ns_declares = zend_accel_memdup(script->ns_declares, sizeof(zend_declarables));
+		script->ns_declares = zend_shared_memdup(
+			(void *) script->ns_declares, sizeof(zend_declarables));
 	}
 
 	if (script->namespaces) {
@@ -1089,7 +1090,8 @@ static void zend_accel_persist_namespace_info(zend_persistent_script *script)
 		for (i = 0; i < script->num_namespaces; i++) {
 			zend_accel_store_interned_string(script->namespaces[i]);
 		}
-		zend_accel_store(script->namespaces, sizeof(zend_string *) * script->num_namespaces);
+		script->namespaces = zend_shared_memdup_free(
+			script->namespaces, sizeof(zend_string *) * script->num_namespaces);
 	}
 }
 

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1078,6 +1078,21 @@ static void zend_accel_persist_class_table(HashTable *class_table)
 	} ZEND_HASH_FOREACH_END();
 }
 
+static void zend_accel_persist_namespace_info(zend_persistent_script *script)
+{
+	if (script->ns_declares) {
+		script->ns_declares = zend_accel_memdup(script->ns_declares, sizeof(zend_declarables));
+	}
+
+	if (script->namespaces) {
+		uint32_t i;
+		for (i = 0; i < script->num_namespaces; i++) {
+			zend_accel_store_interned_string(script->namespaces[i]);
+		}
+		zend_accel_store(script->namespaces, sizeof(zend_string *) * script->num_namespaces);
+	}
+}
+
 zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script, const char **key, unsigned int key_length, int for_shm)
 {
 	Bucket *p;
@@ -1127,6 +1142,7 @@ zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script
 		zend_persist_op_array(&p->val);
 	} ZEND_HASH_FOREACH_END();
 	zend_persist_op_array_ex(&script->script.main_op_array, script);
+	zend_accel_persist_namespace_info(script);
 
 	if (for_shm) {
 		ZCSG(map_ptr_last) = CG(map_ptr_last);

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -521,7 +521,7 @@ static void zend_accel_persist_namespace_info_calc(zend_persistent_script *scrip
 	if (script->namespaces) {
 		uint32_t i;
 		for (i = 0; i < script->num_namespaces; i++) {
-			ADD_INTERNED_STRING(script->namespaces[i], 0);
+			ADD_INTERNED_STRING(script->namespaces[i]);
 		}
 		ADD_SIZE(sizeof(zend_string *) * script->num_namespaces);
 	}

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -512,6 +512,21 @@ static void zend_accel_persist_class_table_calc(HashTable *class_table)
 	} ZEND_HASH_FOREACH_END();
 }
 
+static void zend_accel_persist_namespace_info_calc(zend_persistent_script *script)
+{
+	if (script->ns_declares) {
+		ADD_SIZE(sizeof(zend_declarables));
+	}
+
+	if (script->namespaces) {
+		uint32_t i;
+		for (i = 0; i < script->num_namespaces; i++) {
+			ADD_INTERNED_STRING(script->namespaces[i], 0);
+		}
+		ADD_SIZE(sizeof(zend_string *) * script->num_namespaces);
+	}
+}
+
 uint32_t zend_accel_script_persist_calc(zend_persistent_script *new_persistent_script, const char *key, unsigned int key_length, int for_shm)
 {
 	Bucket *p;
@@ -554,6 +569,7 @@ uint32_t zend_accel_script_persist_calc(zend_persistent_script *new_persistent_s
 		zend_persist_op_array_calc(&p->val);
 	} ZEND_HASH_FOREACH_END();
 	zend_persist_op_array_calc_ex(&new_persistent_script->script.main_op_array);
+	zend_accel_persist_namespace_info_calc(new_persistent_script);
 
 #if defined(__AVX__) || defined(__SSE2__)
 	/* Align size to 64-byte boundary */


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/namespace_scoped_declares

This PR adds support for the `namespace_declare()` function:

```php
namespace_declare('Foo', ['strict_types' => 1]);
```

This will enable `strict_types` for the namespace `Foo` and all sub-namespaces.