### PR TITLE
[WIP] Migrate more checks to the pkg-config macro

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2231,115 +2231,21 @@ dnl Common setup macro for openssl
 dnl
 AC_DEFUN([PHP_SETUP_OPENSSL],[
   found_openssl=no
-  unset OPENSSL_INCDIR
-  unset OPENSSL_LIBDIR
 
   dnl Empty variable means 'no'
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
   test -z "$PHP_IMAP_SSL" && PHP_IMAP_SSL=no
 
-  dnl Fallbacks for different configure options
-  if test "$PHP_OPENSSL" != "no"; then
-    PHP_OPENSSL_DIR=$PHP_OPENSSL
-  elif test "$PHP_IMAP_SSL" != "no"; then
-    PHP_OPENSSL_DIR=$PHP_IMAP_SSL
-  fi
-
-  dnl First try to find pkg-config
-  if test -z "$PKG_CONFIG"; then
-    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-  fi
-
-  dnl If pkg-config is found try using it
-  if test "$PHP_OPENSSL_DIR" = "yes" && test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
-    if $PKG_CONFIG --atleast-version=1.0.1 openssl; then
-      found_openssl=yes
-      OPENSSL_LIBS=`$PKG_CONFIG --libs openssl`
-      OPENSSL_INCS=`$PKG_CONFIG --cflags-only-I openssl`
-      OPENSSL_INCDIR=`$PKG_CONFIG --variable=includedir openssl`
-    else
-      AC_MSG_ERROR([OpenSSL version 1.0.1 or greater required.])
-    fi
+  if test "$PHP_OPENSSL" = "yes"; then
+    PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.0.1], [found_openssl=yes],
+      [AC_MSG_ERROR([OpenSSL version 1.0.1 or greater required.])])
 
     if test -n "$OPENSSL_LIBS"; then
       PHP_EVAL_LIBLINE($OPENSSL_LIBS, $1)
     fi
-    if test -n "$OPENSSL_INCS"; then
-      PHP_EVAL_INCLINE($OPENSSL_INCS)
+    if test -n "$OPENSSL_CFLAGS"; then
+      PHP_EVAL_INCLINE($OPENSSL_CFLAGS)
     fi
