### PR TITLE
[WIP] POC for dynamic GC buffer resizing

### DIFF
--- a/Zend/tests/gc_016.phpt
+++ b/Zend/tests/gc_016.phpt
@@ -18,9 +18,11 @@ $a = new Foo();
 $a->a = $a;
 unset($a);
 var_dump(gc_collect_cycles());
+var_dump(gc_collect_cycles());
 echo "ok\n"
 ?>
 --EXPECT--
--> int(1)
+-> int(0)
+int(1)
 int(1)
 ok

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -327,8 +327,9 @@ ZEND_API void ZEND_FASTCALL gc_possible_root(zend_refcounted *ref)
 		newRoot = GC_TO_BUF(newRootAddr);
 		GC_G(first_unused)++;
 	} else {
-		if (!GC_G(gc_enabled)) {
-			/* TODO Resize here */
+		if (GC_G(buf) == GC_DUMMY_BUF()) {
+			/* This means that the GC is completely disabled, rather than just disabled
+			 * temporarily at run-time. In this case we just let things leak. */
 			return;
 		}
 

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -53,9 +53,9 @@ typedef struct _zend_gc_globals {
 	zend_bool         gc_full;
 
 	gc_root_buffer   *buf;				/* preallocated arrays of buffers   */
+	uint32_t          buf_size;			/* size of the GC buffer            */
 	uint32_t          unused;			/* linked list of unused buffers    */
 	uint32_t          first_unused;		/* first unused buffer              */
-	uint32_t          last_unused;		/* last unused buffer               */
 	uint32_t          next_to_free;     /* next to free in to_free list     */
 
 	uint32_t gc_runs;

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -41,11 +41,17 @@
 #endif
 
 typedef struct _gc_root_buffer {
-	zend_refcounted          *ref;
-	struct _gc_root_buffer   *next;     /* double-linked list               */
-	struct _gc_root_buffer   *prev;
-	uint32_t                 refcount;
+	zend_refcounted *ref;
+	uint32_t         next;     /* double-linked list */
+	uint32_t         prev;
+	uint32_t         refcount;
 } gc_root_buffer;
+
+/* Doubly linked list of root buffers, lists are terminated with GC_INVALID */
+typedef struct _gc_root_list {
+	uint32_t next;
+	uint32_t prev;
+} gc_root_list;
 
 #define GC_NUM_ADDITIONAL_ENTRIES \
 	((4096 - ZEND_MM_OVERHEAD - sizeof(void*) * 2) / sizeof(gc_root_buffer))
@@ -64,13 +70,13 @@ typedef struct _zend_gc_globals {
 	zend_bool         gc_full;
 
 	gc_root_buffer   *buf;				/* preallocated arrays of buffers   */
-	gc_root_buffer    roots;			/* list of possible roots of cycles */
-	gc_root_buffer   *unused;			/* list of unused buffers           */
-	gc_root_buffer   *first_unused;		/* pointer to first unused buffer   */
-	gc_root_buffer   *last_unused;		/* pointer to last unused buffer    */
+	//gc_root_list      roots;			/* list of possible roots of cycles */
+	uint32_t          unused;			/* linked list of unused buffers    */
+	uint32_t          first_unused;		/* first unused buffer              */
+	uint32_t          last_unused;		/* last unused buffer               */
 
-	gc_root_buffer    to_free;			/* list to free                     */
-	gc_root_buffer   *next_to_free;
+	//gc_root_list      to_free;			/* list to free                     */
+	uint32_t          next_to_free;     /* next to free in to_free list     */
 
 	uint32_t gc_runs;
 	uint32_t collected;

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -47,35 +47,15 @@ typedef struct _gc_root_buffer {
 	uint32_t         refcount;
 } gc_root_buffer;
 
-/* Doubly linked list of root buffers, lists are terminated with GC_INVALID */
-typedef struct _gc_root_list {
-	uint32_t next;
-	uint32_t prev;
-} gc_root_list;
-
-#define GC_NUM_ADDITIONAL_ENTRIES \
-	((4096 - ZEND_MM_OVERHEAD - sizeof(void*) * 2) / sizeof(gc_root_buffer))
-
-typedef struct _gc_additional_bufer gc_additional_buffer;
-
-struct _gc_additional_bufer {
-	uint32_t              used;
-	gc_additional_buffer *next;
-	gc_root_buffer        buf[GC_NUM_ADDITIONAL_ENTRIES];
-};
-
 typedef struct _zend_gc_globals {
 	zend_bool         gc_enabled;
 	zend_bool         gc_active;
 	zend_bool         gc_full;
 
 	gc_root_buffer   *buf;				/* preallocated arrays of buffers   */
-	//gc_root_list      roots;			/* list of possible roots of cycles */
 	uint32_t          unused;			/* linked list of unused buffers    */
 	uint32_t          first_unused;		/* first unused buffer              */
 	uint32_t          last_unused;		/* last unused buffer               */
-
-	//gc_root_list      to_free;			/* list to free                     */
 	uint32_t          next_to_free;     /* next to free in to_free list     */
 
 	uint32_t gc_runs;
@@ -89,9 +69,6 @@ typedef struct _zend_gc_globals {
 	uint32_t zval_remove_from_buffer;
 	uint32_t zval_marked_grey;
 #endif
-
-	gc_additional_buffer *additional_buffer;
-
 } zend_gc_globals;
 
 #ifdef ZTS

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -49,8 +49,8 @@ typedef struct _gc_root_buffer {
 
 typedef struct _zend_gc_globals {
 	zend_bool         gc_enabled;
-	zend_bool         gc_active;
-	zend_bool         gc_full;
+	zend_bool         gc_active;        /* GC currently running, forbid nested GC */
+	zend_bool         gc_protected;     /* GC collecting roots, forbid root additions */
 
 	gc_root_buffer   *buf;				/* preallocated arrays of buffers   */
 	uint32_t          buf_size;			/* size of the GC buffer            */

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -42,7 +42,7 @@
 
 typedef struct _gc_root_buffer {
 	zend_refcounted *ref;
-	uint32_t         next;     /* double-linked list */
+	uint32_t         next;
 	uint32_t         prev;
 	uint32_t         refcount;
 } gc_root_buffer;
@@ -50,7 +50,7 @@ typedef struct _gc_root_buffer {
 typedef struct _zend_gc_globals {
 	zend_bool         gc_enabled;
 	zend_bool         gc_active;        /* GC currently running, forbid nested GC */
-	zend_bool         gc_protected;     /* GC collecting roots, forbid root additions */
+	zend_bool         gc_protected;     /* GC protected, forbid root additions */
 
 	gc_root_buffer   *buf;				/* preallocated arrays of buffers   */
 	uint32_t          buf_size;			/* size of the GC buffer            */
@@ -58,6 +58,7 @@ typedef struct _zend_gc_globals {
 	uint32_t          unused;			/* linked list of unused buffers    */
 	uint32_t          first_unused;		/* first unused buffer              */
 	uint32_t          next_to_free;     /* next to free in to_free list     */
+	uint32_t          gc_threshold;     /* GC collection threshold          */
 
 	uint32_t gc_runs;
 	uint32_t collected;

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -54,6 +54,7 @@ typedef struct _zend_gc_globals {
 
 	gc_root_buffer   *buf;				/* preallocated arrays of buffers   */
 	uint32_t          buf_size;			/* size of the GC buffer            */
+	uint32_t          num_roots;        /* number of roots in GC buffer     */
 	uint32_t          unused;			/* linked list of unused buffers    */
 	uint32_t          first_unused;		/* first unused buffer              */
 	uint32_t          next_to_free;     /* next to free in to_free list     */

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -40,26 +40,6 @@
 # define GC_BENCH_PEAK(peak, counter)
 #endif
 
-#define GC_COLOR  0xc000
-
-#define GC_BLACK  0x0000
-#define GC_WHITE  0x8000
-#define GC_GREY   0x4000
-#define GC_PURPLE 0xc000
-
-#define GC_ADDRESS(v) \
-	((v) & ~GC_COLOR)
-#define GC_INFO_GET_COLOR(v) \
-	(((zend_uintptr_t)(v)) & GC_COLOR)
-#define GC_INFO_SET_ADDRESS(v, a) \
-	do {(v) = ((v) & GC_COLOR) | (a);} while (0)
-#define GC_INFO_SET_COLOR(v, c) \
-	do {(v) = ((v) & ~GC_COLOR) | (c);} while (0)
-#define GC_INFO_SET_BLACK(v) \
-	do {(v) = (v) & ~GC_COLOR;} while (0)
-#define GC_INFO_SET_PURPLE(v) \
-	do {(v) = (v) | GC_COLOR;} while (0)
-
 typedef struct _gc_root_buffer {
 	zend_refcounted          *ref;
 	struct _gc_root_buffer   *next;     /* double-linked list               */
@@ -133,16 +113,14 @@ ZEND_API int  zend_gc_collect_cycles(void);
 END_EXTERN_C()
 
 #define GC_REMOVE_FROM_BUFFER(p) do { \
-		zend_refcounted *_p = (zend_refcounted*)(p); \
-		if (GC_ADDRESS(GC_INFO(_p))) { \
+		zend_refcounted *_p = (zend_refcounted *)(p); \
+		if (GC_ADDRESS(_p)) { \
 			gc_remove_from_buffer(_p); \
 		} \
 	} while (0)
 
 #define GC_MAY_LEAK(ref) \
-	((GC_TYPE_INFO(ref) & \
-		(GC_INFO_MASK | (GC_COLLECTABLE << GC_FLAGS_SHIFT))) == \
-	(GC_COLLECTABLE << GC_FLAGS_SHIFT))
+	((GC_FLAGS(ref) & GC_COLLECTABLE) && GC_ADDRESS(ref) == 0)
 
 static zend_always_inline void gc_check_possible_root(zend_refcounted *ref)
 {

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -159,9 +159,8 @@ static const uint32_t uninitialized_bucket[-HT_MIN_MASK] =
 
 ZEND_API const HashTable zend_empty_array = {
 	.gc.rc.refcount = 2,
-	.gc.rc.u.type_info = IS_ARRAY | (GC_IMMUTABLE << GC_FLAGS_SHIFT),
+	.gc.rc.u.type_info = IS_ARRAY | (GC_IMMUTABLE << GC_FLAGS_SHIFT) | (HASH_FLAG_STATIC_KEYS << 16),
 	.gc.gc_root = 0,
-	.u.flags = HASH_FLAG_STATIC_KEYS,
 	.nTableMask = HT_MIN_MASK,
 	.arData = (Bucket*)&uninitialized_bucket[2],
 	.nNumUsed = 0,
@@ -1364,7 +1363,8 @@ ZEND_API void ZEND_FASTCALL zend_array_destroy(HashTable *ht)
 
 	/* break possible cycles */
 	GC_REMOVE_FROM_BUFFER(ht);
-	GC_TYPE_INFO(ht) = IS_NULL | (GC_WHITE << GC_FLAGS_SHIFT);
+	GC_TYPE(ht) = IS_NULL;
+	GC_FLAGS(ht) = GC_WHITE;
 
 	if (ht->nNumUsed) {
 		/* In some rare cases destructors of regular arrays may be changed */

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -42,7 +42,7 @@
 #define HASH_FLAG_HAS_EMPTY_IND    (1<<5)
 #define HASH_FLAG_ALLOW_COW_VIOLATION (1<<6)
 
-#define HT_FLAGS(ht) (ht)->u.flags
+#define HT_FLAGS(ht) GC_EXTRA_FLAGS(ht)
 
 #define HT_IS_PACKED(ht) \
 	((HT_FLAGS(ht) & HASH_FLAG_PACKED) != 0)
@@ -59,7 +59,7 @@
 # define HT_ALLOW_COW_VIOLATION(ht)
 #endif
 
-#define HT_ITERATORS_COUNT(ht) (GC_EXTRA_FLAGS(ht) >> 8)
+#define HT_ITERATORS_COUNT(ht) (HT_FLAGS(ht) >> 8)
 #define HT_ITERATORS_OVERFLOW(ht) (HT_ITERATORS_COUNT(ht) == 0xff)
 #define HT_HAS_ITERATORS(ht) (HT_ITERATORS_COUNT(ht) != 0)
 

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -59,12 +59,12 @@
 # define HT_ALLOW_COW_VIOLATION(ht)
 #endif
 
-#define HT_ITERATORS_COUNT(ht) (ht)->u.v.nIteratorsCount
+#define HT_ITERATORS_COUNT(ht) (GC_EXTRA_FLAGS(ht) >> 8)
 #define HT_ITERATORS_OVERFLOW(ht) (HT_ITERATORS_COUNT(ht) == 0xff)
 #define HT_HAS_ITERATORS(ht) (HT_ITERATORS_COUNT(ht) != 0)
 
 #define HT_SET_ITERATORS_COUNT(ht, iters) \
-	do { HT_ITERATORS_COUNT(ht) = (iters); } while (0)
+	do { GC_EXTRA_FLAGS(ht) = ((iters) << 8) | (GC_EXTRA_FLAGS(ht) & 0xff); } while (0)
 #define HT_INC_ITERATORS_COUNT(ht) \
 	HT_SET_ITERATORS_COUNT(ht, HT_ITERATORS_COUNT(ht) + 1)
 #define HT_DEC_ITERATORS_COUNT(ht) \

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -31,6 +31,7 @@ ZEND_API void ZEND_FASTCALL zend_object_std_init(zend_object *object, zend_class
 {
 	GC_SET_REFCOUNT(object, 1);
 	GC_TYPE_INFO(object) = IS_OBJECT | (GC_COLLECTABLE << GC_FLAGS_SHIFT);
+	object->gc.gc_root = 0;
 	object->ce = ce;
 	object->properties = NULL;
 	zend_objects_store_put(object);

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -74,8 +74,8 @@ static zend_always_inline void zend_object_release(zend_object *obj)
 {
 	if (GC_DELREF(obj) == 0) {
 		zend_objects_store_del(obj);
-	} else if (UNEXPECTED(GC_MAY_LEAK((zend_refcounted*)obj))) {
-		gc_possible_root((zend_refcounted*)obj);
+	} else if (UNEXPECTED(GC_MAY_LEAK(obj))) {
+		gc_possible_root((zend_refcounted *) obj);
 	}
 }
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -249,16 +249,6 @@ typedef struct _zend_array HashTable;
 
 struct _zend_array {
 	zend_refcounted_gc_h gc;
-	union {
-		struct {
-			ZEND_ENDIAN_LOHI_4(
-				zend_uchar    flags,
-				zend_uchar    _unused,
-				zend_uchar    _unused2,
-				zend_uchar    _unused3)
-		} v;
-		uint32_t flags;
-	} u;
 	uint32_t          nTableMask;
 	Bucket           *arData;
 	uint32_t          nNumUsed;

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -204,18 +204,29 @@ struct _zval_struct {
 	} u2;
 };
 
-typedef struct _zend_refcounted_h {
+typedef struct _zend_refcounted_common {
 	uint32_t         refcount;			/* reference counter 32-bit */
 	union {
 		struct {
 			ZEND_ENDIAN_LOHI_3(
 				zend_uchar    type,
-				zend_uchar    flags,    /* used for strings & objects */
-				uint16_t      gc_info)  /* keeps GC root number (or 0) and color */
+				zend_uchar    gc_flags,    /* GC flags, including GC color */
+				uint16_t      extra_flags) /* additional type specific flags */
 		} v;
 		uint32_t type_info;
 	} u;
+} zend_refcounted_common;
+
+/* This wrapper exists so that refcounted_h and refcounted_gc_h use the same
+ * field nesting to access the common RC information. */
+typedef struct _zend_refcounted_h {
+	zend_refcounted_common rc;
 } zend_refcounted_h;
+
+typedef struct _zend_refcounted_gc_h {
+	zend_refcounted_common rc;
+	uint32_t gc_root;
+} zend_refcounted_gc_h;
 
 struct _zend_refcounted {
 	zend_refcounted_h gc;
@@ -237,7 +248,7 @@ typedef struct _Bucket {
 typedef struct _zend_array HashTable;
 
 struct _zend_array {
-	zend_refcounted_h gc;
+	zend_refcounted_gc_h gc;
 	union {
 		struct {
 			ZEND_ENDIAN_LOHI_4(
@@ -336,7 +347,7 @@ typedef struct _HashTableIterator {
 } HashTableIterator;
 
 struct _zend_object {
-	zend_refcounted_h gc;
+	zend_refcounted_gc_h gc;
 	uint32_t          handle; // TODO: may be removed ???
 	zend_class_entry *ce;
 	const zend_object_handlers *handlers;
@@ -442,17 +453,20 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 
 #define Z_TYPE_FLAGS_SHIFT			8
 
-#define GC_REFCOUNT(p)				zend_gc_refcount(&(p)->gc)
-#define GC_SET_REFCOUNT(p, rc)		zend_gc_set_refcount(&(p)->gc, rc)
-#define GC_ADDREF(p)				zend_gc_addref(&(p)->gc)
-#define GC_DELREF(p)				zend_gc_delref(&(p)->gc)
-#define GC_ADDREF_EX(p, rc)			zend_gc_addref_ex(&(p)->gc, rc)
-#define GC_DELREF_EX(p, rc)			zend_gc_delref_ex(&(p)->gc, rc)
+#define GC_REFCOUNT(p)				zend_gc_refcount(&(p)->gc.rc)
+#define GC_SET_REFCOUNT(p, rcnt)	zend_gc_set_refcount(&(p)->gc.rc, rcnt)
+#define GC_ADDREF(p)				zend_gc_addref(&(p)->gc.rc)
+#define GC_DELREF(p)				zend_gc_delref(&(p)->gc.rc)
+#define GC_ADDREF_EX(p, rcnt)		zend_gc_addref_ex(&(p)->gc.rc, rcnt)
+#define GC_DELREF_EX(p, rcnt)		zend_gc_delref_ex(&(p)->gc.rc, rcnt)
 
-#define GC_TYPE(p)					(p)->gc.u.v.type
-#define GC_FLAGS(p)					(p)->gc.u.v.flags
-#define GC_INFO(p)					(p)->gc.u.v.gc_info
-#define GC_TYPE_INFO(p)				(p)->gc.u.type_info
+#define GC_TYPE(p)					(p)->gc.rc.u.v.type
+#define GC_FLAGS(p)					(p)->gc.rc.u.v.gc_flags
+#define GC_EXTRA_FLAGS(p)			(p)->gc.rc.u.v.extra_flags
+#define GC_TYPE_INFO(p)				(p)->gc.rc.u.type_info
+
+#define GC_ADDRESS(p)				zend_gc_address(&(p)->gc.rc)
+#define GC_SET_ADDRESS(p, addr)		zend_gc_set_address(&(p)->gc.rc, addr)
 
 #define Z_GC_TYPE(zval)				GC_TYPE(Z_COUNTED(zval))
 #define Z_GC_TYPE_P(zval_p)			Z_GC_TYPE(*(zval_p))
@@ -460,21 +474,24 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define Z_GC_FLAGS(zval)			GC_FLAGS(Z_COUNTED(zval))
 #define Z_GC_FLAGS_P(zval_p)		Z_GC_FLAGS(*(zval_p))
 
-#define Z_GC_INFO(zval)				GC_INFO(Z_COUNTED(zval))
-#define Z_GC_INFO_P(zval_p)			Z_GC_INFO(*(zval_p))
 #define Z_GC_TYPE_INFO(zval)		GC_TYPE_INFO(Z_COUNTED(zval))
 #define Z_GC_TYPE_INFO_P(zval_p)	Z_GC_TYPE_INFO(*(zval_p))
 
 #define GC_FLAGS_SHIFT				8
-#define GC_INFO_SHIFT				16
-#define GC_INFO_MASK				0xffff0000
 
-/* zval.value->gc.u.v.flags (common flags) */
+/* zval.value->gc.rc.u.v.gc_flags (common flags) */
 #define GC_COLLECTABLE				(1<<0)
 #define GC_PROTECTED                (1<<1) /* used for recursion detection */
 #define GC_IMMUTABLE                (1<<2) /* can't be canged in place */
 #define GC_PERSISTENT               (1<<3) /* allocated using malloc */
 #define GC_PERSISTENT_LOCAL         (1<<4) /* persistent, but thread-local */
+
+/* GC colors */
+#define GC_COLOR                    (3<<6)
+#define GC_BLACK                    (0<<6)
+#define GC_WHITE                    (1<<6)
+#define GC_GREY                     (2<<6)
+#define GC_PURPLE                   (3<<6)
 
 #define GC_ARRAY					(IS_ARRAY          | (GC_COLLECTABLE << GC_FLAGS_SHIFT))
 #define GC_OBJECT					(IS_OBJECT         | (GC_COLLECTABLE << GC_FLAGS_SHIFT))
@@ -493,7 +510,7 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 
 #define IS_CONSTANT_AST_EX			(IS_CONSTANT_AST   | (IS_TYPE_REFCOUNTED << Z_TYPE_FLAGS_SHIFT))
 
-/* string flags (zval.value->gc.u.flags) */
+/* string flags (zval.value->gc.rc.u.gc_flags) */
 #define IS_STR_INTERNED				GC_IMMUTABLE  /* interned string */
 #define IS_STR_PERSISTENT			GC_PERSISTENT /* allocated using malloc */
 #define IS_STR_PERMANENT        	(1<<5)        /* relives request boundary */
@@ -502,13 +519,13 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define IS_ARRAY_IMMUTABLE			GC_IMMUTABLE
 #define IS_ARRAY_PERSISTENT			GC_PERSISTENT
 
-/* object flags (zval.value->gc.u.flags) */
+/* object flags (zval.value->gc.rc.u.extra_flags) */
 #define IS_OBJ_DESTRUCTOR_CALLED	(1<<4)
 #define IS_OBJ_FREE_CALLED			(1<<5)
 #define IS_OBJ_USE_GUARDS           (1<<6)
 #define IS_OBJ_HAS_GUARDS           (1<<7)
 
-#define OBJ_FLAGS(obj)              GC_FLAGS(obj)
+#define OBJ_FLAGS(obj)              GC_EXTRA_FLAGS(obj)
 
 /* Recursion protection macros must be used only for arrays and objects */
 #define GC_IS_RECURSIVE(p) \
@@ -902,8 +919,8 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 extern ZEND_API zend_bool zend_rc_debug;
 # define ZEND_RC_MOD_CHECK(p) do { \
 		if (zend_rc_debug) { \
-			ZEND_ASSERT(!((p)->u.v.flags & GC_IMMUTABLE)); \
-			ZEND_ASSERT(((p)->u.v.flags & (GC_PERSISTENT|GC_PERSISTENT_LOCAL)) != GC_PERSISTENT); \
+			ZEND_ASSERT(!((p)->u.v.gc_flags & GC_IMMUTABLE)); \
+			ZEND_ASSERT(((p)->u.v.gc_flags & (GC_PERSISTENT|GC_PERSISTENT_LOCAL)) != GC_PERSISTENT); \
 		} \
 	} while (0)
 # define GC_MAKE_PERSISTENT_LOCAL(p) do { \
@@ -916,35 +933,45 @@ extern ZEND_API zend_bool zend_rc_debug;
 	do { } while (0)
 #endif
 
-static zend_always_inline uint32_t zend_gc_refcount(const zend_refcounted_h *p) {
+static zend_always_inline uint32_t zend_gc_refcount(const zend_refcounted_common *p) {
 	return p->refcount;
 }
 
-static zend_always_inline uint32_t zend_gc_set_refcount(zend_refcounted_h *p, uint32_t rc) {
+static zend_always_inline uint32_t zend_gc_set_refcount(zend_refcounted_common *p, uint32_t rc) {
 	p->refcount = rc;
 	return p->refcount;
 }
 
-static zend_always_inline uint32_t zend_gc_addref(zend_refcounted_h *p) {
+static zend_always_inline uint32_t zend_gc_addref(zend_refcounted_common *p) {
 	ZEND_RC_MOD_CHECK(p);
 	return ++(p->refcount);
 }
 
-static zend_always_inline uint32_t zend_gc_delref(zend_refcounted_h *p) {
+static zend_always_inline uint32_t zend_gc_delref(zend_refcounted_common *p) {
 	ZEND_RC_MOD_CHECK(p);
 	return --(p->refcount);
 }
 
-static zend_always_inline uint32_t zend_gc_addref_ex(zend_refcounted_h *p, uint32_t rc) {
+static zend_always_inline uint32_t zend_gc_addref_ex(zend_refcounted_common *p, uint32_t rc) {
 	ZEND_RC_MOD_CHECK(p);
 	p->refcount += rc;
 	return p->refcount;
 }
 
-static zend_always_inline uint32_t zend_gc_delref_ex(zend_refcounted_h *p, uint32_t rc) {
+static zend_always_inline uint32_t zend_gc_delref_ex(zend_refcounted_common *p, uint32_t rc) {
 	ZEND_RC_MOD_CHECK(p);
 	p->refcount -= rc;
 	return p->refcount;
+}
+
+static zend_always_inline uint32_t zend_gc_address(zend_refcounted_common *p) {
+	ZEND_ASSERT(p->u.v.gc_flags & GC_COLLECTABLE);
+	return ((zend_refcounted_gc_h *) p)->gc_root;
+}
+
+static zend_always_inline void zend_gc_set_address(zend_refcounted_common *p, uint32_t addr) {
+	ZEND_ASSERT(p->u.v.gc_flags & GC_COLLECTABLE);
+	((zend_refcounted_gc_h *) p)->gc_root = addr;
 }
 
 static zend_always_inline uint32_t zval_refcount_p(const zval* pz) {

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -254,8 +254,8 @@ struct _zend_array {
 			ZEND_ENDIAN_LOHI_4(
 				zend_uchar    flags,
 				zend_uchar    _unused,
-				zend_uchar    nIteratorsCount,
-				zend_uchar    _unused2)
+				zend_uchar    _unused2,
+				zend_uchar    _unused3)
 		} v;
 		uint32_t flags;
 	} u;

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -367,7 +367,8 @@ static void zend_persist_op_array_ex(zend_op_array *op_array, zend_persistent_sc
 			zend_accel_store(op_array->static_variables, sizeof(HashTable));
 			/* make immutable array */
 			GC_SET_REFCOUNT(op_array->static_variables, 2);
-			GC_TYPE_INFO(op_array->static_variables) = IS_ARRAY | (IS_ARRAY_IMMUTABLE << GC_FLAGS_SHIFT);
+			GC_TYPE(op_array->static_variables) = IS_ARRAY;
+			GC_FLAGS(op_array->static_variables) = IS_ARRAY_IMMUTABLE;
 			HT_FLAGS(op_array->static_variables) |= HASH_FLAG_STATIC_KEYS;
 		}
 	}


### PR DESCRIPTION
This PR is based on #2994.

This PR does a couple of things:
 * Move the GC buffers from using pointers to using offsets, similar to what we do in hashtables. The idea behind this is that the GC buffer can now be easily reallocated without having to migrate pointers. Additionally, this reduces the size of the GC buffer on 64-bit systems. I've kept the previous design that uses cyclic linked list. A difference is that the sentinel of the cyclic list now has to be part of the root buffer, so the first two roots are reserved for the roots list and to_free list.
 * Remove the additional buffer mechanism and nested GC runs. If additional space is needed, the GC buffer is simply grown. Nested GCs are forbidden, but additional roots can still be added to the buffer (with potential resizing), so they are no longer necessary.
 * Make sure that we're still rooting everything even if gc_disable() was called. Previously this only collected up to 10k roots, now the buffer will be resized to hold all roots. This makes the temporary gc_disable() + gc_enable() pattern guaranteed leak-free.
 * Finally, this implements a *very simple* dummy heuristic for resizing the root buffer. If during a GC run not enough garbage is collected, the GC collection threshold will be increased by a factor of two. This prevents GC for continuously rerunning without collecting anything.

From some initial testing, this works well to avoid GC performance issues. If the active working set is greater than 10k objects, the GC buffer is increased until GC is no longer continuously triggered.

Of course, the current implementation can cause the reverse issue: Once the buffer becomes too large, GC may never be triggered again. The collection criterion will need to be improved for that. For example, we might want to add a timer-based GC (which triggers a GC VM interrupt) to make sure that GC runs from time to time.

Another issue is that while the GC threshold may shrink again, the GC buffer currently is never reduced. It may make sense to allow making it smaller, but this would require compacting the roots to be contiguous.