### PR TITLE
Don't explicitly install homebrew

### DIFF
--- a/azure/macos/brew.yml
+++ b/azure/macos/brew.yml
@@ -3,9 +3,6 @@ parameters:
 
 steps:
   - script: |
-      /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    displayName: 'Install Homebrew'
-  - script: |
       brew install pkg-config \
                    autoconf \
                    bison \


### PR DESCRIPTION
Azure should already have homebrew and this installation step has been very unreliably lately ... see if we can skip it.