### PR TITLE
Remove HAVE_* for always available extensions

### DIFF
--- a/ext/date/config.w32
+++ b/ext/date/config.w32
@@ -2,7 +2,6 @@
 
 EXTENSION("date", "php_date.c", false, "/Iext/date/lib /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /DHAVE_TIMELIB_CONFIG_H=1");
 ADD_SOURCES("ext/date/lib", "astro.c timelib.c dow.c parse_date.c parse_tz.c tm2unixtime.c unixtime2tm.c parse_iso_intervals.c interval.c", "date");
-AC_DEFINE('HAVE_DATE', 1, 'Have date/time support');
 
 ADD_FLAG('CFLAGS_DATE', "/wd4244");
 

--- a/ext/reflection/config.m4
+++ b/ext/reflection/config.m4
@@ -1,4 +1,3 @@
 dnl config.m4 for extension reflection
 
-AC_DEFINE(HAVE_REFLECTION, 1, [Whether Reflection is enabled])
 PHP_NEW_EXTENSION(reflection, php_reflection.c, no,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)

--- a/ext/reflection/config.w32
+++ b/ext/reflection/config.w32
@@ -1,5 +1,4 @@
 // vim:ft=javascript
 
 EXTENSION("reflection", "php_reflection.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-AC_DEFINE('HAVE_REFLECTION', 1, 'Reflection support enabled');
 PHP_REFLECTION="yes";

--- a/ext/spl/config.m4
+++ b/ext/spl/config.m4
@@ -1,6 +1,5 @@
 dnl config.m4 for extension SPL
 
-  AC_DEFINE(HAVE_SPL, 1, [Whether you want SPL (Standard PHP Library) support])
   PHP_NEW_EXTENSION(spl, php_spl.c spl_functions.c spl_engine.c spl_iterators.c spl_array.c spl_directory.c spl_exceptions.c spl_observer.c spl_dllist.c spl_heap.c spl_fixedarray.c, no,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_INSTALL_HEADERS([ext/spl], [php_spl.h spl_array.h spl_directory.h spl_engine.h spl_exceptions.h spl_functions.h spl_iterators.h spl_observer.h spl_dllist.h spl_heap.h spl_fixedarray.h])
   PHP_ADD_EXTENSION_DEP(spl, pcre, true)

--- a/ext/spl/config.w32
+++ b/ext/spl/config.w32
@@ -1,6 +1,5 @@
 // vim:ft=javascript
 
 EXTENSION("spl", "php_spl.c spl_functions.c spl_engine.c spl_iterators.c spl_array.c spl_directory.c spl_exceptions.c spl_observer.c spl_dllist.c spl_heap.c spl_fixedarray.c", false /*never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-AC_DEFINE('HAVE_SPL', 1);
 PHP_SPL="yes";
 PHP_INSTALL_HEADERS("ext/spl", "php_spl.h spl_array.h spl_directory.h spl_engine.h spl_exceptions.h spl_functions.h spl_iterators.h spl_observer.h spl_dllist.h spl_heap.h spl_fixedarray.h");

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -28,11 +28,7 @@
 #include "ext/standard/php_string.h"
 #include "ext/pcre/php_pcre.h"
 #include "ext/standard/php_filestat.h"
-#if PHP_VERSION_ID >= 70200
 #include "zend_interfaces.h"
-#elif defined(HAVE_SPL)
-#include "ext/spl/spl_iterators.h"
-#endif
 #include "php_zip.h"
 
 /* zip_open is a macro for renaming libzip zipopen, so we need to use PHP_NAMED_FUNCTION */
@@ -3017,11 +3013,7 @@ static PHP_MINIT_FUNCTION(zip)
 	php_zip_register_prop_handler(&zip_prop_handlers, "numFiles",  php_zip_get_num_files, NULL, NULL, IS_LONG);
 	php_zip_register_prop_handler(&zip_prop_handlers, "filename", NULL, NULL, php_zipobj_get_filename, IS_STRING);
 	php_zip_register_prop_handler(&zip_prop_handlers, "comment", NULL, php_zipobj_get_zip_comment, NULL, IS_STRING);
-#if PHP_VERSION_ID >= 70200
 	zend_class_implements(zip_class_entry, 1, zend_ce_countable);
-#elif defined(HAVE_SPL)
-	zend_class_implements(zip_class_entry, 1, spl_ce_Countable);
-#endif
 
 	REGISTER_ZIP_CLASS_CONST_LONG("CREATE", ZIP_CREATE);
 	REGISTER_ZIP_CLASS_CONST_LONG("EXCL", ZIP_EXCL);

--- a/main/internal_functions_win32.c
+++ b/main/internal_functions_win32.c
@@ -52,9 +52,7 @@
 #if HAVE_CTYPE
 #include "ext/ctype/php_ctype.h"
 #endif
-#if HAVE_DATE
 #include "ext/date/php_date.h"
-#endif
 #if HAVE_FTP
 #include "ext/ftp/php_ftp.h"
 #endif
@@ -91,9 +89,7 @@
 #include "ext/xml/php_xml.h"
 #endif
 #include "ext/com_dotnet/php_com_dotnet.h"
-#ifdef HAVE_SPL
 #include "ext/spl/php_spl.h"
-#endif
 #if HAVE_XML && HAVE_XMLREADER
 #include "ext/xmlreader/php_xmlreader.h"
 #endif


### PR DESCRIPTION
As the Reflection extension now builds by default and can't be disabled, these isn't necessary.