### PR TITLE
Fix #77530: PHP crashes when parsing "(2)::class"

### DIFF
--- a/Zend/tests/bug77530.phpt
+++ b/Zend/tests/bug77530.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #77530: PHP crashes when parsing '(2)::class'
+--FILE--
+<?php
+
+echo (2)::class;
+
+?>
+--EXPECTF--
+Fatal error: Illegal class name in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1480,6 +1480,7 @@ static void zend_ensure_valid_class_fetch_type(uint32_t fetch_type) /* {{{ */
 static zend_bool zend_try_compile_const_expr_resolve_class_name(zval *zv, zend_ast *class_ast, zend_ast *name_ast, zend_bool constant) /* {{{ */
 {
 	uint32_t fetch_type;
+	zval *class_name;
 
 	if (name_ast->kind != ZEND_AST_ZVAL) {
 		return 0;
@@ -1494,7 +1495,13 @@ static zend_bool zend_try_compile_const_expr_resolve_class_name(zval *zv, zend_a
 			"Dynamic class names are not allowed in compile-time ::class fetch");
 	}
 
-	fetch_type = zend_get_class_fetch_type(zend_ast_get_str(class_ast));
+	class_name = zend_ast_get_zval(class_ast);
+
+	if (Z_TYPE_P(class_name) != IS_STRING) {
+		zend_error_noreturn(E_COMPILE_ERROR, "Illegal class name");
+	}
+
+	fetch_type = zend_get_class_fetch_type(Z_STR_P(class_name));
 	zend_ensure_valid_class_fetch_type(fetch_type);
 
 	switch (fetch_type) {


### PR DESCRIPTION
Hi! This PR hopes to fix bug: https://bugs.php.net/bug.php?id=77530
Class name was assumed to be a string. The PR checks whether it is a string before type fetch, and throws a fatal error in case it is not.  
Note: I actually fixed this for master first on another local branch, which is a bit different than this version... but wasn't sure if I was solving it the right way, so here's the first attempt.