### PR TITLE
[aarch64] opcache: align to 64-byte boundary

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1365,7 +1365,7 @@ static zend_persistent_script *store_script_in_file_cache(zend_persistent_script
 	memory_used = zend_accel_script_persist_calc(new_persistent_script, NULL, 0, 0);
 
 	/* Allocate memory block */
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(__AVX__) || defined(__SSE2__) || defined(__aarch64__)
 	/* Align to 64-byte boundary */
 	ZCG(mem) = zend_arena_alloc(&CG(arena), memory_used + 64);
 	ZCG(mem) = (void*)(((zend_uintptr_t)ZCG(mem) + 63L) & ~63L);
@@ -1485,12 +1485,12 @@ static zend_persistent_script *cache_script_in_shared_memory(zend_persistent_scr
 	memory_used = zend_accel_script_persist_calc(new_persistent_script, key, key_length, 1);
 
 	/* Allocate shared memory */
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(__AVX__) || defined(__SSE2__) || defined(__aarch64__)
 	/* Align to 64-byte boundary */
 	ZCG(mem) = zend_shared_alloc(memory_used + 64);
 	if (ZCG(mem)) {
 		ZCG(mem) = (void*)(((zend_uintptr_t)ZCG(mem) + 63L) & ~63L);
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__aarch64__)
 		memset(ZCG(mem), 0, memory_used);
 #elif defined(__AVX__)
 		{
@@ -3943,12 +3943,12 @@ static zend_persistent_script* preload_script_in_shared_memory(zend_persistent_s
 	memory_used = zend_accel_script_persist_calc(new_persistent_script, NULL, 0, 1);
 
 	/* Allocate shared memory */
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(__AVX__) || defined(__SSE2__) || defined(__aarch64__)
 	/* Align to 64-byte boundary */
 	ZCG(mem) = zend_shared_alloc(memory_used + 64);
 	if (ZCG(mem)) {
 		ZCG(mem) = (void*)(((zend_uintptr_t)ZCG(mem) + 63L) & ~63L);
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__aarch64__)
 		memset(ZCG(mem), 0, memory_used);
 #elif defined(__AVX__)
 		{

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -931,7 +931,7 @@ int zend_file_cache_script_store(zend_persistent_script *script, int in_shm)
 		return FAILURE;
 	}
 
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(__AVX__) || defined(__SSE2__) || defined(__aarch64__)
 	/* Align to 64-byte boundary */
 	mem = emalloc(script->size + 64);
 	buf = (void*)(((zend_uintptr_t)mem + 63L) & ~63L);
@@ -1579,7 +1579,7 @@ zend_persistent_script *zend_file_cache_script_load(zend_file_handle *file_handl
 	}
 
 	checkpoint = zend_arena_checkpoint(CG(arena));
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(__AVX__) || defined(__SSE2__) || defined(__aarch64__)
 	/* Align to 64-byte boundary */
 	mem = zend_arena_alloc(&CG(arena), info.mem_size + info.str_size + 64);
 	mem = (void*)(((zend_uintptr_t)mem + 63L) & ~63L);
@@ -1640,7 +1640,7 @@ zend_persistent_script *zend_file_cache_script_load(zend_file_handle *file_handl
 			goto use_process_mem;
 		}
 
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(__AVX__) || defined(__SSE2__) || defined(__aarch64__)
 		/* Align to 64-byte boundary */
 		buf = zend_shared_alloc(info.mem_size + 64);
 		buf = (void*)(((zend_uintptr_t)buf + 63L) & ~63L);

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1071,7 +1071,7 @@ zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script
 
 	zend_accel_store_interned_string(script->script.filename);
 
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(__AVX__) || defined(__SSE2__) || defined(__aarch64__)
 	/* Align to 64-byte boundary */
 	ZCG(mem) = (void*)(((zend_uintptr_t)ZCG(mem) + 63L) & ~63L);
 #else

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -517,7 +517,7 @@ uint32_t zend_accel_script_persist_calc(zend_persistent_script *new_persistent_s
 	}
 	ADD_STRING(new_persistent_script->script.filename);
 
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(__AVX__) || defined(__SSE2__) || defined(__aarch64__)
 	/* Align size to 64-byte boundary */
 	new_persistent_script->size = (new_persistent_script->size + 63) & ~63;
 #endif
@@ -537,7 +537,7 @@ uint32_t zend_accel_script_persist_calc(zend_persistent_script *new_persistent_s
 	} ZEND_HASH_FOREACH_END();
 	zend_persist_op_array_calc_ex(&new_persistent_script->script.main_op_array);
 
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(__AVX__) || defined(__SSE2__) || defined(__aarch64__)
 	/* Align size to 64-byte boundary */
 	new_persistent_script->arena_size = (new_persistent_script->arena_size + 63) & ~63;
 #endif


### PR DESCRIPTION
Port to aarch64 the code to 64-bytes align opcache's `persistent_script->arena_mem`.
Tested on aarch64-linux with `make test` on PHP-7.4 and master branches.