### PR TITLE
Fix a typo in Phar module's catch statement's class

### DIFF
--- a/ext/phar/phar/pharcommand.inc
+++ b/ext/phar/phar/pharcommand.inc
@@ -648,7 +648,7 @@ class PharCommand extends CLICommand
 					self::phar_add_file($phar, $level, $dir->getSubPathName(), $file, $compress, $noloader);
 				}
 			}
-		} catch(Excpetion $e) {
+		} catch(Exception $e) {
 			self::error("Unable to complete operation on file '$file'\n" . $e->getMessage() . "\n");
 		}
 	}


### PR DESCRIPTION
I'm not sure which version this should target (7.3 or master seemed safest since many things rely on Phar)

- I'm also not familiar with the code, or if fixing the bug would have unintended consequences.
- However, it seems safe - phar/clicommand.php has `static function error` which will print the error message and exit with an exit code of 1. Previously, the exception would be uncaught

This was detected by a spell checker, not by running into this bug

PR 3433 fixed other typos in ext/phar