### PR TITLE
Add fpm_get_request_headers function

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1543,10 +1543,7 @@ PHP_FUNCTION(fastcgi_finish_request) /* {{{ */
 }
 /* }}} */
 
-ZEND_BEGIN_ARG_INFO(cgi_fcgi_sapi_no_arginfo, 0)
-ZEND_END_ARG_INFO()
-
-PHP_FUNCTION(apache_request_headers) /* {{{ */
+PHP_FUNCTION(fpm_get_request_headers) /* {{{ */
 {
 	fcgi_request *request;
 
@@ -1571,11 +1568,15 @@ PHP_FUNCTION(fpm_get_status) /* {{{ */
 }
 /* }}} */
 
+ZEND_BEGIN_ARG_INFO(cgi_fcgi_sapi_no_arginfo, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry cgi_fcgi_sapi_functions[] = {
-	PHP_FE(fastcgi_finish_request,                    cgi_fcgi_sapi_no_arginfo)
-	PHP_FE(fpm_get_status,                            NULL)
-	PHP_FE(apache_request_headers,                    cgi_fcgi_sapi_no_arginfo)
-	PHP_FALIAS(getallheaders, apache_request_headers, cgi_fcgi_sapi_no_arginfo)
+	PHP_FE(fastcgi_finish_request,                              cgi_fcgi_sapi_no_arginfo)
+	PHP_FE(fpm_get_status,                                      cgi_fcgi_sapi_no_arginfo)
+	PHP_FE(fpm_get_request_headers,                             cgi_fcgi_sapi_no_arginfo)
+	PHP_FALIAS(apache_request_headers, fpm_get_request_headers, cgi_fcgi_sapi_no_arginfo)
+	PHP_FALIAS(getallheaders, fpm_get_request_headers,          cgi_fcgi_sapi_no_arginfo)
 	PHP_FE_END
 };
 

--- a/sapi/fpm/tests/fpm_get_request_headers_basic.phpt
+++ b/sapi/fpm/tests/fpm_get_request_headers_basic.phpt
@@ -1,5 +1,5 @@
 --TEST--
-FPM: Function getallheaders basic test
+FPM: Function fpm_get_request_headers basic test
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--
@@ -22,7 +22,9 @@ EOT;
 $code = <<<EOT
 <?php
 echo "Test Start\n";
-var_dump(getallheaders());
+var_dump(fpm_get_request_headers());
+var_dump(fpm_get_request_headers() === getallheaders());
+var_dump(fpm_get_request_headers() === apache_request_headers());
 echo "Test End\n";
 EOT;
 
@@ -49,6 +51,8 @@ $tester->request(
 			'  ["Content-Type"]=>',
 			'  string(0) ""',
 			'}',
+			'bool(true)',
+            'bool(true)',
 			'Test End',
 		]
 	);


### PR DESCRIPTION
With addition of `fpm_get_status` we have an FPM specific function and it would be nice to have a function named in that way for getting request headers. The PR is more a cosmetic follow up to #3363 . One reason for that is to have a section in php-doc FPM documentation about its functions. I think that `apache_request_headers` is quite confusing as this has nothing to do with Apache in this case but kept it as an alias.