### PR TITLE
OpenSSL: Make stream liveness check non-blocking

### DIFF
--- a/ext/openssl/tests/ServerClientProxyTestCase.inc
+++ b/ext/openssl/tests/ServerClientProxyTestCase.inc
@@ -1,0 +1,117 @@
+<?php
+
+const WORKER_ARGV_VALUE = 'RUN_WORKER';
+
+function phpt_notify($worker = null)
+{
+	ServerClientProxyTestCase::getInstance()->notify($worker);
+}
+
+function phpt_wait($worker = null)
+{
+	ServerClientProxyTestCase::getInstance()->wait($worker);
+}
+
+/**
+ * This is a singleton to let the wait/notify functions work
+ * I know it's horrible, but it's a means to an end
+ */
+class ServerClientProxyTestCase
+{
+	private $isWorker = false;
+
+	private $workerHandles = [];
+
+	private $workerStdIn = [];
+
+	private $workerStdOut = [];
+
+	private static $instance;
+
+	public static function getInstance($isWorker = false)
+	{
+		if (!isset(self::$instance)) {
+			self::$instance = new self($isWorker);
+		}
+
+		return self::$instance;
+	}
+
+	public function __construct($isWorker = false)
+	{
+		if (!isset(self::$instance)) {
+			self::$instance = $this;
+		}
+
+		$this->isWorker = $isWorker;
+	}
+
+	private function spawnWorkerProcess($worker, $code)
+	{
+		if (defined("PHP_WINDOWS_VERSION_MAJOR")) {
+				$ini = php_ini_loaded_file();
+				$cmd = sprintf('%s %s "%s" %s', PHP_BINARY, $ini ? "-n -c $ini" : "", __FILE__, WORKER_ARGV_VALUE);
+		} else {
+				$cmd = sprintf('%s "%s" %s %s', PHP_BINARY, __FILE__, WORKER_ARGV_VALUE, $worker);
+		}
+		$this->workerHandle[$worker] = proc_open($cmd, [['pipe', 'r'], ['pipe', 'w'], STDERR], $pipes);
+		$this->workerStdIn[$worker] = $pipes[0];
+		$this->workerStdOut[$worker] = $pipes[1];
+
+		fwrite($this->workerStdIn[$worker], $code . "\n---\n");
+	}
+
+	private function cleanupWorkerProcess($worker)
+	{
+		fclose($this->workerStdIn[$worker]);
+		fclose($this->workerStdOut[$worker]);
+		proc_close($this->workerHandle[$worker]);
+	}
+
+	private function stripPhpTagsFromCode($code)
+	{
+		return preg_replace('/^\s*<\?(?:php)?|\?>\s*$/i', '', $code);
+	}
+
+	public function runWorker()
+	{
+		$code = '';
+
+		while (1) {
+			$line = fgets(STDIN);
+
+			if (trim($line) === "---") {
+				break;
+			}
+
+			$code .= $line;
+		}
+
+		eval($code);
+	}
+
+	public function run($testCode, array $workerCodes)
+	{
+		foreach ($workerCodes as $worker => $code) {
+			$this->spawnWorkerProcess($worker, $this->stripPhpTagsFromCode($code));
+		}
+		eval($this->stripPhpTagsFromCode($testCode));
+		foreach ($workerCodes as $worker => $code) {
+			$this->cleanupWorkerProcess($worker);
+		}
+	}
+
+	public function wait($worker)
+	{
+		fgets($this->isWorker ? STDIN : $this->workerStdOut[$worker]);
+	}
+
+	public function notify($worker)
+	{
+		fwrite($this->isWorker ? STDOUT : $this->workerStdIn[$worker], "\n");
+	}
+}
+
+if (isset($argv[1]) && $argv[1] === WORKER_ARGV_VALUE) {
+	ServerClientProxyTestCase::getInstance(true)->runWorker();
+}

