### PR TITLE
Use PKG_CHECK_MODULES to detect libxml2

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2091,76 +2091,14 @@ dnl
 dnl Common setup macro for libxml
 dnl
 AC_DEFUN([PHP_SETUP_LIBXML], [
-  found_libxml=no
+  PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= 2.7.6])
 
-  dnl First try to find xml2-config
-  AC_CACHE_CHECK([for xml2-config path], ac_cv_php_xml2_config_path,
-  [
-    for i in $PHP_LIBXML_DIR /usr/local /usr; do
-      if test -x "$i/bin/xml2-config"; then
-        ac_cv_php_xml2_config_path="$i/bin/xml2-config"
-        break
-      fi
-    done
-  ])
+  PHP_EVAL_INCLINE($LIBXML_CFLAGS)
+  PHP_EVAL_LIBLINE($LIBXML_LIBS, $1)
 
-  if test -x "$ac_cv_php_xml2_config_path"; then
-    XML2_CONFIG="$ac_cv_php_xml2_config_path"
-    libxml_full_version=`$XML2_CONFIG --version`
-    ac_IFS=$IFS
-    IFS="."
-    set $libxml_full_version
-    IFS=$ac_IFS
-    LIBXML_VERSION=`expr [$]1 \* 1000000 + [$]2 \* 1000 + [$]3`
-    if test "$LIBXML_VERSION" -ge "2007006"; then
-      found_libxml=yes
-      LIBXML_LIBS=`$XML2_CONFIG --libs`
-      LIBXML_INCS=`$XML2_CONFIG --cflags`
-    else
-      AC_MSG_ERROR([libxml2 version 2.7.6 or greater required.])
-    fi
-  fi
+  AC_DEFINE(HAVE_LIBXML, 1, [ ])
 
-  dnl If xml2-config fails, try pkg-config
-  if test "$found_libxml" = "no"; then
-    if test -z "$PKG_CONFIG"; then
-      AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-    fi
-
-    dnl If pkg-config is found try using it
-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libxml-2.0; then
-      if $PKG_CONFIG --atleast-version=2.6.11 libxml-2.0; then
-        found_libxml=yes
-        LIBXML_LIBS=`$PKG_CONFIG --libs libxml-2.0`
-        LIBXML_INCS=`$PKG_CONFIG --cflags-only-I libxml-2.0`
-      else
-        AC_MSG_ERROR([libxml2 version 2.6.11 or greater required.])
-      fi
-    fi
-  fi
-
-  if test "$found_libxml" = "yes"; then
-    PHP_EVAL_LIBLINE($LIBXML_LIBS, $1)
-    PHP_EVAL_INCLINE($LIBXML_INCS)
-
-    dnl Check that build works with given libs
-    AC_CACHE_CHECK(whether libxml build works, php_cv_libxml_build_works, [
-      PHP_TEST_BUILD(xmlInitParser,
-      [
-        php_cv_libxml_build_works=yes
-      ], [
-        AC_MSG_RESULT(no)
-        AC_MSG_ERROR([build test failed.  Please check the config.log for details.])
-      ], [
-        [$]$1
-      ])
-    ])
-    if test "$php_cv_libxml_build_works" = "yes"; then
-      AC_DEFINE(HAVE_LIBXML, 1, [ ])
-    fi
-    $2
-ifelse([$3],[],,[else $3])
-  fi
+  $2
 ])
 
 dnl -------------------------------------------------------------------------

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -9,7 +9,7 @@ PHP_ARG_ENABLE([dom],
 if test "$PHP_DOM" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([DOM extension requires LIBXML extension, add --enable-libxml])
+    AC_MSG_ERROR([DOM extension requires LIBXML extension, add --with-libxml])
   fi
 
   PHP_SETUP_LIBXML(DOM_SHARED_LIBADD, [

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -6,15 +6,6 @@ PHP_ARG_ENABLE([dom],
     [Disable DOM support])],
   [yes])
 
-if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH([libxml-dir],
-    [libxml2 install dir],
-    [AS_HELP_STRING([[--with-libxml-dir[=DIR]]],
-      [DOM: libxml2 install prefix])],
-    [no],
-    [no])
-fi
-
 if test "$PHP_DOM" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -28,7 +28,5 @@ if test "$PHP_DOM" != "no"; then
     PHP_SUBST(DOM_SHARED_LIBADD)
     PHP_INSTALL_HEADERS([ext/dom/xml_common.h])
     PHP_ADD_EXTENSION_DEP(dom, libxml)
-  ], [
-    AC_MSG_ERROR([libxml2 not found. Please check your libxml2 installation.])
   ])
 fi

