### PR TITLE
fpm process name, FreeBSD 12.x using new setproctitle_fast.

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2100,57 +2100,6 @@ AC_DEFUN([PHP_PROG_BISON], [
 ])
 
 dnl
-dnl PHP_PROG_LEX
-dnl
-dnl Search for (f)lex and check it's version
-dnl
-AC_DEFUN([PHP_PROG_LEX], [
-dnl we only support certain flex versions
-  flex_version_list="2.5.4"
-
-  AC_PROG_LEX
-  dnl ## Make flex scanners use const if they can, even if __STDC__ is not
-  dnl ## true, for compilers like Sun's that only set __STDC__ true in
-  dnl ## "limit-to-ANSI-standard" mode, not in "ANSI-compatible" mode
-  AC_C_CONST
-  if test "$ac_cv_c_const" = "yes" ; then
-    LEX_CFLAGS="-DYY_USE_CONST"
-  fi
-
-  if test "$LEX" = "flex"; then
-    AC_CACHE_CHECK([for flex version], php_cv_flex_version, [
-      flex_version=`$LEX -V -v --version 2>/dev/null | $SED -e 's/^.* //'`
-      php_cv_flex_version=invalid
-      for flex_check_version in $flex_version_list; do
-        if test "$flex_version" = "$flex_check_version"; then
-          php_cv_flex_version="$flex_check_version (ok)"
-        fi
-      done
-    ])
-  else
-    flex_version=none
-  fi
-
-  case $php_cv_flex_version in
-    ""|invalid[)]
-      if test -f "$abs_srcdir/Zend/zend_language_scanner.c" && test -f "$abs_srcdir/Zend/zend_ini_scanner.c"; then
-        AC_MSG_WARN([flex versions supported for regeneration of the Zend/PHP parsers: $flex_version_list  (found: $flex_version)])
-      else
-        flex_msg="Supported flex versions are: $flex_version_list"
-        if test "$flex_version" = "none"; then
-          flex_msg="flex not found. flex is required to generate the Zend/PHP parsers! $flex_msg"
-        else
-          flex_msg="Found invalid flex version: $flex_version. $flex_msg"
-        fi
-        AC_MSG_ERROR([$flex_msg])
-      fi
-      LEX="exit 0;"
-      ;;
-  esac
-  PHP_SUBST(LEX)
-])
-
-dnl
 dnl PHP_PROG_RE2C
 dnl
 dnl Search for the re2c binary and check the version

--- a/build/build2.mk
+++ b/build/build2.mk
@@ -27,7 +27,7 @@ targets = $(TOUCH_FILES) configure $(config_h_in)
 PHP_AUTOCONF ?= 'autoconf'
 PHP_AUTOHEADER ?= 'autoheader'
 
-SUPPRESS_WARNINGS ?= 2>&1 | (egrep -v '(AC_TRY_RUN called without default to allow cross compiling|AC_PROG_CXXCPP was called before AC_PROG_CXX|defined in acinclude.m4 but never used|AC_PROG_LEX invoked multiple times|AC_DECL_YYTEXT is expanded from...|the top level)'||true)
+SUPPRESS_WARNINGS ?= 2>&1 | (egrep -v '(AC_TRY_RUN called without default to allow cross compiling|AC_PROG_CXXCPP was called before AC_PROG_CXX|defined in acinclude.m4 but never used)'||true)
 
 all: $(targets)
 

--- a/makedist
+++ b/makedist
@@ -85,7 +85,7 @@ for i in $LT_TARGETS; do
   fi
 done
 
-# generate some files so people don't need bison, flex and autoconf
+# generate some files so people don't need bison, re2c and autoconf
 # to install
 set -x
 ./buildconf --copy --force

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -6,7 +6,7 @@ PHP_ARG_ENABLE(fpm,,
 dnl configure checks {{{
 AC_DEFUN([AC_FPM_STDLIBS],
 [
-  AC_CHECK_FUNCS(setenv clearenv setproctitle)
+  AC_CHECK_FUNCS(setenv clearenv setproctitle setproctitle_fast)
 
   AC_SEARCH_LIBS(socket, socket)
   AC_SEARCH_LIBS(inet_addr, nsl)

--- a/sapi/fpm/fpm/fpm_env.c
+++ b/sapi/fpm/fpm/fpm_env.c
@@ -119,7 +119,9 @@ static char * nvmatch(char *s1, char *s2) /* {{{ */
 
 void fpm_env_setproctitle(char *title) /* {{{ */
 {
-#ifdef HAVE_SETPROCTITLE
+#if defined(HAVE_SETPROCTITLE_FAST)
+	setproctitle_fast("%s", title);
+#elif defined(HAVE_SETPROCTITLE)
 	setproctitle("%s", title);
 #else
 #ifdef __linux__

--- a/sapi/phpdbg/phpdbg_parser.c
+++ b/sapi/phpdbg/phpdbg_parser.c
@@ -76,8 +76,6 @@
 /*
  * phpdbg_parser.y
  * (from php-src root)
- * flex sapi/phpdbg/dev/phpdbg_lexer.l
- * bison sapi/phpdbg/dev/phpdbg_parser.y
  */
 
 #include "phpdbg.h"

--- a/sapi/phpdbg/phpdbg_parser.y
+++ b/sapi/phpdbg/phpdbg_parser.y
@@ -3,8 +3,6 @@
 /*
  * phpdbg_parser.y
  * (from php-src root)
- * flex sapi/phpdbg/dev/phpdbg_lexer.l
- * bison sapi/phpdbg/dev/phpdbg_parser.y
  */
 
 #include "phpdbg.h"


### PR DESCRIPTION
setproctitle_fast is not a replacement of the classic
setproctitle but only in this type of situation when each
fpm process when call are possibly frequent since
the fast flavor avoid the constant call to the kernel.