### PR TITLE
Create and expose php_sys_symlink() and php_sys_link()

### DIFF
--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -241,6 +241,60 @@ CWD_API ssize_t php_sys_readlink(const char *link, char *target, size_t target_l
 }
 /* }}} */
 
+CWD_API int php_sys_symlink(const char *target, const char *link) /* {{{ */
+{
+	DWORD attr;
+	wchar_t *dstw, *srcw;
+	BOOLEAN ret;
+
+	dstw = php_win32_ioutil_any_to_w(target);
+	if (!dstw) {
+		return -1;
+	}
+	if ((attr = GetFileAttributesW(dstw)) == INVALID_FILE_ATTRIBUTES) {
+		free(dstw);
+		return -1;
+	}
+
+	srcw = php_win32_ioutil_any_to_w(link);
+	if (!srcw) {
+		free(dstw);
+		return -1;
+	}
+
+	ret = CreateSymbolicLinkW(srcw, dstw, (attr & FILE_ATTRIBUTE_DIRECTORY ? 1 : 0));
+
+	free(dstw);
+	free(srcw);
+
+	return ret ? 0 : -1;
+}
+/* }}} */
+
+CWD_API int php_sys_link(const char *target, const char *link) /* {{{ */
+{
+	wchar_t *dstw, *srcw;
+	BOOL ret;
+
+	dstw = php_win32_ioutil_any_to_w(target);
+	if (!dstw) {
+		return -1;
+	}
+	srcw = php_win32_ioutil_any_to_w(link);
+	if (!srcw) {
+		free(dstw);
+		return -1;
+	}
+
+	ret = CreateHardLinkW(dstw, srcw, NULL);
+
+	free(dstw);
+	free(srcw);
+
+	return ret ? 0 : -1;
+}
+/* }}} */
+
 CWD_API int php_sys_stat_ex(const char *path, zend_stat_t *buf, int lstat) /* {{{ */
 {
 	WIN32_FILE_ATTRIBUTE_DATA data;

--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -241,60 +241,6 @@ CWD_API ssize_t php_sys_readlink(const char *link, char *target, size_t target_l
 }
 /* }}} */
 
-CWD_API int php_sys_symlink(const char *target, const char *link) /* {{{ */
-{
-	DWORD attr;
-	wchar_t *dstw, *srcw;
-	BOOLEAN ret;
-
-	dstw = php_win32_ioutil_any_to_w(target);
-	if (!dstw) {
-		return -1;
-	}
-	if ((attr = GetFileAttributesW(dstw)) == INVALID_FILE_ATTRIBUTES) {
-		free(dstw);
-		return -1;
-	}
-
-	srcw = php_win32_ioutil_any_to_w(link);
-	if (!srcw) {
-		free(dstw);
-		return -1;
-	}
-
-	ret = CreateSymbolicLinkW(srcw, dstw, (attr & FILE_ATTRIBUTE_DIRECTORY ? 1 : 0));
-
-	free(dstw);
-	free(srcw);
-
-	return ret ? 0 : -1;
-}
-/* }}} */
-
-CWD_API int php_sys_link(const char *target, const char *link) /* {{{ */
-{
-	wchar_t *dstw, *srcw;
-	BOOL ret;
-
-	dstw = php_win32_ioutil_any_to_w(target);
-	if (!dstw) {
-		return -1;
-	}
-	srcw = php_win32_ioutil_any_to_w(link);
-	if (!srcw) {
-		free(dstw);
-		return -1;
-	}
-
-	ret = CreateHardLinkW(dstw, srcw, NULL);
-
-	free(dstw);
-	free(srcw);
-
-	return ret ? 0 : -1;
-}
-/* }}} */
-
 CWD_API int php_sys_stat_ex(const char *path, zend_stat_t *buf, int lstat) /* {{{ */
 {
 	WIN32_FILE_ATTRIBUTE_DATA data;

--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -122,8 +122,8 @@ CWD_API int php_sys_stat_ex(const char *path, zend_stat_t *buf, int lstat);
 # define php_sys_stat(path, buf) php_sys_stat_ex(path, buf, 0)
 # define php_sys_lstat(path, buf) php_sys_stat_ex(path, buf, 1)
 CWD_API ssize_t php_sys_readlink(const char *link, char *target, size_t target_len);
-CWD_API int php_sys_symlink(const char *target, const char *link);
-CWD_API int php_sys_link(const char *target, const char *link);
+# define php_sys_symlink php_win32_ioutil_symlink
+# define php_sys_link php_win32_ioutil_link
 #else
 # define php_sys_stat stat
 # define php_sys_lstat lstat

--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -122,11 +122,15 @@ CWD_API int php_sys_stat_ex(const char *path, zend_stat_t *buf, int lstat);
 # define php_sys_stat(path, buf) php_sys_stat_ex(path, buf, 0)
 # define php_sys_lstat(path, buf) php_sys_stat_ex(path, buf, 1)
 CWD_API ssize_t php_sys_readlink(const char *link, char *target, size_t target_len);
+CWD_API int php_sys_symlink(const char *target, const char *link);
+CWD_API int php_sys_link(const char *target, const char *link);
 #else
 # define php_sys_stat stat
 # define php_sys_lstat lstat
 # ifdef HAVE_SYMLINK
 # define php_sys_readlink(link, target, target_len) readlink(link, target, target_len)
+# define php_sys_symlink(target, link) symlink(target, link)
+# define php_sys_link(target, link) link(target, link)
 # endif
 #endif
 

--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -129,8 +129,8 @@ CWD_API int php_sys_link(const char *target, const char *link);
 # define php_sys_lstat lstat
 # ifdef HAVE_SYMLINK
 # define php_sys_readlink(link, target, target_len) readlink(link, target, target_len)
-# define php_sys_symlink(target, link) symlink(target, link)
-# define php_sys_link(target, link) link(target, link)
+# define php_sys_symlink symlink
+# define php_sys_link link
 # endif
 #endif
 

--- a/ext/standard/link.c
+++ b/ext/standard/link.c
@@ -162,7 +162,7 @@ PHP_FUNCTION(symlink)
 	/* For the source, an expanded path must be used (in ZTS an other thread could have changed the CWD).
 	 * For the target the exact string given by the user must be used, relative or not, existing or not.
 	 * The target is relative to the link itself, not to the CWD. */
-	ret = symlink(topath, source_p);
+	ret = php_sys_symlink(topath, source_p);
 
 	if (ret == -1) {
 		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
@@ -209,9 +209,9 @@ PHP_FUNCTION(link)
 	}
 
 #ifndef ZTS
-	ret = link(topath, frompath);
+	ret = php_sys_link(topath, frompath);
 #else
-	ret = link(dest_p, source_p);
+	ret = php_sys_link(dest_p, source_p);
 #endif
 	if (ret == -1) {
 		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));

--- a/ext/standard/link_win32.c
+++ b/ext/standard/link_win32.c
@@ -184,7 +184,6 @@ PHP_FUNCTION(link)
 	int ret;
 	char source_p[MAXPATHLEN];
 	char dest_p[MAXPATHLEN];
-	wchar_t *dstw, *srcw;
 
 	/*First argument to link function is the target and hence should go to frompath
 	  Second argument to link function is the link itself and hence should go to topath */

--- a/ext/standard/link_win32.c
+++ b/ext/standard/link_win32.c
@@ -167,7 +167,7 @@ PHP_FUNCTION(symlink)
 	ret = php_sys_symlink(topath, source_p);
 
 	if (ret == -1) {
-		php_error_docref(NULL, E_WARNING, "Cannot create symlink, error code(%d)", GetLastError());
+		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
 		RETURN_FALSE;
 	}
 
@@ -217,7 +217,7 @@ PHP_FUNCTION(link)
 	ret = php_sys_link(dest_p, source_p);
 #endif
 	if (ret == -1) {
-		php_error_docref(NULL, E_WARNING, "Cannot create link, error code(%d)", GetLastError());
+		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/link_win32.c
+++ b/ext/standard/link_win32.c
@@ -171,9 +171,6 @@ PHP_FUNCTION(symlink)
 		RETURN_FALSE;
 	}
 
-	free(dstw);
-	free(srcw);
-
 	RETURN_TRUE;
 }
 /* }}} */

