### PR TITLE
pid & uid available while handling realtime signals

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1275,6 +1275,12 @@ static void pcntl_siginfo_to_zval(int signo, siginfo_t *siginfo, zval *user_sigi
 				break;
 #endif
 		}
+#if defined(SIGRTMIN) && defined(SIGRTMAX)
+		if (SIGRTMIN <= signo && signo <= SIGRTMAX) {
+			add_assoc_long_ex(user_siginfo, "pid", sizeof("pid")-1, siginfo->si_pid);
+			add_assoc_long_ex(user_siginfo, "uid", sizeof("uid")-1, siginfo->si_uid);
+		}
+#endif
 	}
 }
 /* }}} */

--- a/ext/pcntl/tests/pcntl_realtime_signal.phpt
+++ b/ext/pcntl/tests/pcntl_realtime_signal.phpt
@@ -1,0 +1,20 @@
+--TEST--
+pcntl_signal() context of realtime signal
+--SKIPIF--
+<?php if (!defined('SIGRTMIN')) die("skip realtime signal not supported"); ?>
+<?php if (!extension_loaded("pcntl")) print "skip"; ?>
+<?php if (!extension_loaded("posix")) die("skip posix extension not available"); ?>
+--FILE--
+<?php
+
+pcntl_signal(SIGRTMIN, function ($signo, $siginfo) {
+    printf("got realtime signal from %s, ruid:%s\n", $siginfo['pid'] ?? '', $siginfo['uid'] ?? '');
+});
+posix_kill(posix_getpid(), SIGRTMIN);
+pcntl_signal_dispatch();
+
+echo "ok\n";
+?>
+--EXPECTF--
+%rgot realtime signal from \d+, ruid:\d+%r
+ok

--- a/ext/pcntl/tests/pcntl_signal.phpt
+++ b/ext/pcntl/tests/pcntl_signal.phpt
@@ -17,16 +17,6 @@ pcntl_signal(SIGUSR1, function($signo, $siginfo){
 posix_kill(posix_getpid(), SIGUSR1);
 pcntl_signal_dispatch();
 
-if (defined('SIGRTMIN')) {
-    pcntl_signal(SIGRTMIN, function ($signo, $siginfo) {
-        printf("got real time signal from %s, ruid:%s\n", $siginfo['pid'] ?? '', $siginfo['uid'] ?? '');
-    });
-    posix_kill(posix_getpid(), SIGRTMIN);
-    pcntl_signal_dispatch();
-} else {
-    echo "real time signal not supported\n";
-}
-
 var_dump(pcntl_signal());
 var_dump(pcntl_signal(SIGALRM, SIG_IGN));
 var_dump(pcntl_signal(-1, -1));
@@ -41,7 +31,6 @@ echo "ok\n";
 --EXPECTF--
 signal dispatched
 got signal from %r\d+|nobody%r
-%rgot real time signal from \d+, ruid:\d+|real time signal not supported%r
 
 Warning: pcntl_signal() expects at least 2 parameters, 0 given in %s
 NULL

--- a/ext/pcntl/tests/pcntl_signal.phpt
+++ b/ext/pcntl/tests/pcntl_signal.phpt
@@ -17,6 +17,16 @@ pcntl_signal(SIGUSR1, function($signo, $siginfo){
 posix_kill(posix_getpid(), SIGUSR1);
 pcntl_signal_dispatch();
 
+if (defined('SIGRTMIN')) {
+    pcntl_signal(SIGRTMIN, function ($signo, $siginfo) {
+        printf("got real time signal from %s, ruid:%s\n", $siginfo['pid'] ?? '', $siginfo['uid'] ?? '');
+    });
+    posix_kill(posix_getpid(), SIGRTMIN);
+    pcntl_signal_dispatch();
+} else {
+    echo "real time signal not supported\n";
+}
+
 var_dump(pcntl_signal());
 var_dump(pcntl_signal(SIGALRM, SIG_IGN));
 var_dump(pcntl_signal(-1, -1));
@@ -31,6 +41,7 @@ echo "ok\n";
 --EXPECTF--
 signal dispatched
 got signal from %r\d+|nobody%r
+%rgot real time signal from \d+, ruid:\d+|real time signal not supported%r
 
 Warning: pcntl_signal() expects at least 2 parameters, 0 given in %s
 NULL


### PR DESCRIPTION
Add pid & uid into $siginfo while pcntl_signal handles realtime signals, so handler can get sender's pid and real uid