### PR TITLE
Simplify GD null byte injection tests

### DIFF
--- a/ext/gd/tests/imagebmp_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagebmp_nullbyte_injection.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Testing null byte injection in imagebmp
+--SKIPIF--
+<?php
+if(!extension_loaded('gd')) die('skip gd extension not available');
+?>
+--FILE--
+<?php
+$image = imagecreate(1,1);// 1px image
+var_dump(imagebmp($image, "./foo\0bar"));
+?>
+===DONE===
+--EXPECTF--
+Warning: imagebmp(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
+bool(false)
+===DONE===

--- a/ext/gd/tests/imagebmp_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagebmp_nullbyte_injection.phpt
@@ -3,6 +3,7 @@ Testing null byte injection in imagebmp
 --SKIPIF--
 <?php
 if(!extension_loaded('gd')) die('skip gd extension not available');
+if (!gd_info()['BMP Support']) die('skip BMP support not available');
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagegd2_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagegd2_nullbyte_injection.phpt
@@ -4,29 +4,11 @@ Testing null byte injection in imagegd2
 <?php
         if(!extension_loaded('gd')){ die('skip gd extension not available'); }
 ?>
---CLEAN--
-$tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));
-foreach (glob($tempdir . "/test*") as $file ) { unlink($file); }
-rmdir($tempdir);
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-
-$tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));
-if (!is_dir($tempdir)) {
-	mkdir ($tempdir, 0777, true);
-}
-
-$userinput = "1\0"; // from post or get data
-$temp = $tempdir. "/test" . $userinput .".tmp";
-
-echo "\nimagegd2 TEST\n";
-imagegd2($image, $temp);
-var_dump(file_exists($tempdir. "/test1"));
-var_dump(file_exists($tempdir. "/test1.tmp"));
+var_dump(imagegd2($image, "./foo\0bar"));
+?>
 --EXPECTF--
-imagegd2 TEST
-
 Warning: imagegd2() expects parameter 2 to be a valid path, string given in %s on line %d
-bool(false)
-bool(false)
+NULL

--- a/ext/gd/tests/imagegd_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagegd_nullbyte_injection.phpt
@@ -4,30 +4,11 @@ Testing null byte injection in imagegd
 <?php
         if(!extension_loaded('gd')){ die('skip gd extension not available'); }
 ?>
---CLEAN--
-$tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));
-foreach (glob($tempdir . "/test*") as $file ) { unlink($file); }
-rmdir($tempdir);
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-
-$tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));
-if (!is_dir($tempdir)) {
-	mkdir ($tempdir, 0777, true);
-}
-
-$userinput = "1\0"; // from post or get data
-$temp = $tempdir. "/test" . $userinput .".tmp";
-
-echo "\nimagegd TEST\n";
-imagegd($image, $temp);
-var_dump(file_exists($tempdir. "/test1"));
-var_dump(file_exists($tempdir. "/test1.tmp"));
+var_dump(imagegd($image, "./foo\0bar"));
 ?>
 --EXPECTF--
-imagegd TEST
-
 Warning: imagegd() expects parameter 2 to be a valid path, string given in %s on line %d
-bool(false)
-bool(false)
+NULL

--- a/ext/gd/tests/imagegif_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagegif_nullbyte_injection.phpt
@@ -15,23 +15,8 @@ rmdir($tempdir);
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-
-$tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));
-if (!is_dir($tempdir)) {
-	mkdir ($tempdir, 0777, true);
-}
-
-$userinput = "1\0"; // from post or get data
-$temp = $tempdir. "/test" . $userinput .".tmp";
-
-echo "\nimagegif TEST\n";
-imagegif($image, $temp);
-var_dump(file_exists($tempdir. "/test1"));
-var_dump(file_exists($tempdir. "/test1.tmp"));
+var_dump(imagegif($image, "./foo\0bar"));
 ?>
 --EXPECTF--
-imagegif TEST
-
 Warning: imagegif(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
 bool(false)

--- a/ext/gd/tests/imagegif_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagegif_nullbyte_injection.phpt
@@ -3,10 +3,6 @@ Testing null byte injection in imagegif
 --SKIPIF--
 <?php
 if(!extension_loaded('gd')){ die('skip gd extension not available'); }
-$support = gd_info();
-if (!isset($support['GIF Create Support']) || $support['GIF Create Support'] === false) {
-	print 'skip gif support not available';
-}
 ?>
 --CLEAN--
 $tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));

