### PR TITLE
Remove vcsclean script

### DIFF
--- a/build/build.mk
+++ b/build/build.mk
@@ -65,10 +65,4 @@ snapshot:
 	md5sum $$distname.tar.bz2; \
 	bzip2 -t $$distname.tar.bz2
 
-gitclean-work:
-	@if (test ! -f '.git/info/exclude' || grep -s "git-ls-files" .git/info/exclude); then \
-		(echo "Rebuild .git/info/exclude" && echo '*.o' > .git/info/exclude && git svn propget svn:ignore | grep -v config.nice >> .git/info/exclude); \
-	fi; \
-	git clean -X -f -d;
-
 .PHONY: snapshot

--- a/scripts/dev/vcsclean
+++ b/scripts/dev/vcsclean
@@ -1,7 +1,0 @@
-#! /bin/sh
-
-if test -d '.git' -o -f '.git'; then
-    ${MAKE:-make} -f build/build.mk gitclean-work
-else
-    echo "Can't figure out your VCS, not cleaning."
-fi


### PR DESCRIPTION
Hello, the `vcsclean` script is a wrapper for the `git clean -...` command. Developers should use the more proper, clear and native Git command directly instead:
`git clean -Xfd` when working with Git repository or `make clean` when using downloadable archive.

Should be removed by the previous commit directly but haven't gotten to that yet. Besides having such scripts that can change Git configuration in some custom and magic legacy SVN ways is not so good.