### PR TITLE
Fixed bug #77335 (SA_RESTART despite SIGALRM unless no restart)

### DIFF
--- a/ext/pcntl/php_signal.c
+++ b/ext/pcntl/php_signal.c
@@ -43,7 +43,7 @@ Sigfunc *php_signal4(int signo, Sigfunc *func, int restart, int mask_all)
 #ifdef HAVE_STRUCT_SIGINFO_T
 	act.sa_flags |= SA_SIGINFO;
 #endif
-	if (signo == SIGALRM || (! restart)) {
+	if (signo == SIGALRM && (! restart)) {
 #ifdef SA_INTERRUPT
 		act.sa_flags |= SA_INTERRUPT; /* SunOS */
 #endif


### PR DESCRIPTION
For details please refer to [bug report 77335](https://bugs.php.net/patch-display.php?bug=77335&patch=php_signal_diff.log&revision=1545417798)