### PR TITLE
Rename enable-maintainer-zts to enable-zts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ env:
       - PDO_MYSQL_TEST_HOST=127.0.0.1
       - REPORT_EXIT_STATUS=1
     matrix:
-      - ENABLE_MAINTAINER_ZTS=0 ENABLE_DEBUG=0
-      - ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
+      - ENABLE_ZTS=0 ENABLE_DEBUG=0
+      - ENABLE_ZTS=1 ENABLE_DEBUG=1
 
 before_script:
     - ccache --version

--- a/README.GIT-RULES
+++ b/README.GIT-RULES
@@ -39,7 +39,7 @@ Having said that, here are the organizational rules::
       To do so use "make test".
 
    7. For development use the --enable-debug switch to avoid memory leaks
-      and the --enable-maintainer-zts switch to ensure your code handles
+      and the --enable-zts switch to ensure your code handles
       TSRM correctly and doesn't break for those who need that.
 
 Currently we have the following branches in use::

--- a/README.SUBMITTING_PATCH
+++ b/README.SUBMITTING_PATCH
@@ -162,8 +162,8 @@ Checklist for submitting your PHP or PECL code patch
  - Rebuild PHP with --enable-debug (which will show some kinds of
    memory errors) and check the PHP and web server error logs after
    running your PHP tests.
