### PR TITLE
Fix bug #76392

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -581,8 +581,12 @@ AC_TYPE_UID_T
 dnl Checks for sockaddr_storage and sockaddr.sa_len
 PHP_SOCKADDR_CHECKS
 
-AX_GCC_FUNC_ATTRIBUTE([ifunc])
-AX_GCC_FUNC_ATTRIBUTE([target])
+dnl Checks for GCC function attributes on all systems except ones without glibc
+dnl Fix for these systems is already included in GCC 7, but not on GCC 6
+AS_CASE([$host_alias], [*-*-*android*|*-*-*uclibc*|*-*-*musl*], [true], [
+  AX_GCC_FUNC_ATTRIBUTE([ifunc])
+  AX_GCC_FUNC_ATTRIBUTE([target])
+])
 
 dnl Check for IPv6 support
 AC_CACHE_CHECK([for IPv6 support], ac_cv_ipv6_support,


### PR DESCRIPTION
On systems such as Alpine, Musl libc doesn't provide function attributes. Compiler (GCC) provides them, but the runtime afterwards doesn't. This additional check fixes bug [#76392](https://bugs.php.net/bug.php?id=76392).