### PR TITLE
Change opcache.optimization_level

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1784,7 +1784,7 @@ ldap.max_links = -1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes
-;opcache.optimization_level=0xffffffff
+;opcache.optimization_level=0x7FFFBFFF
 
 ;opcache.dups_fix=0
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -1791,7 +1791,7 @@ ldap.max_links = -1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes
-;opcache.optimization_level=0xffffffff
+;opcache.optimization_level=0x7FFFFFFF
 
 ;opcache.dups_fix=0
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -1791,7 +1791,7 @@ ldap.max_links = -1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes
-;opcache.optimization_level=0x7FFFFFFF
+;opcache.optimization_level=0x7FFFBFFF
 
 ;opcache.dups_fix=0
 


### PR DESCRIPTION
opcache.optimization_level should be set to [ZEND_OPTIMIZER_ALL_PASSES](https://github.com/php/php-src/blob/c9034c3b3344287a1a636e43dbcb781bcfbd31af/ext/opcache/Optimizer/zend_optimizer.h#L45).

Bits above that don't exist at this point, so 0xffffffff makes no sense.