### PR TITLE
Fix bug #62397 - disable_functions does not work with eval.

### DIFF
--- a/Zend/tests/errmsg_046.phpt
+++ b/Zend/tests/errmsg_046.phpt
@@ -1,0 +1,14 @@
+--TEST--
+errmsg: disabled eval function
+--INI--
+disable_functions=eval
+--FILE--
+<?php
+
+eval('echo "Eval";');
+
+echo "Done\n";
+?>
+--EXPECTF--
+Warning: eval() has been disabled for security reasons in %s on line %d
+Done

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2751,6 +2751,12 @@ ZEND_API int zend_set_hash_symbol(zval *symbol, const char *name, int name_lengt
 
 /* Disabled functions support */
 
+zend_op_array *display_disabled_compile_string(zval *source_string, char *filename)
+{
+	zend_error(E_WARNING, "eval() has been disabled for security reasons");
+	return NULL;
+}
+
 /* {{{ proto void display_disabled_function(void)
 Dummy function which displays an error when a disabled function is called. */
 ZEND_API ZEND_FUNCTION(display_disabled_function)
@@ -2762,6 +2768,12 @@ ZEND_API ZEND_FUNCTION(display_disabled_function)
 ZEND_API int zend_disable_function(char *function_name, size_t function_name_length) /* {{{ */
 {
 	zend_internal_function *func;
+
+	if (strcmp(function_name, "eval") == 0) {
+		zend_compile_string = display_disabled_compile_string;
+		return SUCCESS;
+	}
+
 	if ((func = zend_hash_str_find_ptr(CG(function_table), function_name, function_name_length))) {
 	    func->fn_flags &= ~(ZEND_ACC_VARIADIC | ZEND_ACC_HAS_TYPE_HINTS);
 		func->num_args = 0;


### PR DESCRIPTION
Related to: https://bugs.php.net/bug.php?id=62397

While `eval` is technically not a function, from a user perspective this implementation detail should not be necessary to know.

The `disable_functions` INI setting is a system level setting and the overwrite of `compile_string` function is then done directly after module init/startup phase of PHP. Technically another extension could change this overwrite again, but the same is true for the way how disabled functions already works.

The alternative introducing a new INI setting `disable_eval` is also not good, because it would require users to know that the ini setting exists vs just listing eval in `disable_functions`. Also this would require adding a global variable which would prevent this fix from getting merged down into stable 7.2 and 7.3