### PR TITLE
Remove the unused localtime parameter from php_idate()

### DIFF
--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -208,7 +208,7 @@ ZEND_END_MODULE_GLOBALS(date)
 /* Backwards compatibility wrapper */
 PHPAPI zend_long php_parse_date(char *string, zend_long *now);
 PHPAPI void php_mktime(INTERNAL_FUNCTION_PARAMETERS, int gmt);
-PHPAPI int php_idate(char format, time_t ts, int localtime);
+PHPAPI int php_idate(char format, time_t ts);
 #if HAVE_STRFTIME
 #define _php_strftime php_strftime
 PHPAPI void php_strftime(INTERNAL_FUNCTION_PARAMETERS, int gm);


### PR DESCRIPTION
While looking through the code coverage details I noticed that the third parameter to `php_idate()` is always passed as zero.

I looked back through the history but I couldn't find anywhere this parameter was ever used since it was [introduced](https://github.com/php/php-src/commit/ea8d11cc8786891e11c3257df0c7d72bd1993646#diff-fcdd3df5190b474664aaf1985d27d661).

This PR removes the parameter to simplify the function. The main chunk of code in the diff is just whitespace from the indentation level of the block
