### PR TITLE
Fix bug #77051 when binded values are changed but reset method is not called

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1560,6 +1560,9 @@ PHP_METHOD(sqlite3stmt, execute)
 
 	SQLITE3_CHECK_INITIALIZED(stmt_obj->db_obj, stmt_obj->initialised, SQLite3);
 
+	/* Always reset statement before execution, see bug #77051 */
+	sqlite3_reset(stmt_obj->stmt);
+
 	if (stmt_obj->bound_params) {
 		ZEND_HASH_FOREACH_PTR(stmt_obj->bound_params, param) {
 			zval *parameter;

--- a/ext/sqlite3/tests/bug77051.phpt
+++ b/ext/sqlite3/tests/bug77051.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Bug #77051 SQLite3::bindParam memory bug when missing ::reset call
+--SKIPIF--
+<?php require_once(__DIR__ . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$db = new SQLite3(':memory:');
+$db->enableExceptions(true);
+
+$stmt = $db->prepare('SELECT :a, :b, ?;');
+
+$a = 42;
+$stmt->bindParam(':a', $a, SQLITE3_INTEGER);
+$stmt->bindValue(':b', 'php');
+$stmt->bindValue(':b', 'PHP');
+$stmt->bindValue(3, 424242);
+
+echo "Execute statement\n";
+var_dump($res = $stmt->execute());
+
+echo "Statement result\n";
+var_dump($res->fetchArray(SQLITE3_NUM));
+
+echo "Change binded param to wrong type\n";
+$a = 'TEST';
+
+echo "Execute statement\n";
+var_dump($res = $stmt->execute());
+
+echo "Statement result\n";
+var_dump($res->fetchArray(SQLITE3_NUM));
+
+echo "Change binded values\n";
+$a = 5252552;
+$stmt->bindValue(':b', 'TEST');
+$stmt->bindValue(3, '!!!');
+
+echo "Execute statement\n";
+var_dump($res = $stmt->execute());
+
+echo "Statement result\n";
+var_dump($res->fetchArray(SQLITE3_NUM));
+
+?>
+--EXPECTF--
+Execute statement
+object(SQLite3Result)#3 (0) {
+}
+Statement result
+array(3) {
+  [0]=>
+  int(42)
+  [1]=>
+  string(3) "PHP"
+  [2]=>
+  int(424242)
+}
+Change binded param to wrong type
+Execute statement
+object(SQLite3Result)#4 (0) {
+}
+Statement result
+array(3) {
+  [0]=>
+  int(0)
+  [1]=>
+  string(3) "PHP"
+  [2]=>
+  int(424242)
+}
+Change binded values
+Execute statement
+object(SQLite3Result)#3 (0) {
+}
+Statement result
+array(3) {
+  [0]=>
+  int(5252552)
+  [1]=>
+  string(4) "TEST"
+  [2]=>
+  string(3) "!!!"
+}


### PR DESCRIPTION
Fix bug #77051 when binded values are changed but reset method is not called, by always resetting the statement when calling execute() method