### PR TITLE
ext/xml/expat_compat.h: add missing php.h include

### DIFF
--- a/ext/xml/expat_compat.h
+++ b/ext/xml/expat_compat.h
@@ -154,6 +154,7 @@ PHP_XML_API const XML_Char *XML_ExpatVersion(void);
 PHP_XML_API void XML_ParserFree(XML_Parser);
 
 #elif defined(HAVE_LIBEXPAT)
+#include "php.h"
 #include <expat.h>
 #endif /* HAVE_LIBEXPAT */
 


### PR DESCRIPTION
When expat support is disabled and libxml support is enabled, the
following part of the code in expat_compat.h gets used:

and therefore "php".h" is included. However, when libexpat support is
enabled, HAVE_LIBEXPAT is defined, and therefore the following part of
the code is used:

In this case, "php.h" is not included. Due to this, zend_alloc.h is
never included when building the ext/xmlrpc/libxmlrpc/xml_element.c
file, and therefore the estrdup -> _estrdup macros are never defined,
causing the following link time failure:

ext/xmlrpc/libxmlrpc/xml_element.o: In function `xml_element_serialize':
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:462: undefined reference to `efree'
ext/xmlrpc/libxmlrpc/xml_element.o: In function `xml_elem_entity_escape':
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:347: undefined reference to `emalloc'
ext/xmlrpc/libxmlrpc/xml_element.o: In function `_xmlrpc_charHandler':
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:646: undefined reference to `efree'
ext/xmlrpc/libxmlrpc/xml_element.o: In function `xml_elem_free_non_recurse':
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:198: undefined reference to `efree'
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:199: undefined reference to `efree'
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:200: undefined reference to `efree'
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:207: undefined reference to `efree'
ext/xmlrpc/libxmlrpc/xml_element.o: In function `xml_elem_new':
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:263: undefined reference to `ecalloc'
ext/xmlrpc/libxmlrpc/xml_element.o: In function `_xmlrpc_startElement':
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:602: undefined reference to `estrdup'
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:607: undefined reference to `emalloc'
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:609: undefined reference to `estrdup'
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:610: undefined reference to `estrdup'
ext/xmlrpc/libxmlrpc/xml_element.o: In function `xml_elem_free_non_recurse':
/home/thomas/projets/php/ext/xmlrpc/libxmlrpc/xml_element.c:211: undefined reference to `efree'
collect2: error: ld returned 1 exit status
make: *** [Makefile:248: sapi/cgi/php-cgi] Error 1

This link time failure can be produced with:

./configure --prefix=/usr --with-libdir=/usr/lib64 --disable-all \
	    --without-pear --with-config-file-path=/etc --disable-phpdbg \
	    --disable-cli --enable-cgi --disable-fpm --enable-xmlreader \
	    --enable-xmlwriter --enable-libxml --enable-wddx --with-xmlrpc \
	    --with-libexpat-dir=/

We fix it by including "php.h" in the HAVE_LIBEXPAT case.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>