### PR TITLE
path to expat_compat.h

### DIFF
--- a/ext/xml/php_xml.h
+++ b/ext/xml/php_xml.h
@@ -36,7 +36,7 @@ extern zend_module_entry xml_module_entry;
 
 #ifdef HAVE_XML
 
-#include "ext/xml/expat_compat.h"
+#include "expat_compat.h"
 
 #ifdef XML_UNICODE
 #error "UTF-16 Unicode support not implemented!"


### PR DESCRIPTION
when I build php with ```--disable-xml``` and then go to ```ext/xml``` to build it as a module it can't find this include file:

```
./php_xml.h:39:10: fatal error: 'ext/xml/expat_compat.h' file not found
#include "ext/xml/expat_compat.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes that. Compiling into php still works as well