### PR TITLE
Fix 76480: Use curl_multi_wait() so that timeouts are respected

### DIFF
--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -190,7 +190,7 @@ PHP_FUNCTION(curl_multi_remove_handle)
 }
 /* }}} */
 
-#if LIBCURL_VERSION_NUM < 0x071c00 /* Available since 7.28.0 */
+#if LIBCURL_VERSION_NUM < 0x071c00
 static void _make_timeval_struct(struct timeval *to, double timeout) /* {{{ */
 {
 	unsigned long conv;

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -190,6 +190,7 @@ PHP_FUNCTION(curl_multi_remove_handle)
 }
 /* }}} */
 
+#if LIBCURL_VERSION_NUM < 0x071c00 /* Available since 7.28.0 */
 static void _make_timeval_struct(struct timeval *to, double timeout) /* {{{ */
 {
 	unsigned long conv;
@@ -199,6 +200,7 @@ static void _make_timeval_struct(struct timeval *to, double timeout) /* {{{ */
 	to->tv_usec = conv % 1000000;
 }
 /* }}} */
+#endif
 
 /* {{{ proto int curl_multi_select(resource mh[, double timeout])
    Get all the sockets associated with the cURL extension, which can then be "selected" */

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -206,12 +206,16 @@ PHP_FUNCTION(curl_multi_select)
 {
 	zval           *z_mh;
 	php_curlm      *mh;
+	double          timeout = 1.0;
+#if LIBCURL_VERSION_NUM >= 0x071c00 /* Available since 7.28.0 */
+	int             numfds = 0;
+#else
 	fd_set          readfds;
 	fd_set          writefds;
 	fd_set          exceptfds;
 	int             maxfd;
-	double          timeout = 1.0;
 	struct timeval  to;
+#endif
 	CURLMcode error = CURLM_OK;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|d", &z_mh, &timeout) == FAILURE) {
@@ -222,6 +226,15 @@ PHP_FUNCTION(curl_multi_select)
 		RETURN_FALSE;
 	}
 
+#if LIBCURL_VERSION_NUM >= 0x071c00 /* Available since 7.28.0 */
+	error = curl_multi_wait(mh->multi, NULL, 0, (unsigned long) timeout * 1000.0, &numfds);
+	if (CURLM_OK != error) {
+		SAVE_CURLM_ERROR(mh, error);
+		RETURN_LONG(-1);
+	}
+
+	RETURN_LONG(numfds);
+#else
 	_make_timeval_struct(&to, timeout);
 
 	FD_ZERO(&readfds);
@@ -235,6 +248,7 @@ PHP_FUNCTION(curl_multi_select)
 		RETURN_LONG(-1);
 	}
 	RETURN_LONG(select(maxfd + 1, &readfds, &writefds, &exceptfds, &to));
+#endif
 }
 /* }}} */
 


### PR DESCRIPTION
[Bug #76480](https://bugs.php.net/bug.php?id=76480)

libcurl 7.28 introduced `curl_multi_wait()`, which is a `select()` wrapper that respects configured timeouts.

This patch will change the implementation of `php curl_multi_select` to use `curl_multi_wait` instead of `curl_multi_fdset` and `select`. It will fix #76480 but also unliked behaviour like #63411.

**Unless anyone have any objection, I plan to commit it on PHP-7.1 since there should not be any BC.**