### PR TITLE
Fix #76712: Assignment of empty string creates extraneous text node

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -384,7 +384,6 @@ static zval *sxe_dimension_read(zval *object, zval *offset, int type, zval *rv)
 static void change_node_zval(xmlNodePtr node, zval *value)
 {
 	xmlChar *buffer;
-	int buffer_len;
 
 	if (!value)
 	{
@@ -401,10 +400,9 @@ static void change_node_zval(xmlNodePtr node, zval *value)
 			/* break missing intentionally */
 		case IS_STRING:
 			buffer = xmlEncodeEntitiesReentrant(node->doc, (xmlChar *)Z_STRVAL_P(value));
-			buffer_len = xmlStrlen(buffer);
 			/* check for NULL buffer in case of memory error in xmlEncodeEntitiesReentrant */
 			if (buffer) {
-				xmlNodeSetContentLen(node, buffer, buffer_len);
+				xmlNodeSetContent(node, buffer);
 				xmlFree(buffer);
 			}
 			break;

--- a/ext/simplexml/tests/bug76712.phpt
+++ b/ext/simplexml/tests/bug76712.phpt
@@ -1,0 +1,24 @@
+--TEST--
+BUg #76712 (Assignment of empty string creates extraneous text node)
+--SKIPIF--
+<?php
+if (!extension_loaded('simplexml')) die('skip simplexml not available');
+?>
+--FILE--
+<?php
+$sxe = new SimpleXMLElement('<foo></foo>');
+$sxe->addChild('bar', '');
+echo $sxe->asXML();
+
+$sxe = new SimpleXMLElement('<foo></foo>');
+$sxe->addChild('bar');
+$sxe->bar = '';
+echo $sxe->asXML();
+?>
+===DONE===
+--EXPECT--
+<?xml version="1.0"?>
+<foo><bar/></foo>
+<?xml version="1.0"?>
+<foo><bar/></foo>
+===DONE===


### PR DESCRIPTION
We work around this peculiarity of libxml by using xmlNodeSetContent(),
which does not exhibit this behavior.  This also saves us from manually
calculating the string length.