### PR TITLE
Remove superfluous SKIPIF sections of always available functions

### DIFF
--- a/Zend/tests/bug21478.phpt
+++ b/Zend/tests/bug21478.phpt
@@ -1,9 +1,5 @@
 --TEST--
 Bug #21478 (Zend/zend_alloc.c :: shutdown_memory_manager produces segfault) 
---SKIPIF--
-<?php 
-	if (!function_exists('stream_filter_register')) die('skip stream_filter_register() not available');
-?>
 --FILE--
 <?php
 class debugfilter extends php_user_filter {

--- a/Zend/tests/bug36568.phpt
+++ b/Zend/tests/bug36568.phpt
@@ -1,9 +1,5 @@
 --TEST--
 Bug #36568 (memory_limit has no effect)
---SKIPIF--
-<?php 
-	if (!function_exists('memory_get_usage')) die('skip PHP is configured without memory_limit');
-?>
 --INI--
 memory_limit=16M
 --FILE--

--- a/Zend/tests/bug43450.phpt
+++ b/Zend/tests/bug43450.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Bug #43450 (Memory leak on some functions with implicit object __toString() call)
---SKIPIF--
-<?php if (!function_exists('memory_get_usage')) die('skip memory_get_usage() not installed'); ?>
 --INI--
 opcache.enable_cli=0
 --FILE--


### PR DESCRIPTION
Following 1461f8ef0d685392e544a594fbb3732a78834a1a, now for `Zend/` tests.