### PR TITLE
Support shared libraries of macOS SDKs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -329,6 +329,7 @@ dnl -------------------------------------------------------------------------
 PTHREADS_CHECK
 PHP_HELP_SEPARATOR([SAPI modules:])
 PHP_SHLIB_SUFFIX_NAMES
+PHP_SYSTEM_SHLIBDIR_PATHS
 PHP_BUILD_PROGRAM
 PHP_SAPI=none
 
@@ -391,7 +392,9 @@ if test -d /usr/pkg/include -a -d /usr/pkg/lib ; then
    CPPFLAGS="$CPPFLAGS -I/usr/pkg/include"
    LDFLAGS="$LDFLAGS -L/usr/pkg/lib"
 fi
-test -d /usr/ucblib && PHP_ADD_LIBPATH(/usr/ucblib)
+if test -d /usr/ucblib; then
+  PHP_ADD_LIBPATH(/usr/ucblib)
+fi
 
 
 dnl First, library checks.
@@ -788,7 +791,7 @@ if test "$PHP_VALGRIND" != "no"; then
   AC_MSG_CHECKING([for valgrind header])
 
   if test "$PHP_VALGRIND" = "yes"; then
-    SEARCH_PATH="/usr/local /usr"
+    SEARCH_PATH="/usr/local $SYSTEM_SHLIBDIR_PATHS"
   else
     SEARCH_PATH="$PHP_VALGRIND"
   fi

--- a/ext/bz2/config.m4
+++ b/ext/bz2/config.m4
@@ -8,7 +8,7 @@ if test "$PHP_BZ2" != "no"; then
     BZIP_DIR=$PHP_BZ2
   else
     AC_MSG_CHECKING(for BZip2 in default path)
-    for i in /usr/local /usr; do
+    for i in /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       if test -r $i/include/bzlib.h; then
         BZIP_DIR=$i
         AC_MSG_RESULT(found in $i)

--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -47,7 +47,7 @@ if test "$PHP_CURL" != "no"; then
       CURL_DIR=$PHP_CURL
     else
       AC_MSG_CHECKING(for cURL in default path)
-      for i in /usr/local /usr; do
+      for i in /usr/local $SYSTEM_SHLIBDIR_PATHS; do
         if test -r $i/include/curl/easy.h; then
           CURL_DIR=$i
           AC_MSG_RESULT(found in $i)

--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -109,7 +109,7 @@ dnl
 # QDBM
 if test "$PHP_QDBM" != "no"; then
   PHP_DBA_STD_BEGIN
-  for i in $PHP_QDBM /usr/local /usr; do
+  for i in $PHP_QDBM /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -f "$i/include/depot.h"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/include/depot.h
@@ -142,7 +142,7 @@ if test "$PHP_GDBM" != "no"; then
   if test "$HAVE_QDBM" = "1"; then
     PHP_DBA_STD_RESULT(gdbm, gdbm, [You cannot combine --with-gdbm with --with-qdbm])
   fi
-  for i in $PHP_GDBM /usr/local /usr; do
+  for i in $PHP_GDBM /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -f "$i/include/gdbm.h"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/include/gdbm.h
@@ -167,7 +167,7 @@ PHP_DBA_STD_RESULT(gdbm)
 # NDBM
 if test "$PHP_NDBM" != "no"; then
   PHP_DBA_STD_BEGIN
-  for i in $PHP_NDBM /usr/local /usr; do
+  for i in $PHP_NDBM /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -f "$i/include/ndbm.h"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/include/ndbm.h
@@ -201,7 +201,7 @@ PHP_DBA_STD_RESULT(ndbm)
 dnl TCADB
 if test "$PHP_TCADB" != "no"; then
   PHP_DBA_STD_BEGIN
-  for i in $PHP_TCADB /usr/local /usr; do
+  for i in $PHP_TCADB /usr/local $SYSTEM_SHLIBDIR_PATHS; do
 	if test -f "$i/include/tcadb.h"; then
 	  THIS_PREFIX=$i
 	  PHP_ADD_INCLUDE($THIS_PREFIX/include)
@@ -232,7 +232,7 @@ PHP_DBA_STD_RESULT(tcadb)
 dnl LMDB
 if test "$PHP_LMDB" != "no"; then
   PHP_DBA_STD_BEGIN
-  for i in $PHP_LMDB /usr/local /usr; do
+  for i in $PHP_LMDB /usr/local $SYSTEM_SHLIBDIR_PATHS; do
 	if test -f "$i/include/lmdb.h"; then
 	  THIS_PREFIX=$i
 	  PHP_ADD_INCLUDE($THIS_PREFIX/include)
