### PR TITLE
Fix #62548

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -141,7 +141,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_date_sunrise, 0, 0, 1)
 	ZEND_ARG_INFO(0, format)
 	ZEND_ARG_INFO(0, latitude)
 	ZEND_ARG_INFO(0, longitude)
-	ZEND_ARG_INFO(0, zenith)
+	ZEND_ARG_INFO(0, azimuth)
 	ZEND_ARG_INFO(0, gmt_offset)
 ZEND_END_ARG_INFO()
 
@@ -150,7 +150,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_date_sunset, 0, 0, 1)
 	ZEND_ARG_INFO(0, format)
 	ZEND_ARG_INFO(0, latitude)
 	ZEND_ARG_INFO(0, longitude)
-	ZEND_ARG_INFO(0, zenith)
+	ZEND_ARG_INFO(0, azimuth)
 	ZEND_ARG_INFO(0, gmt_offset)
 ZEND_END_ARG_INFO()
 
@@ -571,10 +571,10 @@ int php_date_global_timezone_db_enabled;
 #define DATE_DEFAULT_LONGITUDE "35.2333"
 
 /* on 90'35; common sunset declaration (start of sun body appear) */
-#define DATE_SUNSET_ZENITH "90.583333"
+#define DATE_SUNSET_AZIMUTH "90.583333"
 
 /* on 90'35; common sunrise declaration (sun body disappeared) */
-#define DATE_SUNRISE_ZENITH "90.583333"
+#define DATE_SUNRISE_AZIMUTH "90.583333"
 
 static PHP_INI_MH(OnUpdate_date_timezone);
 
@@ -583,8 +583,8 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("date.timezone", "", PHP_INI_ALL, OnUpdate_date_timezone, default_timezone, zend_date_globals, date_globals)
 	PHP_INI_ENTRY("date.default_latitude",           DATE_DEFAULT_LATITUDE,        PHP_INI_ALL, NULL)
 	PHP_INI_ENTRY("date.default_longitude",          DATE_DEFAULT_LONGITUDE,       PHP_INI_ALL, NULL)
-	PHP_INI_ENTRY("date.sunset_zenith",              DATE_SUNSET_ZENITH,           PHP_INI_ALL, NULL)
-	PHP_INI_ENTRY("date.sunrise_zenith",             DATE_SUNRISE_ZENITH,          PHP_INI_ALL, NULL)
+	PHP_INI_ENTRY("date.sunset_azimuth",              DATE_SUNSET_AZIMUTH,           PHP_INI_ALL, NULL)
+	PHP_INI_ENTRY("date.sunrise_azimuth",             DATE_SUNRISE_AZIMUTH,          PHP_INI_ALL, NULL)
 PHP_INI_END()
 /* }}} */
 
