### PR TITLE
 improve performance for array_intersect_key (fix #60836)

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4620,8 +4620,8 @@ static void php_array_intersect_key(INTERNAL_FUNCTION_PARAMETERS, int data_compa
 		if (Z_ISREF_P(val) && Z_REFCOUNT_P(val) == 1) {
 			val = Z_REFVAL_P(val);
 		}
+		ok = 1;
 		if (p->key == NULL) {
-			ok = 1;
 			for (i = 0; i < argc; i++) {
 				if (i == arr_minNumUsed_idx) {
 					continue;
@@ -4634,19 +4634,7 @@ static void php_array_intersect_key(INTERNAL_FUNCTION_PARAMETERS, int data_compa
 					break;
 				}
 			}
-			if (ok) {
-				data = zend_hash_index_find(Z_ARRVAL(args[0]), p->h);
-				if (UNEXPECTED(Z_TYPE_P(data) == IS_INDIRECT)) {
-					data = Z_INDIRECT_P(data);
-				}
-				if (Z_ISREF_P(data) && Z_REFCOUNT_P(data) == 1) {
-					data = Z_REFVAL_P(data);
-				}
-				Z_TRY_ADDREF_P(data);
-				zend_hash_index_update(Z_ARRVAL_P(return_value), p->h, data);
-			}
 		} else {
-			ok = 1;
 			for (i = 0; i < argc; i++) {
 				if (i == arr_minNumUsed_idx) {
 					continue;
@@ -4659,15 +4647,27 @@ static void php_array_intersect_key(INTERNAL_FUNCTION_PARAMETERS, int data_compa
 					break;
 				}
 			}
-			if (ok) {
-				data = zend_hash_find_ex_ind(Z_ARRVAL(args[0]), p->key, 1);
+		}
+		if (ok) {
+			if (arr_minNumUsed_idx == 0) {
+				data = val;
+			} else {
+				if (p->key == NULL) {
+					data = zend_hash_index_find(Z_ARRVAL(args[0]), p->h);
+				} else {
+					data = zend_hash_find_ex_ind(Z_ARRVAL(args[0]), p->key, 1);
+				}
 				if (UNEXPECTED(Z_TYPE_P(data) == IS_INDIRECT)) {
 					data = Z_INDIRECT_P(data);
 				}
 				if (Z_ISREF_P(data) && Z_REFCOUNT_P(data) == 1) {
 					data = Z_REFVAL_P(data);
 				}
-				Z_TRY_ADDREF_P(data);
+			}
+			Z_TRY_ADDREF_P(data);
+			if (p->key == NULL) {
+				zend_hash_index_update(Z_ARRVAL_P(return_value), p->h, data);
+			} else {
 				zend_hash_update(Z_ARRVAL_P(return_value), p->key, data);
 			}
 		}

--- a/ext/standard/tests/array/008.phpt
+++ b/ext/standard/tests/array/008.phpt
@@ -297,12 +297,12 @@ array(11) {
 }
 array_intersect_assoc($a,$b);
 array(5) {
+  [7]=>
+  int(18)
   ["f"]=>
   int(5)
   ["gate"]=>
   string(3) "web"
-  [7]=>
-  int(18)
   [11]=>
   int(42)
   ["som3"]=>

--- a/ext/standard/tests/array/008.phpt
+++ b/ext/standard/tests/array/008.phpt
@@ -299,12 +299,12 @@ array_intersect_assoc($a,$b);
 array(5) {
   [7]=>
   int(18)
-  ["f"]=>
-  int(5)
-  ["gate"]=>
-  string(3) "web"
   [11]=>
   int(42)
   ["som3"]=>
   string(4) "some"
+  ["f"]=>
+  int(5)
+  ["gate"]=>
+  string(3) "web"
 }

--- a/ext/standard/tests/array/array_intersect_assoc_variation8.phpt
+++ b/ext/standard/tests/array/array_intersect_assoc_variation8.phpt
@@ -190,23 +190,23 @@ array(2) {
 }
 -- Iteration 11 --
 array(4) {
-  ["heredoc"]=>
-  string(11) "Hello world"
+  [222]=>
+  string(5) "fruit"
   ["resource"]=>
   resource(%d) of type (stream)
   ["int"]=>
   int(133)
-  [222]=>
-  string(5) "fruit"
+  ["heredoc"]=>
+  string(11) "Hello world"
 }
 array(4) {
-  ["heredoc"]=>
-  string(11) "Hello world"
+  [222]=>
+  string(5) "fruit"
   ["resource"]=>
   resource(%d) of type (stream)
   ["int"]=>
   int(133)
-  [222]=>
-  string(5) "fruit"
+  ["heredoc"]=>
+  string(11) "Hello world"
 }
 Done

--- a/ext/standard/tests/array/array_intersect_key_variation6.phpt
+++ b/ext/standard/tests/array/array_intersect_key_variation6.phpt
@@ -23,10 +23,10 @@ var_dump( array_intersect_key($boolean_indx_array,$input_array ) );
 
 -- Testing array_intersect_key() function with boolean indexed array --
 array(2) {
-  [0]=>
-  string(1) "0"
   [1]=>
   string(1) "1"
+  [0]=>
+  string(1) "0"
 }
 array(2) {
   [1]=>


### PR DESCRIPTION
This pr improves performance for array_intersect_key/array_uintersect_assoc/array_intersect_assoc. The idea is very simple, using the smallest array, rather than the first array, as ground when doing comparison. 

I did a simple [benchmark](https://gist.github.com/jhdxr/181b1d6ae1b908d132e2e8ebba7fa21e),
original implement:
```
[jhdxr@localhost cli]$ ./php test.php 
test1              2.780
test2              4.222
```
this PR:
```
[jhdxr@localhost cli]$ ./php test.php 
test1              2.841
test2              0.000
```
test1 is the case that all arrays have same size, and test2 is a very large array vs empty array.

some detail explanations:
For array_intersect_key, the original implement will keep the value from first array if there are array with same key but different values. Let's say,
```php
$arr1 = ['a'=>1, 'b'=>2, 'c'=>3, 'd'=>4];
$arr2 = ['e'=>5, 'c'=>6, 'a'=>8];
var_dump(array_intersect_key($arr1, $arr2));
/*
output:
array(2) {
  ["a"]=>
  int(1)
  ["c"]=>
  int(3)
}
*/
```
this is why L4650 to L4671 exists.

however, the original implement also keep the order of the keys in the results list as it is in first array. but since this PR use the smallest array as ground, the order may be different. for the example above, the result will be 
```
array(2) {
  ["c"]=>
  int(3)
  ["a"]=>
  int(1)
}
```
I checked our document [1](https://secure.php.net/manual/en/function.array-intersect-key.php), [2](https://secure.php.net/manual/en/function.array-uintersect-assoc.php) and [3](https://secure.php.net/manual/en/function.array-intersect-assoc.php). we didn't mentioned the order will be kept, and intersect should be a operations performed on set, which order doesn't make sense here. so IMHO this BC is ok for a new release, it's also why I target master branch.