### PR TITLE
[Bug #77241] ext/intl: Use pkg-config to detect icu

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2119,55 +2119,16 @@ dnl
 dnl Common setup macro for ICU
 dnl
 AC_DEFUN([PHP_SETUP_ICU],[
-  PHP_ARG_WITH(icu-dir,,
-  [  --with-icu-dir=DIR      Specify where ICU libraries and headers can be found], DEFAULT, no)
+  PKG_CHECK_MODULES([ICU], [icu-io >= 50.1])
 
-  if test "$PHP_ICU_DIR" = "no"; then
-    PHP_ICU_DIR=DEFAULT
-  fi
+  PHP_EVAL_INCLINE($ICU_CFLAGS)
+  PHP_EVAL_LIBLINE($ICU_LIBS, $1)
 
-  if test "$PHP_ICU_DIR" = "DEFAULT"; then
-    dnl Try to find icu-config
-    AC_PATH_PROG(ICU_CONFIG, icu-config, no, [$PATH:/usr/local/bin])
-  else
-    ICU_CONFIG="$PHP_ICU_DIR/bin/icu-config"
-  fi
+  ICU_CFLAGS="$ICU_CFLAGS -DU_NO_DEFAULT_INCLUDE_UTF_HEADERS=1"
+  ICU_CXXFLAGS="$ICU_CXXFLAGS -DUNISTR_FROM_CHAR_EXPLICIT=explicit -DUNISTR_FROM_STRING_EXPLICIT=explicit"
 
-  AC_MSG_CHECKING([for location of ICU headers and libraries])
-
-  dnl Trust icu-config to know better what the install prefix is..
-  icu_install_prefix=`$ICU_CONFIG --prefix 2> /dev/null`
-  if test "$?" != "0" || test -z "$icu_install_prefix"; then
-    AC_MSG_RESULT([not found])
-    AC_MSG_ERROR([Unable to detect ICU prefix or $ICU_CONFIG failed. Please verify ICU install prefix and make sure icu-config works.])
-  else
-    AC_MSG_RESULT([$icu_install_prefix])
-
-    dnl Check ICU version
-    AC_MSG_CHECKING([for ICU 50.1 or greater])
-    icu_version_full=`$ICU_CONFIG --version`
-    ac_IFS=$IFS
-    IFS="."
-    set $icu_version_full
-    IFS=$ac_IFS
-    icu_version=`expr [$]1 \* 1000 + [$]2`
-    AC_MSG_RESULT([found $icu_version_full])
-
-    if test "$icu_version" -lt "50001"; then
-      AC_MSG_ERROR([ICU version 50.1 or later is required])
-    fi
-
-    ICU_VERSION=$icu_version
-    ICU_INCS=`$ICU_CONFIG --cppflags-searchpath`
-    ICU_LIBS=`$ICU_CONFIG --ldflags --ldflags-icuio`
-    PHP_EVAL_INCLINE($ICU_INCS)
-    PHP_EVAL_LIBLINE($ICU_LIBS, $1)
-
-    ICU_CXXFLAGS="$ICU_CXXFLAGS -DUNISTR_FROM_CHAR_EXPLICIT=explicit -DUNISTR_FROM_STRING_EXPLICIT=explicit"
-    ICU_CFLAGS="-DU_NO_DEFAULT_INCLUDE_UTF_HEADERS=1"
-    if test "$icu_version" -ge "60000"; then
-      ICU_CFLAGS="$ICU_CFLAGS -DU_HIDE_OBSOLETE_UTF_OLD_H=1"
-    fi
+  if test "$PKG_CONFIG icu-io --atleast-version=60"; then
+    ICU_CFLAGS="$ICU_CFLAGS -DU_HIDE_OBSOLETE_UTF_OLD_H=1"
   fi
 ])
 

--- a/ext/intl/config.m4
+++ b/ext/intl/config.m4
@@ -8,7 +8,7 @@ PHP_ARG_ENABLE(intl, whether to enable internationalization support,
 if test "$PHP_INTL" != "no"; then
   PHP_SETUP_ICU(INTL_SHARED_LIBADD)
   PHP_SUBST(INTL_SHARED_LIBADD)
-  INTL_COMMON_FLAGS="$ICU_INCS $ICU_CFLAGS -Wno-write-strings -D__STDC_LIMIT_MACROS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  INTL_COMMON_FLAGS="$ICU_CFLAGS -Wno-write-strings -D__STDC_LIMIT_MACROS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
   PHP_NEW_EXTENSION(intl, php_intl.c \
     intl_error.c \
     intl_convert.c \


### PR DESCRIPTION
`icu-config` has been deprecated by its upstream developers for some years now. In icu 63.1, `icu-config` is optional to install, but is installed by default. In the next version, `icu-config` will no longer be installed by default.

The developers recommend downstream packages use `pkg-config` to detect the icu libraries.

Debian (and its derivatives, such as Ubuntu) will remove `icu-config` from its icu development package (libicu-dev) very soon. Hence, php needs to use `pkg-config` to detect icu.