### PR TITLE
Fix ast export in array

### DIFF
--- a/Zend/tests/assert/expect_020.phpt
+++ b/Zend/tests/assert/expect_020.phpt
@@ -1,0 +1,17 @@
+--TEST--
+AST pretty-peinter
+--INI--
+zend.assertions=1
+assert.exception=0
+--FILE--
+<?php
+assert(0 && ($a = function () {
+	$var = 'test';
+	$str = "$var, $var[1], {$var}[], {$var[1]}[], ${var}[], ${var[1]}[]";
+}));
+?>
+--EXPECTF--
+Warning: assert(): assert(0 && ($a = function () {
+    $var = 'test';
+    $str = "$var, {$var[1]}, {$var}[], {$var[1]}[], {$var}[], {$var[1]}[]";
+})) failed in %sexpect_020.php on line %d

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1062,6 +1062,13 @@ static ZEND_COLD int zend_ast_valid_var_name(const char *s, size_t len)
 	return 1;
 }
 
+static ZEND_COLD int zend_ast_var_needs_braces(char ch)
+{
+	if (ch != '[' && !zend_ast_valid_var_char(ch))
+		return 0;
+	return 1;
+}
+
 static ZEND_COLD void zend_ast_export_var(smart_str *str, zend_ast *ast, int priority, int indent)
 {
 	if (ast->kind == ZEND_AST_ZVAL) {
@@ -1109,7 +1116,7 @@ static ZEND_COLD void zend_ast_export_encaps_list(smart_str *str, char quote, ze
 		           ast->child[0]->kind == ZEND_AST_ZVAL &&
 		           (i + 1 == list->children ||
 		            list->child[i + 1]->kind != ZEND_AST_ZVAL ||
-		            !zend_ast_valid_var_char(
+		            !zend_ast_var_needs_braces(
 		                *Z_STRVAL_P(
 		                    zend_ast_get_zval(list->child[i + 1]))))) {
 			zend_ast_export_ex(str, ast, 0, indent);

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1759,6 +1759,8 @@ simple_list:
 				zend_ast_export_ex(str, ast->child[1], 80, indent);
 				smart_str_appends(str, " => ");
 			}
+			if (ast->attr)
+				smart_str_appendc(str, '&');
 			zend_ast_export_ex(str, ast->child[0], 80, indent);
 			break;
 		case ZEND_AST_NEW:


### PR DESCRIPTION
zend_ast_export function has a bug when export an array with reference.
It misses reference sign (&).

Test case:
```
<?php
$var = 1;
$arr = array(&$var, $var);
```
Expected result:
```
$var = 1;
$arr = [&$var, $var];
```
Actual result:
```
$var = 1;
$arr = [$var, $var];
```