### PR TITLE
Make more tests run os MacOS

### DIFF
--- a/ext/standard/tests/file/symlink_link_linkinfo_is_link_variation6.phpt
+++ b/ext/standard/tests/file/symlink_link_linkinfo_is_link_variation6.phpt
@@ -5,9 +5,6 @@ Test symlink(), linkinfo(), link() and is_link() functions : usage variations - 
 if ( substr(PHP_OS, 0, 3) == 'WIN' ) {
     die('skip no symlinks on Windows');
 }
-if ( substr(PHP_OS, 0, 3) == 'MAC' ) {
-    die('skip Not valid for MacOS');
-}
 
 // Skip if being run by root (files are always readable, writeable and executable)
 $filename = dirname(__FILE__)."/symlink_link_linkinfo_is_link6_check_root.tmp";

--- a/ext/standard/tests/general_functions/getservbyname_variation10.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation10.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test function getservbyname() by substituting argument 2 with emptyUnsetUndefNull values.
---SKIPIF--
-<?php
-if(PHP_OS == 'Darwin') {
-  die("skip.. Mac OS X is fine with NULLs in getservbyname");
-}
-?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyname_variation9.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_variation9.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test function getservbyname() by substituting argument 2 with boolean values.
---SKIPIF--
-<?php
-if(PHP_OS == 'Darwin') {
-  die("skip.. Mac OS X is fine with NULLs in getservbyname");
-}
-?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/gettype_settype_variation2.phpt
+++ b/ext/standard/tests/general_functions/gettype_settype_variation2.phpt
@@ -3,10 +3,11 @@ Test gettype() & settype() functions : usage variations
 --SKIPIF--
 <?php
 if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only");
-?>
-if ( strtoupper( substr(PHP_OS, 0, 3) ) == 'MAC' ) {
+
+if (PHP_OS_FAMILY === 'Darwin') {
     die('skip Do not run on MacOS');
 }
+?>
 --INI--
 precision=14
 --FILE--

--- a/ext/standard/tests/math/ceil_basic.phpt
+++ b/ext/standard/tests/math/ceil_basic.phpt
@@ -2,10 +2,6 @@
 Test ceil() - basic function test for ceil()
 --INI--
 precision=14
---SKIPIF--
-if (strtolower(PHP_OS) == 'darwin') {
-    die('SKIP OSX does weird things with -0 so this test doesn't work there');
-}
 --FILE--
 <?php
 /* Prototype  : float ceil  ( float $value  )

--- a/ext/standard/tests/misc/time_nanosleep_error3.phpt
+++ b/ext/standard/tests/misc/time_nanosleep_error3.phpt
@@ -2,7 +2,6 @@
 time_nanosleep — Delay for a number of seconds and nanoseconds
 --SKIPIF--
 <?php
-if (strpos(strtoupper(PHP_OS), 'WIN') !== false) die("skip Test is not valid for Windows");
 if (!function_exists('time_nanosleep')) die("skip");
 ?>
 --CREDITS--


### PR DESCRIPTION
Following #3417, as well #3416.

Looks like the logic we have to figure out if the OS has support to IPv6 does not work on MacOS. For example: the `ext/standard/tests/network/tcp6loop.phpt` test **does** work on MacOS, but due to the logic:
```php
@stream_socket_client('tcp://[::1]:0', $errno);
if ($errno != 111) die('skip IPv6 not supported.');
```

the test is skipped. I didn't come up with a solution for that, so, if someone could help me.

Also, some tests that aren't running on MacOS, but I'll try to fix the implementation or report them as a bug 😊 