### PR TITLE
[PoC] [WIP] throw_legacy_failure declare statement

### DIFF
--- a/Zend/tests/throw_legacy_failure/declare_statement_isolated.phpt
+++ b/Zend/tests/throw_legacy_failure/declare_statement_isolated.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test throw_legacy_failure declare statement is isolated to file
+--FILE--
+<?php
+include 'fixture/no_declare.inc';
+try {
+    include 'fixture/declare_on.inc';
+} catch (\Throwable $e) {
+    echo "Error caught\n";
+}
+include 'fixture/declare_off.inc';
+?>
+DONE
+--EXPECTF--
+Warning: array_combine(): Both parameters should have an equal number of elements in %sfixture/no_declare.inc on line %d
+Error caught
+
+Warning: array_combine(): Both parameters should have an equal number of elements in %sfixture/declare_off.inc on line %d
+DONE

--- a/Zend/tests/throw_legacy_failure/fixture/declare_off.inc
+++ b/Zend/tests/throw_legacy_failure/fixture/declare_off.inc
@@ -1,0 +1,4 @@
+<?php
+declare(throw_legacy_failure=0);
+
+array_combine(array(1, 2), array(1, 2, 3));

--- a/Zend/tests/throw_legacy_failure/fixture/declare_on.inc
+++ b/Zend/tests/throw_legacy_failure/fixture/declare_on.inc
@@ -1,0 +1,4 @@
+<?php
+declare(throw_legacy_failure=1);
+
+array_combine(array(1, 2), array(1, 2, 3));

--- a/Zend/tests/throw_legacy_failure/fixture/no_declare.inc
+++ b/Zend/tests/throw_legacy_failure/fixture/no_declare.inc
@@ -1,0 +1,3 @@
+<?php
+
+array_combine(array(1, 2), array(1, 2, 3));

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5185,6 +5185,26 @@ void zend_compile_declare(zend_ast *ast) /* {{{ */
 				CG(active_op_array)->fn_flags |= ZEND_ACC_STRICT_TYPES;
 			}
 
+		} else if (zend_string_equals_literal_ci(name, "throw_legacy_failure")) {
+			zval value_zv;
+
+			if (FAILURE == zend_declare_is_first_statement(ast)) {
+				zend_error_noreturn(E_COMPILE_ERROR, "throw_legacy_failure declaration must be "
+													 "the very first statement in the script");
+			}
+
+			if (ast->child[1] != NULL) {
+				zend_error_noreturn(E_COMPILE_ERROR, "throw_legacy_failure declaration must not use block mode");
+			}
+
+			zend_const_expr_to_zval(&value_zv, value_ast);
+
+			if (Z_TYPE(value_zv) != IS_LONG || (Z_LVAL(value_zv) != 0 && Z_LVAL(value_zv) != 1)) {
+				zend_error_noreturn(E_COMPILE_ERROR, "throw_legacy_failure declaration must have 0 or 1 as its value");
+			}
+
+			CG(throw_legacy_failure) = zval_get_long(&value_zv);
+
 		} else {
 			zend_error(E_COMPILE_WARNING, "Unsupported declare '%s'", ZSTR_VAL(name));
 		}

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -113,6 +113,7 @@ struct _zend_compiler_globals {
 	zend_bool multibyte;
 	zend_bool detect_unicode;
 	zend_bool encoding_declared;
+	zend_bool throw_legacy_failure;
 
 	zend_ast *ast;
 	zend_arena *ast_arena;

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6419,7 +6419,7 @@ PHP_FUNCTION(array_combine)
 	num_values = zend_hash_num_elements(values);
 
 	if (num_keys != num_values) {
-		php_error_docref(NULL, E_WARNING, "Both parameters should have an equal number of elements");
+		php_exception_or_error_docref(NULL, E_WARNING, "Both parameters should have an equal number of elements");
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/tests/array/array_combine_throw_legacy_failure_error.phpt
+++ b/ext/standard/tests/array/array_combine_throw_legacy_failure_error.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test array_combine() function : error conditions - with throw_legacy_failure declare statement
+--FILE--
+<?php
+
+declare(throw_legacy_failure=1);
+
+try {
+    array_combine(array(1, 2), array(1, 2, 3));
+} catch (\ErrorException $e) {
+    echo "Error caught\n";
+}
+?>
+DONE
+--EXPECTF--
+Error caught
+DONE

--- a/main/main.c
+++ b/main/main.c
@@ -1170,6 +1170,27 @@ PHPAPI ZEND_COLD void php_error_docref2(const char *docref, const char *param1, 
 }
 /* }}} */
 
+/* {{{ php_exception_or_error_docref */
+/* Throw an Exception if throw_legacy_failure declare statement is present otherwise fallback to a traditional
+ * docref error. */
+PHPAPI ZEND_COLD void php_exception_or_error_docref(const char *docref, int type, const char *format, ...)
+{
+	va_list args;
+
+	va_start(args, format);
+	if (CG(throw_legacy_failure) == 1) {
+		char *message = NULL;
+
+		zend_vspprintf(&message, 0, format, args);
+		zend_throw_exception(zend_ce_error_exception, message, E_ERROR);
+		efree(message);
+	} else {
+		php_verror(docref, "", type, format, args);
+	}
+	va_end(args);
+}
+/* }}} */
+
 #ifdef PHP_WIN32
 PHPAPI ZEND_COLD void php_win32_docref2_from_error(DWORD error, const char *param1, const char *param2) {
 	char *buf = php_win32_error_to_msg(error);

--- a/main/php.h
+++ b/main/php.h
@@ -345,6 +345,9 @@ PHPAPI ZEND_COLD void php_error_docref1(const char *docref, const char *param1, 
 	PHP_ATTRIBUTE_FORMAT(printf, 4, 5);
 PHPAPI ZEND_COLD void php_error_docref2(const char *docref, const char *param1, const char *param2, int type, const char *format, ...)
 	PHP_ATTRIBUTE_FORMAT(printf, 5, 6);
+PHPAPI ZEND_COLD void php_exception_or_error_docref(const char *docref, int type, const char *format, ...)
+	PHP_ATTRIBUTE_FORMAT(printf, 3, 4);
+
 #ifdef PHP_WIN32
 PHPAPI ZEND_COLD void php_win32_docref2_from_error(DWORD error, const char *param1, const char *param2);
 #endif


### PR DESCRIPTION
This is a proof of concept for letting internal/old functions be able to throw an Exception in case of failure instead of using the legacy behaviour of returning ``null`` or ``false``.
This behaviour is controlled by the user on a per-file basis, as with ``strict_types``, using the following declare statement: ``declare(throw_legacy_failure=1);``

This declare statement is not meant to throw an Exception on valid ``false``/``null`` return values, e.g. ``strpos()`` returning ``false`` when the needle was not found in the string.

A couple of question still remain:

  - The name of the declare statement
  - Should there be general ``FailureException`` or more specialised exceptions per extension.
  - The functions which would benefit from this feature.
