### PR TITLE
Remove the legacy function_table var usage

### DIFF
--- a/ext/com_dotnet/com_wrapper.c
+++ b/ext/com_dotnet/com_wrapper.c
@@ -286,7 +286,7 @@ static HRESULT STDMETHODCALLTYPE disp_invokeex(
 		} else if (wFlags & DISPATCH_METHOD) {
 			zend_try {
 				retval = &rv;
-				if (SUCCESS == call_user_function(EG(function_table), &disp->object, name,
+				if (SUCCESS == call_user_function(NULL, &disp->object, name,
 							retval, pdp->cArgs, params)) {
 					ret = S_OK;
 					trace("function called ok\n");

--- a/ext/filter/callback_filter.c
+++ b/ext/filter/callback_filter.c
@@ -32,7 +32,7 @@ void php_filter_callback(PHP_INPUT_FILTER_PARAM_DECL)
 	}
 
 	ZVAL_COPY(&args[0], value);
-	status = call_user_function_ex(EG(function_table), NULL, option_array, &retval, 1, args, 0, NULL);
+	status = call_user_function_ex(NULL, NULL, option_array, &retval, 1, args, 0, NULL);
 
 	if (status == SUCCESS && !Z_ISUNDEF(retval)) {
 		zval_ptr_dtor(value);

--- a/ext/interbase/ibase_events.c
+++ b/ext/interbase/ibase_events.c
@@ -232,7 +232,7 @@ static isc_callback  _php_ibase_callback(ibase_event *event, /* {{{ */
 			}
 
 			/* call the callback provided by the user */
-			if (SUCCESS != call_user_function(EG(function_table), NULL,
+			if (SUCCESS != call_user_function(NULL, NULL,
 					&event->callback, &return_value, 2, args)) {
 				_php_ibase_module_error("Error calling callback %s", Z_STRVAL(event->callback));
 				break;

--- a/ext/interbase/php_ibase_udf.c
+++ b/ext/interbase/php_ibase_udf.c
@@ -285,7 +285,7 @@ static void call_php(char *name, PARAMDSC *r, int argc, PARAMDSC **argv)
 		LOCK();
 
 		/* now call the function */
-		if (FAILURE == call_user_function(EG(function_table), NULL,
+		if (FAILURE == call_user_function(NULL, NULL,
 				&callback, &return_value, argc, args)) {
 			UNLOCK();
 			break;

--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -492,7 +492,7 @@ static int php_json_encode_serializable_object(smart_str *buf, zval *val, int op
 
 	ZVAL_STRING(&fname, "jsonSerialize");
 
-	if (FAILURE == call_user_function(EG(function_table), val, &fname, &retval, 0, NULL) || Z_TYPE(retval) == IS_UNDEF) {
+	if (FAILURE == call_user_function(NULL, val, &fname, &retval, 0, NULL) || Z_TYPE(retval) == IS_UNDEF) {
 		if (!EG(exception)) {
 			zend_throw_exception_ex(NULL, 0, "Failed calling %s::jsonSerialize()", ZSTR_VAL(ce->name));
 		}

--- a/ext/oci8/oci8_failover.c
+++ b/ext/oci8/oci8_failover.c
@@ -62,7 +62,7 @@ sb4 callback_fn(void *svchp, void *envhp, void *fo_ctx, ub4 fo_type, ub4 fo_even
 	ZVAL_LONG(&params[2], fo_type);
 
 	/* Call user function (if possible) */
-	if (call_user_function(EG(function_table), NULL, &connection->taf_callback, &retval, 3, params) == FAILURE) {
+	if (call_user_function(NULL, NULL, &connection->taf_callback, &retval, 3, params) == FAILURE) {
 		php_error_docref(NULL, E_WARNING, "Unable to call Oracle TAF callback function");
 	}
 

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1128,7 +1128,7 @@ static void php_openssl_limit_handshake_reneg(const SSL *ssl) /* {{{ */
 
 			/* Closing the stream inside this callback would segfault! */
 			stream->flags |= PHP_STREAM_FLAG_NO_FCLOSE;
-			if (FAILURE == call_user_function_ex(EG(function_table), NULL, val, &retval, 1, &param, 0, NULL)) {
+			if (FAILURE == call_user_function_ex(NULL, NULL, val, &retval, 1, &param, 0, NULL)) {
 				php_error(E_WARNING, "SSL: failed invoking reneg limit notification callback");
 			}
 			stream->flags ^= PHP_STREAM_FLAG_NO_FCLOSE;

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1497,7 +1497,7 @@ void pcntl_signal_dispatch()
 
 				/* Call php signal handler - Note that we do not report errors, and we ignore the return value */
 				/* FIXME: this is probably broken when multiple signals are handled in this while loop (retval) */
-				call_user_function(EG(function_table), NULL, handle, &retval, 2, params);
+				call_user_function(NULL, NULL, handle, &retval, 2, params);
 				zval_ptr_dtor(&retval);
 #ifdef HAVE_STRUCT_SIGINFO_T
 				zval_ptr_dtor(&params[1]);

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -544,7 +544,7 @@ static char **_readline_completion_cb(const char *text, int start, int end)
 	_readline_long_zval(&params[1], start);
 	_readline_long_zval(&params[2], end);
 
-	if (call_user_function(CG(function_table), NULL, &_readline_completion, &_readline_array, 3, params) == SUCCESS) {
+	if (call_user_function(NULL, NULL, &_readline_completion, &_readline_array, 3, params) == SUCCESS) {
 		if (Z_TYPE(_readline_array) == IS_ARRAY) {
 			if (zend_hash_num_elements(Z_ARRVAL(_readline_array))) {
 				matches = rl_completion_matches(text,_readline_command_generator);
@@ -603,7 +603,7 @@ static void php_rl_callback_handler(char *the_line)
 
 	_readline_string_zval(&params[0], the_line);
 
-	call_user_function(CG(function_table), NULL, &_prepped_callback, &dummy, 1, params);
+	call_user_function(NULL, NULL, &_prepped_callback, &dummy, 1, params);
 
 	zval_ptr_dtor(&params[0]);
 	zval_ptr_dtor(&dummy);

--- a/ext/session/mod_user.c
+++ b/ext/session/mod_user.c
@@ -35,7 +35,7 @@ static void ps_call_handler(zval *func, int argc, zval *argv, zval *retval)
 		return;
 	}
 	PS(in_save_handler) = 1;
-	if (call_user_function(EG(function_table), NULL, func, retval, argc, argv) == FAILURE) {
+	if (call_user_function(NULL, NULL, func, retval, argc, argv) == FAILURE) {
 		zval_ptr_dtor(retval);
 		ZVAL_UNDEF(retval);
 	} else if (Z_ISUNDEF_P(retval)) {

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -604,7 +604,7 @@ xmlNodePtr to_xml_user(encodeTypePtr type, zval *data, int style, xmlNodePtr par
 	if (type && type->map && Z_TYPE(type->map->to_xml) != IS_UNDEF) {
 		ZVAL_NULL(&return_value);
 
-		if (call_user_function(EG(function_table), NULL, &type->map->to_xml, &return_value, 1, data) == FAILURE) {
+		if (call_user_function(NULL, NULL, &type->map->to_xml, &return_value, 1, data) == FAILURE) {
 			soap_error0(E_ERROR, "Encoding: Error calling to_xml callback");
 		}
 		if (Z_TYPE(return_value) == IS_STRING) {
@@ -641,7 +641,7 @@ zval *to_zval_user(zval *ret, encodeTypePtr type, xmlNodePtr node)
 		xmlBufferFree(buf);
 		xmlFreeNode(copy);
 
-		if (call_user_function(EG(function_table), NULL, &type->map->to_zval, ret, 1, &data) == FAILURE) {
+		if (call_user_function(NULL, NULL, &type->map->to_zval, ret, 1, &data) == FAILURE) {
 			soap_error0(E_ERROR, "Encoding: Error calling from_xml callback");
 		} else if (EG(exception)) {
 			ZVAL_NULL(ret);

--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -176,12 +176,12 @@ PHP_FUNCTION(assert)
 
 		/* XXX do we want to check for error here? */
 		if (!description) {
-			call_user_function(CG(function_table), NULL, &ASSERTG(callback), &retval, 3, args);
+			call_user_function(NULL, NULL, &ASSERTG(callback), &retval, 3, args);
 			zval_ptr_dtor(&(args[2]));
 			zval_ptr_dtor(&(args[0]));
 		} else {
 			ZVAL_STR(&args[3], zval_get_string(description));
-			call_user_function(CG(function_table), NULL, &ASSERTG(callback), &retval, 4, args);
+			call_user_function(NULL, NULL, &ASSERTG(callback), &retval, 4, args);
 			zval_ptr_dtor(&(args[3]));
 			zval_ptr_dtor(&(args[2]));
 			zval_ptr_dtor(&(args[0]));

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -5056,7 +5056,7 @@ static int user_shutdown_function_call(zval *zv) /* {{{ */
 		return 0;
 	}
 
-	if (call_user_function(EG(function_table), NULL,
+	if (call_user_function(NULL, NULL,
 				&shutdown_function_entry->arguments[0],
 				&retval,
 				shutdown_function_entry->arg_count - 1,
@@ -5077,7 +5077,7 @@ static void user_tick_function_call(user_tick_function_entry *tick_fe) /* {{{ */
 	if (! tick_fe->calling) {
 		tick_fe->calling = 1;
 
-		if (call_user_function(	EG(function_table), NULL,
+		if (call_user_function(NULL, NULL,
 								function,
 								&retval,
 								tick_fe->arg_count - 1,

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -858,7 +858,7 @@ static void user_space_stream_notifier(php_stream_context *context, int notifyco
 	ZVAL_LONG(&zvs[4], bytes_sofar);
 	ZVAL_LONG(&zvs[5], bytes_max);
 
-	if (FAILURE == call_user_function_ex(EG(function_table), NULL, callback, &retval, 6, zvs, 0, NULL)) {
+	if (FAILURE == call_user_function_ex(NULL, NULL, callback, &retval, 6, zvs, 0, NULL)) {
 		php_error_docref(NULL, E_WARNING, "failed to call user notifier");
 	}
 	for (i = 0; i < 6; i++) {

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -719,7 +719,7 @@ static int php_var_serialize_call_sleep(zval *retval, zval *struc) /* {{{ */
 
 	ZVAL_STRINGL(&fname, "__sleep", sizeof("__sleep") - 1);
 	BG(serialize_lock)++;
-	res = call_user_function(CG(function_table), struc, &fname, retval, 0, 0);
+	res = call_user_function(NULL, struc, &fname, retval, 0, 0);
 	BG(serialize_lock)--;
 	zval_ptr_dtor_str(&fname);
 

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -221,7 +221,7 @@ PHPAPI void var_destroy(php_unserialize_data_t *var_hashx)
 					}
 
 					BG(serialize_lock)++;
-					if (call_user_function(CG(function_table), zv, &wakeup_name, &retval, 0, 0) == FAILURE || Z_ISUNDEF(retval)) {
+					if (call_user_function(NULL, zv, &wakeup_name, &retval, 0, 0) == FAILURE || Z_ISUNDEF(retval)) {
 						wakeup_failed = 1;
 						GC_ADD_FLAGS(Z_OBJ_P(zv), IS_OBJ_DESTRUCTOR_CALLED);
 					}
@@ -1033,7 +1033,7 @@ object ":" uiv ":" ["]	{
 
 		ZVAL_STR_COPY(&args[0], class_name);
 		BG(serialize_lock)++;
-		if (call_user_function_ex(CG(function_table), NULL, &user_func, &retval, 1, args, 0, NULL) != SUCCESS) {
+		if (call_user_function_ex(NULL, NULL, &user_func, &retval, 1, args, 0, NULL) != SUCCESS) {
 			BG(serialize_lock)--;
 			if (EG(exception)) {
 				zend_string_release_ex(class_name, 0);

--- a/ext/xmlrpc/xmlrpc-epi-php.c
+++ b/ext/xmlrpc/xmlrpc-epi-php.c
@@ -894,7 +894,7 @@ static XMLRPC_VALUE php_xmlrpc_callback(XMLRPC_SERVER server, XMLRPC_REQUEST xRe
 	/* Use same C function for all methods */
 
 	/* php func prototype: function user_func($method_name, $xmlrpc_params, $user_params) */
-	call_user_function(CG(function_table), NULL, &pData->php_function, &pData->return_data, 3, callback_params);
+	call_user_function(NULL, NULL, &pData->php_function, &pData->return_data, 3, callback_params);
 
 	pData->php_executed = 1;
 
@@ -920,7 +920,7 @@ static void php_xmlrpc_introspection_callback(XMLRPC_SERVER server, void* data) 
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL(pData->server->introspection_map), php_function) {
 		if (zend_is_callable(php_function, 0, &php_function_name)) {
 			/* php func prototype: function string user_func($user_params) */
-			if (call_user_function(CG(function_table), NULL, php_function, &retval, 1, callback_params) == SUCCESS) {
+			if (call_user_function(NULL, NULL, php_function, &retval, 1, callback_params) == SUCCESS) {
 				XMLRPC_VALUE xData;
 				STRUCT_XMLRPC_ERROR err = {0};
 

--- a/win32/signal.c
+++ b/win32/signal.c
@@ -35,7 +35,7 @@ static void php_win32_signal_ctrl_interrupt_function(zend_execute_data *execute_
 		ZVAL_LONG(&params[0], ctrl_evt);
 
 		/* If the function returns, */
-		call_user_function(EG(function_table), NULL, &ctrl_handler, &retval, 1, params);
+		call_user_function(NULL, NULL, &ctrl_handler, &retval, 1, params);
 		zval_ptr_dtor(&retval);
 	}
 


### PR DESCRIPTION
function_table var is not used in call_user_function macro anymore
hence replace the usage with NULL