### PR TITLE
DOM: NO_MODIFICATION_ALLOWED_ERR Standards Compliance

### DIFF
--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -160,6 +160,11 @@ int dom_attr_value_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	if (dom_node_is_read_only((xmlNodePtr) attrp) == SUCCESS) {
+		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
+		return FAILURE;
+	}
+
 	if (attrp->children) {
 		node_list_unlink(attrp->children);
 	}

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -329,6 +329,21 @@ int dom_node_node_value_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	switch (nodep->type) {
+		case XML_ELEMENT_NODE:
+		case XML_ATTRIBUTE_NODE:
+		case XML_TEXT_NODE:
+		case XML_COMMENT_NODE:
+		case XML_CDATA_SECTION_NODE:
+		case XML_PI_NODE:
+			if (dom_node_is_read_only(nodep) == SUCCESS) {
+				php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
+				return FAILURE;
+			}
+		default:
+			break;
+	}
+
 	/* Access to Element node is implemented as a convience method */
 	switch (nodep->type) {
 		case XML_ELEMENT_NODE:

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -874,6 +874,11 @@ int dom_node_text_content_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	if (dom_node_is_read_only(nodep) == SUCCESS) {
+		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
+		return FAILURE;
+	}
+
 	if (nodep->type == XML_ELEMENT_NODE || nodep->type == XML_ATTRIBUTE_NODE) {
 		if (nodep->children) {
 			node_list_unlink(nodep->children);

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -726,6 +726,11 @@ int dom_node_prefix_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	if (dom_node_is_read_only(nodep) == SUCCESS) {
+		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
+		return FAILURE;
+	}
+
 	switch (nodep->type) {
 		case XML_ELEMENT_NODE:
 			nsnode = nodep;

--- a/ext/dom/processinginstruction.c
+++ b/ext/dom/processinginstruction.c
@@ -103,7 +103,7 @@ int dom_processinginstruction_target_read(dom_object *obj, zval *retval)
 
 /* {{{ data	string
 readonly=no
-URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#ID-837822393
+URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-837822393
 Since:
 */
 int dom_processinginstruction_data_read(dom_object *obj, zval *retval)
@@ -135,6 +135,11 @@ int dom_processinginstruction_data_write(dom_object *obj, zval *newval)
 
 	if (nodep == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 0);
+		return FAILURE;
+	}
+
+	if (dom_node_is_read_only(nodep) == SUCCESS) {
+		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(obj->document));
 		return FAILURE;
 	}
 

--- a/ext/dom/tests/DOMAttr_value_basic_002.phpt
+++ b/ext/dom/tests/DOMAttr_value_basic_002.phpt
@@ -2,14 +2,16 @@
 Write non-string $value property
 --CREDITS--
 Eric Berg <ehberg@gmail.com>
+Adam Martinson
 # TestFest Atlanta 2009-05-14
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
-$attr = new DOMAttr('category');
-$attr->value = 1;
-print $attr->value;
+$Doc = new DOMDocument('1.0', 'UTF-8');
+$Attr = $Doc->createAttribute('category');
+$Attr->value = 1;
+print $Attr->value;
 ?>
 --EXPECT--
 1

--- a/ext/dom/tests/DOMAttr_value_error_001.phpt
+++ b/ext/dom/tests/DOMAttr_value_error_001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMAttr->value = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Attr = new DOMAttr('foo');
+try {
+	$Attr->value = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK

--- a/ext/dom/tests/DOMNode_nodeValue_error1.phpt
+++ b/ext/dom/tests/DOMNode_nodeValue_error1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMNode->nodeValue = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Foo = new DOMElement('foo');
+try {
+	$Foo->nodeValue = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK

--- a/ext/dom/tests/DOMNode_prefix_error1.phpt
+++ b/ext/dom/tests/DOMNode_prefix_error1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMNode->prefix = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Foo = new DOMElement('foo', NULL, "http://php.net/test");
+try {
+	$Foo->prefix = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK

--- a/ext/dom/tests/DOMNode_textContent_error1.phpt
+++ b/ext/dom/tests/DOMNode_textContent_error1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMNode->textContent = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Foo = new DOMElement('foo');
+try {
+	$Foo->textContent = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK

--- a/ext/dom/tests/DOMProcessingInstruction_data_error1.phpt
+++ b/ext/dom/tests/DOMProcessingInstruction_data_error1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+readonly DOMProcessingInstruction->data = 'bar'
+--CREDITS--
+Adam Martinson
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+$Foo = new DOMProcessingInstruction('foo');
+try {
+	$Foo->data = 'bar';
+} catch (DOMException $Ex) {
+	if ($Ex->getCode() == DOM_NO_MODIFICATION_ALLOWED_ERR) {
+		echo "OK\n";
+	} else {
+		echo "$Ex\n";
+	}
+}
+?>
+--EXPECT--
+OK


### PR DESCRIPTION
These patches just throw NO_MODIFICATION_ALLOWED_ERR when trying to edit read-only DOM objects.  See [DOM Level 3 Core Specification](https://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html).  I wouldn't consider them bugfixes, but I'd be happy to backport them if you like.