### PR TITLE
Disable opcache per script using "declare(cache=0)"

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5245,6 +5245,29 @@ void zend_compile_declare(zend_ast *ast) /* {{{ */
 				CG(active_op_array)->fn_flags |= ZEND_ACC_STRICT_TYPES;
 			}
 
+		} else if (zend_string_equals_literal_ci(name, "cache")) {
+			zval value_zv;
+
+			if (FAILURE == zend_declare_is_first_statement(ast)) {
+				zend_error_noreturn(E_COMPILE_ERROR, "cache declaration must be "
+					"the very first statement in the script");
+			}
+
+			if (ast->child[1] != NULL) {
+				zend_error_noreturn(E_COMPILE_ERROR, "cache declaration must not "
+					"use block mode");
+			}
+
+			zend_const_expr_to_zval(&value_zv, value_ast);
+
+			if (Z_TYPE(value_zv) != IS_LONG || (Z_LVAL(value_zv) != 0 && Z_LVAL(value_zv) != 1)) {
+				zend_error_noreturn(E_COMPILE_ERROR, "cache declaration must have 0 or 1 as its value");
+			}
+
+			if (Z_LVAL(value_zv) == 0) {
+				CG(active_op_array)->fn_flags |= ZEND_ACC_NEVER_CACHE;
+			}
+
 		} else {
 			zend_error(E_COMPILE_WARNING, "Unsupported declare '%s'", ZSTR_VAL(name));
 		}

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -291,6 +291,7 @@ typedef struct _zend_oparray_context {
 #define ZEND_ACC_CALL_VIA_TRAMPOLINE     (1 << 17) /*     |  X  |     |     */
 /*                                                        |     |     |     */
 /* disable inline caching                                 |     |     |     */
+/* or disable caching in opcache for main op_array        |     |     |     */
 #define ZEND_ACC_NEVER_CACHE             (1 << 18) /*     |  X  |     |     */
 /*                                                        |     |     |     */
 /* Closure related                                        |     |     |     */

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1759,6 +1759,10 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 		return NULL;
 	}
 
+	if (op_array->fn_flags & ZEND_ACC_NEVER_CACHE) {
+		return NULL;
+	}
+
 	/* Build the persistent_script structure.
 	   Here we aren't sure we would store it, but we will need it
 	   further anyway.
@@ -3169,7 +3173,7 @@ static zend_op_array *preload_compile_file(zend_file_handle *file_handle, int ty
 {
 	zend_op_array *op_array = preload_orig_compile_file(file_handle, type);
 
-	if (op_array && op_array->refcount) {
+	if (op_array && op_array->refcount && !(op_array->fn_flags & ZEND_ACC_NEVER_CACHE)) {
 		zend_persistent_script *script;
 
 		script = create_persistent_script();


### PR DESCRIPTION
Allow "declare(cache=0)" syntax to disable sctipt caching in opcache (this also exclude files from preloading).