### PR TITLE
Use default Autoconf configuration options checkings (bug #55634)

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2209,61 +2209,6 @@ EOF
 ])
 
 dnl
-dnl PHP_CHECK_CONFIGURE_OPTIONS
-dnl
-AC_DEFUN([PHP_CHECK_CONFIGURE_OPTIONS],[
-  for arg in $ac_configure_args; do
-    case $arg in
-      --with-*[)]
-        arg_name="`echo [$]arg | $SED -e 's/--with-/with-/g' -e 's/=.*//g'`"
-        ;;
-      --without-*[)]
-        arg_name="`echo [$]arg | $SED -e 's/--without-/with-/g' -e 's/=.*//g'`"
-        ;;
-      --enable-*[)]
-        arg_name="`echo [$]arg | $SED -e 's/--enable-/enable-/g' -e 's/=.*//g'`"
-        ;;
-      --disable-*[)]
-        arg_name="`echo [$]arg | $SED -e 's/--disable-/enable-/g' -e 's/=.*//g'`"
-        ;;
-      *[)]
-        continue
-        ;;
-    esac
-    case $arg_name in
-      dnl Allow --disable-all / --enable-all
-      enable-all[)];;
-
-      dnl Allow certain libtool options
-      enable-libtool-lock | with-pic | with-tags | enable-shared | enable-static | enable-fast-install | with-gnu-ld[)];;
-
-      dnl Allow certain TSRM options
-      with-tsrm-pth | with-tsrm-st | with-tsrm-pthreads [)];;
-
-      dnl Allow certain Zend options
-      with-zend-vm | enable-maintainer-zts | enable-inline-optimization[)];;
-
-      dnl All the rest must be set using the PHP_ARG_* macros. PHP_ARG_* macros
-      dnl set php_enable_<arg_name> or php_with_<arg_name>.
-      *[)]
-        dnl Options that exist before PHP 6
-        if test "$PHP_MAJOR_VERSION" -lt "6"; then
-          case $arg_name in
-            enable-zend-multibyte[)] continue;;
-          esac
-        fi
-
-        is_arg_set=php_[]`echo [$]arg_name | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ-' 'abcdefghijklmnopqrstuvwxyz_'`
-        if eval test "x\$$is_arg_set" = "x"; then
-          PHP_UNKNOWN_CONFIGURE_OPTIONS="$PHP_UNKNOWN_CONFIGURE_OPTIONS
-[$]arg"
-        fi
-        ;;
-    esac
-  done
-])
-
-dnl
 dnl PHP_CHECK_PDO_INCLUDES([found [, not-found]])
 dnl
 AC_DEFUN([PHP_CHECK_PDO_INCLUDES],[

--- a/configure.ac
+++ b/configure.ac
@@ -1590,9 +1590,6 @@ scripts/phpize scripts/man1/phpize.1 \
 scripts/php-config scripts/man1/php-config.1 \
 $PHP_OUTPUT_FILES"
 
-dnl Check for unknown configure options.
-PHP_CHECK_CONFIGURE_OPTIONS
-
 dnl Generate build files.
 AC_CONFIG_FILES([$ALL_OUTPUT_FILES])
 AC_CONFIG_COMMANDS([default],[],[
@@ -1693,15 +1690,6 @@ cat <<X
 Thank you for using PHP.
 
 X
-
-  dnl Output unknown configure options.
-  if test "$PHP_UNKNOWN_CONFIGURE_OPTIONS"; then
-    echo "Notice: Following unknown configure options were used:
-$PHP_UNKNOWN_CONFIGURE_OPTIONS
-
-Check '[$]0 --help' for available options
-"
-  fi
 
 fi
 ])


### PR DESCRIPTION
Instead of building a custom macro for checking configure options, Autoconf 2.62+ outputs a warning at the beginning and the end of the output of configure script. It automatically detects correct and wrong options better.

This is related also to fixing the bug [#55634](https://bugs.php.net/bug.php?id=55634).

Examples:
* `./configure --with-foo` will output warning at the beginning and the end of the ouput
* `./configure --foo` will result in fatal error:

  ```text
  configure: error: unrecognized option: `--foo'
  Try `./configure --help' for more information
  ```
* `./configure --with-foo --enable-option-checking=fatal` results in fatal error:

  ```text
  configure: error: unrecognized options: --with-foo
  ```