### PR TITLE
Fix #78179: MariaDB server version incorrectly detected

### DIFF
--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -1485,6 +1485,14 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_server_version)(const MYSQLND_CONN_DATA * 
 		return 0;
 	}
 
+#define MARIA_DB_VERSION_HACK_PREFIX "5.5.5-"
+
+	if (conn->server_capabilities & CLIENT_PLUGIN_AUTH
+		&& !strncmp(p, MARIA_DB_VERSION_HACK_PREFIX, sizeof(MARIA_DB_VERSION_HACK_PREFIX)-1))
+	{
+		p += sizeof(MARIA_DB_VERSION_HACK_PREFIX)-1;
+	}
+
 	major = ZEND_STRTOL(p, &p, 10);
 	p += 1; /* consume the dot */
 	minor = ZEND_STRTOL(p, &p, 10);


### PR DESCRIPTION
As of MariaDB 10.0.2, the server reports a fake version number as work-
around for replication issues[1].  We apply the same "fix" as in the
MariaDB client to cater to this.

[1] <https://github.com/MariaDB/server/commit/c50ee6c23dbeb090963580754bec2f0a96ac0557#diff-5b45fa673c88c06a9651c7906364f592>