### PR TITLE
Fix arginfo for bzcompress

### DIFF
--- a/ext/bz2/bz2.c
+++ b/ext/bz2/bz2.c
@@ -75,7 +75,7 @@ ZEND_BEGIN_ARG_INFO(arginfo_bzerror, 0)
 	ZEND_ARG_INFO(0, bz)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_bzcompress, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_bzcompress, 0, 0, 1)
 	ZEND_ARG_INFO(0, source)
 	ZEND_ARG_INFO(0, blocksize)
 	ZEND_ARG_INFO(0, workfactor)


### PR DESCRIPTION
bzcompress() has 1 required parameter, not 2.

See http://php.net/manual/en/function.bzcompress.php or invoke
bzcompress with 1 parameter.