### PR TITLE
Simplify instanceof implementation

### DIFF
--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -482,7 +482,7 @@ static int zend_implement_serializable(zend_class_entry *interface, zend_class_e
 {
 	if (class_type->parent
 		&& (class_type->parent->serialize || class_type->parent->unserialize)
-		&& !instanceof_function_ex(class_type->parent, zend_ce_serializable, 1)) {
+		&& !instanceof_function(class_type->parent, zend_ce_serializable)) {
 		return FAILURE;
 	}
 	if (!class_type->serialize) {

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -834,7 +834,7 @@ ZEND_API zval *zend_std_read_dimension(zval *object, zval *offset, int type, zva
 	zend_class_entry *ce = Z_OBJCE_P(object);
 	zval tmp_offset, tmp_object;
 
-	if (EXPECTED(instanceof_function_ex(ce, zend_ce_arrayaccess, 1) != 0)) {
+	if (EXPECTED(instanceof_function(ce, zend_ce_arrayaccess) != 0)) {
 		if (offset == NULL) {
 			/* [] construct */
 			ZVAL_NULL(&tmp_offset);
@@ -883,7 +883,7 @@ ZEND_API void zend_std_write_dimension(zval *object, zval *offset, zval *value) 
 	zend_class_entry *ce = Z_OBJCE_P(object);
 	zval tmp_offset, tmp_object;
 
-	if (EXPECTED(instanceof_function_ex(ce, zend_ce_arrayaccess, 1) != 0)) {
+	if (EXPECTED(instanceof_function(ce, zend_ce_arrayaccess) != 0)) {
 		if (!offset) {
 			ZVAL_NULL(&tmp_offset);
 		} else {
@@ -905,7 +905,7 @@ ZEND_API int zend_std_has_dimension(zval *object, zval *offset, int check_empty)
 	zval retval, tmp_offset, tmp_object;
 	int result;
 
-	if (EXPECTED(instanceof_function_ex(ce, zend_ce_arrayaccess, 1) != 0)) {
+	if (EXPECTED(instanceof_function(ce, zend_ce_arrayaccess) != 0)) {
 		ZVAL_COPY_DEREF(&tmp_offset, offset);
 		ZVAL_COPY(&tmp_object, object);
 		zend_call_method_with_1_params(&tmp_object, ce, NULL, "offsetexists", &retval, &tmp_offset);
@@ -1067,7 +1067,7 @@ ZEND_API void zend_std_unset_dimension(zval *object, zval *offset) /* {{{ */
 	zend_class_entry *ce = Z_OBJCE_P(object);
 	zval tmp_offset, tmp_object;
 
-	if (instanceof_function_ex(ce, zend_ce_arrayaccess, 1)) {
+	if (instanceof_function(ce, zend_ce_arrayaccess)) {
 		ZVAL_COPY_DEREF(&tmp_offset, offset);
 		ZVAL_COPY(&tmp_object, object);
 		zend_call_method_with_1_params(&tmp_object, ce, NULL, "offsetunset", NULL, &tmp_offset);

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -66,8 +66,10 @@ ZEND_API int ZEND_FASTCALL is_not_equal_function(zval *result, zval *op1, zval *
 ZEND_API int ZEND_FASTCALL is_smaller_function(zval *result, zval *op1, zval *op2);
 ZEND_API int ZEND_FASTCALL is_smaller_or_equal_function(zval *result, zval *op1, zval *op2);
 
-ZEND_API zend_bool ZEND_FASTCALL instanceof_function_ex(const zend_class_entry *instance_ce, const zend_class_entry *ce, zend_bool interfaces_only);
 ZEND_API zend_bool ZEND_FASTCALL instanceof_function(const zend_class_entry *instance_ce, const zend_class_entry *ce);
+ZEND_API zend_bool ZEND_FASTCALL instanceof_class(const zend_class_entry *instance_ce, const zend_class_entry *class_ce);
+ZEND_API zend_bool ZEND_FASTCALL instanceof_interface(const zend_class_entry *instance_ce, const zend_class_entry *interface_ce);
+#define instanceof_function_ex(instance_ce, ce, unused) instanceof_function_ex(instance_ce, ce)
 
 /**
  * Checks whether the string "str" with length "length" is numeric. The value

--- a/ext/intl/dateformat/dateformat_helpers.cpp
+++ b/ext/intl/dateformat/dateformat_helpers.cpp
@@ -71,8 +71,7 @@ int datefmt_process_calendar_arg(zval* calendar_zv,
 		cal_int_type = Z_LVAL_P(calendar_zv);
 
 	} else if (Z_TYPE_P(calendar_zv) == IS_OBJECT &&
-			instanceof_function_ex(Z_OBJCE_P(calendar_zv),
-			Calendar_ce_ptr, 0)) {
+			instanceof_function(Z_OBJCE_P(calendar_zv), Calendar_ce_ptr)) {
 
 		cal = calendar_fetch_native_calendar(calendar_zv);
 		if (cal == NULL) {


### PR DESCRIPTION
The `instanceof_function()` implementation is confusing and inefficient, and slightly broken, though no code exists in php-src which hits the broken code path.

- The recursive depth-first search used in [`instanceof_interface()`](https://github.com/php/php-src/blob/aed3de1bc58c21fa00e3e732992ea5e64bcbe1f0/Zend/zend_operators.c#L2302) makes the code very hard to read. It is also completely superfluous, as [`zend_do_inherit_interfaces()`](https://github.com/php/php-src/blob/aed3de1bc58c21fa00e3e732992ea5e64bcbe1f0/Zend/zend_inheritance.c#L751-L762) copies the interfaces from up the tree directly on to the parent. Since more or less every run-time check for whether an object implements an interface passes through this function, changing it to a shallow scan may represent a tiny performance improvement in a codebase with a complex interface hierarchy.
- [`instanceof_interface_only()`](https://github.com/php/php-src/blob/aed3de1bc58c21fa00e3e732992ea5e64bcbe1f0/Zend/zend_operators.c#L2277) is completely broken and can never return anything other than `0`. The code path is [not hit by any tests](http://gcov.php.net/PHP_HEAD/lcov_html/Zend/zend_operators.c.gcov.php#2244). It can be removed completely.
- [`instanceof_function_ex()`](https://github.com/php/php-src/blob/aed3de1bc58c21fa00e3e732992ea5e64bcbe1f0/Zend/zend_operators.c#L2315) is superfluous - the appropriate checks are determined by the presence of the `ZEND_ACC_INTERFACE` ce flag. The only combination of arguments that would result in different behaviour would be passing a `ce` with the `ZEND_ACC_INTERFACE` flag set, and `interfaces_only = 0` - the resulting behaviour would be that the check would be identical to `instance_ce == ce`, no other values would pass the check. It is therefore highly unlikely that any external code is relying on this behaviour.

Any external code that uses `instanceof_function_ex()` should simply be changed to use `instanceof_function()`, discarding the 3rd argument.