### PR TITLE
Pack op1_type and op2_type into one byte, add ex_flags

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7528,7 +7528,7 @@ void zend_compile_isset_or_empty(znode *result, zend_ast *ast) /* {{{ */
 
 	result->op_type = opline->result_type = IS_TMP_VAR;
 	if (!(ast->kind == ZEND_AST_ISSET)) {
-		opline->extended_value |= ZEND_ISEMPTY;
+		opline->ex_flags |= ZEND_ISEMPTY;
 	}
 }
 /* }}} */

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5162,7 +5162,7 @@ void zend_compile_try(zend_ast *ast) /* {{{ */
 			opline->result.var = lookup_cv(CG(active_op_array), var_name);
 
 			if (is_last_catch && is_last_class) {
-				opline->extended_value |= ZEND_LAST_CATCH;
+				opline->ex_flags |= ZEND_LAST_CATCH;
 			}
 
 			if (!is_last_class) {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -95,6 +95,7 @@ static void init_op(zend_op *op)
 {
 	MAKE_NOP(op);
 	op->extended_value = 0;
+	op->ex_flags = 0;
 	op->lineno = CG(zend_lineno);
 }
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -781,6 +781,7 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, zend_bool nullify
 uint32_t zend_get_class_fetch_type(zend_string *name);
 ZEND_API zend_uchar zend_get_call_op(const zend_op *init_op, zend_function *fbc);
 ZEND_API int zend_is_smart_branch(zend_op *opline);
+ZEND_API void zend_set_smart_branch_flags(zend_op *opline, const zend_op *end);
 
 static zend_always_inline uint32_t get_next_op_number(zend_op_array *op_array)
 {
@@ -879,6 +880,8 @@ void zend_assert_valid_class_name(const zend_string *const_name);
 /* Flags stored in ex_flags */
 #define ZEND_LAST_CATCH			(1<<0)
 #define ZEND_ISEMPTY			(1<<0)
+#define ZEND_SMART_BRANCH_JMPZ	(1<<1)
+#define ZEND_SMART_BRANCH_JMPNZ	(1<<2)
 
 #define ZEND_FREE_ON_RETURN     (1<<0)
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -878,6 +878,7 @@ void zend_assert_valid_class_name(const zend_string *const_name);
 
 #define ZEND_ISEMPTY			(1<<0)
 
+/* Stored in ex_flags */
 #define ZEND_LAST_CATCH			(1<<0)
 
 #define ZEND_FREE_ON_RETURN     (1<<0)

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -876,10 +876,9 @@ void zend_assert_valid_class_name(const zend_string *const_name);
 
 #define ZEND_FETCH_TYPE_MASK	0xe
 
-#define ZEND_ISEMPTY			(1<<0)
-
-/* Stored in ex_flags */
+/* Flags stored in ex_flags */
 #define ZEND_LAST_CATCH			(1<<0)
+#define ZEND_ISEMPTY			(1<<0)
 
 #define ZEND_FREE_ON_RETURN     (1<<0)
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -147,9 +147,10 @@ struct _zend_op {
 	uint32_t extended_value;
 	uint32_t lineno;
 	zend_uchar opcode;
-	zend_uchar op1_type;
-	zend_uchar op2_type;
+	zend_uchar op1_type : 4;
+	zend_uchar op2_type : 4;
 	zend_uchar result_type;
+	zend_uchar ex_flags;
 };
 
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3297,9 +3297,9 @@ static zend_never_inline zend_bool ZEND_FASTCALL zend_fe_reset_iterator(zval *ar
 	ZEND_VM_CONTINUE()
 # define ZEND_VM_SMART_BRANCH(_result, _check) do { \
 		int __result; \
-		if (EXPECTED((opline+1)->opcode == ZEND_JMPZ)) { \
+		if (EXPECTED(opline->ex_flags & ZEND_SMART_BRANCH_JMPZ)) { \
 			__result = (_result); \
-		} else if (EXPECTED((opline+1)->opcode == ZEND_JMPNZ)) { \
+		} else if (EXPECTED(opline->ex_flags & ZEND_SMART_BRANCH_JMPNZ)) { \
 			__result = !(_result); \
 		} else { \
 			break; \

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -578,6 +578,10 @@ ZEND_API int pass_two(zend_op_array *op_array)
 	opline = op_array->opcodes;
 	end = opline + op_array->last;
 	while (opline < end) {
+		if (zend_is_smart_branch(opline)) {
+			zend_set_smart_branch_flags(opline, end);
+		}
+
 		switch (opline->opcode) {
 			case ZEND_RECV_INIT:
 				{

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4082,11 +4082,11 @@ ZEND_VM_HANDLER(107, ZEND_CATCH, CONST, JMP_ADDR, LAST_CATCH|CACHE_SLOT)
 	if (EG(exception) == NULL) {
 		ZEND_VM_JMP_EX(OP_JMP_ADDR(opline, opline->op2), 0);
 	}
-	catch_ce = CACHED_PTR(opline->extended_value & ~ZEND_LAST_CATCH);
+	catch_ce = CACHED_PTR(opline->extended_value);
 	if (UNEXPECTED(catch_ce == NULL)) {
 		catch_ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), RT_CONSTANT(opline, opline->op1) + 1, ZEND_FETCH_CLASS_NO_AUTOLOAD);
 
-		CACHE_PTR(opline->extended_value & ~ZEND_LAST_CATCH, catch_ce);
+		CACHE_PTR(opline->extended_value, catch_ce);
 	}
 	ce = EG(exception)->ce;
 
@@ -4098,7 +4098,7 @@ ZEND_VM_HANDLER(107, ZEND_CATCH, CONST, JMP_ADDR, LAST_CATCH|CACHE_SLOT)
 
 	if (ce != catch_ce) {
 		if (!catch_ce || !instanceof_function(ce, catch_ce)) {
-			if (opline->extended_value & ZEND_LAST_CATCH) {
+			if (opline->ex_flags & ZEND_LAST_CATCH) {
 				zend_rethrow_exception(execute_data);
 				HANDLE_EXCEPTION();
 			}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5642,10 +5642,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 
 	SAVE_OPLINE();
 	if (IS_CONST == IS_CONST) {
-		if (IS_CONST == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) != NULL)) {
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+		if (IS_CONST == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value)) != NULL)) {
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
-		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) == NULL)) {
+		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value)) == NULL)) {
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 				ZEND_ASSERT(EG(exception));
@@ -5653,7 +5653,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CONST != IS_CONST) {
-				CACHE_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce);
+				CACHE_PTR(opline->extended_value, ce);
 			}
 		}
 	} else {
@@ -5669,9 +5669,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 			ce = Z_CE_P(EX_VAR(opline->op2.var));
 		}
 		if (IS_CONST == IS_CONST &&
-		    EXPECTED(CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY) == ce)) {
+		    EXPECTED(CACHED_PTR(opline->extended_value) == ce)) {
 
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
 		}
 	}
@@ -5686,7 +5686,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	value = zend_std_get_static_property(ce, name, 1);
 
 	if (IS_CONST == IS_CONST && value) {
-		CACHE_POLYMORPHIC_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce, value);
+		CACHE_POLYMORPHIC_PTR(opline->extended_value, ce, value);
 	}
 
 	if (IS_CONST != IS_CONST) {
@@ -5694,7 +5694,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	}
 
 is_static_prop_return:
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = value && Z_TYPE_P(value) > IS_NULL &&
 		    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
 	} else {
@@ -5746,7 +5746,7 @@ num_index_prop:
 			value = zend_find_array_dim_slow(ht, offset EXECUTE_DATA_CC);
 		}
 
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			/* > IS_NULL means not IS_UNDEF and not IS_NULL */
 			result = value != NULL && Z_TYPE_P(value) > IS_NULL &&
 			    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
@@ -5761,7 +5761,7 @@ num_index_prop:
 		}
 	}
 
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = zend_isset_dim_slow(container, offset EXECUTE_DATA_CC);
 	} else {
 		result = zend_isempty_dim_slow(container, offset EXECUTE_DATA_CC);
@@ -5806,11 +5806,11 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PRO
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 
@@ -7634,7 +7634,7 @@ num_index_prop:
 			value = zend_find_array_dim_slow(ht, offset EXECUTE_DATA_CC);
 		}
 
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			/* > IS_NULL means not IS_UNDEF and not IS_NULL */
 			result = value != NULL && Z_TYPE_P(value) > IS_NULL &&
 			    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
