### PR TITLE
mbstring: Use full case folding in case-insensitive comparisons

### DIFF
--- a/ext/mbstring/php_unicode.h
+++ b/ext/mbstring/php_unicode.h
@@ -88,7 +88,8 @@ MBSTRING_API int php_unicode_is_prop1(unsigned long code, int prop);
 
 MBSTRING_API char *php_unicode_convert_case(
 		int case_mode, const char *srcstr, size_t srclen, size_t *ret_len,
-		const mbfl_encoding *src_encoding, int illegal_mode, int illegal_substchar);
+		const mbfl_encoding *src_encoding, int illegal_mode, int illegal_substchar,
+		HashTable **offset_table);
 
 #define PHP_UNICODE_CASE_UPPER        0
 #define PHP_UNICODE_CASE_LOWER        1

--- a/ext/mbstring/tests/case_folding.phpt
+++ b/ext/mbstring/tests/case_folding.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Test full case folding in case-insensitive operations
+--FILE--
+<?php
+
+$str1 = "ß SS ß";
+$str2 = "ß";
+$len = mb_strlen($str1);
+
+for ($i = -$len; $i <= $len; $i++) {
+    echo "stripos($str1, $str2, $i): " . mb_stripos($str1, $str2, $i) . "\n"; 
+}
+
+for ($i = -$len; $i <= $len; $i++) {
+    echo "strripos($str1, $str2, $i): " . mb_strripos($str1, $str2, $i) . "\n"; 
+}
+
+echo "\nTurkish I:\n";
+$str1 = "İyi akşamlar";
+$str2 = "i̇yi"; // with combining dot above
+$str3 = "iyi"; // without
+
+var_dump(mb_stripos($str1, $str2));
+var_dump(mb_stripos($str1, $str3));
+
+?>
+--EXPECT--
+stripos(ß SS ß, ß, -6): 0
+stripos(ß SS ß, ß, -5): 2
+stripos(ß SS ß, ß, -4): 2
+stripos(ß SS ß, ß, -3): 5
+stripos(ß SS ß, ß, -2): 5
+stripos(ß SS ß, ß, -1): 5
+stripos(ß SS ß, ß, 0): 0
+stripos(ß SS ß, ß, 1): 2
+stripos(ß SS ß, ß, 2): 2
+stripos(ß SS ß, ß, 3): 5
+stripos(ß SS ß, ß, 4): 5
+stripos(ß SS ß, ß, 5): 5
+stripos(ß SS ß, ß, 6): 
+strripos(ß SS ß, ß, -6): 0
+strripos(ß SS ß, ß, -5): 0
+strripos(ß SS ß, ß, -4): 2
+strripos(ß SS ß, ß, -3): 2
+strripos(ß SS ß, ß, -2): 2
+strripos(ß SS ß, ß, -1): 5
+strripos(ß SS ß, ß, 0): 5
+strripos(ß SS ß, ß, 1): 5
+strripos(ß SS ß, ß, 2): 5
+strripos(ß SS ß, ß, 3): 5
+strripos(ß SS ß, ß, 4): 5
+strripos(ß SS ß, ß, 5): 5
+strripos(ß SS ß, ß, 6): 
+
+Turkish I:
+int(0)
+bool(false)


### PR DESCRIPTION
Currently mb_stripos and friends use simple case folding for case-insensitive comparisons. This PR changes them to use full case folding instead, which allows length-increasing folds. A side-table is kept to keep track of string offset changes caused by this.

As an example, full case folding allows us to recognize that `Fuß` and `FUSS` are (case-insensitively) the same. 

I'm not totally sure whether we should actually do this, as the fact that the match no longer necessarily has the same length as the needle makes some code patterns problematic, such as finding all non-overlapping occurrences inside a loop by using mb_stripos and advancing the offset by mb_strlen($needle), which might not be the length of the actual match anymore and might either skip too much or too little.