### PR TITLE
Add MAY_BE_NULL back to opcache info for stream_bucket_make_writeable

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -732,7 +732,7 @@ static const func_info_t func_infos[] = {
 	F1("str_rot13",                    MAY_BE_STRING),
 	F1("stream_get_filters",           MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_OF_STRING),
 	F0("stream_filter_register",       MAY_BE_FALSE | MAY_BE_TRUE),
-	F1("stream_bucket_make_writeable", MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_OBJECT),
+	F1("stream_bucket_make_writeable", MAY_BE_NULL | MAY_BE_OBJECT),
 	F1("stream_bucket_prepend",        MAY_BE_FALSE | MAY_BE_OBJECT),
 	F1("stream_bucket_append",         MAY_BE_FALSE | MAY_BE_OBJECT),
 	F1("stream_bucket_new",            MAY_BE_FALSE | MAY_BE_OBJECT),

--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -732,7 +732,7 @@ static const func_info_t func_infos[] = {
 	F1("str_rot13",                    MAY_BE_STRING),
 	F1("stream_get_filters",           MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_OF_STRING),
 	F0("stream_filter_register",       MAY_BE_FALSE | MAY_BE_TRUE),
-	F1("stream_bucket_make_writeable", MAY_BE_FALSE | MAY_BE_OBJECT),
+	F1("stream_bucket_make_writeable", MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_OBJECT),
 	F1("stream_bucket_prepend",        MAY_BE_FALSE | MAY_BE_OBJECT),
 	F1("stream_bucket_append",         MAY_BE_FALSE | MAY_BE_OBJECT),
 	F1("stream_bucket_new",            MAY_BE_FALSE | MAY_BE_OBJECT),

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -401,7 +401,7 @@ PHP_FUNCTION(stream_bucket_make_writeable)
 
 	if ((brigade = (php_stream_bucket_brigade*)zend_fetch_resource(
 					Z_RES_P(zbrigade), PHP_STREAM_BRIGADE_RES_NAME, le_bucket_brigade)) == NULL) {
-		RETURN_FALSE;
+		RETURN_NULL();
 	}
 
 	ZVAL_NULL(return_value);


### PR DESCRIPTION
This reverts one change in 001d4344494

A php snippet causing the function returning null in practice can be seen in
https://github.com/TysonAndre/php-src-ast-analysis/issues/4

- This repo also has some types that were missing from zend_func_info in
  the examples file (e.g. spl_object_hash, spl_object_id), that may be
  of interest - some entries are inaccurate and have extra/missing types. No other obvious bugs were seen.

The implementation of stream_bucket_make_writeable sets the return value
to null if the head of the bucket no longer exists.

Alternatively, change the ZVAL_NULL macro to something setting the return value to false in the implementation. (I don't use this functionality)


```c
if ((brigade = (php_stream_bucket_brigade*)zend_fetch_resource(
				Z_RES_P(zbrigade), PHP_STREAM_BRIGADE_RES_NAME, le_bucket_brigade)) == NULL) {
	RETURN_FALSE;
}

ZVAL_NULL(return_value);

if (brigade->head && (bucket = php_stream_bucket_make_writeable(brigade->head))) {
```