### PR TITLE
[RFC] Deprecate PHP's Short Open Tags in PHP 7.4

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -511,10 +511,10 @@ static FILE *zend_fopen_wrapper(const char *filename, zend_string **opened_path)
 /* }}} */
 
 #ifdef ZTS
-static zend_bool short_tags_default      = 1;
+static zend_bool short_tags_default      = 0;
 static uint32_t compiler_options_default = ZEND_COMPILE_DEFAULT;
 #else
-# define short_tags_default			1
+# define short_tags_default			0
 # define compiler_options_default	ZEND_COMPILE_DEFAULT
 #endif
 

--- a/ext/standard/tests/strings/strip_tags_basic1.phpt
+++ b/ext/standard/tests/strings/strip_tags_basic1.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : basic functionality - with default arguments
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -43,7 +41,6 @@ foreach($string_array as $string)
 echo "Done";
 ?>
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : basic functionality ***
 -- Iteration 1 --
 string(5) "hello"

--- a/ext/standard/tests/strings/strip_tags_basic1.phpt
+++ b/ext/standard/tests/strings/strip_tags_basic1.phpt
@@ -43,6 +43,7 @@ foreach($string_array as $string)
 echo "Done";
 ?>
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : basic functionality ***
 -- Iteration 1 --
 string(5) "hello"

--- a/ext/standard/tests/strings/strip_tags_basic2.phpt
+++ b/ext/standard/tests/strings/strip_tags_basic2.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : basic functionality - with all arguments
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -39,7 +37,6 @@ foreach($allowed_tags_array as $tags)
 echo "Done";
 ?>
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : basic functionality ***
 -- Iteration 1 --
 string(33) "<html>helloworldOther text</html>"

--- a/ext/standard/tests/strings/strip_tags_basic2.phpt
+++ b/ext/standard/tests/strings/strip_tags_basic2.phpt
@@ -39,6 +39,7 @@ foreach($allowed_tags_array as $tags)
 echo "Done";
 ?>
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : basic functionality ***
 -- Iteration 1 --
 string(33) "<html>helloworldOther text</html>"

--- a/ext/standard/tests/strings/strip_tags_variation10.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation10.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - single quoted strings
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -39,7 +37,6 @@ foreach($single_quote_string as $string_value)
 echo "Done";
 ?>
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(51) "<html> \$ -> This represents the dollar sign</html>"

--- a/ext/standard/tests/strings/strip_tags_variation10.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation10.phpt
@@ -39,6 +39,7 @@ foreach($single_quote_string as $string_value)
 echo "Done";
 ?>
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(51) "<html> \$ -> This represents the dollar sign</html>"

--- a/ext/standard/tests/strings/strip_tags_variation11.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation11.phpt
@@ -29,6 +29,7 @@ foreach($string_array as $string)
 echo "Done";
 ?>
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : obscure functionality ***
 -- Iteration 1 --
 string(12) "hello  world"

--- a/ext/standard/tests/strings/strip_tags_variation11.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation11.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : obscure values within attributes
---INI--
-short_open_tag = on
 --FILE--
 <?php
 
@@ -29,7 +27,6 @@ foreach($string_array as $string)
 echo "Done";
 ?>
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : obscure functionality ***
 -- Iteration 1 --
 string(12) "hello  world"

