### PR TITLE
Remove redundant warning in array_push() and array_unshift()

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3218,7 +3218,7 @@ PHP_FUNCTION(array_push)
 		argc;			/* Number of function arguments */
 
 
-	ZEND_PARSE_PARAMETERS_START(2, -1)
+	ZEND_PARSE_PARAMETERS_START(1, -1)
 		Z_PARAM_ARRAY_EX(stack, 0, 1)
 		Z_PARAM_VARIADIC('+', args, argc)
 	ZEND_PARSE_PARAMETERS_END();
@@ -3418,7 +3418,7 @@ PHP_FUNCTION(array_unshift)
 	zend_string *key;
 	zval *value;
 
-	ZEND_PARSE_PARAMETERS_START(2, -1)
+	ZEND_PARSE_PARAMETERS_START(1, -1)
 		Z_PARAM_ARRAY_EX(stack, 0, 1)
 		Z_PARAM_VARIADIC('+', args, argc)
 	ZEND_PARSE_PARAMETERS_END();

--- a/ext/standard/tests/array/array_push.phpt
+++ b/ext/standard/tests/array/array_push.phpt
@@ -72,7 +72,7 @@ echo"\nDone";
 --EXPECTF--
 *** Testing Error Conditions ***
 
-Warning: array_push() expects at least 2 parameters, 0 given in %s on line %d
+Warning: array_push() expects at least 1 parameter, 0 given in %s on line %d
 NULL
 
 Warning: array_push() expects parameter 1 to be array, integer given in %s on line %d

--- a/ext/standard/tests/array/array_push_empty.phpt
+++ b/ext/standard/tests/array/array_push_empty.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test array_push() function : push empty set to the array
+--FILE--
+<?php
+/* Prototype  : int array_push(array $stack[, mixed $...])
+ * Description: Pushes elements onto the end of the array
+ * Source code: ext/standard/array.c
+ */
+
+$array = [1,2,3];
+$values = [];
+
+var_dump( array_push($array) );
+var_dump( array_push($array, ...$values) );
+var_dump( $array );
+
+echo "Done";
+?>
+--EXPECTF--
+int(3)
+int(3)
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
+Done

--- a/ext/standard/tests/array/array_push_error1.phpt
+++ b/ext/standard/tests/array/array_push_error1.phpt
@@ -2,7 +2,7 @@
 Test array_push() function : error conditions - Pass incorrect number of args
 --FILE--
 <?php
-/* Prototype  : int array_push(array $stack, mixed $var [, mixed $...])
+/* Prototype  : int array_push(array $stack[, mixed $...])
  * Description: Pushes elements onto the end of the array 
  * Source code: ext/standard/array.c
  */
@@ -15,8 +15,7 @@ echo "*** Testing array_push() : error conditions ***\n";
 
 // Testing array_push with one less than the expected number of arguments
 echo "\n-- Testing array_push() function with less than expected no. of arguments --\n";
-$stack = array(1, 2);
-var_dump( array_push($stack) );
+var_dump( array_push() );
 
 echo "Done";
 ?>
@@ -25,6 +24,6 @@ echo "Done";
 
 -- Testing array_push() function with less than expected no. of arguments --
 
-Warning: array_push() expects at least 2 parameters, 1 given in %s on line %d
+Warning: array_push() expects at least 1 parameter, 0 given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_unshift_empty.phpt
+++ b/ext/standard/tests/array/array_unshift_empty.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test array_unshift() function : prepend array with empty set
+--FILE--
+<?php
+/* Prototype  : int array_unshift(array $array[, mixed ...])
+ * Description: Pushes elements onto the beginning of the array
+ * Source code: ext/standard/array.c
+*/
+
+$array = [1,2,3];
+$values = [];
+
+var_dump( array_unshift($array) );
+var_dump( array_unshift($array, ...$values) );
+var_dump( $array );
+
+echo "Done";
+?>
+--EXPECTF--
+int(3)
+int(3)
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
+Done

--- a/ext/standard/tests/array/array_unshift_error.phpt
+++ b/ext/standard/tests/array/array_unshift_error.phpt
@@ -2,7 +2,7 @@
 Test array_unshift() function : error conditions 
 --FILE--
 <?php
-/* Prototype  : int array_unshift(array $array, mixed $var [, mixed ...])
+/* Prototype  : int array_unshift(array $array[, mixed ...])
  * Description: Pushes elements onto the beginning of the array 
  * Source code: ext/standard/array.c
 */
@@ -12,11 +12,6 @@ echo "*** Testing array_unshift() : error conditions ***\n";
 // Zero arguments
 echo "\n-- Testing array_unshift() function with Zero arguments --\n";
 var_dump( array_unshift() );
-
-// Testing array_unshift with one less than the expected number of arguments
-echo "\n-- Testing array_unshift() function with less than expected no. of arguments --\n";
-$array = array(1, 2);
-var_dump( array_unshift($array) );
 echo "Done";
 ?>
 --EXPECTF--
@@ -24,11 +19,6 @@ echo "Done";
 
 -- Testing array_unshift() function with Zero arguments --
 
-Warning: array_unshift() expects at least 2 parameters, 0 given in %s on line %d
-NULL
-
--- Testing array_unshift() function with less than expected no. of arguments --
-
-Warning: array_unshift() expects at least 2 parameters, 1 given in %s on line %d
+Warning: array_unshift() expects at least 1 parameter, 0 given in %s on line %d
 NULL
 Done


### PR DESCRIPTION
The [`array_push`](http://php.net/manual/en/function.array-push.php) and [`array_unshift`](http://php.net/manual/en/function.array-unshift.php) functions require at least 2 arguments. Requirement about second argument was relevant until version 5.6, because the code `array_push($array)` really does not make sense. But with argument unpacking syntax we can use spread operator for array union:
```php
array_push($array, ...$values);
array_unshift($array, ...$values);
```
If the addition list length is not predefined then we should explicitly check the case when this list is emptiness to avoid the warning message, or prepend the expression with `@`-operator. Actually the functions [work well](https://3v4l.org/mpc8c) with single argument, they just do not change it. The warning is completely redundant and explicit checking negates the benefit (code size reducing) gained with the spread operator.

For example, relevant array methods [`push`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push) and [`unshift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift) in the JavaScript work this way:
```javascript
"use strict";
var array = [1,2,3]
var values = []
array.push(...values)
array.unshift(...values)
// no error messages, both methods just return 3, array is still [1,2,3]
```

Adding multiple elements to an array is a _very_ common operation. This patch just will make it a little more convenient.

Unfortunately, it may cause the minor **BC break** for return value. Currently both functions returns `NULL` when second argument is not passed. With this patch in this case they will return the length of array passed as first argument. Do I need to create RFC for such a small change?
  