### PR TITLE
Remove get() object handler

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -438,22 +438,6 @@ ZEND_API int ZEND_FASTCALL zend_parse_arg_str_weak(zval *arg, zend_string **dest
 				*dest = Z_STR_P(arg);
 				return 1;
 			}
-		} else if (zobj->handlers->get) {
-			zval rv;
-			zval *z = zobj->handlers->get(zobj, &rv);
-
-			if (Z_TYPE_P(z) != IS_OBJECT) {
-				OBJ_RELEASE(zobj);
-				if (Z_TYPE_P(z) == IS_STRING) {
-					ZVAL_COPY_VALUE(arg, z);
-				} else {
-					ZVAL_STR(arg, zval_get_string_func(z));
-					zval_ptr_dtor(z);
-				}
-				*dest = Z_STR_P(arg);
-				return 1;
-			}
-			zval_ptr_dtor(z);
 		}
 		return 0;
 	} else {

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -789,7 +789,6 @@ ZEND_FUNCTION(define)
 
 	ZVAL_UNDEF(&val_free);
 
-repeat:
 	switch (Z_TYPE_P(val)) {
 		case IS_LONG:
 		case IS_DOUBLE:
@@ -810,17 +809,10 @@ repeat:
 			}
 			break;
 		case IS_OBJECT:
-			if (Z_TYPE(val_free) == IS_UNDEF) {
-				if (Z_OBJ_HT_P(val)->get) {
-					zval rv;
-					val = Z_OBJ_HT_P(val)->get(Z_OBJ_P(val), &rv);
-					ZVAL_COPY_VALUE(&val_free, val);
-					goto repeat;
-				} else if (Z_OBJ_HT_P(val)->cast_object) {
-					if (Z_OBJ_HT_P(val)->cast_object(Z_OBJ_P(val), &val_free, IS_STRING) == SUCCESS) {
-						val = &val_free;
-						break;
-					}
+			if (Z_OBJ_HT_P(val)->cast_object) {
+				if (Z_OBJ_HT_P(val)->cast_object(Z_OBJ_P(val), &val_free, IS_STRING) == SUCCESS) {
+					val = &val_free;
+					break;
 				}
 			}
 			/* no break */

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1296,15 +1296,6 @@ static zend_never_inline void zend_binary_assign_op_obj_dim(zval *object, zval *
 
 	if ((z = Z_OBJ_HT_P(object)->read_dimension(Z_OBJ_P(object), property, BP_VAR_R, &rv)) != NULL) {
 
-		if (Z_TYPE_P(z) == IS_OBJECT && Z_OBJ_HT_P(z)->get) {
-			zval rv2;
-			zval *value = Z_OBJ_HT_P(z)->get(Z_OBJ_P(z), &rv2);
-
-			if (z == &rv) {
-				zval_ptr_dtor(&rv);
-			}
-			ZVAL_COPY_VALUE(z, value);
-		}
 		if (binary_op(&res, z, value) == SUCCESS) {
 			Z_OBJ_HT_P(object)->write_dimension(Z_OBJ_P(object), property, &res);
 		}
@@ -1783,15 +1774,6 @@ static zend_never_inline void zend_post_incdec_overloaded_property(zend_object *
 		return;
 	}
 
-	if (UNEXPECTED(Z_TYPE_P(z) == IS_OBJECT) && Z_OBJ_HT_P(z)->get) {
-		zval rv2;
-		zval *value = Z_OBJ_HT_P(z)->get(Z_OBJ_P(z), &rv2);
-		if (z == &rv) {
-			zval_ptr_dtor(&rv);
-		}
-		ZVAL_COPY_VALUE(z, value);
-	}
-
 	ZVAL_COPY_DEREF(&z_copy, z);
 	ZVAL_COPY(EX_VAR(opline->result.var), &z_copy);
 	if (inc) {
@@ -1821,15 +1803,6 @@ static zend_never_inline void zend_pre_incdec_overloaded_property(zend_object *o
 		return;
 	}
 
-	if (UNEXPECTED(Z_TYPE_P(z) == IS_OBJECT) && Z_OBJ_HT_P(z)->get) {
-		zval rv2;
-		zval *value = Z_OBJ_HT_P(z)->get(Z_OBJ_P(z), &rv2);
-
-		if (z == &rv) {
-			zval_ptr_dtor(&rv);
-		}
-		ZVAL_COPY_VALUE(z, value);
-	}
 	ZVAL_COPY_DEREF(&z_copy, z);
 	if (inc) {
 		increment_function(&z_copy);
@@ -1858,15 +1831,6 @@ static zend_never_inline void zend_assign_op_overloaded_property(zend_object *ob
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 		}
 		return;
-	}
-	if (Z_TYPE_P(z) == IS_OBJECT && Z_OBJ_HT_P(z)->get) {
-		zval rv2;
-		zval *value = Z_OBJ_HT_P(z)->get(Z_OBJ_P(z), &rv2);
-
-		if (z == &rv) {
-			zval_ptr_dtor(&rv);
-		}
-		ZVAL_COPY_VALUE(z, value);
 	}
 	if (binary_op(&res, z, value) == SUCCESS) {
 		object->handlers->write_property(object, name, &res, cache_slot);

--- a/Zend/zend_iterators.c
+++ b/Zend/zend_iterators.c
@@ -36,7 +36,6 @@ static const zend_object_handlers iterator_object_handlers = {
 	NULL, /* read dim */
 	NULL, /* write dim */
 	NULL,
-	NULL, /* get */
 	NULL, /* has prop */
 	NULL, /* unset prop */
 	NULL, /* has dim */

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1837,7 +1837,6 @@ ZEND_API const zend_object_handlers std_object_handlers = {
 	zend_std_read_dimension,				/* read_dimension */
 	zend_std_write_dimension,				/* write_dimension */
 	zend_std_get_property_ptr_ptr,			/* get_property_ptr_ptr */
-	NULL,									/* get */
 	zend_std_has_property,					/* has_property */
 	zend_std_unset_property,				/* unset_property */
 	zend_std_has_dimension,					/* has_dimension */

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -63,11 +63,6 @@ typedef void (*zend_object_write_dimension_t)(zend_object *object, zval *offset,
 /* Used to create pointer to the property of the object, for future direct r/w access */
 typedef zval *(*zend_object_get_property_ptr_ptr_t)(zend_object *object, zend_string *member, int type, void **cache_slot);
 
-/* Used to get object value. Can be used when converting object value to
- * one of the basic types and when using scalar ops (like ++, +=) on the object
- */
-typedef zval* (*zend_object_get_t)(zend_object *object, zval *rv);
-
 /* Used to check if a property of the object exists */
 /* param has_set_exists:
  * 0 (has) whether property exists and is not NULL
@@ -158,7 +153,6 @@ struct _zend_object_handlers {
 	zend_object_read_dimension_t			read_dimension;       /* required */
 	zend_object_write_dimension_t			write_dimension;      /* required */
 	zend_object_get_property_ptr_ptr_t		get_property_ptr_ptr; /* required */
-	zend_object_get_t						get;                  /* optional */
 	zend_object_has_property_t				has_property;         /* required */
 	zend_object_unset_property_t			unset_property;       /* required */
 	zend_object_has_dimension_t				has_dimension;        /* required */

--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -174,14 +174,6 @@ static void com_write_dimension(zend_object *object, zval *offset, zval *value)
 	}
 }
 
-#if 0
-static zval *com_object_get(zval *property)
-{
-	/* Not yet implemented in the engine */
-	return NULL;
-}
-#endif
-
 static int com_property_exists(zend_object *object, zend_string *member, int check_empty, void **cache_slot)
 {
 	DISPID dispid;
@@ -540,7 +532,6 @@ zend_object_handlers php_com_object_handlers = {
 	com_read_dimension,
 	com_write_dimension,
 	NULL,
-	NULL, /* com_object_get, */
 	com_property_exists,
 	com_property_delete,
 	com_dimension_exists,

--- a/ext/com_dotnet/com_saproxy.c
+++ b/ext/com_dotnet/com_saproxy.c
@@ -274,14 +274,6 @@ static void saproxy_write_dimension(zend_object *object, zval *offset, zval *val
 	}
 }
 
-#if 0
-static zval *saproxy_object_get(zval *property)
-{
-	/* Not yet implemented in the engine */
-	return NULL;
-}
-#endif
-
 static int saproxy_property_exists(zend_object *object, zend_string *member, int check_empty, void **cache_slot)
 {
 	/* no properties */
@@ -397,7 +389,6 @@ zend_object_handlers php_com_saproxy_handlers = {
 	saproxy_read_dimension,
 	saproxy_write_dimension,
 	NULL,
-	NULL, /* saproxy_object_get, */
 	saproxy_property_exists,
 	saproxy_property_delete,
 	saproxy_dimension_exists,

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4610,13 +4610,6 @@ static ZEND_COLD void zend_ffi_free_unset_property(zend_object *obj, zend_string
 }
 /* }}} */
 
-static zval* zend_ffi_free_get(zend_object *obj, zval *rv) /* {{{ */
-{
-	zend_ffi_use_after_free();
-	return NULL;
-}
-/* }}} */
-
 static HashTable *zend_ffi_free_get_debug_info(zend_object *obj, int *is_temp) /* {{{ */
 {
 	zend_ffi_use_after_free();
@@ -4767,7 +4760,6 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_cdata_free_handlers.read_dimension       = zend_ffi_free_read_dimension;
 	zend_ffi_cdata_free_handlers.write_dimension      = zend_ffi_free_write_dimension;
 	zend_ffi_cdata_free_handlers.get_property_ptr_ptr = zend_fake_get_property_ptr_ptr;
-	zend_ffi_cdata_free_handlers.get                  = zend_ffi_free_get;
 	zend_ffi_cdata_free_handlers.has_property         = zend_ffi_free_has_property;
 	zend_ffi_cdata_free_handlers.unset_property       = zend_ffi_free_unset_property;
 	zend_ffi_cdata_free_handlers.has_dimension        = zend_ffi_free_has_dimension;

--- a/ext/intl/collator/collator_convert.c
+++ b/ext/intl/collator/collator_convert.c
@@ -226,29 +226,7 @@ zval* collator_convert_object_to_string( zval* obj, zval *rv )
 	}
 
 	/* Try object's handlers. */
-	if( Z_OBJ_HT_P(obj)->get )
-	{
-		zstr = Z_OBJ_HT_P(obj)->get( Z_OBJ_P(obj), rv );
-
-		switch( Z_TYPE_P( zstr ) )
-		{
-			case IS_OBJECT:
-				{
-					/* Bail out. */
-					zval_ptr_dtor( zstr );
-					COLLATOR_CONVERT_RETURN_FAILED( obj );
-				} break;
-
-			case IS_STRING:
-				break;
-
-			default:
-				{
-					convert_to_string( zstr );
-				} break;
-		}
-	}
-	else if( Z_OBJ_HT_P(obj)->cast_object )
+	if( Z_OBJ_HT_P(obj)->cast_object )
 	{
 		zstr = rv;
 

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -968,15 +968,6 @@ static void ZEND_FASTCALL zend_jit_assign_dim_op_helper(zval *container, zval *d
 		z = Z_OBJ_HT_P(object)->read_dimension(Z_OBJ_P(object), property, BP_VAR_R, &rv);
 		if (z != NULL) {
 
-			if (Z_TYPE_P(z) == IS_OBJECT && Z_OBJ_HT_P(z)->get) {
-				zval rv2;
-				zval *value = Z_OBJ_HT_P(z)->get(Z_OBJ_P(z), &rv2);
-
-				if (z == &rv) {
-					zval_ptr_dtor(&rv);
-				}
-				ZVAL_COPY_VALUE(z, value);
-			}
 			if (binary_op(&res, Z_ISREF_P(z) ? Z_REFVAL_P(z) : z, value) == SUCCESS) {
 				Z_OBJ_HT_P(object)->write_dimension(Z_OBJ_P(object), property, &res);
 			}


### PR DESCRIPTION
Now that set() is gone, I think it makes very little sense to keep get(), because it is essentially just a different way of writing cast_object() now. I don't think it allows you to do anything that you couldn't do with cast_object().

cc @dstogov 