### PR TITLE
Fix accessibility checks for dynamic properties

### DIFF
--- a/Zend/tests/foreach_shadowed_dyn_property.phpt
+++ b/Zend/tests/foreach_shadowed_dyn_property.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Dynamic property shadowed by private property
+--FILE--
+<?php
+  
+class Test {
+    private $prop = "Test";
+
+    function run() {
+        foreach ($this as $k => $v) {
+            echo "$k => $v\n";
+        }
+        var_dump(get_object_vars($this));
+    }
+}
+class Test2 extends Test {
+}
+
+$test2 = new Test2;
+$test2->prop = "Test2";
+$test2->run();
+
+?>
+--EXPECT--
+prop => Test
+array(1) {
+  ["prop"]=>
+  string(4) "Test"
+}

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -224,7 +224,7 @@ ZEND_API void rebuild_object_properties(zend_object *zobj);
 
 ZEND_API int zend_check_protected(zend_class_entry *ce, zend_class_entry *scope);
 
-ZEND_API int zend_check_property_access(zend_object *zobj, zend_string *prop_info_name);
+ZEND_API int zend_check_property_access(zend_object *zobj, zend_string *prop_info_name, zend_bool is_dynamic);
 
 ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend_string *method_name, int is_static);
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5845,10 +5845,12 @@ ZEND_VM_C_LABEL(fe_fetch_r_exit):
 						value = Z_INDIRECT_P(value);
 						value_type = Z_TYPE_INFO_P(value);
 						if (EXPECTED(value_type != IS_UNDEF)
-						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key) == SUCCESS)) {
+						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key, 0) == SUCCESS)) {
 							break;
 						}
-					} else {
+					} else if (EXPECTED(Z_OBJCE_P(array)->default_properties_count == 0)
+							|| !p->key
+							|| zend_check_property_access(Z_OBJ_P(array), p->key, 1) == SUCCESS) {
 						break;
 					}
 				}
@@ -5995,10 +5997,12 @@ ZEND_VM_HANDLER(126, ZEND_FE_FETCH_RW, VAR, ANY, JMP_ADDR)
 						value = Z_INDIRECT_P(value);
 						value_type = Z_TYPE_INFO_P(value);
 						if (EXPECTED(value_type != IS_UNDEF)
-						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key) == SUCCESS)) {
+						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key, 0) == SUCCESS)) {
 							break;
 						}
-					} else {
+					} else if (EXPECTED(Z_OBJCE_P(array)->default_properties_count == 0)
+							|| !p->key
+							|| zend_check_property_access(Z_OBJ_P(array), p->key, 1) == SUCCESS) {
 						break;
 					}
 				}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -21258,10 +21258,12 @@ fe_fetch_r_exit:
 						value = Z_INDIRECT_P(value);
 						value_type = Z_TYPE_INFO_P(value);
 						if (EXPECTED(value_type != IS_UNDEF)
-						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key) == SUCCESS)) {
+						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key, 0) == SUCCESS)) {
 							break;
 						}
-					} else {
+					} else if (EXPECTED(Z_OBJCE_P(array)->default_properties_count == 0)
+							|| !p->key
+							|| zend_check_property_access(Z_OBJ_P(array), p->key, 1) == SUCCESS) {
 						break;
 					}
 				}
@@ -21408,10 +21410,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_FETCH_RW_SPEC_VAR_HANDLER(Z
 						value = Z_INDIRECT_P(value);
 						value_type = Z_TYPE_INFO_P(value);
 						if (EXPECTED(value_type != IS_UNDEF)
-						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key) == SUCCESS)) {
+						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key, 0) == SUCCESS)) {
 							break;
 						}
-					} else {
+					} else if (EXPECTED(Z_OBJCE_P(array)->default_properties_count == 0)
+							|| !p->key
+							|| zend_check_property_access(Z_OBJ_P(array), p->key, 1) == SUCCESS) {
 						break;
 					}
 				}


### PR DESCRIPTION
A dynamic property may be shadowed by a private/protected property. Make sure we check property accessibility for non-indirect properties as well. Previously mentioned in https://github.com/php/php-src/pull/3573#issuecomment-428737944.

There is one more caveat here, in that access checks for the dynamic property case should also treat mangled names as accessible (per existing behavior). This is why I added the `is_dynamic` flag to `check_property_access`.