### PR TITLE
Object gc not working in shutdown

### DIFF
--- a/Zend/tests/object_gc_in_shutdown.phpt
+++ b/Zend/tests/object_gc_in_shutdown.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug object gc not working in shutdown
+--FILE--
+<?php
+ini_set('memory_limit', '2M');
+register_shutdown_function(function () {
+    for ($n = 1000 * 1000; $n--;) {
+        new stdClass;
+    }
+    echo "OK\n";
+});
+?>
+--EXPECT--
+OK

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -232,9 +232,9 @@ struct _zend_executor_globals {
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };
 
-#define EG_FLAGS_INITIAL	           (0)
-#define EG_FLAGS_IN_SHUTDOWN	       (1<<0)
-#define EG_FLAGS_OBJECT_STORE_NO_REUSE (1<<1)
+#define EG_FLAGS_INITIAL				(0)
+#define EG_FLAGS_IN_SHUTDOWN			(1<<0)
+#define EG_FLAGS_OBJECT_STORE_NO_REUSE	(1<<1)
 
 struct _zend_ini_scanner_globals {
 	zend_file_handle *yy_in;

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -232,8 +232,9 @@ struct _zend_executor_globals {
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };
 
-#define EG_FLAGS_INITIAL	0x00
-#define EG_FLAGS_IN_SHUTDOWN	0x01
+#define EG_FLAGS_INITIAL	           (0)
+#define EG_FLAGS_IN_SHUTDOWN	       (1<<0)
+#define EG_FLAGS_OBJECT_STORE_NO_REUSE (1<<1)
 
 struct _zend_ini_scanner_globals {
 	zend_file_handle *yy_in;

--- a/Zend/zend_objects_API.c
+++ b/Zend/zend_objects_API.c
@@ -140,7 +140,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_put(zend_object *object)
 {
 	int handle;
 
-	/* When in shutdown sequesnce - do not reuse previously freed handles, to make sure
+	/* When in shutdown sequence - do not reuse previously freed handles, to make sure
 	 * the dtors for newly created objects are called in zend_objects_store_call_destructors() loop
 	 */
 	if (EG(objects_store).free_list_head != -1 && EXPECTED(!(EG(flags) & EG_FLAGS_IN_SHUTDOWN))) {

--- a/Zend/zend_objects_API.c
+++ b/Zend/zend_objects_API.c
@@ -41,7 +41,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_destroy(zend_objects_store *objec
 
 ZEND_API void ZEND_FASTCALL zend_objects_store_call_destructors(zend_objects_store *objects)
 {
-    EG(flags) |= EG_FLAGS_OBJECT_STORE_NO_REUSE;
+	EG(flags) |= EG_FLAGS_OBJECT_STORE_NO_REUSE;
 	if (objects->top > 1) {
 		uint32_t i;
 		for (i = 1; i < objects->top; i++) {

--- a/Zend/zend_objects_API.c
+++ b/Zend/zend_objects_API.c
@@ -41,6 +41,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_destroy(zend_objects_store *objec
 
 ZEND_API void ZEND_FASTCALL zend_objects_store_call_destructors(zend_objects_store *objects)
 {
+    EG(flags) |= EG_FLAGS_OBJECT_STORE_NO_REUSE;
 	if (objects->top > 1) {
 		uint32_t i;
 		for (i = 1; i < objects->top; i++) {
@@ -143,7 +144,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_store_put(zend_object *object)
 	/* When in shutdown sequence - do not reuse previously freed handles, to make sure
 	 * the dtors for newly created objects are called in zend_objects_store_call_destructors() loop
 	 */
-	if (EG(objects_store).free_list_head != -1 && EXPECTED(!(EG(flags) & EG_FLAGS_IN_SHUTDOWN))) {
+	if (EG(objects_store).free_list_head != -1 && EXPECTED(!(EG(flags) & EG_FLAGS_OBJECT_STORE_NO_REUSE))) {
 		handle = EG(objects_store).free_list_head;
 		EG(objects_store).free_list_head = GET_OBJ_BUCKET_NUMBER(EG(objects_store).object_buckets[handle]);
 	} else if (UNEXPECTED(EG(objects_store).top == EG(objects_store).size)) {


### PR DESCRIPTION
just:
```php
ini_set('memory_limit', '2M');
register_shutdown_function(function () {
    for ($n = 1000 * 1000; $n--;) {
        new stdClass;
    }
    echo "OK\n";
});
```

we will get:
```php
Fatal error: Allowed memory size of 2097152 bytes exhausted at xxx
```

This is a fatal mistake, I was so shot down by that... in swoole extension, when developers forget to call `Swoole\Event::wait`, swoole will start the event loop by `register_shutdown_function` (we always rely on it when we write a simple script), I spent a lot of time to track it today,  but no memory detection tool can detect memory leaks, so I have to suspect that ZendVM has a logic error.


At first, just to save a bit of memory...
```C
ZEND_TLS zend_objects_store_no_reuse; /* Would make more sense to make it a member of zend_objects_store, defining as a global to not break alignments */
```
then someone changed it in the wrong way...
https://github.com/php/php-src/commit/1b1399c95d1358b23f234c14e84dda9b5007904e

If I understand correctly, the purpose of this flag is just to ensure that the `handle` would not be reused when calling `zend_objects_store_call_destructors ` ...
