### PR TITLE
Fix #77812: Interactive mode does not support PHP 7.3-style heredoc

### DIFF
--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -351,7 +351,7 @@ static int cli_is_valid_code(char *code, size_t len, zend_string **prompt) /* {{
 					char c = code[i + 1];
 					char *p = code + i - heredoc_len;
 
-					if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') break;
+					if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c >= 0x80) break;
 					while (*p == ' ' && *p != '\n') p--;
 					if (*p != '\n') break;
 					code_type = body;

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -349,9 +349,14 @@ static int cli_is_valid_code(char *code, size_t len, zend_string **prompt) /* {{
 			case heredoc:
 				if (code[i - (heredoc_len + 1)] == '\n' && !strncmp(code + i - heredoc_len, heredoc_tag, heredoc_len) && code[i] == '\n') {
 					code_type = body;
-				} else if (code[i - (heredoc_len + 2)] == '\n' && !strncmp(code + i - heredoc_len - 1, heredoc_tag, heredoc_len) && code[i-1] == ';' && code[i] == '\n') {
+				} else if (!strncmp(code + i - heredoc_len + 1, heredoc_tag, heredoc_len)) {
+					char c = code[i + 1];
+					char *p = code + i - heredoc_len;
+
+					if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') break;
+					while (*p == ' ' && *p != '\n') p--;
+					if (*p != '\n') break;
 					code_type = body;
-					valid_end = 1;
 				}
 				break;
 			case outside:

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -347,9 +347,7 @@ static int cli_is_valid_code(char *code, size_t len, zend_string **prompt) /* {{
 				}
 				break;
 			case heredoc:
-				if (code[i - (heredoc_len + 1)] == '\n' && !strncmp(code + i - heredoc_len, heredoc_tag, heredoc_len) && code[i] == '\n') {
-					code_type = body;
-				} else if (!strncmp(code + i - heredoc_len + 1, heredoc_tag, heredoc_len)) {
+				if (!strncmp(code + i - heredoc_len + 1, heredoc_tag, heredoc_len)) {
 					char c = code[i + 1];
 					char *p = code + i - heredoc_len;
 

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -352,7 +352,7 @@ static int cli_is_valid_code(char *code, size_t len, zend_string **prompt) /* {{
 					char *p = code + i - heredoc_len;
 
 					if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c >= 0x80) break;
-					while (*p == ' ' && *p != '\n') p--;
+					while (*p == ' ' || *p == '\t') p--;
 					if (*p != '\n') break;
 					code_type = body;
 				}

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -348,7 +348,7 @@ static int cli_is_valid_code(char *code, size_t len, zend_string **prompt) /* {{
 				break;
 			case heredoc:
 				if (!strncmp(code + i - heredoc_len + 1, heredoc_tag, heredoc_len)) {
-					char c = code[i + 1];
+					unsigned char c = code[i + 1];
 					char *p = code + i - heredoc_len;
 
 					if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c >= 0x80) break;

--- a/ext/readline/tests/bug77812-libedit.phpt
+++ b/ext/readline/tests/bug77812-libedit.phpt
@@ -16,6 +16,7 @@ var_dump($proc);
 fwrite($pipes[0], "echo <<<FOO\n    bar\n    FOO;\n");
 fwrite($pipes[0], "print(<<<FOO\nxx\nFOO);\n");
 fwrite($pipes[0], "echo <<<FOO\n    xxx\n    FOO;\nFOO\n;\n");
+fwrite($pipes[0], "echo <<<FOO\nFOOL\nFOO\n,1;\n");
 fclose($pipes[0]);
 proc_close($proc);
 ?>
@@ -28,3 +29,4 @@ xx
 xxx
 
 Warning: Use of undefined constant FOO - assumed 'FOO' (this will throw an Error in a future version of PHP) in php shell code on line %d
+FOOL1

--- a/ext/readline/tests/bug77812-libedit.phpt
+++ b/ext/readline/tests/bug77812-libedit.phpt
@@ -3,8 +3,8 @@ Bug #77812 (Interactive mode does not support PHP 7.3-style heredoc)
 --SKIPIF--
 <?php
 if (!extension_loaded('readline')) die('skip readline extension not available');
-if (READLINE_LIB !== "libedit") die("skip libedit only");
-if (!function_exists('proc_open')) die("proc_open() not available");
+if (READLINE_LIB !== "libedit") die('skip libedit only');
+if (!function_exists('proc_open')) die('skip proc_open() not available');
 ?>
 --FILE--
 <?php

--- a/ext/readline/tests/bug77812-libedit.phpt
+++ b/ext/readline/tests/bug77812-libedit.phpt
@@ -17,6 +17,7 @@ fwrite($pipes[0], "echo <<<FOO\n    bar\n    FOO;\n");
 fwrite($pipes[0], "print(<<<FOO\nxx\nFOO);\n");
 fwrite($pipes[0], "echo <<<FOO\n    xxx\n    FOO;\nFOO\n;\n");
 fwrite($pipes[0], "echo <<<FOO\nFOOL\nFOO\n,1;\n");
+fwrite($pipes[0], "echo <<<FOO\nFOO4\nFOO\n,2;\n");
 fclose($pipes[0]);
 proc_close($proc);
 ?>
@@ -30,3 +31,4 @@ xxx
 
 Warning: Use of undefined constant FOO - assumed 'FOO' (this will throw an Error in a future version of PHP) in php shell code on line %d
 FOOL1
+FOO42

--- a/ext/readline/tests/bug77812-libedit.phpt
+++ b/ext/readline/tests/bug77812-libedit.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bug #77812 (Interactive mode does not support PHP 7.3-style heredoc)
+--SKIPIF--
+<?php
+if (!extension_loaded('readline')) die('skip readline extension not available');
+if (READLINE_LIB !== "libedit") die("skip libedit only");
+if (!function_exists('proc_open')) die("proc_open() not available");
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+$proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+var_dump($proc);
+fwrite($pipes[0], "echo <<<FOO\n    bar\n    FOO;\n");
+fwrite($pipes[0], "print(<<<FOO\nxx\nFOO);\n");
+fwrite($pipes[0], "echo <<<FOO\n    xxx\n    FOO;\nFOO\n;\n");
+fclose($pipes[0]);
+proc_close($proc);
+?>
+--EXPECTF--
+resource(%d) of type (process)
+Interactive shell
+
+bar
+xx
+xxx
+
+Warning: Use of undefined constant FOO - assumed 'FOO' (this will throw an Error in a future version of PHP) in php shell code on line %d

--- a/ext/readline/tests/bug77812-readline.phpt
+++ b/ext/readline/tests/bug77812-readline.phpt
@@ -16,6 +16,7 @@ var_dump($proc);
 fwrite($pipes[0], "echo <<<FOO\n    bar\n    FOO;\n");
 fwrite($pipes[0], "print(<<<FOO\nxx\nFOO);\n");
 fwrite($pipes[0], "echo <<<FOO\n    xxx\n    FOO;\nFOO\n;\n");
+fwrite($pipes[0], "echo <<<FOO\nFOOL\nFOO\n,1;\n");
 fclose($pipes[0]);
 proc_close($proc);
 ?>
@@ -39,4 +40,9 @@ php > FOO
 php > ;
 
 Warning: Use of undefined constant FOO - assumed 'FOO' (this will throw an Error in a future version of PHP) in php shell code on line %d
+php > echo <<<FOO
+<<< > FOOL
+<<< > FOO
+php > ,1;
+FOOL1
 php >

--- a/ext/readline/tests/bug77812-readline.phpt
+++ b/ext/readline/tests/bug77812-readline.phpt
@@ -3,8 +3,8 @@ Bug #77812 (Interactive mode does not support PHP 7.3-style heredoc)
 --SKIPIF--
 <?php
 if (!extension_loaded('readline')) die('skip readline extension not available');
-if (READLINE_LIB !== "readline") die("skip readline only");
-if (!function_exists('proc_open')) die("proc_open() not available");
+if (READLINE_LIB !== "readline") die('skip readline only');
+if (!function_exists('proc_open')) die('skip proc_open() not available');
 ?>
 --FILE--
 <?php

--- a/ext/readline/tests/bug77812-readline.phpt
+++ b/ext/readline/tests/bug77812-readline.phpt
@@ -17,6 +17,7 @@ fwrite($pipes[0], "echo <<<FOO\n    bar\n    FOO;\n");
 fwrite($pipes[0], "print(<<<FOO\nxx\nFOO);\n");
 fwrite($pipes[0], "echo <<<FOO\n    xxx\n    FOO;\nFOO\n;\n");
 fwrite($pipes[0], "echo <<<FOO\nFOOL\nFOO\n,1;\n");
+fwrite($pipes[0], "echo <<<FOO\nFOO4\nFOO\n,2;\n");
 fclose($pipes[0]);
 proc_close($proc);
 ?>
@@ -45,4 +46,9 @@ php > echo <<<FOO
 <<< > FOO
 php > ,1;
 FOOL1
+php > echo <<<FOO
+<<< > FOO4
+<<< > FOO
+php > ,2;
+FOO42
 php >

--- a/ext/readline/tests/bug77812-readline.phpt
+++ b/ext/readline/tests/bug77812-readline.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Bug #77812 (Interactive mode does not support PHP 7.3-style heredoc)
+--SKIPIF--
+<?php
+if (!extension_loaded('readline')) die('skip readline extension not available');
+if (READLINE_LIB !== "readline") die("skip readline only");
+if (!function_exists('proc_open')) die("proc_open() not available");
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+$proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+var_dump($proc);
+fwrite($pipes[0], "echo <<<FOO\n    bar\n    FOO;\n");
+fwrite($pipes[0], "print(<<<FOO\nxx\nFOO);\n");
+fwrite($pipes[0], "echo <<<FOO\n    xxx\n    FOO;\nFOO\n;\n");
+fclose($pipes[0]);
+proc_close($proc);
+?>
+--EXPECTF--
+resource(%d) of type (process)
+Interactive shell
+
+php > echo <<<FOO
+<<< >     bar
+<<< >     FOO;
+bar
+php > print(<<<FOO
+<<< > xx
+<<< > FOO);
+xx
+php > echo <<<FOO
+<<< >     xxx
+<<< >     FOO;
+xxx
+php > FOO
+php > ;
+
+Warning: Use of undefined constant FOO - assumed 'FOO' (this will throw an Error in a future version of PHP) in php shell code on line %d
+php >


### PR DESCRIPTION
As of PHP 7.3.0, the rules regarding the heredoc and nowdoc closing
identifier have been relaxed.  While formerly, the closing identifier
was required to be placed at the beginning of a line and to be
immediately followed by a semicolon and a line break, it may now be
preceeded by whitespace, and may be followed by any non-word character.
We adjust the recognition logic respectively.