- - Rebuild PHP with --enable-maintainer-zts to check your patch
-   compiles on multi-threaded web servers.
+ - Rebuild PHP with --enable-zts to check your patch
+   compiles and operates correctly in a thread safe PHP.
  - Review the patch once more just before submitting it.
 
 

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -79,11 +79,11 @@ int main()
 
 AC_DEFUN([LIBZEND_OTHER_CHECKS],[
 
-AC_ARG_ENABLE([maintainer-zts],
-  [AS_HELP_STRING([--enable-maintainer-zts],
-    [Enable thread safety - for code maintainers only!!])],
-  [ZEND_MAINTAINER_ZTS=$enableval],
-  [ZEND_MAINTAINER_ZTS=no])
+AC_ARG_ENABLE([zts],
+  [AS_HELP_STRING([--enable-zts],
+    [Enable thread safety])],
+  [ZEND_ZTS=$enableval],
+  [ZEND_ZTS=no])
 
 AC_ARG_ENABLE([inline-optimization],
   [AS_HELP_STRING([--disable-inline-optimization],
@@ -92,7 +92,7 @@ AC_ARG_ENABLE([inline-optimization],
   [ZEND_INLINE_OPTIMIZATION=yes])
 
 AC_MSG_CHECKING(whether to enable thread-safety)
-AC_MSG_RESULT($ZEND_MAINTAINER_ZTS)
+AC_MSG_RESULT($ZEND_ZTS)
 
 AC_MSG_CHECKING(whether to enable inline optimization for GCC)
 AC_MSG_RESULT($ZEND_INLINE_OPTIMIZATION)
@@ -115,7 +115,7 @@ fi
 
 test -n "$DEBUG_CFLAGS" && CFLAGS="$CFLAGS $DEBUG_CFLAGS"
 
-if test "$ZEND_MAINTAINER_ZTS" = "yes"; then
+if test "$ZEND_ZTS" = "yes"; then
   AC_DEFINE(ZTS,1,[ ])
   CFLAGS="$CFLAGS -DZTS"
 fi

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -727,7 +727,7 @@ dnl
 dnl PHP_BUILD_THREAD_SAFE
 dnl
 AC_DEFUN([PHP_BUILD_THREAD_SAFE],[
-  enable_maintainer_zts=yes
+  enable_zts=yes
   if test "$pthreads_working" != "yes"; then
     AC_MSG_ERROR([ZTS currently requires working POSIX threads. We were unable to verify that your system supports Pthreads.])
   fi
@@ -2307,7 +2307,7 @@ AC_DEFUN([PHP_CHECK_CONFIGURE_OPTIONS],[
       with-tsrm-pth | with-tsrm-st | with-tsrm-pthreads [)];;
 
       # Allow certain Zend options
-      with-zend-vm | enable-maintainer-zts | enable-inline-optimization[)];;
+      with-zend-vm | enable-zts | enable-inline-optimization[)];;
 
       # All the rest must be set using the PHP_ARG_* macros
       # PHP_ARG_* macros set php_enable_<arg_name> or php_with_<arg_name>

--- a/configure.ac
+++ b/configure.ac
@@ -361,7 +361,7 @@ if test -z "$PHP_INSTALLED_SAPIS"; then
 fi
 
 dnl force ZTS
-if test "$enable_maintainer_zts" = "yes"; then
+if test "$enable_zts" = "yes"; then
   PTHREADS_ASSIGN_VARS
   PTHREADS_FLAGS
 fi
@@ -1218,7 +1218,7 @@ LIBZEND_BASIC_CHECKS
 LIBZEND_DLSYM_CHECK
 LIBZEND_OTHER_CHECKS
 
-if test "$ZEND_MAINTAINER_ZTS" = "yes"; then
+if test "$ZEND_ZTS" = "yes"; then
   AC_DEFINE(ZTS,1,[ ])
   PHP_THREAD_SAFETY=yes
 else
@@ -1289,7 +1289,7 @@ if test -z "$EXTENSION_DIR"; then
     else
       part1=no-debug
     fi
-    if test "$enable_maintainer_zts" = "yes"; then
+    if test "$enable_zts" = "yes"; then
       part2=zts
     else
       part2=non-zts
@@ -1297,7 +1297,7 @@ if test -z "$EXTENSION_DIR"; then
     extbasedir=$part1-$part2-$extbasedir
     EXTENSION_DIR=$libdir/extensions/$extbasedir
   else
-    if test "$enable_maintainer_zts" = "yes"; then
+    if test "$enable_zts" = "yes"; then
       extbasedir=$extbasedir-zts
     fi
 

--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -51,7 +51,7 @@ elif test "$PHP_MYSQLI" != "no"; then
   MYSQL_CONFIG=$PHP_MYSQLI
 
   MYSQL_LIB_NAME='mysqlclient'
-  if test "$enable_maintainer_zts" = "yes"; then
+  if test "$enable_zts" = "yes"; then
     MYSQL_LIB_CFG='--libs_r'
     MYSQL_LIB_NAME='mysqlclient_r'
   else

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -60,7 +60,7 @@ if test "$PHP_PDO_MYSQL" != "no"; then
       if test "x$SED" = "x"; then
         AC_PATH_PROG(SED, sed)
       fi
-      if test "$enable_maintainer_zts" = "yes"; then
+      if test "$enable_zts" = "yes"; then
         PDO_MYSQL_LIBNAME=mysqlclient_r
         PDO_MYSQL_LIBS=`$PDO_MYSQL_CONFIG --libs_r | $SED -e "s/'//g"`
       else

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -33,9 +33,9 @@ if test "$PHP_MM" != "no"; then
     AC_MSG_ERROR(cannot find mm library)
   fi
 
-  if test "$enable_maintainer_zts" = "yes"; then
+  if test "$enable_zts" = "yes"; then
     dnl The mm library is not thread-safe, and mod_mm.c refuses to compile.
-    AC_MSG_ERROR(--with-mm cannot be combined with --enable-maintainer-zts)
+    AC_MSG_ERROR(--with-mm cannot be combined with --enable-zts)
   fi
 
   PHP_ADD_LIBRARY_WITH_PATH(mm, $MM_DIR/$PHP_LIBDIR, SESSION_SHARED_LIBADD)

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -10,12 +10,12 @@ PHP_ARG_WITH([sqlite3],
 if test $PHP_SQLITE3 != "no"; then
   PHP_SQLITE3_CFLAGS=" -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 "
 
-  dnl when running phpize enable_maintainer_zts is not available
-  if test -z "$enable_maintainer_zts"; then
+  dnl when running phpize enable_zts is not available
+  if test -z "$enable_zts"; then
     if test -f "$phpincludedir/main/php_config.h"; then
       ZTS=`grep '#define ZTS' $phpincludedir/main/php_config.h|$SED 's/#define ZTS//'`
       if test "$ZTS" -eq "1"; then
-        enable_maintainer_zts="yes"
+        enable_zts="yes"
       fi
     fi
   fi

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-if [[ "$ENABLE_MAINTAINER_ZTS" == 1 ]]; then
-	TS="--enable-maintainer-zts";
+if [[ "$ENABLE_ZTS" == 1 ]]; then
+	TS="--enable-zts";
 else
 	TS="";
 fi


### PR DESCRIPTION
I think it's about time we admitted this isn't a "maintainer" or experimental option, but a core part of PHP ...