### PR TITLE
use the current directory as default for ftp_nlist, ftp_rawlist and ftp_mlsd

### DIFF
--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -699,16 +699,16 @@ PHP_FUNCTION(ftp_alloc)
 }
 /* }}} */
 
-/* {{{ proto array ftp_nlist(resource stream, string directory)
+/* {{{ proto array ftp_nlist(resource stream [, string directory = "."])
    Returns an array of filenames in the given directory */
 PHP_FUNCTION(ftp_nlist)
 {
 	zval		*z_ftp;
 	ftpbuf_t	*ftp;
-	char		**nlist, **ptr, *dir;
-	size_t		dir_len;
+	char		**nlist, **ptr, *dir = ".";
+	size_t		dir_len = sizeof(dir);
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rp", &z_ftp, &dir, &dir_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|p", &z_ftp, &dir, &dir_len) == FAILURE) {
 		return;
 	}
 
@@ -729,17 +729,17 @@ PHP_FUNCTION(ftp_nlist)
 }
 /* }}} */
 
-/* {{{ proto array ftp_rawlist(resource stream, string directory [, bool recursive])
+/* {{{ proto array ftp_rawlist(resource stream [, string directory = "." [, bool recursive]])
    Returns a detailed listing of a directory as an array of output lines */
 PHP_FUNCTION(ftp_rawlist)
 {
 	zval		*z_ftp;
 	ftpbuf_t	*ftp;
-	char		**llist, **ptr, *dir;
-	size_t		dir_len;
+	char		**llist, **ptr, *dir = ".";
+	size_t		dir_len = sizeof(dir);
 	zend_bool	recursive = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs|b", &z_ftp, &dir, &dir_len, &recursive) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|sb", &z_ftp, &dir, &dir_len, &recursive) == FAILURE) {
 		return;
 	}
 
@@ -760,17 +760,17 @@ PHP_FUNCTION(ftp_rawlist)
 }
 /* }}} */
 
