### PR TITLE
Throw TypeError instead of warning in case of invalid path

### DIFF
--- a/ext/gd/gd_ctx.c
+++ b/ext/gd/gd_ctx.c
@@ -17,6 +17,7 @@
  */
 
 #include "php_gd.h"
+#include "Zend/zend_exceptions.h"
 
 #define CTX_PUTC(c,ctx) ctx->putC(ctx, c)
 
@@ -139,8 +140,8 @@ static void _php_image_output_ctx(INTERNAL_FUNCTION_PARAMETERS, int image_type, 
 			close_stream = 0;
 		} else if (Z_TYPE_P(to_zval) == IS_STRING) {
 			if (CHECK_ZVAL_NULL_PATH(to_zval)) {
-				php_error_docref(NULL, E_WARNING, "Invalid 2nd parameter, filename must not contain null bytes");
-				RETURN_FALSE;
+				zend_throw_exception(zend_ce_type_error, "Invalid 2nd parameter, filename must not contain null bytes", 0);
+				return;
 			}
 
 			stream = php_stream_open_wrapper(Z_STRVAL_P(to_zval), "wb", REPORT_ERRORS|IGNORE_PATH|IGNORE_URL_WIN, NULL);

--- a/ext/gd/gd_ctx.c
+++ b/ext/gd/gd_ctx.c
@@ -17,7 +17,6 @@
  */
 
 #include "php_gd.h"
-#include "Zend/zend_exceptions.h"
 
 #define CTX_PUTC(c,ctx) ctx->putC(ctx, c)
 
@@ -140,7 +139,7 @@ static void _php_image_output_ctx(INTERNAL_FUNCTION_PARAMETERS, int image_type, 
 			close_stream = 0;
 		} else if (Z_TYPE_P(to_zval) == IS_STRING) {
 			if (CHECK_ZVAL_NULL_PATH(to_zval)) {
-				zend_throw_exception(zend_ce_type_error, "Invalid 2nd parameter, filename must not contain null bytes", 0);
+				zend_type_error("Invalid 2nd parameter, filename must not contain null bytes");
 				return;
 			}
 

--- a/ext/gd/tests/imagebmp_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagebmp_nullbyte_injection.phpt
@@ -8,10 +8,11 @@ if (!gd_info()['BMP Support']) die('skip BMP support not available');
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-var_dump(imagebmp($image, "./foo\0bar"));
+try {
+    imagebmp($image, "./foo\0bar");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
-===DONE===
---EXPECTF--
-Warning: imagebmp(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
-===DONE===
+--EXPECT--
+Invalid 2nd parameter, filename must not contain null bytes

--- a/ext/gd/tests/imagegif_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagegif_nullbyte_injection.phpt
@@ -7,8 +7,11 @@ if(!extension_loaded('gd')){ die('skip gd extension not available'); }
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-var_dump(imagegif($image, "./foo\0bar"));
+try {
+    imagegif($image, "./foo\0bar");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
---EXPECTF--
-Warning: imagegif(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
+--EXPECT--
+Invalid 2nd parameter, filename must not contain null bytes

--- a/ext/gd/tests/imagejpeg_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagejpeg_nullbyte_injection.phpt
@@ -11,8 +11,11 @@ if (!isset($support['JPEG Support']) || $support['JPEG Support'] === false) {
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-var_dump(imagejpeg($image, "./foo\0bar"));
+try {
+    imagejpeg($image, "./foo\0bar");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
---EXPECTF--
-Warning: imagejpeg(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
+--EXPECT--
+Invalid 2nd parameter, filename must not contain null bytes

--- a/ext/gd/tests/imagepng_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagepng_nullbyte_injection.phpt
@@ -11,8 +11,11 @@ if (!isset($support['PNG Support']) || $support['PNG Support'] === false) {
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-var_dump(imagepng($image, "./foo\0bar"));
+try {
+    imagepng($image, "./foo\0bar");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECTF--
-Warning: imagepng(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
+Invalid 2nd parameter, filename must not contain null bytes

--- a/ext/gd/tests/imagewbmp_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagewbmp_nullbyte_injection.phpt
@@ -11,8 +11,11 @@ if (!isset($support['WBMP Support']) || $support['WBMP Support'] === false) {
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-var_dump(imagewbmp($image, "./foo\0bar"));
+try {
+    imagewbmp($image, "./foo\0bar");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
---EXPECTF--
-Warning: imagewbmp(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
+--EXPECT--
+Invalid 2nd parameter, filename must not contain null bytes

--- a/ext/gd/tests/imagewebp_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagewebp_nullbyte_injection.phpt
@@ -11,8 +11,11 @@ if (!isset($support['WebP Support']) || $support['WebP Support'] === false) {
 --FILE--
 <?php
 $image = imagecreate(1,1);// 1px image
-var_dump(imagewebp($image, "./foo\0bar"));
+try {
+    imagewebp($image, "./foo\0bar");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
---EXPECTF--
-Warning: imagewebp(): Invalid 2nd parameter, filename must not contain null bytes in %s on line %d
-bool(false)
+--EXPECT--
+Invalid 2nd parameter, filename must not contain null bytes


### PR DESCRIPTION
For consistency with imagegd(), imagegd2() and imagexbm(), which throw
a TypeError if a path containing NUL bytes is given, we throw a
TypeError for the other image writer functions as well.