### PR TITLE
Fix #78543: is_callable() on FFI\CData throws Exception

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3411,12 +3411,17 @@ check_func:
 			}
 			return 0;
 		case IS_OBJECT:
-			if (Z_OBJ_HANDLER_P(callable, get_closure) && Z_OBJ_HANDLER_P(callable, get_closure)(callable, &fcc->calling_scope, &fcc->function_handler, &fcc->object) == SUCCESS) {
-				fcc->called_scope = fcc->calling_scope;
-				if (fcc == &fcc_local) {
-					zend_release_fcall_info_cache(fcc);
+			if (Z_OBJ_HANDLER_P(callable, get_closure)) {
+				if (Z_OBJ_HANDLER_P(callable, get_closure)(callable, &fcc->calling_scope, &fcc->function_handler, &fcc->object) == SUCCESS) {
+					fcc->called_scope = fcc->calling_scope;
+					if (fcc == &fcc_local) {
+						zend_release_fcall_info_cache(fcc);
+					}
+					return 1;
+				} else {
+					/* Discard exceptions thrown from Z_OBJ_HANDLER_P(callable, get_closure) */
+					zend_clear_exception();
 				}
-				return 1;
 			}
 			if (error) *error = estrdup("no array or string given");
 			return 0;

--- a/ext/ffi/tests/bug78543.phpt
+++ b/ext/ffi/tests/bug78543.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #78543 (is_callable() on FFI\CData throws Exception)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$ffi = FFI::cdef(' struct test { int dummy; }; ');
+$test = $ffi->new('struct test');
+var_dump(is_callable($test));
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
If `Z_OBJ_HANDLER_P(callable, get_closure)` throws, we must not let the
exeception pass to userland, if called through `is_callable()`.