### PR TITLE
SQLite3: add DEFENSIVE config option for SQLite >= 3.26.0

### DIFF
--- a/ext/sqlite3/php_sqlite3.h
+++ b/ext/sqlite3/php_sqlite3.h
@@ -26,6 +26,7 @@ extern zend_module_entry sqlite3_module_entry;
 
 ZEND_BEGIN_MODULE_GLOBALS(sqlite3)
 	char *extension_dir;
+	int dbconfig_defensive;
 ZEND_END_MODULE_GLOBALS(sqlite3)
 
 #ifdef ZTS

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -79,6 +79,9 @@ static void php_sqlite3_error(php_sqlite3_db_object *db_obj, char *format, ...)
 */
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("sqlite3.extension_dir",  NULL, PHP_INI_SYSTEM, OnUpdateString, extension_dir, zend_sqlite3_globals, sqlite3_globals)
+#if SQLITE_VERSION_NUMBER >= 3026000
+	STD_PHP_INI_ENTRY("sqlite3.defensive",  "1", PHP_INI_SYSTEM, OnUpdateBool, dbconfig_defensive, zend_sqlite3_globals, sqlite3_globals)
+#endif
 PHP_INI_END()
 /* }}} */
 
@@ -159,6 +162,12 @@ PHP_METHOD(sqlite3, open)
 	if (PG(open_basedir) && *PG(open_basedir)) {
 		sqlite3_set_authorizer(db_obj->db, php_sqlite3_authorizer, NULL);
 	}
+
+#if SQLITE_VERSION_NUMBER >= 3026000
+	if (SQLITE3G(dbconfig_defensive)) {
+		sqlite3_db_config(db_obj->db, SQLITE_DBCONFIG_DEFENSIVE, 1, NULL);
+	}
+#endif
 
 	if (fullpath != filename) {
 		efree(fullpath);

--- a/ext/sqlite3/tests/sqlite3_defensive.phpt
+++ b/ext/sqlite3/tests/sqlite3_defensive.phpt
@@ -1,0 +1,40 @@
+--TEST--
+SQLite3 defensive mode ini setting
+--SKIPIF--
+<?php require_once(__DIR__ . '/skipif.inc');
+
+if (SQLite3::version()['versionNumber'] < 3026000) {
+	die("skip: sqlite3 library version < 3.26: no support for defensive mode");
+}
+
+?>
+--INI--
+sqlite3.defensive=On
+--FILE--
+<?php
+
+$db = new SQLite3(':memory:');
+var_dump($db->exec('CREATE TABLE test (a, b);'));
+
+// This does not generate an error!
+var_dump($db->exec('PRAGMA writable_schema = ON;'));
+var_dump($db->querySingle('PRAGMA writable_schema;'));
+
+// Should be 1
+var_dump($db->querySingle('SELECT COUNT(*) FROM sqlite_master;'));
+
+// Should generate an error!
+var_dump($db->querySingle('DELETE FROM sqlite_master;'));
+
+// Should still be 1
+var_dump($db->querySingle('SELECT COUNT(*) FROM sqlite_master;'));
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+int(1)
+int(1)
+
+Warning: SQLite3::querySingle(): Unable to prepare statement: 1, table sqlite_master may not be modified in %s on line %d
+bool(false)
+int(1)

--- a/php.ini-development
+++ b/php.ini-development
@@ -996,7 +996,18 @@ cli_server.color = On
 ;intl.use_exceptions = 0
 
 [sqlite3]
+; Directory pointing to SQLite3 extensions
+; http://php.net/manual/en/sqlite3.loadextension.php
 ;sqlite3.extension_dir =
+
+; SQLite defensive mode flag (only available from SQLite 3.26+)
+; When the defensive flag is enabled, language features that allow ordinary
+; SQL to deliberately corrupt the database file are disabled. This forbids
+; writing directly to the schema, shadow tables (eg. FTS data tables), or
+; the sqlite_dbpage virtual table.
+; https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
+; (for older SQLite versions, this flag has no use)
+sqlite3.defensive = 1
 
 [Pcre]
 ; PCRE library backtracking limit.

--- a/php.ini-production
+++ b/php.ini-production
@@ -996,7 +996,18 @@ cli_server.color = On
 ;intl.use_exceptions = 0
 
 [sqlite3]
+; Directory pointing to SQLite3 extensions
+; http://php.net/manual/en/sqlite3.loadextension.php
 ;sqlite3.extension_dir =
+
+; SQLite defensive mode flag (only available from SQLite 3.26+)
+; When the defensive flag is enabled, language features that allow ordinary
+; SQL to deliberately corrupt the database file are disabled. This forbids
+; writing directly to the schema, shadow tables (eg. FTS data tables), or
+; the sqlite_dbpage virtual table.
+; https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
+; (for older SQLite versions, this flag has no use)
+sqlite3.defensive = 1
 
 [Pcre]
 ; PCRE library backtracking limit.


### PR DESCRIPTION
This is a new option, available in SQLite starting from 3.26.0 that is meant to prevent any corruption of the database file that could come from arbitrary crafted SQL queries.

From the SQLite doc:
> When the defensive flag is enabled, language features that allow ordinary SQL to deliberately corrupt the database file are disabled. The disabled features include but are not limited to the following:
> -    The PRAGMA writable_schema=ON statement.
> -    Writes to the sqlite_dbpage virtual table.
> -    Direct writes to shadow tables. 

https://www.sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigdefensive

Please note that this could potentially cause BC-breaks if code was writing to sqlite_dbpage, the schema or shadow tables. It is quite unlikely that any PHP code would do that kind of thing IMHO, and if it does I don't think it should be allowed by default.

! BUT another case where it might break things is if you had exported a backup of the DB with SQL statements that would rewrite to the shadow tables. This would be the case for example for database management tools, eg. PHPLiteAdmin. In that case it might be suitable to find a different solution, eg. adding an extra param to the open method to allow disabling the defensive mode. This is open to discussion, if anyone has a better idea I'll try to find some free time to do another PR :)

Also, it is likely that the recent RCE in SQLite is due to users being able to write to shadow tables. See https://news.ycombinator.com/item?id=18685296