### PR TITLE
Remove AC_STRUCT_TM macro

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1402,7 +1402,7 @@ dnl
 AC_DEFUN([PHP_TM_GMTOFF],[
 AC_CACHE_CHECK([for tm_gmtoff in struct tm], ac_cv_struct_tm_gmtoff,
 [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
-#include <$ac_cv_struct_tm>]], [[struct tm tm; tm.tm_gmtoff;]])],
+#include <time.h>]], [[struct tm tm; tm.tm_gmtoff;]])],
   [ac_cv_struct_tm_gmtoff=yes], [ac_cv_struct_tm_gmtoff=no])])
 
 if test "$ac_cv_struct_tm_gmtoff" = yes; then

--- a/configure.ac
+++ b/configure.ac
@@ -507,7 +507,6 @@ PHP_BROKEN_GLIBC_FOPEN_APPEND
 dnl Checks for typedefs, structures, and compiler characteristics.
 dnl -------------------------------------------------------------------------
 
-AC_STRUCT_TM
 AC_STRUCT_TIMEZONE
 
 PHP_MISSING_TIME_R_DECL

--- a/ext/standard/crypt.c
+++ b/ext/standard/crypt.c
@@ -37,11 +37,7 @@
 #  include <crypt.h>
 # endif
 #endif
-#if TM_IN_SYS_TIME
-#include <sys/time.h>
-#else
 #include <time.h>
-#endif
 #if HAVE_STRING_H
 #include <string.h>
 #else

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -23,11 +23,7 @@
 #include "SAPI.h"
 #include "php_main.h"
 #include "head.h"
-#ifdef TM_IN_SYS_TIME
-#include <sys/time.h>
-#else
 #include <time.h>
-#endif
 
 #include "php_globals.h"
 


### PR DESCRIPTION
Autoconf 2.59d (released in 2006) [1] started promoting several macros
as not relevant for newer systems anymore, including the `AC_STRUCT_TM`.

This macro checks if `struct tm` is defined in either `<sys/time.h>` or
`<time.h>` and defines the `TM_IN_SYS_TIME` symbol accordingly. This
check was relevant in times before the C89 for some embedded systems,
microcontrollers or very old systems. For newer systems it can be
avoided and the `<time.h>` should be included instead since current
systems should be well supported by now. [2]

Since PHP requires at least C89, this patch removes the obsolescent call
and time.h checks.

Refs:

- [1]: http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
- [2]: https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Particular-Structures.html