### PR TITLE
Allow wrapper iterators to accept a Traversable.

### DIFF
--- a/ext/spl/tests/CallbackFilterIteratorTest-002.phpt
+++ b/ext/spl/tests/CallbackFilterIteratorTest-002.phpt
@@ -42,7 +42,7 @@ try {
 }
 --EXPECT--
 CallbackFilterIterator::__construct() expects exactly 2 parameters, 0 given
-Argument 1 passed to CallbackFilterIterator::__construct() must implement interface Iterator, null given
+Argument 1 passed to CallbackFilterIterator::__construct() must implement interface Traversable, null given
 CallbackFilterIterator::__construct() expects parameter 2 to be a valid callback, no array or string given
 CallbackFilterIterator::__construct() expects parameter 2 to be a valid callback, array must have exactly two members
 some message

--- a/ext/spl/tests/CallbackFilterIteratorTest.phpt
+++ b/ext/spl/tests/CallbackFilterIteratorTest.phpt
@@ -55,6 +55,20 @@ foreach($tests as $name => $test) {
         echo "=> $value\n";
     }
 }
+
+class C implements IteratorAggregate {
+    public function getIterator() {
+        return new ArrayIterator(array(1));
+    }
+}
+
+$filtered = new CallbackFilterIterator(new C(), function ($current, $key, $iterator) {
+    return true;
+});
+
+foreach($filtered as $key => $value) {
+    echo "=> $value\n";
+}
 --EXPECT--
 = instance method =
 1 / 0 / 1 / 1
@@ -131,3 +145,4 @@ foreach($tests as $name => $test) {
 4 / 3 / 1 / 1
 => 4
 5 / 4 / 1 / 1
+=> 1


### PR DESCRIPTION
Currently, wrapper iterators such as `CallbackFilterIterator` only accept an `Iterator` in their constructor, which requires client code to manually wrap any `AggregateIterators` inside an `IteratorIterator`. This commit allows the user to pass in an `AggregateIterator` directly, letting PHP automatically get the implementation iterator via `getIterator()` instead.

Before:
```php
	class A implements IteratorAggregate {
	    public function getIterator() {
	        return new ArrayIterator(array(1, 2));
	    }
	}

	function filter_test($current, $key, $iterator) {
	    return true;
	}

	$a = new A();

	$filtered = new CallbackFilterIterator(new IteratorIterator($a), 'filter_test');

	foreach($filtered as $key => $value) {
	    echo "=> $value\n";
	}
```
After:
```diff
	< $filtered = new CallbackFilterIterator(new IteratorIterator($a), 'filter_test');
	> $filtered = new CallbackFilterIterator($a, 'filter_test');
```
Temporary Note:

This PR currently only modifies `CallbackFilterIterator`. If this kind of modification is acceptable to the PHP team, I will add the other wrapper iterators to the PR as well.
