### PR TITLE
Make "prototype" the function which inheritance is checked against

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -326,6 +326,9 @@ typedef struct _zend_oparray_context {
 /* function is a destructor                               |     |     |     */
 #define ZEND_ACC_DTOR                    (1 << 29) /*     |  X  |     |     */
 /*                                                        |     |     |     */
+/* function is a destructor                               |     |     |     */
+#define ZEND_ACC_HAS_ABSTRACT_PARENT     (1 << 30) /*     |  X  |     |     */
+/*                                                        |     |     |     */
 /* op_array uses strict mode types                        |     |     |     */
 #define ZEND_ACC_STRICT_TYPES            (1U << 31) /*    |  X  |     |     */
 

--- a/ext/reflection/tests/ReflectionClass_toString_002.phpt
+++ b/ext/reflection/tests/ReflectionClass_toString_002.phpt
@@ -114,7 +114,7 @@ Class [ <user> class D extends C ] {
   }
 
   - Methods [1] {
-    Method [ <user, overwrites B, prototype A> public method f ] {
+    Method [ <user, overwrites B, prototype B> public method f ] {
       @@ %s 12 - 12
     }
   }


### PR DESCRIPTION
Currently the function "prototype" has a very peculiar definition, where it is not the function against which the inheritance check is performed (as would be expected from the name), but rather the first occurrence of the method in the inheritance hierarchy.

For #3732 we'd like the "prototype" field to be the actual prototype, which is almost always the direct parent. The only exception are constructors, in which case it will be either NULL or an abstract constructor somewhere higher up in the hierarchy.

Add a new ZEND_ACC_HAS_ABSTRACT_PARENT flag which is used to determine whether a failing LSP check should error or warn, as this can no longer be determined from the prototype after this change.