### PR TITLE
Fix #76859 stream_get_line skips data if used with data-generating filter

### DIFF
--- a/ext/standard/tests/streams/bug76859.phpt
+++ b/ext/standard/tests/streams/bug76859.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #76859 (stream_get_line skips data if used with filters)
+--FILE--
+<?php
+
+$data = '123';
+
+$fh = fopen('php://memory', 'r+b');
+fwrite($fh, $data);
+rewind($fh);
+stream_filter_append($fh, 'string.rot13', STREAM_FILTER_READ);
+
+$out = '';
+while (!feof($fh)) {
+    $out .= stream_get_line($fh, 1024);
+}
+
+fclose($fh);
+
+echo strlen($out) . "\n";
+--EXPECT--
+3

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -561,10 +561,6 @@ PHPAPI void _php_stream_fill_read_buffer(php_stream *stream, size_t size)
 		php_stream_bucket_brigade brig_in = { NULL, NULL }, brig_out = { NULL, NULL };
 		php_stream_bucket_brigade *brig_inp = &brig_in, *brig_outp = &brig_out, *brig_swap;
 
-		/* Invalidate the existing cache, otherwise reads can fail, see note in
-		   main/streams/filter.c::_php_stream_filter_append */
-		stream->writepos = stream->readpos = 0;
-
 		/* allocate a buffer for reading chunks */
 		chunk_buf = emalloc(stream->chunk_size);
 


### PR DESCRIPTION
`stream_get_line` repeatedly calls `php_stream_fill_read_buffer` until
enough data is accumulated in buffer. However, when stream contains
filters attached to it, then each call to fill buffer essentially
resets buffer read/write pointers and new data is written over old.
This causes `stream_get_line` to skip parts of data from stream
This patch fixes such behavior, so fill buffer call will append.