### PR TITLE
Fix bug #76524 - ZipArchive memory leak

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1095,7 +1095,6 @@ static void php_zip_object_free_storage(void *object TSRMLS_DC) /* {{{ */
 	if (intern->za) {
 		if (zip_close(intern->za) != 0) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot destroy the zip context");
-			return;
 		}
 		intern->za = NULL;
 	}

--- a/ext/zip/tests/bug76524.phpt
+++ b/ext/zip/tests/bug76524.phpt
@@ -1,0 +1,25 @@
+--TEST--
+ZipArchive Bug #76524 (memory leak with ZipArchive::OVERWRITE flag and empty archive)
+--SKIPIF--
+<?php
+/* $Id$ */
+if(!extension_loaded('zip')) die('skip');
+?>
+--FILE--
+<?php
+
+$filename = __DIR__ . '/nonexistent.zip';
+
+// The error is not reproduced when file already exist:
+if (!file_exists($filename)) {
+	$zip = new ZipArchive();
+	$zip->open($filename, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+	echo 'ok';
+} else {
+	echo "file $filename exists, something goes wrong";
+}
+
+?>
+--EXPECTF--
+ok
+Warning: Unknown: Cannot destroy the zip context in Unknown on line 0


### PR DESCRIPTION
The memory leak occurs when 
- a `ZipArchive` is opened with `ZipArchive::CREATE|ZipArchive::OVERWRITE` flags, 
- it's empty,
- it's destroyed without explicit `close()` method call.

The leak does not occur if the zip file already exist. All newer versions are affected too.

Also, it somehow causes a `zend_mm_heap` corruptions. Unfortunately, I cannot reproduce this on development environment, but my production constantly was crashing until I found the workaround for this bug :)