### PR TITLE
Remove check for ApplicationServices/ApplicationServices.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -420,7 +420,6 @@ AC_CHECK_HEADERS([ \
 inttypes.h \
 stdint.h \
 dirent.h \
-ApplicationServices/ApplicationServices.h \
 sys/param.h \
 sys/types.h \
 sys/time.h \


### PR DESCRIPTION
The symbol HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H is not used and check not needed.