### PR TITLE
Fixes #77765: Set mode 40755 for directories, via FTP stream stat

### DIFF
--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -805,7 +805,7 @@ static int php_stream_ftp_url_stat(php_stream_wrapper *wrapper, const char *url,
 	if (result < 200 || result > 299) {
 		ssb->sb.st_mode |= S_IFREG;
 	} else {
-		ssb->sb.st_mode |= S_IFDIR;
+		ssb->sb.st_mode |= S_IFDIR | S_IXUSR | S_IXGRP | S_IXOTH;
 	}
 
 	php_stream_write_string(stream, "TYPE I\r\n"); /* we need this since some servers refuse to accept SIZE command in ASCII mode */

--- a/ext/standard/tests/streams/bug77765.phpt
+++ b/ext/standard/tests/streams/bug77765.phpt
@@ -1,0 +1,22 @@
+--TEST--
+stat() on directory should return 40755 for ftp://
+--SKIPIF--
+<?php
+if (array_search('ftp',stream_get_wrappers()) === FALSE) die("skip ftp wrapper not available.");
+if (!function_exists('pcntl_fork')) die("skip pcntl_fork() not available.");
+?>
+--FILE--
+<?php
+
+require __DIR__ . "/../../../ftp/tests/server.inc";
+
+$path = "ftp://localhost:" . $port."/www";
+
+var_dump(stat($path)['mode']);
+?>
+==DONE==
+--EXPECTF--
+string(11) "SIZE /www
+"
+int(16877)
+==DONE==


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=77765

Because we already manage to `CWD` into the current directory, we should set `40755` as mode, instead of `40644`.

In tests
```php
decoct(16877) == 40755
```