### PR TITLE
Change XMLWriter resources to objects

### DIFF
--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -74,35 +74,15 @@ static PHP_FUNCTION(xmlwriter_flush);
 
 static zend_class_entry *xmlwriter_class_entry_ce;
 
-static void xmlwriter_free_resource_ptr(xmlwriter_object *intern);
-static void xmlwriter_dtor(zend_resource *rsrc);
-
 typedef int (*xmlwriter_read_one_char_t)(xmlTextWriterPtr writer, const xmlChar *content);
 typedef int (*xmlwriter_read_int_t)(xmlTextWriterPtr writer);
 
-/* {{{ xmlwriter_object_free_storage */
-static void xmlwriter_free_resource_ptr(xmlwriter_object *intern)
-{
-	if (intern) {
-		if (intern->ptr) {
-			xmlFreeTextWriter(intern->ptr);
-			intern->ptr = NULL;
-		}
-		if (intern->output) {
-			xmlBufferFree(intern->output);
-			intern->output = NULL;
-		}
-		efree(intern);
-	}
-}
-/* }}} */
-
 /* {{{ XMLWRITER_FROM_OBJECT */
-#define XMLWRITER_FROM_OBJECT(intern, object) \
+#define XMLWRITER_FROM_OBJECT(ptr, object) \
 	{ \
 		ze_xmlwriter_object *obj = Z_XMLWRITER_P(object); \
-		intern = obj->xmlwriter_ptr; \
-		if (!intern) { \
+		ptr = obj->ptr; \
+		if (!ptr) { \
 			php_error_docref(NULL, E_WARNING, "Invalid or uninitialized XMLWriter object"); \
 			RETURN_FALSE; \
 		} \
@@ -118,10 +98,14 @@ static void xmlwriter_object_free_storage(zend_object *object)
 	if (!intern) {
 		return;
 	}
-	if (intern->xmlwriter_ptr) {
-		xmlwriter_free_resource_ptr(intern->xmlwriter_ptr);
+	if (intern->ptr) {
+		xmlFreeTextWriter(intern->ptr);
+		intern->ptr = NULL;
 	}
-	intern->xmlwriter_ptr = NULL;
+	if (intern->output) {
+		xmlBufferFree(intern->output);
+		intern->output = NULL;
+	}
 	zend_object_std_dtor(&intern->std);
 }
 /* }}} */
@@ -247,8 +231,6 @@ static const zend_function_entry xmlwriter_class_functions[] = {
 static PHP_MINIT_FUNCTION(xmlwriter);
 static PHP_MSHUTDOWN_FUNCTION(xmlwriter);
 static PHP_MINFO_FUNCTION(xmlwriter);
-
-static int le_xmlwriter;
 /* }}} */
 
 /* _xmlwriter_get_valid_file_path should be made a
@@ -351,19 +333,8 @@ static void xmlwriter_objects_clone(void *object, void **object_clone)
 }
 }}} */
 
-/* {{{ xmlwriter_dtor */
-static void xmlwriter_dtor(zend_resource *rsrc) {
-	xmlwriter_object *intern;
-
-	intern = (xmlwriter_object *) rsrc->ptr;
-	xmlwriter_free_resource_ptr(intern);
-}
-/* }}} */
-
 static void php_xmlwriter_string_arg(INTERNAL_FUNCTION_PARAMETERS, xmlwriter_read_one_char_t internal_function, char *err_string)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name;
 	size_t name_len;
@@ -375,22 +346,16 @@ static void php_xmlwriter_string_arg(INTERNAL_FUNCTION_PARAMETERS, xmlwriter_rea
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &pind, &name, &name_len) == FAILURE) {
-			return;
-		}
-
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &self, xmlwriter_class_entry_ce, &name, &name_len) == FAILURE) {
 			return;
 		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	if (err_string != NULL) {
 		XMLW_NAME_CHK(err_string);
 	}
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = internal_function(ptr, (xmlChar *) name);
@@ -404,27 +369,20 @@ static void php_xmlwriter_string_arg(INTERNAL_FUNCTION_PARAMETERS, xmlwriter_rea
 
 static void php_xmlwriter_end(INTERNAL_FUNCTION_PARAMETERS, xmlwriter_read_int_t internal_function)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	int retval;
 	zval *self = getThis();
 
 	if (self) {
-		XMLWRITER_FROM_OBJECT(intern, self);
 		if (zend_parse_parameters_none() == FAILURE) {
 			return;
 		}
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &pind) == FAILURE) {
-			return;
-		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &self, xmlwriter_class_entry_ce) == FAILURE) {
 			return;
 		}
 	}
