### PR TITLE
Use pkg-config to detect and configure for system libgd

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -4,9 +4,12 @@ dnl
 dnl Configure options
 dnl
 
-PHP_ARG_WITH(gd, for GD support,
-[  --with-gd[=DIR]           Include GD support.  DIR is the GD library base
-                          install directory [BUNDLED]])
+PHP_ARG_ENABLE(gd, for GD support,
+[  --enable-gd             Include GD support])
+
+PHP_ARG_WITH(external-gd, for external libgd,
+[  --with-external-gd      Use external libgd], no, no)
+
 if test -z "$PHP_WEBP"; then
   PHP_ARG_WITH(webp, for libwebp,
   [  --with-webp             GD: Enable WEBP support], no, no)
@@ -108,92 +111,78 @@ dnl
 dnl Main GD configure
 dnl
 
-if test "$PHP_GD" = "yes"; then
-  GD_MODULE_TYPE=builtin
-  GDLIB_CFLAGS=""
-  extra_sources="libgd/gd.c libgd/gd_gd.c libgd/gd_gd2.c libgd/gd_io.c libgd/gd_io_dp.c \
-                 libgd/gd_io_file.c libgd/gd_ss.c libgd/gd_io_ss.c libgd/gd_webp.c \
-                 libgd/gd_png.c libgd/gd_jpeg.c libgd/gdxpm.c libgd/gdfontt.c libgd/gdfonts.c \
-                 libgd/gdfontmb.c libgd/gdfontl.c libgd/gdfontg.c libgd/gdtables.c libgd/gdft.c \
-                 libgd/gdcache.c libgd/gdkanji.c libgd/wbmp.c libgd/gd_wbmp.c libgd/gdhelpers.c \
-                 libgd/gd_topal.c libgd/gd_gif_in.c libgd/gd_xbm.c libgd/gd_gif_out.c libgd/gd_security.c \
-                 libgd/gd_filter.c libgd/gd_pixelate.c libgd/gd_rotate.c libgd/gd_color_match.c \
-                 libgd/gd_transform.c libgd/gd_crop.c libgd/gd_interpolation.c libgd/gd_matrix.c \
-                 libgd/gd_bmp.c"
+if test "$PHP_GD" != "no"; then
+
+  if test "$PHP_EXTERNAL_GD" = "no"; then
+    GD_MODULE_TYPE=builtin
+    GD_CFLAGS=""
+    extra_sources="libgd/gd.c libgd/gd_gd.c libgd/gd_gd2.c libgd/gd_io.c libgd/gd_io_dp.c \
+                  libgd/gd_io_file.c libgd/gd_ss.c libgd/gd_io_ss.c libgd/gd_webp.c \
+                  libgd/gd_png.c libgd/gd_jpeg.c libgd/gdxpm.c libgd/gdfontt.c libgd/gdfonts.c \
+                  libgd/gdfontmb.c libgd/gdfontl.c libgd/gdfontg.c libgd/gdtables.c libgd/gdft.c \
+                  libgd/gdcache.c libgd/gdkanji.c libgd/wbmp.c libgd/gd_wbmp.c libgd/gdhelpers.c \
+                  libgd/gd_topal.c libgd/gd_gif_in.c libgd/gd_xbm.c libgd/gd_gif_out.c libgd/gd_security.c \
+                  libgd/gd_filter.c libgd/gd_pixelate.c libgd/gd_rotate.c libgd/gd_color_match.c \
+                  libgd/gd_transform.c libgd/gd_crop.c libgd/gd_interpolation.c libgd/gd_matrix.c \
+                  libgd/gd_bmp.c"
 
 dnl check for fabsf and floorf which are available since C99
-  AC_CHECK_FUNCS(fabsf floorf)
+    AC_CHECK_FUNCS(fabsf floorf)
 
 dnl These are always available with bundled library
-  AC_DEFINE(HAVE_GD_BUNDLED,          1, [ ])
-  AC_DEFINE(HAVE_GD_PNG,              1, [ ])
-  AC_DEFINE(HAVE_GD_BMP,              1, [ ])
+    AC_DEFINE(HAVE_GD_BUNDLED,          1, [ ])
+    AC_DEFINE(HAVE_GD_PNG,              1, [ ])
+    AC_DEFINE(HAVE_GD_BMP,              1, [ ])
 
 dnl Various checks for GD features
