### PR TITLE
fix bug #72884  isCloneable() on SplFileObject should return false

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -3157,6 +3157,7 @@ PHP_MINIT_FUNCTION(spl_directory)
 	REGISTER_SPL_IMPLEMENTS(RecursiveDirectoryIterator, RecursiveIterator);
 
 	memcpy(&spl_filesystem_object_check_handlers, &spl_filesystem_object_handlers, sizeof(zend_object_handlers));
+	spl_filesystem_object_check_handlers.clone_obj = 0;
 	spl_filesystem_object_check_handlers.get_method = spl_filesystem_object_get_method_check;
 
 #ifdef HAVE_GLOB

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -371,8 +371,7 @@ static zend_object *spl_filesystem_object_clone(zval *zobject)
 			intern->u.dir.index = index;
 			break;
 		case SPL_FS_FILE:
-			zend_throw_error(NULL, "An object of class %s cannot be cloned", ZSTR_VAL(old_object->ce->name));
-			return new_object;
+			ZEND_ASSERT(0);
 	}
 
 	intern->file_class = source->file_class;
@@ -3157,7 +3156,7 @@ PHP_MINIT_FUNCTION(spl_directory)
 	REGISTER_SPL_IMPLEMENTS(RecursiveDirectoryIterator, RecursiveIterator);
 
 	memcpy(&spl_filesystem_object_check_handlers, &spl_filesystem_object_handlers, sizeof(zend_object_handlers));
-	spl_filesystem_object_check_handlers.clone_obj = 0;
+	spl_filesystem_object_check_handlers.clone_obj = NULL;
 	spl_filesystem_object_check_handlers.get_method = spl_filesystem_object_get_method_check;
 
 #ifdef HAVE_GLOB

--- a/ext/spl/tests/bug72884.phpt
+++ b/ext/spl/tests/bug72884.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #72884:  isCloneable() on SplFileObject should return false
+--FILE--
+<?php
+$x=new SplFileObject(__FILE__);
+$r=new ReflectionObject($x);
+var_dump($r->isCloneable());
+
+--EXPECT--
+bool(false)

--- a/ext/spl/tests/bug72888.phpt
+++ b/ext/spl/tests/bug72888.phpt
@@ -12,7 +12,7 @@ try {
 var_dump($y);
 ?>
 --EXPECTF--
-string(49) "An object of class SplFileObject cannot be cloned"
+string(60) "Trying to clone an uncloneable object of class SplFileObject"
 
 Notice: Undefined variable: y in %sbug72888.php on line %d
 NULL


### PR DESCRIPTION
I removed the `clone_obj` handler on `SplFileObject` so `isCloneable()` is able to return false now. 
please noted I didn't remove [the codes](https://github.com/php/php-src/blob/php-7.3.0beta1/ext/spl/spl_directory.c#L373-L375) rasing error in `spl_filesystem_object_clone` since there might be extensions reusing this method.