### PR TITLE
Make array parsing parameters error message consistency with ZPP failure

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3752,7 +3752,7 @@ static inline void php_array_merge_or_replace_wrapper(INTERNAL_FUNCTION_PARAMETE
 			zval *arg = args + i;
 
 			if (Z_TYPE_P(arg) != IS_ARRAY) {
-				php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+				php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(arg));
 				RETURN_NULL();
 			}
 		}
@@ -3781,7 +3781,7 @@ static inline void php_array_merge_or_replace_wrapper(INTERNAL_FUNCTION_PARAMETE
 			zval *arg = args + i;
 
 			if (Z_TYPE_P(arg) != IS_ARRAY) {
-				php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+				php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(arg));
 				RETURN_NULL();
 			}
 			count += zend_hash_num_elements(Z_ARRVAL_P(arg));
@@ -4639,7 +4639,7 @@ static void php_array_intersect_key(INTERNAL_FUNCTION_PARAMETERS, int data_compa
 
 	for (i = 0; i < argc; i++) {
 		if (Z_TYPE(args[i]) != IS_ARRAY) {
-			php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+			php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(&args[i]));
 			RETURN_NULL();
 		}
 	}
@@ -4810,7 +4810,7 @@ static void php_array_intersect(INTERNAL_FUNCTION_PARAMETERS, int behavior, int 
 
 	for (i = 0; i < arr_argc; i++) {
 		if (Z_TYPE(args[i]) != IS_ARRAY) {
-			php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+			php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(&args[i]));
 			arr_argc = i; /* only free up to i - 1 */
 			goto out;
 		}
@@ -5050,7 +5050,7 @@ static void php_array_diff_key(INTERNAL_FUNCTION_PARAMETERS, int data_compare_ty
 
 	for (i = 0; i < argc; i++) {
 		if (Z_TYPE(args[i]) != IS_ARRAY) {
-			php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+			php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(&args[i]));
 			RETURN_NULL();
 		}
 	}
@@ -5221,7 +5221,7 @@ static void php_array_diff(INTERNAL_FUNCTION_PARAMETERS, int behavior, int data_
 
 	for (i = 0; i < arr_argc; i++) {
 		if (Z_TYPE(args[i]) != IS_ARRAY) {
-			php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+			php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(&args[i]));
 			arr_argc = i; /* only free up to i - 1 */
 			goto out;
 		}
@@ -5398,7 +5398,7 @@ PHP_FUNCTION(array_diff)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (Z_TYPE(args[0]) != IS_ARRAY) {
-		php_error_docref(NULL, E_WARNING, "Argument #1 is not an array");
+		php_error_docref(NULL, E_WARNING, "Expected parameter 1 to be an array, %s given", zend_zval_type_name(&args[0]));
 		RETURN_NULL();
 	}
 
@@ -5406,7 +5406,7 @@ PHP_FUNCTION(array_diff)
 	if (num == 0) {
 		for (i = 1; i < argc; i++) {
 			if (Z_TYPE(args[i]) != IS_ARRAY) {
-				php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+				php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(&args[i]));
 				RETURN_NULL();
 			}
 		}
@@ -5424,7 +5424,7 @@ PHP_FUNCTION(array_diff)
 		if (!value) {
 			for (i = 1; i < argc; i++) {
 				if (Z_TYPE(args[i]) != IS_ARRAY) {
-					php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+					php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(&args[i]));
 					RETURN_NULL();
 				}
 			}
@@ -5436,7 +5436,7 @@ PHP_FUNCTION(array_diff)
 
 		for (i = 1; i < argc; i++) {
 			if (Z_TYPE(args[i]) != IS_ARRAY) {
-				php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+				php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(&args[i]));
 				RETURN_NULL();
 			}
 			if (!found) {
@@ -5466,7 +5466,7 @@ PHP_FUNCTION(array_diff)
 	num = 0;
 	for (i = 1; i < argc; i++) {
 		if (Z_TYPE(args[i]) != IS_ARRAY) {
-			php_error_docref(NULL, E_WARNING, "Argument #%d is not an array", i + 1);
+			php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 1, zend_zval_type_name(&args[i]));
 			RETURN_NULL();
 		}
 		num += zend_hash_num_elements(Z_ARRVAL(args[i]));
@@ -6117,7 +6117,7 @@ PHP_FUNCTION(array_map)
 		int ret;
 
 		if (Z_TYPE(arrays[0]) != IS_ARRAY) {
-			php_error_docref(NULL, E_WARNING, "Argument #%d should be an array", 2);
+			php_error_docref(NULL, E_WARNING, "Expected parameter 2 to be an array, %s given", zend_zval_type_name(&arrays[0]));
 			return;
 		}
 		maxlen = zend_hash_num_elements(Z_ARRVAL(arrays[0]));
@@ -6155,7 +6155,7 @@ PHP_FUNCTION(array_map)
 
 		for (i = 0; i < n_arrays; i++) {
 			if (Z_TYPE(arrays[i]) != IS_ARRAY) {
-				php_error_docref(NULL, E_WARNING, "Argument #%d should be an array", i + 2);
+				php_error_docref(NULL, E_WARNING, "Expected parameter %d to be an array, %s given", i + 2, zend_zval_type_name(&arrays[0]));
 				efree(array_pos);
 				return;
 			}

--- a/ext/standard/tests/array/array_diff_1.phpt
+++ b/ext/standard/tests/array/array_diff_1.phpt
@@ -11,5 +11,5 @@ array_diff($a, $b, $c);
 echo "OK!";
 ?>
 --EXPECTF--
-Warning: array_diff(): Argument #2 is not an array in %s
+Warning: array_diff(): Expected parameter 2 to be an array, int given in %s
 OK!

--- a/ext/standard/tests/array/array_diff_assoc_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_assoc_variation1.phpt
@@ -104,131 +104,131 @@ echo "Done";
 
 -- Iteration 1 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 19 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 22 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 23 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 -- Iteration 24 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 25 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 26 --
 
-Warning: array_diff_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_diff_assoc_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_assoc_variation2.phpt
@@ -105,131 +105,131 @@ echo "Done";
 
 -- Iteration 1 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 19 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 22 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 23 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 -- Iteration 24 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 25 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 26 --
 
-Warning: array_diff_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_assoc(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_diff_key_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_key_variation1.phpt
@@ -102,209 +102,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_diff_key_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_key_variation2.phpt
@@ -103,209 +103,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_diff_key(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_diff_key_variation3.phpt
+++ b/ext/standard/tests/array/array_diff_key_variation3.phpt
@@ -102,131 +102,131 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_diff_key(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_key(): Expected parameter 3 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_diff_uassoc_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_uassoc_variation1.phpt
@@ -114,131 +114,131 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_diff_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_diff_uassoc_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_uassoc_variation2.phpt
@@ -114,131 +114,131 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_diff_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_diff_uassoc_variation4.phpt
+++ b/ext/standard/tests/array/array_diff_uassoc_variation4.phpt
@@ -116,131 +116,131 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_diff_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_uassoc(): Expected parameter 3 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_diff_ukey_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_ukey_variation1.phpt
@@ -110,209 +110,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_diff_ukey_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_ukey_variation2.phpt
@@ -114,209 +114,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_diff_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_diff_ukey_variation3.phpt
+++ b/ext/standard/tests/array/array_diff_ukey_variation3.phpt
@@ -110,131 +110,131 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_diff_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_diff_ukey(): Expected parameter 3 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_diff_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_variation1.phpt
@@ -103,106 +103,106 @@ echo "Done";
 *** Testing array_diff() : usage variations ***
 
 -- Iteration 1 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 19 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 22 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 23 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 -- Iteration 24 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 25 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 26 --
-Warning: array_diff(): Argument #1 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_diff_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_variation2.phpt
@@ -102,106 +102,106 @@ echo "Done";
 *** Testing array_diff() : usage variations ***
 
 -- Iteration 1 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 19 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 22 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 23 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 -- Iteration 24 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 25 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 26 --
-Warning: array_diff(): Argument #2 is not an array in %s on line %d
+Warning: array_diff(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_intersect_assoc_variation1.phpt
+++ b/ext/standard/tests/array/array_intersect_assoc_variation1.phpt
@@ -112,170 +112,170 @@ echo "Done";
 *** Testing array_intersect_assoc() : Passing non-array values to $arr1 argument ***
 
 -- Iteration 1 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 19 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 -- Iteration 22 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 23 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 24 --
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_intersect_assoc_variation2.phpt
+++ b/ext/standard/tests/array/array_intersect_assoc_variation2.phpt
@@ -113,170 +113,170 @@ echo "Done";
 *** Testing array_intersect_assoc() : Passing non-array values to $arr2 argument ***
 
 -- Iteration 1 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 19 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 -- Iteration 22 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 23 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 24 --
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect_assoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_assoc(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_intersect_key_variation1.phpt
+++ b/ext/standard/tests/array/array_intersect_key_variation1.phpt
@@ -106,209 +106,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --resource var--
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_intersect_key_variation2.phpt
+++ b/ext/standard/tests/array/array_intersect_key_variation2.phpt
@@ -107,209 +107,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --resource var--
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect_key(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_intersect_key_variation3.phpt
+++ b/ext/standard/tests/array/array_intersect_key_variation3.phpt
@@ -105,131 +105,131 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --resource var--
 
-Warning: array_intersect_key(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_key(): Expected parameter 3 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_intersect_uassoc_variation1.phpt
+++ b/ext/standard/tests/array/array_intersect_uassoc_variation1.phpt
@@ -115,209 +115,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_intersect_uassoc_variation2.phpt
+++ b/ext/standard/tests/array/array_intersect_uassoc_variation2.phpt
@@ -115,209 +115,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect_uassoc(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_intersect_uassoc_variation3.phpt
+++ b/ext/standard/tests/array/array_intersect_uassoc_variation3.phpt
@@ -114,131 +114,131 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --resource--
 
-Warning: array_intersect_uassoc(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_uassoc(): Expected parameter 3 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_intersect_ukey_variation1.phpt
+++ b/ext/standard/tests/array/array_intersect_ukey_variation1.phpt
@@ -112,209 +112,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 --resource var--
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_intersect_ukey_variation2.phpt
+++ b/ext/standard/tests/array/array_intersect_ukey_variation2.phpt
@@ -112,209 +112,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 --resource var--
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_intersect_ukey_variation4.phpt
+++ b/ext/standard/tests/array/array_intersect_ukey_variation4.phpt
@@ -113,209 +113,209 @@ fclose($fp);
 
 --int 0--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 1--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int 12345--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --int -12345--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --float .5--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, float given in %s on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, bool given in %s on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string DQ--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --string SQ--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --heredoc--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, string given in %s on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, object given in %s on line %d
 NULL
 
 --undefined var--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --unset var--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 
 --resource var--
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect_ukey(): Argument #3 is not an array in %s on line %d
+Warning: array_intersect_ukey(): Expected parameter 3 to be an array, resource given in %s on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_intersect_variation1.phpt
+++ b/ext/standard/tests/array/array_intersect_variation1.phpt
@@ -111,170 +111,170 @@ echo "Done";
 *** Testing array_intersect() : Passing non-array values to $arr1 argument ***
 
 -- Iterator 1 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iterator 2 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iterator 3 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iterator 4 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iterator 5 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 6 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 7 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 8 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 9 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 10 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iterator 11 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iterator 12 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iterator 13 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iterator 14 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iterator 15 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iterator 16 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 17 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 18 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 19 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 20 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 21 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 -- Iterator 22 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iterator 23 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iterator 24 --
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #1 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_intersect_variation2.phpt
+++ b/ext/standard/tests/array/array_intersect_variation2.phpt
@@ -112,170 +112,170 @@ echo "Done";
 *** Testing array_intersect() : Passing non-array values to $arr2 argument ***
 
 -- Iterator 1 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iterator 2 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iterator 3 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iterator 4 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iterator 5 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 6 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 7 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 8 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 9 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iterator 10 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iterator 11 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iterator 12 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iterator 13 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iterator 14 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iterator 15 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iterator 16 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 17 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 18 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 19 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 20 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iterator 21 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 -- Iterator 22 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iterator 23 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iterator 24 --
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 
-Warning: array_intersect(): Argument #2 is not an array in %s on line %d
+Warning: array_intersect(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_map_variation10.phpt
+++ b/ext/standard/tests/array/array_map_variation10.phpt
@@ -85,6 +85,6 @@ array(3) {
 }
 -- passing NULL as 'arr1' --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d
+Warning: array_map(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_map_variation18.phpt
+++ b/ext/standard/tests/array/array_map_variation18.phpt
@@ -104,102 +104,102 @@ echo "Done";
 *** Testing array_map() : unexpected values for 'arr1' ***
 -- Iteration 1 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, int given in %s on line %d%d
 NULL
 -- Iteration 2 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, int given in %s on line %d%d
 NULL
 -- Iteration 3 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, int given in %s on line %d%d
 NULL
 -- Iteration 4 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, int given in %s on line %d%d
 NULL
 -- Iteration 5 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, float given in %s on line %d%d
 NULL
 -- Iteration 6 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, float given in %s on line %d%d
 NULL
 -- Iteration 7 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, float given in %s on line %d%d
 NULL
 -- Iteration 8 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, float given in %s on line %d%d
 NULL
 -- Iteration 9 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, float given in %s on line %d%d
 NULL
 -- Iteration 10 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, null given in %s on line %d%d
 NULL
 -- Iteration 11 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, null given in %s on line %d%d
 NULL
 -- Iteration 12 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, bool given in %s on line %d%d
 NULL
 -- Iteration 13 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, bool given in %s on line %d%d
 NULL
 -- Iteration 14 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, bool given in %s on line %d%d
 NULL
 -- Iteration 15 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, bool given in %s on line %d%d
 NULL
 -- Iteration 16 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, string given in %s on line %d%d
 NULL
 -- Iteration 17 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, string given in %s on line %d%d
 NULL
 -- Iteration 18 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, string given in %s on line %d%d
 NULL
 -- Iteration 19 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, string given in %s on line %d%d
 NULL
 -- Iteration 20 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, string given in %s on line %d%d
 NULL
 -- Iteration 21 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, object given in %s on line %d%d
 NULL
 -- Iteration 22 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, null given in %s on line %d%d
 NULL
 -- Iteration 23 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, null given in %s on line %d%d
 NULL
 -- Iteration 24 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, null given in %s on line %d%d
 NULL
 -- Iteration 25 --
 
-Warning: array_map(): Argument #2 should be an array in %s on line %d%d
+Warning: array_map(): Expected parameter 2 to be an array, resource given in %s on line %d%d
 NULL
 Done

--- a/ext/standard/tests/array/array_merge.phpt
+++ b/ext/standard/tests/array/array_merge.phpt
@@ -749,14 +749,14 @@ array(7) {
 Warning: array_merge() expects at least 1 parameter, 0 given in %s on line %d
 NULL
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
-Warning: array_merge(): Argument #3 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 3 to be an array, int given in %s on line %d
 NULL
 
 Notice: Undefined variable: arr4 in %s on line %d
 
-Warning: array_merge(): Argument #3 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 3 to be an array, null given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_merge_recursive_variation1.phpt
+++ b/ext/standard/tests/array/array_merge_recursive_variation1.phpt
@@ -111,193 +111,193 @@ echo "Done";
 
 -- Iteration 1 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 19 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 22 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 23 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 
 -- Iteration 24 --
 -- With default argument --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 -- With more arguments --
-Warning: array_merge_recursive(): Argument #1 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_merge_recursive_variation2.phpt
+++ b/ext/standard/tests/array/array_merge_recursive_variation2.phpt
@@ -102,98 +102,98 @@ echo "Done";
 *** Testing array_merge_recursive() : Passing non array values to $arr2 argument ***
 
 -- Iteration 1 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 19 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 22 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 23 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 
 -- Iteration 24 --
-Warning: array_merge_recursive(): Argument #2 is not an array in %s on line %d
+Warning: array_merge_recursive(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_merge_variation1.phpt
+++ b/ext/standard/tests/array/array_merge_variation1.phpt
@@ -103,87 +103,87 @@ echo "Done";
 
 -- Iteration 1 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
@@ -196,36 +196,36 @@ array(2) {
 
 -- Iteration 19 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 22 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, object given in %s on line %d
 NULL
 
 -- Iteration 23 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 24 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 25 --
 
-Warning: array_merge(): Argument #1 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 1 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_merge_variation2.phpt
+++ b/ext/standard/tests/array/array_merge_variation2.phpt
@@ -102,87 +102,87 @@ echo "Done";
 
 -- Iteration 1 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 2 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 3 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 4 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, int given in %s on line %d
 NULL
 
 -- Iteration 5 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 6 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 7 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 8 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 9 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, float given in %s on line %d
 NULL
 
 -- Iteration 10 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 11 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 12 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 13 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 14 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 15 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, bool given in %s on line %d
 NULL
 
 -- Iteration 16 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 17 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 18 --
@@ -195,36 +195,36 @@ array(2) {
 
 -- Iteration 19 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 20 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 21 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, string given in %s on line %d
 NULL
 
 -- Iteration 22 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, object given in %s on line %d
 NULL
 
 -- Iteration 23 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 24 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, null given in %s on line %d
 NULL
 
 -- Iteration 25 --
 
-Warning: array_merge(): Argument #2 is not an array in %s on line %d
+Warning: array_merge(): Expected parameter 2 to be an array, resource given in %s on line %d
 NULL
 Done

--- a/ext/standard/tests/array/array_udiff_assoc_variation1.phpt
+++ b/ext/standard/tests/array/array_udiff_assoc_variation1.phpt
@@ -102,126 +102,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, int given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, int given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, int given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, int given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, null given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, null given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, bool given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, bool given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, bool given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, bool given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, object given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, object given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, null given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_udiff_assoc(): Argument #1 is not an array in %sarray_udiff_assoc_variation1.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 1 to be an array, null given in %sarray_udiff_assoc_variation1.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_udiff_assoc_variation2.phpt
+++ b/ext/standard/tests/array/array_udiff_assoc_variation2.phpt
@@ -102,126 +102,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, int given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, int given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, int given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, int given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, null given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, null given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, bool given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, bool given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, bool given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, bool given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, object given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, object given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, null given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_udiff_assoc(): Argument #2 is not an array in %sarray_udiff_assoc_variation2.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 2 to be an array, null given in %sarray_udiff_assoc_variation2.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_udiff_assoc_variation4.phpt
+++ b/ext/standard/tests/array/array_udiff_assoc_variation4.phpt
@@ -103,126 +103,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, int given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, int given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, int given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, int given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, null given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, null given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, bool given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, bool given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, bool given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, bool given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, object given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, object given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, null given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_udiff_assoc(): Argument #3 is not an array in %sarray_udiff_assoc_variation4.php on line %d
+Warning: array_udiff_assoc(): Expected parameter 3 to be an array, null given in %sarray_udiff_assoc_variation4.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_udiff_uassoc_variation1.phpt
+++ b/ext/standard/tests/array/array_udiff_uassoc_variation1.phpt
@@ -103,126 +103,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, int given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, int given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, int given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, int given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, float given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, null given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, null given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, bool given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, bool given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, bool given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, bool given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, string given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, object given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, object given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, null given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_udiff_uassoc(): Argument #1 is not an array in %sarray_udiff_uassoc_variation1.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 1 to be an array, null given in %sarray_udiff_uassoc_variation1.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_udiff_uassoc_variation2.phpt
+++ b/ext/standard/tests/array/array_udiff_uassoc_variation2.phpt
@@ -103,126 +103,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, int given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, int given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, int given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, int given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, float given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, null given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, null given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, bool given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, bool given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, bool given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, bool given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, string given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, object given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, object given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, null given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_udiff_uassoc(): Argument #2 is not an array in %sarray_udiff_uassoc_variation2.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 2 to be an array, null given in %sarray_udiff_uassoc_variation2.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_udiff_uassoc_variation5.phpt
+++ b/ext/standard/tests/array/array_udiff_uassoc_variation5.phpt
@@ -104,126 +104,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, int given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, int given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, int given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, int given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, float given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, null given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, null given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, bool given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, bool given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, bool given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, bool given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, string given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, object given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, object given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, null given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_udiff_uassoc(): Argument #3 is not an array in %sarray_udiff_uassoc_variation5.php on line %d
+Warning: array_udiff_uassoc(): Expected parameter 3 to be an array, null given in %sarray_udiff_uassoc_variation5.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_udiff_variation1.phpt
+++ b/ext/standard/tests/array/array_udiff_variation1.phpt
@@ -102,126 +102,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, int given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, int given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, int given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, int given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, float given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, float given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, float given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, float given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, float given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, null given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, null given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, bool given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, bool given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, bool given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, bool given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, string given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, string given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, string given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, string given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, string given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, string given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, object given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, object given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, null given in %sarray_udiff_variation1.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_udiff(): Argument #1 is not an array in %sarray_udiff_variation1.php on line %d
+Warning: array_udiff(): Expected parameter 1 to be an array, null given in %sarray_udiff_variation1.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_udiff_variation2.phpt
+++ b/ext/standard/tests/array/array_udiff_variation2.phpt
@@ -102,126 +102,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, int given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, int given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, int given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, int given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, float given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, float given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, float given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, float given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, float given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, null given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, null given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, bool given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, bool given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, bool given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, bool given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, string given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, string given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, string given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, string given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, string given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, string given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, object given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, object given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, null given in %sarray_udiff_variation2.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_udiff(): Argument #2 is not an array in %sarray_udiff_variation2.php on line %d
+Warning: array_udiff(): Expected parameter 2 to be an array, null given in %sarray_udiff_variation2.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_udiff_variation4.phpt
+++ b/ext/standard/tests/array/array_udiff_variation4.phpt
@@ -103,126 +103,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, int given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, int given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, int given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, int given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, float given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, float given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, float given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, float given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, float given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, null given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, null given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, bool given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, bool given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, bool given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, bool given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, string given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, string given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, string given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, string given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, string given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, string given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, object given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, object given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, null given in %sarray_udiff_variation4.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_udiff(): Argument #3 is not an array in %sarray_udiff_variation4.php on line %d
+Warning: array_udiff(): Expected parameter 3 to be an array, null given in %sarray_udiff_variation4.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_uintersect_assoc_variation1.phpt
+++ b/ext/standard/tests/array/array_uintersect_assoc_variation1.phpt
@@ -102,126 +102,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, int given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, int given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, int given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, int given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, null given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, null given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, object given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, object given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, null given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_uintersect_assoc(): Argument #1 is not an array in %sarray_uintersect_assoc_variation1.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 1 to be an array, null given in %sarray_uintersect_assoc_variation1.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_uintersect_assoc_variation2.phpt
+++ b/ext/standard/tests/array/array_uintersect_assoc_variation2.phpt
@@ -102,126 +102,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, int given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, int given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, int given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, int given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, null given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, null given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, object given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, object given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, null given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_uintersect_assoc(): Argument #2 is not an array in %sarray_uintersect_assoc_variation2.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 2 to be an array, null given in %sarray_uintersect_assoc_variation2.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_uintersect_assoc_variation4.phpt
+++ b/ext/standard/tests/array/array_uintersect_assoc_variation4.phpt
@@ -103,126 +103,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, int given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, int given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, int given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, int given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, null given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, null given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, object given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, object given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, null given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_uintersect_assoc(): Argument #3 is not an array in %sarray_uintersect_assoc_variation4.php on line %d
+Warning: array_uintersect_assoc(): Expected parameter 3 to be an array, null given in %sarray_uintersect_assoc_variation4.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_uintersect_uassoc_variation1.phpt
+++ b/ext/standard/tests/array/array_uintersect_uassoc_variation1.phpt
@@ -103,126 +103,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, int given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, int given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, int given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, int given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, float given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, null given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, null given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, string given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, object given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, object given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, null given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_uintersect_uassoc(): Argument #1 is not an array in %sarray_uintersect_uassoc_variation1.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 1 to be an array, null given in %sarray_uintersect_uassoc_variation1.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_uintersect_uassoc_variation2.phpt
+++ b/ext/standard/tests/array/array_uintersect_uassoc_variation2.phpt
@@ -103,126 +103,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, int given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, int given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, int given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, int given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, float given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, null given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, null given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, string given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, object given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, object given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, null given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_uintersect_uassoc(): Argument #2 is not an array in %sarray_uintersect_uassoc_variation2.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 2 to be an array, null given in %sarray_uintersect_uassoc_variation2.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_uintersect_uassoc_variation5.phpt
+++ b/ext/standard/tests/array/array_uintersect_uassoc_variation5.phpt
@@ -104,126 +104,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, int given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, int given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, int given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, int given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, float given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, null given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, null given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, string given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, object given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, object given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, null given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_uintersect_uassoc(): Argument #3 is not an array in %sarray_uintersect_uassoc_variation5.php on line %d
+Warning: array_uintersect_uassoc(): Expected parameter 3 to be an array, null given in %sarray_uintersect_uassoc_variation5.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_uintersect_variation1.phpt
+++ b/ext/standard/tests/array/array_uintersect_variation1.phpt
@@ -102,126 +102,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, int given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, int given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, int given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, int given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, float given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, float given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, float given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, float given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, float given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, null given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, null given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, bool given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, string given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, string given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, string given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, string given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, string given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, string given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, object given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, object given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, null given in %sarray_uintersect_variation1.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_uintersect(): Argument #1 is not an array in %sarray_uintersect_variation1.php on line %d
+Warning: array_uintersect(): Expected parameter 1 to be an array, null given in %sarray_uintersect_variation1.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_uintersect_variation2.phpt
+++ b/ext/standard/tests/array/array_uintersect_variation2.phpt
@@ -102,126 +102,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, int given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, int given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, int given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, int given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, float given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, float given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, float given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, float given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, float given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, null given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, null given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, bool given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, string given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, string given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, string given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, string given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, string given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, string given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, object given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, object given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, null given in %sarray_uintersect_variation2.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_uintersect(): Argument #2 is not an array in %sarray_uintersect_variation2.php on line %d
+Warning: array_uintersect(): Expected parameter 2 to be an array, null given in %sarray_uintersect_variation2.php on line %d
 NULL
 ===DONE===

--- a/ext/standard/tests/array/array_uintersect_variation4.phpt
+++ b/ext/standard/tests/array/array_uintersect_variation4.phpt
@@ -103,126 +103,126 @@ foreach($inputs as $key =>$value) {
 
 --int 0--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, int given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --int 1--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, int given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --int 12345--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, int given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --int -12345--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, int given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --float 10.5--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, float given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --float -10.5--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, float given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --float 12.3456789000e10--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, float given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --float -12.3456789000e10--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, float given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --float .5--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, float given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --uppercase NULL--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, null given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --lowercase null--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, null given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --lowercase true--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --lowercase false--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --uppercase TRUE--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --uppercase FALSE--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, bool given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --empty string DQ--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, string given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --empty string SQ--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, string given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --string DQ--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, string given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --string SQ--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, string given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --mixed case string--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, string given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --heredoc--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, string given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --instance of classWithToString--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, object given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --instance of classWithoutToString--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, object given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --undefined var--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, null given in %sarray_uintersect_variation4.php on line %d
 NULL
 
 --unset var--
 
-Warning: array_uintersect(): Argument #3 is not an array in %sarray_uintersect_variation4.php on line %d
+Warning: array_uintersect(): Expected parameter 3 to be an array, null given in %sarray_uintersect_variation4.php on line %d
 NULL
 ===DONE===


### PR DESCRIPTION
As suggested in [#76674](https://bugs.php.net/bug.php?id=76674), we could improve our parsing parameters error messages for `array_` functions, by exposing what was passed, instead of an array.

I'm opening the PR for review before merging, as well asking if this should go for 7.3 or wait for 7.4 :)