### PR TITLE
Replace PHP_TM_GMTOFF with AC_CHECK_MEMBERS

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1338,20 +1338,6 @@ int readdir_r(DIR *, struct dirent *);
 ])
 
 dnl
-dnl PHP_TM_GMTOFF
-dnl
-AC_DEFUN([PHP_TM_GMTOFF],[
-AC_CACHE_CHECK([for tm_gmtoff in struct tm], ac_cv_struct_tm_gmtoff,
-[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
-#include <time.h>]], [[struct tm tm; tm.tm_gmtoff;]])],
-  [ac_cv_struct_tm_gmtoff=yes], [ac_cv_struct_tm_gmtoff=no])])
-
-if test "$ac_cv_struct_tm_gmtoff" = yes; then
-  AC_DEFINE(HAVE_TM_GMTOFF,1,[whether you have tm_gmtoff in struct tm])
-fi
-])
-
-dnl
 dnl PHP_STRUCT_FLOCK
 dnl
 AC_DEFUN([PHP_STRUCT_FLOCK],[

--- a/configure.ac
+++ b/configure.ac
@@ -502,8 +502,6 @@ AC_STRUCT_TIMEZONE
 
 PHP_MISSING_TIME_R_DECL
 PHP_MISSING_FCLOSE_DECL
-
-PHP_TM_GMTOFF
 PHP_STRUCT_FLOCK
 PHP_SOCKLEN_T
 
@@ -552,7 +550,8 @@ PHP_CHECK_CPU_SUPPORTS([sse4.2])
 PHP_CHECK_CPU_SUPPORTS([avx])
 PHP_CHECK_CPU_SUPPORTS([avx2])
 
-dnl Check for members of the stat structure
+dnl Check for structure members
+AC_CHECK_MEMBERS([struct tm.tm_gmtoff],,,[#include <time.h>])
 AC_CHECK_MEMBERS([struct stat.st_blksize, struct stat.st_rdev])
 dnl AC_STRUCT_ST_BLOCKS will screw QNX because fileblocks.o does not exist
 dnl The WARNING_LEVEL required because cc in QNX hates -w option without an argument

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1682,20 +1682,20 @@ PHPAPI void php_strftime(INTERNAL_FUNCTION_PARAMETERS, int gmt)
 	ta.tm_yday  = timelib_day_of_year(ts->y, ts->m, ts->d);
 	if (gmt) {
 		ta.tm_isdst = 0;
-#if HAVE_TM_GMTOFF
+#if HAVE_STRUCT_TM_TM_GMTOFF
 		ta.tm_gmtoff = 0;
 #endif
-#if HAVE_TM_ZONE
+#if HAVE_STRUCT_TM_TM_ZONE
 		ta.tm_zone = "GMT";
 #endif
 	} else {
 		offset = timelib_get_time_zone_info(timestamp, tzi);
 
 		ta.tm_isdst = offset->is_dst;
-#if HAVE_TM_GMTOFF
+#if HAVE_STRUCT_TM_TM_GMTOFF
 		ta.tm_gmtoff = offset->offset;
 #endif
-#if HAVE_TM_ZONE
+#if HAVE_STRUCT_TM_TM_ZONE
 		ta.tm_zone = offset->abbr;
 #endif
 	}

--- a/ext/interbase/ibase_query.c
+++ b/ext/interbase/ibase_query.c
@@ -1390,7 +1390,7 @@ format_date_time:
 			   always sets tm_isdst to 0, sometimes incorrectly (InterBase 6 bug?)
 			*/
 			t.tm_isdst = -1;
-#if HAVE_TM_ZONE
+#if HAVE_STRUCT_TM_TM_ZONE
 			t.tm_zone = tzname[0];
 #endif
 			if (flag & PHP_IBASE_UNIXTIME) {

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1022,7 +1022,7 @@ static time_t php_openssl_asn1_time_to_time_t(ASN1_UTCTIME * timestr) /* {{{ */
 	thetime.tm_isdst = -1;
 	ret = mktime(&thetime);
 
-#if HAVE_TM_GMTOFF
+#if HAVE_STRUCT_TM_TM_GMTOFF
 	gmadjust = thetime.tm_gmtoff;
 #else
 	/*
@@ -2265,10 +2265,10 @@ PHP_FUNCTION(openssl_x509_verify)
 	if (key == NULL) {
 		X509_free(cert);
 		RETURN_LONG(err);
-	}	
-	
+	}
+
 	err = X509_verify(cert, key);
-	
+
 	if (err < 0) {
 		php_openssl_store_errors();
 	}
@@ -2279,7 +2279,7 @@ PHP_FUNCTION(openssl_x509_verify)
 	if (Z_TYPE_P(zcert) != IS_RESOURCE) {
 		X509_free(cert);
 	}
-	
+
 	RETURN_LONG(err);
 }
 /* }}} */

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -2857,7 +2857,7 @@ static xmlNodePtr to_xml_datetime_ex(encodeTypePtr type, zval *data, char *forma
 		}
 
 		/* Time zone support */
-#ifdef HAVE_TM_GMTOFF
+#ifdef HAVE_STRUCT_TM_TM_GMTOFF
 		snprintf(tzbuf, sizeof(tzbuf), "%c%02d:%02d", (ta->tm_gmtoff < 0) ? '-' : '+', abs(ta->tm_gmtoff / 3600), abs( (ta->tm_gmtoff % 3600) / 60 ));
 #else
 # if defined(__CYGWIN__) || (defined(PHP_WIN32) && defined(_MSC_VER) && _MSC_VER >= 1900)

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -61,7 +61,6 @@
 #define HAVE_PUTENV 1
 #define HAVE_LIMITS_H 1
 #define HAVE_TZSET 1
-#define HAVE_TZNAME 1
 #undef HAVE_FLOCK
 #define HAVE_ALLOCA 1
 #undef HAVE_SYS_TIME_H


### PR DESCRIPTION
Changes:
- PHP_TM_GMTOFF removed
- HAVE_TM_GMTOFF replaced with HAVE_STRUCT_TM_TM_GMTOFF
- HAVE_TM_ZONE replaced with HAVE_STRUCT_TM_TM_ZONE
- HAVE_TZNAME removed

The PHP_TM_GMTOFF macro can be replaced with Autoconf's AC_CHECK_MEMBERS
that defines the HAVE_STRUCT_TM_TM_GMTOFF symbol instead of the
HAVE_TM_ZONE.

The HAVE_TZNAME symbol is not used in current code. The obsolete
HAVE_TM_ZONE symbol has been replaced with more proper
HAVE_STRUCT_TM_TM_ZONE. These are defined by the AC_STRUCT_TIMEZONE
macro.