### PR TITLE
Fixing little build warning as ZEND_ALLOCATOR macro

### DIFF
--- a/ext/standard/image.c
+++ b/ext/standard/image.c
@@ -449,9 +449,9 @@ static int php_read_APP(php_stream * stream, unsigned int marker, zval *info)
 	}
 	length -= 2;				/* length includes itself */
 
-	buffer = emalloc(length);
+	buffer = emalloc((size_t)length);
 
-	if (php_stream_read(stream, buffer, (zend_long) length) != length) {
+	if (php_stream_read(stream, buffer, (size_t) length) != length) {
 		efree(buffer);
 		return 0;
 	}


### PR DESCRIPTION
expects larger type than a unsigned short.