### PR TITLE
Fix bug in opcache flags for mysqli_get_charset and mysqli_stat

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -942,7 +942,7 @@ static const func_info_t func_infos[] = {
 	F1("mysqli_query",							MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE | MAY_BE_OBJECT),
 	F0("mysqli_multi_query",					MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F0("mysqli_set_charset",					MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
-	F1("mysqli_get_charset", 					MAY_BE_NULL | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_ANY),
+	F1("mysqli_get_charset", 					MAY_BE_NULL | MAY_BE_OBJECT),
 	F0("mysqli_begin_transaction",				MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F0("mysqli_savepoint",						MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F0("mysqli_release_savepoint",				MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),

--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -1015,7 +1015,7 @@ static const func_info_t func_infos[] = {
 	F0("mysqli_select_db",						MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F1("mysqli_sqlstate",						MAY_BE_NULL | MAY_BE_STRING),
 	F0("mysqli_ssl_set",						MAY_BE_NULL | MAY_BE_TRUE),
-	F1("mysqli_stat",							MAY_BE_NULL | MAY_BE_STRING),
+	F1("mysqli_stat",							MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_STRING),
 	F0("mysqli_refresh",						MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F0("mysqli_stmt_attr_set",					MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F0("mysqli_stmt_attr_get",					MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_LONG),


### PR DESCRIPTION
https://www.php.net/manual/en/mysqli.get-charset.php documents that this returns an object.
tests/mysqli_field_seek.phpt has a test of this returning an object.

Looking at the source in ext/mysqli/mysqli_nonapi.c,
this should be object|null (and nothing else), not array|null

The old flags might actually cause bugs in opcache's inferences,
(no proof of this)
so it might make sense to pull this patch into an earlier minor version.