### PR TITLE
Array reduce key argument

### DIFF
--- a/ext/standard/tests/array/array_reduce_variation1.phpt
+++ b/ext/standard/tests/array/array_reduce_variation1.phpt
@@ -15,8 +15,8 @@ function oneArg($v) {
   return $v;
 }
 
-function threeArgs($v, $w, $x) {
-  return $v + $w + $x;
+function fourArgs($v, $w, $x, $y) {
+  return $v + $w + $x + $y;
 }
 
 $array = array(1);
@@ -26,7 +26,7 @@ var_dump(array_reduce($array, "oneArg", 2));
 
 echo "\n--- Testing with a callback with too many parameters ---\n";
 try {
-	var_dump(array_reduce($array, "threeArgs", 2));
+	var_dump(array_reduce($array, "fourArgs", 2));
 } catch (Throwable $e) {
 	echo "Exception: " . $e->getMessage() . "\n";
 }
@@ -40,5 +40,5 @@ try {
 int(2)
 
 --- Testing with a callback with too many parameters ---
-Exception: Too few arguments to function threeArgs(), 2 passed and exactly 3 expected
+Exception: Too few arguments to function fourArgs(), 3 passed and exactly 4 expected
 ===DONE===

--- a/ext/standard/tests/array/array_reduce_variation4.phpt
+++ b/ext/standard/tests/array/array_reduce_variation4.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Test array_reduce() function : variation - key argument on callback
+--FILE--
+<?php
+/* Prototype  : mixed array_reduce(array input, mixed callback [, int initial])
+ * Description: Iteratively reduce the array to a single value via the callback.
+ * Source code: ext/standard/array.c
+ * Alias to functions:
+ */
+
+echo "*** Testing array_reduce() : variation - key argument on callback ***\n";
+
+echo "\n--- Testing array_reduce() with long key argument  ---\n";
+$array = ["nyan", "lamp", "binary", "php", "elephant"];
+
+function reduce_long_key($v, $w, $x){
+    return "$v,$x-$w";
+}
+var_dump(array_reduce($array, 'reduce_long_key'));
+
+echo "\n--- Testing array_reduce() with string key argument  ---\n";
+$array = ["nyan" => "nyan", "lamp" => "lamp", "binay" =>  "binary", "php" => "php", "elephant" => "elephant"];
+
+function reduce_string_key($v, $w, $x){
+    return "$v,$x-$w";
+}
+var_dump(array_reduce($array, 'reduce_string_key'));
+
+?>
+--EXPECT--
+*** Testing array_reduce() : variation - key argument on callback ***
+
+--- Testing array_reduce() with long key argument  ---
+string(40) ",0-nyan,1-lamp,2-binary,3-php,4-elephant"
+
+--- Testing array_reduce() with string key argument  ---
+string(59) ",nyan-nyan,lamp-lamp,binay-binary,php-php,elephant-elephant"
+
+Done

--- a/ext/standard/tests/array/array_reduce_variation4.phpt
+++ b/ext/standard/tests/array/array_reduce_variation4.phpt
@@ -20,7 +20,7 @@ function reduce_long_key($v, $w, $x){
 var_dump(array_reduce($array, 'reduce_long_key'));
 
 echo "\n--- Testing array_reduce() with string key argument  ---\n";
-$array = ["nyan" => "nyan", "lamp" => "lamp", "binay" =>  "binary", "php" => "php", "elephant" => "elephant"];
+$array = ["nyan" => "nyan", "lamp" => "lamp", "binary" =>  "binary", "php" => "php", "elephant" => "elephant"];
 
 function reduce_string_key($v, $w, $x){
     return "$v,$x-$w";
@@ -36,5 +36,5 @@ var_dump(array_reduce($array, 'reduce_string_key'));
 string(40) ",0-nyan,1-lamp,2-binary,3-php,4-elephant"
 
 --- Testing array_reduce() with string key argument  ---
-string(59) ",nyan-nyan,lamp-lamp,binay-binary,php-php,elephant-elephant"
+string(60) ",nyan-nyan,lamp-lamp,binary-binary,php-php,elephant-elephant"
 ===DONE===

--- a/ext/standard/tests/array/array_reduce_variation4.phpt
+++ b/ext/standard/tests/array/array_reduce_variation4.phpt
@@ -1,7 +1,8 @@
 --TEST--
-Test array_reduce() function : variation - key argument on callback
+Test array_reduce() function : variation
 --FILE--
 <?php
+
 /* Prototype  : mixed array_reduce(array input, mixed callback [, int initial])
  * Description: Iteratively reduce the array to a single value via the callback.
  * Source code: ext/standard/array.c
@@ -27,6 +28,7 @@ function reduce_string_key($v, $w, $x){
 var_dump(array_reduce($array, 'reduce_string_key'));
 
 ?>
+===DONE===
 --EXPECT--
 *** Testing array_reduce() : variation - key argument on callback ***
 
@@ -35,5 +37,4 @@ string(40) ",0-nyan,1-lamp,2-binary,3-php,4-elephant"
 
 --- Testing array_reduce() with string key argument  ---
 string(59) ",nyan-nyan,lamp-lamp,binay-binary,php-php,elephant-elephant"
-
-Done
+===DONE===


### PR DESCRIPTION
I've added a 'key' argument to the reduce callback. This will help users that want to perform operations on the keys of the subject arrays