### PR TITLE
Missing arginfo arginfo_pdostatement_setfetchmode

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -103,6 +103,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pdostatement_setfetchmode, 0, 0, 1)
 	ZEND_ARG_INFO(0, mode)
+	ZEND_ARG_INFO(0, param)
 	ZEND_ARG_INFO(0, params)
 ZEND_END_ARG_INFO()
 /* }}} */


### PR DESCRIPTION
Another found with `PHPStan`:
```
Method PDOStatement::setFetchMode() invoked with 3 parameters, 1-2 required.
```

[By the docs](http://php.net/manual/en/pdostatement.setfetchmode.php), this method has variadics arguments, so how should we call it?