### PR TITLE
Time sleep until bug

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4662,14 +4662,16 @@ PHP_FUNCTION(time_sleep_until)
 	/* 1sec = 1000000000 nanoseconds */
 	php_req.tv_nsec = (long) ((c_ts - php_req.tv_sec) * 1000000000.00);
 
-	while (nanosleep(&php_req, &php_rem)) {
-		if (errno == EINTR) {
+	do {
+		int rc = nanosleep(&php_req, &php_rem);
+
+		if ((rc == FAILURE) && (errno == EINTR)) {
 			php_req.tv_sec = php_rem.tv_sec;
 			php_req.tv_nsec = php_rem.tv_nsec;
 		} else {
 			RETURN_FALSE;
 		}
-	}
+	} while (1);
 
 	RETURN_TRUE;
 }

--- a/ext/standard/tests/misc/time_sleep_until_basic.phpt
+++ b/ext/standard/tests/misc/time_sleep_until_basic.phpt
@@ -32,5 +32,3 @@ Michele Orselli mo@ideato.it
 --EXPECT--
 bool(true)
 bool(true)
---XFAIL--
-gettimeofday cannot be used to reliably implement high precision process synchronization


### PR DESCRIPTION
nanosleep will return -1 *and* set errno EINTR, so the loop that was calling nanosleep mishandles EINTR.