### PR TITLE
Remove zend_config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,6 @@ config.h.in
 /main/build-defs.h
 /main/php_config.h.in
 /main/php_config.h
-/Zend/zend_config.h
 
 # ------------------------------------------------------------------------------
 # Manual (man 1 and 8) pages generated from templates for *nix alike systems

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -37,10 +37,8 @@
 # include "zend_config.w32.h"
 # define ZEND_PATHS_SEPARATOR		';'
 #elif defined(__riscos__)
-# include <zend_config.h>
 # define ZEND_PATHS_SEPARATOR		';'
 #else
-# include <zend_config.h>
 # define ZEND_PATHS_SEPARATOR		':'
 #endif
 
@@ -121,8 +119,6 @@
 #endif
 
 #define zend_quiet_write(...) ZEND_IGNORE_VALUE(write(__VA_ARGS__))
-
-/* all HAVE_XXX test have to be after the include of zend_config above */
 
 #if defined(HAVE_LIBDL) && !defined(ZEND_WIN32)
 

--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -118,7 +118,7 @@ clean:
 	rm -f libphp$(PHP_MAJOR_VERSION).la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(OVERALL_TARGET) modules/* libs/*
 
 distclean: clean
-	rm -f Makefile config.cache config.log config.status Makefile.objects Makefile.fragments libtool main/php_config.h main/internal_functions_cli.c main/internal_functions.c Zend/zend_dtrace_gen.h Zend/zend_dtrace_gen.h.bak Zend/zend_config.h
+	rm -f Makefile config.cache config.log config.status Makefile.objects Makefile.fragments libtool main/php_config.h main/internal_functions_cli.c main/internal_functions.c Zend/zend_dtrace_gen.h Zend/zend_dtrace_gen.h.bak
 	rm -f main/build-defs.h scripts/phpize
 	rm -f ext/date/lib/timelib_config.h ext/mbstring/libmbfl/config.h ext/oci8/oci8_dtrace_gen.h ext/oci8/oci8_dtrace_gen.h.bak
 	rm -f scripts/man1/phpize.1 scripts/php-config scripts/man1/php-config.1 sapi/cli/php.1 sapi/cgi/php-cgi.1 sapi/phpdbg/phpdbg.1 ext/phar/phar.1 ext/phar/phar.phar.1

--- a/configure.ac
+++ b/configure.ac
@@ -1606,14 +1606,6 @@ if test "\$CONFIG_FILES" = "$ALL_OUTPUT_FILES" || test "\$CONFIG_FILES" = " $ALL
   REDO_ALL=yes
 fi
 
-dnl Create configuration headers.
-dnl ----------------------------------------------------------------------------
-test -d Zend || $php_shtool mkdir Zend
-
-cat >Zend/zend_config.h <<FEO
-#include <../main/php_config.h>
-FEO
-
 dnl Run this only when generating all the files.
 if test -n "\$REDO_ALL"; then
   echo "creating main/internal_functions.c"

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -39,7 +39,7 @@
 #if ZEND_WIN32
 # include "zend_config.w32.h"
 #else
-#include "zend_config.h"
+# include "php_config.h"
 # include <sys/time.h>
 # include <sys/resource.h>
 #endif


### PR DESCRIPTION
- zend_config.h file is in current code used only on two places and is a simple wrapper for including the main php_config.h instead.
- The APACHE symbol is part of the PHP 3 functionality and is not used anymore.