### PR TITLE
Fix bug #77677: WCOREDUMP not available on all systems

### DIFF
--- a/sapi/fpm/fpm/fpm_children.c
+++ b/sapi/fpm/fpm/fpm_children.c
@@ -204,7 +204,11 @@ void fpm_children_bury() /* {{{ */
 
 		} else if (WIFSIGNALED(status)) {
 			const char *signame = fpm_signal_names[WTERMSIG(status)];
+#ifdef WCOREDUMP
 			const char *have_core = WCOREDUMP(status) ? " - core dumped" : "";
+#else
+			const char* have_core = "";
+#endif
 
 			if (signame == NULL) {
 				signame = "";

--- a/sapi/litespeed/lsapilib.c
+++ b/sapi/litespeed/lsapilib.c
@@ -2821,12 +2821,12 @@ static void lsapi_sigchild( int signal )
             int sig_num = WTERMSIG( status );
 
 #ifdef WCOREDUMP
-            int dump = WCOREDUMP( status );
+            const char * dump = WCOREDUMP( status ) ? "yes" : "no";
 #else
-            int dump = -1;
+            const char * dump = "unknown";
 #endif
             lsapi_log("Child process with pid: %d was killed by signal: "
-                     "%d, core dump: %d\n", pid, sig_num, dump );
+                     "%d, core dump: %s\n", pid, sig_num, dump );
         }
         if ( pid == s_pid_dump_debug_info )
         {

--- a/sapi/litespeed/lsapilib.c
+++ b/sapi/litespeed/lsapilib.c
@@ -2819,7 +2819,12 @@ static void lsapi_sigchild( int signal )
         if ( WIFSIGNALED( status ))
         {
             int sig_num = WTERMSIG( status );
+
+#ifdef WCOREDUMP
             int dump = WCOREDUMP( status );
+#else
+            int dump = -1;
+#endif
             lsapi_log("Child process with pid: %d was killed by signal: "
                      "%d, core dump: %d\n", pid, sig_num, dump );
         }


### PR DESCRIPTION
Add `#ifdef WCOREDUMP` around all uses