### PR TITLE
Make ABI of SIMD optimized functions independent of compiler flags

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -559,6 +559,7 @@ static zend_always_inline double _zend_get_nan(void) /* {{{ */
 # define ZEND_INTRIN_SSSE3_RESOLVER 1
 #endif
 
+/* Do not use for conditional declaration of API functions! */
 #if ZEND_INTRIN_SSSE3_RESOLVER && ZEND_INTRIN_HAVE_IFUNC_TARGET
 # define ZEND_INTRIN_SSSE3_FUNC_PROTO 1
 #elif ZEND_INTRIN_SSSE3_RESOLVER
@@ -575,7 +576,7 @@ static zend_always_inline double _zend_get_nan(void) /* {{{ */
 # define ZEND_INTRIN_SSSE3_FUNC_DECL(func)
 #endif
 
-#if defined(HAVE_SSE4_2_DEF) || (defined(ZEND_WIN32) && defined(__SSE4_2__))
+#if __SSE4_2__
 /* Instructions compiled directly. */
 # define ZEND_INTRIN_SSE4_2_NATIVE 1
 #elif (defined(HAVE_FUNC_ATTRIBUTE_TARGET) && defined(PHP_HAVE_SSE4_2)) || defined(ZEND_WIN32)
@@ -583,6 +584,7 @@ static zend_always_inline double _zend_get_nan(void) /* {{{ */
 # define ZEND_INTRIN_SSE4_2_RESOLVER 1
 #endif
 
+/* Do not use for conditional declaration of API functions! */
 #if ZEND_INTRIN_SSE4_2_RESOLVER && ZEND_INTRIN_HAVE_IFUNC_TARGET
 # define ZEND_INTRIN_SSE4_2_FUNC_PROTO 1
 #elif ZEND_INTRIN_SSE4_2_RESOLVER
@@ -605,6 +607,7 @@ static zend_always_inline double _zend_get_nan(void) /* {{{ */
 # define ZEND_INTRIN_AVX2_RESOLVER 1
 #endif
 
+/* Do not use for conditional declaration of API functions! */
 #if ZEND_INTRIN_AVX2_RESOLVER && ZEND_INTRIN_HAVE_IFUNC_TARGET
 # define ZEND_INTRIN_AVX2_FUNC_PROTO 1
 #elif ZEND_INTRIN_AVX2_RESOLVER

--- a/configure.ac
+++ b/configure.ac
@@ -561,24 +561,6 @@ PHP_CHECK_CPU_SUPPORTS([sse4.2])
 PHP_CHECK_CPU_SUPPORTS([avx])
 PHP_CHECK_CPU_SUPPORTS([avx2])
 
-dnl The ABI of php_addslashes in PHP 7.3 is dependent on __SSE4_2__,
-dnl which depends on target attributes. Use this check to make sure that
-dnl SSE 4.2 availability during the PHP compilation is used, independently
-dnl of whether extensions are compiled with SSE 4.2 support.
-AC_MSG_CHECKING([whether __SSE4_2__ is defined])
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
-int main() {
-#if defined(__SSE4_2__)
-  return 0;
-#else
-  return 1;
-#endif
-}
-]])], [
-  AC_MSG_RESULT([yes])
-  AC_DEFINE(HAVE_SSE4_2_DEF, 1, [Define if __SSE4_2__ has been defined])
-], [AC_MSG_RESULT([no])], [AC_MSG_RESULT([no])])
-
 dnl Check for members of the stat structure
 AC_CHECK_MEMBERS([struct stat.st_blksize, struct stat.st_rdev])
 dnl AC_STRUCT_ST_BLOCKS will screw QNX because fileblocks.o does not exist

--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -247,26 +247,33 @@ static void *resolve_base64_decode() {
 }
 # else /* (ZEND_INTRIN_AVX2_FUNC_PROTO || ZEND_INTRIN_SSSE3_FUNC_PROTO) */
 
-PHPAPI zend_string *(*php_base64_encode)(const unsigned char *str, size_t length) = NULL;
-PHPAPI zend_string *(*php_base64_decode_ex)(const unsigned char *str, size_t length, zend_bool strict) = NULL;
+PHPAPI zend_string *(*php_base64_encode_ptr)(const unsigned char *str, size_t length) = NULL;
+PHPAPI zend_string *(*php_base64_decode_ex_ptr)(const unsigned char *str, size_t length, zend_bool strict) = NULL;
+
+PHPAPI zend_string *php_base64_encode(const unsigned char *str, size_t length) {
+	return php_base64_encode_ptr(str, length);
+}
+PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length, zend_bool strict) {
+	return php_base64_decode_ex_ptr(str, length, strict);
+}
 
 PHP_MINIT_FUNCTION(base64_intrin)
 {
 # if ZEND_INTRIN_AVX2_FUNC_PTR
 	if (zend_cpu_supports_avx2()) {
-		php_base64_encode = php_base64_encode_avx2;
-		php_base64_decode_ex = php_base64_decode_ex_avx2;
+		php_base64_encode_ptr = php_base64_encode_avx2;
+		php_base64_decode_ex_ptr = php_base64_decode_ex_avx2;
 	} else
 # endif
 #if ZEND_INTRIN_SSSE3_FUNC_PTR
 	if (zend_cpu_supports_ssse3()) {
-		php_base64_encode = php_base64_encode_ssse3;
-		php_base64_decode_ex = php_base64_decode_ex_ssse3;
+		php_base64_encode_ptr = php_base64_encode_ssse3;
+		php_base64_decode_ex_ptr = php_base64_decode_ex_ssse3;
 	} else
 #endif
 	{
-		php_base64_encode = php_base64_encode_default;
-		php_base64_decode_ex = php_base64_decode_ex_default;
+		php_base64_encode_ptr = php_base64_encode_default;
+		php_base64_decode_ex_ptr = php_base64_decode_ex_default;
 	}
 	return SUCCESS;
 }

