### PR TITLE
Fix SOURCE_DATE_EPOCH to not vary on timezones

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1269,7 +1269,7 @@ EXTRA_LDFLAGS="$EXTRA_LDFLAGS $PHP_LDFLAGS"
 EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $PHP_LDFLAGS"
 
 # SOURCE_DATE_EPOCH for reproducible builds https://reproducible-builds.org/specs/source-date-epoch/
-PHP_BUILD_DATE=`date --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d`
+PHP_BUILD_DATE=`date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d`
 AC_DEFINE_UNQUOTED(PHP_BUILD_DATE,"$PHP_BUILD_DATE",[PHP build date])
 
 PHP_UNAME=`uname -a | xargs`


### PR DESCRIPTION
Thanks for incorporating the SOURCE_DATE_EPOCH. There's a minor glitch reported by the Debian Reproducible Builds team - the timestamp is not timezone agnostic. This PR fixes the glitch.