### PR TITLE
Add minimum required PHP version to run-tests.php

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -57,6 +57,11 @@ function main()
 	// Parallel testing
 	global $workers, $workerID;
 
+	// Minimum required PHP version.
+	if (version_compare(phpversion(), '7.0.0', '<=')) {
+		error('At least PHP 7.0.0 is required to execute run-tests.php.');
+	}
+
 	$workerID = 0;
 	if (getenv("TEST_PHP_WORKER")) {
 		$workerID = intval(getenv("TEST_PHP_WORKER"));

--- a/run-tests.php
+++ b/run-tests.php
@@ -29,6 +29,8 @@
 
 /* Let there be no top-level code beyond this point:
  * Only functions and classes, thanks!
+ *
+ * Minimum required PHP version: 7.0.0
  */
 
 /**
@@ -56,11 +58,6 @@ function main()
 		   $user_tests, $valgrind, $sum_results, $shuffle;
 	// Parallel testing
 	global $workers, $workerID;
-
-	// Minimum required PHP version.
-	if (version_compare(phpversion(), '7.0.0', '<=')) {
-		error('At least PHP 7.0.0 is required to execute run-tests.php.');
-	}
 
 	$workerID = 0;
 	if (getenv("TEST_PHP_WORKER")) {


### PR DESCRIPTION
Brought up in the #3981 to make a certain extension case pass and to be able to run tests in parallel on PHP 7.0 versions, however I probably don't need to explain that this is a very bad practice. Since people pushed this change in the code already we at least need to define the minimum constraint to be clear.

For people who are upgrading their code please follow the better recommended practices defined at the supported versions page and use the supported versions: https://www.php.net/supported-versions.php 

So, this now adds a minimum PHP requirement constraint in the run-tests.php script.

Thanks.
