### PR TITLE
Disable PACKAGE_* preprocessor symbols

### DIFF
--- a/build/build2.mk
+++ b/build/build2.mk
@@ -22,17 +22,20 @@ targets = configure $(config_h_in)
 
 PHP_AUTOCONF ?= 'autoconf'
 PHP_AUTOHEADER ?= 'autoheader'
+SED ?= 'sed'
 
 SUPPRESS_WARNINGS ?= 2>&1 | (egrep -v '(AC_PROG_CXXCPP was called before AC_PROG_CXX|defined in acinclude.m4 but never used)'||true)
 
 all: $(targets)
 
 $(config_h_in): configure
-# explicitly remove target since autoheader does not seem to work
-# correctly otherwise (timestamps are not updated)
+# Explicitly remove target since autoheader does not seem to work correctly
+# otherwise (timestamps are not updated).
+# Also disable PACKAGE_* symbols in php_config.h.in
 	@echo rebuilding $@
 	@rm -f $@
 	$(PHP_AUTOHEADER) $(SUPPRESS_WARNINGS)
+	$(SED) -e 's/^#undef PACKAGE_[^ ]*/\/\* && \*\//g' < $@ > $@.tmp && mv $@.tmp $@
 
 aclocal.m4: configure.ac acinclude.m4
 	@echo rebuilding $@

--- a/buildconf
+++ b/buildconf
@@ -3,6 +3,7 @@
 # A wrapper around Autoconf that generates files to build PHP on *nix systems.
 
 MAKE=${MAKE:-make}
+SED=${SED:-sed}
 force=0
 debug=0
 

--- a/configure.ac
+++ b/configure.ac
@@ -1727,11 +1727,4 @@ Check '[$]0 --help' for available options
 fi
 ])
 
-AC_CONFIG_COMMANDS_POST([
-  # Disable PACKAGE_* symbols in main/php_config.h.in
-  $SED -e 's/^#undef PACKAGE_[^ ]*/\/\* & \*\//g' < $srcdir/main/php_config.h.in \
-    > $srcdir/main/php_config.h.in.tmp && \
-    mv $srcdir/main/php_config.h.in.tmp $srcdir/main/php_config.h.in
-])
-
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -1726,4 +1726,12 @@ Check '[$]0 --help' for available options
 
 fi
 ])
+
+AC_CONFIG_COMMANDS_POST([
+  # Disable PACKAGE_* symbols in main/php_config.h.in
+  $SED -e 's/^#undef PACKAGE_[^ ]*/\/\* & \*\//g' < $srcdir/main/php_config.h.in \
+    > $srcdir/main/php_config.h.in.tmp && \
+    mv $srcdir/main/php_config.h.in.tmp $srcdir/main/php_config.h.in
+])
+
 AC_OUTPUT

--- a/ext/mbstring/libmbfl/config.h.in
+++ b/ext/mbstring/libmbfl/config.h.in
@@ -42,30 +42,6 @@
    */
 #undef LT_OBJDIR
 
-/* Name of package */
-#undef PACKAGE
-
-/* Define to the address where bug reports for this package should be sent. */
-#undef PACKAGE_BUGREPORT
-
-/* Define to the full name of this package. */
-#undef PACKAGE_NAME
-
-/* Define to the full name and version of this package. */
-#undef PACKAGE_STRING
-
-/* Define to the one symbol short name of this package. */
-#undef PACKAGE_TARNAME
-
-/* Define to the home page for this package. */
-#undef PACKAGE_URL
-
-/* Define to the version of this package. */
-#undef PACKAGE_VERSION
-
-/* Version number of package */
-#undef VERSION
-
 /* Define to rpl_malloc if the replacement function should be used. */
 #undef malloc
 

--- a/ext/pcre/pcre2lib/config.h
+++ b/ext/pcre/pcre2lib/config.h
@@ -7,11 +7,6 @@
 # include <php_config.h>
 #endif
 
