### PR TITLE
Fix: compile ext/json, use bison instead of yacc

### DIFF
--- a/ext/json/config.m4
+++ b/ext/json/config.m4
@@ -16,6 +16,7 @@ PHP_NEW_EXTENSION(json,
 	  json_scanner.c,
 	  $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_INSTALL_HEADERS([ext/json], [php_json.h php_json_parser.h php_json_scanner.h])
+  PHP_PROG_BISON
   PHP_ADD_MAKEFILE_FRAGMENT()
   PHP_SUBST(JSON_SHARED_LIBADD)
 fi


### PR DESCRIPTION
GNU yacc is a wrapper around bison (yacc replacement). On BSD systems yacc is the original, which does not have --defines. This macro ensures YACC is set to the correct implementation.

Fixes:
```
yacc --defines -l /usr/src/php/php-src/ext/json/json_parser.y -o /usr/src/php/php-src/ext/json/json_parser.tab.c
yacc: unknown option -- -
usage: yacc [-dlrtv] [-b file_prefix] [-o output_file] [-p symbol_prefix] file
*** Error 1 in /usr/src/php/php-src/ext/json (Makefile:197 '/usr/src/php/php-src/ext/json/json_parser.tab.c')
```

@smalyshev  this is a follow up for #3294. This works for me (tested php7.3.0alpha2 on OpenBSD 6.3) but given my previous attempt I do not consider myself experienced enough to know this is actually the right way to fix it.