### PR TITLE
Fix #76675 - Leave a reference to the resource in the curl handle

### DIFF
--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -509,6 +509,7 @@ static int _php_server_push_callback(CURL *parent_ch, CURL *easy, size_t num_hea
 	Z_ADDREF_P(pz_parent_ch);
 
 	res = zend_register_resource(ch, le_curl);
+	ch->res = res;
 	ZVAL_RES(&pz_ch, res);
 
 	size_t i;

--- a/ext/curl/tests/bug76675.phpt
+++ b/ext/curl/tests/bug76675.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Bug #76675 (Segfault with H2 server push write/writeheader handlers)
+--SKIPIF--
+<?php
+include 'skipif.inc';
+if (getenv("SKIP_ONLINE_TESTS")) {
+	die("skip online test");
+}
+?>
+--FILE--
+<?php
+$transfers = 1;
+$callback = function($parent, $passed) use (&$transfers) {
+    curl_setopt($passed, CURLOPT_WRITEFUNCTION, function ($ch, $data) {
+        echo "Received ".strlen($data);
+        return strlen($data);
+    });
+	$transfers++;
+	return CURL_PUSH_OK;
+};
+$mh = curl_multi_init();
+curl_multi_setopt($mh, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
+curl_multi_setopt($mh, CURLMOPT_PUSHFUNCTION, $callback);
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://http2.golang.org/serverpush');
+curl_setopt($ch, CURLOPT_HTTP_VERSION, 3);
+curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_multi_add_handle($mh, $ch);
+$active = null;
+do {
+    $status = curl_multi_exec($mh, $active);
+    do {
+        $info = curl_multi_info_read($mh);
+        if (false !== $info && $info['msg'] == CURLMSG_DONE) {
+            $handle = $info['handle'];
+            if ($handle !== null) {
+                $transfers--;
+                curl_multi_remove_handle($mh, $handle);
+                curl_close($handle);
+            }
+        }
+    } while ($info);
+} while ($transfers);
+curl_multi_close($mh);
+?>
+--EXPECTREGEX--
+(Received \d+)+


### PR DESCRIPTION
Link for bugsnet: https://bugs.php.net/bug.php?id=76675

`curl_write` and `curl_write_header` expect the curl handle to have the reference to their resource set. Currently, the handles returned by `_php_server_push_callback` miss them.