### PR TITLE
Fix a warning about comparing signed/unsigned variables

### DIFF
--- a/ext/hash/php_hash.h
+++ b/ext/hash/php_hash.h
@@ -150,7 +150,7 @@ PHP_HASH_API int php_hash_copy(const void *ops, void *orig_context, void *dest_c
 static inline void php_hash_bin2hex(char *out, const unsigned char *in, size_t in_len)
 {
 	static const char hexits[17] = "0123456789abcdef";
-	int i;
+	size_t i;
 
 	for(i = 0; i < in_len; i++) {
 		out[i * 2]       = hexits[in[i] >> 4];


### PR DESCRIPTION
This can be seen [here]( https://travis-ci.org/nbs-system/snuffleupagus/jobs/473895085#L685 ):
```C
In file included from /home/travis/.phpenv/versions/master/include/php/ext/session/php_session.h:25:0,
                 from /home/travis/build/nbs-system/snuffleupagus/src/php_snuffleupagus.h:21,
                 from /home/travis/build/nbs-system/snuffleupagus/src/sp_var_parser.c:1:
/home/travis/.phpenv/versions/master/include/php/ext/hash/php_hash.h: In function ‘php_hash_bin2hex’:
/home/travis/.phpenv/versions/master/include/php/ext/hash/php_hash.h:155:15: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  for(i = 0; i < in_len; i++) {
               ^
```