### PR TITLE
Use %d when expecting line number in tests

### DIFF
--- a/Zend/tests/generators/errors/serialize_unserialize_error.phpt
+++ b/Zend/tests/generators/errors/serialize_unserialize_error.phpt
@@ -35,7 +35,7 @@ Stack trace:
 
 Warning: Erroneous data format for unserializing 'Generator' in %sserialize_unserialize_error.php on line %d
 
-Notice: unserialize(): Error at offset 19 of 20 bytes in %sserialize_unserialize_error.php on line %s
+Notice: unserialize(): Error at offset 19 of 20 bytes in %sserialize_unserialize_error.php on line %d
 bool(false)
 Exception: Unserialization of 'Generator' is not allowed in %s:%d
 Stack trace:

--- a/Zend/tests/return_types/014.phpt
+++ b/Zend/tests/return_types/014.phpt
@@ -9,4 +9,4 @@ class Foo {
 }
 
 --EXPECTF--
-Fatal error: Constructor %s::%s() cannot declare a return type in %s on line %s
+Fatal error: Constructor %s::%s() cannot declare a return type in %s on line %d

--- a/Zend/tests/return_types/018.phpt
+++ b/Zend/tests/return_types/018.phpt
@@ -9,4 +9,4 @@ class Foo {
 }
 
 --EXPECTF--
-Fatal error: Destructor %s::%s() cannot declare a return type in %s on line %s
+Fatal error: Destructor %s::%s() cannot declare a return type in %s on line %d

--- a/Zend/tests/return_types/019.phpt
+++ b/Zend/tests/return_types/019.phpt
@@ -9,4 +9,4 @@ class Foo {
 }
 
 --EXPECTF--
-Fatal error: %s::%s() cannot declare a return type in %s on line %s
+Fatal error: %s::%s() cannot declare a return type in %s on line %d

