### PR TITLE
Rework valgrind support detection (fixes #75722)

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -3249,23 +3249,3 @@ AC_DEFUN([PHP_CHECK_BUILTIN_SSUBLL_OVERFLOW], [
 
 dnl Load the AX_CHECK_COMPILE_FLAG macro from the autoconf archive.
 m4_include([build/ax_check_compile_flag.m4])
-
-dnl PHP_CHECK_VALGRIND
-AC_DEFUN([PHP_CHECK_VALGRIND], [
-  AC_MSG_CHECKING([for valgrind])
-
-  SEARCH_PATH="/usr/local /usr"
-  SEARCH_FOR="/include/valgrind/valgrind.h"
-  for i in $SEARCH_PATH ; do
-    if test -r $i/$SEARCH_FOR; then
-      VALGRIND_DIR=$i
-    fi
-  done
-
-  if test -z "$VALGRIND_DIR"; then
-    AC_MSG_RESULT([not found])
-  else
-    AC_MSG_RESULT(found in $VALGRIND_DIR)
-    AC_DEFINE(HAVE_VALGRIND, 1, [ ])
-  fi
-])

--- a/configure.ac
+++ b/configure.ac
@@ -753,7 +753,36 @@ if test "x$php_crypt_r" = "x1"; then
   PHP_CRYPT_R_STYLE
 fi
 
-PHP_CHECK_VALGRIND
+dnl Check valgrind support
+PHP_ARG_WITH(valgrind-support, [whether to enable valgrind support],
+[  --with-valgrind-support=DIR
+                          Enable valgrind support], DEFAULT, no)
+
+if test "$PHP_VALGRIND_SUPPORT" != "no"; then
+
+  AC_MSG_CHECKING([for valgrind header])
+
+  if test "$PHP_VALGRIND_SUPPORT" = "DEFAULT" || test "$PHP_VALGRIND_SUPPORT" = "yes"; then
+    SEARCH_PATH="/usr/local /usr"
+  else
+    SEARCH_PATH="$PHP_VALGRIND_SUPPORT"
+  fi
+
+  SEARCH_FOR="/include/valgrind/valgrind.h"
+  for i in $SEARCH_PATH ; do
+    if test -r $i/$SEARCH_FOR; then
+      VALGRIND_DIR=$i
+    fi
+  done
+
+  if test -z "$VALGRIND_DIR"; then
+    AC_MSG_RESULT([not found])
+  else
+    AC_MSG_RESULT(found in $VALGRIND_DIR)
+    AC_DEFINE(HAVE_VALGRIND, 1, [ ])
+  fi
+
+fi
 
 dnl General settings.
 dnl -------------------------------------------------------------------------


### PR DESCRIPTION
As described in bug report #75722, the configure script (acinclude.m4)
currently searches for valgrind header file and enables valgrin support
if found.

When cross-compiling the searched paths are invalid for the target
platform because they belong to the host system. At the moment, there is
no way to tell the build system a dedicated path where to look for the
header file.

This leads to the issue, that when cross-compiling eg. for ARMv5 platform,
that valgrind header file is detected - e.g. because host system is amd64 -
and support is enabled - but target platform will never support valgrind
(valgrind requires e.g. at least ARMv7).

This change reworks the detection so that user could manually opt-in
valgrind support and optionally specify a directory where the build system
should look for the header file.