### PR TITLE
Replace AC_CONFIG_HEADER with AC_CONFIG_HEADERS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ PHP_CONFIG_NICE(config.nice)
 
 PHP_CANONICAL_HOST_TARGET
 
-AC_CONFIG_HEADER(main/php_config.h)
+AC_CONFIG_HEADERS([main/php_config.h])
 AH_TOP([
 #ifndef PHP_CONFIG_H
 #define PHP_CONFIG_H

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -197,6 +197,6 @@ PHP_GEN_GLOBAL_MAKEFILE
 test -d modules || $php_shtool mkdir modules
 touch .deps
 
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 AC_OUTPUT()


### PR DESCRIPTION
Autoconf doesn't mention the `AC_CONFIG_HEADER` macro since the v2.13 released in 1999 anywhere in the documentation. Future of this macro is unclear and commented as possible candidate for obsoletion in the autoconf source code. Since it is just a wrapper around the main `AC_CONFIG_HEADERS` macro, the functionality is the same, and also more clear to find it in the autoconf documentation and avoid possible future obsoletion.

Autoconf source code where it has a comment for obsoletion since 2.59:
* http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/status.m4?h=branch-2.59#n435

Documentation mention `AC_CONFIG_HEADERS` and usage is the same:
* https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Configuration-Headers.html

Also in Autoconf several changelogs mention the obsoletion path for it...

Thanks.