### PR TITLE
Fix #77993: Wrong parse error for invalid hex literal on Windows

### DIFF
--- a/Zend/tests/bug77993.phpt
+++ b/Zend/tests/bug77993.phpt
@@ -1,0 +1,7 @@
+--TEST--
+Bug #77993 (Wrong parse error for invalid hex literal on Windows)
+--FILE--
+<?php
+0xg10;
+--EXPECTF--
+Parse error: syntax error, unexpected 'xg10' (T_STRING) in %s on line %d

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1648,7 +1648,8 @@ NEWLINE ("\r"|"\n"|"\r\n")
 	char *end;
 	if (yyleng < MAX_LENGTH_OF_LONG - 1) { /* Won't overflow */
 		errno = 0;
-		ZVAL_LONG(zendlval, ZEND_STRTOL(yytext, &end, 0));
+		/* base must be passed explicitly for correct parse error on Windows */
+		ZVAL_LONG(zendlval, ZEND_STRTOL(yytext, &end, yytext[0] == '0' ? 8 : 10));
 		/* This isn't an assert, we need to ensure 019 isn't valid octal
 		 * Because the lexing itself doesn't do that for us
 		 */


### PR DESCRIPTION
If a PHP file contains an invalid hex literal such as `0x_10`, the expected error
is `Parse error: syntax error, unexpected 'x_10' (T_STRING) in %s on line %d`.

This already worked correctly on Linux, but on Windows prior to this patch a different
error was produced: `Parse error: Invalid numeric literal in %s on line %d`.