--- a/ext/libxml/config0.m4
+++ b/ext/libxml/config0.m4
@@ -6,15 +6,6 @@ PHP_ARG_ENABLE([libxml],
     [Disable LIBXML support])],
   [yes])
 
-if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH([libxml-dir],
-    [libxml2 install dir],
-    [AS_HELP_STRING([[--with-libxml-dir[=DIR]]],
-      [LIBXML: libxml2 install prefix])],
-    [no],
-    [no])
-fi
-
 if test "$PHP_LIBXML" != "no"; then
 
   dnl This extension can not be build as shared

--- a/ext/libxml/config0.m4
+++ b/ext/libxml/config0.m4
@@ -1,9 +1,9 @@
 dnl config.m4 for extension libxml
 
-PHP_ARG_ENABLE([libxml],
-  [whether to enable LIBXML support],
-  [AS_HELP_STRING([--disable-libxml],
-    [Disable LIBXML support])],
+PHP_ARG_WITH([libxml],
+  [whether to build with LIBXML support],
+  [AS_HELP_STRING([--without-libxml],
+    [Build without LIBXML support])],
   [yes])
 
 if test "$PHP_LIBXML" != "no"; then

--- a/ext/libxml/config0.m4
+++ b/ext/libxml/config0.m4
@@ -15,7 +15,5 @@ if test "$PHP_LIBXML" != "no"; then
     AC_DEFINE(HAVE_LIBXML,1,[ ])
     PHP_NEW_EXTENSION(libxml, [libxml.c], $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
     PHP_INSTALL_HEADERS([ext/libxml/php_libxml.h])
-  ], [
-    AC_MSG_ERROR([libxml2 not found. Please check your libxml2 installation.])
   ])
 fi

--- a/ext/simplexml/config.m4
+++ b/ext/simplexml/config.m4
@@ -6,15 +6,6 @@ PHP_ARG_ENABLE([simplexml],
     [Disable SimpleXML support])],
   [yes])
 
-if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH([libxml-dir],
-    [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir=DIR],
-      [SimpleXML: libxml2 install prefix])],
-    [no],
-    [no])
-fi
-
 if test "$PHP_SIMPLEXML" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then

--- a/ext/simplexml/config.m4
+++ b/ext/simplexml/config.m4
@@ -17,8 +17,6 @@ if test "$PHP_SIMPLEXML" != "no"; then
     PHP_NEW_EXTENSION(simplexml, simplexml.c sxe.c, $ext_shared)
     PHP_INSTALL_HEADERS([ext/simplexml/php_simplexml.h ext/simplexml/php_simplexml_exports.h])
     PHP_SUBST(SIMPLEXML_SHARED_LIBADD)
-  ], [
-    AC_MSG_ERROR([libxml2 not found. Please check your libxml2 installation.])
   ])
   PHP_ADD_EXTENSION_DEP(simplexml, libxml)
   PHP_ADD_EXTENSION_DEP(simplexml, spl, true)

