### PR TITLE
Replace --with-gd by --enable-gd for Travis

### DIFF
--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -40,7 +40,7 @@ $TS \
 --with-pdo-sqlite \
 --enable-intl \
 --without-pear \
---with-gd \
+--enable-gd \
 --with-jpeg \
 --with-webp \
 --with-freetype \


### PR DESCRIPTION
From 570d431 the `--with-gd` option should be replaced by `--enable-gd` to avoid the following warning:
```
configure: WARNING: unrecognized options: --with-gd
```