### PR TITLE
fix double cast to int on 32-bit

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -3101,7 +3101,7 @@ ZEND_API zend_long ZEND_FASTCALL zend_dval_to_lval_slow(double d)
 	if (dmod < 0) {
 		/* we're going to make this number positive; call ceil()
 		 * to simulate rounding towards 0 of the negative number */
-		dmod = ceil(dmod);// + two_pow_32;
+		dmod = ceil(dmod) + two_pow_32;
 	}
 	return (zend_long)(zend_ulong)dmod;
 }


### PR DESCRIPTION
2 tests are failing with GCC 8.2 on 32-bit build

	zend_dval_to_lval preserves low bits  (32 bit long) [Zend/tests/dval_to_lval_32.phpt]
	testing integer underflow (32bit) [Zend/tests/int_underflow_32bit.phpt]

The comment was added in 716da71446e by @dstogov 