### PR TITLE
Indicate that tidy's object methods expect 0 args

### DIFF
--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -329,6 +329,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_diagnose, 0, 0, 1)
     ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_tidy_no_args, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_release, 0)
 ZEND_END_ARG_INFO()
 
@@ -444,40 +447,40 @@ static const zend_function_entry tidy_functions[] = {
 
 static const zend_function_entry tidy_funcs_doc[] = {
 	TIDY_METHOD_MAP(getOpt, tidy_getopt, arginfo_tidy_getopt_method)
-	TIDY_METHOD_MAP(cleanRepair, tidy_clean_repair, NULL)
+	TIDY_METHOD_MAP(cleanRepair, tidy_clean_repair, arginfo_tidy_no_args)
 	TIDY_DOC_ME(parseFile, arginfo_tidy_parse_file)
 	TIDY_DOC_ME(parseString, arginfo_tidy_parse_string)
 	TIDY_METHOD_MAP(repairString, tidy_repair_string, arginfo_tidy_repair_string)
 	TIDY_METHOD_MAP(repairFile, tidy_repair_file, arginfo_tidy_repair_file)
-	TIDY_METHOD_MAP(diagnose, tidy_diagnose, NULL)
-	TIDY_METHOD_MAP(getRelease, tidy_get_release, NULL)
-	TIDY_METHOD_MAP(getConfig, tidy_get_config, NULL)
-	TIDY_METHOD_MAP(getStatus, tidy_get_status, NULL)
-	TIDY_METHOD_MAP(getHtmlVer, tidy_get_html_ver, NULL)
+	TIDY_METHOD_MAP(diagnose, tidy_diagnose, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(getRelease, tidy_get_release, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(getConfig, tidy_get_config, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(getStatus, tidy_get_status, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(getHtmlVer, tidy_get_html_ver, arginfo_tidy_no_args)
 #if HAVE_TIDYOPTGETDOC
 	TIDY_METHOD_MAP(getOptDoc, tidy_get_opt_doc, arginfo_tidy_get_opt_doc_method)
 #endif
-	TIDY_METHOD_MAP(isXhtml, tidy_is_xhtml, NULL)
-	TIDY_METHOD_MAP(isXml, tidy_is_xml, NULL)
-	TIDY_METHOD_MAP(root, tidy_get_root, NULL)
-	TIDY_METHOD_MAP(head, tidy_get_head, NULL)
-	TIDY_METHOD_MAP(html, tidy_get_html, NULL)
-	TIDY_METHOD_MAP(body, tidy_get_body, NULL)
+	TIDY_METHOD_MAP(isXhtml, tidy_is_xhtml, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(isXml, tidy_is_xml, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(root, tidy_get_root, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(head, tidy_get_head, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(html, tidy_get_html, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(body, tidy_get_body, arginfo_tidy_no_args)
 	TIDY_DOC_ME(__construct, arginfo_tidy_construct)
 	PHP_FE_END
 };
 
 static const zend_function_entry tidy_funcs_node[] = {
-	TIDY_NODE_ME(hasChildren, NULL)
-	TIDY_NODE_ME(hasSiblings, NULL)
-	TIDY_NODE_ME(isComment, NULL)
-	TIDY_NODE_ME(isHtml, NULL)
-	TIDY_NODE_ME(isText, NULL)
-	TIDY_NODE_ME(isJste, NULL)
-	TIDY_NODE_ME(isAsp, NULL)
-	TIDY_NODE_ME(isPhp, NULL)
-	TIDY_NODE_ME(getParent, NULL)
-	TIDY_NODE_PRIVATE_ME(__construct, NULL)
+	TIDY_NODE_ME(hasChildren, arginfo_tidy_no_args)
+	TIDY_NODE_ME(hasSiblings, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isComment, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isHtml, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isText, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isJste, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isAsp, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isPhp, arginfo_tidy_no_args)
+	TIDY_NODE_ME(getParent, arginfo_tidy_no_args)
+	TIDY_NODE_PRIVATE_ME(__construct, arginfo_tidy_no_args)
 	PHP_FE_END
 };
 


### PR DESCRIPTION
This prevents subclasses from being written with incompatible
implementations, e.g. expecting more required args.

This is backwards incompatible, so it's being added to PHP 8.0. See the discussion in #3845 