### PR TITLE
Fix ZTS issue regarding new Windows CTRL handling API

### DIFF
--- a/sapi/cli/tests/sapi_windows_set_ctrl_handler.phpt
+++ b/sapi/cli/tests/sapi_windows_set_ctrl_handler.phpt
@@ -8,8 +8,6 @@ include "skipinf.inc";
 if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN')
   die("skip this test is for Windows platforms only");
 ?>
---XFAIL--
-Fails on AppVeyor
 --FILE--
 <?php
 

--- a/win32/signal.c
+++ b/win32/signal.c
@@ -79,7 +79,7 @@ static BOOL WINAPI php_win32_signal_system_ctrl_handler(DWORD evt)
 		return FALSE;
 	}
 
-	(void)InterlockedExchange((LONG*)vm_interrupt_flag, 1);
+	(void)InterlockedExchange8(vm_interrupt_flag, 1);
 
 	ctrl_evt = evt;
 

--- a/win32/signal.c
+++ b/win32/signal.c
@@ -22,9 +22,9 @@
 #include "win32/console.h"
 
 /* true globals; only used from main thread and from kernel callback */
-zval ctrl_handler;
-DWORD ctrl_evt = (DWORD)-1;
-zend_bool *vm_interrupt_flag = NULL;
+static zval ctrl_handler;
+static DWORD ctrl_evt = (DWORD)-1;
+static zend_bool *vm_interrupt_flag = NULL;
 
 static void (*orig_interrupt_function)(zend_execute_data *execute_data);
 

--- a/win32/signal.c
+++ b/win32/signal.c
@@ -21,9 +21,10 @@
 
 #include "win32/console.h"
 
-ZEND_TLS zval ctrl_handler;
-ZEND_TLS DWORD ctrl_evt = (DWORD)-1;
-ZEND_TLS zend_bool *vm_interrupt_flag = NULL;
+/* true globals; only used from main thread and from kernel callback */
+zval ctrl_handler;
+DWORD ctrl_evt = (DWORD)-1;
+zend_bool *vm_interrupt_flag = NULL;
 
 static void (*orig_interrupt_function)(zend_execute_data *execute_data);
 


### PR DESCRIPTION
php_win32_signal_system_ctrl_handler() is called from a kernel thread,
so the former initialization of `vm_interrupt_flag` has no effect,
since it is defined as thread-local.  This is, however, not necessary,
since the CTRL signal handling is supposed to work only for the main
thread anyway.  We therefore change `vm_interrupt_flag` and the related
variables to true globals.

This also allows us to unmark the respective test case as XFAIL.