### PR TITLE
Use pkg-config from the host architecture and switch to PKG_CHECK_MODULES for two extensions

### DIFF
--- a/ext/ffi/config.m4
+++ b/ext/ffi/config.m4
@@ -10,12 +10,6 @@ if test "$PHP_FFI" != "no"; then
     FFI_INCDIR=$PHP_FFI/include
     FFI_LIBDIR=$PHP_FFI
   else
-    dnl First try to find pkg-config
-    if test -z "$PKG_CONFIG"; then
-      AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-    fi
-
-    dnl If pkg-config is installed, try using it
     if test -x "$PKG_CONFIG" && "$PKG_CONFIG" --exists libffi; then
       FFI_VER=`"$PKG_CONFIG" --modversion libffi`
       FFI_INCDIR=`"$PKG_CONFIG" --variable=includedir libffi`

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -327,9 +327,6 @@ PHP_ARG_WITH([iodbc],,
 
   AC_MSG_CHECKING(for iODBC support)
   if test "$PHP_IODBC" != "no"; then
-    if test -z "$PKG_CONFIG"; then
-      AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-    fi
     if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libiodbc ; then
       PHP_ADD_LIBRARY_WITH_PATH(iodbc, $PHP_IODBC/$PHP_LIBDIR)
       ODBC_TYPE=iodbc

--- a/ext/skeleton/config.m4.in
+++ b/ext/skeleton/config.m4.in
@@ -22,7 +22,6 @@ if test "$PHP_%EXTNAMECAPS%" != "no"; then
   dnl Write more examples of tests here...
 
   dnl # get library FOO build options from pkg-config output
-  dnl AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
   dnl AC_MSG_CHECKING(for libfoo)
   dnl if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists foo; then
   dnl   if $PKG_CONFIG foo --atleast-version 1.2.3; then

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -9,7 +9,6 @@ if test "$PHP_SODIUM" != "no"; then
   SEARCH_PATH="/usr/local /usr"     # you might want to change this
   SEARCH_FOR="/include/sodium.h"  # you most likely want to change this
 
-  AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
   AC_MSG_CHECKING([for libsodium])
 
   dnl user provided location

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -2,63 +2,15 @@ dnl config.m4 for extension sodium
 
 PHP_ARG_WITH([sodium],
   [for sodium support],
-  [AS_HELP_STRING([[--with-sodium[=DIR]]],
+  [AS_HELP_STRING([--with-sodium],
     [Include sodium support])])
 
 if test "$PHP_SODIUM" != "no"; then
-  SEARCH_PATH="/usr/local /usr"     # you might want to change this
-  SEARCH_FOR="/include/sodium.h"  # you most likely want to change this
+  PKG_CHECK_MODULES([LIBSODIUM], [libsodium >= 1.0.8])
 
-  AC_MSG_CHECKING([for libsodium])
+  PHP_EVAL_INCLINE($LIBSODIUM_CFLAGS)
+  PHP_EVAL_LIBLINE($LIBSODIUM_LIBS, SODIUM_SHARED_LIBADD)
 
-  dnl user provided location
-  if test -r $PHP_SODIUM/$SEARCH_FOR; then # path given as parameter
-    LIBSODIUM_DIR=$PHP_SODIUM
-    AC_MSG_RESULT([found in $PHP_SODIUM])
-
-  dnl pkg-config output
-  elif test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libsodium; then
-    LIBSODIUM_VERSION=`$PKG_CONFIG libsodium --modversion`
-    if $PKG_CONFIG libsodium --atleast-version=1.0.8; then
-      LIBSODIUM_CFLAGS=`$PKG_CONFIG libsodium --cflags`
-      LIBSODIUM_LIBS=`$PKG_CONFIG libsodium --libs`
-      AC_MSG_RESULT(version $LIBSODIUM_VERSION found using pkg-config)
-      PHP_EVAL_LIBLINE($LIBSODIUM_LIBS, SODIUM_SHARED_LIBADD)
-      PHP_EVAL_INCLINE($LIBSODIUM_CFLAGS)
-    else
-      AC_MSG_ERROR([Libsodium $LIBSODIUM_VERSION is too old, version >= 1.0.8 required])
-    fi
-
-  dnl search default path list
-  else
-    for i in $SEARCH_PATH ; do
-      if test -r $i/$SEARCH_FOR; then
-        LIBSODIUM_DIR=$i
-        AC_MSG_RESULT(found in $i)
-      fi
-    done
-    if test -z "$LIBSODIUM_DIR"; then
-      AC_MSG_ERROR([Please install libsodium - See https://github.com/jedisct1/libsodium])
-    fi
-  fi
-
-  LIBNAME=sodium
-  LIBSYMBOL=sodium_add
-
-  if test -n "$LIBSODIUM_DIR"; then
-    PHP_ADD_INCLUDE($LIBSODIUM_DIR/include)
-    PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $LIBSODIUM_DIR/$PHP_LIBDIR, SODIUM_SHARED_LIBADD)
-  fi
-
-  PHP_CHECK_LIBRARY($LIBNAME,$LIBSYMBOL,
-  [
-    AC_DEFINE(HAVE_LIBSODIUMLIB,1,[ ])
-  ],[
-    AC_MSG_ERROR([wrong libsodium lib version (< 1.0.8) or lib not found])
-  ],[
-  ])
-
-  PHP_SUBST(SODIUM_SHARED_LIBADD)
-
+  AC_DEFINE(HAVE_LIBSODIUMLIB, 1, [ ])
   PHP_NEW_EXTENSION(sodium, libsodium.c, $ext_shared)
 fi

--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -17,9 +17,6 @@ if test "$PHP_ZIP" != "no"; then
   PHP_ZIP_SOURCES="php_zip.c zip_stream.c"
 
   if test "$PHP_LIBZIP" != "no"; then
-
-    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-
     AC_MSG_CHECKING(for libzip)
     if test -r $PHP_LIBZIP/include/zip.h; then
       LIBZIP_CFLAGS="-I$PHP_LIBZIP/include"

--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -1,88 +1,47 @@
 dnl config.m4 for extension zip
 
-PHP_ARG_ENABLE([zip],
-  [for zip archive read/writesupport],
-  [AS_HELP_STRING([--enable-zip],
+PHP_ARG_WITH([zip],
+  [for zip archive read/write support],
+  [AS_HELP_STRING([--with-zip],
     [Include Zip read/write support])])
 
-PHP_ARG_WITH([libzip],
-  [libzip],
-  [AS_HELP_STRING([[--with-libzip[=DIR]]],
-    [ZIP: use libzip])],
-  [yes],
-  [no])
-
 if test "$PHP_ZIP" != "no"; then
+  PKG_CHECK_MODULES([LIBZIP], [libzip >= 0.11])
+  LIBZIP_LIBDIR=`$PKG_CONFIG --variable=libdir libzip`
+
+  dnl Could not think of a simple way to check libzip for overwrite support
+  PHP_CHECK_LIBRARY(zip, zip_open,
+  [
+    PHP_ADD_LIBRARY_WITH_PATH(zip, $LIBZIP_LIBDIR, ZIP_SHARED_LIBADD)
+    AC_DEFINE(HAVE_LIBZIP,1,[ ])
+  ], [
+    AC_MSG_ERROR(could not find usable libzip)
+  ], [
+    -L$LIBZIP_LIBDIR
+  ])
+
+  PHP_CHECK_LIBRARY(zip, zip_file_set_encryption,
+  [
+    PHP_ADD_LIBRARY_WITH_PATH(zip, $LIBZIP_LIBDIR, ZIP_SHARED_LIBADD)
+    AC_DEFINE(HAVE_ENCRYPTION, 1, [Libzip >= 1.2.0 with encryption support])
+  ], [
+    AC_MSG_WARN(Libzip >= 1.2.0 needed for encryption support)
+  ], [
+    -L$LIBZIP_LIBDIR
+  ])
+
+  PHP_CHECK_LIBRARY(zip, zip_libzip_version,
+  [
+    AC_DEFINE(HAVE_LIBZIP_VERSION, 1, [Libzip >= 1.3.1 with zip_libzip_version function])
+  ], [
+  ], [
+    -L$LIBZIP_LIBDIR
+  ])
+
+  AC_DEFINE(HAVE_ZIP,1,[ ])
 
   PHP_ZIP_SOURCES="php_zip.c zip_stream.c"
-
-  if test "$PHP_LIBZIP" != "no"; then
-    AC_MSG_CHECKING(for libzip)
-    if test -r $PHP_LIBZIP/include/zip.h; then
-      LIBZIP_CFLAGS="-I$PHP_LIBZIP/include"
-      LIBZIP_LIBDIR="$PHP_LIBZIP/$PHP_LIBDIR"
-      AC_MSG_RESULT(from option: found in $PHP_LIBZIP)
-
-    elif test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libzip; then
-      if $PKG_CONFIG libzip --atleast-version 0.11; then
-        LIBZIP_CFLAGS=`$PKG_CONFIG libzip --cflags`
-        LIBZIP_LIBDIR=`$PKG_CONFIG libzip --variable=libdir`
-        LIBZIP_VERSON=`$PKG_CONFIG libzip --modversion`
-        AC_MSG_RESULT(from pkgconfig: version $LIBZIP_VERSON found in $LIBZIP_LIBDIR)
-      else
-        AC_MSG_ERROR(system libzip must be upgraded to version >= 0.11)
-      fi
-
-    else
-      for i in /usr/local /usr; do
-        if test -r $i/include/zip.h; then
-          LIBZIP_CFLAGS="-I$i/include"
-          LIBZIP_LIBDIR="$i/$PHP_LIBDIR"
-          AC_MSG_RESULT(in default path: found in $i)
-          break
-        fi
-      done
-    fi
-
-    if test -z "$LIBZIP_LIBDIR"; then
-      AC_MSG_RESULT(not found)
-      AC_MSG_ERROR(Please reinstall the libzip. Header zip.h not found.)
-    fi
-
-    dnl Could not think of a simple way to check libzip for overwrite support
-    PHP_CHECK_LIBRARY(zip, zip_open,
-    [
-      PHP_ADD_LIBRARY_WITH_PATH(zip, $LIBZIP_LIBDIR, ZIP_SHARED_LIBADD)
-      AC_DEFINE(HAVE_LIBZIP,1,[ ])
-    ], [
-      AC_MSG_ERROR(could not find usable libzip)
-    ], [
-      -L$LIBZIP_LIBDIR
-    ])
-
-    PHP_CHECK_LIBRARY(zip, zip_file_set_encryption,
-    [
-      PHP_ADD_LIBRARY_WITH_PATH(zip, $LIBZIP_LIBDIR, ZIP_SHARED_LIBADD)
-      AC_DEFINE(HAVE_ENCRYPTION, 1, [Libzip >= 1.2.0 with encryption support])
-    ], [
-      AC_MSG_WARN(Libzip >= 1.2.0 needed for encryption support)
-    ], [
-      -L$LIBZIP_LIBDIR
-    ])
-
-    PHP_CHECK_LIBRARY(zip, zip_libzip_version,
-    [
-      AC_DEFINE(HAVE_LIBZIP_VERSION, 1, [Libzip >= 1.3.1 with zip_libzip_version function])
-    ], [
-    ], [
-      -L$LIBZIP_LIBDIR
-    ])
-
-    AC_DEFINE(HAVE_ZIP,1,[ ])
-    PHP_NEW_EXTENSION(zip, $PHP_ZIP_SOURCES, $ext_shared,, $LIBZIP_CFLAGS)
-  else
-    AC_MSG_ERROR([libzip is no longer bundled: install libzip version >= 0.11 (1.3.0 recommended for encryption and bzip2 support)])
-  fi
+  PHP_NEW_EXTENSION(zip, $PHP_ZIP_SOURCES, $ext_shared,, $LIBZIP_CFLAGS)
 
   PHP_SUBST(ZIP_SHARED_LIBADD)
 

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -591,9 +591,6 @@ if test "$PHP_FPM" != "no"; then
     [no])
 
   if test "$PHP_FPM_SYSTEMD" != "no" ; then
-    if test -z "$PKG_CONFIG"; then
-      AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-    fi
     unset SYSTEMD_LIBS
     unset SYSTEMD_INCS
 

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -33,6 +33,7 @@ test -z "$CFLAGS" && auto_cflags=1
 abs_srcdir=`(cd $srcdir && pwd)`
 abs_builddir=`pwd`
 
+PKG_PROG_PKG_CONFIG
 AC_PROG_CC([cc gcc])
 PHP_DETECT_ICC
 PHP_DETECT_SUNCC


### PR DESCRIPTION
This patchset:

1. Removes detection of `pkg-config` by `AC_PATH_PROG`. This ensures that (1) `pkg-config` from the host architecture is always used, and (2) any custom override path for `pkg-config` is used.

2. Uses `PKG_CHECK_MODULES` to detect the libsodium and zip libraries.