### PR TITLE
Remove unused Git ident attributes from zip extension

### DIFF
--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -1,6 +1,4 @@
-dnl
-dnl $Id$
-dnl
+dnl config.m4 for extension zip
 
 PHP_ARG_ENABLE(zip, for zip archive read/writesupport,
 [  --enable-zip            Include Zip read/write support])

--- a/ext/zip/config.w32
+++ b/ext/zip/config.w32
@@ -1,4 +1,3 @@
-// $Id$
 // vim:ft=javascript
 
 ARG_ENABLE("zip", "ZIP support", "yes");

--- a/ext/zip/examples/im.php
+++ b/ext/zip/examples/im.php
@@ -1,5 +1,5 @@
 <?php
-/* $Id$ */
+
 $im = imagecreatefromgif('zip://' . dirname(__FILE__) . '/test_im.zip#pear_item.gif');
 imagepng($im, 'a.png');
 

--- a/ext/zip/examples/odt.php
+++ b/ext/zip/examples/odt.php
@@ -1,5 +1,5 @@
 <?php
-/* $Id$ */
+
 $reader = new XMLReader();
 
 $reader->open('zip://' . dirname(__FILE__) . '/test.odt#meta.xml');

--- a/ext/zip/tests/bug11216.phpt
+++ b/ext/zip/tests/bug11216.phpt
@@ -2,7 +2,6 @@
 Bug #11216 (::addEmptyDir() crashes when the directory already exists)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
  ?>
 --FILE--

--- a/ext/zip/tests/bug14962.phpt
+++ b/ext/zip/tests/bug14962.phpt
@@ -2,7 +2,6 @@
 Bug #14962 (::extractTo second argument is not really optional)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/bug47667.phpt
+++ b/ext/zip/tests/bug47667.phpt
@@ -2,7 +2,6 @@
 Bug #47667 (ZipArchive::OVERWRITE seems to have no effect)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/bug49072.phpt
+++ b/ext/zip/tests/bug49072.phpt
@@ -2,7 +2,6 @@
 Bug #49072 (feof never returns true for damaged file in zip)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/bug64342_1-mb.phpt
+++ b/ext/zip/tests/bug64342_1-mb.phpt
@@ -2,7 +2,6 @@
 Bug #64342 ZipArchive::addFile() has to check file existence (variation 2)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/bug64342_1.phpt
+++ b/ext/zip/tests/bug64342_1.phpt
@@ -2,7 +2,6 @@
 Bug #64342 ZipArchive::addFile() has to check file existence (variation 2)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/bug7214.phpt
+++ b/ext/zip/tests/bug7214.phpt
@@ -2,7 +2,6 @@
 Bug #7214 (zip_entry_read() binary safe)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
  ?>
 --FILE--

--- a/ext/zip/tests/bug72258.phpt
+++ b/ext/zip/tests/bug72258.phpt
@@ -2,7 +2,6 @@
 Bug #72258 ZipArchive converts filenames to unrecoverable form
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/bug7658.phpt
+++ b/ext/zip/tests/bug7658.phpt
@@ -2,7 +2,6 @@
 Bug #7658 (modify archive with general bit flag 3 set)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/bug8009.phpt
+++ b/ext/zip/tests/bug8009.phpt
@@ -2,7 +2,6 @@
 Bug #8009 (cannot add again same entry to an archive)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/bug8700.phpt
+++ b/ext/zip/tests/bug8700.phpt
@@ -2,7 +2,6 @@
 Bug #8700 (getFromIndex(0) fails)
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_addemptydir.phpt
+++ b/ext/zip/tests/oo_addemptydir.phpt
@@ -2,7 +2,6 @@
 ziparchive::addEmptyDir
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_addfile.phpt
+++ b/ext/zip/tests/oo_addfile.phpt
@@ -2,7 +2,6 @@
 ziparchive::addFile() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_addglob.phpt
+++ b/ext/zip/tests/oo_addglob.phpt
@@ -6,7 +6,6 @@ w/Kenzo over the shoulder
 #phptek Chicago 2014
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 if(!defined("GLOB_BRACE")) die ('skip');
 ?>

--- a/ext/zip/tests/oo_addpattern.phpt
+++ b/ext/zip/tests/oo_addpattern.phpt
@@ -6,7 +6,6 @@ w/Kenzo over the shoulder
 #phptek Chicago 2014
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_close.phpt
+++ b/ext/zip/tests/oo_close.phpt
@@ -2,7 +2,6 @@
 zip::close() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_count.phpt
+++ b/ext/zip/tests/oo_count.phpt
@@ -2,7 +2,6 @@
 ziparchive::count()
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_delete.phpt
+++ b/ext/zip/tests/oo_delete.phpt
@@ -2,7 +2,6 @@
 Delete entries
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_encryption.phpt
+++ b/ext/zip/tests/oo_encryption.phpt
@@ -2,7 +2,6 @@
 ZipArchive::setEncryption*() functions
 --SKIPIF--
 <?php
