### PR TITLE
Cleanup of remaning E_STRICT

### DIFF
--- a/Zend/tests/bug33771.phpt
+++ b/Zend/tests/bug33771.phpt
@@ -3,7 +3,7 @@ Bug #33771 (error_reporting falls to 0 when @ was used inside try/catch block)
 --FILE--
 <?php
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 var_dump(error_reporting());
 
@@ -14,7 +14,7 @@ function make_exception()
 
 function make_exception_and_change_err_reporting()
 {
-    error_reporting(E_ALL & ~E_STRICT);
+    error_reporting(E_ALL & ~E_NOTICE);
     throw new Exception();
 }
 
@@ -36,5 +36,5 @@ echo "Done\n";
 --EXPECT--
 int(32767)
 int(32767)
-int(30719)
+int(32759)
 Done

--- a/Zend/tests/bug52160.phpt
+++ b/Zend/tests/bug52160.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #52160 (Invalid E_STRICT redefined constructor error)
+Bug #52160 (Invalid E_DEPRECATED redefined constructor error)
 --FILE--
 <?php
 

--- a/Zend/tests/bug62956.phpt
+++ b/Zend/tests/bug62956.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #62956: "incompatible" signatures for private methods should not cause E_STRICT
+Bug #62956: "incompatible" signatures for private methods should not cause E_WARNING
 --FILE--
 <?php
 class Base

