### PR TITLE
Remove HAVE_STRING_H

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -50,7 +50,6 @@ inttypes.h \
 stdint.h \
 limits.h \
 malloc.h \
-string.h \
 unistd.h \
 stdarg.h \
 sys/types.h \

--- a/Zend/configure.ac
+++ b/Zend/configure.ac
@@ -42,11 +42,7 @@ AH_BOTTOM([
 # include <ieeefp.h>
 #endif
 
-#ifdef HAVE_STRING_H
-# include <string.h>
-#else
-# include <strings.h>
-#endif
+#include <string.h>
 
 #if ZEND_BROKEN_SPRINTF
 int zend_sprintf(char *buffer, const char *format, ...);

--- a/configure.ac
+++ b/configure.ac
@@ -51,11 +51,7 @@ AH_BOTTOM([
 # include <ieeefp.h>
 #endif
 
-#ifdef HAVE_STRING_H
-# include <string.h>
-#else
-# include <strings.h>
-#endif
+#include <string.h>
 
 #if ZEND_BROKEN_SPRINTF
 int zend_sprintf(char *buffer, const char *format, ...);
@@ -447,7 +443,6 @@ pwd.h \
 resolv.h \
 signal.h \
 stdarg.h \
-string.h \
 syslog.h \
 sysexits.h \
 sys/ioctl.h \

--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -94,7 +94,7 @@ int main() { return foo(10, "", 3.14); }
         ])
       ])
 
-      AC_CHECK_HEADERS([string.h strings.h unistd.h sys/time.h sys/times.h stdarg.h limits.h])
+      AC_CHECK_HEADERS([strings.h unistd.h sys/time.h sys/times.h stdarg.h limits.h])
       AC_CHECK_SIZEOF(int, 4)
       AC_CHECK_SIZEOF(short, 2)
       AC_CHECK_SIZEOF(long, 4)

--- a/ext/mbstring/libmbfl/config.h.in
+++ b/ext/mbstring/libmbfl/config.h.in
@@ -29,9 +29,6 @@
 /* Define to 1 if you have the <strings.h> header file. */
 #undef HAVE_STRINGS_H
 
-/* Define to 1 if you have the <string.h> header file. */
-#undef HAVE_STRING_H
-
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #undef HAVE_SYS_STAT_H
 

--- a/ext/mbstring/libmbfl/config.h.w32
+++ b/ext/mbstring/libmbfl/config.h.w32
@@ -1,7 +1,6 @@
 #define HAVE_STDIO_H 1
 #define HAVE_MEMORY_H 1
 /* #undef HAVE_STRINGS_H */
-#define HAVE_STRING_H 1
 /* #undef HAVE_STRCASECMP */
 #define HAVE_STRICMP 1
 #define HAVE_WIN32_NATIVE_THREAD 1

--- a/ext/mbstring/libmbfl/filters/mbfilter_htmlent.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_htmlent.c
@@ -31,14 +31,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
-
-#ifdef HAVE_STRINGS_H
-#include <strings.h>
-#endif
-
 #include "mbfilter.h"
 #include "mbfilter_htmlent.h"
 #include "html_entities.h"

--- a/ext/mbstring/libmbfl/mbfl/mbfilter.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.c
@@ -85,14 +85,7 @@
 #endif
 
 #include <stddef.h>
-
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
-
-#ifdef HAVE_STRINGS_H
-#include <strings.h>
-#endif
 
 #include "mbfilter.h"
 #include "mbfl_filter_output.h"

--- a/ext/mbstring/libmbfl/mbfl/mbfl_allocators.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_allocators.c
@@ -38,14 +38,7 @@
 #include <memory.h>
 #endif
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
-
-#ifdef HAVE_STRINGS_H
-#include <strings.h>
-#endif
-
 #include <stddef.h>
 
 #include "mbfl_allocators.h"

--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
@@ -33,10 +33,7 @@
 #endif
 
 #include <stddef.h>
-
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #ifdef HAVE_STRINGS_H
 #include <strings.h>

--- a/ext/mbstring/libmbfl/mbfl/mbfl_language.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_language.c
@@ -33,10 +33,7 @@
 #endif
 
 #include <stddef.h>
