### PR TITLE
Remove unused PHP_AC_BROKEN_SNPRINTF m4 macro

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1436,43 +1436,6 @@ AC_DEFUN([PHP_MISSING_FCLOSE_DECL],[
 ])
 
 dnl
-dnl PHP_AC_BROKEN_SNPRINTF
-dnl
-dnl Check for broken snprintf(), C99 conformance
-dnl
-AC_DEFUN([PHP_AC_BROKEN_SNPRINTF],[
-  AC_CACHE_CHECK(whether snprintf is broken, ac_cv_broken_snprintf,[
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#define NULL (0L)
-main() {
-  char buf[20];
-  int res = 0;
-  res = res || (snprintf(buf, 2, "marcus") != 6);
-  res = res || (buf[1] != '\0');
-  /* Implementations may consider this as an encoding error */
-  snprintf(buf, 0, "boerger");
-  /* However, they MUST ignore the pointer */
-  res = res || (buf[0] != 'm');
-  res = res || (snprintf(NULL, 0, "boerger") != 7);
-  res = res || (snprintf(buf, sizeof(buf), "%f", 0.12345678) != 8);
-  exit(res);
-}
-    ]])],[
-      ac_cv_broken_snprintf=no
-    ],[
-      ac_cv_broken_snprintf=yes
-    ],[
-      ac_cv_broken_snprintf=no
-    ])
-  ])
-  if test "$ac_cv_broken_snprintf" = "yes"; then
-    AC_DEFINE(PHP_BROKEN_SNPRINTF, 1, [Whether snprintf is C99 conform])
-  else
-    AC_DEFINE(PHP_BROKEN_SNPRINTF, 0, [Whether snprintf is C99 conform])
-  fi
-])
-
-dnl
 dnl PHP_SOCKADDR_CHECKS
 dnl
 AC_DEFUN([PHP_SOCKADDR_CHECKS], [

--- a/configure.ac
+++ b/configure.ac
@@ -651,7 +651,6 @@ setsockopt \
 setvbuf \
 shutdown \
 sin \
-snprintf \
 srand48 \
 srandom \
 statfs \
@@ -673,7 +672,6 @@ unlockpt \
 unsetenv \
 usleep \
 utime \
-vsnprintf \
 vasprintf \
 asprintf \
 nanosleep \
@@ -737,7 +735,6 @@ fi
 
 AC_REPLACE_FUNCS(strlcat strlcpy explicit_bzero getopt)
 AC_FUNC_ALLOCA
-dnl PHP_AC_BROKEN_SNPRINTF
 PHP_DECLARED_TIMEZONE
 PHP_TIME_R_TYPE
 PHP_READDIR_R_TYPE

--- a/main/spprintf.h
+++ b/main/spprintf.h
@@ -33,4 +33,4 @@ END_EXTERN_C()
 #define vspprintf zend_vspprintf
 #define vstrpprintf zend_vstrpprintf
 
-#endif /* SNPRINTF_H */
+#endif /* SPPRINTF_H */

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -86,8 +86,6 @@
 # define HAVE_SETVBUF 1
 #endif
 #define HAVE_SHUTDOWN 1
-#define HAVE_SNPRINTF 1
-#define HAVE_VSNPRINTF 1
 #define HAVE_STRCASECMP 1
 #define HAVE_STRDUP 1
 #define HAVE_STRERROR 1


### PR DESCRIPTION
The snprintf function is part of the C99 standard and newer systems in
most cases all support it as defined in the standard. However, on some old
Windows and HP-UX systems it behaves differently. These checks
were also removed and PHP now uses a replacement for the snprintf
function. With gradual transition to C99 usage as a minimum requirement,
it will also be able to be replaced to system's snprintf function
directly.