### PR TITLE
ABI hack for php_addslashes

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -577,7 +577,7 @@ static zend_always_inline double _zend_get_nan(void) /* {{{ */
 # define ZEND_INTRIN_SSSE3_FUNC_DECL(func)
 #endif
 
-#ifdef __SSE4_2__
+#if defined(HAVE_SSE4_2_DEF) || (defined(ZEND_WIN32) && defined(__SSE4_2__))
 /* Instructions compiled directly. */
 # define ZEND_INTRIN_SSE4_2_NATIVE 1
 #elif (defined(HAVE_FUNC_ATTRIBUTE_TARGET) && defined(PHP_HAVE_SSE4_2)) || defined(ZEND_WIN32)

--- a/configure.ac
+++ b/configure.ac
@@ -565,6 +565,24 @@ PHP_CHECK_CPU_SUPPORTS([sse4.2])
 PHP_CHECK_CPU_SUPPORTS([avx])
 PHP_CHECK_CPU_SUPPORTS([avx2])
 
+dnl The ABI of php_addslashes in PHP 7.3 is dependent on __SSE4_2__,
+dnl which depends on target attributes. Use this check to make sure that
+dnl SSE 4.2 availability during the PHP compilation is used, independently
+dnl of whether extensions are compiled with SSE 4.2 support.
+AC_MSG_CHECKING([whether __SSE4_2__ is defined])
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+int main() {
+#if defined(__SSE4_2__)
+  return 0;
+#else
+  return 1;
+#endif
+}
+]])], [
+  AC_MSG_RESULT([yes])
+  AC_DEFINE(HAVE_SSE4_2_DEF, 1, [Define if __SSE4_2__ has been defined])
+], [AC_MSG_RESULT([no])], [AC_MSG_RESULT([no])])
+
 dnl Check for members of the stat structure
 AC_CHECK_MEMBERS([struct stat.st_blksize, struct stat.st_rdev])
 dnl AC_STRUCT_ST_BLOCKS will screw QNX because fileblocks.o does not exist


### PR DESCRIPTION
Possible fix for crashes observed with xdebug on osx.

Currently php_addslashes has different ABI depending on whether `__SSE_4_2__` is set. If PHP and a shared extension are compiled with different `-march` etc then they may end up treating php_addslashes as different symbols (function or function pointer).

This introduces a hack to instead check `__SSE_4_2__` during configure, so the ABI is always the same. For newer versions we should instead fix the php_addslashes declaration to be always the same.