### PR TITLE
Generate PHP parser files

### DIFF
--- a/Zend/Makefile.frag
+++ b/Zend/Makefile.frag
@@ -10,7 +10,19 @@ $(srcdir)/zend_language_scanner.c: $(srcdir)/zend_language_scanner.l
 
 $(srcdir)/zend_language_parser.h: $(srcdir)/zend_language_parser.c
 $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
+# Tweak zendparse to be exported through ZEND_API. This has to be revisited once
+# bison supports foreign skeletons and that bison version is used. Read
+# /usr/share/bison/README for more.
 	@$(YACC) -p zend -v -d $(srcdir)/zend_language_parser.y -o $@
+	@sed -e 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' < $(srcdir)/zend_language_parser.c \
+	> $(srcdir)/zend_language_parser.c.tmp && \
+	mv $(srcdir)/zend_language_parser.c.tmp $(srcdir)/zend_language_parser.c
+	@sed -e 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' < $(srcdir)/zend_language_parser.h \
+	> $(srcdir)/zend_language_parser.h.tmp && \
+	mv $(srcdir)/zend_language_parser.h.tmp $(srcdir)/zend_language_parser.h
+	@sed -e "s,^#ifndef YYTOKENTYPE,#include \"zend.h\"\\n#ifndef YYTOKENTYPE,g" < $(srcdir)/zend_language_parser.h \
+	> $(srcdir)/zend_language_parser.h.tmp && \
+	mv $(srcdir)/zend_language_parser.h.tmp $(srcdir)/zend_language_parser.h
 
 $(srcdir)/zend_ini_parser.h: $(srcdir)/zend_ini_parser.c
 $(srcdir)/zend_ini_parser.c: $(srcdir)/zend_ini_parser.y

--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -96,13 +96,6 @@ rm -fr autom4te.cache/
 # touching everything to be packaged
 find $MY_OLDPWD/php-$VER -exec touch -c {} \;
 
-# tweak zendparse to be exported through ZEND_API
-# NOTE this has to be revisited once bison supports foreign skeletons
-#      and that bison version is used. Read /usr/share/bison/README for more
-sed -i 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' $MY_OLDPWD/php-$VER/Zend/zend_language_parser.c
-sed -i 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' $MY_OLDPWD/php-$VER/Zend/zend_language_parser.h
-sed -i 's,^#ifndef YYTOKENTYPE,#include "zend.h"\n#ifndef YYTOKENTYPE,g' $MY_OLDPWD/php-$VER/Zend/zend_language_parser.h
-
 # download pear
 $ECHO_N "makedist: Attempting to download PEAR's phar archive"
 if test ! -x wget; then


### PR DESCRIPTION
Hello, the PHP versions prior to PHP 7.4 shipped with the generated parser files. With PHP-7.4+ this isn't the case anymore and sources from the Git repository need to have these files generated manually or when compiling user need to have bison and re2c installed.

The PHP releases also additionally include one patch for the Zend parsers - see the patch in the commit. Is this relevant? Can this be fixed maybe somehow in the code itself instead of requiring another patch? 

Thank you for your help.

Please note, that the patch in the commit doesn't work ok... If this patch is required, then I would propose another solution and recheck it out where to patch this on only one place. Windows win32/build/Makefile includes this patch also...

Relevant README from the Bison:
http://git.savannah.gnu.org/cgit/bison.git/tree/data/README.md