### PR TITLE
Fix garbage marking in gc_collect_roots()

### DIFF
--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -1167,11 +1167,10 @@ static int gc_collect_roots(uint32_t *flags)
 	while (idx != end) {
 		current = GC_IDX2PTR(idx);
 		ref = current->ref;
-		if (GC_IS_ROOT(ref)) {
-			if (GC_REF_CHECK_COLOR(ref, GC_WHITE)) {
-				current->ref = GC_MAKE_GARBAGE(ref);
-				count += gc_collect_white(ref, flags);
-			}
+		ZEND_ASSERT(GC_IS_ROOT(ref));
+		current->ref = GC_MAKE_GARBAGE(ref);
+		if (GC_REF_CHECK_COLOR(ref, GC_WHITE)) {
+			count += gc_collect_white(ref, flags);
 		}
 		idx++;
 	}


### PR DESCRIPTION
gc_collect_white() will mark white nodes as black, but only add garbage that's not buffered yet. The already buffered roots are instead marked as garbage in gc_collect_roots() directly. However, if gc_collect_white() marked a (buffered) root as black, it would not subsequently be marked as garbage.