### PR TITLE
Fix #69948: path/domain are not sanitized in setcookie

### DIFF
--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -100,6 +100,16 @@ PHPAPI int php_setcookie(zend_string *name, zend_string *value, time_t expires, 
 		return FAILURE;
 	}
 
+	if (path && strpbrk(ZSTR_VAL(path), ",; \t\r\n\013\014") != NULL) { /* man isspace for \013 and \014 */
+		zend_error(E_WARNING, "Cookie paths cannot contain any of the following ',; \\t\\r\\n\\013\\014'" );
+		return FAILURE;
+	}
+
+	if (domain && strpbrk(ZSTR_VAL(domain), ",; \t\r\n\013\014") != NULL) { /* man isspace for \013 and \014 */
+		zend_error(E_WARNING, "Cookie domains cannot contain any of the following ',; \\t\\r\\n\\013\\014'" );
+		return FAILURE;
+	}
+
 	len += ZSTR_LEN(name);
 	if (value) {
 		if (url_encode) {

--- a/ext/standard/tests/network/bug69948.phpt
+++ b/ext/standard/tests/network/bug69948.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #69948 (path/domain are not sanitized for special characters in setcookie)
+--FILE--
+<?php
+var_dump(
+    setcookie('foo', 'bar', 0, 'asdf;asdf'),
+    setcookie('foo', 'bar', 0, '/', 'foobar; secure')
+);
+?>
+===DONE===
+--EXPECTHEADERS--
+--EXPECTF--
+Warning: Cookie paths cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+
+Warning: Cookie domains cannot contain any of the following ',; \t\r\n\013\014' in %s on line %d
+bool(false)
+bool(false)
+===DONE===


### PR DESCRIPTION
For improved security, characters not allowed for name and value should
also be forbidden for path and domain.