### PR TITLE
Base Convert changes for PHP 7.4

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -850,24 +850,33 @@ PHPAPI int _php_math_basetozval(zval *arg, int base, zval *ret)
 {
 	zend_long num = 0;
 	double fnum = 0;
-	zend_long i;
 	int mode = 0;
-	char c, *s;
+	char c, *s, *e;
 	zend_long cutoff;
 	int cutlim;
-	int lastchar = 0;
 	int invalidchars = 0;
 
-	if (Z_TYPE_P(arg) != IS_STRING || base < 2 || base > 36) {
+	if (Z_TYPE_P(arg) != IS_STRING || base < 1 || base > 36) {
 		return FAILURE;
 	}
-
 	s = Z_STRVAL_P(arg);
+	e = s + Z_STRLEN_P(arg);
+
+	/* Skip leading whitespace */
+	while (s < e && isspace(*s)) s++;
+	/* Skip trailing whitespace */
+	while (s < e && isspace(*(e-1))) e--;
+
+	if (e - s >= 2) {
+			if (base == 16 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+			if (base == 8 && s[0] == '0' && (s[1] == 'o' || s[1] == 'O')) s += 2;
+			if (base == 2 && s[0] == '0' && (s[1] == 'b' || s[1] == 'B')) s += 2;
+	}
 
 	cutoff = ZEND_LONG_MAX / base;
 	cutlim = ZEND_LONG_MAX % base;
 
-	for (i = Z_STRLEN_P(arg); i > 0; i--) {
+	while (s < e) {
 		c = *s++;
 
 		/* might not work for EBCDIC */
@@ -877,38 +886,14 @@ PHPAPI int _php_math_basetozval(zval *arg, int base, zval *ret)
 			c -= 'A' - 10;
 		else if (c >= 'a' && c <= 'z')
 			c -= 'a' - 10;
-		else if (isspace(c)) {
-			if (num == 0 && fnum == 0) {
-				continue;
-			}
-			lastchar = 1;
-			continue;
-		} else {
+		else {
 			invalidchars++;
 			continue;
 		}
-
-		if (lastchar == 1 && c > 0 && c < base) {
-			invalidchars++;
-		}
-		lastchar = 0;
-
 
 		if (c >= base) {
-			if (*(s-2) == '0' && num == 0) {
-				if (base == 16 && c == 33) { /* allow the second char to be x */
-					continue;
-				}
-				if (base == 8 && c == 24) { /* allow the second char to be o */
-					continue;
-				}
-				if (base == 2 && c == 11) { /* allow the second char to be b */
-					continue;
-				}
-			}
-
-				invalidchars++;
-				continue;
+			invalidchars++;
+			continue;
 		}
 
 		switch (mode) {

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -856,7 +856,7 @@ PHPAPI int _php_math_basetozval(zval *arg, int base, zval *ret)
 	int cutlim;
 	int invalidchars = 0;
 
-	if (Z_TYPE_P(arg) != IS_STRING || base < 1 || base > 36) {
+	if (Z_TYPE_P(arg) != IS_STRING || base < 2 || base > 36) {
 		return FAILURE;
 	}
 	s = Z_STRVAL_P(arg);

--- a/ext/standard/tests/math/base_convert_basic.phpt
+++ b/ext/standard/tests/math/base_convert_basic.phpt
@@ -28,119 +28,249 @@ for ($f= 0; $f < count($frombase); $f++) {
 	}
 }
 ?>
---EXPECT--
+--EXPECTF--
 ...from base is 2
 ......to base is 2
 .........value= 10 res = 10
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 10
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 ......to base is 8
 .........value= 10 res = 2
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 2
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 ......to base is 10
 .........value= 10 res = 2
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 2
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 ......to base is 16
 .........value= 10 res = 2
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 2
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 ......to base is 36
 .........value= 10 res = 2
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 0
 .........value= 10 res = 2
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 27 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 0
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 0
 
 ...from base is 8
 ......to base is 2
 .........value= 10 res = 1000
 .........value= 27 res = 10111
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 11
 .........value= 3 res = 11
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 101
 .........value= 10 res = 1000
 .........value= 27 res = 10111
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 11
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 101
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 11
 ......to base is 8
 .........value= 10 res = 10
 .........value= 27 res = 27
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 .........value= 3 res = 3
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 5
 .........value= 10 res = 10
 .........value= 27 res = 27
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 10
 .........value= 10 res = 8
 .........value= 27 res = 23
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 .........value= 3 res = 3
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 5
 .........value= 10 res = 8
 .........value= 27 res = 23
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 16
 .........value= 10 res = 8
 .........value= 27 res = 17
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 .........value= 3 res = 3
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 5
 .........value= 10 res = 8
 .........value= 27 res = 17
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 36
 .........value= 10 res = 8
 .........value= 27 res = n
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
 .........value= 3 res = 3
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 95 res = 5
 .........value= 10 res = 8
 .........value= 27 res = n
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 39 res = 3
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 
 ...from base is 10
@@ -153,7 +283,11 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 10 res = 1010
 .........value= 27 res = 11011
 .........value= 39 res = 100111
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 101
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 11
 ......to base is 8
 .........value= 10 res = 12
@@ -164,7 +298,11 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 10 res = 12
 .........value= 27 res = 33
 .........value= 39 res = 47
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 10
 .........value= 10 res = 10
@@ -175,7 +313,11 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 10 res = 10
 .........value= 27 res = 27
 .........value= 39 res = 39
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 16
 .........value= 10 res = a
@@ -186,7 +328,11 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 10 res = a
 .........value= 27 res = 1b
 .........value= 39 res = 27
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 36
 .........value= 10 res = a
@@ -197,7 +343,11 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 10 res = a
 .........value= 27 res = r
 .........value= 39 res = 13
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 5F res = 5
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 
 ...from base is 16
@@ -211,6 +361,8 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 27 res = 100111
 .........value= 39 res = 111001
 .........value= 5F res = 1011111
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 11
 ......to base is 8
 .........value= 10 res = 20
@@ -222,6 +374,8 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 27 res = 47
 .........value= 39 res = 71
 .........value= 5F res = 137
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 10
 .........value= 10 res = 16
@@ -233,6 +387,8 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 27 res = 39
 .........value= 39 res = 57
 .........value= 5F res = 95
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 16
 .........value= 10 res = 10
@@ -244,6 +400,8 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 27 res = 27
 .........value= 39 res = 39
 .........value= 5F res = 5f
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 ......to base is 36
 .........value= 10 res = g
@@ -255,6 +413,8 @@ for ($f= 0; $f < count($frombase); $f++) {
 .........value= 27 res = 13
 .........value= 39 res = 1l
 .........value= 5F res = 2n
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 .........value= 3XYZ res = 3
 
 ...from base is 36

--- a/ext/standard/tests/math/base_convert_improvements.phpt
+++ b/ext/standard/tests/math/base_convert_improvements.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test base_convert() - see https://wiki.php.net/rfc/base_convert_improvements
+--FILE--
+<?php
+?>
+--EXPECTF--
+255
+16
+255
+255
+255
+255
+255
+7
+10
+=======================================
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 18
+15
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 19
+61695
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 20
+511
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 21
+0
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 22
+7

--- a/ext/standard/tests/math/base_convert_improvements.phpt
+++ b/ext/standard/tests/math/base_convert_improvements.phpt
@@ -33,13 +33,13 @@ echo base_convert("0o7" , 9, 10) . "\n";
 7
 10
 =======================================
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 18
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 15
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 19
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 61695
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 20
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 511
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 21
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 0
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /tmp/test.php on line 22
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 7

--- a/ext/standard/tests/math/base_convert_improvements.phpt
+++ b/ext/standard/tests/math/base_convert_improvements.phpt
@@ -19,8 +19,8 @@ echo base_convert('fg', 16, 10);
 echo base_convert('f 0xff ', 16, 10);
 echo base_convert('1xff ', 16, 10);
 echo base_convert(chr(0), 16, 10);
-echo base_convert("0o7" , 9, 10) . "\n";
-
+echo base_convert("0o7" , 9, 10);
+echo base_convert("0 0" , 9, 10) . "\n";
 ?>
 --EXPECTF--
 255
@@ -43,3 +43,5 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 0
 Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 7
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+0

--- a/ext/standard/tests/math/base_convert_improvements.phpt
+++ b/ext/standard/tests/math/base_convert_improvements.phpt
@@ -2,6 +2,25 @@
 Test base_convert() - see https://wiki.php.net/rfc/base_convert_improvements
 --FILE--
 <?php
+echo base_convert('FF', 16, 10) . "\n";
+echo base_convert('20', 8, 10) . "\n";
+echo base_convert('0xFf', 16, 10) . "\n";
+echo base_convert('0FF', 16, 10) . "\n";
+echo base_convert(" 0xFF\t\n" , 16, 10) . "\n";
+echo base_convert(" 0xFF\t\n" , 16, 10) . "\n";
+echo base_convert("\r\nFF\t\n" , 16, 10) . "\n";
+echo base_convert("0o7" , 8, 10) . "\n";
+echo base_convert("0b1010" , 2, 10) . "\n";
+
+echo "=======================================";
+
+// These should fail
+echo base_convert('fg', 16, 10);
+echo base_convert('f 0xff ', 16, 10);
+echo base_convert('1xff ', 16, 10);
+echo base_convert(chr(0), 16, 10);
+echo base_convert("0o7" , 9, 10) . "\n";
+
 ?>
 --EXPECTF--
 255

--- a/ext/standard/tests/math/base_convert_variation1.phpt
+++ b/ext/standard/tests/math/base_convert_variation1.phpt
@@ -90,24 +90,36 @@ string(1) "1"
 string(2) "14"
 
 -- Iteration 4 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(2) "14"
 
 -- Iteration 5 --
 string(11) "17777777777"
 
 -- Iteration 6 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(3) "151"
 
 -- Iteration 7 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(3) "151"
 
 -- Iteration 8 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(7) "4553207"
 
 -- Iteration 9 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(7) "4553207"
 
 -- Iteration 10 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(1) "5"
 
 -- Iteration 11 --
@@ -137,15 +149,23 @@ string(1) "0"
 -- Iteration 19 --
 
 Notice: Array to string conversion in %s on line %d
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(1) "0"
 
 -- Iteration 20 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(1) "0"
 
 -- Iteration 21 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(1) "0"
 
 -- Iteration 22 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 string(1) "0"
 
 -- Iteration 23 --
@@ -155,5 +175,7 @@ string(1) "0"
 string(1) "0"
 
 -- Iteration 25 --
-string(%d) "%d"
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+string(1) "5"
 ===Done===

--- a/ext/standard/tests/math/bindec_basic.phpt
+++ b/ext/standard/tests/math/bindec_basic.phpt
@@ -33,22 +33,44 @@ for ($i = 0; $i < count($values); $i++) {
 	var_dump($res);
 }
 ?>
---EXPECT--
+--EXPECTF--
 int(455)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(32766)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(5)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(129)
 int(455)
 int(224)
 int(2147483647)
 float(2147483648)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(129)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(13)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(13)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(26)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(6)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 int(1)
 int(0)

--- a/ext/standard/tests/math/bindec_basic_64bit.phpt
+++ b/ext/standard/tests/math/bindec_basic_64bit.phpt
@@ -33,22 +33,44 @@ for ($i = 0; $i < count($values); $i++) {
 	var_dump($res);
 }
 ?>
---EXPECT--
+--EXPECTF--
 int(455)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(32766)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(5)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(129)
 int(455)
 int(224)
 int(2147483647)
 int(2147483648)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(129)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(13)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(13)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(26)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(6)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 int(1)
 int(0)

--- a/ext/standard/tests/math/bindec_variation1.phpt
+++ b/ext/standard/tests/math/bindec_variation1.phpt
@@ -89,24 +89,38 @@ int(0)
 int(1)
 
 -- Iteration 3 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1)
 
 -- Iteration 4 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 5 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2)
 
 -- Iteration 6 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2)
 
 -- Iteration 7 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(8)
 
 -- Iteration 8 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1)
 
 -- Iteration 9 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 10 --
@@ -136,15 +150,23 @@ int(0)
 -- Iteration 18 --
 
 Notice: Array to string conversion in %s on line %d
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 19 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 20 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 21 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 22 --
@@ -154,5 +176,7 @@ int(0)
 int(0)
 
 -- Iteration 24 --
-int(%d)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+int(0)
 ===Done===

--- a/ext/standard/tests/math/bindec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/bindec_variation1_64bit.phpt
@@ -89,24 +89,38 @@ int(0)
 int(1)
 
 -- Iteration 3 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1)
 
 -- Iteration 4 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 5 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2)
 
 -- Iteration 6 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2)
 
 -- Iteration 7 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(8)
 
 -- Iteration 8 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1)
 
 -- Iteration 9 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 10 --