-#undef PACKAGE_NAME
-#undef PACKAGE_VERSION
-#undef PACKAGE_TARNAME
-#undef PACKAGE_STRING
-
 #define SUPPORT_UNICODE 1
 #define SUPPORT_PCRE2_8 1
 

--- a/ext/pcre/upgrade-pcre.php
+++ b/ext/pcre/upgrade-pcre.php
@@ -109,11 +109,6 @@ $prepend_config_h = '
 # include <php_config.h>
 #endif
 
-#undef PACKAGE_NAME
-#undef PACKAGE_VERSION
-#undef PACKAGE_TARNAME
-#undef PACKAGE_STRING
-
 #define SUPPORT_UCP
 #define SUPPORT_UTF8
 

--- a/ext/pdo_pgsql/pdo_pgsql.c
+++ b/ext/pdo_pgsql/pdo_pgsql.c
@@ -29,11 +29,6 @@
 #include "php_pdo_pgsql_int.h"
 
 #ifdef HAVE_PG_CONFIG_H
-#undef PACKAGE_BUGREPORT
-#undef PACKAGE_NAME
-#undef PACKAGE_STRING
-#undef PACKAGE_TARNAME
-#undef PACKAGE_VERSION
 #include <pg_config.h>
 #endif
 

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -31,12 +31,6 @@
 #include "pdo/php_pdo_driver.h"
 #include "pdo/php_pdo_error.h"
 #include "ext/standard/file.h"
-
-#undef PACKAGE_BUGREPORT
-#undef PACKAGE_NAME
-#undef PACKAGE_STRING
-#undef PACKAGE_TARNAME
-#undef PACKAGE_VERSION
 #include "pg_config.h" /* needed for PG_VERSION */
 #include "php_pdo_pgsql.h"
 #include "php_pdo_pgsql_int.h"

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -38,12 +38,6 @@
 #ifdef PHP_WIN32
 # include "win32/time.h"
 #endif
-
-#undef PACKAGE_BUGREPORT
-#undef PACKAGE_NAME
-#undef PACKAGE_STRING
-#undef PACKAGE_TARNAME
-#undef PACKAGE_VERSION
 #include "php_pgsql.h"
 #include "php_globals.h"
 #include "zend_exceptions.h"

--- a/scripts/phpize.in
+++ b/scripts/phpize.in
@@ -160,6 +160,10 @@ phpize_autotools()
 {
   $PHP_AUTOCONF   || exit 1
   $PHP_AUTOHEADER || exit 1
+
+  # Disable PACKAGE_* symbols in config.h.in
+  $SED -e 's/^#undef PACKAGE_[^ ]*/\/\* & \*\//g' < config.h.in > config.h.in.tmp
+  mv config.h.in.tmp config.h.in
 }
 
 # Main script

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -205,4 +205,11 @@ test -d modules || $php_shtool mkdir modules
 
 AC_CONFIG_HEADERS([config.h])
 
+AC_CONFIG_COMMANDS_POST([
+  # Disable PACKAGE_* symbols in config.h.in
+  $SED -e 's/^#undef PACKAGE_[^ ]*/\/\* & \*\//g' < $srcdir/config.h.in \
+    > $srcdir/config.h.in.tmp && \
+    mv $srcdir/config.h.in.tmp $srcdir/config.h.in
+])
+
 AC_OUTPUT

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -205,11 +205,4 @@ test -d modules || $php_shtool mkdir modules
 
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_COMMANDS_POST([
-  # Disable PACKAGE_* symbols in config.h.in
-  $SED -e 's/^#undef PACKAGE_[^ ]*/\/\* & \*\//g' < $srcdir/config.h.in \
-    > $srcdir/config.h.in.tmp && \
-    mv $srcdir/config.h.in.tmp $srcdir/config.h.in
-])
-
 AC_OUTPUT


### PR DESCRIPTION
Hello, this is a fix for issue with phpize and redefined macros mentioned in #3967