### PR TITLE
Fix shifting signed values too far

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -587,12 +587,12 @@ static zend_always_inline int zend_mm_bitset_is_set(zend_mm_bitset *bitset, int 
 
 static zend_always_inline void zend_mm_bitset_set_bit(zend_mm_bitset *bitset, int bit)
 {
-	bitset[bit / ZEND_MM_BITSET_LEN] |= (Z_L(1) << (bit & (ZEND_MM_BITSET_LEN-1)));
+	bitset[bit / ZEND_MM_BITSET_LEN] |= (Z_UL(1) << (bit & (ZEND_MM_BITSET_LEN-1)));
 }
 
 static zend_always_inline void zend_mm_bitset_reset_bit(zend_mm_bitset *bitset, int bit)
 {
-	bitset[bit / ZEND_MM_BITSET_LEN] &= ~(Z_L(1) << (bit & (ZEND_MM_BITSET_LEN-1)));
+	bitset[bit / ZEND_MM_BITSET_LEN] &= ~(Z_UL(1) << (bit & (ZEND_MM_BITSET_LEN-1)));
 }
 
 static zend_always_inline void zend_mm_bitset_set_range(zend_mm_bitset *bitset, int start, int len)

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -325,7 +325,7 @@ typedef struct _zend_oparray_context {
 #define ZEND_ACC_DTOR                    (1 << 29) /*     |  X  |     |     */
 /*                                                        |     |     |     */
 /* op_array uses strict mode types                        |     |     |     */
-#define ZEND_ACC_STRICT_TYPES            (1 << 31) /*     |  X  |     |     */
+#define ZEND_ACC_STRICT_TYPES            (1U << 31) /*    |  X  |     |     */
 
 
 #define ZEND_ACC_PPP_MASK  (ZEND_ACC_PUBLIC | ZEND_ACC_PROTECTED | ZEND_ACC_PRIVATE)

--- a/Zend/zend_cpuinfo.h
+++ b/Zend/zend_cpuinfo.h
@@ -22,7 +22,7 @@
 #include "zend.h"
 
 #define ZEND_CPU_EBX_MASK     (1<<30)
-#define ZEND_CPU_EDX_MASK     (1<<31)
+#define ZEND_CPU_EDX_MASK     (1U<<31)
 
 typedef enum _zend_cpu_feature {
 	/* ECX */

--- a/ext/opcache/Optimizer/zend_cfg.h
+++ b/ext/opcache/Optimizer/zend_cfg.h
@@ -35,7 +35,7 @@
 #define ZEND_BB_LOOP_HEADER      (1<<16)
 #define ZEND_BB_IRREDUCIBLE_LOOP (1<<17)
 
-#define ZEND_BB_REACHABLE        (1<<31)
+#define ZEND_BB_REACHABLE        (1U<<31)
 
 #define ZEND_BB_PROTECTED        (ZEND_BB_ENTRY|ZEND_BB_RECV_ENTRY|ZEND_BB_TRY|ZEND_BB_CATCH|ZEND_BB_FINALLY|ZEND_BB_FINALLY_END|ZEND_BB_UNREACHABLE_FREE)
 
@@ -92,7 +92,7 @@ typedef struct _zend_cfg {
 } zend_cfg;
 
 /* Build Flags */
-#define ZEND_RT_CONSTANTS              (1<<31)
+#define ZEND_RT_CONSTANTS              (1U<<31)
 #define ZEND_CFG_STACKLESS             (1<<30)
 #define ZEND_SSA_DEBUG_LIVENESS        (1<<29)
 #define ZEND_SSA_DEBUG_PHI_PLACEMENT   (1<<28)


### PR DESCRIPTION
Signed shift of 31 for int and 63 for long is flagged as undefined
behavior by UBSan (-fsanitize=undefined) and seems to be indeed so
according to the standard.

The patch converts such cases to use unsigned.