### PR TITLE
Fix bug #68440: [sapi/fpm] FPM fails to reload with high number of pools

### DIFF
--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -47,7 +47,7 @@ static void fpm_sockets_cleanup(int which, void *arg) /* {{{ */
 	unsigned socket_set_count = 0;
 	unsigned socket_set[FPM_ENV_SOCKET_SET_MAX];
 	unsigned socket_set_buf = 0;
-	char envname[16];
+	char envname[32];
 	char *env_value = 0;
 	int p = 0;
 	struct listening_socket_s *ls = sockets_list.data;
@@ -83,8 +83,12 @@ static void fpm_sockets_cleanup(int which, void *arg) /* {{{ */
 	}
 
 	if (env_value) {
-		for(i = 0; i < socket_set_count; i++) {
-			sprintf(envname, "FPM_SOCKETS_%d", i);
+		for (i = 0; i < socket_set_count; i++) {
+			if (!i) {
+				strcpy(envname, "FPM_SOCKETS");
+			} else {
+				sprintf(envname, "FPM_SOCKETS_%d", i);
+			}
 			setenv(envname, env_value + socket_set[i], 1);
 		}
 		free(env_value);
@@ -343,7 +347,7 @@ int fpm_sockets_init_main() /* {{{ */
 {
 	unsigned i, lq_len;
 	struct fpm_worker_pool_s *wp;
-	char sockname[16];
+	char sockname[32];
 	char *inherited;
 	struct listening_socket_s *ls;
 
@@ -353,7 +357,11 @@ int fpm_sockets_init_main() /* {{{ */
 
 	/* import inherited sockets */
 	for (i = 0; i < FPM_ENV_SOCKET_SET_MAX; i++) {
-		sprintf(sockname, "FPM_SOCKETS_%d", i);
+		if (!i) {
+			strcpy(sockname, "FPM_SOCKETS");
+		} else {
+			sprintf(sockname, "FPM_SOCKETS_%d", i);
+		}
 		inherited = getenv(sockname);
 		if (!inherited) break;
 

--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -44,6 +44,10 @@ enum { FPM_GET_USE_SOCKET = 1, FPM_STORE_SOCKET = 2, FPM_STORE_USE_SOCKET = 3 };
 static void fpm_sockets_cleanup(int which, void *arg) /* {{{ */
 {
 	unsigned i;
+	unsigned socket_set_count = 0;
+	unsigned socket_set[FPM_ENV_SOCKET_SET_MAX];
+	unsigned socket_set_buf = 0;
+	char envname[16];
 	char *env_value = 0;
 	int p = 0;
 	struct listening_socket_s *ls = sockets_list.data;
@@ -54,8 +58,20 @@ static void fpm_sockets_cleanup(int which, void *arg) /* {{{ */
 		} else { /* on PARENT EXEC we want socket fds to be inherited through environment variable */
 			char fd[32];
 			sprintf(fd, "%d", ls->sock);
-			env_value = realloc(env_value, p + (p ? 1 : 0) + strlen(ls->key) + 1 + strlen(fd) + 1);
-			p += sprintf(env_value + p, "%s%s=%s", p ? "," : "", ls->key, fd);
+
+			socket_set_buf = (i % FPM_ENV_SOCKET_SET_SIZE == 0 && i) ? 1 : 0;
+			env_value = realloc(env_value, p + (p ? 1 : 0) + strlen(ls->key) + 1 + strlen(fd) + socket_set_buf + 1);
+
+			if (i % FPM_ENV_SOCKET_SET_SIZE == 0) {
+				socket_set[socket_set_count] = p + socket_set_buf;
+				socket_set_count++;
+				if (i) {
+					*(env_value + p + 1) = 0;
+				}
+			}
+
+			p += sprintf(env_value + p + socket_set_buf, "%s%s=%s", (p && !socket_set_buf) ? "," : "", ls->key, fd);
+			p += socket_set_buf;
 		}
 
 		if (which == FPM_CLEANUP_PARENT_EXIT_MAIN) {
@@ -67,7 +83,10 @@ static void fpm_sockets_cleanup(int which, void *arg) /* {{{ */
 	}
 
 	if (env_value) {
-		setenv("FPM_SOCKETS", env_value, 1);
+		for(i = 0; i < socket_set_count; i++) {
+			sprintf(envname, "FPM_SOCKETS_%d", i);
+			setenv(envname, env_value + socket_set[i], 1);
+		}
 		free(env_value);
 	}
 
@@ -324,7 +343,8 @@ int fpm_sockets_init_main() /* {{{ */
 {
 	unsigned i, lq_len;
 	struct fpm_worker_pool_s *wp;
-	char *inherited = getenv("FPM_SOCKETS");
+	char sockname[16];
+	char *inherited;
 	struct listening_socket_s *ls;
 
 	if (0 == fpm_array_init(&sockets_list, sizeof(struct listening_socket_s), 10)) {
@@ -332,28 +352,34 @@ int fpm_sockets_init_main() /* {{{ */
 	}
 
 	/* import inherited sockets */
-	while (inherited && *inherited) {
-		char *comma = strchr(inherited, ',');
-		int type, fd_no;
-		char *eq;
+	for (i = 0; i < FPM_ENV_SOCKET_SET_MAX; i++) {
+		sprintf(sockname, "FPM_SOCKETS_%d", i);
+		inherited = getenv(sockname);
+		if (!inherited) break;
 
-		if (comma) {
-			*comma = '\0';
-		}
+		while (inherited && *inherited) {
+			char *comma = strchr(inherited, ',');
+			int type, fd_no;
+			char *eq;
 
-		eq = strchr(inherited, '=');
-		if (eq) {
-			*eq = '\0';
-			fd_no = atoi(eq + 1);
-			type = fpm_sockets_domain_from_address(inherited);
-			zlog(ZLOG_NOTICE, "using inherited socket fd=%d, \"%s\"", fd_no, inherited);
-			fpm_sockets_hash_op(fd_no, 0, inherited, type, FPM_STORE_SOCKET);
-		}
+			if (comma) {
+				*comma = '\0';
+			}
 
-		if (comma) {
-			inherited = comma + 1;
-		} else {
-			inherited = 0;
+			eq = strchr(inherited, '=');
+			if (eq) {
+				*eq = '\0';
+				fd_no = atoi(eq + 1);
+				type = fpm_sockets_domain_from_address(inherited);
+				zlog(ZLOG_NOTICE, "using inherited socket fd=%d, \"%s\"", fd_no, inherited);
+				fpm_sockets_hash_op(fd_no, 0, inherited, type, FPM_STORE_SOCKET);
+			}
+
+			if (comma) {
+				inherited = comma + 1;
+			} else {
+				inherited = 0;
+			}
 		}
 	}
 

--- a/sapi/fpm/fpm/fpm_sockets.h
+++ b/sapi/fpm/fpm/fpm_sockets.h
@@ -19,8 +19,11 @@
 #if (__FreeBSD__) || (__OpenBSD__)
 #define FPM_BACKLOG_DEFAULT -1
 #else
-#define FPM_BACKLOG_DEFAULT 511 
+#define FPM_BACKLOG_DEFAULT 511
 #endif
+
+#define FPM_ENV_SOCKET_SET_MAX 256
+#define FPM_ENV_SOCKET_SET_SIZE 128
 
 enum fpm_address_domain fpm_sockets_domain_from_address(char *addr);
 int fpm_sockets_init_main();


### PR DESCRIPTION
With a large number of pools (in our case, over approx 1100), PHP-FPM will attempt to reload (upon receiving SIGUSR2), but fail with an `E2BIG` error during execve, as `fpm_sockets_cleanup()` loads all active connections/fds into an env variable that exceeds the Linux kernel's `ARG_MAX_STRLEN` size (max size of a single argument, which is 128 KiB in most configurations). Therefore, my approach was to simply split this massive var into smaller segments, so that each `FPM_SOCKETS_*` var stays a reasonable size. Testing with 5000 pools confirms this works.

This issue affects all versions of PHP that include FPM, but I have submitted the pull request against 7.1 as mentioned in the contributor docs. Please let me know if I should submit additional pull requests against 7.2 and master. Thanks!