### PR TITLE
Remove NO_VERSION_YET symbol usage

### DIFF
--- a/sapi/apache2handler/php_functions.c
+++ b/sapi/apache2handler/php_functions.c
@@ -559,6 +559,6 @@ zend_module_entry php_apache_module = {
 	NULL,
 	NULL,
 	PHP_MINFO(apache),
-	NULL,
+	PHP_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -1730,7 +1730,7 @@ static zend_module_entry cgi_module_entry = {
 	NULL,
 	NULL,
 	PHP_MINFO(cgi),
-	NO_VERSION_YET,
+	PHP_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
 

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1528,7 +1528,7 @@ static zend_module_entry cgi_module_entry = {
 	NULL,
 	NULL,
 	PHP_MINFO(cgi),
-	NO_VERSION_YET,
+	PHP_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
 

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -1413,7 +1413,7 @@ zend_module_entry litespeed_module_entry = {
     NULL,
     NULL,
     NULL,
-    NO_VERSION_YET,
+    PHP_VERSION,
     STANDARD_MODULE_PROPERTIES
 };
 


### PR DESCRIPTION
Hello,

Instead of not defining a version for a module a simple NULL can be used otherwise in PHP repo all so called modules (extensions and sapis) should have some sort of version that is in most cases PHP_VERSION.

This removes the "lazy" usage of the NO_VERSION_YET which is alway NULL anyway.