### PR TITLE
Clean testfile after tests

### DIFF
--- a/ext/bz2/tests/bug72447.phpt
+++ b/ext/bz2/tests/bug72447.phpt
@@ -11,5 +11,9 @@ $fp = fopen('testfile', 'w');
 stream_filter_append($fp, 'bzip2.compress', STREAM_FILTER_WRITE, $param);
 fclose($fp);
 ?>
+--CLEAN--
+<?php
+unlink('testfile');
+?>
 --EXPECTF--
 Warning: stream_filter_append(): Invalid parameter given for number of blocks to allocate. (0) in %s%ebug72447.php on line %d


### PR DESCRIPTION
Now, ext/bz2/tests/bug72447.phpt forget to clean `testfile`, so, `testfile` is left after `make test`.

I added cleaning logic.