### PR TITLE
Warn on "parent" without parent at compile-time

### DIFF
--- a/Zend/tests/bug75573.phpt
+++ b/Zend/tests/bug75573.phpt
@@ -6,10 +6,6 @@ Bug #75573 (Segmentation fault in 7.1.12 and 7.0.26)
 class A
 {
 	var $_stdObject;
-	function initialize($properties = FALSE) {
-		$this->_stdObject = $properties ? (object) $properties : new stdClass();
-		parent::initialize();
-	}
 	function &__get($property)
 	{
 		if (isset($this->_stdObject->{$property})) {
@@ -31,10 +27,6 @@ class A
 
 class B extends A
 {
-	function initialize($properties = array())
-	{
-		parent::initialize($properties);
-	}
 	function &__get($property)
 	{
 		if (isset($this->settings) && isset($this->settings[$property])) {

--- a/Zend/tests/class_name_as_scalar.phpt
+++ b/Zend/tests/class_name_as_scalar.phpt
@@ -8,8 +8,11 @@ namespace Foo\Bar {
         // compile time constants
         const A = self::class;
         const B = Two::class;
+
     }
     class Two extends One {
+        const A = parent::class;
+
         public static function run() {
             var_dump(self::class); // self compile time lookup
             var_dump(static::class); // runtime lookup
@@ -18,6 +21,8 @@ namespace Foo\Bar {
         }
     }
     class Three extends Two {
+        const B = parent::class;
+
         // compile time static lookups
         public static function checkCompileTime(
             $one = self::class,

--- a/Zend/tests/class_name_as_scalar_error_002.phpt
+++ b/Zend/tests/class_name_as_scalar_error_002.phpt
@@ -10,4 +10,6 @@ namespace Foo\Bar {
 }
 ?>
 --EXPECTF--
-Fatal error: parent::class cannot be used for compile-time class name resolution in %s on line %d
+Deprecated: Cannot use "parent" without a parent class in %s on line %d
+
+Fatal error: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/class_name_as_scalar_error_004.phpt
+++ b/Zend/tests/class_name_as_scalar_error_004.phpt
@@ -10,4 +10,6 @@ namespace Foo\Bar {
 }
 ?>
 --EXPECTF--
-Fatal error: parent::class cannot be used for compile-time class name resolution in %s on line %d
+Deprecated: Cannot use "parent" without a parent class in %s on line %d
+
+Fatal error: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_01.phpt
+++ b/Zend/tests/compile_time_parent_error_01.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+class InvalidClass {
+  function method(parent $p) {}
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_02.phpt
+++ b/Zend/tests/compile_time_parent_error_02.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+class InvalidClass {
+  function method(): parent {}
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_03.phpt
+++ b/Zend/tests/compile_time_parent_error_03.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+class InvalidClass {
+  function method() {
+    echo parent::class;
+  }
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_04.phpt
+++ b/Zend/tests/compile_time_parent_error_04.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+$obj = new class() {
+  function method() {
+    echo parent::class;
+  }
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_05.phpt
+++ b/Zend/tests/compile_time_parent_error_05.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+class InvalidClass {
+  function method() {
+    $obj = new class() {
+      function method() {
+        echo parent::class;
+      }
+    };
+  }
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -69,6 +69,7 @@ struct _zend_compiler_globals {
 	zend_stack loop_var_stack;
 
 	zend_class_entry *active_class_entry;
+	zend_string *active_class_entry_parent_name;
 
 	zend_string *compiled_filename;
 


### PR DESCRIPTION
This adds a compile-time warning of level `E_STRICT` to usages of `parent` in class-scope where the class does not have a parent, e.g.

```php
class InvalidClass {
  function method() {
    echo parent::class;
  }
}
```

This currently has two test failures where the `E_STRICT` is emitted twice. I was not sure if the check was always redundant or if in some cases it isn't. I am hoping a reviewer will know better than me.

If a method definition like this is executed it generates a runtime error, so this should not be a controversial change. In PHP 8.0 we should change this from `E_STRICT` to an `E_COMPILE_ERROR`.