### PR TITLE
Make run-tests.php compatible with php 7.0-7.2

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1505,7 +1505,7 @@ escape:
 						$rawMessage = $rawMessageBuffers[$i] . $rawMessage;
 						$rawMessageBuffers[$i] = '';
 					}
-					if ($rawMessage[-1] !== "\n") {
+					if (substr($rawMessage, -1) !== "\n") {
 						$rawMessageBuffers[$i] = $rawMessage;
 						continue;
 					}
@@ -1571,7 +1571,7 @@ escape:
 							}
 							break;
 						case "test_result":
-							[$name, $index, $result, $resultText] = [$message["name"], $message["index"], $message["result"], $message["text"]];
+							list($name, $index, $result, $resultText) = [$message["name"], $message["index"], $message["result"], $message["text"]];
 							foreach ($message["PHP_FAILED_TESTS"] as $category => $tests) {
 								$PHP_FAILED_TESTS[$category] = array_merge($PHP_FAILED_TESTS[$category], $tests);
 							}


### PR DESCRIPTION
Motivation:
As an extension author, I want to speed up running tests in php <=7.3,
both locally and in CI (e.g. when running with valgrind).
This can be done by manually copying php 7.4's run-tests.php script
to replace the one generated by `phpize`

- list() doesn't work in php 7.0
- negative string offset doesn't work in php 7.2
- This fix has been tested with php 7.1 and 7.0 on linux

If run-tests.php can be copied from php-src without any manual patches,
that would be the easiest.

Related to #2822 and #3838 - I didn't see any discussion for/against compatibility
with older php versions in that PR.
except for https://github.com/php/php-src/pull/3838/files#r257469673

- Both of the changes requiring syntax newer than 7.0 were introduced in that PR.