-
-	ptr = intern->ptr;
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	if (ptr) {
 		retval = internal_function(ptr);
@@ -436,12 +394,10 @@ static void php_xmlwriter_end(INTERNAL_FUNCTION_PARAMETERS, xmlwriter_read_int_t
 	RETURN_FALSE;
 }
 
-/* {{{ proto bool xmlwriter_set_indent(resource xmlwriter, bool indent)
+/* {{{ proto bool xmlwriter_set_indent(XMLWriter xmlwriter, bool indent)
 Toggle indentation on/off - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_set_indent)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	int retval;
 	zend_bool indent;
@@ -452,18 +408,13 @@ static PHP_FUNCTION(xmlwriter_set_indent)
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &indent) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rb", &pind, &indent) == FAILURE) {
-			return;
-		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ob", &self, xmlwriter_class_entry_ce, &indent) == FAILURE) {
 			return;
 		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
-
-	ptr = intern->ptr;
 	if (ptr) {
 		retval = xmlTextWriterSetIndent(ptr, indent);
 		if (retval == 0) {
@@ -475,7 +426,7 @@ static PHP_FUNCTION(xmlwriter_set_indent)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_set_indent_string(resource xmlwriter, string indentString)
+/* {{{ proto bool xmlwriter_set_indent_string(XMLWriter xmlwriter, string indentString)
 Set string used for indenting - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_set_indent_string)
 {
@@ -483,7 +434,7 @@ static PHP_FUNCTION(xmlwriter_set_indent_string)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_attribute(resource xmlwriter, string name)
+/* {{{ proto bool xmlwriter_start_attribute(XMLWriter xmlwriter, string name)
 Create start attribute - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_attribute)
 {
@@ -491,7 +442,7 @@ static PHP_FUNCTION(xmlwriter_start_attribute)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_attribute(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_attribute(XMLWriter xmlwriter)
 End attribute - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_attribute)
 {
@@ -499,12 +450,10 @@ static PHP_FUNCTION(xmlwriter_end_attribute)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_attribute_ns(resource xmlwriter, string prefix, string name, string uri)
+/* {{{ proto bool xmlwriter_start_attribute_ns(XMLWriter xmlwriter, string prefix, string name, string uri)
 Create start namespaced attribute - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_attribute_ns)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *prefix, *uri;
 	size_t name_len, prefix_len, uri_len;
@@ -516,20 +465,15 @@ static PHP_FUNCTION(xmlwriter_start_attribute_ns)
 			&prefix, &prefix_len, &name, &name_len, &uri, &uri_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsss!", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Osss!", &self, xmlwriter_class_entry_ce,
 			&prefix, &prefix_len, &name, &name_len, &uri, &uri_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Attribute Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = xmlTextWriterStartAttributeNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri);
@@ -542,12 +486,10 @@ static PHP_FUNCTION(xmlwriter_start_attribute_ns)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_attribute(resource xmlwriter, string name, string content)
+/* {{{ proto bool xmlwriter_write_attribute(XMLWriter xmlwriter, string name, string content)
 Write full attribute - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_attribute)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *content;
 	size_t name_len, content_len;
@@ -559,20 +501,15 @@ static PHP_FUNCTION(xmlwriter_write_attribute)
 			&name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oss", &self, xmlwriter_class_entry_ce,
 			&name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Attribute Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = xmlTextWriterWriteAttribute(ptr, (xmlChar *)name, (xmlChar *)content);
@@ -585,12 +522,10 @@ static PHP_FUNCTION(xmlwriter_write_attribute)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_attribute_ns(resource xmlwriter, string prefix, string name, string uri, string content)
+/* {{{ proto bool xmlwriter_write_attribute_ns(XMLWriter xmlwriter, string prefix, string name, string uri, string content)
 Write full namespaced attribute - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_attribute_ns)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *prefix, *uri, *content;
 	size_t name_len, prefix_len, uri_len, content_len;
@@ -603,20 +538,15 @@ static PHP_FUNCTION(xmlwriter_write_attribute_ns)
 			&prefix, &prefix_len, &name, &name_len, &uri, &uri_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsss!s", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Osss!s", &self, xmlwriter_class_entry_ce,
 			&prefix, &prefix_len, &name, &name_len, &uri, &uri_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Attribute Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = xmlTextWriterWriteAttributeNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri, (xmlChar *)content);
@@ -629,7 +559,7 @@ static PHP_FUNCTION(xmlwriter_write_attribute_ns)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_element(resource xmlwriter, string name)
+/* {{{ proto bool xmlwriter_start_element(XMLWriter xmlwriter, string name)
 Create start element tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_element)
 {
@@ -637,12 +567,10 @@ static PHP_FUNCTION(xmlwriter_start_element)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_element_ns(resource xmlwriter, string prefix, string name, string uri)
+/* {{{ proto bool xmlwriter_start_element_ns(XMLWriter xmlwriter, string prefix, string name, string uri)
 Create start namespaced element tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_element_ns)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *prefix, *uri;
 	size_t name_len, prefix_len, uri_len;
@@ -654,20 +582,15 @@ static PHP_FUNCTION(xmlwriter_start_element_ns)
 			&prefix, &prefix_len, &name, &name_len, &uri, &uri_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs!ss!", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os!ss!", &self, xmlwriter_class_entry_ce,
 			&prefix, &prefix_len, &name, &name_len, &uri, &uri_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Element Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = xmlTextWriterStartElementNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri);
@@ -681,7 +604,7 @@ static PHP_FUNCTION(xmlwriter_start_element_ns)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_element(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_element(XMLWriter xmlwriter)
 End current element - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_element)
 {
@@ -689,7 +612,7 @@ static PHP_FUNCTION(xmlwriter_end_element)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_full_end_element(resource xmlwriter)
+/* {{{ proto bool xmlwriter_full_end_element(XMLWriter xmlwriter)
 End current element - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_full_end_element)
 {
@@ -697,12 +620,10 @@ static PHP_FUNCTION(xmlwriter_full_end_element)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_element(resource xmlwriter, string name[, string content])
+/* {{{ proto bool xmlwriter_write_element(XMLWriter xmlwriter, string name[, string content])
 Write full element tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_element)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *content = NULL;
 	size_t name_len, content_len;
@@ -714,20 +635,15 @@ static PHP_FUNCTION(xmlwriter_write_element)
 			&name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs|s!", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os|s!", &self, xmlwriter_class_entry_ce,
 			&name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Element Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		if (!content) {
@@ -751,12 +667,10 @@ static PHP_FUNCTION(xmlwriter_write_element)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_element_ns(resource xmlwriter, string prefix, string name, string uri[, string content])
+/* {{{ proto bool xmlwriter_write_element_ns(XMLWriter xmlwriter, string prefix, string name, string uri[, string content])
 Write full namesapced element tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_element_ns)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *prefix, *uri, *content = NULL;
 	size_t name_len, prefix_len, uri_len, content_len;
@@ -768,20 +682,15 @@ static PHP_FUNCTION(xmlwriter_write_element_ns)
 			&prefix, &prefix_len, &name, &name_len, &uri, &uri_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs!ss!|s!", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os!ss!|s!", &self, xmlwriter_class_entry_ce,
 			&prefix, &prefix_len, &name, &name_len, &uri, &uri_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Element Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		if (!content) {
@@ -805,7 +714,7 @@ static PHP_FUNCTION(xmlwriter_write_element_ns)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_pi(resource xmlwriter, string target)
+/* {{{ proto bool xmlwriter_start_pi(XMLWriter xmlwriter, string target)
 Create start PI tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_pi)
 {
@@ -813,7 +722,7 @@ static PHP_FUNCTION(xmlwriter_start_pi)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_pi(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_pi(XMLWriter xmlwriter)
 End current PI - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_pi)
 {
@@ -821,12 +730,10 @@ static PHP_FUNCTION(xmlwriter_end_pi)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_pi(resource xmlwriter, string target, string content)
+/* {{{ proto bool xmlwriter_write_pi(XMLWriter xmlwriter, string target, string content)
 Write full PI tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_pi)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *content;
 	size_t name_len, content_len;
@@ -839,20 +746,15 @@ static PHP_FUNCTION(xmlwriter_write_pi)
 			&name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oss", &self, xmlwriter_class_entry_ce,
 			&name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid PI Target");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = xmlTextWriterWritePI(ptr, (xmlChar *)name, (xmlChar *)content);
@@ -865,12 +767,10 @@ static PHP_FUNCTION(xmlwriter_write_pi)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_cdata(resource xmlwriter)
+/* {{{ proto bool xmlwriter_start_cdata(XMLWriter xmlwriter)
 Create start CDATA tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_cdata)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	int retval;
 	zval *self = getThis();
@@ -879,17 +779,12 @@ static PHP_FUNCTION(xmlwriter_start_cdata)
 		if (zend_parse_parameters_none() == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &pind) == FAILURE) {
-			return;
-		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &self, xmlwriter_class_entry_ce) == FAILURE) {
 			return;
 		}
 	}
-
-	ptr = intern->ptr;
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	if (ptr) {
 		retval = xmlTextWriterStartCDATA(ptr);
@@ -902,7 +797,7 @@ static PHP_FUNCTION(xmlwriter_start_cdata)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_cdata(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_cdata(XMLWriter xmlwriter)
 End current CDATA - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_cdata)
 {
@@ -910,7 +805,7 @@ static PHP_FUNCTION(xmlwriter_end_cdata)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_cdata(resource xmlwriter, string content)
+/* {{{ proto bool xmlwriter_write_cdata(XMLWriter xmlwriter, string content)
 Write full CDATA tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_cdata)
 {
@@ -918,7 +813,7 @@ static PHP_FUNCTION(xmlwriter_write_cdata)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_raw(resource xmlwriter, string content)
+/* {{{ proto bool xmlwriter_write_raw(XMLWriter xmlwriter, string content)
 Write text - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_raw)
 {
@@ -926,7 +821,7 @@ static PHP_FUNCTION(xmlwriter_write_raw)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_text(resource xmlwriter, string content)
+/* {{{ proto bool xmlwriter_text(XMLWriter xmlwriter, string content)
 Write text - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_text)
 {
@@ -934,12 +829,10 @@ static PHP_FUNCTION(xmlwriter_text)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_comment(resource xmlwriter)
+/* {{{ proto bool xmlwriter_start_comment(XMLWriter xmlwriter)
 Create start comment - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_comment)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	int retval;
 	zval *self = getThis();
@@ -948,17 +841,12 @@ static PHP_FUNCTION(xmlwriter_start_comment)
 		if (zend_parse_parameters_none() == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &pind) == FAILURE) {
-			return;
-		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &self, xmlwriter_class_entry_ce) == FAILURE) {
 			return;
 		}
 	}
-
-	ptr = intern->ptr;
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	if (ptr) {
 		retval = xmlTextWriterStartComment(ptr);
@@ -971,7 +859,7 @@ static PHP_FUNCTION(xmlwriter_start_comment)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_comment(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_comment(XMLWriter xmlwriter)
 Create end comment - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_comment)
 {
@@ -979,7 +867,7 @@ static PHP_FUNCTION(xmlwriter_end_comment)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_comment(resource xmlwriter, string content)
+/* {{{ proto bool xmlwriter_write_comment(XMLWriter xmlwriter, string content)
 Write full comment tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_comment)
 {
@@ -987,12 +875,10 @@ static PHP_FUNCTION(xmlwriter_write_comment)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_document(resource xmlwriter, string version, string encoding, string standalone)
+/* {{{ proto bool xmlwriter_start_document(XMLWriter xmlwriter, string version, string encoding, string standalone)
 Create document tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_document)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *version = NULL, *enc = NULL, *alone = NULL;
 	size_t version_len, enc_len, alone_len;
@@ -1004,17 +890,12 @@ static PHP_FUNCTION(xmlwriter_start_document)
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!s!s!", &version, &version_len, &enc, &enc_len, &alone, &alone_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|s!s!s!", &pind, &version, &version_len, &enc, &enc_len, &alone, &alone_len) == FAILURE) {
-			return;
-		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|s!s!s!", &self, xmlwriter_class_entry_ce, &version, &version_len, &enc, &enc_len, &alone, &alone_len) == FAILURE) {
 			return;
 		}
 	}
-
-	ptr = intern->ptr;
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	if (ptr) {
 		retval = xmlTextWriterStartDocument(ptr, version, enc, alone);
@@ -1027,7 +908,7 @@ static PHP_FUNCTION(xmlwriter_start_document)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_document(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_document(XMLWriter xmlwriter)
 End current document - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_document)
 {
@@ -1035,12 +916,10 @@ static PHP_FUNCTION(xmlwriter_end_document)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_dtd(resource xmlwriter, string name, string pubid, string sysid)
+/* {{{ proto bool xmlwriter_start_dtd(XMLWriter xmlwriter, string name, string pubid, string sysid)
 Create start DTD tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_dtd)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *pubid = NULL, *sysid = NULL;
 	size_t name_len, pubid_len, sysid_len;
@@ -1051,17 +930,12 @@ static PHP_FUNCTION(xmlwriter_start_dtd)
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s!s!", &name, &name_len, &pubid, &pubid_len, &sysid, &sysid_len) == FAILURE) {
 			return;
 		}
-
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs|s!s!", &pind, &name, &name_len, &pubid, &pubid_len, &sysid, &sysid_len) == FAILURE) {
-			return;
-		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os|s!s!", &self, xmlwriter_class_entry_ce, &name, &name_len, &pubid, &pubid_len, &sysid, &sysid_len) == FAILURE) {
 			return;
 		}
 	}
-	ptr = intern->ptr;
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	if (ptr) {
 		retval = xmlTextWriterStartDTD(ptr, (xmlChar *)name, (xmlChar *)pubid, (xmlChar *)sysid);
@@ -1074,7 +948,7 @@ static PHP_FUNCTION(xmlwriter_start_dtd)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_dtd(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_dtd(XMLWriter xmlwriter)
 End current DTD - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_dtd)
 {
@@ -1082,12 +956,10 @@ static PHP_FUNCTION(xmlwriter_end_dtd)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_dtd(resource xmlwriter, string name, string pubid, string sysid, string subset)
+/* {{{ proto bool xmlwriter_write_dtd(XMLWriter xmlwriter, string name, string pubid, string sysid, string subset)
 Write full DTD tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_dtd)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *pubid = NULL, *sysid = NULL, *subset = NULL;
 	size_t name_len, pubid_len, sysid_len, subset_len;
@@ -1098,19 +970,12 @@ static PHP_FUNCTION(xmlwriter_write_dtd)
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s!s!s!", &name, &name_len, &pubid, &pubid_len, &sysid, &sysid_len, &subset, &subset_len) == FAILURE) {
 			return;
 		}
-
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs|s!s!s!", &pind, &name, &name_len, &pubid, &pubid_len, &sysid, &sysid_len, &subset, &subset_len) == FAILURE) {
-			return;
-		}
-
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os|s!s!s!", &self, xmlwriter_class_entry_ce, &name, &name_len, &pubid, &pubid_len, &sysid, &sysid_len, &subset, &subset_len) == FAILURE) {
 			return;
 		}
 	}
-
-	ptr = intern->ptr;
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	if (ptr) {
 		retval = xmlTextWriterWriteDTD(ptr, (xmlChar *)name, (xmlChar *)pubid, (xmlChar *)sysid, (xmlChar *)subset);
@@ -1123,7 +988,7 @@ static PHP_FUNCTION(xmlwriter_write_dtd)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_dtd_element(resource xmlwriter, string name)
+/* {{{ proto bool xmlwriter_start_dtd_element(XMLWriter xmlwriter, string name)
 Create start DTD element - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_dtd_element)
 {
@@ -1131,7 +996,7 @@ static PHP_FUNCTION(xmlwriter_start_dtd_element)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_dtd_element(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_dtd_element(XMLWriter xmlwriter)
 End current DTD element - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_dtd_element)
 {
@@ -1139,12 +1004,10 @@ static PHP_FUNCTION(xmlwriter_end_dtd_element)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_dtd_element(resource xmlwriter, string name, string content)
+/* {{{ proto bool xmlwriter_write_dtd_element(XMLWriter xmlwriter, string name, string content)
 Write full DTD element tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_dtd_element)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *content;
 	size_t name_len, content_len;
@@ -1155,20 +1018,15 @@ static PHP_FUNCTION(xmlwriter_write_dtd_element)
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oss", &self, xmlwriter_class_entry_ce,
 			&name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Element Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = xmlTextWriterWriteDTDElement(ptr, (xmlChar *)name, (xmlChar *)content);
@@ -1181,7 +1039,7 @@ static PHP_FUNCTION(xmlwriter_write_dtd_element)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_dtd_attlist(resource xmlwriter, string name)
+/* {{{ proto bool xmlwriter_start_dtd_attlist(XMLWriter xmlwriter, string name)
 Create start DTD AttList - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_dtd_attlist)
 {
@@ -1189,7 +1047,7 @@ static PHP_FUNCTION(xmlwriter_start_dtd_attlist)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_dtd_attlist(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_dtd_attlist(XMLWriter xmlwriter)
 End current DTD AttList - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_dtd_attlist)
 {
@@ -1197,12 +1055,10 @@ static PHP_FUNCTION(xmlwriter_end_dtd_attlist)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_dtd_attlist(resource xmlwriter, string name, string content)
+/* {{{ proto bool xmlwriter_write_dtd_attlist(XMLWriter xmlwriter, string name, string content)
 Write full DTD AttList tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_dtd_attlist)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *content;
 	size_t name_len, content_len;
@@ -1214,20 +1070,15 @@ static PHP_FUNCTION(xmlwriter_write_dtd_attlist)
 			&name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oss", &self, xmlwriter_class_entry_ce,
 			&name, &name_len, &content, &content_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Element Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = xmlTextWriterWriteDTDAttlist(ptr, (xmlChar *)name, (xmlChar *)content);
@@ -1240,12 +1091,10 @@ static PHP_FUNCTION(xmlwriter_write_dtd_attlist)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_start_dtd_entity(resource xmlwriter, string name, bool isparam)
+/* {{{ proto bool xmlwriter_start_dtd_entity(XMLWriter xmlwriter, string name, bool isparam)
 Create start DTD Entity - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_start_dtd_entity)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name;
 	size_t name_len;
@@ -1257,19 +1106,14 @@ static PHP_FUNCTION(xmlwriter_start_dtd_entity)
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "sb", &name, &name_len, &isparm) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsb", &pind, &name, &name_len, &isparm) == FAILURE) {
-			return;
-		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Osb", &self, xmlwriter_class_entry_ce, &name, &name_len, &isparm) == FAILURE) {
 			return;
 		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Attribute Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = xmlTextWriterStartDTDEntity(ptr, isparm, (xmlChar *)name);
@@ -1282,7 +1126,7 @@ static PHP_FUNCTION(xmlwriter_start_dtd_entity)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_end_dtd_entity(resource xmlwriter)
+/* {{{ proto bool xmlwriter_end_dtd_entity(XMLWriter xmlwriter)
 End current DTD Entity - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_end_dtd_entity)
 {
@@ -1290,12 +1134,10 @@ static PHP_FUNCTION(xmlwriter_end_dtd_entity)
 }
 /* }}} */
 
-/* {{{ proto bool xmlwriter_write_dtd_entity(resource xmlwriter, string name, string content [, bool pe [, string pubid [, string sysid [, string ndataid]]]])
+/* {{{ proto bool xmlwriter_write_dtd_entity(XMLWriter xmlwriter, string name, string content [, bool pe [, string pubid [, string sysid [, string ndataid]]]])
 Write full DTD Entity tag - returns FALSE on error */
 static PHP_FUNCTION(xmlwriter_write_dtd_entity)
 {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *name, *content;
 	size_t name_len, content_len;
@@ -1312,21 +1154,16 @@ static PHP_FUNCTION(xmlwriter_write_dtd_entity)
 			&sysid, &sysid_len, &ndataid, &ndataid_len) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss|bsss", &pind,
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oss|bsss", &self, xmlwriter_class_entry_ce,
 			&name, &name_len, &content, &content_len, &pe, &pubid, &pubid_len,
 			&sysid, &sysid_len, &ndataid, &ndataid_len) == FAILURE) {
 			return;
 		}
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
-			return;
-		}
 	}
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	XMLW_NAME_CHK("Invalid Element Name");
-
-	ptr = intern->ptr;
 
 	if (ptr) {
 		retval = xmlTextWriterWriteDTDEntity(ptr, pe, (xmlChar *)name, (xmlChar *)pubid, (xmlChar *)sysid, (xmlChar *)ndataid, (xmlChar *)content);
@@ -1339,12 +1176,11 @@ static PHP_FUNCTION(xmlwriter_write_dtd_entity)
 }
 /* }}} */
 
