### PR TITLE
Fix #76827: Introduce a new function str_truncate to make fast truncation

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2499,6 +2499,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_utf8_decode, 0, 0, 1)
 	ZEND_ARG_INFO(0, data)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_str_truncate, 0, 0, 2)
+	ZEND_ARG_INFO(0, str)
+	ZEND_ARG_INFO(0, new_len)
+ZEND_END_ARG_INFO()
 /* }}} */
 /* {{{ syslog.c */
 #ifdef HAVE_SYSLOG_H
@@ -2804,6 +2809,7 @@ static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(substr_compare,													arginfo_substr_compare)
 	PHP_FE(utf8_encode, 													arginfo_utf8_encode)
 	PHP_FE(utf8_decode, 													arginfo_utf8_decode)
+    PHP_FE(str_truncate, 													arginfo_str_truncate)
 
 #ifdef HAVE_STRCOLL
 	PHP_FE(strcoll,															arginfo_strcoll)

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -91,6 +91,7 @@ PHP_FUNCTION(strpbrk);
 PHP_FUNCTION(substr_compare);
 PHP_FUNCTION(utf8_encode);
 PHP_FUNCTION(utf8_decode);
+PHP_FUNCTION(str_truncate);
 #ifdef HAVE_STRCOLL
 PHP_FUNCTION(strcoll);
 #endif

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -6331,6 +6331,38 @@ PHP_FUNCTION(utf8_decode)
 }
 /* }}} */
 
+/* {{{ proto bool str_truncate(string& str, int new_len)
+   Truncates the string to the new length. */
+PHP_FUNCTION(str_truncate)
+{
+	/*
+	 * Note that the proto specifies the str as a string reference, however,
+	 * internally speaking, it isn't. It's specified as a reference just to
+	 * reflect the fact the string would be changed upon calling this
+	 * function.
+	 *
+	 * This function is provided as a far more sufficient alternative of
+	 * truncating a large string to a still-very-large string.
+	 *
+	 * For example,
+	 * str_truncate($str, 1024 * 1024) vs $str = substr($str, 0, 1024 * 1024)
+	 * Obviously the former works far more sufficiently than the latter.
+	 */
+
+	zend_string *str;
+	zend_long new_len;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(str)
+		Z_PARAM_LONG(new_len)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (new_len < ZSTR_LEN(str) && new_len >= 0) {
+		ZSTR_LEN(str) = new_len;
+	}
+}
+/* }}} */
+
 /*
  * Local variables:
  * tab-width: 4

--- a/ext/standard/tests/strings/str_truncate.phpt
+++ b/ext/standard/tests/strings/str_truncate.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Testing str_truncate() function
+--FILE--
+<?php
+
+/* Prototype: string substr( string str, int start[, int length] )
+ * Description: Truncates the string to the new length.
+ */
+
+$string = 'Hello world!';
+
+// Should not take effect, new_len is too big.
+str_truncate($string, strlen($string) + 1);
+var_dump($string);
+// Should not take effect, new_len is less than zero.
+str_truncate($string, -1);
+var_dump($string);
+
+// Should truncate $string to the string "Hello".
+str_truncate($string, strlen('Hello'));
+var_dump($string);
+// Should not take effect, it cannot untruncate back.
+str_truncate($string, strlen('Hello world!'));
+var_dump($string);
+// Should truncate to an empty string.
+str_truncate($string, 0);
+var_dump($string);
+// Should not take effect, it cannot untruncate back.
+str_truncate($string, strlen('Hello'));
+var_dump($string);
+
+echo "\nDone";
+
+?>
+--EXPECTF--
+string(12) "Hello world!"
+string(12) "Hello world!"
+string(5) "Hello"
+string(5) "Hello"
+string(0) ""
+string(0) ""
+
+Done


### PR DESCRIPTION
This function is provided as a far more sufficient alternative of
truncating a large string to a still-very-large string.
For example,
str_truncate($str, 1024 * 1024) vs $str = substr($str, 0, 1024 * 1024)
Obviously the former works far more sufficiently than the latter.