### PR TITLE
possible bugfix #78347 empty hostname which is handled by msqlnd but not socket

### DIFF
--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -819,7 +819,7 @@ static int pdo_mysql_handle_factory(pdo_dbh_t *dbh, zval *driver_options)
 #ifdef PHP_WIN32
 	if (vars[2].optval && !strcmp(".", vars[2].optval)) {
 #else
-	if (vars[2].optval && !strcmp("localhost", vars[2].optval)) {
+	if (strlen(vars[2].optval) == 0 || (vars[2].optval && !strcmp("localhost", vars[2].optval))) {
 #endif
 		unix_socket = vars[4].optval;
 	}


### PR DESCRIPTION
Case:
```php -r 'new \PDO("mysql:host=", "root", "root");' -dpdo_mysql.default_socket=/var/lib/mysql/mysql.sock```
Fails, while 
```php -r 'new \PDO("mysql:", "root", "root");' -dpdo_mysql.default_socket=/var/lib/mysql/mysql.sock```
works

problem :
pdo_mysql/mysql_driver.c  only pass default socket information for localhost, for the first case, default host is 'localhost' so , default socket is passed                                   
in the second case, hostname is empty so pdo_mysql/mysql_driver.c  never passes the default socket                             
but mysqld internally replaces empty hostname with 'localhost' and the default socket with '/tmp/
https://github.com/php/php-src/blob/master/ext/mysqlnd/mysqlnd_connection.c#L555

since default socket configuration is on pdo_mysql , I did the possible fix on pdo_msql