### PR TITLE
Fix protected method and property visibility inconsistencies

### DIFF
--- a/Zend/tests/bug43483.phpt
+++ b/Zend/tests/bug43483.phpt
@@ -4,7 +4,6 @@ Bug #43483 (get_class_methods() does not list all visible methods)
 <?php
 class C {
 	public static function test() {
-		D::prot();
 		print_r(get_class_methods("D"));
 	}
 }
@@ -16,9 +15,7 @@ class D extends C {
 D::test();
 ?>
 --EXPECT--
-Successfully called D::prot().
 Array
 (
-    [0] => prot
-    [1] => test
+    [0] => test
 )

--- a/Zend/tests/bug45862.phpt
+++ b/Zend/tests/bug45862.phpt
@@ -6,7 +6,6 @@ Bug #45862 (get_class_vars is inconsistent with 'protected' and 'private' variab
 class Ancestor {
   function test() {
     var_dump(get_class_vars("Tester"));
-    var_dump(Tester::$prot);
   }
 }
 
@@ -29,11 +28,8 @@ $child->test();
 ?>
 --EXPECT--
  From parent scope
-array(1) {
-  ["prot"]=>
-  string(13) "protected var"
+array(0) {
 }
-string(13) "protected var"
 
  From child scope
 array(1) {

--- a/Zend/tests/class_const_no_prototype_visibility.phpt
+++ b/Zend/tests/class_const_no_prototype_visibility.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Prototype based visibility checks are not used for class constants
+--FILE--
+<?php
+
+class A {
+    protected const FOO = 'A';
+}
+class B1 extends A {
+    public static function test() {
+        var_dump(B2::FOO);
+    }
+}
+class B2 extends A {
+    protected const FOO = 'B2';
+}
+
+B1::test();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Cannot access protected const B2::FOO in %s:%d
+Stack trace:
+#0 %s(%d): B1::test()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/get_class_vars_003.phpt
+++ b/Zend/tests/get_class_vars_003.phpt
@@ -33,11 +33,9 @@ new C;
 
 ?>
 --EXPECT--
-array(6) {
+array(5) {
   ["aaa"]=>
   int(7)
-  ["ccc"]=>
-  int(9)
   ["a"]=>
   int(1)
   ["aa"]=>

--- a/Zend/tests/property_prototype.phpt
+++ b/Zend/tests/property_prototype.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Prototype based protected visibility check for properties
+--FILE--
+<?php
+
+class A {
+    protected $foo = 'A';
+}
+
+class B1 extends A {
+    public function test($obj) {
+        var_dump($obj->foo);
+    }
+}
+
+class B2 extends A {
+    protected $foo = 'B2';
+}
+
+(new B1)->test(new B2);
+
+?>
+--EXPECT--
+string(2) "B2"

--- a/Zend/tests/protected_method_from_child.phpt
+++ b/Zend/tests/protected_method_from_child.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Cannot access protected method from child
+--FILE--
+<?php
+
+class A {
+    public function test() {
+        var_dump($this->method());
+    }
+}
+
+class B extends A {
+    protected function method() {}
+}
+
+(new B)->test();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Call to protected method B::method() from context 'A' in %s:%d
+Stack trace:
+#0 %s(%d): A->test()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/protected_property_from_child.phpt
+++ b/Zend/tests/protected_property_from_child.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Cannot access protected property from child
+--FILE--
+<?php
+
+class A {
+    public function test() {
+        var_dump($this->prop);
+    }
+}
+
+class B extends A {
+    protected $prop;
+}
+
+(new B)->test();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Cannot access protected property B::$prop in %s:%d
+Stack trace:
+#0 %s(%d): A->test()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3464,6 +3464,7 @@ static inline zend_string *zval_make_interned_string(zval *zv) /* {{{ */
 ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type) /* {{{ */
 {
 	zend_property_info *property_info, *property_info_ptr;
+	zend_class_entry *prototype_ce = ce;
 
 	if (ZEND_TYPE_IS_SET(type)) {
 		ce->ce_flags |= ZEND_ACC_HAS_TYPE_HINTS;
@@ -3488,6 +3489,7 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 	if (access_type & ZEND_ACC_STATIC) {
 		if ((property_info_ptr = zend_hash_find_ptr(&ce->properties_info, name)) != NULL &&
 		    (property_info_ptr->flags & ZEND_ACC_STATIC) != 0) {
+			prototype_ce = property_info_ptr->prototype_ce;
 			property_info->offset = property_info_ptr->offset;
 			zval_ptr_dtor(&ce->default_static_members_table[property_info->offset]);
 			zend_hash_del(&ce->properties_info, name);
@@ -3508,6 +3510,7 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 	} else {
 		if ((property_info_ptr = zend_hash_find_ptr(&ce->properties_info, name)) != NULL &&
 		    (property_info_ptr->flags & ZEND_ACC_STATIC) == 0) {
+			prototype_ce = property_info_ptr->prototype_ce;
 			property_info->offset = property_info_ptr->offset;
 			zval_ptr_dtor(&ce->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)]);
 			zend_hash_del(&ce->properties_info, name);
@@ -3556,6 +3559,7 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 	property_info->flags = access_type;
 	property_info->doc_comment = doc_comment;
 	property_info->ce = ce;
+	property_info->prototype_ce = prototype_ce;
 	property_info->type = type;
 
 	zend_hash_update_ptr(&ce->properties_info, name, property_info);

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1172,7 +1172,9 @@ ZEND_API void object_properties_load(zend_object *object, HashTable *properties)
    	zend_string *key;
    	zend_long h;
    	zend_property_info *property_info;
+	zend_class_entry *old_scope = EG(fake_scope);
 
+	EG(fake_scope) = object->ce;
    	ZEND_HASH_FOREACH_KEY_VAL(properties, h, key, prop) {
 		if (key) {
 			if (ZSTR_VAL(key)[0] == '\0') {
@@ -1221,6 +1223,7 @@ ZEND_API void object_properties_load(zend_object *object, HashTable *properties)
 			zval_add_ref(prop);
 		}
 	} ZEND_HASH_FOREACH_END();
+	EG(fake_scope) = old_scope;
 }
 /* }}} */
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1021,7 +1021,7 @@ static void add_class_vars(zend_class_entry *scope, zend_class_entry *ce, int st
 
 	ZEND_HASH_FOREACH_STR_KEY_PTR(&ce->properties_info, key, prop_info) {
 		if (((prop_info->flags & ZEND_ACC_PROTECTED) &&
-			 !zend_check_protected(prop_info->ce, scope)) ||
+			 !zend_check_protected(prop_info->prototype_ce, scope)) ||
 			((prop_info->flags & ZEND_ACC_PRIVATE) &&
 			  prop_info->ce != scope)) {
 			continue;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -336,12 +336,15 @@ typedef struct _zend_oparray_context {
 char *zend_visibility_string(uint32_t fn_flags);
 
 typedef struct _zend_property_info {
-	uint32_t offset; /* property offset for object properties or
-	                      property index for static properties */
+	/* Property offset for object properties or
+	 * property index for static properties. */
+	uint32_t offset;
 	uint32_t flags;
 	zend_string *name;
 	zend_string *doc_comment;
 	zend_class_entry *ce;
+	/* CE to use for this property when performing protected visibility check. */
+	zend_class_entry *prototype_ce;
 	zend_type type;
 } zend_property_info;
 

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -371,7 +371,7 @@ ZEND_METHOD(error_exception, __construct)
 	}
 
 	ZVAL_LONG(&tmp, severity);
-	zend_update_property_ex(zend_ce_exception, object, ZSTR_KNOWN(ZEND_STR_SEVERITY), &tmp);
+	zend_update_property_ex(zend_ce_error_exception, object, ZSTR_KNOWN(ZEND_STR_SEVERITY), &tmp);
 
 	if (argc >= 4) {
 		ZVAL_STR_COPY(&tmp, filename);
@@ -474,7 +474,8 @@ ZEND_METHOD(error_exception, getSeverity)
 
 	DEFAULT_0_PARAMS;
 
-	prop = GET_PROPERTY(ZEND_THIS, ZEND_STR_SEVERITY);
+	prop = zend_read_property_ex(
+		zend_ce_error_exception, ZEND_THIS, ZSTR_KNOWN(ZEND_STR_SEVERITY), 0, &rv);
 	ZVAL_DEREF(prop);
 	ZVAL_COPY(return_value, prop);
 }

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -795,6 +795,9 @@ static void do_inherit_property(zend_property_info *parent_info, zend_string *ke
 		}
 		_zend_hash_append_ptr(&ce->properties_info, key, child_info);
 	}
+
+	child_info->prototype_ce = parent_info->prototype_ce
+		? parent_info->prototype_ce : child_info->ce;
 }
 /* }}} */
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -331,13 +331,6 @@ static zend_always_inline zend_bool is_derived_class(zend_class_entry *child_cla
 }
 /* }}} */
 
-static zend_never_inline int is_protected_compatible_scope(zend_class_entry *ce, zend_class_entry *scope) /* {{{ */
-{
-	return scope &&
-		(is_derived_class(ce, scope) || is_derived_class(scope, ce));
-}
-/* }}} */
-
 static zend_never_inline zend_property_info *zend_get_parent_private_property(zend_class_entry *scope, zend_class_entry *ce, zend_string *member) /* {{{ */
 {
 	zval *zv;
@@ -433,7 +426,7 @@ wrong:
 				}
 			} else {
 				ZEND_ASSERT(flags & ZEND_ACC_PROTECTED);
-				if (UNEXPECTED(!is_protected_compatible_scope(property_info->ce, scope))) {
+				if (UNEXPECTED(!zend_check_protected(property_info->prototype_ce, scope))) {
 					goto wrong;
 				}
 			}
@@ -524,7 +517,7 @@ wrong:
 				}
 			} else {
 				ZEND_ASSERT(flags & ZEND_ACC_PROTECTED);
-				if (UNEXPECTED(!is_protected_compatible_scope(property_info->ce, scope))) {
+				if (UNEXPECTED(!zend_check_protected(property_info->prototype_ce, scope))) {
 					goto wrong;
 				}
 			}
@@ -1425,7 +1418,7 @@ ZEND_API zval *zend_std_get_static_property_with_info(zend_class_entry *ce, zend
 		}
 		if (property_info->ce != scope) {
 			if (UNEXPECTED(property_info->flags & ZEND_ACC_PRIVATE)
-			 || UNEXPECTED(!is_protected_compatible_scope(property_info->ce, scope))) {
+			 || UNEXPECTED(!zend_check_protected(property_info->prototype_ce, scope))) {
 				if (type != BP_VAR_IS) {
 					zend_bad_property_access(property_info, ce, property_name);
 				}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1133,18 +1133,6 @@ static zend_never_inline zend_function *zend_get_parent_private_method(zend_clas
  */
 ZEND_API int zend_check_protected(zend_class_entry *ce, zend_class_entry *scope) /* {{{ */
 {
-	zend_class_entry *fbc_scope = ce;
-
-	/* Is the context that's calling the function, the same as one of
-	 * the function's parents?
-	 */
-	while (fbc_scope) {
-		if (fbc_scope==scope) {
-			return 1;
-		}
-		fbc_scope = fbc_scope->parent;
-	}
-
 	/* Is the function's scope the same as our current object context,
 	 * or any of the parents of our context?
 	 */

--- a/ext/opcache/tests/bug74442.phpt
+++ b/ext/opcache/tests/bug74442.phpt
@@ -11,13 +11,14 @@ class Schema_Base {
     }
 }
 
-class Field_Base {
+abstract class Field_Base {
     public function __construct(array $params = null) {
         if (! is_array($params)) {
             $params = (array) $params;
         }
         call_user_func_array(array($this, 'acceptParams'), $params);
     }
+    abstract protected function acceptParams();
 }
 
 class Field_Integer extends Field_Base {

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -233,6 +233,10 @@ static void zend_hash_clone_prop_info(HashTable *ht)
 				prop_info->ce = ARENA_REALLOC(prop_info->ce);
 			}
 
+			if (IN_ARENA(prop_info->prototype_ce)) {
+				prop_info->prototype_ce = ARENA_REALLOC(prop_info->prototype_ce);
+			}
+
 			if (ZEND_TYPE_IS_CE(prop_info->type)) {
 				zend_class_entry *ce = ZEND_TYPE_CE(prop_info->type);
 				if (IN_ARENA(ce)) {

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -570,6 +570,7 @@ static void zend_file_cache_serialize_prop_info(zval                     *zv,
 		ZEND_ASSERT(prop->ce != NULL && prop->name != NULL);
 		if (!IS_SERIALIZED(prop->ce)) {
 			SERIALIZE_PTR(prop->ce);
+			SERIALIZE_PTR(prop->prototype_ce);
 			SERIALIZE_STR(prop->name);
 			if (prop->doc_comment) {
 				SERIALIZE_STR(prop->doc_comment);
@@ -1263,6 +1264,7 @@ static void zend_file_cache_unserialize_prop_info(zval                    *zv,
 		ZEND_ASSERT(prop->ce != NULL && prop->name != NULL);
 		if (!IS_UNSERIALIZED(prop->ce)) {
 			UNSERIALIZE_PTR(prop->ce);
+			UNSERIALIZE_PTR(prop->prototype_ce);
 			UNSERIALIZE_STR(prop->name);
 			if (prop->doc_comment) {
 				UNSERIALIZE_STR(prop->doc_comment);

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -728,6 +728,10 @@ static void zend_persist_property_info(zval *zv)
 	if (ce) {
 		prop->ce = ce;
 	}
+	ce = zend_shared_alloc_get_xlat_entry(prop->prototype_ce);
+	if (ce) {
+		prop->prototype_ce = ce;
+	}
 	zend_accel_store_interned_string(prop->name);
 	if (prop->doc_comment) {
 		if (ZCG(accel_directives).save_comments) {

--- a/ext/pdo/tests/pdo_018.phpt
+++ b/ext/pdo/tests/pdo_018.phpt
@@ -206,9 +206,9 @@ array(4) {
 ===INSERT===
 TestBase::serialize() = 'a:3:{s:7:"BasePub";s:6:"Public";s:7:"BasePro";s:9:"Protected";s:7:"BasePri";s:7:"Private";}'
 TestDerived::serialize()
-TestBase::serialize() = 'a:5:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:10:"DerivedPro";s:9:"Protected";s:7:"BasePri";s:7:"Private";}'
+TestBase::serialize() = 'a:4:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:7:"BasePri";s:7:"Private";}'
 TestDerived::serialize()
-TestBase::serialize() = 'a:5:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:10:"DerivedPro";s:9:"Protected";s:7:"BasePri";s:7:"Private";}'
+TestBase::serialize() = 'a:4:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:7:"BasePri";s:7:"Private";}'
 ===DATA===
 array(4) {
   [0]=>
@@ -216,9 +216,9 @@ array(4) {
   [1]=>
   string(91) "a:3:{s:7:"BasePub";s:6:"Public";s:7:"BasePro";s:9:"Protected";s:7:"BasePri";s:7:"Private";}"
   [2]=>
-  string(172) "a:5:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:10:"DerivedPro";s:9:"Protected";s:7:"BasePri";s:7:"Private";}"
+  string(138) "a:4:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:7:"BasePri";s:7:"Private";}"
   [3]=>
-  string(172) "a:5:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:10:"DerivedPro";s:9:"Protected";s:7:"BasePri";s:7:"Private";}"
+  string(138) "a:4:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:7:"BasePri";s:7:"Private";}"
 }
 ===FAILURE===
 Exception:SQLSTATE[HY000]: General error: cannot unserialize class
@@ -238,22 +238,22 @@ array(3) {
     ["name"]=>
     string(11) "TestDerived"
     ["val"]=>
-    string(172) "a:5:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:10:"DerivedPro";s:9:"Protected";s:7:"BasePri";s:7:"Private";}"
+    string(138) "a:4:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:7:"BasePri";s:7:"Private";}"
   }
   [2]=>
   array(2) {
     ["name"]=>
     NULL
     ["val"]=>
-    string(172) "a:5:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:10:"DerivedPro";s:9:"Protected";s:7:"BasePri";s:7:"Private";}"
+    string(138) "a:4:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:7:"BasePri";s:7:"Private";}"
   }
 }
 ===FETCHCLASS===
 TestBase::unserialize(a:3:{s:7:"BasePub";s:6:"Public";s:7:"BasePro";s:9:"Protected";s:7:"BasePri";s:7:"Private";})
 TestDerived::unserialize()
-TestBase::unserialize(a:5:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:10:"DerivedPro";s:9:"Protected";s:7:"BasePri";s:7:"Private";})
+TestBase::unserialize(a:4:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:7:"BasePri";s:7:"Private";})
 TestDerived::unserialize()
-TestBase::unserialize(a:5:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:10:"DerivedPro";s:9:"Protected";s:7:"BasePri";s:7:"Private";})
+TestBase::unserialize(a:4:{s:7:"BasePub";s:13:"DerivedPublic";s:7:"BasePro";s:16:"DerivdeProtected";s:10:"DerivedPub";s:6:"Public";s:7:"BasePri";s:7:"Private";})
 array(3) {
   [0]=>
   object(TestBase)#%d (3) {
@@ -273,7 +273,7 @@ array(3) {
     ["DerivedPub"]=>
     string(7) "#Public"
     ["DerivedPro":protected]=>
-    string(10) "#Protected"
+    string(9) "Protected"
     ["DerivedPri":"TestDerived":private]=>
     string(7) "Private"
     ["BasePri":"TestBase":private]=>
@@ -288,7 +288,7 @@ array(3) {
     ["DerivedPub"]=>
     string(7) "#Public"
     ["DerivedPro":protected]=>
-    string(10) "#Protected"
+    string(9) "Protected"
     ["DerivedPri":"TestDerived":private]=>
     string(7) "Private"
     ["BasePri":"TestBase":private]=>

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3744,7 +3744,7 @@ static void add_class_vars(zend_class_entry *ce, int statics, zval *return_value
 
 	ZEND_HASH_FOREACH_STR_KEY_PTR(&ce->properties_info, key, prop_info) {
 		if (((prop_info->flags & ZEND_ACC_PROTECTED) &&
-		     !zend_check_protected(prop_info->ce, ce)) ||
+		     !zend_check_protected(prop_info->prototype_ce, ce)) ||
 		    ((prop_info->flags & ZEND_ACC_PRIVATE) &&
 		     prop_info->ce != ce)) {
 			continue;

--- a/ext/standard/tests/class_object/get_class_methods_basic_002.phpt
+++ b/ext/standard/tests/class_object/get_class_methods_basic_002.phpt
@@ -90,20 +90,18 @@ array(4) {
   string(9) "testFromC"
 }
 Accessing D from C:
-array(7) {
+array(6) {
   [0]=>
-  string(5) "protD"
-  [1]=>
   string(4) "pubD"
-  [2]=>
+  [1]=>
   string(9) "testFromD"
-  [3]=>
+  [2]=>
   string(5) "privC"
-  [4]=>
+  [3]=>
   string(5) "protC"
-  [5]=>
+  [4]=>
   string(4) "pubC"
-  [6]=>
+  [5]=>
   string(9) "testFromC"
 }
 Accessing X from C:

--- a/ext/standard/tests/class_object/get_class_vars_variation2.phpt
+++ b/ext/standard/tests/class_object/get_class_vars_variation2.phpt
@@ -119,27 +119,19 @@ array(6) {
 }
 
 -- From inside an  parent object instance --
-array(4) {
+array(2) {
   ["pub"]=>
   string(10) "public var"
-  ["prot"]=>
-  string(13) "protected var"
   ["pubs"]=>
   string(17) "public static var"
-  ["prots"]=>
-  string(20) "protected static var"
 }
 
 -- From a parents static context --
-array(4) {
+array(2) {
   ["pub"]=>
   string(10) "public var"
-  ["prot"]=>
-  string(13) "protected var"
   ["pubs"]=>
   string(17) "public static var"
-  ["prots"]=>
-  string(20) "protected static var"
 }
 
 -- From inside a child object instance --

--- a/ext/standard/tests/class_object/get_object_vars_basic_001.phpt
+++ b/ext/standard/tests/class_object/get_object_vars_basic_001.phpt
@@ -89,9 +89,7 @@ array(2) {
 
 ---( Superclass: )---
 A::test
-array(3) {
-  ["prot"]=>
-  string(7) "B::prot"
+array(2) {
   ["pub"]=>
   string(6) "B::pub"
   ["hiddenPriv"]=>

--- a/ext/standard/tests/class_object/get_object_vars_basic_002.phpt
+++ b/ext/standard/tests/class_object/get_object_vars_basic_002.phpt
@@ -53,9 +53,7 @@ array(4) {
 
 ---( Superclass: )---
 A::testA
-array(3) {
-  ["prot"]=>
-  string(7) "B::prot"
+array(2) {
   ["pub"]=>
   string(6) "B::pub"
   ["hiddenPriv"]=>

--- a/tests/lang/foreachLoopObjects.002.phpt
+++ b/tests/lang/foreachLoopObjects.002.phpt
@@ -267,7 +267,6 @@ object(C)#%d (5) {
 
 --> Using instance of D:
 in C::doForEachC
-string(10) "Original g"
 string(10) "Original a"
 string(10) "Original b"
 string(10) "Original c"
@@ -277,7 +276,7 @@ object(D)#%d (7) {
   ["f":"D":private]=>
   string(10) "Original f"
   ["g":protected]=>
-  string(9) "changed.g"
+  string(10) "Original g"
   ["a"]=>
   string(9) "changed.a"
   ["b"]=>
@@ -296,7 +295,6 @@ string(12) "Overridden a"
 string(12) "Overridden b"
 string(12) "Overridden c"
 string(12) "Overridden d"
-string(10) "Original g"
 string(10) "Original e"
 object(E)#%d (8) {
   ["a"]=>
@@ -312,7 +310,7 @@ object(E)#%d (8) {
   ["f":"D":private]=>
   string(10) "Original f"
   ["g":protected]=>
-  string(9) "changed.g"
+  string(10) "Original g"
   ["e":"C":private]=>
   string(9) "changed.e"
 }
@@ -376,7 +374,6 @@ object(C)#%d (5) {
 
 --> Using instance of D:
 in C::doForEach
-string(10) "Original g"
 string(10) "Original a"
 string(10) "Original b"
 string(10) "Original c"
@@ -386,7 +383,7 @@ object(D)#%d (7) {
   ["f":"D":private]=>
   string(10) "Original f"
   ["g":protected]=>
-  string(9) "changed.g"
+  string(10) "Original g"
   ["a"]=>
   string(9) "changed.a"
   ["b"]=>
@@ -450,7 +447,6 @@ string(12) "Overridden a"
 string(12) "Overridden b"
 string(12) "Overridden c"
 string(12) "Overridden d"
-string(10) "Original g"
 string(10) "Original e"
 object(E)#%d (8) {
   ["a"]=>
@@ -466,7 +462,7 @@ object(E)#%d (8) {
   ["f":"D":private]=>
   string(10) "Original f"
   ["g":protected]=>
-  string(9) "changed.g"
+  string(10) "Original g"
   ["e":"C":private]=>
   string(9) "changed.e"
 }


### PR DESCRIPTION
This:

 * Introduces a prototype based protected visibility check for properties, to be consistent with methods.
 * Removes bidirectional protected visibility support for everything, because the prototype based check already correctly models exactly what we want to allow and what we want to forbid.

TODO:
 * [ ] Extend prototype mechanism to protected class constants.
 * [ ] Fix opcache segfaults on Travis.