### PR TITLE
Add _IS_NUMBER as cast_object() target type

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -10,6 +10,7 @@ PHP 7.3 INTERNALS UPGRADE NOTES
   g. zend_get_parameters()
   h. zend_register_persistent_resource()
   i. RAND_RANGE()
+  j. cast_object() with _IS_NUMBER
 
 2. Build system changes
   a. Unix build system changes
@@ -85,6 +86,10 @@ PHP 7.3 INTERNALS UPGRADE NOTES
 
   i. The RANGE_RANGE() macro has been removed. php_mt_rand_range() should be
      used instead.
+
+  j. The cast_object() object handler now also accepts the _IS_NUMBER type. The
+     handler should return either an integer or float value in this case,
+     whichever is more appropriate.
 
 ========================
 2. Build system changes

--- a/Zend/tests/add_002.phpt
+++ b/Zend/tests/add_002.phpt
@@ -20,11 +20,11 @@ var_dump($c);
 echo "Done\n";
 ?>
 --EXPECTF--	
-Notice: Object of class stdClass could not be converted to int in %sadd_002.php on line %d
+Notice: Object of class stdClass could not be converted to number in %sadd_002.php on line %d
 
 Exception: Unsupported operand types
 
-Notice: Object of class stdClass could not be converted to int in %s on line %d
+Notice: Object of class stdClass could not be converted to number in %s on line %d
 
 Fatal error: Uncaught Error: Unsupported operand types in %s:%d
 Stack trace:

--- a/Zend/tests/add_003.phpt
+++ b/Zend/tests/add_003.phpt
@@ -20,11 +20,11 @@ var_dump($c);
 echo "Done\n";
 ?>
 --EXPECTF--	
-Notice: Object of class stdClass could not be converted to int in %sadd_003.php on line %d
+Notice: Object of class stdClass could not be converted to number in %sadd_003.php on line %d
 
 Exception: Unsupported operand types
 
-Notice: Object of class stdClass could not be converted to int in %s on line %d
+Notice: Object of class stdClass could not be converted to number in %s on line %d
 
 Fatal error: Uncaught Error: Unsupported operand types in %s:%d
 Stack trace:

--- a/Zend/tests/assert/indirect_var_access_misoptimization.phpt
+++ b/Zend/tests/assert/indirect_var_access_misoptimization.phpt
@@ -17,5 +17,5 @@ test();
 --EXPECTF--
 Deprecated: assert(): Calling assert() with a string argument is deprecated in %s on line %d
 
-Notice: Object of class stdClass could not be converted to int in %s on line %d
+Notice: Object of class stdClass could not be converted to number in %s on line %d
 int(2)

--- a/Zend/tests/bug73337.phpt
+++ b/Zend/tests/bug73337.phpt
@@ -6,7 +6,7 @@ class d { function __destruct() { throw new Exception; } }
 try { new d + new d; } catch (Exception $e) { print "Exception properly caught\n"; }
 ?>
 --EXPECTF--
-Notice: Object of class d could not be converted to int in %sbug73337.php on line 3
+Notice: Object of class d could not be converted to number in %sbug73337.php on line 3
 
-Notice: Object of class d could not be converted to int in %sbug73337.php on line 3
+Notice: Object of class d could not be converted to number in %sbug73337.php on line 3
 Exception properly caught

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -126,6 +126,8 @@ ZEND_API char *zend_get_type_by_const(int type) /* {{{ */
 			return "array";
 		case IS_VOID:
 			return "void";
