### PR TITLE
Remove trailing commas in enum lists

### DIFF
--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -144,7 +144,7 @@ enum _zend_ast_kind {
 
 	/* 4 child nodes */
 	ZEND_AST_FOR = 4 << ZEND_AST_NUM_CHILDREN_SHIFT,
-	ZEND_AST_FOREACH,
+	ZEND_AST_FOREACH
 };
 
 typedef uint16_t zend_ast_kind;

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -48,7 +48,7 @@ typedef unsigned char zend_uchar;
 
 typedef enum {
   SUCCESS =  0,
-  FAILURE = -1,		/* this MUST stay a negative number, or it may affect functions! */
+  FAILURE = -1		/* this MUST stay a negative number, or it may affect functions! */
 } ZEND_RESULT_CODE;
 
 #ifdef ZEND_ENABLE_ZVAL_LONG64

--- a/ext/intl/breakiterator/breakiterator_iterators.h
+++ b/ext/intl/breakiterator/breakiterator_iterators.h
@@ -26,7 +26,7 @@ U_CDECL_END
 typedef enum {
 	PARTS_ITERATOR_KEY_SEQUENTIAL,
 	PARTS_ITERATOR_KEY_LEFT,
-	PARTS_ITERATOR_KEY_RIGHT,
+	PARTS_ITERATOR_KEY_RIGHT
 } parts_iter_key_type;
 
 #ifdef __cplusplus

--- a/ext/mysqlnd/mysqlnd_enum_n_def.h
+++ b/ext/mysqlnd/mysqlnd_enum_n_def.h
@@ -207,7 +207,7 @@ typedef enum mysqlnd_parse_exec_response_type
 	MYSQLND_PARSE_EXEC_RESPONSE_IMPLICIT = 0,
 	MYSQLND_PARSE_EXEC_RESPONSE_IMPLICIT_NEXT_RESULT,
 	MYSQLND_PARSE_EXEC_RESPONSE_IMPLICIT_OUT_VARIABLES,
-	MYSQLND_PARSE_EXEC_RESPONSE_EXPLICIT,
+	MYSQLND_PARSE_EXEC_RESPONSE_EXPLICIT
 } enum_mysqlnd_parse_exec_response_type;
 
 typedef enum mysqlnd_client_option
@@ -666,7 +666,7 @@ enum php_mysqlnd_server_command
 	/* Here follow own, non-protocol, commands */
 	COM_REAP_RESULT=240,	/* own command */
 	COM_ENABLE_SSL,			/* own command */
-	COM_HANDSHAKE,			/* own command */
+	COM_HANDSHAKE			/* own command */
 };
 
 

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -135,7 +135,7 @@ typedef enum {
 	comment_block,
 	heredoc_start,
 	heredoc,
-	outside,
+	outside
 } php_code_type;
 
 static zend_string *cli_get_prompt(char *block, char prompt) /* {{{ */

--- a/sapi/phpdbg/phpdbg_watch.h
+++ b/sapi/phpdbg/phpdbg_watch.h
@@ -47,7 +47,7 @@ typedef enum {
 	WATCH_ON_REFCOUNTED,
 	WATCH_ON_STR,
 	WATCH_ON_HASHDATA,
-	WATCH_ON_BUCKET,
+	WATCH_ON_BUCKET
 } phpdbg_watchtype;
 
 

--- a/win32/ioutil.h
+++ b/win32/ioutil.h
@@ -90,7 +90,7 @@ typedef enum {
 typedef enum {
 	PHP_WIN32_IOUTIL_NORM_OK,
 	PHP_WIN32_IOUTIL_NORM_PARTIAL,
-	PHP_WIN32_IOUTIL_NORM_FAIL,
+	PHP_WIN32_IOUTIL_NORM_FAIL
 } php_win32_ioutil_normalization_result;
 
 #define PHP_WIN32_IOUTIL_FW_SLASHW L'/'


### PR DESCRIPTION
They were generating a number of [warnings](http://gcov.php.net/viewer.php?version=PHP_7_1&func=compile_results).