### PR TITLE
Extend CURLFile to support streams

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2121,6 +2121,40 @@ PHP_FUNCTION(curl_copy_handle)
 }
 /* }}} */
 
+#if LIBCURL_VERSION_NUM >= 0x073800
+static size_t read_cb(char *buffer, size_t size, size_t nitems, void *arg) /* {{{ */
+{
+	php_stream *stream = (php_stream *) arg;
+	size_t numread = php_stream_read(stream, buffer, nitems * size);
+
+	if (numread == (size_t)-1) {
+		return CURL_READFUNC_ABORT;
+	}
+	return numread;
+}
+/* }}} */
+
+static int seek_cb(void *arg, curl_off_t offset, int origin) /* {{{ */
+{
+	php_stream *stream = (php_stream *) arg;
+	int res = php_stream_seek(stream, offset, origin);
+
+	if (res) {
+		return CURL_SEEKFUNC_FAIL;
+	}
+	return CURL_SEEKFUNC_OK;
+}
+/* }}} */
+
+static void free_cb(void *arg) /* {{{ */
+{
+	php_stream *stream = (php_stream *) arg;
+
+	php_stream_close(stream);
+}
+/* }}} */
+#endif
+
 static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{ */
 {
 	CURLcode error = CURLE_OK;
@@ -2756,6 +2790,10 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 						/* new-style file upload */
 						zval *prop, rv;
 						char *type = NULL, *filename = NULL;
+#if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+						php_stream *stream;
+						php_stream_statbuf ssb;
+#endif
 
 						prop = zend_read_property(curl_CURLFile_class, current, "name", sizeof("name")-1, 0, &rv);
 						if (Z_TYPE_P(prop) != IS_STRING) {
@@ -2777,13 +2815,21 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 							}
 
 #if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+							if (!(stream = php_stream_open_wrapper(ZSTR_VAL(postval), "rb", STREAM_MUST_SEEK, NULL))) {
+								zend_string_release_ex(string_key, 0);
+								return FAILURE;
+							}
+							if (php_stream_stat(stream, &ssb)) {
+								zend_string_release_ex(string_key, 0);
+								return FAILURE;
+							}
 							part = curl_mime_addpart(mime);
 							if (part == NULL) {
 								zend_string_release_ex(string_key, 0);
 								return FAILURE;
 							}
 							if ((form_error = curl_mime_name(part, ZSTR_VAL(string_key))) != CURLE_OK
-								|| (form_error = curl_mime_filedata(part, ZSTR_VAL(postval))) != CURLE_OK
+								|| (form_error = curl_mime_data_cb(part, ssb.sb.st_size, read_cb, seek_cb, free_cb, stream)) != CURLE_OK
 								|| (form_error = curl_mime_filename(part, filename ? filename : ZSTR_VAL(postval))) != CURLE_OK
 								|| (form_error = curl_mime_type(part, type ? type : "application/octet-stream")) != CURLE_OK) {
 								error = form_error;

--- a/ext/curl/php_curl.h
+++ b/ext/curl/php_curl.h
@@ -167,6 +167,7 @@ struct _php_curl_send_headers {
 struct _php_curl_free {
 	zend_llist str;
 	zend_llist post;
+	zend_llist stream;
 	HashTable *slist;
 };
 

--- a/ext/curl/tests/bug77711.phpt
+++ b/ext/curl/tests/bug77711.phpt
@@ -1,0 +1,32 @@
+--TEST--
+FR #77711 (CURLFile should support UNICODE filenames)
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_SAFE_UPLOAD, 1);
+curl_setopt($ch, CURLOPT_URL, "{$host}/get.php?test=file");
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+$filename = __DIR__ . '/АБВ.txt';
+file_put_contents($filename, "Test.");
+$file = curl_file_create($filename);
+$params = array('file' => $file);
+var_dump(curl_setopt($ch, CURLOPT_POSTFIELDS, $params));
+
+var_dump(curl_exec($ch));
+curl_close($ch);
+?>
+===DONE===
+--EXPECTF--
+bool(true)
+string(%d) "АБВ.txt|application/octet-stream"
+===DONE===
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/АБВ.txt');
+?>

--- a/ext/curl/tests/curl_copy_handle_variation3.phpt
+++ b/ext/curl/tests/curl_copy_handle_variation3.phpt
@@ -1,0 +1,38 @@
+--TEST--
+curl_copy_handle() allows to post CURLFile multiple times
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$ch1 = curl_init();
+curl_setopt($ch1, CURLOPT_SAFE_UPLOAD, 1);
+curl_setopt($ch1, CURLOPT_URL, "{$host}/get.php?test=file");
+curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
+
+$filename = __DIR__ . '/АБВ.txt';
+file_put_contents($filename, "Test.");
+$file = curl_file_create($filename);
+$params = array('file' => $file);
+var_dump(curl_setopt($ch1, CURLOPT_POSTFIELDS, $params));
+
+$ch2 = curl_copy_handle($ch1);
+
+var_dump(curl_exec($ch1));
+curl_close($ch1);
+
+var_dump(curl_exec($ch2));
+curl_close($ch2);
+?>
+===DONE===
+--EXPECTF--
+bool(true)
+string(%d) "АБВ.txt|application/octet-stream"
+string(%d) "АБВ.txt|application/octet-stream"
+===DONE===
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/АБВ.txt');
+?>

--- a/ext/curl/tests/curl_file_upload_stream.phpt
+++ b/ext/curl/tests/curl_file_upload_stream.phpt
@@ -1,0 +1,26 @@
+--TEST--
+CURL file uploading from stream
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_SAFE_UPLOAD, 1);
+curl_setopt($ch, CURLOPT_URL, "{$host}/get.inc?test=file");
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+$file = curl_file_create('data://text/plain;base64,SSBsb3ZlIFBIUAo=', 'text/plain', 'i-love-php');
+$params = array('file' => $file);
+var_dump(curl_setopt($ch, CURLOPT_POSTFIELDS, $params));
+
+var_dump(curl_exec($ch));
+curl_close($ch);
+?>
+===DONE===
+--EXPECT--
+bool(true)
+string(21) "i-love-php|text/plain"
+===DONE===

--- a/ext/curl/tests/curl_file_upload_stream.phpt
+++ b/ext/curl/tests/curl_file_upload_stream.phpt
@@ -2,6 +2,8 @@
 CURL file uploading from stream
 --SKIPIF--
 <?php include 'skipif.inc'; ?>
+<?php
+if (curl_version()['version_number'] < 0x73800) die('skip requires curl >= 7.56.0');
 --FILE--
 <?php
 include 'server.inc';


### PR DESCRIPTION
Due to former restrictions of the libcurl API, curl multipart/formdata
file uploads supported only proper files.  However, as of curl 7.56.0
the new `curl_mime_*()` API is available (and already supported by
PHP[1]), which allows us to support arbitrary *seekable* streams, which
is generally desirable, and particularly resolves issues with the
transparent Unicode and long part support on Windows (see bug #77711).

Note that older curl versions are still supported, but CURLFile is
still restricted to proper files in this case.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=a83b68ba56714bfa06737a61af795460caa4a105>