### PR TITLE
Fix failed tests for phar

### DIFF
--- a/ext/phar/tests/create_new_and_modify.phpt
+++ b/ext/phar/tests/create_new_and_modify.phpt
@@ -24,6 +24,9 @@ if (function_exists("opcache_get_status")) {
     $status = opcache_get_status();
     if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
         opcache_invalidate($pname . '/a.php', true);
+        // opcache_invalidate is buggy and doesn't work as expected so we add a
+        // minor delay here.
+        sleep(2);
     }
 }
 

--- a/ext/phar/tests/create_new_and_modify.phpt
+++ b/ext/phar/tests/create_new_and_modify.phpt
@@ -20,6 +20,13 @@ $sig1 = $phar->getSignature();
 
 include $pname . '/a.php';
 
+if (function_exists("opcache_get_status")) {
+    $status = opcache_get_status();
+    if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
+        sleep(2);
+    }
+}
+
 file_put_contents($pname .'/a.php', "modified!\n");
 file_put_contents($pname .'/b.php', "another!\n");
 

--- a/ext/phar/tests/create_new_and_modify.phpt
+++ b/ext/phar/tests/create_new_and_modify.phpt
@@ -20,14 +20,6 @@ $sig1 = $phar->getSignature();
 
 include $pname . '/a.php';
 
-if (function_exists("opcache_get_status")) {
-    $status = opcache_get_status();
-    if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
-        ini_set("opcache.revalidate_freq", "0");
-        sleep(2);
-    }
-}
-
 file_put_contents($pname .'/a.php', "modified!\n");
 file_put_contents($pname .'/b.php', "another!\n");
 

--- a/ext/phar/tests/create_new_and_modify.phpt
+++ b/ext/phar/tests/create_new_and_modify.phpt
@@ -23,7 +23,7 @@ include $pname . '/a.php';
 if (function_exists("opcache_get_status")) {
     $status = opcache_get_status();
     if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
-        sleep(2);
+        opcache_invalidate($pname . '/a.php', true);
     }
 }
 

--- a/ext/phar/tests/create_new_and_modify.phpt
+++ b/ext/phar/tests/create_new_and_modify.phpt
@@ -21,11 +21,11 @@ $sig1 = $phar->getSignature();
 include $pname . '/a.php';
 
 if (function_exists("opcache_get_status")) {
-	$status = opcache_get_status();
-	if ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"])) {
-		ini_set("opcache.revalidate_freq", "0");
-		sleep(2);
-	}
+    $status = opcache_get_status();
+    if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
+        ini_set("opcache.revalidate_freq", "0");
+        sleep(2);
+    }
 }
 
 file_put_contents($pname .'/a.php', "modified!\n");