-/* {{{ proto resource xmlwriter_open_uri(string source)
+/* {{{ proto XMLWriter xmlwriter_open_uri(string source)
 Create new xmlwriter using source uri for output */
 static PHP_FUNCTION(xmlwriter_open_uri)
 {
 	char *valid_file = NULL;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	char *source;
 	char resolved_path[MAXPATHLEN + 1];
@@ -1378,26 +1214,29 @@ static PHP_FUNCTION(xmlwriter_open_uri)
 		RETURN_FALSE;
 	}
 
-	intern = emalloc(sizeof(xmlwriter_object));
-	intern->ptr = ptr;
-	intern->output = NULL;
 	if (self) {
-		if (ze_obj->xmlwriter_ptr) {
-			xmlwriter_free_resource_ptr(ze_obj->xmlwriter_ptr);
+		if (ze_obj->ptr) {
+			xmlFreeTextWriter(ze_obj->ptr);
 		}
-		ze_obj->xmlwriter_ptr = intern;
+		if (ze_obj->output) {
+			xmlBufferFree(ze_obj->output);
+		}
+		ze_obj->ptr = ptr;
+		ze_obj->output = NULL;
 		RETURN_TRUE;
 	} else {
-		RETURN_RES(zend_register_resource(intern, le_xmlwriter));
+		ze_obj = php_xmlwriter_fetch_object(xmlwriter_object_new(xmlwriter_class_entry_ce));
+		ze_obj->ptr = ptr;
+		ze_obj->output = NULL;
+		RETURN_OBJ(&ze_obj->std);
 	}
 }
 /* }}} */
 
