### PR TITLE
Fix opcache optimizer info for time_nanosleep+passthru

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -277,7 +277,7 @@ static const func_info_t func_infos[] = {
 	F0("sleep",                        MAY_BE_FALSE | MAY_BE_LONG),
 	F0("usleep",                       MAY_BE_NULL | MAY_BE_FALSE),
 #if HAVE_NANOSLEEP
-	F0("time_nanosleep",               MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
+	F0("time_nanosleep",               MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_LONG),
 	F0("time_sleep_until",             MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 #endif
 #if HAVE_STRPTIME

--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -404,7 +404,7 @@ static const func_info_t func_infos[] = {
 	F1("system",                       MAY_BE_FALSE | MAY_BE_STRING),
 	F1("escapeshellcmd",               MAY_BE_NULL | MAY_BE_STRING),
 	F1("escapeshellarg",               MAY_BE_NULL | MAY_BE_STRING),
-	F1("passthru",                     MAY_BE_FALSE | MAY_BE_STRING),
+	F1("passthru",                     MAY_BE_NULL | MAY_BE_FALSE),
 	F1("shell_exec",                   MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_STRING),
 #ifdef PHP_CAN_SUPPORT_PROC_OPEN
 	F1("proc_open",                    MAY_BE_FALSE | MAY_BE_RESOURCE),


### PR DESCRIPTION
Backported from d95c15e3717ad909a3e4736c4e26ee7a9331d7e1 - PHP 7.1 was also affected but is only receiving security support

- This was the only edit in that change that added a missing type

This can also return an array. See
https://www.php.net/manual/en/function.time-nanosleep.php#refsect1-function.time-nanosleep-returnvalues

> If the delay was interrupted by a signal, an associative array will be
returned with the components:
>
> - seconds - number of seconds remaining in the delay
> - nanoseconds - number of nanoseconds remaining in the delay

Sending a SIGUSR1 to the below program would trigger this behavior.

```php
pcntl_signal(\SIGUSR1, function ($signo, $signinfo) {
    echo "Handling a signal $signo\n";
});
echo "Sleeping for 100 seconds\n";
var_export(time_nanosleep(100, 0));
```

The incomplete signature existed since c88ffa9a5.
No phpt tests existed for time_nanosleep returning an array

----

Also fix signature for passthru

Backported from a1a8d144854acb1c891cf0c21abb0f612b1d8de7
https://www.php.net/manual/en/function.passthru.php#refsect1-function.passthru-returnvalues

`passthru()` is false with invalid args
`passthru('valid or invalid command')` is null.
