### PR TITLE
Ref #77388 - disallow passing BAD_ESCAPE_IS_LITERAL, esp by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,9 @@ PHP                                                                        NEWS
 - mysqlnd:
   . Fixed #60594 (mysqlnd exposes 160 lines of stats in phpinfo). (PeeHaa)
 
+- PCRE:
+  . Remove X modifier and enable it by default. (sjon)
+
 - PDO:
   . Fixed bug #77849 (Disable cloning of PDO handle/connection objects).
     (camporter)

--- a/UPGRADING
+++ b/UPGRADING
@@ -145,6 +145,11 @@ PHP 8.0 UPGRADE NOTES
     as a string instead of an ASCII codepoint. The previous behavior may be
     restored with an explicit call to chr().
 
+- PCRE:
+  . When passing invalid escape sequences they are no longer intepreted as
+    literals. This behaviour previously required the X modifier - which has
+    been removed as well.
+
 - PDO:
   . The method PDOStatement::setFetchMode() now accepts the following signature:
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -147,8 +147,8 @@ PHP 8.0 UPGRADE NOTES
 
 - PCRE:
   . When passing invalid escape sequences they are no longer intepreted as
-    literals. This behaviour previously required the X modifier - which has
-    been removed as well.
+    literals. This behaviour previously required the X modifier - which is
+    now ignored.
 
 - PDO:
   . The method PDOStatement::setFetchMode() now accepts the following signature:

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -694,6 +694,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 			case 'A':	coptions |= PCRE2_ANCHORED;		break;
 			case 'D':	coptions |= PCRE2_DOLLAR_ENDONLY;break;
 			case 'S':	/* Pass. */					break;
+			case 'X':	/* Pass. */					break;
 			case 'U':	coptions |= PCRE2_UNGREEDY;		break;
 			case 'u':	coptions |= PCRE2_UTF;
 	/* In  PCRE,  by  default, \d, \D, \s, \S, \w, and \W recognize only ASCII

--- a/ext/pcre/tests/pcre_extra.phpt
+++ b/ext/pcre/tests/pcre_extra.phpt
@@ -1,5 +1,5 @@
 --TEST--
-X (PCRE_EXTRA) modififier is no longer functional
+X (PCRE_EXTRA) modififier is ignored (no error, no change)
 --FILE--
 <?php
 
@@ -11,5 +11,5 @@ var_dump(preg_match('/\y/X', '\y'));
 Warning: preg_match(): Compilation failed: unrecognized character follows \ at offset 1 in %spcre_extra.php on line 3
 bool(false)
 
-Warning: preg_match(): Unknown modifier 'X' in %spcre_extra.php on line 4
+Warning: preg_match(): Compilation failed: unrecognized character follows \ at offset 1 in %spcre_extra.php on line 4
 bool(false)

--- a/ext/pcre/tests/pcre_extra.phpt
+++ b/ext/pcre/tests/pcre_extra.phpt
@@ -1,5 +1,5 @@
 --TEST--
-X (PCRE_EXTRA) modififer
+X (PCRE_EXTRA) modififier is no longer functional
 --FILE--
 <?php
 
@@ -8,7 +8,8 @@ var_dump(preg_match('/\y/X', '\y'));
 
 ?>
 --EXPECTF--
-int(1)
+Warning: preg_match(): Compilation failed: unrecognized character follows \ at offset 1 in %spcre_extra.php on line 3
+bool(false)
 
-Warning: preg_match(): Compilation failed: unrecognized character follows \ at offset 1 in %spcre_extra.php on line 4
+Warning: preg_match(): Unknown modifier 'X' in %spcre_extra.php on line 4
 bool(false)


### PR DESCRIPTION
this option is considered dangerous and unwanted by [the author of pcre](https://bugs.exim.org/show_bug.cgi?id=2362):

> Absolutely! I'm a bit horrified to learn that somebody set it as a default. It is very much a use-with-care dangerous feature. I hope the PHP developers take note in due course.

While this is a B/C change - it is more likely to expose (existing) problems that can quickly be fixed by fixing the regexp. There were [no objections](https://externals.io/message/104306) against removing it on php-internals

---

this PR is a copy of #4429 - but using a proper feature-branch targeting master instead of PHP-7.4