### PR TITLE
Remove duplicate variables

### DIFF
--- a/ext/date/tests/date_timestamp_get.phpt
+++ b/ext/date/tests/date_timestamp_get.phpt
@@ -6,6 +6,7 @@ Daiane Alves <daiane [at] lt [dot] coop [dot] br>
 Ednaldo Neimeg Marques <neimeg [at] gmail [dot] com>
 Henrique Ramos <henrique [at] habilissimo [dot] com [dot] br>
 Larissa Mourullo <larismourullo [at] gmail [dot] com>
+Vinicius Dias <carlosv775 [at] gmail [dot] com>
 Virgílio de Carvalho Pontes <vigiliocpontes [at] outlook [dot] com>
 Vitor Mattos <vitor [at] php [dot] rio>
 --FILE--
@@ -16,8 +17,6 @@ var_dump($beginTimestamp);
 
 // Test the DateTime feature alias in function date_timestamp_get().
 $dateTimeTz = (new DateTime('1970-01-01T00:00:00UTC'))->getTimeStamp();
-$beginDtObj = date_create('1970-01-01T00:00:00UTC');
-$beginTimestamp = date_timestamp_get($beginDtObj);
 var_dump($dateTimeTz === $beginTimestamp);
 ?>
 --EXPECT--


### PR DESCRIPTION
Removing duplicate variables `$beginDtObj` and `$beginTimestamp`.