### PR TITLE
Remove HAVE_TIME_H

### DIFF
--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -102,7 +102,6 @@ if test "$PHP_PDO_SQLITE" != "no"; then
       PHP_ADD_INCLUDE($abs_srcdir/ext/sqlite3/libsqlite)
 
       AC_CHECK_FUNCS(usleep nanosleep)
-      AC_CHECK_HEADERS(time.h)
   fi
 
   dnl Solaris fix

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -37,10 +37,6 @@
 #include <unixlib/local.h>
 #endif
 
-
-#if HAVE_TIME_H
-#include <time.h>
-#endif
 #if HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif


### PR DESCRIPTION
The `<time.h>` header file is part of the standard C89 headers [1] and
on current systems can be included unconditionally.

Since PHP requires at least C89 or greater, the `HAVE_TIME_H` symbol
defined by Autoconf in ext/pdo_sqlite/config.m4 [2] can be ommitted and
simplifed.

Additionally, since PHP didn't define `HAVE_TIME_H` prior in the
configure.ac the occurrence of this symbol in cli can be removed.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4