### PR TITLE
filter_var: added range options to the float validation filter

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -34,6 +34,18 @@
 #endif
 
 
+/* {{{ FETCH_DOUBLE_OPTION(var_name, option_name) */
+#define FETCH_DOUBLE_OPTION(var_name, option_name) \
+   	var_name = 0; \
+	var_name##_set = 0; \
+	if (option_array) { \
+		if ((option_val = zend_hash_str_find(Z_ARRVAL_P(option_array), option_name, sizeof(option_name) - 1)) != NULL) {	\
+			var_name = zval_get_double(option_val); \
+			var_name##_set = 1; \
+		} \
+	}
+/* }}} */
+
 /* {{{ FETCH_LONG_OPTION(var_name, option_name) */
 #define FETCH_LONG_OPTION(var_name, option_name) \
    	var_name = 0; \
@@ -335,6 +347,8 @@ void php_filter_float(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 
 	zend_long lval;
 	double dval;
+	double min_range, max_range;
+	int   min_range_set, max_range_set;
 
 	int first, n;
 
@@ -367,6 +381,9 @@ void php_filter_float(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 	} else {
 		tsd_sep = "',.";
 	}
+
+	FETCH_DOUBLE_OPTION(min_range, "min_range");
+	FETCH_DOUBLE_OPTION(max_range, "max_range");
 
 	num = p = emalloc(len+1);
 	if (str < end && (*str == '+' || *str == '-')) {
@@ -419,10 +436,16 @@ void php_filter_float(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 	switch (is_numeric_string(num, p - num, &lval, &dval, 0)) {
 		case IS_LONG:
 			zval_ptr_dtor(value);
+			if ((min_range_set && (lval < min_range)) || (max_range_set && (lval > max_range))) {
+				goto error;
+			}
 			ZVAL_DOUBLE(value, (double)lval);
 			break;
 		case IS_DOUBLE:
 			if ((!dval && p - num > 1 && strpbrk(num, "123456789")) || !zend_finite(dval)) {
+				goto error;
+			}
+			if ((min_range_set && (dval < min_range)) || (max_range_set && (dval > max_range))) {
 				goto error;
 			}
 			zval_ptr_dtor(value);

--- a/ext/filter/tests/060.phpt
+++ b/ext/filter/tests/060.phpt
@@ -1,0 +1,78 @@
+--TEST--
+filter_var() - tests for the range options of filter FILTER_VALIDATE_FLOAT
+--INI--
+precision=14
+--SKIPIF--
+<?php if (!extension_loaded("filter")) die("skip"); ?>
+--FILE--
+<?php
+
+$values = [
+    null,
+    false,
+    0,
+    -1,
+    '-5.4',
+    '-5.5',
+    '2,000.00',
+    '2,000.01',
+    '1,999.9999999'
+];
+
+var_dump(filter_var(
+    $values,
+    FILTER_VALIDATE_FLOAT,
+    [
+        'options' => [
+            'min_range' => -5.4,
+            'max_range' => 2000,
+        ],
+        'flags' => FILTER_FLAG_ALLOW_THOUSAND | FILTER_REQUIRE_ARRAY
+    ]
+));
+
+var_dump(filter_var(
+    '1000',
+    FILTER_VALIDATE_FLOAT,
+    [
+        'options' => [
+            'max_range' => 999.999,
+            'default' => 0
+        ]
+    ]
+));
+
+var_dump(filter_var(
+    '-11',
+    FILTER_VALIDATE_FLOAT,
+    [
+        'options' => [
+            'min_range' => -10,
+            'default' => 0
+        ]
+    ]
+));
+?>
+--EXPECT--
+array(9) {
+  [0]=>
+  bool(false)
+  [1]=>
+  bool(false)
+  [2]=>
+  float(0)
+  [3]=>
+  float(-1)
+  [4]=>
+  float(-5.4)
+  [5]=>
+  bool(false)
+  [6]=>
+  float(2000)
+  [7]=>
+  bool(false)
+  [8]=>
+  float(1999.9999999)
+}
+int(0)
+int(0)


### PR DESCRIPTION
php_filter_int (called via the constant FILTER_VALIDATE_INT) has the options min_range
and max_range. they allow the user to not only test if a value is a double but also if
the value is inside a specific range. php_filter_float (called via the constant
FILTER_VALIDATE_FLOAT) didn't provide this yet, making validation of numeric but 
not-only-int values more complicated for the user.
this commits implements the options min_range and max_range for the function
php_filter_float to fix this inconsistency.