### PR TITLE
Fixes #78291 (missing opcache directives)

### DIFF
--- a/ext/opcache/tests/get_configuration_matches_ini.phpt
+++ b/ext/opcache/tests/get_configuration_matches_ini.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test that the directives listed with `opcache_get_configuration` include all those from the ini settings.
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.opt_debug_level=0
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$opts = opcache_get_configuration()['directives'];
+$inis = ini_get_all('zend opcache');
+var_dump(array_diff_key($inis, $opts));
+?>
+--EXPECT--
+array(0) {
+}

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -727,12 +727,24 @@ static ZEND_FUNCTION(opcache_get_configuration)
 
 #ifndef ZEND_WIN32
 	add_assoc_string(&directives, "opcache.lockfile_path",          STRING_NOT_NULL(ZCG(accel_directives).lockfile_path));
+#else
+	add_assoc_string(&directives, "opcache.mmap_base",              STRING_NOT_NULL(ZCG(accel_directives).mmap_base));
 #endif
 
 #ifdef HAVE_OPCACHE_FILE_CACHE
 	add_assoc_string(&directives, "opcache.file_cache",                    ZCG(accel_directives).file_cache ? ZCG(accel_directives).file_cache : "");
 	add_assoc_bool(&directives,   "opcache.file_cache_only",               ZCG(accel_directives).file_cache_only);
 	add_assoc_bool(&directives,   "opcache.file_cache_consistency_checks", ZCG(accel_directives).file_cache_consistency_checks);
+#endif
+#if ENABLE_FILE_CACHE_FALLBACK
+	add_assoc_bool(&directives,   "opcache.file_cache_fallback",           ZCG(accel_directives).file_cache_fallback);
+#endif
+
+	add_assoc_long(&directives,   "opcache.file_update_protection",  ZCG(accel_directives).file_update_protection);
+	add_assoc_long(&directives,   "opcache.opt_debug_level",         ZCG(accel_directives).opt_debug_level);
+	add_assoc_string(&directives, "opcache.restrict_api",            STRING_NOT_NULL(ZCG(accel_directives).restrict_api));
+#ifdef HAVE_HUGE_CODE_PAGES
+	add_assoc_bool(&directives,   "opcache.huge_code_pages",         ZCG(accel_directives).huge_code_pages);
 #endif
 
 	add_assoc_zval(return_value, "directives", &directives);


### PR DESCRIPTION
New opcache directives have been added recently which are returned if using `ini_get_all('zend opcache')` but are not listed in the directives if using `opcache_get_configuration()`.  This fix adds those missing directives as well as if `opcache.mmap_base` is used instead of `opcache.lockfile_path`.  Also adds a test to ensure the directives match with both methods of fetching.