### PR TITLE
Remove old SVN keywords substitutions from xsl and sockets tests

### DIFF
--- a/ext/sockets/tests/socket_getpeername_ipv4loop.phpt
+++ b/ext/sockets/tests/socket_getpeername_ipv4loop.phpt
@@ -1,8 +1,8 @@
 --TEST--
 ext/sockets - socket_getpeername_ipv4loop - basic test
 --CREDITS--
+Tatjana Andersen tatjana.andersen@redpill-linpro.com
 # TestFest 2009 - NorwayUG
-# $Id: socket_getpeername_ipv4loop.phpt 494 2009-06-09 20:38:05Z tatjana.andersen@redpill-linpro.com $
 --SKIPIF--
 <?php   
         if (!extension_loaded('sockets')) {

--- a/ext/sockets/tests/socket_getpeername_ipv6loop.phpt
+++ b/ext/sockets/tests/socket_getpeername_ipv6loop.phpt
@@ -1,8 +1,8 @@
 --TEST--
 ext/sockets - socket_getpeername_ipv6loop - basic test
 --CREDITS--
+Tatjana Andersen tatjana.andersen@redpill-linpro.com
 # TestFest 2009 - NorwayUG
-# $Id: socket_getpeername_ipv6loop.phpt 494 2009-06-09 20:38:05Z tatjana.andersen@redpill-linpro.com $
 --SKIPIF--
 <?php   
 if (!extension_loaded('sockets')) {

--- a/ext/xsl/tests/documentxpath.xsl
+++ b/ext/xsl/tests/documentxpath.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- $Id: documentxpath.xsl,v 1.1 2003-10-27 15:12:20 chregu Exp $ -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
     <xsl:output  method="xml" encoding="iso-8859-1" indent="no"/>
 <xsl:template match="/">

--- a/ext/xsl/tests/phpfunc-nostring.xsl
+++ b/ext/xsl/tests/phpfunc-nostring.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- $Id: phpfunc-nostring.xsl,v 1.1.2.2 2009-05-23 14:49:55 felipe Exp $ -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:php="http://php.net/xsl"
 >

--- a/ext/xsl/tests/phpfunc-undef.xsl
+++ b/ext/xsl/tests/phpfunc-undef.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- $Id: phpfunc-undef.xsl,v 1.1.2.2 2009-05-23 14:49:55 felipe Exp $ -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:php="http://php.net/xsl"
 >

--- a/ext/xsl/tests/phpfunc.xsl
+++ b/ext/xsl/tests/phpfunc.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- $Id: phpfunc.xsl,v 1.1.2.2 2009-05-23 14:49:55 felipe Exp $ -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:php="http://php.net/xsl"
 >

--- a/ext/xsl/tests/streamsinclude.xsl
+++ b/ext/xsl/tests/streamsinclude.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- $Id: streamsinclude.xsl,v 1.1 2003-10-27 15:12:20 chregu Exp $ -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
     <xsl:output  method="xml" encoding="iso-8859-1" indent="no"/>
     <xsl:include href="compress.zlib://xslt.xsl.gz"/>

--- a/ext/xsl/tests/xslt.xsl
+++ b/ext/xsl/tests/xslt.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- $Id: xslt.xsl,v 1.2 2003-11-29 13:01:19 chregu Exp $ -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
 
     <xsl:output  method="xml" encoding="iso-8859-1" indent="no"/>

--- a/ext/xsl/tests/xslt012.xsl
+++ b/ext/xsl/tests/xslt012.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- $Id: xslt012.xsl,v 1.1 2004-08-05 13:31:17 tony2001 Exp $ -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
 
     <xsl:output  method="xml" encoding="iso-8859-1" indent="no"/>

--- a/ext/xsl/tests/私はガラスを食べられますstreamsinclude.xsl
+++ b/ext/xsl/tests/私はガラスを食べられますstreamsinclude.xsl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- $Id: streamsinclude.xsl,v 1.1 2003-10-27 15:12:20 chregu Exp $ -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
     <xsl:output  method="xml" encoding="iso-8859-1" indent="no"/>
     <xsl:include href="compress.zlib://xslt.xsl.gz"/>


### PR DESCRIPTION
Hello, following previous pull request on this issue #3286 this patch removes outdated artifacts from the xsl
and sockets extensions tests files. The removed lines aren't part of the contextual tests themselves and were left in some files since the SVN checkouts. Also credits were added for the TestFest 2009 participant.

Thanks.