### PR TITLE
Set CLI exit code to 1 when invalid parameters are passed

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -158,7 +158,7 @@ static const opt_struct OPTIONS[] = {
 	{'s', 0, "syntax-highlight"},
 	{'s', 0, "syntax-highlighting"},
 	{'w', 0, "strip"},
-	{'?', 0, "usage"},/* help alias (both '?' and 'usage') */
+	{'h', 0, "usage"},/* help alias */
 	{'v', 0, "version"},
 	{'z', 1, "zend-extension"},
  	{'T', 1, "timing"},
@@ -2340,7 +2340,7 @@ parent_loop_end:
 					SG(headers_sent) = 1;
 					php_cgi_usage(argv[0]);
 					php_output_end_all();
-					exit_status = 0;
+					exit_status = (c == 'h') ? 0 : 1;
 					goto out;
 			}
 		}

--- a/sapi/cgi/tests/bug78323.phpt
+++ b/sapi/cgi/tests/bug78323.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #78323 Test exit code for invalid parameters
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+include "include.inc";
+
+$php = get_cgi_path();
+reset_env_vars();
+
+passthru("$php --foo-bar", $exitCode);
+
+echo "\nDone: $exitCode";
+?>
+--EXPECTF--
+Error in argument 1, char 1: no argument for option -
+Usage: %s
+    %a
+
+Done 1

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -167,7 +167,7 @@ const opt_struct OPTIONS[] = {
 	{'S', 1, "server"},
 	{'t', 1, "docroot"},
 	{'w', 0, "strip"},
-	{'?', 0, "usage"},/* help alias (both '?' and 'usage') */
+	{'h', 0, "usage"},/* help alias (both '?' and 'usage') */
 	{'v', 0, "version"},
 	{'z', 1, "zend-extension"},
 	{10,  1, "rf"},
@@ -1328,8 +1328,11 @@ int main(int argc, char *argv[])
 				break;
 #endif
 			case 'h': /* help & quit */
+				php_cli_usage(argv[0]);
+				goto out;
 			case '?':
 				php_cli_usage(argv[0]);
+				exit_status = 1;
 				goto out;
 			case 'i': case 'v': case 'm':
 				sapi_module = &cli_sapi_module;

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -167,7 +167,7 @@ const opt_struct OPTIONS[] = {
 	{'S', 1, "server"},
 	{'t', 1, "docroot"},
 	{'w', 0, "strip"},
-	{'h', 0, "usage"},/* help alias (both '?' and 'usage') */
+	{'h', 0, "usage"},/* help alias */
 	{'v', 0, "version"},
 	{'z', 1, "zend-extension"},
 	{10,  1, "rf"},
@@ -1328,11 +1328,9 @@ int main(int argc, char *argv[])
 				break;
 #endif
 			case 'h': /* help & quit */
-				php_cli_usage(argv[0]);
-				goto out;
 			case '?':
 				php_cli_usage(argv[0]);
-				exit_status = 1;
+				exit_status = (c == 'h') ? 0 : 1;
 				goto out;
 			case 'i': case 'v': case 'm':
 				sapi_module = &cli_sapi_module;

--- a/sapi/cli/tests/bug78323.phpt
+++ b/sapi/cli/tests/bug78323.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Bug #78323 Test exit code for invalid parameters
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+$php = getenv('TEST_PHP_EXECUTABLE');
+
+passthru("$php --memory-limit=1G", $exitCode);
+
+echo "Done: $exitCode\n\n";
+
+passthru("$php -dmemory-limit=1G -v", $exitCode);
+
+echo "\nDone: $exitCode";
+?>
+--EXPECTF--
+
+Usage: %s [options] [-f] <file> [--] [args...]
+   %a
+
+Done: 1
+
+PHP %s
+%a
+
+Done: 0
+

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -149,7 +149,7 @@ static const opt_struct OPTIONS[] = {
 	{'i', 0, "info"},
 	{'m', 0, "modules"},
 	{'n', 0, "no-php-ini"},
-	{'?', 0, "usage"},/* help alias (both '?' and 'usage') */
+	{'h', 0, "usage"},/* help alias */
 	{'v', 0, "version"},
 	{'y', 1, "fpm-config"},
 	{'t', 0, "test"},

--- a/sapi/fpm/tests/bug78323-invalid-parameters-exit-code.phpt
+++ b/sapi/fpm/tests/bug78323-invalid-parameters-exit-code.phpt
@@ -1,0 +1,20 @@
+--TEST--
+FPM: Bug #78323 Test exit code for invalid parameters
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$php = \FPM\Tester::findExecutable();
+
+passthru("$php --foo-bar", $exitCode);
+
+echo "\nDone: $exitCode";
+?>
+--EXPECTF--
+Usage: %s
+   %a
+
+Done: 1


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=78323

When running php with invalid option, e.g. "php --memory-limit=1G" instead "php -dmemory-limit=1G" the PHP help is displayed and return code 1 instead of 0