### PR TITLE
Dont check arginfo types for internal functions

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1150,6 +1150,7 @@ static zend_never_inline int zend_verify_internal_arg_types(zend_function *fbc, 
 	for (i = 0; i < num_args; ++i) {
 		dummy_cache_slot = NULL;
 		if (UNEXPECTED(!zend_verify_arg_type(fbc, i + 1, p, NULL, &dummy_cache_slot, 1))) {
+			zend_throw_error(NULL, "Internal function arginfo verification failed, but function did not throw");
 			EG(current_execute_data) = call->prev_execute_data;
 			zend_vm_stack_free_args(call);
 			return 0;
@@ -4442,13 +4443,6 @@ ZEND_API zval *zend_get_zval_ptr(const zend_op *opline, int op_type, const znode
 			break;
 	}
 	return ret;
-}
-
-ZEND_API void ZEND_FASTCALL zend_check_internal_arg_type(zend_function *zf, uint32_t arg_num, zval *arg)
-{
-	void *dummy_cache_slot = NULL;
-
-	zend_verify_arg_type(zf, arg_num, arg, NULL, &dummy_cache_slot, 1);
 }
 
 ZEND_API int ZEND_FASTCALL zend_check_arg_type(zend_function *zf, uint32_t arg_num, zval *arg, zval *default_value, void **cache_slot)

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1140,7 +1140,7 @@ static zend_always_inline int zend_verify_variadic_arg_type(zend_function *zf, u
 	return 1;
 }
 
-static zend_never_inline int zend_verify_internal_arg_types(zend_function *fbc, zend_execute_data *call)
+static zend_never_inline ZEND_ATTRIBUTE_UNUSED int zend_verify_internal_arg_types(zend_function *fbc, zend_execute_data *call)
 {
 	uint32_t i;
 	uint32_t num_args = ZEND_CALL_NUM_ARGS(call);

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -52,7 +52,6 @@ ZEND_API int zend_eval_stringl_ex(const char *str, size_t str_len, zval *retval_
 /* export zend_pass_function to allow comparisons against it */
 extern ZEND_API const zend_internal_function zend_pass_function;
 
-ZEND_API void ZEND_FASTCALL zend_check_internal_arg_type(zend_function *zf, uint32_t arg_num, zval *arg);
 ZEND_API int  ZEND_FASTCALL zend_check_arg_type(zend_function *zf, uint32_t arg_num, zval *arg, zval *default_value, void **cache_slot);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_missing_arg_error(zend_execute_data *execute_data);
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3954,6 +3954,16 @@ ZEND_VM_HOT_HANDLER(131, ZEND_DO_FCALL_BY_NAME, ANY, ANY, SPEC(RETVAL))
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
+
+#if ZEND_DEBUG
+		/* Type checks for internal functions are usually only performed by zpp.
+		 * In debug mode we additionally run arginfo checks to detect cases where
+		 * arginfo and zpp went out of sync. */
+		zend_bool wrong_arg_types =
+			(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) &&
+			!zend_verify_internal_arg_types(fbc, call);
+#endif
+
 		ret = RETURN_VALUE_USED(opline) ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -3961,19 +3971,11 @@ ZEND_VM_HOT_HANDLER(131, ZEND_DO_FCALL_BY_NAME, ANY, ANY, SPEC(RETVAL))
 
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
+			ZEND_ASSERT(!wrong_arg_types && "Arginfo / zpp type mismatch?");
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
-
-			/* Type checks for internal functions are usually only performed by zpp.
-			 * In debug mode we additionally run arginfo checks to detect cases where
-			 * arginfo and zpp went out of sync. */
-			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-				UNDEF_RESULT();
-				ZEND_VM_C_GOTO(fcall_end);
-			}
 		}
 #endif
 
@@ -4041,6 +4043,15 @@ ZEND_VM_HOT_HANDLER(60, ZEND_DO_FCALL, ANY, ANY, SPEC(RETVAL))
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
+#if ZEND_DEBUG
+		/* Type checks for internal functions are usually only performed by zpp.
+		 * In debug mode we additionally run arginfo checks to detect cases where
+		 * arginfo and zpp went out of sync. */
+		zend_bool wrong_arg_types =
+			(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) &&
+			!zend_verify_internal_arg_types(fbc, call);
+#endif
+
 		ret = RETURN_VALUE_USED(opline) ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -4053,21 +4064,11 @@ ZEND_VM_HOT_HANDLER(60, ZEND_DO_FCALL, ANY, ANY, SPEC(RETVAL))
 
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
+			ZEND_ASSERT(!wrong_arg_types && "Arginfo / zpp type mismatch?");
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
-
-			/* Type checks for internal functions are usually only performed by zpp.
-			 * In debug mode we additionally run arginfo checks to detect cases where
-			 * arginfo and zpp went out of sync. */
-			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-				zend_vm_stack_free_call_frame(call);
-				zend_rethrow_exception(execute_data);
-				UNDEF_RESULT();
-				HANDLE_EXCEPTION();
-			}
 		}
 #endif
 
@@ -8114,6 +8115,15 @@ ZEND_VM_HANDLER(158, ZEND_CALL_TRAMPOLINE, ANY, ANY)
 
 		EG(current_execute_data) = call;
 
+#if ZEND_DEBUG
+		/* Type checks for internal functions are usually only performed by zpp.
+		 * In debug mode we additionally run arginfo checks to detect cases where
+		 * arginfo and zpp went out of sync. */
+		zend_bool wrong_arg_types =
+			(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) &&
+			!zend_verify_internal_arg_types(fbc, call);
+#endif
+
 		if (ret == NULL) {
 			ZVAL_NULL(&retval);
 			ret = &retval;
@@ -8128,20 +8138,11 @@ ZEND_VM_HANDLER(158, ZEND_CALL_TRAMPOLINE, ANY, ANY)
 
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
+			ZEND_ASSERT(!wrong_arg_types && "Arginfo / zpp type mismatch?");
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
-
-			/* Type checks for internal functions are usually only performed by zpp.
-			 * In debug mode we additionally run arginfo checks to detect cases where
-			 * arginfo and zpp went out of sync. */
-			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-				zend_vm_stack_free_call_frame(call);
-				UNDEF_RESULT();
-				ZEND_VM_C_GOTO(call_trampoline_end);
-			}
 		}
 #endif
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4079,7 +4079,7 @@ ZEND_VM_HOT_HANDLER(60, ZEND_DO_FCALL, ANY, ANY, SPEC(RETVAL))
 		}
 	}
 
-ZEND_VM_C_LABEL(fcall_end):
+ZEND_VM_C_LABEL(fcall_end): ZEND_ATTRIBUTE_UNUSED;
 	if (UNEXPECTED(ZEND_CALL_INFO(call) & ZEND_CALL_RELEASE_THIS)) {
 		OBJ_RELEASE(Z_OBJ(call->This));
 	}
