### PR TITLE
[RFC] Deprecate explicit use of FILTER_FLAG_SCHEME|HOST_REQUIRED

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -539,6 +539,11 @@ void php_filter_validate_url(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 	php_url *url;
 	size_t old_len = Z_STRLEN_P(value);
 
+	if (flags & (FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED)) {
+		php_error_docref(NULL, E_DEPRECATED,
+			"explicit use of FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED is deprecated");
+	}
+
 	php_filter_url(value, flags, option_array, charset);
 
 	if (Z_TYPE_P(value) != IS_STRING || old_len != Z_STRLEN_P(value)) {

--- a/ext/filter/tests/deprecated.phpt
+++ b/ext/filter/tests/deprecated.phpt
@@ -1,0 +1,19 @@
+--TEST--
+FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED are deprecated
+--SKIPIF--
+<?php
+if (!extension_loaded('filter')) die('skip filter extension not available');
+?>
+--FILE--
+<?php
+var_dump(filter_var('//example.com/', FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED));
+var_dump(filter_var('http://', FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED));
+?>
+===DONE===
+--EXPECTF--
+Deprecated: filter_var(): explicit use of FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED is deprecated in %s
+bool(false)
+
+Deprecated: filter_var(): explicit use of FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED is deprecated in %s
+bool(false)
+===DONE===


### PR DESCRIPTION
As of PHP 5.2.1 FILTER_VALIDATE_URL implies FILTER_FLAG_SCHEME_REQUIRED
| FILTER_FLAG_HOST_REQUIRED, which makes these constants useless at
best, if not even misleading.  Therefore we deprecate the explicit use
of these constants for FILTER_VALIDATE_URL, to pave the way for their
eventual removal.

See also <https://bugs.php.net/75442> and
<https://externals.io/message/100981>.