### PR TITLE
Convert all php_error_docref0 to php_error_docref

### DIFF
--- a/ext/dba/dba_lmdb.c
+++ b/ext/dba/dba_lmdb.c
@@ -251,14 +251,14 @@ DBA_FIRSTKEY_FUNC(lmdb)
 
 	rc = mdb_txn_begin(LMDB_IT(env), NULL, MDB_RDONLY, &LMDB_IT(txn));
 	if (rc) {
-		php_error_docref0(NULL, E_WARNING, "%s", mdb_strerror(rc));
+		php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		return NULL;
 	}
 
 	rc = mdb_cursor_open(LMDB_IT(txn), LMDB_IT(dbi), &LMDB_IT(cur));
 	if (rc) {
 		mdb_txn_abort(LMDB_IT(txn));
-		php_error_docref0(NULL, E_WARNING, "%s", mdb_strerror(rc));
+		php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		return NULL;
 	}
 
@@ -268,7 +268,7 @@ DBA_FIRSTKEY_FUNC(lmdb)
 		mdb_cursor_close(LMDB_IT(cur));
 		LMDB_IT(cur) = NULL;
 		if (MDB_NOTFOUND != rc) {
-			php_error_docref0(NULL, E_WARNING, "%s", mdb_strerror(rc));
+			php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		}
 		return NULL;
 	}
@@ -291,7 +291,7 @@ DBA_NEXTKEY_FUNC(lmdb)
 
 	rc = mdb_txn_renew(LMDB_IT(txn));
 	if (rc) {
-		php_error_docref0(NULL, E_WARNING, "%s", mdb_strerror(rc));
+		php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		return NULL;
 	}
 
@@ -301,7 +301,7 @@ DBA_NEXTKEY_FUNC(lmdb)
 		mdb_cursor_close(LMDB_IT(cur));
 		LMDB_IT(cur) = NULL;
 		if (MDB_NOTFOUND != rc) {
-			php_error_docref0(NULL, E_WARNING, "%s", mdb_strerror(rc));
+			php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		}
 		return NULL;
 	}
@@ -327,7 +327,7 @@ DBA_SYNC_FUNC(lmdb)
 
 	rc = mdb_env_sync(LMDB_IT(env), 1);
 	if (rc) {
-			php_error_docref0(NULL, E_WARNING, "%s", mdb_strerror(rc));
+			php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 			return FAILURE;
 	}
 

