### PR TITLE
Remove SVN revision from phar phpinfo output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@ ext/mysqlnd/mysqlnd.h           ident
 ext/iconv/php_iconv.h           ident
 ext/ext_skel.php                ident
 ext/phar/phar/pharcommand.inc   ident
-ext/phar/phar.c                 ident
 ext/dba/libinifile/inifile.c    ident
 ext/dba/libflatfile/flatfile.c  ident
 ext/dba/libcdb/cdb_make.c       ident

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -17,8 +17,6 @@
   +----------------------------------------------------------------------+
 */
 
-/* $Id$ */
-
 #define PHAR_MAIN 1
 #include "phar_internal.h"
 #include "SAPI.h"
@@ -3557,7 +3555,6 @@ PHP_MINFO_FUNCTION(phar) /* {{{ */
 	php_info_print_table_header(2, "Phar: PHP Archive support", "enabled");
 	php_info_print_table_row(2, "Phar EXT version", PHP_PHAR_VERSION);
 	php_info_print_table_row(2, "Phar API version", PHP_PHAR_API_VERSION);
-	php_info_print_table_row(2, "SVN revision", "$Id$");
 	php_info_print_table_row(2, "Phar-based phar archives", "enabled");
 	php_info_print_table_row(2, "Tar-based phar archives", "enabled");
 	php_info_print_table_row(2, "ZIP-based phar archives", "enabled");

--- a/ext/phar/tests/phpinfo_001.phpt
+++ b/ext/phar/tests/phpinfo_001.phpt
@@ -26,7 +26,6 @@ phpinfo(INFO_MODULES);
 Phar: PHP Archive support => enabled
 Phar EXT version => %s
 Phar API version => 1.1.1
-SVN revision => %sId: %s $
 Phar-based phar archives => enabled
 Tar-based phar archives => enabled
 ZIP-based phar archives => enabled
@@ -48,7 +47,6 @@ Phar
 Phar: PHP Archive support => enabled
 Phar EXT version => %s
 Phar API version => 1.1.1
-SVN revision => %sId: %s $
 Phar-based phar archives => enabled
 Tar-based phar archives => enabled
 ZIP-based phar archives => enabled

--- a/ext/phar/tests/phpinfo_002.phpt
+++ b/ext/phar/tests/phpinfo_002.phpt
@@ -24,7 +24,6 @@ Phar
 Phar: PHP Archive support => enabled
 Phar EXT version => %s
 Phar API version => 1.1.1
-SVN revision => %sId: %s $
 Phar-based phar archives => enabled
 Tar-based phar archives => enabled
 ZIP-based phar archives => enabled

--- a/ext/phar/tests/phpinfo_003.phpt
+++ b/ext/phar/tests/phpinfo_003.phpt
@@ -24,7 +24,6 @@ Phar
 Phar: PHP Archive support => enabled
 Phar EXT version => %s
 Phar API version => 1.1.1
-SVN revision => %cId: %s $
 Phar-based phar archives => enabled
 Tar-based phar archives => enabled
 ZIP-based phar archives => enabled

--- a/ext/phar/tests/phpinfo_004.phpt
+++ b/ext/phar/tests/phpinfo_004.phpt
@@ -29,7 +29,6 @@ phpinfo(INFO_MODULES);
 <tr class="h"><th>Phar: PHP Archive support</th><th>enabled</th></tr>
 <tr><td class="e">Phar EXT version </td><td class="v">%s </td></tr>
 <tr><td class="e">Phar API version </td><td class="v">1.1.1 </td></tr>
-<tr><td class="e">SVN revision </td><td class="v">%sId: %s $ </td></tr>
 <tr><td class="e">Phar-based phar archives </td><td class="v">enabled </td></tr>
 <tr><td class="e">Tar-based phar archives </td><td class="v">enabled </td></tr>
 <tr><td class="e">ZIP-based phar archives </td><td class="v">enabled </td></tr>
@@ -53,7 +52,6 @@ Phar based on pear/PHP_Archive, original concept by Davey Shafik.<br />Phar full
 <tr class="h"><th>Phar: PHP Archive support</th><th>enabled</th></tr>
 <tr><td class="e">Phar EXT version </td><td class="v">%s </td></tr>
 <tr><td class="e">Phar API version </td><td class="v">1.1.1 </td></tr>
-<tr><td class="e">SVN revision </td><td class="v">%sId: %s $ </td></tr>
 <tr><td class="e">Phar-based phar archives </td><td class="v">enabled </td></tr>
 <tr><td class="e">Tar-based phar archives </td><td class="v">enabled </td></tr>
 <tr><td class="e">ZIP-based phar archives </td><td class="v">enabled </td></tr>


### PR DESCRIPTION
Hello, the SVN revision was utilized with Subversion. The Git ident attribute applies only for particular file and since other core extensions don't output this information anymore this patch removes it from the phpinfo output to sync and make the phpinfo core extensions more consistent.