### PR TITLE
set max_requests to 0

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1583,7 +1583,7 @@ int main(int argc, char *argv[])
 	void ***tsrm_ls;
 #endif
 
-	int max_requests = 500;
+	int max_requests = 0;
 	int requests = 0;
 	int fcgi_fd = 0;
 	fcgi_request *request;


### PR DESCRIPTION
From [here](http://php.net/manual/en/install.fpm.configuration.php#pm.max-requests) we know that the default value of `pm.max_requests` should be 0, which means endless request. Despite [fpm_run()](https://github.com/php/php-src/blob/6053987bc27e8dede37f437193a5cad448f99bce/sapi/fpm/fpm/fpm.c#L121) sets its value from configuration or default value 0 at [L1895](https://github.com/php/php-src/blob/a7fe2570d3ce6915d4ea85c62c0f880ddc225ba7/sapi/fpm/fpm/fpm_main.c#L1895) . The initial value 500 is still confusing.