### PR TITLE
Update editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 
 root = true
 
-[*.{c,h,awk,w32,bat,mk,frag}]
+[*.{c,h,y,awk,w32,bat,mk,frag}]
 charset                  = utf-8
 end_of_line              = lf
 indent_size              = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,12 +2,14 @@
 
 root = true
 
+[*]
+tab_width                = 4
+
 [*.{c,h,y,awk,w32,bat,mk,frag}]
 charset                  = utf-8
 end_of_line              = lf
 indent_size              = 4
 indent_style             = tab
-tab_width                = 4
 trim_trailing_whitespace = true
 insert_final_newline     = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 [*]
 tab_width                = 4
 
-[*.{c,h,y,awk,w32,bat,mk,frag}]
+[*.{c,h,y,awk,w32,bat,mk,frag,cpp}]
 charset                  = utf-8
 end_of_line              = lf
 indent_size              = 4
@@ -13,7 +13,7 @@ indent_style             = tab
 trim_trailing_whitespace = true
 insert_final_newline     = true
 
-[*.{php,phpt}]
+[*.{php,phpt,inc}]
 charset                  = utf-8
 end_of_line              = lf
 indent_size              = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org/
+# https://editorconfig.org/
 
 root = true
 
@@ -31,5 +31,15 @@ insert_final_newline     = true
 charset                  = utf-8
 end_of_line              = lf
 indent_style             = space
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 insert_final_newline     = true
+max_line_length          = 80
+
+[COMMIT_EDITMSG]
+charset                  = utf-8
+end_of_line              = lf
+indent_size              = 4
+indent_style             = space
+trim_trailing_whitespace = true
+insert_final_newline     = true
+max_line_length          = 80


### PR DESCRIPTION
Changes:
- New property max_line_length
- COMMIT_EDITMSG file added when writing commit messages
- Markdown files can have trimmed trailing whitespace also to simplify
  settings.
- https link used to EditorConfig page.

This is targeting the PHP-7.2 branch, because of still using these settings in the PHP-7.2+ branches when fixing bugs.