### PR TITLE
Fix bug #78192 PDO SQLite reset columns on schema changed

### DIFF
--- a/ext/pdo_sqlite/tests/bug78192.phpt
+++ b/ext/pdo_sqlite/tests/bug78192.phpt
@@ -1,0 +1,46 @@
+--TEST--
+PDO SQLite Bug #78192 SegFault when reuse statement after schema change
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_sqlite')) print 'skip not loaded';
+?>
+--FILE--
+<?php
+$connection = new \PDO('sqlite::memory:');
+$connection->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+$connection->query('CREATE TABLE user (id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(255) NOT NULL)');
+
+$stmt = $connection->prepare('INSERT INTO user (id, name) VALUES(:id, :name)');
+$stmt->execute([
+    'id'   => 10,
+    'name' => 'test',
+]);
+
+$stmt = $connection->prepare('SELECT * FROM user WHERE id = :id');
+$stmt->execute(['id' => 10]);
+var_dump($stmt->fetchAll(\PDO::FETCH_ASSOC));
+
+$connection->query('ALTER TABLE user ADD new_col VARCHAR(255)');
+$stmt->execute(['id' => 10]);
+var_dump($stmt->fetchAll(\PDO::FETCH_ASSOC));
+--EXPECT--
+array(1) {
+  [0]=>
+  array(2) {
+    ["id"]=>
+    string(2) "10"
+    ["name"]=>
+    string(4) "test"
+  }
+}
+array(1) {
+  [0]=>
+  array(3) {
+    ["id"]=>
+    string(2) "10"
+    ["name"]=>
+    string(4) "test"
+    ["new_col"]=>
+    NULL
+  }
+}


### PR DESCRIPTION
Reset stmt->columns when column count changed on new execution of prepared statement.

Since PHP 7.2, sqlite3_prepare_v2 is used, which recompile statement on schema changed (and not raise schema changed exception). This behavior will change the result set columns, which can cause a segmentation fault when column count changed.

This fix will reset the loaded columns when the count changed to ensure that there were reloaded.
New columns are now returned on fetch.

Note: If a column name change, but without count change, the columns descriptions is not reloaded.