### PR TITLE
Remove return types from some magic method in protos

### DIFF
--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -1038,7 +1038,7 @@ ZEND_METHOD(Generator, getReturn)
 }
 /* }}} */
 
-/* {{{ proto void Generator::__wakeup()
+/* {{{ proto Generator::__wakeup()
  * Throws an Exception as generators can't be serialized */
 ZEND_METHOD(Generator, __wakeup)
 {

--- a/ext/com_dotnet/com_persist.c
+++ b/ext/com_dotnet/com_persist.c
@@ -645,7 +645,7 @@ CPH_METHOD(SaveToStream)
 }
 /* }}} */
 
-/* {{{ proto int COMPersistHelper::__construct([object com_object])
+/* {{{ proto COMPersistHelper::__construct([object com_object])
    Creates a persistence helper object, usually associated with a com_object */
 CPH_METHOD(__construct)
 {

--- a/ext/curl/curl_file.c
+++ b/ext/curl/curl_file.c
@@ -52,7 +52,7 @@ static void curlfile_ctor(INTERNAL_FUNCTION_PARAMETERS)
 	}
 }
 
-/* {{{ proto void CURLFile::__construct(string $name, [string $mimetype [, string $postfilename]])
+/* {{{ proto CURLFile::__construct(string $name, [string $mimetype [, string $postfilename]])
    Create the CURLFile object */
 ZEND_METHOD(CURLFile, __construct)
 {
@@ -133,7 +133,7 @@ ZEND_METHOD(CURLFile, setPostFilename)
 }
 /* }}} */
 
