### PR TITLE
Fix arginfo for tidy::__construct()

### DIFF
--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -396,7 +396,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_get_body, 0, 0, 1)
 	ZEND_ARG_INFO(0, tidy)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_tidy_construct, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_construct, 0, 0, 0)
     ZEND_ARG_INFO(0, filename)
     ZEND_ARG_INFO(0, config_file)
     ZEND_ARG_INFO(0, encoding)


### PR DESCRIPTION
This was split out of PR #3439

Previously, the arginfo was wrong for these methods.
getNumberOfRequiredParameters() was 4 for that method.
Compare with http://php.net/manual/en/tidy.construct.php)

This fixes the arginfo for __construct added to PHP 7.3 in 97353cda99
(This is why this PR targets PHP 7.3 and the other targets PHP 7.1)