### PR TITLE
Fixes Bug #66960

### DIFF
--- a/ext/phar/tests/bug66960.phpt
+++ b/ext/phar/tests/bug66960.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #66960 phar long filename crash
+--SKIPIF--
+<?php if (!extension_loaded("phar")) die("skip"); ?>
+--INI--
+phar.readonly = 0
+memory_limit = -1
+--FILE--
+<?php
+$file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bug66960.phar';
+$phar = new Phar($file);
+assert(false === file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN-1)));
+assert(false === file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN)));
+assert(false === file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN+1)));
+echo 'done';
+--EXPECTF--
+done

--- a/ext/phar/tests/bug66960.phpt
+++ b/ext/phar/tests/bug66960.phpt
@@ -9,9 +9,16 @@ memory_limit = -1
 <?php
 $file = __DIR__ . DIRECTORY_SEPARATOR . 'bug66960.phar';
 $phar = new Phar($file);
-assert(false === file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN-1)));
-assert(false === file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN)));
-assert(false === file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN+1)));
+var_dump(file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN-1)));
+var_dump(file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN)));
+var_dump(file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN+1)));
 echo 'done';
---EXPECTF--
+?>
+--CLEAN--
+$file = __DIR__ . DIRECTORY_SEPARATOR . 'bug66960.phar';
+unlink($file);
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
 done

--- a/ext/phar/tests/bug66960.phpt
+++ b/ext/phar/tests/bug66960.phpt
@@ -7,7 +7,7 @@ phar.readonly = 0
 memory_limit = -1
 --FILE--
 <?php
-$file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bug66960.phar';
+$file = __DIR__ . DIRECTORY_SEPARATOR . 'bug66960.phar';
 $phar = new Phar($file);
 assert(false === file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN-1)));
 assert(false === file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN)));


### PR DESCRIPTION
If given a non-existent path that exceeds the build-defined maximum path length, we should not find the file -- rather than dumping core as described in the bug report. This PR adds a test asserting the buggy behavior reported in 2014 doesn't re-appear.

https://bugs.php.net/bug.php?id=66960

Note that the use of `__DIR__` in this test is as a temporary directory, as I'm not sure tests can rely upon `sys_get_temp_dir()` to reliably avoid test false failures.