### PR TITLE
Make possible to send file in curl request from buffer string

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -186,6 +186,6 @@ int main(int argc, char *argv[])
     $CURL_LIBS
   ])
 
-  PHP_NEW_EXTENSION(curl, interface.c multi.c share.c curl_file.c, $ext_shared)
+  PHP_NEW_EXTENSION(curl, interface.c multi.c share.c curl_file.c curl_buffer_file.c, $ext_shared)
   PHP_SUBST(CURL_SHARED_LIBADD)
 fi

--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -11,7 +11,7 @@ if (PHP_CURL != "no") {
 		(((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "curl", PHP_CURL))) || 
 			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "curl", PHP_CURL)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED)))
 		) {
-		EXTENSION("curl", "interface.c multi.c share.c curl_buffer_file.c");
+		EXTENSION("curl", "interface.c multi.c share.c curl_file.c curl_buffer_file.c");
 		AC_DEFINE('HAVE_CURL', 1, 'Have cURL library');
 		AC_DEFINE('HAVE_CURL_SSL', 1, 'Have SSL suppurt in cURL');
 		AC_DEFINE('HAVE_CURL_EASY_STRERROR', 1, 'Have curl_easy_strerror in cURL');

--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -11,7 +11,7 @@ if (PHP_CURL != "no") {
 		(((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "curl", PHP_CURL))) || 
 			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "curl", PHP_CURL)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED)))
 		) {
-		EXTENSION("curl", "interface.c multi.c share.c curl_file.c");
+		EXTENSION("curl", "interface.c multi.c share.c curl_buffer_file.c");
 		AC_DEFINE('HAVE_CURL', 1, 'Have cURL library');
 		AC_DEFINE('HAVE_CURL_SSL', 1, 'Have SSL suppurt in cURL');
 		AC_DEFINE('HAVE_CURL_EASY_STRERROR', 1, 'Have curl_easy_strerror in cURL');

--- a/ext/curl/curl_buffer_file.c
+++ b/ext/curl/curl_buffer_file.c
@@ -1,0 +1,149 @@
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2018 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include "php.h"
+#include "Zend/zend_exceptions.h"
+#include "php_curl.h"
+#if HAVE_CURL
+
+PHP_CURL_API zend_class_entry *curl_CURLBufferFile_class;
+
+static void curlbufferfile_ctor(INTERNAL_FUNCTION_PARAMETERS)
+{
+	zend_string *postname, *buffer, *mime = NULL;
+	zval *cf = return_value;
+
+	ZEND_PARSE_PARAMETERS_START(2,3)
+		Z_PARAM_STR(postname)
+		Z_PARAM_STR(buffer)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR(mime)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_update_property_string(curl_CURLBufferFile_class, cf, "postname", sizeof("postname")-1, ZSTR_VAL(postname));
+	zend_update_property_stringl(curl_CURLBufferFile_class, cf, "buffer", sizeof("buffer")-1, ZSTR_VAL(buffer), ZSTR_LEN(buffer));
+
+	if (mime) {
+		zend_update_property_string(curl_CURLBufferFile_class, cf, "mime", sizeof("mime")-1, ZSTR_VAL(mime));
+	}
+}
+
+/* {{{ proto CURLBufferFile::__construct(string $postfilename, string $buffer [, string $mimetype])
+   Create the CURLBufferFile object */
+ZEND_METHOD(CURLBufferFile, __construct)
+{
+	return_value = getThis();
+	curlbufferfile_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+/* }}} */
+
+/* {{{ proto CURLBufferFile curl_buffer_file_create(string $postfilename, string $buffer [, string $mimetype])
+   Create the CURLBufferFile object */
+PHP_FUNCTION(curl_buffer_file_create)
+{
+    object_init_ex( return_value, curl_CURLBufferFile_class );
+    curlbufferfile_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+/* }}} */
+
+static void curlbufferfile_get_property(char *name, size_t name_len, INTERNAL_FUNCTION_PARAMETERS)
+{
+	zval *res, rv;
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+	res = zend_read_property(curl_CURLBufferFile_class, getThis(), name, name_len, 1, &rv);
+	ZVAL_COPY_DEREF(return_value, res);
+}
+
+static void curlbufferfile_set_property(char *name, size_t name_len, INTERNAL_FUNCTION_PARAMETERS)
+{
+	zend_string *arg;
+
+	ZEND_PARSE_PARAMETERS_START(1,1)
+		Z_PARAM_STR(arg)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_update_property_string(curl_CURLBufferFile_class, getThis(), name, name_len, ZSTR_VAL(arg));
+}
+
+/* {{{ proto string CURLBufferFile::getBuffer()
+   Get file name */
+ZEND_METHOD(CURLBufferFile, getBuffer)
+{
+	curlbufferfile_get_property("buffer", sizeof("buffer")-1, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+/* }}} */
+
+/* {{{ proto string CURLBufferFile::getMimeType()
+   Get MIME type */
+ZEND_METHOD(CURLBufferFile, getMimeType)
+{
+	curlbufferfile_get_property("mime", sizeof("mime")-1, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+/* }}} */
+
+/* {{{ proto string CURLBufferFile::getPostFilename()
+   Get file name for POST */
+ZEND_METHOD(CURLBufferFile, getPostFilename)
+{
+	curlbufferfile_get_property("postname", sizeof("postname")-1, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+/* }}} */
+
+/* {{{ proto void CURLBufferFile::setMimeType(string $mime)
+   Set MIME type */
+ZEND_METHOD(CURLBufferFile, setMimeType)
+{
+	curlbufferfile_set_property("mime", sizeof("mime")-1, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+/* }}} */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_curlbufferfile_create, 0, 0, 2)
+	ZEND_ARG_INFO(0, postname)
+	ZEND_ARG_INFO(0, buffer)
+	ZEND_ARG_INFO(0, mimetype)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_curlbufferfile_name, 0)
+	ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry curlbufferfile_funcs[] = {
+	PHP_ME(CURLBufferFile,			__construct,        arginfo_curlbufferfile_create, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
+	PHP_ME(CURLBufferFile,			getPostFilename,    NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(CURLBufferFile,			getBuffer,          NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(CURLBufferFile,			getMimeType,        NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(CURLBufferFile,			setMimeType,        arginfo_curlbufferfile_name, ZEND_ACC_PUBLIC)
+	PHP_FE_END
+};
+
+void curlbufferfile_register_class(void)
+{
+	zend_class_entry ce;
+	INIT_CLASS_ENTRY( ce, "CURLBufferFile", curlbufferfile_funcs );
+	curl_CURLBufferFile_class = zend_register_internal_class(&ce);
+	zend_declare_property_string(curl_CURLBufferFile_class, "buffer", sizeof("buffer")-1, "", ZEND_ACC_PUBLIC);
+	zend_declare_property_string(curl_CURLBufferFile_class, "mime", sizeof("mime")-1, "", ZEND_ACC_PUBLIC);
+	zend_declare_property_string(curl_CURLBufferFile_class, "postname", sizeof("postname")-1, "", ZEND_ACC_PUBLIC);
+}
+
+#endif

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2658,7 +2658,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 
                             postval = Z_STR_P(prop);
 
-                            prop = zend_read_property(curl_CURLFile_class, current, "mime", sizeof("mime")-1, 0, &rv);
+                            prop = zend_read_property(curl_CURLBufferFile_class, current, "mime", sizeof("mime")-1, 0, &rv);
                             if (Z_TYPE_P(prop) == IS_STRING && Z_STRLEN_P(prop) > 0) {
                                 type = Z_STRVAL_P(prop);
                             }

--- a/ext/curl/php_curl.h
+++ b/ext/curl/php_curl.h
@@ -115,7 +115,7 @@ PHP_FUNCTION(curl_pause);
 #endif
 
 PHP_FUNCTION(curl_file_create);
-
+PHP_FUNCTION(curl_buffer_file_create);
 
 void _php_curl_multi_close(zend_resource *);
 void _php_curl_share_close(zend_resource *);
@@ -212,6 +212,9 @@ void _php_setup_easy_copy_handlers(php_curl *ch, php_curl *source);
 
 void curlfile_register_class(void);
 PHP_CURL_API extern zend_class_entry *curl_CURLFile_class;
+
+void curlbufferfile_register_class(void);
+PHP_CURL_API extern zend_class_entry *curl_CURLBufferFile_class;
 
 #else
 #define curl_module_ptr NULL

--- a/ext/curl/tests/curl_buffer_file_upload.phpt
+++ b/ext/curl/tests/curl_buffer_file_upload.phpt
@@ -1,0 +1,47 @@
+--TEST--
+CURL buffer file uploading
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+
+function testcurl($ch, $postname, $buffer, $mime = '')
+{
+	if(!empty($mime)) {
+		$file = new CURLBufferFile($postname, $buffer, $mime);
+	} else {
+		$file = new CURLBufferFile($postname, $buffer);
+	}
+	curl_setopt($ch, CURLOPT_POSTFIELDS, array("file" => $file));
+	var_dump(curl_exec($ch));
+}
+
+include 'server.inc';
+$host = curl_cli_server_start();
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, "{$host}/get.php?test=bufferfile");
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+$buffer = "test\0test";
+var_dump(md5($buffer));
+testcurl($ch, 'foo.txt', $buffer);
+testcurl($ch, 'foo.txt', $buffer, 'text/plain');
+
+$file = new CurlBufferFile('foo.txt', "test");
+$file->setMimeType('text/plain');
+var_dump($file->getMimeType());
+var_dump($file->getPostFilename());
+var_dump($file->getBuffer());
+curl_setopt($ch, CURLOPT_POSTFIELDS, array("file" => $file));
+var_dump(curl_exec($ch));
+
+curl_close($ch);
+?>
+--EXPECTF--
+string(%d) "62942c05ed0d1b501c4afe6dc1c4db1b"
+string(%d) "foo.txt|application/octet-stream|62942c05ed0d1b501c4afe6dc1c4db1b"
+string(%d) "foo.txt|text/plain|62942c05ed0d1b501c4afe6dc1c4db1b"
+string(%d) "text/plain"
+string(%d) "foo.txt"
+string(%d) "test"
+string(%d) "foo.txt|text/plain|098f6bcd4621d373cade4e832627b4f6"

--- a/ext/curl/tests/responder/get.php
+++ b/ext/curl/tests/responder/get.php
@@ -31,6 +31,11 @@
           echo $_FILES['file']['name'] . '|' . $_FILES['file']['type'];
       }
       break;
+    case 'bufferfile':
+      if (isset($_FILES['file'])) {
+          echo $_FILES['file']['name'] . '|' . $_FILES['file']['type'] . '|' . md5_file($_FILES['file']['tmp_name']);
+      }
+      break;
     case 'method':
       echo $_SERVER['REQUEST_METHOD'];
       break;


### PR DESCRIPTION
In this pull request I added new class CURLBufferFile , which provide possible to send file from buffer string , not from disk as CURLFile .

`$File = curl_buffer_file_create($postname, $buffer, $mime = "")` 
`$File = new CURLBufferFile($postname, $buffer, $mime = "")` 

@smalyshev @dstogov 
Many years I tried add it by different ways, but no results. So after testing it in development env we will use this patch internally in Badoo even if this last  try also will failed. 