### PR TITLE
Sync sysvsem and sysvshm versions in phpinfo

### DIFF
--- a/ext/sysvsem/php_sysvsem.h
+++ b/ext/sysvsem/php_sysvsem.h
@@ -30,6 +30,7 @@ extern zend_module_entry sysvsem_module_entry;
 #define PHP_SYSVSEM_VERSION PHP_VERSION
 
 PHP_MINIT_FUNCTION(sysvsem);
+PHP_MINFO_FUNCTION(sysvsem);
 PHP_FUNCTION(sem_get);
 PHP_FUNCTION(sem_acquire);
 PHP_FUNCTION(sem_release);

--- a/ext/sysvsem/sysvsem.c
+++ b/ext/sysvsem/sysvsem.c
@@ -41,6 +41,7 @@
 #include <errno.h>
 
 #include "php_sysvsem.h"
+#include "ext/standard/info.h"
 
 #if !HAVE_SEMUN
 
@@ -99,7 +100,7 @@ zend_module_entry sysvsem_module_entry = {
 	NULL,
 	NULL,
 	NULL,
-	NULL,
+	PHP_MINFO(sysvsem),
 	PHP_SYSVSEM_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
@@ -175,6 +176,16 @@ PHP_MINIT_FUNCTION(sysvsem)
 {
 	php_sysvsem_module.le_sem = zend_register_list_destructors_ex(release_sysvsem_sem, NULL, "sysvsem", module_number);
 	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_MINFO_FUNCTION
+ */
+PHP_MINFO_FUNCTION(sysvsem)
+{
+	php_info_print_table_start();
+	php_info_print_table_row(2, "sysvsem support", "enabled");
+	php_info_print_table_end();
 }
 /* }}} */
 

--- a/ext/sysvshm/php_sysvshm.h
+++ b/ext/sysvshm/php_sysvshm.h
@@ -71,6 +71,7 @@ typedef struct {
 } sysvshm_shm;
 
 PHP_MINIT_FUNCTION(sysvshm);
+PHP_MINFO_FUNCTION(sysvshm);
 PHP_FUNCTION(shm_attach);
 PHP_FUNCTION(shm_detach);
 PHP_FUNCTION(shm_remove);

--- a/ext/sysvshm/sysvshm.c
+++ b/ext/sysvshm/sysvshm.c
@@ -35,6 +35,7 @@
 #include <errno.h>
 
 #include "php_sysvshm.h"
+#include "ext/standard/info.h"
 #include "ext/standard/php_var.h"
 #include "zend_smart_str.h"
 #include "php_ini.h"
@@ -100,7 +101,7 @@ zend_module_entry sysvshm_module_entry = {
 	NULL,
 	NULL,
 	NULL,
-	NULL,
+	PHP_MINFO(sysvshm),
 	PHP_SYSVSHM_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
@@ -144,6 +145,16 @@ PHP_MINIT_FUNCTION(sysvshm)
 		php_sysvshm.init_mem=10000;
 	}
 	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_MINFO_FUNCTION
+ */
+PHP_MINFO_FUNCTION(sysvshm)
+{
+	php_info_print_table_start();
+	php_info_print_table_row(2, "sysvshm support", "enabled");
+	php_info_print_table_end();
 }
 /* }}} */
 


### PR DESCRIPTION
Hello, this patch removes the versions of the sysvsem and sysvshm extensions in the phpinfo output to sync them with PHP core and bundled extensions versions displayed. Instead it displays the extension enabled status.

Instead of this:
![sys_1](https://user-images.githubusercontent.com/1614009/40882500-ffe7274e-66e3-11e8-96ac-00159e5cf613.png)

This is more understandable what is happening (compared to the pattern of the other extensions):
![sys_2](https://user-images.githubusercontent.com/1614009/40882501-0d02273a-66e4-11e8-89d1-1bd702d96d36.png)

Thanks.