### PR TITLE
Bump intl extension version to PHP release version

### DIFF
--- a/ext/intl/php_intl.c
+++ b/ext/intl/php_intl.c
@@ -103,7 +103,6 @@
 #include <ext/standard/info.h>
 
 #include "php_ini.h"
-#define INTL_MODULE_VERSION PHP_INTL_VERSION
 
 /*
  * locale_get_default has a conflict since ICU also has
@@ -879,7 +878,7 @@ zend_module_entry intl_module_entry = {
 	PHP_RINIT( intl ),
 	PHP_RSHUTDOWN( intl ),
 	PHP_MINFO( intl ),
-	INTL_MODULE_VERSION,
+	PHP_INTL_VERSION,
 	PHP_MODULE_GLOBALS(intl),   /* globals descriptor */
 	PHP_GINIT(intl),            /* globals ctor */
 	NULL,                       /* globals dtor */
@@ -1061,7 +1060,6 @@ PHP_MINFO_FUNCTION( intl )
 
 	php_info_print_table_start();
 	php_info_print_table_header( 2, "Internationalization support", "enabled" );
-	php_info_print_table_row( 2, "version", INTL_MODULE_VERSION );
 	php_info_print_table_row( 2, "ICU version", U_ICU_VERSION );
 #ifdef U_ICU_DATA_VERSION
 	php_info_print_table_row( 2, "ICU Data version", U_ICU_DATA_VERSION );

--- a/ext/intl/php_intl.h
+++ b/ext/intl/php_intl.h
@@ -71,7 +71,7 @@ PHP_MINFO_FUNCTION(intl);
 
 const char *intl_locale_get_default( void );
 
-#define PHP_INTL_VERSION "1.1.0"
+#define PHP_INTL_VERSION PHP_VERSION
 
 #endif  /* PHP_INTL_H */
 


### PR DESCRIPTION
Hello, this patch syncs and simplifies intl core extension versioning to match it with the PHP release version.

The [PECL Intl extension](https://pecl.php.net/package/intl) has been archived in favor of the core PHP intl extension so this repo seems to be the main location of the source code for this extension.

Before the patch:
![intl_1](https://user-images.githubusercontent.com/1614009/41440361-82a96504-702e-11e8-907d-599b2a1a17ed.png)

After the patch:
![intl_2](https://user-images.githubusercontent.com/1614009/41440379-90814278-702e-11e8-88c0-36f992bba7ce.png)

## Why is this important?

* Easier and synced versioning of the intl extension and the PHP releases (I think that current version 1.1.0 hasn't been bumped for a while but some changes were made to it)
* Consistency of the PHP software as a whole. As a quick example: Linux packages can split the core extensions into several subpackages). Now, these core extensions are versioned same as the main PHP package anyway in a lot of cases. For example, [Ubuntu php7.2-intl](https://packages.ubuntu.com/bionic/php7.2-intl) vs a [Redis extension](https://packages.ubuntu.com/bionic/php-redis) as an example of a PECL extension versioned on its own and also being able to compile same source code for different PHP versions.

| Extension                | Version |
| -------------------------- | ----------- |
| intl                            | 1.1.0     |
| fileinfo                      |  1.0.5   |
| hash                        | 1.0         |
| json                         | 1.7.0       |
| mysqlnd      | mysqlnd 5.0.12-dev - 20150407 - $Id: xxx $ |
| oci8         | 2.1.8   |
| phar         | 2.0.2   |
| snmp         | 0.1     |
| zip          | 1.15.3  |
| all other 63 core extensions | PHP release version |

Thanks for checking this out...