### PR TITLE
new_variable '{' expr '}' is deprecated as well

### DIFF
--- a/Zend/tests/varSyntax/newVariable.phpt
+++ b/Zend/tests/varSyntax/newVariable.phpt
@@ -23,6 +23,7 @@ var_dump(new $weird[0]->foo::$className);
 
 ?>
 --EXPECTF--
+Deprecated: Array and string offset access syntax with curly braces is deprecated in %s on line %d
 object(stdClass)#%d (0) {
 }
 object(stdClass)#%d (0) {

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1189,7 +1189,7 @@ new_variable:
 	|	new_variable '[' optional_expr ']'
 			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
 	|	new_variable '{' expr '}'
-			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
+			{ $$ = zend_ast_create_ex(ZEND_AST_DIM, ZEND_DIM_ALTERNATIVE_SYNTAX, $1, $3); }
 	|	new_variable T_OBJECT_OPERATOR property_name
 			{ $$ = zend_ast_create(ZEND_AST_PROP, $1, $3); }
 	|	class_name T_PAAMAYIM_NEKUDOTAYIM simple_variable


### PR DESCRIPTION
Curly brace syntax for accessing array elements and string offsets is
deprecated [1]; this should also be the case for respective `new`
expressions.

This issue has been reported by brzuchal@php.net.

[1] <https://wiki.php.net/rfc/deprecate_curly_braces_array_access>