### PR TITLE
Remove confusing GD version info

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -1240,7 +1240,7 @@ PHP_RSHUTDOWN_FUNCTION(gd)
 /* }}} */
 
 #if defined(HAVE_GD_BUNDLED)
-#define PHP_GD_VERSION_STRING "bundled (2.1.0 compatible)"
+#define PHP_GD_VERSION_STRING "bundled"
 #else
 # define PHP_GD_VERSION_STRING GD_VERSION_STRING
 #endif

--- a/ext/gd/libgd/gd.h
+++ b/ext/gd/libgd/gd.h
@@ -11,12 +11,6 @@ extern "C" {
 
 #include "php_compat.h"
 
-#define GD_MAJOR_VERSION 2
-#define GD_MINOR_VERSION 0
-#define GD_RELEASE_VERSION 35
-#define GD_EXTRA_VERSION ""
-#define GD_VERSION_STRING "2.0.35"
-
 #ifdef NETWARE
 /* default fontpath for netware systems */
 #define DEFAULT_FONTPATH "sys:/java/nwgfx/lib/x11/fonts/ttf;."


### PR DESCRIPTION
Since the bundled libgd is actually a partially unsynchronized fork of
the upstream project, it does not make sense to use their version
numbers.  Instead of introducing our own version numbers, we don't even
define `GD_VERSION`, `GD_MAJOR_VERSION`, `GD_MINOR_VERSION`,
`GD_RELEASE_VERSION` and `GD_EXTRA_VERSION` anymore.  If users need to
check the version, they could use `GD_BUNDLED` and the PHP version info
– what's likely the only reasonable thing to do already.

We also simplify `phpinfo()` and `gd_info()` to say "bundled" without
any (erroneous) compatibility statement.

See also https://externals.io/message/101744.