### PR TITLE
Bump PHP_JSON_VERSION

### DIFF
--- a/ext/json/php_json.h
+++ b/ext/json/php_json.h
@@ -20,8 +20,10 @@
 #ifndef PHP_JSON_H
 #define PHP_JSON_H
 
-#define PHP_JSON_VERSION "1.7.0"
+#include "php_version.h"
 #include "zend_smart_str_public.h"
+
+#define PHP_JSON_VERSION PHP_VERSION
 
 extern zend_module_entry json_module_entry;
 #define phpext_json_ptr &json_module_entry


### PR DESCRIPTION
Json extension version should be bumped?

PHP json 1.7.0 from PHP 7.3 !== 1.7.0 from PHP 7.4

PHP_VERSION? 1.8.0? 1.7.1?

Thanks.