### PR TITLE
Fix failing tests

### DIFF
--- a/ext/zip/tests/oo_unchangeIndex.phpt
+++ b/ext/zip/tests/oo_unchangeIndex.phpt
@@ -29,8 +29,10 @@ var_dump($zip->getNameIndex(0));
 var_dump($zip->getCommentIndex(0));
 
 var_dump(md5_file($file));
-
-unlink($file);
+?>
+--CLEAN--
+<?php
+unlink(__DIR__.'/__tmp_oo_unchangeIndex.zip');
 ?>
 --EXPECT--
 string(32) "cb753d0a812b2edb386bdcbc4cd7d131"

--- a/ext/zip/tests/oo_unchangeName.phpt
+++ b/ext/zip/tests/oo_unchangeName.phpt
@@ -29,8 +29,10 @@ var_dump($zip->getNameIndex(0));
 var_dump($zip->getCommentIndex(0));
 
 var_dump(md5_file($file));
-
-unlink($file);
+?>
+--CLEAN--
+<?php
+unlink(__DIR__.'/__tmp_oo_unchangeIndex.zip');
 ?>
 --EXPECT--
 string(32) "cb753d0a812b2edb386bdcbc4cd7d131"


### PR DESCRIPTION
The run-tests script executes the cleaning section separately and interferes with the running test itself less. This should fix two failing tests on the Windows platforms.