### PR TITLE
Fix segfault. Compile param: --enable-maintainer-zts --with-tsrm-pth=pth-config

### DIFF
--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -94,7 +94,12 @@ static FILE *tsrm_error_file;
 	}
 #endif
 
-#if defined(PTHREADS)
+#if defined(GNUPTH)
+static pth_key_t tls_key;
+# define tsrm_tls_set(what)		pth_key_setdata(tls_key, (void*)(what))
+# define tsrm_tls_get()			pth_key_getdata(tls_key)
+
+#elif defined(PTHREADS)
 /* Thread local storage */
 static pthread_key_t tls_key;
 # define tsrm_tls_set(what)		pthread_setspecific(tls_key, (void*)(what))
@@ -123,6 +128,7 @@ TSRM_API int tsrm_startup(int expected_threads, int expected_resources, int debu
 {/*{{{*/
 #if defined(GNUPTH)
 	pth_init();
+	pth_key_create(&tls_key, 0);
 #elif defined(PTHREADS)
 	pthread_key_create( &tls_key, 0 );
 #elif defined(TSRM_ST)


### PR DESCRIPTION
Configure:
```
# ./configure --enable-maintainer-zts --with-tsrm-pth=pth-config --disable-all
```

Compile warning:
```
......
./TSRM/TSRM.c:127:3: предупреждение: #warning tsrm_set_interpreter_context is probably broken on this platform [-Wcpp]
 # warning tsrm_set_interpreter_context is probably broken on this platform
   ^~~~~~~
......
```

Error:
```
# ./sapi/cli/php
fish: './sapi/cli/php' terminated by signal SIGSEGV (Address boundary error)
```

GDB:
```
# gdb ./sapi/cli/php
(gdb) run
Starting program: ./sapi/cli/php 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault.
0x0000555555781bbd in sapi_register_post_entry (post_entry=post_entry@entry=0x555555c81980 <php_post_entries>)
    at ./main/SAPI.c:951
951		if (SG(sapi_started) && EG(current_execute_data)) {
(gdb) print _tsrm_ls_cache
$1 = (void *) 0x0
(gdb) 
```