### PR TITLE
Refactor AC_INIT in configure.ac and PHP versions

### DIFF
--- a/buildconf
+++ b/buildconf
@@ -9,7 +9,7 @@ debug=0
 # Go to project root.
 cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 
-php_extra_version=$(grep '^AC_INIT(\[' configure.ac)
+php_extra_version=$(grep '^AC_INIT(' configure.ac)
 case "$php_extra_version" in
   *-dev*)
     dev=1

--- a/buildconf
+++ b/buildconf
@@ -9,9 +9,9 @@ debug=0
 # Go to project root.
 cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 
-eval $(grep '^PHP_EXTRA_VERSION=' configure.ac)
-case "$PHP_EXTRA_VERSION" in
-  *-dev)
+php_extra_version=$(grep '^AC_INIT(\[' configure.ac)
+case "$php_extra_version" in
+  *-dev*)
     dev=1
     ;;
   *)

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ dnl Basic autoconf initialization, generation of config.nice.
 dnl -------------------------------------------------------------------------
 
 AC_PREREQ([2.68])
-AC_INIT([PHP], [7.4.0-dev], [https://bugs.php.net], [php], [https://www.php.net])
+AC_INIT([PHP],[7.4.0-dev],[https://bugs.php.net],[php],[https://www.php.net])
 AC_CONFIG_SRCDIR([main/php_version.h])
 AC_CONFIG_AUX_DIR([build])
 AC_PRESERVE_HELP_ORDER

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,8 @@ dnl Basic autoconf initialization, generation of config.nice.
 dnl -------------------------------------------------------------------------
 
 AC_PREREQ([2.68])
-AC_INIT([main/php_version.h])
+AC_INIT([PHP], [7.4.0-dev], [https://bugs.php.net], [php], [https://www.php.net])
+AC_CONFIG_SRCDIR([main/php_version.h])
 AC_CONFIG_AUX_DIR([build])
 AC_PRESERVE_HELP_ORDER
 
@@ -99,10 +100,13 @@ extern "C++" {
 #endif /* PHP_CONFIG_H */
 ])
 
-PHP_MAJOR_VERSION=7
-PHP_MINOR_VERSION=4
-PHP_RELEASE_VERSION=0
-PHP_EXTRA_VERSION="-dev"
+ac_IFS=$IFS; IFS="."
+set $(echo AC_PACKAGE_VERSION | $SED 's/\([[0-9\.]]*\)\(.*\)/\1\.\2/')
+IFS=$ac_IFS
+PHP_MAJOR_VERSION=[$]1
+PHP_MINOR_VERSION=[$]2
+PHP_RELEASE_VERSION=[$]3
+PHP_EXTRA_VERSION=[$]4
 PHP_VERSION="$PHP_MAJOR_VERSION.$PHP_MINOR_VERSION.$PHP_RELEASE_VERSION$PHP_EXTRA_VERSION"
 PHP_VERSION_ID=`expr [$]PHP_MAJOR_VERSION \* 10000 + [$]PHP_MINOR_VERSION \* 100 + [$]PHP_RELEASE_VERSION`
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -65,7 +65,7 @@ credits files in ext/standard.
 
 4. Checkout the release branch for this release (e.g., PHP-5.4.2) from the main branch.
 
-5. Bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac``, ``scripts/phpize.m4`` and possibly ``NEWS``.
+5. Bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac`` and possibly ``NEWS``.
 Do not use abbreviations for alpha and beta. Do not use dashes, you should
 ``#define PHP_VERSION "5.4.22RC1"`` and not ``#define PHP_VERSION "5.4.22-RC1"``
 
@@ -79,7 +79,7 @@ Do not use abbreviations for alpha and beta. Do not use dashes, you should
 9. Tag the repository release branch with the version, e.g.:
 ``git tag -u YOURKEYID php-5.4.2RC2``
 
-10. Bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac``, ``scripts/phpize.m4`` and ``NEWS``
+10. Bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac`` and ``NEWS``
 in the *main* branch (PHP-5.4 for example) to prepare for the **next** version.
 F.e. if the RC is "5.4.1RC1" then the new one should be "5.4.2-dev" - regardless if we get
 a new RC or not. This is to make sure ``version_compare()`` can correctly work.
@@ -162,7 +162,7 @@ Rolling a stable release
 ------------------------
 
 1. Checkout your release branch, you should have created when releasing previous RC
-and bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac``, ``scripts/phpize.m4`` and possibly ``NEWS``.
+and bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac`` and possibly ``NEWS``.
 
 2. If a CVE commit needs to be merged to the release, then have it committed to
 the base branches and merged upwards as usual (f.e commit the CVE fix to 5.3,
@@ -336,7 +336,7 @@ Forking a new release branch
 
 2. Just prior to cutting X.Y.0beta1, create the new branch locally.
    Add a commit on master after the branch point clearing the NEWS, UPGRADING
-   and UPGRADING.INTERNALS files, updating the version in configure.ac and scripts/phpize.m4 (run
+   and UPGRADING.INTERNALS files, updating the version in configure.ac (run
    ./configure to automatically update main/php_versions.h, too) and Zend/zend.h.
    Also list the new branch in CONTRIBUTING.md.
      Example: http://git.php.net/?p=php-src.git;a=commit;h=a63c99b

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -65,7 +65,7 @@ credits files in ext/standard.
 
 4. Checkout the release branch for this release (e.g., PHP-5.4.2) from the main branch.
 
-5. Bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac`` and possibly ``NEWS``.
+5. Bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac``, ``scripts/phpize.m4`` and possibly ``NEWS``.
 Do not use abbreviations for alpha and beta. Do not use dashes, you should
 ``#define PHP_VERSION "5.4.22RC1"`` and not ``#define PHP_VERSION "5.4.22-RC1"``
 
@@ -79,7 +79,7 @@ Do not use abbreviations for alpha and beta. Do not use dashes, you should
 9. Tag the repository release branch with the version, e.g.:
 ``git tag -u YOURKEYID php-5.4.2RC2``
 
-10. Bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac`` and ``NEWS``
+10. Bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac``, ``scripts/phpize.m4`` and ``NEWS``
 in the *main* branch (PHP-5.4 for example) to prepare for the **next** version.
 F.e. if the RC is "5.4.1RC1" then the new one should be "5.4.2-dev" - regardless if we get
 a new RC or not. This is to make sure ``version_compare()`` can correctly work.
@@ -162,7 +162,7 @@ Rolling a stable release
 ------------------------
 
 1. Checkout your release branch, you should have created when releasing previous RC
-and bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac`` and possibly ``NEWS``.
+and bump the version numbers in ``main/php_version.h``, ``Zend/zend.h``, ``configure.ac``, ``scripts/phpize.m4`` and possibly ``NEWS``.
 
 2. If a CVE commit needs to be merged to the release, then have it committed to
 the base branches and merged upwards as usual (f.e commit the CVE fix to 5.3,
@@ -336,7 +336,7 @@ Forking a new release branch
 
 2. Just prior to cutting X.Y.0beta1, create the new branch locally.
    Add a commit on master after the branch point clearing the NEWS, UPGRADING
-   and UPGRADING.INTERNALS files, updating the version in configure.ac (run
+   and UPGRADING.INTERNALS files, updating the version in configure.ac and scripts/phpize.m4 (run
    ./configure to automatically update main/php_versions.h, too) and Zend/zend.h.
    Also list the new branch in CONTRIBUTING.md.
      Example: http://git.php.net/?p=php-src.git;a=commit;h=a63c99b

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -1,7 +1,8 @@
 dnl This file becomes configure.ac for self-contained extensions.
 
 AC_PREREQ([2.68])
-AC_INIT(config.m4)
+AC_INIT([PHP], [7.4.0-dev], [https://bugs.php.net], [php], [https://www.php.net])
+AC_CONFIG_SRCDIR([config.m4])
 AC_CONFIG_AUX_DIR([build])
 AC_PRESERVE_HELP_ORDER
 

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -1,7 +1,7 @@
 dnl This file becomes configure.ac for self-contained extensions.
 
 AC_PREREQ([2.68])
-AC_INIT([PHP],[7.4.0-dev],[https://bugs.php.net],[php],[https://www.php.net])
+AC_INIT
 AC_CONFIG_SRCDIR([config.m4])
 AC_CONFIG_AUX_DIR([build])
 AC_PRESERVE_HELP_ORDER

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -1,7 +1,7 @@
 dnl This file becomes configure.ac for self-contained extensions.
 
 AC_PREREQ([2.68])
-AC_INIT([PHP], [7.4.0-dev], [https://bugs.php.net], [php], [https://www.php.net])
+AC_INIT([PHP],[7.4.0-dev],[https://bugs.php.net],[php],[https://www.php.net])
 AC_CONFIG_SRCDIR([config.m4])
 AC_CONFIG_AUX_DIR([build])
 AC_PRESERVE_HELP_ORDER

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -105,24 +105,17 @@ var PHP_VERSION_STRING = "7.3.0";
 function get_version_numbers()
 {
 	var cin = file_get_contents("configure.ac");
+	var regex = /AC_INIT\(\[PHP\], \[(\d+)\.(\d+)\.(\d+)([^\]]*)\],\ .+\)/g;
 
-	if (cin.match(new RegExp("PHP_MAJOR_VERSION=(\\d+)"))) {
+	if (cin.match(new RegExp(regex))) {
 		PHP_VERSION = RegExp.$1;
+		PHP_MINOR_VERSION = RegExp.$2;
+		PHP_RELEASE_VERSION = RegExp.$3;
+		PHP_EXTRA_VERSION = RegExp.$4;
 	}
-	if (cin.match(new RegExp("PHP_MINOR_VERSION=(\\d+)"))) {
-		PHP_MINOR_VERSION = RegExp.$1;
-	}
-	if (cin.match(new RegExp("PHP_RELEASE_VERSION=(\\d+)"))) {
-		PHP_RELEASE_VERSION = RegExp.$1;
-	}
-	PHP_VERSION_STRING = PHP_VERSION + "." + PHP_MINOR_VERSION + "." + PHP_RELEASE_VERSION;
 
-	if (cin.match(new RegExp("PHP_EXTRA_VERSION=\"([^\"]+)\""))) {
-		PHP_EXTRA_VERSION = RegExp.$1;
-		if (PHP_EXTRA_VERSION.length) {
-			PHP_VERSION_STRING += PHP_EXTRA_VERSION;
-		}
-	}
+	PHP_VERSION_STRING = PHP_VERSION + "." + PHP_MINOR_VERSION + "." + PHP_RELEASE_VERSION + PHP_EXTRA_VERSION;
+
 	DEFINE('PHP_VERSION_STRING', PHP_VERSION_STRING);
 }
 

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -105,7 +105,7 @@ var PHP_VERSION_STRING = "7.3.0";
 function get_version_numbers()
 {
 	var cin = file_get_contents("configure.ac");
-	var regex = /AC_INIT\(\[PHP\],\[(\d+)\.(\d+)\.(\d+)([^\]]*)\],.+\)/g;
+	var regex = /AC_INIT.+(\d+)\.(\d+)\.(\d+)([^\,^\]]*).+/g;
 
 	if (cin.match(new RegExp(regex))) {
 		PHP_VERSION = RegExp.$1;

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -105,7 +105,7 @@ var PHP_VERSION_STRING = "7.3.0";
 function get_version_numbers()
 {
 	var cin = file_get_contents("configure.ac");
-	var regex = /AC_INIT\(\[PHP\], \[(\d+)\.(\d+)\.(\d+)([^\]]*)\],\ .+\)/g;
+	var regex = /AC_INIT\(\[PHP\],\[(\d+)\.(\d+)\.(\d+)([^\]]*)\],.+\)/g;
 
 	if (cin.match(new RegExp(regex))) {
 		PHP_VERSION = RegExp.$1;


### PR DESCRIPTION
Hello, since Autoconf 2.53 the `AC_INIT` call has been refactored and now includes several other optional arguments to make installation experience a bit better.

This patch refactors AC_INIT and PHP version definition a bit.

Reference: https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html

~*Some more fixes coming up soon...*~

TODO:
* [x] Refactor `get_version_numbers` in win32/build/confutils.js
