### PR TITLE
Support for ICU 61

### DIFF
--- a/ext/intl/breakiterator/breakiterator_class.cpp
+++ b/ext/intl/breakiterator/breakiterator_class.cpp
@@ -37,6 +37,7 @@ extern "C" {
 #include <assert.h>
 }
 
+using icu::RuleBasedBreakIterator;
 using PHP::CodePointBreakIterator;
 
 /* {{{ Global variables */

--- a/ext/intl/breakiterator/breakiterator_class.h
+++ b/ext/intl/breakiterator/breakiterator_class.h
@@ -28,6 +28,11 @@
 typedef void BreakIterator;
 #endif
 
+#ifdef __cplusplus
+#include <unicode/brkiter.h>
+using icu::BreakIterator;
+#endif
+
 typedef struct {
 	// 	error handling
 	intl_error  err;

--- a/ext/intl/breakiterator/breakiterator_methods.cpp
+++ b/ext/intl/breakiterator/breakiterator_methods.cpp
@@ -31,6 +31,7 @@ extern "C" {
 #include <zend_exceptions.h>
 }
 
+using icu::Locale;
 using PHP::CodePointBreakIterator;
 
 U_CFUNC PHP_METHOD(BreakIterator, __construct)

--- a/ext/intl/breakiterator/codepointiterator_internal.cpp
+++ b/ext/intl/breakiterator/codepointiterator_internal.cpp
@@ -31,6 +31,7 @@ typedef union {
 #define U_ALIGNMENT_OFFSET(ptr) U_POINTER_MASK_LSB(ptr, sizeof(UAlignedMemory) - 1)
 #define U_ALIGNMENT_OFFSET_UP(ptr) (sizeof(UAlignedMemory) - U_ALIGNMENT_OFFSET(ptr))
 
+using icu::UCharCharacterIterator;
 using namespace PHP;
 
 UOBJECT_DEFINE_RTTI_IMPLEMENTATION(CodePointBreakIterator);

--- a/ext/intl/breakiterator/codepointiterator_internal.h
+++ b/ext/intl/breakiterator/codepointiterator_internal.h
@@ -19,6 +19,8 @@
 
 #include <unicode/brkiter.h>
 
+using icu::UnicodeString;
+using icu::CharacterIterator;
 using U_ICU_NAMESPACE::BreakIterator;
 
 namespace PHP {

--- a/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
+++ b/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
@@ -26,6 +26,9 @@ extern "C" {
 #include "../intl_convertcpp.h"
 #include "../intl_common.h"
 
+using icu::UnicodeString;
+using icu::RuleBasedBreakIterator;
+
 static inline RuleBasedBreakIterator *fetch_rbbi(BreakIterator_object *bio) {
 	return (RuleBasedBreakIterator*)bio->biter;
 }

--- a/ext/intl/calendar/calendar_class.cpp
+++ b/ext/intl/calendar/calendar_class.cpp
@@ -34,6 +34,10 @@ extern "C" {
 #include <assert.h>
 }
 
+using icu::Calendar;
+using icu::Locale;
+using icu::GregorianCalendar;
+
 /* {{{ Global variables */
 zend_class_entry *Calendar_ce_ptr;
 zend_class_entry *GregorianCalendar_ce_ptr;

--- a/ext/intl/calendar/calendar_class.h
+++ b/ext/intl/calendar/calendar_class.h
@@ -28,6 +28,10 @@
 typedef void Calendar;
 #endif
 
+#ifdef __cplusplus
+using icu::Calendar;
+#endif
+
 typedef struct {
 	// 	error handling
 	intl_error  err;

--- a/ext/intl/calendar/calendar_methods.cpp
+++ b/ext/intl/calendar/calendar_methods.cpp
@@ -40,6 +40,11 @@ extern "C" {
 }
 #include "../common/common_enum.h"
 
+using icu::Locale;
+using icu::Calendar;
+using icu::StringEnumeration;
+using icu::UnicodeString;
+
 U_CFUNC PHP_METHOD(IntlCalendar, __construct)
 {
 	zend_throw_exception( NULL,

--- a/ext/intl/calendar/gregoriancalendar_methods.cpp
+++ b/ext/intl/calendar/gregoriancalendar_methods.cpp
@@ -34,6 +34,11 @@ extern "C" {
 #include "zend_exceptions.h"
 }
 
+using icu::StringPiece;
+using icu::UnicodeString;
+using icu::GregorianCalendar;
+using icu::Locale;
+
 static inline GregorianCalendar *fetch_greg(Calendar_object *co) {
 	return (GregorianCalendar*)co->ucal;
 }

--- a/ext/intl/common/common_date.cpp
+++ b/ext/intl/common/common_date.cpp
@@ -33,6 +33,10 @@ extern "C" {
 #define NAN (INFINITY-INFINITY)
 #endif
 
+using icu::TimeZone;
+using icu::Calendar;
+using icu::UnicodeString;
+
 /* {{{ timezone_convert_datetimezone
  *      The timezone in DateTime and DateTimeZone is not unified. */
 U_CFUNC TimeZone *timezone_convert_datetimezone(int type,

--- a/ext/intl/common/common_date.h
+++ b/ext/intl/common/common_date.h
@@ -28,6 +28,8 @@ U_CDECL_END
 
 #include <unicode/timezone.h>
 
+using icu::TimeZone;
+
 U_CFUNC TimeZone *timezone_convert_datetimezone(int type, void *object, int is_datetime, intl_error *outside_error, const char *func);
 U_CFUNC int intl_datetime_decompose(zval *z, double *millis, TimeZone **tz,
 		intl_error *err, const char *func);

--- a/ext/intl/common/common_enum.cpp
+++ b/ext/intl/common/common_enum.cpp
@@ -30,6 +30,8 @@ extern "C" {
 #include <zend_exceptions.h>
 }
 
+using icu::StringEnumeration;
+
 zend_class_entry *IntlIterator_ce_ptr;
 zend_object_handlers IntlIterator_handlers;
 

--- a/ext/intl/common/common_enum.h
+++ b/ext/intl/common/common_enum.h
@@ -75,7 +75,7 @@ U_CFUNC zval *zoi_with_current_get_current_data(zend_object_iterator *iter);
 U_CFUNC void zoi_with_current_invalidate_current(zend_object_iterator *iter);
 
 #ifdef __cplusplus
-U_CFUNC void IntlIterator_from_StringEnumeration(StringEnumeration *se, zval *object);
+U_CFUNC void IntlIterator_from_StringEnumeration(icu::StringEnumeration *se, zval *object);
 #endif
 
 U_CFUNC void intl_register_IntlIterator_class(void);

--- a/ext/intl/dateformat/dateformat_attrcpp.cpp
+++ b/ext/intl/dateformat/dateformat_attrcpp.cpp
@@ -33,6 +33,9 @@ extern "C" {
 #include "../intl_convertcpp.h"
 #include "dateformat_helpers.h"
 
+using icu::DateFormat;
+using icu::UnicodeString;
+
 static inline DateFormat *fetch_datefmt(IntlDateFormatter_object *dfo) {
 	return (DateFormat *)dfo->datef_data.udatf;
 }

--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -48,6 +48,8 @@ extern "C" {
 	 UDAT_SHORT_RELATIVE == (i) || UDAT_NONE == (i) || \
 	 UDAT_PATTERN == (i))
 
+using icu::DateFormat;
+
 /* {{{ */
 static int datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_constructor)
 {

--- a/ext/intl/dateformat/dateformat_format_object.cpp
+++ b/ext/intl/dateformat/dateformat_format_object.cpp
@@ -33,6 +33,15 @@ extern "C" {
 #include "../common/common_date.h"
 }
 
+using icu::UnicodeString;
+using icu::SimpleDateFormat;
+using icu::Locale;
+using icu::StringPiece;
+using icu::GregorianCalendar;
+using icu::Calendar;
+using icu::DateFormat;
+using icu::TimeZone;
+
 static const DateFormat::EStyle valid_styles[] = {
 		DateFormat::kNone,
 		DateFormat::kFull,

--- a/ext/intl/dateformat/dateformat_helpers.cpp
+++ b/ext/intl/dateformat/dateformat_helpers.cpp
@@ -28,6 +28,9 @@ extern "C" {
 #include "../calendar/calendar_class.h"
 }
 
+using icu::Locale;
+using icu::GregorianCalendar;
+
 int datefmt_process_calendar_arg(zval* calendar_zv,
 								 Locale const& locale,
 								 const char *func_name,

--- a/ext/intl/dateformat/dateformat_helpers.h
+++ b/ext/intl/dateformat/dateformat_helpers.h
@@ -27,6 +27,9 @@ extern "C" {
 #include "../php_intl.h"
 }
 
+using icu::Locale;
+using icu::Calendar;
+
 int datefmt_process_calendar_arg(zval* calendar_zv,
 								 Locale const& locale,
 								 const char *func_name,

--- a/ext/intl/intl_convertcpp.cpp
+++ b/ext/intl/intl_convertcpp.cpp
@@ -20,9 +20,12 @@
 
 #include "intl_convertcpp.h"
 #include <unicode/ustring.h>
+#include <unicode/unistr.h>
 extern "C" {
 #include <php.h>
 }
+
+using icu::UnicodeString;
 
 /* {{{ intl_stringFromChar */
 int intl_stringFromChar(UnicodeString &ret, char *str, size_t str_len, UErrorCode *status)

--- a/ext/intl/intl_convertcpp.h
+++ b/ext/intl/intl_convertcpp.h
@@ -26,8 +26,8 @@
 #include <unicode/unistr.h>
 #include <zend_types.h>
 
-int intl_stringFromChar(UnicodeString &ret, char *str, size_t str_len, UErrorCode *status);
+int intl_stringFromChar(icu::UnicodeString &ret, char *str, size_t str_len, UErrorCode *status);
 
-zend_string* intl_charFromString(const UnicodeString &from, UErrorCode *status);
+zend_string* intl_charFromString(const icu::UnicodeString &from, UErrorCode *status);
 
 #endif /* INTL_CONVERTCPP_H */

--- a/ext/intl/msgformat/msgformat_helpers.cpp
+++ b/ext/intl/msgformat/msgformat_helpers.cpp
@@ -48,6 +48,9 @@ extern "C" {
 #endif
 
 U_NAMESPACE_BEGIN
+
+using icu::MessageFormat;
+
 /**
  * This class isolates our access to private internal methods of
  * MessageFormat.  It is never instantiated; it exists only for C++
@@ -75,6 +78,15 @@ MessageFormatAdapter::getMessagePattern(MessageFormat* m) {
 }
 #endif
 U_NAMESPACE_END
+
+using icu::MessageFormatAdapter;
+using icu::MessageFormat;
+using icu::Formattable;
+using icu::MessagePattern;
+using icu::UnicodeString;
+using icu::Format;
+using icu::DateFormat;
+using icu::FieldPosition;
 
 U_CFUNC int32_t umsg_format_arg_count(UMessageFormat *fmt)
 {

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -37,6 +37,10 @@ extern "C" {
 #include <ext/date/php_date.h>
 }
 
+using icu::TimeZone;
+using icu::UnicodeString;
+using icu::Calendar;
+
 /* {{{ Global variables */
 U_CDECL_BEGIN
 zend_class_entry *TimeZone_ce_ptr = NULL;

--- a/ext/intl/timezone/timezone_class.h
+++ b/ext/intl/timezone/timezone_class.h
@@ -31,6 +31,10 @@
 typedef void TimeZone;
 #endif
 
+#ifdef __cplusplus
+using icu::TimeZone;
+#endif
+
 typedef struct {
 	// 	error handling
 	intl_error		err;

--- a/ext/intl/timezone/timezone_methods.cpp
+++ b/ext/intl/timezone/timezone_methods.cpp
@@ -37,6 +37,10 @@ extern "C" {
 }
 #include "common/common_enum.h"
 
+using icu::UnicodeString;
+using icu::StringEnumeration;
+using icu::Locale;
+
 U_CFUNC PHP_METHOD(IntlTimeZone, __construct)
 {
 	zend_throw_exception( NULL,


### PR DESCRIPTION
Adds support for the latest icu4c 61.

For additional information http://site.icu-project.org/download/61#TOC-Migration-Issues

tl;dr the `using namespace icu;` was removed from one of the ICU's headers which means that we need to refer to classes by their namespaces explicitly now.