### PR TITLE
Fix bug #77361 (configure fails on 64-bit AIX when opcache enabled)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,10 @@ PHP                                                                        NEWS
   . Fixed bug #75684 (In mysqlnd_ext_plugin.h the plugin methods family has
     no external visibility). (Anatol)
 
+- Opcache:
+  . Fix bug #77361 (configure fails on 64-bit AIX when opcache enabled).
+    (Kevin Adler)
+
 - PDO:
   . Fixed bug #77273 (array_walk_recursive corrupts value types leading to PDO
     failure). (Nikita)

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -90,23 +90,9 @@
 #ifndef ZEND_WIN32
 extern int lock_file;
 
-# if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || (defined(__APPLE__) && defined(__MACH__)/* Darwin */) || defined(__OpenBSD__) || defined(__NetBSD__)
+# if defined(HAVE_FLOCK_AIX64)
 #  define FLOCK_STRUCTURE(name, type, whence, start, len) \
-		struct flock name = {start, len, -1, type, whence}
-# elif defined(__svr4__)
-#  define FLOCK_STRUCTURE(name, type, whence, start, len) \
-		struct flock name = {type, whence, start, len}
-# elif defined(__linux__) || defined(__hpux) || defined(__GNU__)
-#  define FLOCK_STRUCTURE(name, type, whence, start, len) \
-		struct flock name = {type, whence, start, len, 0}
-# elif defined(_AIX)
-#  if defined(_LARGE_FILES) || defined(__64BIT__)
-#   define FLOCK_STRUCTURE(name, type, whence, start, len) \
 		struct flock name = {type, whence, 0, 0, 0, start, len }
-#  else
-#   define FLOCK_STRUCTURE(name, type, whence, start, len) \
-		struct flock name = {type, whence, start, len}
-#  endif
 # elif defined(HAVE_FLOCK_BSD)
 #  define FLOCK_STRUCTURE(name, type, whence, start, len) \
 		struct flock name = {start, len, -1, type, whence}


### PR DESCRIPTION
In f904830, support for GNU Hurd was added to the opcache and the configure check to ensure the opcache knows the flock struct layout prior to building was changed to check for two cases: BSD layout and Linux layout. All the existing hard-coded cases in ZendAccelerator.h follow these two cases, except for 64-bit AIX. This means that even though building on 64-bit AIX would work, the configure script refuses to continue.

Add a new configure check for the 64-bit AIX case and a new compiler definition HAVE_FLOCK_AIX64. Now that all the cases are covered, simplify the ifdef logic around these three HAVE_FLOCK_* macros:
- The macOS and the various BSD flavors fall under HAVE_FLOCK_BSD
- Linux, HP-UX, GNU Hurd, 32-bit AIX, and SVR4 environments fall under HAVE_FLOCK_LINUX
- 64-bit AIX falls under HAVE_FLOCK_AIX64

The only difference between the existing HAVE_FLOCK_LINUX and the hard-coded Linux/HP-UX/Hurd case is that the latter initialized the 5th member to 0, but since the C standard already says that un-initialized members will be initialized to 0, it's effectively the same.