@@ -8154,7 +8154,7 @@ ZEND_VM_HANDLER(158, ZEND_CALL_TRAMPOLINE, ANY, ANY)
 		}
 	}
 
-ZEND_VM_C_LABEL(call_trampoline_end):
+ZEND_VM_C_LABEL(call_trampoline_end): ZEND_ATTRIBUTE_UNUSED;
 	execute_data = EG(current_execute_data);
 
 	if (!EX(func) || !ZEND_USER_CODE(EX(func)->type) || (call_info & ZEND_CALL_TOP)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1129,6 +1129,16 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
+
+#if ZEND_DEBUG
+		/* Type checks for internal functions are usually only performed by zpp.
+		 * In debug mode we additionally run arginfo checks to detect cases where
+		 * arginfo and zpp went out of sync. */
+		zend_bool wrong_arg_types =
+			(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) &&
+			!zend_verify_internal_arg_types(fbc, call);
+#endif
+
 		ret = 0 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -1136,21 +1146,11 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
+			ZEND_ASSERT(!wrong_arg_types && "Arginfo / zpp type mismatch?");
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
-
-			/* Type checks for internal functions are usually only performed by zpp.
-			 * In debug mode we additionally run arginfo checks to detect cases where
-			 * arginfo and zpp went out of sync. */
-			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-				zend_vm_stack_free_call_frame(call);
-				zend_rethrow_exception(execute_data);
-				UNDEF_RESULT();
-				HANDLE_EXCEPTION();
-			}
 		}
 #endif
 
@@ -1208,6 +1208,16 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
+
+#if ZEND_DEBUG
+		/* Type checks for internal functions are usually only performed by zpp.
+		 * In debug mode we additionally run arginfo checks to detect cases where
+		 * arginfo and zpp went out of sync. */
+		zend_bool wrong_arg_types =
+			(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) &&
+			!zend_verify_internal_arg_types(fbc, call);
+#endif
+
 		ret = 1 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -1215,21 +1225,11 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
+			ZEND_ASSERT(!wrong_arg_types && "Arginfo / zpp type mismatch?");
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
-
-			/* Type checks for internal functions are usually only performed by zpp.
-			 * In debug mode we additionally run arginfo checks to detect cases where
-			 * arginfo and zpp went out of sync. */
-			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-				zend_vm_stack_free_call_frame(call);
-				zend_rethrow_exception(execute_data);
-				UNDEF_RESULT();
-				HANDLE_EXCEPTION();
-			}
 		}
 #endif
 
@@ -1297,6 +1297,15 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
+#if ZEND_DEBUG
+		/* Type checks for internal functions are usually only performed by zpp.
+		 * In debug mode we additionally run arginfo checks to detect cases where
+		 * arginfo and zpp went out of sync. */
+		zend_bool wrong_arg_types =
+			(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) &&
+			!zend_verify_internal_arg_types(fbc, call);
+#endif
+
 		ret = 0 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -1309,19 +1318,11 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
+			ZEND_ASSERT(!wrong_arg_types && "Arginfo / zpp type mismatch?");
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
-
-			/* Type checks for internal functions are usually only performed by zpp.
-			 * In debug mode we additionally run arginfo checks to detect cases where
-			 * arginfo and zpp went out of sync. */
-			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-				UNDEF_RESULT();
-				goto fcall_end;
-			}
 		}
 #endif
 
@@ -1395,6 +1396,15 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
+#if ZEND_DEBUG
+		/* Type checks for internal functions are usually only performed by zpp.
+		 * In debug mode we additionally run arginfo checks to detect cases where
+		 * arginfo and zpp went out of sync. */
+		zend_bool wrong_arg_types =
+			(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) &&
+			!zend_verify_internal_arg_types(fbc, call);
+#endif
+
 		ret = 1 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -1407,19 +1417,11 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
+			ZEND_ASSERT(!wrong_arg_types && "Arginfo / zpp type mismatch?");
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
-
-			/* Type checks for internal functions are usually only performed by zpp.
-			 * In debug mode we additionally run arginfo checks to detect cases where
-			 * arginfo and zpp went out of sync. */
-			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-				UNDEF_RESULT();
-				goto fcall_end;
-			}
 		}
 #endif
 
@@ -2430,6 +2432,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_HANDLER(Z
 
 		EG(current_execute_data) = call;
 
+#if ZEND_DEBUG
+		/* Type checks for internal functions are usually only performed by zpp.
+		 * In debug mode we additionally run arginfo checks to detect cases where
+		 * arginfo and zpp went out of sync. */
+		zend_bool wrong_arg_types =
+			(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) &&
+			!zend_verify_internal_arg_types(fbc, call);
+#endif
+
 		if (ret == NULL) {
 			ZVAL_NULL(&retval);
 			ret = &retval;
@@ -2444,20 +2455,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_HANDLER(Z
 
 #if ZEND_DEBUG
 		if (!EG(exception) && call->func) {
+			ZEND_ASSERT(!wrong_arg_types && "Arginfo / zpp type mismatch?");
 			ZEND_ASSERT(!(call->func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) ||
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
-
-			/* Type checks for internal functions are usually only performed by zpp.
-			 * In debug mode we additionally run arginfo checks to detect cases where
-			 * arginfo and zpp went out of sync. */
-			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-				zend_vm_stack_free_call_frame(call);
-				UNDEF_RESULT();
-				goto call_trampoline_end;
-			}
 		}
 #endif
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1333,7 +1333,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		}
 	}
 
-fcall_end:
+fcall_end: ZEND_ATTRIBUTE_UNUSED;
 	if (UNEXPECTED(ZEND_CALL_INFO(call) & ZEND_CALL_RELEASE_THIS)) {
 		OBJ_RELEASE(Z_OBJ(call->This));
 	}
@@ -1431,7 +1431,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		}
 	}
 
-fcall_end:
+fcall_end: ZEND_ATTRIBUTE_UNUSED;
 	if (UNEXPECTED(ZEND_CALL_INFO(call) & ZEND_CALL_RELEASE_THIS)) {
 		OBJ_RELEASE(Z_OBJ(call->This));
 	}
@@ -2470,7 +2470,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_HANDLER(Z
 		}
 	}
 
-call_trampoline_end:
+call_trampoline_end: ZEND_ATTRIBUTE_UNUSED;
 	execute_data = EG(current_execute_data);
 
 	if (!EX(func) || !ZEND_USER_CODE(EX(func)->type) || (call_info & ZEND_CALL_TOP)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1129,14 +1129,6 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
-		if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-		 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-			zend_vm_stack_free_call_frame(call);
-			zend_rethrow_exception(execute_data);
-		    UNDEF_RESULT();
-			HANDLE_EXCEPTION();
-		}
-
 		ret = 0 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -1148,6 +1140,17 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
