### PR TITLE
Move HAVE_SQLITE3_CLOSE_V2 to pdo_sqlite

### DIFF
--- a/ext/pdo_sqlite/config.w32
+++ b/ext/pdo_sqlite/config.w32
@@ -8,6 +8,7 @@ if (PHP_PDO_SQLITE != "no") {
 
 		ADD_EXTENSION_DEP('pdo_sqlite', 'pdo');
 		AC_DEFINE("HAVE_SQLITE3_COLUMN_TABLE_NAME", 1, "have sqlite3_column_table_name");
+		AC_DEFINE("HAVE_SQLITE3_CLOSE_V2", 1, "have sqlite3_close_v2");
 	} else {
 		WARNING("pdo_sqlite not enabled; libraries and/or headers not found");
 	}

--- a/ext/sqlite3/config.w32
+++ b/ext/sqlite3/config.w32
@@ -8,7 +8,6 @@ if (PHP_SQLITE3 != "no") {
 
 		AC_DEFINE("HAVE_SQLITE3", 1, "SQLite support");
 		AC_DEFINE("HAVE_SQLITE3_ERRSTR", 1, "have sqlite3_errstr function");
-		AC_DEFINE("HAVE_SQLITE3_CLOSE_V2", 1, "have sqlite3_close_v2");
 	} else {
 		WARNING("sqlite3 not enabled; libraries and/or headers not found");
 	}


### PR DESCRIPTION
If I'm not mistaken here, this needs to be defined in pdo_sqlite's config.w32 instead of the sqlite3 extension...