### PR TITLE
Remove HAVE_STDDEF_H

### DIFF
--- a/ext/mbstring/libmbfl/config.h.in
+++ b/ext/mbstring/libmbfl/config.h.in
@@ -20,9 +20,6 @@
    and to 0 otherwise. */
 #undef HAVE_REALLOC
 
-/* Define to 1 if you have the <stddef.h> header file. */
-#undef HAVE_STDDEF_H
-
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
 

--- a/ext/mbstring/libmbfl/config.h.w32
+++ b/ext/mbstring/libmbfl/config.h.w32
@@ -1,6 +1,5 @@
 #define HAVE_STDIO_H 1
 #define HAVE_STDLIB_H 1
-#define HAVE_STDDEF_H 1
 #define HAVE_ASSERT_H 1
 #define HAVE_MEMORY_H 1
 /* #undef HAVE_STRINGS_H */

--- a/ext/mbstring/libmbfl/mbfl/mbfilter.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.c
@@ -94,10 +94,6 @@
 #include <strings.h>
 #endif
 
-#ifdef HAVE_STDDEF_H
-#include <stddef.h>
-#endif
-
 #include "mbfilter.h"
 #include "mbfl_filter_output.h"
 #include "mbfilter_8bit.h"

--- a/ext/mbstring/libmbfl/mbfl/mbfilter_8bit.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter_8bit.c
@@ -32,9 +32,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 

--- a/ext/mbstring/libmbfl/mbfl/mbfilter_pass.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter_pass.c
@@ -31,9 +31,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "mbfilter_pass.h"

--- a/ext/mbstring/libmbfl/mbfl/mbfilter_wchar.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter_wchar.c
@@ -32,9 +32,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 

--- a/ext/mbstring/libmbfl/mbfl/mbfl_allocators.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_allocators.c
@@ -48,9 +48,7 @@
 #include <strings.h>
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfl_allocators.h"
 

--- a/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
@@ -32,9 +32,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfl_encoding.h"
 #include "mbfl_allocators.h"

--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
@@ -32,9 +32,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/ext/mbstring/libmbfl/mbfl/mbfl_ident.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_ident.c
@@ -32,9 +32,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfl_ident.h"
 #include "mbfl_allocators.h"

--- a/ext/mbstring/libmbfl/mbfl/mbfl_language.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_language.c
@@ -32,13 +32,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
-
-#ifdef HAVE_STDDEF_H
-#include <stddef.h>
-#endif
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/ext/mbstring/libmbfl/mbfl/mbfl_memory_device.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_memory_device.c
@@ -32,9 +32,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include <string.h>
 #include "mbfl_allocators.h"

--- a/ext/mbstring/libmbfl/mbfl/mbfl_string.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_string.c
@@ -32,9 +32,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfl_allocators.h"
 #include "mbfl_string.h"

--- a/ext/mbstring/libmbfl/nls/nls_de.c
+++ b/ext/mbstring/libmbfl/nls/nls_de.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_de.h"

--- a/ext/mbstring/libmbfl/nls/nls_en.c
+++ b/ext/mbstring/libmbfl/nls/nls_en.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_en.h"

--- a/ext/mbstring/libmbfl/nls/nls_hy.c
+++ b/ext/mbstring/libmbfl/nls/nls_hy.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_hy.h"

--- a/ext/mbstring/libmbfl/nls/nls_ja.c
+++ b/ext/mbstring/libmbfl/nls/nls_ja.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_ja.h"

--- a/ext/mbstring/libmbfl/nls/nls_kr.c
+++ b/ext/mbstring/libmbfl/nls/nls_kr.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_kr.h"

--- a/ext/mbstring/libmbfl/nls/nls_neutral.c
+++ b/ext/mbstring/libmbfl/nls/nls_neutral.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_neutral.h"

--- a/ext/mbstring/libmbfl/nls/nls_ru.c
+++ b/ext/mbstring/libmbfl/nls/nls_ru.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_ru.h"

--- a/ext/mbstring/libmbfl/nls/nls_tr.c
+++ b/ext/mbstring/libmbfl/nls/nls_tr.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_tr.h"

--- a/ext/mbstring/libmbfl/nls/nls_ua.c
+++ b/ext/mbstring/libmbfl/nls/nls_ua.c
@@ -2,11 +2,7 @@
 #include "config.h"
 #endif
 
-
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
-
 
 #include "mbfilter.h"
 #include "nls_ua.h"

--- a/ext/mbstring/libmbfl/nls/nls_uni.c
+++ b/ext/mbstring/libmbfl/nls/nls_uni.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_uni.h"

--- a/ext/mbstring/libmbfl/nls/nls_zh.c
+++ b/ext/mbstring/libmbfl/nls/nls_zh.c
@@ -2,9 +2,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "mbfilter.h"
 #include "nls_zh.h"

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -89,9 +89,7 @@ END_EXTERN_C()
 #include <sys/time.h>
 #endif
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #ifdef PHP_WIN32
 typedef SOCKET php_socket_t;


### PR DESCRIPTION
The `<stddef.h>` header file is part of the standard C89 headers [1] and
on current systems there is no need for a manual check if header is
present.

Since PHP requires at least C89 the `HAVE_STDDEF_H` symbol isn't defined
by Autoconf anywhere else anymore [2] and accross the PHP source code
the header is included unconditionally already.

This patch syncs this also for the bundled libmbfl which is maintaned as
a fork in php-src.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4