### PR TITLE
Fix pecl vs ext typo in phar phpinfo

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -3567,7 +3567,7 @@ PHP_MINFO_FUNCTION(phar) /* {{{ */
 	if (PHAR_G(has_bz2)) {
 		php_info_print_table_row(2, "bzip2 compression", "enabled");
 	} else {
-		php_info_print_table_row(2, "bzip2 compression", "disabled (install pecl/bz2)");
+		php_info_print_table_row(2, "bzip2 compression", "disabled (install ext/bz2)");
 	}
 #ifdef PHAR_HAVE_OPENSSL
 	php_info_print_table_row(2, "Native OpenSSL support", "enabled");

--- a/ext/phar/tests/nophar.phpt
+++ b/ext/phar/tests/nophar.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Phar: phar run without pecl/phar with default stub
+Phar: phar run without ext/phar with default stub
 --SKIPIF--
 <?php if (extension_loaded("phar")) die("skip Phar extension must be disabled for this test"); ?>
 --FILE--

--- a/ext/phar/tests/phpinfo_003.phpt
+++ b/ext/phar/tests/phpinfo_003.phpt
@@ -27,7 +27,7 @@ Phar-based phar archives => enabled
 Tar-based phar archives => enabled
 ZIP-based phar archives => enabled
 gzip compression => disabled (install ext/zlib)
-bzip2 compression => disabled (install pecl/bz2)
+bzip2 compression => disabled (install ext/bz2)
 OpenSSL support => disabled (install ext/openssl)
 
 

--- a/ext/phar/tests/withphar.phpt
+++ b/ext/phar/tests/withphar.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Phar: phar run with pecl/phar with default stub
+Phar: phar run with ext/phar with default stub
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 --FILE--


### PR DESCRIPTION
Phar phpinfo output lists also info about bz2 extension if it's disabled and a quick info about installation. Instead of not maintained pecl package bz2 the ext/bz2 should be mentioned.