### PR TITLE
output_buffering default in Non-CLI mode and ini configuration is missing

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1623,11 +1623,11 @@ int php_request_startup(void)
 		PG(connection_status) = PHP_CONNECTION_NORMAL;
 		PG(in_user_include) = 0;
 
-        /* Non-CLI mode, and the ini configuration is missing */
-        /* Output_buffering should be set to the default value */
-        if (strcmp(sapi_module.name, "cli") && PG(output_buffering) < 1) {
-            PG(output_buffering) = 4096;
-        }
+		/* Non-CLI mode, and the ini configuration is missing */
+		/* Output_buffering should be set to the default value */
+		if (strcmp(sapi_module.name, "cli") && PG(output_buffering) < 1) {
+			PG(output_buffering) = 4096;
+		}
 
 		zend_activate();
 		sapi_activate();

--- a/main/main.c
+++ b/main/main.c
@@ -1623,8 +1623,8 @@ int php_request_startup(void)
 		PG(connection_status) = PHP_CONNECTION_NORMAL;
 		PG(in_user_include) = 0;
 
-        // Non-CLI mode, and the ini configuration is missing;
-        // Output_buffering should be set to the default value;
+        /* Non-CLI mode, and the ini configuration is missing */
+        /* Output_buffering should be set to the default value */
         if (strcmp(sapi_module.name, "cli") && PG(output_buffering) < 1) {
             PG(output_buffering) = 4096;
         }

--- a/main/main.c
+++ b/main/main.c
@@ -1623,6 +1623,12 @@ int php_request_startup(void)
 		PG(connection_status) = PHP_CONNECTION_NORMAL;
 		PG(in_user_include) = 0;
 
+        // Non-CLI mode, and the ini configuration is missing;
+        // Output_buffering should be set to the default value;
+        if (strcmp(sapi_module.name, "cli") && PG(output_buffering) < 1) {
+            PG(output_buffering) = 4096;
+        }
+
 		zend_activate();
 		sapi_activate();
 


### PR DESCRIPTION
In non-CLI mode, and the ini configuration is missing, the system should set output_buffer to the default size of 4096. 