@@ -7649,7 +7649,7 @@ num_index_prop:
 		}
 	}
 
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = zend_isset_dim_slow(container, offset EXECUTE_DATA_CC);
 	} else {
 		result = zend_isempty_dim_slow(container, offset EXECUTE_DATA_CC);
@@ -7694,11 +7694,11 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PRO
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 	zval_ptr_dtor_nogc(free_op2);
@@ -8036,10 +8036,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CONST) {
-		if (IS_CONST == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) != NULL)) {
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+		if (IS_CONST == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value)) != NULL)) {
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
-		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) == NULL)) {
+		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value)) == NULL)) {
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 				ZEND_ASSERT(EG(exception));
@@ -8047,7 +8047,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CONST != IS_CONST) {
-				CACHE_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce);
+				CACHE_PTR(opline->extended_value, ce);
 			}
 		}
 	} else {
@@ -8063,9 +8063,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 			ce = Z_CE_P(EX_VAR(opline->op2.var));
 		}
 		if (IS_CONST == IS_CONST &&
-		    EXPECTED(CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY) == ce)) {
+		    EXPECTED(CACHED_PTR(opline->extended_value) == ce)) {
 
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
 		}
 	}
@@ -8080,7 +8080,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	value = zend_std_get_static_property(ce, name, 1);
 
 	if (IS_CONST == IS_CONST && value) {
-		CACHE_POLYMORPHIC_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce, value);
+		CACHE_POLYMORPHIC_PTR(opline->extended_value, ce, value);
 	}
 
 	if (IS_CONST != IS_CONST) {
@@ -8088,7 +8088,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	}
 
 is_static_prop_return:
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = value && Z_TYPE_P(value) > IS_NULL &&
 		    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
 	} else {
@@ -8986,12 +8986,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_CONST_U
 	}
 
 	if (!value) {
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		if (Z_TYPE_P(value) == IS_INDIRECT) {
 			value = Z_INDIRECT_P(value);
 		}
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			if (Z_ISREF_P(value)) {
 				value = Z_REFVAL_P(value);
 			}
@@ -9018,10 +9018,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 
 	SAVE_OPLINE();
 	if (IS_UNUSED == IS_CONST) {
-		if (IS_CONST == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) != NULL)) {
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+		if (IS_CONST == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value)) != NULL)) {
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
-		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) == NULL)) {
+		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value)) == NULL)) {
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 				ZEND_ASSERT(EG(exception));
@@ -9029,7 +9029,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CONST != IS_CONST) {
-				CACHE_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce);
+				CACHE_PTR(opline->extended_value, ce);
 			}
 		}
 	} else {
@@ -9045,9 +9045,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 			ce = Z_CE_P(EX_VAR(opline->op2.var));
 		}
 		if (IS_CONST == IS_CONST &&
-		    EXPECTED(CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY) == ce)) {
+		    EXPECTED(CACHED_PTR(opline->extended_value) == ce)) {
 
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
 		}
 	}
@@ -9062,7 +9062,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	value = zend_std_get_static_property(ce, name, 1);
 
 	if (IS_CONST == IS_CONST && value) {
-		CACHE_POLYMORPHIC_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce, value);
+		CACHE_POLYMORPHIC_PTR(opline->extended_value, ce, value);
 	}
 
 	if (IS_CONST != IS_CONST) {
@@ -9070,7 +9070,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	}
 
 is_static_prop_return:
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = value && Z_TYPE_P(value) > IS_NULL &&
 		    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
 	} else {
@@ -10701,7 +10701,7 @@ num_index_prop:
 			value = zend_find_array_dim_slow(ht, offset EXECUTE_DATA_CC);
 		}
 
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			/* > IS_NULL means not IS_UNDEF and not IS_NULL */
 			result = value != NULL && Z_TYPE_P(value) > IS_NULL &&
 			    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
@@ -10716,7 +10716,7 @@ num_index_prop:
 		}
 	}
 
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = zend_isset_dim_slow(container, offset EXECUTE_DATA_CC);
 	} else {
 		result = zend_isempty_dim_slow(container, offset EXECUTE_DATA_CC);
@@ -10761,11 +10761,11 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PRO
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 
@@ -14127,10 +14127,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 
 	SAVE_OPLINE();
 	if (IS_CONST == IS_CONST) {
-		if ((IS_TMP_VAR|IS_VAR) == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) != NULL)) {
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+		if ((IS_TMP_VAR|IS_VAR) == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value)) != NULL)) {
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
-		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) == NULL)) {
+		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value)) == NULL)) {
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 				ZEND_ASSERT(EG(exception));
@@ -14138,7 +14138,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 				HANDLE_EXCEPTION();
 			}
 			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				CACHE_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce);
+				CACHE_PTR(opline->extended_value, ce);
 			}
 		}
 	} else {
@@ -14154,9 +14154,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 			ce = Z_CE_P(EX_VAR(opline->op2.var));
 		}
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		    EXPECTED(CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY) == ce)) {
+		    EXPECTED(CACHED_PTR(opline->extended_value) == ce)) {
 
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
 		}
 	}
@@ -14171,7 +14171,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	value = zend_std_get_static_property(ce, name, 1);
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST && value) {
-		CACHE_POLYMORPHIC_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce, value);
+		CACHE_POLYMORPHIC_PTR(opline->extended_value, ce, value);
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
@@ -14180,7 +14180,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	zval_ptr_dtor_nogc(free_op1);
 
 is_static_prop_return:
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = value && Z_TYPE_P(value) > IS_NULL &&
 		    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
 	} else {
@@ -14232,7 +14232,7 @@ num_index_prop:
 			value = zend_find_array_dim_slow(ht, offset EXECUTE_DATA_CC);
 		}
 
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			/* > IS_NULL means not IS_UNDEF and not IS_NULL */
 			result = value != NULL && Z_TYPE_P(value) > IS_NULL &&
 			    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
@@ -14247,7 +14247,7 @@ num_index_prop:
 		}
 	}
 
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = zend_isset_dim_slow(container, offset EXECUTE_DATA_CC);
 	} else {
 		result = zend_isempty_dim_slow(container, offset EXECUTE_DATA_CC);
@@ -14292,11 +14292,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PROP_OBJ_SPEC_TM
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 	zval_ptr_dtor_nogc(free_op1);
@@ -15688,7 +15688,7 @@ num_index_prop:
 			value = zend_find_array_dim_slow(ht, offset EXECUTE_DATA_CC);
 		}
 
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			/* > IS_NULL means not IS_UNDEF and not IS_NULL */
 			result = value != NULL && Z_TYPE_P(value) > IS_NULL &&
 			    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
@@ -15703,7 +15703,7 @@ num_index_prop:
 		}
 	}
 
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = zend_isset_dim_slow(container, offset EXECUTE_DATA_CC);
 	} else {
 		result = zend_isempty_dim_slow(container, offset EXECUTE_DATA_CC);
@@ -15748,11 +15748,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PROP_OBJ_SPEC_TM
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 	zval_ptr_dtor_nogc(free_op2);
@@ -15954,10 +15954,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CONST) {
-		if ((IS_TMP_VAR|IS_VAR) == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) != NULL)) {
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+		if ((IS_TMP_VAR|IS_VAR) == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value)) != NULL)) {
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
-		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) == NULL)) {
+		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value)) == NULL)) {
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 				ZEND_ASSERT(EG(exception));
@@ -15965,7 +15965,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 				HANDLE_EXCEPTION();
 			}
 			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				CACHE_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce);
+				CACHE_PTR(opline->extended_value, ce);
 			}
 		}
 	} else {
@@ -15981,9 +15981,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 			ce = Z_CE_P(EX_VAR(opline->op2.var));
 		}
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		    EXPECTED(CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY) == ce)) {
+		    EXPECTED(CACHED_PTR(opline->extended_value) == ce)) {
 
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
 		}
 	}