--- a/ext/gd/tests/imagejpeg_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagejpeg_nullbyte_injection.phpt
@@ -15,23 +15,8 @@ rmdir($tempdir);
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-
-$tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));
-if (!is_dir($tempdir)) {
-	mkdir ($tempdir, 0777, true);
-}
-
-$userinput = "1\0"; // from post or get data
-$temp = $tempdir. "/test" . $userinput .".tmp";
-
-echo "\nimagejpeg TEST\n";
-imagejpeg($image, $temp);
-var_dump(file_exists($tempdir. "/test1"));
-var_dump(file_exists($tempdir. "/test1.tmp"));
+var_dump(imagejpeg($image, "./foo\0bar"));
 ?>
 --EXPECTF--
-imagejpeg TEST
-
 Warning: imagejpeg(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
 bool(false)

--- a/ext/gd/tests/imagepng_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagepng_nullbyte_injection.phpt
@@ -15,23 +15,8 @@ rmdir($tempdir);
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-
-$tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));
-if (!is_dir($tempdir)) {
-	mkdir ($tempdir, 0777, true);
-}
-
-$userinput = "1\0"; // from post or get data
-$temp = $tempdir. "/test" . $userinput .".tmp";
-
-echo "\nimagepng TEST\n";
-imagepng($image, $temp);
-var_dump(file_exists($tempdir. "/test1"));
-var_dump(file_exists($tempdir. "/test1.tmp"));
+var_dump(imagepng($image, "./foo\0bar"));
 ?>
 --EXPECTF--
-imagepng TEST
-
 Warning: imagepng(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
 bool(false)

--- a/ext/gd/tests/imagewbmp_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagewbmp_nullbyte_injection.phpt
@@ -15,23 +15,8 @@ rmdir($tempdir);
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-
-$tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));
-if (!is_dir($tempdir)) {
-	mkdir ($tempdir, 0777, true);
-}
-
-$userinput = "1\0"; // from post or get data
-$temp = $tempdir. "/test" . $userinput .".tmp";
-
-echo "\nimagewbmp TEST\n";
-imagewbmp($image, $temp);
-var_dump(file_exists($tempdir. "/test1"));
-var_dump(file_exists($tempdir. "/test1.tmp"));
+var_dump(imagewbmp($image, "./foo\0bar"));
 ?>
 --EXPECTF--
-imagewbmp TEST
-
 Warning: imagewbmp(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
 bool(false)

--- a/ext/gd/tests/imagewebp_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagewebp_nullbyte_injection.phpt
@@ -15,23 +15,8 @@ rmdir($tempdir);
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-
-$tempdir = sprintf("%s/%s", sys_get_temp_dir(), preg_replace("~\.php$~", null, __FILE__));
-if (!is_dir($tempdir)) {
-	mkdir ($tempdir, 0777, true);
-}
-
-$userinput = "1\0"; // from post or get data
-$temp = $tempdir. "/test" . $userinput .".tmp";
-
-echo "\nimagewebp TEST\n";
-imagewebp($image, $temp);
-var_dump(file_exists($tempdir. "/test1"));
-var_dump(file_exists($tempdir. "/test1.tmp"));
+var_dump(imagewebp($image, "./foo\0bar"));
 ?>
 --EXPECTF--
-imagewebp TEST
-
 Warning: imagewebp(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
 bool(false)

--- a/ext/gd/tests/imagexbm_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagexbm_nullbyte_injection.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Testing null byte injection in imagexbm
+--SKIPIF--
+<?php
+if(!extension_loaded('gd')) die('skip gd extension not available');
+?>
+--FILE--
+<?php
+$image = imagecreate(1,1);// 1px image
+var_dump(imagexbm($image, "./foo\0bar"));
+?>
+===DONE===
+--EXPECTF--
+Warning: imagexbm() expects parameter 2 to be a valid path, string given in %s on line %d
+NULL
+===DONE===


### PR DESCRIPTION
These tests actually check that no file with a name containing a NUL is
created by the GD image output functions.  This is superfluous, since
it is sufficient to check that the function failed, and that an
appropriate warning has been raised.