### PR TITLE
Fix bug #76198

### DIFF
--- a/Zend/tests/typehints/bug76198.phpt
+++ b/Zend/tests/typehints/bug76198.phpt
@@ -1,0 +1,13 @@
+--TEST--
+"iterable" must not be fully qualified
+--FILE--
+<?php
+
+function foo(): \iterable {
+	return [];
+}
+var_dump(foo());
+
+?>
+--EXPECTF--
+Fatal error: Type declaration 'iterable' must be unqualified in %s on line %d

--- a/Zend/tests/typehints/fully_qualified_scalar.phpt
+++ b/Zend/tests/typehints/fully_qualified_scalar.phpt
@@ -10,4 +10,4 @@ foo(1);
 
 ?>
 --EXPECTF--
-Fatal error: Scalar type declaration 'int' must be unqualified in %s on line %d
+Fatal error: Type declaration 'int' must be unqualified in %s on line %d

--- a/Zend/tests/typehints/namespace_relative_scalar.phpt
+++ b/Zend/tests/typehints/namespace_relative_scalar.phpt
@@ -8,4 +8,4 @@ test(0);
 
 ?>
 --EXPECTF--
-Fatal error: Scalar type declaration 'int' must be unqualified in %s on line %d
+Fatal error: Type declaration 'int' must be unqualified in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5419,7 +5419,7 @@ static void zend_compile_typename(zend_ast *ast, zend_arg_info *arg_info, zend_b
 		if (type != 0) {
 			if ((ast->attr & ZEND_NAME_NOT_FQ) != ZEND_NAME_NOT_FQ) {
 				zend_error_noreturn(E_COMPILE_ERROR,
-					"Scalar type declaration '%s' must be unqualified",
+					"Type declaration '%s' must be unqualified",
 					ZSTR_VAL(zend_string_tolower(class_name)));
 			}
 			arg_info->type = ZEND_TYPE_ENCODE(type, allow_null);


### PR DESCRIPTION
The wording of the warning suggests that `iterable` is a scalar type when it definitely is not as neither `array` nor `Traversable` are scalar types.