@@ -15998,7 +15998,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	value = zend_std_get_static_property(ce, name, 1);
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST && value) {
-		CACHE_POLYMORPHIC_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce, value);
+		CACHE_POLYMORPHIC_PTR(opline->extended_value, ce, value);
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
@@ -16007,7 +16007,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	zval_ptr_dtor_nogc(free_op1);
 
 is_static_prop_return:
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = value && Z_TYPE_P(value) > IS_NULL &&
 		    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
 	} else {
@@ -16428,12 +16428,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_TMPVAR_
 	zval_ptr_dtor_nogc(free_op1);
 
 	if (!value) {
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		if (Z_TYPE_P(value) == IS_INDIRECT) {
 			value = Z_INDIRECT_P(value);
 		}
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			if (Z_ISREF_P(value)) {
 				value = Z_REFVAL_P(value);
 			}
@@ -16460,10 +16460,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 
 	SAVE_OPLINE();
 	if (IS_UNUSED == IS_CONST) {
-		if ((IS_TMP_VAR|IS_VAR) == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) != NULL)) {
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+		if ((IS_TMP_VAR|IS_VAR) == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value)) != NULL)) {
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
-		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) == NULL)) {
+		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value)) == NULL)) {
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 				ZEND_ASSERT(EG(exception));
@@ -16471,7 +16471,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 				HANDLE_EXCEPTION();
 			}
 			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				CACHE_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce);
+				CACHE_PTR(opline->extended_value, ce);
 			}
 		}
 	} else {
@@ -16487,9 +16487,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 			ce = Z_CE_P(EX_VAR(opline->op2.var));
 		}
 		if ((IS_TMP_VAR|IS_VAR) == IS_CONST &&
-		    EXPECTED(CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY) == ce)) {
+		    EXPECTED(CACHED_PTR(opline->extended_value) == ce)) {
 
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
 		}
 	}
@@ -16504,7 +16504,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	value = zend_std_get_static_property(ce, name, 1);
 
 	if ((IS_TMP_VAR|IS_VAR) == IS_CONST && value) {
-		CACHE_POLYMORPHIC_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce, value);
+		CACHE_POLYMORPHIC_PTR(opline->extended_value, ce, value);
 	}
 
 	if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
@@ -16513,7 +16513,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	zval_ptr_dtor_nogc(free_op1);
 
 is_static_prop_return:
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = value && Z_TYPE_P(value) > IS_NULL &&
 		    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
 	} else {
@@ -17547,7 +17547,7 @@ num_index_prop:
 			value = zend_find_array_dim_slow(ht, offset EXECUTE_DATA_CC);
 		}
 
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			/* > IS_NULL means not IS_UNDEF and not IS_NULL */
 			result = value != NULL && Z_TYPE_P(value) > IS_NULL &&
 			    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
@@ -17562,7 +17562,7 @@ num_index_prop:
 		}
 	}
 
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = zend_isset_dim_slow(container, offset EXECUTE_DATA_CC);
 	} else {
 		result = zend_isempty_dim_slow(container, offset EXECUTE_DATA_CC);
@@ -17607,11 +17607,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PROP_OBJ_SPEC_TM
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 	zval_ptr_dtor_nogc(free_op1);
@@ -31864,11 +31864,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PROP_OBJ_SPEC_UN
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 
@@ -33498,11 +33498,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PROP_OBJ_SPEC_UN
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 	zval_ptr_dtor_nogc(free_op2);
@@ -34247,7 +34247,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_THIS_SPEC_UNUSED
 	USE_OPLINE
 
 	ZVAL_BOOL(EX_VAR(opline->result.var),
-		(opline->extended_value & ZEND_ISEMPTY) ^
+		(opline->ex_flags & ZEND_ISEMPTY) ^
 		 (Z_TYPE(EX(This)) == IS_OBJECT));
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -35860,11 +35860,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PROP_OBJ_SPEC_UN
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 
@@ -40882,10 +40882,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 
 	SAVE_OPLINE();
 	if (IS_CONST == IS_CONST) {
-		if (IS_CV == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) != NULL)) {
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+		if (IS_CV == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value)) != NULL)) {
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
-		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) == NULL)) {
+		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value)) == NULL)) {
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 				ZEND_ASSERT(EG(exception));
@@ -40893,7 +40893,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CV != IS_CONST) {
-				CACHE_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce);
+				CACHE_PTR(opline->extended_value, ce);
 			}
 		}
 	} else {
@@ -40909,9 +40909,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 			ce = Z_CE_P(EX_VAR(opline->op2.var));
 		}
 		if (IS_CV == IS_CONST &&
-		    EXPECTED(CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY) == ce)) {
+		    EXPECTED(CACHED_PTR(opline->extended_value) == ce)) {
 
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
 		}
 	}
@@ -40926,7 +40926,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	value = zend_std_get_static_property(ce, name, 1);
 
 	if (IS_CV == IS_CONST && value) {
-		CACHE_POLYMORPHIC_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce, value);
+		CACHE_POLYMORPHIC_PTR(opline->extended_value, ce, value);
 	}
 
 	if (IS_CV != IS_CONST) {
@@ -40934,7 +40934,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	}
 
 is_static_prop_return:
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = value && Z_TYPE_P(value) > IS_NULL &&
 		    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
 	} else {
@@ -40986,7 +40986,7 @@ num_index_prop:
 			value = zend_find_array_dim_slow(ht, offset EXECUTE_DATA_CC);
 		}
 
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			/* > IS_NULL means not IS_UNDEF and not IS_NULL */
 			result = value != NULL && Z_TYPE_P(value) > IS_NULL &&
 			    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
@@ -41001,7 +41001,7 @@ num_index_prop:
 		}
 	}
 
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = zend_isset_dim_slow(container, offset EXECUTE_DATA_CC);
 	} else {
 		result = zend_isempty_dim_slow(container, offset EXECUTE_DATA_CC);
@@ -41046,11 +41046,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PROP_OBJ_SPEC_CV
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 
@@ -44526,7 +44526,7 @@ num_index_prop:
 			value = zend_find_array_dim_slow(ht, offset EXECUTE_DATA_CC);
 		}
 
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			/* > IS_NULL means not IS_UNDEF and not IS_NULL */
 			result = value != NULL && Z_TYPE_P(value) > IS_NULL &&
 			    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
@@ -44541,7 +44541,7 @@ num_index_prop:
 		}
 	}
 
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = zend_isset_dim_slow(container, offset EXECUTE_DATA_CC);
 	} else {
 		result = zend_isempty_dim_slow(container, offset EXECUTE_DATA_CC);
@@ -44586,11 +44586,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PROP_OBJ_SPEC_CV
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), (((IS_TMP_VAR|IS_VAR) == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 	zval_ptr_dtor_nogc(free_op2);
@@ -45163,10 +45163,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CONST) {
-		if (IS_CV == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) != NULL)) {
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+		if (IS_CV == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value)) != NULL)) {
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
-		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) == NULL)) {
+		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value)) == NULL)) {
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 				ZEND_ASSERT(EG(exception));
@@ -45174,7 +45174,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CV != IS_CONST) {
-				CACHE_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce);
+				CACHE_PTR(opline->extended_value, ce);
 			}
 		}
 	} else {
@@ -45190,9 +45190,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 			ce = Z_CE_P(EX_VAR(opline->op2.var));
 		}
 		if (IS_CV == IS_CONST &&
-		    EXPECTED(CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY) == ce)) {
+		    EXPECTED(CACHED_PTR(opline->extended_value) == ce)) {
 
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
 		}
 	}