--- a/ext/standard/base64.h
+++ b/ext/standard/base64.h
@@ -59,12 +59,10 @@ PHP_FUNCTION(base64_encode);
 
 #if (ZEND_INTRIN_AVX2_FUNC_PTR || ZEND_INTRIN_SSSE3_FUNC_PTR) && !ZEND_INTRIN_AVX2_NATIVE
 PHP_MINIT_FUNCTION(base64_intrin);
-PHPAPI extern zend_string *(*php_base64_encode)(const unsigned char *, size_t);
-PHPAPI extern zend_string *(*php_base64_decode_ex)(const unsigned char *, size_t, zend_bool);
-#else
+#endif
+
 PHPAPI extern zend_string *php_base64_encode(const unsigned char *, size_t);
 PHPAPI extern zend_string *php_base64_decode_ex(const unsigned char *, size_t, zend_bool);
-#endif
 
 static inline zend_string *php_base64_encode_str(const zend_string *str) {
 	return php_base64_encode((const unsigned char*)(ZSTR_VAL(str)), ZSTR_LEN(str));

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -124,13 +124,8 @@ PHPAPI char *php_strtolower(char *s, size_t len);
 PHPAPI zend_string *php_string_toupper(zend_string *s);
 PHPAPI zend_string *php_string_tolower(zend_string *s);
 PHPAPI char *php_strtr(char *str, size_t len, const char *str_from, const char *str_to, size_t trlen);
-#if ZEND_INTRIN_SSE4_2_FUNC_PTR
-PHPAPI extern zend_string *(*php_addslashes)(zend_string *str);
-PHPAPI extern void (*php_stripslashes)(zend_string *str);
-#else
 PHPAPI zend_string *php_addslashes(zend_string *str);
 PHPAPI void php_stripslashes(zend_string *str);
-#endif
 PHPAPI zend_string *php_addcslashes_str(const char *str, size_t len, char *what, size_t what_len);
 PHPAPI zend_string *php_addcslashes(zend_string *str, char *what, size_t what_len);
 PHPAPI void php_stripcslashes(zend_string *str);

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3905,7 +3905,7 @@ static void *resolve_addslashes() {
 	if (zend_cpu_supports_sse42()) {
 		return php_addslashes_sse42;
 	}
-	return  php_addslashes_default;
+	return php_addslashes_default;
 }
 
 ZEND_NO_SANITIZE_ADDRESS
@@ -3913,23 +3913,30 @@ static void *resolve_stripslashes() {
 	if (zend_cpu_supports_sse42()) {
 		return php_stripslashes_sse42;
 	}
-	return  php_stripslashes_default;
+	return php_stripslashes_default;
 }
 # else /* ZEND_INTRIN_SSE4_2_FUNC_PTR */
 
-PHPAPI zend_string *(*php_addslashes)(zend_string *str) = NULL;
-PHPAPI void (*php_stripslashes)(zend_string *str) = NULL;
+static zend_string *(*php_addslashes_ptr)(zend_string *str) = NULL;
+static void (*php_stripslashes_ptr)(zend_string *str) = NULL;
+
+PHPAPI zend_string *php_addslashes(zend_string *str) {
+	return php_addslashes_ptr(str);
+}
+PHPAPI void php_stripslashes(zend_string *str) {
+	php_stripslashes_ptr(str);
+}
 
 /* {{{ PHP_MINIT_FUNCTION
  */
 PHP_MINIT_FUNCTION(string_intrin)
 {
 	if (zend_cpu_supports(ZEND_CPU_FEATURE_SSE42)) {
-		php_addslashes = php_addslashes_sse42;
-		php_stripslashes = php_stripslashes_sse42;
+		php_addslashes_ptr = php_addslashes_sse42;
+		php_stripslashes_ptr = php_stripslashes_sse42;
 	} else {
-		php_addslashes = php_addslashes_default;
-		php_stripslashes = php_stripslashes_default;
+		php_addslashes_ptr = php_addslashes_default;
+		php_stripslashes_ptr = php_stripslashes_default;
 	}
 	return SUCCESS;
 }


### PR DESCRIPTION
Followup to #3826 for PHP 7.4.