### PR TITLE
Request #75765 Throw exception instead of a fatal error when extends/implements

### DIFF
--- a/Zend/tests/bug30519.phpt
+++ b/Zend/tests/bug30519.phpt
@@ -6,5 +6,8 @@ class test implements a {
 }
 ?>
 --EXPECTF--
-Fatal error: Interface 'a' not found in %sbug30519.php on line 2
+Fatal error: Uncaught Error: Interface 'a' not found in %sbug30519.php:2
+Stack trace:
+#0 {main}
+  thrown in %sbug30519.php on line 2
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6370,7 +6370,7 @@ void zend_compile_class_decl(zend_ast *ast) /* {{{ */
 				"Cannot use '%s' as class name as it is reserved", ZSTR_VAL(extends_name));
 		}
 
-		zend_compile_class_ref(&extends_node, extends_ast, 0);
+		zend_compile_class_ref(&extends_node, extends_ast, 1);
 		ce->ce_flags |= ZEND_ACC_INHERITED;
 	}
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -6934,7 +6934,7 @@ ZEND_VM_HANDLER(144, ZEND_ADD_INTERFACE, ANY, CONST)
 	SAVE_OPLINE();
 	iface = CACHED_PTR(Z_CACHE_SLOT_P(RT_CONSTANT(opline, opline->op2)));
 	if (UNEXPECTED(iface == NULL)) {
-		iface = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_INTERFACE);
+		iface = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_INTERFACE | ZEND_FETCH_CLASS_EXCEPTION);
 		if (UNEXPECTED(iface == NULL)) {
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2361,7 +2361,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_INTERFACE_SPEC_CONST_HANDL
 	SAVE_OPLINE();
 	iface = CACHED_PTR(Z_CACHE_SLOT_P(RT_CONSTANT(opline, opline->op2)));
 	if (UNEXPECTED(iface == NULL)) {
-		iface = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_INTERFACE);
+		iface = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_INTERFACE | ZEND_FETCH_CLASS_EXCEPTION);
 		if (UNEXPECTED(iface == NULL)) {
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}

--- a/ext/spl/tests/bug73423.phpt
+++ b/ext/spl/tests/bug73423.phpt
@@ -68,4 +68,15 @@ foreach (new \RecursiveIteratorIterator (new fooIterator ($foo)) as $bar) ;
 
 ?>
 --EXPECTF--
-Fatal error: Class 'NotExists' not found in %sbug73423.php(%d) : eval()'d code on line 1
+Fatal error: Uncaught Error: Class 'NotExists' not found in %sbug73423.php(%d) : eval()'d code:1
+Stack trace:
+#0 %sbug73423.php(%d): eval()
+#1 %sbug73423.php(%d): fooIterator->__destruct()
+#2 {main}
+
+Next Error: Class 'NotExists' not found in %sbug73423.php(%d) : eval()'d code:1
+Stack trace:
+#0 %sbug73423.php(%d): eval()
+#1 %sbug73423.php(%d): fooIterator->__destruct()
+#2 {main}
+  thrown in %sbug73423.php(%d) : eval()'d code on line 1

--- a/tests/classes/autoload_010.phpt
+++ b/tests/classes/autoload_010.phpt
@@ -14,4 +14,7 @@ class C implements UndefI
 --EXPECTF--
 In autoload: string(6) "UndefI"
 
-Fatal error: Interface 'UndefI' not found in %s on line %d
+Fatal error: Uncaught Error: Interface 'UndefI' not found in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %sautoload_010.php on line %d

--- a/tests/classes/autoload_011.phpt
+++ b/tests/classes/autoload_011.phpt
@@ -14,4 +14,7 @@ class C extends UndefBase
 --EXPECTF--
 In autoload: string(9) "UndefBase"
 
-Fatal error: Class 'UndefBase' not found in %s on line %d
+Fatal error: Uncaught Error: Class 'UndefBase' not found in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %sautoload_011.php on line %d

--- a/tests/classes/bug75765.phpt
+++ b/tests/classes/bug75765.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Ensure undefined class extending throws the exception.
+--FILE--
+<?php
+try {
+	class C extends UndefinedClass
+	{
+	}
+} catch (Error $e) {
+	var_dump($e->getMessage());
+}
+
+try {
+	class C implements UndefinedInterface
+	{
+	}
+} catch (Error $e) {
+	var_dump($e->getMessage());
+}
+?>
+--EXPECT--
+string(32) "Class 'UndefinedClass' not found"
+string(40) "Interface 'UndefinedInterface' not found"


### PR DESCRIPTION
Extending an undefined class or implementing an undefined interface causes the fatal error instead of throwing Error exception. Relevant issue: https://bugs.php.net/bug.php?id=75765 
This patch is attempt to fix it.

I'm not fully understand the status of current behavior: it is intentional or not. Most of fatal errors was replaced by exceptions, but some errors are still handling in "old manner". As said in the [docs](https://github.com/php/php-src/blob/master/CONTRIBUTING.md#pull-requests), a bugfix PR should be branched against the lowest actively supported branch. But I not sure about BC things, if someone depends on current error handling of this cases. Also the patch cannot be applied for previous versions "as is", because it affects some lines which was changed between versions. So far I've created a branch against master.