### PR TITLE
[EXPERIMENTAL] Skip slow tests on Appveyor

### DIFF
--- a/appveyor/test_task.bat
+++ b/appveyor/test_task.bat
@@ -93,7 +93,7 @@ set TEST_PHP_JUNIT=c:\junit.out.xml
 set SKIP_SLOW_TESTS=1
 
 cd "%APPVEYOR_BUILD_FOLDER%"
-nmake test TESTS="%OPCACHE_OPTS% -q --offline --show-diff --set-timeout 120 -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP --temp-source c:\tests_tmp --temp-target c:\tests_tmp"
+nmake test TESTS="%OPCACHE_OPTS% -q --offline --show-diff --show-slow 0 --set-timeout 120 -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP --temp-source c:\tests_tmp --temp-target c:\tests_tmp"
 
 set EXIT_CODE=%errorlevel%
 

--- a/appveyor/test_task.bat
+++ b/appveyor/test_task.bat
@@ -90,8 +90,10 @@ mkdir c:\tests_tmp
 
 set TEST_PHP_JUNIT=c:\junit.out.xml
 
+set SKIP_SLOW_TESTS=1
+
 cd "%APPVEYOR_BUILD_FOLDER%"
-nmake test TESTS="%OPCACHE_OPTS% -q --offline --show-diff --show-slow 1000 --set-timeout 120 -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP --temp-source c:\tests_tmp --temp-target c:\tests_tmp"
+nmake test TESTS="%OPCACHE_OPTS% -q --offline --show-diff --set-timeout 120 -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP --temp-source c:\tests_tmp --temp-target c:\tests_tmp"
 
 set EXIT_CODE=%errorlevel%
 


### PR DESCRIPTION
Our Appveyor CI times out very often since quite a while.  Let's see
whether we can trim down the build time considerably by skipping slow
tests.