### PR TITLE
Fix #63217: Constant numeric strings become integers when used as ArrayAccess offset

### DIFF
--- a/Zend/tests/bug29883.phpt
+++ b/Zend/tests/bug29883.phpt
@@ -15,7 +15,7 @@ bool(false)
 bool(true)
 bool(true)
 
-Notice: Uninitialized string offset: -10 in %s on line 7
+Notice: Uninitialized string offset: -10 in %s on line 6
 string(0) ""
 string(1) "u"
 string(1) "u"

--- a/Zend/tests/bug29883.phpt
+++ b/Zend/tests/bug29883.phpt
@@ -4,10 +4,18 @@ Bug #29883 (isset gives invalid values on strings)
 <?php
 $x = "bug";
 var_dump(isset($x[-10]));
+var_dump(isset($x[1]));
 var_dump(isset($x["1"]));
-echo $x["1"]."\n";
+var_dump($x[-10])."\n";
+var_dump($x[1])."\n";
+var_dump($x["1"])."\n";
 ?>
---EXPECT--
+--EXPECTF--
 bool(false)
 bool(true)
-u
+bool(true)
+
+Notice: Uninitialized string offset: -10 in %s on line 7
+string(0) ""
+string(1) "u"
+string(1) "u"

--- a/Zend/tests/bug55135.phpt
+++ b/Zend/tests/bug55135.phpt
@@ -19,7 +19,7 @@ unset($array[1]);
 print_r($array);
 
 $array = array(1 => 2);
-$a = 1;
+
 unset($array["1"]);
 print_r($array);
 ?>

