### PR TITLE
Add opcache return type for random_int()

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -413,6 +413,7 @@ static const func_info_t func_infos[] = {
 #endif
 	F0("rand",                         MAY_BE_NULL | MAY_BE_LONG),
 	F1("random_bytes",                 MAY_BE_STRING),
+	F1("random_int",                   MAY_BE_LONG),
 	F0("srand",                        MAY_BE_NULL),
 	F0("getrandmax",                   MAY_BE_NULL | MAY_BE_LONG),
 	F0("mt_rand",                      MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_LONG),


### PR DESCRIPTION
random_int() will throw for incorrect argument counts, types (e.g. float
that can't cast to int), or having min > max.

See ext/standard/random.c

I added random_bytes() earlier but missed this.