### PR TITLE
Fix #77552: Uninitialized buffer in stat functions

### DIFF
--- a/ext/standard/tests/file/bug77552.phpt
+++ b/ext/standard/tests/file/bug77552.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #77552 Unintialized php_stream_statbuf in stat functions 
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) != 'WIN') {
+    die('skip.. only for Windows');
+}
+?>
+--FILE--
+<?php
+// Check lstat on a Windows junction to ensure that st_mode is zero
+$tmpDir = __DIR__.'/test-bug77552';
+
+$target = $tmpDir.'/folder/target';
+mkdir($target, 0777, true);
+
+$junction = $tmpDir.'/junction';
+$cmd = sprintf('mklink /J "%s" "%s"', $junction, $target); 
+exec($cmd);
+
+$stat = lstat($junction);
+var_dump($stat['mode']);
+
+?>
+--CLEAN--
+<?php
+$tmpDir = __DIR__.'/test-bug77552';
+$cmd = sprintf('rmdir /S /Q "%s"', $tmpDir);
+exec($cmd);
+?>
+--EXPECT--
+int(0)

--- a/ext/standard/tests/file/bug77552.phpt
+++ b/ext/standard/tests/file/bug77552.phpt
@@ -3,7 +3,7 @@ Bug #77552 Unintialized php_stream_statbuf in stat functions
 --SKIPIF--
 <?php
 if (substr(PHP_OS, 0, 3) != 'WIN') {
-    die('skip.. only for Windows');
+    die('skip windows only test');
 }
 ?>
 --FILE--

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1887,6 +1887,8 @@ PHPAPI int _php_stream_stat_path(const char *path, int flags, php_stream_statbuf
 	const char *path_to_open = path;
 	int ret;
 
+	memset(ssb, 0, sizeof(*ssb));
+
 	if (!(flags & PHP_STREAM_URL_STAT_NOCACHE)) {
 		/* Try to hit the cache first */
 		if (flags & PHP_STREAM_URL_STAT_LINK) {


### PR DESCRIPTION
An uninitialized `php_stream_statbuf` in php_stat (ext\standard\filestat.c) can cause random `st_mode` values when calling `lstat` on an NTFS junction.

The `php_sys_stat_ex` function (zend\zend_virtual_cwd.c) sets the st_mode for everything except a junction, so the uninitialized value is returned.

I have initialized the buffer in `_php_stream_stat_path`, since this function is called in several places.

Note that this anomaly has been "fixed" on master (https://github.com/php/php-src/commit/e42e8b1051a8abeaa8e6053653a4ff43438766e2) in that @weltling 's code in win32\ioutil.c initializes the individual stat members.