### PR TITLE
Remove ability to import case-insensitive constants from typelibs

### DIFF
--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -832,7 +832,8 @@ PHP_FUNCTION(com_load_typelib)
 	}
 
 	if (!cs) {
-		php_error_docref(NULL, E_DEPRECATED, "Declaration of case-insensitive constants is deprecated");
+		php_error_docref(NULL, E_WARNING, "Declaration of case-insensitive constants is no longer supported");
+		RETURN_FALSE;
 	}
 
 	RETVAL_FALSE;

--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -237,8 +237,7 @@ static PHP_INI_MH(OnTypeLibFileUpdate)
 		modifier = php_strtok_r(NULL, "#", &strtok_buf);
 		if (modifier != NULL) {
 			if (!strcmp(modifier, "cis") || !strcmp(modifier, "case_insensitive")) {
-				php_error_docref("com.configuration", E_WARNING, "Declaration of case-insensitive constants is no longer supported");
-				return FAILURE;
+				php_error_docref("com.configuration", E_WARNING, "Declaration of case-insensitive constants is no longer supported; #cis modifier ignored");
 			}
 		}
 

--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -237,8 +237,8 @@ static PHP_INI_MH(OnTypeLibFileUpdate)
 		modifier = php_strtok_r(NULL, "#", &strtok_buf);
 		if (modifier != NULL) {
 			if (!strcmp(modifier, "cis") || !strcmp(modifier, "case_insensitive")) {
-				php_error_docref("com.configuration", E_DEPRECATED, "Declaration of case-insensitive constants is deprecated");
-				mode &= ~CONST_CS;
+				php_error_docref("com.configuration", E_WARNING, "Declaration of case-insensitive constants is no longer supported");
+				return FAILURE;
 			}
 		}
 
@@ -269,7 +269,8 @@ static PHP_INI_MH(OnTypeLibFileUpdate)
 static ZEND_INI_MH(OnAutoregisterCasesensitive)
 {
 	if (!zend_ini_parse_bool(new_value)) {
-		php_error_docref("com.configuration", E_DEPRECATED, "Declaration of case-insensitive constants is deprecated");
+		php_error_docref("com.configuration", E_WARNING, "Declaration of case-insensitive constants is no longer supported");
+		return FAILURE;
 	}
 	return OnUpdateBool(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }


### PR DESCRIPTION
According to commit 23a5be3696f4d92e1b18fd59f3ac63c6a15ea12a[1], we remove the ability to import case-
insensitive constants, but do not remove the now superfluous parameter
and ini setting.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=23a5be3696f4d92e1b18fd59f3ac63c6a15ea12a>