--- a/ext/phar/tests/delete_in_phar.phpt
+++ b/ext/phar/tests/delete_in_phar.phpt
@@ -16,14 +16,6 @@ $files['a.php'] = '<?php echo "This is a\n"; ?>';
 $files['b.php'] = '<?php echo "This is b\n"; ?>';
 $files['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 
-if (function_exists("opcache_get_status")) {
-    $status = opcache_get_status();
-    if (is_array($status) && $status["opcache_enabled"]) {
-        ini_set("opcache.revalidate_freq", "0");
-        sleep(2);
-    }
-}
-
 include 'files/phar_test.inc';
 
 include $pname . '/a.php';

--- a/ext/phar/tests/delete_in_phar.phpt
+++ b/ext/phar/tests/delete_in_phar.phpt
@@ -17,11 +17,11 @@ $files['b.php'] = '<?php echo "This is b\n"; ?>';
 $files['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 
 if (function_exists("opcache_get_status")) {
-	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
-		ini_set("opcache.revalidate_freq", "0");
-		sleep(2);
-	}
+    $status = opcache_get_status();
+    if (is_array($status) && $status["opcache_enabled"]) {
+        ini_set("opcache.revalidate_freq", "0");
+        sleep(2);
+    }
 }
 
 include 'files/phar_test.inc';
@@ -54,4 +54,3 @@ Warning: include(%sdelete_in_phar.phar.php/b/c.php): failed to open stream: phar
 Warning: include(): Failed opening 'phar://%sdelete_in_phar.phar.php/b/c.php' for inclusion (include_path='%s') in %sdelete_in_phar.php on line %d
 
 ===DONE===
-		

--- a/ext/phar/tests/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/delete_in_phar_confirm.phpt
@@ -18,7 +18,7 @@ $files['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 
 if (function_exists("opcache_get_status")) {
 	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
+	if (is_array($status) && $status["opcache_enabled"]) {
 		ini_set("opcache.revalidate_freq", "0");
 		sleep(2);
 	}

--- a/ext/phar/tests/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/delete_in_phar_confirm.phpt
@@ -16,14 +16,6 @@ $files['a.php'] = '<?php echo "This is a\n"; ?>';
 $files['b.php'] = '<?php echo "This is b\n"; ?>';
 $files['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 
-if (function_exists("opcache_get_status")) {
-	$status = opcache_get_status();
-	if (is_array($status) && $status["opcache_enabled"]) {
-		ini_set("opcache.revalidate_freq", "0");
-		sleep(2);
-	}
-}
-
 include 'files/phar_test.inc';
 
 include $pname . '/a.php';

--- a/ext/phar/tests/tar/create_new_and_modify.phpt
+++ b/ext/phar/tests/tar/create_new_and_modify.phpt
@@ -17,7 +17,7 @@ file_put_contents($pname . '/a.php', "brand new!\n");
 if (function_exists("opcache_get_status")) {
     $status = opcache_get_status();
     if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
-        sleep(2);
+        opcache_invalidate($pname . '/a.php', true);
     }
 }
 

--- a/ext/phar/tests/tar/create_new_and_modify.phpt
+++ b/ext/phar/tests/tar/create_new_and_modify.phpt
@@ -14,14 +14,6 @@ $pname = 'phar://' . $fname;
 
 file_put_contents($pname . '/a.php', "brand new!\n");
 
-if (function_exists("opcache_get_status")) {
-    $status = opcache_get_status();
-    if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
-        ini_set("opcache.revalidate_freq", "0");
-        sleep(2);
-    }
-}
-
 $phar = new Phar($fname);
 var_dump($phar->isFileFormat(Phar::TAR));
 $sig1 = md5_file($fname);

--- a/ext/phar/tests/tar/create_new_and_modify.phpt
+++ b/ext/phar/tests/tar/create_new_and_modify.phpt
@@ -15,11 +15,11 @@ $pname = 'phar://' . $fname;
 file_put_contents($pname . '/a.php', "brand new!\n");
 
 if (function_exists("opcache_get_status")) {
-	$status = opcache_get_status();
-	if ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"])) {
-		ini_set("opcache.revalidate_freq", "0");
-		sleep(2);
-	}
+    $status = opcache_get_status();
+    if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
+        ini_set("opcache.revalidate_freq", "0");
+        sleep(2);
+    }
 }
 
 $phar = new Phar($fname);

--- a/ext/phar/tests/tar/create_new_and_modify.phpt
+++ b/ext/phar/tests/tar/create_new_and_modify.phpt
@@ -14,6 +14,13 @@ $pname = 'phar://' . $fname;
 
 file_put_contents($pname . '/a.php', "brand new!\n");
 
+if (function_exists("opcache_get_status")) {
+    $status = opcache_get_status();
+    if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
+        sleep(2);
+    }
+}
+
 $phar = new Phar($fname);
 var_dump($phar->isFileFormat(Phar::TAR));
 $sig1 = md5_file($fname);

--- a/ext/phar/tests/tar/create_new_and_modify.phpt
+++ b/ext/phar/tests/tar/create_new_and_modify.phpt
@@ -18,6 +18,9 @@ if (function_exists("opcache_get_status")) {
     $status = opcache_get_status();
     if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
         opcache_invalidate($pname . '/a.php', true);
+        // opcache_invalidate is buggy and doesn't work as expected so we add a
+        // minor delay here.
+        sleep(2);
     }
 }
 

--- a/ext/phar/tests/tar/delete_in_phar.phpt
+++ b/ext/phar/tests/tar/delete_in_phar.phpt
@@ -18,14 +18,6 @@ $phar['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 $phar->setStub('<?php __HALT_COMPILER(); ?>');
 $phar->stopBuffering();
 
-if (function_exists("opcache_get_status")) {
-    $status = opcache_get_status();
-    if (is_array($status) && $status["opcache_enabled"]) {
-        ini_set("opcache.revalidate_freq", "0");
-        sleep(2);
-    }
-}
-
 include $alias . '/a.php';
 include $alias . '/b.php';
 include $alias . '/b/c.php';

--- a/ext/phar/tests/tar/delete_in_phar.phpt
+++ b/ext/phar/tests/tar/delete_in_phar.phpt
@@ -19,11 +19,11 @@ $phar->setStub('<?php __HALT_COMPILER(); ?>');
 $phar->stopBuffering();
 
 if (function_exists("opcache_get_status")) {
-	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
-		ini_set("opcache.revalidate_freq", "0");
-		sleep(2);
-	}
+    $status = opcache_get_status();
+    if (is_array($status) && $status["opcache_enabled"]) {
+        ini_set("opcache.revalidate_freq", "0");
+        sleep(2);
+    }
 }
 
 include $alias . '/a.php';

