### PR TITLE
Fix Bug 76345 (fix missing zip.h include when using custom libzip) (7.3)

### DIFF
--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -116,6 +116,7 @@ if test "$PHP_ZIP" != "no"; then
     ])
 
     AC_DEFINE(HAVE_ZIP,1,[ ])
+    PHP_EVAL_INCLINE($LIBZIP_CFLAGS)
     PHP_NEW_EXTENSION(zip, php_zip.c zip_stream.c, $ext_shared,, $LIBZIP_CFLAGS)
     PHP_SUBST(ZIP_SHARED_LIBADD)
   else


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=76345

There is also a PR for the master branch