### PR TITLE
Add hrtime arginfo stubs

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1322,11 +1322,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_http_response_code, 0, 0, 0)
 	ZEND_ARG_INFO(0, response_code)
 ZEND_END_ARG_INFO()
 /* }}} */
-/* {{{ hrtime.c */
-ZEND_BEGIN_ARG_INFO(arginfo_hrtime, 0)
-	ZEND_ARG_INFO(0, get_as_number)
-ZEND_END_ARG_INFO()
-/* }}} */
 /* {{{ html.c */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_htmlspecialchars, 0, 0, 1)
 	ZEND_ARG_INFO(0, string)

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -75,6 +75,11 @@ function crc32(string $str): int {}
 
 function crypt(string $str, string $salt = UNKNOWN): string {}
 
+/* hrtime.c */
+
+/** @return array|int|float|false */
+function hrtime(bool $get_as_number = false) {}
+
 /* syslog.c */
 
 #ifdef HAVE_SYSLOG_H

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -88,6 +88,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_crypt, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, salt, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hrtime, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO(0, get_as_number, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
 #if defined(HAVE_SYSLOG_H)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openlog, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, ident, IS_STRING, 0)
@@ -109,13 +113,13 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_INET_NTOP)
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_inet_ntop, 0, 1, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_inet_ntop, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, in_addr, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_INET_PTON)
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_inet_pton, 0, 1, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_inet_pton, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, ip_address, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif


### PR DESCRIPTION
I'm not sure about the `float` and `false` return types. `false` is only returned if the function isn't available for the platform, and `float` is only returned on 32 bit platforms.