### PR TITLE
Update _bits_per_char to use with new PHP 7.1. or greater

### DIFF
--- a/ext/session/mod_files.sh
+++ b/ext/session/mod_files.sh
@@ -4,9 +4,7 @@ if [[ "$2" = "" ]] || [[ "$3" = "" ]]; then
        echo "Usage: $0 BASE_DIRECTORY DEPTH BITS_PER_CHAR"
        echo "BASE_DIRECTORY will be created if it doesn't exist"
        echo "DEPTH must be an integer number >0"
-       echo "For PHP < 7.1.0. BITS_PER_CHAR(session.hash_bits_per_character) should be one of 4, 5, or 6."
-       echo "For PHP >= 7.1.0. BITS_PER_CHAR(session.sid_bits_per_character) should be one of 4, 5, or 6."
-       # http://php.net/manual/en/session.configuration.php#ini.session.hash-bits-per-character
+       echo "BITS_PER_CHAR(session.sid_bits_per_character) should be one of 4, 5, or 6."
        # http://php.net/manual/en/session.configuration.php#ini.session.sid-bits-per-character
        exit 1
 fi
@@ -59,7 +57,7 @@ if [[ ! -d $directory ]]; then
 fi
 
 
-echo "Creating session path in $directory with a depth of $depth for session.xxx_bits_per_character = $bitsperchar"
+echo "Creating session path in $directory with a depth of $depth for session.sid_bits_per_character = $bitsperchar"
 
 for i in $hash_chars; do
        newpath="$directory/$i"

--- a/ext/session/mod_files.sh
+++ b/ext/session/mod_files.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
 if [[ "$2" = "" ]] || [[ "$3" = "" ]]; then
-       echo "Usage: $0 BASE_DIRECTORY DEPTH HASH_BITS"
+       echo "Usage: $0 BASE_DIRECTORY DEPTH BITS_PER_CHAR"
        echo "BASE_DIRECTORY will be created if it doesn't exist"
        echo "DEPTH must be an integer number >0"
-       echo "HASH_BITS(session.hash_bits_per_character) should be one of 4, 5, or 6"
+       echo "For PHP < 7.1.0. BITS_PER_CHAR(session.hash_bits_per_character) should be one of 4, 5, or 6."
+       echo "For PHP >= 7.1.0. BITS_PER_CHAR(session.sid_bits_per_character) should be one of 4, 5, or 6."
+       # http://php.net/manual/en/session.configuration.php#ini.session.hash-bits-per-character
+       # http://php.net/manual/en/session.configuration.php#ini.session.sid-bits-per-character
        exit 1
 fi
 
@@ -18,15 +21,15 @@ fi
 
 directory="$1"
 depth="$2"
-hashbits="$3"
+bitsperchar="$3"
 
 hash_chars="0 1 2 3 4 5 6 7 8 9 a b c d e f"
 
-if [[ "$hashbits" -ge "5" ]]; then
+if [[ "$bitsperchar" -ge "5" ]]; then
        hash_chars="$hash_chars g h i j k l m n o p q r s t u v"
 fi
 
-if [[ "$hashbits" -ge "6" ]]; then
+if [[ "$bitsperchar" -ge "6" ]]; then
        hash_chars="$hash_chars w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z - ,"
 fi
 
@@ -56,10 +59,10 @@ if [[ ! -d $directory ]]; then
 fi
 
 
-echo "Creating session path in $directory with a depth of $depth for session.hash_bits_per_character = $hashbits"
+echo "Creating session path in $directory with a depth of $depth for session.hash_bits_per_character = $bitsperchar"
 
 for i in $hash_chars; do
        newpath="$directory/$i"
        mkdir $newpath || exit 1
-       bash $0 $newpath `expr $depth - 1` $hashbits recurse
+       bash $0 $newpath `expr $depth - 1` $bitsperchar recurse
 done

--- a/ext/session/mod_files.sh
+++ b/ext/session/mod_files.sh
@@ -59,7 +59,7 @@ if [[ ! -d $directory ]]; then
 fi
 
 
-echo "Creating session path in $directory with a depth of $depth for session.hash_bits_per_character = $bitsperchar"
+echo "Creating session path in $directory with a depth of $depth for session.xxx_bits_per_character = $bitsperchar"
 
 for i in $hash_chars; do
        newpath="$directory/$i"


### PR DESCRIPTION
As the option session.hash_bits_per_character dissapear from PHP 7.1.0 I adapt the script for a friendly use with the session.sid_bits_per_character available in the new releases. Easy to understand.