### PR TITLE
Remove HAVE_LIMITS_H check in timelib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -434,7 +434,6 @@ fcntl.h \
 grp.h \
 ieeefp.h \
 langinfo.h \
-limits.h \
 locale.h \
 malloc.h \
 monetary.h \

--- a/ext/date/lib/timelib_private.h
+++ b/ext/date/lib/timelib_private.h
@@ -68,10 +68,7 @@
 #endif
 
 #include <stdio.h>
-
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #define TIMELIB_SECOND   1
 #define TIMELIB_MINUTE   2

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -58,7 +58,6 @@
 #define HAVE_LIBDL 1
 #define HAVE_GETTIMEOFDAY 1
 #define HAVE_PUTENV 1
-#define HAVE_LIMITS_H 1
 #define HAVE_TZSET 1
 #undef HAVE_FLOCK
 #define HAVE_ALLOCA 1


### PR DESCRIPTION
The limits.h header is part of the C89 and is today available everywhere. There is no need to check for presence of this header anymore.

The timelib has already been patched upstream via
https://github.com/derickr/timelib/pull/43
except not released yet

PHP extensions out there shouldn't rely on symbols defined during the build anyway and neither they do on this particular symbol anymore in most cases. (Has been checked).

May I request we ditch this ancient check also in PHP 7.4? It is one of the very last checks of the pre-C89 stuff. Let me know. Thank you.