### PR TITLE
Fix #67122: PDO::ATTR_EMULATE_PREPARES = false drops microseconds from timestamp

### DIFF
--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -242,7 +242,11 @@ ps_fetch_time(zval * zv, const MYSQLND_FIELD * const field, unsigned int pack_le
 		t.time_type = MYSQLND_TIMESTAMP_TIME;
 	}
 
-	length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u", (t.neg ? "-" : ""), t.hour, t.minute, t.second);
+	if (t.second_part > 0) {
+		length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u.%06u", (t.neg ? "-" : ""), t.hour, t.minute, t.second, t.second_part);
+	} else {
+		length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u", (t.neg ? "-" : ""), t.hour, t.minute, t.second);
+	}
 
 	DBG_INF_FMT("%s", value);
 	ZVAL_STRINGL(zv, value, length, 1);
@@ -323,7 +327,11 @@ ps_fetch_datetime(zval * zv, const MYSQLND_FIELD * const field, unsigned int pac
 		t.time_type = MYSQLND_TIMESTAMP_DATETIME;
 	}
 
-	length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u", t.year, t.month, t.day, t.hour, t.minute, t.second);
+	if (t.second_part > 0) {
+		length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u.%06u", t.year, t.month, t.day, t.hour, t.minute, t.second, t.second_part);
+	} else {
+		length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u", t.year, t.month, t.day, t.hour, t.minute, t.second);
+	}
 
 	DBG_INF_FMT("%s", value);
 	ZVAL_STRINGL(zv, value, length, 1);


### PR DESCRIPTION
[Fix #67122](https://bugs.php.net/bug.php?id=67122)

When the PDO attribute `ATTR_EMULATE_PREPARES` is `false`, any microseconds are dropped from timestamp columns on MySQL >= 5.6.4 & MariaDB >= 5.3.

This bug was filed for PHP 5.5, but I've made PR for lowest yet supported PHP 5.6.

I haven't added any new tests, if they are required I need a bit more time to understand how to write them and append to this PR.