### PR TITLE
Remove HAVE_ERRNO_H from libgd

### DIFF
--- a/ext/gd/libgd/gdkanji.c
+++ b/ext/gd/libgd/gdkanji.c
@@ -11,9 +11,7 @@
 #include <stdarg.h>
 #if defined(HAVE_ICONV_H) || defined(HAVE_ICONV)
 #include <iconv.h>
-#ifdef HAVE_ERRNO_H
 #include <errno.h>
-#endif
 #endif
 
 #if defined(HAVE_ICONV_H) && !defined(HAVE_ICONV)
@@ -349,11 +347,9 @@ do_convert (unsigned char *to, unsigned char *from, const char *code)
   if ((cd = iconv_open (EUCSTR, code)) == (iconv_t) - 1)
     {
       error ("iconv_open() error");
-#ifdef HAVE_ERRNO_H
       if (errno == EINVAL)
 	error ("invalid code specification: \"%s\" or \"%s\"",
 	       EUCSTR, code);
-#endif
       strcpy ((char *) to, (const char *) from);
       return;
     }
@@ -363,7 +359,6 @@ do_convert (unsigned char *to, unsigned char *from, const char *code)
 
   if ((int) iconv(cd, (char **) &from, &from_len, (char **) &to, &to_len) == -1)
     {
-#ifdef HAVE_ERRNO_H
       if (errno == EINVAL)
 	error ("invalid end of input string");
       else if (errno == EILSEQ)
@@ -371,7 +366,6 @@ do_convert (unsigned char *to, unsigned char *from, const char *code)
       else if (errno == E2BIG)
 	error ("output buffer overflow at do_convert()");
       else
-#endif
 	error ("something happen");
       strcpy ((char *) to, (const char *) from);
       return;


### PR DESCRIPTION
The check for errno.h has been removed via 50b9ef8d9435d23be40cea7fb484a02e99fdb617

Upstream libgd library is also patched via
https://github.com/libgd/libgd/commit/1e7f93922fb3adf9f131d7e94aa13386062ffe11

Why removing the check?
- In PHP 7.3 with disabled extensions (./configure --disable-all) this symbol isn't defined.
- In PHP 7.3 with ./configure --disable-all --enable-sockets this symbol is defined

Therefore the sync...