### PR TITLE
Fix Bug 76345 (fix missing zip.h include when using custom libzip) (7.4)

### DIFF
--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -38,6 +38,8 @@ if test "$PHP_ZIP" != "no"; then
 
   AC_DEFINE(HAVE_ZIP,1,[ ])
 
+  PHP_EVAL_INCLINE($LIBZIP_CFLAGS)
+
   PHP_ZIP_SOURCES="php_zip.c zip_stream.c"
   PHP_NEW_EXTENSION(zip, $PHP_ZIP_SOURCES, $ext_shared,, $LIBZIP_CFLAGS)
 


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=76345

Patch for PHP 7.3 and older is different due to removal of the "bundled" libzip since PHP 7.4.
https://github.com/paresy/php-src/commit/092ded376c515ee225ca33b1abcfe37fe7b95b71.patch