### PR TITLE
Remove not needed PHP_PDO_PEAR_CHECK m4 macro

### DIFF
--- a/ext/pdo/config.m4
+++ b/ext/pdo/config.m4
@@ -1,30 +1,5 @@
 dnl config.m4 for extension pdo
 
-AC_DEFUN([PHP_PDO_PEAR_CHECK],[
-  pdo_running_under_pear=0
-  case `pwd` in
-    /var/tmp/pear-build-*)
-      pdo_running_under_pear=1
-      ;;
-  esac
-
-  if test "$pdo_running_under_pear$PHP_PEAR_VERSION" = "1"; then
-    # we're running in an environment that smells like pear,
-    # and the PHP_PEAR_VERSION env var is not set.  That implies
-    # that we're running under a slightly broken pear installer
-    AC_MSG_ERROR([
-PDO requires that you upgrade your PEAR installer tools. Please
-do so now by running:
-
-  % sudo pear upgrade pear
-
-or by manually downloading and installing PEAR version 1.3.5 or higher.
-
-Once you've upgraded, please re-try your PDO install.
-    ])
-  fi
-])
-
 PHP_ARG_ENABLE(pdo, whether to enable PDO support,
 [  --disable-pdo           Disable PHP Data Objects support], yes)
 
@@ -32,8 +7,6 @@ if test "$PHP_PDO" != "no"; then
 
   dnl Make sure $PHP_PDO is 'yes' when it's not 'no' :)
   PHP_PDO=yes
-
-  PHP_PDO_PEAR_CHECK
 
   PHP_NEW_EXTENSION(pdo, pdo.c pdo_dbh.c pdo_stmt.c pdo_sql_parser.c pdo_sqlstate.c, $ext_shared)
   ifdef([PHP_ADD_EXTENSION_DEP],


### PR DESCRIPTION
Checking for a PEAR version here is not needed. The PDO extension also doesn't have release cycle outside of PHP releases and is set to PHP_VERSION. So this patch simply omits this check.

Ref: 
* https://pecl.php.net/package/PDO