### PR TITLE
 Support redirecting descriptors in proc_open

### DIFF
--- a/ext/curl/tests/server.inc
+++ b/ext/curl/tests/server.inc
@@ -12,30 +12,13 @@ function curl_cli_server_start() {
     $php_executable = getenv('TEST_PHP_EXECUTABLE');
     $doc_root = __DIR__;
     $router = "responder/get.inc";
-
-    if (substr(PHP_OS, 0, 3) == 'WIN') {
-        $descriptorspec = array(
-            0 => STDIN,
-            1 => STDOUT,
-            2 => array("pipe", "w"),
-        );
-
-        $cmd = "{$php_executable} -t {$doc_root} -n -S " . PHP_CURL_SERVER_ADDRESS;
-        $cmd .= " {$router}";
-        $handle = proc_open(addslashes($cmd), $descriptorspec, $pipes, $doc_root, NULL, array("bypass_shell" => true,  "suppress_errors" => true));
-    } else {
-        $descriptorspec = array(
-            0 => STDIN,
-            1 => STDOUT,
-            2 => STDERR,
-        );
-
-        $cmd = "exec {$php_executable} -t {$doc_root} -n -S " . PHP_CURL_SERVER_ADDRESS;
-        $cmd .= " {$router}";
-        $cmd .= " 2>/dev/null";
-
-        $handle = proc_open($cmd, $descriptorspec, $pipes, $doc_root);
-    }
+    $cmd = [$php_executable, '-t', $doc_root, '-n', '-S', PHP_CURL_SERVER_ADDRESS, $router];
+    $descriptorspec = array(
+        0 => STDIN,
+        1 => STDOUT,
+        2 => array("null"),
+    );
+    $handle = proc_open($cmd, $descriptorspec, $pipes, $doc_root, null, array("suppress_errors" => true));
 
     // note: even when server prints 'Listening on localhost:8964...Press Ctrl-C to quit.'
     //       it might not be listening yet...need to wait until fsockopen() call returns

--- a/ext/soap/tests/bug73037.phpt
+++ b/ext/soap/tests/bug73037.phpt
@@ -63,7 +63,8 @@ function get_data($max)
 }
 
 $router = "bug73037_server.php";
-$args = substr(PHP_OS, 0, 3) == 'WIN' ? "-d extension_dir=" . ini_get("extension_dir") . " -d extension=php_soap.dll" : "";
+$args = substr(PHP_OS, 0, 3) == 'WIN'
+    ? ["-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=php_soap.dll"] : [];
 $code = <<<'PHP'
 $s = new SoapServer(NULL, array('uri' => 'http://here'));
 $s->setObject(new stdclass());

--- a/ext/soap/tests/custom_content_type.phpt
+++ b/ext/soap/tests/custom_content_type.phpt
@@ -15,13 +15,14 @@ server
 
 include __DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc";
 
-$args = substr(PHP_OS, 0, 3) == 'WIN' ? "-d extension_dir=" . ini_get("extension_dir") . " -d extension=php_soap.dll" : "";
+$args = substr(PHP_OS, 0, 3) == 'WIN'
+    ? ["-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=php_soap.dll"] : [];
 $code = <<<'PHP'
 /* Receive */
 $content = trim(file_get_contents("php://input")) . PHP_EOL;
 PHP;
 
-php_cli_server_start($code, false, $args);
+php_cli_server_start($code, null, $args);
 
 $client = new soapclient(NULL, [
   'location' => 'http://' . PHP_CLI_SERVER_ADDRESS,

--- a/ext/standard/tests/general_functions/proc_open_null.phpt
+++ b/ext/standard/tests/general_functions/proc_open_null.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Null pipes in proc_open()
+--FILE--
+<?php
+
+$php = getenv('TEST_PHP_EXECUTABLE');
+$cmd = [$php, '-r', 'echo "Test"; fprintf(STDERR, "Error");'];
+
+$proc = proc_open($cmd, [1 => ['null'], 2 => ['pipe', 'w']], $pipes);
+var_dump($pipes);
+var_dump(stream_get_contents($pipes[2]));
+proc_close($proc);
+
+$proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['null']], $pipes);
+var_dump($pipes);
+var_dump(stream_get_contents($pipes[1]));
+proc_close($proc);
+
+?>
+--EXPECT--
+array(1) {
+  [2]=>
+  resource(4) of type (stream)
+}
+string(5) "Error"
+array(1) {
+  [1]=>
+  resource(6) of type (stream)
+}
+string(4) "Test"

