### PR TITLE
Remove HAVE_STRFTIME

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -657,7 +657,6 @@ strcasecmp \
 strcoll \
 strdup \
 strerror \
-strftime \
 strnlen \
 strptime \
 strstr \

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -409,12 +409,8 @@ static const zend_function_entry date_functions[] = {
 	PHP_FE(mktime, arginfo_mktime)
 	PHP_FE(gmmktime, arginfo_gmmktime)
 	PHP_FE(checkdate, arginfo_checkdate)
-
-#ifdef HAVE_STRFTIME
 	PHP_FE(strftime, arginfo_strftime)
 	PHP_FE(gmstrftime, arginfo_gmstrftime)
-#endif
-
 	PHP_FE(time, arginfo_time)
 	PHP_FE(localtime, arginfo_localtime)
 	PHP_FE(getdate, arginfo_getdate)
@@ -1636,7 +1632,6 @@ PHP_FUNCTION(checkdate)
 }
 /* }}} */
 
-#ifdef HAVE_STRFTIME
 /* {{{ php_strftime - (gm)strftime helper */
 PHPAPI void php_strftime(INTERNAL_FUNCTION_PARAMETERS, int gmt)
 {
@@ -1748,7 +1743,6 @@ PHP_FUNCTION(gmstrftime)
 	php_strftime(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1);
 }
 /* }}} */
-#endif
 
 /* {{{ proto int time(void)
    Return current UNIX timestamp */

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -37,12 +37,8 @@ PHP_FUNCTION(mktime);
 PHP_FUNCTION(gmmktime);
 
 PHP_FUNCTION(checkdate);
-
-#ifdef HAVE_STRFTIME
 PHP_FUNCTION(strftime);
 PHP_FUNCTION(gmstrftime);
-#endif
-
 PHP_FUNCTION(time);
 PHP_FUNCTION(localtime);
 PHP_FUNCTION(getdate);
@@ -207,10 +203,10 @@ ZEND_END_MODULE_GLOBALS(date)
 PHPAPI zend_long php_parse_date(char *string, zend_long *now);
 PHPAPI void php_mktime(INTERNAL_FUNCTION_PARAMETERS, int gmt);
 PHPAPI int php_idate(char format, time_t ts, int localtime);
-#if HAVE_STRFTIME
+
 #define _php_strftime php_strftime
+
 PHPAPI void php_strftime(INTERNAL_FUNCTION_PARAMETERS, int gm);
-#endif
 PHPAPI zend_string *php_format_date(char *format, size_t format_len, time_t ts, int localtime);
 
 /* Mechanism to set new TZ database */

--- a/ext/date/tests/009.phpt
+++ b/ext/date/tests/009.phpt
@@ -3,7 +3,6 @@ strftime() and gmstrftime() tests
 --SKIPIF--
 <?php
 if (substr(PHP_OS, 0, 3) == 'WIN') die('skip posix only test.');
-if (!function_exists('strftime')) die("skip, strftime not available");
 ?>
 --FILE--
 <?php

--- a/ext/date/tests/009_win32.phpt
+++ b/ext/date/tests/009_win32.phpt
@@ -3,7 +3,6 @@ strftime() and gmstrftime() tests
 --SKIPIF--
 <?php
 if (substr(PHP_OS, 0, 3) != 'WIN') die('skip only windows test.');
-if (!function_exists('strftime')) die("skip, strftime not available");
 if (false === setlocale(LC_TIME, "en-us")) die("skip, couldn't set the locale to en-us");
 ?>
 --FILE--

--- a/ext/interbase/ibase_query.c
+++ b/ext/interbase/ibase_query.c
@@ -1396,9 +1396,7 @@ format_date_time:
 			if (flag & PHP_IBASE_UNIXTIME) {
 				ZVAL_LONG(val, mktime(&t));
 			} else {
-#if HAVE_STRFTIME
 				l = strftime(string_data, sizeof(string_data), format, &t);
-#else
 				switch (type & ~1) {
 					default:
 						l = slprintf(string_data, sizeof(string_data), "%02d/%02d/%4d %02d:%02d:%02d", t.tm_mon+1, t.tm_mday,

--- a/ext/interbase/ibase_query.c
+++ b/ext/interbase/ibase_query.c
@@ -1397,19 +1397,6 @@ format_date_time:
 				ZVAL_LONG(val, mktime(&t));
 			} else {
 				l = strftime(string_data, sizeof(string_data), format, &t);
-				switch (type & ~1) {
-					default:
-						l = slprintf(string_data, sizeof(string_data), "%02d/%02d/%4d %02d:%02d:%02d", t.tm_mon+1, t.tm_mday,
-							t.tm_year + 1900, t.tm_hour, t.tm_min, t.tm_sec);
-						break;
-					case SQL_TYPE_DATE:
-						l = slprintf(string_data, sizeof(string_data), "%02d/%02d/%4d", t.tm_mon + 1, t.tm_mday, t.tm_year+1900);
-						break;
-					case SQL_TYPE_TIME:
-						l = slprintf(string_data, sizeof(string_data), "%02d:%02d:%02d", t.tm_hour, t.tm_min, t.tm_sec);
-						break;
-				}
-#endif
 				ZVAL_STRINGL(val, string_data, l);
 				break;
 			}

--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -878,10 +878,8 @@ static const func_info_t func_infos[] = {
 	F0("mktime",                                MAY_BE_FALSE | MAY_BE_LONG),
 	F0("gmmktime",                              MAY_BE_FALSE | MAY_BE_LONG),
 	F0("checkdate",                             MAY_BE_FALSE | MAY_BE_TRUE),
-#ifdef HAVE_STRFTIME
 	F1("strftime",                              MAY_BE_FALSE | MAY_BE_STRING),
 	F1("gmstrftime",                            MAY_BE_FALSE | MAY_BE_STRING),
-#endif
 	F0("time",                                  MAY_BE_LONG),
 	F1("localtime",                             MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_LONG),
 	F1("getdate",                               MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_LONG | MAY_BE_ARRAY_OF_STRING),

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -105,7 +105,6 @@
 #define HAVE_LIBM 1
 #define HAVE_CUSERID 0
 #undef HAVE_RINT
-#define HAVE_STRFTIME 1
 #define SIZEOF_SHORT 2
 /* int and long are stll 32bit in 64bit compiles */
 #define SIZEOF_INT 4


### PR DESCRIPTION
Function strftime is part of the C89 standard [1] and current systems don't need to check for its presence anymore.

1: https://port70.net/~nsz/c/c89/c89-draft.html