### PR TITLE
Built-in web server: No Content-Type header if MIME type is unknown

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2031,9 +2031,6 @@ static int php_cli_server_begin_send_static(php_cli_server *server, php_cli_serv
 		php_cli_server_chunk *chunk;
 		smart_str buffer = { 0 };
 		const char *mime_type = get_mime_type(server, client->request.ext, client->request.ext_len);
-		if (!mime_type) {
-			mime_type = "application/octet-stream";
-		}
 
 		append_http_status_line(&buffer, client->request.protocol_version, status, 1);
 		if (!buffer.s) {
@@ -2042,12 +2039,14 @@ static int php_cli_server_begin_send_static(php_cli_server *server, php_cli_serv
 			return FAILURE;
 		}
 		append_essential_headers(&buffer, client, 1);
-		smart_str_appendl_ex(&buffer, "Content-Type: ", sizeof("Content-Type: ") - 1, 1);
-		smart_str_appends_ex(&buffer, mime_type, 1);
-		if (strncmp(mime_type, "text/", 5) == 0) {
-			smart_str_appends_ex(&buffer, "; charset=UTF-8", 1);
+		if (mime_type) {
+			smart_str_appendl_ex(&buffer, "Content-Type: ", sizeof("Content-Type: ") - 1, 1);
+			smart_str_appends_ex(&buffer, mime_type, 1);
+			if (strncmp(mime_type, "text/", 5) == 0) {
+				smart_str_appends_ex(&buffer, "; charset=UTF-8", 1);
+			}
+			smart_str_appendl_ex(&buffer, "\r\n", 2, 1);
 		}
-		smart_str_appendl_ex(&buffer, "\r\n", 2, 1);
 		smart_str_appends_ex(&buffer, "Content-Length: ", 1);
 		smart_str_append_unsigned_ex(&buffer, client->request.sb.st_size, 1);
 		smart_str_appendl_ex(&buffer, "\r\n", 2, 1);


### PR DESCRIPTION
The [built-in web server](https://secure.php.net/manual/en/features.commandline.webserver.php) currently sends a response with `Content-Type: application/octet-stream` when the MIME type of a file is unknown. If the web server sends a response without a `Content-Type` header, when the MIME type of a file is unknown, then it will give the web browser a chance to detect the correct type. 

What problem does this solve, why does this matter? For static site generators. Specifically when users want to test a website with clean URLs, where some of the generated HTML files don't have an extension. For example URLs like `http://website/about/what-we-do`, where there's no trailing slash. With this patch it works out of the box, no configuration, no router script necessary. Let me know if you need more information.

See also [HTTP 1.0](https://tools.ietf.org/html/rfc1945#section-7.2.1),  [HTTP 1.1](https://tools.ietf.org/html/rfc2616#section-7.2.1), [Apache 2.4 documentation](http://httpd.apache.org/docs/2.4/mod/core.html#defaulttype), [MIME type for unknown data](https://stackoverflow.com/questions/1176022/unknown-file-type-mime/28652339#28652339)