--- a/ext/standard/tests/file/rename_variation7-win32.phpt
+++ b/ext/standard/tests/file/rename_variation7-win32.phpt
@@ -26,7 +26,7 @@ var_dump(readlink($tmp_link2));
 echo "Done\n";
 ?>
 --EXPECTF--	
-Warning: symlink(): Cannot create symlink, error code(2) in %srename_variation7-win32.php on line %d
+Warning: symlink(): No such file or directory in %srename_variation7-win32.php on line %d
 
 Warning: readlink(): readlink failed to read the symbolic link (%srename_variation7-win32.php.tmp.link), error 2) in %srename_variation7-win32.php on line %d
 bool(false)

--- a/ext/standard/tests/file/rename_variation7-win32.phpt
+++ b/ext/standard/tests/file/rename_variation7-win32.phpt
@@ -26,7 +26,7 @@ var_dump(readlink($tmp_link2));
 echo "Done\n";
 ?>
 --EXPECTF--	
-Warning: symlink(): Could not fetch file information(error 2) in %srename_variation7-win32.php on line %d
+Warning: symlink(): Cannot create symlink, error code(2) in %srename_variation7-win32.php on line %d
 
 Warning: readlink(): readlink failed to read the symbolic link (%srename_variation7-win32.php.tmp.link), error 2) in %srename_variation7-win32.php on line %d
 bool(false)

