### PR TITLE
Fix BC break in Windows readlink

### DIFF
--- a/ext/standard/tests/file/windows_links/readlink_compat.phpt
+++ b/ext/standard/tests/file/windows_links/readlink_compat.phpt
@@ -1,0 +1,89 @@
+--TEST--
+Test readlink bc behaviour on Windows
+--DESCRIPTION--
+Checks readlink is backward-compatible with PHP-7.3 and below
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) != 'WIN') {
+    die('skip windows only test');
+}
+exec('fltmc', $output, $exitCode);
+if ($exitCode !== 0) {
+    die('skip administrator privileges required');
+}
+?>
+--FILE--
+<?php
+$tmpDir = __DIR__ . '\\mnt';
+mkdir($tmpDir);
+
+// mounted volume
+$volume = trim(exec('mountvol C: /L'));
+exec(sprintf('mountvol "%s" %s', $tmpDir, $volume));
+var_dump(readlink($tmpDir)); 
+exec(sprintf('mountvol "%s" /D', $tmpDir));
+
+mkdir($tmpDir . '\\test\\directory', 0777, true);
+chdir($tmpDir . '\\test');
+
+// junction to a volume (same as a mounted volume)
+$link = $tmpDir . '\\test\\volume_junction';
+exec(sprintf('mklink /J "%s" %s', $link, $volume));
+var_dump(readlink($link));
+rmdir($link);
+
+// junction to a directory
+$link = $tmpDir . '\\test\\directory_junction';
+$target = $tmpDir . '\\test\\directory';
+exec(sprintf('mklink /J "%s" "%s"', $link, $target)); 
+var_dump(readlink($link));
+rmdir($link);
+
+// symlink to a directory (absolute and relative)
+$link = $tmpDir . '\\test\\directory_symlink';
+$target = $tmpDir . '\\test\\directory';
+exec(sprintf('mklink /D "%s" "%s"', $link, $target));
+var_dump(readlink($link));
+rmdir($link);
+exec(sprintf('mklink /D "%s" directory', $link));
+var_dump(readlink($link));
+rmdir($link);
+
+// create a file to link to
+$filename = $tmpDir . '\\test\\directory\\a.php';
+$fh = fopen($filename, 'w');
+fclose($fh);
+
+// symlink to a file (absolute and relative)
+$link = $tmpDir . '\\test\\file_symlink';
+exec(sprintf('mklink "%s" "%s"', $link, $filename)); 
+var_dump(readlink($link));
+unlink($link);
+exec(sprintf('mklink "%s" directory\\a.php', $link));
+var_dump(readlink($link));
+unlink($link);
+
+// unexpected behaviour
+echo "\n*** Unexpected behaviour when not a reparse point\n"; 
+var_dump(readlink($tmpDir . '\\test\\directory'));
+var_dump(readlink($filename));
+
+unlink($filename);
+
+chdir(__DIR__);
+rmdir($tmpDir . '\\test\\directory');
+rmdir($tmpDir . '\\test');
+rmdir($tmpDir);
+?>
+--EXPECTF--
+string(3) "C:\"
+string(3) "C:\"
+string(%d) "%s\mnt\test\directory"
+string(%d) "%s\mnt\test\directory"
+string(%d) "%s\mnt\test\directory"
+string(%d) "%s\mnt\test\directory\a.php"
+string(%d) "%s\mnt\test\directory\a.php"
+
+*** Unexpected behaviour when not a reparse point
+string(%d) "%s\mnt\test\directory"
+string(%d) "%s\mnt\test\directory\a.php"

