### PR TITLE
Fix #76859 stream_get_line skips data if used with data-generating filter

### DIFF
--- a/ext/standard/tests/streams/bug46147.phpt
+++ b/ext/standard/tests/streams/bug46147.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #46147 (after stream seek, appending stream filter reads incorrect data)
+--FILE--
+<?php
+$fp = tmpfile();
+fwrite($fp, "this is a lowercase string.\n");
+fseek($fp, 5);
+stream_filter_append($fp, "string.toupper");
+while (!feof($fp)) {
+    echo fread($fp, 5);
+}
+
+--EXPECT--
+IS A LOWERCASE STRING.

--- a/ext/standard/tests/streams/bug76859.phpt
+++ b/ext/standard/tests/streams/bug76859.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #76859 (stream_get_line skips data if used with filters)
+--FILE--
+<?php
+
+$data = '123';
+
+$fh = fopen('php://memory', 'r+b');
+fwrite($fh, $data);
+rewind($fh);
+stream_filter_append($fh, 'string.rot13', STREAM_FILTER_READ);
+
+$out = '';
+while (!feof($fh)) {
+    $out .= stream_get_line($fh, 1024);
+}
+
+fclose($fh);
+
+echo strlen($out) . "\n";
+--EXPECT--
+3

--- a/main/streams/filter.c
+++ b/main/streams/filter.c
@@ -387,8 +387,6 @@ PHPAPI int php_stream_filter_append_ex(php_stream_filter_chain *chain, php_strea
 			case PSFS_PASS_ON:
 				/* If any data is consumed, we cannot rely upon the existing read buffer,
 				   as the filtered data must replace the existing data, so invalidate the cache */
-				/* note that changes here should be reflected in
-				   main/streams/streams.c::php_stream_fill_read_buffer */
 				stream->writepos = 0;
 				stream->readpos = 0;
 

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -561,10 +561,6 @@ PHPAPI void _php_stream_fill_read_buffer(php_stream *stream, size_t size)
 		php_stream_bucket_brigade brig_in = { NULL, NULL }, brig_out = { NULL, NULL };
 		php_stream_bucket_brigade *brig_inp = &brig_in, *brig_outp = &brig_out, *brig_swap;
 
-		/* Invalidate the existing cache, otherwise reads can fail, see note in
-		   main/streams/filter.c::_php_stream_filter_append */
-		stream->writepos = stream->readpos = 0;
-
 		/* allocate a buffer for reading chunks */
 		chunk_buf = emalloc(stream->chunk_size);
 


### PR DESCRIPTION
`stream_get_line` repeatedly calls `php_stream_fill_read_buffer` until
enough data is accumulated in buffer. However, when stream contains
filters attached to it, then each call to fill buffer essentially
resets buffer read/write pointers and new data is written over old.
This causes `stream_get_line` to skip parts of data from stream.
This patch fixes such behavior, so fill buffer call will append new data to existing data in buffer.