### PR TITLE
Add SKIPIF section for not always available functions

### DIFF
--- a/ext/date/tests/gmstrftime_basic.phpt
+++ b/ext/date/tests/gmstrftime_basic.phpt
@@ -1,11 +1,13 @@
 --TEST--
-Test gmstrftime() function : basic functionality 
+Test gmstrftime() function : basic functionality
+--SKIPIF--
+<?php if (!function_exists('gmstrftime')) die('skip gmstrftime function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string gmstrftime(string format [, int timestamp])
- * Description: Format a GMT/UCT time/date according to locale settings 
+ * Description: Format a GMT/UCT time/date according to locale settings
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing gmstrftime() : basic functionality ***\n";

--- a/ext/date/tests/gmstrftime_error.phpt
+++ b/ext/date/tests/gmstrftime_error.phpt
@@ -1,11 +1,13 @@
 --TEST--
-Test gmstrftime() function : error conditions 
+Test gmstrftime() function : error conditions
+--SKIPIF--
+<?php if (!function_exists('gmstrftime')) die('skip gmstrftime function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string gmstrftime(string format [, int timestamp])
- * Description: Format a GMT/UCT time/date according to locale settings 
+ * Description: Format a GMT/UCT time/date according to locale settings
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing gmstrftime() : error conditions ***\n";

--- a/ext/date/tests/gmstrftime_variation1.phpt
+++ b/ext/date/tests/gmstrftime_variation1.phpt
@@ -1,11 +1,13 @@
 --TEST--
 Test gmstrftime() function : usage variation - Passing unexpected values to first argument 'format'.
+--SKIPIF--
+<?php if (!function_exists('gmstrftime')) die('skip gmstrftime function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string gmstrftime(string format [, int timestamp])
- * Description: Format a GMT/UCT time/date according to locale settings 
+ * Description: Format a GMT/UCT time/date according to locale settings
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing gmstrftime() : usage variation ***\n";

--- a/ext/date/tests/gmstrftime_variation3.phpt
+++ b/ext/date/tests/gmstrftime_variation3.phpt
@@ -1,11 +1,13 @@
 --TEST--
 Test gmstrftime() function : usage variation - Passing week related format strings to format argument.
+--SKIPIF--
+<?php if (!function_exists('gmstrftime')) die('skip gmstrftime function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string gmstrftime(string format [, int timestamp])
- * Description: Format a GMT/UCT time/date according to locale settings 
+ * Description: Format a GMT/UCT time/date according to locale settings
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing gmstrftime() : usage variation ***\n";
@@ -18,7 +20,7 @@ $inputs = array(
       'Abbreviated weekday name' => "%a",
       'Full weekday name' => "%A",
 	  'Week number of the year' => "%U",
-	  'Week number of the year in decimal number' => "%W",	
+	  'Week number of the year in decimal number' => "%W",
 );
 
 // loop through each element of the array for timestamp

--- a/ext/date/tests/gmstrftime_variation4.phpt
+++ b/ext/date/tests/gmstrftime_variation4.phpt
@@ -1,11 +1,13 @@
 --TEST--
 Test gmstrftime() function : usage variation - Passing month related format strings to format argument.
+--SKIPIF--
+<?php if (!function_exists('gmstrftime')) die('skip gmstrftime function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string gmstrftime(string format [, int timestamp])
- * Description: Format a GMT/UCT time/date according to locale settings 
+ * Description: Format a GMT/UCT time/date according to locale settings
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing gmstrftime() : usage variation ***\n";

--- a/ext/date/tests/gmstrftime_variation5.phpt
+++ b/ext/date/tests/gmstrftime_variation5.phpt
@@ -1,11 +1,13 @@
 --TEST--
 Test gmstrftime() function : usage variation - Passing date related format strings to format argument.
+--SKIPIF--
+<?php if (!function_exists('gmstrftime')) die('skip gmstrftime function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string gmstrftime(string format [, int timestamp])
- * Description: Format a GMT/UCT time/date according to locale settings 
+ * Description: Format a GMT/UCT time/date according to locale settings
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing gmstrftime() : usage variation ***\n";
@@ -20,7 +22,7 @@ date_default_timezone_set("Asia/Calcutta");
 $inputs = array(
 	  'Year as decimal number without a century' => "%y",
 	  'Year as decimal number including the century' => "%Y",
-	  'Time zone offset' => "%Z",	 	
+	  'Time zone offset' => "%Z",
 	  'Time zone offset' => "%z",
 );
 

--- a/ext/date/tests/gmstrftime_variation6.phpt
+++ b/ext/date/tests/gmstrftime_variation6.phpt
@@ -1,11 +1,13 @@
 --TEST--
 Test gmstrftime() function : usage variation - Passing time related format strings to format argument.
+--SKIPIF--
+<?php if (!function_exists('gmstrftime')) die('skip gmstrftime function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string gmstrftime(string format [, int timestamp])
- * Description: Format a GMT/UCT time/date according to locale settings 
+ * Description: Format a GMT/UCT time/date according to locale settings
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing gmstrftime() : usage variation ***\n";

--- a/ext/date/tests/gmstrftime_variation7.phpt
+++ b/ext/date/tests/gmstrftime_variation7.phpt
@@ -1,11 +1,13 @@
 --TEST--
 Test gmstrftime() function : usage variation - Passing day related format strings to format argument.
+--SKIPIF--
+<?php if (!function_exists('gmstrftime')) die('skip gmstrftime function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string gmstrftime(string format [, int timestamp])
- * Description: Format a GMT/UCT time/date according to locale settings 
+ * Description: Format a GMT/UCT time/date according to locale settings
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing gmstrftime() : usage variation ***\n";

--- a/ext/date/tests/gmstrftime_variation8.phpt
+++ b/ext/date/tests/gmstrftime_variation8.phpt
@@ -1,11 +1,13 @@
 --TEST--
 Test gmstrftime() function : usage variation - Passing literal related strings to format argument.
+--SKIPIF--
+<?php if (!function_exists('gmstrftime')) die('skip gmstrftime function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string gmstrftime(string format [, int timestamp])
- * Description: Format a GMT/UCT time/date according to locale settings 
+ * Description: Format a GMT/UCT time/date according to locale settings
  * Source code: ext/date/php_date.c
- * Alias to functions: 
+ * Alias to functions:
  */
 
 echo "*** Testing gmstrftime() : usage variation ***\n";

--- a/ext/standard/tests/file/proc_open01.phpt
+++ b/ext/standard/tests/file/proc_open01.phpt
@@ -1,13 +1,15 @@
 --TEST--
 proc_open() regression test 1 (proc_open() leak)
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 $pipes = array(1, 2, 3);
 $orig_pipes = $pipes;
-$php = getenv('TEST_PHP_EXECUTABLE'); 
+$php = getenv('TEST_PHP_EXECUTABLE');
 if ($php === false) {
 	die("no php executable defined");
-} 
+}
 $proc = proc_open(
 	"$php -n",
 	array(0 => array('pipe', 'r'), 1 => array('pipe', 'w')),
@@ -24,7 +26,7 @@ fflush($pipes[0]);
 fclose($pipes[0]);
 $cnt = '';
 $n=0;
-for ($left = strlen($test_string); $left > 0;) { 
+for ($left = strlen($test_string); $left > 0;) {
 	if (++$n >1000) {
 	  print "terminated after 1000 iterations\n";
 	  break;

--- a/ext/standard/tests/general_functions/bug34794.phpt
+++ b/ext/standard/tests/general_functions/bug34794.phpt
@@ -3,6 +3,7 @@ Bug #34794 (proc_close() hangs when used with two processes)
 --SKIPIF--
 <?php
 if (!is_executable('/bin/cat')) echo 'skip cat not found';
+if (!function_exists('proc_open')) die ('skip proc_open function not available');
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/general_functions/bug39322.phpt
+++ b/ext/standard/tests/general_functions/bug39322.phpt
@@ -2,6 +2,7 @@
 Bug #39322 (proc_terminate() losing process resource)
 --SKIPIF--
 <?php
+if (!function_exists('proc_open')) die ('skip proc_open function not available');
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 if (!is_executable('/bin/sleep')) echo 'skip sleep not found';
 ?>

--- a/ext/standard/tests/general_functions/bug44667.phpt
+++ b/ext/standard/tests/general_functions/bug44667.phpt
@@ -1,7 +1,10 @@
 --TEST--
 Bug #44667 (proc_open() does not handle pipes with the mode 'wb' correctly)
 --SKIPIF--
-<?php if (!is_executable('/bin/cat')) echo 'skip cat not found'; ?>
+<?php
+if (!is_executable('/bin/cat')) echo 'skip cat not found';
+if (!function_exists('proc_open')) die ('skip proc_open function not available');
+?>
 --FILE--
 <?php
 
@@ -11,19 +14,19 @@ $descriptor_spec = array(
 	0 => array('pipe', 'rb'),
 	1 => array('pipe', 'wb'),
 );
-        
+
 $proc = proc_open('cat', $descriptor_spec, $pipes);
-        
+
 fwrite($pipes[0], 'Hello', 5);
 fflush($pipes[0]);
 fclose($pipes[0]);
-        
+
 $result = fread($pipes[1], 5);
 fclose($pipes[1]);
-        
+
 proc_close($proc);
-        
-echo "Result is: ", $result, "\n";        
+
+echo "Result is: ", $result, "\n";
 
 echo "Done\n";
 

--- a/ext/standard/tests/general_functions/bug72306.phpt
+++ b/ext/standard/tests/general_functions/bug72306.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #72306 (Heap overflow through proc_open and $env parameter)
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 class moo {

--- a/ext/standard/tests/general_functions/getservbyname_basic.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname()
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --CREDITS--
 Italian PHP TestFest 2009 Cesena 19-20-21 june
 Fabio Fabbrucci (fabbrucci@grupporetina.com)

--- a/ext/standard/tests/general_functions/getservbyname_error.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by calling it more than or less than its expected arguments
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --CREDITS--
 Italian PHP TestFest 2009 Cesena 19-20-21 june
 Fabio Fabbrucci (fabbrucci@grupporetina.com)
@@ -8,7 +10,7 @@ Danilo Sanchi (sanchi@grupporetina.com)
 --FILE--
 <?php
 $service = "www";
-$protocol = "tcp"; 
+$protocol = "tcp";
 $extra_arg = 12;
 var_dump(getservbyname($service, $protocol, $extra_arg ) );
 var_dump(getservbyname($service));

--- a/ext/standard/tests/general_functions/getservbyname_variation1.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation1.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by substituting argument 1 with array values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyname_variation11.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation11.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by substituting argument 2 with float values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyname_variation12.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation12.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by substituting argument 2 with int values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyname_variation13.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation13.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by substituting argument 2 with object values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyname_variation14.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation14.phpt
@@ -1,12 +1,14 @@
 --TEST--
 Test function getservbyname() by substituting argument 2 with string values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 
 
 echo "*** Test substituting argument 2 with string values ***\n";
 
-$service = "www"; 
+$service = "www";
 
 
 $heredoc = <<<EOT

--- a/ext/standard/tests/general_functions/getservbyname_variation2.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation2.phpt
@@ -1,12 +1,14 @@
 --TEST--
 Test function getservbyname() by substituting argument 1 with boolean values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 
 
 echo "*** Test substituting argument 1 with boolean values ***\n";
 
-$protocol = "tcp"; 
+$protocol = "tcp";
 
 
 $variation_array = array(

--- a/ext/standard/tests/general_functions/getservbyname_variation3.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation3.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by substituting argument 1 with emptyUnsetUndefNull values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyname_variation4.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation4.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by substituting argument 1 with float values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyname_variation5.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation5.phpt
@@ -1,12 +1,14 @@
 --TEST--
 Test function getservbyname() by substituting argument 1 with int values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 
 
 echo "*** Test substituting argument 1 with int values ***\n";
 
-$protocol = "tcp"; 
+$protocol = "tcp";
 
 
 $variation_array = array (

--- a/ext/standard/tests/general_functions/getservbyname_variation6.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation6.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by substituting argument 1 with object values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyname_variation7.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation7.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by substituting argument 1 with string values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyname_variation8.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation8.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyname() by substituting argument 2 with array values.
+--SKIPIF--
+<?php if (!function_exists('getservbyname')) die('skip getservbyname function not available') ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyport_basic.phpt
+++ b/ext/standard/tests/general_functions/getservbyport_basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyport() by calling it more than or less than its expected arguments
+--SKIPIF--
+<?php if (!function_exists('getservbyport')) die('skip getservbyport function not available'); ?>
 --CREDITS--
 Italian PHP TestFest 2009 Cesena 19-20-21 june
 Fabio Fabbrucci (fabbrucci@grupporetina.com)

--- a/ext/standard/tests/general_functions/getservbyport_error.phpt
+++ b/ext/standard/tests/general_functions/getservbyport_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyport() by calling it more than or less than its expected arguments
+--SKIPIF--
+<?php if (!function_exists('getservbyport')) die('skip getservbyport function not available'); ?>
 --CREDITS--
 Italian PHP TestFest 2009 Cesena 19-20-21 june
 Fabio Fabbrucci (fabbrucci@grupporetina.com)
@@ -8,7 +10,7 @@ Simone Gentili (sensorario@gmail.com)
 --FILE--
 <?php
 $port = 80;
-$protocol = "tcp"; 
+$protocol = "tcp";
 $extra_arg = 12;
 var_dump(getservbyport( $port, $protocol, $extra_arg ) );
 var_dump(getservbyport($port));

--- a/ext/standard/tests/general_functions/getservbyport_variation1.phpt
+++ b/ext/standard/tests/general_functions/getservbyport_variation1.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test function getservbyport() by calling it more than or less than its expected arguments
+--SKIPIF--
+<?php if (!function_exists('getservbyport')) die('skip getservbyport function not available'); ?>
 --DESCRIPTION--
 Test function passing invalid port number and invalid protocol name
 --CREDITS--
@@ -18,7 +20,7 @@ Simone Gentili (sensorario@gmail.com)
 	var_dump(getservbyport( 2, 2));
 	var_dump(getservbyport( "80", "tcp"));
 	var_dump(getservbyport( new stdClass(), new stdClass()));
-	
+
 ?>
 --EXPECTF--
 bool(false)

--- a/ext/standard/tests/general_functions/proc_open02.phpt
+++ b/ext/standard/tests/general_functions/proc_open02.phpt
@@ -2,6 +2,7 @@
 proc_open
 --SKIPIF--
 <?php
+if (!function_exists('proc_open')) die ('skip proc_open function not available');
 if (!is_executable('/bin/sleep')) echo 'skip no sleep';
 if (getenv('SKIP_SLOW_TESTS')) echo 'skip slow test';
 ?>

--- a/ext/standard/tests/general_functions/proc_open_pipes1.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes1.phpt
@@ -1,5 +1,7 @@
 --TEST--
-proc_open() with > 16 pipes 
+proc_open() with > 16 pipes
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/proc_open_pipes2.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes2.phpt
@@ -1,5 +1,7 @@
 --TEST--
-proc_open() with no pipes 
+proc_open() with no pipes
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/proc_open_pipes3.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes3.phpt
@@ -1,5 +1,7 @@
 --TEST--
-proc_open() with invalid pipes 
+proc_open() with invalid pipes
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/uniqid_basic.phpt
+++ b/ext/standard/tests/general_functions/uniqid_basic.phpt
@@ -1,9 +1,11 @@
 --TEST--
 Test uniqid() function : basic functionality
+--SKIPIF--
+<?php if (!function_exists('uniqid')) die('skip uniqid function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string uniqid  ([ string $prefix= ""  [, bool $more_entropy= false  ]] )
- * Description: Gets a prefixed unique identifier based on the current time in microseconds. 
+ * Description: Gets a prefixed unique identifier based on the current time in microseconds.
  * Source code: ext/standard/uniqid.c
 */
 echo "*** Testing uniqid() : basic functionality ***\n";
@@ -16,26 +18,26 @@ echo "\n\n";
 
 echo "uniqid() with a prefix\n";
 
-// Use a fixed prefix so we can ensure length of o/p id is fixed 
+// Use a fixed prefix so we can ensure length of o/p id is fixed
 $prefix = array (
 				99999,
 				"99999",
 				10.5e2,
 				null,
 				true,
-				false				
+				false
 				);
 
-for ($i = 0; $i < count($prefix); $i++) {				
+for ($i = 0; $i < count($prefix); $i++) {
 	var_dump(uniqid($prefix[$i]));
 	var_dump(uniqid($prefix[$i], true));
 	var_dump(uniqid($prefix[$i], false));
 	echo "\n";
-}	
+}
 
 ?>
 ===DONE===
---EXPECTF-- 
+--EXPECTF--
 *** Testing uniqid() : basic functionality ***
 
 uniqid() without a prefix

--- a/ext/standard/tests/general_functions/uniqid_error.phpt
+++ b/ext/standard/tests/general_functions/uniqid_error.phpt
@@ -1,9 +1,11 @@
 --TEST--
 Test uniqid() function : error conditions
+--SKIPIF--
+<?php if (!function_exists('uniqid')) die('skip uniqid function not available'); ?>
 --FILE--
 <?php
 /* Prototype  : string uniqid  ([ string $prefix= ""  [, bool $more_entropy= false  ]] )
- * Description: Gets a prefixed unique identifier based on the current time in microseconds. 
+ * Description: Gets a prefixed unique identifier based on the current time in microseconds.
  * Source code: ext/standard/uniqid.c
 */
 echo "*** Testing uniqid() : error conditions ***\n";
@@ -17,7 +19,7 @@ var_dump(uniqid($prefix, $more_entropy, $extra_arg));
 echo "\n-- Testing uniqid() function with invalid values for \$prefix --\n";
 class class1{}
 $obj = new class1();
-$res = fopen(__FILE__, "r"); 
+$res = fopen(__FILE__, "r");
 $array = array(1,2,3);
 
 uniqid($array, false);
@@ -28,7 +30,7 @@ fclose($res);
 
 ?>
 ===DONE===
---EXPECTF-- 
+--EXPECTF--
 *** Testing uniqid() : error conditions ***
 
 -- Testing uniqid() function with more than expected no. of arguments --

--- a/ext/standard/tests/network/getprotobynumber_basic.phpt
+++ b/ext/standard/tests/network/getprotobynumber_basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 getprotobynumber function basic test
+--SKIPIF--
+<?php if (!function_exists('getprotobynumber')) die('skip getprotobynumber function not available'); ?>
 --CREDITS--
 edgarsandi - <edgar.r.sandi@gmail.com>
 --FILE--

--- a/ext/standard/tests/network/getprotobynumber_error.phpt
+++ b/ext/standard/tests/network/getprotobynumber_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 getprotobynumber function errors test
+--SKIPIF--
+<?php if (!function_exists('getprotobynumber')) die('skip getprotobynumber function not available'); ?>
 --CREDITS--
 edgarsandi - <edgar.r.sandi@gmail.com>
 --FILE--

--- a/ext/standard/tests/streams/bug46024.phpt
+++ b/ext/standard/tests/streams/bug46024.phpt
@@ -1,10 +1,11 @@
 --TEST--
 Bug #46024 stream_select() doesn't return the correct number
 --SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 <?php if (!getenv('TEST_PHP_EXECUTABLE')) die("skip TEST_PHP_EXECUTABLE not defined"); ?>
 --FILE--
 <?php
-$php = realpath(getenv('TEST_PHP_EXECUTABLE')); 
+$php = realpath(getenv('TEST_PHP_EXECUTABLE'));
 $pipes = array();
 $proc = proc_open(
 	"$php -n -i"

--- a/ext/standard/tests/streams/bug60602.phpt
+++ b/ext/standard/tests/streams/bug60602.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #60602 proc_open() modifies environment if it contains arrays
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 
@@ -17,7 +19,7 @@ $p = proc_open($cmd, $descs, $pipes, '.', $environment);
 if (is_resource($p)) {
 	$data = '';
 
-	while (1) {	
+	while (1) {
 		$w = $e = NULL;
 		$n = stream_select($pipes, $w, $e, 300);
 

--- a/ext/standard/tests/streams/bug61019.phpt
+++ b/ext/standard/tests/streams/bug61019.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #61019 (Out of memory on command stream_get_contents)
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 
@@ -23,17 +25,17 @@ if(is_resource($process))
 	$stdin_stream="";
 	$stderr_stream="";
 
-	echo "External command executed\n";   	
-	do                                     	
+	echo "External command executed\n";
+	do
 	{
 		$process_state=proc_get_status($process);
-		$tmp_stdin=stream_get_contents($pipes[1]);   	
-		if($tmp_stdin) 
+		$tmp_stdin=stream_get_contents($pipes[1]);
+		if($tmp_stdin)
 		{
 			$stdin_stream=$stdin_stream.$tmp_stdin;
 		}
 		$tmp_stderr=stream_get_contents($pipes[2]);
-		if($tmp_stderr) 
+		if($tmp_stderr)
 		{
 			$stderr_stream=$stderr_stream.$tmp_stderr;
 		}
@@ -42,13 +44,13 @@ if(is_resource($process))
 	echo "External command exit: ".$process_state['exitcode']."\n";
 
 	//read outstanding data
-	$tmp_stdin=stream_get_contents($pipes[1]);   	
-	if($tmp_stdin) 
+	$tmp_stdin=stream_get_contents($pipes[1]);
+	if($tmp_stdin)
 	{
 		$stdin_stream=$stdin_stream.$tmp_stdin;
 	}
 	$tmp_stderr=stream_get_contents($pipes[2]);
-	if($tmp_stderr) 
+	if($tmp_stderr)
 	{
 		$stderr_stream=$stderr_stream.$tmp_stderr;
 	}
@@ -57,7 +59,7 @@ if(is_resource($process))
 	fclose ($pipes[1]);
 	fclose ($pipes[2]);
 
-	proc_close($process);    
+	proc_close($process);
 
 	echo "STDOUT: ".$stdin_stream."\n";
 	echo "STDERR: ".$stderr_stream."\n";

--- a/ext/standard/tests/streams/bug64770.phpt
+++ b/ext/standard/tests/streams/bug64770.phpt
@@ -1,5 +1,7 @@
 --TEST--
-Bug #64770 stream_select() fails with pipes from proc_open() 
+Bug #64770 stream_select() fails with pipes from proc_open()
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 
@@ -17,7 +19,7 @@ $p = proc_open($cmd, $descs, $pipes, '.', NULL, $other_opts);
 if (is_resource($p)) {
 	$data = '';
 
-	while (1) {	
+	while (1) {
 		$w = $e = NULL;
 		$n = stream_select($pipes, $w, $e, 300);
 

--- a/ext/standard/tests/streams/bug70198.phpt
+++ b/ext/standard/tests/streams/bug70198.phpt
@@ -2,12 +2,13 @@
 Bug #70198 Checking liveness does not work as expected
 --SKIPIF--
 <?php
+if (!function_exists('proc_open')) die ('skip proc_open function not available');
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>
 --FILE--
 <?php
 
-/* What is checked here is 
+/* What is checked here is
 	- start a server and listen
 	- as soon as client connects, close connection and exit
 	- on the client side - sleep(1) and check feof()
@@ -58,4 +59,3 @@ unlink($srv_fl);
 --EXPECT--
 int(0)
 ==DONE==
-

--- a/ext/standard/tests/streams/proc_open_bug51800_right.phpt
+++ b/ext/standard/tests/streams/proc_open_bug51800_right.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #51800 proc_open on Windows hangs forever, the right way to do it
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 $callee = dirname(__FILE__) . "/process_proc_open_bug51800_right.php";
@@ -75,4 +77,3 @@ array(3) {
 int(10000)
 int(10000)
 ===DONE===
-

--- a/ext/standard/tests/streams/proc_open_bug51800_right2.phpt
+++ b/ext/standard/tests/streams/proc_open_bug51800_right2.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #51800 proc_open on Windows hangs forever, the right way to do it with more data
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 $callee = dirname(__FILE__) . "/process_proc_open_bug51800_right2.php";
@@ -81,4 +83,3 @@ array(3) {
 int(1000000)
 int(1000000)
 ===DONE===
-

--- a/ext/standard/tests/streams/proc_open_bug60120.phpt
+++ b/ext/standard/tests/streams/proc_open_bug60120.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #60120 proc_open hangs with stdin/out with 2048+ bytes
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 error_reporting(E_ALL);
@@ -68,4 +70,3 @@ string(2049) "%s"
 string(0) ""
 string(0) ""
 ===DONE===
-

--- a/ext/standard/tests/streams/proc_open_bug64438.phpt
+++ b/ext/standard/tests/streams/proc_open_bug64438.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #64438 proc_open hangs with stdin/out with 4097+ bytes
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 
@@ -67,4 +69,3 @@ string(4097) "%s"
 string(0) ""
 string(0) ""
 ===DONE===
-

--- a/ext/standard/tests/streams/proc_open_bug69900.phpt
+++ b/ext/standard/tests/streams/proc_open_bug69900.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #69900 Commandline input/output weird behaviour with STDIO
+--SKIPIF--
+<?php if (!function_exists('proc_open')) die ('skip proc_open function not available'); ?>
 --FILE--
 <?php
 
@@ -33,7 +35,7 @@ for($i = 0; $i < 10; $i++){
 	$s = fgets($pipes[1]);
 	$t1 = microtime(1);
 
-	echo $s;		
+	echo $s;
 	echo "fgets() took ", (($t1 - $t0)*1000 > $max_ms ? 'more' : 'less'), " than $max_ms ms\n";
 }
 

--- a/ext/standard/tests/time/bug60222.phpt
+++ b/ext/standard/tests/time/bug60222.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #60222 (time_nanosleep() does validate input params)
+--SKIPIF--
+<?php if (!function_exists('time_nanosleep')) die('skip time_nanosleep function not available'); ?>
 --FILE--
 <?php
 	var_dump(time_nanosleep(-1, 0));

--- a/tests/strings/001.phpt
+++ b/tests/strings/001.phpt
@@ -1,7 +1,9 @@
 --TEST--
 String functions
+--SKIPIF--
+<?php if (!function_exists('uniqid')) die('skip uniqid function not available'); ?>
 --FILE--
-<?php 
+<?php
 
 error_reporting(0);
 


### PR DESCRIPTION
Following #3065. Refs:
`getservbyname`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2894;
`getservbyport`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2873;
`getprotobynumber`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2906;
`time_nanosleep`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2729;
`proc_open`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2873
`gmstrftime`: https://github.com/php/php-src/blob/master/ext/date/php_date.c#L417
`uniqid`: https://github.com/php/php-src/blob/master/ext/standard/basic_functions.c#L2997