-  PHP_GD_ZLIB
-  PHP_GD_PNG
-  PHP_GD_WEBP
-  PHP_GD_JPEG
-  PHP_GD_XPM
-  PHP_GD_FREETYPE2
-  PHP_GD_JISX0208
+    PHP_GD_ZLIB
+    PHP_GD_PNG
+    PHP_GD_WEBP
+    PHP_GD_JPEG
+    PHP_GD_XPM
+    PHP_GD_FREETYPE2
+    PHP_GD_JISX0208
 
-else
-
- if test "$PHP_GD" != "no"; then
-  GD_MODULE_TYPE=external
-  extra_sources="gd_compat.c"
-
-dnl Header path
-  for i in include/gd include/gd2 include gd ""; do
-    test -f "$PHP_GD/$i/gd.h" && GD_INCLUDE="$PHP_GD/$i"
-  done
-
-  if test -z "$GD_INCLUDE"; then
-    AC_MSG_ERROR([Unable to find gd.h anywhere under $PHP_GD])
-  fi
-
-dnl Library path
-
-  PHP_CHECK_LIBRARY(gd, gdSetErrorMethod,
-  [
-    PHP_ADD_LIBRARY_WITH_PATH(gd, $PHP_GD/$PHP_LIBDIR, GD_SHARED_LIBADD)
+  else
+    GD_MODULE_TYPE=external
+    extra_sources="gd_compat.c"
+    if test "$ext_shared" = "no"; then
+      PKG_CHECK_MODULES_STATIC([GDLIB], [gdlib >= 2.1.0])
+    else
+      PKG_CHECK_MODULES([GDLIB], [gdlib >= 2.1.0])
+    fi
+    PHP_EVAL_LIBLINE($GDLIB_LIBS, GD_SHARED_LIBADD)
+    PHP_EVAL_INCLINE($GDLIB_CFLAGS)
     AC_DEFINE(HAVE_LIBGD, 1, [ ])
-  ],[
-    AC_MSG_ERROR([Unable to find libgd.(a|so) >= 2.1.0 anywhere under $PHP_GD])
-  ],[
-    -L$PHP_GD/$PHP_LIBDIR
-  ])
-  PHP_GD_CHECK_VERSION
-
-  PHP_EXPAND_PATH($GD_INCLUDE, GD_INCLUDE)
- fi
+    PHP_GD_CHECK_VERSION
+  fi
 fi
 
 dnl
 dnl Common for both builtin and external GD
 dnl
 if test "$PHP_GD" != "no"; then
-  PHP_NEW_EXTENSION(gd, gd.c $extra_sources, $ext_shared,, \\$(GDLIB_CFLAGS))
 
   if test "$GD_MODULE_TYPE" = "builtin"; then
+    PHP_NEW_EXTENSION(gd, gd.c $extra_sources, $ext_shared,, \\$(GD_CFLAGS))
     PHP_ADD_BUILD_DIR($ext_builddir/libgd)
-    GDLIB_CFLAGS="-I$ext_srcdir/libgd $GDLIB_CFLAGS"
+    GD_CFLAGS="-I$ext_srcdir/libgd $GD_CFLAGS"
     GD_HEADER_DIRS="ext/gd/ ext/gd/libgd/"
 
     PHP_TEST_BUILD(foobar, [], [
       AC_MSG_ERROR([GD build test failed. Please check the config.log for details.])
     ], [ $GD_SHARED_LIBADD ], [char foobar () {}])
   else
+    PHP_NEW_EXTENSION(gd, gd.c $extra_sources, $ext_shared)
     GD_HEADER_DIRS="ext/gd/"
-    GDLIB_CFLAGS="-I$GD_INCLUDE $GDLIB_CFLAGS"
-    PHP_ADD_INCLUDE($GD_INCLUDE)
     PHP_CHECK_LIBRARY(gd, gdImageCreate, [], [
       AC_MSG_ERROR([GD build test failed. Please check the config.log for details.])
     ], [ $GD_SHARED_LIBADD ])
   fi
 
   PHP_INSTALL_HEADERS([$GD_HEADER_DIRS])
