### PR TITLE
mkdist.php: recursively check DLL dependencies

### DIFF
--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -118,6 +118,8 @@ function get_depends($module)
 		}
 
 		$per_module_deps[basename($module)][] = $dep;
+		//recursively check dll dependencies
+		get_depends($dep);
 	}
 	fclose($pipes[1]);
 	proc_close($proc);
@@ -329,10 +331,6 @@ Add ADD_DLLS to add extra DLLs like dynamic dependencies for standard
 deps. For example, libenchant.dll loads libenchant_myspell.dll or
 libenchant_ispell.dll
 */
-$ICU_DLLS = $php_build_dir . '/bin/icu*.dll';
-foreach (glob($ICU_DLLS) as $filename) {
-	copy($filename, "$dist_dir/" . basename($filename));
-}
 $ENCHANT_DLLS = array(
 	array('', 'glib-2.dll'),
 	array('', 'gmodule-2.dll'),

--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -117,9 +117,11 @@ function get_depends($module)
 			}
 		}
 
-		$per_module_deps[basename($module)][] = $dep;
-		//recursively check dll dependencies
-		get_depends($dep);
+		if (!isset($per_module_deps[basename($module)]) || !in_array($dep, $per_module_deps[basename($module)])) {
+			$per_module_deps[basename($module)][] = $dep;
+			//recursively check dll dependencies
+			get_depends($dep);
+		}
 	}
 	fclose($pipes[1]);
 	proc_close($proc);


### PR DESCRIPTION
I use `nmake snap` to conveniently bundle up PHP builds for my project (I ship custom-built PHP for my project). Yesterday I noticed that the ICU DLLs are unconditionally copied, despite the fact that I don't ship the intl extension, meaning my packed dist size was doubled unnecessarily (the ICU DLLs are rather large).

This pull request removes the hardcoded ICU DLL copying, allowing the standard module deps checking to deal with it. To facilitate this, I've also made the `get_depends()` function recursively check module dependencies to ensure that everything gets copied appropriately (some of the ICU DLLs are depended on indirectly).

This was tested with the configure line `--enable-snapshot-build` and also `--disable-all --enable-cli`, followed by `nmake snap` after completing the build. Without ICU enabled the DLLs are no longer copied.

It's possible that this will facilitate the removal of other hardcoded DLL copying, but I did not test further than ICU.

I am not sure which is the lowest branch that this should be PR'd to, so I've pulled directly to master.