### PR TITLE
Clean aclocal.m4

### DIFF
--- a/build/build.mk
+++ b/build/build.mk
@@ -31,8 +31,10 @@ $(stamp): build/buildcheck.sh
 	@build/buildcheck.sh $@
 
 configure: configure.ac $(PHP_M4_FILES)
+# Remove aclocal.m4 if present. It is automatically included by autoconf but
+# not used by the PHP build system since PHP 7.4.
 	@echo rebuilding $@
-	@rm -f $@
+	@rm -f $@ aclocal.m4
 	@$(PHP_AUTOCONF) $(PHP_AUTOCONF_FLAGS)
 
 $(config_h_in): configure

--- a/scripts/phpize.in
+++ b/scripts/phpize.in
@@ -157,6 +157,10 @@ phpize_replace_prefix()
 
 phpize_autotools()
 {
+  # Remove aclocal.m4 if present. It is automatically included by autoconf but
+  # not used by the PHP build system since PHP 7.4.
+  rm -f aclocal.m4
+
   $PHP_AUTOCONF   || exit 1
   $PHP_AUTOHEADER || exit 1
 


### PR DESCRIPTION
Hello,

commit 4e7064d173d2b5b22e159fcf52d22b10213b67b8 removed usage of `aclocal.m4`. When using Git repositories, many times cleaning of the generated files is not done prior to running phpize or buildconf. To not accidentally including `aclocal.m4` file in the generated `configure` this enhances shell script experience a bit more by removing `aclocal.m4` file prior to start building the `configure` file.

Ugly, but for example to avoid edge cases like this:

```bash
git clone git://github.com/php/php-src
git checkout PHP-7.3
./buildconf
./configure
make
git checkout PHP-7.4
./buildconf  # -> warnings
./configure # -> errors
make
```

I'll be still looking for other solutions here a bit if anything like adjusting the m4 configs or omitting the usage of aclocal.m4 by autoconf can be done...