### PR TITLE
[RFC]: Argon2 Password Hash Enhancements

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -144,6 +144,15 @@ readline:
     options has been added to readline_info(). These options are only available
     if PHP is linked against libreadline (rather than libedit).
 
+Standard:
+  . The -–with-password-argon2[=dir] configure argument now provides support for 
+    both Argon2i and Argon2id hashes in the password_hash(), password_verify(), 
+    password_get_info(), and password_needs_rehash() functions. Passwords may be
+    hashed and verified using the PASSWORD_ARGON2ID constant.
+    Support for both Argon2i and Argon2id in the password_* functions now requires
+    PHP be linked against libargon2 reference library >= 20161029.
+    (RFC: https://wiki.php.net/rfc/argon2_password_hash_enhancements). 
+
 ========================================
 3. Changes in SAPI modules
 ========================================
@@ -304,6 +313,9 @@ PGSQL:
 	- PGSQL_DIAG_CONSTRAINT_NAME
   . Requires Postgres 9.6
     - PGSQL_DIAG_SEVERITY_NONLOCALIZED
+
+Standard:
+  . PASSWORD_ARGON2ID
 
 ========================================
 11. Changes to INI File Handling

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -434,18 +434,11 @@ if test "$PHP_PASSWORD_ARGON2" != "no"; then
   PHP_ADD_LIBRARY_WITH_PATH(argon2, $ARGON2_DIR/$PHP_LIBDIR)
   PHP_ADD_INCLUDE($ARGON2_DIR/include)
 
-  AC_CHECK_LIB(argon2, argon2_hash, [
+  AC_CHECK_LIB(argon2, argon2id_hash_raw, [
     LIBS="$LIBS -largon2"
     AC_DEFINE(HAVE_ARGON2LIB, 1, [ Define to 1 if you have the <argon2.h> header file ])
   ], [
-    AC_MSG_ERROR([Problem with libargon2.(a|so). Please verify that Argon2 header and libaries are installed])
-  ])
-
-  AC_CHECK_LIB(argon2, argon2id_hash_raw, [
-    LIBS="$LIBS -largon2"
-    AC_DEFINE(HAVE_ARGON2ID, 1, [ Define to 1 if Argon2 library has support for Argon2ID])
-  ], [
-    AC_MSG_RESULT([not found])
+    AC_MSG_ERROR([Problem with libargon2.(a|so). Please verify that Argon2 header and libaries >= 20161029 are installed])
   ])
 fi
 

--- a/ext/standard/config.w32
+++ b/ext/standard/config.w32
@@ -6,10 +6,10 @@ ARG_WITH("password-argon2", "Argon2 support", "no");
 if (PHP_PASSWORD_ARGON2 != "no") {
 	if (CHECK_LIB("argon2_a.lib;argon2.lib", null, PHP_PASSWORD_ARGON2)
 	&& CHECK_HEADER_ADD_INCLUDE("argon2.h", "CFLAGS")) {
-		AC_DEFINE('HAVE_ARGON2LIB', 1);
-		if (CHECK_FUNC_IN_HEADER("argon2.h", "argon2id_hash_raw", PHP_PHP_BUILD + "\\include", "CFLAGS")) {
-			AC_DEFINE('HAVE_ARGON2ID', 1);
+		if (!CHECK_FUNC_IN_HEADER("argon2.h", "argon2id_hash_raw", PHP_PHP_BUILD + "\\include", "CFLAGS")) {
+			ERROR("Please verify that Argon2 header and libaries >= 20161029 are installed");
 		}
+		AC_DEFINE('HAVE_ARGON2LIB', 1);
 	} else {
 		WARNING("Argon2 not enabled; libaries and headers not found");
 	}

--- a/ext/standard/php_password.h
+++ b/ext/standard/php_password.h
@@ -43,6 +43,7 @@ typedef enum {
     PHP_PASSWORD_BCRYPT,
 #if HAVE_ARGON2LIB
     PHP_PASSWORD_ARGON2I,
+    PHP_PASSWORD_ARGON2ID,
 #endif
 } php_password_algo;
 

--- a/ext/standard/tests/password/password_get_info_argon2.phpt
+++ b/ext/standard/tests/password/password_get_info_argon2.phpt
@@ -1,13 +1,15 @@
 --TEST--
-Test normal operation of password_get_info() with Argon2
+Test normal operation of password_get_info() with Argon2i and Argon2id
 --SKIPIF--
 <?php
 if (!defined('PASSWORD_ARGON2I')) die('skip password_get_info not built with Argon2');
+if (!defined('PASSWORD_ARGON2ID')) die('skip password_get_info not built with Argon2');
 ?>
 --FILE--
 <?php
 
 var_dump(password_get_info('$argon2i$v=19$m=65536,t=3,p=1$SWhIcG5MT21Pc01PbWdVZw$WagZELICsz7jlqOR2YzoEVTWb2oOX1tYdnhZYXxptbU'));
+var_dump(password_get_info('$argon2id$v=19$m=1024,t=2,p=2$Zng1U1RHS0h1aUJjbGhPdA$ajQnG5s01Ws1ad8xv+1qGfXF8mYxxWdyul5rBpomuZQ'));
 echo "OK!";
 ?>
 --EXPECT--
@@ -24,6 +26,21 @@ array(3) {
     int(3)
     ["threads"]=>
     int(1)
+  }
+}
+array(3) {
+  ["algo"]=>
+  int(3)
+  ["algoName"]=>
+  string(8) "argon2id"
+  ["options"]=>
+  array(3) {
+    ["memory_cost"]=>
+    int(1024)
+    ["time_cost"]=>
+    int(2)
+    ["threads"]=>
+    int(2)
   }
 }
 OK!

--- a/ext/standard/tests/password/password_hash_argon2.phpt
+++ b/ext/standard/tests/password/password_hash_argon2.phpt
@@ -1,8 +1,9 @@
 --TEST--
-Test normal operation of password_hash() with argon2
+Test normal operation of password_hash() with Argon2i and Argon2id
 --SKIPIF--
 <?php
 if (!defined('PASSWORD_ARGON2I')) die('skip password_hash not built with Argon2');
+if (!defined('PASSWORD_ARGON2ID')) die('skip password_hash not built with Argon2');
 --FILE--
 <?php
 
@@ -11,8 +12,12 @@ $password = "the password for testing 12345!";
 $hash = password_hash($password, PASSWORD_ARGON2I);
 var_dump(password_verify($password, $hash));
 
+$hash = password_hash($password, PASSWORD_ARGON2ID);
+var_dump(password_verify($password, $hash));
+
 echo "OK!";
 ?>
 --EXPECT--
+bool(true)
 bool(true)
 OK!

--- a/ext/standard/tests/password/password_hash_error_argon2.phpt
+++ b/ext/standard/tests/password/password_hash_error_argon2.phpt
@@ -1,16 +1,29 @@
 --TEST--
-Test error operation of password_hash() with argon2
+Test error operation of password_hash() with Argon2i and Argon2id
 --SKIPIF--
 <?php
 if (!defined('PASSWORD_ARGON2I')) die('skip password_hash not built with Argon2');
+if (!defined('PASSWORD_ARGON2ID')) die('skip password_hash not built with Argon2');
 ?>
 --FILE--
 <?php
 var_dump(password_hash('test', PASSWORD_ARGON2I, ['memory_cost' => 0]));
 var_dump(password_hash('test', PASSWORD_ARGON2I, ['time_cost' => 0]));
 var_dump(password_hash('test', PASSWORD_ARGON2I, ['threads' => 0]));
+var_dump(password_hash('test', PASSWORD_ARGON2ID, ['memory_cost' => 0]));
+var_dump(password_hash('test', PASSWORD_ARGON2ID, ['time_cost' => 0]));
+var_dump(password_hash('test', PASSWORD_ARGON2ID, ['threads' => 0]));
 ?>
 --EXPECTF--
+Warning: password_hash(): Memory cost is outside of allowed memory range in %s on line %d
+NULL
+
+Warning: password_hash(): Time cost is outside of allowed time range in %s on line %d
+NULL
+
+Warning: password_hash(): Invalid number of threads in %s on line %d
+NULL
+
 Warning: password_hash(): Memory cost is outside of allowed memory range in %s on line %d
 NULL
 

--- a/ext/standard/tests/password/password_needs_rehash_argon2.phpt
+++ b/ext/standard/tests/password/password_needs_rehash_argon2.phpt
@@ -1,8 +1,9 @@
 --TEST--
-Test normal operation of password_needs_rehash() with argon2
+Test normal operation of password_needs_rehash() with Argon2i and Argon2id
 --SKIPIF--
 <?php
 if (!defined('PASSWORD_ARGON2I')) die('skip password_needs_rehash not built with Argon2');
+if (!defined('PASSWORD_ARGON2ID')) die('skip password_hash not built with Argon2');
 ?>
 --FILE--
 <?php
@@ -12,9 +13,19 @@ var_dump(password_needs_rehash($hash, PASSWORD_ARGON2I));
 var_dump(password_needs_rehash($hash, PASSWORD_ARGON2I, ['memory_cost' => 1<<17]));
 var_dump(password_needs_rehash($hash, PASSWORD_ARGON2I, ['time_cost' => 4]));
 var_dump(password_needs_rehash($hash, PASSWORD_ARGON2I, ['threads' => 4]));
+
+$hash = password_hash('test', PASSWORD_ARGON2ID);
+var_dump(password_needs_rehash($hash, PASSWORD_ARGON2ID));
+var_dump(password_needs_rehash($hash, PASSWORD_ARGON2ID, ['memory_cost' => 1<<17]));
+var_dump(password_needs_rehash($hash, PASSWORD_ARGON2ID, ['time_cost' => 4]));
+var_dump(password_needs_rehash($hash, PASSWORD_ARGON2ID, ['threads' => 4]));
 echo "OK!";
 ?>
 --EXPECT--
+bool(false)
+bool(true)
+bool(true)
+bool(true)
 bool(false)
 bool(true)
 bool(true)

--- a/ext/standard/tests/password/password_verify_argon2.phpt
+++ b/ext/standard/tests/password/password_verify_argon2.phpt
@@ -1,8 +1,9 @@
 --TEST--
-Test normal operation of password_verify() with argon2
+Test normal operation of password_verify() with Argon2i and Argon2id
 --SKIPIF--
 <?php
 if (!defined('PASSWORD_ARGON2I')) die('skip password_verify not built with Argon2');
+if (!defined('PASSWORD_ARGON2ID')) die('skip password_hash not built with Argon2');
 ?>
 --FILE--
 <?php
@@ -10,9 +11,14 @@ if (!defined('PASSWORD_ARGON2I')) die('skip password_verify not built with Argon
 var_dump(password_verify('test', '$argon2i$v=19$m=65536,t=3,p=1$OEVjWWs2Z3YvWlNZQ0ZmNw$JKin7ahjmh8JYvMyFcXri0Ss/Uvd3uYpD7MG6C/5Cy0'));
 
 var_dump(password_verify('argon2', '$argon2i$v=19$m=65536,t=3,p=1$OEVjWWs2Z3YvWlNZQ0ZmNw$JKin7ahjmh8JYvMyFcXri0Ss/Uvd3uYpD7MG6C/5Cy0'));
+
+var_dump(password_verify('test', '$argon2id$v=19$m=1024,t=2,p=2$WS90MHJhd3AwSC5xTDJpZg$8tn2DaIJR2/UX4Cjcy2t3EZaLDL/qh+NbLQAOvTmdAg'));
+var_dump(password_verify('argon2id', '$argon2id$v=19$m=1024,t=2,p=2$WS90MHJhd3AwSC5xTDJpZg$8tn2DaIJR2/UX4Cjcy2t3EZaLDL/qh+NbLQAOvTmdAg'));
 echo "OK!";
 ?>
 --EXPECT--
+bool(true)
+bool(false)
 bool(true)
 bool(false)
 OK!


### PR DESCRIPTION
Implementation of Argon2id per RFC https://wiki.php.net/rfc/argon2_password_hash_enhancements

- m4 and Windows configure scripts now forces Argon2 reference library version >= 20161029
- Implementation tested against 20161029 and 20171227 for Argon2id support
- Updates Argon2 ext/standard/password/tests to run tests for both Argon2i and Argon2id