@@ -4850,7 +4850,7 @@ PHP_FUNCTION(date_default_timezone_get)
  */
 static void php_do_date_sunrise_sunset(INTERNAL_FUNCTION_PARAMETERS, int calc_sunset)
 {
-	double latitude = 0.0, longitude = 0.0, zenith = 0.0, gmt_offset = 0, altitude;
+	double latitude = 0.0, longitude = 0.0, azimuth = 0.0, gmt_offset = 0, altitude;
 	double h_rise, h_set, N;
 	timelib_sll rise, set, transit;
 	zend_long time, retformat = 0;
@@ -4865,7 +4865,7 @@ static void php_do_date_sunrise_sunset(INTERNAL_FUNCTION_PARAMETERS, int calc_su
 		Z_PARAM_LONG(retformat)
 		Z_PARAM_DOUBLE(latitude)
 		Z_PARAM_DOUBLE(longitude)
-		Z_PARAM_DOUBLE(zenith)
+		Z_PARAM_DOUBLE(azimuth)
 		Z_PARAM_DOUBLE(gmt_offset)
 	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
@@ -4878,9 +4878,9 @@ static void php_do_date_sunrise_sunset(INTERNAL_FUNCTION_PARAMETERS, int calc_su
 			longitude = INI_FLT("date.default_longitude");
 		case 4:
 			if (calc_sunset) {
-				zenith = INI_FLT("date.sunset_zenith");
+				azimuth = INI_FLT("date.sunset_azimuth");
 			} else {
-				zenith = INI_FLT("date.sunrise_zenith");
+				azimuth = INI_FLT("date.sunrise_azimuth");
 			}
 		case 5:
 		case 6:
@@ -4897,7 +4897,7 @@ static void php_do_date_sunrise_sunset(INTERNAL_FUNCTION_PARAMETERS, int calc_su
 		php_error_docref(NULL, E_WARNING, "Wrong return format given, pick one of SUNFUNCS_RET_TIMESTAMP, SUNFUNCS_RET_STRING or SUNFUNCS_RET_DOUBLE");
 		RETURN_FALSE;
 	}
-	altitude = 90 - zenith;
+	altitude = 90 - azimuth;
 
 	/* Initialize time struct */
 	t = timelib_time_ctor();
@@ -4938,7 +4938,7 @@ static void php_do_date_sunrise_sunset(INTERNAL_FUNCTION_PARAMETERS, int calc_su
 }
 /* }}} */
 
-/* {{{ proto mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* {{{ proto mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
    Returns time of sunrise for a given day and location */
 PHP_FUNCTION(date_sunrise)
 {
@@ -4946,7 +4946,7 @@ PHP_FUNCTION(date_sunrise)
 }
 /* }}} */
 
-/* {{{ proto mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* {{{ proto mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
    Returns time of sunset for a given day and location */
 PHP_FUNCTION(date_sunset)
 {

--- a/ext/date/tests/date_sunrise_error.phpt
+++ b/ext/date/tests/date_sunrise_error.phpt
@@ -2,7 +2,7 @@
 Test date_sunrise() function : error conditions 
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  */
@@ -13,7 +13,7 @@ echo "*** Testing date_sunrise() : error conditions ***\n";
 $time = time();
 $latitude = 38.4;
 $longitude = -9;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 1;
 $extra_arg = 10;
 
@@ -23,7 +23,7 @@ var_dump( date_sunrise() );
 
 //Test date_sunrise with one more than the expected number of arguments
 echo "\n-- Testing date_sunrise() function with more than expected no. of arguments --\n";
-var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $gmt_offset, $extra_arg) );
+var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $gmt_offset, $extra_arg) );
 ?>
 ===DONE===
 --EXPECTF--

--- a/ext/date/tests/date_sunrise_variation1.phpt
+++ b/ext/date/tests/date_sunrise_variation1.phpt
@@ -2,7 +2,7 @@
 Test date_sunrise() function : usage variation - Passing unexpected values to first argument time.
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  */
@@ -12,7 +12,7 @@ echo "*** Testing date_sunrise() : usage variation ***\n";
 //Initialise the variables
 $latitude = 38.4;
 $longitude = -9;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 1;
 $format = SUNFUNCS_RET_STRING;
 date_default_timezone_set("Asia/Calcutta");
@@ -97,9 +97,9 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunrise($value, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $gmt_offset) );
-      var_dump( date_sunrise($value, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $zenith, $gmt_offset) );
-      var_dump( date_sunrise($value, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $zenith, $gmt_offset) );
+      var_dump( date_sunrise($value, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $gmt_offset) );
+      var_dump( date_sunrise($value, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $azimuth, $gmt_offset) );
+      var_dump( date_sunrise($value, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $azimuth, $gmt_offset) );
 };
 
 ?>

