### PR TITLE
Fix bug #78525

### DIFF
--- a/ext/mysqlnd/mysqlnd_block_alloc.c
+++ b/ext/mysqlnd/mysqlnd_block_alloc.c
@@ -200,6 +200,9 @@ PHPAPI void
 mysqlnd_mempool_restore_state(MYSQLND_MEMORY_POOL * pool)
 {
 	DBG_ENTER("mysqlnd_mempool_restore_state");
+#if ZEND_DEBUG
+	ZEND_ASSERT(pool->checkpoint);
+#endif
 	if (pool->checkpoint) {
 		mysqlnd_arena_release(&pool->arena, pool->checkpoint);
 		pool->last = NULL;


### PR DESCRIPTION
[Bug #78525](https://bugs.php.net/bug.php?id=78525)

When calling free_result_buffers(), also free field metadata and restore the mempool state to what it was before any allocations have been made. Remove the mempool save/restore logic for the inner result set as this is now handled on a higher level.