### PR TITLE
SQLite3: add a new ::backup method implementing the SQLite3 online backup API

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1293,16 +1293,15 @@ PHP_METHOD(sqlite3, backup)
 	int rc; // Return code
 
 	source_obj = Z_SQLITE3_DB_P(source_zval);
+	SQLITE3_CHECK_INITIALIZED(source_obj, source_obj->initialised, SQLite3)
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O|ss", &destination_zval, php_sqlite3_sc_entry, &source_dbname, &source_dbname_length, &destination_dbname, &destination_dbname_length) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|ss", &destination_zval, php_sqlite3_sc_entry, &source_dbname, &source_dbname_length, &destination_dbname, &destination_dbname_length) == FAILURE) {
 		return;
 	}
 
 	destination_obj = Z_SQLITE3_DB_P(destination_zval);
 
-	zend_replace_error_handling(EH_THROW, NULL, &error_handling);
 	SQLITE3_CHECK_INITIALIZED(destination_obj, destination_obj->initialised, SQLite3)
-	zend_restore_error_handling(&error_handling);
 
 	dbBackup = sqlite3_backup_init(destination_obj->db, destination_dbname, source_obj->db, source_dbname);
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2091,7 +2091,7 @@ ZEND_END_ARG_INFO()
 
 #if SQLITE_VERSION_NUMBER >= 3006011
 ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_backup, 0, 0, 1)
-	ZEND_ARG_INFO(1, destination_db)
+	ZEND_ARG_INFO(0, destination_db)
 	ZEND_ARG_INFO(0, source_dbname)
 	ZEND_ARG_INFO(0, destination_dbname)
 ZEND_END_ARG_INFO()

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1308,7 +1308,7 @@ PHP_METHOD(sqlite3, backup)
 
 	if (dbBackup) {
 		do {
-			rc = sqlite3_backup_step(dbBackup, 5);
+			rc = sqlite3_backup_step(dbBackup, -1);
 
 			if (rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED) {
 				sqlite3_sleep(250);

--- a/ext/sqlite3/tests/sqlite3_38_backup.phpt
+++ b/ext/sqlite3/tests/sqlite3_38_backup.phpt
@@ -1,0 +1,54 @@
+--TEST--
+SQLite3::backup test
+--SKIPIF--
+<?php require_once(__DIR__ . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+require_once(__DIR__ . '/new_db.inc');
+
+$db->enableExceptions(true);
+
+echo "Creating table\n";
+$db->exec('CREATE TABLE test (a, b);');
+$db->exec('INSERT INTO test VALUES (42, \'php\');');
+
+echo "Checking if table has been created\n";
+var_dump($db->querySingle('SELECT COUNT(*) FROM sqlite_master;'));
+
+$db2 = new SQLite3(':memory:');
+
+echo "Backup to DB2\n";
+var_dump($db->backup($db2));
+
+echo "Checking if table has been copied\n";
+var_dump($db2->querySingle('SELECT COUNT(*) FROM sqlite_master;'));
+
+echo "Closing DB1\n";
+var_dump($db->close());
+
+echo "Checking backup contents\n";
+var_dump($db2->querySingle('SELECT a FROM test;'));
+var_dump($db2->querySingle('SELECT b FROM test;'));
+
+echo "Closing DB2\n";
+var_dump($db2->close());
+
+echo "Done\n";
+?>
+--EXPECTF--
+Creating table
+Checking if table has been created
+int(1)
+Backup to DB2
+bool(true)
+Checking if table has been copied
+int(1)
+Closing DB1
+bool(true)
+Checking backup contents
+int(42)
+string(3) "php"
+Closing DB2
+bool(true)
+Done


### PR DESCRIPTION
See https://www.sqlite.org/backup.html for details

Usage is: `SQLite3::backup(&destinationDb[, source_dbname = "main"[, destination_dbname = "main"]])`

Note that this method will only be available with SQLite3 >= 3.6.11 released 2009-02-18

```
$db = new SQLite3('a.db');
$db2 = new SQLite3('b.db');

$db->backup($db2);
```

You can specify the name of the source and destination database (in case you have multiple opened database using ATTACH). "main" being the default database and "temp" being the temporary database (different than the ":memory:" database, see https://www.sqlite.org/inmemorydb.html last part for details on temporary database.

```
$db2->exec("ATTACH 'backup.db' AS 'backup';");
$db->backup($db2, "main", "backup");
```