### PR TITLE
ZEND_COMPILE_EXTENDED_INFO split

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1432,11 +1432,11 @@ static void zend_add_to_list(void *result, void *item) /* {{{ */
 }
 /* }}} */
 
-void zend_do_extended_info(void) /* {{{ */
+void zend_do_extended_stmt(void) /* {{{ */
 {
 	zend_op *opline;
 
-	if (!(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+	if (!(CG(compiler_options) & ZEND_COMPILE_EXTENDED_STMT)) {
 		return;
 	}
 
@@ -1450,7 +1450,7 @@ void zend_do_extended_fcall_begin(void) /* {{{ */
 {
 	zend_op *opline;
 
-	if (!(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+	if (!(CG(compiler_options) & ZEND_COMPILE_EXTENDED_FCALL)) {
 		return;
 	}
 
@@ -1464,7 +1464,7 @@ void zend_do_extended_fcall_end(void) /* {{{ */
 {
 	zend_op *opline;
 
-	if (!(CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO)) {
+	if (!(CG(compiler_options) & ZEND_COMPILE_EXTENDED_FCALL)) {
 		return;
 	}
 
@@ -4560,7 +4560,7 @@ void zend_compile_for(zend_ast *ast) /* {{{ */
 
 	zend_update_jump_target_to_next(opnum_jmp);
 	zend_compile_expr_list(&result, cond_ast);
-	zend_do_extended_info();
+	zend_do_extended_stmt();
 
 	zend_emit_cond_jump(ZEND_JMPNZ, &result, opnum_start);
 
@@ -5834,7 +5834,7 @@ void zend_compile_func_decl(znode *result, zend_ast *ast, zend_bool toplevel) /*
 
 	zend_oparray_context_begin(&orig_oparray_context);
 
-	if (CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO) {
+	if (CG(compiler_options) & ZEND_COMPILE_EXTENDED_STMT) {
 		zend_op *opline_ext = zend_emit_op(NULL, ZEND_EXT_NOP, NULL, NULL);
 		opline_ext->lineno = decl->start_lineno;
 	}
@@ -5865,7 +5865,7 @@ void zend_compile_func_decl(znode *result, zend_ast *ast, zend_bool toplevel) /*
 	/* put the implicit return on the really last line */
 	CG(zend_lineno) = decl->end_lineno;
 
-	zend_do_extended_info();
+	zend_do_extended_stmt();
 	zend_emit_final_return(0);
 
 	pass_two(CG(active_op_array));
@@ -8163,8 +8163,8 @@ void zend_compile_stmt(zend_ast *ast) /* {{{ */
 
 	CG(zend_lineno) = ast->lineno;
 
-	if ((CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO) && !zend_is_unticked_stmt(ast)) {
-		zend_do_extended_info();
+	if ((CG(compiler_options) & ZEND_COMPILE_EXTENDED_STMT) && !zend_is_unticked_stmt(ast)) {
+		zend_do_extended_stmt();
 	}
 
 	switch (ast->kind) {

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1028,54 +1028,56 @@ END_EXTERN_C()
  * to change the default compiler behavior */
 
 /* generate extended debug information */
-#define ZEND_COMPILE_EXTENDED_INFO              (1<<0)
+#define ZEND_COMPILE_EXTENDED_STMT              (1<<0)
+#define ZEND_COMPILE_EXTENDED_FCALL             (1<<1)
+#define ZEND_COMPILE_EXTENDED_INFO              (ZEND_COMPILE_EXTENDED_STMT|ZEND_COMPILE_EXTENDED_FCALL)
 
 /* call op_array handler of extendions */
-#define ZEND_COMPILE_HANDLE_OP_ARRAY            (1<<1)
+#define ZEND_COMPILE_HANDLE_OP_ARRAY            (1<<2)
 
 /* generate ZEND_INIT_FCALL_BY_NAME for internal functions instead of ZEND_INIT_FCALL */
-#define ZEND_COMPILE_IGNORE_INTERNAL_FUNCTIONS  (1<<2)
+#define ZEND_COMPILE_IGNORE_INTERNAL_FUNCTIONS  (1<<3)
 
 /* don't perform early binding for classes inherited form internal ones;
  * in namespaces assume that internal class that doesn't exist at compile-time
  * may apper in run-time */
-#define ZEND_COMPILE_IGNORE_INTERNAL_CLASSES    (1<<3)
+#define ZEND_COMPILE_IGNORE_INTERNAL_CLASSES    (1<<4)
 
 /* generate ZEND_DECLARE_INHERITED_CLASS_DELAYED opcode to delay early binding */
-#define ZEND_COMPILE_DELAYED_BINDING            (1<<4)
+#define ZEND_COMPILE_DELAYED_BINDING            (1<<5)
 
 /* disable constant substitution at compile-time */
-#define ZEND_COMPILE_NO_CONSTANT_SUBSTITUTION   (1<<5)
+#define ZEND_COMPILE_NO_CONSTANT_SUBSTITUTION   (1<<6)
 
 /* disable usage of builtin instruction for strlen() */
-#define ZEND_COMPILE_NO_BUILTIN_STRLEN          (1<<6)
+#define ZEND_COMPILE_NO_BUILTIN_STRLEN          (1<<7)
 
 /* disable substitution of persistent constants at compile-time */
-#define ZEND_COMPILE_NO_PERSISTENT_CONSTANT_SUBSTITUTION	(1<<7)
+#define ZEND_COMPILE_NO_PERSISTENT_CONSTANT_SUBSTITUTION	(1<<8)
 
 /* generate ZEND_INIT_FCALL_BY_NAME for userland functions instead of ZEND_INIT_FCALL */
-#define ZEND_COMPILE_IGNORE_USER_FUNCTIONS      (1<<8)
+#define ZEND_COMPILE_IGNORE_USER_FUNCTIONS      (1<<9)
 
 /* force ZEND_ACC_USE_GUARDS for all classes */
-#define ZEND_COMPILE_GUARDS						(1<<9)
+#define ZEND_COMPILE_GUARDS						(1<<10)
 
 /* disable builtin special case function calls */
-#define ZEND_COMPILE_NO_BUILTINS				(1<<10)
+#define ZEND_COMPILE_NO_BUILTINS				(1<<11)
 
 /* result of compilation may be stored in file cache */
-#define ZEND_COMPILE_WITH_FILE_CACHE			(1<<11)
+#define ZEND_COMPILE_WITH_FILE_CACHE			(1<<12)
 
 /* ignore functions and classes declared in other files */
-#define ZEND_COMPILE_IGNORE_OTHER_FILES			(1<<12)
+#define ZEND_COMPILE_IGNORE_OTHER_FILES			(1<<13)
 
 /* this flag is set when compiler invoked by opcache_compile_file() */
-#define ZEND_COMPILE_WITHOUT_EXECUTION          (1<<13)
+#define ZEND_COMPILE_WITHOUT_EXECUTION          (1<<14)
 
 /* this flag is set when compiler invoked during preloading */
-#define ZEND_COMPILE_PRELOAD                    (1<<14)
+#define ZEND_COMPILE_PRELOAD                    (1<<15)
 
 /* disable jumptable optimization for switch statements */
-#define ZEND_COMPILE_NO_JUMPTABLES				(1<<15)
+#define ZEND_COMPILE_NO_JUMPTABLES				(1<<16)
 
 /* The default value for CG(compiler_options) */
 #define ZEND_COMPILE_DEFAULT					ZEND_COMPILE_HANDLE_OP_ARRAY

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -478,7 +478,7 @@ ZEND_API void destroy_op_array(zend_op_array *op_array)
 	}
 }
 
-static void zend_update_extended_info(zend_op_array *op_array)
+static void zend_update_extended_stmts(zend_op_array *op_array)
 {
 	zend_op *opline = op_array->opcodes, *end=opline+op_array->last;
 
@@ -839,8 +839,8 @@ ZEND_API int pass_two(zend_op_array *op_array)
 	if (!ZEND_USER_CODE(op_array->type)) {
 		return 0;
 	}
-	if (CG(compiler_options) & ZEND_COMPILE_EXTENDED_INFO) {
-		zend_update_extended_info(op_array);
+	if (CG(compiler_options) & ZEND_COMPILE_EXTENDED_STMT) {
+		zend_update_extended_stmts(op_array);
 	}
 	if (CG(compiler_options) & ZEND_COMPILE_HANDLE_OP_ARRAY) {
 		if (zend_extension_flags & ZEND_EXTENSIONS_HAVE_OP_ARRAY_HANDLER) {

--- a/ext/opcache/Optimizer/zend_cfg.c
+++ b/ext/opcache/Optimizer/zend_cfg.c
@@ -419,9 +419,11 @@ int zend_build_cfg(zend_arena **arena, const zend_op_array *op_array, uint32_t b
 				break;
 			case ZEND_EXT_NOP:
 			case ZEND_EXT_STMT:
+				flags |= ZEND_FUNC_HAS_EXTENDED_STMT;
+				break;
 			case ZEND_EXT_FCALL_BEGIN:
 			case ZEND_EXT_FCALL_END:
-				flags |= ZEND_FUNC_HAS_EXTENDED_INFO;
+				flags |= ZEND_FUNC_HAS_EXTENDED_FCALL;
 				break;
 			case ZEND_FREE:
 				if (opline->extended_value == ZEND_FREE_SWITCH) {

--- a/ext/opcache/Optimizer/zend_dump.c
+++ b/ext/opcache/Optimizer/zend_dump.c
@@ -927,8 +927,11 @@ void zend_dump_op_array(const zend_op_array *op_array, uint32_t dump_flags, cons
 	if (func_flags & ZEND_FUNC_NO_LOOPS) {
 		fprintf(stderr, ", no_loops");
 	}
-	if (func_flags & ZEND_FUNC_HAS_EXTENDED_INFO) {
-		fprintf(stderr, ", extended_info");
+	if (func_flags & ZEND_FUNC_HAS_EXTENDED_STMT) {
+		fprintf(stderr, ", extended_stmt");
+	}
+	if (func_flags & ZEND_FUNC_HAS_EXTENDED_FCALL) {
+		fprintf(stderr, ", extended_fcall");
 	}
 //TODO: this is useful only for JIT???
 #if 0

--- a/ext/opcache/Optimizer/zend_func_info.h
+++ b/ext/opcache/Optimizer/zend_func_info.h
@@ -31,7 +31,8 @@
 #define ZEND_FUNC_RECURSIVE                (1<<7)
 #define ZEND_FUNC_RECURSIVE_DIRECTLY       (1<<8)
 #define ZEND_FUNC_RECURSIVE_INDIRECTLY     (1<<9)
-#define ZEND_FUNC_HAS_EXTENDED_INFO        (1<<10)
+#define ZEND_FUNC_HAS_EXTENDED_FCALL       (1<<10)
+#define ZEND_FUNC_HAS_EXTENDED_STMT        (1<<11)
 
 /* The following flags are valid only for return values of internal functions
  * returned by zend_get_func_info()


### PR DESCRIPTION
Currently a tool may not decide between debugging and profiling behaviour:
  * We split `ZEND_COMPILE_EXTENDED_INFO` into `ZEND_COMPILE_EXTENDED_FCALL` and `ZEND_COMPILE_EXTENDED_STMT`
  * We define `ZEND_COMPILE_EXTENDED_INFO` as `ZEND_COMPILE_EXTENDED_STMT|ZEND_COMPILE_EXTENDED_FCALL`