### PR TITLE
[WIP] Packages

### DIFF
--- a/Zend/tests/packages/package_declare_errors.phpt
+++ b/Zend/tests/packages/package_declare_errors.phpt
@@ -1,0 +1,111 @@
+--TEST--
+Error conditions of package_declare()
+--FILE--
+<?php
+
+try {
+    package_declare([]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    package_declare([
+        "name" => 42,
+    ]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    package_declare([
+        "name" => "foo/bar",
+        "declares" => 42,
+    ]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    package_declare([
+        "name" => "foo/bar",
+        "declares" => [
+            "foo"
+        ],
+    ]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    package_declare([
+        "name" => "foo/bar",
+        "declares" => [
+            "ticks" => "foo",
+        ],
+    ]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    package_declare([
+        "name" => "foo/bar",
+        "declares" => [
+            "ticks" => -1,
+        ],
+    ]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    package_declare([
+        "name" => "foo/bar",
+        "declares" => [
+            "strict_types" => "foo",
+        ],
+    ]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    package_declare([
+        "name" => "foo/bar",
+        "declares" => [
+            "strict_types" => 42,
+        ],
+    ]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// Allowed for forward-compatibility
+package_declare([
+    "name" => "foo/bar",
+    "declares" => [
+        "unknown" => "foo",
+    ],
+]);
+
+
+try {
+    package_declare([
+        "name" => "foo/bar",
+    ]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Package specification must contain "name" key of type string
+Package specification must contain "name" key of type string
+Package specification key "declares" must be of type array
+Declares array in package specification must have string keys
+Value of "ticks" must be a non-negative integer
+Value of "ticks" must be a non-negative integer
+Value of "strict_types" must be 0 or 1
+Value of "strict_types" must be 0 or 1
+Package "foo/bar" already registered

--- a/Zend/tests/packages/package_first_statement.phpt
+++ b/Zend/tests/packages/package_first_statement.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Package declaration must be the first statement (even before declares)
+--FILE--
+<?php
+
+declare(strict_types=1);
+package "foo/bar";
+
+?>
+--EXPECTF--
+Fatal error: Package declaration must be the first statement in the script in %s on line %d

--- a/Zend/tests/packages/package_strict_types.phpt
+++ b/Zend/tests/packages/package_strict_types.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Specifying strict_types through package declaration
+--FILE--
+<?php
+
+package_declare([
+    "name" => "with_strict_types",
+    "declares" => [
+        "strict_types" => 1,
+    ],
+]);
+
+eval(<<<'PHP'
+// Package defaults to strict types
+package "with_strict_types";
+
+try {
+    var_dump(strlen(42));
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+PHP);
+
+eval(<<<'PHP'
+// Manual override to strict_types=0
+package "with_strict_types";
+declare(strict_types=0);
+
+try {
+    var_dump(strlen(42));
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+PHP);
+
+eval(<<<'PHP'
+// No package, no strict_types
+
+try {
+    var_dump(strlen(42));
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+PHP);
+
+?>
+--EXPECT--
+strlen() expects parameter 1 to be string, int given
+int(2)
+int(2)

--- a/Zend/tests/packages/package_ticks.phpt
+++ b/Zend/tests/packages/package_ticks.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Specifying ticks through package declaration
+--FILE--
+<?php
+
+register_tick_function(function() {
+    echo "Tick\n";
+});
+
+package_declare([
+    "name" => "with_ticks",
+    "declares" => [
+        "ticks" => 1,
+    ],
+]);
+
+eval(<<<'PHP'
+// Package defaults to ticks=1
+package "with_ticks";
+
+echo "Foo\n";
+echo "Foo\n";
+PHP);
+
+eval(<<<'PHP'
+// Manual override to ticks=0
+package "with_ticks";
+declare(ticks=0);
+
+echo "Bar\n";
+echo "Bar\n";
+PHP);
+
+eval(<<<'PHP'
+// No package, no ticks
+
+echo "Baz\n";
+echo "Baz\n";
+PHP);
+
+?>
+--EXPECT--
+Foo
+Tick
+Foo
+Tick
+Bar
+Bar
+Baz
+Baz

--- a/Zend/tests/packages/unknown_package.phpt
+++ b/Zend/tests/packages/unknown_package.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Package declaration references an unknown package
+--FILE--
+<?php
+
+package "foo/bar";
+
+?>
+--EXPECTF--
+Fatal error: Unknown package "foo/bar" in %s on line %d

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -101,6 +101,7 @@ enum _zend_ast_kind {
 	ZEND_AST_GOTO,
 	ZEND_AST_BREAK,
 	ZEND_AST_CONTINUE,
+	ZEND_AST_PACKAGE,
 
 	/* 2 child nodes */
 	ZEND_AST_DIM = 2 << ZEND_AST_NUM_CHILDREN_SHIFT,

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -497,6 +497,14 @@ struct _zend_execute_data {
 	void               **run_time_cache;   /* cache op_array->run_time_cache */
 };
 
+typedef struct {
+	zend_string *name;
+	struct {
+		zend_long ticks;
+		int strict_types : 1;
+	} declares;
+} zend_package_info;
+
 #define ZEND_CALL_HAS_THIS           IS_OBJECT_EX
 
 /* Top 16 bits of Z_TYPE_INFO(EX(This)) are used as call_info flags */

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -127,6 +127,10 @@ struct _zend_compiler_globals {
 
 	HashTable *delayed_variance_obligations;
 	HashTable *delayed_autoloads;
+
+	HashTable *packages;
+	/* Available after compilation for use by opcache */
+	zend_package_info *current_package;
 };
 
 

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -197,6 +197,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %token T_LIST            "list (T_LIST)"
 %token T_ARRAY           "array (T_ARRAY)"
 %token T_CALLABLE        "callable (T_CALLABLE)"
+%token T_PACKAGE         "package (T_PACKAGE)"
 %token T_LINE            "__LINE__ (T_LINE)"
 %token T_FILE            "__FILE__ (T_FILE)"
 %token T_DIR             "__DIR__ (T_DIR)"
@@ -334,6 +335,10 @@ top_statement:
 	|	T_USE use_declarations ';'					{ $$ = $2; $$->attr = ZEND_SYMBOL_CLASS; }
 	|	T_USE use_type use_declarations ';'			{ $$ = $3; $$->attr = $2; }
 	|	T_CONST const_list ';'						{ $$ = $2; }
+	|	T_PACKAGE T_CONSTANT_ENCAPSED_STRING ';'
+			{ $$ = zend_ast_create(ZEND_AST_PACKAGE, $2); }
+	|	T_PACKAGE '(' T_CONSTANT_ENCAPSED_STRING ')' ';'
+			{ $$ = zend_ast_create(ZEND_AST_PACKAGE, $3); }
 ;
 
 use_type:

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1607,6 +1607,11 @@ NEWLINE ("\r"|"\n"|"\r\n")
 	RETURN_TOKEN(T_CALLABLE);
 }
 
+<ST_IN_SCRIPTING>"package" {
+	/* TODO: Implement this as a contextually-reserved keyword instead */
+	RETURN_TOKEN(T_PACKAGE);
+}
+
 <ST_IN_SCRIPTING>"++" {
 	RETURN_TOKEN(T_INC);
 }

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -111,6 +111,7 @@ typedef enum _zend_accel_restart_reason {
 
 typedef struct _zend_persistent_script {
 	zend_script    script;
+	zend_package_info *package;
 	zend_long      compiler_halt_offset;   /* position of __HALT_COMPILER or -1 */
 	int            ping_auto_globals_mask; /* which autoglobals are used by the script */
 	accel_time_t   timestamp;              /* the script modification time */

--- a/ext/opcache/tests/packages_invalidation.phpt
+++ b/ext/opcache/tests/packages_invalidation.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Files are invalidated if the package definition changes
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--CONFLICTS--
+server
+--FILE--
+<?php
+
+include __DIR__ . "/php_cli_server.inc";
+php_cli_server_start(getenv('TEST_PHP_EXTRA_ARGS'));
+
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_without_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_without_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+
+?>
+--EXPECT--
+strlen() expects parameter 1 to be string, int given
+Misses: 2
+strlen() expects parameter 1 to be string, int given
+Misses: 2
+int(1)
+Misses: 4
+int(1)
+Misses: 4
+strlen() expects parameter 1 to be string, int given
+Misses: 5
+strlen() expects parameter 1 to be string, int given
+Misses: 5

--- a/ext/opcache/tests/packages_invalidation_file_cache.phpt
+++ b/ext/opcache/tests/packages_invalidation_file_cache.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Files are invalidated if the package definition changes (with file cache)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--CONFLICTS--
+server
+--INI--
+opcache.file_cache={TMP}
+opcache.file_cache_only=0
+opcache.jit_buffer_size=0
+--FILE--
+<?php
+
+include __DIR__ . "/php_cli_server.inc";
+php_cli_server_start(getenv('TEST_PHP_EXTRA_ARGS'));
+
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_without_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_without_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+
+?>
+--EXPECTF--
+strlen() expects parameter 1 to be string, int given
+Misses: %d
+strlen() expects parameter 1 to be string, int given
+Misses: %d
+int(1)
+Misses: %d
+int(1)
+Misses: %d
+strlen() expects parameter 1 to be string, int given
+Misses: %d
+strlen() expects parameter 1 to be string, int given
+Misses: %d

--- a/ext/opcache/tests/packages_invalidation_file_cache_only.phpt
+++ b/ext/opcache/tests/packages_invalidation_file_cache_only.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Files are invalidated if the package definition changes (with file cache only)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--CONFLICTS--
+server
+--INI--
+opcache.file_cache={TMP}
+opcache.file_cache_only=1
+--FILE--
+<?php
+
+include __DIR__ . "/php_cli_server.inc";
+php_cli_server_start(getenv('TEST_PHP_EXTRA_ARGS'));
+
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_without_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_without_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/packages_invalidation_with_strict_types.php" );
+
+?>
+--EXPECT--
+strlen() expects parameter 1 to be string, int given
+Misses: -
+strlen() expects parameter 1 to be string, int given
+Misses: -
+int(1)
+Misses: -
+int(1)
+Misses: -
+strlen() expects parameter 1 to be string, int given
+Misses: -
+strlen() expects parameter 1 to be string, int given
+Misses: -

--- a/ext/opcache/tests/packages_invalidation_use_pkg.php
+++ b/ext/opcache/tests/packages_invalidation_use_pkg.php
@@ -1,0 +1,9 @@
+<?php
+
+package "pkg";
+
+try {
+    var_dump(strlen(2));
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}

--- a/ext/opcache/tests/packages_invalidation_with_strict_types.php
+++ b/ext/opcache/tests/packages_invalidation_with_strict_types.php
@@ -1,0 +1,9 @@
+<?php
+
+package_declare([
+    "name" => "pkg",
+    "declares" => ["strict_types" => 1],
+]);
+
+require __DIR__ . '/packages_invalidation_use_pkg.php';
+echo "Misses: ", opcache_get_status()["opcache_statistics"]["misses"] ?? "-", "\n";

--- a/ext/opcache/tests/packages_invalidation_without_strict_types.php
+++ b/ext/opcache/tests/packages_invalidation_without_strict_types.php
@@ -1,0 +1,9 @@
+<?php
+
+package_declare([
+    "name" => "pkg",
+    "declares" => ["strict_types" => 0],
+]);
+
+require __DIR__ . '/packages_invalidation_use_pkg.php';
+echo "Misses: ", opcache_get_status()["opcache_statistics"]["misses"] ?? "-", "\n";

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -896,3 +896,16 @@ unsigned int zend_accel_script_checksum(zend_persistent_script *persistent_scrip
 	}
 	return checksum;
 }
+
+zend_bool zend_accel_check_package_consistency(zend_package_info *cached_package)
+{
+	zend_package_info *info =
+		CG(packages) ? zend_hash_find_ptr(CG(packages), cached_package->name) : NULL;
+	if (!info) {
+		/* Package not registered, force a recompilation that will throw an error. */
+		return 0;
+	}
+
+	/* Make sure that the package declares are the same. */
+	return memcmp(&info->declares, &cached_package->declares, sizeof(info->declares)) == 0;
+}

--- a/ext/opcache/zend_accelerator_util_funcs.h
+++ b/ext/opcache/zend_accelerator_util_funcs.h
@@ -38,5 +38,6 @@ zend_op_array* zend_accel_load_script(zend_persistent_script *persistent_script,
 unsigned int zend_adler32(unsigned int checksum, signed char *buf, uint32_t len);
 
 unsigned int zend_accel_script_checksum(zend_persistent_script *persistent_script);
+zend_bool zend_accel_check_package_consistency(zend_package_info *cached_package);
 
 #endif /* ZEND_ACCELERATOR_UTIL_FUNCS_H */

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1047,6 +1047,13 @@ static void zend_accel_persist_class_table(HashTable *class_table)
 	} ZEND_HASH_FOREACH_END();
 }
 
+static void zend_persist_package(zend_package_info **info) {
+	if (*info) {
+		*info = zend_shared_memdup(*info, sizeof(zend_package_info));
+		zend_accel_store_interned_string((*info)->name);
+	}
+}
+
 zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script, const char **key, unsigned int key_length, int for_shm)
 {
 	Bucket *p;
@@ -1096,6 +1103,7 @@ zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script
 		zend_persist_op_array(&p->val);
 	} ZEND_HASH_FOREACH_END();
 	zend_persist_op_array_ex(&script->script.main_op_array, script);
+	zend_persist_package(&script->package);
 
 	ZCSG(map_ptr_last) = CG(map_ptr_last);
 

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -492,6 +492,13 @@ static void zend_accel_persist_class_table_calc(HashTable *class_table)
 	} ZEND_HASH_FOREACH_END();
 }
 
+static void zend_persist_package_calc(zend_package_info *info) {
+	if (info) {
+		ADD_SIZE(sizeof(zend_package_info));
+		ADD_INTERNED_STRING(info->name);
+	}
+}
+
 uint32_t zend_accel_script_persist_calc(zend_persistent_script *new_persistent_script, const char *key, unsigned int key_length, int for_shm)
 {
 	Bucket *p;
@@ -534,6 +541,7 @@ uint32_t zend_accel_script_persist_calc(zend_persistent_script *new_persistent_s
 		zend_persist_op_array_calc(&p->val);
 	} ZEND_HASH_FOREACH_END();
 	zend_persist_op_array_calc_ex(&new_persistent_script->script.main_op_array);
+	zend_persist_package_calc(new_persistent_script->package);
 
 #if defined(__AVX__) || defined(__SSE2__)
 	/* Align size to 64-byte boundary */


### PR DESCRIPTION
Packages are registered using the `package_declare()` function (which should be called by composer in the future, based on composer.json information):
```php
<?php
package_declare([
    "name" => "nikic/php-parser",
    "declares" => [
        "strict_types" => 1,
    ],
]);
```
Files then specify which package they are part of:
```php
<?php
package "nikic/php-parser";
// ...
```
The package concept is orthogonal to namespaces. In this patch it is used only to manage declares for a whole package. In the future it may be used to implement package-private visibility, or any other functionality that is supposed to be package-specific.

This is an alternative to https://wiki.php.net/rfc/namespace_scoped_declares (#2972).

TODO:
 * [ ] Preloading support.