### PR TITLE
Fix tests/output/bug74815.phpt generating errors.log

### DIFF
--- a/tests/output/bug74815.phpt
+++ b/tests/output/bug74815.phpt
@@ -5,10 +5,14 @@ Bug #74815 crash with a combination of INI entries at startup
 
 $php = getenv("TEST_PHP_EXECUTABLE");
 
-echo shell_exec("$php -n -d error_log=errors.log -d error_reporting=E_ALL -d log_errors=On -d track_errors=On -v");
+echo shell_exec("$php -n -d error_log=".__DIR__."/error_log.tmp -d error_reporting=E_ALL -d log_errors=On -d track_errors=On -v");
 
 ?>
 ==DONE==
+--CLEAN--
+<?php
+unlink(__DIR__.'/error_log.tmp');
+?>
 --EXPECTF--
 Deprecated: Directive 'track_errors' is deprecated in Unknown on line 0
 %A


### PR DESCRIPTION
Test tests/output/bug74815.phpt was creating an errors.log file in project root directory and didn't removed it after the test.