### PR TITLE
Fix #78268 Align segments on huge page boundary only for x86

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1227,7 +1227,7 @@ fi
 
 dnl Align segments on huge page boundary
 case $host_alias in
-  *linux*)
+  i[[3456]]86-*-linux-* | x86_64-*-linux-*)
     EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM -Wl,-zcommon-page-size=2097152 -Wl,-zmax-page-size=2097152"
     ;;
 esac


### PR DESCRIPTION
See https://bugs.php.net/bug.php?id=78268
Successfully tested `php -v`  on arm and x86_64