### PR TITLE
Enable IPv6 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ env:
       - ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
 
 before_script:
+    # Enable IPv6
+    - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
     # Compile PHP
     - ./travis/compile.sh
     # Setup Extensions 


### PR DESCRIPTION
Currently IPv6 FPM tests are skipped in Travis. This PR should enable IPv6. It should also show if other IPv6 tests work in Travis.