### PR TITLE
Cleanup unnecessary if guard clause to free buffer.

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1417,12 +1417,6 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 			break;
 	}
 
-	/* Log if necessary */
-	if (!display) {
-		efree(buffer);
-		return;
-	}
-
 	efree(buffer);
 }
 /* }}} */


### PR DESCRIPTION
This probably a left over from refactorings, but below the if statement the buffer is freed anyways, so we can get rid of the condition here and cleanup a little.