### PR TITLE
Fix ffi test - only run it if libc.6.so was loaded [skip ci]

### DIFF
--- a/ext/ffi/tests/bug77632.phpt
+++ b/ext/ffi/tests/bug77632.phpt
@@ -1,7 +1,14 @@
 --TEST--
 Bug #77632 (FFI Segfaults When Called With Variadics)
 --SKIPIF--
-<?php require_once('skipif.inc'); ?>
+<?php
+require_once('skipif.inc');
+try {
+	$libc = FFI::cdef("int printf(const char *format, ...);", "libc.so.6");
+} catch (Throwable $_) {
+	die('skip libc.so.6 not available');
+}
+?>
 --INI--
 ffi.enable=1
 --FILE--

--- a/ext/ffi/tests/bug77632b.phpt
+++ b/ext/ffi/tests/bug77632b.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #77632 (FFI function pointers with variadics)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+try {
+	FFI::cdef("extern void *zend_printf;");
+} catch (Throwable $_) {
+	die('skip PHP symbols not available');
+}
+?>
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+$libc = FFI::cdef("extern size_t (*zend_printf)(const char *format, ...);");
+$args = ["test from zend_printf\n"];
+($libc->zend_printf)(...$args);
+$args2 = ["Hello, %s from zend_printf\n", "world"];
+($libc->zend_printf)(...$args2);
+?>
+--EXPECT--
+test from zend_printf
+Hello, world from zend_printf


### PR DESCRIPTION
This fixes the appveyor build, at least.

Not sure how a more permanent fix would be implemented. Feel free to amend this. This test passes locally on Linux

Fixes a bug in test added in
5661feb1ef929111ef7765672fcb49813eee86fc

https://ci.appveyor.com/project/php/php-src/builds/22456937/job/dyxp0ivgavs94w7n

```
========DIFF========
001+ Fatal error: Uncaught FFI\Exception: Failed loading 'libc.so.6' in C:\projects\php-src\ext\ffi\tests\bug77632.php:2
001- test
002+ Stack trace:
003+ #0 C:\projects\php-src\ext\ffi\tests\bug77632.php(2): FFI::cdef('int printf(cons...', 'libc.so.6')
004+ #1 {main}
005+   thrown in C:\projects\php-src\ext\ffi\tests\bug77632.php on line 2
========DONE========
FAIL Bug #77632 (FFI Segfaults When Called With Variadics) [C:\projects\php-src\ext\ffi\tests\bug77632.phpt] 
SKIP Bug #68996 (Invalid free of CG(interned_empty_string)) [C:\projects\php-src\ext\fileinfo\tests\bug68996.phpt] reason: Need Zend MM disabled
```