### PR TITLE
Using PDO instead because of consistency

### DIFF
--- a/ext/pdo_sqlite/tests/bug44327_2.phpt
+++ b/ext/pdo_sqlite/tests/bug44327_2.phpt
@@ -7,7 +7,7 @@ if (!extension_loaded('pdo_sqlite')) print 'skip not loaded';
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 
 $x = $db->query('select 1 as queryString');
 var_dump($x, $x->queryString);

--- a/ext/pdo_sqlite/tests/bug44327_3.phpt
+++ b/ext/pdo_sqlite/tests/bug44327_3.phpt
@@ -7,7 +7,7 @@ if (!extension_loaded('pdo_sqlite')) print 'skip not loaded';
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 
 $x = $db->query('select 1 as queryStringxx');
 $y = $x->fetch(PDO::FETCH_LAZY);

--- a/ext/pdo_sqlite/tests/bug70862.phpt
+++ b/ext/pdo_sqlite/tests/bug70862.phpt
@@ -5,7 +5,7 @@ PDO_sqlite: Testing sqliteCreateCollation()
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $db->exec('CREATE TABLE test(field BLOB)');

--- a/ext/pdo_sqlite/tests/debugdumpparams_001.phpt
+++ b/ext/pdo_sqlite/tests/debugdumpparams_001.phpt
@@ -7,7 +7,7 @@ if (!extension_loaded('pdo_sqlite')) print 'skip not loaded';
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 
 $x= $db->prepare('select :a, :b, ?');
 $x->bindValue(':a', 1, PDO::PARAM_INT);

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createaggregate.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createaggregate.phpt
@@ -5,7 +5,7 @@ PDO_sqlite: Testing sqliteCreateAggregate()
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 
 $db->query('CREATE TABLE IF NOT EXISTS foobar (id INT AUTO INCREMENT, name TEXT)');
 

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createcollation.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createcollation.phpt
@@ -5,7 +5,7 @@ PDO_sqlite: Testing sqliteCreateCollation()
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $db->query('CREATE TABLE IF NOT EXISTS foobar (id INT AUTO INCREMENT, name TEXT)');

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createfunction.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createfunction.phpt
@@ -5,7 +5,7 @@ PDO_sqlite: Testing sqliteCreateFunction()
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 
 $db->query('CREATE TABLE IF NOT EXISTS foobar (id INT AUTO INCREMENT, name TEXT)');
 

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_with_flags.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_with_flags.phpt
@@ -8,7 +8,7 @@ if (!defined('PDO::SQLITE_DETERMINISTIC')) die('skip system sqlite is too old');
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 
 $db->query('CREATE TABLE IF NOT EXISTS foobar (id INT AUTO INCREMENT, name TEXT)');
 

--- a/ext/pdo_sqlite/tests/pdo_sqlite_lastinsertid.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_lastinsertid.phpt
@@ -5,7 +5,7 @@ PDO_sqlite: Testing lastInsertId()
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 $db->query('CREATE TABLE IF NOT EXISTS foo (id INT AUTO INCREMENT, name TEXT)');
 $db->query('INSERT INTO foo VALUES (NULL, "PHP")');
 $db->query('INSERT INTO foo VALUES (NULL, "PHP6")');

--- a/ext/pdo_sqlite/tests/pdo_sqlite_transaction.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_transaction.phpt
@@ -5,7 +5,7 @@ PDO_sqlite: Testing transaction
 --FILE--
 <?php
 
-$db = new pdo('sqlite::memory:');
+$db = new PDO('sqlite::memory:');
 
 $db->beginTransaction();
 


### PR DESCRIPTION
# Changed log
- Let the `pdo` class instance declaration be the `PDO` words because of consistency.