### PR TITLE
Add missing SKIPIFs

### DIFF
--- a/ext/opcache/tests/block_pass_001.phpt
+++ b/ext/opcache/tests/block_pass_001.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Block pass: Bugs in BOOL/QM_ASSIGN elision
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 (bool) (true ? $x : $y);

--- a/ext/opcache/tests/block_removal_with_duplicate_successors.phpt
+++ b/ext/opcache/tests/block_removal_with_duplicate_successors.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Removing a block that has duplicate successors
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function test($foo) {

--- a/ext/opcache/tests/bool_cp_in_pass1.phpt
+++ b/ext/opcache/tests/bool_cp_in_pass1.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Incorrect constant propagation on BOOL in pass 1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function test($foo) {

--- a/ext/opcache/tests/bug70423.phpt
+++ b/ext/opcache/tests/bug70423.phpt
@@ -5,6 +5,8 @@ open_basedir=.
 opcache.enabled=1
 opcache.enable_cli=1
 opcache.log_verbosity_level=2
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug72762.phpt
+++ b/ext/opcache/tests/bug72762.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #72762: Infinite loop while parsing a file with opcache enabled
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug73654.phpt
+++ b/ext/opcache/tests/bug73654.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #73654: Segmentation fault in zend_call_function
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 echo xyz();

--- a/ext/opcache/tests/bug73668.phpt
+++ b/ext/opcache/tests/bug73668.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #73668: "SIGFPE Arithmetic exception" in opcache when divide by minus 1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 $a/-1;

--- a/ext/opcache/tests/bug73746.phpt
+++ b/ext/opcache/tests/bug73746.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #73746 (Method that returns string returns UNKNOWN:0 instead)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 namespace Core\Bundle\Service\Property\Room\Rooms;

--- a/ext/opcache/tests/bug73789.phpt
+++ b/ext/opcache/tests/bug73789.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #73789 (Strange behavior of class constants in switch/case block)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 class Lexer

--- a/ext/opcache/tests/bug73847.phpt
+++ b/ext/opcache/tests/bug73847.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #73847: Recursion when a variable is redefined as array
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function test() {

--- a/ext/opcache/tests/bug74431.phpt
+++ b/ext/opcache/tests/bug74431.phpt
@@ -4,6 +4,8 @@ Bug #74431 - foreach infinite loop
 opcache.enable=1
 opcache.enable_cli=1
 opcache.optimization_level=0xffffffff
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function test(){

--- a/ext/opcache/tests/bug74442.phpt
+++ b/ext/opcache/tests/bug74442.phpt
@@ -2,6 +2,8 @@
 Bug #74442: Opcached version produces a nested array
 --CREDITS--
 Eric Norris <erictnorris@gmail.com>
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 class Schema_Base {

--- a/ext/opcache/tests/bug74623.phpt
+++ b/ext/opcache/tests/bug74623.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #74623: Infinite loop in type inference when using HTMLPurifier
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug75255.phpt
+++ b/ext/opcache/tests/bug75255.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #75255 (Request hangs and not finish)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function generatePlanImage() {

--- a/ext/opcache/tests/bug75570.phpt
+++ b/ext/opcache/tests/bug75570.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #75570 ("Narrowing occurred during type inference" error)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function renderRawGraph(array $parents) {

--- a/ext/opcache/tests/bug75608.phpt
+++ b/ext/opcache/tests/bug75608.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #75608 ("Narrowing occurred during type inference" error)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 class ReactionRatingService

--- a/ext/opcache/tests/bug75893.phpt
+++ b/ext/opcache/tests/bug75893.phpt
@@ -3,6 +3,8 @@ Bug #75893: file_get_contents $http_response_header variable bugged with opcache
 --INI--
 opcache.enable_cli=1
 track_errors=1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug75938.phpt
+++ b/ext/opcache/tests/bug75938.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #75938: Modulus value not stored in variable
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function borken($columns) {

--- a/ext/opcache/tests/bug75969.phpt
+++ b/ext/opcache/tests/bug75969.phpt
@@ -3,6 +3,8 @@ Bug #75969: Assertion failure in live range DCE due to block pass misoptimizatio
 --INI--
 opcache.enable_cli=1
 opcache.optimization_level=-1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug76074.phpt
+++ b/ext/opcache/tests/bug76074.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #76074 (opcache corrupts variable in for-loop)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug76275.phpt
+++ b/ext/opcache/tests/bug76275.phpt
@@ -4,6 +4,8 @@ Bug #76275: Assertion failure in file cache when unserializing empty try_catch_a
 opcache.enabled=1
 opcache.enable_cli=1
 opcache.file_cache={TMP}
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug76281.phpt
+++ b/ext/opcache/tests/bug76281.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #76281: Opcache causes incorrect "undefined variable" errors
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug76796.phpt
+++ b/ext/opcache/tests/bug76796.phpt
@@ -5,6 +5,8 @@ opcache.enable=1
 opcache.enable_cli=1
 opcache.optimization_level=-1
 disable_functions=strpos
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug77058.phpt
+++ b/ext/opcache/tests/bug77058.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #77058: Type inference in opcache causes side effects
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php 
 

--- a/ext/opcache/tests/bug77092.phpt
+++ b/ext/opcache/tests/bug77092.phpt
@@ -3,6 +3,8 @@ Bug #77092: array_diff_key() - segmentation fault
 --INI--
 opcache.enable_cli=1
 opcache.optimization_level=-1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function test() {

--- a/ext/opcache/tests/bug77215.phpt
+++ b/ext/opcache/tests/bug77215.phpt
@@ -3,6 +3,8 @@ Bug #77215: CFG assertion failure on multiple finalizing switch frees in one blo
 --INI--
 opcache.enable_cli=1
 opcache.optimization_level=-1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug77691.phpt
+++ b/ext/opcache/tests/bug77691.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #77691: Opcache passes wrong value for inline array push assignments
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug77743.phpt
+++ b/ext/opcache/tests/bug77743.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #77743: Incorrect pi node insertion for jmpznz with identical successors
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug78106.phpt
+++ b/ext/opcache/tests/bug78106.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #78106: Path resolution fails if opcache disabled during request
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/bug78185.phpt
+++ b/ext/opcache/tests/bug78185.phpt
@@ -5,6 +5,8 @@ opcache.enable_cli=1
 opcache.optimization_level=-1
 opcache.file_cache={PWD}
 opcache.file_cache_only=1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 if (substr(PHP_OS, 0, 3) !== 'WIN') {

--- a/ext/opcache/tests/invalid_array_key_type.phpt
+++ b/ext/opcache/tests/invalid_array_key_type.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Don't add array value type is key type is illegal
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/jmpz_jmp_elim.phpt
+++ b/ext/opcache/tests/jmpz_jmp_elim.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Edge-cases in elimination of JMPZ JMP with same target
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/method_call_on_literal.phpt
+++ b/ext/opcache/tests/method_call_on_literal.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Literal compaction should take method calls on literals into account
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/neg_range_inference.phpt
+++ b/ext/opcache/tests/neg_range_inference.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Incorrect negative range inference
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/optimize_func_calls_001.phpt
+++ b/ext/opcache/tests/optimize_func_calls_001.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Don't create FETCH_DIM_R with UNUSED op2
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/send_unpack_empty_array.phpt
+++ b/ext/opcache/tests/send_unpack_empty_array.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Type inference of SEND_UNPACK with empty array
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function test() {

--- a/ext/opcache/tests/ssa_bug_001.phpt
+++ b/ext/opcache/tests/ssa_bug_001.phpt
@@ -1,5 +1,7 @@
 --TEST--
 SSA constrution for CFG with unreachable basic blocks
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 class X {

--- a/ext/opcache/tests/ssa_bug_002.phpt
+++ b/ext/opcache/tests/ssa_bug_002.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Incorrect NOP removal on jump to NOP
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/ssa_bug_003.phpt
+++ b/ext/opcache/tests/ssa_bug_003.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Incorrect elision of return type checks
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/ssa_bug_004.phpt
+++ b/ext/opcache/tests/ssa_bug_004.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Assign elision exception safety: ICALL
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/ssa_bug_005.phpt
+++ b/ext/opcache/tests/ssa_bug_005.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Assign elision exception safety: UCALL
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/ssa_bug_006.phpt
+++ b/ext/opcache/tests/ssa_bug_006.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Incorrect optimization of $i = $i++
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/ssa_bug_007.phpt
+++ b/ext/opcache/tests/ssa_bug_007.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Incorrect CFG/SSA construction for SWITCH with few identical successors
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function render($properties) {

--- a/ext/opcache/tests/ssa_bug_008.phpt
+++ b/ext/opcache/tests/ssa_bug_008.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Incorrect CFG/SSA reconstruction
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 if (!is_int($info = gc_collect_cycles()) || ($info < 100)) {

--- a/ext/opcache/tests/ssa_bug_009.phpt
+++ b/ext/opcache/tests/ssa_bug_009.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Incorrect type inference
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 class PHP_CodeCoverage

--- a/ext/opcache/tests/ssa_bug_010.phpt
+++ b/ext/opcache/tests/ssa_bug_010.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Wrong assertion
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function foo($parts, $a, $b) {

--- a/ext/opcache/tests/switch_with_coinciding_targets.phpt
+++ b/ext/opcache/tests/switch_with_coinciding_targets.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Switch where all targets, including default, coincide
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/verify_return_dfg.phpt
+++ b/ext/opcache/tests/verify_return_dfg.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Incorrect liveness computation for verify-return
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 function test($foo): string

--- a/ext/opcache/tests/wrong_inlining_005.phpt
+++ b/ext/opcache/tests/wrong_inlining_005.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Inlining of functions with ref arguments
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
All these tests are meant to run with OPcache available, and some will
even fail inevitably without it, so we add OPcache as SKIPIF
requirement.