### PR TITLE
fixed crash of cases related to mbstring on s390x

### DIFF
--- a/ext/mbstring/oniguruma/src/regint.h
+++ b/ext/mbstring/oniguruma/src/regint.h
@@ -528,7 +528,7 @@ typedef int AbsAddrType;
 typedef int LengthType;
 typedef int RepeatNumType;
 typedef int MemNumType;
-typedef short int StateCheckNumType;
+typedef int StateCheckNumType;
 typedef void* PointerType;
 
 #define SIZE_OPCODE           1


### PR DESCRIPTION
This PR fixes the [bug](https://bugs.php.net/bug.php?id=75863)

Note `type` (StateCheckNumType) is defined as "short" (`ext/mbstring/oniguruma/src/regint.h`),
while "mem" is `int`, 

    191 #define PLATFORM_GET_INC(val,p,type) do{\
    192   val  = *(type* )p;\
    193   (p) += sizeof(type);\
    194 } while(0)
    ...
    553 #define GET_STATE_CHECK_NUM_INC(num,p)  PLATFORM_GET_INC(num, p, StateCheckNumType)

 which causes the issue on Big_Endian platforms.

The solution: change `StateCheckNumType` as `int`.
