### PR TITLE
Remove extra semicolons

### DIFF
--- a/Zend/tests/assert/expect_empty_stmt_bug.phpt
+++ b/Zend/tests/assert/expect_empty_stmt_bug.phpt
@@ -3,7 +3,7 @@ Empty statement in assert() shouldn't segfault
 --FILE--
 <?php
 
-assert((function () { return true;; })());
+assert((function () { return true; })());
 echo "ok";
 
 ?>

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -53,7 +53,7 @@ void init_op_array(zend_op_array *op_array, zend_uchar type, int initial_ops_siz
 	op_array->refcount = (uint32_t *) emalloc(sizeof(uint32_t));
 	*op_array->refcount = 1;
 	op_array->last = 0;
-	op_array->opcodes = emalloc(initial_ops_size * sizeof(zend_op));;
+	op_array->opcodes = emalloc(initial_ops_size * sizeof(zend_op));
 
 	op_array->last_var = 0;
 	op_array->vars = NULL;


### PR DESCRIPTION
Following 9e4d590b1982cf38f23948dff1beffd06fd9e0d3, in `Zend` folder