### PR TITLE
Fix version of sysvmsg in phpinfo() output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@ ext/recode/recode.c             ident
 ext/ext_skel.php                ident
 ext/phar/phar/pharcommand.inc   ident
 ext/phar/phar.c                 ident
-ext/sysvmsg/sysvmsg.c           ident
 ext/enchant/enchant.c           ident
 ext/reflection/php_reflection.c ident
 ext/oci8/oci8.c                 ident

--- a/ext/sysvmsg/sysvmsg.c
+++ b/ext/sysvmsg/sysvmsg.c
@@ -145,7 +145,6 @@ PHP_MINFO_FUNCTION(sysvmsg)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "sysvmsg support", "enabled");
-	php_info_print_table_row(2, "Revision", "$Id$");
 	php_info_print_table_end();
 }
 /* }}} */


### PR DESCRIPTION
Hello, this patch normalizes the sysvmsg extension version in the php info output. Instead of the Git attributes ident blob object name from Git repository it only displays the extension status. Since the extension is bundled with PHP, versioning is not important information here.

So, instead of this:
![phpinfo_1](https://user-images.githubusercontent.com/1614009/40868950-2560de4c-6613-11e8-9fa1-aba4d1fd11c0.png)

this is much more logical what's happening:
![phpinfo_sysvmsg](https://user-images.githubusercontent.com/1614009/40869846-7b9df52e-6622-11e8-9ee5-6d09bb54c241.png)

Thanks.

Edit: pull request synced with other pull requests...