### PR TITLE
Remove exif version from the phpinfo output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,6 @@ ext/dba/libflatfile/flatfile.c  ident
 ext/dba/libcdb/cdb_make.c       ident
 ext/dba/libcdb/cdb.c            ident
 run-tests.php                   ident
-ext/exif/exif.c                 ident
 ext/ldap/ldap.c                 ident
 ext/pdo_pgsql/pdo_pgsql.c       ident
 ext/tidy/tidy.c                 ident

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -17,8 +17,6 @@
    +----------------------------------------------------------------------+
  */
 
-/* $Id$ */
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -113,7 +111,6 @@ PHP_MINFO_FUNCTION(exif)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "EXIF Support", "enabled");
-	php_info_print_table_row(2, "EXIF Version", PHP_EXIF_VERSION);
 	php_info_print_table_row(2, "Supported EXIF Version", "0220");
 	php_info_print_table_row(2, "Supported filetypes", "JPEG, TIFF");
 


### PR DESCRIPTION
Following previous pull requests, this patch removes the exif version in the phpinfo output to sync it with the rest of the php bundled extensions. Also in the past the revision id from the version control system was used and is today not needed anymore.

Thanks for considering merging it or checking this out.