### PR TITLE
Remove unused build checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,8 +398,6 @@ PHP_CHECK_FUNC(socketpair, socket)
 PHP_CHECK_FUNC(htonl, socket)
 PHP_CHECK_FUNC(gethostname, nsl)
 PHP_CHECK_FUNC(gethostbyaddr, nsl)
-PHP_CHECK_FUNC(yp_get_default_domain, nsl)
-
 PHP_CHECK_FUNC(dlopen, dl)
 PHP_CHECK_FUNC(dlsym, dl)
 if test "$ac_cv_func_dlopen" = "yes"; then
@@ -588,7 +586,6 @@ fpclass \
 ftok \
 funopen \
 gai_strerror \
-gcvt \
 getcwd \
 getloadavg \
 getlogin \
@@ -608,10 +605,8 @@ grantpt \
 inet_ntoa \
 inet_ntop \
 inet_pton \
-isascii \
 link \
 localtime_r \
-lockf \
 lchown \
 mbrlen \
 memmove \
@@ -627,11 +622,8 @@ rand_r \
 scandir \
 setitimer \
 setenv \
-setsockopt \
-setvbuf \
 shutdown \
 sigprocmask \
-sin \
 statfs \
 statvfs \
 std_syslog \
@@ -641,7 +633,6 @@ strnlen \
 strptime \
 strtok_r \
 symlink \
-tempnam \
 tzset \
 unlockpt \
 unsetenv \

--- a/configure.ac
+++ b/configure.ac
@@ -605,7 +605,6 @@ grantpt \
 inet_ntoa \
 inet_ntop \
 inet_pton \
-link \
 localtime_r \
 lchown \
 mbrlen \

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -299,8 +299,6 @@ AC_DEFINE('HAVE_IPV6', main_network_has_ipv6);
 ARG_ENABLE('fd-setsize', "Set maximum number of sockets for select(2)", "256");
 ADD_FLAG("CFLAGS", "/D FD_SETSIZE=" + parseInt(PHP_FD_SETSIZE));
 
-AC_DEFINE('HAVE_USLEEP', 1);
-
 /* For snapshot builders, where can we find the additional
  * files that make up the snapshot template? */
 ARG_WITH("snapshot-template", "Path to snapshot builder template dir", "no");

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -39,7 +39,6 @@
 #define HAVE_ERRMSG_H 0
 #undef HAVE_ADABAS
 #undef HAVE_SOLID
-#undef HAVE_LINK
 #undef HAVE_SYMLINK
 
 /* its in win32/time.c */

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -28,7 +28,6 @@
 
 /* Platform-Specific Configuration. Should not be changed. */
 #define PHP_SIGCHILD 0
-#define HAVE_LIBBIND 1
 #define HAVE_GETSERVBYNAME 1
 #define HAVE_GETSERVBYPORT 1
 #define HAVE_GETPROTOBYNAME 1
@@ -48,7 +47,6 @@
 #define HAVE_NANOSLEEP 1
 #define PHP_SLEEP_NON_VOID 1
 
-#define HAVE_GETHOSTNAME 1
 #define HAVE_GETCWD 1
 #define NEED_ISBLANK 1
 #define DISCARD_PATH 0
@@ -67,18 +65,12 @@
 #define HAVE_STRUCT_STAT_ST_RDEV 1
 #define REGEX 1
 #define HSREGEX 1
-#define HAVE_GCVT 1
 #define HAVE_GETLOGIN 1
 #define HAVE_MEMMOVE 1
-#define HAVE_PUTENV 1
 #define HAVE_REGCOMP 1
 #define HAVE_LOCALE_H 1
-#ifndef HAVE_LIBBIND
-# define HAVE_SETVBUF 1
-#endif
 #define HAVE_SHUTDOWN 1
 #define HAVE_STRCASECMP 1
-#define HAVE_TEMPNAM 1
 #define HAVE_UTIME 1
 #undef HAVE_DIRENT_H
 #define HAVE_FCNTL_H 1


### PR DESCRIPTION
- yp_get_default_domain was part of ext/yp
- functions checks produce HAVE_function_name symbols. These checks are
  currently not used in php-src neither in the extensions out there.
- Removed symbols because they are not used in the code:
  - HAVE_GCVT
  - HAVE_PUTENV
  - HAVE_PUTENV
  - HAVE_SETVBUF
  - HAVE_TEMPNAM
  - HAVE_SIN (sin is also defined in C89 standard)
  - HAVE_SETSOCKOPT
  - HAVE_LOCKF
  - HAVE_ISASCII
  - HAVE_YP_GET_DEFAULT_DOMAIN (and other yp extension related unused checks)
- HAVE_USLEEP is already defined in Windows configuration header
- HAVE_LIBBIND has not been used in php-src for a while anymore