### PR TITLE
Allow strings and filenames in openssl_csr_export and openssl_csr_export_to_file

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3319,7 +3319,7 @@ static X509_REQ * php_openssl_csr_from_zval(zval * val, int makeresource, zend_r
 }
 /* }}} */
 
-/* {{{ proto bool openssl_csr_export_to_file(resource csr, string outfilename [, bool notext=true])
+/* {{{ proto bool openssl_csr_export_to_file(mixed csr, string outfilename [, bool notext=true])
    Exports a CSR to file */
 PHP_FUNCTION(openssl_csr_export_to_file)
 {
@@ -3331,7 +3331,7 @@ PHP_FUNCTION(openssl_csr_export_to_file)
 	BIO * bio_out;
 	zend_resource *csr_resource;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rp|b", &zcsr, &filename, &filename_len, &notext) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zp|b", &zcsr, &filename, &filename_len, &notext) == FAILURE) {
 		return;
 	}
 	RETVAL_FALSE;
@@ -3369,7 +3369,7 @@ PHP_FUNCTION(openssl_csr_export_to_file)
 }
 /* }}} */
 
-/* {{{ proto bool openssl_csr_export(resource csr, string &out [, bool notext=true])
+/* {{{ proto bool openssl_csr_export(mixed csr, string &out [, bool notext=true])
    Exports a CSR to file or a var */
 PHP_FUNCTION(openssl_csr_export)
 {
@@ -3379,7 +3379,7 @@ PHP_FUNCTION(openssl_csr_export)
 	BIO * bio_out;
 	zend_resource *csr_resource;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rz/|b", &zcsr, &zout, &notext) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz/|b", &zcsr, &zout, &notext) == FAILURE) {
 		return;
 	}
 

--- a/ext/openssl/tests/openssl_csr_export_bacis.phpt
+++ b/ext/openssl/tests/openssl_csr_export_bacis.phpt
@@ -31,18 +31,20 @@ var_dump(openssl_csr_export($wrong, $output));
 var_dump(openssl_csr_export($privkey, $output));
 var_dump(openssl_csr_export(array(), $output));
 var_dump(openssl_csr_export($csr, $output, false));
+var_dump(openssl_csr_export($output, $output2));
 ?>
 --EXPECTF--
 bool(true)
 
-Warning: openssl_csr_export() expects parameter 1 to be resource, string given in %s on line %d
-NULL
+Warning: openssl_csr_export(): cannot get CSR from parameter 1 in %s on line %d
+bool(false)
 
 Warning: openssl_csr_export(): supplied resource is not a valid OpenSSL X.509 CSR resource in %s on line %d
 
 Warning: openssl_csr_export(): cannot get CSR from parameter 1 in %s on line %d
 bool(false)
 
-Warning: openssl_csr_export() expects parameter 1 to be resource, array given in %s on line %d
-NULL
+Warning: openssl_csr_export(): cannot get CSR from parameter 1 in %s on line %d
+bool(false)
+bool(true)
 bool(true)

--- a/ext/openssl/tests/openssl_csr_export_to_file_basic.phpt
+++ b/ext/openssl/tests/openssl_csr_export_to_file_basic.phpt
@@ -40,6 +40,8 @@ var_dump(openssl_csr_export_to_file($wrong, $csrfile));
 var_dump(openssl_csr_export_to_file($dh, $csrfile));
 var_dump(openssl_csr_export_to_file(array(), $csrfile));
 var_dump(openssl_csr_export_to_file($csr, $csrfile, false));
+var_dump(openssl_csr_export_to_file('file://'.$csrfile, $csrfile));
+var_dump(openssl_csr_export_to_file(file_get_contents($csrfile), $csrfile));
 ?>
 --CLEAN--
 <?php
@@ -70,14 +72,16 @@ JViHkCA9x6m8RJXAFvqmgLlWlUzbDv/cRrDfjWjR
 -----END CERTIFICATE REQUEST-----
 "
 
-Warning: openssl_csr_export_to_file() expects parameter 1 to be resource, string given in %s on line %d
-NULL
+Warning: openssl_csr_export_to_file(): cannot get CSR from parameter 1 in %s on line %d
+bool(false)
 
 Warning: openssl_csr_export_to_file(): supplied resource is not a valid OpenSSL X.509 CSR resource in %s on line %d
 
 Warning: openssl_csr_export_to_file(): cannot get CSR from parameter 1 in %s on line %d
 bool(false)
 
-Warning: openssl_csr_export_to_file() expects parameter 1 to be resource, array given in %s on line %d
-NULL
+Warning: openssl_csr_export_to_file(): cannot get CSR from parameter 1 in %s on line %d
+bool(false)
+bool(true)
+bool(true)
 bool(true)


### PR DESCRIPTION
The manual describe that you can use a resource from openssl_csr_new(), a string or a filename in the fuctions openssl_csr_export and openssl_csr_export_to_file. This is not true as it only accepts a resource from openssl_csr_new().

Expected: bool openssl_csr_export(mixed $csr , string &$out [, bool $notext = TRUE ] )
Current: bool openssl_csr_export(resource $csr , string &$out [, bool $notext = TRUE ] )
http://php.net/manual/en/function.openssl-csr-export-to-file.php

Expected: bool openssl_csr_export_to_file(mixed $csr , string $outfilename [, bool $notext = TRUE ] )
Current: bool openssl_csr_export_to_file(resource $csr , string $outfilename [, bool $notext = TRUE ] )
http://php.net/manual/en/function.openssl-csr-export.php

You cannot use the following functions with a resource as the first argument, if the csr is created from another script before:

* openssl_csr_get_public_key
* openssl_csr_get_subject
* openssl_csr_sign
