### PR TITLE
Move CREDITS from root file to the main README

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,3 +1,0 @@
-For the list of people who've put work into PHP, please see
-
-https://www.php.net/credits.php

--- a/README.md
+++ b/README.md
@@ -108,3 +108,8 @@ of cores (`N`):
 
 The [qa.php.net](https://qa.php.net) site provides more detailed info about
 testing and quality assurance.
+
+## Credits
+
+For the list of people who've put work into PHP, please see the
+[PHP credits page](https://php.net/credits.php)


### PR DESCRIPTION
Hello, this moves the CREDITS file from the root directory to the main README file.

- project root directory includes one file less
- https link with www didn't work for everyone
- contributions should be according to the bc29ceef1b4484d2a5192631894043fc537ec6d5 noted on the php.net page...