### PR TITLE
Switch to bison location tracking

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -113,7 +113,7 @@ ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_class_const_or_name(
 }
 
 ZEND_API zend_ast *zend_ast_create_decl(
-	zend_ast_kind kind, uint32_t flags, uint32_t start_lineno, zend_string *doc_comment,
+	zend_ast_loc *loc, zend_ast_kind kind, uint32_t flags, zend_string *doc_comment,
 	zend_string *name, zend_ast *child0, zend_ast *child1, zend_ast *child2, zend_ast *child3
 ) {
 	zend_ast_decl *ast;
@@ -121,7 +121,7 @@ ZEND_API zend_ast *zend_ast_create_decl(
 	ast = zend_ast_alloc(sizeof(zend_ast_decl));
 	ast->kind = kind;
 	ast->attr = 0;
-	ast->start_lineno = start_lineno;
+	ast->start_lineno = loc->start_line;
 	ast->end_lineno = CG(zend_lineno);
 	ast->flags = flags;
 	ast->lex_pos = LANG_SCNG(yy_text);

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -45,13 +45,13 @@ static inline size_t zend_ast_list_size(uint32_t children) {
 	return sizeof(zend_ast_list) - sizeof(zend_ast *) + sizeof(zend_ast *) * children;
 }
 
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_znode(znode *node) {
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_znode(zend_ast_loc *loc, znode *node) {
 	zend_ast_znode *ast;
 
 	ast = zend_ast_alloc(sizeof(zend_ast_znode));
 	ast->kind = ZEND_AST_ZNODE;
 	ast->attr = 0;
-	ast->lineno = CG(zend_lineno);
+	ast->lineno = loc->start_line;
 	ast->node = *node;
 	return (zend_ast *) ast;
 }

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -196,72 +196,76 @@ typedef struct _zend_ast_decl {
 typedef void (*zend_ast_process_t)(zend_ast *ast);
 extern ZEND_API zend_ast_process_t zend_ast_process;
 
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_with_lineno(zval *zv, uint32_t lineno);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_ex(zval *zv, zend_ast_attr attr);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval(zval *zv);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_from_str(zend_string *str);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_from_long(zend_long lval);
+typedef struct _zend_ast_loc {
+	uint32_t start_line;
+} zend_ast_loc;
 
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_constant(zend_string *name, zend_ast_attr attr);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_class_const_or_name(zend_ast *class_name, zend_ast *name);
+
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_ex(zend_ast_loc *loc, zval *zv, zend_ast_attr attr);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval(zend_ast_loc *loc, zval *zv);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_from_str(zend_ast_loc *loc, zend_string *str);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_from_long(zend_ast_loc *loc, zend_long lval);
+
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_constant(zend_ast_loc *loc, zend_string *name, zend_ast_attr attr);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_class_const_or_name(zend_ast_loc *loc, zend_ast *class_name, zend_ast *name);
 
 #if ZEND_AST_SPEC
 # define ZEND_AST_SPEC_CALL(name, ...) \
 	ZEND_EXPAND_VA(ZEND_AST_SPEC_CALL_(name, __VA_ARGS__, _4, _3, _2, _1, _0)(__VA_ARGS__))
-# define ZEND_AST_SPEC_CALL_(name, _, _4, _3, _2, _1, suffix, ...) \
+# define ZEND_AST_SPEC_CALL_(name, _loc, _kind, _4, _3, _2, _1, suffix, ...) \
 	name ## suffix
 # define ZEND_AST_SPEC_CALL_EX(name, ...) \
 	ZEND_EXPAND_VA(ZEND_AST_SPEC_CALL_EX_(name, __VA_ARGS__, _4, _3, _2, _1, _0)(__VA_ARGS__))
-# define ZEND_AST_SPEC_CALL_EX_(name, _, _5, _4, _3, _2, _1, suffix, ...) \
+# define ZEND_AST_SPEC_CALL_EX_(name, _loc, _kind, _attr, _4, _3, _2, _1, suffix, ...) \
 	name ## suffix
 
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_0(zend_ast_kind kind);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_1(zend_ast_kind kind, zend_ast *child);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_2(zend_ast_kind kind, zend_ast *child1, zend_ast *child2);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_3(zend_ast_kind kind, zend_ast *child1, zend_ast *child2, zend_ast *child3);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_4(zend_ast_kind kind, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_0(zend_ast_loc *loc, zend_ast_kind kind);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_1(zend_ast_loc *loc, zend_ast_kind kind, zend_ast *child);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_2(zend_ast_loc *loc, zend_ast_kind kind, zend_ast *child1, zend_ast *child2);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_3(zend_ast_loc *loc, zend_ast_kind kind, zend_ast *child1, zend_ast *child2, zend_ast *child3);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_4(zend_ast_loc *loc, zend_ast_kind kind, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4);
 
-static zend_always_inline zend_ast * zend_ast_create_ex_0(zend_ast_kind kind, zend_ast_attr attr) {
-	zend_ast *ast = zend_ast_create_0(kind);
+static zend_always_inline zend_ast * zend_ast_create_ex_0(zend_ast_loc *loc, zend_ast_kind kind, zend_ast_attr attr) {
+	zend_ast *ast = zend_ast_create_0(loc, kind);
 	ast->attr = attr;
 	return ast;
 }
-static zend_always_inline zend_ast * zend_ast_create_ex_1(zend_ast_kind kind, zend_ast_attr attr, zend_ast *child) {
-	zend_ast *ast = zend_ast_create_1(kind, child);
+static zend_always_inline zend_ast * zend_ast_create_ex_1(zend_ast_loc *loc, zend_ast_kind kind, zend_ast_attr attr, zend_ast *child) {
+	zend_ast *ast = zend_ast_create_1(loc, kind, child);
 	ast->attr = attr;
 	return ast;
 }
-static zend_always_inline zend_ast * zend_ast_create_ex_2(zend_ast_kind kind, zend_ast_attr attr, zend_ast *child1, zend_ast *child2) {
-	zend_ast *ast = zend_ast_create_2(kind, child1, child2);
+static zend_always_inline zend_ast * zend_ast_create_ex_2(zend_ast_loc *loc, zend_ast_kind kind, zend_ast_attr attr, zend_ast *child1, zend_ast *child2) {
+	zend_ast *ast = zend_ast_create_2(loc, kind, child1, child2);
 	ast->attr = attr;
 	return ast;
 }
-static zend_always_inline zend_ast * zend_ast_create_ex_3(zend_ast_kind kind, zend_ast_attr attr, zend_ast *child1, zend_ast *child2, zend_ast *child3) {
-	zend_ast *ast = zend_ast_create_3(kind, child1, child2, child3);
+static zend_always_inline zend_ast * zend_ast_create_ex_3(zend_ast_loc *loc, zend_ast_kind kind, zend_ast_attr attr, zend_ast *child1, zend_ast *child2, zend_ast *child3) {
+	zend_ast *ast = zend_ast_create_3(loc, kind, child1, child2, child3);
 	ast->attr = attr;
 	return ast;
 }
-static zend_always_inline zend_ast * zend_ast_create_ex_4(zend_ast_kind kind, zend_ast_attr attr, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4) {
-	zend_ast *ast = zend_ast_create_4(kind, child1, child2, child3, child4);
+static zend_always_inline zend_ast * zend_ast_create_ex_4(zend_ast_loc *loc, zend_ast_kind kind, zend_ast_attr attr, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4) {
+	zend_ast *ast = zend_ast_create_4(loc, kind, child1, child2, child3, child4);
 	ast->attr = attr;
 	return ast;
 }
 
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_list_0(zend_ast_kind kind);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_list_1(zend_ast_kind kind, zend_ast *child);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_list_2(zend_ast_kind kind, zend_ast *child1, zend_ast *child2);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_list_0(zend_ast_loc *loc, zend_ast_kind kind);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_list_1(zend_ast_loc *loc, zend_ast_kind kind, zend_ast *child);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_list_2(zend_ast_loc *loc, zend_ast_kind kind, zend_ast *child1, zend_ast *child2);
 
 # define zend_ast_create(...) \
 	ZEND_AST_SPEC_CALL(zend_ast_create, __VA_ARGS__)
 # define zend_ast_create_ex(...) \
 	ZEND_AST_SPEC_CALL_EX(zend_ast_create_ex, __VA_ARGS__)
-# define zend_ast_create_list(init_children, ...) \
-	ZEND_AST_SPEC_CALL(zend_ast_create_list, __VA_ARGS__)
+# define zend_ast_create_list(loc, init_children, ...) \
+	ZEND_AST_SPEC_CALL(zend_ast_create_list, loc, __VA_ARGS__)
 
 #else
-ZEND_API zend_ast *zend_ast_create(zend_ast_kind kind, ...);
-ZEND_API zend_ast *zend_ast_create_ex(zend_ast_kind kind, zend_ast_attr attr, ...);
-ZEND_API zend_ast *zend_ast_create_list(uint32_t init_children, zend_ast_kind kind, ...);
+ZEND_API zend_ast *zend_ast_create(zend_ast_loc *loc, zend_ast_kind kind, ...);
+ZEND_API zend_ast *zend_ast_create_ex(zend_ast_loc *loc, zend_ast_kind kind, zend_ast_attr attr, ...);
+ZEND_API zend_ast *zend_ast_create_list(zend_ast_loc *loc, uint32_t init_children, zend_ast_kind kind, ...);
 #endif
 
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_list_add(zend_ast *list, zend_ast *op);
@@ -318,14 +322,14 @@ static zend_always_inline uint32_t zend_ast_get_lineno(zend_ast *ast) {
 	}
 }
 
-static zend_always_inline zend_ast *zend_ast_create_binary_op(uint32_t opcode, zend_ast *op0, zend_ast *op1) {
-	return zend_ast_create_ex(ZEND_AST_BINARY_OP, opcode, op0, op1);
+static zend_always_inline zend_ast *zend_ast_create_binary_op(zend_ast_loc *loc, uint32_t opcode, zend_ast *op0, zend_ast *op1) {
+	return zend_ast_create_ex(loc, ZEND_AST_BINARY_OP, opcode, op0, op1);
 }
-static zend_always_inline zend_ast *zend_ast_create_assign_op(uint32_t opcode, zend_ast *op0, zend_ast *op1) {
-	return zend_ast_create_ex(ZEND_AST_ASSIGN_OP, opcode, op0, op1);
+static zend_always_inline zend_ast *zend_ast_create_assign_op(zend_ast_loc *loc, uint32_t opcode, zend_ast *op0, zend_ast *op1) {
+	return zend_ast_create_ex(loc, ZEND_AST_ASSIGN_OP, opcode, op0, op1);
 }
-static zend_always_inline zend_ast *zend_ast_create_cast(uint32_t type, zend_ast *op0) {
-	return zend_ast_create_ex(ZEND_AST_CAST, type, op0);
+static zend_always_inline zend_ast *zend_ast_create_cast(zend_ast_loc *loc, uint32_t type, zend_ast *op0) {
+	return zend_ast_create_ex(loc, ZEND_AST_CAST, type, op0);
 }
 static zend_always_inline zend_ast *zend_ast_list_rtrim(zend_ast *ast) {
 	zend_ast_list *list = zend_ast_get_list(ast);

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -200,7 +200,6 @@ typedef struct _zend_ast_loc {
 	uint32_t start_line;
 } zend_ast_loc;
 
-
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_ex(zend_ast_loc *loc, zval *zv, zend_ast_attr attr);
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval(zend_ast_loc *loc, zval *zv);
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_from_str(zend_ast_loc *loc, zend_string *str);
@@ -320,6 +319,12 @@ static zend_always_inline uint32_t zend_ast_get_lineno(zend_ast *ast) {
 	} else {
 		return ast->lineno;
 	}
+}
+
+static inline zend_ast_loc zend_ast_get_loc(zend_ast *ast) {
+	zend_ast_loc loc;
+	loc.start_line = zend_ast_get_lineno(ast);
+	return loc;
 }
 
 static zend_always_inline zend_ast *zend_ast_create_binary_op(zend_ast_loc *loc, uint32_t opcode, zend_ast *op0, zend_ast *op1) {

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -208,6 +208,9 @@ ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_from_long(zend_ast_loc *l
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_constant(zend_ast_loc *loc, zend_string *name, zend_ast_attr attr);
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_class_const_or_name(zend_ast_loc *loc, zend_ast *class_name, zend_ast *name);
 
+struct _znode;
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_znode(zend_ast_loc *loc, struct _znode *node);
+
 #if ZEND_AST_SPEC
 # define ZEND_AST_SPEC_CALL(name, ...) \
 	ZEND_EXPAND_VA(ZEND_AST_SPEC_CALL_(name, __VA_ARGS__, _4, _3, _2, _1, _0)(__VA_ARGS__))

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -270,7 +270,7 @@ ZEND_API zend_ast *zend_ast_create_list(zend_ast_loc *loc, uint32_t init_childre
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_list_add(zend_ast *list, zend_ast *op);
 
 ZEND_API zend_ast *zend_ast_create_decl(
-	zend_ast_kind kind, uint32_t flags, uint32_t start_lineno, zend_string *doc_comment,
+	zend_ast_loc *loc, zend_ast_kind kind, uint32_t flags, zend_string *doc_comment,
 	zend_string *name, zend_ast *child0, zend_ast *child1, zend_ast *child2, zend_ast *child3
 );
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1529,12 +1529,6 @@ ZEND_API void zend_activate_auto_globals(void) /* {{{ */
 int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem, zend_ast_loc *loc) /* {{{ */
 {
 	zval zv;
-
-	if (CG(increment_lineno)) {
-		CG(zend_lineno)++;
-		CG(increment_lineno) = 0;
-	}
-
 	return lex_scan(&zv, elem, loc);
 }
 /* }}} */

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1526,7 +1526,7 @@ ZEND_API void zend_activate_auto_globals(void) /* {{{ */
 }
 /* }}} */
 
-int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem, zend_parser_loc *loc) /* {{{ */
+int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem, zend_ast_loc *loc) /* {{{ */
 {
 	zval zv;
 	int retval;
@@ -2338,7 +2338,9 @@ void zend_compile_assign(znode *result, zend_ast *ast);
 static inline void zend_emit_assign_znode(zend_ast *var_ast, znode *value_node) /* {{{ */
 {
 	znode dummy_node;
-	zend_ast *assign_ast = zend_ast_create(ZEND_AST_ASSIGN, var_ast,
+	zend_ast_loc loc;
+	loc.start_line = zend_ast_get_lineno(var_ast);
+	zend_ast *assign_ast = zend_ast_create(&loc, ZEND_AST_ASSIGN, var_ast,
 		zend_ast_create_znode(value_node));
 	zend_compile_assign(&dummy_node, assign_ast);
 	zend_do_free(&dummy_node);
@@ -2846,7 +2848,9 @@ void zend_compile_assign_ref(znode *result, zend_ast *ast) /* {{{ */
 
 static inline void zend_emit_assign_ref_znode(zend_ast *var_ast, znode *value_node) /* {{{ */
 {
-	zend_ast *assign_ast = zend_ast_create(ZEND_AST_ASSIGN_REF, var_ast,
+	zend_ast_loc loc;
+	loc.start_line = zend_ast_get_lineno(var_ast);
+	zend_ast *assign_ast = zend_ast_create(&loc, ZEND_AST_ASSIGN_REF, var_ast,
 		zend_ast_create_znode(value_node));
 	zend_compile_assign_ref(NULL, assign_ast);
 }
@@ -3449,9 +3453,11 @@ static void zend_compile_assert(znode *result, zend_ast_list *args, zend_string 
 		    (args->child[0]->kind != ZEND_AST_ZVAL ||
 		     Z_TYPE_P(zend_ast_get_zval(args->child[0])) != IS_STRING)) {
 			/* add "assert(condition) as assertion message */
+			zend_ast_loc loc;
+			loc.start_line = zend_ast_get_lineno(args->child[0]);
 			zend_ast_list_add((zend_ast*)args,
 				zend_ast_create_zval_from_str(
-					zend_ast_export("assert(", args->child[0], ")")));
+					&loc, zend_ast_export("assert(", args->child[0], ")")));
 		}
 
 		zend_compile_call_common(result, (zend_ast*)args, fbc);
@@ -4044,8 +4050,10 @@ void zend_compile_global_var(zend_ast *ast) /* {{{ */
 			zend_string_addref(Z_STR(name_node.u.constant));
 		}
 
+		zend_ast_loc loc;
+		loc.start_line = zend_ast_get_lineno(var_ast);
 		zend_emit_assign_ref_znode(
-			zend_ast_create(ZEND_AST_VAR, zend_ast_create_znode(&name_node)),
+			zend_ast_create(&loc, ZEND_AST_VAR, zend_ast_create_znode(&name_node)),
 			&result
 		);
 	}
@@ -6545,7 +6553,10 @@ void zend_compile_group_use(zend_ast *ast) /* {{{ */
 		zend_string *compound_ns = zend_concat_names(ZSTR_VAL(ns), ZSTR_LEN(ns), ZSTR_VAL(name), ZSTR_LEN(name));
 		zend_string_release_ex(name, 0);
 		ZVAL_STR(name_zval, compound_ns);
-		inline_use = zend_ast_create_list(1, ZEND_AST_USE, use);
+
+		zend_ast_loc loc;
+		loc.start_line = zend_ast_get_lineno(ast);
+		inline_use = zend_ast_create_list(&loc, 1, ZEND_AST_USE, use);
 		inline_use->attr = ast->attr ? ast->attr : use->attr;
 		zend_compile_use(inline_use);
 	}
@@ -7547,7 +7558,9 @@ void zend_compile_isset_or_empty(znode *result, zend_ast *ast) /* {{{ */
 	if (!zend_is_variable(var_ast)) {
 		if (ast->kind == ZEND_AST_EMPTY) {
 			/* empty(expr) can be transformed to !expr */
-			zend_ast *not_ast = zend_ast_create_ex(ZEND_AST_UNARY_OP, ZEND_BOOL_NOT, var_ast);
+			zend_ast_loc loc;
+			loc.start_line = zend_ast_get_lineno(ast);
+			zend_ast *not_ast = zend_ast_create_ex(&loc, ZEND_AST_UNARY_OP, ZEND_BOOL_NOT, var_ast);
 			zend_compile_expr(result, not_ast);
 			return;
 		} else {
@@ -7617,9 +7630,11 @@ void zend_compile_shell_exec(znode *result, zend_ast *ast) /* {{{ */
 	zend_ast *name_ast, *args_ast, *call_ast;
 
 	ZVAL_STRING(&fn_name, "shell_exec");
-	name_ast = zend_ast_create_zval(&fn_name);
-	args_ast = zend_ast_create_list(1, ZEND_AST_ARG_LIST, expr_ast);
-	call_ast = zend_ast_create(ZEND_AST_CALL, name_ast, args_ast);
+	zend_ast_loc loc;
+	loc.start_line = zend_ast_get_lineno(ast);
+	name_ast = zend_ast_create_zval(&loc, &fn_name);
+	args_ast = zend_ast_create_list(&loc, 1, ZEND_AST_ARG_LIST, expr_ast);
+	call_ast = zend_ast_create(&loc, ZEND_AST_CALL, name_ast, args_ast);
 
 	zend_compile_expr(result, call_ast);
 
@@ -8023,7 +8038,9 @@ void zend_compile_const_expr_class_const(zend_ast **ast_ptr) /* {{{ */
 	zend_ast_destroy(ast);
 	zend_string_release_ex(class_name, 0);
 
-	*ast_ptr = zend_ast_create_constant(name, fetch_type | ZEND_FETCH_CLASS_EXCEPTION);
+	zend_ast_loc loc;
+	loc.start_line = zend_ast_get_lineno(ast);
+	*ast_ptr = zend_ast_create_constant(&loc, name, fetch_type | ZEND_FETCH_CLASS_EXCEPTION);
 }
 /* }}} */
 
@@ -8058,6 +8075,8 @@ void zend_compile_const_expr_const(zend_ast **ast_ptr) /* {{{ */
 	zend_bool is_fully_qualified;
 	zval result;
 	zend_string *resolved_name;
+	zend_ast_loc loc;
+	loc.start_line = zend_ast_get_lineno(ast);
 
 	resolved_name = zend_resolve_const_name(
 		orig_name, name_ast->attr, &is_fully_qualified);
@@ -8065,24 +8084,26 @@ void zend_compile_const_expr_const(zend_ast **ast_ptr) /* {{{ */
 	if (zend_try_ct_eval_const(&result, resolved_name, is_fully_qualified)) {
 		zend_string_release_ex(resolved_name, 0);
 		zend_ast_destroy(ast);
-		*ast_ptr = zend_ast_create_zval(&result);
+		*ast_ptr = zend_ast_create_zval(&loc, &result);
 		return;
 	}
 
 	zend_ast_destroy(ast);
-	*ast_ptr = zend_ast_create_constant(resolved_name, !is_fully_qualified ? IS_CONSTANT_UNQUALIFIED : 0);
+	*ast_ptr = zend_ast_create_constant(&loc, resolved_name, !is_fully_qualified ? IS_CONSTANT_UNQUALIFIED : 0);
 }
 /* }}} */
 
 void zend_compile_const_expr_magic_const(zend_ast **ast_ptr) /* {{{ */
 {
 	zend_ast *ast = *ast_ptr;
+	zend_ast_loc loc;
+	loc.start_line = zend_ast_get_lineno(ast);
 
 	/* Other cases already resolved by constant folding */
 	ZEND_ASSERT(ast->attr == T_CLASS_C);
 
 	zend_ast_destroy(ast);
-	*ast_ptr = zend_ast_create(ZEND_AST_CONSTANT_CLASS);
+	*ast_ptr = zend_ast_create(&loc, ZEND_AST_CONSTANT_CLASS);
 }
 /* }}} */
 
@@ -8729,7 +8750,10 @@ void zend_eval_const_expr(zend_ast **ast_ptr) /* {{{ */
 			return;
 	}
 
+	zend_ast_loc loc;
+	loc.start_line = zend_ast_get_lineno(ast);
+
 	zend_ast_destroy(ast);
-	*ast_ptr = zend_ast_create_zval(&result);
+	*ast_ptr = zend_ast_create_zval(&loc, &result);
 }
 /* }}} */

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1526,16 +1526,19 @@ ZEND_API void zend_activate_auto_globals(void) /* {{{ */
 }
 /* }}} */
 
-int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem) /* {{{ */
+int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem, zend_parser_loc *loc) /* {{{ */
 {
 	zval zv;
+	int retval;
 
 	if (CG(increment_lineno)) {
 		CG(zend_lineno)++;
 		CG(increment_lineno) = 0;
 	}
 
-	return lex_scan(&zv, elem);
+	retval = lex_scan(&zv, elem);
+	loc->start_line = CG(zend_lineno);
+	return retval;
 }
 /* }}} */
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2331,7 +2331,7 @@ static inline void zend_emit_assign_znode(zend_ast *var_ast, znode *value_node) 
 	znode dummy_node;
 	zend_ast_loc loc = zend_ast_get_loc(var_ast);
 	zend_ast *assign_ast = zend_ast_create(&loc, ZEND_AST_ASSIGN, var_ast,
-		zend_ast_create_znode(value_node));
+		zend_ast_create_znode(&loc, value_node));
 	zend_compile_assign(&dummy_node, assign_ast);
 	zend_do_free(&dummy_node);
 }
@@ -2840,7 +2840,7 @@ static inline void zend_emit_assign_ref_znode(zend_ast *var_ast, znode *value_no
 {
 	zend_ast_loc loc = zend_ast_get_loc(var_ast);
 	zend_ast *assign_ast = zend_ast_create(&loc, ZEND_AST_ASSIGN_REF, var_ast,
-		zend_ast_create_znode(value_node));
+		zend_ast_create_znode(&loc, value_node));
 	zend_compile_assign_ref(NULL, assign_ast);
 }
 /* }}} */
@@ -4040,7 +4040,7 @@ void zend_compile_global_var(zend_ast *ast) /* {{{ */
 
 		zend_ast_loc loc = zend_ast_get_loc(var_ast);
 		zend_emit_assign_ref_znode(
-			zend_ast_create(&loc, ZEND_AST_VAR, zend_ast_create_znode(&name_node)),
+			zend_ast_create(&loc, ZEND_AST_VAR, zend_ast_create_znode(&loc, &name_node)),
 			&result
 		);
 	}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1529,16 +1529,13 @@ ZEND_API void zend_activate_auto_globals(void) /* {{{ */
 int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem, zend_ast_loc *loc) /* {{{ */
 {
 	zval zv;
-	int retval;
 
 	if (CG(increment_lineno)) {
 		CG(zend_lineno)++;
 		CG(increment_lineno) = 0;
 	}
 
-	retval = lex_scan(&zv, elem);
-	loc->start_line = CG(zend_lineno);
-	return retval;
+	return lex_scan(&zv, elem, loc);
 }
 /* }}} */
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2338,8 +2338,7 @@ void zend_compile_assign(znode *result, zend_ast *ast);
 static inline void zend_emit_assign_znode(zend_ast *var_ast, znode *value_node) /* {{{ */
 {
 	znode dummy_node;
-	zend_ast_loc loc;
-	loc.start_line = zend_ast_get_lineno(var_ast);
+	zend_ast_loc loc = zend_ast_get_loc(var_ast);
 	zend_ast *assign_ast = zend_ast_create(&loc, ZEND_AST_ASSIGN, var_ast,
 		zend_ast_create_znode(value_node));
 	zend_compile_assign(&dummy_node, assign_ast);
@@ -2848,8 +2847,7 @@ void zend_compile_assign_ref(znode *result, zend_ast *ast) /* {{{ */
 
 static inline void zend_emit_assign_ref_znode(zend_ast *var_ast, znode *value_node) /* {{{ */
 {
-	zend_ast_loc loc;
-	loc.start_line = zend_ast_get_lineno(var_ast);
+	zend_ast_loc loc = zend_ast_get_loc(var_ast);
 	zend_ast *assign_ast = zend_ast_create(&loc, ZEND_AST_ASSIGN_REF, var_ast,
 		zend_ast_create_znode(value_node));
 	zend_compile_assign_ref(NULL, assign_ast);
@@ -3453,8 +3451,7 @@ static void zend_compile_assert(znode *result, zend_ast_list *args, zend_string 
 		    (args->child[0]->kind != ZEND_AST_ZVAL ||
 		     Z_TYPE_P(zend_ast_get_zval(args->child[0])) != IS_STRING)) {
 			/* add "assert(condition) as assertion message */
-			zend_ast_loc loc;
-			loc.start_line = zend_ast_get_lineno(args->child[0]);
+			zend_ast_loc loc = zend_ast_get_loc(args->child[0]);
 			zend_ast_list_add((zend_ast*)args,
 				zend_ast_create_zval_from_str(
 					&loc, zend_ast_export("assert(", args->child[0], ")")));
@@ -4050,8 +4047,7 @@ void zend_compile_global_var(zend_ast *ast) /* {{{ */
 			zend_string_addref(Z_STR(name_node.u.constant));
 		}
 
-		zend_ast_loc loc;
-		loc.start_line = zend_ast_get_lineno(var_ast);
+		zend_ast_loc loc = zend_ast_get_loc(var_ast);
 		zend_emit_assign_ref_znode(
 			zend_ast_create(&loc, ZEND_AST_VAR, zend_ast_create_znode(&name_node)),
 			&result
@@ -6554,8 +6550,7 @@ void zend_compile_group_use(zend_ast *ast) /* {{{ */
 		zend_string_release_ex(name, 0);
 		ZVAL_STR(name_zval, compound_ns);
 
-		zend_ast_loc loc;
-		loc.start_line = zend_ast_get_lineno(ast);
+		zend_ast_loc loc = zend_ast_get_loc(ast);
 		inline_use = zend_ast_create_list(&loc, 1, ZEND_AST_USE, use);
 		inline_use->attr = ast->attr ? ast->attr : use->attr;
 		zend_compile_use(inline_use);
@@ -7558,8 +7553,7 @@ void zend_compile_isset_or_empty(znode *result, zend_ast *ast) /* {{{ */
 	if (!zend_is_variable(var_ast)) {
 		if (ast->kind == ZEND_AST_EMPTY) {
 			/* empty(expr) can be transformed to !expr */
-			zend_ast_loc loc;
-			loc.start_line = zend_ast_get_lineno(ast);
+			zend_ast_loc loc = zend_ast_get_loc(ast);
 			zend_ast *not_ast = zend_ast_create_ex(&loc, ZEND_AST_UNARY_OP, ZEND_BOOL_NOT, var_ast);
 			zend_compile_expr(result, not_ast);
 			return;
@@ -7630,8 +7624,7 @@ void zend_compile_shell_exec(znode *result, zend_ast *ast) /* {{{ */
 	zend_ast *name_ast, *args_ast, *call_ast;
 
 	ZVAL_STRING(&fn_name, "shell_exec");
-	zend_ast_loc loc;
-	loc.start_line = zend_ast_get_lineno(ast);
+	zend_ast_loc loc = zend_ast_get_loc(ast);
 	name_ast = zend_ast_create_zval(&loc, &fn_name);
 	args_ast = zend_ast_create_list(&loc, 1, ZEND_AST_ARG_LIST, expr_ast);
 	call_ast = zend_ast_create(&loc, ZEND_AST_CALL, name_ast, args_ast);
@@ -8038,8 +8031,7 @@ void zend_compile_const_expr_class_const(zend_ast **ast_ptr) /* {{{ */
 	zend_ast_destroy(ast);
 	zend_string_release_ex(class_name, 0);
 
-	zend_ast_loc loc;
-	loc.start_line = zend_ast_get_lineno(ast);
+	zend_ast_loc loc = zend_ast_get_loc(ast);
 	*ast_ptr = zend_ast_create_constant(&loc, name, fetch_type | ZEND_FETCH_CLASS_EXCEPTION);
 }
 /* }}} */
@@ -8075,8 +8067,7 @@ void zend_compile_const_expr_const(zend_ast **ast_ptr) /* {{{ */
 	zend_bool is_fully_qualified;
 	zval result;
 	zend_string *resolved_name;
-	zend_ast_loc loc;
-	loc.start_line = zend_ast_get_lineno(ast);
+	zend_ast_loc loc = zend_ast_get_loc(ast);
 
 	resolved_name = zend_resolve_const_name(
 		orig_name, name_ast->attr, &is_fully_qualified);
@@ -8096,8 +8087,7 @@ void zend_compile_const_expr_const(zend_ast **ast_ptr) /* {{{ */
 void zend_compile_const_expr_magic_const(zend_ast **ast_ptr) /* {{{ */
 {
 	zend_ast *ast = *ast_ptr;
-	zend_ast_loc loc;
-	loc.start_line = zend_ast_get_lineno(ast);
+	zend_ast_loc loc = zend_ast_get_loc(ast);
 
 	/* Other cases already resolved by constant folding */
 	ZEND_ASSERT(ast->attr == T_CLASS_C);
@@ -8750,9 +8740,7 @@ void zend_eval_const_expr(zend_ast **ast_ptr) /* {{{ */
 			return;
 	}
 
-	zend_ast_loc loc;
-	loc.start_line = zend_ast_get_lineno(ast);
-
+	zend_ast_loc loc = zend_ast_get_loc(ast);
 	zend_ast_destroy(ast);
 	*ast_ptr = zend_ast_create_zval(&loc, &result);
 }

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -732,7 +732,7 @@ void zend_file_context_end(zend_file_context *prev_context);
 extern ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
 extern ZEND_API zend_op_array *(*zend_compile_string)(zval *source_string, char *filename);
 
-ZEND_API int ZEND_FASTCALL lex_scan(zval *zendlval, zend_parser_stack_elem *elem);
+ZEND_API int ZEND_FASTCALL lex_scan(zval *zendlval, zend_parser_stack_elem *elem, zend_ast_loc *loc);
 void startup_scanner(void);
 void shutdown_scanner(void);
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -125,10 +125,6 @@ typedef union _zend_parser_stack_elem {
 	zend_ulong num;
 } zend_parser_stack_elem;
 
-typedef struct _zend_parser_loc {
-	uint32_t start_line;
-} zend_parser_loc;
-
 void zend_compile_top_stmt(zend_ast *ast);
 void zend_compile_stmt(zend_ast *ast);
 void zend_compile_expr(znode *node, zend_ast *ast);
@@ -849,7 +845,7 @@ ZEND_API zend_bool zend_is_auto_global_str(char *name, size_t len);
 ZEND_API size_t zend_dirname(char *path, size_t len);
 ZEND_API void zend_set_function_arg_flags(zend_function *func);
 
-int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem, zend_parser_loc *loc);
+int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem, zend_ast_loc *loc);
 
 void zend_assert_valid_class_name(const zend_string *const_name);
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -125,6 +125,10 @@ typedef union _zend_parser_stack_elem {
 	zend_ulong num;
 } zend_parser_stack_elem;
 
+typedef struct _zend_parser_loc {
+	uint32_t start_line;
+} zend_parser_loc;
+
 void zend_compile_top_stmt(zend_ast *ast);
 void zend_compile_stmt(zend_ast *ast);
 void zend_compile_expr(znode *node, zend_ast *ast);
@@ -845,7 +849,7 @@ ZEND_API zend_bool zend_is_auto_global_str(char *name, size_t len);
 ZEND_API size_t zend_dirname(char *path, size_t len);
 ZEND_API void zend_set_function_arg_flags(zend_function *func);
 
-int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem);
+int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem, zend_parser_loc *loc);
 
 void zend_assert_valid_class_name(const zend_string *const_name);
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -94,8 +94,6 @@ typedef struct _zend_ast_znode {
 	znode node;
 } zend_ast_znode;
 
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_znode(znode *node);
-
 static zend_always_inline znode *zend_ast_get_znode(zend_ast *ast) {
 	return &((zend_ast_znode *) ast)->node;
 }

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -94,7 +94,6 @@ struct _zend_compiler_globals {
 	struct _zend_ini_parser_param *ini_parser_param;
 
 	uint32_t start_lineno;
-	zend_bool increment_lineno;
 
 	zend_string *doc_comment;
 	uint32_t extra_fn_flags;

--- a/Zend/zend_highlight.c
+++ b/Zend/zend_highlight.c
@@ -85,13 +85,14 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 {
 	zval token;
 	int token_type;
+	zend_ast_loc loc;
 	char *last_color = syntax_highlighter_ini->highlight_html;
 	char *next_color;
 
 	zend_printf("<code>");
 	zend_printf("<span style=\"color: %s\">\n", last_color);
 	/* highlight stuff coming back from zendlex() */
-	while ((token_type=lex_scan(&token, NULL))) {
+	while ((token_type = lex_scan(&token, NULL, &loc))) {
 		switch (token_type) {
 			case T_INLINE_HTML:
 				next_color = syntax_highlighter_ini->highlight_html;
@@ -174,10 +175,11 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 ZEND_API void zend_strip(void)
 {
 	zval token;
+	zend_ast_loc loc;
 	int token_type;
 	int prev_space = 0;
 
-	while ((token_type=lex_scan(&token, NULL))) {
+	while ((token_type = lex_scan(&token, NULL, &loc))) {
 		switch (token_type) {
 			case T_WHITESPACE:
 				if (!prev_space) {
@@ -193,7 +195,7 @@ ZEND_API void zend_strip(void)
 			case T_END_HEREDOC:
 				zend_write((char*)LANG_SCNG(yy_text), LANG_SCNG(yy_leng));
 				/* read the following character, either newline or ; */
-				if (lex_scan(&token, NULL) != T_WHITESPACE) {
+				if (lex_scan(&token, NULL, &loc) != T_WHITESPACE) {
 					zend_write((char*)LANG_SCNG(yy_text), LANG_SCNG(yy_leng));
 				}
 				zend_write("\n", sizeof("\n") - 1);

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -496,7 +496,7 @@ unset_variable:
 function_declaration_statement:
 	T_FUNCTION returns_ref T_STRING backup_doc_comment '(' parameter_list ')' return_type
 	backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
-		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2 | $13, @1.start_line, $4,
+		{ $$ = zend_ast_create_decl(&@$, ZEND_AST_FUNC_DECL, $2 | $13, $4,
 		      zend_ast_get_str($3), $6, NULL, $11, $8); CG(extra_fn_flags) = $9; }
 ;
 
@@ -512,9 +512,9 @@ is_variadic:
 
 class_declaration_statement:
 		class_modifiers T_CLASS T_STRING extends_from implements_list backup_doc_comment '{' class_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, $1, @1.start_line, $6, zend_ast_get_str($3), $4, $5, $8, NULL); }
+			{ $$ = zend_ast_create_decl(&@$, ZEND_AST_CLASS, $1, $6, zend_ast_get_str($3), $4, $5, $8, NULL); }
 	|	T_CLASS T_STRING extends_from implements_list backup_doc_comment '{' class_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, 0, @1.start_line, $5, zend_ast_get_str($2), $3, $4, $7, NULL); }
+			{ $$ = zend_ast_create_decl(&@$, ZEND_AST_CLASS, 0, $5, zend_ast_get_str($2), $3, $4, $7, NULL); }
 ;
 
 class_modifiers:
@@ -530,12 +530,12 @@ class_modifier:
 
 trait_declaration_statement:
 		T_TRAIT T_STRING backup_doc_comment '{' class_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_TRAIT, @1.start_line, $3, zend_ast_get_str($2), NULL, NULL, $5, NULL); }
+			{ $$ = zend_ast_create_decl(&@$, ZEND_AST_CLASS, ZEND_ACC_TRAIT, $3, zend_ast_get_str($2), NULL, NULL, $5, NULL); }
 ;
 
 interface_declaration_statement:
 		T_INTERFACE T_STRING interface_extends_list backup_doc_comment '{' class_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_INTERFACE, @1.start_line, $4, zend_ast_get_str($2), NULL, $3, $6, NULL); }
+			{ $$ = zend_ast_create_decl(&@$, ZEND_AST_CLASS, ZEND_ACC_INTERFACE, $4, zend_ast_get_str($2), NULL, $3, $6, NULL); }
 ;
 
 extends_from:
@@ -749,7 +749,7 @@ class_statement:
 			{ $$ = zend_ast_create(&@$, ZEND_AST_USE_TRAIT, $2, $3); }
 	|	method_modifiers T_FUNCTION returns_ref identifier backup_doc_comment '(' parameter_list ')'
 		return_type backup_fn_flags method_body backup_fn_flags
-			{ $$ = zend_ast_create_decl(ZEND_AST_METHOD, $3 | $1 | $12, @2.start_line, $5,
+			{ $$ = zend_ast_create_decl(&@$, ZEND_AST_METHOD, $3 | $1 | $12, $5,
 				  zend_ast_get_str($4), $7, NULL, $11, $9); CG(extra_fn_flags) = $10; }
 ;
 
@@ -880,7 +880,7 @@ non_empty_for_exprs:
 anonymous_class:
         T_CLASS ctor_arguments extends_from implements_list backup_doc_comment '{' class_statement_list '}' {
 			zend_ast *decl = zend_ast_create_decl(
-				ZEND_AST_CLASS, ZEND_ACC_ANON_CLASS, @1.start_line, $5, NULL,
+				&@$, ZEND_AST_CLASS, ZEND_ACC_ANON_CLASS, $5, NULL,
 				$3, $4, $7, NULL);
 			$$ = zend_ast_create(&@$, ZEND_AST_NEW, decl, $2);
 		}
@@ -1008,12 +1008,12 @@ expr:
 	|	T_YIELD_FROM expr { $$ = zend_ast_create(&@$, ZEND_AST_YIELD_FROM, $2); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
 	|	T_FUNCTION returns_ref backup_doc_comment '(' parameter_list ')' lexical_vars return_type
 		backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $2 | $13, @1.start_line, $3,
+			{ $$ = zend_ast_create_decl(&@$, ZEND_AST_CLOSURE, $2 | $13, $3,
 				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0),
 			      $5, $7, $11, $8); CG(extra_fn_flags) = $9; }
 	|	T_STATIC T_FUNCTION returns_ref backup_doc_comment '(' parameter_list ')' lexical_vars
 		return_type backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $3 | $14 | ZEND_ACC_STATIC, @2.start_line, $4,
+			{ $$ = zend_ast_create_decl(&@$, ZEND_AST_CLOSURE, $3 | $14 | ZEND_ACC_STATIC, $4,
 			      zend_string_init("{closure}", sizeof("{closure}") - 1, 0),
 			      $6, $8, $12, $9); CG(extra_fn_flags) = $10; }
 ;

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -35,7 +35,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 #define YYERROR_VERBOSE
 #define YYSTYPE zend_parser_stack_elem
 
-#define YYLTYPE zend_parser_loc
+#define YYLTYPE zend_ast_loc
 #define YYLLOC_DEFAULT(Res, RHS, N) do { \
 	if (N) { \
 		(Res).start_line = YYRHSLOC(RHS, 1).start_line; \
@@ -293,13 +293,13 @@ identifier:
 	| 	semi_reserved  {
 			zval zv;
 			zend_lex_tstring(&zv);
-			$$ = zend_ast_create_zval(&zv);
+			$$ = zend_ast_create_zval(&@$, &zv);
 		}
 ;
 
 top_statement_list:
 		top_statement_list top_statement { $$ = zend_ast_list_add($1, $2); }
-	|	/* empty */ { $$ = zend_ast_create_list(0, ZEND_AST_STMT_LIST); }
+	|	/* empty */ { $$ = zend_ast_create_list(&@$, 0, ZEND_AST_STMT_LIST); }
 ;
 
 namespace_name:
@@ -320,18 +320,18 @@ top_statement:
 	|	trait_declaration_statement			{ $$ = $1; }
 	|	interface_declaration_statement		{ $$ = $1; }
 	|	T_HALT_COMPILER '(' ')' ';'
-			{ $$ = zend_ast_create(ZEND_AST_HALT_COMPILER,
-			      zend_ast_create_zval_from_long(zend_get_scanned_file_offset()));
+			{ $$ = zend_ast_create(&@$, ZEND_AST_HALT_COMPILER,
+			      zend_ast_create_zval_from_long(&@$, zend_get_scanned_file_offset()));
 			  zend_stop_lexing(); }
 	|	T_NAMESPACE namespace_name ';'
-			{ $$ = zend_ast_create(ZEND_AST_NAMESPACE, $2, NULL);
+			{ $$ = zend_ast_create(&@$, ZEND_AST_NAMESPACE, $2, NULL);
 			  RESET_DOC_COMMENT(); }
 	|	T_NAMESPACE namespace_name { RESET_DOC_COMMENT(); }
 		'{' top_statement_list '}'
-			{ $$ = zend_ast_create(ZEND_AST_NAMESPACE, $2, $5); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_NAMESPACE, $2, $5); }
 	|	T_NAMESPACE { RESET_DOC_COMMENT(); }
 		'{' top_statement_list '}'
-			{ $$ = zend_ast_create(ZEND_AST_NAMESPACE, NULL, $4); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_NAMESPACE, NULL, $4); }
 	|	T_USE mixed_group_use_declaration ';'		{ $$ = $2; }
 	|	T_USE use_type group_use_declaration ';'	{ $$ = $3; $$->attr = $2; }
 	|	T_USE use_declarations ';'					{ $$ = $2; $$->attr = ZEND_SYMBOL_CLASS; }
@@ -346,16 +346,16 @@ use_type:
 
 group_use_declaration:
 		namespace_name T_NS_SEPARATOR '{' unprefixed_use_declarations possible_comma '}'
-			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $1, $4); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_GROUP_USE, $1, $4); }
 	|	T_NS_SEPARATOR namespace_name T_NS_SEPARATOR '{' unprefixed_use_declarations possible_comma '}'
-			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $2, $5); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_GROUP_USE, $2, $5); }
 ;
 
 mixed_group_use_declaration:
 		namespace_name T_NS_SEPARATOR '{' inline_use_declarations possible_comma '}'
