### PR TITLE
Fix #78212: Segfault in built-in webserver

### DIFF
--- a/win32/wsyslog.c
+++ b/win32/wsyslog.c
@@ -95,6 +95,10 @@ void vsyslog(int priority, const char *message, va_list args)
 	DWORD evid;
 	wchar_t *strsw[2];
 
+	/* default event source */
+	if (INVALID_HANDLE_VALUE == PW32G(log_source))
+		openlog("php", LOG_PID, LOG_SYSLOG);
+
 	switch (priority) {			/* translate UNIX type into NT type */
 		case LOG_ALERT:
 			etype = EVENTLOG_ERROR_TYPE;


### PR DESCRIPTION
Since syslog's ident and facility parameters have been added to
config[1], vsyslog() segfaults on Windows, if openlog() has not been
called before.  We bring back the removed lines to fix this.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=2475337bd8a0fad0dac03db3f5e7e9d331d53653>