### PR TITLE
Support array command in proc_open()

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -463,7 +463,7 @@ static char *create_win_command_from_args(HashTable *args) {
 PHP_FUNCTION(proc_open)
 {
 	zval *command_zv;
-	char *command, *cwd=NULL;
+	char *command = NULL, *cwd = NULL;
 	size_t cwd_len = 0;
 	zval *descriptorspec;
 	zval *pipes;
@@ -549,6 +549,9 @@ PHP_FUNCTION(proc_open)
 			zend_string_release(arg_str);
 		} ZEND_HASH_FOREACH_END();
 		argv[i] = NULL;
+
+		/* As the array is non-empty, we should have found a command. */
+		ZEND_ASSERT(command);
 #endif
 	} else {
 		convert_to_string(command_zv);

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -956,7 +956,9 @@ PHP_FUNCTION(proc_open)
 
 		if (argv) {
 			/* execvpe() is non-portable, use environ instead. */
-			environ = env.envarray;
+			if (env.envarray) {
+				environ = env.envarray;
+			}
 			execvp(command, argv);
 		} else {
 			if (env.envarray) {

--- a/ext/standard/tests/general_functions/proc_open_array.phpt
+++ b/ext/standard/tests/general_functions/proc_open_array.phpt
@@ -10,21 +10,40 @@ $ds = [
     2 => ['pipe', 'w'],
 ];
 
-// Command array cannot be empty
+echo "Empty command array:";
 $proc = proc_open([], $ds, $pipes);
 
+echo "\nBasic usage:\n";
 $proc = proc_open([$php, '-r', 'echo "Hello World!\n";'], $ds, $pipes);
-var_dump(fgets($pipes[1]));
+fpassthru($pipes[1]);
 proc_close($proc);
 
-$env = ['FOOBARENV' => 'foobar'];
-$proc = proc_open([$php, '-r', 'echo getenv("FOOBARENV");'], $ds, $pipes, null, $env);
-var_dump(fgets($pipes[1]));
+putenv('ENV_1=ENV_1');
+$env = ['ENV_2' => 'ENV_2'];
+$cmd = [$php, '-r', 'var_dump(getenv("ENV_1"), getenv("ENV_2"));'];
+
+echo "\nEnvironment inheritance:\n";
+$proc = proc_open($cmd, $ds, $pipes);
+fpassthru($pipes[1]);
+proc_close($proc);
+
+echo "\nExplicit environment:\n";
+$proc = proc_open($cmd, $ds, $pipes, null, $env);
+fpassthru($pipes[1]);
 proc_close($proc);
 
 ?>
 --EXPECTF--
+Empty command array:
 Warning: proc_open(): Command array must have at least one element in %s on line %d
-string(13) "Hello World!
-"
-string(6) "foobar"
+
+Basic usage:
+Hello World!
+
+Environment inheritance:
+string(5) "ENV_1"
+bool(false)
+
+Explicit environment:
+bool(false)
+string(5) "ENV_2"

--- a/ext/standard/tests/general_functions/proc_open_array.phpt
+++ b/ext/standard/tests/general_functions/proc_open_array.phpt
@@ -11,7 +11,13 @@ $ds = [
 ];
 
 echo "Empty command array:";
-$proc = proc_open([], $ds, $pipes);
+var_dump(proc_open([], $ds, $pipes));
+
+echo "\nNul byte in program name:";
+var_dump(proc_open(["php\0oops"], $ds, $pipes));
+
+echo "\nNul byte in argument:";
+var_dump(proc_open(["php", "arg\0oops"], $ds, $pipes));
 
 echo "\nBasic usage:\n";
 $proc = proc_open([$php, '-r', 'echo "Hello World!\n";'], $ds, $pipes);
@@ -36,7 +42,6 @@ echo "\nCheck that arguments are correctly passed through:\n";
 $args = [
     "Simple",
     "White space\ttab\nnewline",
-    "Nul\0bytes", // Should be cut off
     '"Quoted"',
     'Qu"ot"ed',
     '\\Back\\slash\\',
@@ -52,6 +57,15 @@ proc_close($proc);
 --EXPECTF--
 Empty command array:
 Warning: proc_open(): Command array must have at least one element in %s on line %d
+bool(false)
+
+Nul byte in program name:
+Warning: proc_open(): Command array element 1 contains a null byte in %s on line %d
+bool(false)
+
+Nul byte in argument:
+Warning: proc_open(): Command array element 2 contains a null byte in %s on line %d
+bool(false)
 
 Basic usage:
 Hello World!
@@ -69,10 +83,9 @@ array (
   0 => 'Simple',
   1 => 'White space	tab
 newline',
-  2 => 'Nul',
-  3 => '"Quoted"',
-  4 => 'Qu"ot"ed',
-  5 => '\\Back\\slash\\',
-  6 => '\\\\Back\\\\slash\\\\',
-  7 => '\\"Qu\\"ot\\"ed\\"',
+  2 => '"Quoted"',
+  3 => 'Qu"ot"ed',
+  4 => '\\Back\\slash\\',
+  5 => '\\\\Back\\\\slash\\\\',
+  6 => '\\"Qu\\"ot\\"ed\\"',
 )

--- a/ext/standard/tests/general_functions/proc_open_array.phpt
+++ b/ext/standard/tests/general_functions/proc_open_array.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Using proc_open() with a command array (no shell)
+--FILE--
+<?php
+
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ds = [
+    0 => ['pipe', 'r'],
+    1 => ['pipe', 'w'],
+    2 => ['pipe', 'w'],
+];
+
+// Command array cannot be empty
+$proc = proc_open([], $ds, $pipes);
+
+$proc = proc_open([$php, '-r', 'echo "Hello World!\n";'], $ds, $pipes);
+var_dump(fgets($pipes[1]));
+proc_close($proc);
+
+$env = ['FOOBARENV' => 'foobar'];
+$proc = proc_open([$php, '-r', 'echo getenv("FOOBARENV");'], $ds, $pipes, null, $env);
+var_dump(fgets($pipes[1]));
+proc_close($proc);
+
+?>
+--EXPECTF--
+Warning: proc_open(): Command array must have at least one element in %s on line %d
+string(13) "Hello World!
+"
+string(6) "foobar"

--- a/ext/standard/tests/general_functions/proc_open_array.phpt
+++ b/ext/standard/tests/general_functions/proc_open_array.phpt
@@ -32,6 +32,22 @@ $proc = proc_open($cmd, $ds, $pipes, null, $env);
 fpassthru($pipes[1]);
 proc_close($proc);
 
+echo "\nCheck that arguments are correctly passed through:\n";
+$args = [
+    "Simple",
+    "White space\ttab\nnewline",
+    "Nul\0bytes", // Should be cut off
+    '"Quoted"',
+    'Qu"ot"ed',
+    '\\Back\\slash\\',
+    '\\\\Back\\\\slash\\\\',
+    '\\"Qu\\"ot\\"ed\\"',
+];
+$cmd = [$php, '-r', 'var_export(array_slice($argv, 1));', '--', ...$args];
+$proc = proc_open($cmd, $ds, $pipes);
+fpassthru($pipes[1]);
+proc_close($proc);
+
 ?>
 --EXPECTF--
 Empty command array:
@@ -47,3 +63,16 @@ bool(false)
 Explicit environment:
 bool(false)
 string(5) "ENV_2"
+
+Check that arguments are correctly passed through:
+array (
+  0 => 'Simple',
+  1 => 'White space	tab
+newline',
+  2 => 'Nul',
+  3 => '"Quoted"',
+  4 => 'Qu"ot"ed',
+  5 => '\\Back\\slash\\',
+  6 => '\\\\Back\\\\slash\\\\',
+  7 => '\\"Qu\\"ot\\"ed\\"',
+)


### PR DESCRIPTION
As requested by @nicolas-grekas, this implements support for passing a command array to `proc_open()`. In this case no shell will be used for the execution, and argument escaping (if it is necessary) will be handled internally. Example:

```php
proc_open(['php', '-r', 'echo "Hello World\n";'], $ds, $pipes);
```

On Unix this is implemented using `execvp`. On Windows we use `CreateProcessW` and escape arguments appropriately.

I did the Windows implementation blind, so it likely doesn't work... someone on Windows will have to check that.