### PR TITLE
zend_hash.c deduplication

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -586,15 +586,15 @@ ZEND_API void ZEND_FASTCALL zend_hash_iterators_advance(HashTable *ht, HashPosit
 	}
 }
 
-static zend_always_inline zend_bool zend_hash_key_is_equals(Bucket *p, zend_string *key, zend_ulong h)
+static zend_always_inline zend_bool zend_hash_key_is_equal(Bucket *p, zend_string *key, zend_ulong h)
 {
 	return (p->key == key)
-			||(p->h == h
+			|| (p->h == h
 				&& p->key
 				&& zend_string_equal_content(p->key, key));
 }
 
-static zend_always_inline zend_bool zend_hash_str_key_is_equals(Bucket *p, const char *str, size_t len, zend_ulong h)
+static zend_always_inline zend_bool zend_hash_str_key_is_equal(Bucket *p, const char *str, size_t len, zend_ulong h)
 {
 	return (p->h == h)
 			&& p->key
@@ -627,7 +627,7 @@ static zend_always_inline Bucket *zend_hash_find_bucket(const HashTable *ht, zen
 	}
 
 	while (1) {
-		if (zend_hash_key_is_equals(p, key, h)) {
+		if (zend_hash_key_is_equal(p, key, h)) {
 			return p;
 		}
 		idx = Z_NEXT(p->val);
@@ -653,7 +653,7 @@ static zend_always_inline Bucket *zend_hash_str_find_bucket(const HashTable *ht,
 	while (idx != HT_INVALID_IDX) {
 		ZEND_ASSERT(idx < HT_IDX_TO_HASH(ht->nTableSize));
 		p = HT_HASH_TO_BUCKET_EX(arData, idx);
-		if (zend_hash_str_key_is_equals(p, str, len, h)) {
+		if (zend_hash_str_key_is_equal(p, str, len, h)) {
 			return p;
 		}
 		idx = Z_NEXT(p->val);
@@ -1305,7 +1305,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_del(HashTable *ht, zend_string *key)
 	idx = HT_HASH(ht, nIndex);
 	while (idx != HT_INVALID_IDX) {
 		p = HT_HASH_TO_BUCKET(ht, idx);
-		if (zend_hash_key_is_equals(p, key, h)) {
+		if (zend_hash_key_is_equal(p, key, h)) {
 			_zend_hash_del_el_ex(ht, idx, p, prev);
 			return SUCCESS;
 		}
@@ -1332,7 +1332,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_del_ind(HashTable *ht, zend_string *key)
 	idx = HT_HASH(ht, nIndex);
 	while (idx != HT_INVALID_IDX) {
 		p = HT_HASH_TO_BUCKET(ht, idx);
-		if (zend_hash_key_is_equals(p, key, h)) {
+		if (zend_hash_key_is_equal(p, key, h)) {
 			if (Z_TYPE(p->val) == IS_INDIRECT) {
 				zval *data = Z_INDIRECT(p->val);
 
@@ -1377,7 +1377,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_str_del_ind(HashTable *ht, const char *str,
 	idx = HT_HASH(ht, nIndex);
 	while (idx != HT_INVALID_IDX) {
 		p = HT_HASH_TO_BUCKET(ht, idx);
-		if (zend_hash_str_key_is_equals(p, str, len, h)) {
+		if (zend_hash_str_key_is_equal(p, str, len, h)) {
 			if (Z_TYPE(p->val) == IS_INDIRECT) {
 				zval *data = Z_INDIRECT(p->val);
 
@@ -1418,7 +1418,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_str_del(HashTable *ht, const char *str, siz
 	idx = HT_HASH(ht, nIndex);
 	while (idx != HT_INVALID_IDX) {
 		p = HT_HASH_TO_BUCKET(ht, idx);
-		if (zend_hash_str_key_is_equals(p, str, len, h)) {
+		if (zend_hash_str_key_is_equal(p, str, len, h)) {
 			_zend_hash_del_el_ex(ht, idx, p, prev);
 			return SUCCESS;
 		}

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2480,21 +2480,19 @@ ZEND_API void ZEND_FASTCALL zend_hash_sort_ex(HashTable *ht, sort_func_t sort, c
 		if (!renumber) {
 			zend_hash_packed_to_hash(ht);
 		}
-	} else {
-		if (renumber) {
-			void *new_data, *old_data = HT_GET_DATA_ADDR(ht);
-			Bucket *old_buckets = ht->arData;
+	} else if (renumber) {
+		void *new_data, *old_data = HT_GET_DATA_ADDR(ht);
+		Bucket *old_buckets = ht->arData;
 
-			new_data = pemalloc(HT_SIZE_EX(ht->nTableSize, HT_MIN_MASK), (GC_FLAGS(ht) & IS_ARRAY_PERSISTENT));
-			HT_FLAGS(ht) |= HASH_FLAG_PACKED | HASH_FLAG_STATIC_KEYS;
-			ht->nTableMask = HT_MIN_MASK;
-			HT_SET_DATA_ADDR(ht, new_data);
-			memcpy(ht->arData, old_buckets, sizeof(Bucket) * ht->nNumUsed);
-			pefree(old_data, GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
-			HT_HASH_RESET_PACKED(ht);
-		} else {
-			zend_hash_rehash(ht);
-		}
+		new_data = pemalloc(HT_SIZE_EX(ht->nTableSize, HT_MIN_MASK), (GC_FLAGS(ht) & IS_ARRAY_PERSISTENT));
+		HT_FLAGS(ht) |= HASH_FLAG_PACKED | HASH_FLAG_STATIC_KEYS;
+		ht->nTableMask = HT_MIN_MASK;
+		HT_SET_DATA_ADDR(ht, new_data);
+		memcpy(ht->arData, old_buckets, sizeof(Bucket) * ht->nNumUsed);
+		pefree(old_data, GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
+		HT_HASH_RESET_PACKED(ht);
+	} else {
+		zend_hash_rehash(ht);
 	}
 }
 
@@ -2537,17 +2535,15 @@ static zend_always_inline int zend_hash_compare_impl(HashTable *ht1, HashTable *
 			}
 			pData2 = &p2->val;
 			idx2++;
-		} else {
-			if (p1->key == NULL) { /* numeric index */
-				pData2 = zend_hash_index_find(ht2, p1->h);
-				if (pData2 == NULL) {
-					return 1;
-				}
-			} else { /* string index */
-				pData2 = zend_hash_find(ht2, p1->key);
-				if (pData2 == NULL) {
-					return 1;
-				}
+		} else if (p1->key == NULL) { /* numeric index */
+			pData2 = zend_hash_index_find(ht2, p1->h);
+			if (pData2 == NULL) {
+				return 1;
+			}
+		} else { /* string index */
+			pData2 = zend_hash_find(ht2, p1->key);
+			if (pData2 == NULL) {
+				return 1;
 			}
 		}
 

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1594,35 +1594,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_clean(HashTable *ht)
 		p = ht->arData;
 		end = p + ht->nNumUsed;
 		if (ht->pDestructor) {
-			if (HT_HAS_STATIC_KEYS_ONLY(ht)) {
-				if (HT_IS_WITHOUT_HOLES(ht)) {
-					do {
-						ht->pDestructor(&p->val);
-					} while (++p != end);
-				} else {
-					do {
-						if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF)) {
-							ht->pDestructor(&p->val);
-						}
-					} while (++p != end);
-				}
-			} else if (HT_IS_WITHOUT_HOLES(ht)) {
-				do {
-					ht->pDestructor(&p->val);
-					if (EXPECTED(p->key)) {
-						zend_string_release(p->key);
-					}
-				} while (++p != end);
-			} else {
-				do {
-					if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF)) {
-						ht->pDestructor(&p->val);
-						if (EXPECTED(p->key)) {
-							zend_string_release(p->key);
-						}
-					}
-				} while (++p != end);
-			}
+			_zend_hash_clean_with_destructor(ht, p, end);
 		} else {
 			if (!HT_HAS_STATIC_KEYS_ONLY(ht)) {
 				if (HT_IS_WITHOUT_HOLES(ht)) {

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1142,7 +1142,7 @@ static void ZEND_FASTCALL zend_hash_do_resize(HashTable *ht)
 	}
 }
 
-ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
+ZEND_API void ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 {
 	Bucket *p;
 	uint32_t nIndex, i;
@@ -1154,7 +1154,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 			ht->nNumUsed = 0;
 			HT_HASH_RESET(ht);
 		}
-		return SUCCESS;
+		return;
 	}
 
 	HT_HASH_RESET(ht);
@@ -1225,7 +1225,6 @@ ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 			p++;
 		} while (++i < ht->nNumUsed);
 	}
-	return SUCCESS;
 }
 
 static zend_always_inline void _zend_hash_del_el_ex(HashTable *ht, uint32_t idx, Bucket *p, Bucket *prev)

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -274,7 +274,7 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_minmax(const HashTable *ht, compare_func_
 #define zend_hash_next_free_element(ht) \
 	(ht)->nNextFreeElement
 
-ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht);
+ZEND_API void ZEND_FASTCALL zend_hash_rehash(HashTable *ht);
 
 #if !ZEND_DEBUG && defined(HAVE_BUILTIN_CONSTANT_P)
 # define zend_new_array(size) \

--- a/Zend/zend_ts_hash.c
+++ b/Zend/zend_ts_hash.c
@@ -306,15 +306,11 @@ ZEND_API int zend_ts_hash_num_elements(TsHashTable *ht)
 	return retval;
 }
 
-ZEND_API int zend_ts_hash_rehash(TsHashTable *ht)
+ZEND_API void zend_ts_hash_rehash(TsHashTable *ht)
 {
-	int retval;
-
 	begin_write(ht);
-	retval = zend_hash_rehash(TS_HASH(ht));
+	zend_hash_rehash(TS_HASH(ht));
 	end_write(ht);
-
-	return retval;
 }
 
 ZEND_API zval *zend_ts_hash_str_find(TsHashTable *ht, const char *key, size_t len)

--- a/Zend/zend_ts_hash.h
+++ b/Zend/zend_ts_hash.h
@@ -79,7 +79,7 @@ ZEND_API zval *zend_ts_hash_minmax(TsHashTable *ht, compare_func_t compar, int f
 
 ZEND_API int zend_ts_hash_num_elements(TsHashTable *ht);
 
-ZEND_API int zend_ts_hash_rehash(TsHashTable *ht);
+ZEND_API void zend_ts_hash_rehash(TsHashTable *ht);
 
 #if ZEND_DEBUG
 /* debug */


### PR DESCRIPTION
  * zend_hash_rehash(zend_ts_hash_rehash) always returns SUCCESS. Changed to void
  * deduplication
  * remove one "goto" and reorder others "goto"'s to jump forward instead backward in _zend_hash_index_add_or_update_i
  * reduce nested "else->{if->else}" to "else if -> else"
  * replace 4-space indents by tabs