### PR TITLE
Initialize s_un (sockaddr_un) to zero before using it

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -1802,7 +1802,9 @@ PHP_FUNCTION(socket_recvfrom)
 	switch (php_sock->type) {
 		case AF_UNIX:
 			slen = sizeof(s_un);
+			memset(&s_un, 0, slen);
 			s_un.sun_family = AF_UNIX;
+
 			retval = recvfrom(php_sock->bsd_socket, ZSTR_VAL(recv_buf), arg3, arg4, (struct sockaddr *)&s_un, (socklen_t *)&slen);
 
 			if (retval < 0) {

--- a/ext/sockets/tests/bug76839.phpt
+++ b/ext/sockets/tests/bug76839.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Bug #76839: socket_recvfrom may return an invalid 'from' address on MacOS
+--SKIPIF--
+<?php
+if (strtolower(substr(PHP_OS, 0, 3)) === 'win') {
+    die('skip not valid for Windows.');
+}
+if (!extension_loaded('sockets')) {
+    die('skip sockets extension not available.');
+}
+--FILE--
+<?php
+
+// This bug only occurs when a specific portion of memory is unclean.
+// Unforunately, looping around 10 times and using random paths is the
+// best way I could manage to reproduce this problem without modifying php itself :-/
+
+for ($i = 0; $i < 10; $i++) {
+    $senderSocketPath = '/tmp/' . substr(md5(rand()), 0, rand(8, 16)) . '.sock';
+    $senderSocket = socket_create(AF_UNIX, SOCK_DGRAM, 0);
+    socket_bind($senderSocket, $senderSocketPath);
+
+    $receiverSocketPath = '/tmp/' . substr(md5(rand()), 0, rand(8, 16)) . '.sock';
+    $receiverSocket = socket_create(AF_UNIX, SOCK_DGRAM, 0);
+    socket_bind($receiverSocket, $receiverSocketPath);
+
+    // Send message from sender socket to receiver socket
+    socket_sendto($senderSocket, 'Ping!', 5, 0, $receiverSocketPath);
+
+    // Receive message on receiver socket
+    $from = '';
+    $message = '';
+    socket_recvfrom($receiverSocket, $message, 65535, 0, $from);
+    echo "Received '$message'\n";
+
+    // Respond to the sender using the 'from' address from socket_recvfrom
+    socket_sendto($receiverSocket, 'Pong!', 5, 0, $from);
+    echo "Responded to sender with 'Pong!'\n";
+
+    socket_close($receiverSocket);
+    unlink($receiverSocketPath);
+    socket_close($senderSocket);
+    unlink($senderSocketPath);
+}
+--EXPECT--
+Received 'Ping!'
+Responded to sender with 'Pong!'
+Received 'Ping!'
+Responded to sender with 'Pong!'
+Received 'Ping!'
+Responded to sender with 'Pong!'
+Received 'Ping!'
+Responded to sender with 'Pong!'
+Received 'Ping!'
+Responded to sender with 'Pong!'
+Received 'Ping!'
+Responded to sender with 'Pong!'
+Received 'Ping!'
+Responded to sender with 'Pong!'
+Received 'Ping!'
+Responded to sender with 'Pong!'
+Received 'Ping!'
+Responded to sender with 'Pong!'
+Received 'Ping!'
+Responded to sender with 'Pong!'


### PR DESCRIPTION
On MacOS 10.14 w/PHP 7.2.8, I am unable to send data between two unix datagram sockets due to a bug in PHP's `socket_recvfrom` implementation. This bug caused the path/name of the sender to come back with trailing garbage bytes at the end of the string.

This appears to be caused by a failure to initialize `struct sockaddr_un s_un;` to 0 before passing it into `recvfrom`. This pull requests simply adds a memset to set the memory to 0 first.

Sample output from my program before:
```
Received 'Ping' from '/tmp/mysockclient.sock@c�'
```
Sample output with this fix in place:
```
Received 'Ping' from '/tmp/mysockclient.sock'
```

**Note:** This script runs fine on Ubuntu 16.04 using the stock php package, so I'm assuming this bug only affects MacOS.
