### PR TITLE
Add internal API for Error Notification Callbacks

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -61,6 +61,8 @@ ZEND_TSRMLS_CACHE_DEFINE()
 ZEND_API zend_utility_values zend_uv;
 ZEND_API zend_bool zend_dtrace_enabled;
 
+zend_llist zend_error_notify_callbacks;
+
 /* version information */
 static char *zend_version_info;
 static uint32_t zend_version_info_length;
@@ -815,6 +817,7 @@ int zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 
 	zend_startup_strtod();
 	zend_startup_extensions_mechanism();
+	zend_startup_error_notify_callbacks();
 
 	/* Set up utility functions and values */
 	zend_error_cb = utility_functions->error_function;
@@ -846,6 +849,8 @@ int zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 			zend_compile_file = dtrace_compile_file;
 			zend_execute_ex = dtrace_execute_ex;
 			zend_execute_internal = dtrace_execute_internal;
+
+			zend_register_error_notify_callback(dtrace_error_notify_cb);
 		} else {
 			zend_compile_file = compile_file;
 			zend_execute_ex = execute_ex;
@@ -1075,6 +1080,7 @@ void zend_shutdown(void) /* {{{ */
 	zend_hash_destroy(GLOBAL_AUTO_GLOBALS_TABLE);
 	free(GLOBAL_AUTO_GLOBALS_TABLE);
 
+	zend_shutdown_error_notify_callbacks();
 	zend_shutdown_extensions();
 	free(zend_version_info);
 
@@ -1311,11 +1317,7 @@ static ZEND_COLD void zend_error_impl(
 		}
 	}
 
-#ifdef HAVE_DTRACE
-	if (DTRACE_ERROR_ENABLED()) {
-		DTRACE_ERROR(ZSTR_VAL(message), (char *)error_filename, error_lineno);
-	}
-#endif /* HAVE_DTRACE */
+	zend_error_notify_all_callbacks(type, error_filename, error_lineno, message);
 
 	/* if we don't have a user defined error handler */
 	if (Z_TYPE(EG(user_error_handler)) == IS_UNDEF
@@ -1769,5 +1771,31 @@ ZEND_API void zend_map_ptr_extend(size_t last)
 		ptr = (void**)ZEND_MAP_PTR_REAL_BASE(CG(map_ptr_base)) + CG(map_ptr_last);
 		memset(ptr, 0, (last - CG(map_ptr_last)) * sizeof(void*));
 		CG(map_ptr_last) = last;
+	}
+}
+
+void zend_startup_error_notify_callbacks()
+{
+	zend_llist_init(&zend_error_notify_callbacks, sizeof(zend_error_notify_cb), NULL, 1);
+}
+
+void zend_shutdown_error_notify_callbacks()
+{
+	zend_llist_destroy(&zend_error_notify_callbacks);
+}
+
+void zend_register_error_notify_callback(zend_error_notify_cb cb)
+{
+	zend_llist_add_element(&zend_error_notify_callbacks, &cb);
+}
+
+void zend_error_notify_all_callbacks(int type, const char *error_filename, uint32_t error_lineno, zend_string *message)
+{
+	zend_llist_element *element;
+	zend_error_notify_cb callback;
+
+	for (element = zend_error_notify_callbacks.head; element; element = element->next) {
+		callback = *(zend_error_notify_cb *) (element->data);
+		callback(type, error_filename, error_lineno, message);
 	}
 }

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -351,6 +351,16 @@ ZEND_API void zend_save_error_handling(zend_error_handling *current);
 ZEND_API void zend_replace_error_handling(zend_error_handling_t error_handling, zend_class_entry *exception_class, zend_error_handling *current);
 ZEND_API void zend_restore_error_handling(zend_error_handling *saved);
 
