### PR TITLE
Missing php_openssl_open_base_dir_chk

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3809,6 +3809,9 @@ static EVP_PKEY * php_openssl_evp_from_zval(
 
 		if (Z_STRLEN_P(val) > 7 && memcmp(Z_STRVAL_P(val), "file://", sizeof("file://") - 1) == 0) {
 			filename = Z_STRVAL_P(val) + (sizeof("file://") - 1);
+			if (php_openssl_open_base_dir_chk(filename)) {
+				TMP_CLEAN;
+			}
 		}
 		/* it's an X509 file/cert of some kind, and we need to extract the data from that */
 		if (public_key) {
@@ -3819,9 +3822,6 @@ static EVP_PKEY * php_openssl_evp_from_zval(
 				/* not a X509 certificate, try to retrieve public key */
 				BIO* in;
 				if (filename) {
-					if (php_openssl_open_base_dir_chk(filename)) {
-						TMP_CLEAN;
-					}
 					in = BIO_new_file(filename, PHP_OPENSSL_BIO_MODE_R(PKCS7_BINARY));
 				} else {
 					in = BIO_new_mem_buf(Z_STRVAL_P(val), (int)Z_STRLEN_P(val));
@@ -3838,9 +3838,6 @@ static EVP_PKEY * php_openssl_evp_from_zval(
 			BIO *in;
 
 			if (filename) {
-				if (php_openssl_open_base_dir_chk(filename)) {
-					TMP_CLEAN;
-				}
 				in = BIO_new_file(filename, PHP_OPENSSL_BIO_MODE_R(PKCS7_BINARY));
 			} else {
 				in = BIO_new_mem_buf(Z_STRVAL_P(val), (int)Z_STRLEN_P(val));

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3819,6 +3819,9 @@ static EVP_PKEY * php_openssl_evp_from_zval(
 				/* not a X509 certificate, try to retrieve public key */
 				BIO* in;
 				if (filename) {
+					if (php_openssl_open_base_dir_chk(filename)) {
+						TMP_CLEAN;
+					}
 					in = BIO_new_file(filename, PHP_OPENSSL_BIO_MODE_R(PKCS7_BINARY));
 				} else {
 					in = BIO_new_mem_buf(Z_STRVAL_P(val), (int)Z_STRLEN_P(val));


### PR DESCRIPTION
Not all BIO_new_file calls checks the basedir, php_openssl_x509_from_zval above triggers a warning for a call deeper down.

```
<?php
ini_set('open_basedir', '/tmp/');
openssl_pkey_get_public("file:///any/path/cert.pem");
```