### PR TITLE
Use PKG_CHECK_MODULES to detect the kerberos libraries

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1911,56 +1911,12 @@ dnl
 dnl Common setup macro for kerberos
 dnl
 AC_DEFUN([PHP_SETUP_KERBEROS],[
-  found_kerberos=no
-  unset KERBEROS_CFLAGS
-  unset KERBEROS_LIBS
+  PKG_CHECK_MODULES([KERBEROS], [krb5-gssapi krb5])
 
-  dnl First try to find krb5-config
-  if test -z "$KRB5_CONFIG"; then
-    AC_PATH_PROG(KRB5_CONFIG, krb5-config, no, [$PATH:/usr/kerberos/bin:/usr/local/bin])
-  fi
+  PHP_EVAL_INCLINE($KERBEROS_CFLAGS)
+  PHP_EVAL_LIBLINE($KERBEROS_LIBS, $1)
 
-  dnl If krb5-config is found try using it
-  if test "$PHP_KERBEROS" != "no" && test -x "$KRB5_CONFIG"; then
-    KERBEROS_LIBS=`$KRB5_CONFIG --libs gssapi`
-    KERBEROS_CFLAGS=`$KRB5_CONFIG --cflags gssapi`
-
-    if test -n "$KERBEROS_LIBS"; then
-      found_kerberos=yes
-      PHP_EVAL_LIBLINE($KERBEROS_LIBS, $1)
-      PHP_EVAL_INCLINE($KERBEROS_CFLAGS)
-    fi
-  fi
-
-  dnl If still not found use old skool method
-  if test "$found_kerberos" = "no"; then
-
-    if test "$PHP_KERBEROS" = "yes"; then
-      PHP_KERBEROS="/usr/kerberos /usr/local /usr"
-    fi
-
-    for i in $PHP_KERBEROS; do
-      if test -f $i/$PHP_LIBDIR/libkrb5.a || test -f $i/$PHP_LIBDIR/libkrb5.$SHLIB_SUFFIX_NAME; then
-        PHP_KERBEROS_DIR=$i
-        break
-      fi
-    done
-
-    if test "$PHP_KERBEROS_DIR"; then
-      found_kerberos=yes
-      PHP_ADD_LIBPATH($PHP_KERBEROS_DIR/$PHP_LIBDIR, $1)
-      PHP_ADD_LIBRARY(gssapi_krb5, 1, $1)
-      PHP_ADD_LIBRARY(krb5, 1, $1)
-      PHP_ADD_LIBRARY(k5crypto, 1, $1)
-      PHP_ADD_LIBRARY(com_err,  1, $1)
-      PHP_ADD_INCLUDE($PHP_KERBEROS_DIR/include)
-    fi
-  fi
-
-  if test "$found_kerberos" = "yes"; then
 ifelse([$2],[],:,[$2])
-ifelse([$3],[],,[else $3])
-  fi
 ])
 
 dnl

--- a/ext/imap/config.m4
+++ b/ext/imap/config.m4
@@ -51,11 +51,6 @@ AC_DEFUN([PHP_IMAP_KRB_CHK], [
     PHP_SETUP_KERBEROS(IMAP_SHARED_LIBADD,
     [
       AC_DEFINE(HAVE_IMAP_KRB,1,[ ])
-    ], [
-      AC_MSG_ERROR([Kerberos libraries not found.
-
-      Check the path given to --with-kerberos (if no path is given, searches in /usr/kerberos, /usr/local and /usr )
-      ])
     ])
   else
     AC_EGREP_HEADER(auth_gss, $IMAP_INC_DIR/linkage.h, [
@@ -98,8 +93,8 @@ PHP_ARG_WITH([imap],
 
 PHP_ARG_WITH([kerberos],
   [for IMAP Kerberos support],
-  [AS_HELP_STRING([[--with-kerberos[=DIR]]],
-    [IMAP: Include Kerberos support. DIR is the Kerberos install prefix])],
+  [AS_HELP_STRING([--with-kerberos],
+    [IMAP: Include Kerberos support])],
   [no],
   [no])
 

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -7,7 +7,7 @@ PHP_ARG_WITH([openssl],
 
 PHP_ARG_WITH([kerberos],
   [for Kerberos support],
-  [AS_HELP_STRING([[--with-kerberos[=DIR]]],
+  [AS_HELP_STRING([--with-kerberos],
     [OPENSSL: Include Kerberos support])],
   [no],
   [no])


### PR DESCRIPTION
This patch uses `pkg-config` to detect the kerberos libraries, replacing the legacy `krb5-config` script with the `PKG_CHECK_MODULES` macro.