### PR TITLE
Fix missed SIGKILL to children in PHP-FPM

### DIFF
--- a/sapi/fpm/fpm/fpm_process_ctl.c
+++ b/sapi/fpm/fpm/fpm_process_ctl.c
@@ -58,7 +58,7 @@ static void fpm_pctl_action(struct fpm_event_s *ev, short which, void *arg) /* {
 
 static int fpm_pctl_timeout_set(int sec) /* {{{ */
 {
-	fpm_event_set_timer(&pctl_event, 0, &fpm_pctl_action, NULL);
+	fpm_event_set_timer(&pctl_event, FPM_EV_PERSIST, &fpm_pctl_action, NULL);
 	fpm_event_add(&pctl_event, sec * 1000);
 	return 0;
 }


### PR DESCRIPTION
Use persistent timer to avoid infinite wait for children completion and
to prevent web-sites down time. During reload (reexec) SIGKILL was
never sent by master process to workers due to single-shot timer
implementation details. It just can not be rescheduled after SIGTERM
from the handler.

- Make Bug #76895 ("'break' not in the 'loop' or 'switch' context" when
  opcache is enabled) harmless. It is not a fix however.
- Bug #76601 "Partially working php-fpm ater incomplete reload"
  (SIGUSR2 received at an inconvenient moment during reload)
  could be considered fixed but it is better to add one more patch.

More bugs have similar symptoms:

- Bug #77140 "FPM occassionally hangs"
- Bug #77443 "FPM hangs on reload due to children handling SIGTERM
  since PHP 7.1"