### PR TITLE
Allow strip_tags with an array of allowed tagnames

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4783,6 +4783,7 @@ PHP_FUNCTION(strip_tags)
 	zval *allow=NULL;
 	const char *allowed_tags=NULL;
 	size_t allowed_tags_len=0;
+	smart_str tags_ss = {0};
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR(str)
@@ -4792,22 +4793,21 @@ PHP_FUNCTION(strip_tags)
 
 	if (allow) {
 		if (Z_TYPE_P(allow) == IS_ARRAY) {
-			smart_str tags_ss = {0};
 			zval *tmp;
+			zend_string *tag;
 
 			smart_str_alloc(&tags_ss, 0, 0);
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(allow), tmp) {
-				convert_to_string_ex(tmp);
+				tag = zval_get_string(tmp);
 				smart_str_appendc(&tags_ss, '<');
-				smart_str_append(&tags_ss, Z_STR_P(tmp));
+				smart_str_append(&tags_ss, tag);
 				smart_str_appendc(&tags_ss, '>');
+				zend_string_release(tag);
 			} ZEND_HASH_FOREACH_END();
 			smart_str_0(&tags_ss);
 			allowed_tags = ZSTR_VAL(tags_ss.s);
 			allowed_tags_len = ZSTR_LEN(tags_ss.s);
-			smart_str_free(&tags_ss);
-		}
-		else {
+		} else {
 			/* To maintain a certain BC, we allow anything for the second parameter and return original string */
 			convert_to_string(allow);
 			allowed_tags = Z_STRVAL_P(allow);
@@ -4817,6 +4817,7 @@ PHP_FUNCTION(strip_tags)
 
 	buf = zend_string_init(ZSTR_VAL(str), ZSTR_LEN(str), 0);
 	ZSTR_LEN(buf) = php_strip_tags_ex(ZSTR_VAL(buf), ZSTR_LEN(str), NULL, allowed_tags, allowed_tags_len, 0);
+	smart_str_free(&tags_ss);
 	RETURN_NEW_STR(buf);
 }
 /* }}} */

--- a/ext/standard/tests/strings/strip_tags_array.phpt
+++ b/ext/standard/tests/strings/strip_tags_array.phpt
@@ -8,7 +8,10 @@ var_dump(strip_tags($string));
 var_dump(strip_tags($string, ['a']));
 var_dump(strip_tags($string, ['p', 'a']));
 var_dump(strip_tags($string, []));
+var_dump(strip_tags($string, ['p' => true, 'a' => false]));
+var_dump(strip_tags($string, ['p' => 'a']));
 
+// Previous tests from strip_tags_variation2.phpt
 var_dump(strip_tags($string, [0]));
 var_dump(strip_tags($string, [1]));
 var_dump(strip_tags($string, [1, 2]));
@@ -20,6 +23,8 @@ string(14) "foo bar foobar"
 string(30) "foo bar <a href="#">foobar</a>"
 string(37) "<p>foo bar <a href="#">foobar</a></p>"
 string(14) "foo bar foobar"
+string(14) "foo bar foobar"
+string(30) "foo bar <a href="#">foobar</a>"
 string(14) "foo bar foobar"
 string(14) "foo bar foobar"
 string(14) "foo bar foobar"

--- a/ext/standard/tests/strings/strip_tags_array.phpt
+++ b/ext/standard/tests/strings/strip_tags_array.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test strip_tags() function : basic functionality - with array argument
+--FILE--
+<?php
+
+$string = '<p>foo <b>bar</b> <a href="#">foobar</a></p>';
+var_dump(strip_tags($string));
+var_dump(strip_tags($string, ['a']));
+var_dump(strip_tags($string, ['p', 'a']));
+var_dump(strip_tags($string, []));
+
+var_dump(strip_tags($string, [0]));
+var_dump(strip_tags($string, [1]));
+var_dump(strip_tags($string, [1, 2]));
+var_dump(strip_tags($string, ['color' => 'red', 'item' => 'pen']));
+echo "Done";
+?>
+--EXPECT--
+string(14) "foo bar foobar"
+string(30) "foo bar <a href="#">foobar</a>"
+string(37) "<p>foo bar <a href="#">foobar</a></p>"
+string(14) "foo bar foobar"
+string(14) "foo bar foobar"
+string(14) "foo bar foobar"
+string(14) "foo bar foobar"
+string(14) "foo bar foobar"
+Done

--- a/ext/standard/tests/strings/strip_tags_variation2.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation2.phpt
@@ -48,13 +48,6 @@ $values = array(
       10.6E-10,
       .5,
 
-      // array data
-      array(),
-      array(0),
-      array(1),
-      array(1, 2),
-      array('color' => 'red', 'item' => 'pen'),
-
       // null data
       NULL,
       null,
@@ -113,24 +106,14 @@ string(10) "helloworld"
 -- Iteration 9 --
 string(10) "helloworld"
 -- Iteration 10 --
-
-Notice: Array to string conversion in %s on line %d
 string(10) "helloworld"
 -- Iteration 11 --
-
-Notice: Array to string conversion in %s on line %d
 string(10) "helloworld"
 -- Iteration 12 --
-
-Notice: Array to string conversion in %s on line %d
 string(10) "helloworld"
 -- Iteration 13 --
-
-Notice: Array to string conversion in %s on line %d
 string(10) "helloworld"
 -- Iteration 14 --
-
-Notice: Array to string conversion in %s on line %d
 string(10) "helloworld"
 -- Iteration 15 --
 string(10) "helloworld"
@@ -145,15 +128,5 @@ string(10) "helloworld"
 -- Iteration 20 --
 string(10) "helloworld"
 -- Iteration 21 --
-string(10) "helloworld"
--- Iteration 22 --
-string(10) "helloworld"
--- Iteration 23 --
-string(10) "helloworld"
--- Iteration 24 --
-string(10) "helloworld"
--- Iteration 25 --
-string(10) "helloworld"
--- Iteration 26 --
 string(10) "helloworld"
 Done


### PR DESCRIPTION
Allow an array of tag names as the second argument.

    strip_tags('foo <br /> bar <b><a href="#"><i>foobar</i></a></b>', ['i', 'b']);
