### PR TITLE
Sync HAVE_HASH and HAVE_HASH_EXT symbols usage

### DIFF
--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -11,6 +11,7 @@ if test "$PHP_MHASH" != "no"; then
   AC_DEFINE(PHP_MHASH_BC, 1, [ ])
 fi
 
+dnl Defined for BC.
 AC_DEFINE(HAVE_HASH_EXT,1,[Have HASH Extension])
 
 if test $ac_cv_c_bigendian_php = yes; then

--- a/ext/hash/config.w32
+++ b/ext/hash/config.w32
@@ -6,6 +6,7 @@ if (PHP_MHASH != 'no') {
 	AC_DEFINE('PHP_MHASH_BC', 1);
 }
 
+// Defined for BC.
 AC_DEFINE('HAVE_HASH_EXT', 1);
 
 PHP_HASH = 'yes';

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -1488,7 +1488,3 @@ zend_module_entry hash_module_entry = {
 	STANDARD_MODULE_PROPERTIES
 };
 /* }}} */
-
-#ifdef COMPILE_DL_HASH
-ZEND_GET_MODULE(hash)
-#endif

--- a/ext/phar/config.m4
+++ b/ext/phar/config.m4
@@ -7,13 +7,6 @@ PHP_ARG_ENABLE([phar],
 if test "$PHP_PHAR" != "no"; then
   PHP_NEW_EXTENSION(phar, util.c tar.c zip.c stream.c func_interceptors.c dirstream.c phar.c phar_object.c phar_path_check.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   AC_MSG_CHECKING([for phar openssl support])
-  if test "$PHP_HASH_SHARED" != "yes"; then
-    if test "$PHP_HASH" != "no"; then
-      AC_DEFINE(PHAR_HASH_OK,1,[ ])
-    fi
-  else
-    AC_MSG_WARN([Phar: sha256/sha512 signature support disabled if ext/hash is built shared])
-  fi
   if test "$PHP_OPENSSL_SHARED" = "yes"; then
     AC_MSG_RESULT([no (shared openssl)])
   else

--- a/ext/phar/config.w32
+++ b/ext/phar/config.w32
@@ -34,13 +34,6 @@ if (PHP_PHAR != "no") {
 			STDOUT.WriteLine('        Native OpenSSL support in Phar disabled');
 		}
 	}
-	if (PHP_HASH != "no") {
-		if (!PHP_HASH_SHARED) {
-			AC_DEFINE("PHAR_HASH_OK", 1);
-		} else {
-			WARNING('Phar: sha256/sha512 signature support disabled if ext/hash is built shared');
-		}
-	}
 	ADD_EXTENSION_DEP('phar', 'spl', true);
 
 	ADD_MAKEFILE_FRAGMENT();

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -3624,9 +3624,7 @@ static const zend_module_dep phar_deps[] = {
 	ZEND_MOD_OPTIONAL("openssl")
 	ZEND_MOD_OPTIONAL("zlib")
 	ZEND_MOD_OPTIONAL("standard")
-#if defined(HAVE_HASH) && !defined(COMPILE_DL_HASH)
 	ZEND_MOD_REQUIRED("hash")
-#endif
 	ZEND_MOD_REQUIRED("spl")
 	ZEND_MOD_END
 };

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -842,7 +842,6 @@ static int phar_parse_pharfile(php_stream *fp, char *fname, size_t fname_len, ch
 				efree(sig);
 			}
 			break;
-#if PHAR_HASH_OK
 			case PHAR_SIG_SHA512: {
 				unsigned char digest[64];
 
@@ -897,17 +896,6 @@ static int phar_parse_pharfile(php_stream *fp, char *fname, size_t fname_len, ch
 				}
 				break;
 			}
-#else
-			case PHAR_SIG_SHA512:
-			case PHAR_SIG_SHA256:
-				efree(savebuf);
-				php_stream_close(fp);
-
-				if (error) {
-					spprintf(error, 0, "phar \"%s\" has a unsupported signature", fname);
-				}
-				return FAILURE;
-#endif
 			case PHAR_SIG_SHA1: {
 				unsigned char digest[20];
 
@@ -3122,18 +3110,6 @@ int phar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int conv
 		}
 
 		switch(phar->sig_flags) {
-#ifndef PHAR_HASH_OK
-			case PHAR_SIG_SHA512:
-			case PHAR_SIG_SHA256:
-				if (closeoldfile) {
-					php_stream_close(oldfile);
-				}
-				php_stream_close(newfile);
-				if (error) {
-					spprintf(error, 0, "unable to write contents of file \"%s\" to new phar \"%s\" with requested hash type", entry->filename, phar->fname);
-				}
-				return EOF;
-#endif
 			default: {
 				char *digest = NULL;
 				size_t digest_len;

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -59,10 +59,8 @@
 #include "ext/spl/spl_exceptions.h"
 #include "ext/spl/spl_iterators.h"
 #include "php_phar.h"
-#ifdef PHAR_HASH_OK
 #include "ext/hash/php_hash.h"
 #include "ext/hash/php_hash_sha.h"
-#endif
 
 /* PHP_ because this is public information via MINFO */
 #define PHP_PHAR_API_VERSION      "1.1.1"

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -1275,10 +1275,8 @@ PHP_METHOD(Phar, getSupportedSignatures)
 
 	add_next_index_stringl(return_value, "MD5", 3);
 	add_next_index_stringl(return_value, "SHA-1", 5);
-#ifdef PHAR_HASH_OK
 	add_next_index_stringl(return_value, "SHA-256", 7);
 	add_next_index_stringl(return_value, "SHA-512", 7);
-#endif
 #if PHAR_HAVE_OPENSSL
 	add_next_index_stringl(return_value, "OpenSSL", 7);
 #else
@@ -3061,11 +3059,6 @@ PHP_METHOD(Phar, setSignatureAlgorithm)
 	switch (algo) {
 		case PHAR_SIG_SHA256:
 		case PHAR_SIG_SHA512:
-#ifndef PHAR_HASH_OK
-			zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
-				"SHA-256 and SHA-512 signatures are only supported if the hash extension is enabled and built non-shared");
-			return;
-#endif
 		case PHAR_SIG_MD5:
 		case PHAR_SIG_SHA1:
 		case PHAR_SIG_OPENSSL:

--- a/ext/phar/tests/phar_get_supported_signatures_002.phpt
+++ b/ext/phar/tests/phar_get_supported_signatures_002.phpt
@@ -3,7 +3,6 @@ Phar::getSupportedSignatures()
 --SKIPIF--
 <?php
 if (!extension_loaded("phar")) die("skip");
-if (!extension_loaded("hash")) die("skip extension hash required");
 $arr = Phar::getSupportedSignatures();
 if (in_array("OpenSSL", $arr)) die("skip openssl support enabled");
 if (!in_array('SHA-256', $arr)) die("skip hash extension loaded shared");

--- a/ext/phar/tests/phar_get_supported_signatures_002a.phpt
+++ b/ext/phar/tests/phar_get_supported_signatures_002a.phpt
@@ -3,7 +3,6 @@ Phar::getSupportedSignatures()
 --SKIPIF--
 <?php
 if (!extension_loaded("phar")) die("skip");
-if (!extension_loaded("hash")) die("skip extension hash required");
 $arr = Phar::getSupportedSignatures();
 if (!in_array("OpenSSL", $arr)) die("skip openssl support required");
 if (!in_array('SHA-256', $arr)) die("skip hash extension loaded shared");

--- a/ext/phar/tests/phar_setsignaturealgo2.phpt
+++ b/ext/phar/tests/phar_setsignaturealgo2.phpt
@@ -3,7 +3,6 @@ Phar::setSupportedSignatures() with hash
 --SKIPIF--
 <?php
 if (!extension_loaded("phar")) die("skip");
-if (!extension_loaded("hash")) die("skip hash extension required");
 $arr = Phar::getSupportedSignatures();
 if (!in_array("OpenSSL", $arr)) die("skip openssl support required");
 if (!in_array('SHA-256', $arr)) die("skip hash extension loaded shared");

--- a/ext/phar/tests/tar/phar_setsignaturealgo2.phpt
+++ b/ext/phar/tests/tar/phar_setsignaturealgo2.phpt
@@ -2,7 +2,7 @@
 Phar::setSupportedSignatures() with hash, tar-based
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
-<?php if (!extension_loaded("hash")) die("skip extension hash required");
+<?php
 $arr = Phar::getSupportedSignatures();
 if (!in_array("OpenSSL", $arr)) die("skip openssl support required");
 if (!in_array('SHA-256', $arr)) die("skip hash extension loaded shared"); ?>

--- a/ext/phar/tests/test_signaturealgos.phpt
+++ b/ext/phar/tests/test_signaturealgos.phpt
@@ -3,7 +3,6 @@ Phar: verify signature parsing works
 --SKIPIF--
 <?php
 if (!extension_loaded("phar")) die("skip");
-if (!extension_loaded("hash")) die("skip extension hash conflicts");
 $arr = Phar::getSupportedSignatures();
 if (!in_array("OpenSSL", $arr)) die("skip openssl support required");
 if (!in_array('SHA-256', $arr)) die("skip hash extension loaded shared");

--- a/ext/phar/tests/zip/phar_setsignaturealgo2.phpt
+++ b/ext/phar/tests/zip/phar_setsignaturealgo2.phpt
@@ -2,7 +2,7 @@
 Phar::setSupportedSignatures() with hash, zip-based
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
-<?php if (!extension_loaded("hash")) die("skip extension hash required");
+<?php
 $arr = Phar::getSupportedSignatures();
 if (!in_array("OpenSSL", $arr)) die("skip openssl support required");
 if (!in_array('SHA-256', $arr)) die("skip hash extension loaded shared"); ?>

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -19,9 +19,7 @@
 */
 
 #include "phar_internal.h"
-#ifdef PHAR_HASH_OK
 #include "ext/hash/php_hash_sha.h"
-#endif
 
 #ifdef PHAR_HAVE_OPENSSL
 /* OpenSSL includes */
@@ -1598,7 +1596,6 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t sig_type,
 			*signature_len = phar_hex_str((const char*)sig, sig_len, signature);
 		}
 		break;
-#ifdef PHAR_HASH_OK
 		case PHAR_SIG_SHA512: {
 			unsigned char digest[64];
 			PHP_SHA512_CTX context;
@@ -1679,14 +1676,6 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t sig_type,
 			*signature_len = phar_hex_str((const char*)digest, sizeof(digest), signature);
 			break;
 		}
-#else
-		case PHAR_SIG_SHA512:
-		case PHAR_SIG_SHA256:
-			if (error) {
-				spprintf(error, 0, "unsupported signature");
-			}
-			return FAILURE;
-#endif
 		case PHAR_SIG_SHA1: {
 			unsigned char digest[20];
 			PHP_SHA1_CTX  context;
@@ -1790,7 +1779,6 @@ int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signat
 	}
 
 	switch(phar->sig_flags) {
-#ifdef PHAR_HASH_OK
 		case PHAR_SIG_SHA512: {
 			unsigned char digest[64];
 			PHP_SHA512_CTX context;
@@ -1821,15 +1809,6 @@ int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signat
 			*signature_length = 32;
 			break;
 		}
-#else
-		case PHAR_SIG_SHA512:
-		case PHAR_SIG_SHA256:
-			if (error) {
-				spprintf(error, 0, "unable to write to phar \"%s\" with requested hash type", phar->fname);
-			}
-
-			return FAILURE;
-#endif
 		case PHAR_SIG_OPENSSL: {
 			unsigned char *sigbuf;
 #ifdef PHAR_HAVE_OPENSSL

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -20,10 +20,7 @@
 #define PHP_SESSION_H
 
 #include "ext/standard/php_var.h"
-
-#if defined(HAVE_HASH_EXT) && !defined(COMPILE_DL_HASH)
-# include "ext/hash/php_hash.h"
-#endif
+#include "ext/hash/php_hash.h"
 
 #define PHP_SESSION_API 20161017
 

--- a/main/internal_functions_win32.c
+++ b/main/internal_functions_win32.c
@@ -116,9 +116,7 @@ static zend_module_entry * const php_builtin_extensions[] = {
 #if HAVE_FTP
 	,phpext_ftp_ptr
 #endif
-#if HAVE_HASH
 	,phpext_hash_ptr
-#endif
 #if HAVE_ICONV
 	,phpext_iconv_ptr
 #endif


### PR DESCRIPTION
The hash extension is always available since PHP-7.4. The symbol HAVE_HASH_EXT is kept for BC reasons and removed in PHP-8.0.

This has already been removed via e632537c83af5186d4cf3f0dacb3102ef850fb88 except the typo of usage  `HAVE_HASH` symbol in win32 functions file... Probably doesn't change much if so far didn't cause issues.

I suggest we keep only config.m4 and config.w32 symbol definitions for BC and remove usages also in PHP-7.4 since it is kind of pointless to check this...

Changelog updated via bbd19a127b7d4cf73c5945f54df59f9a69bfcb62