### PR TITLE
Fix warnings defined but not used

### DIFF
--- a/ext/standard/datetime.c
+++ b/ext/standard/datetime.c
@@ -31,18 +31,8 @@
 #endif
 #include <stdio.h>
 
-static const char * const mon_full_names[] = {
-	"January", "February", "March", "April",
-	"May", "June", "July", "August",
-	"September", "October", "November", "December"
-};
-
 static const char * const mon_short_names[] = {
 	"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-};
-
-static const char * const day_full_names[] = {
-	"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 };
 
 static const char * const day_short_names[] = {


### PR DESCRIPTION
Hello, this patch fixes two warnings for the unused variables. When compiling latest master the following warnings appear:

```bash
/php-src/ext/standard/datetime.c:44:27: warning: ‘day_full_names’ defined but not used [-Wunused-const-variable=]
 static const char * const day_full_names[] = {
                           ^~~~~~~~~~~~~~
/php-src/ext/standard/datetime.c:34:27: warning: ‘mon_full_names’ defined but not used [-Wunused-const-variable=]
 static const char * const mon_full_names[] = {
                           ^~~~~~~~~~~~~~
```