### PR TITLE
add gcc global register for aarch64

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -353,6 +353,9 @@ if test "$ZEND_GCC_GLOBAL_REGS" != "no"; then
 #if defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(i386)
 # define ZEND_VM_FP_GLOBAL_REG "%esi"
 # define ZEND_VM_IP_GLOBAL_REG "%edi"
+#elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__aarch64__)
+# define ZEND_VM_FP_GLOBAL_REG "x27"
+# define ZEND_VM_IP_GLOBAL_REG "x28"
 #elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__x86_64__)
 # define ZEND_VM_FP_GLOBAL_REG "%r14"
 # define ZEND_VM_IP_GLOBAL_REG "%r15"

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -353,9 +353,6 @@ if test "$ZEND_GCC_GLOBAL_REGS" != "no"; then
 #if defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(i386)
 # define ZEND_VM_FP_GLOBAL_REG "%esi"
 # define ZEND_VM_IP_GLOBAL_REG "%edi"
-#elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__aarch64__)
-# define ZEND_VM_FP_GLOBAL_REG "x27"
-# define ZEND_VM_IP_GLOBAL_REG "x28"
 #elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__x86_64__)
 # define ZEND_VM_FP_GLOBAL_REG "%r14"
 # define ZEND_VM_IP_GLOBAL_REG "%r15"
@@ -365,6 +362,9 @@ if test "$ZEND_GCC_GLOBAL_REGS" != "no"; then
 #elif defined(__IBMC__) && ZEND_GCC_VERSION >= 4002 && defined(__powerpc64__)
 # define ZEND_VM_FP_GLOBAL_REG "r28"
 # define ZEND_VM_IP_GLOBAL_REG "r29"
+#elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__aarch64__)
+# define ZEND_VM_FP_GLOBAL_REG "x27"
+# define ZEND_VM_IP_GLOBAL_REG "x28"
 #else
 # error "global register variables are not supported"
 #endif

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -47,6 +47,9 @@
 # if defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(i386)
 #  define ZEND_VM_FP_GLOBAL_REG "%esi"
 #  define ZEND_VM_IP_GLOBAL_REG "%edi"
+#elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__aarch64__)
+# define ZEND_VM_FP_GLOBAL_REG "x27"
+# define ZEND_VM_IP_GLOBAL_REG "x28"
 # elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__x86_64__)
 #  define ZEND_VM_FP_GLOBAL_REG "%r14"
 #  define ZEND_VM_IP_GLOBAL_REG "%r15"

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -47,9 +47,6 @@
 # if defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(i386)
 #  define ZEND_VM_FP_GLOBAL_REG "%esi"
 #  define ZEND_VM_IP_GLOBAL_REG "%edi"
-#elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__aarch64__)
-# define ZEND_VM_FP_GLOBAL_REG "x27"
-# define ZEND_VM_IP_GLOBAL_REG "x28"
 # elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__x86_64__)
 #  define ZEND_VM_FP_GLOBAL_REG "%r14"
 #  define ZEND_VM_IP_GLOBAL_REG "%r15"
@@ -59,6 +56,9 @@
 # elif defined(__IBMC__) && ZEND_GCC_VERSION >= 4002 && defined(__powerpc64__)
 #  define ZEND_VM_FP_GLOBAL_REG "r28"
 #  define ZEND_VM_IP_GLOBAL_REG "r29"
+# elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__aarch64__)
+#  define ZEND_VM_FP_GLOBAL_REG "x27"
+#  define ZEND_VM_IP_GLOBAL_REG "x28"
 # endif
 #endif
 


### PR DESCRIPTION
Hello,
I am glad to find out that php works well on arm64. I have tested on arm64 server that enable gcc global register for aarch64 can get obvious performance improved. It earned 10% performance improvement when I tested on wordpress on arm64 virtual machine. I hope to add these codes to master, Could you recieve it?

Best Wishes!