### PR TITLE
Add missing opcache.opt_debug_level ini directive

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1905,6 +1905,10 @@ ldap.max_links = -1
 ; Prevent name collisions in chroot'ed environment.
 ;opcache.validate_root=0
 
+; If specified, it produces opcode dumps for debugging different stages of
+; optimizations.
+;opcache.opt_debug_level=0
+
 [curl]
 ; A default value for the CURLOPT_CAINFO option. This is required to be an
 ; absolute path.

--- a/php.ini-production
+++ b/php.ini-production
@@ -1905,6 +1905,10 @@ ldap.max_links = -1
 ; Prevent name collisions in chroot'ed environment.
 ;opcache.validate_root=0
 
+; If specified, it produces opcode dumps for debugging different stages of
+; optimizations.
+;opcache.opt_debug_level=0
+
 [curl]
 ; A default value for the CURLOPT_CAINFO option. This is required to be an
 ; absolute path.


### PR DESCRIPTION
There are some ini directives missing in the default ini files. This patch adds the `opcache.opt_debug_level` configuration option with a basic description.

Thanks for checking this out or considering merging it. Patch targets branches PHP-7.1 and up to master.