### PR TITLE
Fix bug: date_get_last_errors can't output all the error messages

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3020,14 +3020,30 @@ static void zval_from_error_container(zval *z, timelib_error_container *error) /
 	add_assoc_long(z, "warning_count", error->warning_count);
 	array_init(&element);
 	for (i = 0; i < error->warning_count; i++) {
-		add_index_string(&element, error->warning_messages[i].position, error->warning_messages[i].message);
+		zval *tmp;
+		if ((tmp = zend_hash_index_find(Z_ARRVAL(element), error->warning_messages[i].position)) == NULL) {
+			zval messages;
+			array_init(&messages);
+			add_next_index_string(&element, error->warning_messages[i].message);
+			add_index_string(&element, error->warning_messages[i].position, &messages);
+		} else {
+			add_next_index_string(tmp, error->warning_messages[i].message);
+		}
 	}
 	add_assoc_zval(z, "warnings", &element);
 
 	add_assoc_long(z, "error_count", error->error_count);
 	array_init(&element);
 	for (i = 0; i < error->error_count; i++) {
-		add_index_string(&element, error->error_messages[i].position, error->error_messages[i].message);
+		zval *tmp;
+		if ((tmp = zend_hash_index_find(Z_ARRVAL(element), error->error_messages[i].position)) == NULL) {
+			zval messages;
+			array_init(&messages);
+			add_next_index_string(&element, error->error_messages[i].message);
+			add_index_string(&element, error->error_messages[i].position, &messages);
+		} else {
+			add_next_index_string(tmp, error->error_messages[i].message);
+		}
 	}
 	add_assoc_zval(z, "errors", &element);
 } /* }}} */

--- a/ext/date/tests/date_get_last_errors_3595.phpt
+++ b/ext/date/tests/date_get_last_errors_3595.phpt
@@ -1,0 +1,27 @@
+--TEST--
+date_get_last_errors() output all the error messages
+--FILE--
+<?php
+DateTime::createFromFormat('Y-n-j a g:i:s', '2018-11-8 am 9:57:43');
+print_r(date_get_last_errors());
+?>
+--EXPECT--
+Array
+(
+    [warning_count] => 0
+    [warnings] => Array
+        (
+        )
+
+    [error_count] => 2
+    [errors] => Array
+        (
+            [0] => Array
+                 (
+                     [0] => Meridian can only come after an hour has been found
+                     [1] => Unexpected data found.
+                 )
+
+        )
+
+)


### PR DESCRIPTION
Example:
```php
<?php

DateTime::createFromFormat('Y-n-j a g:i:s', '2018-11-8 am 9:57:43');
print_r(date_get_last_errors());
```
Output:
```text
Array
(
    [warning_count] => 0
    [warnings] => Array
        (
        )

    [error_count] => 2
    [errors] => Array
        (
            [10] => Unexpected data found.
        )

)
```
