### PR TITLE
Enhance the buildconf script

### DIFF
--- a/buildconf
+++ b/buildconf
@@ -1,13 +1,15 @@
 #!/bin/sh
 #
-# A wrapper around the Autoconf tools that generate files for building PHP on
-# *nix systems.
+# A wrapper around Autoconf that generates files to build PHP on *nix systems.
 
 MAKE=${MAKE:-make}
 force=0
 debug=0
 
-eval `grep '^PHP_EXTRA_VERSION=' configure.ac`
+# Go to project root.
+cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+
+eval $(grep '^PHP_EXTRA_VERSION=' configure.ac)
 case "$PHP_EXTRA_VERSION" in
   *-dev)
     dev=1
@@ -17,39 +19,37 @@ case "$PHP_EXTRA_VERSION" in
     ;;
 esac
 
-# Go to the script's directory so buildconf can be run from other locations.
-cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
-
 while test $# -gt 0; do
   if test "$1" = "-h" || test "$1" = "--help"; then
-    echo "PHP buildconf"
-    echo ""
-    echo "A wrapper around the autoconf and autoheader that generate files for"
-    echo "building PHP on *nix systems (configure, main/php_config.h.in,"
-    echo "aclocal.m4...). The configure script is used to customize the PHP"
-    echo "build based on the provided options and system. PHP releases"
-    echo "downloaded from PHP.net already include the configure script so"
-    echo "installing Autoconf and running buildconf is not needed. For the PHP"
-    echo "sources from the Git repository, buildconf is used for generating"
-    echo "a new configure script and required files."
-    echo ""
-    echo "SYNOPSIS:"
-    echo "  buildconf [<options>]"
-    echo ""
-    echo "OPTIONS:"
-    echo "  --force         Clean cache and overwrite configure files."
-    echo "  --debug         Display warnings emitted by Autoconf."
-    echo "  -h, --help      Display this help."
-    echo ""
-    echo "ENVIRONMENT:"
-    echo "  The following optional variables are supported:"
-    echo ""
-    echo "  MAKE            Overrides the path to make tool."
-    echo "                  MAKE=/path/to/make ./buildconf"
-    echo "  PHP_AUTOCONF    Overrides the path to autoconf tool."
-    echo "                  PHP_AUTOCONF=/path/to/autoconf ./buildconf"
-    echo "  PHP_AUTOHEADER  Overrides the path to autoheader tool."
-    echo "                  PHP_AUTOHEADER=/path/to/autoheader ./buildconf"
+    cat << HELP
+PHP buildconf
+
+A wrapper around the autoconf and autoheader that generate files for building
+PHP on *nix systems (configure, main/php_config.h.in, aclocal.m4...). The
+configure script is used to customize the PHP build based on the provided
+options and system. PHP releases downloaded from PHP.net already include the
+configure script so installing Autoconf and running buildconf is not needed. For
+the PHP sources from the Git repository, buildconf is used for generating a new
+configure script and required files.
+
+SYNOPSIS:
+  buildconf [<options>]
+
+OPTIONS:
+  --force         Clean cache and overwrite configure files.
+  --debug         Display warnings emitted by Autoconf.
+  -h, --help      Display this help.
+
+ENVIRONMENT:
+  The following optional variables are supported:
+
+  MAKE            Overrides the path to make tool.
+                  MAKE=/path/to/make ./buildconf
+  PHP_AUTOCONF    Overrides the path to autoconf tool.
+                  PHP_AUTOCONF=/path/to/autoconf ./buildconf
+  PHP_AUTOHEADER  Overrides the path to autoheader tool.
+                  PHP_AUTOHEADER=/path/to/autoheader ./buildconf
+HELP
     exit 0
   fi
 

--- a/buildconf
+++ b/buildconf
@@ -1,4 +1,11 @@
 #!/bin/sh
+#
+# A wrapper around the Autoconf tools that generate files for building PHP on
+# *nix systems.
+
+MAKE=${MAKE:-make}
+force=0
+debug=0
 
 eval `grep '^PHP_EXTRA_VERSION=' configure.ac`
 case "$PHP_EXTRA_VERSION" in
@@ -10,37 +17,84 @@ case "$PHP_EXTRA_VERSION" in
     ;;
 esac
 
-devok=0
-debug=no
+# Go to the script's directory so buildconf can be run from other locations.
+cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 
 while test $# -gt 0; do
