### PR TITLE
Fix bug #76030 RE2C_FLAGS rarely honoured

### DIFF
--- a/ext/json/Makefile.frag
+++ b/ext/json/Makefile.frag
@@ -1,5 +1,5 @@
 $(srcdir)/json_scanner.c: $(srcdir)/json_scanner.re
-	$(RE2C) -t $(srcdir)/php_json_scanner_defs.h --no-generation-date -bci -o $@ $(srcdir)/json_scanner.re
+	$(RE2C) $(RE2C_FLAGS) -t $(srcdir)/php_json_scanner_defs.h --no-generation-date -bci -o $@ $(srcdir)/json_scanner.re
 
 $(srcdir)/json_parser.tab.c: $(srcdir)/json_parser.y
 	$(YACC) --defines -l $(srcdir)/json_parser.y -o $@

--- a/ext/pdo/Makefile.frag
+++ b/ext/pdo/Makefile.frag
@@ -9,9 +9,9 @@ PDO_HEADER_FILES= \
 $(srcdir)/pdo_sql_parser.c: $(srcdir)/pdo_sql_parser.re
 	@(cd $(top_srcdir); \
 	if test -f ./pdo_sql_parser.re; then \
-		$(RE2C) --no-generation-date -o pdo_sql_parser.c pdo_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o pdo_sql_parser.c pdo_sql_parser.re; \
 	else \
-		$(RE2C) --no-generation-date -o ext/pdo/pdo_sql_parser.c ext/pdo/pdo_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo/pdo_sql_parser.c ext/pdo/pdo_sql_parser.re; \
 	fi)
 
 install-pdo-headers:

--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -1,9 +1,9 @@
 $(srcdir)/phar_path_check.c: $(srcdir)/phar_path_check.re
 	@(cd $(top_srcdir); \
 	if test -f ./php_phar.h; then \
-		$(RE2C) --no-generation-date -b -o phar_path_check.c phar_path_check.re; \
+		$(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o phar_path_check.c phar_path_check.re; \
 	else \
-		$(RE2C) --no-generation-date -b -o ext/phar/phar_path_check.c ext/phar/phar_path_check.re; \
+		$(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o ext/phar/phar_path_check.c ext/phar/phar_path_check.re; \
 	fi)
 
 pharcmd: $(builddir)/phar.php $(builddir)/phar.phar

--- a/ext/standard/Makefile.frag
+++ b/ext/standard/Makefile.frag
@@ -1,9 +1,9 @@
 
 $(srcdir)/var_unserializer.c: $(srcdir)/var_unserializer.re
-	@(cd $(top_srcdir); $(RE2C) --no-generation-date -b -o ext/standard/var_unserializer.c ext/standard/var_unserializer.re)
+	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o ext/standard/var_unserializer.c ext/standard/var_unserializer.re)
 
 $(srcdir)/url_scanner_ex.c: $(srcdir)/url_scanner_ex.re
-	@(cd $(top_srcdir); $(RE2C) --no-generation-date -b -o ext/standard/url_scanner_ex.c	ext/standard/url_scanner_ex.re)
+	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o ext/standard/url_scanner_ex.c	ext/standard/url_scanner_ex.re)
 
 $(builddir)/info.lo: $(builddir)/../../main/build-defs.h
 


### PR DESCRIPTION
Since PHP 5.3 the default lexer generator is RE2C. On Unix-alike build systems there is also optional configure option `--enable-re2c-cgoto` which enables optimized conditional jumps using non-standard computed goto extension. It is available since R2C 0.10.3 so it's well covered by RE2C versions PHP uses. This patch syncs usage of `-g` option across the PHP Unix-alike build system.

Patch is added thanks to @crrodriguez reported at [#76030](https://bugs.php.net/bug.php?id=76030).

Since the generated files are added in the Git repository and also shipped with PHP releases, maybe it's still useful for the PHP 7.3 branch...

Note, that other syncs for the RE2C flags will be done in a separate patch for the master branch.

Thanks...