### PR TITLE
Make MySQLPDOTest::extractVersion() more liberal

### DIFF
--- a/ext/pdo_mysql/tests/mysql_pdo_test.inc
+++ b/ext/pdo_mysql/tests/mysql_pdo_test.inc
@@ -107,7 +107,7 @@ class MySQLPDOTest extends PDOTest {
 
 		// stinky string which we need to parse
 		$parts = explode('.', $version_string);
-		if (count($parts) != 3)
+		if (count($parts) < 3)
 			return -1;
 
 		$version = (int)$parts[0] * 10000;


### PR DESCRIPTION
MySQL/MariaDB version strings may have suffixes which may contain dots;
for instance, Debian stretch has 5.5.5-10.1.37-MariaDB-0+deb9u1 or
such.  Therefore, we make the version extraction more liberal, and only
require that there are at least three parts separated by dot, and
ignore additional parts.