### PR TITLE
Implement NUL byte checks for dbnames

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1301,7 +1301,7 @@ PHP_METHOD(sqlite3, openBlob)
 	}
 
 	if (ZEND_NUM_ARGS() >= 4 && CHECK_NULL_PATH(dbname, dbname_len)) {
-		zend_type_error("dbname must not contain NUL bytes");
+		zend_value_error("dbname must not contain NUL bytes");
 		return;
 	}
 
@@ -1376,7 +1376,7 @@ PHP_METHOD(sqlite3, backup)
 	if ((ZEND_NUM_ARGS() >= 2 && CHECK_NULL_PATH(source_dbname, source_dbname_length))
 		|| (ZEND_NUM_ARGS() >= 3 && CHECK_NULL_PATH(destination_dbname, destination_dbname_length))
 	) {
-		zend_type_error("dbname must not contain NUL bytes");
+		zend_value_error("dbname must not contain NUL bytes");
 		return;
 	}
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1300,6 +1300,11 @@ PHP_METHOD(sqlite3, openBlob)
 		return;
 	}
 
+	if (ZEND_NUM_ARGS() >= 4 && CHECK_NULL_PATH(dbname, dbname_len)) {
+		zend_type_error("dbname must not contain NUL bytes");
+		return;
+	}
+
 	sqlite_flags = (flags & SQLITE_OPEN_READWRITE) ? 1 : 0;
 
 	if (sqlite3_blob_open(db_obj->db, dbname, table, column, rowid, sqlite_flags, &blob) != SQLITE_OK) {
@@ -1365,6 +1370,13 @@ PHP_METHOD(sqlite3, backup)
 	SQLITE3_CHECK_INITIALIZED(source_obj, source_obj->initialised, SQLite3)
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|ss", &destination_zval, php_sqlite3_sc_entry, &source_dbname, &source_dbname_length, &destination_dbname, &destination_dbname_length) == FAILURE) {
+		return;
+	}
+
+	if (ZEND_NUM_ARGS() >= 2 && CHECK_NULL_PATH(source_dbname, source_dbname_length)
+		|| ZEND_NUM_ARGS() >= 3 && CHECK_NULL_PATH(destination_dbname, destination_dbname_length)
+	) {
+		zend_type_error("dbname must not contain NUL bytes");
 		return;
 	}
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1373,8 +1373,8 @@ PHP_METHOD(sqlite3, backup)
 		return;
 	}
 
-	if (ZEND_NUM_ARGS() >= 2 && CHECK_NULL_PATH(source_dbname, source_dbname_length)
-		|| ZEND_NUM_ARGS() >= 3 && CHECK_NULL_PATH(destination_dbname, destination_dbname_length)
+	if ((ZEND_NUM_ARGS() >= 2 && CHECK_NULL_PATH(source_dbname, source_dbname_length))
+		|| (ZEND_NUM_ARGS() >= 3 && CHECK_NULL_PATH(destination_dbname, destination_dbname_length))
 	) {
 		zend_type_error("dbname must not contain NUL bytes");
 		return;


### PR DESCRIPTION
Since we're passing these parameter to C functions accepting `char*`
without any further checking, we should reject strings with NUL bytes
in the first place.