### PR TITLE
Remove warnings from inet_pton()/inet_ntop()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -190,6 +190,7 @@ PHP                                                                        NEWS
   . Fixed bug #74719 (fopen() should accept NULL as context). (Alexander Holman)
   . Fixed bug #69948 (path/domain are not sanitized in setcookie). (cmb)
   . Fixed bug #75996 (incorrect url in header for mt_rand). (tatarbj)
+  . Remove superfluous warnings from inet_ntop()/inet_pton(). (daverandom)
 
 - Testing:
   . Implemented request #62055 (Make run-tests.php support --CGI-- sections).

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -3944,12 +3944,10 @@ PHP_NAMED_FUNCTION(zif_inet_ntop)
 	} else
 #endif
 	if (address_len != 4) {
-		php_error_docref(NULL, E_WARNING, "Invalid in_addr value");
 		RETURN_FALSE;
 	}
 
 	if (!inet_ntop(af, address, buffer, sizeof(buffer))) {
-		php_error_docref(NULL, E_WARNING, "An unknown error occurred");
 		RETURN_FALSE;
 	}
 
@@ -3980,14 +3978,12 @@ PHP_NAMED_FUNCTION(php_inet_pton)
 	} else
 #endif
 	if (!strchr(address, '.')) {
-		php_error_docref(NULL, E_WARNING, "Unrecognized address %s", address);
 		RETURN_FALSE;
 	}
 
 	ret = inet_pton(af, address, buffer);
 
 	if (ret <= 0) {
-		php_error_docref(NULL, E_WARNING, "Unrecognized address %s", address);
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/tests/network/inet.phpt
+++ b/ext/standard/tests/network/inet.phpt
@@ -43,33 +43,21 @@ string(13) "255.255.255.0"
 
 Warning: inet_ntop() expects exactly 1 parameter, 0 given in %s on line %d
 bool(false)
-
-Warning: inet_ntop(): Invalid in_addr value in %s on line %d
 bool(false)
-
-Warning: inet_ntop(): Invalid in_addr value in %s on line %d
 bool(false)
-
-Warning: inet_ntop(): Invalid in_addr value in %s on line %d
 bool(false)
 
 Warning: inet_pton() expects exactly 1 parameter, 0 given in %s on line %d
 bool(false)
-
-Warning: inet_pton(): Unrecognized address  in %s on line %d
 bool(false)
-
-Warning: inet_pton(): Unrecognized address -1 in %s on line %d
 bool(false)
-
-Warning: inet_pton(): Unrecognized address abra in %s on line %d
 bool(false)
-string(%d) "7f000001"
+string(8) "7f000001"
 string(9) "127.0.0.1"
-string(%d) "42a3a174"
+string(8) "42a3a174"
 string(14) "66.163.161.116"
-string(%d) "ffffffff"
+string(8) "ffffffff"
 string(15) "255.255.255.255"
-string(%d) "00000000"
+string(8) "00000000"
 string(7) "0.0.0.0"
 Done

--- a/ext/standard/tests/network/inet_ipv6.phpt
+++ b/ext/standard/tests/network/inet_ipv6.phpt
@@ -39,10 +39,6 @@ string(3) "::2"
 string(4) "::35"
 string(5) "::255"
 string(6) "::1024"
-
-Warning: inet_pton(): Unrecognized address  in %s on line %d
-
-Warning: inet_ntop(): Invalid in_addr value in %s on line %d
 bool(false)
 string(36) "2001:db8:85a3:8d3:1319:8a2e:370:7344"
 string(15) "2001:db8:1234::"


### PR DESCRIPTION
This patch removes the warnings emitted by `inet_ntop()`/`inet_pton()` as they do not impart any useful information not already available to userland, and superfluous warnings [can cause debugging problems](https://github.com/amphp/dns/pull/73). These functions are frequently used as a quick mechanism to validate data from external sources along with normalization and conversion, so it is reasonable to expect that bad input may be supplied and this should not be considered exceptional.

<strike>This patch targets 7.1, as the fact that these functions emit warnings is [not](https://secure.php.net/inet-ntop) [documented](https://secure.php.net/inet-pton) and the warnings do not affect the required userland logic - the return value still needs to be checked for failures.</strike>

Updated to target master.