### PR TITLE
Re-add common PDO tests to Firebird test suite

### DIFF
--- a/ext/pdo_firebird/tests/common.phpt
+++ b/ext/pdo_firebird/tests/common.phpt
@@ -1,0 +1,27 @@
+--TEST--
+FIREBIRD
+--SKIPIF--
+<?php # vim:ft=php
+if (!extension_loaded('pdo_firebird')) print 'skip'; ?>
+--REDIRECTTEST--
+# magic auto-configuration
+
+$config = array(
+	'TESTS' => 'ext/pdo/tests'
+);
+	
+
+if (false !== getenv('PDO_FIREBIRD_TEST_DSN')) {
+	# user set them from their shell
+	$config['ENV']['PDOTEST_DSN'] = getenv('PDO_FIREBIRD_TEST_DSN');
+	$config['ENV']['PDOTEST_USER'] = getenv('PDO_FIREBIRD_TEST_USER');
+	$config['ENV']['PDOTEST_PASS'] = getenv('PDO_FIREBIRD_TEST_PASS');
+	if (false !== getenv('PDO_FIREBIRD_TEST_ATTR')) {
+		$config['ENV']['PDOTEST_ATTR'] = getenv('PDO_FIREBIRD_TEST_ATTR');
+	}
+} else {
+	$config['ENV']['PDOTEST_DSN'] = 'firebird:dbname=/opt/firebird/test.gdb';
+	$config['ENV']['PDOTEST_USER'] = 'SYSDBA';
+	$config['ENV']['PDOTEST_PASS'] = 'password';
+}
+return $config;

--- a/ext/pdo_firebird/tests/skipif.inc
+++ b/ext/pdo_firebird/tests/skipif.inc
@@ -4,9 +4,9 @@ if(!extension_loaded('pdo_firebird'))
 {
         die('skip: pdo_firebird not available');
 }
-elseif(!getenv('PDO_FIREBIRD_TEST_DATABASE'))
+elseif(!getenv('PDO_FIREBIRD_TEST_DSN'))
 {
-        die('skip: PDO_FIREBIRD_TEST_DATABASE must be set');
+        die('skip: PDO_FIREBIRD_TEST_DSN must be set');
 }
 
 ?>

--- a/ext/pdo_firebird/tests/testdb.inc
+++ b/ext/pdo_firebird/tests/testdb.inc
@@ -6,24 +6,16 @@
 // Password:	phpfi
 // Database:	<nothing>
 //
-// A path to a database must be specified by using PDO_FIREBIRD_TEST_DATABASE
+// A DSN must be specified by using PDO_FIREBIRD_TEST_DSN
 
-define('PDO_FIREBIRD_TEST_USERNAME', getenv('PDO_FIREBIRD_TEST_USERNAME') ?: 'SYSDBA');
-define('PDO_FIREBIRD_TEST_PASSWORD', getenv('PDO_FIREBIRD_TEST_PASSWORD') ?: 'phpfi');
-define('PDO_FIREBIRD_TEST_HOSTNAME', getenv('PDO_FIREBIRD_TEST_HOSTNAME') ?: 'localhost');
-define('PDO_FIREBIRD_TEST_DATABASE', getenv('PDO_FIREBIRD_TEST_DATABASE') ?: '');
+define('PDO_FIREBIRD_TEST_USER', getenv('PDO_FIREBIRD_TEST_USER') ?: 'SYSDBA');
+define('PDO_FIREBIRD_TEST_PASS', getenv('PDO_FIREBIRD_TEST_PASS') ?: 'phpfi');
+define('PDO_FIREBIRD_TEST_DSN', getenv('PDO_FIREBIRD_TEST_DSN') ?: '');
 
-if(!PDO_FIREBIRD_TEST_DATABASE)
+if(!PDO_FIREBIRD_TEST_DSN)
 {
-        die('Error: PDO_FIREBIRD_TEST_DATABASE must be set');
+        die('Error: PDO_FIREBIRD_TEST_DSN must be set');
 }
 
-if(PDO_FIREBIRD_TEST_HOSTNAME)
-{
-        $dbh = new PDO('firebird:dbname=' . PDO_FIREBIRD_TEST_HOSTNAME . ':' . PDO_FIREBIRD_TEST_DATABASE, PDO_FIREBIRD_TEST_USERNAME, PDO_FIREBIRD_TEST_PASSWORD) or die;
-}
-else
-{
-        $dbh = new PDO('firebird:dbname=' . PDO_FIREBIRD_TEST_DATABASE, PDO_FIREBIRD_TEST_USERNAME, PDO_FIREBIRD_TEST_PASSWORD) or die;
-}
+$dbh = new PDO(PDO_FIREBIRD_TEST_DSN, PDO_FIREBIRD_TEST_USER, PDO_FIREBIRD_TEST_PASS) or die;
 ?>


### PR DESCRIPTION
These have been inadvertently dropped when changing the test suite to
not require ext/interbase anymore, so we add them back.

We also change the required environment variable names to match the
usual PDO names.  Particularly, we replace `PDO_FIREBIRD_TEST_HOSTNAME`
and `_DATABASE` with the more flexible `PDO_FIREBIRD_TEST_DSN`.