### PR TITLE
Fix PS_GC_FUNC(user) convert to long logic

### DIFF
--- a/ext/session/mod_user.c
+++ b/ext/session/mod_user.c
@@ -189,13 +189,14 @@ PS_GC_FUNC(user)
 	ps_call_handler(&PSF(gc), 1, args, &retval);
 
 	if (Z_TYPE(retval) == IS_LONG) {
-		convert_to_long(&retval);
 		return Z_LVAL(retval);
 	}
+
 	/* This is for older API compatibility */
 	if (Z_TYPE(retval) == IS_TRUE) {
 		return 1;
 	}
+
 	/* Anything else is some kind of error */
 	return -1; // Error
 }


### PR DESCRIPTION
The original logic tries to convert a long value zval into a long value, which is incorrect.

We should check if it's IS_TRUE first and then try to convert the zval into long value when it's not a long value.