### PR TITLE
Clean up .diff, .out and .log from tests

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -113,6 +113,7 @@ clean:
 	find . -name \*.gcno -o -name \*.gcda | xargs rm -f
 	find . -name \*.lo -o -name \*.o | xargs rm -f
 	find . -name \*.la -o -name \*.a | xargs rm -f
+	find . -name \*.diff -o -name \*.out | xargs rm -f
 	find . -name \*.so | xargs rm -f
 	find . -name .libs -a -type d|xargs rm -rf
 	rm -f libphp$(PHP_MAJOR_VERSION).la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(OVERALL_TARGET) modules/* libs/*


### PR DESCRIPTION
AFAICT is safety in clean them, and there are a lot of them usually :sweat_smile: 