### PR TITLE
set to NULL to avoid possible double free

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1984,9 +1984,11 @@ static void core_globals_dtor(php_core_globals *core_globals)
 {
 	if (core_globals->last_error_message) {
 		free(core_globals->last_error_message);
+		core_globals->last_error_message = NULL;
 	}
 	if (core_globals->last_error_file) {
 		free(core_globals->last_error_file);
+		core_globals->last_error_file = NULL;
 	}
 	if (core_globals->disable_functions) {
 		free(core_globals->disable_functions);


### PR DESCRIPTION
Despite I wasn't able to reproduce, segfault have been reported, and should be fixed by this sanity set to null.

Perhaps when some extension log some message during its shutdown.

More information on https://bugzilla.redhat.com/1730544