### PR TITLE
Support fixed address mmap without replacement.

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -423,11 +423,15 @@ static void *zend_mm_mmap_fixed(void *addr, size_t size)
 #ifdef _WIN32
 	return VirtualAlloc(addr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 #else
+    int flags = MAP_PRIVATE | MAP_ANON;
+#if defined(MAP_EXCL)
+    flags |= MAP_FIXED | MAP_EXCL;
+#endif
 	/* MAP_FIXED leads to discarding of the old mapping, so it can't be used. */
-	void *ptr = mmap(addr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON /*| MAP_POPULATE | MAP_HUGETLB*/, -1, 0);
+	void *ptr = mmap(addr, size, PROT_READ | PROT_WRITE, flags /*| MAP_POPULATE | MAP_HUGETLB*/, -1, 0);
 
 	if (ptr == MAP_FAILED) {
-#if ZEND_MM_ERROR
+#if ZEND_MM_ERROR && !defined(MAP_EXCL)
 		fprintf(stderr, "\nmmap() failed: [%d] %s\n", errno, strerror(errno));
 #endif
 		return NULL;


### PR DESCRIPTION
Reput changes for Zend fixed mapping but only for FreeBSD.
Other BSD might expose some day a similar flag (private
for OpenBSD for the moment for example).
The Linux's part could be brought back but not before 7.4,
at this time, distributions with kernel > 4.17 will be
more widely available.