### PR TITLE
Remove HAVE_SYS_VARARGS_H

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -466,7 +466,6 @@ sys/statfs.h \
 sys/statvfs.h \
 sys/vfs.h \
 sys/sysexits.h \
-sys/varargs.h \
 sys/wait.h \
 sys/loadavg.h \
 termios.h \

--- a/ext/gd/libgd/gd.h
+++ b/ext/gd/libgd/gd.h
@@ -47,17 +47,7 @@ extern "C" {
 #include "gd_io.h"
 
 /* va_list needed in gdErrorMethod */
-#ifdef PHP_WIN32
-# include <stdarg.h>
-#else
-# if HAVE_STDARG_H
-# include <stdarg.h>
-# else
-#  if HAVE_SYS_VARARGS_H
-#  include <sys/varargs.h>
-#  endif
-# endif
-#endif
+#include <stdarg.h>
 
 /* The maximum number of palette entries in palette-based images.
 	In the wonderful new world of gd 2.0, you can of course have

--- a/main/php.h
+++ b/main/php.h
@@ -224,13 +224,8 @@ typedef unsigned int socklen_t;
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#if HAVE_STDARG_H
+
 #include <stdarg.h>
-#else
-# if HAVE_SYS_VARARGS_H
-# include <sys/varargs.h>
-# endif
-#endif
 
 #include "php_stdint.h"
 


### PR DESCRIPTION
Outdated systems used to provide the `<varargs.h>` and in case of PHP `<sys/varargs.h>`. [1]

Current systems have `<stdarg.h>` which is also a C89 standard header and systems have it always present. [2]

[1] https://en.wikipedia.org/wiki/Stdarg.h#varargs.h
[2] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2