+  if test "$1" = "-h" || test "$1" = "--help"; then
+    echo "PHP buildconf"
+    echo ""
+    echo "A wrapper around the autoconf and autoheader that generate files for"
+    echo "building PHP on *nix systems (configure, main/php_config.h.in,"
+    echo "aclocal.m4...). The configure script is used to customize the PHP"
+    echo "build based on the provided options and system. PHP releases"
+    echo "downloaded from PHP.net already include the configure script so"
+    echo "installing Autoconf and running buildconf is not needed. For the PHP"
+    echo "sources from the Git repository, buildconf is used for generating"
+    echo "a new configure script and required files."
+    echo ""
+    echo "SYNOPSIS:"
+    echo "  buildconf [<options>]"
+    echo ""
+    echo "OPTIONS:"
+    echo "  --force         Clean cache and overwrite configure files."
+    echo "  --debug         Display warnings emitted by Autoconf."
+    echo "  -h, --help      Display this help."
+    echo ""
+    echo "ENVIRONMENT:"
+    echo "  The following optional variables are supported:"
+    echo ""
+    echo "  MAKE            Overrides the path to make tool."
+    echo "                  MAKE=/path/to/make ./buildconf"
+    echo "  PHP_AUTOCONF    Overrides the path to autoconf tool."
+    echo "                  PHP_AUTOCONF=/path/to/autoconf ./buildconf"
+    echo "  PHP_AUTOHEADER  Overrides the path to autoheader tool."
+    echo "                  PHP_AUTOHEADER=/path/to/autoheader ./buildconf"
+    exit 0
+  fi
+
   if test "$1" = "--force"; then
-    devok=1
-    echo "Forcing buildconf"
+    force=1
   fi
 
   if test "$1" = "--debug"; then
-    debug=yes
+    debug=1
   fi
 
   shift
 done
 
-if test "$dev" = "0" -a "$devok" = "0"; then
-  echo "You should not run buildconf in a release package." >&2
-  echo "use buildconf --force to override this check." >&2
+if test "$dev" = "0" -a "$force" = "0"; then
+  if test -f "configure"; then
+    echo "The configure script has already been built for you. All done."
+    echo "Run ./configure to proceed with customizing the PHP build."
+    exit 0
+  else
+    echo "Configure script is missing." >&2
+    echo "Run ./buildconf --force to create a configure script." >&2
+    exit 1
+  fi
+fi
+
+# Check if make exists.
+if ! test -x "$(command -v $MAKE)"; then
+  echo "buildconf: make not found." >&2
+  echo "           You need to have make installed to build PHP." >&2
   exit 1
 fi
 
-if test "$devok" = "1"; then
-  echo "Removing configure caches"
+if test "$force" = "1"; then
+  echo "buildconf: Forcing buildconf"
+  echo "buildconf: Removing configure caches"
   rm -rf autom4te.cache config.cache
 fi
 
+echo "buildconf: Building configure files"
+
 rm -f generated_lists
 
-if test "$debug" = "yes"; then
-  ${MAKE:-make} -s -f build/build.mk SUPPRESS_WARNINGS=""
+if test "$debug" = "1"; then
+  $MAKE -s -f build/build.mk SUPPRESS_WARNINGS=""
 else
-  ${MAKE:-make} -s -f build/build.mk
+  $MAKE -s -f build/build.mk
 fi

--- a/buildconf
+++ b/buildconf
@@ -3,8 +3,6 @@
 # A wrapper around Autoconf that generates files to build PHP on *nix systems.
 
 MAKE=${MAKE:-make}
-PHP_AUTOCONF=${PHP_AUTOCONF:-autoconf}
-PHP_AUTOHEADER=${PHP_AUTOHEADER:-autoheader}
 force=0
 debug=0
 

--- a/buildconf
+++ b/buildconf
@@ -3,6 +3,8 @@
 # A wrapper around Autoconf that generates files to build PHP on *nix systems.
 
 MAKE=${MAKE:-make}
+PHP_AUTOCONF=${PHP_AUTOCONF:-autoconf}
+PHP_AUTOHEADER=${PHP_AUTOHEADER:-autoheader}
 force=0
 debug=0
 


### PR DESCRIPTION
Changes:
- Added a missing file license header
- Added a short introduction what this script does
- Messages changed a bit so the PHP installation procedure becomes simpler without needing to constantly remind the user what to run and what not.
- ...