### PR TITLE
Remove unused PHP_SYS_LFS m4 macro

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1555,52 +1555,6 @@ AC_DEFUN([PHP_SOLARIS_PIC_WEIRDNESS],[
 ])
 
 dnl
-dnl PHP_SYS_LFS
-dnl
-dnl The problem is that the default compilation flags in Solaris 2.6 won't
-dnl let programs access large files;  you need to tell the compiler that
-dnl you actually want your programs to work on large files.  For more
-dnl details about this brain damage please see:
-dnl http://www.sas.com/standards/large.file/x_open.20Mar96.html
-dnl
-dnl Written by Paul Eggert <eggert@twinsun.com>.
-dnl
-AC_DEFUN([PHP_SYS_LFS],
-[dnl
-  # If available, prefer support for large files unless the user specified
-  # one of the CPPFLAGS, LDFLAGS, or LIBS variables.
-  AC_MSG_CHECKING([whether large file support needs explicit enabling])
-  ac_getconfs=''
-  ac_result=yes
-  ac_set=''
-  ac_shellvars='CPPFLAGS LDFLAGS LIBS'
-  for ac_shellvar in $ac_shellvars; do
-    case $ac_shellvar in
-      CPPFLAGS[)] ac_lfsvar=LFS_CFLAGS ;;
-      *[)] ac_lfsvar=LFS_$ac_shellvar ;;
-    esac
-    eval test '"${'$ac_shellvar'+set}"' = set && ac_set=$ac_shellvar
-    (getconf $ac_lfsvar) >/dev/null 2>&1 || { ac_result=no; break; }
-    ac_getconf=`getconf $ac_lfsvar`
-    ac_getconfs=$ac_getconfs$ac_getconf
-    eval ac_test_$ac_shellvar=\$ac_getconf
-  done
-  case "$ac_result$ac_getconfs" in
-    yes[)] ac_result=no ;;
-  esac
-  case "$ac_result$ac_set" in
-    yes?*[)] ac_result="yes, but $ac_set is already set, so use its settings"
-  esac
-  AC_MSG_RESULT([$ac_result])
-  case $ac_result in
-    yes[)]
-      for ac_shellvar in $ac_shellvars; do
-        eval $ac_shellvar=\$ac_test_$ac_shellvar
-      done ;;
-  esac
-])
-
-dnl
 dnl PHP_SOCKADDR_CHECKS
 dnl
 AC_DEFUN([PHP_SOCKADDR_CHECKS], [


### PR DESCRIPTION
This was once named as AC_SYS_LFS and today it is not used in current
PHP code base anymore.