### PR TITLE
fixed Big_endian issue on s390x for stream test cases

### DIFF
--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -1627,7 +1627,7 @@ PHP_FUNCTION(stream_isatty)
 {
 	zval *zsrc;
 	php_stream *stream;
-	zend_long fileno;
+	php_socket_t fileno;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_RESOURCE(zsrc)


### PR DESCRIPTION
This PR solves the issue [75864](https://bugs.php.net/bug.php?id=75864)

The root reason happens at  `main/streams/plain_wrapper.c:578`

     578                                     *(php_socket_t *)ret = fd;

Note `php_socket_t` is int type (4 bytes) and `ret` (`fileno`) is long (8 bytes).
The  point operation is sensitive on Big/Little Endian platforms, it is ok on LE, but causes the issue on BE.

The solution is to change `fileno"`to int type.

Test `make test` shows all cases related stream are passed.
