### PR TITLE
Test http_response_code function

### DIFF
--- a/ext/standard/tests/general_functions/http_response_code.phpt
+++ b/ext/standard/tests/general_functions/http_response_code.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test http_response_code basic functionality
+--CREDITS--
+Gabriel Caruso (carusogabriel34@gmail.com)
+--FILE--
+<?php
+var_dump(
+    // Get the current default response code
+    http_response_code(),
+    // Set a response code
+    http_response_code(201),
+    // Get the new response code
+    http_response_code()
+);
+?>
+--EXPECT--
+bool(false)
+bool(true)
+int(201)


### PR DESCRIPTION
The `http_response_code` function wasn't been tested (http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/head.c.gcov.php)