### PR TITLE
Throw notice on array offset access of null/bool/int/etc

### DIFF
--- a/Zend/tests/024.phpt
+++ b/Zend/tests/024.phpt
@@ -16,19 +16,23 @@ var_dump($a->$b->{$c[1]});
 ?>
 --EXPECTF--
 Notice: Undefined variable: a in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
 
-Notice: Undefined variable: %s in %s on line %d
+Notice: Undefined variable: a in %s on line %d
 
-Notice: Undefined variable: %s in %s on line %d
+Notice: Undefined variable: c in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
 
 Notice: Undefined variable: a in %s on line %d
 int(1)
 
-Notice: Undefined variable: %s in %s on line %d
+Notice: Undefined variable: a in %s on line %d
 
-Notice: Undefined variable: %s in %s on line %d
+Notice: Undefined variable: b in %s on line %d
 int(0)
 
 Notice: Undefined variable: a in %s on line %d
@@ -44,6 +48,8 @@ Notice: Trying to get property '1' of non-object in %s on line %d
 NULL
 
 Notice: Undefined variable: c in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 
 Notice: Trying to get property '1' of non-object in %s on line %d
 

--- a/Zend/tests/033.phpt
+++ b/Zend/tests/033.phpt
@@ -19,9 +19,39 @@ $arr[][]->bar = 2;
 --EXPECTF--
 Notice: Undefined variable: arr in %s on line %d
 
-Notice: Undefined variable: arr in %s on line %d
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 
 Notice: Undefined variable: arr in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Undefined variable: arr in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 
 Notice: Trying to get property 'foo' of non-object in %s on line %d
 

--- a/Zend/tests/assign_to_var_003.phpt
+++ b/Zend/tests/assign_to_var_003.phpt
@@ -12,7 +12,8 @@ var_dump($var1);
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
+Notice: Trying to access array offset on value of type float in %s on line %d
 NULL
 NULL
 Done

--- a/Zend/tests/call_user_func_007.phpt
+++ b/Zend/tests/call_user_func_007.phpt
@@ -13,6 +13,8 @@ var_dump($a);
 --EXPECTF--
 Notice: Undefined offset: 0 in %s on line %d
 
+Notice: Trying to access array offset on value of type null in %s on line %d
+
 Warning: Parameter 1 to foo() expected to be a reference, value given in %s on line %d
 array(0) {
 }

--- a/Zend/tests/dereference_002.phpt
+++ b/Zend/tests/dereference_002.phpt
@@ -69,6 +69,8 @@ array(2) {
   int(5)
 }
 int(1)
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
 
 Notice: Undefined offset: 4 in %s on line %d

--- a/Zend/tests/dereference_010.phpt
+++ b/Zend/tests/dereference_010.phpt
@@ -21,7 +21,10 @@ var_dump(b()[1]);
 
 ?>
 --EXPECTF--
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
 
 Fatal error: Uncaught Error: Cannot use object of type stdClass as array in %s:%d

--- a/Zend/tests/dereference_014.phpt
+++ b/Zend/tests/dereference_014.phpt
@@ -27,8 +27,12 @@ var_dump($h);
 
 ?>
 --EXPECTF--
+Notice: Trying to access array offset on value of type null in %s on line %d
+
 Notice: Trying to get property 'a' of non-object in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 
 Notice: Trying to get property 'b' of non-object in %s on line %d
 NULL

--- a/Zend/tests/isset_003.phpt
+++ b/Zend/tests/isset_003.phpt
@@ -33,6 +33,8 @@ Notice: Undefined variable: c in %s on line %d
 
 Notice: Undefined variable: d in %s on line %d
 
+Notice: Trying to access array offset on value of type null in %s on line %d
+
 Notice: Trying to get property '' of non-object in %s on line %d
 bool(false)
 bool(true)

--- a/Zend/tests/offset_bool.phpt
+++ b/Zend/tests/offset_bool.phpt
@@ -24,14 +24,31 @@ var_dump($bool[$arr]);
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
+Notice: Trying to access array offset on value of type bool in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type bool in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type bool in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type bool in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type bool in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type bool in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type bool in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type bool in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type bool in %s on line %d
 NULL
 Done

