### PR TITLE
Remove redelcaration of zend_parse_parameters_none

### DIFF
--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -35,11 +35,6 @@
 
 #define SAFE_STR(a) ((a)?a:"")
 
-#ifndef zend_parse_parameters_none
-#define zend_parse_parameters_none()	\
-        zend_parse_parameters(ZEND_NUM_ARGS(), "")
-#endif
-
 /* {{{ php_mysqli_set_error
  */
 static void php_mysqli_set_error(zend_long mysql_errno, char *mysql_err)


### PR DESCRIPTION
Is there a specific reason for this check?