### PR TITLE
Normalize the POSIX phpinfo output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 ext/mysqlnd/mysqlnd.h           ident
 ext/simplexml/simplexml.c       ident
 ext/iconv/php_iconv.h           ident
-ext/posix/posix.c               ident
 ext/recode/recode.c             ident
 ext/ext_skel.php                ident
 ext/phar/phar/pharcommand.inc   ident

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -321,7 +321,7 @@ static const zend_function_entry posix_functions[] = {
 static PHP_MINFO_FUNCTION(posix)
 {
 	php_info_print_table_start();
-	php_info_print_table_row(2, "Revision", "$Id$");
+	php_info_print_table_row(2, "POSIX support", "enabled");
 	php_info_print_table_end();
 }
 /* }}} */


### PR DESCRIPTION
Hello, this patch displays only the POSIX extension status in the phpinfo output instead of the Git attributes ident blob object name display only extension status (enabled).

Before:
![posix_2](https://user-images.githubusercontent.com/1614009/40869938-afd8795c-6624-11e8-9b21-0af790a4ee5e.png)

After:
![phpinfoposix](https://user-images.githubusercontent.com/1614009/40869939-b3bdb0f0-6624-11e8-9ab8-23e49a959ce9.png)

This is done to sync the display of other bundled PHP extensions.