### PR TITLE
Implementing array_every() and array_any()

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -848,6 +848,8 @@ static const func_info_t func_infos[] = {
 	FN("array_map",                    MAY_BE_NULL | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_REF | MAY_BE_ARRAY_OF_ANY),
 	F1("array_chunk",                  MAY_BE_NULL | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_REF | MAY_BE_ARRAY_OF_ANY),
 	F1("array_combine",                MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_REF | MAY_BE_ARRAY_OF_ANY),
+	F1("array_every",                  MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
+	F1("array_any",                    MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F0("array_key_exists",             MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F1("pos",                          UNKNOWN_INFO),
 	F0("sizeof",                       MAY_BE_NULL | MAY_BE_LONG),

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -911,6 +911,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_iterator_apply, 0, 0, 2)
 	ZEND_ARG_ARRAY_INFO(0, args, 1)
 ZEND_END_ARG_INFO();
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_iterator_until, 0, 0, 2)
+	ZEND_ARG_OBJ_INFO(0, iterator, Traversable, 0)
+	ZEND_ARG_INFO(0, function)
+ZEND_END_ARG_INFO();
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_parents, 0, 0, 1)
 	ZEND_ARG_INFO(0, instance)
 	ZEND_ARG_INFO(0, autoload)
@@ -984,6 +989,8 @@ static const zend_function_entry spl_functions[] = {
 	PHP_FE(iterator_to_array,       arginfo_iterator_to_array)
 	PHP_FE(iterator_count,          arginfo_iterator)
 	PHP_FE(iterator_apply,          arginfo_iterator_apply)
+	PHP_FE(iterator_every,          arginfo_iterator_until)
+	PHP_FE(iterator_any,            arginfo_iterator_until)
 #endif /* SPL_ITERATORS_H */
 	PHP_FE_END
 };

--- a/ext/spl/spl_iterators.h
+++ b/ext/spl/spl_iterators.h
@@ -58,6 +58,8 @@ PHP_MINIT_FUNCTION(spl_iterators);
 PHP_FUNCTION(iterator_to_array);
 PHP_FUNCTION(iterator_count);
 PHP_FUNCTION(iterator_apply);
+PHP_FUNCTION(iterator_every);
+PHP_FUNCTION(iterator_any);
 
 typedef enum {
 	DIT_Default = 0,

--- a/ext/spl/tests/iterator_any_001.phpt
+++ b/ext/spl/tests/iterator_any_001.phpt
@@ -1,0 +1,12 @@
+--TEST--
+SPL: iterator_any() bool argument exception test
+--FILE--
+<?php
+iterator_any(true);
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Argument 1 passed to iterator_any() must implement interface Traversable, bool given in %s:%d
+Stack trace:
+#0 %s(%d): iterator_any(true)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/spl/tests/iterator_any_002.phpt
+++ b/ext/spl/tests/iterator_any_002.phpt
@@ -1,0 +1,12 @@
+--TEST--
+SPL: iterator_any() array argument exception test
+--FILE--
+<?php
+iterator_any([]);
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Argument 1 passed to iterator_any() must implement interface Traversable, array given in %s:%d
+Stack trace:
+#0 %s(%d): iterator_any(Array)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/spl/tests/iterator_any_003.phpt
+++ b/ext/spl/tests/iterator_any_003.phpt
@@ -1,0 +1,72 @@
+--TEST--
+Test iterator_any() function
+--FILE--
+<?php
+/*
+	Prototype: bool iterator_any(array $array, mixed $callback);
+	Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($nr)
+{
+	return is_int($nr);
+}
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+var_dump(iterator_any());
+var_dump(iterator_any(new ArrayIterator()));
+var_dump(iterator_any(new ArrayIterator(), true));
+
+echo "\n*** Testing basic functionality ***\n";
+
+var_dump(iterator_any(new ArrayIterator(['hello', 'world']), 'is_int_ex'));
+var_dump(iterator_any(new ArrayIterator(['hello', 1, 2, 3]), 'is_int_ex'));
+$iterations = 0;
+var_dump(iterator_any(new ArrayIterator(['hello', 1, 2, 3]), function($item) use (&$iterations) {
+	++$iterations;
+	return is_int($item);
+}));
+var_dump($iterations);
+
+echo "\n*** Testing second argument to predicate ***\n";
+
+var_dump(iterator_any(new ArrayIterator([1, 2, 3]), function($item, $key) {
+	var_dump($key);
+	return false;
+}));
+
+echo "\n*** Testing edge cases ***\n";
+
+var_dump(iterator_any(new ArrayIterator(), 'is_int_ex'));
+
+echo "\nDone";
+?>
+--EXPECTF--
+*** Testing not enough or wrong arguments ***
+
+Warning: iterator_any() expects exactly 2 parameters, 0 given in %s on line %d
+NULL
+
+Warning: iterator_any() expects exactly 2 parameters, 1 given in %s on line %d
+NULL
+
+Warning: iterator_any() expects parameter 2 to be a valid callback, no array or string given in %s on line %d
+NULL
+
+*** Testing basic functionality ***
+bool(false)
+bool(true)
+bool(true)
+int(2)
+
+*** Testing second argument to predicate ***
+int(0)
+int(1)
+int(2)
+bool(false)
+
+*** Testing edge cases ***
+bool(false)
+
+Done

--- a/ext/spl/tests/iterator_every_001.phpt
+++ b/ext/spl/tests/iterator_every_001.phpt
@@ -1,0 +1,12 @@
+--TEST--
+SPL: iterator_every() bool argument exception test
+--FILE--
+<?php
+iterator_every(true);
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Argument 1 passed to iterator_every() must implement interface Traversable, bool given in %s:%d
+Stack trace:
+#0 %s(%d): iterator_every(true)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/spl/tests/iterator_every_002.phpt
+++ b/ext/spl/tests/iterator_every_002.phpt
@@ -1,0 +1,12 @@
+--TEST--
+SPL: iterator_every() array argument exception test
+--FILE--
+<?php
+iterator_every([]);
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Argument 1 passed to iterator_every() must implement interface Traversable, array given in %s:%d
+Stack trace:
+#0 %s(%d): iterator_every(Array)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/spl/tests/iterator_every_003.phpt
+++ b/ext/spl/tests/iterator_every_003.phpt
@@ -1,0 +1,72 @@
+--TEST--
+Test iterator_every() function
+--FILE--
+<?php
+/*
+	Prototype: bool iterator_every(array $array, mixed $callback);
+	Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($item)
+{
+	return is_int($item);
+}
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+var_dump(iterator_every());
+var_dump(iterator_every(new ArrayIterator()));
+var_dump(iterator_every(new ArrayIterator(), true));
+
+echo "\n*** Testing basic functionality ***\n";
+
+var_dump(iterator_every(new ArrayIterator([1, 2, 3]), 'is_int_ex'));
+var_dump(iterator_every(new ArrayIterator(['hello', 1, 2, 3]), 'is_int_ex'));
+$iterations = 0;
+var_dump(iterator_every(new ArrayIterator(['hello', 1, 2, 3]), function($item) use (&$iterations) {
+	++$iterations;
+	return is_int($item);
+}));
+var_dump($iterations);
+
+echo "\n*** Testing second argument to predicate ***\n";
+
+var_dump(iterator_every(new ArrayIterator([1, 2, 3]), function($item, $key) {
+	var_dump($key);
+	return true;
+}));
+
+echo "\n*** Testing edge cases ***\n";
+
+var_dump(iterator_every(new ArrayIterator(), 'is_int_ex'));
+
+echo "\nDone";
+?>
+--EXPECTF--
+*** Testing not enough or wrong arguments ***
+
+Warning: iterator_every() expects exactly 2 parameters, 0 given in %s on line %d
+NULL
+
+Warning: iterator_every() expects exactly 2 parameters, 1 given in %s on line %d
+NULL
+
+Warning: iterator_every() expects parameter 2 to be a valid callback, no array or string given in %s on line %d
+NULL
+
+*** Testing basic functionality ***
+bool(true)
+bool(false)
+bool(false)
+int(1)
+
+*** Testing second argument to predicate ***
+int(0)
+int(1)
+int(2)
+bool(true)
+
+*** Testing edge cases ***
+bool(true)
+
+Done

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -604,6 +604,11 @@ ZEND_BEGIN_ARG_INFO(arginfo_array_combine, 0)
 	ZEND_ARG_INFO(0, keys)   /* ARRAY_INFO(0, keys, 0) */
 	ZEND_ARG_INFO(0, values) /* ARRAY_INFO(0, values, 0) */
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_array_until, 0)
+	ZEND_ARG_INFO(0, arg)
+	ZEND_ARG_INFO(0, callback)
+ZEND_END_ARG_INFO()
 /* }}} */
 /* {{{ basic_functions.c */
 ZEND_BEGIN_ARG_INFO(arginfo_get_magic_quotes_gpc, 0)
@@ -3399,6 +3404,8 @@ static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(array_map,														arginfo_array_map)
 	PHP_FE(array_chunk,														arginfo_array_chunk)
 	PHP_FE(array_combine,													arginfo_array_combine)
+	PHP_FE(array_every,														arginfo_array_until)
+	PHP_FE(array_any,														arginfo_array_until)
 	PHP_FE(array_key_exists,												arginfo_array_key_exists)
 
 	/* aliases from array.c */

--- a/ext/standard/php_array.h
+++ b/ext/standard/php_array.h
@@ -102,6 +102,8 @@ PHP_FUNCTION(array_map);
 PHP_FUNCTION(array_key_exists);
 PHP_FUNCTION(array_chunk);
 PHP_FUNCTION(array_combine);
+PHP_FUNCTION(array_every);
+PHP_FUNCTION(array_any);
 
 PHPAPI int php_array_merge(HashTable *dest, HashTable *src);
 PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src);

