### PR TITLE
ext/tidy: Only support Tidy-HTML5

### DIFF
--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -28,7 +28,6 @@ if test "$PHP_TIDY" != "no"; then
   fi
 
   TIDY_LIBDIR=$TIDY_DIR/$PHP_LIBDIR
-  AC_DEFINE(HAVE_TIDY_H, 1, [defined if tidy.h exists])
 
   PHP_CHECK_LIBRARY(tidy, tidyOptGetDoc,
   [

--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -29,13 +29,6 @@ if test "$PHP_TIDY" != "no"; then
 
   if test -z "$TIDY_DIR"; then
     AC_MSG_ERROR(Cannot find libtidy)
-  else
-    dnl Check for tidybuffio.h (as opposed to simply buffio.h) which indicates
-    dnl that we are building against tidy-html5 and not the legacy htmltidy. The
-    dnl two are compatible, except for with regard to this header file.
-    if test -f "$TIDY_INCDIR/tidybuffio.h"; then
-      AC_DEFINE(HAVE_TIDYBUFFIO_H,1,[defined if tidybuffio.h exists])
-    fi
   fi
 
   TIDY_LIBDIR=$TIDY_DIR/$PHP_LIBDIR

--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -1,47 +1,27 @@
 PHP_ARG_WITH([tidy],
-  [for TIDY support],
-  [AS_HELP_STRING([[--with-tidy[=DIR]]],
-    [Include TIDY support])])
+  [whether to build with Tidy-HTML5 support],
+  [AS_HELP_STRING([--with-tidy],
+    [Build with Tidy-HTML5 support])])
 
 if test "$PHP_TIDY" != "no"; then
+  PKG_CHECK_MODULES([TIDY], [tidy])
 
-  if test "$PHP_TIDY" != "yes"; then
-    TIDY_SEARCH_DIRS=$PHP_TIDY
-  else
-    TIDY_SEARCH_DIRS="/usr/local /usr"
-  fi
-
-  for i in $TIDY_SEARCH_DIRS; do
-    if test -f $i/include/$j/$j.h; then
-      TIDY_DIR=$i
-      TIDY_INCDIR=$i/include/$j
-      break
-    elif test -f $i/include/$j.h; then
-      TIDY_DIR=$i
-      TIDY_INCDIR=$i/include
-      break
-    fi
-  done
-
-  if test -z "$TIDY_DIR"; then
-    AC_MSG_ERROR(Cannot find libtidy)
-  fi
-
-  TIDY_LIBDIR=$TIDY_DIR/$PHP_LIBDIR
+  PHP_EVAL_INCLINE($TIDY_CFLAGS)
+  PHP_EVAL_LIBLINE($TIDY_LIBS, TIDY_SHARED_LIBADD)
 
   PHP_CHECK_LIBRARY(tidy, tidyOptGetDoc,
   [
     AC_DEFINE(HAVE_TIDYOPTGETDOC,1,[ ])
-  ], [], [])
+  ], [], [
+    $TIDY_LIBS
+  ])
 
   PHP_CHECK_LIBRARY(tidy, tidyReleaseDate,
   [
     AC_DEFINE(HAVE_TIDYRELEASEDATE,1,[ ])
-  ], [], [])
-
-  PHP_ADD_LIBRARY_WITH_PATH(tidy, $TIDY_LIBDIR, TIDY_SHARED_LIBADD)
-  PHP_ADD_INCLUDE($TIDY_INCDIR)
-
+  ], [], [
+    $TIDY_LIBS
+  ])
 
   PHP_NEW_EXTENSION(tidy, tidy.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_SUBST(TIDY_SHARED_LIBADD)

--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -12,19 +12,15 @@ if test "$PHP_TIDY" != "no"; then
   fi
 
   for i in $TIDY_SEARCH_DIRS; do
-    for j in tidy tidyp; do
-        if test -f $i/include/$j/$j.h; then
-            TIDY_DIR=$i
-            TIDY_INCDIR=$i/include/$j
-            TIDY_LIB_NAME=$j
-        break
-        elif test -f $i/include/$j.h; then
-            TIDY_DIR=$i
-            TIDY_INCDIR=$i/include
-            TIDY_LIB_NAME=$j
-        break
-        fi
-    done
+    if test -f $i/include/$j/$j.h; then
+      TIDY_DIR=$i
+      TIDY_INCDIR=$i/include/$j
+      break
+    elif test -f $i/include/$j.h; then
+      TIDY_DIR=$i
+      TIDY_INCDIR=$i/include
+      break
+    fi
   done
 
   if test -z "$TIDY_DIR"; then
@@ -32,30 +28,19 @@ if test "$PHP_TIDY" != "no"; then
   fi
 
   TIDY_LIBDIR=$TIDY_DIR/$PHP_LIBDIR
-  if test "$TIDY_LIB_NAME" == 'tidyp'; then
-    AC_DEFINE(HAVE_TIDYP_H,1,[defined if tidyp.h exists])
-  else
-    AC_DEFINE(HAVE_TIDY_H,1,[defined if tidy.h exists])
-  fi
+  AC_DEFINE(HAVE_TIDY_H, 1, [defined if tidy.h exists])
 
-
-  PHP_CHECK_LIBRARY($TIDY_LIB_NAME,tidyOptGetDoc,
+  PHP_CHECK_LIBRARY(tidy, tidyOptGetDoc,
   [
     AC_DEFINE(HAVE_TIDYOPTGETDOC,1,[ ])
-  ],[
-    PHP_CHECK_LIBRARY(tidy5,tidyOptGetDoc,
-    [
-      TIDY_LIB_NAME=tidy5
-      AC_DEFINE(HAVE_TIDYOPTGETDOC,1,[ ])
-    ], [], [])
-  ],[])
+  ], [], [])
 
