### PR TITLE
Fix reflection arguments for sodium_memzero function

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -37,9 +37,8 @@ static zend_class_entry *sodium_exception_ce;
 ZEND_BEGIN_ARG_INFO_EX(AI_None, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(AI_FirstArgByReferenceSecondLength, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(AI_FirstArgByReference, 0, 0, 1)
 	ZEND_ARG_INFO(1, reference)
-	ZEND_ARG_INFO(0, length)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(AI_String, 0, 0, 1)
@@ -339,7 +338,7 @@ const zend_function_entry sodium_functions[] = {
 	PHP_FE(sodium_compare, AI_TwoStrings)
 	PHP_FE(sodium_increment, AI_StringRef)
 	PHP_FE(sodium_memcmp, AI_TwoStrings)
-	PHP_FE(sodium_memzero, AI_FirstArgByReferenceSecondLength)
+	PHP_FE(sodium_memzero, AI_FirstArgByReference)
 	PHP_FE(sodium_pad, AI_StringAndLength)
 	PHP_FE(sodium_unpad, AI_StringAndLength)
 


### PR DESCRIPTION
As mentioned in phpstan/phpstan#726 the reflection parameters for `sodium_memzero` are actually incorrect.

As of today, the documentation for the function looks correct, so I'd assume that was already fixed so I believe the arg info is all that needed updating now.

There is not currently a php bug reported, is this required for merge? Happy to make one to link up to this patch if necessary. Thanks!