### PR TITLE
Extend function flags space

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5237,9 +5237,7 @@ ZEND_API void zend_set_function_arg_flags(zend_function *func) /* {{{ */
 {
 	uint32_t i, n;
 
-	func->common.arg_flags[0] = 0;
-	func->common.arg_flags[1] = 0;
-	func->common.arg_flags[2] = 0;
+	func->common.arg_flags = 0;
 	if (func->common.arg_info) {
 		n = MIN(func->common.num_args, MAX_ARG_FLAG_NUM);
 		i = 0;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -404,7 +404,8 @@ typedef struct _zend_internal_function_info {
 struct _zend_op_array {
 	/* Common elements */
 	zend_uchar type;
-	zend_uchar arg_flags[3]; /* bitset of arg_info.pass_by_reference */
+	zend_uchar fn_flags2;
+	uint16_t arg_flags; /* bitset of arg_info.pass_by_reference */
 	uint32_t fn_flags;
 	zend_string *function_name;
 	zend_class_entry *scope;
@@ -453,7 +454,8 @@ typedef void (ZEND_FASTCALL *zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
 typedef struct _zend_internal_function {
 	/* Common elements */
 	zend_uchar type;
-	zend_uchar arg_flags[3]; /* bitset of arg_info.pass_by_reference */
+	zend_uchar fn_flags2;
+	uint16_t arg_flags; /* bitset of arg_info.pass_by_reference */
 	uint32_t fn_flags;
 	zend_string* function_name;
 	zend_class_entry *scope;
@@ -476,7 +478,8 @@ union _zend_function {
 
 	struct {
 		zend_uchar type;  /* never used */
-		zend_uchar arg_flags[3]; /* bitset of arg_info.pass_by_reference */
+		zend_uchar fn_flags2;
+		uint16_t arg_flags; /* bitset of arg_info.pass_by_reference */
 		uint32_t fn_flags;
 		zend_string *function_name;
 		zend_class_entry *scope;
@@ -952,8 +955,8 @@ static zend_always_inline int zend_check_arg_send_type(const zend_function *zf, 
 #define ARG_MAY_BE_SENT_BY_REF(zf, arg_num) \
 	zend_check_arg_send_type(zf, arg_num, ZEND_SEND_PREFER_REF)
 
-/* Quick API to check first 12 arguments */
-#define MAX_ARG_FLAG_NUM 12
+/* Quick API to check first 8 arguments */
+#define MAX_ARG_FLAG_NUM 8
 
 #ifdef WORDS_BIGENDIAN
 # define ZEND_SET_ARG_FLAG(zf, arg_num, mask) do { \
@@ -963,10 +966,10 @@ static zend_always_inline int zend_check_arg_send_type(const zend_function *zf, 
 	(((zf)->quick_arg_flags >> (((arg_num) - 1) * 2)) & (mask))
 #else
 # define ZEND_SET_ARG_FLAG(zf, arg_num, mask) do { \
-		(zf)->quick_arg_flags |= (((mask) << 6) << (arg_num) * 2); \
+		(zf)->quick_arg_flags |= (((mask) << (16-2)) << (arg_num) * 2); \
 	} while (0)
 # define ZEND_CHECK_ARG_FLAG(zf, arg_num, mask) \
-	(((zf)->quick_arg_flags >> (((arg_num) + 3) * 2)) & (mask))
+	(((zf)->quick_arg_flags >> (((arg_num) + (8-1)) * 2)) & (mask))
 #endif
 
 #define QUICK_ARG_MUST_BE_SENT_BY_REF(zf, arg_num) \

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -128,7 +128,8 @@ static ZEND_FUNCTION(pass)
 
 ZEND_API const zend_internal_function zend_pass_function = {
 	ZEND_INTERNAL_FUNCTION, /* type              */
-	{0, 0, 0},              /* arg_flags         */
+	0,                      /* fn_flags2         */
+	0,                      /* arg_flags         */
 	0,                      /* fn_flags          */
 	NULL,                   /* name              */
 	NULL,                   /* scope             */

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1234,10 +1234,9 @@ ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend
 	}
 
 	func->type = ZEND_USER_FUNCTION;
-	func->arg_flags[0] = 0;
-	func->arg_flags[1] = 0;
-	func->arg_flags[2] = 0;
+	func->arg_flags = 0;
 	func->fn_flags = ZEND_ACC_CALL_VIA_TRAMPOLINE | ZEND_ACC_PUBLIC;
+	func->fn_flags2 = 0;
 	if (is_static) {
 		func->fn_flags |= ZEND_ACC_STATIC;
 	}

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -46,9 +46,7 @@ static void zend_extension_op_array_dtor_handler(zend_extension *extension, zend
 void init_op_array(zend_op_array *op_array, zend_uchar type, int initial_ops_size)
 {
 	op_array->type = type;
-	op_array->arg_flags[0] = 0;
-	op_array->arg_flags[1] = 0;
-	op_array->arg_flags[2] = 0;
+	op_array->arg_flags = 0;
 
 	op_array->refcount = (uint32_t *) emalloc(sizeof(uint32_t));
 	*op_array->refcount = 1;
@@ -80,6 +78,7 @@ void init_op_array(zend_op_array *op_array, zend_uchar type, int initial_ops_siz
 	op_array->last_try_catch = 0;
 
 	op_array->fn_flags = 0;
+	op_array->fn_flags2 = 0;
 
 	op_array->last_literal = 0;
 	op_array->literals = NULL;

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -2029,9 +2029,8 @@ static int zend_ffi_cdata_get_closure(zval *obj, zend_class_entry **ce_ptr, zend
 		func = ecalloc(sizeof(zend_internal_function), 1);
 	}
 	func->type = ZEND_INTERNAL_FUNCTION;
-	func->common.arg_flags[0] = 0;
-	func->common.arg_flags[1] = 0;
-	func->common.arg_flags[2] = 0;
+	func->common.fn_flags2 = 0;
+	func->common.arg_flags = 0;
 	func->common.fn_flags = ZEND_ACC_CALL_VIA_TRAMPOLINE;
 	func->common.function_name = ZSTR_KNOWN(ZEND_STR_MAGIC_INVOKE);
 	/* set to 0 to avoid arg_info[] allocation, because all values are passed by value anyway */
@@ -2762,9 +2761,8 @@ static zend_function *zend_ffi_get_func(zend_object **obj, zend_string *name, co
 		func = ecalloc(sizeof(zend_internal_function), 1);
 	}
 	func->common.type = ZEND_INTERNAL_FUNCTION;
-	func->common.arg_flags[0] = 0;
-	func->common.arg_flags[1] = 0;
-	func->common.arg_flags[2] = 0;
+	func->common.fn_flags2 = 0;
+	func->common.arg_flags = 0;
 	func->common.fn_flags = ZEND_ACC_CALL_VIA_TRAMPOLINE;
 	func->common.function_name = zend_string_copy(name);
 	/* set to 0 to avoid arg_info[] allocation, because all values are passed by value anyway */


### PR DESCRIPTION
We only have one free function flag left, which I intend to use. We should make sure that we have some leeway here, as we may have to add new flags in 7.4.x to fix bugs.

This steals 8 bits from the quick arg info space to create a new `fn_flags2` field (currently unused).

cc @dstogov 
cc @derickr for ABI change