### PR TITLE
Fix #77800: phpdbg segfaults on listing some conditional breakpoints

### DIFF
--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -213,10 +213,12 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 										zend_string_release(filename);
 									} break;
 
-									default: { /* do nothing */ } break;
+									default: {
+                                                                            phpdbg_asprintf(&new_str, "%sbreak %s\n", *str, conditional->code);
+                                                                        } break;
 								}
 							} else {
-								phpdbg_asprintf(&new_str, "%sbreak if %s\n", str, conditional->code);
+								phpdbg_asprintf(&new_str, "%sbreak if %s\n", *str, conditional->code);
 							}
 						} break;
 

--- a/sapi/phpdbg/phpdbg_break.c
+++ b/sapi/phpdbg/phpdbg_break.c
@@ -42,7 +42,30 @@ const phpdbg_command_t phpdbg_break_commands[] = {
 
 PHPDBG_BREAK(at) /* {{{ */
 {
-	phpdbg_set_breakpoint_at(param);
+        switch (param->type) {
+                case NUMERIC_PARAM: {
+                        if (!PHPDBG_G(exec)) {
+                                phpdbg_error("inactive", "type=\"noexec\"", "Execution context not set!");
+                                return FAILURE;
+                        }
+
+                        phpdbg_param_t new_param;
+                        new_param = *(param);
+                        new_param.file.name = phpdbg_current_file();
+                        new_param.file.line = param->num;
+                        new_param.len = strlen(phpdbg_current_file());
+                        new_param.type = FILE_PARAM;
+
+                        phpdbg_set_breakpoint_at(&new_param);
+
+                } break;
+
+                case FILE_PARAM: {
+                        phpdbg_set_breakpoint_at(param);
+                } break;
+
+                phpdbg_default_switch_case();
+        }
 
 	return SUCCESS;
 } /* }}} */

--- a/sapi/phpdbg/tests/breakpoints_009.phpt
+++ b/sapi/phpdbg/tests/breakpoints_009.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Basic conditional breakpoint functionality
+--PHPDBG--
+b @ 3 if $i > 1
+r
+b @ 4 if $i > 2
+info break
+c
+b @ 5 if $i > 10
+c
+q
+--EXPECTF--
+[Successful compilation of %s]
+prompt> [Conditional breakpoint #0 added %s]
+prompt> [Conditional breakpoint #0: at %s:3#3 %s at %s:3, hits: 1]
+>00003: echo $i++;
+ 00004: echo $i++;
+ 00005: echo $i++;
+prompt> [Conditional breakpoint #1 added %s]
+prompt> ------------------------------------------------
+Conditional Breakpoints:
+#0%wat %s:3 if $i > 1
+#1%wat %s:4 if $i > 2
+prompt> 1
+[Conditional breakpoint #1: at %s:4#4 %s at %s:4, hits: 1]
+>00004: echo $i++;
+ 00005: echo $i++;
+ 00006: echo $i++;
+prompt> [Conditional breakpoint #2 added %s]
+prompt> 234
+[Script ended normally]
+prompt>
+--FILE--
+<?php
+$i = 1;
+echo $i++;
+echo $i++;
+echo $i++;
+echo $i++;


### PR DESCRIPTION
Fixes segfault when attempting to run after setting a conditional breakpoint
without specifying the file path.

Additionally, adds functionality so that NUMERIC_PARAM breakpoints
are supported in addition to FILE type. Emits an error if
other conditional breakpoint formats are used as they are currently
unsupported.