### PR TITLE
Remove unnecessary check leading to FALSE return in bin2hex()

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -223,7 +223,7 @@ PHP_MSHUTDOWN_FUNCTION(localeconv)
 /* }}} */
 #endif
 
-/* {{{ proto string|false bin2hex(string data)
+/* {{{ proto string bin2hex(string data)
    Converts the binary representation of data to hex */
 PHP_FUNCTION(bin2hex)
 {
@@ -235,10 +235,6 @@ PHP_FUNCTION(bin2hex)
 	ZEND_PARSE_PARAMETERS_END();
 
 	result = php_bin2hex((unsigned char *)ZSTR_VAL(data), ZSTR_LEN(data));
-
-	if (!result) {
-		RETURN_FALSE;
-	}
 
 	RETURN_STR(result);
 }


### PR DESCRIPTION
From my testing of trying to get a return value of ``false`` this check seems unnecessary as ``result`` is always a ``zend_string`` generated from ``php_bin2hex()`` [1]

Moreover, if the input argument can't be converted to a string ZPP takes care of throwing a TypeError.

If there is indeed a case where FALSE can be returned a test should be created to cover that case.

[1] https://lxr.room11.org/xref/php-src%40master/ext/standard/string.c#116