### PR TITLE
Fixed possible crashes, because of inconsistent PCRE cache and opcache SHM reset

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -196,6 +196,8 @@ typedef struct _zend_accel_globals {
 	int                     counted;   /* the process uses shared memory */
 	zend_bool               enabled;
 	zend_bool               locked;    /* thread obtained exclusive lock */
+	zend_bool               accelerator_enabled; /* accelerator enabled for current request */
+	zend_bool               pcre_reseted;
 	HashTable               bind_hash; /* prototype and zval lookup table */
 	zend_accel_directives   accel_directives;
 	zend_string            *cwd;                  /* current working directory or NULL */

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -439,11 +439,11 @@ void zend_accel_info(ZEND_MODULE_INFO_FUNC_ARGS)
 {
 	php_info_print_table_start();
 
-	if (ZCG(enabled) && accel_startup_ok &&
+	if (
 #ifdef HAVE_OPCACHE_FILE_CACHE
-		((ZCG(counted) || ZCSG(accelerator_enabled)) || file_cache_only)
+		(ZCG(accelerator_enabled) || file_cache_only)
 #else
-		(ZCG(counted) || ZCSG(accelerator_enabled))
+		(ZCG(accelerator_enabled))
 #endif
 	) {
 		php_info_print_table_row(2, "Opcode Caching", "Up and Running");
@@ -547,7 +547,7 @@ static int accelerator_get_scripts(zval *return_value)
 	struct timeval exec_time;
 	struct timeval fetch_time;
 
-	if (!ZCG(enabled) || !accel_startup_ok || !ZCSG(accelerator_enabled) || accelerator_shm_read_lock() != SUCCESS) {
+	if (!ZCG(accelerator_enabled) || accelerator_shm_read_lock() != SUCCESS) {
 		return 0;
 	}
 
@@ -609,7 +609,7 @@ static ZEND_FUNCTION(opcache_get_status)
 	array_init(return_value);
 
 	/* Trivia */
-	add_assoc_bool(return_value, "opcache_enabled", ZCG(enabled) && (ZCG(counted) || ZCSG(accelerator_enabled)));
+	add_assoc_bool(return_value, "opcache_enabled", ZCG(enabled) && ZCG(accelerator_enabled));
 
 #ifdef HAVE_OPCACHE_FILE_CACHE
 	if (ZCG(accel_directives).file_cache) {
@@ -807,7 +807,7 @@ static ZEND_FUNCTION(opcache_compile_file)
 		return;
 	}
 
-	if (!ZCG(enabled) || !accel_startup_ok || !ZCSG(accelerator_enabled)) {
+	if (!ZCG(accelerator_enabled)) {
 		zend_error(E_NOTICE, ACCELERATOR_PRODUCT_NAME " seems to be disabled, can't compile file");
 		RETURN_FALSE;
 	}
@@ -846,7 +846,7 @@ static ZEND_FUNCTION(opcache_is_script_cached)
 		RETURN_FALSE;
 	}
 
-	if (!ZCG(enabled) || !accel_startup_ok || !ZCSG(accelerator_enabled)) {
+	if (!ZCG(accelerator_enabled)) {
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
Opcache reset may remove interned strings, that are used as keys in per-process PCRE caches.
PHP workers clear per-process PCRE cache on startup of next request after opcache reset, but crashes are possible in requests started before the actual reset.

To fix the problem, we reset PCRE caches on request startup, if we see restart pending event.

We also decide, if process may use opcache SHM once, by copying ZCSG(accelerator_enabled) into ZSG(accelerator_enabled) on request startup.