### PR TITLE
TSRM environ Lock

### DIFF
--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -99,6 +99,10 @@ extern "C" {
 TSRM_API int tsrm_startup(int expected_threads, int expected_resources, int debug_level, char *debug_filename);
 TSRM_API void tsrm_shutdown(void);
 
+/* environ lock API */
+TSRM_API int tsrm_env_lock();
+TSRM_API int tsrm_env_unlock();
+
 /* allocates a new thread-safe-resource id */
 TSRM_API ts_rsrc_id ts_allocate_id(ts_rsrc_id *rsrc_id, size_t size, ts_allocate_ctor ctor, ts_allocate_dtor dtor);
 
@@ -204,6 +208,9 @@ TSRM_API const char *tsrm_api_name(void);
 #endif
 
 #else /* non ZTS */
+
+#define tsrm_env_lock()    0
+#define tsrm_env_unlock()  0
 
 #define TSRMLS_FETCH()
 #define TSRMLS_FETCH_FROM_CTX(ctx)

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -954,6 +954,7 @@ PHPAPI void php_print_info(int flag)
 		SECTION("Environment");
 		php_info_print_table_start();
 		php_info_print_table_header(2, "Variable", "Value");
+		tsrm_env_lock();
 		for (env=environ; env!=NULL && *env !=NULL; env++) {
 			tmp1 = estrdup(*env);
 			if (!(tmp2=strchr(tmp1,'='))) { /* malformed entry? */
@@ -965,6 +966,7 @@ PHPAPI void php_print_info(int flag)
 			php_info_print_table_row(2, tmp1, tmp2);
 			efree(tmp1);
 		}
+        tsrm_env_unlock();
 		php_info_print_table_end();
 	}
 

--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -548,6 +548,8 @@ void _php_import_environment_variables(zval *array_ptr)
 	zval val;
 	zend_ulong idx;
 
+	tsrm_env_lock();
+
 	for (env = environ; env != NULL && *env != NULL; env++) {
 		p = strchr(*env, '=');
 		if (!p
@@ -572,6 +574,8 @@ void _php_import_environment_variables(zval *array_ptr)
 			php_register_variable_quick(*env, name_len, &val, Z_ARRVAL_P(array_ptr));
 		}
 	}
+	
+	tsrm_env_unlock();
 }
 
 zend_bool php_std_auto_global_callback(char *name, uint32_t name_len)

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -244,6 +244,7 @@ static void litespeed_php_import_environment_variables(zval *array_ptr)
         return;
     }
 
+    tsrm_env_lock();
     for (env = environ; env != NULL && *env != NULL; env++) {
         p = strchr(*env, '=');
         if (!p) {               /* malformed entry? */
@@ -258,6 +259,7 @@ static void litespeed_php_import_environment_variables(zval *array_ptr)
         t[nlen] = '\0';
         add_variable(t, nlen, p + 1, strlen( p + 1 ), array_ptr);
     }
+    tsrm_env_unlock();
     if (t != buf && t != NULL) {
         efree(t);
     }


### PR DESCRIPTION
This is a unix implementation of an environment lock for ZTS:

  - We use this to make putenv/getenv safe across threads.
  - We may use this to make setlocale behave also, I think.

I've tested this with an unreasonable number of threads thrashing the environment, there are no races, and no faults.

Issues:
  - We cannot write a test for this.

Thoughts welcome