### PR TITLE
Test ReflectionClass::getReflectionConstant method

### DIFF
--- a/ext/reflection/tests/ReflectionClass_getReflectionConstant.phpt
+++ b/ext/reflection/tests/ReflectionClass_getReflectionConstant.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test ReflectionClass::getReflectionConstant method
+--CREDITS--
+Gabriel Caruso (carusogabriel34@gmail.com)
+--FILE--
+<?php
+$refleClass = new ReflectionClass(ReflectionClass::class);
+var_dump(gettype($refleClass->getReflectionConstant('IS_IMPLICIT_ABSTRACT')));
+var_dump($refleClass->getReflectionConstant('FOO_BAR'));
+?>
+--EXPECT--
+string(6) "object"
+bool(false)


### PR DESCRIPTION
Several `zpp` fail [weren't being tested](http://gcov.php.net/PHP_HEAD/lcov_html/ext/reflection/php_reflection.c.gcov.php)

PS: As commented in https://github.com/php/php-src/commit/26af57592665c7cbfdaa7cca1a69c72359e24425#commitcomment-27510157, `ReflectionZendExtension` isn't been test, but I couldn't configure my environment to enable Opcache. How should I do it?