### PR TITLE
Use pkg-config for sqlite3 and pdo_sqlite

### DIFF
--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -1,12 +1,10 @@
 PHP_ARG_WITH([sqlite3],
   [whether to enable the SQLite3 extension],
-  [AS_HELP_STRING([[--without-sqlite3[=DIR]]],
-    [Do not include SQLite3 support. DIR is the prefix to SQLite3 installation
-    directory.])],
+  [AS_HELP_STRING([--without-sqlite3],
+    [Do not include SQLite3 support.])],
   [yes])
 
 if test $PHP_SQLITE3 != "no"; then
-  PHP_SQLITE3_CFLAGS=" -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 "
 
   dnl when running phpize enable_maintainer_zts is not available
   if test -z "$enable_maintainer_zts"; then
@@ -18,52 +16,34 @@ if test $PHP_SQLITE3 != "no"; then
     fi
   fi
 
-  AC_MSG_CHECKING([for sqlite3 files in default path])
-  for i in $PHP_SQLITE3 /usr/local /usr; do
-    if test -r $i/include/sqlite3.h; then
-      SQLITE3_DIR=$i
-      AC_MSG_RESULT(found in $i)
-      break
-    fi
-  done
+  PKG_CHECK_MODULES([SQLITE], [sqlite3 > 3.7.4])
 
-  if test -z "$SQLITE3_DIR"; then
-    AC_MSG_RESULT([not found])
-    AC_MSG_ERROR([Please reinstall the sqlite distribution from http://www.sqlite.org])
-  fi
-
-  AC_MSG_CHECKING([for SQLite 3.7.4+])
-  PHP_CHECK_LIBRARY(sqlite3, sqlite3_stmt_readonly, [
-    AC_MSG_RESULT(found)
-    PHP_ADD_LIBRARY_WITH_PATH(sqlite3, $SQLITE3_DIR/$PHP_LIBDIR, SQLITE3_SHARED_LIBADD)
-    PHP_ADD_INCLUDE($SQLITE3_DIR/include)
-  ],[
-    AC_MSG_RESULT([not found])
+  PHP_CHECK_LIBRARY(sqlite3, sqlite3_stmt_readonly,
+  [
+    PHP_EVAL_INCLINE($SQLITE_CFLAGS)
+    PHP_EVAL_LIBLINE($SQLITE_LIBS, SQLITE_SHARED_LIBADD)
+    AC_DEFINE(HAVE_SQLITE3, 1, [Define to 1 if you have the sqlite3 extension enabled.])
+  ], [
     AC_MSG_ERROR([Please install SQLite 3.7.4 first or check libsqlite3 is present])
-  ],[
-    -L$SQLITE3_DIR/$PHP_LIBDIR -lm
   ])
 
-  PHP_CHECK_LIBRARY(sqlite3,sqlite3_key,[
+  PHP_CHECK_LIBRARY(sqlite3, sqlite3_key, [
     AC_DEFINE(HAVE_SQLITE3_KEY, 1, [have commercial sqlite3 with crypto support])
   ])
-  PHP_CHECK_LIBRARY(sqlite3,sqlite3_column_table_name,[
+
+  PHP_CHECK_LIBRARY(sqlite3, sqlite3_column_table_name, [
     AC_DEFINE(SQLITE_ENABLE_COLUMN_METADATA, 1, [have sqlite3 with column metadata enabled])
   ])
-  PHP_CHECK_LIBRARY(sqlite3,sqlite3_errstr,[
+
+  PHP_CHECK_LIBRARY(sqlite3, sqlite3_errstr, [
     AC_DEFINE(HAVE_SQLITE3_ERRSTR, 1, [have sqlite3_errstr function])
   ])
 
   PHP_CHECK_LIBRARY(sqlite3,sqlite3_load_extension,
-  [],
-  [AC_DEFINE(SQLITE_OMIT_LOAD_EXTENSION, 1, [have sqlite3 with extension support])
+    [],
+    [AC_DEFINE(SQLITE_OMIT_LOAD_EXTENSION, 1, [have sqlite3 with extension support])
   ])
 
-  AC_DEFINE(HAVE_SQLITE3,1,[ ])
-
-  sqlite3_sources="sqlite3.c"
-
-  PHP_NEW_EXTENSION(sqlite3, $sqlite3_sources, $ext_shared,,$PHP_SQLITE3_CFLAGS)
-  PHP_ADD_BUILD_DIR([$ext_builddir/libsqlite])
+  PHP_NEW_EXTENSION(sqlite3, sqlite3.c, $ext_shared,,-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_SUBST(SQLITE3_SHARED_LIBADD)
 fi


### PR DESCRIPTION
Following other migrations to pkg-config usage for the *nix build system this migrates also sqlite3 and pdo_sqlite extensions.

BC break changes:
- configure options --with-sqlite3 and --with-pdo-sqlite don't take DIR as an arugment anymore

To override the pkg-config stuff:

```bash
PKG_CONFIG_PATH=/path/to/sqlite/pkgconfig:$PKG_CONFIG_PATH \
./configure --disable-all --with-sqlite3 --enable-pdo --with-pdo-sqlite
```

```bash
SQLITE_LIBS="-L/path/to/sqlite/lib -lsqlite3" \
SQLITE_CFLAGS="-I/path/to/sqlite/include" \
./configure --disable-all --with-sqlite3 --enable-pdo --with-pdo-sqlite
```

* Minimum sqlite library version synced with sqlite3 extension and pdo_sqlite to 3.7.4