### PR TITLE
EINPROGRESS constant value fixed in WIN32

### DIFF
--- a/main/php_network.h
+++ b/main/php_network.h
@@ -42,7 +42,7 @@
 #  undef EINPROGRESS
 # endif
 # define EWOULDBLOCK WSAEWOULDBLOCK
-# define EINPROGRESS	WSAEWOULDBLOCK
+# define EINPROGRESS WSAEINPROGRESS
 # define fsync _commit
 # define ftruncate(a, b) chsize(a, b)
 #endif /* defined(PHP_WIN32) */


### PR DESCRIPTION
EINPROGRESS wrongly mapped to WSAEWOULDBLOCK before.