### PR TITLE
Simple Fiber API

### DIFF
--- a/Zend/Makefile.am
+++ b/Zend/Makefile.am
@@ -16,7 +16,7 @@ libZend_la_SOURCES=\
 	zend_ini.c zend_sort.c zend_objects.c zend_object_handlers.c \
 	zend_objects_API.c zend_ts_hash.c zend_stream.c \
 	zend_default_classes.c \
-	zend_iterators.c zend_interfaces.c zend_exceptions.c \
+	zend_iterators.c zend_interfaces.c zend_exceptions.c zend_fiber.c \
 	zend_strtod.c zend_closures.c zend_float.c zend_string.c zend_signal.c \
 	zend_generators.c zend_virtual_cwd.c zend_ast.c zend_smart_str.c zend_cpuinfo.c
 

--- a/Zend/zend_default_classes.c
+++ b/Zend/zend_default_classes.c
@@ -26,6 +26,7 @@
 #include "zend_exceptions.h"
 #include "zend_closures.h"
 #include "zend_generators.h"
+#include "zend_fiber.h"
 
 
 ZEND_API void zend_register_default_classes(void)
@@ -35,6 +36,7 @@ ZEND_API void zend_register_default_classes(void)
 	zend_register_iterator_wrapper();
 	zend_register_closure_ce();
 	zend_register_generator_ce();
+	zend_register_fiber_ce();
 }
 
 /*

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -152,6 +152,7 @@ void init_executor(void) /* {{{ */
 	zend_hash_init(&EG(included_files), 8, NULL, NULL, 0);
 
 	EG(ticks_count) = 0;
+	EG(vm_count) = 0;
 
 	ZVAL_UNDEF(&EG(user_error_handler));
 	ZVAL_UNDEF(&EG(user_exception_handler));

