### PR TITLE
Fix shared module generation on AIX bug #77676

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -839,8 +839,8 @@ AC_DEFUN([PHP_SHARED_MODULE],[
 
   case $host_alias in
     *aix*[)]
-      suffix=so
-      link_cmd='$(LIBTOOL) --mode=link ifelse($4,,[$(CC)],[$(CXX)]) $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) $(LDFLAGS) -Wl,-G -o '$3'/$1.la -export-dynamic -avoid-version -prefer-pic -module -rpath $(phplibdir) $(EXTRA_LDFLAGS) $($2) $(translit($1,a-z_-,A-Z__)_SHARED_LIBADD) && mv -f '$3'/.libs/$1.so '$3'/$1.so'
+      suffix=la
+      link_cmd='$(LIBTOOL) --mode=link ifelse($4,,[$(CC)],[$(CXX)]) $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) $(LDFLAGS) -Wl,-G -o '$3'/$1.la -export-dynamic -avoid-version -prefer-pic -module -rpath $(phplibdir) $(EXTRA_LDFLAGS) $($2) $(translit($1,a-z_-,A-Z__)_SHARED_LIBADD)'
       ;;
     *[)]
       suffix=la


### PR DESCRIPTION
Makefiles for PHP extensions generated by phpize expect the PHP_MODULES to contain a list of libtool .la files so that it can read the $dlname variable from them by sourcing them in to a shell. On AIX, the code was setting PHP_MODULES to a list of .so files, which meant the dlname was blank, preventing the tests from being able to run.

Change the AIX code path in the PHP_SHARED_MODULE macro to match the output on other platforms, using libtool .la files.