### PR TITLE
fixed issue #77697--crash on phar test cases

### DIFF
--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1829,7 +1829,11 @@ int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signat
 			return FAILURE;
 #endif
 		case PHAR_SIG_OPENSSL: {
+#if (PLATFORM_BYTE_ORDER == IS_BIG_ENDIAN)
+			unsigned int siglen;
+#else 
 			size_t siglen;
+#endif
 			unsigned char *sigbuf;
 #ifdef PHAR_HAVE_OPENSSL
 			BIO *in;


### PR DESCRIPTION
See the issue  [77697](https://bugs.php.net/bug.php?id=77697) for details.
This PR fixes the crash on big_endian platform for phar test cases