--- a/ext/standard/tests/strings/strip_tags_variation2.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation2.phpt
@@ -86,6 +86,7 @@ foreach($values as $value) {
 echo "Done";
 ?>
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(10) "helloworld"

--- a/ext/standard/tests/strings/strip_tags_variation2.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation2.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - unexpected values for 'allowable_tags'
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -86,7 +84,6 @@ foreach($values as $value) {
 echo "Done";
 ?>
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(10) "helloworld"

--- a/ext/standard/tests/strings/strip_tags_variation4.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation4.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - invalid values for 'str' and valid 'allowable_tags'
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -46,7 +44,6 @@ foreach($strings as $string_value)
 echo "Done";
 ?>
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(32) "hello 		world... strip_tags_test"

--- a/ext/standard/tests/strings/strip_tags_variation4.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation4.phpt
@@ -46,6 +46,7 @@ foreach($strings as $string_value)
 echo "Done";
 ?>
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(32) "hello 		world... strip_tags_test"

--- a/ext/standard/tests/strings/strip_tags_variation5.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation5.phpt
@@ -87,8 +87,7 @@ string(67) "<html>hello world</html>
 
 This is a double quoted string"
 -- Iteration 4 --
-string(44) "<html>hello
- world	
+string(44) "<html>hello world	
 1111		 != 2222</html>
 "
 -- Iteration 5 --

--- a/ext/standard/tests/strings/strip_tags_variation5.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation5.phpt
@@ -90,8 +90,7 @@ string(67) "<html>hello world</html>
 
 This is a double quoted string"
 -- Iteration 4 --
-string(44) "<html>hello
- world	
+string(44) "<html>hello world	
 1111		 != 2222</html>
 "
 -- Iteration 5 --

--- a/ext/standard/tests/strings/strip_tags_variation5.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation5.phpt
@@ -78,6 +78,7 @@ for($index =0; $index < count($res_heredoc_strings); $index ++) {
 echo "Done\n";
 ?>
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(0) ""
@@ -89,7 +90,8 @@ string(67) "<html>hello world</html>
 
 This is a double quoted string"
 -- Iteration 4 --
-string(44) "<html>hello world	
+string(44) "<html>hello
+ world	
 1111		 != 2222</html>
 "
 -- Iteration 5 --

--- a/ext/standard/tests/strings/strip_tags_variation5.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation5.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - heredoc strings
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -78,7 +76,6 @@ for($index =0; $index < count($res_heredoc_strings); $index ++) {
 echo "Done\n";
 ?>
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(0) ""
@@ -90,7 +87,8 @@ string(67) "<html>hello world</html>
 
 This is a double quoted string"
 -- Iteration 4 --
-string(44) "<html>hello world	
+string(44) "<html>hello
+ world	
 1111		 != 2222</html>
 "
 -- Iteration 5 --

--- a/ext/standard/tests/strings/strip_tags_variation6.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation6.phpt
@@ -35,6 +35,7 @@ foreach($strings as $value)
 echo "Done";
 ?>
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(18) " I am html string "

--- a/ext/standard/tests/strings/strip_tags_variation6.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation6.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - binary safe checking
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -35,7 +33,6 @@ foreach($strings as $value)
 echo "Done";
 ?>
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(18) " I am html string "

--- a/ext/standard/tests/strings/strip_tags_variation7.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation7.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - invalid values for 'str' and 'allowable_tags'
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -44,7 +42,6 @@ foreach($strings as $string_value)
 echo "Done";
 ?>
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(43) "<abc>hello</abc> 		world... strip_tags_test"

--- a/ext/standard/tests/strings/strip_tags_variation7.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation7.phpt
@@ -44,6 +44,7 @@ foreach($strings as $string_value)
 echo "Done";
 ?>
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(43) "<abc>hello</abc> 		world... strip_tags_test"

--- a/ext/standard/tests/strings/strip_tags_variation8.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation8.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - valid value for 'str' and invalid values for 'allowable_tags'
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -39,7 +37,6 @@ foreach($quotes as $string_value)
 
 echo "Done";
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(33) "hello 	world... strip_tags_test"

--- a/ext/standard/tests/strings/strip_tags_variation8.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation8.phpt
@@ -39,6 +39,7 @@ foreach($quotes as $string_value)
 
 echo "Done";
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(33) "hello 	world... strip_tags_test"

--- a/ext/standard/tests/strings/strip_tags_variation9.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation9.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - double quoted strings
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])
@@ -37,12 +35,12 @@ foreach($double_quote_string as $string_value)
 
 echo "Done";
 --EXPECT--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(50) "<html> $ -> This represents the dollar sign</html>"
 -- Iteration 2 --
-string(59) "<html>	 The quick brown fox jumped over the lazy dog</p>"
+string(59) "<html>	
+ The quick brown fox jumped over the lazy dog</p>"
 -- Iteration 3 --
 string(31) "<a>This is a hyper text tag</a>"
 -- Iteration 4 --
@@ -50,6 +48,7 @@ string(0) ""
 -- Iteration 5 --
 string(26) "<p>This is a paragraph</p>"
 -- Iteration 6 --
-string(62) "<b>This is 	a text in bold letters\s\malong with slashes
+string(62) "<b>This is 	a text in bold letters
+\s\malong with slashes
 </b>"
 Done

--- a/ext/standard/tests/strings/strip_tags_variation9.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation9.phpt
@@ -42,8 +42,7 @@ Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 -- Iteration 1 --
 string(50) "<html> $ -> This represents the dollar sign</html>"
 -- Iteration 2 --
-string(59) "<html>	
- The quick brown fox jumped over the lazy dog</p>"
+string(59) "<html>	 The quick brown fox jumped over the lazy dog</p>"
 -- Iteration 3 --
 string(31) "<a>This is a hyper text tag</a>"
 -- Iteration 4 --
@@ -51,7 +50,6 @@ string(0) ""
 -- Iteration 5 --
 string(26) "<p>This is a paragraph</p>"
 -- Iteration 6 --
-string(62) "<b>This is 	a text in bold letters
-\s\malong with slashes
+string(62) "<b>This is 	a text in bold letters\s\malong with slashes
 </b>"
 Done

--- a/ext/standard/tests/strings/strip_tags_variation9.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation9.phpt
@@ -37,11 +37,13 @@ foreach($double_quote_string as $string_value)
 
 echo "Done";
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing strip_tags() : usage variations ***
 -- Iteration 1 --
 string(50) "<html> $ -> This represents the dollar sign</html>"
 -- Iteration 2 --
-string(59) "<html>	 The quick brown fox jumped over the lazy dog</p>"
+string(59) "<html>	
+ The quick brown fox jumped over the lazy dog</p>"
 -- Iteration 3 --
 string(31) "<a>This is a hyper text tag</a>"
 -- Iteration 4 --
@@ -49,6 +51,7 @@ string(0) ""
 -- Iteration 5 --
 string(26) "<p>This is a paragraph</p>"
 -- Iteration 6 --
-string(62) "<b>This is 	a text in bold letters\s\malong with slashes
+string(62) "<b>This is 	a text in bold letters
+\s\malong with slashes
 </b>"
 Done

--- a/ext/standard/tests/strings/strip_tags_variation9.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation9.phpt
@@ -39,8 +39,7 @@ echo "Done";
 -- Iteration 1 --
 string(50) "<html> $ -> This represents the dollar sign</html>"
 -- Iteration 2 --
-string(59) "<html>	
- The quick brown fox jumped over the lazy dog</p>"
+string(59) "<html>	 The quick brown fox jumped over the lazy dog</p>"
 -- Iteration 3 --
 string(31) "<a>This is a hyper text tag</a>"
 -- Iteration 4 --
@@ -48,7 +47,6 @@ string(0) ""
 -- Iteration 5 --
 string(26) "<p>This is a paragraph</p>"
 -- Iteration 6 --
-string(62) "<b>This is 	a text in bold letters
-\s\malong with slashes
+string(62) "<b>This is 	a text in bold letters\s\malong with slashes
 </b>"
 Done

--- a/ext/tokenizer/tests/002.phpt
+++ b/ext/tokenizer/tests/002.phpt
@@ -3,7 +3,7 @@ token_get_all()
 --SKIPIF--
 <?php if (!extension_loaded("tokenizer")) print "skip"; ?>
 --INI--
-short_open_tag=1
+short_open_tag=On
 --FILE--
 <?php
 
@@ -22,6 +22,7 @@ foreach ($strings as $s) {
 echo "Done\n";
 ?>
 --EXPECTF--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 array(49) {
   [0]=>
   array(3) {

--- a/ext/tokenizer/tests/token_get_all_variation15.phpt
+++ b/ext/tokenizer/tests/token_get_all_variation15.phpt
@@ -49,6 +49,7 @@ var_dump( token_get_all($source));
 echo "Done"
 ?>
 --EXPECTF--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing token_get_all() : with heredoc source string ***
 array(103) {
   [0]=>

--- a/ext/tokenizer/tests/token_get_all_variation15.phpt
+++ b/ext/tokenizer/tests/token_get_all_variation15.phpt
@@ -2,8 +2,6 @@
 Test token_get_all() function : usage variations - heredoc string for 'source'
 --SKIPIF--
 <?php if (!extension_loaded("tokenizer")) print "skip"; ?>
---INI--
-short_open_tag=On
 --FILE--
 <?php
 /* Prototype  : array token_get_all(string $source)
@@ -49,7 +47,6 @@ var_dump( token_get_all($source));
 echo "Done"
 ?>
 --EXPECTF--
-Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 *** Testing token_get_all() : with heredoc source string ***
 array(103) {
   [0]=>

--- a/main/main.c
+++ b/main/main.c
@@ -2413,6 +2413,7 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 				"Directive '%s' is deprecated",
 				{
 					"track_errors",
+					"short_open_tag",
 					NULL
 				}
 			},

--- a/php.ini-development
+++ b/php.ini-development
@@ -176,11 +176,8 @@ engine = On
 ; documents, however this remains supported for backward compatibility reasons.
 ; Note that this directive does not control the <?= shorthand tag, which can be
 ; used regardless of this directive.
-; Default Value: Off
-; Development Value: Off
-; Production Value: Off
 ; http://php.net/short-open-tag
-;short_open_tag =
+;short_open_tag = Off
 
 ; The number of significant digits displayed in floating point numbers.
 ; http://php.net/precision

--- a/php.ini-development
+++ b/php.ini-development
@@ -174,6 +174,7 @@
 ; http://php.net/engine
 engine = On
 
+; This directive is DEPRECATED.
 ; This directive determines whether or not PHP will recognize code between
 ; <? and ?> tags as PHP source which should be processed as such. It is
 ; generally recommended that <?php and ?> should be used and that this feature
@@ -181,7 +182,7 @@ engine = On
 ; documents, however this remains supported for backward compatibility reasons.
 ; Note that this directive does not control the <?= shorthand tag, which can be
 ; used regardless of this directive.
-; Default Value: On
+; Default Value: Off
 ; Development Value: Off
 ; Production Value: Off
 ; http://php.net/short-open-tag

--- a/php.ini-development
+++ b/php.ini-development
@@ -143,8 +143,9 @@
 ;   Development Value: 5
 ;   Production Value: 5
 
+; This directive is DEPRECATED.
 ; short_open_tag
-;   Default Value: On
+;   Default Value: Off
 ;   Development Value: Off
 ;   Production Value: Off
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -143,12 +143,6 @@
 ;   Development Value: 5
 ;   Production Value: 5
 
-; This directive is DEPRECATED.
-; short_open_tag
-;   Default Value: Off
-;   Development Value: Off
-;   Production Value: Off
-
 ; variables_order
 ;   Default Value: "EGPCS"
 ;   Development Value: "GPCS"
@@ -186,7 +180,7 @@ engine = On
 ; Development Value: Off
 ; Production Value: Off
 ; http://php.net/short-open-tag
-short_open_tag = Off
+;short_open_tag =
 
 ; The number of significant digits displayed in floating point numbers.
 ; http://php.net/precision

--- a/php.ini-production
+++ b/php.ini-production
@@ -181,11 +181,8 @@ engine = On
 ; documents, however this remains supported for backward compatibility reasons.
 ; Note that this directive does not control the <?= shorthand tag, which can be
 ; used regardless of this directive.
-; Default Value: Off
-; Development Value: Off
-; Production Value: Off
 ; http://php.net/short-open-tag
-;short_open_tag =
+;short_open_tag = Off
 
 ; The number of significant digits displayed in floating point numbers.
 ; http://php.net/precision

--- a/php.ini-production
+++ b/php.ini-production
@@ -179,6 +179,7 @@
 ; http://php.net/engine
 engine = On
 
+; This directive is DEPRECATED.
 ; This directive determines whether or not PHP will recognize code between
 ; <? and ?> tags as PHP source which should be processed as such. It is
 ; generally recommended that <?php and ?> should be used and that this feature
@@ -186,7 +187,7 @@ engine = On
 ; documents, however this remains supported for backward compatibility reasons.
 ; Note that this directive does not control the <?= shorthand tag, which can be
 ; used regardless of this directive.
-; Default Value: On
+; Default Value: Off
 ; Development Value: Off
 ; Production Value: Off
 ; http://php.net/short-open-tag

--- a/php.ini-production
+++ b/php.ini-production
@@ -143,8 +143,9 @@
 ;   Development Value: 5
 ;   Production Value: 5
 
+; This directive is DEPRECATED.
 ; short_open_tag
-;   Default Value: On
+;   Default Value: Off
 ;   Development Value: Off
 ;   Production Value: Off
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -143,12 +143,6 @@
 ;   Development Value: 5
 ;   Production Value: 5
 
-; This directive is DEPRECATED.
-; short_open_tag
-;   Default Value: Off
-;   Development Value: Off
-;   Production Value: Off
-
 ; track_errors
 ;   Default Value: Off
 ;   Development Value: On
@@ -191,7 +185,7 @@ engine = On
 ; Development Value: Off
 ; Production Value: Off
 ; http://php.net/short-open-tag
-short_open_tag = Off
+;short_open_tag =
 
 ; The number of significant digits displayed in floating point numbers.
 ; http://php.net/precision

--- a/tests/lang/short_tags.001.phpt
+++ b/tests/lang/short_tags.001.phpt
@@ -8,5 +8,6 @@ echo "Used a short tag\n";
 ?>
 Finished
 --EXPECT--
+Deprecated: Directive 'short_open_tag' is deprecated in Unknown on line 0
 Used a short tag
 Finished

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -24,7 +24,7 @@
 /* PHP Runtime Configuration */
 #define PHP_URL_FOPEN 1
 #define USE_CONFIG_FILE 1
-#define DEFAULT_SHORT_OPEN_TAG "1"
+#define DEFAULT_SHORT_OPEN_TAG "0"
 
 /* Platform-Specific Configuration. Should not be changed. */
 #define PHP_SIGCHILD 0


### PR DESCRIPTION
Implementation of my RFC for deprecating PHP Short tags: https://wiki.php.net/rfc/deprecate_php_short_tags

First time making a PR so help/reviews are appreciated.

On my local machine, some tests fail but I suppose this is due to me using WSL and not a native Linux.

~Also, I'm having trouble fixing two tests related to strip_tags:~
*  ~ext/standard/tests/strings/strip_tags_variation5.phpt~
*  ~ext/standard/tests/strings/strip_tags_variation9.phpt~

~And it seems I made some changes to the output which I only realized with the diff view (don't know if that's due to my IDE or being on WSL).~
Fixed.

Probably gonna do a second PR for the removal in PHP 8.