### PR TITLE
Remove HAVE_ASSERT_H

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -434,7 +434,6 @@ netinet/in.h \
 alloca.h \
 arpa/inet.h \
 arpa/nameser.h \
-assert.h \
 crypt.h \
 dns.h \
 fcntl.h \
@@ -477,7 +476,6 @@ utime.h \
 sys/utsname.h \
 sys/ipc.h \
 dlfcn.h \
-assert.h \
 tmmintrin.h \
 nmmintrin.h \
 immintrin.h

--- a/ext/bcmath/libbcmath/src/add.c
+++ b/ext/bcmath/libbcmath/src/add.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/compare.c
+++ b/ext/bcmath/libbcmath/src/compare.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/debug.c
+++ b/ext/bcmath/libbcmath/src/debug.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/divmod.c
+++ b/ext/bcmath/libbcmath/src/divmod.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/init.c
+++ b/ext/bcmath/libbcmath/src/init.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/int2num.c
+++ b/ext/bcmath/libbcmath/src/int2num.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/nearzero.c
+++ b/ext/bcmath/libbcmath/src/nearzero.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/neg.c
+++ b/ext/bcmath/libbcmath/src/neg.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/num2long.c
+++ b/ext/bcmath/libbcmath/src/num2long.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/num2str.c
+++ b/ext/bcmath/libbcmath/src/num2str.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/outofmem.c
+++ b/ext/bcmath/libbcmath/src/outofmem.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/output.c
+++ b/ext/bcmath/libbcmath/src/output.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/raise.c
+++ b/ext/bcmath/libbcmath/src/raise.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/raisemod.c
+++ b/ext/bcmath/libbcmath/src/raisemod.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/rmzero.c
+++ b/ext/bcmath/libbcmath/src/rmzero.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/sqrt.c
+++ b/ext/bcmath/libbcmath/src/sqrt.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/sub.c
+++ b/ext/bcmath/libbcmath/src/sub.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/bcmath/libbcmath/src/zero.c
+++ b/ext/bcmath/libbcmath/src/zero.c
@@ -31,7 +31,6 @@
 
 #include <config.h>
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>

--- a/ext/mbstring/libmbfl/config.h.in
+++ b/ext/mbstring/libmbfl/config.h.in
@@ -1,8 +1,5 @@
 /* config.h.in.  Generated from configure.in by autoheader.  */
 
-/* Define to 1 if you have the <assert.h> header file. */
-#undef HAVE_ASSERT_H
-
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 

--- a/ext/mbstring/libmbfl/config.h.w32
+++ b/ext/mbstring/libmbfl/config.h.w32
@@ -1,6 +1,5 @@
 #define HAVE_STDIO_H 1
 #define HAVE_STDLIB_H 1
-#define HAVE_ASSERT_H 1
 #define HAVE_MEMORY_H 1
 /* #undef HAVE_STRINGS_H */
 #define HAVE_STRING_H 1

--- a/ext/standard/strnatcmp.c
+++ b/ext/standard/strnatcmp.c
@@ -24,7 +24,6 @@
 
 #include <ctype.h>
 #include <string.h>
-#include <assert.h>
 #include <stdio.h>
 
 #include "php.h"

--- a/main/php.h
+++ b/main/php.h
@@ -123,7 +123,6 @@ typedef int pid_t;
 # endif
 #endif
 
-#if HAVE_ASSERT_H
 #if PHP_DEBUG
 #undef NDEBUG
 #else
@@ -132,9 +131,6 @@ typedef int pid_t;
 #endif
 #endif
 #include <assert.h>
-#else /* HAVE_ASSERT_H */
-#define assert(expr) ((void) (0))
-#endif /* HAVE_ASSERT_H */
 
 #define APACHE 0
 

--- a/main/php_syslog.c
+++ b/main/php_syslog.c
@@ -18,7 +18,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include <stdlib.h>
 #include "php.h"
 #include "php_syslog.h"

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -95,7 +95,6 @@
 #define HAVE_TEMPNAM 1
 #define HAVE_UTIME 1
 #undef HAVE_DIRENT_H
-#define HAVE_ASSERT_H 1
 #define HAVE_FCNTL_H 1
 #define HAVE_GRP_H 0
 #undef HAVE_PWD_H


### PR DESCRIPTION
The `<assert.h>` header file is part of the standard C89 headers [1] and
on older systems there needed to be also a manual check if header is
present.

Since PHP requires at least C89 manual check and the `HAVE_ASSERT_H`
symbol defined by Autoconf in configure.ac can be both removed [2].

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4