### PR TITLE
skeleton: support PHP7.2

### DIFF
--- a/ext/skeleton/skeleton.c
+++ b/ext/skeleton/skeleton.c
@@ -8,6 +8,12 @@
 #include "ext/standard/info.h"
 #include "php_%EXTNAME%.h"
 
+#ifndef ZEND_PARSE_PARAMETERS_NONE
+#define ZEND_PARSE_PARAMETERS_NONE()  \
+        ZEND_PARSE_PARAMETERS_START(0, 0) \
+        ZEND_PARSE_PARAMETERS_END()
+#endif /* ZEND_PARSE_PARAMETERS_NONE */
+
 /* {{{ void %EXTNAME%_test1()
  */
 PHP_FUNCTION(%EXTNAME%_test1)


### PR DESCRIPTION
skeleton can still be leveraged with older PHP releses, included PHP7.2

I wanted to add this capability since PHP7.2 is still widely provided
with most Linux distributions.

I am using ext_skel.php on a vanilla Ubuntu 18.04 and Windows
in order to illustrate how to develop a PHP extension for both
OS using the default tools provided by the distributions.
  see: https://github.com/vjardin/php-bonjour