--- a/ext/date/tests/date_sunrise_variation2.phpt
+++ b/ext/date/tests/date_sunrise_variation2.phpt
@@ -4,7 +4,7 @@ Test date_sunrise() function : usage variation - Passing unexpected values to se
 <?php if (PHP_INT_SIZE != 4) echo "skip this test is for 32-bit only"; ?>
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -17,7 +17,7 @@ date_default_timezone_set("Asia/Calcutta");
 $time = mktime(8, 8, 8, 8, 8, 2008);
 $latitude = 38.4;
 $longitude = -9;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 1;
 
 //get an unset variable
@@ -96,7 +96,7 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunrise($time, $value, $latitude, $longitude, $zenith, $gmt_offset) );
+      var_dump( date_sunrise($time, $value, $latitude, $longitude, $azimuth, $gmt_offset) );
 };
 
 ?>

--- a/ext/date/tests/date_sunrise_variation3.phpt
+++ b/ext/date/tests/date_sunrise_variation3.phpt
@@ -2,7 +2,7 @@
 Test date_sunrise() function : usage variation - Passing unexpected values to third argument latitude.
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  */
@@ -13,7 +13,7 @@ echo "*** Testing date_sunrise() : usage variation ***\n";
 date_default_timezone_set("Asia/Calcutta");
 $time = mktime(8, 8, 8, 8, 8, 2008);
 $longitude = -9;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = -5.5;
 
 //get an unset variable
@@ -91,9 +91,9 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $value, $longitude, $zenith, $gmt_offset) );
-      var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $value, $longitude, $zenith, $gmt_offset) );
-      var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $value, $longitude, $zenith, $gmt_offset) );
+      var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $value, $longitude, $azimuth, $gmt_offset) );
+      var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $value, $longitude, $azimuth, $gmt_offset) );
+      var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $value, $longitude, $azimuth, $gmt_offset) );
 };
 ?>
 ===DONE===

--- a/ext/date/tests/date_sunrise_variation4.phpt
+++ b/ext/date/tests/date_sunrise_variation4.phpt
@@ -2,7 +2,7 @@
 Test date_sunrise() function : usage variation - Passing unexpected values to fourth argument longitude.
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -14,7 +14,7 @@ echo "*** Testing date_sunrise() : usage variation ***\n";
 date_default_timezone_set("Asia/Calcutta");
 $time = mktime(8, 8, 8, 8, 8, 2008);
 $latitude = 38.4;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 0;
 
 //get an unset variable
@@ -92,9 +92,9 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $value, $zenith, $gmt_offset) );
-      var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $value, $zenith, $gmt_offset) );
-      var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $value, $zenith, $gmt_offset) );
+      var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $value, $azimuth, $gmt_offset) );
+      var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $value, $azimuth, $gmt_offset) );
+      var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $value, $azimuth, $gmt_offset) );
 };
 
 ?>

--- a/ext/date/tests/date_sunrise_variation5.phpt
+++ b/ext/date/tests/date_sunrise_variation5.phpt
@@ -1,8 +1,8 @@
 --TEST--
-Test date_sunrise() function : usage variation - Passing unexpected values to fifth argument zenith
+Test date_sunrise() function : usage variation - Passing unexpected values to fifth argument azimuth
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -88,7 +88,7 @@ $inputs = array(
       'unset var' => @$unset_var,
 );
 
-// loop through each element of the array for zenith
+// loop through each element of the array for azimuth
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";

--- a/ext/date/tests/date_sunrise_variation6.phpt
+++ b/ext/date/tests/date_sunrise_variation6.phpt
@@ -2,7 +2,7 @@
 Test date_sunrise() function : usage variation - Passing unexpected values to sixth argument gmt_offset.
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -14,7 +14,7 @@ date_default_timezone_set("Asia/Calcutta");
 $time = mktime(8, 8, 8, 8, 8, 2008);
 $latitude = 38.4;
 $longitude = -9;
-$zenith = 90;
+$azimuth = 90;
 
 //get an unset variable
 $unset_var = 10;
