### PR TITLE
Remove revision from OCI8 extension

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@ ext/iconv/php_iconv.h           ident
 ext/ext_skel.php                ident
 ext/phar/phar/pharcommand.inc   ident
 ext/phar/phar.c                 ident
-ext/oci8/oci8.c                 ident
 ext/dba/libinifile/inifile.c    ident
 ext/dba/libflatfile/flatfile.c  ident
 ext/dba/libcdb/cdb_make.c       ident

--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -1207,7 +1207,6 @@ PHP_MINFO_FUNCTION(oci)
 	php_info_print_table_row(2, "OCI8 DTrace Support", "disabled");
 #endif
 	php_info_print_table_row(2, "OCI8 Version", PHP_OCI8_VERSION);
-	php_info_print_table_row(2, "Revision", "$Id$");
 
 #if ((OCI_MAJOR_VERSION > 10) || ((OCI_MAJOR_VERSION == 10) && (OCI_MINOR_VERSION >= 2)))
 	php_oci_client_get_version(ver, sizeof(ver));


### PR DESCRIPTION
The revisions were used in SVN. Other core extensions don't provide this information in the phpinfo output anymore so this patch removes it from the OCI8 info output to make it consistent with other extensions.