### PR TITLE
Add compile-time warning on invalid parent use

### DIFF
--- a/Zend/tests/bug75573.phpt
+++ b/Zend/tests/bug75573.phpt
@@ -6,10 +6,6 @@ Bug #75573 (Segmentation fault in 7.1.12 and 7.0.26)
 class A
 {
 	var $_stdObject;
-	function initialize($properties = FALSE) {
-		$this->_stdObject = $properties ? (object) $properties : new stdClass();
-		parent::initialize();
-	}
 	function &__get($property)
 	{
 		if (isset($this->_stdObject->{$property})) {
@@ -31,10 +27,6 @@ class A
 
 class B extends A
 {
-	function initialize($properties = array())
-	{
-		parent::initialize($properties);
-	}
 	function &__get($property)
 	{
 		if (isset($this->settings) && isset($this->settings[$property])) {

--- a/Zend/tests/class_name_as_scalar.phpt
+++ b/Zend/tests/class_name_as_scalar.phpt
@@ -8,8 +8,11 @@ namespace Foo\Bar {
         // compile time constants
         const A = self::class;
         const B = Two::class;
+
     }
     class Two extends One {
+        const A = parent::class;
+
         public static function run() {
             var_dump(self::class); // self compile time lookup
             var_dump(static::class); // runtime lookup
@@ -18,6 +21,8 @@ namespace Foo\Bar {
         }
     }
     class Three extends Two {
+        const B = parent::class;
+
         // compile time static lookups
         public static function checkCompileTime(
             $one = self::class,

--- a/Zend/tests/class_name_as_scalar_error_002.phpt
+++ b/Zend/tests/class_name_as_scalar_error_002.phpt
@@ -10,4 +10,6 @@ namespace Foo\Bar {
 }
 ?>
 --EXPECTF--
-Fatal error: parent::class cannot be used for compile-time class name resolution in %s on line %d
+Deprecated: Cannot use "parent" without a parent class in %s on line %d
+
+Fatal error: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/class_name_as_scalar_error_004.phpt
+++ b/Zend/tests/class_name_as_scalar_error_004.phpt
@@ -10,4 +10,6 @@ namespace Foo\Bar {
 }
 ?>
 --EXPECTF--
-Fatal error: parent::class cannot be used for compile-time class name resolution in %s on line %d
+Deprecated: Cannot use "parent" without a parent class in %s on line %d
+
+Fatal error: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_01.phpt
+++ b/Zend/tests/compile_time_parent_error_01.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+class InvalidClass {
+  function method(parent $p) {}
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_02.phpt
+++ b/Zend/tests/compile_time_parent_error_02.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+class InvalidClass {
+  function method(): parent {}
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_03.phpt
+++ b/Zend/tests/compile_time_parent_error_03.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+class InvalidClass {
+  function method() {
+    echo parent::class;
+  }
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_04.phpt
+++ b/Zend/tests/compile_time_parent_error_04.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+$obj = new class() {
+  function method() {
+    echo parent::class;
+  }
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/compile_time_parent_error_05.phpt
+++ b/Zend/tests/compile_time_parent_error_05.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Using "parent" in class without parent results in compile-time error
+--FILE--
+<?php
+class InvalidClass {
+  function method() {
+    $obj = new class() {
+      function method() {
+        echo parent::class;
+      }
+    };
+  }
+}
+
+?>
+--EXPECTF--
+Deprecated: Cannot use "parent" without a parent class in %s on line %d

--- a/Zend/tests/traits/parent_001.phpt
+++ b/Zend/tests/traits/parent_001.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Using parent does not create compile-time warnings
+--FILE--
+<?php
+
+trait P {
+	public function m(parent $arg): parent {
+		return $arg;
+	}
+}
+
+class A {}
+
+class B extends A {
+	use P;
+}
+
+$b = new B();
+$a = $b->m(new A());
+
+print "OK\n";
+
+?>
+--EXPECT--
+OK
+

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1370,10 +1370,17 @@ static uint32_t zend_get_class_fetch_type_ast(zend_ast *name_ast) /* {{{ */
 
 static void zend_ensure_valid_class_fetch_type(uint32_t fetch_type) /* {{{ */
 {
-	if (fetch_type != ZEND_FETCH_CLASS_DEFAULT && !CG(active_class_entry) && zend_is_scope_known()) {
-		zend_error_noreturn(E_COMPILE_ERROR, "Cannot use \"%s\" when no class scope is active",
-			fetch_type == ZEND_FETCH_CLASS_SELF ? "self" :
-			fetch_type == ZEND_FETCH_CLASS_PARENT ? "parent" : "static");
+	if (fetch_type != ZEND_FETCH_CLASS_DEFAULT && zend_is_scope_known()) {
+		zend_class_entry *ce = CG(active_class_entry);
+		if (!ce) {
+			zend_error_noreturn(E_COMPILE_ERROR,
+				"Cannot use \"%s\" when no class scope is active",
+				fetch_type == ZEND_FETCH_CLASS_SELF ? "self" :
+				fetch_type == ZEND_FETCH_CLASS_PARENT ? "parent" : "static");
+		} else if (fetch_type == ZEND_FETCH_CLASS_PARENT && !ce->parent_name) {
+			zend_error(E_DEPRECATED,
+				"Cannot use \"parent\" without a parent class");
+		}
 	}
 }
 /* }}} */
@@ -1396,7 +1403,6 @@ static zend_bool zend_try_compile_const_expr_resolve_class_name(zval *zv, zend_a
 	}
 
 	fetch_type = zend_get_class_fetch_type(zend_ast_get_str(class_ast));
-	zend_ensure_valid_class_fetch_type(fetch_type);
 
 	switch (fetch_type) {
 		case ZEND_FETCH_CLASS_SELF:
@@ -1406,13 +1412,29 @@ static zend_bool zend_try_compile_const_expr_resolve_class_name(zval *zv, zend_a
 				ZVAL_NULL(zv);
 			}
 			return 1;
-		case ZEND_FETCH_CLASS_STATIC:
+
 		case ZEND_FETCH_CLASS_PARENT:
+			if (zend_is_scope_known()) {
+				if (CG(active_class_entry)->parent_name) {
+					ZVAL_STR_COPY(zv, CG(active_class_entry)->parent_name);
+					return 1;
+				}
+				if (constant) {
+					zend_error_noreturn(E_COMPILE_ERROR,
+						"Cannot use \"parent\" without a parent class");
+				} else {
+					zend_error(E_DEPRECATED,
+						"Cannot use \"parent\" without a parent class");
+				}
+			}
+			ZVAL_NULL(zv);
+			return 1;
+
+		case ZEND_FETCH_CLASS_STATIC:
+			zend_ensure_valid_class_fetch_type(fetch_type);
 			if (constant) {
 				zend_error_noreturn(E_COMPILE_ERROR,
-					"%s::class cannot be used for compile-time class name resolution",
-					fetch_type == ZEND_FETCH_CLASS_STATIC ? "static" : "parent"
-				);
+					"static::class cannot be used for compile-time class name resolution");
 			} else {
 				ZVAL_NULL(zv);
 			}


### PR DESCRIPTION
This is a new attempt at fixing the issue from PR #3404.