### PR TITLE
Report mem leaks to stderr if no Win debugger is present

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1680,7 +1680,15 @@ static ZEND_COLD void php_message_handler_for_zend(zend_long message, const void
 
 					snprintf(memory_leak_buf, 512, "Last leak repeated %lu time%s\n", leak_count, (leak_count>1?"s":""));
 				}
+#	if defined(PHP_WIN32)
+				if (IsDebuggerPresent()) {
+					OutputDebugString(memory_leak_buf);
+				} else {
+					fprintf(stderr, "%s", memory_leak_buf);
+				}
+#	else
 				fprintf(stderr, "%s", memory_leak_buf);
+#	endif
 			}
 #endif
 			break;
@@ -1690,7 +1698,15 @@ static ZEND_COLD void php_message_handler_for_zend(zend_long message, const void
 				char memory_leak_buf[512];
 
 				snprintf(memory_leak_buf, 512, "=== Total %d memory leaks detected ===\n", *((uint32_t *) data));
+#	if defined(PHP_WIN32)
+				if (IsDebuggerPresent()) {
+					OutputDebugString(memory_leak_buf);
+				} else {
+					fprintf(stderr, "%s", memory_leak_buf);
+				}
+#	else
 				fprintf(stderr, "%s", memory_leak_buf);
+#	endif
 			}
 #endif
 			break;
@@ -1709,7 +1725,15 @@ static ZEND_COLD void php_message_handler_for_zend(zend_long message, const void
 				} else {
 					snprintf(memory_leak_buf, sizeof(memory_leak_buf), "[null]  Script:  '%s'\n", SAFE_FILENAME(SG(request_info).path_translated));
 				}
+#	if defined(PHP_WIN32)
+				if (IsDebuggerPresent()) {
+					OutputDebugString(memory_leak_buf);
+				} else {
+					fprintf(stderr, "%s", memory_leak_buf);
+				}
+#	else
 				fprintf(stderr, "%s", memory_leak_buf);
+#	endif
 			}
 			break;
 	}

--- a/main/main.c
+++ b/main/main.c
@@ -1680,11 +1680,7 @@ static ZEND_COLD void php_message_handler_for_zend(zend_long message, const void
 
 					snprintf(memory_leak_buf, 512, "Last leak repeated %lu time%s\n", leak_count, (leak_count>1?"s":""));
 				}
-#	if defined(PHP_WIN32)
-				OutputDebugString(memory_leak_buf);
-#	else
 				fprintf(stderr, "%s", memory_leak_buf);
-#	endif
 			}
 #endif
 			break;
@@ -1694,11 +1690,7 @@ static ZEND_COLD void php_message_handler_for_zend(zend_long message, const void
 				char memory_leak_buf[512];
 
 				snprintf(memory_leak_buf, 512, "=== Total %d memory leaks detected ===\n", *((uint32_t *) data));
-#	if defined(PHP_WIN32)
-				OutputDebugString(memory_leak_buf);
-#	else
 				fprintf(stderr, "%s", memory_leak_buf);
-#	endif
 			}
 #endif
 			break;
@@ -1717,11 +1709,7 @@ static ZEND_COLD void php_message_handler_for_zend(zend_long message, const void
 				} else {
 					snprintf(memory_leak_buf, sizeof(memory_leak_buf), "[null]  Script:  '%s'\n", SAFE_FILENAME(SG(request_info).path_translated));
 				}
-#	if defined(PHP_WIN32)
-				OutputDebugString(memory_leak_buf);
-#	else
 				fprintf(stderr, "%s", memory_leak_buf);
-#	endif
 			}
 			break;
 	}


### PR DESCRIPTION
Formerly, we sent debug output regarding memory leaks to the debugger
on Windows, but this appears to be not useful especially for the PHPTs,
which usually are not run under a debugger, and so important info will
not be available there.