### PR TITLE
SOAP: Stop overwriting the node name when creating XML nodes from zvals

### DIFF
--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -308,7 +308,6 @@ static zend_bool soap_check_zval_ref(zval *data, xmlNodePtr node) {
 			if (node_ptr == node) {
 				return 0;
 			}
-			xmlNodeSetName(node, node_ptr->name);
 			xmlSetNs(node, node_ptr->ns);
 			if (SOAP_GLOBAL(soap_version) == SOAP_1_1) {
 				while (1) {

--- a/ext/soap/tests/bugs/bug50675.phpt
+++ b/ext/soap/tests/bugs/bug50675.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Bug #50675 SoapClient can't handle object references correctly.
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+class TestSoapClient extends SoapClient {
+  function __doRequest($request, $location, $action, $version, $one_way = 0) {
+    return <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<soapenv:Body>
+		<soapenv:Fault>
+			<faultcode>soapenv:Server.userException</faultcode>
+			<faultstring>service.EchoServiceException</faultstring>
+			<detail>
+				<service.EchoServiceException xsi:type="ns1:EchoServiceException" xmlns:ns1="urn:service.EchoService">
+					<intParameter xsi:type="xsd:int">105</intParameter>
+					<parameter xsi:type="soapenc:string" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">string param</parameter>
+				</service.EchoServiceException>
+				<ns2:hostname xmlns:ns2="http://xml.apache.org/axis/">steckovic</ns2:hostname>
+			</detail>
+		</soapenv:Fault>
+	</soapenv:Body>
+</soapenv:Envelope>
+EOF;
+	}
+}
+
+ini_set('soap.wsdl_cache_enabled', 0);
+
+$parameters = [
+	'trace' => 1,
+	'exceptions' => 0,
+];
+$client = new TestSoapClient(dirname(__FILE__) . '/bug50675.wsdl', $parameters);
+
+$person = new stdClass();
+$person->name = 'name';
+
+$result = $client->echoPerson($person, $person);
+
+print($client->__getLastRequest());
+--EXPECT--
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://service" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="urn:service.EchoService" xmlns:xsd="http://www.w3.org/2001/XMLSchema" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoPerson><p xsi:type="ns2:Person" id="ref1"><name xsi:type="SOAP-ENC:string">name</name></p><p2 href="#ref1"/></ns1:echoPerson></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/ext/soap/tests/bugs/bug50675.wsdl
+++ b/ext/soap/tests/bugs/bug50675.wsdl
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions targetNamespace="http://212.24.157.117:8080/axis/services/echo" xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:impl="http://212.24.157.117:8080/axis/services/echo" xmlns:intf="http://212.24.157.117:8080/axis/services/echo" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns1="urn:service.EchoService" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <wsdl:types>
+        <schema targetNamespace="urn:service.EchoService" xmlns="http://www.w3.org/2001/XMLSchema">
+            <import namespace="http://schemas.xmlsoap.org/soap/encoding/"/>
+            <complexType name="EchoServiceException">
+                <sequence>
+                    <element name="intParameter" type="xsd:int"/>
+                    <element name="parameter" nillable="true" type="soapenc:string"/>
+                </sequence>
+            </complexType>
+            <complexType name="Person">
+                <sequence>
+                    <element name="name" nillable="true" type="soapenc:string"/>
+                </sequence>
+            </complexType>
+        </schema>
+    </wsdl:types>
+
+    <wsdl:message name="EchoServiceException">
+
+        <wsdl:part name="EchoServiceException" type="tns1:EchoServiceException"/>
+
+    </wsdl:message>
+
+    <wsdl:message name="echoPersonResponse">
+
+        <wsdl:part name="echoPersonReturn" type="tns1:Person"/>
+
+    </wsdl:message>
+
+    <wsdl:message name="echoPersonRequest">
+
+        <wsdl:part name="p" type="tns1:Person"/>
+        <wsdl:part name="p2" type="tns1:Person"/>
+
+    </wsdl:message>
+
+    <wsdl:portType name="EchoService">
+
+        <wsdl:operation name="echoPerson" parameterOrder="p">
+
+            <wsdl:input message="impl:echoPersonRequest" name="echoPersonRequest"/>
+
+            <wsdl:output message="impl:echoPersonResponse" name="echoPersonResponse"/>
+
+            <wsdl:fault message="impl:EchoServiceException" name="EchoServiceException"/>
+
+        </wsdl:operation>
+
+    </wsdl:portType>
+
+    <wsdl:binding name="echoSoapBinding" type="impl:EchoService">
+
+        <wsdlsoap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+
+        <wsdl:operation name="echoPerson">
+
+            <wsdlsoap:operation soapAction=""/>
+
+            <wsdl:input name="echoPersonRequest">
+
+                <wsdlsoap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="http://service" use="encoded"/>
+
+            </wsdl:input>
+
+            <wsdl:output name="echoPersonResponse">
+
+                <wsdlsoap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="http://212.24.157.117:8080/axis/services/echo" use="encoded"/>
+
+            </wsdl:output>
+
+            <wsdl:fault name="EchoServiceException">
+
+                <wsdlsoap:fault encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" name="EchoServiceException" namespace="http://212.24.157.117:8080/axis/services/echo" use="encoded"/>
+
+            </wsdl:fault>
+
+        </wsdl:operation>
+
+    </wsdl:binding>
+
+    <wsdl:service name="EchoServiceService">
+
+        <wsdl:port binding="impl:echoSoapBinding" name="echo">
+
+            <wsdlsoap:address location="http://212.24.157.117:8080/axis/services/echo"/>
+
+        </wsdl:port>
+
+    </wsdl:service>
+
+</wsdl:definitions>


### PR DESCRIPTION
Fixes [bug #50675](https://bugs.php.net/bug.php?id=50675).
