### PR TITLE
Fix for bug #76386: Prepared Statement formatter truncates fractional seconds from date/time column

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -20,8 +20,8 @@ PHP 7.3 UPGRADE NOTES
 ========================================
 
 Core:
-  . The ext_skel utility has been completely redesigned with new options and 
-    some old options removed. This is now written in PHP and has no external 
+  . The ext_skel utility has been completely redesigned with new options and
+    some old options removed. This is now written in PHP and has no external
 	dependencies.
   . Support for BeOS has been dropped.
   . Exceptions thrown due to automatic conversion of warnings into exceptions
@@ -50,6 +50,23 @@ BCMath:
     Formerly some warnings have directly been written to stderr.
   . bcmul() and bcpow() now return numbers with the requested scale. Formerly,
     the returned numbers may have omitted trailing decimal zeroes.
+
+mysqli:
+  . Prepared statements now properly report the fractional seconds for DATETIME/
+    TIME/TIMESTAMP columns with decimals specifier (e.g. TIMESTAMP(6) when using
+    microseconds). Formerly, the fractional seconds part was simply omitted from
+    the returned values.
+
+PDO/MySQL:
+  . Prepared statements now properly report the fractional seconds for DATETIME/
+    TIME/TIMESTAMP columns with decimals specifier (e.g. TIMESTAMP(6) when using
+    microseconds). Formerly, the fractional seconds part was simply omitted from
+    the returned values.
+    Please note that this only affects the usage of PDO_MYSQL with emulated
+    prepares turned off (e.g. using the native preparation functionality).
+    Statements using connections having PDO::ATTR_EMULATE_PREPARES=true (which
+    is the default) were not affected by the bug fixed and have already been
+    getting the proper fractional seconds values from the engine.
 
 Reflection:
   . Reflection export to string now uses `int` and `bool` instead of `integer`
@@ -254,7 +271,7 @@ JSON:
  MBString:
   . The configuration option --with-libmbfl is no longer available.
 
- ODBC: 
+ ODBC:
   . Support for ODBCRouter has been removed.
   . Support for Birdstep has been removed.
 

--- a/ext/mysqli/tests/bug76386.phpt
+++ b/ext/mysqli/tests/bug76386.phpt
@@ -25,12 +25,16 @@ $link->query(
     '"2018-04-04 11:22:33.999999");'
 );
 $stmt = $link->prepare('SELECT * FROM ts_test;'); // must be statement
-$stmt->execute();
-$tsid = $ts = $ts2 = $ts4 = $ts6 = null;
-$stmt->bind_result($tsid, $ts, $ts2, $ts4, $ts6);
-$stmt->fetch();
-var_dump($ts, $ts2, $ts4, $ts6);
-$stmt->free_result();
+if ($stmt) {
+    $stmt->execute();
+    $tsid = $ts = $ts2 = $ts4 = $ts6 = null;
+    $stmt->bind_result($tsid, $ts, $ts2, $ts4, $ts6);
+    $stmt->fetch();
+    var_dump($ts, $ts2, $ts4, $ts6);
+    $stmt->free_result();
+} else {
+    echo('[FIRST][FAIL] mysqli::prepare returned false: ' . $link->error . PHP_EOL);
+}
 $link->close();
 
 // test part 2 - TIME(n)
@@ -47,12 +51,16 @@ $link->query(
     '"21:22:33.5555", "21:22:33.676767");'
 );
 $stmt = $link->prepare('SELECT * FROM t_test;');
-$stmt->execute();
-$tid = $t = $t2 = $t3 = $t4 = null;
-$stmt->bind_result($tid, $t, $t2, $t4, $t6);
-$stmt->fetch();
-var_dump($t, $t2, $t4, $t6);
-$stmt->free_result();
+if ($stmt) {
+    $stmt->execute();
+    $tid = $t = $t2 = $t3 = $t4 = null;
+    $stmt->bind_result($tid, $t, $t2, $t4, $t6);
+    $stmt->fetch();
+    var_dump($t, $t2, $t4, $t6);
+    $stmt->free_result();
+} else {
+    echo('[SECOND][FAIL] mysqli::prepare returned false: ' . $link->error . PHP_EOL);
+}
 $link->close();
 ?>
 --EXPECTF--

