### PR TITLE
Provide default value

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -878,7 +878,7 @@ static zend_always_inline zend_bool zend_check_type(
 static zend_always_inline int zend_verify_arg_type(zend_function *zf, uint32_t arg_num, zval *arg, zval *default_value, void **cache_slot)
 {
 	zend_arg_info *cur_arg_info;
-	zend_class_entry *ce;
+	zend_class_entry *ce = NULL;
 
 	if (EXPECTED(arg_num <= zf->common.num_args)) {
 		cur_arg_info = &zf->common.arg_info[arg_num-1];


### PR DESCRIPTION
This variable is passed uninitialized as a function call argument. I suspect that this can cause undefined behavior. I'm setting it to null as a fix.