### PR TITLE
Add support for PCRE callouts

### DIFF
--- a/ext/pcre/php_pcre.h
+++ b/ext/pcre/php_pcre.h
@@ -78,6 +78,9 @@ ZEND_BEGIN_MODULE_GLOBALS(pcre)
 	/* Used for unmatched subpatterns in OFFSET_CAPTURE mode */
 	zval unmatched_null_pair;
 	zval unmatched_empty_pair;
+	/* Callout support */
+	zend_fcall_info callout_fci;
+	zend_fcall_info_cache callout_fcc;
 ZEND_END_MODULE_GLOBALS(pcre)
 
 PHPAPI ZEND_EXTERN_MODULE_GLOBALS(pcre)

--- a/ext/pcre/tests/callout_basic.phpt
+++ b/ext/pcre/tests/callout_basic.phpt
@@ -1,0 +1,98 @@
+--TEST--
+Basic callout functionality
+--FILE--
+<?php
+
+preg_callout_function(function($info) {
+    var_dump($info);
+    return 0;
+});
+var_dump(preg_match('/((foo)(bar))(?C42)baz/', 'foobarbaz', $matches));
+var_dump($matches);
+
+preg_callout_function(function($info) {
+    var_dump($info["callout"]);
+    // Abort this path
+    return 1;
+});
+var_dump(preg_match('/foo(?C"name")bar|foo/', 'foobar', $matches));
+var_dump($matches);
+
+preg_callout_function(function($info) {
+    var_dump($info["callout"]);
+    // Abort whole match
+    return -1;
+});
+var_dump(preg_match('/foo(?C"name")bar|foo/', 'foobar', $matches));
+var_dump($matches);
+
+?>
+--EXPECT--
+array(8) {
+  ["callout"]=>
+  int(42)
+  ["subject"]=>
+  string(9) "foobarbaz"
+  ["captures"]=>
+  array(4) {
+    [0]=>
+    array(2) {
+      [0]=>
+      NULL
+      [1]=>
+      int(-1)
+    }
+    [1]=>
+    array(2) {
+      [0]=>
+      string(6) "foobar"
+      [1]=>
+      int(0)
+    }
+    [2]=>
+    array(2) {
+      [0]=>
+      string(3) "foo"
+      [1]=>
+      int(0)
+    }
+    [3]=>
+    array(2) {
+      [0]=>
+      string(3) "bar"
+      [1]=>
+      int(3)
+    }
+  }
+  ["capture_last"]=>
+  int(1)
+  ["start_match"]=>
+  int(0)
+  ["current_position"]=>
+  int(6)
+  ["pattern_position"]=>
+  int(18)
+  ["next_item_length"]=>
+  int(1)
+}
+int(1)
+array(4) {
+  [0]=>
+  string(9) "foobarbaz"
+  [1]=>
+  string(6) "foobar"
+  [2]=>
+  string(3) "foo"
+  [3]=>
+  string(3) "bar"
+}
+string(4) "name"
+int(1)
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(4) "name"
+int(0)
+array(0) {
+}

