### PR TITLE
Refactor undefining PACKAGE_* symbols

### DIFF
--- a/build/build.mk
+++ b/build/build.mk
@@ -34,9 +34,7 @@ configure: configure.ac $(PHP_M4_FILES)
 
 $(config_h_in): configure
 # Explicitly remove target since autoheader does not seem to work correctly
-# otherwise (timestamps are not updated). Also disable PACKAGE_* symbols in the
-# generated php_config.h.in template.
+# otherwise (timestamps are not updated).
 	@echo rebuilding $@
 	@rm -f $@
 	@$(PHP_AUTOHEADER) $(PHP_AUTOCONF_FLAGS)
-	@sed -e 's/^#undef PACKAGE_[^ ]*/\/\* & \*\//g' < $@ > $@.tmp && mv $@.tmp $@

--- a/build/php.m4
+++ b/build/php.m4
@@ -2716,3 +2716,19 @@ int main() {
   AC_DEFINE_UNQUOTED(AS_TR_CPP([PHP_HAVE_$1_INSTRUCTIONS]),
    [$have_ext_instructions], [Whether the compiler supports $1 instructions])
 ])
+
+dnl
+dnl PHP_PATCH_CONFIG_HEADERS([FILE])
+dnl
+dnl PACKAGE_* symbols are automatically defined by Autoconf. When including
+dnl php_config.h header in PHP extensions or headers from other libraries
+dnl warnings about redefined symbols are emitted for such symbols. This disables
+dnl all PACKAGE_* symbols in the generated configuration header template FILE.
+dnl For example, php_config.h.in or config.h.in.
+dnl
+AC_DEFUN([PHP_PATCH_CONFIG_HEADERS], [
+  echo "patching $1"
+
+  $SED -e 's/^#undef PACKAGE_[^ ]*/\/\* & \*\//g' < $srcdir/$1 \
+    > $srcdir/$1.tmp && mv $srcdir/$1.tmp $srcdir/$1
+])

--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,12 @@ PHP_CONFIG_NICE(config.nice)
 
 PHP_CANONICAL_HOST_TARGET
 
-AC_CONFIG_HEADERS([main/php_config.h])
+AC_CONFIG_HEADERS(
+  [main/php_config.h],
+  [],
+  [PHP_PATCH_CONFIG_HEADERS([main/php_config.h.in])]
+)
+
 AH_TOP([
 #ifndef PHP_CONFIG_H
 #define PHP_CONFIG_H

--- a/scripts/phpize.in
+++ b/scripts/phpize.in
@@ -163,10 +163,6 @@ phpize_autotools()
 
   $PHP_AUTOCONF   || exit 1
   $PHP_AUTOHEADER || exit 1
-
-  # Disable PACKAGE_* symbols in config.h.in
-  $SED -e 's/^#undef PACKAGE_[^ ]*/\/\* & \*\//g' < config.h.in > config.h.in.tmp
-  mv config.h.in.tmp config.h.in
 }
 
 # Main script

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -212,6 +212,6 @@ PHP_GEN_GLOBAL_MAKEFILE
 
 test -d modules || $php_shtool mkdir modules
 
-AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_HEADERS([config.h], [], [PHP_PATCH_CONFIG_HEADERS([config.h.in])])
 
 AC_OUTPUT


### PR DESCRIPTION
Instead of patching configuration headers template generated by the given tools - autoheader, this moves patching these symbols to the configure step when invoking the config.status and before the configuration file is generated from the patched template.
![php-build-buildconf_3(1)](https://user-images.githubusercontent.com/1614009/60772478-7150d580-a0f7-11e9-9680-cfda65ef0c13.png)

Why?
- To be able to call `autoheader` manually without buildconf and the patch is "coded" in the configure step...