-/* $Id$ */
 if (!extension_loaded('zip')) die('skip');
 if (!method_exists('ZipArchive', 'setEncryptionName')) die('skip encrytion not supported');
 ?>

--- a/ext/zip/tests/oo_ext_zip.phpt
+++ b/ext/zip/tests/oo_ext_zip.phpt
@@ -2,7 +2,6 @@
 Extending Zip class and array property
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_externalattributes.phpt
+++ b/ext/zip/tests/oo_externalattributes.phpt
@@ -2,7 +2,6 @@
 ZipArchive::*ExternalAttributes*() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if (!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_extract.phpt
+++ b/ext/zip/tests/oo_extract.phpt
@@ -2,7 +2,6 @@
 extractTo
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_getcomment.phpt
+++ b/ext/zip/tests/oo_getcomment.phpt
@@ -2,7 +2,6 @@
 getComment
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_getnameindex.phpt
+++ b/ext/zip/tests/oo_getnameindex.phpt
@@ -2,7 +2,6 @@
 getNameIndex
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_namelocate.phpt
+++ b/ext/zip/tests/oo_namelocate.phpt
@@ -2,7 +2,6 @@
 Locate entries by name
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_open.phpt
+++ b/ext/zip/tests/oo_open.phpt
@@ -2,7 +2,6 @@
 zip::open() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_properties.phpt
+++ b/ext/zip/tests/oo_properties.phpt
@@ -2,7 +2,6 @@
 ziparchive::properties isset()/empty() checks
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_rename.phpt
+++ b/ext/zip/tests/oo_rename.phpt
@@ -2,7 +2,6 @@
 Rename entries
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_setcomment.phpt
+++ b/ext/zip/tests/oo_setcomment.phpt
@@ -2,7 +2,6 @@
 setComment
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_setcompression.phpt
+++ b/ext/zip/tests/oo_setcompression.phpt
@@ -2,7 +2,6 @@
 setCompressionName and setCompressionIndex methods
 --SKIPIF--
 <?php
-/* $Id$ */
 if (!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/oo_stream.phpt
+++ b/ext/zip/tests/oo_stream.phpt
@@ -2,7 +2,6 @@
 getStream
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/utils.inc
+++ b/ext/zip/tests/utils.inc
@@ -1,5 +1,5 @@
 <?php
-/* $Id$ */
+
 function dump_entries_name($z) {
 	for($i=0; $i<$z->numFiles; $i++) {
 	    $sb = $z->statIndex($i);

--- a/ext/zip/tests/zip_close.phpt
+++ b/ext/zip/tests/zip_close.phpt
@@ -2,7 +2,6 @@
 zip_close() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/zip_entry_close.phpt
+++ b/ext/zip/tests/zip_entry_close.phpt
@@ -2,7 +2,6 @@
 zip_entry_close() function: simple and double call
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/zip_entry_compressedsize.phpt
+++ b/ext/zip/tests/zip_entry_compressedsize.phpt
@@ -2,7 +2,6 @@
 zip_entry_compressedsize() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/zip_entry_compressionmethod.phpt
+++ b/ext/zip/tests/zip_entry_compressionmethod.phpt
@@ -2,7 +2,6 @@
 zip_entry_compressionmethod() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/zip_entry_filesize.phpt
+++ b/ext/zip/tests/zip_entry_filesize.phpt
@@ -2,7 +2,6 @@
 zip_entry_filesize() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/zip_entry_name.phpt
+++ b/ext/zip/tests/zip_entry_name.phpt
@@ -2,7 +2,6 @@
 zip_entry_name() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/zip_entry_open.phpt
+++ b/ext/zip/tests/zip_entry_open.phpt
@@ -2,7 +2,6 @@
 zip_entry_open() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/zip_entry_read.phpt
+++ b/ext/zip/tests/zip_entry_read.phpt
@@ -2,7 +2,6 @@
 zip_entry_read() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/zip_open.phpt
+++ b/ext/zip/tests/zip_open.phpt
@@ -2,7 +2,6 @@
 zip_open() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--

--- a/ext/zip/tests/zip_read.phpt
+++ b/ext/zip/tests/zip_read.phpt
@@ -2,7 +2,6 @@
 zip_read() function
 --SKIPIF--
 <?php
-/* $Id$ */
 if(!extension_loaded('zip')) die('skip');
 ?>
 --FILE--


### PR DESCRIPTION
Hello, this pull request follows #3336 and is for the zip extension separately, since it might be maintained elsewhere.

$Id attributes were used with SVN. With Git most of the Git ident attributes in source code files are not used anymore.