### PR TITLE
Fixed bug #78010

### DIFF
--- a/Zend/tests/bug78010.phpt
+++ b/Zend/tests/bug78010.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #78010: Segmentation fault during GC
+--INI--
+memory_limit=2G
+--FILE--
+<?php
+
+class foo
+{
+    public function __construct()
+    {
+        $this->x = $this;
+
+        for ($i = 0; $i < 898; $i++) { //Will not trigger with <898
+            $obj = [new stdClass, new stdClass]; //This must have at least 2 elements
+            $this->y[] = $obj;
+        }
+    }
+}
+
+for ($i = 0; $i < 2; ++$i) { //This must run >=2 (increasing the number of elements in the array *2 will not do)
+    $x = []; //This must be reset
+    foreach (array_fill(0, 389, 'x') as &$params) { //Will not trigger <389
+        $x[] = new foo;
+    }
+}
+
+echo "Completed\n";
+
+?>
+--EXPECT--
+Completed

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -150,7 +150,7 @@
 #define GC_DEFAULT_BUF_SIZE  (16 * 1024)
 #define GC_BUF_GROW_STEP     (128 * 1024)
 
-#define GC_MAX_UNCOMPRESSED  (1024 * 1024)
+#define GC_MAX_UNCOMPRESSED  (512 * 1024)
 #define GC_MAX_BUF_SIZE      0x40000000
 
 #define GC_THRESHOLD_DEFAULT 10000
@@ -314,7 +314,10 @@ static void gc_stack_free(gc_stack *stack)
 
 static zend_always_inline uint32_t gc_compress(uint32_t idx)
 {
-	return idx % GC_MAX_UNCOMPRESSED;
+	if (EXPECTED(idx < GC_MAX_UNCOMPRESSED)) {
+		return idx;
+	}
+	return (idx % GC_MAX_UNCOMPRESSED) | GC_MAX_UNCOMPRESSED;
 }
 
 static zend_always_inline gc_root_buffer* gc_decompress(zend_refcounted *ref, uint32_t idx)


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=78010. We need to avoid the gc_info becoming completely zero during GC destroy phase, otherwise GC_REMOVE_FROM_BUFFER will skip them.

I'm doing this here by setting the top bit of compressed addresses to 1. An alternative would be to change the coloring, so that roots do not have color 0 during destruction (or any other phase where GC_REMOVE_FROM_BUFFER may be used).