+		case _IS_NUMBER:
+			return "number";
 		default:
 			return "unknown";
 	}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1698,6 +1698,11 @@ ZEND_API int zend_std_cast_object_tostring(zval *readobj, zval *writeobj, int ty
 			zend_error(E_NOTICE, "Object of class %s could not be converted to float", ZSTR_VAL(ce->name));
 			ZVAL_DOUBLE(writeobj, 1);
 			return SUCCESS;
+		case _IS_NUMBER:
+			ce = Z_OBJCE_P(readobj);
+			zend_error(E_NOTICE, "Object of class %s could not be converted to number", ZSTR_VAL(ce->name));
+			ZVAL_LONG(writeobj, 1);
+			return SUCCESS;
 		default:
 			ZVAL_NULL(writeobj);
 			break;

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -136,6 +136,26 @@ ZEND_API zend_long ZEND_FASTCALL zend_atol(const char *str, size_t str_len) /* {
 }
 /* }}} */
 
+/* {{{ convert_object_to_type: dst will be either ctype or UNDEF */
+#define convert_object_to_type(op, dst, ctype, conv_func)									\
+	ZVAL_UNDEF(dst);																		\
+	if (Z_OBJ_HT_P(op)->cast_object) {														\
+		if (Z_OBJ_HT_P(op)->cast_object(op, dst, ctype) == FAILURE) {				\
+			zend_error(E_RECOVERABLE_ERROR,													\
+				"Object of class %s could not be converted to %s", ZSTR_VAL(Z_OBJCE_P(op)->name),\
+			zend_get_type_by_const(ctype));													\
+		} 																					\
+	} else if (Z_OBJ_HT_P(op)->get) {														\
+		zval *newop = Z_OBJ_HT_P(op)->get(op, dst);								\
+		if (Z_TYPE_P(newop) != IS_OBJECT) {													\
+			/* for safety - avoid loop */													\
+			ZVAL_COPY_VALUE(dst, newop);													\
+			conv_func(dst);																	\
+		}																					\
+	}
+
+/* }}} */
+
 void ZEND_FASTCALL _convert_scalar_to_number(zval *op, zend_bool silent) /* {{{ */
 {
 try_again:
@@ -172,7 +192,18 @@ try_again:
 			}
 			break;
 		case IS_OBJECT:
-			convert_to_long_base(op, 10);
+			{
+				zval dst;
+
+				convert_object_to_type(op, &dst, _IS_NUMBER, convert_scalar_to_number);
+				zval_dtor(op);
+
+				if (Z_TYPE(dst) == IS_LONG || Z_TYPE(dst) == IS_DOUBLE) {
+					ZVAL_COPY_VALUE(op, &dst);
+				} else {
+					ZVAL_LONG(op, 1);
+				}
+			}
 			break;
 	}
 }
@@ -215,44 +246,21 @@ ZEND_API void ZEND_FASTCALL convert_scalar_to_number(zval *op) /* {{{ */
 					break;											\
 				case IS_OBJECT:										\
 					ZVAL_COPY(&(holder), op);						\
-					convert_to_long_base(&(holder), 10);			\
+					_convert_scalar_to_number(&(holder), silent);	\
 					if (UNEXPECTED(EG(exception))) {				\
 						if (result != op1) {						\
 							ZVAL_UNDEF(result);						\
 						}											\
 						return FAILURE;								\
 					}												\
-					if (Z_TYPE(holder) == IS_LONG) {				\
-						if (op == result) {							\
-							zval_ptr_dtor(op);						\
-							ZVAL_LONG(op, Z_LVAL(holder));			\
-						} else {									\
-							(op) = &(holder);						\
-						}											\
+					if (op == result) {								\
+						zval_dtor(op);								\
+						ZVAL_COPY(op, &(holder));					\
+					} else {										\
+						(op) = &(holder);							\
 					}												\
-					break;											\
 			}														\
 		}															\
