### PR TITLE
Add methods DateTime::createFrom and DateTimeImmutable::createFrom

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2916,9 +2916,9 @@ PHP_METHOD(DateTimeImmutable, createFrom)
 	php_date_obj *new_obj = NULL;
 	php_date_obj *old_obj = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &datetime_object, date_ce_interface) == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJECT_OF_CLASS(datetime_object, date_ce_interface)
+	ZEND_PARSE_PARAMETERS_END();
 
 	php_date_instantiate(date_ce_immutable, return_value);
 	old_obj = Z_PHPDATE_P(datetime_object);

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -319,6 +319,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_date_method_create_from_mutable, 0, 0, 1)
 	ZEND_ARG_INFO(0, DateTime)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_date_method_create_from, 0, 0, 1)
+	ZEND_ARG_INFO(0, DateTimeInterface)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_timezone_open, 0, 0, 1)
 	ZEND_ARG_INFO(0, timezone)
 ZEND_END_ARG_INFO()
@@ -521,6 +525,7 @@ static const zend_function_entry date_funcs_immutable[] = {
 	PHP_ME(DateTimeImmutable, setISODate,    arginfo_date_method_isodate_set, 0)
 	PHP_ME(DateTimeImmutable, setTimestamp,  arginfo_date_method_timestamp_set, 0)
 	PHP_ME(DateTimeImmutable, createFromMutable, arginfo_date_method_create_from_mutable, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateTimeImmutable, createFrom       , arginfo_date_method_create_from, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_FE_END
 };
 
@@ -2899,6 +2904,34 @@ PHP_METHOD(DateTimeImmutable, createFromMutable)
 	new_obj = Z_PHPDATE_P(return_value);
 
 	new_obj->time = timelib_time_clone(old_obj->time);
+}
+/* }}} */
+
+/* {{{ proto DateTimeImmutable::createFrom(DateTimeInterface object)
+   Creates new DateTimeImmutable object from an existing DateTimeInterface object.
+*/
+PHP_METHOD(DateTimeImmutable, createFrom)
+{
+	zval *datetime_object = NULL;
+	php_date_obj *new_obj = NULL;
+	php_date_obj *old_obj = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &datetime_object, date_ce_interface) == FAILURE) {
+		return;
+	}
+
+	php_date_instantiate(date_ce_immutable, return_value);
+	old_obj = Z_PHPDATE_P(datetime_object);
+	new_obj = Z_PHPDATE_P(return_value);
+
+	new_obj->time = timelib_time_ctor();
+	*new_obj->time = *old_obj->time;
+	if (old_obj->time->tz_abbr) {
+		new_obj->time->tz_abbr = timelib_strdup(old_obj->time->tz_abbr);
+	}
+	if (old_obj->time->tz_info) {
+		new_obj->time->tz_info = old_obj->time->tz_info;
+	}
 }
 /* }}} */
 

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -487,6 +487,7 @@ static const zend_function_entry date_funcs_date[] = {
 	PHP_ME(DateTime,			__wakeup,			NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(DateTime,			__set_state,		arginfo_date_set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(DateTime,			createFromImmutable,	arginfo_date_method_create_from_immutable, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(DateTime,			createFrom,			arginfo_date_method_create_from, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(createFromFormat, date_create_from_format,	arginfo_date_create_from_format, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(getLastErrors, date_get_last_errors,	arginfo_date_get_last_errors, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME_MAPPING(format,		date_format,		arginfo_date_method_format, 0)
@@ -2900,6 +2901,26 @@ PHP_METHOD(DateTimeImmutable, createFromMutable)
 	ZEND_PARSE_PARAMETERS_END();
 
 	php_date_instantiate(date_ce_immutable, return_value);
+	old_obj = Z_PHPDATE_P(datetime_object);
+	new_obj = Z_PHPDATE_P(return_value);
+
+	new_obj->time = timelib_time_clone(old_obj->time);
+}
+/* }}} */
+/* {{{ proto DateTime::createFrom(DateTimeInterface object)
+   Creates new DateTime object from an existing DateTimeInterface object.
+*/
+PHP_METHOD(DateTime, createFrom)
+{
+	zval *datetime_object = NULL;
+	php_date_obj *new_obj = NULL;
+	php_date_obj *old_obj = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJECT_OF_CLASS(datetime_object, date_ce_interface)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_date_instantiate(date_ce_date, return_value);
 	old_obj = Z_PHPDATE_P(datetime_object);
 	new_obj = Z_PHPDATE_P(return_value);
 

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2924,14 +2924,7 @@ PHP_METHOD(DateTimeImmutable, createFrom)
 	old_obj = Z_PHPDATE_P(datetime_object);
 	new_obj = Z_PHPDATE_P(return_value);
 
-	new_obj->time = timelib_time_ctor();
-	*new_obj->time = *old_obj->time;
-	if (old_obj->time->tz_abbr) {
-		new_obj->time->tz_abbr = timelib_strdup(old_obj->time->tz_abbr);
-	}
-	if (old_obj->time->tz_info) {
-		new_obj->time->tz_info = old_obj->time->tz_info;
-	}
+	new_obj->time = timelib_time_clone(old_obj->time);
 }
 /* }}} */
 

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -54,6 +54,7 @@ PHP_METHOD(DateTime, __construct);
 PHP_METHOD(DateTime, __wakeup);
 PHP_METHOD(DateTime, __set_state);
 PHP_METHOD(DateTime, createFromImmutable);
+PHP_METHOD(DateTime, createFrom);
 PHP_FUNCTION(date_create);
 PHP_FUNCTION(date_create_immutable);
 PHP_FUNCTION(date_create_from_format);

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -87,6 +87,7 @@ PHP_METHOD(DateTimeImmutable, setDate);
 PHP_METHOD(DateTimeImmutable, setISODate);
 PHP_METHOD(DateTimeImmutable, setTimestamp);
 PHP_METHOD(DateTimeImmutable, createFromMutable);
+PHP_METHOD(DateTimeImmutable, createFrom);
 
 PHP_METHOD(DateTimeZone, __construct);
 PHP_METHOD(DateTimeZone, __wakeup);

--- a/ext/date/tests/DateTimeImmutable_createFrom.phpt
+++ b/ext/date/tests/DateTimeImmutable_createFrom.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Tests for DateTimeImmutable::createFrom
+--INI--
+date.timezone=Europe/London
+--FILE--
+<?php
+$current = "2014-03-02 16:24:08";
+
+$i = DateTimeImmutable::createFrom( date_create( $current ) );
+var_dump( $i );
+
+$i = DateTimeImmutable::createFrom( date_create_immutable( $current ) );
+var_dump( $i );
+?>
+--EXPECTF--
+object(DateTimeImmutable)#%d (3) {
+  ["date"]=>
+  string(26) "2014-03-02 16:24:08.000000"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(13) "Europe/London"
+}
+object(DateTimeImmutable)#%d (3) {
+  ["date"]=>
+  string(26) "2014-03-02 16:24:08.000000"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(13) "Europe/London"
+}

--- a/ext/date/tests/DateTime_createFrom.phpt
+++ b/ext/date/tests/DateTime_createFrom.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Tests for DateTime::createFrom
+--INI--
+date.timezone=Europe/London
+--FILE--
+<?php
+$current = "2014-03-02 16:24:08";
+
+$i = DateTime::createFrom( date_create( $current ) );
+var_dump( $i );
+
+$i = DateTime::createFrom( date_create_immutable( $current ) );
+var_dump( $i );
+?>
+--EXPECTF--
+object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "2014-03-02 16:24:08.000000"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(13) "Europe/London"
+}
+object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "2014-03-02 16:24:08.000000"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(13) "Europe/London"
+}

--- a/ext/date/tests/DateTime_verify.phpt
+++ b/ext/date/tests/DateTime_verify.phpt
@@ -32,7 +32,7 @@ object(ReflectionClass)#%d (1) {
   string(8) "DateTime"
 }
 ..and get names of all its methods
-array(19) {
+array(20) {
   [0]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
@@ -64,102 +64,109 @@ array(19) {
   [4]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(16) "createFromFormat"
+    string(10) "createFrom"
     ["class"]=>
     string(8) "DateTime"
   }
   [5]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(13) "getLastErrors"
+    string(16) "createFromFormat"
     ["class"]=>
     string(8) "DateTime"
   }
   [6]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(6) "format"
+    string(13) "getLastErrors"
     ["class"]=>
     string(8) "DateTime"
   }
   [7]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(6) "modify"
+    string(6) "format"
     ["class"]=>
     string(8) "DateTime"
   }
   [8]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(3) "add"
