### PR TITLE
Fix #78003: strip_tags output change since PHP 7.3

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5284,6 +5284,10 @@ state_3:
 	c = *p;
 	switch (c) {
 		case '>':
+			if (depth) {
+				depth--;
+				break;
+			}
 			if (in_q) {
 				break;
 			}

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5227,6 +5227,10 @@ state_2:
 			}
 			break;
 		case '>':
+			if (depth) {
+				depth--;
+				break;
+			}
 			if (in_q) {
 				break;
 			}

--- a/ext/standard/tests/strings/bug78003.phpt
+++ b/ext/standard/tests/strings/bug78003.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #78003 (strip_tags output change since PHP 7.3)
+--FILE--
+<?php
+var_dump(
+    strip_tags('<foo<>bar>'),
+    strip_tags('<foo<!>bar>')
+);
+?>
+===DONE===
+--EXPECT--
+string(0) ""
+string(0) ""
+===DONE===

--- a/ext/standard/tests/strings/bug78003.phpt
+++ b/ext/standard/tests/strings/bug78003.phpt
@@ -4,11 +4,13 @@ Bug #78003 (strip_tags output change since PHP 7.3)
 <?php
 var_dump(
     strip_tags('<foo<>bar>'),
-    strip_tags('<foo<!>bar>')
+    strip_tags('<foo<!>bar>'),
+    strip_tags('<foo<?>bar>')
 );
 ?>
 ===DONE===
 --EXPECT--
+string(0) ""
 string(0) ""
 string(0) ""
 ===DONE===


### PR DESCRIPTION
A refactoring of the strip tags state machine[1] missed the special
treatment of `depth > 0` when a `>` is encountered in state 3.  We
re-add it for BC reasons.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=5cf64742773ddbf9af69d962a4d12b567fcf0084>