### PR TITLE
Implement DateComparableInterval

### DIFF
--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -98,6 +98,9 @@ PHP_FUNCTION(timezone_version_get);
 PHP_METHOD(DateInterval, __construct);
 PHP_METHOD(DateInterval, __wakeup);
 PHP_METHOD(DateInterval, __set_state);
+PHP_METHOD(DateComparableInterval, __construct);
+PHP_METHOD(DateComparableInterval, __wakeup);
+PHP_METHOD(DateComparableInterval, __set_state);
 PHP_FUNCTION(date_interval_format);
 PHP_FUNCTION(date_interval_create_from_date_string);
 

--- a/ext/date/tests/DateComparableInterval_comparison.phpt
+++ b/ext/date/tests/DateComparableInterval_comparison.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Comparison of DateComparableInterval
+--FILE--
+<?php
+
+$d1 = new DateTime('2019-04-01');
+$d2 = new DateTime('2019-05-01');
+$d3 = new DateTime('2019-06-01');
+$d4 = new DateTime('2019-07-01');
+$i1 = $d1->diff($d2);
+$i2 = $d2->diff($d3);
+$i3 = $d3->diff($d4);
+
+// $i1, $i2 and $i3 are all one month long, however
+// $i1 and $i3 have 30 days, while $i2 has 31.
+var_dump($i1 <=> $i2);
+var_dump($i2 <=> $i3);
+var_dump($i1 <=> $i3);
+
+?>
+--EXPECT--
+int(-1)
+int(1)
+int(0)

--- a/ext/date/tests/DateComparableInterval_construction.phpt
+++ b/ext/date/tests/DateComparableInterval_construction.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Ensure no invalid DateComparableIntervals can be constructed
+--FILE--
+<?php
+
+try {
+    new DateComparableInterval("P1M");
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$payloads = [
+'O:22:"DateComparableInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:6;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:-99999;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}',
+'O:22:"DateComparableInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:6;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:6;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:1;s:21:"have_special_relative";i:0;}',
+'O:22:"DateComparableInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:6;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:6;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:1;}',
+];
+foreach ($payloads as $payload) {
+    try {
+        unserialize($payload);
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+try {
+    DateComparableInterval::__set_state(array(
+       'y' => 0,
+       'm' => 0,
+       'd' => 6,
+       'h' => 0,
+       'i' => 0,
+       's' => 0,
+       'f' => 0,
+       'weekday' => 0,
+       'weekday_behavior' => 0,
+       'first_last_day_of' => 0,
+       'invert' => 0,
+       'days' => -99999,
+       'special_type' => 0,
+       'special_amount' => 0,
+       'have_weekday_relative' => 0,
+       'have_special_relative' => 0,
+    ));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Call to private DateComparableInterval::__construct() from invalid context
+Malformed comparable interval
+Malformed comparable interval
+Malformed comparable interval
+Malformed comparable interval

--- a/ext/date/tests/bug45682.phpt
+++ b/ext/date/tests/bug45682.phpt
@@ -12,7 +12,7 @@ $diff = date_diff($date, $other);
 
 var_dump($diff);
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateComparableInterval)#%d (16) {
   ["y"]=>
   int(0)
   ["m"]=>

--- a/ext/date/tests/bug49081.phpt
+++ b/ext/date/tests/bug49081.phpt
@@ -9,7 +9,7 @@ Bug #49081 (DateTime::diff() mistake if start in January and interval > 28 days)
    print_r($d);
 ?>
 --EXPECT--
-DateInterval Object
+DateComparableInterval Object
 (
     [y] => 0
     [m] => 0

--- a/ext/date/tests/bug52113.phpt
+++ b/ext/date/tests/bug52113.phpt
@@ -33,7 +33,7 @@ var_dump($unser, $p);
 
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateComparableInterval)#%d (16) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -67,8 +67,8 @@ object(DateInterval)#%d (16) {
   ["have_special_relative"]=>
   int(0)
 }
-string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
-DateInterval::__set_state(array(
+string(342) "O:22:"DateComparableInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
+DateComparableInterval::__set_state(array(
    'y' => 0,
    'm' => 0,
    'd' => 0,
@@ -85,7 +85,7 @@ DateInterval::__set_state(array(
    'special_amount' => 0,
    'have_weekday_relative' => 0,
    'have_special_relative' => 0,
-))object(DateInterval)#%d (16) {
+))object(DateComparableInterval)#%d (16) {
   ["y"]=>
   int(0)
   ["m"]=>

--- a/ext/date/tests/bug53437_var4.phpt
+++ b/ext/date/tests/bug53437_var4.phpt
@@ -22,7 +22,7 @@ var_dump($df,
 ?>
 ==DONE==
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateComparableInterval)#%d (16) {
   ["y"]=>
   int(0)
   ["m"]=>

--- a/ext/date/tests/date_diff1.phpt
+++ b/ext/date/tests/date_diff1.phpt
@@ -28,7 +28,7 @@ object(DateTime)#2 (3) {
   ["timezone"]=>
   string(3) "EDT"
 }
-object(DateInterval)#%d (16) {
+object(DateComparableInterval)#%d (16) {
   ["y"]=>
   int(0)
   ["m"]=>

--- a/ext/date/tests/date_time_fractions.phpt
+++ b/ext/date/tests/date_time_fractions.phpt
@@ -58,7 +58,7 @@ microseconds = true
 2016-10-02 00:00:00.000000
 2016-10-03 12:00:00.000000
 2016-10-17 00:00:00.000000
-object(DateInterval)#%d (16) {
+object(DateComparableInterval)#%d (16) {
   ["y"]=>
   int(0)
   ["m"]=>


### PR DESCRIPTION
Following @derickr's suggestion in #4039, this changes DateTime::diff() to return a new DateComparableInterval class, which has well-defined comparison semantics.

TODO:

 * [ ] More comparison tests (only checked the tricky P1M case for now)
 * [ ] Naming? I've used DateComparableInterval here, Derick suggested DateAbsoluteInterval.

cc @frederikbosch @Antnee