### PR TITLE
Fix #78460: PEAR installation failure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1550,6 +1550,8 @@ PHP_GEN_GLOBAL_MAKEFILE
 
 AC_DEFINE([HAVE_BUILD_DEFS_H], 1, [ ])
 
+dnl Make directories when building in a separate build directory.
+$php_shtool mkdir -p pear
 $php_shtool mkdir -p scripts
 $php_shtool mkdir -p scripts/man1
 


### PR DESCRIPTION
When building PHP outside of the source tree:

    mkdir custom-build-dir
    cd custom-build-dir
    ../path/to/php-src/configure

The directories need to be manually created including the pear directory
so the pear installation PHAR file doesn't need to be downloaded from
the remote location.