### PR TITLE
store vm instance count

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -152,6 +152,7 @@ void init_executor(void) /* {{{ */
 	zend_hash_init(&EG(included_files), 8, NULL, NULL, 0);
 
 	EG(ticks_count) = 0;
+	EG(vm_count) = 0;
 
 	ZVAL_UNDEF(&EG(user_error_handler));
 	ZVAL_UNDEF(&EG(user_exception_handler));

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -163,6 +163,7 @@ struct _zend_executor_globals {
 	zend_long precision;
 
 	int ticks_count;
+	int vm_count;
 
 	HashTable *in_autoload;
 	zend_function *autoload_func;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -316,6 +316,9 @@ static zend_uchar zend_user_opcodes[256] = {0,
 #define SPEC_RULE_DIM_OBJ      0x00400000
 #define SPEC_RULE_COMMUTATIVE  0x00800000
 
+#define ZEND_INCR_VM_COUNT() EG(vm_count)++
+#define ZEND_DECR_VM_COUNT() EG(vm_count)--
+
 static const uint32_t *zend_spec_handlers;
 static const void * const *zend_opcode_handlers;
 static int zend_handlers_count;
@@ -371,17 +374,17 @@ static const void *zend_vm_get_opcode_handler_func(zend_uchar opcode, const zend
 #  define ZEND_VM_CONTINUE()     return
 # endif
 # if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)
-#  define ZEND_VM_RETURN()        opline = &hybrid_halt_op; return
+#  define ZEND_VM_RETURN()        opline = &hybrid_halt_op; ZEND_DECR_VM_COUNT(); return
 #  define ZEND_VM_HOT             zend_always_inline ZEND_OPT_SIZE
 # else
-#  define ZEND_VM_RETURN()        opline = NULL; return
+#  define ZEND_VM_RETURN()        opline = NULL; ZEND_DECR_VM_COUNT(); return
 #  define ZEND_VM_HOT
 # endif
 #else
 # define ZEND_OPCODE_HANDLER_RET int
 # define ZEND_VM_TAIL_CALL(call) return call
 # define ZEND_VM_CONTINUE()      return  0
-# define ZEND_VM_RETURN()        return -1
+# define ZEND_VM_RETURN()        ZEND_DECR_VM_COUNT(); return -1
 # define ZEND_VM_HOT
 #endif
 
@@ -50941,6 +50944,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NULL_HANDLER(ZEND_OPCODE_HANDL
 
 ZEND_API void execute_ex(zend_execute_data *ex)
 {
+#if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)
+	if (EXPECTED(execute_data != NULL)) {
+		ZEND_INCR_VM_COUNT();
+	}
+#else
+	ZEND_INCR_VM_COUNT();
+#endif
+
 	DCL_OPLINE
 
 #ifdef ZEND_VM_IP_GLOBAL_REG

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -2,6 +2,14 @@
 
 ZEND_API void {%EXECUTOR_NAME%}_ex(zend_execute_data *ex)
 {
+#if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)
+	if (EXPECTED(execute_data != NULL)) {
+		ZEND_INCR_VM_COUNT();
+	}
+#else
+	ZEND_INCR_VM_COUNT();
+#endif
+
 	DCL_OPLINE
 
 	{%HELPER_VARS%}


### PR DESCRIPTION
PHP will init new zend_vm instance by functions like `zend_call_function` and this will pause current vm instance and create a new c stack frame and entrance a new vm loop.

In some situation (like the [Fiber](https://github.com/fiberphp/fiber-ext)), we need to detect whether the execution has switched into a new zend vm loop. My solution is to introduce the `EG(vm_count)` and incr/decr this value when enter or leave the zend vm.

Please offer your comments.

@dstogov 

Thank you.