### PR TITLE
Remove PTHREADS_ASSIGN_VARS

### DIFF
--- a/TSRM/threads.m4
+++ b/TSRM/threads.m4
@@ -102,13 +102,6 @@ dnl  -qthreaded        AIX cc V5
 dnl  -threads          gcc (HP-UX)
 dnl
 AC_DEFUN([PTHREADS_CHECK],[
-save_CFLAGS=$CFLAGS
-save_LIBS=$LIBS
-PTHREADS_ASSIGN_VARS
-PTHREADS_CHECK_COMPILE
-LIBS=$save_LIBS
-CFLAGS=$save_CFLAGS
-
 AC_CACHE_CHECK(for pthreads_cflags,ac_cv_pthreads_cflags,[
 ac_cv_pthreads_cflags=
 if test "$pthreads_working" != "yes"; then
@@ -143,26 +136,5 @@ fi
 
 if test "x$ac_cv_pthreads_cflags" != "x" -o "x$ac_cv_pthreads_lib" != "x"; then
   pthreads_working="yes"
-fi
-
-if test "$pthreads_working" = "yes"; then
-  threads_result="POSIX-Threads found"
-else
-  threads_result="POSIX-Threads not found"
-fi
-])
-
-dnl
-dnl PTHREADS_ASSIGN_VARS
-dnl
-dnl Adds pthreads linker and compiler flags.
-dnl
-AC_DEFUN([PTHREADS_ASSIGN_VARS],[
-if test -n "$ac_cv_pthreads_lib"; then
-  LIBS="$LIBS -l$ac_cv_pthreads_lib"
-fi
-
-if test -n "$ac_cv_pthreads_cflags"; then
-  CFLAGS="$CFLAGS $ac_cv_pthreads_cflags"
 fi
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,8 @@ m4_include([build/libtool.m4])
 m4_include([build/php_cxx_compile_stdcxx.m4])
 m4_include([build/php.m4])
 m4_include([build/pkg.m4])
+m4_include([TSRM/threads.m4])
+m4_include([TSRM/tsrm.m4])
 
 dnl Basic autoconf initialization, generation of config.nice.
 dnl ----------------------------------------------------------------------------
@@ -313,12 +315,10 @@ case $host_alias in
     ;;
 esac
 
-dnl Include Zend and TSRM configurations.
+dnl Include Zend configurations.
 dnl ----------------------------------------------------------------------------
 
 sinclude(Zend/Zend.m4)
-sinclude(TSRM/threads.m4)
-sinclude(TSRM/tsrm.m4)
 
 dnl ----------------------------------------------------------------------------
 
@@ -359,7 +359,14 @@ fi
 
 dnl Force ZTS.
 if test "$enable_maintainer_zts" = "yes"; then
-  PTHREADS_ASSIGN_VARS
+  dnl Add pthreads linker and compiler flags.
+  if test -n "$ac_cv_pthreads_lib"; then
+    LIBS="$LIBS -l$ac_cv_pthreads_lib"
+  fi
+  if test -n "$ac_cv_pthreads_cflags"; then
+    CFLAGS="$CFLAGS $ac_cv_pthreads_cflags"
+  fi
+
   PTHREADS_FLAGS
 fi
 


### PR DESCRIPTION
This simplifies TSRM build steps a bit and avoids doing unnecessary steps:
- The `PTHREADS_CHECK_COMPILE` can be called inside the for loops only since this is only where the `$pthreads_checked` variable is used.
- After that, assigning variables can be then done only in the configure.ac once. In the `PTHREADS_CHECK` they get rewritten back anyway.
- Using `m4_include()` instead of the `sinclude()` in the middle of the build steps is more readable, and doesn't change anything since these are all macro definitions only.
- The `$threads_result` variable is not used in the code or in extensions.
