### PR TITLE
Remove PHP_DEBUG_MACRO

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2118,37 +2118,6 @@ IFS="- /.
 ])
 
 dnl
-dnl PHP_DEBUG_MACRO(filename)
-dnl
-AC_DEFUN([PHP_DEBUG_MACRO],[
-  DEBUG_LOG=$1
-  cat >$1 <<X
-CONFIGURE:  $CONFIGURE_COMMAND
-CC:         $CC
-CFLAGS:     $CFLAGS
-CPPFLAGS:   $CPPFLAGS
-CXX:        $CXX
-CXXFLAGS:   $CXXFLAGS
-INCLUDES:   $INCLUDES
-LDFLAGS:    $LDFLAGS
-LIBS:       $LIBS
-DLIBS:      $DLIBS
-SAPI:       $PHP_SAPI
-PHP_RPATHS: $PHP_RPATHS
-uname -a:   `uname -a`
-
-X
-    cat >conftest.$ac_ext <<X
-main()
-{
-  exit(0);
-}
-X
-    (eval echo \"$ac_link\"; eval $ac_link && ./conftest) >>$1 2>&1
-    rm -fr conftest*
-])
-
-dnl
 dnl PHP_CONFIG_NICE(filename)
 dnl
 dnl This macro creates script file with given filename which includes the last

--- a/configure.ac
+++ b/configure.ac
@@ -1644,23 +1644,6 @@ if test -n "\$REDO_ALL"; then
     echo "| and make the changes described there and try again.                |"
   fi
 
-  if test -n "$DEBUG_LOG"; then
-    rm -f config.cache
-cat <<X
-+--------------------------------------------------------------------+
-|                       *** ATTENTION ***                            |
-|                                                                    |
-| Something is likely to be messed up here, because the configure    |
-| script was not able to detect a simple feature on your platform.   |
-| This is often caused by incorrect configuration parameters. Please |
-| see the file debug.log for error messages.                         |
-|                                                                    |
-| If you are unable to fix this, send the file debug.log to the      |
-| php-install@lists.php.net mailing list and include appropriate     |
-| information about your setup.                                      |
-X
-  fi
-
     if test "$PHP_SAPI" = "apache2handler"; then
       if test "$APACHE_VERSION" -ge 2004001; then
         if test -z "$APACHE_THREADED_MPM"; then


### PR DESCRIPTION
The PHP_DEBUG_MACRO macro is no longer used and the warning at the end of the configure script output therefore is also no longer used.