### PR TITLE
Add new core INI setting "error_date_format" to customize date format

### DIFF
--- a/ext/standard/tests/general_functions/error_log_format.phpt
+++ b/ext/standard/tests/general_functions/error_log_format.phpt
@@ -1,0 +1,16 @@
+--TEST--
+error_date_format ini variable
+--INI--
+error_date_format=d.m.Y
+log_errors=On
+--FILE--
+<?php
+
+$dir = dirname(__FILE__);
+$log = $dir . "/tmp.err";
+ini_set("error_log", $log);
+error_log("dummy");
+readfile($log);
+unlink($log);
+--EXPECTF--
+[%d.%d.%d] dummy

--- a/main/main.c
+++ b/main/main.c
@@ -747,6 +747,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("input_encoding",			NULL,			PHP_INI_ALL,	OnUpdateInputEncoding,				input_encoding,		php_core_globals, core_globals)
 	STD_PHP_INI_ENTRY("output_encoding",		NULL,			PHP_INI_ALL,	OnUpdateOutputEncoding,				output_encoding,	php_core_globals, core_globals)
 	STD_PHP_INI_ENTRY("error_log",				NULL,		PHP_INI_ALL,		OnUpdateErrorLog,			error_log,				php_core_globals,	core_globals)
+	STD_PHP_INI_ENTRY("error_date_format",		"d-M-Y H:i:s e",		PHP_INI_ALL,		OnUpdateStringUnempty,			error_date_format,				php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("extension_dir",			PHP_EXTENSION_DIR,		PHP_INI_SYSTEM,		OnUpdateStringUnempty,	extension_dir,			php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("sys_temp_dir",			NULL,		PHP_INI_SYSTEM,		OnUpdateStringUnempty,	sys_temp_dir,			php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("include_path",			PHP_INCLUDE_PATH,		PHP_INI_ALL,		OnUpdateStringUnempty,	include_path,			php_core_globals,	core_globals)
@@ -858,13 +859,14 @@ PHPAPI ZEND_COLD void php_log_err_with_severity(char *log_message, int syslog_ty
 
 			time(&error_time);
 #ifdef ZTS
+
 			if (!php_during_module_startup()) {
-				error_time_str = php_format_date("d-M-Y H:i:s e", 13, error_time, 1);
+				error_time_str = php_format_date(PG(error_date_format), strlen(PG(error_date_format)), error_time, 1);
 			} else {
-				error_time_str = php_format_date("d-M-Y H:i:s e", 13, error_time, 0);
+				error_time_str = php_format_date(PG(error_date_format), strlen(PG(error_date_format)), error_time, 0);
 			}
 #else
-			error_time_str = php_format_date("d-M-Y H:i:s e", 13, error_time, 1);
+			error_time_str = php_format_date(PG(error_date_format), strlen(PG(error_date_format)), error_time, 1);
 #endif
 			len = spprintf(&tmp, 0, "[%s] %s%s", ZSTR_VAL(error_time_str), log_message, PHP_EOL);
 #ifdef PHP_WIN32

--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -75,6 +75,7 @@ struct _php_core_globals {
 	zend_bool ignore_repeated_source;
 	zend_bool report_memleaks;
 	char *error_log;
+	char *error_date_format;
 
 	char *doc_root;
 	char *user_dir;

--- a/php.ini-development
+++ b/php.ini-development
@@ -580,6 +580,11 @@ html_errors = On
 ; Log errors to syslog (Event Log on Windows).
 ;error_log = syslog
 
+; Date Format that is used to timestamp log messages in error_log
+; This value defaults to 'd-M-Y H:i:s e'
+; Example:
+;error_date_format = "Y-m-d H:i:s"
+
 ; The syslog ident is a string which is prepended to every message logged
 ; to syslog. Only used when error_log is set to syslog.
 ;syslog.ident = php

--- a/php.ini-production
+++ b/php.ini-production
@@ -587,6 +587,11 @@ html_errors = On
 ; Log errors to syslog (Event Log on Windows).
 ;error_log = syslog
 
+; Date Format that is used to timestamp log messages in error_log
+; This value defaults to 'd-M-Y H:i:s e'
+; Example:
+;error_date_format = "Y-m-d H:i:s"
+
 ; The syslog ident is a string which is prepended to every message logged
 ; to syslog. Only used when error_log is set to syslog.
 ;syslog.ident = php


### PR DESCRIPTION
Inspired by https://bugs.php.net/bug.php?id=77667 added the possibility to format the date that is displayed before error_log entries.

```
error_date_format=d.m.Y
```
Questions:
- Is the test in the right location? I couldn't find any tests that are specifically for `error_log` ini configuration.
- Is the ini setting named good?
- I don't allow an empty `error_date_format` for now, which we could use to not render the whole `[date]` block in the line, is that something desirable?