### PR TITLE
Avoid leaking the urandom fd

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -637,6 +637,7 @@ PHP_MINIT_FUNCTION(sodium)
 
 PHP_MSHUTDOWN_FUNCTION(sodium)
 {
+	randombytes_close();
 	return SUCCESS;
 }
 


### PR DESCRIPTION
When Apache is reloaded, it unloads the extension, but the open file descriptor to /dev/urandom is left hanging around and is leaked. This fixes the bug.

Duplicate of https://github.com/jedisct1/libsodium-php/pull/173