### PR TITLE
Fix #76954 Use while loop in func add_response_header

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -1684,9 +1684,9 @@ static void add_response_header(sapi_header_struct *h, zval *return_value) /* {{
 			len = p - h->header;
 		}
 		if (len > 0) {
-			do {
+			while (len != 0 && (h->header[len-1] == ' ' || h->header[len-1] == '\t')) {
 				len--;
-			} while (len != 0 && (h->header[len-1] == ' ' || h->header[len-1] == '\t'));
+			}
 			if (len) {
 				s = do_alloca(len + 1, use_heap);
 				memcpy(s, h->header, len);

--- a/sapi/cgi/tests/apache_response_headers.phpt
+++ b/sapi/cgi/tests/apache_response_headers.phpt
@@ -1,0 +1,42 @@
+--TEST--
+apache_response_headers()
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+include "include.inc";
+
+$php = get_cgi_path();
+reset_env_vars();
+
+$filename = dirname(__FILE__) . DIRECTORY_SEPARATOR ."apache_response_headers.test.php";
+
+$code  = '<?php';
+$code .= '
+header( "X-Robots-Tag : noindex,nofollow,noarchive" );
+header( "Content-type: text/html; charset=UTF-8" );
+header( "Bad-header" );
+header( " : " );
+header( ":" );
+flush();
+foreach ( apache_response_headers() as $hdr_key => $hdr_val ) {
+        echo "$hdr_key => $hdr_val\n";
+}
+?>
+';
+
+file_put_contents($filename, $code);
+
+passthru("$php -n -q $filename");
+
+@unlink($filename);
+
+?>
+===DONE===
+--EXPECTF--
+X-Powered-By => PHP/%s
+X-Robots-Tag => noindex,nofollow,noarchive
+Content-type => text/html; charset=UTF-8
+===DONE===

--- a/sapi/cgi/tests/apache_response_headers.phpt
+++ b/sapi/cgi/tests/apache_response_headers.phpt
@@ -11,7 +11,7 @@ include "include.inc";
 $php = get_cgi_path();
 reset_env_vars();
 
-$filename = dirname(__FILE__) . DIRECTORY_SEPARATOR ."apache_response_headers.test.php";
+$test_file = dirname(__FILE__) . DIRECTORY_SEPARATOR ."apache_response_headers.test.php";
 
 $code  = '<?php';
 $code .= '
@@ -21,22 +21,28 @@ header( "Bad-header" );
 header( " : " );
 header( ":" );
 flush();
-foreach ( apache_response_headers() as $hdr_key => $hdr_val ) {
-        echo "$hdr_key => $hdr_val\n";
-}
+
+var_dump( apache_response_headers() );
 ?>
 ';
 
-file_put_contents($filename, $code);
+file_put_contents( $test_file, $code );
 
-passthru("$php -n -q $filename");
-
-@unlink($filename);
+passthru( "$php -n -q " . escapeshellarg( $test_file ) );
 
 ?>
 ===DONE===
+--CLEAN--
+<?php
+@unlink( dirname(__FILE__) . DIRECTORY_SEPARATOR ."apache_response_headers.test.php" );
+?>
 --EXPECTF--
-X-Powered-By => PHP/%s
-X-Robots-Tag => noindex,nofollow,noarchive
-Content-type => text/html; charset=UTF-8
+array(3) {
+  ["X-Powered-By"]=>
+  string(%d) "PHP/%s"
+  ["X-Robots-Tag"]=>
+  string(26) "noindex,nofollow,noarchive"
+  ["Content-type"]=>
+  string(24) "text/html; charset=UTF-8"
+}
 ===DONE===


### PR DESCRIPTION
Related issues:

https://bugs.php.net/bug.php?id=76954
https://github.com/Automattic/wp-super-cache/issues/539

PHP 5.6 uses _while_ loop, but PHP 7.x uses _do ... while_ which decreases `len` before condition. Parameter `len` in function [`memcpy`](http://pubs.opengroup.org/onlinepubs/007904975/functions/memcpy.html) has decreased length and last character isn't copied.