### PR TITLE
Replace LT_AC_PROG_SED with AC_PROG_SED

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2608,7 +2608,7 @@ dnl Generates the config.nice file
 dnl
 AC_DEFUN([PHP_CONFIG_NICE],[
   AC_REQUIRE([AC_PROG_EGREP])
-  AC_REQUIRE([LT_AC_PROG_SED])
+  AC_REQUIRE([AC_PROG_SED])
   PHP_SUBST_OLD(EGREP)
   PHP_SUBST_OLD(SED)
   test -f $1 && mv $1 $1.old


### PR DESCRIPTION
The LT_AC_PROG_SED libtool's macro has been integrated in the Autoconf since Autoconf 2.59b [1] and is recommended to be replaced with it [2].

[1] https://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
[2] http://git.savannah.gnu.org/cgit/libtool.git/tree/m4/libtool.m4