### PR TITLE
Use int instead of integer in proto

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -434,7 +434,7 @@ PHP_FUNCTION(hash_update)
 }
 /* }}} */
 
-/* {{{ proto int hash_update_stream(HashContext context, resource handle[, integer length])
+/* {{{ proto int hash_update_stream(HashContext context, resource handle[, int length])
 Pump data into the hashing algorithm from an open stream */
 PHP_FUNCTION(hash_update_stream)
 {

--- a/ext/intl/dateformat/dateformat_parse.c
+++ b/ext/intl/dateformat/dateformat_parse.c
@@ -121,9 +121,9 @@ static void internal_parse_to_localtime(IntlDateFormatter_object *dfo, char* tex
 /* }}} */
 
 
-/* {{{ proto integer IntlDateFormatter::parse( string $text_to_parse  [, int $parse_pos] )
+/* {{{ proto int IntlDateFormatter::parse( string $text_to_parse  [, int $parse_pos] )
  * Parse the string $value starting at parse_pos to a Unix timestamp -int }}}*/
-/* {{{ proto integer datefmt_parse( IntlDateFormatter $fmt, string $text_to_parse [, int $parse_pos] )
+/* {{{ proto int datefmt_parse( IntlDateFormatter $fmt, string $text_to_parse [, int $parse_pos] )
  * Parse the string $value starting at parse_pos to a Unix timestamp -int }}}*/
 PHP_FUNCTION(datefmt_parse)
 {
@@ -166,9 +166,9 @@ PHP_FUNCTION(datefmt_parse)
 }
 /* }}} */
 
-/* {{{ proto integer IntlDateFormatter::localtime( string $text_to_parse[, int $parse_pos] )
+/* {{{ proto int IntlDateFormatter::localtime( string $text_to_parse[, int $parse_pos] )
  * Parse the string $value to a localtime array  }}}*/
-/* {{{ proto integer datefmt_localtime( IntlDateFormatter $fmt, string $text_to_parse[, int $parse_pos ])
+/* {{{ proto int datefmt_localtime( IntlDateFormatter $fmt, string $text_to_parse[, int $parse_pos ])
  * Parse the string $value to a localtime array  }}}*/
 PHP_FUNCTION(datefmt_localtime)
 {

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -248,8 +248,8 @@ ZEND_BEGIN_ARG_INFO_EX( arginfo_resourcebundle_get, 0, 0, 1 )
 ZEND_END_ARG_INFO()
 /* }}} */
 
-/* {{{ proto mixed ResourceBundle::get( integer|string $resindex [, bool $fallback = true ] )
- * proto mixed resourcebundle_get( ResourceBundle $rb, integer|string $resindex [, bool $fallback = true ] )
+/* {{{ proto mixed ResourceBundle::get( int|string $resindex [, bool $fallback = true ] )
+ * proto mixed resourcebundle_get( ResourceBundle $rb, int|string $resindex [, bool $fallback = true ] )
  * Get resource identified by numerical index or key name.
  */
 PHP_FUNCTION( resourcebundle_get )

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -6739,7 +6739,7 @@ PHP_FUNCTION(openssl_cipher_iv_length)
 /* }}} */
 
 
-/* {{{ proto string openssl_random_pseudo_bytes(integer length [, &bool returned_strong_result])
+/* {{{ proto string openssl_random_pseudo_bytes(int length [, &bool returned_strong_result])
    Returns a string of the length specified filled with random pseudo bytes */
 PHP_FUNCTION(openssl_random_pseudo_bytes)
 {
@@ -6807,4 +6807,3 @@ PHP_FUNCTION(openssl_random_pseudo_bytes)
  * vim600: sw=4 ts=4 fdm=marker
  * vim<600: sw=4 ts=4
  */
-

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -212,7 +212,7 @@ PHP_FUNCTION(password_get_info)
 }
 /** }}} */
 
-/* {{{ proto boolean password_needs_rehash(string $hash, integer $algo[, array $options])
+/* {{{ proto boolean password_needs_rehash(string $hash, int $algo[, array $options])
 Determines if a given hash requires re-hashing based upon parameters */
 PHP_FUNCTION(password_needs_rehash)
 {

--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -490,7 +490,7 @@ static php_stream *user_wrapper_opendir(php_stream_wrapper *wrapper, const char 
 }
 
 
-/* {{{ proto bool stream_wrapper_register(string protocol, string classname[, integer flags])
+/* {{{ proto bool stream_wrapper_register(string protocol, string classname[, int flags])
    Registers a custom URL protocol handler class */
 PHP_FUNCTION(stream_wrapper_register)
 {

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -370,7 +370,7 @@ static PHP_FUNCTION(phpdbg_break_next)
 	phpdbg_set_breakpoint_opline_ex((phpdbg_opline_ptr_t) ex->opline + 1);
 } /* }}} */
 
-/* {{{ proto void phpdbg_break_file(string file, integer line) */
+/* {{{ proto void phpdbg_break_file(string file, int line) */
 static PHP_FUNCTION(phpdbg_break_file)
 {
 	char *file;
@@ -425,7 +425,7 @@ static PHP_FUNCTION(phpdbg_clear)
 	zend_hash_clean(&PHPDBG_G(bp)[PHPDBG_BREAK_COND]);
 } /* }}} */
 
-/* {{{ proto void phpdbg_color(integer element, string color) */
+/* {{{ proto void phpdbg_color(int element, string color) */
 static PHP_FUNCTION(phpdbg_color)
 {
 	zend_long element;


### PR DESCRIPTION
These were the last cases of `integer` in prototypes.