--- a/ext/standard/tests/general_functions/proc_open_redirect.phpt
+++ b/ext/standard/tests/general_functions/proc_open_redirect.phpt
@@ -1,0 +1,64 @@
+--TEST--
+Redirection support in proc_open
+--FILE--
+<?php
+
+$php = getenv('TEST_PHP_EXECUTABLE');
+var_dump(proc_open([$php], [['redirect']], $pipes));
+var_dump(proc_open([$php], [['redirect', 'foo']], $pipes));
+var_dump(proc_open([$php], [['redirect', 42]], $pipes));
+
+echo "\nWith pipe:\n";
+$cmd = [$php, '-r', 'echo "Test\n"; fprintf(STDERR, "Error");'];
+$proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['redirect', 1]], $pipes);
+var_dump($pipes);
+var_dump(stream_get_contents($pipes[1]));
+proc_close($proc);
+
+echo "\nWith filename:\n";
+$fileName = __DIR__ . '/proc_open_redirect.txt';
+$proc = proc_open($cmd, [1 => ['file', $fileName, 'w'], 2 => ['redirect', 1]], $pipes);
+var_dump($pipes);
+proc_close($proc);
+var_dump(file_get_contents($fileName));
+unlink($fileName);
+
+echo "\nWith file:\n";
+$file = fopen($fileName, 'w');
+$proc = proc_open($cmd, [1 => $file, 2 => ['redirect', 1]], $pipes);
+var_dump($pipes);
+proc_close($proc);
+fclose($file);
+var_dump(file_get_contents($fileName));
+unlink($fileName);
+
+?>
+--EXPECTF--
+Warning: proc_open(): Missing redirection target in %s on line %d
+bool(false)
+
+Warning: proc_open(): Redirection target must be an integer in %s on line %d
+bool(false)
+
+Warning: proc_open(): Redirection target 42 not found in %s on line %d
+bool(false)
+
+With pipe:
+array(1) {
+  [1]=>
+  resource(4) of type (stream)
+}
+string(10) "Test
+Error"
+
+With filename:
+array(0) {
+}
+string(10) "Test
+Error"
+
+With file:
+array(0) {
+}
+string(10) "Test
+Error"

--- a/ext/standard/tests/general_functions/proc_open_redirect.phpt
+++ b/ext/standard/tests/general_functions/proc_open_redirect.phpt
@@ -32,6 +32,10 @@ fclose($file);
 var_dump(file_get_contents($fileName));
 unlink($fileName);
 
+echo "\nWith inherited stdout:\n";
+$proc = proc_open($cmd, [2 => ['redirect', 1]], $pipes);
+proc_close($proc);
+
 ?>
 --EXPECTF--
 Warning: proc_open(): Missing redirection target in %s on line %d
@@ -62,3 +66,7 @@ array(0) {
 }
 string(10) "Test
 Error"
+
+With inherited stdout:
+Test
+Error

--- a/sapi/cli/tests/php_cli_server.inc
+++ b/sapi/cli/tests/php_cli_server.inc
@@ -3,7 +3,11 @@ define ("PHP_CLI_SERVER_HOSTNAME", "localhost");
 define ("PHP_CLI_SERVER_PORT", 8964);
 define ("PHP_CLI_SERVER_ADDRESS", PHP_CLI_SERVER_HOSTNAME.":".PHP_CLI_SERVER_PORT);
 
