### PR TITLE
[WIP] Preparation for large/dynamic GC buffers

### DIFF
--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -104,16 +104,21 @@ ZEND_API int (*gc_collect_cycles)(void);
 # define GC_TRACE(str)
 #endif
 
-#define GC_REF_SET_ADDRESS(ref, a) \
-	GC_INFO_SET_ADDRESS(GC_INFO(ref), a)
 #define GC_REF_GET_COLOR(ref) \
-	GC_INFO_GET_COLOR(GC_INFO(ref))
+	(GC_FLAGS(ref) & GC_COLOR)
+#define GC_REF_SET_COLOR_EX(ref, c) \
+	do { GC_FLAGS(ref) = (GC_FLAGS(ref) & ~GC_COLOR) | (c); } while (0);
+#define GC_REF_SET_BLACK_EX(ref) \
+	do { GC_FLAGS(ref) = GC_FLAGS(ref) & ~GC_COLOR; } while (0);
+#define GC_REF_SET_PURPLE_EX(ref) \
+	do { GC_FLAGS(ref) |= GC_COLOR; } while (0);
+
 #define GC_REF_SET_COLOR(ref, c) \
-	do { GC_TRACE_SET_COLOR(ref, c); GC_INFO_SET_COLOR(GC_INFO(ref), c); } while (0)
+	do { GC_TRACE_SET_COLOR(ref, c); GC_REF_SET_COLOR_EX(ref, c); } while (0)
 #define GC_REF_SET_BLACK(ref) \
-	do { GC_TRACE_SET_COLOR(ref, GC_BLACK); GC_INFO_SET_BLACK(GC_INFO(ref)); } while (0)
+	do { GC_TRACE_SET_COLOR(ref, GC_BLACK); GC_REF_SET_BLACK_EX(ref); } while (0)
 #define GC_REF_SET_PURPLE(ref) \
