### PR TITLE
Remove .deps files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@
 *.tar.xz.asc
 .FBCIndex
 .FBCLockFolder
-.deps
 .libs
 phpt.*
 core

--- a/ext/skeleton/.gitignore.in
+++ b/ext/skeleton/.gitignore.in
@@ -1,4 +1,3 @@
-.deps
 *.lo
 *.la
 .libs

--- a/scripts/phpize.in
+++ b/scripts/phpize.in
@@ -11,7 +11,7 @@ SED="@SED@"
 
 FILES_BUILD="mkdep.awk scan_makefile_in.awk shtool libtool.m4 ax_check_compile_flag.m4 ax_gcc_func_attribute.m4 php_cxx_compile_stdcxx.m4"
 FILES="acinclude.m4 Makefile.global config.sub config.guess ltmain.sh run-tests*.php"
-CLEAN_FILES="$FILES *.o *.lo *.la .deps .libs/ build/ modules/ install-sh \
+CLEAN_FILES="$FILES *.o *.lo *.la .libs/ build/ modules/ install-sh \
 	mkinstalldirs missing config.nice config.sub config.guess configure configure.ac \
 	aclocal.m4 config.h config.h.in conftest* ltmain.sh libtool config.cache autom4te.cache/ \
 	config.log config.status Makefile Makefile.fragments Makefile.objects confdefs.h \

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -195,7 +195,6 @@ PHP_GEN_BUILD_DIRS
 PHP_GEN_GLOBAL_MAKEFILE
 
 test -d modules || $php_shtool mkdir modules
-touch .deps
 
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
The `.deps` file(s) was once used by Automake and created to write dependencies to it. The file creation has been removed via the commit 779c11af21cf8a627b8f2f2edef9e9073c76ed94.