### PR TITLE
Remove HAVE_LIMITS_H

### DIFF
--- a/TSRM/tsrm_config_common.h
+++ b/TSRM/tsrm_config_common.h
@@ -35,9 +35,7 @@ char *alloca ();
 #include <unistd.h>
 #endif
 
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #ifndef MAXPATHLEN
 # if _WIN32

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -42,7 +42,6 @@ fi
 AC_CHECK_HEADERS(
 inttypes.h \
 stdint.h \
-limits.h \
 malloc.h \
 unistd.h \
 sys/types.h \

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -77,9 +77,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 #include <fcntl.h>
 #include <errno.h>
 

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -60,9 +60,7 @@
 # include <dlfcn.h>
 #endif
 
-#ifdef HAVE_LIMITS_H
-# include <limits.h>
-#endif
+#include <limits.h>
 
 #if HAVE_ALLOCA_H && !defined(_ALLOCA_H)
 # include <alloca.h>

--- a/configure.ac
+++ b/configure.ac
@@ -439,7 +439,6 @@ fcntl.h \
 grp.h \
 ieeefp.h \
 langinfo.h \
-limits.h \
 locale.h \
 monetary.h \
 netdb.h \

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -49,9 +49,7 @@
 #include <unistd.h>
 #endif
 
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #ifdef PHP_WIN32
 # include "win32/nice.h"

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -90,12 +90,6 @@ void register_string_constants(INIT_FUNC_ARGS)
 
 #ifdef HAVE_LOCALECONV
 	/* If last members of struct lconv equal CHAR_MAX, no grouping is done */
-
-/* This is bad, but since we are going to be hardcoding in the POSIX stuff anyway... */
-# ifndef HAVE_LIMITS_H
-# define CHAR_MAX 127
-# endif
-
 	REGISTER_LONG_CONSTANT("CHAR_MAX", CHAR_MAX, CONST_CS | CONST_PERSISTENT);
 #endif
 

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -22,10 +22,8 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_LIMITS_H
-#include <limits.h>
-#endif
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/main/php.h
+++ b/main/php.h
@@ -256,9 +256,7 @@ char *strerror(int);
 # endif
 #endif
 
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #ifndef LONG_MAX
 #define LONG_MAX 2147483647L

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -59,7 +59,6 @@
 #define HAVE_LIBDL 1
 #define HAVE_GETTIMEOFDAY 1
 #define HAVE_PUTENV 1
-#define HAVE_LIMITS_H 1
 #define HAVE_TZSET 1
 #define HAVE_TZNAME 1
 #undef HAVE_FLOCK


### PR DESCRIPTION
The `<limits.h>` header file is part of the standard C89 headers [1]
and on current systems can be included unconditionally.

Since PHP requires at least C89 or greater, the `HAVE_LIMITS_H` symbol
defined by Autoconf in configure.ac [2] can be ommitted and simplifed.

Current bundled libraries libtime, ~oniguruma~, and libmagic still include
partial `HAVE_LIMITS_H` usage, however they are compiled together with
PHP header files where <limits.h> header is included.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4

TODO:
* [ ] upgrade bundled libmagic (file) to latest version