### PR TITLE
Split pcre cache into permanent and per-request caches

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2264,15 +2264,11 @@ static void accel_reset_pcre_cache(void)
 {
 	Bucket *p;
 
-	if (PCRE_G(per_request_cache)) {
-		return;
-	}
-
-	ZEND_HASH_FOREACH_BUCKET(&PCRE_G(pcre_cache), p) {
+	ZEND_HASH_FOREACH_BUCKET(&PCRE_G(pcre_permanent_cache), p) {
 		/* Remove PCRE cache entries with inconsistent keys */
 		if (zend_accel_in_shm(p->key)) {
 			p->key = NULL;
-			zend_hash_del_bucket(&PCRE_G(pcre_cache), p);
+			zend_hash_del_bucket(&PCRE_G(pcre_permanent_cache), p);
 		}
 	} ZEND_HASH_FOREACH_END();
 }

--- a/ext/pcre/php_pcre.h
+++ b/ext/pcre/php_pcre.h
@@ -64,13 +64,13 @@ PHPAPI pcre2_match_data *php_pcre_create_match_data(uint32_t, pcre2_code *);
 PHPAPI void php_pcre_free_match_data(pcre2_match_data *);
 
 ZEND_BEGIN_MODULE_GLOBALS(pcre)
-	HashTable pcre_cache;
+	HashTable pcre_permanent_cache;
+	HashTable pcre_request_cache;
 	zend_long backtrack_limit;
 	zend_long recursion_limit;
 #ifdef HAVE_PCRE_JIT_SUPPORT
 	zend_bool jit;
 #endif
-	zend_bool per_request_cache;
 	int  error_code;
 	/* Used for unmatched subpatterns in OFFSET_CAPTURE mode */
 	zval unmatched_null_pair;


### PR DESCRIPTION
In addition to the permanent pcre cache, maintain a separate per-request cache so that we can use string identity comparisons instead of having to do full zend_string_equal_content() on every cache fetch -- this can be quite costly if the regular expression is large.

This is an alternative to PR #3994 and could be considered a follow-up to PR #3985.

Uses the pcre_cache_entry refcount field to ensure that the permanent cache isn't cleaned while there is still a pointer to the entry in the request cache, but this cleaning mechanism could be further tuned.