### PR TITLE
Remove unused defines

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -73,20 +73,6 @@ int main(int argc, char *argv[])
     $CURL_LIBS
   ])
 
-  PHP_CHECK_LIBRARY(curl,curl_easy_strerror,
-  [
-    AC_DEFINE(HAVE_CURL_EASY_STRERROR,1,[ ])
-  ],[],[
-    $CURL_LIBS
-  ])
-
-  PHP_CHECK_LIBRARY(curl,curl_multi_strerror,
-  [
-    AC_DEFINE(HAVE_CURL_MULTI_STRERROR,1,[ ])
-  ],[],[
-    $CURL_LIBS
-  ])
-
   PHP_NEW_EXTENSION(curl, interface.c multi.c share.c curl_file.c, $ext_shared)
   PHP_SUBST(CURL_SHARED_LIBADD)
 fi

--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -29,8 +29,6 @@ if (PHP_CURL != "no") {
 		EXTENSION("curl", "interface.c multi.c share.c curl_file.c");
 		AC_DEFINE('HAVE_CURL', 1, 'Have cURL library');
 		AC_DEFINE('HAVE_CURL_SSL', 1, 'Have SSL suppurt in cURL');
-		AC_DEFINE('HAVE_CURL_EASY_STRERROR', 1, 'Have curl_easy_strerror in cURL');
-		AC_DEFINE('HAVE_CURL_MULTI_STRERROR', 1, 'Have curl_multi_strerror in cURL');
 		ADD_FLAG("CFLAGS_CURL", "/D CURL_STATICLIB");
 		// TODO: check for curl_version_info
 	} else {

--- a/ext/gmp/config.w32
+++ b/ext/gmp/config.w32
@@ -8,7 +8,6 @@ if (PHP_GMP != "no") {
 		EXTENSION("gmp", "gmp.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		PHP_INSTALL_HEADERS("ext/gmp", "php_gmp_int.h");
 		AC_DEFINE('HAVE_GMP', 1, 'GMP support');
-		AC_DEFINE('HAVE_MPIR', 1, 'MPIR support');
 	} else {
 		WARNING("GMP not enabled; libraries and headers not found");
 	}

--- a/ext/imap/config.w32
+++ b/ext/imap/config.w32
@@ -17,7 +17,6 @@ if (PHP_IMAP == "yes") {
 
 		ADD_FLAG("CFLAGS_IMAP", "/D HAVE_IMAP2000=1 /D HAVE_IMAP2004=1 /D HAVE_IMAP2007a=1 /D HAVE_IMAP2007b=1 /D HAVE_IMAP_SSL=1");
 		AC_DEFINE('HAVE_IMAP', 1, 'Have IMAP support', true);
-		AC_DEFINE('HAVE_NEW_MIME2TEXT', 1, 'Have utf8_mime2text', true);
 		AC_DEFINE('HAVE_RFC822_OUTPUT_ADDRESS_LIST', 1, 'Have rfc822_output_address_list', true);
 		AC_DEFINE('HAVE_IMAP_MUTF7', 1, 'Have modified utf7 support', true);
 		AC_DEFINE('HAVE_NEW_MIME2TEXT', 1, 'Whether utf8_mime2text() has new signature');

--- a/ext/mbstring/config.w32
+++ b/ext/mbstring/config.w32
@@ -15,8 +15,7 @@ if (PHP_MBSTRING != "no") {
 		STDOUT.WriteLine("Using bundled libmbfl...");
 
 		ADD_FLAG("CFLAGS_MBSTRING", "-Iext/mbstring/libmbfl -Iext/mbstring/libmbfl/mbfl \
-			/D NOT_RUBY=1 /D LIBMBFL_EXPORTS=1 \
-			/D HAVE_STDARG_PROTOTYPES=1 /D HAVE_CONFIG_H \
+			/D HAVE_CONFIG_H \
 			/D HAVE_STRICMP /D MBFL_DLL_EXPORT=1 /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1")
 
 		FSO.CopyFile("ext\\mbstring\\libmbfl\\config.h.w32",
@@ -56,14 +55,8 @@ if (PHP_MBSTRING != "no") {
 		PHP_INSTALL_HEADERS("ext/mbstring", "mbstring.h php_mbregex.h php_onig_compat.h libmbfl/config.h libmbfl/mbfl/eaw_table.h libmbfl/mbfl/mbfilter.h libmbfl/mbfl/mbfilter_8bit.h libmbfl/mbfl/mbfilter_pass.h libmbfl/mbfl/mbfilter_wchar.h libmbfl/mbfl/mbfl_allocators.h libmbfl/mbfl/mbfl_consts.h libmbfl/mbfl/mbfl_convert.h libmbfl/mbfl/mbfl_defs.h libmbfl/mbfl/mbfl_encoding.h libmbfl/mbfl/mbfl_filter_output.h libmbfl/mbfl/mbfl_ident.h libmbfl/mbfl/mbfl_language.h libmbfl/mbfl/mbfl_memory_device.h libmbfl/mbfl/mbfl_string.h");
 
 		AC_DEFINE('HAVE_MBSTRING', 1, 'Have mbstring support');
-		AC_DEFINE('HAVE_MBSTR_CN', 1, 'CN');
-		AC_DEFINE('HAVE_MBSTR_JA', 1, 'JA');
-		AC_DEFINE('HAVE_MBSTR_KR', 1, 'KR');
-		AC_DEFINE('HAVE_MBSTR_RU', 1, 'RU');
-		AC_DEFINE('HAVE_MBSTR_TW', 1, 'TW');
 
 		if (PHP_MBREGEX != "no") {
-			AC_DEFINE('HAVE_STDARG_PROTOTYPES', 1, 'have stdarg.h');
 			AC_DEFINE('HAVE_MBREGEX', 1);
 			ADD_SOURCES("ext/mbstring", "php_mbregex.c", "mbstring");
 			PHP_INSTALL_HEADERS("ext/mbstring", "php_mbregex.h");


### PR DESCRIPTION
Used in php-src the past and today removed and not used anymore:
- HAVE_CURL_EASY_STRERROR
- HAVE_CURL_MULTI_STRERROR
- HAVE_NEW_MIME2TEXT
- HAVE_MBSTR_CN
- HAVE_MBSTR_JA
- HAVE_MBSTR_KR
- HAVE_MBSTR_RU
- HAVE_MBSTR_TW

Part of oniguruma which doesn't use these anymore
- NOT_RUBY
- HAVE_STDARG_PROTOTYPES

Unused:
- HAVE_MPIR