@@ -91,9 +91,9 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $value) );
-      var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $zenith, $value) );
-      var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $zenith, $value) );
+      var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $value) );
+      var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $azimuth, $value) );
+      var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $azimuth, $value) );
 };
 
 ?>

--- a/ext/date/tests/date_sunrise_variation7.phpt
+++ b/ext/date/tests/date_sunrise_variation7.phpt
@@ -2,7 +2,7 @@
 Test date_sunrise() function : usage variation -  Checking sunrise for consecutive days in specific timezone
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 

--- a/ext/date/tests/date_sunrise_variation8.phpt
+++ b/ext/date/tests/date_sunrise_variation8.phpt
@@ -2,7 +2,7 @@
 Test date_sunrise() function : usage variation -  Checking with North and South poles when Sun is up and down all day
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 

--- a/ext/date/tests/date_sunrise_variation9.phpt
+++ b/ext/date/tests/date_sunrise_variation9.phpt
@@ -4,7 +4,7 @@ Test date_sunrise() function : usage variation -  Passing high positive and nega
 <?php if (PHP_INT_SIZE != 4) echo "skip this test is for 32-bit only"; ?>
 --FILE--
 <?php
-/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunrise(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -17,20 +17,20 @@ date_default_timezone_set("Asia/Calcutta");
 //Initialise the variables
 $latitude = 38.4;
 $longitude = -9;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 1;
 
 echo "\n-- Testing date_sunrise() function by passing float 12.3456789000e10 value to time --\n";
 $time = 12.3456789000e10;
-var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $zenith, $gmt_offset) );
+var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $gmt_offset) );
+var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $azimuth, $gmt_offset) );
+var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $azimuth, $gmt_offset) );
 
 echo "\n-- Testing date_sunrise() function by passing float -12.3456789000e10 value to time --\n";
 $time = -12.3456789000e10;
-var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $zenith, $gmt_offset) );
+var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $gmt_offset) );
+var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $azimuth, $gmt_offset) );
+var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $azimuth, $gmt_offset) );
 
 ?>
 ===DONE===

--- a/ext/date/tests/date_sunset_error.phpt
+++ b/ext/date/tests/date_sunset_error.phpt
@@ -2,7 +2,7 @@
 Test date_sunset() function : error conditions 
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunset for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -14,7 +14,7 @@ echo "*** Testing date_sunset() : error conditions ***\n";
 $time = time();
 $latitude = 38.4;
 $longitude = -9;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 1;
 $extra_arg = 10;
 
@@ -24,9 +24,9 @@ var_dump( date_sunset() );
 
 //Test date_sunset with one more than the expected number of arguments
 echo "\n-- Testing date_sunset() function with more than expected no. of arguments --\n";
-var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $gmt_offset, $extra_arg) );
-var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $zenith, $gmt_offset, $extra_arg) );
-var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $zenith, $gmt_offset, $extra_arg) );
+var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $gmt_offset, $extra_arg) );
+var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $azimuth, $gmt_offset, $extra_arg) );
+var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $azimuth, $gmt_offset, $extra_arg) );
 ?>
 ===DONE===
 --EXPECTF--

--- a/ext/date/tests/date_sunset_variation1.phpt
+++ b/ext/date/tests/date_sunset_variation1.phpt
@@ -2,7 +2,7 @@
 Test date_sunset() function : usage variation - Passing unexpected values to first argument time.
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunset for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -13,7 +13,7 @@ echo "*** Testing date_sunset() : usage variation ***\n";
 //Initialise the variables
 $latitude = 38.4;
 $longitude = -9;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 1;
 date_default_timezone_set("Asia/Calcutta");
 
@@ -97,9 +97,9 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunset($value, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $gmt_offset) );
-      var_dump( date_sunset($value, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $zenith, $gmt_offset) );
-      var_dump( date_sunset($value, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $zenith, $gmt_offset) );
+      var_dump( date_sunset($value, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $gmt_offset) );
+      var_dump( date_sunset($value, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $azimuth, $gmt_offset) );
+      var_dump( date_sunset($value, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $azimuth, $gmt_offset) );
 };
 
 ?>