+
+			/* Type checks for internal functions are usually only performed by zpp.
+			 * In debug mode we additionally run arginfo checks to detect cases where
+			 * arginfo and zpp went out of sync. */
+			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
+			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
+				zend_vm_stack_free_call_frame(call);
+				zend_rethrow_exception(execute_data);
+				UNDEF_RESULT();
+				HANDLE_EXCEPTION();
+			}
 		}
 #endif
 
@@ -1205,14 +1208,6 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
-		if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-		 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-			zend_vm_stack_free_call_frame(call);
-			zend_rethrow_exception(execute_data);
-		    UNDEF_RESULT();
-			HANDLE_EXCEPTION();
-		}
-
 		ret = 1 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -1224,6 +1219,17 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
+
+			/* Type checks for internal functions are usually only performed by zpp.
+			 * In debug mode we additionally run arginfo checks to detect cases where
+			 * arginfo and zpp went out of sync. */
+			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
+			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
+				zend_vm_stack_free_call_frame(call);
+				zend_rethrow_exception(execute_data);
+				UNDEF_RESULT();
+				HANDLE_EXCEPTION();
+			}
 		}
 #endif
 
@@ -1291,12 +1297,6 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
-		if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-		  && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-			UNDEF_RESULT();
-			goto fcall_end;
-		}
-
 		ret = 0 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -1313,6 +1313,15 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
+
+			/* Type checks for internal functions are usually only performed by zpp.
+			 * In debug mode we additionally run arginfo checks to detect cases where
+			 * arginfo and zpp went out of sync. */
+			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
+			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
+				UNDEF_RESULT();
+				goto fcall_end;
+			}
 		}
 #endif
 
@@ -1386,12 +1395,6 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		call->prev_execute_data = execute_data;
 		EG(current_execute_data) = call;
 
-		if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-		  && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-			UNDEF_RESULT();
-			goto fcall_end;
-		}
-
 		ret = 1 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
@@ -1408,6 +1411,15 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
+
+			/* Type checks for internal functions are usually only performed by zpp.
+			 * In debug mode we additionally run arginfo checks to detect cases where
+			 * arginfo and zpp went out of sync. */
+			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
+			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
+				UNDEF_RESULT();
+				goto fcall_end;
+			}
 		}
 #endif
 
@@ -2418,15 +2430,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_HANDLER(Z
 
 		EG(current_execute_data) = call;
 
-		if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
-		 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
-			zend_vm_stack_free_call_frame(call);
-			if (ret) {
-				ZVAL_UNDEF(ret);
-			}
-			goto call_trampoline_end;
-		}
-
 		if (ret == NULL) {
 			ZVAL_NULL(&retval);
 			ret = &retval;
@@ -2445,6 +2448,16 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_HANDLER(Z
 				zend_verify_internal_return_type(call->func, ret));
 			ZEND_ASSERT((call->func->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)
 				? Z_ISREF_P(ret) : !Z_ISREF_P(ret));
+
+			/* Type checks for internal functions are usually only performed by zpp.
+			 * In debug mode we additionally run arginfo checks to detect cases where
+			 * arginfo and zpp went out of sync. */
+			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)
+			 && UNEXPECTED(!zend_verify_internal_arg_types(fbc, call))) {
+				zend_vm_stack_free_call_frame(call);
+				UNDEF_RESULT();
+				goto call_trampoline_end;
+			}
 		}
 #endif
 

--- a/ext/date/tests/014.phpt
+++ b/ext/date/tests/014.phpt
@@ -33,7 +33,7 @@ object(DateTimeZone)#%d (2) {
 }
 int(0)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, instance of DateTime given in %s:%d
+Fatal error: Uncaught TypeError: timezone_offset_get() expects parameter 1 to be DateTimeZone, object given in %s:%d
 Stack trace:
 #0 %s(%d): timezone_offset_get(Object(DateTime), Object(DateTimeZone))
 #1 {main}

--- a/ext/date/tests/timezone_offset_get_error.phpt
+++ b/ext/date/tests/timezone_offset_get_error.phpt
@@ -62,22 +62,22 @@ try {
 }
 ?>
 ===DONE===
---EXPECTF--
+--EXPECT--
 *** Testing timezone_offset_get() : error conditions ***
 
 -- Testing timezone_offset_get() function with an invalid values for $object argument --
-string(%d) "Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, instance of stdClass given"
+string(74) "timezone_offset_get() expects parameter 1 to be DateTimeZone, object given"
 
-string(%d) "Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, int given"
+string(71) "timezone_offset_get() expects parameter 1 to be DateTimeZone, int given"
 
-string(%d) "Argument 1 passed to timezone_offset_get() must be an instance of DateTimeZone, null given"
+string(72) "timezone_offset_get() expects parameter 1 to be DateTimeZone, null given"
 
 
 -- Testing timezone_offset_get() function with an invalid values for $datetime argument --
-string(%d) "Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, instance of stdClass given"
+string(79) "timezone_offset_get() expects parameter 2 to be DateTimeInterface, object given"
 
-string(%d) "Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, int given"
+string(76) "timezone_offset_get() expects parameter 2 to be DateTimeInterface, int given"
 
-string(%d) "Argument 2 passed to timezone_offset_get() must implement interface DateTimeInterface, null given"
+string(77) "timezone_offset_get() expects parameter 2 to be DateTimeInterface, null given"
 
 ===DONE===

--- a/ext/intl/tests/calendar_add_error.phpt
+++ b/ext/intl/tests/calendar_add_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_add(1, 2, 3));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_add() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_add() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_add(1, 2, 3)
 #1 {main}

--- a/ext/intl/tests/calendar_before_after_error.phpt
+++ b/ext/intl/tests/calendar_before_after_error.phpt
@@ -65,9 +65,9 @@ error: 0, IntlCalendar::after() expects exactly 1 parameter, 0 given
 
 error: 0, IntlCalendar::before() expects exactly 1 parameter, 0 given
 
-error: 0, Argument 1 passed to IntlCalendar::after() must be an instance of IntlCalendar, int given
+error: 0, IntlCalendar::after() expects parameter 1 to be IntlCalendar, int given
 
-error: 0, Argument 1 passed to IntlCalendar::before() must be an instance of IntlCalendar, int given
+error: 0, IntlCalendar::before() expects parameter 1 to be IntlCalendar, int given
 
 error: 0, IntlCalendar::after() expects exactly 1 parameter, 2 given
 

--- a/ext/intl/tests/calendar_clear_error.phpt
+++ b/ext/intl/tests/calendar_clear_error.phpt
@@ -23,7 +23,7 @@ bool(false)
 Warning: intlcal_clear(): intlcal_clear: invalid field in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_clear() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_clear() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_clear(1, 2)
 #1 {main}

