### PR TITLE
Fixes bug 65414

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -3635,14 +3635,18 @@ PHP_METHOD(Phar, offsetGet)
  */
 static void phar_add_file(phar_archive_data **pphar, char *filename, int filename_len, char *cont_str, size_t cont_len, zval *zresource)
 {
+	int start_pos=0;
 	char *error;
 	size_t contents_len;
 	phar_entry_data *data;
 	php_stream *contents_file;
 
-	if (filename_len >= (int)sizeof(".phar")-1 && !memcmp(filename, ".phar", sizeof(".phar")-1) && (filename[5] == '/' || filename[5] == '\\' || filename[5] == '\0')) {
-		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot create any files in magic \".phar\" directory");
-		return;
+	if (filename_len >= (int)sizeof(".phar")-1) {
+		start_pos = ('/' == filename[0] ? 1 : 0); /* account for any leading slash: multiple-leads handled elsewhere */
+		if (!memcmp(&filename[start_pos], ".phar", sizeof(".phar")-1) && (filename[start_pos+5] == '/' || filename[start_pos+5] == '\\' || filename[start_pos+5] == '\0')) {
+			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot create any files in magic \".phar\" directory");
+			return;
+		}
 	}
 
 	if (!(data = phar_get_or_create_entry_data((*pphar)->fname, (*pphar)->fname_len, filename, filename_len, "w+b", 0, &error, 1))) {

--- a/ext/phar/tests/bug65414.phpt
+++ b/ext/phar/tests/bug65414.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Bug #65414 Injection (A1) in .phar files magic .phar directory
+--SKIPIF--
+<?php if (!extension_loaded("phar")) die("skip"); ?>
+--INI--
+phar.readonly = 0
+--FILE--
+<?php
+$phar = new \Phar(__DIR__ . '/bug65414.phar', 0, 'bug65414.phar');
+$bads = [
+    '.phar/injected-1.txt',
+    '/.phar/injected-2.txt',
+    '//.phar/injected-3.txt',
+    '/.phar/',
+];
+foreach ($bads as $bad) {
+    echo $bad . ':';
+    try {
+        $phar->addFromString($bad, 'this content is injected');
+        echo 'Failed to throw expected exception';
+    } catch (BadMethodCallException $ex) {
+        echo $ex->getMessage() . PHP_EOL;
+    }
+}
+echo 'done' . PHP_EOL;
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/bug65414.phar');
+?>
+--EXPECT--
+.phar/injected-1.txt:Cannot create any files in magic ".phar" directory
+/.phar/injected-2.txt:Cannot create any files in magic ".phar" directory
+//.phar/injected-3.txt:Entry //.phar/injected-3.txt does not exist and cannot be created: phar error: invalid path "//.phar/injected-3.txt" contains double slash
+/.phar/:Cannot create any files in magic ".phar" directory
+done


### PR DESCRIPTION
While the common method `phar_add_file` was protected from being given files with multiple leading `/`, it was not prepared to deal with files containing a leading slash when verifying file addition to the state
directory `.phar`. Adds a check for leading slash, and test cases covering no, one, and several leading slashes.

https://bugs.php.net/bug.php?id=65414