### PR TITLE
Update hyperlinks used in phpinfo function

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -808,7 +808,7 @@ PHPAPI void php_print_info(int flag)
 	        the_time = time(NULL);
 	        ta = php_localtime_r(&the_time, &tmbuf);
 
-            php_info_print("<a href=\"http://www.php.net/\"><img border=\"0\" src=\"");
+            php_info_print("<a href=\"https://php.net/\"><img border=\"0\" src=\"");
 	        if (ta && (ta->tm_mon==3) && (ta->tm_mday==1)) {
 		        php_info_print(PHP_EGG_LOGO_DATA_URI "\" alt=\"PHP logo\" /></a>");
 	        } else {
@@ -916,7 +916,7 @@ PHPAPI void php_print_info(int flag)
 		/* Zend Engine */
 		php_info_print_box_start(0);
 		if (!sapi_module.phpinfo_as_text) {
-			php_info_print("<a href=\"http://www.zend.com/\"><img border=\"0\" src=\"");
+			php_info_print("<a href=\"https://www.zend.com/\"><img border=\"0\" src=\"");
 			php_info_print(ZEND_LOGO_DATA_URI "\" alt=\"Zend logo\" /></a>\n");
 		}
 		php_info_print("This program makes use of the Zend Scripting Language Engine:");

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -808,7 +808,7 @@ PHPAPI void php_print_info(int flag)
 	        the_time = time(NULL);
 	        ta = php_localtime_r(&the_time, &tmbuf);
 
-            php_info_print("<a href=\"https://php.net/\"><img border=\"0\" src=\"");
+            php_info_print("<a href=\"https://secure.php.net/\"><img border=\"0\" src=\"");
 	        if (ta && (ta->tm_mon==3) && (ta->tm_mday==1)) {
 		        php_info_print(PHP_EGG_LOGO_DATA_URI "\" alt=\"PHP logo\" /></a>");
 	        } else {


### PR DESCRIPTION
1. The www.php.net site is extremely slow on the first request, probably because it's rarely used and needs to "wake up" to serve the first request in a while, compared to just php.net which is always fast. Also changing it to HTTPS.

2. Now referencing HTTPS Zend website.