### PR TITLE
In some systems, net/if.h needs sys/socket.h for sockaddr type,

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -451,7 +451,14 @@ fi
 dnl
 dnl net_get_interfaces
 dnl
-AC_CHECK_HEADERS([net/if.h netdb.h])
+AC_CHECK_HEADERS([net/if.h],[], [],
+[
+  #ifdef HAVE_SYS_SOCKET_H
+  #include <sys/socket.h>
+  #endif
+  #include <net/if.h>
+])
+AC_CHECK_HEADERS([netdb.h])
 AC_MSG_CHECKING([for usable getifaddrs])
 AC_TRY_LINK([
   #include <sys/types.h>


### PR DESCRIPTION
thus led to detection failure of this particular header.