--- a/ext/mysqli/tests/bug76386.phpt
+++ b/ext/mysqli/tests/bug76386.phpt
@@ -10,28 +10,36 @@ require_once('skipifconnectfailure.inc');
 <?php
 require_once('connect.inc');
 $link = new mysqli($host, $user, $passwd, $db, $port, $socket);
-try {
-    $link->query(
-        'CREATE TABLE IF NOT EXISTS ts_test (id bigint unsigned auto_increment ' .
-        'primary key, ts timestamp default 0, ts2 timestamp(2) default 0, ' . 
-        'ts4 timestamp(4) default 0, ts6 timestamp(6) default 0) character ' .
-        'set utf8 collate utf8_general_ci;'
-    );
-    $link->query('TRUNCATE TABLE ts_test;');
-    $link->query('INSERT INTO ts_test VALUES ();');
-    $stmt = $link->prepare('SELECT * FROM ts_test;'); // must be statement
-    $stmt->execute();
-    $id = $ts = $ts2 = $ts4 = $ts6 = null;
-    $stmt->bind_result($id, $ts, $ts2, $ts4, $ts6);
-    $stmt->fetch();
-    var_dump($ts, $ts2, $ts4, $ts6);
-} finally {
-    $link->query('DROP TABLE IF EXISTS ts_test;');
-    $link->close();
-}
+$link->query('DROP TABLE IF EXISTS ts_test;');
+$link->query(
+    'CREATE TABLE ts_test (id bigint unsigned auto_increment primary key, ' .
+    'ts timestamp default current_timestamp(), ts2 timestamp(2) default ' .
+    'current_timestamp(2), ts4 timestamp(4) default current_timestamp(4), ' .
+    'ts6 timestamp(6) default current_timestamp(6)) character set utf8 collate ' .
+    'utf8_general_ci;'
+);
+$link->query(
+    'INSERT INTO ts_test (ts, ts2, ts4, ts6) VALUES ("2018-01-01 11:22:33", ' .
+    '"2018-02-02 11:22:33.77", "2018-03-03 11:22:33.8888", ' .
+    '"2018-04-04 11:22:33.999999");'
+);
+$stmt = $link->prepare('SELECT * FROM ts_test;'); // must be statement
+$stmt->execute();
+$id = $ts = $ts2 = $ts4 = $ts6 = null;
+$stmt->bind_result($id, $ts, $ts2, $ts4, $ts6);
+$stmt->fetch();
+$link->close();
+var_dump($ts, $ts2, $ts4, $ts6);
 ?>
 --EXPECTF--
-string(19) "0000-00-00 00:00:00"
-string(22) "0000-00-00 00:00:00.00"
-string(24) "0000-00-00 00:00:00.0000"
-string(26) "0000-00-00 00:00:00.000000"
+string(19) "2018-01-01 11:22:33"
+string(22) "2018-02-02 11:22:33.77"
+string(24) "2018-03-03 11:22:33.8888"
+string(26) "2018-04-04 11:22:33.999999"
+--CLEAN--
+<?php
+require_once('connect.inc');
+$link = new mysqli($host, $user, $passwd, $db, $port, $socket);
+$link->query('DROP TABLE ts_test;');
+$link->close();
+?>

