### PR TITLE
Fix #77011: configure cannot detect iconv library on Mojave (macOS 10.14)

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2112,7 +2112,8 @@ AC_DEFUN([PHP_SETUP_ICONV], [
     fi
 
     if test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.a ||
-       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME
+       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME ||
+       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.tbd
     then
       PHP_CHECK_LIBRARY($iconv_lib_name, libiconv, [
         found_iconv=yes


### PR DESCRIPTION
Added ".tbd" extension support for libiconv on Mac to use CommandLineTools SDK shared library.

I know library detection code is being [ported](https://github.com/php/php-src/pull/3616#issuecomment-465039472) and [another PR](https://github.com/php/php-src/pull/3616) solved the same problem, but this is a simple and temporary solution which enables Mac Mojave users to keep contributing with PHP on this mean time.

I tested this patch running:

```bash
./configure --enable-debug --enable-cli --with-iconv=$(xcrun --show-sdk-path)/usr
```