-			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $1, $4);}
+			{ $$ = zend_ast_create(&@$, ZEND_AST_GROUP_USE, $1, $4);}
 	|	T_NS_SEPARATOR namespace_name T_NS_SEPARATOR '{' inline_use_declarations possible_comma '}'
-			{ $$ = zend_ast_create(ZEND_AST_GROUP_USE, $2, $5); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_GROUP_USE, $2, $5); }
 ;
 
 possible_comma:
@@ -367,21 +367,21 @@ inline_use_declarations:
 		inline_use_declarations ',' inline_use_declaration
 			{ $$ = zend_ast_list_add($1, $3); }
 	|	inline_use_declaration
-			{ $$ = zend_ast_create_list(1, ZEND_AST_USE, $1); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_USE, $1); }
 ;
 
 unprefixed_use_declarations:
 		unprefixed_use_declarations ',' unprefixed_use_declaration
 			{ $$ = zend_ast_list_add($1, $3); }
 	|	unprefixed_use_declaration
-			{ $$ = zend_ast_create_list(1, ZEND_AST_USE, $1); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_USE, $1); }
 ;
 
 use_declarations:
 		use_declarations ',' use_declaration
 			{ $$ = zend_ast_list_add($1, $3); }
 	|	use_declaration
-			{ $$ = zend_ast_create_list(1, ZEND_AST_USE, $1); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_USE, $1); }
 ;
 
 inline_use_declaration:
