### PR TITLE
Remove dead DEBUG_CFLAGS setting

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -215,8 +215,6 @@ if test "$ZEND_DEBUG" = "yes"; then
   if test "$CFLAGS" = "-g -O2"; then
   	CFLAGS=-g
   fi
-  test -n "$GCC" && test "$USE_MAINTAINER_MODE" = "yes" && \
-    DEBUG_CFLAGS="$DEBUG_CFLAGS -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations"
 else
   AC_DEFINE(ZEND_DEBUG,0,[ ])
 fi


### PR DESCRIPTION
The USE_MAINTAINER_MODE has been removed via a4c484a4d85e01874653570b7829a248330eb9fb and 43ed9039494a7484c2e3997ceae191ed6b640a62

(not related to --enable-maintainers-zts and other debug settings)