### PR TITLE
Fix detection of gmp on clang

### DIFF
--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -4,27 +4,29 @@ PHP_ARG_WITH([gmp],
     [Include GNU MP support])])
 
 if test "$PHP_GMP" != "no"; then
+  if test "$PHP_GMP" = "yes"; then
+    PHP_CHECK_LIBRARY(gmp, __gmpz_rootrem,
+    [],[
+      AC_MSG_ERROR([GNU MP Library version 4.2 or greater required.])
+    ])
 
-  MACHINE_INCLUDES=$($CC -dumpmachine)
+    PHP_ADD_LIBRARY(gmp, GMP_SHARED_LIBADD)
+  else
+    if test ! -f $PHP_GMP/include/gmp.h; then
+      AC_MSG_ERROR(Unable to locate gmp.h)
+    fi
 
-  for i in $PHP_GMP /usr/local /usr; do
-    test -f $i/include/gmp.h && GMP_DIR=$i && break
-    test -f $i/include/$MACHINE_INCLUDES/gmp.h && GMP_DIR=$i && break
-  done
+    PHP_CHECK_LIBRARY(gmp, __gmpz_rootrem,
+    [],[
+      AC_MSG_ERROR([GNU MP Library version 4.2 or greater required.])
+    ],[
+      -L$PHP_GMP/$PHP_LIBDIR
+    ])
 
-  if test -z "$GMP_DIR"; then
-    AC_MSG_ERROR(Unable to locate gmp.h)
+    PHP_ADD_LIBRARY_WITH_PATH(gmp, $PHP_GMP/$PHP_LIBDIR, GMP_SHARED_LIBADD)
+    PHP_ADD_INCLUDE($PHP_GMP/include)
   fi
 
-  PHP_CHECK_LIBRARY(gmp, __gmpz_rootrem,
-  [],[
-    AC_MSG_ERROR([GNU MP Library version 4.2 or greater required.])
-  ],[
-    -L$GMP_DIR/$PHP_LIBDIR
-  ])
-
-  PHP_ADD_LIBRARY_WITH_PATH(gmp, $GMP_DIR/$PHP_LIBDIR, GMP_SHARED_LIBADD)
-  PHP_ADD_INCLUDE($GMP_DIR/include)
   PHP_INSTALL_HEADERS([ext/gmp/php_gmp_int.h])
 
   PHP_NEW_EXTENSION(gmp, gmp.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -80,7 +80,7 @@ if test "$PHP_LDAP" != "no"; then
   fi
 
   dnl -pc removal is a hack for clang
-  MACHINE_INCLUDES=$($CC -dumpmachine | sed 's/-pc//')
+  MACHINE_INCLUDES=$($CC -dumpmachine | $SED 's/-pc//')
 
   if test -f $LDAP_LIBDIR/liblber.a || test -f $LDAP_LIBDIR/liblber.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.a || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.$SHLIB_SUFFIX_NAME; then
     PHP_ADD_LIBRARY_WITH_PATH(lber, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -79,7 +79,8 @@ if test "$PHP_LDAP" != "no"; then
     LDAP_PTHREAD=
   fi
 
-  MACHINE_INCLUDES=$($CC -dumpmachine)
+  dnl -pc removal is a hack for clang
+  MACHINE_INCLUDES=$($CC -dumpmachine | sed 's/-pc//')
 
   if test -f $LDAP_LIBDIR/liblber.a || test -f $LDAP_LIBDIR/liblber.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.a || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.$SHLIB_SUFFIX_NAME; then
     PHP_ADD_LIBRARY_WITH_PATH(lber, $LDAP_LIBDIR, LDAP_SHARED_LIBADD)


### PR DESCRIPTION
This is an alternative to #4488. It splits the default and custom path case. If default is used, we assuming that the header must be on the include path and the library in the libdir, so we don't add anything more than that. For the custom path case we do what we previously did.

I also added a small hack for ldap, because it has some very complex detection logic that I don't want to touch.

cc @smalyshev @petk 