### PR TITLE
Allow throwing from __toString()

### DIFF
--- a/Zend/tests/bug26166.phpt
+++ b/Zend/tests/bug26166.phpt
@@ -31,12 +31,6 @@ echo $o;
 
 echo "===NONE===\n";
 
-function my_error_handler($errno, $errstr, $errfile, $errline) {
-	var_dump($errstr);
-}
-
-set_error_handler('my_error_handler');
-
 class NoneTest
 {
 	function __toString() {
@@ -44,7 +38,11 @@ class NoneTest
 }
 
 $o = new NoneTest;
-echo $o;
+try {
+    echo $o;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 echo "===THROW===\n";
 
@@ -58,17 +56,16 @@ class ErrorTest
 $o = new ErrorTest;
 try {
 	echo $o;
-}
-catch (Exception $e) {
-	echo "Got the exception\n";
+} catch (Exception $e) {
+	echo $e->getMessage(), "\n";
 }
 
 ?>
 ===DONE===
---EXPECTF--
+--EXPECT--
 Hello World!
 ===NONE===
-string(%d) "Method NoneTest::__toString() must return a string value"
+Method NoneTest::__toString() must return a string value
 ===THROW===
-
-Fatal error: Method ErrorTest::__toString() must not throw an exception, caught Exception: This is an error! in %sbug26166.php on line %d
+This is an error!
+===DONE===

--- a/Zend/tests/bug28444.phpt
+++ b/Zend/tests/bug28444.phpt
@@ -3,12 +3,6 @@ Bug #28444 (Cannot access undefined property for object with overloaded property
 --FILE--
 <?php
 
-function my_error_handler($errno, $errstr, $errfile, $errline) {
-	var_dump($errstr);
-}
-
-set_error_handler('my_error_handler');
-
 class ObjectOne
 {
 	public $x;
@@ -16,6 +10,10 @@ class ObjectOne
 	function __construct($x)
 	{
 		$this->x = $x;
+	}
+
+	function __toString() {
+		return "Object";
 	}
 }
 
@@ -55,8 +53,8 @@ var_dump($y->z->x = 6);
 
 ?>
 ===DONE===
---EXPECTF--
-object(ObjectOne)#%d (1) {
+--EXPECT--
+object(ObjectOne)#2 (1) {
   ["x"]=>
   int(2)
 }
@@ -66,9 +64,8 @@ Overloaded::__set(y,3)
 int(3)
 Overloaded::__get(y)
 int(3)
-string(58) "Object of class ObjectOne could not be converted to string"
-Overloaded::__set(z,)
-object(ObjectOne)#%d (1) {
+Overloaded::__set(z,Object)
+object(ObjectOne)#3 (1) {
   ["x"]=>
   int(4)
 }

--- a/Zend/tests/bug30791.phpt
+++ b/Zend/tests/bug30791.phpt
@@ -3,32 +3,25 @@ Bug #30791 (magic methods (__sleep/__wakeup/__toString) call __call if object is
 --FILE--
 <?php
 
-function my_error_handler($errno, $errstr, $errfile, $errline) {
-	var_dump($errstr);
-}
-
-set_error_handler('my_error_handler');
-
 class a
 {
-   public $a = 4;
-   function __call($a,$b) {
-       return "unknown method";
-   }
+    public $a = 4;
+    function __call($name, $args) {
+        echo __METHOD__, "\n";
+    }
 }
 
 $b = new a;
-echo $b,"\n";
+var_dump($b);
 $c = unserialize(serialize($b));
-echo $c,"\n";
 var_dump($c);
 
 ?>
 --EXPECT--
-string(50) "Object of class a could not be converted to string"
-
-string(50) "Object of class a could not be converted to string"
-
+object(a)#1 (1) {
+  ["a"]=>
+  int(4)
+}
 object(a)#2 (1) {
   ["a"]=>
   int(4)

--- a/Zend/tests/bug60909_2.phpt
+++ b/Zend/tests/bug60909_2.phpt
@@ -3,18 +3,21 @@ Bug #60909 (custom error handler throwing Exception + fatal error = no shutdown 
 --FILE--
 <?php
 register_shutdown_function(function(){echo("\n\n!!!shutdown!!!\n\n");});
-set_error_handler(function($errno, $errstr, $errfile, $errline){throw new Exception("Foo");});
 
 class Bad {
     public function __toString() {
-        throw new Exception('Oops, I cannot do this');
+        throw new Exception('I CAN DO THIS');
     }
 }
 
 $bad = new Bad();
 echo "$bad";
 --EXPECTF--
-Fatal error: Method Bad::__toString() must not throw an exception, caught Exception: Oops, I cannot do this in %sbug60909_2.php on line %d
+Fatal error: Uncaught Exception: I CAN DO THIS in %s:%d
+Stack trace:
+#0 %s(%d): Bad->__toString()
+#1 {main}
+  thrown in %s on line %d
 
 
 !!!shutdown!!!

