### PR TITLE
Disable sqlite3 and pdo_sqlite by default

### DIFF
--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -2,9 +2,9 @@ dnl config.m4 for extension pdo_sqlite
 dnl vim:et:sw=2:ts=2:
 
 PHP_ARG_WITH(pdo-sqlite, for sqlite 3 support for PDO,
-[  --without-pdo-sqlite[=DIR]
+[  --with-pdo-sqlite[=DIR]
                           PDO: sqlite 3 support.  DIR is the sqlite base
-                          install directory [BUNDLED]], $PHP_PDO)
+                          install directory [BUNDLED]])
 
 if test "$PHP_PDO_SQLITE" != "no"; then
 

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -2,8 +2,8 @@ dnl config.m4 for extension sqlite3
 dnl vim:et:ts=2:sw=2
 
 PHP_ARG_WITH(sqlite3, whether to enable the SQLite3 extension,
-[  --without-sqlite3[=DIR]   Do not include SQLite3 support. DIR is the prefix to
-                          SQLite3 installation directory.], yes)
+[  --with-sqlite3[=DIR]   Include SQLite3 support. DIR is the prefix to
+                          SQLite3 installation directory.])
 
 if test $PHP_SQLITE3 != "no"; then
   sqlite3_extra_sources=""


### PR DESCRIPTION
Since libsqlite has been unbundled[1], it makes sense to change the
defaults of building ext/sqlite3 and ext/pdo_sqlite, i.e. to disable
both extensions by default – this is more in line with other bundled
extension which rely on external dependencies.

Nothing has to be done for Windows, since both extensions are disabled
by default already.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=6083a387a81dbbd66d6316a3a12a63f06d5f7109>