### PR TITLE
Add missing INI directives to curl phpinfo

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -623,6 +623,8 @@ PHP_MINFO_FUNCTION(curl)
 	}
 #endif
 	php_info_print_table_end();
+
+	DISPLAY_INI_ENTRIES();
 }
 /* }}} */
 


### PR DESCRIPTION
Curl has also `curl.cainfo` INI directive so it might be useful to have all INI values displayed in the phpinfo output.