--- a/ext/phar/tests/tar/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/tar/delete_in_phar_confirm.phpt
@@ -18,14 +18,6 @@ $phar['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 $phar->setStub('<?php __HALT_COMPILER(); ?>');
 $phar->stopBuffering();
 
-if (function_exists("opcache_get_status")) {
-    $status = opcache_get_status();
-    if (is_array($status) && $status["opcache_enabled"]) {
-        ini_set("opcache.revalidate_freq", "0");
-        sleep(2);
-    }
-}
-
 include $alias . '/a.php';
 include $alias . '/b.php';
 include $alias . '/b/c.php';

--- a/ext/phar/tests/tar/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/tar/delete_in_phar_confirm.phpt
@@ -19,11 +19,11 @@ $phar->setStub('<?php __HALT_COMPILER(); ?>');
 $phar->stopBuffering();
 
 if (function_exists("opcache_get_status")) {
-	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
-		ini_set("opcache.revalidate_freq", "0");
-		sleep(2);
-	}
+    $status = opcache_get_status();
+    if (is_array($status) && $status["opcache_enabled"]) {
+        ini_set("opcache.revalidate_freq", "0");
+        sleep(2);
+    }
 }
 
 include $alias . '/a.php';

--- a/ext/phar/tests/zip/create_new_and_modify.phpt
+++ b/ext/phar/tests/zip/create_new_and_modify.phpt
@@ -17,7 +17,7 @@ file_put_contents($pname . '/a.php', "brand new!\n");
 if (function_exists("opcache_get_status")) {
     $status = opcache_get_status();
     if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
-        sleep(2);
+        opcache_invalidate($pname . '/a.php', true);
     }
 }
 

--- a/ext/phar/tests/zip/create_new_and_modify.phpt
+++ b/ext/phar/tests/zip/create_new_and_modify.phpt
@@ -14,14 +14,6 @@ $pname = 'phar://' . $fname;
 
 file_put_contents($pname . '/a.php', "brand new!\n");
 
-if (function_exists("opcache_get_status")) {
-    $status = opcache_get_status();
-    if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
-        ini_set("opcache.revalidate_freq", "0");
-        sleep(2);
-    }
-}
-
 $phar = new Phar($fname);
 var_dump($phar->isFileFormat(Phar::ZIP));
 $sig1 = md5_file($fname);

--- a/ext/phar/tests/zip/create_new_and_modify.phpt
+++ b/ext/phar/tests/zip/create_new_and_modify.phpt
@@ -15,11 +15,11 @@ $pname = 'phar://' . $fname;
 file_put_contents($pname . '/a.php', "brand new!\n");
 
 if (function_exists("opcache_get_status")) {
-	$status = opcache_get_status();
-	if ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"])) {
-		ini_set("opcache.revalidate_freq", "0");
-		sleep(2);
-	}
+    $status = opcache_get_status();
+    if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
+        ini_set("opcache.revalidate_freq", "0");
+        sleep(2);
+    }
 }
 
 $phar = new Phar($fname);

--- a/ext/phar/tests/zip/create_new_and_modify.phpt
+++ b/ext/phar/tests/zip/create_new_and_modify.phpt
@@ -18,6 +18,9 @@ if (function_exists("opcache_get_status")) {
     $status = opcache_get_status();
     if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
         opcache_invalidate($pname . '/a.php', true);
+        // opcache_invalidate is buggy and doesn't work as expected so we add a
+        // minor delay here.
+        sleep(2);
     }
 }
 

--- a/ext/phar/tests/zip/create_new_and_modify.phpt
+++ b/ext/phar/tests/zip/create_new_and_modify.phpt
@@ -14,6 +14,13 @@ $pname = 'phar://' . $fname;
 
 file_put_contents($pname . '/a.php', "brand new!\n");
 
