### PR TITLE
[WIP] Remove deprecated functionality in PHP 8

### DIFF
--- a/Zend/tests/bug29890.phpt
+++ b/Zend/tests/bug29890.phpt
@@ -2,7 +2,7 @@
 Bug #29890 (crash if error handler fails)
 --FILE--
 <?php
-function customErrorHandler($fErrNo,$fErrStr,$fErrFile,$fErrLine,$fClass) {
+function customErrorHandler($fErrNo,$fErrStr,$fErrFile,$fErrLine) {
 echo "error :".$fErrStr."\n";
 }
 

--- a/Zend/tests/bug29896.phpt
+++ b/Zend/tests/bug29896.phpt
@@ -2,7 +2,7 @@
 Bug #29896 (Backtrace argument list out of sync)
 --FILE--
 <?php
-function userErrorHandler($num, $msg, $file, $line, $vars)
+function userErrorHandler($num, $msg, $file, $line)
 {
     debug_print_backtrace();
 }
@@ -22,6 +22,6 @@ function GenerateError2($A1)
 GenerateError2("Test2");
 ?>
 --EXPECTF--
-#0  userErrorHandler(8, Undefined variable: b, %sbug29896.php, 11, Array ([A1] => Test1)) called at [%sbug29896.php:11]
+#0  userErrorHandler(8, Undefined variable: b, %sbug29896.php, 11) called at [%sbug29896.php:11]
 #1  GenerateError1(Test1) called at [%sbug29896.php:16]
 #2  GenerateError2(Test2) called at [%sbug29896.php:19]

--- a/Zend/tests/bug35017.phpt
+++ b/Zend/tests/bug35017.phpt
@@ -13,7 +13,7 @@ try {
 } catch(Exception $e) {
   echo "This Exception should be caught\n";
 }
-function errorHandler($errno, $errstr, $errfile, $errline, $vars) {
+function errorHandler($errno, $errstr, $errfile, $errline) {
 	throw new Exception('Some Exception');
 }
 ?>

--- a/Zend/tests/bug41209.phpt
+++ b/Zend/tests/bug41209.phpt
@@ -41,6 +41,6 @@ echo "Done\n";
 --EXPECTF--
 Fatal error: Uncaught ErrorException: Undefined variable: id in %s:%d
 Stack trace:
-#0 %s(%d): env::errorHandler(8, '%s', '%s', 34, Array)
+#0 %s(%d): env::errorHandler(8, '%s', '%s', 34)
 #1 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug45805.phpt
+++ b/Zend/tests/bug45805.phpt
@@ -38,7 +38,7 @@ $o->bar();
 --EXPECTF--
 Fatal error: Uncaught RuntimeException in %sbug45805.php:%d
 Stack trace:
-#0 %sbug45805.php(%d): PHPUnit_Util_ErrorHandler::handleError(8, 'Only variables ...', '%s', %d, Array)
+#0 %sbug45805.php(%d): PHPUnit_Util_ErrorHandler::handleError(8, 'Only variables ...', '%s', %d)
 #1 [internal function]: B->foo()
 #2 %sbug45805.php(%d): ReflectionMethod->invoke(Object(B))
 #3 %sbug45805.php(%d): B->bar()

--- a/Zend/tests/bug48004.phpt
+++ b/Zend/tests/bug48004.phpt
@@ -2,7 +2,7 @@
 Bug #48004 (Error handler prevents creation of default object)
 --FILE--
 <?php
-function error_handler($errno, $errstr, $errfile, $errline, $errcontext) {
+function error_handler($errno, $errstr, $errfile, $errline) {
         return true;
 }
 

--- a/Zend/tests/bug51394.phpt
+++ b/Zend/tests/bug51394.phpt
@@ -15,6 +15,6 @@ $a = $empty($b);
 --EXPECTF--
 Fatal error: Uncaught Exception: error! in %sbug51394.php:%d
 Stack trace:
-#0 %sbug51394.php(%d): eh(8, 'Undefined varia%s', '%s', %d, Array)
+#0 %sbug51394.php(%d): eh(8, 'Undefined varia%s', '%s', %d)
 #1 {main}
   thrown in %sbug51394.php on line %d

--- a/Zend/tests/bug60909_1.phpt
+++ b/Zend/tests/bug60909_1.phpt
@@ -13,7 +13,7 @@ require 'notfound.php';
 error(require(notfound.php): failed to open stream: %s)
 Warning: Uncaught Exception: Foo in %sbug60909_1.php:5
 Stack trace:
-#0 %sbug60909_1.php(8): {closure}(2, 'require(notfoun...', '%s', 8, Array)
+#0 %sbug60909_1.php(8): {closure}(2, 'require(notfoun...', '%s', 8)
 #1 %sbug60909_1.php(8): require()
 #2 {main}
   thrown in %sbug60909_1.php on line 5

--- a/Zend/tests/bug61767.phpt
+++ b/Zend/tests/bug61767.phpt
@@ -19,7 +19,7 @@ Error handler called (Undefined variable: undefined)
 
 Fatal error: Uncaught ErrorException: Undefined variable: undefined in %sbug61767.php:%d
 Stack trace:
-#0 %sbug61767.php(%d): {closure}(%s, 'Undefined varia...', '%s', %d, Array)
+#0 %sbug61767.php(%d): {closure}(%s, 'Undefined varia...', '%s', %d)
 #1 {main}
   thrown in %sbug61767.php on line %d
 Shutting down

--- a/Zend/tests/bug64960.phpt
+++ b/Zend/tests/bug64960.phpt
@@ -33,7 +33,7 @@ Notice: ob_end_flush(): failed to delete and flush buffer. No buffer to delete o
 
 Fatal error: Uncaught Exception in %sbug64960.php:19
 Stack trace:
-#0 [internal function]: {closure}(8, 'ob_end_clean():...', '%s', 9, Array)
+#0 [internal function]: {closure}(8, 'ob_end_clean():...', '%s', 9)
 #1 %sbug64960.php(9): ob_end_clean()
 #2 [internal function]: ExceptionHandler->__invoke(Object(Exception))
 #3 {main}

--- a/Zend/tests/bug69388.phpt
+++ b/Zend/tests/bug69388.phpt
@@ -3,7 +3,7 @@ Bug #69388: Use after free on recursive calls to PHP compiler
 --FILE--
 <?php
 
-function handle_error($code, $message, $file, $line, $context) {
+function handle_error($code, $message, $file, $line) {
 	if (!function_exists("bla")) {
 		eval('function bla($s) {echo "$s\n";}');
 	}

--- a/Zend/tests/bug69388_2.phpt
+++ b/Zend/tests/bug69388_2.phpt
@@ -2,7 +2,7 @@
 Bug #69388 - Variation
 --FILE--
 <?php
-function handle_error($code, $message, $file, $line, $context) {
+function handle_error($code, $message, $file, $line) {
     eval('namespace Foo;');
     echo "$message\n";
 }

--- a/Zend/tests/bug72057.phpt
+++ b/Zend/tests/bug72057.phpt
@@ -13,7 +13,7 @@ set_error_handler(
 --EXPECTF--
 Fatal error: Uncaught Exception: My custom error in %s:%d
 Stack trace:
-#0 %s(%d): {closure}(8, 'A non well form...', '%s', %d, Array)
+#0 %s(%d): {closure}(8, 'A non well form...', '%s', %d)
 #1 %s(%d): {closure}('7as')
 #2 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug72101.phpt
+++ b/Zend/tests/bug72101.phpt
@@ -76,7 +76,7 @@ $foo->bar($a, $b, $c);
 --EXPECTF--
 Fatal error: Uncaught Error: Class 'DoesNotExists' not found in %sbug72101.php:61
 Stack trace:
-#0 %sbug72101.php(8): {closure}(2, 'Parameter 1 to ...', '%s', 8, Array)
+#0 %sbug72101.php(8): {closure}(2, 'Parameter 1 to ...', '%s', 8)
 #1 %sbug72101.php(27): PHPUnit_Framework_MockObject_Stub_ReturnCallback->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))
 #2 %sbug72101.php(19): PHPUnit_Framework_MockObject_Matcher->invoked(Object(PHPUnit_Framework_MockObject_Invocation_Static))
 #3 %sbug72101.php(52): PHPUnit_Framework_MockObject_InvocationMocker->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))

--- a/Zend/tests/bug76025.phpt
+++ b/Zend/tests/bug76025.phpt
@@ -13,6 +13,6 @@ $c = $b[$a];
 --EXPECTF--
 Fatal error: Uncaught Exception: blah in %sbug76025.php:%d
 Stack trace:
-#0 %sbug76025.php(%d): handleError(8, 'Undefined varia...', '%s', %d, Array)
+#0 %sbug76025.php(%d): handleError(8, 'Undefined varia...', '%s', %d)
 #1 {main}
   thrown in %sbug76025.php on line %d

--- a/Zend/tests/bug76534.phpt
+++ b/Zend/tests/bug76534.phpt
@@ -12,6 +12,6 @@ $y = &$x["bar"];
 --EXPECTF--
 Fatal error: Uncaught Exception: Illegal string offset 'bar' in %sbug76534.php:%d
 Stack trace:
-#0 %sbug76534.php(%d): {closure}(2, 'Illegal string ...', '%s', %d, Array)
+#0 %sbug76534.php(%d): {closure}(2, 'Illegal string ...', '%s', %d)
 #1 {main}
   thrown in %sbug76534.php on line %d

--- a/Zend/tests/nowdoc_015.phpt
+++ b/Zend/tests/nowdoc_015.phpt
@@ -2,7 +2,7 @@
 Test nowdoc and line numbering
 --FILE--
 <?php
-function error_handler($num, $msg, $file, $line, $vars) {
+function error_handler($num, $msg, $file, $line) {
 	echo $line,"\n";
 }
 set_error_handler('error_handler');

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1246,7 +1246,7 @@ static ZEND_COLD void zend_error_va_list(int type, const char *format, va_list a
 	va_list args;
 #endif
 	va_list usr_copy;
-	zval params[5];
+	zval params[4];
 	zval retval;
 	const char *error_filename;
 	uint32_t error_lineno = 0;
@@ -1255,7 +1255,6 @@ static ZEND_COLD void zend_error_va_list(int type, const char *format, va_list a
 	zend_class_entry *saved_class_entry;
 	zend_stack loop_var_stack;
 	zend_stack delayed_oplines_stack;
-	zend_array *symbol_table;
 	zend_class_entry *orig_fake_scope;
 
 	/* Report about uncaught exception in case of fatal errors */
@@ -1385,15 +1384,6 @@ static ZEND_COLD void zend_error_va_list(int type, const char *format, va_list a
 
 			ZVAL_LONG(&params[3], error_lineno);
 
-			symbol_table = zend_rebuild_symbol_table();
-
-			/* during shutdown the symbol table table can be still null */
-			if (!symbol_table) {
-				ZVAL_NULL(&params[4]);
-			} else {
-				ZVAL_ARR(&params[4], zend_array_dup(symbol_table));
-			}
-
 			ZVAL_COPY_VALUE(&orig_user_error_handler, &EG(user_error_handler));
 			ZVAL_UNDEF(&EG(user_error_handler));
 
@@ -1414,7 +1404,7 @@ static ZEND_COLD void zend_error_va_list(int type, const char *format, va_list a
 			orig_fake_scope = EG(fake_scope);
 			EG(fake_scope) = NULL;
 
-			if (call_user_function(CG(function_table), NULL, &orig_user_error_handler, &retval, 5, params) == SUCCESS) {
+			if (call_user_function(CG(function_table), NULL, &orig_user_error_handler, &retval, 4, params) == SUCCESS) {
 				if (Z_TYPE(retval) != IS_UNDEF) {
 					if (Z_TYPE(retval) == IS_FALSE) {
 						zend_error_cb(type, error_filename, error_lineno, format, args);
@@ -1435,7 +1425,6 @@ static ZEND_COLD void zend_error_va_list(int type, const char *format, va_list a
 				CG(in_compilation) = 1;
 			}
 
-			zval_ptr_dtor(&params[4]);
 			zval_ptr_dtor(&params[2]);
 			zval_ptr_dtor(&params[1]);
 

--- a/ext/iconv/tests/iconv_mime_decode.phpt
+++ b/ext/iconv/tests/iconv_mime_decode.phpt
@@ -6,7 +6,7 @@ iconv_mime_decode()
 iconv.internal_charset=iso-8859-1
 --FILE--
 <?php
-function my_error_handler($errno, $errmsg, $filename, $linenum, $vars)
+function my_error_handler($errno, $errmsg, $filename, $linenum)
 {
 	echo "$errno: $errmsg\n";
 }

--- a/ext/iconv/tests/iconv_mime_encode.phpt
+++ b/ext/iconv/tests/iconv_mime_encode.phpt
@@ -6,7 +6,7 @@ iconv_mime_encode()
 iconv.internal_charset=iso-8859-1
 --FILE--
 <?php
-function my_error_handler($errno, $errmsg, $filename, $linenum, $vars)
+function my_error_handler($errno, $errmsg, $filename, $linenum)
 {
 	echo "$errno: $errmsg\n";
 }

--- a/ext/iconv/tests/iconv_strpos.phpt
+++ b/ext/iconv/tests/iconv_strpos.phpt
@@ -6,7 +6,7 @@ iconv_strpos()
 iconv.internal_charset=ISO-8859-1
 --FILE--
 <?php
-function my_error_handler($errno, $errmsg, $filename, $linenum, $vars)
+function my_error_handler($errno, $errmsg, $filename, $linenum)
 {
 	echo "$errno: $errmsg\n";
 }

--- a/ext/iconv/tests/iconv_strrpos.phpt
+++ b/ext/iconv/tests/iconv_strrpos.phpt
@@ -6,7 +6,7 @@ iconv_strrpos()
 iconv.internal_charset=ISO-8859-1
 --FILE--
 <?php
-function my_error_handler($errno, $errmsg, $filename, $linenum, $vars)
+function my_error_handler($errno, $errmsg, $filename, $linenum)
 {
 	echo "$errno: $errmsg\n";
 }

--- a/ext/mbstring/tests/common.inc
+++ b/ext/mbstring/tests/common.inc
@@ -4,7 +4,7 @@
  */
 
 // Custom Error Hanlder for testing
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	global $debug;
 
 	$err_type = array (

--- a/ext/mbstring/tests/mb_substitute_character_variation1.phpt
+++ b/ext/mbstring/tests/mb_substitute_character_variation1.phpt
@@ -16,7 +16,7 @@ function_exists('mb_substitute_character') or die("skip mb_substitute_character(
 echo "*** Testing mb_substitute_character() : usage variation ***\n";
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/posix/tests/posix_ttyname_variation6.phpt
+++ b/ext/posix/tests/posix_ttyname_variation6.phpt
@@ -18,7 +18,7 @@ echo "*** Test substituting argument 1 with object values ***\n";
 
 
 
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
         if (error_reporting() != 0) {
                 // report non-silenced errors
                 echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/spl/tests/class_implements_variation1.phpt
+++ b/ext/spl/tests/class_implements_variation1.phpt
@@ -12,7 +12,7 @@ echo "*** Testing class_implements() : variation ***\n";
 
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/spl/tests/class_uses_variation1.phpt
+++ b/ext/spl/tests/class_uses_variation1.phpt
@@ -12,7 +12,7 @@ echo "*** Testing class_uses() : variation ***\n";
 
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/array/array_diff_uassoc_variation14.phpt
+++ b/ext/standard/tests/array/array_diff_uassoc_variation14.phpt
@@ -19,7 +19,7 @@ class classWithoutToString
 }
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/array/array_diff_ukey_variation11.phpt
+++ b/ext/standard/tests/array/array_diff_ukey_variation11.phpt
@@ -15,7 +15,7 @@ $array2 = array('blue'  => 1, 'red'  => 2, 'green'  => 3, 'purple' => 4);
 $array3 = array(1, 2, 3, 4, 5);
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
         if (error_reporting() != 0) {
                 // report non-silenced errors
                 echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/array/array_intersect_uassoc_variation11.phpt
+++ b/ext/standard/tests/array/array_intersect_uassoc_variation11.phpt
@@ -14,7 +14,7 @@ $array1 = array("a" => "green", "b" => "brown", "c" => "blue", "red");
 $array2 = array("a" => "green", "yellow", "red");
 $array3 = array("a"=>"green", "brown");
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
         if (error_reporting() != 0) {
                 // report non-silenced errors
                 echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/array/array_intersect_ukey_variation10.phpt
+++ b/ext/standard/tests/array/array_intersect_ukey_variation10.phpt
@@ -15,7 +15,7 @@ $array2 = array('green' => 5, 'blue' => 6, 'yellow' => 7, 'cyan'   => 8);
 $array3 = array("a"=>"green", "cyan");
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
         if (error_reporting() != 0) {
                 // report non-silenced errors
                 echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/array/array_multisort_variation1.phpt
+++ b/ext/standard/tests/array/array_multisort_variation1.phpt
@@ -11,7 +11,7 @@ Test array_multisort() function : usage variation
 echo "*** Testing array_multisort() : usage variation ***\n";
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/array/array_multisort_variation2.phpt
+++ b/ext/standard/tests/array/array_multisort_variation2.phpt
@@ -11,7 +11,7 @@ Test array_multisort() function : usage variation
 echo "*** Testing array_multisort() : usage variation ***\n";
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/array/array_multisort_variation3.phpt
+++ b/ext/standard/tests/array/array_multisort_variation3.phpt
@@ -11,7 +11,7 @@ Test array_multisort() function : usage variation
 echo "*** Testing array_multisort() : usage variation ***\n";
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/array/array_multisort_variation8.phpt
+++ b/ext/standard/tests/array/array_multisort_variation8.phpt
@@ -11,7 +11,7 @@ Test array_multisort() function : usage variation - test sort order of all types
 echo "*** Testing array_multisort() : usage variation  - test sort order of all types***\n";
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	// We're testing sort order not errors so ignore.
 }
 set_error_handler('test_error_handler');

--- a/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
+++ b/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
@@ -9,7 +9,7 @@ Test get_class_methods() function : usage variations  - unexpected types
  */
 
 
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	echo "Error: $err_no - $err_msg, $filename($linenum)\n";
 }
 set_error_handler('test_error_handler');

--- a/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
+++ b/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
@@ -12,7 +12,7 @@ spl_autoload_register(function ($className) {
 	echo "In autoload($className)\n";
 });
 
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	echo "Error: $err_no - $err_msg, $filename($linenum)\n";
 }
 set_error_handler('test_error_handler');

--- a/ext/standard/tests/class_object/is_subclass_of_variation_001.phpt
+++ b/ext/standard/tests/class_object/is_subclass_of_variation_001.phpt
@@ -12,7 +12,7 @@ spl_autoload_register(function ($className) {
 	echo "In autoload($className)\n";
 });
 
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	echo "Error: $err_no - $err_msg, $filename($linenum)\n";
 }
 set_error_handler('test_error_handler');

--- a/ext/standard/tests/class_object/is_subclass_of_variation_004.phpt
+++ b/ext/standard/tests/class_object/is_subclass_of_variation_004.phpt
@@ -12,7 +12,7 @@ spl_autoload_register(function ($className) {
 	echo "In autoload($className)\n";
 });
 
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	echo "Error: $err_no - $err_msg, $filename($linenum)\n";
 }
 set_error_handler('test_error_handler');

--- a/ext/standard/tests/class_object/method_exists_variation_001.phpt
+++ b/ext/standard/tests/class_object/method_exists_variation_001.phpt
@@ -12,7 +12,7 @@ spl_autoload_register(function ($className) {
 	echo "In autoload($className)\n";
 });
 
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	echo "Error: $err_no - $err_msg, $filename($linenum)\n";
 }
 set_error_handler('test_error_handler');

--- a/ext/standard/tests/file/file_put_contents_variation2.phpt
+++ b/ext/standard/tests/file/file_put_contents_variation2.phpt
@@ -13,7 +13,7 @@ Dave Kelsey <d_kelsey@uk.ibm.com>
 echo "*** Testing file_put_contents() : usage variation ***\n";
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/file/file_put_contents_variation3.phpt
+++ b/ext/standard/tests/file/file_put_contents_variation3.phpt
@@ -13,7 +13,7 @@ Dave Kelsey <d_kelsey@uk.ibm.com>
 echo "*** Testing file_put_contents() : usage variation ***\n";
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/general_functions/intval_variation1.phpt
+++ b/ext/standard/tests/general_functions/intval_variation1.phpt
@@ -11,7 +11,7 @@ Test intval() function : usage variation
 echo "*** Testing intval() : usage variation ***\n";
 
 // Define error handler
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	if (error_reporting() != 0) {
 		// report non-silenced errors
 		echo "Error: $err_no - $err_msg, $filename($linenum)\n";

--- a/ext/standard/tests/image/getimagesize_variation2.phpt
+++ b/ext/standard/tests/image/getimagesize_variation2.phpt
@@ -8,7 +8,7 @@ Test getimagesize() function : usage variations  - unexpected type for arg 2
  * Alias to functions:
  */
 
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
 	echo "Error: $err_no - $err_msg, $filename($linenum)\n";
 }
 set_error_handler('test_error_handler');

--- a/tests/classes/tostring_004.phpt
+++ b/tests/classes/tostring_004.phpt
@@ -2,7 +2,7 @@
 Object to string conversion: error cases and behaviour variations.
 --FILE--
 <?php
-function test_error_handler($err_no, $err_msg, $filename, $linenum, $vars) {
+function test_error_handler($err_no, $err_msg, $filename, $linenum) {
         echo "Error: $err_no - $err_msg\n";
 }
 set_error_handler('test_error_handler');

--- a/tests/lang/bug25547.phpt
+++ b/tests/lang/bug25547.phpt
@@ -3,7 +3,7 @@ Bug #25547 (error_handler and array index with function call)
 --FILE--
 <?php
 
-function handler($errno, $errstr, $errfile, $errline, $context)
+function handler($errno, $errstr, $errfile, $errline)
 {
 	echo __FUNCTION__ . "($errstr)\n";
 }


### PR DESCRIPTION
Work in progress removal of deprecated functionality. 

From https://wiki.php.net/rfc/deprecations_php_7_2:

 * [x] __autoload (https://github.com/php/php-src/commit/0dfd918ee7a3520836b875b8c24f0a5f98fbee15)
 * [x] track_errors and $php_errormsg (https://github.com/php/php-src/commit/920b4b249f71e6cbfd795f81c6a08126a33c659e)
 * [x] create_function() (https://github.com/php/php-src/commit/ee16d99504f0014c3d292809da927fb622293f41)
 * [x] mbstring.func_overload (https://github.com/php/php-src/commit/331e56ce38a91e87a6fb8e88154bb5bde445b132)
 * [x] (unset) (https://github.com/php/php-src/commit/d74d3922ce6f9ea07c1226b0cb2a94fc333f7a02)
 * [x] parse_str() without second argument (https://github.com/php/php-src/commit/ff780feca4f1b2dd5c1b7cf692781070d49df7cb)
 * [x] gmp_random() (https://github.com/php/php-src/commit/734c305a822581c27ca3608cba482385dc247cf0)
 * [x] each() (https://github.com/php/php-src/commit/6db97f5e3ea3ac9774a06981226a0fe1bca02b38)
 * [x] assert() with string argument (https://github.com/php/php-src/commit/9bc2cacf7f97b4fc235baa29d7c8cf7604fb39c1)
 * [x] $errcontext argument of error handler (https://github.com/php/php-src/commit/2f1f34952e9a0dfb3adcbec82ba69f4ac82b3a3d)

From https://wiki.php.net/rfc/deprecations_php_7_3:

 * [x] Undocumented mbstring function aliases (https://github.com/php/php-src/commit/83bc092d40671ebe8bc7c5df1ee9c4456c7baf20)
 * [x] String search functions with integer needle (https://github.com/php/php-src/commit/c97b9aa2266736beb1ddb6fec0ec2d2af94e3a6c)
 * [x] fgetss() function and string.strip_tags filter (https://github.com/php/php-src/commit/c7d7af8069246c886606501e30e6e8741e6683c2)
 * [x] Defining a free-standing assert() function (https://github.com/php/php-src/commit/55dbb573226cf98d77e23becfd5148f0ea93d640)
 * [x] FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED flags (https://github.com/php/php-src/commit/6b89dbcc5bb9ae5e4852e4b8060934e405c5e1a1)
 * [ ] pdo_odbc.db2_instance_name php.ini directive

From https://wiki.php.net/rfc/remove_php4_constructors:

 * [x] PHP 4 style constructors (https://github.com/php/php-src/commit/371e4270b7e3975edb503b1f8901fac6b868cca1, https://github.com/php/php-src/commit/4d8dc2b05e7126bfcd5b639ca632906f96d5ff65, https://github.com/php/php-src/commit/682b54f68748715f85e9ac4a267477d9ac61918a)

From https://wiki.php.net/rfc/case_insensitive_constant_deprecation:

 * [x] Declaration of case-insensitive constants (https://github.com/php/php-src/commit/23a5be3696f4d92e1b18fd59f3ac63c6a15ea12a)
 * [x] Use of case-insensitive constants / handling of true/false/null (https://github.com/php/php-src/commit/3d39479f4d7c86c66aa92fc5d0d97fb660109ee9)

From https://wiki.php.net/rfc/deprecate_mb_ereg_replace_eval_option:

 * [x] mb_ereg_replace /e modifier (https://github.com/php/php-src/commit/52a9325328ca360b5ccf3c6efc2de3f7c53c5b58)

From https://externals.io/message/85595:

 * [x] password_hash salt parameter (https://github.com/php/php-src/commit/94ae35c9fbc34b26c514b2ba097e021744100f28)

From https://externals.io/message/86849:

 * [x] ldap_sort (https://github.com/php/php-src/commit/f0ddc93f46b31d117ae1c18dbce2bf39f1b91b94)

From https://wiki.php.net/rfc/deprecate-bareword-strings:

 * [x] Constant bareword fallback (https://github.com/php/php-src/commit/aad39879f2d2e89de105c4f87d334ee129b4321c)

From https://wiki.php.net/rfc/reclassify_e_strict (and followup):

 * [x] Static call to non-static method (https://github.com/php/php-src/commit/6c73b50cf6cf71be26700ce168d5e69350637d71, https://github.com/php/php-src/commit/e93bbf4d5d2812c698a4711fc0ff751b170bdf2b)
 * [x] mktime() and gmmktime() without arguments (https://github.com/php/php-src/commit/5a2787a02d56003e2e9731e2fad5b468180ec19a)

From https://github.com/php/php-src/commit/ba28d75c2c72bc17841dbc410496e8d62e139681:

 * [x] read_exif_data (https://github.com/php/php-src/commit/c88e2cce815a6d2d3fa0e7e8f46fe0fc8de6abe3)