### PR TITLE
Remove HAVE_STRCOLL check

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -1969,7 +1969,6 @@ ZEND_API int ZEND_FASTCALL string_case_compare_function(zval *op1, zval *op2) /*
 }
 /* }}} */
 
-#if HAVE_STRCOLL
 ZEND_API int ZEND_FASTCALL string_locale_compare_function(zval *op1, zval *op2) /* {{{ */
 {
 	zend_string *tmp_str1, *tmp_str2;
@@ -1982,7 +1981,6 @@ ZEND_API int ZEND_FASTCALL string_locale_compare_function(zval *op1, zval *op2) 
 	return ret;
 }
 /* }}} */
-#endif
 
 ZEND_API int ZEND_FASTCALL numeric_compare_function(zval *op1, zval *op2) /* {{{ */
 {

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -394,9 +394,7 @@ ZEND_API int ZEND_FASTCALL numeric_compare_function(zval *op1, zval *op2);
 ZEND_API int ZEND_FASTCALL string_compare_function_ex(zval *op1, zval *op2, zend_bool case_insensitive);
 ZEND_API int ZEND_FASTCALL string_compare_function(zval *op1, zval *op2);
 ZEND_API int ZEND_FASTCALL string_case_compare_function(zval *op1, zval *op2);
-#if HAVE_STRCOLL
 ZEND_API int ZEND_FASTCALL string_locale_compare_function(zval *op1, zval *op2);
-#endif
 
 ZEND_API void         ZEND_FASTCALL zend_str_tolower(char *str, size_t length);
 ZEND_API char*        ZEND_FASTCALL zend_str_tolower_copy(char *dest, const char *source, size_t length);

--- a/configure.ac
+++ b/configure.ac
@@ -641,7 +641,6 @@ statfs \
 statvfs \
 std_syslog \
 strcasecmp \
-strcoll \
 strdup \
 strerror \
 strnlen \

--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -335,9 +335,7 @@ static const func_info_t func_infos[] = {
 	F1("str_split",                    MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_OF_STRING),
 	F1("strpbrk",                      MAY_BE_FALSE | MAY_BE_STRING),
 	F0("substr_compare",               MAY_BE_FALSE | MAY_BE_LONG),
-#ifdef HAVE_STRCOLL
 	F0("strcoll",                      MAY_BE_NULL | MAY_BE_LONG),
-#endif
 #ifdef HAVE_STRFMON
 	F1("money_format",                 MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_STRING),
 #endif

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -327,7 +327,6 @@ static int php_array_reverse_key_compare_string_natural(const void *a, const voi
 }
 /* }}} */
 
-#if HAVE_STRCOLL
 static int php_array_key_compare_string_locale(const void *a, const void *b) /* {{{ */
 {
 	Bucket *f = (Bucket *) a;
@@ -355,7 +354,6 @@ static int php_array_reverse_key_compare_string_locale(const void *a, const void
 	return php_array_key_compare_string_locale(b, a);
 }
 /* }}} */
-#endif
 
 /* Numbers are always smaller than strings int this function as it
  * anyway doesn't make much sense to compare two different data types.
@@ -528,7 +526,6 @@ static int php_array_reverse_natural_case_compare(const void *a, const void *b) 
 }
 /* }}} */
 
-#if HAVE_STRCOLL
 static int php_array_data_compare_string_locale(const void *a, const void *b) /* {{{ */
 {
 	Bucket *f;
@@ -558,7 +555,6 @@ static int php_array_reverse_data_compare_string_locale(const void *a, const voi
 	return php_array_data_compare_string_locale(b, a);
 }
 /* }}} */
-#endif
 
 static compare_func_t php_get_key_compare_func(zend_long sort_type, int reverse) /* {{{ */
 {
@@ -603,7 +599,6 @@ static compare_func_t php_get_key_compare_func(zend_long sort_type, int reverse)
 			}
 			break;
 
-#if HAVE_STRCOLL
 		case PHP_SORT_LOCALE_STRING:
 			if (reverse) {
 				return php_array_reverse_key_compare_string_locale;
@@ -611,7 +606,6 @@ static compare_func_t php_get_key_compare_func(zend_long sort_type, int reverse)
 				return php_array_key_compare_string_locale;
 			}
 			break;
-#endif
 
 		case PHP_SORT_REGULAR:
 		default:
@@ -669,7 +663,6 @@ static compare_func_t php_get_data_compare_func(zend_long sort_type, int reverse
 			}
 			break;
 
-#if HAVE_STRCOLL
 		case PHP_SORT_LOCALE_STRING:
 			if (reverse) {
 				return php_array_reverse_data_compare_string_locale;
@@ -677,7 +670,6 @@ static compare_func_t php_get_data_compare_func(zend_long sort_type, int reverse
 				return php_array_data_compare_string_locale;
 			}
 			break;
-#endif
 
 		case PHP_SORT_REGULAR:
 		default:
@@ -5709,9 +5701,7 @@ PHP_FUNCTION(array_multisort)
 				case PHP_SORT_NUMERIC:
 				case PHP_SORT_STRING:
 				case PHP_SORT_NATURAL:
-#if HAVE_STRCOLL
 				case PHP_SORT_LOCALE_STRING:
-#endif
 					/* flag allowed here */
 					if (parse_state[MULTISORT_TYPE] == 1) {
 						/* Save the flag and make sure then next arg is not the current flag. */

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2162,12 +2162,10 @@ ZEND_BEGIN_ARG_INFO(arginfo_nl_langinfo, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#ifdef HAVE_STRCOLL
 ZEND_BEGIN_ARG_INFO(arginfo_strcoll, 0)
 	ZEND_ARG_INFO(0, str1)
 	ZEND_ARG_INFO(0, str2)
 ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_trim, 0, 0, 1)
 	ZEND_ARG_INFO(0, str)
@@ -2803,10 +2801,7 @@ static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(substr_compare,													arginfo_substr_compare)
 	PHP_FE(utf8_encode, 													arginfo_utf8_encode)
 	PHP_FE(utf8_decode, 													arginfo_utf8_decode)
-
-#ifdef HAVE_STRCOLL
 	PHP_FE(strcoll,															arginfo_strcoll)
-#endif
 
 #ifdef HAVE_STRFMON
 	PHP_FE(money_format,													arginfo_money_format)
@@ -4140,10 +4135,10 @@ PHP_FUNCTION(getenv)
 #else
 
     tsrm_env_lock();
-    
+
 	/* system method returns a const */
 	ptr = getenv(str);
-	
+
 	if (ptr) {
 		RETVAL_STRING(ptr);
 	}

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -91,9 +91,7 @@ PHP_FUNCTION(strpbrk);
 PHP_FUNCTION(substr_compare);
 PHP_FUNCTION(utf8_encode);
 PHP_FUNCTION(utf8_decode);
-#ifdef HAVE_STRCOLL
 PHP_FUNCTION(strcoll);
-#endif
 #if HAVE_STRFMON
 PHP_FUNCTION(money_format);
 #endif

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -701,7 +701,6 @@ PHP_FUNCTION(nl_langinfo)
 #endif
 /* }}} */
 
-#ifdef HAVE_STRCOLL
 /* {{{ proto int strcoll(string str1, string str2)
    Compares two strings using the current locale */
 PHP_FUNCTION(strcoll)
@@ -717,7 +716,6 @@ PHP_FUNCTION(strcoll)
 	                    (const char *) ZSTR_VAL(s2)));
 }
 /* }}} */
-#endif
 
 /* {{{ php_charmask
  * Fills a 256-byte bytemask with input. You can specify a range like 'a..z',

--- a/ext/standard/tests/strings/strcoll.phpt
+++ b/ext/standard/tests/strings/strcoll.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Testing Basic behaviour of strcoll()
---SKIPIF--
-<?php if (!function_exists('strcoll')) die('skip strcoll function not available') ?>
 --CREDITS--
 Sebastian Schürmann
 sebs@php.net

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -300,7 +300,6 @@ ARG_ENABLE('fd-setsize', "Set maximum number of sockets for select(2)", "256");
 ADD_FLAG("CFLAGS", "/D FD_SETSIZE=" + parseInt(PHP_FD_SETSIZE));
 
 AC_DEFINE('HAVE_USLEEP', 1);
-AC_DEFINE('HAVE_STRCOLL', 1);
 
 /* For snapshot builders, where can we find the additional
  * files that make up the snapshot template? */

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -122,9 +122,6 @@
 #define PHP_SHLIB_EXT_PREFIX "php_"
 #define HAVE_SQLDATASOURCES
 
-/* Win32 supports strcoll */
-#define HAVE_STRCOLL 1
-
 /* Win32 supports socketpair by the emulation in win32/sockets.c */
 #define HAVE_SOCKETPAIR 1
 #define HAVE_SOCKLEN_T 1


### PR DESCRIPTION
The strcoll function is defined in the C89 standard and should be on today's systems always available via the <string.h> header.

https://port70.net/~nsz/c/c89/c89-draft.html#4.11.4.3