### PR TITLE
Suppress already used warning

### DIFF
--- a/ext/sockets/tests/socket_getpeername_ipv6loop.phpt
+++ b/ext/sockets/tests/socket_getpeername_ipv6loop.phpt
@@ -25,7 +25,7 @@ require 'ipv6_skipif.inc';
 	$maxport = 31356;
 	$bound = false;
 	for($port = $minport; $port <= $maxport; ++$port) {
-        	if (socket_bind($server, $localhost, $port)) {
+		if (@socket_bind($server, $localhost, $port)) {
 			$bound = true;
 			break;
 		}


### PR DESCRIPTION
Now, although ext/sockets/tests/socket_getpeername_ipv6loop.phpt includes fallback to bind port,  it fails when port 31337 is already used.
The reason is that socket_bind throws E_WARNING, 'Address already in use'.

This PR suppress such warnings and is through the test even if the port is already used.