### PR TITLE
Remove invalids SKIPIF sections in Reflection tests

### DIFF
--- a/ext/reflection/tests/010.phpt
+++ b/ext/reflection/tests/010.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionMethod::__toString() tests (overriden method)
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 class Foo {
@@ -15,7 +13,7 @@ class Bar extends Foo {
 $m = new ReflectionMethod("Bar::func");
 echo $m;
 ?>
---EXPECTF--	
+--EXPECTF--
 Method [ <user, overwrites Foo, prototype Foo> public method func ] {
   @@ %s010.php 7 - 8
 }

--- a/ext/reflection/tests/011.phpt
+++ b/ext/reflection/tests/011.phpt
@@ -1,12 +1,10 @@
 --TEST--
 ReflectionExtension::getClasses()
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 $ext = new ReflectionExtension("reflection");
 $classes = $ext->getClasses();
 echo $classes["ReflectionException"]->getName();
 ?>
---EXPECT--	
+--EXPECT--
 ReflectionException

--- a/ext/reflection/tests/012.phpt
+++ b/ext/reflection/tests/012.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionClass::getDefaultProperties()
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 class Foo {
@@ -11,6 +9,5 @@ $class = new ReflectionClass("Foo");
 $props = $class->getDefaultProperties();
 echo $props["test"];
 ?>
---EXPECT--	
+--EXPECT--
 ok
-

--- a/ext/reflection/tests/013.phpt
+++ b/ext/reflection/tests/013.phpt
@@ -1,13 +1,10 @@
 --TEST--
 ReflectionExtension::getFunctions()
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 $ext = new ReflectionExtension("standard");
 $funcs = $ext->getFunctions();
 echo $funcs["sleep"]->getName();
 ?>
---EXPECT--	
+--EXPECT--
 sleep
-

--- a/ext/reflection/tests/014.phpt
+++ b/ext/reflection/tests/014.phpt
@@ -1,13 +1,10 @@
 --TEST--
 ReflectionExtension::getConstants()
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 $ext = new ReflectionExtension("standard");
 $consts = $ext->getConstants();
 var_dump($consts["CONNECTION_NORMAL"]);
 ?>
---EXPECT--	
+--EXPECT--
 int(0)
-

--- a/ext/reflection/tests/015.phpt
+++ b/ext/reflection/tests/015.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionExtension::getINIEntries()
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --INI--
 user_agent=php
 --FILE--
@@ -10,6 +8,5 @@ $ext = new ReflectionExtension("standard");
 $inis = $ext->getINIEntries();
 var_dump($inis["user_agent"]);
 ?>
---EXPECT--	
+--EXPECT--
 string(3) "php"
-

--- a/ext/reflection/tests/016.phpt
+++ b/ext/reflection/tests/016.phpt
@@ -2,7 +2,6 @@
 ReflectionExtension::getDependencies()
 --SKIPIF--
 <?php
-extension_loaded('reflection') or die('skip'); 
 if (!extension_loaded("xml")) {
   die('skip xml extension not available');
 }
@@ -13,7 +12,7 @@ $ext = new ReflectionExtension("xml");
 $deps = $ext->getDependencies();
 var_dump($deps);
 ?>
---EXPECT--	
+--EXPECT--
 array(1) {
   ["libxml"]=>
   string(8) "Required"

--- a/ext/reflection/tests/017.phpt
+++ b/ext/reflection/tests/017.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionClass::__toString() (constants)
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 class Foo {
@@ -30,4 +28,3 @@ Class [ <user> class Foo ] {
   - Methods [0] {
   }
 }
-

--- a/ext/reflection/tests/018.phpt
+++ b/ext/reflection/tests/018.phpt
@@ -1,12 +1,10 @@
 --TEST--
 Reflection::getModifierNames
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 var_dump(Reflection::getModifierNames(ReflectionMethod::IS_FINAL | ReflectionMethod::IS_PROTECTED));
 ?>
---EXPECT--	
+--EXPECT--
 array(2) {
   [0]=>
   string(5) "final"

--- a/ext/reflection/tests/019.phpt
+++ b/ext/reflection/tests/019.phpt
@@ -1,11 +1,9 @@
 --TEST--
 ReflectionFunction::getExtensionName
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 $f = new ReflectionFunction("sleep");
 var_dump($f->getExtensionName());
 ?>
---EXPECT--	
+--EXPECT--
 string(8) "standard"

--- a/ext/reflection/tests/020.phpt
+++ b/ext/reflection/tests/020.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionObject::hasProperty
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 class Foo {
@@ -20,7 +18,7 @@ var_dump($obj->hasProperty("p2"));
 var_dump($obj->hasProperty("p3"));
 var_dump($obj->hasProperty("p4"));
 ?>
---EXPECT--	
+--EXPECT--
 bool(true)
 bool(true)
 bool(true)

--- a/ext/reflection/tests/021.phpt
+++ b/ext/reflection/tests/021.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionClass::hasConstant
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 class Foo {
@@ -11,6 +9,6 @@ $class = new ReflectionClass("Foo");
 var_dump($class->hasConstant("c1"));
 var_dump($class->hasConstant("c2"));
 ?>
---EXPECT--	
+--EXPECT--
 bool(true)
 bool(false)

--- a/ext/reflection/tests/022.phpt
+++ b/ext/reflection/tests/022.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionClass::getConstant
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 class Foo {
@@ -11,6 +9,6 @@ $class = new ReflectionClass("Foo");
 var_dump($class->getConstant("c1"));
 var_dump($class->getConstant("c2"));
 ?>
---EXPECT--	
+--EXPECT--
 int(1)
 bool(false)

--- a/ext/reflection/tests/023.phpt
+++ b/ext/reflection/tests/023.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionClass::getDefaultProperties (filtering parent privates)
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 class C1 {
@@ -17,7 +15,7 @@ class C2 extends C1 {
 $class = new ReflectionClass("C2");
 var_dump($class->getDefaultProperties());
 ?>
---EXPECT--	
+--EXPECT--
 array(5) {
   ["p4"]=>
   int(4)

--- a/ext/reflection/tests/024.phpt
+++ b/ext/reflection/tests/024.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionObject::__toString (filtering privates/protected dynamic properties)
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --FILE--
 <?php
 class C1 {
@@ -17,7 +15,7 @@ $x->p3 = 5;
 $obj = new ReflectionObject($x);
 echo $obj;
 ?>
---EXPECTF--	
+--EXPECTF--
 Object of class [ <user> class C1 ] {
   @@ %s024.php 2-6
 

--- a/ext/reflection/tests/025.phpt
+++ b/ext/reflection/tests/025.phpt
@@ -1,7 +1,5 @@
 --TEST--
 ReflectionFunction basic tests
---SKIPIF--
-<?php extension_loaded('reflection') or die('skip'); ?>
 --INI--
 opcache.save_comments=1
 --FILE--
@@ -49,7 +47,7 @@ var_dump($func->getNumberOfRequiredParameters());
 echo "Done\n";
 
 ?>
---EXPECTF--	
+--EXPECTF--
 /**
 hoho
 */

--- a/ext/reflection/tests/ReflectionClass_CannotClone_basic.phpt
+++ b/ext/reflection/tests/ReflectionClass_CannotClone_basic.phpt
@@ -3,14 +3,11 @@ Reflection class can not be cloned
 --CREDITS--
 Stefan Koopmanschap <stefan@phpgg.nl>
 TestFest PHP|Tek
---SKIPIF--
-<?php
-if (!extension_loaded('reflection')) print 'skip';
-?>
---FILE-- 
+--FILE--
 <?php
 $rc = new ReflectionClass("stdClass");
 $rc2 = clone($rc);
+?>
 --EXPECTF--
 Fatal error: Uncaught Error: Trying to clone an uncloneable object of class ReflectionClass in %s:%d
 Stack trace:

--- a/ext/reflection/tests/ReflectionExtension_bug66218.phpt
+++ b/ext/reflection/tests/ReflectionExtension_bug66218.phpt
@@ -2,7 +2,6 @@
 ReflectionExtension::getFunctions() ##6218 zend_register_functions breaks reflection
 --SKIPIF--
 <?php
-if (!extension_loaded('reflection')) print 'skip missing reflection extension';
 if (PHP_SAPI != "cli") die("skip CLI only test");
 if (!function_exists("dl")) die("skip need dl");
 ?>

--- a/ext/reflection/tests/ReflectionFunction_getClosureScopeClass.phpt
+++ b/ext/reflection/tests/ReflectionFunction_getClosureScopeClass.phpt
@@ -1,10 +1,6 @@
 --TEST--
 Reflection::getClosureScopeClass()
---SKIPIF--
-<?php
-if (!extension_loaded('reflection')) print 'skip';
-?>
---FILE-- 
+--FILE--
 <?php
 $closure = function($param) { return "this is a closure"; };
 $rf = new ReflectionFunction($closure);
@@ -20,6 +16,7 @@ $closure = A::getClosure();
 $rf = new ReflectionFunction($closure);
 var_dump($rf->getClosureScopeClass());
 echo "Done!\n";
+?>
 --EXPECTF--
 NULL
 object(ReflectionClass)#%d (1) {

--- a/ext/reflection/tests/ReflectionFunction_getClosureThis.phpt
+++ b/ext/reflection/tests/ReflectionFunction_getClosureThis.phpt
@@ -1,15 +1,12 @@
 --TEST--
 Reflection::getClosureThis()
---SKIPIF--
-<?php
-if (!extension_loaded('reflection')) print 'skip';
-?>
---FILE-- 
+--FILE--
 <?php
 $closure = function($param) { return "this is a closure"; };
 $rf = new ReflectionFunction($closure);
 var_dump($rf->getClosureThis());
 echo "Done!\n";
+?>
 --EXPECTF--
 NULL
 Done!

--- a/ext/reflection/tests/ReflectionFunction_isClosure_basic.phpt
+++ b/ext/reflection/tests/ReflectionFunction_isClosure_basic.phpt
@@ -3,14 +3,11 @@ Reflection::isClosure
 --CREDITS--
 Stefan Koopmanschap <stefan@phpgg.nl>
 TestFest PHP|Tek
---SKIPIF--
-<?php
-if (!extension_loaded('reflection')) print 'skip';
-?>
---FILE-- 
+--FILE--
 <?php
 $closure = function($param) { return "this is a closure"; };
 $rc = new ReflectionFunction($closure);
 var_dump($rc->isClosure());
+?>
 --EXPECTF--
 bool(true)

--- a/ext/reflection/tests/ReflectionFunction_isDisabled_basic.phpt
+++ b/ext/reflection/tests/ReflectionFunction_isDisabled_basic.phpt
@@ -3,15 +3,12 @@ ReflectionFunction::isDisabled
 --CREDITS--
 Stefan Koopmanschap <stefan@phpgg.nl>
 TestFest PHP|Tek
---SKIPIF--
-<?php
-if (!extension_loaded('reflection')) print 'skip';
-?>
 --INI--
 disable_functions=is_file
---FILE-- 
+--FILE--
 <?php
 $rc = new ReflectionFunction('is_file');
 var_dump($rc->isDisabled());
+?>
 --EXPECTF--
 bool(true)

--- a/ext/reflection/tests/ReflectionMethod_getClosureThis.phpt
+++ b/ext/reflection/tests/ReflectionMethod_getClosureThis.phpt
@@ -1,10 +1,6 @@
 --TEST--
 Reflection::getClosureThis()
---SKIPIF--
-<?php
-if (!extension_loaded('reflection')) print 'skip';
-?>
---FILE-- 
+--FILE--
 <?php
 class StaticExample
 {
@@ -42,6 +38,7 @@ $rf = new ReflectionFunction($closure);
 var_dump($rf->getClosureThis());
 
 echo "Done!\n";
+?>
 --EXPECTF--
 NULL
 object(Example)#%d (1) {

--- a/ext/reflection/tests/bug64936.phpt
+++ b/ext/reflection/tests/bug64936.phpt
@@ -1,11 +1,9 @@
 --TEST--
 ReflectionMethod::getDocComment() uses left over doc comment from previous scanner run
+--SKIPIF--
+<?php if (!extension_loaded('tokenizer')) die('skip tokenizer extension not loaded'); ?>
 --INI--
 opcache.save_comments=1
---SKIPIF--
-<?php
-if (!extension_loaded('reflection') || !extension_loaded('tokenizer')) print 'skip missing reflection of tokernizer extension';
-?>
 --FILE--
 <?php
 


### PR DESCRIPTION
AFAIK, Reflection tests are always run, even with `--disable-all`.