--- a/ext/mysqli/tests/bug76386.phpt
+++ b/ext/mysqli/tests/bug76386.phpt
@@ -15,8 +15,10 @@ $link->query('DROP TABLE IF EXISTS ts_test;');
 $link->query(
     'CREATE TABLE ts_test (id bigint unsigned auto_increment primary key, ' .
     'ts timestamp default current_timestamp(), ts2 timestamp(2) default ' .
-    'current_timestamp(2), ts4 timestamp(4) default current_timestamp(4), ' .
-    'ts6 timestamp(6) default current_timestamp(6)) character set utf8 collate ' .
+    'current_timestamp(2), ts2b timestamp(2) default "2018-01-01 03:04:05.06", ' .
+    'ts4 timestamp(4) default current_timestamp(4), ts4b timestamp(4) default ' .
+    '"2018-01-01 03:04:05.0070", ts6 timestamp(6) default current_timestamp(6), ts6b ' .
+    'timestamp(6) default "2018-01-01 03:04:05.008000") character set utf8 collate ' .
     'utf8_general_ci;'
 );
 $link->query(
@@ -27,10 +29,10 @@ $link->query(
 $stmt = $link->prepare('SELECT * FROM ts_test;'); // must be statement
 if ($stmt) {
     $stmt->execute();
-    $tsid = $ts = $ts2 = $ts4 = $ts6 = null;
-    $stmt->bind_result($tsid, $ts, $ts2, $ts4, $ts6);
+    $tsid = $ts = $ts2 = $ts2b = $ts4 = $ts4b = $ts6 = $ts6b = null;
+    $stmt->bind_result($tsid, $ts, $ts2, $ts2b, $ts4, $ts4b, $ts6, $ts6b);
     $stmt->fetch();
-    var_dump($ts, $ts2, $ts4, $ts6);
+    var_dump($ts, $ts2, $ts2b, $ts4, $ts4b, $ts6, $ts6b);
     $stmt->free_result();
 } else {
     echo('[FIRST][FAIL] mysqli::prepare returned false: ' . $link->error . PHP_EOL);
@@ -42,21 +44,24 @@ $link = new mysqli($host, $user, $passwd, $db, $port, $socket);
 $link->query('DROP TABLE IF EXISTS t_test;');
 $link->query(
     'CREATE TABLE t_test (id bigint unsigned auto_increment primary key, ' .
-    't time default current_time(), t2 time(2) default current_time(2), t4 ' .
-    'time(4) default current_time(4), t6 time(6) default current_time(6)) ' .
+    't time default "11:00:00", t2 time(2) default "11:00:00.22", t4 ' .
+    'time(4) default "11:00:00.4444", t6 time(6) default "11:00:00.006054") ' .
     'character set utf8 collate utf8_general_ci;'
 );
 $link->query(
     'INSERT INTO t_test (t, t2, t4, t6) VALUES ("21:22:33", "21:22:33.44", ' .
     '"21:22:33.5555", "21:22:33.676767");'
 );
+$link->query('INSERT INTO t_test VALUES ();');
+
 $stmt = $link->prepare('SELECT * FROM t_test;');
 if ($stmt) {
     $stmt->execute();
     $tid = $t = $t2 = $t3 = $t4 = null;
     $stmt->bind_result($tid, $t, $t2, $t4, $t6);
-    $stmt->fetch();
-    var_dump($t, $t2, $t4, $t6);
+    while ($stmt->fetch()) {
+        var_dump($t, $t2, $t4, $t6);
+    }
     $stmt->free_result();
 } else {
     echo('[SECOND][FAIL] mysqli::prepare returned false: ' . $link->error . PHP_EOL);
@@ -66,12 +71,19 @@ $link->close();
 --EXPECTF--
 string(19) "2018-01-01 11:22:33"
 string(22) "2018-02-02 11:22:33.77"
+string(22) "2018-01-01 03:04:05.06"
 string(24) "2018-03-03 11:22:33.8888"
+string(24) "2018-01-01 03:04:05.0070"
 string(26) "2018-04-04 11:22:33.999999"
+string(26) "2018-01-01 03:04:05.008000"
 string(8) "21:22:33"
 string(11) "21:22:33.44"
 string(13) "21:22:33.5555"
 string(15) "21:22:33.676767"
+string(8) "11:00:00"
+string(11) "11:00:00.22"
+string(13) "11:00:00.4444"
+string(15) "11:00:00.006054"
 --CLEAN--
 <?php
 require_once('connect.inc');

--- a/ext/mysqli/tests/bug76386.phpt
+++ b/ext/mysqli/tests/bug76386.phpt
@@ -9,9 +9,9 @@ require_once('skipifconnectfailure.inc');
 --FILE--
 <?php
 require_once('connect.inc');
+// test part 1 - TIMESTAMP(n)
 $link = new mysqli($host, $user, $passwd, $db, $port, $socket);
 $link->query('DROP TABLE IF EXISTS ts_test;');
-$link->query('DROP TABLE IF EXISTS t_test;');
 $link->query(
     'CREATE TABLE ts_test (id bigint unsigned auto_increment primary key, ' .
     'ts timestamp default current_timestamp(), ts2 timestamp(2) default ' .
@@ -20,37 +20,39 @@ $link->query(
     'utf8_general_ci;'
 );
 $link->query(
+    'INSERT INTO ts_test (ts, ts2, ts4, ts6) VALUES ("2018-01-01 11:22:33", ' .
+    '"2018-02-02 11:22:33.77", "2018-03-03 11:22:33.8888", ' .
+    '"2018-04-04 11:22:33.999999");'
+);
+$stmt = $link->prepare('SELECT * FROM ts_test;'); // must be statement
+$stmt->execute();
+$tsid = $ts = $ts2 = $ts4 = $ts6 = null;
+$stmt->bind_result($tsid, $ts, $ts2, $ts4, $ts6);
+$stmt->fetch();
+var_dump($ts, $ts2, $ts4, $ts6);
+$stmt->free_result();
+$link->close();
+
+// test part 2 - TIME(n)
+$link = new mysqli($host, $user, $passwd, $db, $port, $socket);
+$link->query('DROP TABLE IF EXISTS t_test;');
+$link->query(
     'CREATE TABLE t_test (id bigint unsigned auto_increment primary key, ' .
     't time default current_time(), t2 time(2) default current_time(2), t4 ' .
     'time(4) default current_time(4), t6 time(6) default current_time(6)) ' .
     'character set utf8 collate utf8_general_ci;'
 );
 $link->query(
-    'INSERT INTO ts_test (ts, ts2, ts4, ts6) VALUES ("2018-01-01 11:22:33", ' .
-    '"2018-02-02 11:22:33.77", "2018-03-03 11:22:33.8888", ' .
-    '"2018-04-04 11:22:33.999999");'
-);
-$link->query(
     'INSERT INTO t_test (t, t2, t4, t6) VALUES ("21:22:33", "21:22:33.44", ' .
     '"21:22:33.5555", "21:22:33.676767");'
 );
-
-$stmt = $link->prepare('SELECT * FROM ts_test;'); // must be statement
+$stmt = $link->prepare('SELECT * FROM t_test;');
 $stmt->execute();
-$id = $ts = $ts2 = $ts4 = $ts6 = null;
-$stmt->bind_result($id, $ts, $ts2, $ts4, $ts6);
+$tid = $t = $t2 = $t3 = $t4 = null;
+$stmt->bind_result($tid, $t, $t2, $t4, $t6);
 $stmt->fetch();
-var_dump($ts, $ts2, $ts4, $ts6);
-$stmt->free_result();
-
-$stmt2 = $link->prepare('SELECT * FROM t_test;');
-$stmt2->execute();
-$id = $t = $t2 = $t3 = $t4 = null;
-$stmt2->bind_result($id, $t, $t2, $t4, $t6);
-$stmt2->fetch();
 var_dump($t, $t2, $t4, $t6);
-$stmt2->free_result();
-
+$stmt->free_result();
 $link->close();
 ?>
 --EXPECTF--
@@ -66,7 +68,7 @@ string(15) "21:22:33.676767"
 <?php
 require_once('connect.inc');
 $link = new mysqli($host, $user, $passwd, $db, $port, $socket);
-//$link->query('DROP TABLE ts_test;');
-//$link->query('DROP TABLE t_test;');
+$link->query('DROP TABLE ts_test;');
+$link->query('DROP TABLE t_test;');
 $link->close();
 ?>

--- a/ext/mysqli/tests/bug76386.phpt
+++ b/ext/mysqli/tests/bug76386.phpt
@@ -43,12 +43,13 @@ $stmt->fetch();
 var_dump($ts, $ts2, $ts4, $ts6);
 $stmt->free_result();
 
-$stmt = $link->prepare('SELECT * FROM t_test;');
-$stmt->execute();
+$stmt2 = $link->prepare('SELECT * FROM t_test;');
+$stmt2->execute();
 $id = $t = $t2 = $t3 = $t4 = null;
-$stmt->bind_result($id, $t, $t2, $t4, $t6);
-$stmt->fetch();
+$stmt2->bind_result($id, $t, $t2, $t4, $t6);
+$stmt2->fetch();
 var_dump($t, $t2, $t4, $t6);
+$stmt2->free_result();
 
 $link->close();
 ?>

--- a/ext/mysqli/tests/bug76386.phpt
+++ b/ext/mysqli/tests/bug76386.phpt
@@ -11,6 +11,7 @@ require_once('skipifconnectfailure.inc');
 require_once('connect.inc');
 $link = new mysqli($host, $user, $passwd, $db, $port, $socket);
 $link->query('DROP TABLE IF EXISTS ts_test;');
+$link->query('DROP TABLE IF EXISTS t_test;');
 $link->query(
     'CREATE TABLE ts_test (id bigint unsigned auto_increment primary key, ' .
     'ts timestamp default current_timestamp(), ts2 timestamp(2) default ' .
@@ -19,27 +20,52 @@ $link->query(
     'utf8_general_ci;'
 );
 $link->query(
+    'CREATE TABLE t_test (id bigint unsigned auto_increment primary key, ' .
+    't time default current_time(), t2 time(2) default current_time(2), t4 ' .
+    'time(4) default current_time(4), t6 time(6) default current_time(6)) ' .
+    'character set utf8 collate utf8_general_ci;'
+);
+$link->query(
     'INSERT INTO ts_test (ts, ts2, ts4, ts6) VALUES ("2018-01-01 11:22:33", ' .
     '"2018-02-02 11:22:33.77", "2018-03-03 11:22:33.8888", ' .
     '"2018-04-04 11:22:33.999999");'
 );
+$link->query(
+    'INSERT INTO t_test (t, t2, t4, t6) VALUES ("21:22:33", "21:22:33.44", ' .
+    '"21:22:33.5555", "21:22:33.676767");'
+);
+
 $stmt = $link->prepare('SELECT * FROM ts_test;'); // must be statement
 $stmt->execute();
 $id = $ts = $ts2 = $ts4 = $ts6 = null;
 $stmt->bind_result($id, $ts, $ts2, $ts4, $ts6);
 $stmt->fetch();
-$link->close();
 var_dump($ts, $ts2, $ts4, $ts6);
+$stmt->free_result();
+
+$stmt = $link->prepare('SELECT * FROM t_test;');
+$stmt->execute();
+$id = $t = $t2 = $t3 = $t4 = null;
+$stmt->bind_result($id, $t, $t2, $t4, $t6);
+$stmt->fetch();
+var_dump($t, $t2, $t4, $t6);
+
+$link->close();
 ?>
 --EXPECTF--
 string(19) "2018-01-01 11:22:33"
 string(22) "2018-02-02 11:22:33.77"
 string(24) "2018-03-03 11:22:33.8888"
 string(26) "2018-04-04 11:22:33.999999"
+string(8) "21:22:33"
+string(11) "21:22:33.44"
+string(13) "21:22:33.5555"
+string(15) "21:22:33.676767"
 --CLEAN--
 <?php
 require_once('connect.inc');
 $link = new mysqli($host, $user, $passwd, $db, $port, $socket);
-$link->query('DROP TABLE ts_test;');
+//$link->query('DROP TABLE ts_test;');
+//$link->query('DROP TABLE t_test;');
 $link->close();
 ?>

--- a/ext/mysqli/tests/bug76386.phpt
+++ b/ext/mysqli/tests/bug76386.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Prepared Statement formatter truncates fractional seconds from date/time column (bug #76386)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifemb.inc');
+require_once('skipifconnectfailure.inc');
+?>
+--FILE--
+<?php
+require_once('connect.inc');
+$link = new mysqli($host, $user, $passwd, $db, $port, $socket);
+try {
+    $link->query(
+        'CREATE TABLE IF NOT EXISTS ts_test (id bigint unsigned auto_increment ' .
+        'primary key, ts timestamp default 0, ts2 timestamp(2) default 0, ' . 
+        'ts4 timestamp(4) default 0, ts6 timestamp(6) default 0) character ' .
+        'set utf8 collate utf8_general_ci;'
+    );
+    $link->query('TRUNCATE TABLE ts_test;');
+    $link->query('INSERT INTO ts_test VALUES ();');
+    $stmt = $link->prepare('SELECT * FROM ts_test;'); // must be statement
+    $stmt->execute();
+    $id = $ts = $ts2 = $ts4 = $ts6 = null;
+    $stmt->bind_result($id, $ts, $ts2, $ts4, $ts6);
+    $stmt->fetch();
+    var_dump($ts, $ts2, $ts4, $ts6);
+} finally {
+    $link->query('DROP TABLE IF EXISTS ts_test;');
+    $link->close();
+}
+?>
+--EXPECTF--
+string(19) "0000-00-00 00:00:00"
+string(22) "0000-00-00 00:00:00.00"
+string(24) "0000-00-00 00:00:00.0000"
+string(26) "0000-00-00 00:00:00.000000"

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -17,6 +17,7 @@
   +----------------------------------------------------------------------+
 */
 
+#include <math.h>
 #include "php.h"
 #include "mysqlnd.h"
 #include "mysqlnd_wireprotocol.h"
@@ -241,8 +242,18 @@ ps_fetch_time(zval * zv, const MYSQLND_FIELD * const field, const unsigned int p
 		t.time_type = MYSQLND_TIMESTAMP_TIME;
 	}
 
-    if (field->decimals > 0) {
-        length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u.%0*u", (t.neg ? "-" : ""), t.hour, t.minute, t.second, field->decimals, t.second_part);
+    if (field->decimals > 0 && field->decimals < 7) {
+        length = mnd_sprintf(
+            &value,
+            0,
+            "%s%02u:%02u:%02u.%0*" ZEND_ULONG_FMT_SPEC,
+            (t.neg ? "-" : ""),
+            t.hour,
+            t.minute,
+            t.second,
+            field->decimals,
+           (int) (t.second_part / pow(10, 6 - field->decimals))
+        );
     } else {
         length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u", (t.neg ? "-" : ""), t.hour, t.minute, t.second);
     }
@@ -326,8 +337,20 @@ ps_fetch_datetime(zval * zv, const MYSQLND_FIELD * const field, const unsigned i
 		t.time_type = MYSQLND_TIMESTAMP_DATETIME;
 	}
 
-    if (field->decimals > 0) {
-    	length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u.%0*u", t.year, t.month, t.day, t.hour, t.minute, t.second, field->decimals, t.second_part);
+    if (field->decimals > 0 && field->decimals < 7) {
+    	length = mnd_sprintf(
+            &value,
+            0,
+            "%04u-%02u-%02u %02u:%02u:%02u.%0*" ZEND_ULONG_FMT_SPEC,
+            t.year,
+            t.month,
+            t.day,
+            t.hour,
+            t.minute,
+            t.second,
+            field->decimals,
+            (int) (t.second_part / pow(10, 6 - field->decimals))
+        );
     } else {
     	length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u", t.year, t.month, t.day, t.hour, t.minute, t.second);
     }

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -252,7 +252,7 @@ ps_fetch_time(zval * zv, const MYSQLND_FIELD * const field, const unsigned int p
             t.minute,
             t.second,
             field->decimals,
-           (int) (t.second_part / pow(10, 6 - field->decimals))
+           (uint32_t) (t.second_part / pow(10, 6 - field->decimals))
         );
     } else {
         length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u", (t.neg ? "-" : ""), t.hour, t.minute, t.second);
@@ -349,7 +349,7 @@ ps_fetch_datetime(zval * zv, const MYSQLND_FIELD * const field, const unsigned i
             t.minute,
             t.second,
             field->decimals,
-            (int) (t.second_part / pow(10, 6 - field->decimals))
+            (uint32_t) (t.second_part / pow(10, 6 - field->decimals))
         );
     } else {
     	length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u", t.year, t.month, t.day, t.hour, t.minute, t.second);

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -246,7 +246,7 @@ ps_fetch_time(zval * zv, const MYSQLND_FIELD * const field, const unsigned int p
         length = mnd_sprintf(
             &value,
             0,
-            "%s%02u:%02u:%02u.%*u",
+            "%s%02u:%02u:%02u.%0*u",
             (t.neg ? "-" : ""),
             t.hour,
             t.minute,
@@ -341,7 +341,7 @@ ps_fetch_datetime(zval * zv, const MYSQLND_FIELD * const field, const unsigned i
     	length = mnd_sprintf(
             &value,
             0,
-            "%04u-%02u-%02u %02u:%02u:%02u.%*u",
+            "%04u-%02u-%02u %02u:%02u:%02u.%0*u",
             t.year,
             t.month,
             t.day,

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -241,7 +241,14 @@ ps_fetch_time(zval * zv, const MYSQLND_FIELD * const field, const unsigned int p
 		t.time_type = MYSQLND_TIMESTAMP_TIME;
 	}
 
-	length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u", (t.neg ? "-" : ""), t.hour, t.minute, t.second);
+    if (field->decimals > 0) {
+        char * format;
+        mnd_sprintf(&format, 0, "%%s%%02u:%%02u:%%02u.%%%02uu", field->decimals);
+        length = mnd_sprintf(&value, 0, format, (t.neg ? "-" : ""), t.hour, t.minute, t.second, t.second_part);
+        mnd_sprintf_free(format);
+    } else {
+        length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u", (t.neg ? "-" : ""), t.hour, t.minute, t.second);
+    }
 
 	DBG_INF_FMT("%s", value);
 	ZVAL_STRINGL(zv, value, length);
@@ -322,7 +329,14 @@ ps_fetch_datetime(zval * zv, const MYSQLND_FIELD * const field, const unsigned i
 		t.time_type = MYSQLND_TIMESTAMP_DATETIME;
 	}
 
-	length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u", t.year, t.month, t.day, t.hour, t.minute, t.second);
+    if (field->decimals > 0) {
+        char * format;
+        mnd_sprintf(&format, 0, "%%04u-%%02u-%%02u %%02u:%%02u:%%02u.%%%02uu", field->decimals);
+        length = mnd_sprintf(&value, 0, format, t.year, t.month, t.day, t.hour, t.minute, t.second, t.second_part);
+        mnd_sprintf_free(format);
+    } else {
+    	length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u", t.year, t.month, t.day, t.hour, t.minute, t.second);
+    }
 
 	DBG_INF_FMT("%s", value);
 	ZVAL_STRINGL(zv, value, length);

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -246,7 +246,7 @@ ps_fetch_time(zval * zv, const MYSQLND_FIELD * const field, const unsigned int p
         length = mnd_sprintf(
             &value,
             0,
-            "%s%02u:%02u:%02u.%0*" ZEND_ULONG_FMT_SPEC,
+            "%s%02u:%02u:%02u.%*u",
             (t.neg ? "-" : ""),
             t.hour,
             t.minute,
@@ -341,7 +341,7 @@ ps_fetch_datetime(zval * zv, const MYSQLND_FIELD * const field, const unsigned i
     	length = mnd_sprintf(
             &value,
             0,
-            "%04u-%02u-%02u %02u:%02u:%02u.%0*" ZEND_ULONG_FMT_SPEC,
+            "%04u-%02u-%02u %02u:%02u:%02u.%*u",
             t.year,
             t.month,
             t.day,

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -242,10 +242,7 @@ ps_fetch_time(zval * zv, const MYSQLND_FIELD * const field, const unsigned int p
 	}
 
     if (field->decimals > 0) {
-        char * format;
-        mnd_sprintf(&format, 0, "%%s%%02u:%%02u:%%02u.%%%02uu", field->decimals);
-        length = mnd_sprintf(&value, 0, format, (t.neg ? "-" : ""), t.hour, t.minute, t.second, t.second_part);
-        mnd_sprintf_free(format);
+        length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u.%0*u", (t.neg ? "-" : ""), t.hour, t.minute, t.second, field->decimals, t.second_part);
     } else {
         length = mnd_sprintf(&value, 0, "%s%02u:%02u:%02u", (t.neg ? "-" : ""), t.hour, t.minute, t.second);
     }
@@ -330,10 +327,7 @@ ps_fetch_datetime(zval * zv, const MYSQLND_FIELD * const field, const unsigned i
 	}
 
     if (field->decimals > 0) {
-        char * format;
-        mnd_sprintf(&format, 0, "%%04u-%%02u-%%02u %%02u:%%02u:%%02u.%%%02uu", field->decimals);
-        length = mnd_sprintf(&value, 0, format, t.year, t.month, t.day, t.hour, t.minute, t.second, t.second_part);
-        mnd_sprintf_free(format);
+    	length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u.%0*u", t.year, t.month, t.day, t.hour, t.minute, t.second, field->decimals, t.second_part);
     } else {
     	length = mnd_sprintf(&value, 0, "%04u-%02u-%02u %02u:%02u:%02u", t.year, t.month, t.day, t.hour, t.minute, t.second);
     }


### PR DESCRIPTION
..that is also a duplicate of #67122.

URLs for bugs that have been fixed with this PR:
https://bugs.php.net/bug.php?id=76386
https://bugs.php.net/bug.php?id=76386

~There is also a pull request #3245 that is intended to address this issue, but that is not acceptable since it ignores precision and only supports DATETIME(6) or TIMESTAMP(6).~

This fix supports arbitrary precision from the driver.
I ran all previous tests, it does not break mysqli neither.

I tried to adapt to naming && coding conventions, unsure if this was successful.
