### PR TITLE
Fix #75245: Don't set content of elements with only whitespaces

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1197,7 +1197,7 @@ static HashTable *sxe_get_prop_hash(zval *object, int is_debug) /* {{{ */
 		}
 
 		while (node) {
-			if (node->children != NULL || node->prev != NULL || node->next != NULL) {
+			if (node->children != NULL || node->prev != NULL || node->next != NULL || xmlIsBlankNode(node)) {
 				SKIP_TEXT(node);
 			} else {
 				if (node->type == XML_TEXT_NODE) {

--- a/ext/simplexml/tests/bug39662.phpt
+++ b/ext/simplexml/tests/bug39662.phpt
@@ -19,17 +19,9 @@ var_dump($clone->asXML());
 echo "Done\n";
 ?>
 --EXPECTF--
-object(SimpleXMLElement)#%d (1) {
-  [0]=>
-  string(2) "
-
-"
+object(SimpleXMLElement)#%d (0) {
 }
-object(SimpleXMLElement)#%d (1) {
-  [0]=>
-  string(2) "
-
-"
+object(SimpleXMLElement)#%d (0) {
 }
 string(15) "<test>
 

--- a/ext/simplexml/tests/bug75245.phpt
+++ b/ext/simplexml/tests/bug75245.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #75245 Don't set content of elements with only whitespaces
+--SKIPIF--
+<?php
+if (!extension_loaded('simplexml')) die('skip simplexml not available');
+?>
+--FILE--
+<?php
+var_dump(simplexml_load_string('<test1><test2>    </test2><test3></test3></test1>'));
+?>
+===DONE===
+--EXPECT--
+object(SimpleXMLElement)#1 (2) {
+  ["test2"]=>
+  object(SimpleXMLElement)#2 (0) {
+  }
+  ["test3"]=>
+  object(SimpleXMLElement)#3 (0) {
+  }
+}
+===DONE===


### PR DESCRIPTION
[Bug #75245](https://bugs.php.net/bug.php?id=75245)

Test code:
`var_dump(simplexml_load_string('<test1><test2>    </test2><test3></test3></test1>'));`

Expected results (PHP 5.4.16)
```
object(SimpleXMLElement)#1 (2) {
  ["test2"]=>
  object(SimpleXMLElement)#2 (0) {
  }
  ["test3"]=>
  object(SimpleXMLElement)#3 (0) {
  }
}
```

Results from PHP 7.3.8+:
```
object(SimpleXMLElement)#1 (2) {
  ["test2"]=>
  object(SimpleXMLElement)#2 (1) {
    [0]=>
    string(4) "    "
  }
  ["test3"]=>
  object(SimpleXMLElement)#3 (0) {
  }
}
```

Results after patch:
```
object(SimpleXMLElement)#1 (2) {
  ["test2"]=>
  object(SimpleXMLElement)#2 (0) {
  }
  ["test3"]=>
  object(SimpleXMLElement)#3 (0) {
  }
}

```