### PR TITLE
Make DateInterval objects uncomparable

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -656,8 +656,9 @@ static HashTable *date_object_get_gc_timezone(zval *object, zval **table, int *n
 static HashTable *date_object_get_debug_info_timezone(zval *object, int *is_temp);
 static void php_timezone_to_string(php_timezone_obj *tzobj, zval *zv);
 
-zval *date_interval_read_property(zval *object, zval *member, int type, void **cache_slot, zval *rv);
-zval *date_interval_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+static int date_interval_compare_objects(zval *o1, zval *o2);
+static zval *date_interval_read_property(zval *object, zval *member, int type, void **cache_slot, zval *rv);
+static zval *date_interval_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 static zval *date_interval_get_property_ptr_ptr(zval *object, zval *member, int type, void **cache_slot);
 static zval *date_period_read_property(zval *object, zval *member, int type, void **cache_slot, zval *rv);
 static zval *date_period_write_property(zval *object, zval *member, zval *value, void **cache_slot);
@@ -2164,6 +2165,7 @@ static void date_register_classes(void) /* {{{ */
 	date_object_handlers_interval.get_properties = date_object_get_properties_interval;
 	date_object_handlers_interval.get_property_ptr_ptr = date_interval_get_property_ptr_ptr;
 	date_object_handlers_interval.get_gc = date_object_get_gc_interval;
+	date_object_handlers_interval.compare_objects = date_interval_compare_objects;
 
 	INIT_CLASS_ENTRY(ce_period, "DatePeriod", date_funcs_period);
 	ce_period.create_object = date_object_new_period;
@@ -4142,8 +4144,16 @@ static int date_interval_initialize(timelib_rel_time **rt, /*const*/ char *forma
 	return retval;
 } /* }}} */
 
+static int date_interval_compare_objects(zval *o1, zval *o2) {
+	/* There is no well defined way to compare intervals like P1M and P30D, which may compare
+	 * smaller, equal or greater depending on the point in time at which the interval starts. As
+	 * such, we treat DateInterval objects are non-comparable and emit a warning. */
+	zend_error(E_WARNING, "Cannot compare DateInterval objects");
+	return 1;
+}
+
 /* {{{ date_interval_read_property */
-zval *date_interval_read_property(zval *object, zval *member, int type, void **cache_slot, zval *rv)
+static zval *date_interval_read_property(zval *object, zval *member, int type, void **cache_slot, zval *rv)
 {
 	php_interval_obj *obj;
 	zval *retval;
@@ -4214,7 +4224,7 @@ zval *date_interval_read_property(zval *object, zval *member, int type, void **c
 /* }}} */
 
 /* {{{ date_interval_write_property */
-zval *date_interval_write_property(zval *object, zval *member, zval *value, void **cache_slot)
+static zval *date_interval_write_property(zval *object, zval *member, zval *value, void **cache_slot)
 {
 	php_interval_obj *obj;
 	zval tmp_member;

--- a/ext/date/tests/bug70810.phpt
+++ b/ext/date/tests/bug70810.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug #70810: DateInterval equals every other DateInterval
+--FILE--
+<?php
+
+$i1 = new DateInterval('P1D');
+$i2 = new DateInterval('PT1H');
+var_dump($i1 == $i2);
+var_dump($i1 < $i2);
+var_dump($i1 > $i2);
+
+$i2 = new DateInterval('P1D');
+var_dump($i1 == $i2);
+var_dump($i1 < $i2);
+var_dump($i1 > $i2);
+
+?>
+--EXPECTF--
+Warning: Cannot compare DateInterval objects in %s on line %d
+bool(false)
+
+Warning: Cannot compare DateInterval objects in %s on line %d
+bool(false)
+
+Warning: Cannot compare DateInterval objects in %s on line %d
+bool(false)
+
+Warning: Cannot compare DateInterval objects in %s on line %d
+bool(false)
+
+Warning: Cannot compare DateInterval objects in %s on line %d
+bool(false)
+
+Warning: Cannot compare DateInterval objects in %s on line %d
+bool(false)

--- a/ext/date/tests/bug74639.phpt
+++ b/ext/date/tests/bug74639.phpt
@@ -19,10 +19,6 @@ if ($period->getEndDate() != $clonedPeriod->getEndDate()) {
     echo "failure\n";
 }
 
-if ($period->getDateInterval() != $clonedPeriod->getDateInterval()) {
-    echo "failure\n";
-}
-
 if ($interval->format('Y-m-d H:i:s') != $clonedInterval->format('Y-m-d H:i:s')) {
     echo "failure\n";
 }


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=70810 among others.

The problem is that right now DateInterval uses normal object property comparison. As it doesn't have properties, all DateIntervals are considered equal, which is ... bad.

I've went through a couple iterations here, but in the end went with the simplest variant: When trying to compare two DateInterval objects, throw a warning and return 1 (uncomparable).

The problem here is that there are some intervals like `P1M` vs `P30D` that just don't have a well-defined comparison (in absence of a start point). We could carve out some special rules (e.g. consider DateIntervals equal if all components are equal), but I think we might be better off forbidding this entirely. A well-defied comparison of DateIntervals is possible by adding them to a start DateTime and comparing the result.