### PR TITLE
Adds print_global_vars to gdbinit

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -16,9 +16,11 @@ define ____executor_globals
 		end
 		set $eg = ((zend_executor_globals*) (*((void ***) $tsrm_ls))[executor_globals_id-1])
 		set $cg = ((zend_compiler_globals*) (*((void ***) $tsrm_ls))[compiler_globals_id-1])
+		set $eg_ptr = $eg
 	else
 		set $eg = executor_globals
 		set $cg = compiler_globals
+		set $eg_ptr = (zend_executor_globals*) &executor_globals
 	end
 end
 
@@ -287,6 +289,16 @@ define ____printzv
 	else
 		____printzv_contents $zcontents 0 
 	end
+end
+
+define print_global_vars
+	____executor_globals
+	set $symtable = ((HashTable *)&($eg_ptr->symbol_table))
+	print_ht $symtable
+end
+
+document print_global_vars
+	Prints the global variables
 end
 
 define print_const_table


### PR DESCRIPTION
```
(gdb) print_global_vars
Hash(8)[0xa09330]: {
  [0] _GET => [0x7f5c68e5f100] (refcount=2) array: 
  [1] _POST => [0x7f5c68e5f120] (refcount=2) array: 
  [2] _COOKIE => [0x7f5c68e5f140] (refcount=2) array: 
  [3] _FILES => [0x7f5c68e5f160] (refcount=2) array: 
  [4] argv => [0x7f5c68e5f180] (refcount=2) array: 
  [5] argc => [0x7f5c68e5f1a0] long: 1
  [6] _SERVER => [0x7f5c68e5f1c0] (refcount=2) array: 
  [7] bar => [0x7f5c68e5f1e0] indirect: [0x7f5c68e1c080] (refcount=3) object(MyClass) #1

}
```