@@ -136,15 +150,23 @@ int(0)
 -- Iteration 18 --
 
 Notice: Array to string conversion in %s on line %d
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 19 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 20 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 21 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 22 --
@@ -154,5 +176,7 @@ int(0)
 int(0)
 
 -- Iteration 24 --
-int(%d)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+int(0)
 ===Done===

--- a/ext/standard/tests/math/hexdec.phpt
+++ b/ext/standard/tests/math/hexdec.phpt
@@ -14,11 +14,17 @@ var_dump((float)hexdec("1234500001"));
 var_dump((float)hexdec("17fffffff"));
 
 ?>
---EXPECT--
+--EXPECTF--
 int(74565)
 int(74565)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(74565)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(74565)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(74565)
 float(78187069441)
 float(6442450943)

--- a/ext/standard/tests/math/hexdec_basic.phpt
+++ b/ext/standard/tests/math/hexdec_basic.phpt
@@ -29,7 +29,7 @@ for ($i = 0; $i < count($values); $i++) {
 	var_dump($res);
 }
 ?>
---EXPECT--
+--EXPECTF--
 int(18433668)
 int(126895953)
 float(142929835591)
@@ -38,9 +38,13 @@ int(1194684)
 int(7904751)
 int(2147483647)
 float(2147483648)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1194684)
 int(3215381)
 int(3215381)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(3215379)
 int(51446064)
 int(18279)

