### PR TITLE
Add AS_HELP_STRING to *nix build configure options

### DIFF
--- a/README.SELF-CONTAINED-EXTENSIONS
+++ b/README.SELF-CONTAINED-EXTENSIONS
@@ -79,8 +79,10 @@ CREATING THE M4 CONFIGURATION FILE
   macro calls.
 
 ------------------------------------------------------------------------------
-PHP_ARG_ENABLE(foobar,whether to enable foobar,
-[  --enable-foobar            Enable foobar])
+PHP_ARG_ENABLE([foobar],
+  [whether to enable foobar],
+  [AS_HELP_STRING([--enable-foobar],
+    [Enable foobar])])
 
 if test "$PHP_FOOBAR" != "no"; then
   PHP_NEW_EXTENSION(foobar, foo.c bar.c, $ext_shared)

--- a/TSRM/tsrm.m4
+++ b/TSRM/tsrm.m4
@@ -68,27 +68,23 @@ AC_DEFUN([TSRM_THREADS_CHECKS],[
 dnl For the thread implementations, we always use --with-*
 dnl to maintain consistency
 
-AC_ARG_WITH(tsrm-pth,
-[  --with-tsrm-pth[=pth-config]
-                          Use GNU Pth],[
-  TSRM_PTH=$withval
-],[
-  TSRM_PTH=no
-])
+AC_ARG_WITH([tsrm-pth],
+  [AS_HELP_STRING([--with-tsrm-pth[=pth-config]],
+    [Use GNU Pth])],
+  [TSRM_PTH=$withval],
+  [TSRM_PTH=no])
 
-AC_ARG_WITH(tsrm-st,
-[  --with-tsrm-st          Use SGI's State Threads],[
-  TSRM_ST=$withval
-],[
-  TSRM_ST=no
-])
+AC_ARG_WITH([tsrm-st],
+  [AS_HELP_STRING([--with-tsrm-st],
+    [Use SGI's State Threads])],
+  [TSRM_ST=$withval],
+  [TSRM_ST=no])
 
-AC_ARG_WITH(tsrm-pthreads,
-[  --with-tsrm-pthreads    Use POSIX threads (default)],[
-  TSRM_PTHREADS=$withval
-],[
-  TSRM_PTHREADS=yes
-])
+AC_ARG_WITH([tsrm-pthreads],
+  [AS_HELP_STRING([--with-tsrm-pthreads],
+    [Use POSIX threads (default)])],
+  [TSRM_PTHREADS=$withval],
+  [TSRM_PTHREADS=yes])
 
 test "$TSRM_PTH" = "yes" && TSRM_PTH=pth-config
 

--- a/TSRM/tsrm.m4
+++ b/TSRM/tsrm.m4
@@ -69,7 +69,7 @@ dnl For the thread implementations, we always use --with-*
 dnl to maintain consistency
 
 AC_ARG_WITH([tsrm-pth],
-  [AS_HELP_STRING([--with-tsrm-pth[=pth-config]],
+  [AS_HELP_STRING([--with-tsrm-pth@<:@=pth-config@:>@],
     [Use GNU Pth])],
   [TSRM_PTH=$withval],
   [TSRM_PTH=no])

--- a/TSRM/tsrm.m4
+++ b/TSRM/tsrm.m4
@@ -69,7 +69,7 @@ dnl For the thread implementations, we always use --with-*
 dnl to maintain consistency
 
 AC_ARG_WITH([tsrm-pth],
-  [AS_HELP_STRING([--with-tsrm-pth@<:@=pth-config@:>@],
+  [AS_HELP_STRING([[--with-tsrm-pth[=pth-config]]],
     [Use GNU Pth])],
   [TSRM_PTH=$withval],
   [TSRM_PTH=no])

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -198,7 +198,6 @@ AC_MSG_RESULT(done)
 
 AC_CHECK_FUNCS(mremap)
 
-
 AC_ARG_ENABLE([zend-signals],
   [AS_HELP_STRING([--disable-zend-signals],
     [whether to enable zend signal handling])],

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -87,20 +87,17 @@ int main()
 
 AC_DEFUN([LIBZEND_OTHER_CHECKS],[
 
-AC_ARG_ENABLE(maintainer-zts,
-[  --enable-maintainer-zts Enable thread safety - for code maintainers only!!],[
-  ZEND_MAINTAINER_ZTS=$enableval
-],[
-  ZEND_MAINTAINER_ZTS=no
-])
+AC_ARG_ENABLE([maintainer-zts],
+  [AS_HELP_STRING([--enable-maintainer-zts],
+    [Enable thread safety - for code maintainers only!!])],
+  [ZEND_MAINTAINER_ZTS=$enableval],
+  [ZEND_MAINTAINER_ZTS=no])
 
-AC_ARG_ENABLE(inline-optimization,
-[  --disable-inline-optimization
-                          If building zend_execute.lo fails, try this switch],[
-  ZEND_INLINE_OPTIMIZATION=$enableval
-],[
-  ZEND_INLINE_OPTIMIZATION=yes
-])
+AC_ARG_ENABLE([inline-optimization],
+  [AS_HELP_STRING([--disable-inline-optimization],
+    [If building zend_execute.lo fails, try this switch])],
+  [ZEND_INLINE_OPTIMIZATION=$enableval],
+  [ZEND_INLINE_OPTIMIZATION=yes])
 
 AC_MSG_CHECKING(whether to enable thread-safety)
 AC_MSG_RESULT($ZEND_MAINTAINER_ZTS)
@@ -202,12 +199,11 @@ AC_MSG_RESULT(done)
 AC_CHECK_FUNCS(mremap)
 
 
-AC_ARG_ENABLE(zend-signals,
-[  --disable-zend-signals  whether to enable zend signal handling],[
-  ZEND_SIGNALS=$enableval
-],[
-  ZEND_SIGNALS=yes
-])
+AC_ARG_ENABLE([zend-signals],
+  [AS_HELP_STRING([--disable-zend-signals],
+    [whether to enable zend signal handling])],
+  [ZEND_SIGNALS=$enableval],
+  [ZEND_SIGNALS=yes])
 
 AC_CHECK_FUNC(sigaction, [
 	AC_DEFINE(HAVE_SIGACTION, 1, [Whether sigaction() is available])
@@ -240,13 +236,12 @@ else
   AC_MSG_RESULT(no)
 fi
 
-AC_ARG_ENABLE(gcc-global-regs,
-[  --disable-gcc-global-regs
-                          whether to enable GCC global register variables],[
-  ZEND_GCC_GLOBAL_REGS=$enableval
-],[
-  ZEND_GCC_GLOBAL_REGS=yes
-])
+AC_ARG_ENABLE([gcc-global-regs],
+  [AS_HELP_STRING([--disable-gcc-global-regs],
+    [whether to enable GCC global register variables])],
+  [ZEND_GCC_GLOBAL_REGS=$enableval],
+  [ZEND_GCC_GLOBAL_REGS=yes])
+
 AC_MSG_CHECKING(for global register variables support)
 if test "$ZEND_GCC_GLOBAL_REGS" != "no"; then
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[

--- a/configure.ac
+++ b/configure.ac
@@ -939,8 +939,7 @@ fi
 PHP_ARG_WITH([layout],
   [layout of installed files],
   [AS_HELP_STRING([--with-layout=TYPE],
-    [Set how installed files will be laid out. Type can be either PHP or GNU 
-    @<:@PHP@:>@])],
+    [Set how installed files will be laid out. Type can be either PHP or GNU [PHP]])],
   [PHP],
   [no])
 
@@ -956,7 +955,7 @@ esac
 PHP_ARG_WITH([config-file-path],
   [path to configuration file],
   [AS_HELP_STRING([--with-config-file-path=PATH],
-    [Set the path in which to look for php.ini @<:@PREFIX/lib@:>@])],
+    [Set the path in which to look for php.ini [PREFIX/lib]])],
   [DEFAULT],
   [no])
 
@@ -1180,8 +1179,8 @@ fi
 
 PHP_ARG_WITH([pear],
   [whether to install PEAR],
-  [AS_HELP_STRING([--with-pear@<:@=DIR@:>@],
-    [Install PEAR in DIR @<:@PREFIX/lib/php@:>@])],
+  [AS_HELP_STRING([[--with-pear[=DIR]]],
+    [Install PEAR in DIR [PREFIX/lib/php]])],
   [no],
   [yes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -183,12 +183,19 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_LN_S
 
 dnl Support systems with system libraries in e.g. /usr/lib64
-PHP_ARG_WITH(libdir, for system library directory,
-[  --with-libdir=NAME      Look for libraries in .../NAME rather than .../lib],lib,no)
+PHP_ARG_WITH([libdir],
+  [for system library directory],
+  [AS_HELP_STRING([--with-libdir=NAME],
+    [Look for libraries in .../NAME rather than .../lib])],
+  [lib],
+  [no])
 
-PHP_ARG_ENABLE(rpath, whether to enable runpaths,
-[  --disable-rpath         Disable passing additional runtime library
-                          search paths], yes, no)
+PHP_ARG_ENABLE([rpath],
+  [whether to enable runpaths],
+  [AS_HELP_STRING([--disable-rpath],
+    [Disable passing additional runtime library search paths])],
+  [yes],
+  [no])
 
 dnl check for -R, etc. switch
 PHP_RUNPATH_SWITCH
@@ -207,8 +214,12 @@ case $php_cv_bison_version in
     ;;
 esac
 
-PHP_ARG_ENABLE(re2c-cgoto, whether to enable computed goto gcc extension with re2c,
-[  --enable-re2c-cgoto     Enable -g flag to re2c to use computed goto gcc extension], no, no)
+PHP_ARG_ENABLE([re2c-cgoto],
+  [whether to enable computed goto gcc extension with re2c],
+  [AS_HELP_STRING([--enable-re2c-cgoto],
+    [Enable -g flag to re2c to use computed goto gcc extension])],
+  [no],
+  [no])
 
 if test "$PHP_RE2C_CGOTO" = "no"; then
   RE2C_FLAGS=""
@@ -768,8 +779,12 @@ if test "$ac_cv__compiler_c99_vla" = yes; then
 fi
 
 dnl Check valgrind support
-PHP_ARG_WITH(valgrind, [whether to enable valgrind support],
-[  --with-valgrind=DIR     Enable valgrind support], yes, no)
+PHP_ARG_WITH([valgrind],
+  [whether to enable valgrind support],
+  [AS_HELP_STRING([--with-valgrind=DIR],
+    [Enable valgrind support])],
+  [yes],
+  [no])
 
 if test "$PHP_VALGRIND" != "no"; then
 
@@ -803,8 +818,12 @@ PHP_CONFIGURE_PART(General settings)
 
 PHP_HELP_SEPARATOR([General settings:])
 
-PHP_ARG_ENABLE(gcov,  whether to include gcov symbols,
-[  --enable-gcov           Enable GCOV code coverage (requires LTP) - FOR DEVELOPERS ONLY!!], no, no)
+PHP_ARG_ENABLE([gcov],
+  [whether to include gcov symbols],
+  [AS_HELP_STRING([--enable-gcov],
+    [Enable GCOV code coverage (requires LTP) - FOR DEVELOPERS ONLY!!])],
+  [no],
+  [no])
 
 if test "$PHP_GCOV" = "yes"; then
 
@@ -884,8 +903,12 @@ if test "$PHP_GCOV" = "yes"; then
   CXXFLAGS="$CXXFLAGS -O0 -fprofile-arcs -ftest-coverage"
 fi
 
-PHP_ARG_ENABLE(debug, whether to include debugging symbols,
-[  --enable-debug          Compile with debugging symbols], no, no)
+PHP_ARG_ENABLE([debug],
+  [whether to include debugging symbols],
+  [AS_HELP_STRING([--enable-debug],
+    [Compile with debugging symbols])],
+  [no],
+  [no])
 
 if test "$PHP_DEBUG" = "yes"; then
   PHP_DEBUG=1
@@ -913,9 +936,12 @@ else
   ZEND_DEBUG=no
 fi
 
-PHP_ARG_WITH(layout, layout of installed files,
-[  --with-layout=TYPE      Set how installed files will be laid out.  Type can
-                          be either PHP or GNU @<:@PHP@:>@], PHP, no)
+PHP_ARG_WITH([layout],
+  [layout of installed files],
+  [AS_HELP_STRING([--with-layout=TYPE],
+    [Set how installed files will be laid out. Type can be either PHP or GNU @<:@PHP@:>@])],
+  [PHP],
+  [no])
 
 case $PHP_LAYOUT in
   GNU)
@@ -926,9 +952,12 @@ case $PHP_LAYOUT in
     ;;
 esac
 
-PHP_ARG_WITH(config-file-path, path to configuration file,
-[  --with-config-file-path=PATH
-                          Set the path in which to look for php.ini @<:@PREFIX/lib@:>@], DEFAULT, no)
+PHP_ARG_WITH([config-file-path],
+  [path to configuration file],
+  [AS_HELP_STRING([--with-config-file-path=PATH],
+    [Set the path in which to look for php.ini @<:@PREFIX/lib@:>@])],
+  [DEFAULT],
+  [no])
 
 if test "$PHP_CONFIG_FILE_PATH" = "DEFAULT"; then
   case $PHP_LAYOUT in
@@ -942,9 +971,12 @@ if test "$PHP_CONFIG_FILE_PATH" = "DEFAULT"; then
 fi
 
 AC_MSG_CHECKING([where to scan for configuration files])
-PHP_ARG_WITH(config-file-scan-dir,,
-[  --with-config-file-scan-dir=PATH
-                          Set the path where to scan for configuration files], DEFAULT, no)
+PHP_ARG_WITH([config-file-scan-dir],,
+  [AS_HELP_STRING([--with-config-file-scan-dir=PATH],
+    [Set the path where to scan for configuration files])],
+  [DEFAULT],
+  [no])
+
 if test "$PHP_CONFIG_FILE_SCAN_DIR" = "DEFAULT"; then
   PHP_CONFIG_FILE_SCAN_DIR=
 fi
@@ -952,8 +984,12 @@ AC_MSG_RESULT([$PHP_CONFIG_FILE_SCAN_DIR])
 
 test -n "$DEBUG_CFLAGS" && CFLAGS="$CFLAGS $DEBUG_CFLAGS"
 
-PHP_ARG_ENABLE(sigchild, whether to enable PHP's own SIGCHLD handler,
-[  --enable-sigchild       Enable PHP's own SIGCHLD handler], no, no)
+PHP_ARG_ENABLE([sigchild],
+  [whether to enable PHP's own SIGCHLD handler],
+  [AS_HELP_STRING([--enable-sigchild],
+    [Enable PHP's own SIGCHLD handler])],
+  [no],
+  [no])
 
 if test "$PHP_SIGCHILD" = "yes"; then
   AC_DEFINE(PHP_SIGCHILD, 1, [ ])
@@ -961,8 +997,12 @@ else
   AC_DEFINE(PHP_SIGCHILD, 0, [ ])
 fi
 
-PHP_ARG_ENABLE(libgcc, whether to explicitly link against libgcc,
-[  --enable-libgcc         Enable explicitly linking against libgcc], no, no)
+PHP_ARG_ENABLE([libgcc],
+  [whether to explicitly link against libgcc],
+  [AS_HELP_STRING([--enable-libgcc],
+    [Enable explicitly linking against libgcc])],
+  [no],
+  [no])
 
 if test "$PHP_LIBGCC" = "yes"; then
   PHP_LIBGCC_LIBPATH(gcc)
@@ -973,8 +1013,12 @@ if test "$PHP_LIBGCC" = "yes"; then
   PHP_ADD_LIBRARY(gcc, yes)
 fi
 
-PHP_ARG_ENABLE(short-tags, whether to enable short tags by default,
-[  --disable-short-tags    Disable the short-form <? start tag by default], yes, no)
+PHP_ARG_ENABLE([short-tags],
+  [whether to enable short tags by default],
+  [AS_HELP_STRING([--disable-short-tags],
+    [Disable the short-form <? start tag by default])],
+  [yes],
+  [no])
 
 if test "$PHP_SHORT_TAGS" = "yes"; then
   AC_DEFINE(DEFAULT_SHORT_OPEN_TAG, "1", [ ])
@@ -982,8 +1026,12 @@ else
   AC_DEFINE(DEFAULT_SHORT_OPEN_TAG, "0", [ ])
 fi
 
-PHP_ARG_ENABLE(dmalloc, whether to enable dmalloc,
-[  --enable-dmalloc        Enable dmalloc], no, no)
+PHP_ARG_ENABLE([dmalloc],
+  [whether to enable dmalloc],
+  [AS_HELP_STRING([--enable-dmalloc],
+    [Enable dmalloc])],
+  [no],
+  [no])
 
 if test "$PHP_DMALLOC" = "yes"; then
   AC_CHECK_LIB(dmalloc, dmalloc_error, [
@@ -995,8 +1043,12 @@ if test "$PHP_DMALLOC" = "yes"; then
   ])
 fi
 
-PHP_ARG_ENABLE(ipv6, whether to enable IPv6 support,
-[  --disable-ipv6          Disable IPv6 support], yes, no)
+PHP_ARG_ENABLE([ipv6],
+  [whether to enable IPv6 support],
+  [AS_HELP_STRING([--disable-ipv6],
+    [Disable IPv6 support])],
+  [yes],
+  [no])
 
 if test "$PHP_IPV6" != "no" && test "$ac_cv_ipv6_support" = yes; then
   AC_DEFINE(HAVE_IPV6, 1, [Whether to enable IPv6 support])
@@ -1006,8 +1058,12 @@ dnl ##
 dnl ## DTRACE CHECKS
 dnl ## Note: this has to be done after SAPI configuration!
 dnl ##
-PHP_ARG_ENABLE(dtrace, whether to enable DTrace support,
-[  --enable-dtrace         Enable DTrace support], no, no)
+PHP_ARG_ENABLE([dtrace],
+  [whether to enable DTrace support],
+  [AS_HELP_STRING([--enable-dtrace],
+    [Enable DTrace support])],
+  [no],
+  [no])
 
 if test "$PHP_DTRACE" = "yes"; then
   AC_CHECK_HEADERS([sys/sdt.h], [
@@ -1022,8 +1078,11 @@ if test "$PHP_DTRACE" = "yes"; then
 fi
 
 AC_MSG_CHECKING([how big to make fd sets])
-PHP_ARG_ENABLE(fd-setsize,,
-[  --enable-fd-setsize     Set size of descriptor sets], no, no)
+PHP_ARG_ENABLE([fd-setsize],,
+  [AS_HELP_STRING([--enable-fd-setsize],
+    [Set size of descriptor sets])],
+  [no],
+  [no])
 
 if test "$PHP_FD_SETSIZE" != "no"; then
   if test "0$PHP_FD_SETSIZE" -gt 0 2>/dev/null; then
@@ -1057,11 +1116,10 @@ dnl
 dnl Check if all enabled by default extensions should be disabled
 dnl
 
-AC_ARG_ENABLE(all,
-[  --disable-all           Disable all extensions which are enabled by default
-], [
-  PHP_ENABLE_ALL=$enableval
-])
+AC_ARG_ENABLE([all],
+  [AS_HELP_STRING([--disable-all],
+    [Disable all extensions which are enabled by default])],
+  [PHP_ENABLE_ALL=$enableval])
 
 # reading config stubs
 esyscmd(./build/config-stubs ext)
@@ -1119,8 +1177,12 @@ if test "$PHP_CLI" = "no"; then
   with_pear=no
 fi
 
-PHP_ARG_WITH(pear, [whether to install PEAR],
-[  --with-pear=DIR         Install PEAR in DIR @<:@PREFIX/lib/php@:>@], no, yes)
+PHP_ARG_WITH([pear],
+  [whether to install PEAR],
+  [AS_HELP_STRING([--with-pear=DIR],
+    [Install PEAR in DIR @<:@PREFIX/lib/php@:>@])],
+  [no],
+  [yes])
 
 if test "$PHP_PEAR" != "no"; then
 

--- a/configure.ac
+++ b/configure.ac
@@ -939,7 +939,8 @@ fi
 PHP_ARG_WITH([layout],
   [layout of installed files],
   [AS_HELP_STRING([--with-layout=TYPE],
-    [Set how installed files will be laid out. Type can be either PHP or GNU @<:@PHP@:>@])],
+    [Set how installed files will be laid out. Type can be either PHP or GNU 
+    @<:@PHP@:>@])],
   [PHP],
   [no])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1180,7 +1180,7 @@ fi
 
 PHP_ARG_WITH([pear],
   [whether to install PEAR],
-  [AS_HELP_STRING([--with-pear=DIR],
+  [AS_HELP_STRING([--with-pear@<:@=DIR@:>@],
     [Install PEAR in DIR @<:@PREFIX/lib/php@:>@])],
   [no],
   [yes])

--- a/ext/bcmath/config.m4
+++ b/ext/bcmath/config.m4
@@ -1,9 +1,9 @@
 dnl config.m4 for extension bcmath
 
 PHP_ARG_ENABLE([bcmath],
-               [whether to enable bc style precision math functions],
-               [AS_HELP_STRING([--enable-bcmath],
-                               [Enable bc style precision math functions])])
+  [whether to enable bc style precision math functions],
+  [AS_HELP_STRING([--enable-bcmath],
+    [Enable bc style precision math functions])])
 
 if test "$PHP_BCMATH" != "no"; then
   PHP_NEW_EXTENSION(bcmath, bcmath.c \

--- a/ext/bcmath/config.m4
+++ b/ext/bcmath/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension bcmath
 
-PHP_ARG_ENABLE(bcmath, whether to enable bc style precision math functions,
-[  --enable-bcmath         Enable bc style precision math functions])
+PHP_ARG_ENABLE([bcmath],
+               [whether to enable bc style precision math functions],
+               [AS_HELP_STRING([--enable-bcmath],
+                               [Enable bc style precision math functions])])
 
 if test "$PHP_BCMATH" != "no"; then
   PHP_NEW_EXTENSION(bcmath, bcmath.c \

--- a/ext/bz2/config.m4
+++ b/ext/bz2/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension bz2
 
-PHP_ARG_WITH(bz2, for BZip2 support,
-[  --with-bz2[=DIR]          Include BZip2 support])
+PHP_ARG_WITH([bz2],
+             [for BZip2 support],
+             [AS_HELP_STRING([--with-bz2[=DIR]],
+                             [Include BZip2 support])])
 
 if test "$PHP_BZ2" != "no"; then
   if test -r $PHP_BZ2/include/bzlib.h; then

--- a/ext/bz2/config.m4
+++ b/ext/bz2/config.m4
@@ -1,9 +1,9 @@
 dnl config.m4 for extension bz2
 
 PHP_ARG_WITH([bz2],
-             [for BZip2 support],
-             [AS_HELP_STRING([--with-bz2[=DIR]],
-                             [Include BZip2 support])])
+  [for BZip2 support],
+  [AS_HELP_STRING([--with-bz2[=DIR]],
+    [Include BZip2 support])])
 
 if test "$PHP_BZ2" != "no"; then
   if test -r $PHP_BZ2/include/bzlib.h; then

--- a/ext/bz2/config.m4
+++ b/ext/bz2/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension bz2
 
 PHP_ARG_WITH([bz2],
   [for BZip2 support],
-  [AS_HELP_STRING([--with-bz2@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-bz2[=DIR]]],
     [Include BZip2 support])])
 
 if test "$PHP_BZ2" != "no"; then

--- a/ext/bz2/config.m4
+++ b/ext/bz2/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension bz2
 
 PHP_ARG_WITH([bz2],
   [for BZip2 support],
-  [AS_HELP_STRING([--with-bz2[=DIR]],
+  [AS_HELP_STRING([--with-bz2@<:@=DIR@:>@],
     [Include BZip2 support])])
 
 if test "$PHP_BZ2" != "no"; then

--- a/ext/calendar/config.m4
+++ b/ext/calendar/config.m4
@@ -1,9 +1,9 @@
 dnl config.m4 for extension calendar
 
 PHP_ARG_ENABLE([calendar],
-               [whether to enable calendar conversion support],
-               [AS_HELP_STRING([--enable-calendar],
-                               [Enable support for calendar conversion])])
+  [whether to enable calendar conversion support],
+  [AS_HELP_STRING([--enable-calendar],
+    [Enable support for calendar conversion])])
 
 if test "$PHP_CALENDAR" = "yes"; then
   AC_DEFINE(HAVE_CALENDAR,1,[ ])

--- a/ext/calendar/config.m4
+++ b/ext/calendar/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension calendar
 
-PHP_ARG_ENABLE(calendar,whether to enable calendar conversion support,
-[  --enable-calendar       Enable support for calendar conversion])
+PHP_ARG_ENABLE([calendar],
+               [whether to enable calendar conversion support],
+               [AS_HELP_STRING([--enable-calendar],
+                               [Enable support for calendar conversion])])
 
 if test "$PHP_CALENDAR" = "yes"; then
   AC_DEFINE(HAVE_CALENDAR,1,[ ])

--- a/ext/ctype/config.m4
+++ b/ext/ctype/config.m4
@@ -1,7 +1,10 @@
 dnl config.m4 for extension ctype
 
-PHP_ARG_ENABLE(ctype, whether to enable ctype functions,
-[  --disable-ctype         Disable ctype functions], yes)
+PHP_ARG_ENABLE([ctype],
+               [whether to enable ctype functions],
+               [AS_HELP_STRING([--disable-ctype],
+                               [Disable ctype functions])],
+               [yes])
 
 if test "$PHP_CTYPE" != "no"; then
   AC_DEFINE(HAVE_CTYPE, 1, [ ])

--- a/ext/ctype/config.m4
+++ b/ext/ctype/config.m4
@@ -1,10 +1,10 @@
 dnl config.m4 for extension ctype
 
 PHP_ARG_ENABLE([ctype],
-               [whether to enable ctype functions],
-               [AS_HELP_STRING([--disable-ctype],
-                               [Disable ctype functions])],
-               [yes])
+  [whether to enable ctype functions],
+  [AS_HELP_STRING([--disable-ctype],
+    [Disable ctype functions])],
+  [yes])
 
 if test "$PHP_CTYPE" != "no"; then
   AC_DEFINE(HAVE_CTYPE, 1, [ ])

--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension curl
 
-PHP_ARG_WITH(curl, for cURL support,
-[  --with-curl               Include cURL support])
+PHP_ARG_WITH([curl],
+             [for cURL support],
+             [AS_HELP_STRING([--with-curl],
+                             [Include cURL support])])
 
 if test "$PHP_CURL" != "no"; then
   PKG_CHECK_MODULES([CURL], [libcurl >= 7.15.5])

--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -1,9 +1,9 @@
 dnl config.m4 for extension curl
 
 PHP_ARG_WITH([curl],
-             [for cURL support],
-             [AS_HELP_STRING([--with-curl],
-                             [Include cURL support])])
+  [for cURL support],
+  [AS_HELP_STRING([--with-curl],
+    [Include cURL support])])
 
 if test "$PHP_CURL" != "no"; then
   PKG_CHECK_MODULES([CURL], [libcurl >= 7.15.5])

--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -67,40 +67,69 @@ dnl
 dnl Options
 dnl
 
-PHP_ARG_ENABLE(dba,,
-[  --enable-dba            Build DBA with bundled modules. To build shared DBA
-                          extension use --enable-dba=shared])
+PHP_ARG_ENABLE([dba],,
+  [AS_HELP_STRING([--enable-dba],
+    [Build DBA with bundled modules. To build shared DBA extension use --enable-dba=shared])])
 
-PHP_ARG_WITH(qdbm,,
-[  --with-qdbm[=DIR]         DBA: QDBM support], no, no)
+PHP_ARG_WITH([qdbm],,
+  [AS_HELP_STRING([--with-qdbm[=DIR]],
+    [DBA: QDBM support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(gdbm,,
-[  --with-gdbm[=DIR]         DBA: GDBM support], no, no)
+PHP_ARG_WITH([gdbm],,
+  [AS_HELP_STRING([--with-gdbm[=DIR]],
+    [DBA: GDBM support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(ndbm,,
-[  --with-ndbm[=DIR]         DBA: NDBM support], no, no)
+PHP_ARG_WITH([ndbm],,
+  [AS_HELP_STRING([--with-ndbm[=DIR]],
+    [DBA: NDBM support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(db4,,
-[  --with-db4[=DIR]          DBA: Oracle Berkeley DB 4.x or 5.x support], no, no)
+PHP_ARG_WITH([db4],,
+  [AS_HELP_STRING([--with-db4[=DIR]],
+    [DBA: Oracle Berkeley DB 4.x or 5.x support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(db3,,
-[  --with-db3[=DIR]          DBA: Oracle Berkeley DB 3.x support], no, no)
+PHP_ARG_WITH([db3],,
+  [AS_HELP_STRING([--with-db3[=DIR]],
+    [DBA: Oracle Berkeley DB 3.x support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(db2,,
-[  --with-db2[=DIR]          DBA: Oracle Berkeley DB 2.x support], no, no)
+PHP_ARG_WITH([db2],,
+  [AS_HELP_STRING([--with-db2[=DIR]],
+    [DBA: Oracle Berkeley DB 2.x support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(db1,,
-[  --with-db1[=DIR]          DBA: Oracle Berkeley DB 1.x support/emulation], no, no)
+PHP_ARG_WITH([db1],,
+  [AS_HELP_STRING([--with-db1[=DIR]],
+    [DBA: Oracle Berkeley DB 1.x support/emulation])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(dbm,,
-[  --with-dbm[=DIR]          DBA: DBM support], no, no)
+PHP_ARG_WITH([dbm],,
+  [AS_HELP_STRING([--with-dbm[=DIR]],
+    [DBA: DBM support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(tcadb,,
-[  --with-tcadb[=DIR]        DBA: Tokyo Cabinet abstract DB support], no, no)
+PHP_ARG_WITH([tcadb],,
+  [AS_HELP_STRING([--with-tcadb[=DIR]],
+    [DBA: Tokyo Cabinet abstract DB support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(lmdb,,
-[  --with-lmdb[=DIR]         DBA: Lightning memory-mapped database support], no, no)
-
+PHP_ARG_WITH([lmdb],,
+  [AS_HELP_STRING([--with-lmdb[=DIR]],
+    [DBA: Lightning memory-mapped database support])],
+  [no],
+  [no])
 
 dnl
 dnl Library checks
@@ -589,14 +618,23 @@ else
   php_dba_enable=no
 fi
 
-PHP_ARG_WITH(cdb,,
-[  --without-cdb[=DIR]       DBA: CDB support (bundled)], $php_dba_enable, no)
+PHP_ARG_WITH([cdb],,
+  [AS_HELP_STRING([--without-cdb[=DIR]],
+    [DBA: CDB support (bundled)])],
+    [$php_dba_enable],
+    [no])
 
-PHP_ARG_ENABLE(inifile,,
-[  --disable-inifile       DBA: INI support (bundled)], $php_dba_enable, no)
+PHP_ARG_ENABLE([inifile],,
+  [AS_HELP_STRING([--disable-inifile],
+    [DBA: INI support (bundled)])],
+  [$php_dba_enable],
+  [no])
 
-PHP_ARG_ENABLE(flatfile,,
-[  --disable-flatfile      DBA: FlatFile support (bundled)], $php_dba_enable, no)
+PHP_ARG_ENABLE([flatfile],,
+  [AS_HELP_STRING([--disable-flatfile],
+    [DBA: FlatFile support (bundled)])],
+  [$php_dba_enable],
+  [no])
 
 # CDB
 if test "$PHP_CDB" = "yes"; then

--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -69,7 +69,8 @@ dnl
 
 PHP_ARG_ENABLE([dba],,
   [AS_HELP_STRING([--enable-dba],
-    [Build DBA with bundled modules. To build shared DBA extension use --enable-dba=shared])])
+    [Build DBA with bundled modules. To build shared DBA extension use
+    --enable-dba=shared])])
 
 PHP_ARG_WITH([qdbm],,
   [AS_HELP_STRING([--with-qdbm[=DIR]],
@@ -621,8 +622,8 @@ fi
 PHP_ARG_WITH([cdb],,
   [AS_HELP_STRING([--without-cdb[=DIR]],
     [DBA: CDB support (bundled)])],
-    [$php_dba_enable],
-    [no])
+  [$php_dba_enable],
+  [no])
 
 PHP_ARG_ENABLE([inifile],,
   [AS_HELP_STRING([--disable-inifile],

--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -73,61 +73,61 @@ PHP_ARG_ENABLE([dba],,
     --enable-dba=shared])])
 
 PHP_ARG_WITH([qdbm],,
-  [AS_HELP_STRING([--with-qdbm[=DIR]],
+  [AS_HELP_STRING([--with-qdbm@<:@=DIR@:>@],
     [DBA: QDBM support])],
   [no],
   [no])
 
 PHP_ARG_WITH([gdbm],,
-  [AS_HELP_STRING([--with-gdbm[=DIR]],
+  [AS_HELP_STRING([--with-gdbm@<:@=DIR@:>@],
     [DBA: GDBM support])],
   [no],
   [no])
 
 PHP_ARG_WITH([ndbm],,
-  [AS_HELP_STRING([--with-ndbm[=DIR]],
+  [AS_HELP_STRING([--with-ndbm@<:@=DIR@:>@],
     [DBA: NDBM support])],
   [no],
   [no])
 
 PHP_ARG_WITH([db4],,
-  [AS_HELP_STRING([--with-db4[=DIR]],
+  [AS_HELP_STRING([--with-db4@<:@=DIR@:>@],
     [DBA: Oracle Berkeley DB 4.x or 5.x support])],
   [no],
   [no])
 
 PHP_ARG_WITH([db3],,
-  [AS_HELP_STRING([--with-db3[=DIR]],
+  [AS_HELP_STRING([--with-db3@<:@=DIR@:>@],
     [DBA: Oracle Berkeley DB 3.x support])],
   [no],
   [no])
 
 PHP_ARG_WITH([db2],,
-  [AS_HELP_STRING([--with-db2[=DIR]],
+  [AS_HELP_STRING([--with-db2@<:@=DIR@:>@],
     [DBA: Oracle Berkeley DB 2.x support])],
   [no],
   [no])
 
 PHP_ARG_WITH([db1],,
-  [AS_HELP_STRING([--with-db1[=DIR]],
+  [AS_HELP_STRING([--with-db1@<:@=DIR@:>@],
     [DBA: Oracle Berkeley DB 1.x support/emulation])],
   [no],
   [no])
 
 PHP_ARG_WITH([dbm],,
-  [AS_HELP_STRING([--with-dbm[=DIR]],
+  [AS_HELP_STRING([--with-dbm@<:@=DIR@:>@],
     [DBA: DBM support])],
   [no],
   [no])
 
 PHP_ARG_WITH([tcadb],,
-  [AS_HELP_STRING([--with-tcadb[=DIR]],
+  [AS_HELP_STRING([--with-tcadb@<:@=DIR@:>@],
     [DBA: Tokyo Cabinet abstract DB support])],
   [no],
   [no])
 
 PHP_ARG_WITH([lmdb],,
-  [AS_HELP_STRING([--with-lmdb[=DIR]],
+  [AS_HELP_STRING([--with-lmdb@<:@=DIR@:>@],
     [DBA: Lightning memory-mapped database support])],
   [no],
   [no])
@@ -620,7 +620,7 @@ else
 fi
 
 PHP_ARG_WITH([cdb],,
-  [AS_HELP_STRING([--without-cdb[=DIR]],
+  [AS_HELP_STRING([--without-cdb@<:@=DIR@:>@],
     [DBA: CDB support (bundled)])],
   [$php_dba_enable],
   [no])

--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -73,61 +73,61 @@ PHP_ARG_ENABLE([dba],,
     --enable-dba=shared])])
 
 PHP_ARG_WITH([qdbm],,
-  [AS_HELP_STRING([--with-qdbm@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-qdbm[=DIR]]],
     [DBA: QDBM support])],
   [no],
   [no])
 
 PHP_ARG_WITH([gdbm],,
-  [AS_HELP_STRING([--with-gdbm@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-gdbm[=DIR]]],
     [DBA: GDBM support])],
   [no],
   [no])
 
 PHP_ARG_WITH([ndbm],,
-  [AS_HELP_STRING([--with-ndbm@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-ndbm[=DIR]]],
     [DBA: NDBM support])],
   [no],
   [no])
 
 PHP_ARG_WITH([db4],,
-  [AS_HELP_STRING([--with-db4@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-db4[=DIR]]],
     [DBA: Oracle Berkeley DB 4.x or 5.x support])],
   [no],
   [no])
 
 PHP_ARG_WITH([db3],,
-  [AS_HELP_STRING([--with-db3@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-db3[=DIR]]],
     [DBA: Oracle Berkeley DB 3.x support])],
   [no],
   [no])
 
 PHP_ARG_WITH([db2],,
-  [AS_HELP_STRING([--with-db2@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-db2[=DIR]]],
     [DBA: Oracle Berkeley DB 2.x support])],
   [no],
   [no])
 
 PHP_ARG_WITH([db1],,
-  [AS_HELP_STRING([--with-db1@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-db1[=DIR]]],
     [DBA: Oracle Berkeley DB 1.x support/emulation])],
   [no],
   [no])
 
 PHP_ARG_WITH([dbm],,
-  [AS_HELP_STRING([--with-dbm@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-dbm[=DIR]]],
     [DBA: DBM support])],
   [no],
   [no])
 
 PHP_ARG_WITH([tcadb],,
-  [AS_HELP_STRING([--with-tcadb@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-tcadb[=DIR]]],
     [DBA: Tokyo Cabinet abstract DB support])],
   [no],
   [no])
 
 PHP_ARG_WITH([lmdb],,
-  [AS_HELP_STRING([--with-lmdb@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-lmdb[=DIR]]],
     [DBA: Lightning memory-mapped database support])],
   [no],
   [no])
@@ -620,7 +620,7 @@ else
 fi
 
 PHP_ARG_WITH([cdb],,
-  [AS_HELP_STRING([--without-cdb@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--without-cdb[=DIR]]],
     [DBA: CDB support (bundled)])],
   [$php_dba_enable],
   [no])

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -9,7 +9,7 @@ PHP_ARG_ENABLE([dom],
 if test -z "$PHP_LIBXML_DIR"; then
   PHP_ARG_WITH([libxml-dir],
     [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir[=DIR]],
+    [AS_HELP_STRING([--with-libxml-dir@<:@=DIR@:>@],
       [DOM: libxml2 install prefix])],
     [no],
     [no])

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -9,7 +9,7 @@ PHP_ARG_ENABLE([dom],
 if test -z "$PHP_LIBXML_DIR"; then
   PHP_ARG_WITH([libxml-dir],
     [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir@<:@=DIR@:>@],
+    [AS_HELP_STRING([[--with-libxml-dir[=DIR]]],
       [DOM: libxml2 install prefix])],
     [no],
     [no])

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -1,11 +1,18 @@
 dnl config.m4 for extension dom
 
-PHP_ARG_ENABLE(dom, whether to enable DOM support,
-[  --disable-dom           Disable DOM support], yes)
+PHP_ARG_ENABLE([dom],
+  [whether to enable DOM support],
+  [AS_HELP_STRING([--disable-dom],
+    [Disable DOM support])],
+  [yes])
 
 if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH(libxml-dir, libxml2 install dir,
-  [  --with-libxml-dir[=DIR]   DOM: libxml2 install prefix], no, no)
+  PHP_ARG_WITH([libxml-dir],
+    [libxml2 install dir],
+    [AS_HELP_STRING([--with-libxml-dir[=DIR]],
+      [DOM: libxml2 install prefix])],
+    [no],
+    [no])
 fi
 
 if test "$PHP_DOM" != "no"; then

--- a/ext/enchant/config.m4
+++ b/ext/enchant/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension enchant
 
 PHP_ARG_WITH([enchant],
   [for ENCHANT support],
-  [AS_HELP_STRING([--with-enchant[=DIR]],
+  [AS_HELP_STRING([--with-enchant@<:@=DIR@:>@],
     [Include enchant support. GNU Aspell version 1.1.3 or higher required.])])
 
 if test "$PHP_ENCHANT" != "no"; then

--- a/ext/enchant/config.m4
+++ b/ext/enchant/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension enchant
 
 PHP_ARG_WITH([enchant],
   [for ENCHANT support],
-  [AS_HELP_STRING([--with-enchant@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-enchant[=DIR]]],
     [Include enchant support. GNU Aspell version 1.1.3 or higher required.])])
 
 if test "$PHP_ENCHANT" != "no"; then

--- a/ext/enchant/config.m4
+++ b/ext/enchant/config.m4
@@ -1,8 +1,9 @@
 dnl config.m4 for extension enchant
 
-PHP_ARG_WITH(enchant,for ENCHANT support,
-[  --with-enchant[=DIR]      Include enchant support.
-                          GNU Aspell version 1.1.3 or higher required.])
+PHP_ARG_WITH([enchant],
+  [for ENCHANT support],
+  [AS_HELP_STRING([--with-enchant[=DIR]],
+    [Include enchant support. GNU Aspell version 1.1.3 or higher required.])])
 
 if test "$PHP_ENCHANT" != "no"; then
 	PHP_NEW_EXTENSION(enchant, enchant.c, $ext_shared)

--- a/ext/exif/config.m4
+++ b/ext/exif/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension exif
 
-PHP_ARG_ENABLE(exif, whether to enable EXIF (metadata from images) support,
-[  --enable-exif           Enable EXIF (metadata from images) support])
+PHP_ARG_ENABLE([exif],
+  [whether to enable EXIF (metadata from images) support],
+  [AS_HELP_STRING([--enable-exif],
+    [Enable EXIF (metadata from images) support])])
 
 if test "$PHP_EXIF" != "no"; then
   AC_DEFINE(HAVE_EXIF, 1, [Whether you want EXIF (metadata from images) support])

--- a/ext/ffi/config.m4
+++ b/ext/ffi/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension FFI
 
-PHP_ARG_WITH(ffi, for FFI support,
-[  --with-ffi             Include FFI support])
+PHP_ARG_WITH([ffi],
+  [for FFI support],
+  [AS_HELP_STRING([--with-ffi],
+    [Include FFI support])])
 
 if test "$PHP_FFI" != "no"; then
   if test -r $PHP_FFI/include/ffi.h; then
@@ -42,7 +44,7 @@ if test "$PHP_FFI" != "no"; then
 
   AC_CHECK_TYPES(long double)
 
-  PHP_CHECK_LIBRARY(ffi, ffi_call, 
+  PHP_CHECK_LIBRARY(ffi, ffi_call,
   [
     PHP_ADD_INCLUDE($FFI_INCDIR)
     PHP_ADD_LIBRARY_WITH_PATH(ffi, $FFI_LIBDIR, FFI_SHARED_LIBADD)

--- a/ext/fileinfo/config.m4
+++ b/ext/fileinfo/config.m4
@@ -1,7 +1,10 @@
 dnl config.m4 for extension fileinfo
 
-PHP_ARG_ENABLE(fileinfo, for fileinfo support,
-[  --disable-fileinfo      Disable fileinfo support], yes)
+PHP_ARG_ENABLE([fileinfo],
+  [for fileinfo support],
+  [AS_HELP_STRING([--disable-fileinfo],
+    [Disable fileinfo support])],
+  [yes])
 
 if test "$PHP_FILEINFO" != "no"; then
 

--- a/ext/filter/config.m4
+++ b/ext/filter/config.m4
@@ -1,10 +1,17 @@
 dnl config.m4 for input filtering extension
 
-PHP_ARG_ENABLE(filter, whether to enable input filter support,
-[  --disable-filter        Disable input filter support], yes)
+PHP_ARG_ENABLE([filter],
+  [whether to enable input filter support],
+  [AS_HELP_STRING([--disable-filter],
+    [Disable input filter support])],
+  [yes])
 
-PHP_ARG_WITH(pcre-dir, pcre install prefix,
-[  --with-pcre-dir         FILTER: pcre install prefix], no, no)
+PHP_ARG_WITH([pcre-dir],
+  [pcre install prefix],
+  [AS_HELP_STRING([--with-pcre-dir],
+    [FILTER: pcre install prefix])],
+  [no],
+  [no])
 
 if test "$PHP_FILTER" != "no"; then
 

--- a/ext/ftp/config.m4
+++ b/ext/ftp/config.m4
@@ -1,10 +1,16 @@
 dnl config.m4 for extension ftp
 
-PHP_ARG_ENABLE(ftp,whether to enable FTP support,
-[  --enable-ftp            Enable FTP support])
+PHP_ARG_ENABLE([ftp],
+  [whether to enable FTP support],
+  [AS_HELP_STRING([--enable-ftp],
+    [Enable FTP support])])
 
-PHP_ARG_WITH(openssl-dir,OpenSSL dir for FTP,
-[  --with-openssl-dir[=DIR]  FTP: openssl install prefix], no, no)
+PHP_ARG_WITH([openssl-dir],
+  [OpenSSL dir for FTP],
+  [AS_HELP_STRING([--with-openssl-dir[=DIR]],
+    [FTP: openssl install prefix])],
+  [no],
+  [no])
 
 if test "$PHP_FTP" = "yes"; then
   AC_DEFINE(HAVE_FTP,1,[Whether you want FTP support])

--- a/ext/ftp/config.m4
+++ b/ext/ftp/config.m4
@@ -7,7 +7,7 @@ PHP_ARG_ENABLE([ftp],
 
 PHP_ARG_WITH([openssl-dir],
   [OpenSSL dir for FTP],
-  [AS_HELP_STRING([--with-openssl-dir@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-openssl-dir[=DIR]]],
     [FTP: openssl install prefix])],
   [no],
   [no])

--- a/ext/ftp/config.m4
+++ b/ext/ftp/config.m4
@@ -7,7 +7,7 @@ PHP_ARG_ENABLE([ftp],
 
 PHP_ARG_WITH([openssl-dir],
   [OpenSSL dir for FTP],
-  [AS_HELP_STRING([--with-openssl-dir[=DIR]],
+  [AS_HELP_STRING([--with-openssl-dir@<:@=DIR@:>@],
     [FTP: openssl install prefix])],
   [no],
   [no])

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -4,30 +4,56 @@ dnl
 dnl Configure options
 dnl
 
-PHP_ARG_ENABLE(gd, for GD support,
-[  --enable-gd             Include GD support])
+PHP_ARG_ENABLE([gd],
+  [for GD support],
+  [AS_HELP_STRING([--enable-gd],
+    [Include GD support])])
 
-PHP_ARG_WITH(external-gd, for external libgd,
-[  --with-external-gd      Use external libgd], no, no)
+PHP_ARG_WITH([external-gd],
+  [for external libgd],
+  [AS_HELP_STRING([--with-external-gd],
+    [Use external libgd])],
+  [no],
+  [no])
 
 if test -z "$PHP_WEBP"; then
-  PHP_ARG_WITH(webp, for libwebp,
-  [  --with-webp             GD: Enable WEBP support], no, no)
+  PHP_ARG_WITH([webp],
+    [for libwebp],
+    [AS_HELP_STRING([--with-webp],
+      [GD: Enable WEBP support])],
+    [no],
+    [no])
 fi
 
 if test -z "$PHP_JPEG"; then
-  PHP_ARG_WITH(jpeg, for libjpeg,
-  [  --with-jpeg             GD: Enable JPEG support], no, no)
+  PHP_ARG_WITH([jpeg],
+    [for libjpeg],
+    [AS_HELP_STRING([--with-jpeg],
+      [GD: Enable JPEG support])],
+    [no],
+    [no])
 fi
 
-PHP_ARG_WITH(xpm, for libXpm,
-[  --with-xpm              GD: Enable XPM support], no, no)
+PHP_ARG_WITH([xpm],
+  [for libXpm],
+  [AS_HELP_STRING([--with-xpm],
+    [GD: Enable XPM support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(freetype, for FreeType 2,
-[  --with-freetype         GD: Enable FreeType 2 support], no, no)
+PHP_ARG_WITH([freetype],
+  [for FreeType 2],
+  [AS_HELP_STRING([--with-freetype],
+    [GD: Enable FreeType 2 support])],
+  [no],
+  [no])
 
-PHP_ARG_ENABLE(gd-jis-conv, whether to enable JIS-mapped Japanese font support in GD,
-[  --enable-gd-jis-conv    GD: Enable JIS-mapped Japanese font support], no, no)
+PHP_ARG_ENABLE([gd-jis-conv],
+  [whether to enable JIS-mapped Japanese font support in GD],
+  [AS_HELP_STRING([--enable-gd-jis-conv],
+    [GD: Enable JIS-mapped Japanese font support])],
+  [no],
+  [no])
 
 dnl
 dnl Checks for the configure options

--- a/ext/gettext/config.m4
+++ b/ext/gettext/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension gettext
 
 PHP_ARG_WITH([gettext],
   [for GNU gettext support],
-  [AS_HELP_STRING([--with-gettext[=DIR]],
+  [AS_HELP_STRING([--with-gettext@<:@=DIR@:>@],
     [Include GNU gettext support])])
 
 if test "$PHP_GETTEXT" != "no"; then

--- a/ext/gettext/config.m4
+++ b/ext/gettext/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension gettext
 
-PHP_ARG_WITH(gettext,for GNU gettext support,
-[  --with-gettext[=DIR]      Include GNU gettext support])
+PHP_ARG_WITH([gettext],
+  [for GNU gettext support],
+  [AS_HELP_STRING([--with-gettext[=DIR]],
+    [Include GNU gettext support])])
 
 if test "$PHP_GETTEXT" != "no"; then
   for i in $PHP_GETTEXT /usr/local /usr; do

--- a/ext/gettext/config.m4
+++ b/ext/gettext/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension gettext
 
 PHP_ARG_WITH([gettext],
   [for GNU gettext support],
-  [AS_HELP_STRING([--with-gettext@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-gettext[=DIR]]],
     [Include GNU gettext support])])
 
 if test "$PHP_GETTEXT" != "no"; then

--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -1,6 +1,6 @@
 PHP_ARG_WITH([gmp],
   [for GNU MP support],
-  [AS_HELP_STRING([--with-gmp[=DIR]],
+  [AS_HELP_STRING([--with-gmp@<:@=DIR@:>@],
     [Include GNU MP support])])
 
 if test "$PHP_GMP" != "no"; then

--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -1,6 +1,6 @@
 PHP_ARG_WITH([gmp],
   [for GNU MP support],
-  [AS_HELP_STRING([--with-gmp@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-gmp[=DIR]]],
     [Include GNU MP support])])
 
 if test "$PHP_GMP" != "no"; then

--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -1,5 +1,7 @@
-PHP_ARG_WITH(gmp, for GNU MP support,
-[  --with-gmp[=DIR]          Include GNU MP support])
+PHP_ARG_WITH([gmp],
+  [for GNU MP support],
+  [AS_HELP_STRING([--with-gmp[=DIR]],
+    [Include GNU MP support])])
 
 if test "$PHP_GMP" != "no"; then
 

--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension hash
 
 PHP_ARG_WITH([mhash],
   [for mhash support],
-  [AS_HELP_STRING([--with-mhash@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-mhash[=DIR]]],
     [Include mhash support])])
 
 if test "$PHP_MHASH" != "no"; then

--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension hash
 
 PHP_ARG_WITH([mhash],
   [for mhash support],
-  [AS_HELP_STRING([--with-mhash[=DIR]],
+  [AS_HELP_STRING([--with-mhash@<:@=DIR@:>@],
     [Include mhash support])])
 
 if test "$PHP_MHASH" != "no"; then

--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension hash
 
-PHP_ARG_WITH(mhash, for mhash support,
-[  --with-mhash[=DIR]        Include mhash support])
+PHP_ARG_WITH([mhash],
+  [for mhash support],
+  [AS_HELP_STRING([--with-mhash[=DIR]],
+    [Include mhash support])])
 
 if test "$PHP_MHASH" != "no"; then
   if test "$PHP_HASH" = "no"; then

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension iconv
 
 PHP_ARG_WITH([iconv],
   [for iconv support],
-  [AS_HELP_STRING([--without-iconv@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--without-iconv[=DIR]]],
     [Exclude iconv support])],
   [yes])
 

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -1,7 +1,10 @@
 dnl config.m4 for extension iconv
 
-PHP_ARG_WITH(iconv, for iconv support,
-[  --without-iconv[=DIR]     Exclude iconv support], yes)
+PHP_ARG_WITH([iconv],
+  [for iconv support],
+  [AS_HELP_STRING([--without-iconv[=DIR]],
+    [Exclude iconv support])],
+  [yes])
 
 if test "$PHP_ICONV" != "no"; then
 

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension iconv
 
 PHP_ARG_WITH([iconv],
   [for iconv support],
-  [AS_HELP_STRING([--without-iconv[=DIR]],
+  [AS_HELP_STRING([--without-iconv@<:@=DIR@:>@],
     [Exclude iconv support])],
   [yes])
 

--- a/ext/imap/config.m4
+++ b/ext/imap/config.m4
@@ -93,19 +93,19 @@ AC_DEFUN([PHP_IMAP_SSL_CHK], [
 
 PHP_ARG_WITH([imap],
   [for IMAP support],
-  [AS_HELP_STRING([--with-imap@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-imap[=DIR]]],
     [Include IMAP support. DIR is the c-client install prefix])])
 
 PHP_ARG_WITH([kerberos],
   [for IMAP Kerberos support],
-  [AS_HELP_STRING([--with-kerberos@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-kerberos[=DIR]]],
     [IMAP: Include Kerberos support. DIR is the Kerberos install prefix])],
   [no],
   [no])
 
 PHP_ARG_WITH([imap-ssl],
   [for IMAP SSL support],
-  [AS_HELP_STRING([--with-imap-ssl@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-imap-ssl[=DIR]]],
     [IMAP: Include SSL support. DIR is the OpenSSL install prefix])],
   [no],
   [no])

--- a/ext/imap/config.m4
+++ b/ext/imap/config.m4
@@ -91,16 +91,24 @@ AC_DEFUN([PHP_IMAP_SSL_CHK], [
   fi
 ])
 
+PHP_ARG_WITH([imap],
+  [for IMAP support],
+  [AS_HELP_STRING([--with-imap[=DIR]],
+    [Include IMAP support. DIR is the c-client install prefix])])
 
-PHP_ARG_WITH(imap,for IMAP support,
-[  --with-imap[=DIR]         Include IMAP support. DIR is the c-client install prefix])
+PHP_ARG_WITH([kerberos],
+  [for IMAP Kerberos support],
+  [AS_HELP_STRING([--with-kerberos[=DIR]],
+    [IMAP: Include Kerberos support. DIR is the Kerberos install prefix])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(kerberos,for IMAP Kerberos support,
-[  --with-kerberos[=DIR]     IMAP: Include Kerberos support. DIR is the Kerberos install prefix], no, no)
-
-PHP_ARG_WITH(imap-ssl,for IMAP SSL support,
-[  --with-imap-ssl[=DIR]     IMAP: Include SSL support. DIR is the OpenSSL install prefix], no, no)
-
+PHP_ARG_WITH([imap-ssl],
+  [for IMAP SSL support],
+  [AS_HELP_STRING([--with-imap-ssl[=DIR]],
+    [IMAP: Include SSL support. DIR is the OpenSSL install prefix])],
+  [no],
+  [no])
 
 if test "$PHP_IMAP" != "no"; then
     PHP_SUBST(IMAP_SHARED_LIBADD)

--- a/ext/imap/config.m4
+++ b/ext/imap/config.m4
@@ -93,19 +93,19 @@ AC_DEFUN([PHP_IMAP_SSL_CHK], [
 
 PHP_ARG_WITH([imap],
   [for IMAP support],
-  [AS_HELP_STRING([--with-imap[=DIR]],
+  [AS_HELP_STRING([--with-imap@<:@=DIR@:>@],
     [Include IMAP support. DIR is the c-client install prefix])])
 
 PHP_ARG_WITH([kerberos],
   [for IMAP Kerberos support],
-  [AS_HELP_STRING([--with-kerberos[=DIR]],
+  [AS_HELP_STRING([--with-kerberos@<:@=DIR@:>@],
     [IMAP: Include Kerberos support. DIR is the Kerberos install prefix])],
   [no],
   [no])
 
 PHP_ARG_WITH([imap-ssl],
   [for IMAP SSL support],
-  [AS_HELP_STRING([--with-imap-ssl[=DIR]],
+  [AS_HELP_STRING([--with-imap-ssl@<:@=DIR@:>@],
     [IMAP: Include SSL support. DIR is the OpenSSL install prefix])],
   [no],
   [no])

--- a/ext/interbase/config.m4
+++ b/ext/interbase/config.m4
@@ -1,7 +1,8 @@
 PHP_ARG_WITH([interbase],
   [for Firebird support],
   [AS_HELP_STRING([--with-interbase[=DIR]],
-    [Include Firebird support. DIR is the Firebird base install directory [/opt/firebird]])])
+    [Include Firebird support. DIR is the Firebird base install directory
+    @<:@/opt/firebird@:>@])])
 
 if test "$PHP_INTERBASE" != "no"; then
 

--- a/ext/interbase/config.m4
+++ b/ext/interbase/config.m4
@@ -1,8 +1,8 @@
 PHP_ARG_WITH([interbase],
   [for Firebird support],
-  [AS_HELP_STRING([--with-interbase@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-interbase[=DIR]]],
     [Include Firebird support. DIR is the Firebird base install directory
-    @<:@/opt/firebird@:>@])])
+    [/opt/firebird]])])
 
 if test "$PHP_INTERBASE" != "no"; then
 

--- a/ext/interbase/config.m4
+++ b/ext/interbase/config.m4
@@ -1,6 +1,7 @@
-PHP_ARG_WITH(interbase,for Firebird support,
-[  --with-interbase[=DIR]    Include Firebird support.  DIR is the Firebird base
-                          install directory [/opt/firebird]])
+PHP_ARG_WITH([interbase],
+  [for Firebird support],
+  [AS_HELP_STRING([--with-interbase[=DIR]],
+    [Include Firebird support. DIR is the Firebird base install directory [/opt/firebird]])])
 
 if test "$PHP_INTERBASE" != "no"; then
 

--- a/ext/interbase/config.m4
+++ b/ext/interbase/config.m4
@@ -1,6 +1,6 @@
 PHP_ARG_WITH([interbase],
   [for Firebird support],
-  [AS_HELP_STRING([--with-interbase[=DIR]],
+  [AS_HELP_STRING([--with-interbase@<:@=DIR@:>@],
     [Include Firebird support. DIR is the Firebird base install directory
     @<:@/opt/firebird@:>@])])
 

--- a/ext/intl/config.m4
+++ b/ext/intl/config.m4
@@ -2,8 +2,10 @@ dnl config.m4 for extension intl
 
 dnl ##########################################################################
 dnl Initialize the extension
-PHP_ARG_ENABLE(intl, whether to enable internationalization support,
-[  --enable-intl           Enable internationalization support])
+PHP_ARG_ENABLE([intl],
+  [whether to enable internationalization support],
+  [AS_HELP_STRING([--enable-intl],
+    [Enable internationalization support])])
 
 if test "$PHP_INTL" != "no"; then
   PHP_SETUP_ICU(INTL_SHARED_LIBADD)

--- a/ext/json/config.m4
+++ b/ext/json/config.m4
@@ -1,7 +1,10 @@
 dnl config.m4 for extension json
 
-PHP_ARG_ENABLE(json, whether to enable JavaScript Object Serialization support,
-[  --disable-json          Disable JavaScript Object Serialization support], yes)
+PHP_ARG_ENABLE([json],
+  [whether to enable JavaScript Object Serialization support],
+  [AS_HELP_STRING([--disable-json],
+    [Disable JavaScript Object Serialization support])],
+  [yes])
 
 if test "$PHP_JSON" != "no"; then
   AC_DEFINE([HAVE_JSON],1 ,[whether to enable JavaScript Object Serialization support])

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -84,12 +84,12 @@ AC_DEFUN([PHP_LDAP_SASL_CHECKS], [
 
 PHP_ARG_WITH([ldap],
   [for LDAP support],
-  [AS_HELP_STRING([--with-ldap@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-ldap[=DIR]]],
     [Include LDAP support])])
 
 PHP_ARG_WITH([ldap-sasl],
   [for LDAP Cyrus SASL support],
-  [AS_HELP_STRING([--with-ldap-sasl@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-ldap-sasl[=DIR]]],
     [LDAP: Include Cyrus SASL support])],
   [no],
   [no])

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -82,11 +82,17 @@ AC_DEFUN([PHP_LDAP_SASL_CHECKS], [
   ])
 ])
 
-PHP_ARG_WITH(ldap,for LDAP support,
-[  --with-ldap[=DIR]         Include LDAP support])
+PHP_ARG_WITH([ldap],
+  [for LDAP support],
+  [AS_HELP_STRING([--with-ldap[=DIR]],
+    [Include LDAP support])])
 
-PHP_ARG_WITH(ldap-sasl,for LDAP Cyrus SASL support,
-[  --with-ldap-sasl[=DIR]    LDAP: Include Cyrus SASL support], no, no)
+PHP_ARG_WITH([ldap-sasl],
+  [for LDAP Cyrus SASL support],
+  [AS_HELP_STRING([--with-ldap-sasl[=DIR]],
+    [LDAP: Include Cyrus SASL support])],
+  [no],
+  [no])
 
 if test "$PHP_LDAP" != "no"; then
 

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -84,12 +84,12 @@ AC_DEFUN([PHP_LDAP_SASL_CHECKS], [
 
 PHP_ARG_WITH([ldap],
   [for LDAP support],
-  [AS_HELP_STRING([--with-ldap[=DIR]],
+  [AS_HELP_STRING([--with-ldap@<:@=DIR@:>@],
     [Include LDAP support])])
 
 PHP_ARG_WITH([ldap-sasl],
   [for LDAP Cyrus SASL support],
-  [AS_HELP_STRING([--with-ldap-sasl[=DIR]],
+  [AS_HELP_STRING([--with-ldap-sasl@<:@=DIR@:>@],
     [LDAP: Include Cyrus SASL support])],
   [no],
   [no])

--- a/ext/libxml/config0.m4
+++ b/ext/libxml/config0.m4
@@ -9,7 +9,7 @@ PHP_ARG_ENABLE([libxml],
 if test -z "$PHP_LIBXML_DIR"; then
   PHP_ARG_WITH([libxml-dir],
     [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir[=DIR]],
+    [AS_HELP_STRING([--with-libxml-dir@<:@=DIR@:>@],
       [LIBXML: libxml2 install prefix])],
     [no],
     [no])

--- a/ext/libxml/config0.m4
+++ b/ext/libxml/config0.m4
@@ -1,11 +1,18 @@
 dnl config.m4 for extension libxml
 
-PHP_ARG_ENABLE(libxml, whether to enable LIBXML support,
-[  --disable-libxml        Disable LIBXML support], yes)
+PHP_ARG_ENABLE([libxml],
+  [whether to enable LIBXML support],
+  [AS_HELP_STRING([--disable-libxml],
+    [Disable LIBXML support])],
+  [yes])
 
 if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH(libxml-dir, libxml2 install dir,
-  [  --with-libxml-dir[=DIR]   LIBXML: libxml2 install prefix], no, no)
+  PHP_ARG_WITH([libxml-dir],
+    [libxml2 install dir],
+    [AS_HELP_STRING([--with-libxml-dir[=DIR]],
+      [LIBXML: libxml2 install prefix])],
+    [no],
+    [no])
 fi
 
 if test "$PHP_LIBXML" != "no"; then

--- a/ext/libxml/config0.m4
+++ b/ext/libxml/config0.m4
@@ -9,7 +9,7 @@ PHP_ARG_ENABLE([libxml],
 if test -z "$PHP_LIBXML_DIR"; then
   PHP_ARG_WITH([libxml-dir],
     [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir@<:@=DIR@:>@],
+    [AS_HELP_STRING([[--with-libxml-dir[=DIR]]],
       [LIBXML: libxml2 install prefix])],
     [no],
     [no])

--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -202,11 +202,17 @@ dnl
 dnl Main config
 dnl
 
-PHP_ARG_ENABLE(mbstring, whether to enable multibyte string support,
-[  --enable-mbstring       Enable multibyte string support])
+PHP_ARG_ENABLE([mbstring],
+  [whether to enable multibyte string support],
+  [AS_HELP_STRING([--enable-mbstring],
+    [Enable multibyte string support])])
 
-PHP_ARG_ENABLE([mbregex], [whether to enable multibyte regex support (requires oniguruma)],
-[  --disable-mbregex       MBSTRING: Disable multibyte regex support], yes, no)
+PHP_ARG_ENABLE([mbregex],
+  [whether to enable multibyte regex support (requires oniguruma)],
+  [AS_HELP_STRING([--disable-mbregex],
+    [MBSTRING: Disable multibyte regex support])],
+  [yes],
+  [no])
 
 if test "$PHP_MBSTRING" != "no"; then
   AC_DEFINE([HAVE_MBSTRING],1,[whether to have multibyte string support])

--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -29,14 +29,14 @@ AC_DEFUN([PHP_MYSQL_SOCKET_SEARCH], [
 
 PHP_ARG_WITH([mysqli],
   [for MySQLi support],
-  [AS_HELP_STRING([--with-mysqli[=FILE]],
+  [AS_HELP_STRING([--with-mysqli@<:@=FILE@:>@],
     [Include MySQLi support. FILE is the path to mysql_config. If no value or
     mysqlnd is passed as FILE, the MySQL native driver will be used])])
 
 dnl ext/pdo_mysql/config.m4 also depends on this configure option.
 PHP_ARG_WITH([mysql-sock],
   [for specified location of the MySQL UNIX socket],
-  [AS_HELP_STRING([--with-mysql-sock[=SOCKPATH]],
+  [AS_HELP_STRING([--with-mysql-sock@<:@=SOCKPATH@:>@],
     [MySQLi/PDO_MYSQL: Location of the MySQL unix socket pointer. If unspecified,
     the default locations are searched])],
   [no],

--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -29,14 +29,14 @@ AC_DEFUN([PHP_MYSQL_SOCKET_SEARCH], [
 
 PHP_ARG_WITH([mysqli],
   [for MySQLi support],
-  [AS_HELP_STRING([--with-mysqli@<:@=FILE@:>@],
+  [AS_HELP_STRING([[--with-mysqli[=FILE]]],
     [Include MySQLi support. FILE is the path to mysql_config. If no value or
     mysqlnd is passed as FILE, the MySQL native driver will be used])])
 
 dnl ext/pdo_mysql/config.m4 also depends on this configure option.
 PHP_ARG_WITH([mysql-sock],
   [for specified location of the MySQL UNIX socket],
-  [AS_HELP_STRING([--with-mysql-sock@<:@=SOCKPATH@:>@],
+  [AS_HELP_STRING([[--with-mysql-sock[=SOCKPATH]]],
     [MySQLi/PDO_MYSQL: Location of the MySQL unix socket pointer. If unspecified,
     the default locations are searched])],
   [no],

--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -30,13 +30,15 @@ AC_DEFUN([PHP_MYSQL_SOCKET_SEARCH], [
 PHP_ARG_WITH([mysqli],
   [for MySQLi support],
   [AS_HELP_STRING([--with-mysqli[=FILE]],
-    [Include MySQLi support. FILE is the path to mysql_config. If no value or mysqlnd is passed as FILE, the MySQL native driver will be used])])
+    [Include MySQLi support. FILE is the path to mysql_config. If no value or
+    mysqlnd is passed as FILE, the MySQL native driver will be used])])
 
 dnl ext/pdo_mysql/config.m4 also depends on this configure option.
 PHP_ARG_WITH([mysql-sock],
   [for specified location of the MySQL UNIX socket],
   [AS_HELP_STRING([--with-mysql-sock[=SOCKPATH]],
-    [MySQLi/PDO_MYSQL: Location of the MySQL unix socket pointer. If unspecified, the default locations are searched])],
+    [MySQLi/PDO_MYSQL: Location of the MySQL unix socket pointer. If unspecified,
+    the default locations are searched])],
   [no],
   [no])
 

--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -27,16 +27,18 @@ AC_DEFUN([PHP_MYSQL_SOCKET_SEARCH], [
   fi
 ])
 
-PHP_ARG_WITH(mysqli, for MySQLi support,
-[  --with-mysqli[=FILE]      Include MySQLi support.  FILE is the path
-                          to mysql_config.  If no value or mysqlnd is passed
-                          as FILE, the MySQL native driver will be used])
+PHP_ARG_WITH([mysqli],
+  [for MySQLi support],
+  [AS_HELP_STRING([--with-mysqli[=FILE]],
+    [Include MySQLi support. FILE is the path to mysql_config. If no value or mysqlnd is passed as FILE, the MySQL native driver will be used])])
 
 dnl ext/pdo_mysql/config.m4 also depends on this configure option.
-PHP_ARG_WITH(mysql-sock, for specified location of the MySQL UNIX socket,
-[  --with-mysql-sock[=SOCKPATH]
-                          MySQLi/PDO_MYSQL: Location of the MySQL unix socket pointer.
-                          If unspecified, the default locations are searched], no, no)
+PHP_ARG_WITH([mysql-sock],
+  [for specified location of the MySQL UNIX socket],
+  [AS_HELP_STRING([--with-mysql-sock[=SOCKPATH]],
+    [MySQLi/PDO_MYSQL: Location of the MySQL unix socket pointer. If unspecified, the default locations are searched])],
+  [no],
+  [no])
 
 if test "$PHP_MYSQLI" = "yes" || test "$PHP_MYSQLI" = "mysqlnd"; then
   dnl This needs to be set in any extension which wishes to use mysqlnd

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -18,7 +18,7 @@ PHP_ARG_ENABLE([mysqlnd_compression_support],
 if test -z "$PHP_ZLIB_DIR"; then
   PHP_ARG_WITH([zlib-dir],
     [for the location of libz],
-    [AS_HELP_STRING([--with-zlib-dir[=DIR]],
+    [AS_HELP_STRING([--with-zlib-dir@<:@=DIR@:>@],
       [mysqlnd: Set the path to libz install prefix])],
     [no],
     [no])

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -18,7 +18,7 @@ PHP_ARG_ENABLE([mysqlnd_compression_support],
 if test -z "$PHP_ZLIB_DIR"; then
   PHP_ARG_WITH([zlib-dir],
     [for the location of libz],
-    [AS_HELP_STRING([--with-zlib-dir@<:@=DIR@:>@],
+    [AS_HELP_STRING([[--with-zlib-dir[=DIR]]],
       [mysqlnd: Set the path to libz install prefix])],
     [no],
     [no])

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -1,16 +1,26 @@
 dnl config.m4 for mysqlnd driver
 
-PHP_ARG_ENABLE(mysqlnd, whether to enable mysqlnd,
-  [  --enable-mysqlnd        Enable mysqlnd explicitly, will be done implicitly
-                          when required by other extensions], no, yes)
+PHP_ARG_ENABLE([mysqlnd],
+  [whether to enable mysqlnd],
+  [AS_HELP_STRING([--enable-mysqlnd],
+    [Enable mysqlnd explicitly, will be done implicitly when required by other extensions])],
+    [no],
+    [yes])
 
-PHP_ARG_ENABLE(mysqlnd_compression_support, whether to disable compressed protocol support in mysqlnd,
-[  --disable-mysqlnd-compression-support
-                          Disable support for the MySQL compressed protocol in mysqlnd], yes, no)
+PHP_ARG_ENABLE([mysqlnd_compression_support],
+  [whether to disable compressed protocol support in mysqlnd],
+  [AS_HELP_STRING([--disable-mysqlnd-compression-support],
+    [Disable support for the MySQL compressed protocol in mysqlnd])],
+  [yes],
+  [no])
 
 if test -z "$PHP_ZLIB_DIR"; then
-  PHP_ARG_WITH(zlib-dir, for the location of libz,
-  [  --with-zlib-dir[=DIR]     mysqlnd: Set the path to libz install prefix], no, no)
+  PHP_ARG_WITH([zlib-dir],
+    [for the location of libz],
+    [AS_HELP_STRING([--with-zlib-dir[=DIR]],
+      [mysqlnd: Set the path to libz install prefix])],
+    [no],
+    [no])
 fi
 
 dnl If some extension uses mysqlnd it will get compiled in PHP core

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -3,9 +3,10 @@ dnl config.m4 for mysqlnd driver
 PHP_ARG_ENABLE([mysqlnd],
   [whether to enable mysqlnd],
   [AS_HELP_STRING([--enable-mysqlnd],
-    [Enable mysqlnd explicitly, will be done implicitly when required by other extensions])],
-    [no],
-    [yes])
+    [Enable mysqlnd explicitly, will be done implicitly when required by other
+    extensions])],
+  [no],
+  [yes])
 
 PHP_ARG_ENABLE([mysqlnd_compression_support],
   [whether to disable compressed protocol support in mysqlnd],

--- a/ext/oci8/config.m4
+++ b/ext/oci8/config.m4
@@ -170,8 +170,8 @@ dnl or
 dnl --with-oci8=shared,/path/to/oracle/home
 PHP_ARG_WITH([oci8],
   [for Oracle Database OCI8 support],
-  [AS_HELP_STRING([--with-oci8@<:@=DIR@:>@],
-    [Include Oracle Database OCI8 support. DIR defaults to @S|@ORACLE_HOME. Use
+  [AS_HELP_STRING([[--with-oci8[=DIR]]],
+    [Include Oracle Database OCI8 support. DIR defaults to $RACLE_HOME. Use
     --with-oci8=instantclient,/path/to/instant/client/lib to use an Oracle
     Instant Client installation])])
 

--- a/ext/oci8/config.m4
+++ b/ext/oci8/config.m4
@@ -171,7 +171,9 @@ dnl --with-oci8=shared,/path/to/oracle/home
 PHP_ARG_WITH([oci8],
   [for Oracle Database OCI8 support],
   [AS_HELP_STRING([--with-oci8[=DIR]],
-    [Include Oracle Database OCI8 support. DIR defaults to [$]ORACLE_HOME. Use --with-oci8=instantclient,/path/to/instant/client/lib to use an Oracle Instant Client installation])])
+    [Include Oracle Database OCI8 support. DIR defaults to [$]ORACLE_HOME. Use
+    --with-oci8=instantclient,/path/to/instant/client/lib to use an Oracle
+    Instant Client installation])])
 
 if test "$PHP_OCI8" != "no"; then
 

--- a/ext/oci8/config.m4
+++ b/ext/oci8/config.m4
@@ -171,7 +171,7 @@ dnl --with-oci8=shared,/path/to/oracle/home
 PHP_ARG_WITH([oci8],
   [for Oracle Database OCI8 support],
   [AS_HELP_STRING([[--with-oci8[=DIR]]],
-    [Include Oracle Database OCI8 support. DIR defaults to $RACLE_HOME. Use
+    [Include Oracle Database OCI8 support. DIR defaults to $ORACLE_HOME. Use
     --with-oci8=instantclient,/path/to/instant/client/lib to use an Oracle
     Instant Client installation])])
 

--- a/ext/oci8/config.m4
+++ b/ext/oci8/config.m4
@@ -170,7 +170,7 @@ dnl or
 dnl --with-oci8=shared,/path/to/oracle/home
 PHP_ARG_WITH([oci8],
   [for Oracle Database OCI8 support],
-  [AS_HELP_STRING([--with-oci8[=DIR]],
+  [AS_HELP_STRING([--with-oci8@<:@=DIR@:>@],
     [Include Oracle Database OCI8 support. DIR defaults to [$]ORACLE_HOME. Use
     --with-oci8=instantclient,/path/to/instant/client/lib to use an Oracle
     Instant Client installation])])

--- a/ext/oci8/config.m4
+++ b/ext/oci8/config.m4
@@ -168,10 +168,10 @@ EOF
 dnl --with-oci8=shared,instantclient,/path/to/client/dir/lib
 dnl or
 dnl --with-oci8=shared,/path/to/oracle/home
-PHP_ARG_WITH(oci8, for Oracle Database OCI8 support,
-[  --with-oci8[=DIR]         Include Oracle Database OCI8 support. DIR defaults to [$]ORACLE_HOME.
-                          Use --with-oci8=instantclient,/path/to/instant/client/lib
-                          to use an Oracle Instant Client installation])
+PHP_ARG_WITH([oci8],
+  [for Oracle Database OCI8 support],
+  [AS_HELP_STRING([--with-oci8[=DIR]],
+    [Include Oracle Database OCI8 support. DIR defaults to [$]ORACLE_HOME. Use --with-oci8=instantclient,/path/to/instant/client/lib to use an Oracle Instant Client installation])])
 
 if test "$PHP_OCI8" != "no"; then
 

--- a/ext/oci8/config.m4
+++ b/ext/oci8/config.m4
@@ -171,7 +171,7 @@ dnl --with-oci8=shared,/path/to/oracle/home
 PHP_ARG_WITH([oci8],
   [for Oracle Database OCI8 support],
   [AS_HELP_STRING([--with-oci8@<:@=DIR@:>@],
-    [Include Oracle Database OCI8 support. DIR defaults to [$]ORACLE_HOME. Use
+    [Include Oracle Database OCI8 support. DIR defaults to @S|@ORACLE_HOME. Use
     --with-oci8=instantclient,/path/to/instant/client/lib to use an Oracle
     Instant Client installation])])
 

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -98,13 +98,15 @@ dnl
 dnl configure options
 dnl
 
-PHP_ARG_WITH(odbcver,,
-[  --with-odbcver[=HEX]      Force support for the passed ODBC version. A hex number is expected, default 0x0350.
-                          Use the special value of 0 to prevent an explicit ODBCVER to be defined. ], 0x0350)
+PHP_ARG_WITH([odbcver],,
+  [AS_HELP_STRING([--with-odbcver[=HEX]],
+    [Force support for the passed ODBC version. A hex number is expected, default 0x0350. Use the special value of 0 to prevent an explicit ODBCVER to be defined.])],
+  [0x0350])
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(adabas,,
-[  --with-adabas[=DIR]       Include Adabas D support [/usr/local]])
+PHP_ARG_WITH([adabas],,
+  [AS_HELP_STRING([--with-adabas[=DIR]],
+    [Include Adabas D support [/usr/local]])])
 
   AC_MSG_CHECKING([for Adabas support])
   if test "$PHP_ADABAS" != "no"; then
@@ -132,8 +134,9 @@ PHP_ARG_WITH(adabas,,
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(sapdb,,
-[  --with-sapdb[=DIR]        Include SAP DB support [/usr/local]])
+PHP_ARG_WITH([sapdb],,
+  [AS_HELP_STRING([--with-sapdb[=DIR]],
+    [Include SAP DB support [/usr/local]])])
 
   AC_MSG_CHECKING([for SAP DB support])
   if test "$PHP_SAPDB" != "no"; then
@@ -152,8 +155,9 @@ PHP_ARG_WITH(sapdb,,
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(solid,,
-[  --with-solid[=DIR]        Include Solid support [/usr/local/solid]])
+PHP_ARG_WITH([solid],,
+  [AS_HELP_STRING([--with-solid[=DIR]],
+    [Include Solid support [/usr/local/solid]])])
 
   AC_MSG_CHECKING(for Solid support)
   if test "$PHP_SOLID" != "no"; then
@@ -179,8 +183,9 @@ PHP_ARG_WITH(solid,,
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(ibm-db2,,
-[  --with-ibm-db2[=DIR]      Include IBM DB2 support [/home/db2inst1/sqllib]])
+PHP_ARG_WITH([ibm-db2],,
+  [AS_HELP_STRING([--with-ibm-db2[=DIR]],
+    [Include IBM DB2 support [/home/db2inst1/sqllib]])])
 
   AC_MSG_CHECKING(for IBM DB2 support)
   if test "$PHP_IBM_DB2" != "no"; then
@@ -218,9 +223,9 @@ You need to source your DB2 environment before running PHP configure:
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(empress,,
-[  --with-empress[=DIR]      Include Empress support [\$EMPRESSPATH]
-                          (Empress Version >= 8.60 required)])
+PHP_ARG_WITH([empress],,
+  [AS_HELP_STRING([--with-empress[=DIR]],
+    [Include Empress support [\$EMPRESSPATH] (Empress Version >= 8.60 required)])])
 
   AC_MSG_CHECKING(for Empress support)
   if test "$PHP_EMPRESS" != "no"; then
@@ -243,9 +248,9 @@ PHP_ARG_WITH(empress,,
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(empress-bcs,,
-[  --with-empress-bcs[=DIR]  Include Empress Local Access support [\$EMPRESSPATH]
-                          (Empress Version >= 8.60 required)])
+PHP_ARG_WITH([empress-bcs],,
+  [AS_HELP_STRING([--with-empress-bcs[=DIR]],
+    [Include Empress Local Access support [\$EMPRESSPATH] (Empress Version >= 8.60 required)])])
 
   AC_MSG_CHECKING(for Empress local access support)
   if test "$PHP_EMPRESS_BCS" != "no"; then
@@ -284,15 +289,16 @@ PHP_ARG_WITH(empress-bcs,,
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(custom-odbc,,
-[  --with-custom-odbc[=DIR]  Include user defined ODBC support. DIR is ODBC install base
-                          directory [/usr/local]. Make sure to define CUSTOM_ODBC_LIBS and
-                          have some odbc.h in your include dirs. f.e. you should define
-                          following for Sybase SQL Anywhere 5.5.00 on QNX, prior to
-                          running this configure script:
-                            CPPFLAGS=\"-DODBC_QNX -DSQLANY_BUG\"
-                            LDFLAGS=-lunix
-                            CUSTOM_ODBC_LIBS=\"-ldblib -lodbc\"])
+PHP_ARG_WITH([custom-odbc],,
+  [AS_HELP_STRING([--with-custom-odbc[=DIR]],
+    [Include user defined ODBC support. DIR is ODBC install base
+      directory [/usr/local]. Make sure to define CUSTOM_ODBC_LIBS and
+      have some odbc.h in your include dirs. f.e. you should define
+      following for Sybase SQL Anywhere 5.5.00 on QNX, prior to
+      running this configure script:
+      CPPFLAGS=\"-DODBC_QNX -DSQLANY_BUG\"
+      LDFLAGS=-lunix
+      CUSTOM_ODBC_LIBS=\"-ldblib -lodbc\"])])
 
   AC_MSG_CHECKING(for a custom ODBC support)
   if test "$PHP_CUSTOM_ODBC" != "no"; then
@@ -313,8 +319,9 @@ PHP_ARG_WITH(custom-odbc,,
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(iodbc,,
-[  --with-iodbc[=DIR]        Include iODBC support [/usr/local]])
+PHP_ARG_WITH([iodbc],,
+  [AS_HELP_STRING([--with-iodbc[=DIR]],
+    [Include iODBC support [/usr/local]])])
 
   AC_MSG_CHECKING(for iODBC support)
   if test "$PHP_IODBC" != "no"; then
@@ -351,8 +358,9 @@ PHP_ARG_WITH(iodbc,,
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(esoob,,
-[  --with-esoob[=DIR]        Include Easysoft OOB support [/usr/local/easysoft/oob/client]])
+PHP_ARG_WITH([esoob],,
+  [AS_HELP_STRING([--with-esoob[=DIR]],
+    [Include Easysoft OOB support [/usr/local/easysoft/oob/client]])])
 
   AC_MSG_CHECKING(for Easysoft ODBC-ODBC Bridge support)
   if test "$PHP_ESOOB" != "no"; then
@@ -373,8 +381,9 @@ PHP_ARG_WITH(esoob,,
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(unixODBC,,
-[  --with-unixODBC[=DIR]     Include unixODBC support [/usr/local]])
+PHP_ARG_WITH([unixODBC],,
+  [AS_HELP_STRING([--with-unixODBC[=DIR]],
+    [Include unixODBC support [/usr/local]])])
 
   AC_MSG_CHECKING(for unixODBC support)
   if test "$PHP_UNIXODBC" != "no"; then
@@ -396,8 +405,9 @@ PHP_ARG_WITH(unixODBC,,
 fi
 
 if test -z "$ODBC_TYPE"; then
-PHP_ARG_WITH(dbmaker,,
-[  --with-dbmaker[=DIR]      Include DBMaker support])
+PHP_ARG_WITH([dbmaker],,
+  [AS_HELP_STRING([--with-dbmaker[=DIR]],
+    [Include DBMaker support])])
 
   AC_MSG_CHECKING(for DBMaker support)
   if test "$PHP_DBMAKER" != "no"; then

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -100,13 +100,15 @@ dnl
 
 PHP_ARG_WITH([odbcver],,
   [AS_HELP_STRING([--with-odbcver[=HEX]],
-    [Force support for the passed ODBC version. A hex number is expected, default 0x0350. Use the special value of 0 to prevent an explicit ODBCVER to be defined.])],
+    [Force support for the passed ODBC version. A hex number is expected,
+    default 0x0350. Use the special value of 0 to prevent an explicit ODBCVER to
+    be defined.])],
   [0x0350])
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([adabas],,
   [AS_HELP_STRING([--with-adabas[=DIR]],
-    [Include Adabas D support [/usr/local]])])
+    [Include Adabas D support @<:@/usr/local@:>@])])
 
   AC_MSG_CHECKING([for Adabas support])
   if test "$PHP_ADABAS" != "no"; then
@@ -225,7 +227,8 @@ fi
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([empress],,
   [AS_HELP_STRING([--with-empress[=DIR]],
-    [Include Empress support [\$EMPRESSPATH] (Empress Version >= 8.60 required)])])
+    [Include Empress support [\$EMPRESSPATH] (Empress Version >= 8.60
+    required)])])
 
   AC_MSG_CHECKING(for Empress support)
   if test "$PHP_EMPRESS" != "no"; then
@@ -250,7 +253,8 @@ fi
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([empress-bcs],,
   [AS_HELP_STRING([--with-empress-bcs[=DIR]],
-    [Include Empress Local Access support [\$EMPRESSPATH] (Empress Version >= 8.60 required)])])
+    [Include Empress Local Access support [\$EMPRESSPATH] (Empress Version >=
+    8.60 required)])])
 
   AC_MSG_CHECKING(for Empress local access support)
   if test "$PHP_EMPRESS_BCS" != "no"; then
@@ -291,14 +295,12 @@ fi
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([custom-odbc],,
   [AS_HELP_STRING([--with-custom-odbc[=DIR]],
-    [Include user defined ODBC support. DIR is ODBC install base
-      directory [/usr/local]. Make sure to define CUSTOM_ODBC_LIBS and
-      have some odbc.h in your include dirs. f.e. you should define
-      following for Sybase SQL Anywhere 5.5.00 on QNX, prior to
-      running this configure script:
-      CPPFLAGS=\"-DODBC_QNX -DSQLANY_BUG\"
-      LDFLAGS=-lunix
-      CUSTOM_ODBC_LIBS=\"-ldblib -lodbc\"])])
+    [Include user defined ODBC support. DIR is ODBC install base directory
+    @<:@/usr/local@:>@. Make sure to define CUSTOM_ODBC_LIBS and have some
+    odbc.h in your include dirs. f.e. you should define following for Sybase SQL
+    Anywhere 5.5.00 on QNX, prior to running this configure script:
+    CPPFLAGS=\"-DODBC_QNX -DSQLANY_BUG\" LDFLAGS=-lunix
+    CUSTOM_ODBC_LIBS=\"-ldblib -lodbc\"])])
 
   AC_MSG_CHECKING(for a custom ODBC support)
   if test "$PHP_CUSTOM_ODBC" != "no"; then

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -99,7 +99,7 @@ dnl configure options
 dnl
 
 PHP_ARG_WITH([odbcver],,
-  [AS_HELP_STRING([--with-odbcver@<:@=HEX@:>@],
+  [AS_HELP_STRING([[--with-odbcver[=HEX]]],
     [Force support for the passed ODBC version. A hex number is expected,
     default 0x0350. Use the special value of 0 to prevent an explicit ODBCVER to
     be defined.])],
@@ -107,8 +107,8 @@ PHP_ARG_WITH([odbcver],,
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([adabas],,
-  [AS_HELP_STRING([--with-adabas@<:@=DIR@:>@],
-    [Include Adabas D support @<:@/usr/local@:>@])])
+  [AS_HELP_STRING([[--with-adabas[=DIR]]],
+    [Include Adabas D support [/usr/local]])])
 
   AC_MSG_CHECKING([for Adabas support])
   if test "$PHP_ADABAS" != "no"; then
@@ -137,7 +137,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([sapdb],,
-  [AS_HELP_STRING([--with-sapdb@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-sapdb[=DIR]]],
     [Include SAP DB support [/usr/local]])])
 
   AC_MSG_CHECKING([for SAP DB support])
@@ -158,7 +158,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([solid],,
-  [AS_HELP_STRING([--with-solid@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-solid[=DIR]]],
     [Include Solid support [/usr/local/solid]])])
 
   AC_MSG_CHECKING(for Solid support)
@@ -186,7 +186,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([ibm-db2],,
-  [AS_HELP_STRING([--with-ibm-db2@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-ibm-db2[=DIR]]],
     [Include IBM DB2 support [/home/db2inst1/sqllib]])])
 
   AC_MSG_CHECKING(for IBM DB2 support)
@@ -226,8 +226,8 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([empress],,
-  [AS_HELP_STRING([--with-empress@<:@=DIR@:>@],
-    [Include Empress support @S|@EMPRESSPATH (Empress Version >= 8.60
+  [AS_HELP_STRING([[--with-empress[=DIR]]],
+    [Include Empress support $EMPRESSPATH (Empress Version >= 8.60
     required)])])
 
   AC_MSG_CHECKING(for Empress support)
@@ -252,8 +252,8 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([empress-bcs],,
-  [AS_HELP_STRING([--with-empress-bcs@<:@=DIR@:>@],
-    [Include Empress Local Access support @S|@EMPRESSPATH (Empress Version >=
+  [AS_HELP_STRING([[--with-empress-bcs[=DIR]]],
+    [Include Empress Local Access support $EMPRESSPATH (Empress Version >=
     8.60 required)])])
 
   AC_MSG_CHECKING(for Empress local access support)
@@ -294,11 +294,11 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([custom-odbc],,
-  [AS_HELP_STRING([--with-custom-odbc@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-custom-odbc[=DIR]]],
     [Include user defined ODBC support. DIR is ODBC install base directory
-    @<:@/usr/local@:>@. Make sure to define CUSTOM_ODBC_LIBS and have some
-    odbc.h in your include dirs. f.e. you should define following for Sybase SQL
-    Anywhere 5.5.00 on QNX, prior to running this configure script:
+    [/usr/local]. Make sure to define CUSTOM_ODBC_LIBS and have some odbc.h in
+    your include dirs. f.e. you should define following for Sybase SQL Anywhere
+    5.5.00 on QNX, prior to running this configure script:
     CPPFLAGS=\"-DODBC_QNX -DSQLANY_BUG\" LDFLAGS=-lunix
     CUSTOM_ODBC_LIBS=\"-ldblib -lodbc\"])])
 
@@ -322,7 +322,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([iodbc],,
-  [AS_HELP_STRING([--with-iodbc@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-iodbc[=DIR]]],
     [Include iODBC support [/usr/local]])])
 
   AC_MSG_CHECKING(for iODBC support)
@@ -361,7 +361,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([esoob],,
-  [AS_HELP_STRING([--with-esoob@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-esoob[=DIR]]],
     [Include Easysoft OOB support [/usr/local/easysoft/oob/client]])])
 
   AC_MSG_CHECKING(for Easysoft ODBC-ODBC Bridge support)
@@ -384,7 +384,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([unixODBC],,
-  [AS_HELP_STRING([--with-unixODBC@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-unixODBC[=DIR]]],
     [Include unixODBC support [/usr/local]])])
 
   AC_MSG_CHECKING(for unixODBC support)
@@ -408,7 +408,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([dbmaker],,
-  [AS_HELP_STRING([--with-dbmaker@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-dbmaker[=DIR]]],
     [Include DBMaker support])])
 
   AC_MSG_CHECKING(for DBMaker support)

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -227,7 +227,7 @@ fi
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([empress],,
   [AS_HELP_STRING([--with-empress@<:@=DIR@:>@],
-    [Include Empress support [\$EMPRESSPATH] (Empress Version >= 8.60
+    [Include Empress support @S|@EMPRESSPATH (Empress Version >= 8.60
     required)])])
 
   AC_MSG_CHECKING(for Empress support)
@@ -253,7 +253,7 @@ fi
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([empress-bcs],,
   [AS_HELP_STRING([--with-empress-bcs@<:@=DIR@:>@],
-    [Include Empress Local Access support [\$EMPRESSPATH] (Empress Version >=
+    [Include Empress Local Access support @S|@EMPRESSPATH (Empress Version >=
     8.60 required)])])
 
   AC_MSG_CHECKING(for Empress local access support)

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -299,8 +299,8 @@ PHP_ARG_WITH([custom-odbc],,
     [/usr/local]. Make sure to define CUSTOM_ODBC_LIBS and have some odbc.h in
     your include dirs. f.e. you should define following for Sybase SQL Anywhere
     5.5.00 on QNX, prior to running this configure script:
-    CPPFLAGS=\"-DODBC_QNX -DSQLANY_BUG\" LDFLAGS=-lunix
-    CUSTOM_ODBC_LIBS=\"-ldblib -lodbc\"])])
+    CPPFLAGS="-DODBC_QNX -DSQLANY_BUG" LDFLAGS=-lunix
+    CUSTOM_ODBC_LIBS="-ldblib -lodbc"])])
 
   AC_MSG_CHECKING(for a custom ODBC support)
   if test "$PHP_CUSTOM_ODBC" != "no"; then

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -99,7 +99,7 @@ dnl configure options
 dnl
 
 PHP_ARG_WITH([odbcver],,
-  [AS_HELP_STRING([--with-odbcver[=HEX]],
+  [AS_HELP_STRING([--with-odbcver@<:@=HEX@:>@],
     [Force support for the passed ODBC version. A hex number is expected,
     default 0x0350. Use the special value of 0 to prevent an explicit ODBCVER to
     be defined.])],
@@ -107,7 +107,7 @@ PHP_ARG_WITH([odbcver],,
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([adabas],,
-  [AS_HELP_STRING([--with-adabas[=DIR]],
+  [AS_HELP_STRING([--with-adabas@<:@=DIR@:>@],
     [Include Adabas D support @<:@/usr/local@:>@])])
 
   AC_MSG_CHECKING([for Adabas support])
@@ -137,7 +137,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([sapdb],,
-  [AS_HELP_STRING([--with-sapdb[=DIR]],
+  [AS_HELP_STRING([--with-sapdb@<:@=DIR@:>@],
     [Include SAP DB support [/usr/local]])])
 
   AC_MSG_CHECKING([for SAP DB support])
@@ -158,7 +158,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([solid],,
-  [AS_HELP_STRING([--with-solid[=DIR]],
+  [AS_HELP_STRING([--with-solid@<:@=DIR@:>@],
     [Include Solid support [/usr/local/solid]])])
 
   AC_MSG_CHECKING(for Solid support)
@@ -186,7 +186,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([ibm-db2],,
-  [AS_HELP_STRING([--with-ibm-db2[=DIR]],
+  [AS_HELP_STRING([--with-ibm-db2@<:@=DIR@:>@],
     [Include IBM DB2 support [/home/db2inst1/sqllib]])])
 
   AC_MSG_CHECKING(for IBM DB2 support)
@@ -226,7 +226,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([empress],,
-  [AS_HELP_STRING([--with-empress[=DIR]],
+  [AS_HELP_STRING([--with-empress@<:@=DIR@:>@],
     [Include Empress support [\$EMPRESSPATH] (Empress Version >= 8.60
     required)])])
 
@@ -252,7 +252,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([empress-bcs],,
-  [AS_HELP_STRING([--with-empress-bcs[=DIR]],
+  [AS_HELP_STRING([--with-empress-bcs@<:@=DIR@:>@],
     [Include Empress Local Access support [\$EMPRESSPATH] (Empress Version >=
     8.60 required)])])
 
@@ -294,7 +294,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([custom-odbc],,
-  [AS_HELP_STRING([--with-custom-odbc[=DIR]],
+  [AS_HELP_STRING([--with-custom-odbc@<:@=DIR@:>@],
     [Include user defined ODBC support. DIR is ODBC install base directory
     @<:@/usr/local@:>@. Make sure to define CUSTOM_ODBC_LIBS and have some
     odbc.h in your include dirs. f.e. you should define following for Sybase SQL
@@ -322,7 +322,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([iodbc],,
-  [AS_HELP_STRING([--with-iodbc[=DIR]],
+  [AS_HELP_STRING([--with-iodbc@<:@=DIR@:>@],
     [Include iODBC support [/usr/local]])])
 
   AC_MSG_CHECKING(for iODBC support)
@@ -361,7 +361,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([esoob],,
-  [AS_HELP_STRING([--with-esoob[=DIR]],
+  [AS_HELP_STRING([--with-esoob@<:@=DIR@:>@],
     [Include Easysoft OOB support [/usr/local/easysoft/oob/client]])])
 
   AC_MSG_CHECKING(for Easysoft ODBC-ODBC Bridge support)
@@ -384,7 +384,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([unixODBC],,
-  [AS_HELP_STRING([--with-unixODBC[=DIR]],
+  [AS_HELP_STRING([--with-unixODBC@<:@=DIR@:>@],
     [Include unixODBC support [/usr/local]])])
 
   AC_MSG_CHECKING(for unixODBC support)
@@ -408,7 +408,7 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([dbmaker],,
-  [AS_HELP_STRING([--with-dbmaker[=DIR]],
+  [AS_HELP_STRING([--with-dbmaker@<:@=DIR@:>@],
     [Include DBMaker support])])
 
   AC_MSG_CHECKING(for DBMaker support)

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -1,11 +1,17 @@
 dnl config.m4 for extension opcache
 
-PHP_ARG_ENABLE(opcache, whether to enable Zend OPcache support,
-[  --disable-opcache       Disable Zend OPcache support], yes)
+PHP_ARG_ENABLE([opcache],
+  [whether to enable Zend OPcache support],
+  [AS_HELP_STRING([--disable-opcache],
+    [Disable Zend OPcache support])],
+  [yes])
 
-PHP_ARG_ENABLE(huge-code-pages, whether to enable copying PHP CODE pages into HUGE PAGES,
-[  --disable-huge-code-pages
-                          Disable copying PHP CODE pages into HUGE PAGES], yes, no)
+PHP_ARG_ENABLE([huge-code-pages],
+  [whether to enable copying PHP CODE pages into HUGE PAGES],
+  [AS_HELP_STRING([--disable-huge-code-pages],
+    [Disable copying PHP CODE pages into HUGE PAGES])],
+  [yes],
+  [no])
 
 if test "$PHP_OPCACHE" != "no"; then
 

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -9,8 +9,8 @@ PHP_ARG_WITH([kerberos],
   [for Kerberos support],
   [AS_HELP_STRING([--with-kerberos[=DIR]],
     [OPENSSL: Include Kerberos support])],
-    [no],
-    [no])
+  [no],
+  [no])
 
 PHP_ARG_WITH([system-ciphers],
   [whether to use system default cipher list instead of hardcoded value],

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -1,13 +1,23 @@
 dnl config.m4 for extension openssl
 
-PHP_ARG_WITH(openssl, for OpenSSL support,
-[  --with-openssl            Include OpenSSL support (requires OpenSSL >= 1.0.1)])
+PHP_ARG_WITH([openssl],
+  [for OpenSSL support],
+  [AS_HELP_STRING([--with-openssl],
+    [Include OpenSSL support (requires OpenSSL >= 1.0.1)])])
 
-PHP_ARG_WITH(kerberos, for Kerberos support,
-[  --with-kerberos[=DIR]     OPENSSL: Include Kerberos support], no, no)
+PHP_ARG_WITH([kerberos],
+  [for Kerberos support],
+  [AS_HELP_STRING([--with-kerberos[=DIR]],
+    [OPENSSL: Include Kerberos support])],
+    [no],
+    [no])
 
-PHP_ARG_WITH(system-ciphers, whether to use system default cipher list instead of hardcoded value,
-[  --with-system-ciphers   OPENSSL: Use system default cipher list instead of hardcoded value], no, no)
+PHP_ARG_WITH([system-ciphers],
+  [whether to use system default cipher list instead of hardcoded value],
+  [AS_HELP_STRING([--with-system-ciphers],
+    [OPENSSL: Use system default cipher list instead of hardcoded value])],
+  [no],
+  [no])
 
 if test "$PHP_OPENSSL" != "no"; then
   PHP_NEW_EXTENSION(openssl, openssl.c xp_ssl.c, $ext_shared)

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -7,7 +7,7 @@ PHP_ARG_WITH([openssl],
 
 PHP_ARG_WITH([kerberos],
   [for Kerberos support],
-  [AS_HELP_STRING([--with-kerberos@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-kerberos[=DIR]]],
     [OPENSSL: Include Kerberos support])],
   [no],
   [no])

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -7,7 +7,7 @@ PHP_ARG_WITH([openssl],
 
 PHP_ARG_WITH([kerberos],
   [for Kerberos support],
-  [AS_HELP_STRING([--with-kerberos[=DIR]],
+  [AS_HELP_STRING([--with-kerberos@<:@=DIR@:>@],
     [OPENSSL: Include Kerberos support])],
   [no],
   [no])

--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension pcntl
 
-PHP_ARG_ENABLE(pcntl, whether to enable pcntl support,
-[  --enable-pcntl          Enable pcntl support (CLI/CGI only)])
+PHP_ARG_ENABLE([pcntl],
+  [whether to enable pcntl support],
+  [AS_HELP_STRING([--enable-pcntl],
+    [Enable pcntl support (CLI/CGI only)])])
 
 if test "$PHP_PCNTL" != "no"; then
   AC_CHECK_FUNCS(fork, [ AC_DEFINE(HAVE_FORK,1,[ ]) ], [ AC_MSG_ERROR(pcntl: fork() not supported by this platform) ])

--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -3,10 +3,17 @@ dnl config.m4 for extension pcre
 dnl By default we'll compile and link against the bundled PCRE library
 dnl if DIR is supplied, we'll use that for linking
 
-PHP_ARG_WITH(external-pcre,,
-[  --with-external-pcre    Use external library for PCRE support], no, no)
+PHP_ARG_WITH([external-pcre],,
+  [AS_HELP_STRING([--with-external-pcre],
+    [Use external library for PCRE support])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(pcre-jit,,[  --with-pcre-jit         Enable PCRE JIT functionality], yes, no)
+PHP_ARG_WITH([pcre-jit],,
+  [AS_HELP_STRING([--with-pcre-jit],
+    [Enable PCRE JIT functionality])],
+  [yes],
+  [no])
 
 if test "$PHP_EXTERNAL_PCRE" != "no"; then
 
@@ -77,8 +84,12 @@ else
   fi
 fi
 
-PHP_ARG_WITH(pcre-valgrind,,[  --with-pcre-valgrind=DIR
-                          Enable PCRE valgrind support. Developers only!], no, no)
+PHP_ARG_WITH([pcre-valgrind],,
+  [AS_HELP_STRING([--with-pcre-valgrind=DIR],
+    [Enable PCRE valgrind support. Developers only!])],
+  [no],
+  [no])
+
   if test "$PHP_EXTERNAL_PCRE" != "no"; then
     AC_MSG_WARN([PHP is going to be linked with an external PCRE, --with-pcre-valgrind has no effect])
   else

--- a/ext/pdo/config.m4
+++ b/ext/pdo/config.m4
@@ -1,7 +1,10 @@
 dnl config.m4 for extension pdo
 
-PHP_ARG_ENABLE(pdo, whether to enable PDO support,
-[  --disable-pdo           Disable PHP Data Objects support], yes)
+PHP_ARG_ENABLE([pdo],
+  [whether to enable PDO support],
+  [AS_HELP_STRING([--disable-pdo],
+    [Disable PHP Data Objects support])],
+  [yes])
 
 if test "$PHP_PDO" != "no"; then
 

--- a/ext/pdo_dblib/config.m4
+++ b/ext/pdo_dblib/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension pdo_dblib
 
 PHP_ARG_WITH([pdo-dblib],
   [for PDO_DBLIB support via FreeTDS],
-  [AS_HELP_STRING([--with-pdo-dblib[=DIR]],
+  [AS_HELP_STRING([--with-pdo-dblib@<:@=DIR@:>@],
     [PDO: DBLIB-DB support. DIR is the FreeTDS home directory])])
 
 if test "$PHP_PDO_DBLIB" != "no"; then

--- a/ext/pdo_dblib/config.m4
+++ b/ext/pdo_dblib/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension pdo_dblib
 
 PHP_ARG_WITH([pdo-dblib],
   [for PDO_DBLIB support via FreeTDS],
-  [AS_HELP_STRING([--with-pdo-dblib@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-pdo-dblib[=DIR]]],
     [PDO: DBLIB-DB support. DIR is the FreeTDS home directory])])
 
 if test "$PHP_PDO_DBLIB" != "no"; then

--- a/ext/pdo_dblib/config.m4
+++ b/ext/pdo_dblib/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension pdo_dblib
 
-PHP_ARG_WITH(pdo-dblib, for PDO_DBLIB support via FreeTDS,
-[  --with-pdo-dblib[=DIR]    PDO: DBLIB-DB support.  DIR is the FreeTDS home directory])
+PHP_ARG_WITH([pdo-dblib],
+  [for PDO_DBLIB support via FreeTDS],
+  [AS_HELP_STRING([--with-pdo-dblib[=DIR]],
+    [PDO: DBLIB-DB support. DIR is the FreeTDS home directory])])
 
 if test "$PHP_PDO_DBLIB" != "no"; then
 

--- a/ext/pdo_firebird/config.m4
+++ b/ext/pdo_firebird/config.m4
@@ -1,6 +1,6 @@
 PHP_ARG_WITH([pdo-firebird],
   [for Firebird support for PDO],
-  [AS_HELP_STRING([--with-pdo-firebird[=DIR]],
+  [AS_HELP_STRING([--with-pdo-firebird@<:@=DIR@:>@],
     [PDO: Firebird support. DIR is the Firebird base install directory
     @<:@/opt/firebird@:>@])])
 

--- a/ext/pdo_firebird/config.m4
+++ b/ext/pdo_firebird/config.m4
@@ -1,6 +1,7 @@
-PHP_ARG_WITH(pdo-firebird,for Firebird support for PDO,
-[  --with-pdo-firebird[=DIR] PDO: Firebird support.  DIR is the Firebird base
-                          install directory [/opt/firebird]])
+PHP_ARG_WITH([pdo-firebird],
+  [for Firebird support for PDO],
+  [AS_HELP_STRING([--with-pdo-firebird[=DIR]],
+    [PDO: Firebird support. DIR is the Firebird base install directory [/opt/firebird]])])
 
 if test "$PHP_PDO_FIREBIRD" != "no"; then
 

--- a/ext/pdo_firebird/config.m4
+++ b/ext/pdo_firebird/config.m4
@@ -1,8 +1,8 @@
 PHP_ARG_WITH([pdo-firebird],
   [for Firebird support for PDO],
-  [AS_HELP_STRING([--with-pdo-firebird@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-pdo-firebird[=DIR]]],
     [PDO: Firebird support. DIR is the Firebird base install directory
-    @<:@/opt/firebird@:>@])])
+    [/opt/firebird]])])
 
 if test "$PHP_PDO_FIREBIRD" != "no"; then
 

--- a/ext/pdo_firebird/config.m4
+++ b/ext/pdo_firebird/config.m4
@@ -1,7 +1,8 @@
 PHP_ARG_WITH([pdo-firebird],
   [for Firebird support for PDO],
   [AS_HELP_STRING([--with-pdo-firebird[=DIR]],
-    [PDO: Firebird support. DIR is the Firebird base install directory [/opt/firebird]])])
+    [PDO: Firebird support. DIR is the Firebird base install directory
+    @<:@/opt/firebird@:>@])])
 
 if test "$PHP_PDO_FIREBIRD" != "no"; then
 

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -1,13 +1,17 @@
 dnl config.m4 for extension pdo_mysql
 
-PHP_ARG_WITH(pdo-mysql, for MySQL support for PDO,
-[  --with-pdo-mysql[=DIR]    PDO: MySQL support. DIR is the MySQL base directory
-                          If no value or mysqlnd is passed as DIR, the
-                          MySQL native driver will be used])
+PHP_ARG_WITH([pdo-mysql],
+  [for MySQL support for PDO],
+  [AS_HELP_STRING([--with-pdo-mysql[=DIR]],
+    [PDO: MySQL support. DIR is the MySQL base directory. If no value or mysqlnd is passed as DIR, the MySQL native driver will be used])])
 
 if test -z "$PHP_ZLIB_DIR"; then
-  PHP_ARG_WITH(zlib-dir, for the location of libz,
-  [  --with-zlib-dir[=DIR]     PDO_MySQL: Set the path to libz install prefix], no, no)
+  PHP_ARG_WITH([zlib-dir],
+    [for the location of libz],
+    [AS_HELP_STRING([--with-zlib-dir[=DIR]],
+      [PDO_MySQL: Set the path to libz install prefix])],
+    [no],
+    [no])
 fi
 
 if test "$PHP_PDO_MYSQL" != "no"; then

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -2,14 +2,14 @@ dnl config.m4 for extension pdo_mysql
 
 PHP_ARG_WITH([pdo-mysql],
   [for MySQL support for PDO],
-  [AS_HELP_STRING([--with-pdo-mysql@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-pdo-mysql[=DIR]]],
     [PDO: MySQL support. DIR is the MySQL base directory. If no value or mysqlnd
     is passed as DIR, the MySQL native driver will be used])])
 
 if test -z "$PHP_ZLIB_DIR"; then
   PHP_ARG_WITH([zlib-dir],
     [for the location of libz],
-    [AS_HELP_STRING([--with-zlib-dir@<:@=DIR@:>@],
+    [AS_HELP_STRING([[--with-zlib-dir[=DIR]]],
       [PDO_MySQL: Set the path to libz install prefix])],
     [no],
     [no])

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -3,7 +3,8 @@ dnl config.m4 for extension pdo_mysql
 PHP_ARG_WITH([pdo-mysql],
   [for MySQL support for PDO],
   [AS_HELP_STRING([--with-pdo-mysql[=DIR]],
-    [PDO: MySQL support. DIR is the MySQL base directory. If no value or mysqlnd is passed as DIR, the MySQL native driver will be used])])
+    [PDO: MySQL support. DIR is the MySQL base directory. If no value or mysqlnd
+    is passed as DIR, the MySQL native driver will be used])])
 
 if test -z "$PHP_ZLIB_DIR"; then
   PHP_ARG_WITH([zlib-dir],

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -2,14 +2,14 @@ dnl config.m4 for extension pdo_mysql
 
 PHP_ARG_WITH([pdo-mysql],
   [for MySQL support for PDO],
-  [AS_HELP_STRING([--with-pdo-mysql[=DIR]],
+  [AS_HELP_STRING([--with-pdo-mysql@<:@=DIR@:>@],
     [PDO: MySQL support. DIR is the MySQL base directory. If no value or mysqlnd
     is passed as DIR, the MySQL native driver will be used])])
 
 if test -z "$PHP_ZLIB_DIR"; then
   PHP_ARG_WITH([zlib-dir],
     [for the location of libz],
-    [AS_HELP_STRING([--with-zlib-dir[=DIR]],
+    [AS_HELP_STRING([--with-zlib-dir@<:@=DIR@:>@],
       [PDO_MySQL: Set the path to libz install prefix])],
     [no],
     [no])

--- a/ext/pdo_oci/config.m4
+++ b/ext/pdo_oci/config.m4
@@ -53,10 +53,10 @@ AC_DEFUN([AC_PDO_OCI_CHECK_LIB_DIR],[
   AC_MSG_RESULT($PDO_OCI_LIB_DIR)
 ])
 
-PHP_ARG_WITH(pdo-oci, Oracle OCI support for PDO,
-[  --with-pdo-oci[=DIR]      PDO: Oracle OCI support. DIR defaults to [$]ORACLE_HOME.
-                          Use --with-pdo-oci=instantclient,/path/to/instant/client/lib
-                          for an Oracle Instant Client installation.])
+PHP_ARG_WITH([pdo-oci],
+  [Oracle OCI support for PDO],
+  [AS_HELP_STRING([--with-pdo-oci[=DIR]],
+    [PDO: Oracle OCI support. DIR defaults to [$]ORACLE_HOME. Use --with-pdo-oci=instantclient,/path/to/instant/client/lib for an Oracle Instant Client installation.])])
 
 if test "$PHP_PDO_OCI" != "no"; then
 

--- a/ext/pdo_oci/config.m4
+++ b/ext/pdo_oci/config.m4
@@ -56,7 +56,7 @@ AC_DEFUN([AC_PDO_OCI_CHECK_LIB_DIR],[
 PHP_ARG_WITH([pdo-oci],
   [Oracle OCI support for PDO],
   [AS_HELP_STRING([--with-pdo-oci@<:@=DIR@:>@],
-    [PDO: Oracle OCI support. DIR defaults to [$]ORACLE_HOME. Use
+    [PDO: Oracle OCI support. DIR defaults to @S|@ORACLE_HOME. Use
     --with-pdo-oci=instantclient,/path/to/instant/client/lib for an Oracle
     Instant Client installation.])])
 

--- a/ext/pdo_oci/config.m4
+++ b/ext/pdo_oci/config.m4
@@ -55,7 +55,7 @@ AC_DEFUN([AC_PDO_OCI_CHECK_LIB_DIR],[
 
 PHP_ARG_WITH([pdo-oci],
   [Oracle OCI support for PDO],
-  [AS_HELP_STRING([--with-pdo-oci[=DIR]],
+  [AS_HELP_STRING([--with-pdo-oci@<:@=DIR@:>@],
     [PDO: Oracle OCI support. DIR defaults to [$]ORACLE_HOME. Use
     --with-pdo-oci=instantclient,/path/to/instant/client/lib for an Oracle
     Instant Client installation.])])

--- a/ext/pdo_oci/config.m4
+++ b/ext/pdo_oci/config.m4
@@ -55,8 +55,8 @@ AC_DEFUN([AC_PDO_OCI_CHECK_LIB_DIR],[
 
 PHP_ARG_WITH([pdo-oci],
   [Oracle OCI support for PDO],
-  [AS_HELP_STRING([--with-pdo-oci@<:@=DIR@:>@],
-    [PDO: Oracle OCI support. DIR defaults to @S|@ORACLE_HOME. Use
+  [AS_HELP_STRING([[--with-pdo-oci[=DIR]]],
+    [PDO: Oracle OCI support. DIR defaults to $ORACLE_HOME. Use
     --with-pdo-oci=instantclient,/path/to/instant/client/lib for an Oracle
     Instant Client installation.])])
 

--- a/ext/pdo_oci/config.m4
+++ b/ext/pdo_oci/config.m4
@@ -56,7 +56,9 @@ AC_DEFUN([AC_PDO_OCI_CHECK_LIB_DIR],[
 PHP_ARG_WITH([pdo-oci],
   [Oracle OCI support for PDO],
   [AS_HELP_STRING([--with-pdo-oci[=DIR]],
-    [PDO: Oracle OCI support. DIR defaults to [$]ORACLE_HOME. Use --with-pdo-oci=instantclient,/path/to/instant/client/lib for an Oracle Instant Client installation.])])
+    [PDO: Oracle OCI support. DIR defaults to [$]ORACLE_HOME. Use
+    --with-pdo-oci=instantclient,/path/to/instant/client/lib for an Oracle
+    Instant Client installation.])])
 
 if test "$PHP_PDO_OCI" != "no"; then
 

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -1,21 +1,13 @@
 dnl config.m4 for extension pdo_odbc
 
 define([PDO_ODBC_HELP_TEXT],[[
-			  include and lib dirs are looked for under 'dir'.
-
-			  'flavour' can be one of:  ibm-db2, iODBC, unixODBC, generic
-			  If ',dir' part is omitted, default for the flavour
-			  you have selected will be used. e.g.:
-
-			    --with-pdo-odbc=unixODBC
-
-			  will check for unixODBC under /usr/local. You may attempt
-			  to use an otherwise unsupported driver using the 'generic'
-			  flavour.  The syntax for generic ODBC support is:
-
-			    --with-pdo-odbc=generic,dir,libname,ldflags,cflags
-
-			  When built as 'shared' the extension filename is always pdo_odbc.so]])
+  The include and lib dirs are looked for under 'dir'. The 'flavour' can be one
+  of: ibm-db2, iODBC, unixODBC, generic. If ',dir' part is omitted, default for
+  the flavour you have selected will be used. e.g.: --with-pdo-odbc=unixODBC
+  will check for unixODBC under /usr/local. You may attempt to use an otherwise
+  unsupported driver using the 'generic' flavour. The syntax for generic ODBC
+  support is: --with-pdo-odbc=generic,dir,libname,ldflags,cflags. When built as
+  'shared' the extension filename is always pdo_odbc.so]])
 
 PHP_ARG_WITH([pdo-odbc],
   [for ODBC v3 support for PDO],

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -17,10 +17,10 @@ define([PDO_ODBC_HELP_TEXT],[[
 
 			  When built as 'shared' the extension filename is always pdo_odbc.so]])
 
-PHP_ARG_WITH(pdo-odbc, for ODBC v3 support for PDO,
-[  --with-pdo-odbc=flavour,dir
-                          PDO: Support for 'flavour' ODBC driver.]PDO_ODBC_HELP_TEXT)
-
+PHP_ARG_WITH([pdo-odbc],
+  [for ODBC v3 support for PDO],
+  [AS_HELP_STRING([--with-pdo-odbc=flavour,dir],
+  [PDO: Support for 'flavour' ODBC driver.]PDO_ODBC_HELP_TEXT)])
 
 AC_DEFUN([PDO_ODBC_CHECK_HEADER],[
   AC_MSG_CHECKING([for $1 in $PDO_ODBC_INCDIR])

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -12,7 +12,7 @@ define([PDO_ODBC_HELP_TEXT],[[
 PHP_ARG_WITH([pdo-odbc],
   [for ODBC v3 support for PDO],
   [AS_HELP_STRING([--with-pdo-odbc=flavour,dir],
-  [PDO: Support for 'flavour' ODBC driver.]PDO_ODBC_HELP_TEXT)])
+    [PDO: Support for 'flavour' ODBC driver.]PDO_ODBC_HELP_TEXT)])
 
 AC_DEFUN([PDO_ODBC_CHECK_HEADER],[
   AC_MSG_CHECKING([for $1 in $PDO_ODBC_INCDIR])

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -3,7 +3,8 @@ dnl config.m4 for extension pdo_pgsql
 PHP_ARG_WITH([pdo-pgsql],
   [for PostgreSQL support for PDO],
   [AS_HELP_STRING([--with-pdo-pgsql[=DIR]],
-    [PDO: PostgreSQL support. DIR is the PostgreSQL base install directory or the path to pg_config])])
+    [PDO: PostgreSQL support. DIR is the PostgreSQL base install directory or
+    the path to pg_config])])
 
 if test "$PHP_PDO_PGSQL" != "no"; then
 

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension pdo_pgsql
 
 PHP_ARG_WITH([pdo-pgsql],
   [for PostgreSQL support for PDO],
-  [AS_HELP_STRING([--with-pdo-pgsql[=DIR]],
+  [AS_HELP_STRING([--with-pdo-pgsql@<:@=DIR@:>@],
     [PDO: PostgreSQL support. DIR is the PostgreSQL base install directory or
     the path to pg_config])])
 

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension pdo_pgsql
 
 PHP_ARG_WITH([pdo-pgsql],
   [for PostgreSQL support for PDO],
-  [AS_HELP_STRING([--with-pdo-pgsql@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-pdo-pgsql[=DIR]]],
     [PDO: PostgreSQL support. DIR is the PostgreSQL base install directory or
     the path to pg_config])])
 

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -1,8 +1,9 @@
 dnl config.m4 for extension pdo_pgsql
 
-PHP_ARG_WITH(pdo-pgsql,for PostgreSQL support for PDO,
-[  --with-pdo-pgsql[=DIR]    PDO: PostgreSQL support.  DIR is the PostgreSQL base
-                          install directory or the path to pg_config])
+PHP_ARG_WITH([pdo-pgsql],
+  [for PostgreSQL support for PDO],
+  [AS_HELP_STRING([--with-pdo-pgsql[=DIR]],
+    [PDO: PostgreSQL support. DIR is the PostgreSQL base install directory or the path to pg_config])])
 
 if test "$PHP_PDO_PGSQL" != "no"; then
 

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -1,9 +1,10 @@
 dnl config.m4 for extension pdo_sqlite
 
-PHP_ARG_WITH(pdo-sqlite, for sqlite 3 support for PDO,
-[  --without-pdo-sqlite[=DIR]
-                          PDO: sqlite 3 support.  DIR is the sqlite base
-                          install directory [BUNDLED]], $PHP_PDO)
+PHP_ARG_WITH([pdo-sqlite],
+  [for sqlite 3 support for PDO],
+  [AS_HELP_STRING([--without-pdo-sqlite[=DIR]],
+    [PDO: sqlite 3 support. DIR is the sqlite base install directory [BUNDLED]])],
+  [$PHP_PDO])
 
 if test "$PHP_PDO_SQLITE" != "no"; then
 

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension pdo_sqlite
 
 PHP_ARG_WITH([pdo-sqlite],
   [for sqlite 3 support for PDO],
-  [AS_HELP_STRING([--without-pdo-sqlite[=DIR]],
+  [AS_HELP_STRING([--without-pdo-sqlite@<:@=DIR@:>@],
     [PDO: sqlite 3 support. DIR is the sqlite base install directory
     @<:@BUNDLED@:>@])],
   [$PHP_PDO])

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -3,7 +3,8 @@ dnl config.m4 for extension pdo_sqlite
 PHP_ARG_WITH([pdo-sqlite],
   [for sqlite 3 support for PDO],
   [AS_HELP_STRING([--without-pdo-sqlite[=DIR]],
-    [PDO: sqlite 3 support. DIR is the sqlite base install directory [BUNDLED]])],
+    [PDO: sqlite 3 support. DIR is the sqlite base install directory
+    @<:@BUNDLED@:>@])],
   [$PHP_PDO])
 
 if test "$PHP_PDO_SQLITE" != "no"; then

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -2,9 +2,9 @@ dnl config.m4 for extension pdo_sqlite
 
 PHP_ARG_WITH([pdo-sqlite],
   [for sqlite 3 support for PDO],
-  [AS_HELP_STRING([--without-pdo-sqlite@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--without-pdo-sqlite[=DIR]]],
     [PDO: sqlite 3 support. DIR is the sqlite base install directory
-    @<:@BUNDLED@:>@])],
+    [BUNDLED]])],
   [$PHP_PDO])
 
 if test "$PHP_PDO_SQLITE" != "no"; then

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -1,8 +1,9 @@
 dnl config.m4 for extension pgsql
 
-PHP_ARG_WITH(pgsql,for PostgreSQL support,
-[  --with-pgsql[=DIR]        Include PostgreSQL support.  DIR is the PostgreSQL
-                          base install directory or the path to pg_config])
+PHP_ARG_WITH([pgsql],
+  [for PostgreSQL support],
+  [AS_HELP_STRING([--with-pgsql[=DIR]],
+    [Include PostgreSQL support. DIR is the PostgreSQL base install directory or the path to pg_config])])
 
 if test "$PHP_PGSQL" != "no"; then
   PHP_EXPAND_PATH($PGSQL_INCLUDE, PGSQL_INCLUDE)

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension pgsql
 
 PHP_ARG_WITH([pgsql],
   [for PostgreSQL support],
-  [AS_HELP_STRING([--with-pgsql[=DIR]],
+  [AS_HELP_STRING([--with-pgsql@<:@=DIR@:>@],
     [Include PostgreSQL support. DIR is the PostgreSQL base install directory or
     the path to pg_config])])
 

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -3,7 +3,8 @@ dnl config.m4 for extension pgsql
 PHP_ARG_WITH([pgsql],
   [for PostgreSQL support],
   [AS_HELP_STRING([--with-pgsql[=DIR]],
-    [Include PostgreSQL support. DIR is the PostgreSQL base install directory or the path to pg_config])])
+    [Include PostgreSQL support. DIR is the PostgreSQL base install directory or
+    the path to pg_config])])
 
 if test "$PHP_PGSQL" != "no"; then
   PHP_EXPAND_PATH($PGSQL_INCLUDE, PGSQL_INCLUDE)

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension pgsql
 
 PHP_ARG_WITH([pgsql],
   [for PostgreSQL support],
-  [AS_HELP_STRING([--with-pgsql@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-pgsql[=DIR]]],
     [Include PostgreSQL support. DIR is the PostgreSQL base install directory or
     the path to pg_config])])
 

--- a/ext/phar/config.m4
+++ b/ext/phar/config.m4
@@ -1,7 +1,10 @@
 dnl config.m4 for extension phar
 
-PHP_ARG_ENABLE(phar, for phar archive support,
-[  --disable-phar          Disable phar support], yes)
+PHP_ARG_ENABLE([phar],
+  [for phar archive support],
+  [AS_HELP_STRING([--disable-phar],
+    [Disable phar support])],
+  [yes])
 
 if test "$PHP_PHAR" != "no"; then
   PHP_NEW_EXTENSION(phar, util.c tar.c zip.c stream.c func_interceptors.c dirstream.c phar.c phar_object.c phar_path_check.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)

--- a/ext/posix/config.m4
+++ b/ext/posix/config.m4
@@ -1,7 +1,10 @@
 dnl config.m4 for extension posix
 
-PHP_ARG_ENABLE(posix,whether to enable POSIX-like functions,
-[  --disable-posix         Disable POSIX-like functions], yes)
+PHP_ARG_ENABLE([posix],
+  [whether to enable POSIX-like functions],
+  [AS_HELP_STRING([--disable-posix],
+    [Disable POSIX-like functions])],
+  [yes])
 
 if test "$PHP_POSIX" = "yes"; then
   AC_DEFINE(HAVE_POSIX, 1, [whether to include POSIX-like functions])

--- a/ext/pspell/config.m4
+++ b/ext/pspell/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension pspell
 
 PHP_ARG_WITH([pspell],
   [for PSPELL support],
-  [AS_HELP_STRING([--with-pspell[=DIR]],
+  [AS_HELP_STRING([--with-pspell@<:@=DIR@:>@],
     [Include PSPELL support. GNU Aspell version 0.50.0 or higher required])])
 
 if test "$PHP_PSPELL" != "no"; then

--- a/ext/pspell/config.m4
+++ b/ext/pspell/config.m4
@@ -1,8 +1,9 @@
 dnl config.m4 for extension pspell
 
-PHP_ARG_WITH(pspell,for PSPELL support,
-[  --with-pspell[=DIR]       Include PSPELL support.
-                          GNU Aspell version 0.50.0 or higher required])
+PHP_ARG_WITH([pspell],
+  [for PSPELL support],
+  [AS_HELP_STRING([--with-pspell[=DIR]],
+    [Include PSPELL support. GNU Aspell version 0.50.0 or higher required])])
 
 if test "$PHP_PSPELL" != "no"; then
 	PHP_NEW_EXTENSION(pspell, pspell.c, $ext_shared)

--- a/ext/pspell/config.m4
+++ b/ext/pspell/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension pspell
 
 PHP_ARG_WITH([pspell],
   [for PSPELL support],
-  [AS_HELP_STRING([--with-pspell@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-pspell[=DIR]]],
     [Include PSPELL support. GNU Aspell version 0.50.0 or higher required])])
 
 if test "$PHP_PSPELL" != "no"; then

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -8,7 +8,7 @@ PHP_ARG_WITH([libedit],
 if test "$PHP_LIBEDIT" = "no"; then
   PHP_ARG_WITH([readline],
     [for readline support],
-    [AS_HELP_STRING([--with-readline[=DIR]],
+    [AS_HELP_STRING([--with-readline@<:@=DIR@:>@],
       [Include readline support (CLI/CGI only)])])
 else
   dnl "register" the --with-readline option to preven invalid "unknown configure option" warning

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -1,11 +1,15 @@
 dnl config.m4 for extension readline
 
-PHP_ARG_WITH(libedit,for libedit readline replacement,
-[  --with-libedit          Include libedit readline replacement (CLI/CGI only)])
+PHP_ARG_WITH([libedit],
+  [for libedit readline replacement],
+  [AS_HELP_STRING([--with-libedit],
+    [Include libedit readline replacement (CLI/CGI only)])])
 
 if test "$PHP_LIBEDIT" = "no"; then
-  PHP_ARG_WITH(readline,for readline support,
-  [  --with-readline[=DIR]     Include readline support (CLI/CGI only)])
+  PHP_ARG_WITH([readline],
+    [for readline support],
+    [AS_HELP_STRING([--with-readline[=DIR]],
+      [Include readline support (CLI/CGI only)])])
 else
   dnl "register" the --with-readline option to preven invalid "unknown configure option" warning
   php_with_readline=no

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -8,7 +8,7 @@ PHP_ARG_WITH([libedit],
 if test "$PHP_LIBEDIT" = "no"; then
   PHP_ARG_WITH([readline],
     [for readline support],
-    [AS_HELP_STRING([--with-readline@<:@=DIR@:>@],
+    [AS_HELP_STRING([[--with-readline[=DIR]]],
       [Include readline support (CLI/CGI only)])])
 else
   dnl "register" the --with-readline option to preven invalid "unknown configure option" warning

--- a/ext/recode/config.m4
+++ b/ext/recode/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension recode
 
 PHP_ARG_WITH([recode],
   [for recode support],
-  [AS_HELP_STRING([--with-recode@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-recode[=DIR]]],
     [Include recode support])])
 
 if test "$PHP_RECODE" != "no"; then

--- a/ext/recode/config.m4
+++ b/ext/recode/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension recode
 
-PHP_ARG_WITH(recode,for recode support,
-[  --with-recode[=DIR]       Include recode support])
+PHP_ARG_WITH([recode],
+  [for recode support],
+  [AS_HELP_STRING([--with-recode[=DIR]],
+    [Include recode support])])
 
 if test "$PHP_RECODE" != "no"; then
   RECODE_LIST="$PHP_RECODE /usr/local /usr /opt"

--- a/ext/recode/config.m4
+++ b/ext/recode/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension recode
 
 PHP_ARG_WITH([recode],
   [for recode support],
-  [AS_HELP_STRING([--with-recode[=DIR]],
+  [AS_HELP_STRING([--with-recode@<:@=DIR@:>@],
     [Include recode support])])
 
 if test "$PHP_RECODE" != "no"; then

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -1,10 +1,17 @@
 dnl config.m4 for extension session
 
-PHP_ARG_ENABLE(session, whether to enable PHP sessions,
-[  --disable-session       Disable session support], yes)
+PHP_ARG_ENABLE([session],
+  [whether to enable PHP sessions],
+  [AS_HELP_STRING([--disable-session],
+    [Disable session support])],
+  [yes])
 
-PHP_ARG_WITH(mm,for mm support,
-[  --with-mm[=DIR]           SESSION: Include mm support for session storage], no, no)
+PHP_ARG_WITH([mm],
+  [for mm support],
+  [AS_HELP_STRING([--with-mm[=DIR]],
+    [SESSION: Include mm support for session storage])],
+  [no],
+  [no])
 
 if test "$PHP_SESSION" != "no"; then
   PHP_PWRITE_TEST

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -8,7 +8,7 @@ PHP_ARG_ENABLE([session],
 
 PHP_ARG_WITH([mm],
   [for mm support],
-  [AS_HELP_STRING([--with-mm@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-mm[=DIR]]],
     [SESSION: Include mm support for session storage])],
   [no],
   [no])

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -8,7 +8,7 @@ PHP_ARG_ENABLE([session],
 
 PHP_ARG_WITH([mm],
   [for mm support],
-  [AS_HELP_STRING([--with-mm[=DIR]],
+  [AS_HELP_STRING([--with-mm@<:@=DIR@:>@],
     [SESSION: Include mm support for session storage])],
   [no],
   [no])

--- a/ext/shmop/config.m4
+++ b/ext/shmop/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension shmop
 
-PHP_ARG_ENABLE(shmop, whether to enable shmop support,
-[  --enable-shmop          Enable shmop support])
+PHP_ARG_ENABLE([shmop],
+  [whether to enable shmop support],
+  [AS_HELP_STRING([--enable-shmop],
+    [Enable shmop support])])
 
 if test "$PHP_SHMOP" != "no"; then
   AC_DEFINE(HAVE_SHMOP, 1, [ ])

--- a/ext/simplexml/config.m4
+++ b/ext/simplexml/config.m4
@@ -1,11 +1,18 @@
 dnl config.m4 for extension simplexml
 
-PHP_ARG_ENABLE(simplexml, whether to enable SimpleXML support,
-[  --disable-simplexml     Disable SimpleXML support], yes)
+PHP_ARG_ENABLE([simplexml],
+  [whether to enable SimpleXML support],
+  [AS_HELP_STRING([--disable-simplexml],
+    [Disable SimpleXML support])],
+  [yes])
 
 if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH(libxml-dir, libxml2 install dir,
-  [  --with-libxml-dir=DIR   SimpleXML: libxml2 install prefix], no, no)
+  PHP_ARG_WITH([libxml-dir],
+    [libxml2 install dir],
+    [AS_HELP_STRING([--with-libxml-dir=DIR],
+      [SimpleXML: libxml2 install prefix])],
+    [no],
+    [no])
 fi
 
 if test "$PHP_SIMPLEXML" != "no"; then

--- a/ext/skeleton/config.m4.in
+++ b/ext/skeleton/config.m4.in
@@ -5,15 +5,18 @@ dnl Remove where necessary.
 
 dnl If your extension references something external, use with:
 
-dnl PHP_ARG_WITH(%EXTNAME%, for %EXTNAME% support,
-dnl Make sure that the comment is aligned:
-dnl [  --with-%EXTNAME%             Include %EXTNAME% support])
+dnl PHP_ARG_WITH([%EXTNAME%],
+dnl   [for %EXTNAME% support],
+dnl   [AS_HELP_STRING([--with-%EXTNAME%],
+dnl     [Include %EXTNAME% support])])
 
 dnl Otherwise use enable:
 
-PHP_ARG_ENABLE(%EXTNAME%, whether to enable %EXTNAME% support,
-dnl Make sure that the comment is aligned:
-[  --enable-%EXTNAME%          Enable %EXTNAME% support], no)
+PHP_ARG_ENABLE([%EXTNAME%],
+  [whether to enable %EXTNAME% support],
+  [AS_HELP_STRING([--enable-%EXTNAME%],
+    [Enable %EXTNAME% support])],
+  [no])
 
 if test "$PHP_%EXTNAMECAPS%" != "no"; then
   dnl Write more examples of tests here...

--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -2,12 +2,12 @@ dnl config.m4 for extension snmp
 
 PHP_ARG_WITH([snmp],
   [for SNMP support],
-  [AS_HELP_STRING([--with-snmp@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-snmp[=DIR]]],
     [Include SNMP support])])
 
 PHP_ARG_WITH([openssl-dir],
   [OpenSSL dir for SNMP],
-  [AS_HELP_STRING([--with-openssl-dir@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-openssl-dir[=DIR]]],
     [SNMP: openssl install prefix])],
   [no],
   [no])

--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -2,12 +2,12 @@ dnl config.m4 for extension snmp
 
 PHP_ARG_WITH([snmp],
   [for SNMP support],
-  [AS_HELP_STRING([--with-snmp[=DIR]],
+  [AS_HELP_STRING([--with-snmp@<:@=DIR@:>@],
     [Include SNMP support])])
 
 PHP_ARG_WITH([openssl-dir],
   [OpenSSL dir for SNMP],
-  [AS_HELP_STRING([--with-openssl-dir[=DIR]],
+  [AS_HELP_STRING([--with-openssl-dir@<:@=DIR@:>@],
     [SNMP: openssl install prefix])],
   [no],
   [no])

--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -1,10 +1,16 @@
 dnl config.m4 for extension snmp
 
-PHP_ARG_WITH(snmp,for SNMP support,
-[  --with-snmp[=DIR]         Include SNMP support])
+PHP_ARG_WITH([snmp],
+  [for SNMP support],
+  [AS_HELP_STRING([--with-snmp[=DIR]],
+    [Include SNMP support])])
 
-PHP_ARG_WITH(openssl-dir,OpenSSL dir for SNMP,
-[  --with-openssl-dir[=DIR]  SNMP: openssl install prefix], no, no)
+PHP_ARG_WITH([openssl-dir],
+  [OpenSSL dir for SNMP],
+  [AS_HELP_STRING([--with-openssl-dir[=DIR]],
+    [SNMP: openssl install prefix])],
+  [no],
+  [no])
 
 if test "$PHP_SNMP" != "no"; then
 

--- a/ext/soap/config.m4
+++ b/ext/soap/config.m4
@@ -1,11 +1,17 @@
 dnl config.m4 for extension soap
 
-PHP_ARG_ENABLE(soap, whether to enable SOAP support,
-[  --enable-soap           Enable SOAP support])
+PHP_ARG_ENABLE([soap],
+  [whether to enable SOAP support],
+  [AS_HELP_STRING([--enable-soap],
+    [Enable SOAP support])])
 
 if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH(libxml-dir, libxml2 install dir,
-  [  --with-libxml-dir=DIR   SOAP: libxml2 install prefix], no, no)
+  PHP_ARG_WITH([libxml-dir],
+    [libxml2 install dir],
+    [AS_HELP_STRING([--with-libxml-dir=DIR],
+      [SOAP: libxml2 install prefix])],
+    [no],
+    [no])
 fi
 
 if test "$PHP_SOAP" != "no"; then

--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension sockets
 
-PHP_ARG_ENABLE(sockets, whether to enable sockets support,
-[  --enable-sockets        Enable sockets support])
+PHP_ARG_ENABLE([sockets],
+  [whether to enable sockets support],
+  [AS_HELP_STRING([--enable-sockets],
+    [Enable sockets support])])
 
 if test "$PHP_SOCKETS" != "no"; then
   dnl Check for struct cmsghdr

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension sodium
 
 PHP_ARG_WITH([sodium],
   [for sodium support],
-  [AS_HELP_STRING([--with-sodium[=DIR]],
+  [AS_HELP_STRING([--with-sodium@<:@=DIR@:>@],
     [Include sodium support])])
 
 if test "$PHP_SODIUM" != "no"; then

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension sodium
 
-PHP_ARG_WITH(sodium, for sodium support,
-[  --with-sodium[=DIR]       Include sodium support])
+PHP_ARG_WITH([sodium],
+  [for sodium support],
+  [AS_HELP_STRING([--with-sodium[=DIR]],
+    [Include sodium support])])
 
 if test "$PHP_SODIUM" != "no"; then
   SEARCH_PATH="/usr/local /usr"     # you might want to change this

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension sodium
 
 PHP_ARG_WITH([sodium],
   [for sodium support],
-  [AS_HELP_STRING([--with-sodium@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-sodium[=DIR]]],
     [Include sodium support])])
 
 if test "$PHP_SODIUM" != "no"; then

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -3,7 +3,8 @@ dnl config.m4 for extension sqlite3
 PHP_ARG_WITH([sqlite3],
   [whether to enable the SQLite3 extension],
   [AS_HELP_STRING([--without-sqlite3[=DIR]],
-    [Do not include SQLite3 support. DIR is the prefix to SQLite3 installation directory.])],
+    [Do not include SQLite3 support. DIR is the prefix to SQLite3 installation
+    directory.])],
   [yes])
 
 if test $PHP_SQLITE3 != "no"; then

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension sqlite3
 
 PHP_ARG_WITH([sqlite3],
   [whether to enable the SQLite3 extension],
-  [AS_HELP_STRING([--without-sqlite3[=DIR]],
+  [AS_HELP_STRING([--without-sqlite3@<:@=DIR@:>@],
     [Do not include SQLite3 support. DIR is the prefix to SQLite3 installation
     directory.])],
   [yes])

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -1,8 +1,10 @@
 dnl config.m4 for extension sqlite3
 
-PHP_ARG_WITH(sqlite3, whether to enable the SQLite3 extension,
-[  --without-sqlite3[=DIR]   Do not include SQLite3 support. DIR is the prefix to
-                          SQLite3 installation directory.], yes)
+PHP_ARG_WITH([sqlite3],
+  [whether to enable the SQLite3 extension],
+  [AS_HELP_STRING([--without-sqlite3[=DIR]],
+    [Do not include SQLite3 support. DIR is the prefix to SQLite3 installation directory.])],
+  [yes])
 
 if test $PHP_SQLITE3 != "no"; then
   PHP_SQLITE3_CFLAGS=" -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 "

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension sqlite3
 
 PHP_ARG_WITH([sqlite3],
   [whether to enable the SQLite3 extension],
-  [AS_HELP_STRING([--without-sqlite3@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--without-sqlite3[=DIR]]],
     [Do not include SQLite3 support. DIR is the prefix to SQLite3 installation
     directory.])],
   [yes])

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -410,7 +410,8 @@ dnl
 PHP_ARG_WITH([password-argon2],
   [for Argon2 support],
   [AS_HELP_STRING([--with-password-argon2[=DIR]],
-    [Include Argon2 support in password_*. DIR is the Argon2 shared library path])])
+    [Include Argon2 support in password_*. DIR is the Argon2 shared library
+    path])])
 
 if test "$PHP_PASSWORD_ARGON2" != "no"; then
   AC_MSG_CHECKING([for Argon2 library])

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -407,9 +407,10 @@ AC_CHECK_DECLS([arc4random_buf])
 dnl
 dnl Check for argon2
 dnl
-PHP_ARG_WITH(password-argon2, for Argon2 support,
-[  --with-password-argon2[=DIR]
-                          Include Argon2 support in password_*. DIR is the Argon2 shared library path])
+PHP_ARG_WITH([password-argon2],
+  [for Argon2 support],
+  [AS_HELP_STRING([--with-password-argon2[=DIR]],
+    [Include Argon2 support in password_*. DIR is the Argon2 shared library path])])
 
 if test "$PHP_PASSWORD_ARGON2" != "no"; then
   AC_MSG_CHECKING([for Argon2 library])

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -409,7 +409,7 @@ dnl Check for argon2
 dnl
 PHP_ARG_WITH([password-argon2],
   [for Argon2 support],
-  [AS_HELP_STRING([--with-password-argon2@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-password-argon2[=DIR]]],
     [Include Argon2 support in password_*. DIR is the Argon2 shared library
     path])])
 

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -409,7 +409,7 @@ dnl Check for argon2
 dnl
 PHP_ARG_WITH([password-argon2],
   [for Argon2 support],
-  [AS_HELP_STRING([--with-password-argon2[=DIR]],
+  [AS_HELP_STRING([--with-password-argon2@<:@=DIR@:>@],
     [Include Argon2 support in password_*. DIR is the Argon2 shared library
     path])])
 

--- a/ext/sysvmsg/config.m4
+++ b/ext/sysvmsg/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension sysvmsg
 
-PHP_ARG_ENABLE(sysvmsg,whether to enable System V IPC support,
-[  --enable-sysvmsg        Enable sysvmsg support])
+PHP_ARG_ENABLE([sysvmsg],
+  [whether to enable System V IPC support],
+  [AS_HELP_STRING([--enable-sysvmsg],
+    [Enable sysvmsg support])])
 
 if test "$PHP_SYSVMSG" != "no"; then
   AC_CHECK_HEADER([sys/msg.h],

--- a/ext/sysvsem/config.m4
+++ b/ext/sysvsem/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension sysvsem
 
-PHP_ARG_ENABLE(sysvsem,whether to enable System V semaphore support,
-[  --enable-sysvsem        Enable System V semaphore support])
+PHP_ARG_ENABLE([sysvsem],
+  [whether to enable System V semaphore support],
+  [AS_HELP_STRING([--enable-sysvsem],
+    [Enable System V semaphore support])])
 
 if test "$PHP_SYSVSEM" != "no"; then
  PHP_NEW_EXTENSION(sysvsem, sysvsem.c, $ext_shared)

--- a/ext/sysvshm/config.m4
+++ b/ext/sysvshm/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension sysvshm
 
-PHP_ARG_ENABLE(sysvshm,whether to enable System V shared memory support,
-[  --enable-sysvshm        Enable the System V shared memory support])
+PHP_ARG_ENABLE([sysvshm],
+  [whether to enable System V shared memory support],
+  [AS_HELP_STRING([--enable-sysvshm],
+    [Enable the System V shared memory support])])
 
 if test "$PHP_SYSVSHM" != "no"; then
   AC_DEFINE(HAVE_SYSVSHM, 1, [ ])

--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension tidy
 
-PHP_ARG_WITH(tidy,for TIDY support,
-[  --with-tidy[=DIR]         Include TIDY support])
+PHP_ARG_WITH([tidy],
+  [for TIDY support],
+  [AS_HELP_STRING([--with-tidy[=DIR]],
+    [Include TIDY support])])
 
 if test "$PHP_TIDY" != "no"; then
 

--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension tidy
 
 PHP_ARG_WITH([tidy],
   [for TIDY support],
-  [AS_HELP_STRING([--with-tidy[=DIR]],
+  [AS_HELP_STRING([--with-tidy@<:@=DIR@:>@],
     [Include TIDY support])])
 
 if test "$PHP_TIDY" != "no"; then

--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension tidy
 
 PHP_ARG_WITH([tidy],
   [for TIDY support],
-  [AS_HELP_STRING([--with-tidy@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-tidy[=DIR]]],
     [Include TIDY support])])
 
 if test "$PHP_TIDY" != "no"; then

--- a/ext/tokenizer/config.m4
+++ b/ext/tokenizer/config.m4
@@ -2,8 +2,11 @@ dnl config.m4 for extension tokenizer
 
 dnl Otherwise use enable:
 
-PHP_ARG_ENABLE(tokenizer, whether to enable tokenizer support,
-[  --disable-tokenizer     Disable tokenizer support], yes)
+PHP_ARG_ENABLE([tokenizer],
+  [whether to enable tokenizer support],
+  [AS_HELP_STRING([--disable-tokenizer],
+    [Disable tokenizer support])],
+  [yes])
 
 if test "$PHP_TOKENIZER" != "no"; then
   PHP_NEW_EXTENSION(tokenizer, tokenizer.c tokenizer_data.c, $ext_shared)

--- a/ext/wddx/config.m4
+++ b/ext/wddx/config.m4
@@ -1,15 +1,25 @@
 dnl config.m4 for extension wddx
 
-PHP_ARG_ENABLE(wddx,whether to enable WDDX support,
-[  --enable-wddx           Enable WDDX support])
+PHP_ARG_ENABLE([wddx],
+  [whether to enable WDDX support],
+  [AS_HELP_STRING([--enable-wddx],
+    [Enable WDDX support])])
 
 if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH(libxml-dir, libxml2 install dir,
-  [  --with-libxml-dir=DIR   WDDX: libxml2 install prefix], no, no)
+  PHP_ARG_WITH([libxml-dir],
+    [libxml2 install dir],
+    [AS_HELP_STRING([--with-libxml-dir=DIR],
+      [WDDX: libxml2 install prefix])],
+    [no],
+    [no])
 fi
 
-PHP_ARG_WITH(libexpat-dir, libexpat dir for WDDX,
-[  --with-libexpat-dir=DIR WDDX: libexpat dir for XMLRPC-EPI (deprecated)],no,no)
+PHP_ARG_WITH([libexpat-dir],
+  [libexpat dir for WDDX],
+  [AS_HELP_STRING([--with-libexpat-dir=DIR],
+    [WDDX: libexpat dir for XMLRPC-EPI (deprecated)])],
+  [no],
+  [no])
 
 if test "$PHP_WDDX" != "no"; then
 

--- a/ext/xml/config.m4
+++ b/ext/xml/config.m4
@@ -1,15 +1,26 @@
 dnl config.m4 for extension xml
 
-PHP_ARG_ENABLE(xml,whether to enable XML support,
-[  --disable-xml           Disable XML support], yes)
+PHP_ARG_ENABLE([xml],
+  [whether to enable XML support],
+  [AS_HELP_STRING([--disable-xml],
+    [Disable XML support])],
+  [yes])
 
 if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH(libxml-dir, libxml2 install dir,
-  [  --with-libxml-dir=DIR   XML: libxml2 install prefix], no, no)
+  PHP_ARG_WITH([libxml-dir],
+    [libxml2 install dir],
+    [AS_HELP_STRING([--with-libxml-dir=DIR],
+      [XML: libxml2 install prefix])],
+    [no],
+    [no])
 fi
 
-PHP_ARG_WITH(libexpat-dir, libexpat install dir,
-[  --with-libexpat-dir=DIR XML: libexpat install prefix (deprecated)], no, no)
+PHP_ARG_WITH([libexpat-dir],
+  [libexpat install dir],
+  [AS_HELP_STRING([--with-libexpat-dir=DIR],
+    [XML: libexpat install prefix (deprecated)])],
+  [no],
+  [no])
 
 if test "$PHP_XML" != "no"; then
 

--- a/ext/xmlreader/config.m4
+++ b/ext/xmlreader/config.m4
@@ -1,11 +1,18 @@
 dnl config.m4 for extension xmlreader
 
-PHP_ARG_ENABLE(xmlreader, whether to enable XMLReader support,
-[  --disable-xmlreader     Disable XMLReader support], yes)
+PHP_ARG_ENABLE([xmlreader],
+  [whether to enable XMLReader support],
+  [AS_HELP_STRING([--disable-xmlreader],
+    [Disable XMLReader support])],
+  [yes])
 
 if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH(libxml-dir, libxml2 install dir,
-  [  --with-libxml-dir=DIR   XMLReader: libxml2 install prefix], no, no)
+  PHP_ARG_WITH([libxml-dir],
+    [libxml2 install dir],
+    [AS_HELP_STRING([--with-libxml-dir=DIR],
+      [XMLReader: libxml2 install prefix])],
+    [no],
+    [no])
 fi
 
 if test "$PHP_XMLREADER" != "no"; then

--- a/ext/xmlrpc/config.m4
+++ b/ext/xmlrpc/config.m4
@@ -7,7 +7,7 @@ sinclude(libxmlrpc/xmlrpc.m4)
 
 PHP_ARG_WITH([xmlrpc],
   [for XMLRPC-EPI support],
-  [AS_HELP_STRING([--with-xmlrpc@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-xmlrpc[=DIR]]],
     [Include XMLRPC-EPI support])])
 
 if test -z "$PHP_LIBXML_DIR"; then

--- a/ext/xmlrpc/config.m4
+++ b/ext/xmlrpc/config.m4
@@ -7,7 +7,7 @@ sinclude(libxmlrpc/xmlrpc.m4)
 
 PHP_ARG_WITH([xmlrpc],
   [for XMLRPC-EPI support],
-  [AS_HELP_STRING([--with-xmlrpc[=DIR]],
+  [AS_HELP_STRING([--with-xmlrpc@<:@=DIR@:>@],
     [Include XMLRPC-EPI support])])
 
 if test -z "$PHP_LIBXML_DIR"; then

--- a/ext/xmlrpc/config.m4
+++ b/ext/xmlrpc/config.m4
@@ -5,19 +5,33 @@ sinclude(ext/xmlrpc/libxmlrpc/xmlrpc.m4)
 sinclude(libxmlrpc/acinclude.m4)
 sinclude(libxmlrpc/xmlrpc.m4)
 
-PHP_ARG_WITH(xmlrpc, for XMLRPC-EPI support,
-[  --with-xmlrpc[=DIR]       Include XMLRPC-EPI support])
+PHP_ARG_WITH([xmlrpc],
+  [for XMLRPC-EPI support],
+  [AS_HELP_STRING([--with-xmlrpc[=DIR]],
+    [Include XMLRPC-EPI support])])
 
 if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH(libxml-dir, libxml2 install dir,
-  [  --with-libxml-dir=DIR   XMLRPC-EPI: libxml2 install prefix], no, no)
+  PHP_ARG_WITH([libxml-dir],
+    [libxml2 install dir],
+    [AS_HELP_STRING([--with-libxml-dir=DIR],
+      [XMLRPC-EPI: libxml2 install prefix])],
+    [no],
+    [no])
 fi
 
-PHP_ARG_WITH(libexpat-dir, libexpat dir for XMLRPC-EPI,
-[  --with-libexpat-dir=DIR XMLRPC-EPI: libexpat dir for XMLRPC-EPI (deprecated)],no,no)
+PHP_ARG_WITH([libexpat-dir],
+  [libexpat dir for XMLRPC-EPI],
+  [AS_HELP_STRING([--with-libexpat-dir=DIR],
+    [XMLRPC-EPI: libexpat dir for XMLRPC-EPI (deprecated)])],
+  [no],
+  [no])
 
-PHP_ARG_WITH(iconv-dir, iconv dir for XMLRPC-EPI,
-[  --with-iconv-dir=DIR    XMLRPC-EPI: iconv dir for XMLRPC-EPI],no,no)
+PHP_ARG_WITH([iconv-dir],
+  [iconv dir for XMLRPC-EPI],
+  [AS_HELP_STRING([--with-iconv-dir=DIR],
+    [XMLRPC-EPI: iconv dir for XMLRPC-EPI])],
+  [no],
+  [no])
 
 if test "$PHP_XMLRPC" != "no"; then
 

--- a/ext/xmlwriter/config.m4
+++ b/ext/xmlwriter/config.m4
@@ -1,11 +1,18 @@
 dnl config.m4 for extension xmlwriter
 
-PHP_ARG_ENABLE(xmlwriter, whether to enable XMLWriter support,
-[  --disable-xmlwriter     Disable XMLWriter support], yes)
+PHP_ARG_ENABLE([xmlwriter],
+  [whether to enable XMLWriter support],
+  [AS_HELP_STRING([--disable-xmlwriter],
+    [Disable XMLWriter support])],
+  [yes])
 
 if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH(libxml-dir, libxml2 install dir,
-  [  --with-libxml-dir=DIR   XMLWriter: libxml2 install prefix], no, no)
+  PHP_ARG_WITH([libxml-dir],
+    [libxml2 install dir],
+    [AS_HELP_STRING([--with-libxml-dir=DIR],
+      [XMLWriter: libxml2 install prefix])],
+    [no],
+    [no])
 fi
 
 if test "$PHP_XMLWRITER" != "no"; then

--- a/ext/xsl/config.m4
+++ b/ext/xsl/config.m4
@@ -1,8 +1,9 @@
 dnl config.m4 for extension xsl
 
-PHP_ARG_WITH(xsl, for XSL support,
-[  --with-xsl[=DIR]          Include XSL support.  DIR is the libxslt base
-                          install directory (libxslt >= 1.1.0 required)])
+PHP_ARG_WITH([xsl],
+  [for XSL support],
+  [AS_HELP_STRING([--with-xsl[=DIR]],
+    [Include XSL support. DIR is the libxslt base install directory (libxslt >= 1.1.0 required)])])
 
 if test "$PHP_XSL" != "no"; then
 

--- a/ext/xsl/config.m4
+++ b/ext/xsl/config.m4
@@ -2,7 +2,7 @@ dnl config.m4 for extension xsl
 
 PHP_ARG_WITH([xsl],
   [for XSL support],
-  [AS_HELP_STRING([--with-xsl[=DIR]],
+  [AS_HELP_STRING([[--with-xsl[=DIR]]],
     [Include XSL support. DIR is the libxslt base install directory (libxslt >=
     1.1.0 required)])])
 

--- a/ext/xsl/config.m4
+++ b/ext/xsl/config.m4
@@ -3,7 +3,8 @@ dnl config.m4 for extension xsl
 PHP_ARG_WITH([xsl],
   [for XSL support],
   [AS_HELP_STRING([--with-xsl[=DIR]],
-    [Include XSL support. DIR is the libxslt base install directory (libxslt >= 1.1.0 required)])])
+    [Include XSL support. DIR is the libxslt base install directory (libxslt >=
+    1.1.0 required)])])
 
 if test "$PHP_XSL" != "no"; then
 

--- a/ext/zend_test/config.m4
+++ b/ext/zend_test/config.m4
@@ -1,5 +1,7 @@
-PHP_ARG_ENABLE(zend-test, whether to enable zend-test extension,
-[  --enable-zend-test      Enable zend-test extension])
+PHP_ARG_ENABLE([zend-test],
+  [whether to enable zend-test extension],
+  [AS_HELP_STRING([--enable-zend-test],
+    [Enable zend-test extension])])
 
 if test "$PHP_ZEND_TEST" != "no"; then
   PHP_NEW_EXTENSION(zend_test, test.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)

--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -7,7 +7,7 @@ PHP_ARG_ENABLE([zip],
 
 PHP_ARG_WITH([libzip],
   [libzip],
-  [AS_HELP_STRING([--with-libzip[=DIR]],
+  [AS_HELP_STRING([--with-libzip@<:@=DIR@:>@],
     [ZIP: use libzip])],
   [yes],
   [no])

--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -1,10 +1,16 @@
 dnl config.m4 for extension zip
 
-PHP_ARG_ENABLE(zip, for zip archive read/writesupport,
-[  --enable-zip            Include Zip read/write support])
+PHP_ARG_ENABLE([zip],
+  [for zip archive read/writesupport],
+  [AS_HELP_STRING([--enable-zip],
+    [Include Zip read/write support])])
 
-PHP_ARG_WITH(libzip, libzip,
-[  --with-libzip[=DIR]       ZIP: use libzip], yes, no)
+PHP_ARG_WITH([libzip],
+  [libzip],
+  [AS_HELP_STRING([--with-libzip[=DIR]],
+    [ZIP: use libzip])],
+  [yes],
+  [no])
 
 if test "$PHP_ZIP" != "no"; then
 

--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -7,7 +7,7 @@ PHP_ARG_ENABLE([zip],
 
 PHP_ARG_WITH([libzip],
   [libzip],
-  [AS_HELP_STRING([--with-libzip@<:@=DIR@:>@],
+  [AS_HELP_STRING([[--with-libzip[=DIR]]],
     [ZIP: use libzip])],
   [yes],
   [no])

--- a/ext/zlib/config0.m4
+++ b/ext/zlib/config0.m4
@@ -1,7 +1,9 @@
 dnl config.m4 for extension zlib
 
-PHP_ARG_WITH(zlib,for ZLIB support,
-[  --with-zlib               Include ZLIB support (requires zlib >= 1.2.0.4)])
+PHP_ARG_WITH([zlib],
+  [for ZLIB support],
+  [AS_HELP_STRING([--with-zlib],
+    [Include ZLIB support (requires zlib >= 1.2.0.4)])])
 
 if test "$PHP_ZLIB" != "no"; then
   PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0.4])

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -1,7 +1,7 @@
 dnl config.m4 for sapi apache2handler
 
 PHP_ARG_WITH([apxs2],,
-  [AS_HELP_STRING([--with-apxs2@<:@=FILE@:>@],
+  [AS_HELP_STRING([[--with-apxs2[=FILE]]],
     [Build shared Apache 2.0 Handler module. FILE is the optional pathname to
     the Apache apxs tool [apxs]])],
   [no],

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -1,8 +1,10 @@
 dnl config.m4 for sapi apache2handler
 
-PHP_ARG_WITH(apxs2,,
-[  --with-apxs2[=FILE]       Build shared Apache 2.0 Handler module. FILE is the optional
-                          pathname to the Apache apxs tool [apxs]], no, no)
+PHP_ARG_WITH([apxs2],,
+  [AS_HELP_STRING([--with-apxs2[=FILE]],
+    [Build shared Apache 2.0 Handler module. FILE is the optional pathname to the Apache apxs tool [apxs]])],
+  [no],
+  [no])
 
 AC_MSG_CHECKING([for Apache 2.0 handler-module support via DSO through APXS])
 

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -2,7 +2,8 @@ dnl config.m4 for sapi apache2handler
 
 PHP_ARG_WITH([apxs2],,
   [AS_HELP_STRING([--with-apxs2[=FILE]],
-    [Build shared Apache 2.0 Handler module. FILE is the optional pathname to the Apache apxs tool [apxs]])],
+    [Build shared Apache 2.0 Handler module. FILE is the optional pathname to
+    the Apache apxs tool [apxs]])],
   [no],
   [no])
 

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -1,7 +1,7 @@
 dnl config.m4 for sapi apache2handler
 
 PHP_ARG_WITH([apxs2],,
-  [AS_HELP_STRING([--with-apxs2[=FILE]],
+  [AS_HELP_STRING([--with-apxs2@<:@=FILE@:>@],
     [Build shared Apache 2.0 Handler module. FILE is the optional pathname to
     the Apache apxs tool [apxs]])],
   [no],

--- a/sapi/cgi/config9.m4
+++ b/sapi/cgi/config9.m4
@@ -1,7 +1,10 @@
 dnl config.m4 for sapi cgi
 
-PHP_ARG_ENABLE(cgi,,
-[  --disable-cgi           Disable building CGI version of PHP], yes, no)
+PHP_ARG_ENABLE([cgi],,
+  [AS_HELP_STRING([--disable-cgi],
+    [Disable building CGI version of PHP])],
+  [yes],
+  [no])
 
 dnl
 dnl CGI setup

--- a/sapi/cli/config.m4
+++ b/sapi/cli/config.m4
@@ -1,8 +1,10 @@
 dnl config.m4 for sapi cli
 
-PHP_ARG_ENABLE(cli,,
-[  --disable-cli           Disable building CLI version of PHP
-                          (this forces --without-pear)], yes, no)
+PHP_ARG_ENABLE([cli],,
+  [AS_HELP_STRING([--disable-cli],
+    [Disable building CLI version of PHP (this forces --without-pear)])],
+  [yes],
+  [no])
 
 AC_CHECK_FUNCS(setproctitle)
 

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -1,7 +1,7 @@
 dnl config.m4 for sapi embed
 
 PHP_ARG_ENABLE([embed],,
-  [AS_HELP_STRING([--enable-embed[=TYPE]],
+  [AS_HELP_STRING([--enable-embed@<:@=TYPE@:>@],
     [EXPERIMENTAL: Enable building of embedded SAPI library TYPE is either
     'shared' or 'static'. @<:@TYPE=shared@:>@])],
   [no],

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -1,9 +1,9 @@
 dnl config.m4 for sapi embed
 
 PHP_ARG_ENABLE([embed],,
-  [AS_HELP_STRING([--enable-embed@<:@=TYPE@:>@],
+  [AS_HELP_STRING([[--enable-embed[=TYPE]]],
     [EXPERIMENTAL: Enable building of embedded SAPI library TYPE is either
-    'shared' or 'static'. @<:@TYPE=shared@:>@])],
+    'shared' or 'static'. [TYPE=shared]])],
   [no],
   [no])
 

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -1,8 +1,10 @@
 dnl config.m4 for sapi embed
 
-PHP_ARG_ENABLE(embed,,
-[  --enable-embed[=TYPE]     EXPERIMENTAL: Enable building of embedded SAPI library
-                          TYPE is either 'shared' or 'static'. [TYPE=shared]], no, no)
+PHP_ARG_ENABLE([embed],,
+  [AS_HELP_STRING([--enable-embed[=TYPE]],
+    [EXPERIMENTAL: Enable building of embedded SAPI library TYPE is either 'shared' or 'static'. [TYPE=shared]])],
+  [no],
+  [no])
 
 AC_MSG_CHECKING([for embedded SAPI library support])
 

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -2,7 +2,8 @@ dnl config.m4 for sapi embed
 
 PHP_ARG_ENABLE([embed],,
   [AS_HELP_STRING([--enable-embed[=TYPE]],
-    [EXPERIMENTAL: Enable building of embedded SAPI library TYPE is either 'shared' or 'static'. [TYPE=shared]])],
+    [EXPERIMENTAL: Enable building of embedded SAPI library TYPE is either
+    'shared' or 'static'. @<:@TYPE=shared@:>@])],
   [no],
   [no])
 

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -1,7 +1,10 @@
 dnl config.m4 for sapi fpm
 
-PHP_ARG_ENABLE(fpm,,
-[  --enable-fpm            Enable building of the fpm SAPI executable], no, no)
+PHP_ARG_ENABLE([fpm],,
+  [AS_HELP_STRING([--enable-fpm],
+    [Enable building of the fpm SAPI executable])],
+  [no],
+  [no])
 
 dnl configure checks {{{
 AC_DEFUN([AC_FPM_STDLIBS],
@@ -562,18 +565,29 @@ if test "$PHP_FPM" != "no"; then
   AC_FPM_SELECT
   AC_FPM_APPARMOR
 
-  PHP_ARG_WITH(fpm-user,,
-  [  --with-fpm-user[=USER]    Set the user for php-fpm to run as. (default: nobody)], nobody, no)
+  PHP_ARG_WITH([fpm-user],,
+    [AS_HELP_STRING([--with-fpm-user[=USER]],
+      [Set the user for php-fpm to run as. (default: nobody)])],
+    [nobody],
+    [no])
 
-  PHP_ARG_WITH(fpm-group,,
-  [  --with-fpm-group[=GRP]    Set the group for php-fpm to run as. For a system user, this
-                          should usually be set to match the fpm username (default: nobody)], nobody, no)
+  PHP_ARG_WITH([fpm-group],,
+    [AS_HELP_STRING([--with-fpm-group[=GRP]],
+      [Set the group for php-fpm to run as. For a system user, this should usually be set to match the fpm username (default: nobody)])],
+    [nobody],
+    [no])
 
-  PHP_ARG_WITH(fpm-systemd,,
-  [  --with-fpm-systemd      Activate systemd integration], no, no)
+  PHP_ARG_WITH([fpm-systemd],,
+    [AS_HELP_STRING([--with-fpm-systemd],
+      [Activate systemd integration])],
+    [no],
+    [no])
 
-  PHP_ARG_WITH(fpm-acl,,
-  [  --with-fpm-acl          Use POSIX Access Control Lists], no, no)
+  PHP_ARG_WITH([fpm-acl],,
+    [AS_HELP_STRING([--with-fpm-acl],
+      [Use POSIX Access Control Lists])],
+    [no],
+    [no])
 
   if test "$PHP_FPM_SYSTEMD" != "no" ; then
     if test -z "$PKG_CONFIG"; then

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -566,13 +566,13 @@ if test "$PHP_FPM" != "no"; then
   AC_FPM_APPARMOR
 
   PHP_ARG_WITH([fpm-user],,
-    [AS_HELP_STRING([--with-fpm-user[=USER]],
+    [AS_HELP_STRING([--with-fpm-user@<:@=USER@:>@],
       [Set the user for php-fpm to run as. (default: nobody)])],
     [nobody],
     [no])
 
   PHP_ARG_WITH([fpm-group],,
-    [AS_HELP_STRING([--with-fpm-group[=GRP]],
+    [AS_HELP_STRING([--with-fpm-group@<:@=GRP@:>@],
       [Set the group for php-fpm to run as. For a system user, this should
       usually be set to match the fpm username (default: nobody)])],
     [nobody],

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -573,7 +573,8 @@ if test "$PHP_FPM" != "no"; then
 
   PHP_ARG_WITH([fpm-group],,
     [AS_HELP_STRING([--with-fpm-group[=GRP]],
-      [Set the group for php-fpm to run as. For a system user, this should usually be set to match the fpm username (default: nobody)])],
+      [Set the group for php-fpm to run as. For a system user, this should
+      usually be set to match the fpm username (default: nobody)])],
     [nobody],
     [no])
 

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -566,13 +566,13 @@ if test "$PHP_FPM" != "no"; then
   AC_FPM_APPARMOR
 
   PHP_ARG_WITH([fpm-user],,
-    [AS_HELP_STRING([--with-fpm-user@<:@=USER@:>@],
+    [AS_HELP_STRING([[--with-fpm-user[=USER]]],
       [Set the user for php-fpm to run as. (default: nobody)])],
     [nobody],
     [no])
 
   PHP_ARG_WITH([fpm-group],,
-    [AS_HELP_STRING([--with-fpm-group@<:@=GRP@:>@],
+    [AS_HELP_STRING([[--with-fpm-group[=GRP]]],
       [Set the group for php-fpm to run as. For a system user, this should
       usually be set to match the fpm username (default: nobody)])],
     [nobody],

--- a/sapi/litespeed/config.m4
+++ b/sapi/litespeed/config.m4
@@ -2,8 +2,10 @@ dnl config.m4 for sapi litespeed
 
 AC_MSG_CHECKING(for LiteSpeed support)
 
-PHP_ARG_WITH(litespeed,,
-[  --with-litespeed        Build PHP as litespeed module], no)
+PHP_ARG_WITH([litespeed],,
+  [AS_HELP_STRING([--with-litespeed],
+    [Build PHP as litespeed module])],
+  [no])
 
 if test "$PHP_LITESPEED" != "no"; then
   PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/sapi/litespeed/Makefile.frag,$abs_srcdir/sapi/litespeed,sapi/litespeed)

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -1,14 +1,23 @@
 dnl config.m4 for sapi phpdbg
 
-PHP_ARG_ENABLE(phpdbg, for phpdbg support,
-[  --enable-phpdbg         Build phpdbg], yes, yes)
+PHP_ARG_ENABLE([phpdbg],
+  [for phpdbg support],
+  [AS_HELP_STRING([--enable-phpdbg],
+    [Build phpdbg])],
+  [yes],
+  [yes])
 
-PHP_ARG_ENABLE(phpdbg-webhelper, for phpdbg web SAPI support,
-[  --enable-phpdbg-webhelper
-                          Build phpdbg web SAPI support], no)
+PHP_ARG_ENABLE([phpdbg-webhelper],
+  [for phpdbg web SAPI support],
+  [AS_HELP_STRING([--enable-phpdbg-webhelper],
+    [Build phpdbg web SAPI support])], no)
 
-PHP_ARG_ENABLE(phpdbg-debug, for phpdbg debug build,
-[  --enable-phpdbg-debug   Build phpdbg in debug mode], no, no)
+PHP_ARG_ENABLE([phpdbg-debug],
+  [for phpdbg debug build],
+  [AS_HELP_STRING([--enable-phpdbg-debug],
+    [Build phpdbg in debug mode])],
+  [no],
+  [no])
 
 if test "$BUILD_PHPDBG" = "" && test "$PHP_PHPDBG" != "no"; then
   AC_HEADER_TIOCGWINSZ

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -10,7 +10,8 @@ PHP_ARG_ENABLE([phpdbg],
 PHP_ARG_ENABLE([phpdbg-webhelper],
   [for phpdbg web SAPI support],
   [AS_HELP_STRING([--enable-phpdbg-webhelper],
-    [Build phpdbg web SAPI support])], no)
+    [Build phpdbg web SAPI support])],
+  [no])
 
 PHP_ARG_ENABLE([phpdbg-debug],
   [for phpdbg debug build],

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -28,15 +28,22 @@ PHP_DETECT_ICC
 PHP_DETECT_SUNCC
 
 dnl Support systems with system libraries in e.g. /usr/lib64
-PHP_ARG_WITH(libdir, for system library directory,
-[  --with-libdir=NAME      Look for libraries in .../NAME rather than .../lib], lib, no)
+PHP_ARG_WITH([libdir],
+  [for system library directory],
+  [AS_HELP_STRING([--with-libdir=NAME],
+    [Look for libraries in .../NAME rather than .../lib])],
+  [lib],
+  [no])
 
 PHP_RUNPATH_SWITCH
 PHP_SHLIB_SUFFIX_NAMES
 
 dnl Find php-config script
-PHP_ARG_WITH(php-config,,
-[  --with-php-config=PATH  Path to php-config [php-config]], php-config, no)
+PHP_ARG_WITH([php-config],,
+  [AS_HELP_STRING([--with-php-config=PATH],
+    [Path to php-config [php-config]])],
+  [php-config],
+  [no])
 
 dnl For BC
 PHP_CONFIG=$PHP_PHP_CONFIG

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -41,7 +41,7 @@ PHP_SHLIB_SUFFIX_NAMES
 dnl Find php-config script
 PHP_ARG_WITH([php-config],,
   [AS_HELP_STRING([--with-php-config=PATH],
-    [Path to php-config @<:@[php-config]@:>@])],
+    [Path to php-config [php-config]])],
   [php-config],
   [no])
 

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -41,7 +41,7 @@ PHP_SHLIB_SUFFIX_NAMES
 dnl Find php-config script
 PHP_ARG_WITH([php-config],,
   [AS_HELP_STRING([--with-php-config=PATH],
-    [Path to php-config [php-config]])],
+    [Path to php-config @<:@[php-config]@:>@])],
   [php-config],
   [no])
 


### PR DESCRIPTION
The Autoconf's default [`AS_HELP_STRING`](https://www.gnu.org/software/autoconf/manual/autoconf.html#Pretty-Help-Strings) macro can properly format help strings [1] so watching out if columns are aligned manually won't be needed anymore.

These strings are visible in the `configure --help` output.

TODO:

* [x] Format PHP_ARG_*s in `configure.ac`
* [x] Fix tabs in pdop_odbc
* [x] CS style fixes here and there.
* [x] Update README.SELF-CONTAINED-EXTENSIONS
* [x] Replace special characters with [quadrigraphs](https://www.gnu.org/software/autoconf/manual/autoconf.html#Quadrigraphs)