### PR TITLE
Convert json functions arginfo to php stubs

### DIFF
--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -29,6 +29,7 @@
 #include "php_json.h"
 #include "php_json_encoder.h"
 #include "php_json_parser.h"
+#include "json_arginfo.h"
 #include <zend_exceptions.h>
 
 static PHP_MINFO_FUNCTION(json);
@@ -41,27 +42,6 @@ PHP_JSON_API zend_class_entry *php_json_serializable_ce;
 PHP_JSON_API zend_class_entry *php_json_exception_ce;
 
 PHP_JSON_API ZEND_DECLARE_MODULE_GLOBALS(json)
-
-/* {{{ arginfo */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_json_encode, 0, 0, 1)
-	ZEND_ARG_INFO(0, value)
-	ZEND_ARG_INFO(0, options)
-	ZEND_ARG_INFO(0, depth)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_json_decode, 0, 0, 1)
-	ZEND_ARG_INFO(0, json)
-	ZEND_ARG_INFO(0, assoc)
-	ZEND_ARG_INFO(0, depth)
-	ZEND_ARG_INFO(0, options)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_json_last_error, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_json_last_error_msg, 0)
-ZEND_END_ARG_INFO()
-/* }}} */
 
 /* {{{ json_functions[] */
 static const zend_function_entry json_functions[] = {

--- a/ext/json/json.stub.php
+++ b/ext/json/json.stub.php
@@ -1,0 +1,11 @@
+<?php
+
+/** @return string|false */
+function json_encode($value, int $options = 0, int $depth = 512) {}
+
+/** @return mixed */
+function json_decode(string $json, ?bool $assoc = null, int $depth = 512, int $options = 0) {}
+
+function json_last_error(): int {}
+
+function json_last_error_msg(): string {}

--- a/ext/json/json_arginfo.h
+++ b/ext/json/json_arginfo.h
@@ -1,0 +1,20 @@
+/* This is a generated file, edit the .stub.php file instead. */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_json_encode, 0, 0, 1)
+	ZEND_ARG_INFO(0, value)
+	ZEND_ARG_TYPE_INFO(0, options, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_json_decode, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, json, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, assoc, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_json_last_error, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_json_last_error_msg, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()


### PR DESCRIPTION
Following the [Call for participation](https://externals.io/message/106522) this PR attempts to convert a few `json` functions to stubs