### PR TITLE
Add configure.lineno to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ configuration-parser.h
 configuration-parser.output
 configuration-scanner.c
 configure
+configure.lineno
 conftest
 conftest.c
 debug.log


### PR DESCRIPTION
The `configure.lineno` script file is autogenerated when running the `configure` script. On most systems with bash present it gets removed, but on some systems, such as Alpine Linux, it doesn't get removed automatically.