### PR TITLE
Add support for getting SKIP_TAGSTART and SKIP_WHITE options

### DIFF
--- a/ext/xml/tests/xml_parser_get_option_variation3.phpt
+++ b/ext/xml/tests/xml_parser_get_option_variation3.phpt
@@ -1,0 +1,29 @@
+--TEST--
+xml_parser_get_option() with XML_OPTION_SKIP_TAGSTART and XML_OPTION_SKIP_WHITE
+--SKIPIF--
+<?php
+if (!extension_loaded('xml')) die('skip xml extension not available');
+?>
+--FILE--
+<?php
+$parser = xml_parser_create();
+echo "defaults:\n";
+var_dump(xml_parser_get_option($parser, XML_OPTION_SKIP_TAGSTART));
+var_dump(xml_parser_get_option($parser, XML_OPTION_SKIP_WHITE));
+echo "setting:\n";
+var_dump(xml_parser_set_option($parser, XML_OPTION_SKIP_TAGSTART, 7));
+var_dump(xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 1));
+echo "getting:\n";
+var_dump(xml_parser_get_option($parser, XML_OPTION_SKIP_TAGSTART));
+var_dump(xml_parser_get_option($parser, XML_OPTION_SKIP_WHITE));
+?>
+--EXPECT--
+defaults:
+int(0)
+int(0)
+setting:
+bool(true)
+bool(true)
+getting:
+int(7)
+int(1)

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1663,6 +1663,12 @@ PHP_FUNCTION(xml_parser_get_option)
 		case PHP_XML_OPTION_CASE_FOLDING:
 			RETURN_LONG(parser->case_folding);
 			break;
+		case PHP_XML_OPTION_SKIP_TAGSTART:
+			RETURN_LONG(parser->toffset);
+			break;
+		case PHP_XML_OPTION_SKIP_WHITE:
+			RETURN_LONG(parser->skipwhite);
+			break;
 		case PHP_XML_OPTION_TARGET_ENCODING:
 			RETURN_STRING((char *)parser->target_encoding);
 			break;


### PR DESCRIPTION
When `XML_OPTION_SKIP_TAGSTART` and `XML_OPTION_SKIP_WHITE` had been
introduced[1], it had been overlooked to also support them for
`xml_parser_get_option()`.  We catch up on that.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=b57dc275950b228f2399990471c4f22b7d154c6c>