### PR TITLE
Don't invoke __set() on accessible declared but unset properties

### DIFF
--- a/Zend/tests/bug63462.phpt
+++ b/Zend/tests/bug63462.phpt
@@ -67,6 +67,5 @@ __isset publicProperty
 __isset protectedProperty
 __isset privateProperty
 __set nonExisting
-__set publicProperty
 __set protectedProperty
 __set privateProperty

--- a/Zend/tests/bug78226.phpt
+++ b/Zend/tests/bug78226.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bug #78226: Unexpected __set behavior with typed properties
+--FILE--
+<?php
+
+class Test {
+    public int $prop1;
+    public $prop2;
+
+    public function __set($name, $val) {
+        echo "__set($name, $val)\n";
+    }
+}
+
+$test = new Test;
+unset($test->prop2);
+
+$test->prop1 = 1;
+$test->prop2 = 2;
+
+var_dump($test);
+
+?>
+--EXPECT--
+object(Test)#1 (2) {
+  ["prop1"]=>
+  int(1)
+  ["prop2"]=>
+  int(2)
+}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -819,23 +819,21 @@ ZEND_API zval *zend_std_write_property(zval *object, zval *member, zval *value, 
 
 	if (EXPECTED(IS_VALID_PROPERTY_OFFSET(property_offset))) {
 		variable_ptr = OBJ_PROP(zobj, property_offset);
-		if (Z_TYPE_P(variable_ptr) != IS_UNDEF) {
-			Z_TRY_ADDREF_P(value);
+		Z_TRY_ADDREF_P(value);
 
-			if (UNEXPECTED(prop_info)) {
-				ZVAL_COPY_VALUE(&tmp, value);
-				if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, EG(current_execute_data) && ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data))))) {
-					Z_TRY_DELREF_P(value);
-					variable_ptr = &EG(error_zval);
-					goto exit;
-				}
-				value = &tmp;
+		if (UNEXPECTED(prop_info)) {
+			ZVAL_COPY_VALUE(&tmp, value);
+			if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, EG(current_execute_data) && ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data))))) {
+				Z_TRY_DELREF_P(value);
+				variable_ptr = &EG(error_zval);
+				goto exit;
 			}
+			value = &tmp;
+		}
 
 found:
-			zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EG(current_execute_data) && ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)));
-			goto exit;
-		}
+		zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EG(current_execute_data) && ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)));
+		goto exit;
 	} else if (EXPECTED(IS_DYNAMIC_PROPERTY_OFFSET(property_offset))) {
 		if (EXPECTED(zobj->properties != NULL)) {
 			if (UNEXPECTED(GC_REFCOUNT(zobj->properties) > 1)) {

--- a/tests/classes/unset_properties.phpt
+++ b/tests/classes/unset_properties.phpt
@@ -132,22 +132,22 @@ true
 __isset "publicProperty"
 __get "publicProperty"
 __get "publicProperty"
-__set "publicProperty" to "new publicProperty value via setter"
+
 new publicProperty value via setter
-__set "publicProperty" to "new publicProperty value via public access"
+
 true
 new publicProperty value via public access
 
 protectedProperty set
 __isset "protectedProperty"false
 __get "protectedProperty"
-__set "protectedProperty" to "new protectedProperty value via setter"
+
 __isset "protectedProperty"true
 new protectedProperty value via setter
 
 privateProperty set
 __isset "privateProperty"false
 __get "privateProperty"
-__set "privateProperty" to "new privateProperty value via setter"
+
 __isset "privateProperty"true
 new privateProperty value via setter


### PR DESCRIPTION
Fixes [bug #78226](https://bugs.php.net/bug.php?id=78226) by no longer calling `__set()` for properties that have been declared and are visible, but which are either uninitialized (typed props) or explicitly unset. With the current behavior there is no direct way to actually set those properties.

This is an existing issue, but made critical by the fact that typed properties start out uninitialized (while previously you could only hit this with an explicit unset). This means that essentially typed properties and `__set()` are completely incompatible right now, because it's impossible to actually initialize them (apart from the default value). This also affects some internal mechanisms like class fetches in PDO.

This change does not affect the other magic methods, and in particular `__get()` can still be used as usual for lazy initialization.

cc @krakjoe @MarkRandall As discussed...

cc @Ocramius Are you aware of anything this is going to break?