### PR TITLE
feat(zend) Add documentation about `_zend_function.common.arg_info`

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -460,7 +460,7 @@ typedef struct _zend_internal_function {
 	zend_function *prototype;
 	uint32_t num_args;
 	uint32_t required_num_args;
-	zend_internal_arg_info *arg_info; /* index -1 —if set— represents the returned value info */
+	zend_internal_arg_info *arg_info;
 	/* END of common elements */
 
 	zif_handler handler;
@@ -483,7 +483,7 @@ union _zend_function {
 		zend_function *prototype;
 		uint32_t num_args;
 		uint32_t required_num_args;
-		zend_arg_info *arg_info;  /* index -1 —if set— represents the returned value info */
+		zend_arg_info *arg_info;  /* index -1 represents the returned value info if any */
 	} common;
 
 	zend_op_array op_array;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -460,7 +460,7 @@ typedef struct _zend_internal_function {
 	zend_function *prototype;
 	uint32_t num_args;
 	uint32_t required_num_args;
-	zend_internal_arg_info *arg_info;
+	zend_internal_arg_info *arg_info; /* index -1 —if set— represents the returned value info */
 	/* END of common elements */
 
 	zif_handler handler;
@@ -483,7 +483,7 @@ union _zend_function {
 		zend_function *prototype;
 		uint32_t num_args;
 		uint32_t required_num_args;
-		zend_arg_info *arg_info;
+		zend_arg_info *arg_info;  /* index -1 —if set— represents the returned value info */
 	} common;
 
 	zend_op_array op_array;


### PR DESCRIPTION
Hej,

I lost some time trying to know how to find the returned type of a function. It's not that obvious it is stored in the _argument_ information array. I understand why it's done like this to keep BC though. A little comment can help future contributors.

For the sake of Internet, here is the full code checking that a function _has_ a returned type:

```c
zend_function *function = /* e.g. fci_cache->function_handler */;

if (!(function->op_array.fn_flags & ZEND_ACC_HAS_RETURN_TYPE)) {
    php_printf("no return type\n");
} else {
    php_printf("has a return type\n");
    php_printf("return type = %s\n", zend_get_type_by_const(ZEND_TYPE_CODE(function->common.arg_info[-1].type)));
}
```