### PR TITLE
Add ValueError

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1560,6 +1560,18 @@ ZEND_API ZEND_COLD void zend_argument_count_error(const char *format, ...) /* {{
 	va_end(va);
 } /* }}} */
 
+ZEND_API ZEND_COLD void zend_value_error(const char *format, ...) /* {{{ */
+{
+	va_list va;
+	char *message = NULL;
+
+	va_start(va, format);
+	zend_vspprintf(&message, 0, format, va);
+	zend_throw_exception(zend_ce_value_error, message, 0);
+	efree(message);
+	va_end(va);
+} /* }}} */
+
 ZEND_API ZEND_COLD void zend_output_debug_string(zend_bool trigger_break, const char *format, ...) /* {{{ */
 {
 #if ZEND_DEBUG

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -301,6 +301,7 @@ ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_at_noreturn(int type, const cha
 ZEND_API ZEND_COLD void zend_throw_error(zend_class_entry *exception_ce, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
 ZEND_API ZEND_COLD void zend_type_error(const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 1, 2);
 ZEND_API ZEND_COLD void zend_argument_count_error(const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 1, 2);
+ZEND_API ZEND_COLD void zend_value_error(const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 1, 2);
 
 ZEND_COLD void zenderror(const char *error);
 

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -36,6 +36,7 @@ ZEND_API zend_class_entry *zend_ce_compile_error;
 ZEND_API zend_class_entry *zend_ce_parse_error;
 ZEND_API zend_class_entry *zend_ce_type_error;
 ZEND_API zend_class_entry *zend_ce_argument_count_error;
+ZEND_API zend_class_entry *zend_ce_value_error;
 ZEND_API zend_class_entry *zend_ce_arithmetic_error;
 ZEND_API zend_class_entry *zend_ce_division_by_zero_error;
 
@@ -871,6 +872,10 @@ void zend_register_default_exception(void) /* {{{ */
 	INIT_CLASS_ENTRY(ce, "ArgumentCountError", NULL);
 	zend_ce_argument_count_error = zend_register_internal_class_ex(&ce, zend_ce_type_error);
 	zend_ce_argument_count_error->create_object = zend_default_exception_new;
+
+	INIT_CLASS_ENTRY(ce, "ValueError", NULL);
+	zend_ce_value_error = zend_register_internal_class_ex(&ce, zend_ce_error);
+	zend_ce_value_error->create_object = zend_default_exception_new;
 
 	INIT_CLASS_ENTRY(ce, "ArithmeticError", NULL);
 	zend_ce_arithmetic_error = zend_register_internal_class_ex(&ce, zend_ce_error);

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -32,6 +32,7 @@ extern ZEND_API zend_class_entry *zend_ce_compile_error;
 extern ZEND_API zend_class_entry *zend_ce_parse_error;
 extern ZEND_API zend_class_entry *zend_ce_type_error;
 extern ZEND_API zend_class_entry *zend_ce_argument_count_error;
+extern ZEND_API zend_class_entry *zend_ce_value_error;
 extern ZEND_API zend_class_entry *zend_ce_arithmetic_error;
 extern ZEND_API zend_class_entry *zend_ce_division_by_zero_error;
 

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -829,12 +829,12 @@ PHP_FUNCTION(imagecreatetruecolor)
 	}
 
 	if (x_size <= 0 || x_size >= INT_MAX) {
-		zend_throw_error(NULL, "Invalid width (x_size)");
+		zend_value_error("Invalid width (x_size)");
 		return;
 	}
 
 	if (y_size <= 0 || y_size >= INT_MAX) {
-		zend_throw_error(NULL, "Invalid height (y_size)");
+		zend_value_error("Invalid height (y_size)");
 		return;
 	}
 
@@ -1473,12 +1473,12 @@ PHP_FUNCTION(imagecreate)
 	}
 
 	if (x_size <= 0 || x_size >= INT_MAX) {
-		zend_throw_error(NULL, "Invalid width (x_size)");
+		zend_value_error("Invalid width (x_size)");
 		return;
 	}
 
 	if (y_size <= 0 || y_size >= INT_MAX) {
-		zend_throw_error(NULL, "Invalid height (y_size)");
+		zend_value_error("Invalid height (y_size)");
 		return;
 	}
 

--- a/ext/gd/tests/imagecreate_error.phpt
+++ b/ext/gd/tests/imagecreate_error.phpt
@@ -17,5 +17,5 @@ trycatch_dump(
 
 ?>
 --EXPECT--
-!! [Error] Invalid width (x_size)
-!! [Error] Invalid height (y_size)
+!! [ValueError] Invalid width (x_size)
+!! [ValueError] Invalid height (y_size)

--- a/ext/gd/tests/imagecreatetruecolor_error2.phpt
+++ b/ext/gd/tests/imagecreatetruecolor_error2.phpt
@@ -19,5 +19,5 @@ trycatch_dump(
 
 ?>
 --EXPECT--
-!! [Error] Invalid width (x_size)
-!! [Error] Invalid height (y_size)
+!! [ValueError] Invalid width (x_size)
+!! [ValueError] Invalid height (y_size)


### PR DESCRIPTION
ValueError is intended to be thrown when a function or method receives an argument that has the right type (incorrect type should throw a [TypeError](https://www.php.net/typeerror)) but an inappropriate value.