### PR TITLE
Upgrade deprecated directives and use non-posix bison

### DIFF
--- a/ext/json/json_parser.y
+++ b/ext/json/json_parser.y
@@ -47,7 +47,7 @@ int json_yydebug = 1;
 }
 
 %pure-parser
-%name-prefix "php_json_yy"
+%define api.prefix {php_json_yy}
 %lex-param  { php_json_parser *parser  }
 %parse-param { php_json_parser *parser }
 

--- a/sapi/phpdbg/phpdbg_parser.y
+++ b/sapi/phpdbg/phpdbg_parser.y
@@ -29,7 +29,7 @@ ZEND_EXTERN_MODULE_GLOBALS(phpdbg)
 %}
 
 %pure-parser
-%error-verbose
+%define parse.error verbose
 
 %code requires {
 #include "phpdbg.h"

--- a/scripts/dev/genfiles
+++ b/scripts/dev/genfiles
@@ -35,7 +35,7 @@
 
 # Parser generator
 YACC=${YACC:-bison}
-YACC="$YACC -y -l"
+YACC="$YACC -l"
 
 # Lexer generator
 RE2C=${RE2C:-re2c}


### PR DESCRIPTION
With Bison 3.0 some directives are deprecated:
- %name-prefix "x" should be %define api.prefix {x}
- %error-verbose should be %define parse.error verbose

Bison 3.3 also started emiting more warnings and since PHP souce parsers
are not POSIX compliant this patch fixes this as pointed out via
495a46aa1dc564656bf919cb49aae48a31ae15f4.

Warnings can be reproduced with:
./scripts/dev/genfiles and using bison 3.3+ version...

This is not done as a bugfix for PHP-7.2+ because PHP up to PHP-7.3 have these files bundled in the Git and releases.

Now, I'm not sure if following POSIX in this case should be done but I think there are quite a lot of parsers code written without watching on this...