### PR TITLE
Close file handles and add files to included files after opening

### DIFF
--- a/sapi/phpdbg/phpdbg_list.c
+++ b/sapi/phpdbg/phpdbg_list.c
@@ -287,6 +287,9 @@ zend_op_array *phpdbg_compile_file(zend_file_handle *file, int type) {
 	zend_hash_add_ptr(&PHPDBG_G(file_sources), ret->filename, dataptr);
 	phpdbg_resolve_pending_file_break(ZSTR_VAL(ret->filename));
 
+	if (file->opened_path) {
+		zend_hash_add_empty_element(&EG(included_files), file->opened_path);
+	}
 	fake.opened_path = NULL;
 	zend_destroy_file_handle(&fake);
 	zend_file_handle_dtor(&fake);
@@ -306,6 +309,7 @@ zend_op_array *phpdbg_init_compile_file(zend_file_handle *file, int type) {
 		if (file->opened_path) {
 			zend_string_release(file->opened_path);
 			file->opened_path = zend_string_init(filename, strlen(filename), 0);
+			zend_hash_add_empty_element(&EG(included_files), file->opened_path);
 		} else {
 			if (file->free_filename) {
 				efree((char *) file->filename);

--- a/sapi/phpdbg/phpdbg_list.c
+++ b/sapi/phpdbg/phpdbg_list.c
@@ -288,6 +288,7 @@ zend_op_array *phpdbg_compile_file(zend_file_handle *file, int type) {
 	phpdbg_resolve_pending_file_break(ZSTR_VAL(ret->filename));
 
 	fake.opened_path = NULL;
+	zend_destroy_file_handle(&fake);
 	zend_file_handle_dtor(&fake);
 
 	return ret;
@@ -315,6 +316,8 @@ zend_op_array *phpdbg_init_compile_file(zend_file_handle *file, int type) {
 	}
 
 	op_array = PHPDBG_G(init_compile_file)(file, type);
+	zend_destroy_file_handle(file);
+	zend_file_handle_dtor(file);
 
 	if (op_array == NULL) {
 		return NULL;

--- a/sapi/phpdbg/tests/bug76801-1.phpt
+++ b/sapi/phpdbg/tests/bug76801-1.phpt
@@ -1,0 +1,16 @@
+--TEST--
+get_included_files() tests
+--FILE--
+<?php
+
+file_put_contents(__DIR__ . '/bug76801-2.php', '<?php echo __LINE__;');
+require(__DIR__."/bug76801-2.php");
+file_put_contents(__DIR__ . '/bug76801-2.php', '<?php');
+
+echo "Done\n";
+?>
+--EXPECTF--
+1Done
+--CLEAN--
+<?php
+@unlink(__DIR__.'/bug76801-2.php');

--- a/sapi/phpdbg/tests/bug76801-2.inc
+++ b/sapi/phpdbg/tests/bug76801-2.inc
@@ -1,0 +1,3 @@
+<?php
+echo "Included\n";
+?>

--- a/sapi/phpdbg/tests/bug76801-2.phpt
+++ b/sapi/phpdbg/tests/bug76801-2.phpt
@@ -1,0 +1,44 @@
+--TEST--
+get_included_files() tests
+--FILE--
+<?php
+
+var_dump(get_included_files());
+
+include(__DIR__."/bug76801-2.inc");
+var_dump(get_included_files());
+
+include_once(__DIR__."/bug76801-2.inc");
+var_dump(get_included_files());
+
+include(__DIR__."/bug76801-2.inc");
+var_dump(get_included_files());
+
+echo "Done\n";
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  string(%d) "%s"
+}
+Included
+array(2) {
+  [0]=>
+  string(%d) "%s"
+  [1]=>
+  string(%d) "%s"
+}
+array(2) {
+  [0]=>
+  string(%d) "%s"
+  [1]=>
+  string(%d) "%s"
+}
+Included
+array(2) {
+  [0]=>
+  string(%d) "%s"
+  [1]=>
+  string(%d) "%s"
+}
+Done

--- a/sapi/phpdbg/tests/clean_001.phpt
+++ b/sapi/phpdbg/tests/clean_001.phpt
@@ -32,7 +32,7 @@ prompt> Do you really want to clean your current environment? (type y or n): Cle
 Classes    %d
 Functions  %d
 Constants  %d
-Includes   0
+Includes   1
 prompt> [Not running]
 prompt> 1
 [Breakpoint #0 at %s:4, hits: 1]

--- a/sapi/phpdbg/tests/info_001.phpt
+++ b/sapi/phpdbg/tests/info_001.phpt
@@ -48,7 +48,8 @@ prompt> ------------------------------------------------
 Function Breakpoints:
 #0		foo
 prompt> [User-defined constants (0)]
-prompt> [Included files: 0]
+prompt> [Included files: 1]
+File: %s/info_001.php
 prompt> [No error found!]
 prompt> [Literal Constants in foo() (2)]
 |-------- C0 -------> [var_dump]


### PR DESCRIPTION
Fixes bug #76801

Note: This patch largely came from @cmb69 but I discovered that the inclusion of that patch prevented the list of included files from being filled so I've fixed that too.


I also discovered whilst fixing the list of included files that the behaviour of `phpdbg` is different to that of `php` in that the original script being run was not included via `phpdbg` but is via `php`:

# Initial demonstration of files not closed
Script to demonstrate the issue of files not being closed:
```
<?php

for ($i = 0; $i < 10; $i++) {
    echo "Requiring setup for run {$i}\n";
    require_once('example.php');
}


$mypid = getmypid();
echo "\n";
echo "Take a look and see what's included:\n\n";
echo "lsof -p {$mypid}\n\n";
passthru("lsof -p {$mypid}");
```
# Demonstration of included files being incomplete

Test script:
---------------
```
<?php

require('example.php');
print_r(get_included_files());
```
Expected result:
---------------
```
Array
(
    [0] => /private/tmp/argh/test2.php
    [1] => /private/tmp/argh/example.php
)
```
Actual result with PHP:
---------------
```
php test2.php
Array
(
    [0] => /private/tmp/argh/test2.php
    [1] => /private/tmp/argh/example.php
)
```

Actual result with PHPDBG before this patch:
---------------
```
phpdbg -rr test2.php
[Welcome to phpdbg, the interactive PHP debugger, v0.5.0]
To get help using phpdbg type "help" and press enter
[Please report bugs to <http://bugs.php.net/report.php>]
Array
(
    [0] => /private/tmp/argh/example.php
)
```