### PR TITLE
curl_error: return an empty string if no error occurred

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -3429,8 +3429,12 @@ PHP_FUNCTION(curl_error)
 		RETURN_FALSE;
 	}
 
-	ch->err.str[CURL_ERROR_SIZE] = 0;
-	RETURN_STRING(ch->err.str);
+	if (ch->err.no) {
+		ch->err.str[CURL_ERROR_SIZE] = 0;
+		RETURN_STRING(ch->err.str);
+	} else {
+		RETURN_STRING("");
+	}
 }
 /* }}} */
 


### PR DESCRIPTION
CURLOPT_ERRORBUFFER doc says "Do not rely on the contents of the
buffer unless an error code was returned." [1]

Prior to this change the error buffer was returned even if no error had
occurred, and that buffer may contain incorrect information in such a
case. [2]

[1]: https://curl.haxx.se/libcurl/c/CURLOPT_ERRORBUFFER.html
[2]: https://github.com/curl/curl/issues/3629

Closes #xxxx

---

Also I noticed a comment _"CURLE_PARTIAL_FILE is returned by HEAD requests"_. I don't see that happening unless HEAD was sent as a CURLOPT_CUSTOMREQUEST... The right way is CURLOPT_NOBODY, also see https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/

https://github.com/php/php-src/blob/54ef8d13d8c91f2bdd3c9a65871918efad370571/ext/curl/interface.c#L3114-L3120

/cc @bagder @Schnitzel
