### PR TITLE
Add configuration value (raw) to syslog.filter

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -344,6 +344,10 @@ static PHP_INI_MH(OnSetLogFilter)
 		PG(syslog_filter) = PHP_SYSLOG_FILTER_ASCII;
 		return SUCCESS;
 	}
+	if (!strcmp(filter, "raw")) {
+		PG(syslog_filter) = PHP_SYSLOG_FILTER_RAW;
+		return SUCCESS;
+	}
 
 	return FAILURE;
 }

--- a/main/php_syslog.c
+++ b/main/php_syslog.c
@@ -76,6 +76,13 @@ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
 	smart_string_0(&fbuf);
 	va_end(args);
 
+	if (PG(syslog_filter) == PHP_SYSLOG_FILTER_RAW) {
+		/* Just send it directly to the syslog */
+		syslog(priority, "%.*s", (int)fbuf.len, fbuf.c);
+		smart_string_free(&fbuf);
+		return;
+	}
+
 	for (ptr = fbuf.c; ; ++ptr) {
 		c = *ptr;
 		if (c == '\0') {

--- a/main/php_syslog.h
+++ b/main/php_syslog.h
@@ -34,6 +34,7 @@
 #define PHP_SYSLOG_FILTER_ALL		0
 #define PHP_SYSLOG_FILTER_NO_CTRL	1
 #define PHP_SYSLOG_FILTER_ASCII		2
+#define PHP_SYSLOG_FILTER_RAW		3
 
 BEGIN_EXTERN_C()
 PHPAPI void php_syslog(int, const char *format, ...);


### PR DESCRIPTION
Background:
In newer versions of PHP the syslog logging is forced to multiline logging and it's not possible to turn this off. This is especially problematic when you have a lot of logging and need to search and find connected lines from a single call to syslog(). For example when debugging multiline sql-queries.

Test code:
syslog(LOG_INFO, "test1\t\ttest2\ntest3");

Old behaviour (PHP 5.4.16 (cli) - CentOS 7):
Jun 15 08:55:45 server php: test1#011#011test2#012test3

New behaviour (PHP 7.4 (dev)- CentOS 7):
Jun 15 08:55:45 server php: test1\x09\x09test2
Jun 15 08:55:45 server php: test3

After patch and with configuration value (syslog.filter=raw):
Jun 15 08:55:45 server php: test1#011#011test2#012test3

Suggested patch:
This patch includes a new configuration value for syslog.filter (raw) which allows to send the logging data in it's raw form to the syslog. The code for the other configuration values should be untouched by this change.