### PR TITLE
Fix: follow the indent of the other configure options

### DIFF
--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -101,7 +101,7 @@ PHP_ARG_WITH(tcadb,,
 [  --with-tcadb[=DIR]        DBA: Tokyo Cabinet abstract DB support], no, no)
 
 PHP_ARG_WITH(lmdb,,
-[  --with-lmdb[=DIR]        DBA: Lightning memory-mapped database support], no, no)
+[  --with-lmdb[=DIR]         DBA: Lightning memory-mapped database support], no, no)
 
 
 dnl

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -11,7 +11,7 @@ PHP_ARG_WITH(gd, for GD support,
                           install directory [BUNDLED]])
 if test -z "$PHP_WEBP_DIR"; then
   PHP_ARG_WITH(webp-dir, for the location of libwebp,
-  [  --with-webp-dir[=DIR]      GD: Set the path to libwebp install prefix], no, no)
+  [  --with-webp-dir[=DIR]     GD: Set the path to libwebp install prefix], no, no)
 fi
 
 if test -z "$PHP_JPEG_DIR"; then

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -102,7 +102,7 @@ dnl
 
 PHP_ARG_WITH(odbcver,,
 [  --with-odbcver[=HEX]      Force support for the passed ODBC version. A hex number is expected, default 0x0350.
-                             Use the special value of 0 to prevent an explicit ODBCVER to be defined. ], 0x0350)
+                          Use the special value of 0 to prevent an explicit ODBCVER to be defined. ], 0x0350)
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(adabas,,
@@ -246,8 +246,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH(empress-bcs,,
-[  --with-empress-bcs[=DIR]
-                          Include Empress Local Access support [\$EMPRESSPATH]
+[  --with-empress-bcs[=DIR]  Include Empress Local Access support [\$EMPRESSPATH]
                           (Empress Version >= 8.60 required)])
 
   AC_MSG_CHECKING(for Empress local access support)

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -2,7 +2,7 @@ dnl $Id$
 dnl config.m4 for extension sodium
 
 PHP_ARG_WITH(sodium, for sodium support,
-[  --with-sodium[=DIR]     Include sodium support])
+[  --with-sodium[=DIR]       Include sodium support])
 
 if test "$PHP_SODIUM" != "no"; then
   SEARCH_PATH="/usr/local /usr"     # you might want to change this

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -413,7 +413,8 @@ dnl
 dnl Check for argon2
 dnl
 PHP_ARG_WITH(password-argon2, for Argon2 support,
-[  --with-password-argon2[=DIR]           Include Argon2 support in password_*. DIR is the Argon2 shared library path]])
+[  --with-password-argon2[=DIR]
+                          Include Argon2 support in password_*. DIR is the Argon2 shared library path]])
 
 if test "$PHP_PASSWORD_ARGON2" != "no"; then
   AC_MSG_CHECKING([for Argon2 library])

--- a/ext/zend_test/config.m4
+++ b/ext/zend_test/config.m4
@@ -1,5 +1,5 @@
 PHP_ARG_ENABLE(zend-test, whether to enable zend-test extension,
-[  --enable-zend-test           Enable zend-test extension])
+[  --enable-zend-test      Enable zend-test extension])
 
 if test "$PHP_ZEND_TEST" != "no"; then
   PHP_NEW_EXTENSION(zend_test, test.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -3,13 +3,14 @@ dnl $Id$
 dnl
 
 PHP_ARG_ENABLE(phpdbg, for phpdbg support,
-[  --enable-phpdbg            Build phpdbg], yes, yes)
+[  --enable-phpdbg         Build phpdbg], yes, yes)
 
 PHP_ARG_ENABLE(phpdbg-webhelper, for phpdbg web SAPI support,
-[  --enable-phpdbg-webhelper  Build phpdbg web SAPI support], no)
+[  --enable-phpdbg-webhelper
+                          Build phpdbg web SAPI support], no)
 
 PHP_ARG_ENABLE(phpdbg-debug, for phpdbg debug build,
-[  --enable-phpdbg-debug      Build phpdbg in debug mode], no, no)
+[  --enable-phpdbg-debug   Build phpdbg in debug mode], no, no)
 
 if test "$BUILD_PHPDBG" = "" && test "$PHP_PHPDBG" != "no"; then
   AC_HEADER_TIOCGWINSZ


### PR DESCRIPTION
This improves the ```./configure --help``` output so that everything is aligned the same way.