### PR TITLE
document open_basedir and realpath cache coupling in php.ini

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -300,6 +300,7 @@ serialize_precision = -1
 ; open_basedir, if set, limits all file operations to the defined directory
 ; and below.  This directive makes most sense if used in a per-directory
 ; or per-virtualhost web server configuration file.
+; Note: disables the realpath cache
 ; http://php.net/open-basedir
 ;open_basedir =
 
@@ -332,6 +333,7 @@ disable_classes =
 ; Determines the size of the realpath cache to be used by PHP. This value should
 ; be increased on systems where PHP opens many files to reflect the quantity of
 ; the file operations performed.
+; Note: if open_basedir is set, the cache is disabled
 ; http://php.net/realpath-cache-size
 ;realpath_cache_size = 4096k
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -305,6 +305,7 @@ serialize_precision = -1
 ; open_basedir, if set, limits all file operations to the defined directory
 ; and below.  This directive makes most sense if used in a per-directory
 ; or per-virtualhost web server configuration file.
+; Note: disables the realpath cache
 ; http://php.net/open-basedir
 ;open_basedir =
 
@@ -337,6 +338,7 @@ disable_classes =
 ; Determines the size of the realpath cache to be used by PHP. This value should
 ; be increased on systems where PHP opens many files to reflect the quantity of
 ; the file operations performed.
+; Note: if open_basedir is set, the cache is disabled
 ; http://php.net/realpath-cache-size
 ;realpath_cache_size = 4096k
 


### PR DESCRIPTION
The [coupling](https://github.com/php/php-src/blob/PHP-7.3.0/main/main.c#L1800) of open_basedir to the realpath_cache was underdocumented until [recently](https://bugs.php.net/bug.php?id=77406). I think it has value to bring this in front of users.