### PR TITLE
[PDO] Disable cloning of PDO handle/connection objects to avoid segfault

### DIFF
--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1403,6 +1403,7 @@ void pdo_dbh_init(void)
 	pdo_dbh_object_handlers.offset = XtOffsetOf(pdo_dbh_object_t, std);
 	pdo_dbh_object_handlers.dtor_obj = zend_objects_destroy_object;
 	pdo_dbh_object_handlers.free_obj = pdo_dbh_free_storage;
+	pdo_dbh_object_handlers.clone_obj = NULL;
 	pdo_dbh_object_handlers.get_method = dbh_method_get;
 	pdo_dbh_object_handlers.compare_objects = dbh_compare;
 	pdo_dbh_object_handlers.get_gc = dbh_get_gc;

--- a/ext/pdo/tests/bug_77849.phpt
+++ b/ext/pdo/tests/bug_77849.phpt
@@ -1,0 +1,35 @@
+--TEST--
+PDO Common: Bug #77849 (Unexpected segfault attempting to use cloned PDO object)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip');
+$dir = getenv('REDIR_TEST_DIR');
+if (false == $dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE__) . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+
+$db = PDOTest::factory();
+$db->exec('CREATE TABLE test(id INT NULL)');
+
+$stmt = $db->query('SELECT * FROM test');
+var_dump($stmt->fetchAll());
+
+$db2 = clone $db;
+
+$stmt2 = $db2->query('SELECT * FROM test');
+var_dump($stmt2->fetchAll());
+
+?>
+--EXPECTF--
+array(0) {
+}
+
+Fatal error: Uncaught Error: Trying to clone an uncloneable object of class PDO in %s
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/pdo/tests/bug_77849.phpt
+++ b/ext/pdo/tests/bug_77849.phpt
@@ -14,21 +14,9 @@ if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE_
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 
 $db = PDOTest::factory();
-$db->exec('CREATE TABLE test(id INT NULL)');
-
-$stmt = $db->query('SELECT * FROM test');
-var_dump($stmt->fetchAll());
-
 $db2 = clone $db;
-
-$stmt2 = $db2->query('SELECT * FROM test');
-var_dump($stmt2->fetchAll());
-
 ?>
 --EXPECTF--
-array(0) {
-}
-
 Fatal error: Uncaught Error: Trying to clone an uncloneable object of class PDO in %s
 Stack trace:
 #0 {main}


### PR DESCRIPTION
A simple fix for [bug 77849](https://bugs.php.net/bug.php?id=77849). However, there may be connections that can clone without issue, in which case a clone handle would be needed and would need to be done selectively.