### PR TITLE
Remove AC_HEADER_DIRENT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -420,7 +420,6 @@ dnl -------------------------------------------------------------------------
 
 dnl Checks for header files.
 AC_HEADER_STDC
-AC_HEADER_DIRENT
 
 dnl QNX requires unix.h to allow functions in libunix to work properly
 AC_CHECK_HEADERS([ \

--- a/ext/opcache/shared_alloc_shm.c
+++ b/ext/opcache/shared_alloc_shm.c
@@ -29,7 +29,6 @@
 #include <sys/types.h>
 #include <sys/shm.h>
 #include <sys/ipc.h>
-#include <dirent.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -28,7 +28,6 @@
 #include <fcntl.h>
 #ifndef ZEND_WIN32
 # include <sys/types.h>
-# include <dirent.h>
 # include <signal.h>
 # include <sys/stat.h>
 # include <stdio.h>

--- a/ext/standard/dir.c
+++ b/ext/standard/dir.c
@@ -26,10 +26,6 @@
 #include "php_scandir.h"
 #include "basic_functions.h"
 
-#ifdef HAVE_DIRENT_H
-#include <dirent.h>
-#endif
-
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/main/php_scandir.h
+++ b/main/php_scandir.h
@@ -22,10 +22,6 @@
 
 #include <sys/types.h>
 
-#ifdef HAVE_SYS_DIR_H
-#include <sys/dir.h>
-#endif
-
 #ifdef PHP_WIN32
 #include "config.w32.h"
 #include "win32/readdir.h"


### PR DESCRIPTION
Autoconf 2.59d (released in 2006) [1] started promoting several macros
as not relevant for newer systems anymore, including the `AC_HEADER_DIRENT`.

This macro checks which header defines the `DIR` type. If `<dirent.h>`
is available it defines the `HAVE_DIRENT_H` symbol. Since the `<dirent.h>`
header is already checked in the `configure.ac`, this check is not needed
anymore. This macro also additionally checks for SCO Xenix (discontinued,
latest release 1989) dir and x libraries. [2]

Commit 6ed790685f9ddae11834f36b0ba4fea58afc805a introduced also
`<sys/dir.h>`. This header exists from times of UNIX System V and
provided definition of DIR type on these systems such as 4.3BSD.
Today `<sys/dir.h>` is kept for backwards compatibility and includes
the `<dirent.h>` on current systems. With `dirent.h>` present this
include is no longer required.

Refs:
[1] http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
[2] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html