### PR TITLE
Fix a typo in opcache func info for "get_parrent_class"

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -234,7 +234,7 @@ static const func_info_t func_infos[] = {
 	FC("defined",                 zend_b_s_info), // TODO: inline
 	FN("get_class",               MAY_BE_FALSE | MAY_BE_STRING),
 	FN("get_called_class",        MAY_BE_FALSE | MAY_BE_STRING),
-	FN("get_parrent_class",       MAY_BE_FALSE | MAY_BE_STRING),
+	FN("get_parent_class",        MAY_BE_FALSE | MAY_BE_STRING | MAY_BE_NULL),
 	F0("is_subclass_of",          MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE), // TODO: inline
 	F0("is_a",                    MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE), // TODO: inline
 	F1("get_class_vars",          MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_ANY | MAY_BE_ARRAY_OF_REF),


### PR DESCRIPTION
This should only have one r.
http://php.net/get_parent_class mentions that it returns string|false

Also, I'm not 100% sure if this is right - should this include
MAY_BE_NULL to handle the case of too many parameters?
(then again, get_called_class() also returns null with too many parameters)

```
php > var_export(get_parent_class(2,3));
Warning: get_parent_class() expects at most 1 parameter, 2 given in php
shell code on line 1
NULL
```