### PR TITLE
Fixes for #77841

### DIFF
--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -411,7 +411,10 @@ PHP_FUNCTION(http_response_code)
 		zend_long old_response_code;
 
 		old_response_code = SG(sapi_headers).http_response_code;
-		SG(sapi_headers).http_response_code = (int)response_code;
+
+		if (strcmp(sapi_module.name, "cli") != 0) {
+			SG(sapi_headers).http_response_code = (int)response_code;
+		}
 
 		if (old_response_code) {
 			RETURN_LONG(old_response_code);

--- a/ext/standard/tests/general_functions/http_response_code.phpt
+++ b/ext/standard/tests/general_functions/http_response_code.phpt
@@ -16,4 +16,4 @@ var_dump(
 --EXPECT--
 bool(false)
 bool(true)
-int(201)
+bool(false)


### PR DESCRIPTION
# Changed log
- Resolves [#77841](https://bugs.php.net/bug.php?id=77841)
- I use the `sapi_module.name` to detect whether the environment is `CLI`.

If it's `CLI` environment, it will not set any response code for `SG(sapi_headers).http_response_code`.

- I think it's a quick way to fix this, feel free to add the comment on this.