### PR TITLE
Remove support for Rhapsody code name

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -39,12 +39,6 @@ if test "$CC" = "gcc" -a "$ac_cv_prog_cc_g" = "yes" -a \
 	CFLAGS=`echo $CFLAGS | sed -e 's/-g//'`
 fi
 
-dnl Hack to work around a Mac OS X cpp problem
-dnl Known versions needing this workaround are 5.3 and 5.4
-if test "$ac_cv_prog_gcc" = "yes" -a "`uname -s`" = "Rhapsody"; then
-        CPPFLAGS="$CPPFLAGS -traditional-cpp"
-fi
-
 AC_CHECK_HEADERS(
 inttypes.h \
 stdint.h \

--- a/configure.ac
+++ b/configure.ac
@@ -275,7 +275,7 @@ case $host_alias in
   *dgux*)
     CPPFLAGS="$CPPFLAGS -D_BSD_TIMEOFDAY_FLAVOR"
     ;;
-  *darwin*|*rhapsody*)
+  *darwin*)
     if test -n "$GCC"; then
       PHP_CHECK_GCC_ARG(-no-cpp-precomp, gcc_no_cpp_precomp=yes)
       if test "$gcc_no_cpp_precomp" = "yes"; then


### PR DESCRIPTION
The Rhapsody code name was once used for computers with operating system by Apple and was mostly replaced with a newer code name Darwin:
- https://en.wikipedia.org/wiki/Rhapsody_(operating_system)
- https://en.wikipedia.org/wiki/Darwin_(operating_system)

This patch removes obsolete checks from the *nix build script files.