### PR TITLE
Fix some compile results warning

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -3328,7 +3328,7 @@ PHP_FUNCTION(ldap_parse_result)
 	zval *link, *result, *errcode, *matcheddn, *errmsg, *referrals, *serverctrls;
 	ldap_linkdata *ld;
 	LDAPMessage *ldap_result;
-	LDAPControl **lserverctrls = NULL, **ctrlp = NULL;
+	LDAPControl **lserverctrls = NULL;
 	char **lreferrals, **refp;
 	char *lmatcheddn, *lerrmsg;
 	int rc, lerrcode, myargcount = ZEND_NUM_ARGS();

--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -1537,7 +1537,7 @@ sb4 php_oci_error(OCIError *err_p, sword errstatus)
 		case OCI_ERROR:
 			errcode = php_oci_fetch_errmsg(err_p, errbuf, sizeof(errbuf));
 			if (errcode) {
-				php_error_docref(NULL, E_WARNING, "%s", errbuf, sizeof(errbuf));
+				php_error_docref(NULL, E_WARNING, "%s", errbuf);
 			} else {
 				php_error_docref(NULL, E_WARNING, "failed to fetch error message");
 			}


### PR DESCRIPTION
Ref: http://gcov.php.net/viewer.php?version=PHP_HEAD&func=compile_results
* too many arguments for format
* unused variables