### PR TITLE
Handle closed stdio streams

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -549,7 +549,7 @@ static zend_bool cli_is_valid_fd(int fd) {
 }
 
 static zend_bool cli_stdin_valid, cli_stdout_valid, cli_stderr_valid;
-static void cli_check_std_stream_validity() {
+static void cli_check_stdio_stream_validity() {
 	cli_stdin_valid = cli_is_valid_fd(0);
 	cli_stdout_valid = cli_is_valid_fd(1);
 	cli_stderr_valid = cli_is_valid_fd(2);
@@ -933,10 +933,6 @@ static int do_cli(int argc, char **argv) /* {{{ */
 #endif
 			fflush(stdout);
 		}
-
-		/* Check std stream validity before opening the script,
-		 * otherwise an std file descriptor may be overwritten. */
-		cli_check_std_stream_validity();
 
 		/* only set script_file if not set already and not in direct mode and not at end of parameter list */
 		if (argc > php_optind
@@ -1367,6 +1363,10 @@ exit_loop:
 	}
 
 	sapi_module->ini_entries = ini_entries;
+
+	/* Check std stream validity prior to module startup, in case MINIT opens file
+	 * descriptors and overrides the stdio file descriptors. */
+	cli_check_stdio_stream_validity();
 
 	/* startup after we get the above ini override se we get things right */
 	if (sapi_module->startup(sapi_module) == FAILURE) {

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1228,6 +1228,10 @@ int main(int argc, char *argv[])
 	 */
 	argv = save_ps_args(argc, argv);
 
+	/* Check std stream validity very early, to avoid some code opening a file
+	 * and overwriting an stdio file descriptor. */
+	cli_check_stdio_stream_validity();
+
 #if defined(PHP_WIN32) && !defined(PHP_CLI_WIN32_NO_CONSOLE)
 	php_win32_console_fileno_set_vt100(STDOUT_FILENO, TRUE);
 	php_win32_console_fileno_set_vt100(STDERR_FILENO, TRUE);
@@ -1363,10 +1367,6 @@ exit_loop:
 	}
 
 	sapi_module->ini_entries = ini_entries;
-
-	/* Check std stream validity prior to module startup, in case MINIT opens file
-	 * descriptors and overrides the stdio file descriptors. */
-	cli_check_stdio_stream_validity();
 
 	/* startup after we get the above ini override se we get things right */
 	if (sapi_module->startup(sapi_module) == FAILURE) {

--- a/sapi/cli/tests/std_streams_closed.inc
+++ b/sapi/cli/tests/std_streams_closed.inc
@@ -1,0 +1,10 @@
+<?php
+
+ob_start();
+var_dump(ftell(STDIN));
+var_dump(ftell(STDERR));
+var_dump(ftell(STDOUT));
+var_dump(fread(STDIN, 1));
+var_dump(fwrite(STDERR, "a"));
+var_dump(fwrite(STDOUT, "a"));
+file_put_contents(__DIR__ . '/std_streams_closed.txt', ob_get_clean());

--- a/sapi/cli/tests/std_streams_closed.phpt
+++ b/sapi/cli/tests/std_streams_closed.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Testing ftell() and fread() on closed std streams
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') die("skip not for Windows");
+?>
+--FILE--
+<?php
+
+shell_exec(PHP_BINARY . " -n " . __DIR__ . "/std_streams_closed.inc 0<&- 1>&- 2>&-");
+echo file_get_contents(__DIR__ . '/std_streams_closed.txt');
+unlink(__DIR__ . '/std_streams_closed.txt');
+
+?>
+--EXPECTF--
+bool(false)
+bool(false)
+bool(false)
+
+Warning: Trying to read from closed stdio stream in %s on line %d
+bool(false)
+
+Warning: Trying to write to closed stdio stream in %s on line %d
+bool(false)
+
+Warning: Trying to write to closed stdio stream in %s on line %d
+bool(false)


### PR DESCRIPTION
Detect closed stdio streams on startup and open a dummy stream for
them on which all operations fail. This avoids random FDs being
adopted as stdio streams.

Fixes [bug #74252](https://bugs.php.net/bug.php?id=74252).