### PR TITLE
Remove html_errors from INI Quick Reference

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -108,11 +108,6 @@
 ;   Development Value: E_ALL
 ;   Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
 
-; html_errors
-;   Default Value: On
-;   Development Value: On
-;   Production value: On
-
 ; log_errors
 ;   Default Value: Off
 ;   Development Value: On
@@ -542,7 +537,7 @@ report_memleaks = On
 ; Development Value: On
 ; Production value: On
 ; http://php.net/html-errors
-html_errors = On
+;html_errors =
 
 ; If html_errors is set to On *and* docref_root is not empty, then PHP
 ; produces clickable error messages that direct to a page describing the error

--- a/php.ini-development
+++ b/php.ini-development
@@ -533,11 +533,8 @@ report_memleaks = On
 ; error message as HTML for easier reading. This directive controls whether
 ; the error message is formatted as HTML or not.
 ; Note: This directive is hardcoded to Off for the CLI SAPI
-; Default Value: On
-; Development Value: On
-; Production value: On
 ; http://php.net/html-errors
-;html_errors =
+;html_errors = On
 
 ; If html_errors is set to On *and* docref_root is not empty, then PHP
 ; produces clickable error messages that direct to a page describing the error

--- a/php.ini-production
+++ b/php.ini-production
@@ -108,11 +108,6 @@
 ;   Development Value: E_ALL
 ;   Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
 
-; html_errors
-;   Default Value: On
-;   Development Value: On
-;   Production value: On
-
 ; log_errors
 ;   Default Value: Off
 ;   Development Value: On
@@ -549,7 +544,7 @@ report_memleaks = On
 ; Development Value: On
 ; Production value: On
 ; http://php.net/html-errors
-html_errors = On
+;html_errors =
 
 ; If html_errors is set to On *and* docref_root is not empty, then PHP
 ; produces clickable error messages that direct to a page describing the error

--- a/php.ini-production
+++ b/php.ini-production
@@ -540,11 +540,8 @@ report_memleaks = On
 ; error message as HTML for easier reading. This directive controls whether
 ; the error message is formatted as HTML or not.
 ; Note: This directive is hardcoded to Off for the CLI SAPI
-; Default Value: On
-; Development Value: On
-; Production value: On
 ; http://php.net/html-errors
-;html_errors =
+;html_errors = On
 
 ; If html_errors is set to On *and* docref_root is not empty, then PHP
 ; produces clickable error messages that direct to a page describing the error


### PR DESCRIPTION
Just saw that compared to what @nikic told me for #3972 the html_erros INI is still present in the quick reference even though the values are identical in both INI files and in-engine (believing the comments).