### PR TITLE
Add ReflectionReference::getRefcount()

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6190,7 +6190,7 @@ ZEND_METHOD(reflection_reference, fromArrayElement)
 	}
 
 	/* Treat singleton reference as non-reference. */
-	if (Z_TYPE_P(item) != IS_REFERENCE || Z_REFCOUNT_P(item) == 1) {
+	if (Z_TYPE_P(item) != IS_REFERENCE) {
 		RETURN_NULL();
 	}
 
@@ -6235,6 +6235,30 @@ ZEND_METHOD(reflection_reference, getId)
 	PHP_SHA1Final(digest, &context);
 
 	RETURN_STRINGL((char *) digest, sizeof(digest));
+}
+/* }}} */
+
+/* {{{ proto public int ReflectionReference::getRefcount()
+ *     Returns reference count of the held reference.
+ *     ReflectionReference itself increases the refcount, as such:
+ *      * Refcount 1 indicates that the reference is only held by this ReflectionReference.
+ *      * Refcount 2 indicates that it is a singleton reference (often not treated as a reference).
+ *      * Refcount 3 or higher is an ordinary shared reference. */
+ZEND_METHOD(reflection_reference, getRefcount)
+{
+	reflection_object *intern;
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	intern = Z_REFLECTION_P(getThis());
+	if (Z_TYPE(intern->obj) != IS_REFERENCE) {
+		_DO_THROW("Corrupted ReflectionReference object");
+		return;
+	}
+
+	RETURN_LONG(Z_REFCOUNT(intern->obj));
 }
 /* }}} */
 
@@ -6727,6 +6751,7 @@ ZEND_END_ARG_INFO()
 static const zend_function_entry reflection_reference_functions[] = {
 	ZEND_ME(reflection_reference, fromArrayElement, arginfo_reflection_reference_fromArrayElement, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(reflection_reference, getId, arginfo_reflection__void, ZEND_ACC_PUBLIC)
+	ZEND_ME(reflection_reference, getRefcount, arginfo_reflection__void, ZEND_ACC_PUBLIC)
 
 	/* Always throwing dummy methods */
 	ZEND_ME(reflection, __clone, arginfo_reflection__void, ZEND_ACC_PRIVATE)

--- a/ext/reflection/tests/ReflectionReference.phpt
+++ b/ext/reflection/tests/ReflectionReference.phpt
@@ -13,11 +13,19 @@ echo "fromArrayElement():\n";
 $r0 = ReflectionReference::fromArrayElement($ary, 0);
 var_dump($r0 === null);
 $r1 = ReflectionReference::fromArrayElement($ary, 1);
-var_dump($r1 === null);
+var_dump($r1 instanceof ReflectionReference);
 $r2 = ReflectionReference::fromArrayElement($ary, 2);
 var_dump($r2 instanceof ReflectionReference);
 $r3 = ReflectionReference::fromArrayElement($ary, 3);
 var_dump($r2 instanceof ReflectionReference);
+
+echo "getRefcount():\n";
+var_dump($r1->getRefcount());
+var_dump($r2->getRefcount());
+var_dump($r3->getRefcount());
+
+unset($ary[1]);
+var_dump($r1->getRefcount());
 
 echo "getId() #1:\n";
 var_dump($r2->getId() === $r2->getId());
@@ -47,6 +55,11 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
+getRefcount():
+int(2)
+int(3)
+int(3)
+int(1)
 getId() #1:
 bool(true)
 bool(true)


### PR DESCRIPTION
And don't return null for rc=1 references. Leave it to the user to decide whether or not they want to consider these as references or not.

This is for https://bugs.php.net/bug.php?id=78263. /cc @nicolas-grekas 