### PR TITLE
Remove unnecessary short_open_tag INI directive in tests

### DIFF
--- a/ext/standard/tests/strings/strip_tags_basic1.phpt
+++ b/ext/standard/tests/strings/strip_tags_basic1.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : basic functionality - with default arguments
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/standard/tests/strings/strip_tags_basic2.phpt
+++ b/ext/standard/tests/strings/strip_tags_basic2.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : basic functionality - with all arguments
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/standard/tests/strings/strip_tags_variation10.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation10.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - single quoted strings
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/standard/tests/strings/strip_tags_variation11.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation11.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : obscure values within attributes
---INI--
-short_open_tag = on
 --FILE--
 <?php
 

--- a/ext/standard/tests/strings/strip_tags_variation2.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation2.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - unexpected values for 'allowable_tags'
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/standard/tests/strings/strip_tags_variation4.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation4.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - invalid values for 'str' and valid 'allowable_tags'
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/standard/tests/strings/strip_tags_variation5.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation5.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - heredoc strings
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/standard/tests/strings/strip_tags_variation6.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation6.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - binary safe checking
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/standard/tests/strings/strip_tags_variation7.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation7.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - invalid values for 'str' and 'allowable_tags'
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/standard/tests/strings/strip_tags_variation8.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation8.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - valid value for 'str' and invalid values for 'allowable_tags'
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/standard/tests/strings/strip_tags_variation9.phpt
+++ b/ext/standard/tests/strings/strip_tags_variation9.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test strip_tags() function : usage variations - double quoted strings
---INI--
-short_open_tag = on
 --FILE--
 <?php
 /* Prototype  : string strip_tags(string $str [, string $allowable_tags])

--- a/ext/tokenizer/tests/token_get_all_variation15.phpt
+++ b/ext/tokenizer/tests/token_get_all_variation15.phpt
@@ -2,8 +2,6 @@
 Test token_get_all() function : usage variations - heredoc string for 'source'
 --SKIPIF--
 <?php if (!extension_loaded("tokenizer")) print "skip"; ?>
---INI--
-short_open_tag=On
 --FILE--
 <?php
 /* Prototype  : array token_get_all(string $source)


### PR DESCRIPTION
Making a separate PR for these tests to simplify the PR for a new short_open_tag deprecation implementation.