### PR TITLE
Fix 75958: Remove true return when isn't helpful

### DIFF
--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -559,7 +559,7 @@ static HashTable *spl_dllist_object_get_gc(zval *obj, zval **gc_data, int *gc_da
 }
 /* }}} */
 
-/* {{{ proto bool SplDoublyLinkedList::push(mixed value)
+/* {{{ proto void SplDoublyLinkedList::push(mixed value)
 	   Push $value on the SplDoublyLinkedList */
 SPL_METHOD(SplDoublyLinkedList, push)
 {
@@ -572,12 +572,10 @@ SPL_METHOD(SplDoublyLinkedList, push)
 
 	intern = Z_SPLDLLIST_P(getThis());
 	spl_ptr_llist_push(intern->llist, value);
-
-	RETURN_TRUE;
 }
 /* }}} */
 
-/* {{{ proto bool SplDoublyLinkedList::unshift(mixed value)
+/* {{{ proto void SplDoublyLinkedList::unshift(mixed value)
 	   Unshift $value on the SplDoublyLinkedList */
 SPL_METHOD(SplDoublyLinkedList, unshift)
 {
@@ -590,8 +588,6 @@ SPL_METHOD(SplDoublyLinkedList, unshift)
 
 	intern = Z_SPLDLLIST_P(getThis());
 	spl_ptr_llist_unshift(intern->llist, value);
-
-	RETURN_TRUE;
 }
 /* }}} */
 

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -348,7 +348,7 @@ static zval *spl_fixedarray_object_read_dimension(zval *object, zval *offset, in
 
 	if (type == BP_VAR_IS && intern->fptr_offset_has) {
 		SEPARATE_ARG_IF_REF(offset);
-		zend_call_method_with_1_params(object, intern->std.ce, &intern->fptr_offset_has, "offsetexists", rv, offset); 
+		zend_call_method_with_1_params(object, intern->std.ce, &intern->fptr_offset_has, "offsetexists", rv, offset);
 		if (UNEXPECTED(Z_ISUNDEF_P(rv))) {
 			zval_ptr_dtor(offset);
 			return NULL;
@@ -737,7 +737,7 @@ SPL_METHOD(SplFixedArray, getSize)
 }
 /* }}} */
 
-/* {{{ proto bool SplFixedArray::setSize(int size)
+/* {{{ proto void SplFixedArray::setSize(int size)
 */
 SPL_METHOD(SplFixedArray, setSize)
 {
@@ -757,7 +757,6 @@ SPL_METHOD(SplFixedArray, setSize)
 	intern = Z_SPLFIXEDARRAY_P(object);
 
 	spl_fixedarray_resize(&intern->array, size);
-	RETURN_TRUE;
 }
 /* }}} */
 

--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -573,7 +573,7 @@ SPL_METHOD(SplHeap, isEmpty)
 }
 /* }}} */
 
-/* {{{ proto bool SplHeap::insert(mixed value)
+/* {{{ proto void SplHeap::insert(mixed value)
 	   Push $value on the heap */
 SPL_METHOD(SplHeap, insert)
 {
@@ -593,8 +593,6 @@ SPL_METHOD(SplHeap, insert)
 
 	if (Z_REFCOUNTED_P(value)) Z_ADDREF_P(value);
 	spl_ptr_heap_insert(intern->heap, value, getThis());
-
-	RETURN_TRUE;
 }
 /* }}} */
 
@@ -624,7 +622,7 @@ SPL_METHOD(SplHeap, extract)
 }
 /* }}} */
 
-/* {{{ proto bool SplPriorityQueue::insert(mixed value, mixed priority)
+/* {{{ proto void SplPriorityQueue::insert(mixed value, mixed priority)
 	   Push $value with the priority $priodiry on the priorityqueue */
 SPL_METHOD(SplPriorityQueue, insert)
 {
@@ -650,8 +648,6 @@ SPL_METHOD(SplPriorityQueue, insert)
 	add_assoc_zval_ex(&elem, "priority", sizeof("priority") - 1, priority);
 
 	spl_ptr_heap_insert(intern->heap, &elem, getThis());
-
-	RETURN_TRUE;
 }
 /* }}} */
 
@@ -767,7 +763,7 @@ SPL_METHOD(SplPriorityQueue, getExtractFlags)
 }
 /* }}} */
 
-/* {{{ proto int SplHeap::recoverFromCorruption()
+/* {{{ proto void SplHeap::recoverFromCorruption()
  Recover from a corrupted state*/
 SPL_METHOD(SplHeap, recoverFromCorruption)
 {
@@ -780,8 +776,6 @@ SPL_METHOD(SplHeap, recoverFromCorruption)
 	intern = Z_SPLHEAP_P(getThis());
 
 	intern->heap->flags = intern->heap->flags & ~SPL_HEAP_CORRUPTED;
-
-	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1255,4 +1249,3 @@ PHP_MINIT_FUNCTION(spl_heap) /* {{{ */
  * vim600: fdm=marker
  * vim: noet sw=4 ts=4
  */
-

--- a/ext/spl/tests/spl_priorityqeue_insert_two_params_error.phpt
+++ b/ext/spl/tests/spl_priorityqeue_insert_two_params_error.phpt
@@ -24,7 +24,7 @@ NULL
 
 Warning: SplPriorityQueue::insert() expects exactly 2 parameters, 1 given in %s on line 8
 NULL
-bool(true)
+NULL
 
 Warning: SplPriorityQueue::insert() expects exactly 2 parameters, 3 given in %s on line 10
 NULL


### PR DESCRIPTION
As described in [#75958](https://bugs.php.net/bug.php?id=75958), some `Spl*` methods have an always return `true`, which isn't helpful if it can't have a return `false` somehow.