-	do { GC_TRACE_SET_COLOR(ref, GC_PURPLE); GC_INFO_SET_PURPLE(GC_INFO(ref)); } while (0)
+	do { GC_TRACE_SET_COLOR(ref, GC_PURPLE); GC_REF_SET_PURPLE_EX(ref); } while (0)
 
 #if ZEND_GC_DEBUG > 1
 static const char *gc_color_name(uint32_t color) {
@@ -129,18 +134,18 @@ static void gc_trace_ref(zend_refcounted *ref) {
 	if (GC_TYPE(ref) == IS_OBJECT) {
 		zend_object *obj = (zend_object *) ref;
 		fprintf(stderr, "[%p] rc=%d addr=%d %s object(%s)#%d ",
-			ref, GC_REFCOUNT(ref), GC_ADDRESS(GC_INFO(ref)),
+			ref, GC_REFCOUNT(ref), GC_ADDRESS(ref),
 			gc_color_name(GC_REF_GET_COLOR(ref)),
 			obj->ce->name->val, obj->handle);
 	} else if (GC_TYPE(ref) == IS_ARRAY) {
 		zend_array *arr = (zend_array *) ref;
 		fprintf(stderr, "[%p] rc=%d addr=%d %s array(%d) ",
-			ref, GC_REFCOUNT(ref), GC_ADDRESS(GC_INFO(ref)),
+			ref, GC_REFCOUNT(ref), GC_ADDRESS(ref),
 			gc_color_name(GC_REF_GET_COLOR(ref)),
 			zend_hash_num_elements(arr));
 	} else {
 		fprintf(stderr, "[%p] rc=%d addr=%d %s %s ",
-			ref, GC_REFCOUNT(ref), GC_ADDRESS(GC_INFO(ref)),
+			ref, GC_REFCOUNT(ref), GC_ADDRESS(ref),
 			gc_color_name(GC_REF_GET_COLOR(ref)),
 			zend_get_type_by_const(GC_TYPE(ref)));
 	}
@@ -268,7 +273,7 @@ ZEND_API void ZEND_FASTCALL gc_possible_root(zend_refcounted *ref)
 
 	ZEND_ASSERT(GC_TYPE(ref) == IS_ARRAY || GC_TYPE(ref) == IS_OBJECT);
 	ZEND_ASSERT(EXPECTED(GC_REF_GET_COLOR(ref) == GC_BLACK));
-	ZEND_ASSERT(!GC_ADDRESS(GC_INFO(ref)));
+	ZEND_ASSERT(!GC_ADDRESS(ref));
 
 	GC_BENCH_INC(zval_possible_root);
 
@@ -289,7 +294,7 @@ ZEND_API void ZEND_FASTCALL gc_possible_root(zend_refcounted *ref)
 			zval_dtor_func(ref);
 			return;
 		}
-		if (UNEXPECTED(GC_INFO(ref))) {
+		if (UNEXPECTED(GC_ADDRESS(ref))) {
 			return;
 		}
 		newRoot = GC_G(unused);
@@ -306,7 +311,8 @@ ZEND_API void ZEND_FASTCALL gc_possible_root(zend_refcounted *ref)
 	}
 
 	GC_TRACE_SET_COLOR(ref, GC_PURPLE);
-	GC_INFO(ref) = (newRoot - GC_G(buf)) | GC_PURPLE;
+	GC_SET_ADDRESS(ref, newRoot - GC_G(buf));
+	GC_REF_SET_PURPLE(ref);
 	newRoot->ref = ref;
 
 	newRoot->next = GC_G(roots).next;
@@ -325,7 +331,7 @@ static zend_always_inline gc_root_buffer* gc_find_additional_buffer(zend_refcoun
 
 	/* We have to check each additional_buffer to find which one holds the ref */
 	while (additional_buffer) {
-		uint32_t idx = GC_ADDRESS(GC_INFO(ref)) - GC_ROOT_BUFFER_MAX_ENTRIES;
+		uint32_t idx = GC_ADDRESS(ref) - GC_ROOT_BUFFER_MAX_ENTRIES;
 		if (idx < additional_buffer->used) {
 			gc_root_buffer *root = additional_buffer->buf + idx;
 			if (root->ref == ref) {
@@ -343,12 +349,12 @@ ZEND_API void ZEND_FASTCALL gc_remove_from_buffer(zend_refcounted *ref)
 {
 	gc_root_buffer *root;
 
-	ZEND_ASSERT(GC_ADDRESS(GC_INFO(ref)));
+	ZEND_ASSERT(GC_ADDRESS(ref));
 
 	GC_BENCH_INC(zval_remove_from_buffer);
 
-	if (EXPECTED(GC_ADDRESS(GC_INFO(ref)) < GC_ROOT_BUFFER_MAX_ENTRIES)) {
-		root = GC_G(buf) + GC_ADDRESS(GC_INFO(ref));
+	if (EXPECTED(GC_ADDRESS(ref) < GC_ROOT_BUFFER_MAX_ENTRIES)) {
+		root = GC_G(buf) + GC_ADDRESS(ref);
 		gc_remove_from_roots(root);
 	} else {
 		root = gc_find_additional_buffer(ref);
@@ -357,7 +363,7 @@ ZEND_API void ZEND_FASTCALL gc_remove_from_buffer(zend_refcounted *ref)
 	if (GC_REF_GET_COLOR(ref) != GC_BLACK) {
 		GC_TRACE_SET_COLOR(ref, GC_PURPLE);
 	}
-	GC_INFO(ref) = 0;
+	GC_SET_ADDRESS(ref, 0);
 
 	/* updete next root that is going to be freed */
 	if (GC_G(next_to_free) == root) {
@@ -379,7 +385,7 @@ tail_call:
 		zend_object_get_gc_t get_gc;
 		zend_object *obj = (zend_object*)ref;
 
-		if (EXPECTED(!(GC_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
+		if (EXPECTED(!(GC_EXTRA_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
 		             (get_gc = obj->handlers->get_gc) != NULL)) {
 			int n;
 			zval *zv, *end;
@@ -489,7 +495,7 @@ tail_call:
 			zend_object_get_gc_t get_gc;
 			zend_object *obj = (zend_object*)ref;
 
-			if (EXPECTED(!(GC_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
+			if (EXPECTED(!(GC_EXTRA_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
 		                 (get_gc = obj->handlers->get_gc) != NULL)) {
 				int n;
 				zval *zv, *end;
@@ -602,7 +608,7 @@ tail_call:
 				zend_object_get_gc_t get_gc;
 				zend_object *obj = (zend_object*)ref;
 
-				if (EXPECTED(!(GC_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
+				if (EXPECTED(!(GC_EXTRA_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
 				             (get_gc = obj->handlers->get_gc) != NULL)) {
 					int n;
 					zval *zv, *end;
@@ -699,21 +705,13 @@ static void gc_add_garbage(zend_refcounted *ref)
 
 	if (buf) {
 		GC_G(unused) = buf->prev;
-#if 1
 		/* optimization: color is already GC_BLACK (0) */
-		GC_INFO(ref) = buf - GC_G(buf);
-#else
-		GC_REF_SET_ADDRESS(ref, buf - GC_G(buf));
-#endif
+		GC_SET_ADDRESS(ref, buf - GC_G(buf));
 	} else if (GC_G(first_unused) != GC_G(last_unused)) {
 		buf = GC_G(first_unused);
 		GC_G(first_unused)++;
-#if 1
 		/* optimization: color is already GC_BLACK (0) */
-		GC_INFO(ref) = buf - GC_G(buf);
-#else
-		GC_REF_SET_ADDRESS(ref, buf - GC_G(buf));
-#endif
+		GC_SET_ADDRESS(ref, buf - GC_G(buf));
 	} else {
 		/* If we don't have free slots in the buffer, allocate a new one and
 		 * set it's address above GC_ROOT_BUFFER_MAX_ENTRIES that have special
@@ -726,12 +724,8 @@ static void gc_add_garbage(zend_refcounted *ref)
 			GC_G(additional_buffer) = new_buffer;
 		}
 		buf = GC_G(additional_buffer)->buf + GC_G(additional_buffer)->used;
-#if 1
 		/* optimization: color is already GC_BLACK (0) */
-		GC_INFO(ref) = GC_ROOT_BUFFER_MAX_ENTRIES + GC_G(additional_buffer)->used;
-#else
-		GC_REF_SET_ADDRESS(ref, GC_ROOT_BUFFER_MAX_ENTRIES) + GC_G(additional_buffer)->used;
-#endif
+		GC_SET_ADDRESS(ref, GC_ROOT_BUFFER_MAX_ENTRIES + GC_G(additional_buffer)->used);
 		GC_G(additional_buffer)->used++;
 	}
 	if (buf) {
@@ -764,18 +758,13 @@ tail_call:
 			zend_object_get_gc_t get_gc;
 			zend_object *obj = (zend_object*)ref;
 
-			if (EXPECTED(!(GC_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
+			if (EXPECTED(!(GC_EXTRA_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
 			             (get_gc = obj->handlers->get_gc) != NULL)) {
 				int n;
 				zval *zv, *end;
 				zval tmp;
 
-#if 1
-				/* optimization: color is GC_BLACK (0) */
-				if (!GC_INFO(ref)) {
-#else
-				if (!GC_ADDRESS(GC_INFO(ref))) {
-#endif
+				if (!GC_ADDRESS(ref)) {
 					gc_add_garbage(ref);
 				}
 				if (obj->handlers->dtor_obj &&
@@ -816,12 +805,7 @@ tail_call:
 				return count;
 			}
 		} else if (GC_TYPE(ref) == IS_ARRAY) {
-#if 1
-				/* optimization: color is GC_BLACK (0) */
-				if (!GC_INFO(ref)) {
-#else
-				if (!GC_ADDRESS(GC_INFO(ref))) {
-#endif
+			if (!GC_ADDRESS(ref)) {
 				gc_add_garbage(ref);
 			}
 			ht = (zend_array*)ref;
@@ -889,12 +873,12 @@ static int gc_collect_roots(uint32_t *flags)
 	while (current != &GC_G(roots)) {
 		gc_root_buffer *next = current->next;
 		if (GC_REF_GET_COLOR(current->ref) == GC_BLACK) {
-			if (EXPECTED(GC_ADDRESS(GC_INFO(current->ref)) < GC_ROOT_BUFFER_MAX_ENTRIES)) {
+			if (EXPECTED(GC_ADDRESS(current->ref) < GC_ROOT_BUFFER_MAX_ENTRIES)) {
 				gc_remove_from_roots(current);
 			} else {
 				gc_remove_from_additional_roots(current);
 			}
-			GC_INFO(current->ref) = 0; /* reset GC_ADDRESS() and keep GC_BLACK */
+			GC_SET_ADDRESS(current->ref, 0); /* reset GC_ADDRESS() and keep GC_BLACK */
 		}
 		current = next;
 	}
@@ -937,16 +921,17 @@ static void gc_remove_nested_data_from_buffer(zend_refcounted *ref, gc_root_buff
 
 tail_call:
 	if (root ||
-	    (GC_ADDRESS(GC_INFO(ref)) != 0 &&
+	    ((GC_FLAGS(ref) & GC_COLLECTABLE) &&
+		 GC_ADDRESS(ref) != 0 &&
 	     GC_REF_GET_COLOR(ref) == GC_BLACK)) {
 		GC_TRACE_REF(ref, "removing from buffer");
 		if (root) {
-			if (EXPECTED(GC_ADDRESS(GC_INFO(root->ref)) < GC_ROOT_BUFFER_MAX_ENTRIES)) {
+			if (EXPECTED(GC_ADDRESS(root->ref) < GC_ROOT_BUFFER_MAX_ENTRIES)) {
 				gc_remove_from_roots(root);
 			} else {
 				gc_remove_from_additional_roots(root);
 			}
-			GC_INFO(ref) = 0;
+			GC_SET_ADDRESS(ref, 0);
 			root = NULL;
 		} else {
 			GC_REMOVE_FROM_BUFFER(ref);
@@ -956,7 +941,7 @@ tail_call:
 			zend_object_get_gc_t get_gc;
 			zend_object *obj = (zend_object*)ref;
 
-			if (EXPECTED(!(GC_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
+			if (EXPECTED(!(GC_EXTRA_FLAGS(ref) & IS_OBJ_FREE_CALLED) &&
 		                 (get_gc = obj->handlers->get_gc) != NULL)) {
 				int n;
 				zval *zv, *end;
@@ -1112,9 +1097,9 @@ ZEND_API int zend_gc_collect_cycles(void)
 				if (GC_TYPE(p) == IS_OBJECT) {
 					zend_object *obj = (zend_object*)p;
 
-					if (!(GC_FLAGS(obj) & IS_OBJ_DESTRUCTOR_CALLED)) {
+					if (!(GC_EXTRA_FLAGS(obj) & IS_OBJ_DESTRUCTOR_CALLED)) {
 						GC_TRACE_REF(obj, "calling destructor");
-						GC_FLAGS(obj) |= IS_OBJ_DESTRUCTOR_CALLED;
+						GC_EXTRA_FLAGS(obj) |= IS_OBJ_DESTRUCTOR_CALLED;
 						if (obj->handlers->dtor_obj
 						 && (obj->handlers->dtor_obj != zend_objects_destroy_object
 						  || obj->ce->destructor)) {
@@ -1151,8 +1136,8 @@ ZEND_API int zend_gc_collect_cycles(void)
 
 				EG(objects_store).object_buckets[obj->handle] = SET_OBJ_INVALID(obj);
 				GC_TYPE(obj) = IS_NULL;
-				if (!(GC_FLAGS(obj) & IS_OBJ_FREE_CALLED)) {
-					GC_FLAGS(obj) |= IS_OBJ_FREE_CALLED;
+				if (!(GC_EXTRA_FLAGS(obj) & IS_OBJ_FREE_CALLED)) {
+					GC_EXTRA_FLAGS(obj) |= IS_OBJ_FREE_CALLED;
 					if (obj->handlers->free_obj) {
 						GC_ADDREF(obj);
 						obj->handlers->free_obj(obj);

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -40,26 +40,6 @@
 # define GC_BENCH_PEAK(peak, counter)
 #endif
 
-#define GC_COLOR  0xc000
-
-#define GC_BLACK  0x0000
-#define GC_WHITE  0x8000
-#define GC_GREY   0x4000
-#define GC_PURPLE 0xc000
-
-#define GC_ADDRESS(v) \
-	((v) & ~GC_COLOR)
-#define GC_INFO_GET_COLOR(v) \
-	(((zend_uintptr_t)(v)) & GC_COLOR)
-#define GC_INFO_SET_ADDRESS(v, a) \
-	do {(v) = ((v) & GC_COLOR) | (a);} while (0)
-#define GC_INFO_SET_COLOR(v, c) \
-	do {(v) = ((v) & ~GC_COLOR) | (c);} while (0)
-#define GC_INFO_SET_BLACK(v) \
-	do {(v) = (v) & ~GC_COLOR;} while (0)
-#define GC_INFO_SET_PURPLE(v) \
-	do {(v) = (v) | GC_COLOR;} while (0)
-
 typedef struct _gc_root_buffer {
 	zend_refcounted          *ref;
 	struct _gc_root_buffer   *next;     /* double-linked list               */
@@ -133,16 +113,14 @@ ZEND_API int  zend_gc_collect_cycles(void);
 END_EXTERN_C()
 
 #define GC_REMOVE_FROM_BUFFER(p) do { \
-		zend_refcounted *_p = (zend_refcounted*)(p); \
-		if (GC_ADDRESS(GC_INFO(_p))) { \
+		zend_refcounted *_p = (zend_refcounted *)(p); \
+		if (GC_ADDRESS(_p)) { \
 			gc_remove_from_buffer(_p); \
 		} \
 	} while (0)
 
 #define GC_MAY_LEAK(ref) \
-	((GC_TYPE_INFO(ref) & \
-		(GC_INFO_MASK | (GC_COLLECTABLE << GC_FLAGS_SHIFT))) == \
-	(GC_COLLECTABLE << GC_FLAGS_SHIFT))
+	((GC_FLAGS(ref) & GC_COLLECTABLE) && GC_ADDRESS(ref) == 0)
 
 static zend_always_inline void gc_check_possible_root(zend_refcounted *ref)
 {

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -35,7 +35,8 @@
 
 #define HT_POISONED_PTR ((HashTable *) (intptr_t) -1)
 
-#if ZEND_DEBUG
+/* TODO */
+#if 0&&ZEND_DEBUG
 
 #define HT_OK					0x00
 #define HT_IS_DESTROYING		0x40

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -321,8 +321,8 @@ ZEND_API uint32_t ZEND_FASTCALL zend_hash_iterator_add(HashTable *ht, HashPositi
 	HashTableIterator *end  = iter + EG(ht_iterators_count);
 	uint32_t idx;
 
-	if (EXPECTED(ht->u.v.nIteratorsCount != 255)) {
-		ht->u.v.nIteratorsCount++;
+	if (EXPECTED(!HT_ITERATORS_OVERFLOW(ht))) {
+		HT_INC_ITERATORS_COUNT(ht);
 	}
 	while (iter != end) {
 		if (iter->ht == NULL) {
@@ -361,11 +361,11 @@ ZEND_API HashPosition ZEND_FASTCALL zend_hash_iterator_pos(uint32_t idx, HashTab
 		return HT_INVALID_IDX;
 	} else if (UNEXPECTED(iter->ht != ht)) {
 		if (EXPECTED(iter->ht) && EXPECTED(iter->ht != HT_POISONED_PTR)
-				&& EXPECTED(iter->ht->u.v.nIteratorsCount != 255)) {
-			iter->ht->u.v.nIteratorsCount--;
+				&& EXPECTED(!HT_ITERATORS_OVERFLOW(iter->ht))) {
+			HT_DEC_ITERATORS_COUNT(iter->ht);
 		}
-		if (EXPECTED(ht->u.v.nIteratorsCount != 255)) {
-			ht->u.v.nIteratorsCount++;
+		if (EXPECTED(!HT_ITERATORS_OVERFLOW(ht))) {
+			HT_INC_ITERATORS_COUNT(ht);
 		}
 		iter->ht = ht;
 		iter->pos = ht->nInternalPointer;
@@ -383,13 +383,13 @@ ZEND_API HashPosition ZEND_FASTCALL zend_hash_iterator_pos_ex(uint32_t idx, zval
 		return HT_INVALID_IDX;
 	} else if (UNEXPECTED(iter->ht != ht)) {
 		if (EXPECTED(iter->ht) && EXPECTED(iter->ht != HT_POISONED_PTR)
-				&& EXPECTED(iter->ht->u.v.nIteratorsCount != 255)) {
-			iter->ht->u.v.nIteratorsCount--;
+				&& EXPECTED(!HT_ITERATORS_OVERFLOW(ht))) {
+			HT_DEC_ITERATORS_COUNT(iter->ht);
 		}
 		SEPARATE_ARRAY(array);
 		ht = Z_ARRVAL_P(array);
-		if (EXPECTED(ht->u.v.nIteratorsCount != 255)) {
-			ht->u.v.nIteratorsCount++;
+		if (EXPECTED(!HT_ITERATORS_OVERFLOW(ht))) {
+			HT_INC_ITERATORS_COUNT(ht);
 		}
 		iter->ht = ht;
 		iter->pos = ht->nInternalPointer;
@@ -404,8 +404,8 @@ ZEND_API void ZEND_FASTCALL zend_hash_iterator_del(uint32_t idx)
 	ZEND_ASSERT(idx != (uint32_t)-1);
 
 	if (EXPECTED(iter->ht) && EXPECTED(iter->ht != HT_POISONED_PTR)
-			&& EXPECTED(iter->ht->u.v.nIteratorsCount != 255)) {
-		iter->ht->u.v.nIteratorsCount--;
+			&& EXPECTED(!HT_ITERATORS_OVERFLOW(iter->ht))) {
+		HT_DEC_ITERATORS_COUNT(iter->ht);
 	}
 	iter->ht = NULL;
 
@@ -432,7 +432,7 @@ static zend_never_inline void ZEND_FASTCALL _zend_hash_iterators_remove(HashTabl
 
 static zend_always_inline void zend_hash_iterators_remove(HashTable *ht)
 {
-	if (UNEXPECTED(ht->u.v.nIteratorsCount)) {
+	if (UNEXPECTED(HT_HAS_ITERATORS(ht))) {
 		_zend_hash_iterators_remove(ht);
 	}
 }
@@ -980,7 +980,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 				uint32_t j = i;
 				Bucket *q = p;
 
-				if (EXPECTED(ht->u.v.nIteratorsCount == 0)) {
+				if (EXPECTED(!HT_HAS_ITERATORS(ht))) {
 					while (++i < ht->nNumUsed) {
 						p++;
 						if (EXPECTED(Z_TYPE_INFO(p->val) != IS_UNDEF)) {
@@ -1048,7 +1048,7 @@ static zend_always_inline void _zend_hash_del_el_ex(HashTable *ht, uint32_t idx,
 		} while (ht->nNumUsed > 0 && (UNEXPECTED(Z_TYPE(ht->arData[ht->nNumUsed-1].val) == IS_UNDEF)));
 	}
 	ht->nNumOfElements--;
-	if (HT_IDX_TO_HASH(ht->nInternalPointer) == idx || UNEXPECTED(ht->u.v.nIteratorsCount)) {
+	if (HT_IDX_TO_HASH(ht->nInternalPointer) == idx || UNEXPECTED(HT_HAS_ITERATORS(ht))) {
 		uint32_t new_idx;
 
 		new_idx = idx = HT_HASH_TO_IDX(idx);

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -26,7 +26,7 @@
 
 #if ZEND_DEBUG
 # define HT_ASSERT(ht, expr) \
-	ZEND_ASSERT((expr) || ((ht)->u.flags & HASH_FLAG_ALLOW_COW_VIOLATION))
+	ZEND_ASSERT((expr) || (HT_FLAGS(ht) & HASH_FLAG_ALLOW_COW_VIOLATION))
 #else
 # define HT_ASSERT(ht, expr)
 #endif
@@ -118,15 +118,15 @@ static zend_always_inline uint32_t zend_hash_check_size(uint32_t nSize)
 static zend_always_inline void zend_hash_real_init_ex(HashTable *ht, int packed)
 {
 	HT_ASSERT_RC1(ht);
-	ZEND_ASSERT(!((ht)->u.flags & HASH_FLAG_INITIALIZED));
+	ZEND_ASSERT(!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED));
 	if (packed) {
 		HT_SET_DATA_ADDR(ht, pemalloc(HT_SIZE(ht), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT));
-		(ht)->u.flags |= HASH_FLAG_INITIALIZED | HASH_FLAG_PACKED;
+		HT_FLAGS(ht) |= HASH_FLAG_INITIALIZED | HASH_FLAG_PACKED;
 		HT_HASH_RESET_PACKED(ht);
 	} else {
 		(ht)->nTableMask = -(ht)->nTableSize;
 		HT_SET_DATA_ADDR(ht, pemalloc(HT_SIZE(ht), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT));
-		(ht)->u.flags |= HASH_FLAG_INITIALIZED;
+		HT_FLAGS(ht) |= HASH_FLAG_INITIALIZED;
 		if (EXPECTED(ht->nTableMask == (uint32_t)-8)) {
 			Bucket *arData = ht->arData;
 
@@ -147,7 +147,7 @@ static zend_always_inline void zend_hash_real_init_ex(HashTable *ht, int packed)
 static zend_always_inline void zend_hash_check_init(HashTable *ht, int packed)
 {
 	HT_ASSERT_RC1(ht);
-	if (UNEXPECTED(!((ht)->u.flags & HASH_FLAG_INITIALIZED))) {
+	if (UNEXPECTED(!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED))) {
 		zend_hash_real_init_ex(ht, packed);
 	}
 }
@@ -160,9 +160,8 @@ static const uint32_t uninitialized_bucket[-HT_MIN_MASK] =
 
 ZEND_API const HashTable zend_empty_array = {
 	.gc.rc.refcount = 2,
-	.gc.rc.u.type_info = IS_ARRAY | (GC_IMMUTABLE << GC_FLAGS_SHIFT),
+	.gc.rc.u.type_info = IS_ARRAY | (GC_IMMUTABLE << GC_FLAGS_SHIFT) | (HASH_FLAG_STATIC_KEYS << 16),
 	.gc.gc_root = 0,
-	.u.flags = HASH_FLAG_STATIC_KEYS,
 	.nTableMask = HT_MIN_MASK,
 	.arData = (Bucket*)&uninitialized_bucket[2],
 	.nNumUsed = 0,
@@ -178,7 +177,7 @@ static zend_always_inline void _zend_hash_init_int(HashTable *ht, uint32_t nSize
 	GC_SET_REFCOUNT(ht, 1);
 	GC_TYPE_INFO(ht) = IS_ARRAY | (persistent ? (GC_PERSISTENT << GC_FLAGS_SHIFT) : (GC_COLLECTABLE << GC_FLAGS_SHIFT));
 	ht->gc.gc_root = 0;
-	ht->u.flags = HASH_FLAG_STATIC_KEYS;
+	HT_FLAGS(ht) = HASH_FLAG_STATIC_KEYS;
 	ht->nTableMask = HT_MIN_MASK;
 	HT_SET_DATA_ADDR(ht, &uninitialized_bucket);
 	ht->nNumUsed = 0;
@@ -225,7 +224,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_packed_to_hash(HashTable *ht)
 	Bucket *old_buckets = ht->arData;
 
 	HT_ASSERT_RC1(ht);
-	ht->u.flags &= ~HASH_FLAG_PACKED;
+	HT_FLAGS(ht) &= ~HASH_FLAG_PACKED;
 	new_data = pemalloc(HT_SIZE_EX(ht->nTableSize, -ht->nTableSize), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
 	ht->nTableMask = -ht->nTableSize;
 	HT_SET_DATA_ADDR(ht, new_data);
@@ -241,7 +240,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_to_packed(HashTable *ht)
 
 	HT_ASSERT_RC1(ht);
 	new_data = pemalloc(HT_SIZE_EX(ht->nTableSize, HT_MIN_MASK), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
-	ht->u.flags |= HASH_FLAG_PACKED | HASH_FLAG_STATIC_KEYS;
+	HT_FLAGS(ht) |= HASH_FLAG_PACKED | HASH_FLAG_STATIC_KEYS;
 	ht->nTableMask = HT_MIN_MASK;
 	HT_SET_DATA_ADDR(ht, new_data);
 	HT_HASH_RESET_PACKED(ht);
@@ -253,20 +252,20 @@ ZEND_API void ZEND_FASTCALL zend_hash_extend(HashTable *ht, uint32_t nSize, zend
 {
 	HT_ASSERT_RC1(ht);
 	if (nSize == 0) return;
-	if (UNEXPECTED(!((ht)->u.flags & HASH_FLAG_INITIALIZED))) {
+	if (UNEXPECTED(!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED))) {
 		if (nSize > ht->nTableSize) {
 			ht->nTableSize = zend_hash_check_size(nSize);
 		}
 		zend_hash_check_init(ht, packed);
 	} else {
 		if (packed) {
-			ZEND_ASSERT(ht->u.flags & HASH_FLAG_PACKED);
+			ZEND_ASSERT(HT_FLAGS(ht) & HASH_FLAG_PACKED);
 			if (nSize > ht->nTableSize) {
 				ht->nTableSize = zend_hash_check_size(nSize);
 				HT_SET_DATA_ADDR(ht, perealloc2(HT_GET_DATA_ADDR(ht), HT_SIZE(ht), HT_USED_SIZE(ht), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT));
 			}
 		} else {
-			ZEND_ASSERT(!(ht->u.flags & HASH_FLAG_PACKED));
+			ZEND_ASSERT(!(HT_FLAGS(ht) & HASH_FLAG_PACKED));
 			if (nSize > ht->nTableSize) {
 				void *new_data, *old_data = HT_GET_DATA_ADDR(ht);
 				Bucket *old_buckets = ht->arData;
@@ -302,10 +301,10 @@ static uint32_t zend_array_recalc_elements(HashTable *ht)
 ZEND_API uint32_t zend_array_count(HashTable *ht)
 {
 	uint32_t num;
-	if (UNEXPECTED(ht->u.v.flags & HASH_FLAG_HAS_EMPTY_IND)) {
+	if (UNEXPECTED(HT_FLAGS(ht) & HASH_FLAG_HAS_EMPTY_IND)) {
 		num = zend_array_recalc_elements(ht);
 		if (UNEXPECTED(ht->nNumOfElements == num)) {
-			ht->u.v.flags &= ~HASH_FLAG_HAS_EMPTY_IND;
+			HT_FLAGS(ht) &= ~HASH_FLAG_HAS_EMPTY_IND;
 		}
 	} else if (UNEXPECTED(ht == &EG(symbol_table))) {
 		num = zend_array_recalc_elements(ht);
@@ -550,19 +549,19 @@ static zend_always_inline zval *_zend_hash_add_or_update_i(HashTable *ht, zend_s
 	IS_CONSISTENT(ht);
 	HT_ASSERT_RC1(ht);
 
-	if (UNEXPECTED(!(ht->u.flags & HASH_FLAG_INITIALIZED))) {
+	if (UNEXPECTED(!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED))) {
 		CHECK_INIT(ht, 0);
 		if (!ZSTR_IS_INTERNED(key)) {
 			zend_string_addref(key);
-			ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
+			HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 			zend_string_hash_val(key);
 		}
 		goto add_to_hash;
-	} else if (ht->u.flags & HASH_FLAG_PACKED) {
+	} else if (HT_FLAGS(ht) & HASH_FLAG_PACKED) {
 		zend_hash_packed_to_hash(ht);
 		if (!ZSTR_IS_INTERNED(key)) {
 			zend_string_addref(key);
-			ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
+			HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 			zend_string_hash_val(key);
 		}
 	} else if ((flag & HASH_ADD_NEW) == 0) {
@@ -600,11 +599,11 @@ static zend_always_inline zval *_zend_hash_add_or_update_i(HashTable *ht, zend_s
 		}
 		if (!ZSTR_IS_INTERNED(key)) {
 			zend_string_addref(key);
-			ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
+			HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 		}
 	} else if (!ZSTR_IS_INTERNED(key)) {
 		zend_string_addref(key);
-		ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
+		HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 		zend_string_hash_val(key);
 	}
 
@@ -638,10 +637,10 @@ static zend_always_inline zval *_zend_hash_str_add_or_update_i(HashTable *ht, co
 	IS_CONSISTENT(ht);
 	HT_ASSERT_RC1(ht);
 
-	if (UNEXPECTED(!(ht->u.flags & HASH_FLAG_INITIALIZED))) {
+	if (UNEXPECTED(!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED))) {
 		CHECK_INIT(ht, 0);
 		goto add_to_hash;
-	} else if (ht->u.flags & HASH_FLAG_PACKED) {
+	} else if (HT_FLAGS(ht) & HASH_FLAG_PACKED) {
 		zend_hash_packed_to_hash(ht);
 	} else if ((flag & HASH_ADD_NEW) == 0) {
 		p = zend_hash_str_find_bucket(ht, str, len, h);
@@ -690,7 +689,7 @@ add_to_hash:
 	p = ht->arData + idx;
 	p->key = key = zend_string_init(str, len, GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
 	p->h = ZSTR_H(key) = h;
-	ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
+	HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 	ZVAL_COPY_VALUE(&p->val, pData);
 	nIndex = h | ht->nTableMask;
 	Z_NEXT(p->val) = HT_HASH(ht, nIndex);
@@ -792,14 +791,14 @@ static zend_always_inline zval *_zend_hash_index_add_or_update_i(HashTable *ht, 
 	IS_CONSISTENT(ht);
 	HT_ASSERT_RC1(ht);
 
-	if (UNEXPECTED(!(ht->u.flags & HASH_FLAG_INITIALIZED))) {
+	if (UNEXPECTED(!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED))) {
 		CHECK_INIT(ht, h < ht->nTableSize);
 		if (h < ht->nTableSize) {
 			p = ht->arData + h;
 			goto add_to_packed;
 		}
 		goto add_to_hash;
-	} else if (ht->u.flags & HASH_FLAG_PACKED) {
+	} else if (HT_FLAGS(ht) & HASH_FLAG_PACKED) {
 		if (h < ht->nNumUsed) {
 			p = ht->arData + h;
 			if (Z_TYPE(p->val) != IS_UNDEF) {
@@ -958,7 +957,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 	IS_CONSISTENT(ht);
 
 	if (UNEXPECTED(ht->nNumOfElements == 0)) {
-		if (ht->u.flags & HASH_FLAG_INITIALIZED) {
+		if (HT_FLAGS(ht) & HASH_FLAG_INITIALIZED) {
 			ht->nNumUsed = 0;
 			HT_HASH_RESET(ht);
 		}
@@ -1036,7 +1035,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 
 static zend_always_inline void _zend_hash_del_el_ex(HashTable *ht, uint32_t idx, Bucket *p, Bucket *prev)
 {
-	if (!(ht->u.flags & HASH_FLAG_PACKED)) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_PACKED)) {
 		if (prev) {
 			Z_NEXT(prev->val) = Z_NEXT(p->val);
 		} else {
@@ -1084,7 +1083,7 @@ static zend_always_inline void _zend_hash_del_el(HashTable *ht, uint32_t idx, Bu
 {
 	Bucket *prev = NULL;
 
-	if (!(ht->u.flags & HASH_FLAG_PACKED)) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_PACKED)) {
 		uint32_t nIndex = p->h | ht->nTableMask;
 		uint32_t i = HT_HASH(ht, nIndex);
 
@@ -1172,7 +1171,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_del_ind(HashTable *ht, zend_string *key)
 					} else {
 						ZVAL_UNDEF(data);
 					}
-					ht->u.v.flags |= HASH_FLAG_HAS_EMPTY_IND;
+					HT_FLAGS(ht) |= HASH_FLAG_HAS_EMPTY_IND;
 				}
 			} else {
 				_zend_hash_del_el_ex(ht, idx, p, prev);
@@ -1216,7 +1215,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_str_del_ind(HashTable *ht, const char *str,
 						ht->pDestructor(data);
 					}
 					ZVAL_UNDEF(data);
-					ht->u.v.flags |= HASH_FLAG_HAS_EMPTY_IND;
+					HT_FLAGS(ht) |= HASH_FLAG_HAS_EMPTY_IND;
 				}
 			} else {
 				_zend_hash_del_el_ex(ht, idx, p, prev);
@@ -1269,7 +1268,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_index_del(HashTable *ht, zend_ulong h)
 	IS_CONSISTENT(ht);
 	HT_ASSERT_RC1(ht);
 
-	if (ht->u.flags & HASH_FLAG_PACKED) {
+	if (HT_FLAGS(ht) & HASH_FLAG_PACKED) {
 		if (h < ht->nNumUsed) {
 			p = ht->arData + h;
 			if (Z_TYPE(p->val) != IS_UNDEF) {
@@ -1350,7 +1349,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_destroy(HashTable *ht)
 			}
 		}
 		zend_hash_iterators_remove(ht);
-	} else if (EXPECTED(!(ht->u.flags & HASH_FLAG_INITIALIZED))) {
+	} else if (EXPECTED(!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED))) {
 		return;
 	}
 	pefree(HT_GET_DATA_ADDR(ht), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
@@ -1365,7 +1364,8 @@ ZEND_API void ZEND_FASTCALL zend_array_destroy(HashTable *ht)
 
 	/* break possible cycles */
 	GC_REMOVE_FROM_BUFFER(ht);
-	GC_TYPE_INFO(ht) = IS_NULL | (GC_WHITE << GC_FLAGS_SHIFT);
+	GC_TYPE(ht) = IS_NULL;
+	GC_FLAGS(ht) = GC_WHITE;
 
 	if (ht->nNumUsed) {
 		/* In some rare cases destructors of regular arrays may be changed */
@@ -1401,7 +1401,7 @@ ZEND_API void ZEND_FASTCALL zend_array_destroy(HashTable *ht)
 		}
 		zend_hash_iterators_remove(ht);
 		SET_INCONSISTENT(HT_DESTROYED);
-	} else if (EXPECTED(!(ht->u.flags & HASH_FLAG_INITIALIZED))) {
+	} else if (EXPECTED(!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED))) {
 		goto free_ht;
 	}
 	efree(HT_GET_DATA_ADDR(ht));
@@ -1468,7 +1468,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_clean(HashTable *ht)
 				}
 			}
 		}
-		if (!(ht->u.flags & HASH_FLAG_PACKED)) {
+		if (!(HT_FLAGS(ht) & HASH_FLAG_PACKED)) {
 			HT_HASH_RESET(ht);
 		}
 	}
@@ -1530,7 +1530,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_graceful_destroy(HashTable *ht)
 		if (UNEXPECTED(Z_TYPE(p->val) == IS_UNDEF)) continue;
 		_zend_hash_del_el(ht, HT_IDX_TO_HASH(idx), p);
 	}
-	if (ht->u.flags & HASH_FLAG_INITIALIZED) {
+	if (HT_FLAGS(ht) & HASH_FLAG_INITIALIZED) {
 		pefree(HT_GET_DATA_ADDR(ht), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
 	}
 
@@ -1554,7 +1554,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_graceful_reverse_destroy(HashTable *ht)
 		_zend_hash_del_el(ht, HT_IDX_TO_HASH(idx), p);
 	}
 
-	if (ht->u.flags & HASH_FLAG_INITIALIZED) {
+	if (HT_FLAGS(ht) & HASH_FLAG_INITIALIZED) {
 		pefree(HT_GET_DATA_ADDR(ht), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
 	}
 
@@ -1837,7 +1837,7 @@ ZEND_API HashTable* ZEND_FASTCALL zend_array_dup(HashTable *source)
 	target->pDestructor = source->pDestructor;
 
 	if (source->nNumUsed == 0) {
-		target->u.flags = (source->u.flags & ~(HASH_FLAG_INITIALIZED|HASH_FLAG_PACKED)) | HASH_FLAG_STATIC_KEYS;
+		HT_FLAGS(target) = (HT_FLAGS(source) & ~(HASH_FLAG_INITIALIZED|HASH_FLAG_PACKED)) | HASH_FLAG_STATIC_KEYS;
 		target->nTableMask = HT_MIN_MASK;
 		target->nNumUsed = 0;
 		target->nNumOfElements = 0;
@@ -1845,7 +1845,7 @@ ZEND_API HashTable* ZEND_FASTCALL zend_array_dup(HashTable *source)
 		target->nInternalPointer = HT_INVALID_IDX;
 		HT_SET_DATA_ADDR(target, &uninitialized_bucket);
 	} else if (GC_FLAGS(source) & IS_ARRAY_IMMUTABLE) {
-		target->u.flags = source->u.flags;
+		HT_FLAGS(target) = HT_FLAGS(source);
 		target->nTableMask = source->nTableMask;
 		target->nNumUsed = source->nNumUsed;
 		target->nNumOfElements = source->nNumOfElements;
@@ -1861,8 +1861,8 @@ ZEND_API HashTable* ZEND_FASTCALL zend_array_dup(HashTable *source)
 			}
 			target->nInternalPointer = idx;
 		}
-	} else if (source->u.flags & HASH_FLAG_PACKED) {
-		target->u.flags = source->u.flags;
+	} else if (HT_FLAGS(source) & HASH_FLAG_PACKED) {
+		HT_FLAGS(target) = HT_FLAGS(source);
 		target->nTableMask = source->nTableMask;
 		target->nNumUsed = source->nNumUsed;
 		target->nNumOfElements = source->nNumOfElements;
@@ -1885,7 +1885,7 @@ ZEND_API HashTable* ZEND_FASTCALL zend_array_dup(HashTable *source)
 			target->nInternalPointer = idx;
 		}
 	} else {
-		target->u.flags = source->u.flags;
+		HT_FLAGS(target) = HT_FLAGS(source);
 		target->nTableMask = source->nTableMask;
 		target->nNextFreeElement = source->nNextFreeElement;
 		target->nInternalPointer = source->nInternalPointer;
@@ -2078,7 +2078,7 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_index_find(const HashTable *ht, zend_ulon
 
 	IS_CONSISTENT(ht);
 
-	if (ht->u.flags & HASH_FLAG_PACKED) {
+	if (HT_FLAGS(ht) & HASH_FLAG_PACKED) {
 		if (h < ht->nNumUsed) {
 			p = ht->arData + h;
 			if (Z_TYPE(p->val) != IS_UNDEF) {
@@ -2108,7 +2108,7 @@ ZEND_API zend_bool ZEND_FASTCALL zend_hash_index_exists(const HashTable *ht, zen
 
 	IS_CONSISTENT(ht);
 
-	if (ht->u.flags & HASH_FLAG_PACKED) {
+	if (HT_FLAGS(ht) & HASH_FLAG_PACKED) {
 		if (h < ht->nNumUsed) {
 			if (Z_TYPE(ht->arData[h].val) != IS_UNDEF) {
 				return 1;
@@ -2348,7 +2348,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_sort_ex(HashTable *ht, sort_func_t sort, co
 
 	sort((void *)ht->arData, i, sizeof(Bucket), compar,
 			(swap_func_t)(renumber? zend_hash_bucket_renum_swap :
-				((ht->u.flags & HASH_FLAG_PACKED) ? zend_hash_bucket_packed_swap : zend_hash_bucket_swap)));
+				((HT_FLAGS(ht) & HASH_FLAG_PACKED) ? zend_hash_bucket_packed_swap : zend_hash_bucket_swap)));
 
 	ht->nNumUsed = i;
 	ht->nInternalPointer = 0;
@@ -2365,7 +2365,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_sort_ex(HashTable *ht, sort_func_t sort, co
 
 		ht->nNextFreeElement = i;
 	}
-	if (ht->u.flags & HASH_FLAG_PACKED) {
+	if (HT_FLAGS(ht) & HASH_FLAG_PACKED) {
 		if (!renumber) {
 			zend_hash_packed_to_hash(ht);
 		}
@@ -2375,7 +2375,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_sort_ex(HashTable *ht, sort_func_t sort, co
 			Bucket *old_buckets = ht->arData;
 
 			new_data = pemalloc(HT_SIZE_EX(ht->nTableSize, HT_MIN_MASK), (GC_FLAGS(ht) & IS_ARRAY_PERSISTENT));
-			ht->u.flags |= HASH_FLAG_PACKED | HASH_FLAG_STATIC_KEYS;
+			HT_FLAGS(ht) |= HASH_FLAG_PACKED | HASH_FLAG_STATIC_KEYS;
 			ht->nTableMask = HT_MIN_MASK;
 			HT_SET_DATA_ADDR(ht, new_data);
 			memcpy(ht->arData, old_buckets, sizeof(Bucket) * ht->nNumUsed);

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -158,8 +158,9 @@ static const uint32_t uninitialized_bucket[-HT_MIN_MASK] =
 	{HT_INVALID_IDX, HT_INVALID_IDX};
 
 ZEND_API const HashTable zend_empty_array = {
-	.gc.refcount = 2,
-	.gc.u.type_info = IS_ARRAY | (GC_IMMUTABLE << GC_FLAGS_SHIFT),
+	.gc.rc.refcount = 2,
+	.gc.rc.u.type_info = IS_ARRAY | (GC_IMMUTABLE << GC_FLAGS_SHIFT),
+	.gc.gc_root = 0,
 	.u.flags = HASH_FLAG_STATIC_KEYS,
 	.nTableMask = HT_MIN_MASK,
 	.arData = (Bucket*)&uninitialized_bucket[2],
@@ -175,6 +176,7 @@ static zend_always_inline void _zend_hash_init_int(HashTable *ht, uint32_t nSize
 {
 	GC_SET_REFCOUNT(ht, 1);
 	GC_TYPE_INFO(ht) = IS_ARRAY | (persistent ? (GC_PERSISTENT << GC_FLAGS_SHIFT) : (GC_COLLECTABLE << GC_FLAGS_SHIFT));
+	ht->gc.gc_root = 0;
 	ht->u.flags = HASH_FLAG_STATIC_KEYS;
 	ht->nTableMask = HT_MIN_MASK;
 	HT_SET_DATA_ADDR(ht, &uninitialized_bucket);
@@ -1362,7 +1364,7 @@ ZEND_API void ZEND_FASTCALL zend_array_destroy(HashTable *ht)
 
 	/* break possible cycles */
 	GC_REMOVE_FROM_BUFFER(ht);
-	GC_TYPE_INFO(ht) = IS_NULL | (GC_WHITE << 16);
+	GC_TYPE_INFO(ht) = IS_NULL | (GC_WHITE << GC_FLAGS_SHIFT);
 
 	if (ht->nNumUsed) {
 		/* In some rare cases destructors of regular arrays may be changed */
@@ -1828,6 +1830,7 @@ ZEND_API HashTable* ZEND_FASTCALL zend_array_dup(HashTable *source)
 	ALLOC_HASHTABLE(target);
 	GC_SET_REFCOUNT(target, 1);
 	GC_TYPE_INFO(target) = IS_ARRAY | (GC_COLLECTABLE << GC_FLAGS_SHIFT);
+	GC_SET_ADDRESS(target, 0);
 
 	target->nTableSize = source->nTableSize;
 	target->pDestructor = source->pDestructor;

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -41,22 +41,24 @@
 #define HASH_FLAG_HAS_EMPTY_IND    (1<<5)
 #define HASH_FLAG_ALLOW_COW_VIOLATION (1<<6)
 
+#define HT_FLAGS(ht) GC_EXTRA_FLAGS(ht)
+
 #define HT_IS_PACKED(ht) \
-	(((ht)->u.flags & HASH_FLAG_PACKED) != 0)
+	((HT_FLAGS(ht) & HASH_FLAG_PACKED) != 0)
 
 #define HT_IS_WITHOUT_HOLES(ht) \
 	((ht)->nNumUsed == (ht)->nNumOfElements)
 
 #define HT_HAS_STATIC_KEYS_ONLY(ht) \
-	(((ht)->u.flags & (HASH_FLAG_PACKED|HASH_FLAG_STATIC_KEYS)) != 0)
+	((HT_FLAGS(ht) & (HASH_FLAG_PACKED|HASH_FLAG_STATIC_KEYS)) != 0)
 
 #if ZEND_DEBUG
-# define HT_ALLOW_COW_VIOLATION(ht) (ht)->u.flags |= HASH_FLAG_ALLOW_COW_VIOLATION
+# define HT_ALLOW_COW_VIOLATION(ht) HT_FLAGS(ht) |= HASH_FLAG_ALLOW_COW_VIOLATION
 #else
 # define HT_ALLOW_COW_VIOLATION(ht)
 #endif
 
-#define HT_ITERATORS_COUNT(ht) (GC_EXTRA_FLAGS(ht) >> 8)
+#define HT_ITERATORS_COUNT(ht) (HT_FLAGS(ht) >> 8)
 #define HT_ITERATORS_OVERFLOW(ht) (HT_ITERATORS_COUNT(ht) == 0xff)
 #define HT_HAS_ITERATORS(ht) (HT_ITERATORS_COUNT(ht) != 0)
 
@@ -203,7 +205,7 @@ static zend_always_inline zval *zend_hash_find_ex(const HashTable *ht, zend_stri
 }
 
 #define ZEND_HASH_INDEX_FIND(_ht, _h, _ret, _not_found) do { \
-		if (EXPECTED((_ht)->u.flags & HASH_FLAG_PACKED)) { \
+		if (EXPECTED(HT_FLAGS(_ht) & HASH_FLAG_PACKED)) { \
 			if (EXPECTED((zend_ulong)(_h) < (zend_ulong)(_ht)->nNumUsed)) { \
 				_ret = &_ht->arData[_h].val; \
 				if (UNEXPECTED(Z_TYPE_P(_ret) == IS_UNDEF)) { \
@@ -1074,7 +1076,7 @@ static zend_always_inline void *zend_hash_get_current_data_ptr_ex(HashTable *ht,
 		HashTable *__fill_ht = (ht); \
 		Bucket *__fill_bkt = __fill_ht->arData + __fill_ht->nNumUsed; \
 		uint32_t __fill_idx = __fill_ht->nNumUsed; \
-		ZEND_ASSERT(__fill_ht->u.flags & HASH_FLAG_PACKED);
+		ZEND_ASSERT(HT_FLAGS(__fill_ht) & HASH_FLAG_PACKED);
 
 #define ZEND_HASH_FILL_ADD(_val) do { \
 		ZVAL_COPY_VALUE(&__fill_bkt->val, _val); \
@@ -1099,7 +1101,7 @@ static zend_always_inline zval *_zend_hash_append(HashTable *ht, zend_string *ke
 
 	ZVAL_COPY_VALUE(&p->val, zv);
 	if (!ZSTR_IS_INTERNED(key)) {
-		ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
+		HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 		zend_string_addref(key);
 		zend_string_hash_val(key);
 	}
@@ -1121,7 +1123,7 @@ static zend_always_inline zval *_zend_hash_append_ptr(HashTable *ht, zend_string
 
 	ZVAL_PTR(&p->val, ptr);
 	if (!ZSTR_IS_INTERNED(key)) {
-		ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
+		HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 		zend_string_addref(key);
 		zend_string_hash_val(key);
 	}
@@ -1143,7 +1145,7 @@ static zend_always_inline void _zend_hash_append_ind(HashTable *ht, zend_string 
 
 	ZVAL_INDIRECT(&p->val, ptr);
 	if (!ZSTR_IS_INTERNED(key)) {
-		ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
+		HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 		zend_string_addref(key);
 		zend_string_hash_val(key);
 	}

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -56,6 +56,17 @@
 # define HT_ALLOW_COW_VIOLATION(ht)
 #endif
 
+#define HT_ITERATORS_COUNT(ht) (GC_EXTRA_FLAGS(ht) >> 8)
+#define HT_ITERATORS_OVERFLOW(ht) (HT_ITERATORS_COUNT(ht) == 0xff)
+#define HT_HAS_ITERATORS(ht) (HT_ITERATORS_COUNT(ht) != 0)
+
+#define HT_SET_ITERATORS_COUNT(ht, iters) \
+	do { GC_EXTRA_FLAGS(ht) = ((iters) << 8) | (GC_EXTRA_FLAGS(ht) & 0xff); } while (0)
+#define HT_INC_ITERATORS_COUNT(ht) \
+	HT_SET_ITERATORS_COUNT(ht, HT_ITERATORS_COUNT(ht) + 1)
+#define HT_DEC_ITERATORS_COUNT(ht) \
+	HT_SET_ITERATORS_COUNT(ht, HT_ITERATORS_COUNT(ht) - 1)
+
 extern ZEND_API const HashTable zend_empty_array;
 
 #define ZVAL_EMPTY_ARRAY(z) do {						\
@@ -293,7 +304,7 @@ ZEND_API void         ZEND_FASTCALL _zend_hash_iterators_update(HashTable *ht, H
 
 static zend_always_inline void zend_hash_iterators_update(HashTable *ht, HashPosition from, HashPosition to)
 {
-	if (UNEXPECTED(ht->u.v.nIteratorsCount)) {
+	if (UNEXPECTED(HT_HAS_ITERATORS(ht))) {
 		_zend_hash_iterators_update(ht, from, to);
 	}
 }

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -75,7 +75,7 @@ ZEND_API void rebuild_object_properties(zend_object *zobj) /* {{{ */
 				    (prop_info->flags & ZEND_ACC_STATIC) == 0) {
 
 					if (UNEXPECTED(Z_TYPE_P(OBJ_PROP(zobj, prop_info->offset)) == IS_UNDEF)) {
-						zobj->properties->u.v.flags |= HASH_FLAG_HAS_EMPTY_IND;
+						HT_FLAGS(zobj->properties) |= HASH_FLAG_HAS_EMPTY_IND;
 					}
 
 					_zend_hash_append_ind(zobj->properties, prop_info->name,
@@ -91,7 +91,7 @@ ZEND_API void rebuild_object_properties(zend_object *zobj) /* {{{ */
 						zval zv;
 
 						if (UNEXPECTED(Z_TYPE_P(OBJ_PROP(zobj, prop_info->offset)) == IS_UNDEF)) {
-							zobj->properties->u.v.flags |= HASH_FLAG_HAS_EMPTY_IND;
+							HT_FLAGS(zobj->properties) |= HASH_FLAG_HAS_EMPTY_IND;
 						}
 
 						ZVAL_INDIRECT(&zv, OBJ_PROP(zobj, prop_info->offset));
@@ -966,7 +966,7 @@ static void zend_std_unset_property(zval *object, zval *member, void **cache_slo
 			zval_ptr_dtor(slot);
 			ZVAL_UNDEF(slot);
 			if (zobj->properties) {
-				zobj->properties->u.v.flags |= HASH_FLAG_HAS_EMPTY_IND;
+				HT_FLAGS(zobj->properties) |= HASH_FLAG_HAS_EMPTY_IND;
 			}
 			goto exit;
 		}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -495,7 +495,7 @@ ZEND_API uint32_t *zend_get_property_guard(zend_object *zobj, zend_string *membe
 	zval *zv;
 	uint32_t *ptr;
 
-	ZEND_ASSERT(GC_FLAGS(zobj) & IS_OBJ_USE_GUARDS);
+	ZEND_ASSERT(GC_EXTRA_FLAGS(zobj) & IS_OBJ_USE_GUARDS);
 	zv = zobj->properties_table + zobj->ce->default_properties_count;
 	if (EXPECTED(Z_TYPE_P(zv) == IS_STRING)) {
 		zend_string *str = Z_STR_P(zv);
@@ -526,7 +526,7 @@ ZEND_API uint32_t *zend_get_property_guard(zend_object *zobj, zend_string *membe
 		}
 	} else {
 		ZEND_ASSERT(Z_TYPE_P(zv) == IS_UNDEF);
-		GC_FLAGS(zobj) |= IS_OBJ_HAS_GUARDS;
+		GC_EXTRA_FLAGS(zobj) |= IS_OBJ_HAS_GUARDS;
 		ZVAL_STR_COPY(zv, member);
 		zv->u2.property_guard = 0;
 		return &zv->u2.property_guard;

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -204,8 +204,8 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 			zend_hash_extend(new_object->properties, new_object->properties->nNumUsed + zend_hash_num_elements(old_object->properties), 0);
 		}
 
-		new_object->properties->u.v.flags |=
-			old_object->properties->u.v.flags & HASH_FLAG_HAS_EMPTY_IND;
+		HT_FLAGS(new_object->properties) |=
+			HT_FLAGS(old_object->properties) & HASH_FLAG_HAS_EMPTY_IND;
 
 		ZEND_HASH_FOREACH_KEY_VAL(old_object->properties, num_key, key, prop) {
 			if (Z_TYPE_P(prop) == IS_INDIRECT) {

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -31,11 +31,12 @@ ZEND_API void ZEND_FASTCALL zend_object_std_init(zend_object *object, zend_class
 {
 	GC_SET_REFCOUNT(object, 1);
 	GC_TYPE_INFO(object) = IS_OBJECT | (GC_COLLECTABLE << GC_FLAGS_SHIFT);
+	object->gc.gc_root = 0;
 	object->ce = ce;
 	object->properties = NULL;
 	zend_objects_store_put(object);
 	if (UNEXPECTED(ce->ce_flags & ZEND_ACC_USE_GUARDS)) {
-		GC_FLAGS(object) |= IS_OBJ_USE_GUARDS;
+		GC_EXTRA_FLAGS(object) |= IS_OBJ_USE_GUARDS;
 		ZVAL_UNDEF(object->properties_table + object->ce->default_properties_count);
 	}
 }
@@ -59,7 +60,7 @@ ZEND_API void zend_object_std_dtor(zend_object *object)
 			p++;
 		} while (p != end);
 	}
-	if (UNEXPECTED(GC_FLAGS(object) & IS_OBJ_HAS_GUARDS)) {
+	if (UNEXPECTED(GC_EXTRA_FLAGS(object) & IS_OBJ_HAS_GUARDS)) {
 		if (EXPECTED(Z_TYPE_P(p) == IS_STRING)) {
 			zend_string_release(Z_STR_P(p));
 		} else {

--- a/Zend/zend_objects_API.c
+++ b/Zend/zend_objects_API.c
@@ -48,8 +48,8 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_call_destructors(zend_objects_sto
 		for (i = 1; i < objects->top; i++) {
 			zend_object *obj = objects->object_buckets[i];
 			if (IS_OBJ_VALID(obj)) {
-				if (!(GC_FLAGS(obj) & IS_OBJ_DESTRUCTOR_CALLED)) {
-					GC_FLAGS(obj) |= IS_OBJ_DESTRUCTOR_CALLED;
+				if (!(GC_EXTRA_FLAGS(obj) & IS_OBJ_DESTRUCTOR_CALLED)) {
+					GC_EXTRA_FLAGS(obj) |= IS_OBJ_DESTRUCTOR_CALLED;
 
 					if (obj->handlers->dtor_obj
 					 && (obj->handlers->dtor_obj != zend_objects_destroy_object
@@ -74,7 +74,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_mark_destructed(zend_objects_stor
 			zend_object *obj = *obj_ptr;
 
 			if (IS_OBJ_VALID(obj)) {
-				GC_FLAGS(obj) |= IS_OBJ_DESTRUCTOR_CALLED;
+				GC_EXTRA_FLAGS(obj) |= IS_OBJ_DESTRUCTOR_CALLED;
 			}
 			obj_ptr++;
 		} while (obj_ptr != end);
@@ -98,8 +98,8 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_free_object_storage(zend_objects_
 			obj_ptr--;
 			obj = *obj_ptr;
 			if (IS_OBJ_VALID(obj)) {
-				if (!(GC_FLAGS(obj) & IS_OBJ_FREE_CALLED)) {
-					GC_FLAGS(obj) |= IS_OBJ_FREE_CALLED;
+				if (!(GC_EXTRA_FLAGS(obj) & IS_OBJ_FREE_CALLED)) {
+					GC_EXTRA_FLAGS(obj) |= IS_OBJ_FREE_CALLED;
 					if (obj->handlers->free_obj && obj->handlers->free_obj != zend_object_std_dtor) {
 						GC_ADDREF(obj);
 						obj->handlers->free_obj(obj);
@@ -113,8 +113,8 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_free_object_storage(zend_objects_
 			obj_ptr--;
 			obj = *obj_ptr;
 			if (IS_OBJ_VALID(obj)) {
-				if (!(GC_FLAGS(obj) & IS_OBJ_FREE_CALLED)) {
-					GC_FLAGS(obj) |= IS_OBJ_FREE_CALLED;
+				if (!(GC_EXTRA_FLAGS(obj) & IS_OBJ_FREE_CALLED)) {
+					GC_EXTRA_FLAGS(obj) |= IS_OBJ_FREE_CALLED;
 					if (obj->handlers->free_obj) {
 						GC_ADDREF(obj);
 						obj->handlers->free_obj(obj);
@@ -164,8 +164,8 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_del(zend_object *object) /* {{{ *
 	ZEND_ASSERT(IS_OBJ_VALID(EG(objects_store).object_buckets[object->handle]));
 	ZEND_ASSERT(GC_REFCOUNT(object) == 0);
 
-	if (!(GC_FLAGS(object) & IS_OBJ_DESTRUCTOR_CALLED)) {
-		GC_FLAGS(object) |= IS_OBJ_DESTRUCTOR_CALLED;
+	if (!(GC_EXTRA_FLAGS(object) & IS_OBJ_DESTRUCTOR_CALLED)) {
+		GC_EXTRA_FLAGS(object) |= IS_OBJ_DESTRUCTOR_CALLED;
 
 		if (object->handlers->dtor_obj
 		 && (object->handlers->dtor_obj != zend_objects_destroy_object
@@ -181,8 +181,8 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_del(zend_object *object) /* {{{ *
 		void *ptr;
 
 		EG(objects_store).object_buckets[handle] = SET_OBJ_INVALID(object);
-		if (!(GC_FLAGS(object) & IS_OBJ_FREE_CALLED)) {
-			GC_FLAGS(object) |= IS_OBJ_FREE_CALLED;
+		if (!(GC_EXTRA_FLAGS(object) & IS_OBJ_FREE_CALLED)) {
+			GC_EXTRA_FLAGS(object) |= IS_OBJ_FREE_CALLED;
 			if (object->handlers->free_obj) {
 				GC_ADDREF(object);
 				object->handlers->free_obj(object);

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -62,7 +62,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_del(zend_object *object);
 /* Called when the ctor was terminated by an exception */
 static zend_always_inline void zend_object_store_ctor_failed(zend_object *obj)
 {
-	GC_FLAGS(obj) |= IS_OBJ_DESTRUCTOR_CALLED;
+	GC_EXTRA_FLAGS(obj) |= IS_OBJ_DESTRUCTOR_CALLED;
 }
 
 #define ZEND_OBJECTS_STORE_HANDLERS 0, zend_object_std_dtor, zend_objects_destroy_object, zend_objects_clone_obj
@@ -74,8 +74,8 @@ static zend_always_inline void zend_object_release(zend_object *obj)
 {
 	if (GC_DELREF(obj) == 0) {
 		zend_objects_store_del(obj);
-	} else if (UNEXPECTED(GC_MAY_LEAK((zend_refcounted*)obj))) {
-		gc_possible_root((zend_refcounted*)obj);
+	} else if (UNEXPECTED(GC_MAY_LEAK(obj))) {
+		gc_possible_root((zend_refcounted *) obj);
 	}
 }
 

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -142,7 +142,7 @@ static zend_always_inline zend_string *zend_string_alloc(size_t len, int persist
 #else
 	GC_TYPE(ret) = IS_STRING;
 	GC_FLAGS(ret) = (persistent ? IS_STR_PERSISTENT : 0);
-	GC_INFO(ret) = 0;
+	GC_EXTRA_FLAGS(ret) = 0;
 #endif
 	zend_string_forget_hash_val(ret);
 	ZSTR_LEN(ret) = len;
@@ -160,7 +160,7 @@ static zend_always_inline zend_string *zend_string_safe_alloc(size_t n, size_t m
 #else
 	GC_TYPE(ret) = IS_STRING;
 	GC_FLAGS(ret) = (persistent ? IS_STR_PERSISTENT : 0);
-	GC_INFO(ret) = 0;
+	GC_EXTRA_FLAGS(ret) = 0;
 #endif
 	zend_string_forget_hash_val(ret);
 	ZSTR_LEN(ret) = (n * m) + l;

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -253,7 +253,7 @@ struct _zend_array {
 			ZEND_ENDIAN_LOHI_4(
 				zend_uchar    flags,
 				zend_uchar    _unused,
-				zend_uchar    nIteratorsCount,
+				zend_uchar    _unused2,
 				zend_uchar    consistency)
 		} v;
 		uint32_t flags;

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -203,18 +203,29 @@ struct _zval_struct {
 	} u2;
 };
 
-typedef struct _zend_refcounted_h {
+typedef struct _zend_refcounted_common {
 	uint32_t         refcount;			/* reference counter 32-bit */
 	union {
 		struct {
 			ZEND_ENDIAN_LOHI_3(
 				zend_uchar    type,
-				zend_uchar    flags,    /* used for strings & objects */
-				uint16_t      gc_info)  /* keeps GC root number (or 0) and color */
+				zend_uchar    gc_flags,    /* GC flags, including GC color */
+				uint16_t      extra_flags) /* additional type specific flags */
 		} v;
 		uint32_t type_info;
 	} u;
+} zend_refcounted_common;
+
+/* This wrapper exists so that refcounted_h and refcounted_gc_h use the same
+ * field nesting to access the common RC information. */
+typedef struct _zend_refcounted_h {
+	zend_refcounted_common rc;
 } zend_refcounted_h;
+
+typedef struct _zend_refcounted_gc_h {
+	zend_refcounted_common rc;
+	uint32_t gc_root;
+} zend_refcounted_gc_h;
 
 struct _zend_refcounted {
 	zend_refcounted_h gc;
@@ -236,7 +247,7 @@ typedef struct _Bucket {
 typedef struct _zend_array HashTable;
 
 struct _zend_array {
-	zend_refcounted_h gc;
+	zend_refcounted_gc_h gc;
 	union {
 		struct {
 			ZEND_ENDIAN_LOHI_4(
@@ -335,7 +346,7 @@ typedef struct _HashTableIterator {
 } HashTableIterator;
 
 struct _zend_object {
-	zend_refcounted_h gc;
+	zend_refcounted_gc_h gc;
 	uint32_t          handle; // TODO: may be removed ???
 	zend_class_entry *ce;
 	const zend_object_handlers *handlers;
@@ -432,17 +443,20 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 
 #define Z_TYPE_FLAGS_SHIFT			8
 
-#define GC_REFCOUNT(p)				zend_gc_refcount(&(p)->gc)
-#define GC_SET_REFCOUNT(p, rc)		zend_gc_set_refcount(&(p)->gc, rc)
-#define GC_ADDREF(p)				zend_gc_addref(&(p)->gc)
-#define GC_DELREF(p)				zend_gc_delref(&(p)->gc)
-#define GC_ADDREF_EX(p, rc)			zend_gc_addref_ex(&(p)->gc, rc)
-#define GC_DELREF_EX(p, rc)			zend_gc_delref_ex(&(p)->gc, rc)
+#define GC_REFCOUNT(p)				zend_gc_refcount(&(p)->gc.rc)
+#define GC_SET_REFCOUNT(p, rcnt)	zend_gc_set_refcount(&(p)->gc.rc, rcnt)
+#define GC_ADDREF(p)				zend_gc_addref(&(p)->gc.rc)
+#define GC_DELREF(p)				zend_gc_delref(&(p)->gc.rc)
+#define GC_ADDREF_EX(p, rcnt)		zend_gc_addref_ex(&(p)->gc.rc, rcnt)
+#define GC_DELREF_EX(p, rcnt)		zend_gc_delref_ex(&(p)->gc.rc, rcnt)
 
-#define GC_TYPE(p)					(p)->gc.u.v.type
-#define GC_FLAGS(p)					(p)->gc.u.v.flags
-#define GC_INFO(p)					(p)->gc.u.v.gc_info
-#define GC_TYPE_INFO(p)				(p)->gc.u.type_info
+#define GC_TYPE(p)					(p)->gc.rc.u.v.type
+#define GC_FLAGS(p)					(p)->gc.rc.u.v.gc_flags
+#define GC_EXTRA_FLAGS(p)			(p)->gc.rc.u.v.extra_flags
+#define GC_TYPE_INFO(p)				(p)->gc.rc.u.type_info
+
+#define GC_ADDRESS(p)				zend_gc_address(&(p)->gc.rc)
+#define GC_SET_ADDRESS(p, addr)		zend_gc_set_address(&(p)->gc.rc, addr)
 
 #define Z_GC_TYPE(zval)				GC_TYPE(Z_COUNTED(zval))
 #define Z_GC_TYPE_P(zval_p)			Z_GC_TYPE(*(zval_p))
@@ -450,21 +464,24 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_GC_FLAGS(zval)			GC_FLAGS(Z_COUNTED(zval))
 #define Z_GC_FLAGS_P(zval_p)		Z_GC_FLAGS(*(zval_p))
 
-#define Z_GC_INFO(zval)				GC_INFO(Z_COUNTED(zval))
-#define Z_GC_INFO_P(zval_p)			Z_GC_INFO(*(zval_p))
 #define Z_GC_TYPE_INFO(zval)		GC_TYPE_INFO(Z_COUNTED(zval))
 #define Z_GC_TYPE_INFO_P(zval_p)	Z_GC_TYPE_INFO(*(zval_p))
 
 #define GC_FLAGS_SHIFT				8
-#define GC_INFO_SHIFT				16
-#define GC_INFO_MASK				0xffff0000
 
-/* zval.value->gc.u.v.flags (common flags) */
+/* zval.value->gc.rc.u.v.gc_flags (common flags) */
 #define GC_COLLECTABLE				(1<<0)
 #define GC_PROTECTED                (1<<1) /* used for recursion detection */
 #define GC_IMMUTABLE                (1<<2) /* can't be canged in place */
 #define GC_PERSISTENT               (1<<3) /* allocated using malloc */
 #define GC_PERSISTENT_LOCAL         (1<<4) /* persistent, but thread-local */
+
+/* GC colors */
+#define GC_COLOR                    (3<<6)
+#define GC_BLACK                    (0<<6)
+#define GC_WHITE                    (1<<6)
+#define GC_GREY                     (2<<6)
+#define GC_PURPLE                   (3<<6)
 
 #define GC_ARRAY					(IS_ARRAY          | (GC_COLLECTABLE << GC_FLAGS_SHIFT))
 #define GC_OBJECT					(IS_OBJECT         | (GC_COLLECTABLE << GC_FLAGS_SHIFT))
@@ -484,7 +501,7 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 
 #define IS_CONSTANT_AST_EX			(IS_CONSTANT_AST   | ((IS_TYPE_REFCOUNTED                   ) << Z_TYPE_FLAGS_SHIFT))
 
-/* string flags (zval.value->gc.u.flags) */
+/* string flags (zval.value->gc.rc.u.gc_flags) */
 #define IS_STR_INTERNED				GC_IMMUTABLE  /* interned string */
 #define IS_STR_PERSISTENT			GC_PERSISTENT /* allocated using malloc */
 #define IS_STR_PERMANENT        	(1<<5)        /* relives request boundary */
@@ -493,7 +510,7 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define IS_ARRAY_IMMUTABLE			GC_IMMUTABLE
 #define IS_ARRAY_PERSISTENT			GC_PERSISTENT
 
-/* object flags (zval.value->gc.u.flags) */
+/* object flags (zval.value->gc.rc.u.extra_flags) */
 #define IS_OBJ_DESTRUCTOR_CALLED	(1<<4)
 #define IS_OBJ_FREE_CALLED			(1<<5)
 #define IS_OBJ_USE_GUARDS           (1<<6)
@@ -903,35 +920,45 @@ extern ZEND_API zend_bool zend_rc_debug;
 	do { } while (0)
 #endif
 
-static zend_always_inline uint32_t zend_gc_refcount(const zend_refcounted_h *p) {
+static zend_always_inline uint32_t zend_gc_refcount(const zend_refcounted_common *p) {
 	return p->refcount;
 }
 
-static zend_always_inline uint32_t zend_gc_set_refcount(zend_refcounted_h *p, uint32_t rc) {
+static zend_always_inline uint32_t zend_gc_set_refcount(zend_refcounted_common *p, uint32_t rc) {
 	p->refcount = rc;
 	return p->refcount;
 }
 
-static zend_always_inline uint32_t zend_gc_addref(zend_refcounted_h *p) {
+static zend_always_inline uint32_t zend_gc_addref(zend_refcounted_common *p) {
 	ZEND_RC_MOD_CHECK(p);
 	return ++(p->refcount);
 }
 
-static zend_always_inline uint32_t zend_gc_delref(zend_refcounted_h *p) {
+static zend_always_inline uint32_t zend_gc_delref(zend_refcounted_common *p) {
 	ZEND_RC_MOD_CHECK(p);
 	return --(p->refcount);
 }
 
-static zend_always_inline uint32_t zend_gc_addref_ex(zend_refcounted_h *p, uint32_t rc) {
+static zend_always_inline uint32_t zend_gc_addref_ex(zend_refcounted_common *p, uint32_t rc) {
 	ZEND_RC_MOD_CHECK(p);
 	p->refcount += rc;
 	return p->refcount;
 }
 
-static zend_always_inline uint32_t zend_gc_delref_ex(zend_refcounted_h *p, uint32_t rc) {
+static zend_always_inline uint32_t zend_gc_delref_ex(zend_refcounted_common *p, uint32_t rc) {
 	ZEND_RC_MOD_CHECK(p);
 	p->refcount -= rc;
 	return p->refcount;
+}
+
+static zend_always_inline uint32_t zend_gc_address(zend_refcounted_common *p) {
+	ZEND_ASSERT(p->u.v.gc_flags & GC_COLLECTABLE);
+	return ((zend_refcounted_gc_h *) p)->gc_root;
+}
+
+static zend_always_inline void zend_gc_set_address(zend_refcounted_common *p, uint32_t addr) {
+	ZEND_ASSERT(p->u.v.gc_flags & GC_COLLECTABLE);
+	((zend_refcounted_gc_h *) p)->gc_root = addr;
 }
 
 static zend_always_inline uint32_t zval_refcount_p(const zval* pz) {

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -248,16 +248,6 @@ typedef struct _zend_array HashTable;
 
 struct _zend_array {
 	zend_refcounted_gc_h gc;
-	union {
-		struct {
-			ZEND_ENDIAN_LOHI_4(
-				zend_uchar    flags,
-				zend_uchar    _unused,
-				zend_uchar    _unused2,
-				zend_uchar    _unused3)
-		} v;
-		uint32_t flags;
-	} u;
 	uint32_t          nTableMask;
 	Bucket           *arData;
 	uint32_t          nNumUsed;

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -254,7 +254,7 @@ struct _zend_array {
 				zend_uchar    flags,
 				zend_uchar    _unused,
 				zend_uchar    _unused2,
-				zend_uchar    consistency)
+				zend_uchar    _unused3)
 		} v;
 		uint32_t flags;
 	} u;

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -180,15 +180,15 @@ static void zend_hash_clone_constants(HashTable *ht, HashTable *source)
 	ht->nNumOfElements = source->nNumOfElements;
 	ht->nNextFreeElement = source->nNextFreeElement;
 	ht->pDestructor = ZVAL_PTR_DTOR;
-	ht->u.flags = (source->u.flags & HASH_FLAG_INITIALIZED);
+	HT_FLAGS(ht) = (HT_FLAGS(source) & HASH_FLAG_INITIALIZED);
 	ht->nInternalPointer = source->nNumOfElements ? 0 : HT_INVALID_IDX;
 
-	if (!(ht->u.flags & HASH_FLAG_INITIALIZED)) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED)) {
 		ht->arData = source->arData;
 		return;
 	}
 
-	ZEND_ASSERT((source->u.flags & HASH_FLAG_PACKED) == 0);
+	ZEND_ASSERT((HT_FLAGS(source) & HASH_FLAG_PACKED) == 0);
 	HT_SET_DATA_ADDR(ht, emalloc(HT_SIZE(ht)));
 	HT_HASH_RESET(ht);
 
@@ -231,15 +231,15 @@ static void zend_hash_clone_methods(HashTable *ht, HashTable *source, zend_class
 	ht->nNumOfElements = source->nNumOfElements;
 	ht->nNextFreeElement = source->nNextFreeElement;
 	ht->pDestructor = ZEND_FUNCTION_DTOR;
-	ht->u.flags = (source->u.flags & HASH_FLAG_INITIALIZED);
+	HT_FLAGS(ht) = (HT_FLAGS(source) & HASH_FLAG_INITIALIZED);
 	ht->nInternalPointer = source->nNumOfElements ? 0 : HT_INVALID_IDX;
 
-	if (!(ht->u.flags & HASH_FLAG_INITIALIZED)) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED)) {
 		ht->arData = source->arData;
 		return;
 	}
 
-	ZEND_ASSERT(!(source->u.flags & HASH_FLAG_PACKED));
+	ZEND_ASSERT(!(HT_FLAGS(source) & HASH_FLAG_PACKED));
 	HT_SET_DATA_ADDR(ht, emalloc(HT_SIZE(ht)));
 	HT_HASH_RESET(ht);
 
@@ -289,15 +289,15 @@ static void zend_hash_clone_prop_info(HashTable *ht, HashTable *source, zend_cla
 	ht->nNumOfElements = source->nNumOfElements;
 	ht->nNextFreeElement = source->nNextFreeElement;
 	ht->pDestructor = NULL;
-	ht->u.flags = (source->u.flags & HASH_FLAG_INITIALIZED);
+	HT_FLAGS(ht) = (HT_FLAGS(source) & HASH_FLAG_INITIALIZED);
 	ht->nInternalPointer = source->nNumOfElements ? 0 : HT_INVALID_IDX;
 
-	if (!(ht->u.flags & HASH_FLAG_INITIALIZED)) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED)) {
 		ht->arData = source->arData;
 		return;
 	}
 
-	ZEND_ASSERT(!(source->u.flags & HASH_FLAG_PACKED));
+	ZEND_ASSERT(!(HT_FLAGS(source) & HASH_FLAG_PACKED));
 	HT_SET_DATA_ADDR(ht, emalloc(HT_SIZE(ht)));
 	HT_HASH_RESET(ht);
 

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -255,7 +255,7 @@ static void zend_file_cache_serialize_hash(HashTable                *ht,
 {
 	Bucket *p, *end;
 
-	if (!(ht->u.flags & HASH_FLAG_INITIALIZED)) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED)) {
 		ht->arData = NULL;
 		return;
 	}
@@ -880,7 +880,7 @@ static void zend_file_cache_unserialize_hash(HashTable               *ht,
 	Bucket *p, *end;
 
 	ht->pDestructor = dtor;
-	if (!(ht->u.flags & HASH_FLAG_INITIALIZED)) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED)) {
 		HT_SET_DATA_ADDR(ht, &uninitialized_bucket);
 		return;
 	}

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -86,7 +86,7 @@ static void zend_hash_persist(HashTable *ht, zend_persist_func_t pPersistElement
 	uint32_t idx, nIndex;
 	Bucket *p;
 
-	if (!(ht->u.flags & HASH_FLAG_INITIALIZED)) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED)) {
 		HT_SET_DATA_ADDR(ht, &uninitialized_bucket);
 		return;
 	}
@@ -94,10 +94,10 @@ static void zend_hash_persist(HashTable *ht, zend_persist_func_t pPersistElement
 		efree(HT_GET_DATA_ADDR(ht));
 		ht->nTableMask = HT_MIN_MASK;
 		HT_SET_DATA_ADDR(ht, &uninitialized_bucket);
-		ht->u.flags &= ~HASH_FLAG_INITIALIZED;
+		HT_FLAGS(ht) &= ~HASH_FLAG_INITIALIZED;
 		return;
 	}
-	if (ht->u.flags & HASH_FLAG_PACKED) {
+	if (HT_FLAGS(ht) & HASH_FLAG_PACKED) {
 		void *data = HT_GET_DATA_ADDR(ht);
 		zend_accel_store(data, HT_USED_SIZE(ht));
 		HT_SET_DATA_ADDR(ht, data);
@@ -170,7 +170,7 @@ static void zend_hash_persist_immutable(HashTable *ht)
 	uint32_t idx, nIndex;
 	Bucket *p;
 
-	if (!(ht->u.flags & HASH_FLAG_INITIALIZED)) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED)) {
 		HT_SET_DATA_ADDR(ht, &uninitialized_bucket);
 		return;
 	}
@@ -178,10 +178,10 @@ static void zend_hash_persist_immutable(HashTable *ht)
 		efree(HT_GET_DATA_ADDR(ht));
 		ht->nTableMask = HT_MIN_MASK;
 		HT_SET_DATA_ADDR(ht, &uninitialized_bucket);
-		ht->u.flags &= ~HASH_FLAG_INITIALIZED;
+		HT_FLAGS(ht) &= ~HASH_FLAG_INITIALIZED;
 		return;
 	}
-	if (ht->u.flags & HASH_FLAG_PACKED) {
+	if (HT_FLAGS(ht) & HASH_FLAG_PACKED) {
 		HT_SET_DATA_ADDR(ht, zend_accel_memdup(HT_GET_DATA_ADDR(ht), HT_USED_SIZE(ht)));
 	} else if (ht->nNumUsed < (uint32_t)(-(int32_t)ht->nTableMask) / 2) {
 		/* compact table */
@@ -302,7 +302,7 @@ static void zend_persist_zval(zval *z)
 					Z_TYPE_FLAGS_P(z) = IS_TYPE_COPYABLE;
 					GC_SET_REFCOUNT(Z_COUNTED_P(z), 2);
 					GC_FLAGS(Z_COUNTED_P(z)) |= IS_ARRAY_IMMUTABLE;
-					Z_ARRVAL_P(z)->u.flags |= HASH_FLAG_STATIC_KEYS;
+					HT_FLAGS(Z_ARRVAL_P(z)) |= HASH_FLAG_STATIC_KEYS;
 				}
 			}
 			break;
@@ -367,8 +367,9 @@ static void zend_persist_op_array_ex(zend_op_array *op_array, zend_persistent_sc
 			zend_accel_store(op_array->static_variables, sizeof(HashTable));
 			/* make immutable array */
 			GC_SET_REFCOUNT(op_array->static_variables, 2);
-			GC_TYPE_INFO(op_array->static_variables) = IS_ARRAY | (IS_ARRAY_IMMUTABLE << GC_FLAGS_SHIFT);
-			op_array->static_variables->u.flags |= HASH_FLAG_STATIC_KEYS;
+			GC_TYPE(op_array->static_variables) = IS_ARRAY;
+			GC_FLAGS(op_array->static_variables) = IS_ARRAY_IMMUTABLE;
+			HT_FLAGS(op_array->static_variables) |= HASH_FLAG_STATIC_KEYS;
 		}
 	}
 

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -56,11 +56,11 @@ static void zend_hash_persist_calc(HashTable *ht, void (*pPersistElement)(zval *
 	uint32_t idx;
 	Bucket *p;
 
-	if (!(ht->u.flags & HASH_FLAG_INITIALIZED) || ht->nNumUsed == 0) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_INITIALIZED) || ht->nNumUsed == 0) {
 		return;
 	}
 
-	if (!(ht->u.flags & HASH_FLAG_PACKED) && ht->nNumUsed < (uint32_t)(-(int32_t)ht->nTableMask) / 2) {
+	if (!(HT_FLAGS(ht) & HASH_FLAG_PACKED) && ht->nNumUsed < (uint32_t)(-(int32_t)ht->nTableMask) / 2) {
 		/* compact table */
 		uint32_t hash_size;
 

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -90,7 +90,7 @@ static int pdo_mysql_stmt_dtor(pdo_stmt_t *stmt) /* {{{ */
 
 	if (!Z_ISUNDEF(stmt->database_object_handle)
 		&& IS_OBJ_VALID(EG(objects_store).object_buckets[Z_OBJ_HANDLE(stmt->database_object_handle)])
-		&& (!(GC_FLAGS(Z_OBJ(stmt->database_object_handle)) & IS_OBJ_FREE_CALLED))) {
+		&& (!(GC_EXTRA_FLAGS(Z_OBJ(stmt->database_object_handle)) & IS_OBJ_FREE_CALLED))) {
 		while (mysql_more_results(S->H->server)) {
 			MYSQL_RES *res;
 			if (mysql_next_result(S->H->server) != 0) {

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -63,7 +63,7 @@ static int pgsql_stmt_dtor(pdo_stmt_t *stmt)
 	pdo_pgsql_stmt *S = (pdo_pgsql_stmt*)stmt->driver_data;
 	zend_bool server_obj_usable = !Z_ISUNDEF(stmt->database_object_handle)
 		&& IS_OBJ_VALID(EG(objects_store).object_buckets[Z_OBJ_HANDLE(stmt->database_object_handle)])
-		&& !(GC_FLAGS(Z_OBJ(stmt->database_object_handle)) & IS_OBJ_FREE_CALLED);
+		&& !(GC_EXTRA_FLAGS(Z_OBJ(stmt->database_object_handle)) & IS_OBJ_FREE_CALLED);
 
 	if (S->result) {
 		/* free the resource */

--- a/ext/phar/dirstream.c
+++ b/ext/phar/dirstream.c
@@ -44,9 +44,9 @@ static int phar_dir_close(php_stream *stream, int close_handle)  /* {{{ */
 {
 	HashTable *data = (HashTable *)stream->abstract;
 
-	if (data && data->u.flags) {
+	if (data && HT_FLAGS(data)) {
 		zend_hash_destroy(data);
-		data->u.flags = 0;
+		HT_FLAGS(data) = 0;
 		FREE_HASHTABLE(data);
 		stream->abstract = NULL;
 	}
@@ -361,7 +361,7 @@ php_stream *phar_wrapper_open_dir(php_stream_wrapper *wrapper, const char *path,
 		return ret;
 	}
 
-	if (!phar->manifest.u.flags) {
+	if (!HT_FLAGS(&phar->manifest)) {
 		php_url_free(resource);
 		return NULL;
 	}

--- a/ext/phar/func_interceptors.c
+++ b/ext/phar/func_interceptors.c
@@ -33,8 +33,8 @@ PHAR_FUNC(phar_opendir) /* {{{ */
 		goto skip_phar;
 	}
 
-	if ((PHAR_G(phar_fname_map.u.flags) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
-		&& !cached_phars.u.flags) {
+	if ((HT_FLAGS(&PHAR_G(phar_fname_map)) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
+		&& !HT_FLAGS(&cached_phars)) {
 		goto skip_phar;
 	}
 
@@ -106,8 +106,8 @@ PHAR_FUNC(phar_file_get_contents) /* {{{ */
 		goto skip_phar;
 	}
 
-	if ((PHAR_G(phar_fname_map.u.flags) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
-		&& !cached_phars.u.flags) {
+	if ((HT_FLAGS(&PHAR_G(phar_fname_map)) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
+		&& !HT_FLAGS(&cached_phars)) {
 		goto skip_phar;
 	}
 
@@ -239,8 +239,8 @@ PHAR_FUNC(phar_readfile) /* {{{ */
 		goto skip_phar;
 	}
 
-	if ((PHAR_G(phar_fname_map.u.flags) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
-		&& !cached_phars.u.flags) {
+	if ((HT_FLAGS(&PHAR_G(phar_fname_map)) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
+		&& !HT_FLAGS(&cached_phars)) {
 		goto skip_phar;
 	}
 	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "p|br!", &filename, &filename_len, &use_include_path, &zcontext) == FAILURE) {
@@ -339,8 +339,8 @@ PHAR_FUNC(phar_fopen) /* {{{ */
 		goto skip_phar;
 	}
 
-	if ((PHAR_G(phar_fname_map.u.flags) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
-		&& !cached_phars.u.flags) {
+	if ((HT_FLAGS(&PHAR_G(phar_fname_map)) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
+		&& !HT_FLAGS(&cached_phars)) {
 		/* no need to check, include_path not even specified in fopen/ no active phars */
 		goto skip_phar;
 	}
@@ -854,8 +854,8 @@ PHAR_FUNC(phar_is_file) /* {{{ */
 		goto skip_phar;
 	}
 
-	if ((PHAR_G(phar_fname_map.u.flags) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
-		&& !cached_phars.u.flags) {
+	if ((HT_FLAGS(&PHAR_G(phar_fname_map)) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
+		&& !HT_FLAGS(&cached_phars)) {
 		goto skip_phar;
 	}
 	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "p", &filename, &filename_len) == FAILURE) {
@@ -921,8 +921,8 @@ PHAR_FUNC(phar_is_link) /* {{{ */
 		goto skip_phar;
 	}
 
-	if ((PHAR_G(phar_fname_map.u.flags) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
-		&& !cached_phars.u.flags) {
+	if ((HT_FLAGS(&PHAR_G(phar_fname_map)) && !zend_hash_num_elements(&(PHAR_G(phar_fname_map))))
+		&& !HT_FLAGS(&cached_phars)) {
 		goto skip_phar;
 	}
 	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "p", &filename, &filename_len) == FAILURE) {

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -82,7 +82,7 @@ ZEND_INI_MH(phar_ini_modify_handler) /* {{{ */
 
 	if (ZSTR_LEN(entry->name) == sizeof("phar.readonly")-1) {
 		PHAR_G(readonly) = ini;
-		if (PHAR_G(request_init) && PHAR_G(phar_fname_map.u.flags)) {
+		if (PHAR_G(request_init) && HT_FLAGS(&PHAR_G(phar_fname_map))) {
 			zend_hash_apply_with_argument(&(PHAR_G(phar_fname_map)), phar_set_writeable_bit, (void *)&ini);
 		}
 	} else {
@@ -146,9 +146,9 @@ finish_error:
 				PHAR_G(manifest_cached) = 0;
 				efree(tmp);
 				zend_hash_destroy(&(PHAR_G(phar_fname_map)));
-				PHAR_G(phar_fname_map.u.flags) = 0;
+				HT_FLAGS(&PHAR_G(phar_fname_map)) = 0;
 				zend_hash_destroy(&(PHAR_G(phar_alias_map)));
-				PHAR_G(phar_alias_map.u.flags) = 0;
+				HT_FLAGS(&PHAR_G(phar_alias_map)) = 0;
 				zend_hash_destroy(&cached_phars);
 				zend_hash_destroy(&cached_alias);
 				zend_hash_graceful_reverse_destroy(&EG(regular_list));
@@ -173,8 +173,8 @@ finish_error:
 	zend_hash_destroy(&cached_alias);
 	cached_phars = PHAR_G(phar_fname_map);
 	cached_alias = PHAR_G(phar_alias_map);
-	PHAR_G(phar_fname_map.u.flags) = 0;
-	PHAR_G(phar_alias_map.u.flags) = 0;
+	HT_FLAGS(&PHAR_G(phar_fname_map)) = 0;
+	HT_FLAGS(&PHAR_G(phar_alias_map)) = 0;
 	zend_hash_graceful_reverse_destroy(&EG(regular_list));
 	memset(&EG(regular_list), 0, sizeof(HashTable));
 	efree(tmp);
@@ -220,19 +220,19 @@ void phar_destroy_phar_data(phar_archive_data *phar) /* {{{ */
 		phar->signature = NULL;
 	}
 
-	if (phar->manifest.u.flags) {
+	if (HT_FLAGS(&phar->manifest)) {
 		zend_hash_destroy(&phar->manifest);
-		phar->manifest.u.flags = 0;
+		HT_FLAGS(&phar->manifest) = 0;
 	}
 
-	if (phar->mounted_dirs.u.flags) {
+	if (HT_FLAGS(&phar->mounted_dirs)) {
 		zend_hash_destroy(&phar->mounted_dirs);
-		phar->mounted_dirs.u.flags = 0;
+		HT_FLAGS(&phar->mounted_dirs) = 0;
 	}
 
-	if (phar->virtual_dirs.u.flags) {
+	if (HT_FLAGS(&phar->virtual_dirs)) {
 		zend_hash_destroy(&phar->virtual_dirs);
-		phar->virtual_dirs.u.flags = 0;
+		HT_FLAGS(&phar->virtual_dirs) = 0;
 	}
 
 	if (Z_TYPE(phar->metadata) != IS_UNDEF) {
@@ -3515,11 +3515,11 @@ PHP_RSHUTDOWN_FUNCTION(phar) /* {{{ */
 	{
 		phar_release_functions();
 		zend_hash_destroy(&(PHAR_G(phar_alias_map)));
-		PHAR_G(phar_alias_map.u.flags) = 0;
+		HT_FLAGS(&PHAR_G(phar_alias_map)) = 0;
 		zend_hash_destroy(&(PHAR_G(phar_fname_map)));
-		PHAR_G(phar_fname_map.u.flags) = 0;
+		HT_FLAGS(&PHAR_G(phar_fname_map)) = 0;
 		zend_hash_destroy(&(PHAR_G(phar_persist_map)));
-		PHAR_G(phar_persist_map.u.flags) = 0;
+		HT_FLAGS(&PHAR_G(phar_persist_map)) = 0;
 		PHAR_G(phar_SERVER_mung_list) = 0;
 
 		if (PHAR_G(cached_fp)) {

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -512,7 +512,7 @@ carry_on:
 		}
 
 		return;
-	} else if (PHAR_G(phar_fname_map.u.flags) && NULL != (pphar = zend_hash_str_find_ptr(&(PHAR_G(phar_fname_map)), fname, fname_len))) {
+	} else if (HT_FLAGS(&PHAR_G(phar_fname_map)) && NULL != (pphar = zend_hash_str_find_ptr(&(PHAR_G(phar_fname_map)), fname, fname_len))) {
 		goto carry_on;
 	} else if (PHAR_G(manifest_cached) && NULL != (pphar = zend_hash_str_find_ptr(&cached_phars, fname, fname_len))) {
 		if (SUCCESS == phar_copy_on_write(&pphar)) {

--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -106,7 +106,7 @@ php_url* phar_parse_url(php_stream_wrapper *wrapper, const char *filename, const
 	if (mode[0] == 'w' || (mode[0] == 'r' && mode[1] == '+')) {
 		phar_archive_data *pphar = NULL, *phar;
 
-		if (PHAR_G(request_init) && PHAR_G(phar_fname_map.u.flags) && NULL == (pphar = zend_hash_find_ptr(&(PHAR_G(phar_fname_map)), resource->host))) {
+		if (PHAR_G(request_init) && HT_FLAGS(&PHAR_G(phar_fname_map)) && NULL == (pphar = zend_hash_find_ptr(&(PHAR_G(phar_fname_map)), resource->host))) {
 			pphar = NULL;
 		}
 		if (PHAR_G(readonly) && (!pphar || !pphar->is_data)) {
@@ -597,7 +597,7 @@ static int phar_wrapper_stat(php_stream_wrapper *wrapper, const char *url, int f
 		php_url_free(resource);
 		return SUCCESS;
 	}
-	if (!phar->manifest.u.flags) {
+	if (!HT_FLAGS(&phar->manifest)) {
 		php_url_free(resource);
 		return FAILURE;
 	}
@@ -614,7 +614,7 @@ static int phar_wrapper_stat(php_stream_wrapper *wrapper, const char *url, int f
 		return SUCCESS;
 	}
 	/* check for mounted directories */
-	if (phar->mounted_dirs.u.flags && zend_hash_num_elements(&phar->mounted_dirs)) {
+	if (HT_FLAGS(&phar->mounted_dirs) && zend_hash_num_elements(&phar->mounted_dirs)) {
 		zend_string *str_key;
 
 		ZEND_HASH_FOREACH_STR_KEY(&phar->mounted_dirs, str_key) {

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -922,7 +922,7 @@ phar_entry_info * phar_open_jit(phar_archive_data *phar, phar_entry_info *entry,
 
 PHP_PHAR_API int phar_resolve_alias(char *alias, int alias_len, char **filename, int *filename_len) /* {{{ */ {
 	phar_archive_data *fd_ptr;
-	if (PHAR_G(phar_alias_map.u.flags)
+	if (HT_FLAGS(&PHAR_G(phar_alias_map))
 			&& NULL != (fd_ptr = zend_hash_str_find_ptr(&(PHAR_G(phar_alias_map)), alias, alias_len))) {
 		*filename = fd_ptr->fname;
 		*filename_len = fd_ptr->fname_len;
@@ -1246,7 +1246,7 @@ phar_entry_info *phar_get_entry_info_dir(phar_archive_data *phar, char *path, in
 		return NULL;
 	}
 
-	if (!phar->manifest.u.flags) {
+	if (!HT_FLAGS(&phar->manifest)) {
 		return NULL;
 	}
 
@@ -1291,7 +1291,7 @@ phar_entry_info *phar_get_entry_info_dir(phar_archive_data *phar, char *path, in
 		}
 	}
 
-	if (phar->mounted_dirs.u.flags && zend_hash_num_elements(&phar->mounted_dirs)) {
+	if (HT_FLAGS(&phar->mounted_dirs) && zend_hash_num_elements(&phar->mounted_dirs)) {
 		zend_string *str_key;
 
 		ZEND_HASH_FOREACH_STR_KEY(&phar->mounted_dirs, str_key) {

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -293,11 +293,11 @@ foundit:
 	entry.is_persistent = mydata->is_persistent;
 #define PHAR_ZIP_FAIL_FREE(errmsg, save) \
 			zend_hash_destroy(&mydata->manifest); \
-			mydata->manifest.u.flags = 0; \
+			HT_FLAGS(&mydata->manifest) = 0; \
 			zend_hash_destroy(&mydata->mounted_dirs); \
-			mydata->mounted_dirs.u.flags = 0; \
+			HT_FLAGS(&mydata->mounted_dirs) = 0; \
 			zend_hash_destroy(&mydata->virtual_dirs); \
-			mydata->virtual_dirs.u.flags = 0; \
+			HT_FLAGS(&mydata->virtual_dirs) = 0; \
 			php_stream_close(fp); \
 			zval_dtor(&mydata->metadata); \
 			if (mydata->signature) { \
@@ -315,11 +315,11 @@ foundit:
 			return FAILURE;
 #define PHAR_ZIP_FAIL(errmsg) \
 			zend_hash_destroy(&mydata->manifest); \
-			mydata->manifest.u.flags = 0; \
+			HT_FLAGS(&mydata->manifest) = 0; \
 			zend_hash_destroy(&mydata->mounted_dirs); \
-			mydata->mounted_dirs.u.flags = 0; \
+			HT_FLAGS(&mydata->mounted_dirs) = 0; \
 			zend_hash_destroy(&mydata->virtual_dirs); \
-			mydata->virtual_dirs.u.flags = 0; \
+			HT_FLAGS(&mydata->virtual_dirs) = 0; \
 			php_stream_close(fp); \
 			zval_dtor(&mydata->metadata); \
 			if (mydata->signature) { \

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -560,7 +560,7 @@ try_again:
 					} else {
 						zval_ptr_dtor(data);
 						ZVAL_UNDEF(data);
-						ht->u.v.flags |= HASH_FLAG_HAS_EMPTY_IND;
+						HT_FLAGS(ht) |= HASH_FLAG_HAS_EMPTY_IND;
 						zend_hash_move_forward_ex(ht, spl_array_get_pos_ptr(ht, intern));
 						if (spl_array_is_object(intern)) {
 							spl_array_skip_protected(intern, ht);

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2989,7 +2989,7 @@ static void php_array_data_shuffle(zval *array) /* {{{ */
 	hash = Z_ARRVAL_P(array);
 	n_left = n_elems;
 
-	if (EXPECTED(hash->u.v.nIteratorsCount == 0)) {
+	if (EXPECTED(!HT_HAS_ITERATORS(hash))) {
 		if (hash->nNumUsed != hash->nNumOfElements) {
 			for (j = 0, idx = 0; idx < hash->nNumUsed; idx++) {
 				p = hash->arData + idx;
@@ -3190,7 +3190,7 @@ static void php_splice(HashTable *in_hash, zend_long offset, zend_long length, H
 	}
 
 	/* replace HashTable data */
-	in_hash->u.v.nIteratorsCount = 0;
+	HT_SET_ITERATORS_COUNT(in_hash, 0);
 	in_hash->pDestructor = NULL;
 	zend_hash_destroy(in_hash);
 
@@ -3345,7 +3345,7 @@ PHP_FUNCTION(array_shift)
 	if (Z_ARRVAL_P(stack)->u.flags & HASH_FLAG_PACKED) {
 		uint32_t k = 0;
 
-		if (EXPECTED(Z_ARRVAL_P(stack)->u.v.nIteratorsCount == 0)) {
+		if (EXPECTED(!HT_HAS_ITERATORS(Z_ARRVAL_P(stack)))) {
 			for (idx = 0; idx < Z_ARRVAL_P(stack)->nNumUsed; idx++) {
 				p = Z_ARRVAL_P(stack)->arData + idx;
 				if (Z_TYPE(p->val) == IS_UNDEF) continue;
@@ -3428,7 +3428,7 @@ PHP_FUNCTION(array_unshift)
 		Z_TRY_ADDREF(args[i]);
 		zend_hash_next_index_insert_new(&new_hash, &args[i]);
 	}
-	if (EXPECTED(Z_ARRVAL_P(stack)->u.v.nIteratorsCount == 0)) {
+	if (EXPECTED(!HT_HAS_ITERATORS(Z_ARRVAL_P(stack)))) {
 		ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(stack), key, value) {
 			if (key) {
 				zend_hash_add_new(&new_hash, key, value);
@@ -3457,7 +3457,7 @@ PHP_FUNCTION(array_unshift)
 	}
 
 	/* replace HashTable data */
-	Z_ARRVAL_P(stack)->u.v.nIteratorsCount = 0;
+	HT_SET_ITERATORS_COUNT(Z_ARRVAL_P(stack), 0);
 	Z_ARRVAL_P(stack)->pDestructor = NULL;
 	zend_hash_destroy(Z_ARRVAL_P(stack));
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3047,7 +3047,7 @@ static void php_array_data_shuffle(zval *array) /* {{{ */
 		p->key = NULL;
 	}
 	hash->nNextFreeElement = n_elems;
-	if (!(hash->u.flags & HASH_FLAG_PACKED)) {
+	if (!(HT_FLAGS(hash) & HASH_FLAG_PACKED)) {
 		zend_hash_to_packed(hash);
 	}
 }
@@ -3194,7 +3194,7 @@ static void php_splice(HashTable *in_hash, zend_long offset, zend_long length, H
 	in_hash->pDestructor = NULL;
 	zend_hash_destroy(in_hash);
 
-	in_hash->u.v.flags         = out_hash.u.v.flags;
+	HT_FLAGS(in_hash)          = HT_FLAGS(&out_hash);
 	in_hash->nTableSize        = out_hash.nTableSize;
 	in_hash->nTableMask        = out_hash.nTableMask;
 	in_hash->nNumUsed          = out_hash.nNumUsed;
@@ -3342,7 +3342,7 @@ PHP_FUNCTION(array_shift)
 	}
 
 	/* re-index like it did before */
-	if (Z_ARRVAL_P(stack)->u.flags & HASH_FLAG_PACKED) {
+	if (HT_FLAGS(Z_ARRVAL_P(stack)) & HASH_FLAG_PACKED) {
 		uint32_t k = 0;
 
 		if (EXPECTED(!HT_HAS_ITERATORS(Z_ARRVAL_P(stack)))) {
@@ -3461,7 +3461,7 @@ PHP_FUNCTION(array_unshift)
 	Z_ARRVAL_P(stack)->pDestructor = NULL;
 	zend_hash_destroy(Z_ARRVAL_P(stack));
 
-	Z_ARRVAL_P(stack)->u.v.flags         = new_hash.u.v.flags;
+	HT_FLAGS(Z_ARRVAL_P(stack))          = HT_FLAGS(&new_hash);
 	Z_ARRVAL_P(stack)->nTableSize        = new_hash.nTableSize;
 	Z_ARRVAL_P(stack)->nTableMask        = new_hash.nTableMask;
 	Z_ARRVAL_P(stack)->nNumUsed          = new_hash.nNumUsed;
@@ -3716,7 +3716,7 @@ PHPAPI int php_array_merge(HashTable *dest, HashTable *src) /* {{{ */
 	zval *src_entry;
 	zend_string *string_key;
 
-	if ((dest->u.flags & HASH_FLAG_PACKED) && (src->u.flags & HASH_FLAG_PACKED)) {
+	if ((HT_FLAGS(dest) & HASH_FLAG_PACKED) && (HT_FLAGS(src) & HASH_FLAG_PACKED)) {
 		zend_hash_extend(dest, zend_hash_num_elements(dest) + zend_hash_num_elements(src), 1);
 		ZEND_HASH_FILL_PACKED(dest) {
 			ZEND_HASH_FOREACH_VAL(src, src_entry) {
@@ -3874,7 +3874,7 @@ static inline void php_array_merge_or_replace_wrapper(INTERNAL_FUNCTION_PARAMETE
 		/* copy first array */
 		array_init_size(return_value, count);
 		dest = Z_ARRVAL_P(return_value);
-		if (src->u.flags & HASH_FLAG_PACKED) {
+		if (HT_FLAGS(src) & HASH_FLAG_PACKED) {
 			zend_hash_real_init(dest, 1);
 			ZEND_HASH_FILL_PACKED(dest) {
 				ZEND_HASH_FOREACH_VAL(src, src_entry) {
@@ -4276,7 +4276,7 @@ PHP_FUNCTION(array_reverse)
 
 	/* Initialize return array */
 	array_init_size(return_value, zend_hash_num_elements(Z_ARRVAL_P(input)));
-	if ((Z_ARRVAL_P(input)->u.flags & HASH_FLAG_PACKED) && !preserve_keys) {
+	if ((HT_FLAGS(Z_ARRVAL_P(input)) & HASH_FLAG_PACKED) && !preserve_keys) {
 		zend_hash_real_init(Z_ARRVAL_P(return_value), 1);
 		ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
 			ZEND_HASH_REVERSE_FOREACH_VAL(Z_ARRVAL_P(input), entry) {
@@ -4345,7 +4345,7 @@ PHP_FUNCTION(array_pad)
 	}
 
 	array_init_size(return_value, pad_size_abs);
-	if (Z_ARRVAL_P(input)->u.flags & HASH_FLAG_PACKED) {
+	if (HT_FLAGS(Z_ARRVAL_P(input)) & HASH_FLAG_PACKED) {
 		zend_hash_real_init(Z_ARRVAL_P(return_value), 1);
 
 		if (pad_size < 0) {
@@ -5756,7 +5756,7 @@ PHP_FUNCTION(array_multisort)
 		hash = Z_ARRVAL_P(arrays[i]);
 		hash->nNumUsed = array_size;
 		hash->nInternalPointer = 0;
-		repack = !(hash->u.flags & HASH_FLAG_PACKED);
+		repack = !(HT_FLAGS(hash) & HASH_FLAG_PACKED);
 
 		for (n = 0, k = 0; k < array_size; k++) {
 			hash->arData[k] = indirect[k][i];
@@ -6154,7 +6154,7 @@ PHP_FUNCTION(array_map)
 		}
 
 		array_init_size(return_value, maxlen);
-		zend_hash_real_init(Z_ARRVAL_P(return_value), Z_ARRVAL(arrays[0])->u.flags & HASH_FLAG_PACKED);
+		zend_hash_real_init(Z_ARRVAL_P(return_value), HT_FLAGS(Z_ARRVAL(arrays[0])) & HASH_FLAG_PACKED);
 
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL(arrays[0]), num_key, str_key, zv) {
 			fci.retval = &result;

--- a/ext/standard/var_unserializer.c
+++ b/ext/standard/var_unserializer.c
@@ -223,13 +223,13 @@ PHPAPI void var_destroy(php_unserialize_data_t *var_hashx)
 					BG(serialize_lock)++;
 					if (call_user_function_ex(CG(function_table), zv, &wakeup_name, &retval, 0, 0, 1, NULL) == FAILURE || Z_ISUNDEF(retval)) {
 						wakeup_failed = 1;
-						GC_FLAGS(Z_OBJ_P(zv)) |= IS_OBJ_DESTRUCTOR_CALLED;
+						GC_EXTRA_FLAGS(Z_OBJ_P(zv)) |= IS_OBJ_DESTRUCTOR_CALLED;
 					}
 					BG(serialize_lock)--;
 
 					zval_ptr_dtor(&retval);
 				} else {
-					GC_FLAGS(Z_OBJ_P(zv)) |= IS_OBJ_DESTRUCTOR_CALLED;
+					GC_EXTRA_FLAGS(Z_OBJ_P(zv)) |= IS_OBJ_DESTRUCTOR_CALLED;
 				}
 			}
 
@@ -603,7 +603,7 @@ static inline int object_common2(UNSERIALIZE_PARAMETER, zend_long elements)
 	if (!process_nested_data(UNSERIALIZE_PASSTHRU, ht, elements, 1)) {
 		if (has_wakeup) {
 			ZVAL_DEREF(rval);
-			GC_FLAGS(Z_OBJ_P(rval)) |= IS_OBJ_DESTRUCTOR_CALLED;
+			GC_EXTRA_FLAGS(Z_OBJ_P(rval)) |= IS_OBJ_DESTRUCTOR_CALLED;
 		}
 		return 0;
 	}

--- a/ext/standard/var_unserializer.c
+++ b/ext/standard/var_unserializer.c
@@ -599,7 +599,7 @@ static inline int object_common2(UNSERIALIZE_PARAMETER, zend_long elements)
 		return 0;
 	}
 
-	zend_hash_extend(ht, zend_hash_num_elements(ht) + elements, (ht->u.flags & HASH_FLAG_PACKED));
+	zend_hash_extend(ht, zend_hash_num_elements(ht) + elements, HT_FLAGS(ht) & HASH_FLAG_PACKED);
 	if (!process_nested_data(UNSERIALIZE_PASSTHRU, ht, elements, 1)) {
 		if (has_wakeup) {
 			ZVAL_DEREF(rval);

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -603,7 +603,7 @@ static inline int object_common2(UNSERIALIZE_PARAMETER, zend_long elements)
 		return 0;
 	}
 
-	zend_hash_extend(ht, zend_hash_num_elements(ht) + elements, (ht->u.flags & HASH_FLAG_PACKED));
+	zend_hash_extend(ht, zend_hash_num_elements(ht) + elements, HT_FLAGS(ht) & HASH_FLAG_PACKED);
 	if (!process_nested_data(UNSERIALIZE_PASSTHRU, ht, elements, 1)) {
 		if (has_wakeup) {
 			ZVAL_DEREF(rval);

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -221,13 +221,13 @@ PHPAPI void var_destroy(php_unserialize_data_t *var_hashx)
 					BG(serialize_lock)++;
 					if (call_user_function_ex(CG(function_table), zv, &wakeup_name, &retval, 0, 0, 1, NULL) == FAILURE || Z_ISUNDEF(retval)) {
 						wakeup_failed = 1;
-						GC_FLAGS(Z_OBJ_P(zv)) |= IS_OBJ_DESTRUCTOR_CALLED;
+						GC_EXTRA_FLAGS(Z_OBJ_P(zv)) |= IS_OBJ_DESTRUCTOR_CALLED;
 					}
 					BG(serialize_lock)--;
 
 					zval_ptr_dtor(&retval);
 				} else {
-					GC_FLAGS(Z_OBJ_P(zv)) |= IS_OBJ_DESTRUCTOR_CALLED;
+					GC_EXTRA_FLAGS(Z_OBJ_P(zv)) |= IS_OBJ_DESTRUCTOR_CALLED;
 				}
 			}
 
@@ -607,7 +607,7 @@ static inline int object_common2(UNSERIALIZE_PARAMETER, zend_long elements)
 	if (!process_nested_data(UNSERIALIZE_PASSTHRU, ht, elements, 1)) {
 		if (has_wakeup) {
 			ZVAL_DEREF(rval);
-			GC_FLAGS(Z_OBJ_P(rval)) |= IS_OBJ_DESTRUCTOR_CALLED;
+			GC_EXTRA_FLAGS(Z_OBJ_P(rval)) |= IS_OBJ_DESTRUCTOR_CALLED;
 		}
 		return 0;
 	}


### PR DESCRIPTION
The GC root buffer currently has a size of 10k entries. For object oriented applications, and especially CLI applications, the active working set is often significantly larger than that, which leads to many unnecessary GC runs. Nowadays it is common that GC takes up a significant percentage of the runtime (often on the order of 10-20%, but I've also observed 5x slowdowns in unfortunate cases).

There are a number of ways to improve this situation, but they all require the ability to use larger root buffers. However, the GC root address is currently packed into 14 bits, with an additional 2 bits used for the GC color. As such, we cannot use root buffers with more than ~16k entries.

This patch changes the layout of a number of core structures to support 32-bit root buffers. In particular:
 * Arrays and objects now use the zend_refcounted_gc header, which is zend_refcounted followed by a u32 gc_root field.
 * The 16-bit field in zend_refcounted that previously held the gc_info is now extra_flags. This flag space is freely usable for type-specific flags.
 * The GC color is now stored as part of the GC flags.
 * The object flags have been moved from the GC flags to the extra flags, as there is no longer enough space for them.
 * The hashtable flags have been moved from the HT structure into the extra flags. 8 bits are used for the iterator count and the other 8 bits for the flags proper.
 * Hashtable consistency checks have been disabled temporarily. These can be added back either as 2 bits in the flags, or as a separate field in debug builds. Though I wonder if we shouldn't drop this mechanism altogether, it does not seem useful nowadays.

These changes are size-neutral on 64-bit: For objects, we are now using 32-bit of previously unused padding, for arrays, we the root address replaces the HT flags.

On 32-bit the change is size-neutral for arrays, but increases object size by 32-bit.

This changeset does not change (or make dynamic) the root buffer size, it only lays the necessary groundwork for such a change to be possible in the first place.