### PR TITLE
Remove HAVE_DEV_ARANDOM

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -329,14 +329,6 @@ else
   AC_MSG_RESULT(no)
 fi
 
-AC_MSG_CHECKING(whether /dev/arandom exists)
-if test -r "/dev/arandom" && test -c "/dev/arandom"; then
-  AC_DEFINE([HAVE_DEV_ARANDOM], 1, [Define if the target system has /dev/arandom device])
-  AC_MSG_RESULT(yes)
-else
-  AC_MSG_RESULT(no)
-fi
-
 AC_ARG_ENABLE([gcc-global-regs],
   [AS_HELP_STRING([--disable-gcc-global-regs],
     [whether to enable GCC global register variables])],


### PR DESCRIPTION
The /dev/arandom check is not needed anymore since the implementations of:
3467526a65bfb15eaf9ec49a0b5673b84e26bca4
and
6554f721f770c99037f07d465a7d610568576ce4

The /dev/arandom device is also not available on every system so checking it for the PHP extensions out there is not reliable.