### PR TITLE
Fix #74170: locale information change after mime_content_type

### DIFF
--- a/ext/fileinfo/libmagic/funcs.c
+++ b/ext/fileinfo/libmagic/funcs.c
@@ -471,11 +471,9 @@ file_replace(struct magic_set *ms, const char *pat, const char *rep)
 	zend_string *repl;
 	int  rep_cnt = 0;
 
-	(void)setlocale(LC_CTYPE, "C");
-
 	opts |= PCRE_MULTILINE;
 	convert_libmagic_pattern(&patt, (char*)pat, strlen(pat), opts);
-	if ((pce = pcre_get_compiled_regex_cache(Z_STR(patt))) == NULL) {
+	if ((pce = pcre_get_compiled_regex_cache_ex(Z_STR(patt), 0)) == NULL) {
 		zval_ptr_dtor(&patt);
 		rep_cnt = -1;
 		goto out;
@@ -497,7 +495,6 @@ file_replace(struct magic_set *ms, const char *pat, const char *rep)
 	zend_string_release(res);
 
 out:
-	(void)setlocale(LC_CTYPE, "");
 	return rep_cnt;
 }
 

--- a/ext/fileinfo/libmagic/readcdf.c
+++ b/ext/fileinfo/libmagic/readcdf.c
@@ -120,14 +120,25 @@ cdf_app_to_mime(const char *vbuf, const struct nv *nv)
 {
 	size_t i;
 	const char *rv = NULL;
+	char *vbuf_lower;
 
-	(void)setlocale(LC_CTYPE, "C");
-	for (i = 0; nv[i].pattern != NULL; i++)
-		if (strcasestr(vbuf, nv[i].pattern) != NULL) {
+	vbuf_lower = zend_str_tolower_dup(vbuf, strlen(vbuf));
+	for (i = 0; nv[i].pattern != NULL; i++) {
+		char *pattern_lower;
+		int found = 0;
+
+
+		pattern_lower = zend_str_tolower_dup(nv[i].pattern, strlen(nv[i].pattern));
+		found = (strstr(vbuf_lower, pattern_lower) != NULL);
+		efree(pattern_lower);
+
+		if (found) {
 			rv = nv[i].mime;
 			break;
 		}
-	(void)setlocale(LC_CTYPE, "");
+	}
+
+	efree(vbuf_lower);
 	return rv;
 }
 

--- a/ext/fileinfo/libmagic/readcdf.c
+++ b/ext/fileinfo/libmagic/readcdf.c
@@ -125,8 +125,7 @@ cdf_app_to_mime(const char *vbuf, const struct nv *nv)
 	vbuf_lower = zend_str_tolower_dup(vbuf, strlen(vbuf));
 	for (i = 0; nv[i].pattern != NULL; i++) {
 		char *pattern_lower;
-		int found = 0;
-
+		int found;
 
 		pattern_lower = zend_str_tolower_dup(nv[i].pattern, strlen(nv[i].pattern));
 		found = (strstr(vbuf_lower, pattern_lower) != NULL);

--- a/ext/fileinfo/libmagic/softmagic.c
+++ b/ext/fileinfo/libmagic/softmagic.c
@@ -412,23 +412,20 @@ flush:
 private int
 check_fmt(struct magic_set *ms, struct magic *m)
 {
-	pcre *pce;
-	int re_options, rv = -1;
-	pcre_extra *re_extra;
+	pcre_cache_entry *pce;
+	int rv = -1;
 	zend_string *pattern;
 
 	if (strchr(m->desc, '%') == NULL)
 		return 0;
 
-	(void)setlocale(LC_CTYPE, "C");
 	pattern = zend_string_init("~%[-0-9\\.]*s~", sizeof("~%[-0-9\\.]*s~") - 1, 0);
-	if ((pce = pcre_get_compiled_regex(pattern, &re_extra, &re_options)) == NULL) {
+	if ((pce = pcre_get_compiled_regex_cache_ex(pattern, 0)) == NULL) {
 		rv = -1;
 	} else {
-	 	rv = !pcre_exec(pce, re_extra, m->desc, strlen(m->desc), 0, re_options, NULL, 0);
+	 	rv = !pcre_exec(pce->re, pce->extra, m->desc, strlen(m->desc), 0, pce->preg_options, NULL, 0);
 	}
 	zend_string_release(pattern);
-	(void)setlocale(LC_CTYPE, "");
 	return rv;
 }
 

--- a/ext/fileinfo/tests/bug74170.phpt
+++ b/ext/fileinfo/tests/bug74170.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #74170 locale information change after mime_content_type
+--SKIPIF--
+<?php
+if (!class_exists('finfo'))
+	die('skip no fileinfo extension');
+if (!extension_loaded('intl'))
+	die('skip intl extension not enabled');
+if (setlocale(LC_CTYPE, 'ru_RU.koi8r') === false)
+	die('skip ru_RU.koi8r locale is not available');
+?>
+--FILE--
+<?php
+var_dump(setlocale(LC_CTYPE, 'ru_RU.koi8r'));
+var_dump(nl_langinfo(CODESET));
+var_dump(mime_content_type(__DIR__ . '/resources/test.ppt'));
+var_dump(nl_langinfo(CODESET));
+--EXPECT--
+string(11) "ru_RU.koi8r"
+string(6) "KOI8-R"
+string(29) "application/vnd.ms-powerpoint"
+string(6) "KOI8-R"


### PR DESCRIPTION
Fix for [bug #74170](https://bugs.php.net/bug.php?id=74170).

Some functions in libmagic (distributed with fileinfo extension) perform this sequence of calls:
  func() {
     setlocale(LC_TYPE, "C")
     .. do some work ..
     setlocale(LC_TYPE, "")
  }

It effectively resets LC_TYPE if it that was set before the function call.

This bug was fixed in upstream file[aka libmagic] ver 5.18
(https://github.com/file/file/commit/c397fb230f70cfa1dc8f3d387f4df8ebec6c1a63)

So I just humbly ported it.