### PR TITLE
Fix build warnings

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -990,7 +990,10 @@ static char *php_openssl_cipher_get_version(const SSL_CIPHER *c, char *buffer, s
 {
 	const char *version = SSL_CIPHER_get_version(c);
 
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wstringop-truncation"
 	strncpy(buffer, version, max_len);
+# pragma GCC diagnostic pop
 	if (max_len <= strlen(version)) {
 		buffer[max_len - 1] = 0;
 	}

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -772,9 +772,9 @@ static int phar_tar_writeheaders_int(phar_entry_info *entry, void *argument) /* 
 		}
 	}
 
-	strncpy(header.magic, "ustar", sizeof("ustar")-1);
-	strncpy(header.version, "00", sizeof("00")-1);
-	strncpy(header.checksum, "        ", sizeof("        ")-1);
+	memcpy(header.magic, "ustar", sizeof("ustar")-1);
+	memcpy(header.version, "00", sizeof("00")-1);
+	memcpy(header.checksum, "        ", sizeof("        ")-1);
 	entry->crc32 = phar_tar_checksum((char *)&header, sizeof(header));
 
 	if (FAILURE == phar_tar_octal(header.checksum, entry->crc32, sizeof(header.checksum)-1)) {

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -821,8 +821,8 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 	memset(&local, 0, sizeof(local));
 	memset(&central, 0, sizeof(central));
 	memset(&perms, 0, sizeof(perms));
-	strncpy(local.signature, "PK\3\4", 4);
-	strncpy(central.signature, "PK\1\2", 4);
+	memcpy(local.signature, "PK\3\4", 4);
+	memcpy(central.signature, "PK\1\2", 4);
 	PHAR_SET_16(central.extra_len, sizeof(perms));
 	PHAR_SET_16(local.extra_len, sizeof(perms));
 	perms.tag[0] = 'n';
@@ -1409,7 +1409,7 @@ fperror:
 	pass.free_fp = pass.free_ufp = 1;
 	memset(&eocd, 0, sizeof(eocd));
 
-	strncpy(eocd.signature, "PK\5\6", 4);
+	memcpy(eocd.signature, "PK\5\6", 4);
 	if (!phar->is_data && !phar->sig_flags) {
 		phar->sig_flags = PHAR_SIG_SHA1;
 	}

--- a/ext/standard/crypt.c
+++ b/ext/standard/crypt.c
@@ -255,7 +255,7 @@ PHP_FUNCTION(crypt)
 
 	/* The automatic salt generation covers standard DES, md5-crypt and Blowfish (simple) */
 	if (!*salt) {
-		strncpy(salt, "$1$", 3);
+		memcpy(salt, "$1$", 3);
 		php_random_bytes_throw(&salt[3], 8);
 		php_to64(&salt[3], 8);
 		strncpy(&salt[11], "$", PHP_MAX_SALT_LEN - 11);

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -125,7 +125,7 @@ static php_process_env_t _php_array_to_envp(zval *environment, int is_persistent
 		if (key) {
 			l = ZSTR_LEN(key) + ZSTR_LEN(str) + 2;
 			memcpy(p, ZSTR_VAL(key), ZSTR_LEN(key));
-			strncat(p, "=", 1);
+			strncat(p, "=", 2);
 			strncat(p, ZSTR_VAL(str), ZSTR_LEN(str));
 
 #ifndef PHP_WIN32

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -293,7 +293,7 @@ static php_stream_filter *user_filter_factory_create(const char *filtername,
 			period = wildcard + (period - filtername);
 			while (period) {
 				*period = '\0';
-				strncat(wildcard, ".*", 2);
+				strncat(wildcard, ".*", 3);
 				if (NULL != (fdat = zend_hash_str_find_ptr(BG(user_filter_map), wildcard, strlen(wildcard)))) {
 					period = NULL;
 				} else {

--- a/main/streams/filter.c
+++ b/main/streams/filter.c
@@ -240,7 +240,7 @@ PHPAPI php_stream_filter *php_stream_filter_create(const char *filtername, zval 
 		period = wildname + (period - filtername);
 		while (period && !filter) {
 			*period = '\0';
-			strncat(wildname, ".*", 2);
+			strncat(wildname, ".*", 3);
 			if (NULL != (factory = zend_hash_str_find_ptr(filter_hash, wildname, strlen(wildname)))) {
 				filter = factory->create_filter(filtername, filterparams, persistent);
 			}


### PR DESCRIPTION
- switch from strncpy to memcpy for -Wstringop-truncation
- copy nul byte from src in strncat for -Wstringop-overflow
- ignore strncpy warning when safely managed