### PR TITLE
base64: Remove unused branch

### DIFF
--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -790,11 +790,7 @@ PHP_FUNCTION(base64_encode)
 	ZEND_PARSE_PARAMETERS_END();
 
 	result = php_base64_encode((unsigned char*)str, str_len);
-	if (result != NULL) {
-		RETURN_STR(result);
-	} else {
-		RETURN_FALSE;
-	}
+	RETURN_STR(result);
 }
 /* }}} */
 


### PR DESCRIPTION
php_base64_encode() never returns NULL, so base64_encode() will never return false.