### PR TITLE
Remove superfluous SKIPIF sections

### DIFF
--- a/ext/mbstring/tests/mb_split.phpt
+++ b/ext/mbstring/tests/mb_split.phpt
@@ -3,7 +3,6 @@ mb_split()
 --SKIPIF--
 <?php
 extension_loaded('mbstring') or die('skip mbstring not available');
-extension_loaded('pcre') or die('skip pcre not available');
 function_exists('mb_split') or die("skip mb_split() is not available in this build");
 ?>
 --INI--
@@ -21,7 +20,7 @@ mbstring.func_overload=0
 			print "ok\n";
 		} else {
 			print count($result1).'-'.count($result2)."\n";
-		}	
+		}
 	}
 
 	var_dump( mb_split( " ", "a b c d e f g" )
@@ -46,4 +45,3 @@ ok
 2-2
 3-3
 4-4
-

--- a/ext/spl/tests/bug70868.phpt
+++ b/ext/spl/tests/bug70868.phpt
@@ -2,8 +2,6 @@
 Bug #70868, with PCRE JIT
 --INI--
 pcre.jit=1
---SKIPIF--
-<?php if (!extension_loaded("pcre")) die("skip"); ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
Following #3062, `pcre` extension is always available, even with `--disable-all`. This check in `run-tests.php` should also be removed?
https://github.com/php/php-src/blob/5a4ff9f1a92c167bd7cd202994581864af99f43e/run-tests.php#L43-L52 