@@ -45207,7 +45207,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	value = zend_std_get_static_property(ce, name, 1);
 
 	if (IS_CV == IS_CONST && value) {
-		CACHE_POLYMORPHIC_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce, value);
+		CACHE_POLYMORPHIC_PTR(opline->extended_value, ce, value);
 	}
 
 	if (IS_CV != IS_CONST) {
@@ -45215,7 +45215,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	}
 
 is_static_prop_return:
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = value && Z_TYPE_P(value) > IS_NULL &&
 		    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
 	} else {
@@ -46575,12 +46575,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_CV_UNUS
 	}
 
 	if (!value) {
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		if (Z_TYPE_P(value) == IS_INDIRECT) {
 			value = Z_INDIRECT_P(value);
 		}
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			if (Z_ISREF_P(value)) {
 				value = Z_REFVAL_P(value);
 			}
@@ -46607,10 +46607,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 
 	SAVE_OPLINE();
 	if (IS_UNUSED == IS_CONST) {
-		if (IS_CV == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) != NULL)) {
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+		if (IS_CV == IS_CONST && EXPECTED((ce = CACHED_PTR(opline->extended_value)) != NULL)) {
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
-		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY)) == NULL)) {
+		} else if (UNEXPECTED((ce = CACHED_PTR(opline->extended_value)) == NULL)) {
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op2)), RT_CONSTANT(opline, opline->op2) + 1, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 				ZEND_ASSERT(EG(exception));
@@ -46618,7 +46618,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CV != IS_CONST) {
-				CACHE_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce);
+				CACHE_PTR(opline->extended_value, ce);
 			}
 		}
 	} else {
@@ -46634,9 +46634,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 			ce = Z_CE_P(EX_VAR(opline->op2.var));
 		}
 		if (IS_CV == IS_CONST &&
-		    EXPECTED(CACHED_PTR(opline->extended_value & ~ZEND_ISEMPTY) == ce)) {
+		    EXPECTED(CACHED_PTR(opline->extended_value) == ce)) {
 
-			value = CACHED_PTR((opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*));
+			value = CACHED_PTR((opline->extended_value) + sizeof(void*));
 			goto is_static_prop_return;
 		}
 	}
@@ -46651,7 +46651,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	value = zend_std_get_static_property(ce, name, 1);
 
 	if (IS_CV == IS_CONST && value) {
-		CACHE_POLYMORPHIC_PTR(opline->extended_value & ~ZEND_ISEMPTY, ce, value);
+		CACHE_POLYMORPHIC_PTR(opline->extended_value, ce, value);
 	}
 
 	if (IS_CV != IS_CONST) {
@@ -46659,7 +46659,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_STATIC_PROP_SPEC
 	}
 
 is_static_prop_return:
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = value && Z_TYPE_P(value) > IS_NULL &&
 		    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
 	} else {
@@ -50138,7 +50138,7 @@ num_index_prop:
 			value = zend_find_array_dim_slow(ht, offset EXECUTE_DATA_CC);
 		}
 
-		if (!(opline->extended_value & ZEND_ISEMPTY)) {
+		if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 			/* > IS_NULL means not IS_UNDEF and not IS_NULL */
 			result = value != NULL && Z_TYPE_P(value) > IS_NULL &&
 			    (!Z_ISREF_P(value) || Z_TYPE_P(Z_REFVAL_P(value)) != IS_NULL);
@@ -50153,7 +50153,7 @@ num_index_prop:
 		}
 	}
 
-	if (!(opline->extended_value & ZEND_ISEMPTY)) {
+	if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 		result = zend_isset_dim_slow(container, offset EXECUTE_DATA_CC);
 	} else {
 		result = zend_isempty_dim_slow(container, offset EXECUTE_DATA_CC);
@@ -50198,11 +50198,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_PROP_OBJ_SPEC_CV
 	if (UNEXPECTED(!Z_OBJ_HT_P(container)->has_property)) {
 		zend_wrong_property_check(offset);
 isset_no_object:
-		result = (opline->extended_value & ZEND_ISEMPTY);
+		result = (opline->ex_flags & ZEND_ISEMPTY);
 	} else {
 		result =
-			(opline->extended_value & ZEND_ISEMPTY) ^
-			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->extended_value & ZEND_ISEMPTY), ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_ISEMPTY) : NULL));
+			(opline->ex_flags & ZEND_ISEMPTY) ^
+			Z_OBJ_HT_P(container)->has_property(container, offset, (opline->ex_flags & ZEND_ISEMPTY), ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL));
 	}
 
 
@@ -64171,7 +64171,7 @@ static const void* ZEND_FASTCALL zend_vm_get_opcode_handler_ex(uint32_t spec, co
 				offset += 2;
 			}
 		}
-		else if (spec & SPEC_RULE_ISSET) offset = offset * 2 + (op->extended_value & ZEND_ISEMPTY);
+		else if (spec & SPEC_RULE_ISSET) offset = offset * 2 + (op->ex_flags & ZEND_ISEMPTY);
 	}
 	return zend_opcode_handlers[(spec & SPEC_START_MASK) + offset];
 }
@@ -64221,7 +64221,7 @@ static const void *zend_vm_get_opcode_handler_func(zend_uchar opcode, const zend
 				offset += 2;
 			}
 		}
