### PR TITLE
Don't assume URIs with dots as static (#61286).

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1373,7 +1373,7 @@ static void php_cli_server_request_translate_vpath(php_cli_server_request *reque
 	char *buf = safe_pemalloc(1, request->vpath_len, 1 + document_root_len + 1 + sizeof("index.html"), 1);
 	char *p = buf, *prev_path = NULL, *q, *vpath;
 	size_t prev_path_len = 0;
-	int  is_static_file = 0;
+	int is_php = 0;
 
 	if (!buf) {
 		return;
@@ -1385,11 +1385,12 @@ static void php_cli_server_request_translate_vpath(php_cli_server_request *reque
 	if (request->vpath_len > 0 && request->vpath[0] != '/') {
 		*p++ = DEFAULT_SLASH;
 	}
-	q = request->vpath + request->vpath_len;
-	while (q > request->vpath) {
-		if (*q-- == '.') {
-			is_static_file = 1;
-			break;
+	q = request->vpath;
+	{
+		if (q) {
+			char *dot = strrchr(q, '.');
+			if (dot && !strcmp(dot, ".php"))
+				is_php = 1;
 		}
 	}
 	memmove(p, request->vpath, request->vpath_len);
@@ -1420,7 +1421,7 @@ static void php_cli_server_request_translate_vpath(php_cli_server_request *reque
 					}
 					file++;
 				}
-				if (!*file || is_static_file) {
+				if (!*file || is_php) {
 					if (prev_path) {
 						pefree(prev_path, 1);
 					}

--- a/sapi/cli/tests/bug61286.phpt
+++ b/sapi/cli/tests/bug61286.phpt
@@ -21,7 +21,7 @@ if (!$fp) {
 }
 
 if(fwrite($fp, <<<HEADER
-GET /foo/bar HTTP/1.1
+GET /foo/bar.anyext HTTP/1.1
 Host: {$host}
 
 
@@ -39,9 +39,8 @@ if (!$fp) {
   die("connect failed");
 }
 
-
 if(fwrite($fp, <<<HEADER
-GET /foo/bar/ HTTP/1.0
+GET /foo/bar.php HTTP/1.1
 Host: {$host}
 
 
@@ -49,26 +48,7 @@ HEADER
 )) {
 	while (!feof($fp)) {
 		echo fgets($fp);
-	}
-}
-
-fclose($fp);
-
-$fp = fsockopen($host, $port, $errno, $errstr, 0.5);
-if (!$fp) {
-  die("connect failed");
-}
-
-
-if(fwrite($fp, <<<HEADER
-GET /foo/bar.js HTTP/1.0
-Host: {$host}
-
-
-HEADER
-)) {
-	while (!feof($fp)) {
-		echo fgets($fp);
+    break;
 	}
 }
 
@@ -82,20 +62,5 @@ Connection: close
 X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8
 
-string(8) "/foo/bar"
-HTTP/1.0 200 OK
-Host: %s
-Date: %s
-Connection: close
-X-Powered-By: PHP/%s
-Content-type: text/html; charset=UTF-8
-
-string(9) "/foo/bar/"
-HTTP/1.0 200 OK
-Host: %s
-Date: %s
-Connection: close
-X-Powered-By: PHP/%s
-Content-type: text/html; charset=UTF-8
-
-string(11) "/foo/bar.js"
+string(15) "/foo/bar.anyext"
+HTTP/1.1 404 Not Found

--- a/sapi/cli/tests/php_cli_server_016.phpt
+++ b/sapi/cli/tests/php_cli_server_016.phpt
@@ -42,5 +42,5 @@ HEADER
 
 fclose($fp);
 ?>
---EXPECTF--
-HTTP/1.1 404 Not Found
+--EXPECT--
+HTTP/1.1 200 OK


### PR DESCRIPTION
The build-in server, on serving an URI containg dots, behaves exactly as
for an URI without dots. Only if the URI ends with '.php', the server
gives a 404 status if the php file is not present.

Now the behaviour matches the one expected by reading the documentation.

http://php.net/manual/en/features.commandline.webserver.php