--- a/ext/standard/tests/array/array_any.phpt
+++ b/ext/standard/tests/array/array_any.phpt
@@ -1,0 +1,80 @@
+--TEST--
+Test array_any() function
+--FILE--
+<?php
+/*
+	Prototype: bool array_any(array $array, mixed $callback);
+	Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($nr)
+{
+	return is_int($nr);
+}
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+var_dump(array_any());
+var_dump(array_any(true));
+var_dump(array_any([]));
+var_dump(array_any(true, function () {}));
+var_dump(array_any([], true));
+
+echo "\n*** Testing basic functionality ***\n";
+
+var_dump(array_any(['hello', 'world'], 'is_int_ex'));
+var_dump(array_any(['hello', 1, 2, 3], 'is_int_ex'));
+$iterations = 0;
+var_dump(array_any(['hello', 1, 2, 3], function($item) use (&$iterations) {
+	++$iterations;
+	return is_int($item);
+}));
+var_dump($iterations);
+
+echo "\n*** Testing second argument to predicate ***\n";
+
+var_dump(array_any([1, 2, 3], function($item, $key) {
+	var_dump($key);
+	return false;
+}));
+
+echo "\n*** Testing edge cases ***\n";
+
+var_dump(array_any([], 'is_int_ex'));
+
+echo "\nDone";
+?>
+--EXPECTF--
+*** Testing not enough or wrong arguments ***
+
+Warning: array_any() expects exactly 2 parameters, 0 given in %s on line %d
+NULL
+
+Warning: array_any() expects exactly 2 parameters, 1 given in %s on line %d
+NULL
+
+Warning: array_any() expects exactly 2 parameters, 1 given in %s on line %d
+NULL
+
+Warning: array_any() expects parameter 1 to be array, bool given in %s on line %d
+NULL
+
+Warning: array_any() expects parameter 2 to be a valid callback, no array or string given in %s on line %d
+NULL
+
+*** Testing basic functionality ***
+bool(false)
+bool(true)
+bool(true)
+int(2)
+
+*** Testing second argument to predicate ***
+int(0)
+int(1)
+int(2)
+bool(false)
+
+*** Testing edge cases ***
+bool(false)
+
+Done

--- a/ext/standard/tests/array/array_every.phpt
+++ b/ext/standard/tests/array/array_every.phpt
@@ -1,0 +1,80 @@
+--TEST--
+Test array_every() function
+--FILE--
+<?php
+/*
+	Prototype: bool array_every(array $array, mixed $callback);
+	Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($item)
+{
+	return is_int($item);
+}
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+var_dump(array_every());
+var_dump(array_every(true));
+var_dump(array_every([]));
+var_dump(array_every(true, function () {}));
+var_dump(array_every([], true));
+
+echo "\n*** Testing basic functionality ***\n";
+
+var_dump(array_every([1, 2, 3], 'is_int_ex'));
+var_dump(array_every(['hello', 1, 2, 3], 'is_int_ex'));
+$iterations = 0;
+var_dump(array_every(['hello', 1, 2, 3], function($item) use (&$iterations) {
+	++$iterations;
+	return is_int($item);
+}));
+var_dump($iterations);
+
+echo "\n*** Testing second argument to predicate ***\n";
+
+var_dump(array_every([1, 2, 3], function($item, $key) {
+	var_dump($key);
+	return true;
+}));
+
+echo "\n*** Testing edge cases ***\n";
+
+var_dump(array_every([], 'is_int_ex'));
+
+echo "\nDone";
+?>
+--EXPECTF--
+*** Testing not enough or wrong arguments ***
+
+Warning: array_every() expects exactly 2 parameters, 0 given in %s on line %d
+NULL
+
+Warning: array_every() expects exactly 2 parameters, 1 given in %s on line %d
+NULL
+
+Warning: array_every() expects exactly 2 parameters, 1 given in %s on line %d
+NULL
+
+Warning: array_every() expects parameter 1 to be array, bool given in %s on line %d
+NULL
+
+Warning: array_every() expects parameter 2 to be a valid callback, no array or string given in %s on line %d
+NULL
+
+*** Testing basic functionality ***
+bool(true)
+bool(false)
+bool(false)
+int(1)
+
+*** Testing second argument to predicate ***
+int(0)
+int(1)
+int(2)
+bool(true)
+
+*** Testing edge cases ***
+bool(true)
+
+Done


### PR DESCRIPTION
This is a follow-up to #1385 which was abandoned from inactivity. This implementation does have differences:
- `iterator_every()` and `iterator_any()` were added instead of using `traversable` parameters, waiting for https://bugs.php.net/bug.php?id=76865
- the array isn't passed as an argument to the callback
    - I don't think any other function does that, but it would be easy to add