### PR TITLE
Bump extension & module API numbers for 7.3

### DIFF
--- a/Zend/zend_extensions.h
+++ b/Zend/zend_extensions.h
@@ -46,7 +46,7 @@ You can use the following macro to check the extension API version for compatibi
 
 /* The first number is the engine version and the rest is the date (YYYYMMDD).
  * This way engine 2/3 API no. is always greater than engine 1 API no..  */
-#define ZEND_EXTENSION_API_NO	320170718
+#define ZEND_EXTENSION_API_NO	320180606
 
 typedef struct _zend_extension_version_info {
 	int zend_extension_api_no;

--- a/Zend/zend_modules.h
+++ b/Zend/zend_modules.h
@@ -33,7 +33,7 @@
 #define ZEND_MODULE_INFO_FUNC_ARGS zend_module_entry *zend_module
 #define ZEND_MODULE_INFO_FUNC_ARGS_PASSTHRU zend_module
 
-#define ZEND_MODULE_API_NO 20170718
+#define ZEND_MODULE_API_NO 20180606
 #ifdef ZTS
 #define USING_ZTS 1
 #else

--- a/main/php.h
+++ b/main/php.h
@@ -26,7 +26,7 @@
 #include <dmalloc.h>
 #endif
 
-#define PHP_API_VERSION 20180123
+#define PHP_API_VERSION 20180606
 #define PHP_HAVE_STREAMS
 #define YYDEBUG 0
 #define PHP_DEFAULT_CHARSET "UTF-8"


### PR DESCRIPTION
Same story as #2574.

PHP 7.3.0alpha1 currently overrides modules for PHP 7.2 during `make install`, breaking its shared libraries.

The date is bumped to the day when alpha 1 was tagged - let me know if there is another way / rule to follow.