### PR TITLE
Fix opcache zend_func_info for microtime/gettimeofday

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -503,8 +503,8 @@ static const func_info_t func_infos[] = {
 	F1("sys_getloadavg",               MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_OF_DOUBLE),
 #endif
 #ifdef HAVE_GETTIMEOFDAY
-	F1("microtime",                    MAY_BE_NULL | MAY_BE_DOUBLE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_OF_LONG | MAY_BE_STRING),
-	F1("gettimeofday",                 MAY_BE_NULL | MAY_BE_DOUBLE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_LONG | MAY_BE_STRING),
+	F1("microtime",                    MAY_BE_NULL | MAY_BE_DOUBLE | MAY_BE_STRING),
+	F1("gettimeofday",                 MAY_BE_NULL | MAY_BE_DOUBLE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_LONG),
 #endif
 #ifdef HAVE_GETRUSAGE
 	F1("getrusage",                    MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_LONG),


### PR DESCRIPTION
microtime() doesn't return an array,
and gettimeofday() doesn't return a string.
See _php_gettimeofday in microtime.c (mode is non-zero for gettimeofday)

- See comments on 4690

This initially targeted php 7.2 because of the missing MAY_BE_FALSE. However, this can be moved to 7.4 safely.

This microtime signature was part of the initial commit c88ffa9a567

Note that microtime.c has `RETURN_FALSE;`, but that only happens on
`EFAULT` of `gettimeofday(&tp, NULL)`
