### PR TITLE
Fix and update build files for bundled libmbfl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,8 +157,9 @@ ext/iconv/php_have_iconv.h
 ext/iconv/php_iconv_supports_errno.h
 ext/iconv/php_iconv_broken_ignore.h
 ext/iconv/php_iconv_aliased_libiconv.h
-ext/mbstring/libmbfl/Makefile.in
+ext/mbstring/libmbfl/**/Makefile.in
 ext/mbstring/libmbfl/autoscan.log
+ext/mbstring/libmbfl/compile
 ext/mbstring/libmbfl/config.sub
 ext/mbstring/libmbfl/depcomp
 ext/mbstring/libmbfl/ltmain.sh
@@ -169,10 +170,7 @@ ext/mbstring/libmbfl/*.RES
 ext/mbstring/libmbfl/*.res
 ext/mbstring/libmbfl/*.obj
 ext/mbstring/libmbfl/*.tds
-ext/mbstring/libmbfl/filters/Makefile.in
-ext/mbstring/libmbfl/mbfl/Makefile.in
 ext/mbstring/libmbfl/mbfl/EastAsianWidth.txt
-ext/mbstring/libmbfl/nls/Makefile.in
 ext/mbstring/oniguruma/oniguruma.h
 ext/oci8/tests/*.vglog
 ext/pdo/conftest*

--- a/ext/mbstring/libmbfl/config.h.in
+++ b/ext/mbstring/libmbfl/config.h.in
@@ -1,4 +1,4 @@
-/* config.h.in.  Generated from configure.in by autoheader.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
 
 /* Define to 1 if you have the <assert.h> header file. */
 #undef HAVE_ASSERT_H
@@ -50,8 +50,7 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 
 /* Name of package */

--- a/ext/mbstring/libmbfl/configure.ac
+++ b/ext/mbstring/libmbfl/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
-AC_INIT(mbfl/mbfilter.c)
-AM_INIT_AUTOMAKE(libmbfl, 1.1.0)
-AC_CONFIG_SRCDIR(mbfl/mbfilter.c)
+AC_INIT([libmbfl], [1.1.0])
+AC_CONFIG_SRCDIR([mbfl/mbfilter.c])
+AM_INIT_AUTOMAKE
 AM_CONFIG_HEADER(config.h)
 
 # SHLIB isn't a version number but the API reference

--- a/ext/mbstring/libmbfl/filters/Makefile.am
+++ b/ext/mbstring/libmbfl/filters/Makefile.am
@@ -1,6 +1,6 @@
 EXTRA_DIST=Makefile.bcc32 mk_sb_tbl.awk
 noinst_LTLIBRARIES=libmbfl_filters.la
-INCLUDES=-I../mbfl
+AM_CPPFLAGS=-I../mbfl
 PERL=perl
 libmbfl_filters_la_LDFLAGS=-version-info $(SHLIB_VERSION)
 libmbfl_filters_la_SOURCES=mbfilter_cp936.c \

--- a/ext/mbstring/libmbfl/nls/Makefile.am
+++ b/ext/mbstring/libmbfl/nls/Makefile.am
@@ -1,5 +1,5 @@
 noinst_LTLIBRARIES=libmbfl_nls.la
-INCLUDES=-I../mbfl
+AM_CPPFLAGS=-I../mbfl
 libmbfl_nls_la_LDFLAGS=-version-info $(SHLIB_VERSION)
 libmbfl_nls_la_SOURCES=nls_ja.c \
 	nls_de.c \


### PR DESCRIPTION
Hello, the libmbfl library for the mbstring extension has been bundled into the core and is maintained here as a fork since PHP 7.2. This patch is more of a consistency thing to make the build system of this particular library actually work again in case someone will be trying to build it as a shared library elsewhere. Changes:
* Simplified root .gitignore file
* Updated Makefile.am files
* regenerated configure.ac and config.h.in files

Thanks for checking this out or considering merging it.