### PR TITLE
Fix tests

### DIFF
--- a/ext/pdo_mysql/tests/pdo_mysql___construct_uri-win32.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql___construct_uri-win32.phpt
@@ -21,7 +21,7 @@ MySQLPDOTest::skip();
 			$dsn = MySQLPDOTest::getDSN();
 			$user = PDO_MYSQL_TEST_USER;
 			$pass = PDO_MYSQL_TEST_PASS;
-			$uri = sprintf('uri:file:%s', $file);
+			$uri = sprintf('uri:file://%s', str_replace('\\', '/', $file));
 
 			if ($fp = @fopen($file, 'w')) {
 				// ok, great we can create a file with a DSN in it
@@ -71,9 +71,5 @@ MySQLPDOTest::skip();
 	print "done!";
 ?>
 --EXPECTF--
-Warning: PDO::__construct(file:%spdomuri.tst): failed to open stream: Invalid argument in %s on line %d
-[002] URI=uri:file:%spdomuri.tst, DSN=mysql%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql%sdbname=%s'), invalid data source URI
-
-Warning: PDO::__construct(file:%spdomuri.tst): failed to open stream: Invalid argument in %s on line %d
-[003] URI=uri:file:%spdomuri.tst, DSN=mysql%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql%sdbname=letshopeinvalid%s'), chr(0) test, invalid data source URI
+[003] URI=uri:file://%spdomuri.tst, DSN=mysql%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql%sdbname=letshopeinvalid%s'), chr(0) test, SQLSTATE[HY000] [1049] Unknown database 'letshopeinvalid'
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
@@ -21,7 +21,7 @@ MySQLPDOTest::skip();
 			$dsn = MySQLPDOTest::getDSN();
 			$user = PDO_MYSQL_TEST_USER;
 			$pass = PDO_MYSQL_TEST_PASS;
-			$uri = sprintf('uri:file:%s', $file);
+			$uri = sprintf('uri:file://%s', $file);
 
 			if ($fp = @fopen($file, 'w')) {
 				// ok, great we can create a file with a DSN in it
@@ -71,9 +71,5 @@ MySQLPDOTest::skip();
 	print "done!";
 ?>
 --EXPECTF--
-Warning: PDO::__construct(file:/tmp/pdomuri.tst): failed to open stream: No such file or directory in %s on line %d
-[002] URI=uri:file:%spdomuri.tst, DSN=mysql%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql%sdbname=%s'), invalid data source URI
-
-Warning: PDO::__construct(file:/tmp/pdomuri.tst): failed to open stream: No such file or directory in %s on line %d
-[003] URI=uri:file:%spdomuri.tst, DSN=mysql%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql%sdbname=letshopeinvalid%s'), chr(0) test, invalid data source URI
+[003] URI=uri:file://%spdomuri.tst, DSN=mysql%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql%sdbname=letshopeinvalid%s'), chr(0) test, SQLSTATE[HY000] [1049] Unknown database 'letshopeinvalid'
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
@@ -71,5 +71,5 @@ MySQLPDOTest::skip();
 	print "done!";
 ?>
 --EXPECTF--
-[003] URI=uri:file://%spdomuri.tst, DSN=mysql%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql%sdbname=letshopeinvalid%s'), chr(0) test, SQLSTATE[HY000] [1049] Unknown database 'letshopeinvalid'
+[003] URI=uri:file://%spdomuri.tst, DSN=mysql%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql%sdbname=letshopeinvalid%s'), chr(0) test, SQLSTATE[HY000] [2002] No such file or directory
 done!


### PR DESCRIPTION
These tests are obviously meant to test successful and failing uri:
DSNs, but did not pass proper file:// URIs, so actually ended up
testing for invalid data source URIs twice.  We fix this, and adjust
the expectations accordingly.