### PR TITLE
Remove obsolete AC_TYPE_SIGNAL

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -63,7 +63,6 @@ stdlib.h \
 dlfcn.h)
 
 AC_TYPE_SIZE_T
-AC_TYPE_SIGNAL
 
 AC_DEFUN([LIBZEND_LIBDL_CHECKS],[
 AC_CHECK_LIB(dl, dlopen, [LIBS="-ldl $LIBS"])


### PR DESCRIPTION
The `AC_TYPE_SIGNAL` macro defined the `RETSIGTYPE` based on the signal type defined in the signal.h. On pre C89 sistems (K&R C) it could be `void` or `int`. Since C89 it can be safely assumed that the signal and therefore the `RETSIGTYPE` is always `void`, so the `RETSIGTYPE` can be replaced with `void` in the code if it uses it. PHP doesn't use the `RETSIGTYPE` in current code anyway.

Refs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html