### PR TITLE
Expand FTP delete basic test with "unknown file" coverage

### DIFF
--- a/ext/ftp/tests/ftp_delete.phpt
+++ b/ext/ftp/tests/ftp_delete.phpt
@@ -2,6 +2,8 @@
 Testing ftp_delete basic functionality
 --CREDITS--
 Gabriel Caruso (carusogabriel34@gmail.com)
+Contributed by Ward Cappelle <wardcappelle@gmail.com>
+User Group: PHP-WVL & PHPGent #PHPTestFest
 --SKIPIF--
 <?php require 'skipif.inc'; ?>
 --FILE--
@@ -12,7 +14,18 @@ $ftp = ftp_connect('127.0.0.1', $port);
 ftp_login($ftp, 'user', 'pass');
 $ftp or die("Couldn't connect to the server");
 
-var_dump(ftp_delete($ftp, 'file'));
+echo "Test case #1: removal of existing file from FTP, should return true:", PHP_EOL;
+var_dump(ftp_delete($ftp, 'file1'));
+
+echo "Test case #2: removal of non-existent file from FTP, should return false:", PHP_EOL;
+var_dump(ftp_delete($ftp, 'false-file.boo'));
+
+ftp_close($ftp);
 ?>
---EXPECT--
+--EXPECTF--
+Test case #1: removal of existing file from FTP, should return true:
 bool(true)
+Test case #2: removal of non-existent file from FTP, should return false:
+
+Warning: ftp_delete(): No such file or directory in %s on line %d
+bool(false)

--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -464,9 +464,12 @@ if ($pid) {
 		} elseif (preg_match('/^SITE CHMOD/', $buf, $matches)) {
 			fputs($s, "200 OK\r\n");
 
-		} elseif (preg_match('/^DELE/', $buf, $matches)) {
-			fputs($s, "250 OK\r\n");
-
+		} elseif (preg_match('/^DELE ([\w\h]+)/', $buf, $matches)) {
+			if (isset($matches[1]) && in_array($matches[1], ['file1', "file\nb0rk"])){
+				fputs($s, "250 Delete successful\r\n");
+			} else {
+				fputs($s, "550 No such file or directory\r\n");
+			}
 		} elseif (preg_match('/^ALLO (\d+)/', $buf, $matches)) {
 			fputs($s, "200 " . $matches[1] . " bytes allocated\r\n");
 


### PR DESCRIPTION
A port of the original https://github.com/phpcommunity/phptestfest-php-src/pull/148 pull
request, created earlier during #PHPTestFest (User Group: PHP-WVL & PHPGent).

Expands the existing FTP delete command test with coverage for deletion of
non-existing files (which returns a 550 status code).