### PR TITLE
Remove strings.h usage from libmbfl

### DIFF
--- a/ext/mbstring/libmbfl/config.h.w32
+++ b/ext/mbstring/libmbfl/config.h.w32
@@ -1,5 +1,4 @@
 #define HAVE_MEMORY_H 1
-/* #undef HAVE_STRINGS_H */
 /* #undef HAVE_STRCASECMP */
 #define HAVE_STRICMP 1
 #define HAVE_WIN32_NATIVE_THREAD 1

--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
@@ -35,10 +35,6 @@
 #include <stddef.h>
 #include <string.h>
 
-#ifdef HAVE_STRINGS_H
-#include <strings.h>
-#endif
-
 #include "mbfl_encoding.h"
 #include "mbfilter_pass.h"
 #include "mbfilter_8bit.h"

--- a/ext/mbstring/libmbfl/mbfl/mbfl_language.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_language.c
@@ -35,10 +35,6 @@
 #include <stddef.h>
 #include <string.h>
 
-#ifdef HAVE_STRINGS_H
-#include <strings.h>
-#endif
-
 #include "mbfl_encoding.h"
 #include "mbfl_language.h"
 


### PR DESCRIPTION
The strings.h header file is part of POSIX standard. And current code uses all elements already defined by stddef.h and other headers. This was once part of some legacy string functions usage which are already also included by the C89 compliant string.h header file.