### PR TITLE
Add println function

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -758,6 +758,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_print_r, 0, 0, 1)
 	ZEND_ARG_INFO(0, return)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_println, 0, 0, 1)
+	ZEND_ARG_INFO(0, message)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_connection_aborted, 0)
 ZEND_END_ARG_INFO()
 
@@ -3027,6 +3031,7 @@ static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(var_export,														arginfo_var_export)
 	PHP_FE(debug_zval_dump,													arginfo_debug_zval_dump)
 	PHP_FE(print_r,															arginfo_print_r)
+	PHP_FE(println,															arginfo_println)
 	PHP_FE(memory_get_usage,												arginfo_memory_get_usage)
 	PHP_FE(memory_get_peak_usage,											arginfo_memory_get_peak_usage)
 
@@ -5652,6 +5657,20 @@ PHP_FUNCTION(print_r)
 		zend_print_zval_r(var, 0);
 		RETURN_TRUE;
 	}
+}
+/* }}} */
+
+/* {{{ proto void println(string message) */
+PHP_FUNCTION(println)
+{
+	zend_string *message;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(message)
+	ZEND_PARSE_PARAMETERS_END();
+
+	PHPWRITE(ZSTR_VAL(message), ZSTR_LEN(message));
+	PHPWRITE(PHP_EOL, sizeof(PHP_EOL) - 1);
 }
 /* }}} */
 

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -101,6 +101,7 @@ PHP_FUNCTION(set_include_path);
 PHP_FUNCTION(restore_include_path);
 
 PHP_FUNCTION(print_r);
+PHP_FUNCTION(println);
 PHP_FUNCTION(fprintf);
 PHP_FUNCTION(vfprintf);
 

--- a/ext/standard/tests/strings/println.phpt
+++ b/ext/standard/tests/strings/println.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Test println() function : basic functionality
+--FILE--
+<?php
+
+/* Prototype  : void println ( string $arg )
+ * Description: Output a string
+ * Source code: ext/standard/basic_functions.c
+*/
+
+echo "*** Testing println() : basic functionality ***\n";
+
+echo "-- Iteration 1 --\n";
+println("Hello World");
+
+echo "-- Iteration 2 --\n";
+println("This spans
+multiple lines. The newlines will be
+output as well");
+
+echo "-- Iteration 3 --\n";
+println("escaping characters is done \"Like this\".");
+
+// You can use variables inside of a println statement
+$foo = "foobar";
+$bar = "barbaz";
+
+echo "-- Iteration 4 --\n";
+println("foo is $foo"); // foo is foobar
+
+// You can also use arrays
+$bar = array("value" => "foo");
+
+echo "-- Iteration 5 --\n";
+println("this is {$bar['value']} !"); // this is foo !
+
+// Using single quotes will output the variable name, not the value
+echo "-- Iteration 6 --\n";
+println('foo is $foo'); // foo is $foo
+
+// If you are not using any other characters, you can just output variables
+echo "-- Iteration 7 --\n";
+println($foo); // foobar
+
+echo "-- Iteration 8 --\n";
+$variable = "VARIABLE";
+println(<<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon no extra whitespace!
+END
+);
+?>
+===DONE===
+--EXPECT--
+*** Testing println() : basic functionality ***
+-- Iteration 1 --
+Hello World
+-- Iteration 2 --
+This spans
+multiple lines. The newlines will be
+output as well
+-- Iteration 3 --
+escaping characters is done "Like this".
+-- Iteration 4 --
+foo is foobar
+-- Iteration 5 --
+this is foo !
+-- Iteration 6 --
+foo is $foo
+-- Iteration 7 --
+foobar
+-- Iteration 8 --
+This uses the "here document" syntax to output
+multiple lines with VARIABLE interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon no extra whitespace!
+===DONE===


### PR DESCRIPTION
with PHP, several methods are available to produce output:

    echo "hello world\n";
    print "hello world\n";
    print_r("hello world\n");
    var_export("hello world\n");

However all these methods have something in common: they do not produce their
own newline. With each method, the user is required to provide a newline with
"\n", PHP_EOL or similar. This is bothersome because many other programming
languages offer such a method. For example Python:

    print('hello world')

Perl:

    use feature say;
    say 'hello world';

Ruby:

    puts 'hello world'

Lua:

    print 'hello world'

Even C:

    #include <stdio.h>
    int main() {
       puts("hello world");
    }

To resolve, implement PHP "println" function.