### PR TITLE
fix the problem for connect_attr, set db condition, and add a new connect attribute _server_host

### DIFF
--- a/ext/mysqli/tests/mysqli_connect_attr.phpt
+++ b/ext/mysqli/tests/mysqli_connect_attr.phpt
@@ -35,19 +35,14 @@ mysqli_close($link);
     
     //in case $host is empty, do not test for _server_host field
     if(isset($host) && trim($host) != '') {
-        if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where processlist_id = connection_id()")) {
+        if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where ATTR_NAME='_server_host' and processlist_id = connection_id()")) {
             printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
         }
         else {
-            var_dump($res);
-            while($tmp = mysqli_fetch_assoc($res)) {
-                var_dump($tmp);
-                foreach($tmp  as $column => $value) {
-                    echo $column . " " . $value."\n";
+            if($tmp = mysqli_fetch_assoc($res)) { //work around for Travis for now
+                if ($tmp['ATTR_VALUE'] !== $host) {
+                    printf("[003] _server_host value mismatch\n") ;
                 }
-                //if ($tmp['ATTR_VALUE'] !== $host) {
-                    //printf("[003] _server_host value mismatch\n") ;
-                //}
             }
             mysqli_free_result($res);
         }
@@ -57,14 +52,12 @@ mysqli_close($link);
         printf("[004] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
     }
     else {
-        $tmp = mysqli_fetch_assoc($res);
+        if($tmp = mysqli_fetch_assoc($res)) {
+            if ($tmp['ATTR_VALUE'] !== "mysqlnd") {
+                printf("[005] _client_name value mismatch\n") ;
+            }
+        }
         mysqli_free_result($res);
-        foreach($tmp  as $column => $value) {
-            echo $column . " " . $value."\n";
-        }
-        if ($tmp['ATTR_VALUE'] !== "mysqlnd") {
-            printf("[005] _client_name value mismatch\n") ;
-        }
     }
 
     printf("done!");

--- a/ext/mysqli/tests/mysqli_connect_attr.phpt
+++ b/ext/mysqli/tests/mysqli_connect_attr.phpt
@@ -35,15 +35,21 @@ mysqli_close($link);
     
     //in case $host is empty, do not test for _server_host field
     if(isset($host) && trim($host) != '') {
-        if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where ATTR_NAME='_server_host' and processlist_id = connection_id()")) {
+        if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where processlist_id = connection_id()")) {
             printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
         }
         else {
-            $tmp = mysqli_fetch_assoc($res);
-            mysqli_free_result($res);
-            if ($tmp['ATTR_VALUE'] !== $host) {
-            printf("[003] _server_host value mismatch\n") ;
+            var_dump($res);
+            while($tmp = mysqli_fetch_assoc($res)) {
+                var_dump($tmp);
+                foreach($tmp  as $column => $value) {
+                    echo $column . " " . $value."\n";
+                }
+                //if ($tmp['ATTR_VALUE'] !== $host) {
+                    //printf("[003] _server_host value mismatch\n") ;
+                //}
             }
+            mysqli_free_result($res);
         }
     }
 
@@ -53,6 +59,9 @@ mysqli_close($link);
     else {
         $tmp = mysqli_fetch_assoc($res);
         mysqli_free_result($res);
+        foreach($tmp  as $column => $value) {
+            echo $column . " " . $value."\n";
+        }
         if ($tmp['ATTR_VALUE'] !== "mysqlnd") {
             printf("[005] _client_name value mismatch\n") ;
         }

--- a/ext/mysqli/tests/mysqli_connect_attr.phpt
+++ b/ext/mysqli/tests/mysqli_connect_attr.phpt
@@ -46,26 +46,28 @@ mysqli_close($link);
 		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",$host, $user, $db, $port, $socket);
 
     //in case $host is empty, do not test for _server_host field
-    if(isset($host) && trim($host) != '') {
+    if (isset($host) && trim($host) != '') {
         if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where ATTR_NAME='_server_host' and processlist_id = connection_id()")) {
             printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-        }
-        else {
+        } else {
             $tmp = mysqli_fetch_assoc($res);
-            if ($tmp['ATTR_VALUE'] !== $host) {
-                printf("[003] _server_host value mismatch\n") ;
+            if (!$tmp || !isset($tmp['ATTR_NAME'])) {
+                echo "[003] _server_host missing\n";
+            } elseif ($tmp['ATTR_VALUE'] !== $host) {
+                printf("[004] _server_host value mismatch\n") ;
             }
             mysqli_free_result($res);
         }
     }
 
     if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where ATTR_NAME='_client_name' and processlist_id = connection_id()")) {
-        printf("[004] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-    }
-    else {
+        printf("[005] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    } else {
         $tmp = mysqli_fetch_assoc($res);
-        if ($tmp['ATTR_VALUE'] !== "mysqlnd") {
-            printf("[005] _client_name value mismatch\n") ;
+        if (!$tmp || !isset($tmp['ATTR_NAME'])) {
+            echo "[006] _client_name missing\n";
+        } elseif ($tmp['ATTR_VALUE'] !== "mysqlnd") {
+            printf("[007] _client_name value mismatch\n") ;
         }
         mysqli_free_result($res);
     }

--- a/ext/mysqli/tests/mysqli_connect_attr.phpt
+++ b/ext/mysqli/tests/mysqli_connect_attr.phpt
@@ -11,14 +11,13 @@ if (!$IS_MYSQLND)
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
 	die("skip Cannot connect to the server");
 
-/* skip test for mysql versions <= 5.5*/
-if (!$res = mysqli_query($link, "select version() as version;")) 
-    die("skip select version() query failed");
+/* skip test if the server version does not have session_connect_attrs table yet*/
+if (!$res = mysqli_query($link, "select count(*) as count from information_schema.tables where table_schema='performance_schema' and table_name='session_connect_attrs';"))
+    die("skip select from information_schema.tables for session_connect_attrs  query failed");
 
 $tmp = mysqli_fetch_assoc($res);
 mysqli_free_result($res);
-$version = explode(".", $tmp['version']);
-if($version[0]<5 || ($version[0]==5 && $version[1]<=5)) {
+if($tmp['count'] == "0") {
     mysqli_close($link);
     die("skip mysql does not support session_connect_attrs table yet");
 }
@@ -34,14 +33,17 @@ mysqli_close($link);
 	if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket))
 		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",$host, $user, $db, $port, $socket);
     
-    if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where ATTR_NAME='_server_host' and processlist_id = connection_id()")) {
-        printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-    }
-    else {
-        $tmp = mysqli_fetch_assoc($res);
-        mysqli_free_result($res);
-        if ($tmp['ATTR_VALUE'] !== $host) {
-        printf("[003] _server_host value mismatch\n") ;
+    //in case $host is empty, do not test for _server_host field
+    if(isset($host) && trim($host) != '') {
+        if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where ATTR_NAME='_server_host' and processlist_id = connection_id()")) {
+            printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+        }
+        else {
+            $tmp = mysqli_fetch_assoc($res);
+            mysqli_free_result($res);
+            if ($tmp['ATTR_VALUE'] !== $host) {
+            printf("[003] _server_host value mismatch\n") ;
+            }
         }
     }
 

--- a/ext/mysqli/tests/mysqli_connect_attr.phpt
+++ b/ext/mysqli/tests/mysqli_connect_attr.phpt
@@ -1,5 +1,5 @@
 --TEST--
-mysqli_connect()
+mysqli check the session_connect_attrs table for connection attributes
 --SKIPIF--
 <?php
 require_once('skipif.inc');

--- a/ext/mysqli/tests/mysqli_connect_attr.phpt
+++ b/ext/mysqli/tests/mysqli_connect_attr.phpt
@@ -1,0 +1,62 @@
+--TEST--
+mysqli_connect()
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnectfailure.inc');
+
+if (!$IS_MYSQLND)
+	die("skip: test applies only to mysqlnd");
+
+if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+	die("skip Cannot connect to the server");
+
+/* skip test for mysql versions <= 5.5*/
+if (!$res = mysqli_query($link, "select version() as version;")) 
+    die("skip select version() query failed");
+
+$tmp = mysqli_fetch_assoc($res);
+mysqli_free_result($res);
+$version = explode(".", $tmp['version']);
+if($version[0]<5 || ($version[0]==5 && $version[1]<=5)) {
+    mysqli_close($link);
+    die("skip mysql does not support session_connect_attrs table yet");
+}
+mysqli_close($link);
+?>
+--FILE--
+<?php
+	require_once("connect.inc");
+
+	$tmp    = NULL;
+	$link   = NULL;
+    $res    = NULL;
+	if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",$host, $user, $db, $port, $socket);
+    
+    if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where ATTR_NAME='_server_host' and processlist_id = connection_id()")) {
+        printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+    else {
+        $tmp = mysqli_fetch_assoc($res);
+        mysqli_free_result($res);
+        if ($tmp['ATTR_VALUE'] !== $host) {
+        printf("[003] _server_host value mismatch\n") ;
+        }
+    }
+
+    if (!$res = mysqli_query($link, "select * from performance_schema.session_connect_attrs where ATTR_NAME='_client_name' and processlist_id = connection_id()")) {
+        printf("[004] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+    else {
+        $tmp = mysqli_fetch_assoc($res);
+        mysqli_free_result($res);
+        if ($tmp['ATTR_VALUE'] !== "mysqlnd") {
+            printf("[005] _client_name value mismatch\n") ;
+        }
+    }
+
+    printf("done!");
+?>
+--EXPECTF--
+done!

--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -420,6 +420,9 @@ mysqlnd_auth_change_user(MYSQLND_CONN_DATA * const conn,
 		auth_packet.auth_data_len = auth_plugin_data_len;
 		auth_packet.auth_plugin_name = auth_protocol;
 
+        if (conn->server_capabilities & CLIENT_CONNECT_ATTRS) {
+			auth_packet.connect_attr = conn->options->connect_attr;
+        }
 
 		if (conn->m->get_server_version(conn) >= 50123) {
 			auth_packet.charset_no	= conn->charset->nr;

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -511,7 +511,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_updated_connect_flags)(MYSQLND_CONN_DATA *
 #endif
 
     if (conn->options->connect_attr && zend_hash_num_elements(conn->options->connect_attr)) {
-		//mysql_flags |= CLIENT_CONNECT_ATTRS;
+		mysql_flags |= CLIENT_CONNECT_ATTRS;
 	}
 
 	DBG_RETURN(mysql_flags);

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -829,7 +829,7 @@ MYSQLND_METHOD(mysqlnd_conn, connect)(MYSQLND * conn_handle,
 
 	if (PASS == conn->m->local_tx_start(conn, this_func)) {
 		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_client_name", "mysqlnd");
-        if(hostname.l > 0) {
+        if (hostname.l > 0) {
             mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
         }
 		ret = conn->m->connect(conn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -511,7 +511,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_updated_connect_flags)(MYSQLND_CONN_DATA *
 #endif
 
     if (conn->options->connect_attr && zend_hash_num_elements(conn->options->connect_attr)) {
-		mysql_flags |= CLIENT_CONNECT_ATTRS;
+		//mysql_flags |= CLIENT_CONNECT_ATTRS;
 	}
 
 	DBG_RETURN(mysql_flags);

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -510,6 +510,10 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_updated_connect_flags)(MYSQLND_CONN_DATA *
 	}
 #endif
 
+    if (conn->options->connect_attr && zend_hash_num_elements(conn->options->connect_attr)) {
+		mysql_flags |= CLIENT_CONNECT_ATTRS;
+	}
+
 	DBG_RETURN(mysql_flags);
 }
 /* }}} */
@@ -653,7 +657,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, connect)(MYSQLND_CONN_DATA * conn,
 		password.s = "";
 		password.l = 0;
 	}
-	if (!database.s) {
+	if (!database.s || !database.s[0]) {
 		DBG_INF_FMT("no db given, using empty string");
 		database.s = "";
 		database.l = 0;
@@ -825,6 +829,9 @@ MYSQLND_METHOD(mysqlnd_conn, connect)(MYSQLND * conn_handle,
 
 	if (PASS == conn->m->local_tx_start(conn, this_func)) {
 		mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_client_name", "mysqlnd");
+        if(hostname.l > 0) {
+            mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
+        }
 		ret = conn->m->connect(conn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 
 		conn->m->local_tx_end(conn, this_func, FAIL);

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -546,7 +546,7 @@ size_t php_mysqlnd_auth_write(MYSQLND_CONN_DATA * conn, void * _packet)
 		}
 
 		if (packet->db_len > 0) {
-			/* CLIENT_CONNECT_WITH_DB should have been set if !is_change_user_packet*/
+			/* CLIENT_CONNECT_WITH_DB should have been set */
 			size_t real_db_len = MIN(MYSQLND_MAX_ALLOWED_DB_LEN, packet->db_len);
 			memcpy(p, packet->db, real_db_len);
 			p+= real_db_len;

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -545,8 +545,8 @@ size_t php_mysqlnd_auth_write(MYSQLND_CONN_DATA * conn, void * _packet)
 			p+= packet->auth_data_len;
 		}
 
-		if (packet->db) {
-			/* CLIENT_CONNECT_WITH_DB should have been set */
+		if (packet->db_len > 0) {
+			/* CLIENT_CONNECT_WITH_DB should have been set if !is_change_user_packet*/
 			size_t real_db_len = MIN(MYSQLND_MAX_ALLOWED_DB_LEN, packet->db_len);
 			memcpy(p, packet->db, real_db_len);
 			p+= real_db_len;

--- a/ext/pdo_mysql/tests/pdo_mysql_connect_attr.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_connect_attr.phpt
@@ -1,0 +1,58 @@
+--TEST--
+PDO_MYSQL: check the session_connect_attrs table for connection attributes
+--SKIPIF--
+<?php
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'skipif.inc');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+
+if (!MySQLPDOTest::isPDOMySQLnd()) die('skip only for mysqlnd');
+
+$pdo = MySQLPDOTest::factory();
+
+$stmt = $pdo->query("select count(*) from information_schema.tables where table_schema='performance_schema' and table_name='session_connect_attrs'");
+if (!$stmt || !$stmt->fetchColumn()) {
+    die("skip mysql does not support session_connect_attrs table yet");
+}
+
+$stmt = $pdo->query("show variables like 'performance_schema'");
+if (!$stmt || $stmt->fetchColumn(1) !== 'ON') {
+    die("skip performance_schema is OFF");
+}
+
+?>
+--FILE--
+<?php
+
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+$pdo = MySQLPDOTest::factory();
+
+if (preg_match('/host=([^;]+)/', PDO_MYSQL_TEST_DSN, $m)) {
+    $host = $m[1];
+}
+
+//in case $host is empty, do not test for _server_host field
+if (isset($host) && $host !== '') {
+    $stmt = $pdo->query("select * from performance_schema.session_connect_attrs where ATTR_NAME='_server_host' and processlist_id = connection_id()");
+
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$row || !isset($row['attr_name'])) {
+        echo "_server_host missing\n";
+    } elseif ($row['attr_value'] !== $host) {
+        printf("_server_host mismatch (expected '%s', got '%s')\n", $host, $row['attr_value']);
+    }
+}
+
+$stmt = $pdo->query("select * from performance_schema.session_connect_attrs where ATTR_NAME='_client_name' and processlist_id = connection_id()");
+
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$row || !isset($row['attr_name'])) {
+    echo "_client_name missing\n";
+} elseif ($row['attr_value'] !== 'mysqlnd') {
+    printf("_client_name mismatch (expected 'mysqlnd', got '%s')\n", $row['attr_value']);
+}
+
+printf("done!");
+?>
+--EXPECT--
+done!

--- a/ext/pdo_mysql/tests/pdo_mysql_connect_attr.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_connect_attr.phpt
@@ -4,7 +4,7 @@ PDO_MYSQL: check the session_connect_attrs table for connection attributes
 <?php
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'skipif.inc');
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
-
+MySQLPDOTest::skip();
 if (!MySQLPDOTest::isPDOMySQLnd()) die('skip only for mysqlnd');
 
 $pdo = MySQLPDOTest::factory();


### PR DESCRIPTION
1. The connection attribute feature in mysqlnd did not work properly since the flag CLIENT_CONNECT_ATTRS was never set. PR to fix the problem.

2. After add the flag, from Wireshark result and protocol https://dev.mysql.com/doc/internals/en/com-change-user.html#packet-COM_CHANGE_USER
, it should also send the connect attr in the com_change_user packet, add this part when send packet

2. After CLIENT_CONNECT_ATTRS is set, it exposes another problem when there is no db in connection string, it will cause handshake fail, 
since the logic is to check packet->db!=NULL, but the fact is when DB is not set, this field is !=null, but contains empty string. 
Related code snippet is as follows:
//before write packet, the logic to set flag and field
if (!database.s) {
DBG_INF_FMT("no db given, using empty string");
database.s = "";
database.l = 0;
} else {
mysql_flags |= CLIENT_CONNECT_WITH_DB;
}
//set packet field
auth_packet.db = db;
auth_packet.db_len = db_len;
//logic to write db info before change:
if (packet->db) {
...
p++= '\0';
}
/ no \0 for no DB */

3. Add a new connection attribute _server_host which will give the host name information. This field is needed for the scenario such as when 
connect to Azure MySQL database, previously it required the user name in the format of user@server or server%user. In order to get rid of
 the need of server name in the user name information, we need the support of the connection attribute _server_host. 
This attribute has been already added in driver MariaDB Connector C and MariaDB Connector J （reference: https://github.com/MariaDB/mariadb-connector-j/commit/de8883b00a4f0e875fb6189652c9851b93a6f88a )