### PR TITLE
Bump minimum Autoconf requirement for phpize from 2.59 to 2.64

### DIFF
--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -1,6 +1,6 @@
 dnl This file becomes configure.ac for self-contained extensions.
 
-AC_PREREQ(2.59)
+AC_PREREQ([2.64])
 AC_INIT(config.m4)
 ifdef([AC_PRESERVE_HELP_ORDER], [AC_PRESERVE_HELP_ORDER], [])
 


### PR DESCRIPTION
This patch syncs the minimum version used for the phpize.m4 script as is current requirement for the rest of the php code base and the main configure.ac.

At the time of this writing Autoconf 2.63 is still the version on Centos 6, however by the PHP next release current systems out there should all have pretty much updated Autoconf versions to 2.64+ at least. Centos 7 already has Autoconf 2.69, for example.

This provides more options to update and get current with the *nix build system.

Additionally, phpize also already provides AX_CHECK_COMPILE_FLAG Autoconf Archive m4 file that has Autoconf 2.64 minimum requirement.

I think we should be ready to bump this slightly delayed and a bit forgotten part also...