### PR TITLE
Remove LIBZEND_CHECK_INT_TYPE and PHP_CHECK_TYPES

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -2,28 +2,6 @@ dnl
 dnl This file contains Zend specific autoconf functions.
 dnl
 
-AC_DEFUN([LIBZEND_CHECK_INT_TYPE],[
-AC_MSG_CHECKING(for $1)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#if HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-#if HAVE_INTTYPES_H
-#include <inttypes.h>
-#elif HAVE_STDINT_H
-#include <stdint.h>
-#endif]],
-[[if (($1 *) 0)
-  return 0;
-if (sizeof ($1))
-  return 0;
-]])],[
-  AC_DEFINE_UNQUOTED([HAVE_]translit($1,a-z_-,A-Z__), 1,[Define if $1 type is present. ])
-  AC_MSG_RESULT(yes)
-], [AC_MSG_RESULT(no)
-])dnl
-])
-
 AC_DEFUN([LIBZEND_BASIC_CHECKS],[
 
 AC_REQUIRE([AC_PROG_YACC])
@@ -71,10 +49,6 @@ _LT_AC_TRY_DLOPEN_SELF([
 dnl This is required for QNX and may be some BSD derived systems
 AC_CHECK_TYPE( uint, unsigned int )
 AC_CHECK_TYPE( ulong, unsigned long )
-
-dnl Check if int32_t and uint32_t are defined
-LIBZEND_CHECK_INT_TYPE(int32_t)
-LIBZEND_CHECK_INT_TYPE(uint32_t)
 
 dnl Checks for library functions.
 AC_FUNC_ALLOCA

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1014,12 +1014,6 @@ dnl -------------------------------------------------------------------------
 
 dnl Internal helper macros
 dnl
-dnl _PHP_DEF_HAVE_FILE(what, filename)
-AC_DEFUN([_PHP_DEF_HAVE_FILE], [
-  php_def_have_what=HAVE_[]`echo $1 | tr 'abcdefghijklmnopqrstuvwxyz-' 'ABCDEFGHIJKLMNOPQRSTUVWXYZ_' `
-  echo "#define $php_def_have_what 1" >> $2
-])
-dnl
 dnl _PHP_CHECK_SIZEOF(type, cross-value, extra-headers [, found-action [, not-found-action]])
 dnl
 AC_DEFUN([_PHP_CHECK_SIZEOF], [
@@ -1073,21 +1067,6 @@ AC_DEFUN([PHP_CHECK_SIZEOF], [
     AC_DEFINE_UNQUOTED([HAVE_]translit($1,a-z,A-Z_), 1, [Whether $1 is available])
   ])
   AC_MSG_RESULT([[$][php_cv_sizeof_]translit($1, ,_)])
-])
-
-dnl
-dnl PHP_CHECK_TYPES(type-list, include-file [, extra-headers])
-dnl
-AC_DEFUN([PHP_CHECK_TYPES], [
-  for php_typename in $1; do
-    AC_MSG_CHECKING([whether $php_typename exists])
-    _PHP_CHECK_SIZEOF($php_typename, 0, $3, [
-      _PHP_DEF_HAVE_FILE($php_typename, $2)
-      AC_MSG_RESULT([yes])
-    ], [
-      AC_MSG_RESULT([no])
-    ])
-  done
 ])
 
 dnl
@@ -2652,7 +2631,6 @@ AC_DEFUN([PHP_CHECK_STDINT_TYPES], [
 # include <sys/types.h>
 #endif
   ])
-  AC_DEFINE([PHP_HAVE_STDINT_TYPES], [1], [Checked for stdint types])
 ])
 
 dnl PHP_CHECK_BUILTIN_EXPECT


### PR DESCRIPTION
Checking for int32_t and uint32_t types is already done by the PHP_CHECK_STDINT_TYPES m4 macro.

The PHP_CHECK_TYPES m4 macro has been once used by the mysqlnd and has been removed via 14caf174ff219376e4f1234bd297ffe973cc416e and additionally, the internal unused macro _PHP_DEF_HAVE_FILE has been removed.

Additionally, the unused PHP_HAVE_STDINT_TYPES symbol has been removed.