### PR TITLE
[aarch64] use rev64 to reverse strings

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3376,6 +3376,8 @@ PHP_FUNCTION(strtr)
    Reverse a string */
 #if ZEND_INTRIN_SSSE3_NATIVE
 #include <tmmintrin.h>
+#elif defined(__aarch64__)
+#include <arm_neon.h>
 #endif
 PHP_FUNCTION(strrev)
 {
@@ -3404,6 +3406,19 @@ PHP_FUNCTION(strrev)
 		do {
 			const __m128i str = _mm_loadu_si128((__m128i *)(e - 15));
 			_mm_storeu_si128((__m128i *)p, _mm_shuffle_epi8(str, map));
+			p += 16;
+			e -= 16;
+		} while (e - s > 15);
+	}
+#elif defined(__aarch64__)
+	if (e - s > 15) {
+		do {
+			const uint8x16_t str = vld1q_u8((uint8_t *)(e - 15));
+			/* Synthesize rev128 with a rev64 + ext. */
+			const uint8x16_t rev = vrev64q_u8(str);
+			const uint8x16_t ext = (uint8x16_t)
+				vextq_u64((uint64x2_t)rev, (uint64x2_t)rev, 1);
+			vst1q_u8((uint8_t *)p, ext);
 			p += 16;
 			e -= 16;
 		} while (e - s > 15);


### PR DESCRIPTION
The execution time goes from 4.388s down to 0.563s on a Graviton A1 instance for
the benchmark:

```
function reverse_strings() {
  $a = "foo";
  for ($i = 0; $i < 100000; $i++) {
      strrev($a);
      $a .= "o";
  }
}
```