### PR TITLE
main/php_ini.c: build empty php_load_zend_extension_cb() when !HAVE_L…

### DIFF
--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -350,6 +350,7 @@ static void php_load_php_extension_cb(void *arg)
 
 /* {{{ php_load_zend_extension_cb
  */
+#ifdef HAVE_LIBDL
 static void php_load_zend_extension_cb(void *arg)
 {
 	char *filename = *((char **) arg);
@@ -409,6 +410,9 @@ static void php_load_zend_extension_cb(void *arg)
 		efree(libpath);
 	}
 }
+#else
+static void php_load_zend_extension_cb(void *arg) { }
+#endif
 /* }}} */
 
 /* {{{ php_init_config


### PR DESCRIPTION
…IBDL

Commit 0782a7fc6314c8bd3cbfd57f12d0479bf9cc8dc7 ("Fixed bug #74866
extension_dir = "./ext" now use current directory for base") modified
the php_load_zend_extension_cb() function to use php_load_shlib(), and
pass a handle to the newly introduced zend_load_extension_handle()
function instead of passing the extension path to
zend_load_extension().

While doing so, it introduced a call to php_load_shlib() from code
that is built even when HAVE_LIBDL is not defined. However,
php_load_shlib() is not implemented when HAVE_LIBDL is not defined,
for obvious reasons.

It turns out that zend_load_extension_handle() anyway doesn't do
anything when ZEND_EXTENSIONS_SUPPORT is defined to 0, and
ZEND_EXTENSIONS_SUPPORT is not defined when HAVE_LIBDL is not defined
(Zend/zend_portability.h).

Fixes the following build failure when building on a system that
doesn't have libdl:

main/php_ini.o: In function `php_load_zend_extension_cb':
php_ini.c:(.text+0x478): undefined reference to `php_load_shlib'
php_ini.c:(.text+0x4b0): undefined reference to `php_load_shlib'
collect2: error: ld returned 1 exit status

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>