### PR TITLE
Remove timelib outdated defines

### DIFF
--- a/ext/date/config.w32
+++ b/ext/date/config.w32
@@ -8,8 +8,6 @@ ADD_FLAG('CFLAGS_DATE', "/wd4244");
 var tl_config = FSO.CreateTextFile("ext/date/lib/timelib_config.h", true);
 tl_config.WriteLine("#include \"config.w32.h\"");
 tl_config.WriteLine("#include <php_stdint.h>");
-tl_config.WriteLine("#define TIMELIB_OMIT_STDINT 1");
-tl_config.WriteLine("#define HAVE_GETTIMEOFDAY 1");
 tl_config.WriteLine("#include \"zend.h\"");
 tl_config.WriteLine("#define timelib_malloc  emalloc");
 tl_config.WriteLine("#define timelib_realloc erealloc");

--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -24,7 +24,6 @@ cat > $ext_builddir/lib/timelib_config.h <<EOF
 # include <php_config.h>
 #endif
 #include <php_stdint.h>
-#define TIMELIB_OMIT_STDINT 1
 
 #include "zend.h"
 

--- a/ext/date/lib/timelib_config.h.win32
+++ b/ext/date/lib/timelib_config.h.win32
@@ -1,1 +1,0 @@
-# include "config.w32.h"

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -69,7 +69,6 @@
 #define HSREGEX 1
 #define HAVE_GCVT 1
 #define HAVE_GETLOGIN 1
-#define HAVE_GETTIMEOFDAY 1
 #define HAVE_MEMMOVE 1
 #define HAVE_PUTENV 1
 #define HAVE_REGCOMP 1


### PR DESCRIPTION
- TIMELIB_OMIT_STDINT is not used anymore since
  https://github.com/derickr/timelib/commit/a171f99cf02baf39549ab7209e37565b8b8f6529
- HAVE_GETTIMEOFDAY was defined multiple times in Windows headers
- ext/date/lib/timelib_config.h.win32 does not seem to be used