### PR TITLE
Replace obsolete AC_AIX with AC_USE_SYSTEM_EXTENSIONS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,7 +181,7 @@ AC_PROG_CC_C_O
 dnl Change to AC_PROG_CC_STDC when we start requiring a post-2.13 autoconf
 dnl AC_PROG_CC_STDC
 AC_PROG_CPP
-AC_AIX
+AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_LN_S
 
 dnl Support systems with system libraries in e.g. /usr/lib64


### PR DESCRIPTION
Since Autoconf 2.62 the `AC_AIX` macro has been made obsolete and should be replaced with the `AC_USE_SYSTEM_EXTENSIONS` instead.

Both macro behaviors are the same since the old one is just a wrapper around the new `AC_USE_SYSTEM_EXTENSIONS`:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/specific.m4

PHP 7.2+ and the main configure.ac script require minimum Autoconf 2.64+.

Refs:
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html