-  PHP_CHECK_LIBRARY($TIDY_LIB_NAME,tidyReleaseDate,
+  PHP_CHECK_LIBRARY(tidy, tidyReleaseDate,
   [
     AC_DEFINE(HAVE_TIDYRELEASEDATE,1,[ ])
   ], [], [])
 
-  PHP_ADD_LIBRARY_WITH_PATH($TIDY_LIB_NAME, $TIDY_LIBDIR, TIDY_SHARED_LIBADD)
+  PHP_ADD_LIBRARY_WITH_PATH(tidy, $TIDY_LIBDIR, TIDY_SHARED_LIBADD)
   PHP_ADD_INCLUDE($TIDY_INCDIR)
 
 

--- a/ext/tidy/config.w32
+++ b/ext/tidy/config.w32
@@ -14,7 +14,6 @@ if (PHP_TIDY != "no") {
 
 		EXTENSION("tidy", "tidy.c");
 		AC_DEFINE('HAVE_TIDY', 1, 'Have TIDY library');
-		AC_DEFINE('HAVE_TIDY_H', 1, "tidy include header")
 		AC_DEFINE('HAVE_TIDYOPTGETDOC', 1, "tidy_get_opt_doc function")
 		AC_DEFINE('HAVE_TIDYRELEASEDATE', 1, "tidy release date function")
 		ADD_FLAG('CFLAGS_TIDY', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');

--- a/ext/tidy/config.w32
+++ b/ext/tidy/config.w32
@@ -12,10 +12,6 @@ if (PHP_TIDY != "no") {
 				CHECK_HEADER_ADD_INCLUDE("libtidy/tidy.h", "CFLAGS_TIDY", null, null, true)
 			)) {
 
-		if (CHECK_HEADER_ADD_INCLUDE("tidybuffio.h", "CFLAGS_TIDY")) {
-			AC_DEFINE('HAVE_TIDYBUFFIO_H', 1, 'Have tidybuffio.h header file');
-		}
-
 		EXTENSION("tidy", "tidy.c");
 		AC_DEFINE('HAVE_TIDY', 1, 'Have TIDY library');
 		AC_DEFINE('HAVE_TIDY_H', 1, "tidy include header")

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -30,8 +30,6 @@
 
 #if HAVE_TIDY_H
 #include "tidy.h"
-#elif HAVE_TIDYP_H
-#include "tidyp.h"
 #endif
 
 #include "tidybuffio.h"
@@ -1105,9 +1103,6 @@ static PHP_MINFO_FUNCTION(tidy)
 	php_info_print_table_start();
 	php_info_print_table_row(2, "Tidy support", "enabled");
 	php_info_print_table_row(2, "libTidy Version", (char *)tidyLibraryVersion());
-#if HAVE_TIDYP_H
-	php_info_print_table_row(2, "libtidyp Version", (char *)tidyVersion());
-#endif
 #if HAVE_TIDYRELEASEDATE
 	php_info_print_table_row(2, "libTidy Release", (char *)tidyReleaseDate());
 #endif

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -34,11 +34,7 @@
 #include "tidyp.h"
 #endif
 
-#if HAVE_TIDYBUFFIO_H
 #include "tidybuffio.h"
-#else
-#include "buffio.h"
-#endif
 
 /* compatibility with older versions of libtidy */
 #ifndef TIDY_CALL
@@ -1108,9 +1104,8 @@ static PHP_MINFO_FUNCTION(tidy)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "Tidy support", "enabled");
-#if HAVE_TIDYBUFFIO_H
 	php_info_print_table_row(2, "libTidy Version", (char *)tidyLibraryVersion());
-#elif HAVE_TIDYP_H
+#if HAVE_TIDYP_H
 	php_info_print_table_row(2, "libtidyp Version", (char *)tidyVersion());
 #endif
 #if HAVE_TIDYRELEASEDATE
@@ -2032,7 +2027,6 @@ static void _php_tidy_register_tags(INIT_FUNC_ARGS)
 	TIDY_TAG_CONST(VAR);
 	TIDY_TAG_CONST(WBR);
 	TIDY_TAG_CONST(XMP);
-# if HAVE_TIDYBUFFIO_H
 	TIDY_TAG_CONST(ARTICLE);
 	TIDY_TAG_CONST(ASIDE);
 	TIDY_TAG_CONST(AUDIO);
@@ -2061,7 +2055,6 @@ static void _php_tidy_register_tags(INIT_FUNC_ARGS)
 	TIDY_TAG_CONST(TIME);
 	TIDY_TAG_CONST(TRACK);
 	TIDY_TAG_CONST(VIDEO);
-# endif
 }
 
 #endif

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -28,10 +28,7 @@
 #include "php_ini.h"
 #include "ext/standard/info.h"
 
-#if HAVE_TIDY_H
 #include "tidy.h"
-#endif
-
 #include "tidybuffio.h"
 
 /* compatibility with older versions of libtidy */


### PR DESCRIPTION
html-tidy and the tidyp fork haven't been actively developed or used in many years.