### PR TITLE
Add configuration value to enable/disable stack trace logging

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -174,6 +174,7 @@ ZEND_INI_BEGIN()
 #ifdef ZEND_SIGNALS
 	STD_ZEND_INI_BOOLEAN("zend.signal_check", "0", ZEND_INI_SYSTEM, OnUpdateBool, check, zend_signal_globals_t, zend_signal_globals)
 #endif
+	STD_ZEND_INI_BOOLEAN("zend.log_exception_trace",	"0",    ZEND_INI_ALL,		OnUpdateBool, log_exception_trace, zend_compiler_globals, compiler_globals)
 ZEND_INI_END()
 
 ZEND_API size_t zend_vspprintf(char **pbuf, size_t max_len, const char *format, va_list ap) /* {{{ */

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -127,6 +127,8 @@ struct _zend_compiler_globals {
 
 	HashTable *delayed_variance_obligations;
 	HashTable *delayed_autoloads;
+
+	zend_bool log_exception_trace;
 };
 
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -354,6 +354,11 @@ zend.enable_gc = On
 ; Default: ""
 ;zend.script_encoding =
 
+; Add stack traces to fatal errors and exceptions. This could potentially contain
+; sensitive information and should not be enabled in a production environment.
+; Default: Off
+;zend.log_exception_trace = Off
+
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;
 ;;;;;;;;;;;;;;;;;

--- a/php.ini-production
+++ b/php.ini-production
@@ -359,6 +359,11 @@ zend.enable_gc = On
 ; Default: ""
 ;zend.script_encoding =
 
+; Add stack traces to fatal errors and exceptions. This	could potentially contain
+; sensitive information and should not be enabled in a production environment.
+; Default: Off
+;zend.log_exception_trace = Off
+
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;
 ;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
**Background:**
The latest version of PHP seems to handle fatal errors as exceptions which results in stack traces being logged. Stack traces can potentially contain sensitive information and should not be logged in a production environment.

**Test code:**
```
<?php
function handle_password($a) {
        does_not_exist();
}
handle_password('s3cretp4ssword');
```

PHP 5.4.16:
Jun 17 15:58:01 server php[29650]: PHP Fatal error:  Call to undefined function does_not_exist() in /var/www/html/index.php on line 3

PHP 7.4 (dev):
Jun 17 15:58:01 server php[18159]: PHP Fatal error:  Uncaught Error: Call to undefined function does_not_exist() in /var/www/html/index.php:3#012Stack trace:#012#0 /var/www/html/index.php(5): handle_password('s3cretp4ssword')#012#1 {main}#012  thrown in /var/www/html/index.php on line 3

**Suggested patch:**
Add a configuration value to be able to prevent exceptions from logging stack traces.

`log_exception_trace = On/Off`

It would be optimal to have this disabled as default as novice administrators would perhaps not be aware that this information would be logged. For debugging purposes it would be helpful to be able to enable this but maybe the default value should be set conservatively to minimize unnecessary problems?

I've added this configuration value in Zend/zend.c as the exception message is compiled in Zend/zend_exceptions.c. Adding it to main/main.c would change the scope from zend_compiler_globals to php_core_globals and I guess that you wouldn't want to mix them?
