### PR TITLE
Remove HAVE_STRTOD and strtod check

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -155,7 +155,7 @@ _LT_AC_TRY_DLOPEN_SELF([
 ])
 
 dnl Checks for library functions.
-AC_CHECK_FUNCS(getpid kill strtod finite fpclass sigsetjmp)
+AC_CHECK_FUNCS(getpid kill finite fpclass sigsetjmp)
 
 AC_CHECK_DECLS([isfinite, isnan, isinf], [], [], [[#include <math.h>]])
 


### PR DESCRIPTION
There is no need to check for the strtod function. It is part of C89 standard which PHP-7.4+ supports.

http://port70.net/~nsz/c/c89/c89-draft.html#4.10.1.4