### PR TITLE
Replace obsolete AC_TRY_CPP with AC_PREPROC_IFELSE

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1375,12 +1375,13 @@ main() {
     ],[
       ac_cv_what_readdir_r=POSIX
     ],[
-      AC_TRY_CPP([
+      AC_PREPROC_IFELSE([
+        AC_LANG_SOURCE([[
 #define _REENTRANT
 #include <sys/types.h>
 #include <dirent.h>
 int readdir_r(DIR *, struct dirent *);
-        ],[
+        ]])],[
           ac_cv_what_readdir_r=old-style
         ],[
           ac_cv_what_readdir_r=none


### PR DESCRIPTION
The AC_TRY_CPP macro is obsolete since Autoconf 2.50 in 2001:
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
