### PR TITLE
Remove --disable-opcache-file-cache option

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -104,7 +104,7 @@ extern int lock_file;
 # endif
 #endif
 
-#if defined(HAVE_OPCACHE_FILE_CACHE) && defined(ZEND_WIN32)
+#if defined(ZEND_WIN32)
 # define ENABLE_FILE_CACHE_FALLBACK 1
 #else
 # define ENABLE_FILE_CACHE_FALLBACK 0
@@ -188,11 +188,9 @@ typedef struct _zend_accel_directives {
 #ifndef ZEND_WIN32
 	char          *lockfile_path;
 #endif
-#ifdef HAVE_OPCACHE_FILE_CACHE
 	char          *file_cache;
 	zend_bool      file_cache_only;
 	zend_bool      file_cache_consistency_checks;
-#endif
 #if ENABLE_FILE_CACHE_FALLBACK
 	zend_bool      file_cache_fallback;
 #endif
@@ -284,9 +282,7 @@ typedef struct _zend_accel_shared_globals {
 } zend_accel_shared_globals;
 
 extern zend_bool accel_startup_ok;
-#ifdef HAVE_OPCACHE_FILE_CACHE
 extern zend_bool file_cache_only;
-#endif
 #if ENABLE_FILE_CACHE_FALLBACK
 extern zend_bool fallback_process;
 #endif

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -3,18 +3,11 @@ dnl config.m4 for extension opcache
 PHP_ARG_ENABLE(opcache, whether to enable Zend OPcache support,
 [  --disable-opcache       Disable Zend OPcache support], yes)
 
-PHP_ARG_ENABLE(opcache-file, whether to enable file based caching,
-[  --disable-opcache-file  Disable file based caching], yes, no)
-
 PHP_ARG_ENABLE(huge-code-pages, whether to enable copying PHP CODE pages into HUGE PAGES,
 [  --disable-huge-code-pages
                           Disable copying PHP CODE pages into HUGE PAGES], yes, no)
 
 if test "$PHP_OPCACHE" != "no"; then
-
-  if test "$PHP_OPCACHE_FILE" = "yes"; then
-    AC_DEFINE(HAVE_OPCACHE_FILE_CACHE, 1, [Define to enable file based caching (experimental)])
-  fi
 
   if test "$PHP_HUGE_CODE_PAGES" = "yes"; then
     AC_DEFINE(HAVE_HUGE_CODE_PAGES, 1, [Define to enable copying PHP CODE pages into HUGE PAGES (experimental)])

--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -1,14 +1,8 @@
 ARG_ENABLE("opcache", "whether to enable Zend OPcache support", "yes");
 
-ARG_ENABLE("opcache-file", "whether to enable file based caching", "yes");
-
 /* var PHP_OPCACHE_PGO = false; */
 
 if (PHP_OPCACHE != "no") {
-
-	if (PHP_OPCACHE_FILE == "yes") {
-		AC_DEFINE('HAVE_OPCACHE_FILE_CACHE', 1, 'Define to enable file based caching (experimental)');
-	}
 
 	ZEND_EXTENSION('opcache', "\
 		ZendAccelerator.c \

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -245,7 +245,6 @@ static ZEND_INI_MH(OnEnable)
 	}
 }
 
-#ifdef HAVE_OPCACHE_FILE_CACHE
 static ZEND_INI_MH(OnUpdateFileCache)
 {
 	if (new_value) {
@@ -270,7 +269,6 @@ static ZEND_INI_MH(OnUpdateFileCache)
 	OnUpdateString(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 	return SUCCESS;
 }
-#endif
 
 ZEND_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("opcache.enable"             , "1", PHP_INI_ALL,    OnEnable,     enabled                             , zend_accel_globals, accel_globals)
@@ -312,11 +310,9 @@ ZEND_INI_BEGIN()
 	STD_PHP_INI_ENTRY("opcache.mmap_base", NULL, PHP_INI_SYSTEM,	OnUpdateString,	                             accel_directives.mmap_base,                 zend_accel_globals, accel_globals)
 #endif
 
-#ifdef HAVE_OPCACHE_FILE_CACHE
 	STD_PHP_INI_ENTRY("opcache.file_cache"                    , NULL  , PHP_INI_SYSTEM, OnUpdateFileCache, accel_directives.file_cache,                    zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.file_cache_only"               , "0"   , PHP_INI_SYSTEM, OnUpdateBool,	   accel_directives.file_cache_only,               zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.file_cache_consistency_checks" , "1"   , PHP_INI_SYSTEM, OnUpdateBool,	   accel_directives.file_cache_consistency_checks, zend_accel_globals, accel_globals)
-#endif
 #if ENABLE_FILE_CACHE_FALLBACK
 	STD_PHP_INI_ENTRY("opcache.file_cache_fallback"           , "1"   , PHP_INI_SYSTEM, OnUpdateBool,	   accel_directives.file_cache_fallback,           zend_accel_globals, accel_globals)
 #endif
@@ -404,12 +400,10 @@ void zend_accel_override_file_functions(void)
 {
 	zend_function *old_function;
 	if (ZCG(enabled) && accel_startup_ok && ZCG(accel_directives).file_override_enabled) {
-#ifdef HAVE_OPCACHE_FILE_CACHE
 		if (file_cache_only) {
 			zend_accel_error(ACCEL_LOG_WARNING, "file_override_enabled has no effect when file_cache_only is set");
 			return;
 		}
-#endif
 		/* override file_exists */
 		if ((old_function = zend_hash_str_find_ptr(CG(function_table), "file_exists", sizeof("file_exists")-1)) != NULL) {
 			orig_file_exists = old_function->internal_function.handler;
@@ -440,11 +434,7 @@ void zend_accel_info(ZEND_MODULE_INFO_FUNC_ARGS)
 	php_info_print_table_start();
 
 	if (ZCG(enabled) && accel_startup_ok &&
-#ifdef HAVE_OPCACHE_FILE_CACHE
 		((ZCG(counted) || ZCSG(accelerator_enabled)) || file_cache_only)
-#else
-		(ZCG(counted) || ZCSG(accelerator_enabled))
-#endif
 	) {
 		php_info_print_table_row(2, "Opcode Caching", "Up and Running");
 	} else {
@@ -455,7 +445,6 @@ void zend_accel_info(ZEND_MODULE_INFO_FUNC_ARGS)
 	} else {
 		php_info_print_table_row(2, "Optimization", "Disabled");
 	}
-#ifdef HAVE_OPCACHE_FILE_CACHE
 	if (!file_cache_only) {
 		php_info_print_table_row(2, "SHM Cache", "Enabled");
 	} else {
@@ -473,7 +462,6 @@ void zend_accel_info(ZEND_MODULE_INFO_FUNC_ARGS)
 			php_info_print_table_row(2, "Startup", "OK");
 		}
 	} else
-#endif
 	if (ZCG(enabled)) {
 		if (!accel_startup_ok || zps_api_failure_reason) {
 			php_info_print_table_row(2, "Startup Failed", zps_api_failure_reason);
@@ -611,7 +599,6 @@ static ZEND_FUNCTION(opcache_get_status)
 	/* Trivia */
 	add_assoc_bool(return_value, "opcache_enabled", ZCG(enabled) && (ZCG(counted) || ZCSG(accelerator_enabled)));
 
-#ifdef HAVE_OPCACHE_FILE_CACHE
 	if (ZCG(accel_directives).file_cache) {
 		add_assoc_string(return_value, "file_cache", ZCG(accel_directives).file_cache);
 	}
@@ -619,7 +606,6 @@ static ZEND_FUNCTION(opcache_get_status)
 		add_assoc_bool(return_value, "file_cache_only", 1);
 		return;
 	}
-#endif
 
 	add_assoc_bool(return_value, "cache_full", ZSMMG(memory_exhausted));
 	add_assoc_bool(return_value, "restart_pending", ZCSG(restart_pending));
@@ -770,11 +756,9 @@ static ZEND_FUNCTION(opcache_get_configuration)
 	add_assoc_string(&directives, "opcache.lockfile_path",          STRING_NOT_NULL(ZCG(accel_directives).lockfile_path));
 #endif
 
-#ifdef HAVE_OPCACHE_FILE_CACHE
 	add_assoc_string(&directives, "opcache.file_cache",                    ZCG(accel_directives).file_cache ? ZCG(accel_directives).file_cache : "");
 	add_assoc_bool(&directives,   "opcache.file_cache_only",               ZCG(accel_directives).file_cache_only);
 	add_assoc_bool(&directives,   "opcache.file_cache_consistency_checks", ZCG(accel_directives).file_cache_consistency_checks);
-#endif
 
 	add_assoc_zval(return_value, "directives", &directives);
 

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -27,8 +27,6 @@
 #include "ext/standard/md5.h"
 #endif
 
-#ifdef HAVE_OPCACHE_FILE_CACHE
-
 #include "ZendAccelerator.h"
 #include "zend_file_cache.h"
 #include "zend_shared_alloc.h"
@@ -1691,5 +1689,3 @@ void zend_file_cache_invalidate(zend_string *full_path)
 	zend_file_cache_unlink(filename);
 	efree(filename);
 }
-
-#endif /* HAVE_OPCACHE_FILE_CACHE */

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -29,7 +29,6 @@
 #include "zend_operators.h"
 #include "zend_interfaces.h"
 
-#ifdef HAVE_OPCACHE_FILE_CACHE
 #define zend_set_str_gc_flags(str) do { \
 	if (file_cache_only) { \
 		GC_TYPE_INFO(str) = IS_STRING | (IS_STR_INTERNED << GC_FLAGS_SHIFT); \
@@ -37,11 +36,6 @@
 		GC_TYPE_INFO(str) = IS_STRING | ((IS_STR_INTERNED | IS_STR_PERMANENT) << GC_FLAGS_SHIFT); \
 	} \
 } while (0)
-#else
-#define zend_set_str_gc_flags(str) do {\
-	GC_TYPE_INFO(str) = IS_STRING | ((IS_STR_INTERNED | IS_STR_PERMANENT) << GC_FLAGS_SHIFT); \
-} while (0)
-#endif
 
 #define zend_accel_store_string(str) do { \
 		zend_string *new_str = zend_shared_alloc_get_xlat_entry(str); \


### PR DESCRIPTION
This is no longer an experimental feature, and we have the ability to control this at runtime via an ini setting already. There doesn't seem to be any good reason for also having a compile-time option which requires littering the whole code with `HAVE_OPCODE_FILE_CACHE` checks. Case in point, the `--disable-opcache-file-cache` build is currently broken, because such a check was missed in one place.

@dstogov Any objections?