-
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #ifdef HAVE_STRINGS_H
 #include <strings.h>

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -28,11 +28,7 @@
 #include <math.h>
 #include <time.h>
 #include <stdio.h>
-#if HAVE_STRING_H
 #include <string.h>
-#else
-#include <strings.h>
-#endif
 #ifdef PHP_WIN32
 #include "win32/unistd.h"
 #endif

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -75,11 +75,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 # include <unistd.h>
 #endif
 
-#if HAVE_STRING_H
-# include <string.h>
-#else
-# include <strings.h>
-#endif
+#include <string.h>
 
 #if HAVE_LOCALE_H
 # include <locale.h>

--- a/ext/standard/crypt.c
+++ b/ext/standard/crypt.c
@@ -38,11 +38,7 @@
 # endif
 #endif
 #include <time.h>
-#if HAVE_STRING_H
 #include <string.h>
-#else
-#include <strings.h>
-#endif
 
 #ifdef PHP_WIN32
 #include <process.h>

--- a/ext/standard/crypt_sha256.c
+++ b/ext/standard/crypt_sha256.c
@@ -26,11 +26,7 @@
 #else
 # include <sys/param.h>
 # include <sys/types.h>
-# if HAVE_STRING_H
-#  include <string.h>
-# else
-#  include <strings.h>
-# endif
+# include <string.h>
 #endif
 
 char * __php_stpncpy(char *dst, const char *src, size_t len)

--- a/ext/standard/crypt_sha512.c
+++ b/ext/standard/crypt_sha512.c
@@ -25,11 +25,7 @@
 #else
 # include <sys/param.h>
 # include <sys/types.h>
-# if HAVE_STRING_H
-#  include <string.h>
-# else
-#  include <strings.h>
-# endif
+# include <string.h>
 #endif
 
 extern void * __php_mempcpy(void * dst, const void * src, size_t len);

--- a/ext/standard/dl.c
+++ b/ext/standard/dl.c
@@ -29,11 +29,7 @@
 #if defined(HAVE_LIBDL)
 #include <stdlib.h>
 #include <stdio.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#else
-#include <strings.h>
-#endif
 #ifdef PHP_WIN32
 #include "win32/param.h"
 #include "win32/winutil.h"

--- a/ext/xmlrpc/libxmlrpc/acinclude.m4
+++ b/ext/xmlrpc/libxmlrpc/acinclude.m4
@@ -12,7 +12,7 @@ AC_CHECK_FUNCS( \
 
 AC_DEFUN([XMLRPC_HEADER_CHECKS],[
 AC_HEADER_STDC
-AC_CHECK_HEADERS(xmlparse.h xmltok.h strings.h string.h)
+AC_CHECK_HEADERS(xmlparse.h xmltok.h strings.h)
 ])
 
 AC_DEFUN([XMLRPC_TYPE_CHECKS],[

--- a/main/alloca.c
+++ b/main/alloca.c
@@ -25,10 +25,7 @@
 
 #if !HAVE_ALLOCA
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
-
 #include <stdlib.h>
 
 #ifdef emacs

--- a/main/php_scandir.c
+++ b/main/php_scandir.c
@@ -42,9 +42,7 @@
 
 #ifndef HAVE_ALPHASORT
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 PHPAPI int php_alphasort(const struct dirent **a, const struct dirent **b)
 {

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -98,7 +98,6 @@
 #define HAVE_FCNTL_H 1
 #define HAVE_GRP_H 0
 #undef HAVE_PWD_H
-#define HAVE_STRING_H 1
 #undef HAVE_SYS_FILE_H
 #undef HAVE_SYS_SOCKET_H
 #undef HAVE_SYS_WAIT_H


### PR DESCRIPTION
The C89 standard and later defines the `<string.h>` header as part of
the standard headers [1] and on current systems it is always present.

Code included also `<strings.h>` header as an alterinative in some
files. This kind of check was relevant on some older systems where the
`<strings.h>` file included definitions for the C89 compliant
`<string.h>`. Today such alternative check is not required anymore. The
`<strings.h>` file is part of the POSIX definition these days.

Also Autoconf suggests doing this and relying on C89 or above [2] and [3].

[1]: https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2]: http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4
[3]: https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html