### PR TITLE
Add Travis CI Build Stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: trusty
 language: c
 sudo: false
+
 addons:
   apt:
     packages:
@@ -20,7 +21,7 @@ addons:
       - libzip-dev
 
 notifications:
-    email: 
+    email:
        on_failure: change
     irc:
       template:
@@ -47,6 +48,24 @@ env:
       - ENABLE_MAINTAINER_ZTS=0 ENABLE_DEBUG=0
       - ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
 
+jobs:
+    include:
+        stage: Fast test
+        before_script:
+            - ccache --version
+            - ccache --zero-stats
+            - export USE_CCACHE=1
+            # Compile PHP fast
+            - ./travis/compile-fast.sh
+
+        # Run PHPs run-tests.php
+        script:
+            - ./sapi/cli/php run-tests.php -p `pwd`/sapi/cli/php -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --offline --show-diff --set-timeout 120
+
+stages:
+    - Fast test
+    - Test
+
 before_script:
     - ccache --version
     - ccache --zero-stats
@@ -60,7 +79,7 @@ before_script:
     - . ./travis/ext/pgsql/setup.sh
     - . ./travis/ext/pdo_pgsql/setup.sh
 
-# Run PHPs run-tests.php 
+# Run PHPs run-tests.php
 script:
     - ./sapi/cli/php run-tests.php -p `pwd`/sapi/cli/php $(if [ $ENABLE_DEBUG == 0 ]; then echo "-d opcache.enable_cli=1 -d zend_extension=`pwd`/modules/opcache.so"; fi) -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --offline --show-diff --show-slow 1000 --set-timeout 120
 

--- a/ext/standard/tests/streams/proc_open_bug69900.phpt
+++ b/ext/standard/tests/streams/proc_open_bug69900.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #69900 Commandline input/output weird behaviour with STDIO
+--XFAIL--
+@weltling "This test is one of the sporadic fails happening from time to time."
 --FILE--
 <?php
 
@@ -33,7 +35,7 @@ for($i = 0; $i < 10; $i++){
 	$s = fgets($pipes[1]);
 	$t1 = microtime(1);
 
-	echo $s;		
+	echo $s;
 	echo "fgets() took ", (($t1 - $t0)*1000 > $max_ms ? 'more' : 'less'), " than $max_ms ms\n";
 }
 

--- a/travis/compile-fast.sh
+++ b/travis/compile-fast.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+if [[ -z "$CONFIG_LOG_FILE" ]]; then
+	CONFIG_QUIET="--quiet"
+	CONFIG_LOG_FILE="/dev/stdout"
+else
+	CONFIG_QUIET=""
+fi
+if [[ -z "$MAKE_LOG_FILE" ]]; then
+	MAKE_QUIET="--quiet"
+	MAKE_LOG_FILE="/dev/stdout"
+else
+	MAKE_QUIET=""
+fi
+
+MAKE_JOBS=${MAKE_JOBS:-2}
+
+./buildconf --force
+./configure \
+--prefix="$HOME"/php-install \
+$CONFIG_QUIET \
+--disable-all \
+> "$CONFIG_LOG_FILE"
+
+make "-j${MAKE_JOBS}" $MAKE_QUIET > "$MAKE_LOG_FILE"
+make install >> "$MAKE_LOG_FILE"


### PR DESCRIPTION
With this PR I want to propose some improvement to our tests, IMHO, a huge improvement in terms of speed.

### Background
Here in GitHub, take at least 20min to receive a response from Travis CI telling if our tests have failed or not. I agree that we already provide a lot of scripts for users to test locally, but what happens in Travis CI and AppVeyor matters the most, and this is a lot of time.

### [Statistic](https://travis-ci.org/php/php-src/jobs/336883835#L2415)
Using `--disable-all`, we can see that we have %55 (distributed in ~8500 files) of our tests concentrates in 6 major extensions: `sapi`, `standard`, `spl`, `reflection`, `pcre` and `date`, including the `Zend` tests. They took (at most in poor machines) 300s (5min), which can be considering fast. The others %45 tests (in 7175 files), they test 69 extensions. With a little bit of math and logic, have %55 tests concentrated in 6 extensions, make them important, and should be the first to test and fix.

### Current environment
We current test 87.5% of our code base in Travis CI in ~950s (16 min). So, we expand 5 minutes only compiling PHP to then start run our tests.

### Travis CI Build Stages
Travis CI has a functionality called [Build Stages](https://docs.travis-ci.com/user/build-stages), that allow us to create stages to our build process, and if one of the builds fail, the whole process is canceled, and the response is return.

### Proposal
My proposal is to adopt Travis CI Build Stages and a `Fast test` stage including a PHP compile version with `--disable-all`, to test half of our test, containing the most important tests, and speed up in 75% the feedback of fails.

### Pros and cons
Besides speed, this would force almost every test has it `SKIPIF` config. A downside would be increasing in more 5 minutes the original build, as we need to wait until the `Fast test` pass. This could be converted in just another build in the current environment but is wasted of time and process to Travis CI, knowing that it will fail.

### Failing tests
Current, [there is 1 test that is failing in this fast build](https://travis-ci.org/php/php-src/jobs/336883835#L2282), and I guess is because of speed, and I would love some help to fix it. Also, should we enable online tests here without `--offline`? It'd slow down only 2~3 minutes, but test more code.

Email to internals: https://externals.io/message/101747