### PR TITLE
Fix version of filter in phpinfo() output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,8 +14,6 @@ ext/dba/libinifile/inifile.c    ident
 ext/dba/libflatfile/flatfile.c  ident
 ext/dba/libcdb/cdb_make.c       ident
 ext/dba/libcdb/cdb.c            ident
-ext/filter/filter.c             ident
-README.input_filter             ident
 run-tests.php                   ident
 ext/exif/exif.c                 ident
 ext/ldap/ldap.c                 ident

--- a/README.input_filter
+++ b/README.input_filter
@@ -86,7 +86,6 @@ PHP_MINFO_FUNCTION(my_input_filter)
 {
     php_info_print_table_start();
     php_info_print_table_row( 2, "My Input Filter Support", "enabled" );
-    php_info_print_table_row( 2, "Revision", "$Id$");
     php_info_print_table_end();
 }
 

--- a/ext/filter/filter.c
+++ b/ext/filter/filter.c
@@ -330,7 +330,6 @@ PHP_MINFO_FUNCTION(filter)
 {
 	php_info_print_table_start();
 	php_info_print_table_row( 2, "Input Validation and Filtering", "enabled" );
-	php_info_print_table_row( 2, "Revision", "$Id$");
 	php_info_print_table_end();
 
 	DISPLAY_INI_ENTRIES();


### PR DESCRIPTION
This patch normalizes the filter extension version in the php info output. The Git attributes ident blob object name from Git repository is removed since extension is bundled with PHP and isn't maintained anywhere else.

Similar as is practice with other PHP core and bundled extensions, instead of this:
![phpinfo_1a](https://user-images.githubusercontent.com/1614009/40869156-248060d0-6616-11e8-8bab-57f61ee9716c.png)

This is more logical:
![filterphpinfo](https://user-images.githubusercontent.com/1614009/40869885-6efe333c-6623-11e8-8fdd-5ddbbee2aa70.png)

Note, that [filter PECL extension](https://pecl.php.net/package/filter) has been archived so there isn't any other versioning happening here.
