### PR TITLE
Add extensions naming conventions to ext_skel.php

### DIFF
--- a/ext/ext_skel.php
+++ b/ext/ext_skel.php
@@ -228,9 +228,9 @@ function process_args($argv, $argc) {
 
 	// Validate extension name
 	if (!preg_match('/^[a-z][a-z0-9_]+$/i', $options['ext'])) {
-		error('Invalid extension name. Name must start with a letter and'
-			.' preferably include only lower case letters. Optionally, numbers'
-			.' and underscores are also allowed.');
+		error('Invalid extension name. Valid names start with a letter,'
+			.' followed by any number of letters, numbers, or underscores.'
+			.' Using only lower case letters is preferred.');
 	}
 
 	$options['ext'] = str_replace(['\\', '/'], '', strtolower($options['ext']));

--- a/ext/ext_skel.php
+++ b/ext/ext_skel.php
@@ -226,6 +226,13 @@ function process_args($argv, $argc) {
 		error('The skeleton directory was not found');
 	}
 
+	// Validate extension name
+	if (!preg_match('/^[a-z][a-z0-9_]+$/i', $options['ext'])) {
+		error('Invalid extension name. Name must start with a letter and'
+			.' preferably include only lower case letters. Optionally, numbers'
+			.' and underscores are also allowed.');
+	}
+
 	$options['ext'] = str_replace(['\\', '/'], '', strtolower($options['ext']));
 
 	return $options;


### PR DESCRIPTION
Naming conventions, for the new extensions:

- first character is a letter
- followed by any number of letters
- preferred are lower case letters, but optionally allowed also upper case letters, numbers and underscores.

Synced with:

https://github.com/php/web-pecl/blob/4eb380c54af31f48d7c41b2b4e427e814b1b5f8d/public_html/package-new.php#L58

and https://bugs.php.net/bug.php?id=77968