### PR TITLE
php-zlib-for-getimagesize.patch

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -280,6 +280,20 @@ else
 fi
 
 dnl
+dnl Check for -lz
+dnl
+PHP_ARG_WITH([zlib],
+  [for ZLIB support],
+  [AS_HELP_STRING([--with-zlib],
+    [Include ZLIB support (requires zlib >= 1.2.0.4)])])
+
+if test "$PHP_ZLIB" != "no"; then
+  PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0.4])
+  LIBS="-lz $LIBS"
+  AC_DEFINE(HAVE_ZLIB,1,[ ])
+fi
+
+dnl
 dnl Check for __attribute__ ((__aligned__)) support in the compiler
 dnl
 AC_CACHE_CHECK(whether the compiler supports aligned attribute, ac_cv_attribute_aligned,[

--- a/ext/standard/image.c
+++ b/ext/standard/image.c
@@ -27,7 +27,7 @@
 #endif
 #include "php_image.h"
 
-#if HAVE_ZLIB && !defined(COMPILE_DL_ZLIB)
+#if HAVE_ZLIB
 #include "zlib.h"
 #endif
 
@@ -79,7 +79,7 @@ PHP_MINIT_FUNCTION(imagetypes)
 	REGISTER_LONG_CONSTANT("IMAGETYPE_JP2",     IMAGE_FILETYPE_JP2,     CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("IMAGETYPE_JPX",     IMAGE_FILETYPE_JPX,     CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("IMAGETYPE_JB2",     IMAGE_FILETYPE_JB2,     CONST_CS | CONST_PERSISTENT);
-#if HAVE_ZLIB && !defined(COMPILE_DL_ZLIB)
+#if HAVE_ZLIB
 	REGISTER_LONG_CONSTANT("IMAGETYPE_SWC",     IMAGE_FILETYPE_SWC,     CONST_CS | CONST_PERSISTENT);
 #endif
 	REGISTER_LONG_CONSTANT("IMAGETYPE_IFF",     IMAGE_FILETYPE_IFF,     CONST_CS | CONST_PERSISTENT);
@@ -186,7 +186,7 @@ static unsigned long int php_swf_get_bits (unsigned char* buffer, unsigned int p
 }
 /* }}} */
 
-#if HAVE_ZLIB && !defined(COMPILE_DL_ZLIB)
+#if HAVE_ZLIB
 /* {{{ php_handle_swc */
 static struct gfxinfo *php_handle_swc(php_stream * stream)
 {
@@ -1398,7 +1398,7 @@ static void php_getimagesize_from_stream(php_stream *stream, char *input, zval *
 			result = php_handle_swf(stream);
 			break;
 		case IMAGE_FILETYPE_SWC:
-#if HAVE_ZLIB && !defined(COMPILE_DL_ZLIB)
+#if HAVE_ZLIB
 			result = php_handle_swc(stream);
 #else
 			php_error_docref(NULL, E_NOTICE, "The image is a compressed SWF file, but you do not have a static version of the zlib extension enabled");

--- a/ext/zlib/config0.m4
+++ b/ext/zlib/config0.m4
@@ -1,15 +1,12 @@
-PHP_ARG_WITH([zlib],
-  [for ZLIB support],
-  [AS_HELP_STRING([--with-zlib],
-    [Include ZLIB support (requires zlib >= 1.2.0.4)])])
+PHP_ARG_ENABLE([zlib],
+  [whether to enable zlib extension],
+  [AS_HELP_STRING([--enable-zlib],
+    [Enable zlib extension])],
+  [no])
 
 if test "$PHP_ZLIB" != "no"; then
-  PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0.4])
-
   PHP_EVAL_LIBLINE($ZLIB_LIBS, ZLIB_SHARED_LIBADD)
   PHP_EVAL_INCLINE($ZLIB_CFLAGS)
-
-  AC_DEFINE(HAVE_ZLIB,1,[ ])
 
   PHP_NEW_EXTENSION(zlib, zlib.c zlib_fopen_wrapper.c zlib_filter.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_SUBST(ZLIB_SHARED_LIBADD)


### PR DESCRIPTION
Make `getimagesize()` work for compressed .swf without static zlib extension.

In PLD LInux `php-common` was already linked with `-lz`.

This is long standing bug why (some) distros have to compile extensions like `filter` or `zlib` static:
- https://gitlab.alpinelinux.org/alpine/aports/issues/8299
- https://github.com/alpinelinux/aports/pull/2951

As the missing symbol comes from `libz` not from `ext-zlib`, and `-lz` is present by default, the ifdef can just be removed.

Import PLD Linux patch:
- https://github.com/pld-linux/php/blob/auto/th/php74-7.4.0-1.beta4.1/php-zlib-for-getimagesize.patch

----

Changes:

- apply php-zlib-for-getimagesize.patch
- add --with-zlib for library, --enable-zlib for extension
