### PR TITLE
Make PCRE cache per-request on CLI

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2261,6 +2261,10 @@ static void accel_reset_pcre_cache(void)
 {
 	Bucket *p;
 
+	if (PCRE_G(per_request_cache)) {
+		return;
+	}
+
 	ZEND_HASH_FOREACH_BUCKET(&PCRE_G(pcre_cache), p) {
 		/* Remove PCRE cache entries with inconsistent keys */
 		if (zend_accel_in_shm(p->key)) {

--- a/ext/pcre/php_pcre.h
+++ b/ext/pcre/php_pcre.h
@@ -72,6 +72,7 @@ ZEND_BEGIN_MODULE_GLOBALS(pcre)
 #ifdef HAVE_PCRE_JIT_SUPPORT
 	zend_bool jit;
 #endif
+	zend_bool per_request_cache;
 	int  error_code;
 	/* Used for unmatched subpatterns in OFFSET_CAPTURE mode */
 	zval unmatched_null_pair;


### PR DESCRIPTION
As mentioned on the internals list recently, when running without opcache (specifically on CLI), looking up the regular expression from the cache might actually be the bottleneck: As the cache lives across request boundaries, only permanent/persistent strings may be inserted (per-request interned strings cannot be inserted). This means that each lookup has to perform a full string comparison, which can take a lot of time for very large (especially generated) regular expressions.

This implements a small hack for the CLI SAPI, where we only ever deal with one request. A `per_request_cache` flag is set, in which case non-permanent strings are allowed into the cache and the cache is destroyed after the request.