### PR TITLE
Fix arginfo for functions/methods of the Tidy extension

### DIFF
--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -360,17 +360,21 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_tidy_config_count, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_getopt, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_getopt, 0, 0, 2)
 	ZEND_ARG_INFO(0, option)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_root, 0)
+ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_root, 1)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_html, 0)
+ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_html, 1)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_head, 0)
+ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_head, 1)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_get_body, 0, 0, 1)


### PR DESCRIPTION
The second argument (Tidy instance) is mandatory.
See http://php.net/tidy_getopt

This targets PHP 7.3 since it changes Reflection arginfo - I'm not 100% sure of the typical release rules for arginfo fixes.

Previously, the arginfo was wrong for these methods. (e.g. `(new ReflectionMethod('Tidy', '__construct'))->getNumberOfRequiredParameters()` was 4. Compare with http://php.net/manual/en/tidy.construct.php)