--- a/Zend/tests/return_types/023.phpt
+++ b/Zend/tests/return_types/023.phpt
@@ -11,4 +11,4 @@ class Foo {
 --EXPECTF--
 Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; Foo has a deprecated constructor in %s on line %d
 
-Fatal error: Constructor %s::%s() cannot declare a return type in %s on line %s
+Fatal error: Constructor %s::%s() cannot declare a return type in %s on line %d

--- a/ext/pcre/tests/bug74183.phpt
+++ b/ext/pcre/tests/bug74183.phpt
@@ -10,6 +10,6 @@ var_dump(preg_match($sRegex, $sTest));
 var_dump(preg_last_error() === \PREG_INTERNAL_ERROR);
 ?>
 --EXPECTF--
-Warning: preg_match(): Compilation failed: regular expression is too large at offset %s in %s on line %s
+Warning: preg_match(): Compilation failed: regular expression is too large at offset %s in %s on line %d
 bool(false)
 bool(true)

--- a/ext/pcre/tests/bug75539.phpt
+++ b/ext/pcre/tests/bug75539.phpt
@@ -8,6 +8,6 @@ var_dump(preg_last_error() === \PREG_INTERNAL_ERROR);
 
 ?>
 --EXPECTF--
-Warning: preg_match(): Compilation failed: recursive call could loop indefinitely at offset %s in %s on line %s
+Warning: preg_match(): Compilation failed: recursive call could loop indefinitely at offset %s in %s on line %d
 bool(false)
 bool(true)

--- a/ext/posix/tests/posix_ttyname_error_wrongparams.phpt
+++ b/ext/posix/tests/posix_ttyname_error_wrongparams.phpt
@@ -30,7 +30,7 @@ Warning: posix_ttyname() expects exactly 1 parameter, 0 given in %s on line %d
 bool(false)
 bool(false)
 
-Warning: posix_ttyname(): supplied resource is not a valid stream resource in %s on line %s
+Warning: posix_ttyname(): supplied resource is not a valid stream resource in %s on line %d
 
 Warning: posix_ttyname(): expects argument 1 to be a valid stream resource in %s on line %d
 bool(false)

--- a/ext/session/tests/session_set_save_handler_variation4.phpt
+++ b/ext/session/tests/session_set_save_handler_variation4.phpt
@@ -81,7 +81,7 @@ array(3) {
 }
 Destroy [%s,%s]
 
-Warning: unlink(%s): No such file or directory in %s on line %s
+Warning: unlink(%s): No such file or directory in %s on line %d
 Close [%s,PHPSESSID]
 bool(true)
 

--- a/ext/snmp/tests/snmp2_set.phpt
+++ b/ext/snmp/tests/snmp2_set.phpt
@@ -188,25 +188,25 @@ bool(true)
 More error handing
 Single OID, single type in array, single value
 
-Warning: snmp2_set(): Single objid and multiple type or values are not supported in %s on line %s
+Warning: snmp2_set(): Single objid and multiple type or values are not supported in %s on line %d
 bool(false)
 bool(true)
 bool(true)
 Single OID, single type, single value in array
 
-Warning: snmp2_set(): Single objid and multiple type or values are not supported in %s on line %s
+Warning: snmp2_set(): Single objid and multiple type or values are not supported in %s on line %d
 bool(false)
 bool(true)
 bool(true)
 Multiple OID, 1st wrong type
 
-Warning: snmp2_set(): '%s': bogus type 'sw', should be single char, got 2 in %s on line %s
+Warning: snmp2_set(): '%s': bogus type 'sw', should be single char, got 2 in %s on line %d
 bool(false)
 bool(true)
 bool(true)
 Multiple OID, 2nd wrong type
 
-Warning: snmp2_set(): '%s': bogus type 'sb', should be single char, got 2 in %s on line %s
+Warning: snmp2_set(): '%s': bogus type 'sb', should be single char, got 2 in %s on line %d
 bool(false)
 bool(true)
 bool(true)

--- a/ext/snmp/tests/snmpset.phpt
+++ b/ext/snmp/tests/snmpset.phpt
@@ -188,25 +188,25 @@ bool(true)
 More error handing
 Single OID, single type in array, single value
 
-Warning: snmpset(): Single objid and multiple type or values are not supported in %s on line %s
+Warning: snmpset(): Single objid and multiple type or values are not supported in %s on line %d
 bool(false)
 bool(true)
 bool(true)
 Single OID, single type, single value in array
 
-Warning: snmpset(): Single objid and multiple type or values are not supported in %s on line %s
+Warning: snmpset(): Single objid and multiple type or values are not supported in %s on line %d
 bool(false)
 bool(true)
 bool(true)
 Multiple OID, 1st wrong type
 
-Warning: snmpset(): '%s': bogus type 'sw', should be single char, got 2 in %s on line %s
+Warning: snmpset(): '%s': bogus type 'sw', should be single char, got 2 in %s on line %d
 bool(false)
 bool(true)
 bool(true)
 Multiple OID, 2nd wrong type
 
-Warning: snmpset(): '%s': bogus type 'sb', should be single char, got 2 in %s on line %s
+Warning: snmpset(): '%s': bogus type 'sb', should be single char, got 2 in %s on line %d
 bool(false)
 bool(true)
 bool(true)

--- a/ext/sockets/tests/socket_bind_params.phpt
+++ b/ext/sockets/tests/socket_bind_params.phpt
@@ -22,8 +22,8 @@ fa@php.net
 ?>
 --EXPECTF--
 
-Warning: socket_bind() expects at least 2 parameters, 0 given in %s on line %i
+Warning: socket_bind() expects at least 2 parameters, 0 given in %s on line %d
 NULL
 
-Warning: socket_bind() expects at least 2 parameters, 1 given in %s on line %i
+Warning: socket_bind() expects at least 2 parameters, 1 given in %s on line %d
 NULL

--- a/ext/sockets/tests/socket_close_params.phpt
+++ b/ext/sockets/tests/socket_close_params.phpt
@@ -17,5 +17,5 @@ fa@php.net
 ?>
 --EXPECTF--
 
-Warning: socket_close() expects exactly 1 parameter, 0 given in %s on line %i
+Warning: socket_close() expects exactly 1 parameter, 0 given in %s on line %d
 NULL

--- a/ext/sockets/tests/socket_connect_params.phpt
+++ b/ext/sockets/tests/socket_connect_params.phpt
@@ -24,10 +24,10 @@ fa@php.net
 ?>
 --EXPECTF--
 
-Warning: socket_connect() expects at least 2 parameters, 0 given in %s on line %i
+Warning: socket_connect() expects at least 2 parameters, 0 given in %s on line %d
 
-Warning: socket_connect() expects at least 2 parameters, 1 given in %s on line %i
+Warning: socket_connect() expects at least 2 parameters, 1 given in %s on line %d
 
-Warning: socket_connect(): Socket of type AF_INET requires 3 arguments in %s on line %i
+Warning: socket_connect(): Socket of type AF_INET requires 3 arguments in %s on line %d
 
-Warning: socket_connect(): unable to connect [%i]: %a in %s on line %i
+Warning: socket_connect(): unable to connect [%i]: %a in %s on line %d

--- a/ext/sockets/tests/socket_create_listen_params.phpt
+++ b/ext/sockets/tests/socket_create_listen_params.phpt
@@ -19,5 +19,5 @@ fa@php.net
     }
 ?>
 --EXPECTF--
