### PR TITLE
Make some session tests more robust

### DIFF
--- a/ext/session/tests/session_set_save_handler_class_017.phpt
+++ b/ext/session/tests/session_set_save_handler_class_017.phpt
@@ -55,7 +55,7 @@ class MySession2 extends SessionHandler {
 	}
 
 	public function create_sid() {
-		return 'session_set_save_handler_class_017';
+		return pathinfo(__FILE__)['filename'];
 	}
 }
 

--- a/ext/session/tests/session_set_save_handler_class_017.phpt
+++ b/ext/session/tests/session_set_save_handler_class_017.phpt
@@ -55,7 +55,7 @@ class MySession2 extends SessionHandler {
 	}
 
 	public function create_sid() {
-		return 'my_sid';
+		return 'session_set_save_handler_class_017';
 	}
 }
 
@@ -75,9 +75,12 @@ var_dump($_SESSION);
 
 session_write_close();
 session_unset();
---EXPECTF--
+--CLEAN--
+<?php
+@unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_class_017');
+--EXPECT--
 *** Testing session_set_save_handler() function: class with create_sid ***
-string(%d) "my_sid"
+string(34) "session_set_save_handler_class_017"
 string(4) "user"
 array(1) {
   ["foo"]=>

--- a/ext/session/tests/session_set_save_handler_class_017.phpt
+++ b/ext/session/tests/session_set_save_handler_class_017.phpt
@@ -72,9 +72,6 @@ session_unset();
 
 session_start();
 var_dump($_SESSION);
-
-session_write_close();
-session_unset();
 --CLEAN--
 <?php
 @unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_class_017');

--- a/ext/session/tests/session_set_save_handler_class_018.phpt
+++ b/ext/session/tests/session_set_save_handler_class_018.phpt
@@ -76,9 +76,6 @@ session_unset();
 
 session_start();
 var_dump($_SESSION);
-
-session_write_close();
-session_unset();
 --CLEAN--
 <?php
 @unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_class_018');

--- a/ext/session/tests/session_set_save_handler_class_018.phpt
+++ b/ext/session/tests/session_set_save_handler_class_018.phpt
@@ -55,11 +55,11 @@ class MySession2 extends SessionHandler {
 	}
 
 	public function create_sid() {
-		return 'session_set_save_handler_class_018';
+		return pathinfo(__FILE__)['filename'];
 	}
 
 	public function validate_sid($id) {
-		return 'session_set_save_handler_class_018'===$id;
+		return pathinfo(__FILE__)['filename']===$id;
 	}
 }
 

--- a/ext/session/tests/session_set_save_handler_class_018.phpt
+++ b/ext/session/tests/session_set_save_handler_class_018.phpt
@@ -34,7 +34,7 @@ class MySession2 extends SessionHandler {
 	}
 
 	public function read($id) {
-		return @file_get_contents($this->path . $id);
+		return (string)@file_get_contents($this->path . $id);
 	}
 
 	public function write($id, $data) {
@@ -55,11 +55,11 @@ class MySession2 extends SessionHandler {
 	}
 
 	public function create_sid() {
-		return 'my_sid';
+		return 'session_set_save_handler_class_018';
 	}
 
 	public function validate_sid($id) {
-		return 'my_sid'===$id;
+		return 'session_set_save_handler_class_018'===$id;
 	}
 }
 
@@ -79,9 +79,12 @@ var_dump($_SESSION);
 
 session_write_close();
 session_unset();
---EXPECTF--
+--CLEAN--
+<?php
+@unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_class_018');
+--EXPECT--
 *** Testing session_set_save_handler() function: class with validate_sid ***
