### PR TITLE
Change ReflectionMethod object construction to support get_method-based methods

### DIFF
--- a/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_003.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_003.phpt
@@ -1,0 +1,37 @@
+--TEST--
+PDO_sqlite: Testing sqliteCreateFunction() with reflection
+--SKIPIF--
+<?php if (!extension_loaded('pdo_sqlite')) print 'skip not loaded'; ?>
+--FILE--
+<?php
+
+$db = new pdo('sqlite::memory:');
+
+$db->query('CREATE TABLE IF NOT EXISTS foobar (id INT AUTO INCREMENT, name TEXT)');
+
+$db->query('INSERT INTO foobar VALUES (NULL, "PHP")');
+$db->query('INSERT INTO foobar VALUES (NULL, "PHP6")');
+
+$method = new ReflectionMethod($db, 'sqliteCreateFunction');
+$method->invoke($db, 'testing', function($v) { return strtolower($v); }, 1);
+
+foreach ($db->query('SELECT testing(name) FROM foobar') as $row) {
+	var_dump($row);
+}
+
+$db->query('DROP TABLE foobar');
+
+?>
+--EXPECTF--
+array(2) {
+  ["testing(name)"]=>
+  string(3) "php"
+  [0]=>
+  string(3) "php"
+}
+array(2) {
+  ["testing(name)"]=>
+  string(4) "php6"
+  [0]=>
+  string(4) "php6"
+}


### PR DESCRIPTION
Support constructing a `ReflectionMethod` from an object that has a `get_method` object handler that can be used to reflect methods that aren't in the class entry, such as PDO driver-specific methods.

Some downsides are that `ReflectionClass::getMethods()` used with a `PDO` object of a specific driver type still won't list the driver-specific methods. I'm also not sure this can be supported on `ReflectionClass::getMethod()`.

This is just an experiment for trying to solve issues like reported in [bug 78126](https://bugs.php.net/bug.php?id=78126).
Not using `get_method` to add driver specific methods (add them to the PDO class entry directly?) would be another way to solve the issue, but that's obviously a much larger change and has side effects.