### PR TITLE
generate-phpt - set default value in some attributes

### DIFF
--- a/scripts/dev/generate-phpt/src/gtTestSubject.php
+++ b/scripts/dev/generate-phpt/src/gtTestSubject.php
@@ -1,8 +1,8 @@
 <?php
 abstract class gtTestSubject {
 
-  protected $optionalArgumentNames;
-  protected $mandatoryArgumentNames;
+  protected $optionalArgumentNames = [];
+  protected $mandatoryArgumentNames = [];
 
   protected $extraArgumentList = '';
   protected $shortArgumentList = '';


### PR DESCRIPTION
Hello,

I was creating some phpt test file using generate-phpt.phar, but depending on the function (Functions that do not have optional parameters), I was getting some warnings.

Function example: is_int()

```
Warning: count (): Parameter must be an array or an object that implements Countable in phar: ///usr/src/php/scripts/dev/generate-phpt.phar/gtTestSubject.php on line 109

Warning: count (): Parameter must be an array or an object that implements Countable in phar: ///usr/src/php/scripts/dev/generate-phpt.phar/gtTestSubject.php on line 52

Warning: count (): Parameter must be an array or an object that implements Countable in phar: ///usr/src/php/scripts/dev/generate-phpt.phar/gtTestSubject.php on line 150
```

These warnings are occurring because of this feature that was implemented
https://wiki.php.net/rfc/counting_non_countables

I made the fix in the generate-phpt library to no longer receive these warnings