### PR TITLE
Fix #77956 - When mysqli.allow_local_infile = Off, return a client error

### DIFF
--- a/ext/mysqli/tests/bug77956.phpt
+++ b/ext/mysqli/tests/bug77956.phpt
@@ -1,0 +1,50 @@
+--TEST--
+ensure an error is returned when mysqli.allow_local_infile is off
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnectfailure.inc');
+?>
+--INI--
+mysqli.allow_local_infile=0
+--FILE--
+<?php
+	require_once("connect.inc");
+	if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+		printf("[001] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
+	}
+	if (!$link->query("DROP TABLE IF EXISTS test")) {
+		printf("[002] [%d] %s\n", $link->errno, $link->error);
+	}
+	if (!$link->query("CREATE TABLE test (dump1 INT UNSIGNED NOT NULL PRIMARY KEY) ENGINE=" . $engine)) {
+		printf("[003] [%d] %s\n", $link->errno, $link->error);
+	}
+	if (FALSE == file_put_contents('bug77956.data', "waa? meukee!"))
+		printf("[004] Failed to create CVS file\n");
+	if (!$link->query("SELECT 1 FROM DUAL"))
+		printf("[005] [%d] %s\n", $link->errno, $link->error);
+	if (!$link->query("LOAD DATA LOCAL INFILE 'bug77956.data' INTO TABLE test")) {
+		printf("[006] [%d] %s\n", $link->errno, $link->error);
+		echo "done";
+	} else {
+		echo "bug";
+	}
+	$link->close();
+?>
+--CLEAN--
+<?php
+require_once('connect.inc');
+if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+	printf("[clean] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
+		$host, $user, $db, $port, $socket);
+}
+if (!$link->query($link, 'DROP TABLE IF EXISTS test')) {
+	printf("[clean] Failed to drop old test table: [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+}
+$link->close();
+unlink('bug77956.data');
+?>
+--EXPECTF--
+Warning: mysqli::query(): LOAD DATA LOCAL INFILE forbidden in %s on line %d
+[006] [2000] LOAD DATA LOCAL INFILE is forbidden, check mysqli.allow_local_infile
+done

--- a/ext/mysqlnd/mysqlnd_loaddata.c
+++ b/ext/mysqlnd/mysqlnd_loaddata.c
@@ -156,6 +156,8 @@ mysqlnd_handle_local_infile(MYSQLND_CONN_DATA * conn, const char * const filenam
 
 	if (!(conn->options->flags & CLIENT_LOCAL_FILES)) {
 		php_error_docref(NULL, E_WARNING, "LOAD DATA LOCAL INFILE forbidden");
+		SET_CLIENT_ERROR(conn->error_info, CR_UNKNOWN_ERROR, UNKNOWN_SQLSTATE,
+						"LOAD DATA LOCAL INFILE is forbidden, check mysqli.allow_local_infile");
 		/* write empty packet to server */
 		ret = net->data->m.send(net, vio, empty_packet, 0, conn->stats, conn->error_info);
 		*is_warning = TRUE;


### PR DESCRIPTION
This fixes bug [#77956](https://bugs.php.net/bug.php?id=77956).