### PR TITLE
Fix 74719

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1034,7 +1034,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(zend_bool throw_
 	Z_PARAM_RESOURCE_EX2(dest, check_null, separate, separate)
 
 #define Z_PARAM_RESOURCE(dest) \
-	Z_PARAM_RESOURCE_EX(dest, 1, 0)
+	Z_PARAM_RESOURCE_EX(dest, 0, 0)
 
 /* old "s" */
 #define Z_PARAM_STRING_EX2(dest, dest_len, check_null, deref, separate) \

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1034,7 +1034,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(zend_bool throw_
 	Z_PARAM_RESOURCE_EX2(dest, check_null, separate, separate)
 
 #define Z_PARAM_RESOURCE(dest) \
-	Z_PARAM_RESOURCE_EX(dest, 0, 0)
+	Z_PARAM_RESOURCE_EX(dest, 1, 0)
 
 /* old "s" */
 #define Z_PARAM_STRING_EX2(dest, dest_len, check_null, deref, separate) \

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -883,7 +883,7 @@ PHP_NAMED_FUNCTION(php_if_fopen)
 		Z_PARAM_STRING(mode, mode_len)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_BOOL(use_include_path)
-		Z_PARAM_RESOURCE(zcontext)
+		Z_PARAM_RESOURCE(zcontext, 1, 0)
 	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
 	context = php_stream_context_from_zval(zcontext, 0);

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -883,7 +883,7 @@ PHP_NAMED_FUNCTION(php_if_fopen)
 		Z_PARAM_STRING(mode, mode_len)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_BOOL(use_include_path)
-		Z_PARAM_RESOURCE(zcontext, 1, 0)
+		Z_PARAM_RESOURCE(zcontext)
 	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
 	context = php_stream_context_from_zval(zcontext, 0);

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -883,7 +883,7 @@ PHP_NAMED_FUNCTION(php_if_fopen)
 		Z_PARAM_STRING(mode, mode_len)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_BOOL(use_include_path)
-		Z_PARAM_RESOURCE(zcontext)
+		Z_PARAM_RESOURCE_EX(zcontext, 1, 0)
 	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
 	context = php_stream_context_from_zval(zcontext, 0);

--- a/ext/standard/tests/file/bug74719.phpt
+++ b/ext/standard/tests/file/bug74719.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Bug #74719 Allow NULL as context
+--CREDITS--
+Alexander Holman <alexander@holman.org.uk>
+--FILE--
+<?php
+/* Prototype  : resource fopen(string filename, string mode [, bool use_include_path [, resource context]])
+ * Description: Open a file or a URL and return a file pointer 
+ * Source code: ext/standard/file.c
+ * Alias to functions: 
+ */
+
+require_once('fopen_include_path.inc');
+
+$thisTestDir =  basename(__FILE__, ".php") . ".dir";
+mkdir($thisTestDir);
+chdir($thisTestDir);
+
+$newpath = relative_include_path();
+set_include_path($newpath);
+
+$tmpfile =  basename(__FILE__, ".php") . ".tmp";
+$h = fopen($tmpfile, "w", true, NULL);
+if ($h === false) {
+    echo "Unable to open file to write\n";
+}
+else {
+    echo "open and write okay\n";
+    fwrite($h, "This is the test file");
+	fclose($h);
+	$h = fopen($tmpfile, "r", false, NULL);
+	if ($h === false) {
+	   echo "Unable to open file to read file\n";
+	}
+	else {
+	   echo "open and read okay\n";
+	   fclose($h);
+	}
+	unlink($tmpfile);
+}
+
+teardown_relative_path();
+restore_include_path();
+chdir("..");
+rmdir($thisTestDir);
+
+function runtest() {
+}
+?>
+===DONE===
+--EXPECT--
+open and write okay
+open and read okay
+===DONE===


### PR DESCRIPTION
Fix for bug [#74719](https://bugs.php.net/bug.php?id=74719) to allow `NULL` context in `fopen` without warning e.g.:
```
fopen ('/tmp/foo', 'r', false, NULL);
```