### PR TITLE
Fix #41997: SP call yields additional empty result set

### DIFF
--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -425,14 +425,14 @@ static int pdo_mysql_stmt_next_rowset(pdo_stmt_t *stmt) /* {{{ */
 		pdo_mysql_error_stmt(stmt);
 		PDO_DBG_RETURN(0);
 	} else {
-		PDO_DBG_RETURN(pdo_mysql_fill_stmt_from_result(stmt));
+		PDO_DBG_RETURN(pdo_mysql_fill_stmt_from_result(stmt) && stmt->row_count);
 	}
 #else
 	if (mysql_next_result(H->server) > 0) {
 		pdo_mysql_error_stmt(stmt);
 		PDO_DBG_RETURN(0);
 	} else {
-		PDO_DBG_RETURN(pdo_mysql_fill_stmt_from_result(stmt));
+		PDO_DBG_RETURN(pdo_mysql_fill_stmt_from_result(stmt) && stmt->row_count);
 	}
 #endif
 }

--- a/ext/pdo_mysql/tests/bug_39858.phpt
+++ b/ext/pdo_mysql/tests/bug_39858.phpt
@@ -18,8 +18,6 @@ if ($version < 50000)
 	die(sprintf("skip Need MySQL Server 5.0.0+, found %d.%02d.%02d (%d)\n",
 		$matches[0], $matches[1], $matches[2], $version));
 ?>
---XFAIL--
-nextRowset() problem with stored proc & emulation mode & mysqlnd
 --FILE--
 <?php
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');

--- a/ext/pdo_mysql/tests/bug_41997.phpt
+++ b/ext/pdo_mysql/tests/bug_41997.phpt
@@ -1,7 +1,5 @@
 --TEST--
 PDO MySQL Bug #41997 (stored procedure call returning single rowset blocks future queries)
---XFAIL--
-nextRowset() problem with stored proc & emulation mode & mysqlnd
 --SKIPIF--
 <?php
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'skipif.inc');

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_variable_columncount.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_variable_columncount.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MySQL Prepared Statements and different column counts
---XFAIL--
-nextRowset() problem with stored proc & emulation mode & mysqlnd
 --SKIPIF--
 <?php
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'skipif.inc');


### PR DESCRIPTION
When stored procedures are called, the "final result set is a status
result that includes no result set".  Calling `::nextRowset()` on the
actual last result set should return FALSE, since there is actually no
further result set to be processed.