### PR TITLE
Add missing autoconf m4 quotes

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1725,7 +1725,7 @@ int main(int argc, char *argv[])
 ],
 [_cv_have_broken_glibc_fopen_append=no],
 [_cv_have_broken_glibc_fopen_append=yes ],
-AC_TRY_COMPILE([
+[AC_TRY_COMPILE([
 #include <features.h>
 ],[
 #if !__GLIBC_PREREQ(2,2)
@@ -1733,7 +1733,7 @@ choke me
 #endif
 ],
 [_cv_have_broken_glibc_fopen_append=yes],
-[_cv_have_broken_glibc_fopen_append=no ])
+[_cv_have_broken_glibc_fopen_append=no ])]
 )])
 
   if test "$_cv_have_broken_glibc_fopen_append" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -689,7 +689,7 @@ dnl Also check for working getaddrinfo
 AC_CACHE_CHECK([for getaddrinfo], ac_cv_func_getaddrinfo,
 [AC_TRY_LINK([#include <netdb.h>],
                 [struct addrinfo *g,h;g=&h;getaddrinfo("","",g,&g);], 
-  AC_TRY_RUN([
+  [AC_TRY_RUN([
 #include <netdb.h>
 #include <sys/types.h>
 #ifndef AF_INET
@@ -725,7 +725,7 @@ int main(void) {
   freeaddrinfo(ai);
   exit(0);
 }
-  ],ac_cv_func_getaddrinfo=yes, ac_cv_func_getaddrinfo=no, ac_cv_func_getaddrinfo=no),
+  ],ac_cv_func_getaddrinfo=yes, ac_cv_func_getaddrinfo=no, ac_cv_func_getaddrinfo=no)],
 ac_cv_func_getaddrinfo=no)])
 if test "$ac_cv_func_getaddrinfo" = yes; then
   AC_DEFINE(HAVE_GETADDRINFO,1,[Define if you have the getaddrinfo function])


### PR DESCRIPTION
Hello, two macro calls were missing quotes and in order to be able to run the autoupdate script, this patch adds them.

To update autoconf m4 scripts there is a convenient tool `autoupdate` that can do that automatically. In order to be able to run it, this patch fixes it and such errors are not shown anymore:

```
/usr/bin/m4:/tmp/aukq63QO/input.m4:1845: ERROR: end of file in string
autoupdate: /usr/bin/m4 failed with exit status: 1
```
