### PR TITLE
Extend wildcard files section in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ end_of_line              = lf
 charset                  = utf-8
 tab_width                = 4
 
-[{*.{awk,bat,c,cpp,d,h,mk,re,skl,w32,y},Makefile*}]
+[{*.{awk,bat,c,cpp,d,h,l,mk,re,skl,w32,y},Makefile*}]
 indent_size              = 4
 indent_style             = tab
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ end_of_line              = lf
 charset                  = utf-8
 tab_width                = 4
 
-[{*.{awk,bat,c,cpp,d,h,l,mk,re,skl,w32,y},Makefile*}]
+[{*.{awk,bat,c,cpp,d,h,mk,re,skl,w32,y},Makefile*}]
 indent_size              = 4
 indent_style             = tab
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,45 +3,32 @@
 root = true
 
 [*]
+trim_trailing_whitespace = true
+insert_final_newline     = true
+end_of_line              = lf
+charset                  = utf-8
 tab_width                = 4
 
-[*.{c,h,y,awk,w32,bat,mk,frag,cpp}]
-charset                  = utf-8
-end_of_line              = lf
+[{*.{awk,bat,c,cpp,d,h,l,mk,re,skl,w32,y},Makefile*}]
 indent_size              = 4
 indent_style             = tab
-trim_trailing_whitespace = true
-insert_final_newline     = true
 
-[*.{php,phpt,inc}]
-charset                  = utf-8
-end_of_line              = lf
+[*.{dtd,html,inc,php,phpt,rng,wsdl,xml,xsd,xsl}]
 indent_size              = 4
 indent_style             = space
-trim_trailing_whitespace = true
-insert_final_newline     = true
 
-[*.{yml,m4,sh}]
-charset                  = utf-8
-end_of_line              = lf
+[{*.{ac,m4,sh,yml},buildconf}]
 indent_size              = 2
 indent_style             = space
-trim_trailing_whitespace = true
-insert_final_newline     = true
 
 [*.md]
-charset                  = utf-8
-end_of_line              = lf
 indent_style             = space
-trim_trailing_whitespace = true
-insert_final_newline     = true
 max_line_length          = 80
 
 [COMMIT_EDITMSG]
-charset                  = utf-8
-end_of_line              = lf
 indent_size              = 4
 indent_style             = space
-trim_trailing_whitespace = true
-insert_final_newline     = true
 max_line_length          = 80
+
+[*.patch]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Changes:
- Trim trailing whitespace for all files. There isn't really any practical reason to not trim the trailing whitespace in all files. Binary files or phpt files that include trailing whitespace as part of the test will need to be manually set in such environments or by disabling the editorconfig.
- Add *.ac files (configure.ac), *.re, and *.wsdl files

Listing separate files is a mission impossible for EditorConfig. So, this now limits to changing only spaces and tabs settings for different file extensions. Targeting PHP-7.2 because the EditorConfig is useful setting when checking out different branches. And also adding *.wsdl files as noted in https://github.com/php/php-src/commit/b15bfb9129eb7941b3643209243caba891e4d25d#comments

I'll recheck soon, if these can be applied to all files.