### PR TITLE
Define LiteSpeed SAPI module version with PHP_VERSION

### DIFF
--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -448,7 +448,7 @@ static int sapi_lsapi_activate()
 static sapi_module_struct lsapi_sapi_module =
 {
     "litespeed",
-    "LiteSpeed V7.3.2",
+    "LiteSpeed" PHP_VERSION,
 
     php_lsapi_startup,              /* startup */
     php_module_shutdown_wrapper,    /* shutdown */
@@ -1413,7 +1413,7 @@ zend_module_entry litespeed_module_entry = {
     NULL,
     NULL,
     NULL,
-    NO_VERSION_YET,
+    PHP_VERSION,
     STANDARD_MODULE_PROPERTIES
 };
 

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -448,7 +448,7 @@ static int sapi_lsapi_activate()
 static sapi_module_struct lsapi_sapi_module =
 {
     "litespeed",
-    "LiteSpeed" PHP_VERSION,
+    "LiteSpeed",
 
     php_lsapi_startup,              /* startup */
     php_module_shutdown_wrapper,    /* shutdown */


### PR DESCRIPTION
Hello,

Currently there are 3 versions used as far as litespeed sapi module are concerned:
sapi/litespeed/php -v (PHP_VERSION)
sapi/litespeed/php -i (LiteSpeed V7.3.2)
zend_module_entry - NO_VERSION_YET

This patch syncs versioning of the LiteSpeed SAPI module by making it in sync with the rest of the majority of bundled PHP extensions, SAPIs, and core PHP version - MAJOR.MINOR.PATCH and having simpler development of the new features, bug fixes, and overall consistencies with the PHP releases. Also files between PHP 7.2 litespeed and PHP 7.4-dev litespeed differ quite a lot already. So having the same release cycle as PHP makes much more sense to me I think with this SAPI.

To get a better overview of the versioning inconsistencies in php-src:

| Extension | Version |
| --------- | ------ |
| sapi/litespeed | V7.3.2 |
| sapi/cli | PHP_VERSION | 
| sapi/apache2handler | PHP_VERSION |
| sapi/phpdbg | PHP_VERSION |
| sapi/fpm | PHP_VERSION |
| sapi/cgi | PHP_VERSION |
| sapi/embed | ... |
| ext/* (67 exts) | PHP_VERSION |
| ext/json | 1.7.0 |
| ext/mysqlnd | 5.0.12-dev - 20150407 - $Id: f95aaf36a23f02a778d68b3ddba5c86578fe0c48 $ |
| ext/oci8 | 2.2.0 |
| ext/zend_test | 0.1.0 |
| ext/zip | 1.15.4 |
| ext/skeleton | 0.1.0 |
| Zend | 3.4.0|

cc @litespeedtech, @davidlst