### PR TITLE
Bump json extension version to match PHP release version

### DIFF
--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -186,7 +186,6 @@ static PHP_MINFO_FUNCTION(json)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "json support", "enabled");
-	php_info_print_table_row(2, "json version", PHP_JSON_VERSION);
 	php_info_print_table_end();
 }
 /* }}} */

--- a/ext/json/php_json.h
+++ b/ext/json/php_json.h
@@ -20,7 +20,8 @@
 #ifndef PHP_JSON_H
 #define PHP_JSON_H
 
-#define PHP_JSON_VERSION "1.6.0"
+#include "php_version.h"
+#define PHP_JSON_VERSION PHP_VERSION
 #include "zend_smart_str_public.h"
 
 extern zend_module_entry json_module_entry;


### PR DESCRIPTION
Hello, the core extensions versioning are in most cases the same as PHP release cycle and versions (there most likely won't happen that some core extension will be released prior to PHP release and user would need to update it like that). To sync and simplify the versioning of the json extension this patch bumps the version of json extension to match the PHP version. The [PECL json](https://pecl.php.net/package/json) extension has been marked as being superseded in favor of the core maintained extension already.

Also from the user point of view this change makes it easier to understand that json is a core extension, not intended to be build separately for different PHP versions and installations, unlike PECL 3rd party extensions.

Before:
![json_1](https://user-images.githubusercontent.com/1614009/41399915-e0ea82d8-6fbb-11e8-8bf0-57af6bd2fcd9.png)

After:
![json_2](https://user-images.githubusercontent.com/1614009/41399922-e5e30e7c-6fbb-11e8-8b95-92a4710a94bb.png)

Pinging also @bukka as noted in the extension readme if the change is agreed and good for all.

Thank you.