### PR TITLE
Fix arginfo for Reflection (Some parameters should be variadic)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,10 @@ PHP                                                                        NEWS
   . Fixed bug #76595 (phpdbg man page contains outdated information).
     (Kevin Abel)
 
+- Reflection:
+  . Fix arginfo for ReflectionClass::newInstance(), ReflectionFunction::invoke(), and ReflectionMethod::invoke()
+    (tandre)
+
 - Standard:
   . Fixed bug #76688 (Disallow excessive parameters after options array).
     (pmmaga)

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6130,7 +6130,7 @@ ZEND_BEGIN_ARG_INFO(arginfo_reflection_function___construct, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_reflection_function_invoke, 0, 0, 0)
-	ZEND_ARG_INFO(0, args)
+	ZEND_ARG_VARIADIC_INFO(0, args)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_reflection_function_invokeArgs, 0)
@@ -6210,7 +6210,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_reflection_method_invoke, 0)
 	ZEND_ARG_INFO(0, object)
-	ZEND_ARG_INFO(0, args)
+	ZEND_ARG_VARIADIC_INFO(0, args)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_reflection_method_invokeArgs, 0)
@@ -6305,7 +6305,7 @@ ZEND_BEGIN_ARG_INFO(arginfo_reflection_class_isInstance, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_reflection_class_newInstance, 0)
-	ZEND_ARG_INFO(0, args)
+	ZEND_ARG_VARIADIC_INFO(0, args)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_reflection_class_newInstanceWithoutConstructor, 0)


### PR DESCRIPTION
Fix arginfo for ReflectionClass::newInstance(), ReflectionFunction::invoke(), and ReflectionMethod::invoke()

E.g. `var_export((new ReflectionMethod('ReflectionFunction', 'invoke'))->getParameters()[0]->isVariadic());` would previously output `false`. I expect it to output `true`

- See http://php.net/manual/en/reflectionfunction.invoke.php and http://php.net/manual/en/reflectionclass.newinstance.php