### PR TITLE
[WIP] Add strictness to run-tests script

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -69,7 +69,7 @@ NO_PROC_OPEN_ERROR;
 }
 
 // If timezone is not set, use UTC.
-if (ini_get('date.timezone') == '') {
+if (ini_get('date.timezone') === '') {
 	date_default_timezone_set('UTC');
 }
 
@@ -105,14 +105,14 @@ if (empty($environment['TEMP'])) {
 		// (likely a different path). The parent will initialize the OpCache in that path, and child will fail to reattach to
 		// the OpCache because it will be using the wrong path.
 		die("TEMP environment is NOT set");
-	} else if (count($environment) == 1) {
+	} else if (count($environment) === 1) {
 		// not having other environment variables, only having TEMP, is probably ok, but strange and may make a
 		// difference in the test pass rate, so warn the user.
 		echo "WARNING: Only 1 environment variable will be available to tests(TEMP environment variable)" . PHP_EOL;
 	}
 }
 //
-if ((substr(PHP_OS, 0, 3) == "WIN") && empty($environment["SystemRoot"])) {
+if ((substr(PHP_OS, 0, 3) === "WIN") && empty($environment["SystemRoot"])) {
 	$environment["SystemRoot"] = getenv("SystemRoot");
 }
 
@@ -127,7 +127,7 @@ $phpdbg = null;
 if (getenv('TEST_PHP_EXECUTABLE')) {
 	$php = getenv('TEST_PHP_EXECUTABLE');
 
-	if ($php == 'auto') {
+	if ($php === 'auto') {
 		$php = TEST_PHP_SRCDIR . '/sapi/cli/php';
 		putenv("TEST_PHP_EXECUTABLE=$php");
 
@@ -147,7 +147,7 @@ if (getenv('TEST_PHP_EXECUTABLE')) {
 if (getenv('TEST_PHP_CGI_EXECUTABLE')) {
 	$php_cgi = getenv('TEST_PHP_CGI_EXECUTABLE');
 
-	if ($php_cgi == 'auto') {
+	if ($php_cgi === 'auto') {
 		$php_cgi = TEST_PHP_SRCDIR . '/sapi/cgi/php-cgi';
 		putenv("TEST_PHP_CGI_EXECUTABLE=$php_cgi");
 	}
@@ -175,7 +175,7 @@ if (!getenv('TEST_PHPDBG_EXECUTABLE')) {
 if (getenv('TEST_PHPDBG_EXECUTABLE')) {
 	$phpdbg = getenv('TEST_PHPDBG_EXECUTABLE');
 
-	if ($phpdbg == 'auto') {
+	if ($phpdbg === 'auto') {
 		$phpdbg = TEST_PHP_SRCDIR . '/sapi/phpdbg/phpdbg';
 		putenv("TEST_PHPDBG_EXECUTABLE=$phpdbg");
 	}
@@ -375,11 +375,11 @@ function save_or_mail_results()
 		flush();
 
 		$user_input = fgets($fp, 10);
-		$just_save_results = (strtolower($user_input[0]) == 's');
+		$just_save_results = (strtolower($user_input[0]) === 's');
 	}
 
 	if ($just_save_results || !getenv('NO_INTERACTION') || TRAVIS_CI) {
-		if ($just_save_results || TRAVIS_CI || strlen(trim($user_input)) == 0 || strtolower($user_input[0]) == 'y') {
+		if ($just_save_results || TRAVIS_CI || strlen(trim($user_input)) === 0 || strtolower($user_input[0]) === 'y') {
 			/*
 			 * Collect information about the host system for our report
 			 * Fetch phpinfo() output so that we can see the PHP environment
@@ -393,7 +393,7 @@ function save_or_mail_results()
 			/* Ask the user to provide an email address, so that QA team can contact the user */
 			if (TRAVIS_CI) {
 				$user_email = 'travis at php dot net';
-			} elseif (!strncasecmp($user_input, 'y', 1) || strlen(trim($user_input)) == 0) {
+			} elseif (!strncasecmp($user_input, 'y', 1) || strlen(trim($user_input)) === 0) {
 				echo "\nPlease enter your email address.\n(Your address will be mangled so that it will not go out on any\nmailinglist in plain text): ";
 				flush();
 				$user_email = trim(fgets($fp, 1024));
@@ -421,7 +421,7 @@ function save_or_mail_results()
 			$failed_tests_data .= "OS:\n" . PHP_OS . " - " . php_uname() . "\n\n";
 			$ldd = $autoconf = $sys_libtool = $libtool = $compiler = 'N/A';
 
-			if (substr(PHP_OS, 0, 3) != "WIN") {
+			if (substr(PHP_OS, 0, 3) !== "WIN") {
 				/* If PHP_AUTOCONF is set, use it; otherwise, use 'autoconf'. */
 				if (getenv('PHP_AUTOCONF')) {
 					$autoconf = shell_exec(getenv('PHP_AUTOCONF') . ' --version');
@@ -445,7 +445,7 @@ function save_or_mail_results()
 
 				foreach ($flags as $flag) {
 					system(getenv('CC') . " $flag >/dev/null 2>&1", $cc_status);
-					if ($cc_status == 0) {
+					if ($cc_status === 0) {
 						$compiler = shell_exec(getenv('CC') . " $flag 2>&1");
 						break;
 					}
@@ -538,7 +538,7 @@ if (isset($argc) && $argc > 1) {
 	for ($i = 1; $i < $argc; $i++) {
 		$is_switch = false;
 		$switch = substr($argv[$i], 1, 1);
-		$repeat = substr($argv[$i], 0, 1) == '-';
+		$repeat = substr($argv[$i], 0, 1) === '-';
 
 		while ($repeat) {
 
@@ -552,7 +552,7 @@ if (isset($argc) && $argc > 1) {
 				foreach ($cfgtypes as $type) {
 					if (strpos($switch, '--' . $type) === 0) {
 						foreach ($cfgfiles as $file) {
-							if ($switch == '--' . $type . '-' . $file) {
+							if ($switch === '--' . $type . '-' . $file) {
 								$cfg[$type][$file] = true;
 								$is_switch = false;
 								break;
@@ -583,7 +583,7 @@ if (isset($argc) && $argc > 1) {
 							}
 						}
 					}
-					if ($switch != 'l') {
+					if ($switch !== 'l') {
 						break;
 					}
 					$i--;
@@ -687,7 +687,7 @@ if (isset($argc) && $argc > 1) {
 				case '-':
 					// repeat check with full switch
 					$switch = $argv[$i];
-					if ($switch != '-') {
+					if ($switch !== '-') {
 						$repeat = true;
 					}
 					break;
@@ -793,7 +793,7 @@ HELP;
 
 			if (!$testfile && strpos($argv[$i], '*') !== false && function_exists('glob')) {
 
-				if (substr($argv[$i], -5) == '.phpt') {
+				if (substr($argv[$i], -5) === '.phpt') {
 					$pattern_match = glob($argv[$i]);
 				} else if (preg_match("/\*$/", $argv[$i])) {
 					$pattern_match = glob($argv[$i] . '.phpt');
@@ -807,7 +807,7 @@ HELP;
 
 			} else if (is_dir($testfile)) {
 				find_files($testfile);
-			} else if (substr($testfile, -5) == '.phpt') {
+			} else if (substr($testfile, -5) === '.phpt') {
 				$test_files[] = $testfile;
 			} else {
 				die('Cannot find test file "' . $argv[$i] . '".' . PHP_EOL);
@@ -816,7 +816,7 @@ HELP;
 	}
 
 	if (strlen($conf_passed)) {
-		if (substr(PHP_OS, 0, 3) == "WIN") {
+		if (substr(PHP_OS, 0, 3) === "WIN") {
 			$pass_options .= " -c " . escapeshellarg($conf_passed);
 		} else {
 			$pass_options .= " -c '$conf_passed'";
@@ -869,7 +869,7 @@ HELP;
 			fclose($html_file);
 		}
 
-		if ($output_file != '' && $just_save_results) {
+		if ($output_file !== '' && $just_save_results) {
 			save_or_mail_results();
 		}
 
@@ -908,11 +908,11 @@ foreach ($exts_to_test as $key => $val) {
 }
 
 foreach ($test_dirs as $dir) {
-	find_files(TEST_PHP_SRCDIR . "/{$dir}", $dir == 'ext');
+	find_files(TEST_PHP_SRCDIR . "/{$dir}", $dir === 'ext');
 }
 
 foreach ($user_tests as $dir) {
-	find_files($dir, $dir == 'ext');
+	find_files($dir, $dir === 'ext');
 }
 
 function find_files(string $dir, bool $is_ext_dir = false, bool $ignore = false): void
@@ -932,13 +932,13 @@ function find_files(string $dir, bool $is_ext_dir = false, bool $ignore = false)
 		}
 
 		// Cleanup any left-over tmp files from last run.
-		if (substr($name, -4) == '.tmp') {
+		if (substr($name, -4) === '.tmp') {
 			@unlink("$dir/$name");
 			continue;
 		}
 
 		// Otherwise we're only interested in *.phpt files.
-		if (substr($name, -5) == '.phpt') {
+		if (substr($name, -5) === '.phpt') {
 			if ($ignore) {
 				$ignored_by_ext++;
 			} else {
@@ -975,7 +975,7 @@ function test_sort($a, $b): int
 	$ta = strpos($a, TEST_PHP_SRCDIR . "/tests") === 0 ? 1 + (strpos($a, TEST_PHP_SRCDIR . "/tests/run-test") === 0 ? 1 : 0) : 0;
 	$tb = strpos($b, TEST_PHP_SRCDIR . "/tests") === 0 ? 1 + (strpos($b, TEST_PHP_SRCDIR . "/tests/run-test") === 0 ? 1 : 0) : 0;
 
-	if ($ta == $tb) {
+	if ($ta === $tb) {
 		return strcmp($a, $b);
 	} else {
 		return $tb - $ta;
@@ -1003,7 +1003,7 @@ if ($result_tests_file) {
 
 // Summarize results
 
-if (0 == count($test_results)) {
+if (0 === count($test_results)) {
 	echo "No tests were run.\n";
 	return;
 }
@@ -1078,7 +1078,7 @@ function save_text(string $filename, string $text, string $filename_copy = null)
 {
 	global $DETAILED;
 
-	if ($filename_copy && $filename_copy != $filename) {
+	if ($filename_copy && $filename_copy !== $filename) {
 		if (file_put_contents($filename_copy, $text, FILE_BINARY) === false) {
 			error("Cannot open file '" . $filename_copy . "' (save_text)");
 		}
@@ -1178,7 +1178,7 @@ function system_with_timeout(string $commandline, $env = null, string $stdin = n
 			} else {
 				$line = '';
 			}
-			if (strlen($line) == 0) {
+			if (strlen($line) === 0) {
 				/* EOF */
 				break;
 			}
@@ -1219,9 +1219,9 @@ function run_all_tests(array $test_files, $env, string $redir_tested = null): vo
 		$test_idx++;
 		$result = run_test($php, $name, $env);
 
-		if (!is_array($name) && $result != 'REDIR') {
+		if (!is_array($name) && $result !== 'REDIR') {
 			$test_results[$index] = $result;
-			if ($failed_tests_file && ($result == 'XFAILED' || $result == 'FAILED' || $result == 'WARNED' || $result == 'LEAKED')) {
+			if ($failed_tests_file && ($result === 'XFAILED' || $result === 'FAILED' || $result === 'WARNED' || $result === 'LEAKED')) {
 				fwrite($failed_tests_file, "$index\n");
 			}
 			if ($result_tests_file) {
@@ -1331,7 +1331,7 @@ TEST $file
 			}
 
 			$section_text[$section] = '';
-			$secfile = $section == 'FILE' || $section == 'FILEEOF' || $section == 'FILE_EXTERNAL';
+			$secfile = $section === 'FILE' || $section === 'FILEEOF' || $section === 'FILE_EXTERNAL';
 			$secdone = false;
 			continue;
 		}
@@ -1358,7 +1358,7 @@ TEST $file
 
 		} else {
 
-			if (!isset($section_text['PHPDBG']) && @count($section_text['FILE']) + @count($section_text['FILEEOF']) + @count($section_text['FILE_EXTERNAL']) != 1) {
+			if (!isset($section_text['PHPDBG']) && @count($section_text['FILE']) + @count($section_text['FILEEOF']) + @count($section_text['FILE_EXTERNAL']) !== 1) {
 				$bork_info = "missing section --FILE--";
 			}
 
@@ -1383,7 +1383,7 @@ TEST $file
 				}
 			}
 
-			if ((@count($section_text['EXPECT']) + @count($section_text['EXPECTF']) + @count($section_text['EXPECTREGEX'])) != 1) {
+			if ((@count($section_text['EXPECT']) + @count($section_text['EXPECTF']) + @count($section_text['EXPECTREGEX'])) !== 1) {
 				$bork_info = "missing section --EXPECT--, --EXPECTF-- or --EXPECTREGEX--";
 			}
 		}
@@ -1584,7 +1584,7 @@ TEST $file
 		$ext_prefix = substr(PHP_OS, 0, 3) === "WIN" ? "php_" : "";
 		foreach ($extensions as $req_ext) {
 			if (!in_array($req_ext, $loaded)) {
-				if ($req_ext == 'opcache') {
+				if ($req_ext === 'opcache') {
 					$ini_settings['zend_extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $ext_prefix . $req_ext . '.' . PHP_SHLIB_SUFFIX;
 				} else {
 					$ini_settings['extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $ext_prefix . $req_ext . '.' . PHP_SHLIB_SUFFIX;
@@ -1738,7 +1738,7 @@ TEST $file
 		}
 	}
 
-	if (is_array($org_file) || @count($section_text['REDIRECTTEST']) == 1) {
+	if (is_array($org_file) || @count($section_text['REDIRECTTEST']) === 1) {
 
 		if (is_array($org_file)) {
 			$file = $org_file[0];
@@ -2392,7 +2392,7 @@ function settings2array(array $settings, &$ini_settings): void
 			$name = trim($setting[0]);
 			$value = trim($setting[1]);
 
-			if ($name == 'extension' || $name == 'zend_extension') {
+			if ($name === 'extension' || $name === 'zend_extension') {
 
 				if (!isset($ini_settings[$name])) {
 					$ini_settings[$name] = array();
@@ -2419,10 +2419,10 @@ function settings2params(&$ini_settings): void
 				$settings .= " -d \"$name=$val\"";
 			}
 		} else {
-			if (substr(PHP_OS, 0, 3) == "WIN" && !empty($value) && $value{0} == '"') {
+			if (substr(PHP_OS, 0, 3) === "WIN" && !empty($value) && $value{0} === '"') {
 				$len = strlen($value);
 
-				if ($value{$len - 1} == '"') {
+				if ($value{$len - 1} === '"') {
 					$value{0} = "'";
 					$value{$len - 1} = "'";
 				}
@@ -2866,18 +2866,18 @@ function junit_mark_test_as($type, string $file_name, string $test_name, $time =
 		$output_type = $type . 'ED';
 	}
 
-	if ('PASS' == $type || 'XFAIL' == $type) {
+	if ('PASS' === $type || 'XFAIL' === $type) {
 		junit_suite_record($suite, 'test_pass');
-	} elseif ('BORK' == $type) {
+	} elseif ('BORK' === $type) {
 		junit_suite_record($suite, 'test_error');
 		$JUNIT['files'][$file_name]['xml'] .= "<error type='$output_type' message='$escaped_message'/>\n";
-	} elseif ('SKIP' == $type) {
+	} elseif ('SKIP' === $type) {
 		junit_suite_record($suite, 'test_skip');
 		$JUNIT['files'][$file_name]['xml'] .= "<skipped>$escaped_message</skipped>\n";
-	} elseif ('WARN' == $type) {
+	} elseif ('WARN' === $type) {
 		junit_suite_record($suite, 'test_warn');
 		$JUNIT['files'][$file_name]['xml'] .= "<warning>$escaped_message</warning>\n";
-	} elseif ('FAIL' == $type) {
+	} elseif ('FAIL' === $type) {
 		junit_suite_record($suite, 'test_fail');
 		$JUNIT['files'][$file_name]['xml'] .= "<failure type='$output_type' message='$escaped_message'>$escaped_details</failure>\n";
 	} else {
@@ -2933,7 +2933,7 @@ function junit_get_suitename_for(string $file_name): string
 
 function junit_path_to_classname(string $file_name): string
 {
-    global $JUNIT;
+	global $JUNIT;
 
 	$ret = $JUNIT['name'];
 	$_tmp = array();
@@ -3028,7 +3028,7 @@ class RuntestsValgrind
 		}
 		$count = 0;
 		$version = preg_replace("/valgrind-(\d+)\.(\d+)\.(\d+)([.\w_-]+)?(\s+)/", '$1.$2.$3', $header, 1, $count);
-		if ($count != 1) {
+		if ($count !== 1) {
 			error("Valgrind returned invalid version info (\"{$header}\"), cannot proceed.");
 		}
 		$this->version = $version;

--- a/run-tests.php
+++ b/run-tests.php
@@ -915,7 +915,7 @@ foreach ($user_tests as $dir) {
 	find_files($dir, $dir == 'ext');
 }
 
-function find_files($dir, $is_ext_dir = false, $ignore = false)
+function find_files(string $dir, bool $is_ext_dir = false, bool $ignore = false): void
 {
 	global $test_files, $exts_to_test, $ignored_by_ext, $exts_skipped;
 
@@ -951,7 +951,10 @@ function find_files($dir, $is_ext_dir = false, $ignore = false)
 	closedir($o);
 }
 
-function test_name($name)
+/**
+ * @param string|array $name
+ */
+function test_name($name): string
 {
 	if (is_array($name)) {
 		return $name[0] . ':' . $name[1];
@@ -960,7 +963,11 @@ function test_name($name)
 	}
 }
 
-function test_sort($a, $b)
+/**
+ * @param string|array $a
+ * @param string|array $b
+ */
+function test_sort($a, $b): int
 {
 	$a = test_name($a);
 	$b = test_name($b);
@@ -1019,11 +1026,10 @@ if (getenv('REPORT_EXIT_STATUS') !== '0' &&
 }
 exit(0);
 
-//
-// Send Email to QA Team
-//
-
-function mail_qa_team($data, $status = false)
+/**
+ * Send Email to QA Team
+ */
+function mail_qa_team(string $data, bool $status = false): bool
 {
 	$url_bits = parse_url(QA_SUBMISSION_PAGE);
 
@@ -1062,15 +1068,13 @@ function mail_qa_team($data, $status = false)
 	fwrite($fs, "\r\n\r\n");
 	fclose($fs);
 
-	return 1;
+	return true;
 }
 
-
-//
-//  Write the given text to a temporary file, and return the filename.
-//
-
-function save_text($filename, $text, $filename_copy = null)
+/**
+ * Write the given text to a temporary file, and return the filename.
+ */
+function save_text(string $filename, string $text, string $filename_copy = null): void
 {
 	global $DETAILED;
 
@@ -1091,11 +1095,10 @@ $text
 ";
 }
 
-//
-//  Write an error in a format recognizable to Emacs or MSVC.
-//
-
-function error_report($testname, $logname, $tested)
+/**
+ * Write an error in a format recognizable to Emacs or MSVC.
+ */
+function error_report(string $testname, string $logname, $tested): void
 {
 	$testname = realpath($testname);
 	$logname = realpath($logname);
@@ -1112,7 +1115,10 @@ function error_report($testname, $logname, $tested)
 	}
 }
 
-function system_with_timeout($commandline, $env = null, $stdin = null, $captureStdIn = true, $captureStdOut = true, $captureStdErr = true)
+/**
+ * @return string|bool
+ */
+function system_with_timeout(string $commandline, $env = null, string $stdin = null, bool $captureStdIn = true, bool $captureStdOut = true, bool $captureStdErr = true)
 {
 	global $valgrind;
 
@@ -1193,7 +1199,7 @@ function system_with_timeout($commandline, $env = null, $stdin = null, $captureS
 	return $data;
 }
 
-function run_all_tests($test_files, $env, $redir_tested = null)
+function run_all_tests(array $test_files, $env, string $redir_tested = null): void
 {
 	global $test_results, $failed_tests_file, $result_tests_file, $php, $test_idx;
 
@@ -1225,10 +1231,10 @@ function run_all_tests($test_files, $env, $redir_tested = null)
 	}
 }
 
-//
-//  Show file or result block
-//
-function show_file_block($file, $block, $section = null)
+/**
+ * Show file or result block
+ */
+function show_file_block($file, $block, $section = null): void
 {
 	global $cfg;
 
@@ -1244,10 +1250,10 @@ function show_file_block($file, $block, $section = null)
 	}
 }
 
-//
-//  Run an individual test case.
-//
-function run_test($php, $file, $env)
+/**
+ * Run an individual test case.
+ */
+function run_test(string $php, string $file, array $env): string
 {
 	global $log_format, $ini_overwrites, $PHP_FAILED_TESTS;
 	global $pass_options, $DETAILED, $IN_REDIRECT, $test_cnt, $test_idx;
@@ -1265,10 +1271,6 @@ function run_test($php, $file, $env)
 
 	if (isset($env['TEST_PHPDBG_EXECUTABLE'])) {
 		$phpdbg = $env['TEST_PHPDBG_EXECUTABLE'];
-	}
-
-	if (is_array($file)) {
-		$file = $file[0];
 	}
 
 	if ($DETAILED) echo "
@@ -2243,7 +2245,7 @@ $output
 	return $restype[0] . 'ED';
 }
 
-function comp_line($l1, $l2, $is_reg)
+function comp_line(string $l1, string $l2, bool $is_reg): int
 {
 	if ($is_reg) {
 		return preg_match('/^' . $l1 . '$/s', $l2);
@@ -2252,7 +2254,7 @@ function comp_line($l1, $l2, $is_reg)
 	}
 }
 
-function count_array_diff($ar1, $ar2, $is_reg, $w, $idx1, $idx2, $cnt1, $cnt2, $steps)
+function count_array_diff($ar1, $ar2, $is_reg, $w, $idx1, $idx2, $cnt1, $cnt2, $steps): int
 {
 	$equal = 0;
 
@@ -2294,7 +2296,7 @@ function count_array_diff($ar1, $ar2, $is_reg, $w, $idx1, $idx2, $cnt1, $cnt2, $
 	return $equal;
 }
 
-function generate_array_diff($ar1, $ar2, $is_reg, $w)
+function generate_array_diff($ar1, $ar2, $is_reg, $w): array
 {
 	$idx1 = 0;
 	$cnt1 = @count($ar1);
@@ -2365,7 +2367,7 @@ function generate_array_diff($ar1, $ar2, $is_reg, $w)
 	return $diff;
 }
 
-function generate_diff($wanted, $wanted_re, $output)
+function generate_diff(string $wanted, $wanted_re, string $output): string
 {
 	$w = explode("\n", $wanted);
 	$o = explode("\n", $output);
@@ -2375,13 +2377,13 @@ function generate_diff($wanted, $wanted_re, $output)
 	return implode("\r\n", $diff);
 }
 
-function error($message)
+function error(string $message): void
 {
 	echo "ERROR: {$message}\n";
 	exit(1);
 }
 
-function settings2array($settings, &$ini_settings)
+function settings2array(array $settings, &$ini_settings): void
 {
 	foreach ($settings as $setting) {
 
@@ -2405,7 +2407,7 @@ function settings2array($settings, &$ini_settings)
 	}
 }
 
-function settings2params(&$ini_settings)
+function settings2params(&$ini_settings): void
 {
 	$settings = '';
 
@@ -2435,7 +2437,7 @@ function settings2params(&$ini_settings)
 	$ini_settings = $settings;
 }
 
-function compute_summary()
+function compute_summary(): void
 {
 	global $n_total, $test_results, $ignored_by_ext, $sum_results, $percent_results;
 
@@ -2463,7 +2465,7 @@ function compute_summary()
 	}
 }
 
-function get_summary($show_ext_summary, $show_html)
+function get_summary(bool $show_ext_summary, bool $show_html): string
 {
 	global $exts_skipped, $exts_tested, $n_total, $sum_results, $percent_results, $end_time, $start_time, $failed_test_summary, $PHP_FAILED_TESTS, $valgrind;
 
@@ -2612,7 +2614,7 @@ LEAKED TEST SUMMARY
 	return $summary;
 }
 
-function show_start($start_time)
+function show_start(int $start_time): void
 {
 	global $html_output, $html_file;
 
@@ -2624,7 +2626,7 @@ function show_start($start_time)
 	echo "TIME START " . date('Y-m-d H:i:s', $start_time) . "\n=====================================================================\n";
 }
 
-function show_end($end_time)
+function show_end(int $end_time): void
 {
 	global $html_output, $html_file;
 
@@ -2636,7 +2638,7 @@ function show_end($end_time)
 	echo "=====================================================================\nTIME END " . date('Y-m-d H:i:s', $end_time) . "\n";
 }
 
-function show_summary()
+function show_summary(): void
 {
 	global $html_output, $html_file;
 
@@ -2647,7 +2649,7 @@ function show_summary()
 	echo get_summary(true, false);
 }
 
-function show_redirect_start($tests, $tested, $tested_file)
+function show_redirect_start($tests, $tested, $tested_file): void
 {
 	global $html_output, $html_file, $line_length, $SHOW_ONLY_GROUPS;
 
@@ -2663,7 +2665,7 @@ function show_redirect_start($tests, $tested, $tested_file)
 	}
 }
 
-function show_redirect_ends($tests, $tested, $tested_file)
+function show_redirect_ends($tests, $tested, $tested_file): void
 {
 	global $html_output, $html_file, $line_length, $SHOW_ONLY_GROUPS;
 
@@ -2679,7 +2681,7 @@ function show_redirect_ends($tests, $tested, $tested_file)
 	}
 }
 
-function show_test($test_idx, $shortname)
+function show_test($test_idx, $shortname): void
 {
 	global $test_cnt;
 	global $line_length;
@@ -2690,7 +2692,7 @@ function show_test($test_idx, $shortname)
 	flush();
 }
 
-function show_result($result, $tested, $tested_file, $extra = '', $temp_filenames = null)
+function show_result(string $result, $tested, $tested_file, string $extra = '', array $temp_filenames = null): void
 {
 	global $html_output, $html_file, $temp_target, $temp_urlbase, $line_length, $SHOW_ONLY_GROUPS;
 
@@ -2748,7 +2750,7 @@ function show_result($result, $tested, $tested_file, $extra = '', $temp_filename
 	}
 }
 
-function junit_init()
+function junit_init(): void
 {
 	// Check whether a junit log is wanted.
 	$JUNIT = getenv('TEST_PHP_JUNIT');
@@ -2775,7 +2777,7 @@ function junit_init()
 	$GLOBALS['JUNIT'] = $JUNIT;
 }
 
-function junit_save_xml()
+function junit_save_xml(): void
 {
 	global $JUNIT;
 	if (!junit_enabled()) return;
@@ -2795,7 +2797,7 @@ function junit_save_xml()
 	fwrite($JUNIT['fp'], $xml);
 }
 
-function junit_get_suite_xml($suite_name = '')
+function junit_get_suite_xml(string $suite_name = ''): string
 {
 	global $JUNIT;
 
@@ -2824,7 +2826,7 @@ function junit_get_suite_xml($suite_name = '')
 	return $result;
 }
 
-function junit_enabled()
+function junit_enabled(): bool
 {
 	global $JUNIT;
 	return !empty($JUNIT);
@@ -2832,14 +2834,10 @@ function junit_enabled()
 
 /**
  * @param array|string $type
- * @param string $file_name
- * @param string $test_name
  * @param int|string $time
- * @param string $message
- * @param string $details
  * @return void
  */
-function junit_mark_test_as($type, $file_name, $test_name, $time = null, $message = '', $details = '')
+function junit_mark_test_as($type, string $file_name, string $test_name, $time = null, string $message = '', string $details = ''): void
 {
 	global $JUNIT;
 	if (!junit_enabled()) return;
@@ -2891,7 +2889,7 @@ function junit_mark_test_as($type, $file_name, $test_name, $time = null, $messag
 
 }
 
-function junit_suite_record($suite, $param, $value = 1)
+function junit_suite_record($suite, string $param, int $value = 1): void
 {
 	global $JUNIT;
 
@@ -2899,6 +2897,9 @@ function junit_suite_record($suite, $param, $value = 1)
 	$JUNIT['suites'][$suite][$param] += $value;
 }
 
+/**
+ * @return int|string
+ */
 function junit_get_timer($file_name)
 {
 	global $JUNIT;
@@ -2911,7 +2912,7 @@ function junit_get_timer($file_name)
 	return 0;
 }
 
-function junit_start_timer($file_name)
+function junit_start_timer(string $file_name): void
 {
 	global $JUNIT;
 	if (!junit_enabled()) return;
@@ -2925,14 +2926,14 @@ function junit_start_timer($file_name)
 	}
 }
 
-function junit_get_suitename_for($file_name)
+function junit_get_suitename_for(string $file_name): string
 {
 	return junit_path_to_classname(dirname($file_name));
 }
 
-function junit_path_to_classname($file_name)
+function junit_path_to_classname(string $file_name): string
 {
-	global $JUNIT;
+    global $JUNIT;
 
 	$ret = $JUNIT['name'];
 	$_tmp = array();
@@ -2962,7 +2963,7 @@ function junit_path_to_classname($file_name)
 	return $JUNIT['name'] . '.' . str_replace(array(DIRECTORY_SEPARATOR, '-'), '.', $file_name);
 }
 
-function junit_init_suite($suite_name)
+function junit_init_suite(string $suite_name): void
 {
 	global $JUNIT;
 	if (!junit_enabled()) return;
@@ -2984,7 +2985,7 @@ function junit_init_suite($suite_name)
 	);
 }
 
-function junit_finish_timer($file_name)
+function junit_finish_timer(string $file_name): void
 {
 	global $JUNIT;
 	if (!junit_enabled()) return;
@@ -3009,12 +3010,12 @@ class RuntestsValgrind
 	protected $version_3_3_0 = false;
 	protected $version_3_8_0 = false;
 
-	public function getVersion()
+	public function getVersion(): string
 	{
 		return $this->version;
 	}
 
-	public function getHeader()
+	public function getHeader(): string
 	{
 		return $this->header;
 	}
@@ -3036,7 +3037,7 @@ class RuntestsValgrind
 		$this->version_3_8_0 = version_compare($version, '3.8.0', '>=');
 	}
 
-	public function wrapCommand($cmd, $memcheck_filename, $check_all)
+	public function wrapCommand(string $cmd, string $memcheck_filename, bool $check_all): string
 	{
 		$vcmd = 'valgrind -q --tool=memcheck --trace-children=yes';
 		if ($check_all) {


### PR DESCRIPTION
This patch introduces some strictness to our Tests BlackBox: `run-tests.php`. If this patch gets accepted, I'd like to introduce to the other ones we have.

TODO list:
- [x] Use `===` over `==`
- [ ] Use param/return types
- [ ] Use `declare(strict_types=1)`
- [ ] Use the `$strict` parameter in function like `in_array`, `array_search`, `base64_decode`, etc 
- [ ] Improve `if` checks, instead of just `if ($foo)` or `if (!$foo)`