### PR TITLE
Use uint64_t for time_sleep_until calculations

### DIFF
--- a/ext/standard/tests/misc/time_sleep_until_basic.phpt
+++ b/ext/standard/tests/misc/time_sleep_until_basic.phpt
@@ -32,5 +32,3 @@ Michele Orselli mo@ideato.it
 --EXPECT--
 bool(true)
 bool(true)
---XFAIL--
-gettimeofday cannot be used to reliably implement high precision process synchronization


### PR DESCRIPTION
To avoid rounding issues.

cc @krakjoe 