--- a/ext/date/tests/date_sunset_variation2.phpt
+++ b/ext/date/tests/date_sunset_variation2.phpt
@@ -4,7 +4,7 @@ Test date_sunset() function : usage variation - Passing unexpected values to sec
 <?php if (PHP_INT_SIZE != 4) echo "skip this test is for 32-bit only"; ?>
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunset for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -17,7 +17,7 @@ date_default_timezone_set("Asia/Calcutta");
 $time = mktime(8, 8, 8, 8, 8, 2008);
 $latitude = 22.34;
 $longitude = 88.21;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 5.5;
 
 //get an unset variable
@@ -96,7 +96,7 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunset($time, $value, $latitude, $longitude, $zenith, $gmt_offset) );
+      var_dump( date_sunset($time, $value, $latitude, $longitude, $azimuth, $gmt_offset) );
 };
 
 ?>

--- a/ext/date/tests/date_sunset_variation3.phpt
+++ b/ext/date/tests/date_sunset_variation3.phpt
@@ -2,7 +2,7 @@
 Test date_sunset() function : usage variation - Passing unexpected values to third argument latitude.
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunset for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -14,7 +14,7 @@ echo "*** Testing date_sunset() : usage variation ***\n";
 date_default_timezone_set("Asia/Calcutta");
 $time = mktime(8, 8, 8, 8, 8, 2008);
 $longitude = 88.21;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 5.5;
 
 //get an unset variable
@@ -92,9 +92,9 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $value, $longitude, $zenith, $gmt_offset) );
-      var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $value, $longitude, $zenith, $gmt_offset) );
-      var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $value, $longitude, $zenith, $gmt_offset) );
+      var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $value, $longitude, $azimuth, $gmt_offset) );
+      var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $value, $longitude, $azimuth, $gmt_offset) );
+      var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $value, $longitude, $azimuth, $gmt_offset) );
       
 };
 

--- a/ext/date/tests/date_sunset_variation4.phpt
+++ b/ext/date/tests/date_sunset_variation4.phpt
@@ -2,7 +2,7 @@
 Test date_sunset() function : usage variation - Passing unexpected values to fourth argument longitude.
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunset for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -14,7 +14,7 @@ echo "*** Testing date_sunset() : usage variation ***\n";
 date_default_timezone_set("Asia/Calcutta");
 $time = mktime(8, 8, 8, 8, 8, 2008);
 $latitude = 22.34;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 5.5;
 
 //get an unset variable
@@ -92,9 +92,9 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $value, $zenith, $gmt_offset) );
-      var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $value, $zenith, $gmt_offset) );
-      var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $value, $zenith, $gmt_offset) );
+      var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $value, $azimuth, $gmt_offset) );
+      var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $value, $azimuth, $gmt_offset) );
+      var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $value, $azimuth, $gmt_offset) );
 };
 
 ?>

--- a/ext/date/tests/date_sunset_variation5.phpt
+++ b/ext/date/tests/date_sunset_variation5.phpt
@@ -1,8 +1,8 @@
 --TEST--
-Test date_sunset() function : usage variation - Passing unexpected values to fifth argument zenith.
+Test date_sunset() function : usage variation - Passing unexpected values to fifth argument azimuth.
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunset for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -88,7 +88,7 @@ $inputs = array(
       'unset var' => @$unset_var,
 );
 
-// loop through each element of the array for zenith
+// loop through each element of the array for azimuth
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";

--- a/ext/date/tests/date_sunset_variation6.phpt
+++ b/ext/date/tests/date_sunset_variation6.phpt
@@ -2,7 +2,7 @@
 Test date_sunset() function : usage variation - Passing unexpected values to sixth argument gmt_offset.
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunset for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -15,7 +15,7 @@ date_default_timezone_set("Asia/Calcutta");
 $time = mktime(8, 8, 8, 8, 8, 2008);
 $longitude = 88.21;
 $latitude = 22.34;
