### PR TITLE
ext/standard/basic_functions.c: add puts function

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -763,6 +763,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_print_r, 0, 0, 1)
 	ZEND_ARG_INFO(0, return)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_puts, 0, 0, 1)
+	ZEND_ARG_INFO(0, message)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_connection_aborted, 0)
 ZEND_END_ARG_INFO()
 
@@ -3032,6 +3036,7 @@ static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(var_export,														arginfo_var_export)
 	PHP_FE(debug_zval_dump,													arginfo_debug_zval_dump)
 	PHP_FE(print_r,															arginfo_print_r)
+	PHP_FE(puts,															arginfo_puts)
 	PHP_FE(memory_get_usage,												arginfo_memory_get_usage)
 	PHP_FE(memory_get_peak_usage,											arginfo_memory_get_peak_usage)
 
@@ -5642,6 +5647,20 @@ PHP_FUNCTION(print_r)
 		zend_print_zval_r(var, 0);
 		RETURN_TRUE;
 	}
+}
+/* }}} */
+
+/* {{{ proto void puts(string message) */
+PHP_FUNCTION(puts)
+{
+	zend_string *message;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(message)
+	ZEND_PARSE_PARAMETERS_END();
+
+	PHPWRITE(ZSTR_VAL(message), ZSTR_LEN(message));
+	PHPWRITE(PHP_EOL, sizeof(PHP_EOL) - 1);
 }
 /* }}} */
 

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -101,6 +101,7 @@ PHP_FUNCTION(set_include_path);
 PHP_FUNCTION(restore_include_path);
 
 PHP_FUNCTION(print_r);
+PHP_FUNCTION(puts);
 PHP_FUNCTION(fprintf);
 PHP_FUNCTION(vfprintf);
 

