### PR TITLE
Fixed bug #77909: DatePeriod::__construct() with invalid recurrence count value

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4578,6 +4578,10 @@ PHP_METHOD(DatePeriod, __construct)
 			dpobj->end = clone;
 		}
 	}
+ 
+	if (dpobj->end == NULL && recurrences < 1) {
+		php_error_docref(NULL, E_WARNING, "The recurrence count '%d' is invalid. Needs to be > 0", (int) recurrences);
+	}
 
 	/* options */
 	dpobj->include_start_date = !(options & PHP_DATE_PERIOD_EXCLUDE_START_DATE);

--- a/ext/date/tests/DatePeriod_wrong_recurrence_on_constructor.phpt
+++ b/ext/date/tests/DatePeriod_wrong_recurrence_on_constructor.phpt
@@ -1,0 +1,19 @@
+--TEST--
+DatePeriod: Test wrong recurrence parameter on __construct
+--FILE--
+<?php
+try {
+    new DatePeriod(new DateTime('yesterday'), new DateInterval('P1D'), 0);
+} catch (Exception $exception) {
+    echo $exception->getMessage(), "\n";
+}
+
+try {
+    new DatePeriod(new DateTime('yesterday'), new DateInterval('P1D'),-1);
+} catch (Exception $exception) {
+    echo $exception->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+DatePeriod::__construct(): The recurrence count '0' is invalid. Needs to be > 0
+DatePeriod::__construct(): The recurrence count '-1' is invalid. Needs to be > 0


### PR DESCRIPTION
This bug was encountered when adding [DatePeriod::getRecurrences](https://github.com/php/php-src/pull/3888). 

Currently when instantiating a `DatePeriod` object with the ISO Interval notation an exception is thrown if the recurrence count value is lesser than  `1`.
```php
new DatePeriod('R0/2012-07-01T00:00:00Z/P7D'); //throws an exception
```
when using the alternate constructor no exception is thrown

```php
new DatePeriod(
    new DateTime('2012-07-01T00:00:00Z'),
    new DateInterval('P7D'),
    0
);
```
This lead to `DatePeriod::getRecurrences` returning a value that could be `0` or negative which should not be possible as the recurrence count should be equal or greater than `1`.

The submitted bugfix will make the second example throw like the first example instead of returning an object in invalid state. For any code relying on the current behavior this means a BC break as the current behavior silently returns a object that may be iterable at most once if the recurrence count value is equal to `0`.