### PR TITLE
Remove unused ext/bz2/php_bz2.def

### DIFF
--- a/ext/bz2/php_bz2.def
+++ b/ext/bz2/php_bz2.def
@@ -1,7 +1,0 @@
-EXPORTS
-	BZ2_bzCompressInit
-	BZ2_bzCompress
-	BZ2_bzCompressEnd
-	BZ2_bzDecompressInit
-	BZ2_bzDecompress
-	BZ2_bzDecompressEnd


### PR DESCRIPTION
Exporting symbols has been added via a7ba08a0bdb1b7de6a5f1f44ae3d243ea8cedb64 and then removed via d5c68252418e7ad40fd8527676e9ce4696c19a3c