--- a/Zend/zend_fiber.c
+++ b/Zend/zend_fiber.c
@@ -1,0 +1,628 @@
+/* fiber extension for PHP (c) 2017 Haitao Lv <php@lvht.net> */
+
+#include "zend.h"
+#include "zend_API.h"
+#include "zend_closures.h"
+#include "zend_exceptions.h"
+#include "zend_fiber.h"
+#include "zend_interfaces.h"
+#include "zend_vm.h"
+
+static zend_class_entry *zend_ce_fiber;
+static zend_object_handlers zend_fiber_handlers;
+
+ZEND_DECLARE_MODULE_GLOBALS(fiber)
+
+static zend_object *zend_fiber_create(zend_class_entry *ce);
+static void zend_fiber_close(zend_fiber *fiber);
+static void fiber_interrupt_function(zend_execute_data *execute_data);
+
+static void (*orig_interrupt_function)(zend_execute_data *execute_data);
+
+static zend_op_array fiber_terminate_func;
+static zend_try_catch_element fiber_terminate_try_catch_array = {0,1,0,0};
+static zend_op fiber_terminate_op[2];
+
+static void zend_fiber_cleanup_unfinished_execution(zend_execute_data *execute_data) /* {{{ */
+{
+	if (execute_data->opline != execute_data->func->op_array.opcodes) {
+		/* -1 required because we want the last run opcode, not the next to-be-run one. */
+		uint32_t op_num = execute_data->opline - execute_data->func->op_array.opcodes - 1;
+
+		zend_cleanup_unfinished_execution(execute_data, op_num, 0);
+	}
+}
+/* }}} */
+
+static void zend_fiber_close(zend_fiber *fiber) /* {{{ */
+{
+	zend_vm_stack original_stack;
+	size_t original_stack_page_size;
+	zend_execute_data *execute_data;
+
+	if (UNEXPECTED(fiber->status == ZEND_FIBER_STATUS_INIT)) {
+		return;
+	}
+
+	original_stack = EG(vm_stack);
+	original_stack->top = EG(vm_stack_top);
+	original_stack->end = EG(vm_stack_end);
+	original_stack_page_size = EG(vm_stack_page_size);
+
+	EG(vm_stack_top) = fiber->stack->top;
+	EG(vm_stack_end) = fiber->stack->end;
+	EG(vm_stack) = fiber->stack;
+	EG(vm_stack_page_size) = fiber->stack_size;
+
+	if (EXPECTED(fiber->status == ZEND_FIBER_STATUS_FINISHED)) {
+		goto LABEL_FREE_STACK;
+	}
+
+	if (UNEXPECTED(fiber->status == ZEND_FIBER_STATUS_DEAD)) {
+		goto LABEL_FREE_STACK;
+	}
+
+	execute_data = fiber->execute_data;
+
+	while (execute_data) {
+		if (EX_CALL_INFO() & ZEND_CALL_HAS_SYMBOL_TABLE) {
+			zend_clean_and_cache_symbol_table(execute_data->symbol_table);
+		}
+
+		zend_free_compiled_variables(execute_data);
+
+		if (UNEXPECTED(EX_CALL_INFO() & ZEND_CALL_RELEASE_THIS)) {
+			zend_object *object = Z_OBJ(execute_data->This);
+			if (UNEXPECTED(EG(exception) != NULL) && (EX_CALL_INFO() & ZEND_CALL_CTOR)) {
+				GC_DELREF(object);
+				zend_object_store_ctor_failed(object);
+			}
+			OBJ_RELEASE(object);
+		} else if (UNEXPECTED(EX_CALL_INFO() & ZEND_CALL_CLOSURE)) {
+			OBJ_RELEASE(ZEND_CLOSURE_OBJECT(execute_data->func));
+		}
+
+		zend_vm_stack_free_extra_args(execute_data);
+
+		/* A fatal error / die occurred during the fiber execution.
+		 * Trying to clean up the stack may not be safe in this case. */
+		if (UNEXPECTED(CG(unclean_shutdown))) {
+			EG(vm_stack_top) = original_stack->top;
+			EG(vm_stack_end) = original_stack->end;
+			EG(vm_stack) = original_stack;
+			EG(vm_stack_page_size) = original_stack_page_size;
+			return;
+		}
+
+		/* Some cleanups are only necessary if the fiber was closed
+		 * before it could finish execution (reach a return statement). */
+		zend_fiber_cleanup_unfinished_execution(execute_data);
+
+		zend_execute_data *call = execute_data;
+		execute_data = execute_data->prev_execute_data;
+
+		zend_vm_stack_free_call_frame(call);
+	}
+
+LABEL_FREE_STACK:
+	zend_vm_stack_destroy();
+
+	fiber->stack = NULL;
+
+	EG(vm_stack_top) = original_stack->top;
+	EG(vm_stack_end) = original_stack->end;
+	EG(vm_stack) = original_stack;
+	EG(vm_stack_page_size) = original_stack_page_size;
+}
+/* }}} */
+
+static void zend_fiber_free_storage(zend_object *object) /* {{{ */
+{
+	zend_fiber *fiber = (zend_fiber*) object;
+
+	zend_fiber_close(fiber);
+
+	zval_ptr_dtor(&fiber->callable);
+
+	zend_object_std_dtor(&fiber->std);
+}
+/* }}} */
+
+static zend_object *zend_fiber_create(zend_class_entry *ce) /* {{{ */
+{
+	zend_fiber *fiber;
+
+	fiber = emalloc(sizeof(zend_fiber));
+	memset(fiber, 0, sizeof(zend_fiber));
+
+	zend_object_std_init(&fiber->std, ce);
+	fiber->std.handlers = &zend_fiber_handlers;
+
+	return &fiber->std;
+}
+/* }}} */
+
+static int zend_fiber_start(zend_fiber *fiber, zval *params, uint32_t param_count) /* {{{ */
+{
+	zend_execute_data *call;
+	zend_fcall_info_cache fci_cache;
+	zend_function *func;
+	char *error = NULL;
+	zend_vm_stack stack;
+	zend_vm_stack current_stack;
+	size_t current_stack_page_size;
+	zend_execute_data *fiber_frame;
+	uint32_t i;
+
+	if (!zend_is_callable_ex(&fiber->callable, NULL, IS_CALLABLE_CHECK_SILENT, NULL, &fci_cache, &error)) {
+		zend_throw_error(NULL, "Attempt to start non callable Fiber, %s", error);
+		efree(error);
+		return FAILURE;
+	}
+
+	func = fci_cache.function_handler;
+
+	if (param_count < func->common.required_num_args) {
+		zend_throw_error(zend_ce_argument_count_error,
+			"Too few arguments for callable given to Fiber, %d required, %d given",
+			func->common.required_num_args,
+			param_count);
+		return FAILURE;
+	}
+
+	current_stack = EG(vm_stack);
+	current_stack->top = EG(vm_stack_top);
+	current_stack->end = EG(vm_stack_end);
+	current_stack_page_size = EG(vm_stack_page_size);
+
+	stack = (zend_vm_stack)emalloc(fiber->stack_size);
+	stack->top = ZEND_VM_STACK_ELEMENTS(stack) + 1;
+	stack->end = (zval*)((char*)stack + fiber->stack_size);
+	stack->prev = NULL;
+
+	EG(vm_stack) = stack;
+	EG(vm_stack_top) = EG(vm_stack)->top;
+	EG(vm_stack_end) = EG(vm_stack)->end;
+	EG(vm_stack_page_size) = fiber->stack_size;
+
+	fiber_frame = (zend_execute_data*)EG(vm_stack_top);
+	EG(vm_stack_top) = (zval*)fiber_frame + ZEND_CALL_FRAME_SLOT;
+	zend_vm_init_call_frame(fiber_frame, ZEND_CALL_TOP_FUNCTION, (zend_function*)&fiber_terminate_func, 0, NULL, NULL);
+	fiber_frame->opline = fiber_terminate_op;
+	fiber_frame->call = NULL;
+	fiber_frame->return_value = NULL;
+	fiber_frame->prev_execute_data = NULL;
+
+	call = zend_vm_stack_push_call_frame(ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_DYNAMIC,
+		func, param_count, fci_cache.called_scope, fci_cache.object);
+
+	for (i = 0; i < param_count; i++) {
+		zval *param;
+		zval *arg = &params[i];
+
+		if (ARG_SHOULD_BE_SENT_BY_REF(func, i + 1)) {
+			if (UNEXPECTED(!Z_ISREF_P(arg))) {
+				if (!ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
+					/* By-value send is not allowed -- emit a warning,
+					 * but still perform the call with a by-value send. */
+					zend_error(E_WARNING,
+						"Parameter %d to %s%s%s() expected to be a reference, value given", i+1,
+						func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
+						func->common.scope ? "::" : "",
+						ZSTR_VAL(func->common.function_name));
+					if (UNEXPECTED(EG(exception))) {
+						ZEND_CALL_NUM_ARGS(call) = i;
+						zend_vm_stack_free_args(call);
+						zend_vm_stack_free_call_frame(call);
+
+						// TODO: cleanup
+
+						EG(vm_stack) = current_stack;
+						EG(vm_stack_top) = current_stack->top;
+						EG(vm_stack_end) = current_stack->end;
+						EG(vm_stack_page_size) = current_stack_page_size;
+
+						return FAILURE;
+					}
+				}
+			}
+		} else {
+			if (Z_ISREF_P(arg) && !(func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
+				/* don't separate references for __call */
+				arg = Z_REFVAL_P(arg);
+			}
+		}
+
+		param = ZEND_CALL_ARG(call, i+1);
+		ZVAL_COPY(param, arg);
+	}
+
+	if (UNEXPECTED(func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
+		uint32_t call_info;
+
+		GC_ADDREF(ZEND_CLOSURE_OBJECT(func));
+		call_info = ZEND_CALL_CLOSURE;
+		if (func->common.fn_flags & ZEND_ACC_FAKE_CLOSURE) {
+			call_info |= ZEND_CALL_FAKE_CLOSURE;
+		}
+		ZEND_ADD_CALL_FLAG(call, call_info);
+	}
+
+	zend_init_func_execute_data(call, &func->op_array, NULL);
+	call->prev_execute_data = fiber_frame;
+
+	fiber->root_execute_data = call;
+	fiber->execute_data = call;
+	fiber->status = ZEND_FIBER_STATUS_SUSPENDED;
+
+	fiber->stack = EG(vm_stack);
+	fiber->stack->top = EG(vm_stack_top);
+	fiber->stack->end = EG(vm_stack_end);
+
+	EG(vm_stack) = current_stack;
+	EG(vm_stack_top) = current_stack->top;
+	EG(vm_stack_end) = current_stack->end;
+	EG(vm_stack_page_size) = current_stack_page_size;
+
+	return SUCCESS;
+}
+/* }}} */
+
+static void fiber_interrupt_function(zend_execute_data *execute_data)/*{{{*/
+{
+	zend_fiber *fiber;
+	zval *exception;
+
+	if (FIBER_G(pending_interrupt)) {
+		FIBER_G(pending_interrupt) = 0;
+
+		fiber = FIBER_G(current_fiber);
+		if (fiber) {
+			/* Suspend current fiber */
+			if (EXPECTED(fiber->status == ZEND_FIBER_STATUS_RUNNING)) {
+				fiber->execute_data = execute_data;
+				fiber->status = ZEND_FIBER_STATUS_SUSPENDED;
+			}
+			fiber->stack = EG(vm_stack);
+			fiber->stack->top = EG(vm_stack_top);
+			fiber->stack->end = EG(vm_stack_end);
+		} else {
+			/* Backup main execution context */
+			FIBER_G(orig_execute_data) = execute_data;
+			FIBER_G(orig_stack) = EG(vm_stack);
+			FIBER_G(orig_stack)->top = EG(vm_stack_top);
+			FIBER_G(orig_stack)->end = EG(vm_stack_end);
+			FIBER_G(orig_stack_page_size) = EG(vm_stack_page_size);
+		}
+
+		fiber = FIBER_G(next_fiber);
+		if (fiber) {
+			/* Resume next fiber */
+			ZEND_ASSERT(fiber->status == ZEND_FIBER_STATUS_SUSPENDED);
+			EG(current_execute_data) = fiber->execute_data;
+			EG(vm_stack) = fiber->stack;
+			EG(vm_stack_top) = fiber->stack->top;
+			EG(vm_stack_end) = fiber->stack->end;
+			EG(vm_stack_page_size) = fiber->stack_size;
+			fiber->status = ZEND_FIBER_STATUS_RUNNING;
+
+			if (UNEXPECTED(FIBER_G(exception))) {
+				exception = FIBER_G(exception);
+				FIBER_G(exception) = NULL;
+
+				fiber->execute_data->opline--;
+				zend_throw_exception_internal(exception);
+				fiber->execute_data->opline++;
+			}
+		} else {
+			/* Restore main execution context */
+			EG(current_execute_data) = FIBER_G(orig_execute_data);
+			EG(vm_stack) = FIBER_G(orig_stack);
+			EG(vm_stack_top) = FIBER_G(orig_stack)->top;
+			EG(vm_stack_end) = FIBER_G(orig_stack)->end;
+			EG(vm_stack_page_size) = FIBER_G(orig_stack_page_size);
+		}
+
+		FIBER_G(current_fiber) = fiber;
+		FIBER_G(next_fiber) = NULL;
+
+		if (UNEXPECTED(EG(exception))) {
+			zend_rethrow_exception(EG(current_execute_data));
+		}
+	}
+
+	if (UNEXPECTED(FIBER_G(release_this))) {
+		GC_DELREF((zend_object *)fiber);
+		FIBER_G(release_this) = 0;
+	}
+
+	if (orig_interrupt_function) {
+		orig_interrupt_function(execute_data);
+	}
+}/*}}}*/
+
+static int fiber_terminate_opcode_handler(zend_execute_data *execute_data) /* {{{ */
+{
+	zend_fiber *fiber = FIBER_G(current_fiber);
+
+	ZEND_ASSERT(fiber != NULL);
+
+	FIBER_G(next_fiber) = fiber->original_fiber;
+	FIBER_G(pending_interrupt) = 1;
+
+	fiber->original_fiber = NULL;
+	fiber->send_value = NULL;
+	if (EG(exception)) {
+		fiber->status = ZEND_FIBER_STATUS_DEAD;
+	} else {
+		fiber->status = ZEND_FIBER_STATUS_FINISHED;
+	}
+
+	fiber_interrupt_function(execute_data);
+
+	return ZEND_USER_OPCODE_ENTER;
+}
+/* }}} */
+
+/* {{{ proto Fiber Fiber::__construct(callable, int stack_size)
+ * Create a Fiber from a callable. */
+ZEND_METHOD(Fiber, __construct)
+{
+	zval *callable = NULL;
+	zend_fiber *fiber = NULL;
+	zend_long stack_size = EG(fiber_stack_page_size);
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_ZVAL(callable);
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(stack_size);
+	ZEND_PARSE_PARAMETERS_END();
+
+	fiber = (zend_fiber *) Z_OBJ_P(getThis());
+	fiber->status = ZEND_FIBER_STATUS_INIT;
+	fiber->stack_size = stack_size;
+
+	if (callable) {
+		ZVAL_COPY(&fiber->callable, callable);
+	}
+}
+/* }}} */
+
+/* {{{ proto mixed Fiber::resume(vars...)
+ * Resume and send a value to the fiber */
+ZEND_METHOD(Fiber, resume)
+{
+	zval *params;
+	uint32_t param_count;
+	zend_fiber *fiber;
+
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC('+', params, param_count)
+	ZEND_PARSE_PARAMETERS_END();
+
+	fiber = (zend_fiber *) Z_OBJ_P(getThis());
+
+	if (fiber->status == ZEND_FIBER_STATUS_INIT) {
+		if (zend_fiber_start(fiber, params, param_count) != SUCCESS) {
+			return;
+		}
+		fiber->zend_vm_id = EG(vm_count);
+	} else if (fiber->status == ZEND_FIBER_STATUS_SUSPENDED) {
+		if (param_count) {
+			if (param_count == 1) {
+				if (fiber->send_value) {
+					ZVAL_COPY(fiber->send_value, params);
+					fiber->send_value = NULL;
+				}
+			} else {
+				zend_throw_error(zend_ce_argument_count_error,
+					"Only one argument allowed when resuming an initialized Fiber");
+				return;
+			}
+		}
+	} else {
+		zend_throw_error(NULL, "Attempt to resume non suspended Fiber");
+		return;
+	}
+
+	fiber->root_execute_data->return_value = USED_RET() ? return_value : NULL;
+	fiber->original_fiber = FIBER_G(current_fiber);
+	FIBER_G(next_fiber) = fiber;
+	FIBER_G(pending_interrupt) = 1;
+	EG(vm_interrupt) = 1;
+
+	if (UNEXPECTED(EX_CALL_INFO() & ZEND_CALL_RELEASE_THIS)) {
+		GC_ADDREF((zend_object *)fiber);
+		FIBER_G(release_this) = 1;
+	}
+}
+/* }}} */
+
+/* {{{ proto mixed Fiber::yield([var])
+ * Pause and return a value to the fiber */
+ZEND_METHOD(Fiber, yield)
+{
+	zend_fiber *fiber = FIBER_G(current_fiber);
+	zval *ret = NULL;
+
+	if (!fiber) {
+		zend_throw_error(NULL, "Cannot call Fiber::yield out of Fiber");
+		return;
+	}
+
+	if (UNEXPECTED(fiber->zend_vm_id != EG(vm_count))) {
+		zend_throw_error(NULL, "Attempt to resume across internal call");
+		return;
+	}
+
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL(ret);
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (ret && fiber->root_execute_data->return_value) {
+		ZVAL_COPY(fiber->root_execute_data->return_value, ret);
+		fiber->root_execute_data->return_value = NULL;
+	}
+
+	fiber->send_value = USED_RET() ? return_value : NULL;
+
+	FIBER_G(next_fiber) = fiber->original_fiber;
+	fiber->original_fiber = NULL;
+	FIBER_G(pending_interrupt) = 1;
+	EG(vm_interrupt) = 1;
+}
+/* }}} */
+
+/* {{{ proto void Fiber::status()
+ * Get fiber's status */
+ZEND_METHOD(Fiber, status)
+{
+	zend_fiber *fiber = (zend_fiber *) Z_OBJ_P(getThis());
+	RETURN_LONG(fiber->status);
+}
+/* }}} */
+
+/* {{{ proto void Fiber::__wakeup()
+ * Throws an Exception as fibers can't be serialized */
+ZEND_METHOD(Fiber, __wakeup)
+{
+	/* Just specifying the zend_class_unserialize_deny handler is not enough,
+	 * because it is only invoked for C unserialization. For O the error has
+	 * to be thrown in __wakeup. */
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	zend_throw_exception(NULL, "Unserialization of 'Fiber' is not allowed", 0);
+}
+/* }}} */
+
+/* {{{ proto mixed Fiber::throw(Throwable exception)
+ * Throws an exception into the fiber */
+ZEND_METHOD(Fiber, throw)
+{
+	zval *exception;
+	zend_fiber *fiber;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(exception)
+	ZEND_PARSE_PARAMETERS_END();
+
+	Z_TRY_ADDREF_P(exception);
+
+	fiber = (zend_fiber *) Z_OBJ_P(getThis());
+
+	if (fiber->status == ZEND_FIBER_STATUS_SUSPENDED) {
+		FIBER_G(exception) = exception;
+	} else {
+		zend_throw_exception_object(exception);
+		return;
+	}
+
+	fiber->root_execute_data->return_value = USED_RET() ? return_value : NULL;
+	fiber->original_fiber = FIBER_G(current_fiber);
+	FIBER_G(next_fiber) = fiber;
+	FIBER_G(pending_interrupt) = 1;
+	EG(vm_interrupt) = 1;
+
+	if (UNEXPECTED(EX_CALL_INFO() & ZEND_CALL_RELEASE_THIS)) {
+		GC_ADDREF((zend_object *)fiber);
+		FIBER_G(release_this) = 1;
+	}
+}
+/* }}} */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_fiber_create, 0, 0, 1)/*{{{*/
+	ZEND_ARG_CALLABLE_INFO(0, callable, 0)
+	ZEND_ARG_TYPE_INFO(0, stack_size, IS_LONG, 0)
+ZEND_END_ARG_INFO()/*}}}*/
+
+ZEND_BEGIN_ARG_INFO(arginfo_fiber_void, 0)/*{{{*/
+ZEND_END_ARG_INFO()/*}}}*/
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_fiber_resume, 0, 0, 0)/*{{{*/
+	ZEND_ARG_VARIADIC_INFO(0, vars)
+ZEND_END_ARG_INFO()/*}}}*/
+
+ZEND_BEGIN_ARG_INFO(arginfo_fiber_yield, 0)/*{{{*/
+	ZEND_ARG_INFO(0, ret)
+ZEND_END_ARG_INFO()/*}}}*/
+
+ZEND_BEGIN_ARG_INFO(arginfo_fiber_throw, 0)/*{{{*/
+	 ZEND_ARG_OBJ_INFO(0, exception, Throwable, 0)
+ZEND_END_ARG_INFO()/*}}}*/
+
+static const zend_function_entry fiber_functions[] = {/*{{{*/
+	ZEND_ME(Fiber, __construct, arginfo_fiber_create, ZEND_ACC_PUBLIC)
+	ZEND_ME(Fiber, resume,      arginfo_fiber_resume, ZEND_ACC_PUBLIC)
+	ZEND_ME(Fiber, yield,       arginfo_fiber_yield,  ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Fiber, throw,       arginfo_fiber_throw,  ZEND_ACC_PUBLIC)
+	ZEND_ME(Fiber, status,      arginfo_fiber_void,   ZEND_ACC_PUBLIC)
+	ZEND_ME(Fiber, __wakeup,    arginfo_fiber_void,   ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};/*}}}*/
+
+/* {{{ PHP_MINIT_FUNCTION
+ **/
+void zend_register_fiber_ce()
+{
+	zend_class_entry ce;
+	zend_uchar opcode = ZEND_VM_LAST_OPCODE + 1;
+
+	/* Create new user opcode to terminate Fiber */
+	while (1) {
+		if (opcode == 255) {
+			// TODO FAIL
+			return;
+		} else if (zend_get_user_opcode_handler(opcode) == NULL) {
+			break;
+		}
+		opcode++;
+	}
+	zend_set_user_opcode_handler(opcode, fiber_terminate_opcode_handler);
+
+	memset(fiber_terminate_op, 0, sizeof(fiber_terminate_op));
+	/* Also set op1_type, op2_type and result_type to IS_UNUSED */
+
+	fiber_terminate_op[0].opcode = opcode;
+	zend_vm_set_opcode_handler_ex(fiber_terminate_op, 0, 0, 0);
+	fiber_terminate_op[1].opcode = opcode;
+	zend_vm_set_opcode_handler_ex(fiber_terminate_op + 1, 0, 0, 0);
+
+	memset(&fiber_terminate_func, 0, sizeof(fiber_terminate_func));
+	fiber_terminate_func.type = ZEND_USER_FUNCTION;
+	fiber_terminate_func.function_name = zend_string_init("Fiber::__construct", sizeof("Fiber::__construct")-1, 1);
+	fiber_terminate_func.filename = ZSTR_EMPTY_ALLOC();
+	fiber_terminate_func.opcodes = fiber_terminate_op;
+	fiber_terminate_func.last_try_catch = 1;
+	fiber_terminate_func.try_catch_array = &fiber_terminate_try_catch_array;
+
+	INIT_CLASS_ENTRY(ce, "Fiber", fiber_functions);
+	zend_ce_fiber = zend_register_internal_class(&ce);
+	zend_ce_fiber->ce_flags |= ZEND_ACC_FINAL;
+	zend_ce_fiber->create_object = zend_fiber_create;
+	zend_ce_fiber->serialize = zend_class_serialize_deny;
+	zend_ce_fiber->unserialize = zend_class_unserialize_deny;
+
+	memcpy(&zend_fiber_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+	zend_fiber_handlers.free_obj = zend_fiber_free_storage;
+	zend_fiber_handlers.clone_obj = NULL;
+
+	REGISTER_FIBER_CLASS_CONST_LONG("STATUS_INIT", (zend_long)ZEND_FIBER_STATUS_INIT);
+	REGISTER_FIBER_CLASS_CONST_LONG("STATUS_SUSPENDED", (zend_long)ZEND_FIBER_STATUS_SUSPENDED);
+	REGISTER_FIBER_CLASS_CONST_LONG("STATUS_RUNNING", (zend_long)ZEND_FIBER_STATUS_RUNNING);
+	REGISTER_FIBER_CLASS_CONST_LONG("STATUS_FINISHED", (zend_long)ZEND_FIBER_STATUS_FINISHED);
+	REGISTER_FIBER_CLASS_CONST_LONG("STATUS_DEAD", (zend_long)ZEND_FIBER_STATUS_DEAD);
+
+	orig_interrupt_function = zend_interrupt_function;
+	zend_interrupt_function = fiber_interrupt_function;
+}
+/* }}} */
+
+/*
+ * vim: sw=4 ts=4
+ * vim600: fdm=marker
+ */

--- a/Zend/zend_fiber.h
+++ b/Zend/zend_fiber.h
@@ -1,0 +1,63 @@
+/* fiber extension for PHP (c) 2017 Haitao Lv <php@lvht.net> */
+
+#ifndef PHP_FIBER_H
+# define PHP_FIBER_H
+
+extern zend_module_entry fiber_module_entry;
+
+typedef struct _zend_fiber zend_fiber;
+
+struct _zend_fiber {
+	zend_object std;
+
+	zval callable;
+
+	/* The suspended execution context. */
+	zend_execute_data *root_execute_data;
+	zend_execute_data *execute_data;
+
+	/* The separate stack used by fiber */
+	zend_vm_stack stack;
+	size_t stack_size;
+	int zend_vm_id;
+
+	/* original fiber to yield from this */
+	zend_fiber *original_fiber;
+
+	zval *send_value;
+
+	zend_uchar status;
+};
+
+static const zend_uchar ZEND_FIBER_STATUS_INIT      = 0;
+static const zend_uchar ZEND_FIBER_STATUS_SUSPENDED = 1;
+static const zend_uchar ZEND_FIBER_STATUS_RUNNING   = 2;
+static const zend_uchar ZEND_FIBER_STATUS_FINISHED  = 3;
+static const zend_uchar ZEND_FIBER_STATUS_DEAD      = 4;
+
+#define REGISTER_FIBER_CLASS_CONST_LONG(const_name, value) \
+	zend_declare_class_constant_long(zend_ce_fiber, const_name, sizeof(const_name)-1, (zend_long)value);
+
+ZEND_BEGIN_MODULE_GLOBALS(fiber)
+	zend_fiber *current_fiber;
+	zend_fiber *next_fiber;
+	zval       *exception;
+
+	/* Suspended main execution context */
+	zend_execute_data *orig_execute_data;
+	zend_vm_stack orig_stack;
+	size_t orig_stack_page_size;
+
+	volatile zend_bool pending_interrupt;
+	volatile zend_bool release_this;
+ZEND_END_MODULE_GLOBALS(fiber)
+
+#define FIBER_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(fiber, v)
+
+void zend_register_generator_ce(void);
+
+#endif	/* PHP_FIBER_H */
+/*
+ * vim: sw=4 ts=4
+ * vim600: fdm=marker
+ */

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -163,6 +163,7 @@ struct _zend_executor_globals {
 	zend_long precision;
 
 	int ticks_count;
+	int vm_count;
 
 	HashTable *in_autoload;
 	zend_function *autoload_func;

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -157,6 +157,8 @@ struct _zend_executor_globals {
 	zend_vm_stack  vm_stack;
 	size_t         vm_stack_page_size;
 
+	zend_long fiber_stack_page_size;
+
 	struct _zend_execute_data *current_execute_data;
 	zend_class_entry *fake_scope; /* used to avoid checks accessing properties */
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -318,6 +318,9 @@ static zend_uchar zend_user_opcodes[256] = {0,
 #define SPEC_RULE_COMMUTATIVE  0x00800000
 #define SPEC_RULE_ISSET        0x01000000
 
+#define ZEND_INCR_VM_COUNT() EG(vm_count)++
+#define ZEND_DECR_VM_COUNT() EG(vm_count)--
+
 static const uint32_t *zend_spec_handlers;
 static const void * const *zend_opcode_handlers;
 static int zend_handlers_count;
@@ -373,17 +376,17 @@ static const void *zend_vm_get_opcode_handler_func(zend_uchar opcode, const zend
 #  define ZEND_VM_CONTINUE()     return
 # endif
 # if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)
-#  define ZEND_VM_RETURN()        opline = &hybrid_halt_op; return
+#  define ZEND_VM_RETURN()        opline = &hybrid_halt_op; ZEND_DECR_VM_COUNT(); return
 #  define ZEND_VM_HOT             zend_always_inline ZEND_OPT_SIZE
 # else
-#  define ZEND_VM_RETURN()        opline = NULL; return
+#  define ZEND_VM_RETURN()        opline = NULL; ZEND_DECR_VM_COUNT(); return
 #  define ZEND_VM_HOT
 # endif
 #else
 # define ZEND_OPCODE_HANDLER_RET int
 # define ZEND_VM_TAIL_CALL(call) return call
 # define ZEND_VM_CONTINUE()      return  0
-# define ZEND_VM_RETURN()        return -1
+# define ZEND_VM_RETURN()        ZEND_DECR_VM_COUNT(); return -1
 # define ZEND_VM_HOT
 #endif
 
@@ -50809,6 +50812,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NULL_HANDLER(ZEND_OPCODE_HANDL
 
 ZEND_API void execute_ex(zend_execute_data *ex)
 {
+#if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)
+	if (EXPECTED(execute_data != NULL)) {
+		ZEND_INCR_VM_COUNT();
+	}
+#else
+	ZEND_INCR_VM_COUNT();
+#endif
+
 	DCL_OPLINE
 
 #ifdef ZEND_VM_IP_GLOBAL_REG

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -2,6 +2,14 @@
 
 ZEND_API void {%EXECUTOR_NAME%}_ex(zend_execute_data *ex)
 {
+#if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)
+	if (EXPECTED(execute_data != NULL)) {
+		ZEND_INCR_VM_COUNT();
+	}
+#else
+	ZEND_INCR_VM_COUNT();
+#endif
+
 	DCL_OPLINE
 
 	{%HELPER_VARS%}

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -1729,6 +1729,9 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
 					out($f,"#define SPEC_RULE_COMMUTATIVE  0x00800000\n");
 					out($f,"#define SPEC_RULE_ISSET        0x01000000\n");
 					out($f,"\n");
+					out($f,"#define ZEND_INCR_VM_COUNT() EG(vm_count)++\n");
+					out($f,"#define ZEND_DECR_VM_COUNT() EG(vm_count)--\n");
+					out($f,"\n");
 					out($f,"static const uint32_t *zend_spec_handlers;\n");
 					out($f,"static const void * const *zend_opcode_handlers;\n");
 					out($f,"static int zend_handlers_count;\n");
@@ -1790,20 +1793,20 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
 							out($f,"# endif\n");
 							if ($kind == ZEND_VM_KIND_HYBRID) {
 								out($f,"# if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)\n");
-								out($f,"#  define ZEND_VM_RETURN()        opline = &hybrid_halt_op; return\n");
+								out($f,"#  define ZEND_VM_RETURN()        opline = &hybrid_halt_op; ZEND_DECR_VM_COUNT(); return\n");
 								out($f,"#  define ZEND_VM_HOT             zend_always_inline ZEND_OPT_SIZE\n");
 								out($f,"# else\n");
-								out($f,"#  define ZEND_VM_RETURN()        opline = NULL; return\n");
+								out($f,"#  define ZEND_VM_RETURN()        opline = NULL; ZEND_DECR_VM_COUNT(); return\n");
 								out($f,"#  define ZEND_VM_HOT\n");
 								out($f,"# endif\n");
 							} else {
-								out($f,"# define ZEND_VM_RETURN()        opline = NULL; return\n");
+								out($f,"# define ZEND_VM_RETURN()        opline = NULL; ZEND_DECR_VM_COUNT(); return\n");
 							}
 							out($f,"#else\n");
 							out($f,"# define ZEND_OPCODE_HANDLER_RET int\n");
 							out($f,"# define ZEND_VM_TAIL_CALL(call) return call\n");
 							out($f,"# define ZEND_VM_CONTINUE()      return  0\n");
-							out($f,"# define ZEND_VM_RETURN()        return -1\n");
+							out($f,"# define ZEND_VM_RETURN()        ZEND_DECR_VM_COUNT(); return -1\n");
 							if ($kind == ZEND_VM_KIND_HYBRID) {
 								out($f,"# define ZEND_VM_HOT\n");
 							}
@@ -1883,7 +1886,7 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
 							out($f,"#define HANDLE_EXCEPTION() LOAD_OPLINE(); ZEND_VM_CONTINUE()\n");
 							out($f,"#define HANDLE_EXCEPTION_LEAVE() LOAD_OPLINE(); ZEND_VM_LEAVE()\n");
 							out($f,"#define ZEND_VM_CONTINUE() goto zend_vm_continue\n");
-							out($f,"#define ZEND_VM_RETURN()   return\n");
+							out($f,"#define ZEND_VM_RETURN()   ZEND_DECR_VM_COUNT(); return\n");
 							out($f,"#define ZEND_VM_ENTER_EX() ZEND_VM_INTERRUPT_CHECK(); ZEND_VM_CONTINUE()\n");
 							out($f,"#define ZEND_VM_ENTER()    execute_data = EG(current_execute_data); LOAD_OPLINE(); ZEND_VM_ENTER_EX()\n");
 							out($f,"#define ZEND_VM_LEAVE()    ZEND_VM_CONTINUE()\n");
@@ -1920,7 +1923,7 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
 								out($f,"#define HANDLE_EXCEPTION_LEAVE() goto ZEND_HANDLE_EXCEPTION_LABEL\n");
 							}
 							out($f,"#define ZEND_VM_CONTINUE() goto *(void**)(OPLINE->handler)\n");
-							out($f,"#define ZEND_VM_RETURN()   return\n");
+							out($f,"#define ZEND_VM_RETURN()   ZEND_DECR_VM_COUNT(); return\n");
 							out($f,"#define ZEND_VM_ENTER_EX() ZEND_VM_INTERRUPT_CHECK(); ZEND_VM_CONTINUE()\n");
 							out($f,"#define ZEND_VM_ENTER()    execute_data = EG(current_execute_data); LOAD_OPLINE(); ZEND_VM_ENTER_EX()\n");
 							out($f,"#define ZEND_VM_LEAVE()    ZEND_VM_CONTINUE()\n");
@@ -2912,7 +2915,7 @@ function gen_vm($def, $skel) {
 		out($f,"#undef ZEND_VM_LEAVE\n");
 		out($f,"#undef ZEND_VM_DISPATCH\n");
 		out($f,"#define ZEND_VM_CONTINUE()   return  0\n");
-		out($f,"#define ZEND_VM_RETURN()     return -1\n");
+		out($f,"#define ZEND_VM_RETURN()     ZEND_DECR_VM_COUNT(); return -1\n");
 		out($f,"#define ZEND_VM_ENTER_EX()   return  1\n");
 		out($f,"#define ZEND_VM_ENTER()      return  1\n");
 		out($f,"#define ZEND_VM_LEAVE()      return  2\n");

--- a/configure.ac
+++ b/configure.ac
@@ -1522,7 +1522,7 @@ PHP_ADD_SOURCES(Zend, \
     zend_list.c zend_builtin_functions.c zend_sprintf.c \
     zend_ini.c zend_sort.c zend_multibyte.c zend_ts_hash.c zend_stream.c \
     zend_iterators.c zend_interfaces.c zend_exceptions.c zend_strtod.c zend_gc.c \
-    zend_closures.c zend_float.c zend_string.c zend_signal.c zend_generators.c \
+    zend_closures.c zend_float.c zend_string.c zend_signal.c zend_generators.c zend_fiber.c\
     zend_virtual_cwd.c zend_ast.c zend_objects.c zend_object_handlers.c zend_objects_API.c \
     zend_default_classes.c zend_inheritance.c zend_smart_str.c zend_cpuinfo.c, \
 	-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)

--- a/main/main.c
+++ b/main/main.c
@@ -633,6 +633,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("user_ini.filename",		".user.ini",	PHP_INI_SYSTEM,		OnUpdateString,		user_ini_filename,	php_core_globals,		core_globals)
 	STD_PHP_INI_ENTRY("user_ini.cache_ttl",		"300",			PHP_INI_SYSTEM,		OnUpdateLong,		user_ini_cache_ttl,	php_core_globals,		core_globals)
 	STD_PHP_INI_ENTRY("hard_timeout",			"2",			PHP_INI_SYSTEM,		OnUpdateLong,		hard_timeout,		zend_executor_globals,	executor_globals)
+	STD_PHP_INI_ENTRY("fiber.stack_size",		"4096",			PHP_INI_SYSTEM,		OnUpdateLongGEZero,	fiber_stack_page_size,	zend_executor_globals,	executor_globals)
 #ifdef PHP_WIN32
 	STD_PHP_INI_BOOLEAN("windows.show_crt_warning",		"0",		PHP_INI_ALL,		OnUpdateBool,			windows_show_crt_warning,			php_core_globals,	core_globals)
 #endif

--- a/tests/fiber/001-fiber-class-exists.phpt
+++ b/tests/fiber/001-fiber-class-exists.phpt
@@ -1,0 +1,12 @@
+--TEST--
+tests Fiber class
+--FILE--
+<?php
+echo class_exists('Fiber'), "\n";
+$f = new Fiber(function () {});
+var_dump($f);
+?>
+--EXPECTF--
+1
+object(Fiber)#%d (0) {
+}

--- a/tests/fiber/002-simple-yield.phpt
+++ b/tests/fiber/002-simple-yield.phpt
@@ -1,0 +1,17 @@
+--TEST--
+tests Fiber::yield
+--FILE--
+<?php
+$f = new Fiber(function () {
+    echo "start\n";
+    Fiber::yield();
+    echo "end\n";
+});
+$f->resume();
+echo "fiber\n";
+$f->resume();
+?>
+--EXPECTF--
+start
+fiber
+end

--- a/tests/fiber/003-variable-yield.phpt
+++ b/tests/fiber/003-variable-yield.phpt
@@ -1,0 +1,26 @@
+--TEST--
+tests Fiber::yield variable
+--FILE--
+<?php
+$f = new Fiber(function () {
+    Fiber::yield("string");
+    Fiber::yield(1);
+    Fiber::yield([1, 2]);
+    Fiber::yield(new stdclass);
+});
+var_dump($f->resume());
+var_dump($f->resume());
+var_dump($f->resume());
+var_dump($f->resume());
+?>
+--EXPECTF--
+string(6) "string"
+int(1)
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+}
+object(stdClass)#%d (0) {
+}

--- a/tests/fiber/004-resume-with-arguments.phpt
+++ b/tests/fiber/004-resume-with-arguments.phpt
@@ -1,0 +1,26 @@
+--TEST--
+tests Fiber resume args
+--FILE--
+<?php
+$f = new Fiber(function ($a) {
+    var_dump($a);
+    var_dump(Fiber::yield());
+    var_dump(Fiber::yield());
+    var_dump(Fiber::yield());
+});
+$f->resume("string");
+$f->resume(1);
+$f->resume([1,2]);
+$f->resume(new stdclass);
+?>
+--EXPECTF--
+string(6) "string"
+int(1)
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+}
+object(stdClass)#%d (0) {
+}

--- a/tests/fiber/005-stacked-yield.phpt
+++ b/tests/fiber/005-stacked-yield.phpt
@@ -1,0 +1,27 @@
+--TEST--
+tests Fiber stackful await
+--FILE--
+<?php
+function foo()
+{
+    echo "before\n";
+    Fiber::yield();
+    echo "after\n";
+}
+$f = new Fiber(function () {
+    foo();
+    Fiber::yield();
+    echo "bye\n";
+});
+$f->resume();
+echo "await\n";
+$f->resume();
+echo "await2\n";
+$f->resume();
+?>
+--EXPECTF--
+before
+await
+after
+await2
+bye

--- a/tests/fiber/006-status.phpt
+++ b/tests/fiber/006-status.phpt
@@ -1,0 +1,36 @@
+--TEST--
+tests Fiber status
+--FILE--
+<?php
+$f = new Fiber(function () {
+    Fiber::yield();
+});
+
+var_dump($f->status() == Fiber::STATUS_INIT);
+$f->resume();
+var_dump($f->status() == Fiber::STATUS_SUSPENDED);
+$f->resume();
+var_dump($f->status() == Fiber::STATUS_FINISHED);
+try {
+    $f->resume();
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+var_dump($f->status() == Fiber::STATUS_FINISHED);
+
+$f = new Fiber(function () {
+    throw new Exception;
+});
+try {
+    $f->resume();
+} catch (Exception $e) {
+}
+var_dump($f->status() == Fiber::STATUS_DEAD);
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(true)
+Attempt to resume non suspended Fiber
+bool(true)
+bool(true)

--- a/tests/fiber/007-uncaught-error.phpt
+++ b/tests/fiber/007-uncaught-error.phpt
@@ -1,0 +1,30 @@
+--TEST--
+tests Fiber status
+--FILE--
+<?php
+function bar()
+{
+    $a = null;
+    Fiber::yield();
+    $a->foo();
+}
+function foo()
+{
+    bar();
+}
+$f = new Fiber(function () {
+    foo();
+});
+
+$f->resume();
+$f->resume();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Call to a member function foo() on null in %s%e007-uncaught-error.php:6
+Stack trace:
+#0 %s%e007-uncaught-error.php(10): bar()
+#1 %s%e007-uncaught-error.php(13): foo()
+#2 (0): {closure}()
+#3 {main}
+  thrown in %s%e007-uncaught-error.php on line 6

--- a/tests/fiber/008-yield-across-inner-call.phpt
+++ b/tests/fiber/008-yield-across-inner-call.phpt
@@ -1,0 +1,22 @@
+--TEST--
+tests Fiber::yield across inner call
+--FILE--
+<?php
+$f = new Fiber(function () {
+    array_map(function ($i) {
+        Fiber::yield($i);
+    }, [1]);
+});
+
+$f->resume();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Attempt to resume across internal call in %s/008-yield-across-inner-call.php:%d
+Stack trace:
+#0 %s/008-yield-across-inner-call.php(%d): Fiber::yield(%d)
+#1 [internal function]: {closure}(%d)
+#2 %s/008-yield-across-inner-call.php(%d): array_map(Object(Closure), Array)
+#3 (0): {closure}()
+#4 {main}
+  thrown in %s/008-yield-across-inner-call.php on line %d

--- a/tests/fiber/009-yield-outside-fiber.phpt
+++ b/tests/fiber/009-yield-outside-fiber.phpt
@@ -1,0 +1,12 @@
+--TEST--
+tests Fiber::yield out of fiber internal call
+--FILE--
+<?php
+Fiber::yield();
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Cannot call Fiber::yield out of Fiber in %s/009-yield-outside-fiber.php:%d
+Stack trace:
+#0 %s/009-yield-outside-fiber.php(%d): Fiber::yield()
+#1 {main}
+  thrown in %s/009-yield-outside-fiber.php on line %d

--- a/tests/fiber/010-yield-as-statement.phpt
+++ b/tests/fiber/010-yield-as-statement.phpt
@@ -1,0 +1,14 @@
+--TEST--
+tests Fiber::yield without assign
+--FILE--
+<?php
+$f = new Fiber(function ($a) {
+    Fiber::yield(1);
+    Fiber::yield(1);
+});
+
+$f->resume(1);
+$f->resume(1);
+$f->resume(1);
+?>
+--EXPECTF--

--- a/tests/fiber/014-stacked-resume.phpt
+++ b/tests/fiber/014-stacked-resume.phpt
@@ -1,0 +1,16 @@
+--TEST--
+tests Fiber stackful resume value
+--FILE--
+<?php
+function foo()
+{
+    return Fiber::yield();
+}
+$f = new Fiber(function () {
+    echo foo();
+});
+$f->resume();
+$f->resume('foo');
+?>
+--EXPECTF--
+foo

--- a/tests/fiber/015-stacked-yield-with-value.phpt
+++ b/tests/fiber/015-stacked-yield-with-value.phpt
@@ -1,0 +1,19 @@
+--TEST--
+tests Fiber stackful yield value
+--FILE--
+<?php
+function foo()
+{
+    Fiber::yield(1);
+}
+
+$f = new Fiber(function () {
+    foo();
+    Fiber::yield(2);
+});
+var_dump($f->resume());
+var_dump($f->resume());
+?>
+--EXPECTF--
+int(1)
+int(2)

--- a/tests/fiber/016-extended-stack-frame.phpt
+++ b/tests/fiber/016-extended-stack-frame.phpt
@@ -1,0 +1,22 @@
+--TEST--
+tests Fiber for extended stack frame
+--FILE--
+<?php
+function foo()
+{
+    Fiber::yield(1);
+}
+
+$f = new Fiber(function () {
+    foo(1, 2, 3, 4);
+    Fiber::yield(2);
+    return 3;
+}, 128);
+var_dump($f->resume());
+var_dump($f->resume());
+var_dump($f->resume());
+?>
+--EXPECTF--
+int(1)
+int(2)
+int(3)

--- a/tests/fiber/017-exception-on-resume.phpt
+++ b/tests/fiber/017-exception-on-resume.phpt
@@ -1,0 +1,31 @@
+--TEST--
+tests Fiber for exception
+--FILE--
+<?php
+function foo()
+{
+    Fiber::yield();
+    throw new Exception();
+}
+
+function bar()
+{
+    Fiber::yield();
+    foo();
+}
+
+$f = new Fiber('bar');
+
+$f->resume();
+$f->resume();
+
+try {
+    $f->resume();
+} catch (\Exception $e) {
+    echo $e->getTraceAsString();
+}
+?>
+--EXPECTF--
+#0 %s/017-exception-on-resume.php(11): foo()
+#1 (0): bar()
+#2 {main}

--- a/tests/fiber/018-construct-with-non-callable.phpt
+++ b/tests/fiber/018-construct-with-non-callable.phpt
@@ -1,0 +1,15 @@
+--TEST--
+tests Fiber for error memory leak
+--FILE--
+<?php
+$f = new Fiber;
+$f->resume();
+?>
+--EXPECTF--
+Warning: Fiber::__construct() expects at least 1 parameter, 0 given in %s/018-construct-with-non-callable.php on line 2
+
+Fatal error: Uncaught Error: Attempt to start non callable Fiber, no array or string given in %s/018-construct-with-non-callable.php:3
+Stack trace:
+#0 %s/018-construct-with-non-callable.php(3): Fiber->resume()
+#1 {main}
+  thrown in %s/018-construct-with-non-callable.php on line 3

--- a/tests/fiber/019-throw.phpt
+++ b/tests/fiber/019-throw.phpt
@@ -1,0 +1,16 @@
+--TEST--
+tests Fiber for throw exception
+--FILE--
+<?php
+$f = new Fiber(function () {
+    try {
+        $a = Fiber::yield();
+    } catch (Exception $e) {
+        echo $e->getMessage();
+    }
+});
+$f->resume();
+$f->throw(new Exception("foo"));
+?>
+--EXPECTF--
+foo

--- a/tests/fiber/020-resume-with-too-few-arguments.phpt
+++ b/tests/fiber/020-resume-with-too-few-arguments.phpt
@@ -1,0 +1,15 @@
+--TEST--
+test too few arguments to resume
+--FILE--
+<?php
+$f = new Fiber(function ($a) {
+    Fiber::yield($a);
+});
+$f->resume();
+?>
+--EXPECTF--
+Fatal error: Uncaught ArgumentCountError: Too few arguments for callable given to Fiber, 1 required, 0 given in %s/020-resume-with-too-few-arguments.php:5
+Stack trace:
+#0 %s/020-resume-with-too-few-arguments.php(5): Fiber->resume()
+#1 {main}
+  thrown in %s/020-resume-with-too-few-arguments.php on line 5

--- a/tests/fiber/021-throw-return-value.phpt
+++ b/tests/fiber/021-throw-return-value.phpt
@@ -1,0 +1,16 @@
+--TEST--
+tests Fiber for throw exception
+--FILE--
+<?php
+$f = new Fiber(function () {
+    try {
+        $a = Fiber::yield();
+    } catch (Exception $e) {
+        return $e->getMessage();
+    }
+});
+$f->resume();
+echo $f->throw(new Exception("foo"));
+?>
+--EXPECTF--
+foo

--- a/tests/fiber/022-throw-catch-and-yield.phpt
+++ b/tests/fiber/022-throw-catch-and-yield.phpt
@@ -1,0 +1,17 @@
+--TEST--
+tests yield from catch block within fiber
+--FILE--
+<?php
+$f = new Fiber(function () {
+    try {
+        $a = Fiber::yield();
+    } catch (Exception $e) {
+        return Fiber::yield($e->getMessage());
+    }
+});
+$f->resume();
+echo $f->throw(new Exception("foo"));
+echo $f->resume("bar");
+?>
+--EXPECTF--
+foobar

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -231,7 +231,7 @@ ADD_SOURCES("Zend", "zend_language_parser.c zend_language_scanner.c \
 	zend_hash.c zend_list.c zend_builtin_functions.c \
 	zend_sprintf.c zend_ini.c zend_sort.c zend_multibyte.c zend_ts_hash.c \
 	zend_stream.c zend_iterators.c zend_interfaces.c zend_objects.c \
-	zend_object_handlers.c zend_objects_API.c \
+	zend_object_handlers.c zend_objects_API.c zend_fiber.c \
 	zend_default_classes.c zend_execute.c zend_strtod.c zend_gc.c zend_closures.c \
 	zend_float.c zend_string.c zend_generators.c zend_virtual_cwd.c zend_ast.c \
 	zend_inheritance.c zend_smart_str.c zend_cpuinfo.c");


### PR DESCRIPTION
The RFC is at [here](https://wiki.php.net/rfc/fiber) and the original work can be founded at [here](https://github.com/fiberphp/fiber-ext).

This is a simple implementation. We only backup/restore the zend stack. So the following code will trigger fatal error(not core dump).
```
<?php
$f = new Fiber(function () {
    array_map(function ($i) {
        Fiber::yield($i);
    }, [1]);
});

$f->resume();
```

And @martinschroeder are working at a more powerful and more heavy weight implementation at [here](https://github.com/fiberphp/fiber-ext/pull/30). @martinschroeder's implementation backup/restore both the zend stack and the c stack, so it works for almost all situations.

However, I think @martinschroeder's implementation is a little completed. So I make this simple PR.

Please offer your @dstogov comments.

Thanks.