### PR TITLE
Fix #78429: opcache_compile_file(__FILE__); segfaults

### DIFF
--- a/ext/opcache/tests/bug78429.phpt
+++ b/ext/opcache/tests/bug78429.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #78429 (opcache_compile_file(__FILE__); segfaults)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--INI--
+opcache.enable_cli=0
+--FILE--
+<?php
+var_dump(opcache_compile_file(__FILE__));
+?>
+--EXPECTF--
+Notice: Zend OPcache has not been properly started, can't compile file in %s on line %d
+bool(false)

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -852,6 +852,11 @@ static ZEND_FUNCTION(opcache_compile_file)
 		return;
 	}
 
+	if (!accel_startup_ok) {
+		zend_error(E_NOTICE, ACCELERATOR_PRODUCT_NAME " has not been properly started, can't compile file");
+		RETURN_FALSE;
+	}
+
 	zend_stream_init_filename(&handle, script_name);
 
 	orig_execute_data = EG(current_execute_data);


### PR DESCRIPTION
We have to ensure that OPcache has been properly started up when
`opcache_compile_file()` is called.