### PR TITLE
[RFC] Add a warning for excess of arguments in sprintf like functions

### DIFF
--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -645,6 +645,10 @@ php_formatted_print(zend_execute_data *execute_data, int use_array, int format_o
 		}
 	}
 
+	if (argc - 1 > argnum) {
+  	php_error_docref(NULL, E_WARNING, "Expected %d argument%s, %d given", argnum, argnum == 1 ? "" : "s", argc - 1);
+	}
+
 	if (newargs) {
 		efree(newargs);
 	}

--- a/ext/standard/tests/strings/printf_64bit.phpt
+++ b/ext/standard/tests/strings/printf_64bit.phpt
@@ -690,6 +690,8 @@ C
 
 
 *** Output for excess of mixed type arguments  ***
+
+Warning: printf(): Expected 1 argument, 3 given in %s on line %d
 abcdefghjklmnpqrstuvwxyz
 
 *** Output for string format parameter and integer type argument ***


### PR DESCRIPTION
This is the implementation for the upcoming RFC.

TODO:
- [ ] Fix tests
- [ ] Write RFC
- [ ] Refactor current implementation to change `To few arguments` to something like `expected 2 arguments, 1 given` (???)