--- a/ext/simplexml/config.m4
+++ b/ext/simplexml/config.m4
@@ -9,7 +9,7 @@ PHP_ARG_ENABLE([simplexml],
 if test "$PHP_SIMPLEXML" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([SimpleXML extension requires LIBXML extension, add --enable-libxml])
+    AC_MSG_ERROR([SimpleXML extension requires LIBXML extension, add --with-libxml])
   fi
 
   PHP_SETUP_LIBXML(SIMPLEXML_SHARED_LIBADD, [

--- a/ext/soap/config.m4
+++ b/ext/soap/config.m4
@@ -8,7 +8,7 @@ PHP_ARG_ENABLE([soap],
 if test "$PHP_SOAP" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([SOAP extension requires LIBXML extension, add --enable-libxml])
+    AC_MSG_ERROR([SOAP extension requires LIBXML extension, add --with-libxml])
   fi
 
   PHP_SETUP_LIBXML(SOAP_SHARED_LIBADD, [

--- a/ext/soap/config.m4
+++ b/ext/soap/config.m4
@@ -15,7 +15,5 @@ if test "$PHP_SOAP" != "no"; then
     AC_DEFINE(HAVE_SOAP,1,[ ])
     PHP_NEW_EXTENSION(soap, soap.c php_encoding.c php_http.c php_packet_soap.c php_schema.c php_sdl.c php_xml.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
     PHP_SUBST(SOAP_SHARED_LIBADD)
-  ], [
-    AC_MSG_ERROR([libxml2 not found. Please check your libxml2 installation.])
   ])
 fi

--- a/ext/soap/config.m4
+++ b/ext/soap/config.m4
@@ -5,15 +5,6 @@ PHP_ARG_ENABLE([soap],
   [AS_HELP_STRING([--enable-soap],
     [Enable SOAP support])])
 
-if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH([libxml-dir],
-    [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir=DIR],
-      [SOAP: libxml2 install prefix])],
-    [no],
-    [no])
-fi
-
 if test "$PHP_SOAP" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then

--- a/ext/xml/config.m4
+++ b/ext/xml/config.m4
@@ -6,15 +6,6 @@ PHP_ARG_ENABLE([xml],
     [Disable XML support])],
   [yes])
 
-if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH([libxml-dir],
-    [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir=DIR],
-      [XML: libxml2 install prefix])],
-    [no],
-    [no])
-fi
-
 PHP_ARG_WITH([libexpat-dir],
   [libexpat install dir],
   [AS_HELP_STRING([--with-libexpat-dir=DIR],
@@ -37,7 +28,7 @@ if test "$PHP_XML" != "no"; then
       xml_extra_sources="compat.c"
       PHP_ADD_EXTENSION_DEP(xml, libxml)
     ], [
-      AC_MSG_ERROR([libxml2 not found. Use --with-libxml-dir=<DIR>])
+      AC_MSG_ERROR([libxml2 not found.])
     ])
   fi
 

--- a/ext/xml/config.m4
+++ b/ext/xml/config.m4
@@ -27,8 +27,6 @@ if test "$PHP_XML" != "no"; then
     PHP_SETUP_LIBXML(XML_SHARED_LIBADD, [
       xml_extra_sources="compat.c"
       PHP_ADD_EXTENSION_DEP(xml, libxml)
-    ], [
-      AC_MSG_ERROR([libxml2 not found.])
     ])
   fi
 

--- a/ext/xml/config.m4
+++ b/ext/xml/config.m4
@@ -21,7 +21,7 @@ if test "$PHP_XML" != "no"; then
   if test "$PHP_LIBEXPAT_DIR" = "no"; then
 
     if test "$PHP_LIBXML" = "no"; then
-      AC_MSG_ERROR([XML extension requires LIBXML extension, add --enable-libxml])
+      AC_MSG_ERROR([XML extension requires LIBXML extension, add --with-libxml])
     fi
 
     PHP_SETUP_LIBXML(XML_SHARED_LIBADD, [

--- a/ext/xmlreader/config.m4
+++ b/ext/xmlreader/config.m4
@@ -9,7 +9,7 @@ PHP_ARG_ENABLE([xmlreader],
 if test "$PHP_XMLREADER" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([XMLReader extension requires LIBXML extension, add --enable-libxml])
+    AC_MSG_ERROR([XMLReader extension requires LIBXML extension, add --with-libxml])
   fi
 
   PHP_SETUP_LIBXML(XMLREADER_SHARED_LIBADD, [

--- a/ext/xmlreader/config.m4
+++ b/ext/xmlreader/config.m4
@@ -17,7 +17,5 @@ if test "$PHP_XMLREADER" != "no"; then
     PHP_NEW_EXTENSION(xmlreader, php_xmlreader.c, $ext_shared)
     PHP_ADD_EXTENSION_DEP(xmlreader, dom, true)
     PHP_SUBST(XMLREADER_SHARED_LIBADD)
-  ], [
-    AC_MSG_ERROR([libxml2 not found. Please check your libxml2 installation.])
   ])
 fi

--- a/ext/xmlreader/config.m4
+++ b/ext/xmlreader/config.m4
@@ -6,15 +6,6 @@ PHP_ARG_ENABLE([xmlreader],
     [Disable XMLReader support])],
   [yes])
 
-if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH([libxml-dir],
-    [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir=DIR],
-      [XMLReader: libxml2 install prefix])],
-    [no],
-    [no])
-fi
-
 if test "$PHP_XMLREADER" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then

