### PR TITLE
Support using acl_* functions on *BSD

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -630,11 +630,16 @@ if test "$PHP_FPM" != "no"; then
 
   if test "$PHP_FPM_ACL" != "no" ; then
     AC_CHECK_HEADERS([sys/acl.h])
-    AC_CHECK_LIB(acl, acl_free, [
-      PHP_ADD_LIBRARY(acl)
+    dnl *BSD has acl_* built into libc
+    AC_CHECK_FUNC(acl_free, [
       AC_DEFINE(HAVE_FPM_ACL, 1, [ POSIX Access Control List ])
     ],[
-      AC_MSG_ERROR(libacl required not found)
+      AC_CHECK_LIB(acl, acl_free, [
+        PHP_ADD_LIBRARY(acl)
+        AC_DEFINE(HAVE_FPM_ACL, 1, [ POSIX Access Control List ])
+      ],[
+        AC_MSG_ERROR(libacl required not found)
+      ])
     ])
   fi
 


### PR DESCRIPTION
The *BSD systems have ACL routines built-in in libc rather than
in separate libacl. Update the configure check to detect that and enable
ACL support without adding 'acl' library.