### PR TITLE
Fix #76896: don't overwrite header fields on certain packets

### DIFF
--- a/ext/mysqlnd/mysqlnd_result.c
+++ b/ext/mysqlnd/mysqlnd_result.c
@@ -495,7 +495,7 @@ mysqlnd_query_read_result_set_header(MYSQLND_CONN_DATA * conn, MYSQLND_STMT * s)
 				SET_EMPTY_MESSAGE(conn->last_message.s, conn->last_message.l, persistent);
 
 				MYSQLND_INC_CONN_STATISTIC(conn->stats, STAT_RSET_QUERY);
-				UPSERT_STATUS_RESET(conn->upsert_status);
+				
 				/* restore after zeroing */
 				UPSERT_STATUS_SET_AFFECTED_ROWS_TO_ERROR(conn->upsert_status);
 
@@ -1367,7 +1367,6 @@ MYSQLND_METHOD(mysqlnd_res, store_result_fetch_data)(MYSQLND_CONN_DATA * const c
 
 	/* Finally clean */
 	if (row_packet->eof) {
-		UPSERT_STATUS_RESET(conn->upsert_status);
 		UPSERT_STATUS_SET_WARNINGS(conn->upsert_status, row_packet->warning_count);
 		UPSERT_STATUS_SET_SERVER_STATUS(conn->upsert_status, row_packet->server_status);
 	}

--- a/ext/pdo_mysql/tests/bug_76896.phpt
+++ b/ext/pdo_mysql/tests/bug_76896.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Bug #76896 (Last insert ID overwritten after SELECT statement)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_mysql')) die('skip');
+require dirname(__FILE__) . '/config.inc';
+MySQLPDOTest::skip();
+?>
+--FILE--
+<?php
+require dirname(__FILE__) . '/mysql_pdo_test.inc';
+$db = MySQLPDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+
+$db->query("DROP TABLE IF EXISTS `test`;");
+$db->query("CREATE TABLE `test` (
+				`id` int(11) NOT NULL AUTO_INCREMENT,
+				`label` char(1) NOT NULL,
+				PRIMARY KEY (`id`)
+			) ENGINE=InnoDB  DEFAULT CHARSET=utf8;");
+
+$db->query("INSERT INTO test(label) VALUES ('x')");
+var_dump($db->lastInsertId());
+
+$db->query("SELECT * FROM test LIMIT 1");
+var_dump($db->lastInsertId());
+
+$db->query("DROP TABLE IF EXISTS `test`;");
+?>
+--EXPECT--
+string(1) "1"
+string(1) "1"


### PR DESCRIPTION
This is actually a mysqlnd bug. 

According to the [MySQL Client/Server Query Protocol](https://dev.mysql.com/doc/internals/en/com-query-response.html), the client should expect other data than an OK packet. The OK packet is the only packet to contain `last_insert_id`. In the current code, mysqlnd overwrites all header fields, including `last_insert_id` on retrieval of non-OK packets. 

The proposed solution is to not overwrite these fields when a SELECT is requested by the client.

It's overwritten twice during the SELECT

1. client receives ProtocolText:ResultSet
2. client receives EOF packet

Se Bug [#76896](ttps://bugs.php.net/bug.php?id=76896)