### PR TITLE
fix the CLIENT_CONNECT_ATTRS flag, condition to write db info, and add a new connection attribute _server_host

### DIFF
--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -510,6 +510,10 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_updated_connect_flags)(MYSQLND_CONN_DATA *
 	}
 #endif
 
+	if (conn->options->connect_attr && zend_hash_num_elements(conn->options->connect_attr)) {
+		mysql_flags |= CLIENT_CONNECT_ATTRS;
+	}
+
 	DBG_RETURN(mysql_flags);
 }
 /* }}} */
@@ -825,6 +829,7 @@ MYSQLND_METHOD(mysqlnd_conn, connect)(MYSQLND * conn_handle,
 
 	if (PASS == conn->m->local_tx_start(conn, this_func)) {
 		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_client_name", "mysqlnd");
+		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
 		ret = conn->m->connect(conn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 
 		conn->m->local_tx_end(conn, this_func, FAIL);

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -510,9 +510,9 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_updated_connect_flags)(MYSQLND_CONN_DATA *
 	}
 #endif
 
-	//if (conn->options->connect_attr && zend_hash_num_elements(conn->options->connect_attr)) {
-	//	mysql_flags |= CLIENT_CONNECT_ATTRS;
-	//}
+	if (conn->options->connect_attr && zend_hash_num_elements(conn->options->connect_attr)) {
+		mysql_flags |= CLIENT_CONNECT_ATTRS;
+	}
 
 	DBG_RETURN(mysql_flags);
 }
@@ -829,7 +829,7 @@ MYSQLND_METHOD(mysqlnd_conn, connect)(MYSQLND * conn_handle,
 
 	if (PASS == conn->m->local_tx_start(conn, this_func)) {
 		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_client_name", "mysqlnd");
-		//mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
+		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
 		ret = conn->m->connect(conn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 
 		conn->m->local_tx_end(conn, this_func, FAIL);

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -829,8 +829,9 @@ MYSQLND_METHOD(mysqlnd_conn, connect)(MYSQLND * conn_handle,
 
 	if (PASS == conn->m->local_tx_start(conn, this_func)) {
 		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_client_name", "mysqlnd");
-        if(hostname.l>0)
+        if(hostname.l>0) {
             mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
+        }
 		ret = conn->m->connect(conn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 
 		conn->m->local_tx_end(conn, this_func, FAIL);

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -657,7 +657,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, connect)(MYSQLND_CONN_DATA * conn,
 		password.s = "";
 		password.l = 0;
 	}
-	if (!database.s) {
+	if (!database.s || !database.s[0]) {
 		DBG_INF_FMT("no db given, using empty string");
 		database.s = "";
 		database.l = 0;

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -829,7 +829,7 @@ MYSQLND_METHOD(mysqlnd_conn, connect)(MYSQLND * conn_handle,
 
 	if (PASS == conn->m->local_tx_start(conn, this_func)) {
 		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_client_name", "mysqlnd");
-		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
+		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", "hostname");
 		ret = conn->m->connect(conn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 
 		conn->m->local_tx_end(conn, this_func, FAIL);

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -829,7 +829,8 @@ MYSQLND_METHOD(mysqlnd_conn, connect)(MYSQLND * conn_handle,
 
 	if (PASS == conn->m->local_tx_start(conn, this_func)) {
 		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_client_name", "mysqlnd");
-		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", "hostname");
+        if(hostname.l>0)
+            mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
 		ret = conn->m->connect(conn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 
 		conn->m->local_tx_end(conn, this_func, FAIL);

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -510,9 +510,9 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_updated_connect_flags)(MYSQLND_CONN_DATA *
 	}
 #endif
 
-	if (conn->options->connect_attr && zend_hash_num_elements(conn->options->connect_attr)) {
-		mysql_flags |= CLIENT_CONNECT_ATTRS;
-	}
+	//if (conn->options->connect_attr && zend_hash_num_elements(conn->options->connect_attr)) {
+	//	mysql_flags |= CLIENT_CONNECT_ATTRS;
+	//}
 
 	DBG_RETURN(mysql_flags);
 }
@@ -829,7 +829,7 @@ MYSQLND_METHOD(mysqlnd_conn, connect)(MYSQLND * conn_handle,
 
 	if (PASS == conn->m->local_tx_start(conn, this_func)) {
 		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_client_name", "mysqlnd");
-		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
+		//mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
 		ret = conn->m->connect(conn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 
 		conn->m->local_tx_end(conn, this_func, FAIL);

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -546,6 +546,7 @@ size_t php_mysqlnd_auth_write(MYSQLND_CONN_DATA * conn, void * _packet)
 		}
 
 		if (packet->db_len > 0) {
+            /* CLIENT_CONNECT_WITH_DB should have been set if !is_change_user_packet*/
 			size_t real_db_len = MIN(MYSQLND_MAX_ALLOWED_DB_LEN, packet->db_len);
 			memcpy(p, packet->db, real_db_len);
 			p+= real_db_len;

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -545,8 +545,7 @@ size_t php_mysqlnd_auth_write(MYSQLND_CONN_DATA * conn, void * _packet)
 			p+= packet->auth_data_len;
 		}
 
-		if (packet->db) {
-			/* CLIENT_CONNECT_WITH_DB should have been set */
+		if ((packet->client_flags & CLIENT_CONNECT_WITH_DB) && (packet->db_len > 0)) {
 			size_t real_db_len = MIN(MYSQLND_MAX_ALLOWED_DB_LEN, packet->db_len);
 			memcpy(p, packet->db, real_db_len);
 			p+= real_db_len;

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -545,7 +545,7 @@ size_t php_mysqlnd_auth_write(MYSQLND_CONN_DATA * conn, void * _packet)
 			p+= packet->auth_data_len;
 		}
 
-		if ((packet->client_flags & CLIENT_CONNECT_WITH_DB) && (packet->db_len > 0)) {
+		if (packet->db_len > 0) {
 			size_t real_db_len = MIN(MYSQLND_MAX_ALLOWED_DB_LEN, packet->db_len);
 			memcpy(p, packet->db, real_db_len);
 			p+= real_db_len;


### PR DESCRIPTION
1. The connection attribute feature in mysqlnd did not work properly since the flag CLIENT_CONNECT_ATTRS was never set. PR to fix the problem.
2. After CLIENT_CONNECT_ATTRS is set, it exposes another problem when there is no db in connection string, it will cause handshake fail, since the logic is to check packet->db!=NULL, but the fact is when DB is not set, this field is !=null, but contains empty string. Related code snippet is as follows:
//before write packet, the logic to set flag and field
	if (!database.s) {
		DBG_INF_FMT("no db given, using empty string");
		database.s = "";
		database.l = 0;
	} else {
		mysql_flags |= CLIENT_CONNECT_WITH_DB;
	}
//set packet field
		auth_packet.db		= db;
		auth_packet.db_len		= db_len;

//logic to write db info before change:
		if (packet->db) {
			...
			*p++= '\0';
		} 
		/* no \0 for no DB */

3. Add a new connection attribute _server_host which will give the host name information. This field is needed for the scenario such as when connect to Azure MySQL database, previously it required the user name in the format of user@server or server%user. In order to get rid of the need of server name in the user name information, we need the support of the connection attribute _server_host. This attribute has been already added in driver MariaDB Connector C and MariaDB Connector J.