### PR TITLE
Use __cpuid_count() from cpuid.h instead of custom assembly

### DIFF
--- a/Zend/zend_cpuinfo.c
+++ b/Zend/zend_cpuinfo.c
@@ -29,12 +29,9 @@ typedef struct _zend_cpu_info {
 static zend_cpu_info cpuinfo = {0};
 
 #if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+#include <cpuid.h>
 static void __zend_cpuid(uint32_t func, uint32_t subfunc, zend_cpu_info *cpuinfo) {
-	__asm__ __volatile__ (
-		"cpuid"
-		: "=a"(cpuinfo->eax), "=b"(cpuinfo->ebx), "=c"(cpuinfo->ecx), "=d"(cpuinfo->edx)
-		: "a"(func), "c"(subfunc)
-	);
+	__cpuid_count(func, subfunc, cpuinfo->eax, cpuinfo->ebx, cpuinfo->ecx, cpuinfo->edx);
 }
 #elif defined(ZEND_WIN32)
 # include <intrin.h>


### PR DESCRIPTION
While reviewing while PHP 7.3 fails to build on Debian Jessie i386 (yeah, buggy gcc), I changed the custom assembly (that doesn't have to be volatile anyway) to use `__cpuid_count()` from `#include <cpuid.h>` (provided both by GCC and Clang).