### PR TITLE
Move distribution generator script to scripts/dev

### DIFF
--- a/README.RELEASE_PROCESS
+++ b/README.RELEASE_PROCESS
@@ -90,7 +90,7 @@ Commit the changes to the main branch.
 ``git push origin {main branch}``
 ``git push origin {release branch}``
 
-12. run: ``PHPROOT=. ./makedist 5.4.2RC2``, this will export the tree, create configure
+12. run: ``PHPROOT=. ./scripts/dev/makedist 5.4.2RC2``, this will export the tree, create configure
 and build three tarballs (gz, bz2 and xz).
 
 13. run ``scripts/dev/gen_verify_stub <version> [identity]``, this will sign the tarballs
@@ -184,7 +184,7 @@ credits files in ext/standard.
 
 8. Push the tag f.e. "``git push origin php-5.4.1``"
 
-9. run: ``PHPROOT=. ./makedist php 5.4.1``, this will export the tag, create configure
+9. run: ``PHPROOT=. ./scripts/dev/makedist php 5.4.1``, this will export the tag, create configure
 and build three tarballs (gz, bz2 and xz).
    Check if the pear files are updated (phar).
    On some systems the behavior of GNU tar can default to produce POSIX compliant archives

--- a/scripts/dev/genfiles
+++ b/scripts/dev/genfiles
@@ -45,7 +45,7 @@ RE2C_FLAGS="-i"
 original_path=`pwd`
 
 # Project root directory
-project_root=`CDPATH= cd -- "$(dirname -- "$0")" && pwd -P`
+project_root=`CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P`
 cd $project_root
 
 echo "Generating Zend parser and lexer files"

--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -18,6 +18,8 @@
 # Written by Stig Bakken <ssb@guardian.no> 1997-05-28.
 # Adapted to git by Stanislav Malyshev <stas@php.net>
 
+# Go to project root directory.
+cd $(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)
 
 if test "$#" != "1"; then
     echo "Usage: makedist <version>" >&2
@@ -94,7 +96,7 @@ set -x
 # when a user runs buildconf in the distribution.
 rm -f buildmk.stamp
 
-./genfiles
+./scripts/dev/genfiles
 
 # now restore our versions of libtool-generated files
 for i in $LT_TARGETS; do


### PR DESCRIPTION
The more proper place for shell scripts dedicated for development, and
releasing PHP should be the `scripts/dev` directory. Having a cleaner root
project directory helps find the main README.md and files relevant to
install PHP.

These scripts are also used by the release managers mostly who create
release packages and aren't used often by the majority of developers
working on and installing PHP.

TODO:
* [x] recheck running the makedist from other locations...