### PR TITLE
Fix #76700 - Methods with altered visibility need to be added again

### DIFF
--- a/Zend/tests/traits/bug76700.phpt
+++ b/Zend/tests/traits/bug76700.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Bug #76700 (false-positive "Error: Call to protected method" when using trait aliases)
+--FILE--
+<?php
+trait T1
+{
+    protected function aa() { echo 123; }
+}
+
+trait T2
+{
+    use T1 {
+        aa as public;
+    }
+}
+
+class A
+{
+    use T1;
+}
+
+class B extends A
+{
+    use T2;
+}
+
+$b = new B();
+$b->aa();
+
+--EXPECT--
+123

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1178,8 +1178,10 @@ static void zend_add_trait_method(zend_class_entry *ce, const char *name, zend_s
 	zend_function *new_fn;
 
 	if ((existing_fn = zend_hash_find_ptr(&ce->function_table, key)) != NULL) {
-		/* if it is the same function regardless of where it is coming from, there is no conflict and we do not need to add it again */
-		if (existing_fn->op_array.opcodes == fn->op_array.opcodes) {
+		/* if it is the same function with the same visibility regardless of where it is coming from */
+		/* there is no conflict and we do not need to add it again */
+		if (existing_fn->op_array.opcodes == fn->op_array.opcodes &&
+			(existing_fn->common.fn_flags & ZEND_ACC_PPP_MASK) == (fn->common.fn_flags & ZEND_ACC_PPP_MASK)) {
 			return;
 		}
 


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=76700

This was caused by #2797 which allows the same function to be imported more than once (as it ignores duplicates). However, if there is a change in visibility, the function needs to be added again.