### PR TITLE
Add bless_tests.php script

### DIFF
--- a/scripts/dev/bless_tests.php
+++ b/scripts/dev/bless_tests.php
@@ -1,0 +1,49 @@
+#!/usr/bin/env php
+<?php
+
+if ($argc < 2) {
+    die("Usage: php bless_tests.php dir/");
+}
+
+$dir = $argv[1];
+$it = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($dir),
+    RecursiveIteratorIterator::LEAVES_ONLY
+);
+foreach ($it as $file) {
+    $path = $file->getPathName();
+    if (!preg_match('/^(.*)\.phpt$/', $path, $matches)) {
+        // Not a phpt test
+        continue;
+    }
+
+    $outPath = $matches[1] . '.out';
+    if (!file_exists($outPath)) {
+        // Test did not fail
+        continue;
+    }
+
+    $phpt = file_get_contents($path);
+    if (false !== strpos($phpt, '--XFAIL--')) {
+        // Don't modify expected output of XFAIL tests
+        continue;
+    }
+
+    $out = file_get_contents($outPath);
+    $out = normalizeOutput($out);
+    $phpt = insertOutput($phpt, $out);
+    file_put_contents($path, $phpt);
+}
+
+function normalizeOutput(string $out): string {
+    $out = preg_replace('/in .+ on line \d+/', 'in %s on line %d', $out);
+    $out = preg_replace('/Resource id #\d+/', 'Resource id #%d', $out);
+    return $out;
+}
+
+function insertOutput(string $phpt, string $out): string {
+    return preg_replace_callback('/--EXPECTF?--.*$/s', function($matches) use($out) {
+        $F = strpos($out, '%') !== false ? 'F' : '';
+        return "--EXPECT$F--\n" . $out;
+    }, $phpt);
+}


### PR DESCRIPTION
This can be used for mass-updates of tests. After running
run-tests.php, call bless_tests.php on the relevant directory to
automatically update the expected test outputs. Afterwards review
the diff to check that the new output is indeed correct.

This is particularly useful for dealing with annoying variation
tests, where every little change has to be replicated dozens of
times.