### PR TITLE
Skip socket sendrecv test (WIN32) not for Windows

### DIFF
--- a/ext/sockets/tests/socket_sendrecvmsg_multi_msg.phpt
+++ b/ext/sockets/tests/socket_sendrecvmsg_multi_msg.phpt
@@ -6,6 +6,8 @@ if (!extension_loaded('sockets'))
 	die('skip sockets extension not available.');
 if (!defined('IPPROTO_IPV6'))
 	die('skip IPv6 not available.');
+if (substr(PHP_OS, 0, 3) != 'WIN')
+	die('skip not for Windows');
 /* Windows supports IPV6_RECVTCLASS and is able to receive the tclass via
  * WSARecvMsg (though only the top 6 bits seem to reported), but WSASendMsg
  * does not accept IPV6_TCLASS messages. We still  test that sendmsg() works


### PR DESCRIPTION
[This](https://github.com/php/php-src/blob/8021e0f5dcc52af60d1b1b823c732e22a390d48a/ext/sockets/tests/socket_sendrecvmsg_multi_msg-unix.phpt) seems to be for Unix test.
And, https://github.com/php/php-src/blob/8021e0f5dcc52af60d1b1b823c732e22a390d48a/ext/sockets/tests/socket_sendrecvmsg_multi_msg.phpt is for Windows, right?

So, we should skip the test for Windows on macOS or Linux.