### PR TITLE
Fix auto_detect_line_endings type

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -166,7 +166,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("user_agent", NULL, PHP_INI_ALL, OnUpdateString, user_agent, php_file_globals, file_globals)
 	STD_PHP_INI_ENTRY("from", NULL, PHP_INI_ALL, OnUpdateString, from_address, php_file_globals, file_globals)
 	STD_PHP_INI_ENTRY("default_socket_timeout", "60", PHP_INI_ALL, OnUpdateLong, default_socket_timeout, php_file_globals, file_globals)
-	STD_PHP_INI_ENTRY("auto_detect_line_endings", "0", PHP_INI_ALL, OnUpdateLong, auto_detect_line_endings, php_file_globals, file_globals)
+	STD_PHP_INI_ENTRY("auto_detect_line_endings", "0", PHP_INI_ALL, OnUpdateBool, auto_detect_line_endings, php_file_globals, file_globals)
 PHP_INI_END()
 
 PHP_MINIT_FUNCTION(file)

--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -119,7 +119,7 @@ php_meta_tags_token php_next_meta_token(php_meta_tags_data *);
 typedef struct {
 	int pclose_ret;
 	size_t def_chunk_size;
-	zend_long auto_detect_line_endings;
+	zend_bool auto_detect_line_endings;
 	zend_long default_socket_timeout;
 	char *user_agent; /* for the http wrapper */
 	char *from_address; /* for the ftp and http wrappers */

--- a/ext/standard/tests/file/auto_detect_line_endings_1.phpt
+++ b/ext/standard/tests/file/auto_detect_line_endings_1.phpt
@@ -1,0 +1,24 @@
+--TEST--
+auto_detect_line_endings --INI-- bool
+--INI--
+auto_detect_line_endings=on
+--STDIN--
+fooBar1fooBar2fooBar3
+--FILE--
+<?php
+
+var_dump(ini_get("auto_detect_line_endings"));
+
+var_dump(fgets(STDIN));
+var_dump(fgets(STDIN));
+var_dump(fgets(STDIN));
+
+echo "Done\n";
+?>
+--EXPECTF--
+string(1) "1"
+string(8) "fooBar1"
+string(8) "fooBar2"
+string(8) "fooBar3
+"
+Done

--- a/ext/standard/tests/file/auto_detect_line_endings_2.phpt
+++ b/ext/standard/tests/file/auto_detect_line_endings_2.phpt
@@ -1,0 +1,28 @@
+--TEST--
+ini_set auto_detect_line_endings bool
+--FILE--
+<?php
+
+ini_set("auto_detect_line_endings", "on");
+var_dump(ini_get("auto_detect_line_endings"));
+
+$filePath = __DIR__ . DIRECTORY_SEPARATOR . "auto_detect_line_endings_2.txt";
+file_put_contents($filePath, "fooBar1\rfooBar2\rfooBar3");
+
+$stdin = fopen($filePath, "r");
+var_dump(fgets($stdin));
+var_dump(fgets($stdin));
+var_dump(fgets($stdin));
+
+echo "Done\n";
+?>
+--EXPECTF--
+string(2) "on"
+string(8) "fooBar1"
+string(8) "fooBar2"
+string(7) "fooBar3"
+Done
+--CLEAN--
+<?php
+unlink(__DIR__ . DIRECTORY_SEPARATOR . "auto_detect_line_endings_2.txt");
+?>


### PR DESCRIPTION
Setting `auto_detect_line_endings` to `on` with `ini_set` doesn't enable it, because the value's parsed as a long.