### PR TITLE
Remove TSRM configuration header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,6 @@ config.h.in
 /main/build-defs.h
 /main/php_config.h.in
 /main/php_config.h
-/TSRM/tsrm_config.h
 /Zend/zend_config.h
 
 # ------------------------------------------------------------------------------

--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -17,7 +17,7 @@
 # define TSRM_WIN32
 # include "tsrm_config.w32.h"
 #else
-# include <tsrm_config.h>
+# include <../main/php_config.h>
 #endif
 
 #include "main/php_stdint.h"

--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -17,7 +17,7 @@
 # define TSRM_WIN32
 # include "tsrm_config.w32.h"
 #else
-# include <../main/php_config.h>
+# include "main/php_config.h"
 #endif
 
 #include "main/php_stdint.h"

--- a/TSRM/tsrm_config_common.h
+++ b/TSRM/tsrm_config_common.h
@@ -10,7 +10,7 @@
 #ifdef TSRM_WIN32
 # include "tsrm_config.w32.h"
 #else
-# include <../main/php_config.h>
+# include "main/php_config.h"
 # include <sys/param.h>
 #endif
 

--- a/TSRM/tsrm_config_common.h
+++ b/TSRM/tsrm_config_common.h
@@ -10,7 +10,7 @@
 #ifdef TSRM_WIN32
 # include "tsrm_config.w32.h"
 #else
-# include <tsrm_config.h>
+# include <../main/php_config.h>
 # include <sys/param.h>
 #endif
 

--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -118,7 +118,7 @@ clean:
 	rm -f libphp$(PHP_MAJOR_VERSION).la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(OVERALL_TARGET) modules/* libs/*
 
 distclean: clean
-	rm -f Makefile config.cache config.log config.status Makefile.objects Makefile.fragments libtool main/php_config.h main/internal_functions_cli.c main/internal_functions.c Zend/zend_dtrace_gen.h Zend/zend_dtrace_gen.h.bak Zend/zend_config.h TSRM/tsrm_config.h
+	rm -f Makefile config.cache config.log config.status Makefile.objects Makefile.fragments libtool main/php_config.h main/internal_functions_cli.c main/internal_functions.c Zend/zend_dtrace_gen.h Zend/zend_dtrace_gen.h.bak Zend/zend_config.h
 	rm -f main/build-defs.h scripts/phpize
 	rm -f ext/date/lib/timelib_config.h ext/mbstring/libmbfl/config.h ext/oci8/oci8_dtrace_gen.h ext/oci8/oci8_dtrace_gen.h.bak
 	rm -f scripts/man1/phpize.1 scripts/php-config scripts/man1/php-config.1 sapi/cli/php.1 sapi/cgi/php-cgi.1 sapi/phpdbg/phpdbg.1 ext/phar/phar.1 ext/phar/phar.phar.1

--- a/configure.ac
+++ b/configure.ac
@@ -1624,9 +1624,6 @@ fi
 # Create configuration headers
 #
 
-test -d TSRM || $php_shtool mkdir TSRM
-echo '#include <../main/php_config.h>' > TSRM/tsrm_config.h
-
 test -d Zend || $php_shtool mkdir Zend
 
 cat >Zend/zend_config.h <<FEO


### PR DESCRIPTION
TSRM configuration header file was once created by separate autoconf build system for TSRM and is with the current code not directly needed like this anymore.