### PR TITLE
less complicated pm.start_servers calculation

### DIFF
--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -114,7 +114,7 @@ pm.max_children = 5
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
-; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+; Default Value: (max_spare_servers - min_spare_servers) / 2 + min_spare_servers
 pm.start_servers = 2
 
 ; The desired minimum number of idle server processes.

--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -114,7 +114,7 @@ pm.max_children = 5
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
-; Default Value: (max_spare_servers - min_spare_servers) / 2 + min_spare_servers
+; Default Value: (max_spare_servers + min_spare_servers) / 2
 pm.start_servers = 2
 
 ; The desired minimum number of idle server processes.


### PR DESCRIPTION
For people having trouble with applying order of operations (PEMDAS), this would avoid miscalculations and breaking the config by accident.