### PR TITLE
Fixed print_const_table function and zval types in ____printzv_contents

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -171,7 +171,7 @@ define ____printzv_contents
 		printf "UNDEF"
 	end
 	if $type == 1
-        printf "NULL"
+		printf "NULL"
 	end
 	if $type == 2
 		printf "bool: false"
@@ -179,15 +179,15 @@ define ____printzv_contents
 	if $type == 3
 		printf "bool: true"
 	end
-    if $type == 4
+	if $type == 4
 		printf "long: %ld", $zvalue->value.lval
-    end
-    if $type == 5
-        printf "double: %f", $zvalue->value.dval
-    end
-    if $type == 6
-       printf "string: %s", $zvalue->value.str->val
-    end
+	end
+	if $type == 5
+		printf "double: %f", $zvalue->value.dval
+	end
+	if $type == 6
+		printf "string: %s", $zvalue->value.str->val
+	end
 	if $type == 7 
 		printf "array: "
 		if ! $arg1
@@ -245,25 +245,31 @@ define ____printzv_contents
 		printf "const: %s", $zvalue->value.str->val
 	end
 	if $type == 12
-		printf "const_ast"
+		printf "CONSTANT_AST"
 	end
 	if $type == 13
-		printf "_IS_BOOL"
+		printf "_BOOL"
 	end
 	if $type == 14
-		printf "IS_CALLABLE"
+		printf "CALLABLE"
 	end
 	if $type == 15
 		printf "indirect: "
 		____printzv $zvalue->value.zv $arg1
 	end
-	if $type == 16
-		printf "string_offset"
-	end
 	if $type == 17
 		printf "pointer: %p", $zvalue->value.ptr
 	end
-	if $type > 17
+	if $type == 18
+		printf "ITERABLE"
+	end
+	if $type == 19
+		printf "VOID"
+	end
+	if $type == 20
+		printf "_ERROR"
+	end
+	if $type == 16 || $type > 20
 		printf "unknown type %d", $type
 	end
 	printf "\n"
@@ -283,36 +289,16 @@ define ____printzv
 	end
 end
 
-define ____print_const_table
-	set $ht = $arg0
-	set $p = $ht->pListHead
-
-	while $p != 0
-		set $const = (zend_constant *) $p->pData
-
-		set $i = $ind
-		while $i > 0
-			printf "  "
-			set $i = $i - 1
-		end
-
-		if $p->nKeyLength > 0
-			____print_str $p->arKey $p->nKeyLength
-			printf " => "
-		else
-			printf "%d => ", $p->h
-		end
-
-		____printzv_contents &$const->value 0
-		set $p = $p->pListNext
-	end
-end
-
 define print_const_table
 	set $ind = 1
 	printf "[%p] {\n", $arg0
-	____print_const_table $arg0
+	____print_ht $arg0 4
 	printf "}\n"
+end
+
+document print_const_table
+	Dumps elements of Constants HashTable
+	Example: print_const_table executor_globals.zend_constants
 end
 
 define ____print_ht
@@ -360,6 +346,10 @@ define ____print_ht
 			if $arg1 == 3
 				set $func = (zend_function*)$p->val.value.ptr
 				printf "\"%s\"\n", $func->common.function_name->val
+			end
+			if $arg1 == 4
+				set $const = (zend_constant *)$p->val.value.ptr
+				____printzv $const 1
 			end
 		end
 		set $i = $i + 1


### PR DESCRIPTION
1. Fixed print_const_table to work in ZE3
2. Removed ____print_const_table to use more generic ____print_ht
3. Fixed up zval types in ____printzv_contents

Example:
```
(gdb) print_const_table executor_globals.zend_constants
[0x239f870] {
  Hash(2293)[0x239f870]: {
    [0] E_ERROR => [0x23b4b50] long: 1
    [1] E_RECOVERABLE_ERROR => [0x23b5d90] long: 4096
    [2] E_WARNING => [0x23b5df0] long: 2
    [3] E_PARSE => [0x23b5e50] long: 4
    [4] E_NOTICE => [0x23b5eb0] long: 8
    [5] E_STRICT => [0x23b5f10] long: 2048
    [6] E_DEPRECATED => [0x23b5f70] long: 8192
```