### PR TITLE
Fix #76834: single-char scheme not recognized

### DIFF
--- a/ext/standard/tests/streams/bug76834.phpt
+++ b/ext/standard/tests/streams/bug76834.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #76834 (single-char schemes are not recognized)
+--FILE--
+<?php
+$path = "0://google.com/../../INSTALL";
+var_dump(file_get_contents($path, false, null, 0, 10));
+?>
+===DONE===
+--EXPECTF--
+Warning: file_get_contents(): Unable to find the wrapper "0" - did you forget to enable it when you configured PHP? in %s on line %d
+string(10) "For instal"
+===DONE===

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1737,7 +1737,7 @@ PHPAPI php_stream_wrapper *php_stream_locate_url_wrapper(const char *path, const
 		n++;
 	}
 
-	if ((*p == ':') && (n > 1) && (!strncmp("//", p+1, 2) || (n == 4 && !memcmp("data:", path, 5)))) {
+	if ((*p == ':') && (n >= 1) && (!strncmp("//", p+1, 2) || (n == 4 && !memcmp("data:", path, 5)))) {
 		protocol = path;
 	}
 


### PR DESCRIPTION
According to RFC 3986, section 3.1, schemes consisting of a single
letter are valid[1].  Therefore we should recognize single-character
schemes, since we already recognize schemes where the first character
is not a letter.

We acknowledge the minor BC break with regard to Windows drive
letters, where paths like `C://Windows` have not issued a warning, but
now would.

[1] <https://tools.ietf.org/html/rfc3986#section-3.1>