### PR TITLE
Reduce code required by json_determine_array_type

### DIFF
--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -49,18 +49,7 @@ static int php_json_determine_array_type(zval *val) /* {{{ */
 		if (HT_IS_PACKED(myht) && HT_IS_WITHOUT_HOLES(myht)) {
 			return PHP_JSON_OUTPUT_ARRAY;
 		}
-
-		idx = 0;
-		ZEND_HASH_FOREACH_KEY(myht, index, key) {
-			if (key) {
-				return PHP_JSON_OUTPUT_OBJECT;
-			} else {
-				if (index != idx) {
-					return PHP_JSON_OUTPUT_OBJECT;
-				}
-			}
-			idx++;
-		} ZEND_HASH_FOREACH_END();
+        return PHP_JSON_OUTPUT_OBJECT;
 	}
 
 	return PHP_JSON_OUTPUT_ARRAY;


### PR DESCRIPTION
Knowing that an array is packed without holes is enough to know if it should be encoded as an array or as an object.

There is no test who check the results of json_encode called with a packed array with holes. Not sure if worth to add one. I'll gladly do if required.