### PR TITLE
Remove unused TSRM/readdir.h header

### DIFF
--- a/TSRM/readdir.h
+++ b/TSRM/readdir.h
@@ -1,3 +1,0 @@
-/* Keep this header for compatibility with external code, it's currently not
-	used anywhere in the core and there are no implementations in TSRM. */
-#include "win32/readdir.h"

--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -49,7 +49,7 @@
 #endif
 
 #ifdef ZEND_WIN32
-#include "readdir.h"
+#include "win32/readdir.h"
 #include <sys/utime.h>
 #include "win32/ioutil.h"
 /* mode_t isn't defined on Windows */


### PR DESCRIPTION
Hello, this was once part of TSRM but then got refactored into the windows implementation win32/readdir.h directly. Instead of having empty header files for inclusions outside of php, this can  get removed at some point probably and the win32/readdir.h can be used directly instead.

UPGRADING.INTERNALS probably should mention this also then:
* `#include <TSRM/readdir.h>` -> `#include <win32/readdir.h>`

On Unix systems this is not even used yet it gets installed.

PHP-7.4 is ready for this already?