### PR TITLE
Remove unused PHP_PROG_LEX macro

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2100,57 +2100,6 @@ AC_DEFUN([PHP_PROG_BISON], [
 ])
 
 dnl
-dnl PHP_PROG_LEX
-dnl
-dnl Search for (f)lex and check it's version
-dnl
-AC_DEFUN([PHP_PROG_LEX], [
-dnl we only support certain flex versions
-  flex_version_list="2.5.4"
-
-  AC_PROG_LEX
-  dnl ## Make flex scanners use const if they can, even if __STDC__ is not
-  dnl ## true, for compilers like Sun's that only set __STDC__ true in
-  dnl ## "limit-to-ANSI-standard" mode, not in "ANSI-compatible" mode
-  AC_C_CONST
-  if test "$ac_cv_c_const" = "yes" ; then
-    LEX_CFLAGS="-DYY_USE_CONST"
-  fi
-
-  if test "$LEX" = "flex"; then
-    AC_CACHE_CHECK([for flex version], php_cv_flex_version, [
-      flex_version=`$LEX -V -v --version 2>/dev/null | $SED -e 's/^.* //'`
-      php_cv_flex_version=invalid
-      for flex_check_version in $flex_version_list; do
-        if test "$flex_version" = "$flex_check_version"; then
-          php_cv_flex_version="$flex_check_version (ok)"
-        fi
-      done
-    ])
-  else
-    flex_version=none
-  fi
-
-  case $php_cv_flex_version in
-    ""|invalid[)]
-      if test -f "$abs_srcdir/Zend/zend_language_scanner.c" && test -f "$abs_srcdir/Zend/zend_ini_scanner.c"; then
-        AC_MSG_WARN([flex versions supported for regeneration of the Zend/PHP parsers: $flex_version_list  (found: $flex_version)])
-      else
-        flex_msg="Supported flex versions are: $flex_version_list"
-        if test "$flex_version" = "none"; then
-          flex_msg="flex not found. flex is required to generate the Zend/PHP parsers! $flex_msg"
-        else
-          flex_msg="Found invalid flex version: $flex_version. $flex_msg"
-        fi
-        AC_MSG_ERROR([$flex_msg])
-      fi
-      LEX="exit 0;"
-      ;;
-  esac
-  PHP_SUBST(LEX)
-])
-
-dnl
 dnl PHP_PROG_RE2C
 dnl
 dnl Search for the re2c binary and check the version

--- a/build/build2.mk
+++ b/build/build2.mk
@@ -27,7 +27,7 @@ targets = $(TOUCH_FILES) configure $(config_h_in)
 PHP_AUTOCONF ?= 'autoconf'
 PHP_AUTOHEADER ?= 'autoheader'
 
-SUPPRESS_WARNINGS ?= 2>&1 | (egrep -v '(AC_TRY_RUN called without default to allow cross compiling|AC_PROG_CXXCPP was called before AC_PROG_CXX|defined in acinclude.m4 but never used|AC_PROG_LEX invoked multiple times|AC_DECL_YYTEXT is expanded from...|the top level)'||true)
+SUPPRESS_WARNINGS ?= 2>&1 | (egrep -v '(AC_TRY_RUN called without default to allow cross compiling|AC_PROG_CXXCPP was called before AC_PROG_CXX|defined in acinclude.m4 but never used)'||true)
 
 all: $(targets)
 

--- a/makedist
+++ b/makedist
@@ -85,7 +85,7 @@ for i in $LT_TARGETS; do
   fi
 done
 
-# generate some files so people don't need bison, flex and autoconf
+# generate some files so people don't need bison, re2c and autoconf
 # to install
 set -x
 ./buildconf --copy --force

--- a/sapi/phpdbg/phpdbg_parser.c
+++ b/sapi/phpdbg/phpdbg_parser.c
@@ -76,8 +76,6 @@
 /*
  * phpdbg_parser.y
  * (from php-src root)
- * flex sapi/phpdbg/dev/phpdbg_lexer.l
- * bison sapi/phpdbg/dev/phpdbg_parser.y
  */
 
 #include "phpdbg.h"

--- a/sapi/phpdbg/phpdbg_parser.y
+++ b/sapi/phpdbg/phpdbg_parser.y
@@ -3,8 +3,6 @@
 /*
  * phpdbg_parser.y
  * (from php-src root)
- * flex sapi/phpdbg/dev/phpdbg_lexer.l
- * bison sapi/phpdbg/dev/phpdbg_parser.y
  */
 
 #include "phpdbg.h"


### PR DESCRIPTION
Since PHP 5.3 flex lexer has been replaced with re2c. Commit
0f9e2b1753661afe1c0dee6982e161fcf00d349f made `PHP_PROG_LEX` macro still available for BC.

In commit df6bd506d492292ef4353b0f8da0c34eeb076be5 it was updated.

Since this macro is entirely not used in PHP source code anymore from PHP 5.3 and up, this patch removes it together with some old traces of warnings suppression and comments.