### PR TITLE
Readline arginfo stubs

### DIFF
--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -25,6 +25,7 @@
 #include "php.h"
 #include "php_readline.h"
 #include "readline_cli.h"
+#include "readline_arginfo.h"
 
 #if HAVE_LIBREADLINE || HAVE_LIBEDIT
 
@@ -69,62 +70,6 @@ PHP_MSHUTDOWN_FUNCTION(readline);
 PHP_RSHUTDOWN_FUNCTION(readline);
 PHP_MINFO_FUNCTION(readline);
 
-/* }}} */
-
-/* {{{ arginfo */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_readline, 0, 0, 0)
-	ZEND_ARG_INFO(0, prompt)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_info, 0, 0, 0)
-	ZEND_ARG_INFO(0, varname)
-	ZEND_ARG_INFO(0, newvalue)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_add_history, 0, 0, 1)
-	ZEND_ARG_INFO(0, prompt)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_readline_clear_history, 0)
-ZEND_END_ARG_INFO()
-
-#ifdef HAVE_HISTORY_LIST
-ZEND_BEGIN_ARG_INFO(arginfo_readline_list_history, 0)
-ZEND_END_ARG_INFO()
-#endif
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_read_history, 0, 0, 0)
-	ZEND_ARG_INFO(0, filename)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_write_history, 0, 0, 0)
-	ZEND_ARG_INFO(0, filename)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_completion_function, 0, 0, 1)
-	ZEND_ARG_INFO(0, funcname)
-ZEND_END_ARG_INFO()
-
-#if HAVE_RL_CALLBACK_READ_CHAR
-ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_callback_handler_install, 0, 0, 2)
-	ZEND_ARG_INFO(0, prompt)
-	ZEND_ARG_INFO(0, callback)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_readline_callback_read_char, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_readline_callback_handler_remove, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_readline_redisplay, 0)
-ZEND_END_ARG_INFO()
-
-#if HAVE_RL_ON_NEW_LINE
-ZEND_BEGIN_ARG_INFO(arginfo_readline_on_new_line, 0)
-ZEND_END_ARG_INFO()
-#endif
-#endif
 /* }}} */
 
 /* {{{ module stuff */

--- a/ext/readline/readline.stub.php
+++ b/ext/readline/readline.stub.php
@@ -18,11 +18,17 @@ function readline_read_history(string $filename = null): bool {}
 
 function readline_write_history(string $filename = null): bool {}
 
-function readline_completion_function(callable $funcname): bool {}
+/**
+ * @param callable $funcname
+ */
+function readline_completion_function($funcname): bool {}
 
 
 #if HAVE_RL_CALLBACK_READ_CHAR
-function readline_callback_handler_install(string $prompt, callable $callback): bool {}
+/**
+ * @param callable $callback
+ */
+function readline_callback_handler_install(string $prompt, $callback): bool {}
 
 function readline_callback_read_char(): void {}
 

--- a/ext/readline/readline.stub.php
+++ b/ext/readline/readline.stub.php
@@ -18,35 +18,19 @@ function readline_read_history(string $filename = null): bool {}
 
 function readline_write_history(string $filename = null): bool {}
 
-function readline_completion_function(callable $funcname): ?string {}
-
-
-//ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_completion_function, 0, 0, 1)
-//	ZEND_ARG_INFO(0, funcname)
-//ZEND_END_ARG_INFO()
+function readline_completion_function(callable $funcname): bool {}
 
 
 #if HAVE_RL_CALLBACK_READ_CHAR
-//ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_callback_handler_install, 0, 0, 2)
-//	ZEND_ARG_INFO(0, prompt)
-//	ZEND_ARG_INFO(0, callback)
-//ZEND_END_ARG_INFO()
+function readline_callback_handler_install(string $prompt, callable $callback): bool {}
 
+function readline_callback_read_char(): void {}
 
-//ZEND_BEGIN_ARG_INFO(arginfo_readline_callback_read_char, 0)
-//ZEND_END_ARG_INFO()
+function readline_callback_handler_remove(): bool {}
 
-
-//ZEND_BEGIN_ARG_INFO(arginfo_readline_callback_handler_remove, 0)
-//ZEND_END_ARG_INFO()
-
-
-//ZEND_BEGIN_ARG_INFO(arginfo_readline_redisplay, 0)
-//ZEND_END_ARG_INFO()
-
+function readline_redisplay(): void {}
 
 #if HAVE_RL_ON_NEW_LINE
-//ZEND_BEGIN_ARG_INFO(arginfo_readline_on_new_line, 0)
-//ZEND_END_ARG_INFO()
+function readline_on_new_line(): void {}
 #endif
 #endif

--- a/ext/readline/readline.stub.php
+++ b/ext/readline/readline.stub.php
@@ -4,7 +4,7 @@
 function readline(string $prompt = null) {}
 
 /** @return mixed */
-function readline_info(string $varname = null, string $newvalue = null) {}
+function readline_info(string $varname = null, string $newvalue = UNKNOWN) {}
 
 function readline_add_history(string $prompt): bool {}
 

