### PR TITLE
Strict comparison for switch cases

### DIFF
--- a/Zend/tests/switch-strict.phpt
+++ b/Zend/tests/switch-strict.phpt
@@ -26,6 +26,16 @@ switch ($a) {
   default:
     echo "Default\n";
 }
+
+switch ($a) {
+  case === 123:
+    echo "Should match\n";
+    break;
+  default:
+    echo "Default\n";
+}
+
 --EXPECT--
+Should match
 Should match
 Should match

--- a/Zend/tests/switch-strict.phpt
+++ b/Zend/tests/switch-strict.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Strict switch cases
+--FILE--
+<?php
+
+$a = 123;
+
+switch ($a) {
+  case === '123':
+    echo "Should not match\n";
+    break;
+  case == '123':
+    echo "Should match\n";
+    break;
+  default:
+    echo "Default\n";
+}
+
+switch ($a) {
+  case === 123.0:
+    echo "Should not match\n";
+    break;
+  case 123.0:
+    echo "Should match\n";
+    break;
+  default:
+    echo "Default\n";
+}
+--EXPECT--
+Should match
+Should match

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -579,6 +579,14 @@ case_list:
 		/* empty */ { $$ = zend_ast_create_list(0, ZEND_AST_SWITCH_LIST); }
 	|	case_list T_CASE expr case_separator inner_statement_list
 			{ $$ = zend_ast_list_add($1, zend_ast_create(ZEND_AST_SWITCH_CASE, $3, $5)); }
+	|	case_list T_CASE T_IS_EQUAL expr case_separator inner_statement_list
+			{ zend_ast *case_ast = zend_ast_create(ZEND_AST_SWITCH_CASE, $4, $6);
+		      case_ast->attr = ZEND_IS_EQUAL;
+			  $$ = zend_ast_list_add($1, case_ast); }
+	|	case_list T_CASE T_IS_IDENTICAL expr case_separator inner_statement_list
+			{ zend_ast *case_ast = zend_ast_create(ZEND_AST_SWITCH_CASE, $4, $6);
+		      case_ast->attr = ZEND_IS_IDENTICAL;
+			  $$ = zend_ast_list_add($1, case_ast); }
 	|	case_list T_DEFAULT case_separator inner_statement_list
 			{ $$ = zend_ast_list_add($1, zend_ast_create(ZEND_AST_SWITCH_CASE, NULL, $4)); }
 ;


### PR DESCRIPTION
For discussion...

```php
switch ($a) {
  case FOO:
      // Works exactly as current behavior.
      break;
  case == FOO:
     // Nearly identical, though we don't use the ZEND_CASE optimization.
     // Can probably make this equivalent to `case FOO`, but it felt like an interesting direction.
     break;
  case === FOO:
     // Only triggers if `$a === FOO`, no type juggling
     break;
}
```

Jump table optimizations should be unimpacted since I believe they are already strict, but I haven't confirmed this yet.