### PR TITLE
Normalize SimpleXML phpinfo output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 ext/mysqlnd/mysqlnd.h           ident
-ext/simplexml/simplexml.c       ident
 ext/iconv/php_iconv.h           ident
 ext/posix/posix.c               ident
 ext/recode/recode.c             ident

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2711,7 +2711,7 @@ PHP_MINIT_FUNCTION(simplexml)
 	sxe_object_handlers.get_debug_info = sxe_get_debug_info;
 	sxe_object_handlers.get_closure = NULL;
 	sxe_object_handlers.get_gc = sxe_get_gc;
-	
+
 	sxe_class_entry->serialize = zend_class_serialize_deny;
 	sxe_class_entry->unserialize = zend_class_unserialize_deny;
 
@@ -2737,8 +2737,7 @@ PHP_MSHUTDOWN_FUNCTION(simplexml)
 PHP_MINFO_FUNCTION(simplexml)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "Simplexml support", "enabled");
-	php_info_print_table_row(2, "Revision", "$Id$");
+	php_info_print_table_row(2, "SimpleXML support", "enabled");
 	php_info_print_table_row(2, "Schema support",
 #ifdef LIBXML_SCHEMAS_ENABLED
 		"enabled");


### PR DESCRIPTION
Hello, SimpleXML extension is bundled with PHP and isn't having any upstream or versioning elsewhere so following previous PRs, this is more logical also. This patch removes the Git attribute ident from the phpinfo output and syncs the table rows as are with other extensions.

Before:
![simplexml_1](https://user-images.githubusercontent.com/1614009/40870340-9717a0f6-662d-11e8-980a-89890bdf4be7.png)

After:
![simplexml_2](https://user-images.githubusercontent.com/1614009/40870341-9bfdf476-662d-11e8-8c86-827a3aa5a7e6.png)

Thanks.