### PR TITLE
- silent unitialised var warning

### DIFF
--- a/sapi/phpdbg/phpdbg_out.c
+++ b/sapi/phpdbg/phpdbg_out.c
@@ -872,7 +872,7 @@ PHPDBG_API int phpdbg_xml_vasprintf(char **buf, const char *format, zend_bool es
 }
 /* copy end */
 
-PHPDBG_API int _phpdbg_xml_asprintf(char **buf, const char *format, zend_bool escape_xml, ...) {
+PHPDBG_API int _phpdbg_xml_asprintf(char **buf, const char *format, unsigned int escape_xml, ...) {
 	int ret;
 	va_list va;
 

--- a/sapi/phpdbg/phpdbg_out.h
+++ b/sapi/phpdbg/phpdbg_out.h
@@ -68,7 +68,7 @@ PHPDBG_API int phpdbg_rlog_internal(int fd, const char *fmt, ...) PHPDBG_ATTRIBU
 #define phpdbg_rlog(fd, fmt, ...) phpdbg_rlog_internal(fd, fmt, ##__VA_ARGS__)
 
 #define phpdbg_xml_asprintf(buf, ...) _phpdbg_xml_asprintf(buf, ##__VA_ARGS__)
-PHPDBG_API int _phpdbg_xml_asprintf(char **buf, const char *format, zend_bool escape_xml, ...);
+PHPDBG_API int _phpdbg_xml_asprintf(char **buf, const char *format, unsigned int escape_xml, ...);
 
 #define phpdbg_asprintf(buf, ...) _phpdbg_asprintf(buf, ##__VA_ARGS__)
 PHPDBG_API int _phpdbg_asprintf(char **buf, const char *format, ...);

--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -1014,7 +1014,7 @@ void phpdbg_check_watchpoint(phpdbg_watchpoint_t *watch) {
 	}
 	if (watch->type == WATCH_ON_BUCKET) {
 		if (watch->backup.bucket.key != watch->addr.bucket->key || (watch->backup.bucket.key != NULL && watch->backup.bucket.h != watch->addr.bucket->h)) {
-			phpdbg_watch_element *element;
+			phpdbg_watch_element *element = NULL;
 			zval *new;
 
 			ZEND_HASH_FOREACH_PTR(&watch->elements, element) {


### PR DESCRIPTION
- using a more compatible type to the variadic asprintf-like function