### PR TITLE
Rename configure --with-litespeed to --enable-litespeed

### DIFF
--- a/sapi/litespeed/README.md
+++ b/sapi/litespeed/README.md
@@ -25,13 +25,13 @@ with LiteSpeed web server.
 
 ## Building PHP with LiteSpeed SAPI
 
-You need to add `--with-litespeed` to the configure command to build PHP with
+You need to add `--enable-litespeed` to the configure command to build PHP with
 LiteSpeed SAPI, all other SAPI related configure options should be removed.
 
 For example:
 
 ```bash
-./configure --with-litespeed
+./configure --enable-litespeed
 make
 ```
 

--- a/sapi/litespeed/config.m4
+++ b/sapi/litespeed/config.m4
@@ -2,8 +2,8 @@ dnl config.m4 for sapi litespeed
 
 AC_MSG_CHECKING(for LiteSpeed support)
 
-PHP_ARG_WITH([litespeed],,
-  [AS_HELP_STRING([--with-litespeed],
+PHP_ARG_ENABLE([litespeed],,
+  [AS_HELP_STRING([--enable-litespeed],
     [Build PHP as litespeed module])],
   [no])
 


### PR DESCRIPTION
This syncs the configuration option of the litespeed module to be compliant with the approach of:
--with-foo (when something additional needs to be installed such as
  libfoo)
--enable-foo (when extension/sapi doesn't have dependencies on some
  library)

BC break, but since many configuration options will be renamed or changed for the PHP-7.4 anyway, it's perfect timing for this also.