### PR TITLE
Convert short tag to standard tag in Zend test file.

### DIFF
--- a/Zend/tests/bug78271.phpt
+++ b/Zend/tests/bug78271.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #78271: Invalid result of if-else
 --FILE--
-<?
+<?php
 function test($a, $b){
     if ($a==10) {
         $w="x";


### PR DESCRIPTION
Causes test fails for #4263 