### PR TITLE
fixed pcntl_wexitstatus and similar functions  on  big_endian platforms (s390x)

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -775,7 +775,7 @@ PHP_FUNCTION(pcntl_wifexited)
 	       return;
 	}
 
-	if (WIFEXITED(status_word))
+	if (WIFEXITED((int)status_word))
 		RETURN_TRUE;
 #endif
 	RETURN_FALSE;
@@ -793,7 +793,7 @@ PHP_FUNCTION(pcntl_wifstopped)
 	       return;
 	}
 
-	if (WIFSTOPPED(status_word))
+	if (WIFSTOPPED((int)status_word))
 		RETURN_TRUE;
 #endif
 	RETURN_FALSE;
@@ -811,7 +811,7 @@ PHP_FUNCTION(pcntl_wifsignaled)
 	       return;
 	}
 
-	if (WIFSIGNALED(status_word))
+	if (WIFSIGNALED((int)status_word))
 		RETURN_TRUE;
 #endif
 	RETURN_FALSE;
@@ -828,7 +828,7 @@ PHP_FUNCTION(pcntl_wifcontinued)
 	       return;
 	}
 
-	if (WIFCONTINUED(status_word))
+	if (WIFCONTINUED((int)status_word))
 		RETURN_TRUE;
 #endif
 	RETURN_FALSE;
@@ -846,8 +846,7 @@ PHP_FUNCTION(pcntl_wexitstatus)
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &status_word) == FAILURE) {
 	       return;
 	}
-
-	RETURN_LONG(WEXITSTATUS(status_word));
+	RETURN_LONG(WEXITSTATUS((int)status_word));
 #else
 	RETURN_FALSE;
 #endif
@@ -865,7 +864,7 @@ PHP_FUNCTION(pcntl_wtermsig)
 	       return;
 	}
 
-	RETURN_LONG(WTERMSIG(status_word));
+	RETURN_LONG(WTERMSIG((int)status_word));
 #else
 	RETURN_FALSE;
 #endif
@@ -883,7 +882,7 @@ PHP_FUNCTION(pcntl_wstopsig)
 	       return;
 	}
 
-	RETURN_LONG(WSTOPSIG(status_word));
+	RETURN_LONG(WSTOPSIG((int)status_word));
 #else
 	RETURN_FALSE;
 #endif


### PR DESCRIPTION
Fixed [75873](https://bugs.php.net/bug.php?id=75873)

code `pcntl_wexitstatus` of `ext/pcntl/pcntl.c` :

    841 PHP_FUNCTION(pcntl_wexitstatus)
    842 {
    843 #ifdef WEXITSTATUS
    844         zend_long status_word;
    845
    846         if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &status_word) == FAILURE) {
    847                return;
    848         }
    849         RETURN_LONG(WEXITSTATUS(status_word));
    850 #else
    851         RETURN_FALSE;
    852 #endif

Here `status_word` is long, but `WEXITSTATUS` needs the input as` int`. (see https://www.gnu.org/software/libc/manual/html_node/Process-Completion-Status.html)
This works on Little_Endian, but causes the problem on Big_Endian platform (s390x).

Solution:
Cast `status_word` to `int` before  macro `WEXITSTATUS`:

    849         RETURN_LONG(WEXITSTATUS((int)status_word));

Similarly following function need to change:

     pcntl_wifexited
     pcntl_wifstopped
     pcntl_wifsignaled
     pcntl_wifcontinued
     pcntl_wexitstatus
     pcntl_wtermsig
     pcntl_wstopsig