-Warning: socket_create_listen() expects at least 1 parameter, 0 given in %s on line %i
+Warning: socket_create_listen() expects at least 1 parameter, 0 given in %s on line %d
 NULL

--- a/ext/sockets/tests/socket_create_listen_used.phpt
+++ b/ext/sockets/tests/socket_create_listen_used.phpt
@@ -24,7 +24,7 @@ fa@php.net
 --EXPECTF--
 resource(%i) of type (Socket)
 
-Warning: socket_create_listen(): unable to bind to given address [%i]: %a in %s on line %i
+Warning: socket_create_listen(): unable to bind to given address [%i]: %a in %s on line %d
 bool(false)
 
-Warning: socket_close() expects parameter 1 to be resource, boolean given in %s on line %i
+Warning: socket_close() expects parameter 1 to be resource, boolean given in %s on line %d

--- a/ext/sockets/tests/socket_create_params.phpt
+++ b/ext/sockets/tests/socket_create_params.phpt
@@ -17,8 +17,8 @@ fa@php.net
 ?>
 --EXPECTF--
 
-Warning: socket_create() expects exactly 3 parameters, 0 given in %s on line %i
+Warning: socket_create() expects exactly 3 parameters, 0 given in %s on line %d
 
-Warning: socket_create() expects exactly 3 parameters, 1 given in %s on line %i
+Warning: socket_create() expects exactly 3 parameters, 1 given in %s on line %d
 
-Warning: socket_create() expects exactly 3 parameters, 2 given in %s on line %i
+Warning: socket_create() expects exactly 3 parameters, 2 given in %s on line %d

--- a/ext/sockets/tests/socket_getpeername.phpt
+++ b/ext/sockets/tests/socket_getpeername.phpt
@@ -27,7 +27,7 @@ fa@php.net
 --EXPECTF--
 bool(true)
 
-Warning: socket_getpeername(): unable to retrieve peer name [%i]: %a in %s on line %i
+Warning: socket_getpeername(): unable to retrieve peer name [%i]: %a in %s on line %d
 bool(false)
 NULL
 NULL

--- a/ext/sockets/tests/socket_listen_params.phpt
+++ b/ext/sockets/tests/socket_listen_params.phpt
@@ -17,5 +17,5 @@ fa@php.net
 ?>
 --EXPECTF--
 
-Warning: socket_listen() expects at least 1 parameter, 0 given in %s on line %i
+Warning: socket_listen() expects at least 1 parameter, 0 given in %s on line %d
 NULL

--- a/ext/sockets/tests/socket_read_params.phpt
+++ b/ext/sockets/tests/socket_read_params.phpt
@@ -21,8 +21,8 @@ fa@php.net
 ?>
 --EXPECTF--
 
