### PR TITLE
BCmath fix for validation arguments

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -198,11 +198,15 @@ static void php_str2num(bc_num *num, char *str)
 	char *p;
 
 	if (!(p = strchr(str, '.'))) {
-		bc_str2num(num, str, 0);
+		if (!bc_str2num(num, str, 0)) {
+			php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
+		}
 		return;
 	}
 
-	bc_str2num(num, str, strlen(p+1));
+	if (!bc_str2num(num, str, strlen(p+1))) {
+			php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
+	}
 }
 /* }}} */
 
@@ -527,8 +531,12 @@ PHP_FUNCTION(bccomp)
 	bc_init_num(&first);
 	bc_init_num(&second);
 
-	bc_str2num(&first, ZSTR_VAL(left), scale);
-	bc_str2num(&second, ZSTR_VAL(right), scale);
+	if (!bc_str2num(&first, ZSTR_VAL(left), scale)) {
+		php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
+	}
+	if (!bc_str2num(&second, ZSTR_VAL(right), scale)) {
+	    php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
+	}
 	RETVAL_LONG(bc_compare(first, second));
 
 	bc_free_num(&first);

--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -108,7 +108,7 @@ _PROTOTYPE(bc_num bc_copy_num, (bc_num num));
 
 _PROTOTYPE(void bc_init_num, (bc_num *num));
 
-_PROTOTYPE(void bc_str2num, (bc_num *num, char *str, int scale));
+_PROTOTYPE(int bc_str2num, (bc_num *num, char *str, int scale));
 
 _PROTOTYPE(zend_string *bc_num2str_ex, (bc_num num, int scale));
 

--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -39,7 +39,7 @@
 
 /* Convert strings to bc numbers.  Base 10 only.*/
 
-void
+int
 bc_str2num (bc_num *num, char *str, int scale)
 {
   int digits, strscale;
@@ -62,7 +62,7 @@ bc_str2num (bc_num *num, char *str, int scale)
   if ((*ptr != '\0') || (digits+strscale == 0))
     {
       *num = bc_copy_num (BCG(_zero_));
-      return;
+      return *ptr == '\0';
     }
 
   /* Adjust numbers and allocate storage and initialize fields. */
@@ -107,4 +107,6 @@ bc_str2num (bc_num *num, char *str, int scale)
 
   if (bc_is_zero (*num))
     (*num)->n_sign = PLUS;
+
+  return 1;
 }

--- a/ext/bcmath/tests/bug60377.phpt
+++ b/ext/bcmath/tests/bug60377.phpt
@@ -6,8 +6,8 @@ if (PHP_INT_SIZE != 8) die("skip: 64-bit only"); ?>
 --FILE--
 <?php
 $var48 = bcscale(634314234334311);
-$var67 = bcsqrt(false);
-$var414 = bcadd(false,null,10);
+$var67 = bcsqrt(0);
+$var414 = bcadd(0,-1,10);
 die('ALIVE');
 ?>
 --EXPECT--

--- a/ext/bcmath/tests/bug72093.phpt
+++ b/ext/bcmath/tests/bug72093.phpt
@@ -6,7 +6,7 @@ if(!extension_loaded("bcmath")) print "skip";
 ?>
 --FILE--
 <?php
-var_dump(bcpowmod(1, "A", 128, -200));
+var_dump(bcpowmod(1, 0, 128, -200));
 var_dump(bcpowmod(1, 1.2, 1, 1));
 ?>
 --EXPECTF--

--- a/ext/bcmath/tests/str2num_formatting.phpt
+++ b/ext/bcmath/tests/str2num_formatting.phpt
@@ -1,0 +1,69 @@
+--TEST--
+bcmath lib arguments formatting
+--DESCRIPTION--
+1 and 2 argument of bcadd/bcsub/bcmul/bcdiv/bcmod/bcpowmod/bcpow/bccomp (last one works different then others internally);
+1 argument of bcsqrt
+All of the name above must be well-formed
+--SKIPIF--
+<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--FILE--
+<?php
+echo bcadd("1", "2"),"\n";
+echo bcadd("1.1", "2", 2),"\n";
+echo bcadd("", "2", 2),"\n";
+echo bcadd("+0", "2"), "\n";
+echo bcadd("-0", "2"), "\n";
+
+echo bcadd(" 0", "2");
+echo bcadd("1e1", "2");
+echo bcadd("1,1", "2");
+echo bcadd("Hello", "2");
+echo bcadd("1 1", "2");
+echo "\n", "\n";
+
+echo bccomp("1", "2"),"\n";
+echo bccomp("1.1", "2", 2),"\n";
+echo bccomp("", "2"),"\n";
+echo bccomp("+0", "2"), "\n";
+echo bccomp("-0", "2"), "\n";
+
+echo bccomp(" 0", "2");
+echo bccomp("1e1", "2");
+echo bccomp("1,1", "2");
+echo bccomp("Hello", "2");
+echo bccomp("1 1", "2");
+?>
+--EXPECTF--
+3
+3.10
+2.00
+2
+2
+
+Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
+2
+Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
+2
+Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
+2
+Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
+2
+Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
+2
+
+-1
+-1
+-1
+-1
+-1
+
+Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
+-1
+Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
+-1
+Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
+-1
+Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
+-1
+Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
+-1


### PR DESCRIPTION
I've added only todo for it here since I'm not C dev.

my concept looks like this, but some why it doesn't work as expected.

```c
static void php_str2num(bc_num *num, char *str)
{
        zend_string *regex  = zend_string_init("/^[+-]?[0-9]+(.[0-9]+)?$/", sizeof("/^[+-]?[0-9]+(.[0-9]+)?$/") - 1, 0);
        pcre_cache_entry *pce;                          /* Compiled regex */
        zval *subpats = NULL;                           /* Parts (not used) */
        int global = 0;
        zval return_value;

        ZVAL_NULL(&return_value);

        if ((pce = pcre_get_compiled_regex_cache(regex))== NULL) {
                zend_string_release(regex);
                php_error_docref(NULL, E_WARNING, "bcmath function argument is not well formatted");
        }

        zend_string_release(regex);
        php_pcre_match_impl(pce, zend_string_init(str, sizeof(str) -1, 0), &return_value, subpats, global,0, Z_L(0), Z_L(0));

        if (!Z_LVAL(return_value)) {
                php_error_docref(NULL, E_WARNING, "bcmath function argument is not well formatted");
        }

        char *p;

        if (!(p = strchr(str, '.'))) {
                bc_str2num(num, str, 0);
                return;
        }

        bc_str2num(num, str, strlen(p+1));
}
```

I think this should be easy for people who know how to do C right way.

Here are threads from internals mailing list to get what I want to implement
https://externals.io/message/104295#104295
https://externals.io/message/104374#105461