### PR TITLE
Upgrade AX_FUNC_WHICH_GETHOSTBYNAME_R to serial 8

### DIFF
--- a/TSRM/m4/ax_func_which_gethostbyname_r.m4
+++ b/TSRM/m4/ax_func_which_gethostbyname_r.m4
@@ -1,6 +1,6 @@
-# =================================================================================
-#  http://www.gnu.org/software/autoconf-archive/ax_func_which_gethostbyname_r.html
-# =================================================================================
+# ==================================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_func_which_gethostbyname_r.html
+# ==================================================================================
 #
 # SYNOPSIS
 #
@@ -46,7 +46,7 @@
 #   Public License for more details.
 #
 #   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #   As a special exception, the respective Autoconf Macro's copyright owner
 #   gives unlimited permission to copy, distribute and modify the configure
@@ -61,7 +61,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 7
+#serial 8
 
 AC_DEFUN([AX_FUNC_WHICH_GETHOSTBYNAME_R], [
 
@@ -194,4 +194,3 @@ esac
 AC_LANG_POP
 
 ]) dnl end AC_DEFUN
-

--- a/TSRM/tsrm.m4
+++ b/TSRM/tsrm.m4
@@ -1,4 +1,4 @@
-m4_include([TSRM/m4/gethostbyname.m4])
+m4_include([TSRM/m4/ax_func_which_gethostbyname_r.m4])
 
 dnl TSRM_CHECK_GCC_ARG(ARG, ACTION-IF-FOUND, ACTION-IF-NOT_FOUND)	
 AC_DEFUN([TSRM_CHECK_GCC_ARG],[


### PR DESCRIPTION
The `AX_FUNC_WHICH_GETHOSTBYNAME_R` macro is from the Autoconf Archive. Latest version of the file has few docs changes. File is also renamed as is a pattern of other m4 Autoconf Archive files.

Refs:
- http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_func_which_gethostbyname_r.m4