### PR TITLE
Remove date.default_latitude and .default_longitude inis

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -578,8 +578,8 @@ static PHP_GINIT_FUNCTION(date);
 timelib_tzdb *php_date_global_timezone_db;
 int php_date_global_timezone_db_enabled;
 
-#define DATE_DEFAULT_LATITUDE "31.7667"
-#define DATE_DEFAULT_LONGITUDE "35.2333"
+#define DATE_DEFAULT_LATITUDE 31.7667
+#define DATE_DEFAULT_LONGITUDE 35.2333
 
 /* on 90'50; common sunset declaration (start of sun body appear) */
 #define DATE_SUNSET_ZENITH "90.833333"
@@ -592,8 +592,6 @@ static PHP_INI_MH(OnUpdate_date_timezone);
 /* {{{ INI Settings */
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("date.timezone", "", PHP_INI_ALL, OnUpdate_date_timezone, default_timezone, zend_date_globals, date_globals)
-	PHP_INI_ENTRY("date.default_latitude",           DATE_DEFAULT_LATITUDE,        PHP_INI_ALL, NULL)
-	PHP_INI_ENTRY("date.default_longitude",          DATE_DEFAULT_LONGITUDE,       PHP_INI_ALL, NULL)
 	PHP_INI_ENTRY("date.sunset_zenith",              DATE_SUNSET_ZENITH,           PHP_INI_ALL, NULL)
 	PHP_INI_ENTRY("date.sunrise_zenith",             DATE_SUNRISE_ZENITH,          PHP_INI_ALL, NULL)
 PHP_INI_END()
@@ -4901,9 +4899,9 @@ static void php_do_date_sunrise_sunset(INTERNAL_FUNCTION_PARAMETERS, int calc_su
 		case 1:
 			retformat = SUNFUNCS_RET_STRING;
 		case 2:
-			latitude = INI_FLT("date.default_latitude");
+			latitude = DATE_DEFAULT_LATITUDE;
 		case 3:
-			longitude = INI_FLT("date.default_longitude");
+			longitude = DATE_DEFAULT_LONGITUDE;
 		case 4:
 			if (calc_sunset) {
 				zenith = INI_FLT("date.sunset_zenith");

--- a/ext/reflection/tests/026.phpt
+++ b/ext/reflection/tests/026.phpt
@@ -26,8 +26,6 @@ Default timezone => %s
 
 Directive => %s => %s
 date.timezone => %s => %s
-date.default_latitude => %s => %s
-date.default_longitude => %s => %s
 date.sunset_zenith => %s => %s
 date.sunrise_zenith => %s => %s
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -940,12 +940,6 @@ cli_server.color = On
 ; http://php.net/date.timezone
 ;date.timezone =
 
-; http://php.net/date.default-latitude
-;date.default_latitude = 31.7667
-
-; http://php.net/date.default-longitude
-;date.default_longitude = 35.2333
-
 ; http://php.net/date.sunrise-zenith
 ;date.sunrise_zenith = 90.833333
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -942,12 +942,6 @@ cli_server.color = On
 ; http://php.net/date.timezone
 ;date.timezone =
 
-; http://php.net/date.default-latitude
-;date.default_latitude = 31.7667
-
-; http://php.net/date.default-longitude
-;date.default_longitude = 35.2333
-
 ; http://php.net/date.sunrise-zenith
 ;date.sunrise_zenith = 90.833333
 


### PR DESCRIPTION
The only purpose of these ini settings is to serve as defaults for
`date_sunrise()` and `date_sunset()`, which is is obviously of limited
usefulness.

This topic came up in PR #4412, and this PR is meant as a base for discussing and evaluating what to do with these INI settings. See also https://externals.io/message/26033 for a former discussion about changing the default values of the settings.

cc @derickr