--- a/ext/standard/tests/strings/puts.phpt
+++ b/ext/standard/tests/strings/puts.phpt
@@ -1,0 +1,88 @@
+--TEST--
+Test puts() function : basic functionality
+--FILE--
+<?php
+
+/* Prototype  : void puts ( string $arg )
+ * Description: Output a string
+ * Source code: ext/standard/basic_functions.c
+*/
+
+echo "*** Testing puts() : basic functionality ***\n";
+
+echo "\n-- Iteration 1 --\n";
+puts("Hello World");
+
+echo "\n-- Iteration 2 --\n";
+puts("This spans
+multiple lines. The newlines will be
+output as well");
+
+echo "\n-- Iteration 3 --\n";
+puts("This also spans\nmultiple lines. The newlines will be\noutput as well.");
+
+echo "\n-- Iteration 4 --\n";
+puts("escaping characters is done \"Like this\".");
+
+// You can use variables inside of a puts statement
+$foo = "foobar";
+$bar = "barbaz";
+
+echo "\n-- Iteration 5 --\n";
+puts("foo is $foo"); // foo is foobar
+
+// You can also use arrays
+$bar = array("value" => "foo");
+
+echo "\n-- Iteration 6 --\n";
+puts("this is {$bar['value']} !"); // this is foo !
+
+// Using single quotes will output the variable name, not the value
+echo "\n-- Iteration 7 --\n";
+puts('foo is $foo'); // foo is $foo
+
+// If you are not using any other characters, you can just output variables
+echo "\n-- Iteration 8 --\n";
+puts($foo); // foobar
+
+echo "\n-- Iteration 9 --\n";
+$variable = "VARIABLE";
+puts(<<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon no extra whitespace!\n
+END
+);
+
+?>
+===DONE===
+--EXPECT--
+*** Testing puts() : basic functionality ***
+
+-- Iteration 1 --
+Hello World
+-- Iteration 2 --
+This spans
+multiple lines. The newlines will be
+output as well
+-- Iteration 3 --
+This also spans
+multiple lines. The newlines will be
+output as well.
+-- Iteration 4 --
+escaping characters is done "Like this".
+-- Iteration 5 --
+foo is foobar
+-- Iteration 6 --
+this is foo !
+-- Iteration 7 --
+foo is $foo
+-- Iteration 8 --
+foobar
+-- Iteration 9 --
+This uses the "here document" syntax to output
+multiple lines with VARIABLE interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon no extra whitespace!
+===DONE===

--- a/ext/standard/tests/strings/puts.phpt
+++ b/ext/standard/tests/strings/puts.phpt
@@ -10,56 +10,51 @@ Test puts() function : basic functionality
 
 echo "*** Testing puts() : basic functionality ***\n";
 
-echo "\n-- Iteration 1 --\n";
+echo "-- Iteration 1 --\n";
 puts("Hello World");
 
-echo "\n-- Iteration 2 --\n";
+echo "-- Iteration 2 --\n";
 puts("This spans
 multiple lines. The newlines will be
 output as well");
 
-echo "\n-- Iteration 3 --\n";
-puts("This also spans\nmultiple lines. The newlines will be\noutput as well.");
-
-echo "\n-- Iteration 4 --\n";
+echo "-- Iteration 3 --\n";
 puts("escaping characters is done \"Like this\".");
 
 // You can use variables inside of a puts statement
 $foo = "foobar";
 $bar = "barbaz";
 
-echo "\n-- Iteration 5 --\n";
+echo "-- Iteration 4 --\n";
 puts("foo is $foo"); // foo is foobar
 
 // You can also use arrays
 $bar = array("value" => "foo");
 
-echo "\n-- Iteration 6 --\n";
+echo "-- Iteration 5 --\n";
 puts("this is {$bar['value']} !"); // this is foo !
 
 // Using single quotes will output the variable name, not the value
-echo "\n-- Iteration 7 --\n";
+echo "-- Iteration 6 --\n";
 puts('foo is $foo'); // foo is $foo
 
 // If you are not using any other characters, you can just output variables
-echo "\n-- Iteration 8 --\n";
+echo "-- Iteration 7 --\n";
 puts($foo); // foobar
 
-echo "\n-- Iteration 9 --\n";
+echo "-- Iteration 8 --\n";
 $variable = "VARIABLE";
 puts(<<<END
 This uses the "here document" syntax to output
 multiple lines with $variable interpolation. Note
 that the here document terminator must appear on a
-line with just a semicolon no extra whitespace!\n
+line with just a semicolon no extra whitespace!
 END
 );
-
 ?>
 ===DONE===
 --EXPECT--
 *** Testing puts() : basic functionality ***
-
 -- Iteration 1 --
 Hello World
 -- Iteration 2 --
@@ -67,20 +62,16 @@ This spans
 multiple lines. The newlines will be
 output as well
 -- Iteration 3 --
-This also spans
-multiple lines. The newlines will be
-output as well.
--- Iteration 4 --
 escaping characters is done "Like this".
--- Iteration 5 --
+-- Iteration 4 --
 foo is foobar
--- Iteration 6 --
+-- Iteration 5 --
 this is foo !
--- Iteration 7 --
+-- Iteration 6 --
 foo is $foo
--- Iteration 8 --
+-- Iteration 7 --
 foobar
--- Iteration 9 --
+-- Iteration 8 --
 This uses the "here document" syntax to output
 multiple lines with VARIABLE interpolation. Note
 that the here document terminator must appear on a


### PR DESCRIPTION
with PHP, several methods are available to produce output:

~~~php
echo "hello world\n";
print "hello world\n";
print_r("hello world\n");
var_export("hello world\n");
~~~

However all these methods have something in common: they do not produce their
own newline. With each method, the user is required to provide a newline with
`\n`, `PHP_EOL` or similar. This is bothersome because many other programming
languages offer such a method. For example Python:

~~~py
print('hello world')
~~~

Perl:

~~~pl
use feature say;
say 'hello world';
~~~

Ruby:

~~~rb
puts 'hello world'
~~~

Lua:

~~~lua
print 'hello world'
~~~

Even C:

~~~c
#include <stdio.h>
int main() {
   puts("hello world");
}
~~~

To resolve, implement "puts" function similar to Ruby or C:

- http://pubs.opengroup.org/onlinepubs/9699919799/functions/puts.html
- http://ruby-doc.org/core/IO.html#method-i-puts