### PR TITLE
Remove some old occurrences of configure.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,6 @@ Zend/zend_language_parser.h
 Zend/zend_language_parser.output
 
 # Extension specific ignores
-ext/*/configure.in
 ext/*/configure.ac
 ext/*/ltmain.sh
 ext/*/libs.mk

--- a/ext/odbc/php_odbc_includes.h
+++ b/ext/odbc/php_odbc_includes.h
@@ -25,7 +25,7 @@
 
 #if HAVE_UODBC
 
-/* checking in the same order as in configure.in */
+/* checking in the same order as in configure.ac */
 
 #if defined(HAVE_SOLID) || defined(HAVE_SOLID_30) || defined(HAVE_SOLID_35) /* Solid Server */
 

--- a/win32/build/config.w32.phpize.in
+++ b/win32/build/config.w32.phpize.in
@@ -1,6 +1,6 @@
 // vim:ft=javascript
 // $Id: config.w32 306241 2010-12-11 22:18:10Z pajoye $
-// "Master" config file; think of it as a configure.in
+// "Master" config file; think of it as a configure.ac
 // equivalent.
 
 ARG_WITH("verbosity", "Output verbosity, 0-2.", "1");


### PR DESCRIPTION
Hello, this patch removes some old occurrences of the `configure.in` files in some source code files. The new configure.ac is now the recommended file to use instead of the old configure.in which will be removed in autotools future versions.

The PHP build system already uses the new configure.ac files.