### PR TITLE
Remove HAVE_LIMITS_H

### DIFF
--- a/TSRM/tsrm_config_common.h
+++ b/TSRM/tsrm_config_common.h
@@ -35,9 +35,7 @@ char *alloca ();
 #include <unistd.h>
 #endif
 
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #ifndef MAXPATHLEN
 # if _WIN32

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -48,7 +48,6 @@ fi
 AC_CHECK_HEADERS(
 inttypes.h \
 stdint.h \
-limits.h \
 malloc.h \
 string.h \
 unistd.h \

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -76,9 +76,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 #include <fcntl.h>
 #include <errno.h>
 

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -62,9 +62,7 @@
 # include <dlfcn.h>
 #endif
 
-#ifdef HAVE_LIMITS_H
-# include <limits.h>
-#endif
+#include <limits.h>
 
 #if HAVE_ALLOCA_H && !defined(_ALLOCA_H)
 # include <alloca.h>

--- a/configure.ac
+++ b/configure.ac
@@ -441,7 +441,6 @@ fcntl.h \
 grp.h \
 ieeefp.h \
 langinfo.h \
-limits.h \
 locale.h \
 monetary.h \
 netdb.h \

--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -94,7 +94,7 @@ int main() { return foo(10, "", 3.14); }
         ])
       ])
 
-      AC_CHECK_HEADERS([stdlib.h string.h strings.h unistd.h sys/time.h sys/times.h stdarg.h limits.h])
+      AC_CHECK_HEADERS([stdlib.h string.h strings.h unistd.h sys/time.h sys/times.h stdarg.h])
       AC_CHECK_SIZEOF(int, 4)
       AC_CHECK_SIZEOF(short, 2)
       AC_CHECK_SIZEOF(long, 4)

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -49,9 +49,7 @@
 #include <unistd.h>
 #endif
 
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #ifdef PHP_WIN32
 # include "win32/nice.h"

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -90,12 +90,6 @@ void register_string_constants(INIT_FUNC_ARGS)
 
 #ifdef HAVE_LOCALECONV
 	/* If last members of struct lconv equal CHAR_MAX, no grouping is done */
-
-/* This is bad, but since we are going to be hardcoding in the POSIX stuff anyway... */
-# ifndef HAVE_LIMITS_H
-# define CHAR_MAX 127
-# endif
-
 	REGISTER_LONG_CONSTANT("CHAR_MAX", CHAR_MAX, CONST_CS | CONST_PERSISTENT);
 #endif
 

--- a/ext/standard/url_scanner_ex.c
+++ b/ext/standard/url_scanner_ex.c
@@ -24,9 +24,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -172,7 +170,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("url_rewriter.hosts", "", PHP_INI_ALL, OnUpdateOutputHosts, url_adapt_session_hosts_ht, php_basic_globals, basic_globals)
 PHP_INI_END()
 
-#line 179 "ext/standard/url_scanner_ex.re"
+#line 177 "ext/standard/url_scanner_ex.re"
 
 
 #define YYFILL(n) goto done
@@ -520,7 +518,7 @@ state_plain_begin:
 state_plain:
 	start = YYCURSOR;
 