--- a/Zend/tests/bug63217.phpt
+++ b/Zend/tests/bug63217.phpt
@@ -60,16 +60,31 @@ function test(): string {
 var_dump(test());
 
 /**
- * Just to make sure we don't break arrays.
+ * Make sure we don't break arrays.
  */
+$array = [];
+
 $key = '123';
 
-$array = [];
 $array[$key] = 1;
 $array['321'] = 2;
 $array['abc'] = 3;
 
 var_dump($array);
+
+/**
+ * Make sure that we haven't broken ArrayObject
+ */
+$ao = new ArrayObject();
+
+$key = '123';
+
+$ao = [];
+$ao[$key] = 1;
+$ao['321'] = 2;
+$ao['abc'] = 3;
+
+var_dump($ao);
 
 ?>
 --EXPECT--
@@ -90,6 +105,14 @@ offsetSet given string(3) "123"
 offsetGet given string(1) "0"
 offsetGet given string(3) "123"
 string(2) "10"
+array(3) {
+  [123]=>
+  int(1)
+  [321]=>
+  int(2)
+  ["abc"]=>
+  int(3)
+}
 array(3) {
   [123]=>
   int(1)

--- a/Zend/tests/bug63217.phpt
+++ b/Zend/tests/bug63217.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Bug #63217 (Constant numeric strings become integers when used as ArrayAccess offset)
+--FILE--
+<?php
+class Test implements ArrayAccess {
+    public function offsetExists($offset) {
+        echo "offsetExists given ";
+        var_dump($offset);
+    }
+    public function offsetUnset($offset) {
+        echo "offsetUnset given ";
+        var_dump($offset);
+    }
+    public function offsetSet($offset, $value) {
+        echo "offsetSet given ";
+        var_dump($offset);
+    }
+    public function offsetGet($offset) {
+        echo "offsetGet given ";
+        var_dump($offset);
+    }
+}
+$test = new Test;
+// These should all produce string(...) "..." output
+// the incorrect output is int(...)
+isset($test['0']);
+isset($test['123']);
+unset($test['0']);
+unset($test['123']);
+$test['0'] = true;
+$test['123'] = true;
+$foo = $test['0'];
+$foo = $test['123'];
+// These caused the same bug, but in opcache rather than the compiler
+isset($test[(string)'0']);
+isset($test[(string)'123']);
+unset($test[(string)'0']);
+unset($test[(string)'123']);
+$test[(string)'0'] = true;
+$test[(string)'123'] = true;
+$foo = $test[(string)'0'];
+$foo = $test[(string)'123'];
+/**
+ * @see https://github.com/php/php-src/pull/2607#issuecomment-313781748
+ */
+function test(): string {
+    $array["10"] = 42;
+    foreach ($array as $key => $value) {
+        return $key;
+    }
+}
+var_dump(test());
+?>
+--EXPECT--
+offsetExists given string(1) "0"
+offsetExists given string(3) "123"
+offsetUnset given string(1) "0"
+offsetUnset given string(3) "123"
+offsetSet given string(1) "0"
+offsetSet given string(3) "123"
+offsetGet given string(1) "0"
+offsetGet given string(3) "123"
+offsetExists given string(1) "0"
+offsetExists given string(3) "123"
+offsetUnset given string(1) "0"
+offsetUnset given string(3) "123"
+offsetSet given string(1) "0"
+offsetSet given string(3) "123"
+offsetGet given string(1) "0"
+offsetGet given string(3) "123"
+string(2) "10"

--- a/Zend/tests/empty_str_offset.phpt
+++ b/Zend/tests/empty_str_offset.phpt
@@ -17,16 +17,24 @@ var_dump(empty($str[5])); // 1
 var_dump(empty($str[8]));
 var_dump(empty($str[10000]));
 // non-numeric offsets
-print "- string ---\n";
-var_dump(empty($str['-1']));
+print "- string literal ---\n";
+var_dump(empty($str['-1'])); // 3
 var_dump(empty($str['-10']));
-var_dump(empty($str['-4'])); // 0
 var_dump(empty($str['0']));
 var_dump(empty($str['1']));
 var_dump(empty($str['4'])); // 0
 var_dump(empty($str['1.5']));
 var_dump(empty($str['good']));
 var_dump(empty($str['3 and a half']));
+print "- string variable ---\n";
+var_dump(empty($str[$key = '-1'])); // 3
+var_dump(empty($str[$key = '-10']));
+var_dump(empty($str[$key = '0']));
+var_dump(empty($str[$key = '1']));
+var_dump(empty($str[$key = '4'])); // 0
+var_dump(empty($str[$key = '1.5']));
+var_dump(empty($str[$key = 'good']));
+var_dump(empty($str[$key = '3 and a half']));
 print "- bool ---\n";
 var_dump(empty($str[true]));
 var_dump(empty($str[false]));
@@ -54,7 +62,7 @@ var_dump(empty($str[$f]));
 print "done\n";
 
 ?>
---EXPECT--
+--EXPECTF--
 - empty ---
 bool(false)
 bool(true)
@@ -65,9 +73,17 @@ bool(true)
 bool(false)
 bool(true)
 bool(true)
-- string ---
+- string literal ---
 bool(false)
 bool(true)
+bool(false)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+- string variable ---
+bool(false)
 bool(true)
 bool(false)
 bool(false)

--- a/Zend/tests/isset_str_offset.phpt
+++ b/Zend/tests/isset_str_offset.phpt
@@ -16,8 +16,8 @@ var_dump(isset($str[5])); // 1
 var_dump(isset($str[8]));
 var_dump(isset($str[10000]));
 // non-numeric offsets
-print "- string ---\n";
-var_dump(isset($str['-1']));
+print "- string literal ---\n";
+var_dump(isset($str['-1'])); // 3
 var_dump(isset($str['-10']));
 var_dump(isset($str['0']));
 var_dump(isset($str['1']));
@@ -25,6 +25,15 @@ var_dump(isset($str['4'])); // 0
 var_dump(isset($str['1.5']));
 var_dump(isset($str['good']));
 var_dump(isset($str['3 and a half']));
+print "- string variable ---\n";
+var_dump(isset($str[$key = '-1'])); // 3
+var_dump(isset($str[$key = '-10']));
+var_dump(isset($str[$key = '0']));
+var_dump(isset($str[$key = '1']));
+var_dump(isset($str[$key = '4'])); // 0
+var_dump(isset($str[$key = '1.5']));
+var_dump(isset($str[$key = 'good']));
+var_dump(isset($str[$key = '3 and a half']));
 print "- bool ---\n";
 var_dump(isset($str[true]));
 var_dump(isset($str[false]));
@@ -51,7 +60,7 @@ var_dump(isset($str[$f]));
 print "done\n";
 
 ?>
---EXPECT--
+--EXPECTF--
 - isset ---
 bool(true)
 bool(false)
@@ -61,7 +70,16 @@ bool(true)
 bool(true)
 bool(false)
 bool(false)
-- string ---
+- string literal ---
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+bool(false)
+- string variable ---
 bool(true)
 bool(false)
 bool(true)

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2672,7 +2672,6 @@ static zend_op *zend_delayed_compile_dim(znode *result, zend_ast *ast, uint32_t 
 		dim_node.op_type = IS_UNUSED;
 	} else {
 		zend_compile_expr(&dim_node, dim_ast);
-		zend_handle_numeric_op(&dim_node);
 	}
 
 	opline = zend_delayed_emit_op(result, ZEND_FETCH_DIM_R, &var_node, &dim_node);

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1731,10 +1731,8 @@ num_undef:
 		}
 	} else if (EXPECTED(Z_TYPE_P(dim) == IS_STRING)) {
 		offset_key = Z_STR_P(dim);
-		if (dim_type != IS_CONST) {
-			if (ZEND_HANDLE_NUMERIC(offset_key, hval)) {
-				goto num_index;
-			}
+		if (ZEND_HANDLE_NUMERIC(offset_key, hval)) {
+			goto num_index;
 		}
 str_index:
 		retval = zend_hash_find_ex(ht, offset_key, dim_type == IS_CONST);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5190,10 +5190,8 @@ ZEND_VM_HANDLER(72, ZEND_ADD_ARRAY_ELEMENT, CONST|TMP|VAR|CV, CONST|TMPVAR|UNUSE
 ZEND_VM_C_LABEL(add_again):
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (OP2_TYPE != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					ZEND_VM_C_GOTO(num_index);
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				ZEND_VM_C_GOTO(num_index);
 			}
 ZEND_VM_C_LABEL(str_index):
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -5538,10 +5536,8 @@ ZEND_VM_C_LABEL(unset_dim_array):
 ZEND_VM_C_LABEL(offset_again):
 			if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 				key = Z_STR_P(offset);
-				if (OP2_TYPE != IS_CONST) {
-					if (ZEND_HANDLE_NUMERIC(key, hval)) {
-						ZEND_VM_C_GOTO(num_index_dim);
-					}
+				if (ZEND_HANDLE_NUMERIC(key, hval)) {
+					ZEND_VM_C_GOTO(num_index_dim);
 				}
 ZEND_VM_C_LABEL(str_index_dim):
 				if (ht == &EG(symbol_table)) {
@@ -6286,10 +6282,8 @@ ZEND_VM_C_LABEL(isset_dim_obj_array):
 ZEND_VM_C_LABEL(isset_again):
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (OP2_TYPE != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					ZEND_VM_C_GOTO(num_index_prop);
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				ZEND_VM_C_GOTO(num_index_prop);
 			}
 			value = zend_hash_find_ex_ind(ht, str, OP2_TYPE == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5190,8 +5190,10 @@ ZEND_VM_HANDLER(72, ZEND_ADD_ARRAY_ELEMENT, CONST|TMP|VAR|CV, CONST|TMPVAR|UNUSE
 ZEND_VM_C_LABEL(add_again):
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				ZEND_VM_C_GOTO(num_index);
+			if (OP2_TYPE != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					ZEND_VM_C_GOTO(num_index);
+				}
 			}
 ZEND_VM_C_LABEL(str_index):
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5520,10 +5520,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CONST_C
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CONST != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -5738,10 +5736,8 @@ isset_dim_obj_array:
 isset_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CONST != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index_prop;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index_prop;
 			}
 			value = zend_hash_find_ex_ind(ht, str, IS_CONST == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
@@ -7544,10 +7540,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CONST_T
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -7632,10 +7626,8 @@ isset_dim_obj_array:
 isset_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index_prop;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index_prop;
 			}
 			value = zend_hash_find_ex_ind(ht, str, (IS_TMP_VAR|IS_VAR) == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
@@ -8822,10 +8814,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CONST_U
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_UNUSED != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -10628,10 +10618,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CONST_C
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CV != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -10716,10 +10704,8 @@ isset_dim_obj_array:
 isset_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CV != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index_prop;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index_prop;
 			}
 			value = zend_hash_find_ex_ind(ht, str, IS_CV == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
@@ -14254,10 +14240,8 @@ isset_dim_obj_array:
 isset_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CONST != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index_prop;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index_prop;
 			}
 			value = zend_hash_find_ex_ind(ht, str, IS_CONST == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
@@ -15716,10 +15700,8 @@ isset_dim_obj_array:
 isset_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index_prop;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index_prop;
 			}
 			value = zend_hash_find_ex_ind(ht, str, (IS_TMP_VAR|IS_VAR) == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
@@ -17582,10 +17564,8 @@ isset_dim_obj_array:
 isset_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CV != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index_prop;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index_prop;
 			}
 			value = zend_hash_find_ex_ind(ht, str, IS_CV == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
@@ -18638,10 +18618,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_TMP_CON
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CONST != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -19052,10 +19030,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_TMP_TMP
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -19542,10 +19518,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_TMP_UNU
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_UNUSED != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -20012,10 +19986,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_TMP_CV_
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CV != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -23757,10 +23729,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_VAR_CON
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CONST != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -23845,10 +23815,8 @@ unset_dim_array:
 offset_again:
 			if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 				key = Z_STR_P(offset);
-				if (IS_CONST != IS_CONST) {
-					if (ZEND_HANDLE_NUMERIC(key, hval)) {
-						goto num_index_dim;
-					}
+				if (ZEND_HANDLE_NUMERIC(key, hval)) {
+					goto num_index_dim;
 				}
 str_index_dim:
 				if (ht == &EG(symbol_table)) {
@@ -25902,10 +25870,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_VAR_TMP
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -25990,10 +25956,8 @@ unset_dim_array:
 offset_again:
 			if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 				key = Z_STR_P(offset);
-				if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-					if (ZEND_HANDLE_NUMERIC(key, hval)) {
-						goto num_index_dim;
-					}
+				if (ZEND_HANDLE_NUMERIC(key, hval)) {
+					goto num_index_dim;
 				}
 str_index_dim:
 				if (ht == &EG(symbol_table)) {
@@ -27485,10 +27449,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_VAR_UNU
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_UNUSED != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -29706,10 +29668,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_VAR_CV_
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CV != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -29794,10 +29754,8 @@ unset_dim_array:
 offset_again:
 			if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 				key = Z_STR_P(offset);
-				if (IS_CV != IS_CONST) {
-					if (ZEND_HANDLE_NUMERIC(key, hval)) {
-						goto num_index_dim;
-					}
+				if (ZEND_HANDLE_NUMERIC(key, hval)) {
+					goto num_index_dim;
 				}
 str_index_dim:
 				if (ht == &EG(symbol_table)) {
@@ -40705,10 +40663,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CV_CONS
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CONST != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -40847,10 +40803,8 @@ unset_dim_array:
 offset_again:
 			if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 				key = Z_STR_P(offset);
-				if (IS_CONST != IS_CONST) {
-					if (ZEND_HANDLE_NUMERIC(key, hval)) {
-						goto num_index_dim;
-					}
+				if (ZEND_HANDLE_NUMERIC(key, hval)) {
+					goto num_index_dim;
 				}
 str_index_dim:
 				if (ht == &EG(symbol_table)) {
@@ -41050,10 +41004,8 @@ isset_dim_obj_array:
 isset_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CONST != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index_prop;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index_prop;
 			}
 			value = zend_hash_find_ex_ind(ht, str, IS_CONST == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
@@ -44379,10 +44331,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CV_TMPV
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -44467,10 +44417,8 @@ unset_dim_array:
 offset_again:
 			if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 				key = Z_STR_P(offset);
-				if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-					if (ZEND_HANDLE_NUMERIC(key, hval)) {
-						goto num_index_dim;
-					}
+				if (ZEND_HANDLE_NUMERIC(key, hval)) {
+					goto num_index_dim;
 				}
 str_index_dim:
 				if (ht == &EG(symbol_table)) {
@@ -44596,10 +44544,8 @@ isset_dim_obj_array:
 isset_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index_prop;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index_prop;
 			}
 			value = zend_hash_find_ex_ind(ht, str, (IS_TMP_VAR|IS_VAR) == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
@@ -46411,10 +46357,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CV_UNUS
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_UNUSED != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -49996,10 +49940,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CV_CV_H
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CV != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index;
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -50084,10 +50026,8 @@ unset_dim_array:
 offset_again:
 			if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 				key = Z_STR_P(offset);
-				if (IS_CV != IS_CONST) {
-					if (ZEND_HANDLE_NUMERIC(key, hval)) {
-						goto num_index_dim;
-					}
+				if (ZEND_HANDLE_NUMERIC(key, hval)) {
+					goto num_index_dim;
 				}
 str_index_dim:
 				if (ht == &EG(symbol_table)) {
@@ -50211,10 +50151,8 @@ isset_dim_obj_array:
 isset_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (IS_CV != IS_CONST) {
-				if (ZEND_HANDLE_NUMERIC(str, hval)) {
-					goto num_index_prop;
-				}
+			if (ZEND_HANDLE_NUMERIC(str, hval)) {
+				goto num_index_prop;
 			}
 			value = zend_hash_find_ex_ind(ht, str, IS_CV == IS_CONST);
 		} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5520,8 +5520,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CONST_C
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_CONST != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -7540,8 +7542,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CONST_T
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -8814,8 +8818,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CONST_U
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_UNUSED != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -10618,8 +10624,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CONST_C
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_CV != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -18618,8 +18626,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_TMP_CON
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_CONST != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -19030,8 +19040,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_TMP_TMP
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -19518,8 +19530,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_TMP_UNU
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_UNUSED != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -19986,8 +20000,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_TMP_CV_
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_CV != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -23729,8 +23745,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_VAR_CON
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_CONST != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -25870,8 +25888,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_VAR_TMP
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -27449,8 +27469,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_VAR_UNU
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_UNUSED != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -29668,8 +29690,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_VAR_CV_
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_CV != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -40663,8 +40687,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CV_CONS
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_CONST != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -44331,8 +44357,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CV_TMPV
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -46357,8 +46385,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CV_UNUS
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_UNUSED != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);
@@ -49940,8 +49970,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_ELEMENT_SPEC_CV_CV_H
 add_again:
 		if (EXPECTED(Z_TYPE_P(offset) == IS_STRING)) {
 			str = Z_STR_P(offset);
-			if (ZEND_HANDLE_NUMERIC(str, hval)) {
-				goto num_index;
+			if (IS_CV != IS_CONST) {
+				if (ZEND_HANDLE_NUMERIC(str, hval)) {
+					goto num_index;
+				}
 			}
 str_index:
 			zend_hash_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), str, expr_ptr);

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -2111,11 +2111,7 @@ static uint32_t assign_dim_result_type(
 				tmp |= MAY_BE_ARRAY_KEY_LONG;
 			}
 			if (dim_type & MAY_BE_STRING) {
-				tmp |= MAY_BE_ARRAY_KEY_STRING;
-				if (dim_op_type != IS_CONST) {
-					// FIXME: numeric string
-					tmp |= MAY_BE_ARRAY_KEY_LONG;
-				}
+				tmp |= (MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_KEY_STRING);
 			}
 			if (dim_type & (MAY_BE_UNDEF|MAY_BE_NULL)) {
 				tmp |= MAY_BE_ARRAY_KEY_STRING;

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -2678,7 +2678,7 @@ static int zend_update_type_info(const zend_op_array *op_array,
 			break;
 		case ZEND_ASSIGN_DIM:
 			if (opline->op1_type == IS_CV) {
-				tmp = assign_dim_result_type(t1, t2, OP1_DATA_INFO(), opline->op1_type, 
+				tmp = assign_dim_result_type(t1, t2, OP1_DATA_INFO(), opline->op2_type, 
 					CRT_CONSTANT_EX(op_array, opline, opline->op2, ssa->rt_constants));
 
 				UPDATE_SSA_TYPE(tmp, ssa_ops[i].op1_def);

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -2085,8 +2085,43 @@ uint32_t zend_array_element_type(uint32_t t1, int write, int insert)
 	return tmp;
 }
 
+static uint32_t get_dim_array_key_type(uint32_t dim_type, zend_uchar dim_op_type, zval *dim_op) 
+{
+	uint32_t tmp = 0;
+
+	if (dim_op_type == IS_UNUSED) {
+		tmp |= MAY_BE_ARRAY_KEY_LONG;
+	} else {
+		if (dim_type & (MAY_BE_LONG|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_RESOURCE|MAY_BE_DOUBLE)) {
+			tmp |= MAY_BE_ARRAY_KEY_LONG;
+		}
+		if (dim_type & MAY_BE_STRING) {
+			tmp |= MAY_BE_ARRAY_KEY_STRING;
+
+			if (dim_op_type != IS_CONST) {
+				tmp |= MAY_BE_ARRAY_KEY_LONG;
+			} else {
+				zend_ulong hval;
+				if (ZEND_HANDLE_NUMERIC(Z_STR_P(dim_op), hval)) {
+					tmp |= MAY_BE_ARRAY_KEY_LONG;
+				}
+			}
+		}
+		if (dim_type & (MAY_BE_UNDEF|MAY_BE_NULL)) {
+			tmp |= MAY_BE_ARRAY_KEY_STRING;
+		}
+	}
+
+	return tmp;
+}
+
 static uint32_t assign_dim_result_type(
-		uint32_t arr_type, uint32_t dim_type, uint32_t value_type, zend_uchar dim_op_type) {
+	uint32_t arr_type, 
+	uint32_t dim_type, 
+	uint32_t value_type, 
+	zend_uchar dim_op_type, 
+	zval *dim_op
+) {
 	uint32_t tmp = arr_type & ~(MAY_BE_RC1|MAY_BE_RCN);
 
 	if (arr_type & (MAY_BE_UNDEF|MAY_BE_NULL|MAY_BE_FALSE)) {
@@ -2104,19 +2139,7 @@ static uint32_t assign_dim_result_type(
 		if (value_type & MAY_BE_UNDEF) {
 			tmp |= MAY_BE_ARRAY_OF_NULL;
 		}
-		if (dim_op_type == IS_UNUSED) {
-			tmp |= MAY_BE_ARRAY_KEY_LONG;
-		} else {
-			if (dim_type & (MAY_BE_LONG|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_RESOURCE|MAY_BE_DOUBLE)) {
-				tmp |= MAY_BE_ARRAY_KEY_LONG;
-			}
-			if (dim_type & MAY_BE_STRING) {
-				tmp |= (MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_KEY_STRING);
-			}
-			if (dim_type & (MAY_BE_UNDEF|MAY_BE_NULL)) {
-				tmp |= MAY_BE_ARRAY_KEY_STRING;
-			}
-		}
+		tmp |= get_dim_array_key_type(dim_type, dim_op_type, dim_op);
 	}
 	return tmp;
 }
@@ -2492,7 +2515,8 @@ static int zend_update_type_info(const zend_op_array *op_array,
 
 			if (opline->extended_value == ZEND_ASSIGN_DIM) {
 				if (opline->op1_type == IS_CV) {
-					orig = assign_dim_result_type(orig, OP2_INFO(), tmp, opline->op2_type);
+					orig = assign_dim_result_type(orig, OP2_INFO(), tmp, opline->op2_type, 
+						CRT_CONSTANT_EX(op_array, opline, opline->op2, ssa->rt_constants));
 					UPDATE_SSA_TYPE(orig, ssa_ops[i].op1_def);
 					COPY_SSA_OBJ_TYPE(ssa_ops[i].op1_use, ssa_ops[i].op1_def);
 				}
@@ -2654,7 +2678,9 @@ static int zend_update_type_info(const zend_op_array *op_array,
 			break;
 		case ZEND_ASSIGN_DIM:
 			if (opline->op1_type == IS_CV) {
-				tmp = assign_dim_result_type(t1, t2, OP1_DATA_INFO(), opline->op2_type);
+				tmp = assign_dim_result_type(t1, t2, OP1_DATA_INFO(), opline->op1_type, 
+					CRT_CONSTANT_EX(op_array, opline, opline->op2, ssa->rt_constants));
+
 				UPDATE_SSA_TYPE(tmp, ssa_ops[i].op1_def);
 				COPY_SSA_OBJ_TYPE(ssa_ops[i].op1_use, ssa_ops[i].op1_def);
 			}
@@ -3053,19 +3079,9 @@ static int zend_update_type_info(const zend_op_array *op_array,
 				if (ssa_ops[i].result_use >= 0) {
 					tmp |= ssa_var_info[ssa_ops[i].result_use].type;
 				}
-				if (opline->op2_type == IS_UNUSED) {
-					tmp |= MAY_BE_ARRAY_KEY_LONG;
-				} else {
-					if (t2 & (MAY_BE_LONG|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_DOUBLE)) {
-						tmp |= MAY_BE_ARRAY_KEY_LONG;
-					}
-					if (t2 & (MAY_BE_STRING)) {
-						tmp |= (MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_KEY_STRING);
-					}
-					if (t2 & (MAY_BE_UNDEF | MAY_BE_NULL)) {
-						tmp |= MAY_BE_ARRAY_KEY_STRING;
-					}
-				}
+				tmp |= get_dim_array_key_type(t2, opline->op2_type, 
+					CRT_CONSTANT_EX(op_array, opline, opline->op2, ssa->rt_constants));
+
 				UPDATE_SSA_TYPE(tmp, ssa_ops[i].result_def);
 			}
 			break;
@@ -3178,19 +3194,9 @@ static int zend_update_type_info(const zend_op_array *op_array,
 					if (t1 & (MAY_BE_OBJECT|MAY_BE_RESOURCE)) {
 						tmp |= t1 & (MAY_BE_RC1|MAY_BE_RCN);
 					}
-					if (opline->op2_type == IS_UNUSED) {
-						tmp |= MAY_BE_ARRAY_KEY_LONG;
-					} else {
-						if (t2 & (MAY_BE_LONG|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_RESOURCE|MAY_BE_DOUBLE)) {
-							tmp |= MAY_BE_ARRAY_KEY_LONG;
-						}
-						if (t2 & MAY_BE_STRING) {
-							tmp |= (MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_KEY_STRING);
-						}
-						if (t2 & (MAY_BE_UNDEF | MAY_BE_NULL)) {
-							tmp |= MAY_BE_ARRAY_KEY_STRING;
-						}
-					}
+					tmp |= get_dim_array_key_type(t2, opline->op2_type, 
+						CRT_CONSTANT_EX(op_array, opline, opline->op2, ssa->rt_constants));
+
 				} else if (opline->opcode == ZEND_FETCH_DIM_UNSET) {
 					if (t1 & MAY_BE_ARRAY) {
 						tmp |= MAY_BE_RC1;

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -2100,14 +2100,14 @@ static inline uint32_t get_dim_array_key_type(uint32_t dim_type, zend_uchar dim_
 			tmp |= MAY_BE_ARRAY_KEY_LONG;
 		}
 		if (dim_type & MAY_BE_STRING) {
-			tmp |= MAY_BE_ARRAY_KEY_STRING;
-
 			if (dim_op_type != IS_CONST) {
-				tmp |= MAY_BE_ARRAY_KEY_LONG;
+				tmp |= MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_KEY_LONG;
 			} else {
 				zend_ulong hval;
 				if (ZEND_HANDLE_NUMERIC(Z_STR_P(dim_op), hval)) {
 					tmp |= MAY_BE_ARRAY_KEY_LONG;
+				} else {
+					tmp |= MAY_BE_ARRAY_KEY_STRING;
 				}
 			}
 		}
@@ -2115,7 +2115,7 @@ static inline uint32_t get_dim_array_key_type(uint32_t dim_type, zend_uchar dim_
 			tmp |= MAY_BE_ARRAY_KEY_STRING;
 		}
 	}
-
+	
 	return tmp;
 }
 

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -3060,11 +3060,7 @@ static int zend_update_type_info(const zend_op_array *op_array,
 						tmp |= MAY_BE_ARRAY_KEY_LONG;
 					}
 					if (t2 & (MAY_BE_STRING)) {
-						tmp |= MAY_BE_ARRAY_KEY_STRING;
-						if (opline->op2_type != IS_CONST) {
-							// FIXME: numeric string
-							tmp |= MAY_BE_ARRAY_KEY_LONG;
-						}
+						tmp |= (MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_KEY_STRING);
 					}
 					if (t2 & (MAY_BE_UNDEF | MAY_BE_NULL)) {
 						tmp |= MAY_BE_ARRAY_KEY_STRING;
@@ -3189,11 +3185,7 @@ static int zend_update_type_info(const zend_op_array *op_array,
 							tmp |= MAY_BE_ARRAY_KEY_LONG;
 						}
 						if (t2 & MAY_BE_STRING) {
-							tmp |= MAY_BE_ARRAY_KEY_STRING;
-							if (opline->op2_type != IS_CONST) {
-								// FIXME: numeric string
-								tmp |= MAY_BE_ARRAY_KEY_LONG;
-							}
+							tmp |= (MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_KEY_STRING);
 						}
 						if (t2 & (MAY_BE_UNDEF | MAY_BE_NULL)) {
 							tmp |= MAY_BE_ARRAY_KEY_STRING;

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -518,20 +518,14 @@ int zend_optimizer_update_op2_const(zend_op_array *op_array,
 				opline->op2.constant = zend_optimizer_add_literal(op_array, val);
 			}
 			break;
-		case ZEND_ISSET_ISEMPTY_DIM_OBJ:
 		case ZEND_ADD_ARRAY_ELEMENT:
-		case ZEND_INIT_ARRAY:
-		case ZEND_ASSIGN_DIM:
-		case ZEND_UNSET_DIM:
-		case ZEND_FETCH_DIM_R:
-		case ZEND_FETCH_DIM_W:
-		case ZEND_FETCH_DIM_RW:
-		case ZEND_FETCH_DIM_IS:
-		case ZEND_FETCH_DIM_FUNC_ARG:
-		case ZEND_FETCH_DIM_UNSET:
-		case ZEND_FETCH_LIST_R:
-		case ZEND_FETCH_LIST_W:
-			opline->op2.constant = zend_optimizer_add_literal(op_array, val);
+			if (Z_TYPE_P(val) == IS_STRING) {
+				zend_ulong index;
+				if (ZEND_HANDLE_NUMERIC(Z_STR_P(val), index)) {
+					zval_ptr_dtor_nogc(val);
+					ZVAL_LONG(val, index);
+				}
+			}
 			break;
 		case ZEND_ROPE_INIT:
 		case ZEND_ROPE_ADD:

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -531,13 +531,13 @@ int zend_optimizer_update_op2_const(zend_op_array *op_array,
 		case ZEND_FETCH_DIM_UNSET:
 		case ZEND_FETCH_LIST_R:
 		case ZEND_FETCH_LIST_W:
-			if (Z_TYPE_P(val) == IS_STRING) {
-				zend_ulong index;
-				if (ZEND_HANDLE_NUMERIC(Z_STR_P(val), index)) {
-					zval_ptr_dtor_nogc(val);
-					ZVAL_LONG(val, index);
-				}
-			}
+			// if (Z_TYPE_P(val) == IS_STRING) {
+			// 	zend_ulong index;
+			// 	if (ZEND_HANDLE_NUMERIC(Z_STR_P(val), index)) {
+			// 		zval_ptr_dtor_nogc(val);
+			// 		ZVAL_LONG(val, index);
+			// 	}
+			// }
 			opline->op2.constant = zend_optimizer_add_literal(op_array, val);
 			break;
 		case ZEND_ROPE_INIT:

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -531,13 +531,6 @@ int zend_optimizer_update_op2_const(zend_op_array *op_array,
 		case ZEND_FETCH_DIM_UNSET:
 		case ZEND_FETCH_LIST_R:
 		case ZEND_FETCH_LIST_W:
-			// if (Z_TYPE_P(val) == IS_STRING) {
-			// 	zend_ulong index;
-			// 	if (ZEND_HANDLE_NUMERIC(Z_STR_P(val), index)) {
-			// 		zval_ptr_dtor_nogc(val);
-			// 		ZVAL_LONG(val, index);
-			// 	}
-			// }
 			opline->op2.constant = zend_optimizer_add_literal(op_array, val);
 			break;
 		case ZEND_ROPE_INIT:

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -526,6 +526,7 @@ int zend_optimizer_update_op2_const(zend_op_array *op_array,
 					ZVAL_LONG(val, index);
 				}
 			}
+			opline->op2.constant = zend_optimizer_add_literal(op_array, val);
 			break;
 		case ZEND_ROPE_INIT:
 		case ZEND_ROPE_ADD:


### PR DESCRIPTION
This is a refresh of https://github.com/php/php-src/pull/2607, from which I'm quoting:

> See: 
>  - https://bugs.php.net/bug.php?id=63217
>  - https://3v4l.org/dagUP
>  - https://externals.io/thread/1005
> 
> This PR is an extension and re-opening of #1649 in an attempt to fix this as part of [7.2](https://wiki.php.net/todo/php72#timetable). I've rebased on master and updated some tests that are failing. @nikic mentioned in #1649 that [further changes are necessary](https://github.com/php/php-src/pull/1649#issuecomment-231017890) but I'm not sure what they are or why they are necessary. 
> 
> **This patch does not affect the array or string API and behaviour at all** - only `ArrayAccess`. 
