### PR TITLE
Block signals during fpm master initialization

### DIFF
--- a/sapi/fpm/fpm/fpm_process_ctl.c
+++ b/sapi/fpm/fpm/fpm_process_ctl.c
@@ -78,6 +78,10 @@ static void fpm_pctl_exit() /* {{{ */
 
 static void fpm_pctl_exec() /* {{{ */
 {
+	zlog(ZLOG_DEBUG, "Blocking some signals before reexec");
+	if (0 > fpm_signals_block()) {
+		zlog(ZLOG_WARNING, "concurrent reloads may be unstable");
+	}
 
 	zlog(ZLOG_NOTICE, "reloading: execvp(\"%s\", {\"%s\""
 			"%s%s%s" "%s%s%s" "%s%s%s" "%s%s%s" "%s%s%s"

--- a/sapi/fpm/fpm/fpm_signals.c
+++ b/sapi/fpm/fpm/fpm_signals.c
@@ -20,6 +20,7 @@
 #include "zlog.h"
 
 static int sp[2];
+static sigset_t block_sigset;
 
 const char *fpm_signal_names[NSIG + 1] = {
 #ifdef SIGHUP
@@ -211,6 +212,11 @@ int fpm_signals_init_main() /* {{{ */
 		zlog(ZLOG_SYSERROR, "failed to init signals: sigaction()");
 		return -1;
 	}
+
+	zlog(ZLOG_DEBUG, "Unblocking all signals");
+	if (0 > fpm_signals_unblock()) {
+		return -1;
+	}
 	return 0;
 }
 /* }}} */
@@ -249,5 +255,52 @@ int fpm_signals_init_child() /* {{{ */
 int fpm_signals_get_fd() /* {{{ */
 {
 	return sp[0];
+}
+/* }}} */
+
+int fpm_signals_init_mask(int *signum_array, size_t size) /* {{{ */
+{
+	size_t i = 0;
+	if (0 > sigemptyset(&block_sigset)) {
+		zlog(ZLOG_SYSERROR, "failed to prepare signal block mask: sigemptyset()");
+		return -1;
+	}
+	for (i = 0; i < size; ++i) {
+		int sig_i = signum_array[i];
+		if (0 > sigaddset(&block_sigset, sig_i)) {
+			if (sig_i <= NSIG && fpm_signal_names[sig_i] != NULL) {
+				zlog(ZLOG_SYSERROR, "failed to prepare signal block mask: sigaddset(%s)",
+						fpm_signal_names[sig_i]);
+			} else {
+				zlog(ZLOG_SYSERROR, "failed to prepare signal block mask: sigaddset(%d)", sig_i);
+			}
+			return -1;
+		}
+	}
+	return 0;
+}
+/* }}} */
+
+int fpm_signals_block() /* {{{ */
+{
+	if (0 > sigprocmask(SIG_BLOCK, &block_sigset, NULL)) {
+		zlog(ZLOG_SYSERROR, "failed to block signals");
+		return -1;
+	}
+	return 0;
+}
+/* }}} */
+
+int fpm_signals_unblock() /* {{{ */
+{
+	/* Ensure that during reload after upgrade all signals are unblocked.
+		block_sigset could have different value before execve() */
+	sigset_t all_signals;
+	sigfillset(&all_signals);
+	if (0 > sigprocmask(SIG_UNBLOCK, &all_signals, NULL)) {
+		zlog(ZLOG_SYSERROR, "failed to unblock signals");
+		return -1;
+	}
+	return 0;
 }
 /* }}} */

--- a/sapi/fpm/fpm/fpm_signals.h
+++ b/sapi/fpm/fpm/fpm_signals.h
@@ -9,6 +9,9 @@
 int fpm_signals_init_main();
 int fpm_signals_init_child();
 int fpm_signals_get_fd();
+int fpm_signals_init_mask(int *signum_array, size_t size);
+int fpm_signals_block();
+int fpm_signals_unblock();
 
 extern const char *fpm_signal_names[NSIG + 1];
 

--- a/sapi/fpm/tests/bug74083-concurrent-reload.phpt
+++ b/sapi/fpm/tests/bug74083-concurrent-reload.phpt
@@ -1,0 +1,76 @@
+--TEST--
+Concurrent reload signals should not kill PHP-FPM master process. (Bug: #74083)
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+pid = {{FILE:PID}}
+process_control_timeout=1
+[unconfined]
+listen = {{ADDR}}
+ping.path = /ping
+ping.response = pong
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 1
+EOT;
+
+$code = <<<EOT
+<?php
+/* empty */
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->ping('{{ADDR}}');
+
+/* Vary interval between concurrent reload requests
+    since performance of test instance is not known in advance */
+$max_interval = 25000;
+$step = 1000;
+$pid = $tester->getPid();
+for ($interval = 0; $interval < $max_interval; $interval += $step) {
+    exec("kill -USR2 $pid", $out, $killExitCode);
+    if ($killExitCode) {
+        echo "ERROR: master process is dead\n";
+        break;
+    }
+    usleep($interval);
+}
+echo "Reached interval $interval us with $step us steps\n";
+$tester->expectLogNotice('Reloading in progress ...');
+/* Consume mix of 'Reloading in progress ...' and 'reloading: .*' */
+$tester->getLogLines(2000);
+
+$tester->signal('USR2');
+$tester->expectLogNotice('Reloading in progress ...');
+$tester->expectLogNotice('reloading: .*');
+$tester->expectLogNotice('using inherited socket fd=\d+, "127.0.0.1:\d+"');
+$tester->expectLogStartNotices();
+$tester->ping('{{ADDR}}');
+
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Reached interval 25000 us with 1000 us steps
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/bug74083-concurrent-reload.phpt
+++ b/sapi/fpm/tests/bug74083-concurrent-reload.phpt
@@ -2,6 +2,7 @@
 Concurrent reload signals should not kill PHP-FPM master process. (Bug: #74083)
 --SKIPIF--
 <?php
+include "skipif.inc";
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>
 --FILE--


### PR DESCRIPTION
Fix PHP-FPM failure in the case of concurrent reload attempts.

Postpone signal delivery to the fpm master process till proper signal
handlers are set. Prevent the following case:

- Running master process receives `SIGUSR2` and performs `execvp()`.
- Another `SIGUSR2` is arrived before signal handlers are set.
- Master process dies.
- Requests to the HTTP server handled by PHP-fpm can not be served
  any more.

Block some signals using `sigprocmask()` before `execvp()` and early
in the `main()` function. Unblock signals as soon as proper
handlers are set.

Fixes bug #74083