### PR TITLE
Add HP-UX specific Changes to build the PHP on HP-UX

### DIFF
--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -75,7 +75,13 @@ static int		ftp_putcmd(	ftpbuf_t *ftp,
 /* wrapper around send/recv to handle timeouts */
 static int		my_send(ftpbuf_t *ftp, php_socket_t s, void *buf, size_t len);
 static int		my_recv(ftpbuf_t *ftp, php_socket_t s, void *buf, size_t len);
+
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+static int		my_accept(ftpbuf_t *ftp, php_socket_t s, struct sockaddr *addr, int *addrlen);
+#else
 static int		my_accept(ftpbuf_t *ftp, php_socket_t s, struct sockaddr *addr, socklen_t *addrlen);
+#endif
 
 /* reads a line the socket , returns true on success, false on error */
 static int		ftp_readline(ftpbuf_t *ftp);
@@ -111,7 +117,12 @@ ftpbuf_t*
 ftp_open(const char *host, short port, zend_long timeout_sec)
 {
 	ftpbuf_t		*ftp;
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+	int 			 size;
+#else
 	socklen_t		 size;
+#endif
 	struct timeval tv;
 
 
@@ -790,7 +801,12 @@ ftp_pasv(ftpbuf_t *ftp, int pasv)
 	char			*ptr;
 	union ipbox		ipbox;
 	unsigned long		b[6];
-	socklen_t			n;
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+	int 			n;
+#else
+	socklen_t		n;
+#endif
 	struct sockaddr *sa;
 	struct sockaddr_in *sin;
 
@@ -1613,7 +1629,12 @@ data_writeable(ftpbuf_t *ftp, php_socket_t s)
 /* {{{ my_accept
  */
 int
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+my_accept(ftpbuf_t *ftp, php_socket_t s, struct sockaddr *addr, int *addrlen)
+#else
 my_accept(ftpbuf_t *ftp, php_socket_t s, struct sockaddr *addr, socklen_t *addrlen)
+#endif
 {
 	int		n;
 
@@ -1644,7 +1665,12 @@ ftp_getdata(ftpbuf_t *ftp)
 	databuf_t		*data;
 	php_sockaddr_storage addr;
 	struct sockaddr *sa;
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+	int			size;
+#else
 	socklen_t		size;
+#endif
 	union ipbox		ipbox;
 	char			arg[sizeof("255, 255, 255, 255, 255, 255")];
 	struct timeval	tv;
@@ -1772,8 +1798,12 @@ databuf_t*
 data_accept(databuf_t *data, ftpbuf_t *ftp)
 {
 	php_sockaddr_storage addr;
-	socklen_t			size;
-
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+        int                     size;
+#else
+        socklen_t               size;
+#endif
 #ifdef HAVE_FTP_SSL
 	SSL_CTX		*ctx;
 	SSL_SESSION *session;

--- a/ext/standard/random.c
+++ b/ext/standard/random.c
@@ -168,7 +168,12 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, zend_bool should_throw)
 		}
 
 		for (read_bytes = 0; read_bytes < size; read_bytes += (size_t) n) {
+#if defined (__hpux)
+/* on HP-UX, for the "bytes" variable, do typecast from "void" to "char" pointer. */
+			n = read(fd, ((char *)bytes) + read_bytes, size - read_bytes);
+#else
 			n = read(fd, bytes + read_bytes, size - read_bytes);
+#endif
 			if (n <= 0) {
 				break;
 			}

--- a/main/network.c
+++ b/main/network.c
@@ -291,7 +291,12 @@ typedef int php_non_blocking_flags_t;
 /* {{{ php_network_connect_socket */
 PHPAPI int php_network_connect_socket(php_socket_t sockfd,
 		const struct sockaddr *addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int	 addrlen,
+#else
 		socklen_t addrlen,
+#endif
 		int asynchronous,
 		struct timeval *timeout,
 		zend_string **error_string,
@@ -300,7 +305,12 @@ PHPAPI int php_network_connect_socket(php_socket_t sockfd,
 	php_non_blocking_flags_t orig_flags;
 	int n;
 	int error = 0;
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+	int	  len;
+#else
 	socklen_t len;
+#endif
 	int ret = 0;
 
 	SET_SOCKET_BLOCKING_MODE(sockfd, orig_flags);
@@ -404,7 +414,12 @@ php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsigned po
 	int num_addrs, n, err = 0;
 	php_socket_t sock;
 	struct sockaddr **sal, **psal, *sa;
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+	int	  socklen;
+#else
 	socklen_t socklen;
+#endif
 	int sockoptval = 1;
 
 	num_addrs = php_network_getaddresses(host, socktype, &psal, error_string);
@@ -500,7 +515,12 @@ bound:
 }
 /* }}} */
 
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+PHPAPI int php_network_parse_network_address_with_port(const char *addr, zend_long addrlen, struct sockaddr *sa, int *sl)
+#else
 PHPAPI int php_network_parse_network_address_with_port(const char *addr, zend_long addrlen, struct sockaddr *sa, socklen_t *sl)
+#endif
 {
 	char *colon;
 	char *tmp;
@@ -589,12 +609,22 @@ out:
 
 PHPAPI void php_network_populate_name_from_sockaddr(
 		/* input address */
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		struct sockaddr *sa, int sl,
+#else
 		struct sockaddr *sa, socklen_t sl,
+#endif
 		/* output readable address */
 		zend_string **textaddr,
 		/* output address */
 		struct sockaddr **addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int *addrlen
+#else
 		socklen_t *addrlen
+#endif
 		)
 {
 	if (addr) {
@@ -655,11 +685,21 @@ PHPAPI void php_network_populate_name_from_sockaddr(
 PHPAPI int php_network_get_peer_name(php_socket_t sock,
 		zend_string **textaddr,
 		struct sockaddr **addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int 	  *addrlen
+#else
 		socklen_t *addrlen
+#endif
 		)
 {
 	php_sockaddr_storage sa;
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+	int sl = sizeof(sa);
+#else
 	socklen_t sl = sizeof(sa);
+#endif
 	memset(&sa, 0, sizeof(sa));
 
 	if (getpeername(sock, (struct sockaddr*)&sa, &sl) == 0) {
@@ -675,11 +715,21 @@ PHPAPI int php_network_get_peer_name(php_socket_t sock,
 PHPAPI int php_network_get_sock_name(php_socket_t sock,
 		zend_string **textaddr,
 		struct sockaddr **addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int 	  *addrlen
+#else
 		socklen_t *addrlen
+#endif
 		)
 {
 	php_sockaddr_storage sa;
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+	int sl = sizeof(sa);
+#else
 	socklen_t sl = sizeof(sa);
+#endif
 	memset(&sa, 0, sizeof(sa));
 
 	if (getsockname(sock, (struct sockaddr*)&sa, &sl) == 0) {
@@ -706,7 +756,12 @@ PHPAPI int php_network_get_sock_name(php_socket_t sock,
 PHPAPI php_socket_t php_network_accept_incoming(php_socket_t srvsock,
 		zend_string **textaddr,
 		struct sockaddr **addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int	  *addrlen,
+#else
 		socklen_t *addrlen,
+#endif
 		struct timeval *timeout,
 		zend_string **error_string,
 		int *error_code,
@@ -716,7 +771,12 @@ PHPAPI php_socket_t php_network_accept_incoming(php_socket_t srvsock,
 	php_socket_t clisock = -1;
 	int error = 0, n;
 	php_sockaddr_storage sa;
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+	int 	  sl;
+#else
 	socklen_t sl;
+#endif
 
 	n = php_pollfd_for(srvsock, PHP_POLLREADABLE, timeout);
 
@@ -772,7 +832,12 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
 	php_socket_t sock;
 	struct sockaddr **sal, **psal, *sa;
 	struct timeval working_timeout;
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+	int  socklen;
+#else
 	socklen_t socklen;
+#endif
 #if HAVE_GETTIMEOFDAY
 	struct timeval limit_time, time_now;
 #endif

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -250,7 +250,12 @@ PHPAPI php_socket_t php_network_connect_socket_to_host(const char *host, unsigne
 
 PHPAPI int php_network_connect_socket(php_socket_t sockfd,
 		const struct sockaddr *addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int addrlen,
+#else
 		socklen_t addrlen,
+#endif
 		int asynchronous,
 		struct timeval *timeout,
 		zend_string **error_string,
@@ -266,7 +271,12 @@ PHPAPI php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsi
 PHPAPI php_socket_t php_network_accept_incoming(php_socket_t srvsock,
 		zend_string **textaddr,
 		struct sockaddr **addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int       *addrlen,
+#else
 		socklen_t *addrlen,
+#endif
 		struct timeval *timeout,
 		zend_string **error_string,
 		int *error_code,
@@ -276,13 +286,23 @@ PHPAPI php_socket_t php_network_accept_incoming(php_socket_t srvsock,
 PHPAPI int php_network_get_sock_name(php_socket_t sock,
 		zend_string **textaddr,
 		struct sockaddr **addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int 	  *addrlen
+#else
 		socklen_t *addrlen
+#endif
 		);
 
 PHPAPI int php_network_get_peer_name(php_socket_t sock,
 		zend_string **textaddr,
 		struct sockaddr **addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int       *addrlen
+#else
 		socklen_t *addrlen
+#endif
 		);
 
 PHPAPI void php_any_addr(int family, php_sockaddr_storage *addr, unsigned short port);
@@ -308,17 +328,31 @@ PHPAPI php_stream *_php_stream_sock_open_host(const char *host, unsigned short p
 		int socktype, struct timeval *timeout, const char *persistent_id STREAMS_DC);
 PHPAPI void php_network_populate_name_from_sockaddr(
 		/* input address */
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		struct sockaddr *sa, int sl,
+#else
 		struct sockaddr *sa, socklen_t sl,
+#endif
 		/* output readable address */
 		zend_string **textaddr,
 		/* output address */
 		struct sockaddr **addr,
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+		int 	 *addrlen
+#else
 		socklen_t *addrlen
+#endif
 		);
-
+#if defined (__hpux)
+/* On HP-UX, socket APIs expect "integer" as data type for length of the "option" data structure. */
+PHPAPI int php_network_parse_network_address_with_port(const char *addr,
+		zend_long addrlen, struct sockaddr *sa, int *sl);
+#else
 PHPAPI int php_network_parse_network_address_with_port(const char *addr,
 		zend_long addrlen, struct sockaddr *sa, socklen_t *sl);
-
+#endif
 PHPAPI struct hostent*	php_network_gethostbyname(char *name);
 
 PHPAPI int php_set_sock_blocking(php_socket_t socketd, int block);

--- a/sapi/apache2handler/php_functions.c
+++ b/sapi/apache2handler/php_functions.c
@@ -44,6 +44,11 @@
 #include "unixd.h"
 #endif
 
+#if defined (__hpux)
+/* HP-UX include following header to get the latest version of apache modules */
+#include "ap_mmn.h"
+#endif
+
 #include "php_apache.h"
 
 #ifdef ZTS

--- a/sapi/phpdbg/phpdbg_out.h
+++ b/sapi/phpdbg/phpdbg_out.h
@@ -46,7 +46,17 @@ PHPDBG_API int phpdbg_xml_internal(int fd, const char *fmt, ...) PHPDBG_ATTRIBUT
 PHPDBG_API int phpdbg_log_internal(int fd, const char *fmt, ...) PHPDBG_ATTRIBUTE_FORMAT(printf, 2, 3);
 PHPDBG_API int phpdbg_out_internal(int fd, const char *fmt, ...) PHPDBG_ATTRIBUTE_FORMAT(printf, 2, 3);
 PHPDBG_API int phpdbg_rlog_internal(int fd, const char *fmt, ...) PHPDBG_ATTRIBUTE_FORMAT(printf, 2, 3);
-
+#if defined ( __hppa)
+/* Compiler of HP-UX on PA-RISC platform,  does not support "variable arguments". */
+#define phpdbg_error(tag, xmlfmt, strfmt, ...)              phpdbg_print(P_ERROR  , PHPDBG_G(io)[PHPDBG_STDOUT].fd, tag,  xmlfmt, strfmt)
+#define phpdbg_notice(tag, xmlfmt, strfmt, ...)             phpdbg_print(P_NOTICE , PHPDBG_G(io)[PHPDBG_STDOUT].fd, tag,  xmlfmt, strfmt)
+#define phpdbg_writeln(tag, xmlfmt, strfmt, ...)            phpdbg_print(P_WRITELN, PHPDBG_G(io)[PHPDBG_STDOUT].fd, tag,  xmlfmt, strfmt)
+#define phpdbg_write(tag, xmlfmt, strfmt, ...)              phpdbg_print(P_WRITE  , PHPDBG_G(io)[PHPDBG_STDOUT].fd, tag,  xmlfmt, strfmt)
+#define phpdbg_script(type, fmt, ...)                       phpdbg_print(type     , PHPDBG_G(io)[PHPDBG_STDOUT].fd, NULL, NULL,   fmt)
+#define phpdbg_log(fmt, ...) phpdbg_log_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt)
+#define phpdbg_xml(fmt, ...) phpdbg_xml_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt)
+#define phpdbg_out(fmt, ...) phpdbg_out_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt)
+#else
 #define phpdbg_error(tag, xmlfmt, strfmt, ...)              phpdbg_print(P_ERROR  , PHPDBG_G(io)[PHPDBG_STDOUT].fd, tag,  xmlfmt, strfmt, ##__VA_ARGS__)
 #define phpdbg_notice(tag, xmlfmt, strfmt, ...)             phpdbg_print(P_NOTICE , PHPDBG_G(io)[PHPDBG_STDOUT].fd, tag,  xmlfmt, strfmt, ##__VA_ARGS__)
 #define phpdbg_writeln(tag, xmlfmt, strfmt, ...)            phpdbg_print(P_WRITELN, PHPDBG_G(io)[PHPDBG_STDOUT].fd, tag,  xmlfmt, strfmt, ##__VA_ARGS__)
@@ -55,6 +65,7 @@ PHPDBG_API int phpdbg_rlog_internal(int fd, const char *fmt, ...) PHPDBG_ATTRIBU
 #define phpdbg_log(fmt, ...) phpdbg_log_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt, ##__VA_ARGS__)
 #define phpdbg_xml(fmt, ...) phpdbg_xml_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt, ##__VA_ARGS__)
 #define phpdbg_out(fmt, ...) phpdbg_out_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt, ##__VA_ARGS__)
+#endif
 
 #define phpdbg_error_ex(out, tag, xmlfmt, strfmt, ...)      phpdbg_print(P_ERROR  , out, tag,  xmlfmt, strfmt, ##__VA_ARGS__)
 #define phpdbg_notice_ex(out, tag, xmlfmt, strfmt, ...)     phpdbg_print(P_NOTICE , out, tag,  xmlfmt, strfmt, ##__VA_ARGS__)


### PR DESCRIPTION
Description:
When we build the PHP on HP-UX machine, we are getting prototype error(compiler error) for some API's and also socket API's fail for 64-bit PHP on HP-UX.

I have fixed these issues in this pull request.
Please review my changes and integrate this changes  to PHP main line  which helps
to build PHP seamlessly on HP-UX.

I have attached that patch to the bug that I submitted earlier:
https://bugs.php.net/bug.php?id=76138   
