### PR TITLE
Remove legacy AC_CHECK_TYPE calls for uint and ulong

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -46,10 +46,6 @@ _LT_AC_TRY_DLOPEN_SELF([
 ], [])
 ])
 
-dnl This is required for QNX and may be some BSD derived systems
-AC_CHECK_TYPE( uint, unsigned int )
-AC_CHECK_TYPE( ulong, unsigned long )
-
 dnl Checks for library functions.
 AC_FUNC_ALLOCA
 AC_CHECK_FUNCS(strdup getpid kill strtod strtol finite fpclass sigsetjmp)

--- a/Zend/zend_config.w32.h
+++ b/Zend/zend_config.w32.h
@@ -38,9 +38,6 @@
 
 #include <float.h>
 
-typedef unsigned long ulong;
-typedef unsigned int uint;
-
 #define HAVE_STDIOSTR_H 1
 #define HAVE_CLASS_ISTDIOSTREAM
 #define istdiostream stdiostream

--- a/configure.ac
+++ b/configure.ac
@@ -31,9 +31,6 @@ AH_TOP([
 #endif
 
 #define ZEND_DLIMPORT
-
-#undef uint
-#undef ulong
 ])
 AH_BOTTOM([
 #ifndef ZEND_ACCONFIG_H_NO_C_PROTOS

--- a/ext/com_dotnet/com_iterator.c
+++ b/ext/com_dotnet/com_iterator.c
@@ -100,18 +100,18 @@ static void com_iter_move_forwards(zend_object_iterator *iter)
 			I->key++;
 		} else {
 			/* indicate that there are no more items */
-			I->key = (ulong)-1;
+			I->key = (zend_ulong)-1;
 			return;
 		}
 	} else {
 		/* safe array */
 		if (I->key >= (ULONG) I->sa_max) {
-			I->key = (ulong)-1;
+			I->key = (zend_ulong)-1;
 			return;
 		}
 		I->key++;
 		if (php_com_safearray_get_elem(&I->safe_array, &I->v, (LONG)I->key) == 0) {
-			I->key = (ulong)-1;
+			I->key = (zend_ulong)-1;
 			return;
 		}
 	}
@@ -193,7 +193,7 @@ zend_object_iterator *php_com_iter_get(zend_class_entry *ce, zval *object, int b
 			php_com_zval_from_variant(&ptr, &I->v, I->code_page);
 			ZVAL_COPY_VALUE(&I->zdata, &ptr);
 		} else {
-			I->key = (ulong)-1;
+			I->key = (zend_ulong)-1;
 		}
 
 	} else {
@@ -228,7 +228,7 @@ zend_object_iterator *php_com_iter_get(zend_class_entry *ce, zval *object, int b
 			ZVAL_COPY_VALUE(&I->zdata, &ptr);
 		} else {
 			/* indicate that there are no more items */
-			I->key = (ulong)-1;
+			I->key = (zend_ulong)-1;
 		}
 	}
 