--- a/ext/pcre/tests/callout_example_1.phpt
+++ b/ext/pcre/tests/callout_example_1.phpt
@@ -1,0 +1,102 @@
+--TEST--
+Auto callout tracing
+--FILE--
+<?php
+
+$pattern = '/^(?:a(?=a*(\1?+b)))+\1$/C';
+$subject = 'aaabbb';
+
+preg_callout_function(function($info) use($pattern) {
+    $subject = $info['subject'];
+    echo $pattern . " against " . $subject, "\n";
+    $patternPos = $info['pattern_position'];
+    $subjectPos = $info['current_position'];
+    echo str_pad(str_repeat(' ', $patternPos) . '^', strlen($pattern));
+    echo str_repeat(' ', strlen(' against '));
+    echo str_pad(str_repeat(' ', $subjectPos) . '^', strlen($subject) + 1);
+
+    $captures = [];
+    foreach ($info['captures'] as $i => $capture) {
+        if ($capture[0] === null) {
+            $captures[] = "_";
+            continue;
+        }
+
+        $last = $i === $info['capture_last'] ? '(*) ' : '';
+        $captures[] = $last . '"' . $capture[0] . '" @ ' . $capture[1];
+    }
+    echo "  [", implode(", ", $captures), "]\n";
+
+    return 0;
+});
+var_dump(preg_match($pattern, $subject));
+
+?>
+--EXPECT--
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+^                                  ^        [_]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+ ^                                 ^        [_]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+    ^                              ^        [_]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+     ^                              ^       [_]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+        ^                           ^       [_]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+          ^                           ^     [_]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+           ^                          ^     [_]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+               ^                      ^     [_]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                ^                      ^    [_]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                 ^                     ^    [_, (*) "b" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                  ^                 ^       [_, (*) "b" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+    ^                               ^       [_, (*) "b" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+     ^                               ^      [_, (*) "b" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+        ^                            ^      [_, (*) "b" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+          ^                           ^     [_, (*) "b" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+           ^                          ^     [_, (*) "b" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+               ^                       ^    [_, (*) "b" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                ^                       ^   [_, (*) "b" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                 ^                      ^   [_, (*) "bb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                  ^                  ^      [_, (*) "bb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+    ^                                ^      [_, (*) "bb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+     ^                                ^     [_, (*) "bb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+        ^                             ^     [_, (*) "bb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+          ^                           ^     [_, (*) "bb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+           ^                          ^     [_, (*) "bb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+               ^                        ^   [_, (*) "bb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                ^                        ^  [_, (*) "bb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                 ^                       ^  [_, (*) "bbb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                  ^                   ^     [_, (*) "bbb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+    ^                                 ^     [_, (*) "bbb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                    ^                 ^     [_, (*) "bbb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                      ^                  ^  [_, (*) "bbb" @ 3]
+/^(?:a(?=a*(\1?+b)))+\1$/C against aaabbb
+                       ^                 ^  [_, (*) "bbb" @ 3]
+int(1)


### PR DESCRIPTION
This PR adds support for PCRE callouts, which are documented at https://www.pcre.org/current/doc/html/pcre2callout.html. Callouts provide a way to call a custom function during pattern matching, which can inspect the current matching state and has limited control over pattern matching.

A callout function is specified using `preg_callout_function()`, which also returns the previously set callout function. A typical usage would thus be:

```
$oldCallout = preg_callout_function(function($info) {
    var_dump($info);
    return 0; // Continue match
});
preg_match($regex, $subject);
preg_callout_function($oldCallout);
```

The callout function is passed a single array as argument which contains various information about the matching state. For the regular expression `'/((foo)(bar))(?C42)baz/'` against `'foobarbaz'` the contents of `$info` are:

```
array(8) {
  ["callout"]=>
  int(42)
  ["subject"]=>
  string(9) "foobarbaz"
  ["captures"]=>
  array(4) {
    [0]=>
    array(2) {
      [0]=>
      NULL
      [1]=>
      int(-1)
    }
    [1]=>
    array(2) {
      [0]=>
      string(6) "foobar"
      [1]=>
      int(0)
    }
    [2]=>
    array(2) {
      [0]=>
      string(3) "foo"
      [1]=>
      int(0)
    }
    [3]=>
    array(2) {
      [0]=>
      string(3) "bar"
      [1]=>
      int(3)
    }
  }
  ["capture_last"]=>
  int(1)
  ["start_match"]=>
  int(0)
  ["current_position"]=>
  int(6)
  ["pattern_position"]=>
  int(18)
  ["next_item_length"]=>
  int(1)
}
```

The meaning of the contents is the same as described in the PCRE documentation. In particular this information is exposed: The callout name/number, the subject string, the captured subpatterns (to this point) including offsets, which one was captured last, at which position matching started, the current position in the subject, the current position in the pattern and the length of the current item in the pattern.

The callout function can exert limited control over pattern matching through the return value. This is an integer that is one of:

 * `== 0`: Continue matching as usual.
 * `> 0`: Abort current matching attempt, but still backtrack (equivalent to failing lookahead assertion).
 * `< 0`: Abort match entirely.

Additionally a new modifier `/C` is added, which enables `AUTO_CALLOUT` mode. This will insert callouts into many points in the pattern, allowing you to easily trace the pattern matching behavior. See callout_example_1.phpt for an example of a simple tracing function that can be used.