### PR TITLE
Remove checks for locale.h, setlocale, localeconv

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -451,7 +451,7 @@ ZEND_API void ZEND_FASTCALL zend_locale_sprintf_double(zval *op ZEND_FILE_LINE_D
 		convert_scalar_to_number(pzv);					\
 	}
 
-#if HAVE_SETLOCALE && defined(ZEND_WIN32) && !defined(ZTS) && defined(_MSC_VER)
+#if defined(ZEND_WIN32) && !defined(ZTS) && defined(_MSC_VER)
 /* This performance improvement of tolower() on Windows gives 10-18% on bench.php */
 #define ZEND_USE_TOLOWER_L 1
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -434,6 +434,7 @@ grp.h \
 ieeefp.h \
 langinfo.h \
 limits.h \
+locale.h \
 monetary.h \
 netdb.h \
 poll.h \

--- a/configure.ac
+++ b/configure.ac
@@ -434,7 +434,6 @@ grp.h \
 ieeefp.h \
 langinfo.h \
 limits.h \
-locale.h \
 monetary.h \
 netdb.h \
 poll.h \
@@ -628,8 +627,6 @@ random \
 rand_r \
 scandir \
 setitimer \
-setlocale \
-localeconv \
 setenv \
 setpgid \
 setsockopt \

--- a/ext/pcre/php_pcre.h
+++ b/ext/pcre/php_pcre.h
@@ -25,9 +25,7 @@
 #include "pcre2.h"
 #endif
 
-#if HAVE_LOCALE_H
 #include <locale.h>
-#endif
 
 PHPAPI zend_string *php_pcre_replace(zend_string *regex, zend_string *subject_str, char *subject, size_t subject_len, zend_string *replace_str, size_t limit, size_t *replace_count);
 PHPAPI pcre2_code* pcre_get_compiled_regex(zend_string *regex, uint32_t *capture_count);

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -33,10 +33,7 @@
 #include "zend_modules.h"
 
 #include "SAPI.h"
-
-#if HAVE_SETLOCALE
 #include <locale.h>
-#endif
 #include "zend.h"
 #include "zend_extensions.h"
 #include "php_ini.h"

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -76,10 +76,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #endif
 
 #include <string.h>
-
-#if HAVE_LOCALE_H
-# include <locale.h>
-#endif
+#include <locale.h>
 
 #if HAVE_SYS_MMAN_H
 # include <sys/mman.h>
@@ -3685,7 +3682,7 @@ PHP_MINIT_FUNCTION(basic) /* {{{ */
 	BASIC_MINIT_SUBMODULE(password)
 	BASIC_MINIT_SUBMODULE(mt_rand)
 
-#if defined(HAVE_LOCALECONV) && defined(ZTS)
+#if defined(ZTS)
 	BASIC_MINIT_SUBMODULE(localeconv)
 #endif
 
@@ -3769,7 +3766,7 @@ PHP_MSHUTDOWN_FUNCTION(basic) /* {{{ */
 	BASIC_MSHUTDOWN_SUBMODULE(url_scanner_ex)
 	BASIC_MSHUTDOWN_SUBMODULE(file)
 	BASIC_MSHUTDOWN_SUBMODULE(standard_filters)
-#if defined(HAVE_LOCALECONV) && defined(ZTS)
+#if defined(ZTS)
 	BASIC_MSHUTDOWN_SUBMODULE(localeconv)
 #endif
 	BASIC_MSHUTDOWN_SUBMODULE(crypt)

--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -23,16 +23,12 @@
 #include "zend_execute.h"
 #include <stdio.h>
 
-#ifdef HAVE_LOCALE_H
 #include <locale.h>
 #ifdef ZTS
 #include "ext/standard/php_string.h"
 #define LCONV_DECIMAL_POINT (*lconv.decimal_point)
 #else
 #define LCONV_DECIMAL_POINT (*lconv->decimal_point)
-#endif
-#else
-#define LCONV_DECIMAL_POINT '.'
 #endif
 
 #define ALIGN_LEFT 0
