### PR TITLE
Fix version of Reflection in phpinfo() output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,6 @@ ext/phar/phar/pharcommand.inc   ident
 ext/phar/phar.c                 ident
 ext/sysvmsg/sysvmsg.c           ident
 ext/enchant/enchant.c           ident
-ext/reflection/php_reflection.c ident
 ext/oci8/oci8.c                 ident
 ext/dba/libinifile/inifile.c    ident
 ext/dba/libflatfile/flatfile.c  ident

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -20,8 +20,6 @@
    +----------------------------------------------------------------------+
 */
 
-/* $Id$ */
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -6821,10 +6819,7 @@ PHP_MINIT_FUNCTION(reflection) /* {{{ */
 PHP_MINFO_FUNCTION(reflection) /* {{{ */
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "Reflection", "enabled");
-
-	php_info_print_table_row(2, "Version", "$Id$");
-
+	php_info_print_table_row(2, "Reflection", "enabled");
 	php_info_print_table_end();
 } /* }}} */
 

--- a/ext/reflection/tests/026.phpt
+++ b/ext/reflection/tests/026.phpt
@@ -15,7 +15,6 @@ echo "\nDone!\n";
 Reflection
 
 Reflection => enabled
-Version => %s
 
 date
 


### PR DESCRIPTION
Hello, this patch normalizes the Reflection extension version in the phpinfo() output. It removes the Git attributes ident blob object name from Git repository as an extension version and the extension status is displayed instead (i.e. enabled).

Before:
![phpinfo_1b](https://user-images.githubusercontent.com/1614009/40869524-04b8473e-661d-11e8-8ae0-0ac656b0a9f3.png)

After:
![phpinforeflection](https://user-images.githubusercontent.com/1614009/40869914-20c93fb2-6624-11e8-9da1-4e4d5d598288.png)

Thanks.