### PR TITLE
cURL: Save multi_info_read() result into easy handle

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -152,8 +152,6 @@ static void _php_curl_close_ex(php_curl *ch);
 static void _php_curl_close(zend_resource *rsrc);
 
 
-#define SAVE_CURL_ERROR(__handle, __err) (__handle)->err.no = (int) __err;
-
 #define CAAL(s, v) add_assoc_long_ex(return_value, s, sizeof(s) - 1, (zend_long) v);
 #define CAAD(s, v) add_assoc_double_ex(return_value, s, sizeof(s) - 1, (double) v);
 #define CAAS(s, v) add_assoc_string_ex(return_value, s, sizeof(s) - 1, (char *) (v ? v : ""));

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -339,6 +339,7 @@ PHP_FUNCTION(curl_multi_info_read)
 	CURLMsg	  *tmp_msg;
 	int        queued_msgs;
 	zval      *zmsgs_in_queue = NULL;
+	php_curl  *ch;
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_RESOURCE(z_mh)
@@ -375,6 +376,10 @@ PHP_FUNCTION(curl_multi_info_read)
 			   SEPARATE_ZVAL, but those create new zvals, which is already
 			   being done in add_assoc_resource */
 			Z_ADDREF_P(pz_ch);
+
+			/* we must save result to be able to read error message */
+			ch = (php_curl*)zend_fetch_resource(Z_RES_P(pz_ch), le_curl_name, le_curl);
+			SAVE_CURLM_ERROR(ch, tmp_msg->data.result);
 
 			/* add_assoc_resource automatically creates a new zval to
 			   wrap the "resource" represented by the current pz_ch */

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -379,7 +379,7 @@ PHP_FUNCTION(curl_multi_info_read)
 
 			/* we must save result to be able to read error message */
 			ch = (php_curl*)zend_fetch_resource(Z_RES_P(pz_ch), le_curl_name, le_curl);
-			SAVE_CURLM_ERROR(ch, tmp_msg->data.result);
+			SAVE_CURL_ERROR(ch, tmp_msg->data.result);
 
 			/* add_assoc_resource automatically creates a new zval to
 			   wrap the "resource" represented by the current pz_ch */

--- a/ext/curl/php_curl.h
+++ b/ext/curl/php_curl.h
@@ -60,6 +60,8 @@ extern zend_module_entry curl_module_entry;
 #define PHP_CURL_RETURN 4
 #define PHP_CURL_IGNORE 7
 
+#define SAVE_CURL_ERROR(__handle, __err) (__handle)->err.no = (int) __err;
+
 extern int  le_curl;
 #define le_curl_name "cURL handle"
 extern int  le_curl_multi_handle;

--- a/ext/curl/tests/bug77946.phpt
+++ b/ext/curl/tests/bug77946.phpt
@@ -11,7 +11,7 @@ if (!extension_loaded('curl')) {
 --FILE--
 <?php
 $urls = array(
-   'http://nonexistent.tld',
+   'unknown://scheme.tld',
 );
 
 $mh = curl_multi_init();
@@ -37,7 +37,7 @@ foreach ($urls as $i => $url) {
 
 curl_multi_close($mh);
 ?>
---EXPECT--
-int(6)
-int(6)
-string(39) "Could not resolve host: nonexistent.tld"
+--EXPECTF--
+int(1)
+int(1)
+string(%d) "Protocol %Sunknown%S not supported or disabled in libcurl"

--- a/ext/curl/tests/bug77946.phpt
+++ b/ext/curl/tests/bug77946.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #77946 (Errored cURL resources returned by curl_multi_info_read() must be compatible with curl_errno() and curl_error())
+--SKIPIF--
+<?php
+
+if (!extension_loaded('curl')) {
+	exit('skip curl extension not loaded');
+}
+
+?>
+--FILE--
+<?php
+$urls = array(
+   'http://nonexistent.tld',
+);
+
+$mh = curl_multi_init();
+
+foreach ($urls as $i => $url) {
+    $conn[$i] = curl_init($url);
+    curl_multi_add_handle($mh, $conn[$i]);
+}
+
+do {
+    $status = curl_multi_exec($mh, $active);
+    $info = curl_multi_info_read($mh);
+    if (false !== $info) {
+        var_dump($info['result']);
+        var_dump(curl_errno($info['handle']));
+        var_dump(curl_error($info['handle']));
+    }
+} while ($status === CURLM_CALL_MULTI_PERFORM || $active);
+
+foreach ($urls as $i => $url) {
+    curl_close($conn[$i]);
+}
+
+curl_multi_close($mh);
+?>
+--EXPECT--
+int(6)
+int(6)
+string(39) "Could not resolve host: nonexistent.tld"


### PR DESCRIPTION
5025eb05bde83a0a51eb0668c45c240b366545bf introduced a regression: one can't obtain error messages from handles returned from `curl_multi_info_read()` calls anymore, because they are always empty. It happens because error num is being returned via associative array (under `result` key) instead of being saved into a handle, so `curl_error()` always returns an empty string.

Fixes #77946, replaces #4075.

/cc @jay 