### PR TITLE
Fix #71592: External entity processing never fails

### DIFF
--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -359,7 +359,10 @@ _external_entity_ref_handler(void *user, const xmlChar *names, int type, const x
 		return;
 	}
 
-	parser->h_external_entity_ref(parser, names, (XML_Char *) "", sys_id, pub_id);
+	if (!parser->h_external_entity_ref(parser, names, (XML_Char *) "", sys_id, pub_id)) {
+		xmlStopParser(parser->parser);
+		parser->parser->errNo = XML_ERROR_EXTERNAL_ENTITY_HANDLING;
+	};
 }
 
 static xmlEntityPtr

--- a/ext/xml/tests/bug71592.phpt
+++ b/ext/xml/tests/bug71592.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bug #71592 (External entity processing never fails)
+--SKIPIF--
+<?php
+if (!extension_loaded('xml')) die('skip xml extension not available');
+?>
+--FILE--
+<?php
+$xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE p [
+  <!ENTITY pic PUBLIC "image.gif" "http://example.org/image.gif">
+]>
+<root>
+<p>&pic;</p>
+<p></nop>
+</root>
+XML;
+
+$parser = xml_parser_create_ns('UTF-8');
+xml_set_external_entity_ref_handler($parser, function () {
+    return false;
+});
+xml_parse($parser, $xml);
+var_dump(xml_get_error_code($parser));
+?>
+===DONE===
+--EXPECT--
+int(21)
+===DONE===


### PR DESCRIPTION
If the callback set via `xml_set_external_entity_ref_handler()` returns
a falsy value, parsing is supposed to stop and the error number set to
`XML_ERROR_EXTERNAL_ENTITY_HANDLING`.  This is already correctly done
by the libexpat binding, but the libxml2 binding ignores the return
value.  We fix this by calling `xmlStopParser()` which is available as
of libxml 2.1.0[1] (PHP-7.1 requires at least libxml 2.6.11 anyway),
and setting the desired `errNo` ourselves.

[1] <http://xmlsoft.org/news.html>