### PR TITLE
zend_hash_rehash, return void

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1170,7 +1170,7 @@ static void ZEND_FASTCALL zend_hash_do_resize(HashTable *ht)
 	}
 }
 
-ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
+ZEND_API void ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 {
 	Bucket *p;
 	uint32_t nIndex, i;
@@ -1182,7 +1182,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 			ht->nNumUsed = 0;
 			HT_HASH_RESET(ht);
 		}
-		return SUCCESS;
+		return;
 	}
 
 	HT_HASH_RESET(ht);
@@ -1260,7 +1260,6 @@ ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 			_zend_hash_iterators_update(ht, old_num_used, ht->nNumUsed);
 		}
 	}
-	return SUCCESS;
 }
 
 static zend_always_inline void _zend_hash_del_el_ex(HashTable *ht, uint32_t idx, Bucket *p, Bucket *prev)

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -277,7 +277,7 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_minmax(const HashTable *ht, compare_func_
 #define zend_hash_next_free_element(ht) \
 	(ht)->nNextFreeElement
 
-ZEND_API int ZEND_FASTCALL zend_hash_rehash(HashTable *ht);
+ZEND_API void ZEND_FASTCALL zend_hash_rehash(HashTable *ht);
 
 #if !ZEND_DEBUG && defined(HAVE_BUILTIN_CONSTANT_P)
 # define zend_new_array(size) \

--- a/Zend/zend_ts_hash.c
+++ b/Zend/zend_ts_hash.c
@@ -306,15 +306,11 @@ ZEND_API int zend_ts_hash_num_elements(TsHashTable *ht)
 	return retval;
 }
 
-ZEND_API int zend_ts_hash_rehash(TsHashTable *ht)
+ZEND_API void zend_ts_hash_rehash(TsHashTable *ht)
 {
-	int retval;
-
 	begin_write(ht);
-	retval = zend_hash_rehash(TS_HASH(ht));
+	zend_hash_rehash(TS_HASH(ht));
 	end_write(ht);
-
-	return retval;
 }
 
 ZEND_API zval *zend_ts_hash_str_find(TsHashTable *ht, const char *key, size_t len)

--- a/Zend/zend_ts_hash.h
+++ b/Zend/zend_ts_hash.h
@@ -79,7 +79,7 @@ ZEND_API zval *zend_ts_hash_minmax(TsHashTable *ht, compare_func_t compar, int f
 
 ZEND_API int zend_ts_hash_num_elements(TsHashTable *ht);
 
-ZEND_API int zend_ts_hash_rehash(TsHashTable *ht);
+ZEND_API void zend_ts_hash_rehash(TsHashTable *ht);
 
 #if ZEND_DEBUG
 /* debug */


### PR DESCRIPTION
zend_hash_rehash/zend_ts_hash_rehash always returns SUCCESS that never use. Changed to void.
Replacement for https://github.com/php/php-src/pull/3983