### PR TITLE
Deprecate case-insensitive constants via typelib import

### DIFF
--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -831,6 +831,10 @@ PHP_FUNCTION(com_load_typelib)
 		return;
 	}
 
+	if (!cs) {
+		php_error_docref(NULL, E_DEPRECATED, "Declaration of case-insensitive constants is deprecated");
+	}
+
 	RETVAL_FALSE;
 
 	php_com_initialize();

--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -265,11 +265,19 @@ static PHP_INI_MH(OnTypeLibFileUpdate)
 	return SUCCESS;
 }
 
+static ZEND_INI_MH(OnAutoregisterCasesensitive)
+{
+	if (!zend_ini_parse_bool(new_value)) {
+		php_error_docref("com.configuration", E_DEPRECATED, "Declaration of case-insensitive constants is deprecated");
+	}
+	return OnUpdateBool(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
+}
+
 PHP_INI_BEGIN()
     STD_PHP_INI_ENTRY("com.allow_dcom",				"0", PHP_INI_SYSTEM, OnUpdateBool, allow_dcom, zend_com_dotnet_globals, com_dotnet_globals)
     STD_PHP_INI_ENTRY("com.autoregister_verbose",	"0", PHP_INI_ALL, OnUpdateBool, autoreg_verbose, zend_com_dotnet_globals, com_dotnet_globals)
     STD_PHP_INI_ENTRY("com.autoregister_typelib",	"0", PHP_INI_ALL, OnUpdateBool, autoreg_on, zend_com_dotnet_globals, com_dotnet_globals)
-    STD_PHP_INI_ENTRY("com.autoregister_casesensitive",	"1", PHP_INI_ALL, OnUpdateBool, autoreg_case_sensitive, zend_com_dotnet_globals, com_dotnet_globals)
+    STD_PHP_INI_ENTRY("com.autoregister_casesensitive",	"1", PHP_INI_ALL, OnAutoregisterCasesensitive, autoreg_case_sensitive, zend_com_dotnet_globals, com_dotnet_globals)
 	STD_PHP_INI_ENTRY("com.code_page", "", PHP_INI_ALL, OnUpdateLong, code_page, zend_com_dotnet_globals, com_dotnet_globals)
 	PHP_INI_ENTRY("com.typelib_file", "", PHP_INI_SYSTEM, OnTypeLibFileUpdate)
 PHP_INI_END()


### PR DESCRIPTION
As of PHP 7.3.0, case-insensitive constants are deprecated.  We catch
up on this with regard to ext/com_dotnet, which allows to import
constants from typelibs, by triggering a deprecation notice whenever
`com_load_typelib()` is called with `$case_sensitive` being `false`,
and whenever `com.autoregister_casesensitive` is set to `false`,
regardless of whether there are actually constants in the typelib which
would be imported.