### PR TITLE
Remove not needed checks for functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -588,7 +588,6 @@ alphasort \
 asctime_r \
 chroot \
 ctime_r \
-cuserid \
 crypt \
 explicit_memset \
 flock \
@@ -621,7 +620,6 @@ link \
 localtime_r \
 lockf \
 lchown \
-lrand48 \
 mbrlen \
 memmove \
 mkstemp \
@@ -632,7 +630,6 @@ poll \
 ptsname \
 putenv \
 realpath \
-random \
 rand_r \
 scandir \
 setitimer \
@@ -642,13 +639,10 @@ setvbuf \
 shutdown \
 sigprocmask \
 sin \
-srand48 \
-srandom \
 statfs \
 statvfs \
 std_syslog \
 strcasecmp \
-strdup \
 strerror \
 strfmon \
 strnlen \

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -80,7 +80,6 @@
 #endif
 #define HAVE_SHUTDOWN 1
 #define HAVE_STRCASECMP 1
-#define HAVE_STRDUP 1
 #define HAVE_STRERROR 1
 #define HAVE_TEMPNAM 1
 #define HAVE_UTIME 1
@@ -98,7 +97,6 @@
 #undef HAVE_KILL
 #define HAVE_GETPID 1
 #define HAVE_LIBM 1
-#define HAVE_CUSERID 0
 #undef HAVE_RINT
 #define SIZEOF_SHORT 2
 /* int and long are stll 32bit in 64bit compiles */


### PR DESCRIPTION
The following functions don't need to be checked anymore since they are either not used across the code or the symbols aren't used anymore:
- cuserid (not used)
- lrand48 (not used and removed via
  6d6ef7aacc7f9b17709d2f93b70b359c75011f89)
- random (check is not used)
- srand48 (not used)
- srandom (not used)
- strdup (check is not used)

and the unused check symbols:
- HAVE_CUSERID
- HAVE_LRAND48
- HAVE_RANDOM
- HAVE_SRAND48
- HAVE_SRANDOM
- HAVE_STRDUP

Also extensions out there don't rely on these after a quick check... Thanks.