### PR TITLE
Remove some more Apache 1 left overs

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2104,7 +2104,7 @@ AC_DEFUN([PHP_INSTALL_HEADERS],[
 dnl
 dnl PHP_AP_EXTRACT_VERSION(/path/httpd)
 dnl
-dnl This macro is used to get a comparable version for apache1/2.
+dnl This macro is used to get a comparable version for Apache.
 dnl
 AC_DEFUN([PHP_AP_EXTRACT_VERSION],[
   ac_output=`$1 -v 2>&1 | grep version | $SED -e 's/Oracle-HTTP-//'`

--- a/configure.ac
+++ b/configure.ac
@@ -1636,14 +1636,6 @@ if test -n "\$REDO_ALL"; then
   cli_extensions="$EXT_CLI_STATIC"
   sh $srcdir/build/genif.sh $srcdir/main/internal_functions.c.in $srcdir "$EXTRA_MODULE_PTRS" $AWK \$cli_extensions > main/internal_functions_cli.c
 
-  if test -n "$PHP_APXS_BROKEN"; then
-    echo "+--------------------------------------------------------------------+"
-    echo "| WARNING: Your $APXS script is most likely broken."
-    echo "|                                                                    |"
-    echo "| Please go read http://www.php.net/faq.build#faq.build.apxs         |"
-    echo "| and make the changes described there and try again.                |"
-  fi
-
   if test -n "$DEBUG_LOG"; then
     rm -f config.cache
 cat <<X

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -1,11 +1,11 @@
 PHP_ARG_WITH([apxs2],,
   [AS_HELP_STRING([[--with-apxs2[=FILE]]],
-    [Build shared Apache 2.0 Handler module. FILE is the optional pathname to
+    [Build shared Apache 2 handler module. FILE is the optional pathname to
     the Apache apxs tool [apxs]])],
   [no],
   [no])
 
-AC_MSG_CHECKING([for Apache 2.0 handler-module support via DSO through APXS])
+AC_MSG_CHECKING([for Apache 2 handler module support via DSO through APXS])
 
 if test "$PHP_APXS2" != "no"; then
   if test "$PHP_APXS2" = "yes"; then
@@ -59,9 +59,7 @@ if test "$PHP_APXS2" != "no"; then
 
   dnl Test that we're trying to configure with apache 2.x
   PHP_AP_EXTRACT_VERSION($APXS_HTTPD)
-  if test "$APACHE_VERSION" -le 2000000; then
-    AC_MSG_ERROR([You have enabled Apache 2 support while your server is Apache 1.3.  Please use the appropriate switch --with-apxs (without the 2)])
-  elif test "$APACHE_VERSION" -lt 2000044; then
+  if test "$APACHE_VERSION" -lt 2000044; then
     AC_MSG_ERROR([Please note that Apache version >= 2.0.44 is required])
   fi
 
@@ -113,7 +111,7 @@ if test "$PHP_APXS2" != "no"; then
       PHP_BUILD_THREAD_SAFE
     fi
   else
-    APACHE_THREADED_MPM=`$APXS_HTTPD -V | grep 'threaded:.*yes'`
+    APACHE_THREADED_MPM=`$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes'`
     if test -n "$APACHE_THREADED_MPM"; then
       PHP_BUILD_THREAD_SAFE
     fi


### PR DESCRIPTION
- warning in configure.ac is relevant for the sapi/apache
- errors output redirected to /dev/null when checking Apache version