### PR TITLE
Remove HAVE_STDLIB_H

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -57,7 +57,6 @@ sys/types.h \
 sys/time.h \
 signal.h \
 unix.h \
-stdlib.h \
 cpuid.h \
 dlfcn.h)
 

--- a/Zend/configure.ac
+++ b/Zend/configure.ac
@@ -28,9 +28,7 @@ AH_TOP([
 AH_BOTTOM([
 #ifndef ZEND_ACCONFIG_H_NO_C_PROTOS
 
-#ifdef HAVE_STDLIB_H
-# include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 #ifdef HAVE_SYS_TYPES_H
 # include <sys/types.h>

--- a/configure.ac
+++ b/configure.ac
@@ -37,9 +37,7 @@ AH_TOP([
 AH_BOTTOM([
 #ifndef ZEND_ACCONFIG_H_NO_C_PROTOS
 
-#ifdef HAVE_STDLIB_H
-# include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 #ifdef HAVE_SYS_TYPES_H
 # include <sys/types.h>
@@ -449,7 +447,6 @@ pwd.h \
 resolv.h \
 signal.h \
 stdarg.h \
-stdlib.h \
 string.h \
 syslog.h \
 sysexits.h \

--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -29,10 +29,7 @@
 #include "SAPI.h"
 #include "php_ini.h"
 
-#ifdef HAVE_STDLIB_H
-# include <stdlib.h>
-#endif
-
+#include <stdlib.h>
 #include <errno.h>
 
 #include "php_iconv.h"

--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -94,7 +94,7 @@ int main() { return foo(10, "", 3.14); }
         ])
       ])
 
-      AC_CHECK_HEADERS([stdlib.h string.h strings.h unistd.h sys/time.h sys/times.h stdarg.h limits.h])
+      AC_CHECK_HEADERS([string.h strings.h unistd.h sys/time.h sys/times.h stdarg.h limits.h])
       AC_CHECK_SIZEOF(int, 4)
       AC_CHECK_SIZEOF(short, 2)
       AC_CHECK_SIZEOF(long, 4)

--- a/ext/mbstring/config.w32
+++ b/ext/mbstring/config.w32
@@ -15,7 +15,7 @@ if (PHP_MBSTRING != "no") {
 
 	ADD_FLAG("CFLAGS_MBSTRING", "-Iext/mbstring/libmbfl -Iext/mbstring/libmbfl/mbfl \
 		-Iext/mbstring/oniguruma /D NOT_RUBY=1 /D LIBMBFL_EXPORTS=1 \
-		/D HAVE_STDARG_PROTOTYPES=1 /D HAVE_CONFIG_H /D HAVE_STDLIB_H \
+		/D HAVE_STDARG_PROTOTYPES=1 /D HAVE_CONFIG_H \
 		/D HAVE_STRICMP /D MBFL_DLL_EXPORT=1 /D ONIGURUMA_EXPORT /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1")
 
 	FSO.CopyFile("ext\\mbstring\\libmbfl\\config.h.w32",

--- a/ext/mbstring/libmbfl/config.h.in
+++ b/ext/mbstring/libmbfl/config.h.in
@@ -20,9 +20,6 @@
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
 
-/* Define to 1 if you have the <stdlib.h> header file. */
-#undef HAVE_STDLIB_H
-
 /* Define to 1 if you have the `strcasecmp' function. */
 #undef HAVE_STRCASECMP
 

--- a/ext/mbstring/libmbfl/config.h.w32
+++ b/ext/mbstring/libmbfl/config.h.w32
@@ -1,5 +1,4 @@
 #define HAVE_STDIO_H 1
-#define HAVE_STDLIB_H 1
 #define HAVE_MEMORY_H 1
 /* #undef HAVE_STRINGS_H */
 #define HAVE_STRING_H 1

--- a/ext/mbstring/libmbfl/mbfl/mbfl_allocators.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_allocators.c
@@ -32,9 +32,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 #ifdef HAVE_MEMORY_H
 #include <memory.h>

--- a/ext/xmlrpc/libxmlrpc/acinclude.m4
+++ b/ext/xmlrpc/libxmlrpc/acinclude.m4
@@ -12,7 +12,7 @@ AC_CHECK_FUNCS( \
 
 AC_DEFUN([XMLRPC_HEADER_CHECKS],[
 AC_HEADER_STDC
-AC_CHECK_HEADERS(xmlparse.h xmltok.h stdlib.h strings.h string.h)
+AC_CHECK_HEADERS(xmlparse.h xmltok.h strings.h string.h)
 ])
 
 AC_DEFUN([XMLRPC_TYPE_CHECKS],[

--- a/main/alloca.c
+++ b/main/alloca.c
@@ -28,9 +28,8 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif
-#ifdef HAVE_STDLIB_H
+
 #include <stdlib.h>
-#endif
 
 #ifdef emacs
 #include "blockinput.h"

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -11,7 +11,7 @@ AC_DEFUN([AC_FPM_STDLIBS],
   AC_SEARCH_LIBS(socket, socket)
   AC_SEARCH_LIBS(inet_addr, nsl)
 
-  AC_CHECK_HEADERS([fcntl.h stdio.h stdlib.h unistd.h sys/uio.h])
+  AC_CHECK_HEADERS([fcntl.h stdio.h unistd.h sys/uio.h])
   AC_CHECK_HEADERS([sys/select.h sys/socket.h sys/time.h])
   AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
   AC_CHECK_HEADERS([sysexits.h])

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -28,10 +28,7 @@
 #include "lsapilib.h"
 
 #include <stdio.h>
-
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 #if HAVE_UNISTD_H
 #include <unistd.h>

--- a/sapi/litespeed/lscriu.c
+++ b/sapi/litespeed/lscriu.c
@@ -51,10 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "lsapilib.h"
 
 #include <stdio.h>
-
-#if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 #if HAVE_UNISTD_H
 #include <unistd.h>

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -161,7 +161,6 @@
 #ifndef _WIN64
 # define _USE_32BIT_TIME_T 1
 #endif
-#define HAVE_STDLIB_H 1
 
 #define _REENTRANT 1
 #define HAVE_MBRLEN 1


### PR DESCRIPTION
The C89 and later standard defines the `<stdlib.h>` header as part of
the standard headers [1] and on current systems it is always present
and the `HAVE_STDLIB_H` symbol can be removed.

Also Autoconf suggests doing this and relying on C89 or above [2] and [3].

[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4
[3] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html