### PR TITLE
Add putenv for setlocale

### DIFF
--- a/ext/gettext/tests/gettext_basic-enus.phpt
+++ b/ext/gettext/tests/gettext_basic-enus.phpt
@@ -13,6 +13,7 @@ Gettext basic test with en_US locale that should be on nearly every system
 <?php
 
 chdir(dirname(__FILE__));
+putenv('LC_ALL=en_US.UTF-8');
 setlocale(LC_ALL, 'en_US.UTF-8');
 bindtextdomain ("messages", "./locale");
 textdomain ("messages");

--- a/ext/gettext/tests/gettext_basic.phpt
+++ b/ext/gettext/tests/gettext_basic.phpt
@@ -13,6 +13,7 @@ Gettext basic test
 <?php
 
 chdir(dirname(__FILE__));
+putenv('LC_ALL=fi_FI');
 setlocale(LC_ALL, 'fi_FI');
 bindtextdomain ("messages", "./locale");
 textdomain ("messages");

--- a/ext/gettext/tests/gettext_bindtextdomain-cwd.phpt
+++ b/ext/gettext/tests/gettext_bindtextdomain-cwd.phpt
@@ -12,6 +12,7 @@ if (!setlocale(LC_ALL, 'en_US.UTF-8')) {
 <?php
 $base_dir = dirname(__FILE__);
 chdir($base_dir);
+putenv('LC_ALL=en_US.UTF-8');
 setlocale(LC_ALL, 'en_US.UTF-8');
 bindtextdomain('messages',null);
 var_dump(gettext('Basic test'));

--- a/ext/gettext/tests/gettext_dcgettext.phpt
+++ b/ext/gettext/tests/gettext_dcgettext.phpt
@@ -11,7 +11,9 @@ if (!setlocale(LC_ALL, 'en_US.UTF-8')) {
 --FILE--
 <?php
 chdir(dirname(__FILE__));
+putenv('LC_MESSAGES=en_US.UTF-8');
 setlocale(LC_MESSAGES, 'en_US.UTF-8');
+putenv('LC_ALL=en_US.UTF-8');
 setlocale(LC_ALL, 'en_US.UTF-8');
 bindtextdomain('dngettextTest', './locale');
 

--- a/ext/gettext/tests/gettext_dgettext.phpt
+++ b/ext/gettext/tests/gettext_dgettext.phpt
@@ -11,7 +11,9 @@ if (!setlocale(LC_ALL, 'en_US.UTF-8')) {
 --FILE--
 <?php
 chdir(dirname(__FILE__));
+putenv('LC_MESSAGES=en_US.UTF-8');
 setlocale(LC_MESSAGES, 'en_US.UTF-8');
+putenv('LC_ALL=en_US.UTF-8');
 setlocale(LC_ALL, 'en_US.UTF-8');
 bindtextdomain('dgettextTest', './locale');
 bindtextdomain('dgettextTest_switch', './locale');

--- a/ext/gettext/tests/gettext_dngettext-plural.phpt
+++ b/ext/gettext/tests/gettext_dngettext-plural.phpt
@@ -11,6 +11,7 @@ if (!setlocale(LC_ALL, 'en_US.UTF-8')) {
 --FILE--
 <?php
 chdir(dirname(__FILE__));
+putenv('LC_ALL=en_US.UTF-8');
 setlocale(LC_ALL, 'en_US.UTF-8');
 bindtextdomain('dngettextTest', './locale');
 

--- a/ext/gettext/tests/gettext_ngettext.phpt
+++ b/ext/gettext/tests/gettext_ngettext.phpt
@@ -12,6 +12,7 @@ Test ngettext() functionality
 --FILE--
 <?php
 chdir(dirname(__FILE__));
+putenv('LC_ALL=en_US.UTF-8');
 setlocale(LC_ALL, 'en_US.UTF-8');
 bindtextdomain('dngettextTest', './locale');
 textdomain('dngettextTest');


### PR DESCRIPTION
On macOS, some gettext tests fails because gettext does not work well with just setlocale.
We should also call putenv.

See also: http://php.net/manual/en/function.gettext.php#refsect1-function.gettext-examples