### PR TITLE
Report unknown sections in run-tests.php

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1305,6 +1305,20 @@ TEST $file
 				$borked    = true;
 			}
 
+			// check for unknown sections
+			if (!in_array($section, array(
+				'EXPECT', 'EXPECTF', 'EXPECTREGEX', 'EXPECTREGEX_EXTERNAL', 'EXPECT_EXTERNAL', 'EXPECTF_EXTERNAL', 'EXPECTHEADERS',
+				'POST', 'POST_RAW', 'GZIP_POST', 'DEFLATE_POST', 'GET', 'COOKIE', 'ARGS', 'REQUEST', 'HEADERS',
+				'FILE', 'FILEEOF', 'FILE_EXTERNAL', 'REDIRECTTEST',
+				'CAPTURE_STDIO', 'STDIN', 'CGI', 'PHPDBG',
+				'INI', 'ENV', 'EXTENSIONS',
+				'SKIPIF', 'XFAIL', 'CLEAN',
+				'CREDITS', 'DESCRIPTION',
+			))) {
+				$bork_info = 'Unknown section "' . $section . '"';
+				$borked = true;
+			}
+
 			$section_text[$section] = '';
 			$secfile = $section == 'FILE' || $section == 'FILEEOF' || $section == 'FILE_EXTERNAL';
 			$secdone = false;


### PR DESCRIPTION
Based on @nikic's https://github.com/php/php-src/commit/3616b6b935ffc67c447d6e60ba654ba3903b9bae#commitcomment-27333118, [some founds](https://github.com/php/php-src/pull/3070/files#diff-1975f231262a66347512ab6cadb23851L5) in #3070 and with this PR, `run-tests.php` now reports unknown sections in tests.

Note to self: PR some undocumented sections, like `EXTENSIONS`, to QA.