### PR TITLE
add readline_list_history with libedit >= 3.1

### DIFF
--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -74,6 +74,7 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
     -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
   ])
 
+  AC_DEFINE(HAVE_HISTORY_LIST, 1, [ ])
   AC_DEFINE(HAVE_LIBREADLINE, 1, [ ])
 
 elif test "$PHP_LIBEDIT" != "no"; then
@@ -124,6 +125,13 @@ elif test "$PHP_LIBEDIT" != "no"; then
   PHP_CHECK_LIBRARY(edit, rl_completion_matches,
   [
     AC_DEFINE(HAVE_RL_COMPLETION_MATCHES, 1, [ ])
+  ],[],[
+    -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
+  ])
+
+  PHP_CHECK_LIBRARY(edit, history_list,
+  [
+    AC_DEFINE(HAVE_HISTORY_LIST, 1, [ ])
   ],[],[
     -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
   ])

--- a/ext/readline/config.w32
+++ b/ext/readline/config.w32
@@ -9,6 +9,7 @@ if (PHP_READLINE != "no") {
 		EXTENSION("readline", "readline.c readline_cli.c");
 		ADD_FLAG("CFLAGS_READLINE", "/D HAVE_LIBEDIT");
 		ADD_FLAG("CFLAGS_READLINE", "/D HAVE_RL_COMPLETION_MATCHES");
+		ADD_FLAG("CFLAGS_READLINE", "/D HAVE_HISTORY_LIST");
 	} else {
 		WARNING("readline not enabled; libraries and headers not found");
 	}

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -45,7 +45,7 @@ PHP_FUNCTION(readline);
 PHP_FUNCTION(readline_add_history);
 PHP_FUNCTION(readline_info);
 PHP_FUNCTION(readline_clear_history);
-#ifndef HAVE_LIBEDIT
+#ifdef HAVE_HISTORY_LIST
 PHP_FUNCTION(readline_list_history);
 #endif
 PHP_FUNCTION(readline_read_history);
@@ -90,7 +90,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_readline_clear_history, 0)
 ZEND_END_ARG_INFO()
 
-#ifndef HAVE_LIBEDIT
+#ifdef HAVE_HISTORY_LIST
 ZEND_BEGIN_ARG_INFO(arginfo_readline_list_history, 0)
 ZEND_END_ARG_INFO()
 #endif
@@ -135,7 +135,7 @@ static const zend_function_entry php_readline_functions[] = {
 	PHP_FE(readline_info,  	            arginfo_readline_info)
 	PHP_FE(readline_add_history, 		arginfo_readline_add_history)
 	PHP_FE(readline_clear_history, 		arginfo_readline_clear_history)
-#ifndef HAVE_LIBEDIT
+#ifdef HAVE_HISTORY_LIST
 	PHP_FE(readline_list_history, 		arginfo_readline_list_history)
 #endif
 	PHP_FE(readline_read_history, 		arginfo_readline_read_history)
@@ -377,9 +377,10 @@ PHP_FUNCTION(readline_clear_history)
 }
 
 /* }}} */
+
+#ifdef HAVE_HISTORY_LIST
 /* {{{ proto array readline_list_history(void)
    Lists the history */
-#ifndef HAVE_LIBEDIT
 PHP_FUNCTION(readline_list_history)
 {
 	HIST_ENTRY **history;
@@ -388,19 +389,48 @@ PHP_FUNCTION(readline_list_history)
 		return;
 	}
 
+	array_init(return_value);
+
+#if defined(HAVE_LIBEDIT) && defined(PHP_WIN32) /* Winedit on Windows */
 	history = history_list();
 
-	array_init(return_value);
+	if (history) {
+		int i, n = history_length();
+		for (i = 0; i < n; i++) {
+				add_next_index_string(return_value, history[i]->line);
+		}
+	}
+
+#elif defined(HAVE_LIBEDIT) /* libedit */
+    {
+		HISTORY_STATE *hs;
+		int i;
+
+		using_history();
+		history = history_list();
+		hs = history_get_history_state();
+
+		if (history && hs) {
+			for (i = 0; i < hs->length; i++) {
+				add_next_index_string(return_value, history[i]->line);
+			}
+		}
+    }
+
+#else /* readline */
+	history = history_list();
 
 	if (history) {
 		int i;
 		for (i = 0; history[i]; i++) {
-			add_next_index_string(return_value,history[i]->line);
+			add_next_index_string(return_value, history[i]->line);
 		}
 	}
-}
 #endif
+}
 /* }}} */
+#endif
+
 /* {{{ proto bool readline_read_history([string filename])
    Reads the history */
 PHP_FUNCTION(readline_read_history)

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -407,12 +407,13 @@ PHP_FUNCTION(readline_list_history)
 		int i;
 
 		using_history();
-		history = history_list();
 		hs = history_get_history_state();
-
-		if (history && hs) {
-			for (i = 0; i < hs->length; i++) {
-				add_next_index_string(return_value, history[i]->line);
+		if (hs && hs->length) {
+			history = history_list();
+			if (history) {
+				for (i = 0; i < hs->length; i++) {
+					add_next_index_string(return_value, history[i]->line);
+				}
 			}
 		}
     }

--- a/ext/readline/tests/readline_read_history_001.phpt
+++ b/ext/readline/tests/readline_read_history_001.phpt
@@ -5,9 +5,9 @@ readline_read_history(): Basic test
 --FILE--
 <?php
 
-$name = tempnam('/tmp', 'readline.tmp');
+$name = tempnam(sys_get_temp_dir(), 'readline.tmp');
 
-readline_add_history("foo\n");
+readline_add_history("foo");
 
 var_dump(readline_write_history($name));
 

--- a/ext/readline/tests/readline_read_history_error_001.phpt
+++ b/ext/readline/tests/readline_read_history_error_001.phpt
@@ -6,9 +6,7 @@ Pedro Manoel Evangelista <pedro.evangelista at gmail dot com>
 <?php if (!extension_loaded("readline") || !function_exists('readline_read_history') || READLINE_LIB != "libedit") die("skip"); ?>
 --FILE--
 <?php
-var_dump(readline_read_history());
 var_dump(readline_read_history('nofile'));
 ?>
 --EXPECT--
-bool(false)
 bool(false)


### PR DESCRIPTION
@weltling can you please check change needed for windows 
 (can't find libedit in  win32/build/libs_version.txt)