### PR TITLE
Fixes #76285 - DOMDocument::formatOutput attribute sometimes ignored

### DIFF
--- a/ext/dom/tests/bug76285.phpt
+++ b/ext/dom/tests/bug76285.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #76285 DOMDocument::formatOutput attribute sometimes ignored
+--FILE--
+<?php
+
+$dom = new DOMDocument();
+$dom->formatOutput = false;
+$html = '<div><div><a>test</a></div><div><a>test2</a></div></div>';
+$dom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+$rootNode = $dom->documentElement;
+var_dump($dom->saveHTML($rootNode));
+var_dump($dom->saveHTML());
+
+?>
+--EXPECT--
+string(56) "<div><div><a>test</a></div><div><a>test2</a></div></div>"
+string(57) "<div><div><a>test</a></div><div><a>test2</a></div></div>
+"


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=76285