### PR TITLE
Remove AC_C_CONST

### DIFF
--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -98,7 +98,6 @@ int main() { return foo(10, "", 3.14); }
       AC_CHECK_SIZEOF(int, 4)
       AC_CHECK_SIZEOF(short, 2)
       AC_CHECK_SIZEOF(long, 4)
-      AC_C_CONST
       AC_HEADER_TIME
       AC_FUNC_ALLOCA
       AC_FUNC_MEMCMP

--- a/ext/mbstring/libmbfl/config.h.in
+++ b/ext/mbstring/libmbfl/config.h.in
@@ -81,9 +81,6 @@
 /* Version number of package */
 #undef VERSION
 
-/* Define to empty if `const' does not conform to ANSI C. */
-#undef const
-
 /* Define to rpl_malloc if the replacement function should be used. */
 #undef malloc
 

--- a/ext/xmlrpc/libxmlrpc/acinclude.m4
+++ b/ext/xmlrpc/libxmlrpc/acinclude.m4
@@ -17,7 +17,6 @@ AC_CHECK_HEADERS(xmlparse.h xmltok.h stdlib.h strings.h string.h)
 
 AC_DEFUN([XMLRPC_TYPE_CHECKS],[
 
-AC_REQUIRE([AC_C_CONST])
 AC_REQUIRE([AC_C_INLINE])
 AC_CHECK_SIZEOF(char, 1)
 


### PR DESCRIPTION
Autoconf 2.59d (released in 2006) [1] started promoting several macros
as not relevant for newer systems, including the `AC_C_CONST`.

The `const` keyword is used in C since C89. On old systems some compilers
lacked the `const` and this macro defined it to be empty. This check was
relevant on systems with compilers before C89 and on current systems it
can be omitted. [2]

PHP also requires at least C89 so `const` is always available.

Refs:
[1] http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
[2] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html