### PR TITLE
Remove superfluous SKIPIF sections of always available functions

### DIFF
--- a/Zend/tests/bug21478.phpt
+++ b/Zend/tests/bug21478.phpt
@@ -1,9 +1,5 @@
 --TEST--
 Bug #21478 (Zend/zend_alloc.c :: shutdown_memory_manager produces segfault) 
---SKIPIF--
-<?php 
-	if (!function_exists('stream_filter_register')) die('skip stream_filter_register() not available');
-?>
 --FILE--
 <?php
 class debugfilter extends php_user_filter {
@@ -27,7 +23,7 @@ fwrite($fp, "This is a test.\n");
 print "Done.\n";
 fclose($fp);
 // Uncommenting the following 'print' line causes the segfault to stop occurring
-// print "2\n";  
+// print "2\n";
 readfile(dirname(__FILE__)."/test.txt");
 unlink(dirname(__FILE__)."/test.txt");
 ?>

--- a/Zend/tests/bug36568.phpt
+++ b/Zend/tests/bug36568.phpt
@@ -1,9 +1,5 @@
 --TEST--
 Bug #36568 (memory_limit has no effect)
---SKIPIF--
-<?php 
-	if (!function_exists('memory_get_usage')) die('skip PHP is configured without memory_limit');
-?>
 --INI--
 memory_limit=16M
 --FILE--

--- a/Zend/tests/bug43450.phpt
+++ b/Zend/tests/bug43450.phpt
@@ -1,13 +1,11 @@
 --TEST--
 Bug #43450 (Memory leak on some functions with implicit object __toString() call)
---SKIPIF--
-<?php if (!function_exists('memory_get_usage')) die('skip memory_get_usage() not installed'); ?>
 --INI--
 opcache.enable_cli=0
 --FILE--
 <?php
 
-class Foo 
+class Foo
 {
     public function __toString()
 	{
@@ -18,7 +16,7 @@ class Foo
 $num_repeats = 100000;
 
 $start = memory_get_usage() / 1024;
-for ($i=1;$i<$num_repeats;$i++) 
+for ($i=1;$i<$num_repeats;$i++)
 {
 	$foo = new Foo();
 	md5($foo);

--- a/ext/date/tests/date_add_basic.phpt
+++ b/ext/date/tests/date_add_basic.phpt
@@ -1,16 +1,14 @@
 --TEST--
-Test date_add() function : basic functionality 
+Test date_add() function : basic functionality
 --CREDITS--
 Felix De Vliegher <felix.devliegher@gmail.com>
---SKIPIF--
-<?php if (!function_exists('date_add')) echo "skip: date_add() function not found!"; ?>
 --FILE--
 <?php
 date_default_timezone_set('UTC');
 /* Prototype  : void date_add(DateTime object, DateInterval interval)
  * Description: Adds an interval to the current date in object.
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing date_add() : basic functionality ***\n";

--- a/ext/date/tests/date_create-1.phpt
+++ b/ext/date/tests/date_create-1.phpt
@@ -1,7 +1,5 @@
 --TEST--
 date_create() function [1]
---SKIPIF--
-<?php if (!function_exists('date_create')) echo "SKIP"; ?>
 --FILE--
 <?php
 date_default_timezone_set('Europe/Oslo');

--- a/ext/date/tests/date_create-2.phpt
+++ b/ext/date/tests/date_create-2.phpt
@@ -1,7 +1,5 @@
 --TEST--
 date_create() function [2]
---SKIPIF--
-<?php if (!function_exists('date_create')) echo "SKIP"; ?>
 --FILE--
 <?php
 date_default_timezone_set("GMT");

--- a/ext/date/tests/date_modify-1.phpt
+++ b/ext/date/tests/date_modify-1.phpt
@@ -1,7 +1,5 @@
 --TEST--
 date_modify() function [1]
---SKIPIF--
-<?php if (!function_exists('date_create')) echo "SKIP"; ?>
 --FILE--
 <?php
 date_default_timezone_set("Pacific/Kwajalein");

--- a/ext/date/tests/date_modify-2.phpt
+++ b/ext/date/tests/date_modify-2.phpt
@@ -1,7 +1,5 @@
 --TEST--
 date_modify() function [2]
---SKIPIF--
-<?php if (!function_exists('date_create')) echo "SKIP"; ?>
 --FILE--
 <?php
 date_default_timezone_set("GMT");

--- a/ext/date/tests/date_sub_basic.phpt
+++ b/ext/date/tests/date_sub_basic.phpt
@@ -1,16 +1,14 @@
 --TEST--
-Test date_sub() function : basic functionality 
+Test date_sub() function : basic functionality
 --CREDITS--
 Felix De Vliegher <felix.devliegher@gmail.com>
---SKIPIF--
-<?php if (!function_exists('date_sub')) echo "skip: date_sub() function not found!"; ?>
 --FILE--
 <?php
 date_default_timezone_set('UTC');
 /* Prototype  : void date_sub(DateTime object, DateInterval interval)
  * Description: Subtracts an interval from the current date in object.
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing date_sub() : basic functionality ***\n";

--- a/ext/date/tests/strtotime_basic.phpt
+++ b/ext/date/tests/strtotime_basic.phpt
@@ -1,7 +1,5 @@
 --TEST--
 strtotime() function - a test to show the difference in behaviour between 'first' and '1', "second" and "2"...
---SKIPIF--
-<?php if (!function_exists('strtotime')) echo "SKIP"; ?>
 --FILE--
 <?php
 date_default_timezone_set('UTC');
@@ -12,29 +10,29 @@ date_default_timezone_set('UTC');
 
 /*
  * This is parsed as the "first following Monday OR the current day if it is a Monday"
- */ 
+ */
 var_dump(date('Y-m-d', strtotime('1 Monday December 2008')));
 /*
- * This is parsed as the "second following Monday OR the first following 
+ * This is parsed as the "second following Monday OR the first following
  * Monday if the current day is a Monday"
  */
 var_dump(date('Y-m-d', strtotime('2 Monday December 2008')));
 /*
- * This is parsed as the "third following Monday OR the second following 
+ * This is parsed as the "third following Monday OR the second following
  * Monday if the current day is a Monday"
  */
 var_dump(date('Y-m-d', strtotime('3 Monday December 2008')));
 /*
  * This is parsed as the "first following Monday after the first Monday in December"
- */ 
+ */
 var_dump(date('Y-m-d', strtotime('first Monday December 2008')));
 /*
  * This is parsed as the "second following Monday after the first Monday in December"
- */ 
+ */
 var_dump(date('Y-m-d', strtotime('second Monday December 2008')));
 /*
  * This is parsed as the "third following Monday after the first Monday in December"
- */ 
+ */
 var_dump(date('Y-m-d', strtotime('third Monday December 2008')));
 ?>
 --EXPECTF--

--- a/ext/pcre/tests/locales.phpt
+++ b/ext/pcre/tests/locales.phpt
@@ -3,7 +3,6 @@ Localized match
 --SKIPIF--
 <?php 
 
-if (!function_exists('setlocale')) die('skip: setlocale() not available');
 if (!@setlocale(LC_ALL, 'pt_PT', 'pt', 'pt_PT.ISO8859-1', 'portuguese')) die('skip pt locale not available');
 
 ?>

--- a/ext/soap/tests/bugs/bug39815.phpt
+++ b/ext/soap/tests/bugs/bug39815.phpt
@@ -1,9 +1,8 @@
 --TEST--
 Bug #39815 (to_zval_double() in ext/soap/php_encoding.c is not locale-independent)
 --SKIPIF--
-<?php 
-require_once('skipif.inc'); 
-if (!function_exists('setlocale')) die('skip setlocale() not available'); 
+<?php
+require_once('skipif.inc');
 if (!@setlocale(LC_ALL, 'sv_SE', 'sv_SE.ISO8859-1')) die('skip sv_SE locale not available');
 if (!@setlocale(LC_ALL, 'en_US', 'en_US.ISO8859-1')) die('skip en_US locale not available');
 ?>
@@ -32,15 +31,16 @@ class LocalSoapClient extends SoapClient {
   }
 
 }
-$x = new LocalSoapClient(NULL,array('location'=>'test://', 
+$x = new LocalSoapClient(NULL,array('location'=>'test://',
                                    'uri'=>'http://testuri.org',
-                                   "trace"=>1)); 
+                                   "trace"=>1));
 setlocale(LC_ALL,"sv_SE","sv_SE.ISO8859-1");
 var_dump($x->test());
 echo $x->__getLastResponse();
 setlocale(LC_ALL,"en_US","en_US.ISO8859-1");
 var_dump($x->test());
 echo $x->__getLastResponse();
+?>
 --EXPECT--
 float(123,456)
 <?xml version="1.0" encoding="UTF-8"?>

--- a/ext/standard/tests/file/file_get_contents_error001.phpt
+++ b/ext/standard/tests/file/file_get_contents_error001.phpt
@@ -8,8 +8,6 @@ display_errors=false
 --SKIPIF--
 <?php
 	if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-	if (!function_exists("file_get_contents"))
-		die ("skip file_get_contents function is not found");
 	if (getenv("SKIP_ONLINE_TESTS")) die("skip online test");
 ?>
 --FILE--

--- a/ext/standard/tests/file/file_get_contents_error002.phpt
+++ b/ext/standard/tests/file/file_get_contents_error002.phpt
@@ -5,11 +5,6 @@ file_get_contents() test using negative parameter for length (last parameter)
 "Sylvain R." <sracine@phpquebec.org>
 --INI--
 display_errors=false
---SKIPIF--
-<?php
-	if (!function_exists("file_get_contents"))
-		die ("skip file_get_contents function is not found");
-?>
 --FILE--
 <?php
 	var_dump(file_get_contents("http://checkip.dyndns.com",null,null,0,-1));

--- a/ext/standard/tests/math/decbin_error.phpt
+++ b/ext/standard/tests/math/decbin_error.phpt
@@ -2,14 +2,10 @@
 Test expm1() - Error conditions
 --INI--
 precision=14
---SKIPIF--
-<?php
-	function_exists('expm1') or die('skip expm1() is not supported in this build.');
-?>
 --FILE--
 <?php
 /* Prototype  : float expm1  ( float $arg  )
- * Description: Returns exp(number) - 1, computed in a way that is accurate even 
+ * Description: Returns exp(number) - 1, computed in a way that is accurate even
  *              when the value of number is close to zero.
  * Source code: ext/standard/math.c
  */
@@ -34,4 +30,3 @@ Warning: expm1() expects exactly 1 parameter, 0 given in %s on line %d
 
 Warning: expm1() expects exactly 1 parameter, 2 given in %s on line %d
 ===Done===
-

--- a/ext/standard/tests/strings/bug73058.phpt
+++ b/ext/standard/tests/strings/bug73058.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Bug #73058 crypt broken when salt is 'too' long
---SKIPIF--
-<?php
-if (!function_exists('crypt'))) {
-	die("SKIP crypt() is not available");
-}
-?> 
 --FILE--
 <?php
 $pass = 'secret';
@@ -26,4 +20,3 @@ string(60) "$2y$07$usesomesillystringforex.u2VJUMLRWaJNuw0Hu2FvCEimdeYVO"
 string(60) "$2y$07$usesomesillystringforex.u2VJUMLRWaJNuw0Hu2FvCEimdeYVO"
 string(60) "$2y$07$usesomesillystringforuw2Gm1ef7lMsvtzSK2p/14F0q1e8uOCO"
 ==OK==
-

--- a/ext/standard/tests/strings/crypt.phpt
+++ b/ext/standard/tests/strings/crypt.phpt
@@ -1,11 +1,5 @@
 --TEST--
 crypt() function
---SKIPIF--
-<?php
-if (!function_exists('crypt')) {
-	die("SKIP crypt() is not available");
-}
-?> 
 --FILE--
 <?php
 

--- a/ext/standard/tests/strings/crypt_blowfish.phpt
+++ b/ext/standard/tests/strings/crypt_blowfish.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Official blowfish tests (http://cvsweb.openwall.com/cgi/cvsweb.cgi/Owl/packages/glibc/crypt_blowfish/wrapper.c)
---SKIPIF--
-<?php
-if (!function_exists('crypt') || !defined("CRYPT_BLOWFISH")) {
-    die("SKIP crypt()-blowfish is not available");
-}
-?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/strings/crypt_blowfish_variation1.phpt
+++ b/ext/standard/tests/strings/crypt_blowfish_variation1.phpt
@@ -2,7 +2,7 @@
 Test Blowfish crypt() with invalid rounds
 --SKIPIF--
 <?php
-if (!function_exists('crypt') || !defined("CRYPT_BLOWFISH")) {
+if (!defined("CRYPT_BLOWFISH")) {
     die("SKIP crypt()-blowfish is not available");
 }
 ?>

--- a/ext/standard/tests/strings/crypt_chars.phpt
+++ b/ext/standard/tests/strings/crypt_chars.phpt
@@ -1,17 +1,12 @@
 --TEST--
 crypt() function - characters > 0x80
---SKIPIF--
-<?php
-if (!function_exists('crypt')) {
-        die("SKIP crypt() is not available");
-}
-?>
 --FILE--
 <?php
 var_dump(crypt("À1234abcd", "99"));
 var_dump(crypt("À9234abcd", "99"));
 var_dump(crypt("À1234abcd", "_01234567"));
 var_dump(crypt("À9234abcd", "_01234567"));
+?>
 --EXPECT--
 string(13) "99PxawtsTfX56"
 string(13) "99jcVcGxUZOWk"

--- a/ext/standard/tests/strings/crypt_des_error.phpt
+++ b/ext/standard/tests/strings/crypt_des_error.phpt
@@ -1,11 +1,5 @@
 --TEST--
 crypt(): *0 should return *1
---SKIPIF--
-<?php
-if (!function_exists('crypt')) {
-	die("SKIP crypt() is not available");
-}
-?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/strings/crypt_sha256.phpt
+++ b/ext/standard/tests/strings/crypt_sha256.phpt
@@ -1,11 +1,11 @@
 --TEST--
-crypt() SHA-256 
+crypt() SHA-256
 --SKIPIF--
 <?php
-if (!function_exists('crypt') || !defined("CRYPT_SHA256")) {
+if (!defined("CRYPT_SHA256")) {
 	die("SKIP crypt()-sha256 is not available");
 }
-?> 
+?>
 --FILE--
 <?php
 
@@ -61,4 +61,3 @@ Got       <$res>\n";
 echo "Passes.";?>
 --EXPECT--
 Passes.
-

--- a/ext/standard/tests/strings/crypt_sha512.phpt
+++ b/ext/standard/tests/strings/crypt_sha512.phpt
@@ -2,10 +2,10 @@
 crypt() SHA-512
 --SKIPIF--
 <?php
-if (!function_exists('crypt') || !defined("CRYPT_SHA512")) {
+if (!defined("CRYPT_SHA512")) {
 	die("SKIP crypt()-sha512 is not available");
 }
-?> 
+?>
 --FILE--
 <?php
 
@@ -62,4 +62,3 @@ echo "Passes.";
 ?>
 --EXPECT--
 Passes.
-

--- a/ext/standard/tests/strings/crypt_variation1.phpt
+++ b/ext/standard/tests/strings/crypt_variation1.phpt
@@ -1,11 +1,5 @@
 --TEST--
 crypt() function - long salt
---SKIPIF--
-<?php
-if (!function_exists('crypt')) {
-	die("SKIP crypt() is not available");
-}
-?> 
 --FILE--
 <?php
 

--- a/ext/standard/tests/strings/moneyformat.phpt
+++ b/ext/standard/tests/strings/moneyformat.phpt
@@ -2,7 +2,7 @@
 money_format test
 --SKIPIF--
 <?php
-	if (!function_exists('money_format') || !function_exists('setlocale')) {
+	if (!function_exists('money_format')) {
 		die("SKIP money_format - not supported\n");
 	}
 

--- a/ext/standard/tests/time/001.phpt
+++ b/ext/standard/tests/time/001.phpt
@@ -1,9 +1,8 @@
 --TEST--
 microtime() function
 --SKIPIF--
-<?php 
-	if (!function_exists('microtime'))  die('skip microtime() not available'); 
-	die('warn system dependent');
+<?php
+	if (!function_exists('microtime'))  die('skip microtime() not available');
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Refs:
`stream_filter_register`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L3427
`memory_get_usage`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L3036
`date_add`: https://github.com/php/php-src/blob/master/ext/date/php_date.c#L432
`date_create`: https://github.com/php/php-src/blob/master/ext/date/php_date.c#L423
`date_sub`: https://github.com/php/php-src/blob/master/ext/date/php_date.c#L433
`strtotime`: https://github.com/php/php-src/blob/master/ext/date/php_date.c#L405
`setlocale`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2838
`file_get_contents`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L3155
`expm1`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2953
`crypt`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L3239
`image_type_to_mime_type`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2765
`image_type_to_extension`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2766
`utf8_encode`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2805
`utf8_decode`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2806