### PR TITLE
Set Computer English language for credits sorting

### DIFF
--- a/scripts/dev/credits
+++ b/scripts/dev/credits
@@ -26,8 +26,8 @@ do
 */
 
 END
-  # Do not process skeleton #
+  # Do not process skeleton
   files=`find "$what" -name CREDITS | grep -v "$what"/skeleton/CREDITS`
-  awk "$awkprog" $files | sort -f | uniq >> $file
+  awk "$awkprog" $files | LC_ALL=C sort -f | uniq >> $file
   echo "Updated $file"
 done


### PR DESCRIPTION
This makes the script a bit more portable when used on systems with different LC_ALL and LANG settings.

Meaning: The sorting is different when `LANG is set to `en_US.UTF-8` or something else... For example, this https://github.com/php/php-src/commit/ec57ba5eddbc1592ff0ece88111b8f184e9fe037 is using computer English language. Previous sort used English US UTF 8...