### PR TITLE
ext/ffi: Remove symbol check for ffi_open

### DIFF
--- a/ext/ffi/config.m4
+++ b/ext/ffi/config.m4
@@ -6,16 +6,12 @@ PHP_ARG_WITH([ffi],
 if test "$PHP_FFI" != "no"; then
   PKG_CHECK_MODULES([FFI], [libffi >= 3.0.11])
 
-  AC_CHECK_TYPES(long double)
+  PHP_EVAL_INCLINE($FFI_CFLAGS)
+  PHP_EVAL_LIBLINE($FFI_LIBS, FFI_SHARED_LIBADD)
 
-  PHP_CHECK_LIBRARY(ffi, ffi_call,
-  [
-    PHP_EVAL_INCLINE($FFI_CFLAGS)
-    PHP_EVAL_LIBLINE($FFI_LIBS, FFI_SHARED_LIBADD)
-    AC_DEFINE(HAVE_FFI,1,[ Have ffi support ])
-  ], [
-    AC_MSG_ERROR(FFI module requires libffi)
-  ])
+  AC_DEFINE(HAVE_FFI, 1, [Have ffi support])
+
+  AC_CHECK_TYPES(long double)
 
   AC_CACHE_CHECK([for fastcall calling convention], ac_cv_ffi_fastcall,
     [


### PR DESCRIPTION
`configure` fails when `--with-ffi=shared` is specified and ffi is not installed in a system path, because it cannot find the ffi library.

Shared builds were broken in my pull request with commit 4ffbf4e.