### PR TITLE
Deprecate CURLPIPE_HTTP1

### DIFF
--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -567,11 +567,13 @@ static int _php_curl_multi_setopt(php_curlm *mh, zend_long option, zval *zvalue,
 		{
 			zend_long lval = zval_get_long(zvalue);
 
-#if LIBCURL_VERSION_NUM >= 0x073e00 /* 7.62.0 */
 			if (option == CURLMOPT_PIPELINING && (lval & 1)) {
-				php_error_docref(NULL, E_DEPRECATED, "CURLPIPE_HTTP1 is deprecated and has no effect");
-			}
+#if LIBCURL_VERSION_NUM >= 0x073e00 /* 7.62.0 */
+				php_error_docref(NULL, E_WARNING, "CURLPIPE_HTTP1 is no longer supported");
+#else
+				php_error_docref(NULL, E_DEPRECATED, "CURLPIPE_HTTP1 is deprecated");
 #endif
+			}
 			error = curl_multi_setopt(mh->multi, option, lval);
 			break;
 		}

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -564,8 +564,17 @@ static int _php_curl_multi_setopt(php_curlm *mh, zend_long option, zval *zvalue,
 		case CURLMOPT_MAX_PIPELINE_LENGTH:
 		case CURLMOPT_MAX_TOTAL_CONNECTIONS:
 #endif
-			error = curl_multi_setopt(mh->multi, option, zval_get_long(zvalue));
+		{
+			zend_long lval = zval_get_long(zvalue);
+
+#if LIBCURL_VERSION_NUM >= 0x073e00 /* 7.62.0 */
+			if (option == CURLMOPT_PIPELINING && (lval & 1)) {
+				php_error_docref(NULL, E_DEPRECATED, "CURLPIPE_HTTP1 is deprecated and has no effect");
+			}
+#endif
+			error = curl_multi_setopt(mh->multi, option, lval);
 			break;
+		}
 #if LIBCURL_VERSION_NUM > 0x072D00 /* Available since 7.45.0 */
 		case CURLMOPT_PUSHFUNCTION:
 			if (mh->handlers->server_push == NULL) {


### PR DESCRIPTION
`CURLPIPE_HTTP1` is deprecated and has no effect as of cURL 7.62.0[1].
As it is *silently* ignored by cURL, we add an explicit deprecation
notice.

[1] <https://curl.haxx.se/libcurl/c/CURLMOPT_PIPELINING.html>