### PR TITLE
Fix bug #72185 - php-fpm writes stdout with contentlength =0 causing nginx 502

### DIFF
--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -1595,10 +1595,10 @@ int fcgi_write(fcgi_request *req, fcgi_request_type type, const char *str, int l
 		memcpy(req->out_pos, str, len);
 		req->out_pos += len;
 	} else if (len - limit < (int)(sizeof(req->out_buf) - sizeof(fcgi_header))) {
-		if (!req->out_hdr) {
-			open_packet(req, type);
-		}
 		if (limit > 0) {
+			if (!req->out_hdr) {
+				open_packet(req, type);
+			}
 			memcpy(req->out_pos, str, limit);
 			req->out_pos += limit;
 		}


### PR DESCRIPTION
Assuming:
- "len" != 0
- "limit" already includes space for an fcgi_header (line 1587: "limit -= sizeof(fcgi_header);")