--- a/Zend/tests/offset_long.phpt
+++ b/Zend/tests/offset_long.phpt
@@ -24,14 +24,31 @@ var_dump($long[$arr]);
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type int in %s on line %d
 NULL
 Done

--- a/Zend/tests/offset_null.phpt
+++ b/Zend/tests/offset_null.phpt
@@ -24,14 +24,31 @@ var_dump($null[$arr]);
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
 Done

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2390,10 +2390,14 @@ try_string_offset:
 		}
 	} else {
 		if (type != BP_VAR_IS && UNEXPECTED(Z_TYPE_P(container) == IS_UNDEF)) {
-			ZVAL_UNDEFINED_OP1();
+			container = ZVAL_UNDEFINED_OP1();
 		}
 		if (/*dim_type == IS_CV &&*/ UNEXPECTED(Z_TYPE_P(dim) == IS_UNDEF)) {
 			ZVAL_UNDEFINED_OP2();
+		}
+		if (!is_list && type != BP_VAR_IS) {
+			zend_error(E_NOTICE, "Trying to access array offset on value of type %s",
+				zend_zval_type_name(container));
 		}
 		ZVAL_NULL(result);
 	}

--- a/ext/spl/tests/array_026.phpt
+++ b/ext/spl/tests/array_026.phpt
@@ -8,8 +8,10 @@ $test['d1']['d3'] = 'world';
 var_dump($test, $test3['mmmmm']);
 ?>
 --EXPECTF--
-Notice: Undefined variable: test3 in %s%earray_026.php on line %d
-object(ArrayObject)#%d (1) {
+Notice: Undefined variable: test3 in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
+object(ArrayObject)#1 (1) {
   ["storage":"ArrayObject":private]=>
   array(1) {
     ["d1"]=>

--- a/ext/spl/tests/bug62978.phpt
+++ b/ext/spl/tests/bug62978.phpt
@@ -32,6 +32,8 @@ Notice: Undefined index: epic_magic in %sbug62978.php on line %d
 NULL
 
 Notice: Undefined variable: c in %sbug62978.php on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 NULL
 
 Notice: Undefined index: epic_magic in %sbug62978.php on line %d

--- a/ext/standard/tests/array/bug31158.phpt
+++ b/ext/standard/tests/array/bug31158.phpt
@@ -15,4 +15,6 @@ echo "ok\n";
 ?>
 --EXPECTF--
 Notice: Undefined variable: GLOBALS in %sbug31158.php on line 6
+
+Notice: Trying to access array offset on value of type null in %sbug31158.php on line 6
 ok

--- a/tests/lang/bug25922.phpt
+++ b/tests/lang/bug25922.phpt
@@ -20,4 +20,5 @@ test();
 ?>
 --EXPECT--
 Undefined variable: data
+Trying to access array offset on value of type null
 Undefined index here: ''

--- a/tests/lang/passByReference_003.phpt
+++ b/tests/lang/passByReference_003.phpt
@@ -25,14 +25,16 @@ var_dump($undef2)
 --EXPECTF--
 Passing undefined by value
 
-Notice: Undefined variable: undef1 in %s on line 13
+Notice: Undefined variable: undef1 in %s on line %d
+
+Notice: Trying to access array offset on value of type null in %s on line %d
 
 Inside passbyVal call:
 NULL
 
 After call
 
-Notice: Undefined variable: undef1 in %s on line 15
+Notice: Undefined variable: undef1 in %s on line %d
 NULL
 
 Passing undefined by reference


### PR DESCRIPTION
This is a followup to #2031 for RFC https://wiki.php.net/rfc/notice-for-non-valid-array-container.

This implements the dead-simple variant of throwing a notice for array accesses on null/bool/int/float/resource (everything but array, string and object), while excluding list(), for which we did not reach an agreement on #2031. It does not try to suppress duplicate notices on nested accesses, because the additional complexity is not worthwhile.