### PR TITLE
Add {TMP} placeholder for PHPT INI sections

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1604,12 +1604,8 @@ TEST $file
 	// Any special ini settings
 	// these may overwrite the test defaults...
 	if (array_key_exists('INI', $section_text)) {
-		if (strpos($section_text['INI'], '{PWD}') !== false) {
-			$section_text['INI'] = str_replace('{PWD}', dirname($file), $section_text['INI']);
-		}
-		if (strpos($section_text['INI'], '{TMP}') !== false) {
-			$section_text['INI'] = str_replace('{TMP}', sys_get_temp_dir(), $section_text['INI']);
-		}
+		$section_text['INI'] = str_replace('{PWD}', dirname($file), $section_text['INI']);
+		$section_text['INI'] = str_replace('{TMP}', sys_get_temp_dir(), $section_text['INI']);
 		settings2array(preg_split( "/[\n\r]+/", $section_text['INI']), $ini_settings);
 	}
 

--- a/run-tests.php
+++ b/run-tests.php
@@ -1607,6 +1607,9 @@ TEST $file
 		if (strpos($section_text['INI'], '{PWD}') !== false) {
 			$section_text['INI'] = str_replace('{PWD}', dirname($file), $section_text['INI']);
 		}
+		if (strpos($section_text['INI'], '{TMP}') !== false) {
+			$section_text['INI'] = str_replace('{TMP}', sys_get_temp_dir(), $section_text['INI']);
+		}
 		settings2array(preg_split( "/[\n\r]+/", $section_text['INI']), $ini_settings);
 	}
 


### PR DESCRIPTION
Several tests use `/tmp` in the `--INI--` section, but this is not
portable.  We therefore introduce the `{TMP}` placeholder which
evaluates to the system's temporary directory using
`sys_get_temp_dir()`.