### PR TITLE
[RFC] Add is_countable function

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4379,6 +4379,23 @@ ZEND_API zend_bool zend_is_iterable(zval *iterable) /* {{{ */
 }
 /* }}} */
 
+ZEND_API zend_bool zend_is_countable(zval *countable) /* {{{ */
+{
+	switch (Z_TYPE_P(countable)) {
+		case IS_ARRAY:
+			return 1;
+		case IS_OBJECT:
+			if (Z_OBJ_HT_P(countable)->count_elements) {
+				return 1;
+			}
+
+			return instanceof_function(Z_OBJCE_P(countable), zend_ce_countable);
+		default:
+			return 0;
+	}
+}
+/* }}} */
+
 /*
  * Local variables:
  * tab-width: 4

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -562,6 +562,8 @@ ZEND_API const char *zend_get_object_type(const zend_class_entry *ce);
 
 ZEND_API zend_bool zend_is_iterable(zval *iterable);
 
+ZEND_API zend_bool zend_is_countable(zval *countable);
+
 #define add_method(arg, key, method)	add_assoc_function((arg), (key), (method))
 
 ZEND_API ZEND_FUNCTION(display_disabled_function);

--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -610,6 +610,7 @@ static const func_info_t func_infos[] = {
 	F0("is_object",                    MAY_BE_FALSE | MAY_BE_TRUE), // TODO: inline with support for incomplete class
 	F0("is_scalar",                    MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F0("is_callable",                  MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
+	F0("is_countable",                 MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F0("pclose",                       MAY_BE_FALSE | MAY_BE_LONG),
 	F1("popen",                        MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_RESOURCE),
 	F0("readfile",                     MAY_BE_FALSE | MAY_BE_LONG),

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2586,6 +2586,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_is_iterable, 0, 0, 1)
 	ZEND_ARG_INFO(0, var)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_is_countable, 0)
+	ZEND_ARG_INFO(0, var)
+ZEND_END_ARG_INFO()
 /* }}} */
 /* {{{ uniqid.c */
 #ifdef HAVE_GETTIMEOFDAY
@@ -3111,6 +3115,7 @@ static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(is_scalar,														arginfo_is_scalar)
 	PHP_FE(is_callable,														arginfo_is_callable)
 	PHP_FE(is_iterable,														arginfo_is_iterable)
+	PHP_FE(is_countable,													arginfo_is_countable)
 
 	/* functions from file.c */
 	PHP_FE(pclose,															arginfo_pclose)

--- a/ext/standard/php_type.h
+++ b/ext/standard/php_type.h
@@ -39,5 +39,6 @@ PHP_FUNCTION(is_object);
 PHP_FUNCTION(is_scalar);
 PHP_FUNCTION(is_callable);
 PHP_FUNCTION(is_iterable);
+PHP_FUNCTION(is_countable);
 
 #endif

--- a/ext/standard/tests/general_functions/is_countable_with_classes.phpt
+++ b/ext/standard/tests/general_functions/is_countable_with_classes.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test is_countable() function
+--CREDITS--
+Gabriel Caruso (carusogabriel34@gmail.com)
+--FILE--
+<?php
+var_dump(is_countable(new class extends ArrayIterator {}));
+var_dump(is_countable((array) new stdClass()));
+var_dump(is_countable(new class implements Countable {
+    public function count()
+    {
+        return count(1, 'foo');
+    }
+}));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)

--- a/ext/standard/tests/general_functions/is_countable_with_variables.phpt
+++ b/ext/standard/tests/general_functions/is_countable_with_variables.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test is_countable() function
+--CREDITS--
+Gabriel Caruso (carusogabriel34@gmail.com)
+--FILE--
+<?php
+var_dump(is_countable([1, 2, 3]));
+var_dump(is_countable((array) 1));
+var_dump(is_countable((object) ['foo', 'bar', 'baz']));
+var_dump(is_countable());
+
+$foo = ['', []];
+
+if (is_countable($foo)) {
+    var_dump(count($foo));
+}
+
+$bar = null;
+if (!is_countable($bar)) {
+    count($bar);
+}
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(false)
+
+Warning: is_countable() expects exactly 1 parameter, 0 given in %s on line %d
+NULL
+int(2)
+
+Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d

--- a/ext/standard/type.c
+++ b/ext/standard/type.c
@@ -395,6 +395,20 @@ PHP_FUNCTION(is_iterable)
 }
 /* }}} */
 
+/* {{{ proto bool is_countable(mixed var)
+   Returns true if var is countable (array or instance of Countable). */
+PHP_FUNCTION(is_countable)
+{
+	zval *var;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(var)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_BOOL(zend_is_countable(var));
+}
+/* }}} */
+
 /*
  * Local variables:
  * tab-width: 4


### PR DESCRIPTION
In #2185 a `Warning` was added while trying to count non-countables:
```
Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d
```
and we start to see everyone changing their codes, usually adding the following condition:
```php
if (is_array($foo) || $foo instanceof \Countable) {...
```
Inspired by that, this PR adds `is_countable()` function that returns a boolean:
- `true`, if a value is an `array` or an instance of `Countable` interface
- `false` for other values

RFC: https://wiki.php.net/rfc/is-countable