### PR TITLE
PHP 7.1 is now security-only branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@ implement RFCs. Please be sure to include tests as appropriate!
 If you are fixing a bug, then please submit your PR against the lowest actively
 supported branch of PHP that the bug affects (only green branches on
 [the supported version page](http://php.net/supported-versions.php) are supported).
-For example, at the time of writing in early-2018, the lowest supported version is
-PHP 7.1, which corresponds to the `PHP-7.1` branch in Git. Please also make sure you
-add a link to the PR in the bug on [the bug tracker](https://bugs.php.net/).
+For example, at the time of writing, the lowest supported version is PHP 7.2,
+which corresponds to the `PHP-7.2` branch in Git. Please also make sure you add
+a link to the PR in the bug on [the bug tracker](https://bugs.php.net/).
 
 Pull requests implementing RFCs should be submitted against `master`.
 


### PR DESCRIPTION
Refs:
- http://news.php.net/php.internals/103486