### PR TITLE
Fix #66486: strtotime only with whitespaces should return false

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1488,6 +1488,11 @@ PHP_FUNCTION(strtotime)
 		RETURN_FALSE;
 	}
 
+	while (isspace(*times)) {
+		times++;
+		time_len--;
+	}
+
 	tzi = get_timezone_info();
 
 	now = timelib_time_ctor();

--- a/ext/date/tests/bug66486.phpt
+++ b/ext/date/tests/bug66486.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #66486 strtotime only with whitespaces should return false
+--CREDITS--
+Gabriel Caruso (carusogabriel@php.net)
+--FILE--
+<?php
+var_dump(
+    strtotime(''),
+    strtotime(' '),
+    strtotime('  ')
+);
+?>
+--EXPECTF--
+bool(false)
+bool(false)
+bool(false)


### PR DESCRIPTION
Reopening #615 as the bug [#66486](https://bugs.php.net/bug.php?id=66486) doesn't seem to be patched yet.

https://3v4l.org/vOdgJ