### PR TITLE
Remove redundant memory.h file

### DIFF
--- a/ext/mbstring/libmbfl/config.h.w32
+++ b/ext/mbstring/libmbfl/config.h.w32
@@ -1,4 +1,3 @@
-#define HAVE_MEMORY_H 1
 /* #undef HAVE_STRINGS_H */
 /* #undef HAVE_STRCASECMP */
 #define HAVE_STRICMP 1

--- a/ext/mbstring/libmbfl/mbfl/mbfl_allocators.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_allocators.c
@@ -33,11 +33,6 @@
 #endif
 
 #include <stdlib.h>
-
-#ifdef HAVE_MEMORY_H
-#include <memory.h>
-#endif
-
 #include <string.h>
 #include <stddef.h>
 

--- a/win32/sendmail.c
+++ b/win32/sendmail.c
@@ -26,7 +26,6 @@
 #include <string.h>
 #include <math.h>
 #include <malloc.h>
-#include <memory.h>
 #include <winbase.h>
 #include "sendmail.h"
 #include "php_ini.h"


### PR DESCRIPTION
The memory.h file is part of the pre-C89 era and is on today's systems only a simple wrapper for including the final string.h header file.