### PR TITLE
Initial ReflectionReference implementation

### DIFF
--- a/ext/reflection/php_reflection.h
+++ b/ext/reflection/php_reflection.h
@@ -43,6 +43,7 @@ extern PHPAPI zend_class_entry *reflection_method_ptr;
 extern PHPAPI zend_class_entry *reflection_property_ptr;
 extern PHPAPI zend_class_entry *reflection_extension_ptr;
 extern PHPAPI zend_class_entry *reflection_zend_extension_ptr;
+extern PHPAPI zend_class_entry *reflection_reference_ptr;
 
 PHPAPI void zend_reflection_class_factory(zend_class_entry *ce, zval *object);
 

--- a/ext/reflection/tests/ReflectionExtension_getClasses_basic.phpt
+++ b/ext/reflection/tests/ReflectionExtension_getClasses_basic.phpt
@@ -9,7 +9,7 @@ var_dump($ext->getClasses());
 ?>
 ==DONE==
 --EXPECT--
-array(16) {
+array(17) {
   ["ReflectionException"]=>
   object(ReflectionClass)#2 (1) {
     ["name"]=>
@@ -89,6 +89,11 @@ array(16) {
   object(ReflectionClass)#17 (1) {
     ["name"]=>
     string(23) "ReflectionZendExtension"
+  }
+  ["ReflectionReference"]=>
+  object(ReflectionClass)#18 (1) {
+    ["name"]=>
+    string(19) "ReflectionReference"
   }
 }
 ==DONE==

--- a/ext/reflection/tests/ReflectionReference.phpt
+++ b/ext/reflection/tests/ReflectionReference.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Basic ReflectionReference functionality
+--FILE--
+<?php
+
+$ary = [0, 1, 2];
+$ref1 =& $ary[1];
+unset($ref1);
+$ref2 =& $ary[2];
+
+echo "fromArrayElement():\n";
+$r0 = ReflectionReference::fromArrayElement($ary, 0);
+var_dump($r0 === null);
+$r1 = ReflectionReference::fromArrayElement($ary, 1);
+var_dump($r1 instanceof ReflectionReference);
+$r2 = ReflectionReference::fromArrayElement($ary, 2);
+var_dump($r2 instanceof ReflectionReference);
+
+echo "getId() #1:\n";
+var_dump($r1->getId() === $r1->getId());
+var_dump($r2->getId() === $r2->getId());
+var_dump($r1->getId() !== $r2->getId());
+
+echo "getId() #2:\n";
+$ary2 = [&$ary[1], &$ref2];
+$r1_2 = ReflectionReference::fromArrayElement($ary2, 0);
+$r2_2 = ReflectionReference::fromArrayElement($ary2, 1);
+var_dump($r1->getId() === $r1_2->getId());
+var_dump($r2->getId() === $r2_2->getId());
+
+echo "getId() #3:\n";
+$r1_id = $r1->getId();
+$r2_id = $r2->getId();
+unset($r0, $r1, $r2, $r1_2, $r2_2);
+$r1 = ReflectionReference::fromArrayElement($ary, 1);
+$r2 = ReflectionReference::fromArrayElement($ary, 2);
+var_dump($r1_id === $r1->getId());
+var_dump($r2_id === $r2->getId());
+
+?>
+--EXPECT--
+fromArrayElement():
+bool(true)
+bool(true)
+bool(true)
+getId() #1:
+bool(true)
+bool(true)
+bool(true)
+getId() #2:
+bool(true)
+bool(true)
+getId() #3:
+bool(true)
+bool(true)

--- a/ext/reflection/tests/ReflectionReference_errors.phpt
+++ b/ext/reflection/tests/ReflectionReference_errors.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Various error conditions for ReflectionReference
+--FILE--
+<?php
+
+try {
+    new ReflectionReference();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    ReflectionReference::fromArrayElement(new stdClass, "test");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    ReflectionReference::fromArrayElement([], 1.5);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $ary = [0, 1, 2];
+    ReflectionReference::fromArrayElement($ary, 3);
+} catch (ReflectionException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $ary = [&$ary];
+    $ref = ReflectionReference::fromArrayElement($ary, 0);
+    var_dump(serialize($ref));
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+
+var_dump(unserialize('O:19:"ReflectionReference":0:{}'));
+
+?>
+--EXPECTF--
+Call to private ReflectionReference::__construct() from invalid context
+ReflectionReference::fromArrayElement() expects parameter 1 to be array, object given
+Key must be array or string
+Array key not found
+Serialization of 'ReflectionReference' is not allowed
+
+Warning: Erroneous data format for unserializing 'ReflectionReference' in %s on line %d
+
+Notice: unserialize(): Error at offset 30 of 31 bytes in %s on line %d
+bool(false)


### PR DESCRIPTION
Implementation of `ReflectionReference` based on the discussion in https://externals.io/message/102638. Currently the class definition is

```php
final class ReflectionReference {
    /* Returns ReflectionReference if array element is a reference, null otherwise. */
    public static function fromArrayElement(array $array, int|string $key): ?ReflectionReference;
    /* Returns unique identifier for the reference. The return value format is unspecified. */
    public function getId(): int|string;

    private function __construct(); // Always throws
    private function __clone(); // Always throws
}
```

The return value of `getId()` uniquely identifies the reference for the duration of its lifetime. An ID may be reused if the reference is destroyed. The format of the return value is unspecified any may change. Only the fact that it will be an integer or string is guaranteed.

In the current implementation ~~the address of the reference is directly returned as the ID. We should be hiding the address here, possibly by hashing it with a secret key.~~ the ID is a raw SHA1 hash of the reference address and a per-process key. Raw meaning 20 character binary data, no hex encoding.