--- a/ext/readline/readline.stub.php
+++ b/ext/readline/readline.stub.php
@@ -1,0 +1,52 @@
+<?php
+
+/** @return string|false */
+function readline(string $prompt = null) {}
+
+/** @return mixed */
+function readline_info(string $varname = null, string $newvalue = null) {}
+
+function readline_add_history(string $prompt): bool {}
+
+function readline_clear_history(): bool {}
+
+#ifdef HAVE_HISTORY_LIST
+function readline_list_history(): array {}
+#endif
+
+function readline_read_history(string $filename = null): bool {}
+
+function readline_write_history(string $filename = null): bool {}
+
+function readline_completion_function(callable $funcname): ?string {}
+
+
+//ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_completion_function, 0, 0, 1)
+//	ZEND_ARG_INFO(0, funcname)
+//ZEND_END_ARG_INFO()
+
+
+#if HAVE_RL_CALLBACK_READ_CHAR
+//ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_callback_handler_install, 0, 0, 2)
+//	ZEND_ARG_INFO(0, prompt)
+//	ZEND_ARG_INFO(0, callback)
+//ZEND_END_ARG_INFO()
+
+
+//ZEND_BEGIN_ARG_INFO(arginfo_readline_callback_read_char, 0)
+//ZEND_END_ARG_INFO()
+
+
+//ZEND_BEGIN_ARG_INFO(arginfo_readline_callback_handler_remove, 0)
+//ZEND_END_ARG_INFO()
+
+
+//ZEND_BEGIN_ARG_INFO(arginfo_readline_redisplay, 0)
+//ZEND_END_ARG_INFO()
+
+
+#if HAVE_RL_ON_NEW_LINE
+//ZEND_BEGIN_ARG_INFO(arginfo_readline_on_new_line, 0)
+//ZEND_END_ARG_INFO()
+#endif
+#endif

--- a/ext/readline/readline.stub.php
+++ b/ext/readline/readline.stub.php
@@ -4,7 +4,7 @@
 function readline(string $prompt = null) {}
 
 /** @return mixed */
-function readline_info(string $varname = null, string $newvalue = UNKNOWN) {}
+function readline_info(string $varname = UNKNOWN, string $newvalue = UNKNOWN) {}
 
 function readline_add_history(string $prompt): bool {}
 
@@ -14,9 +14,9 @@ function readline_clear_history(): bool {}
 function readline_list_history(): array {}
 #endif
 
-function readline_read_history(string $filename = null): bool {}
+function readline_read_history(string $filename = UNKNOWN): bool {}
 
-function readline_write_history(string $filename = null): bool {}
+function readline_write_history(string $filename = UNKNOWN): bool {}
 
 /**
  * @param callable $funcname

--- a/ext/readline/readline_arginfo.h
+++ b/ext/readline/readline_arginfo.h
@@ -1,1 +1,58 @@
 /* This is a generated file, edit the .stub.php file instead. */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_readline, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO(0, prompt, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_readline_info, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO(0, varname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, newvalue, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_add_history, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, prompt, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_clear_history, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+#if defined(HAVE_HISTORY_LIST)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_list_history, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_read_history, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_readline_write_history arginfo_readline_read_history
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_completion_function, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, funcname, IS_CALLABLE, 0)
+ZEND_END_ARG_INFO()
+
+#if HAVE_RL_CALLBACK_READ_CHAR
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_callback_handler_install, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, prompt, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if HAVE_RL_CALLBACK_READ_CHAR
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_callback_read_char, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if HAVE_RL_CALLBACK_READ_CHAR
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_callback_handler_remove, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if HAVE_RL_CALLBACK_READ_CHAR
+#define arginfo_readline_redisplay arginfo_readline_callback_read_char
+#endif
+
+#if HAVE_RL_CALLBACK_READ_CHAR && HAVE_RL_ON_NEW_LINE
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_on_new_line, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+#endif

--- a/ext/readline/readline_arginfo.h
+++ b/ext/readline/readline_arginfo.h
@@ -1,0 +1,1 @@
+/* This is a generated file, edit the .stub.php file instead. */

--- a/ext/readline/readline_arginfo.h
+++ b/ext/readline/readline_arginfo.h
@@ -28,13 +28,13 @@ ZEND_END_ARG_INFO()
 #define arginfo_readline_write_history arginfo_readline_read_history
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_completion_function, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, funcname, IS_CALLABLE, 0)
+	ZEND_ARG_INFO(0, funcname)
 ZEND_END_ARG_INFO()
 
 #if HAVE_RL_CALLBACK_READ_CHAR
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_callback_handler_install, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, prompt, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+	ZEND_ARG_INFO(0, callback)
 ZEND_END_ARG_INFO()
 #endif
 


### PR DESCRIPTION
The `readline_arginfo.h` file won't re-generate properly with the *current* stubs generator, #4516 adds support for `callable` to resolve that issue.