### PR TITLE
Remove PHP_MYSQL variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1436,12 +1436,6 @@ if test "$PHP_THREAD_SAFETY" = "yes" && test -n "$ac_cv_pthreads_cflags"; then
   CPPFLAGS="$CPPFLAGS $ac_cv_pthreads_cflags"
 fi
 
-dnl This will go away, if we have a facility to run per-extension code after the
-dnl thread_safety decision was done.
-if test "$PHP_THREAD_SAFETY" = "yes" && test "$PHP_MYSQL" = "yes"; then
-  CPPFLAGS="$CPPFLAGS -DTHREAD=1"
-fi
-
 if test "$PHP_WERROR" = "yes"; then
   CFLAGS="$CFLAGS -Werror"
   CPPFLAGS="$CPPFLAGS -Werror"

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -131,15 +131,14 @@ if test "$PHP_PDO_MYSQL" != "no"; then
     AC_DEFINE_UNQUOTED(PDO_MYSQL_UNIX_ADDR, "$PDO_MYSQL_SOCKET", [ ])
   fi
 
-  dnl fix after renaming to pdo_mysql
   PHP_NEW_EXTENSION(pdo_mysql, pdo_mysql.c mysql_driver.c mysql_statement.c, $ext_shared,,-I$pdo_cv_inc_path -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  ifdef([PHP_ADD_EXTENSION_DEP],
-  [
-    PHP_ADD_EXTENSION_DEP(pdo_mysql, pdo)
-    if test "$PHP_MYSQL" = "mysqlnd"; then
-      PHP_ADD_EXTENSION_DEP(pdo_mysql, mysqlnd)
-    fi
-  ])
+
+  PHP_ADD_EXTENSION_DEP(pdo_mysql, pdo)
+
+  if test "$PHP_PDO_MYSQL" = "yes" || test "$PHP_PDO_MYSQL" = "mysqlnd"; then
+    PHP_ADD_EXTENSION_DEP(pdo_mysql, mysqlnd)
+  fi
+
   PDO_MYSQL_MODULE_TYPE=external
 
   PHP_SUBST(PDO_MYSQL_SHARED_LIBADD)


### PR DESCRIPTION
PHP_MYSQL variable was once defined by the ext/mysql (--with-mysql).