### PR TITLE
Convert ext/xml to use object instead of resource

### DIFF
--- a/ext/xml/tests/bug72793.phpt
+++ b/ext/xml/tests/bug72793.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Bug #72793: xml_parser_free leaks mem when execute xml_set_object
+--FILE--
+<?php
+
+class xml  {
+    var $parser;
+
+    function __construct()
+    {
+        $this->parser = xml_parser_create();
+        xml_set_object($this->parser, $this);
+    }
+
+    function parse($data)
+    {
+        xml_parse($this->parser, $data);
+    }
+
+    function free(){
+        xml_parser_free($this->parser);
+    }
+}
+
+$xml_test = '<?xml version="1.0" encoding="utf-8"?><test></test>';
+$xml_parser = new xml();
+$xml_parser->parse($xml_test);
+$xml_parser->free();
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/ext/xml/tests/bug76874.phpt
+++ b/ext/xml/tests/bug76874.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Bug #76874: xml_parser_free() should never leak memory
+--FILE--
+<?php
+
+class c
+{
+	private $xml;
+	private $test;
+
+	public function test()
+	{
+		$this->xml = xml_parser_create();
+		xml_set_character_data_handler($this->xml, array(&$this, 'handle_cdata'));
+		xml_parser_free($this->xml);
+	}
+
+	public function handle_cdata(&$parser, $data)
+	{
+	}
+}
+
+$object = new c();
+$object->test();
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -177,6 +177,7 @@ PHP_FUNCTION(xml_parse_into_struct);
 static zend_object *xml_parser_create_object(zend_class_entry *class_type);
 static void xml_parser_free_obj(zend_object *object);
 static HashTable *xml_parser_get_gc(zval *object, zval **table, int *n);
+static zend_function *xml_parser_get_constructor(zend_object *object);
 
 static zend_string *xml_utf8_decode(const XML_Char *, size_t, const XML_Char *);
 static void xml_set_handler(zval *, zval *);
@@ -408,7 +409,6 @@ static void php_xml_free_wrapper(void *ptr)
 }
 
 static const zend_function_entry xml_parser_methods[] = {
-	// TODO
 	PHP_FE_END
 };
 
@@ -424,6 +424,7 @@ PHP_MINIT_FUNCTION(xml)
 	xml_parser_object_handlers.offset = XtOffsetOf(xml_parser, std);
 	xml_parser_object_handlers.free_obj = xml_parser_free_obj;
 	xml_parser_object_handlers.get_gc = xml_parser_get_gc;
+	xml_parser_object_handlers.get_constructor = xml_parser_get_constructor;
 
 	REGISTER_LONG_CONSTANT("XML_ERROR_NONE", XML_ERROR_NONE, CONST_CS|CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("XML_ERROR_NO_MEMORY", XML_ERROR_NO_MEMORY, CONST_CS|CONST_PERSISTENT);
@@ -577,6 +578,11 @@ static HashTable *xml_parser_get_gc(zval *object, zval **table, int *n)
 	*table = &parser->object;
 	*n = XML_PARSER_NUM_ZVALS;
 	return zend_std_get_properties(object);
+}
+
+static zend_function *xml_parser_get_constructor(zend_object *object) {
+	zend_throw_error(NULL, "Cannot directly construct XmlParser, use xml_parser_create() or xml_parser_create_ns() instead");
+	return NULL;
 }
 
 /* {{{ xml_set_handler() */
@@ -1577,7 +1583,6 @@ PHP_FUNCTION(xml_parser_free)
 		RETURN_FALSE;
 	}
 
-	// TODO ???
 	RETURN_TRUE;
 }
 /* }}} */


### PR DESCRIPTION
The primary motivation here is to fix https://bugs.php.net/bug.php?id=72793 and https://bugs.php.net/bug.php?id=76874, which cannot be done with a resource, as resources are not part of cycle GC.

The object is called `XmlParser`. An open question is what `xml_parser_free()` is supposed to do. Right now I've left it as essentially a no-op.

Targeting PHP 7.4 based on precedent. ext/gmp was converted in 5.6, ext/hash in 7.2, so we seem to be fine with doing these resource->object conversions in minor versions.

 * [x] Implement proper get_gc
 * [x] Forbid explicit construction of the object
 * [ ] Decide what to do with xml_parser_free()