### PR TITLE
Add missing opcache return types for functions in spl

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -1607,6 +1607,17 @@ static const func_info_t func_infos[] = {
 	F0("imagesetinterpolation",					MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE),
 	F1("imageresolution",						MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_TRUE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_OF_LONG),
 
+	/* ext/spl */
+	F1("class_implements",						MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
+	F1("class_parents",							MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
+	F1("class_uses",							MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
+	F0("iterator_apply",						MAY_BE_NULL | MAY_BE_LONG),
+	F0("iterator_count",						MAY_BE_FALSE | MAY_BE_LONG),
+	F1("iterator_to_array",						MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_REF | MAY_BE_ARRAY_OF_ANY),
+	F1("spl_classes",							MAY_BE_NULL | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
+	F1("spl_object_hash",						MAY_BE_NULL | MAY_BE_STRING),
+	F0("spl_object_id",							MAY_BE_NULL | MAY_BE_LONG),
+
 };
 
 static HashTable func_info;


### PR DESCRIPTION
(excluding spl_autoload)

spl_object_id() is of the most interest to me,
since I frequently call it in an application.

This includes false/null types caused by wrong argument types and wrong argument
counts.

I can't rule out iterator_to_array returning null in spl_iterator_apply,
so leave MAY_BE_NULL in.

This targets php 7.4. I'm not sure if there are guidelines for what signatures get added to zend_func_info.c.