### PR TITLE
Fix caching of PHP_SAPI value in opcache file_cache

### DIFF
--- a/ext/opcache/Optimizer/block_pass.c
+++ b/ext/opcache/Optimizer/block_pass.c
@@ -54,7 +54,7 @@ int zend_optimizer_get_persistent_constant(zend_string *name, zval *result, int 
 	}
 
 	if (retval) {
-		if (c->flags & CONST_PERSISTENT) {
+		if ((c->flags & CONST_PERSISTENT) && strcmp(c->name->val, "PHP_SAPI")) {
 			ZVAL_COPY_VALUE(result, &c->value);
 			if (copy) {
 				Z_TRY_ADDREF_P(result);

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1691,6 +1691,7 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 		CG(compiler_options) |= ZEND_COMPILE_IGNORE_INTERNAL_CLASSES;
 		CG(compiler_options) |= ZEND_COMPILE_DELAYED_BINDING;
 		CG(compiler_options) |= ZEND_COMPILE_NO_CONSTANT_SUBSTITUTION;
+		CG(compiler_options) |= ZEND_COMPILE_NO_PERSISTENT_CONSTANT_SUBSTITUTION;
 		op_array = *op_array_p = accelerator_orig_compile_file(file_handle, type);
 		CG(compiler_options) = orig_compiler_options;
 	} zend_catch {

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -27,9 +27,10 @@
 #include "ext/standard/md5.h"
 #endif
 
+#include "ZendAccelerator.h"
+
 #ifdef HAVE_OPCACHE_FILE_CACHE
 
-#include "ZendAccelerator.h"
 #include "zend_file_cache.h"
 #include "zend_shared_alloc.h"
 #include "zend_accelerator_util_funcs.h"


### PR DESCRIPTION
When using opcache.file_cache option both in web and cli contexts you get very strange results when PHP_SAPI constant value has different values in different files (it depends on context in which file was included first: cli or web).

This pull requests makes attempt to fix this in a bit hacky way (we only disallow a single constant, PHP_SAPI, from being substituted).

I am not sure whether or not adding new constant like CONST_CT_NO_PERSISTENT_SUBST would be better.