### PR TITLE
Fix typo

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2925,7 +2925,7 @@ static int php_date_initialize_from_hash(php_date_obj **dateobj, HashTable *myht
 	timelib_tzinfo   *tzi;
 	php_timezone_obj *tzobj;
 
-	z_date = zend_hash_str_find(myht, "date", sizeof("data")-1);
+	z_date = zend_hash_str_find(myht, "date", sizeof("date")-1);
 	if (z_date && Z_TYPE_P(z_date) == IS_STRING) {
 		z_timezone_type = zend_hash_str_find(myht, "timezone_type", sizeof("timezone_type")-1);
 		if (z_timezone_type && Z_TYPE_P(z_timezone_type) == IS_LONG) {


### PR DESCRIPTION
`sizeof("data")-1` and `sizeof("date")-1` are both 4, so no change in behaviour