### PR TITLE
Remove revision for recode from phpinfo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@ ext/mysqlnd/mysqlnd.h           ident
 ext/simplexml/simplexml.c       ident
 ext/iconv/php_iconv.h           ident
 ext/posix/posix.c               ident
-ext/recode/recode.c             ident
 ext/ext_skel.php                ident
 ext/phar/phar/pharcommand.inc   ident
 ext/phar/phar.c                 ident

--- a/ext/recode/recode.c
+++ b/ext/recode/recode.c
@@ -135,7 +135,6 @@ PHP_MINFO_FUNCTION(recode)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "Recode Support", "enabled");
-	php_info_print_table_row(2, "Revision", "$Id$");
 	php_info_print_table_end();
 }
 


### PR DESCRIPTION
Hello, this patch is related to previous patches to sync the phpinfo output. Currently with some extensions there are revision ids and since the recode extension is not maintined elsewhere but this repository together with PHP release cycle it can be left out of phpinfo as well.

Before:
![recode_1](https://user-images.githubusercontent.com/1614009/40871261-c434e958-6638-11e8-9bc9-dcb9e142b990.png)

After:
![recode_2](https://user-images.githubusercontent.com/1614009/40871271-e432211c-6638-11e8-856e-5d7d243dd8a2.png)

Thanks.