### PR TITLE
ext/session: catch incompatible configure flags earlier.

### DIFF
--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -27,7 +27,12 @@ if test "$PHP_MM" != "no"; then
   if test -z "$MM_DIR" ; then
     AC_MSG_ERROR(cannot find mm library)
   fi
-  
+
+  if test "$enable_maintainer_zts" = "yes"; then
+    dnl The mm library is not thread-safe, and mod_mm.c refuses to compile.
+    AC_MSG_ERROR(--with-mm cannot be combined with --enable-maintainer-zts)
+  fi
+
   PHP_ADD_LIBRARY_WITH_PATH(mm, $MM_DIR/$PHP_LIBDIR, SESSION_SHARED_LIBADD)
   PHP_ADD_INCLUDE($MM_DIR/include)
   PHP_INSTALL_HEADERS([ext/session/mod_mm.h])


### PR DESCRIPTION
The session extension has a --with-mm flag that tells it to build
the mm backend ("mm" is the name of the library). However, that
backend is not thread-safe, and mod_mm.c will refuse to compile if
the --enable-maintainer-zts flag was also passed to the configure
script.

Rather than crash halfway through the build, this commit adds a check
to the session extension's config.m4 file. If both --with-mm and
--enable-maintainer-zts are "on," then the configure script will
die and explain that they can't be used together.

PHP-bug: 14269