### PR TITLE
Clean up files after the tests are run

### DIFF
--- a/ext/standard/tests/file/flock_basic.phpt
+++ b/ext/standard/tests/file/flock_basic.phpt
@@ -9,7 +9,6 @@ Description: PHP supports a portable way of locking complete files
 */
 
 echo "*** Testing flock() fun with file and dir ***\n";
-$file_path = __DIR__;
 
 $lock_file = preg_replace("~\.phpt?$~", null, __FILE__);
 

--- a/ext/standard/tests/file/flock_error.phpt
+++ b/ext/standard/tests/file/flock_error.phpt
@@ -10,7 +10,7 @@ Description: PHP supports a portable way of locking complete files
 
 echo "*** Testing error conditions ***\n";
 
-$file = preg_replace("~\.phpt?$~", null, __FILE__);
+$file = preg_replace("~\.phpt?$~", '.tmp', __FILE__);
 $fp = fopen($file, "w");
 
 /* array of operatons */
@@ -52,7 +52,7 @@ echo "\n*** Done ***\n";
 ?>
 --CLEAN--
 <?php
-$file = __DIR__."/flock.tmp";
+$file = __DIR__."/flock_error.tmp";
 unlink($file);
 ?>
 --EXPECTF--


### PR DESCRIPTION
There is a generated lock file left after running the ext/standard/tests/file/flock_error.phpt and one minor unused variable.

*.tmp files are btw, also Git ignored:
https://github.com/php/php-src/blob/4d07bba919b63e1e94c4994cbdc3a203ee060d01/.gitignore#L19-L20
