### PR TITLE
Remove obsolete macro AC_DECL_YYTEXT

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2110,13 +2110,6 @@ dnl we only support certain flex versions
   flex_version_list="2.5.4"
    
   AC_PROG_LEX
-  if test "$LEX" = "flex"; then
-dnl AC_DECL_YYTEXT is obsolete since autoconf 2.50 and merged into AC_PROG_LEX
-dnl this is what causes that annoying "PHP_PROG_LEX is expanded from" warning with autoconf 2.50+
-dnl it should be removed once we drop support of autoconf 2.13 (if ever)
-    AC_DECL_YYTEXT
-    :
-  fi
   dnl ## Make flex scanners use const if they can, even if __STDC__ is not
   dnl ## true, for compilers like Sun's that only set __STDC__ true in
   dnl ## "limit-to-ANSI-standard" mode, not in "ANSI-compatible" mode


### PR DESCRIPTION
The macro `AC_DECL_YYTEXT` has been obsolete since Autoconf 2.50 released in 2001. Now it is included in the `AC_PROG_LEX` macro.

Autoconf news info about obsoletion:
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS

Docs:
https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html

PHP 5.4 to 7.1 require Autoconf 2.59+ version, PHP 7.2 and above require 2.64+ version, and the PHP 7.2 phpize script requires 2.59+ version which are all greater than above mentioned 2.50 version. Systems out there should well support this by now.
