### PR TITLE
Fix #76688 - Disallow excessive parameters after options array

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1704,6 +1704,15 @@ static PHP_FUNCTION(session_set_cookie_params)
 		zend_string *key;
 		zval *value;
 
+		if (path) {
+			path = NULL;
+			domain = NULL;
+			secure_null = 1;
+			httponly_null = 1;
+			php_error_docref(NULL, E_WARNING, "Cannot pass arguments after the options array");
+			RETURN_FALSE;
+		}
+
 		ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(lifetime_or_options), key, value) {
 			if (key) {
 				ZVAL_DEREF(value);

--- a/ext/session/tests/session_set_cookie_params_variation7.phpt
+++ b/ext/session/tests/session_set_cookie_params_variation7.phpt
@@ -36,6 +36,10 @@ var_dump(ini_get("session.cookie_lifetime"));
 var_dump(session_set_cookie_params(["lifetime" => 42]));
 var_dump(ini_get("session.cookie_lifetime"));
 
+var_dump(ini_get("session.cookie_path"));
+var_dump(session_set_cookie_params(["path" => "newpath/"], "arg after options array"));
+var_dump(ini_get("session.cookie_path"));
+
 echo "Done";
 ob_end_flush();
 ?>
@@ -57,4 +61,9 @@ string(6) "please"
 string(1) "0"
 bool(true)
 string(2) "42"
+string(1) "/"
+
+Warning: session_set_cookie_params(): Cannot pass arguments after the options array in %s
+bool(false)
+string(1) "/"
 Done

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -206,7 +206,7 @@ PHPAPI int php_setcookie(zend_string *name, zend_string *value, time_t expires, 
 	return result;
 }
 
-static int php_head_parse_cookie_options_array(zval *options, zend_long *expires, zend_string **path, zend_string **domain, zend_bool *secure, zend_bool *httponly, zend_string **samesite) {
+static void php_head_parse_cookie_options_array(zval *options, zend_long *expires, zend_string **path, zend_string **domain, zend_bool *secure, zend_bool *httponly, zend_string **samesite) {
 	int found = 0;
 	zend_string *key;
 	zval *value;
@@ -243,10 +243,7 @@ static int php_head_parse_cookie_options_array(zval *options, zend_long *expires
 	/* Array is not empty but no valid keys were found */
 	if (found == 0 && zend_hash_num_elements(Z_ARRVAL_P(options)) > 0) {
 		php_error_docref(NULL, E_WARNING, "No valid options were found in the given array");
-		return 0;
 	}
-
-	return 1;
 }
 
 /* {{{ proto bool setcookie(string name [, string value [, int expires [, string path [, string domain [, bool secure[, bool httponly]]]]]])
@@ -273,10 +270,7 @@ PHP_FUNCTION(setcookie)
 	if (expires_or_options) {
 		if (Z_TYPE_P(expires_or_options) == IS_ARRAY) {
 			options_array = 1;
-			if (!php_head_parse_cookie_options_array(expires_or_options, &expires, &path, &domain, &secure, &httponly, &samesite)) {
-				RETVAL_FALSE;
-				goto cleanup;
-			}
+			php_head_parse_cookie_options_array(expires_or_options, &expires, &path, &domain, &secure, &httponly, &samesite);
 		} else {
 			expires = Z_LVAL_P(expires_or_options);
 		}
@@ -288,7 +282,6 @@ PHP_FUNCTION(setcookie)
 		RETVAL_FALSE;
 	}
 
-cleanup:
 	if (options_array) {
 		if (path) {
 			zend_string_release(path);
@@ -327,10 +320,7 @@ PHP_FUNCTION(setrawcookie)
 	if (expires_or_options) {
 		if (Z_TYPE_P(expires_or_options) == IS_ARRAY) {
 			options_array = 1;
-			if (!php_head_parse_cookie_options_array(expires_or_options, &expires, &path, &domain, &secure, &httponly, &samesite)) {
-				RETVAL_FALSE;
-				goto cleanup;
-			}
+			php_head_parse_cookie_options_array(expires_or_options, &expires, &path, &domain, &secure, &httponly, &samesite);
 		} else {
 			expires = Z_LVAL_P(expires_or_options);
 		}
@@ -342,7 +332,6 @@ PHP_FUNCTION(setrawcookie)
 		RETVAL_FALSE;
 	}
 
-cleanup:
 	if (options_array) {
 		if (path) {
 			zend_string_release(path);

--- a/ext/standard/tests/network/setcookie_error.phpt
+++ b/ext/standard/tests/network/setcookie_error.phpt
@@ -13,6 +13,8 @@ setcookie('name', 'value', ['unknown_key' => 'only']);
 setcookie('name2', 'value2', [0 => 'numeric_key']);
 // Unrecognized key
 setcookie('name3', 'value3', ['path' => '/path/', 'foo' => 'bar']);
+// Arguments after options array (will not be set)
+setcookie('name4', 'value4', [], "path", "domain.tld", true, true);
 
 var_dump(headers_list());
 
@@ -28,6 +30,8 @@ Warning: setcookie(): Numeric key found in the options array in %s
 Warning: setcookie(): No valid options were found in the given array in %s
 
 Warning: setcookie(): Unrecognized key 'foo' found in the options array in %s
+
+Warning: setcookie(): Cannot pass arguments after the options array in %s
 array(4) {
   [0]=>
   string(%d) "X-Powered-By: PHP/%s"

--- a/ext/standard/tests/network/setcookie_error.phpt
+++ b/ext/standard/tests/network/setcookie_error.phpt
@@ -10,9 +10,13 @@ ob_start();
 // Unrecognized key and no valid keys
 setcookie('name', 'value', ['unknown_key' => 'only']);
 // Numeric key and no valid keys
-setcookie('name', 'value', [0 => 'numeric_key']);
+setcookie('name2', 'value2', [0 => 'numeric_key']);
 // Unrecognized key
-setcookie('name', 'value', ['path' => '/path/', 'foo' => 'bar']);
+setcookie('name3', 'value3', ['path' => '/path/', 'foo' => 'bar']);
+
+var_dump(headers_list());
+
+--EXPECTHEADERS--
 
 --EXPECTF--
 Warning: setcookie(): Unrecognized key 'unknown_key' found in the options array in %s
@@ -24,3 +28,13 @@ Warning: setcookie(): Numeric key found in the options array in %s
 Warning: setcookie(): No valid options were found in the given array in %s
 
 Warning: setcookie(): Unrecognized key 'foo' found in the options array in %s
+array(4) {
+  [0]=>
+  string(%d) "X-Powered-By: PHP/%s"
+  [1]=>
+  string(22) "Set-Cookie: name=value"
+  [2]=>
+  string(24) "Set-Cookie: name2=value2"
+  [3]=>
+  string(37) "Set-Cookie: name3=value3; path=/path/"
+}


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=76688

I can create a different PR for the first commit but that's something that should also be fixed. There is no good reason to not set the cookie even if no valid option was found in the array.