### PR TITLE
Remove duplicate AC_PROG_CPP call

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -30,7 +30,6 @@ if test "$PHP_CURL" != "no"; then
     save_LDFLAGS="$LDFLAGS"
     LDFLAGS="$LDFLAGS $CURL_LIBS"
 
-    AC_PROG_CPP
     AC_MSG_CHECKING([for openssl support in libcurl])
     AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <strings.h>


### PR DESCRIPTION
AC_PROG_CPP is already called in configure.ac.