### PR TITLE
PDO_SQLite: fix bug #40913 (fixes types handling)

### DIFF
--- a/ext/pdo_sqlite/tests/bug40913.phpt
+++ b/ext/pdo_sqlite/tests/bug40913.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Bug #40913 (PDO::PARAM_LOB does not bind to a stream for fetching a BLOB)
+--SKIPIF--
+<?php if (!extension_loaded('pdo_sqlite')) print 'skip not loaded'; ?>
+--FILE--
+<?php
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->exec('CREATE TABLE test (a INTEGER, b BLOB);');
+$pdo->exec('INSERT INTO test VALUES (42, zeroblob(5000));');
+
+$stmt = $pdo->prepare('SELECT a, b FROM test WHERE a = 42;');
+$stmt->bindColumn(1, $id, PDO::PARAM_INT);
+$stmt->bindColumn(2, $blob, PDO::PARAM_LOB);
+$stmt->execute();
+$stmt->fetch(PDO::FETCH_BOUND);
+
+var_dump($id);
+var_dump(is_resource($blob));
+var_dump(stream_get_meta_data($blob));
+var_dump(strlen(fread($blob, 6000)));
+
+// Try to seek and see if it works
+var_dump(fseek($blob, 1000));
+var_dump(strlen(fread($blob, 6000)));
+
+// Close
+var_dump(fclose($blob));
+
+?>
+--EXPECTF--
+int(42)
+bool(true)
+array(7) {
+  ["timed_out"]=>
+  bool(false)
+  ["blocked"]=>
+  bool(true)
+  ["eof"]=>
+  bool(false)
+  ["stream_type"]=>
+  string(6) "MEMORY"
+  ["mode"]=>
+  string(2) "rb"
+  ["unread_bytes"]=>
+  int(0)
+  ["seekable"]=>
+  bool(true)
+}
+int(5000)
+int(0)
+int(4000)
+bool(true)


### PR DESCRIPTION
Assigns correct PHP types corresponding to the SQLite types when required.

This fixes this long outstanding bug: https://bugs.php.net/bug.php?id=40913 for SQLite (didn't look for MySQL).

One side effect is that previously integers were returned as strings by default, they will now be returned as integers.

While working on this issue I met other bugs:

* incorrect handling of streams for insertions: https://bugs.php.net/bug.php?id=77067
* seems that bindValue is not using the right type either, similar issue as https://bugs.php.net/bug.php?id=68849 but with PDO_SQLite. I'm looking into that and will file a bug or a PR.