### PR TITLE
Remove duplicate zend_unset_timeout()

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1927,11 +1927,6 @@ void php_request_shutdown(void *dummy)
 		shutdown_memory_manager(CG(unclean_shutdown) || !report_memleaks, 0);
 	} zend_end_try();
 
-	/* 16. Reset max_execution_time */
-	zend_try {
-		zend_unset_timeout();
-	} zend_end_try();
-
 #ifdef PHP_WIN32
 	if (PG(com_initialized)) {
 		CoUninitialize();


### PR DESCRIPTION
Steps 4 and 16 in `php_request_shutdown()` are the same. They both call `zend_unset_timeout()`.

It looks like the second was mistakenly not removed in 939875133a2c389d621a9999a8ede3ddbc9b6637.