### PR TITLE
getlogin/cuserid:

### DIFF
--- a/ext/posix/config.m4
+++ b/ext/posix/config.m4
@@ -9,7 +9,7 @@ if test "$PHP_POSIX" = "yes"; then
 
   AC_CHECK_HEADERS([sys/mkdev.h sys/sysmacros.h])
 
-  AC_CHECK_FUNCS(seteuid setegid setsid getsid setpgid getpgid ctermid mkfifo mknod setrlimit getrlimit getlogin getgroups makedev initgroups getpwuid_r getgrgid_r)
+  AC_CHECK_FUNCS(seteuid setegid setsid getsid setpgid getpgid ctermid mkfifo mknod setrlimit getrlimit getlogin getgroups makedev initgroups getpwuid_r getgrgid_r cuserid)
 
   AC_MSG_CHECKING([for working ttyname_r() implementation])
   AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -582,6 +582,7 @@ PHP_FUNCTION(posix_getgroups)
 #ifdef HAVE_GETLOGIN
 PHP_FUNCTION(posix_getlogin)
 {
+#ifndef HAVE_CUSERID
 	char *p;
 
 	PHP_POSIX_NO_ARGS;
@@ -592,6 +593,19 @@ PHP_FUNCTION(posix_getlogin)
 	}
 
 	RETURN_STRING(p);
+#else
+	char buf[33];
+	char *p;
+
+	PHP_POSIX_NO_ARGS;
+
+	if (NULL == (p = cuserid(buf))) {
+		POSIX_G(last_error) = errno;
+		RETURN_FALSE;
+	}
+
+	RETURN_STRING(p);
+#endif
 }
 #endif
 /* }}} */


### PR DESCRIPTION
If possible, using alternative implementation using external buffer.