### PR TITLE
Bug 75921: consistancy when creating stdObject for empty values

### DIFF
--- a/Zend/tests/bug52041.phpt
+++ b/Zend/tests/bug52041.phpt
@@ -31,6 +31,8 @@ Notice: Undefined variable: x in %sbug52041.php on line 3
 
 Warning: Creating default object from empty value in %sbug52041.php on line 7
 
+Warning: Creating default object from empty value in %sbug52041.php on line 7
+
 Notice: Undefined variable: x in %sbug52041.php on line 3
 
 Warning: Creating default object from empty value in %sbug52041.php on line 8
@@ -38,6 +40,8 @@ Warning: Creating default object from empty value in %sbug52041.php on line 8
 Notice: Undefined property: stdClass::$a in %sbug52041.php on line 8
 
 Notice: Undefined variable: x in %sbug52041.php on line 3
+
+Warning: Creating default object from empty value in %sbug52041.php on line 9
 
 Notice: Undefined property: stdClass::$a in %sbug52041.php on line 9
 
@@ -52,6 +56,8 @@ Warning: Creating default object from empty value in %sbug52041.php on line 10
 Notice: Undefined property: stdClass::$a in %sbug52041.php on line 10
 
 Notice: Undefined variable: x in %sbug52041.php on line 3
+
+Warning: Creating default object from empty value in %sbug52041.php on line 11
 
 Notice: Undefined property: stdClass::$a in %sbug52041.php on line 11
 

--- a/Zend/tests/bug71539_5.phpt
+++ b/Zend/tests/bug71539_5.phpt
@@ -7,7 +7,8 @@ $array['']->prop =& $array[0];
 $array[0] = 42;
 var_dump($array);
 ?>
---EXPECT--
+--EXPECTF--
+Warning: Creating default object from empty value in %sbug71539_5.php on line 3
 array(2) {
   [0]=>
   &int(42)

--- a/Zend/tests/bug75921.phpt
+++ b/Zend/tests/bug75921.phpt
@@ -1,0 +1,80 @@
+--TEST--
+Bug #75921: Inconsistent error when creating stdObject from empty variable
+--FILE--
+<?php
+
+$null->a = 42;
+var_dump($null);
+unset($null);
+
+$null->a['hello'] = 42;
+var_dump($null);
+unset($null);
+
+$null->a->b = 42;
+var_dump($null);
+unset($null);
+
+$null->a['hello']->b = 42;
+var_dump($null);
+unset($null);
+
+$null->a->b['hello'] = 42;
+var_dump($null);
+unset($null);
+
+?>
+--EXPECTF--
+Warning: Creating default object from empty value in %sbug75921.php on line 3
+object(stdClass)#1 (1) {
+  ["a"]=>
+  int(42)
+}
+
+Warning: Creating default object from empty value in %sbug75921.php on line 7
+object(stdClass)#1 (1) {
+  ["a"]=>
+  array(1) {
+    ["hello"]=>
+    int(42)
+  }
+}
+
+Warning: Creating default object from empty value in %sbug75921.php on line 11
+
+Warning: Creating default object from empty value in %sbug75921.php on line 11
+object(stdClass)#1 (1) {
+  ["a"]=>
+  object(stdClass)#2 (1) {
+    ["b"]=>
+    int(42)
+  }
+}
+
+Warning: Creating default object from empty value in %sbug75921.php on line 15
+
+Warning: Creating default object from empty value in %sbug75921.php on line 15
+object(stdClass)#1 (1) {
+  ["a"]=>
+  array(1) {
+    ["hello"]=>
+    object(stdClass)#2 (1) {
+      ["b"]=>
+      int(42)
+    }
+  }
+}
+
+Warning: Creating default object from empty value in %sbug75921.php on line 19
+
+Warning: Creating default object from empty value in %sbug75921.php on line 19
+object(stdClass)#1 (1) {
+  ["a"]=>
+  object(stdClass)#2 (1) {
+    ["b"]=>
+    array(1) {
+      ["hello"]=>
+      int(42)
+    }
+  }
+}

--- a/Zend/tests/objects_020.phpt
+++ b/Zend/tests/objects_020.phpt
@@ -14,6 +14,7 @@ var_dump($$test);
 
 ?>
 --EXPECTF--