--- a/Zend/tests/bug64988.phpt
+++ b/Zend/tests/bug64988.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #64988 (Class loading order affects E_STRICT warning)
+Bug #64988 (Class loading order affects E_WARNING warning)
 --FILE--
 <?php
 abstract class Base1 {

--- a/Zend/tests/bug67436/bug67436_nohandler.phpt
+++ b/Zend/tests/bug67436/bug67436_nohandler.phpt
@@ -1,5 +1,5 @@
 --TEST--
-bug67436: E_STRICT instead of custom error handler
+bug67436: E_WARNING instead of custom error handler
 --FILE--
 <?php
 

--- a/Zend/tests/error_reporting02.phpt
+++ b/Zend/tests/error_reporting02.phpt
@@ -3,13 +3,13 @@ testing @ and error_reporting - 2
 --FILE--
 <?php
 
-error_reporting(E_ALL);
+error_reporting(E_ALL & ~E_DEPRECATED);
 
 function foo($arg) {
 }
 
 function bar() {
-	error_reporting(E_ALL|E_STRICT);
+	error_reporting(E_ALL);
 	throw new Exception("test");
 }
 

--- a/Zend/tests/error_reporting03.phpt
+++ b/Zend/tests/error_reporting03.phpt
@@ -3,7 +3,7 @@ testing @ and error_reporting - 3
 --FILE--
 <?php
 
-error_reporting(E_ALL);
+error_reporting(E_ALL & ~E_DEPRECATED);
 
 function foo($arg) {
 	echo @$nonex_foo;
@@ -16,7 +16,7 @@ function bar() {
 
 function foo1() {
 	echo $undef1;
-	error_reporting(E_ALL|E_STRICT);
+	error_reporting(E_ALL);
 	echo $undef2;
 }
 

--- a/Zend/tests/error_reporting04.phpt
+++ b/Zend/tests/error_reporting04.phpt
@@ -3,11 +3,11 @@ testing @ and error_reporting - 4
 --FILE--
 <?php
 
-error_reporting(E_ALL);
+error_reporting(E_ALL & ~E_DEPRECATED);
 
 function foo() {
 	echo $undef;
-	error_reporting(E_ALL|E_STRICT);
+	error_reporting(E_ALL);
 }
 
 

--- a/Zend/tests/error_reporting08.phpt
+++ b/Zend/tests/error_reporting08.phpt
@@ -3,7 +3,7 @@ testing @ and error_reporting - 8
 --FILE--
 <?php
 
-error_reporting(E_ALL);
+error_reporting(E_ALL & ~E_DEPRECATED);
 
 function foo1($arg) {
 }
@@ -12,7 +12,7 @@ function foo2($arg) {
 }
 
 function foo3() {
-	error_reporting(E_ALL|E_STRICT);
+	error_reporting(E_ALL);
 	echo $undef3;
 	throw new Exception("test");
 }

--- a/Zend/tests/error_reporting09.phpt
+++ b/Zend/tests/error_reporting09.phpt
@@ -3,7 +3,7 @@ testing @ and error_reporting - 9
 --FILE--
 <?php
 
-error_reporting(E_ALL);
+error_reporting(E_ALL & ~E_DEPRECATED);
 
 function bar() {
 	echo @$blah;
@@ -12,7 +12,7 @@ function bar() {
 
 function foo() {
 	echo @$undef;
-	error_reporting(E_ALL|E_STRICT);
+	error_reporting(E_ALL);
 	echo $blah;
 	return bar();
 }

--- a/Zend/tests/exception_004.phpt
+++ b/Zend/tests/exception_004.phpt
@@ -3,8 +3,6 @@ Throwing exception using a class that isn't derived from the Exception base clas
 --FILE--
 <?php
 
-error_reporting(E_ALL|E_STRICT);
-
 class Foo { }
 
 try {

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -764,7 +764,7 @@ static int make_callable_ex(pdo_stmt_t *stmt, zval *callable, zend_fcall_info * 
 		return 0;
 	}
 	if (is_callable_error) {
-		/* Possible E_STRICT error message */
+		/* Possible error message */
 		efree(is_callable_error);
 	}
 

--- a/ext/pdo_mysql/tests/pdo_mysql_subclass.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_subclass.phpt
@@ -10,10 +10,6 @@ MySQLPDOTest::skip();
 <?php
 	require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 
-	// No silly strict mode warnings, please!
-	error_reporting(E_ALL^E_STRICT);
-	ini_set('display_errors', false);
-
 	try {
 
 		class MyPDO extends PDO {
@@ -23,9 +19,9 @@ MySQLPDOTest::skip();
 				return call_user_func_array(array($this, 'parent::__construct'), func_get_args());
 			}
 
-			public function exec() {
+			public function exec($statement) {
 				$this->protocol();
-				return call_user_func_array(array($this, 'parent::exec'), func_get_args());
+				return parent::exec($statement);
 			}
 
 			public function query() {

--- a/ext/pdo_pgsql/tests/bug72294.phpt
+++ b/ext/pdo_pgsql/tests/bug72294.phpt
@@ -74,7 +74,7 @@ class PHPUnit_Framework_TestResult
 
         $oldErrorHandler = set_error_handler(
             'handleError',
-            E_ALL | E_STRICT
+            E_ALL
         );
 
         try {

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -934,7 +934,7 @@ int phar_free_alias(phar_archive_data *phar, char *alias, size_t alias_len) /* {
 		return FAILURE;
 	}
 
-	/* this archive has no open references, so emit an E_STRICT and remove it */
+	/* this archive has no open references, so emit a notice and remove it */
 	if (zend_hash_str_del(&(PHAR_G(phar_fname_map)), phar->fname, phar->fname_len) != SUCCESS) {
 		return FAILURE;
 	}

--- a/ext/soap/tests/bugs/bug46427.phpt
+++ b/ext/soap/tests/bugs/bug46427.phpt
@@ -4,7 +4,6 @@ Bug #46427 (SoapClient() stumbles over its "stream_context" parameter)
 <?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
-error_reporting(E_ALL|E_STRICT);
 
 function getSoapClient_1() {
     $ctx = stream_context_create();

--- a/ext/standard/tests/general_functions/parse_ini_booleans.data
+++ b/ext/standard/tests/general_functions/parse_ini_booleans.data
@@ -3,8 +3,8 @@ foo = E_ALL E_NOTICE
 error_reporting = E_ALL
 error_reporting1 = E_COMPILE_ERROR|E_RECOVERABLE_ERROR	|E_ERROR|E_CORE_ERROR 	
 error_reporting2 = E_ALL&~E_NOTICE	 	 	
-error_reporting3 =  E_ALL & ~E_NOTICE 	 
-error_reporting4 = E_ALL & ~E_NOTICE | E_STRICT 
+error_reporting3 =  E_ALL & ~E_NOTICE
+error_reporting4 = E_ALL & ~E_NOTICE | E_PARSE
 
 ['true or false']
 bool_true = 	true 

--- a/ext/standard/tests/mail/mail_basic_alt1-win32.phpt
+++ b/ext/standard/tests/mail/mail_basic_alt1-win32.phpt
@@ -19,7 +19,6 @@ max_execution_time = 120
  * Alias to functions:
  */
 
-error_reporting(E_ALL & ~E_STRICT);
 ini_set("SMTP", "localhost");
 ini_set("smtp_port", 25);
 ini_set("sendmail_from", "user@example.com");

--- a/ext/standard/tests/mail/mail_basic_alt2-win32.phpt
+++ b/ext/standard/tests/mail/mail_basic_alt2-win32.phpt
@@ -18,8 +18,6 @@ max_execution_time = 120
  * Alias to functions:
  */
 
-error_reporting(E_ALL & ~E_STRICT);
-
 echo "*** Testing mail() : basic functionality ***\n";
 require_once(__DIR__.'/mail_include.inc');
 $subject_prefix = "!**PHPT**!";

--- a/ext/standard/tests/mail/mail_basic_alt3-win32.phpt
+++ b/ext/standard/tests/mail/mail_basic_alt3-win32.phpt
@@ -18,8 +18,6 @@ max_execution_time = 120
  * Alias to functions:
  */
 
-error_reporting(E_ALL & ~E_STRICT);
-
 echo "*** Testing mail() : basic functionality ***\n";
 require_once(__DIR__.'/mail_include.inc');
 $subject_prefix = "!**PHPT**!";

--- a/ext/standard/tests/mail/mail_basic_alt4-win32.phpt
+++ b/ext/standard/tests/mail/mail_basic_alt4-win32.phpt
@@ -18,8 +18,6 @@ max_execution_time = 120
  * Alias to functions:
  */
 
-error_reporting(E_ALL & ~E_STRICT);
-
 echo "*** Testing mail() : basic functionality ***\n";
 require_once(__DIR__.'/mail_include.inc');
 $subject_prefix = "!**PHPT**!";

--- a/ext/standard/tests/mail/mail_variation_alt1-win32.phpt
+++ b/ext/standard/tests/mail/mail_variation_alt1-win32.phpt
@@ -18,7 +18,6 @@ max_execution_time = 120
  * Alias to functions:
  */
 
-error_reporting(E_ALL & ~E_STRICT);
 ini_set("SMTP", "localhost");
 ini_set("smtp_port", 2525);
 ini_set("sendmail_from", "user@example.com");

--- a/ext/standard/tests/mail/mail_variation_alt2-win32.phpt
+++ b/ext/standard/tests/mail/mail_variation_alt2-win32.phpt
@@ -18,7 +18,6 @@ max_execution_time = 120
  * Alias to functions:
  */
 
-error_reporting(E_ALL & ~E_STRICT);
 ini_set("SMTP", "localplace");
 ini_set("smtp_port", 25);
 ini_set("sendmail_from", "user@example.com");

--- a/ext/standard/tests/mail/mail_variation_alt3-win32.phpt
+++ b/ext/standard/tests/mail/mail_variation_alt3-win32.phpt
@@ -18,7 +18,6 @@ max_execution_time = 120
  * Alias to functions:
  */
 
-error_reporting(E_ALL & ~E_STRICT);
 ini_set("SMTP", "localhost");
 ini_set("smtp_port", 25);
 

--- a/ext/zip/examples/get_set_comments.php
+++ b/ext/zip/examples/get_set_comments.php
@@ -1,5 +1,4 @@
 <?php
-error_reporting(E_ALL|E_STRICT);
 
 copy('test_with_comment.zip', 't.zip');
 $z = new ZipArchive;

--- a/run-tests.php
+++ b/run-tests.php
@@ -238,7 +238,7 @@ NO_PROC_OPEN_ERROR;
 		'open_basedir=',
 		'disable_functions=',
 		'output_buffering=Off',
-		'error_reporting=' . (E_ALL | E_STRICT),
+		'error_reporting=' . E_ALL,
 		'display_errors=1',
 		'display_startup_errors=1',
 		'log_errors=0',
@@ -1623,7 +1623,7 @@ escape:
 								'E_USER_ERROR',
 								'E_USER_WARNING',
 								'E_USER_NOTICE',
-								'E_STRICT',
+								'E_STRICT', // TODO Cleanup when removed from Zend Engine.
 								'E_RECOVERABLE_ERROR',
 								'E_USER_DEPRECATED'
 							];

--- a/tests/func/011.phpt
+++ b/tests/func/011.phpt
@@ -1,10 +1,10 @@
 --TEST--
 Test bitwise AND, OR, XOR, NOT and logical NOT in INI via error_reporting
 --INI--
-error_reporting = E_ALL & E_NOTICE | E_STRICT ^ E_DEPRECATED & ~E_WARNING | !E_ERROR
+error_reporting = E_ALL & E_NOTICE | E_PARSE ^ E_DEPRECATED & ~E_WARNING | !E_ERROR
 --FILE--
 <?php
 echo ini_get('error_reporting');
 ?>
 --EXPECT--
-10248
+8204

--- a/tests/func/bug64523.phpt
+++ b/tests/func/bug64523.phpt
@@ -1,10 +1,10 @@
 --TEST--
 Bug #64523: XOR not parsed in INI
 --INI--
-error_reporting = E_ALL ^ E_NOTICE ^ E_STRICT ^ E_DEPRECATED
+error_reporting = E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED
 --FILE--
 <?php
 echo ini_get('error_reporting');
 ?>
 --EXPECT--
-22519
+24565


### PR DESCRIPTION
Removed usage of E_STRICT in a couple of places by using lxr [1]
I've converted the last usages to ``E_NOTICE`` however as @nikic is the author of the RFC to reclassify them [2] could you have a look at them?

Removed the E_STRICT in the default error handling mode as this shouldn't trigger anything more now.

Not sure if we should keep the mention of E_STRICT in the INI files, I've removed them as they seem pointless ATM.
The constant still exists in the Zend engine which we may want to remove in PHP 8.

[1] https://lxr.room11.org/search?project=php-src%407.4&q=E_STRICT&defs=&refs=&path=&hist=&type=
[2] https://wiki.php.net/rfc/reclassify_e_strict