### PR TITLE
Remove outdated PEAR artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,10 +81,6 @@ main/internal_functions_cli.c
 main/config.w32.h
 main/streams/build-defs.h
 pear/install-pear-nozlib.phar
-pear/phpize
-pear/run-tests
-pear/php-config
-pear/scripts
 sapi/apache2handler/libphp7.module
 sapi/cgi/php-cgi
 sapi/cgi/php-cgi.1

--- a/configure.ac
+++ b/configure.ac
@@ -1534,7 +1534,6 @@ PHP_GEN_GLOBAL_MAKEFILE
 
 AC_DEFINE([HAVE_BUILD_DEFS_H], 1, [ ])
 
-$php_shtool mkdir -p pear/scripts
 $php_shtool mkdir -p scripts
 $php_shtool mkdir -p scripts/man1
 


### PR DESCRIPTION
The `pear/scripts`, `pear/php-config`, `pear/phpize`, and `pear/run-tests` used to be part of the PEAR installation. Now, the pear installation PHAR file is directly downloaded from pear.php.net instead.