### PR TITLE
keep DIR option to --with-unixODBC for old versions without libodbc.pc

### DIFF
--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -362,9 +362,20 @@ PHP_ARG_WITH([unixODBC],,
 
   AC_MSG_CHECKING(whether to build with unixODBC support)
   if test "$PHP_UNIXODBC" != "no"; then
-    AC_MSG_RESULT(yes)
-    PKG_CHECK_MODULES([ODBC], [odbc])
-    PHP_EVAL_INCLINE($ODBC_CFLAGS)
+    if test "$PHP_UNIXODBC" = "yes"; then
+      AC_MSG_RESULT(yes from pkgconfig)
+      PKG_CHECK_MODULES([ODBC], [odbc])
+      PHP_EVAL_INCLINE($ODBC_CFLAGS)
+    else
+      dnl keep old DIR way for old version without libodbc.pc
+      ODBC_INCDIR=$PHP_UNIXODBC/include
+      ODBC_LIBDIR=$PHP_UNIXODBC/$PHP_LIBDIR
+      ODBC_LFLAGS=-L$ODBC_LIBDIR
+      ODBC_CFLAGS=-I$ODBC_INCDIR
+      ODBC_LIBS=-lodbc
+      PHP_ODBC_CHECK_HEADER(sqlext.h)
+      AC_MSG_RESULT(yes in $PHP_UNIXODBC)
+    fi
     ODBC_TYPE=unixODBC
     AC_DEFINE(HAVE_UNIXODBC,1,[ ])
   else


### PR DESCRIPTION
Was able to build 7.4.0-dev on Fedora 29-30 and RHEL 7-8 using this patch  (RHEL-7 build was broken)