### PR TITLE
 Fix #54556: array access to empty var does not trigger a notice

### DIFF
--- a/Zend/tests/024.phpt
+++ b/Zend/tests/024.phpt
@@ -16,9 +16,13 @@ var_dump($a->$b->{$c[1]});
 ?>
 --EXPECTF--
 Notice: Undefined variable: a in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
 
 Notice: Undefined variable: %s in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 
 Notice: Undefined variable: %s in %s on line %d
 NULL
@@ -44,6 +48,8 @@ Notice: Trying to get property '1' of non-object in %s on line %d
 NULL
 
 Notice: Undefined variable: c in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 
 Notice: Trying to get property '1' of non-object in %s on line %d
 

--- a/Zend/tests/033.phpt
+++ b/Zend/tests/033.phpt
@@ -3,13 +3,13 @@ Using undefined multidimensional array
 --FILE--
 <?php 
 
-$arr[1][2][3][4][5];
+$arr[1][2][3];
 
-echo $arr[1][2][3][4][5];
+echo $arr[1][2][3];
 
-$arr[1][2][3][4][5]->foo;
+$arr[1][2][3]->foo;
 
-$arr[1][2][3][4][5]->foo = 1;
+$arr[1][2][3]->foo = 1;
 
 $arr[][] = 2;
 
@@ -20,9 +20,27 @@ $arr[][]->bar = 2;
 
 Notice: Undefined variable: arr in %s on line %d
 
-Notice: Undefined variable: arr in %s on line %d
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 
 Notice: Undefined variable: arr in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
+Notice: Undefined variable: arr in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 
 Notice: Trying to get property 'foo' of non-object in %s on line %d
 

--- a/Zend/tests/assign_to_var_003.phpt
+++ b/Zend/tests/assign_to_var_003.phpt
@@ -12,7 +12,8 @@ var_dump($var1);
 
 echo "Done\n";
 ?>
---EXPECT--	
+--EXPECTF--	
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
 NULL
 Done

--- a/Zend/tests/bug54556.phpt
+++ b/Zend/tests/bug54556.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #54556 (array access to empty var does not trigger a notice)
+--FILE--
+<?php
+class Foo {
+  private $bar;
+  function nonotice(){
+    var_dump($this->bar['yeah']);
+  }
+}
+
+$foo = new Foo();
+$foo->nonotice();
+?>
+--EXPECTF--
+Notice: Cannot get offset of a non-array variable in %s on line %d
+NULL

--- a/Zend/tests/call_user_func_007.phpt
+++ b/Zend/tests/call_user_func_007.phpt
@@ -13,6 +13,8 @@ var_dump($a);
 --EXPECTF--
 Notice: Undefined offset: 0 in %s on line %d
 
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
 Warning: Parameter 1 to foo() expected to be a reference, value given in %s on line %d
 array(0) {
 }

--- a/Zend/tests/dereference_002.phpt
+++ b/Zend/tests/dereference_002.phpt
@@ -69,6 +69,8 @@ array(2) {
   int(5)
 }
 int(1)
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
 
 Notice: Undefined offset: 4 in %s on line %d

--- a/Zend/tests/dereference_010.phpt
+++ b/Zend/tests/dereference_010.phpt
@@ -21,7 +21,10 @@ var_dump(b()[1]);
 
 ?>
 --EXPECTF--
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
 
 Fatal error: Uncaught Error: Cannot use object of type stdClass as array in %s:%d

--- a/Zend/tests/dereference_014.phpt
+++ b/Zend/tests/dereference_014.phpt
@@ -27,8 +27,12 @@ var_dump($h);
 
 ?>
 --EXPECTF--
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
 Notice: Trying to get property 'a' of non-object in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 
 Notice: Trying to get property 'b' of non-object in %s on line %d
 NULL

--- a/Zend/tests/isset_003.phpt
+++ b/Zend/tests/isset_003.phpt
@@ -31,6 +31,8 @@ bool(false)
 
 Notice: Undefined variable: c in %s on line %d
 
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
 Notice: Undefined variable: d in %s on line %d
 
 Notice: Trying to get property '' of non-object in %s on line %d

--- a/Zend/tests/list_003.phpt
+++ b/Zend/tests/list_003.phpt
@@ -4,16 +4,19 @@ list() with non-array
 <?php
 
 list($a) = NULL;
+var_dump($a);
 
 list($b) = 1;
+var_dump($b);
 
 list($c) = 1.;
+var_dump($c);
 
 list($d) = 'foo';
+var_dump($d);
 
 list($e) = print '';
-
-var_dump($a, $b, $c, $d, $e);
+var_dump($e);
 
 ?>
 --EXPECT--

