### PR TITLE
Implement FR #77230: Support custom CFLAGS and LDFLAGS from environment

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -431,6 +431,10 @@ can be built that way. \
 			}
 			STDOUT.WriteLine("  " + arg.arg + pad + word_wrap_and_indent(max_width + 5, arg.helptext));
 		}
+		STDOUT.WriteBlankLines(1);
+		STDOUT.WriteLine("Some influential environment variables:");
+		STDOUT.WriteLine("  CFLAGS      C compiler flags");
+		STDOUT.WriteLine("  LDFLAGS     linker flags");
 		WScript.Quit(1);
 	}
 
@@ -3207,6 +3211,8 @@ function toolset_setup_linker()
 
 function toolset_setup_common_cflags()
 {
+	var envCFLAGS = WshShell.Environment("PROCESS").Item("CFLAGS");
+
 	// CFLAGS for building the PHP dll
 	DEFINE("CFLAGS_PHP", "/D _USRDLL /D PHP7DLLTS_EXPORTS /D PHP_EXPORTS \
 	/D LIBZEND_EXPORTS /D TSRM_EXPORTS /D SAPI_EXPORTS /D WINVER=" + WINVER);
@@ -3217,6 +3223,10 @@ function toolset_setup_common_cflags()
 	DEFINE("CFLAGS", "/nologo $(BASE_INCLUDES) /D _WINDOWS /D WINDOWS=1 \
 		/D ZEND_WIN32=1 /D PHP_WIN32=1 /D WIN32 /D _MBCS /W3 \
 		/D _USE_MATH_DEFINES");
+
+	if (envCFLAGS) {
+		ADD_FLAG("CFLAGS", envCFLAGS);
+	}
 
 	if (VS_TOOLSET) {
 		ADD_FLAG("CFLAGS", " /FD ");
@@ -3368,6 +3378,8 @@ function toolset_setup_intrinsic_cflags()
 
 function toolset_setup_common_ldlags()
 {
+	var envLDFLAGS = WshShell.Environment("PROCESS").Item("LDFLAGS");
+
 	// General DLL link flags
 	DEFINE("DLL_LDFLAGS", "/dll ");
 
@@ -3375,6 +3387,10 @@ function toolset_setup_common_ldlags()
 	DEFINE("PHP_LDFLAGS", "$(DLL_LDFLAGS)");
 
 	DEFINE("LDFLAGS", "/nologo ");
+
+	if (envLDFLAGS) {
+		ADD_FLAG("LDFLAGS", envLDFLAGS);
+	}
 
 	// we want msvcrt in the PHP DLL
 	ADD_FLAG("PHP_LDFLAGS", "/nodefaultlib:libcmt");


### PR DESCRIPTION
While it is already possible to *set* CFLAGS and LDFLAGS (actually all
variables) from the environment for `nmake` (by passing the `/E`
option), it is not possible to *add* any (C|LD)FLAGS, which can be
useful in some cases.  Instead of allowing this for `nmake`, we add
support for additional custom (C|LD)FLAGS to `configure`, similar to
how that works on Linux, so one could actually write:
````
set CFLAGS=foo & set LDFLAGS=bar & configure
````
This also allows us to use these flags during configure.