### PR TITLE
Fix php 8.0's opcache flags for pathinfo()

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -194,7 +194,7 @@ static const func_info_t func_infos[] = {
 	FN("nl2br",                        MAY_BE_STRING),
 	F1("basename",                     MAY_BE_STRING),
 	F1("dirname",                      MAY_BE_NULL | MAY_BE_STRING),
-	F1("pathinfo",                     MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
+	F1("pathinfo",                     MAY_BE_STRING | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
 	F1("stripslashes",                 MAY_BE_STRING),
 	F1("stripcslashes",                MAY_BE_STRING),
 	F1("strstr",                       MAY_BE_FALSE | MAY_BE_STRING),

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1666,7 +1666,7 @@ PHP_FUNCTION(dirname)
 }
 /* }}} */
 
-/* {{{ proto array pathinfo(string path[, int options])
+/* {{{ proto array|string pathinfo(string path[, int options])
    Returns information about a certain string */
 PHP_FUNCTION(pathinfo)
 {


### PR DESCRIPTION
See https://php.net/pathinfo

This fixes a bug introduced in the cleanup for commit
0d79c70cf3c10f60a2e8fbfd68903d8716b7b43c (other bugs were already identified)

`pathinfo($str, PATHINFO_EXTENSION)` will always return a string
(if there is no extension, the function returns the empty string)