### PR TITLE
Enable -Werror in CI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1076,6 +1076,12 @@ else
   AC_MSG_RESULT([using system default])
 fi
 
+PHP_ARG_ENABLE([werror],,
+  [AS_HELP_STRING([--enable-werror],
+    [Enable -Werror])],
+  [no],
+  [no])
+
 dnl Extension configuration.
 dnl -------------------------------------------------------------------------
 
@@ -1446,6 +1452,11 @@ dnl This will go away, if we have a facility to run per-extension code
 dnl after the thread_safety decision was done
 if test "$PHP_THREAD_SAFETY" = "yes" && test "$PHP_MYSQL" = "yes"; then
   CPPFLAGS="$CPPFLAGS -DTHREAD=1"
+fi
+
+if test "$PHP_WERROR" = "yes"; then
+  CFLAGS="$CFLAGS -Werror"
+  CPPFLAGS="$CPPFLAGS -Werror"
 fi
 
 ZEND_EXT_TYPE="zend_extension"

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -74,6 +74,7 @@ $TS \
 --with-kerberos \
 --enable-sysvmsg \
 --enable-zend-test=shared \
+--enable-werror \
 > "$CONFIG_LOG_FILE"
 
 make "-j${MAKE_JOBS}" $MAKE_QUIET > "$MAKE_LOG_FILE"


### PR DESCRIPTION
Adding a new `--enable-werror` option to configure, because this needs to be set late, otherwise configure checks throwing warnings will fail.