### PR TITLE
Remove unused sqlite symbols

### DIFF
--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -23,10 +23,6 @@ if test "$PHP_PDO_SQLITE" != "no"; then
     AC_MSG_ERROR([Please install SQLite 3.7.4 first or check libsqlite3 is present])
   ])
 
-  PHP_CHECK_LIBRARY(sqlite3, sqlite3_key, [
-    AC_DEFINE(HAVE_SQLITE3_KEY, 1, [have commercial sqlite3 with crypto support])
-  ])
-
   PHP_CHECK_LIBRARY(sqlite3, sqlite3_close_v2, [
     AC_DEFINE(HAVE_SQLITE3_CLOSE_V2, 1, [have sqlite3_close_v2])
   ])

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -16,14 +16,6 @@ if test $PHP_SQLITE3 != "no"; then
     AC_MSG_ERROR([Please install SQLite 3.7.4 first or check libsqlite3 is present])
   ])
 
-  PHP_CHECK_LIBRARY(sqlite3, sqlite3_key, [
-    AC_DEFINE(HAVE_SQLITE3_KEY, 1, [have commercial sqlite3 with crypto support])
-  ])
-
-  PHP_CHECK_LIBRARY(sqlite3, sqlite3_column_table_name, [
-    AC_DEFINE(SQLITE_ENABLE_COLUMN_METADATA, 1, [have sqlite3 with column metadata enabled])
-  ])
-
   PHP_CHECK_LIBRARY(sqlite3, sqlite3_errstr, [
     AC_DEFINE(HAVE_SQLITE3_ERRSTR, 1, [have sqlite3_errstr function])
   ])


### PR DESCRIPTION
- HAVE_SQLITE3_KEY is no longer used in php-src
- SQLITE_ENABLE_COLUMN_METADATA is no longer used in php-src