-Warning: socket_read() expects at least 2 parameters, 0 given in %s on line %i
+Warning: socket_read() expects at least 2 parameters, 0 given in %s on line %d
 
-Warning: socket_read() expects at least 2 parameters, 1 given in %s on line %i
+Warning: socket_read() expects at least 2 parameters, 1 given in %s on line %d
 
-Warning: socket_read(): unable to read from socket [%i]: %a in %s on line %i
+Warning: socket_read(): unable to read from socket [%i]: %a in %s on line %d

--- a/ext/sockets/tests/socket_strerror.phpt
+++ b/ext/sockets/tests/socket_strerror.phpt
@@ -21,7 +21,7 @@ fa@php.net
 ?>
 --EXPECTF--
 
-Warning: socket_strerror() expects exactly 1 parameter, 0 given in %s on line %i
+Warning: socket_strerror() expects exactly 1 parameter, 0 given in %s on line %d
 string(7) "Success"
 string(23) "Operation not permitted"
 string(25) "No such file or directory"

--- a/ext/sockets/tests/socket_write_params.phpt
+++ b/ext/sockets/tests/socket_write_params.phpt
@@ -21,8 +21,8 @@ fa@php.net
 ?>
 --EXPECTF--
 
-Warning: socket_write() expects at least 2 parameters, 0 given in %s on line %i
+Warning: socket_write() expects at least 2 parameters, 0 given in %s on line %d
 
-Warning: socket_write() expects at least 2 parameters, 1 given in %s on line %i
+Warning: socket_write() expects at least 2 parameters, 1 given in %s on line %d
 
-Warning: socket_write(): unable to write to socket [%i]: %a in %s on line %i
+Warning: socket_write(): unable to write to socket [%i]: %a in %s on line %d

--- a/ext/spl/tests/bug74669.phpt
+++ b/ext/spl/tests/bug74669.phpt
@@ -98,7 +98,7 @@ var_dump($selfArray['foo']);
 0 => test1
 1 => test2
 
-Notice: Undefined index: foo in %s on line %s
+Notice: Undefined index: foo in %s on line %d
 NULL
 object(SelfArray)#9 (1) {
   ["foo"]=>

