### PR TITLE
Trailing whitespaces on cpp files

### DIFF
--- a/ext/intl/calendar/gregoriancalendar_methods.cpp
+++ b/ext/intl/calendar/gregoriancalendar_methods.cpp
@@ -57,7 +57,7 @@ static void _php_intlgregcal_constructor_body(
 			zend_get_parameters_array_ex(ZEND_NUM_ARGS(), args) == FAILURE) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
 			"intlgregcal_create_instance: too many arguments", 0);
-		if (!is_constructor) {		
+		if (!is_constructor) {
 			zval_dtor(return_value);
 			RETVAL_NULL();
 		}
@@ -70,7 +70,7 @@ static void _php_intlgregcal_constructor_body(
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
 			"intlgregcal_create_instance: no variant with 4 arguments "
 			"(excluding trailing NULLs)", 0);
-		if (!is_constructor) {		
+		if (!is_constructor) {
 			zval_dtor(return_value);
 			RETVAL_NULL();
 		}
@@ -83,7 +83,7 @@ static void _php_intlgregcal_constructor_body(
 				"|z!s!", &tz_object, &locale, &locale_len) == FAILURE) {
 			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
 				"intlgregcal_create_instance: bad arguments", 0);
-			if (!is_constructor) {		
+			if (!is_constructor) {
 				zval_dtor(return_value);
 				RETVAL_NULL();
 			}
@@ -95,7 +95,7 @@ static void _php_intlgregcal_constructor_body(
 			&largs[5]) == FAILURE) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
 			"intlgregcal_create_instance: bad arguments", 0);
-		if (!is_constructor) {		
+		if (!is_constructor) {
 			zval_dtor(return_value);
 			RETVAL_NULL();
 		}
@@ -113,7 +113,7 @@ static void _php_intlgregcal_constructor_body(
 			if (!EG(exception)) {
 				zend_throw_exception(IntlException_ce_ptr, "Constructor failed", 0);
 			}
-			if (!is_constructor) {		
+			if (!is_constructor) {
 				zval_dtor(return_value);
 				RETVAL_NULL();
 			}
@@ -132,7 +132,7 @@ static void _php_intlgregcal_constructor_body(
 				delete gcal;
 			}
 			delete tz;
-			if (!is_constructor) {		
+			if (!is_constructor) {
 				zval_dtor(return_value);
 				RETVAL_NULL();
 			}
@@ -145,7 +145,7 @@ static void _php_intlgregcal_constructor_body(
 				intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
 					"intlgregcal_create_instance: at least one of the arguments"
 					" has an absolute value that is too large", 0);
-				if (!is_constructor) {		
+				if (!is_constructor) {
 					zval_dtor(return_value);
 					RETVAL_NULL();
 				}
@@ -170,7 +170,7 @@ static void _php_intlgregcal_constructor_body(
 			if (gcal) {
 				delete gcal;
 			}
-			if (!is_constructor) {		
+			if (!is_constructor) {
 				zval_dtor(return_value);
 				RETVAL_NULL();
 			}
@@ -190,7 +190,7 @@ static void _php_intlgregcal_constructor_body(
 				"from PHP's default timezone name (see date_default_timezone_get())",
 				0);
 			delete gcal;
-			if (!is_constructor) {		
+			if (!is_constructor) {
 				zval_dtor(return_value);
 				RETVAL_NULL();
 			}


### PR DESCRIPTION
Following #3001, and the last PR of its kind :+1: 

Next ones will remove duplicate empty lines :octocat: 
  