### PR TITLE
Fix DateTime*::__set_state arginfo

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -393,6 +393,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_date_period_construct, 0, 0, 3)
 	ZEND_ARG_INFO(0, end)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_date_set_state, 0, 0, 1)
+	ZEND_ARG_INFO(0, array)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_date_interval_construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, interval_spec)
 ZEND_END_ARG_INFO()
@@ -477,7 +481,7 @@ static const zend_function_entry date_funcs_interface[] = {
 static const zend_function_entry date_funcs_date[] = {
 	PHP_ME(DateTime,			__construct,		arginfo_date_create, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
 	PHP_ME(DateTime,			__wakeup,			NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(DateTime,			__set_state,		NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateTime,			__set_state,		arginfo_date_set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(DateTime,			createFromImmutable,	arginfo_date_method_create_from_immutable, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(createFromFormat, date_create_from_format,	arginfo_date_create_from_format, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(getLastErrors, date_get_last_errors,	arginfo_date_get_last_errors, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
@@ -500,7 +504,7 @@ static const zend_function_entry date_funcs_date[] = {
 static const zend_function_entry date_funcs_immutable[] = {
 	PHP_ME(DateTimeImmutable, __construct,   arginfo_date_create, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
 	PHP_ME(DateTime, __wakeup,       NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(DateTimeImmutable, __set_state,   NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateTimeImmutable, __set_state,   arginfo_date_set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(createFromFormat, date_create_immutable_from_format, arginfo_date_create_from_format, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(getLastErrors,    date_get_last_errors,    arginfo_date_get_last_errors, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(format,           date_format,             arginfo_date_method_format, 0)
@@ -523,7 +527,7 @@ static const zend_function_entry date_funcs_immutable[] = {
 static const zend_function_entry date_funcs_timezone[] = {
 	PHP_ME(DateTimeZone,              __construct,                 arginfo_timezone_open, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
 	PHP_ME(DateTimeZone,              __wakeup,                    NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(DateTimeZone,              __set_state,                 NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateTimeZone,              __set_state,                 arginfo_date_set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(getName,           timezone_name_get,           arginfo_timezone_method_name_get, 0)
 	PHP_ME_MAPPING(getOffset,         timezone_offset_get,         arginfo_timezone_method_offset_get, 0)
 	PHP_ME_MAPPING(getTransitions,    timezone_transitions_get,    arginfo_timezone_method_transitions_get, 0)
@@ -536,7 +540,7 @@ static const zend_function_entry date_funcs_timezone[] = {
 static const zend_function_entry date_funcs_interval[] = {
 	PHP_ME(DateInterval,              __construct,                 arginfo_date_interval_construct, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
 	PHP_ME(DateInterval,              __wakeup,                    NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(DateInterval,              __set_state,                 NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateInterval,              __set_state,                 arginfo_date_set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(format,            date_interval_format,        arginfo_date_method_interval_format, 0)
 	PHP_ME_MAPPING(createFromDateString, date_interval_create_from_date_string,	arginfo_date_interval_create_from_date_string, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_FE_END
@@ -545,7 +549,7 @@ static const zend_function_entry date_funcs_interval[] = {
 static const zend_function_entry date_funcs_period[] = {
 	PHP_ME(DatePeriod,                __construct,                 arginfo_date_period_construct, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
 	PHP_ME(DatePeriod,                __wakeup,                    NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(DatePeriod,                __set_state,                 NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DatePeriod,                __set_state,                 arginfo_date_set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(DatePeriod,                getStartDate,                NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(DatePeriod,                getEndDate,                  NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(DatePeriod,                getDateInterval,             NULL, ZEND_ACC_PUBLIC)
@@ -2908,7 +2912,7 @@ static int php_date_initialize_from_hash(php_date_obj **dateobj, HashTable *myht
 	return 0;
 } /* }}} */
 
-/* {{{ proto DateTime::__set_state()
+/* {{{ proto DateTime::__set_state(array $array)
 */
 PHP_METHOD(DateTime, __set_state)
 {
@@ -2930,7 +2934,7 @@ PHP_METHOD(DateTime, __set_state)
 }
 /* }}} */
 
-/* {{{ proto DateTimeImmutable::__set_state()
+/* {{{ proto DateTimeImmutable::__set_state(array $array)
 */
 PHP_METHOD(DateTimeImmutable, __set_state)
 {
@@ -3834,7 +3838,7 @@ static int php_date_timezone_initialize_from_hash(zval **return_value, php_timez
 	return FAILURE;
 } /* }}} */
 
-/* {{{ proto DateTimeZone::__set_state()
+/* {{{ proto DateTimeZone::__set_state(array $array)
  *  */
 PHP_METHOD(DateTimeZone, __set_state)
 {
@@ -4357,7 +4361,7 @@ static int php_date_interval_initialize_from_hash(zval **return_value, php_inter
 	return 0;
 } /* }}} */
 
-/* {{{ proto DateInterval::__set_state()
+/* {{{ proto DateInterval::__set_state(array $array)
 */
 PHP_METHOD(DateInterval, __set_state)
 {
@@ -5210,7 +5214,7 @@ static int php_date_period_initialize_from_hash(php_period_obj *period_obj, Hash
 	return 1;
 } /* }}} */
 
-/* {{{ proto DatePeriod::__set_state()
+/* {{{ proto DatePeriod::__set_state(array $array)
 */
 PHP_METHOD(DatePeriod, __set_state)
 {

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2912,7 +2912,7 @@ static int php_date_initialize_from_hash(php_date_obj **dateobj, HashTable *myht
 	return 0;
 } /* }}} */
 
-/* {{{ proto DateTime::__set_state(array $array)
+/* {{{ proto DateTime::__set_state(array array)
 */
 PHP_METHOD(DateTime, __set_state)
 {
@@ -2934,7 +2934,7 @@ PHP_METHOD(DateTime, __set_state)
 }
 /* }}} */
 
-/* {{{ proto DateTimeImmutable::__set_state(array $array)
+/* {{{ proto DateTimeImmutable::__set_state(array array)
 */
 PHP_METHOD(DateTimeImmutable, __set_state)
 {
@@ -3838,7 +3838,7 @@ static int php_date_timezone_initialize_from_hash(zval **return_value, php_timez
 	return FAILURE;
 } /* }}} */
 
-/* {{{ proto DateTimeZone::__set_state(array $array)
+/* {{{ proto DateTimeZone::__set_state(array array)
  *  */
 PHP_METHOD(DateTimeZone, __set_state)
 {
@@ -4361,7 +4361,7 @@ static int php_date_interval_initialize_from_hash(zval **return_value, php_inter
 	return 0;
 } /* }}} */
 
-/* {{{ proto DateInterval::__set_state(array $array)
+/* {{{ proto DateInterval::__set_state(array array)
 */
 PHP_METHOD(DateInterval, __set_state)
 {
@@ -5214,7 +5214,7 @@ static int php_date_period_initialize_from_hash(php_period_obj *period_obj, Hash
 	return 1;
 } /* }}} */
 
-/* {{{ proto DatePeriod::__set_state(array $array)
+/* {{{ proto DatePeriod::__set_state(array array)
 */
 PHP_METHOD(DatePeriod, __set_state)
 {

--- a/ext/date/tests/DateTime_verify.phpt
+++ b/ext/date/tests/DateTime_verify.phpt
@@ -10,12 +10,17 @@ $class = new ReflectionClass('DateTime');
 var_dump($class);
 
 echo "..and get names of all its methods\n";
-$methods = $class->getMethods(); 
+$methods = $class->getMethods();
 var_dump($methods);
 
-echo "..and get names of all its class constants\n"; 
+echo "..and get names of all its class constants\n";
 $constants = $class->getConstants();
 var_dump($constants);
+
+echo "..and get __set_state arguments\n";
+$method = new ReflectionMethod('DateTime', '__set_state');
+var_dump($method->getParameters());
+var_dump($method->getParameters()[0]->isOptional());
 
 ?>
 ===DONE===
@@ -191,4 +196,13 @@ array(13) {
   ["W3C"]=>
   string(13) "Y-m-d\TH:i:sP"
 }
+..and get __set_state arguments
+array(1) {
+  [0]=>
+  object(ReflectionParameter)#%d (1) {
+    ["name"]=>
+    string(5) "array"
+  }
+}
+bool(false)
 ===DONE===

--- a/ext/date/tests/ExtendDateTime.phpt
+++ b/ext/date/tests/ExtendDateTime.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Extendig DatTime and calling __set_state without args
+--CREDITS--
+Gabriel Caruso (carusogabriel34@gmail.com)
+--FILE--
+<?php
+class MyDateTime extends DateTime {
+    public static function __set_state() {}
+}
+?>
+--EXPECTF--
+Warning: Declaration of MyDateTime::__set_state() should be compatible with DateTime::__set_state($array) in %s on line %d


### PR DESCRIPTION
Recently I tried to Reflect the `DateTime::__set_state` parameters, and I got an empty array: https://3v4l.org/LVhgJ

This PR fixes the correct `arginfo` for the `__set_state` method, which receives a mandatory `$array`.

`__set_state` magic method documentation: http://php.net/manual/en/language.oop5.magic.php#language.oop5.magic.set-state
`DateTime::__set_state` method documentation: http://php.net/manual/en/datetime.set-state.php