### PR TITLE
Check for Windows utf-8 support in run-tests.php

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1351,9 +1351,17 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
 	$workerProcs = [];
 	$workerSocks = [];
 
-	echo "====⚡️===========================================================⚡️====\n";
-	echo "====⚡️==== WELCOME TO THE FUTURE: run-tests PARALLEL EDITION ====⚡️====\n";
-	echo "====⚡️===========================================================⚡️====\n";
+	$c = "⚡️";
+	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+		if (!function_exists('sapi_windows_cp_is_utf8') || !sapi_windows_cp_is_utf8()) {
+			// This is Windows, and the terminal (probably) doesn't support UTF-8. Use a different character instead.
+			$c = "x";
+		}
+	}
+
+	echo "====$c===========================================================$c====\n";
+	echo "====$c==== WELCOME TO THE FUTURE: run-tests PARALLEL EDITION ====$c====\n";
+	echo "====$c===========================================================$c====\n";
 
 	// Each test may specify a list of conflict keys. While a test that conflicts with
 	// key K is running, no other test that conflicts with K may run. Conflict keys are


### PR DESCRIPTION
Windows terminals can have different codepages.
In some locales (especially in older OS versions),
the default codepage isn't necessarily utf-8.
Non-utf8 codepages wouldn't render this utf-8 character properly.

This is based on a similar utf-8 check in a different application : https://github.com/phan/phan/commit/874e908666668ee47c9c0e4292448315caca12fc#diff-c47b128e8e4f783d984687a8796dc74dR1464