-/* {{{ proto array ftp_mlsd(resource stream, string directory)
+/* {{{ proto array ftp_mlsd(resource stream [, string directory = "."])
    Returns a detailed listing of a directory as an array of parsed output lines */
 PHP_FUNCTION(ftp_mlsd)
 {
 	zval		*z_ftp;
 	ftpbuf_t	*ftp;
-	char		**llist, **ptr, *dir;
-	size_t		dir_len;
+	char		**llist, **ptr, *dir = ".";
+	size_t		dir_len = sizeof(dir);
 	zval		entry;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &z_ftp, &dir, &dir_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|s", &z_ftp, &dir, &dir_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/ftp/tests/ftp_mlsd_cwd.phpt
+++ b/ext/ftp/tests/ftp_mlsd_cwd.phpt
@@ -1,0 +1,97 @@
+--TEST--
+ftp_mlsd() without the optional parameter $directory (defaults to ".")
+--SKIPIF--
+<?php
+require 'skipif.inc';
+?>
+--FILE--
+<?php
+require 'server.inc';
+
+$ftp = ftp_connect('127.0.0.1', $port);
+if (!$ftp) die("Couldn't connect to the server");
+
+var_dump(ftp_login($ftp, 'user', 'pass'));
+
+var_dump(ftp_mlsd($ftp));
+
+ftp_close($ftp);
+?>
+--EXPECTF--
+bool(true)
+
+Warning: ftp_mlsd(): Missing pathname in MLSD response in %s on line %d
+
+Warning: ftp_mlsd(): Malformed fact in MLSD response in %s on line %d
+
+Warning: ftp_mlsd(): Malformed fact in MLSD response in %s on line %d
+array(4) {
+  [0]=>
+  array(8) {
+    ["name"]=>
+    string(1) "."
+    ["modify"]=>
+    string(14) "20170127230002"
+    ["perm"]=>
+    string(7) "flcdmpe"
+    ["type"]=>
+    string(4) "cdir"
+    ["unique"]=>
+    string(11) "811U4340002"
+    ["UNIX.group"]=>
+    string(2) "33"
+    ["UNIX.mode"]=>
+    string(4) "0755"
+    ["UNIX.owner"]=>
+    string(2) "33"
+  }
+  [1]=>
+  array(8) {
+    ["name"]=>
+    string(2) ".."
+    ["modify"]=>
+    string(14) "20170127230002"
+    ["perm"]=>
+    string(7) "flcdmpe"
+    ["type"]=>
+    string(4) "pdir"
+    ["unique"]=>
+    string(11) "811U4340002"
+    ["UNIX.group"]=>
+    string(2) "33"
+    ["UNIX.mode"]=>
+    string(4) "0755"
+    ["UNIX.owner"]=>
+    string(2) "33"
+  }
+  [2]=>
+  array(9) {
+    ["name"]=>
+    string(6) "foobar"
+    ["modify"]=>
+    string(14) "20170126121225"
+    ["perm"]=>
+    string(5) "adfrw"
+    ["size"]=>
+    string(4) "4729"
+    ["type"]=>
+    string(4) "file"
+    ["unique"]=>
+    string(11) "811U4340CB9"
+    ["UNIX.group"]=>
+    string(2) "33"
+    ["UNIX.mode"]=>
+    string(4) "0644"
+    ["UNIX.owner"]=>
+    string(2) "33"
+  }
+  [3]=>
+  array(3) {
+    ["name"]=>
+    string(9) "path;name"
+    ["fact"]=>
+    string(6) "val=ue"
+    ["empty"]=>
+    string(0) ""
+  }
+}

--- a/ext/ftp/tests/ftp_nlist_cwd.phpt
+++ b/ext/ftp/tests/ftp_nlist_cwd.phpt
@@ -1,0 +1,29 @@
+--TEST--
+ftp_nlist() without the optional parameter $directory (defaults to ".")
+--SKIPIF--
+<?php
+require 'skipif.inc';
+?>
+--FILE--
+<?php
+$bug39458=1;
+require 'server.inc';
+
+$ftp = ftp_connect('127.0.0.1', $port);
+if (!$ftp) die("Couldn't connect to the server");
+
+var_dump(ftp_login($ftp, 'user', 'pass'));
+var_dump(ftp_nlist($ftp));
+ftp_close($ftp);
+?>
+--EXPECT--
+bool(true)
+array(3) {
+  [0]=>
+  string(5) "file1"
+  [1]=>
+  string(5) "file1"
+  [2]=>
+  string(9) "file
+b0rk"
+}

--- a/ext/ftp/tests/ftp_rawlist_cwd.phpt
+++ b/ext/ftp/tests/ftp_rawlist_cwd.phpt
@@ -1,0 +1,18 @@
+--TEST--
+ftp_rawlist() without the optional parameter $directory (defaults to ".")
+--SKIPIF--
+<?php
+require 'skipif.inc';
+?>
+--FILE--
+<?php
+require 'server.inc';
+
+$ftp = ftp_connect('127.0.0.1', $port);
+ftp_login($ftp, 'user', 'pass');
+if (!$ftp) die("Couldn't connect to the server");
+
+var_dump(is_array(ftp_rawlist($ftp)));
+?>
+--EXPECT--
+bool(true)

--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -314,7 +314,7 @@ if ($pid) {
 				die("SSLv23 handshake failed.\n");
 			}
 
-			if (empty($m[1]) || $m[1] !== 'emptydir') {
+			if (empty($m[1]) || $m[1] !== 'emptydir' || $m[1] !== '.') {
 				fputs($fs, "file1\r\nfile1\r\nfile\nb0rk\r\n");
 			}
 
@@ -473,6 +473,9 @@ if ($pid) {
 		}elseif (preg_match('/^LIST www\//', $buf, $matches)) {
 			fputs($s, "226 Transfer complete\r\n");
 
+		}elseif (preg_match('/^LIST \./', $buf, $matches)) {
+			fputs($s, "226 Transfer complete\r\n");
+
 		}elseif (preg_match('/^LIST no_exists\//', $buf, $matches)) {
 			fputs($s, "425 Error establishing connection\r\n");
 
@@ -517,7 +520,7 @@ if ($pid) {
 				die("SSLv23 handshake failed.\n");
 			}
 
-			if(empty($m[1]) || $m[1] !== 'emptydir') {
+			if(empty($m[1]) || $m[1] !== 'emptydir' || $m[1] !== '.') {
 				fputs($fs, "modify=20170127230002;perm=flcdmpe;type=cdir;unique=811U4340002;UNIX.group=33;UNIX.mode=0755;UNIX.owner=33; .\r\n");
 				fputs($fs, "modify=20170127230002;perm=flcdmpe;type=pdir;unique=811U4340002;UNIX.group=33;UNIX.mode=0755;UNIX.owner=33; ..\r\n");
 				fputs($fs, "modify=20170126121225;perm=adfrw;size=4729;type=file;unique=811U4340CB9;UNIX.group=33;UNIX.mode=0644;UNIX.owner=33; foobar\r\n");


### PR DESCRIPTION
Set the default value for $directory to "." to use the current directory for the file list.

    ftp_nlist(resource $ftp_stream, string $directory = "."): array
    ftp_rawlist(resource $ftp_stream, string $directory = ".", bool $recursive = FALSE): array
    ftp_mlsd(resource $ftp_stream, string $directory = "."): array

Im unsure what is the "p" at zend_parse_parameters in ftp_nlist(). Should I change is to "s" as in ftp_rawlist() and ftp_mlsd()?

