### PR TITLE
Fix #65547: Default value for sunrise/sunset zenith still wrong

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -559,11 +559,11 @@ int php_date_global_timezone_db_enabled;
 #define DATE_DEFAULT_LATITUDE "31.7667"
 #define DATE_DEFAULT_LONGITUDE "35.2333"
 
-/* on 90'35; common sunset declaration (start of sun body appear) */
-#define DATE_SUNSET_ZENITH "90.583333"
+/* on 90'50; common sunset declaration (start of sun body appear) */
+#define DATE_SUNSET_ZENITH "90.833333"
 
-/* on 90'35; common sunrise declaration (sun body disappeared) */
-#define DATE_SUNRISE_ZENITH "90.583333"
+/* on 90'50; common sunrise declaration (sun body disappeared) */
+#define DATE_SUNRISE_ZENITH "90.833333"
 
 static PHP_INI_MH(OnUpdate_date_timezone);
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -945,10 +945,10 @@ cli_server.color = On
 ;date.default_longitude = 35.2333
 
 ; http://php.net/date.sunrise-zenith
-;date.sunrise_zenith = 90.583333
+;date.sunrise_zenith = 90.833333
 
 ; http://php.net/date.sunset-zenith
-;date.sunset_zenith = 90.583333
+;date.sunset_zenith = 90.833333
 
 [filter]
 ; http://php.net/filter.default

--- a/php.ini-production
+++ b/php.ini-production
@@ -945,10 +945,10 @@ cli_server.color = On
 ;date.default_longitude = 35.2333
 
 ; http://php.net/date.sunrise-zenith
-;date.sunrise_zenith = 90.583333
+;date.sunrise_zenith = 90.833333
 
 ; http://php.net/date.sunset-zenith
-;date.sunset_zenith = 90.583333
+;date.sunset_zenith = 90.833333
 
 [filter]
 ; http://php.net/filter.default


### PR DESCRIPTION
The value of the zenith angle to calculate sunrise and sunset times is
commonly defined as 90°50', and is "obtained by adding the average
apparent radius of the Sun (16') to the average amount of atmospheric
refraction at the horizon (34')", according to
http://aa.usno.navy.mil/faq/docs/RST_defs.php.

This value is also used for the Sunrise/Sunset Algorithm published in
the Almanac for Computers, 1990, see
https://web.archive.org/web/20161202180207/http://williams.best.vwh.net/sunrise_sunset_algorithm.htm.