### PR TITLE
Be consistent in is_executable on a directory in any stream wrapper.

### DIFF
--- a/ext/phar/tests/phar_oo_002.phpt
+++ b/ext/phar/tests/phar_oo_002.phpt
@@ -71,7 +71,7 @@ int(0)
 string(3) "dir"
 bool(false)
 bool(true)
-bool(false)
+bool(true)
 bool(false)
 bool(true)
 bool(false)

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -905,7 +905,7 @@ PHPAPI void php_stat(const char *filename, size_t filename_length, int type, zva
 	case FS_IS_R:
 		RETURN_BOOL((ssb.sb.st_mode&rmask)!=0);
 	case FS_IS_X:
-		RETURN_BOOL((ssb.sb.st_mode&xmask)!=0 && !S_ISDIR(ssb.sb.st_mode));
+		RETURN_BOOL((ssb.sb.st_mode&xmask)!=0);
 	case FS_IS_FILE:
 		RETURN_BOOL(S_ISREG(ssb.sb.st_mode));
 	case FS_IS_DIR:


### PR DESCRIPTION
  Current code treats the 'local files' stream wrapper ('php_plain_files_wrapper')
  different than all other stream wrappers. For the 'local' stream wrapper,
  is_executable only checks the mode key in the filestat array on the file or
  directory in question. For other stream wrappers, is_executable always returns
  FALSE on a directory. This treatment is inconsistent on its face.

  Also, for a custom stream wrapper that also points to local files, the result
  of is_executable is always FALSE even though it may be TRUE if the function were
  called on the same item using the 'local' stream wrapper from PHP.

  NOTE: patch does not attempt to add a test for this as there are no tests of
  is_executable for stream wrappers.