### PR TITLE
Fix opcache return type for hash_update_stream

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -1192,7 +1192,7 @@ static const func_info_t func_infos[] = {
 	F1("hash_hmac_file",                        MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_STRING),
 	F1("hash_init",                             MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_OBJECT),
 	F0("hash_update",                           MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
-	F0("hash_update_stream",                    MAY_BE_NULL | MAY_BE_LONG),
+	F0("hash_update_stream",                    MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_LONG),
 	F0("hash_update_file",                      MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F1("hash_final",                            MAY_BE_NULL | MAY_BE_STRING),
 	F1("hash_copy",                             MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_OBJECT),


### PR DESCRIPTION
It can return false if the resource type is wrong.

```
php > var_export(hash_update_stream(hash_init('md5'),
        imagecreate(1,1)));

Warning: hash_update_stream(): supplied resource is not a valid stream
resource in php shell code on line 1
false
```

The return types were initially added in
c88ffa9a5673cb3141660626ba1921671f0b84d6