### PR TITLE
Fix VirtualProtect() related Phar issues

### DIFF
--- a/appveyor/test_task.bat
+++ b/appveyor/test_task.bat
@@ -58,7 +58,7 @@ rem set OPENSSL_CONF=
 rem set SSLEAY_CONF=
 
 rem prepare for Opcache
-if "%OPCACHE%" equ "1" set OPCACHE_OPTS=-d opcache.enabled=1 -d opcache.enable_cli=1
+if "%OPCACHE%" equ "1" set OPCACHE_OPTS=-d opcache.enabled=1 -d opcache.enable_cli=1 -d opcache.protect_memory=1
 
 rem prepare for enchant
 mkdir c:\enchant_plugins

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -542,7 +542,7 @@ int phar_open_parsed_phar(char *fname, size_t fname_len, char *alias, size_t ali
 	}
 #ifdef PHP_WIN32
 	save_fname = fname;
-  if (memchr(fname, '\\', fname_len)) {
+	if (memchr(fname, '\\', fname_len)) {
 		fname = do_alloca(fname_len + 1, fname_use_heap);
 		memcpy(fname, save_fname, fname_len);
 		fname[fname_len] = '\0';

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -438,7 +438,7 @@ PHP_METHOD(Phar, mount)
 	size_t fname_len, arch_len, entry_len;
 	size_t path_len, actual_len;
 	phar_archive_data *pphar;
-#if PHP_WIN32
+#ifdef PHP_WIN32
 	char *save_fname;
 	ALLOCA_FLAG(fname_use_heap)
 #endif
@@ -467,10 +467,12 @@ PHP_METHOD(Phar, mount)
 		if (path_len > 7 && !memcmp(path, "phar://", 7)) {
 			zend_throw_exception_ex(phar_ce_PharException, 0, "Can only mount internal paths within a phar archive, use a relative path instead of \"%s\"", path);
 			efree(arch);
+#ifdef PHP_WIN32
 			if (fname != save_fname) {
 				free_alloca(fname, fname_use_heap);
 				fname = save_fname;
 			}
+#endif
 			return;
 		}
 carry_on2:
@@ -486,10 +488,12 @@ carry_on2:
 			if (arch) {
 				efree(arch);
 			}
+#ifdef PHP_WIN32
 			if (fname != save_fname) {
 				free_alloca(fname, fname_use_heap);
 				fname = save_fname;
 			}
+#endif
 			return;
 		}
 carry_on:
@@ -503,11 +507,12 @@ carry_on:
 				efree(arch);
 			}
 
+#ifdef PHP_WIN32
 			if (fname != save_fname) {
 				free_alloca(fname, fname_use_heap);
 				fname = save_fname;
 			}
-
+#endif
 			return;
 		}
 
@@ -519,11 +524,12 @@ carry_on:
 			efree(arch);
 		}
 
+#ifdef PHP_WIN32
 		if (fname != save_fname) {
 			free_alloca(fname, fname_use_heap);
 			fname = save_fname;
 		}
-
+#endif
 		return;
 	} else if (HT_IS_INITIALIZED(&PHAR_G(phar_fname_map)) && NULL != (pphar = zend_hash_str_find_ptr(&(PHAR_G(phar_fname_map)), fname, fname_len))) {
 		goto carry_on;
@@ -539,10 +545,12 @@ carry_on:
 		goto carry_on2;
 	}
 
+#ifdef PHP_WIN32
 	if (fname != save_fname) {
 		free_alloca(fname, fname_use_heap);
 		fname = save_fname;
 	}
+#endif
 	zend_throw_exception_ex(phar_ce_PharException, 0, "Mounting of %s to %s failed", path, actual);
 }
 /* }}} */


### PR DESCRIPTION
We must not (try to) modify shared values, but rather have to use our
own copies, if unixified filenames are required on Windows.  To avoid
excessive string duplication, we add checks whether the filenames are
already unixified (i.e. do not contain backslashes).  To improve the
performance if we need to copy strings, we use do_alloca() and friends.

Besides generally being somewhat messy, the handling of unixified
filenames is still suboptimal performance-wise, but we leave this for a
future cleanup, and focus on fixing the issue at hand for now.