-/* {{{ proto resource xmlwriter_open_memory()
+/* {{{ proto XMLWriter xmlwriter_open_memory()
 Create new xmlwriter using memory for string output */
 static PHP_FUNCTION(xmlwriter_open_memory)
 {
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	xmlBufferPtr buffer;
 	zval *self = getThis();
@@ -1425,17 +1264,21 @@ static PHP_FUNCTION(xmlwriter_open_memory)
 		RETURN_FALSE;
 	}
 
-	intern = emalloc(sizeof(xmlwriter_object));
-	intern->ptr = ptr;
-	intern->output = buffer;
 	if (self) {
-		if (ze_obj->xmlwriter_ptr) {
-			xmlwriter_free_resource_ptr(ze_obj->xmlwriter_ptr);
+		if (ze_obj->ptr) {
+			xmlFreeTextWriter(ze_obj->ptr);
 		}
-		ze_obj->xmlwriter_ptr = intern;
+		if (ze_obj->output) {
+			xmlBufferFree(ze_obj->output);
+		}
+		ze_obj->ptr = ptr;
+		ze_obj->output = buffer;
 		RETURN_TRUE;
 	} else {
-		RETURN_RES(zend_register_resource(intern, le_xmlwriter));
+		ze_obj = php_xmlwriter_fetch_object(xmlwriter_object_new(xmlwriter_class_entry_ce));
+		ze_obj->ptr = ptr;
+		ze_obj->output = buffer;
+		RETURN_OBJ(&ze_obj->std);
 	}
 
 }
