### PR TITLE
Fix #77680: Correctly implement recursive mkdir on FTP stream

### DIFF
--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -289,8 +289,13 @@ if ($pid) {
             }
 
 		}elseif (preg_match("~^CWD ([A-Za-z./]+)\r\n$~", $buf, $m)) {
-			change_dir($m[1]);
-			fputs($s, "250 CWD command successful.\r\n");
+			if (isset($bug77680)) {
+				fputs($s, "550 Directory change to $m[1] failed: file does not exist\r\n");
+				var_dump($buf);
+			} else {
+				change_dir($m[1]);
+				fputs($s, "250 CWD command successful.\r\n");
+			}
 
 		} elseif (preg_match("~^NLST(?: ([A-Za-z./]+))?\r\n$~", $buf, $m)) {
 
@@ -332,6 +337,9 @@ if ($pid) {
 			if (isset($bug7216)) {
 				fputs($s, "257 OK.\r\n");
 			} else {
+				if (isset($bug77680)) {
+					var_dump($buf);
+				}
 				fputs($s, "257 \"/path/to/ftproot$cwd$m[1]\" created.\r\n");
 			}
 

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -1070,6 +1070,9 @@ static int php_stream_ftp_mkdir(php_stream_wrapper *wrapper, const char *url, in
 
         /* find a top level directory we need to create */
         while ((p = strrchr(buf, '/'))) {
+            if (p == buf) {
+                break;
+            }
             *p = '\0';
 			php_stream_printf(stream, "CWD %s\r\n", buf);
 			result = GET_FTP_RESULT(stream);

--- a/ext/standard/tests/streams/bug77680.phpt
+++ b/ext/standard/tests/streams/bug77680.phpt
@@ -11,15 +11,25 @@ $bug77680=1;
 
 require __DIR__ . "/../../../ftp/tests/server.inc";
 
-$path = "ftp://localhost:" . $port."/one/two/three";
+$path = "ftp://localhost:" . $port."/one/two/three/";
 mkdir($path, 0755, true);
 
 ?>
 ==DONE==
 --EXPECTF--
+string(20) "CWD /one/two/three
+"
 string(14) "CWD /one/two
 "
 string(10) "CWD /one
+"
+string(7) "CWD /
+"
+string(7) "MKD /
+"
+string(10) "MKD /one
+"
+string(14) "MKD /one/two
 "
 string(20) "MKD /one/two/three
 "

--- a/ext/standard/tests/streams/bug77680.phpt
+++ b/ext/standard/tests/streams/bug77680.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Recursive mkdir() on ftp should create missing directories.
+--SKIPIF--
+<?php
+if (array_search('ftp',stream_get_wrappers()) === FALSE) die("skip ftp wrapper not available.");
+if (!function_exists('pcntl_fork')) die("skip pcntl_fork() not available.");
+?>
+--FILE--
+<?php
+$bug77680=1;
+
+require __DIR__ . "/../../../ftp/tests/server.inc";
+
+$path = "ftp://localhost:" . $port."/one/two/three";
+mkdir($path, 0755, true);
+
+?>
+==DONE==
+--EXPECTF--
+string(14) "CWD /one/two
+"
+string(10) "CWD /one
+"
+string(20) "MKD /one/two/three
+"
+==DONE==


### PR DESCRIPTION
Fixes [#77680](https://bugs.php.net/bug.php?id=77680).

If the root directory was missing, an extra `CWD` without arguments was made. Also, the`MKD` contained an empty string.

The current behavior will stop and issue the last `CWD` with the root directory as an argument. The following `MKD` will have the full path as an argument.