--- a/win32/ioutil.c
+++ b/win32/ioutil.c
@@ -788,17 +788,33 @@ PW32IO char *realpath(const char *path, char *resolved)
 PW32IO int php_win32_ioutil_symlink_w(const wchar_t *target, const wchar_t *link)
 {/*{{{*/
 	DWORD attr;
+	BOOLEAN res;
 
 	if ((attr = GetFileAttributesW(target)) == INVALID_FILE_ATTRIBUTES) {
+		SET_ERRNO_FROM_WIN32_CODE(GetLastError());
 		return -1;
 	}
 
-	return CreateSymbolicLinkW(link, target, (attr & FILE_ATTRIBUTE_DIRECTORY ? 1 : 0)) ? 0 : -1;
+	res = CreateSymbolicLinkW(link, target, (attr & FILE_ATTRIBUTE_DIRECTORY ? 1 : 0));
+	if (!res) {
+		SET_ERRNO_FROM_WIN32_CODE(GetLastError());
+		return -1;
+	}
+
+	return 0;
 }/*}}}*/
 
 PW32IO int php_win32_ioutil_link_w(const wchar_t *target, const wchar_t *link)
 {/*{{{*/
-	return CreateHardLinkW(target, link, NULL) ? 0 : -1;
+	BOOL res;
+
+	res = CreateHardLinkW(target, link, NULL);
+	if (!res) {
+		SET_ERRNO_FROM_WIN32_CODE(GetLastError());
+		return -1;
+	}
+
+	return 0;
 }/*}}}*/
 
 /*

--- a/win32/ioutil.c
+++ b/win32/ioutil.c
@@ -785,6 +785,58 @@ PW32IO char *realpath(const char *path, char *resolved)
 	return php_win32_ioutil_realpath(path, resolved);
 }/*}}}*/
 
+PW32IO int php_win32_ioutil_symlink(const char *target, const char *link)
+{/*{{{*/
+	DWORD attr;
+	wchar_t *dstw, *srcw;
+	BOOLEAN ret;
+
+	dstw = php_win32_ioutil_any_to_w(target);
+	if (!dstw) {
+		return -1;
+	}
+	if ((attr = GetFileAttributesW(dstw)) == INVALID_FILE_ATTRIBUTES) {
+		free(dstw);
+		return -1;
+	}
+
+	srcw = php_win32_ioutil_any_to_w(link);
+	if (!srcw) {
+		free(dstw);
+		return -1;
+	}
+
+	ret = CreateSymbolicLinkW(srcw, dstw, (attr & FILE_ATTRIBUTE_DIRECTORY ? 1 : 0));
+
+	free(dstw);
+	free(srcw);
+
+	return ret ? 0 : -1;
+}/*}}}*/
+
+PW32IO int php_win32_ioutil_link(const char *target, const char *link)
+{/*{{{*/
+	wchar_t *dstw, *srcw;
+	BOOL ret;
+
+	dstw = php_win32_ioutil_any_to_w(target);
+	if (!dstw) {
+		return -1;
+	}
+	srcw = php_win32_ioutil_any_to_w(link);
+	if (!srcw) {
+		free(dstw);
+		return -1;
+	}
+
+	ret = CreateHardLinkW(dstw, srcw, NULL);
+
+	free(dstw);
+	free(srcw);
+
+	return ret ? 0 : -1;
+}/*}}}*/
+
 /*
  * Local variables:
  * tab-width: 4

--- a/win32/ioutil.c
+++ b/win32/ioutil.c
@@ -785,56 +785,20 @@ PW32IO char *realpath(const char *path, char *resolved)
 	return php_win32_ioutil_realpath(path, resolved);
 }/*}}}*/
 