-	}
-
-/* }}} */
-
-/* {{{ convert_object_to_type: dst will be either ctype or UNDEF */
-#define convert_object_to_type(op, dst, ctype, conv_func)									\
-	ZVAL_UNDEF(dst);																		\
-	if (Z_OBJ_HT_P(op)->cast_object) {														\
-		if (Z_OBJ_HT_P(op)->cast_object(op, dst, ctype) == FAILURE) {				\
-			zend_error(E_RECOVERABLE_ERROR,													\
-				"Object of class %s could not be converted to %s", ZSTR_VAL(Z_OBJCE_P(op)->name),\
-			zend_get_type_by_const(ctype));													\
-		} 																					\
-	} else if (Z_OBJ_HT_P(op)->get) {														\
-		zval *newop = Z_OBJ_HT_P(op)->get(op, dst);								\
-		if (Z_TYPE_P(newop) != IS_OBJECT) {													\
-			/* for safety - avoid loop */													\
-			ZVAL_COPY_VALUE(dst, newop);													\
-			conv_func(dst);																	\
-		}																					\
 	}
 
 /* }}} */

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -386,6 +386,7 @@ struct _zend_ast_ref {
 #define IS_CALLABLE					17
 #define IS_ITERABLE					18
 #define IS_VOID						19
+#define _IS_NUMBER					20
 
 static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 	return pz->u1.v.type;

--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -484,6 +484,7 @@ static int com_object_cast(zval *readobj, zval *writeobj, int type)
 
 	switch(type) {
 		case IS_LONG:
+		case _IS_NUMBER:
 			vt = VT_INT;
 			break;
 		case IS_DOUBLE:

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -425,6 +425,14 @@ static int gmp_cast_object(zval *readobj, zval *writeobj, int type) /* {{{ */
 		gmpnum = GET_GMP_FROM_ZVAL(readobj);
 		ZVAL_DOUBLE(writeobj, mpz_get_d(gmpnum));
 		return SUCCESS;
+	case _IS_NUMBER:
+		gmpnum = GET_GMP_FROM_ZVAL(readobj);
+		if (mpz_fits_slong_p(gmpnum)) {
+			ZVAL_LONG(writeobj, mpz_get_si(gmpnum));
+		} else {
+			ZVAL_DOUBLE(writeobj, mpz_get_d(gmpnum));
+		}
+		return SUCCESS;
 	default:
 		return FAILURE;
 	}

--- a/ext/intl/tests/bug48227.phpt
+++ b/ext/intl/tests/bug48227.phpt
@@ -17,5 +17,5 @@ string(1) "0"
 string(1) "1"
 string(1) "0"
 
-Notice: Object of class NumberFormatter could not be converted to int in %s on line %d
+Notice: Object of class NumberFormatter could not be converted to number in %s on line %d
 string(1) "1"

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1857,6 +1857,9 @@ static int cast_object(zval *object, int type, char *contents)
 		case IS_DOUBLE:
 			convert_to_double(object);
 			break;
+		case _IS_NUMBER:
+			convert_scalar_to_number(object);
+			break;
 		default:
 			return FAILURE;
 	}

--- a/ext/simplexml/tests/bug53033.phpt
+++ b/ext/simplexml/tests/bug53033.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #53033: Mathematical operations convert objects to integers
+--FILE--
+<?php
+
+$x = simplexml_load_string('<x>2.5</x>');
+var_dump($x*1);
+// type of other operand is irrelevant
+var_dump($x*1.0);
+
+// strings behave differently
+$y = '2.5';
+var_dump($y*1);
+var_dump((string)$x*1);
+
+?>
+--EXPECT--
+float(2.5)
+float(2.5)
+float(2.5)
+float(2.5)

--- a/ext/simplexml/tests/bug54973.phpt
+++ b/ext/simplexml/tests/bug54973.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #54973: SimpleXML casts integers wrong
+--FILE--
+<?php
+$xml = simplexml_load_string("<xml><number>9223372036854775808</number></xml>");
+
+var_dump($xml->number);
+
+$int = $xml->number / 1024 / 1024 / 1024;
+var_dump($int);
+
+$double = (double) $xml->number / 1024 / 1024 / 1024;
+var_dump($double);
+?>
+--EXPECT--
+object(SimpleXMLElement)#2 (1) {
+  [0]=>
+  string(19) "9223372036854775808"
+}
+float(8589934592)
+float(8589934592)

