### PR TITLE
Fix #73291: imagecropauto() $threshold differs from external libgd

### DIFF
--- a/ext/gd/libgd/gd_crop.c
+++ b/ext/gd/libgd/gd_crop.c
@@ -198,7 +198,7 @@ gdImagePtr gdImageCropThreshold(gdImagePtr im, const unsigned int color, const f
 	crop.height = 0;
 
 	/* Pierre: crop everything sounds bad */
-	if (threshold > 1.0) {
+	if (threshold > 100.0) {
 		return NULL;
 	}
 
@@ -303,10 +303,9 @@ static int gdColorMatch(gdImagePtr im, int col1, int col2, float threshold)
 	const int dg = gdImageGreen(im, col1) - gdImageGreen(im, col2);
 	const int db = gdImageBlue(im, col1) - gdImageBlue(im, col2);
 	const int da = gdImageAlpha(im, col1) - gdImageAlpha(im, col2);
-	const double dist = sqrt(dr * dr + dg * dg + db * db + da * da);
-	const double dist_perc = sqrt(dist / (255^2 + 255^2 + 255^2));
-	return (dist_perc <= threshold);
-	//return (100.0 * dist / 195075) < threshold;
+	const int dist = dr * dr + dg * dg + db * db + da * da;
+
+	return (100.0 * dist / 195075) < threshold;
 }
 
 /*

--- a/ext/gd/tests/bug73291.phpt
+++ b/ext/gd/tests/bug73291.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug #73291 (imagecropauto() $threshold differs from external libgd)
+--SKIPIF--
+<?php
+if (!extension_loaded('gd')) die('skip gd extension not available');
+?>
+--FILE--
+<?php
+
+$src = imagecreatetruecolor(255, 255);
+$white = imagecolorallocate($src, 255, 255, 255);
+imagefilledrectangle($src, 0, 0, 254, 254, $white);
+
+for ($i = 254; $i > 0; $i--) {
+    $color = imagecolorallocate($src, $i, $i, $i);
+    imagefilledellipse($src, 127, 127, $i, $i, $color);
+}
+
+foreach ([0.1, 0.5, 1.0, 10.0] as $threshold) {
+    $dst = imagecropauto($src, IMG_CROP_THRESHOLD, $threshold, $white);
+    if ($dst !== false) {
+        printf("size: %d*%d\n", imagesx($dst), imagesy($dst));
+    } else {
+        echo "cropped to zero size\n";
+    }
+}
+
+?>
+===DONE===
+--EXPECT--
+size: 247*247
+size: 237*237
+size: 229*229
+size: 175*175
+===DONE===


### PR DESCRIPTION
Since upstream does not appear to move in any way[1], we sync our
behavior.  Even though the BC break is ugly (which is the reason we
target master only), having to deal with different algorithms is even
worse for portable userland code.

[1] <https://github.com/libgd/libgd/issues/334>