### PR TITLE
Treat \stdClass as iterable

### DIFF
--- a/Zend/tests/type_declarations/iterable_001.phpt
+++ b/Zend/tests/type_declarations/iterable_001.phpt
@@ -16,6 +16,7 @@ function gen() {
 test([1, 2, 3]);
 test(gen());
 test(new ArrayIterator([1, 2, 3]));
+test((object) [1]);
 
 try {
     test(1);
@@ -43,5 +44,9 @@ object(ArrayIterator)#1 (1) {
     [2]=>
     int(3)
   }
+}
+object(stdClass)#1 (1) {
+  ["0"]=>
+  int(1)
 }
 Argument 1 passed to test() must be iterable, int given, called in %s on line %d

--- a/Zend/tests/type_declarations/iterable_003.phpt
+++ b/Zend/tests/type_declarations/iterable_003.phpt
@@ -9,6 +9,9 @@ function foo(): iterable {
 function bar(): iterable {
 	return (function () { yield; })();
 }
+function stdClass(): iterable {
+	return (object) [];
+}
 
 function baz(): iterable {
     return 1;
@@ -16,6 +19,7 @@ function baz(): iterable {
 
 var_dump(foo());
 var_dump(bar());
+var_dump(stdClass());
 
 try {
     baz();
@@ -28,5 +32,7 @@ try {
 array(0) {
 }
 object(Generator)#2 (0) {
+}
+object(stdClass)#2 (0) {
 }
 Return value of baz() must be iterable, int returned

--- a/Zend/tests/type_declarations/iterable_006.phpt
+++ b/Zend/tests/type_declarations/iterable_006.phpt
@@ -1,0 +1,21 @@
+--TEST--
+iterable type#006 - Iterating stdClass by reference
+--FILE--
+<?php
+
+$test = (object) ["one" => 1, "two" => 2];
+
+foreach ($test as &$value) {
+   ++$value;
+}
+unset($value);
+
+var_dump($test);
+
+--EXPECT--
+ object(stdClass)#1 (2) {
+  ["one"]=>
+  int(2)
+  ["two"]=>
+  int(3)
+}

--- a/ext/standard/tests/general_functions/is_iterable.phpt
+++ b/ext/standard/tests/general_functions/is_iterable.phpt
@@ -12,7 +12,9 @@ var_dump(is_iterable(new ArrayIterator([1, 2, 3])));
 var_dump(is_iterable(gen()));
 var_dump(is_iterable(1));
 var_dump(is_iterable(3.14));
+var_dump(is_iterable(new DateTime));
 var_dump(is_iterable(new stdClass()));
+var_dump(is_iterable(new class extends stdClass {}));
 
 ?>
 --EXPECT--
@@ -21,4 +23,6 @@ bool(true)
 bool(true)
 bool(false)
 bool(false)
+bool(false)
+bool(true)
 bool(false)


### PR DESCRIPTION
The `stdClass` is analogous in many ways to an array, `foreach` handles it without issue, so it is unexpected that the `iterable` type rejects this structure. This PR adds support for it

```php
function iter(iterable $items)
{
    foreach ($items as $key => $item) {
        echo "[{$key}] = '{$item}'" . PHP_EOL;
    }
}

$result = json_decode('{"one": "1", "two": "2"}');
iter($result);
```

This replaces #3382, I'll be drafting an RFC once the list is a little quieter