### PR TITLE
Bump snmp extension version to PHP version

### DIFF
--- a/ext/snmp/php_snmp.h
+++ b/ext/snmp/php_snmp.h
@@ -26,7 +26,7 @@
 #ifndef PHP_SNMP_H
 #define PHP_SNMP_H
 
-#define PHP_SNMP_VERSION "0.1"
+#define PHP_SNMP_VERSION PHP_VERSION
 
 #if HAVE_SNMP
 

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -2360,7 +2360,6 @@ PHP_MINFO_FUNCTION(snmp)
 	php_info_print_table_start();
 	php_info_print_table_row(2, "NET-SNMP Support", "enabled");
 	php_info_print_table_row(2, "NET-SNMP Version", netsnmp_get_version());
-	php_info_print_table_row(2, "PHP SNMP Version", PHP_SNMP_VERSION);
 	php_info_print_table_end();
 }
 /* }}} */


### PR DESCRIPTION
Hello, this patch syncs the snmp extension version to match it with the PHP release version. This is done to sync possible remaining PHP core extensions with the version of the PHP release.

Before the patch:
![snmp_1](https://user-images.githubusercontent.com/1614009/41464837-fe2c10c4-709b-11e8-84d9-b16b257537ed.png)

After:
![snmp_2](https://user-images.githubusercontent.com/1614009/41464844-02143e00-709c-11e8-9afa-fc38d9524356.png)