### PR TITLE
Fix warning unused variable ret

### DIFF
--- a/main/output.c
+++ b/main/output.c
@@ -636,7 +636,6 @@ PHPAPI int php_output_handler_reverse_conflict_register(const char *name, size_t
 	if (NULL != (rev_ptr = zend_hash_str_find_ptr(&php_output_handler_reverse_conflicts, name, name_len))) {
 		return zend_hash_next_index_insert_ptr(rev_ptr, check_func) ? SUCCESS : FAILURE;
 	} else {
-		int ret;
 		zend_string *str;
 
 		zend_hash_init(&rev, 8, NULL, NULL, 1);
@@ -664,7 +663,6 @@ PHPAPI php_output_handler_alias_ctor_t php_output_handler_alias(const char *name
  * Registers an internal output handler as alias for a user handler */
 PHPAPI int php_output_handler_alias_register(const char *name, size_t name_len, php_output_handler_alias_ctor_t func)
 {
-	int ret;
 	zend_string *str;
 
 	if (!EG(current_module)) {


### PR DESCRIPTION
Hello, this patch fixes warning when doing `./configure --disable-all --enable-debug && make`:

```bash
/php-src/main/output.c: In function ‘php_output_handler_reverse_conflict_register’:
/php-src/main/output.c:639:7: warning: unused variable ‘ret’ [-Wunused-variable]
   int ret;
       ^~~
/php-src/main/output.c: In function ‘php_output_handler_alias_register’:
/php-src/main/output.c:667:6: warning: unused variable ‘ret’ [-Wunused-variable]
  int ret;
      ^~~
```

The `ret` variable is not used anymore in this code.