### PR TITLE
Fix posix_errno test without PCNTL dep

### DIFF
--- a/ext/posix/tests/posix_errno_variation2.phpt
+++ b/ext/posix/tests/posix_errno_variation2.phpt
@@ -12,7 +12,10 @@ Francesco Fullone ff@ideato.it
 <?php
 echo "*** Test by calling function with pid error ***\n";
 
-posix_kill((2 ** 22) + 1, SIGKILL);
+// Don't rely on PCNTL extension being around
+$SIGKILL = 9;
+
+posix_kill((2 ** 22) + 1, $SIGKILL);
 
 var_dump(posix_errno());
 ?>


### PR DESCRIPTION
When PCNTL extension is not enabled, the SIGKILL constant is also not available.

Taken based on the ext/posix/tests/posix_kill_basic.phpt test. Previous version of this test had check for PCNTL extension but since only this constant is involved here, this might do...

Otherwise, the default build and test procedure fails:

```bash
./buildconf
./configure
make
make test
```