+Warning: Creating default object from empty value in %sobjects_020.php on line 7
 object(stdClass)#%d (2) {
   ["a"]=>
   *RECURSION*

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2214,6 +2214,11 @@ static zend_always_inline void zend_fetch_property_address(zval *result, zval *c
 			/* this should modify object only if it's empty */
 			if (type == BP_VAR_UNSET ||
 				UNEXPECTED(!make_real_object_rw(container, prop_ptr OPLINE_CC))) {
+				if (container_op_type != IS_VAR || EXPECTED(!Z_ISERROR_P(container))) {
+					zend_string *property_name = zval_get_string(prop_ptr);
+					zend_error(E_WARNING, "Attempt to modify property '%s' of non-object", ZSTR_VAL(property_name));
+					zend_string_release(property_name);
+				}
 				ZVAL_ERROR(result);
 				return;
 			}

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -721,6 +721,7 @@ static zend_never_inline ZEND_COLD int ZEND_FASTCALL make_real_object_rw(zval *o
 		return 0;
 	}
 	object_init(object);
+	zend_error(E_WARNING, "Creating default object from empty value");
 	return 1;
 }
 

--- a/ext/simplexml/tests/bug36611.phpt
+++ b/ext/simplexml/tests/bug36611.phpt
@@ -14,17 +14,19 @@ $xml_str = <<<EOD
 </c_fpobel>
 EOD;
 
-$xml = simplexml_load_string ($xml_str) ;
+$xml = simplexml_load_string($xml_str);
 
 $val = 1;
 
 var_dump($val);
 $zml->pos["act_idx"] = $val;
-var_dump($val) ;
+var_dump($val);
 
 ?>
 ===DONE===
---EXPECT--	
+--EXPECTF--
 int(1)
+
+Warning: Creating default object from empty value in %sbug36611.php on line 17
 int(1)
 ===DONE===

--- a/tests/lang/engine_assignExecutionOrder_008.phpt
+++ b/tests/lang/engine_assignExecutionOrder_008.phpt
@@ -70,9 +70,15 @@ Warning: Creating default object from empty value in %s on line %d
 good
 $i->p->q=f(): 
 Warning: Creating default object from empty value in %s on line %d
+
+Warning: Creating default object from empty value in %s on line %d
 good
-$i->p[0]=f(): good
+$i->p[0]=f(): 
+Warning: Creating default object from empty value in %s on line %d
+good
 $i->p[0]->p=f(): 
+Warning: Creating default object from empty value in %s on line %d
+
 Warning: Creating default object from empty value in %s on line %d
 good
 C::$p=f(): good

--- a/tests/lang/foreachLoop.016.phpt
+++ b/tests/lang/foreachLoop.016.phpt
@@ -159,24 +159,32 @@ array(1) {
 $a->b->c
 
 Warning: Creating default object from empty value in %s on line %d
+
+Warning: Creating default object from empty value in %s on line %d
 array(1) {
   [0]=>
   string(8) "original"
 }
 
 $a->b[0]
+
+Warning: Creating default object from empty value in %s on line %d
 array(1) {
   [0]=>
   string(8) "original"
 }
 
 $a->b[0][0]
+
+Warning: Creating default object from empty value in %s on line %d
 array(1) {
   [0]=>
   string(8) "original"
 }
 
 $a->b[0]->c
+
+Warning: Creating default object from empty value in %s on line %d
 
 Warning: Creating default object from empty value in %s on line %d
 array(1) {

--- a/tests/lang/passByReference_006.phpt
+++ b/tests/lang/passByReference_006.phpt
@@ -56,6 +56,18 @@ var_dump($u1, $u2, $u3, $u4, $u5);
 --EXPECTF--
 
  ---- Pass uninitialised array & object by ref: function call ---
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
 array(1) {
   [0]=>
   string(12) "Ref1 changed"
@@ -92,6 +104,18 @@ object(stdClass)#%d (1) {
  ---- Pass uninitialised arrays & objects by ref: static method call ---
 
 Deprecated: Non-static method C::refs() should not be called statically in %s on line 39
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
 array(1) {
   [0]=>
   string(12) "Ref1 changed"
@@ -127,6 +151,18 @@ object(stdClass)#%d (1) {
 
 
 ---- Pass uninitialised arrays & objects by ref: constructor ---
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
 array(1) {
   [0]=>
   string(12) "Ref1 changed"
@@ -161,6 +197,18 @@ object(stdClass)#%d (1) {
 }
 
  ---- Pass uninitialised arrays & objects by ref: instance method call ---
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
+
+Warning: Creating default object from empty value in %spassByReference_006.php on line %d
 array(1) {
   [0]=>
   string(12) "Ref1 changed"


### PR DESCRIPTION
[Bug #75921](https://bugs.php.net/bug.php?id=75921)

Add some consistancy when warning about creating a stdObject against an
empty LHS variable.  The warning was not being properly reported when
doing a FETCH_OBJ_W.