### PR TITLE
Promote warnings to errors in array_merge(_recursive)() and array_replace()

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3572,7 +3572,7 @@ PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 				ZVAL_DEREF(dest_zval);
 				thash = Z_TYPE_P(dest_zval) == IS_ARRAY ? Z_ARRVAL_P(dest_zval) : NULL;
 				if ((thash && GC_IS_RECURSIVE(thash)) || (src_entry == dest_entry && Z_ISREF_P(dest_entry) && (Z_REFCOUNT_P(dest_entry) % 2))) {
-					php_error_docref(NULL, E_WARNING, "recursion detected");
+					zend_throw_error(NULL, "Recursion detected");
 					return 0;
 				}
 
@@ -3693,7 +3693,7 @@ PHPAPI int php_array_replace_recursive(HashTable *dest, HashTable *src) /* {{{ *
 		if (Z_IS_RECURSIVE_P(dest_zval) ||
 		    Z_IS_RECURSIVE_P(src_zval) ||
 		    (Z_ISREF_P(src_entry) && Z_ISREF_P(dest_entry) && Z_REF_P(src_entry) == Z_REF_P(dest_entry) && (Z_REFCOUNT_P(dest_entry) % 2))) {
-			php_error_docref(NULL, E_WARNING, "recursion detected");
+			zend_throw_error(NULL, "Recursion detected");
 			return 0;
 		}
 

--- a/ext/standard/tests/array/array_replace.phpt
+++ b/ext/standard/tests/array/array_replace.phpt
@@ -42,11 +42,15 @@ $data = array_replace_recursive($array1, $array2);
 var_dump($data);
 
 echo " -- Testing array_replace_recursive() w/ endless recusrsion --\n";
-$data = array_replace_recursive($array3, $array4);
+try {
+    $data = array_replace_recursive($array3, $array4);
+    var_dump($data);
+} catch (\Error $e) {
+    echo $e->getMessage() . "\n";
+}
 
-var_dump($data);
 ?>
---EXPECTF--
+--EXPECT--
  -- Testing array_replace() --
 array(5) {
   [0]=>
@@ -107,16 +111,4 @@ array(5) {
   }
 }
  -- Testing array_replace_recursive() w/ endless recusrsion --
-
-Warning: array_replace_recursive(): recursion detected in %s on line %d
-array(1) {
-  [0]=>
-  array(1) {
-    [0]=>
-    array(1) {
-      [0]=>
-      array(0) {
-      }
-    }
-  }
-}
+Recursion detected

--- a/ext/standard/tests/array/bug42177.phpt
+++ b/ext/standard/tests/array/bug42177.phpt
@@ -18,7 +18,11 @@ unset( $a1, $a2 );
 $a1 = array();
 $a2 = array( 'key1' => &$a1 );
 $a1 = array_merge_recursive( $a1, $a2 );
-$a1 = array_merge_recursive( $a1, $a2 );
+try {
+    $a1 = array_merge_recursive( $a1, $a2 );
+} catch (\Error $e) {
+    echo $e->getMessage() . " on line " . $e->getLine() . "\n";
+}
 unset( $a1, $a2 );
 
 $x = 'foo';
@@ -30,5 +34,5 @@ $a1 = array_merge_recursive( $a1, $a2 );
 unset( $a1, $a2 );
 
 ?>
---EXPECTF--
-Warning: array_merge_recursive(): recursion detected in %s on line 18
+--EXPECT--
+Recursion detected on line 19

--- a/ext/standard/tests/array/bug43495.phpt
+++ b/ext/standard/tests/array/bug43495.phpt
@@ -8,14 +8,21 @@ $a["key1"]["key2"]["key3"]=&$a;
 $b=array("key1"=>array("key2"=>array()));
 $b["key1"]["key2"]["key3"]=&$b;
 
-array_merge_recursive($a,$b);
+
+try {
+    array_merge_recursive($a,$b);
+} catch (\Error $e) {
+    echo $e->getMessage() . "\n";
+}
 
 /* Break recursion */
 $a["key1"]["key2"]["key3"] = null;
 $b["key1"]["key2"]["key3"] = null;
 
-echo "Done.\n";
 ?>
---EXPECTF--
-Warning: array_merge_recursive(): recursion detected in %sbug43495.php on line %d
-Done.
+
+DONE
+--EXPECT--
+Recursion detected
+
+DONE

--- a/ext/standard/tests/array/bug65251.phpt
+++ b/ext/standard/tests/array/bug65251.phpt
@@ -3,8 +3,12 @@ Bug #65251: array_merge_recursive() recursion detection broken
 --FILE--
 <?php
 
-array_merge_recursive($GLOBALS, $GLOBALS)
+try {
+    array_merge_recursive($GLOBALS, $GLOBALS);
+} catch (\Error $e) {
+    echo $e->getMessage() . "\n";
+}
 
 ?>
---EXPECTF--
-Warning: array_merge_recursive(): recursion detected in %s on line %d
+--EXPECT--
+Recursion detected


### PR DESCRIPTION
Split from #4566 

Grouping these together as they use the same internal handler.