### PR TITLE
Clean build system

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -22,8 +22,6 @@ unix.h \
 cpuid.h \
 dlfcn.h)
 
-AC_TYPE_SIZE_T
-
 AC_DEFUN([LIBZEND_DLSYM_CHECK],[
 dnl
 dnl Ugly hack to check if dlsym() requires a leading underscore in symbol name.
@@ -40,8 +38,7 @@ _LT_AC_TRY_DLOPEN_SELF([
 ])
 
 dnl Checks for library functions.
-AC_FUNC_ALLOCA
-AC_CHECK_FUNCS(strdup getpid kill strtod strtol finite fpclass sigsetjmp)
+AC_CHECK_FUNCS(getpid kill strtod strtol finite fpclass sigsetjmp)
 
 AC_CHECK_DECLS([isfinite, isnan, isinf], [], [], [[#include <math.h>]])
 

--- a/configure.ac
+++ b/configure.ac
@@ -631,7 +631,6 @@ memmove \
 mkstemp \
 mmap \
 nl_langinfo \
-perror \
 poll \
 ptsname \
 putenv \
@@ -660,7 +659,6 @@ strerror \
 strftime \
 strnlen \
 strptime \
-strstr \
 strtok_r \
 symlink \
 tempnam \

--- a/ext/xmlrpc/libxmlrpc/acinclude.m4
+++ b/ext/xmlrpc/libxmlrpc/acinclude.m4
@@ -4,10 +4,8 @@ AC_DEFUN([XMLRPC_FUNCTION_CHECKS],[
 
 # Standard XMLRPC list
 AC_CHECK_FUNCS( \
- strtoul strtoull snprintf \
- strstr strpbrk strerror\
- memmove)
-
+ strtoul strtoull \
+ strpbrk)
 ])
 
 AC_DEFUN([XMLRPC_HEADER_CHECKS],[
@@ -22,8 +20,4 @@ AC_CHECK_SIZEOF(char, 1)
 AC_CHECK_SIZEOF(int, 4)
 AC_CHECK_SIZEOF(long, 4)
 AC_CHECK_SIZEOF(long long, 8)
-AC_TYPE_SIZE_T
-AC_TYPE_UID_T
-
-
 ])

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -9,7 +9,7 @@ PHP_ARG_ENABLE([fpm],,
 dnl configure checks {{{
 AC_DEFUN([AC_FPM_STDLIBS],
 [
-  AC_CHECK_FUNCS(setenv clearenv setproctitle setproctitle_fast)
+  AC_CHECK_FUNCS(clearenv setproctitle setproctitle_fast)
 
   AC_SEARCH_LIBS(socket, socket)
   AC_SEARCH_LIBS(inet_addr, nsl)

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -86,7 +86,6 @@
 #define HAVE_STRCASECMP 1
 #define HAVE_STRDUP 1
 #define HAVE_STRERROR 1
-#define HAVE_STRSTR 1
 #define HAVE_TEMPNAM 1
 #define HAVE_UTIME 1
 #undef HAVE_DIRENT_H


### PR DESCRIPTION
Changes:
- AC_TYPE_SIZE_T called on only one place (configure.ac)
- AC_FUNC_ALLOCA called on only one place (configure.ac)
- AC_TYPE_UID_T called on only one place (configure.ac)
- HAVE_STRSTR removed since strstr is part of C89 standard [1]
- checking for the presence of perror function is not needed anymore
  since it is part of C89 standard and PHP calls it unconditionally.
- Checking for functions strdup, setenv, strerror, and memmove done only
  on one place (configure.ac)
- outdated check for snprintf removed

1: https://port70.net/~nsz/c/c89/c89-draft.html