--- a/ext/standard/tests/math/hexdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_basic_64bit.phpt
@@ -34,7 +34,7 @@ foreach($values as $value) {
 
 ?>
 ===Done===
---EXPECT--
+--EXPECTF--
 *** Testing hexdec() : basic functionality ***
 
 -- hexdec 1194684 --
@@ -62,6 +62,8 @@ int(2147483647)
 int(2147483648)
 
 -- hexdec 0x123XYZABC --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1194684)
 
 -- hexdec 311015 --
@@ -71,6 +73,8 @@ int(3215381)
 int(3215381)
 
 -- hexdec 31101.3 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(3215379)
 
 -- hexdec 3110130 --

--- a/ext/standard/tests/math/hexdec_variation1.phpt
+++ b/ext/standard/tests/math/hexdec_variation1.phpt
@@ -96,6 +96,8 @@ int(1)
 int(74565)
 
 -- Iteration 4 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(9029)
 
 -- Iteration 5 --
@@ -105,18 +107,26 @@ float(285960729237)
 float(285960729238)
 
 -- Iteration 7 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(261)
 
 -- Iteration 8 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(261)
 
 -- Iteration 9 --
 float(20015998341120)
 
 -- Iteration 10 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 float(1250999896553)
 
 -- Iteration 11 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(5)
 
 -- Iteration 12 --
