### PR TITLE
WIP: Implement function to get fpm status from php `fastcgi_get_status`

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1549,6 +1549,7 @@ PHP_FUNCTION(fastcgi_finish_request) /* {{{ */
 
 static const zend_function_entry cgi_fcgi_sapi_functions[] = {
 	PHP_FE(fastcgi_finish_request,              NULL)
+	PHP_FE(fastcgi_get_status,                  NULL)
 	PHP_FE_END
 };
 

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1549,7 +1549,7 @@ PHP_FUNCTION(fastcgi_finish_request) /* {{{ */
 
 static const zend_function_entry cgi_fcgi_sapi_functions[] = {
 	PHP_FE(fastcgi_finish_request,              NULL)
-	PHP_FE(fastcgi_get_status,                  NULL)
+	PHP_FE(fpm_get_status,                  NULL)
 	PHP_FE_END
 };
 

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1547,6 +1547,18 @@ PHP_FUNCTION(fastcgi_finish_request) /* {{{ */
 }
 /* }}} */
 
+/* {{{ proto array fpm_get_status
+ * Returns the status of the fastcgi process manager */
+PHP_FUNCTION(fpm_get_status) /* {{{ */
+{
+	int error = fpm_status_export_to_zval(return_value);
+	if(error){
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
+
 static const zend_function_entry cgi_fcgi_sapi_functions[] = {
 	PHP_FE(fastcgi_finish_request,              NULL)
 	PHP_FE(fpm_get_status,                  NULL)

--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -46,9 +46,9 @@ int fpm_status_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 }
 /* }}} */
 
-/* {{{ proto array fastcgi_get_status
+/* {{{ proto array fpm_get_status
  * Returns the status of the fastcgi process manager */
-PHP_FUNCTION(fastcgi_get_status)
+PHP_FUNCTION(fpm_get_status)
 {
 	struct fpm_scoreboard_s scoreboard, *scoreboard_p;
 	struct fpm_scoreboard_proc_s proc;

--- a/sapi/fpm/fpm/fpm_status.h
+++ b/sapi/fpm/fpm/fpm_status.h
@@ -22,13 +22,13 @@ struct fpm_status_s {
 };
 
 int fpm_status_init_child(struct fpm_worker_pool_s *wp);
-PHP_FUNCTION(fpm_get_status);
 void fpm_status_update_activity(struct fpm_shm_s *shm, int idle, int active, int total, unsigned cur_lq, int max_lq, int clear_last_update);
 void fpm_status_update_accepted_conn(struct fpm_shm_s *shm, unsigned long int accepted_conn);
 void fpm_status_increment_accepted_conn(struct fpm_shm_s *shm);
 void fpm_status_set_pm(struct fpm_shm_s *shm, int pm);
 void fpm_status_update_max_children_reached(struct fpm_shm_s *shm, unsigned int max_children_reached);
 void fpm_status_increment_max_children_reached(struct fpm_shm_s *shm);
+int fpm_status_export_to_zval(zval *status);
 int fpm_status_handle_request(void);
 
 extern struct fpm_shm_s *fpm_status_shm;

--- a/sapi/fpm/fpm/fpm_status.h
+++ b/sapi/fpm/fpm/fpm_status.h
@@ -22,6 +22,7 @@ struct fpm_status_s {
 };
 
 int fpm_status_init_child(struct fpm_worker_pool_s *wp);
+PHP_FUNCTION(fastcgi_get_status);
 void fpm_status_update_activity(struct fpm_shm_s *shm, int idle, int active, int total, unsigned cur_lq, int max_lq, int clear_last_update);
 void fpm_status_update_accepted_conn(struct fpm_shm_s *shm, unsigned long int accepted_conn);
 void fpm_status_increment_accepted_conn(struct fpm_shm_s *shm);

--- a/sapi/fpm/fpm/fpm_status.h
+++ b/sapi/fpm/fpm/fpm_status.h
@@ -22,7 +22,7 @@ struct fpm_status_s {
 };
 
 int fpm_status_init_child(struct fpm_worker_pool_s *wp);
-PHP_FUNCTION(fastcgi_get_status);
+PHP_FUNCTION(fpm_get_status);
 void fpm_status_update_activity(struct fpm_shm_s *shm, int idle, int active, int total, unsigned cur_lq, int max_lq, int clear_last_update);
 void fpm_status_update_accepted_conn(struct fpm_shm_s *shm, unsigned long int accepted_conn);
 void fpm_status_increment_accepted_conn(struct fpm_shm_s *shm);

--- a/sapi/fpm/tests/025.phpt
+++ b/sapi/fpm/tests/025.phpt
@@ -1,0 +1,132 @@
+--TEST--
+FPM: Test fastcgi_get_status function
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+include "include.inc";
+
+$logfile = __DIR__.'/php-fpm.log.tmp';
+$srcfile = __DIR__.'/php-fpm.tmp.php';
+$port = 9000+PHP_INT_SIZE;
+
+$cfg = <<<EOT
+[global]
+error_log = $logfile
+[unconfined]
+listen = 127.0.0.1:$port
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+EOT;
+
+$code = <<<EOT
+<?php
+echo "Test Start\n";
+var_dump(fastcgi_get_status());
+echo "Test End\n";
+EOT;
+file_put_contents($srcfile, $code);
+
+$fpm = run_fpm($cfg, $tail);
+if (is_resource($fpm)) {
+    fpm_display_log($tail, 2);
+    try {
+		$req = run_request('127.0.0.1', $port, $srcfile);
+		echo strstr($req, "Test Start");
+		echo "Request ok\n";
+	} catch (Exception $e) {
+		echo "Request error\n";
+	}
+    proc_terminate($fpm);
+    fpm_display_log($tail, -1);
+    fclose($tail);
+    proc_close($fpm);
+}
+
+?>
+Done
+--EXPECTF--
+[%s] NOTICE: fpm is running, pid %d
+[%s] NOTICE: ready to handle connections
+Test Start
+array(15) {
+  ["pool"]=>
+  string(10) "unconfined"
+  ["process-manager"]=>
+  string(7) "dynamic"
+  ["start-time"]=>
+  int(%d)
+  ["start-since"]=>
+  int(%d)
+  ["accepted-conn"]=>
+  int(1)
+  ["listen-queue"]=>
+  int(0)
+  ["max-listen-queue"]=>
+  int(0)
+  ["listen-queue-len"]=>
+  int(128)
+  ["idle-processes"]=>
+  int(0)
+  ["active-processes"]=>
+  int(1)
+  ["total-processes"]=>
+  int(1)
+  ["max-active-processes"]=>
+  int(1)
+  ["max-children-reached"]=>
+  int(0)
+  ["slow-requests"]=>
+  int(0)
+  ["procs"]=>
+  array(1) {
+    [0]=>
+    array(14) {
+      ["pid"]=>
+      int(%d)
+      ["state"]=>
+      string(7) "Running"
+      ["start-time"]=>
+      int(%d)
+      ["start-since"]=>
+      int(%d)
+      ["requests"]=>
+      int(1)
+      ["request-duration"]=>
+      int(%d)
+      ["request-method"]=>
+      string(3) "GET"
+      ["request-uri"]=>
+      string(%d) "%s"
+      ["query-string"]=>
+      string(0) ""
+      ["request-length"]=>
+      int(0)
+      ["user"]=>
+      string(1) "-"
+      ["script"]=>
+      string(%d) "%s"
+      ["last-request-cpu"]=>
+      float(0)
+      ["last-request-memory"]=>
+      int(0)
+    }
+  }
+}
+Test End
+
+Request ok
+[%s] NOTICE: Terminating ...
+[%s] NOTICE: exiting, bye-bye!
+Done
+--CLEAN--
+<?php
+	$logfile = __DIR__.'/php-fpm.log.tmp';
+	$srcfile = __DIR__.'/php-fpm.tmp.php';
+    @unlink($logfile);
+    @unlink($srcfile);
+?>

--- a/sapi/fpm/tests/025.phpt
+++ b/sapi/fpm/tests/025.phpt
@@ -1,5 +1,5 @@
 --TEST--
-FPM: Test fastcgi_get_status function
+FPM: Test fpm_get_status function
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--
@@ -26,7 +26,7 @@ EOT;
 $code = <<<EOT
 <?php
 echo "Test Start\n";
-var_dump(fastcgi_get_status());
+var_dump(fpm_get_status());
 echo "Test End\n";
 EOT;
 file_put_contents($srcfile, $code);


### PR DESCRIPTION
fastcgi_get_status allows to get fpm status information from within php. This allows to implement further status pages in php and to integrate fpm metrics with application metrics.