--- a/ext/intl/tests/calendar_equals_error.phpt
+++ b/ext/intl/tests/calendar_equals_error.phpt
@@ -47,10 +47,10 @@ try {
 --EXPECT--
 error: 0, IntlCalendar::equals() expects exactly 1 parameter, 0 given
 
-error: 0, Argument 1 passed to IntlCalendar::equals() must be an instance of IntlCalendar, instance of stdClass given
+error: 0, IntlCalendar::equals() expects parameter 1 to be IntlCalendar, object given
 
-error: 0, Argument 1 passed to IntlCalendar::equals() must be an instance of IntlCalendar, int given
+error: 0, IntlCalendar::equals() expects exactly 1 parameter, 2 given
 
-error: 0, Argument 2 passed to intlcal_equals() must be an instance of IntlCalendar, array given
+error: 0, intlcal_equals() expects parameter 2 to be IntlCalendar, array given
 
-error: 0, Argument 1 passed to intlcal_equals() must be an instance of IntlCalendar, int given
+error: 0, intlcal_equals() expects parameter 1 to be IntlCalendar, int given

--- a/ext/intl/tests/calendar_fieldDifference_error.phpt
+++ b/ext/intl/tests/calendar_fieldDifference_error.phpt
@@ -32,7 +32,7 @@ Warning: IntlCalendar::fieldDifference(): intlcal_field_difference: Call to ICU 
 bool(false)
 intlcal_field_difference() expects exactly 3 parameters, 4 given
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_field_difference() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_field_difference() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_field_difference(1, 0, 1)
 #1 {main}

--- a/ext/intl/tests/calendar_getDayOfWeekType_error.phpt
+++ b/ext/intl/tests/calendar_getDayOfWeekType_error.phpt
@@ -19,7 +19,7 @@ var_dump(intlcal_get_day_of_week_type(1, 1));
 Warning: IntlCalendar::getDayOfWeekType(): intlcal_get_day_of_week_type: invalid day of week in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_day_of_week_type() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_day_of_week_type() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_day_of_week_type(1, 1)
 #1 {main}

--- a/ext/intl/tests/calendar_getErrorCode_error.phpt
+++ b/ext/intl/tests/calendar_getErrorCode_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_get_error_code(null));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_error_code() must be an instance of IntlCalendar, null given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_error_code() expects parameter 1 to be IntlCalendar, null given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_error_code(NULL)
 #1 {main}

--- a/ext/intl/tests/calendar_getErrorMessage_error.phpt
+++ b/ext/intl/tests/calendar_getErrorMessage_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_get_error_message(null));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_error_message() must be an instance of IntlCalendar, null given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_error_message() expects parameter 1 to be IntlCalendar, null given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_error_message(NULL)
 #1 {main}