-		else if (spec & SPEC_RULE_ISSET) offset = offset * 2 + (op->extended_value & ZEND_ISEMPTY);
+		else if (spec & SPEC_RULE_ISSET) offset = offset * 2 + (op->ex_flags & ZEND_ISEMPTY);
 	}
 	return zend_opcode_handler_funcs[(spec & SPEC_START_MASK) + offset];
 }

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -64157,9 +64157,9 @@ static const void* ZEND_FASTCALL zend_vm_get_opcode_handler_ex(uint32_t spec, co
 		else if (spec & SPEC_RULE_QUICK_ARG) offset = offset * 2 + (op->op2.num <= MAX_ARG_FLAG_NUM);
 		else if (spec & SPEC_RULE_SMART_BRANCH) {
 			offset = offset * 3;
-			if ((op+1)->opcode == ZEND_JMPZ) {
+			if (op->ex_flags & ZEND_SMART_BRANCH_JMPZ) {
 				offset += 1;
-			} else if ((op+1)->opcode == ZEND_JMPNZ) {
+			} else if (op->ex_flags & ZEND_SMART_BRANCH_JMPNZ) {
 				offset += 2;
 			}
 		}
@@ -64207,9 +64207,9 @@ static const void *zend_vm_get_opcode_handler_func(zend_uchar opcode, const zend
 		else if (spec & SPEC_RULE_QUICK_ARG) offset = offset * 2 + (op->op2.num <= MAX_ARG_FLAG_NUM);
 		else if (spec & SPEC_RULE_SMART_BRANCH) {
 			offset = offset * 3;
-			if ((op+1)->opcode == ZEND_JMPZ) {
+			if (op->ex_flags & ZEND_SMART_BRANCH_JMPZ) {
 				offset += 1;
-			} else if ((op+1)->opcode == ZEND_JMPNZ) {
+			} else if (op->ex_flags & ZEND_SMART_BRANCH_JMPNZ) {
 				offset += 2;
 			}
 		}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2978,11 +2978,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CATCH_SPEC_CONST_HANDLER(ZEND_
 	if (EG(exception) == NULL) {
 		ZEND_VM_JMP_EX(OP_JMP_ADDR(opline, opline->op2), 0);
 	}
-	catch_ce = CACHED_PTR(opline->extended_value & ~ZEND_LAST_CATCH);
+	catch_ce = CACHED_PTR(opline->extended_value);
 	if (UNEXPECTED(catch_ce == NULL)) {
 		catch_ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), RT_CONSTANT(opline, opline->op1) + 1, ZEND_FETCH_CLASS_NO_AUTOLOAD);
 
-		CACHE_PTR(opline->extended_value & ~ZEND_LAST_CATCH, catch_ce);
+		CACHE_PTR(opline->extended_value, catch_ce);
 	}
 	ce = EG(exception)->ce;
 
@@ -2994,7 +2994,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CATCH_SPEC_CONST_HANDLER(ZEND_
 
 	if (ce != catch_ce) {
 		if (!catch_ce || !instanceof_function(ce, catch_ce)) {
-			if (opline->extended_value & ZEND_LAST_CATCH) {
+			if (opline->ex_flags & ZEND_LAST_CATCH) {
 				zend_rethrow_exception(execute_data);
 				HANDLE_EXCEPTION();
 			}

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -802,8 +802,7 @@ function gen_code($f, $spec, $kind, $export, $code, $op1, $op2, $name, $extra_sp
 			"/opline->extended_value\s*==\s*0/",
 			"/opline->extended_value\s*==\s*ZEND_ASSIGN_DIM/",
 			"/opline->extended_value\s*==\s*ZEND_ASSIGN_OBJ/",
-			"/opline->extended_value\s*&\s*ZEND_ISEMPTY/",
-			"/opline->extended_value\s*&\s*~\s*ZEND_ISEMPTY/",
+			"/opline->ex_flags\s*&\s*ZEND_ISEMPTY/",
 		),
 		array(
 			$op1_type[$op1],
@@ -872,9 +871,6 @@ function gen_code($f, $spec, $kind, $export, $code, $op1, $op2, $name, $extra_sp
 				: "\\0",
 			isset($extra_spec['ISSET']) ?
 				($extra_spec['ISSET'] == 0 ? "0" : "1")
-				: "\\0",
-			isset($extra_spec['ISSET']) ?
-				($extra_spec['ISSET'] == 0 ? "\\0" : "opline->extended_value")
 				: "\\0",
 		),
 		$code);
@@ -2739,7 +2735,7 @@ function gen_vm($def, $skel) {
 				$else = "else ";
 			}
 			if (isset($used_extra_spec["ISSET"])) {
-				out($f, "\t\t{$else}if (spec & SPEC_RULE_ISSET) offset = offset * 2 + (op->extended_value & ZEND_ISEMPTY);\n");
+				out($f, "\t\t{$else}if (spec & SPEC_RULE_ISSET) offset = offset * 2 + (op->ex_flags & ZEND_ISEMPTY);\n");
 				$else = "else ";
 			}
 			out($f, "\t}\n");
@@ -2827,7 +2823,7 @@ function gen_vm($def, $skel) {
 					$else = "else ";
 				}
 				if (isset($used_extra_spec["ISSET"])) {
-					out($f, "\t\t{$else}if (spec & SPEC_RULE_ISSET) offset = offset * 2 + (op->extended_value & ZEND_ISEMPTY);\n");
+					out($f, "\t\t{$else}if (spec & SPEC_RULE_ISSET) offset = offset * 2 + (op->ex_flags & ZEND_ISEMPTY);\n");
 					$else = "else ";
 				}
 				out($f, "\t}\n");

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -2715,9 +2715,9 @@ function gen_vm($def, $skel) {
 			if (isset($used_extra_spec["SMART_BRANCH"])) {
 				out($f, "\t\t{$else}if (spec & SPEC_RULE_SMART_BRANCH) {\n");
 				out($f,	"\t\t\toffset = offset * 3;\n");
-				out($f, "\t\t\tif ((op+1)->opcode == ZEND_JMPZ) {\n");
+				out($f, "\t\t\tif (op->ex_flags & ZEND_SMART_BRANCH_JMPZ) {\n");
 				out($f,	"\t\t\t\toffset += 1;\n");
-				out($f, "\t\t\t} else if ((op+1)->opcode == ZEND_JMPNZ) {\n");
+				out($f, "\t\t\t} else if (op->ex_flags & ZEND_SMART_BRANCH_JMPNZ) {\n");
 				out($f,	"\t\t\t\toffset += 2;\n");
 				out($f, "\t\t\t}\n");
 				out($f, "\t\t}\n");
@@ -2803,9 +2803,9 @@ function gen_vm($def, $skel) {
 				if (isset($used_extra_spec["SMART_BRANCH"])) {
 					out($f, "\t\t{$else}if (spec & SPEC_RULE_SMART_BRANCH) {\n");
 					out($f,	"\t\t\toffset = offset * 3;\n");
-					out($f, "\t\t\tif ((op+1)->opcode == ZEND_JMPZ) {\n");
+					out($f, "\t\t\tif (op->ex_flags & ZEND_SMART_BRANCH_JMPZ) {\n");
 					out($f,	"\t\t\t\toffset += 1;\n");
-					out($f, "\t\t\t} else if ((op+1)->opcode == ZEND_JMPNZ) {\n");
+					out($f, "\t\t\t} else if (op->ex_flags & ZEND_SMART_BRANCH_JMPNZ) {\n");
 					out($f,	"\t\t\t\toffset += 2;\n");
 					out($f, "\t\t\t}\n");
 					out($f, "\t\t}\n");

--- a/ext/opcache/Optimizer/block_pass.c
+++ b/ext/opcache/Optimizer/block_pass.c
@@ -993,7 +993,7 @@ static void assemble_code_blocks(zend_cfg *cfg, zend_op_array *op_array, zend_op
 				ZEND_SET_OP_JMP_ADDR(opline, opline->op2, new_opcodes + blocks[b->successors[0]].start);
 				break;
 			case ZEND_CATCH:
-				if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+				if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 					ZEND_SET_OP_JMP_ADDR(opline, opline->op2, new_opcodes + blocks[b->successors[0]].start);
 				}
 				break;

--- a/ext/opcache/Optimizer/block_pass.c
+++ b/ext/opcache/Optimizer/block_pass.c
@@ -91,17 +91,7 @@ int zend_optimizer_get_persistent_constant(zend_string *name, zval *result, int 
 static void strip_leading_nops(zend_op_array *op_array, zend_basic_block *b)
 {
 	zend_op *opcodes = op_array->opcodes;
-
 	while (b->len > 0 && opcodes[b->start].opcode == ZEND_NOP) {
-	    /* check if NOP breaks incorrect smart branch */
-		if (b->len == 2
-		 && (op_array->opcodes[b->start + 1].opcode == ZEND_JMPZ
-		  || op_array->opcodes[b->start + 1].opcode == ZEND_JMPNZ)
-		 && (op_array->opcodes[b->start + 1].op1_type & (IS_CV|IS_CONST))
-		 && b->start > 0
-		 && zend_is_smart_branch(op_array->opcodes + b->start - 1)) {
-			break;
-		}
 		b->start++;
 		b->len--;
 	}
@@ -123,14 +113,6 @@ static void strip_nops(zend_op_array *op_array, zend_basic_block *b)
 			if (i != j) {
 				op_array->opcodes[j] = op_array->opcodes[i];
 			}
-			j++;
-		}
-		if (i + 1 < b->start + b->len
-		 && (op_array->opcodes[i+1].opcode == ZEND_JMPZ
-		  || op_array->opcodes[i+1].opcode == ZEND_JMPNZ)
-		 && op_array->opcodes[i+1].op1_type & (IS_CV|IS_CONST)
-		 && zend_is_smart_branch(op_array->opcodes + j - 1)) {
-			/* don't remove NOP, that splits incorrect smart branch */
 			j++;
 		}
 		i++;

--- a/ext/opcache/Optimizer/compact_literals.c
+++ b/ext/opcache/Optimizer/compact_literals.c
@@ -715,11 +715,11 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 					if (opline->op1_type == IS_CONST) {
 						// op1 class
 						if (class_slot[opline->op1.constant] >= 0) {
-							opline->extended_value = class_slot[opline->op1.constant] | (opline->extended_value & ZEND_LAST_CATCH);
+							opline->extended_value = class_slot[opline->op1.constant];
 						} else {
-							opline->extended_value = cache_size | (opline->extended_value & ZEND_LAST_CATCH);
+							opline->extended_value = cache_size;
 							cache_size += sizeof(void *);
-							class_slot[opline->op1.constant] = opline->extended_value & ~ZEND_LAST_CATCH;
+							class_slot[opline->op1.constant] = opline->extended_value;
 						}
 					}
 					break;

--- a/ext/opcache/Optimizer/compact_literals.c
+++ b/ext/opcache/Optimizer/compact_literals.c
@@ -517,6 +517,7 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 				case ZEND_PRE_DEC_OBJ:
 				case ZEND_POST_INC_OBJ:
 				case ZEND_POST_DEC_OBJ:
+				case ZEND_ISSET_ISEMPTY_PROP_OBJ:
 					if (opline->op2_type == IS_CONST) {
 						// op2 property
 						if (opline->op1_type == IS_UNUSED &&
@@ -527,21 +528,6 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 							cache_size += 2 * sizeof(void *);
 							if (opline->op1_type == IS_UNUSED) {
 								property_slot[opline->op2.constant] = opline->extended_value;
-							}
-						}
-					}
-					break;
-				case ZEND_ISSET_ISEMPTY_PROP_OBJ:
-					if (opline->op2_type == IS_CONST) {
-						// op2 property
-						if (opline->op1_type == IS_UNUSED &&
-						    property_slot[opline->op2.constant] >= 0) {
-							opline->extended_value = property_slot[opline->op2.constant] | (opline->extended_value & ZEND_ISEMPTY);
-						} else {
-							opline->extended_value = cache_size | (opline->extended_value & ZEND_ISEMPTY);
-							cache_size += 2 * sizeof(void *);
-							if (opline->op1_type == IS_UNUSED) {
-								property_slot[opline->op2.constant] = opline->extended_value & ~ZEND_ISEMPTY;
 							}
 						}
 					}
@@ -637,6 +623,7 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 				case ZEND_FETCH_STATIC_PROP_UNSET:
 				case ZEND_FETCH_STATIC_PROP_FUNC_ARG:
 				case ZEND_UNSET_STATIC_PROP:
+				case ZEND_ISSET_ISEMPTY_STATIC_PROP:
 					if (opline->op1_type == IS_CONST) {
 						// op1 static property
 						if (opline->op2_type == IS_CONST) {
@@ -657,30 +644,6 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 							opline->extended_value = cache_size;
 							cache_size += sizeof(void *);
 							class_slot[opline->op2.constant] = opline->extended_value;
-						}
-					}
-					break;
-				case ZEND_ISSET_ISEMPTY_STATIC_PROP:
-					if (opline->op1_type == IS_CONST) {
-						// op1 static property
-						if (opline->op2_type == IS_CONST) {
-							opline->extended_value = add_static_slot(&hash, op_array,
-								opline->op2.constant,
-								opline->op1.constant,
-								LITERAL_STATIC_PROPERTY,
-								&cache_size) | (opline->extended_value & ZEND_ISEMPTY);
-						} else {
-							opline->extended_value = cache_size | (opline->extended_value & ZEND_ISEMPTY);
-							cache_size += 2 * sizeof(void *);
-						}
-					} else if (opline->op2_type == IS_CONST) {
-						// op2 class
-						if (class_slot[opline->op2.constant] >= 0) {
-							opline->extended_value = class_slot[opline->op2.constant] | (opline->extended_value & ZEND_ISEMPTY);
-						} else {
-							opline->extended_value = cache_size | (opline->extended_value & ZEND_ISEMPTY);
-							cache_size += sizeof(void *);
-							class_slot[opline->op2.constant] = opline->extended_value & ~ZEND_ISEMPTY;
 						}
 					}
 					break;

--- a/ext/opcache/Optimizer/dfa_pass.c
+++ b/ext/opcache/Optimizer/dfa_pass.c
@@ -173,14 +173,7 @@ static void zend_ssa_remove_nops(zend_op_array *op_array, zend_ssa *ssa, zend_op
 				b->start = target;
 				while (i < end) {
 					shiftlist[i] = i - target;
-					if (EXPECTED(op_array->opcodes[i].opcode != ZEND_NOP) ||
-					   /* Keep NOP to support ZEND_VM_SMART_BRANCH. Using "target-1" instead of
-					    * "i-1" here to check the last non-NOP instruction. */
-					   (target > 0 &&
-					    i + 1 < op_array->last &&
-					    (op_array->opcodes[i+1].opcode == ZEND_JMPZ ||
-					     op_array->opcodes[i+1].opcode == ZEND_JMPNZ) &&
-					    zend_is_smart_branch(op_array->opcodes + target - 1))) {
+					if (EXPECTED(op_array->opcodes[i].opcode != ZEND_NOP)) {
 						if (i != target) {
 							op_array->opcodes[target] = op_array->opcodes[i];
 							ssa->ops[target] = ssa->ops[i];
@@ -500,9 +493,7 @@ static void compress_block(zend_op_array *op_array, zend_basic_block *block)
 {
 	while (block->len > 0) {
 		zend_op *opline = &op_array->opcodes[block->start + block->len - 1];
-
-		if (opline->opcode == ZEND_NOP
-				&& (block->len == 1 || !zend_is_smart_branch(opline - 1))) {
+		if (opline->opcode == ZEND_NOP) {
 			block->len--;
 		} else {
 			break;

--- a/ext/opcache/Optimizer/dfa_pass.c
+++ b/ext/opcache/Optimizer/dfa_pass.c
@@ -553,7 +553,7 @@ static void zend_ssa_replace_control_link(zend_op_array *op_array, zend_ssa *ssa
 				}
 				break;
 			case ZEND_CATCH:
-				if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+				if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 					if (ZEND_OP2_JMP_ADDR(opline) == op_array->opcodes + old->start) {
 						ZEND_SET_OP_JMP_ADDR(opline, opline->op2, op_array->opcodes + dst->start);
 					}

--- a/ext/opcache/Optimizer/sccp.c
+++ b/ext/opcache/Optimizer/sccp.c
@@ -419,7 +419,7 @@ static inline int ct_eval_fetch_dim(zval *result, zval *op1, zval *op2, int supp
 	return FAILURE;
 }
 
-static inline int ct_eval_isset_dim(zval *result, uint32_t extended_value, zval *op1, zval *op2) {
+static inline int ct_eval_isset_dim(zval *result, zend_uchar ex_flags, zval *op1, zval *op2) {
 	if (Z_TYPE_P(op1) == IS_ARRAY || IS_PARTIAL_ARRAY(op1)) {
 		zval *value;
 		if (fetch_array_elem(&value, op1, op2) == FAILURE) {
@@ -428,7 +428,7 @@ static inline int ct_eval_isset_dim(zval *result, uint32_t extended_value, zval 
 		if (IS_PARTIAL_ARRAY(op1) && (!value || IS_BOT(value))) {
 			return FAILURE;
 		}
-		if (!(extended_value & ZEND_ISEMPTY)) {
+		if (!(ex_flags & ZEND_ISEMPTY)) {
 			ZVAL_BOOL(result, value && Z_TYPE_P(value) != IS_NULL);
 		} else {
 			ZVAL_BOOL(result, !value || !zend_is_true(value));
@@ -438,7 +438,7 @@ static inline int ct_eval_isset_dim(zval *result, uint32_t extended_value, zval 
 		// TODO
 		return FAILURE;
 	} else {
-		ZVAL_BOOL(result, (extended_value & ZEND_ISEMPTY));
+		ZVAL_BOOL(result, (ex_flags & ZEND_ISEMPTY));
 		return SUCCESS;
 	}
 }
@@ -576,7 +576,7 @@ static inline int ct_eval_fetch_obj(zval *result, zval *op1, zval *op2) {
 	return FAILURE;
 }
 
-static inline int ct_eval_isset_obj(zval *result, uint32_t extended_value, zval *op1, zval *op2) {
+static inline int ct_eval_isset_obj(zval *result, zend_uchar ex_flags, zval *op1, zval *op2) {
 	if (IS_PARTIAL_OBJECT(op1)) {
 		zval *value;
 		if (fetch_obj_prop(&value, op1, op2) == FAILURE) {
@@ -585,14 +585,14 @@ static inline int ct_eval_isset_obj(zval *result, uint32_t extended_value, zval 
 		if (!value || IS_BOT(value)) {
 			return FAILURE;
 		}
-		if (!(extended_value & ZEND_ISEMPTY)) {
+		if (!(ex_flags & ZEND_ISEMPTY)) {
 			ZVAL_BOOL(result, value && Z_TYPE_P(value) != IS_NULL);
 		} else {
 			ZVAL_BOOL(result, !value || !zend_is_true(value));
 		}
 		return SUCCESS;
 	} else {
-		ZVAL_BOOL(result, (extended_value & ZEND_ISEMPTY));
+		ZVAL_BOOL(result, (ex_flags & ZEND_ISEMPTY));
 		return SUCCESS;
 	}
 }
@@ -650,8 +650,8 @@ static inline int ct_eval_incdec(zval *result, zend_uchar opcode, zval *op1) {
 	return SUCCESS;
 }
 
-static inline int ct_eval_isset_isempty(zval *result, uint32_t extended_value, zval *op1) {
-	if (!(extended_value & ZEND_ISEMPTY)) {
+static inline int ct_eval_isset_isempty(zval *result, zend_uchar ex_flags, zval *op1) {
+	if (!(ex_flags & ZEND_ISEMPTY)) {
 		ZVAL_BOOL(result, Z_TYPE_P(op1) != IS_NULL);
 	} else {
 		ZVAL_BOOL(result, !zend_is_true(op1));
@@ -1587,7 +1587,7 @@ static void sccp_visit_instr(scdf_ctx *scdf, zend_op *opline, zend_ssa_op *ssa_o
 			SKIP_IF_TOP(op1);
 			SKIP_IF_TOP(op2);
 
-			if (ct_eval_isset_dim(&zv, opline->extended_value, op1, op2) == SUCCESS) {
+			if (ct_eval_isset_dim(&zv, opline->ex_flags, op1, op2) == SUCCESS) {
 				SET_RESULT(result, &zv);
 				zval_ptr_dtor_nogc(&zv);
 				break;
@@ -1613,7 +1613,7 @@ static void sccp_visit_instr(scdf_ctx *scdf, zend_op *opline, zend_ssa_op *ssa_o
 				SKIP_IF_TOP(op1);
 				SKIP_IF_TOP(op2);
 
-				if (ct_eval_isset_obj(&zv, opline->extended_value, op1, op2) == SUCCESS) {
+				if (ct_eval_isset_obj(&zv, opline->ex_flags, op1, op2) == SUCCESS) {
 					SET_RESULT(result, &zv);
 					zval_ptr_dtor_nogc(&zv);
 					break;
@@ -1637,7 +1637,7 @@ static void sccp_visit_instr(scdf_ctx *scdf, zend_op *opline, zend_ssa_op *ssa_o
 #endif
 		case ZEND_ISSET_ISEMPTY_CV:
 			SKIP_IF_TOP(op1);
-			if (ct_eval_isset_isempty(&zv, opline->extended_value, op1) == SUCCESS) {
+			if (ct_eval_isset_isempty(&zv, opline->ex_flags, op1) == SUCCESS) {
 				SET_RESULT(result, &zv);
 				zval_ptr_dtor_nogc(&zv);
 				break;

--- a/ext/opcache/Optimizer/zend_cfg.c
+++ b/ext/opcache/Optimizer/zend_cfg.c
@@ -128,15 +128,6 @@ static void zend_mark_reachable_blocks(const zend_op_array *op_array, zend_cfg *
 				b = blocks + block_map[live_range->start];
 				if (b->flags & ZEND_BB_REACHABLE) {
 					while (b->len > 0 && op_array->opcodes[b->start].opcode == ZEND_NOP) {
-					    /* check if NOP breaks incorrect smart branch */
-						if (b->len == 2
-						 && (op_array->opcodes[b->start + 1].opcode == ZEND_JMPZ
-						  || op_array->opcodes[b->start + 1].opcode == ZEND_JMPNZ)
-						 && (op_array->opcodes[b->start + 1].op1_type & (IS_CV|IS_CONST))
-						 && b->start > 0
-						 && zend_is_smart_branch(op_array->opcodes + b->start - 1)) {
-							break;
-						}
 						b->start++;
 						b->len--;
 					}

--- a/ext/opcache/Optimizer/zend_cfg.c
+++ b/ext/opcache/Optimizer/zend_cfg.c
@@ -385,7 +385,7 @@ int zend_build_cfg(zend_arena **arena, const zend_op_array *op_array, uint32_t b
 				BB_START(i + 1);
 				break;
 			case ZEND_CATCH:
-				if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+				if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 					BB_START(OP_JMP_ADDR(opline, opline->op2) - op_array->opcodes);
 				}
 				BB_START(i + 1);
@@ -546,7 +546,7 @@ int zend_build_cfg(zend_arena **arena, const zend_op_array *op_array, uint32_t b
 				block->successors[1] = j + 1;
 				break;
 			case ZEND_CATCH:
-				if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+				if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 					block->successors_count = 2;
 					block->successors[0] = block_map[OP_JMP_ADDR(opline, opline->op2) - op_array->opcodes];
 					block->successors[1] = j + 1;

--- a/ext/opcache/Optimizer/zend_dump.c
+++ b/ext/opcache/Optimizer/zend_dump.c
@@ -670,7 +670,7 @@ static void zend_dump_op(const zend_op_array *op_array, const zend_basic_block *
 	} else {
 		uint32_t op2_flags = ZEND_VM_OP2_FLAGS(flags);
 		if (ZEND_VM_OP_JMP_ADDR == (op2_flags & ZEND_VM_OP_MASK)) {
-			if (opline->opcode != ZEND_CATCH || !(opline->extended_value & ZEND_LAST_CATCH)) {
+			if (opline->opcode != ZEND_CATCH || !(opline->ex_flags & ZEND_LAST_CATCH)) {
 				if (b) {
 					fprintf(stderr, " BB%d", b->successors[n++]);
 				} else {

--- a/ext/opcache/Optimizer/zend_dump.c
+++ b/ext/opcache/Optimizer/zend_dump.c
@@ -568,7 +568,7 @@ static void zend_dump_op(const zend_op_array *op_array, const zend_basic_block *
 			}
 		}
 		if (ZEND_VM_EXT_ISSET & flags) {
-			if (!(opline->extended_value & ZEND_ISEMPTY)) {
+			if (!(opline->ex_flags & ZEND_ISEMPTY)) {
 				fprintf(stderr, " (isset)");
 			} else {
 				fprintf(stderr, " (empty)");

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -1178,6 +1178,9 @@ static void zend_redo_pass_two(zend_op_array *op_array)
 	opline = op_array->opcodes;
 	end = opline + op_array->last;
 	while (opline < end) {
+		if (zend_is_smart_branch(opline)) {
+			zend_set_smart_branch_flags(opline, end);
+		}
 		if (opline->op1_type == IS_CONST) {
 			ZEND_PASS_TWO_UPDATE_CONSTANT(op_array, opline, opline->op1);
 		}
@@ -1255,6 +1258,9 @@ static void zend_redo_pass_two_ex(zend_op_array *op_array, zend_ssa *ssa)
 	opline = op_array->opcodes;
 	end = opline + op_array->last;
 	while (opline < end) {
+		if (zend_is_smart_branch(opline)) {
+			zend_set_smart_branch_flags(opline, end);
+		}
 		zend_vm_set_opcode_handler_ex(opline,
 			opline->op1_type == IS_UNUSED ? 0 : (OP1_INFO() & (MAY_BE_UNDEF|MAY_BE_ANY|MAY_BE_REF|MAY_BE_ARRAY_OF_ANY|MAY_BE_ARRAY_KEY_ANY)),
 			opline->op2_type == IS_UNUSED ? 0 : (OP2_INFO() & (MAY_BE_UNDEF|MAY_BE_ANY|MAY_BE_REF|MAY_BE_ARRAY_OF_ANY|MAY_BE_ARRAY_KEY_ANY)),

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -275,7 +275,7 @@ int zend_optimizer_update_op1_const(zend_op_array *op_array,
 			REQUIRES_STRING(val);
 			drop_leading_backslash(val);
 			opline->op1.constant = zend_optimizer_add_literal(op_array, val);
-			opline->extended_value = alloc_cache_slots(op_array, 1) | (opline->extended_value & ZEND_LAST_CATCH);
+			opline->extended_value = alloc_cache_slots(op_array, 1);
 			zend_optimizer_add_literal_string(op_array, zend_string_tolower(Z_STR_P(val)));
 			break;
 		case ZEND_DEFINED:
@@ -819,7 +819,7 @@ void zend_optimizer_migrate_jump(zend_op_array *op_array, zend_op *new_opline, z
 			new_opline->extended_value = ZEND_OPLINE_NUM_TO_OFFSET(op_array, new_opline, ZEND_OFFSET_TO_OPLINE_NUM(op_array, opline, opline->extended_value));
 			break;
 		case ZEND_CATCH:
-			if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+			if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 				ZEND_SET_OP_JMP_ADDR(new_opline, new_opline->op2, ZEND_OP2_JMP_ADDR(opline));
 			}
 			break;
@@ -859,7 +859,7 @@ void zend_optimizer_shift_jump(zend_op_array *op_array, zend_op *opline, uint32_
 			ZEND_SET_OP_JMP_ADDR(opline, opline->op2, ZEND_OP2_JMP_ADDR(opline) - shiftlist[ZEND_OP2_JMP_ADDR(opline) - op_array->opcodes]);
 			break;
 		case ZEND_CATCH:
-			if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+			if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 				ZEND_SET_OP_JMP_ADDR(opline, opline->op2, ZEND_OP2_JMP_ADDR(opline) - shiftlist[ZEND_OP2_JMP_ADDR(opline) - op_array->opcodes]);
 			}
 			break;
@@ -1227,7 +1227,7 @@ static void zend_redo_pass_two(zend_op_array *op_array)
 					opline->op2.jmp_addr = &op_array->opcodes[opline->op2.jmp_addr - old_opcodes];
 					break;
 				case ZEND_CATCH:
-					if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+					if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 						opline->op2.jmp_addr = &op_array->opcodes[opline->op2.jmp_addr - old_opcodes];
 					}
 					break;
@@ -1313,7 +1313,7 @@ static void zend_redo_pass_two_ex(zend_op_array *op_array, zend_ssa *ssa)
 					opline->op2.jmp_addr = &op_array->opcodes[opline->op2.jmp_addr - old_opcodes];
 					break;
 				case ZEND_CATCH:
-					if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+					if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 						opline->op2.jmp_addr = &op_array->opcodes[opline->op2.jmp_addr - old_opcodes];
 					}
 					break;

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -317,21 +317,13 @@ int zend_optimizer_update_op1_const(zend_op_array *op_array,
 		case ZEND_FETCH_STATIC_PROP_UNSET:
 		case ZEND_FETCH_STATIC_PROP_FUNC_ARG:
 		case ZEND_UNSET_STATIC_PROP:
+		case ZEND_ISSET_ISEMPTY_STATIC_PROP:
 			TO_STRING_NOWARN(val);
 			opline->op1.constant = zend_optimizer_add_literal(op_array, val);
 			if (opline->op2_type == IS_CONST && opline->extended_value + sizeof(void*) == op_array->cache_size) {
 				op_array->cache_size += sizeof(void *);
 			} else {
 				opline->extended_value = alloc_cache_slots(op_array, 2);
-			}
-			break;
-		case ZEND_ISSET_ISEMPTY_STATIC_PROP:
-			TO_STRING_NOWARN(val);
-			opline->op1.constant = zend_optimizer_add_literal(op_array, val);
-			if (opline->op2_type == IS_CONST && (opline->extended_value & ~ZEND_ISEMPTY) + sizeof(void*) == op_array->cache_size) {
-				op_array->cache_size += sizeof(void *);
-			} else {
-				opline->extended_value = alloc_cache_slots(op_array, 2) | (opline->extended_value & ZEND_ISEMPTY);
 			}
 			break;
 		case ZEND_SEND_VAR:
@@ -412,21 +404,13 @@ int zend_optimizer_update_op2_const(zend_op_array *op_array,
 		case ZEND_FETCH_STATIC_PROP_UNSET:
 		case ZEND_FETCH_STATIC_PROP_FUNC_ARG:
 		case ZEND_UNSET_STATIC_PROP:
-			REQUIRES_STRING(val);
-			drop_leading_backslash(val);
-			opline->op2.constant = zend_optimizer_add_literal(op_array, val);
-			zend_optimizer_add_literal_string(op_array, zend_string_tolower(Z_STR_P(val)));
-			if (opline->op1_type != IS_CONST) {
-				opline->extended_value = alloc_cache_slots(op_array, 1);
-			}
-			break;
 		case ZEND_ISSET_ISEMPTY_STATIC_PROP:
 			REQUIRES_STRING(val);
 			drop_leading_backslash(val);
 			opline->op2.constant = zend_optimizer_add_literal(op_array, val);
 			zend_optimizer_add_literal_string(op_array, zend_string_tolower(Z_STR_P(val)));
 			if (opline->op1_type != IS_CONST) {
-				opline->extended_value = alloc_cache_slots(op_array, 1) | (opline->extended_value & ZEND_ISEMPTY);
+				opline->extended_value = alloc_cache_slots(op_array, 1);
 			}
 			break;
 		case ZEND_INIT_FCALL:
@@ -488,14 +472,10 @@ int zend_optimizer_update_op2_const(zend_op_array *op_array,
 		case ZEND_PRE_DEC_OBJ:
 		case ZEND_POST_INC_OBJ:
 		case ZEND_POST_DEC_OBJ:
-			TO_STRING_NOWARN(val);
-			opline->op2.constant = zend_optimizer_add_literal(op_array, val);
-			opline->extended_value = alloc_cache_slots(op_array, 2);
-			break;
 		case ZEND_ISSET_ISEMPTY_PROP_OBJ:
 			TO_STRING_NOWARN(val);
 			opline->op2.constant = zend_optimizer_add_literal(op_array, val);
-			opline->extended_value = alloc_cache_slots(op_array, 2) | (opline->extended_value & ZEND_ISEMPTY);
+			opline->extended_value = alloc_cache_slots(op_array, 2);
 			break;
 		case ZEND_ASSIGN_ADD:
 		case ZEND_ASSIGN_SUB:

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -452,7 +452,7 @@ static void zend_file_cache_serialize_op_array(zend_op_array            *op_arra
 					SERIALIZE_PTR(opline->op2.jmp_addr);
 					break;
 				case ZEND_CATCH:
-					if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+					if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 						SERIALIZE_PTR(opline->op2.jmp_addr);
 					}
 					break;
@@ -1092,7 +1092,7 @@ static void zend_file_cache_unserialize_op_array(zend_op_array           *op_arr
 					UNSERIALIZE_PTR(opline->op2.jmp_addr);
 					break;
 				case ZEND_CATCH:
-					if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+					if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 						UNSERIALIZE_PTR(opline->op2.jmp_addr);
 					}
 					break;

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -475,7 +475,7 @@ static void zend_persist_op_array_ex(zend_op_array *op_array, zend_persistent_sc
 						opline->op2.jmp_addr = &new_opcodes[opline->op2.jmp_addr - op_array->opcodes];
 						break;
 					case ZEND_CATCH:
-						if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+						if (!(opline->ex_flags & ZEND_LAST_CATCH)) {
 							opline->op2.jmp_addr = &new_opcodes[opline->op2.jmp_addr - op_array->opcodes];
 						}
 						break;

--- a/sapi/phpdbg/phpdbg_opcode.c
+++ b/sapi/phpdbg/phpdbg_opcode.c
@@ -111,7 +111,7 @@ char *phpdbg_decode_opline(zend_op_array *ops, zend_op *opline) /*{{{ */
 	/* RESULT */
 	switch (opline->opcode) {
 	case ZEND_CATCH:
-		if (opline->extended_value & ZEND_LAST_CATCH) {
+		if (opline->ex_flags & ZEND_LAST_CATCH) {
 			if (decode[2]) {
 				efree(decode[2]);
 				decode[2] = NULL;

--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -764,16 +764,16 @@ PHPDBG_API zend_bool phpdbg_check_caught_ex(zend_execute_data *execute_data, zen
 			while (1) {
 				zend_class_entry *ce;
 
-				if (!(ce = CACHED_PTR(cur->extended_value & ~ZEND_LAST_CATCH))) {
+				if (!(ce = CACHED_PTR(cur->extended_value))) {
 					ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(cur, cur->op1)), RT_CONSTANT(cur, cur->op1) + 1, ZEND_FETCH_CLASS_NO_AUTOLOAD);
-					CACHE_PTR(cur->extended_value & ~ZEND_LAST_CATCH, ce);
+					CACHE_PTR(cur->extended_value, ce);
 				}
 
 				if (ce == exception->ce || (ce && instanceof_function(exception->ce, ce))) {
 					return 1;
 				}
 
-				if (cur->extended_value & ZEND_LAST_CATCH) {
+				if (cur->ex_flags & ZEND_LAST_CATCH) {
 					return 0;
 				}
 


### PR DESCRIPTION
This packs op1_type and op2_type into one byte using bitfields, to free up space for a new one byte ex_flags field. `ZEND_LAST_CATCH` and `ZEND_ISEMPTY` are moved to use the new flags field.

As we do not usually access the op type at runtime, the additional packing should not be a performance problem. Additionally, if the op type is checked using a bit check, then it doesn't matter anyway.

A previous version of this patch introduced macros like `ZEND_OP1_TYPE()` etc. to get and set the op types with manual bit operations. However, this turned out to be quite ugly, as there are many places in the codebase that use `##_type` macros. That's why I switched to using bitfields here.

Background: The need came up while implementing typed properties support.