### PR TITLE
fix strncpy misuse detected by GCC 8.x

### DIFF
--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -45,33 +45,33 @@ int _pdo_sqlite_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file, int li
 		}
 		einfo->errmsg = pestrdup((char*)sqlite3_errmsg(H->db), dbh->is_persistent);
 	} else { /* no error */
-		strncpy(*pdo_err, PDO_ERR_NONE, sizeof(PDO_ERR_NONE));
+		strlcpy(*pdo_err, PDO_ERR_NONE, sizeof(PDO_ERR_NONE));
 		return 0;
 	}
 	switch (einfo->errcode) {
 		case SQLITE_NOTFOUND:
-			strncpy(*pdo_err, "42S02", sizeof("42S02"));
+			strlcpy(*pdo_err, "42S02", sizeof("42S02"));
 			break;
 
 		case SQLITE_INTERRUPT:
-			strncpy(*pdo_err, "01002", sizeof("01002"));
+			strlcpy(*pdo_err, "01002", sizeof("01002"));
 			break;
 
 		case SQLITE_NOLFS:
-			strncpy(*pdo_err, "HYC00", sizeof("HYC00"));
+			strlcpy(*pdo_err, "HYC00", sizeof("HYC00"));
 			break;
 
 		case SQLITE_TOOBIG:
-			strncpy(*pdo_err, "22001", sizeof("22001"));
+			strlcpy(*pdo_err, "22001", sizeof("22001"));
 			break;
 
 		case SQLITE_CONSTRAINT:
-			strncpy(*pdo_err, "23000", sizeof("23000"));
+			strlcpy(*pdo_err, "23000", sizeof("23000"));
 			break;
 
 		case SQLITE_ERROR:
 		default:
-			strncpy(*pdo_err, "HY000", sizeof("HY000"));
+			strlcpy(*pdo_err, "HY000", sizeof("HY000"));
 			break;
 	}
 


### PR DESCRIPTION
Fix multiple warnings emited by GCC 8.x

/home/crrodriguez/scm/php-src/ext/pdo_sqlite/sqlite_driver.c: In function ‘_pdo_sqlite_error’:
/home/crrodriguez/scm/php-src/ext/pdo_sqlite/sqlite_driver.c:48:41: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
   strncpy(*pdo_err, PDO_ERR_NONE, sizeof(PDO_ERR_NONE));
                                         ^
/home/crrodriguez/scm/php-src/ext/pdo_sqlite/sqlite_driver.c:53:37: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
    strncpy(*pdo_err, "42S02", sizeof("42S02"));
                                     ^
/home/crrodriguez/scm/php-src/ext/pdo_sqlite/sqlite_driver.c:57:37: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
    strncpy(*pdo_err, "01002", sizeof("01002"));
                                     ^
/home/crrodriguez/scm/php-src/ext/pdo_sqlite/sqlite_driver.c:61:37: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
    strncpy(*pdo_err, "HYC00", sizeof("HYC00"));
                                     ^
/home/crrodriguez/scm/php-src/ext/pdo_sqlite/sqlite_driver.c:65:37: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
    strncpy(*pdo_err, "22001", sizeof("22001"));
                                     ^
/home/crrodriguez/scm/php-src/ext/pdo_sqlite/sqlite_driver.c:69:37: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
    strncpy(*pdo_err, "23000", sizeof("23000"));
                                     ^
/home/crrodriguez/scm/php-src/ext/pdo_sqlite/sqlite_driver.c:74:37: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
    strncpy(*pdo_err, "HY000", sizeof("HY000"));

As using strncpy correctly is error prone, switch to strlcpy instead.