@@ -391,9 +391,9 @@ inline_use_declaration:
 
 unprefixed_use_declaration:
 		namespace_name
-			{ $$ = zend_ast_create(ZEND_AST_USE_ELEM, $1, NULL); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_USE_ELEM, $1, NULL); }
 	|	namespace_name T_AS T_STRING
-			{ $$ = zend_ast_create(ZEND_AST_USE_ELEM, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_USE_ELEM, $1, $3); }
 ;
 
 use_declaration:
@@ -403,14 +403,14 @@ use_declaration:
 
 const_list:
 		const_list ',' const_decl { $$ = zend_ast_list_add($1, $3); }
-	|	const_decl { $$ = zend_ast_create_list(1, ZEND_AST_CONST_DECL, $1); }
+	|	const_decl { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_CONST_DECL, $1); }
 ;
 
 inner_statement_list:
 		inner_statement_list inner_statement
 			{ $$ = zend_ast_list_add($1, $2); }
 	|	/* empty */
-			{ $$ = zend_ast_create_list(0, ZEND_AST_STMT_LIST); }
+			{ $$ = zend_ast_create_list(&@$, 0, ZEND_AST_STMT_LIST); }
 ;
 
 
@@ -431,48 +431,48 @@ statement:
 	|	if_stmt { $$ = $1; }
 	|	alt_if_stmt { $$ = $1; }
 	|	T_WHILE '(' expr ')' while_statement
