### PR TITLE
Add missing opcache return info for ext/standard.

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -412,6 +412,7 @@ static const func_info_t func_infos[] = {
 	F0("proc_nice",                    MAY_BE_FALSE | MAY_BE_TRUE),
 #endif
 	F0("rand",                         MAY_BE_NULL | MAY_BE_LONG),
+	F1("random_bytes",                 MAY_BE_STRING),
 	F0("srand",                        MAY_BE_NULL),
 	F0("getrandmax",                   MAY_BE_NULL | MAY_BE_LONG),
 	F0("mt_rand",                      MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_LONG),
@@ -848,6 +849,8 @@ static const func_info_t func_infos[] = {
 	F1("array_chunk",                  MAY_BE_NULL | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_REF | MAY_BE_ARRAY_OF_ANY),
 	F1("array_combine",                MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_REF | MAY_BE_ARRAY_OF_ANY),
 	F0("array_key_exists",             MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
+	F1("array_key_first",              MAY_BE_NULL | MAY_BE_LONG | MAY_BE_STRING),
+	F1("array_key_last",               MAY_BE_NULL | MAY_BE_LONG | MAY_BE_STRING),
 	F1("pos",                          UNKNOWN_INFO),
 	F0("sizeof",                       MAY_BE_NULL | MAY_BE_LONG),
 	F0("key_exists",                   MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),


### PR DESCRIPTION
array_key_first/last returns null for invalid args,
wrong argument counts (including objects), and empty arrays.

random_bytes returns a string or throws.