### PR TITLE
Bump FFI extension version to PHP_VERSION

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4670,8 +4670,6 @@ ZEND_MINFO_FUNCTION(ffi)
 }
 /* }}} */
 
-#define ZEND_FFI_VERSION "0.1.0"
-
 static const zend_ffi_type zend_ffi_type_void = {.kind=ZEND_FFI_TYPE_VOID, .size=1, .align=1};
 static const zend_ffi_type zend_ffi_type_char = {.kind=ZEND_FFI_TYPE_CHAR, .size=1, .align=_Alignof(char)};
 static const zend_ffi_type zend_ffi_type_bool = {.kind=ZEND_FFI_TYPE_BOOL, .size=1, .align=_Alignof(uint8_t)};

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4774,7 +4774,7 @@ zend_module_entry ffi_module_entry = {
 	NULL,					/* ZEND_RINIT - Request initialization */
 	ZEND_RSHUTDOWN(ffi),	/* ZEND_RSHUTDOWN - Request shutdown */
 	ZEND_MINFO(ffi),		/* ZEND_MINFO - Module info */
-	PHP_FFI_VERSION,		/* Version */
+	PHP_VERSION,			/* Version */
 	ZEND_MODULE_GLOBALS(ffi),
 	ZEND_GINIT(ffi),
 	ZEND_GSHUTDOWN(ffi),

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4774,7 +4774,7 @@ zend_module_entry ffi_module_entry = {
 	NULL,					/* ZEND_RINIT - Request initialization */
 	ZEND_RSHUTDOWN(ffi),	/* ZEND_RSHUTDOWN - Request shutdown */
 	ZEND_MINFO(ffi),		/* ZEND_MINFO - Module info */
-	ZEND_FFI_VERSION,		/* Version */
+	PHP_FFI_VERSION,		/* Version */
 	ZEND_MODULE_GLOBALS(ffi),
 	ZEND_GINIT(ffi),
 	ZEND_GSHUTDOWN(ffi),

--- a/ext/ffi/php_ffi.h
+++ b/ext/ffi/php_ffi.h
@@ -19,6 +19,9 @@
 #ifndef PHP_FFI_H
 #define PHP_FFI_H
 
+#include "php_version.h"
+#define ZEND_FFI_VERSION PHP_VERSION
+
 extern zend_module_entry ffi_module_entry;
 #define phpext_ffi_ptr &ffi_module_entry
 

--- a/ext/ffi/php_ffi.h
+++ b/ext/ffi/php_ffi.h
@@ -19,9 +19,6 @@
 #ifndef PHP_FFI_H
 #define PHP_FFI_H
 
-#include "php_version.h"
-#define ZEND_FFI_VERSION PHP_VERSION
-
 extern zend_module_entry ffi_module_entry;
 #define phpext_ffi_ptr &ffi_module_entry
 


### PR DESCRIPTION
This simplifies bumping the FFI extension version. Instead of `0.1.0` simply current PHP version can be used.