### PR TITLE
Fix #75205: Dynamically check internet connection when running tests

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -786,6 +786,11 @@ HELP;
 					exit(1);
 			}
 		}
+		
+		// check for internet connection if `--offline` option wasn't set up
+		if (!isset($environment['SKIP_ONLINE_TESTS']) && !@fsockopen('www.php.net', 80)) {
+			$environment['SKIP_ONLINE_TESTS'] = 1;
+		}
 
 		if (!$is_switch) {
 			$testfile = realpath($argv[$i]);


### PR DESCRIPTION
As mentioned in [Bug #75205](https://bugs.php.net/bug.php?id=75205), if we don't pass the option `--offline` to run-tests, it won't really check for internet connection, causing the failure of those ones that need it.

This PR proposes the dynamically check for this when the `--offline` option wasn't set up.