-  fi
-
-  dnl If pkg-config fails for some reason, revert to the old method
-  if test "$found_openssl" = "no"; then
-
-    if test "$PHP_OPENSSL_DIR" = "yes"; then
-      PHP_OPENSSL_DIR="/usr/local/ssl /usr/local /usr /usr/local/openssl"
-    fi
-
-    for i in $PHP_OPENSSL_DIR; do
-      if test -r $i/include/openssl/evp.h; then
-        OPENSSL_INCDIR=$i/include
-      fi
-      if test -r $i/$PHP_LIBDIR/libssl.a -o -r $i/$PHP_LIBDIR/libssl.$SHLIB_SUFFIX_NAME; then
-        OPENSSL_LIBDIR=$i/$PHP_LIBDIR
-      fi
-      test -n "$OPENSSL_INCDIR" && test -n "$OPENSSL_LIBDIR" && break
-    done
-
-    if test -z "$OPENSSL_INCDIR"; then
-      AC_MSG_ERROR([Cannot find OpenSSL's <evp.h>])
-    fi
-
-    if test -z "$OPENSSL_LIBDIR"; then
-      AC_MSG_ERROR([Cannot find OpenSSL's libraries])
-    fi
-
-    old_CPPFLAGS=$CPPFLAGS
-    CPPFLAGS=-I$OPENSSL_INCDIR
-    AC_MSG_CHECKING([for OpenSSL version])
-    AC_EGREP_CPP(yes,[
-#include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER >= 0x10001001L
-  yes
-#endif
-    ],[
-      AC_MSG_RESULT([>= 1.0.1])
-    ],[
-      AC_MSG_ERROR([OpenSSL version 1.0.1 or greater required.])
-    ])
-    CPPFLAGS=$old_CPPFLAGS
-
-    PHP_ADD_INCLUDE($OPENSSL_INCDIR)
-
-    PHP_CHECK_LIBRARY(crypto, CRYPTO_free, [
-      PHP_ADD_LIBRARY(crypto,,$1)
-    ],[
-      AC_MSG_ERROR([libcrypto not found!])
-    ],[
-      -L$OPENSSL_LIBDIR
-    ])
-
-    old_LIBS=$LIBS
-    LIBS="$LIBS -lcrypto"
-    PHP_CHECK_LIBRARY(ssl, SSL_CTX_set_ssl_version, [
-      found_openssl=yes
-    ],[
-      AC_MSG_ERROR([libssl not found!])
-    ],[
-      -L$OPENSSL_LIBDIR
-    ])
-    LIBS=$old_LIBS
-    PHP_ADD_LIBRARY(ssl,,$1)
-    PHP_ADD_LIBRARY(crypto,,$1)
-
-    PHP_ADD_LIBPATH($OPENSSL_LIBDIR, $1)
-  fi
-
-  if test "$found_openssl" = "yes"; then
-  dnl For apache 1.3.x static build
-  OPENSSL_INCDIR_OPT=-I$OPENSSL_INCDIR
-  AC_SUBST(OPENSSL_INCDIR_OPT)
-
 ifelse([$2],[],:,[$2])
 ifelse([$3],[],,[else $3])
   fi

--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -1,102 +1,35 @@
 dnl config.m4 for extension curl
 
 PHP_ARG_WITH(curl, for cURL support,
-[  --with-curl[=DIR]         Include cURL support])
+[  --with-curl               Include cURL support])
 
 if test "$PHP_CURL" != "no"; then
-  if test -z "$PKG_CONFIG"; then
-    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-  fi
-
-  if test -x "$PKG_CONFIG"; then
-    dnl using pkg-config output
-
-    AC_MSG_CHECKING(for libcurl.pc)
-    if test "$PHP_CURL" = "yes" -o "$PHP_CURL" = "/usr"; then
-      PKNAME=libcurl
-      AC_MSG_RESULT(using default path)
-    elif test -r $PHP_CURL/$PHP_LIBDIR/pkgconfig/libcurl.pc; then
-      PKNAME=$PHP_CURL/$PHP_LIBDIR/pkgconfig/libcurl.pc
-      AC_MSG_RESULT(using $PKNAME)
-    elif test -r $PHP_CURL/lib/pkgconfig/libcurl.pc; then
-      PKNAME=$PHP_CURL/lib/pkgconfig/libcurl.pc
-      AC_MSG_RESULT(using $PKNAME)
-    else
-      AC_MSG_RESULT(not found)
-      AC_MSG_WARN(Could not find libcurl.pc. Try without $PHP_CURL or set PKG_CONFIG_PATH)
-    fi
-  fi
-
-  if test -n "$PKNAME"; then
-    AC_MSG_CHECKING(for cURL 7.15.5 or greater)
-    if $PKG_CONFIG --atleast-version 7.15.5 $PKNAME; then
-      curl_version_full=`$PKG_CONFIG --modversion $PKNAME`
-      AC_MSG_RESULT($curl_version_full)
-    else
-      AC_MSG_ERROR(cURL version 7.15.5 or later is required to compile php with cURL support)
-    fi
-
-    CURL_LIBS=`$PKG_CONFIG --libs   $PKNAME`
-    CURL_INCL=`$PKG_CONFIG --cflags $PKNAME`
-    CURL_SSL=`$PKG_CONFIG --variable=supported_features $PKNAME| $EGREP SSL`
-  else
-    dnl fallback to old vay, using curl-config
-    AC_MSG_WARN(Fallback: search for curl headers and curl-config)
-
-    if test -r $PHP_CURL/include/curl/easy.h; then
-      CURL_DIR=$PHP_CURL
-    else
-      AC_MSG_CHECKING(for cURL in default path)
-      for i in /usr/local /usr; do
-        if test -r $i/include/curl/easy.h; then
-          CURL_DIR=$i
-          AC_MSG_RESULT(found in $i)
-          break
-        fi
-      done
-    fi
-
-    if test -z "$CURL_DIR"; then
-      AC_MSG_RESULT(not found)
-      AC_MSG_ERROR(Please reinstall the libcurl distribution -
-      easy.h should be in <curl-dir>/include/curl/)
-    fi
-
-    CURL_CONFIG="curl-config"
-    AC_MSG_CHECKING(for cURL 7.15.5 or greater)
-
-    if ${CURL_DIR}/bin/curl-config --libs > /dev/null 2>&1; then
-      CURL_CONFIG=${CURL_DIR}/bin/curl-config
-    else
-      if ${CURL_DIR}/curl-config --libs > /dev/null 2>&1; then
-        CURL_CONFIG=${CURL_DIR}/curl-config
-      fi
-    fi
-
-    curl_version_full=`$CURL_CONFIG --version`
-    curl_version=`echo ${curl_version_full} | sed -e 's/libcurl //' | $AWK 'BEGIN { FS = "."; } { printf "%d", ($1 * 1000 + $2) * 1000 + $3;}'`
-    if test "$curl_version" -ge 7015005; then
-      AC_MSG_RESULT($curl_version_full)
-      CURL_LIBS=`$CURL_CONFIG --libs`
-      CURL_INCL=`$CURL_CONFIG --cflags`
-      CURL_SSL=`$CURL_CONFIG --feature | $EGREP SSL`
-    else
-      AC_MSG_ERROR(cURL version 7.15.5 or later is required to compile php with cURL support)
-    fi
-  fi
+  PKG_CHECK_MODULES([CURL], [libcurl >= 7.15.5], [CURL_FOUND=true],
+    AC_MSG_ERROR(cURL version 7.15.5 or later is required to compile php with cURL support))
+  PKG_CHECK_VAR([CURL_FEATURES], [libcurl], [supported_features])
 
   dnl common stuff (pkg-config / curl-config)
 
   PHP_EVAL_LIBLINE($CURL_LIBS, CURL_SHARED_LIBADD)
-  PHP_EVAL_INCLINE($CURL_INCL, CURL_SHARED_LIBADD)
+  PHP_EVAL_INCLINE($CURL_CFLAGS, CURL_SHARED_LIBADD)
 
   AC_MSG_CHECKING([for SSL support in libcurl])
-  if test -n "$CURL_SSL"; then
-    AC_MSG_RESULT([yes])
+  case "$CURL_FEATURES" in
+    *SSL*)
+      CURL_SSL=yes
+      AC_MSG_RESULT([yes])
+      ;;
+    *)
+      CURL_SSL=no
+      AC_MSG_RESULT([no])
+      ;;
+  esac
+
+  if test "$CURL_SSL" = yes; then
     AC_DEFINE([HAVE_CURL_SSL], [1], [Have cURL with  SSL support])
 
     save_CFLAGS="$CFLAGS"
-    CFLAGS=$CURL_INCL
+    CFLAGS=$CURL_CFLAGS
     save_LDFLAGS="$LDFLAGS"
     LDFLAGS=$CURL_LIBS
 

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -30,8 +30,8 @@ fi
 PHP_ARG_WITH(xpm-dir, for the location of libXpm,
 [  --with-xpm-dir[=DIR]      GD: Set the path to libXpm install prefix], no, no)
 
-PHP_ARG_ENABLE(freetype, for FreeType 2,
-[  --enable-freetype       GD: Enable FreeType 2 support], no, no)
+PHP_ARG_WITH(freetype, for FreeType 2,
+[  --with-freetype         GD: Enable FreeType 2 support], no, no)
 
 PHP_ARG_ENABLE(gd-jis-conv, whether to enable JIS-mapped Japanese font support in GD,
 [  --enable-gd-jis-conv    GD: Enable JIS-mapped Japanese font support], no, no)

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -1,7 +1,7 @@
 dnl config.m4 for extension openssl
 
 PHP_ARG_WITH(openssl, for OpenSSL support,
-[  --with-openssl[=DIR]      Include OpenSSL support (requires OpenSSL >= 1.0.1)])
+[  --with-openssl            Include OpenSSL support (requires OpenSSL >= 1.0.1)])
 
 PHP_ARG_WITH(kerberos, for Kerberos support,
 [  --with-kerberos[=DIR]     OPENSSL: Include Kerberos support], no, no)

