### PR TITLE
Content-type: HTTP header

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -619,7 +619,8 @@ try_again:
 		if (soap_version == SOAP_1_2) {
 			if (context &&
 		           (tmp = php_stream_context_get_option(context, "http", "content_type")) != NULL &&
-		           Z_TYPE_P(tmp) == IS_STRING) {
+		           Z_TYPE_P(tmp) == IS_STRING &&
+		           Z_STRLEN_P(tmp) > 0) {
 				if (Z_STRLEN_P(tmp) > 0) {
 					smart_str_append_const(&soap_headers,"Content-Type: ");
 					smart_str_appendl(&soap_headers, Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
@@ -636,7 +637,8 @@ try_again:
 		} else {
 			if (context &&
 		           (tmp = php_stream_context_get_option(context, "http", "content_type")) != NULL &&
-		           Z_TYPE_P(tmp) == IS_STRING) {
+		           Z_TYPE_P(tmp) == IS_STRING &&
+		           Z_STRLEN_P(tmp) > 0) {
 				if (Z_STRLEN_P(tmp) > 0) {
 					smart_str_append_const(&soap_headers,"Content-Type: ");
 					smart_str_appendl(&soap_headers, Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -617,7 +617,16 @@ try_again:
 		smart_str_append_smart_str(&soap_headers, &soap_headers_z);
 
 		if (soap_version == SOAP_1_2) {
-			smart_str_append_const(&soap_headers,"Content-Type: application/soap+xml; charset=utf-8");
+			if (context &&
+		           (tmp = php_stream_context_get_option(context, "http", "content_type")) != NULL &&
+		           Z_TYPE_P(tmp) == IS_STRING) {
+				if (Z_STRLEN_P(tmp) > 0) {
+					smart_str_append_const(&soap_headers,"Content-Type: ");
+					smart_str_appendl(&soap_headers, Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
+				}
+			} else {
+				smart_str_append_const(&soap_headers,"Content-Type: application/soap+xml; charset=utf-8");
+			}
 			if (soapaction) {
 				smart_str_append_const(&soap_headers,"; action=\"");
 				smart_str_appends(&soap_headers, soapaction);
@@ -625,7 +634,17 @@ try_again:
 			}
 			smart_str_append_const(&soap_headers,"\r\n");
 		} else {
-			smart_str_append_const(&soap_headers,"Content-Type: text/xml; charset=utf-8\r\n");
+			if (context &&
+		           (tmp = php_stream_context_get_option(context, "http", "content_type")) != NULL &&
+		           Z_TYPE_P(tmp) == IS_STRING) {
+				if (Z_STRLEN_P(tmp) > 0) {
+					smart_str_append_const(&soap_headers,"Content-Type: ");
+					smart_str_appendl(&soap_headers, Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
+					smart_str_append_const(&soap_headers, "\r\n");
+				}
+			} else {
+				smart_str_append_const(&soap_headers,"Content-Type: text/xml; charset=utf-8\r\n");
+			}
 			if (soapaction) {
 				smart_str_append_const(&soap_headers, "SOAPAction: \"");
 				smart_str_appends(&soap_headers, soapaction);

--- a/ext/soap/tests/custumheader.phpt
+++ b/ext/soap/tests/custumheader.phpt
@@ -45,8 +45,34 @@ if (strpos($headers, 'Multipart/Related; action="misc-uri#foo"') === FALSE)
 else
   printf("Content-Type OK" . PHP_EOL);
 
+/*
+ * In case of an empty content-type, let's fallback to the default content.
+ */
+$client2 = new soapclient(NULL, [
+  'location' => 'http://' . PHP_CLI_SERVER_ADDRESS,
+  'uri' => 'misc-uri',
+  'soap_version' => SOAP_1_2,
+  'user_agent' => 'Vincent JARDIN, test headers',
+  'trace' => true, /* record the headers before sending */
+  'stream_context' => stream_context_create([
+    'http' => [
+      'header' => sprintf("MIME-Version: 1.0\r\n"),
+      'content_type' => sprintf("")
+    ],
+  ]),
+]);
+
+$client2->__soapCall("foo", [ 'arg1' => "XXXbar"]);
+
+$headers = $client2->__getLastRequestHeaders();
+
+if (strpos($headers, 'Content-Type: application/soap+xml; charset=utf-8; action="misc-uri#foo"') === FALSE)
+  printf("Content-Type Default NOK %s" . PHP_EOL, $headers);
+else
+  printf("Content-Type Default OK" . PHP_EOL);
 ?>
 ==DONE==
 --EXPECT--
 Content-Type OK
+Content-Type Default OK
 ==DONE==

--- a/ext/soap/tests/custumheader.phpt
+++ b/ext/soap/tests/custumheader.phpt
@@ -1,0 +1,70 @@
+--TEST--
+SOAP customized Content-Type, eg. SwA use case
+--SKIPIF--
+<?php
+	require_once('skipif.inc');
+
+	if (!file_exists(dirname(__FILE__) . "/../../../sapi/cli/tests/php_cli_server.inc")) {
+		echo "skip sapi/cli/tests/php_cli_server.inc required but not found";
+	}
+?>
+--FILE--
+<?php
+
+include dirname(__FILE__) . "/../../../sapi/cli/tests/php_cli_server.inc";
+
+$router = "custh_stubserver.php";
+$args = substr(PHP_OS, 0, 3) == 'WIN' ? "-d extension_dir=" . ini_get("extension_dir") . " -d extension=php_soap.dll" : "";
+$code = <<<'PHP'
+/* Receive */
+$content = trim(file_get_contents("php://input")) . PHP_EOL;
+
+$vars = serialize($_SERVER);
+
+/* record the headers */
+file_put_contents("custh_dump.log", $vars);
+//file_put_contents("custh_dump.log", $content, FILE_APPEND);
+PHP;
+
+php_cli_server_start($code, $router, $args);
+
+$client = new soapclient(NULL, [
+  'location' => 'http://' . PHP_CLI_SERVER_ADDRESS,
+  'uri' => 'misc-uri',
+  'soap_version' => SOAP_1_2,
+  'user_agent' => 'Vincent JARDIN, test headers',
+  'stream_context' => stream_context_create([
+    'http' => [
+      'header' => sprintf("MIME-Version: 1.0\r\n"),
+      'content_type' => sprintf("Multipart/Related")
+    ],
+  ]),
+]);
+
+$client->__soapCall("foo", [ 'arg1' => "XXXbar"]);
+
+$headers = unserialize(file_get_contents(dirname(__FILE__) . "/../../../sapi/cli/tests/" . "custh_dump.log"));
+
+//var_dump($headers);
+
+if ($headers['CONTENT_TYPE'] === 'Multipart/Related; action="misc-uri#foo"')
+  echo "Content-Type OK" . PHP_EOL;
+
+if ($headers['HTTP_CONTENT_TYPE'] === 'Multipart/Related; action="misc-uri#foo"')
+  echo "Content-Type OK" . PHP_EOL;
+
+if ($headers['HTTP_MIME_VERSION'] == '1.0')
+  echo "Mime OK" . PHP_EOL;
+
+?>
+==DONE==
+--CLEAN--
+<?php
+//unlink(dirname(__FILE__) . DIRECTORY_SEPARATOR . "custh_stubserver.php");
+unlink(dirname(__FILE__) . "/../../../sapi/cli/tests/" . "custh_dump.log");
+?>
+--EXPECT--
+Content-Type OK
+Content-Type OK
+Mime OK
+==DONE==

--- a/ext/soap/tests/custumheader.phpt
+++ b/ext/soap/tests/custumheader.phpt
@@ -4,14 +4,14 @@ SOAP customized Content-Type, eg. SwA use case
 <?php
 	require_once('skipif.inc');
 
-	if (!file_exists(dirname(__FILE__) . "/../../../sapi/cli/tests/php_cli_server.inc")) {
+	if (!file_exists(__DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc")) {
 		echo "skip sapi/cli/tests/php_cli_server.inc required but not found";
 	}
 ?>
 --FILE--
 <?php
 
-include dirname(__FILE__) . "/../../../sapi/cli/tests/php_cli_server.inc";
+include __DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc";
 
 $router = "custh_stubserver.php";
 $args = substr(PHP_OS, 0, 3) == 'WIN' ? "-d extension_dir=" . ini_get("extension_dir") . " -d extension=php_soap.dll" : "";
@@ -23,7 +23,6 @@ $vars = serialize($_SERVER);
 
 /* record the headers */
 file_put_contents("custh_dump.log", $vars);
-//file_put_contents("custh_dump.log", $content, FILE_APPEND);
 PHP;
 
 php_cli_server_start($code, $router, $args);
@@ -43,9 +42,7 @@ $client = new soapclient(NULL, [
 
 $client->__soapCall("foo", [ 'arg1' => "XXXbar"]);
 
-$headers = unserialize(file_get_contents(dirname(__FILE__) . "/../../../sapi/cli/tests/" . "custh_dump.log"));
-
-//var_dump($headers);
+$headers = unserialize(file_get_contents(__DIR__ . "/../../../sapi/cli/tests/custh_dump.log"));
 
 if ($headers['CONTENT_TYPE'] === 'Multipart/Related; action="misc-uri#foo"')
   echo "Content-Type OK" . PHP_EOL;
@@ -60,8 +57,7 @@ if ($headers['HTTP_MIME_VERSION'] == '1.0')
 ==DONE==
 --CLEAN--
 <?php
-//unlink(dirname(__FILE__) . DIRECTORY_SEPARATOR . "custh_stubserver.php");
-unlink(dirname(__FILE__) . "/../../../sapi/cli/tests/" . "custh_dump.log");
+unlink(__DIR__ . "/../../../sapi/cli/tests/custh_dump.log");
 ?>
 --EXPECT--
 Content-Type OK


### PR DESCRIPTION
override the HTTP header using the HTTP context:
$client = new SoapClient('http://url.wsdl&v=latest',
  [ 'stream_context' => stream_context_create([
    'http' => [
      'content_type' => 'foobarX',
    ],
                                              ]),
  ]);

This patch has been tested with PHP 7.2.x and 7.3.x too.