--- a/ext/standard/tests/array/array_count_values2.phpt
+++ b/ext/standard/tests/array/array_count_values2.phpt
@@ -18,11 +18,11 @@ $array1 = array(1,
 var_dump(array_count_values($array1));
 ?>
 --EXPECTF--
-Warning: array_count_values(): Can only count STRING and INTEGER values! in %s on line %s
+Warning: array_count_values(): Can only count STRING and INTEGER values! in %s on line %d
 
-Warning: array_count_values(): Can only count STRING and INTEGER values! in %s on line %s
+Warning: array_count_values(): Can only count STRING and INTEGER values! in %s on line %d
 
-Warning: array_count_values(): Can only count STRING and INTEGER values! in %s on line %s
+Warning: array_count_values(): Can only count STRING and INTEGER values! in %s on line %d
 array(8) {
   [1]=>
   int(2)

--- a/ext/standard/tests/file/007_variation15.phpt
+++ b/ext/standard/tests/file/007_variation15.phpt
@@ -54,5 +54,5 @@ int(0)
 bool(true)
 %unicode|string%(7) "Unknown"
 
-Warning: fopen(%s): failed to open stream: File exists in %s on line %s
+Warning: fopen(%s): failed to open stream: File exists in %s on line %d
 *** Done ***

--- a/ext/standard/tests/file/007_variation23.phpt
+++ b/ext/standard/tests/file/007_variation23.phpt
@@ -54,5 +54,5 @@ int(0)
 bool(true)
 %unicode|string%(7) "Unknown"
 
-Warning: fopen(%s): failed to open stream: File exists in %s on line %s
+Warning: fopen(%s): failed to open stream: File exists in %s on line %d
 *** Done ***

--- a/ext/standard/tests/file/007_variation7.phpt
+++ b/ext/standard/tests/file/007_variation7.phpt
@@ -54,5 +54,5 @@ int(0)
 bool(true)
 %unicode|string%(7) "Unknown"
 
-Warning: fopen(%s): failed to open stream: File exists in %s on line %s
+Warning: fopen(%s): failed to open stream: File exists in %s on line %d
 *** Done ***

--- a/ext/standard/tests/file/copy_variation16-win32.phpt
+++ b/ext/standard/tests/file/copy_variation16-win32.phpt
@@ -131,7 +131,7 @@ Size of destination file => int(3500)
 -- Iteration 7 --
 Size of source file => int(3500)
 Copy operation => 
-Warning: copy(%s): failed to open stream: No such file or directory in %s on line %s
+Warning: copy(%s): failed to open stream: No such file or directory in %s on line %d
 bool(false)
 Existence of destination file => bool(false)
 

--- a/ext/standard/tests/math/base_convert_error.phpt
+++ b/ext/standard/tests/math/base_convert_error.phpt
@@ -37,7 +37,7 @@ Warning: base_convert() expects exactly 3 parameters, 2 given in %s on line %d
 
 Warning: base_convert(): Invalid `from base' (1) in %s on line %d
 
-Warning: base_convert(): Invalid `to base' (37) in %s on line %s
+Warning: base_convert(): Invalid `to base' (37) in %s on line %d
 Incorrect input
 
 Recoverable fatal error: Object of class classA could not be converted to string in %s on line %d

--- a/ext/standard/tests/streams/bug44712.phpt
+++ b/ext/standard/tests/streams/bug44712.phpt
@@ -6,5 +6,5 @@ $ctx = stream_context_get_default();
 stream_context_set_params($ctx, array("options" => 1));
 ?>
 --EXPECTF--
-Warning: stream_context_set_params(): Invalid stream/context parameter in %sbug44712.php on line %s
+Warning: stream_context_set_params(): Invalid stream/context parameter in %sbug44712.php on line %d
 

--- a/ext/standard/tests/streams/stream_get_meta_data_file_error.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_file_error.phpt
@@ -37,21 +37,21 @@ echo "Done";
 
 -- Testing stream_get_meta_data() function with Zero arguments --
 
-Warning: stream_get_meta_data() expects exactly 1 parameter, 0 given in %s on line %i
+Warning: stream_get_meta_data() expects exactly 1 parameter, 0 given in %s on line %d
 NULL
 
 -- Testing stream_get_meta_data() function with more than expected no. of arguments --
 
-Warning: stream_get_meta_data() expects exactly 1 parameter, 2 given in %s on line %i
+Warning: stream_get_meta_data() expects exactly 1 parameter, 2 given in %s on line %d
 NULL
 
 -- Testing stream_get_meta_data() function with invalid stream resource --
 
-Warning: stream_get_meta_data() expects parameter 1 to be resource, null given in %s on line %i
+Warning: stream_get_meta_data() expects parameter 1 to be resource, null given in %s on line %d
 NULL
 
 -- Testing stream_get_meta_data() function with closed stream resource --
 
-Warning: stream_get_meta_data(): supplied resource is not a valid stream resource in %s on line %i
+Warning: stream_get_meta_data(): supplied resource is not a valid stream resource in %s on line %d
 bool(false)
 Done

--- a/ext/standard/tests/streams/stream_set_timeout_error.phpt
+++ b/ext/standard/tests/streams/stream_set_timeout_error.phpt
@@ -57,22 +57,22 @@ echo "Done";
 
 -- Testing stream_set_timeout() function with more than expected no. of arguments --
 
-Warning: stream_set_timeout() expects at most 3 parameters, 4 given in %s on line %i
+Warning: stream_set_timeout() expects at most 3 parameters, 4 given in %s on line %d
 NULL
 
 -- Testing stream_set_timeout() function with less than expected no. of arguments --
 
-Warning: stream_set_timeout() expects at least 2 parameters, 1 given in %s on line %i
+Warning: stream_set_timeout() expects at least 2 parameters, 1 given in %s on line %d
 NULL
 
 -- Testing stream_set_timeout() function with a closed socket --
 
-Warning: stream_set_timeout(): supplied resource is not a valid stream resource in %s on line %i
+Warning: stream_set_timeout(): supplied resource is not a valid stream resource in %s on line %d
 bool(false)
 
 -- Testing stream_set_timeout() function with an invalid stream --
 
-Warning: stream_set_timeout() expects parameter 1 to be resource, integer given in %s on line %i
+Warning: stream_set_timeout() expects parameter 1 to be resource, integer given in %s on line %d
 NULL
 
 -- Testing stream_set_timeout() function with a stream that does not support timeouts --

--- a/ext/standard/tests/streams/stream_socket_sendto.phpt
+++ b/ext/standard/tests/streams/stream_socket_sendto.phpt
@@ -27,32 +27,32 @@ if (is_resource($sock)) {
 }
 ?>
 --EXPECTF--
-Notice: fwrite(): send of %i bytes failed with errno=%i Broken pipe in %s on line %i
+Notice: fwrite(): send of %i bytes failed with errno=%i Broken pipe in %s on line %d
 
-Warning: stream_socket_sendto() expects at least %i parameters, %i given in %s on line %i
+Warning: stream_socket_sendto() expects at least %i parameters, %i given in %s on line %d
 bool(%s)
 
-Warning: stream_socket_sendto() expects at least %i parameters, %i given in %s on line %i
+Warning: stream_socket_sendto() expects at least %i parameters, %i given in %s on line %d
 bool(%s)
 
 Warning: stream_socket_sendto(): Broken pipe
- in %s on line %i
+ in %s on line %d
 int(%i)
 
 Warning: stream_socket_sendto(): Broken pipe
- in %s on line %i
+ in %s on line %d
 int(%i)
 
-Warning: stream_socket_sendto(): php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %i
+Warning: stream_socket_sendto(): php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %d
 
-Warning: stream_socket_sendto(): Failed to resolve %s: php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %i
+Warning: stream_socket_sendto(): Failed to resolve %s: php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %d
 
-Warning: stream_socket_sendto(): Failed to parse %s into a valid network address in %s on line %i
+Warning: stream_socket_sendto(): Failed to parse %s into a valid network address in %s on line %d
 bool(%s)
 
-Warning: stream_socket_sendto(): php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %i
+Warning: stream_socket_sendto(): php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %d
 
-Warning: stream_socket_sendto(): Failed to resolve %s: php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %i
+Warning: stream_socket_sendto(): Failed to resolve %s: php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %d
 
-Warning: stream_socket_sendto(): Failed to parse %s into a valid network address in %s on line %i
+Warning: stream_socket_sendto(): Failed to parse %s into a valid network address in %s on line %d
 bool(%s)

--- a/ext/standard/tests/strings/get_html_translation_table_variation2.phpt
+++ b/ext/standard/tests/strings/get_html_translation_table_variation2.phpt
@@ -88,23 +88,23 @@ echo "Done\n";
 --- Testing get_html_translation_table() by supplying different values for 'quote_style' argument ---
 -- Iteration 1 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %d
 NULL
 -- Iteration 2 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %d
 NULL
 -- Iteration 3 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %d
 NULL
 -- Iteration 4 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %d
 NULL
 -- Iteration 5 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, array given in %s on line %d
 NULL
 -- Iteration 6 --
 array(4) {
@@ -148,23 +148,23 @@ array(3) {
 }
 -- Iteration 10 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, string given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, string given in %s on line %d
 NULL
 -- Iteration 11 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, string given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, string given in %s on line %d
 NULL
 -- Iteration 12 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, object given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, object given in %s on line %d
 NULL
 -- Iteration 13 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, string given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, string given in %s on line %d
 NULL
 -- Iteration 14 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, string given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, string given in %s on line %d
 NULL
 -- Iteration 15 --
 array(3) {
@@ -186,7 +186,7 @@ array(3) {
 }
 -- Iteration 17 --
 
-Warning: get_html_translation_table() expects parameter 2 to be integer, resource given in %s on line %s
+Warning: get_html_translation_table() expects parameter 2 to be integer, resource given in %s on line %d
 NULL
 -- Iteration 18 --
 array(3) {

--- a/ext/xsl/tests/bug54446.phpt
+++ b/ext/xsl/tests/bug54446.phpt
@@ -74,7 +74,7 @@ if (file_exists($outputfile)) {
 --EXPECTF--
 Warning: XSLTProcessor::transformToXml(): runtime error: file %s line %s element output in %s on line %d
 
-Warning: XSLTProcessor::transformToXml(): File write for %s/bug54446test.txt refused in %s on line %s
+Warning: XSLTProcessor::transformToXml(): File write for %s/bug54446test.txt refused in %s on line %d
 
 Warning: XSLTProcessor::transformToXml(): runtime error: file %s line %d element output in %s on line %d
 
@@ -84,7 +84,7 @@ OK, file exists
 
 Warning: XSLTProcessor::transformToXml(): runtime error: file %s line %s element output in %s on line %d
 
-Warning: XSLTProcessor::transformToXml(): File write for %s/bug54446test.txt refused in %s on line %s
+Warning: XSLTProcessor::transformToXml(): File write for %s/bug54446test.txt refused in %s on line %d
 
 Warning: XSLTProcessor::transformToXml(): runtime error: file %s line %d element output in %s on line %d
 

--- a/ext/xsl/tests/bug54446_with_ini.phpt
+++ b/ext/xsl/tests/bug54446_with_ini.phpt
@@ -74,7 +74,7 @@ if (file_exists($outputfile)) {
 --EXPECTF--
 Warning: XSLTProcessor::transformToXml(): runtime error: file %s line %s element output in %s on line %d
 
-Warning: XSLTProcessor::transformToXml(): File write for %s/bug54446test.txt refused in %s on line %s
+Warning: XSLTProcessor::transformToXml(): File write for %s/bug54446test.txt refused in %s on line %d
 
 Warning: XSLTProcessor::transformToXml(): runtime error: file %s line %d element output in %s on line %d
 
@@ -84,7 +84,7 @@ OK, file exists
 
 Warning: XSLTProcessor::transformToXml(): runtime error: file %s line %s element output in %s on line %d
 
-Warning: XSLTProcessor::transformToXml(): File write for %s/bug54446test.txt refused in %s on line %s
+Warning: XSLTProcessor::transformToXml(): File write for %s/bug54446test.txt refused in %s on line %d
 
 Warning: XSLTProcessor::transformToXml(): runtime error: file %s line %d element output in %s on line %d
 

--- a/ext/xsl/tests/xsltprocessor_hasExsltSupport_not_available_extension.phpt
+++ b/ext/xsl/tests/xsltprocessor_hasExsltSupport_not_available_extension.phpt
@@ -10,4 +10,4 @@ $proc = new XSLTProcessor();
 var_dump($proc->hasExsltSupport());
 ?>
 --EXPECTF--
-Fatal error: Class 'XSLTProcessor' not found in %s on line %i
+Fatal error: Class 'XSLTProcessor' not found in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToDoc_nullparam.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToDoc_nullparam.phpt
@@ -51,4 +51,4 @@ $proc->importStyleSheet($xsldoc);
 echo $proc->transformToDoc(null);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToDoc() expects parameter 1 to be object, null given in %s on line %i
+Warning: XSLTProcessor::transformToDoc() expects parameter 1 to be object, null given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToDoc_wrongparam_001.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToDoc_wrongparam_001.phpt
@@ -53,4 +53,4 @@ $wrong_parameter = array();
 echo $proc->transformToDoc($wrong_parameter);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToDoc() expects parameter 1 to be object, array given in %s on line %i
+Warning: XSLTProcessor::transformToDoc() expects parameter 1 to be object, array given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToDoc_wrongparam_002.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToDoc_wrongparam_002.phpt
@@ -51,4 +51,4 @@ $proc->importStyleSheet($xsldoc);
 echo $proc->transformToDoc($xmldoc, 'string', 98, true);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToDoc() expects at most 2 parameters, 4 given in %s on line %i
+Warning: XSLTProcessor::transformToDoc() expects at most 2 parameters, 4 given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToDoc_wrongparam_003.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToDoc_wrongparam_003.phpt
@@ -53,4 +53,4 @@ $wrong_parameter = 'stringValue';
 echo $proc->transformToDoc($wrong_parameter);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToDoc() expects parameter 1 to be object, string given in %s on line %i
+Warning: XSLTProcessor::transformToDoc() expects parameter 1 to be object, string given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToDoc_wrongparam_004.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToDoc_wrongparam_004.phpt
@@ -53,4 +53,4 @@ $wrong_parameter = true;
 echo $proc->transformToDoc($wrong_parameter);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToDoc() expects parameter 1 to be object, boolean given in %s on line %i
+Warning: XSLTProcessor::transformToDoc() expects parameter 1 to be object, boolean given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToURI_nullparam.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToURI_nullparam.phpt
@@ -51,4 +51,4 @@ $proc->importStyleSheet($xsldoc);
 echo $proc->transformToURI(null, null);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToUri() expects parameter 1 to be object, null given in %s on line %i
+Warning: XSLTProcessor::transformToUri() expects parameter 1 to be object, null given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToURI_wrongparam_001.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToURI_wrongparam_001.phpt
@@ -54,4 +54,4 @@ $uri = 'php://output';
 echo $proc->transformToURI($wrong_parameter, $uri);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToUri() expects parameter 1 to be object, array given in %s on line %i
+Warning: XSLTProcessor::transformToUri() expects parameter 1 to be object, array given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToURI_wrongparam_002.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToURI_wrongparam_002.phpt
@@ -54,4 +54,4 @@ $uri = 'php://output';
 echo $proc->transformToURI($wrong_parameter, $uri);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToUri() expects parameter 1 to be object, string given in %s on line %i
+Warning: XSLTProcessor::transformToUri() expects parameter 1 to be object, string given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToURI_wrongparam_003.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToURI_wrongparam_003.phpt
@@ -54,4 +54,4 @@ $uri = 'php://output';
 echo $proc->transformToURI($wrong_parameter, $uri);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToUri() expects parameter 1 to be object, boolean given in %s on line %i
+Warning: XSLTProcessor::transformToUri() expects parameter 1 to be object, boolean given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToURI_wrongparam_004.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToURI_wrongparam_004.phpt
@@ -53,4 +53,4 @@ $uri = 'php://output';
 echo $proc->transformToURI($xsldoc, $uri, 'stringValue');
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToUri() expects exactly 2 parameters, 3 given in %s on line %i
+Warning: XSLTProcessor::transformToUri() expects exactly 2 parameters, 3 given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToXML_nullparam.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToXML_nullparam.phpt
@@ -51,4 +51,4 @@ $proc->importStyleSheet($xsldoc);
 echo $proc->transformToXML(null);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToXml() expects parameter 1 to be object, null given in %s on line %i
+Warning: XSLTProcessor::transformToXml() expects parameter 1 to be object, null given in %s on line %d

--- a/ext/xsl/tests/xsltprocessor_transformToXML_wrongparam_002.phpt
+++ b/ext/xsl/tests/xsltprocessor_transformToXML_wrongparam_002.phpt
@@ -51,4 +51,4 @@ $proc->importStyleSheet($xsldoc);
 echo $proc->transformToXML($xmldoc, 'string', 98);
 ?>
 --EXPECTF--
-Warning: XSLTProcessor::transformToXml() expects exactly 1 parameter, 3 given in %s on line %i
+Warning: XSLTProcessor::transformToXml() expects exactly 1 parameter, 3 given in %s on line %d


### PR DESCRIPTION
I targeted `PHP-7.1` as this is a "bug-fix". For somehow someone submits a patch with line numbers now returns a string instead of int, this tests wouldn't catch that.