### PR TITLE
fixed crash of cases related to mbstring on Big_Endian platform(s390x)

### DIFF
--- a/ext/mbstring/oniguruma/regint.h
+++ b/ext/mbstring/oniguruma/regint.h
@@ -553,8 +553,8 @@ typedef int RelAddrType;
 typedef int AbsAddrType;
 typedef int LengthType;
 typedef int RepeatNumType;
-typedef short int MemNumType;
-typedef short int StateCheckNumType;
+typedef int MemNumType;
+typedef int StateCheckNumType;
 typedef void* PointerType;
 
 #define SIZE_OPCODE           1


### PR DESCRIPTION
Follow #3143 to fixPHP-7.1 on the issue [75863](https://bugs.php.net/bug.php?id=75863)