-			{ $$ = zend_ast_create(ZEND_AST_WHILE, $3, $5); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_WHILE, $3, $5); }
 	|	T_DO statement T_WHILE '(' expr ')' ';'
-			{ $$ = zend_ast_create(ZEND_AST_DO_WHILE, $2, $5); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_DO_WHILE, $2, $5); }
 	|	T_FOR '(' for_exprs ';' for_exprs ';' for_exprs ')' for_statement
-			{ $$ = zend_ast_create(ZEND_AST_FOR, $3, $5, $7, $9); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_FOR, $3, $5, $7, $9); }
 	|	T_SWITCH '(' expr ')' switch_case_list
-			{ $$ = zend_ast_create(ZEND_AST_SWITCH, $3, $5); }
-	|	T_BREAK optional_expr ';'		{ $$ = zend_ast_create(ZEND_AST_BREAK, $2); }
-	|	T_CONTINUE optional_expr ';'	{ $$ = zend_ast_create(ZEND_AST_CONTINUE, $2); }
-	|	T_RETURN optional_expr ';'		{ $$ = zend_ast_create(ZEND_AST_RETURN, $2); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_SWITCH, $3, $5); }
+	|	T_BREAK optional_expr ';'		{ $$ = zend_ast_create(&@$, ZEND_AST_BREAK, $2); }
+	|	T_CONTINUE optional_expr ';'	{ $$ = zend_ast_create(&@$, ZEND_AST_CONTINUE, $2); }
+	|	T_RETURN optional_expr ';'		{ $$ = zend_ast_create(&@$, ZEND_AST_RETURN, $2); }
 	|	T_GLOBAL global_var_list ';'	{ $$ = $2; }
 	|	T_STATIC static_var_list ';'	{ $$ = $2; }
 	|	T_ECHO echo_expr_list ';'		{ $$ = $2; }
-	|	T_INLINE_HTML { $$ = zend_ast_create(ZEND_AST_ECHO, $1); }
+	|	T_INLINE_HTML { $$ = zend_ast_create(&@$, ZEND_AST_ECHO, $1); }
 	|	expr ';' { $$ = $1; }
 	|	T_UNSET '(' unset_variables possible_comma ')' ';' { $$ = $3; }
 	|	T_FOREACH '(' expr T_AS foreach_variable ')' foreach_statement
-			{ $$ = zend_ast_create(ZEND_AST_FOREACH, $3, $5, NULL, $7); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_FOREACH, $3, $5, NULL, $7); }
 	|	T_FOREACH '(' expr T_AS foreach_variable T_DOUBLE_ARROW foreach_variable ')'
 		foreach_statement
-			{ $$ = zend_ast_create(ZEND_AST_FOREACH, $3, $7, $5, $9); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_FOREACH, $3, $7, $5, $9); }
 	|	T_DECLARE '(' const_list ')'
 			{ if (!zend_handle_encoding_declaration($3)) { YYERROR; } }
 		declare_statement
-			{ $$ = zend_ast_create(ZEND_AST_DECLARE, $3, $6); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_DECLARE, $3, $6); }
 	|	';'	/* empty statement */ { $$ = NULL; }
 	|	T_TRY '{' inner_statement_list '}' catch_list finally_statement
-			{ $$ = zend_ast_create(ZEND_AST_TRY, $3, $5, $6); }
-	|	T_THROW expr ';' { $$ = zend_ast_create(ZEND_AST_THROW, $2); }
-	|	T_GOTO T_STRING ';' { $$ = zend_ast_create(ZEND_AST_GOTO, $2); }
-	|	T_STRING ':' { $$ = zend_ast_create(ZEND_AST_LABEL, $1); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_TRY, $3, $5, $6); }
+	|	T_THROW expr ';' { $$ = zend_ast_create(&@$, ZEND_AST_THROW, $2); }
+	|	T_GOTO T_STRING ';' { $$ = zend_ast_create(&@$, ZEND_AST_GOTO, $2); }
+	|	T_STRING ':' { $$ = zend_ast_create(&@$, ZEND_AST_LABEL, $1); }
 ;
 
 catch_list:
 		/* empty */
-			{ $$ = zend_ast_create_list(0, ZEND_AST_CATCH_LIST); }
+			{ $$ = zend_ast_create_list(&@$, 0, ZEND_AST_CATCH_LIST); }
 	|	catch_list T_CATCH '(' catch_name_list T_VARIABLE ')' '{' inner_statement_list '}'
-			{ $$ = zend_ast_list_add($1, zend_ast_create(ZEND_AST_CATCH, $4, $5, $8)); }
+			{ $$ = zend_ast_list_add($1, zend_ast_create(&@$, ZEND_AST_CATCH, $4, $5, $8)); }
 ;
 
 catch_name_list:
-		name { $$ = zend_ast_create_list(1, ZEND_AST_NAME_LIST, $1); }
+		name { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_NAME_LIST, $1); }
 	|	catch_name_list '|' name { $$ = zend_ast_list_add($1, $3); }
 ;
 
@@ -482,12 +482,12 @@ finally_statement:
 ;
 
 unset_variables:
-		unset_variable { $$ = zend_ast_create_list(1, ZEND_AST_STMT_LIST, $1); }
+		unset_variable { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_STMT_LIST, $1); }
 	|	unset_variables ',' unset_variable { $$ = zend_ast_list_add($1, $3); }
 ;
 
 unset_variable:
-		variable { $$ = zend_ast_create(ZEND_AST_UNSET, $1); }
+		variable { $$ = zend_ast_create(&@$, ZEND_AST_UNSET, $1); }
 ;
 
 function_declaration_statement:
@@ -552,7 +552,7 @@ implements_list:
 
 foreach_variable:
 		variable			{ $$ = $1; }
-	|	'&' variable		{ $$ = zend_ast_create(ZEND_AST_REF, $2); }
+	|	'&' variable		{ $$ = zend_ast_create(&@$, ZEND_AST_REF, $2); }
 	|	T_LIST '(' array_pair_list ')' { $$ = $3; $$->attr = ZEND_ARRAY_SYNTAX_LIST; }
 	|	'[' array_pair_list ']' { $$ = $2; $$->attr = ZEND_ARRAY_SYNTAX_SHORT; }
 ;
@@ -580,11 +580,11 @@ switch_case_list:
 ;
 
 case_list:
-		/* empty */ { $$ = zend_ast_create_list(0, ZEND_AST_SWITCH_LIST); }
+		/* empty */ { $$ = zend_ast_create_list(&@$, 0, ZEND_AST_SWITCH_LIST); }
 	|	case_list T_CASE expr case_separator inner_statement_list
-			{ $$ = zend_ast_list_add($1, zend_ast_create(ZEND_AST_SWITCH_CASE, $3, $5)); }
+			{ $$ = zend_ast_list_add($1, zend_ast_create(&@$, ZEND_AST_SWITCH_CASE, $3, $5)); }
 	|	case_list T_DEFAULT case_separator inner_statement_list
-			{ $$ = zend_ast_list_add($1, zend_ast_create(ZEND_AST_SWITCH_CASE, NULL, $4)); }
+			{ $$ = zend_ast_list_add($1, zend_ast_create(&@$, ZEND_AST_SWITCH_CASE, NULL, $4)); }
 ;
 
 case_separator:
@@ -601,53 +601,53 @@ while_statement:
 
 if_stmt_without_else:
 		T_IF '(' expr ')' statement
