### PR TITLE
[Bug] 65672 - Allow DatePeriod extensions to have writable properties

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -5310,12 +5310,35 @@ PHP_METHOD(DatePeriod, __wakeup)
 }
 /* }}} */
 
+/* {{{ date_period_is_magic_property
+ *  Common for date_period_read_property() and date_period_write_property() functions
+ */
+static int date_period_is_magic_property(zend_string *name)
+{
+	if (zend_string_equals_literal(name, "recurrences")
+		|| zend_string_equals_literal(name, "include_start_date")
+		|| zend_string_equals_literal(name, "start")
+		|| zend_string_equals_literal(name, "current")
+		|| zend_string_equals_literal(name, "end")
+		|| zend_string_equals_literal(name, "interval")
+	) {
+		return 1;
+	}
+	return 0;
+}
+/* }}} */
+
 /* {{{ date_period_read_property */
 static zval *date_period_read_property(zval *object, zval *member, int type, void **cache_slot, zval *rv)
 {
 	if (type != BP_VAR_IS && type != BP_VAR_R) {
-		zend_throw_error(NULL, "Retrieval of DatePeriod properties for modification is unsupported");
-		return &EG(uninitialized_zval);
+		zend_string *name = zval_get_string(member);
+		if (date_period_is_magic_property(name)) {
+			zend_throw_error(NULL, "Retrieval of DatePeriod->%s for modification is unsupported", ZSTR_VAL(name));
+			zend_string_release(name);
+			return &EG(uninitialized_zval);
+		}
+		zend_string_release(name);
 	}
 
 	Z_OBJPROP_P(object); /* build properties hash table */
@@ -5327,7 +5350,15 @@ static zval *date_period_read_property(zval *object, zval *member, int type, voi
 /* {{{ date_period_write_property */
 static void date_period_write_property(zval *object, zval *member, zval *value, void **cache_slot)
 {
-	zend_throw_error(NULL, "Writing to DatePeriod properties is unsupported");
+	zend_string *name = zval_get_string(member);
+	if (date_period_is_magic_property(name)) {
+		zend_throw_error(NULL, "Writing to DatePeriod->%s is unsupported", ZSTR_VAL(name));
+		zend_string_release(name);
+		return;
+	}
+	zend_string_release(name);
+
+	std_object_handlers.write_property(object, member, value, cache_slot);
 }
 /* }}} */
 

--- a/ext/date/tests/DatePeriod_properties1.phpt
+++ b/ext/date/tests/DatePeriod_properties1.phpt
@@ -1,0 +1,37 @@
+--TEST--
+DatePeriod: Test read only properties
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+
+$start = new DateTime;
+$interval = new DateInterval('P1D');
+$end = new DateTime;
+$period = new DatePeriod($start, $interval, $end);
+
+echo "recurrences: ";
+var_dump($period->recurrences);
+
+echo "include_start_date: ";
+var_dump($period->include_start_date);
+
+echo "start: ";
+var_dump($period->start == $start);
+
+echo "current: ";
+var_dump($period->current);
+
+echo "end: ";
+var_dump($period->end == $end);
+
+echo "interval: ";
+var_dump($period->interval == $interval);
+?>
+--EXPECT--
+recurrences: int(1)
+include_start_date: bool(true)
+start: bool(true)
+current: NULL
+end: bool(true)
+interval: bool(true)

--- a/ext/date/tests/DatePeriod_properties2.phpt
+++ b/ext/date/tests/DatePeriod_properties2.phpt
@@ -1,0 +1,46 @@
+--TEST--
+DatePeriod: Test cannot modify read only properties
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+
+$period = new DatePeriod(new DateTime, new DateInterval('P1D'), new DateTime);
+
+$properties = [
+    "recurrences",
+    "include_start_date",
+    "start",
+    "current",
+    "end",
+    "interval",
+];
+
+foreach ($properties as $property) {
+    try {
+        $period->$property = "new";
+    } catch (Error $e) {
+        echo $e->getMessage() . "\n";
+    }
+
+    try {
+        $period->$property[] = "extra";
+    } catch (Error $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+?>
+--EXPECT--
+Writing to DatePeriod->recurrences is unsupported
+Retrieval of DatePeriod->recurrences for modification is unsupported
+Writing to DatePeriod->include_start_date is unsupported
+Retrieval of DatePeriod->include_start_date for modification is unsupported
+Writing to DatePeriod->start is unsupported
+Retrieval of DatePeriod->start for modification is unsupported
+Writing to DatePeriod->current is unsupported
+Retrieval of DatePeriod->current for modification is unsupported
+Writing to DatePeriod->end is unsupported
+Retrieval of DatePeriod->end for modification is unsupported
+Writing to DatePeriod->interval is unsupported
+Retrieval of DatePeriod->interval for modification is unsupported

--- a/ext/date/tests/bug65672.phpt
+++ b/ext/date/tests/bug65672.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Test for bug #65672: Broken classes inherited from DatePeriod
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+
+$interval = new DateInterval('P1D');
+$period = new class(new DateTime, $interval, new DateTime) extends DatePeriod {
+    public $extra = "stuff";
+};
+
+var_dump($period->extra);
+$period->extra = "modified";
+var_dump($period->extra);
+
+# Ensure we can modify properties (retrieve for write)
+$period->extra = [];
+$period->extra[] = "array";
+var_dump($period->extra);
+
+var_dump(isset($period->dynamic1));
+$period->dynamic1 = "dynamic";
+var_dump($period->dynamic1);
+
+# Ensure we can modify properties (retrieve for write)
+$period->dynamic2 = [];
+$period->dynamic2[] = "array";
+var_dump($period->dynamic2);
+
+?>
+--EXPECT--
+string(5) "stuff"
+string(8) "modified"
+array(1) {
+  [0]=>
+  string(5) "array"
+}
+bool(false)
+string(7) "dynamic"
+array(1) {
+  [0]=>
+  string(5) "array"
+}


### PR DESCRIPTION
It looks like the properties were prevented from being writable as part of a serialization fix: https://github.com/php/php-src/commit/0ee71557ffd285552659b6aa37ea236e3bad493f

However there are no tests for this, so it seems it may have been unintentional. Also [a bug](https://bugs.php.net/bug.php?id=65672) was opened and hasn't been marked as "not a bug" so this PR restores the previous functionality, and includes tests for it.