-#line 524 "ext/standard/url_scanner_ex.c"
+#line 522 "ext/standard/url_scanner_ex.c"
 {
 	YYCTYPE yych;
 	static const unsigned char yybm[] = {
@@ -570,22 +568,22 @@ yy2:
 	if (yybm[0+yych] & 128) {
 		goto yy2;
 	}
-#line 527 "ext/standard/url_scanner_ex.re"
+#line 525 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); goto state_plain; }
-#line 576 "ext/standard/url_scanner_ex.c"
+#line 574 "ext/standard/url_scanner_ex.c"
 yy5:
 	++YYCURSOR;
-#line 526 "ext/standard/url_scanner_ex.re"
+#line 524 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); STATE = STATE_TAG; goto state_tag; }
-#line 581 "ext/standard/url_scanner_ex.c"
+#line 579 "ext/standard/url_scanner_ex.c"
 }
-#line 528 "ext/standard/url_scanner_ex.re"
+#line 526 "ext/standard/url_scanner_ex.re"
 
 
 state_tag:
 	start = YYCURSOR;
 
-#line 589 "ext/standard/url_scanner_ex.c"
+#line 587 "ext/standard/url_scanner_ex.c"
 {
 	YYCTYPE yych;
 	static const unsigned char yybm[] = {
@@ -628,9 +626,9 @@ state_tag:
 		goto yy11;
 	}
 	++YYCURSOR;
-#line 534 "ext/standard/url_scanner_ex.re"
+#line 532 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); goto state_plain_begin; }
-#line 634 "ext/standard/url_scanner_ex.c"
+#line 632 "ext/standard/url_scanner_ex.c"
 yy11:
 	++YYCURSOR;
 	if (YYLIMIT <= YYCURSOR) YYFILL(1);
@@ -638,11 +636,11 @@ yy11:
 	if (yybm[0+yych] & 128) {
 		goto yy11;
 	}
-#line 533 "ext/standard/url_scanner_ex.re"
+#line 531 "ext/standard/url_scanner_ex.re"
 	{ handle_tag(STD_ARGS); /* Sets STATE */; passthru(STD_ARGS); if (STATE == STATE_PLAIN) goto state_plain; else goto state_next_arg; }
-#line 644 "ext/standard/url_scanner_ex.c"
+#line 642 "ext/standard/url_scanner_ex.c"
 }
-#line 535 "ext/standard/url_scanner_ex.re"
+#line 533 "ext/standard/url_scanner_ex.re"
 
 
 state_next_arg_begin:
@@ -651,7 +649,7 @@ state_next_arg_begin:
 state_next_arg:
 	start = YYCURSOR;
 
-#line 655 "ext/standard/url_scanner_ex.c"
+#line 653 "ext/standard/url_scanner_ex.c"
 {
 	YYCTYPE yych;
 	static const unsigned char yybm[] = {
@@ -707,9 +705,9 @@ state_next_arg:
 yy16:
 	++YYCURSOR;
 yy17:
-#line 546 "ext/standard/url_scanner_ex.re"
+#line 544 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); goto state_plain_begin; }
-#line 713 "ext/standard/url_scanner_ex.c"
+#line 711 "ext/standard/url_scanner_ex.c"
 yy18:
 	++YYCURSOR;
 	if (YYLIMIT <= YYCURSOR) YYFILL(1);
@@ -717,30 +715,30 @@ yy18:
 	if (yybm[0+yych] & 128) {
 		goto yy18;
 	}
-#line 544 "ext/standard/url_scanner_ex.re"
+#line 542 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); goto state_next_arg; }
-#line 723 "ext/standard/url_scanner_ex.c"
+#line 721 "ext/standard/url_scanner_ex.c"
 yy21:
 	yych = *++YYCURSOR;
 	if (yych != '>') goto yy17;
 yy22:
 	++YYCURSOR;
-#line 543 "ext/standard/url_scanner_ex.re"
+#line 541 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); handle_form(STD_ARGS); goto state_plain_begin; }
-#line 731 "ext/standard/url_scanner_ex.c"
+#line 729 "ext/standard/url_scanner_ex.c"
 yy24:
 	++YYCURSOR;
-#line 545 "ext/standard/url_scanner_ex.re"
+#line 543 "ext/standard/url_scanner_ex.re"
 	{ --YYCURSOR; STATE = STATE_ARG; goto state_arg; }
-#line 736 "ext/standard/url_scanner_ex.c"
+#line 734 "ext/standard/url_scanner_ex.c"
 }
-#line 547 "ext/standard/url_scanner_ex.re"
+#line 545 "ext/standard/url_scanner_ex.re"
 
 
 state_arg:
 	start = YYCURSOR;
 
-#line 744 "ext/standard/url_scanner_ex.c"
+#line 742 "ext/standard/url_scanner_ex.c"
 {
 	YYCTYPE yych;
 	static const unsigned char yybm[] = {
@@ -785,9 +783,9 @@ state_arg:
 	if (yych <= 'z') goto yy30;
 yy28:
 	++YYCURSOR;
-#line 553 "ext/standard/url_scanner_ex.re"
+#line 551 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); STATE = STATE_NEXT_ARG; goto state_next_arg; }
-#line 791 "ext/standard/url_scanner_ex.c"
+#line 789 "ext/standard/url_scanner_ex.c"
 yy30:
 	++YYCURSOR;
 	if (YYLIMIT <= YYCURSOR) YYFILL(1);
@@ -795,17 +793,17 @@ yy30:
 	if (yybm[0+yych] & 128) {
 		goto yy30;
 	}
-#line 552 "ext/standard/url_scanner_ex.re"
+#line 550 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); handle_arg(STD_ARGS); STATE = STATE_BEFORE_VAL; goto state_before_val; }
-#line 801 "ext/standard/url_scanner_ex.c"
+#line 799 "ext/standard/url_scanner_ex.c"
 }
-#line 554 "ext/standard/url_scanner_ex.re"
+#line 552 "ext/standard/url_scanner_ex.re"
 
 
 state_before_val:
 	start = YYCURSOR;
 
-#line 809 "ext/standard/url_scanner_ex.c"
+#line 807 "ext/standard/url_scanner_ex.c"
 {
 	YYCTYPE yych;
 	static const unsigned char yybm[] = {
@@ -848,9 +846,9 @@ state_before_val:
 	if (yych == '=') goto yy38;
 	++YYCURSOR;
 yy36:
-#line 560 "ext/standard/url_scanner_ex.re"
+#line 558 "ext/standard/url_scanner_ex.re"
 	{ --YYCURSOR; goto state_next_arg_begin; }
-#line 854 "ext/standard/url_scanner_ex.c"
+#line 852 "ext/standard/url_scanner_ex.c"
 yy37:
 	yych = *(YYMARKER = ++YYCURSOR);
 	if (yych == ' ') goto yy41;
@@ -862,9 +860,9 @@ yy38:
 	if (yybm[0+yych] & 128) {
 		goto yy38;
 	}
-#line 559 "ext/standard/url_scanner_ex.re"
+#line 557 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); STATE = STATE_VAL; goto state_val; }
-#line 868 "ext/standard/url_scanner_ex.c"
+#line 866 "ext/standard/url_scanner_ex.c"
 yy41:
 	++YYCURSOR;
 	if (YYLIMIT <= YYCURSOR) YYFILL(1);
@@ -874,14 +872,14 @@ yy41:
 	YYCURSOR = YYMARKER;
 	goto yy36;
 }
-#line 561 "ext/standard/url_scanner_ex.re"
+#line 559 "ext/standard/url_scanner_ex.re"
 
 
 
 state_val:
 	start = YYCURSOR;
 
-#line 885 "ext/standard/url_scanner_ex.c"
+#line 883 "ext/standard/url_scanner_ex.c"
 {
 	YYCTYPE yych;
 	static const unsigned char yybm[] = {
@@ -934,15 +932,15 @@ yy46:
 	if (yybm[0+yych] & 32) {
 		goto yy46;
 	}
-#line 569 "ext/standard/url_scanner_ex.re"
+#line 567 "ext/standard/url_scanner_ex.re"
 	{ handle_val(STD_ARGS, 0, ' '); goto state_next_arg_begin; }
-#line 940 "ext/standard/url_scanner_ex.c"
+#line 938 "ext/standard/url_scanner_ex.c"
 yy49:
 	++YYCURSOR;
 yy50:
-#line 570 "ext/standard/url_scanner_ex.re"
+#line 568 "ext/standard/url_scanner_ex.re"
 	{ passthru(STD_ARGS); goto state_next_arg_begin; }
-#line 946 "ext/standard/url_scanner_ex.c"
+#line 944 "ext/standard/url_scanner_ex.c"
 yy51:
 	yych = *(YYMARKER = ++YYCURSOR);
 	if (yych == '>') goto yy50;
@@ -965,9 +963,9 @@ yy55:
 	goto yy50;
 yy56:
 	++YYCURSOR;
-#line 567 "ext/standard/url_scanner_ex.re"
+#line 565 "ext/standard/url_scanner_ex.re"
 	{ handle_val(STD_ARGS, 1, '"'); goto state_next_arg_begin; }
-#line 971 "ext/standard/url_scanner_ex.c"
+#line 969 "ext/standard/url_scanner_ex.c"
 yy58:
 	++YYCURSOR;
 	if (YYLIMIT <= YYCURSOR) YYFILL(1);
@@ -978,11 +976,11 @@ yy59:
 	}
 	if (yych >= '(') goto yy55;
 	++YYCURSOR;
-#line 568 "ext/standard/url_scanner_ex.re"
+#line 566 "ext/standard/url_scanner_ex.re"
 	{ handle_val(STD_ARGS, 1, '\''); goto state_next_arg_begin; }
-#line 984 "ext/standard/url_scanner_ex.c"
+#line 982 "ext/standard/url_scanner_ex.c"
 }
-#line 571 "ext/standard/url_scanner_ex.re"
+#line 569 "ext/standard/url_scanner_ex.re"
 
 
 stop:

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -22,9 +22,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/main/php.h
+++ b/main/php.h
@@ -266,9 +266,7 @@ char *strerror(int);
 # endif
 #endif
 
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #ifndef LONG_MAX
 #define LONG_MAX 2147483647L

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -59,7 +59,6 @@
 #define HAVE_LIBDL 1
 #define HAVE_GETTIMEOFDAY 1
 #define HAVE_PUTENV 1
-#define HAVE_LIMITS_H 1
 #define HAVE_TZSET 1
 #define HAVE_TZNAME 1
 #undef HAVE_FLOCK


### PR DESCRIPTION
The `<limits.h>` header file is part of the standard C89 headers [1]
and on current systems can be included unconditionally.

Since PHP requires at least C89 or greater, the `HAVE_LIMITS_H` symbol
defined by Autoconf in configure.ac [2] can be ommitted and simplifed.

Current bundled libraries libtime, oniguruma, and libmagic still include
partial `HAVE_LIMITS_H` usage, however they are compiled together with
PHP header files where <limits.h> header is included.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4