### PR TITLE
Added test for openssl_pkcs12_export_to_file errors

### DIFF
--- a/ext/openssl/tests/openssl_pkcs12_export_to_file_error.phpt
+++ b/ext/openssl/tests/openssl_pkcs12_export_to_file_error.phpt
@@ -1,0 +1,37 @@
+--TEST--
+openssl_pkcs12_export_to_file() error tests
+--SKIPIF--
+<?php if (!extension_loaded("openssl")) print "skip"; ?>
+--FILE--
+<?php
+$pkcsfile = dirname(__FILE__) . "/openssl_pkcs12_export_to_file__pkcsfile.tmp";
+
+$cert_file = dirname(__FILE__) . "/public.crt";
+$cert = file_get_contents($cert_file);
+$cert_path = "file://" . $cert_file;
+$priv_file = dirname(__FILE__) . "/private.crt";
+$priv = file_get_contents($priv_file);
+$wrong_priv_file = dirname(__FILE__) . "/private_rsa_1024.key";
+$wrong_priv = file_get_contents($wrong_priv_file);
+$pass = 'test';
+
+var_dump(openssl_pkcs12_export_to_file($cert, $pkcsfile, null, $pass));
+var_dump(openssl_pkcs12_export_to_file($cert, $pkcsfile, $wrong_priv, $pass));
+var_dump(openssl_pkcs12_export_to_file($cert, '.', $priv, $pass));
+?>
+--CLEAN--
+<?php
+$pkcsfile = dirname(__FILE__) . "/openssl_pkcs12_export_to_file__pkcsfile.tmp";
+if (file_exists($pkcsfile)) {
+	unlink($pkcsfile);
+}
+?>
+--EXPECTF--
+Warning: openssl_pkcs12_export_to_file(): cannot get private key from parameter 3 in %s on line %d
+bool(false)
+
+Warning: openssl_pkcs12_export_to_file(): private key does not correspond to cert in %s on line %d
+bool(false)
+
+Warning: openssl_pkcs12_export_to_file(): error opening file . in %s on line %d
+bool(false)


### PR DESCRIPTION
This PR adds test for `openssl_pkcs12_export_to_file()` function, covering some missing error use cases.
The errors covered are three, reported in the following lines of `/ext/openssl/openssl.c` [L2791-L2794](https://github.com/php/php-src/blob/master/ext/openssl/openssl.c#L2791-L2794), [L2795-L2799](https://github.com/php/php-src/blob/master/ext/openssl/openssl.c#L2795-L2799), and [L2833-L2836](https://github.com/php/php-src/blob/master/ext/openssl/openssl.c#L2833-L2836). These errors are not covered from the [existing tests](http://gcov.php.net/PHP_HEAD/lcov_html/ext/openssl/openssl.c.gcov.php).

This PR has been realized during the PHP TestFest of 20th Dec, organized by [PUGTorino](https://twitter.com/pugtorino).