### PR TITLE
Parallel test improvements

### DIFF
--- a/appveyor/test_task.bat
+++ b/appveyor/test_task.bat
@@ -91,7 +91,7 @@ mkdir c:\tests_tmp
 set TEST_PHP_JUNIT=c:\junit.out.xml
 
 cd "%APPVEYOR_BUILD_FOLDER%"
-nmake test TESTS="%OPCACHE_OPTS% -q --offline --show-diff --show-slow 1000 --set-timeout 120 -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP --temp-source c:\tests_tmp --temp-target c:\tests_tmp -j2"
+nmake test TESTS="%OPCACHE_OPTS% -q --offline --show-diff --show-slow 1000 --set-timeout 120 -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP --temp-source c:\tests_tmp --temp-target c:\tests_tmp -j3"
 
 set EXIT_CODE=%errorlevel%
 

--- a/run-tests.php
+++ b/run-tests.php
@@ -1283,7 +1283,8 @@ function run_all_tests($test_files, $env, $redir_tested = null)
 	global $PHP_FAILED_TESTS, $workers, $workerID, $workerSock;
 
 	if ($workers !== null && !$workerID) {
-		run_all_tests_parallel($test_files, $env, $redir_tested);
+		if ($redir_tested) die("redir_tested set for coordinator process");
+		run_all_tests_parallel($test_files, $env);
 		return;
 	}
 
@@ -1336,7 +1337,7 @@ function run_all_tests($test_files, $env, $redir_tested = null)
 }
 
 /** The heart of parallel testing. */
-function run_all_tests_parallel($test_files, $env, $redir_tested) {
+function run_all_tests_parallel($test_files, $env) {
 	global $workers, $test_idx, $test_cnt, $test_results, $failed_tests_file, $result_tests_file, $PHP_FAILED_TESTS, $shuffle;
 
 	// The PHP binary running run-tests.php, and run-tests.php itself
@@ -1561,7 +1562,6 @@ escape:
 									"type" => "run_tests",
 									"test_files" => $files,
 									"env" => $env,
-									"redir_tested" => $redir_tested
 								]);
 							} else {
 								proc_terminate($workerProcs[$i]);
@@ -1694,7 +1694,7 @@ function run_worker() {
 
 		switch ($command["type"]) {
 			case "run_tests":
-				run_all_tests($command["test_files"], $command["env"], $command["redir_tested"]);
+				run_all_tests($command["test_files"], $command["env"]);
 				send_message($workerSock, [
 					"type" => "tests_finished"
 				]);


### PR DESCRIPTION
This a) reenables IO capture tests by inheriting std streams from the main process and b) implements the `--CONFLICTS--` mechanism mentioned in #2822.

Some more CONFLICTS very likely missing, but I hope that we can start using this in CI and fix issues as they come up.

cc @hikari-no-yume 