-string(%d) "my_sid"
+string(34) "session_set_save_handler_class_018"
 string(4) "user"
 array(1) {
   ["foo"]=>

--- a/ext/session/tests/session_set_save_handler_iface_003.phpt
+++ b/ext/session/tests/session_set_save_handler_iface_003.phpt
@@ -34,7 +34,7 @@ class MySession2 implements SessionHandlerInterface, SessionIdInterface {
 	}
 
 	public function read($id) {
-		return @file_get_contents($this->path . $id);
+		return (string)@file_get_contents($this->path . $id);
 	}
 
 	public function write($id, $data) {
@@ -56,7 +56,7 @@ class MySession2 implements SessionHandlerInterface, SessionIdInterface {
 	}
 
 	public function create_sid() {
-		return 'my_sid';
+		return 'session_set_save_handler_iface_003';
 	}
 }
 
@@ -76,9 +76,12 @@ var_dump($_SESSION);
 
 session_write_close();
 session_unset();
---EXPECTF--
+--CLEAN--
+<?php
+@unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_iface_003');
+--EXPECT--
 *** Testing session_set_save_handler() function: id interface ***
-string(%d) "my_sid"
+string(34) "session_set_save_handler_iface_003"
 string(4) "user"
 array(1) {
   ["foo"]=>

--- a/ext/session/tests/session_set_save_handler_iface_003.phpt
+++ b/ext/session/tests/session_set_save_handler_iface_003.phpt
@@ -56,7 +56,7 @@ class MySession2 implements SessionHandlerInterface, SessionIdInterface {
 	}
 
 	public function create_sid() {
-		return 'session_set_save_handler_iface_003';
+		return pathinfo(__FILE__)['filename'];
 	}
 }
 

--- a/ext/session/tests/session_set_save_handler_iface_003.phpt
+++ b/ext/session/tests/session_set_save_handler_iface_003.phpt
@@ -73,9 +73,6 @@ session_unset();
 
 session_start();
 var_dump($_SESSION);
-
-session_write_close();
-session_unset();
 --CLEAN--
 <?php
 @unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_iface_003');

--- a/ext/session/tests/session_set_save_handler_sid_001.phpt
+++ b/ext/session/tests/session_set_save_handler_sid_001.phpt
@@ -68,9 +68,6 @@ session_unset();
 
 session_start();
 var_dump($_SESSION);
-
-session_write_close();
-session_unset();
 --CLEAN--
 <?php
 @unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_sid_001');

--- a/ext/session/tests/session_set_save_handler_sid_001.phpt
+++ b/ext/session/tests/session_set_save_handler_sid_001.phpt
@@ -28,7 +28,7 @@ class MySession2 {
 	}
 
 	public function read($id) {
-		return @file_get_contents($this->path . $id);
+		return (string)@file_get_contents($this->path . $id);
 	}
 
 	public function write($id, $data) {
@@ -50,7 +50,7 @@ class MySession2 {
 	}
 
 	public function create_sid() {
-		return 'my_sid';
+		return 'session_set_save_handler_sid_001';
 	}
 }
 
@@ -71,9 +71,12 @@ var_dump($_SESSION);
 
 session_write_close();
 session_unset();
---EXPECTF--
+--CLEAN--
+<?php
+@unlink(session_save_path().'/u_sess_PHPSESSIDsession_set_save_handler_sid_001');
+--EXPECT--
 *** Testing session_set_save_handler() function: create_sid ***
-string(%d) "my_sid"
+string(32) "session_set_save_handler_sid_001"
 string(4) "user"
 array(1) {
   ["foo"]=>

--- a/ext/session/tests/session_set_save_handler_sid_001.phpt
+++ b/ext/session/tests/session_set_save_handler_sid_001.phpt
@@ -50,7 +50,7 @@ class MySession2 {
 	}
 
 	public function create_sid() {
-		return 'session_set_save_handler_sid_001';
+		return pathinfo(__FILE__)['filename'];
 	}
 }
 


### PR DESCRIPTION
https://dev.azure.com/phpazuredevops/PHP/_build/results?buildId=2579&view=ms.vss-test-web.build-test-results-tab
After @nikic pointed me out to this failing test I was wondering if the usage of `session_module_name('files')` could cause conflicts.