### PR TITLE
update ext/mbstring/config.m4 and acinclude.m4

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -945,6 +945,7 @@ dnl "cxx" can be used to indicate that a C++ shared module is desired.
 dnl "zend_ext" indicates a zend extension.
 AC_DEFUN([PHP_NEW_EXTENSION],[
   ext_builddir=[]PHP_EXT_BUILDDIR($1)
+  ext_abs_builddir=`readlink -f $ext_builddir`
   ext_srcdir=[]PHP_EXT_SRCDIR($1)
   ext_dir=[]PHP_EXT_DIR($1)
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -945,7 +945,7 @@ dnl "cxx" can be used to indicate that a C++ shared module is desired.
 dnl "zend_ext" indicates a zend extension.
 AC_DEFUN([PHP_NEW_EXTENSION],[
   ext_builddir=[]PHP_EXT_BUILDDIR($1)
-  ext_abs_builddir=`readlink -f $ext_builddir`
+  ext_abs_builddir=`cd $ext_builddir; pwd`
   ext_srcdir=[]PHP_EXT_SRCDIR($1)
   ext_dir=[]PHP_EXT_DIR($1)
 

--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -47,7 +47,13 @@ AC_DEFUN([PHP_MBSTRING_EXTENSION], [
   else
     PHP_ADD_SOURCES_X(PHP_EXT_DIR(mbstring),$PHP_MBSTRING_BASE_SOURCES,,shared_objects_mbstring,yes)
     if test -f "$ext_builddir/config.h.in"; then
-      out="$abs_builddir/config.h"
+dnl if is not empty $ext_abs_builddir from php-src/acinclude.m4
+      if ! test -z "$ext_abs_builddir"; then
+        out="$ext_abs_builddir/config.h"
+      else
+dnl use $abs_builddir from configure.ac
+        out="$abs_builddir/config.h"
+      fi
     else
       out="php_config.h"
     fi


### PR DESCRIPTION
```./configure --enable-mbstring=shared``` bug causing inclusion invalid header file into ext/mbstring/onigurama/src/config.h
This patch adds new variable (absolute path to the extension dir) which using when compiling from the php-src dir.