### PR TITLE
Fix #65547: Default value for sunrise/sunset zenith still wrong

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -581,11 +581,11 @@ int php_date_global_timezone_db_enabled;
 #define DATE_DEFAULT_LATITUDE "31.7667"
 #define DATE_DEFAULT_LONGITUDE "35.2333"
 
-/* on 90'35; common sunset declaration (start of sun body appear) */
-#define DATE_SUNSET_ZENITH "90.583333"
+/* on 90'50; common sunset declaration (start of sun body appear) */
+#define DATE_SUNSET_ZENITH "90.833333"
 
-/* on 90'35; common sunrise declaration (sun body disappeared) */
-#define DATE_SUNRISE_ZENITH "90.583333"
+/* on 90'50; common sunrise declaration (sun body disappeared) */
+#define DATE_SUNRISE_ZENITH "90.833333"
 
 static PHP_INI_MH(OnUpdate_date_timezone);
 
@@ -5013,7 +5013,7 @@ PHP_FUNCTION(date_sun_info)
 	array_init(return_value);
 
 	/* Get sun up/down and transit */
-	rs = timelib_astro_rise_set_altitude(t, longitude, latitude, -35.0/60, 1, &ddummy, &ddummy, &rise, &set, &transit);
+	rs = timelib_astro_rise_set_altitude(t, longitude, latitude, -50.0/60, 1, &ddummy, &ddummy, &rise, &set, &transit);
 	switch (rs) {
 		case -1: /* always below */
 			add_assoc_bool(return_value, "sunrise", 0);

--- a/ext/date/tests/date_sun_info_001.phpt
+++ b/ext/date/tests/date_sun_info_001.phpt
@@ -10,9 +10,9 @@ echo "Done\n";
 --EXPECT--
 array(9) {
   ["sunrise"]=>
-  int(1165897761)
+  int(1165897682)
   ["sunset"]=>
-  int(1165934160)
+  int(1165934239)
   ["transit"]=>
   int(1165915961)
   ["civil_twilight_begin"]=>

--- a/ext/date/tests/date_sun_info_002.phpt
+++ b/ext/date/tests/date_sun_info_002.phpt
@@ -11,8 +11,8 @@ foreach ($sun_info as $key => $elem )
 echo "Done\n";
 ?>
 --EXPECT--
-2007-04-13 06:13:31 CEST sunrise
-2007-04-13 20:30:51 CEST sunset
+2007-04-13 06:11:26 CEST sunrise
+2007-04-13 20:32:56 CEST sunset
 2007-04-13 13:22:11 CEST transit
 2007-04-13 05:29:22 CEST civil_twilight_begin
 2007-04-13 21:15:00 CEST civil_twilight_end

--- a/php.ini-development
+++ b/php.ini-development
@@ -947,10 +947,10 @@ cli_server.color = On
 ;date.default_longitude = 35.2333
 
 ; http://php.net/date.sunrise-zenith
-;date.sunrise_zenith = 90.583333
+;date.sunrise_zenith = 90.833333
 
 ; http://php.net/date.sunset-zenith
-;date.sunset_zenith = 90.583333
+;date.sunset_zenith = 90.833333
 
 [filter]
 ; http://php.net/filter.default

--- a/php.ini-production
+++ b/php.ini-production
@@ -949,10 +949,10 @@ cli_server.color = On
 ;date.default_longitude = 35.2333
 
 ; http://php.net/date.sunrise-zenith
-;date.sunrise_zenith = 90.583333
+;date.sunrise_zenith = 90.833333
 
 ; http://php.net/date.sunset-zenith
-;date.sunset_zenith = 90.583333
+;date.sunset_zenith = 90.833333
 
 [filter]
 ; http://php.net/filter.default


### PR DESCRIPTION
The value of the zenith angle to calculate sunrise and sunset times is
commonly defined as 90°50', and is "obtained by adding the average
apparent radius of the Sun (16') to the average amount of atmospheric
refraction at the horizon (34')", according to
http://aa.usno.navy.mil/faq/docs/RST_defs.php.

This value is also used for the Sunrise/Sunset Algorithm published in
the Almanac for Computers, 1990, see
https://web.archive.org/web/20161202180207/http://williams.best.vwh.net/sunrise_sunset_algorithm.htm.