### PR TITLE
Better error message when fail to find test file

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -98,7 +98,7 @@ if (empty($environment)) {
 }
 if (empty($environment['TEMP'])) {
 	$environment['TEMP'] = sys_get_temp_dir();
-	
+
 	if (empty($environment['TEMP'])) {
 		// for example, OpCache on Windows will fail in this case because child processes (for tests) will not get
 		// a TEMP variable, so GetTempPath() will fallback to c:\windows, while GetTempPath() will return %TEMP% for parent
@@ -106,7 +106,7 @@ if (empty($environment['TEMP'])) {
 		// the OpCache because it will be using the wrong path.
 		die("TEMP environment is NOT set");
 	} else if (count($environment)==1) {
-		// not having other environment variables, only having TEMP, is probably ok, but strange and may make a 
+		// not having other environment variables, only having TEMP, is probably ok, but strange and may make a
 		// difference in the test pass rate, so warn the user.
 		echo "WARNING: Only 1 environment variable will be available to tests(TEMP environment variable)".PHP_EOL;
 	}
@@ -783,7 +783,7 @@ HELP;
 				} else if (preg_match("/\*$/", $argv[$i])) {
 					$pattern_match = glob($argv[$i] . '.phpt');
 				} else {
-					die("bogus test name " . $argv[$i] . "\n");
+					die('Cannot found test file "' . $argv[$i] . '".' . PHP_EOL);
 				}
 
 				if (is_array($pattern_match)) {
@@ -795,7 +795,7 @@ HELP;
 			} else if (preg_match("/\.phpt$/", $testfile)) {
 				$test_files[] = $testfile;
 			} else {
-				die("bogus test name " . $argv[$i] . "\n");
+				die('Cannot found test file "' . $argv[$i] . '".' . PHP_EOL);
 			}
 		}
 	}


### PR DESCRIPTION
Small one: change `bogus test name file.phpt` to `Cannot found test file "file.phpt".`.