### PR TITLE
Deprecate == and != operators

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug #76427 (Segfault in zend_objects_store_put). (Laruence)
   . Fixed bug #76422 (ftruncate fails on files > 2GB). (Anatol)
+  . The == and != operators have been deprecated.
 
 - Date:
   . Fixed bug #76462 (Undefined property: DateInterval::$f). (Anatol)

--- a/UPGRADING
+++ b/UPGRADING
@@ -135,6 +135,9 @@ readline:
 4. Deprecated Functionality
 ========================================
 
+Core:
+  . The == and != operators have been deprecated.
+
 GD:
   . image2wbmp() has been deprecated.
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7021,6 +7021,13 @@ void zend_compile_binary_op(znode *result, zend_ast *ast) /* {{{ */
 	uint32_t opcode = ast->attr;
 
 	znode left_node, right_node;
+
+	if (opcode == ZEND_IS_EQUAL) {
+		zend_error(E_DEPRECATED, "The == operator is deprecated");
+	} else if (opcode == ZEND_IS_NOT_EQUAL) {
+		zend_error(E_DEPRECATED, "The != operator is deprecated");
+	}
+
 	zend_compile_expr(&left_node, left_ast);
 	zend_compile_expr(&right_node, right_ast);
 


### PR DESCRIPTION
Can't find the related RFC.

Is that another joke like Doctrine 4? Still has no idea why doctrine guys want that 'thing' that much...