### PR TITLE
Enable default escape for pg_insert()/pg_select()/pg_update()/pg_delete()

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -6710,7 +6710,7 @@ PHP_FUNCTION(pg_insert)
 	zval *pgsql_link, *values;
 	char *table;
 	size_t table_len;
-	zend_ulong option = PGSQL_DML_EXEC, return_sql;
+	zend_ulong option = PGSQL_DML_EXEC | PSQL_DML_ESCAPE, return_sql;
 	PGconn *pg_link;
 	PGresult *pg_result;
 	ExecStatusType status;
@@ -6924,7 +6924,7 @@ PHP_FUNCTION(pg_update)
 	zval *pgsql_link, *values, *ids;
 	char *table;
 	size_t table_len;
-	zend_ulong option =  PGSQL_DML_EXEC;
+	zend_ulong option =  PGSQL_DML_EXEC | PSQL_DML_ESCAPE;
 	PGconn *pg_link;
 	zend_string *sql = NULL;
 	int argc = ZEND_NUM_ARGS();
@@ -7016,7 +7016,7 @@ PHP_FUNCTION(pg_delete)
 	zval *pgsql_link, *ids;
 	char *table;
 	size_t table_len;
-	zend_ulong option = PGSQL_DML_EXEC;
+	zend_ulong option = PGSQL_DML_EXEC | PSQL_DML_ESCAPE;
 	PGconn *pg_link;
 	zend_string *sql;
 	int argc = ZEND_NUM_ARGS();
@@ -7156,7 +7156,7 @@ PHP_FUNCTION(pg_select)
 	zval *pgsql_link, *ids;
 	char *table;
 	size_t table_len;
-	zend_ulong option = PGSQL_DML_EXEC;
+	zend_ulong option = PGSQL_DML_EXEC | PSQL_DML_ESCAPE;
 	long result_type = PGSQL_ASSOC;
 	PGconn *pg_link;
 	zend_string *sql = NULL;

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -6710,7 +6710,7 @@ PHP_FUNCTION(pg_insert)
 	zval *pgsql_link, *values;
 	char *table;
 	size_t table_len;
-	zend_ulong option = PGSQL_DML_EXEC | PSQL_DML_ESCAPE, return_sql;
+	zend_ulong option = PGSQL_DML_EXEC | PGSQL_DML_ESCAPE, return_sql;
 	PGconn *pg_link;
 	PGresult *pg_result;
 	ExecStatusType status;
@@ -6924,7 +6924,7 @@ PHP_FUNCTION(pg_update)
 	zval *pgsql_link, *values, *ids;
 	char *table;
 	size_t table_len;
-	zend_ulong option =  PGSQL_DML_EXEC | PSQL_DML_ESCAPE;
+	zend_ulong option =  PGSQL_DML_EXEC | PGSQL_DML_ESCAPE;
 	PGconn *pg_link;
 	zend_string *sql = NULL;
 	int argc = ZEND_NUM_ARGS();
@@ -7016,7 +7016,7 @@ PHP_FUNCTION(pg_delete)
 	zval *pgsql_link, *ids;
 	char *table;
 	size_t table_len;
-	zend_ulong option = PGSQL_DML_EXEC | PSQL_DML_ESCAPE;
+	zend_ulong option = PGSQL_DML_EXEC | PGSQL_DML_ESCAPE;
 	PGconn *pg_link;
 	zend_string *sql;
 	int argc = ZEND_NUM_ARGS();
@@ -7156,7 +7156,7 @@ PHP_FUNCTION(pg_select)
 	zval *pgsql_link, *ids;
 	char *table;
 	size_t table_len;
-	zend_ulong option = PGSQL_DML_EXEC | PSQL_DML_ESCAPE;
+	zend_ulong option = PGSQL_DML_EXEC | PGSQL_DML_ESCAPE;
 	long result_type = PGSQL_ASSOC;
 	PGconn *pg_link;
 	zend_string *sql = NULL;

--- a/ext/pgsql/tests/pg_delete_001.phpt
+++ b/ext/pgsql/tests/pg_delete_001.phpt
@@ -36,7 +36,7 @@ var_dump(pg_fetch_all(pg_query('SELECT * FROM foo')));
 var_dump(pg_fetch_all(pg_query('SELECT * FROM phptests.foo')));
 
 /* Inexistent */
-pg_delete($conn, 'bar', array('id' => 1, 'id2' => 2));
+pg_delete($conn, 'bar', array('id' => 1, 'id2' => 2), PGSQL_DML_EXEC);
 var_dump(pg_delete($conn, 'bar', array('id' => 1, 'id2' => 2), PGSQL_DML_STRING));
 
 pg_query('DROP TABLE foo');

--- a/ext/pgsql/tests/pg_insert_001.phpt
+++ b/ext/pgsql/tests/pg_insert_001.phpt
@@ -13,7 +13,7 @@ pg_query('CREATE SCHEMA phptests');
 pg_query('CREATE TABLE phptests.foo (id INT, id2 INT)');
 
 
-pg_insert($conn, 'foo', array('id' => 1, 'id2' => 1));
+pg_insert($conn, 'foo', array('id' => 1, 'id2' => 1), PGSQL_DML_EXEC);
 
 pg_insert($conn, 'phptests.foo', array('id' => 1, 'id2' => 2));
 

--- a/ext/pgsql/tests/pg_insert_002.phpt
+++ b/ext/pgsql/tests/pg_insert_002.phpt
@@ -10,7 +10,7 @@ include('config.inc');
 $conn = pg_connect($conn_str);
 
 foreach (array('', '.', '..') as $table) {
-	var_dump(pg_insert($conn, $table,  array('id' => 1, 'id2' => 1)));
+	var_dump(pg_insert($conn, $table,  array('id' => 1, 'id2' => 1), PGSQL_DML_EXEC));
 }
 ?>
 Done

--- a/ext/pgsql/tests/pg_select_001.phpt
+++ b/ext/pgsql/tests/pg_select_001.phpt
@@ -20,16 +20,16 @@ pg_query('INSERT INTO phptests.bar VALUES (4,5)');
 pg_query('INSERT INTO phptests.bar VALUES (6,7)');
 
 /* Inexistent table */
-var_dump(pg_select($conn, 'foo', array('id' => 1)));
+var_dump(pg_select($conn, 'foo', array('id' => 1), PGSQL_DML_EXEC));
 
 /* Existent column */
-var_dump(pg_select($conn, 'phptests.foo', array('id' => 1)));
+var_dump(pg_select($conn, 'phptests.foo', array('id' => 1), PGSQL_DML_EXEC));
 
 /* Testing with inexistent column */
-var_dump(pg_select($conn, 'phptests.bar', array('id' => 1)));
+var_dump(pg_select($conn, 'phptests.bar', array('id' => 1), PGSQL_DML_EXEC));
 
 /* Existent column */
-var_dump(pg_select($conn, 'phptests.bar', array('id4' => 4)));
+var_dump(pg_select($conn, 'phptests.bar', array('id4' => 4), PGSQL_DML_EXEC));
 
 
 pg_query('DROP TABLE phptests.foo');


### PR DESCRIPTION
Escape was not enabled by default because it cannot work correctly when PostgreSQL array is used. PostgreSQL array has 2 forms:

 - {"abc", "xyz"}
 - ARRAY['abc', 'xyz']

Therefore unconditional escape does not work simply. First form allows unwanted element injection, latter form result in invalid SQL.

However, default escape is nicer and this issue can be documented in the manual. In the future we may add:

 - Prepared statement support for these.
 - Array value support. i.e. Convert PHP array to PostgreSQL array string.
