### PR TITLE
Fixed bug #77326 (ReflectionClass::getReflectionConstant() returns false instead of exception)

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -4436,7 +4436,10 @@ ZEND_METHOD(reflection_class, getReflectionConstant)
 	}
 
 	if ((constant = zend_hash_find_ptr(&ce->constants_table, name)) == NULL) {
-		RETURN_FALSE;
+		zend_throw_exception_ex(reflection_exception_ptr, 0,
+			"Constant %s::%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+		zval_dtor(return_value);
+		RETURN_NULL();
 	}
 	reflection_class_constant_factory(ce, name, constant, return_value);
 }

--- a/ext/reflection/tests/bug77326.phpt
+++ b/ext/reflection/tests/bug77326.phpt
@@ -1,0 +1,20 @@
+--TEST--
+ReflectionClass::getReflectionConstant()
+--CREDITS--
+Yanlong He <yanlong.hee@gmail.com>
+--FILE--
+<?php
+class C {
+}
+
+$rc = new ReflectionClass('C');
+try {
+	var_dump($rc->getReflectionConstant("XXX"));
+} catch (Exception $e) {
+	echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECTF--
+Constant C::XXX does not exist
+NULL


### PR DESCRIPTION
For details please refer to [ bug report 77326](https://bugs.php.net/bug.php?id=77326)