### PR TITLE
Support SQLite3 @name notation

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1408,7 +1408,7 @@ static int register_bound_parameter_to_sqlite(struct php_sqlite3_bound_param *pa
 
 	/* We need a : prefix to resolve a name to a parameter number */
 	if (param->name) {
-		if (ZSTR_VAL(param->name)[0] != ':') {
+		if (ZSTR_VAL(param->name)[0] != ':' && ZSTR_VAL(param->name)[0] != '@') {
 			/* pre-increment for character + 1 for null */
 			zend_string *temp = zend_string_alloc(ZSTR_LEN(param->name) + 1, 0);
 			ZSTR_VAL(temp)[0] = ':';

--- a/ext/sqlite3/tests/sqlite3_bound_value_at_name.phpt
+++ b/ext/sqlite3/tests/sqlite3_bound_value_at_name.phpt
@@ -1,0 +1,51 @@
+--TEST--
+SQLite3::prepare Bound Value test
+--SKIPIF--
+<?php require_once(__DIR__ . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+require_once(__DIR__ . '/new_db.inc');
+define('TIMENOW', time());
+
+echo "Creating Table\n";
+var_dump($db->exec('CREATE TABLE test (time INTEGER, id STRING)'));
+
+echo "INSERT into table\n";
+var_dump($db->exec("INSERT INTO test (time, id) VALUES (" . TIMENOW . ", 'a')"));
+var_dump($db->exec("INSERT INTO test (time, id) VALUES (" . TIMENOW . ", 'b')"));
+
+echo "SELECTING results\n";
+$stmt = $db->prepare("SELECT * FROM test WHERE id = @id ORDER BY id ASC");
+$foo = 'a';
+echo "BINDING Value\n";
+var_dump($stmt->bindValue('@id', $foo, SQLITE3_TEXT));
+$results = $stmt->execute();
+while ($result = $results->fetchArray(SQLITE3_NUM))
+{
+	var_dump($result);
+}
+$results->finalize();
+
+echo "Closing database\n";
+var_dump($db->close());
+echo "Done\n";
+?>
+--EXPECTF--
+Creating Table
+bool(true)
+INSERT into table
+bool(true)
+bool(true)
+SELECTING results
+BINDING Value
+bool(true)
+array(2) {
+  [0]=>
+  int(%d)
+  [1]=>
+  string(1) "a"
+}
+Closing database
+bool(true)
+Done


### PR DESCRIPTION
Besides the common `:param` notation to designate named parameters in
prepared statements, SQLite3 also supports `@param` and `$param`.
While the latter is mostly to support the Tcl programming language, and
would be confusing for PHP's sqlite3 binding due to the similarity with
string interpolation, the former is common under .NET and raises no
such issue.  Therefore we add support for it.

This patch has been developed in cooperation with @BohwaZ.