### PR TITLE
Removing 'bogus' memory exhaustions cheks in php_chunk_split()

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2127,7 +2127,6 @@ static zend_string *php_chunk_split(const char *src, size_t srclen, const char *
 	const char *p;
 	size_t chunks;
 	size_t restlen;
-	size_t out_len;
 	zend_string *dest;
 
 	chunks = srclen / chunklen;
@@ -2138,17 +2137,7 @@ static zend_string *php_chunk_split(const char *src, size_t srclen, const char *
 		chunks++;
 	}
 
-	out_len = chunks;
-	if (endlen !=0 && out_len > INT_MAX/endlen) {
-		return NULL;
-	}
-	out_len *= endlen;
-	if (out_len > INT_MAX - srclen) {
-		return NULL;
-	}
-	out_len += srclen;
-
-	dest = zend_string_alloc(out_len * sizeof(char), 0);
+	dest = zend_string_safe_alloc(chunks, endlen, srclen, 0);
 
 	for (p = src, q = ZSTR_VAL(dest); p < (src + srclen - chunklen + 1); ) {
 		memcpy(q, p, chunklen);
@@ -2172,7 +2161,7 @@ static zend_string *php_chunk_split(const char *src, size_t srclen, const char *
 }
 /* }}} */
 
-/* {{{ proto string|false chunk_split(string str [, int chunklen [, string ending]])
+/* {{{ proto string chunk_split(string str [, int chunklen [, string ending]])
    Returns split line */
 PHP_FUNCTION(chunk_split)
 {
@@ -2209,11 +2198,7 @@ PHP_FUNCTION(chunk_split)
 
 	result = php_chunk_split(ZSTR_VAL(str), ZSTR_LEN(str), end, endlen, (size_t)chunklen);
 
-	if (result) {
-		RETURN_STR(result);
-	} else {
-		RETURN_FALSE;
-	}
+	RETURN_STR(result);
 }
 /* }}} */
 

--- a/ext/standard/tests/strings/chunk_split.phpt
+++ b/ext/standard/tests/strings/chunk_split.phpt
@@ -7,17 +7,6 @@ echo chunk_split('foooooooooooooooo', 5)."\n";
 echo chunk_split(str_repeat('X', 2*76))."\n";
 echo chunk_split("test", 10, "|end") . "\n";
 
-$a=str_repeat("B", 65535);
-$b=1;
-$c=str_repeat("B", 65535);
-var_dump(chunk_split($a,$b,$c));
-
-$a=str_repeat("B", 65537);
-$b=1;
-$c=str_repeat("B", 65537);
-var_dump(chunk_split($a,$b,$c));
-
-
 ?>
 --EXPECT--
 a-b-c-
@@ -30,5 +19,3 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 test|end
-bool(false)
-bool(false)

--- a/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
@@ -21,8 +21,5 @@ var_dump(chunk_split($a,$b,$c));
 ?>
 --EXPECTF--
 *** Testing chunk_split() : unexpected large 'end' string argument variation 1 ***
-mmap() failed: [12] Cannot allocate memory
 
-mmap() failed: [12] Cannot allocate memory
-
-Fatal error: Out of memory (allocated 2097152) in %s on line %d
+Fatal error: Out of memory (allocated %d) in %s on line %d

--- a/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
@@ -22,4 +22,4 @@ var_dump(chunk_split($a,$b,$c));
 --EXPECTF--
 *** Testing chunk_split() : unexpected large 'end' string argument variation 1 ***
 
-Fatal error: Out of memory (allocated %d) in %s on line %d
+Fatal error: Allowed memory size of %d bytes exhausted at %s (tried to allocate %d bytes) in %s on line %d

--- a/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test chunk_split() function : usage variations - unexpected large '$end' string argument variation 1
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only");
+?>
+--FILE--
+<?php
+/* Prototype  : string chunk_split(string $str [, int $chunklen [, string $ending]])
+ * Description: Returns split line
+ * Source code: ext/standard/string.c
+ * Alias to functions: none
+*/
+
+echo "*** Testing chunk_split() : unexpected large 'end' string argument variation 1 ***\n";
+
+$a=str_repeat("B", 65535);
+$b=1;
+$c=str_repeat("B", 65535);
+var_dump(chunk_split($a,$b,$c));
+?>
+--EXPECTF--
+*** Testing chunk_split() : unexpected large 'end' string argument variation 1 ***
+mmap() failed: [12] Cannot allocate memory
+
+mmap() failed: [12] Cannot allocate memory
+
+Fatal error: Out of memory (allocated 2097152) in %s on line %d

--- a/ext/standard/tests/strings/chunk_split_variation1_64bit.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation1_64bit.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test chunk_split() function : usage variations - unexpected large '$end' string argument variation 1
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
+?>
+--FILE--
+<?php
+/* Prototype  : string chunk_split(string $str [, int $chunklen [, string $ending]])
+ * Description: Returns split line
+ * Source code: ext/standard/string.c
+ * Alias to functions: none
+*/
+
+echo "*** Testing chunk_split() : unexpected large 'end' string argument variation 1 ***\n";
+
+$a=str_repeat("B", 65535);
+$b=1;
+$c=str_repeat("B", 65535);
+var_dump(chunk_split($a,$b,$c));
+?>
+--EXPECTF--
+*** Testing chunk_split() : unexpected large 'end' string argument variation 1 ***
+
+Fatal error: Allowed memory size of %d bytes exhausted%s(tried to allocate %d bytes) in %s on line %d

--- a/ext/standard/tests/strings/chunk_split_variation2_32bit.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation2_32bit.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test chunk_split() function : usage variations - unexpected large '$end' string argument variation 2
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only");
+?>
+--FILE--
+<?php
+/* Prototype  : string chunk_split(string $str [, int $chunklen [, string $ending]])
+ * Description: Returns split line
+ * Source code: ext/standard/string.c
+ * Alias to functions: none
+*/
+
+echo "*** Testing chunk_split() : unexpected large 'end' string argument variation 2 ***\n";
+
+$a=str_repeat("B", 65537);
+$b=1;
+$c=str_repeat("B", 65537);
+var_dump(chunk_split($a,$b,$c));
+?>
+--EXPECTF--
+*** Testing chunk_split() : unexpected large 'end' string argument variation 2 ***
+
+Fatal error: Possible integer overflow in memory allocation (65537 * 65537 + 65556) in %s on line %d

--- a/ext/standard/tests/strings/chunk_split_variation2_64bit.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation2_64bit.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test chunk_split() function : usage variations - unexpected large '$end' string argument variation 2
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
+?>
+--FILE--
+<?php
+/* Prototype  : string chunk_split(string $str [, int $chunklen [, string $ending]])
+ * Description: Returns split line
+ * Source code: ext/standard/string.c
+ * Alias to functions: none
+*/
+
+echo "*** Testing chunk_split() : unexpected large 'end' string argument variation 2 ***\n";
+
+$a=str_repeat("B", 65537);
+$b=1;
+$c=str_repeat("B", 65537);
+var_dump(chunk_split($a,$b,$c));
+?>
+--EXPECTF--
+*** Testing chunk_split() : unexpected large 'end' string argument variation 2 ***
+
+Fatal error: Allowed memory size of %d bytes exhausted%s(tried to allocate %d bytes) in %s on line %d

--- a/ext/standard/tests/strings/chunk_split_variation3.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation3.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test chunk_split() function : usage variations - unexpected large number of chunks
+--FILE--
+<?php
+/* Prototype  : string chunk_split(string $str [, int $chunklen [, string $ending]])
+ * Description: Returns split line
+ * Source code: ext/standard/string.c
+ * Alias to functions: none
+*/
+
+$chunk_length = 1;
+
+echo "*** Testing chunk_split() : unexpected large 'end' string argument variation 2 ***\n";
+
+echo "Body generation\n";
+$body = str_repeat("Hello", 10000000);
+
+echo "Using chunk_split()\n";
+var_dump(chunk_split($body, $chunk_length));
+?>
+--EXPECTF--
+*** Testing chunk_split() : unexpected large 'end' string argument variation 2 ***
+Body generation
+Using chunk_split()
+
+Fatal error: Allowed memory size of %d bytes exhausted%s(tried to allocate %d bytes) in %s on line %d


### PR DESCRIPTION
Similar to #4613 

Not sure if the tests should use explicit line numbers.