### PR TITLE
Remove outdated comments about PHP 3

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -23,8 +23,6 @@
 
 /* $Id$ */
 
-/* Synced with php 3.0 revision 1.218 1999-06-16 [ssb] */
-
 /* {{{ includes */
 
 #include "php.h"

--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -18,8 +18,6 @@
 
 /* $Id$ */
 
-/* Synced with php 3.0 revision 1.30 1999-06-16 [ssb] */
-
 #ifndef FILE_H
 #define FILE_H
 

--- a/ext/standard/fsock.h
+++ b/ext/standard/fsock.h
@@ -20,8 +20,6 @@
 
 /* $Id$ */
 
-/* Synced with php 3.0 revision 1.24 1999-06-18 [ssb] */
-
 #ifndef FSOCK_H
 #define FSOCK_H
 

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -19,8 +19,6 @@
 
 /* $Id$ */
 
-/* Synced with php 3.0 revision 1.43 1999-06-16 [ssb] */
-
 #ifndef PHP_STRING_H
 #define PHP_STRING_H
 


### PR DESCRIPTION
Hello, this is a minor patch that removes some outdated comments about PHP 3 and the revision info.