### PR TITLE
Include the request method in CLI server logs

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1120,7 +1120,7 @@ static void php_cli_server_log_response(php_cli_server_client *client, int statu
 #endif
 
 	/* basic */
-	spprintf(&basic_buf, 0, "%s [%d]: %s", client->addr_str, status, client->request.request_uri);
+	spprintf(&basic_buf, 0, "%s [%d]: %s %s", client->addr_str, status, SG(request_info).request_method, client->request.request_uri);
 	if (!basic_buf) {
 		return;
 	}


### PR DESCRIPTION
My use case for this is when doing API development with CORS requests. Being able to tell apart the CORS OPTIONS request from the normal requests would be useful.