### PR TITLE
Bump fileinfo extension version to PHP release version

### DIFF
--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -278,7 +278,6 @@ PHP_MINFO_FUNCTION(fileinfo)
 
 	php_info_print_table_start();
 	php_info_print_table_row(2, "fileinfo support", "enabled");
-	php_info_print_table_row(2, "version", PHP_FILEINFO_VERSION);
 	php_info_print_table_row(2, "libmagic", magic_ver);
 	php_info_print_table_end();
 }

--- a/ext/fileinfo/php_fileinfo.h
+++ b/ext/fileinfo/php_fileinfo.h
@@ -24,7 +24,7 @@
 extern zend_module_entry fileinfo_module_entry;
 #define phpext_fileinfo_ptr &fileinfo_module_entry
 
-#define PHP_FILEINFO_VERSION "1.0.5"
+#define PHP_FILEINFO_VERSION PHP_VERSION
 
 #ifdef PHP_WIN32
 #define PHP_FILEINFO_API __declspec(dllexport)


### PR DESCRIPTION
Hello, this is a minor suggestion and a patch since the [PECL fileinfo](https://pecl.php.net/package/fileinfo) extension has been archived in favor of the core extension. To sync and simplify the core extensions and their versioning more, the fileinfo extension can be versioned in same way as PHP releases.

The phpinfo output before this patch was something like this:
![fileinfo](https://user-images.githubusercontent.com/1614009/41389876-697690f2-6f93-11e8-8038-3e94bf13d070.png)

The new phpinfo:
![fileinfo_2](https://user-images.githubusercontent.com/1614009/41389905-90796e2c-6f93-11e8-8623-ba903fd68a1a.png)
