### PR TITLE
Fix bug #52752 by not using mmap() to lex files

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1583,13 +1583,6 @@ static void php_zend_stream_closer(void *handle) /* {{{ */
 }
 /* }}} */
 
-static void php_zend_stream_mmap_closer(void *handle) /* {{{ */
-{
-	php_stream_mmap_unmap((php_stream*)handle);
-	php_zend_stream_closer(handle);
-}
-/* }}} */
-
 static size_t php_zend_stream_fsizer(void *handle) /* {{{ */
 {
 	php_stream_statbuf  ssb;
@@ -1608,38 +1601,18 @@ static int php_stream_open_for_zend(const char *filename, zend_file_handle *hand
 
 PHPAPI int php_stream_open_for_zend_ex(const char *filename, zend_file_handle *handle, int mode) /* {{{ */
 {
-	char *p;
-	size_t len, mapped_len;
 	php_stream *stream = php_stream_open_wrapper((char *)filename, "rb", mode, &handle->opened_path);
 
 	if (stream) {
-#if HAVE_MMAP || defined(PHP_WIN32)
-		size_t page_size = REAL_PAGE_SIZE;
-#endif
-
+		handle->type = ZEND_HANDLE_STREAM;
 		handle->filename = (char*)filename;
 		handle->free_filename = 0;
 		handle->handle.stream.handle  = stream;
 		handle->handle.stream.reader  = (zend_stream_reader_t)_php_stream_read;
 		handle->handle.stream.fsizer  = php_zend_stream_fsizer;
 		handle->handle.stream.isatty  = 0;
-		/* can we mmap immediately? */
 		memset(&handle->handle.stream.mmap, 0, sizeof(handle->handle.stream.mmap));
-		len = php_zend_stream_fsizer(stream);
-		if (len != 0
-#if HAVE_MMAP || defined(PHP_WIN32)
-		&& ((len - 1) % page_size) <= page_size - ZEND_MMAP_AHEAD
-#endif
-		&& php_stream_mmap_possible(stream)
-		&& (p = php_stream_mmap_range(stream, 0, len, PHP_STREAM_MAP_MODE_SHARED_READONLY, &mapped_len)) != NULL) {
-			handle->handle.stream.closer   = php_zend_stream_mmap_closer;
-			handle->handle.stream.mmap.buf = p;
-			handle->handle.stream.mmap.len = mapped_len;
-			handle->type = ZEND_HANDLE_MAPPED;
-		} else {
-			handle->handle.stream.closer = php_zend_stream_closer;
-			handle->type = ZEND_HANDLE_STREAM;
-		}
+		handle->handle.stream.closer = php_zend_stream_closer;
 		/* suppress warning if this stream is not explicitly closed */
 		php_stream_auto_cleanup(stream);
 


### PR DESCRIPTION
Fix bug https://bugs.php.net/bug.php?id=52752.

Using mmap() is unsafe under concurrent modification. If the file is truncated access past the end of the file may occur, which will generate a SIGBUS error. Even if the length does not change, the contents may, which is a situation that the lexer certainly is not prepared to deal with either.

Reproduce with test.php:

    <?php
    file_put_contents(__DIR__ . '/test.tpl',
        'AAA<?php $string = "'. str_repeat('A', mt_rand(1, 256 * 1024)) .'"; ?>BBB' . "\r\n");
    require_once __DIR__ . '/test.tpl';

And `for ((n=0;n<100;n++)); do sapi/cli/php test.php & done`.

This patch removes the use of mmap() when lexing files. I will remove the leftover mmap handling in zend_stream in a separate patch to keep this smaller.