### PR TITLE
Monitoring anonymous pages on mac via vmmap.

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -111,6 +111,15 @@ static size_t _real_page_size = ZEND_MM_PAGE_SIZE;
 # undef HAVE_MREMAP
 #endif
 
+#ifndef __APPLE__
+# define ZEND_MM_FD -1
+#else
+/* Mac allows to track anonymous page via vmmap per TAG id.
+ * user land applications are allowed to take from 240 to 255.
+ */
+# define ZEND_MM_FD (250<<24)
+#endif
+
 #ifndef ZEND_MM_STAT
 # define ZEND_MM_STAT 1    /* track current and peak memory usage            */
 #endif
@@ -417,7 +426,7 @@ static void *zend_mm_mmap_fixed(void *addr, size_t size)
 	flags |= MAP_FIXED | MAP_EXCL;
 #endif
 	/* MAP_FIXED leads to discarding of the old mapping, so it can't be used. */
-	void *ptr = mmap(addr, size, PROT_READ | PROT_WRITE, flags /*| MAP_POPULATE | MAP_HUGETLB*/, -1, 0);
+	void *ptr = mmap(addr, size, PROT_READ | PROT_WRITE, flags /*| MAP_POPULATE | MAP_HUGETLB*/, ZEND_MM_FD, 0);
 
 	if (ptr == MAP_FAILED) {
 #if ZEND_MM_ERROR && !defined(MAP_EXCL)
@@ -461,7 +470,7 @@ static void *zend_mm_mmap(size_t size)
 	}
 #endif
 
-	ptr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+	ptr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, ZEND_MM_FD, 0);
 
 	if (ptr == MAP_FAILED) {
 #if ZEND_MM_ERROR


### PR DESCRIPTION
Allows displaying these outputs :
```
                                VIRTUAL RESIDENT    DIRTY  SWAPPED VOLATILE   NONVOL    EMPTY   REGION 
REGION TYPE                        SIZE     SIZE     SIZE     SIZE     SIZE     SIZE     SIZE    COUNT (non-coalesced) 
===========                     ======= ========    =====  ======= ========   ======    =====  ======= 
Activity Tracing                   256K      16K      16K       0K       0K      16K       0K        1 
Kernel Alloc Once                    8K       4K       4K       0K       0K       0K       0K        1 
MALLOC guard page                   16K       0K       0K       0K       0K       0K       0K        3 
MALLOC metadata                     60K      60K      60K       0K       0K       0K       0K        5 
MALLOC_LARGE                      1192K     816K     816K       0K       0K       0K       0K        4         see MALLOC ZONE table below
MALLOC_LARGE (empty)               488K     408K     408K       0K       0K       0K       0K        3         see MALLOC ZONE table below
MALLOC_LARGE metadata                4K       4K       4K       0K       0K       0K       0K        1         see MALLOC ZONE table below
MALLOC_SMALL                      32.0M     412K     412K       0K       0K       0K       0K        2         see MALLOC ZONE table below
MALLOC_TINY                       6144K    1640K    1640K       0K       0K       0K       0K        2         see MALLOC ZONE table below
Memory Tag 250                    2048K     192K     192K       0K       0K       0K       0K        1
```