### PR TITLE
Update ext/mbstring/oniguruma/src/regparse.c

### DIFF
--- a/ext/mbstring/oniguruma/src/regparse.c
+++ b/ext/mbstring/oniguruma/src/regparse.c
@@ -393,7 +393,7 @@ save_entry(ScanEnv* env, enum SaveType type, int* id)
   c = ONIGENC_MBC_TO_CODE(enc, p, end); \
   pfetch_prev = p; \
   p += ONIGENC_MBC_ENC_LEN(enc, p); \
-  if(UNEXPECTED(p > end)) p = end; \
+  if(UNEXPECTED(p > end)) p = (UChar *)end; \
 } while (0)
 
 #define PINC_S     do { \


### PR DESCRIPTION
Macro minor fix to avoid compilator warning message ```warning assignmennt discards 'const' qualifier from pointer```