### PR TITLE
Convert sqlite3 functions arginfo to php stubs

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -25,6 +25,7 @@
 #include "ext/standard/info.h"
 #include "php_sqlite3.h"
 #include "php_sqlite3_structs.h"
+#include "sqlite3_arginfo.h"
 #include "main/SAPI.h"
 
 #include <sqlite3.h>
@@ -322,7 +323,7 @@ PHP_METHOD(sqlite3, enableExtendedResultCodes)
 	int ret;
 
 	SQLITE3_CHECK_INITIALIZED(db_obj, db_obj->db, SQLite3)
-	
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &enable) == FAILURE) {
 		return;
 	}
@@ -2106,174 +2107,65 @@ PHP_METHOD(sqlite3result, __construct)
 }
 /* }}} */
 
-/* {{{ arginfo */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_open, 0, 0, 1)
-	ZEND_ARG_INFO(0, filename)
-	ZEND_ARG_INFO(0, flags)
-	ZEND_ARG_INFO(0, encryption_key)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_sqlite3_busytimeout, 0)
-	ZEND_ARG_INFO(0, ms)
-ZEND_END_ARG_INFO()
-
-#ifndef SQLITE_OMIT_LOAD_EXTENSION
-ZEND_BEGIN_ARG_INFO(arginfo_sqlite3_loadextension, 0)
-	ZEND_ARG_INFO(0, shared_library)
-ZEND_END_ARG_INFO()
-#endif
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_escapestring, 0, 0, 1)
-	ZEND_ARG_INFO(0, value)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_query, 0, 0, 1)
-	ZEND_ARG_INFO(0, query)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_querysingle, 0, 0, 1)
-	ZEND_ARG_INFO(0, query)
-	ZEND_ARG_INFO(0, entire_row)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_createfunction, 0, 0, 2)
-	ZEND_ARG_INFO(0, name)
-	ZEND_ARG_INFO(0, callback)
-	ZEND_ARG_INFO(0, argument_count)
-	ZEND_ARG_INFO(0, flags)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_createaggregate, 0, 0, 3)
-	ZEND_ARG_INFO(0, name)
-	ZEND_ARG_INFO(0, step_callback)
-	ZEND_ARG_INFO(0, final_callback)
-	ZEND_ARG_INFO(0, argument_count)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_createcollation, 0, 0, 2)
-	ZEND_ARG_INFO(0, name)
-	ZEND_ARG_INFO(0, callback)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_openblob, 0, 0, 3)
-	ZEND_ARG_INFO(0, table)
-	ZEND_ARG_INFO(0, column)
-	ZEND_ARG_INFO(0, rowid)
-	ZEND_ARG_INFO(0, dbname)
-	ZEND_ARG_INFO(0, flags)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_enableexceptions, 0, 0, 0)
-	ZEND_ARG_INFO(0, enableExceptions)
-ZEND_END_ARG_INFO()
-
-#if SQLITE_VERSION_NUMBER >= 3006011
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_backup, 0, 0, 1)
-	ZEND_ARG_INFO(0, destination_db)
-	ZEND_ARG_INFO(0, source_dbname)
-	ZEND_ARG_INFO(0, destination_dbname)
-ZEND_END_ARG_INFO()
-#endif
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3stmt_bindparam, 0, 0, 2)
-	ZEND_ARG_INFO(0, param_number)
-	ZEND_ARG_INFO(1, param)
-	ZEND_ARG_INFO(0, type)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3stmt_bindvalue, 0, 0, 2)
-	ZEND_ARG_INFO(0, param_number)
-	ZEND_ARG_INFO(0, param)
-	ZEND_ARG_INFO(0, type)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3stmt_construct, 0, 0, 1)
-	ZEND_ARG_INFO(0, sqlite3)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3stmt_getsql, 0, 0, 0)
-	ZEND_ARG_INFO(0, expanded)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3result_columnname, 0, 0, 1)
-	ZEND_ARG_INFO(0, column_number)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3result_columntype, 0, 0, 1)
-	ZEND_ARG_INFO(0, column_number)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3result_fetcharray, 0, 0, 0)
-	ZEND_ARG_INFO(0, mode)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_sqlite3_enableextended, 0, 0, 1)
-	ZEND_ARG_INFO(0, enable)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_sqlite3_void, 0)
-ZEND_END_ARG_INFO()
-/* }}} */
-
 /* {{{ php_sqlite3_class_methods */
 static const zend_function_entry php_sqlite3_class_methods[] = {
-	PHP_ME(sqlite3,		open,						arginfo_sqlite3_open, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		close,						arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		exec,						arginfo_sqlite3_query, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		version,					arginfo_sqlite3_void, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	PHP_ME(sqlite3,		lastInsertRowID,			arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		lastErrorCode,				arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		lastExtendedErrorCode,		arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		enableExtendedResultCodes,	arginfo_sqlite3_enableextended, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		lastErrorMsg,				arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		busyTimeout,				arginfo_sqlite3_busytimeout, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		open,						arginfo_SQLite3_open, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		close,						arginfo_SQLite3_close, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		exec,						arginfo_SQLite3_query, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		version,					arginfo_SQLite3_version, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(sqlite3,		lastInsertRowID,			arginfo_SQLite3_lastInsertRowID, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		lastErrorCode,				arginfo_SQLite3_lastErrorCode, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		lastExtendedErrorCode,		arginfo_SQLite3_lastExtendedErrorCode, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		enableExtendedResultCodes,	arginfo_SQLite3_enableExtendedResultCodes, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		lastErrorMsg,				arginfo_SQLite3_lastErrorMsg, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		busyTimeout,				arginfo_SQLite3_busyTimeout, ZEND_ACC_PUBLIC)
 #ifndef SQLITE_OMIT_LOAD_EXTENSION
-	PHP_ME(sqlite3,		loadExtension,				arginfo_sqlite3_loadextension, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		loadExtension,				arginfo_SQLite3_loadExtension, ZEND_ACC_PUBLIC)
 #endif
-	PHP_ME(sqlite3,		changes,					arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		escapeString,				arginfo_sqlite3_escapestring, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	PHP_ME(sqlite3,		prepare,					arginfo_sqlite3_query, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		query,						arginfo_sqlite3_query, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		querySingle,				arginfo_sqlite3_querysingle, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		createFunction,				arginfo_sqlite3_createfunction, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		createAggregate,			arginfo_sqlite3_createaggregate, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		createCollation,			arginfo_sqlite3_createcollation, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		openBlob,					arginfo_sqlite3_openblob, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3,		enableExceptions,			arginfo_sqlite3_enableexceptions, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		changes,					arginfo_SQLite3_changes, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		escapeString,				arginfo_SQLite3_escapeString, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(sqlite3,		prepare,					arginfo_SQLite3_query, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		query,						arginfo_SQLite3_query, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		querySingle,				arginfo_SQLite3_querySingle, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		createFunction,				arginfo_SQLite3_createFunction, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		createAggregate,			arginfo_SQLite3_createAggregate, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		createCollation,			arginfo_SQLite3_createCollation, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		openBlob,					arginfo_SQLite3_openBlob, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		enableExceptions,			arginfo_SQLite3_enableExceptions, ZEND_ACC_PUBLIC)
 #if SQLITE_VERSION_NUMBER >= 3006011
-	PHP_ME(sqlite3,		backup,						arginfo_sqlite3_backup, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3,		backup,						arginfo_SQLite3_backup, ZEND_ACC_PUBLIC)
 #endif
 	/* Aliases */
-	PHP_MALIAS(sqlite3,	__construct, open, arginfo_sqlite3_open, ZEND_ACC_PUBLIC)
+	PHP_MALIAS(sqlite3,	__construct, open, arginfo_SQLite3___construct, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 /* }}} */
 
 /* {{{ php_sqlite3_stmt_class_methods */
 static const zend_function_entry php_sqlite3_stmt_class_methods[] = {
-	PHP_ME(sqlite3stmt, paramCount,	arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3stmt, close,		arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3stmt, reset,		arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3stmt, clear,		arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3stmt, execute,	arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3stmt, bindParam,	arginfo_sqlite3stmt_bindparam, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3stmt, bindValue,	arginfo_sqlite3stmt_bindvalue, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3stmt, readOnly,	arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3stmt, getSQL,		arginfo_sqlite3stmt_getsql, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3stmt, __construct, arginfo_sqlite3stmt_construct, ZEND_ACC_PRIVATE)
+	PHP_ME(sqlite3stmt, paramCount,	arginfo_SQLite3Stmt_paramCount, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3stmt, close,		arginfo_SQLite3Stmt_close, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3stmt, reset,		arginfo_SQLite3Stmt_reset, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3stmt, clear,		arginfo_SQLite3Stmt_clear, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3stmt, execute,	arginfo_SQLite3Stmt_execute, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3stmt, bindParam,	arginfo_SQLite3Stmt_bindParam, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3stmt, bindValue,	arginfo_SQLite3Stmt_bindValue, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3stmt, readOnly,	arginfo_SQLite3Stmt_readOnly, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3stmt, getSQL,		arginfo_SQLite3Stmt_getSQL, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3stmt, __construct, arginfo_SQLite3Stmt___construct, ZEND_ACC_PRIVATE)
 	PHP_FE_END
 };
 /* }}} */
 
 /* {{{ php_sqlite3_result_class_methods */
 static const zend_function_entry php_sqlite3_result_class_methods[] = {
-	PHP_ME(sqlite3result, numColumns,		arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3result, columnName,		arginfo_sqlite3result_columnname, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3result, columnType,		arginfo_sqlite3result_columntype, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3result, fetchArray,		arginfo_sqlite3result_fetcharray, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3result, reset,			arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3result, finalize,			arginfo_sqlite3_void, ZEND_ACC_PUBLIC)
-	PHP_ME(sqlite3result, __construct, 		arginfo_sqlite3_void, ZEND_ACC_PRIVATE)
+	PHP_ME(sqlite3result, numColumns,		arginfo_SQLite3Result_numColumns, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3result, columnName,		arginfo_SQLite3Result_columnName, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3result, columnType,		arginfo_SQLite3Result_columnType, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3result, fetchArray,		arginfo_SQLite3Result_fetchArray, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3result, reset,			arginfo_SQLite3Result_reset, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3result, finalize,			arginfo_SQLite3Result_finalize, ZEND_ACC_PUBLIC)
+	PHP_ME(sqlite3result, __construct, 		arginfo_SQLite3Result___construct, ZEND_ACC_PRIVATE)
 	PHP_FE_END
 };
 /* }}} */

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -4,33 +4,45 @@ class SQLite3
 {
     function __construct(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, ?string $encryption_key = null);
 
-    function open(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, ?string $encryption_key = null): void;
+    /** @return void */
+    function open(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, ?string $encryption_key = null);
 
-    function close(): void;
+    /** @return void */
+    function close();
 
-    function version(): void;
+    /** @return void */
+    function version();
 
-    function lastInsertRowID(): void;
+    /** @return void */
+    function lastInsertRowID();
 
-    function lastErrorCode(): void;
+    /** @return void */
+    function lastErrorCode();
 
-    function lastExtendedErrorCode(): void;
+    /** @return void */
+    function lastExtendedErrorCode();
 
-    function lastErrorMsg(): void;
+    /** @return void */
+    function lastErrorMsg();
 
-    function changes(): void;
+    /** @return void */
+    function changes();
 
-    function busyTimeout(int $ms): bool;
+    /** @return bool */
+    function busyTimeout(int $ms);
 
 #ifndef SQLITE_OMIT_LOAD_EXTENSION
-    function loadExtension(string $shared_library): bool;
+    /** @return bool */
+    function loadExtension(string $shared_library);
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3006011
-    function backup(SQLite3 $destination_db, string $source_dbname = "main", string $destination_dbname = "main"): bool;
+    /** @return bool */
+    function backup(SQLite3 $destination_db, string $source_dbname = "main", string $destination_dbname = "main");
 #endif
 
-    function escapeString(string $value): string;
+    /** @return string */
+    function escapeString(string $value);
 
     /** @return SQLite3Result|false */
     function query(string $query);
@@ -38,31 +50,40 @@ class SQLite3
     /** @return mixed */
     function querySingle(string $query, bool $entire_row = false);
 
-    function createFunction(string $name, $callback, int $argument_count = -1, int $flags = 0): bool;
+    /** @return bool */
+    function createFunction(string $name, $callback, int $argument_count = -1, int $flags = 0);
 
-    function createAggregate(string $name, $step_callback, $final_callback, int $argument_count = -1): bool;
+    /** @return bool */
+    function createAggregate(string $name, $step_callback, $final_callback, int $argument_count = -1);
 
-    function createCollation(string $name, $callback): bool;
+    /** @return bool */
+    function createCollation(string $name, $callback);
 
     /** @return resource|false */
     function openBlob(string $table, string $column, int $rowid, string $dbname = "main", int $flags = SQLITE3_OPEN_READONLY);
 
-    function enableExceptions(bool $enableExceptions = false): bool;
+    /** @return bool */
+    function enableExceptions(bool $enableExceptions = false);
 
-    function enableExtendedResultCodes(bool $enable = true): bool;
+    /** @return bool */
+    function enableExtendedResultCodes(bool $enable = true);
 }
 
 class SQLite3Stmt
 {
     function __construct(SQLite3 $sqlite3);
 
-    function bindParam($param_number, &$param, int $type = SQLITE3_TEXT): bool;
+    /** @return bool */
+    function bindParam($param_number, &$param, int $type = SQLITE3_TEXT);
 
-    function bindValue($param_number, $param, int $type = SQLITE3_TEXT): bool;
+    /** @return bool */
+    function bindValue($param_number, $param, int $type = SQLITE3_TEXT);
 
-    function clear(): bool;
+    /** @return bool */
+    function clear();
 
-    function close(): bool;
+    /** @return bool */
+    function close();
 
     /** @return SQLite3Result|false */
     function execute();
@@ -70,18 +91,22 @@ class SQLite3Stmt
     /** @return string|false */
     function getSQL(bool $expanded = false);
 
-    function paramCount(): int;
+    /** @return int */
+    function paramCount();
 
-    function readOnly(): bool;
+    /** @return bool */
+    function readOnly();
 
-    function reset(): bool;
+    /** @return bool */
+    function reset();
 }
 
 class SQLite3Result
 {
     function __construct();
 
-    function numColumns(): void;
+    /** @return void */
+    function numColumns();
 
     /** @return int|false */
     function columnName(int $column_number);
@@ -92,7 +117,9 @@ class SQLite3Result
     /** @return array|false */
     function fetchArray(int $mode = SQLITE3_BOTH);
 
-    function reset(): void;
+    /** @return void */
+    function reset();
 
-    function finalize(): void;
+    /** @return void */
+    function finalize();
 }

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -1,0 +1,98 @@
+<?php
+
+class SQLite3
+{
+    function __construct(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, ?string $encryption_key = null);
+
+    function open(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, ?string $encryption_key = null): void;
+
+    function close(): void;
+
+    function version(): void;
+
+    function lastInsertRowID(): void;
+
+    function lastErrorCode(): void;
+
+    function lastExtendedErrorCode(): void;
+
+    function lastErrorMsg(): void;
+
+    function changes(): void;
+
+    function busyTimeout(int $ms): bool;
+
+#ifndef SQLITE_OMIT_LOAD_EXTENSION
+    function loadExtension(string $shared_library): bool;
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3006011
+    function backup(SQLite3 $destination_db, string $source_dbname = "main", string $destination_dbname = "main"): bool;
+#endif
+
+    function escapeString(string $value): string;
+
+    /** @return SQLite3Result|false */
+    function query(string $query);
+
+    /** @return mixed */
+    function querySingle(string $query, bool $entire_row = false);
+
+    function createFunction(string $name, $callback, int $argument_count = -1, int $flags = 0): bool;
+
+    function createAggregate(string $name, $step_callback, $final_callback, int $argument_count = -1): bool;
+
+    function createCollation(string $name, $callback): bool;
+
+    /** @return resource|false */
+    function openBlob(string $table, string $column, int $rowid, string $dbname = "main", int $flags = SQLITE3_OPEN_READONLY);
+
+    function enableExceptions(bool $enableExceptions = false): bool;
+
+    function enableExtendedResultCodes(bool $enable = true): bool;
+}
+
+class SQLite3Stmt
+{
+    function __construct(SQLite3 $sqlite3);
+
+    function bindParam($param_number, &$param, int $type = SQLITE3_TEXT): bool;
+
+    function bindValue($param_number, $param, int $type = SQLITE3_TEXT): bool;
+
+    function clear(): bool;
+
+    function close(): bool;
+
+    /** @return SQLite3Result|false */
+    function execute();
+
+    /** @return string|false */
+    function getSQL(bool $expanded = false);
+
+    function paramCount(): int;
+
+    function readOnly(): bool;
+
+    function reset(): bool;
+}
+
+class SQLite3Result
+{
+    function __construct();
+
+    function numColumns(): void;
+
+    /** @return int|false */
+    function columnName(int $column_number);
+
+    /** @return int|false */
+    function columnType(int $column_number);
+
+    /** @return array|false */
+    function fetchArray(int $mode = SQLITE3_BOTH);
+
+    function reset(): void;
+
+    function finalize(): void;
+}

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,0 +1,147 @@
+/* This is a generated file, edit the .stub.php file instead. */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, encryption_key, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_open, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, encryption_key, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_close, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_SQLite3_version arginfo_SQLite3_close
+
+#define arginfo_SQLite3_lastInsertRowID arginfo_SQLite3_close
+
+#define arginfo_SQLite3_lastErrorCode arginfo_SQLite3_close
+
+#define arginfo_SQLite3_lastExtendedErrorCode arginfo_SQLite3_close
+
+#define arginfo_SQLite3_lastErrorMsg arginfo_SQLite3_close
+
+#define arginfo_SQLite3_changes arginfo_SQLite3_close
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_busyTimeout, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, ms, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#if !defined(SQLITE_OMIT_LOAD_EXTENSION)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_loadExtension, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, shared_library, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3006011
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_backup, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, destination_db, SQLite3, 0)
+	ZEND_ARG_TYPE_INFO(0, source_dbname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, destination_dbname, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_escapeString, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_query, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_querySingle, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, entire_row, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_createFunction, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_INFO(0, callback)
+	ZEND_ARG_TYPE_INFO(0, argument_count, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_createAggregate, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_INFO(0, step_callback)
+	ZEND_ARG_INFO(0, final_callback)
+	ZEND_ARG_TYPE_INFO(0, argument_count, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_createCollation, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_INFO(0, callback)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_openBlob, 0, 0, 3)
+	ZEND_ARG_TYPE_INFO(0, table, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, column, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, rowid, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, dbname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_enableExceptions, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, enableExceptions, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_enableExtendedResultCodes, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Stmt___construct, 0, 0, 1)
+	ZEND_ARG_OBJ_INFO(0, sqlite3, SQLite3, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3Stmt_bindParam, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, param_number)
+	ZEND_ARG_INFO(1, param)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3Stmt_bindValue, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, param_number)
+	ZEND_ARG_INFO(0, param)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3Stmt_clear, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_SQLite3Stmt_close arginfo_SQLite3Stmt_clear
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Stmt_execute, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Stmt_getSQL, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO(0, expanded, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3Stmt_paramCount, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_SQLite3Stmt_readOnly arginfo_SQLite3Stmt_clear
+
+#define arginfo_SQLite3Stmt_reset arginfo_SQLite3Stmt_clear
+
+#define arginfo_SQLite3Result___construct arginfo_SQLite3Stmt_execute
+
+#define arginfo_SQLite3Result_numColumns arginfo_SQLite3_close
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Result_columnName, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, column_number, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_SQLite3Result_columnType arginfo_SQLite3Result_columnName
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Result_fetchArray, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_SQLite3Result_reset arginfo_SQLite3_close
+
+#define arginfo_SQLite3Result_finalize arginfo_SQLite3_close

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -6,13 +6,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, encryption_key, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_open, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, encryption_key, IS_STRING, 1)
-ZEND_END_ARG_INFO()
+#define arginfo_SQLite3_open arginfo_SQLite3___construct
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_close, 0, 0, IS_VOID, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_close, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_SQLite3_version arginfo_SQLite3_close
@@ -27,25 +23,25 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_SQLite3_changes arginfo_SQLite3_close
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_busyTimeout, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_busyTimeout, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, ms, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if !defined(SQLITE_OMIT_LOAD_EXTENSION)
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_loadExtension, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_loadExtension, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, shared_library, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3006011
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_backup, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_backup, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, destination_db, SQLite3, 0)
 	ZEND_ARG_TYPE_INFO(0, source_dbname, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, destination_dbname, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_escapeString, 0, 1, IS_STRING, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_escapeString, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -58,21 +54,21 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_querySingle, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, entire_row, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_createFunction, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_createFunction, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_INFO(0, callback)
 	ZEND_ARG_TYPE_INFO(0, argument_count, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_createAggregate, 0, 3, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_createAggregate, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_INFO(0, step_callback)
 	ZEND_ARG_INFO(0, final_callback)
 	ZEND_ARG_TYPE_INFO(0, argument_count, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_createCollation, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_createCollation, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_INFO(0, callback)
 ZEND_END_ARG_INFO()
@@ -85,11 +81,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_openBlob, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_enableExceptions, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_enableExceptions, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO(0, enableExceptions, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3_enableExtendedResultCodes, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3_enableExtendedResultCodes, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
@@ -97,38 +93,35 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Stmt___construct, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, sqlite3, SQLite3, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3Stmt_bindParam, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Stmt_bindParam, 0, 0, 2)
 	ZEND_ARG_INFO(0, param_number)
 	ZEND_ARG_INFO(1, param)
 	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3Stmt_bindValue, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Stmt_bindValue, 0, 0, 2)
 	ZEND_ARG_INFO(0, param_number)
 	ZEND_ARG_INFO(0, param)
 	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3Stmt_clear, 0, 0, _IS_BOOL, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_SQLite3Stmt_clear arginfo_SQLite3_close
 
-#define arginfo_SQLite3Stmt_close arginfo_SQLite3Stmt_clear
+#define arginfo_SQLite3Stmt_close arginfo_SQLite3_close
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Stmt_execute, 0, 0, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_SQLite3Stmt_execute arginfo_SQLite3_close
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_SQLite3Stmt_getSQL, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO(0, expanded, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_SQLite3Stmt_paramCount, 0, 0, IS_LONG, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_SQLite3Stmt_paramCount arginfo_SQLite3_close
 
-#define arginfo_SQLite3Stmt_readOnly arginfo_SQLite3Stmt_clear
+#define arginfo_SQLite3Stmt_readOnly arginfo_SQLite3_close
 
-#define arginfo_SQLite3Stmt_reset arginfo_SQLite3Stmt_clear
+#define arginfo_SQLite3Stmt_reset arginfo_SQLite3_close
 
-#define arginfo_SQLite3Result___construct arginfo_SQLite3Stmt_execute
+#define arginfo_SQLite3Result___construct arginfo_SQLite3_close
 
 #define arginfo_SQLite3Result_numColumns arginfo_SQLite3_close
 


### PR DESCRIPTION
All of the existing arginfo was in lowercase, so this has now been converted to the correct case for each method.
Also a lot of the methods reused generic void arginfo, they now all have their own specific declarations in the stubs