### PR TITLE
Make zend_closure public

### DIFF
--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -32,14 +32,6 @@
 #define ZEND_CLOSURE_PROPERTY_ERROR() \
 	zend_throw_error(NULL, "Closure object cannot have properties")
 
-typedef struct _zend_closure {
-	zend_object       std;
-	zend_function     func;
-	zval              this_ptr;
-	zend_class_entry *called_scope;
-	zif_handler       orig_internal_handler;
-} zend_closure;
-
 /* non-static since it needs to be referenced */
 ZEND_API zend_class_entry *zend_ce_closure;
 static zend_object_handlers closure_handlers;

--- a/Zend/zend_closures.h
+++ b/Zend/zend_closures.h
@@ -22,6 +22,14 @@
 
 BEGIN_EXTERN_C()
 
+typedef struct _zend_closure {
+	zend_object       std;
+	zend_function     func;
+	zval              this_ptr;
+	zend_class_entry *called_scope;
+	zif_handler       orig_internal_handler;
+} zend_closure;
+
 /* This macro depends on zend_closure structure layout */
 #define ZEND_CLOSURE_OBJECT(op_array) \
 	((zend_object*)((char*)(op_array) - sizeof(zend_object)))


### PR DESCRIPTION
Make `zend_closure` structure public so that third party extensions will have full access to this data type.