### PR TITLE
Fix concurrent testing of bug 61964

### DIFF
--- a/ext/fileinfo/tests/bug61964-mb.phpt
+++ b/ext/fileinfo/tests/bug61964-mb.phpt
@@ -10,7 +10,7 @@ $magic_file = __DIR__ . DIRECTORY_SEPARATOR . 'magic私はガラスを食べら�
 $ret = @finfo_open(FILEINFO_NONE, $magic_file . ".non-exits私はガラスを食べられます");
 var_dump($ret);
 
-$dir = __DIR__ . "/test-folder";
+$dir = __DIR__ . "/.tmp-bug61964-mb";
 @mkdir($dir);
 
 $magic_file_copy = $dir . "/magic私はガラスを食べられます.copy";
@@ -60,6 +60,6 @@ Notice: finfo_open(): Warning: offset `a' invalid in %sbug61964-mb.php on line %
 
 Notice: finfo_open(): Warning: offset `b' invalid in %sbug61964-mb.php on line %d
 
-Warning: finfo_open(): Failed to load magic database at '%stest-folder'. in %sbug61964-mb.php on line %d
+Warning: finfo_open(): Failed to load magic database at '%s.tmp-bug61964-mb'. in %sbug61964-mb.php on line %d
 DONE: testing dir with files
 ===DONE===

--- a/ext/fileinfo/tests/bug61964-mb.phpt
+++ b/ext/fileinfo/tests/bug61964-mb.phpt
@@ -10,7 +10,7 @@ $magic_file = __DIR__ . DIRECTORY_SEPARATOR . 'magic私はガラスを食べら�
 $ret = @finfo_open(FILEINFO_NONE, $magic_file . ".non-exits私はガラスを食べられます");
 var_dump($ret);
 
-$dir = __DIR__ . "/.tmp-bug61964-mb";
+$dir = __DIR__ . "/bug61964-mb";
 @mkdir($dir);
 
 $magic_file_copy = $dir . "/magic私はガラスを食べられます.copy";
@@ -60,6 +60,6 @@ Notice: finfo_open(): Warning: offset `a' invalid in %sbug61964-mb.php on line %
 
 Notice: finfo_open(): Warning: offset `b' invalid in %sbug61964-mb.php on line %d
 
-Warning: finfo_open(): Failed to load magic database at '%s.tmp-bug61964-mb'. in %sbug61964-mb.php on line %d
+Warning: finfo_open(): Failed to load magic database at '%sbug61964-mb'. in %sbug61964-mb.php on line %d
 DONE: testing dir with files
 ===DONE===

--- a/ext/fileinfo/tests/bug61964.phpt
+++ b/ext/fileinfo/tests/bug61964.phpt
@@ -10,7 +10,7 @@ $magic_file = __DIR__ . DIRECTORY_SEPARATOR . 'magic';
 $ret = @finfo_open(FILEINFO_NONE, $magic_file . ".non-exits");
 var_dump($ret);
 
-$dir = __DIR__ . "/.tmp-bug61964";
+$dir = __DIR__ . "/bug61964";
 @mkdir($dir);
 
 $magic_file_copy = $dir . "/magic.copy";
@@ -60,6 +60,6 @@ Notice: finfo_open(): Warning: offset `a' invalid in %sbug61964.php on line %d
 
 Notice: finfo_open(): Warning: offset `b' invalid in %sbug61964.php on line %d
 
-Warning: finfo_open(): Failed to load magic database at '%s.tmp-bug61964'. in %sbug61964.php on line %d
+Warning: finfo_open(): Failed to load magic database at '%sbug61964'. in %sbug61964.php on line %d
 DONE: testing dir with files
 ===DONE===

--- a/ext/fileinfo/tests/bug61964.phpt
+++ b/ext/fileinfo/tests/bug61964.phpt
@@ -10,7 +10,7 @@ $magic_file = __DIR__ . DIRECTORY_SEPARATOR . 'magic';
 $ret = @finfo_open(FILEINFO_NONE, $magic_file . ".non-exits");
 var_dump($ret);
 
-$dir = __DIR__ . "/test-folder";
+$dir = __DIR__ . "/.tmp-bug61964";
 @mkdir($dir);
 
 $magic_file_copy = $dir . "/magic.copy";
@@ -60,6 +60,6 @@ Notice: finfo_open(): Warning: offset `a' invalid in %sbug61964.php on line %d
 
 Notice: finfo_open(): Warning: offset `b' invalid in %sbug61964.php on line %d
 
-Warning: finfo_open(): Failed to load magic database at '%stest-folder'. in %sbug61964.php on line %d
+Warning: finfo_open(): Failed to load magic database at '%s.tmp-bug61964'. in %sbug61964.php on line %d
 DONE: testing dir with files
 ===DONE===


### PR DESCRIPTION
When tests are run concurrently using the -j option there might be a change of failure and writing to the same directory from both tests.

Targeting only PHP-7.4 because this is when concurrent testing started.

Happened during the test in #4308 A rare yet obviously possible situation:

```
=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Bug #61964 (finfo_open with directory cause invalid free) [ext/fileinfo/tests/bug61964.phpt]
Bug #61964 (finfo_open with directory cause invalid free) [ext/fileinfo/tests/bug61964-mb.phpt]
=====================================================================
```
