### PR TITLE
Add WebAssembly to supported MIME types

### DIFF
--- a/sapi/cli/mime_type_map.h
+++ b/sapi/cli/mime_type_map.h
@@ -1013,6 +1013,7 @@ static const php_cli_server_ext_mime_type_pair mime_type_map[] = {
 	{ "ice", "x-conference/x-cooltalk" },
 	{ "map", "application/json" },
 	{ "jsm", "application/javascript" },
+	{ "wasm", "application/wasm" },
 	{ NULL, NULL }
 };
 


### PR DESCRIPTION
WebAssembly's MIME type is `application/wasm`. If not set; Firefox, Chrome and Vivaldi won't be able to run the WASM.

```
util.js:1632 wasm streaming compile failed: TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.
```