### PR TITLE
Fix FPM timer event re-registration

### DIFF
--- a/sapi/fpm/tests/reload-uses-sigkill-as-last-measure.phpt
+++ b/sapi/fpm/tests/reload-uses-sigkill-as-last-measure.phpt
@@ -1,0 +1,56 @@
+--TEST--
+If SIGQUIT and SIGTERM during reloading fail, SIGKILL should be sent
+--SKIPIF--
+<?php
+include "skipif.inc";
+if (!function_exists('pcntl_sigprocmask')) die('skip Requires pcntl_sigprocmask()');
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+pid = {{FILE:PID}}
+process_control_timeout=1
+[unconfined]
+listen = {{ADDR}}
+ping.path = /ping
+ping.response = pong
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 1
+EOT;
+
+$code = <<<EOT
+<?php
+pcntl_sigprocmask(SIG_BLOCK, [SIGQUIT, SIGTERM]);
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->request()->expectEmptyBody();
+$tester->signal('USR2');
+$tester->expectLogNotice('Reloading in progress ...');
+$tester->expectLogNotice('reloading: .*');
+$tester->expectLogNotice('using inherited socket fd=\d+, "127.0.0.1:\d+"');
+$tester->expectLogStartNotices();
+$tester->ping('{{ADDR}}');
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -627,7 +627,7 @@ class Tester
         $read = [$this->outDesc];
         $write = null;
         $except = null;
-        if (stream_select($read, $write, $except, 2 )) {
+        if (stream_select($read, $write, $except, 3)) {
             return fgets($this->outDesc);
         } else {
             return null;


### PR DESCRIPTION
Make sure that fpm_event_add calls inside a timer callback work by unregistering the event from the queue before invoking its callback.

This is an alternative fix for #4460.