@@ -1443,8 +1286,6 @@ static PHP_FUNCTION(xmlwriter_open_memory)
 
 /* {{{ php_xmlwriter_flush */
 static void php_xmlwriter_flush(INTERNAL_FUNCTION_PARAMETERS, int force_string) {
-	zval *pind;
-	xmlwriter_object *intern;
 	xmlTextWriterPtr ptr;
 	xmlBufferPtr buffer;
 	zend_bool empty = 1;
@@ -1455,20 +1296,15 @@ static void php_xmlwriter_flush(INTERNAL_FUNCTION_PARAMETERS, int force_string) 
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &empty) == FAILURE) {
 			return;
 		}
-		XMLWRITER_FROM_OBJECT(intern, self);
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|b", &pind, &empty) == FAILURE) {
-			return;
-		}
-
-		if ((intern = (xmlwriter_object *)zend_fetch_resource(Z_RES_P(pind), "XMLWriter", le_xmlwriter)) == NULL) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|b", &self, xmlwriter_class_entry_ce, &empty) == FAILURE) {
 			return;
 		}
 	}
-	ptr = intern->ptr;
+	XMLWRITER_FROM_OBJECT(ptr, self);
 
 	if (ptr) {
-		buffer = intern->output;
+		buffer = Z_XMLWRITER_P(self)->output;
 		if (force_string == 1 && buffer == NULL) {
 			RETURN_EMPTY_STRING();
 		}
@@ -1488,7 +1324,7 @@ static void php_xmlwriter_flush(INTERNAL_FUNCTION_PARAMETERS, int force_string) 
 }
 /* }}} */
 
