### PR TITLE
Fix bug #76979: define() error message does not mention resources as valid values

### DIFF
--- a/Zend/tests/008.phpt
+++ b/Zend/tests/008.phpt
@@ -14,7 +14,8 @@ var_dump(define("[[[", 2));
 var_dump(define("test const", 3));
 var_dump(define("test const", 3));
 var_dump(define("test", array(1)));
-var_dump(define("test1", new stdclass));
+var_dump(define("test1", fopen(__FILE__, 'r')));
+var_dump(define("test2", new stdclass));
 
 var_dump(constant(" "));
 var_dump(constant("[[["));
@@ -42,8 +43,9 @@ bool(true)
 Notice: Constant test const already defined in %s on line %d
 bool(false)
 bool(true)
+bool(true)
 
-Warning: Constants may only evaluate to scalar values or arrays in %s on line %d
+Warning: Constants may only evaluate to scalar values, arrays or resources in %s on line %d
 bool(false)
 int(1)
 int(2)

--- a/Zend/tests/bug37811.phpt
+++ b/Zend/tests/bug37811.phpt
@@ -21,7 +21,7 @@ var_dump(Baz);
 --EXPECTF--
 string(3) "Foo"
 
-Warning: Constants may only evaluate to scalar values or arrays in %sbug37811.php on line %d
+Warning: Constants may only evaluate to scalar values, arrays or resources in %sbug37811.php on line %d
 
 Warning: Use of undefined constant Baz - assumed 'Baz' (this will throw an Error in a future version of PHP) in %sbug37811.php on line %d
 string(3) "Baz"

--- a/Zend/tests/constant_arrays.phpt
+++ b/Zend/tests/constant_arrays.phpt
@@ -94,7 +94,7 @@ array(1) {
   int(7)
 }
 
-Warning: Constants may only evaluate to scalar values or arrays in %s on line %d
+Warning: Constants may only evaluate to scalar values, arrays or resources in %s on line %d
 bool(false)
 
 Warning: Constants cannot be recursive arrays in %s on line %d

--- a/Zend/tests/constants_002.phpt
+++ b/Zend/tests/constants_002.phpt
@@ -11,7 +11,7 @@ var_dump(foo);
 
 ?>
 --EXPECTF--
-Warning: Constants may only evaluate to scalar values or arrays in %s on line %d
+Warning: Constants may only evaluate to scalar values, arrays or resources in %s on line %d
 
 Warning: Use of undefined constant foo - assumed 'foo' (this will throw an Error in a future version of PHP) in %s on line %d
 string(%d) "foo"

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -794,7 +794,7 @@ static int validate_constant_array(HashTable *ht) /* {{{ */
 					}
 				}
 			} else if (Z_TYPE_P(val) != IS_STRING && Z_TYPE_P(val) != IS_RESOURCE) {
-				zend_error(E_WARNING, "Constants may only evaluate to scalar values or arrays");
+				zend_error(E_WARNING, "Constants may only evaluate to scalar values, arrays or resources");
 				ret = 0;
 				break;
 			}
@@ -895,7 +895,7 @@ repeat:
 			}
 			/* no break */
 		default:
-			zend_error(E_WARNING, "Constants may only evaluate to scalar values or arrays");
+			zend_error(E_WARNING, "Constants may only evaluate to scalar values, arrays or resources");
 			zval_ptr_dtor(&val_free);
 			RETURN_FALSE;
 	}


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=76979
https://github.com/php/php-langspec/blob/be010b4435e7b0801737bb66b5bbdd8f9fb51dde/spec/06-constants.md#constants