### PR TITLE
Clean headers checks

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -126,16 +126,7 @@ dnl
 AC_DEFUN([LIBZEND_BASIC_CHECKS],[
 AC_REQUIRE([AC_PROG_CC])
 
-AC_CHECK_HEADERS(
-inttypes.h \
-stdint.h \
-malloc.h \
-unistd.h \
-sys/types.h \
-sys/time.h \
-unix.h \
-cpuid.h \
-dlfcn.h)
+AC_CHECK_HEADERS([cpuid.h])
 
 dnl
 dnl LIBZEND_DLSYM_CHECK

--- a/configure.ac
+++ b/configure.ac
@@ -436,12 +436,14 @@ ieeefp.h \
 langinfo.h \
 limits.h \
 locale.h \
+malloc.h \
 monetary.h \
 netdb.h \
 poll.h \
 pwd.h \
 resolv.h \
 signal.h \
+strings.h \
 syslog.h \
 sysexits.h \
 sys/ioctl.h \
@@ -457,6 +459,7 @@ sys/statfs.h \
 sys/statvfs.h \
 sys/vfs.h \
 sys/sysexits.h \
+sys/uio.h \
 sys/wait.h \
 sys/loadavg.h \
 termios.h \

--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -1,8 +1,5 @@
 dnl Check for headers needed by timelib
-AC_CHECK_HEADERS([ \
-strings.h \
-io.h
-])
+AC_CHECK_HEADERS([io.h])
 
 dnl Check for strtoll, atoll
 AC_CHECK_FUNCS(strtoll atoll)

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -21,8 +21,6 @@ if test "$PHP_OPCACHE" != "no"; then
     AC_DEFINE(HAVE_MPROTECT, 1, [Define if you have mprotect() function])
   ])
 
-  AC_CHECK_HEADERS([unistd.h sys/uio.h])
-
   AC_MSG_CHECKING(for sysvipc shared memory support)
   AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <sys/types.h>

--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -17,7 +17,7 @@ if test "$PHP_SOCKETS" != "no"; then
   fi
 
   AC_CHECK_FUNCS([hstrerror socketpair if_nametoindex if_indextoname])
-  AC_CHECK_HEADERS([netdb.h netinet/tcp.h sys/un.h sys/sockio.h])
+  AC_CHECK_HEADERS([netinet/tcp.h sys/un.h sys/sockio.h])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -448,7 +448,6 @@ AC_CHECK_HEADERS([net/if.h],[], [],
   #endif
   #include <net/if.h>
 ])
-AC_CHECK_HEADERS([netdb.h])
 AC_MSG_CHECKING([for usable getifaddrs])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   #include <sys/types.h>

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -11,11 +11,6 @@ AC_DEFUN([AC_FPM_STDLIBS],
 
   AC_SEARCH_LIBS(socket, socket)
   AC_SEARCH_LIBS(inet_addr, nsl)
-
-  AC_CHECK_HEADERS([fcntl.h unistd.h sys/uio.h])
-  AC_CHECK_HEADERS([sys/select.h sys/socket.h sys/time.h])
-  AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
-  AC_CHECK_HEADERS([sysexits.h])
 ])
 
 AC_DEFUN([AC_FPM_PRCTL],


### PR DESCRIPTION
Some headers were checked multiple times in the main configure.ac file and in the bundled extensions or SAPIs themselves. Also many of these checks are then used accross other extensions or SAPIs so a central configure.ac makes most sense for these checks.

This doesn't remove defined symbols in the `main/php_config.h` but reduces redundant `./configure` checks a bit more.