-			{ $$ = zend_ast_create_list(1, ZEND_AST_IF,
-			      zend_ast_create(ZEND_AST_IF_ELEM, $3, $5)); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_IF,
+			      zend_ast_create(&@$, ZEND_AST_IF_ELEM, $3, $5)); }
 	|	if_stmt_without_else T_ELSEIF '(' expr ')' statement
 			{ $$ = zend_ast_list_add($1,
-			      zend_ast_create(ZEND_AST_IF_ELEM, $4, $6)); }
+			      zend_ast_create(&@$, ZEND_AST_IF_ELEM, $4, $6)); }
 ;
 
 if_stmt:
 		if_stmt_without_else %prec T_NOELSE { $$ = $1; }
 	|	if_stmt_without_else T_ELSE statement
-			{ $$ = zend_ast_list_add($1, zend_ast_create(ZEND_AST_IF_ELEM, NULL, $3)); }
+			{ $$ = zend_ast_list_add($1, zend_ast_create(&@$, ZEND_AST_IF_ELEM, NULL, $3)); }
 ;
 
 alt_if_stmt_without_else:
 		T_IF '(' expr ')' ':' inner_statement_list
-			{ $$ = zend_ast_create_list(1, ZEND_AST_IF,
-			      zend_ast_create(ZEND_AST_IF_ELEM, $3, $6)); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_IF,
+			      zend_ast_create(&@$, ZEND_AST_IF_ELEM, $3, $6)); }
 	|	alt_if_stmt_without_else T_ELSEIF '(' expr ')' ':' inner_statement_list
 			{ $$ = zend_ast_list_add($1,
-			      zend_ast_create(ZEND_AST_IF_ELEM, $4, $7)); }
+			      zend_ast_create(&@$, ZEND_AST_IF_ELEM, $4, $7)); }
 ;
 
 alt_if_stmt:
 		alt_if_stmt_without_else T_ENDIF ';' { $$ = $1; }
 	|	alt_if_stmt_without_else T_ELSE ':' inner_statement_list T_ENDIF ';'
 			{ $$ = zend_ast_list_add($1,
-			      zend_ast_create(ZEND_AST_IF_ELEM, NULL, $4)); }
+			      zend_ast_create(&@$, ZEND_AST_IF_ELEM, NULL, $4)); }
 ;
 
 parameter_list:
 		non_empty_parameter_list { $$ = $1; }
-	|	/* empty */	{ $$ = zend_ast_create_list(0, ZEND_AST_PARAM_LIST); }
+	|	/* empty */	{ $$ = zend_ast_create_list(&@$, 0, ZEND_AST_PARAM_LIST); }
 ;
 
 
 non_empty_parameter_list:
 		parameter
-			{ $$ = zend_ast_create_list(1, ZEND_AST_PARAM_LIST, $1); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_PARAM_LIST, $1); }
 	|	non_empty_parameter_list ',' parameter
 			{ $$ = zend_ast_list_add($1, $3); }
 ;
 
 parameter:
 		optional_type is_reference is_variadic T_VARIABLE
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2 | $3, $1, $4, NULL); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_PARAM, $2 | $3, $1, $4, NULL); }
 	|	optional_type is_reference is_variadic T_VARIABLE '=' expr
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2 | $3, $1, $4, $6); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_PARAM, $2 | $3, $1, $4, $6); }
 ;
 
 
@@ -662,8 +662,8 @@ type_expr:
 ;
 
 type:
-		T_ARRAY		{ $$ = zend_ast_create_ex(ZEND_AST_TYPE, IS_ARRAY); }
-	|	T_CALLABLE	{ $$ = zend_ast_create_ex(ZEND_AST_TYPE, IS_CALLABLE); }
+		T_ARRAY		{ $$ = zend_ast_create_ex(&@$, ZEND_AST_TYPE, IS_ARRAY); }
+	|	T_CALLABLE	{ $$ = zend_ast_create_ex(&@$, ZEND_AST_TYPE, IS_CALLABLE); }
 	|	name		{ $$ = $1; }
 ;
 
@@ -673,41 +673,41 @@ return_type:
 ;
 
 argument_list:
-		'(' ')'	{ $$ = zend_ast_create_list(0, ZEND_AST_ARG_LIST); }
+		'(' ')'	{ $$ = zend_ast_create_list(&@$, 0, ZEND_AST_ARG_LIST); }
 	|	'(' non_empty_argument_list possible_comma ')' { $$ = $2; }
 ;
 
 non_empty_argument_list:
 		argument
-			{ $$ = zend_ast_create_list(1, ZEND_AST_ARG_LIST, $1); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_ARG_LIST, $1); }
 	|	non_empty_argument_list ',' argument
 			{ $$ = zend_ast_list_add($1, $3); }
 ;
 
 argument:
 		expr			{ $$ = $1; }
-	|	T_ELLIPSIS expr	{ $$ = zend_ast_create(ZEND_AST_UNPACK, $2); }
+	|	T_ELLIPSIS expr	{ $$ = zend_ast_create(&@$, ZEND_AST_UNPACK, $2); }
 ;
 
 global_var_list:
 		global_var_list ',' global_var { $$ = zend_ast_list_add($1, $3); }
-	|	global_var { $$ = zend_ast_create_list(1, ZEND_AST_STMT_LIST, $1); }
+	|	global_var { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_STMT_LIST, $1); }
 ;
 
 global_var:
 	simple_variable
-		{ $$ = zend_ast_create(ZEND_AST_GLOBAL, zend_ast_create(ZEND_AST_VAR, $1)); }
+		{ $$ = zend_ast_create(&@$, ZEND_AST_GLOBAL, zend_ast_create(&@$, ZEND_AST_VAR, $1)); }
 ;
 
 
 static_var_list:
 		static_var_list ',' static_var { $$ = zend_ast_list_add($1, $3); }
-	|	static_var { $$ = zend_ast_create_list(1, ZEND_AST_STMT_LIST, $1); }
+	|	static_var { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_STMT_LIST, $1); }
 ;
 
 static_var:
-		T_VARIABLE			{ $$ = zend_ast_create(ZEND_AST_STATIC, $1, NULL); }
-	|	T_VARIABLE '=' expr	{ $$ = zend_ast_create(ZEND_AST_STATIC, $1, $3); }
+		T_VARIABLE			{ $$ = zend_ast_create(&@$, ZEND_AST_STATIC, $1, NULL); }
+	|	T_VARIABLE '=' expr	{ $$ = zend_ast_create(&@$, ZEND_AST_STATIC, $1, $3); }
 ;
 
 
@@ -715,18 +715,18 @@ class_statement_list:
 		class_statement_list class_statement
 			{ $$ = zend_ast_list_add($1, $2); }
 	|	/* empty */
-			{ $$ = zend_ast_create_list(0, ZEND_AST_STMT_LIST); }
+			{ $$ = zend_ast_create_list(&@$, 0, ZEND_AST_STMT_LIST); }
 ;
 
 
 class_statement:
 		variable_modifiers optional_type property_list ';'
-			{ $$ = zend_ast_create(ZEND_AST_PROP_GROUP, $2, $3);
+			{ $$ = zend_ast_create(&@$, ZEND_AST_PROP_GROUP, $2, $3);
 			  $$->attr = $1; }
 	|	method_modifiers T_CONST class_const_list ';'
 			{ $$ = $3; $$->attr = $1; }
 	|	T_USE name_list trait_adaptations
-			{ $$ = zend_ast_create(ZEND_AST_USE_TRAIT, $2, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_USE_TRAIT, $2, $3); }
 	|	method_modifiers T_FUNCTION returns_ref identifier backup_doc_comment '(' parameter_list ')'
 		return_type backup_fn_flags method_body backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_METHOD, $3 | $1 | $12, @2.start_line, $5,
@@ -734,7 +734,7 @@ class_statement:
 ;
 
 name_list:
-		name { $$ = zend_ast_create_list(1, ZEND_AST_NAME_LIST, $1); }
+		name { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_NAME_LIST, $1); }
 	|	name_list ',' name { $$ = zend_ast_list_add($1, $3); }
 ;
 
@@ -746,7 +746,7 @@ trait_adaptations:
 
 trait_adaptation_list:
 		trait_adaptation
-			{ $$ = zend_ast_create_list(1, ZEND_AST_TRAIT_ADAPTATIONS, $1); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_TRAIT_ADAPTATIONS, $1); }
 	|	trait_adaptation_list trait_adaptation
 			{ $$ = zend_ast_list_add($1, $2); }
 ;
@@ -758,29 +758,29 @@ trait_adaptation:
 
 trait_precedence:
 	absolute_trait_method_reference T_INSTEADOF name_list
-		{ $$ = zend_ast_create(ZEND_AST_TRAIT_PRECEDENCE, $1, $3); }
+		{ $$ = zend_ast_create(&@$, ZEND_AST_TRAIT_PRECEDENCE, $1, $3); }
 ;
 
 trait_alias:
 		trait_method_reference T_AS T_STRING
-			{ $$ = zend_ast_create(ZEND_AST_TRAIT_ALIAS, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_TRAIT_ALIAS, $1, $3); }
 	|	trait_method_reference T_AS reserved_non_modifiers
-			{ zval zv; zend_lex_tstring(&zv); $$ = zend_ast_create(ZEND_AST_TRAIT_ALIAS, $1, zend_ast_create_zval(&zv)); }
+			{ zval zv; zend_lex_tstring(&zv); $$ = zend_ast_create(&@$, ZEND_AST_TRAIT_ALIAS, $1, zend_ast_create_zval(&@$, &zv)); }
 	|	trait_method_reference T_AS member_modifier identifier
-			{ $$ = zend_ast_create_ex(ZEND_AST_TRAIT_ALIAS, $3, $1, $4); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_TRAIT_ALIAS, $3, $1, $4); }
 	|	trait_method_reference T_AS member_modifier
-			{ $$ = zend_ast_create_ex(ZEND_AST_TRAIT_ALIAS, $3, $1, NULL); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_TRAIT_ALIAS, $3, $1, NULL); }
 ;
 
 trait_method_reference:
 		identifier
-			{ $$ = zend_ast_create(ZEND_AST_METHOD_REFERENCE, NULL, $1); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_METHOD_REFERENCE, NULL, $1); }
 	|	absolute_trait_method_reference { $$ = $1; }
 ;
 
 absolute_trait_method_reference:
 	name T_PAAMAYIM_NEKUDOTAYIM identifier
-		{ $$ = zend_ast_create(ZEND_AST_METHOD_REFERENCE, $1, $3); }
+		{ $$ = zend_ast_create(&@$, ZEND_AST_METHOD_REFERENCE, $1, $3); }
 ;
 
 method_body:
@@ -816,35 +816,35 @@ member_modifier:
 
 property_list:
 		property_list ',' property { $$ = zend_ast_list_add($1, $3); }
-	|	property { $$ = zend_ast_create_list(1, ZEND_AST_PROP_DECL, $1); }
+	|	property { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_PROP_DECL, $1); }
 ;
 
 property:
 		T_VARIABLE backup_doc_comment
-			{ $$ = zend_ast_create(ZEND_AST_PROP_ELEM, $1, NULL, ($2 ? zend_ast_create_zval_from_str($2) : NULL)); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_PROP_ELEM, $1, NULL, ($2 ? zend_ast_create_zval_from_str(&@$, $2) : NULL)); }
 	|	T_VARIABLE '=' expr backup_doc_comment
-			{ $$ = zend_ast_create(ZEND_AST_PROP_ELEM, $1, $3, ($4 ? zend_ast_create_zval_from_str($4) : NULL)); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_PROP_ELEM, $1, $3, ($4 ? zend_ast_create_zval_from_str(&@$, $4) : NULL)); }
 ;
 
 class_const_list:
 		class_const_list ',' class_const_decl { $$ = zend_ast_list_add($1, $3); }
-	|	class_const_decl { $$ = zend_ast_create_list(1, ZEND_AST_CLASS_CONST_DECL, $1); }
+	|	class_const_decl { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_CLASS_CONST_DECL, $1); }
 ;
 
 class_const_decl:
-	identifier '=' expr backup_doc_comment { $$ = zend_ast_create(ZEND_AST_CONST_ELEM, $1, $3, ($4 ? zend_ast_create_zval_from_str($4) : NULL)); }
+	identifier '=' expr backup_doc_comment { $$ = zend_ast_create(&@$, ZEND_AST_CONST_ELEM, $1, $3, ($4 ? zend_ast_create_zval_from_str(&@$, $4) : NULL)); }
 ;
 
 const_decl:
-	T_STRING '=' expr backup_doc_comment { $$ = zend_ast_create(ZEND_AST_CONST_ELEM, $1, $3, ($4 ? zend_ast_create_zval_from_str($4) : NULL)); }
+	T_STRING '=' expr backup_doc_comment { $$ = zend_ast_create(&@$, ZEND_AST_CONST_ELEM, $1, $3, ($4 ? zend_ast_create_zval_from_str(&@$, $4) : NULL)); }
 ;
 
 echo_expr_list:
 		echo_expr_list ',' echo_expr { $$ = zend_ast_list_add($1, $3); }
-	|	echo_expr { $$ = zend_ast_create_list(1, ZEND_AST_STMT_LIST, $1); }
+	|	echo_expr { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_STMT_LIST, $1); }
 ;
 echo_expr:
-	expr { $$ = zend_ast_create(ZEND_AST_ECHO, $1); }
+	expr { $$ = zend_ast_create(&@$, ZEND_AST_ECHO, $1); }
 ;
 
 for_exprs:
@@ -854,7 +854,7 @@ for_exprs:
 
 non_empty_for_exprs:
 		non_empty_for_exprs ',' expr { $$ = zend_ast_list_add($1, $3); }
-	|	expr { $$ = zend_ast_create_list(1, ZEND_AST_EXPR_LIST, $1); }
+	|	expr { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_EXPR_LIST, $1); }
 ;
 
 anonymous_class:
