### PR TITLE
Fix bug #75961 - array_walk() and forced references

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1380,6 +1380,8 @@ static int php_array_walk(zval *array, zval *userdata, int recursive) /* {{{ */
 
 	/* Iterate through hash */
 	do {
+		zval *orig;
+
 		/* Retrieve value */
 		zv = zend_hash_get_current_data_ex(target_hash, &pos);
 		if (zv == NULL) {
@@ -1396,7 +1398,10 @@ static int php_array_walk(zval *array, zval *userdata, int recursive) /* {{{ */
 		}
 
 		/* Ensure the value is a reference. Otherwise the location of the value may be freed. */
-		ZVAL_MAKE_REF(zv);
+		if (!Z_ISREF_P(zv)) {
+			orig = zv;
+			ZVAL_NEW_REF(zv, zv);
+		}
 
 		/* Retrieve key */
 		zend_hash_get_current_key_zval_ex(target_hash, &args[1], &pos);
@@ -1451,6 +1456,10 @@ static int php_array_walk(zval *array, zval *userdata, int recursive) /* {{{ */
 			}
 
 			zval_ptr_dtor(&args[0]);
+		}
+
+		if (orig && zv == orig && Z_ISREF_P(zv)) {
+			ZVAL_UNREF(zv);
 		}
 
 		if (Z_TYPE(args[1]) != IS_UNDEF) {

--- a/ext/standard/tests/array/bug75961.phpt
+++ b/ext/standard/tests/array/bug75961.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #75961: array_walk() converts items into references
+--FILE--
+<?php
+
+$arr = [[1]];
+
+array_walk($arr, function(){});
+array_map('array_shift', $arr);
+var_dump($arr);
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(1) {
+    [0]=>
+    int(1)
+  }
+}


### PR DESCRIPTION
An attempt to fix #75961.

The problem is `array_walk()` forces every item to be a reference, but doesn't unref them after processing.