### PR TITLE
Add configurable warning if mysqlnd encounters duplicate column name in result

### DIFF
--- a/ext/mysqlnd/mysqlnd.h
+++ b/ext/mysqlnd/mysqlnd.h
@@ -323,6 +323,7 @@ ZEND_BEGIN_MODULE_GLOBALS(mysqlnd)
 	zend_long		debug_realloc_fail_threshold;
 	char *			sha256_server_public_key;
 	zend_bool		fetch_data_copy;
+	zend_bool		duplicate_column_warning;
 	zend_bool		collect_statistics;
 	zend_bool		collect_memory_statistics;
 ZEND_END_MODULE_GLOBALS(mysqlnd)

--- a/ext/mysqlnd/mysqlnd_result.c
+++ b/ext/mysqlnd/mysqlnd_result.c
@@ -1049,6 +1049,7 @@ MYSQLND_METHOD(mysqlnd_result_buffered_zval, fetch_row)(MYSQLND_RES * result, vo
 	const unsigned int field_count = meta->field_count;
 	MYSQLND_RES_BUFFERED_ZVAL * set = (MYSQLND_RES_BUFFERED_ZVAL *) result->stored_data;
 	MYSQLND_CONN_DATA * const conn = result->conn;
+	zend_bool duplicate_column_warning = MYSQLND_G(duplicate_column_warning);
 
 	DBG_ENTER("mysqlnd_result_buffered_zval::fetch_row");
 
@@ -1103,6 +1104,8 @@ MYSQLND_METHOD(mysqlnd_result_buffered_zval, fetch_row)(MYSQLND_RES * result, vo
 				*/
 				Z_TRY_ADDREF_P(data);
 				if (meta->fields[i].is_numeric == FALSE) {
+					if (duplicate_column_warning && zend_hash_exists(Z_ARRVAL_P(row), meta->fields[i].sname))
+						php_error_docref(NULL, E_WARNING, "Result contains duplicate column name '%s'", meta->fields[i].name);
 					zend_hash_update(Z_ARRVAL_P(row), meta->fields[i].sname, data);
 				} else {
 					zend_hash_index_update(Z_ARRVAL_P(row), meta->fields[i].num_key, data);

--- a/ext/mysqlnd/mysqlnd_result.c
+++ b/ext/mysqlnd/mysqlnd_result.c
@@ -1104,8 +1104,9 @@ MYSQLND_METHOD(mysqlnd_result_buffered_zval, fetch_row)(MYSQLND_RES * result, vo
 				*/
 				Z_TRY_ADDREF_P(data);
 				if (meta->fields[i].is_numeric == FALSE) {
-					if (duplicate_column_warning && zend_hash_exists(Z_ARRVAL_P(row), meta->fields[i].sname))
-						php_error_docref(NULL, E_WARNING, "Result contains duplicate column name '%s'", meta->fields[i].name);
+					if (duplicate_column_warning && zend_hash_exists(Z_ARRVAL_P(row), meta->fields[i].sname)) {
+						php_error_docref(NULL, E_WARNING, "Result contains duplicate column name '%s', overwriting previous value", meta->fields[i].name);
+					}
 					zend_hash_update(Z_ARRVAL_P(row), meta->fields[i].sname, data);
 				} else {
 					zend_hash_index_update(Z_ARRVAL_P(row), meta->fields[i].num_key, data);

--- a/ext/mysqlnd/php_mysqlnd.c
+++ b/ext/mysqlnd/php_mysqlnd.c
@@ -198,6 +198,7 @@ static PHP_GINIT_FUNCTION(mysqlnd)
 	mysqlnd_globals->debug_realloc_fail_threshold = -1;
 	mysqlnd_globals->sha256_server_public_key = NULL;
 	mysqlnd_globals->fetch_data_copy = FALSE;
+	mysqlnd_globals->duplicate_column_warning = FALSE;
 }
 /* }}} */
 
@@ -233,6 +234,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("mysqlnd.mempool_default_size","16000",   PHP_INI_ALL,	OnUpdateLong,	mempool_default_size,	zend_mysqlnd_globals,		mysqlnd_globals)
 	STD_PHP_INI_ENTRY("mysqlnd.sha256_server_public_key",NULL, 	PHP_INI_PERDIR, OnUpdateString,	sha256_server_public_key, zend_mysqlnd_globals, mysqlnd_globals)
 	STD_PHP_INI_BOOLEAN("mysqlnd.fetch_data_copy",	"0", 		PHP_INI_ALL,	OnUpdateBool,	fetch_data_copy, zend_mysqlnd_globals, mysqlnd_globals)
+	STD_PHP_INI_BOOLEAN("mysqlnd.duplicate_column_warning",	"0", 	PHP_INI_ALL,	OnUpdateBool,	duplicate_column_warning, zend_mysqlnd_globals, mysqlnd_globals)
 #if PHP_DEBUG
 	STD_PHP_INI_ENTRY("mysqlnd.debug_emalloc_fail_threshold","-1",   PHP_INI_SYSTEM,	OnUpdateLong,	debug_emalloc_fail_threshold,	zend_mysqlnd_globals,		mysqlnd_globals)
 	STD_PHP_INI_ENTRY("mysqlnd.debug_ecalloc_fail_threshold","-1",   PHP_INI_SYSTEM,	OnUpdateLong,	debug_ecalloc_fail_threshold,	zend_mysqlnd_globals,		mysqlnd_globals)


### PR DESCRIPTION
When joining two tables with the same column names MySQL returns both but mysqlnd overwrites the first one with the second on mysqli_fetch_assoc/mysqli_fetch_object.

This (quick and dirty) patch adds an option to emit a warning when this happens so it can be detected more easily.

Open questions:
1) Should it be enabled by default or should even the php.ini-setting be removed?
2) Is there a more efficient version than zend_hash_exists()?
3) Are there other places where the same check should be added (mysqli, ...)?