### PR TITLE
Properly check for array_replace_recursive in sccp.c

### DIFF
--- a/ext/opcache/Optimizer/sccp.c
+++ b/ext/opcache/Optimizer/sccp.c
@@ -735,7 +735,7 @@ static inline int ct_eval_func_call(
 		} else if (zend_string_equals_literal(name, "array_merge")
 				|| zend_string_equals_literal(name, "array_replace")
 				|| zend_string_equals_literal(name, "array_merge_recursive")
-				|| zend_string_equals_literal(name, "array_merge_recursive")
+				|| zend_string_equals_literal(name, "array_replace_recursive")
 				|| zend_string_equals_literal(name, "array_diff")
 				|| zend_string_equals_literal(name, "array_diff_assoc")
 				|| zend_string_equals_literal(name, "array_diff_key")) {
@@ -800,7 +800,7 @@ static inline int ct_eval_func_call(
 		} else if (zend_string_equals_literal(name, "array_merge")
 				|| zend_string_equals_literal(name, "array_replace")
 				|| zend_string_equals_literal(name, "array_merge_recursive")
-				|| zend_string_equals_literal(name, "array_merge_recursive")
+				|| zend_string_equals_literal(name, "array_replace_recursive")
 				|| zend_string_equals_literal(name, "array_diff")
 				|| zend_string_equals_literal(name, "array_diff_assoc")
 				|| zend_string_equals_literal(name, "array_diff_key")) {


### PR DESCRIPTION
This was harmless but unnecessary.