### PR TITLE
Fix opcache optimizer info for time_nanosleep (again)

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -277,7 +277,7 @@ static const func_info_t func_infos[] = {
 	F0("sleep",                        MAY_BE_FALSE | MAY_BE_LONG),
 	F0("usleep",                       MAY_BE_NULL | MAY_BE_FALSE),
 #if HAVE_NANOSLEEP
-	F0("time_nanosleep",               MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_LONG),
+	F1("time_nanosleep",               MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_LONG),
 	F0("time_sleep_until",             MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 #endif
 #if HAVE_STRPTIME


### PR DESCRIPTION
Fixes my earlier PR #4617

If I remember correctly,
The F0 macro is used for return values that are guaranteed to not be
reference counted.
The F1 macro is used for return values that may have up to 1 reference
(i.e. MAY_BE_RC1).

I didn't notice that time_nanosleep needed to be F1 since it could
return an array, and that array is reference counted.