### PR TITLE
Normalize the ldap extension version in phpinfo output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,6 @@ ext/dba/libcdb/cdb_make.c       ident
 ext/dba/libcdb/cdb.c            ident
 run-tests.php                   ident
 ext/exif/exif.c                 ident
-ext/ldap/ldap.c                 ident
 ext/pdo_pgsql/pdo_pgsql.c       ident
 ext/tidy/tidy.c                 ident
 NEWS                            merge=NEWS

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -24,7 +24,6 @@
    +----------------------------------------------------------------------+
  */
 
-/* $Id$ */
 #define IS_EXT_MODULE
 
 #ifdef HAVE_CONFIG_H
@@ -906,7 +905,6 @@ PHP_MINFO_FUNCTION(ldap)
 
 	php_info_print_table_start();
 	php_info_print_table_row(2, "LDAP Support", "enabled");
-	php_info_print_table_row(2, "RCS Version", "$Id$");
 
 	if (LDAPG(max_links) == -1) {
 		snprintf(tmp, 31, ZEND_LONG_FMT "/unlimited", LDAPG(num_links));


### PR DESCRIPTION
This patch drops the Git attribute ident blob object name for the ldap extension in the phpinfo output.

![ldap](https://user-images.githubusercontent.com/1614009/40879404-9557cbfc-669f-11e8-9cd7-1eccfe4ec6a1.png)

Edit: pull request changes synced with other similar pull requests (the bundled PHP extensions with versions equal to PHP release version are duplicating the information and are not an informative output in the phpinfo() so this has been removed here also).

Thanks.