### PR TITLE
Reset imap_errorstack after outputting it

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -1082,6 +1082,7 @@ PHP_RSHUTDOWN_FUNCTION(imap)
 			}
 		}
 		mail_free_errorlist(&IMAPG(imap_errorstack));
+		IMAPG(imap_errorstack) = NIL;
 	}
 
 	if (IMAPG(imap_alertstack) != NIL) {


### PR DESCRIPTION
This happens in `imap_errors` as well ([source](https://github.com/php/php-src/blob/master/ext/imap/php_imap.c#L4211)), but seems to be omitted in the `shutdown` routine.