### PR TITLE
Consider phpdbg as cli

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -972,7 +972,7 @@ dnl ---------------------------------------------- Shared module
 dnl ---------------------------------------------- CLI static module
     [PHP_]translit($1,a-z_-,A-Z__)[_SHARED]=no
     case "$PHP_SAPI" in
-      cgi|embed[)]
+      cgi|embed|phpdbg[)]
         PHP_ADD_SOURCES($ext_dir,$2,$ac_extra,)
         EXT_STATIC="$EXT_STATIC $1;$ext_dir"
         ;;


### PR DESCRIPTION
* When configuring extensions, considers the PHPDBG SAPI as CLI thus
  allowing e.g. to have the pcntl extension available within PHPDBG.

Signed-off-by: Samuele Kaplun <kaplun@protonmail.com>