### PR TITLE
Use PKG_CHECK_MODULES to detect the iODBC library

### DIFF
--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -168,7 +168,7 @@ PHP_ARG_WITH([solid],,
     fi
     ODBC_INCDIR=$PHP_SOLID/include
     ODBC_LIBDIR=$PHP_SOLID/$PHP_LIBDIR
-    ODBC_INCLUDE=-I$ODBC_INCDIR
+    ODBC_CFLAGS=-I$ODBC_INCDIR
     ODBC_TYPE=solid
     if test -f $ODBC_LIBDIR/soc*35.a; then
       AC_DEFINE(HAVE_SOLID_35,1,[ ])
@@ -201,7 +201,7 @@ PHP_ARG_WITH([ibm-db2],,
 
     PHP_ODBC_CHECK_HEADER(sqlcli1.h)
 
-    ODBC_INCLUDE=-I$ODBC_INCDIR
+    ODBC_CFLAGS=-I$ODBC_INCDIR
     ODBC_LFLAGS=-L$ODBC_LIBDIR
     ODBC_TYPE=ibm-db2
     ODBC_LIBS=-ldb2
@@ -239,7 +239,7 @@ PHP_ARG_WITH([empress],,
       ODBC_INCDIR=$PHP_EMPRESS/include/odbc
       ODBC_LIBDIR=$PHP_EMPRESS/shlib
     fi
-    ODBC_INCLUDE=-I$ODBC_INCDIR
+    ODBC_CFLAGS=-I$ODBC_INCDIR
     ODBC_LFLAGS=-L$ODBC_LIBDIR
     ODBC_TYPE=empress
     AC_DEFINE(HAVE_EMPRESS,1,[ ])
@@ -267,7 +267,7 @@ PHP_ARG_WITH([empress-bcs],,
     fi
     CC="empocc -bcs";export CC;
     LD="empocc -bcs";export LD;
-    ODBC_INCLUDE=-I$ODBC_INCDIR
+    ODBC_CFLAGS=-I$ODBC_INCDIR
     ODBC_LFLAGS=-L$ODBC_LIBDIR
     LIST=`empocc -listlines -bcs -o a a.c`
 
@@ -310,7 +310,7 @@ PHP_ARG_WITH([custom-odbc],,
     ODBC_INCDIR=$PHP_CUSTOM_ODBC/include
     ODBC_LIBDIR=$PHP_CUSTOM_ODBC/$PHP_LIBDIR
     ODBC_LFLAGS=-L$ODBC_LIBDIR
-    ODBC_INCLUDE=-I$ODBC_INCDIR
+    ODBC_CFLAGS=-I$ODBC_INCDIR
     ODBC_LIBS=$CUSTOM_ODBC_LIBS
     ODBC_TYPE=custom-odbc
     AC_DEFINE(HAVE_CODBC,1,[ ])
@@ -322,35 +322,17 @@ fi
 
 if test -z "$ODBC_TYPE"; then
 PHP_ARG_WITH([iodbc],,
-  [AS_HELP_STRING([[--with-iodbc[=DIR]]],
-    [Include iODBC support [/usr/local]])])
+  [AS_HELP_STRING([--with-iodbc],
+    [Include iODBC support])])
 
-  AC_MSG_CHECKING(for iODBC support)
+  AC_MSG_CHECKING(whether to build with iODBC support)
   if test "$PHP_IODBC" != "no"; then
-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libiodbc ; then
-      PHP_ADD_LIBRARY_WITH_PATH(iodbc, $PHP_IODBC/$PHP_LIBDIR)
-      ODBC_TYPE=iodbc
-      ODBC_INCLUDE=`$PKG_CONFIG --cflags-only-I libiodbc`
-      ODBC_LFLAGS=`$PKG_CONFIG --libs-only-L libiodbc`
-      ODBC_LIBS=`$PKG_CONFIG --libs-only-l libiodbc`
-      PHP_EVAL_INCLINE($ODBC_INCLUDE)
-      AC_DEFINE(HAVE_IODBC,1,[ ])
-      AC_DEFINE(HAVE_ODBC2,1,[ ])
-      AC_MSG_RESULT([$ext_output])
-    else
-      if test "$PHP_IODBC" = "yes"; then
-        PHP_IODBC=/usr/local
-      fi
-      PHP_ADD_LIBRARY_WITH_PATH(iodbc, $PHP_IODBC/$PHP_LIBDIR)
-      PHP_ADD_INCLUDE($PHP_IODBC/include, 1)
-      ODBC_TYPE=iodbc
-      ODBC_INCLUDE=-I$PHP_IODBC/include
-      ODBC_LFLAGS=-L$PHP_IODBC/$PHP_LIBDIR
-      ODBC_LIBS=-liodbc
-      AC_DEFINE(HAVE_IODBC,1,[ ])
-      AC_DEFINE(HAVE_ODBC2,1,[ ])
-      AC_MSG_RESULT([$ext_output])
-    fi
+    AC_MSG_RESULT(yes)
+    PKG_CHECK_MODULES([ODBC], [libiodbc])
+    PHP_EVAL_INCLINE($ODBC_CFLAGS)
+    ODBC_TYPE=iodbc
+    AC_DEFINE(HAVE_IODBC,1,[ ])
+    AC_DEFINE(HAVE_ODBC2,1,[ ])
   else
     AC_MSG_RESULT(no)
   fi
@@ -369,7 +351,7 @@ PHP_ARG_WITH([esoob],,
     ODBC_INCDIR=$PHP_ESOOB/include
     ODBC_LIBDIR=$PHP_ESOOB/$PHP_LIBDIR
     ODBC_LFLAGS=-L$ODBC_LIBDIR
-    ODBC_INCLUDE=-I$ODBC_INCDIR
+    ODBC_CFLAGS=-I$ODBC_INCDIR
     ODBC_LIBS=-lesoobclient
     ODBC_TYPE=esoob
     AC_DEFINE(HAVE_ESOOB,1,[ ])
@@ -392,7 +374,7 @@ PHP_ARG_WITH([unixODBC],,
     ODBC_INCDIR=$PHP_UNIXODBC/include
     ODBC_LIBDIR=$PHP_UNIXODBC/$PHP_LIBDIR
     ODBC_LFLAGS=-L$ODBC_LIBDIR
-    ODBC_INCLUDE=-I$ODBC_INCDIR
+    ODBC_CFLAGS=-I$ODBC_INCDIR
     ODBC_LIBS=-lodbc
     ODBC_TYPE=unixODBC
     PHP_ODBC_CHECK_HEADER(sqlext.h)
@@ -433,9 +415,8 @@ PHP_ARG_WITH([dbmaker],,
 
     ODBC_INCDIR=$PHP_DBMAKER/include
     ODBC_LIBDIR=$PHP_DBMAKER/$PHP_LIBDIR
-    ODBC_INCLUDE=-I$ODBC_INCDIR
+    ODBC_CFLAGS=-I$ODBC_INCDIR
     ODBC_LFLAGS=-L$ODBC_LIBDIR
-    ODBC_INCLUDE=-I$ODBC_INCDIR
     ODBC_LIBS="-ldmapic -lc"
     ODBC_TYPE=dbmaker
 
@@ -480,12 +461,12 @@ if test -n "$ODBC_TYPE"; then
   PHP_SUBST(ODBC_SHARED_LIBADD)
   PHP_SUBST(ODBC_INCDIR)
   PHP_SUBST(ODBC_LIBDIR)
-  PHP_SUBST_OLD(ODBC_INCLUDE)
+  PHP_SUBST_OLD(ODBC_CFLAGS)
   PHP_SUBST_OLD(ODBC_LIBS)
   PHP_SUBST_OLD(ODBC_LFLAGS)
   PHP_SUBST_OLD(ODBC_TYPE)
 
-  PHP_NEW_EXTENSION(odbc, php_odbc.c, $ext_shared,, [$ODBC_INCLUDE -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+  PHP_NEW_EXTENSION(odbc, php_odbc.c, $ext_shared,, [$ODBC_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 else
   AC_MSG_CHECKING([for any ODBC driver support])
   AC_MSG_RESULT(no)


### PR DESCRIPTION
This patch converts ext/odbc/config.m4 to use PKG_CHECK_MODULES to detect the iODBC library.