--- a/win32/ioutil.c
+++ b/win32/ioutil.c
@@ -1004,6 +1004,13 @@ static ssize_t php_win32_ioutil_readlink_int(HANDLE h, wchar_t *buf, size_t buf_
 
 	if (reparse_data->ReparseTag == IO_REPARSE_TAG_SYMLINK) {
 		/* Real symlink */
+
+		/* BC - relative links are shown as absolute */
+		if (reparse_data->SymbolicLinkReparseBuffer.Flags & SYMLINK_FLAG_RELATIVE) {
+			SET_ERRNO_FROM_WIN32_CODE(ERROR_SYMLINK_NOT_SUPPORTED);
+			return -1;
+		}
+
 		reparse_target = reparse_data->SymbolicLinkReparseBuffer.ReparseTarget +
 			(reparse_data->SymbolicLinkReparseBuffer.SubstituteNameOffset /
 			sizeof(wchar_t));
@@ -1111,7 +1118,11 @@ PW32IO ssize_t php_win32_ioutil_readlink_w(const wchar_t *path, wchar_t *buf, si
 
 	ret = php_win32_ioutil_readlink_int(h, buf, buf_len);
 
-	if (ret < 0) {
+	if (ret < 0) {		
+		wchar_t target[PHP_WIN32_IOUTIL_MAXPATHLEN];		
+		size_t target_len;
+		size_t offset = 0;
+
 		/* BC - get a handle to the target (if path is a symbolic link) */
 		CloseHandle(h);
 		h = CreateFileW(path,
@@ -1127,9 +1138,7 @@ PW32IO ssize_t php_win32_ioutil_readlink_w(const wchar_t *path, wchar_t *buf, si
 			return -1;
 		}
 
-		wchar_t target[PHP_WIN32_IOUTIL_MAXPATHLEN];
-		size_t offset = 0,
-			   target_len = GetFinalPathNameByHandleW(h, target, PHP_WIN32_IOUTIL_MAXPATHLEN, VOLUME_NAME_DOS);
+		target_len = GetFinalPathNameByHandleW(h, target, PHP_WIN32_IOUTIL_MAXPATHLEN, VOLUME_NAME_DOS);
 
 		if(target_len >= buf_len || target_len >= PHP_WIN32_IOUTIL_MAXPATHLEN || target_len == 0) {
 			CloseHandle(h);

--- a/win32/ioutil.h
+++ b/win32/ioutil.h
@@ -88,6 +88,11 @@ typedef unsigned short mode_t;
 #define F_OK 0x00
 #endif
 
+/* from ntifs.h */
+#ifndef SYMLINK_FLAG_RELATIVE
+#define SYMLINK_FLAG_RELATIVE 0x01
+#endif
+
 typedef struct {
 	DWORD access;
 	DWORD share;

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -398,6 +398,8 @@ PHP_WINUTIL_API int php_win32_code_to_errno(unsigned long w32Err)
         /* 1314 */   ,  {   ERROR_PRIVILEGE_NOT_HELD        ,   EACCES          }
         /* 1816 */  ,   {   ERROR_NOT_ENOUGH_QUOTA          ,   ENOMEM          }
 					,   {   ERROR_ABANDONED_WAIT_0          ,   EIO }
+		/* 1464 */	,	{	ERROR_SYMLINK_NOT_SUPPORTED		,	EINVAL			}
+		/* 4390 */	,	{	ERROR_NOT_A_REPARSE_POINT		,	EINVAL			}
     };
 
     for(i = 0; i < sizeof(errmap)/sizeof(struct code_to_errno_map); ++i)


### PR DESCRIPTION
GetFinalPathNameByHandleW is given a file handle to a symbolic link, rather than one to the target, and therefore returns an incorrect path.

This happens with a volume mount point. Given a volume at `D:` mounted to a folder at `C:\mnt`:
```php
<?php
   # PHP-7.3 and down
    readlink('C:\\mnt')  // returns 'D:\'

   # PHP-7.4 and up
    readlink('C:\\mnt')  // returns 'C:\mnt'     
```
The readlink code was refactored in 91c905e83 with a backward-compatibility fix in 14628f1c5

I needed to add `ERROR_SYMLINK_NOT_SUPPORTED` to the `code_to_errno_map` in win32\winutil.c because debug builds were aborting.

I also added `ERROR_NOT_A_REPARSE_POINT` forthe same reason, which is set if DeviceIoControl is given a file handle that is not a reparse point (when FSCTL_GET_REPARSE_POINT is given as the dwIoControlCode).

It would appear that readlink on Windows will always succeed if given a file or directory path and return this path if it is not a link.

@weltling I would appreciate your input about this. Thanks.
 


