### PR TITLE
Remove space between function name and open parentheses

### DIFF
--- a/ext/gettext/gettext.c
+++ b/ext/gettext/gettext.c
@@ -299,7 +299,7 @@ PHP_NAMED_FUNCTION(zif_ngettext)
 #endif
 
 #if HAVE_DNGETTEXT
-/* {{{ proto string dngettext (string domain, string msgid1, string msgid2, int count)
+/* {{{ proto string dngettext(string domain, string msgid1, string msgid2, int count)
    Plural version of dgettext() */
 PHP_NAMED_FUNCTION(zif_dngettext)
 {
@@ -325,7 +325,7 @@ PHP_NAMED_FUNCTION(zif_dngettext)
 #endif
 
 #if HAVE_DCNGETTEXT
-/* {{{ proto string dcngettext (string domain, string msgid1, string msgid2, int n, int category)
+/* {{{ proto string dcngettext(string domain, string msgid1, string msgid2, int n, int category)
    Plural version of dcgettext() */
 PHP_NAMED_FUNCTION(zif_dcngettext)
 {

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -546,7 +546,7 @@ static void php_do_chown(INTERNAL_FUNCTION_PARAMETERS, int do_lchown) /* {{{ */
 /* }}} */
 
 
-/* {{{ proto bool chown (string filename, mixed user)
+/* {{{ proto bool chown(string filename, mixed user)
    Change file owner */
 PHP_FUNCTION(chown)
 {
@@ -554,7 +554,7 @@ PHP_FUNCTION(chown)
 }
 /* }}} */
 
-/* {{{ proto bool chown (string filename, mixed user)
+/* {{{ proto bool chown(string filename, mixed user)
    Change file owner */
 #if HAVE_LCHOWN
 PHP_FUNCTION(lchown)


### PR DESCRIPTION
These were the last cases of spaces in proto open parentheses :smile: 