### PR TITLE
Don't need interactive progress on git clones in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+git:
+  quiet: true
+
 dist: trusty
 language: c
 sudo: required


### PR DESCRIPTION
Travis logs are usually inspected after the build completes, by which time
progress info is useless.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>