### PR TITLE
curl_exec: remove bad check for CURLE_PARTIAL_FILE

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -3113,8 +3113,8 @@ PHP_FUNCTION(curl_exec)
 
 	error = curl_easy_perform(ch->cp);
 	SAVE_CURL_ERROR(ch, error);
-	/* CURLE_PARTIAL_FILE is returned by HEAD requests */
-	if (error != CURLE_OK && error != CURLE_PARTIAL_FILE) {
+
+	if (error != CURLE_OK) {
 		smart_str_free(&ch->handlers->write->buf);
 		RETURN_FALSE;
 	}


### PR DESCRIPTION
This check introduced in 2004 is wrong and removed. A HEAD request with
curl does *not* cause this error code - only if you make a regular GET
request but tell curl to send a HEAD using CURLOPT_CUSTOMREQUEST and
then you've asked for it.

You do a proper HEAD request with curl by setting the CURLOPT_NOBODY
option to 1L.

This was the case in 2004. This is still the case in 2019. This is also
documented in libcurl documentation.

This check hides the possibly serious error when this error code is
genuinely and correctly returned by curl because the transfer was
truncated and ended up partial.

As can be seen, I objected to this change already in the original bug:
https://bugs.php.net/bug.php?id=27341

/cc @jay @nikic 