### PR TITLE
Fallback to `curl` in `gen_stub.php` if `wget` fails

### DIFF
--- a/scripts/dev/gen_stub.php
+++ b/scripts/dev/gen_stub.php
@@ -360,11 +360,10 @@ function initPhpParser() {
     if (!is_dir($phpParserDir)) {
         $cwd = getcwd();
         chdir(__DIR__);
-        if (PHP_OS === 'Darwin') {
+
+        passthru("wget https://github.com/nikic/PHP-Parser/archive/v$version.tar.gz", $exit);
+        if ($exit !== 0) {
             passthru("curl -LO https://github.com/nikic/PHP-Parser/archive/v$version.tar.gz", $exit);
-        }
-        else {
-            passthru("wget https://github.com/nikic/PHP-Parser/archive/v$version.tar.gz", $exit);
         }
         if ($exit !== 0) {
             throw new Exception("Failed to download PHP-Parser tarball");

--- a/scripts/dev/gen_stub.php
+++ b/scripts/dev/gen_stub.php
@@ -360,7 +360,12 @@ function initPhpParser() {
     if (!is_dir($phpParserDir)) {
         $cwd = getcwd();
         chdir(__DIR__);
-        passthru("wget https://github.com/nikic/PHP-Parser/archive/v$version.tar.gz", $exit);
+        if (PHP_OS === 'Darwin') {
+            passthru("curl -LO https://github.com/nikic/PHP-Parser/archive/v$version.tar.gz", $exit);
+        }
+        else {
+            passthru("wget https://github.com/nikic/PHP-Parser/archive/v$version.tar.gz", $exit);
+        }
         if ($exit !== 0) {
             throw new Exception("Failed to download PHP-Parser tarball");
         }


### PR DESCRIPTION
By default macOS does not ship with `wget`. Some packages of `wget` for macOS do not integrate with Keychain, and thus have no root certs, thus https fails.
