### PR TITLE
Removed mysqlnd stats from phpinfo page

### DIFF
--- a/ext/mysqli/tests/mysqli_phpinfo.phpt
+++ b/ext/mysqli/tests/mysqli_phpinfo.phpt
@@ -46,17 +46,6 @@ require_once('skipifconnectfailure.inc');
 
 	if ($IS_MYSQLND) {
 		$expected = array(
-			'mysqlnd statistics',
-			'bytes_sent', 'bytes_received', 'packets_sent', 'packets_received',
-			'protocol_overhead_in', 'protocol_overhead_out', 'result_set_queries',
-			'non_result_set_queries', 'no_index_used', 'bad_index_used',
-			'buffered_sets', 'unbuffered_sets', 'ps_buffered_sets', 'ps_unbuffered_sets',
-			'flushed_normal_sets', 'flushed_ps_sets', 'rows_fetched_from_server',
-			'rows_fetched_from_client', 'rows_skipped', 'copy_on_write_saved',
-			'copy_on_write_performed', 'command_buffer_too_small', 'connect_success',
-			'connect_failure', 'connection_reused', 'explicit_close', 'implicit_close',
-			'disconnect_close', 'in_middle_of_command_close', 'explicit_free_result',
-			'implicit_free_result', 'explicit_stmt_close', 'implicit_stmt_close',
 			'size',
 			'mysqli.allow_local_infile',
 			'mysqli.allow_persistent', 'mysqli.max_persistent'

--- a/ext/mysqlnd/php_mysqlnd.c
+++ b/ext/mysqlnd/php_mysqlnd.c
@@ -51,29 +51,6 @@ mysqlnd_minfo_print_hash(zval *values)
 /* }}} */
 
 
-/* {{{ mysqlnd_minfo_dump_plugin_stats */
-static int
-mysqlnd_minfo_dump_plugin_stats(zval *el, void * argument)
-{
-	struct st_mysqlnd_plugin_header * plugin_header = (struct st_mysqlnd_plugin_header *)Z_PTR_P(el);
-	if (plugin_header->plugin_stats.values) {
-		char buf[64];
-		zval values;
-		snprintf(buf, sizeof(buf), "%s statistics", plugin_header->plugin_name);
-
-		mysqlnd_fill_stats_hash(plugin_header->plugin_stats.values, plugin_header->plugin_stats.names, &values ZEND_FILE_LINE_CC);
-
-		php_info_print_table_start();
-		php_info_print_table_header(2, buf, "");
-		mysqlnd_minfo_print_hash(&values);
-		php_info_print_table_end();
-		zend_array_destroy(Z_ARR(values));
-	}
-	return ZEND_HASH_APPLY_KEEP;
-}
-/* }}} */
-
-
 /* {{{ mysqlnd_minfo_dump_loaded_plugins */
 static int
 mysqlnd_minfo_dump_loaded_plugins(zval *el, void * buf)
@@ -161,10 +138,6 @@ PHP_MINFO_FUNCTION(mysqlnd)
 	}
 
 	php_info_print_table_end();
-
-
-	/* Print client stats */
-	mysqlnd_plugin_apply_with_argument(mysqlnd_minfo_dump_plugin_stats, NULL);
 }
 /* }}} */
 


### PR DESCRIPTION
Currently all stats from mysqlnd are being displayed on our phpinfo() page.  
Do we really need to display them here making the info page unnecessary long and hard to scroll past the long mysqlnd list. 

![mysqlnd-stats](https://user-images.githubusercontent.com/1330296/57783245-79fbdf80-7736-11e9-8c9b-29c016dc929a.png)

All information can already be retrieved using the APIs at https://www.php.net/manual/en/mysqlnd.stats.php if really needed.

Closes https://bugs.php.net/bug.php?id=60594