### PR TITLE
expose_php defaults to off in production

### DIFF
--- a/php.ini-production
+++ b/php.ini-production
@@ -371,7 +371,7 @@ zend.enable_gc = On
 ; threat in any way, but it makes it possible to determine whether you use PHP
 ; on your server or not.
 ; http://php.net/expose-php
-expose_php = On
+expose_php = Off
 
 ;;;;;;;;;;;;;;;;;;;
 ; Resource Limits ;


### PR DESCRIPTION
The comment says `It is no security threat in any way` but I think it is: if an old server exposes a version that is known to be buggy it is far easier to exploit vulnerabilities (e.g. https://www.evonide.com/how-we-broke-php-hacked-pornhub-and-earned-20000-dollar/)