### PR TITLE
Remove unused check for struct cmsghdr

### DIFF
--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -4,18 +4,6 @@ PHP_ARG_ENABLE([sockets],
     [Enable sockets support])])
 
 if test "$PHP_SOCKETS" != "no"; then
-  dnl Check for struct cmsghdr
-  AC_CACHE_CHECK([for struct cmsghdr], ac_cv_cmsghdr,
-  [
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/types.h>
-#include <sys/socket.h>]], [[struct cmsghdr s; s]])], [ac_cv_cmsghdr=yes], [ac_cv_cmsghdr=no])
-  ])
-
-  if test "$ac_cv_cmsghdr" = yes; then
-    AC_DEFINE(HAVE_CMSGHDR,1,[Whether you have struct cmsghdr])
-  fi
-
   AC_CHECK_FUNCS([hstrerror if_nametoindex if_indextoname])
   AC_CHECK_HEADERS([netinet/tcp.h sys/un.h sys/sockio.h])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[


### PR DESCRIPTION
The result of this check is to whether to define the HAVE_CMSGHDR symbol or not. The HAVE_CMSGHDR is never used in the code and it has been removed via 90289924c031c5b0b2aa1f99ecf317640c926a62.

P.S: the check is most likely not needed to be used in the code since there is a check for the presence of the header sys/socket.h...

* https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html