+    string(6) "modify"
     ["class"]=>
     string(8) "DateTime"
   }
   [9]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(3) "sub"
+    string(3) "add"
     ["class"]=>
     string(8) "DateTime"
   }
   [10]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(11) "getTimezone"
+    string(3) "sub"
     ["class"]=>
     string(8) "DateTime"
   }
   [11]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(11) "setTimezone"
+    string(11) "getTimezone"
     ["class"]=>
     string(8) "DateTime"
   }
   [12]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(9) "getOffset"
+    string(11) "setTimezone"
     ["class"]=>
     string(8) "DateTime"
   }
   [13]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(7) "setTime"
+    string(9) "getOffset"
     ["class"]=>
     string(8) "DateTime"
   }
   [14]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(7) "setDate"
+    string(7) "setTime"
     ["class"]=>
     string(8) "DateTime"
   }
   [15]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(10) "setISODate"
+    string(7) "setDate"
     ["class"]=>
     string(8) "DateTime"
   }
   [16]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(12) "setTimestamp"
+    string(10) "setISODate"
     ["class"]=>
     string(8) "DateTime"
   }
   [17]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
-    string(12) "getTimestamp"
+    string(12) "setTimestamp"
     ["class"]=>
     string(8) "DateTime"
   }
   [18]=>
+  object(ReflectionMethod)#%d (2) {
+    ["name"]=>
+    string(12) "getTimestamp"
+    ["class"]=>
+    string(8) "DateTime"
+  }
+  [19]=>
   object(ReflectionMethod)#%d (2) {
     ["name"]=>
     string(4) "diff"


### PR DESCRIPTION
I like to write methods that are liberal and will accept a `DateTimeInterface`, but quite often I explicitly want to work with the input as instances of `DateTimeImmutable`. The existing `DateTimeImmutable::createFromMutable` method doesn't really help me much here, so I figured we could just have a `createFrom` method. I added a corresponding `DateTime::createFrom` for consistency.

 ``` php
<?php
 // We want to be liberal in what we accept
function foo(DateTimeInterface $input) {

    // but for our processing we want $input to be immutable

    // Currently
    $input = $input instanceof DateTimeImmutable
        ? $input
        : DateTimeImmutable::createFromMutable($input);

    // Proposed DateTimeImmutable::createFrom(DateTimeInterface $input)
    $input = DateTimeImmutable::createFrom($input);

    // ...
}
```

I'm not overly familiar with php internals, but I cobbled this patch together. I'm also not too sure if new methods like this require an RFC. An RFC seems a little overkill, but will look to put one together if needs be.