### PR TITLE
Fixed bug #76136 (stream_socket_get_name enclosed IPv6 in brackets)

### DIFF
--- a/main/network.c
+++ b/main/network.c
@@ -648,7 +648,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
 			case AF_INET6:
 				buf = (char*)inet_ntop(sa->sa_family, &((struct sockaddr_in6*)sa)->sin6_addr, (char *)&abuf, sizeof(abuf));
 				if (buf) {
-					*textaddr = strpprintf(0, "%s:%d",
+					*textaddr = strpprintf(0, "[%s]:%d",
 						buf, ntohs(((struct sockaddr_in6*)sa)->sin6_port));
 				}
 

--- a/tests/output/bug76136.phpt
+++ b/tests/output/bug76136.phpt
@@ -6,6 +6,7 @@ $server = stream_socket_server("tcp://[::1]:1337/");
 echo stream_socket_get_name($server, false).PHP_EOL;
 $server = stream_socket_server("tcp://127.0.0.1:1337/");
 echo stream_socket_get_name($server, false);
---EXPECTF--
+?>
+--EXPECT--
 [::1]:1337
 127.0.0.1:1337

--- a/tests/output/bug76136.phpt
+++ b/tests/output/bug76136.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #76136: stream_socket_get_name should enclose IPv6 in brackets
+--FILE--
+<?php
+$server = stream_socket_server("tcp://[::1]:1337/");
+echo stream_socket_get_name($server, false).PHP_EOL;
+$server = stream_socket_server("tcp://127.0.0.1:1337/");
+echo stream_socket_get_name($server, false);
+--EXPECTF--
+[::1]:1337
+127.0.0.1:1337


### PR DESCRIPTION
The IPv6 IP of a socket is provided by the inet_ntop as a string,
but this function doesn't enclose the ip in brackets. This patch
adds them in the php_network_populate_name_from_sockaddr function.