### PR TITLE
Fix #75932: zend_user_opcode_handlers crash

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7295,7 +7295,12 @@ ZEND_VM_HANDLER(150, ZEND_USER_OPCODE, ANY, ANY)
 	int ret;
 
 	SAVE_OPLINE();
-	ret = zend_user_opcode_handlers[opline->opcode](execute_data);
+	/* Check that a user handler has been set */
+	if (EXPECTED(zend_user_opcode_handlers[opline->opcode] != NULL)) {
+		ret = zend_user_opcode_handlers[opline->opcode](execute_data);
+	} else {
+		ret = ZEND_USER_OPCODE_DISPATCH;
+	}
 	opline = EX(opline);
 
 	switch (ret) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1800,7 +1800,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_USER_OPCODE_SPEC_HANDLER(ZEND_
 	int ret;
 
 	SAVE_OPLINE();
-	ret = zend_user_opcode_handlers[opline->opcode](execute_data);
+	/* Check that a user handler has been set */
+	if (EXPECTED(zend_user_opcode_handlers[opline->opcode] != NULL)) {
+		ret = zend_user_opcode_handlers[opline->opcode](execute_data);
+	} else {
+		ret = ZEND_USER_OPCODE_DISPATCH;
+	}
 	opline = EX(opline);
 
 	switch (ret) {


### PR DESCRIPTION
Only call a user_opcode_handler if it has been set, otherwise call the
original opcode handler. When using opcache, a user handler will not be
set if the cache was created by an extension that used its own handlers,
then hit later by a process not using the extension. Also fixes #75886.