### PR TITLE
Remove binary_pipes option from test script

### DIFF
--- a/ext/standard/tests/file/bug60120.phpt
+++ b/ext/standard/tests/file/bug60120.phpt
@@ -24,7 +24,7 @@ $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'))
 $stdin = str_repeat('*', 1024 * 16) . '!';
 $stdin = str_repeat('*', 2049 );
 
-$options = array_merge(array('suppress_errors' => true, 'binary_pipes' => true, 'bypass_shell' => false));
+$options = array_merge(array('suppress_errors' => true, 'bypass_shell' => false));
 $process = proc_open($cmd, $descriptors, $pipes, getcwd(), array(), $options);
 
 foreach ($pipes as $pipe) {

--- a/ext/standard/tests/file/proc_open01.phpt
+++ b/ext/standard/tests/file/proc_open01.phpt
@@ -11,7 +11,7 @@ if ($php === false) {
 $proc = proc_open(
 	"$php -n",
 	array(0 => array('pipe', 'r'), 1 => array('pipe', 'w')),
-	$pipes, getcwd(), array(), array('binary_pipes' => true)
+	$pipes, getcwd(), array(), array()
 );
 if ($proc === false) {
 	print "something went wrong.\n";

--- a/ext/standard/tests/streams/bug46024.phpt
+++ b/ext/standard/tests/streams/bug46024.phpt
@@ -9,7 +9,7 @@ $pipes = array();
 $proc = proc_open(
 	"$php -n -i"
 	,array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'))
-	,$pipes, dirname(__FILE__), array(), array('binary_pipes' => true)
+	,$pipes, dirname(__FILE__), array(), array()
 );
 var_dump($proc);
 if (!$proc) {

--- a/ext/standard/tests/streams/bug64770.phpt
+++ b/ext/standard/tests/streams/bug64770.phpt
@@ -9,7 +9,7 @@ $descs = array(
 	2 => array('pipe', 'w'), // strerr
 );
 
-$other_opts = array('suppress_errors' => false, 'binary_pipes' => true);
+$other_opts = array('suppress_errors' => false);
 
 $cmd = (substr(PHP_OS, 0, 3) == 'WIN') ? 'dir' : 'ls';
 $p = proc_open($cmd, $descs, $pipes, '.', NULL, $other_opts);

--- a/ext/standard/tests/streams/proc_open_bug60120.phpt
+++ b/ext/standard/tests/streams/proc_open_bug60120.phpt
@@ -13,7 +13,7 @@ $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'))
 $stdin = str_repeat('*', 1024 * 16) . '!';
 $stdin = str_repeat('*', 2049 );
 
-$options = array_merge(array('suppress_errors' => true, 'binary_pipes' => true, 'bypass_shell' => false));
+$options = array_merge(array('suppress_errors' => true, 'bypass_shell' => false));
 $process = proc_open($cmd, $descriptors, $pipes, getcwd(), array(), $options);
 
 foreach ($pipes as $pipe) {

--- a/ext/standard/tests/streams/proc_open_bug64438.phpt
+++ b/ext/standard/tests/streams/proc_open_bug64438.phpt
@@ -13,7 +13,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'));
 $stdin = str_repeat('*', 4097);
 
-$options = array_merge(array('suppress_errors' => true, 'binary_pipes' => true, 'bypass_shell' => false));
+$options = array_merge(array('suppress_errors' => true, 'bypass_shell' => false));
 $process = proc_open($cmd, $descriptors, $pipes, getcwd(), array(), $options);
 
 foreach ($pipes as $pipe) {

--- a/run-tests.php
+++ b/run-tests.php
@@ -1120,7 +1120,7 @@ function system_with_timeout($commandline, $env = null, $stdin = null, $captureS
 	if ($captureStdErr) {
 		$descriptorspec[2] = array('pipe', 'w');
 	}
-	$proc = proc_open($commandline, $descriptorspec, $pipes, TEST_PHP_SRCDIR, $bin_env, array('suppress_errors' => true, 'binary_pipes' => true));
+	$proc = proc_open($commandline, $descriptorspec, $pipes, TEST_PHP_SRCDIR, $bin_env, array('suppress_errors' => true));
 
 	if (!$proc) {
 		return false;


### PR DESCRIPTION
Option `binary_pipes` was added in PHP 6 which was then refactored and this option was removed. So I think it doesn't do anything.

The only info that I can find is in some archives and in some [docs](http://php.net/manual/pt_BR/function.proc-open.php):

* binary_pipes: opens pipes in binary mode, instead of using stream_encoding
* 6.0.0 | Added the context and binary_pipes options in the parameter other_options.

Currently this option is also present in some tests files:
* ext/standard/tests/file/bug60120.phpt
* ext/standard/tests/file/proc_open01.phpt
* ext/standard/tests/streams/proc_open_bug60120.phpt
* ext/standard/tests/streams/proc_open_bug64438.phpt
* ext/standard/tests/streams/bug64770.phpt
* ext/standard/tests/streams/bug46024.phpt
