### PR TITLE
ext/xml: Use PKG_CHECK_MODULES to detect the Expat library

### DIFF
--- a/ext/xml/config.m4
+++ b/ext/xml/config.m4
@@ -4,19 +4,19 @@ PHP_ARG_ENABLE([xml],
     [Disable XML support])],
   [yes])
 
-PHP_ARG_WITH([libexpat-dir],
-  [libexpat install dir],
-  [AS_HELP_STRING([--with-libexpat-dir=DIR],
-    [XML: libexpat install prefix (deprecated)])],
+PHP_ARG_WITH([expat],
+  [whether to build with expat support],
+  [AS_HELP_STRING([--with-expat],
+    [XML: use expat instead of libxml2])],
   [no],
   [no])
 
 if test "$PHP_XML" != "no"; then
 
   dnl
-  dnl Default to libxml2 if --with-libexpat-dir is not used.
+  dnl Default to libxml2 if --with-expat is not specified.
   dnl
-  if test "$PHP_LIBEXPAT_DIR" = "no"; then
+  if test "$PHP_EXPAT" = "no"; then
 
     if test "$PHP_LIBXML" = "no"; then
       AC_MSG_ERROR([XML extension requires LIBXML extension, add --with-libxml])
@@ -26,25 +26,12 @@ if test "$PHP_XML" != "no"; then
       xml_extra_sources="compat.c"
       PHP_ADD_EXTENSION_DEP(xml, libxml)
     ])
-  fi
+  else
+    PKG_CHECK_MODULES([EXPAT], [expat])
 
-  dnl
-  dnl Check for expat only if --with-libexpat-dir is used.
-  dnl
-  if test "$PHP_LIBEXPAT_DIR" != "no"; then
-    for i in $PHP_XML $PHP_LIBEXPAT_DIR /usr /usr/local; do
-      if test -f "$i/$PHP_LIBDIR/libexpat.a" || test -f "$i/$PHP_LIBDIR/libexpat.$SHLIB_SUFFIX_NAME"; then
-        EXPAT_DIR=$i
-        break
-      fi
-    done
+    PHP_EVAL_INCLINE($EXPAT_CFLAGS)
+    PHP_EVAL_LIBLINE($EXPAT_LIBS, XML_SHARED_LIBADD)
 
-    if test -z "$EXPAT_DIR"; then
-      AC_MSG_ERROR([not found. Please reinstall the expat distribution.])
-    fi
-
-    PHP_ADD_INCLUDE($EXPAT_DIR/include)
-    PHP_ADD_LIBRARY_WITH_PATH(expat, $EXPAT_DIR/$PHP_LIBDIR, XML_SHARED_LIBADD)
     AC_DEFINE(HAVE_LIBEXPAT, 1, [ ])
   fi
 


### PR DESCRIPTION
The use of Expat is deprecated, but I don't see any reason not to make the conversion to PKG_CHECK_MODULES.