### PR TITLE
Fix #70153 \DateInterval incorrectly unserialized

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4675,7 +4675,7 @@ PHP_METHOD(DatePeriod, __construct)
 			dpobj->end = clone;
 		}
 	}
-
+	
 	if (dpobj->end == NULL && recurrences < 1) {
 		php_error_docref(NULL, E_WARNING, "The recurrence count '%d' is invalid. Needs to be > 0", (int) recurrences);
 	}

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4675,7 +4675,7 @@ PHP_METHOD(DatePeriod, __construct)
 			dpobj->end = clone;
 		}
 	}
-	
+
 	if (dpobj->end == NULL && recurrences < 1) {
 		php_error_docref(NULL, E_WARNING, "The recurrence count '%d' is invalid. Needs to be > 0", (int) recurrences);
 	}

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4357,7 +4357,7 @@ static int php_date_interval_initialize_from_hash(zval **return_value, php_inter
 		zval *z_arg = zend_hash_str_find(myht, element, sizeof(element) - 1); \
 		if (z_arg && Z_TYPE_P(z_arg) <= IS_STRING) { \
 			zend_string *str = zval_get_string(z_arg); \
-			if (str->len) { \
+			if (ZSTR_LEN(str)) { \
 				DATE_A64I((*intobj)->diff->member, ZSTR_VAL(str)); \
 			} else { \
 				(*intobj)->diff->member = -99999; \

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4357,7 +4357,11 @@ static int php_date_interval_initialize_from_hash(zval **return_value, php_inter
 		zval *z_arg = zend_hash_str_find(myht, element, sizeof(element) - 1); \
 		if (z_arg && Z_TYPE_P(z_arg) <= IS_STRING) { \
 			zend_string *str = zval_get_string(z_arg); \
-			DATE_A64I((*intobj)->diff->member, ZSTR_VAL(str)); \
+			if (str->len) { \
+				DATE_A64I((*intobj)->diff->member, ZSTR_VAL(str)); \
+			} else { \
+				(*intobj)->diff->member = -99999; \
+			} \
 			zend_string_release(str); \
 		} else { \
 			(*intobj)->diff->member = -1LL; \
@@ -4661,7 +4665,7 @@ PHP_METHOD(DatePeriod, __construct)
 			dpobj->end = clone;
 		}
 	}
- 
+
 	if (dpobj->end == NULL && recurrences < 1) {
 		php_error_docref(NULL, E_WARNING, "The recurrence count '%d' is invalid. Needs to be > 0", (int) recurrences);
 	}

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4357,11 +4357,21 @@ static int php_date_interval_initialize_from_hash(zval **return_value, php_inter
 		zval *z_arg = zend_hash_str_find(myht, element, sizeof(element) - 1); \
 		if (z_arg && Z_TYPE_P(z_arg) <= IS_STRING) { \
 			zend_string *str = zval_get_string(z_arg); \
-			if (ZSTR_LEN(str)) { \
-				DATE_A64I((*intobj)->diff->member, ZSTR_VAL(str)); \
-			} else { \
-				(*intobj)->diff->member = -99999; \
-			} \
+			DATE_A64I((*intobj)->diff->member, ZSTR_VAL(str)); \
+			zend_string_release(str); \
+		} else { \
+			(*intobj)->diff->member = -1LL; \
+		} \
+	} while (0);
+
+#define PHP_DATE_INTERVAL_READ_PROPERTY_DAYS(member) \
+	do { \
+		zval *z_arg = zend_hash_str_find(myht, "days", sizeof("days") - 1); \
+		if (z_arg && Z_TYPE_P(z_arg) == IS_FALSE) { \
+			(*intobj)->diff->member = -99999; \
+		} else if (z_arg && Z_TYPE_P(z_arg) <= IS_STRING) { \
+			zend_string *str = zval_get_string(z_arg); \
+			DATE_A64I((*intobj)->diff->member, ZSTR_VAL(str)); \
 			zend_string_release(str); \
 		} else { \
 			(*intobj)->diff->member = -1LL; \
@@ -4396,7 +4406,7 @@ static int php_date_interval_initialize_from_hash(zval **return_value, php_inter
 	PHP_DATE_INTERVAL_READ_PROPERTY("weekday_behavior", weekday_behavior, int, -1)
 	PHP_DATE_INTERVAL_READ_PROPERTY("first_last_day_of", first_last_day_of, int, -1)
 	PHP_DATE_INTERVAL_READ_PROPERTY("invert", invert, int, 0);
-	PHP_DATE_INTERVAL_READ_PROPERTY_I64("days", days);
+	PHP_DATE_INTERVAL_READ_PROPERTY_DAYS(days);
 	PHP_DATE_INTERVAL_READ_PROPERTY("special_type", special.type, unsigned int, 0);
 	PHP_DATE_INTERVAL_READ_PROPERTY_I64("special_amount", special.amount);
 	PHP_DATE_INTERVAL_READ_PROPERTY("have_weekday_relative", have_weekday_relative, unsigned int, 0);

--- a/ext/date/tests/bug48678.phpt
+++ b/ext/date/tests/bug48678.phpt
@@ -39,7 +39,7 @@ DateInterval Object
     [weekday_behavior] => 0
     [first_last_day_of] => 0
     [invert] => 0
-    [days] => 0
+    [days] => 
     [special_type] => 0
     [special_amount] => 0
     [have_weekday_relative] => 0

--- a/ext/date/tests/bug53437.phpt
+++ b/ext/date/tests/bug53437.phpt
@@ -136,7 +136,7 @@ object(DatePeriod)#5 (6) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    int(0)
+    bool(false)
     ["special_type"]=>
     int(0)
     ["special_amount"]=>

--- a/ext/date/tests/bug53437_var2.phpt
+++ b/ext/date/tests/bug53437_var2.phpt
@@ -71,7 +71,7 @@ object(DateInterval)#2 (16) {
   ["invert"]=>
   int(0)
   ["days"]=>
-  int(0)
+  bool(false)
   ["special_type"]=>
   int(0)
   ["special_amount"]=>

--- a/ext/date/tests/bug70153.phpt
+++ b/ext/date/tests/bug70153.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #70153 (\DateInterval incorrectly unserialized)
+--FILE--
+<?php
+$i1 = \DateInterval::createFromDateString('+1 month');
+$i2 = unserialize(serialize($i1));
+var_dump($i1->days, $i2->days);
+var_dump($i2->special_amount, $i2->special_amount);
+?>
+--EXPECT--
+bool(false)
+bool(false)
+int(0)
+int(0)


### PR DESCRIPTION
Fixes: https://bugs.php.net/bug.php?id=70153

Added a special handling for the days property, so that bool(false) is
correctly converted to the proper internal representation.

Solution is based on Christoph M. Becker's (@cmb69) patch
proposed in the bug page.