### PR TITLE
Trim trailing whitespaces in build files

### DIFF
--- a/TSRM/configure.ac
+++ b/TSRM/configure.ac
@@ -11,10 +11,10 @@ AH_TOP([
 ])
 
 sinclude(tsrm.m4)
-	
+
 TSRM_BASIC_CHECKS
 TSRM_THREADS_CHECKS
-	
+
 AM_PROG_LIBTOOL
 if test "$enable_debug" != "yes"; then
   AM_SET_LIBTOOL_VARIABLE([--silent])

--- a/TSRM/tsrm.m4
+++ b/TSRM/tsrm.m4
@@ -1,6 +1,6 @@
 m4_include([TSRM/m4/gethostbyname.m4])
 
-dnl TSRM_CHECK_GCC_ARG(ARG, ACTION-IF-FOUND, ACTION-IF-NOT_FOUND)	
+dnl TSRM_CHECK_GCC_ARG(ARG, ACTION-IF-FOUND, ACTION-IF-NOT_FOUND)
 AC_DEFUN([TSRM_CHECK_GCC_ARG],[
   gcc_arg_name=[ac_cv_gcc_arg]translit($1,A-Z-,a-z_)
   AC_CACHE_CHECK([whether $CC supports $1], [ac_cv_gcc_arg]translit($1,A-Z-,a-z_), [
@@ -75,9 +75,9 @@ AC_DEFUN([TSRM_CHECK_ST],[
 sinclude(threads.m4)
 
 AC_DEFUN([TSRM_CHECK_PTHREADS],[
-		
+
 PTHREADS_CHECK
-	
+
 if test "$pthreads_working" != "yes"; then
   AC_MSG_ERROR(Your system seems to lack POSIX threads.)
 fi

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -5,10 +5,10 @@ dnl
 AC_DEFUN([LIBZEND_CHECK_INT_TYPE],[
 AC_MSG_CHECKING(for $1)
 AC_TRY_COMPILE([
-#if HAVE_SYS_TYPES_H  
+#if HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#if HAVE_INTTYPES_H  
+#if HAVE_INTTYPES_H
 #include <inttypes.h>
 #elif HAVE_STDINT_H
 #include <stdint.h>
@@ -135,7 +135,7 @@ int main()
 ], [
   AC_MSG_RESULT(no)
 ])
-	
+
 ])
 
 AC_DEFUN([LIBZEND_ENABLE_DEBUG],[
@@ -145,7 +145,7 @@ AC_ARG_ENABLE(debug,
   ZEND_DEBUG=$enableval
 ],[
   ZEND_DEBUG=no
-])  
+])
 
 ])
 
@@ -156,10 +156,10 @@ AC_ARG_ENABLE(maintainer-zts,
   ZEND_MAINTAINER_ZTS=$enableval
 ],[
   ZEND_MAINTAINER_ZTS=no
-])  
+])
 
 AC_ARG_ENABLE(inline-optimization,
-[  --disable-inline-optimization 
+[  --disable-inline-optimization
                           If building zend_execute.lo fails, try this switch],[
   ZEND_INLINE_OPTIMIZATION=$enableval
 ],[
@@ -194,7 +194,7 @@ if test "$ZEND_MAINTAINER_ZTS" = "yes"; then
   AC_DEFINE(ZTS,1,[ ])
   CFLAGS="$CFLAGS -DZTS"
   LIBZEND_CPLUSPLUS_CHECKS
-fi  
+fi
 
 changequote({,})
 if test -n "$GCC" && test "$ZEND_INLINE_OPTIMIZATION" != "yes"; then
@@ -247,7 +247,7 @@ int main()
   }
 
   fp = fopen("conftest.zend", "w");
-  fprintf(fp, "%d %d\n", ZEND_MM_ALIGNMENT, zeros);  
+  fprintf(fp, "%d %d\n", ZEND_MM_ALIGNMENT, zeros);
   fclose(fp);
 
   exit(0);
@@ -256,7 +256,7 @@ int main()
   LIBZEND_MM_ALIGN=`cat conftest.zend | cut -d ' ' -f 1`
   LIBZEND_MM_ALIGN_LOG2=`cat conftest.zend | cut -d ' ' -f 2`
   AC_DEFINE_UNQUOTED(ZEND_MM_ALIGNMENT, $LIBZEND_MM_ALIGN, [ ])
-  AC_DEFINE_UNQUOTED(ZEND_MM_ALIGNMENT_LOG2, $LIBZEND_MM_ALIGN_LOG2, [ ]) 
+  AC_DEFINE_UNQUOTED(ZEND_MM_ALIGNMENT_LOG2, $LIBZEND_MM_ALIGN_LOG2, [ ])
 ], [], [
   dnl cross-compile needs something here
   LIBZEND_MM_ALIGN=8
@@ -372,7 +372,7 @@ AC_ARG_ENABLE(zend-signals,
   ZEND_SIGNALS=$enableval
 ],[
   ZEND_SIGNALS=yes
-])  
+])
 
 AC_CHECK_FUNC(sigaction, [
 	AC_DEFINE(HAVE_SIGACTION, 1, [Whether sigaction() is available])
@@ -393,24 +393,24 @@ AC_DEFUN([LIBZEND_CPLUSPLUS_CHECKS],[
 
 ])
 
-AC_MSG_CHECKING(whether /dev/urandom exists) 
-if test -r "/dev/urandom" && test -c "/dev/urandom"; then 
+AC_MSG_CHECKING(whether /dev/urandom exists)
+if test -r "/dev/urandom" && test -c "/dev/urandom"; then
   AC_DEFINE([HAVE_DEV_URANDOM], 1, [Define if the target system has /dev/urandom device])
-  AC_MSG_RESULT(yes) 
-else 
-  AC_MSG_RESULT(no) 
+  AC_MSG_RESULT(yes)
+else
+  AC_MSG_RESULT(no)
 fi
 
-AC_MSG_CHECKING(whether /dev/arandom exists) 
-if test -r "/dev/arandom" && test -c "/dev/arandom"; then 
+AC_MSG_CHECKING(whether /dev/arandom exists)
+if test -r "/dev/arandom" && test -c "/dev/arandom"; then
   AC_DEFINE([HAVE_DEV_ARANDOM], 1, [Define if the target system has /dev/arandom device])
-  AC_MSG_RESULT(yes) 
-else 
-  AC_MSG_RESULT(no) 
-fi 
+  AC_MSG_RESULT(yes)
+else
+  AC_MSG_RESULT(no)
+fi
 
 AC_ARG_ENABLE(gcc-global-regs,
-[  --disable-gcc-global-regs 
+[  --disable-gcc-global-regs
                           whether to enable GCC global register variables],[
   ZEND_GCC_GLOBAL_REGS=$enableval
 ],[

--- a/Zend/acinclude.m4
+++ b/Zend/acinclude.m4
@@ -5,7 +5,7 @@ AC_DEFUN([LIBZEND_BISON_CHECK],[
   # min: 2.4 (i.e. 204, major * 100 + minor for easier comparison)
   bison_version_min="204"
   # non-working versions, e.g. "3.0 3.2";
-  # remove "none" when introducing the first incompatible bison version an 
+  # remove "none" when introducing the first incompatible bison version an
   # separate any following additions by spaces
   bison_version_exclude=""
 
@@ -137,7 +137,7 @@ AC_DEFUN([ZEND_CHECK_FLOAT_PRECISION],[
   else
     AC_MSG_RESULT(no)
   fi
-  
+
   AC_MSG_CHECKING([for usable fpsetprec])
   AC_TRY_LINK([
     #include <machine/ieeefp.h>


### PR DESCRIPTION
Some editors utilizing .editorconfig automatically trim whitespaces. For convenience this patch removes whitespaces in certain build files in Zend and TSRM folders.

Thanks.