@@ -146,15 +156,23 @@ int(0)
 -- Iteration 20 --
 
 Notice: Array to string conversion in %s on line %d
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(170)
 
 -- Iteration 21 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2748)
 
 -- Iteration 22 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2748)
 
 -- Iteration 23 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2748)
 
 -- Iteration 24 --
@@ -164,5 +182,7 @@ int(0)
 int(0)
 
 -- Iteration 26 --
-%s
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+int(970453)
 ===Done===

--- a/ext/standard/tests/math/hexdec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_variation1_64bit.phpt
@@ -96,6 +96,8 @@ int(1)
 int(74565)
 
 -- Iteration 4 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(9029)
 
 -- Iteration 5 --
@@ -105,18 +107,26 @@ int(285960729237)
 int(285960729238)
 
 -- Iteration 7 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(261)
 
 -- Iteration 8 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(261)
 
 -- Iteration 9 --
 int(20015998341120)
 
 -- Iteration 10 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1250999896553)
 
 -- Iteration 11 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(5)
 
 -- Iteration 12 --
@@ -146,15 +156,23 @@ int(0)
 -- Iteration 20 --
 
 Notice: Array to string conversion in %s on line %d
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(170)
 
 -- Iteration 21 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2748)
 
 -- Iteration 22 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2748)
 
 -- Iteration 23 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(2748)
 
 -- Iteration 24 --