--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -11,21 +11,10 @@ PHP_ARG_WITH(pcre-jit,,[  --with-pcre-jit         Enable PCRE JIT functionality 
 
   if test "$PHP_PCRE_REGEX" != "yes" && test "$PHP_PCRE_REGEX" != "no"; then
 
+    # FIXME: don't define "I'm not bundled" as only versions installed in /usr
     if test "$PHP_PCRE_REGEX" = "/usr"; then
-      if test -z "$PKG_CONFIG"; then
-        AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-      fi
-      if test -x "$PKG_CONFIG"; then
-        AC_MSG_CHECKING(for PCRE2 10.30 or greater)
-        if $PKG_CONFIG --atleast-version 10.30 libpcre2-8; then
-          PCRE2_VER=`$PKG_CONFIG --modversion libpcre2-8`
-          AC_MSG_RESULT($PCRE2_VER)
-        else
-          AC_MSG_ERROR(PCRE2 version 10.30 or later is required to compile php with PCRE2 support)
-        fi
-        PCRE2_LIB=`$PKG_CONFIG --libs libpcre2-8`
-        PCRE2_INC=`$PKG_CONFIG --cflags libpcre2-8`
-      fi
+      PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30], ,
+        AC_MSG_ERROR(PCRE2 version 10.30 or later is required to compile php with PCRE2 support))
     fi
 
     dnl PCRE2 in a non standard  prefix should still have its config tool.
