### PR TITLE
Refactor README.md

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,3 +1,0 @@
-For installation of PHP, please refer to the online documentation available at:
-
-https://php.net/install

--- a/README.WIN32-BUILD-SYSTEM
+++ b/README.WIN32-BUILD-SYSTEM
@@ -1,3 +1,0 @@
-The Win32 Build System.
-
-See https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2

--- a/README.md
+++ b/README.md
@@ -1,46 +1,102 @@
-The PHP Interpreter
-===================
+<div align="center">
+    <a href="https://php.net">
+        <img
+            alt="PHP"
+            src="https://static.php.net/www.php.net/images/logos/new-php-logo.svg"
+            width="150">
+    </a>
+</div>
 
-This is the github mirror of the official PHP repository located at
-https://git.php.net.
+# The PHP Interpreter
 
-[![Build Status](https://secure.travis-ci.org/php/php-src.svg?branch=master)](http://travis-ci.org/php/php-src)
+PHP is a popular general-purpose scripting language that is especially suited to
+web development. Fast, flexible and pragmatic, PHP powers everything from your
+blog to the most popular websites in the world. PHP is distributed under the PHP
+License v3.01.
+
+[![Build status](https://travis-ci.org/php/php-src.svg?branch=master)](https://travis-ci.org/php/php-src)
 [![Build status](https://ci.appveyor.com/api/projects/status/meyur6fviaxgdwdy?svg=true)](https://ci.appveyor.com/project/php/php-src)
 
-Pull Requests
-=============
-PHP accepts pull requests via github. Discussions are done on github, but
-depending on the topic can also be relayed to the official PHP developer
-mailing list internals@lists.php.net.
+## Documentation
 
-New features require an RFC and must be accepted by the developers.
-See https://wiki.php.net/rfc and https://wiki.php.net/rfc/voting for more
+The PHP manual is available online at https://php.net/docs.
+
+## Installation
+
+### Prebuilt packages and binaries
+
+Prebuilt packages and binaries can be used to get up and running fast with PHP.
+
+For Windows, the PHP binaries can be obtained from https://windows.php.net.
+After extracting the archive the `*.exe` files are ready to use.
+
+For other systems, see the documentation at https://php.net/install.
+
+### Building PHP from source
+
+On \*nix systems:
+
+    ./buildconf
+    ./configure
+    make
+    make test
+    sudo make install
+
+See `./configure -h` and `make -h` for all options. For example, the optional
+`-j` option allows parallel execution of the build recipes based on the number
+of available processor cores. On 8-core and 16-threads processor the command is
+then `make -j 16`.
+
+For Windows see https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2.
+
+## PHP extensions
+
+Extensions provide additional functionality on top of PHP. PHP consists of many
+essential bundled extensions. Additional extensions can be found in the PHP
+Extension Community Library (PECL) at https://pecl.php.net.
+
+## Contributing
+
+The PHP source code is located in the Git repository at https://git.php.net.
+Contributions are most welcome by forking the GitHub mirror repository
+https://github.com/php/php-src and sending a pull request.
+
+Discussions are done on GitHub, but depending on the topic can also be relayed
+to the official PHP developer mailing list internals@lists.php.net.
+
+New features require an RFC and must be accepted by the developers. See
+https://wiki.php.net/rfc and https://wiki.php.net/rfc/voting for more
 information on the process.
 
-Bug fixes **do not** require an RFC, but require a bugtracker ticket. Always
-open a ticket at https://bugs.php.net and reference the bug id using #NNNNNN.
+Bug fixes **do not** require an RFC, but require a bug tracker ticket. Open a
+ticket at https://bugs.php.net and reference the bug id using #NNNNNN.
 
     Fix #55371: get_magic_quotes_gpc() throws deprecation warning
 
-    After removing magic quotes, the get_magic_quotes_gpc function caused
-    a deprecate warning. get_magic_quotes_gpc can be used to detected
-    the magic_quotes behavior and therefore should not raise a warning at any
-    time. The patch removes this warning
+    After removing magic quotes, the get_magic_quotes_gpc function caused a
+    deprecated warning. get_magic_quotes_gpc can be used to detect the
+    magic_quotes behavior and therefore should not raise a warning at any time.
+    The patch removes this warning.
 
-We do not merge pull requests directly on github. All PRs will be
-pulled and pushed through https://git.php.net.
+Pull requests are not merged directly on GitHub. All PRs will be pulled and
+pushed through https://git.php.net. See https://wiki.php.net/vcs/gitworkflow for
+more details.
 
+### Guidelines for contributors
 
-Guidelines for contributors
-===========================
-- [CODING_STANDARDS](/CODING_STANDARDS)
-- [README.GIT-RULES](/README.GIT-RULES)
-- [README.MAILINGLIST_RULES](/README.MAILINGLIST_RULES)
-- [README.RELEASE_PROCESS](/README.RELEASE_PROCESS)
+See further documents in the repository for more information how to contribute:
+
+- [Contributing to PHP](/CONTRIBUTING.md)
+- [PHP coding standards](/CODING_STANDARDS)
+- [Git rules](/README.GIT-RULES)
+- [Mailinglist rules](/README.MAILINGLIST_RULES)
+- [PHP release process](/README.RELEASE_PROCESS)
 
 ## Testing
 
-To run tests the `make test` is used after successful compilation of the sources.
+To run tests the `make test` is used after a successful compilation of the
+sources. For faster parallel execution, use `make -j N test`, where `N` is the
+number of cores.
 
-See [Creating new test files](https://qa.php.net/write-test.php) chapter for more
-information about testing.
+The https://qa.php.net site provides more detailed info about testing and
+quality assurance.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ License v3.01.
 
 ## Documentation
 
-The PHP manual is available online at https://php.net/docs.
+The PHP manual is available online at [php.net/docs](https://php.net/docs).
 
 ## Installation
 
@@ -27,10 +27,11 @@ The PHP manual is available online at https://php.net/docs.
 
 Prebuilt packages and binaries can be used to get up and running fast with PHP.
 
-For Windows, the PHP binaries can be obtained from https://windows.php.net.
-After extracting the archive the `*.exe` files are ready to use.
+For Windows, the PHP binaries can be obtained from
+[windows.php.net](https://windows.php.net). After extracting the archive the
+`*.exe` files are ready to use.
 
-For other systems, see the documentation at https://php.net/install.
+For other systems, see the [installation chapter](https://php.net/install).
 
 ### Building PHP from source
 
@@ -42,34 +43,40 @@ On \*nix systems:
     make test
     sudo make install
 
-See `./configure -h` and `make -h` for all options. For example, the optional
-`-j` option allows parallel execution of the build recipes based on the number
-of available processor cores. On 8-core and 16-threads processor the command is
-then `make -j 16`.
+See `./configure -h` and `make -h` for configuration options. For example, the
+optional `-j` option allows parallel execution of the build recipes based on the
+number of available processor cores. For example, on 8-core and 16-threads
+processor the build command is then:
 
-For Windows see https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2.
+    make -j 16
+
+For Windows, see
+[wiki pages](https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2).
 
 ## PHP extensions
 
 Extensions provide additional functionality on top of PHP. PHP consists of many
 essential bundled extensions. Additional extensions can be found in the PHP
-Extension Community Library (PECL) at https://pecl.php.net.
+Extension Community Library ([PECL](https://pecl.php.net)).
 
 ## Contributing
 
-The PHP source code is located in the Git repository at https://git.php.net.
-Contributions are most welcome by forking the GitHub mirror repository
-https://github.com/php/php-src and sending a pull request.
+The PHP source code is located in the Git repository at
+[git.php.net](https://git.php.net). Contributions are most welcome by forking
+the [GitHub mirror repository](https://github.com/php/php-src) and sending a
+pull request.
 
 Discussions are done on GitHub, but depending on the topic can also be relayed
 to the official PHP developer mailing list internals@lists.php.net.
 
 New features require an RFC and must be accepted by the developers. See
-https://wiki.php.net/rfc and https://wiki.php.net/rfc/voting for more
-information on the process.
+[Request for Comments - RFC](https://wiki.php.net/rfc) and
+[Voting on PHP features](https://wiki.php.net/rfc/voting) for more information
+on the process.
 
 Bug fixes **do not** require an RFC, but require a bug tracker ticket. Open a
-ticket at https://bugs.php.net and reference the bug id using #NNNNNN.
+ticket at [bugs.php.net](https://bugs.php.net) and reference the bug id using
+`#NNNNNN`.
 
     Fix #55371: get_magic_quotes_gpc() throws deprecation warning
 
@@ -79,8 +86,8 @@ ticket at https://bugs.php.net and reference the bug id using #NNNNNN.
     The patch removes this warning.
 
 Pull requests are not merged directly on GitHub. All PRs will be pulled and
-pushed through https://git.php.net. See https://wiki.php.net/vcs/gitworkflow for
-more details.
+pushed through [git.php.net](https://git.php.net). See
+[Git workflow](https://wiki.php.net/vcs/gitworkflow) for more details.
 
 ### Guidelines for contributors
 
@@ -95,8 +102,10 @@ See further documents in the repository for more information how to contribute:
 ## Testing
 
 To run tests the `make test` is used after a successful compilation of the
-sources. For faster parallel execution, use `make -j N test`, where `N` is the
-number of cores.
+sources. The `-j` option provides faster parallel execution, where `N` is the
+number of cores:
 
-The https://qa.php.net site provides more detailed info about testing and
-quality assurance.
+    make -j N test
+
+The [qa.php.net](https://qa.php.net) site provides more detailed info about
+testing and quality assurance.

--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -229,7 +229,6 @@ snap: build-snap build-devel build-dist
 $(BUILD_DIR)\deplister.exe:	win32\build\deplister.c
 	$(CC) /nologo /Fo$(BUILD_DIR)\ /Fd$(BUILD_DIR)\ /Fp$(BUILD_DIR)\ /FR$(BUILD_DIR) /Fe$(BUILD_DIR)\deplister.exe win32\build\deplister.c imagehlp.lib
 
-# need to redirect, since INSTALL is a file in the root...
 install: really-install install-sdk
 
 build-lib: build-ext-libs

--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -251,7 +251,7 @@ if(sizeof($pecl_targets)) {
 $text_files = array(
 	"LICENSE" => "license.txt",
 	"NEWS" => "news.txt",
-	"INSTALL" => "install.txt",
+	"README.md" => "readme.txt",
 	"README.REDIST.BINS" => "readme-redist-bins.txt",
 	"php.ini-development" => "php.ini-development",
 	"php.ini-production" => "php.ini-production"

--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -251,7 +251,7 @@ if(sizeof($pecl_targets)) {
 $text_files = array(
 	"LICENSE" => "license.txt",
 	"NEWS" => "news.txt",
-	"README.md" => "readme.txt",
+	"README.md" => "README.md",
 	"README.REDIST.BINS" => "readme-redist-bins.txt",
 	"php.ini-development" => "php.ini-development",
 	"php.ini-production" => "php.ini-production"


### PR DESCRIPTION
Hello,

This refactors the `README.md` file into a bit more useful source of information for people who visit the repository via GitHub and for those who unzip the php-src downloaded release files. `README.md` file is located in *nix releases, and copied to `readme.txt` on windows releases. So, the syntax can be Markdown with a bit of a thought for Windows systems where opening *.md files by default requires selecting an application or editor (so probably that's why there is a *.txt done now).
