### PR TITLE
ext/enchant: Pass $ENCHANT_LIBS to PHP_CHECK_LIBRARY for shared builds

### DIFF
--- a/ext/enchant/config.m4
+++ b/ext/enchant/config.m4
@@ -15,6 +15,8 @@ if test "$PHP_ENCHANT" != "no"; then
   [
     AC_DEFINE(HAVE_ENCHANT_BROKER_SET_PARAM, 1, [ ])
     AC_DEFINE(ENCHANT_VERSION_STRING, "1.5.x", [ ])
+  ], [ ], [
+    $ENCHANT_LIBS
   ])
 
   PHP_NEW_EXTENSION(enchant, enchant.c, $ext_shared)


### PR DESCRIPTION
When `--with-enchant=shared` is passed to `configure` and enchant is not installed in a system path, the symbol `enchant_broker_set_param` is not found.