### PR TITLE
Remove superfluous accel_gen_system_id() call

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2584,9 +2584,6 @@ static void accel_globals_ctor(zend_accel_globals *accel_globals)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif
 	memset(accel_globals, 0, sizeof(zend_accel_globals));
-
-	/* TODO refactor to init this just once. */
-	accel_gen_system_id();
 }
 
 #define ZEND_BIN_ID "BIN_" ZEND_TOSTR(SIZEOF_INT) ZEND_TOSTR(SIZEOF_LONG) ZEND_TOSTR(SIZEOF_SIZE_T) ZEND_TOSTR(SIZEOF_ZEND_LONG) ZEND_TOSTR(ZEND_MM_ALIGNMENT)


### PR DESCRIPTION
There is no need to call accel_gen_system_id() in accel_globals_ctor(),
since it's called shortly afterwards in accel_startup() anyway.