### PR TITLE
is(_not)_equal improvement

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2222,6 +2222,9 @@ ZEND_API int ZEND_FASTCALL is_not_identical_function(zval *result, zval *op1, zv
 
 ZEND_API int ZEND_FASTCALL is_equal_function(zval *result, zval *op1, zval *op2) /* {{{ */
 {
+	if (Z_TYPE_P(op1) == Z_TYPE_P(op2)) {
+		return is_identical_function(result, op1, op2);
+	}
 	if (compare_function(result, op1, op2) == FAILURE) {
 		return FAILURE;
 	}
@@ -2232,6 +2235,9 @@ ZEND_API int ZEND_FASTCALL is_equal_function(zval *result, zval *op1, zval *op2)
 
 ZEND_API int ZEND_FASTCALL is_not_equal_function(zval *result, zval *op1, zval *op2) /* {{{ */
 {
+	if (Z_TYPE_P(op1) == Z_TYPE_P(op2)) {
+		return is_not_identical_function(result, op1, op2);
+	}
 	if (compare_function(result, op1, op2) == FAILURE) {
 		return FAILURE;
 	}


### PR DESCRIPTION
Used more fast is_identical_function function instead compare_function if types of operands is indentical