### PR TITLE
skeleton: spread the usage of strict_types

### DIFF
--- a/ext/skeleton/tests/001.phpt
+++ b/ext/skeleton/tests/001.phpt
@@ -7,7 +7,7 @@ if (!extension_loaded('%EXTNAME%')) {
 }
 ?>
 --FILE--
-<?php
+<?php declare(strict_types=1);
 echo 'The extension "%EXTNAME%" is available';
 ?>
 --EXPECT--

--- a/ext/skeleton/tests/002.phpt
+++ b/ext/skeleton/tests/002.phpt
@@ -7,7 +7,7 @@ if (!extension_loaded('%EXTNAME%')) {
 }
 ?>
 --FILE--
-<?php
+<?php declare(strict_types=1);
 $ret = %EXTNAME%_test1();
 
 var_dump($ret);

--- a/ext/skeleton/tests/003.phpt
+++ b/ext/skeleton/tests/003.phpt
@@ -7,7 +7,7 @@ if (!extension_loaded('%EXTNAME%')) {
 }
 ?>
 --FILE--
-<?php
+<?php declare(strict_types=1);
 var_dump(%EXTNAME%_test2());
 var_dump(%EXTNAME%_test2('PHP'));
 ?>


### PR DESCRIPTION
For anyone who uses the PHP skeleton in order to create a new
PHP extension, the unit tests should leverage strict_types
by default.