### PR TITLE
SimpleXMLElement and ResourceBundle implement Countable

### DIFF
--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -455,6 +455,6 @@ void resourcebundle_register_class( void )
 	ResourceBundle_object_handlers.read_dimension = resourcebundle_array_get;
 	ResourceBundle_object_handlers.count_elements = resourcebundle_array_count;
 
-	zend_class_implements(ResourceBundle_ce_ptr, 1, zend_ce_traversable);
+	zend_class_implements(ResourceBundle_ce_ptr, 2, zend_ce_traversable, zend_ce_countable);
 }
 /* }}} */

--- a/ext/intl/tests/resourcebundle_countable.phpt
+++ b/ext/intl/tests/resourcebundle_countable.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test ResourceBundle implements Countable
+--SKIPIF--
+<?php if( !extension_loaded( 'intl' ) ) print 'skip'; ?>
+--FILE--
+<?php
+	include "resourcebundle.inc";
+
+	$r = new ResourceBundle( 'es', BUNDLE );
+
+	var_dump($r instanceof Countable);
+?>
+--EXPECT--
+bool(true)

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2686,7 +2686,7 @@ PHP_MINIT_FUNCTION(simplexml)
 	sxe.create_object = sxe_object_new;
 	sxe_class_entry = zend_register_internal_class(&sxe);
 	sxe_class_entry->get_iterator = php_sxe_get_iterator;
-	zend_class_implements(sxe_class_entry, 1, zend_ce_traversable);
+	zend_class_implements(sxe_class_entry, 2, zend_ce_traversable, zend_ce_countable);
 
 	memcpy(&sxe_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	sxe_object_handlers.offset = XtOffsetOf(php_sxe_object, zo);

--- a/ext/simplexml/tests/037.phpt
+++ b/ext/simplexml/tests/037.phpt
@@ -1,0 +1,15 @@
+--TEST--
+SimpleXML: implement Countable
+--SKIPIF--
+<?php if (!extension_loaded("simplexml")) print "skip"; ?>
+--FILE--
+<?php
+
+$str = '<xml></xml>';
+$sxe = new SimpleXmlElement($str);
+var_dump($sxe instanceof Countable);
+?>
+==Done==
+--EXPECT--
+bool(true)
+==Done==


### PR DESCRIPTION
Both classes already have a count() method and are considered countable by \is_countable().


This is inconsistent and can be confusing for users (both PHPStan and Psalm got bite by this, see phpstan/phpstan#1761 and vimeo/psalm#1701).



I was a bit unsure on which to target with this PR, I can update if needed.