### PR TITLE
FPM: For pm = ondemand, don't respawn processes that reached pm.max_requests

### DIFF
--- a/sapi/fpm/fpm/fpm.h
+++ b/sapi/fpm/fpm/fpm.h
@@ -34,6 +34,7 @@
 #define FPM_EXIT_CONFIG 78
 #endif
 
+#define FPM_EXIT_MAX_REQUESTS 2
 
 int fpm_run(int *max_requests);
 int fpm_init(int argc, char **argv, char *config, char *prefix, char *pid, int test_conf, int run_as_root, int force_daemon, int force_stderr);

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1997,6 +1997,7 @@ fastcgi_request_done:
 			if (UNEXPECTED(max_requests && (requests == max_requests))) {
 				fcgi_request_set_keep(request, 0);
 				fcgi_finish_request(request, 0);
+				exit_status = FPM_EXIT_MAX_REQUESTS;
 				break;
 			}
 			/* end of fastcgi loop */


### PR DESCRIPTION
This addresses https://bugs.php.net/bug.php?id=77959.

In short: When using `pm = ondemand` and there is a short peak in load, many worker processes will be spawned. As workers will be used in a round-robin fashion, even for a lightly loaded server it may happen that every of those workers will be used before `pm.process_idle_timeout` is reached. In this case, the numer of workers will never decrease again as every process reaching `pm.max_requests` will immediately be replaced by a new one.

With this PR, for `ondemand` workers that reached `pm.max_requests` will not automatically be replaced, but a new process will only be forked if deemed necessary by the process management.

Please be lenient with me – this is my first `php-src` contribution. 