### PR TITLE
Properly shut down font cache mutex

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -1029,7 +1029,11 @@ zend_module_entry gd_module_entry = {
 	"gd",
 	gd_functions,
 	PHP_MINIT(gd),
+#if HAVE_GD_BUNDLED && HAVE_LIBFREETYPE
+	PHP_MSHUTDOWN(gd),
+#else
 	NULL,
+#endif
 	NULL,
 #if HAVE_GD_FREETYPE && HAVE_LIBFREETYPE
 	PHP_RSHUTDOWN(gd),
@@ -1236,6 +1240,17 @@ PHP_MINIT_FUNCTION(gd)
 
 	return SUCCESS;
 }
+/* }}} */
+
+/* {{{ PHP_MSHUTDOWN_FUNCTION
+ */
+#if HAVE_GD_BUNDLED && HAVE_LIBFREETYPE
+PHP_MSHUTDOWN_FUNCTION(gd)
+{
+	gdFontCacheMutexShutdown();
+	return SUCCESS;
+}
+#endif
 /* }}} */
 
 /* {{{ PHP_RSHUTDOWN_FUNCTION

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -1029,11 +1029,7 @@ zend_module_entry gd_module_entry = {
 	"gd",
 	gd_functions,
 	PHP_MINIT(gd),
-#if HAVE_GD_BUNDLED && HAVE_LIBFREETYPE
 	PHP_MSHUTDOWN(gd),
-#else
-	NULL,
-#endif
 	NULL,
 #if HAVE_GD_FREETYPE && HAVE_LIBFREETYPE
 	PHP_RSHUTDOWN(gd),
@@ -1244,13 +1240,13 @@ PHP_MINIT_FUNCTION(gd)
 
 /* {{{ PHP_MSHUTDOWN_FUNCTION
  */
-#if HAVE_GD_BUNDLED && HAVE_LIBFREETYPE
 PHP_MSHUTDOWN_FUNCTION(gd)
 {
+#if HAVE_GD_BUNDLED && HAVE_LIBFREETYPE
 	gdFontCacheMutexShutdown();
+#endif
 	return SUCCESS;
 }
-#endif
 /* }}} */
 
 /* {{{ PHP_RSHUTDOWN_FUNCTION

--- a/ext/gd/php_gd.h
+++ b/ext/gd/php_gd.h
@@ -83,9 +83,7 @@ extern zend_module_entry gd_module_entry;
 /* gd.c functions */
 PHP_MINFO_FUNCTION(gd);
 PHP_MINIT_FUNCTION(gd);
-#if HAVE_GD_BUNDLED && HAVE_LIBFREETYPE
 PHP_MSHUTDOWN_FUNCTION(gd);
-#endif
 #if HAVE_GD_FREETYPE && HAVE_LIBFREETYPE
 PHP_RSHUTDOWN_FUNCTION(gd);
 #endif

--- a/ext/gd/php_gd.h
+++ b/ext/gd/php_gd.h
@@ -83,6 +83,9 @@ extern zend_module_entry gd_module_entry;
 /* gd.c functions */
 PHP_MINFO_FUNCTION(gd);
 PHP_MINIT_FUNCTION(gd);
+#if HAVE_GD_BUNDLED && HAVE_LIBFREETYPE
+PHP_MSHUTDOWN_FUNCTION(gd);
+#endif
 #if HAVE_GD_FREETYPE && HAVE_LIBFREETYPE
 PHP_RSHUTDOWN_FUNCTION(gd);
 #endif


### PR DESCRIPTION
Since the font cache mutex in set up in MINIT, we have to shut it down
in MSHUTDOWN.