### PR TITLE
Fix FR #15184 (Calculate the quarter with date('Q')?)

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1156,6 +1156,9 @@ static zend_string *date_format(char *format, size_t format_len, timelib_time *t
 			case 'n': length = slprintf(buffer, sizeof(buffer), "%d", (int) t->m); break;
 			case 't': length = slprintf(buffer, sizeof(buffer), "%d", (int) timelib_days_in_month(t->y, t->m)); break;
 
+			/* quarter */
+			case 'q': length = slprintf(buffer, sizeof(buffer), "%d", (int) ceil(t->m / 3.0)); break;
+
 			/* year */
 			case 'L': length = slprintf(buffer, sizeof(buffer), "%d", timelib_is_leap((int) t->y)); break;
 			case 'y': length = slprintf(buffer, sizeof(buffer), "%02d", (int) (t->y % 100)); break;

--- a/ext/date/tests/DateTime_format_basic1.phpt
+++ b/ext/date/tests/DateTime_format_basic1.phpt
@@ -23,6 +23,7 @@ var_dump( $date->format( '\i\t \i\s \t\h\e jS \d\a\y.') );
 var_dump( $date->format( "D M j G:i:s T Y") );
 var_dump( $date->format( 'H:m:s \m \i\s\ \m\o\n\t\h') );
 var_dump( $date->format( "H:i:s") );
+var_dump( $date->format( "q") );
 
 ?>
 ===DONE===
@@ -37,4 +38,5 @@ string(19) "it is the 14th day."
 string(28) "Thu Jul 14 22:30:41 BST 2005"
 string(19) "22:07:41 m is month"
 string(8) "22:30:41"
+string(1) "3"
 ===DONE===

--- a/ext/date/tests/req15184.phpt
+++ b/ext/date/tests/req15184.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Request #15184 (Calculate the quarter with date('Q')?)
+--FILE--
+<?php
+for($m = 1 ; $m <= 12 ; $m++)
+  echo date('q', mktime(0, 0, 0, $m, 1, 2000));
+
+echo "\nDONE\n";
+?>
+--EXPECT--
+111222333444
+DONE


### PR DESCRIPTION
See https://bugs.php.net/bug.php?id=15184.

Support for "%q" to retrieve the quarter was added to GNU coreutils in 2016: https://lists.gnu.org/archive/html/coreutils/2016-11/txtyou3dsgRqN.txt

I believe it makes sense to support it in PHP too. E.g. if you have a dynamic format passed to DateTime format() that might include quarter, you don't have to detect and calculate the quarter separately.