### PR TITLE
Fix #78114: segfault when calling sodium_* functions from eval

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -387,8 +387,10 @@ static void sodium_remove_param_values_from_backtrace(zend_object *obj) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(trace), frame) {
 			if (Z_TYPE_P(frame) == IS_ARRAY) {
 				zval *args = zend_hash_str_find(Z_ARRVAL_P(frame), "args", sizeof("args")-1);
-				zval_ptr_dtor(args);
-				ZVAL_EMPTY_ARRAY(args);
+				if (args) {
+					zval_ptr_dtor(args);
+					ZVAL_EMPTY_ARRAY(args);
+				}
 			}
 		} ZEND_HASH_FOREACH_END();
 	}

--- a/ext/sodium/tests/bug78114.phpt
+++ b/ext/sodium/tests/bug78114.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #78114 (segfault when calling sodium_* functions from eval)
+--SKIPIF--
+<?php
+if (!extension_loaded('sodium')) die('skip sodium extension not available');
+?>
+--FILE--
+<?php
+try {
+    eval('sodium_bin2hex();');
+} catch (Throwable $ex) {
+    echo $ex->getMessage(), PHP_EOL;
+}
+?>
+===DONE===
+--EXPECT--
+sodium_bin2hex() expects exactly 1 parameter, 0 given
+===DONE===


### PR DESCRIPTION
We must not follow the NULL pointer.