### PR TITLE
Implement iterable_to_array()

### DIFF
--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -889,6 +889,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_iterator_apply, 0, 0, 2)
 	ZEND_ARG_ARRAY_INFO(0, args, 1)
 ZEND_END_ARG_INFO();
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_iterable_to_array, 0, 0, 1)
+	ZEND_ARG_INFO(0, iterable)
+	ZEND_ARG_INFO(0, use_keys)
+ZEND_END_ARG_INFO();
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_parents, 0, 0, 1)
 	ZEND_ARG_INFO(0, instance)
 	ZEND_ARG_INFO(0, autoload)
@@ -962,6 +967,7 @@ static const zend_function_entry spl_functions[] = {
 	PHP_FE(iterator_to_array,       arginfo_iterator_to_array)
 	PHP_FE(iterator_count,          arginfo_iterator)
 	PHP_FE(iterator_apply,          arginfo_iterator_apply)
+	PHP_FE(iterable_to_array,       arginfo_iterable_to_array)
 #endif /* SPL_ITERATORS_H */
 	PHP_FE_END
 };

--- a/ext/spl/spl_iterators.h
+++ b/ext/spl/spl_iterators.h
@@ -60,6 +60,7 @@ PHP_MINIT_FUNCTION(spl_iterators);
 PHP_FUNCTION(iterator_to_array);
 PHP_FUNCTION(iterator_count);
 PHP_FUNCTION(iterator_apply);
+PHP_FUNCTION(iterable_to_array);
 
 typedef enum {
 	DIT_Default = 0,

--- a/ext/spl/tests/iterable_to_array.phpt
+++ b/ext/spl/tests/iterable_to_array.phpt
@@ -1,0 +1,83 @@
+--TEST--
+SPL: iterable_to_array() test
+--FILE--
+<?php
+
+$array = ['a' => 1, 'b' => 2, 'c' => 3];
+$iterator = new ArrayIterator($array);
+$generator = function () { yield 'a' => 1; yield 'a' => 2; yield 'a' => 3; };
+
+iterable_to_array();
+iterable_to_array([], 1, 2);
+
+var_dump(iterable_to_array([]));
+var_dump(iterable_to_array($array));
+var_dump(iterable_to_array($iterator));
+var_dump(iterable_to_array($generator()));
+
+var_dump(iterable_to_array([], false));
+var_dump(iterable_to_array($array, false));
+var_dump(iterable_to_array($iterator, false));
+var_dump(iterable_to_array($generator(), false));
+
+iterable_to_array(new stdClass);
+
+?>
+--EXPECTF--
+Warning: iterable_to_array() expects at least 1 parameter, 0 given in %s
+
+Warning: iterable_to_array() expects at most 2 parameters, 3 given in %s
+array(0) {
+}
+array(3) {
+  ["a"]=>
+  int(1)
+  ["b"]=>
+  int(2)
+  ["c"]=>
+  int(3)
+}
+array(3) {
+  ["a"]=>
+  int(1)
+  ["b"]=>
+  int(2)
+  ["c"]=>
+  int(3)
+}
+array(1) {
+  ["a"]=>
+  int(3)
+}
+array(0) {
+}
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
+
+Fatal error: Uncaught TypeError: Argument 1 passed to iterable_to_array() must be iterable, object given in %s:%d
+Stack trace:
+#0 %s(%d): iterable_to_array(Object(stdClass))
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
`iterable` type is gaining popularity, unfortunately it is sometimes hard to work with. Especially when the output is needed to be converted into an array, as array_*() functions don't accept iterable, only plain array.

The proposal is simple: add `iterable_to_array($iterable)` sibling function to `iterator_to_array($iterator)` which will work with `iterable` (array or Traversable).

Before:
```diff
- is_array($iterable) ? $iterable : iterator_to_array($iterable)
```
After:
```diff
+ iterable_to_array($iterable)
```

This would be really convenient together with `iterable` typehint. :blush: 

---

Implemented:
* [x] `iterable_to_array()`
* [ ] `iterable_count()`