@@ -862,13 +862,13 @@ anonymous_class:
 			zend_ast *decl = zend_ast_create_decl(
 				ZEND_AST_CLASS, ZEND_ACC_ANON_CLASS, @1.start_line, $5, NULL,
 				$3, $4, $7, NULL);
-			$$ = zend_ast_create(ZEND_AST_NEW, decl, $2);
+			$$ = zend_ast_create(&@$, ZEND_AST_NEW, decl, $2);
 		}
 ;
 
 new_expr:
 		T_NEW class_name_reference ctor_arguments
-			{ $$ = zend_ast_create(ZEND_AST_NEW, $2, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_NEW, $2, $3); }
 	|	T_NEW anonymous_class
 			{ $$ = $2; }
 ;
@@ -877,115 +877,115 @@ expr:
 		variable
 			{ $$ = $1; }
 	|	T_LIST '(' array_pair_list ')' '=' expr
-			{ $3->attr = ZEND_ARRAY_SYNTAX_LIST; $$ = zend_ast_create(ZEND_AST_ASSIGN, $3, $6); }
+			{ $3->attr = ZEND_ARRAY_SYNTAX_LIST; $$ = zend_ast_create(&@$, ZEND_AST_ASSIGN, $3, $6); }
 	|	'[' array_pair_list ']' '=' expr
-			{ $2->attr = ZEND_ARRAY_SYNTAX_SHORT; $$ = zend_ast_create(ZEND_AST_ASSIGN, $2, $5); }
+			{ $2->attr = ZEND_ARRAY_SYNTAX_SHORT; $$ = zend_ast_create(&@$, ZEND_AST_ASSIGN, $2, $5); }
 	|	variable '=' expr
-			{ $$ = zend_ast_create(ZEND_AST_ASSIGN, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_ASSIGN, $1, $3); }
 	|	variable '=' '&' variable
-			{ $$ = zend_ast_create(ZEND_AST_ASSIGN_REF, $1, $4); }
-	|	T_CLONE expr { $$ = zend_ast_create(ZEND_AST_CLONE, $2); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_ASSIGN_REF, $1, $4); }
+	|	T_CLONE expr { $$ = zend_ast_create(&@$, ZEND_AST_CLONE, $2); }
 	|	variable T_PLUS_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_ADD, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_ADD, $1, $3); }
 	|	variable T_MINUS_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_SUB, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_SUB, $1, $3); }
 	|	variable T_MUL_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_MUL, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_MUL, $1, $3); }
 	|	variable T_POW_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_POW, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_POW, $1, $3); }
 	|	variable T_DIV_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_DIV, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_DIV, $1, $3); }
 	|	variable T_CONCAT_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_CONCAT, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_CONCAT, $1, $3); }
 	|	variable T_MOD_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_MOD, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_MOD, $1, $3); }
 	|	variable T_AND_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_BW_AND, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_BW_AND, $1, $3); }
 	|	variable T_OR_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_BW_OR, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_BW_OR, $1, $3); }
 	|	variable T_XOR_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_BW_XOR, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_BW_XOR, $1, $3); }
 	|	variable T_SL_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_SL, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_SL, $1, $3); }
 	|	variable T_SR_EQUAL expr
-			{ $$ = zend_ast_create_assign_op(ZEND_ASSIGN_SR, $1, $3); }
+			{ $$ = zend_ast_create_assign_op(&@$, ZEND_ASSIGN_SR, $1, $3); }
 	|	variable T_COALESCE_EQUAL expr
-			{ $$ = zend_ast_create(ZEND_AST_ASSIGN_COALESCE, $1, $3); }
-	|	variable T_INC { $$ = zend_ast_create(ZEND_AST_POST_INC, $1); }
-	|	T_INC variable { $$ = zend_ast_create(ZEND_AST_PRE_INC, $2); }
-	|	variable T_DEC { $$ = zend_ast_create(ZEND_AST_POST_DEC, $1); }
-	|	T_DEC variable { $$ = zend_ast_create(ZEND_AST_PRE_DEC, $2); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_ASSIGN_COALESCE, $1, $3); }
+	|	variable T_INC { $$ = zend_ast_create(&@$, ZEND_AST_POST_INC, $1); }
+	|	T_INC variable { $$ = zend_ast_create(&@$, ZEND_AST_PRE_INC, $2); }
+	|	variable T_DEC { $$ = zend_ast_create(&@$, ZEND_AST_POST_DEC, $1); }
+	|	T_DEC variable { $$ = zend_ast_create(&@$, ZEND_AST_PRE_DEC, $2); }
 	|	expr T_BOOLEAN_OR expr
-			{ $$ = zend_ast_create(ZEND_AST_OR, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_OR, $1, $3); }
 	|	expr T_BOOLEAN_AND expr
-			{ $$ = zend_ast_create(ZEND_AST_AND, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_AND, $1, $3); }
 	|	expr T_LOGICAL_OR expr
-			{ $$ = zend_ast_create(ZEND_AST_OR, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_OR, $1, $3); }
 	|	expr T_LOGICAL_AND expr
-			{ $$ = zend_ast_create(ZEND_AST_AND, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_AND, $1, $3); }
 	|	expr T_LOGICAL_XOR expr
-			{ $$ = zend_ast_create_binary_op(ZEND_BOOL_XOR, $1, $3); }
-	|	expr '|' expr	{ $$ = zend_ast_create_binary_op(ZEND_BW_OR, $1, $3); }
-	|	expr '&' expr	{ $$ = zend_ast_create_binary_op(ZEND_BW_AND, $1, $3); }
-	|	expr '^' expr	{ $$ = zend_ast_create_binary_op(ZEND_BW_XOR, $1, $3); }
-	|	expr '.' expr 	{ $$ = zend_ast_create_binary_op(ZEND_CONCAT, $1, $3); }
-	|	expr '+' expr 	{ $$ = zend_ast_create_binary_op(ZEND_ADD, $1, $3); }
-	|	expr '-' expr 	{ $$ = zend_ast_create_binary_op(ZEND_SUB, $1, $3); }
-	|	expr '*' expr	{ $$ = zend_ast_create_binary_op(ZEND_MUL, $1, $3); }
-	|	expr T_POW expr	{ $$ = zend_ast_create_binary_op(ZEND_POW, $1, $3); }
-	|	expr '/' expr	{ $$ = zend_ast_create_binary_op(ZEND_DIV, $1, $3); }
-	|	expr '%' expr 	{ $$ = zend_ast_create_binary_op(ZEND_MOD, $1, $3); }
-	| 	expr T_SL expr	{ $$ = zend_ast_create_binary_op(ZEND_SL, $1, $3); }
-	|	expr T_SR expr	{ $$ = zend_ast_create_binary_op(ZEND_SR, $1, $3); }
-	|	'+' expr %prec T_INC { $$ = zend_ast_create(ZEND_AST_UNARY_PLUS, $2); }
-	|	'-' expr %prec T_INC { $$ = zend_ast_create(ZEND_AST_UNARY_MINUS, $2); }
-	|	'!' expr { $$ = zend_ast_create_ex(ZEND_AST_UNARY_OP, ZEND_BOOL_NOT, $2); }
-	|	'~' expr { $$ = zend_ast_create_ex(ZEND_AST_UNARY_OP, ZEND_BW_NOT, $2); }
+			{ $$ = zend_ast_create_binary_op(&@$, ZEND_BOOL_XOR, $1, $3); }
+	|	expr '|' expr	{ $$ = zend_ast_create_binary_op(&@$, ZEND_BW_OR, $1, $3); }
+	|	expr '&' expr	{ $$ = zend_ast_create_binary_op(&@$, ZEND_BW_AND, $1, $3); }
+	|	expr '^' expr	{ $$ = zend_ast_create_binary_op(&@$, ZEND_BW_XOR, $1, $3); }
+	|	expr '.' expr 	{ $$ = zend_ast_create_binary_op(&@$, ZEND_CONCAT, $1, $3); }
+	|	expr '+' expr 	{ $$ = zend_ast_create_binary_op(&@$, ZEND_ADD, $1, $3); }
+	|	expr '-' expr 	{ $$ = zend_ast_create_binary_op(&@$, ZEND_SUB, $1, $3); }
+	|	expr '*' expr	{ $$ = zend_ast_create_binary_op(&@$, ZEND_MUL, $1, $3); }
+	|	expr T_POW expr	{ $$ = zend_ast_create_binary_op(&@$, ZEND_POW, $1, $3); }
+	|	expr '/' expr	{ $$ = zend_ast_create_binary_op(&@$, ZEND_DIV, $1, $3); }
+	|	expr '%' expr 	{ $$ = zend_ast_create_binary_op(&@$, ZEND_MOD, $1, $3); }
+	| 	expr T_SL expr	{ $$ = zend_ast_create_binary_op(&@$, ZEND_SL, $1, $3); }
+	|	expr T_SR expr	{ $$ = zend_ast_create_binary_op(&@$, ZEND_SR, $1, $3); }
+	|	'+' expr %prec T_INC { $$ = zend_ast_create(&@$, ZEND_AST_UNARY_PLUS, $2); }
+	|	'-' expr %prec T_INC { $$ = zend_ast_create(&@$, ZEND_AST_UNARY_MINUS, $2); }
+	|	'!' expr { $$ = zend_ast_create_ex(&@$, ZEND_AST_UNARY_OP, ZEND_BOOL_NOT, $2); }
+	|	'~' expr { $$ = zend_ast_create_ex(&@$, ZEND_AST_UNARY_OP, ZEND_BW_NOT, $2); }
 	|	expr T_IS_IDENTICAL expr
-			{ $$ = zend_ast_create_binary_op(ZEND_IS_IDENTICAL, $1, $3); }
+			{ $$ = zend_ast_create_binary_op(&@$, ZEND_IS_IDENTICAL, $1, $3); }
 	|	expr T_IS_NOT_IDENTICAL expr
-			{ $$ = zend_ast_create_binary_op(ZEND_IS_NOT_IDENTICAL, $1, $3); }
+			{ $$ = zend_ast_create_binary_op(&@$, ZEND_IS_NOT_IDENTICAL, $1, $3); }
 	|	expr T_IS_EQUAL expr
-			{ $$ = zend_ast_create_binary_op(ZEND_IS_EQUAL, $1, $3); }
+			{ $$ = zend_ast_create_binary_op(&@$, ZEND_IS_EQUAL, $1, $3); }
 	|	expr T_IS_NOT_EQUAL expr
-			{ $$ = zend_ast_create_binary_op(ZEND_IS_NOT_EQUAL, $1, $3); }
+			{ $$ = zend_ast_create_binary_op(&@$, ZEND_IS_NOT_EQUAL, $1, $3); }
 	|	expr '<' expr
-			{ $$ = zend_ast_create_binary_op(ZEND_IS_SMALLER, $1, $3); }
+			{ $$ = zend_ast_create_binary_op(&@$, ZEND_IS_SMALLER, $1, $3); }
 	|	expr T_IS_SMALLER_OR_EQUAL expr
-			{ $$ = zend_ast_create_binary_op(ZEND_IS_SMALLER_OR_EQUAL, $1, $3); }
+			{ $$ = zend_ast_create_binary_op(&@$, ZEND_IS_SMALLER_OR_EQUAL, $1, $3); }
 	|	expr '>' expr
-			{ $$ = zend_ast_create(ZEND_AST_GREATER, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_GREATER, $1, $3); }
 	|	expr T_IS_GREATER_OR_EQUAL expr
-			{ $$ = zend_ast_create(ZEND_AST_GREATER_EQUAL, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_GREATER_EQUAL, $1, $3); }
 	|	expr T_SPACESHIP expr
-			{ $$ = zend_ast_create_binary_op(ZEND_SPACESHIP, $1, $3); }
+			{ $$ = zend_ast_create_binary_op(&@$, ZEND_SPACESHIP, $1, $3); }
 	|	expr T_INSTANCEOF class_name_reference
-			{ $$ = zend_ast_create(ZEND_AST_INSTANCEOF, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_INSTANCEOF, $1, $3); }
 	|	'(' expr ')' { $$ = $2; }
 	|	new_expr { $$ = $1; }
 	|	expr '?' expr ':' expr
-			{ $$ = zend_ast_create(ZEND_AST_CONDITIONAL, $1, $3, $5); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_CONDITIONAL, $1, $3, $5); }
 	|	expr '?' ':' expr
-			{ $$ = zend_ast_create(ZEND_AST_CONDITIONAL, $1, NULL, $4); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_CONDITIONAL, $1, NULL, $4); }
 	|	expr T_COALESCE expr
-			{ $$ = zend_ast_create(ZEND_AST_COALESCE, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_COALESCE, $1, $3); }
 	|	internal_functions_in_yacc { $$ = $1; }