+if (function_exists("opcache_get_status")) {
+    $status = opcache_get_status();
+    if (is_array($status) && ($status["opcache_enabled"] || (isset($status["file_cache_only"]) && $status["file_cache_only"]))) {
+        sleep(2);
+    }
+}
+
 $phar = new Phar($fname);
 var_dump($phar->isFileFormat(Phar::ZIP));
 $sig1 = md5_file($fname);

--- a/ext/phar/tests/zip/delete_in_phar.phpt
+++ b/ext/phar/tests/zip/delete_in_phar.phpt
@@ -18,14 +18,6 @@ $phar['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 $phar->setStub('<?php __HALT_COMPILER(); ?>');
 $phar->stopBuffering();
 
-if (function_exists("opcache_get_status")) {
-    $status = opcache_get_status();
-    if (is_array($status) && $status["opcache_enabled"]) {
-        ini_set("opcache.revalidate_freq", "0");
-        sleep(2);
-    }
-}
-
 include $alias . '/a.php';
 include $alias . '/b.php';
 include $alias . '/b/c.php';

--- a/ext/phar/tests/zip/delete_in_phar.phpt
+++ b/ext/phar/tests/zip/delete_in_phar.phpt
@@ -19,11 +19,11 @@ $phar->setStub('<?php __HALT_COMPILER(); ?>');
 $phar->stopBuffering();
 
 if (function_exists("opcache_get_status")) {
-	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
-		ini_set("opcache.revalidate_freq", "0");
-		sleep(2);
-	}
+    $status = opcache_get_status();
+    if (is_array($status) && $status["opcache_enabled"]) {
+        ini_set("opcache.revalidate_freq", "0");
+        sleep(2);
+    }
 }
 
 include $alias . '/a.php';
@@ -54,4 +54,3 @@ Warning: include(%sdelete_in_phar.phar.zip/b/c.php): failed to open stream: phar
 Warning: include(): Failed opening 'phar://%sdelete_in_phar.phar.zip/b/c.php' for inclusion (include_path='%s') in %sdelete_in_phar.php on line %d
 
 ===DONE===
-		

--- a/ext/phar/tests/zip/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/zip/delete_in_phar_confirm.phpt
@@ -18,14 +18,6 @@ $phar['b/c.php'] = '<?php echo "This is b/c\n"; ?>';
 $phar->setStub('<?php __HALT_COMPILER(); ?>');
 $phar->stopBuffering();
 
-if (function_exists("opcache_get_status")) {
-    $status = opcache_get_status();
-    if (is_array($status) && $status["opcache_enabled"]) {
-        ini_set("opcache.revalidate_freq", "0");
-        sleep(2);
-    }
-}
-
 include $alias . '/a.php';
 include $alias . '/b.php';
 include $alias . '/b/c.php';

--- a/ext/phar/tests/zip/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/zip/delete_in_phar_confirm.phpt
@@ -19,11 +19,11 @@ $phar->setStub('<?php __HALT_COMPILER(); ?>');
 $phar->stopBuffering();
 
 if (function_exists("opcache_get_status")) {
-	$status = opcache_get_status();
-	if ($status["opcache_enabled"]) {
-		ini_set("opcache.revalidate_freq", "0");
-		sleep(2);
-	}
+    $status = opcache_get_status();
+    if (is_array($status) && $status["opcache_enabled"]) {
+        ini_set("opcache.revalidate_freq", "0");
+        sleep(2);
+    }
 }
 
 include $alias . '/a.php';

--- a/run-tests.php
+++ b/run-tests.php
@@ -258,6 +258,7 @@ NO_PROC_OPEN_ERROR;
 		'log_errors_max_len=0',
 		'opcache.fast_shutdown=0',
 		'opcache.file_update_protection=0',
+		'opcache.revalidate_freq=0',
 		'zend.assertions=1',
 	);
 

--- a/run-tests.php
+++ b/run-tests.php
@@ -258,7 +258,6 @@ NO_PROC_OPEN_ERROR;
 		'log_errors_max_len=0',
 		'opcache.fast_shutdown=0',
 		'opcache.file_update_protection=0',
-		'opcache.revalidate_freq=0',
 		'zend.assertions=1',
 	);
 


### PR DESCRIPTION
- when $status is boolean, E_NOTICE appears and tests fail
- opcache is never enabled on these tests anyway due to php ini settings probably

Tests otherwise fail on latest Ubuntu system, for example with default ./configure step).