### PR TITLE
add FFI::isNull() to check whether a FFI\CData is a null pointer

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4359,6 +4359,35 @@ ZEND_METHOD(FFI, string) /* {{{ */
 }
 /* }}} */
 
+ZEND_METHOD(FFI, isNull) /* {{{ */
+{
+	zval *zv;
+	zend_ffi_type *type;
+	void *ptr = NULL;
+
+	ZEND_FFI_VALIDATE_API_RESTRICTION();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(zv);
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZVAL_DEREF(zv);
+	if (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ffi_cdata_ce) {
+		zend_ffi_cdata *cdata = (zend_ffi_cdata*)Z_OBJ_P(zv);
+		type = ZEND_FFI_TYPE(cdata->type);
+		ptr = cdata->ptr;
+	} else {
+		zend_wrong_parameter_class_error(1, "FFI\\CData", zv);
+		return;
+	}
+
+	if (type->kind != ZEND_FFI_TYPE_POINTER){
+		zend_throw_error(zend_ffi_exception_ce, "FFI\\Cdata is not a pointer");
+	}
+
+	RETURN_BOOL(*(void**)ptr == NULL);
+}
+/* }}} */
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_func_cdef, 0, 0, 0)
 	ZEND_ARG_INFO(0, code)
 	ZEND_ARG_INFO(0, lib)
@@ -4435,6 +4464,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_func_string, 0, 0, 1)
 	ZEND_ARG_INFO(0, size)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_func_isnull, 0, 0, 1)
+	ZEND_ARG_INFO(ZEND_SEND_PREFER_REF, ptr)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry zend_ffi_functions[] = {
 	ZEND_ME(FFI, cdef,        arginfo_func_cdef,    ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(FFI, load,        arginfo_func_load,    ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
@@ -4452,6 +4485,7 @@ static const zend_function_entry zend_ffi_functions[] = {
 	ZEND_ME(FFI, memcmp,      arginfo_func_memcmp,  ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(FFI, memset,      arginfo_func_memset,  ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(FFI, string,      arginfo_func_string,  ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(FFI, isNull,      arginfo_func_isnull,  ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END
 };
 


### PR DESCRIPTION
This PR is a response to an issue I found with the FFI extension that makes is incredibly hard to figure out whether something is a pointer to NULL or not.

A use case for this is an API that uses out-parameters to set a pointer to some struct that would work like this:

```C
Error *err;
func(&err);
```

where `func` would then either set err to point to NULL or to some Error struct somewhere that has more information about that failed.

As it stands now, it feels impossible to check whether `err` (or any other out pointer parameter of course) is indeed NULL or not.

Given this code:

```php
$ffi = FFI::cdef("...", "...");
$err = $ffi->new("Error*");
$ffi->func(FFI::addr($err));
```

Attempts at checking whether $err was set or not fails with various failure modes:

```php
!isset($err); // understandably returns false because $err is a CData instance
$err == NULL; // dito
$err[0] == null; // also returns false because $err[0] also is a CData instance
$err->{0} == null; // FFI\Exception: NULL pointer dereference
(bool)$err[0]; // Object of class FFI\CData could not be converted to bool
(bool)$err->{0}; // FFI\Exception: NULL pointer dereference 
var_dump($err[0]); // segfault
```

This PR adds a `FFI::isNull()` method that can be used on that `$err` like this:

```php
FFI::isNull($err);
```

which will return true if $err is a CData instance of kind pointer and pointing to NULL.

See https://externals.io/message/106910 for the whole discussion.