### PR TITLE
Remove sqlite and xmlrpc extension versions from phpinfo output

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2346,7 +2346,6 @@ PHP_MINFO_FUNCTION(sqlite3)
 {
 	php_info_print_table_start();
 	php_info_print_table_header(2, "SQLite3 support", "enabled");
-	php_info_print_table_row(2, "SQLite3 module version", PHP_SQLITE3_VERSION);
 	php_info_print_table_row(2, "SQLite Library", sqlite3_libversion());
 	php_info_print_table_end();
 

--- a/ext/xmlrpc/xmlrpc-epi-php.c
+++ b/ext/xmlrpc/xmlrpc-epi-php.c
@@ -298,7 +298,6 @@ PHP_MINFO_FUNCTION(xmlrpc)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "core library version", XMLRPC_GetVersionString());
-	php_info_print_table_row(2, "php extension version", PHP_XMLRPC_VERSION);
 	php_info_print_table_row(2, "author", "Dan Libby");
 	php_info_print_table_row(2, "homepage", "http://xmlrpc-epi.sourceforge.net");
 	php_info_print_table_row(2, "open sourced by", "Epinions.com");


### PR DESCRIPTION
Hello, the rest of the core extensions don't display the extension versions in the phpinfo output since they in most cases match the PHP release version.