### PR TITLE
Sync tidy phpinfo extension version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,7 +14,6 @@ run-tests.php                   ident
 ext/exif/exif.c                 ident
 ext/ldap/ldap.c                 ident
 ext/pdo_pgsql/pdo_pgsql.c       ident
-ext/tidy/tidy.c                 ident
 NEWS                            merge=NEWS
 UPGRADING                       merge=NEWS
 UPGRADING.INTERNALS             merge=NEWS

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -16,8 +16,6 @@
   +----------------------------------------------------------------------+
 */
 
-/* $Id$ */
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -1098,7 +1096,7 @@ static PHP_MSHUTDOWN_FUNCTION(tidy)
 static PHP_MINFO_FUNCTION(tidy)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "Tidy support", "enabled");
+	php_info_print_table_row(2, "Tidy support", "enabled");
 #if HAVE_TIDYBUFFIO_H
 	php_info_print_table_row(2, "libTidy Version", (char *)tidyLibraryVersion());
 #elif HAVE_TIDYP_H
@@ -1107,7 +1105,6 @@ static PHP_MINFO_FUNCTION(tidy)
 #if HAVE_TIDYRELEASEDATE
 	php_info_print_table_row(2, "libTidy Release", (char *)tidyReleaseDate());
 #endif
-	php_info_print_table_row(2, "Extension Version", PHP_TIDY_VERSION " ($Id$)");
 	php_info_print_table_end();
 
 	DISPLAY_INI_ENTRIES();


### PR DESCRIPTION
This patch removes the tidy extension Git ident attribute blob name from the phpinfo output to be synced with other extensions versioning system and replaces table header with table row as in most other extensions atm used.

The tidy extension is located also in [PECL](https://pecl.php.net/package/tidy) which is outdated anyway and the bundled version should be used anyway.

Before:
![tidy](https://user-images.githubusercontent.com/1614009/40878297-311b4b24-668f-11e8-8862-d0d6e5f21497.png)

After:
![tidyy](https://user-images.githubusercontent.com/1614009/40879459-55e1e79a-66a0-11e8-8e23-26e4c08e81f4.png)


Thank you.

Edited: pull request changes synced with other extensions versions.