### PR TITLE
Remove safe_mode directive when installing ext/phar

### DIFF
--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -8,7 +8,7 @@ $(srcdir)/phar_path_check.c: $(srcdir)/phar_path_check.re
 
 pharcmd: $(builddir)/phar.php $(builddir)/phar.phar
 
-PHP_PHARCMD_SETTINGS = -n -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1' -d phar.readonly=0 -d 'safe_mode=0'
+PHP_PHARCMD_SETTINGS = -n -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1' -d phar.readonly=0
 PHP_PHARCMD_EXECUTABLE = ` \
 	if test -x "$(top_builddir)/$(SAPI_CLI_PATH)"; then \
 		$(top_srcdir)/build/shtool echo -n -- "$(top_builddir)/$(SAPI_CLI_PATH) -n"; \


### PR DESCRIPTION
safe_mode is removed ini directive since PHP 5.4.