### PR TITLE
Remove not needed checking for <errno.h>

### DIFF
--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -17,7 +17,7 @@ if test "$PHP_SOCKETS" != "no"; then
   fi
 
   AC_CHECK_FUNCS([hstrerror socketpair if_nametoindex if_indextoname])
-  AC_CHECK_HEADERS([netdb.h netinet/tcp.h sys/un.h sys/sockio.h errno.h])
+  AC_CHECK_HEADERS([netdb.h netinet/tcp.h sys/un.h sys/sockio.h])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -11,7 +11,7 @@ AC_DEFUN([AC_FPM_STDLIBS],
   AC_SEARCH_LIBS(socket, socket)
   AC_SEARCH_LIBS(inet_addr, nsl)
 
-  AC_CHECK_HEADERS([errno.h fcntl.h stdio.h stdlib.h unistd.h sys/uio.h])
+  AC_CHECK_HEADERS([fcntl.h stdio.h stdlib.h unistd.h sys/uio.h])
   AC_CHECK_HEADERS([sys/select.h sys/socket.h sys/time.h])
   AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
   AC_CHECK_HEADERS([sysexits.h])


### PR DESCRIPTION
Header `<errno.h>` is part of the standard C89 headers [1] and on
current systems checking is not need anymore since PHP requires at
least C89. This is noted also by Autoconf itself in the docs and
code [2].

The Autoconf check defined the `HAVE_ERRNO_H` symbol when building PHP
with sockets extension or fpm sapi. This symbol is not utilized across
the PHP source code except in the current version of bundled GD library
which has worked ok so far also with sockets extension or fpm sapi
disabled anyway.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4