### PR TITLE
Enable option checking on CI

### DIFF
--- a/azure/i386/job.yml
+++ b/azure/i386/job.yml
@@ -15,6 +15,7 @@ jobs:
         export LDFLAGS=-L/usr/lib/i386-linux-gnu
         export PKG_CONFIG=/usr/bin/i686-linux-gnu-pkg-config
         ./configure ${{ parameters.configurationParameters }} \
+            --enable-option-checking=fatal \
             --prefix=/usr \
             --enable-phpdbg \
             --enable-fpm \

--- a/azure/job.yml
+++ b/azure/job.yml
@@ -14,6 +14,7 @@ jobs:
     - script: |
         ./buildconf --force
         ./configure ${{ parameters.configurationParameters }} \
+            --enable-option-checking=fatal \
             --prefix=/usr \
             --enable-phpdbg \
             --enable-fpm \

--- a/azure/macos/job.yml
+++ b/azure/macos/job.yml
@@ -19,6 +19,7 @@ jobs:
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig"
         ./buildconf --force
         ./configure ${{ parameters.configurationParameters }} \
+            --enable-option-checking=fatal \
             --prefix=/usr/local \
             --disable-phpdbg \
             --enable-fpm \

--- a/azure/msan_job.yml
+++ b/azure/msan_job.yml
@@ -20,6 +20,7 @@ jobs:
         # msan requires all used libraries to be instrumented,
         # so we should avoiding linking against anything but libc here
         ./configure ${{ parameters.configurationParameters }} \
+            --enable-option-checking=fatal \
             --prefix=/usr \
             --without-sqlite3 \
             --without-pdo-sqlite \

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -47,7 +47,7 @@ $TS \
 --with-freetype \
 --with-xpm \
 --enable-exif \
---enable-zip \
+--with-zip \
 --with-zlib \
 --with-zlib-dir=/usr \
 --enable-soap \

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -5,7 +5,7 @@ else
 	TS="";
 fi
 if [[ "$ENABLE_DEBUG" == 1 ]]; then
-	DEBUG="--enable-debug --without-pcre-valgrind";
+	DEBUG="--enable-debug";
 else
 	DEBUG="";
 fi

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -27,6 +27,7 @@ MAKE_JOBS=${MAKE_JOBS:-2}
 
 ./buildconf --force
 ./configure \
+--enable-option-checking=fatal \
 --prefix="$HOME"/php-install \
 $CONFIG_QUIET \
 $DEBUG \


### PR DESCRIPTION
This adds the Autoconf's `--enable-option-checking=fatal` option so when a non existing option from the PHP's configure options is used a fatal error happens.

Added to azure pipelines and travis for PHP-7.4. If there is need to have this in PHP-7.2 and up for travis, I think a separate commit for travis should be done then. 

```text
./configure --enable-foo --enable-option-checking=fatal
configure: error: unrecognized options: --enable-foo
```