@@ -41,13 +30,13 @@ PHP_ARG_WITH(pcre-jit,,[  --with-pcre-jit         Enable PCRE JIT functionality 
           AC_MSG_RESULT($PCRE2_VER)
         fi
         PCRE2_LIB=`$PCRE2_CONF --libs8`
-        PCRE2_INC=`$PCRE2_CONF --cflags`
+        PCRE2_CFLAGS=`$PCRE2_CONF --cflags`
       else
         AC_MSG_ERROR(Couldn't find pcre2-config)
       fi
     fi
 
-    PHP_EVAL_INCLINE($PCRE2_INC)
+    PHP_EVAL_INCLINE($PCRE2_CFLAGS)
     PHP_EVAL_LIBLINE($PCRE2_LIB)
     AC_DEFINE(PCRE2_CODE_UNIT_WIDTH, 8, [ ])
     AC_DEFINE(HAVE_PCRE, 1, [ ])

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -67,19 +67,6 @@ if test "$PHP_PDO_PGSQL" != "no"; then
 
   AC_DEFINE(HAVE_PDO_PGSQL,1,[Whether to build PostgreSQL for PDO support or not])
 
-  AC_MSG_CHECKING([for openssl dependencies])
-  grep openssl $PGSQL_INCLUDE/libpq-fe.h >/dev/null 2>&1
-  if test $? -eq 0 ; then
-    AC_MSG_RESULT([yes])
-    dnl First try to find pkg-config
-    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
-      PDO_PGSQL_CFLAGS=`$PKG_CONFIG openssl --cflags`
-    fi
-  else
-    AC_MSG_RESULT([no])
-  fi
-
   old_LIBS=$LIBS
   old_LDFLAGS=$LDFLAGS
   LDFLAGS="-L$PGSQL_LIBDIR $LDFLAGS"
@@ -114,7 +101,7 @@ if test "$PHP_PDO_PGSQL" != "no"; then
     AC_MSG_RESULT($pdo_cv_inc_path)
   ])
 
-  PHP_NEW_EXTENSION(pdo_pgsql, pdo_pgsql.c pgsql_driver.c pgsql_statement.c, $ext_shared,,-I$pdo_cv_inc_path $PDO_PGSQL_CFLAGS)
+  PHP_NEW_EXTENSION(pdo_pgsql, pdo_pgsql.c pgsql_driver.c pgsql_statement.c, $ext_shared,,-I$pdo_cv_inc_path)
   ifdef([PHP_ADD_EXTENSION_DEP],
   [
     PHP_ADD_EXTENSION_DEP(pdo_pgsql, pdo)

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -70,7 +70,7 @@ $TS \
 --with-pspell=/usr \
 --with-enchant=/usr \
 --enable-wddx \
---enable-freetype \
+--with-freetype \
 --with-xpm-dir=/usr \
 --with-kerberos \
 --enable-sysvmsg \

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -50,7 +50,6 @@ $TS \
 --enable-soap \
 --enable-xmlreader \
 --with-xsl \
---with-curl=/usr \
 --with-tidy \
 --with-xmlrpc \
 --enable-sysvsem \


### PR DESCRIPTION
Followup on #3632.

Now that there's a nice pkg.m4 macro to use, start using it more consistently.

Currently implemented:

- curl (now requires pkg-config)
- openssl (now requires pkg-config)
- pcre (migrate current pkg-config checks to the macro, do not drop pcre-config code)
- pdo_pgsql's openssl support is fake and can be dropped