### PR TITLE
Disable shift optimization when building for fuzzing

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -439,7 +439,7 @@ char *alloca();
 #define MIN(a, b)  (((a)<(b))?(a):(b))
 
 /* x86 instructions BT, SHL, SHR don't require masking */
-#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__)) || defined(ZEND_WIN32)
+#if (defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__)) || defined(ZEND_WIN32)) && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 # define ZEND_BIT_TEST(bits, bit) (((bits)[(bit) / (sizeof((bits)[0])*8)] >> (bit)) & 1)
 #else
 # define ZEND_BIT_TEST(bits, bit) (((bits)[(bit) / (sizeof((bits)[0])*8)] >> ((bit) & (sizeof((bits)[0])*8-1))) & 1)


### PR DESCRIPTION
UBSan does not understand such shifts and complains.