--- a/ext/intl/tests/calendar_getFirstDayOfWeek_error.phpt
+++ b/ext/intl/tests/calendar_getFirstDayOfWeek_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_get_first_day_of_week(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_first_day_of_week() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_first_day_of_week() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_first_day_of_week(1)
 #1 {main}

--- a/ext/intl/tests/calendar_getLocale_error.phpt
+++ b/ext/intl/tests/calendar_getLocale_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_get_locale(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_locale() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught ArgumentCountError: intlcal_get_locale() expects exactly 2 parameters, 1 given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_locale(1)
 #1 {main}

--- a/ext/intl/tests/calendar_getMinimalDaysInFirstWeek_error.phpt
+++ b/ext/intl/tests/calendar_getMinimalDaysInFirstWeek_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_get_minimal_days_in_first_week(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_minimal_days_in_first_week() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_minimal_days_in_first_week() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_minimal_days_in_first_week(1)
 #1 {main}

--- a/ext/intl/tests/calendar_getSkipped_RepeatedWallTimeOption_error.phpt
+++ b/ext/intl/tests/calendar_getSkipped_RepeatedWallTimeOption_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_get_skipped_wall_time_option(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_skipped_wall_time_option() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_skipped_wall_time_option() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_skipped_wall_time_option(1)
 #1 {main}

--- a/ext/intl/tests/calendar_getTimeZone_error.phpt
+++ b/ext/intl/tests/calendar_getTimeZone_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_get_time_zone(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_time_zone() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_time_zone() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_time_zone(1)
 #1 {main}

--- a/ext/intl/tests/calendar_getTime_error.phpt
+++ b/ext/intl/tests/calendar_getTime_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_get_time(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_time() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_time() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_time(1)
 #1 {main}

--- a/ext/intl/tests/calendar_getType_error.phpt
+++ b/ext/intl/tests/calendar_getType_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_get_type(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_type() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_type() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_type(1)
 #1 {main}

--- a/ext/intl/tests/calendar_getWeekendTransition_error.phpt
+++ b/ext/intl/tests/calendar_getWeekendTransition_error.phpt
@@ -18,7 +18,7 @@ var_dump(intlcal_get_weekend_transition(1, 1));
 Warning: IntlCalendar::getWeekendTransition(): intlcal_get_weekend_transition: invalid day of week in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_get_weekend_transition() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_get_weekend_transition() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_get_weekend_transition(1, 1)
 #1 {main}

--- a/ext/intl/tests/calendar_get_Least_Greatest_Minimum_Maximum_error.phpt
+++ b/ext/intl/tests/calendar_get_Least_Greatest_Minimum_Maximum_error.phpt
@@ -71,10 +71,10 @@ bool(false)
 
 Warning: intlcal_get_minimum(): intlcal_get_minimum: invalid field in %s on line %d
 bool(false)
-error: 0, Argument 1 passed to intlcal_get_least_maximum() must be an instance of IntlCalendar, int given
+error: 0, intlcal_get_least_maximum() expects parameter 1 to be IntlCalendar, int given
 
-error: 0, Argument 1 passed to intlcal_get_maximum() must be an instance of IntlCalendar, int given
+error: 0, intlcal_get_maximum() expects parameter 1 to be IntlCalendar, int given
 
-error: 0, Argument 1 passed to intlcal_get_greatest_minimum() must be an instance of IntlCalendar, int given
+error: 0, intlcal_get_greatest_minimum() expects parameter 1 to be IntlCalendar, int given
 
-error: 0, Argument 1 passed to intlcal_get_minimum() must be an instance of IntlCalendar, int given
+error: 0, intlcal_get_minimum() expects parameter 1 to be IntlCalendar, int given

--- a/ext/intl/tests/calendar_get_getActualMaximum_Minumum_error2.phpt
+++ b/ext/intl/tests/calendar_get_getActualMaximum_Minumum_error2.phpt
@@ -99,8 +99,8 @@ error: 0, intlcal_get_actual_maximum() expects parameter 2 to be int, string giv
 
 error: 0, intlcal_get_actual_minimum() expects parameter 2 to be int, string given
 
-error: 0, Argument 1 passed to intlcal_get() must be an instance of IntlCalendar, int given
+error: 0, intlcal_get() expects exactly 2 parameters, 1 given
 
-error: 0, Argument 1 passed to intlcal_get_actual_maximum() must be an instance of IntlCalendar, int given
+error: 0, intlcal_get_actual_maximum() expects exactly 2 parameters, 1 given
 
-error: 0, Argument 1 passed to intlcal_get_actual_minimum() must be an instance of IntlCalendar, int given
+error: 0, intlcal_get_actual_minimum() expects exactly 2 parameters, 1 given

--- a/ext/intl/tests/calendar_inDaylightTime_error.phpt
+++ b/ext/intl/tests/calendar_inDaylightTime_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_in_daylight_time(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_in_daylight_time() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_in_daylight_time() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_in_daylight_time(1)
 #1 {main}

--- a/ext/intl/tests/calendar_isEquivalentTo_error.phpt
+++ b/ext/intl/tests/calendar_isEquivalentTo_error.phpt
@@ -49,14 +49,14 @@ try {
 	echo "error: " . $ex->getCode() . ", " . $ex->getMessage() . "\n\n";
 }
 --EXPECT--
-error: 0, Argument 1 passed to IntlCalendar::isEquivalentTo() must be an instance of IntlCalendar, int given
+error: 0, IntlCalendar::isEquivalentTo() expects parameter 1 to be IntlCalendar, int given
 
 error: 0, IntlCalendar::isEquivalentTo() expects exactly 1 parameter, 2 given
 
-error: 0, Argument 1 passed to IntlCalendar::isEquivalentTo() must be an instance of IntlCalendar, int given
+error: 0, IntlCalendar::isEquivalentTo() expects parameter 1 to be IntlCalendar, int given
 
 error: 0, intlcal_is_equivalent_to() expects exactly 2 parameters, 1 given
 
-error: 0, Argument 2 passed to intlcal_is_equivalent_to() must be an instance of IntlCalendar, int given
+error: 0, intlcal_is_equivalent_to() expects parameter 2 to be IntlCalendar, int given
 
-error: 0, Argument 1 passed to intlcal_is_equivalent_to() must be an instance of IntlCalendar, int given
+error: 0, intlcal_is_equivalent_to() expects parameter 1 to be IntlCalendar, int given

--- a/ext/intl/tests/calendar_isLenient_error.phpt
+++ b/ext/intl/tests/calendar_isLenient_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_is_lenient(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_is_lenient() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_is_lenient() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_is_lenient(1)
 #1 {main}

--- a/ext/intl/tests/calendar_isSet_error.phpt
+++ b/ext/intl/tests/calendar_isSet_error.phpt
@@ -19,7 +19,7 @@ var_dump(intlcal_is_set(1, 2));
 Warning: IntlCalendar::isSet(): intlcal_is_set: invalid field in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_is_set() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_is_set() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_is_set(1, 2)
 #1 {main}

--- a/ext/intl/tests/calendar_isWeekend_error.phpt
+++ b/ext/intl/tests/calendar_isWeekend_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_is_weekend(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_is_weekend() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_is_weekend() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_is_weekend(1)
 #1 {main}

--- a/ext/intl/tests/calendar_roll_error.phpt
+++ b/ext/intl/tests/calendar_roll_error.phpt
@@ -19,7 +19,7 @@ var_dump(intlcal_roll(1, 2, 3));
 Warning: IntlCalendar::roll(): intlcal_roll: invalid field in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_roll() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_roll() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_roll(1, 2, 3)
 #1 {main}

--- a/ext/intl/tests/calendar_setFirstDayOfWeek_error.phpt
+++ b/ext/intl/tests/calendar_setFirstDayOfWeek_error.phpt
@@ -23,7 +23,7 @@ bool(false)
 Warning: intlcal_set_first_day_of_week(): intlcal_set_first_day_of_week: invalid day of week in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_set_first_day_of_week() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_set_first_day_of_week() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_set_first_day_of_week(1, 2)
 #1 {main}

--- a/ext/intl/tests/calendar_setLenient_error.phpt
+++ b/ext/intl/tests/calendar_setLenient_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_set_lenient(1, false));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_set_lenient() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_set_lenient() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_set_lenient(1, false)
 #1 {main}

--- a/ext/intl/tests/calendar_setMinimalDaysInFirstWeek_error.phpt
+++ b/ext/intl/tests/calendar_setMinimalDaysInFirstWeek_error.phpt
@@ -23,7 +23,7 @@ bool(false)
 Warning: intlcal_set_minimal_days_in_first_week(): intlcal_set_minimal_days_in_first_week: invalid number of days; must be between 1 and 7 in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_set_minimal_days_in_first_week() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_set_minimal_days_in_first_week() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_set_minimal_days_in_first_week(1, 2)
 #1 {main}

--- a/ext/intl/tests/calendar_setSkipped_RepeatedWallTimeOption_error.phpt
+++ b/ext/intl/tests/calendar_setSkipped_RepeatedWallTimeOption_error.phpt
@@ -23,7 +23,7 @@ bool(false)
 Warning: IntlCalendar::setRepeatedWallTimeOption(): intlcal_set_repeated_wall_time_option: invalid option in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_set_repeated_wall_time_option() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_set_repeated_wall_time_option() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_set_repeated_wall_time_option(1, 1)
 #1 {main}

--- a/ext/intl/tests/calendar_setTimeZone_error.phpt
+++ b/ext/intl/tests/calendar_setTimeZone_error.phpt
@@ -47,4 +47,4 @@ error: 0, IntlCalendar::setTimeZone() expects exactly 1 parameter, 0 given
 
 error: 0, intlcal_set_time_zone() expects exactly 2 parameters, 3 given
 
-error: 0, Argument 1 passed to intlcal_set_time_zone() must be an instance of IntlCalendar, int given
+error: 0, intlcal_set_time_zone() expects parameter 1 to be IntlCalendar, int given

--- a/ext/intl/tests/calendar_setTime_error.phpt
+++ b/ext/intl/tests/calendar_setTime_error.phpt
@@ -12,7 +12,7 @@ ini_set("intl.error_level", E_WARNING);
 
 var_dump(intlcal_set_time(1));
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_set_time() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught ArgumentCountError: intlcal_set_time() expects exactly 2 parameters, 1 given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_set_time(1)
 #1 {main}

--- a/ext/intl/tests/calendar_set_error.phpt
+++ b/ext/intl/tests/calendar_set_error.phpt
@@ -27,7 +27,7 @@ bool(false)
 Warning: intlcal_set(): intlcal_set: invalid field in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_set() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_set() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_set(1, 2, 3)
 #1 {main}

--- a/ext/intl/tests/calendar_toDateTime_error.phpt
+++ b/ext/intl/tests/calendar_toDateTime_error.phpt
@@ -21,7 +21,7 @@ var_dump(intlcal_to_date_time(3));
 Warning: IntlCalendar::toDateTime(): intlcal_to_date_time: DateTimeZone constructor threw exception in %s on line %d
 string(77) "exception: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)"
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intlcal_to_date_time() must be an instance of IntlCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlcal_to_date_time() expects parameter 1 to be IntlCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlcal_to_date_time(3)
 #1 {main}

--- a/ext/intl/tests/gregoriancalendar_getGregorianChange_error.phpt
+++ b/ext/intl/tests/gregoriancalendar_getGregorianChange_error.phpt
@@ -14,7 +14,7 @@ var_dump(intlgregcal_get_gregorian_change(1));
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlgregcal_get_gregorian_change() must be an instance of IntlGregorianCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlgregcal_get_gregorian_change() expects parameter 1 to be IntlGregorianCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlgregcal_get_gregorian_change(1)
 #1 {main}

--- a/ext/intl/tests/gregoriancalendar_isLeapYear_error.phpt
+++ b/ext/intl/tests/gregoriancalendar_isLeapYear_error.phpt
@@ -14,7 +14,7 @@ var_dump(intlgregcal_is_leap_year(1, 2));
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intlgregcal_is_leap_year() must be an instance of IntlGregorianCalendar, int given in %s:%d
+Fatal error: Uncaught TypeError: intlgregcal_is_leap_year() expects parameter 1 to be IntlGregorianCalendar, int given in %s:%d
 Stack trace:
 #0 %s(%d): intlgregcal_is_leap_year(1, 2)
 #1 {main}

--- a/ext/intl/tests/timezone_getDSTSavings_error.phpt
+++ b/ext/intl/tests/timezone_getDSTSavings_error.phpt
@@ -11,7 +11,7 @@ ini_set("intl.error_level", E_WARNING);
 var_dump(intltz_get_dst_savings(null));
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intltz_get_dst_savings() must be an instance of IntlTimeZone, null given in %s:%d
+Fatal error: Uncaught TypeError: intltz_get_dst_savings() expects parameter 1 to be IntlTimeZone, null given in %s:%d
 Stack trace:
 #0 %s(%d): intltz_get_dst_savings(NULL)
 #1 {main}

--- a/ext/intl/tests/timezone_getDisplayName_error.phpt
+++ b/ext/intl/tests/timezone_getDisplayName_error.phpt
@@ -16,7 +16,7 @@ var_dump(intltz_get_display_name(null, IntlTimeZone::DISPLAY_SHORT, false, 'pt_P
 Warning: IntlTimeZone::getDisplayName(): intltz_get_display_name: wrong display type in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intltz_get_display_name() must be an instance of IntlTimeZone, null given in %s:%d
+Fatal error: Uncaught TypeError: intltz_get_display_name() expects parameter 1 to be IntlTimeZone, null given in %s:%d
 Stack trace:
 #0 %s(%d): intltz_get_display_name(NULL, 1, false, 'pt_PT')
 #1 {main}

--- a/ext/intl/tests/timezone_getErrorCode_error.phpt
+++ b/ext/intl/tests/timezone_getErrorCode_error.phpt
@@ -11,7 +11,7 @@ ini_set("intl.error_level", E_WARNING);
 var_dump(intltz_get_error_code(null));
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intltz_get_error_code() must be an instance of IntlTimeZone, null given in %s:%d
+Fatal error: Uncaught TypeError: intltz_get_error_code() expects parameter 1 to be IntlTimeZone, null given in %s:%d
 Stack trace:
 #0 %s(%d): intltz_get_error_code(NULL)
 #1 {main}

--- a/ext/intl/tests/timezone_getErrorMessage_error.phpt
+++ b/ext/intl/tests/timezone_getErrorMessage_error.phpt
@@ -11,7 +11,7 @@ ini_set("intl.error_level", E_WARNING);
 var_dump(intltz_get_error_message(null));
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intltz_get_error_message() must be an instance of IntlTimeZone, null given in %s:%d
+Fatal error: Uncaught TypeError: intltz_get_error_message() expects parameter 1 to be IntlTimeZone, null given in %s:%d
 Stack trace:
 #0 %s(%d): intltz_get_error_message(NULL)
 #1 {main}

--- a/ext/intl/tests/timezone_getID_error.phpt
+++ b/ext/intl/tests/timezone_getID_error.phpt
@@ -11,7 +11,7 @@ ini_set("intl.error_level", E_WARNING);
 intltz_get_id(null);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intltz_get_id() must be an instance of IntlTimeZone, null given in %s:%d
+Fatal error: Uncaught TypeError: intltz_get_id() expects parameter 1 to be IntlTimeZone, null given in %s:%d
 Stack trace:
 #0 %s(%d): intltz_get_id(NULL)
 #1 {main}

--- a/ext/intl/tests/timezone_getOffset_error.phpt
+++ b/ext/intl/tests/timezone_getOffset_error.phpt
@@ -17,7 +17,7 @@ intltz_get_offset(null, time()*1000, false, $a, $a);
 Warning: IntlTimeZone::getOffset(): intltz_get_offset: error obtaining offset in %s on line %d
 bool(false)
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intltz_get_offset() must be an instance of IntlTimeZone, null given in %s:%d
+Fatal error: Uncaught TypeError: intltz_get_offset() expects parameter 1 to be IntlTimeZone, null given in %s:%d
 Stack trace:
 #0 %s(%d): intltz_get_offset(NULL, %d, false, NULL, NULL)
 #1 {main}

--- a/ext/intl/tests/timezone_getRawOffset_error.phpt
+++ b/ext/intl/tests/timezone_getRawOffset_error.phpt
@@ -11,7 +11,7 @@ ini_set("intl.error_level", E_WARNING);
 intltz_get_raw_offset(null);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intltz_get_raw_offset() must be an instance of IntlTimeZone, null given in %s:%d
+Fatal error: Uncaught TypeError: intltz_get_raw_offset() expects parameter 1 to be IntlTimeZone, null given in %s:%d
 Stack trace:
 #0 %s(%d): intltz_get_raw_offset(NULL)
 #1 {main}

--- a/ext/intl/tests/timezone_hasSameRules_error.phpt
+++ b/ext/intl/tests/timezone_hasSameRules_error.phpt
@@ -31,7 +31,7 @@ try {
 }
 --EXPECT--
 int(0)
-string(99) "Argument 1 passed to IntlTimeZone::hasSameRules() must be an instance of IntlTimeZone, string given"
+string(81) "IntlTimeZone::hasSameRules() expects parameter 1 to be IntlTimeZone, string given"
 
 int(0)
-string(92) "Argument 1 passed to intltz_has_same_rules() must be an instance of IntlTimeZone, null given"
+string(74) "intltz_has_same_rules() expects parameter 1 to be IntlTimeZone, null given"

--- a/ext/intl/tests/timezone_toDateTimeZone_error.phpt
+++ b/ext/intl/tests/timezone_toDateTimeZone_error.phpt
@@ -21,7 +21,7 @@ var_dump(intltz_to_date_time_zone(1));
 Warning: IntlTimeZone::toDateTimeZone(): intltz_to_date_time_zone: DateTimeZone constructor threw exception in %s on line %d
 string(66) "DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)"
 
-Fatal error: Uncaught TypeError: Argument 1 passed to intltz_to_date_time_zone() must be an instance of IntlTimeZone, int given in %s:%d
+Fatal error: Uncaught TypeError: intltz_to_date_time_zone() expects parameter 1 to be IntlTimeZone, int given in %s:%d
 Stack trace:
 #0 %s(%d): intltz_to_date_time_zone(1)
 #1 {main}

--- a/ext/intl/tests/timezone_useDaylightTime_error.phpt
+++ b/ext/intl/tests/timezone_useDaylightTime_error.phpt
@@ -11,7 +11,7 @@ ini_set("intl.error_level", E_WARNING);
 intltz_use_daylight_time(null);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to intltz_use_daylight_time() must be an instance of IntlTimeZone, null given in %s:%d
+Fatal error: Uncaught TypeError: intltz_use_daylight_time() expects parameter 1 to be IntlTimeZone, null given in %s:%d
 Stack trace:
 #0 %s(%d): intltz_use_daylight_time(NULL)
 #1 {main}

--- a/ext/intl/tests/transliterator_create_inverse_error.phpt
+++ b/ext/intl/tests/transliterator_create_inverse_error.phpt
@@ -10,7 +10,7 @@ ini_set("intl.error_level", E_WARNING);
 transliterator_create_inverse("jj");
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to transliterator_create_inverse() must be an instance of Transliterator, string given in %s:%d
+Fatal error: Uncaught TypeError: transliterator_create_inverse() expects parameter 1 to be Transliterator, string given in %s:%d
 Stack trace:
 #0 %s(%d): transliterator_create_inverse('jj')
 #1 {main}

--- a/ext/intl/tests/transliterator_get_error_code_error.phpt
+++ b/ext/intl/tests/transliterator_get_error_code_error.phpt
@@ -8,7 +8,7 @@ ini_set("intl.error_level", E_WARNING);
 echo transliterator_get_error_code(array()), "\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to transliterator_get_error_code() must be an instance of Transliterator, array given in %s:%d
+Fatal error: Uncaught TypeError: transliterator_get_error_code() expects parameter 1 to be Transliterator, array given in %s:%d
 Stack trace:
 #0 %s(%d): transliterator_get_error_code(Array)
 #1 {main}

--- a/ext/intl/tests/transliterator_get_error_message_error.phpt
+++ b/ext/intl/tests/transliterator_get_error_message_error.phpt
@@ -8,7 +8,7 @@ ini_set("intl.error_level", E_WARNING);
 echo transliterator_get_error_message(array()), "\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to transliterator_get_error_message() must be an instance of Transliterator, array given in %s:%d
+Fatal error: Uncaught TypeError: transliterator_get_error_message() expects parameter 1 to be Transliterator, array given in %s:%d
 Stack trace:
 #0 %s(%d): transliterator_get_error_message(Array)
 #1 {main}

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -1198,7 +1198,7 @@ void php_mysqli_fetch_into_hash(INTERNAL_FUNCTION_PARAMETERS, int override_flags
 	if (into_object) {
 		zend_string *class_name = NULL;
 
-		if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|Sz", &mysql_result, mysqli_result_class_entry, &class_name, &ctor_params) == FAILURE) {
+		if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|Sa", &mysql_result, mysqli_result_class_entry, &class_name, &ctor_params) == FAILURE) {
 			return;
 		}
 		if (class_name == NULL) {

--- a/ext/mysqli/tests/mysqli_fetch_object.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object.phpt
@@ -142,6 +142,6 @@ NULL
 NULL
 [E_WARNING] mysqli_fetch_object(): Couldn't fetch mysqli_result in %s on line %d
 bool(false)
-[0] Argument 3 passed to mysqli_fetch_object() must be of the type array, string given in %s on line %d
+[0] mysqli_fetch_object() expects parameter 3 to be array, string given in %s on line %d
 
 Fatal error: Class 'this_class_does_not_exist' not found in %s on line %d

--- a/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
@@ -123,12 +123,12 @@ require_once('skipifconnectfailure.inc');
 	require_once("clean_table.inc");
 ?>
 --EXPECTF--
-[E_WARNING] mysqli_result::__construct(): invalid object or resource mysql%s
-%s on line %d
+[E_WARNING] mysqli_result::__construct(): invalid object or resource mysqli
+ in %s on line %d
 [E_WARNING] mysqli_result::fetch_object(): Couldn't fetch mysqli_result in %s on line %d
-[0] Argument 2 passed to mysqli_result::fetch_object() must be of the type array, object given in %s on line %d
-[0] Argument 2 passed to mysqli_result::fetch_object() must be of the type array, object given in %s on line %d
-[0] Argument 2 passed to mysqli_result::fetch_object() must be of the type array, null given in %s on line %d
+[0] mysqli_result::fetch_object() expects parameter 1 to be string, object given in %s on line %d
+[0] mysqli_result::fetch_object() expects at most 2 parameters, 3 given in %s on line %d
+[0] mysqli_result::fetch_object() expects parameter 2 to be array, null given in %s on line %d
 Exception: Too few arguments to function mysqli_fetch_object_construct::__construct(), 1 passed and exactly 2 expected
 NULL
 NULL

--- a/ext/opcache/jit/zend_jit_disasm_x86.c
+++ b/ext/opcache/jit/zend_jit_disasm_x86.c
@@ -433,7 +433,6 @@ static int zend_jit_disasm_init(void)
 	REGISTER_HELPER(zend_jit_vm_stack_free_args_helper);
 	REGISTER_HELPER(zend_jit_copy_extra_args_helper);
 	REGISTER_HELPER(zend_jit_deprecated_or_abstract_helper);
-	REGISTER_HELPER(zend_jit_verify_internal_arg_types_helper);
 	REGISTER_HELPER(zend_jit_assign_const_to_typed_ref);
 	REGISTER_HELPER(zend_jit_assign_tmp_to_typed_ref);
 	REGISTER_HELPER(zend_jit_assign_var_to_typed_ref);

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -1489,25 +1489,6 @@ static void ZEND_FASTCALL zend_jit_vm_stack_free_args_helper(zend_execute_data *
 	zend_vm_stack_free_args(call);
 }
 
-static int ZEND_FASTCALL zend_jit_verify_internal_arg_types_helper(zend_execute_data *call)
-{
-	zend_function *fbc = call->func;
-	uint32_t i;
-	uint32_t num_args = ZEND_CALL_NUM_ARGS(call);
-	zval *p = ZEND_CALL_ARG(call, 1);
-
-	for (i = 0; i < num_args; ++i) {
-		zend_check_internal_arg_type(fbc, i + 1, p);
-		if (UNEXPECTED(EG(exception))) {
-			EG(current_execute_data) = call->prev_execute_data;
-			zend_vm_stack_free_args(call);
-			return 0;
-		}
-		p++;
-	}
-	return 1;
-}
-
 static zend_always_inline void zend_jit_assign_to_typed_ref(zend_reference *ref, zval *value, zend_uchar value_type)
 {
 	zval variable;

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -7680,26 +7680,6 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, zend_op_ar
 		|	// EG(current_execute_data) = execute_data;
 		|	MEM_OP2_1_ZTS mov, aword, executor_globals, current_execute_data, RX, r1
 
-		if (!func || (func->common.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
-			if (!func) {
-				|	test dword [r0 + offsetof(zend_op_array, fn_flags)], ZEND_ACC_HAS_TYPE_HINTS
-				|	jnz >1
-				|.cold_code
-			}
-			|1:
-			|	mov FCARG1a, RX
-			|	EXT_CALL zend_jit_verify_internal_arg_types_helper, r0
-			|	test r0, r0
-			|	je >8
-			|	LOAD_ZVAL_ADDR FCARG2a, res_addr // reload
-			if (!func) {
-				|	mov r0, EX:RX->func // reload
-				|	jmp >1
-				|.code
-			}
-			|1:
-		}
-
 		zend_jit_reset_opline(Dst, NULL);
 
 		|	// fbc->internal_function.handler(call, ret);

--- a/ext/reflection/tests/ReflectionClass_newInstanceArgs_002.phpt
+++ b/ext/reflection/tests/ReflectionClass_newInstanceArgs_002.phpt
@@ -16,8 +16,8 @@ var_dump($a);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to ReflectionClass::newInstanceArgs() must be of the type array, string given in %s:8
+Fatal error: Uncaught TypeError: ReflectionClass::newInstanceArgs() expects parameter 1 to be array, string given in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->newInstanceArgs('x')
 #1 {main}
-  thrown in %s on line 8
+  thrown in %s on line %d

--- a/ext/reflection/tests/ReflectionMethod_invokeArgs_error2.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invokeArgs_error2.phpt
@@ -24,4 +24,4 @@ try {
 
 ?>
 --EXPECT--
-string(89) "Argument 2 passed to ReflectionMethod::invokeArgs() must be of the type array, bool given"
+string(74) "ReflectionMethod::invokeArgs() expects parameter 2 to be array, bool given"

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -3293,7 +3293,7 @@ SPL_METHOD(AppendIterator, append)
 
 	SPL_FETCH_AND_CHECK_DUAL_IT(intern, ZEND_THIS);
 
-	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "O", &it, zend_ce_iterator) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &it, zend_ce_iterator) == FAILURE) {
 		return;
 	}
 	if (intern->u.append.iterator->funcs->valid(intern->u.append.iterator) == SUCCESS && spl_dual_it_valid(intern) != SUCCESS) {

--- a/ext/spl/tests/CallbackFilterIteratorTest-002.phpt
+++ b/ext/spl/tests/CallbackFilterIteratorTest-002.phpt
@@ -42,7 +42,7 @@ try {
 }
 --EXPECT--
 CallbackFilterIterator::__construct() expects exactly 2 parameters, 0 given
-Argument 1 passed to CallbackFilterIterator::__construct() must implement interface Iterator, null given
+CallbackFilterIterator::__construct() expects exactly 2 parameters, 1 given
 CallbackFilterIterator::__construct() expects parameter 2 to be a valid callback, no array or string given
 CallbackFilterIterator::__construct() expects parameter 2 to be a valid callback, array must have exactly two members
 some message

--- a/ext/spl/tests/iterator_042.phpt
+++ b/ext/spl/tests/iterator_042.phpt
@@ -41,7 +41,7 @@ foreach($it as $k => $v)
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-Error Argument 1 passed to AppendIterator::append() must implement interface Iterator, array given in %siterator_042.php on line %d
+Error AppendIterator::append() expects parameter 1 to be Iterator, array given in %s on line %d
 object(ArrayIterator)#%d (1) {
   %s"storage"%s"ArrayIterator":private]=>
   array(2) {

--- a/ext/spl/tests/iterator_count.phpt
+++ b/ext/spl/tests/iterator_count.phpt
@@ -13,7 +13,7 @@ iterator_count('1');
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to iterator_count() must implement interface Traversable, string given in %s:%d
+Fatal error: Uncaught TypeError: iterator_count() expects parameter 1 to be Traversable, string given in %s:%d
 Stack trace:
 #0 %s(%d): iterator_count('1')
 #1 {main}

--- a/ext/spl/tests/iterator_to_array.phpt
+++ b/ext/spl/tests/iterator_to_array.phpt
@@ -13,7 +13,7 @@ iterator_to_array('test','test');
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to iterator_to_array() must implement interface Traversable, string given in %s:%d
+Fatal error: Uncaught TypeError: iterator_to_array() expects parameter 1 to be Traversable, string given in %s:%d
 Stack trace:
 #0 %s(%d): iterator_to_array('test', 'test')
 #1 {main}

--- a/ext/spl/tests/spl_004.phpt
+++ b/ext/spl/tests/spl_004.phpt
@@ -86,7 +86,7 @@ int(5)
 int(6)
 int(4)
 ===ERRORS===
-Argument 3 passed to iterator_apply() must be of the type array or null, int given
+iterator_apply() expects parameter 3 to be array, int given
 iterator_apply() expects parameter 2 to be a valid callback, function 'non_existing_function' not found or invalid function name
 iterator_apply() expects at most 3 parameters, 4 given
 ===DONE===


### PR DESCRIPTION
This patch disables checking of arginfo types on internal function calls. Types will only be checked by zpp now. This will allow us to add arginfo information to internal functions without introducing a significant performance hit by performing duplicate type checks.

In debug builds, we make sure that either the function threw or the arginfo verification succeeds. This will help to detect cases where types specified in arginfo are out of sync with what is specified in zpp. This sanity check currently allows null for scalar typed arguments -- we can forbid them if/when we do so in zpp as well (relevant discussion: https://externals.io/message/105845).

This patch also fixes two existing places with an arginfo/zpp mismatch.

Test differences are due to different error messages for arginfo and zpp. We might want to unify these as well, but let's do that separately.