### PR TITLE
Implement RF bug #72777 - ensure stack limits on mbstring functions.

### DIFF
--- a/ext/mbstring/mbstring.h
+++ b/ext/mbstring/mbstring.h
@@ -166,6 +166,7 @@ ZEND_BEGIN_MODULE_GLOBALS(mbstring)
     void *http_output_conv_mimetypes;
 #if HAVE_MBREGEX
     struct _zend_mb_regex_globals *mb_regex_globals;
+    zend_long regex_stack_limit;
 #endif
 	char *last_used_encoding_name;
 	const mbfl_encoding *last_used_encoding;

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -34,6 +34,18 @@
 #include <oniguruma.h>
 #undef UChar
 
+#if ONIGURUMA_VERSION_INT < 60800
+typedef void OnigMatchParam;
+#define onig_new_match_param() (NULL)
+#define onig_initialize_match_param(x)
+#define onig_set_match_stack_limit_size_of_match_param(x, y)
+#define onig_free_match_param(x)
+#define onig_search_with_param(reg, str, end, start, range, region, option, mp) \
+		onig_search(reg, str, end, start, range, region, option)
+#define onig_match_with_param(re, str, end, at, region, option, mp) \
+		onig_match(re, str, end, at, region, option)
+#endif
+
 ZEND_EXTERN_MODULE_GLOBALS(mbstring)
 
 struct _zend_mb_regex_globals {
@@ -856,7 +868,7 @@ static int _php_mb_onig_search(regex_t* reg, const OnigUChar* str, const OnigUCh
 	OnigMatchParam *mp = onig_new_match_param();
 	int err;
 	onig_initialize_match_param(mp);
-	if(MBSTRG(regex_stack_limit) > 0 && MBSTRG(regex_stack_limit) < UINT_MAX) {
+	if (!ZEND_LONG_UINT_OVFL(MBSTRG(regex_stack_limit))) {
 		onig_set_match_stack_limit_size_of_match_param(mp, (unsigned int)MBSTRG(regex_stack_limit));
 	}
 	/* search */

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -850,6 +850,23 @@ PHP_FUNCTION(mb_regex_encoding)
 }
 /* }}} */
 
+/* {{{ _php_mb_onig_search */
+static int _php_mb_onig_search(regex_t* reg, const OnigUChar* str, const OnigUChar* end, const OnigUChar* start,
+                   const OnigUChar* range, OnigRegion* region, OnigOptionType option) {
+	OnigMatchParam *mp = onig_new_match_param();
+	int err;
+	onig_initialize_match_param(mp);
+	if(MBSTRG(regex_stack_limit) > 0 && MBSTRG(regex_stack_limit) < UINT_MAX) {
+		onig_set_match_stack_limit_size_of_match_param(mp, (unsigned int)MBSTRG(regex_stack_limit));
+	}
+	/* search */
+	err = onig_search_with_param(reg, str, end, start, range, region, option, mp);
+	onig_free_match_param(mp);
+	return err;
+}
+/* }}} */
+
+
 /* {{{ _php_mb_regex_ereg_exec */
 static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 {
@@ -909,7 +926,7 @@ static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 	regs = onig_region_new();
 
 	/* actually execute the regular expression */
-	if (onig_search(re, (OnigUChar *)string, (OnigUChar *)(string + string_len), (OnigUChar *)string, (OnigUChar *)(string + string_len), regs, 0) < 0) {
+	if (_php_mb_onig_search(re, (OnigUChar *)string, (OnigUChar *)(string + string_len), (OnigUChar *)string, (OnigUChar *)(string + string_len), regs, 0) < 0) {
 		RETVAL_FALSE;
 		goto out;
 	}
@@ -1086,7 +1103,7 @@ static void _php_mb_regex_ereg_replace_exec(INTERNAL_FUNCTION_PARAMETERS, OnigOp
 	string_lim = (OnigUChar*)(string + string_len);
 	regs = onig_region_new();
 	while (err >= 0) {
-		err = onig_search(re, (OnigUChar *)string, (OnigUChar *)string_lim, pos, (OnigUChar *)string_lim, regs, 0);
+		err = _php_mb_onig_search(re, (OnigUChar *)string, (OnigUChar *)string_lim, pos, (OnigUChar *)string_lim, regs, 0);
 		if (err <= -2) {
 			OnigUChar err_str[ONIG_MAX_ERROR_MESSAGE_LEN];
 			onig_error_code_to_str(err_str, err);
@@ -1262,7 +1279,7 @@ PHP_FUNCTION(mb_split)
 	/* churn through str, generating array entries as we go */
 	while (count != 0 && (size_t)(pos - (OnigUChar *)string) < string_len) {
 		size_t beg, end;
-		err = onig_search(re, (OnigUChar *)string, (OnigUChar *)(string + string_len), pos, (OnigUChar *)(string + string_len), regs, 0);
+		err = _php_mb_onig_search(re, (OnigUChar *)string, (OnigUChar *)(string + string_len), pos, (OnigUChar *)(string + string_len), regs, 0);
 		if (err < 0) {
 			break;
 		}
@@ -1319,6 +1336,7 @@ PHP_FUNCTION(mb_ereg_match)
 	OnigSyntaxType *syntax;
 	OnigOptionType option = 0;
 	int err;
+	OnigMatchParam *mp;
 
 	{
 		char *option_str = NULL;
@@ -1342,8 +1360,14 @@ PHP_FUNCTION(mb_ereg_match)
 		RETURN_FALSE;
 	}
 
+	mp = onig_new_match_param();
+	onig_initialize_match_param(mp);
+	if(MBSTRG(regex_stack_limit) > 0 && MBSTRG(regex_stack_limit) < UINT_MAX) {
+		onig_set_match_stack_limit_size_of_match_param(mp, (unsigned int)MBSTRG(regex_stack_limit));
+	}
 	/* match */
-	err = onig_match(re, (OnigUChar *)string, (OnigUChar *)(string + string_len), (OnigUChar *)string, NULL, 0);
+	err = onig_match_with_param(re, (OnigUChar *)string, (OnigUChar *)(string + string_len), (OnigUChar *)string, NULL, 0, mp);
+	onig_free_match_param(mp);
 	if (err >= 0) {
 		RETVAL_TRUE;
 	} else {
@@ -1406,7 +1430,7 @@ _php_mb_regex_ereg_search_exec(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	}
 	MBREX(search_regs) = onig_region_new();
 
-	err = onig_search(MBREX(search_re), str, str + len, str + pos, str  + len, MBREX(search_regs), 0);
+	err = _php_mb_onig_search(MBREX(search_re), str, str + len, str + pos, str  + len, MBREX(search_regs), 0);
 	if (err == ONIG_MISMATCH) {
 		MBREX(search_pos) = len;
 		RETVAL_FALSE;

--- a/ext/mbstring/tests/mbregex_stack_limit.phpt
+++ b/ext/mbstring/tests/mbregex_stack_limit.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test oniguruma stack limit
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
+--FILE--
+<?php
+$s = str_repeat(' ', 30000);
+
+ini_set('mbstring.regex_stack_limit', 10000);
+var_dump(mb_ereg('\\s+$', $s));
+
+ini_set('mbstring.regex_stack_limit', 30000);
+var_dump(mb_ereg('\\s+$', $s));
+
+ini_set('mbstring.regex_stack_limit', 30001);
+var_dump(mb_ereg('\\s+$', $s));
+
+echo 'OK';
+?>
+--EXPECT--
+bool(false)
+bool(false)
+int(1)
+OK

--- a/ext/mbstring/tests/mbregex_stack_limit2.phpt
+++ b/ext/mbstring/tests/mbregex_stack_limit2.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test oniguruma stack limit
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
+--FILE--
+<?php
+function mb_trim( $string, $chars = "", $chars_array = array() )
+{
+    for( $x=0; $x<iconv_strlen( $chars ); $x++ ) $chars_array[] = preg_quote( iconv_substr( $chars, $x, 1 ) );
+    $encoded_char_list = implode( "|", array_merge( array( "\s","\t","\n","\r", "\0", "\x0B" ), $chars_array ) );
+
+    $string = mb_ereg_replace( "^($encoded_char_list)*", "", $string );
+    $string = mb_ereg_replace( "($encoded_char_list)*$", "", $string );
+    return $string;
+}
+
+ini_set('mbstring.regex_stack_limit', 10000);
+var_dump(mb_trim(str_repeat(' ', 10000)));
+
+echo 'OK';
+?>
+--EXPECTF--
+Warning: mb_ereg_replace(): mbregex search failure in php_mbereg_replace_exec(): match-stack limit over in %s on line %d
+string(0) ""
+OK

--- a/php.ini-development
+++ b/php.ini-development
@@ -1712,6 +1712,11 @@ zend.assertions = 1
 ; Default: mbstring.http_output_conv_mimetype=^(text/|application/xhtml\+xml)
 ;mbstring.http_output_conv_mimetype=
 
+; This directive specifies maximum stack depth for mbstring regular expressions. It is similar
+; to the pcre.recursion_limit for PCRE. 
+; Default: 100000
+;mbstring.regex_stack_limit=100000
+
 [gd]
 ; Tell the jpeg decode to ignore warnings and try to create
 ; a gd image. The warning will then be displayed as notices

--- a/php.ini-production
+++ b/php.ini-production
@@ -1719,6 +1719,11 @@ zend.assertions = -1
 ; Default: mbstring.http_output_conv_mimetype=^(text/|application/xhtml\+xml)
 ;mbstring.http_output_conv_mimetype=
 
+; This directive specifies maximum stack depth for mbstring regular expressions. It is similar
+; to the pcre.recursion_limit for PCRE. 
+; Default: 100000
+;mbstring.regex_stack_limit=100000
+
 [gd]
 ; Tell the jpeg decode to ignore warnings and try to create
 ; a gd image. The warning will then be displayed as notices


### PR DESCRIPTION
The patch creates new config: mbstring.regex_stack_limit, which defaults to 100000.

This is a port of https://github.com/php/php-src/pull/2109 to 7.3 since it has up-to-date oniguruma lib which allows to use thread-safe functions. Ideally should be also backported down to 7.1 but that requires either code change or oniguruma upgrade, so that will come later.