### PR TITLE
Bump phar and hash extension version to match PHP version

### DIFF
--- a/ext/hash/php_hash.h
+++ b/ext/hash/php_hash.h
@@ -24,8 +24,8 @@
 #include "php.h"
 
 #define PHP_HASH_EXTNAME	"hash"
-#define PHP_HASH_VERSION	"1.0"
-#define PHP_MHASH_VERSION	"1.0"
+#define PHP_HASH_VERSION	PHP_VERSION
+#define PHP_MHASH_VERSION	PHP_VERSION
 
 #define PHP_HASH_HMAC		0x0001
 

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -3553,7 +3553,6 @@ PHP_MINFO_FUNCTION(phar) /* {{{ */
 	phar_request_initialize();
 	php_info_print_table_start();
 	php_info_print_table_header(2, "Phar: PHP Archive support", "enabled");
-	php_info_print_table_row(2, "Phar EXT version", PHP_PHAR_VERSION);
 	php_info_print_table_row(2, "Phar API version", PHP_PHAR_API_VERSION);
 	php_info_print_table_row(2, "Phar-based phar archives", "enabled");
 	php_info_print_table_row(2, "Tar-based phar archives", "enabled");

--- a/ext/phar/php_phar.h
+++ b/ext/phar/php_phar.h
@@ -22,7 +22,7 @@
 #ifndef PHP_PHAR_H
 #define PHP_PHAR_H
 
-#define PHP_PHAR_VERSION "2.0.2"
+#define PHP_PHAR_VERSION PHP_VERSION
 
 #include "ext/standard/basic_functions.h"
 extern zend_module_entry phar_module_entry;

--- a/ext/phar/tests/phpinfo_001.phpt
+++ b/ext/phar/tests/phpinfo_001.phpt
@@ -24,7 +24,6 @@ phpinfo(INFO_MODULES);
 %aPhar
 
 Phar: PHP Archive support => enabled
-Phar EXT version => %s
 Phar API version => 1.1.1
 Phar-based phar archives => enabled
 Tar-based phar archives => enabled
@@ -45,7 +44,6 @@ phar.require_hash => Off => Off
 Phar
 
 Phar: PHP Archive support => enabled
-Phar EXT version => %s
 Phar API version => 1.1.1
 Phar-based phar archives => enabled
 Tar-based phar archives => enabled

--- a/ext/phar/tests/phpinfo_002.phpt
+++ b/ext/phar/tests/phpinfo_002.phpt
@@ -22,7 +22,6 @@ phpinfo(INFO_MODULES);
 Phar
 
 Phar: PHP Archive support => enabled
-Phar EXT version => %s
 Phar API version => 1.1.1
 Phar-based phar archives => enabled
 Tar-based phar archives => enabled

--- a/ext/phar/tests/phpinfo_003.phpt
+++ b/ext/phar/tests/phpinfo_003.phpt
@@ -22,7 +22,6 @@ phpinfo(INFO_MODULES);
 Phar
 
 Phar: PHP Archive support => enabled
-Phar EXT version => %s
 Phar API version => 1.1.1
 Phar-based phar archives => enabled
 Tar-based phar archives => enabled

--- a/ext/phar/tests/phpinfo_004.phpt
+++ b/ext/phar/tests/phpinfo_004.phpt
@@ -27,7 +27,6 @@ phpinfo(INFO_MODULES);
 <h2><a name="module_phar">Phar</a></h2>
 <table>
 <tr class="h"><th>Phar: PHP Archive support</th><th>enabled</th></tr>
-<tr><td class="e">Phar EXT version </td><td class="v">%s </td></tr>
 <tr><td class="e">Phar API version </td><td class="v">1.1.1 </td></tr>
 <tr><td class="e">Phar-based phar archives </td><td class="v">enabled </td></tr>
 <tr><td class="e">Tar-based phar archives </td><td class="v">enabled </td></tr>
@@ -50,7 +49,6 @@ Phar based on pear/PHP_Archive, original concept by Davey Shafik.<br />Phar full
 <h2><a name="module_phar">Phar</a></h2>
 <table>
 <tr class="h"><th>Phar: PHP Archive support</th><th>enabled</th></tr>
-<tr><td class="e">Phar EXT version </td><td class="v">%s </td></tr>
 <tr><td class="e">Phar API version </td><td class="v">1.1.1 </td></tr>
 <tr><td class="e">Phar-based phar archives </td><td class="v">enabled </td></tr>
 <tr><td class="e">Tar-based phar archives </td><td class="v">enabled </td></tr>


### PR DESCRIPTION
Following the discussion done in the #3307, this patch bumps the versions for the hash and phar extensions.

So, the version of the hash extension, mhash interface, and phar extension now match the PHP release version and PHP gets another step ahead with consistency.

The phar extension tests included the phpinfo output so the versions are removed. Phpinfo output for the phar matches the ongoing fixes from some previous pull requests where extension versions with PHP version are omitted from the phpinfo() output.

| Extension                | Version | Note |
| -------------------------- | ----------- | ----- |
| hash                        | 1.0         |  This PR bumps version |
| json                         | 1.7.0       | PR rejected - It will be 1.7.0 |
| mysqlnd      | mysqlnd 5.0.12-dev - 20150407 - $Id: xxx $ |  |
| oci8         | 2.1.8   | Also PECL extension with its own versioning |
| phar         | 2.0.2   | This PR bumps version |
| zip          | 1.15.3  | Also PECL extension with its own versioning |
| all other 63 core extensions | `PHP_VERSION` | |

Thanks.