### PR TITLE
Add a new --with-fpm-apparmor configure flag (fixes bug 75519)

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -488,22 +488,6 @@ AC_DEFUN([AC_FPM_SELECT],
 	])
 ])
 
-AC_DEFUN([AC_FPM_APPARMOR],
-[
-	AC_MSG_CHECKING([for apparmor])
-
-	SAVED_LIBS="$LIBS"
-	LIBS="$LIBS -lapparmor"
-
-	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <sys/apparmor.h>]], [[change_hat("test", 0);]])], [
-		AC_DEFINE([HAVE_APPARMOR], 1, [do we have apparmor support?])
-		AC_MSG_RESULT([yes])
-	], [
-		LIBS="$SAVED_LIBS"
-		AC_MSG_RESULT([no])
-	])
-])
-
 AC_MSG_CHECKING(for FPM build)
 if test "$PHP_FPM" != "no"; then
   AC_MSG_RESULT($PHP_FPM)
@@ -521,7 +505,6 @@ if test "$PHP_FPM" != "no"; then
   AC_FPM_DEVPOLL
   AC_FPM_EPOLL
   AC_FPM_SELECT
-  AC_FPM_APPARMOR
 
   PHP_ARG_WITH([fpm-user],,
     [AS_HELP_STRING([[--with-fpm-user[=USER]]],
@@ -545,6 +528,12 @@ if test "$PHP_FPM" != "no"; then
   PHP_ARG_WITH([fpm-acl],,
     [AS_HELP_STRING([--with-fpm-acl],
       [Use POSIX Access Control Lists])],
+    [no],
+    [no])
+
+  PHP_ARG_WITH([fpm-apparmor],,
+    [AS_HELP_STRING([--with-fpm-apparmor],
+      [Support AppArmor confinement through libapparmor])],
     [no],
     [no])
 
@@ -577,6 +566,16 @@ if test "$PHP_FPM" != "no"; then
       ],[
         AC_MSG_ERROR(libacl required not found)
       ])
+    ])
+  fi
+
+  if test "x$PHP_FPM_APPARMOR" != "xno" ; then
+    AC_CHECK_HEADERS([sys/apparmor.h])
+    AC_CHECK_LIB(apparmor, change_hat, [
+      PHP_ADD_LIBRARY(apparmor)
+      AC_DEFINE(HAVE_APPARMOR, 1, [ AppArmor confinement available ])
+    ],[
+      AC_MSG_ERROR(libapparmor required but not found)
     ])
   fi
 


### PR DESCRIPTION
The existing `AC_FPM_APPARMOR` macro (which is always run when FPM is
enabled) checks for the existence of libapparmor, and adds it to $LIBS
if found. The result is an "automagic" dependency on libapparmor that
depends not only on the user's configuration, but also on the build
host's environment.