### PR TITLE
Fix short tags suggested in cli help and man pages

### DIFF
--- a/sapi/cli/php.1.in
+++ b/sapi/cli/php.1.in
@@ -222,7 +222,7 @@ Show compiled in modules
 Run PHP
 .IR code
 without using script tags
-.B '<?..?>'
+.B '<?php...?>'
 .TP
 .PD 0
 .B \-\-process\-begin \fIcode\fP

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -510,7 +510,7 @@ static void php_cli_usage(char *argv0)
 				"  -i               PHP information\n"
 				"  -l               Syntax check only (lint)\n"
 				"  -m               Show compiled in modules\n"
-				"  -r <code>        Run PHP <code> without using script tags <?..?>\n"
+				"  -r <code>        Run PHP <code> without using script tags <?php...?>\n"
 				"  -B <begin_code>  Run PHP <begin_code> before processing input lines\n"
 				"  -R <code>        Run PHP <code> for every input line\n"
 				"  -F <file>        Parse and execute <file> for every input line\n"


### PR DESCRIPTION
Every time a short opening tag is used in PHP, a kitten dies. This fixes two forgotten occurrences in docs.