+  PHP_SUBST(GD_CFLAGS)
   PHP_SUBST(GDLIB_CFLAGS)
+  PHP_SUBST(GDLIB_LIBS)
   PHP_SUBST(GD_SHARED_LIBADD)
 fi

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -114,7 +114,6 @@ dnl
 if test "$PHP_GD" != "no"; then
 
   if test "$PHP_EXTERNAL_GD" = "no"; then
-    GD_MODULE_TYPE=builtin
     GD_CFLAGS=""
     extra_sources="libgd/gd.c libgd/gd_gd.c libgd/gd_gd2.c libgd/gd_io.c libgd/gd_io_dp.c \
                   libgd/gd_io_file.c libgd/gd_ss.c libgd/gd_io_ss.c libgd/gd_webp.c \
@@ -143,23 +142,6 @@ dnl Various checks for GD features
     PHP_GD_FREETYPE2
     PHP_GD_JISX0208
 
-  else
-    GD_MODULE_TYPE=external
-    extra_sources="gd_compat.c"
-    PKG_CHECK_MODULES([GDLIB], [gdlib >= 2.1.0])
-    PHP_EVAL_LIBLINE($GDLIB_LIBS, GD_SHARED_LIBADD)
-    PHP_EVAL_INCLINE($GDLIB_CFLAGS)
-    AC_DEFINE(HAVE_LIBGD, 1, [ ])
-    PHP_GD_CHECK_VERSION
-  fi
-fi
-
-dnl
-dnl Common for both builtin and external GD
-dnl
-if test "$PHP_GD" != "no"; then
-
-  if test "$GD_MODULE_TYPE" = "builtin"; then
     PHP_NEW_EXTENSION(gd, gd.c $extra_sources, $ext_shared,, \\$(GD_CFLAGS))
     PHP_ADD_BUILD_DIR($ext_builddir/libgd)
     GD_CFLAGS="-I$ext_srcdir/libgd $GD_CFLAGS"
@@ -168,7 +150,15 @@ if test "$PHP_GD" != "no"; then
     PHP_TEST_BUILD(foobar, [], [
       AC_MSG_ERROR([GD build test failed. Please check the config.log for details.])
     ], [ $GD_SHARED_LIBADD ], [char foobar () {}])
+
   else
+    extra_sources="gd_compat.c"
+    PKG_CHECK_MODULES([GDLIB], [gdlib >= 2.1.0])
+    PHP_EVAL_LIBLINE($GDLIB_LIBS, GD_SHARED_LIBADD)
+    PHP_EVAL_INCLINE($GDLIB_CFLAGS)
+    AC_DEFINE(HAVE_LIBGD, 1, [ ])
+    PHP_GD_CHECK_VERSION
+
     PHP_NEW_EXTENSION(gd, gd.c $extra_sources, $ext_shared)
     GD_HEADER_DIRS="ext/gd/"
     PHP_CHECK_LIBRARY(gd, gdImageCreate, [], [

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -146,11 +146,7 @@ dnl Various checks for GD features
   else
     GD_MODULE_TYPE=external
     extra_sources="gd_compat.c"
-    if test "$ext_shared" = "no"; then
-      PKG_CHECK_MODULES_STATIC([GDLIB], [gdlib >= 2.1.0])
-    else
-      PKG_CHECK_MODULES([GDLIB], [gdlib >= 2.1.0])
-    fi
+    PKG_CHECK_MODULES([GDLIB], [gdlib >= 2.1.0])
     PHP_EVAL_LIBLINE($GDLIB_LIBS, GD_SHARED_LIBADD)
     PHP_EVAL_INCLINE($GDLIB_CFLAGS)
     AC_DEFINE(HAVE_LIBGD, 1, [ ])


### PR DESCRIPTION
Formerly, a single option `--with-gd` was sufficient to enable the
extension, and to determine whether to use the system or the bundled
libgd depending on whether a directory was passed.  Since pkg-config
determines the path automatically, we now offer `--enable-gd` (whether
the extension should be build) and `--with-external-gd` (whether to use
the system libgd).