### PR TITLE
Remove enchant version from the phpinfo output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@ ext/iconv/php_iconv.h           ident
 ext/ext_skel.php                ident
 ext/phar/phar/pharcommand.inc   ident
 ext/phar/phar.c                 ident
-ext/enchant/enchant.c           ident
 ext/reflection/php_reflection.c ident
 ext/oci8/oci8.c                 ident
 ext/dba/libinifile/inifile.c    ident

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -15,8 +15,6 @@
   | Author: Pierre-Alain Joye <paj@pearfr.org>                           |
   |         Ilia Alshanetsky <ilia@prohost.org>                          |
   +----------------------------------------------------------------------+
-
-  $Id$
 */
 
 #ifdef HAVE_CONFIG_H
@@ -316,8 +314,7 @@ PHP_MINFO_FUNCTION(enchant)
 
 	pbroker = enchant_broker_init();
 	php_info_print_table_start();
-	php_info_print_table_header(2, "enchant support", "enabled");
-	php_info_print_table_row(2, "Version", PHP_ENCHANT_VERSION);
+	php_info_print_table_row(2, "enchant support", "enabled");
 #ifdef ENCHANT_VERSION_STRING
 	php_info_print_table_row(2, "Libenchant Version", ENCHANT_VERSION_STRING);
 #elif defined(HAVE_ENCHANT_BROKER_SET_PARAM)


### PR DESCRIPTION
This patch syncs the phpinfo output with other bundled extensions.

Before:
![enchant_1](https://user-images.githubusercontent.com/1614009/40882914-7e64f4b4-66f0-11e8-8bb3-75b971571c3f.png)

After:
![enchant_2](https://user-images.githubusercontent.com/1614009/40882915-81e19142-66f0-11e8-87fa-621301475d0f.png)
