### PR TITLE
Fix arginfo for array_replace(_recursive) and array_merge(_recursive)

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2788,7 +2788,7 @@ PHP_FUNCTION(array_unshift)
 	Z_ARRVAL_P(stack)->nNextFreeElement  = new_hash.nNextFreeElement;
 	Z_ARRVAL_P(stack)->arData            = new_hash.arData;
 	Z_ARRVAL_P(stack)->pDestructor       = new_hash.pDestructor;
-	
+
 	zend_hash_internal_pointer_reset(Z_ARRVAL_P(stack));
 
 	/* Clean up and return the number of elements in the stack */
@@ -3229,7 +3229,7 @@ static inline void php_array_merge_or_replace_wrapper(INTERNAL_FUNCTION_PARAMETE
 }
 /* }}} */
 
-/* {{{ proto array array_merge(array arr1, array arr2 [, array ...])
+/* {{{ proto array array_merge(array arr1 [, array ...])
    Merges elements from passed arrays into one array */
 PHP_FUNCTION(array_merge)
 {
@@ -3237,7 +3237,7 @@ PHP_FUNCTION(array_merge)
 }
 /* }}} */
 
-/* {{{ proto array array_merge_recursive(array arr1, array arr2 [, array ...])
+/* {{{ proto array array_merge_recursive(array arr1 [, array ...])
    Recursively merges elements from passed arrays into one array */
 PHP_FUNCTION(array_merge_recursive)
 {
@@ -3245,7 +3245,7 @@ PHP_FUNCTION(array_merge_recursive)
 }
 /* }}} */
 
-/* {{{ proto array array_replace(array arr1, array arr2 [, array ...])
+/* {{{ proto array array_replace(array arr1 [, array ...])
    Replaces elements from passed arrays into one array */
 PHP_FUNCTION(array_replace)
 {
@@ -3253,7 +3253,7 @@ PHP_FUNCTION(array_replace)
 }
 /* }}} */
 
-/* {{{ proto array array_replace_recursive(array arr1, array arr2 [, array ...])
+/* {{{ proto array array_replace_recursive(array arr1 [, array ...])
    Recursively replaces elements from passed arrays into one array */
 PHP_FUNCTION(array_replace_recursive)
 {
@@ -4099,7 +4099,7 @@ static void php_array_intersect(INTERNAL_FUNCTION_PARAMETERS, int behavior, int 
 		ZVAL_UNDEF(&list->val);
 		if (hash->nNumOfElements > 1) {
 			if (behavior == INTERSECT_NORMAL) {
-				zend_sort((void *) lists[i], hash->nNumOfElements, 
+				zend_sort((void *) lists[i], hash->nNumOfElements,
 						sizeof(Bucket), intersect_data_compare_func, (swap_func_t)zend_hash_bucket_swap);
 			} else if (behavior & INTERSECT_ASSOC) { /* triggered also when INTERSECT_KEY */
 				zend_sort((void *) lists[i], hash->nNumOfElements,

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -393,22 +393,22 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_array_slice, 0, 0, 2)
 	ZEND_ARG_INFO(0, preserve_keys)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_array_merge, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_array_merge, 0, 0, 1)
 	ZEND_ARG_INFO(0, arr1) /* ARRAY_INFO(0, arg, 0) */
 	ZEND_ARG_VARIADIC_INFO(0, arrays)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_array_merge_recursive, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_array_merge_recursive, 0, 0, 1)
 	ZEND_ARG_INFO(0, arr1) /* ARRAY_INFO(0, arg, 0) */
 	ZEND_ARG_VARIADIC_INFO(0, arrays)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_array_replace, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_array_replace, 0, 0, 1)
 	ZEND_ARG_INFO(0, arr1) /* ARRAY_INFO(0, arg, 0) */
 	ZEND_ARG_VARIADIC_INFO(0, arrays)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_array_replace_recursive, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_array_replace_recursive, 0, 0, 1)
 	ZEND_ARG_INFO(0, arr1) /* ARRAY_INFO(0, arg, 0) */
 	ZEND_ARG_VARIADIC_INFO(0, arrays)
 ZEND_END_ARG_INFO()
@@ -4042,7 +4042,7 @@ PHP_FUNCTION(long2ip)
  ********************/
 
 /* {{{ proto string getenv(string varname[, bool local_only]
-   Get the value of an environment variable or every available environment variable 
+   Get the value of an environment variable or every available environment variable
    if no varname is present  */
 PHP_FUNCTION(getenv)
 {


### PR DESCRIPTION
Am I wrong, or `array_merge` and `array_merge_recursive` can only take one array https://3v4l.org/XJlGN?

If so, note to self: fix https://php.net/array-merge-recursive
```diff
-array_merge_recursive — Merge two or more arrays recursively
+array_merge_recursive — Merge one or more arrays recursively
```

(IMHO only take one argument makes no sense, we should require two or more arrays, but I guess this would break the signature of the function, right? :disappointed: )