+typedef void (*zend_error_notify_cb)(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
+
+BEGIN_EXTERN_C()
+
+void zend_register_error_notify_callback(zend_error_notify_cb callback);
+void zend_startup_error_notify_callbacks();
+void zend_shutdown_error_notify_callbacks();
+void zend_error_notify_all_callbacks(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
+END_EXTERN_C()
+
 #define DEBUG_BACKTRACE_PROVIDE_OBJECT (1<<0)
 #define DEBUG_BACKTRACE_IGNORE_ARGS    (1<<1)
 

--- a/Zend/zend_dtrace.c
+++ b/Zend/zend_dtrace.c
@@ -109,6 +109,13 @@ ZEND_API void dtrace_execute_internal(zend_execute_data *execute_data, zval *ret
 	}
 }
 
+void dtrace_error_notify_cb(int type, const char *error_filename, uint32_t error_lineno, zend_string *message)
+{
+	if (DTRACE_ERROR_ENABLED()) {
+		DTRACE_ERROR(ZSTR_VAL(message), (char *)error_filename, error_lineno);
+	}
+}
+
 /* }}} */
 
 #endif /* HAVE_DTRACE */

--- a/Zend/zend_dtrace.h
+++ b/Zend/zend_dtrace.h
@@ -37,6 +37,8 @@ ZEND_API void dtrace_execute_ex(zend_execute_data *execute_data);
 ZEND_API void dtrace_execute_internal(zend_execute_data *execute_data, zval *return_value);
 #include <zend_dtrace_gen.h>
 
+void dtrace_error_notify_cb(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
+
 #endif /* HAVE_DTRACE */
 
 #ifdef	__cplusplus

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -893,6 +893,7 @@ static void zend_error_va(int type, const char *file, uint32_t lineno, const cha
 	va_list args;
 	va_start(args, format);
 	zend_string *message = zend_vstrpprintf(0, format, args);
+	zend_error_notify_all_callbacks(type, file, lineno, message);
 	zend_error_cb(type, file, lineno, message);
 	zend_string_release(message);
 	va_end(args);
@@ -913,10 +914,10 @@ ZEND_API ZEND_COLD int zend_exception_error(zend_object *ex, int severity) /* {{
 		zend_string *message = zval_get_string(GET_PROPERTY(&exception, ZEND_STR_MESSAGE));
 		zend_string *file = zval_get_string(GET_PROPERTY_SILENT(&exception, ZEND_STR_FILE));
 		zend_long line = zval_get_long(GET_PROPERTY_SILENT(&exception, ZEND_STR_LINE));
+		int type = (ce_exception == zend_ce_parse_error ? E_PARSE : E_COMPILE_ERROR) | E_DONT_BAIL;
 
-		zend_error_cb(
-			(ce_exception == zend_ce_parse_error ? E_PARSE : E_COMPILE_ERROR) | E_DONT_BAIL,
-			ZSTR_VAL(file), line, message);
+		zend_error_notify_all_callbacks(type, ZSTR_VAL(file), line, message);
+		zend_error_cb(type, ZSTR_VAL(file), line, message);
 
 		zend_string_release_ex(file, 0);
 		zend_string_release_ex(message, 0);


### PR DESCRIPTION
PHP Extensions are able to hook into the error mechanism of the Zend Engine by overwriting the `zend_error_cb` callback. This callback has a lot of responsibilities though (display, repeated error supression, logging, exception conversion), so that overwriting is quite difficult. A few extensions also overwrite the error handler in a way that previous handlers are not called anymore (xdebug), making it unreliable.

This PR introduces a new API that allows extensions to register global error notification handlers. 

- These handlers are only responsible for processing errors and notifying third party systems with a guarantee that they are called. Stopping propagation is explicitly not the idea of this API. Handlers are supposed to have no side effects on further error processing.
- These handlers are implemented as zend_llist, so no care has to be taken to call previous handlers, making it more robust than chaining function pointers.
- The notification callbacks are triggered outside of `php_error_cb`, so that it is guaranteed they are always called when an error occurs, even when `zend_error_cb` is overwritten. This also means that the notification happens **before** repeatable errors are ignored and last_error is updated.
- This API is internal and not exposed to userland.

### Example

As an example I was able to refactor the inlined DTrace notification handling into the new API. 

`report_zend_debug` code is also be a candidate for being a notification callback and was migrated. This debug code is not used anywhere, maybe it should be removed though?

Usage Example:

```c
void dtrace_error_notify_cb(int type, const char *error_filename, uint32_t error_lineno, zend_string *message)
{
	if (DTRACE_ERROR_ENABLED()) {
		DTRACE_ERROR(ZSTR_VAL(message), (char *)error_filename, error_lineno);
	}
}

zend_register_error_notify_callback(dtrace_error_notify_cb);
```

### Questions

- Should this be part of the proposed new [zend_instrument AP](https://github.com/SammyK/php-src/commit/8c3d8f082a9bfd4793c133a6160f60b4dd569c29)I? `zend_instrument_install_error_callback(cb)`

### Out of scope

The error mechanism can use a larger cleanup as discussed in the [Improved Error Callbacks Mechanism RFC](https://wiki.php.net/rfc/improved_error_callback_mechanism) that was never implemented.

This PR is only about a reliable notification callback for now. Other changes may follow this.