### PR TITLE
Fix to output errors to stderr

### DIFF
--- a/build/buildcheck.sh
+++ b/build/buildcheck.sh
@@ -28,16 +28,16 @@ fi
 # autoconf 2.68 or newer
 ac_version=`$PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//'`
 if test -z "$ac_version"; then
-echo "buildconf: autoconf not found."
-echo "           You need autoconf version 2.68 or newer installed"
-echo "           to build PHP from Git."
+echo "buildconf: autoconf not found." >&2
+echo "           You need autoconf version 2.68 or newer installed" 1>&2
+echo "           to build PHP from Git." >&2
 exit 1
 fi
 IFS=.; set $ac_version; IFS=' '
 if test "$1" = "2" -a "$2" -lt "68" || test "$1" -lt "2"; then
-echo "buildconf: autoconf version $ac_version found."
-echo "           You need autoconf version 2.68 or newer installed"
-echo "           to build PHP from Git."
+echo "buildconf: autoconf version $ac_version found." >&2
+echo "           You need autoconf version 2.68 or newer installed" 1>&2
+echo "           to build PHP from Git." >&2
 exit 1
 else
 echo "buildconf: autoconf version $ac_version (ok)"

--- a/build/buildcheck.sh
+++ b/build/buildcheck.sh
@@ -29,14 +29,14 @@ fi
 ac_version=`$PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//'`
 if test -z "$ac_version"; then
 echo "buildconf: autoconf not found." >&2
-echo "           You need autoconf version 2.68 or newer installed" 1>&2
+echo "           You need autoconf version 2.68 or newer installed" >&2
 echo "           to build PHP from Git." >&2
 exit 1
 fi
 IFS=.; set $ac_version; IFS=' '
 if test "$1" = "2" -a "$2" -lt "68" || test "$1" -lt "2"; then
 echo "buildconf: autoconf version $ac_version found." >&2
-echo "           You need autoconf version 2.68 or newer installed" 1>&2
+echo "           You need autoconf version 2.68 or newer installed" >&2
 echo "           to build PHP from Git." >&2
 exit 1
 else

--- a/build/genif.sh
+++ b/build/genif.sh
@@ -12,7 +12,7 @@ awk=$1
 shift
 
 if test -z "$infile" || test -z "$srcdir"; then
-	echo "please supply infile and srcdir"
+	echo "please supply infile and srcdir" >&2
 	exit 1
 fi
 

--- a/buildconf
+++ b/buildconf
@@ -27,8 +27,8 @@ while test $# -gt 0; do
 done
 
 if test "$dev" = "0" -a "$devok" = "0"; then
-  echo "You should not run buildconf in a release package."
-  echo "use buildconf --force to override this check."
+  echo "You should not run buildconf in a release package." >&2
+  echo "use buildconf --force to override this check." >&2
   exit 1
 fi
 

--- a/config.sub
+++ b/config.sub
@@ -89,7 +89,7 @@ while test $# -gt 0 ; do
     - )	# Use stdin as input.
        break ;;
     -* )
-       echo "$me: invalid option $1$help"
+       echo "$me: invalid option $1$help" >&2
        exit 1 ;;
 
     *local*)

--- a/config.sub
+++ b/config.sub
@@ -89,7 +89,7 @@ while test $# -gt 0 ; do
     - )	# Use stdin as input.
        break ;;
     -* )
-       echo "$me: invalid option $1$help" >&2
+       echo "$me: invalid option $1$help"
        exit 1 ;;
 
     *local*)

--- a/makedist
+++ b/makedist
@@ -65,8 +65,8 @@ DIR=php-$VER
 DIRPATH=$MY_OLDPWD/$DIR
 
 if test -d "$DIRPATH"; then
-    echo "The directory $DIR"
-    echo "already exists, rename or remove it and run makedist again."
+    echo "The directory $DIR" >&2
+    echo "already exists, rename or remove it and run makedist again." >&2
     exit 1
 fi
 


### PR DESCRIPTION
resolve https://bugs.php.net/bug.php?id=77041

Now, ./buildconf output some error messages to stdout.  But, error messages should be written on stderr.