-PW32IO int php_win32_ioutil_symlink(const char *target, const char *link)
+PW32IO int php_win32_ioutil_symlink_w(const wchar_t *target, const wchar_t *link)
 {/*{{{*/
 	DWORD attr;
-	wchar_t *dstw, *srcw;
-	BOOLEAN ret;
 
-	dstw = php_win32_ioutil_any_to_w(target);
-	if (!dstw) {
-		return -1;
-	}
-	if ((attr = GetFileAttributesW(dstw)) == INVALID_FILE_ATTRIBUTES) {
-		free(dstw);
+	if ((attr = GetFileAttributesW(target)) == INVALID_FILE_ATTRIBUTES) {
 		return -1;
 	}
 
-	srcw = php_win32_ioutil_any_to_w(link);
-	if (!srcw) {
-		free(dstw);
-		return -1;
-	}
-
-	ret = CreateSymbolicLinkW(srcw, dstw, (attr & FILE_ATTRIBUTE_DIRECTORY ? 1 : 0));
-
-	free(dstw);
-	free(srcw);
-
-	return ret ? 0 : -1;
+	return CreateSymbolicLinkW(link, target, (attr & FILE_ATTRIBUTE_DIRECTORY ? 1 : 0)) ? 0 : -1;
 }/*}}}*/
 
-PW32IO int php_win32_ioutil_link(const char *target, const char *link)
+PW32IO int php_win32_ioutil_link_w(const wchar_t *target, const wchar_t *link)
 {/*{{{*/
-	wchar_t *dstw, *srcw;
-	BOOL ret;
-
-	dstw = php_win32_ioutil_any_to_w(target);
-	if (!dstw) {
-		return -1;
-	}
-	srcw = php_win32_ioutil_any_to_w(link);
-	if (!srcw) {
-		free(dstw);
-		return -1;
-	}
-
-	ret = CreateHardLinkW(dstw, srcw, NULL);
-
-	free(dstw);
-	free(srcw);
-
-	return ret ? 0 : -1;
+	return CreateHardLinkW(target, link, NULL) ? 0 : -1;
 }/*}}}*/
 
 /*

--- a/win32/ioutil.h
+++ b/win32/ioutil.h
@@ -261,6 +261,8 @@ PW32IO int php_win32_ioutil_mkdir_w(const wchar_t *path, mode_t mode);
 PW32IO FILE *php_win32_ioutil_fopen_w(const wchar_t *path, const wchar_t *mode);
 PW32IO wchar_t *php_win32_ioutil_realpath_w(const wchar_t *path, wchar_t *resolved);
 PW32IO wchar_t *php_win32_ioutil_realpath_w_ex0(const wchar_t *path, wchar_t *resolved, PBY_HANDLE_FILE_INFORMATION info);
+PW32IO int php_win32_ioutil_symlink(const char *target, const char *link);
+PW32IO int php_win32_ioutil_link(const char *target, const char *link);
 
 __forceinline static int php_win32_ioutil_access(const char *path, mode_t mode)
 {/*{{{*/

--- a/win32/ioutil.h
+++ b/win32/ioutil.h
@@ -261,8 +261,8 @@ PW32IO int php_win32_ioutil_mkdir_w(const wchar_t *path, mode_t mode);
 PW32IO FILE *php_win32_ioutil_fopen_w(const wchar_t *path, const wchar_t *mode);
 PW32IO wchar_t *php_win32_ioutil_realpath_w(const wchar_t *path, wchar_t *resolved);
 PW32IO wchar_t *php_win32_ioutil_realpath_w_ex0(const wchar_t *path, wchar_t *resolved, PBY_HANDLE_FILE_INFORMATION info);
-PW32IO int php_win32_ioutil_symlink(const char *target, const char *link);
-PW32IO int php_win32_ioutil_link(const char *target, const char *link);
+PW32IO int php_win32_ioutil_symlink_w(const wchar_t *target, const wchar_t *link);
+PW32IO int php_win32_ioutil_link_w(const wchar_t *target, const wchar_t *link);
 
 __forceinline static int php_win32_ioutil_access(const char *path, mode_t mode)
 {/*{{{*/
@@ -569,6 +569,53 @@ __forceinline static int php_win32_ioutil_mkdir(const char *path, mode_t mode)
 	if (0 > ret) {
 		SET_ERRNO_FROM_WIN32_CODE(err);
 	}
+
+	return ret;
+}/*}}}*/
+
+__forceinline static int php_win32_ioutil_symlink(const char *target, const char *link)
+{/*{{{*/
+	wchar_t *targetw, *linkw;
+	int ret;
+
+	targetw = php_win32_ioutil_any_to_w(target);
+	if (!targetw) {
+		return -1;
+	}
+
+	linkw = php_win32_ioutil_any_to_w(link);
+	if (!linkw) {
+		free(targetw);
+		return -1;
+	}
+
+	ret = php_win32_ioutil_symlink_w(targetw, linkw);
+
+	free(targetw);
+	free(linkw);
+
+	return ret;
+}/*}}}*/
+
+__forceinline static int php_win32_ioutil_link(const char *target, const char *link)
+{/*{{{*/
+	wchar_t *targetw, *linkw;
+	int ret;
+
+	targetw = php_win32_ioutil_any_to_w(target);
+	if (!targetw) {
+		return -1;
+	}
+	linkw = php_win32_ioutil_any_to_w(link);
+	if (!linkw) {
+		free(targetw);
+		return -1;
+	}
+
+	ret = php_win32_ioutil_link_w(targetw, linkw);
+
+	free(targetw);
+	free(linkw);
 
 	return ret;
 }/*}}}*/

--- a/win32/ioutil.h
+++ b/win32/ioutil.h
@@ -580,12 +580,14 @@ __forceinline static int php_win32_ioutil_symlink(const char *target, const char
 
 	targetw = php_win32_ioutil_any_to_w(target);
 	if (!targetw) {
+		SET_ERRNO_FROM_WIN32_CODE(ERROR_INVALID_PARAMETER);
 		return -1;
 	}
 
 	linkw = php_win32_ioutil_any_to_w(link);
 	if (!linkw) {
 		free(targetw);
+		SET_ERRNO_FROM_WIN32_CODE(ERROR_INVALID_PARAMETER);
 		return -1;
 	}
 
@@ -604,11 +606,13 @@ __forceinline static int php_win32_ioutil_link(const char *target, const char *l
 
 	targetw = php_win32_ioutil_any_to_w(target);
 	if (!targetw) {
+		SET_ERRNO_FROM_WIN32_CODE(ERROR_INVALID_PARAMETER);
 		return -1;
 	}
 	linkw = php_win32_ioutil_any_to_w(link);
 	if (!linkw) {
 		free(targetw);
+		SET_ERRNO_FROM_WIN32_CODE(ERROR_INVALID_PARAMETER);
 		return -1;
 	}
 


### PR DESCRIPTION
On POSIX compliant systems these are just macros which map directly to
symlink() and link(), respectively.  On Windows they are implemented as
functions which try to conform as closely as possible to the POSIX
specification with regard to PHP's needs.  Actually, they have been
inlined in link_win32.c to implement PHP's symlink() and link()
functions.  It is noteworthy to mention that POSIX systems store the
error in `errno`, while on Windows `GetLastError()` has to be used to
retrieve the error (analogous to php_sys_readlink()).

Future scope: merge link.c and link_win32.c