### PR TITLE
Remove ZEND_FP_EXCEPT macro and HAVE_FP_EXCEPT

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -83,8 +83,6 @@ AC_CHECK_FUNCS(memcpy strdup getpid kill strtod strtol finite fpclass sigsetjmp)
 
 AC_CHECK_DECLS([isfinite, isnan, isinf], [], [], [[#include <math.h>]])
 
-ZEND_FP_EXCEPT
-
 ZEND_CHECK_FLOAT_PRECISION
 
 dnl test whether double cast to long preserves least significant bits

--- a/Zend/acinclude.m4
+++ b/Zend/acinclude.m4
@@ -42,22 +42,6 @@ AC_DEFUN([LIBZEND_BISON_CHECK],[
   esac
 ])
 
-AC_DEFUN([ZEND_FP_EXCEPT],[
-  AC_CACHE_CHECK(whether fp_except is defined, ac_cv_type_fp_except,[
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <floatingpoint.h>
-]],[[
-fp_except x = (fp_except) 0;
-]])],[
-     ac_cv_type_fp_except=yes
-],[
-     ac_cv_type_fp_except=no
-])])
-  if test "$ac_cv_type_fp_except" = "yes"; then
-    AC_DEFINE(HAVE_FP_EXCEPT, 1, [whether floatingpoint.h defines fp_except])
-  fi
-])
-
 dnl x87 floating point internal precision control checks
 dnl See: http://wiki.php.net/rfc/rounding
 AC_DEFUN([ZEND_CHECK_FLOAT_PRECISION],[


### PR DESCRIPTION
Usage of the HAVE_FP_EXCEPT symbol has been removed via c3340584128a9c8b75e2c1aa5630911ad2dc9b9f and isn't used in current code anymore.