### PR TITLE
Fix failing tests for readline without input

### DIFF
--- a/ext/readline/tests/readline_without_input.phpt
+++ b/ext/readline/tests/readline_without_input.phpt
@@ -10,6 +10,6 @@ User Group: PHP-WVL & PHPGent #PHPTestFest
 var_dump(readline());
 var_dump(readline('Prompt:'));
 ?>
---EXPECT--
+--EXPECTF--
 bool(false)
-bool(false)
+%Abool(false)


### PR DESCRIPTION
This should fix the failed basic tests for `readline()` without input. When readline is used as a libedit wrapper it behaves a bit different than the one with libreadline...