### PR TITLE
Remove libtool and automake from azure installs

### DIFF
--- a/azure/macos/brew.yml
+++ b/azure/macos/brew.yml
@@ -8,8 +8,6 @@ steps:
   - script: |
       brew install pkg-config \
                    autoconf \
-                   automake \
-                   libtool \
                    bison \
                    re2c
     displayName: 'Install Build Tools'


### PR DESCRIPTION
Hello. These two deps are most likely not needed to build PHP on Azure...