### PR TITLE
Ignore getaddrinfo failed message

### DIFF
--- a/ext/ftp/tests/ftp_ssl_connect_error.phpt
+++ b/ext/ftp/tests/ftp_ssl_connect_error.phpt
@@ -29,7 +29,7 @@ echo "===DONE===\n";
 
 -- Testing ftp_ssl_connect() function on failure --
 
-Warning: ftp_ssl_connect(): php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %d
+Warning: ftp_ssl_connect(): php_network_getaddresses: getaddrinfo failed: %s in %s on line %d
 bool(false)
 
 -- Testing ftp_ssl_connect() function invalid argument type --


### PR DESCRIPTION
On macOS, EAI_NONAME is shown 'hostname or servname not provided, or not known': https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/gai_strerror.3.html#//apple_ref/doc/man/3/gai_strerror

So, ext/ftp/tests/ftp_ssl_connect_error.phpt is always failed.  This PR fixed it.