### PR TITLE
Port various autoconf bits to C99 compilers

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -157,6 +157,7 @@ AC_MSG_CHECKING(whether double cast to long preserves least significant bits)
 
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <limits.h>
+#include <stdlib.h>
 
 int main()
 {
@@ -256,6 +257,7 @@ AC_MSG_CHECKING(for MM alignment and log values)
 
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
+#include <stdlib.h>
 
 typedef union _mm_align_test {
   void *ptr;

--- a/build/libtool.m4
+++ b/build/libtool.m4
@@ -945,6 +945,7 @@ else
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifdef RTLD_GLOBAL
 #  define LT_DLGLOBAL		RTLD_GLOBAL
@@ -976,10 +977,6 @@ else
 #      endif
 #    endif
 #  endif
-#endif
-
-#ifdef __cplusplus
-extern "C" void exit (int);
 #endif
 
 void fnord() { int i=42;}

--- a/build/php.m4
+++ b/build/php.m4
@@ -1118,7 +1118,7 @@ AC_CACHE_CHECK(for type of reentrant time-related functions, ac_cv_time_r_type,[
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <time.h>
 
-main() {
+int main() {
 char buf[27];
 struct tm t;
 time_t old = 0;
@@ -1134,7 +1134,7 @@ return (1);
 ],[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <time.h>
-main() {
+int main() {
   struct tm t, *s;
   time_t old = 0;
   char buf[27], *p;
@@ -1173,8 +1173,9 @@ AC_DEFUN([PHP_DOES_PWRITE_WORK],[
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <stdlib.h>
 $1
-    main() {
+    int main() {
     int fd = open("conftest_in", O_WRONLY|O_CREAT, 0600);
 
     if (fd < 0) exit(1);
@@ -1206,8 +1207,9 @@ AC_DEFUN([PHP_DOES_PREAD_WORK],[
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <stdlib.h>
 $1
-    main() {
+    int main() {
     char buf[3];
     int fd = open("conftest_in", O_RDONLY);
     if (fd < 0) exit(1);
@@ -1460,6 +1462,7 @@ dnl Even newer glibcs have a different seeker definition.
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #define _GNU_SOURCE
 #include <stdio.h>
+#include <stdlib.h>
 
 struct cookiedata {
   __off64_t pos;
@@ -1476,7 +1479,7 @@ int seeker(void *cookie, __off64_t *position, int whence)
 
 cookie_io_functions_t funcs = {reader, writer, seeker, closer};
 
-main() {
+int main() {
   struct cookiedata g = { 0 };
   FILE *fp = fopencookie(&g, "r", funcs);
 
@@ -1595,7 +1598,7 @@ AC_DEFUN([PHP_CHECK_FUNC_LIB],[
   if test "$found" = "yes"; then
     ac_libs=$LIBS
     LIBS="$LIBS -l$2"
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[main() { return (0); }]])],[found=yes],[found=no],[found=no])
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[int main() { return (0); }]])],[found=yes],[found=no],[found=no])
     LIBS=$ac_libs
   fi
 
@@ -2281,7 +2284,7 @@ AC_DEFUN([PHP_TEST_WRITE_STDOUT],[
 
 #define TEXT "This is the test message -- "
 
-main()
+int main()
 {
   int n;
 

--- a/configure.ac
+++ b/configure.ac
@@ -662,6 +662,8 @@ AC_CACHE_CHECK([for getaddrinfo], ac_cv_func_getaddrinfo,
   [[struct addrinfo *g,h;g=&h;getaddrinfo("","",g,&g);]])],[AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <netdb.h>
 #include <sys/types.h>
+#include <string.h>
+#include <stdlib.h>
 #ifndef AF_INET
 # include <sys/socket.h>
 #endif

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -5,6 +5,10 @@ AC_CACHE_CHECK([whether flush should be called explicitly after a buffered io], 
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <string.h>
 
 int main(int argc, char **argv)
 {
@@ -67,6 +71,9 @@ AC_CACHE_CHECK(for standard DES crypt, ac_cv_crypt_des,[
 #include <crypt.h>
 #endif
 
+#include <stdlib.h>
+#include <string.h>
+
 int main() {
 #if HAVE_CRYPT
 	char *encrypted = crypt("rasmuslerdorf","rl");
@@ -92,6 +99,9 @@ AC_CACHE_CHECK(for extended DES crypt, ac_cv_crypt_ext_des,[
 #include <crypt.h>
 #endif
 
+#include <stdlib.h>
+#include <string.h>
+
 int main() {
 #if HAVE_CRYPT
 	char *encrypted = crypt("rasmuslerdorf","_J9..rasm");
@@ -116,6 +126,9 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #if HAVE_CRYPT_H
 #include <crypt.h>
 #endif
+
+#include <stdlib.h>
+#include <string.h>
 
 int main() {
 #if HAVE_CRYPT
@@ -152,6 +165,9 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <crypt.h>
 #endif
 
+#include <stdlib.h>
+#include <string.h>
+
 int main() {
 #if HAVE_CRYPT
 	char salt[30], answer[70];
@@ -184,6 +200,9 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <crypt.h>
 #endif
 
+#include <stdlib.h>
+#include <string.h>
+
 int main() {
 #if HAVE_CRYPT
 	char salt[21], answer[21+86];
@@ -214,6 +233,9 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #if HAVE_CRYPT_H
 #include <crypt.h>
 #endif
+
+#include <stdlib.h>
+#include <string.h>
 
 int main() {
 #if HAVE_CRYPT


### PR DESCRIPTION
C99 no longer has implicit function declarations and implicit ints.
Current GCC versions enable them as an extension, but this will
change in a future GCC version.