### PR TITLE
zend fixed address not being discarded.

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -423,8 +423,13 @@ static void *zend_mm_mmap_fixed(void *addr, size_t size)
 #ifdef _WIN32
 	return VirtualAlloc(addr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 #else
-	/* MAP_FIXED leads to discarding of the old mapping, so it can't be used. */
-	void *ptr = mmap(addr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON /*| MAP_POPULATE | MAP_HUGETLB*/, -1, 0);
+	int flags = MAP_PRIVATE | MAP_ANON;
+#ifdef MAP_FIXED_NOREPLACE
+	flags |= MAP_FIXED_NOREPLACE;
+#elif defined MAP_EXCL
+	flags |= MAP_FIXED | MAP_EXCL;
+#endif
+	void *ptr = mmap(addr, size, PROT_READ | PROT_WRITE, flags /*| MAP_POPULATE | MAP_HUGETLB*/, -1, 0);
 
 	if (ptr == MAP_FAILED) {
 #if ZEND_MM_ERROR


### PR DESCRIPTION
On Linux/FreeBSD, using flags guaranting it.