--- a/ext/com_dotnet/com_wrapper.c
+++ b/ext/com_dotnet/com_wrapper.c
@@ -397,7 +397,7 @@ static HRESULT STDMETHODCALLTYPE disp_getnextdispid(
 	/* [in] */ DISPID id,
 	/* [out] */ DISPID *pid)
 {
-	ulong next = id+1;
+	zend_ulong next = id+1;
 	FETCH_DISP("GetNextDispID");
 
 	while(!zend_hash_index_exists(disp->dispid_to_name, next))

--- a/ext/mysqli/php_mysqli_structs.h
+++ b/ext/mysqli/php_mysqli_structs.h
@@ -54,10 +54,6 @@
 #define WE_HAD_MBSTATE_T
 #endif
 
-#if defined(ulong) && !defined(HAVE_ULONG)
-#define HAVE_ULONG
-#endif
-
 #include <my_global.h>
 
 #if !defined(HAVE_MBRLEN) && defined(WE_HAD_MBRLEN)

--- a/ext/mysqlnd/mysqlnd_charset.c
+++ b/ext/mysqlnd/mysqlnd_charset.c
@@ -819,9 +819,9 @@ PHPAPI zend_ulong mysqlnd_cset_escape_quotes(const MYSQLND_CHARSET * const cset,
 	*newstr = '\0';
 
 	if (escape_overflow) {
-		DBG_RETURN((ulong)~0);
+		DBG_RETURN((zend_ulong)~0);
 	}
-	DBG_RETURN((ulong)(newstr - newstr_s));
+	DBG_RETURN((zend_ulong)(newstr - newstr_s));
 }
 /* }}} */
 
@@ -899,9 +899,9 @@ PHPAPI zend_ulong mysqlnd_cset_escape_slashes(const MYSQLND_CHARSET * const cset
 	*newstr = '\0';
 
 	if (escape_overflow) {
-		DBG_RETURN((ulong)~0);
+		DBG_RETURN((zend_ulong)~0);
 	}
-	DBG_RETURN((ulong)(newstr - newstr_s));
+	DBG_RETURN((zend_ulong)(newstr - newstr_s));
 }
 /* }}} */
 

--- a/ext/mysqlnd/mysqlnd_portability.h
+++ b/ext/mysqlnd/mysqlnd_portability.h
@@ -49,13 +49,7 @@ This file is public domain and comes with NO WARRANTY of any kind */
 #define _LONG_LONG 1        /* For AIX string library */
 #endif
 
-
 /* Go around some bugs in different OS and compilers */
-#if defined(_HPUX_SOURCE) && defined(HAVE_SYS_STREAM_H)
-#include <sys/stream.h>        /* HPUX 10.20 defines ulong here. UGLY !!! */
-#define HAVE_ULONG
-#endif
-
 
 #if SIZEOF_LONG_LONG > 4
 #define HAVE_LONG_LONG 1

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -231,7 +231,7 @@ typedef struct st_mysqlnd_session_options
 
 	char 		*charset_name;
 	/* maximum allowed packet size for communication */
-	size_t		max_allowed_packet;
+	unsigned int		max_allowed_packet;
 
 #ifdef MYSQLND_STRING_TO_INT_CONVERSION
 	zend_bool	int_and_float_native;

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -206,7 +206,7 @@ typedef struct st_mysqlnd_infile
 
 typedef struct st_mysqlnd_session_options
 {
-	ulong		flags;
+	zend_ulong		flags;
 
 	/* init commands - we need to send them to server directly after connect */
 	unsigned int	num_commands;
@@ -231,7 +231,7 @@ typedef struct st_mysqlnd_session_options
 
 	char 		*charset_name;
 	/* maximum allowed packet size for communication */
-	ulong		max_allowed_packet;
+	zend_ulong		max_allowed_packet;
 
 #ifdef MYSQLND_STRING_TO_INT_CONVERSION
 	zend_bool	int_and_float_native;

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -206,7 +206,7 @@ typedef struct st_mysqlnd_infile
 
 typedef struct st_mysqlnd_session_options
 {
-	zend_ulong		flags;
+	unsigned int		flags;
 
 	/* init commands - we need to send them to server directly after connect */
 	unsigned int	num_commands;
@@ -231,7 +231,7 @@ typedef struct st_mysqlnd_session_options
 
 	char 		*charset_name;
 	/* maximum allowed packet size for communication */
-	zend_ulong		max_allowed_packet;
+	size_t		max_allowed_packet;
 
 #ifdef MYSQLND_STRING_TO_INT_CONVERSION
 	zend_bool	int_and_float_native;

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -26,7 +26,7 @@
 #include "zend_shared_alloc.h"
 
 #if SIZEOF_SIZE_T <= SIZEOF_ZEND_LONG
-/* If sizeof(void*) == sizeof(ulong) we can use zend_hash index functions */
+/* If sizeof(void*) == sizeof(zend_ulong) we can use zend_hash index functions */
 # define accel_xlat_set(old, new)	zend_hash_index_add_new_ptr(&ZCG(bind_hash), (zend_ulong)(zend_uintptr_t)(old), (new))
 # define accel_xlat_get(old)		zend_hash_index_find_ptr(&ZCG(bind_hash), (zend_ulong)(zend_uintptr_t)(old))
 #else

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2382,7 +2382,7 @@ static void pdo_stmt_iter_get_key(zend_object_iterator *iter, zval *key)
 {
 	struct php_pdo_iterator *I = (struct php_pdo_iterator*)iter;
 
-	if (I->key == (ulong)-1) {
+	if (I->key == (zend_ulong)-1) {
 		ZVAL_NULL(key);
 	} else {
 		ZVAL_LONG(key, I->key);
@@ -2402,7 +2402,7 @@ static void pdo_stmt_iter_move_forwards(zend_object_iterator *iter)
 			PDO_FETCH_ORI_NEXT, 0, 0)) {
 
 		PDO_HANDLE_STMT_ERR();
-		I->key = (ulong)-1;
+		I->key = (zend_ulong)-1;
 		ZVAL_UNDEF(&I->fetch_ahead);
 
 		return;
@@ -2439,7 +2439,7 @@ zend_object_iterator *pdo_stmt_iter_get(zend_class_entry *ce, zval *object, int 
 	if (!do_fetch(stmt, 1, &I->fetch_ahead, PDO_FETCH_USE_DEFAULT,
 			PDO_FETCH_ORI_NEXT, 0, 0)) {
 		PDO_HANDLE_STMT_ERR();
-		I->key = (ulong)-1;
+		I->key = (zend_ulong)-1;
 		ZVAL_UNDEF(&I->fetch_ahead);
 	}
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2864,7 +2864,7 @@ double_str:
 		}
 	} else {
 		zend_long low, high;
-		/* lstep is a ulong so that comparisons to it don't overflow, i.e. low - high < lstep */
+		/* lstep is a zend_ulong so that comparisons to it don't overflow, i.e. low - high < lstep */
 		zend_ulong lstep;
 		uint32_t i, size;
 long_str:

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -695,7 +695,7 @@ static inline void php_url_scanner_session_handler_impl(char *output, size_t out
 
 	if (ZSTR_LEN(url_state->url_app.s) != 0) {
 		*handled_output = url_adapt_ext(output, output_len, &len, (zend_bool) (mode & (PHP_OUTPUT_HANDLER_END | PHP_OUTPUT_HANDLER_CONT | PHP_OUTPUT_HANDLER_FLUSH | PHP_OUTPUT_HANDLER_FINAL) ? 1 : 0), url_state);
-		if (sizeof(uint) < sizeof(size_t)) {
+		if (sizeof(unsigned int) < sizeof(size_t)) {
 			if (len > UINT_MAX)
 				len = UINT_MAX;
 		}

--- a/main/php.h
+++ b/main/php.h
@@ -95,8 +95,6 @@
 typedef int uid_t;
 typedef int gid_t;
 typedef char * caddr_t;
-typedef unsigned int uint;
-typedef unsigned long ulong;
 typedef int pid_t;
 
 # ifndef PHP_DEBUG

--- a/sapi/phpdbg/phpdbg_cmd.c
+++ b/sapi/phpdbg/phpdbg_cmd.c
@@ -573,7 +573,7 @@ PHPDBG_API const phpdbg_command_t *phpdbg_stack_resolve(const phpdbg_command_t *
 	const phpdbg_command_t *command = commands;
 	phpdbg_param_t *name = *top;
 	const phpdbg_command_t *matched[3] = {NULL, NULL, NULL};
-	ulong matches = 0L;
+	zend_ulong matches = 0L;
 
 	while (command && command->name && command->handler) {
 		if (name->len == 1 || command->name_len >= name->len) {


### PR DESCRIPTION
The AC_CHECK_TYPE was refactored in more recent versions of Autoconf
and the call with two arguments is obsolete and not recommended anymore.

This patch also refactors some leftovers of using ulong and uint which
are not standard nor common usages of types in C.

The ulong can be used as zend_ulong and uint usage is actually
`unsigned int`.

The usage of HAVE_ULONG removed since it is not used in current code
base.

Legacy edgecase for some legacy HPUX systems removed:
- sys/stream.h header is not checked and the HAVE_SYS_STREAM_H is
  not defined with current build system.