### PR TITLE
fix #77642: typo "incompatibe" in Zend/zend_compile.c

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3930,7 +3930,7 @@ void zend_compile_static_call(znode *result, zend_ast *ast, uint32_t type) /* {{
 				  || (CG(active_class_entry)
 				   && !(CG(active_class_entry)->ce_flags & ZEND_ACC_LINKED))
 				  || !zend_check_protected(zend_get_function_root_class(fbc), CG(active_class_entry)))) {
-					/* incompatibe function */
+					/* incompatible function */
 					fbc = NULL;
 				}
 			}


### PR DESCRIPTION
the word "incompatible" was accidentally written as "incompatibe"

guilty commit: 7e597f48e9fda982e930e4f617d2b2d98d8878a5