### PR TITLE
Crc32 header spelling fix

### DIFF
--- a/ext/standard/crc32.h
+++ b/ext/standard/crc32.h
@@ -22,7 +22,7 @@
  * This code implements the AUTODIN II polynomial
  * The variable corresponding to the macro argument "crc" should
  * be an unsigned long.
- * Oroginal code  by Spencer Garrett <srg@quick.com>
+ * Original code by Spencer Garrett <srg@quick.com>
  */
 
 #define CRC32(crc, ch)	 (crc = (crc >> 8) ^ crc32tab[(crc ^ (ch)) & 0xff])

--- a/ext/standard/tags
+++ b/ext/standard/tags
@@ -1,0 +1,3 @@
+!_TAG_FILE_SORTED	2	/0=unsorted, 1=sorted, 2=foldcase/
+CRC32	/home/khan/Documents/projects/OpenSource/php/rnaby-php-src/ext/standard/crc32.h	28;"	d	language:C++
+crc32tab	/home/khan/Documents/projects/OpenSource/php/rnaby-php-src/ext/standard/crc32.h	/^static const unsigned int crc32tab[256] = {$/;"	v	language:C++

--- a/ext/standard/tags
+++ b/ext/standard/tags
@@ -1,3 +1,0 @@
-!_TAG_FILE_SORTED	2	/0=unsorted, 1=sorted, 2=foldcase/
-CRC32	/home/khan/Documents/projects/OpenSource/php/rnaby-php-src/ext/standard/crc32.h	28;"	d	language:C++
-crc32tab	/home/khan/Documents/projects/OpenSource/php/rnaby-php-src/ext/standard/crc32.h	/^static const unsigned int crc32tab[256] = {$/;"	v	language:C++


### PR DESCRIPTION
A spelling fix and an extra space deleted.