### PR TITLE
Add force to autoconf only when used

### DIFF
--- a/build/build.mk
+++ b/build/build.mk
@@ -21,7 +21,8 @@
 config_h_in = main/php_config.h.in
 PHP_AUTOCONF = autoconf
 PHP_AUTOHEADER = autoheader
-PHP_AUTOCONF_FLAGS =
+PHP_AUTOCONF_FLAGS = -f
+PHP_AUTOHEADER_FLAGS =
 
 all: configure $(config_h_in)
 
@@ -38,5 +39,5 @@ $(config_h_in): configure
 # generated php_config.h.in template.
 	@echo rebuilding $@
 	@rm -f $@
-	@$(PHP_AUTOHEADER) $(PHP_AUTOCONF_FLAGS)
+	@$(PHP_AUTOHEADER) $(PHP_AUTOHEADER_FLAGS)
 	@sed -e 's/^#undef PACKAGE_[^ ]*/\/\* & \*\//g' < $@ > $@.tmp && mv $@.tmp $@

--- a/build/build.mk
+++ b/build/build.mk
@@ -21,7 +21,7 @@
 config_h_in = main/php_config.h.in
 PHP_AUTOCONF = autoconf
 PHP_AUTOHEADER = autoheader
-PHP_AUTOCONF_FLAGS = -f
+PHP_AUTOCONF_FLAGS =
 
 all: configure $(config_h_in)
 

--- a/buildconf
+++ b/buildconf
@@ -7,6 +7,8 @@ PHP_AUTOCONF=${PHP_AUTOCONF:-autoconf}
 PHP_AUTOHEADER=${PHP_AUTOHEADER:-autoheader}
 force=0
 debug=0
+autoconf_flags="-f"
+autoheader_flags=
 
 # Go to project root.
 cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
@@ -82,7 +84,7 @@ if test "$force" = "1"; then
   echo "buildconf: Forcing buildconf"
   echo "buildconf: Removing configure caches and files"
   rm -rf autom4te.cache config.cache configure
-  autoconf_flags="-f"
+  autoheader_flags="-f"
 fi
 
 echo "buildconf: Checking installation"
@@ -126,12 +128,12 @@ echo "buildconf: Building configure files"
 
 if test "$debug" = "1"; then
   autoconf_flags="${autoconf_flags} -Wall"
-else
-  autoconf_flags="${autoconf_flags}"
+  autoheader_flags="${autoheader_flags} -Wall"
 fi
 
 $MAKE -s -f build/build.mk \
   PHP_AUTOCONF="$PHP_AUTOCONF" \
   PHP_AUTOHEADER="$PHP_AUTOHEADER" \
   PHP_AUTOCONF_FLAGS="$autoconf_flags" \
+  PHP_AUTOHEADER_FLAGS="$autoheader_flags" \
   PHP_M4_FILES="$(echo TSRM/*.m4 Zend/Zend.m4 build/*.m4 ext/*/config*.m4 sapi/*/config*.m4)"

--- a/buildconf
+++ b/buildconf
@@ -82,6 +82,7 @@ if test "$force" = "1"; then
   echo "buildconf: Forcing buildconf"
   echo "buildconf: Removing configure caches and files"
   rm -rf autom4te.cache config.cache configure
+  autoconf_flags="-f"
 fi
 
 echo "buildconf: Checking installation"
@@ -124,9 +125,9 @@ fi
 echo "buildconf: Building configure files"
 
 if test "$debug" = "1"; then
-  autoconf_flags="-f -Wall"
+  autoconf_flags="${autoconf_flags} -Wall"
 else
-  autoconf_flags="-f"
+  autoconf_flags="${autoconf_flags}"
 fi
 
 $MAKE -s -f build/build.mk \


### PR DESCRIPTION
The -f or --force option used on autoconf and autoheader considers that all files are obsolete and it recreates all files again without using cache. Instead of doing this when running the default buildconf script, this should be done only when running using `./buildconf --force`.

This improves the default buildconf step a little more - from about 2.5s to 1.5s.

P.S: also tested for edge cases of:

```
git checkout PHP-7.3
./buildconf
./configure
git checkout PHP-7.4
./buildconf
./configure
```
