### PR TITLE
Fix #68825: Exception in DirectoryIterator::getLinkTarget()

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1229,6 +1229,9 @@ SPL_METHOD(SplFileInfo, getLinkTarget)
 
 	zend_replace_error_handling(EH_THROW, spl_ce_RuntimeException, &error_handling);
 
+	if (intern->file_name == NULL) {
+		spl_filesystem_object_get_file_name(intern);
+	}
 #if defined(PHP_WIN32) || HAVE_SYMLINK
 	if (intern->file_name == NULL) {
 		php_error_docref(NULL, E_WARNING, "Empty filename");

--- a/ext/spl/tests/bug68825.phpt
+++ b/ext/spl/tests/bug68825.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug #68825 (Exception in DirectoryIterator::getLinkTarget())
+--FILE--
+<?php
+$dir = __DIR__ . '/bug68825';
+mkdir($dir);
+symlink(__FILE__, "$dir/foo");
+
+$di = new \DirectoryIterator($dir);
+foreach ($di as $entry) {
+    if ('foo' === $entry->getFilename()) {
+        var_dump($entry->getLinkTarget());
+    }
+}
+?>
+===DONE===
+--EXPECTF--
+string(%d) "%s%eext%espl%etests%ebug68825.php"
+===DONE===
+--CLEAN--
+<?php
+$dir = __DIR__ . '/bug68825';
+unlink("$dir/foo");
+rmdir($dir);
+?>


### PR DESCRIPTION
intern->file_name may not have been properly set when
DirectoryIterator::getLinkTarget() is called, so we make sure it is
before using it.