### PR TITLE
Fix #78348: Remove -lrt from pdo_sqlite.so

### DIFF
--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -35,8 +35,5 @@ if test "$PHP_PDO_SQLITE" != "no"; then
   PHP_NEW_EXTENSION(pdo_sqlite, pdo_sqlite.c sqlite_driver.c sqlite_statement.c,
     $ext_shared,,-I$pdo_cv_inc_path)
 
-  dnl Solaris fix
-  PHP_CHECK_LIBRARY(rt, fdatasync, [PHP_ADD_LIBRARY(rt,, PDO_SQLITE_SHARED_LIBADD)])
-
   PHP_ADD_EXTENSION_DEP(pdo_sqlite, pdo)
 fi


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=78348

The fdatasync check has been removed since PHP 5.3.

The Solaris fix was introduced via 8d63360fc40dec579af5b5f455ef02b85caff5c5 and is today no longer relevant since the sqlite library is neither bundled in php-src anymore neither the check needs to be done via the PHP build system.