### PR TITLE
Remove AC_FUNC_MEMCMP

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -91,7 +91,6 @@ LIBZEND_CHECK_INT_TYPE(int32_t)
 LIBZEND_CHECK_INT_TYPE(uint32_t)
 
 dnl Checks for library functions.
-AC_FUNC_MEMCMP
 AC_FUNC_ALLOCA
 AC_CHECK_FUNCS(memcpy strdup getpid kill strtod strtol finite fpclass sigsetjmp)
 AC_ZEND_BROKEN_SPRINTF

--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -99,7 +99,6 @@ int main() { return foo(10, "", 3.14); }
       AC_CHECK_SIZEOF(short, 2)
       AC_CHECK_SIZEOF(long, 4)
       AC_FUNC_ALLOCA
-      AC_FUNC_MEMCMP
       AC_CHECK_HEADER([stdarg.h], [
         AC_DEFINE([HAVE_STDARG_PROTOTYPES], [1], [Define to 1 if you have the <stdarg.h> header file.])
       ], [])


### PR DESCRIPTION
Autoconf 2.59d (released in 2006) [1] started promoting several macros
as not relevant for newer systems anymore, including the `AC_FUNC_MEMCMP`.

On some old systems such as SunOS 4.1.3 (EOL in 2003) and NeXT x86
OpenStep (discontinued) the `memcmp` function wasn't present or it
didn't work properly. [2]

On current systems including at least Solaris 10+ this check is not
relevant anymore.

Refs:
[1] http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
[2] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html