-	|	T_INT_CAST expr		{ $$ = zend_ast_create_cast(IS_LONG, $2); }
-	|	T_DOUBLE_CAST expr	{ $$ = zend_ast_create_cast(IS_DOUBLE, $2); }
-	|	T_STRING_CAST expr	{ $$ = zend_ast_create_cast(IS_STRING, $2); }
-	|	T_ARRAY_CAST expr	{ $$ = zend_ast_create_cast(IS_ARRAY, $2); }
-	|	T_OBJECT_CAST expr	{ $$ = zend_ast_create_cast(IS_OBJECT, $2); }
-	|	T_BOOL_CAST expr	{ $$ = zend_ast_create_cast(_IS_BOOL, $2); }
-	|	T_UNSET_CAST expr	{ $$ = zend_ast_create_cast(IS_NULL, $2); }
-	|	T_EXIT exit_expr	{ $$ = zend_ast_create(ZEND_AST_EXIT, $2); }
-	|	'@' expr			{ $$ = zend_ast_create(ZEND_AST_SILENCE, $2); }
+	|	T_INT_CAST expr		{ $$ = zend_ast_create_cast(&@$, IS_LONG, $2); }
+	|	T_DOUBLE_CAST expr	{ $$ = zend_ast_create_cast(&@$, IS_DOUBLE, $2); }
+	|	T_STRING_CAST expr	{ $$ = zend_ast_create_cast(&@$, IS_STRING, $2); }
+	|	T_ARRAY_CAST expr	{ $$ = zend_ast_create_cast(&@$, IS_ARRAY, $2); }
+	|	T_OBJECT_CAST expr	{ $$ = zend_ast_create_cast(&@$, IS_OBJECT, $2); }
+	|	T_BOOL_CAST expr	{ $$ = zend_ast_create_cast(&@$, _IS_BOOL, $2); }
+	|	T_UNSET_CAST expr	{ $$ = zend_ast_create_cast(&@$, IS_NULL, $2); }
+	|	T_EXIT exit_expr	{ $$ = zend_ast_create(&@$, ZEND_AST_EXIT, $2); }
+	|	'@' expr			{ $$ = zend_ast_create(&@$, ZEND_AST_SILENCE, $2); }
 	|	scalar { $$ = $1; }
-	|	'`' backticks_expr '`' { $$ = zend_ast_create(ZEND_AST_SHELL_EXEC, $2); }
-	|	T_PRINT expr { $$ = zend_ast_create(ZEND_AST_PRINT, $2); }
-	|	T_YIELD { $$ = zend_ast_create(ZEND_AST_YIELD, NULL, NULL); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
-	|	T_YIELD expr { $$ = zend_ast_create(ZEND_AST_YIELD, $2, NULL); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
-	|	T_YIELD expr T_DOUBLE_ARROW expr { $$ = zend_ast_create(ZEND_AST_YIELD, $4, $2); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
-	|	T_YIELD_FROM expr { $$ = zend_ast_create(ZEND_AST_YIELD_FROM, $2); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
+	|	'`' backticks_expr '`' { $$ = zend_ast_create(&@$, ZEND_AST_SHELL_EXEC, $2); }
+	|	T_PRINT expr { $$ = zend_ast_create(&@$, ZEND_AST_PRINT, $2); }
+	|	T_YIELD { $$ = zend_ast_create(&@$, ZEND_AST_YIELD, NULL, NULL); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
+	|	T_YIELD expr { $$ = zend_ast_create(&@$, ZEND_AST_YIELD, $2, NULL); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
+	|	T_YIELD expr T_DOUBLE_ARROW expr { $$ = zend_ast_create(&@$, ZEND_AST_YIELD, $4, $2); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
+	|	T_YIELD_FROM expr { $$ = zend_ast_create(&@$, ZEND_AST_YIELD_FROM, $2); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
 	|	T_FUNCTION returns_ref backup_doc_comment '(' parameter_list ')' lexical_vars return_type
 		backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $2 | $13, @1.start_line, $3,
@@ -1018,7 +1018,7 @@ lexical_vars:
 
 lexical_var_list:
 		lexical_var_list ',' lexical_var { $$ = zend_ast_list_add($1, $3); }
-	|	lexical_var { $$ = zend_ast_create_list(1, ZEND_AST_CLOSURE_USES, $1); }
+	|	lexical_var { $$ = zend_ast_create_list(&@$, 1, ZEND_AST_CLOSURE_USES, $1); }
 ;
 
 lexical_var:
@@ -1028,19 +1028,19 @@ lexical_var:
 
 function_call:
 		name argument_list
-			{ $$ = zend_ast_create(ZEND_AST_CALL, $1, $2); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_CALL, $1, $2); }
 	|	class_name T_PAAMAYIM_NEKUDOTAYIM member_name argument_list
-			{ $$ = zend_ast_create(ZEND_AST_STATIC_CALL, $1, $3, $4); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_STATIC_CALL, $1, $3, $4); }
 	|	variable_class_name T_PAAMAYIM_NEKUDOTAYIM member_name argument_list
-			{ $$ = zend_ast_create(ZEND_AST_STATIC_CALL, $1, $3, $4); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_STATIC_CALL, $1, $3, $4); }
 	|	callable_expr argument_list
-			{ $$ = zend_ast_create(ZEND_AST_CALL, $1, $2); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_CALL, $1, $2); }
 ;
 
 class_name:
 		T_STATIC
 			{ zval zv; ZVAL_INTERNED_STR(&zv, ZSTR_KNOWN(ZEND_STR_STATIC));
-			  $$ = zend_ast_create_zval_ex(&zv, ZEND_NAME_NOT_FQ); }
+			  $$ = zend_ast_create_zval_ex(&@$, &zv, ZEND_NAME_NOT_FQ); }
 	|	name { $$ = $1; }
 ;
 
@@ -1056,14 +1056,14 @@ exit_expr:
 
 backticks_expr:
 		/* empty */
-			{ $$ = zend_ast_create_zval_from_str(ZSTR_EMPTY_ALLOC()); }
+			{ $$ = zend_ast_create_zval_from_str(&@$, ZSTR_EMPTY_ALLOC()); }
 	|	T_ENCAPSED_AND_WHITESPACE { $$ = $1; }
 	|	encaps_list { $$ = $1; }
 ;
 
 
 ctor_arguments:
-		/* empty */	{ $$ = zend_ast_create_list(0, ZEND_AST_ARG_LIST); }
+		/* empty */	{ $$ = zend_ast_create_list(&@$, 0, ZEND_AST_ARG_LIST); }
 	|	argument_list { $$ = $1; }
 ;
 
@@ -1077,17 +1077,17 @@ dereferencable_scalar:
 scalar:
 		T_LNUMBER 	{ $$ = $1; }
 	|	T_DNUMBER 	{ $$ = $1; }
-	|	T_LINE 		{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_LINE); }
-	|	T_FILE 		{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_FILE); }
-	|	T_DIR   	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_DIR); }
-	|	T_TRAIT_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_TRAIT_C); }
-	|	T_METHOD_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_METHOD_C); }
-	|	T_FUNC_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_FUNC_C); }
-	|	T_NS_C		{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_NS_C); }
-	|	T_CLASS_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_CLASS_C); }
+	|	T_LINE 		{ $$ = zend_ast_create_ex(&@$, ZEND_AST_MAGIC_CONST, T_LINE); }
+	|	T_FILE 		{ $$ = zend_ast_create_ex(&@$, ZEND_AST_MAGIC_CONST, T_FILE); }
+	|	T_DIR   	{ $$ = zend_ast_create_ex(&@$, ZEND_AST_MAGIC_CONST, T_DIR); }
+	|	T_TRAIT_C	{ $$ = zend_ast_create_ex(&@$, ZEND_AST_MAGIC_CONST, T_TRAIT_C); }
+	|	T_METHOD_C	{ $$ = zend_ast_create_ex(&@$, ZEND_AST_MAGIC_CONST, T_METHOD_C); }
+	|	T_FUNC_C	{ $$ = zend_ast_create_ex(&@$, ZEND_AST_MAGIC_CONST, T_FUNC_C); }
+	|	T_NS_C		{ $$ = zend_ast_create_ex(&@$, ZEND_AST_MAGIC_CONST, T_NS_C); }
+	|	T_CLASS_C	{ $$ = zend_ast_create_ex(&@$, ZEND_AST_MAGIC_CONST, T_CLASS_C); }
 	|	T_START_HEREDOC T_ENCAPSED_AND_WHITESPACE T_END_HEREDOC { $$ = $2; }
 	|	T_START_HEREDOC T_END_HEREDOC
-			{ $$ = zend_ast_create_zval_from_str(ZSTR_EMPTY_ALLOC()); }
+			{ $$ = zend_ast_create_zval_from_str(&@$, ZSTR_EMPTY_ALLOC()); }
 	|	'"' encaps_list '"' 	{ $$ = $2; }
 	|	T_START_HEREDOC encaps_list T_END_HEREDOC { $$ = $2; }
 	|	dereferencable_scalar	{ $$ = $1; }
@@ -1095,11 +1095,11 @@ scalar:
 ;
 
 constant:
-		name { $$ = zend_ast_create(ZEND_AST_CONST, $1); }
+		name { $$ = zend_ast_create(&@$, ZEND_AST_CONST, $1); }
 	|	class_name T_PAAMAYIM_NEKUDOTAYIM identifier
-			{ $$ = zend_ast_create_class_const_or_name($1, $3); }
+			{ $$ = zend_ast_create_class_const_or_name(&@$, $1, $3); }
 	|	variable_class_name T_PAAMAYIM_NEKUDOTAYIM identifier
-			{ $$ = zend_ast_create_class_const_or_name($1, $3); }
+			{ $$ = zend_ast_create_class_const_or_name(&@$, $1, $3); }
 ;
 
 optional_expr:
@@ -1125,15 +1125,15 @@ callable_expr:
 
 callable_variable:
 		simple_variable
-			{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_VAR, $1); }
 	|	dereferencable '[' optional_expr ']'
-			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_DIM, $1, $3); }
 	|	constant '[' optional_expr ']'
-			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_DIM, $1, $3); }
 	|	dereferencable '{' expr '}'
-			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_DIM, $1, $3); }
 	|	dereferencable T_OBJECT_OPERATOR property_name argument_list
-			{ $$ = zend_ast_create(ZEND_AST_METHOD_CALL, $1, $3, $4); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_METHOD_CALL, $1, $3, $4); }
 	|	function_call { $$ = $1; }
 ;
 
@@ -1143,47 +1143,47 @@ variable:
 	|	static_member
 			{ $$ = $1; }
 	|	dereferencable T_OBJECT_OPERATOR property_name
-			{ $$ = zend_ast_create(ZEND_AST_PROP, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_PROP, $1, $3); }
 ;
 
 simple_variable:
 		T_VARIABLE			{ $$ = $1; }
 	|	'$' '{' expr '}'	{ $$ = $3; }
-	|	'$' simple_variable	{ $$ = zend_ast_create(ZEND_AST_VAR, $2); }
+	|	'$' simple_variable	{ $$ = zend_ast_create(&@$, ZEND_AST_VAR, $2); }
 ;
 
 static_member:
 		class_name T_PAAMAYIM_NEKUDOTAYIM simple_variable
-			{ $$ = zend_ast_create(ZEND_AST_STATIC_PROP, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_STATIC_PROP, $1, $3); }
 	|	variable_class_name T_PAAMAYIM_NEKUDOTAYIM simple_variable
-			{ $$ = zend_ast_create(ZEND_AST_STATIC_PROP, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_STATIC_PROP, $1, $3); }
 ;
 
 new_variable:
 		simple_variable
-			{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_VAR, $1); }
 	|	new_variable '[' optional_expr ']'
-			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_DIM, $1, $3); }
 	|	new_variable '{' expr '}'
-			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_DIM, $1, $3); }
 	|	new_variable T_OBJECT_OPERATOR property_name
-			{ $$ = zend_ast_create(ZEND_AST_PROP, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_PROP, $1, $3); }
 	|	class_name T_PAAMAYIM_NEKUDOTAYIM simple_variable
-			{ $$ = zend_ast_create(ZEND_AST_STATIC_PROP, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_STATIC_PROP, $1, $3); }
 	|	new_variable T_PAAMAYIM_NEKUDOTAYIM simple_variable
-			{ $$ = zend_ast_create(ZEND_AST_STATIC_PROP, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_STATIC_PROP, $1, $3); }
 ;
 
 member_name:
 		identifier { $$ = $1; }
 	|	'{' expr '}'	{ $$ = $2; }
-	|	simple_variable	{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
+	|	simple_variable	{ $$ = zend_ast_create(&@$, ZEND_AST_VAR, $1); }
 ;
 
 property_name:
 		T_STRING { $$ = $1; }
 	|	'{' expr '}'	{ $$ = $2; }
-	|	simple_variable	{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
+	|	simple_variable	{ $$ = zend_ast_create(&@$, ZEND_AST_VAR, $1); }
 ;
 
 array_pair_list:
@@ -1200,24 +1200,24 @@ non_empty_array_pair_list:
 		non_empty_array_pair_list ',' possible_array_pair
 			{ $$ = zend_ast_list_add($1, $3); }
 	|	possible_array_pair
-			{ $$ = zend_ast_create_list(1, ZEND_AST_ARRAY, $1); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_ARRAY, $1); }
 ;
 
 array_pair:
 		expr T_DOUBLE_ARROW expr
-			{ $$ = zend_ast_create(ZEND_AST_ARRAY_ELEM, $3, $1); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_ARRAY_ELEM, $3, $1); }
 	|	expr
-			{ $$ = zend_ast_create(ZEND_AST_ARRAY_ELEM, $1, NULL); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_ARRAY_ELEM, $1, NULL); }
 	|	expr T_DOUBLE_ARROW '&' variable
-			{ $$ = zend_ast_create_ex(ZEND_AST_ARRAY_ELEM, 1, $4, $1); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_ARRAY_ELEM, 1, $4, $1); }
 	|	'&' variable
-			{ $$ = zend_ast_create_ex(ZEND_AST_ARRAY_ELEM, 1, $2, NULL); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_ARRAY_ELEM, 1, $2, NULL); }
 	|	expr T_DOUBLE_ARROW T_LIST '(' array_pair_list ')'
 			{ $5->attr = ZEND_ARRAY_SYNTAX_LIST;
-			  $$ = zend_ast_create(ZEND_AST_ARRAY_ELEM, $5, $1); }
+			  $$ = zend_ast_create(&@$, ZEND_AST_ARRAY_ELEM, $5, $1); }
 	|	T_LIST '(' array_pair_list ')'
 			{ $3->attr = ZEND_ARRAY_SYNTAX_LIST;
-			  $$ = zend_ast_create(ZEND_AST_ARRAY_ELEM, $3, NULL); }
+			  $$ = zend_ast_create(&@$, ZEND_AST_ARRAY_ELEM, $3, NULL); }
 ;
 
 encaps_list:
