### PR TITLE
Fix failing readline() basic test

### DIFF
--- a/ext/readline/tests/readline_basic.phpt
+++ b/ext/readline/tests/readline_basic.phpt
@@ -14,5 +14,4 @@ var_dump(readline('Enter some text:'));
 --STDIN--
 I love PHP
 --EXPECTF--
-Enter some text:I love PHP
-string(10) "I love PHP"
+%Astring(10) "I love PHP"


### PR DESCRIPTION
Test for `readline()` basic doesn't seem to capture the STDIN in the output for some systems such as macOS and Windows.
