### PR TITLE
[Bug] 77024 - Correct the behaviour of casting spl files to strings 

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -3112,7 +3112,7 @@ static const zend_function_entry spl_SplFileObject_functions[] = {
 	SPL_ME(SplFileObject, seek,           arginfo_file_object_seek,          ZEND_ACC_PUBLIC)
 	/* mappings */
 	SPL_MA(SplFileObject, getCurrentLine, SplFileObject, fgets,      arginfo_splfileinfo_void, ZEND_ACC_PUBLIC)
-	SPL_MA(SplFileObject, __toString,     SplFileObject, current,    arginfo_splfileinfo_void, ZEND_ACC_PUBLIC)
+	SPL_MA(SplFileObject, __toString,     SplFileObject, fgets,      arginfo_splfileinfo_void, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 

--- a/ext/spl/tests/bug77024.phpt
+++ b/ext/spl/tests/bug77024.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #77024 SplFileObject::__toString() may return array
+--FILE--
+<?php
+
+$file = new SplTempFileObject;
+$file->fputcsv(['foo', 'bar', 'baz']);
+$file->rewind();
+$file->setFlags(SplFileObject::READ_CSV);
+echo $file . "\n";
+
+$tmp = tempnam(sys_get_temp_dir(), "php-tests-");
+file_put_contents($tmp, "line1\nline2\nline3\n");
+$file = new SplFileObject($tmp);
+$file->rewind();
+echo $file . "\n";
+unset($file);
+unlink($tmp);
+
+?>
+--EXPECT--
+foo,bar,baz
+
+line1


### PR DESCRIPTION
[Bug #77024](https://bugs.php.net/bug.php?id=77024)

This PR makes `__toString()` in a CSV context consistent with a plain text file.

This behaviour contradicts the manual (and common sense as far as I can tell) but this PR ensures backwards compatibility