### PR TITLE
Add a test for iterating properties by reference

### DIFF
--- a/ext/simplexml/tests/foreach_by_reference.phpt
+++ b/ext/simplexml/tests/foreach_by_reference.phpt
@@ -1,0 +1,21 @@
+--TEST--
+SimpleXml: foreach by reference
+--SKIPIF--
+<?php if (!extension_loaded("simplexml")) print "skip"; ?>
+--FILE--
+<?php
+
+$xml = <<<XML
+<people>
+  <person>Lucy</person>
+  <person>Mikasa</person>
+</people>
+XML;
+
+$people = simplexml_load_string($xml);
+
+foreach ($people as &$person) {}
+
+?>
+--EXPECTF--
+Fatal error: An iterator cannot be used with foreach by reference in %s on line %d


### PR DESCRIPTION
There was no test to ensure we can't iterate by reference, this PR adds one