-$zenith = 90;
+$azimuth = 90;
 
 //get an unset variable
 $unset_var = 10;
@@ -92,9 +92,9 @@ $inputs = array(
 
 foreach($inputs as $key =>$value) {
       echo "\n--$key--\n";
-      var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $value) );
-      var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $zenith, $value) );
-      var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $zenith, $value) );
+      var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $value) );
+      var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $azimuth, $value) );
+      var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $azimuth, $value) );
 };
 
 ?>

--- a/ext/date/tests/date_sunset_variation7.phpt
+++ b/ext/date/tests/date_sunset_variation7.phpt
@@ -2,7 +2,7 @@
 Test date_sunset() function : usage variation -  Checking sunrise for consecutive days in specific timezone
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 

--- a/ext/date/tests/date_sunset_variation8.phpt
+++ b/ext/date/tests/date_sunset_variation8.phpt
@@ -2,7 +2,7 @@
 Test date_sunset() function : usage variation -  Checking with North and South poles when Sun is up and down all day
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunrise for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 

--- a/ext/date/tests/date_sunset_variation9.phpt
+++ b/ext/date/tests/date_sunset_variation9.phpt
@@ -4,7 +4,7 @@ Test date_sunset() function : usage variation - Passing high positive and negati
 <?php if (PHP_INT_SIZE != 4) echo "skip this test is for 32-bit only"; ?>
 --FILE--
 <?php
-/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float zenith [, float gmt_offset]]]]])
+/* Prototype  : mixed date_sunset(mixed time [, int format [, float latitude [, float longitude [, float azimuth [, float gmt_offset]]]]])
  * Description: Returns time of sunset for a given day and location 
  * Source code: ext/date/php_date.c
  * Alias to functions: 
@@ -17,20 +17,20 @@ date_default_timezone_set("Asia/Calcutta");
 //Initialise the variables
 $latitude = 38.4;
 $longitude = -9;
-$zenith = 90;
+$azimuth = 90;
 $gmt_offset = 1;
 
 echo "\n-- Testing date_sunset() function by passing float 12.3456789000e10 value to time --\n";
 $time = 12.3456789000e10;
-var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $zenith, $gmt_offset) );
+var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $gmt_offset) );
+var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $azimuth, $gmt_offset) );
+var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $azimuth, $gmt_offset) );
 
 echo "\n-- Testing date_sunset() function by passing float -12.3456789000e10 value to time --\n";
 $time = -12.3456789000e10;
-var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $zenith, $gmt_offset) );
+var_dump( date_sunset($time, SUNFUNCS_RET_STRING, $latitude, $longitude, $azimuth, $gmt_offset) );
+var_dump( date_sunset($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude, $azimuth, $gmt_offset) );
+var_dump( date_sunset($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude, $azimuth, $gmt_offset) );
 
 ?>
 ===DONE===

--- a/ext/reflection/tests/026.phpt
+++ b/ext/reflection/tests/026.phpt
@@ -29,7 +29,7 @@ Directive => %s => %s
 date.timezone => %s => %s
 date.default_latitude => %s => %s
 date.default_longitude => %s => %s
-date.sunset_zenith => %s => %s
-date.sunrise_zenith => %s => %s
+date.sunset_azimuth => %s => %s
+date.sunrise_azimuth => %s => %s
 
 Done!


### PR DESCRIPTION
> The 3rd term in date-sunset and date-sunrise should be called 'azimuth', which is used in the sunrise, sunset calculations to tell if the bearing of the sun from the observer is East or West of North.

I even watch a video to confirm this https://www.youtube.com/watch?v=OR8EQ0DWpPw :smile: 

(PS: If this gets approved, how should I proceed to fix our documentation?)