### PR TITLE
Issue rtld now

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -139,12 +139,18 @@
 #  define RTLD_GLOBAL 0
 # endif
 
-# if defined(RTLD_GROUP) && defined(RTLD_WORLD) && defined(RTLD_PARENT)
-#  define DL_LOAD(libname)			dlopen(libname, RTLD_LAZY | RTLD_GLOBAL | RTLD_GROUP | RTLD_WORLD | RTLD_PARENT)
-# elif defined(RTLD_DEEPBIND) && !defined(__SANITIZE_ADDRESS__)
-#  define DL_LOAD(libname)			dlopen(libname, RTLD_LAZY | RTLD_GLOBAL | RTLD_DEEPBIND)
+# ifdef PHP_USE_RTLD_NOW
+#  define PHP_RTLD_MODE  RTLD_NOW
 # else
-#  define DL_LOAD(libname)			dlopen(libname, RTLD_LAZY | RTLD_GLOBAL)
+#  define PHP_RTLD_MODE  RTLD_LAZY
+# endif
+
+# if defined(RTLD_GROUP) && defined(RTLD_WORLD) && defined(RTLD_PARENT)
+#  define DL_LOAD(libname)			dlopen(libname, PHP_RTLD_MODE | RTLD_GLOBAL | RTLD_GROUP | RTLD_WORLD | RTLD_PARENT)
+# elif defined(RTLD_DEEPBIND) && !defined(__SANITIZE_ADDRESS__)
+#  define DL_LOAD(libname)			dlopen(libname, PHP_RTLD_MODE | RTLD_GLOBAL | RTLD_DEEPBIND)
+# else
+#  define DL_LOAD(libname)			dlopen(libname, PHP_RTLD_MODE | RTLD_GLOBAL)
 # endif
 # define DL_UNLOAD					dlclose
 # if defined(DLSYM_NEEDS_UNDERSCORE)

--- a/configure.ac
+++ b/configure.ac
@@ -927,6 +927,17 @@ else
   ZEND_DEBUG=no
 fi
 
+PHP_ARG_ENABLE([rtld-now],
+  [whether to dlopen extensions with RTLD_NOW instead of RTLD_LAZY],
+  [AS_HELP_STRING([--enable-rtld-now],
+    [Use dlopen with RTLD_NOW instead of RTLD_LAZY])],
+  [no],
+  [no])
+
+if test "$PHP_RTLD_NOW" = "yes"; then
+  AC_DEFINE(PHP_USE_RTLD_NOW, 1, [ Use dlopen with RTLD_NOW instead of RTLD_LAZY ])
+fi
+
 PHP_ARG_WITH([layout],
   [layout of installed files],
   [AS_HELP_STRING([--with-layout=TYPE],

--- a/sapi/litespeed/lsapilib.c
+++ b/sapi/litespeed/lsapilib.c
@@ -92,6 +92,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define uint32 uint32_t
 #endif
 
+#include <Zend/zend_portability.h>
+
 struct lsapi_MD5Context {
     uint32 buf[4];
     uint32 bits[2];
@@ -767,7 +769,7 @@ static int (*fp_lve_leave)(struct liblve *, uint32_t *) = NULL;
 static int (*fp_lve_jail)( struct passwd *, char *) = NULL;
 static int lsapi_load_lve_lib(void)
 {
-    s_liblve = dlopen("liblve.so.0", RTLD_LAZY);
+    s_liblve = DL_LOAD("liblve.so.0");
     if (s_liblve)
     {
         fp_lve_is_available = dlsym(s_liblve, "lve_is_available");

--- a/sapi/litespeed/lscriu.c
+++ b/sapi/litespeed/lscriu.c
@@ -88,6 +88,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 #include "lscriu.h"
 
+#include <Zend/zend_portability.h>
+
 #define  LSCRIU_PATH    256
 
 // Begin CRIU inclusion
@@ -262,8 +264,8 @@ static int LSCRIU_load_liblscapi(void)
     int error = 1;
     char *last;
 
-    if (!(lib_handle = dlopen(last = "liblscapi.so", RTLD_LAZY)) /*||
-        !(pthread_lib_handle = dlopen(last = "libpthread.so", RTLD_LAZY))*/)
+    if (!(lib_handle = DL_LOAD(last = "liblscapi.so")) /*||
+        !(pthread_lib_handle = DL_LOAD(last = "libpthread.so"))*/)
         fprintf(stderr, "LSCRIU (%d): failed to dlopen %s: %s - ignore CRIU\n",
                 s_pid, last, dlerror());
     else if (!(s_lscapi_dump_me = dlsym(lib_handle, last = "lscapi_dump_me")) ||


### PR DESCRIPTION
RTLD_NOW is used in most linux distribution (centos, debian, fedora, rhel, ubuntu...), for years, and for security purposes.

This option will simplify downstream work.

Notice: this option break default behavior, making extension load order important.

Probably a great idea to enable it, for dev, in debug build