--- a/Zend/tests/bug70967.phpt
+++ b/Zend/tests/bug70967.phpt
@@ -11,4 +11,8 @@ class A {
 echo (new A);
 ?>
 --EXPECTF--
-Fatal error: Method A::__toString() must not throw an exception, caught Error: Call to undefined function undefined_function() in %sbug70967.php on line %d
+Fatal error: Uncaught Error: Call to undefined function undefined_function() in %s:%d
+Stack trace:
+#0 %s(%d): A->__toString()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/bug72162.phpt
+++ b/Zend/tests/bug72162.phpt
@@ -7,4 +7,8 @@ $var11 = new StdClass();
 $var16 = error_reporting($var11);
 ?>
 --EXPECTF--
-Recoverable fatal error: Object of class stdClass could not be converted to string in %sbug72162.php on line %d
+Fatal error: Uncaught Error: Object of class stdClass could not be converted to string in %s:%d
+Stack trace:
+#0 %s(%d): error_reporting(Object(stdClass))
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/call_with_refs.phpt
+++ b/Zend/tests/call_with_refs.phpt
@@ -2,16 +2,17 @@
 Check call to non-ref function with call-time refs
 --FILE--
 <?php
-function my_errorhandler($errno,$errormsg) {
-  global $my_var;
-  $my_var=0x12345;
-  echo $errormsg."\n";
-  return true;
+class Test {
+    public function __toString() {
+        global $my_var;
+        $my_var=0x12345;
+        return "";
+    }
 }
-$oldhandler = set_error_handler("my_errorhandler");
+
 $my_var = str_repeat("A",64);
-$data = call_user_func_array("substr_replace",array(&$my_var, new StdClass(),1));
+$data = call_user_func_array("substr_replace",array(&$my_var, new Test(), 1));
 echo "OK!";
+?>
 --EXPECT--
-Object of class stdClass could not be converted to string
 OK!

--- a/Zend/tests/class_properties_const.phpt
+++ b/Zend/tests/class_properties_const.phpt
@@ -22,4 +22,7 @@ NULL
 Notice: Undefined property: A::$1 in %sclass_properties_const.php on line %d
 NULL
 
-Recoverable fatal error: Object of class Closure could not be converted to string in %sclass_properties_const.php on line %d
+Fatal error: Uncaught Error: Object of class Closure could not be converted to string in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/closure_015.phpt
+++ b/Zend/tests/closure_015.phpt
@@ -2,18 +2,20 @@
 Closure 015: converting to string/unicode
 --FILE--
 <?php
-set_error_handler('myErrorHandler', E_RECOVERABLE_ERROR);
-function myErrorHandler($errno, $errstr, $errfile, $errline) {
-  echo "Error: $errstr at $errfile($errline)\n";
-  return true;
-}
-$x = function() { return 1; };
-print (string) $x;
-print "\n";
-print $x;
-print "\n";
-?>
---EXPECTF--
-Error: Object of class Closure could not be converted to string at %sclosure_015.php(8)
 
-Error: Object of class Closure could not be converted to string at %sclosure_015.php(10)
+$x = function() { return 1; };
+try {
+    print (string) $x;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    print $x;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Object of class Closure could not be converted to string
+Object of class Closure could not be converted to string

--- a/Zend/tests/exception_009.phpt
+++ b/Zend/tests/exception_009.phpt
@@ -25,4 +25,8 @@ throw new my_exception;
 
 ?>
 --EXPECT--
-Recoverable fatal error: Object of class stdClass could not be converted to string in Unknown on line 0
+Fatal error: Uncaught Error: Object of class stdClass could not be converted to string in [no active file]:0
+Stack trace:
+#0 [internal function]: Exception->__toString()
+#1 {main}
+  thrown in [no active file] on line 0

--- a/Zend/tests/exception_from_toString.phpt
+++ b/Zend/tests/exception_from_toString.phpt
@@ -1,0 +1,135 @@
+--TEST--
+Test exceptions thrown from __toString() in various contexts
+--FILE--
+<?php
+
+class BadStr {
+    public function __toString() {
+        throw new Exception("Exception");
+    }
+}
+
+$str = "a";
+$num = 42;
+$badStr = new BadStr;
+
+try { $x = $str . $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = $badStr . $str; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = $str .= $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($str); 
+try { $x = $num . $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = $badStr . $num; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = $num .= $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($num);
+
+try { $x = $badStr .= $str; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($badStr);
+try { $x = $badStr .= $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($badStr);
+
+try { $x = "x$badStr"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "{$badStr}x"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "$str$badStr"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "$badStr$str"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { $x = "x$badStr$str"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "x$str$badStr"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "{$str}x$badStr"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $x = "{$badStr}x$str"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { $x = (string) $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { $x = include $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { echo $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+${""} = 42;
+try { unset(${$badStr}); }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump(${""});
+
+unset(${""});
+try { $x = ${$badStr}; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { $x = isset(${$badStr}); }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+$obj = new stdClass;
+try { $x = $obj->{$badStr} = $str; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($obj);
+
+try { $str[0] = $badStr; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($str);
+
+$obj = new DateInterval('P1D');
+try { $x = $obj->{$badStr} = $str; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump(!isset($obj->{""}));
+
+try { strlen($badStr); } catch (Exception $e) { echo "Exception\n"; }
+try { substr($badStr, 0); } catch (Exception $e) { echo "Exception\n"; }
+try { new ArrayObject([], 0, $badStr); } catch (Exception $e) { echo "Exception\n"; }
+
+?>
+--EXPECT--
+Exception
+Exception
+Exception
+string(1) "a"
+Exception
+Exception
+Exception
+int(42)
+Exception
+object(BadStr)#1 (0) {
+}
+Exception
+object(BadStr)#1 (0) {
+}
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+int(42)
+Exception
+Exception
+Exception
+object(stdClass)#2 (0) {
+}
+Exception
+string(1) "a"
+Exception
+bool(true)
+Exception
+Exception
+Exception

--- a/Zend/tests/instanceof_001.phpt
+++ b/Zend/tests/instanceof_001.phpt
@@ -16,8 +16,6 @@ var_dump($c[0] instanceof stdClass);
 
 var_dump(@$inexistent instanceof stdClass);
 
-var_dump("$a" instanceof stdClass);
-
 ?>
 --EXPECTF--
 bool(true)
@@ -27,5 +25,3 @@ Deprecated: Function create_function() is deprecated in %s on line %d
 bool(true)
 bool(true)
 bool(false)
-
-Recoverable fatal error: Object of class stdClass could not be converted to string in %s on line %d

--- a/Zend/tests/unexpected_ref_bug.phpt
+++ b/Zend/tests/unexpected_ref_bug.phpt
@@ -2,16 +2,17 @@
 Crash when function parameter modified via unexpected reference
 --FILE--
 <?php
-function my_errorhandler($errno,$errormsg) {
-  global $my_var;
-  $my_var = 0;
-  return true;
+class Test {
+    public function __toString() {
+        global $my_var;
+        $my_var = 0;
+        return ",";
+    }
 }
-set_error_handler("my_errorhandler");
 $my_var = str_repeat("A",64);
-$data = call_user_func_array("explode",array(new StdClass(), &$my_var));
+$data = call_user_func_array("explode",array(new Test(), &$my_var));
 $my_var=array(1,2,3);
-$data = call_user_func_array("implode",array(&$my_var, new StdClass()));
+$data = call_user_func_array("implode",array(&$my_var, new Test()));
 echo "Done.\n";
 ?>
 --EXPECT--

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -334,8 +334,7 @@ ZEND_API int ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **pc
 		*pce = NULL;
 		return 1;
 	}
-	convert_to_string_ex(arg);
-	if (EG(exception)) {
+	if (!try_convert_to_string(arg)) {
 		*pce = NULL;
 		return 0;
 	}
@@ -736,8 +735,7 @@ static const char *zend_parse_arg_impl(int arg_num, zval *arg, va_list *va, cons
 					*pce = NULL;
 					break;
 				}
-				convert_to_string_ex(arg);
-				if (EG(exception)) {
+				if (!try_convert_to_string(arg)) {
 					*pce = NULL;
 					return "valid class name";
 				}

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -335,6 +335,11 @@ ZEND_API int ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **pc
 		return 1;
 	}
 	convert_to_string_ex(arg);
+	if (EG(exception)) {
+		*pce = NULL;
+		return 0;
+	}
+
 	*pce = zend_lookup_class(Z_STR_P(arg));
 	if (ce_base) {
 		if ((!*pce || !instanceof_function(*pce, ce_base))) {
@@ -732,6 +737,11 @@ static const char *zend_parse_arg_impl(int arg_num, zval *arg, va_list *va, cons
 					break;
 				}
 				convert_to_string_ex(arg);
+				if (EG(exception)) {
+					*pce = NULL;
+					return "valid class name";
+				}
+
 				if ((lookup = zend_lookup_class(Z_STR_P(arg))) == NULL) {
 					*pce = NULL;
 				} else {
@@ -817,6 +827,9 @@ static int zend_parse_arg(int arg_num, zval *arg, va_list *va, const char **spec
 
 	expected_type = zend_parse_arg_impl(arg_num, arg, va, spec, &error, &severity);
 	if (expected_type) {
+		if (EG(exception)) {
+			return FAILURE;
+		}
 		if (!(flags & ZEND_PARSE_PARAMS_QUIET) && (*expected_type || error)) {
 			const char *space;
 			const char *class_name = get_active_class_name(&space);

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3231,7 +3231,7 @@ try_again:
 			}
 
 			if (obj == NULL || method == NULL || Z_TYPE_P(method) != IS_STRING) {
-				return zend_string_init("Array", sizeof("Array")-1, 0);
+				return ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED);
 			}
 
 			if (Z_TYPE_P(obj) == IS_STRING) {
@@ -3239,7 +3239,7 @@ try_again:
 			} else if (Z_TYPE_P(obj) == IS_OBJECT) {
 				return zend_create_method_string(Z_OBJCE_P(obj)->name, Z_STR_P(method));
 			} else {
-				return zend_string_init("Array", sizeof("Array")-1, 0);
+				return ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED);
 			}
 		}
 		case IS_OBJECT:

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1136,7 +1136,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_exception(int num, cha
 		int _min_num_args = (min_num_args); \
 		int _max_num_args = (max_num_args); \
 		int _num_args = EX_NUM_ARGS(); \
-		int _i; \
+		int _i = 0; \
 		zval *_real_arg, *_arg = NULL; \
 		zend_expected_type _expected_type = Z_EXPECTED_LONG; \
 		char *_error = NULL; \
@@ -1165,7 +1165,6 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_exception(int num, cha
 				_error_code = ZPP_ERROR_FAILURE; \
 				break; \
 			} \
-			_i = 0; \
 			_real_arg = ZEND_CALL_ARG(execute_data, 0);
 
 #define ZEND_PARSE_PARAMETERS_START(min_num_args, max_num_args) \

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1181,7 +1181,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_exception(int num, cha
 #define ZEND_PARSE_PARAMETERS_END_EX(failure) \
 		} while (0); \
 		if (UNEXPECTED(_error_code != ZPP_ERROR_OK)) { \
-			if (!(_flags & ZEND_PARSE_PARAMS_QUIET)) { \
+			if (!(_flags & ZEND_PARSE_PARAMS_QUIET) && !EG(exception)) { \
 				if (_error_code == ZPP_ERROR_WRONG_CALLBACK) { \
 					if (_flags & ZEND_PARSE_PARAMS_THROW) { \
 						zend_wrong_callback_exception(_i, _error); \

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -737,6 +737,10 @@ ZEND_FUNCTION(error_reporting)
 	old_error_reporting = EG(error_reporting);
 	if (ZEND_NUM_ARGS() != 0) {
 		zend_string *new_val = zval_get_string(err);
+		if (UNEXPECTED(EG(exception))) {
+			return;
+		}
+
 		do {
 			zend_ini_entry *p = EG(error_reporting_ini_entry);
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1551,7 +1551,7 @@ static zend_never_inline void zend_assign_to_string_offset(zval *str, zval *dim,
 		zend_string *tmp = zval_get_string_func(value);
 		if (UNEXPECTED(EG(exception))) {
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				ZVAL_NULL(EX_VAR(opline->result.var));
+				ZVAL_UNDEF(EX_VAR(opline->result.var));
 			}
 			return;
 		}

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1549,6 +1549,12 @@ static zend_never_inline void zend_assign_to_string_offset(zval *str, zval *dim,
 	if (Z_TYPE_P(value) != IS_STRING) {
 		/* Convert to string, just the time to pick the 1st byte */
 		zend_string *tmp = zval_get_string_func(value);
+		if (UNEXPECTED(EG(exception))) {
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			return;
+		}
 
 		string_len = ZSTR_LEN(tmp);
 		c = (zend_uchar)ZSTR_VAL(tmp)[0];
@@ -4024,6 +4030,9 @@ static zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval 
 	if (Z_TYPE_P(inc_filename) != IS_STRING) {
 		ZVAL_STR(&tmp_inc_filename, zval_get_string_func(inc_filename));
 		inc_filename = &tmp_inc_filename;
+		if (UNEXPECTED(EG(exception))) {
+			return NULL;
+		}
 	}
 
 	switch (type) {

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -605,7 +605,7 @@ try_again:
 }
 /* }}} */
 
-ZEND_API zend_bool ZEND_FASTCALL try_convert_to_string(zval *op)
+ZEND_API zend_bool ZEND_FASTCALL _try_convert_to_string(zval *op)
 {
 	if (Z_TYPE_P(op) != IS_STRING) {
 		zend_string *str = zval_get_string_func(op);

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -605,6 +605,19 @@ try_again:
 }
 /* }}} */
 
+ZEND_API zend_bool ZEND_FASTCALL try_convert_to_string(zval *op)
+{
+	if (Z_TYPE_P(op) != IS_STRING) {
+		zend_string *str = zval_get_string_func(op);
+		if (UNEXPECTED(EG(exception))) {
+			return 0;
+		}
+		zval_ptr_dtor(op);
+		ZVAL_STR(op, str);
+	}
+	return 1;
+}
+
 static void convert_scalar_to_array(zval *op) /* {{{ */
 {
 	HashTable *ht = zend_new_array(1);

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -568,7 +568,7 @@ try_again:
 		case IS_ARRAY:
 			zend_error(E_NOTICE, "Array to string conversion");
 			zval_ptr_dtor(op);
-			ZVAL_NEW_STR(op, zend_string_init("Array", sizeof("Array")-1, 0));
+			ZVAL_INTERNED_STR(op, ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED));
 			break;
 		case IS_OBJECT: {
 			zval tmp;

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -873,7 +873,7 @@ try_again:
 		}
 		case IS_ARRAY:
 			zend_error(E_NOTICE, "Array to string conversion");
-			return zend_string_init("Array", sizeof("Array")-1, 0);
+			return ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED);
 		case IS_OBJECT: {
 			zval tmp;
 			if (Z_OBJ_HT_P(op)->cast_object) {

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -258,6 +258,7 @@ ZEND_API void multi_convert_to_string_ex(int argc, ...);
 ZEND_API zend_long    ZEND_FASTCALL zval_get_long_func(zval *op);
 ZEND_API double       ZEND_FASTCALL zval_get_double_func(zval *op);
 ZEND_API zend_string* ZEND_FASTCALL zval_get_string_func(zval *op);
+ZEND_API zend_string* ZEND_FASTCALL zval_try_get_string_func(zval *op);
 
 static zend_always_inline zend_long zval_get_long(zval *op) {
 	return EXPECTED(Z_TYPE_P(op) == IS_LONG) ? Z_LVAL_P(op) : zval_get_long_func(op);
@@ -280,6 +281,16 @@ static zend_always_inline zend_string *zval_get_tmp_string(zval *op, zend_string
 static zend_always_inline void zend_tmp_string_release(zend_string *tmp) {
 	if (UNEXPECTED(tmp)) {
 		zend_string_release_ex(tmp, 0);
+	}
+}
+
+/* Like zval_get_tmp_string, but returns NULL if the conversion fails with an exception. */
+static zend_always_inline zend_string *zval_try_get_tmp_string(zval *op, zend_string **tmp) {
+	if (EXPECTED(Z_TYPE_P(op) == IS_STRING)) {
+		*tmp = NULL;
+		return Z_STR_P(op);
+	} else {
+		return *tmp = zval_try_get_string_func(op);
 	}
 }
 

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -251,7 +251,6 @@ ZEND_API void ZEND_FASTCALL convert_to_null(zval *op);
 ZEND_API void ZEND_FASTCALL convert_to_boolean(zval *op);
 ZEND_API void ZEND_FASTCALL convert_to_array(zval *op);
 ZEND_API void ZEND_FASTCALL convert_to_object(zval *op);
-ZEND_API zend_bool ZEND_FASTCALL try_convert_to_string(zval *op);
 ZEND_API void multi_convert_to_long_ex(int argc, ...);
 ZEND_API void multi_convert_to_double_ex(int argc, ...);
 ZEND_API void multi_convert_to_string_ex(int argc, ...);
@@ -293,6 +292,16 @@ static zend_always_inline zend_string *zval_try_get_tmp_string(zval *op, zend_st
 	} else {
 		return *tmp = zval_try_get_string_func(op);
 	}
+}
+
+/* Like convert_to_string(), but returns whether the conversion succeeded and does not modify the
+ * zval in-place if it fails. */
+ZEND_API zend_bool ZEND_FASTCALL _try_convert_to_string(zval *op);
+static zend_always_inline zend_bool try_convert_to_string(zval *op) {
+	if (Z_TYPE_P(op) == IS_STRING) {
+		return 1;
+	}
+	return _try_convert_to_string(op);
 }
 
 /* Compatibility macros for 7.2 and below */

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -251,6 +251,7 @@ ZEND_API void ZEND_FASTCALL convert_to_null(zval *op);
 ZEND_API void ZEND_FASTCALL convert_to_boolean(zval *op);
 ZEND_API void ZEND_FASTCALL convert_to_array(zval *op);
 ZEND_API void ZEND_FASTCALL convert_to_object(zval *op);
+ZEND_API zend_bool ZEND_FASTCALL try_convert_to_string(zval *op);
 ZEND_API void multi_convert_to_long_ex(int argc, ...);
 ZEND_API void multi_convert_to_double_ex(int argc, ...);
 ZEND_API void multi_convert_to_string_ex(int argc, ...);

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -284,6 +284,15 @@ static zend_always_inline void zend_tmp_string_release(zend_string *tmp) {
 	}
 }
 
+/* Like zval_get_string, but returns NULL if the conversion fails with an exception. */
+static zend_always_inline zend_string *zval_try_get_string(zval *op) {
+	if (EXPECTED(Z_TYPE_P(op) == IS_STRING)) {
+		return Z_STR_P(op);
+	} else {
+		return zval_try_get_string_func(op);
+	}
+}
+
 /* Like zval_get_tmp_string, but returns NULL if the conversion fails with an exception. */
 static zend_always_inline zend_string *zval_try_get_tmp_string(zval *op, zend_string **tmp) {
 	if (EXPECTED(Z_TYPE_P(op) == IS_STRING)) {

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -506,6 +506,7 @@ EMPTY_SWITCH_DEFAULT_CASE()
 	_(ZEND_STR_NAME,                   "name") \
 	_(ZEND_STR_ARGV,                   "argv") \
 	_(ZEND_STR_ARGC,                   "argc") \
+	_(ZEND_STR_ARRAY_CAPITALIZED,      "Array") \
 
 
 typedef enum _zend_known_string_id {

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1651,6 +1651,7 @@ ZEND_VM_HELPER(zend_fetch_var_address_helper, CONST|TMPVAR|CV, UNUSED, int type)
 		name = zval_get_tmp_string(varname, &tmp_name);
 		if (UNEXPECTED(EG(exception))) {
 			FREE_OP1();
+			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1649,6 +1649,10 @@ ZEND_VM_HELPER(zend_fetch_var_address_helper, CONST|TMPVAR|CV, UNUSED, int type)
 			ZVAL_UNDEFINED_OP1();
 		}
 		name = zval_get_tmp_string(varname, &tmp_name);
+		if (UNEXPECTED(EG(exception))) {
+			FREE_OP1();
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(opline->extended_value EXECUTE_DATA_CC);
@@ -5909,6 +5913,10 @@ ZEND_VM_HANDLER(74, ZEND_UNSET_VAR, CONST|TMPVAR|CV, UNUSED, VAR_FETCH)
 			varname = ZVAL_UNDEFINED_OP1();
 		}
 		name = zval_get_tmp_string(varname, &tmp_name);
+		if (UNEXPECTED(EG(exception))) {
+			FREE_OP1();
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(opline->extended_value EXECUTE_DATA_CC);
@@ -7923,7 +7931,9 @@ ZEND_VM_COLD_CONST_HANDLER(121, ZEND_STRLEN, CONST|TMPVAR|CV, ANY)
 				}
 				zval_ptr_dtor(&tmp);
 			}
-			zend_internal_type_error(strict, "strlen() expects parameter 1 to be string, %s given", zend_get_type_by_const(Z_TYPE_P(value)));
+			if (!EG(exception)) {
+				zend_internal_type_error(strict, "strlen() expects parameter 1 to be string, %s given", zend_get_type_by_const(Z_TYPE_P(value)));
+			}
 			ZVAL_NULL(EX_VAR(opline->result.var));
 		} while (0);
 	}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -4184,7 +4184,9 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_STRLEN_SPEC_CONST
 				}
 				zval_ptr_dtor(&tmp);
 			}
-			zend_internal_type_error(strict, "strlen() expects parameter 1 to be string, %s given", zend_get_type_by_const(Z_TYPE_P(value)));
+			if (!EG(exception)) {
+				zend_internal_type_error(strict, "strlen() expects parameter 1 to be string, %s given", zend_get_type_by_const(Z_TYPE_P(value)));
+			}
 			ZVAL_NULL(EX_VAR(opline->result.var));
 		} while (0);
 	}
@@ -8694,6 +8696,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			ZVAL_UNDEFINED_OP1();
 		}
 		name = zval_get_tmp_string(varname, &tmp_name);
+		if (UNEXPECTED(EG(exception))) {
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(opline->extended_value EXECUTE_DATA_CC);
@@ -9205,6 +9211,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_CONST_UNUSED_HA
 			varname = ZVAL_UNDEFINED_OP1();
 		}
 		name = zval_get_tmp_string(varname, &tmp_name);
+		if (UNEXPECTED(EG(exception))) {
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(opline->extended_value EXECUTE_DATA_CC);
@@ -12959,7 +12969,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_STRLEN_SPEC_TMPVAR_HANDLER(ZEN
 				}
 				zval_ptr_dtor(&tmp);
 			}
-			zend_internal_type_error(strict, "strlen() expects parameter 1 to be string, %s given", zend_get_type_by_const(Z_TYPE_P(value)));
+			if (!EG(exception)) {
+				zend_internal_type_error(strict, "strlen() expects parameter 1 to be string, %s given", zend_get_type_by_const(Z_TYPE_P(value)));
+			}
 			ZVAL_NULL(EX_VAR(opline->result.var));
 		} while (0);
 	}
@@ -16093,6 +16105,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			ZVAL_UNDEFINED_OP1();
 		}
 		name = zval_get_tmp_string(varname, &tmp_name);
+		if (UNEXPECTED(EG(exception))) {
+			zval_ptr_dtor_nogc(free_op1);
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(opline->extended_value EXECUTE_DATA_CC);
@@ -16213,6 +16229,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_TMPVAR_UNUSED_H
 			varname = ZVAL_UNDEFINED_OP1();
 		}
 		name = zval_get_tmp_string(varname, &tmp_name);
+		if (UNEXPECTED(EG(exception))) {
+			zval_ptr_dtor_nogc(free_op1);
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(opline->extended_value EXECUTE_DATA_CC);
@@ -40041,7 +40061,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_STRLEN_SPEC_CV_HANDLER(ZEND_OP
 				}
 				zval_ptr_dtor(&tmp);
 			}
-			zend_internal_type_error(strict, "strlen() expects parameter 1 to be string, %s given", zend_get_type_by_const(Z_TYPE_P(value)));
+			if (!EG(exception)) {
+				zend_internal_type_error(strict, "strlen() expects parameter 1 to be string, %s given", zend_get_type_by_const(Z_TYPE_P(value)));
+			}
 			ZVAL_NULL(EX_VAR(opline->result.var));
 		} while (0);
 	}
@@ -48775,6 +48797,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 			ZVAL_UNDEFINED_OP1();
 		}
 		name = zval_get_tmp_string(varname, &tmp_name);
+		if (UNEXPECTED(EG(exception))) {
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(opline->extended_value EXECUTE_DATA_CC);
@@ -49597,6 +49623,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_CV_UNUSED_HANDL
 			varname = ZVAL_UNDEFINED_OP1();
 		}
 		name = zval_get_tmp_string(varname, &tmp_name);
+		if (UNEXPECTED(EG(exception))) {
+
+			HANDLE_EXCEPTION();
+		}
 	}
 
 	target_symbol_table = zend_get_target_symbol_table(opline->extended_value EXECUTE_DATA_CC);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -8698,6 +8698,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_var_address_helper_SPEC_
 		name = zval_get_tmp_string(varname, &tmp_name);
 		if (UNEXPECTED(EG(exception))) {
 
+			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -16231,6 +16232,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_TMPVAR_UNUSED_H
 		name = zval_get_tmp_string(varname, &tmp_name);
 		if (UNEXPECTED(EG(exception))) {
 			zval_ptr_dtor_nogc(free_op1);
+			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -49625,6 +49627,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_UNSET_VAR_SPEC_CV_UNUSED_HANDL
 		name = zval_get_tmp_string(varname, &tmp_name);
 		if (UNEXPECTED(EG(exception))) {
 
+			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2043,6 +2043,9 @@ static int date_interval_has_property(zval *object, zval *member, int type, void
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
 		cache_slot = NULL;
+		if (EG(exception)) {
+			return 0;
+		}
 	}
 
 	obj = Z_PHPINTERVAL_P(object);
@@ -4167,6 +4170,9 @@ static zval *date_interval_read_property(zval *object, zval *member, int type, v
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
 		cache_slot = NULL;
+		if (EG(exception)) {
+			return &EG(uninitialized_zval);
+		}
 	}
 
 	obj = Z_PHPINTERVAL_P(object);
@@ -4235,6 +4241,9 @@ static zval *date_interval_write_property(zval *object, zval *member, zval *valu
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
 		cache_slot = NULL;
+		if (EG(exception)) {
+			return value;
+		}
 	}
 
 	obj = Z_PHPINTERVAL_P(object);
@@ -4286,6 +4295,9 @@ static zval *date_interval_get_property_ptr_ptr(zval *object, zval *member, int 
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
 		cache_slot = NULL;
+		if (EG(exception)) {
+			return NULL;
+		}
 	}
 
 	if(zend_binary_strcmp("y", sizeof("y") - 1, Z_STRVAL_P(member), Z_STRLEN_P(member)) == 0 ||

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -674,7 +674,7 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 
 	/* Exception during string conversion */
 	if (EG(exception)) {
-		efree(args);
+		FREENOW;
 		return;
 	}
 

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -672,6 +672,12 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 		keylen += Z_STRLEN(args[i]);
 	}
 
+	/* Exception during string conversion */
+	if (EG(exception)) {
+		efree(args);
+		return;
+	}
+
 	if (persistent) {
 		zend_resource *le;
 

--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -160,13 +160,13 @@ int dom_attr_value_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
-	if (attrp->children) {
-		node_list_unlink(attrp->children);
-	}
-
 	str = zval_get_string(newval);
 	if (EG(exception)) {
 		return FAILURE;
+	}
+
+	if (attrp->children) {
+		node_list_unlink(attrp->children);
 	}
 
 	xmlNodeSetContentLen((xmlNodePtr) attrp, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);

--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -165,6 +165,9 @@ int dom_attr_value_write(dom_object *obj, zval *newval)
 	}
 
 	str = zval_get_string(newval);
+	if (EG(exception)) {
+		return FAILURE;
+	}
 
 	xmlNodeSetContentLen((xmlNodePtr) attrp, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);
 

--- a/ext/dom/characterdata.c
+++ b/ext/dom/characterdata.c
@@ -105,6 +105,9 @@ int dom_characterdata_data_write(dom_object *obj, zval *newval)
 	}
 
 	str = zval_get_string(newval);
+	if (EG(exception)) {
+		return FAILURE;
+	}
 
 	xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);
 

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -338,6 +338,9 @@ int dom_document_encoding_write(dom_object *obj, zval *newval)
 	}
 
 	str = zval_get_string(newval);
+	if (EG(exception)) {
+		return FAILURE;
+	}
 
 	handler = xmlFindCharEncodingHandler(Z_STRVAL_P(newval));
 
@@ -431,11 +434,14 @@ int dom_document_version_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	str = zval_get_string(newval);
+	if (EG(exception)) {
+		return FAILURE;
+	}
+
 	if (docp->version != NULL) {
 		xmlFree((xmlChar *) docp->version );
 	}
-
-	str = zval_get_string(newval);
 
 	docp->version = xmlStrdup((const xmlChar *) ZSTR_VAL(str));
 
@@ -659,11 +665,14 @@ int dom_document_document_uri_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	str = zval_get_string(newval);
+	if (EG(exception)) {
+		return FAILURE;
+	}
+
 	if (docp->URL != NULL) {
 		xmlFree((xmlChar *) docp->URL);
 	}
-
-	str = zval_get_string(newval);
 
 	docp->URL = xmlStrdup((const xmlChar *) ZSTR_VAL(str));
 

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -323,9 +323,15 @@ int dom_node_node_value_read(dom_object *obj, zval *retval)
 int dom_node_node_value_write(dom_object *obj, zval *newval)
 {
 	xmlNode *nodep = dom_object_get_node(obj);
+	zend_string *str;
 
 	if (nodep == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 0);
+		return FAILURE;
+	}
+
+	str = zval_get_string(newval);
+	if (EG(exception)) {
 		return FAILURE;
 	}
 
@@ -342,16 +348,13 @@ int dom_node_node_value_write(dom_object *obj, zval *newval)
 		case XML_COMMENT_NODE:
 		case XML_CDATA_SECTION_NODE:
 		case XML_PI_NODE:
-			{
-				zend_string *str = zval_get_string(newval);
-				xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);
-				zend_string_release_ex(str, 0);
-				break;
-			}
+			xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);
+			break;
 		default:
 			break;
 	}
 
+	zend_string_release_ex(str, 0);
 	return SUCCESS;
 }
 
@@ -722,6 +725,10 @@ int dom_node_prefix_write(dom_object *obj, zval *newval)
 				}
 			}
 			str = zval_get_string(newval);
+			if (EG(exception)) {
+				return FAILURE;
+			}
+
 			prefix = ZSTR_VAL(str);
 			if (nsnode && nodep->ns != NULL && !xmlStrEqual(nodep->ns->prefix, (xmlChar *)prefix)) {
 				strURI = (char *) nodep->ns->href;
@@ -854,6 +861,11 @@ int dom_node_text_content_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
+	str = zval_get_string(newval);
+	if (EG(exception)) {
+		return FAILURE;
+	}
+
 	if (nodep->type == XML_ELEMENT_NODE || nodep->type == XML_ATTRIBUTE_NODE) {
 		if (nodep->children) {
 			node_list_unlink(nodep->children);
@@ -862,7 +874,6 @@ int dom_node_text_content_write(dom_object *obj, zval *newval)
 		}
 	}
 
-	str = zval_get_string(newval);
 	/* we have to use xmlNodeAddContent() to get the same behavior as with xmlNewText() */
 	xmlNodeSetContent(nodep, (xmlChar *) "");
 	xmlNodeAddContent(nodep, (xmlChar *) ZSTR_VAL(str));

--- a/ext/dom/processinginstruction.c
+++ b/ext/dom/processinginstruction.c
@@ -139,6 +139,9 @@ int dom_processinginstruction_data_write(dom_object *obj, zval *newval)
 	}
 
 	str = zval_get_string(newval);
+	if (EG(exception)) {
+		return FAILURE;
+	}
 
 	xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);
 

--- a/ext/dom/tests/toString_exceptions.phpt
+++ b/ext/dom/tests/toString_exceptions.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Handling of exceptions during __toString
+--FILE--
+<?php
+
+class BadStr {
+    public function __toString() {
+        throw new Exception("Exception");
+    }
+}
+
+$badStr = new BadStr;
+
+$doc = new DOMDocument();
+$doc->loadXML(
+    '<root xmlns:ns="foo"><node attr="foo" /><node>Text</node><ns:node/><?pi foobar?></root>');
+
+try { $doc->encoding = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+try { $doc->version = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+try { $doc->documentURI = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+$root = $doc->childNodes[0];
+
+$node = $root->childNodes[0];
+$attrs = $node->attributes;
+$attr = $attrs[0];
+try { $attr->value = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+try { $attr->nodeValue = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+
+$node2 = $root->childNodes[1];
+try { $node2->nodeValue = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+try { $node2->textContent = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+$data = $node2->childNodes[0];
+try { $data->data = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+
+$node3 = $root->childNodes[2];
+try { $node3->prefix = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+
+$pi = $root->childNodes[3];
+try { $pi->data = $badStr; } catch (Exception $e) { echo "Exception\n"; }
+
+echo $doc->saveXML();
+
+?>
+--EXPECT--
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+Exception
+<?xml version="1.0"?>
+<root xmlns:ns="foo"><node attr="foo"/><node>Text</node><ns:node/><?pi foobar?></root>

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -4419,8 +4419,7 @@ PHP_FUNCTION(exif_read_data)
 
 		ret = exif_read_from_stream(&ImageInfo, p_stream, read_thumbnail, read_all);
 	} else {
-		convert_to_string(stream);
-		if (EG(exception)) {
+		if (!try_convert_to_string(stream)) {
 			return;
 		}
 
@@ -4592,8 +4591,7 @@ PHP_FUNCTION(exif_thumbnail)
 
 		ret = exif_read_from_stream(&ImageInfo, p_stream, 1, 0);
 	} else {
-		convert_to_string(stream);
-		if (EG(exception)) {
+		if (!try_convert_to_string(stream)) {
 			return;
 		}
 

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -4420,6 +4420,9 @@ PHP_FUNCTION(exif_read_data)
 		ret = exif_read_from_stream(&ImageInfo, p_stream, read_thumbnail, read_all);
 	} else {
 		convert_to_string(stream);
+		if (EG(exception)) {
+			return;
+		}
 
 		if (!Z_STRLEN_P(stream)) {
 			exif_error_docref(NULL EXIFERR_CC, &ImageInfo, E_WARNING, "Filename cannot be empty");
@@ -4590,6 +4593,9 @@ PHP_FUNCTION(exif_thumbnail)
 		ret = exif_read_from_stream(&ImageInfo, p_stream, 1, 0);
 	} else {
 		convert_to_string(stream);
+		if (EG(exception)) {
+			return;
+		}
 
 		if (!Z_STRLEN_P(stream)) {
 			exif_error_docref(NULL EXIFERR_CC, &ImageInfo, E_WARNING, "Filename cannot be empty");

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -2299,6 +2299,10 @@ PHP_FUNCTION(imagecreatefromstring)
 	}
 
 	convert_to_string_ex(data);
+	if (EG(exception)) {
+		return;
+	}
+
 	if (Z_STRLEN_P(data) < sizeof(sig)) {
 		php_error_docref(NULL, E_WARNING, "Empty string or invalid image");
 		RETURN_FALSE;

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -2298,8 +2298,7 @@ PHP_FUNCTION(imagecreatefromstring)
 		return;
 	}
 
-	convert_to_string_ex(data);
-	if (EG(exception)) {
+	if (!try_convert_to_string(data)) {
 		return;
 	}
 

--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -2243,7 +2243,7 @@ PHP_FUNCTION(iconv_mime_encode)
 	if (pref != NULL) {
 		zval *pzval;
 
-		if ((pzval = zend_hash_str_find(Z_ARRVAL_P(pref), "scheme", sizeof("scheme") - 1)) != NULL) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "scheme", sizeof("scheme") - 1)) != NULL) {
 			if (Z_TYPE_P(pzval) == IS_STRING && Z_STRLEN_P(pzval) > 0) {
 				switch (Z_STRVAL_P(pzval)[0]) {
 					case 'B': case 'b':
@@ -2257,7 +2257,7 @@ PHP_FUNCTION(iconv_mime_encode)
 			}
 		}
 
-		if ((pzval = zend_hash_str_find(Z_ARRVAL_P(pref), "input-charset", sizeof("input-charset") - 1)) != NULL && Z_TYPE_P(pzval) == IS_STRING) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "input-charset", sizeof("input-charset") - 1)) != NULL && Z_TYPE_P(pzval) == IS_STRING) {
 			if (Z_STRLEN_P(pzval) >= ICONV_CSNMAXLEN) {
 				php_error_docref(NULL, E_WARNING, "Charset parameter exceeds the maximum allowed length of %d characters", ICONV_CSNMAXLEN);
 				RETURN_FALSE;
@@ -2269,7 +2269,7 @@ PHP_FUNCTION(iconv_mime_encode)
 		}
 
 
-		if ((pzval = zend_hash_str_find(Z_ARRVAL_P(pref), "output-charset", sizeof("output-charset") - 1)) != NULL && Z_TYPE_P(pzval) == IS_STRING) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "output-charset", sizeof("output-charset") - 1)) != NULL && Z_TYPE_P(pzval) == IS_STRING) {
 			if (Z_STRLEN_P(pzval) >= ICONV_CSNMAXLEN) {
 				php_error_docref(NULL, E_WARNING, "Charset parameter exceeds the maximum allowed length of %d characters", ICONV_CSNMAXLEN);
 				RETURN_FALSE;
@@ -2280,13 +2280,16 @@ PHP_FUNCTION(iconv_mime_encode)
 			}
 		}
 
-		if ((pzval = zend_hash_str_find(Z_ARRVAL_P(pref), "line-length", sizeof("line-length") - 1)) != NULL) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "line-length", sizeof("line-length") - 1)) != NULL) {
 			line_len = zval_get_long(pzval);
 		}
 
-		if ((pzval = zend_hash_str_find(Z_ARRVAL_P(pref), "line-break-chars", sizeof("line-break-chars") - 1)) != NULL) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "line-break-chars", sizeof("line-break-chars") - 1)) != NULL) {
 			if (Z_TYPE_P(pzval) != IS_STRING) {
 				tmp_str = zval_get_string_func(pzval);
+				if (EG(exception)) {
+					return;
+				}
 				lfchars = ZSTR_VAL(tmp_str);
 			} else {
 				lfchars = Z_STRVAL_P(pzval);

--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -2061,6 +2061,9 @@ PHP_FUNCTION(imap_delete)
 	}
 
 	convert_to_string_ex(sequence);
+	if (EG(exception)) {
+		return;
+	}
 
 	mail_setflag_full(imap_le_struct->imap_stream, Z_STRVAL_P(sequence), "\\DELETED", (argc == 3 ? flags : NIL));
 	RETVAL_TRUE;
@@ -2085,6 +2088,9 @@ PHP_FUNCTION(imap_undelete)
 	}
 
 	convert_to_string_ex(sequence);
+	if (EG(exception)) {
+		return;
+	}
 
 	mail_clearflag_full(imap_le_struct->imap_stream, Z_STRVAL_P(sequence), "\\DELETED", (argc == 3 ? flags : NIL));
 	RETVAL_TRUE;
@@ -2504,6 +2510,9 @@ PHP_FUNCTION(imap_savebody)
 
 		default:
 			convert_to_string_ex(out);
+			if (EG(exception)) {
+				return;
+			}
 			writer = php_stream_open_wrapper(Z_STRVAL_P(out), "wb", REPORT_ERRORS, NULL);
 		break;
 	}

--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -2060,8 +2060,7 @@ PHP_FUNCTION(imap_delete)
 		RETURN_FALSE;
 	}
 
-	convert_to_string_ex(sequence);
-	if (EG(exception)) {
+	if (!try_convert_to_string(sequence)) {
 		return;
 	}
 
@@ -2087,8 +2086,7 @@ PHP_FUNCTION(imap_undelete)
 		RETURN_FALSE;
 	}
 
-	convert_to_string_ex(sequence);
-	if (EG(exception)) {
+	if (!try_convert_to_string(sequence)) {
 		return;
 	}
 
@@ -2509,8 +2507,7 @@ PHP_FUNCTION(imap_savebody)
 		break;
 
 		default:
-			convert_to_string_ex(out);
-			if (EG(exception)) {
+			if (!try_convert_to_string(out)) {
 				return;
 			}
 			writer = php_stream_open_wrapper(Z_STRVAL_P(out), "wb", REPORT_ERRORS, NULL);

--- a/ext/intl/dateformat/dateformat_format_object.cpp
+++ b/ext/intl/dateformat/dateformat_format_object.cpp
@@ -142,8 +142,7 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 		}
 		dateStyle = timeStyle = (DateFormat::EStyle)Z_LVAL_P(format);
 	} else {
-		convert_to_string_ex(format);
-		if (EG(exception)) {
+		if (!try_convert_to_string(format)) {
 			return;
 		}
 		if (Z_STRLEN_P(format) == 0) {

--- a/ext/intl/dateformat/dateformat_format_object.cpp
+++ b/ext/intl/dateformat/dateformat_format_object.cpp
@@ -143,6 +143,9 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 		dateStyle = timeStyle = (DateFormat::EStyle)Z_LVAL_P(format);
 	} else {
 		convert_to_string_ex(format);
+		if (EG(exception)) {
+			return;
+		}
 		if (Z_STRLEN_P(format) == 0) {
 			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
 					"datefmt_format_object: the format is empty", 0);

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -179,8 +179,7 @@ U_CFUNC TimeZone *timezone_process_timezone_argument(zval *zv_timezone,
 		UnicodeString	id,
 						gottenId;
 		UErrorCode		status = U_ZERO_ERROR; /* outside_error may be NULL */
-		convert_to_string_ex(zv_timezone);
-		if (EG(exception)) {
+		if (!try_convert_to_string(zv_timezone)) {
 			zval_ptr_dtor_str(&local_zv_tz);
 			return NULL;
 		}

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -180,6 +180,10 @@ U_CFUNC TimeZone *timezone_process_timezone_argument(zval *zv_timezone,
 						gottenId;
 		UErrorCode		status = U_ZERO_ERROR; /* outside_error may be NULL */
 		convert_to_string_ex(zv_timezone);
+		if (EG(exception)) {
+			zval_ptr_dtor_str(&local_zv_tz);
+			return NULL;
+		}
 		if (intl_stringFromChar(id, Z_STRVAL_P(zv_timezone), Z_STRLEN_P(zv_timezone),
 				&status) == FAILURE) {
 			spprintf(&message, 0, "%s: Time zone identifier given is not a "

--- a/ext/intl/timezone/timezone_methods.cpp
+++ b/ext/intl/timezone/timezone_methods.cpp
@@ -177,8 +177,7 @@ double_offset:
 	} else if (Z_TYPE_P(arg) == IS_OBJECT || Z_TYPE_P(arg) == IS_STRING) {
 		zend_long lval;
 		double dval;
-		convert_to_string_ex(arg);
-		if (EG(exception)) {
+		if (!try_convert_to_string(arg)) {
 			return;
 		}
 		switch (is_numeric_string(Z_STRVAL_P(arg), Z_STRLEN_P(arg), &lval, &dval, 0)) {

--- a/ext/intl/timezone/timezone_methods.cpp
+++ b/ext/intl/timezone/timezone_methods.cpp
@@ -178,6 +178,9 @@ double_offset:
 		zend_long lval;
 		double dval;
 		convert_to_string_ex(arg);
+		if (EG(exception)) {
+			return;
+		}
 		switch (is_numeric_string(Z_STRVAL_P(arg), Z_STRLEN_P(arg), &lval, &dval, 0)) {
 		case IS_DOUBLE:
 			zval_ptr_dtor(arg);

--- a/ext/intl/transliterator/transliterator_class.c
+++ b/ext/intl/transliterator/transliterator_class.c
@@ -189,7 +189,7 @@ err:
 }
 /* }}} */
 
-#define TRANSLITERATOR_PROPERTY_HANDLER_PROLOG  \
+#define TRANSLITERATOR_PROPERTY_HANDLER_PROLOG(return_fail) \
 	zval tmp_member;							\
 	if( Z_TYPE_P( member ) != IS_STRING )		\
 	{											\
@@ -197,6 +197,7 @@ err:
 			zval_get_string_func(member));		\
 		member = &tmp_member;					\
 		cache_slot = NULL;						\
+		if (EG(exception)) { return_fail; }		\
     }
 
 #define TRANSLITERATOR_PROPERTY_HANDLER_EPILOG	\
@@ -210,7 +211,7 @@ static zval *Transliterator_get_property_ptr_ptr( zval *object, zval *member, in
 {
 	zval *retval;
 
-	TRANSLITERATOR_PROPERTY_HANDLER_PROLOG;
+	TRANSLITERATOR_PROPERTY_HANDLER_PROLOG(return NULL);
 
 	if(zend_binary_strcmp( "id", sizeof( "id" ) - 1,
 		Z_STRVAL_P( member ), Z_STRLEN_P( member ) ) == 0 )
@@ -233,7 +234,7 @@ static zval *Transliterator_read_property( zval *object, zval *member, int type,
 {
 	zval *retval;
 
-	TRANSLITERATOR_PROPERTY_HANDLER_PROLOG;
+	TRANSLITERATOR_PROPERTY_HANDLER_PROLOG(return &EG(uninitialized_zval));
 
 	if( ( type != BP_VAR_R && type != BP_VAR_IS ) &&
 		( zend_binary_strcmp( "id", sizeof( "id" ) - 1,
@@ -258,7 +259,7 @@ static zval *Transliterator_read_property( zval *object, zval *member, int type,
 static zval *Transliterator_write_property( zval *object, zval *member, zval *value, void **cache_slot )
 {
 	zend_class_entry *scope;
-	TRANSLITERATOR_PROPERTY_HANDLER_PROLOG;
+	TRANSLITERATOR_PROPERTY_HANDLER_PROLOG(return value);
 
 	if (EG(fake_scope)) {
 		scope = EG(fake_scope);

--- a/ext/intl/transliterator/transliterator_methods.c
+++ b/ext/intl/transliterator/transliterator_methods.c
@@ -333,6 +333,9 @@ PHP_FUNCTION( transliterator_transliterate )
 			if(Z_TYPE_P( arg1 ) != IS_STRING )
 			{
 				convert_to_string( arg1 );
+				if (EG(exception)) {
+					return;
+				}
 			}
 			object = &tmp_object;
 			res = create_transliterator( Z_STRVAL_P( arg1 ), Z_STRLEN_P( arg1 ),

--- a/ext/intl/transliterator/transliterator_methods.c
+++ b/ext/intl/transliterator/transliterator_methods.c
@@ -330,12 +330,8 @@ PHP_FUNCTION( transliterator_transliterate )
 		else
 		{ /* not a transliterator object as first argument */
 			int res;
-			if(Z_TYPE_P( arg1 ) != IS_STRING )
-			{
-				convert_to_string( arg1 );
-				if (EG(exception)) {
-					return;
-				}
+			if( !try_convert_to_string( arg1 ) ) {
+				return;
 			}
 			object = &tmp_object;
 			res = create_transliterator( Z_STRVAL_P( arg1 ), Z_STRLEN_P( arg1 ),

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -662,8 +662,7 @@ is_string:
 			}
 		} else if (Z_TYPE(retval) != IS_NULL) {
 			/* retval not string nor resource nor null; convert to string */
-			convert_to_string(&retval);
-			if (!EG(exception)) {
+			if (try_convert_to_string(&retval)) {
 				goto is_string;
 			}
 		} /* else is null; don't try anything */

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -663,7 +663,9 @@ is_string:
 		} else if (Z_TYPE(retval) != IS_NULL) {
 			/* retval not string nor resource nor null; convert to string */
 			convert_to_string(&retval);
-			goto is_string;
+			if (!EG(exception)) {
+				goto is_string;
+			}
 		} /* else is null; don't try anything */
 	}
 

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2006,8 +2006,7 @@ PHP_FUNCTION(mb_detect_order)
 				}
 				break;
 			default:
-				convert_to_string_ex(arg1);
-				if (EG(exception)) {
+				if (!try_convert_to_string(arg1)) {
 					return;
 				}
 				if (FAILURE == php_mb_parse_encoding_list(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1), &list, &size, 0)) {
@@ -3337,8 +3336,7 @@ PHP_FUNCTION(mb_convert_encoding)
 	}
 
 	if (Z_TYPE_P(input) != IS_STRING && Z_TYPE_P(input) != IS_ARRAY) {
-		convert_to_string(input);
-		if (EG(exception)) {
+		if (!try_convert_to_string(input)) {
 			return;
 		}
 	}
@@ -3377,8 +3375,7 @@ PHP_FUNCTION(mb_convert_encoding)
 				s_free = _from_encodings;
 				break;
 			default:
-				convert_to_string(arg_old);
-				if (EG(exception)) {
+				if (!try_convert_to_string(arg_old)) {
 					return;
 				}
 
@@ -3557,8 +3554,7 @@ PHP_FUNCTION(mb_detect_encoding)
 			}
 			break;
 		default:
-			convert_to_string(encoding_list);
-			if (EG(exception)) {
+			if (!try_convert_to_string(encoding_list)) {
 				return;
 			}
 			if (FAILURE == php_mb_parse_encoding_list(Z_STRVAL_P(encoding_list), Z_STRLEN_P(encoding_list), &list, &size, 0)) {
@@ -3969,8 +3965,7 @@ PHP_FUNCTION(mb_convert_variables)
 			php_mb_parse_encoding_array(zfrom_enc, &elist, &elistsz, 0);
 			break;
 		default:
-			convert_to_string_ex(zfrom_enc);
-			if (EG(exception)) {
+			if (!try_convert_to_string(zfrom_enc)) {
 				return;
 			}
 			php_mb_parse_encoding_list(Z_STRVAL_P(zfrom_enc), Z_STRLEN_P(zfrom_enc), &elist, &elistsz, 0);

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -924,8 +924,7 @@ static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 		if (Z_TYPE_P(arg_pattern) == IS_DOUBLE) {
 			convert_to_long_ex(arg_pattern);	/* get rid of decimal places */
 		}
-		convert_to_string_ex(arg_pattern);
-		if (EG(exception)) {
+		if (!try_convert_to_string(arg_pattern)) {
 			return;
 		}
 		/* don't bother doing an extended regex with just a number */

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -925,6 +925,9 @@ static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 			convert_to_long_ex(arg_pattern);	/* get rid of decimal places */
 		}
 		convert_to_string_ex(arg_pattern);
+		if (EG(exception)) {
+			return;
+		}
 		/* don't bother doing an extended regex with just a number */
 	}
 

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -309,6 +309,9 @@ zval *mysqli_read_property(zval *object, zval *member, int type, void **cache_sl
 	if (Z_TYPE_P(member) != IS_STRING) {
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
+		if (EG(exception)) {
+			return &EG(uninitialized_zval);
+		}
 	}
 
 	if (obj->prop_handler != NULL) {
@@ -342,6 +345,9 @@ zval *mysqli_write_property(zval *object, zval *member, zval *value, void **cach
 	if (Z_TYPE_P(member) != IS_STRING) {
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
+		if (EG(exception)) {
+			return value;
+		}
 	}
 
 	obj = Z_MYSQLI_P(object);

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -900,6 +900,10 @@ PHP_FUNCTION(mysqli_stmt_execute)
 				switch (stmt->stmt->params[i].buffer_type) {
 					case MYSQL_TYPE_VAR_STRING:
 						convert_to_string_ex(param);
+						if (EG(exception)) {
+							return;
+						}
+
 						stmt->stmt->params[i].buffer = Z_STRVAL_P(param);
 						stmt->stmt->params[i].buffer_length = Z_STRLEN_P(param);
 						break;
@@ -1782,6 +1786,9 @@ PHP_FUNCTION(mysqli_options)
 		switch (expected_type) {
 			case IS_STRING:
 				convert_to_string_ex(mysql_value);
+				if (EG(exception)) {
+					return;
+				}
 				break;
 			case IS_LONG:
 				convert_to_long_ex(mysql_value);

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -899,8 +899,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 			if (!(stmt->param.is_null[i] = (Z_ISNULL_P(param)))) {
 				switch (stmt->stmt->params[i].buffer_type) {
 					case MYSQL_TYPE_VAR_STRING:
-						convert_to_string_ex(param);
-						if (EG(exception)) {
+						if (!try_convert_to_string(param)) {
 							return;
 						}
 
@@ -1785,8 +1784,7 @@ PHP_FUNCTION(mysqli_options)
 	if (expected_type != Z_TYPE_P(mysql_value)) {
 		switch (expected_type) {
 			case IS_STRING:
-				convert_to_string_ex(mysql_value);
-				if (EG(exception)) {
+				if (!try_convert_to_string(mysql_value)) {
 					return;
 				}
 				break;

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -778,8 +778,7 @@ use_string:
 					the_var = &((*copies_param)[i]);
 				}
 
-				convert_to_string_ex(the_var);
-				if (EG(exception)) {
+				if (!try_convert_to_string(the_var)) {
 					goto end;
 				}
 				*data_size += Z_STRLEN_P(the_var);

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -777,7 +777,11 @@ use_string:
 					}
 					the_var = &((*copies_param)[i]);
 				}
+
 				convert_to_string_ex(the_var);
+				if (EG(exception)) {
+					goto end;
+				}
 				*data_size += Z_STRLEN_P(the_var);
 				break;
 		}

--- a/ext/oci8/oci8_statement.c
+++ b/ext/oci8/oci8_statement.c
@@ -1772,7 +1772,14 @@ php_oci_bind *php_oci_bind_array_helper_string(zval *var, zend_long max_table_le
 
 	for (i = 0; i < bind->array.current_length; i++) {
 		if ((entry = zend_hash_get_current_data(hash)) != NULL) {
-			ZEND_ASSERT(Z_TYPE_P(entry) == IS_STRING);
+			if (!try_convert_to_string(entry)) {
+				efree(bind->array.elements);
+				efree(bind->array.element_lengths);
+				efree(bind->array.indicators);
+				efree(bind);
+				return NULL;
+			}
+
 			bind->array.element_lengths[i] = (ub2) Z_STRLEN_P(entry);
 			if (Z_STRLEN_P(entry) == 0) {
 				bind->array.indicators[i] = -1;
@@ -1787,8 +1794,14 @@ php_oci_bind *php_oci_bind_array_helper_string(zval *var, zend_long max_table_le
 	for (i = 0; i < max_table_length; i++) {
 		if ((i < bind->array.current_length) && (entry = zend_hash_get_current_data(hash)) != NULL) {
 			int element_length;
+			if (!try_convert_to_string(entry)) {
+				efree(bind->array.elements);
+				efree(bind->array.element_lengths);
+				efree(bind->array.indicators);
+				efree(bind);
+				return NULL;
+			}
 
-			ZEND_ASSERT(Z_TYPE_P(entry) == IS_STRING);
 			element_length = ((size_t) maxlength > Z_STRLEN_P(entry)) ? (int) Z_STRLEN_P(entry) : (int) maxlength;
 
 			memcpy((text *)bind->array.elements + i*maxlength, Z_STRVAL_P(entry), element_length);

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1343,8 +1343,7 @@ PHP_FUNCTION(odbc_execute)
 			}
 
 			otype = Z_TYPE_P(tmp);
-			convert_to_string_ex(tmp);
-			if (EG(exception)) {
+			if (!try_convert_to_string(tmp)) {
 				SQLFreeStmt(result->stmt, SQL_RESET_PARAMS);
 				for (i = 0; i < result->numparams; i++) {
 					if (params[i].fp != -1) {

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1344,8 +1344,7 @@ PHP_FUNCTION(odbc_execute)
 
 			otype = Z_TYPE_P(tmp);
 			convert_to_string_ex(tmp);
-			if (Z_TYPE_P(tmp) != IS_STRING) {
-				php_error_docref(NULL, E_WARNING,"Error converting parameter");
+			if (EG(exception)) {
 				SQLFreeStmt(result->stmt, SQL_RESET_PARAMS);
 				for (i = 0; i < result->numparams; i++) {
 					if (params[i].fp != -1) {

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1725,8 +1725,7 @@ static X509 * php_openssl_x509_from_zval(zval * val, int makeresource, zend_reso
 	}
 
 	/* force it to be a string and check if it refers to a file */
-	convert_to_string_ex(val);
-	if (EG(exception)) {
+	if (!try_convert_to_string(val)) {
 		return NULL;
 	}
 
@@ -3817,8 +3816,7 @@ static EVP_PKEY * php_openssl_evp_from_zval(
 			passphrase_len = Z_STRLEN_P(zphrase);
 		} else {
 			ZVAL_COPY(&tmp, zphrase);
-			convert_to_string(&tmp);
-			if (EG(exception)) {
+			if (!try_convert_to_string(&tmp)) {
 				return NULL;
 			}
 
@@ -3882,8 +3880,7 @@ static EVP_PKEY * php_openssl_evp_from_zval(
 		if (!(Z_TYPE_P(val) == IS_STRING || Z_TYPE_P(val) == IS_OBJECT)) {
 			TMP_CLEAN;
 		}
-		convert_to_string_ex(val);
-		if (EG(exception)) {
+		if (!try_convert_to_string(val)) {
 			TMP_CLEAN;
 		}
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1726,6 +1726,9 @@ static X509 * php_openssl_x509_from_zval(zval * val, int makeresource, zend_reso
 
 	/* force it to be a string and check if it refers to a file */
 	convert_to_string_ex(val);
+	if (EG(exception)) {
+		return NULL;
+	}
 
 	if (Z_STRLEN_P(val) > 7 && memcmp(Z_STRVAL_P(val), "file://", sizeof("file://") - 1) == 0) {
 
@@ -2671,32 +2674,37 @@ static X509_STORE *php_openssl_setup_verify(zval *calist)
 
 	if (calist && (Z_TYPE_P(calist) == IS_ARRAY)) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(calist), item) {
-			convert_to_string_ex(item);
+			zend_string *str = zval_get_string(item);
+			if (EG(exception)) {
+				return NULL;
+			}
 
-			if (VCWD_STAT(Z_STRVAL_P(item), &sb) == -1) {
-				php_error_docref(NULL, E_WARNING, "unable to stat %s", Z_STRVAL_P(item));
+			if (VCWD_STAT(ZSTR_VAL(str), &sb) == -1) {
+				php_error_docref(NULL, E_WARNING, "unable to stat %s", ZSTR_VAL(str));
+				zend_string_release(str);
 				continue;
 			}
 
 			if ((sb.st_mode & S_IFREG) == S_IFREG) {
 				file_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file());
-				if (file_lookup == NULL || !X509_LOOKUP_load_file(file_lookup, Z_STRVAL_P(item), X509_FILETYPE_PEM)) {
+				if (file_lookup == NULL || !X509_LOOKUP_load_file(file_lookup, ZSTR_VAL(str), X509_FILETYPE_PEM)) {
 					php_openssl_store_errors();
-					php_error_docref(NULL, E_WARNING, "error loading file %s", Z_STRVAL_P(item));
+					php_error_docref(NULL, E_WARNING, "error loading file %s", ZSTR_VAL(str));
 				} else {
 					nfiles++;
 				}
 				file_lookup = NULL;
 			} else {
 				dir_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_hash_dir());
-				if (dir_lookup == NULL || !X509_LOOKUP_add_dir(dir_lookup, Z_STRVAL_P(item), X509_FILETYPE_PEM)) {
+				if (dir_lookup == NULL || !X509_LOOKUP_add_dir(dir_lookup, ZSTR_VAL(str), X509_FILETYPE_PEM)) {
 					php_openssl_store_errors();
-					php_error_docref(NULL, E_WARNING, "error loading directory %s", Z_STRVAL_P(item));
+					php_error_docref(NULL, E_WARNING, "error loading directory %s", ZSTR_VAL(str));
 				} else {
 					ndirs++;
 				}
 				dir_lookup = NULL;
 			}
+			zend_string_release(str);
 		} ZEND_HASH_FOREACH_END();
 	}
 	if (nfiles == 0) {
@@ -3145,23 +3153,25 @@ static int php_openssl_make_REQ(struct php_x509_request * req, X509_REQ * csr, z
 		/* apply values from the dn hash */
 		ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(dn), strindex, item) {
 			if (strindex) {
-				int nid;
-
-				convert_to_string_ex(item);
-
-				nid = OBJ_txt2nid(ZSTR_VAL(strindex));
+				int nid = OBJ_txt2nid(ZSTR_VAL(strindex));
 				if (nid != NID_undef) {
+					zend_string *str_item = zval_get_string(item);
+					if (EG(exception)) {
+						return FAILURE;
+					}
 					if (!X509_NAME_add_entry_by_NID(subj, nid, MBSTRING_UTF8,
-								(unsigned char*)Z_STRVAL_P(item), -1, -1, 0))
+								(unsigned char*)ZSTR_VAL(str_item), -1, -1, 0))
 					{
 						php_openssl_store_errors();
 						php_error_docref(NULL, E_WARNING,
 							"dn: add_entry_by_NID %d -> %s (failed; check error"
 							" queue and value of string_mask OpenSSL option "
 							"if illegal characters are reported)",
-							nid, Z_STRVAL_P(item));
+							nid, ZSTR_VAL(str_item));
+						zend_string_release(str_item);
 						return FAILURE;
 					}
+					zend_string_release(str_item);
 				} else {
 					php_error_docref(NULL, E_WARNING, "dn: %s is not a recognized name", ZSTR_VAL(strindex));
 				}
@@ -3226,15 +3236,19 @@ static int php_openssl_make_REQ(struct php_x509_request * req, X509_REQ * csr, z
 					continue;
 				}
 
-				convert_to_string_ex(item);
-
 				nid = OBJ_txt2nid(ZSTR_VAL(strindex));
 				if (nid != NID_undef) {
-					if (!X509_NAME_add_entry_by_NID(subj, nid, MBSTRING_UTF8, (unsigned char*)Z_STRVAL_P(item), -1, -1, 0)) {
-						php_openssl_store_errors();
-						php_error_docref(NULL, E_WARNING, "attribs: add_entry_by_NID %d -> %s (failed)", nid, Z_STRVAL_P(item));
+					zend_string *str_item = zval_get_string(item);
+					if (EG(exception)) {
 						return FAILURE;
 					}
+					if (!X509_NAME_add_entry_by_NID(subj, nid, MBSTRING_UTF8, (unsigned char*)ZSTR_VAL(str_item), -1, -1, 0)) {
+						php_openssl_store_errors();
+						php_error_docref(NULL, E_WARNING, "attribs: add_entry_by_NID %d -> %s (failed)", nid, ZSTR_VAL(str_item));
+						zend_string_release(str_item);
+						return FAILURE;
+					}
+					zend_string_release(str_item);
 				} else {
 					php_error_docref(NULL, E_WARNING, "dn: %s is not a recognized name", ZSTR_VAL(strindex));
 				}
@@ -3804,6 +3818,10 @@ static EVP_PKEY * php_openssl_evp_from_zval(
 		} else {
 			ZVAL_COPY(&tmp, zphrase);
 			convert_to_string(&tmp);
+			if (EG(exception)) {
+				return NULL;
+			}
+
 			passphrase = Z_STRVAL(tmp);
 			passphrase_len = Z_STRLEN(tmp);
 		}
@@ -3865,6 +3883,9 @@ static EVP_PKEY * php_openssl_evp_from_zval(
 			TMP_CLEAN;
 		}
 		convert_to_string_ex(val);
+		if (EG(exception)) {
+			TMP_CLEAN;
+		}
 
 		if (Z_STRLEN_P(val) > 7 && memcmp(Z_STRVAL_P(val), "file://", sizeof("file://") - 1) == 0) {
 			filename = Z_STRVAL_P(val) + (sizeof("file://") - 1);
@@ -5351,13 +5372,16 @@ PHP_FUNCTION(openssl_pkcs7_encrypt)
 	/* tack on extra headers */
 	if (zheaders) {
 		ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(zheaders), strindex, zcertval) {
-			convert_to_string_ex(zcertval);
-
-			if (strindex) {
-				BIO_printf(outfile, "%s: %s\n", ZSTR_VAL(strindex), Z_STRVAL_P(zcertval));
-			} else {
-				BIO_printf(outfile, "%s\n", Z_STRVAL_P(zcertval));
+			zend_string *str = zval_get_string(zcertval);
+			if (EG(exception)) {
+				goto clean_exit;
 			}
+			if (strindex) {
+				BIO_printf(outfile, "%s: %s\n", ZSTR_VAL(strindex), ZSTR_VAL(str));
+			} else {
+				BIO_printf(outfile, "%s\n", ZSTR_VAL(str));
+			}
+			zend_string_release(str);
 		} ZEND_HASH_FOREACH_END();
 	}
 
@@ -5566,13 +5590,16 @@ PHP_FUNCTION(openssl_pkcs7_sign)
 		int ret;
 
 		ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(zheaders), strindex, hval) {
-			convert_to_string_ex(hval);
-
-			if (strindex) {
-				ret = BIO_printf(outfile, "%s: %s\n", ZSTR_VAL(strindex), Z_STRVAL_P(hval));
-			} else {
-				ret = BIO_printf(outfile, "%s\n", Z_STRVAL_P(hval));
+			zend_string *str = zval_get_string(hval);
+			if (EG(exception)) {
+				goto clean_exit;
 			}
+			if (strindex) {
+				ret = BIO_printf(outfile, "%s: %s\n", ZSTR_VAL(strindex), ZSTR_VAL(str));
+			} else {
+				ret = BIO_printf(outfile, "%s\n", ZSTR_VAL(str));
+			}
+			zend_string_release(str);
 			if (ret < 0) {
 				php_openssl_store_errors();
 			}

--- a/ext/openssl/tests/bug38261.phpt
+++ b/ext/openssl/tests/bug38261.phpt
@@ -19,7 +19,11 @@ var_dump(openssl_x509_parse($t));
 var_dump(openssl_x509_parse(array()));
 var_dump(openssl_x509_parse());
 var_dump(openssl_x509_parse($cert));
-var_dump(openssl_x509_parse(new stdClass));
+try {
+    var_dump(openssl_x509_parse(new stdClass));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
 --EXPECTF--
@@ -30,5 +34,4 @@ bool(false)
 Warning: openssl_x509_parse() expects at least 1 parameter, 0 given in %sbug38261.php on line %d
 NULL
 bool(false)
-
-Recoverable fatal error: Object of class stdClass could not be converted to string in %sbug38261.php on line %d 
+Object of class stdClass could not be converted to string

--- a/ext/openssl/tests/openssl_pkcs7_decrypt_error.phpt
+++ b/ext/openssl/tests/openssl_pkcs7_decrypt_error.phpt
@@ -15,7 +15,11 @@ $b = 1;
 $c = new stdclass;
 $d = new stdclass;
 
-var_dump(openssl_pkcs7_decrypt($a, $b, $c, $d));
+try {
+    var_dump(openssl_pkcs7_decrypt($a, $b, $c, $d));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 var_dump($c);
 
 var_dump(openssl_pkcs7_decrypt($b, $b, $b, $b));
@@ -26,9 +30,7 @@ var_dump(openssl_pkcs7_decrypt($a, $b, 0, 0));
 echo "Done\n";
 ?>
 --EXPECT--
-string(57) "Object of class stdClass could not be converted to string"
-string(66) "openssl_pkcs7_decrypt(): unable to coerce parameter 3 to x509 cert"
-bool(false)
+Object of class stdClass could not be converted to string
 object(stdClass)#1 (0) {
 }
 string(66) "openssl_pkcs7_decrypt(): unable to coerce parameter 3 to x509 cert"

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -98,8 +98,7 @@
 	(PHP_STREAM_CONTEXT(stream) && (val = php_stream_context_get_option(PHP_STREAM_CONTEXT(stream), "ssl", name)) != NULL)
 #define GET_VER_OPT_STRING(name, str) \
 	if (GET_VER_OPT(name)) { \
-		convert_to_string_ex(val); \
-		if (!EG(exception)) str = Z_STRVAL_P(val); \
+		if (try_convert_to_string(val)) str = Z_STRVAL_P(val); \
 	}
 #define GET_VER_OPT_LONG(name, num) \
 	if (GET_VER_OPT(name)) { num = zval_get_long(val); }
@@ -1254,8 +1253,7 @@ static int php_openssl_set_server_dh_param(php_stream * stream, SSL_CTX *ctx) /*
 		return SUCCESS;
 	}
 
-	convert_to_string_ex(zdhpath);
-	if (EG(exception)) {
+	if (!try_convert_to_string(zdhpath)) {
 		return FAILURE;
 	}
 
@@ -1302,8 +1300,7 @@ static int php_openssl_set_server_ecdh_curve(php_stream *stream, SSL_CTX *ctx) /
 		curve_nid = NID_X9_62_prime256v1;
 #endif
 	} else {
-		convert_to_string_ex(zvcurve);
-		if (EG(exception)) {
+		if (!try_convert_to_string(zvcurve)) {
 			return FAILURE;
 		}
 

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -976,8 +976,7 @@ PHP_FUNCTION(pcntl_exec)
 		current_arg = argv+1;
 		ZEND_HASH_FOREACH_VAL(args_hash, element) {
 			if (argi >= argc) break;
-			convert_to_string_ex(element);
-			if (EG(exception)) {
+			if (!try_convert_to_string(element)) {
 				efree(argv);
 				return;
 			}
@@ -1008,8 +1007,7 @@ PHP_FUNCTION(pcntl_exec)
 				zend_string_addref(key);
 			}
 
-			convert_to_string_ex(element);
-			if (EG(exception)) {
+			if (!try_convert_to_string(element)) {
 				zend_string_release(key);
 				efree(argv);
 				efree(envp);

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -1529,6 +1529,11 @@ PHPAPI zend_string *php_pcre_replace(zend_string *regex,
 	pcre_cache_entry	*pce;			    /* Compiled regular expression */
 	zend_string	 		*result;			/* Function result */
 
+	/* Abort on pending exception, e.g. thrown from __toString(). */
+	if (UNEXPECTED(EG(exception))) {
+		return NULL;
+	}
+
 	/* Compile regex or get it from cache. */
 	if ((pce = pcre_get_compiled_regex_cache(regex)) == NULL) {
 		return NULL;

--- a/ext/pcre/tests/preg_replace_error1.phpt
+++ b/ext/pcre/tests/preg_replace_error1.phpt
@@ -24,7 +24,11 @@ foreach($regex_array as $regex_value) {
     var_dump(preg_replace($regex_value, $replace, $subject));
 }
 $regex_value = new stdclass(); //Object
-var_dump(preg_replace($regex_value, $replace, $subject));
+try {
+    var_dump(preg_replace($regex_value, $replace, $subject));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECTF--
 *** Testing preg_replace() : error conditions***
@@ -54,5 +58,4 @@ string(1) "a"
 
 Arg value is /[a-zA-Z]/
 string(1) "1"
-
-Recoverable fatal error: Object of class stdClass could not be converted to string in %spreg_replace_error1.php on line %d
+Object of class stdClass could not be converted to string

--- a/ext/pcre/tests/preg_replace_error2.phpt
+++ b/ext/pcre/tests/preg_replace_error2.phpt
@@ -19,7 +19,11 @@ foreach($replace as $value) {
     var_dump(preg_replace($regex, $value, $subject));
 }
 $value = new stdclass(); //Object
-var_dump(preg_replace($regex, $value, $subject));
+try {
+    var_dump(preg_replace($regex, $value, $subject));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 echo "Done";
 ?>
 --EXPECTF--
@@ -32,5 +36,5 @@ Arg value is: Array
 
 Warning: preg_replace(): Parameter mismatch, pattern is a string while replacement is an array in %spreg_replace_error2.php on line %d
 bool(false)
-
-Recoverable fatal error: Object of class stdClass could not be converted to string in %spreg_replace_error2.php on line %d
+Object of class stdClass could not be converted to string
+Done

--- a/ext/pdo/pdo_sql_parser.re
+++ b/ext/pdo/pdo_sql_parser.re
@@ -269,7 +269,8 @@ safe:
 
 						default:
 							buf = zval_get_string(parameter);
-							if (!stmt->dbh->methods->quoter(stmt->dbh, ZSTR_VAL(buf),
+							if (EG(exception) ||
+								!stmt->dbh->methods->quoter(stmt->dbh, ZSTR_VAL(buf),
 									ZSTR_LEN(buf), &plc->quoted, &plc->qlen,
 									param_type)) {
 								/* bork */

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -308,6 +308,9 @@ static int really_register_bound_param(struct pdo_bound_param_data *param, pdo_s
 			efree(p);
 		} else {
 			convert_to_string(parameter);
+			if (EG(exception)) {
+				return 0;
+			}
 		}
 	} else if (PDO_PARAM_TYPE(param->param_type) == PDO_PARAM_INT && (Z_TYPE_P(parameter) == IS_FALSE || Z_TYPE_P(parameter) == IS_TRUE)) {
 		convert_to_long(parameter);
@@ -912,6 +915,9 @@ static int do_fetch(pdo_stmt_t *stmt, int do_bind, zval *return_value, enum pdo_
 					fetch_value(stmt, &val, i++, NULL);
 					if (Z_TYPE(val) != IS_NULL) {
 						convert_to_string(&val);
+						if (EG(exception)) {
+							return 0;
+						}
 						if ((cep = zend_lookup_class(Z_STR(val))) == NULL) {
 							stmt->fetch.cls.ce = ZEND_STANDARD_CLASS_DEF_PTR;
 						} else {
@@ -2181,6 +2187,9 @@ static zval *dbstmt_prop_write(zval *object, zval *member, zval *value, void **c
 	pdo_stmt_t *stmt = Z_PDO_STMT_P(object);
 
 	convert_to_string(member);
+	if (EG(exception)) {
+		return value;
+	}
 
 	if (strcmp(Z_STRVAL_P(member), "queryString") == 0) {
 		pdo_raise_impl_error(stmt->dbh, stmt, "HY000", "property queryString is read only");
@@ -2195,6 +2204,9 @@ static void dbstmt_prop_delete(zval *object, zval *member, void **cache_slot)
 	pdo_stmt_t *stmt = Z_PDO_STMT_P(object);
 
 	convert_to_string(member);
+	if (EG(exception)) {
+		return;
+	}
 
 	if (strcmp(Z_STRVAL_P(member), "queryString") == 0) {
 		pdo_raise_impl_error(stmt->dbh, stmt, "HY000", "property queryString is read only");
@@ -2460,6 +2472,10 @@ static zval *row_prop_read(zval *object, zval *member, int type, void **cache_sl
 			}
 		} else {
 			convert_to_string(member);
+			if (EG(exception)) {
+				return &EG(uninitialized_zval);
+			}
+
 			/* TODO: replace this with a hash of available column names to column
 			 * numbers */
 			for (colno = 0; colno < stmt->column_count; colno++) {
@@ -2512,6 +2528,9 @@ static int row_prop_exists(zval *object, zval *member, int check_empty, void **c
 			}
 		} else {
 			convert_to_string(member);
+			if (EG(exception)) {
+				return 0;
+			}
 		}
 
 		/* TODO: replace this with a hash of available column names to column

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -307,8 +307,7 @@ static int really_register_bound_param(struct pdo_bound_param_data *param, pdo_s
 			ZVAL_STRINGL(parameter, p, len);
 			efree(p);
 		} else {
-			convert_to_string(parameter);
-			if (EG(exception)) {
+			if (!try_convert_to_string(parameter)) {
 				return 0;
 			}
 		}

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -913,8 +913,7 @@ static int do_fetch(pdo_stmt_t *stmt, int do_bind, zval *return_value, enum pdo_
 
 					fetch_value(stmt, &val, i++, NULL);
 					if (Z_TYPE(val) != IS_NULL) {
-						convert_to_string(&val);
-						if (EG(exception)) {
+						if (!try_convert_to_string(&val)) {
 							return 0;
 						}
 						if ((cep = zend_lookup_class(Z_STR(val))) == NULL) {
@@ -2185,8 +2184,7 @@ static zval *dbstmt_prop_write(zval *object, zval *member, zval *value, void **c
 {
 	pdo_stmt_t *stmt = Z_PDO_STMT_P(object);
 
-	convert_to_string(member);
-	if (EG(exception)) {
+	if (!try_convert_to_string(member)) {
 		return value;
 	}
 
@@ -2202,8 +2200,7 @@ static void dbstmt_prop_delete(zval *object, zval *member, void **cache_slot)
 {
 	pdo_stmt_t *stmt = Z_PDO_STMT_P(object);
 
-	convert_to_string(member);
-	if (EG(exception)) {
+	if (!try_convert_to_string(member)) {
 		return;
 	}
 
@@ -2470,8 +2467,7 @@ static zval *row_prop_read(zval *object, zval *member, int type, void **cache_sl
 				fetch_value(stmt, rv, lval, NULL);
 			}
 		} else {
-			convert_to_string(member);
-			if (EG(exception)) {
+			if (!try_convert_to_string(member)) {
 				return &EG(uninitialized_zval);
 			}
 
@@ -2526,8 +2522,7 @@ static int row_prop_exists(zval *object, zval *member, int check_empty, void **c
 				return lval >=0 && lval < stmt->column_count;
 			}
 		} else {
-			convert_to_string(member);
-			if (EG(exception)) {
+			if (!try_convert_to_string(member)) {
 				return 0;
 			}
 		}

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -215,7 +215,11 @@ static inline zend_string *pdo_attr_strval(zval *options, enum pdo_attribute_typ
 	zval *v;
 
 	if (options && (v = zend_hash_index_find(Z_ARRVAL_P(options), option_name))) {
-		return zval_get_string(v);
+		zend_string *str = zval_get_string(v);
+		if (EG(exception)) {
+			return NULL;
+		}
+		return str;
 	}
 	return defval ? zend_string_copy(defval) : NULL;
 }

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -215,11 +215,7 @@ static inline zend_string *pdo_attr_strval(zval *options, enum pdo_attribute_typ
 	zval *v;
 
 	if (options && (v = zend_hash_index_find(Z_ARRVAL_P(options), option_name))) {
-		zend_string *str = zval_get_string(v);
-		if (EG(exception)) {
-			return NULL;
-		}
-		return str;
+		return zval_try_get_string(v);
 	}
 	return defval ? zend_string_copy(defval) : NULL;
 }

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -466,6 +466,9 @@ static int firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 		case PDO_FB_ATTR_DATE_FORMAT:
 			{
 				zend_string *str = zval_get_string(val);
+				if (EG(exception)) {
+					return 0;
+				}
 				if (H->date_format) {
 					efree(H->date_format);
 				}
@@ -477,6 +480,9 @@ static int firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 		case PDO_FB_ATTR_TIME_FORMAT:
 			{
 				zend_string *str = zval_get_string(val);
+				if (EG(exception)) {
+					return 0;
+				}
 				if (H->time_format) {
 					efree(H->time_format);
 				}
@@ -488,6 +494,9 @@ static int firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 		case PDO_FB_ATTR_TIMESTAMP_FORMAT:
 			{
 				zend_string *str = zval_get_string(val);
+				if (EG(exception)) {
+					return 0;
+				}
 				if (H->timestamp_format) {
 					efree(H->timestamp_format);
 				}

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -729,6 +729,9 @@ static int firebird_stmt_set_attribute(pdo_stmt_t *stmt, zend_long attr, zval *v
 			return 0;
 		case PDO_ATTR_CURSOR_NAME:
 			convert_to_string(val);
+			if (EG(exception)) {
+				return 0;
+			}
 
 			if (isc_dsql_set_cursor_name(S->H->isc_status, &S->stmt, Z_STRVAL_P(val),0)) {
 				RECORD_ERROR(stmt);

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -728,8 +728,7 @@ static int firebird_stmt_set_attribute(pdo_stmt_t *stmt, zend_long attr, zval *v
 		default:
 			return 0;
 		case PDO_ATTR_CURSOR_NAME:
-			convert_to_string(val);
-			if (EG(exception)) {
+			if (!try_convert_to_string(val)) {
 				return 0;
 			}
 

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -461,6 +461,9 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 		{
 #if (OCI_MAJOR_VERSION >= 10)
 			zend_string *action = zval_get_string(val);
+			if (EG(exception)) {
+				return 0;
+			}
 
 			H->last_err = OCIAttrSet(H->session, OCI_HTYPE_SESSION,
 				(dvoid *) ZSTR_VAL(action), (ub4) ZSTR_LEN(action),
@@ -479,6 +482,9 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 		{
 #if (OCI_MAJOR_VERSION >= 10)
 			zend_string *client_info = zval_get_string(val);
+			if (EG(exception)) {
+				return 0;
+			}
 
 			H->last_err = OCIAttrSet(H->session, OCI_HTYPE_SESSION,
 				(dvoid *) ZSTR_VAL(client_info), (ub4) ZSTR_LEN(client_info),
@@ -497,6 +503,9 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 		{
 #if (OCI_MAJOR_VERSION >= 10)
 			zend_string *identifier = zval_get_string(val);
+			if (EG(exception)) {
+				return 0;
+			}
 
 			H->last_err = OCIAttrSet(H->session, OCI_HTYPE_SESSION,
 				(dvoid *) ZSTR_VAL(identifier), (ub4) ZSTR_LEN(identifier),
@@ -515,6 +524,9 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 		{
 #if (OCI_MAJOR_VERSION >= 10)
 			zend_string *module = zval_get_string(val);
+			if (EG(exception)) {
+				return 0;
+			}
 
 			H->last_err = OCIAttrSet(H->session, OCI_HTYPE_SESSION,
 				(dvoid *) ZSTR_VAL(module), (ub4) ZSTR_LEN(module),

--- a/ext/pdo_oci/oci_statement.c
+++ b/ext/pdo_oci/oci_statement.c
@@ -222,6 +222,9 @@ static sb4 oci_bind_input_cb(dvoid *ctx, OCIBind *bindp, ub4 iter, ub4 index, dv
 	} else if (!P->thing) {
 		/* regular string bind */
 		convert_to_string(parameter);
+		if (EG(exception)) {
+			return OCI_ERROR;
+		}
 		*bufpp = Z_STRVAL_P(parameter);
 		*alenp = (ub4) Z_STRLEN_P(parameter);
 	}
@@ -260,8 +263,7 @@ static sb4 oci_bind_output_cb(dvoid *ctx, OCIBind *bindp, ub4 iter, ub4 index, d
 		return OCI_CONTINUE;
 	}
 
-	convert_to_string(parameter);
-	zval_ptr_dtor_str(parameter);
+	zval_ptr_dtor(parameter);
 
 	Z_STR_P(parameter) = zend_string_alloc(param->max_value_len, 1);
 	P->used_for_output = 1;

--- a/ext/pdo_oci/oci_statement.c
+++ b/ext/pdo_oci/oci_statement.c
@@ -221,8 +221,7 @@ static sb4 oci_bind_input_cb(dvoid *ctx, OCIBind *bindp, ub4 iter, ub4 index, dv
 		*alenp = -1;
 	} else if (!P->thing) {
 		/* regular string bind */
-		convert_to_string(parameter);
-		if (EG(exception)) {
+		if (!try_convert_to_string(parameter)) {
 			return OCI_ERROR;
 		}
 		*bufpp = Z_STRVAL_P(parameter);

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -592,8 +592,7 @@ static PHP_METHOD(PDO, pgsqlCopyFromArray)
 		PQclear(pgsql_result);
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(pg_rows), tmp) {
 			size_t query_len;
-			convert_to_string_ex(tmp);
-			if (EG(exception)) {
+			if (!try_convert_to_string(tmp)) {
 				efree(query);
 				return;
 			}

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -593,6 +593,10 @@ static PHP_METHOD(PDO, pgsqlCopyFromArray)
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(pg_rows), tmp) {
 			size_t query_len;
 			convert_to_string_ex(tmp);
+			if (EG(exception)) {
+				efree(query);
+				return;
+			}
 
 			if (buffer_len < Z_STRLEN_P(tmp)) {
 				buffer_len = Z_STRLEN_P(tmp);

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -412,6 +412,10 @@ static int do_callback(struct pdo_sqlite_fci *fc, zval *cb,
 
 				default:
 					convert_to_string_ex(&retval);
+					if (EG(exception)) {
+						ret = FAILURE;
+						break;
+					}
 					sqlite3_result_text(context, Z_STRVAL(retval), Z_STRLEN(retval), SQLITE_TRANSIENT);
 					break;
 			}

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -411,8 +411,7 @@ static int do_callback(struct pdo_sqlite_fci *fc, zval *cb,
 					break;
 
 				default:
-					convert_to_string_ex(&retval);
-					if (EG(exception)) {
+					if (!try_convert_to_string(&retval)) {
 						ret = FAILURE;
 						break;
 					}

--- a/ext/pdo_sqlite/sqlite_statement.c
+++ b/ext/pdo_sqlite/sqlite_statement.c
@@ -154,6 +154,9 @@ static int pdo_sqlite_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_d
 							return 0;
 						} else {
 							convert_to_string(parameter);
+							if (EG(exception)) {
+								return 0;
+							}
 						}
 
 						if (SQLITE_OK == sqlite3_bind_blob(S->stmt, param->paramno + 1,
@@ -177,6 +180,9 @@ static int pdo_sqlite_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_d
 							}
 						} else {
 							convert_to_string(parameter);
+							if (EG(exception)) {
+								return 0;
+							}
 							if (SQLITE_OK == sqlite3_bind_text(S->stmt, param->paramno + 1,
 									Z_STRVAL_P(parameter),
 									Z_STRLEN_P(parameter),

--- a/ext/pdo_sqlite/sqlite_statement.c
+++ b/ext/pdo_sqlite/sqlite_statement.c
@@ -153,8 +153,7 @@ static int pdo_sqlite_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_d
 							pdo_sqlite_error_stmt(stmt);
 							return 0;
 						} else {
-							convert_to_string(parameter);
-							if (EG(exception)) {
+							if (!try_convert_to_string(parameter)) {
 								return 0;
 							}
 						}
@@ -179,8 +178,7 @@ static int pdo_sqlite_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_d
 								return 1;
 							}
 						} else {
-							convert_to_string(parameter);
-							if (EG(exception)) {
+							if (!try_convert_to_string(parameter)) {
 								return 0;
 							}
 							if (SQLITE_OK == sqlite3_bind_text(S->stmt, param->paramno + 1,

--- a/ext/pdo_sqlite/tests/pdo_sqlite_tostring_exception.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_tostring_exception.phpt
@@ -1,0 +1,45 @@
+--TEST--
+__toString() exception during PDO Sqlite parameter binding
+--SKIPIF--
+<?php if (!extension_loaded('pdo_sqlite')) print 'skip not loaded'; ?>
+--FILE--
+<?php
+
+class throws {
+    function __toString() {
+        throw new Exception("Sorry");
+    }
+}
+
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE t(id int, v varchar(255))');
+
+$stmt = $db->prepare('INSERT INTO t VALUES(:i, :v)');
+$param1 = 1234;
+$stmt->bindValue('i', $param1);
+$param2 = "foo";
+$stmt->bindParam('v', $param2);
+
+$param2 = new throws;
+
+try {
+    $stmt->execute();
+} catch (Exception $e) {
+    echo "Exception thrown ...\n";
+}
+
+try {
+    $stmt->execute();
+} catch (Exception $e) {
+    echo "Exception thrown ...\n";
+}
+
+$query = $db->query("SELECT * FROM t");
+while ($row = $query->fetch(PDO::FETCH_ASSOC)) {
+    print_r($row);
+}
+
+?>
+--EXPECT--
+Exception thrown ...
+Exception thrown ...

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -279,8 +279,7 @@ PHP_FUNCTION(readline_info)
 			oldstr = rl_line_buffer;
 			if (value) {
 				/* XXX if (rl_line_buffer) free(rl_line_buffer); */
-				convert_to_string_ex(value);
-				if (EG(exception)) {
+				if (!try_convert_to_string(value)) {
 					return;
 				}
 				rl_line_buffer = strdup(Z_STRVAL_P(value));
@@ -305,8 +304,7 @@ PHP_FUNCTION(readline_info)
 		} else if (!strcasecmp(what, "pending_input")) {
 			oldval = rl_pending_input;
 			if (value) {
-				convert_to_string_ex(value);
-				if (EG(exception)) {
+				if (!try_convert_to_string(value)) {
 					return;
 				}
 				rl_pending_input = Z_STRVAL_P(value)[0];
@@ -325,8 +323,7 @@ PHP_FUNCTION(readline_info)
 		} else if (!strcasecmp(what, "completion_append_character")) {
 			oldval = rl_completion_append_character;
 			if (value) {
-				convert_to_string_ex(value);
-				if (EG(exception)) {
+				if (!try_convert_to_string(value)) {
 					return;
 				}
 				rl_completion_append_character = (int)Z_STRVAL_P(value)[0];
@@ -351,8 +348,7 @@ PHP_FUNCTION(readline_info)
 			oldstr = (char*)rl_readline_name;
 			if (value) {
 				/* XXX if (rl_readline_name) free(rl_readline_name); */
-				convert_to_string_ex(value);
-				if (EG(exception)) {
+				if (!try_convert_to_string(value)) {
 					return;
 				}
 				rl_readline_name = strdup(Z_STRVAL_P(value));

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -280,6 +280,9 @@ PHP_FUNCTION(readline_info)
 			if (value) {
 				/* XXX if (rl_line_buffer) free(rl_line_buffer); */
 				convert_to_string_ex(value);
+				if (EG(exception)) {
+					return;
+				}
 				rl_line_buffer = strdup(Z_STRVAL_P(value));
 			}
 			RETVAL_STRING(SAFE_STRING(oldstr));
@@ -303,6 +306,9 @@ PHP_FUNCTION(readline_info)
 			oldval = rl_pending_input;
 			if (value) {
 				convert_to_string_ex(value);
+				if (EG(exception)) {
+					return;
+				}
 				rl_pending_input = Z_STRVAL_P(value)[0];
 			}
 			RETVAL_LONG(oldval);
@@ -319,7 +325,10 @@ PHP_FUNCTION(readline_info)
 		} else if (!strcasecmp(what, "completion_append_character")) {
 			oldval = rl_completion_append_character;
 			if (value) {
-				convert_to_string_ex(value)
+				convert_to_string_ex(value);
+				if (EG(exception)) {
+					return;
+				}
 				rl_completion_append_character = (int)Z_STRVAL_P(value)[0];
 			}
 			RETVAL_INTERNED_STR(
@@ -343,6 +352,9 @@ PHP_FUNCTION(readline_info)
 			if (value) {
 				/* XXX if (rl_readline_name) free(rl_readline_name); */
 				convert_to_string_ex(value);
+				if (EG(exception)) {
+					return;
+				}
 				rl_readline_name = strdup(Z_STRVAL_P(value));
 			}
 			RETVAL_STRING(SAFE_STRING(oldstr));

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2347,8 +2347,7 @@ ZEND_METHOD(reflection_parameter, __construct)
 		uint32_t i;
 
 		position = -1;
-		convert_to_string_ex(parameter);
-		if (EG(exception)) {
+		if (!try_convert_to_string(parameter)) {
 			goto failure;
 		}
 
@@ -3701,8 +3700,7 @@ static void reflection_class_object_ctor(INTERNAL_FUNCTION_PARAMETERS, int is_ob
 			ZVAL_COPY(&intern->obj, argument);
 		}
 	} else {
-		convert_to_string_ex(argument);
-		if (EG(exception)) {
+		if (!try_convert_to_string(argument)) {
 			return;
 		}
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2263,7 +2263,7 @@ ZEND_METHOD(reflection_parameter, __construct)
 		case IS_ARRAY: {
 				zval *classref;
 				zval *method;
-				zend_string *lcname;
+				zend_string *name, *lcname;
 
 				if (((classref = zend_hash_index_find(Z_ARRVAL_P(reference), 0)) == NULL)
 					|| ((method = zend_hash_index_find(Z_ARRVAL_P(reference), 1)) == NULL))
@@ -2275,27 +2275,38 @@ ZEND_METHOD(reflection_parameter, __construct)
 				if (Z_TYPE_P(classref) == IS_OBJECT) {
 					ce = Z_OBJCE_P(classref);
 				} else {
-					convert_to_string_ex(classref);
-					if ((ce = zend_lookup_class(Z_STR_P(classref))) == NULL) {
-						zend_throw_exception_ex(reflection_exception_ptr, 0,
-								"Class %s does not exist", Z_STRVAL_P(classref));
+					name = zval_get_string(classref);
+					if (EG(exception)) {
 						return;
 					}
+					if ((ce = zend_lookup_class(name)) == NULL) {
+						zend_throw_exception_ex(reflection_exception_ptr, 0,
+								"Class %s does not exist", ZSTR_VAL(name));
+						zend_string_release(name);
+						return;
+					}
+					zend_string_release(name);
 				}
 
-				convert_to_string_ex(method);
-				lcname = zend_string_tolower(Z_STR_P(method));
+				name = zval_get_string(method);
+				if (EG(exception)) {
+					return;
+				}
+
+				lcname = zend_string_tolower(name);
 				if (Z_TYPE_P(classref) == IS_OBJECT && is_closure_invoke(ce, lcname)
 					&& (fptr = zend_get_closure_invoke_method(Z_OBJ_P(classref))) != NULL)
 				{
 					/* nothing to do. don't set is_closure since is the invoke handler,
 					   not the closure itself */
 				} else if ((fptr = zend_hash_find_ptr(&ce->function_table, lcname)) == NULL) {
+					zend_string_release(name);
 					zend_string_release(lcname);
 					zend_throw_exception_ex(reflection_exception_ptr, 0,
 						"Method %s::%s() does not exist", ZSTR_VAL(ce->name), Z_STRVAL_P(method));
 					return;
 				}
+				zend_string_release(name);
 				zend_string_release(lcname);
 			}
 			break;
@@ -2329,29 +2340,24 @@ ZEND_METHOD(reflection_parameter, __construct)
 	if (Z_TYPE_P(parameter) == IS_LONG) {
 		position= (int)Z_LVAL_P(parameter);
 		if (position < 0 || (uint32_t)position >= num_args) {
-			if (fptr->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
-				if (fptr->type != ZEND_OVERLOADED_FUNCTION) {
-					zend_string_release_ex(fptr->common.function_name, 0);
-				}
-				zend_free_trampoline(fptr);
-			}
-			if (is_closure) {
-				zval_ptr_dtor(reference);
-			}
 			_DO_THROW("The parameter specified by its offset could not be found");
-			return;
+			goto failure;
 		}
 	} else {
 		uint32_t i;
 
-		position= -1;
+		position = -1;
 		convert_to_string_ex(parameter);
+		if (EG(exception)) {
+			goto failure;
+		}
+
 		if (fptr->type == ZEND_INTERNAL_FUNCTION &&
 		    !(fptr->common.fn_flags & ZEND_ACC_USER_ARG_INFO)) {
 			for (i = 0; i < num_args; i++) {
 				if (arg_info[i].name) {
 					if (strcmp(((zend_internal_arg_info*)arg_info)[i].name, Z_STRVAL_P(parameter)) == 0) {
-						position= i;
+						position = i;
 						break;
 					}
 
@@ -2361,24 +2367,15 @@ ZEND_METHOD(reflection_parameter, __construct)
 			for (i = 0; i < num_args; i++) {
 				if (arg_info[i].name) {
 					if (strcmp(ZSTR_VAL(arg_info[i].name), Z_STRVAL_P(parameter)) == 0) {
-						position= i;
+						position = i;
 						break;
 					}
 				}
 			}
 		}
 		if (position == -1) {
-			if (fptr->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
-				if (fptr->type != ZEND_OVERLOADED_FUNCTION) {
-					zend_string_release_ex(fptr->common.function_name, 0);
-				}
-				zend_free_trampoline(fptr);
-			}
-			if (is_closure) {
-				zval_ptr_dtor(reference);
-			}
 			_DO_THROW("The parameter specified by its name could not be found");
-			return;
+			goto failure;
 		}
 	}
 
@@ -2405,6 +2402,18 @@ ZEND_METHOD(reflection_parameter, __construct)
 		}
 	} else {
 		ZVAL_NULL(prop_name);
+	}
+	return;
+
+failure:
+	if (fptr->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
+		if (fptr->type != ZEND_OVERLOADED_FUNCTION) {
+			zend_string_release_ex(fptr->common.function_name, 0);
+		}
+		zend_free_trampoline(fptr);
+	}
+	if (is_closure) {
+		zval_ptr_dtor(reference);
 	}
 }
 /* }}} */
@@ -3693,6 +3702,10 @@ static void reflection_class_object_ctor(INTERNAL_FUNCTION_PARAMETERS, int is_ob
 		}
 	} else {
 		convert_to_string_ex(argument);
+		if (EG(exception)) {
+			return;
+		}
+
 		if ((ce = zend_lookup_class(Z_STR_P(argument))) == NULL) {
 			if (!EG(exception)) {
 				zend_throw_exception_ex(reflection_exception_ptr, -1, "Class %s does not exist", Z_STRVAL_P(argument));

--- a/ext/reflection/tests/bug74673.phpt
+++ b/ext/reflection/tests/bug74673.phpt
@@ -19,4 +19,9 @@ $class = new ReflectionClass('A');
 echo $class;
 ?>
 --EXPECTF--
-Fatal error: Method ReflectionClass::__toString() must not throw an exception, caught Exception:  in %sbug74673.php on line %d
+Fatal error: Uncaught Exception in %s:%d
+Stack trace:
+#0 [internal function]: {closure}(2, 'Use of undefine...', %s, %d, Array)
+#1 %s(%d): ReflectionClass->__toString()
+#2 {main}
+  thrown in %s on line %d

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1752,35 +1752,36 @@ static PHP_FUNCTION(session_set_cookie_params)
 		lifetime = zval_get_string(lifetime_or_options);
 	}
 
+	/* Exception during string conversion */
+	if (EG(exception)) {
+		goto cleanup;
+	}
+
 	if (lifetime) {
 		ini_name = zend_string_init("session.cookie_lifetime", sizeof("session.cookie_lifetime") - 1, 0);
 		result = zend_alter_ini_entry(ini_name, lifetime, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
-		zend_string_release(lifetime);
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
-			RETURN_FALSE;
+			RETVAL_FALSE;
+			goto cleanup;
 		}
 	}
 	if (path) {
 		ini_name = zend_string_init("session.cookie_path", sizeof("session.cookie_path") - 1, 0);
 		result = zend_alter_ini_entry(ini_name, path, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
-		if (found > 0) {
-			zend_string_release(path);
-		}
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
-			RETURN_FALSE;
+			RETVAL_FALSE;
+			goto cleanup;
 		}
 	}
 	if (domain) {
 		ini_name = zend_string_init("session.cookie_domain", sizeof("session.cookie_domain") - 1, 0);
 		result = zend_alter_ini_entry(ini_name, domain, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
-		if (found > 0) {
-			zend_string_release(domain);
-		}
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
-			RETURN_FALSE;
+			RETVAL_FALSE;
+			goto cleanup;
 		}
 	}
 	if (!secure_null) {
@@ -1788,7 +1789,8 @@ static PHP_FUNCTION(session_set_cookie_params)
 		result = zend_alter_ini_entry_chars(ini_name, secure ? "1" : "0", 1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
-			RETURN_FALSE;
+			RETVAL_FALSE;
+			goto cleanup;
 		}
 	}
 	if (!httponly_null) {
@@ -1796,22 +1798,29 @@ static PHP_FUNCTION(session_set_cookie_params)
 		result = zend_alter_ini_entry_chars(ini_name, httponly ? "1" : "0", 1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
-			RETURN_FALSE;
+			RETVAL_FALSE;
+			goto cleanup;
 		}
 	}
 	if (samesite) {
 		ini_name = zend_string_init("session.cookie_samesite", sizeof("session.cookie_samesite") - 1, 0);
 		result = zend_alter_ini_entry(ini_name, samesite, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
-		if (found > 0) {
-			zend_string_release(samesite);
-		}
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
-			RETURN_FALSE;
+			RETVAL_FALSE;
+			goto cleanup;
 		}
 	}
 
-	RETURN_TRUE;
+	RETVAL_TRUE;
+
+cleanup:
+	if (lifetime) zend_string_release(lifetime);
+	if (found > 0) {
+		if (path) zend_string_release(path);
+		if (domain) zend_string_release(domain);
+		if (samesite) zend_string_release(samesite);
+	}
 }
 /* }}} */
 
@@ -2365,6 +2374,10 @@ static PHP_FUNCTION(session_cache_expire)
 
 	if (expires) {
 		convert_to_string_ex(expires);
+		if (EG(exception)) {
+			return;
+		}
+
 		ini_name = zend_string_init("session.cache_expire", sizeof("session.cache_expire") - 1, 0);
 		zend_alter_ini_entry(ini_name, Z_STR_P(expires), ZEND_INI_USER, ZEND_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2373,8 +2373,7 @@ static PHP_FUNCTION(session_cache_expire)
 	RETVAL_LONG(PS(cache_expire));
 
 	if (expires) {
-		convert_to_string_ex(expires);
-		if (EG(exception)) {
+		if (!try_convert_to_string(expires)) {
 			return;
 		}
 

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -260,6 +260,9 @@ long_dim:
 			if (Z_TYPE_P(member) != IS_STRING) {
 				ZVAL_STR(&tmp_zv, zval_get_string_func(member));
 				member = &tmp_zv;
+				if (EG(exception)) {
+					return &EG(uninitialized_zval);
+				}
 			}
 			name = Z_STRVAL_P(member);
 		}
@@ -455,6 +458,10 @@ long_dim:
 		} else {
 			if (Z_TYPE_P(member) != IS_STRING) {
 				trim_str = zval_get_string_func(member);
+				if (EG(exception)) {
+					return &EG(error_zval);
+				}
+
 				ZVAL_STR(&tmp_zv, php_trim(trim_str, NULL, 0, 3));
 				zend_string_release_ex(trim_str, 0);
 				member = &tmp_zv;
@@ -672,10 +679,13 @@ static zval *sxe_property_get_adr(zval *object, zval *member, int fetch_type, vo
 	char           *name;
 	SXE_ITER        type;
 
-	sxe = Z_SXEOBJ_P(object);
-
-	GET_NODE(sxe, node);
 	convert_to_string(member);
+	if (EG(exception)) {
+		return NULL;
+	}
+
+	sxe = Z_SXEOBJ_P(object);
+	GET_NODE(sxe, node);
 	name = Z_STRVAL_P(member);
 	node = sxe_get_element_by_name(sxe, node, &name, &type);
 	if (node) {
@@ -713,6 +723,9 @@ static int sxe_prop_dim_exists(zval *object, zval *member, int check_empty, zend
 	if (Z_TYPE_P(member) != IS_STRING && Z_TYPE_P(member) != IS_LONG) {
 		ZVAL_STR(&tmp_zv, zval_get_string_func(member));
 		member = &tmp_zv;
+		if (EG(exception)) {
+			return 0;
+		}
 	}
 
 	sxe = Z_SXEOBJ_P(object);
@@ -832,6 +845,9 @@ static void sxe_prop_dim_delete(zval *object, zval *member, zend_bool elements, 
 	if (Z_TYPE_P(member) != IS_STRING && Z_TYPE_P(member) != IS_LONG) {
 		ZVAL_STR(&tmp_zv, zval_get_string_func(member));
 		member = &tmp_zv;
+		if (EG(exception)) {
+			return;
+		}
 	}
 
 	sxe = Z_SXEOBJ_P(object);

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -679,8 +679,7 @@ static zval *sxe_property_get_adr(zval *object, zval *member, int fetch_type, vo
 	char           *name;
 	SXE_ITER        type;
 
-	convert_to_string(member);
-	if (EG(exception)) {
+	if (!try_convert_to_string(member)) {
 		return NULL;
 	}
 

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1920,6 +1920,9 @@ zval *php_snmp_read_property(zval *object, zval *member, int type, void **cache_
 	if (Z_TYPE_P(member) != IS_STRING) {
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
+		if (EG(exception)) {
+			return &EG(uninitialized_zval);
+		}
 	}
 
 	hnd = zend_hash_find_ptr(&php_snmp_properties, Z_STR_P(member));
@@ -1954,6 +1957,9 @@ zval *php_snmp_write_property(zval *object, zval *member, zval *value, void **ca
 	if (Z_TYPE_P(member) != IS_STRING) {
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
+		if (EG(exception)) {
+			return value;
+		}
 	}
 
 	obj = Z_SNMP_P(object);

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -332,8 +332,7 @@ double_case:
 		zend_long lval;
 		double dval;
 
-		convert_to_string(&lzval);
-		if (EG(exception)) {
+		if (!try_convert_to_string(&lzval)) {
 			ctx->err.has_error = 1;
 			break;
 		}

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -333,6 +333,10 @@ double_case:
 		double dval;
 
 		convert_to_string(&lzval);
+		if (EG(exception)) {
+			ctx->err.has_error = 1;
+			break;
+		}
 
 		switch (is_numeric_string(Z_STRVAL(lzval), Z_STRLEN(lzval), &lval, &dval, 0)) {
 		case IS_DOUBLE:

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -1066,15 +1066,11 @@ static void spl_recursive_tree_iterator_get_entry(spl_recursive_it_object *objec
 {
 	zend_object_iterator      *iterator = object->iterators[object->level].iterator;
 	zval                      *data;
-	zend_error_handling        error_handling;
 
 	data = iterator->funcs->get_current_data(iterator);
-
-	/* Replace exception handling so the catchable fatal error that is thrown when a class
-	 * without __toString is converted to string is converted into an exception. */
-	zend_replace_error_handling(EH_THROW, spl_ce_UnexpectedValueException, &error_handling);
 	if (data) {
 		ZVAL_DEREF(data);
+		/* TODO: Remove this special case? */
 		if (Z_TYPE_P(data) == IS_ARRAY) {
 			RETVAL_INTERNED_STR(ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED));
 		} else {
@@ -1082,7 +1078,6 @@ static void spl_recursive_tree_iterator_get_entry(spl_recursive_it_object *objec
 			convert_to_string(return_value);
 		}
 	}
-	zend_restore_error_handling(&error_handling);
 }
 
 static void spl_recursive_tree_iterator_get_postfix(spl_recursive_it_object *object, zval *return_value)

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -1076,7 +1076,7 @@ static void spl_recursive_tree_iterator_get_entry(spl_recursive_it_object *objec
 	if (data) {
 		ZVAL_DEREF(data);
 		if (Z_TYPE_P(data) == IS_ARRAY) {
-			ZVAL_STRINGL(return_value, "Array", sizeof("Array")-1);
+			RETVAL_INTERNED_STR(ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED));
 		} else {
 			ZVAL_COPY(return_value, data);
 			convert_to_string(return_value);

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -2006,7 +2006,7 @@ SPL_METHOD(RegexIterator, accept)
 	spl_dual_it_object *intern;
 	zend_string *result, *subject;
 	size_t count = 0;
-	zval zcount, *replacement, tmp_replacement, rv;
+	zval zcount, rv;
 	pcre2_match_data *match_data;
 	pcre2_code *re;
 	int rc;
@@ -2028,6 +2028,11 @@ SPL_METHOD(RegexIterator, accept)
 			RETURN_FALSE;
 		}
 		subject = zval_get_string(&intern->current.data);
+	}
+
+	/* Exception during string conversion. */
+	if (EG(exception)) {
+		return;
 	}
 
 	switch (intern->u.regex.mode)
@@ -2061,14 +2066,14 @@ SPL_METHOD(RegexIterator, accept)
 			RETVAL_BOOL(count > 1);
 			break;
 
-		case REGIT_MODE_REPLACE:
-			replacement = zend_read_property(intern->std.ce, ZEND_THIS, "replacement", sizeof("replacement")-1, 1, &rv);
-			if (Z_TYPE_P(replacement) != IS_STRING) {
-				ZVAL_COPY(&tmp_replacement, replacement);
-				convert_to_string(&tmp_replacement);
-				replacement = &tmp_replacement;
+		case REGIT_MODE_REPLACE: {
+			zval *replacement = zend_read_property(intern->std.ce, ZEND_THIS, "replacement", sizeof("replacement")-1, 1, &rv);
+			zend_string *replacement_str = zval_get_string(replacement);
+			if (EG(exception)) {
+				return;
 			}
-			result = php_pcre_replace_impl(intern->u.regex.pce, subject, ZSTR_VAL(subject), ZSTR_LEN(subject), Z_STR_P(replacement), -1, &count);
+
+			result = php_pcre_replace_impl(intern->u.regex.pce, subject, ZSTR_VAL(subject), ZSTR_LEN(subject), replacement_str, -1, &count);
 
 			if (intern->u.regex.flags & REGIT_USE_KEY) {
 				zval_ptr_dtor(&intern->current.key);
@@ -2078,10 +2083,9 @@ SPL_METHOD(RegexIterator, accept)
 				ZVAL_STR(&intern->current.data, result);
 			}
 
-			if (replacement == &tmp_replacement) {
-				zval_ptr_dtor(replacement);
-			}
+			zend_string_release(replacement_str);
 			RETVAL_BOOL(count > 0);
+		}
 	}
 
 	if (intern->u.regex.flags & REGIT_INVERTED) {

--- a/ext/spl/tests/iterator_036.phpt
+++ b/ext/spl/tests/iterator_036.phpt
@@ -18,4 +18,9 @@ test(new CachingIterator($ar, 0));
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Method CachingIterator::__toString() must not throw an exception, caught BadMethodCallException: CachingIterator does not fetch string value (see CachingIterator::__construct) in %siterator_036.php on line %d
+Fatal error: Uncaught BadMethodCallException: CachingIterator does not fetch string value (see CachingIterator::__construct) in %s:%d
+Stack trace:
+#0 %s(%d): CachingIterator->__toString()
+#1 %s(%d): test(Object(CachingIterator))
+#2 {main}
+  thrown in %s on line %d

--- a/ext/spl/tests/recursive_tree_iterator_007.phpt
+++ b/ext/spl/tests/recursive_tree_iterator_007.phpt
@@ -22,12 +22,12 @@ try {
 	foreach(new RecursiveTreeIterator($it) as $k => $v) {
 		echo "[$k] => $v\n";
 	}
-} catch (UnexpectedValueException $e) {
-	echo "UnexpectedValueException thrown\n";
+} catch (Error $e) {
+	echo $e->getMessage(), "\n";
 }
 
 ?>
 ===DONE===
 --EXPECT--
-UnexpectedValueException thrown
+Object of class stdClass could not be converted to string
 ===DONE===

--- a/ext/sqlite3/tests/exception_from_toString.phpt
+++ b/ext/sqlite3/tests/exception_from_toString.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Check that exceptions from __toString() are handled correctly
+--FILE--
+<?php
+
+class throws {
+    function __toString() {
+        throw new Exception("Sorry");
+    }
+}
+
+$db = new sqlite3(':memory:');
+$db->exec('CREATE TABLE t(id int, v varchar(255))');
+
+$stmt = $db->prepare('INSERT INTO t VALUES(:i, :v)');
+$stmt->bindValue('i', 1234);
+$stmt->bindValue('v', new throws);
+
+try {
+    $stmt->execute();
+} catch (Exception $e) {
+    echo "Exception thrown ...\n";
+}
+
+try {
+    $stmt->execute();
+} catch (Exception $e) {
+    echo "Exception thrown ...\n";
+}
+
+$query = $db->query("SELECT * FROM t");
+while ($row = $query->fetchArray(SQLITE3_ASSOC)) {
+    print_r($row);
+}
+
+?>
+--EXPECT--
+Exception thrown ...
+Exception thrown ...

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2459,6 +2459,10 @@ PHP_FUNCTION(extract)
 
 	if (prefix) {
 		convert_to_string(prefix);
+		if (EG(exception)) {
+			return;
+		}
+
 		if (Z_STRLEN_P(prefix) && !php_valid_var_name(Z_STRVAL_P(prefix), Z_STRLEN_P(prefix))) {
 			php_error_docref(NULL, E_WARNING, "prefix is not a valid identifier");
 			return;
@@ -4135,6 +4139,9 @@ zend_bool array_column_param_helper(zval *param,
 
 		case IS_OBJECT:
 			convert_to_string_ex(param);
+			if (EG(exception)) {
+				return 0;
+			}
 			/* fallthrough */
 		case IS_STRING:
 			return 1;

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2458,8 +2458,7 @@ PHP_FUNCTION(extract)
 	}
 
 	if (prefix) {
-		convert_to_string(prefix);
-		if (EG(exception)) {
+		if (!try_convert_to_string(prefix)) {
 			return;
 		}
 
@@ -4138,8 +4137,7 @@ zend_bool array_column_param_helper(zval *param,
 			return 1;
 
 		case IS_OBJECT:
-			convert_to_string_ex(param);
-			if (EG(exception)) {
+			if (!try_convert_to_string(param)) {
 				return 0;
 			}
 			/* fallthrough */

--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -300,6 +300,10 @@ PHP_FUNCTION(assert_options)
 		oldint = ASSERTG(active);
 		if (ac == 2) {
 			zend_string *value_str = zval_get_string(value);
+			if (EG(exception)) {
+				return;
+			}
+
 			key = zend_string_init("assert.active", sizeof("assert.active")-1, 0);
 			zend_alter_ini_entry_ex(key, value_str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0);
 			zend_string_release_ex(key, 0);
@@ -312,6 +316,10 @@ PHP_FUNCTION(assert_options)
 		oldint = ASSERTG(bail);
 		if (ac == 2) {
 			zend_string *value_str = zval_get_string(value);
+			if (EG(exception)) {
+				return;
+			}
+
 			key = zend_string_init("assert.bail", sizeof("assert.bail")-1, 0);
 			zend_alter_ini_entry_ex(key, value_str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0);
 			zend_string_release_ex(key, 0);
@@ -324,6 +332,10 @@ PHP_FUNCTION(assert_options)
 		oldint = ASSERTG(quiet_eval);
 		if (ac == 2) {
 			zend_string *value_str = zval_get_string(value);
+			if (EG(exception)) {
+				return;
+			}
+
 			key = zend_string_init("assert.quiet_eval", sizeof("assert.quiet_eval")-1, 0);
 			zend_alter_ini_entry_ex(key, value_str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0);
 			zend_string_release_ex(key, 0);
@@ -336,6 +348,10 @@ PHP_FUNCTION(assert_options)
 		oldint = ASSERTG(warning);
 		if (ac == 2) {
 			zend_string *value_str = zval_get_string(value);
+			if (EG(exception)) {
+				return;
+			}
+
 			key = zend_string_init("assert.warning", sizeof("assert.warning")-1, 0);
 			zend_alter_ini_entry_ex(key, value_str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0);
 			zend_string_release_ex(key, 0);
@@ -361,8 +377,12 @@ PHP_FUNCTION(assert_options)
 	case ASSERT_EXCEPTION:
 		oldint = ASSERTG(exception);
 		if (ac == 2) {
-			zend_string *key = zend_string_init("assert.exception", sizeof("assert.exception")-1, 0);
 			zend_string *val = zval_get_string(value);
+			if (EG(exception)) {
+				return;
+			}
+
+			key = zend_string_init("assert.exception", sizeof("assert.exception")-1, 0);
 			zend_alter_ini_entry_ex(key, val, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0);
 			zend_string_release_ex(val, 0);
 			zend_string_release_ex(key, 0);

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -5358,6 +5358,9 @@ PHP_FUNCTION(highlight_string)
 		Z_PARAM_BOOL(i)
 	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 	convert_to_string_ex(expr);
+	if (EG(exception)) {
+		return;
+	}
 
 	if (i) {
 		php_output_start_default();

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -5357,8 +5357,8 @@ PHP_FUNCTION(highlight_string)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_BOOL(i)
 	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
-	convert_to_string_ex(expr);
-	if (EG(exception)) {
+
+	if (!try_convert_to_string(expr)) {
 		return;
 	}
 

--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -250,8 +250,6 @@ static php_stream_filter *strfilter_strip_tags_create(const char *filtername, zv
 
 	php_error_docref(NULL, E_DEPRECATED, "The string.strip_tags filter is deprecated");
 
-	inst = pemalloc(sizeof(php_strip_tags_filter), persistent);
-
 	if (filterparams != NULL) {
 		if (Z_TYPE_P(filterparams) == IS_ARRAY) {
 			smart_str tags_ss = {0};
@@ -268,8 +266,17 @@ static php_stream_filter *strfilter_strip_tags_create(const char *filtername, zv
 		} else {
 			allowed_tags = zval_get_string(filterparams);
 		}
+
+		/* Exception during string conversion. */
+		if (EG(exception)) {
+			if (allowed_tags) {
+				zend_string_release(allowed_tags);
+			}
+			return NULL;
+		}
 	}
 
+	inst = pemalloc(sizeof(php_strip_tags_filter), persistent);
 	if (php_strip_tags_filter_ctor(inst, allowed_tags, persistent) == SUCCESS) {
 		filter = php_stream_filter_alloc(&strfilter_strip_tags_ops, inst, persistent);
 	} else {

--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -400,8 +400,7 @@ php_formatted_print(zval *z_format, zval *args, int argc)
 	int always_sign;
 	size_t format_len;
 
-	convert_to_string_ex(z_format);
-	if (EG(exception)) {
+	if (!try_convert_to_string(z_format)) {
 		return NULL;
 	}
 

--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -401,6 +401,10 @@ php_formatted_print(zval *z_format, zval *args, int argc)
 	size_t format_len;
 
 	convert_to_string_ex(z_format);
+	if (EG(exception)) {
+		return NULL;
+	}
+
 	format = Z_STRVAL_P(z_format);
 	format_len = Z_STRLEN_P(z_format);
 	result = zend_string_alloc(size, 0);

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -258,10 +258,12 @@ PHP_FUNCTION(setcookie)
 		}
 	}
 
-	if (php_setcookie(name, value, expires, path, domain, secure, httponly, samesite, 1) == SUCCESS) {
-		RETVAL_TRUE;
-	} else {
-		RETVAL_FALSE;
+	if (!EG(exception)) {
+		if (php_setcookie(name, value, expires, path, domain, secure, httponly, samesite, 1) == SUCCESS) {
+			RETVAL_TRUE;
+		} else {
+			RETVAL_FALSE;
+		}
 	}
 
 	if (expires_or_options && Z_TYPE_P(expires_or_options) == IS_ARRAY) {
@@ -311,10 +313,12 @@ PHP_FUNCTION(setrawcookie)
 		}
 	}
 
-	if (php_setcookie(name, value, expires, path, domain, secure, httponly, samesite, 0) == SUCCESS) {
-		RETVAL_TRUE;
-	} else {
-		RETVAL_FALSE;
+	if (!EG(exception)) {
+		if (php_setcookie(name, value, expires, path, domain, secure, httponly, samesite, 0) == SUCCESS) {
+			RETVAL_TRUE;
+		} else {
+			RETVAL_FALSE;
+		}
 	}
 
 	if (expires_or_options && Z_TYPE_P(expires_or_options) == IS_ARRAY) {

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1091,8 +1091,7 @@ PHP_FUNCTION(base_convert)
 		Z_PARAM_LONG(tobase)
 	ZEND_PARSE_PARAMETERS_END();
 
-	convert_to_string_ex(number);
-	if (EG(exception)) {
+	if (!try_convert_to_string(number)) {
 		return;
 	}
 

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1090,7 +1090,11 @@ PHP_FUNCTION(base_convert)
 		Z_PARAM_LONG(frombase)
 		Z_PARAM_LONG(tobase)
 	ZEND_PARSE_PARAMETERS_END();
+
 	convert_to_string_ex(number);
+	if (EG(exception)) {
+		return;
+	}
 
 	if (frombase < 2 || frombase > 36) {
 		php_error_docref(NULL, E_WARNING, "Invalid `from base' (" ZEND_LONG_FMT ")", frombase);

--- a/ext/standard/pack.c
+++ b/ext/standard/pack.c
@@ -297,8 +297,7 @@ PHP_FUNCTION(pack)
 				}
 
 				if (arg < 0) {
-					convert_to_string(&argv[currentarg]);
-					if (EG(exception)) {
+					if (!try_convert_to_string(&argv[currentarg])) {
 						efree(formatcodes);
 						efree(formatargs);
 						return;

--- a/ext/standard/pack.c
+++ b/ext/standard/pack.c
@@ -298,6 +298,12 @@ PHP_FUNCTION(pack)
 
 				if (arg < 0) {
 					convert_to_string(&argv[currentarg]);
+					if (EG(exception)) {
+						efree(formatcodes);
+						efree(formatargs);
+						return;
+					}
+
 					arg = Z_STRLEN(argv[currentarg]);
 					if (code == 'Z') {
 						/* add one because Z is always NUL-terminated:

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -140,6 +140,9 @@ static zend_string* php_password_get_salt(zval *unused_, size_t required_salt_le
 		case IS_DOUBLE:
 		case IS_OBJECT:
 			buffer = zval_get_string(option_buffer);
+			if (EG(exception)) {
+				return NULL;
+			}
 			break;
 		case IS_FALSE:
 		case IS_TRUE:

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -553,6 +553,9 @@ PHP_FUNCTION(proc_open)
 
 			if ((ztype = zend_hash_index_find(Z_ARRVAL_P(descitem), 0)) != NULL) {
 				convert_to_string_ex(ztype);
+				if (EG(exception)) {
+					goto exit_fail;
+				}
 			} else {
 				php_error_docref(NULL, E_WARNING, "Missing handle qualifier in array");
 				goto exit_fail;
@@ -564,6 +567,9 @@ PHP_FUNCTION(proc_open)
 
 				if ((zmode = zend_hash_index_find(Z_ARRVAL_P(descitem), 1)) != NULL) {
 					convert_to_string_ex(zmode);
+					if (EG(exception)) {
+						goto exit_fail;
+					}
 				} else {
 					php_error_docref(NULL, E_WARNING, "Missing mode parameter for 'pipe'");
 					goto exit_fail;
@@ -603,6 +609,9 @@ PHP_FUNCTION(proc_open)
 
 				if ((zfile = zend_hash_index_find(Z_ARRVAL_P(descitem), 1)) != NULL) {
 					convert_to_string_ex(zfile);
+					if (EG(exception)) {
+						goto exit_fail;
+					}
 				} else {
 					php_error_docref(NULL, E_WARNING, "Missing file name parameter for 'file'");
 					goto exit_fail;
@@ -610,6 +619,9 @@ PHP_FUNCTION(proc_open)
 
 				if ((zmode = zend_hash_index_find(Z_ARRVAL_P(descitem), 2)) != NULL) {
 					convert_to_string_ex(zmode);
+					if (EG(exception)) {
+						goto exit_fail;
+					}
 				} else {
 					php_error_docref(NULL, E_WARNING, "Missing mode parameter for 'file'");
 					goto exit_fail;

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -552,8 +552,7 @@ PHP_FUNCTION(proc_open)
 		} else {
 
 			if ((ztype = zend_hash_index_find(Z_ARRVAL_P(descitem), 0)) != NULL) {
-				convert_to_string_ex(ztype);
-				if (EG(exception)) {
+				if (!try_convert_to_string(ztype)) {
 					goto exit_fail;
 				}
 			} else {
@@ -566,8 +565,7 @@ PHP_FUNCTION(proc_open)
 				zval *zmode;
 
 				if ((zmode = zend_hash_index_find(Z_ARRVAL_P(descitem), 1)) != NULL) {
-					convert_to_string_ex(zmode);
-					if (EG(exception)) {
+					if (!try_convert_to_string(zmode)) {
 						goto exit_fail;
 					}
 				} else {
@@ -608,8 +606,7 @@ PHP_FUNCTION(proc_open)
 				descriptors[ndesc].mode = DESC_FILE;
 
 				if ((zfile = zend_hash_index_find(Z_ARRVAL_P(descitem), 1)) != NULL) {
-					convert_to_string_ex(zfile);
-					if (EG(exception)) {
+					if (!try_convert_to_string(zfile)) {
 						goto exit_fail;
 					}
 				} else {
@@ -618,8 +615,7 @@ PHP_FUNCTION(proc_open)
 				}
 
 				if ((zmode = zend_hash_index_find(Z_ARRVAL_P(descitem), 2)) != NULL) {
-					convert_to_string_ex(zmode);
-					if (EG(exception)) {
+					if (!try_convert_to_string(zmode)) {
 						goto exit_fail;
 					}
 				} else {

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -1576,8 +1576,7 @@ PHP_FUNCTION(stream_is_local)
 		}
 		wrapper = stream->wrapper;
 	} else {
-		convert_to_string_ex(zstream);
-		if (EG(exception)) {
+		if (!try_convert_to_string(zstream)) {
 			return;
 		}
 

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -1577,6 +1577,9 @@ PHP_FUNCTION(stream_is_local)
 		wrapper = stream->wrapper;
 	} else {
 		convert_to_string_ex(zstream);
+		if (EG(exception)) {
+			return;
+		}
 
 		wrapper = php_stream_locate_url_wrapper(Z_STRVAL_P(zstream), NULL, 0);
 	}

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3522,8 +3522,7 @@ PHP_FUNCTION(strtr)
 			php_strtr_array(return_value, str, pats);
 		}
 	} else {
-		convert_to_string_ex(from);
-		if (EG(exception)) {
+		if (!try_convert_to_string(from)) {
 			return;
 		}
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2494,6 +2494,10 @@ PHP_FUNCTION(substr_replace)
 		convert_to_long_ex(from);
 	}
 
+	if (EG(exception)) {
+		return;
+	}
+
 	if (argc > 3) {
 		if (Z_TYPE_P(len) != IS_ARRAY) {
 			convert_to_long_ex(len);
@@ -3519,6 +3523,9 @@ PHP_FUNCTION(strtr)
 		}
 	} else {
 		convert_to_string_ex(from);
+		if (EG(exception)) {
+			return;
+		}
 
 		RETURN_STR(php_strtr_ex(str,
 				  Z_STRVAL_P(from),
@@ -4438,6 +4445,10 @@ static void php_str_replace_common(INTERNAL_FUNCTION_PARAMETERS, int case_sensit
 		convert_to_string_ex(replace);
 	}
 
+	if (EG(exception)) {
+		return;
+	}
+
 	/* if subject is an array */
 	if (Z_TYPE_P(subject) == IS_ARRAY) {
 		array_init(return_value);
@@ -4840,6 +4851,9 @@ PHP_FUNCTION(setlocale)
 		}
 
 		loc = zval_get_string(plocale);
+		if (EG(exception)) {
+			return;
+		}
 
 		if (!strcmp("0", ZSTR_VAL(loc))) {
 			zend_string_release_ex(loc, 0);

--- a/ext/standard/tests/array/array_multisort_variation8.phpt
+++ b/ext/standard/tests/array/array_multisort_variation8.phpt
@@ -34,7 +34,6 @@ $inputs = array(
       'empty string DQ' => "",
       'string DQ' => "string",
       'instance of classWithToString' => new classWithToString(),
-      'instance of classWithoutToString' => new classWithoutToString(),
       'undefined var' => @$undefined_var,
 );
 
@@ -46,14 +45,11 @@ var_dump($inputs);
 --EXPECT--
 *** Testing array_multisort() : usage variation  - test sort order of all types***
 bool(true)
-array(10) {
+array(9) {
   ["uppercase NULL"]=>
   NULL
   ["empty string DQ"]=>
   string(0) ""
-  ["instance of classWithoutToString"]=>
-  object(classWithoutToString)#2 (0) {
-  }
   ["undefined var"]=>
   NULL
   ["float -10.5"]=>

--- a/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
+++ b/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
@@ -76,10 +76,9 @@ $values = array(
 // loop through each element of the array for class
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( get_class_methods($value) );
 };
-
 echo "Done";
 ?>
 --EXPECTF--
@@ -163,9 +162,8 @@ NULL
 
 Arg value string 
 NULL
-Error: 4096 - Object of class stdClass could not be converted to string, %s(76)
 
-Arg value  
+Arg value stdClass 
 array(0) {
 }
 

--- a/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
+++ b/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
@@ -77,7 +77,7 @@ $values = array(
 // loop through each element of the array for object
 
 foreach($values as $value) {
-      echo "\nArg value $value \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
       var_dump( get_parent_class($value) );
 };
 
@@ -166,9 +166,8 @@ bool(false)
 Arg value String 
 In autoload(String)
 bool(false)
-Error: 4096 - Object of class stdClass could not be converted to string, %s(77)
 
-Arg value  
+Arg value stdClass 
 bool(false)
 
 Arg value  

--- a/ext/standard/tests/general_functions/type.phpt
+++ b/ext/standard/tests/general_functions/type.phpt
@@ -47,7 +47,11 @@ foreach ($array as $var) {
 
 foreach ($types as $type) {
 	foreach ($array as $var) {
-		var_dump(settype($var, $type));
+		try {
+			var_dump(settype($var, $type));
+		} catch (Error $e) {
+			echo "Error: ", $e->getMessage(), "\n";
+		}
 		var_dump($var);
 	}
 }
@@ -344,7 +348,6 @@ bool(true)
 string(14) "Resource id #%d"
 bool(true)
 string(14) "Resource id #%d"
-string(57) "Object of class stdClass could not be converted to string"
-bool(true)
-string(6) "Object"
+Error: Object of class stdClass could not be converted to string
+string(0) ""
 Done

--- a/ext/standard/tests/math/base_convert_error.phpt
+++ b/ext/standard/tests/math/base_convert_error.phpt
@@ -22,7 +22,11 @@ base_convert(1234, 1, 10);
 base_convert(1234, 10, 37);
 
 echo "Incorrect input\n";
-base_convert(new classA(), 8, 10);
+try {
+    base_convert(new classA(), 8, 10);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
 --EXPECTF--
@@ -39,5 +43,4 @@ Warning: base_convert(): Invalid `from base' (1) in %s on line %d
 
 Warning: base_convert(): Invalid `to base' (37) in %s on line %d
 Incorrect input
-
-Recoverable fatal error: Object of class classA could not be converted to string in %s on line %d
+Object of class classA could not be converted to string

--- a/ext/standard/tests/streams/bug61115.phpt
+++ b/ext/standard/tests/streams/bug61115.phpt
@@ -7,7 +7,11 @@ $arrayLarge = array_fill(0, 113663, '*');
 
 $resourceFileTemp = fopen('php://temp', 'r+');
 stream_context_set_params($resourceFileTemp, array());
-preg_replace('', function() {}, $resourceFileTemp);
+try {
+    preg_replace('', function() {}, $resourceFileTemp);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECTF--
-Recoverable fatal error: Object of class Closure could not be converted to string in %s on line %d
+Object of class Closure could not be converted to string

--- a/ext/standard/tests/strings/strval_error.phpt
+++ b/ext/standard/tests/strings/strval_error.phpt
@@ -29,7 +29,11 @@ var_dump( strval() );
 
 // Testing strval with a object which has no toString() method
 echo "\n-- Testing strval() function with object which has not toString() method  --\n";
-var_dump( strval(new MyClass()) );
+try {
+    var_dump( strval(new MyClass()) );
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
 ===DONE===
@@ -47,5 +51,5 @@ Warning: strval() expects exactly 1 parameter, 0 given in %s on line %d
 NULL
 
 -- Testing strval() function with object which has not toString() method  --
-
-Recoverable fatal error: Object of class MyClass could not be converted to string in %s on line %d
+Object of class MyClass could not be converted to string
+===DONE===

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1222,6 +1222,13 @@ PHP_FUNCTION(unserialize)
 				zend_hash_add_empty_element(class_hash, lcname);
 		        zend_string_release_ex(lcname, 0);
 			} ZEND_HASH_FOREACH_END();
+
+			/* Exception during string conversion. */
+			if (EG(exception)) {
+				zend_hash_destroy(class_hash);
+				FREE_HASHTABLE(class_hash);
+				PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
+			}
 		}
 		php_var_unserialize_set_allowed_classes(var_hash, class_hash);
 	}

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1629,8 +1629,7 @@ PHP_FUNCTION(xml_parser_set_option)
 			break;
 		case PHP_XML_OPTION_TARGET_ENCODING: {
 			const xml_encoding *enc;
-			convert_to_string_ex(val);
-			if (EG(exception)) {
+			if (!try_convert_to_string(val)) {
 				return;
 			}
 

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1630,6 +1630,10 @@ PHP_FUNCTION(xml_parser_set_option)
 		case PHP_XML_OPTION_TARGET_ENCODING: {
 			const xml_encoding *enc;
 			convert_to_string_ex(val);
+			if (EG(exception)) {
+				return;
+			}
+
 			enc = xml_get_encoding((XML_Char*)Z_STRVAL_P(val));
 			if (enc == NULL) {
 				php_error_docref(NULL, E_WARNING, "Unsupported target encoding \"%s\"", Z_STRVAL_P(val));

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -124,6 +124,9 @@ zval *xmlreader_get_property_ptr_ptr(zval *object, zval *member, int type, void 
  	if (Z_TYPE_P(member) != IS_STRING) {
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
+		if (EG(exception)) {
+			return NULL;
+		}
 	}
 
 	obj = Z_XMLREADER_P(object);
@@ -155,6 +158,9 @@ zval *xmlreader_read_property(zval *object, zval *member, int type, void **cache
  	if (Z_TYPE_P(member) != IS_STRING) {
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
+		if (EG(exception)) {
+			return &EG(uninitialized_zval);
+		}
 	}
 
 	obj = Z_XMLREADER_P(object);
@@ -190,6 +196,9 @@ zval *xmlreader_write_property(zval *object, zval *member, zval *value, void **c
  	if (Z_TYPE_P(member) != IS_STRING) {
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
+		if (EG(exception)) {
+			return value;
+		}
 	}
 
 	obj = Z_XMLREADER_P(object);

--- a/ext/xmlrpc/xmlrpc-epi-php.c
+++ b/ext/xmlrpc/xmlrpc-epi-php.c
@@ -523,6 +523,9 @@ static XMLRPC_VALUE PHP_to_XMLRPC_worker (const char* key, zval* in_val, int dep
 					break;
 				case xmlrpc_datetime:
 					convert_to_string(&val);
+					if (EG(exception)) {
+						return NULL;
+					}
 					xReturn = XMLRPC_CreateValueDateTime_ISO8601(key, Z_STRVAL(val));
 					break;
 				case xmlrpc_boolean:
@@ -539,6 +542,9 @@ static XMLRPC_VALUE PHP_to_XMLRPC_worker (const char* key, zval* in_val, int dep
 					break;
 				case xmlrpc_string:
 					convert_to_string(&val);
+					if (EG(exception)) {
+						return NULL;
+					}
 					xReturn = XMLRPC_CreateValueString(key, Z_STRVAL(val), Z_STRLEN(val));
 					break;
 				case xmlrpc_vector:
@@ -926,6 +932,10 @@ static void php_xmlrpc_introspection_callback(XMLRPC_SERVER server, void* data) 
 
 				/* return value should be a string */
 				convert_to_string(&retval);
+				if (EG(exception)) {
+					zend_string_release_ex(php_function_name, 0);
+					break;
+				}
 
 				xData = XMLRPC_IntrospectionCreateDescription(Z_STRVAL(retval), &err);
 

--- a/ext/xmlrpc/xmlrpc-epi-php.c
+++ b/ext/xmlrpc/xmlrpc-epi-php.c
@@ -522,8 +522,7 @@ static XMLRPC_VALUE PHP_to_XMLRPC_worker (const char* key, zval* in_val, int dep
 					}
 					break;
 				case xmlrpc_datetime:
-					convert_to_string(&val);
-					if (EG(exception)) {
+					if (!try_convert_to_string(&val)) {
 						return NULL;
 					}
 					xReturn = XMLRPC_CreateValueDateTime_ISO8601(key, Z_STRVAL(val));
@@ -541,8 +540,7 @@ static XMLRPC_VALUE PHP_to_XMLRPC_worker (const char* key, zval* in_val, int dep
 					xReturn = XMLRPC_CreateValueDouble(key, Z_DVAL(val));
 					break;
 				case xmlrpc_string:
-					convert_to_string(&val);
-					if (EG(exception)) {
+					if (!try_convert_to_string(&val)) {
 						return NULL;
 					}
 					xReturn = XMLRPC_CreateValueString(key, Z_STRVAL(val), Z_STRLEN(val));
@@ -931,8 +929,7 @@ static void php_xmlrpc_introspection_callback(XMLRPC_SERVER server, void* data) 
 				STRUCT_XMLRPC_ERROR err = {0};
 
 				/* return value should be a string */
-				convert_to_string(&retval);
-				if (EG(exception)) {
+				if (!try_convert_to_string(&retval)) {
 					zend_string_release_ex(php_function_name, 0);
 					break;
 				}

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -151,6 +151,10 @@ static char **php_xsl_xslt_make_params(HashTable *parht, int xpath_params)
 		} else {
 			if (Z_TYPE_P(value) != IS_STRING) {
 				convert_to_string(value);
+				if (EG(exception)) {
+					efree(params);
+					return NULL;
+				}
 			}
 
 			if (!xpath_params) {
@@ -758,6 +762,9 @@ PHP_FUNCTION(xsl_xsltprocessor_set_parameter)
 				RETURN_FALSE;
 			}
 			convert_to_string_ex(entry);
+			if (EG(exception)) {
+				return;
+			}
 			Z_TRY_ADDREF_P(entry);
 			zend_hash_update(intern->parameter, string_key, entry);
 		} ZEND_HASH_FOREACH_END();
@@ -842,7 +849,10 @@ PHP_FUNCTION(xsl_xsltprocessor_register_php_functions)
 
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(array_value), entry) {
 			convert_to_string_ex(entry);
-			ZVAL_LONG(&new_string ,1);
+			if (EG(exception)) {
+				return;
+			}
+			ZVAL_LONG(&new_string, 1);
 			zend_hash_update(intern->registered_phpfunctions, Z_STR_P(entry), &new_string);
 		} ZEND_HASH_FOREACH_END();
 

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -150,8 +150,7 @@ static char **php_xsl_xslt_make_params(HashTable *parht, int xpath_params)
 			return NULL;
 		} else {
 			if (Z_TYPE_P(value) != IS_STRING) {
-				convert_to_string(value);
-				if (EG(exception)) {
+				if (!try_convert_to_string(value)) {
 					efree(params);
 					return NULL;
 				}
@@ -757,16 +756,16 @@ PHP_FUNCTION(xsl_xsltprocessor_set_parameter)
 	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "sa", &namespace, &namespace_len, &array_value) == SUCCESS) {
 		intern = Z_XSL_P(id);
 		ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(array_value), string_key, entry) {
+			zval tmp;
 			if (string_key == NULL) {
 				php_error_docref(NULL, E_WARNING, "Invalid parameter array");
 				RETURN_FALSE;
 			}
-			convert_to_string_ex(entry);
+			ZVAL_STR(&tmp, zval_get_string(entry));
 			if (EG(exception)) {
 				return;
 			}
-			Z_TRY_ADDREF_P(entry);
-			zend_hash_update(intern->parameter, string_key, entry);
+			zend_hash_update(intern->parameter, string_key, &tmp);
 		} ZEND_HASH_FOREACH_END();
 		RETURN_TRUE;
 	} else if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "sSS", &namespace, &namespace_len, &name, &value) == SUCCESS) {
@@ -848,12 +847,13 @@ PHP_FUNCTION(xsl_xsltprocessor_register_php_functions)
 		intern = Z_XSL_P(id);
 
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(array_value), entry) {
-			convert_to_string_ex(entry);
+			zend_string *str = zval_get_string(entry);
 			if (EG(exception)) {
 				return;
 			}
 			ZVAL_LONG(&new_string, 1);
-			zend_hash_update(intern->registered_phpfunctions, Z_STR_P(entry), &new_string);
+			zend_hash_update(intern->registered_phpfunctions, str, &new_string);
+			zend_string_release(str);
 		} ZEND_HASH_FOREACH_END();
 
 		intern->registerPhpFunctions = 2;

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -876,6 +876,9 @@ static zval *php_zip_get_property_ptr_ptr(zval *object, zval *member, int type, 
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
 		cache_slot = NULL;
+		if (EG(exception)) {
+			return NULL;
+		}
 	}
 
 	obj = Z_ZIP_P(object);
@@ -907,6 +910,9 @@ static zval *php_zip_read_property(zval *object, zval *member, int type, void **
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
 		cache_slot = NULL;
+		if (EG(exception)) {
+			return &EG(uninitialized_zval);
+		}
 	}
 
 	obj = Z_ZIP_P(object);
@@ -943,6 +949,9 @@ static int php_zip_has_property(zval *object, zval *member, int type, void **cac
 		ZVAL_STR(&tmp_member, zval_get_string_func(member));
 		member = &tmp_member;
 		cache_slot = NULL;
+		if (EG(exception)) {
+			return 0;
+		}
 	}
 
 	obj = Z_ZIP_P(object);

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -777,7 +777,7 @@ static zend_bool zlib_create_dictionary_string(HashTable *options, char **dict, 
 						size_t i;
 
 						*++ptr = zval_get_string(cur);
-						if (!*ptr || ZSTR_LEN(*ptr) == 0) {
+						if (!*ptr || ZSTR_LEN(*ptr) == 0 || EG(exception)) {
 							if (*ptr) {
 								efree(*ptr);
 							}
@@ -785,7 +785,9 @@ static zend_bool zlib_create_dictionary_string(HashTable *options, char **dict, 
 								efree(ptr);
 							}
 							efree(strings);
-							php_error_docref(NULL, E_WARNING, "dictionary entries must be non-empty strings");
+							if (!EG(exception)) {
+								php_error_docref(NULL, E_WARNING, "dictionary entries must be non-empty strings");
+							}
 							return 0;
 						}
 						for (i = 0; i < ZSTR_LEN(*ptr); i++) {

--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -670,6 +670,10 @@ static size_t php_userstreamop_read(php_stream *stream, char *buf, size_t count)
 
 	if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
 		convert_to_string(&retval);
+		if (EG(exception)) {
+			return -1;
+		}
+
 		didread = Z_STRLEN(retval);
 		if (didread > count) {
 			php_error_docref(NULL, E_WARNING, "%s::" USERSTREAM_READ " - read " ZEND_LONG_FMT " bytes more data than requested (" ZEND_LONG_FMT " read, " ZEND_LONG_FMT " max) - excess data will be lost",

--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -669,8 +669,7 @@ static size_t php_userstreamop_read(php_stream *stream, char *buf, size_t count)
 	}
 
 	if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
-		convert_to_string(&retval);
-		if (EG(exception)) {
+		if (!try_convert_to_string(&retval)) {
 			return -1;
 		}
 

--- a/tests/classes/tostring_001.phpt
+++ b/tests/classes/tostring_001.phpt
@@ -3,12 +3,6 @@ ZE2 __toString()
 --FILE--
 <?php
 
-function my_error_handler($errno, $errstr, $errfile, $errline) {
-	var_dump($errstr);
-}
-
-set_error_handler('my_error_handler');
-
 class test1
 {
 }
@@ -33,7 +27,11 @@ class test3
 echo "====test1====\n";
 $o = new test1;
 print_r($o);
-var_dump((string)$o);
+try {
+    var_dump((string)$o);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 var_dump($o);
 
 echo "====test2====\n";
@@ -70,7 +68,11 @@ echo sprintf("%s", $o);
 echo "====test10====\n";
 $o = new test3;
 var_dump($o);
-echo $o;
+try {
+    echo $o;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
 ====DONE====
@@ -79,9 +81,8 @@ echo $o;
 test1 Object
 (
 )
-string(54) "Object of class test1 could not be converted to string"
-string(0) ""
-object(test1)#%d (0) {
+Object of class test1 could not be converted to string
+object(test1)#1 (0) {
 }
 ====test2====
 test2 Object
@@ -89,7 +90,7 @@ test2 Object
 )
 test2::__toString()
 Converted
-object(test2)#%d (0) {
+object(test2)#3 (0) {
 }
 ====test3====
 test2::__toString()
@@ -113,7 +114,8 @@ test2::__toString()
 Converted
 ====test7====
 test2::__toString()
-string(19) "Illegal offset type"
+
+Warning: Illegal offset type in %s on line %d
 ====test8====
 test2::__toString()
 string(9) "Converted"
@@ -123,8 +125,8 @@ string(9) "Converted"
 test2::__toString()
 Converted
 ====test10====
-object(test3)#%d (0) {
+object(test3)#1 (0) {
 }
 test3::__toString()
-string(53) "Method test3::__toString() must return a string value"
+Method test3::__toString() must return a string value
 ====DONE====

--- a/tests/classes/tostring_003.phpt
+++ b/tests/classes/tostring_003.phpt
@@ -29,5 +29,6 @@ catch(Exception $e)
 
 ?>
 ====DONE====
---EXPECTF--
-Fatal error: Method Test::__toString() must not throw an exception, caught Exception: Damn! in %stostring_003.php on line %d
+--EXPECT--
+string(5) "Damn!"
+====DONE====

--- a/tests/classes/tostring_004.phpt
+++ b/tests/classes/tostring_004.phpt
@@ -12,12 +12,19 @@ error_reporting(8191);
 echo "Object with no __toString():\n";
 $obj = new stdClass;
 echo "Try 1:\n";
-printf($obj);
+try {
+    printf($obj);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 printf("\n");
 
 echo "\nTry 2:\n";
-printf($obj . "\n");
-
+try {
+    printf($obj . "\n");
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 echo "\n\nObject with bad __toString():\n";
 class badToString {
@@ -25,30 +32,38 @@ class badToString {
 		return 0;
 	}
 }
+
 $obj = new badToString;
 echo "Try 1:\n";
-printf($obj);
+try {
+    printf($obj);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 printf("\n");
 
 echo "\nTry 2:\n";
-printf($obj . "\n");
+try {
+    printf($obj . "\n");
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
 --EXPECT--
 Object with no __toString():
 Try 1:
-Error: 4096 - Object of class stdClass could not be converted to string
-Object
+Object of class stdClass could not be converted to string
+
 
 Try 2:
-Error: 4096 - Object of class stdClass could not be converted to string
-
+Object of class stdClass could not be converted to string
 
 
 Object with bad __toString():
 Try 1:
-Error: 4096 - Method badToString::__toString() must return a string value
+Method badToString::__toString() must return a string value
 
 
 Try 2:
-Error: 4096 - Method badToString::__toString() must return a string value
+Method badToString::__toString() must return a string value

--- a/win32/codepage.c
+++ b/win32/codepage.c
@@ -657,8 +657,7 @@ PHP_FUNCTION(sapi_windows_cp_conv)
 			RETURN_NULL();
 		}
 	} else {
-		convert_to_string(z_in_cp);
-		if (EG(exception)) {
+		if (!try_convert_to_string(z_in_cp)) {
 			return;
 		}
 
@@ -681,8 +680,7 @@ PHP_FUNCTION(sapi_windows_cp_conv)
 			RETURN_NULL();
 		}
 	} else {
-		convert_to_string(z_out_cp);
-		if (EG(exception)) {
+		if (!try_convert_to_string(z_out_cp)) {
 			return;
 		}
 

--- a/win32/codepage.c
+++ b/win32/codepage.c
@@ -658,6 +658,9 @@ PHP_FUNCTION(sapi_windows_cp_conv)
 		}
 	} else {
 		convert_to_string(z_in_cp);
+		if (EG(exception)) {
+			return;
+		}
 
 		in_cp = php_win32_cp_get_by_enc(Z_STRVAL_P(z_in_cp));
 		if (!in_cp) {
@@ -679,6 +682,9 @@ PHP_FUNCTION(sapi_windows_cp_conv)
 		}
 	} else {
 		convert_to_string(z_out_cp);
+		if (EG(exception)) {
+			return;
+		}
 
 		out_cp = php_win32_cp_get_by_enc(Z_STRVAL_P(z_out_cp));
 		if (!out_cp) {


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/tostring_exceptions

Also convert existing recoverable errors for object to string conversions into proper Error exceptions.

Uses of zval_get_string and convert_to_string in the codebase are reviewed and exception checks are added. While at it I have also fixed many issues relating to in-place modification of non-owned arrays.