-/* {{{ proto string xmlwriter_output_memory(resource xmlwriter [,bool flush])
+/* {{{ proto string xmlwriter_output_memory(XMLWriter xmlwriter [,bool flush])
 Output current buffer as string */
 static PHP_FUNCTION(xmlwriter_output_memory)
 {
@@ -1496,7 +1332,7 @@ static PHP_FUNCTION(xmlwriter_output_memory)
 }
 /* }}} */
 
-/* {{{ proto mixed xmlwriter_flush(resource xmlwriter [,bool empty])
+/* {{{ proto mixed xmlwriter_flush(XMLWriter xmlwriter [,bool empty])
 Output current buffer */
 static PHP_FUNCTION(xmlwriter_flush)
 {
@@ -1509,7 +1345,6 @@ static PHP_FUNCTION(xmlwriter_flush)
 static PHP_MINIT_FUNCTION(xmlwriter)
 {
 	zend_class_entry ce;
-	le_xmlwriter = zend_register_list_destructors_ex(xmlwriter_dtor, NULL, "xmlwriter", module_number);
 
 	memcpy(&xmlwriter_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	xmlwriter_object_handlers.offset = XtOffsetOf(ze_xmlwriter_object, std);

--- a/ext/xmlwriter/php_xmlwriter.h
+++ b/ext/xmlwriter/php_xmlwriter.h
@@ -34,16 +34,10 @@ extern zend_module_entry xmlwriter_module_entry;
 #include <libxml/xmlwriter.h>
 #include <libxml/uri.h>
 
-/* Resource struct, not the object :) */
-typedef struct _xmlwriter_object {
-	xmlTextWriterPtr ptr;
-	xmlBufferPtr output;
-} xmlwriter_object;
-
-
 /* Extends zend object */
 typedef struct _ze_xmlwriter_object {
-	xmlwriter_object *xmlwriter_ptr;
+	xmlTextWriterPtr ptr;
+	xmlBufferPtr output;
 	zend_object std;
 } ze_xmlwriter_object;
 

--- a/ext/xmlwriter/xmlwriter.stub.php
+++ b/ext/xmlwriter/xmlwriter.stub.php
@@ -1,133 +1,91 @@
 <?php
 
-/** @return resource|false */
+/** @return XMLWriter|false */
 function xmlwriter_open_uri(string $uri) {}
 
-/** @return resource|false */
+/** @return XMLWriter|false */
 function xmlwriter_open_memory() {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_set_indent($xmlwriter, bool $indent): bool {}
+function xmlwriter_set_indent(XMLWriter $xmlwriter, bool $indent): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_set_indent_string($xmlwriter, string $indentString): bool {}
+function xmlwriter_set_indent_string(XMLWriter $xmlwriter, string $indentString): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_comment($xmlwriter): bool {}
+function xmlwriter_start_comment(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_comment($xmlwriter): bool {}
+function xmlwriter_end_comment(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_attribute($xmlwriter, string $name): bool {}
+function xmlwriter_start_attribute(XMLWriter $xmlwriter, string $name): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_attribute($xmlwriter): bool {}
+function xmlwriter_end_attribute(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_attribute($xmlwriter, string $name, string $value): bool {}
+function xmlwriter_write_attribute(XMLWriter $xmlwriter, string $name, string $value): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_attribute_ns($xmlwriter, string $prefix, string $name, ?string $uri): bool {}
+function xmlwriter_start_attribute_ns(XMLWriter $xmlwriter, string $prefix, string $name, ?string $uri): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_attribute_ns($xmlwriter, string $prefix, string $name, ?string $uri, string $content): bool {}
+function xmlwriter_write_attribute_ns(XMLWriter $xmlwriter, string $prefix, string $name, ?string $uri, string $content): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_element($xmlwriter, string $name): bool {}
+function xmlwriter_start_element(XMLWriter $xmlwriter, string $name): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_element($xmlwriter): bool {}
+function xmlwriter_end_element(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_full_end_element($xmlwriter): bool {}
+function xmlwriter_full_end_element(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_element_ns($xmlwriter, ?string $prefix, string $name, ?string $uri): bool {}
+function xmlwriter_start_element_ns(XMLWriter $xmlwriter, ?string $prefix, string $name, ?string $uri): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_element($xmlwriter, string $name, ?string $content = null): bool {}
+function xmlwriter_write_element(XMLWriter $xmlwriter, string $name, ?string $content = null): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_element_ns($xmlwriter, ?string $prefix, string $name, ?string $uri, ?string $content = null): bool {}
+function xmlwriter_write_element_ns(XMLWriter $xmlwriter, ?string $prefix, string $name, ?string $uri, ?string $content = null): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_pi($xmlwriter, string $target): bool {}
+function xmlwriter_start_pi(XMLWriter $xmlwriter, string $target): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_pi($xmlwriter): bool {}
+function xmlwriter_end_pi(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_pi($xmlwriter, string $target, string $content): bool {}
+function xmlwriter_write_pi(XMLWriter $xmlwriter, string $target, string $content): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_cdata($xmlwriter): bool {}
+function xmlwriter_start_cdata(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_cdata($xmlwriter): bool {}
+function xmlwriter_end_cdata(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_cdata($xmlwriter, string $content): bool {}
+function xmlwriter_write_cdata(XMLWriter $xmlwriter, string $content): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_text($xmlwriter, string $content): bool {}
+function xmlwriter_text(XMLWriter $xmlwriter, string $content): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_raw($xmlwriter, string $content): bool {}
+function xmlwriter_write_raw(XMLWriter $xmlwriter, string $content): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_document($xmlwriter, ?string $version = '1.0', ?string $encoding = null, ?string $standalone = null) {}
+function xmlwriter_start_document(XMLWriter $xmlwriter, ?string $version = '1.0', ?string $encoding = null, ?string $standalone = null) {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_document($xmlwriter): bool {}
+function xmlwriter_end_document(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_comment($xmlwriter, string $content): bool {}
+function xmlwriter_write_comment(XMLWriter $xmlwriter, string $content): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_dtd($xmlwriter, string $qualifiedName, ?string $publicId = null, ?string $systemId = null): bool {}
+function xmlwriter_start_dtd(XMLWriter $xmlwriter, string $qualifiedName, ?string $publicId = null, ?string $systemId = null): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_dtd($xmlwriter): bool {}
+function xmlwriter_end_dtd(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_dtd($xmlwriter, string $name, ?string $publicId = null, ?string $systemId = null, ?string $subset = null): bool {}
+function xmlwriter_write_dtd(XMLWriter $xmlwriter, string $name, ?string $publicId = null, ?string $systemId = null, ?string $subset = null): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_dtd_element($xmlwriter, string $qualifiedName): bool {}
+function xmlwriter_start_dtd_element(XMLWriter $xmlwriter, string $qualifiedName): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_dtd_element($xmlwriter): bool {}
+function xmlwriter_end_dtd_element(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_dtd_element($xmlwriter, string $name, string $content): bool {}
+function xmlwriter_write_dtd_element(XMLWriter $xmlwriter, string $name, string $content): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_dtd_attlist($xmlwriter, string $name): bool {}
+function xmlwriter_start_dtd_attlist(XMLWriter $xmlwriter, string $name): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_dtd_attlist($xmlwriter): bool {}
+function xmlwriter_end_dtd_attlist(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_dtd_attlist($xmlwriter, string $name, string $content): bool {}
+function xmlwriter_write_dtd_attlist(XMLWriter $xmlwriter, string $name, string $content): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_start_dtd_entity($xmlwriter, string $name, bool $isparam): bool {}
+function xmlwriter_start_dtd_entity(XMLWriter $xmlwriter, string $name, bool $isparam): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_end_dtd_entity($xmlwriter): bool {}
+function xmlwriter_end_dtd_entity(XMLWriter $xmlwriter): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_write_dtd_entity($xmlwriter, string $name, string $content, bool $isparam, string $publicId = UNKNOWN, string $systemId = UNKNOWN, string $ndataid = UNKNOWN): bool {}
+function xmlwriter_write_dtd_entity(XMLWriter $xmlwriter, string $name, string $content, bool $isparam, string $publicId = UNKNOWN, string $systemId = UNKNOWN, string $ndataid = UNKNOWN): bool {}
 
-/** @param resource $xmlwriter */
-function xmlwriter_output_memory($xmlwriter, bool $flush = true): string {}
+function xmlwriter_output_memory(XMLWriter $xmlwriter, bool $flush = true): string {}
 
-/**
- * @param resource $xmlwriter
- * @return string|int
- */
-function xmlwriter_flush($xmlwriter, bool $empty = true) {}
+/** @return string|int */
+function xmlwriter_flush(XMLWriter $xmlwriter, bool $empty = true) {}
 
 class XMLWriter
 {

--- a/ext/xmlwriter/xmlwriter_arginfo.h
+++ b/ext/xmlwriter/xmlwriter_arginfo.h
@@ -8,43 +8,43 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_xmlwriter_open_memory, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_set_indent, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, indent, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_set_indent_string, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, indentString, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_comment, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_xmlwriter_end_comment arginfo_xmlwriter_start_comment
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_attribute, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_xmlwriter_end_attribute arginfo_xmlwriter_start_comment
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_attribute, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_attribute_ns, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_attribute_ns, 0, 5, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
@@ -58,20 +58,20 @@ ZEND_END_ARG_INFO()
 #define arginfo_xmlwriter_full_end_element arginfo_xmlwriter_start_comment
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_element_ns, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_element, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_element_ns, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
@@ -79,14 +79,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_element_ns, 0, 4
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_pi, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_xmlwriter_end_pi arginfo_xmlwriter_start_comment
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_pi, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -96,7 +96,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_xmlwriter_end_cdata arginfo_xmlwriter_start_comment
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_cdata, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -105,7 +105,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_xmlwriter_write_raw arginfo_xmlwriter_write_cdata
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_xmlwriter_start_document, 0, 0, 1)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, version, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, encoding, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, standalone, IS_STRING, 1)
@@ -116,7 +116,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_xmlwriter_write_comment arginfo_xmlwriter_write_cdata
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_dtd, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, publicId, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, systemId, IS_STRING, 1)
@@ -125,7 +125,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_xmlwriter_end_dtd arginfo_xmlwriter_start_comment
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_dtd, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, publicId, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, systemId, IS_STRING, 1)
@@ -133,14 +133,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_dtd, 0, 2, _IS_B
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_dtd_element, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_xmlwriter_end_dtd_element arginfo_xmlwriter_start_comment
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_dtd_element, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -152,7 +152,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_xmlwriter_write_dtd_attlist arginfo_xmlwriter_write_dtd_element
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_dtd_entity, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, isparam, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
@@ -160,7 +160,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_xmlwriter_end_dtd_entity arginfo_xmlwriter_start_comment
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_dtd_entity, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, isparam, _IS_BOOL, 0)
@@ -170,12 +170,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_dtd_entity, 0, 4
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_output_memory, 0, 1, IS_STRING, 0)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, flush, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_xmlwriter_flush, 0, 0, 1)
-	ZEND_ARG_INFO(0, xmlwriter)
+	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
 	ZEND_ARG_TYPE_INFO(0, empty, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
While we generally prefer objects over resources for quite a while, the
procedural XMLWriter API still uses resources, although there is
already an object-oriented API which uses objects.  This dichotomy
makes no sense, slightly complicates the implementation, and doesn't
allow a stepwise migration to the object-oriented API, which might be
desired.  Thus we completely drop the XMLWriter resources in favor of
XMLWriter objects.

We consider the minor BC break acceptable for a major version, since
only explicit type checks (`is_resource()`, `gettype()` etc.) need to
be adapted.