### PR TITLE
Allow SA_RESTART for SIGALRM

### DIFF
--- a/ext/pcntl/php_signal.c
+++ b/ext/pcntl/php_signal.c
@@ -41,7 +41,7 @@ Sigfunc *php_signal4(int signo, Sigfunc *func, int restart, int mask_all)
 #ifdef HAVE_STRUCT_SIGINFO_T
 	act.sa_flags |= SA_SIGINFO;
 #endif
-	if (signo == SIGALRM || (! restart)) {
+	if (!restart) {
 #ifdef SA_INTERRUPT
 		act.sa_flags |= SA_INTERRUPT; /* SunOS */
 #endif


### PR DESCRIPTION
If no explicit restart_syscalls is passed, default to restart_syscalls=0 for SIGALRM only, to reduce BC impact.

Fix for [bug #77335](https://bugs.php.net/bug.php?id=77335), followup to #3717.