### PR TITLE
Make "MySQL server has gone away" errors more consistent

### DIFF
--- a/ext/mysqli/tests/mysqli_change_user_new.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_new.phpt
@@ -35,9 +35,6 @@ if (mysqli_get_server_version($link) < 50600)
 
 	print "done!";
 ?>
---EXPECTF--
-Warning: mysqli_query(): MySQL server has gone away in %s on line %d
-
-Warning: mysqli_query(): Error reading result set's header in %s on line %d
+--EXPECT--
 [003] [2006] MySQL server has gone away
 done!

--- a/ext/mysqli/tests/mysqli_mysqlnd_read_timeout.phpt
+++ b/ext/mysqli/tests/mysqli_mysqlnd_read_timeout.phpt
@@ -28,9 +28,6 @@ mysqlnd.net_read_timeout=1
 
 	print "done!";
 ?>
---EXPECTF--
-Warning: mysqli_query(): MySQL server has gone away in %s on line %d
-
-Warning: mysqli_query(): Error reading result set's header in %s on line %d
-[002] [%d] %s
+--EXPECT--
+[002] [2006] MySQL server has gone away
 done!

--- a/ext/mysqli/tests/mysqli_pconn_max_links.phpt
+++ b/ext/mysqli/tests/mysqli_pconn_max_links.phpt
@@ -234,10 +234,6 @@ Before second pconnect:array(3) {
   ["cached_plinks"]=>
   int(0)
 }
-
-Warning: main(): MySQL server has gone away in %s on line %d
-
-Warning: main(): Error reading result set's header in %s line %d
 After second pconnect:array(3) {
   ["total"]=>
   int(1)

--- a/ext/mysqlnd/mysqlnd_result.c
+++ b/ext/mysqlnd/mysqlnd_result.c
@@ -391,7 +391,9 @@ mysqlnd_query_read_result_set_header(MYSQLND_CONN_DATA * conn, MYSQLND_STMT * s)
 		UPSERT_STATUS_SET_AFFECTED_ROWS_TO_ERROR(conn->upsert_status);
 
 		if (FAIL == (ret = PACKET_READ(conn, &rset_header))) {
-			php_error_docref(NULL, E_WARNING, "Error reading result set's header");
+			if (conn->error_info->error_no != CR_SERVER_GONE_ERROR) {
+				php_error_docref(NULL, E_WARNING, "Error reading result set's header");
+			}
 			break;
 		}
 

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -296,7 +296,6 @@ mysqlnd_read_packet_header_and_body(MYSQLND_PACKET_HEADER * packet_header,
 	if (FAIL == mysqlnd_read_header(pfc, vio, packet_header, stats, error_info)) {
 		SET_CONNECTION_STATE(connection_state, CONN_QUIT_SENT);
 		SET_CLIENT_ERROR(error_info, CR_SERVER_GONE_ERROR, UNKNOWN_SQLSTATE, mysqlnd_server_gone);
-		php_error_docref(NULL, E_WARNING, "%s", mysqlnd_server_gone);
 		DBG_ERR_FMT("Can't read %s's header", packet_type_as_text);
 		DBG_RETURN(FAIL);
 	}
@@ -308,7 +307,6 @@ mysqlnd_read_packet_header_and_body(MYSQLND_PACKET_HEADER * packet_header,
 	if (FAIL == pfc->data->m.receive(pfc, vio, buf, packet_header->size, stats, error_info)) {
 		SET_CONNECTION_STATE(connection_state, CONN_QUIT_SENT);
 		SET_CLIENT_ERROR(error_info, CR_SERVER_GONE_ERROR, UNKNOWN_SQLSTATE, mysqlnd_server_gone);
-		php_error_docref(NULL, E_WARNING, "%s", mysqlnd_server_gone);
 		DBG_ERR_FMT("Empty '%s' packet body", packet_type_as_text);
 		DBG_RETURN(FAIL);
 	}
@@ -2532,7 +2530,7 @@ MYSQLND_METHOD(mysqlnd_protocol, send_command)(
 	MYSQLND_INC_CONN_STATISTIC(stats, STAT_COM_QUIT + command - 1 /* because of COM_SLEEP */ );
 
 	if (! PACKET_WRITE(payload_decoder_factory->conn, &cmd_packet)) {
-		if (!silent) {
+		if (!silent && error_info->error_no != CR_SERVER_GONE_ERROR) {
 			DBG_ERR_FMT("Error while sending %s packet", mysqlnd_command_to_text[command]);
 			php_error(E_WARNING, "Error while sending %s packet. PID=%d", mysqlnd_command_to_text[command], getpid());
 		}


### PR DESCRIPTION
Don't generate explicit warnings for these in two places, use usual error handling mechanism. Additionally suppress a number of warnings if the server has gone away.

This fixes test failures for me locally and should fix the failures on Azure ... hopefully Travis passes as well.