### PR TITLE
Fix #76204: CONNECT method is partially supported

### DIFF
--- a/sapi/cli/php_http_parser.c
+++ b/sapi/cli/php_http_parser.c
@@ -82,7 +82,6 @@ static const char *method_strings[] =
   , "POST"
   , "PUT"
   , "PATCH"
-  , "CONNECT"
   , "OPTIONS"
   , "TRACE"
   , "COPY"
@@ -512,7 +511,7 @@ size_t php_http_parser_execute (php_http_parser *parser,
         parser->method = (enum php_http_method) 0;
         index = 1;
         switch (ch) {
-          case 'C': parser->method = PHP_HTTP_CONNECT; /* or COPY, CHECKOUT */ break;
+          case 'C': parser->method = PHP_HTTP_CHECKOUT; /* or COPY */ break;
           case 'D': parser->method = PHP_HTTP_DELETE; break;
           case 'G': parser->method = PHP_HTTP_GET; break;
           case 'H': parser->method = PHP_HTTP_HEAD; break;
@@ -544,10 +543,8 @@ size_t php_http_parser_execute (php_http_parser *parser,
           state = s_req_spaces_before_url;
         } else if (parser->method == PHP_HTTP_NOT_IMPLEMENTED || ch == matcher[index]) {
           ; /* nada */
-        } else if (parser->method == PHP_HTTP_CONNECT) {
-          if (index == 1 && ch == 'H') {
-            parser->method = PHP_HTTP_CHECKOUT;
-          } else if (index == 2  && ch == 'P') {
+        } else if (parser->method == PHP_HTTP_CHECKOUT) {
+          if (index == 1 && ch == 'O') {
             parser->method = PHP_HTTP_COPY;
           } else {
             parser->method = PHP_HTTP_NOT_IMPLEMENTED;
@@ -1315,7 +1312,7 @@ size_t php_http_parser_execute (php_http_parser *parser,
 
         nread = 0;
 
-        if (parser->flags & F_UPGRADE || parser->method == PHP_HTTP_CONNECT) {
+        if (parser->flags & F_UPGRADE) {
           parser->upgrade = 1;
         }
 

--- a/sapi/cli/php_http_parser.h
+++ b/sapi/cli/php_http_parser.h
@@ -80,7 +80,6 @@ enum php_http_method
   , PHP_HTTP_PUT
   , PHP_HTTP_PATCH
   /* pathological */
-  , PHP_HTTP_CONNECT
   , PHP_HTTP_OPTIONS
   , PHP_HTTP_TRACE
   /* webdav */

--- a/sapi/cli/tests/bug76204.phpt
+++ b/sapi/cli/tests/bug76204.phpt
@@ -1,0 +1,26 @@
+--TEST--
+CONNECT method is partially supported
+--SKIPIF--
+<?php include 'skipif.inc' ?>
+--FILE--
+<?php
+include 'php_cli_server.inc';
+
+php_cli_server_start();
+
+list($host, $port) = explode(':', PHP_CLI_SERVER_ADDRESS);
+$port = intval($port) ?: 80;
+
+$fp = fsockopen($host, $port, $errno, $errstr, 0.5);
+if (!$fp) {
+    die("connect failed");
+}
+
+if (fwrite($fp, "CONNECT www.example.com:443 HTTP/1.1\r\n\r\n")) {
+    echo fgets($fp);
+}
+?>
+===DONE===
+--EXPECT--
+HTTP/1.1 501 Not Implemented
+===DONE===


### PR DESCRIPTION
The built-in Webserver recognizes the CONNECT method, but does not
handle it in any way.  Since support for HTTP tunneling is out of scope
for the built-in Webserver, we unrecognize the verb, which results in
an "HTTP/1.1 501 Not Implemented" response.