--- a/ext/intl/idn/idn.c
+++ b/ext/intl/idn/idn.c
@@ -287,7 +287,7 @@ static void php_intl_idn_handoff(INTERNAL_FUNCTION_PARAMETERS, int mode)
 
 	if (idna_info != NULL) {
 		if (variant == INTL_IDN_VARIANT_2003) {
-			php_error_docref0(NULL, E_NOTICE,
+			php_error_docref(NULL, E_NOTICE,
 				"4 arguments were provided, but INTL_IDNA_VARIANT_2003 only "
 				"takes 3 - extra argument ignored");
 		} else {

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -505,7 +505,7 @@ U_CFUNC void timezone_register_IntlTimeZone_class(void)
 	TimeZone_ce_ptr = zend_register_internal_class(&ce);
 	if (!TimeZone_ce_ptr) {
 		//can't happen now without bigger problems before
-		php_error_docref0(NULL, E_ERROR,
+		php_error_docref(NULL, E_ERROR,
 			"IntlTimeZone: class registration has failed.");
 		return;
 	}

--- a/ext/intl/transliterator/transliterator_class.c
+++ b/ext/intl/transliterator/transliterator_class.c
@@ -241,7 +241,7 @@ static zval *Transliterator_read_property( zval *object, zval *member, int type,
 		( zend_binary_strcmp( "id", sizeof( "id" ) - 1,
 		Z_STRVAL_P( member ), Z_STRLEN_P( member ) ) == 0 ) )
 	{
-		php_error_docref0( NULL, E_WARNING, "The property \"id\" is read-only" );
+		php_error_docref(NULL, E_WARNING, "The property \"id\" is read-only" );
 		retval = &EG( uninitialized_zval );
 	}
 	else
@@ -271,7 +271,7 @@ static zval *Transliterator_write_property( zval *object, zval *member, zval *va
 		( zend_binary_strcmp( "id", sizeof( "id" ) - 1,
 		Z_STRVAL_P( member ), Z_STRLEN_P( member ) ) == 0 ) )
 	{
-		php_error_docref0( NULL, E_WARNING, "The property \"id\" is read-only" );
+		php_error_docref(NULL, E_WARNING, "The property \"id\" is read-only" );
 	}
 	else
 	{

--- a/ext/intl/transliterator/transliterator_methods.c
+++ b/ext/intl/transliterator/transliterator_methods.c
@@ -339,7 +339,7 @@ PHP_FUNCTION( transliterator_transliterate )
 			if( res == FAILURE )
 			{
 				zend_string *message = intl_error_get_message( NULL );
-				php_error_docref0( NULL, E_WARNING, "Could not create "
+				php_error_docref(NULL, E_WARNING, "Could not create "
 					"transliterator with ID \"%s\" (%s)", Z_STRVAL_P( arg1 ), ZSTR_VAL(message) );
 				zend_string_free( message );
 				ZVAL_UNDEF(&tmp_object);

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -199,7 +199,7 @@ static void do_to_zval_err(res_context *ctx, const char *fmt, ...)
 void err_msg_dispose(struct err_s *err)
 {
 	if (err->msg != NULL) {
-		php_error_docref0(NULL, err->level, "%s", err->msg);
+		php_error_docref(NULL, err->level, "%s", err->msg);
 		if (err->should_free) {
 			efree(err->msg);
 		}

--- a/ext/sockets/sendrecvmsg.c
+++ b/ext/sockets/sendrecvmsg.c
@@ -71,7 +71,7 @@ inline ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags)
 #define LONG_CHECK_VALID_INT(l) \
 	do { \
 		if ((l) < INT_MIN && (l) > INT_MAX) { \
-			php_error_docref0(NULL, E_WARNING, "The value " ZEND_LONG_FMT " does not fit inside " \
+			php_error_docref(NULL, E_WARNING, "The value " ZEND_LONG_FMT " does not fit inside " \
 					"the boundaries of a native integer", (l)); \
 			return; \
 		} \
@@ -292,14 +292,14 @@ PHP_FUNCTION(socket_cmsg_space)
 	LONG_CHECK_VALID_INT(n);
 
 	if (n < 0) {
-		php_error_docref0(NULL, E_WARNING, "The third argument "
+		php_error_docref(NULL, E_WARNING, "The third argument "
 				"cannot be negative");
 		return;
 	}
 
 	entry = get_ancillary_reg_entry(level, type);
 	if (entry == NULL) {
-		php_error_docref0(NULL, E_WARNING, "The pair level " ZEND_LONG_FMT "/type " ZEND_LONG_FMT " is "
+		php_error_docref(NULL, E_WARNING, "The pair level " ZEND_LONG_FMT "/type " ZEND_LONG_FMT " is "
 				"not supported by PHP", level, type);
 		return;
 	}
@@ -307,7 +307,7 @@ PHP_FUNCTION(socket_cmsg_space)
 	if (entry->var_el_size > 0 && n > (zend_long)((ZEND_LONG_MAX - entry->size -
 			CMSG_SPACE(0) - 15L) / entry->var_el_size)) {
 		/* the -15 is to account for any padding CMSG_SPACE may add after the data */
-		php_error_docref0(NULL, E_WARNING, "The value for the "
+		php_error_docref(NULL, E_WARNING, "The value for the "
 				"third argument (" ZEND_LONG_FMT ") is too large", n);
 		return;
 	}
@@ -331,7 +331,7 @@ int php_do_setsockopt_ipv6_rfc3542(php_socket *php_sock, int level, int optname,
 	case IPV6_PKTINFO:
 #ifdef PHP_WIN32
 		if (Z_TYPE_P(arg4) == IS_ARRAY) {
-			php_error_docref0(NULL, E_WARNING, "Windows does not "
+			php_error_docref(NULL, E_WARNING, "Windows does not "
 					"support sticky IPV6_PKTINFO");
 			return FAILURE;
 		} else {

--- a/ext/standard/html.c
+++ b/ext/standard/html.c
@@ -1187,7 +1187,7 @@ PHPAPI zend_string *php_escape_html_entities_ex(unsigned char *old, size_t oldle
 
 	if (all) { /* replace with all named entities */
 		if (CHARSET_PARTIAL_SUPPORT(charset)) {
-			php_error_docref0(NULL, E_STRICT, "Only basic entities "
+			php_error_docref(NULL, E_STRICT, "Only basic entities "
 				"substitution is supported for multi-byte encodings other than UTF-8; "
 				"functionality is equivalent to htmlspecialchars");
 		}

--- a/main/main.c
+++ b/main/main.c
@@ -1163,9 +1163,9 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int typ
 }
 /* }}} */
 
-/* {{{ php_error_docref0 */
-/* See: CODING_STANDARDS.md for details. */
-PHPAPI ZEND_COLD void php_error_docref0(const char *docref, int type, const char *format, ...)
+/* {{{ php_error_docref */
+/* Generate an error which links to docref or the php.net documentation if docref is NULL */
+PHPAPI ZEND_COLD void php_error_docref(const char *docref, int type, const char *format, ...)
 {
 	va_list args;
 

--- a/main/php.h
+++ b/main/php.h
@@ -339,7 +339,7 @@ static inline ZEND_ATTRIBUTE_DEPRECATED void php_std_error_handling() {}
 PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int type, const char *format, va_list args) PHP_ATTRIBUTE_FORMAT(printf, 4, 0);
 
 /* PHPAPI void php_error(int type, const char *format, ...); */
-PHPAPI ZEND_COLD void php_error_docref0(const char *docref, int type, const char *format, ...)
+PHPAPI ZEND_COLD void php_error_docref(const char *docref, int type, const char *format, ...)
 	PHP_ATTRIBUTE_FORMAT(printf, 3, 4);
 PHPAPI ZEND_COLD void php_error_docref1(const char *docref, const char *param1, int type, const char *format, ...)
 	PHP_ATTRIBUTE_FORMAT(printf, 4, 5);
@@ -349,8 +349,6 @@ PHPAPI ZEND_COLD void php_error_docref2(const char *docref, const char *param1, 
 PHPAPI ZEND_COLD void php_win32_docref2_from_error(DWORD error, const char *param1, const char *param2);
 #endif
 END_EXTERN_C()
-
-#define php_error_docref php_error_docref0
 
 #define zenderror phperror
 #define zendlex phplex


### PR DESCRIPTION
Splits #4254 

Takes the rather straight forward conversion of ``php_error_docref0()`` to ``php_error_docref()`` and remove the define in ``php.h``