### PR TITLE
Drop support for libreadline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - locales
       - language-pack-de
       - re2c
+      - libedit-dev
       - libgmp-dev
       - libicu-dev
       - libtidy-dev

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -3,79 +3,7 @@ dnl config.m4 for extension readline
 PHP_ARG_WITH(libedit,for libedit readline replacement,
 [  --with-libedit          Include libedit readline replacement (CLI/CGI only)])
 
-if test "$PHP_LIBEDIT" = "no"; then
-  PHP_ARG_WITH(readline,for readline support,
-  [  --with-readline[=DIR]     Include readline support (CLI/CGI only)])
-else
-  dnl "register" the --with-readline option to preven invalid "unknown configure option" warning
-  php_with_readline=no
-fi
-
-if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
-  for i in $PHP_READLINE /usr/local /usr; do
-    test -f $i/include/readline/readline.h && READLINE_DIR=$i && break
-  done
-
-  if test -z "$READLINE_DIR"; then
-    AC_MSG_ERROR(Please reinstall readline - I cannot find readline.h)
-  fi
-
-  PHP_ADD_INCLUDE($READLINE_DIR/include)
-
-  PHP_READLINE_LIBS=""
-  AC_CHECK_LIB(ncurses, tgetent,
-  [
-    PHP_ADD_LIBRARY(ncurses,,READLINE_SHARED_LIBADD)
-    PHP_READLINE_LIBS="$PHP_READLINE_LIBS -lncurses"
-  ],[
-    AC_CHECK_LIB(termcap, tgetent,
-    [
-      PHP_ADD_LIBRARY(termcap,,READLINE_SHARED_LIBADD)
-      PHP_READLINE_LIBS="$PHP_READLINE_LIBS -ltermcap"
-    ])
-  ])
-
-  PHP_CHECK_LIBRARY(readline, readline,
-  [
-    PHP_ADD_LIBRARY_WITH_PATH(readline, $READLINE_DIR/$PHP_LIBDIR, READLINE_SHARED_LIBADD)
-  ], [
-    AC_MSG_ERROR(readline library not found)
-  ], [
-    -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
-  ])
-
-  PHP_CHECK_LIBRARY(readline, rl_pending_input,
-  [], [
-    AC_MSG_ERROR([invalid readline installation detected. Try --with-libedit instead.])
-  ], [
-    -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
-  ])
-
-  PHP_CHECK_LIBRARY(readline, rl_callback_read_char,
-  [
-    AC_DEFINE(HAVE_RL_CALLBACK_READ_CHAR, 1, [ ])
-  ],[],[
-    -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
-  ])
-
-  PHP_CHECK_LIBRARY(readline, rl_on_new_line,
-  [
-    AC_DEFINE(HAVE_RL_ON_NEW_LINE, 1, [ ])
-  ],[],[
-    -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
-  ])
-
-  PHP_CHECK_LIBRARY(readline, rl_completion_matches,
-  [
-    AC_DEFINE(HAVE_RL_COMPLETION_MATCHES, 1, [ ])
-  ],[],[
-    -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
-  ])
-
-  AC_DEFINE(HAVE_HISTORY_LIST, 1, [ ])
-  AC_DEFINE(HAVE_LIBREADLINE, 1, [ ])
-
-elif test "$PHP_LIBEDIT" != "no"; then
+if test "$PHP_LIBEDIT" != "no"; then
   if test "$PHP_LIBEDIT" != "yes"; then
     AC_MSG_WARN([libedit directory ignored, rely on pkg-config])
   fi
@@ -131,9 +59,7 @@ elif test "$PHP_LIBEDIT" != "no"; then
   ])
 
   AC_DEFINE(HAVE_LIBEDIT, 1, [ ])
-fi
-
-if test "$PHP_READLINE" != "no" || test "$PHP_LIBEDIT" != "no"; then
   PHP_NEW_EXTENSION(readline, readline.c readline_cli.c, $ext_shared, cli)
   PHP_SUBST(READLINE_SHARED_LIBADD)
 fi
+

--- a/ext/readline/php_readline.h
+++ b/ext/readline/php_readline.h
@@ -19,7 +19,7 @@
 #ifndef PHP_READLINE_H
 #define PHP_READLINE_H
 
-#if HAVE_LIBREADLINE || HAVE_LIBEDIT
+#if HAVE_LIBEDIT
 #ifndef PHP_WIN32
 #ifdef ZTS
 #warning Readline module will *NEVER* be thread-safe
@@ -36,6 +36,6 @@ extern zend_module_entry readline_module_entry;
 
 #define phpext_readline_ptr NULL
 
-#endif /* HAVE_LIBREADLINE */
+#endif /* HAVE_LIBEDIT */
 
 #endif /* PHP_READLINE_H */

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -50,12 +50,7 @@
 #include <unixlib/local.h>
 #endif
 
-#if HAVE_LIBEDIT
 #include <editline/readline.h>
-#else
-#include <readline/readline.h>
-#include <readline/history.h>
-#endif
 
 #include "zend_compile.h"
 #include "zend_execute.h"
@@ -667,11 +662,7 @@ static int readline_shell_run(void) /* {{{ */
 		}
 
 		if (history_lines_to_write) {
-#if HAVE_LIBEDIT
 			write_history(history_file);
-#else
-			append_history(history_lines_to_write, history_file);
-#endif
 			history_lines_to_write = 0;
 		}
 
@@ -750,11 +741,7 @@ PHP_MINIT_FUNCTION(cli_readline)
 	ZEND_INIT_MODULE_GLOBALS(cli_readline, cli_readline_init_globals, NULL);
 	REGISTER_INI_ENTRIES();
 
-#if HAVE_LIBEDIT
 	REGISTER_STRING_CONSTANT("READLINE_LIB", "libedit", CONST_CS|CONST_PERSISTENT);
-#else
-	REGISTER_STRING_CONSTANT("READLINE_LIB", "readline", CONST_CS|CONST_PERSISTENT);
-#endif
 
 	GET_SHELL_CB(cb);
 	if (cb) {

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -58,7 +58,7 @@ $TS \
 --enable-sysvshm \
 --enable-shmop \
 --enable-pcntl \
---with-readline \
+--with-libedit \
 --enable-mbstring \
 --with-curl \
 --with-gettext \


### PR DESCRIPTION
libreadline is GPL, so incompatible with PHP

- remove --with-libedit option and rely on pkg-config instead
- remove --with-readline DIR option
- cleanup conditions using HAVELIBREADLINE or HAVE_LIBEDIT
- keep HAVE_LIBEDIT in php_config.h is some extension use it

Notice: Windows already only support libedit