--- a/Zend/tests/offset_bool.phpt
+++ b/Zend/tests/offset_bool.phpt
@@ -24,14 +24,31 @@ var_dump($bool[$arr]);
 
 echo "Done\n";
 ?>
---EXPECT--	
+--EXPECTF--	
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
 Done

--- a/Zend/tests/offset_long.phpt
+++ b/Zend/tests/offset_long.phpt
@@ -24,14 +24,31 @@ var_dump($long[$arr]);
 
 echo "Done\n";
 ?>
---EXPECT--	
+--EXPECTF--	
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
 Done

--- a/Zend/tests/offset_null.phpt
+++ b/Zend/tests/offset_null.phpt
@@ -24,14 +24,31 @@ var_dump($null[$arr]);
 
 echo "Done\n";
 ?>
---EXPECT--	
+--EXPECTF--	
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
 Done

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2025,8 +2025,11 @@ try_string_offset:
 			}
 		}
 	} else {
-		if (type != BP_VAR_IS && UNEXPECTED(Z_TYPE_P(container) == IS_UNDEF)) {
-			zval_undefined_cv(EX(opline)->op1.var EXECUTE_DATA_CC);
+		if (type != BP_VAR_IS) {
+			if (UNEXPECTED(Z_TYPE_P(container) == IS_UNDEF)) {
+				zval_undefined_cv(EX(opline)->op1.var EXECUTE_DATA_CC);
+			}
+			zend_error(E_NOTICE, "Cannot get offset of a non-array variable");
 		}
 		if (/*dim_type == IS_CV &&*/ UNEXPECTED(Z_TYPE_P(dim) == IS_UNDEF)) {
 			zval_undefined_cv(EX(opline)->op2.var EXECUTE_DATA_CC);

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1925,7 +1925,7 @@ static zend_never_inline void ZEND_FASTCALL zend_fetch_dimension_address_UNSET(z
 	zend_fetch_dimension_address(result, container_ptr, dim, dim_type, BP_VAR_UNSET EXECUTE_DATA_CC);
 }
 
-static zend_always_inline void zend_fetch_dimension_address_read(zval *result, zval *container, zval *dim, int dim_type, int type, int support_strings, int slow EXECUTE_DATA_DC)
+static zend_always_inline void zend_fetch_dimension_address_read(zval *result, zval *container, zval *dim, int dim_type, int type, int is_list, int slow EXECUTE_DATA_DC)
 {
 	zval *retval;
 
@@ -1942,7 +1942,7 @@ try_array:
 			}
 		}
 	}
-	if (support_strings && EXPECTED(Z_TYPE_P(container) == IS_STRING)) {
+	if (!is_list && EXPECTED(Z_TYPE_P(container) == IS_STRING)) {
 		zend_long offset;
 
 try_string_offset:
@@ -2029,7 +2029,9 @@ try_string_offset:
 			if (UNEXPECTED(Z_TYPE_P(container) == IS_UNDEF)) {
 				zval_undefined_cv(EX(opline)->op1.var EXECUTE_DATA_CC);
 			}
-			zend_error(E_NOTICE, "Cannot get offset of a non-array variable");
+			if (!is_list) {
+				zend_error(E_NOTICE, "Cannot get offset of a non-array variable");
+			}
 		}
 		if (/*dim_type == IS_CV &&*/ UNEXPECTED(Z_TYPE_P(dim) == IS_UNDEF)) {
 			zval_undefined_cv(EX(opline)->op2.var EXECUTE_DATA_CC);
@@ -2041,30 +2043,30 @@ try_string_offset:
 static zend_never_inline void ZEND_FASTCALL zend_fetch_dimension_address_read_R(zval *container, zval *dim, int dim_type OPLINE_DC EXECUTE_DATA_DC)
 {
 	zval *result = EX_VAR(opline->result.var);
-	zend_fetch_dimension_address_read(result, container, dim, dim_type, BP_VAR_R, 1, 0 EXECUTE_DATA_CC);
+	zend_fetch_dimension_address_read(result, container, dim, dim_type, BP_VAR_R, 0, 0 EXECUTE_DATA_CC);
 }
 
 static zend_never_inline void zend_fetch_dimension_address_read_R_slow(zval *container, zval *dim OPLINE_DC EXECUTE_DATA_DC)
 {
 	zval *result = EX_VAR(opline->result.var);
-	zend_fetch_dimension_address_read(result, container, dim, IS_CV, BP_VAR_R, 1, 1 EXECUTE_DATA_CC);
+	zend_fetch_dimension_address_read(result, container, dim, IS_CV, BP_VAR_R, 0, 1 EXECUTE_DATA_CC);
 }
 
 static zend_never_inline void ZEND_FASTCALL zend_fetch_dimension_address_read_IS(zval *container, zval *dim, int dim_type OPLINE_DC EXECUTE_DATA_DC)
 {
 	zval *result = EX_VAR(opline->result.var);
-	zend_fetch_dimension_address_read(result, container, dim, dim_type, BP_VAR_IS, 1, 0 EXECUTE_DATA_CC);
+	zend_fetch_dimension_address_read(result, container, dim, dim_type, BP_VAR_IS, 0, 0 EXECUTE_DATA_CC);
 }
 
 static zend_never_inline void ZEND_FASTCALL zend_fetch_dimension_address_LIST_r(zval *container, zval *dim, int dim_type OPLINE_DC EXECUTE_DATA_DC)
 {
 	zval *result = EX_VAR(opline->result.var);
-	zend_fetch_dimension_address_read(result, container, dim, dim_type, BP_VAR_R, 0, 0 EXECUTE_DATA_CC);
+	zend_fetch_dimension_address_read(result, container, dim, dim_type, BP_VAR_R, 1, 0 EXECUTE_DATA_CC);
 }
 
 ZEND_API void zend_fetch_dimension_const(zval *result, zval *container, zval *dim, int type)
 {
-	zend_fetch_dimension_address_read(result, container, dim, IS_TMP_VAR, type, 1, 0 NO_EXECUTE_DATA_CC);
+	zend_fetch_dimension_address_read(result, container, dim, IS_TMP_VAR, type, 0, 0 NO_EXECUTE_DATA_CC);
 }
 
 static zend_never_inline zval* ZEND_FASTCALL zend_find_array_dim_slow(HashTable *ht, zval *offset EXECUTE_DATA_DC)

--- a/ext/mysqli/tests/mysqli_fork.phpt
+++ b/ext/mysqli/tests/mysqli_fork.phpt
@@ -111,7 +111,7 @@ if (!have_innodb($link))
 						continue;
 					$tmp = mysqli_fetch_assoc($pres);
 					mysqli_free_result($pres);
-					if ($tmp['msg_id'] == $msg_id)
+					if ($tmp === null || $tmp['msg_id'] == $msg_id)
 						/* no new message */
 						continue;
 					if ($tmp['msg'] == 'stop')
@@ -143,7 +143,7 @@ if (!have_innodb($link))
 				$wait_id = pcntl_waitpid($pid, $status, WNOHANG);
 				if ($pres = mysqli_query($plink, $sql)) {
 					$row = mysqli_fetch_assoc($pres);
-					if ($row['msg_id'] != $last_msg_id) {
+					if ($row !== null && $row['msg_id'] != $last_msg_id) {
 						$last_msg_id = $row['msg_id'];
 						switch ($row['msg']) {
 							case 'start':
@@ -179,7 +179,7 @@ if (!have_innodb($link))
 
 								if ($parent_row != $client_row) {
 									printf("[015] Child indicates different results than parent.\n");
-									var_dump($child_row);
+									var_dump($client_row);
 									var_dump($parent_row);
 									if (!mysqli_query($plink, sprintf($parent_sql, 'stop'))) {
 										printf("[016] Parent cannot inform child\n", mysqli_errno($plink), mysqli_error($plink));

--- a/ext/phar/tests/create_new_and_modify.phpt
+++ b/ext/phar/tests/create_new_and_modify.phpt
@@ -22,7 +22,7 @@ include $pname . '/a.php';
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"])) {
+	if ($status !== false && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/phar/tests/delete_in_phar.phpt
+++ b/ext/phar/tests/delete_in_phar.phpt
@@ -18,7 +18,7 @@ $files['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
+	if ($status !== false && $status["opcache_enabled"]) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/phar/tests/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/delete_in_phar_confirm.phpt
@@ -18,7 +18,7 @@ $files['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
+	if ($status !== false && $status["opcache_enabled"]) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/phar/tests/tar/create_new_and_modify.phpt
+++ b/ext/phar/tests/tar/create_new_and_modify.phpt
@@ -16,7 +16,7 @@ file_put_contents($pname . '/a.php', "brand new!\n");
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"])) {
+	if ($status !== false && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/phar/tests/tar/delete_in_phar.phpt
+++ b/ext/phar/tests/tar/delete_in_phar.phpt
@@ -20,7 +20,7 @@ $phar->stopBuffering();
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
+	if ($status !== false && $status["opcache_enabled"]) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/phar/tests/tar/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/tar/delete_in_phar_confirm.phpt
@@ -20,7 +20,7 @@ $phar->stopBuffering();
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
+	if ($status !== false && $status["opcache_enabled"]) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/phar/tests/zip/create_new_and_modify.phpt
+++ b/ext/phar/tests/zip/create_new_and_modify.phpt
@@ -16,7 +16,7 @@ file_put_contents($pname . '/a.php', "brand new!\n");
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"])) {
+	if ($status !== false && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/phar/tests/zip/delete_in_phar.phpt
+++ b/ext/phar/tests/zip/delete_in_phar.phpt
@@ -20,7 +20,7 @@ $phar->stopBuffering();
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
+	if ($status !== false && $status["opcache_enabled"]) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/phar/tests/zip/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/zip/delete_in_phar_confirm.phpt
@@ -20,7 +20,7 @@ $phar->stopBuffering();
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
+	if ($status !== false && $status["opcache_enabled"]) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/simplexml/tests/017.phpt
+++ b/ext/simplexml/tests/017.phpt
@@ -75,12 +75,24 @@ person: Boe
 ---22---
 person: Joe
   child: Ann
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
   child: 
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 person: 
 
 Notice: Trying to get property 'child' of non-object in %s017.php on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
   child: 
 
 Notice: Trying to get property 'child' of non-object in %s017.php on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
   child: 
 ===DONE===

--- a/ext/spl/tests/array_026.phpt
+++ b/ext/spl/tests/array_026.phpt
@@ -9,6 +9,8 @@ var_dump($test, $test3['mmmmm']);
 ?>
 --EXPECTF--
 Notice: Undefined variable: test3 in %s%earray_026.php on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 object(ArrayObject)#%d (1) {
   ["storage":"ArrayObject":private]=>
   array(1) {

--- a/ext/spl/tests/bug62978.phpt
+++ b/ext/spl/tests/bug62978.phpt
@@ -32,6 +32,8 @@ Notice: Undefined index: epic_magic in %sbug62978.php on line %d
 NULL
 
 Notice: Undefined variable: c in %sbug62978.php on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 NULL
 
 Notice: Undefined index: epic_magic in %sbug62978.php on line %d

--- a/ext/standard/tests/array/bug31158.phpt
+++ b/ext/standard/tests/array/bug31158.phpt
@@ -15,5 +15,7 @@ echo "ok\n";
 ?>
 --EXPECTF--
 Notice: Undefined variable: GLOBALS in %sbug31158.php on line 6
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 ok
 

--- a/ext/standard/tests/strings/bug72433.phpt
+++ b/ext/standard/tests/strings/bug72433.phpt
@@ -20,4 +20,6 @@ var_dump($free_me);
 ?>
 --EXPECTF--
 Notice: unserialize(): Error at offset %d of %d bytes in %sbug72433.php on line 8
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 bool(false)

--- a/ext/standard/tests/strings/bug72663.phpt
+++ b/ext/standard/tests/strings/bug72663.phpt
@@ -25,4 +25,6 @@ Notice: unserialize(): Unexpected end of serialized data in %sbug72663.php on li
 Notice: unserialize(): Error at offset 46 of 47 bytes in %sbug72663.php on line %d
 
 Notice: unserialize(): Error at offset 79 of 80 bytes in %sbug72663.php on line %d
+
+Notice: Cannot get offset of a non-array variable in %s on line %d
 DONE

--- a/sapi/fpm/tests/fcgi.inc
+++ b/sapi/fpm/tests/fcgi.inc
@@ -589,8 +589,11 @@ class Client
         // but still not get the response requested
         $startTime = microtime(true);
 
-        do {
+        while (true) {
             $resp = $this->readPacket();
+            if (!$resp) {
+                break;
+            }
 
             if ($resp['type'] == self::STDOUT || $resp['type'] == self::STDERR) {
                 if ($resp['type'] == self::STDERR) {
@@ -612,7 +615,7 @@ class Client
                 $this->set_ms_timeout($this->_readWriteTimeout);
                 throw new \Exception('Timed out');
             }
-        } while ($resp);
+        }
 
         if (!is_array($resp)) {
             $info = stream_get_meta_data($this->_sock);

--- a/tests/lang/bug25922.phpt
+++ b/tests/lang/bug25922.phpt
@@ -20,4 +20,5 @@ test();
 ?>
 --EXPECT--
 Undefined variable: data
+Cannot get offset of a non-array variable
 Undefined index here: ''

--- a/tests/lang/passByReference_003.phpt
+++ b/tests/lang/passByReference_003.phpt
@@ -28,6 +28,8 @@ Passing undefined by value
 
 Notice: Undefined variable: undef1 in %s on line 13
 
+Notice: Cannot get offset of a non-array variable in %s on line %d
+
 Inside passbyVal call:
 NULL
 


### PR DESCRIPTION
list() is excluded because it makes using each() difficult.