### PR TITLE
Fix failing tests upstream

### DIFF
--- a/ext/standard/tests/streams/bug70198.phpt
+++ b/ext/standard/tests/streams/bug70198.phpt
@@ -7,13 +7,13 @@ if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 --FILE--
 <?php
 
-/* What is checked here is 
+/* What is checked here is
 	- start a server and listen
 	- as soon as client connects, close connection and exit
 	- on the client side - sleep(1) and check feof()
 */
 
-$srv_addr = "tcp://127.0.0.1:8964";
+$srv_addr = "tcp://127.0.0.1:10000";
 $srv_fl = dirname(__FILE__) . "/bug70198_svr_" . md5(uniqid()) . ".php";
 $srv_fl_cont = <<<SRV
 <?php
@@ -58,4 +58,3 @@ unlink($srv_fl);
 --EXPECT--
 int(0)
 ==DONE==
-

--- a/sapi/cli/tests/php_cli_server.inc
+++ b/sapi/cli/tests/php_cli_server.inc
@@ -1,6 +1,6 @@
 <?php
 define ("PHP_CLI_SERVER_HOSTNAME", "localhost");
-define ("PHP_CLI_SERVER_PORT", 8964);
+define ("PHP_CLI_SERVER_PORT", 10000);
 define ("PHP_CLI_SERVER_ADDRESS", PHP_CLI_SERVER_HOSTNAME.":".PHP_CLI_SERVER_PORT);
 
 function php_cli_server_start($code = 'echo "Hello world";', $router = 'index.php', $cmd_args = null) {
@@ -91,4 +91,3 @@ function php_cli_server_stop($handle) {
     return $success;
 }
 ?>
-

--- a/sapi/cli/tests/php_cli_server_002.phpt
+++ b/sapi/cli/tests/php_cli_server_002.phpt
@@ -4,7 +4,7 @@ $_SERVER variable
 allow_url_fopen=1
 --SKIPIF--
 <?php
-include "skipif.inc"; 
+include "skipif.inc";
 ?>
 --FILE--
 <?php
@@ -12,9 +12,9 @@ include "php_cli_server.inc";
 php_cli_server_start('var_dump($_SERVER["DOCUMENT_ROOT"], $_SERVER["SERVER_SOFTWARE"], $_SERVER["SERVER_NAME"], $_SERVER["SERVER_PORT"]);');
 var_dump(file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS));
 ?>
---EXPECTF--	
+--EXPECTF--
 string(%d) "string(%d) "%stests"
 string(%d) "PHP %s Development Server"
 string(%d) "localhost"
-string(%d) "8964"
+string(%d) "10000"
 "


### PR DESCRIPTION
Several tests are failing upstream (http://gcov.php.net/viewer.php?version=PHP_HEAD&func=tests) due some connection refuse:
```
Warning: stream_socket_client(): unable to connect to tcp://127.0.0.1:8964 (Connection refused)
```

This is an attempt to fix it changing the port