### PR TITLE
Fix #76342: file_get_contents waits twice specified timeout

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -726,6 +726,11 @@ finish:
 			}
 			ZVAL_STRINGL(&http_response, tmp_line, tmp_line_len);
 			zend_hash_next_index_insert(Z_ARRVAL_P(response_header), &http_response);
+		} else {
+			php_stream_close(stream);
+			stream = NULL;
+			php_stream_wrapper_log_error(wrapper, options, "HTTP request failed!");
+			goto out;
 		}
 	} else {
 		php_stream_wrapper_log_error(wrapper, options, "HTTP request failed, unexpected end of socket!");

--- a/ext/standard/tests/http/bug76342.phpt
+++ b/ext/standard/tests/http/bug76342.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Bug #76342 (file_get_contents waits twice specified timeout)
+--INI--
+allow_url_fopen=1
+--SKIPIF--
+<?php require 'server.inc'; http_server_skipif('tcp://127.0.0.1:12342'); ?>
+--FILE--
+<?php
+require 'server.inc';
+
+$options = [
+  'http' => [
+    'timeout' => '0.1',
+  ],
+];
+
+$ctx = stream_context_create($options);
+
+$pid = http_server_sleep('tcp://127.0.0.1:12342');
+
+$start = microtime(true);
+file_get_contents('http://127.0.0.1:12342/', false, $ctx);
+if (microtime(true) - $start >= 0.2) {
+    echo 'FAIL';
+}
+
+http_server_kill($pid);
+
+?>
+DONE
+--EXPECTF--
+Warning: file_get_contents(http://127.0.0.1:12342/): failed to open stream: HTTP request failed! in %s on line %d
+DONE

--- a/ext/standard/tests/http/server.inc
+++ b/ext/standard/tests/http/server.inc
@@ -7,14 +7,7 @@ function http_server_skipif($socket_string) {
 	if (!stream_socket_server($socket_string)) die('skip stream_socket_server() failed');
 }
 
-/* Minimal HTTP server with predefined responses.
- *
- * $socket_string is the socket to create and listen on (e.g. tcp://127.0.0.1:1234)
- * $files is an array of files containing N responses for N expected requests. Server dies after N requests.
- * $output is a stream on which everything sent by clients is written to
- */
-function http_server($socket_string, array $files, &$output = null) {
-
+function http_server_init($socket_string, &$output = null) {
 	pcntl_alarm(60);
 
 	$server = stream_socket_server($socket_string, $errno, $errstr);
@@ -34,6 +27,21 @@ function http_server($socket_string, array $files, &$output = null) {
 		die('could not fork');
 	} else if ($pid) {
 		return $pid;
+	}
+
+	return $server;
+}
+
+/* Minimal HTTP server with predefined responses.
+ *
+ * $socket_string is the socket to create and listen on (e.g. tcp://127.0.0.1:1234)
+ * $files is an array of files containing N responses for N expected requests. Server dies after N requests.
+ * $output is a stream on which everything sent by clients is written to
+ */
+function http_server($socket_string, array $files, &$output = null) {
+
+	if (!is_resource($server = http_server_init($socket_string, $output))) {
+		return $server;
 	}
 
 	foreach($files as $file) {
@@ -80,6 +88,24 @@ function http_server($socket_string, array $files, &$output = null) {
 
 		fclose($sock);
 	}
+
+	exit(0);
+}
+
+function http_server_sleep($socket_string, $micro_seconds = 500000)
+{
+	if (!is_resource($server = http_server_init($socket_string, $output))) {
+		return $server;
+	}
+
+	$sock = stream_socket_accept($server);
+	if (!$sock) {
+		exit(1);
+	}
+
+	usleep($micro_seconds);
+
+	fclose($sock);
 
 	exit(0);
 }


### PR DESCRIPTION
Currently, if getting the response headers fails, we are still trying to read past them to get the content. Is that logical? 🤔 

That's the cause of the fixed bug : the current behavior makes 2 call to `php_stream_get_line`, thus "applying" 2 times the timeout. I guess that in the particular described setup, the end of stream is not detected. However, the timeout being applied 2 times is not coherent at all.

I just moved the `/* read past HTTP headers */` code block so it is executed only if getting the headers was successful. We can also fix it by forcing `$stream->eof = 1;` when the first call fails but I guess that's dirtier.

I know close to nothing about C and PHP source code but at least the test can be used if it can be fixed in a better way 😄 