### PR TITLE
Remove phar.phar version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 # Replace $Id$ strings with 40-character hexadecimal blob object name.
 /ext/mysqlnd/mysqlnd.h          ident
 /ext/ext_skel.php               ident
-/ext/phar/phar/pharcommand.inc  ident
 /ext/dba/libinifile/inifile.c   ident
 /ext/dba/libflatfile/flatfile.c ident
 /ext/dba/libcdb/cdb_make.c      ident

--- a/ext/phar/phar/pharcommand.inc
+++ b/ext/phar/phar/pharcommand.inc
@@ -1566,7 +1566,6 @@ class PharCommand extends CLICommand
 		$use_ext = extension_loaded('phar');
 		$version = array(
 			'PHP Version' => phpversion(),
-			'phar.phar version' => '$Id$',
 			'Phar EXT version' => $use_ext ? phpversion('phar') : 'Not available',
 			'Phar API version' => Phar::apiVersion(),
 			'Phar-based phar archives' => true,


### PR DESCRIPTION
The phar.phar command line script also included additional phar.phar
version with Git attributes ident.

```bash
ext/phar/phar.phar version
```

The `$Id$` keywords were used in CVS and Subversion where they can be
substituted with filename, last revision number change, last changed
date, and last user who changed it.

In Git this functionality is different and can be done with Git
attribute ident. These need to be defined manually for each file in the
`.gitattributes` file and are afterwards replaced with 40-character
hexadecimal blob object name which is based only on the particular file
contents.

This patch simplifies handling of `$Id$` keywords by removing it.

The real phar.phar version of the file is not $Id$ because the file is
created from multiple files and not only the pharcommand.inc.