### PR TITLE
don't build phpdbg by default

### DIFF
--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -3,7 +3,7 @@ dnl $Id$
 dnl
 
 PHP_ARG_ENABLE(phpdbg, for phpdbg support,
-[  --enable-phpdbg         Build phpdbg], yes, yes)
+[  --enable-phpdbg         Build phpdbg], no, no)
 
 PHP_ARG_ENABLE(phpdbg-webhelper, for phpdbg web SAPI support,
 [  --enable-phpdbg-webhelper


### PR DESCRIPTION
When compiling readline as shared extension for the cli SAPI, this failed because phpdbg is compiled by default and needs readline. Compiling with or without readline works, only compiling as shared extension makes phpdbg fail.

```
/usr/src/php/php-src/sapi/phpdbg/phpdbg_cmd.c:765: undefined reference to `readline'
/usr/src/php/php-src/sapi/phpdbg/phpdbg_cmd.c:773: undefined reference to `add_history'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
*** Error 1 in /usr/src/php/php-src (Makefile:293 'sapi/phpdbg/phpdbg')
```

I don't know why phpdbg is compiled by default. Maybe this was commited by mistake in https://github.com/php/php-src/commit/378a05f0de7#diff-70ffcc68633eb9f00e5f1aea6023fcdeR6

This PR suggests to turn it off again. Or, maybe we should leave it on by default and need a ```--disable-phpdbg``` instead?