### PR TITLE
Indicate entry is skipped in error message for array_fill and array_count_values

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4106,7 +4106,7 @@ PHP_FUNCTION(array_count_values)
 				Z_LVAL_P(tmp)++;
 			}
 		} else {
-			php_error_docref(NULL, E_WARNING, "Can only count STRING and INTEGER values!");
+			php_error_docref(NULL, E_WARNING, "Can only count string and integer values, entry skipped");
 		}
 	} ZEND_HASH_FOREACH_END();
 }
@@ -4449,7 +4449,7 @@ PHP_FUNCTION(array_flip)
 			}
 			zend_symtable_update(Z_ARRVAL_P(return_value), Z_STR_P(entry), &data);
 		} else {
-			php_error_docref(NULL, E_WARNING, "Can only flip STRING and INTEGER values!");
+			php_error_docref(NULL, E_WARNING, "Can only flip string and integer values, entry skipped");
 		}
 	} ZEND_HASH_FOREACH_END();
 }

--- a/ext/standard/tests/array/array_count_values2.phpt
+++ b/ext/standard/tests/array/array_count_values2.phpt
@@ -18,11 +18,11 @@ $array1 = array(1,
 var_dump(array_count_values($array1));
 ?>
 --EXPECTF--
-Warning: array_count_values(): Can only count STRING and INTEGER values! in %s on line %d
+Warning: array_count_values(): Can only count string and integer values, entry skipped in %s on line %d
 
-Warning: array_count_values(): Can only count STRING and INTEGER values! in %s on line %d
+Warning: array_count_values(): Can only count string and integer values, entry skipped in %s on line %d
 
-Warning: array_count_values(): Can only count STRING and INTEGER values! in %s on line %d
+Warning: array_count_values(): Can only count string and integer values, entry skipped in %s on line %d
 array(8) {
   [1]=>
   int(2)

--- a/ext/standard/tests/array/array_flip.phpt
+++ b/ext/standard/tests/array/array_flip.phpt
@@ -16,11 +16,11 @@ $trans = array_flip($trans);
 var_dump($trans);
 ?>
 --EXPECTF--
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 array(6) {
   [1]=>
   string(1) "b"

--- a/ext/standard/tests/array/array_flip_variation4.phpt
+++ b/ext/standard/tests/array/array_flip_variation4.phpt
@@ -62,29 +62,29 @@ echo "Done"
 --EXPECTF--
 *** Testing array_flip() : different invalid values in 'input' array argument ***
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 
-Warning: array_flip(): Can only flip STRING and INTEGER values! in %s on line %d
+Warning: array_flip(): Can only flip string and integer values, entry skipped in %s on line %d
 array(0) {
 }
 Done


### PR DESCRIPTION
Mention entry is skipped for ``array_count_values()`` and ``array_fill()`` when value is different than string or integer.