### PR TITLE
DOM: Standards Compliance + <?php-class ...?> Processing Instruction

### DIFF
--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -160,6 +160,11 @@ int dom_attr_value_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	if (dom_node_is_read_only((xmlNodePtr) attrp) == SUCCESS) {
+		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
+		return FAILURE;
+	}
+
 	if (attrp->children) {
 		node_list_unlink(attrp->children);
 	}

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -105,6 +105,9 @@ PHP_METHOD(domdocumentfragment, appendXML);
 
 /* domdocument methods */
 PHP_FUNCTION(dom_document_create_element);
+#if defined(DOM_PHP_CLASS_PI)
+PHP_FUNCTION(dom_document_create_object);
+#endif
 PHP_FUNCTION(dom_document_create_document_fragment);
 PHP_FUNCTION(dom_document_create_text_node);
 PHP_FUNCTION(dom_document_create_comment);
@@ -115,6 +118,9 @@ PHP_FUNCTION(dom_document_create_entity_reference);
 PHP_FUNCTION(dom_document_get_elements_by_tag_name);
 PHP_FUNCTION(dom_document_import_node);
 PHP_FUNCTION(dom_document_create_element_ns);
+#if defined(DOM_PHP_CLASS_PI)
+PHP_FUNCTION(dom_document_create_object_ns);
+#endif
 PHP_FUNCTION(dom_document_create_attribute_ns);
 PHP_FUNCTION(dom_document_get_elements_by_tag_name_ns);
 PHP_FUNCTION(dom_document_get_element_by_id);

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -329,6 +329,21 @@ int dom_node_node_value_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	switch (nodep->type) {
+		case XML_ELEMENT_NODE:
+		case XML_ATTRIBUTE_NODE:
+		case XML_TEXT_NODE:
+		case XML_COMMENT_NODE:
+		case XML_CDATA_SECTION_NODE:
+		case XML_PI_NODE:
+			if (dom_node_is_read_only(nodep) == SUCCESS) {
+				php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
+				return FAILURE;
+			}
+		default:
+			break;
+	}
+
 	/* Access to Element node is implemented as a convience method */
 	switch (nodep->type) {
 		case XML_ELEMENT_NODE:

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -874,6 +874,11 @@ int dom_node_text_content_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	if (dom_node_is_read_only(nodep) == SUCCESS) {
+		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
+		return FAILURE;
+	}
+
 	if (nodep->type == XML_ELEMENT_NODE || nodep->type == XML_ATTRIBUTE_NODE) {
 		if (nodep->children) {
 			node_list_unlink(nodep->children);

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -726,6 +726,11 @@ int dom_node_prefix_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	if (dom_node_is_read_only(nodep) == SUCCESS) {
+		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
+		return FAILURE;
+	}
+
 	switch (nodep->type) {
 		case XML_ELEMENT_NODE:
 			nsnode = nodep;

--- a/ext/dom/processinginstruction.c
+++ b/ext/dom/processinginstruction.c
@@ -64,6 +64,19 @@ PHP_METHOD(domprocessinginstruction, __construct)
 		RETURN_FALSE;
 	}
 
+	intern = Z_DOMOBJ_P(ZEND_THIS);
+
+#if defined(DOM_PHP_CLASS_PI)
+	// check for DOM_PHP_CLASS_PI
+	if (!xmlStrcasecmp((xmlChar *) name, DOM_PHP_CLASS_PI)) {
+		char *str;
+		spprintf(&str, 0, "<?%s ...?> processing instruction may not be explicitly created", (const char *) DOM_PHP_CLASS_PI);
+		php_dom_throw_error_with_message(0, str, dom_get_strict_error(intern->document));
+		efree(str);
+		RETURN_FALSE;
+	}
+#endif
+
 	nodep = xmlNewPI((xmlChar *) name, (xmlChar *) value);
 
 	if (!nodep) {
@@ -71,7 +84,6 @@ PHP_METHOD(domprocessinginstruction, __construct)
 		RETURN_FALSE;
 	}
 
-	intern = Z_DOMOBJ_P(ZEND_THIS);
 	oldnode = dom_object_get_node(intern);
 	if (oldnode != NULL) {
 		php_libxml_node_free_resource(oldnode );

--- a/ext/dom/processinginstruction.c
+++ b/ext/dom/processinginstruction.c
@@ -103,7 +103,7 @@ int dom_processinginstruction_target_read(dom_object *obj, zval *retval)
 
 /* {{{ data	string
 readonly=no
-URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#ID-837822393
+URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-837822393
 Since:
 */
 int dom_processinginstruction_data_read(dom_object *obj, zval *retval)
@@ -135,6 +135,11 @@ int dom_processinginstruction_data_write(dom_object *obj, zval *newval)
 
 	if (nodep == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 0);
+		return FAILURE;
+	}
+
+	if (dom_node_is_read_only(nodep) == SUCCESS) {
+		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
 		return FAILURE;
 	}
 

--- a/ext/dom/tests/DOMAttr_value_basic_002.phpt
+++ b/ext/dom/tests/DOMAttr_value_basic_002.phpt
@@ -2,14 +2,16 @@
 Write non-string $value property
 --CREDITS--
 Eric Berg <ehberg@gmail.com>
+Adam Martinson
 # TestFest Atlanta 2009-05-14
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
-$attr = new DOMAttr('category');
-$attr->value = 1;
-print $attr->value;
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Attr = $Doc->createAttribute('category');
+$Attr->value = 1;
+print $Attr->value;
 ?>
 --EXPECT--
 1

--- a/ext/dom/tests/DOMAttr_value_error_001.phpt
+++ b/ext/dom/tests/DOMAttr_value_error_001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMAttr->value = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Attr = new DOMAttr('foo');
+try {
+	$Attr->value = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK

--- a/ext/dom/tests/DOMDocument_createObjectNS_basic.phpt
+++ b/ext/dom/tests/DOMDocument_createObjectNS_basic.phpt
@@ -1,0 +1,105 @@
+--TEST--
+DOMDocument::createObjectNS()
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObjectNS'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+class Bar extends DOMElement
+{
+
+}
+
+class Chi extends DOMElement
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Doc->preserveWhiteSpace = false;
+$Doc->formatOutput = true;
+
+$uri = 'http://php.net/test';
+
+$Root = $Doc->createElementNS($uri, 'test:root');
+$Doc->appendChild($Root);
+
+$Foo = $Doc->createObjectNS($uri, 'test:empty', 'Foo');
+$Root->appendChild($Foo);
+
+$Bar = $Doc->createObjectNS($uri, 'test:complex', 'Bar');
+$Root->appendChild($Bar);
+
+$Chi = $Doc->createObjectNS($uri, 'test:simple', 'Chi', 'chi');
+$Bar->appendChild($Chi);
+
+$Doc->normalizeDocument();
+
+echo get_class($Root) . "\n";
+echo get_class($Foo) . "\n";
+echo $Foo->textContent . "\n";
+echo get_class($Bar) . "\n";
+echo $Bar->textContent . "\n";
+echo get_class($Chi) . "\n";
+echo $Chi->textContent . "\n";
+
+echo "\n";
+unset($Foo);
+unset($Bar);
+unset($Chi);
+unset($Root);
+
+echo get_class($Doc->documentElement->firstChild) . "\n";
+echo get_class($Doc->documentElement->lastChild) . "\n";
+echo get_class($Doc->documentElement->lastChild->lastChild) . "\n";
+
+$xml = $Doc->saveXML();
+unset($Doc);
+echo "\n$xml\n";
+
+$Doc = new DOMDocument();
+$Doc->preserveWhiteSpace = false;
+$Doc->loadXML($xml);
+echo get_class($Doc->documentElement) . "\n";
+echo get_class($Doc->documentElement->firstChild) . "\n";
+echo get_class($Doc->documentElement->lastChild) . "\n";
+echo get_class($Doc->documentElement->lastChild->lastChild) . "\n";
+?>
+--EXPECT--
+DOMElement
+Foo
+
+Bar
+chi
+Chi
+chi
+
+Foo
+Bar
+Chi
+
+<?xml version="1.0" encoding="UTF-8"?>
+<test:root xmlns:test="http://php.net/test">
+  <test:empty>
+    <?php-class Foo?>
+  </test:empty>
+  <test:complex>
+    <?php-class Bar?>
+    <test:simple><?php-class Chi?>chi</test:simple>
+  </test:complex>
+</test:root>
+
+DOMElement
+Foo
+Bar
+Chi

--- a/ext/dom/tests/DOMDocument_createObjectNS_error1.phpt
+++ b/ext/dom/tests/DOMDocument_createObjectNS_error1.phpt
@@ -1,0 +1,25 @@
+--TEST--
+DOMDocument::createObjectNS() class must extend DOMElement
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObjectNS'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$uri = 'http://php.net/test';
+$Foo = $Doc->createObjectNS($uri, 'test:root', 'Foo');
+var_dump($Foo);
+?>
+--EXPECTF--
+Warning: DOMDocument::createObjectNS() expects parameter 3 to be a class name derived from DOMElement, 'Foo' given in %s on line %d
+NULL

--- a/ext/dom/tests/DOMDocument_createObject_basic.phpt
+++ b/ext/dom/tests/DOMDocument_createObject_basic.phpt
@@ -1,0 +1,103 @@
+--TEST--
+DOMDocument::createObject()
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+class Bar extends DOMElement
+{
+
+}
+
+class Chi extends DOMElement
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Doc->preserveWhiteSpace = false;
+$Doc->formatOutput = true;
+
+$Root = $Doc->createElement('root');
+$Doc->appendChild($Root);
+
+$Foo = $Doc->createObject('empty', 'Foo');
+$Root->appendChild($Foo);
+
+$Bar = $Doc->createObject('complex', 'Bar');
+$Root->appendChild($Bar);
+
+$Chi = $Doc->createObject('simple', 'Chi', 'chi');
+$Bar->appendChild($Chi);
+
+$Doc->normalizeDocument();
+
+echo get_class($Root) . "\n";
+echo get_class($Foo) . "\n";
+echo $Foo->textContent . "\n";
+echo get_class($Bar) . "\n";
+echo $Bar->textContent . "\n";
+echo get_class($Chi) . "\n";
+echo $Chi->textContent . "\n";
+
+echo "\n";
+unset($Foo);
+unset($Bar);
+unset($Chi);
+unset($Root);
+
+echo get_class($Doc->documentElement->firstChild) . "\n";
+echo get_class($Doc->documentElement->lastChild) . "\n";
+echo get_class($Doc->documentElement->lastChild->lastChild) . "\n";
+
+$xml = $Doc->saveXML();
+unset($Doc);
+echo "\n$xml\n";
+
+$Doc = new DOMDocument();
+$Doc->preserveWhiteSpace = false;
+$Doc->loadXML($xml);
+echo get_class($Doc->documentElement) . "\n";
+echo get_class($Doc->documentElement->firstChild) . "\n";
+echo get_class($Doc->documentElement->lastChild) . "\n";
+echo get_class($Doc->documentElement->lastChild->lastChild) . "\n";
+?>
+--EXPECT--
+DOMElement
+Foo
+
+Bar
+chi
+Chi
+chi
+
+Foo
+Bar
+Chi
+
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <empty>
+    <?php-class Foo?>
+  </empty>
+  <complex>
+    <?php-class Bar?>
+    <simple><?php-class Chi?>chi</simple>
+  </complex>
+</root>
+
+DOMElement
+Foo
+Bar
+Chi

--- a/ext/dom/tests/DOMDocument_createObject_error1.phpt
+++ b/ext/dom/tests/DOMDocument_createObject_error1.phpt
@@ -1,0 +1,24 @@
+--TEST--
+DOMDocument::createObject() class must extend DOMElement
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Foo = $Doc->createObject('root', 'Foo');
+var_dump($Foo);
+?>
+--EXPECTF--
+Warning: DOMDocument::createObject() expects parameter 2 to be a class name derived from DOMElement, 'Foo' given in %s on line %d
+NULL

--- a/ext/dom/tests/DOMDocument_createObject_error2.phpt
+++ b/ext/dom/tests/DOMDocument_createObject_error2.phpt
@@ -1,0 +1,53 @@
+--TEST--
+DOMDocument::createObject() <?php-class ...?> PI is read-only
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Foo = $Doc->createObject('root', 'Foo');
+$Doc->appendChild($Foo);
+
+try {
+	$Foo->firstChild->nodeValue = 'Bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+try {
+	$Foo->firstChild->textContent = 'Bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+try {
+	$Foo->firstChild->data = 'Bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK
+OK
+OK

--- a/ext/dom/tests/DOMDocument_createObject_error3.phpt
+++ b/ext/dom/tests/DOMDocument_createObject_error3.phpt
@@ -1,0 +1,34 @@
+--TEST--
+DOMDocument::createObject() <?php-class ...?> PI must be first child
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Foo = $Doc->createObject('root', 'Foo');
+$Doc->appendChild($Foo);
+
+$Child = $Doc->createElement('child');
+try {
+	$Foo->insertBefore($Child, $Foo->firstChild);
+} catch (DOMException $Ex) {
+	echo $Ex->getMessage() . "\n";
+	if ($Ex->getCode() == DOM_PHP_ERR) {
+		echo "OK\n";
+	}
+}
+?>
+--EXPECT--
+<?php-class ...?> processing instruction must be the first child
+OK

--- a/ext/dom/tests/DOMDocument_createObject_error4.phpt
+++ b/ext/dom/tests/DOMDocument_createObject_error4.phpt
@@ -1,0 +1,33 @@
+--TEST--
+DOMDocument::createObject() <?php-class ...?> PI may not be removed
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Foo = $Doc->createObject('root', 'Foo');
+$Doc->appendChild($Foo);
+
+try {
+	$Foo->removeChild($Foo->firstChild);
+} catch (DOMException $Ex) {
+	echo $Ex->getMessage() . "\n";
+	if ($Ex->getCode() == DOM_PHP_ERR) {
+		echo "OK\n";
+	}
+}
+?>
+--EXPECT--
+<?php-class ...?> processing instruction may not be removed
+OK

--- a/ext/dom/tests/DOMDocument_createObject_error5.phpt
+++ b/ext/dom/tests/DOMDocument_createObject_error5.phpt
@@ -1,0 +1,35 @@
+--TEST--
+DOMDocument::createObject() <?php-class ...?> PI may not be replaced
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Foo = $Doc->createObject('root', 'Foo');
+$Doc->appendChild($Foo);
+
+$Child = $Doc->createElement('child');
+
+try {
+	$Foo->replaceChild($Child, $Foo->firstChild);
+} catch (DOMException $Ex) {
+	echo $Ex->getMessage() . "\n";
+	if ($Ex->getCode() == DOM_PHP_ERR) {
+		echo "OK\n";
+	}
+}
+?>
+--EXPECT--
+<?php-class ...?> processing instruction may not be replaced
+OK

--- a/ext/dom/tests/DOMDocument_createObject_error6.phpt
+++ b/ext/dom/tests/DOMDocument_createObject_error6.phpt
@@ -1,0 +1,34 @@
+--TEST--
+DOMDocument::createObject() <?php-class ...?> PI may not be moved
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Root = $Doc->appendChild($Doc->createElement('root'));
+$Foo = $Root->appendChild($Doc->createObject('foo', 'Foo'));
+$Bar = $Root->appendChild($Doc->createElement('bar'));
+
+try {
+	$Bar->appendChild($Foo->firstChild);
+} catch (DOMException $Ex) {
+	echo $Ex->getMessage() . "\n";
+	if ($Ex->getCode() == DOM_PHP_ERR) {
+		echo "OK\n";
+	}
+}
+?>
+--EXPECT--
+<?php-class ...?> processing instruction may not be moved
+OK

--- a/ext/dom/tests/DOMDocument_createObject_nodeValue.phpt
+++ b/ext/dom/tests/DOMDocument_createObject_nodeValue.phpt
@@ -1,0 +1,35 @@
+--TEST--
+DOMDocument::createObject()->nodeValue = "bar"
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Foo = $Doc->createObject('root', 'Foo');
+$Doc->appendChild($Foo);
+
+echo $Foo->nodeValue . "\n";
+$Foo->nodeValue = "bar";
+echo $Foo->nodeValue . "\n";
+$Foo->nodeValue = "chi";
+echo $Foo->nodeValue . "\n";
+if ($Foo->firstChild->nodeType == XML_PI_NODE) {
+	echo "OK\n";
+}
+?>
+--EXPECT--
+
+bar
+chi
+OK

--- a/ext/dom/tests/DOMDocument_createObject_textContent.phpt
+++ b/ext/dom/tests/DOMDocument_createObject_textContent.phpt
@@ -1,0 +1,32 @@
+--TEST--
+DOMDocument::createObject()->textContent = "chi"
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Foo = $Doc->createObject('root', 'Foo', "bar");
+$Doc->appendChild($Foo);
+
+echo $Foo->textContent . "\n";
+$Foo->textContent = "chi";
+echo $Foo->textContent . "\n";
+if ($Foo->firstChild->nodeType == XML_PI_NODE) {
+	echo "OK\n";
+}
+?>
+--EXPECT--
+bar
+chi
+OK

--- a/ext/dom/tests/DOMDocument_createProcessingInstruction_php_class.phpt
+++ b/ext/dom/tests/DOMDocument_createProcessingInstruction_php_class.phpt
@@ -1,0 +1,25 @@
+--TEST--
+DOMDocument::createProcessingInstruction("php-class") should fail
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+$Doc = new DOMDocument('1.0', 'UTF-8');
+try {
+	$Pi = $Doc->createProcessingInstruction("php-class");
+} catch (DOMException $Ex) {
+	echo $Ex->getMessage() . "\n";
+	if ($Ex->getCode() == DOM_PHP_ERR) {
+		echo "OK\n";
+	}
+}
+?>
+--EXPECT--
+<?php-class ...?> processing instruction may not be explicitly created
+OK

--- a/ext/dom/tests/DOMDocument_loadXML_php_class_PI.phpt
+++ b/ext/dom/tests/DOMDocument_loadXML_php_class_PI.phpt
@@ -1,0 +1,47 @@
+--TEST--
+DOMDocument::loadXML() with <?php-class ...?> PIs
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+class Foo extends DOMElement
+{
+
+}
+
+class Bar
+{
+
+}
+
+$xml = '<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <object><?php-class Foo?></object>
+  <object><?php-class Bar?></object>
+  <object><?php-class Chi?></object>
+</root>';
+
+$Doc = new DOMDocument();
+$Doc->preserveWhiteSpace = false;
+$Doc->loadXML($xml);
+
+echo get_class($Doc->documentElement) . "\n";
+echo get_class($Doc->documentElement->firstChild) . "\n";
+echo get_class($Doc->documentElement->firstChild->nextSibling) . "\n";
+echo get_class($Doc->documentElement->lastChild) . "\n";
+?>
+--EXPECTF--
+DOMElement
+Foo
+
+Warning: %s: Class Bar is not derived from DOMElement; ignoring <?php-class Bar?> in %s on line %d
+DOMElement
+
+Warning: %s: Class Chi does not exist; ignoring <?php-class Chi?> in %s on line %d
+DOMElement

--- a/ext/dom/tests/DOMNode_nodeValue_error1.phpt
+++ b/ext/dom/tests/DOMNode_nodeValue_error1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMNode->nodeValue = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Foo = new DOMElement('foo');
+try {
+	$Foo->nodeValue = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK

--- a/ext/dom/tests/DOMNode_prefix_error1.phpt
+++ b/ext/dom/tests/DOMNode_prefix_error1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMNode->prefix = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Foo = new DOMElement('foo', NULL, "http://php.net/test");
+try {
+	$Foo->prefix = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK

--- a/ext/dom/tests/DOMNode_textContent_error1.phpt
+++ b/ext/dom/tests/DOMNode_textContent_error1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMNode->textContent = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Foo = new DOMElement('foo');
+try {
+	$Foo->textContent = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK

--- a/ext/dom/tests/DOMProcessingInstruction_construct_php_class.phpt
+++ b/ext/dom/tests/DOMProcessingInstruction_construct_php_class.phpt
@@ -1,0 +1,24 @@
+--TEST--
+new DOMProcessingInstruction("php-class") should fail
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!method_exists('DOMDocument', 'createObject'))
+	die('DOM_PHP_CLASS_PI_DISABLED');
+?>
+--FILE--
+<?php
+try {
+	$Pi = new DOMProcessingInstruction("php-class");
+} catch (DOMException $Ex) {
+	echo $Ex->getMessage() . "\n";
+	if ($Ex->getCode() == DOM_PHP_ERR) {
+		echo "OK\n";
+	}
+}
+?>
+--EXPECT--
+<?php-class ...?> processing instruction may not be explicitly created
+OK

--- a/ext/dom/tests/DOMProcessingInstruction_data_error1.phpt
+++ b/ext/dom/tests/DOMProcessingInstruction_data_error1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMProcessingInstruction->data = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Foo = new DOMProcessingInstruction('foo');
+try {
+	$Foo->data = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK

--- a/ext/dom/xml_common.h
+++ b/ext/dom/xml_common.h
@@ -61,6 +61,11 @@ PHP_DOM_EXPORT xmlNodePtr dom_object_get_node(dom_object *obj);
 #define DOM_XMLNS_NAMESPACE \
     (const xmlChar *) "http://www.w3.org/2000/xmlns/"
 
+#if !defined(DOM_PHP_CLASS_PI_DISABLED)
+#	define DOM_PHP_CLASS_PI \
+		(const xmlChar *) "php-class"
+#endif
+
 #define NODE_GET_OBJ(__ptr, __id, __prtype, __intern) { \
 	__intern = Z_LIBXML_NODE_P(__id); \
 	if (__intern->node == NULL || !(__ptr = (__prtype)__intern->node->node)) { \


### PR DESCRIPTION
First 5 commits are just for standards compliance. See [DOM Level 3 Core Specification](https://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html).
I wouldn't really consider these bug fixes, as they just make sure read-only nodes throw the proper exceptions, but I can backport them if you like.

Last 2 commits implement a `<?php-class ...?>` processing instruction.  When used as the first child of an XML element, PHP will use the class name stored in the PI to represent the element, rather than [DOMElement](http://php.net/manual/en/class.domelement.php), or the single class set with [DOMDocument::registerNodeClass()](http://php.net/manual/en/domdocument.registernodeclass.php).  The PI itself is read-only, and is fixed as the first child of the parent element.  2 new methods are added to handle object creation:

`$DOMDocument->createObject(string $name, string $class, string $value = NULL)`
is equivalent to:
`$DOMDocument->createElement(string $name, string $value = NULL)`
except that it returns a `$class` object instead of `DOMElement` (provided `$class` extends `DOMElement`), and it will have a `<?php-class $class?>` PI as its first child.

`$DOMDocument->createObjectNS(string $nsURI, string $qName, string $class, string $value = NULL)`
is similarly equivalent to:
`$DOMDocument->createElementNS(string $nsURI, string $qName, string $value = NULL)`
except that it returns a `$class` object instead of `DOMElement` (provided `$class` extends `DOMElement`), and it will have a `<?php-class $class?>` PI as its first child.

Comparing the XML:
- `$DOMDocument->createElement('foo', 'bar');` = `<foo>bar</foo>`
- `$DOMDocument->createElement('foo', 'Foo', 'bar');` = `<foo><?php-class Foo?>bar</foo>`

This allows implementation of complex PHP tree structures using multiple object classes with the DOM as a back-end, taking advantage of all of the features XML provides, without the overhead of a translation layer.

The overhead required is almost nothing, but the code can be disabled by defining `DOM_PHP_CLASS_PI_DISABLED` during the build process if desired.