### PR TITLE
New test added for an error case on stream_bucket_new function

### DIFF
--- a/ext/standard/tests/streams/stream_bucket_new_error.phpt
+++ b/ext/standard/tests/streams/stream_bucket_new_error.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test stream_bucket_new function with invalid stream.
+--DESCRIPTION--
+If we define an invalid stream to the stream_bucket_new function it should raise a warning and return false.
+Looks like in PHP 8 this is going to throw a Fatal Error
+--CREDITS--
+Vinicius Dias carlosv775@gmail.com
+--FILE--
+<?php
+$bucket = stream_bucket_new(null, 'test');
+var_dump($bucket);
+?>
+--EXPECTF--
+Warning: stream_bucket_new(): supplied argument is not a valid stream resource in %s on line %d
+bool(false)

--- a/ext/standard/tests/streams/stream_bucket_new_error.phpt
+++ b/ext/standard/tests/streams/stream_bucket_new_error.phpt
@@ -1,8 +1,5 @@
 --TEST--
 Test stream_bucket_new function with invalid stream.
---DESCRIPTION--
-If we define an invalid stream to the stream_bucket_new function it should raise a warning and return false.
-Looks like in PHP 8 this is going to throw a Fatal Error
 --CREDITS--
 Vinicius Dias carlosv775@gmail.com
 --FILE--


### PR DESCRIPTION
The function `stream_bucket_new` didn't seem to have any error case test. I added this one that makes sure it returns `false` if the stream isn't valid and also it raises a warning.
Note: Looks like this is going to change on PHP 8 and a Fatal Error is going to be raised.