### PR TITLE
Remove EXPERIMENTAL files from embed and xmlrpc

### DIFF
--- a/ext/xmlrpc/EXPERIMENTAL
+++ b/ext/xmlrpc/EXPERIMENTAL
@@ -1,5 +1,0 @@
-this extension is experimental,
-its functions may change their names
-or move to extension all together
-so do not rely to much on them
-you have been warned!

--- a/sapi/embed/EXPERIMENTAL
+++ b/sapi/embed/EXPERIMENTAL
@@ -1,5 +1,0 @@
-this module is experimental,
-its functions may change their names
-or move to extension all together
-so do not rely to much on them
-you have been warned!

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -1,7 +1,7 @@
 dnl config.m4 for sapi embed
 
 PHP_ARG_ENABLE(embed,,
-[  --enable-embed[=TYPE]     EXPERIMENTAL: Enable building of embedded SAPI library
+[  --enable-embed[=TYPE]     Enable building of embedded SAPI library
                           TYPE is either 'shared' or 'static'. [TYPE=shared]], no, no)
 
 AC_MSG_CHECKING([for embedded SAPI library support])


### PR DESCRIPTION
The two have been updated a bit over the years. PHP core bundled extensions or SAPIs also probably shouldn't be marked as experimental since they are maintained and developed otherwise bugs can be resolved anyhow.