### PR TITLE
Add re2c checking with error exit code

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2097,7 +2097,13 @@ AC_DEFUN([PHP_PROG_RE2C],[
   fi
   case $php_cv_re2c_version in
     ""|invalid[)]
-      AC_MSG_WARN([You will need re2c 0.13.4 or later if you want to regenerate PHP parsers.])
+      msg="You will need re2c 0.13.4 or later if you want to regenerate PHP parsers."
+
+      AC_CHECK_FILE([$abs_srcdir/Zend/zend_language_scanner.c],
+        [AC_MSG_WARN([$msg])],
+        [AC_MSG_ERROR([$msg])]
+      )
+
       RE2C="exit 0;"
       ;;
   esac


### PR DESCRIPTION
To make installation experience better instead of only outputting warning when `re2c` is not present this patch also exits if the PHP lexer file(s) were not generated yet and `re2c` is not present on the system.

(it checks if `Zend/zend_language_scanner.c` file is present)
Related to #3673 