### PR TITLE
Don't skip uninitialized typed props in get_class_vars()

### DIFF
--- a/Zend/tests/get_class_vars_typed_props.phpt
+++ b/Zend/tests/get_class_vars_typed_props.phpt
@@ -1,0 +1,26 @@
+--TEST--
+get_class_vars() returns uninitialized typed properties with a null value
+--FILE--
+<?php
+
+class Test {
+    public static int $int1;
+    public static int $int2 = 42;
+    public int $int3;
+    public int $int4 = 42;
+}
+
+var_dump(get_class_vars(Test::class));
+
+?>
+--EXPECT--
+array(4) {
+  ["int3"]=>
+  NULL
+  ["int4"]=>
+  int(42)
+  ["int1"]=>
+  NULL
+  ["int2"]=>
+  int(42)
+}

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1123,12 +1123,17 @@ static void add_class_vars(zend_class_entry *scope, zend_class_entry *ce, int st
 		} else if (!statics && (prop_info->flags & ZEND_ACC_STATIC) == 0) {
 			prop = &ce->default_properties_table[OBJ_PROP_TO_NUM(prop_info->offset)];
 		}
-		if (!prop || Z_TYPE_P(prop) == IS_UNDEF) {
+		if (!prop) {
 			continue;
 		}
 
-		/* copy: enforce read only access */
-		ZVAL_COPY_OR_DUP(&prop_copy, prop);
+		if (Z_ISUNDEF_P(prop)) {
+			/* Return uninitialized typed properties as a null value */
+			ZVAL_NULL(&prop_copy);
+		} else {
+			/* copy: enforce read only access */
+			ZVAL_COPY_OR_DUP(&prop_copy, prop);
+		}
 		prop = &prop_copy;
 
 		/* this is necessary to make it able to work with default array


### PR DESCRIPTION
For https://bugs.php.net/bug.php?id=78319.

@bwoebi Not great, but this probably makes more sense than having these properties missing entirely?