### PR TITLE
Remove WARNING_LEVEL fix for QNX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -547,13 +547,9 @@ PHP_CHECK_CPU_SUPPORTS([avx2])
 dnl Check for structure members.
 AC_CHECK_MEMBERS([struct tm.tm_gmtoff],,,[#include <time.h>])
 AC_CHECK_MEMBERS([struct stat.st_blksize, struct stat.st_rdev])
-dnl AC_STRUCT_ST_BLOCKS will screw QNX because fileblocks.o does not exist. The
-dnl WARNING_LEVEL required because cc in QNX hates -w option without an argument
+dnl AC_STRUCT_ST_BLOCKS will screw QNX because fileblocks.o does not exist.
 if test "`uname -s 2>/dev/null`" != "QNX"; then
   AC_STRUCT_ST_BLOCKS
-else
-  AC_MSG_WARN([warnings level for cc set to 0])
-  WARNING_LEVEL=0
 fi
 
 dnl Checks for types.
@@ -1429,7 +1425,6 @@ PHP_SUBST_OLD(PHP_VERSION)
 PHP_SUBST_OLD(PHP_VERSION_ID)
 PHP_SUBST(SHELL)
 PHP_SUBST(SHARED_LIBTOOL)
-PHP_SUBST(WARNING_LEVEL)
 PHP_SUBST(PHP_FRAMEWORKS)
 PHP_SUBST(PHP_FRAMEWORKPATH)
 PHP_SUBST(INSTALL_HEADERS)


### PR DESCRIPTION
Fix is no longer relevant since the environment variable WARNING_LEVEL is no longer used to define the value of the -w option for cc.

WARNING_LEVEL was once used in Makefiles via `$(CC) $(CFLAGS) -w$(WARNING_LEVEL) ...`

For example, removed via 2c0ad3ee25cd8e449b02c4668a39f48998507739
