### PR TITLE
Remove unused recode extension artefacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
       - libenchant-dev
       - libaspell-dev
       - libpspell-dev
-      - librecode-dev
       - libsasl2-dev
       - libxpm-dev
       - libzip-dev

--- a/EXTENSIONS
+++ b/EXTENSIONS
@@ -429,11 +429,6 @@ PRIMARY MAINTAINER:  Unkown
 MAINTENANCE:         Unknown
 STATUS:              Working
 -------------------------------------------------------------------------------
-EXTENSION:           recode
-PRIMARY MAINTAINER:  Kristian Köhntopp <kris@koehntopp.de> (2000 - 2000)
-MAINTENANCE:         Maintained
-STATUS:              Working
--------------------------------------------------------------------------------
 EXTENSION:           reflection
 PRIMARY MAINTAINER:  Marcus Börger <helly@php.net> (2003 - 2009)
                      Johannes Schlüter <johannes@php.net> (2006 - 2014)

--- a/azure/apt.yml
+++ b/azure/apt.yml
@@ -15,7 +15,6 @@ steps:
                        libenchant-dev \
                        libaspell-dev \
                        libpspell-dev \
-                       librecode-dev \
                        libsasl2-dev \
                        libxpm-dev \
                        libzip-dev \

--- a/azure/i386/apt.yml
+++ b/azure/i386/apt.yml
@@ -22,7 +22,6 @@ steps:
                               libenchant-dev:i386 \
                               libaspell-dev:i386 \
                               libpspell-dev:i386 \
-                              librecode-dev:i386 \
                               libsasl2-dev:i386 \
                               libxpm-dev:i386 \
                               libjpeg-dev:i386 \

--- a/ext/standard/credits_ext.h
+++ b/ext/standard/credits_ext.h
@@ -56,7 +56,6 @@ CREDIT_LINE("PostgreSQL driver for PDO", "Edin Kadribasic, Ilia Alshanetsky");
 CREDIT_LINE("PostgreSQL", "Jouni Ahto, Zeev Suraski, Yasuo Ohgaki, Chris Kings-Lynne");
 CREDIT_LINE("Pspell", "Vlad Krupin");
 CREDIT_LINE("Readline", "Thies C. Arntzen");
-CREDIT_LINE("Recode", "Kristian Koehntopp");
 CREDIT_LINE("Reflection", "Marcus Boerger, Timm Friebe, George Schlossnagle, Andrei Zmievski, Johannes Schlueter");
 CREDIT_LINE("Sessions", "Sascha Schumann, Andrei Zmievski");
 CREDIT_LINE("Shared Memory Operations", "Slava Poliakov, Ilia Alshanetsky");


### PR DESCRIPTION
Follow up of 58b607c9ea6cdc631a61b18de0cf5c0b3c96c074

I'm not sure where is the best place to note contributors such as the one being removed from here (luckily there is another mention in the posix extension). This shouldn't be removed actually from php-src but the `scripts/dev/credits` is currently made to sync all such data :/ I don't like it but I also don't have any good solution at the moment regarding this.