@@ -1226,27 +1226,27 @@ encaps_list:
 	|	encaps_list T_ENCAPSED_AND_WHITESPACE
 			{ $$ = zend_ast_list_add($1, $2); }
 	|	encaps_var
-			{ $$ = zend_ast_create_list(1, ZEND_AST_ENCAPS_LIST, $1); }
+			{ $$ = zend_ast_create_list(&@$, 1, ZEND_AST_ENCAPS_LIST, $1); }
 	|	T_ENCAPSED_AND_WHITESPACE encaps_var
-			{ $$ = zend_ast_create_list(2, ZEND_AST_ENCAPS_LIST, $1, $2); }
+			{ $$ = zend_ast_create_list(&@$, 2, ZEND_AST_ENCAPS_LIST, $1, $2); }
 ;
 
 encaps_var:
 		T_VARIABLE
-			{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_VAR, $1); }
 	|	T_VARIABLE '[' encaps_var_offset ']'
-			{ $$ = zend_ast_create(ZEND_AST_DIM,
-			      zend_ast_create(ZEND_AST_VAR, $1), $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_DIM,
+			      zend_ast_create(&@$, ZEND_AST_VAR, $1), $3); }
 	|	T_VARIABLE T_OBJECT_OPERATOR T_STRING
-			{ $$ = zend_ast_create(ZEND_AST_PROP,
-			      zend_ast_create(ZEND_AST_VAR, $1), $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_PROP,
+			      zend_ast_create(&@$, ZEND_AST_VAR, $1), $3); }
 	|	T_DOLLAR_OPEN_CURLY_BRACES expr '}'
-			{ $$ = zend_ast_create(ZEND_AST_VAR, $2); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_VAR, $2); }
 	|	T_DOLLAR_OPEN_CURLY_BRACES T_STRING_VARNAME '}'
-			{ $$ = zend_ast_create(ZEND_AST_VAR, $2); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_VAR, $2); }
 	|	T_DOLLAR_OPEN_CURLY_BRACES T_STRING_VARNAME '[' expr ']' '}'
-			{ $$ = zend_ast_create(ZEND_AST_DIM,
-			      zend_ast_create(ZEND_AST_VAR, $2), $4); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_DIM,
+			      zend_ast_create(&@$, ZEND_AST_VAR, $2), $4); }
 	|	T_CURLY_OPEN variable '}' { $$ = $2; }
 ;
 
@@ -1254,33 +1254,33 @@ encaps_var_offset:
 		T_STRING			{ $$ = $1; }
 	|	T_NUM_STRING		{ $$ = $1; }
 	|	'-' T_NUM_STRING 	{ $$ = zend_negate_num_string($2); }
-	|	T_VARIABLE			{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
+	|	T_VARIABLE			{ $$ = zend_ast_create(&@$, ZEND_AST_VAR, $1); }
 ;
 
 
 internal_functions_in_yacc:
 		T_ISSET '(' isset_variables possible_comma ')' { $$ = $3; }
-	|	T_EMPTY '(' expr ')' { $$ = zend_ast_create(ZEND_AST_EMPTY, $3); }
+	|	T_EMPTY '(' expr ')' { $$ = zend_ast_create(&@$, ZEND_AST_EMPTY, $3); }
 	|	T_INCLUDE expr
-			{ $$ = zend_ast_create_ex(ZEND_AST_INCLUDE_OR_EVAL, ZEND_INCLUDE, $2); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_INCLUDE_OR_EVAL, ZEND_INCLUDE, $2); }
 	|	T_INCLUDE_ONCE expr
-			{ $$ = zend_ast_create_ex(ZEND_AST_INCLUDE_OR_EVAL, ZEND_INCLUDE_ONCE, $2); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_INCLUDE_OR_EVAL, ZEND_INCLUDE_ONCE, $2); }
 	|	T_EVAL '(' expr ')'
-			{ $$ = zend_ast_create_ex(ZEND_AST_INCLUDE_OR_EVAL, ZEND_EVAL, $3); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_INCLUDE_OR_EVAL, ZEND_EVAL, $3); }
 	|	T_REQUIRE expr
-			{ $$ = zend_ast_create_ex(ZEND_AST_INCLUDE_OR_EVAL, ZEND_REQUIRE, $2); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_INCLUDE_OR_EVAL, ZEND_REQUIRE, $2); }
 	|	T_REQUIRE_ONCE expr
-			{ $$ = zend_ast_create_ex(ZEND_AST_INCLUDE_OR_EVAL, ZEND_REQUIRE_ONCE, $2); }
+			{ $$ = zend_ast_create_ex(&@$, ZEND_AST_INCLUDE_OR_EVAL, ZEND_REQUIRE_ONCE, $2); }
 ;
 
 isset_variables:
 		isset_variable { $$ = $1; }
 	|	isset_variables ',' isset_variable
-			{ $$ = zend_ast_create(ZEND_AST_AND, $1, $3); }
+			{ $$ = zend_ast_create(&@$, ZEND_AST_AND, $1, $3); }
 ;
 
 isset_variable:
-		expr { $$ = zend_ast_create(ZEND_AST_ISSET, $1); }
+		expr { $$ = zend_ast_create(&@$, ZEND_AST_ISSET, $1); }
 ;
 
 %%

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -40,7 +40,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 	if (N) { \
 		(Res).start_line = YYRHSLOC(RHS, 1).start_line; \
 	} else { \
-		(Res).start_line = YYRHSLOC(RHS, 0).start_line; \
+		(Res).start_line = yylloc.start_line; \
 	} \
 } while (0)
 

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1233,7 +1233,7 @@ static void copy_heredoc_label_stack(void *void_heredoc_label)
 		goto skip_token; \
 	} while (0)
 
-int ZEND_FASTCALL lex_scan(zval *zendlval, zend_parser_stack_elem *elem)
+int ZEND_FASTCALL lex_scan(zval *zendlval, zend_parser_stack_elem *elem, zend_ast_loc *loc)
 {
 int token;
 int offset;
@@ -2363,9 +2363,10 @@ skip_escape_conversion:
 		while (heredoc_nesting_level) {
 			zval zv;
 			int retval;
+            zend_ast_loc loc;
 
 			ZVAL_UNDEF(&zv);
-			retval = lex_scan(&zv, NULL);
+			retval = lex_scan(&zv, NULL, &loc);
 			zval_ptr_dtor_nogc(&zv);
 
 			if (EG(exception)) {
@@ -2773,16 +2774,16 @@ emit_token_with_str:
 
 emit_token_with_val:
 	if (PARSER_MODE()) {
-		zend_ast_loc loc;
-		loc.start_line = start_line;
 		ZEND_ASSERT(Z_TYPE_P(zendlval) != IS_UNDEF);
-		elem->ast = zend_ast_create_zval(&loc, zendlval);
+		loc->start_line = start_line;
+		elem->ast = zend_ast_create_zval(loc, zendlval);
 	}
 
 emit_token:
 	if (SCNG(on_event)) {
 		SCNG(on_event)(ON_TOKEN, token, start_line, SCNG(on_event_context));
 	}
+    loc->start_line = start_line;
 	return token;
 
 return_whitespace:
@@ -2794,6 +2795,7 @@ return_whitespace:
 		start_line = CG(zend_lineno);
 		goto restart;
 	} else {
+        loc->start_line = start_line;
 		return T_WHITESPACE;
 	}
 

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -567,7 +567,6 @@ ZEND_API int open_file_for_scanning(zend_file_handle *file_handle)
 	}
 
 	RESET_DOC_COMMENT();
-	CG(increment_lineno) = 0;
 	return SUCCESS;
 }
 END_EXTERN_C()
@@ -720,7 +719,6 @@ ZEND_API int zend_prepare_string_for_scanning(zval *str, char *filename)
 	zend_set_compiled_filename(new_compiled_filename);
 	zend_string_release_ex(new_compiled_filename, 0);
 	CG(zend_lineno) = 1;
-	CG(increment_lineno) = 0;
 	RESET_DOC_COMMENT();
 	return SUCCESS;
 }
@@ -2126,7 +2124,7 @@ inline_char_handler:
 <ST_IN_SCRIPTING>"?>"{NEWLINE}? {
 	BEGIN(INITIAL);
 	if (yytext[yyleng-1] != '>') {
-		CG(increment_lineno) = 1;
+		CG(zend_lineno)++;
 	}
 	if (PARSER_MODE()) {
 		RETURN_TOKEN(';');  /* implicit ';' at php-end tag */
@@ -2404,7 +2402,6 @@ skip_escape_conversion:
 
 		zend_restore_lexical_state(&current_state);
 		SCNG(heredoc_scan_ahead) = 0;
-		CG(increment_lineno) = 0;
 	}
 
 	RETURN_TOKEN(T_START_HEREDOC);
@@ -2604,8 +2601,6 @@ double_quotes_scan_done:
 						newline = 1;
 					}
 
-					CG(increment_lineno) = 1; /* For newline before label */
-
 					if (SCNG(heredoc_scan_ahead)) {
 						SCNG(heredoc_indentation) = indentation;
 						SCNG(heredoc_indentation_uses_spaces) = (spacing == HEREDOC_USING_SPACES);
@@ -2666,6 +2661,9 @@ heredoc_scan_done:
 		HANDLE_NEWLINES(yytext, yyleng - newline);
 	}
 
+    if (newline) {
+        CG(zend_lineno)++;
+    }
 	RETURN_TOKEN_WITH_VAL(T_ENCAPSED_AND_WHITESPACE);
 }
 
@@ -2725,8 +2723,6 @@ heredoc_scan_done:
 						newline = 1;
 					}
 
-					CG(increment_lineno) = 1; /* For newline before label */
-
 					YYCURSOR -= indentation;
 					heredoc_label->indentation = indentation;
 
@@ -2754,6 +2750,9 @@ nowdoc_scan_done:
 	}
 
 	HANDLE_NEWLINES(yytext, yyleng - newline);
+    if (newline) {
+        CG(zend_lineno)++;
+    }
 	RETURN_TOKEN_WITH_VAL(T_ENCAPSED_AND_WHITESPACE);
 }
 

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -2773,8 +2773,10 @@ emit_token_with_str:
 
 emit_token_with_val:
 	if (PARSER_MODE()) {
+		zend_ast_loc loc;
+		loc.start_line = start_line;
 		ZEND_ASSERT(Z_TYPE_P(zendlval) != IS_UNDEF);
-		elem->ast = zend_ast_create_zval_with_lineno(zendlval, start_line);
+		elem->ast = zend_ast_create_zval(&loc, zendlval);
 	}
 
 emit_token:

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -127,8 +127,8 @@ static zend_bool tokenize(zval *return_value, zend_string *source)
 	zval source_zval;
 	zend_lex_state original_lex_state;
 	zval token;
+	zend_ast_loc loc;
 	int token_type;
-	int token_line = 1;
 	int need_tokens = -1; /* for __halt_compiler lexing. -1 = disabled */
 
 	ZVAL_STR_COPY(&source_zval, source);
@@ -142,8 +142,8 @@ static zend_bool tokenize(zval *return_value, zend_string *source)
 	LANG_SCNG(yy_state) = yycINITIAL;
 	array_init(return_value);
 
-	while ((token_type = lex_scan(&token, NULL))) {
-		add_token(return_value, token_type, zendtext, zendleng, token_line);
+	while ((token_type = lex_scan(&token, NULL, &loc))) {
+		add_token(return_value, token_type, zendtext, zendleng, loc.start_line);
 
 		if (Z_TYPE(token) != IS_UNDEF) {
 			zval_ptr_dtor_nogc(&token);
@@ -159,7 +159,7 @@ static zend_bool tokenize(zval *return_value, zend_string *source)
 				/* fetch the rest into a T_INLINE_HTML */
 				if (zendcursor != zendlimit) {
 					add_token(return_value, T_INLINE_HTML,
-						zendcursor, zendlimit - zendcursor, token_line);
+						zendcursor, zendlimit - zendcursor, loc.start_line);
 				}
 				break;
 			}
@@ -171,8 +171,6 @@ static zend_bool tokenize(zval *return_value, zend_string *source)
 			CG(zend_lineno)++;
 			CG(increment_lineno) = 0;
 		}
-
-		token_line = CG(zend_lineno);
 	}
 
 	zval_ptr_dtor_str(&source_zval);

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -166,11 +166,6 @@ static zend_bool tokenize(zval *return_value, zend_string *source)
 		} else if (token_type == T_HALT_COMPILER) {
 			need_tokens = 3;
 		}
-
-		if (CG(increment_lineno)) {
-			CG(zend_lineno)++;
-			CG(increment_lineno) = 0;
-		}
 	}
 
 	zval_ptr_dtor_str(&source_zval);


### PR DESCRIPTION
This switches the location tracking for AST nodes from some custom code based on CG(zend_lineno) to using bison location tracking.

What we were doing before is to take the zend_lineno (end line of a token) of the first available AST child node, or the current zend_lineno if there is none. This mostly works out okay, but is not fully precise, rather convoluted and not extensible. If we ever want to have additional information (such as precise offsets), the current approach will no longer work.

This patch instead uses the native location tracking provided by bison. Similar to AST nodes, locations are kept on a separate stack. Right now the location is just the start line number, but this can now be easily extended.

All the AST constructors now take `zend_ast_loc*` as the first argument, which is passed as `&@$` (in most cases) on the bison side.