### PR TITLE
Enhance build checking script

### DIFF
--- a/build/buildcheck.sh
+++ b/build/buildcheck.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 #  +----------------------------------------------------------------------+
 #  | PHP Version 7                                                        |
@@ -16,6 +16,9 @@
 #  | Authors: Stig Bakken <ssb@php.net>                                   |
 #  |          Sascha Schumann <sascha@schumann.cx>                        |
 #  +----------------------------------------------------------------------+
+#
+# Checks if autoconf is installed and version matches the minimum defined in the
+# configure.ac file.
 
 echo "buildconf: checking installation..."
 
@@ -26,15 +29,14 @@ if test -z "$PHP_AUTOCONF"; then
   PHP_AUTOCONF='autoconf'
 fi
 
-# Get required Autoconf version from the configure.ac
-required_version=$(sed -n 's/AC_PREREQ(\[\(.*\)\])/\1/p' configure.ac)
-set -f; IFS='.'
-set -- $required_version
-required_num="$(expr ${1} \* 10000 + ${2} \* 100)"
-set +f; unset IFS
+# Go to project root.
+cd $(CDPATH= cd -- "$(dirname -- "$0")/../" && pwd -P)
 
-# Check autoconf version
-ac_version=`$PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//'`
+# Get required autoconf version from the configure.ac file.
+required_version=$(sed -n 's/AC_PREREQ(\[\(.*\)\])/\1/p' configure.ac)
+
+# Check if autoconf exists.
+ac_version=$($PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//')
 if test -z "$ac_version"; then
   echo "buildconf: autoconf not found." >&2
   echo "           You need autoconf version $required_version or newer installed" >&2
@@ -42,7 +44,11 @@ if test -z "$ac_version"; then
   exit 1
 fi
 
-IFS=.; set $ac_version; IFS=' '
+# Check autoconf version.
+set -f; IFS='.'; set -- $required_version; set +f; IFS=' '
+required_num="$(expr ${1} \* 10000 + ${2} \* 100)"
+
+set -f; IFS='.'; set -- $ac_version; set +f; IFS=' '
 ac_version_num="$(expr ${1} \* 10000 + ${2} \* 100)"
 
 if test "$ac_version_num" -lt "$required_num"; then

--- a/build/buildcheck.sh
+++ b/build/buildcheck.sh
@@ -24,9 +24,7 @@ echo "buildconf: checking installation..."
 stamp=$1
 
 # Allow the autoconf executable to be overridden by $PHP_AUTOCONF.
-if test -z "$PHP_AUTOCONF"; then
-  PHP_AUTOCONF='autoconf'
-fi
+PHP_AUTOCONF=${PHP_AUTOCONF:-autoconf}
 
 # Go to project root.
 cd $(CDPATH= cd -- "$(dirname -- "$0")/../" && pwd -P)
@@ -60,5 +58,3 @@ else
 fi
 
 test -n "$stamp" && touch $stamp
-
-exit 0

--- a/build/buildcheck.sh
+++ b/build/buildcheck.sh
@@ -17,8 +17,7 @@
 #  |          Sascha Schumann <sascha@schumann.cx>                        |
 #  +----------------------------------------------------------------------+
 #
-# Checks if autoconf is installed and version matches the minimum defined in the
-# configure.ac file.
+# Check if autoconf exists and matches minimum required version in configure.ac.
 
 echo "buildconf: checking installation..."
 

--- a/build/buildcheck.sh
+++ b/build/buildcheck.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
+#
 #  +----------------------------------------------------------------------+
 #  | PHP Version 7                                                        |
 #  +----------------------------------------------------------------------+
@@ -25,22 +26,32 @@ if test -z "$PHP_AUTOCONF"; then
   PHP_AUTOCONF='autoconf'
 fi
 
-# autoconf 2.68 or newer
+# Get required Autoconf version from the configure.ac
+required_version=$(sed -n 's/AC_PREREQ(\[\(.*\)\])/\1/p' configure.ac)
+set -f; IFS='.'
+set -- $required_version
+required_num="$(expr ${1} \* 10000 + ${2} \* 100)"
+set +f; unset IFS
+
+# Check autoconf version
 ac_version=`$PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//'`
 if test -z "$ac_version"; then
-echo "buildconf: autoconf not found." >&2
-echo "           You need autoconf version 2.68 or newer installed" >&2
-echo "           to build PHP from Git." >&2
-exit 1
+  echo "buildconf: autoconf not found." >&2
+  echo "           You need autoconf version $required_version or newer installed" >&2
+  echo "           to build PHP from Git." >&2
+  exit 1
 fi
+
 IFS=.; set $ac_version; IFS=' '
-if test "$1" = "2" -a "$2" -lt "68" || test "$1" -lt "2"; then
-echo "buildconf: autoconf version $ac_version found." >&2
-echo "           You need autoconf version 2.68 or newer installed" >&2
-echo "           to build PHP from Git." >&2
-exit 1
+ac_version_num="$(expr ${1} \* 10000 + ${2} \* 100)"
+
+if test "$ac_version_num" -lt "$required_num"; then
+  echo "buildconf: autoconf version $ac_version found." >&2
+  echo "           You need autoconf version $required_version or newer installed" >&2
+  echo "           to build PHP from Git." >&2
+  exit 1
 else
-echo "buildconf: autoconf version $ac_version (ok)"
+  echo "buildconf: autoconf version $ac_version (ok)"
 fi
 
 test -n "$stamp" && touch $stamp

--- a/build/buildcheck.sh
+++ b/build/buildcheck.sh
@@ -17,7 +17,19 @@
 #  |          Sascha Schumann <sascha@schumann.cx>                        |
 #  +----------------------------------------------------------------------+
 #
-# Check if autoconf exists and matches minimum required version in configure.ac.
+# Check PHP build system tools such as autoconf and their versions.
+#
+# SYNOPSIS:
+#   buildcheck.sh [stampfile]
+#
+# DESCRIPTION:
+#   Optional stampfile is for Makefile to check build system only once.
+#
+# ENVIRONMENT:
+#   The following optional variables are supported:
+#
+#   PHP_AUTOCONF    Overrides the path to autoconf tool.
+#                   PHP_AUTOCONF=/path/to/autoconf buildcheck.sh
 
 echo "buildconf: checking installation..."
 
@@ -29,28 +41,28 @@ PHP_AUTOCONF=${PHP_AUTOCONF:-autoconf}
 # Go to project root.
 cd $(CDPATH= cd -- "$(dirname -- "$0")/../" && pwd -P)
 
-# Get required autoconf version from the configure.ac file.
-required_version=$(sed -n 's/AC_PREREQ(\[\(.*\)\])/\1/p' configure.ac)
+# Get minimum required autoconf version from the configure.ac file.
+min_version=$(sed -n 's/AC_PREREQ(\[\(.*\)\])/\1/p' configure.ac)
 
 # Check if autoconf exists.
 ac_version=$($PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//')
+
 if test -z "$ac_version"; then
   echo "buildconf: autoconf not found." >&2
-  echo "           You need autoconf version $required_version or newer installed" >&2
+  echo "           You need autoconf version $min_version or newer installed" >&2
   echo "           to build PHP from Git." >&2
   exit 1
 fi
 
 # Check autoconf version.
-set -f; IFS='.'; set -- $required_version; set +f; IFS=' '
-required_num="$(expr ${1} \* 10000 + ${2} \* 100)"
-
 set -f; IFS='.'; set -- $ac_version; set +f; IFS=' '
 ac_version_num="$(expr ${1} \* 10000 + ${2} \* 100)"
+set -f; IFS='.'; set -- $min_version; set +f; IFS=' '
+min_version_num="$(expr ${1} \* 10000 + ${2} \* 100)"
 
-if test "$ac_version_num" -lt "$required_num"; then
+if test "$ac_version_num" -lt "$min_version_num"; then
   echo "buildconf: autoconf version $ac_version found." >&2
-  echo "           You need autoconf version $required_version or newer installed" >&2
+  echo "           You need autoconf version $min_version or newer installed" >&2
   echo "           to build PHP from Git." >&2
   exit 1
 else


### PR DESCRIPTION
With this, the required Autoconf version is now defined only on two places:
- configure.ac
- scripts/phpize.m4