@@ -232,12 +228,10 @@ php_sprintf_appenddouble(zend_string **buffer, size_t *pos,
 	char *s = NULL;
 	size_t s_len = 0;
 	int is_negative = 0;
-#ifdef HAVE_LOCALE_H
 #ifdef ZTS
 	struct lconv lconv;
 #else
 	struct lconv *lconv;
-#endif
 #endif
 
 	PRINTF_DEBUG(("sprintf: appenddouble(%x, %x, %x, %f, %d, '%c', %d, %c)\n",
@@ -268,12 +262,10 @@ php_sprintf_appenddouble(zend_string **buffer, size_t *pos,
 		case 'E':
 		case 'f':
 		case 'F':
-#ifdef HAVE_LOCALE_H
 #ifdef ZTS
 			localeconv_r(&lconv);
 #else
 			lconv = localeconv();
-#endif
 #endif
 			s = php_conv_fp((fmt == 'f')?'F':fmt, number, 0, precision,
 						(fmt == 'f')?LCONV_DECIMAL_POINT:'.',
@@ -296,12 +288,10 @@ php_sprintf_appenddouble(zend_string **buffer, size_t *pos,
 			/*
 			 * * We use &num_buf[ 1 ], so that we have room for the sign
 			 */
-#ifdef HAVE_LOCALE_H
 #ifdef ZTS
 			localeconv_r(&lconv);
 #else
 			lconv = localeconv();
-#endif
 #endif
 			s = php_gcvt(number, precision, LCONV_DECIMAL_POINT, (fmt == 'G')?'E':'e', &num_buf[1]);
 			is_negative = 0;

--- a/ext/standard/html.c
+++ b/ext/standard/html.c
@@ -45,9 +45,7 @@
 #include "php_standard.h"
 #include "php_string.h"
 #include "SAPI.h"
-#if HAVE_LOCALE_H
 #include <locale.h>
-#endif
 #if HAVE_LANGINFO_H
 #include <langinfo.h>
 #endif
@@ -408,14 +406,13 @@ static enum entity_charset determine_charset(char *charset_hint)
 	}
 
 	/* try to detect the charset for the locale */
-#if HAVE_NL_LANGINFO && HAVE_LOCALE_H && defined(CODESET)
+#if HAVE_NL_LANGINFO && defined(CODESET)
 	charset_hint = nl_langinfo(CODESET);
 	if (charset_hint != NULL && (len=strlen(charset_hint)) != 0) {
 		goto det_charset;
 	}
 #endif
 
-#if HAVE_LOCALE_H
 	/* try to figure out the charset from the locale */
 	{
 		char *localename;
@@ -441,7 +438,6 @@ static enum entity_charset determine_charset(char *charset_hint)
 			len = strlen(charset_hint);
 		}
 	}
-#endif
 
 det_charset:
 

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -98,7 +98,7 @@ PHP_FUNCTION(strcoll);
 PHP_FUNCTION(money_format);
 #endif
 
-#if defined(HAVE_LOCALECONV) && defined(ZTS)
+#if defined(ZTS)
 PHP_MINIT_FUNCTION(localeconv);
 PHP_MSHUTDOWN_FUNCTION(localeconv);
 #endif
@@ -114,11 +114,7 @@ PHP_MINIT_FUNCTION(string_intrin);
 #define strnatcasecmp(a, b) \
 	strnatcmp_ex(a, strlen(a), b, strlen(b), 1)
 PHPAPI int strnatcmp_ex(char const *a, size_t a_len, char const *b, size_t b_len, int fold_case);
-
-#ifdef HAVE_LOCALECONV
 PHPAPI struct lconv *localeconv_r(struct lconv *out);
-#endif
-
 PHPAPI char *php_strtoupper(char *s, size_t len);
 PHPAPI char *php_strtolower(char *s, size_t len);
 PHPAPI zend_string *php_string_toupper(zend_string *s);

--- a/ext/standard/scanf.c
+++ b/ext/standard/scanf.c
@@ -68,9 +68,7 @@
 #include <ctype.h>
 #include "php.h"
 #include "php_variables.h"
-#ifdef HAVE_LOCALE_H
 #include <locale.h>
-#endif
 #include "zend_execute.h"
 #include "zend_operators.h"
 #include "zend_strtod.h"

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -23,9 +23,7 @@
 #include "php_rand.h"
 #include "php_string.h"
 #include "php_variables.h"
-#ifdef HAVE_LOCALE_H
-# include <locale.h>
-#endif
+#include <locale.h>
 #ifdef HAVE_LANGINFO_H
 # include <langinfo.h>
 #endif
@@ -88,12 +86,8 @@ void register_string_constants(INIT_FUNC_ARGS)
 	REGISTER_LONG_CONSTANT("PATHINFO_EXTENSION", PHP_PATHINFO_EXTENSION, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("PATHINFO_FILENAME", PHP_PATHINFO_FILENAME, CONST_CS | CONST_PERSISTENT);
 
-#ifdef HAVE_LOCALECONV
 	/* If last members of struct lconv equal CHAR_MAX, no grouping is done */
 	REGISTER_LONG_CONSTANT("CHAR_MAX", CHAR_MAX, CONST_CS | CONST_PERSISTENT);
-#endif
-
-#ifdef HAVE_LOCALE_H
 	REGISTER_LONG_CONSTANT("LC_CTYPE", LC_CTYPE, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("LC_NUMERIC", LC_NUMERIC, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("LC_TIME", LC_TIME, CONST_CS | CONST_PERSISTENT);
@@ -103,7 +97,6 @@ void register_string_constants(INIT_FUNC_ARGS)
 # ifdef LC_MESSAGES
 	REGISTER_LONG_CONSTANT("LC_MESSAGES", LC_MESSAGES, CONST_CS | CONST_PERSISTENT);
 # endif
-#endif
 
 }
 /* }}} */
@@ -176,15 +169,14 @@ static zend_string *php_hex2bin(const unsigned char *old, const size_t oldlen)
 }
 /* }}} */
 
-#ifdef HAVE_LOCALECONV
 /* {{{ localeconv_r
  * glibc's localeconv is not reentrant, so lets make it so ... sorta */
 PHPAPI struct lconv *localeconv_r(struct lconv *out)
 {
 
-# ifdef ZTS
+#ifdef ZTS
 	tsrm_mutex_lock( locale_mutex );
-# endif
+#endif
 
 /*  cur->locinfo is struct __crt_locale_info which implementation is
 	hidden in vc14. TODO revisit this and check if a workaround available
@@ -202,15 +194,15 @@ PHPAPI struct lconv *localeconv_r(struct lconv *out)
 	*out = *localeconv();
 #endif
 
-# ifdef ZTS
+#ifdef ZTS
 	tsrm_mutex_unlock( locale_mutex );
-# endif
+#endif
 
 	return out;
 }
 /* }}} */
 
-# ifdef ZTS
+#ifdef ZTS
 /* {{{ PHP_MINIT_FUNCTION
  */
 PHP_MINIT_FUNCTION(localeconv)
@@ -229,7 +221,6 @@ PHP_MSHUTDOWN_FUNCTION(localeconv)
 	return SUCCESS;
 }
 /* }}} */
-# endif
 #endif
 
 /* {{{ proto string bin2hex(string data)
@@ -4838,7 +4829,6 @@ PHP_FUNCTION(setlocale)
 		Z_PARAM_VARIADIC('+', args, num_args)
 	ZEND_PARSE_PARAMETERS_END();
 
-#ifdef HAVE_SETLOCALE
 	idx = 0;
 	while (1) {
 		if (Z_TYPE(args[0]) == IS_ARRAY) {
@@ -4907,7 +4897,6 @@ PHP_FUNCTION(setlocale)
 		}
 	}
 
-#endif
 	RETURN_FALSE;
 }
 /* }}} */
@@ -5600,7 +5589,6 @@ PHP_FUNCTION(localeconv)
 	array_init(&grouping);
 	array_init(&mon_grouping);
 
-#ifdef HAVE_LOCALECONV
 	{
 		struct lconv currlocdata;
 
@@ -5637,30 +5625,6 @@ PHP_FUNCTION(localeconv)
 		add_assoc_long(  return_value, "p_sign_posn",       currlocdata.p_sign_posn);
 		add_assoc_long(  return_value, "n_sign_posn",       currlocdata.n_sign_posn);
 	}
-#else
-	/* Ok, it doesn't look like we have locale info floating around, so I guess it
-	   wouldn't hurt to just go ahead and return the POSIX locale information?  */
-
-	add_index_long(&grouping, 0, -1);
-	add_index_long(&mon_grouping, 0, -1);
-
-	add_assoc_string(return_value, "decimal_point",     "\x2E");
-	add_assoc_string(return_value, "thousands_sep",     "");
-	add_assoc_string(return_value, "int_curr_symbol",   "");
-	add_assoc_string(return_value, "currency_symbol",   "");
-	add_assoc_string(return_value, "mon_decimal_point", "\x2E");
-	add_assoc_string(return_value, "mon_thousands_sep", "");
-	add_assoc_string(return_value, "positive_sign",     "");
-	add_assoc_string(return_value, "negative_sign",     "");
-	add_assoc_long(  return_value, "int_frac_digits",   CHAR_MAX);
-	add_assoc_long(  return_value, "frac_digits",       CHAR_MAX);
-	add_assoc_long(  return_value, "p_cs_precedes",     CHAR_MAX);
-	add_assoc_long(  return_value, "p_sep_by_space",    CHAR_MAX);
-	add_assoc_long(  return_value, "n_cs_precedes",     CHAR_MAX);
-	add_assoc_long(  return_value, "n_sep_by_space",    CHAR_MAX);
-	add_assoc_long(  return_value, "p_sign_posn",       CHAR_MAX);
-	add_assoc_long(  return_value, "n_sign_posn",       CHAR_MAX);
-#endif
 
 	zend_hash_str_update(Z_ARRVAL_P(return_value), "grouping", sizeof("grouping")-1, &grouping);
 	zend_hash_str_update(Z_ARRVAL_P(return_value), "mon_grouping", sizeof("mon_grouping")-1, &mon_grouping);

--- a/main/main.c
+++ b/main/main.c
@@ -41,10 +41,7 @@
 #endif
 
 #include <signal.h>
-
-#if HAVE_SETLOCALE
 #include <locale.h>
-#endif
 #include "zend.h"
 #include "zend_types.h"
 #include "zend_extensions.h"
@@ -2176,11 +2173,8 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 	zuf.getenv_function = sapi_getenv;
 	zuf.resolve_path_function = php_resolve_path_for_zend;
 	zend_startup(&zuf);
-
-#if HAVE_SETLOCALE
 	setlocale(LC_CTYPE, "");
 	zend_update_current_locale();
-#endif
 
 #if HAVE_TZSET
 	tzset();

--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -34,16 +34,12 @@
 #include <inttypes.h>
 #endif
 
-#ifdef HAVE_LOCALE_H
 #include <locale.h>
 #ifdef ZTS
 #include "ext/standard/php_string.h"
 #define LCONV_DECIMAL_POINT (*lconv.decimal_point)
 #else
 #define LCONV_DECIMAL_POINT (*lconv->decimal_point)
-#endif
-#else
-#define LCONV_DECIMAL_POINT '.'
 #endif
 
 /*
@@ -612,12 +608,10 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 	char num_buf[NUM_BUF_SIZE];
 	char char_buf[2];			/* for printing %% and %<unknown> */
 
-#ifdef HAVE_LOCALE_H
 #ifdef ZTS
 	struct lconv lconv;
 #else
 	struct lconv *lconv = NULL;
-#endif
 #endif
 
 	/*
@@ -1025,14 +1019,12 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 						s = "INF";
 						s_len = 3;
 					} else {
-#ifdef HAVE_LOCALE_H
 #ifdef ZTS
 						localeconv_r(&lconv);
 #else
 						if (!lconv) {
 							lconv = localeconv();
 						}
-#endif
 #endif
 						s = php_conv_fp((*fmt == 'f')?'F':*fmt, fp_num, alternate_form,
 						 (adjust_precision == NO) ? FLOAT_DIGITS : precision,
@@ -1086,14 +1078,12 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 					/*
 					 * * We use &num_buf[ 1 ], so that we have room for the sign
 					 */
-#ifdef HAVE_LOCALE_H
 #ifdef ZTS
 					localeconv_r(&lconv);
 #else
 					if (!lconv) {
 						lconv = localeconv();
 					}
-#endif
 #endif
 					s = php_gcvt(fp_num, precision, (*fmt=='H' || *fmt == 'k') ? '.' : LCONV_DECIMAL_POINT, (*fmt == 'G' || *fmt == 'H')?'E':'e', &num_buf[1]);
 					if (*s == '-') {

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -89,16 +89,12 @@
 #include <inttypes.h>
 #endif
 
-#ifdef HAVE_LOCALE_H
 #include <locale.h>
 #ifdef ZTS
 #include "ext/standard/php_string.h"
 #define LCONV_DECIMAL_POINT (*lconv.decimal_point)
 #else
 #define LCONV_DECIMAL_POINT (*lconv->decimal_point)
-#endif
-#else
-#define LCONV_DECIMAL_POINT '.'
 #endif
 
 #include "snprintf.h"
@@ -215,12 +211,10 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 	char num_buf[NUM_BUF_SIZE];
 	char char_buf[2];			/* for printing %% and %<unknown> */
 
-#ifdef HAVE_LOCALE_H
 #ifdef ZTS
 	struct lconv lconv;
 #else
 	struct lconv *lconv = NULL;
-#endif
 #endif
 
 	/*
@@ -633,14 +627,12 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 						s = "inf";
 						s_len = 3;
 					} else {
-#ifdef HAVE_LOCALE_H
 #ifdef ZTS
 						localeconv_r(&lconv);
 #else
 						if (!lconv) {
 							lconv = localeconv();
 						}
-#endif
 #endif
 						s = php_conv_fp((*fmt == 'f')?'F':*fmt, fp_num, alternate_form,
 						 (adjust_precision == NO) ? FLOAT_DIGITS : precision,
@@ -693,14 +685,12 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 					/*
 					 * * We use &num_buf[ 1 ], so that we have room for the sign
 					 */
-#ifdef HAVE_LOCALE_H
 #ifdef ZTS
 					localeconv_r(&lconv);
 #else
 					if (!lconv) {
 						lconv = localeconv();
 					}
-#endif
 #endif
 					s = php_gcvt(fp_num, precision, (*fmt=='H' || *fmt == 'k') ? '.' : LCONV_DECIMAL_POINT, (*fmt == 'G' || *fmt == 'H')?'E':'e', &num_buf[1]);
 					if (*s == '-')

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -47,9 +47,7 @@
 
 #include <signal.h>
 
-#if HAVE_SETLOCALE
-# include <locale.h>
-#endif
+#include <locale.h>
 
 #if HAVE_SYS_TYPES_H
 # include <sys/types.h>

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -48,10 +48,7 @@
 #endif
 
 #include <signal.h>
-
-#if HAVE_SETLOCALE
 #include <locale.h>
-#endif
 #include "zend.h"
 #include "zend_extensions.h"
 #include "php_ini.h"

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -43,10 +43,10 @@
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+
 #include <signal.h>
-#if HAVE_SETLOCALE
 #include <locale.h>
-#endif
+
 #if HAVE_DLFCN_H
 #include <dlfcn.h>
 #endif

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -45,9 +45,7 @@
 
 #include <signal.h>
 
-#if HAVE_SETLOCALE
-# include <locale.h>
-#endif
+#include <locale.h>
 
 #if HAVE_SYS_TYPES_H
 # include <sys/types.h>

--- a/sapi/phpdbg/phpdbg_out.c
+++ b/sapi/phpdbg/phpdbg_out.c
@@ -114,13 +114,8 @@ typedef struct buf_area buffy;
  */
 #define PREFIX( str, length, ch )	 *--str = ch ; length++ ; has_prefix = YES
 
-
-#ifdef HAVE_LOCALE_H
 #include <locale.h>
 #define LCONV_DECIMAL_POINT (*lconv->decimal_point)
-#else
-#define LCONV_DECIMAL_POINT '.'
-#endif
 #define NUL '\0'
 #define S_NULL "(null)"
 #define S_NULL_LEN 6
@@ -155,9 +150,7 @@ static int format_converter(register buffy *odp, const char *fmt, zend_bool esca
 	char num_buf[NUM_BUF_SIZE];
 	char char_buf[2];			/* for printing %% and %<unknown> */
 
-#ifdef HAVE_LOCALE_H
 	struct lconv *lconv = NULL;
-#endif
 
 	/*
 	 * Flag variables
@@ -621,11 +614,10 @@ static int format_converter(register buffy *odp, const char *fmt, zend_bool esca
 						s = "INF";
 						s_len = 3;
 					} else {
-#ifdef HAVE_LOCALE_H
 						if (!lconv) {
 							lconv = localeconv();
 						}
-#endif
+
 						s = php_conv_fp((*fmt == 'f')?'F':*fmt, fp_num, alternate_form,
 						 (adjust_precision == NO) ? FLOAT_DIGITS : precision,
 						 (*fmt == 'f')?LCONV_DECIMAL_POINT:'.',
@@ -678,11 +670,10 @@ static int format_converter(register buffy *odp, const char *fmt, zend_bool esca
 					/*
 					 * * We use &num_buf[ 1 ], so that we have room for the sign
 					 */
-#ifdef HAVE_LOCALE_H
 					if (!lconv) {
 						lconv = localeconv();
 					}
-#endif
+
 					s = php_gcvt(fp_num, precision, (*fmt=='H' || *fmt == 'k') ? '.' : LCONV_DECIMAL_POINT, (*fmt == 'G' || *fmt == 'H')?'E':'e', &num_buf[1]);
 					if (*s == '-') {
 						prefix_char = *s++;

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -76,9 +76,6 @@
 #define HAVE_MEMMOVE 1
 #define HAVE_PUTENV 1
 #define HAVE_REGCOMP 1
-#define HAVE_SETLOCALE 1
-#define HAVE_LOCALECONV 1
-#define HAVE_LOCALE_H 1
 #ifndef HAVE_LIBBIND
 # define HAVE_SETVBUF 1
 #endif

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -76,6 +76,7 @@
 #define HAVE_MEMMOVE 1
 #define HAVE_PUTENV 1
 #define HAVE_REGCOMP 1
+#define HAVE_LOCALE_H 1
 #ifndef HAVE_LIBBIND
 # define HAVE_SETVBUF 1
 #endif


### PR DESCRIPTION
The `<loccale.h>` header file, setlocale, and localeconv are part of the
standard C89 [1] and on current systems can be used unconditionally.

Since PHP 7.4 requires at least C89 or greater, the `HAVE_LOCALE_H`,
`HAVE_SETLOCALE`, and `HAVE_LOCALECONV` symbols defined by Autoconf in
configure.ac [2] can be ommitted and simplifed.

The bundled libmagic (file) has also been patched already in version
5.35 and up.

[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.4
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4

TODO:
* [ ] Maybe also remove checks of `USE_LOCALE` in `Zend/zend_strtod.c` and `Zend/zend_strtod_int.h`?
* [ ] bundled libmagic (file) patches
