### PR TITLE
Enable HRTime on OpenBSD

### DIFF
--- a/ext/standard/hrtime.h
+++ b/ext/standard/hrtime.h
@@ -28,7 +28,7 @@
 #define PHP_HRTIME_PLATFORM_HPUX    0
 #define PHP_HRTIME_PLATFORM_AIX     0
 
-#if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK) && defined(CLOCK_MONOTONIC)
+#if defined(_POSIX_TIMERS) && ((_POSIX_TIMERS > 0) || defined(__OpenBSD__)) && defined(_POSIX_MONOTONIC_CLOCK) && defined(CLOCK_MONOTONIC)
 # undef  PHP_HRTIME_PLATFORM_POSIX
 # define PHP_HRTIME_PLATFORM_POSIX 1
 #elif defined(_WIN32) || defined(_WIN64)


### PR DESCRIPTION
OpenBSD has clock_gettime() so this will work. They have _POSIX_TIMERS on -1 in
unistd because they don't have per-process timers.