### PR TITLE
fixed crash of cases related to mbstring on Big_Endian platform(s390x)

### DIFF
--- a/ext/mbstring/oniguruma/src/regint.h
+++ b/ext/mbstring/oniguruma/src/regint.h
@@ -528,7 +528,11 @@ typedef int AbsAddrType;
 typedef int LengthType;
 typedef int RepeatNumType;
 typedef int MemNumType;
+#if defined(__s390x__)
+typedef int StateCheckNumType;
+#else
 typedef short int StateCheckNumType;
+#endif
 typedef void* PointerType;
 
 #define SIZE_OPCODE           1


### PR DESCRIPTION
This PR fixes the [75863](https://bugs.php.net/bug.php?id=75863)

Note `type` (StateCheckNumType) is defined as "short" (`ext/mbstring/oniguruma/src/regint.h`),
while "mem" is `int`, 

    191 #define PLATFORM_GET_INC(val,p,type) do{\
    192   val  = *(type* )p;\
    193   (p) += sizeof(type);\
    194 } while(0)
    ...
    553 #define GET_STATE_CHECK_NUM_INC(num,p)  PLATFORM_GET_INC(num, p, StateCheckNumType)

 which causes the issue on Big_Endian platforms.

The solution: change `StateCheckNumType` as `int` on s390x, 
and  `ifdef` for safe on other platforms.