--- a/ext/xmlrpc/config.m4
+++ b/ext/xmlrpc/config.m4
@@ -10,15 +10,6 @@ PHP_ARG_WITH([xmlrpc],
   [AS_HELP_STRING([[--with-xmlrpc[=DIR]]],
     [Include XMLRPC-EPI support])])
 
-if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH([libxml-dir],
-    [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir=DIR],
-      [XMLRPC-EPI: libxml2 install prefix])],
-    [no],
-    [no])
-fi
-
 PHP_ARG_WITH([libexpat-dir],
   [libexpat dir for XMLRPC-EPI],
   [AS_HELP_STRING([--with-libexpat-dir=DIR],
@@ -54,7 +45,7 @@ if test "$PHP_XMLRPC" != "no"; then
         PHP_ADD_BUILD_DIR(ext/xml)
       fi
     ], [
-      AC_MSG_ERROR([libxml2 not found. Use --with-libxml-dir=<DIR>])
+      AC_MSG_ERROR([libxml2 not found.])
     ])
   else
     testval=no

--- a/ext/xmlrpc/config.m4
+++ b/ext/xmlrpc/config.m4
@@ -36,7 +36,7 @@ if test "$PHP_XMLRPC" != "no"; then
   if test "$PHP_LIBEXPAT_DIR" = "no"; then
 
     if test "$PHP_LIBXML" = "no"; then
-      AC_MSG_ERROR([XML-RPC extension requires LIBXML extension, add --enable-libxml])
+      AC_MSG_ERROR([XML-RPC extension requires LIBXML extension, add --with-libxml])
     fi
 
     PHP_SETUP_LIBXML(XMLRPC_SHARED_LIBADD, [

--- a/ext/xmlrpc/config.m4
+++ b/ext/xmlrpc/config.m4
@@ -44,8 +44,6 @@ if test "$PHP_XMLRPC" != "no"; then
         PHP_ADD_SOURCES(ext/xml, compat.c)
         PHP_ADD_BUILD_DIR(ext/xml)
       fi
-    ], [
-      AC_MSG_ERROR([libxml2 not found.])
     ])
   else
     testval=no

--- a/ext/xmlwriter/config.m4
+++ b/ext/xmlwriter/config.m4
@@ -6,15 +6,6 @@ PHP_ARG_ENABLE([xmlwriter],
     [Disable XMLWriter support])],
   [yes])
 
-if test -z "$PHP_LIBXML_DIR"; then
-  PHP_ARG_WITH([libxml-dir],
-    [libxml2 install dir],
-    [AS_HELP_STRING([--with-libxml-dir=DIR],
-      [XMLWriter: libxml2 install prefix])],
-    [no],
-    [no])
-fi
-
 if test "$PHP_XMLWRITER" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then

--- a/ext/xmlwriter/config.m4
+++ b/ext/xmlwriter/config.m4
@@ -9,7 +9,7 @@ PHP_ARG_ENABLE([xmlwriter],
 if test "$PHP_XMLWRITER" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([XMLWriter extension requires LIBXML extension, add --enable-libxml])
+    AC_MSG_ERROR([XMLWriter extension requires LIBXML extension, add --with-libxml])
   fi
 
   PHP_SETUP_LIBXML(XMLWRITER_SHARED_LIBADD, [

--- a/ext/xmlwriter/config.m4
+++ b/ext/xmlwriter/config.m4
@@ -16,7 +16,5 @@ if test "$PHP_XMLWRITER" != "no"; then
     AC_DEFINE(HAVE_XMLWRITER,1,[ ])
     PHP_NEW_EXTENSION(xmlwriter, php_xmlwriter.c, $ext_shared)
     PHP_SUBST(XMLWRITER_SHARED_LIBADD)
-  ], [
-    AC_MSG_ERROR([libxml2 not found. Please check your libxml2 installation.])
   ])
 fi

--- a/ext/xsl/config.m4
+++ b/ext/xsl/config.m4
@@ -9,7 +9,7 @@ PHP_ARG_WITH([xsl],
 if test "$PHP_XSL" != "no"; then
 
   if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([XSL extension requires LIBXML extension, add --enable-libxml])
+    AC_MSG_ERROR([XSL extension requires LIBXML extension, add --with-libxml])
   fi
 
   if test "$PHP_DOM" = "no"; then


### PR DESCRIPTION
This patchset updates libxml2 detection to use `PKG_CHECK_MODULES` instead of the legacy `xml2-config`, which does not support cross-compiling.