### PR TITLE
Fix handling for JIT recognition when cross compiling

### DIFF
--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -36,16 +36,7 @@ if test "$PHP_EXTERNAL_PCRE" != "no"; then
       AC_MSG_RESULT([no])
     ],
     [
-      AC_CANONICAL_HOST
-      case $host_cpu in
-      arm*|i[34567]86|x86_64|mips*|powerpc*|sparc)
-        AC_MSG_RESULT([yes])
-        AC_DEFINE(HAVE_PCRE_JIT_SUPPORT, 1, [])
-        ;;
-      *)
-        AC_MSG_RESULT([no])
-        ;;
-      esac
+      AC_MSG_RESULT([no])
     ])
   fi
 


### PR DESCRIPTION
This commit reverts 68ad401. External PCRE2 could be built without JIT option. During cross-compilation PHP JIT option relies on architecture as a result JIT option will be enabled when PCRE2 was built without JIT support.