### PR TITLE
Implement #64517: Add AC_ARG_PROGRAM macro

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -27,6 +27,8 @@ PHP 7.4 INTERNALS UPGRADE NOTES
 ========================
 
   a. Unix build system changes
+    - configure --help now also outputs --program-suffix and --program-prefix
+      information by using the Autoconf AC_ARG_PROGRAM macro.
 
   b. Windows build system changes
 

--- a/configure.ac
+++ b/configure.ac
@@ -1207,6 +1207,8 @@ EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $LDFLAGS"
 EXTRA_LIBS="$EXTRA_LIBS $LIBS"
 unset LIBS LDFLAGS
 
+AC_ARG_PROGRAM
+
 test "$prefix" = "NONE" && prefix=/usr/local
 test "$exec_prefix" = "NONE" && exec_prefix='${prefix}'
 test "$program_prefix" = "NONE" && program_prefix=


### PR DESCRIPTION
The `AC_ARG_PROGRAM` Autoconf macro provides program name transformations when installing. This patch fixes [bug #64517](https://bugs.php.net/64517) and prepares the implementation for the [request #60518](https://bugs.php.net/60518).

In `./configure --help` it additionally outputs `--program-prefix=PREFIX`, `--program-suffix=SUFFIX` and the upcoming `--program-transform-name=PROGRAM` option.

Macro `AC_ARG_PROGRAM` is available since Autoconf 2.0 and needs to be called after the `AC_CANONICAL_TARGET` macro.

Refs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Transforming-Names.html