### PR TITLE
Promote warnings to errors in array_pad()

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4325,7 +4325,7 @@ PHP_FUNCTION(array_reverse)
 }
 /* }}} */
 
-/* {{{ proto array|false array_pad(array input, int pad_size, mixed pad_value)
+/* {{{ proto array array_pad(array input, int pad_size, mixed pad_value)
    Returns a copy of input array padded with pad_value to size pad_size */
 PHP_FUNCTION(array_pad)
 {
@@ -4349,8 +4349,8 @@ PHP_FUNCTION(array_pad)
 	input_size = zend_hash_num_elements(Z_ARRVAL_P(input));
 	pad_size_abs = ZEND_ABS(pad_size);
 	if (pad_size_abs < 0 || pad_size_abs - input_size > Z_L(1048576)) {
-		php_error_docref(NULL, E_WARNING, "You may only pad up to 1048576 elements at a time");
-		RETURN_FALSE;
+		zend_throw_error(NULL, "Only 1048576 elements may be pad up at a time.");
+		return;
 	}
 
 	if (input_size >= pad_size_abs) {

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4349,7 +4349,7 @@ PHP_FUNCTION(array_pad)
 	input_size = zend_hash_num_elements(Z_ARRVAL_P(input));
 	pad_size_abs = ZEND_ABS(pad_size);
 	if (pad_size_abs < 0 || pad_size_abs - input_size > Z_L(1048576)) {
-		zend_throw_error(NULL, "Only 1048576 elements may be pad up at a time.");
+		zend_throw_error(NULL, "You may only pad up to 1048576 elements at a time");
 		return;
 	}
 

--- a/ext/standard/tests/array/array_pad.phpt
+++ b/ext/standard/tests/array/array_pad.phpt
@@ -86,6 +86,6 @@ array(4) {
   [3]=>
   float(2)
 }
-Only 1048576 elements may be pad up at a time.
+You may only pad up to 1048576 elements at a time
 
 DONE

--- a/ext/standard/tests/array/array_pad.phpt
+++ b/ext/standard/tests/array/array_pad.phpt
@@ -12,11 +12,17 @@ var_dump(array_pad(array("", -1, 2.0), 5, array()));
 var_dump(array_pad(array("", -1, 2.0), 2, array()));
 var_dump(array_pad(array("", -1, 2.0), -3, array()));
 var_dump(array_pad(array("", -1, 2.0), -4, array()));
-var_dump(array_pad(array("", -1, 2.0), 2000000, 0));
 
-echo "Done\n";
+try {
+    var_dump(array_pad(array("", -1, 2.0), 2000000, 0));
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
 ?>
---EXPECTF--
+
+DONE
+--EXPECT--
 array(1) {
   [0]=>
   int(0)
@@ -80,7 +86,6 @@ array(4) {
   [3]=>
   float(2)
 }
+Only 1048576 elements may be pad up at a time.
 
-Warning: array_pad(): You may only pad up to 1048576 elements at a time in %s on line %d
-bool(false)
-Done
+DONE


### PR DESCRIPTION
Split from #4566 