### PR TITLE
Sync phpinfo output for pdo_pgsql

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,7 +13,6 @@ ext/dba/libcdb/cdb.c            ident
 run-tests.php                   ident
 ext/exif/exif.c                 ident
 ext/ldap/ldap.c                 ident
-ext/pdo_pgsql/pdo_pgsql.c       ident
 ext/tidy/tidy.c                 ident
 NEWS                            merge=NEWS
 UPGRADING                       merge=NEWS

--- a/ext/pdo_pgsql/pdo_pgsql.c
+++ b/ext/pdo_pgsql/pdo_pgsql.c
@@ -16,8 +16,6 @@
   +----------------------------------------------------------------------+
 */
 
-/* $Id$ */
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -105,13 +103,10 @@ PHP_MSHUTDOWN_FUNCTION(pdo_pgsql)
 PHP_MINFO_FUNCTION(pdo_pgsql)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "PDO Driver for PostgreSQL", "enabled");
+	php_info_print_table_row(2, "PDO Driver for PostgreSQL", "enabled");
 #ifdef HAVE_PG_CONFIG_H
 	php_info_print_table_row(2, "PostgreSQL(libpq) Version", PG_VERSION);
 #endif
-	php_info_print_table_row(2, "Module version", pdo_pgsql_module_entry.version);
-	php_info_print_table_row(2, "Revision", " $Id$ ");
-
 	php_info_print_table_end();
 }
 /* }}} */


### PR DESCRIPTION
Hello, this patch removes the module version and revision from the phpinfo output to sync the phpinfo with the rest of the bundled extensions.

Before:
![pdopgsql_1](https://user-images.githubusercontent.com/1614009/40882604-a9496542-66e7-11e8-9bf4-da5d704a8c56.png)

After:
![pdopgsql_2](https://user-images.githubusercontent.com/1614009/40882606-ad43595a-66e7-11e8-9642-32a4b79d0159.png)

The module version above is in this case always the PHP release version and is removed to sync it with other extensions. The [PDO PGSQL](https://pecl.php.net/package/PDO_PGSQL) hasn't it's own versioning but the main maintenance and development is happening in this repository anyway.

Thanks.