### PR TITLE
Drop deprecated /Gm compile option

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3372,7 +3372,7 @@ function toolset_setup_common_libs()
 function toolset_setup_build_mode()
 {
 	if (PHP_DEBUG == "yes") {
-		ADD_FLAG("CFLAGS", "/LDd /MDd /W3 /Gm /Od /D _DEBUG /D ZEND_DEBUG=1 " +
+		ADD_FLAG("CFLAGS", "/LDd /MDd /W3 /Od /D _DEBUG /D ZEND_DEBUG=1 " +
 			(X64?"/Zi":"/ZI"));
 		ADD_FLAG("LDFLAGS", "/debug");
 		// Avoid problems when linking to release libraries that use the release


### PR DESCRIPTION
The `/Gm` option of `cl` is deprecated[1], and `cl` claims that it will
be removed in the future, so we're dropping it right away.

[1] <https://docs.microsoft.com/en-us/cpp/build/reference/gm-enable-minimal-rebuild?view=vs-2017>