### PR TITLE
oci8-bugfix: releasing persistent connections

### DIFF
--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -2304,7 +2304,6 @@ int php_oci_connection_release(php_oci_connection *connection)
 		connection->svc = NULL;
 		connection->server = NULL;
 		connection->session = NULL;
-		connection->id = NULL;
 
 		connection->is_attached = connection->is_open = connection->rb_on_disconnect = connection->used_this_request = 0;
 		connection->is_stub = 1;
@@ -2320,6 +2319,9 @@ int php_oci_connection_release(php_oci_connection *connection)
 		}
 #endif /* HAVE_OCI8_DTRACE */
 	}
+
+	/* Always set id to null, so next time a new resource is being registered. */
+	connection->id = NULL;
 
 	OCI_G(in_call) = in_call_save;
 	return result;


### PR DESCRIPTION
When not using spool, creating a persistent connection, releasing the handle and recreating a persistent connection, leads to the second connection being an invalid resource.

**How to reproduce**
```php
<?php
ini_set( 'display_errors', 'on' );
ini_set( 'log_errors', 'off' );
$use_wallet         = true;
$userName           = '/';
$password           = '';
$connection_string  = 'DB_CONNECTION_STRING';
$character_set      = 'AL32UTF8';
$session_mode       = OCI_CRED_EXT;

$conn = oci_pconnect( $userName, $password, $connection_string, $character_set, $session_mode );
var_dump( $conn );
$conn = null;
$conn = oci_pconnect( $userName, $password, $connection_string, $character_set, $session_mode );
var_dump( $conn );
```

A possible result would be:
> resource(1) of type (oci8 connection)
> resource(-1555988216) of type (Unknown)

**Cause**
This probably happens because the function `php_oci_connection_release(...)` currently doesn't set the `connection->id` to null (only when using spool). While the function `php_oci_do_connect_ex(...)` checks `if (connection->id) { ... }`, this check works for the first time, but not for the second time `oci_pconnect(...)` is being called.

**Fix**
Always performing a `connection->id = NULL;` fixed the problem for us.