-/* {{{ proto void CURLFile::__wakeup()
+/* {{{ proto CURLFile::__wakeup()
    Unserialization handler */
 ZEND_METHOD(CURLFile, __wakeup)
 {

--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -52,7 +52,7 @@ const zend_function_entry php_dom_attr_class_functions[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void DOMAttr::__construct(string name, [string value]) */
+/* {{{ proto DOMAttr::__construct(string name, [string value]) */
 PHP_METHOD(domattr, __construct)
 {
 	zval *id = getThis();

--- a/ext/dom/cdatasection.c
+++ b/ext/dom/cdatasection.c
@@ -46,7 +46,7 @@ const zend_function_entry php_dom_cdatasection_class_functions[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void DOMCdataSection::__construct(string value); */
+/* {{{ proto DOMCdataSection::__construct(string value); */
 PHP_METHOD(domcdatasection, __construct)
 {
 

--- a/ext/dom/comment.c
+++ b/ext/dom/comment.c
@@ -46,7 +46,7 @@ const zend_function_entry php_dom_comment_class_functions[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void DOMComment::__construct([string value]); */
+/* {{{ proto DOMComment::__construct([string value]); */
 PHP_METHOD(domcomment, __construct)
 {
 

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1250,7 +1250,7 @@ PHP_FUNCTION(dom_document_rename_node)
 }
 /* }}} end dom_document_rename_node */
 
-/* {{{ proto void DOMDocument::__construct([string version], [string encoding]); */
+/* {{{ proto DOMDocument::__construct([string version], [string encoding]); */
 PHP_METHOD(domdocument, __construct)
 {
 

--- a/ext/dom/documentfragment.c
+++ b/ext/dom/documentfragment.c
@@ -49,7 +49,7 @@ const zend_function_entry php_dom_documentfragment_class_functions[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void DOMDocumentFragment::__construct() */
+/* {{{ proto DOMDocumentFragment::__construct() */
 PHP_METHOD(domdocumentfragment, __construct)
 {
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -150,7 +150,7 @@ const zend_function_entry php_dom_element_class_functions[] = { /* {{{ */
 };
 /* }}} */
 
-/* {{{ proto void DOMElement::__construct(string name, [string value], [string uri]) */
+/* {{{ proto DOMElement::__construct(string name, [string value], [string uri]) */
 PHP_METHOD(domelement, __construct)
 {
 

--- a/ext/dom/entityreference.c
+++ b/ext/dom/entityreference.c
@@ -45,7 +45,7 @@ const zend_function_entry php_dom_entityreference_class_functions[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void DOMEntityReference::__construct(string name) */
+/* {{{ proto DOMEntityReference::__construct(string name) */
 PHP_METHOD(domentityreference, __construct)
 {
 	zval *id = getThis();

--- a/ext/dom/processinginstruction.c
+++ b/ext/dom/processinginstruction.c
@@ -47,7 +47,7 @@ const zend_function_entry php_dom_processinginstruction_class_functions[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void DOMProcessingInstruction::__construct(string name, [string value]); */
+/* {{{ proto DOMProcessingInstruction::__construct(string name, [string value]); */
 PHP_METHOD(domprocessinginstruction, __construct)
 {
 	zval *id = getThis();

--- a/ext/dom/text.c
+++ b/ext/dom/text.c
@@ -61,7 +61,7 @@ const zend_function_entry php_dom_text_class_functions[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void DOMText::__construct([string value]); */
+/* {{{ proto DOMText::__construct([string value]); */
 PHP_METHOD(domtext, __construct)
 {
 

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -249,7 +249,7 @@ static void dom_xpath_ext_function_object_php(xmlXPathParserContextPtr ctxt, int
 }
 /* }}} */
 
-/* {{{ proto void DOMXPath::__construct(DOMDocument doc) U */
+/* {{{ proto DOMXPath::__construct(DOMDocument doc) U */
 PHP_METHOD(domxpath, __construct)
 {
 	zval *id = getThis(), *doc;

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -882,7 +882,7 @@ PHP_FUNCTION(hash_equals)
 }
 /* }}} */
 
-/* {{{ proto void HashContext::__construct() */
+/* {{{ proto HashContext::__construct() */
 static PHP_METHOD(HashContext, __construct) {
 	/* Normally unreachable as private/final */
 	zend_throw_exception(zend_ce_error, "Illegal call to private/final constructor", 0);

--- a/ext/intl/collator/collator_create.c
+++ b/ext/intl/collator/collator_create.c
@@ -71,7 +71,7 @@ PHP_FUNCTION( collator_create )
 }
 /* }}} */
 
-/* {{{ proto Collator Collator::__construct( string $locale )
+/* {{{ proto Collator::__construct( string $locale )
  * Collator object constructor.
  */
 PHP_METHOD( Collator, __construct )

--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -545,7 +545,7 @@ static void php_converter_resolve_callback(zval *zobj,
 }
 /* }}} */
 
-/* {{{ proto void UConverter::__construct([string dest = 'utf-8',[string src = 'utf-8']]) */
+/* {{{ proto UConverter::__construct([string dest = 'utf-8',[string src = 'utf-8']]) */
 ZEND_BEGIN_ARG_INFO_EX(php_converter_arginfo, 0, ZEND_RETURN_VALUE, 0)
 	ZEND_ARG_INFO(0, destination_encoding)
 	ZEND_ARG_INFO(0, source_encoding)

--- a/ext/intl/formatter/formatter_main.c
+++ b/ext/intl/formatter/formatter_main.c
@@ -86,7 +86,7 @@ PHP_FUNCTION( numfmt_create )
 }
 /* }}} */
 
-/* {{{ proto void NumberFormatter::__construct( string $locale, int style[, string $pattern ] )
+/* {{{ proto NumberFormatter::__construct( string $locale, int style[, string $pattern ] )
  * NumberFormatter object constructor.
  */
 PHP_METHOD( NumberFormatter, __construct )

--- a/ext/intl/msgformat/msgformat.c
+++ b/ext/intl/msgformat/msgformat.c
@@ -105,7 +105,7 @@ PHP_FUNCTION( msgfmt_create )
 }
 /* }}} */
 
-/* {{{ proto void MessageFormatter::__construct( string $locale, string $pattern )
+/* {{{ proto MessageFormatter::__construct( string $locale, string $pattern )
  * MessageFormatter object constructor.
  */
 PHP_METHOD( MessageFormatter, __construct )

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -144,7 +144,7 @@ ZEND_BEGIN_ARG_INFO_EX( arginfo_resourcebundle___construct, 0, 0, 2 )
 ZEND_END_ARG_INFO()
 /* }}} */
 
-/* {{{ proto void ResourceBundle::__construct( string $locale [, string $bundlename [, bool $fallback = true ]] )
+/* {{{ proto ResourceBundle::__construct( string $locale [, string $bundlename [, bool $fallback = true ]] )
  * ResourceBundle object constructor
  */
 PHP_METHOD( ResourceBundle, __construct )

--- a/ext/intl/spoofchecker/spoofchecker_create.c
+++ b/ext/intl/spoofchecker/spoofchecker_create.c
@@ -23,7 +23,7 @@
 #include "spoofchecker_create.h"
 #include "intl_data.h"
 
-/* {{{ proto Spoofchecker Spoofchecker::__construct()
+/* {{{ proto Spoofchecker::__construct()
  * Spoofchecker object constructor.
  */
 PHP_METHOD(Spoofchecker, __construct)

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -192,7 +192,7 @@ static char *dsn_from_uri(char *uri, char *buf, size_t buflen) /* {{{ */
 }
 /* }}} */
 
-/* {{{ proto void PDO::__construct(string dsn[, string username[, string passwd [, array options]]])
+/* {{{ proto PDO::__construct(string dsn[, string username[, string passwd [, array options]]])
    */
 static PHP_METHOD(PDO, dbh_constructor)
 {
@@ -1156,7 +1156,7 @@ static PHP_METHOD(PDO, quote)
 }
 /* }}} */
 
-/* {{{ proto int PDO::__wakeup()
+/* {{{ proto PDO::__wakeup()
    Prevents use of a PDO instance that has been unserialized */
 static PHP_METHOD(PDO, __wakeup)
 {

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2148,7 +2148,7 @@ static PHP_METHOD(PDOStatement, debugDumpParams)
 }
 /* }}} */
 
-/* {{{ proto int PDOStatement::__wakeup()
+/* {{{ proto PDOStatement::__wakeup()
    Prevents use of a PDOStatement instance that has been unserialized */
 static PHP_METHOD(PDOStatement, __wakeup)
 {

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -1134,10 +1134,10 @@ static const spl_other_handler phar_spl_foreign_handler = {
 	phar_spl_foreign_clone
 };
 
-/* {{{ proto void Phar::__construct(string fname [, int flags [, string alias]])
+/* {{{ proto Phar::__construct(string fname [, int flags [, string alias]])
  * Construct a Phar archive object
  *
- * proto void PharData::__construct(string fname [[, int flags [, string alias]], int file format = Phar::TAR])
+ * proto PharData::__construct(string fname [[, int flags [, string alias]], int file format = Phar::TAR])
  * Construct a PharData archive object
  *
  * This function is used as the constructor for both the Phar and PharData
@@ -1402,7 +1402,7 @@ PHP_METHOD(Phar, unlinkArchive)
 		return; \
 	}
 
-/* {{{ proto void Phar::__destruct()
+/* {{{ proto Phar::__destruct()
  * if persistent, remove from the cache
  */
 PHP_METHOD(Phar, __destruct)
@@ -4497,7 +4497,7 @@ PHP_METHOD(Phar, extractTo)
 /* }}} */
 
 
-/* {{{ proto void PharFileInfo::__construct(string entry)
+/* {{{ proto PharFileInfo::__construct(string entry)
  * Construct a Phar entry object
  */
 PHP_METHOD(PharFileInfo, __construct)
@@ -4572,7 +4572,7 @@ PHP_METHOD(PharFileInfo, __construct)
 		return; \
 	}
 
-/* {{{ proto void PharFileInfo::__destruct()
+/* {{{ proto PharFileInfo::__destruct()
  * clean up directory-based entry objects
  */
 PHP_METHOD(PharFileInfo, __destruct)

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1745,7 +1745,7 @@ PHP_FUNCTION(snmp_read_mib)
 }
 /* }}} */
 
-/* {{{ proto SNMP SNMP::__construct(int version, string hostname, string community|securityName [, int timeout [, int retries]])
+/* {{{ proto SNMP::__construct(int version, string hostname, string community|securityName [, int timeout [, int retries]])
 	Creates a new SNMP session to specified host. */
 PHP_METHOD(snmp, __construct)
 {

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1192,7 +1192,7 @@ zend_object_iterator *spl_array_get_iterator(zend_class_entry *ce, zval *object,
 }
 /* }}} */
 
-/* {{{ proto void ArrayObject::__construct([array|object ar = array() [, int flags = 0 [, string iterator_class = "ArrayIterator"]]])
+/* {{{ proto ArrayObject::__construct([array|object ar = array() [, int flags = 0 [, string iterator_class = "ArrayIterator"]]])
    Constructs a new array object from an array or object. */
 SPL_METHOD(Array, __construct)
 {
@@ -1222,7 +1222,7 @@ SPL_METHOD(Array, __construct)
 }
  /* }}} */
 
-/* {{{ proto void ArrayIterator::__construct([array|object ar = array() [, int flags = 0]])
+/* {{{ proto ArrayIterator::__construct([array|object ar = array() [, int flags = 0]])
    Constructs a new array iterator from an array or object. */
 SPL_METHOD(ArrayIterator, __construct)
 {

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -750,7 +750,7 @@ void spl_filesystem_object_construct(INTERNAL_FUNCTION_PARAMETERS, zend_long cto
 }
 /* }}} */
 
-/* {{{ proto void DirectoryIterator::__construct(string path)
+/* {{{ proto DirectoryIterator::__construct(string path)
  Cronstructs a new dir iterator from a path. */
 SPL_METHOD(DirectoryIterator, __construct)
 {
@@ -1117,7 +1117,7 @@ SPL_METHOD(DirectoryIterator, isDot)
 }
 /* }}} */
 
-/* {{{ proto void SplFileInfo::__construct(string file_name)
+/* {{{ proto SplFileInfo::__construct(string file_name)
  Cronstructs a new SplFileInfo from a path. */
 /* When the constructor gets called the object is already created
    by the engine, so we must only call 'additional' initializations.
@@ -1420,7 +1420,7 @@ SPL_METHOD(SplFileInfo, _bad_state_ex)
 }
 /* }}} */
 
-/* {{{ proto void FilesystemIterator::__construct(string path [, int flags])
+/* {{{ proto FilesystemIterator::__construct(string path [, int flags])
  Cronstructs a new dir iterator from a path. */
 SPL_METHOD(FilesystemIterator, __construct)
 {
@@ -1575,7 +1575,7 @@ SPL_METHOD(RecursiveDirectoryIterator, getSubPathname)
 }
 /* }}} */
 
-/* {{{ proto int RecursiveDirectoryIterator::__construct(string path [, int flags])
+/* {{{ proto RecursiveDirectoryIterator::__construct(string path [, int flags])
  Cronstructs a new dir iterator from a path. */
 SPL_METHOD(RecursiveDirectoryIterator, __construct)
 {
@@ -1584,7 +1584,7 @@ SPL_METHOD(RecursiveDirectoryIterator, __construct)
 /* }}} */
 
 #ifdef HAVE_GLOB
-/* {{{ proto int GlobIterator::__construct(string path [, int flags])
+/* {{{ proto GlobIterator::__construct(string path [, int flags])
  Cronstructs a new dir iterator from a glob expression (no glob:// needed). */
 SPL_METHOD(GlobIterator, __construct)
 {
@@ -2246,7 +2246,7 @@ static void spl_filesystem_file_rewind(zval * this_ptr, spl_filesystem_object *i
 	}
 } /* }}} */
 
-/* {{{ proto void SplFileObject::__construct(string filename [, string mode = 'r' [, bool use_include_path  [, resource context]]]])
+/* {{{ proto SplFileObject::__construct(string filename [, string mode = 'r' [, bool use_include_path  [, resource context]]]])
    Construct a new file object */
 SPL_METHOD(SplFileObject, __construct)
 {
@@ -2306,7 +2306,7 @@ SPL_METHOD(SplFileObject, __construct)
 
 } /* }}} */
 
-/* {{{ proto void SplTempFileObject::__construct([int max_memory])
+/* {{{ proto SplTempFileObject::__construct([int max_memory])
    Construct a new temp file object */
 SPL_METHOD(SplTempFileObject, __construct)
 {

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -546,7 +546,7 @@ static int spl_fixedarray_object_count_elements(zval *object, zend_long *count) 
 }
 /* }}} */
 
-/* {{{ proto void SplFixedArray::__construct([int size])
+/* {{{ proto SplFixedArray::__construct([int size])
 */
 SPL_METHOD(SplFixedArray, __construct)
 {
@@ -574,7 +574,7 @@ SPL_METHOD(SplFixedArray, __construct)
 }
 /* }}} */
 
-/* {{{ proto void SplFixedArray::__wakeup()
+/* {{{ proto SplFixedArray::__wakeup()
 */
 SPL_METHOD(SplFixedArray, __wakeup)
 {

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -603,7 +603,7 @@ static void spl_recursive_it_it_construct(INTERNAL_FUNCTION_PARAMETERS, zend_cla
 	}
 }
 
-/* {{{ proto void RecursiveIteratorIterator::__construct(RecursiveIterator|IteratorAggregate it [, int mode = RIT_LEAVES_ONLY [, int flags = 0]]) throws InvalidArgumentException
+/* {{{ proto RecursiveIteratorIterator::__construct(RecursiveIterator|IteratorAggregate it [, int mode = RIT_LEAVES_ONLY [, int flags = 0]]) throws InvalidArgumentException
    Creates a RecursiveIteratorIterator from a RecursiveIterator. */
 SPL_METHOD(RecursiveIteratorIterator, __construct)
 {
@@ -1097,7 +1097,7 @@ static void spl_recursive_tree_iterator_get_postfix(spl_recursive_it_object *obj
 	Z_ADDREF_P(return_value);
 }
 
-/* {{{ proto void RecursiveTreeIterator::__construct(RecursiveIterator|IteratorAggregate it [, int flags = RTIT_BYPASS_KEY [, int cit_flags = CIT_CATCH_GET_CHILD [, mode = RIT_SELF_FIRST ]]]) throws InvalidArgumentException
+/* {{{ proto RecursiveTreeIterator::__construct(RecursiveIterator|IteratorAggregate it [, int flags = RTIT_BYPASS_KEY [, int cit_flags = CIT_CATCH_GET_CHILD [, mode = RIT_SELF_FIRST ]]]) throws InvalidArgumentException
    RecursiveIteratorIterator to generate ASCII graphic trees for the entries in a RecursiveIterator */
 SPL_METHOD(RecursiveTreeIterator, __construct)
 {
@@ -1610,14 +1610,14 @@ static spl_dual_it_object* spl_dual_it_construct(INTERNAL_FUNCTION_PARAMETERS, z
 	return intern;
 }
 
-/* {{{ proto void FilterIterator::__construct(Iterator it)
+/* {{{ proto FilterIterator::__construct(Iterator it)
    Create an Iterator from another iterator */
 SPL_METHOD(FilterIterator, __construct)
 {
 	spl_dual_it_construct(INTERNAL_FUNCTION_PARAM_PASSTHRU, spl_ce_FilterIterator, zend_ce_iterator, DIT_FilterIterator);
 } /* }}} */
 
-/* {{{ proto void CallbackFilterIterator::__construct(Iterator it, callback func)
+/* {{{ proto CallbackFilterIterator::__construct(Iterator it, callback func)
    Create an Iterator from another iterator */
 SPL_METHOD(CallbackFilterIterator, __construct)
 {
@@ -1899,7 +1899,7 @@ SPL_METHOD(FilterIterator, next)
 	spl_filter_it_next(getThis(), intern);
 } /* }}} */
 
-/* {{{ proto void RecursiveCallbackFilterIterator::__construct(RecursiveIterator it, callback func)
+/* {{{ proto RecursiveCallbackFilterIterator::__construct(RecursiveIterator it, callback func)
    Create a RecursiveCallbackFilterIterator from a RecursiveIterator */
 SPL_METHOD(RecursiveCallbackFilterIterator, __construct)
 {
@@ -1907,7 +1907,7 @@ SPL_METHOD(RecursiveCallbackFilterIterator, __construct)
 } /* }}} */
 
 
-/* {{{ proto void RecursiveFilterIterator::__construct(RecursiveIterator it)
+/* {{{ proto RecursiveFilterIterator::__construct(RecursiveIterator it)
    Create a RecursiveFilterIterator from a RecursiveIterator */
 SPL_METHOD(RecursiveFilterIterator, __construct)
 {
@@ -1974,7 +1974,7 @@ SPL_METHOD(RecursiveCallbackFilterIterator, getChildren)
 	}
 	zval_ptr_dtor(&retval);
 } /* }}} */
-/* {{{ proto void ParentIterator::__construct(RecursiveIterator it)
+/* {{{ proto ParentIterator::__construct(RecursiveIterator it)
    Create a ParentIterator from a RecursiveIterator */
 SPL_METHOD(ParentIterator, __construct)
 {
@@ -1982,7 +1982,7 @@ SPL_METHOD(ParentIterator, __construct)
 } /* }}} */
 
 #if HAVE_PCRE || HAVE_BUNDLED_PCRE
-/* {{{ proto void RegexIterator::__construct(Iterator it, string regex [, int mode [, int flags [, int preg_flags]]])
+/* {{{ proto RegexIterator::__construct(Iterator it, string regex [, int mode [, int flags [, int preg_flags]]])
    Create an RegexIterator from another iterator and a regular expression */
 SPL_METHOD(RegexIterator, __construct)
 {
@@ -2236,7 +2236,7 @@ SPL_METHOD(RegexIterator, setPregFlags)
 	intern->u.regex.use_flags = 1;
 } /* }}} */
 
-/* {{{ proto void RecursiveRegexIterator::__construct(RecursiveIterator it, string regex [, int mode [, int flags [, int preg_flags]]])
+/* {{{ proto RecursiveRegexIterator::__construct(RecursiveIterator it, string regex [, int mode [, int flags [, int preg_flags]]])
    Create an RecursiveRegexIterator from another recursive iterator and a regular expression */
 SPL_METHOD(RecursiveRegexIterator, __construct)
 {
@@ -2722,7 +2722,7 @@ static inline void spl_caching_it_rewind(spl_dual_it_object *intern)
 	spl_caching_it_next(intern);
 }
 
-/* {{{ proto void CachingIterator::__construct(Iterator it [, flags = CIT_CALL_TOSTRING])
+/* {{{ proto CachingIterator::__construct(Iterator it [, flags = CIT_CALL_TOSTRING])
    Construct a CachingIterator from an Iterator */
 SPL_METHOD(CachingIterator, __construct)
 {
@@ -3044,7 +3044,7 @@ static const zend_function_entry spl_funcs_CachingIterator[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void RecursiveCachingIterator::__construct(RecursiveIterator it [, flags = CIT_CALL_TOSTRING])
+/* {{{ proto RecursiveCachingIterator::__construct(RecursiveIterator it [, flags = CIT_CALL_TOSTRING])
    Create an iterator from a RecursiveIterator */
 SPL_METHOD(RecursiveCachingIterator, __construct)
 {
@@ -3100,7 +3100,7 @@ static const zend_function_entry spl_funcs_RecursiveCachingIterator[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void IteratorIterator::__construct(Traversable it)
+/* {{{ proto IteratorIterator::__construct(Traversable it)
    Create an iterator from anything that is traversable */
 SPL_METHOD(IteratorIterator, __construct)
 {
@@ -3122,7 +3122,7 @@ static const zend_function_entry spl_funcs_IteratorIterator[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void NoRewindIterator::__construct(Iterator it)
+/* {{{ proto NoRewindIterator::__construct(Iterator it)
    Create an iterator from another iterator */
 SPL_METHOD(NoRewindIterator, __construct)
 {
@@ -3220,7 +3220,7 @@ static const zend_function_entry spl_funcs_NoRewindIterator[] = {
 	PHP_FE_END
 };
 
-/* {{{ proto void InfiniteIterator::__construct(Iterator it)
+/* {{{ proto InfiniteIterator::__construct(Iterator it)
    Create an iterator from another iterator */
 SPL_METHOD(InfiniteIterator, __construct)
 {
@@ -3359,7 +3359,7 @@ void spl_append_it_next(spl_dual_it_object *intern) /* {{{ */
 	spl_append_it_fetch(intern);
 } /* }}} */
 
-/* {{{ proto void AppendIterator::__construct()
+/* {{{ proto AppendIterator::__construct()
    Create an AppendIterator */
 SPL_METHOD(AppendIterator, __construct)
 {

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -939,7 +939,7 @@ typedef enum {
 #define SPL_MULTIPLE_ITERATOR_GET_ALL_CURRENT   1
 #define SPL_MULTIPLE_ITERATOR_GET_ALL_KEY       2
 
-/* {{{ proto void MultipleIterator::__construct([int flags = MIT_NEED_ALL|MIT_KEYS_NUMERIC])
+/* {{{ proto MultipleIterator::__construct([int flags = MIT_NEED_ALL|MIT_KEYS_NUMERIC])
    Iterator that iterates over several iterators one after the other */
 SPL_METHOD(MultipleIterator, __construct)
 {

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1669,7 +1669,7 @@ PHP_METHOD(sqlite3stmt, execute)
 }
 /* }}} */
 
-/* {{{ proto int SQLite3Stmt::__construct(SQLite3 dbobject, String Statement)
+/* {{{ proto SQLite3Stmt::__construct(SQLite3 dbobject, String Statement)
    __constructor for SQLite3Stmt. */
 PHP_METHOD(sqlite3stmt, __construct)
 {
@@ -1891,7 +1891,7 @@ PHP_METHOD(sqlite3result, finalize)
 }
 /* }}} */
 
-/* {{{ proto int SQLite3Result::__construct()
+/* {{{ proto SQLite3Result::__construct()
    __constructor for SQLite3Result. */
 PHP_METHOD(sqlite3result, __construct)
 {

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -1877,7 +1877,7 @@ static TIDY_NODE_METHOD(getParent)
 /* }}} */
 
 
-/* {{{ proto void tidyNode::__construct()
+/* {{{ proto tidyNode::__construct()
          __constructor for tidyNode. */
 static TIDY_NODE_METHOD(__construct)
 {


### PR DESCRIPTION
As pointed by @krakjoe in https://github.com/php/php-src/commit/a2c7c46d5ef5b9fc945d7b655d31d5c9f1a72d34#r27762092, methods like `__construct`, `__destruct`, `__wakeup`, etc, do not have return types defined. Sorry for this misunderstand :disappointed: 