### PR TITLE
Require SQLite ≥ 3.5.0

### DIFF
--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -52,14 +52,14 @@ if test "$PHP_PDO_SQLITE" != "no"; then
   PHP_ADD_INCLUDE($PDO_SQLITE_DIR/include)
 
   LIBNAME=sqlite3
-  LIBSYMBOL=sqlite3_open
+  LIBSYMBOL=sqlite3_open_v2
 
   PHP_CHECK_LIBRARY($LIBNAME,$LIBSYMBOL,
   [
     PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $PDO_SQLITE_DIR/$PHP_LIBDIR, PDO_SQLITE_SHARED_LIBADD)
     AC_DEFINE(HAVE_PDO_SQLITELIB,1,[ ])
   ],[
-    AC_MSG_ERROR([wrong sqlite lib version or lib not found])
+    AC_MSG_ERROR([wrong sqlite lib version (< 3.5.0) or lib not found])
   ],[
     -L$PDO_SQLITE_DIR/$PHP_LIBDIR -lm
   ])

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -809,11 +809,7 @@ static int pdo_sqlite_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{
 
 	flags = pdo_attr_lval(driver_options, PDO_SQLITE_ATTR_OPEN_FLAGS, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 
-#if SQLITE_VERSION_NUMBER >= 3005000
 	i = sqlite3_open_v2(filename, &H->db, flags, NULL);
-#else
-	i = sqlite3_open(filename, &H->db);
-#endif
 
 	efree(filename);
 

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -19,46 +19,46 @@ if test $PHP_SQLITE3 != "no"; then
     fi
   fi
 
-    AC_MSG_CHECKING([for sqlite3 files in default path])
-    for i in $PHP_SQLITE3 /usr/local /usr; do
-      if test -r $i/include/sqlite3.h; then
-        SQLITE3_DIR=$i
-        AC_MSG_RESULT(found in $i)
-        break
-      fi
-    done
-
-    if test -z "$SQLITE3_DIR"; then
-      AC_MSG_RESULT([not found])
-      AC_MSG_ERROR([Please reinstall the sqlite distribution from http://www.sqlite.org])
+  AC_MSG_CHECKING([for sqlite3 files in default path])
+  for i in $PHP_SQLITE3 /usr/local /usr; do
+    if test -r $i/include/sqlite3.h; then
+      SQLITE3_DIR=$i
+      AC_MSG_RESULT(found in $i)
+      break
     fi
+  done
 
-    AC_MSG_CHECKING([for SQLite 3.5.0+])
-    PHP_CHECK_LIBRARY(sqlite3, sqlite3_open_v2, [
-      AC_MSG_RESULT(found)
-      PHP_ADD_LIBRARY_WITH_PATH(sqlite3, $SQLITE3_DIR/$PHP_LIBDIR, SQLITE3_SHARED_LIBADD)
-      PHP_ADD_INCLUDE($SQLITE3_DIR/include)
-    ],[
-      AC_MSG_RESULT([not found])
-      AC_MSG_ERROR([Please install SQLite 3.5.0 first or check libsqlite3 is present])
-    ],[
-      -L$SQLITE3_DIR/$PHP_LIBDIR -lm
-    ])
+  if test -z "$SQLITE3_DIR"; then
+    AC_MSG_RESULT([not found])
+    AC_MSG_ERROR([Please reinstall the sqlite distribution from http://www.sqlite.org])
+  fi
 
-    PHP_CHECK_LIBRARY(sqlite3,sqlite3_key,[
-      AC_DEFINE(HAVE_SQLITE3_KEY, 1, [have commercial sqlite3 with crypto support])
-    ])
-    PHP_CHECK_LIBRARY(sqlite3,sqlite3_column_table_name,[
-      AC_DEFINE(SQLITE_ENABLE_COLUMN_METADATA, 1, [have sqlite3 with column metadata enabled])
-    ])
-    PHP_CHECK_LIBRARY(sqlite3,sqlite3_errstr,[
-      AC_DEFINE(HAVE_SQLITE3_ERRSTR, 1, [have sqlite3_errstr function])
-    ])
+  AC_MSG_CHECKING([for SQLite 3.5.0+])
+  PHP_CHECK_LIBRARY(sqlite3, sqlite3_open_v2, [
+    AC_MSG_RESULT(found)
+    PHP_ADD_LIBRARY_WITH_PATH(sqlite3, $SQLITE3_DIR/$PHP_LIBDIR, SQLITE3_SHARED_LIBADD)
+    PHP_ADD_INCLUDE($SQLITE3_DIR/include)
+  ],[
+    AC_MSG_RESULT([not found])
+    AC_MSG_ERROR([Please install SQLite 3.5.0 first or check libsqlite3 is present])
+  ],[
+    -L$SQLITE3_DIR/$PHP_LIBDIR -lm
+  ])
 
-    PHP_CHECK_LIBRARY(sqlite3,sqlite3_load_extension,
-    [],
-    [AC_DEFINE(SQLITE_OMIT_LOAD_EXTENSION, 1, [have sqlite3 with extension support])
-    ])
+  PHP_CHECK_LIBRARY(sqlite3,sqlite3_key,[
+    AC_DEFINE(HAVE_SQLITE3_KEY, 1, [have commercial sqlite3 with crypto support])
+  ])
+  PHP_CHECK_LIBRARY(sqlite3,sqlite3_column_table_name,[
+    AC_DEFINE(SQLITE_ENABLE_COLUMN_METADATA, 1, [have sqlite3 with column metadata enabled])
+  ])
+  PHP_CHECK_LIBRARY(sqlite3,sqlite3_errstr,[
+    AC_DEFINE(HAVE_SQLITE3_ERRSTR, 1, [have sqlite3_errstr function])
+  ])
+
+  PHP_CHECK_LIBRARY(sqlite3,sqlite3_load_extension,
+  [],
+  [AC_DEFINE(SQLITE_OMIT_LOAD_EXTENSION, 1, [have sqlite3 with extension support])
+  ])
 
   AC_DEFINE(HAVE_SQLITE3,1,[ ])
 

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -19,46 +19,46 @@ if test $PHP_SQLITE3 != "no"; then
     fi
   fi
 
-  AC_MSG_CHECKING([for sqlite3 files in default path])
-  for i in $PHP_SQLITE3 /usr/local /usr; do
-    if test -r $i/include/sqlite3.h; then
-      SQLITE3_DIR=$i
-      AC_MSG_RESULT(found in $i)
-      break
+    AC_MSG_CHECKING([for sqlite3 files in default path])
+    for i in $PHP_SQLITE3 /usr/local /usr; do
+      if test -r $i/include/sqlite3.h; then
+        SQLITE3_DIR=$i
+        AC_MSG_RESULT(found in $i)
+        break
+      fi
+    done
+
+    if test -z "$SQLITE3_DIR"; then
+      AC_MSG_RESULT([not found])
+      AC_MSG_ERROR([Please reinstall the sqlite distribution from http://www.sqlite.org])
     fi
-  done
 
-  if test -z "$SQLITE3_DIR"; then
-    AC_MSG_RESULT([not found])
-    AC_MSG_ERROR([Please reinstall the sqlite distribution from http://www.sqlite.org])
-  fi
+    AC_MSG_CHECKING([for SQLite 3.5.0+])
+    PHP_CHECK_LIBRARY(sqlite3, sqlite3_open_v2, [
+      AC_MSG_RESULT(found)
+      PHP_ADD_LIBRARY_WITH_PATH(sqlite3, $SQLITE3_DIR/$PHP_LIBDIR, SQLITE3_SHARED_LIBADD)
+      PHP_ADD_INCLUDE($SQLITE3_DIR/include)
+    ],[
+      AC_MSG_RESULT([not found])
+      AC_MSG_ERROR([Please install SQLite 3.5.0 first or check libsqlite3 is present])
+    ],[
+      -L$SQLITE3_DIR/$PHP_LIBDIR -lm
+    ])
 
-  AC_MSG_CHECKING([for SQLite 3.3.9+])
-  PHP_CHECK_LIBRARY(sqlite3, sqlite3_prepare_v2, [
-    AC_MSG_RESULT(found)
-    PHP_ADD_LIBRARY_WITH_PATH(sqlite3, $SQLITE3_DIR/$PHP_LIBDIR, SQLITE3_SHARED_LIBADD)
-    PHP_ADD_INCLUDE($SQLITE3_DIR/include)
-  ],[
-    AC_MSG_RESULT([not found])
-    AC_MSG_ERROR([Please install SQLite 3.3.9 first or check libsqlite3 is present])
-  ],[
-    -L$SQLITE3_DIR/$PHP_LIBDIR -lm
-  ])
+    PHP_CHECK_LIBRARY(sqlite3,sqlite3_key,[
+      AC_DEFINE(HAVE_SQLITE3_KEY, 1, [have commercial sqlite3 with crypto support])
+    ])
+    PHP_CHECK_LIBRARY(sqlite3,sqlite3_column_table_name,[
+      AC_DEFINE(SQLITE_ENABLE_COLUMN_METADATA, 1, [have sqlite3 with column metadata enabled])
+    ])
+    PHP_CHECK_LIBRARY(sqlite3,sqlite3_errstr,[
+      AC_DEFINE(HAVE_SQLITE3_ERRSTR, 1, [have sqlite3_errstr function])
+    ])
 
-  PHP_CHECK_LIBRARY(sqlite3,sqlite3_key,[
-    AC_DEFINE(HAVE_SQLITE3_KEY, 1, [have commercial sqlite3 with crypto support])
-  ])
-  PHP_CHECK_LIBRARY(sqlite3,sqlite3_column_table_name,[
-    AC_DEFINE(SQLITE_ENABLE_COLUMN_METADATA, 1, [have sqlite3 with column metadata enabled])
-  ])
-  PHP_CHECK_LIBRARY(sqlite3,sqlite3_errstr,[
-    AC_DEFINE(HAVE_SQLITE3_ERRSTR, 1, [have sqlite3_errstr function])
-  ])
-
-  PHP_CHECK_LIBRARY(sqlite3,sqlite3_load_extension,
-  [],
-  [AC_DEFINE(SQLITE_OMIT_LOAD_EXTENSION, 1, [have sqlite3 with extension support])
-  ])
+    PHP_CHECK_LIBRARY(sqlite3,sqlite3_load_extension,
+    [],
+    [AC_DEFINE(SQLITE_OMIT_LOAD_EXTENSION, 1, [have sqlite3 with extension support])
+    ])
 
   AC_DEFINE(HAVE_SQLITE3,1,[ ])
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -131,11 +131,7 @@ PHP_METHOD(sqlite3, open)
 		fullpath = filename;
 	}
 
-#if SQLITE_VERSION_NUMBER >= 3005000
 	rc = sqlite3_open_v2(fullpath, &(db_obj->db), flags, NULL);
-#else
-	rc = sqlite3_open(fullpath, &(db_obj->db));
-#endif
 	if (rc != SQLITE_OK) {
 		zend_throw_exception_ex(zend_ce_exception, 0, "Unable to open database: %s",
 #ifdef HAVE_SQLITE3_ERRSTR


### PR DESCRIPTION
It is possible to pass flags when opening an SQLite database.  For
Sqlite < 3.5.0 these are ignored, since `sqlite3_open` doesn't support
flags.  Neither a warning or notice is raised in this case, nor is this
behavior documented in the PHP manual.  Instead of fixing it either
way, we lift the requirement to SQLite 3.5.0 (released on 2007-09-04)
instead of the former SQLite 3.3.9 (released on 2007-01-04).