### PR TITLE
Fix duplicate symbols _zend_ce_weakref

### DIFF
--- a/Zend/zend_weakrefs.h
+++ b/Zend/zend_weakrefs.h
@@ -21,7 +21,7 @@
 
 BEGIN_EXTERN_C()
 
-ZEND_API zend_class_entry *zend_ce_weakref;
+extern ZEND_API zend_class_entry *zend_ce_weakref;
 
 void zend_register_weakref_ce(void);
 


### PR DESCRIPTION
The zend_ce_weakref need to be external...

Reproducing issue:
```
./buildconf
./configure
make
```

and then at the end there appears some errors of duplicate symbols `_zend_ce_weakref`:

```
Generating phar.php
Generating phar.phar
PEAR package PHP_Archive not installed: generated phar will require PHP's phar extension be enabled.
directorytreeiterator.inc
clicommand.inc
directorygraphiterator.inc
invertedregexiterator.inc
pharcommand.inc
phar.inc
duplicate symbol _zend_ce_weakref in:
    Zend/.libs/zend_execute_API.o
    Zend/.libs/zend_weakrefs.o
duplicate symbol _zend_ce_weakref in:
    Zend/.libs/zend_execute_API.o
    Zend/.libs/zend_objects.o
duplicate symbol _zend_ce_weakref in:
    Zend/.libs/zend_execute_API.o
    Zend/.libs/zend_default_classes.o
ld: 3 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:283: sapi/phpdbg/phpdbg] Error 1
```