### PR TITLE
Zend function arg_info memory leak fix

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -303,6 +303,9 @@ typedef struct _zend_oparray_context {
 /* class constants updated */
 #define ZEND_ACC_CONSTANTS_UPDATED	  0x100000
 
+/* class contains built-in methods with allocated arginfo */
+#define ZEND_ACC_BUILTIN_FUNCTIONS_ARGINFO	0x200000
+
 /* user class has methods with static variables */
 #define ZEND_HAS_STATIC_IN_METHODS    0x800000
 


### PR DESCRIPTION
This PR fixes memory leaks in the registration of internal function when allocating arg_info if the function has type hint or return type. The leak was introduced by https://github.com/php/php-src/commit/141d1ba9801f742dc5d9ccd06e02b94284c4deb7 and currently it is visible in Valgrind.

The idea is to free arginfo in the following situations:

- module functions unregistration
- cleaning module classes for temporary module
- cleaning up all internal classes using extended  `class_cleanup_handlers`

Ping @dstogov and @nikic - this is kind of follow up to #2462 