### PR TITLE
Remove AC_FPM_POLL

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -459,30 +459,6 @@ AC_DEFUN([AC_FPM_EPOLL],
 	])
 ])
 
-AC_DEFUN([AC_FPM_POLL],
-[
-	AC_MSG_CHECKING([for poll])
-
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-		#include <poll.h>
-	]], [[
-		struct pollfd fds[2];
-
-		fds[0].fd = 0;
-		fds[0].events = POLLIN;
-
-		fds[1].fd = 0;
-		fds[1].events = POLLIN;
-
-		 poll(fds, 2, 1);
-	]])], [
-		AC_DEFINE([HAVE_POLL], 1, [do we have poll?])
-		AC_MSG_RESULT([yes])
-	], [
-		AC_MSG_RESULT([no])
-	])
-])
-
 AC_DEFUN([AC_FPM_SELECT],
 [
 	AC_MSG_CHECKING([for select])
@@ -544,7 +520,6 @@ if test "$PHP_FPM" != "no"; then
   AC_FPM_PORT
   AC_FPM_DEVPOLL
   AC_FPM_EPOLL
-  AC_FPM_POLL
   AC_FPM_SELECT
   AC_FPM_APPARMOR
 


### PR DESCRIPTION
AC_FPM_POLL defines HAVE_POLL symbol which is already checked by configure.ac and function poll in AC_CHECK_FUNCS.