@@ -164,5 +182,7 @@ int(0)
 int(0)
 
 -- Iteration 26 --
-%s
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+int(970453)
 ===Done===

--- a/ext/standard/tests/math/octdec_basic.phpt
+++ b/ext/standard/tests/math/octdec_basic.phpt
@@ -29,19 +29,30 @@ for ($i = 0; $i < count($values); $i++) {
 	var_dump($res);
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(14489)
 int(253)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(36947879)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(4618484)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(4104)
 int(5349)
 int(342391)
 int(375)
 int(2147483647)
 float(2147483648)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(668)
 int(5349)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(102923)
 int(823384)
 int(1)

--- a/ext/standard/tests/math/octdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/octdec_basic_64bit.phpt
@@ -33,20 +33,32 @@ for ($i = 0; $i < count($values); $i++) {
 }
 ?>
 ===Done===
---EXPECT--
+--EXPECTF--
 *** Testing octdec() : basic functionality ***
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(14489)
 int(253)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(36947879)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(4618484)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(4104)
 int(5349)
 int(342391)
 int(375)
 int(2147483647)
 int(2147483648)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(668)
 int(5349)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(102923)
 int(823384)
 int(1)

--- a/ext/standard/tests/math/octdec_variation1.phpt
+++ b/ext/standard/tests/math/octdec_variation1.phpt
@@ -92,27 +92,43 @@ int(1)
 int(5349)
 
 -- Iteration 4 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1253)
 
 -- Iteration 5 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1134037)
 
 -- Iteration 6 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(1134038)
 
 -- Iteration 7 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(69)
 
 -- Iteration 8 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(69)
 
 -- Iteration 9 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(175304192)
 
 -- Iteration 10 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(342391)
 
 -- Iteration 11 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(5)
 
 -- Iteration 12 --
@@ -142,15 +158,23 @@ int(0)
 -- Iteration 20 --
 
 Notice: Array to string conversion in %s on line %d
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 21 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 22 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 23 --
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
 int(0)
 
 -- Iteration 24 --
@@ -160,5 +184,7 @@ int(0)
 int(0)
 
 -- Iteration 26 --
-int(%d)
+
+Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
+int(5)
 ---Done---


### PR DESCRIPTION
See https://wiki.php.net/rfc/base_convert_improvements

Old tests are updated for the deprecated error.
These will have to be removed for PHP8

ext/standard/tests/math/base_convert_improvements.phpt contains the new
tests

This takes over from the original PR and contains only the deprecated chars error