### PR TITLE
Skip SQLite3::loadExtension tests if SQLITE_OMIT_LOAD_EXTENSION defined

### DIFF
--- a/ext/sqlite3/tests/skipif_loadExtension.inc
+++ b/ext/sqlite3/tests/skipif_loadExtension.inc
@@ -1,0 +1,5 @@
+<?php
+
+if (!method_exists(new SQLite3(':memory:'), 'loadExtension')) {
+	die("skip if SQLITE_OMIT_LOAD_EXTENSION defined");
+}

--- a/ext/sqlite3/tests/sqlite3_33_load_extension_param.phpt
+++ b/ext/sqlite3/tests/sqlite3_33_load_extension_param.phpt
@@ -6,7 +6,10 @@ Jelle Lampaert
 --INI--
 sqlite3.extension_dir=/tmp
 --SKIPIF--
-<?php require_once(__DIR__ . '/skipif.inc'); ?>
+<?php
+require_once(__DIR__ . '/skipif.inc');
+require_once(__DIR__ . '/skipif_loadExtension.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/sqlite3/tests/sqlite3_34_load_extension_ext_dir.phpt
+++ b/ext/sqlite3/tests/sqlite3_34_load_extension_ext_dir.phpt
@@ -4,7 +4,10 @@ SQLite3::loadExtension with disabled extensions
 Jelle Lampaert
 #Belgian Testfest 2009
 --SKIPIF--
-<?php require_once(__DIR__ . '/skipif.inc'); ?>
+<?php
+require_once(__DIR__ . '/skipif.inc');
+require_once(__DIR__ . '/skipif_loadExtension.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/sqlite3/tests/sqlite3_loadextension_with_wrong_param.phpt
+++ b/ext/sqlite3/tests/sqlite3_loadextension_with_wrong_param.phpt
@@ -4,7 +4,10 @@ SQLite3::loadExtension test with wrong parameter type
 Thijs Feryn <thijs@feryn.eu>
 #TestFest PHPBelgium 2009
 --SKIPIF--
-<?php require_once(__DIR__ . '/skipif.inc'); ?>
+<?php
+require_once(__DIR__ . '/skipif.inc');
+require_once(__DIR__ . '/skipif_loadExtension.inc');
+?>
 --FILE--
 <?php
 $db = new SQLite3(':memory:');


### PR DESCRIPTION
If and only if linked sqlite3 have load_extension, SQLite3 class have loadExtension method: https://github.com/php/php-src/blob/master/ext/sqlite3/sqlite3.c#L336 .

We should check whether exists loadExtension method for some tests.