### PR TITLE
Fix class crash in isSubclassOf when using unbound anonymous classes

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1796,7 +1796,8 @@ ZEND_FUNCTION(get_declared_classes)
 	ZEND_HASH_FOREACH_STR_KEY_PTR(EG(class_table), key, ce) {
 		if (key
 		 && ZSTR_VAL(key)[0] != 0
-		 && !(ce->ce_flags & (ZEND_ACC_INTERFACE | ZEND_ACC_TRAIT))) {
+		 && !(ce->ce_flags & (ZEND_ACC_INTERFACE | ZEND_ACC_TRAIT))
+		 && (ce->ce_flags & ZEND_ACC_LINKED)) {
 			copy_class_or_interface_name(return_value, key, ce);
 		}
 	} ZEND_HASH_FOREACH_END();

--- a/ext/reflection/tests/ReflectionClass_isSubclassOf_error2.phpt
+++ b/ext/reflection/tests/ReflectionClass_isSubclassOf_error2.phpt
@@ -1,0 +1,35 @@
+--TEST--
+ReflectionClass::isSubclassOf() - fixed crash for unbound anonymous class
+--FILE--
+<?php
+class X {
+    public static function main() {
+        return new class() extends Base {};
+    }
+}
+class Base {}
+$check = function () {
+    $base = Base::class;
+    foreach (get_declared_classes() as $class) {
+        if (strpos($class, 'class@anonymous') === false) {
+            continue;
+        }
+        echo "Checking for $class\n";
+        flush();
+        $rc = new ReflectionClass($class);
+        var_export($rc->isSubclassOf($base));
+        echo "\n";
+    }
+};
+// Should not show up in get_declared_classes until the anonymous class is bound.
+$check();
+echo "After first check\n";
+X::main();
+$check();
+echo "Done\n";
+?>
+--EXPECTF--
+After first check
+Checking for class@%s
+true
+Done


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=77631

Add a test that crashed in previous commits.
Note that earlier PHP versions would include the anonymous class in
get_declared_classes(), and return false until the class was bound,
but would not crash.

I'm not quite sure what to write or where in NEWS/UPGRADING - something along the lines of

> Reflection: Exclude anonymous classes from get_declared_classes if they haven't been instantiated yet