### PR TITLE
[WIP] enter/leave callbacks

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3021,6 +3021,10 @@ uint32_t zend_compile_args(zend_ast *ast, zend_function *fbc) /* {{{ */
 
 ZEND_API zend_uchar zend_get_call_op(const zend_op *init_op, zend_function *fbc) /* {{{ */
 {
+	if (zend_vm_entering || zend_vm_leaving) {
+		return ZEND_DO_FCALL;
+	}
+
 	if (fbc) {
 		if (fbc->type == ZEND_INTERNAL_FUNCTION) {
 			if (init_op->opcode == ZEND_INIT_FCALL && !zend_execute_internal) {

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -31,6 +31,9 @@ struct _zend_fcall_info;
 ZEND_API extern void (*zend_execute_ex)(zend_execute_data *execute_data);
 ZEND_API extern void (*zend_execute_internal)(zend_execute_data *execute_data, zval *return_value);
 
+ZEND_API extern void (*zend_vm_entering)(zend_execute_data*);
+ZEND_API extern void (*zend_vm_leaving)(zend_execute_data*);
+
 void init_executor(void);
 void shutdown_executor(void);
 void shutdown_destructors(void);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -43,6 +43,9 @@
 ZEND_API void (*zend_execute_ex)(zend_execute_data *execute_data);
 ZEND_API void (*zend_execute_internal)(zend_execute_data *execute_data, zval *return_value);
 
+ZEND_API void (*zend_vm_entering)(zend_execute_data*);
+ZEND_API void (*zend_vm_leaving)(zend_execute_data*);
+
 /* true globals */
 ZEND_API const zend_fcall_info empty_fcall_info = { 0, {{0}, {{0}}, {0}}, NULL, NULL, NULL, 0, 0 };
 ZEND_API const zend_fcall_info_cache empty_fcall_info_cache = { NULL, NULL, NULL, NULL };

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1235,14 +1235,22 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
 
-		if (EXPECTED(zend_execute_ex == execute_ex)) {
+		if (EXPECTED(zend_execute_ex == execute_ex && !zend_vm_entering && !zend_vm_leaving)) {
 			LOAD_OPLINE();
 			ZEND_VM_ENTER_EX();
 		} else {
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
 			ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);
+			if (UNEXPECTED(zend_vm_entering)) {
+				zend_vm_entering(call);
+			}
+
 			zend_execute_ex(call);
+
+			if (UNEXPECTED(zend_vm_leaving)) {
+				zend_vm_leaving(call);
+			}
 		}
 	} else {
 		zval retval;
@@ -1260,13 +1268,18 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		ret = 0 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+		if (UNEXPECTED(zend_vm_entering)) {
+			zend_vm_entering(call);
+		}
 		if (!zend_execute_internal) {
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(call, ret);
 		} else {
 			zend_execute_internal(call, ret);
 		}
-
+		if (UNEXPECTED(zend_vm_leaving)) {
+			zend_vm_leaving(call);
+		}
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||
@@ -1341,14 +1354,22 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
 
-		if (EXPECTED(zend_execute_ex == execute_ex)) {
+		if (EXPECTED(zend_execute_ex == execute_ex && !zend_vm_entering && !zend_vm_leaving)) {
 			LOAD_OPLINE();
 			ZEND_VM_ENTER_EX();
 		} else {
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
 			ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);
+			if (UNEXPECTED(zend_vm_entering)) {
+				zend_vm_entering(call);
+			}
+
 			zend_execute_ex(call);
+
+			if (UNEXPECTED(zend_vm_leaving)) {
+				zend_vm_leaving(call);
+			}
 		}
 	} else {
 		zval retval;
@@ -1366,13 +1387,18 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		ret = 1 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+		if (UNEXPECTED(zend_vm_entering)) {
+			zend_vm_entering(call);
+		}
 		if (!zend_execute_internal) {
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(call, ret);
 		} else {
 			zend_execute_internal(call, ret);
 		}
-
+		if (UNEXPECTED(zend_vm_leaving)) {
+			zend_vm_leaving(call);
+		}
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||


### PR DESCRIPTION
For review by @dstogov @nikic and anyone else ...

This is the vm part of the solution suggested by Dmitry for enter/leave callbacks for tracing extensions ...

Note that, this still cannot replace custom executor loops for things like pcov that need to (potentially) trace every instruction.

I'm not sure of the optimal way to arrange get_call_op, suggestions welcome ... pretty sure it is not optimal.

Question, should leave callback take return value for simplicity ?