### PR TITLE
Dump obsolete EBCDIC support

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -2717,12 +2717,6 @@ static void _php_image_output(INTERNAL_FUNCTION_PARAMETERS, int image_type, char
 
 		fseek(tmp, 0, SEEK_SET);
 
-#if APACHE && defined(CHARSET_EBCDIC)
-		/* XXX this is unlikely to work any more thies@thieso.net */
-
-		/* This is a binary file already: avoid EBCDIC->ASCII conversion */
-		ap_bsetflag(php3_rqst->connection->client, B_EBCDIC2ASCII, 0);
-#endif
 		while ((b = fread(buf, 1, sizeof(buf), tmp)) > 0) {
 			php_write(buf, b);
 		}

--- a/ext/gd/gd_ctx.c
+++ b/ext/gd/gd_ctx.c
@@ -164,12 +164,6 @@ static void _php_image_output_ctx(INTERNAL_FUNCTION_PARAMETERS, int image_type, 
 		ctx->putC = _php_image_output_putc;
 		ctx->putBuf = _php_image_output_putbuf;
 		ctx->gd_free = _php_image_output_ctxfree;
-
-#if APACHE && defined(CHARSET_EBCDIC)
-		/* XXX this is unlikely to work any more thies@thieso.net */
-		/* This is a binary file already: avoid EBCDIC->ASCII conversion */
-		ap_bsetflag(php3_rqst->connection->client, B_EBCDIC2ASCII, 0);
-#endif
 	}
 
 	if (!ctx)	{


### PR DESCRIPTION
As already suggested by Thies this code won't compile anymore, because
php3_rqst has been removed in 1999[1].  Since apparently nobody
complained about that, we assume that EBCDIC support isn't required
here, and rid the respective code.

Furthermore, the code appears to be erroneous anyway, since at least
XBM isn't a binary file format.

[1] <https://github.com/php/php-src/commit/3cd0af11eea32f802228004af8fe424c62c8fbfb#diff-1a9cfc6173e3a434387996e46086da56L258>