@@ -267,7 +267,8 @@ AC_DEFUN([PHP_DBA_DB_CHECK],[
     AC_MSG_ERROR([DBA: Could not find necessary header file(s).])
   fi
   for LIB in $2; do
-    if test -f $THIS_PREFIX/$PHP_LIBDIR/lib$LIB.a || test -f $THIS_PREFIX/$PHP_LIBDIR/lib$LIB.$SHLIB_SUFFIX_NAME; then
+    PHP_CHECK_SHLIB_EXISTS($THIS_PREFIX/$PHP_LIBDIR/lib$LIB, dba_lib_exists)
+    if test $dba_lib_exists = "yes"; then
       lib_found="";
       PHP_TEMP_LDFLAGS(-L$THIS_PREFIX/$PHP_LIBDIR, -l$LIB,[
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[
@@ -343,7 +344,7 @@ if test "$PHP_DB4" != "no"; then
   PHP_DBA_STD_BEGIN
   dbdp4="/usr/local/BerkeleyDB.4."
   dbdp5="/usr/local/BerkeleyDB.5."
-  for i in $PHP_DB4 ${dbdp5}1 ${dbdp5}0 ${dbdp4}8 ${dbdp4}7 ${dbdp4}6 ${dbdp4}5 ${dbdp4}4 ${dbdp4}3 ${dbdp4}2 ${dbdp4}1 ${dbdp}0 /usr/local /usr; do
+  for i in $PHP_DB4 ${dbdp5}1 ${dbdp5}0 ${dbdp4}8 ${dbdp4}7 ${dbdp4}6 ${dbdp4}5 ${dbdp4}4 ${dbdp4}3 ${dbdp4}2 ${dbdp4}1 ${dbdp}0 /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -f "$i/db5/db.h"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/db5/db.h
@@ -408,7 +409,8 @@ if test "$PHP_DB3" != "no"; then
   if test "$HAVE_DB4" = "1"; then
     PHP_DBA_STD_RESULT(db3, Berkeley DB3, [You cannot combine --with-db3 with --with-db4])
   fi
-  for i in $PHP_DB3 /usr/local/BerkeleyDB.3.3 /usr/local/BerkeleyDB.3.2 /usr/local/BerkeleyDB.3.1 /usr/local/BerkeleyDB.3.0 /usr/local /usr; do
+  dbdp3="/usr/local/BerkeleyDB.3."
+  for i in $PHP_DB3 ${dbdp3}.3 ${dbdp3}.2 ${dbdp3}.1 ${dbdp3}.0 /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -f "$i/db3/db.h"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/include/db3/db.h
@@ -441,7 +443,7 @@ if test "$PHP_DB2" != "no"; then
   if test "$HAVE_DB3" = "1" || test "$HAVE_DB4" = "1"; then
     PHP_DBA_STD_RESULT(db2, Berkeley DB2, [You cannot combine --with-db2 with --with-db3 or --with-db4])
   fi
-  for i in $PHP_DB2 $PHP_DB2/BerkeleyDB /usr/BerkeleyDB /usr/local /usr; do
+  for i in $PHP_DB2 $PHP_DB2/BerkeleyDB /usr/BerkeleyDB /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -f "$i/db2/db.h"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/db2/db.h
@@ -494,7 +496,7 @@ if test "$PHP_DB1" != "no"; then
     done
   else
     AC_DEFINE_UNQUOTED(DB1_VERSION, "Unknown DB1", [ ])
-    for i in $PHP_DB1 /usr/local /usr; do
+    for i in $PHP_DB1 /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       if test -f "$i/db1/db.h"; then
         THIS_PREFIX=$i
         THIS_INCLUDE=$i/db1/db.h
@@ -541,7 +543,7 @@ if test "$PHP_DBM" != "no"; then
   if test "$HAVE_QDBM" = "1"; then
     PHP_DBA_STD_RESULT(dbm, dbm, [You cannot combine --with-dbm with --with-qdbm])
   fi
-  for i in $PHP_DBM /usr/local /usr; do
+  for i in $PHP_DBM /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -f "$i/include/dbm.h"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/include/dbm.h
@@ -607,7 +609,7 @@ if test "$PHP_CDB" = "yes"; then
   THIS_RESULT="builtin"
 elif test "$PHP_CDB" != "no"; then
   PHP_DBA_STD_BEGIN
-  for i in $PHP_CDB /usr/local /usr; do
+  for i in $PHP_CDB /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -f "$i/include/cdb.h"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/include/cdb.h

--- a/ext/enchant/config.m4
+++ b/ext/enchant/config.m4
@@ -9,7 +9,7 @@ if test "$PHP_ENCHANT" != "no"; then
 	if test "$PHP_ENCHANT" != "yes"; then
 	    ENCHANT_SEARCH_DIRS=$PHP_ENCHANT
 	else
-	    ENCHANT_SEARCH_DIRS="/usr/local /usr"
+	    ENCHANT_SEARCH_DIRS="/usr/local $SYSTEM_SHLIBDIR_PATHS"
 	fi
 	for i in $ENCHANT_SEARCH_DIRS; do
 		if test -f $i/include/enchant/enchant.h; then

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -52,7 +52,7 @@ AC_DEFUN([PHP_GD_ZLIB],[
 			AC_MSG_ERROR([Can't find zlib headers under "$PHP_ZLIB_DIR"])
 		fi
 	else
-		for i in /usr/local /usr; do
+		for i in /usr/local $SYSTEM_SHLIBDIR_PATHS; do
 			if test -f "$i/include/zlib/zlib.h"; then
 				PHP_ZLIB_DIR="$i"
 				PHP_ZLIB_INCDIR="$i/include/zlib"
@@ -67,7 +67,7 @@ AC_DEFUN([PHP_GD_ZLIB],[
 AC_DEFUN([PHP_GD_WEBP],[
   if test "$PHP_WEBP_DIR" != "no"; then
 
-    for i in $PHP_WEBP_DIR /usr/local /usr; do
+    for i in $PHP_WEBP_DIR /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       test -f $i/include/webp/decode.h && GD_WEBP_DIR=$i && break
     done
 
@@ -75,7 +75,7 @@ AC_DEFUN([PHP_GD_WEBP],[
       AC_MSG_ERROR([webp/decode.h not found.])
     fi
 
-    for i in $PHP_WEBP_DIR /usr/local /usr; do
+    for i in $PHP_WEBP_DIR /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       test -f $i/include/webp/encode.h && GD_WEBP_DIR=$i && break
     done
 
@@ -101,7 +101,7 @@ AC_DEFUN([PHP_GD_WEBP],[
 AC_DEFUN([PHP_GD_JPEG],[
   if test "$PHP_JPEG_DIR" != "no"; then
 
-    for i in $PHP_JPEG_DIR /usr/local /usr; do
+    for i in $PHP_JPEG_DIR /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       test -f $i/include/jpeglib.h && GD_JPEG_DIR=$i && break
     done
 
@@ -126,7 +126,7 @@ AC_DEFUN([PHP_GD_JPEG],[
 AC_DEFUN([PHP_GD_PNG],[
   if test "$PHP_PNG_DIR" != "no"; then
 
-    for i in $PHP_PNG_DIR /usr/local /usr; do
+    for i in $PHP_PNG_DIR /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       test -f $i/include/png.h && GD_PNG_DIR=$i && break
     done
 
@@ -157,9 +157,12 @@ AC_DEFUN([PHP_GD_PNG],[
 AC_DEFUN([PHP_GD_XPM],[
   if test "$PHP_XPM_DIR" != "no"; then
 
-    for i in $PHP_XPM_DIR /usr/local /usr/X11R6 /usr; do
-      test -f $i/include/xpm.h && GD_XPM_DIR=$i && GD_XPM_INC=$i && break
-      test -f $i/include/X11/xpm.h && GD_XPM_DIR=$i && GD_XPM_INC=$i/X11 && break
+    for i in $PHP_XPM_DIR /usr/X11 /usr/X11R6 /usr/local $SYSTEM_SHLIBDIR_PATHS; do
+      if test -f $i/include/X11/xpm.h; then
+        GD_XPM_DIR=$i
+        GD_XPM_INC=$i/include
+        break
+      fi
     done
 
     if test -z "$GD_XPM_DIR"; then

--- a/ext/gettext/config.m4
+++ b/ext/gettext/config.m4
@@ -4,7 +4,7 @@ PHP_ARG_WITH(gettext,for GNU gettext support,
 [  --with-gettext[=DIR]      Include GNU gettext support])
 
 if test "$PHP_GETTEXT" != "no"; then
-  for i in $PHP_GETTEXT /usr/local /usr; do
+  for i in $PHP_GETTEXT /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     test -r $i/include/libintl.h && GETTEXT_DIR=$i && break
   done
 

--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -5,7 +5,7 @@ if test "$PHP_GMP" != "no"; then
 
   MACHINE_INCLUDES=$($CC -dumpmachine)
 
-  for i in $PHP_GMP /usr/local /usr; do
+  for i in $PHP_GMP /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     test -f $i/include/gmp.h && GMP_DIR=$i && break
     test -f $i/include/$MACHINE_INCLUDES/gmp.h && GMP_DIR=$i && break
   done

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -13,7 +13,7 @@ if test "$PHP_ICONV" != "no"; then
 
   if test "$iconv_avail" != "no"; then
     if test -z "$ICONV_DIR"; then
-      for i in /usr/local /usr; do
+      for i in /usr/local $SYSTEM_SHLIBDIR_PATHS; do
         if test -f "$i/include/iconv.h" || test -f "$i/include/giconv.h"; then
           PHP_ICONV_PREFIX="$i"
           break
@@ -33,7 +33,7 @@ if test "$PHP_ICONV" != "no"; then
       PHP_ICONV_H_PATH="$PHP_ICONV_PREFIX/include/giconv.h"
     else
       PHP_ICONV_H_PATH="$PHP_ICONV_PREFIX/include/iconv.h"
-	fi
+    fi
 
     AC_MSG_CHECKING([if iconv is glibc's])
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <gnu/libc-version.h>]], [[gnu_get_libc_version();]])],[

--- a/ext/imap/config.m4
+++ b/ext/imap/config.m4
@@ -107,7 +107,7 @@ if test "$PHP_IMAP" != "no"; then
     PHP_NEW_EXTENSION(imap, php_imap.c, $ext_shared)
     AC_DEFINE(HAVE_IMAP,1,[ ])
 
-    for i in $PHP_IMAP /usr/local /usr; do
+    for i in $PHP_IMAP /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       IMAP_INC_CHK()
       el[]IMAP_INC_CHK(/include/c-client)
       el[]IMAP_INC_CHK(/include/imap)

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -40,7 +40,7 @@ AC_DEFUN([PHP_LDAP_CHECKS], [
 
 AC_DEFUN([PHP_LDAP_SASL_CHECKS], [
   if test "$1" = "yes"; then
-    SEARCH_DIRS="/usr/local /usr"
+    SEARCH_DIRS="/usr/local $SYSTEM_SHLIBDIR_PATHS"
   else
     SEARCH_DIRS=$1
   fi
@@ -93,7 +93,7 @@ if test "$PHP_LDAP" != "no"; then
   PHP_NEW_EXTENSION(ldap, ldap.c, $ext_shared,,-DLDAP_DEPRECATED=1)
 
   if test "$PHP_LDAP" = "yes"; then
-    for i in /usr/local /usr; do
+    for i in /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       PHP_LDAP_CHECKS($i)
     done
   else
@@ -117,70 +117,152 @@ if test "$PHP_LDAP" != "no"; then
 
   MACHINE_INCLUDES=$($CC -dumpmachine)
 
-  if test -f $LDAP_LIBDIR/liblber.a || test -f $LDAP_LIBDIR/liblber.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.a || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.$SHLIB_SUFFIX_NAME; then
-    PHP_ADD_LIBRARY_WITH_PATH(lber, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(ldap, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+  FOUND_LIB="no"
 
-  elif test -f $LDAP_LIBDIR/libldap.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/libldap.$SHLIB_SUFFIX_NAME.3 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libldap.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libldap.$SHLIB_SUFFIX_NAME.3 || test -f $LDAP_LIBDIR/libldap.3.dylib; then
-    PHP_ADD_LIBRARY_WITH_PATH(ldap, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-
-  elif test -f $LDAP_LIBDIR/libssldap50.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libssldap50.$SHLIB_SUFFIX_NAME; then
-    if test -n "$LDAP_PTHREAD"; then
-      PHP_ADD_LIBRARY($LDAP_PTHREAD)
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/liblber, lib_exists)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/liblber, lib_exists)
     fi
-    PHP_ADD_LIBRARY_WITH_PATH(nspr4, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(plc4, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(plds4, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(ssldap50, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(ldap50, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(prldap50, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(ssl3, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    AC_DEFINE(HAVE_NSLDAP,1,[ ])
-
-  elif test -f $LDAP_LIBDIR/libldapssl41.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libldapssl41.$SHLIB_SUFFIX_NAME; then
-    if test -n "$LDAP_PTHREAD"; then
-      PHP_ADD_LIBRARY($LDAP_PTHREAD)
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      PHP_ADD_LIBRARY_WITH_PATH(lber, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(ldap, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
     fi
-    PHP_ADD_LIBRARY_WITH_PATH(nspr3, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(plc3, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(plds3, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(ldapssl41, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    AC_DEFINE(HAVE_NSLDAP,1,[ ])
+  fi
 
-  elif test -f $LDAP_LIBDIR/libldapssl30.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libldapssl30.$SHLIB_SUFFIX_NAME; then
-    if test -n "$LDAP_PTHREAD"; then
-      PHP_ADD_LIBRARY($LDAP_PTHREAD)
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/libldap, lib_exists, 3)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/libldap, lib_exists, 3)
     fi
-    PHP_ADD_LIBRARY_WITH_PATH(ldapssl30, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    AC_DEFINE(HAVE_NSLDAP,1,[ ])
-
-  elif test -f $LDAP_LIBDIR/libldap30.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libldap30.$SHLIB_SUFFIX_NAME; then
-    if test -n "$LDAP_PTHREAD"; then
-      PHP_ADD_LIBRARY($LDAP_PTHREAD)
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      PHP_ADD_LIBRARY_WITH_PATH(ldap, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
     fi
-    PHP_ADD_LIBRARY_WITH_PATH(ldap30, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    AC_DEFINE(HAVE_NSLDAP,1,[ ])
+  fi
 
-  elif test -f $LDAP_LIBDIR/libumich_ldap.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libumich_ldap.$SHLIB_SUFFIX_NAME; then
-    PHP_ADD_LIBRARY_WITH_PATH(umich_lber, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    PHP_ADD_LIBRARY_WITH_PATH(umich_ldap, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/libssldap50, lib_exists)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/libssldap50, lib_exists)
+    fi
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      if test -n "$LDAP_PTHREAD"; then
+        PHP_ADD_LIBRARY($LDAP_PTHREAD)
+      fi
+      PHP_ADD_LIBRARY_WITH_PATH(nspr4, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(plc4, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(plds4, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(ssldap50, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(ldap50, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(prldap50, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(ssl3, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      AC_DEFINE(HAVE_NSLDAP,1,[ ])
+    fi
+  fi
 
-  elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.12.1 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME.12.1; then
-    PHP_ADD_LIBRARY_WITH_PATH(clntsh, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    AC_DEFINE(HAVE_ORALDAP,1,[ ])
-    AC_DEFINE(HAVE_ORALDAP_12,1,[ ])
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/libldapssl41, lib_exists)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/libssldap41, lib_exists)
+    fi
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      if test -n "$LDAP_PTHREAD"; then
+        PHP_ADD_LIBRARY($LDAP_PTHREAD)
+      fi
+      PHP_ADD_LIBRARY_WITH_PATH(nspr3, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(plc3, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(plds3, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(ldapssl41, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      AC_DEFINE(HAVE_NSLDAP,1,[ ])
+    fi
+  fi
 
-  elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.11.1 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME.11.1; then
-    PHP_ADD_LIBRARY_WITH_PATH(clntsh, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-    AC_DEFINE(HAVE_ORALDAP,1,[ ])
-    AC_DEFINE(HAVE_ORALDAP_11,1,[ ])
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/libldapssl30, lib_exists)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/libssldap30, lib_exists)
+    fi
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      if test -n "$LDAP_PTHREAD"; then
+        PHP_ADD_LIBRARY($LDAP_PTHREAD)
+      fi
+      PHP_ADD_LIBRARY_WITH_PATH(ldapssl30, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      AC_DEFINE(HAVE_NSLDAP,1,[ ])
+    fi
+  fi
 
-  elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME; then
-     PHP_ADD_LIBRARY_WITH_PATH(clntsh, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
-     AC_DEFINE(HAVE_ORALDAP,1,[ ])
-     AC_DEFINE(HAVE_ORALDAP_10,1,[ ])
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/libldap30, lib_exists)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/libdap30, lib_exists)
+    fi
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      if test -n "$LDAP_PTHREAD"; then
+        PHP_ADD_LIBRARY($LDAP_PTHREAD)
+      fi
+      PHP_ADD_LIBRARY_WITH_PATH(ldap30, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      AC_DEFINE(HAVE_NSLDAP,1,[ ])
+    fi
+  fi
 
-  else
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/libumich_ldap, lib_exists)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/libumich_ldap, lib_exists)
+    fi
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      PHP_ADD_LIBRARY_WITH_PATH(umich_lber, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      PHP_ADD_LIBRARY_WITH_PATH(umich_ldap, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+    fi
+  fi
+
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/libclntsh, lib_exists, 12.1)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh, lib_exists, 12.1)
+    fi
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      PHP_ADD_LIBRARY_WITH_PATH(clntsh, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      AC_DEFINE(HAVE_ORALDAP,1,[ ])
+      AC_DEFINE(HAVE_ORALDAP_12,1,[ ])
+    fi
+  fi
+
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/libclntsh, lib_exists, 11.1)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh, lib_exists, 11.1)
+    fi
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      PHP_ADD_LIBRARY_WITH_PATH(clntsh, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      AC_DEFINE(HAVE_ORALDAP,1,[ ])
+      AC_DEFINE(HAVE_ORALDAP_11,1,[ ])
+    fi
+  fi
+
+  if test $FOUND_LIB = "no"; then
+    PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/libclntsh, lib_exists, 10.1)
+    if test $lib_exists = "no"; then
+      PHP_CHECK_SHLIB_EXISTS($LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh, lib_exists, 10.1)
+    fi
+    if test $lib_exists = "yes"; then
+      FOUND_LIB="yes"
+      PHP_ADD_LIBRARY_WITH_PATH(clntsh, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)
+      AC_DEFINE(HAVE_ORALDAP,1,[ ])
+      AC_DEFINE(HAVE_ORALDAP_10,1,[ ])
+    fi
+  fi
+
+  if test $FOUND_LIB = "no"; then
     AC_MSG_ERROR(Cannot find ldap libraries in $LDAP_LIBDIR.)
   fi
 

--- a/ext/pdo_dblib/config.m4
+++ b/ext/pdo_dblib/config.m4
@@ -11,7 +11,7 @@ if test "$PHP_PDO_DBLIB" != "no"; then
 
   if test "$PHP_PDO_DBLIB" = "yes"; then
 
-    for i in /usr/local /usr; do
+    for i in /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       if test -f $i/include/sybdb.h; then
         PDO_FREETDS_INSTALLATION_DIR=$i
         PDO_FREETDS_INCLUDE_DIR=$i/include

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -29,7 +29,7 @@ if test "$PHP_PDO_PGSQL" != "no"; then
   else
     AC_MSG_RESULT(not found)
     if test "$PHP_PDO_PGSQL" = "yes"; then
-      PGSQL_SEARCH_PATHS="/usr /usr/local /usr/local/pgsql"
+      PGSQL_SEARCH_PATHS="/usr/local $SYSTEM_SHLIBDIR_PATHS /usr/local/pgsql"
     else
       PGSQL_SEARCH_PATHS=$PHP_PDO_PGSQL
     fi

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -31,7 +31,7 @@ if test "$PHP_PDO_SQLITE" != "no"; then
 
   php_pdo_sqlite_sources_core="pdo_sqlite.c sqlite_driver.c sqlite_statement.c"
 
-  SEARCH_PATH="$PHP_PDO_SQLITE /usr/local /usr"     # you might want to change this
+  SEARCH_PATH="$PHP_PDO_SQLITE /usr/local $SYSTEM_SHLIBDIR_PATHS"     # you might want to change this
   SEARCH_FOR="/include/sqlite3.h"  # you most likely want to change this
   if test -r $PHP_PDO_SQLITE/$SEARCH_FOR; then # path given as parameter
     PDO_SQLITE_DIR=$PHP_PDO_SQLITE

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -25,7 +25,7 @@ if test "$PHP_PGSQL" != "no"; then
   else
     AC_MSG_RESULT(not found)
     if test "$PHP_PGSQL" = "yes"; then
-      PGSQL_SEARCH_PATHS="/usr /usr/local /usr/local/pgsql"
+      PGSQL_SEARCH_PATHS="/usr/local $SYSTEM_SHLIBDIR_PATHS /usr/local/pgsql"
     else
       PGSQL_SEARCH_PATHS=$PHP_PGSQL
     fi

--- a/ext/pspell/config.m4
+++ b/ext/pspell/config.m4
@@ -9,7 +9,7 @@ if test "$PHP_PSPELL" != "no"; then
 	if test "$PHP_PSPELL" != "yes"; then
 	    PSPELL_SEARCH_DIRS=$PHP_PSPELL
 	else
-	    PSPELL_SEARCH_DIRS="/usr/local /usr"
+	    PSPELL_SEARCH_DIRS="/usr/local $SYSTEM_SHLIBDIR_PATHS"
 	fi
 	for i in $PSPELL_SEARCH_DIRS; do
 		if test -f $i/include/pspell/pspell.h; then

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -12,7 +12,7 @@ else
 fi
 
 if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
-  for i in $PHP_READLINE /usr/local /usr; do
+  for i in $PHP_READLINE /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     test -f $i/include/readline/readline.h && READLINE_DIR=$i && break
   done
 
@@ -69,7 +69,7 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
 
 elif test "$PHP_LIBEDIT" != "no"; then
 
-  for i in $PHP_LIBEDIT /usr/local /usr; do
+  for i in $PHP_LIBEDIT /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     test -f $i/include/editline/readline.h && LIBEDIT_DIR=$i && break
   done
 

--- a/ext/recode/config.m4
+++ b/ext/recode/config.m4
@@ -4,7 +4,7 @@ PHP_ARG_WITH(recode,for recode support,
 [  --with-recode[=DIR]       Include recode support])
 
 if test "$PHP_RECODE" != "no"; then
-  RECODE_LIST="$PHP_RECODE /usr/local /usr /opt"
+  RECODE_LIST="$PHP_RECODE /usr/local $SYSTEM_SHLIBDIR_PATHS /opt"
 
   for i in $RECODE_LIST; do
     if test -f $i/include/recode.h; then

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -18,7 +18,7 @@ if test "$PHP_SESSION" != "no"; then
 fi
 
 if test "$PHP_MM" != "no"; then
-  for i in $PHP_MM /usr/local /usr; do
+  for i in $PHP_MM /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     test -f "$i/include/mm.h" && MM_DIR=$i && break
   done
 

--- a/ext/skeleton/config.m4.in
+++ b/ext/skeleton/config.m4.in
@@ -37,7 +37,7 @@ if test "$PHP_%EXTNAMECAPS%" != "no"; then
   dnl PHP_EVAL_INCLINE($LIBFOO_CFLAGS)
 
   dnl # --with-%EXTNAME% -> check with-path
-  dnl SEARCH_PATH="/usr/local /usr"     # you might want to change this
+  dnl SEARCH_PATH="/usr/local $SYSTEM_SHLIBDIR_PATHS"     # you might want to change this
   dnl SEARCH_FOR="/include/%EXTNAME%.h"  # you most likely want to change this
   dnl if test -r $PHP_%EXTNAMECAPS%/$SEARCH_FOR; then # path given as parameter
   dnl   %EXTNAMECAPS%_DIR=$PHP_%EXTNAMECAPS%

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -4,7 +4,7 @@ PHP_ARG_WITH(sodium, for sodium support,
 [  --with-sodium[=DIR]       Include sodium support])
 
 if test "$PHP_SODIUM" != "no"; then
-  SEARCH_PATH="/usr/local /usr"     # you might want to change this
+  SEARCH_PATH="/usr/local $SYSTEM_SHLIBDIR_PATHS"     # you might want to change this
   SEARCH_FOR="/include/sodium.h"  # you most likely want to change this
 
   AC_PATH_PROG(PKG_CONFIG, pkg-config, no)

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -20,7 +20,7 @@ if test $PHP_SQLITE3 != "no"; then
   fi
 
   AC_MSG_CHECKING([for sqlite3 files in default path])
-  for i in $PHP_SQLITE3 /usr/local /usr; do
+  for i in $PHP_SQLITE3 /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -r $i/include/sqlite3.h; then
       SQLITE3_DIR=$i
       AC_MSG_RESULT(found in $i)

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -413,7 +413,7 @@ PHP_ARG_WITH(password-argon2, for Argon2 support,
 
 if test "$PHP_PASSWORD_ARGON2" != "no"; then
   AC_MSG_CHECKING([for Argon2 library])
-  for i in $PHP_PASSWORD_ARGON2 /usr /usr/local ; do
+  for i in $PHP_PASSWORD_ARGON2 /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -r $i/include/argon2.h; then
       ARGON2_DIR=$i;
       AC_MSG_RESULT(found in $i)

--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -8,7 +8,7 @@ if test "$PHP_TIDY" != "no"; then
   if test "$PHP_TIDY" != "yes"; then
     TIDY_SEARCH_DIRS=$PHP_TIDY
   else
-    TIDY_SEARCH_DIRS="/usr/local /usr"
+    TIDY_SEARCH_DIRS="/usr/local $SYSTEM_SHLIBDIR_PATHS"
   fi
 
   for i in $TIDY_SEARCH_DIRS; do

--- a/ext/wddx/config.m4
+++ b/ext/wddx/config.m4
@@ -35,8 +35,9 @@ if test "$PHP_WDDX" != "no"; then
   dnl Check for expat only if --with-libexpat-dir is used.
   dnl
   if test "$PHP_LIBEXPAT_DIR" != "no"; then
-    for i in $PHP_XML $PHP_LIBEXPAT_DIR /usr /usr/local; do
-      if test -f "$i/$PHP_LIBDIR/libexpat.a" || test -f "$i/$PHP_LIBDIR/libexpat.$SHLIB_SUFFIX_NAME"; then
+    for i in $PHP_XML $PHP_LIBEXPAT_DIR /usr/local $SYSTEM_SHLIBDIR_PATHS; do
+      PHP_CHECK_SHLIB_EXISTS($i/$PHP_LIBDIR/libexpat, expat_lib_exists)
+      if test $expat_lib_exists = "yes"; then
         EXPAT_DIR=$i
         break
       fi

--- a/ext/xml/config.m4
+++ b/ext/xml/config.m4
@@ -34,8 +34,9 @@ if test "$PHP_XML" != "no"; then
   dnl Check for expat only if --with-libexpat-dir is used.
   dnl
   if test "$PHP_LIBEXPAT_DIR" != "no"; then
-    for i in $PHP_XML $PHP_LIBEXPAT_DIR /usr /usr/local; do
-      if test -f "$i/$PHP_LIBDIR/libexpat.a" || test -f "$i/$PHP_LIBDIR/libexpat.$SHLIB_SUFFIX_NAME"; then
+    for i in $PHP_XML $PHP_LIBEXPAT_DIR /usr/local $SYSTEM_SHLIBDIR_PATHS; do
+      PHP_CHECK_SHLIB_EXISTS($i/$PHP_LIBDIR/libexpat, expat_lib_exists)
+      if test $expat_lib_exists = "yes"; then
         EXPAT_DIR=$i
         break
       fi

--- a/ext/xmlrpc/config.m4
+++ b/ext/xmlrpc/config.m4
@@ -44,8 +44,9 @@ if test "$PHP_XMLRPC" != "no"; then
     ])
   else
     testval=no
-    for i in $PHP_LIBEXPAT_DIR $XMLRPC_DIR /usr/local /usr; do
-      if test -f $i/$PHP_LIBDIR/libexpat.a || test -f $i/$PHP_LIBDIR/libexpat.$SHLIB_SUFFIX_NAME; then
+    for i in $PHP_LIBEXPAT_DIR $XMLRPC_DIR /usr/local $SYSTEM_SHLIBDIR_PATHS; do
+      PHP_CHECK_SHLIB_EXISTS($i/$PHP_LIBDIR/libexpat, expat_lib_exists)
+      if test $expat_lib_exists = "yes"; then
         AC_DEFINE(HAVE_LIBEXPAT,1,[ ])
         PHP_ADD_LIBRARY_WITH_PATH(expat, $i/$PHP_LIBDIR, XMLRPC_SHARED_LIBADD)
         PHP_ADD_INCLUDE($i/include)
@@ -100,7 +101,7 @@ dnl for xmlrpc-epi because of this.
     XMLRPC_DIR=$PHP_XMLRPC/include/xmlrpc-epi
   else
     AC_MSG_CHECKING(for XMLRPC-EPI in default path)
-    for i in /usr/local /usr; do
+    for i in /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       if test -r $i/include/xmlrpc.h; then
         XMLRPC_DIR=$i/include
         AC_MSG_RESULT(found in $i)

--- a/ext/xsl/config.m4
+++ b/ext/xsl/config.m4
@@ -14,7 +14,7 @@ if test "$PHP_XSL" != "no"; then
     AC_MSG_ERROR([XSL extension requires DOM extension, add --enable-dom])
   fi
 
-  for i in $PHP_XSL /usr/local /usr; do
+  for i in $PHP_XSL /usr/local $SYSTEM_SHLIBDIR_PATHS; do
     if test -x "$i/bin/xslt-config"; then
       XSLT_CONFIG=$i/bin/xslt-config
       break
@@ -37,7 +37,7 @@ if test "$PHP_XSL" != "no"; then
       PHP_EVAL_INCLINE($XSL_INCS)
 
       AC_MSG_CHECKING([for EXSLT support])
-      for i in $PHP_XSL /usr/local /usr; do
+      for i in $PHP_XSL /usr/local $SYSTEM_SHLIBDIR_PATHS; do
         if test -r "$i/include/libexslt/exslt.h"; then
           PHP_XSL_EXSL_DIR=$i
           break

--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -31,7 +31,7 @@ if test "$PHP_ZIP" != "no"; then
       fi
 
     else
-      for i in /usr/local /usr; do
+      for i in /usr/local $SYSTEM_SHLIBDIR_PATHS; do
         if test -r $i/include/zip.h; then
           LIBZIP_CFLAGS="-I$i/include"
           LIBZIP_LIBDIR="$i/$PHP_LIBDIR"

--- a/ext/zlib/config0.m4
+++ b/ext/zlib/config0.m4
@@ -19,7 +19,7 @@ if test "$PHP_ZLIB" != "no" || test "$PHP_ZLIB_DIR" != "no"; then
       ZLIB_INCDIR=$ZLIB_DIR/include
     fi
   else
-    for i in /usr/local /usr $PHP_ZLIB_DIR; do
+    for i in $PHP_ZLIB_DIR /usr/local $SYSTEM_SHLIBDIR_PATHS; do
       if test -f $i/include/zlib/zlib.h; then
         ZLIB_DIR=$i
         ZLIB_INCDIR=$i/include/zlib

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -33,6 +33,7 @@ PHP_ARG_WITH(libdir, for system library directory,
 
 PHP_RUNPATH_SWITCH
 PHP_SHLIB_SUFFIX_NAMES
+PHP_SYSTEM_SHLIBDIR_PATHS
 
 dnl Find php-config script
 PHP_ARG_WITH(php-config,,


### PR DESCRIPTION
resolve https://bugs.php.net/bug.php?id=77011

From Mojave (macOS 10.14), it was deprecated `/usr/include` and we should use SDK paths explicitly: https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes#3035624.
Although we can restore `/usr/include` by /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg,
> In a future release, this package will no longer be provided.

Therefore, we should support SDK paths for users building PHP from sources (e.g. [Homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/php.rb), [php-build](https://github.com/php-build/php-build), [phpbrew](https://github.com/phpbrew/phpbrew) and etc.)  Because the shared libraries of SDK paths use `.tbd` as file extension, we also should support new extension; `.tbd`.

This patch includes `.tbd` and SDK paths support and some fixes to resolve prefix correctly.

I tested this patch in some situations:

On macOS Mojave with configure options of php-build:
```bash
brew update && brew install pkg-config autoconf \
  openssl \
  icu4c \
  re2c \
  bison \
  libzip
export PATH="$(brew --prefix bison)/bin:$PATH"
make clean
./buildconf --force
./configure \
  --without-pear \
  --enable-bcmath \
  --enable-cgi \
  --enable-exif \
  --enable-fpm \
  --enable-ftp \
  --enable-intl \
  --enable-mbstring \
  --enable-pcntl \
  --enable-phpdbg \
  --enable-shmop \
  --enable-soap \
  --enable-sockets \
  --enable-sysvsem \
  --enable-sysvshm \
  --enable-xmlreader \
  --enable-zip \
  --disable-debug \
  --with-bz2 \
  --with-curl \
  --with-freetype-dir \
  --with-gd \
  --with-jpeg-dir \
  --with-kerberos \
  --with-libzip \
  --with-mysqli=mysqlnd \
  --with-openssl=$(brew --prefix openssl) \
  --with-pdo-mysql=mysqlnd \
  --with-pdo-sqlite \
  --with-tidy \
  --with-webp-dir \
  --with-xmlrpc \
  --with-xpm-dir \
  --with-xsl \
  --with-zlib \
  --with-zlib-dir \
  --with-libedit \
  --with-png-dir \
  --with-icu-dir=$(brew --prefix icu4c)
make
```

On macOS Mojave with configure options of Homebrew's php formula:
```
brew update && brew install pkg-config autoconf \
  openssl \
  re2c \
  bison \
  httpd \
  argon2 \
  aspell \
  freetds \
  freetype \
  gettext \
  gmp \
  icu4c \
  libpq \
  libsodium \
  openldap \
  unixodbc
export PATH="$(brew --prefix bison)/bin:$PATH"
make clean
./buildconf --force
./configure \
  --enable-bcmath \
  --enable-calendar \
  --enable-dba \
  --enable-dtrace \
  --enable-exif \
  --enable-ftp \
  --enable-fpm \
  --enable-intl \
  --enable-mbregex \
  --enable-mbstring \
  --enable-mysqlnd \
  --enable-opcache-file \
  --enable-pcntl \
  --enable-phpdbg \
  --enable-phpdbg-webhelper \
  --enable-shmop \
  --enable-soap \
  --enable-sockets \
  --enable-sysvmsg \
  --enable-sysvsem \
  --enable-sysvshm \
  --enable-wddx \
  --enable-zip \
  --with-apxs2=$(brew --prefix httpd)/bin/apxs \
  --with-bz2 \
  --with-fpm-user=_www \
  --with-fpm-group=_www \
  --with-freetype-dir=$(brew --prefix freetype) \
  --with-gd \
  --with-gettext=$(brew --prefix gettext) \
  --with-gmp=$(brew --prefix gmp) \
  --with-icu-dir=$(brew --prefix icu4c) \
  --with-jpeg-dir \
  --with-kerberos \
  --with-layout=GNU \
  --with-ldap=$(brew --prefix openldap) \
  --with-ldap-sasl \
  --with-libxml-dir \
  --with-libedit \
  --with-libzip \
  --with-mhash \
  --with-mysql-sock=/tmp/mysql.sock \
  --with-mysqli=mysqlnd \
  --with-ndbm \
  --with-openssl=$(brew --prefix openssl) \
  --with-password-argon2=$(brew --prefix argon2) \
  --with-pdo-dblib=$(brew --prefix freetds) \
  --with-pdo-mysql=mysqlnd \
  --with-pdo-odbc=unixODBC,$(brew --prefix unixodbc) \
  --with-pdo-pgsql=$(brew --prefix libpq) \
  --with-pdo-sqlite \
  --with-pgsql=$(brew --prefix libpq) \
  --with-pic \
  --with-png-dir \
  --with-pspell=$(brew --prefix aspell) \
  --with-sodium=$(brew --prefix libsodium) \
  --with-sqlite3 \
  --with-unixODBC=$(brew --prefix unixodbc) \
  --with-webp-dir \
  --with-xmlrpc \
  --with-xsl \
  --with-zlib \
  --with-curl \
  --with-iconv
make
```

On docker debian stable(stretch) image with configure options of php-build:
```bash
apt update && apt install -y make autoconf gcc g++ pkg-config \
  libc-dev \
  bison \
  re2c \
  libbz2-dev \
  libcurl4-openssl-dev \
  libedit-dev \
  libfreetype6-dev \
  libicu-dev \
  libjpeg62-turbo-dev \
  libpng-dev \
  libsqlite3-dev \
  libssl-dev \
  libtidy-dev \
  libwebp-dev \
  libxml2-dev \
  libxpm-dev \
  libxslt1-dev \
  libzip-dev \
  zlib1g-dev
make clean
./buildconf --force
./configure \
  --without-pear \
  --enable-bcmath \
  --enable-cgi \
  --enable-exif \
  --enable-fpm \
  --enable-ftp \
  --enable-intl \
  --enable-mbstring \
  --enable-pcntl \
  --enable-phpdbg \
  --enable-shmop \
  --enable-soap \
  --enable-sockets \
  --enable-sysvsem \
  --enable-sysvshm \
  --enable-xmlreader \
  --enable-zip \
  --disable-debug \
  --with-bz2 \
  --with-curl \
  --with-freetype-dir \
  --with-gd \
  --with-jpeg-dir \
  --with-kerberos \
  --with-libzip \
  --with-mysqli=mysqlnd \
  --with-openssl \
  --with-pdo-mysql=mysqlnd \
  --with-pdo-sqlite \
  --with-tidy \
  --with-webp-dir \
  --with-xmlrpc \
  --with-xpm-dir \
  --with-xsl \
  --with-zlib \
  --with-zlib-dir \
  --with-libedit \
  --with-png-dir
make
```
