### PR TITLE
Fix #75765 Exception on extend of undefined class

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6370,7 +6370,7 @@ void zend_compile_class_decl(zend_ast *ast) /* {{{ */
 				"Cannot use '%s' as class name as it is reserved", ZSTR_VAL(extends_name));
 		}
 
-		zend_compile_class_ref(&extends_node, extends_ast, 0);
+		zend_compile_class_ref(&extends_node, extends_ast, 1);
 		ce->ce_flags |= ZEND_ACC_INHERITED;
 	}
 

--- a/ext/spl/tests/bug73423.phpt
+++ b/ext/spl/tests/bug73423.phpt
@@ -68,4 +68,15 @@ foreach (new \RecursiveIteratorIterator (new fooIterator ($foo)) as $bar) ;
 
 ?>
 --EXPECTF--
-Fatal error: Class 'NotExists' not found in %sbug73423.php(%d) : eval()'d code on line 1
+Fatal error: Uncaught Error: Class 'NotExists' not found in %sbug73423.php(%d) : eval()'d code:1
+Stack trace:
+#0 %sbug73423.php(%d): eval()
+#1 %sbug73423.php(%d): fooIterator->__destruct()
+#2 {main}
+
+Next Error: Class 'NotExists' not found in %sbug73423.php(%d) : eval()'d code:1
+Stack trace:
+#0 %sbug73423.php(%d): eval()
+#1 %sbug73423.php(%d): fooIterator->__destruct()
+#2 {main}
+  thrown in %sbug73423.php(%d) : eval()'d code on line 1

--- a/tests/classes/autoload_011.phpt
+++ b/tests/classes/autoload_011.phpt
@@ -14,4 +14,7 @@ class C extends UndefBase
 --EXPECTF--
 In autoload: string(9) "UndefBase"
 
-Fatal error: Class 'UndefBase' not found in %s on line %d
+Fatal error: Uncaught Error: Class 'UndefBase' not found in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %sautoload_011.php on line %d

--- a/tests/classes/bug75765.phpt
+++ b/tests/classes/bug75765.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Ensure that extending of undefined class throws the exception
+--FILE--
+<?php
+
+try {
+	class A extends B {}
+} catch (Error $e) {
+	var_dump(class_exists('A'));
+	var_dump(class_exists('B'));
+	throw $e;
+}
+
+?>
+--EXPECTF--
+bool(false)
+bool(false)
+
+Fatal error: Uncaught Error: Class 'B' not found in %sbug75765.php:%d
+Stack trace:
+#0 {main}
+  thrown in %sbug75765.php on line %d


### PR DESCRIPTION
Extending an undefined class causes the fatal error instead of throwing Error exception. 
Relevant issue: https://bugs.php.net/bug.php?id=75765 

The [previous](https://github.com/php/php-src/pull/3010) patch contained a fix for "implements" handling, but it had [errors](https://github.com/php/php-src/pull/3010#issuecomment-356089518), so I removed all related with interfaces and made a new PR. 