### PR TITLE
Fix bugs #75120 and #69625

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1911,6 +1911,12 @@ consult the installation file that came with this distribution, or visit \n\
 			/* check if request_method has been sent.
 			 * if not, it's certainly not an HTTP over fcgi request */
 			if (UNEXPECTED(!SG(request_info).request_method)) {
+				zend_try {
+					zlog(ZLOG_ERROR, "SCRIPT_FILENAME not found in cgi env");
+					SG(sapi_headers).http_response_code = 500;
+					PUTS("Method not found.\n");
+				} zend_catch {
+				} zend_end_try();
 				goto fastcgi_request_done;
 			}
 


### PR DESCRIPTION
On empty SCRIPT_FILENAME and/or REQUEST_METHOD return HTTP 500

I reused patch from PR #1270 and tested it.
php-fpm now return "500: method not found" instead of "200: with an empty body".

Replacement for #3226 