--- a/ext/openssl/tests/non_blocking_eof.phpt
+++ b/ext/openssl/tests/non_blocking_eof.phpt
@@ -1,0 +1,99 @@
+--TEST--
+php_stream_eof() should not block on SSL non-blocking streams when packets are fragmented
+--SKIPIF--
+<?php
+if (!extension_loaded("openssl")) die("skip openssl not loaded");
+if (!function_exists("proc_open")) die("skip no proc_open");
+?>
+--FILE--
+<?php
+
+$clientCode = <<<'CODE'
+	$context = stream_context_create(['ssl' => ['verify_peer' => false, 'peer_name' => 'bug54992.local']]);
+
+	phpt_wait('server');
+	phpt_notify('proxy');
+	
+	phpt_wait('proxy');
+	$fp = stream_socket_client("ssl://127.0.0.1:10012", $errornum, $errorstr, 3000, STREAM_CLIENT_CONNECT, $context);
+	stream_set_blocking($fp, false);
+
+	$read = [$fp];
+	$buf = '';
+	while (stream_select($read, $write, $except, 1000)) {
+		$chunk = stream_get_contents($fp, 4096);
+		var_dump($chunk);
+		$buf .= $chunk;
+		if ($buf === 'hello, world') {
+			break;
+		}
+	}
+	
+	phpt_notify('server');
+	phpt_notify('proxy');
+CODE;
+
+$serverCode = <<<'CODE'
+	$context = stream_context_create(['ssl' => ['local_cert' => __DIR__ . '/bug54992.pem']]);
+
+	$flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+	$fp = stream_socket_server("ssl://127.0.0.1:10011", $errornum, $errorstr, $flags, $context);
+	phpt_notify();
+	
+	$conn = stream_socket_accept($fp);
+	fwrite($conn, 'hello, world');
+	
+	phpt_wait();
+	fclose($conn);
+CODE;
+
+$proxyCode = <<<'CODE'
+	phpt_wait();
+
+	$upstream = stream_socket_client("tcp://127.0.0.1:10011", $errornum, $errorstr, 3000, STREAM_CLIENT_CONNECT);
+	stream_set_blocking($upstream, false);
+
+	$flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+	$server = stream_socket_server("tcp://127.0.0.1:10012", $errornum, $errorstr, $flags);
+	phpt_notify();
+	
+	$conn = stream_socket_accept($server);
+	stream_set_blocking($conn, false);
+	
+	$read = [$upstream, $conn];
+	while (stream_select($read, $write, $except, 1)) {
+		foreach ($read as $fp) {
+			$data = stream_get_contents($fp);
+			if ($fp === $conn) {
+				fwrite($upstream, $data);
+			} else {
+				if ($data !== '' && $data[0] === chr(23)) {
+					$parts = str_split($data, (int) ceil(strlen($data) / 3));
+					foreach ($parts as $part) {
+						fwrite($conn, $part);
+						usleep(1000);
+					}
+				} else {
+					fwrite($conn, $data);
+				}
+			}
+		}
+		if (feof($upstream)) {
+			break;
+		}
+		$read = [$upstream, $conn];
+	}
+	
+	phpt_wait();
+CODE;
+
+include 'ServerClientProxyTestCase.inc';
+ServerClientProxyTestCase::getInstance()->run($clientCode, [
+	'server' => $serverCode,
+	'proxy' => $proxyCode,
+]);
+?>
+--EXPECT--
+string(0) ""
+string(0) ""
+string(12) "hello, world"

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2410,9 +2410,11 @@ static int php_openssl_sockop_set_option(php_stream *stream, int option, int val
 
 								switch (err) {
 									case SSL_ERROR_SYSCALL:
+										alive = php_socket_errno() == EAGAIN;
+										break;
 									case SSL_ERROR_WANT_READ:
 									case SSL_ERROR_WANT_WRITE:
-										alive = php_socket_errno() == EAGAIN;
+										alive = 1;
 										break;
 									default:
 										/* any other problem is a fatal error */

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2408,18 +2408,16 @@ static int php_openssl_sockop_set_option(php_stream *stream, int option, int val
 							if (n <= 0) {
 								int err = SSL_get_error(sslsock->ssl_handle, n);
 
-								if (err == SSL_ERROR_SYSCALL) {
-									alive = php_socket_errno() == EAGAIN;
-									break;
+								switch (err) {
+									case SSL_ERROR_SYSCALL:
+									case SSL_ERROR_WANT_READ:
+									case SSL_ERROR_WANT_WRITE:
+										alive = php_socket_errno() == EAGAIN;
+										break;
+									default:
+										/* any other problem is a fatal error */
+										alive = 0;
 								}
-
-								if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
-									/* re-negotiate */
-									continue;
-								}
-
-								/* any other problem is a fatal error */
-								alive = 0;
 							}
 							/* either peek succeeded or there was an error; we
 							 * have set the alive flag appropriately */


### PR DESCRIPTION
The problem: `stream_get_contents()` blocks on SSL-enabled stream is some cases when the stream is in non-blocking mode. For example, it happens when SSL packets are fragmented heavily, so the stream liveness check blocks until whole packet is received. It also causes high CPU usage because of `read()` calls in a loop without poll or delay.

strace:
```
read(131, "\27\3\3\0\235", 5)           = 5
read(131, "Nr\243\242\243V\205'\234bE\306", 157) = 12
read(131, 0x55c877eba524, 145)          = -1 EAGAIN (Resource temporarily unavailable)
read(131, 0x55c877eba524, 145)          = -1 EAGAIN (Resource temporarily unavailable)
... 600+ identical lines skipped ...
read(131, 0x55c877eba524, 145)          = -1 EAGAIN (Resource temporarily unavailable)
read(131, 0x55c877eba524, 145)          = -1 EAGAIN (Resource temporarily unavailable)
read(131, "\205\223\274\277 B\35V\231\325\373\360\37&J\6V\367\264D\357h67\276\235\324\270\305\205v\262"..., 145) = 36
read(131, 0x55c877eba548, 109)          = -1 EAGAIN (Resource temporarily unavailable)
read(131, 0x55c877eba548, 109)          = -1 EAGAIN (Resource temporarily unavailable)
... 800+ identical lines skipped ...
read(131, 0x55c877eba548, 109)          = -1 EAGAIN (Resource temporarily unavailable)
read(131, 0x55c877eba548, 109)          = -1 EAGAIN (Resource temporarily unavailable)
read(131, "\305q\214\205G\252\372\336\271\2\34\253\3625j\375nJ\315\vNL-\202+\351S$\37\240EZ"..., 109) = 72
read(131, 0x55c877eba590, 37)           = -1 EAGAIN (Resource temporarily unavailable)
read(131, 0x55c877eba590, 37)           = -1 EAGAIN (Resource temporarily unavailable)
... 1300+ identical lines skipped ...
read(131, 0x55c877eba590, 37)           = -1 EAGAIN (Resource temporarily unavailable)
read(131, 0x55c877eba590, 37)           = -1 EAGAIN (Resource temporarily unavailable)
read(131, "l\\\321$\223\226\32\243\356\312\223\267XLo\0325(\357d\6\305\337\261'\330|\3560\25\334F"..., 37) = 36
read(131, 0x55c877eba5b4, 1)            = -1 EAGAIN (Resource temporarily unavailable)
read(131, 0x55c877eba5b4, 1)            = -1 EAGAIN (Resource temporarily unavailable)
... 500+ identical lines skipped ...
read(131, 0x55c877eba5b4, 1)            = -1 EAGAIN (Resource temporarily unavailable)
read(131, 0x55c877eba5b4, 1)            = -1 EAGAIN (Resource temporarily unavailable)
read(131, "\253", 1)                    = 1
poll([{fd=131, events=POLLIN|POLLPRI|POLLERR|POLLHUP}], 1, 0) = 0 (Timeout)
read(131, 0x55c877eba513, 5)            = -1 EAGAIN (Resource temporarily unavailable)
```

backtrace:
```
0x00007fc8371d5e60 in __errno_location () from /lib64/libc.so.6
#0  0x00007fc8371d5e60 in __errno_location () from /lib64/libc.so.6
#1  0x00007fc837692fb9 in BIO_sock_should_retry () from /lib64/libcrypto.so.10
#2  0x00007fc837693027 in sock_read () from /lib64/libcrypto.so.10
#3  0x00007fc83769103b in BIO_read () from /lib64/libcrypto.so.10
#4  0x00007fc837a023e4 in ssl3_read_n () from /lib64/libssl.so.10
#5  0x00007fc837a03da0 in ssl3_read_bytes () from /lib64/libssl.so.10
#6  0x00007fc837a006f4 in ssl3_read_internal () from /lib64/libssl.so.10
#7  0x000055bb89ff9507 in php_openssl_sockop_set_option ()
#8  0x000055bb8a14079d in _php_stream_set_option ()
#9  0x000055bb8a14085c in _php_stream_eof ()
#10 0x000055bb8a140a78 in _php_stream_copy_to_mem ()
#11 0x000055bb8a1217b1 in zif_stream_get_contents ()
#12 0x000055bb8a22ed92 in ZEND_DO_FCALL_BY_NAME_SPEC_RETVAL_USED_HANDLER ()
... skipped ...
```