### PR TITLE
Add missing parameter to __set_state

### DIFF
--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -202,7 +202,7 @@ class DateTimeImmutable implements DateTimeInterface {
     public function __construct(string $time, ?DateTimeZone $timezone = null);
 
     /** @return DateTimeZone */
-    public static function __set_state();
+    public static function __set_state(array $array);
 
     /** @return DateTimeImmutable */
     public static function createFromMutable(DateTime $object);


### PR DESCRIPTION
DateTimeImmutable::__set_state cannot work without parameter.
And interface should match the doc.
https://www.php.net/manual/en/datetimeimmutable.set-state.php