### PR TITLE
Don't expose the SQLite3::readOnly method with SQLite < 3.7.4

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1371,6 +1371,7 @@ PHP_METHOD(sqlite3stmt, clear)
 }
 /* }}} */
 
+#if SQLITE_VERSION_NUMBER >= 3007004
 /* {{{ proto bool SQLite3Stmt::readOnly()
    Returns true if a statement is definitely read only */
 PHP_METHOD(sqlite3stmt, readOnly)
@@ -1386,14 +1387,14 @@ PHP_METHOD(sqlite3stmt, readOnly)
 	SQLITE3_CHECK_INITIALIZED(stmt_obj->db_obj, stmt_obj->initialised, SQLite3);
 	SQLITE3_CHECK_INITIALIZED_STMT(stmt_obj->stmt, SQLite3Stmt);
 
-#if SQLITE_VERSION_NUMBER >= 3007004
 	if (sqlite3_stmt_readonly(stmt_obj->stmt)) {
 		RETURN_TRUE;
 	}
-#endif
+
 	RETURN_FALSE;
 }
 /* }}} */
+#endif
 
 static int register_bound_parameter_to_sqlite(struct php_sqlite3_bound_param *param, php_sqlite3_stmt *stmt) /* {{{ */
 {

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2025,7 +2025,9 @@ static const zend_function_entry php_sqlite3_stmt_class_methods[] = {
 	PHP_ME(sqlite3stmt, execute,	arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
 	PHP_ME(sqlite3stmt, bindParam,	arginfo_sqlite3stmt_bindparam, ZEND_ACC_PUBLIC)
 	PHP_ME(sqlite3stmt, bindValue,	arginfo_sqlite3stmt_bindvalue, ZEND_ACC_PUBLIC)
+#if SQLITE_VERSION_NUMBER >= 3007004
 	PHP_ME(sqlite3stmt, readOnly,	arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
+#endif
 	PHP_ME(sqlite3stmt, __construct, arginfo_sqlite3stmt_construct, ZEND_ACC_PRIVATE)
 	PHP_FE_END
 };


### PR DESCRIPTION
Instead of returning false when the SQLite3 library is too old, just don't expose the method as it doesn't make any sense as the feature is just not present.