### PR TITLE
Remove some unused HAVE_* symbols

### DIFF
--- a/ext/pdo_dblib/config.m4
+++ b/ext/pdo_dblib/config.m4
@@ -55,12 +55,10 @@ if test "$PHP_PDO_DBLIB" != "no"; then
 
   PDO_DBLIB_DEFS="-DPDO_DBLIB_FLAVOUR=\\\"freetds\\\""
   PHP_NEW_EXTENSION(pdo_dblib, pdo_dblib.c dblib_driver.c dblib_stmt.c, $ext_shared,,-I$pdo_cv_inc_path $PDO_DBLIB_DEFS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  AC_CHECK_LIB(dnet_stub, dnet_addr,
-     [ PHP_ADD_LIBRARY_WITH_PATH(dnet_stub,,PDO_DBLIB_SHARED_LIBADD)
-        AC_DEFINE(HAVE_LIBDNET_STUB,1,[ ])
-     ])
+  AC_CHECK_LIB(dnet_stub, dnet_addr, [
+    PHP_ADD_LIBRARY_WITH_PATH(dnet_stub,,PDO_DBLIB_SHARED_LIBADD)
+  ])
   AC_DEFINE(HAVE_PDO_DBLIB,1,[ ])
-  AC_DEFINE(HAVE_FREETDS,1,[ ])
   PHP_SUBST(PDO_DBLIB_SHARED_LIBADD)
 
   PHP_ADD_EXTENSION_DEP(pdo_dblib, pdo)

--- a/ext/snmp/config.w32
+++ b/ext/snmp/config.w32
@@ -8,7 +8,6 @@ if (PHP_SNMP != "no") {
 		if (CHECK_LIB("netsnmp.lib", "snmp", PHP_SNMP)) {
 			EXTENSION('snmp', 'snmp.c');
 			AC_DEFINE('HAVE_SNMP', 1);
-			AC_DEFINE("HAVE_NET_SNMP", 1);
 		} else {
 			WARNING("snmp not enabled; libraries and headers not found");
 		}

--- a/ext/sodium/config.w32
+++ b/ext/sodium/config.w32
@@ -6,7 +6,6 @@ if (PHP_SODIUM != "no") {
 	if (CHECK_LIB("libsodium.lib", "sodium", PHP_SODIUM) && CHECK_HEADER_ADD_INCLUDE("sodium.h", "CFLAGS_SODIUM")) {
 		EXTENSION("sodium", "libsodium.c sodium_pwhash.c");
 		AC_DEFINE('HAVE_LIBSODIUMLIB', 1 , 'Have the Sodium library');
-		AC_DEFINE("HAVE_CRYPTO_AEAD_AES256GCM", 1, "");
 		PHP_INSTALL_HEADERS("ext/sodium/", "php_libsodium.h");
 	} else {
 		WARNING("libsodium not enabled; libraries and headers not found");


### PR DESCRIPTION
- HAVE_NET_SNMP removed via cab643f615d4f592778b7234dabed772d5d66866
- HAVE_CRYPTO_AEAD_AES256GCM ad120c5ae93b49aeb4661b84f981beda2b31cde8
- Remove HAVE_FREETDS and HAVE_LIBDNET_STUB (not used in current
  extension; copy paste from other removed extensions)