### PR TITLE
add ftp extension option externalip.

### DIFF
--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1744,7 +1744,12 @@ ftp_getdata(ftpbuf_t *ftp)
 	/* send the PORT */
 	ipbox.ia[0] = ((struct sockaddr_in*) sa)->sin_addr;
 	ipbox.s[2] = ((struct sockaddr_in*) &addr)->sin_port;
-	arg_len = snprintf(arg, sizeof(arg), "%u,%u,%u,%u,%u,%u", ipbox.c[0], ipbox.c[1], ipbox.c[2], ipbox.c[3], ipbox.c[4], ipbox.c[5]);
+	if(ftp->externalip.s_addr != FTP_DEFAULT_EXTERNALIP){
+		unsigned char *bytes = (unsigned char *)&ftp->externalip.s_addr;
+		arg_len = snprintf(arg, sizeof(arg), "%u,%u,%u,%u,%u,%u", bytes[0], bytes[1], bytes[2], bytes[3], ipbox.c[4], ipbox.c[5]);
+	}else{
+		arg_len = snprintf(arg, sizeof(arg), "%u,%u,%u,%u,%u,%u", ipbox.c[0], ipbox.c[1], ipbox.c[2], ipbox.c[3], ipbox.c[4], ipbox.c[5]);
+	}
 
 	if (arg_len < 0) {
 		goto bail;

--- a/ext/ftp/ftp.h
+++ b/ext/ftp/ftp.h
@@ -32,6 +32,7 @@
 #define	FTP_DEFAULT_TIMEOUT	90
 #define FTP_DEFAULT_AUTOSEEK 1
 #define FTP_DEFAULT_USEPASVADDRESS	1
+#define FTP_DEFAULT_EXTERNALIP	0
 #define PHP_FTP_FAILED			0
 #define PHP_FTP_FINISHED		1
 #define PHP_FTP_MOREDATA		2
@@ -73,6 +74,7 @@ typedef struct ftpbuf
 	zend_long	timeout_sec;	/* User configurable timeout (seconds) */
 	int			autoseek;	/* User configurable autoseek flag */
 	int			usepasvaddress;	/* Use the address returned by the pasv command */
+	struct in_addr externalip;
 
 	int				nb;		/* "nonblocking" transfer in progress */
 	databuf_t		*data;	/* Data connection for "nonblocking" transfers */

--- a/ext/ftp/ftp.h
+++ b/ext/ftp/ftp.h
@@ -74,7 +74,7 @@ typedef struct ftpbuf
 	zend_long	timeout_sec;	/* User configurable timeout (seconds) */
 	int			autoseek;	/* User configurable autoseek flag */
 	int			usepasvaddress;	/* Use the address returned by the pasv command */
-	struct in_addr externalip;
+	struct		in_addr externalip;
 
 	int				nb;		/* "nonblocking" transfer in progress */
 	databuf_t		*data;	/* Data connection for "nonblocking" transfers */

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -374,7 +374,6 @@ PHP_FUNCTION(ftp_connect)
 	size_t		host_len;
 	zend_long 		port = 0;
 	zend_long		timeout_sec = FTP_DEFAULT_TIMEOUT;
-	struct in_addr externalip;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|ll", &host, &host_len, &port, &timeout_sec) == FAILURE) {
 		return;
@@ -1606,6 +1605,8 @@ PHP_FUNCTION(ftp_get_option)
 	zval		*z_ftp;
 	zend_long		option;
 	ftpbuf_t	*ftp;
+	char		returnbuffer[18];
+	unsigned char	*bytes = (unsigned char *)&ftp->externalip.s_addr;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &z_ftp, &option) == FAILURE) {
 		return;
@@ -1615,8 +1616,6 @@ PHP_FUNCTION(ftp_get_option)
 		RETURN_FALSE;
 	}
 
-	char returnbuffer[18];
-	unsigned char *bytes = (unsigned char *) &ftp->externalip.s_addr;
 	switch (option) {
 		case PHP_FTP_OPT_TIMEOUT_SEC:
 			RETURN_LONG(ftp->timeout_sec);

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -1605,8 +1605,6 @@ PHP_FUNCTION(ftp_get_option)
 	zval		*z_ftp;
 	zend_long		option;
 	ftpbuf_t	*ftp;
-	char		returnbuffer[18];
-	unsigned char	*bytes = (unsigned char *)&ftp->externalip.s_addr;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &z_ftp, &option) == FAILURE) {
 		return;
@@ -1626,9 +1624,12 @@ PHP_FUNCTION(ftp_get_option)
 		case PHP_FTP_OPT_USEPASVADDRESS:
 			RETURN_BOOL(ftp->usepasvaddress);
 			break;
-		case PHP_FTP_OPT_EXTERNALIP:
-			snprintf(returnbuffer, sizeof(returnbuffer), "%d.%d.%d.%d",bytes[0],bytes[1],bytes[2],bytes[3]);
-			RETURN_STRING(returnbuffer);
+		case PHP_FTP_OPT_EXTERNALIP: {
+				char		returnbuffer[18];
+				unsigned char	*bytes = (unsigned char *)&ftp->externalip.s_addr;
+				snprintf(returnbuffer, sizeof(returnbuffer), "%d.%d.%d.%d", bytes[0], bytes[1], bytes[2], bytes[3]);
+				RETURN_STRING(returnbuffer);
+			}
 			break;
 		default:
 			php_error_docref(NULL, E_WARNING, "Unknown option '" ZEND_LONG_FMT "'", option);

--- a/ext/ftp/php_ftp.h
+++ b/ext/ftp/php_ftp.h
@@ -33,6 +33,7 @@ extern zend_module_entry php_ftp_module_entry;
 #define PHP_FTP_OPT_TIMEOUT_SEC	0
 #define PHP_FTP_OPT_AUTOSEEK	1
 #define PHP_FTP_OPT_USEPASVADDRESS	2
+#define PHP_FTP_OPT_EXTERNALIP	3
 #define PHP_FTP_AUTORESUME		-1
 
 PHP_MINIT_FUNCTION(ftp);


### PR DESCRIPTION
I adding an external IP address option to the ftp function.
This option overrides the IP address of the PORT command sent in creating the ftp data connection.
Such options are also found in the Apache Commons Library. https://commons.apache.org/proper/commons-net/apidocs/org/apache/commons/net/ftp/FTPClient.html

Why:
Currently, that command sending a self IP address.
But that is not working well, if the host connected by NAT.
If that PORT command with NAT external IP address, it is working well.
It is useful when active FTP transfer is required in the 1:1 NAT connected host, so like AWS VPC.

model:
FTP Server -- x.x.x.x(NAT external address) - NAT BOX -- y.y.y.y(Client private address) - Client

Current:
<- PORT y.y.y.y
-> Open y.y.y.y (y.y.y.y unreachable!!)

Using this option :
<- PORT x.x.x.x (overrided)
-> Open x.x.x.x (reachable) -> NAT (rewrite x.x.x.x to y.y.y.y) ->  y.y.y.y (Good)

Example:
$c = ftp_connect('ftp.myserver');
ftp_login($c,'user','password');
var_dump(ftp_nlist($c, '/')); // return false. It is the same as before. [default]

$publicip = file_get_contents("http://169.254.169.254/latest/meta-data/public-ipv4");
ftp_set_option($c, FTP_EXTERNALIP, $publicip);
var_dump(ftp_nlist($c, '/')); // PORT command with publicip.

ftp_set_option($c, FTP_EXTERNALIP, false); // reset.
var_dump(ftp_nlist($c, '/')); // return false.