### PR TITLE
Fix #64705 PDO driver constructor throw PDOException but not setting errorInfo

### DIFF
--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -60,6 +60,7 @@ void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_e
 			pdo_exception_message
 		);
 		efree(pdo_exception_message);
+		zval_ptr_dtor(&error_info);
 		zend_throw_exception_object(&pdo_exception);
 }
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -42,6 +42,7 @@ void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_e
 {
 		zval error_info,pdo_exception;
 		char *pdo_exception_message;
+
 		object_init_ex(&pdo_exception, php_pdo_get_exception());
 		array_init(&error_info);
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -38,6 +38,30 @@
 
 static int pdo_dbh_attribute_set(pdo_dbh_t *dbh, zend_long attr, zval *value);
 
+void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_error_type *pdo_error)
+{
+		zval error_info,pdo_exception;
+		char *pdo_exception_message;
+		object_init_ex(&pdo_exception, php_pdo_get_exception());
+		array_init(&error_info);
+
+		add_next_index_string(&error_info, *pdo_error);
+		add_next_index_long(&error_info, driver_errcode);
+		add_next_index_string(&error_info, driver_errmsg);
+ 
+		spprintf(&pdo_exception_message, 0,"SQLSTATE[%s] [%d] %s",*pdo_error, driver_errcode, driver_errmsg);
+		zend_update_property(php_pdo_get_exception(), &pdo_exception, "errorInfo", sizeof("errorInfo")-1, &error_info);
+		zend_update_property_long(php_pdo_get_exception(), &pdo_exception, "code", sizeof("code")-1, driver_errcode);
+		zend_update_property_string(
+			php_pdo_get_exception(), 
+			&pdo_exception, 
+			"message", 
+			sizeof("message")-1, 
+			pdo_exception_message
+		);
+		zend_throw_exception_object(&pdo_exception);
+}
+
 void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *sqlstate, const char *supp) /* {{{ */
 {
 	pdo_error_type *pdo_err = &dbh->error_code;

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -59,6 +59,7 @@ void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_e
 			sizeof("message")-1, 
 			pdo_exception_message
 		);
+		efree(pdo_exception_message);
 		zend_throw_exception_object(&pdo_exception);
 }
 

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -693,6 +693,7 @@ PDO_API void php_pdo_dbh_delref(pdo_dbh_t *dbh);
 PDO_API void php_pdo_free_statement(pdo_stmt_t *stmt);
 
 
+PDO_API void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_error_type *pdo_error);
 #endif /* PHP_PDO_DRIVER_H */
 /*
  * Local variables:

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -105,8 +105,7 @@ int _pdo_mysql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file, int lin
 
 	if (!dbh->methods) {
 		PDO_DBG_INF("Throwing exception");
-		zend_throw_exception_ex(php_pdo_get_exception(), einfo->errcode, "SQLSTATE[%s] [%d] %s",
-				*pdo_err, einfo->errcode, einfo->errmsg);
+		pdo_throw_exception(einfo->errcode, einfo->errmsg, pdo_err);
 	}
 
 	PDO_DBG_RETURN(einfo->errcode);

--- a/ext/pdo_mysql/tests/bug_64705.phpt
+++ b/ext/pdo_mysql/tests/bug_64705.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #64705 errorInfo property of PDOException is null when PDO::__construct() fails
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_mysql')) print 'skip not loaded';
+?>
+--FILE--
+<?php
+$dsn = 'mysql:host=DonotExistsHost;dbname=test;user=foo;password=wrongpass';
+try {
+  $pdo = new \PDO($dsn, null, null);
+} catch (\PDOException $e) {
+  var_dump(!empty($e->errorInfo) && is_array($e->errorInfo));
+}
+?>
+--EXPECTF--
+bool(true)

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -105,8 +105,7 @@ int _pdo_pgsql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, int errcode, const char *
 	}
 
 	if (!dbh->methods) {
-		zend_throw_exception_ex(php_pdo_get_exception(), einfo->errcode, "SQLSTATE[%s] [%d] %s",
-				*pdo_err, einfo->errcode, einfo->errmsg);
+		pdo_throw_exception(einfo->errcode, einfo->errmsg, pdo_err);
 	}
 
 	return errcode;

--- a/ext/pdo_pgsql/tests/bug_64705.phpt
+++ b/ext/pdo_pgsql/tests/bug_64705.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #64705 errorInfo property of PDOException is null when PDO::__construct() fails
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_pgsql')) print 'skip not loaded';
+?>
+--FILE--
+<?php
+$dsn = 'pgsql:host=DonotExistsHost;dbname=test;user=foo;password=wrongpass';
+try {
+  $pdo = new \PDO($dsn, null, null);
+} catch (\PDOException $e) {
+  var_dump(!empty($e->errorInfo) && is_array($e->errorInfo));
+}
+?>
+--EXPECTF--
+bool(true)

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -78,8 +78,7 @@ int _pdo_sqlite_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file, int li
 	}
 
 	if (!dbh->methods) {
-		zend_throw_exception_ex(php_pdo_get_exception(), einfo->errcode, "SQLSTATE[%s] [%d] %s",
-				*pdo_err, einfo->errcode, einfo->errmsg);
+		pdo_throw_exception(einfo->errcode, einfo->errmsg, pdo_err);
 	}
 
 	return einfo->errcode;

--- a/ext/pdo_sqlite/tests/bug_64705.phpt
+++ b/ext/pdo_sqlite/tests/bug_64705.phpt
@@ -6,7 +6,7 @@ if (!extension_loaded('pdo_sqlite')) print 'skip not loaded';
 ?>
 --FILE--
 <?php
-$dsn = 'sqlite:./bug64705NonExistingDb';
+$dsn = 'sqlite:./bug64705NonExistingDir/bug64705NonExistingDb';
 try {
   $pdo = new \PDO($dsn, null, null);
 } catch (\PDOException $e) {

--- a/ext/pdo_sqlite/tests/bug_64705.phpt
+++ b/ext/pdo_sqlite/tests/bug_64705.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #64705 errorInfo property of PDOException is null when PDO::__construct() fails
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_sqlite')) print 'skip not loaded';
+?>
+--FILE--
+<?php
+$dsn = 'sqlite:/bug64705NonExistingDb';
+try {
+  $pdo = new \PDO($dsn, null, null);
+} catch (\PDOException $e) {
+  var_dump(!empty($e->errorInfo) && is_array($e->errorInfo));
+}
+?>
+--EXPECTF--
+bool(true)

--- a/ext/pdo_sqlite/tests/bug_64705.phpt
+++ b/ext/pdo_sqlite/tests/bug_64705.phpt
@@ -6,7 +6,7 @@ if (!extension_loaded('pdo_sqlite')) print 'skip not loaded';
 ?>
 --FILE--
 <?php
-$dsn = 'sqlite:/bug64705NonExistingDb';
+$dsn = 'sqlite:./bug64705NonExistingDb';
 try {
   $pdo = new \PDO($dsn, null, null);
 } catch (\PDOException $e) {


### PR DESCRIPTION
Fix [#64705](https://bugs.php.net/bug.php?id=64705) errorInfo property of PDOException is null when PDO::__construct() fails
    
Pdo drivers constructors are throwing PdoException wtihout setting errorInfo,
so creating new reusable function that throw exceptions for pdo and will set the errorInfo also,
and using this function with pdo_mysql,pdo_sqlite,pdo_pgsql.