### PR TITLE
Fix bug #71041 dynamic embed SAPI load error

### DIFF
--- a/Zend/zend_signal.h
+++ b/Zend/zend_signal.h
@@ -88,7 +88,7 @@ ZEND_API void zend_signal_handler_unblock(void);
 void zend_signal_activate(void);
 void zend_signal_deactivate(void);
 BEGIN_EXTERN_C()
-void zend_signal_startup(void);
+ZEND_API void zend_signal_startup(void);
 END_EXTERN_C()
 void zend_signal_init(void);
 


### PR DESCRIPTION
If the library is built with ZEND_SIGNALS defined, it's unusable with an external SAPI module because the zend_signal_startup() call is mandatory in this case.

This bug is similar to #74149, but related to dynamic loading of PHP library.

https://bugs.php.net/bug.php?id=74149
https://bugs.php.net/bug.php?id=71041