### PR TITLE
Fixed #76136 - stream_socket_get_name should enclose IPv6 in brackets

### DIFF
--- a/ext/standard/tests/streams/bug76136.phpt
+++ b/ext/standard/tests/streams/bug76136.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug#76136 stream_socket_get_name should enclose IPv6 in brackets
+--FILE--
+<?php
+$server = stream_socket_server("tcp://[::1]:1337/");
+var_dump(stream_socket_get_name($server, false));
+
+--EXPECTF--
+string(10) "[::1]:1337"

--- a/main/network.c
+++ b/main/network.c
@@ -636,7 +636,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
 			case AF_INET6:
 				buf = (char*)inet_ntop(sa->sa_family, &((struct sockaddr_in6*)sa)->sin6_addr, (char *)&abuf, sizeof(abuf));
 				if (buf) {
-					*textaddr = strpprintf(0, "%s:%d",
+					*textaddr = strpprintf(0, "[%s]:%d",
 						buf, ntohs(((struct sockaddr_in6*)sa)->sin6_port));
 				}
 


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=76136