### PR TITLE
Fixed #76564: bad regex for checking libzip static lib

### DIFF
--- a/ext/zip/config.w32
+++ b/ext/zip/config.w32
@@ -10,7 +10,7 @@ if (PHP_ZIP != "no") {
 	) {
 		EXTENSION('zip', 'php_zip.c zip_stream.c');
 
-		if (get_define("LIBS_ZIP").match("libzip_a.lib")) {
+		if (get_define("LIBS_ZIP").match("libzip_a(?:_debug)?\.lib")) {
 			/* Using static dependency lib. */
 			AC_DEFINE("ZIP_STATIC", 1);
 		}


### PR DESCRIPTION
This bug caused linking issues in debug mode (see bug [#76564](https://bugs.php.net/bug.php?id=76564))

This issue affects PHP 7.2 and master.