### PR TITLE
Remove HAVE_LOCALE_H and locale.h check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -413,7 +413,6 @@ dnl Then headers.
 dnl ----------------------------------------------------------------------------
 
 dnl QNX requires unix.h to allow functions in libunix to work properly.
-dnl locale.h is checked for supporting old code in extensions such as imagick.
 AC_CHECK_HEADERS([ \
 inttypes.h \
 stdint.h \
@@ -431,7 +430,6 @@ fcntl.h \
 grp.h \
 ieeefp.h \
 langinfo.h \
-locale.h \
 malloc.h \
 monetary.h \
 netdb.h \

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -67,7 +67,6 @@
 #define HAVE_GETLOGIN 1
 #define HAVE_MEMMOVE 1
 #define HAVE_REGCOMP 1
-#define HAVE_LOCALE_H 1
 #define HAVE_SHUTDOWN 1
 #define HAVE_STRCASECMP 1
 #define HAVE_UTIME 1


### PR DESCRIPTION
This was a left over for supporting old code in PHP extensions out there. Check is not needed anymore since this is part of C89+ standard.