### PR TITLE
Add support for PCRE partial matching

### DIFF
--- a/ext/pcre/tests/partial_match.phpt
+++ b/ext/pcre/tests/partial_match.phpt
@@ -1,0 +1,81 @@
+--TEST--
+PCRE partial matching
+--FILE--
+<?php
+
+function test($regex, $subject, $offsetCapture = false) {
+    $withOffsetCapture = $offsetCapture ? "with offset capture" : "";
+    echo "Match $regex against $subject$withOffsetCapture:\n";
+    $retval = preg_match($regex, $subject, $matches, $offsetCapture ? PREG_OFFSET_CAPTURE : 0);
+    if ($retval === 0) {
+        echo "No match.\n";
+    } else if ($retval === 1) {
+        if (preg_last_error() === PREG_PARTIAL_MATCH_ERROR) {
+            echo "Partial match: ";
+        } else {
+            echo "Full match: ";
+        }
+        var_dump($matches);
+    } else {
+        echo "Error: " . preg_last_error() . "\n";
+    }
+    echo "\n";
+}
+
+test('/dog(sbody)?/p', 'dog');
+test('/dog(sbody)?/P', 'dog');
+
+test('/baz(?<=barbaz)(?=quux)/p', 'abcfoobarbazqu');
+test('/abc(?<=äöüabc)(?=quux)/p', 'foobaräöüabcqu');
+
+test('/abc(?<=äöüabc)(?=quux)/p', 'foobaräöüabcqu', true);
+
+?>
+--EXPECT--
+Match /dog(sbody)?/p against dog:
+Full match: array(1) {
+  [0]=>
+  string(3) "dog"
+}
+
+Match /dog(sbody)?/P against dog:
+Partial match: array(2) {
+  [0]=>
+  string(3) "dog"
+  [1]=>
+  string(3) "dog"
+}
+
+Match /baz(?<=barbaz)(?=quux)/p against abcfoobarbazqu:
+Partial match: array(2) {
+  [0]=>
+  string(5) "bazqu"
+  [1]=>
+  string(11) "foobarbazqu"
+}
+
+Match /abc(?<=äöüabc)(?=quux)/p against foobaräöüabcqu:
+Partial match: array(2) {
+  [0]=>
+  string(5) "abcqu"
+  [1]=>
+  string(14) "baräöüabcqu"
+}
+
+Match /abc(?<=äöüabc)(?=quux)/p against foobaräöüabcquwith offset capture:
+Partial match: array(2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    string(5) "abcqu"
+    [1]=>
+    int(12)
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    string(14) "baräöüabcqu"
+    [1]=>
+    int(3)
+  }
+}

--- a/ext/pcre/tests/partial_match_all.phpt
+++ b/ext/pcre/tests/partial_match_all.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Partial matching can be used with preg_match_all() in PREG_SET_ORDER
+--FILE--
+<?php
+
+$str = "abc abc ab";
+var_dump(preg_match_all("/abc/P", $str));
+echo "\n";
+
+var_dump(preg_match_all("/abc/P", $str, $matches, PREG_SET_ORDER));
+var_dump(preg_last_error() == PREG_PARTIAL_MATCH_ERROR);
+var_dump($matches);
+
+?>
+--EXPECTF--
+Warning: preg_match_all(): Partial matching in preg_match_all() can only be used with PREG_SET_ORDER in %s on line %d
+NULL
+
+int(3)
+bool(true)
+array(3) {
+  [0]=>
+  array(1) {
+    [0]=>
+    string(3) "abc"
+  }
+  [1]=>
+  array(1) {
+    [0]=>
+    string(3) "abc"
+  }
+  [2]=>
+  array(2) {
+    [0]=>
+    string(2) "ab"
+    [1]=>
+    string(2) "ab"
+  }
+}

--- a/ext/pcre/tests/partial_match_unsupported.phpt
+++ b/ext/pcre/tests/partial_match_unsupported.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Partial matching is only supported by preg_match() and preg_match_all()
+--FILE--
+<?php
+
+$regex = '/abc/p';
+$subject = 'foobar ab';
+
+var_dump(preg_replace($regex, 'replacement', $subject));
+var_dump(preg_replace_callback($regex, function() {}, $subject));
+var_dump(preg_replace_callback_array([$regex => function() {}], $subject));
+
+var_dump(preg_grep($regex, [$subject]));
+var_dump(preg_filter($regex, 'replacement', [$subject]));
+var_dump(preg_split($regex, $subject));
+?>
+--EXPECTF--
+Warning: preg_replace(): Partial matching is not supported in %s on line %d
+NULL
+
+Warning: preg_replace_callback(): Partial matching is not supported in %s on line %d
+NULL
+
+Warning: preg_replace_callback_array(): Partial matching is not supported in %s on line %d
+NULL
+
+Warning: preg_grep(): Partial matching is not supported in %s on line %d
+NULL
+
+Warning: preg_filter(): Partial matching is not supported in %s on line %d
+array(0) {
+}
+
+Warning: preg_split(): Partial matching is not supported in %s on line %d
+bool(false)


### PR DESCRIPTION
This is requested in https://bugs.php.net/bug.php?id=77459. Relevant PCRE documentation is https://www.pcre.org/current/doc/html/pcre2partial.html. This is useful for streaming processing of data.

The implementation uses two new modifiers `/p` for soft partial matching and `/P` for hard partial matching. From the test output:

```
Match /dog(sbody)?/p against dog:
Full match: array(1) {
  [0]=>
  string(3) "dog"
}

Match /dog(sbody)?/P against dog:
Partial match: array(2) {
  [0]=>
  string(3) "dog"
  [1]=>
  string(3) "dog"
}
```

The main difference is that a soft partial match recognizes `dog` as a full match in the above example, while a hard partial match takes into account that a greedy match would prefer matching `dogsbody` against a longer string, so it only returns a partial match.

The return value of `preg_match()` is the same for partial matches as full matches (1). A partial match can be determined by checking `preg_last_error() == PREG_PARTIAL_MATCH_ERROR`.

The `$matches` array contains two elements: The first is the partial match (which will always be adjacent to the end of the string), while the second contains the part of the subject that might have been inspected to arrive at this partial change. In particular this includes the maximum lookbehind:

```
Match /baz(?<=barbaz)(?=quux)/p against abcfoobarbazqu:
Partial match: array(2) {
  [0]=>
  string(5) "bazqu"
  [1]=>
  string(11) "foobarbazqu"
}
```

In application this means that the next match with more data can be started from the position of `bazqu`, but the string starting from `foobarbazqu` potentially needs to be preserved for a successful match. (As the above example shows, this may be an overapproximation.)

The `$matches` output is also affected by the `PREG_OFFSET_CAPTURE` flag:

```
Match /abc(?<=äöüabc)(?=quux)/p against foobaräöüabcquwith offset capture:
Partial match: array(2) {
  [0]=>
  array(2) {
    [0]=>
    string(5) "abcqu"
    [1]=>
    int(12)
  }
  [1]=>
  array(2) {
    [0]=>
    string(14) "baräöüabcqu"
    [1]=>
    int(3)
  }
}
```

Partial matching can be used with `preg_match_all()` as well, but only if `PREG_SET_ORDER` is used. In this case, if after the match `preg_last_error() == PREG_PARTIAL_MATCH_ERROR`, then the last array in `$matches` will correspond to the trailing partial match and have the structure described above. All other matches before that will be full matches.

All other functions (like `preg_replace` etc) do not support partial matching and will generate a warning if used in conjunction with `/p` or `/P`.