### PR TITLE
Bump Autoconf version in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ sinclude(Zend/acinclude.m4)
 dnl Basic autoconf + automake initialization, generation of config.nice.
 dnl -------------------------------------------------------------------------
 
-AC_PREREQ(2.59)
+AC_PREREQ([2.64])
 AC_INIT(README.GIT-RULES)
 ifdef([AC_PRESERVE_HELP_ORDER], [AC_PRESERVE_HELP_ORDER], [])
 


### PR DESCRIPTION
Since PHP 7.2 the minimal required Autoconf version has been 2.64

More info at https://bugs.php.net/bug.php?id=75142

Redacted:

There is also a phpize.m4 script with outdated autoconf 2.59 version requirement but for the sake of supporting it on Centos 6 (still maintained until 2020) for possible old extensions that bumping is not done yet.

Thanks.