### PR TITLE
Optimize MySQL statement execute without parameter.

### DIFF
--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -938,7 +938,7 @@ mysqlnd_stmt_execute_generate_request(MYSQLND_STMT * const s, zend_uchar ** requ
 	zend_uchar	*p = stmt->execute_cmd_buffer.buffer,
 				*cmd_buffer = stmt->execute_cmd_buffer.buffer;
 	size_t cmd_buffer_length = stmt->execute_cmd_buffer.length;
-	enum_func_status ret;
+	enum_func_status ret = PASS;
 
 	DBG_ENTER("mysqlnd_stmt_execute_generate_request");
 
@@ -955,7 +955,9 @@ mysqlnd_stmt_execute_generate_request(MYSQLND_STMT * const s, zend_uchar ** requ
 	int1store(p, 1); /* and send 1 for iteration count */
 	p+= 4;
 
-	ret = mysqlnd_stmt_execute_store_params(s, &cmd_buffer, &p, &cmd_buffer_length);
+	if (stmt->param_count != 0) {
+	    ret = mysqlnd_stmt_execute_store_params(s, &cmd_buffer, &p, &cmd_buffer_length);
+	}
 
 	*free_buffer = (cmd_buffer != stmt->execute_cmd_buffer.buffer);
 	*request_len = (p - cmd_buffer);


### PR DESCRIPTION
Hi, I notice that when I use MySQL statement execute without params,  there are be some extra unnecessary bytes in the package after iterations,  so I added a judgment here.
The mysqlnd is a bit complicated, I don't know if it will cause other effects.

---
example
---
```php
$pdo = new PDO("mysql:host=127.0.0.1;dbname=test;charset=utf8", 'root', 'root');
$pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
$stmt = $pdo->prepare('select * from userinfo LIMIT 1');
$stmt->execute();
```
before
---
![image](https://user-images.githubusercontent.com/25978241/46285927-d6e3c480-c5af-11e8-8969-2345bc2f253c.png)
after
---
![image](https://user-images.githubusercontent.com/25978241/46285932-d9461e80-c5af-11e8-9639-9e426079e6c9.png)
