### PR TITLE
Add a new test covering DOMXPath::__construct error case

### DIFF
--- a/ext/dom/tests/DOMXPath_construct_error.phpt
+++ b/ext/dom/tests/DOMXPath_construct_error.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test to ensure that calling DOMXPath::__construct passing an invalid parameter fails
+--CREDITS--
+Vinicius Dias carlosv775@gmail.com
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+try {
+    new DOMXpath(null);
+} catch (\TypeError $e) {
+    echo $e->getMessage();
+}
+?>
+--EXPECT--
+DOMXPath::__construct() expects parameter 1 to be DOMDocument, null given


### PR DESCRIPTION
Add a new test covering the error thrown when an invalid parameter is passed to DOMXPath::__construct.

This covers the line ext/dom/xpath.c:260 that wasn't previously covered.