--- a/ext/standard/tests/math/abs_variation.phpt
+++ b/ext/standard/tests/math/abs_variation.phpt
@@ -121,7 +121,7 @@ int(0)
 
 -- Iteration 13 --
 
-Notice: Object of class classA could not be converted to int in %s on line %d
+Notice: Object of class classA could not be converted to number in %s on line %d
 int(1)
 
 -- Iteration 14 --

--- a/ext/standard/tests/math/ceil_variation1.phpt
+++ b/ext/standard/tests/math/ceil_variation1.phpt
@@ -114,7 +114,7 @@ float(0)
 
 -- Iteration 13 --
 
-Notice: Object of class classA could not be converted to int in %s on line %d
+Notice: Object of class classA could not be converted to number in %s on line %d
 float(1)
 
 -- Iteration 14 --

--- a/ext/standard/tests/math/floor_variation1.phpt
+++ b/ext/standard/tests/math/floor_variation1.phpt
@@ -114,7 +114,7 @@ float(0)
 
 -- Iteration 13 --
 
-Notice: Object of class classA could not be converted to int in %s on line %d
+Notice: Object of class classA could not be converted to number in %s on line %d
 float(1)
 
 -- Iteration 14 --

--- a/ext/standard/tests/math/pow_variation1.phpt
+++ b/ext/standard/tests/math/pow_variation1.phpt
@@ -172,7 +172,7 @@ int(0)
 
 -- Iteration 23 --
 
-Notice: Object of class classA could not be converted to int in %s on line %d
+Notice: Object of class classA could not be converted to number in %s on line %d
 int(1)
 
 -- Iteration 24 --

--- a/ext/standard/tests/math/pow_variation1_64bit.phpt
+++ b/ext/standard/tests/math/pow_variation1_64bit.phpt
@@ -172,7 +172,7 @@ int(0)
 
 -- Iteration 23 --
 
-Notice: Object of class classA could not be converted to int in %s on line %d
+Notice: Object of class classA could not be converted to number in %s on line %d
 int(1)
 
 -- Iteration 24 --

--- a/ext/standard/tests/math/pow_variation2.phpt
+++ b/ext/standard/tests/math/pow_variation2.phpt
@@ -168,7 +168,7 @@ float(1)
 
 -- Iteration 23 --
 
-Notice: Object of class classA could not be converted to int in %s on line %d
+Notice: Object of class classA could not be converted to number in %s on line %d
 float(20.3)
 
 -- Iteration 24 --

--- a/ext/standard/tests/math/round_variation1.phpt
+++ b/ext/standard/tests/math/round_variation1.phpt
@@ -159,7 +159,7 @@ float(0)
 
 -- Iteration 23 --
 
-Notice: Object of class classA could not be converted to int in %s on line %d
+Notice: Object of class classA could not be converted to number in %s on line %d
 float(1)
 
 -- Iteration 24 --

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -733,6 +733,7 @@ static int tidy_doc_cast_handler(zval *in, zval *out, int type)
 
 	switch (type) {
 		case IS_LONG:
+		case _IS_NUMBER:
 			ZVAL_LONG(out, 0);
 			break;
 
@@ -766,6 +767,7 @@ static int tidy_node_cast_handler(zval *in, zval *out, int type)
 
 	switch(type) {
 		case IS_LONG:
+		case _IS_NUMBER:
 			ZVAL_LONG(out, 0);
 			break;
 


### PR DESCRIPTION
convert_scalar_to_number() will now call cast_object() with an
_IS_NUMBER argument, in which case the cast handler should return
either an integer or floating point number, whichever is more
appropriate.

Previously convert_scalar_to_number() unconditionally converted
objects to integers instead.

Fixes bug #53033.
Fixes bug #54973.
Fixes bug #73108.