-function php_cli_server_start($code = 'echo "Hello world";', $router = 'index.php', $cmd_args = null) {
+function php_cli_server_start(
+	?string $code = 'echo "Hello world";',
+	?string $router = 'index.php',
+	array $cmd_args = []
+) {
 	$php_executable = getenv('TEST_PHP_EXECUTABLE');
 	$doc_root = __DIR__;
     $error = null;
@@ -12,34 +16,17 @@ function php_cli_server_start($code = 'echo "Hello world";', $router = 'index.ph
 		file_put_contents($doc_root . '/' . ($router ?: 'index.php'), '<?php ' . $code . ' ?>');
 	}
 
-	if (substr(PHP_OS, 0, 3) == 'WIN') {
-		$descriptorspec = array(
-			0 => STDIN,
-			1 => STDOUT,
-			2 => array("pipe", "w"),
-		);
-
-		$cmd = "{$php_executable} -t {$doc_root} -n {$cmd_args} -S " . PHP_CLI_SERVER_ADDRESS;
-		if (!is_null($router)) {
-			$cmd .= " {$router}";
-		}
-
-		$handle = proc_open(addslashes($cmd), $descriptorspec, $pipes, $doc_root, NULL, array("bypass_shell" => true,  "suppress_errors" => true));
-	} else {
-		$descriptorspec = array(
-			0 => STDIN,
-			1 => STDOUT,
-			2 => STDERR,
-		);
-
-		$cmd = "exec {$php_executable} -t {$doc_root} -n {$cmd_args} -S " . PHP_CLI_SERVER_ADDRESS;
-		if (!is_null($router)) {
-			$cmd .= " {$router}";
-		}
-		$cmd .= " 2>/dev/null";
-
-		$handle = proc_open($cmd, $descriptorspec, $pipes, $doc_root);
+	$cmd = [$php_executable, '-t', $doc_root, '-n', ...$cmd_args, '-S', PHP_CLI_SERVER_ADDRESS];
+	if (!is_null($router)) {
+		$cmd[] = $router;
 	}
+
+	$descriptorspec = array(
+		0 => STDIN,
+		1 => STDOUT,
+		2 => array("null"),
+	);
+	$handle = proc_open($cmd, $descriptorspec, $pipes, $doc_root, null, array("suppress_errors" => true));
 
     // note: here we check the process is running
     for ($i=0; $i < 120; $i++) {

--- a/sapi/cli/tests/upload_2G.phpt
+++ b/sapi/cli/tests/upload_2G.phpt
@@ -37,8 +37,8 @@ echo "Test\n";
 
 include "php_cli_server.inc";
 
-php_cli_server_start("var_dump(\$_FILES);", false,
-	"-d post_max_size=3G -d upload_max_filesize=3G");
+php_cli_server_start("var_dump(\$_FILES);", null,
+	["-d", "post_max_size=3G", "-d", "upload_max_filesize=3G"]);
 
 list($host, $port) = explode(':', PHP_CLI_SERVER_ADDRESS);
 $port = intval($port)?:80;

--- a/sapi/fpm/tests/main-global-prefix.phpt
+++ b/sapi/fpm/tests/main-global-prefix.phpt
@@ -27,7 +27,7 @@ EOT;
 
 $prefix = __DIR__;
 $tester = new FPM\Tester($cfg);
-$tester->start('--prefix ' . $prefix);
+$tester->start(['--prefix', $prefix]);
 $tester->expectLogStartNotices();
 $tester->expectFile(FPM\Tester::FILE_EXT_LOG_ACC, $prefix);
 $tester->expectFile(FPM\Tester::FILE_EXT_LOG_ERR, $prefix);

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -320,25 +320,21 @@ class Tester
     /**
      * Start PHP-FPM master process
      *
-     * @param string $extraArgs
+     * @param array $extraArgs
      * @return bool
      * @throws \Exception
      */
-    public function start(string $extraArgs = '')
+    public function start(array $extraArgs = [])
     {
         $configFile = $this->createConfig();
-        $desc = $this->outDesc ? [] : [1 => array('pipe', 'w')];
-        $asRoot = getenv('TEST_FPM_RUN_AS_ROOT') ? '--allow-to-run-as-root' : '';
-        $cmd = self::findExecutable() . " $asRoot -F -O -y $configFile $extraArgs";
-        /* Since it's not possible to spawn a process under linux without using a
-         * shell in php (why?!?) we need a little shell trickery, so that we can
-         * actually kill php-fpm */
-        $this->masterProcess = proc_open(
-            "killit () { kill \$child 2> /dev/null; }; " .
-                "trap killit TERM; $cmd 2>&1 & child=\$!; wait",
-            $desc,
-            $pipes
-        );
+        $desc = $this->outDesc ? [] : [1 => array('pipe', 'w'), 2 => array('redirect', 1)];
+        $cmd = [self::findExecutable(), '-F', '-O', '-y', $configFile];
+        if (getenv('TEST_FPM_RUN_AS_ROOT')) {
+            $cmd[] = '--allow-to-run-as-root';
+        }
+        $cmd = array_merge($cmd, $extraArgs);
+
+        $this->masterProcess = proc_open($cmd, $desc, $pipes);
         register_shutdown_function(
             function($masterProcess) use($configFile) {
                 @unlink($configFile);

--- a/tests/basic/bug67198.phpt
+++ b/tests/basic/bug67198.phpt
@@ -35,7 +35,9 @@ $opts = array('http' =>
 
 $context  = stream_context_create($opts);
 
-php_cli_server_start("exit(file_get_contents('php://input'));", false, "-d enable_post_data_reading=Off");
+php_cli_server_start(
+    "exit(file_get_contents('php://input'));", null,
+    ["-d", "enable_post_data_reading=Off"]);
 
 var_dump(file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS, false, $context));
 var_dump(file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS, false, $context));


### PR DESCRIPTION
This adds support for doing something like:

    [1 => ['pipe', 'w'], 2 => ['redirect', 1]]

This will make descriptor 2 on the child end a dup'd descriptor 1. This is mainly useful in conjunction with shell-less mode, because we don't have an easy way to do `2>&1` there.