### PR TITLE
Allow empty $escape to eschew escaping CSV

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -323,7 +323,7 @@ static int spl_filesystem_file_open(spl_filesystem_object *intern, int use_inclu
 
 	intern->u.file.delimiter = ',';
 	intern->u.file.enclosure = '"';
-	intern->u.file.escape = '\\';
+	intern->u.file.escape = (unsigned char) '\\';
 
 	intern->u.file.func_getCurr = zend_hash_str_find_ptr(&intern->std.ce->function_table, "getcurrentline", sizeof("getcurrentline") - 1);
 
@@ -2109,7 +2109,7 @@ static int spl_filesystem_file_call(spl_filesystem_object *intern, zend_function
 	spl_filesystem_file_call(intern, func_ptr, pass_num_args, return_value, arg2); \
 } /* }}} */
 
-static int spl_filesystem_file_read_csv(spl_filesystem_object *intern, char delimiter, char enclosure, char escape, zval *return_value) /* {{{ */
+static int spl_filesystem_file_read_csv(spl_filesystem_object *intern, char delimiter, char enclosure, int escape, zval *return_value) /* {{{ */
 {
 	int ret = SUCCESS;
 	zval *value;
@@ -2562,7 +2562,8 @@ SPL_METHOD(SplFileObject, func_name) \
 SPL_METHOD(SplFileObject, fgetcsv)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
-	char delimiter = intern->u.file.delimiter, enclosure = intern->u.file.enclosure, escape = intern->u.file.escape;
+	char delimiter = intern->u.file.delimiter, enclosure = intern->u.file.enclosure;
+	int escape = intern->u.file.escape;
 	char *delim = NULL, *enclo = NULL, *esc = NULL;
 	size_t d_len = 0, e_len = 0, esc_len = 0;
 
@@ -2576,11 +2577,15 @@ SPL_METHOD(SplFileObject, fgetcsv)
 		switch(ZEND_NUM_ARGS())
 		{
 		case 3:
-			if (esc_len != 1) {
-				php_error_docref(NULL, E_WARNING, "escape must be a character");
+			if (esc_len > 1) {
+				php_error_docref(NULL, E_WARNING, "escape must be empty or a single character");
 				RETURN_FALSE;
 			}
-			escape = esc[0];
+			if (esc_len == 0) {
+				escape = PHP_CSV_NO_ESCAPE;
+			} else {
+				escape = (unsigned char) esc[0];
+			}
 			/* no break */
 		case 2:
 			if (e_len != 1) {
@@ -2609,7 +2614,8 @@ SPL_METHOD(SplFileObject, fgetcsv)
 SPL_METHOD(SplFileObject, fputcsv)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
-	char delimiter = intern->u.file.delimiter, enclosure = intern->u.file.enclosure, escape = intern->u.file.escape;
+	char delimiter = intern->u.file.delimiter, enclosure = intern->u.file.enclosure;
+	int escape = intern->u.file.escape;
 	char *delim = NULL, *enclo = NULL, *esc = NULL;
 	size_t d_len = 0, e_len = 0, esc_len = 0;
 	zend_long ret;
@@ -2619,11 +2625,17 @@ SPL_METHOD(SplFileObject, fputcsv)
 		switch(ZEND_NUM_ARGS())
 		{
 		case 4:
-			if (esc_len != 1) {
-				php_error_docref(NULL, E_WARNING, "escape must be a character");
-				RETURN_FALSE;
+			switch (esc_len) {
+				case 0:
+					escape = PHP_CSV_NO_ESCAPE;
+					break;
+				case 1:
+					escape = (unsigned char) esc[0];
+					break;
+				default:
+					php_error_docref(NULL, E_WARNING, "escape must be empty or a single character");
+					RETURN_FALSE;
 			}
-			escape = esc[0];
 			/* no break */
 		case 3:
 			if (e_len != 1) {
@@ -2654,7 +2666,8 @@ SPL_METHOD(SplFileObject, fputcsv)
 SPL_METHOD(SplFileObject, setCsvControl)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
-	char delimiter = ',', enclosure = '"', escape='\\';
+	char delimiter = ',', enclosure = '"';
+	int escape = (unsigned char) '\\';
 	char *delim = NULL, *enclo = NULL, *esc = NULL;
 	size_t d_len = 0, e_len = 0, esc_len = 0;
 
@@ -2662,11 +2675,17 @@ SPL_METHOD(SplFileObject, setCsvControl)
 		switch(ZEND_NUM_ARGS())
 		{
 		case 3:
-			if (esc_len != 1) {
-				php_error_docref(NULL, E_WARNING, "escape must be a character");
-				RETURN_FALSE;
+			switch (esc_len) {
+				case 0: 
+					escape = PHP_CSV_NO_ESCAPE;
+					break;
+				case 1:
+					escape = (unsigned char) esc[0];
+					break;
+				default:
+					php_error_docref(NULL, E_WARNING, "escape must be empty or a single character");
+					RETURN_FALSE;
 			}
-			escape = esc[0];
 			/* no break */
 		case 2:
 			if (e_len != 1) {
@@ -2705,8 +2724,12 @@ SPL_METHOD(SplFileObject, getCsvControl)
 	delimiter[1] = '\0';
 	enclosure[0] = intern->u.file.enclosure;
 	enclosure[1] = '\0';
-	escape[0] = intern->u.file.escape;
-	escape[1] = '\0';
+	if (intern->u.file.escape == PHP_CSV_NO_ESCAPE) {
+		escape[0] = '\0';
+	} else {
+		escape[0] = (unsigned char) intern->u.file.escape;
+		escape[1] = '\0';
+	}
 
 	add_next_index_string(return_value, delimiter);
 	add_next_index_string(return_value, enclosure);

--- a/ext/spl/spl_directory.h
+++ b/ext/spl/spl_directory.h
@@ -96,7 +96,7 @@ struct _spl_filesystem_object {
 			zend_function      *func_getCurr;
 			char               delimiter;
 			char               enclosure;
-			char               escape;
+			int                escape;
 		} file;
 	} u;
 	zend_object        std;

--- a/ext/spl/tests/SplFileObject_fgetcsv_escape_empty.phpt
+++ b/ext/spl/tests/SplFileObject_fgetcsv_escape_empty.phpt
@@ -1,0 +1,31 @@
+--TEST--
+SplFileObject::fgetcsv() with empty $escape
+--FILE--
+<?php
+$contents = <<<EOS
+"cell1","cell2\\","cell3","cell4"
+"\\\\\\line1
+line2\\\\\\"
+EOS;
+$file = new SplTempFileObject;
+$file->fwrite($contents);
+$file->rewind();
+while (($data = $file->fgetcsv(',', '"', ''))) {
+    print_r($data);
+}
+?>
+===DONE===
+--EXPECT--
+Array
+(
+    [0] => cell1
+    [1] => cell2\
+    [2] => cell3
+    [3] => cell4
+)
+Array
+(
+    [0] => \\\line1
+line2\\\
+)
+===DONE===

--- a/ext/spl/tests/SplFileObject_fgetcsv_escape_error.phpt
+++ b/ext/spl/tests/SplFileObject_fgetcsv_escape_error.phpt
@@ -14,5 +14,5 @@ var_dump($fo->fgetcsv(',', '"', 'invalid'));
 unlink('SplFileObject__fgetcsv8.csv');
 ?>
 --EXPECTF--
-Warning: SplFileObject::fgetcsv(): escape must be a character in %s on line %d
+Warning: SplFileObject::fgetcsv(): escape must be empty or a single character in %s on line %d
 bool(false)

--- a/ext/spl/tests/SplFileObject_fputcsv_variation15.phpt
+++ b/ext/spl/tests/SplFileObject_fputcsv_variation15.phpt
@@ -1,0 +1,22 @@
+--TEST--
+SplFileObject::fputcsv() with empty $escape
+--FILE--
+<?php
+$data = array(
+    ['\\'],
+    ['\\"']
+);
+$file = new SplTempFileObject;
+foreach ($data as $record) {
+    $file->fputcsv($record, ',', '"', '');
+}
+$file->rewind();
+foreach ($file as $line) {
+    echo $line;
+}
+?>
+===DONE===
+--EXPECT--
+\
+"\"""
+===DONE===

--- a/ext/spl/tests/SplFileObject_setCsvControl_error003.phpt
+++ b/ext/spl/tests/SplFileObject_setCsvControl_error003.phpt
@@ -22,4 +22,4 @@ $s->setCsvControl('|', '\'', 'three');
 unlink('csv_control_data.csv');
 ?>
 --EXPECTF--
-Warning: SplFileObject::setCsvControl(): escape must be a character in %s on line %d
+Warning: SplFileObject::setCsvControl(): escape must be empty or a single character in %s on line %d

--- a/ext/spl/tests/SplFileObject_setCsvControl_variation002.phpt
+++ b/ext/spl/tests/SplFileObject_setCsvControl_variation002.phpt
@@ -1,0 +1,19 @@
+--TEST--
+SplFileObject::setCsvControl() and ::getCsvControl() with empty $escape
+--FILE--
+<?php
+$file = new SplTempFileObject;
+$file->setCsvControl(',', '"', '');
+var_dump($file->getCsvControl());
+?>
+===DONE===
+--EXPECT--
+array(3) {
+  [0]=>
+  string(1) ","
+  [1]=>
+  string(1) """
+  [2]=>
+  string(0) ""
+}
+===DONE===

--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -77,8 +77,10 @@ PHPAPI int php_copy_file_ex(const char *src, const char *dest, int src_chk);
 PHPAPI int php_copy_file_ctx(const char *src, const char *dest, int src_chk, php_stream_context *ctx);
 PHPAPI int php_mkdir_ex(const char *dir, zend_long mode, int options);
 PHPAPI int php_mkdir(const char *dir, zend_long mode);
-PHPAPI void php_fgetcsv(php_stream *stream, char delimiter, char enclosure, char escape_char, size_t buf_len, char *buf, zval *return_value);
-PHPAPI size_t php_fputcsv(php_stream *stream, zval *fields, char delimiter, char enclosure, char escape_char);
+
+#define PHP_CSV_NO_ESCAPE EOF
+PHPAPI void php_fgetcsv(php_stream *stream, char delimiter, char enclosure, int escape_char, size_t buf_len, char *buf, zval *return_value);
+PHPAPI size_t php_fputcsv(php_stream *stream, zval *fields, char delimiter, char enclosure, int escape_char);
 
 #define META_DEF_BUFSIZE 8192
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5365,7 +5365,8 @@ Parse a CSV string into an array */
 PHP_FUNCTION(str_getcsv)
 {
 	zend_string *str;
-	char delim = ',', enc = '"', esc = '\\';
+	char delim = ',', enc = '"';
+	int esc = (unsigned char) '\\';
 	char *delim_str = NULL, *enc_str = NULL, *esc_str = NULL;
 	size_t delim_len = 0, enc_len = 0, esc_len = 0;
 
@@ -5379,7 +5380,9 @@ PHP_FUNCTION(str_getcsv)
 
 	delim = delim_len ? delim_str[0] : delim;
 	enc = enc_len ? enc_str[0] : enc;
-	esc = esc_len ? esc_str[0] : esc;
+	if (esc_str != NULL) {
+		esc = esc_len ? (unsigned char) esc_str[0] : PHP_CSV_NO_ESCAPE;
+	}
 
 	php_fgetcsv(NULL, delim, enc, esc, ZSTR_LEN(str), ZSTR_VAL(str), return_value);
 }

--- a/ext/standard/tests/file/fgetcsv_variation32.phpt
+++ b/ext/standard/tests/file/fgetcsv_variation32.phpt
@@ -1,0 +1,32 @@
+--TEST--
+fgetcsv() with empty $escape
+--FILE--
+<?php
+$contents = <<<EOS
+"cell1","cell2\\","cell3","cell4"
+"\\\\\\line1
+line2\\\\\\"
+EOS;
+$stream = fopen('php://memory', 'w+');
+fwrite($stream, $contents);
+rewind($stream);
+while (($data = fgetcsv($stream, 0, ',', '"', '')) !== false) {
+    print_r($data);
+}
+fclose($stream);
+?>
+===DONE===
+--EXPECT--
+Array
+(
+    [0] => cell1
+    [1] => cell2\
+    [2] => cell3
+    [3] => cell4
+)
+Array
+(
+    [0] => \\\line1
+line2\\\
+)
+===DONE===

--- a/ext/standard/tests/file/fputcsv_variation16.phpt
+++ b/ext/standard/tests/file/fputcsv_variation16.phpt
@@ -1,0 +1,21 @@
+--TEST--
+fputcsv() with empty $escape
+--FILE--
+<?php
+$data = array(
+    ['\\'],
+    ['\\"']
+);
+$stream = fopen('php://memory', 'w+');
+foreach ($data as $record) {
+    fputcsv($stream, $record, ',', '"', '');
+}
+rewind($stream);
+echo stream_get_contents($stream);
+fclose($stream);
+?>
+===DONE===
+--EXPECT--
+\
+"\"""
+===DONE===

--- a/ext/standard/tests/strings/str_getcsv_002.phpt
+++ b/ext/standard/tests/strings/str_getcsv_002.phpt
@@ -1,0 +1,19 @@
+--TEST--
+str_getcsv() with empty $escape
+--FILE--
+<?php
+$contents = <<<EOS
+"cell1","cell2\\","cell3","cell4"
+EOS;
+print_r(str_getcsv($contents, ',', '"', ''));
+?>
+===DONE===
+--EXPECT--
+Array
+(
+    [0] => cell1
+    [1] => cell2\
+    [2] => cell3
+    [3] => cell4
+)
+===DONE===


### PR DESCRIPTION
Albeit CSV is still a widespread data exchange format, it has never been
officially standardized.  There exists, however, the “informational” RFC
4180[1] which has no notion of escape characters, but rather defines
`escaped` as strings enclosed in double-quotes where contained
double-quotes have to be doubled.  While this concept is supported by
PHP's implementation (`$enclosure`), the `$escape` sometimes interferes,
so that `fgetcsv()` is unable to correctly parse externally generated
CSV, and `fputcsv()` is sometimes generating non-compliant CSV.  Since
PHP's `$escape` concept is availble for many years, we cannot drop it
for BC reasons (even though many consider it as bug).  Instead we allow
to pass an empty string as `$escape` parameter to the respective
functions, which results in ignoring/omitting any escaping, and as such
is more inline with RFC 4180.  It is noteworthy that this is almost no
userland BC break, since formerly most functions did not accept an empty
string, and failed in this case.  The only exception was `str_getcsv()`
which did accept an empty string, and used a backslash as escape
character then (which appears to be unintended behavior, anyway).

The changed functions are `fputcsv()`, `fgetcsv()` and `str_getcsv()`,
and also the `::setCsvControl()`, `::getCsvControl()`, `::fputcsv()`,
and `::fgetcsv()` methods of `SplFileObject`.

The implementation also changes the type of the escape parameter of the
PHP_APIs `php_fgetcsv()` and `php_fputcsv()` from `char` to `int`, where
`EOF` means to ignore/omit escaping.  The parameter accepts the same
values as `isalpha()` and friends, i.e. “the value of which shall be
representable as an `unsigned char` or shall equal the value of the
macro `EOF`.  If the argument has any other value, the behavior is
undefined.”  This is a subtle BC break, since the character `chr(128)`
has the value `-1` if `char` is signed, and so likely would be confused
with `EOF` when converted to `int`.  We consider this BC break to be
acceptable, since it's rather unlikely that anybody uses `chr(128)` as
escape character, and it easily can be fixed by casting all `escape`
arguments to `unsigned char`.

This patch implements the feature requests 38301[2] and 51496[3].

[1] <https://tools.ietf.org/html/rfc4180>
[2] <https://bugs.php.net/bug.php?id=38301>
[3] <https://bugs.php.net/bug.php?id=51496>