### PR TITLE
Remove old SVN keywords substitutions from the zip tests

### DIFF
--- a/ext/zip/tests/bug38943_2.phpt
+++ b/ext/zip/tests/bug38943_2.phpt
@@ -2,7 +2,6 @@
 #38943, properties in extended class cannot be set (5.3)
 --SKIPIF--
 <?php
-/* $Id: bug38943_2.phpt 271800 2008-12-24 11:28:25Z pajoye $ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/bug53579.phpt
+++ b/ext/zip/tests/bug53579.phpt
@@ -2,7 +2,6 @@
 Bug #53579 (stream_get_contents() segfaults on ziparchive streams)
 --SKIPIF--
 <?php
-/* $Id: oo_stream.phpt 260091 2008-05-21 09:27:41Z pajoye $ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/stream_meta_data.phpt
+++ b/ext/zip/tests/stream_meta_data.phpt
@@ -2,7 +2,6 @@
 stream_get_meta_data() on zip stream
 --SKIPIF--
 <?php
-/* $Id: oo_stream.phpt 260091 2008-05-21 09:27:41Z pajoye $ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--


### PR DESCRIPTION
Hello, this pull request follows #3286 and #3289 to remove some old SVN info from the code and is done separately since the zip extension might still be distributed in pecl and maintained separately.

Thanks.