### PR TITLE
Improve test usleep_basic by inlining its output

### DIFF
--- a/ext/standard/tests/general_functions/usleep_basic.phpt
+++ b/ext/standard/tests/general_functions/usleep_basic.phpt
@@ -27,17 +27,16 @@ usleep($sleeptime);
 $time_end = microtime(true);
 $time = ($time_end - $time_start) * 1000 * 1000;
 
-echo "Thread slept for " . $time . " micro-seconds\n";
+$summary = "Thread slept for " . $time . " micro-seconds\n";
 
 if ($time >= $sleeplow) {
-	echo "TEST PASSED\n";
+	echo "TEST PASSED: $summary";
 } else {
-	echo "TEST FAILED\n";
+	echo "TEST FAILED: $summary";
 }
 ?>
 ===DONE===
 --EXPECTF--
 *** Testing usleep() : basic functionality ***
-Thread slept for %f micro-seconds
-TEST PASSED
+TEST PASSED: Thread slept for %f micro-seconds
 ===DONE===


### PR DESCRIPTION
Here the current diff when _usleep_basic.phpt_ fails:
```
========DIFF========
003+ TEST FAILED
003- TEST PASSED
========DONE========
FAIL Test usleep() function [ext/standard/tests/general_functions/usleep_basic.phpt]
```
This PR makes it more informative by adding the actual time spent sleeping:
```
========DIFF========
002+ TEST FAILED: Thread slept for 970171.21315002 micro-seconds
002- TEST PASSED: Thread slept for %f micro-seconds
========DONE========
FAIL Test usleep() function [ext/standard/tests/general_functions/usleep_basic.phpt]
```