### PR TITLE
Fix #48725: Support for flushing in zlib stream

### DIFF
--- a/ext/standard/tests/streams/bug48725_generic.phpt
+++ b/ext/standard/tests/streams/bug48725_generic.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Bug #48725 (Support for flushing in zlib stream, more generic issue)
+--FILE--
+<?php
+class DebugClosingFilter extends php_user_filter {
+	public function filter($in, $out, &$consumed, $closing) {
+		if ($closing) {
+			echo "Closing" . PHP_EOL;
+		}
+		while ($bucket = stream_bucket_make_writeable($in)) {
+			$consumed += $bucket->datalen;
+			stream_bucket_append($out, $bucket);
+		}
+		return PSFS_PASS_ON;
+	}
+}
+
+stream_filter_register('debug.closing', 'DebugClosingFilter');
+
+$stream = fopen('data://text/plain;base64,' . base64_encode('Foo bar baz'), 'r');
+stream_filter_append($stream, 'debug.closing', STREAM_FILTER_READ);
+$stream_contents = stream_get_contents($stream);
+print $stream_contents . PHP_EOL;
+?>
+===DONE===
+--EXPECT--
+Closing
+Foo bar baz
+===DONE===

--- a/ext/zlib/tests/bug48725.phpt
+++ b/ext/zlib/tests/bug48725.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #48725 (Support for flushing in zlib stream)
+--SKIPIF--
+<?php if (!extension_loaded("zlib")) print "skip"; ?>
+--FILE--
+<?php
+$stream = fopen('data://text/plain;base64,' . base64_encode('Foo bar baz'), 'r');
+stream_filter_append($stream, 'zlib.deflate', STREAM_FILTER_READ);
+print bin2hex(stream_get_contents($stream)) . PHP_EOL;
+?>
+===DONE===
+--EXPECT--
+73cbcf57484a2c02e22a00
+===DONE===

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -528,6 +528,7 @@ PHPAPI void _php_stream_fill_read_buffer(php_stream *stream, size_t size)
 	if (stream->readfilters.head) {
 		char *chunk_buf;
 		int err_flag = 0;
+		size_t justread = 0;
 		php_stream_bucket_brigade brig_in = { NULL, NULL }, brig_out = { NULL, NULL };
 		php_stream_bucket_brigade *brig_inp = &brig_in, *brig_outp = &brig_out, *brig_swap;
 
@@ -538,8 +539,7 @@ PHPAPI void _php_stream_fill_read_buffer(php_stream *stream, size_t size)
 		/* allocate a buffer for reading chunks */
 		chunk_buf = emalloc(stream->chunk_size);
 
-		while (!stream->eof && !err_flag && (stream->writepos - stream->readpos < (zend_off_t)size)) {
-			size_t justread = 0;
+		while ((justread != 0 || !stream->eof) && !err_flag && (stream->writepos - stream->readpos < (zend_off_t)size)) {
 			int flags;
 			php_stream_bucket *bucket;
 			php_stream_filter_status_t status = PSFS_ERR_FATAL;


### PR DESCRIPTION
Actually this bug is not limited to zlib, but more about stream filters not being called with the `CLOSING` flag for data-, temp- and memory-streams. The more generic testcase aims to illustrate this.

This issue was fixed in 5.5.21 by 86f18755, but resurfaced in 7.2.0 due to 5060fc23. Apparently the fix for another break in 0a45e8f0 was not enough to fix this issue.

This PR takes another approach by ensuring that a final pass through the stream filter with the `CLOSING`-flag is made, even if the stream turns EOF directly after reading the last bytes.