### PR TITLE
Fix #76825: Undefined symbols ___cpuid_count

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -596,3 +596,21 @@ dnl This is the most probable fallback so we assume yes in case of cross compile
 if test "$ac_cv_huge_val_nan" = "yes"; then
   AC_DEFINE([HAVE_HUGE_VAL_NAN], 1, [whether HUGE_VAL + -HUGEVAL == NAN])
 fi
+
+dnl
+dnl Check whether __cpuid_count is available
+dnl
+AC_CACHE_CHECK(whether __cpuid_count is available, ac_cv_cpuid_count_available, [
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+  #include <cpuid.h>
+]], [[
+  unsigned eax, ebx, ecx, edx;
+  __cpuid_count(0, 0, eax, ebx, ecx, edx);
+]])], [
+  ac_cv_cpuid_count_available=yes
+], [
+  ac_cv_cpuid_count_available=no
+])])
+if test "$ac_cv_cpuid_count_available" = "yes"; then
+  AC_DEFINE([HAVE_CPUID_COUNT], 1, [whether __cpuid_count is available])
+fi

--- a/Zend/zend_cpuinfo.c
+++ b/Zend/zend_cpuinfo.c
@@ -29,7 +29,7 @@ typedef struct _zend_cpu_info {
 static zend_cpu_info cpuinfo = {0};
 
 #if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
-# ifdef HAVE_CPUID_H
+# if defined(HAVE_CPUID_H) && defined(HAVE_CPUID_COUNT)
 # include <cpuid.h>
 static void __zend_cpuid(uint32_t func, uint32_t subfunc, zend_cpu_info *cpuinfo) {
 	__cpuid_count(func, subfunc, cpuinfo->eax, cpuinfo->ebx, cpuinfo->ecx, cpuinfo->edx);


### PR DESCRIPTION
Apparently, the presence of `cpuid.h` is not necessarily sufficient to
guarantee the availability of `__cpuid_count()`.  We therefore test for
the latter explicitly.