### PR TITLE
fix #77298 segfault occurs when add property to unserialized empty ArrayObject

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1842,7 +1842,8 @@ SPL_METHOD(Array, unserialize)
 
 		if (Z_TYPE_P(array) == IS_ARRAY) {
 			zval_ptr_dtor(&intern->array);
-			ZVAL_COPY(&intern->array, array);
+			ZVAL_COPY_VALUE(&intern->array, array);
+			ZVAL_NULL(array);
 			SEPARATE_ARRAY(&intern->array);
 		} else {
 			spl_array_set_array(object, intern, array, 0L, 1);

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -91,7 +91,6 @@ static inline HashTable **spl_array_get_hash_table_ptr(spl_array_object* intern)
 		spl_array_object *other = Z_SPLARRAY_P(&intern->array);
 		return spl_array_get_hash_table_ptr(other);
 	} else if (Z_TYPE(intern->array) == IS_ARRAY) {
-		SEPARATE_ARRAY(&intern->array);
 		return &Z_ARRVAL(intern->array);
 	} else {
 		zend_object *obj = Z_OBJ(intern->array);
@@ -1844,6 +1843,7 @@ SPL_METHOD(Array, unserialize)
 		if (Z_TYPE_P(array) == IS_ARRAY) {
 			zval_ptr_dtor(&intern->array);
 			ZVAL_COPY(&intern->array, array);
+			SEPARATE_ARRAY(&intern->array);
 		} else {
 			spl_array_set_array(object, intern, array, 0L, 1);
 		}

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -91,6 +91,7 @@ static inline HashTable **spl_array_get_hash_table_ptr(spl_array_object* intern)
 		spl_array_object *other = Z_SPLARRAY_P(&intern->array);
 		return spl_array_get_hash_table_ptr(other);
 	} else if (Z_TYPE(intern->array) == IS_ARRAY) {
+		SEPARATE_ARRAY(&intern->array);
 		return &Z_ARRVAL(intern->array);
 	} else {
 		zend_object *obj = Z_OBJ(intern->array);

--- a/ext/spl/tests/bug77298.phpt
+++ b/ext/spl/tests/bug77298.phpt
@@ -6,11 +6,23 @@ $o = new ArrayObject();
 $o2 = unserialize(serialize($o));
 $o2[1]=123;
 var_dump($o2);
+
+$o3 = new ArrayObject();
+$o3->unserialize($o->serialize());
+$o3['xm']=456;
+var_dump($o3);
 --EXPECT--
 object(ArrayObject)#2 (1) {
   ["storage":"ArrayObject":private]=>
   array(1) {
     [1]=>
     int(123)
+  }
+}
+object(ArrayObject)#3 (1) {
+  ["storage":"ArrayObject":private]=>
+  array(1) {
+    ["xm"]=>
+    int(456)
   }
 }

--- a/ext/spl/tests/bug77298.phpt
+++ b/ext/spl/tests/bug77298.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #77298 	segfault occurs when add property to unserialized ArrayObject
+--FILE--
+<?php
+$o = new ArrayObject();
+$o2 = unserialize(serialize($o));
+$o2[1]=123;
+var_dump($o2);
+--EXPECT--
+object(ArrayObject)#2 (1) {
+  ["storage":"ArrayObject":private]=>
+  array(1) {
+    [1]=>
+    int(123)
+  }
+}


### PR DESCRIPTION
9cf87aa1965504b1cd9dc595a3c6af418a416cfc brings `zend_empty_array`, whose gc.refcount is 2, when unserialize a string representing empty array (`"a:0:{}"`), and leads to `HT_ASSERT_RC1` failure.

to be honest I don't think it's a good fix, since `spl_array_get_hash_table` is very common used in `ArrayObject`, and `SEPARATE_ARRAY` will check gc_refcount everytime, the overhead may defeat the benfit of using `zend_empty_array`. Another possible solution is we can do `SEPARATE_ARRAY` in `ArrayObject::unserialize`, which defeats the purpose of `zend_empty_array` as well.