### PR TITLE
Fix bug #78454

### DIFF
--- a/Zend/tests/bug78454_1.phpt
+++ b/Zend/tests/bug78454_1.phpt
@@ -1,0 +1,7 @@
+--TEST--
+Invalid consecutive numeric separators after hex literal
+--FILE--
+<?php
+0x0__F;
+--EXPECTF--
+Parse error: syntax error, unexpected '__F' (T_STRING) in %s on line %d

--- a/Zend/tests/bug78454_2.phpt
+++ b/Zend/tests/bug78454_2.phpt
@@ -1,0 +1,7 @@
+--TEST--
+Invalid consecutive numeric separators after binary literal
+--FILE--
+<?php
+0b0__1
+--EXPECTF--
+Parse error: syntax error, unexpected '__1' (T_STRING) in %s on line %d

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1775,7 +1775,7 @@ NEWLINE ("\r"|"\n"|"\r\n")
 	char *end, *bin = yytext + 2;
 
 	/* Skip any leading 0s */
-	while (*bin == '0' || *bin == '_') {
+	while (len > 0 && (*bin == '0' || *bin == '_')) {
 		++bin;
 		--len;
 	}
@@ -1892,7 +1892,7 @@ NEWLINE ("\r"|"\n"|"\r\n")
 	char *end, *hex = yytext + 2;
 
 	/* Skip any leading 0s */
-	while (*hex == '0' || *hex == '_') {
+	while (len > 0 && (*hex == '0' || *hex == '_')) {
 		++hex;
 		--len;
 	}


### PR DESCRIPTION
Resolves out of memory error when consecutive numeric separators follow a binary/hex literal.