### PR TITLE
Don't make argument nullable based on AST null initializer

### DIFF
--- a/Zend/tests/bug68446.phpt
+++ b/Zend/tests/bug68446.phpt
@@ -9,7 +9,7 @@ function a(array $a = FOO) {
 	var_dump($a);
 }
 
-function b(array $b = BAR) {
+function b(?array $b = BAR) {
 	var_dump($b);
 }
 

--- a/Zend/tests/type_declarations/scalar_constant_defaults.phpt
+++ b/Zend/tests/type_declarations/scalar_constant_defaults.phpt
@@ -39,6 +39,10 @@ function int_val_default_null(int $a = NULL_VAL) {
 	return $a;
 }
 
+function nullable_int_val_default_null(?int $a = NULL_VAL) {
+	return $a;
+}
+
 echo "Testing int val" . PHP_EOL;
 var_dump(int_val());
 
@@ -58,13 +62,27 @@ echo "Testing string add val" . PHP_EOL;
 var_dump(string_add_val());
 
 echo "Testing int with default null constant" . PHP_EOL;
-var_dump(int_val_default_null());
+try {
+    var_dump(int_val_default_null());
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
 
 echo "Testing int with null null constant" . PHP_EOL;
-var_dump(int_val_default_null(null));
+try {
+    var_dump(int_val_default_null(null));
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "Testing nullable int with default null constant" . PHP_EOL;
+var_dump(nullable_int_val_default_null());
+
+echo "Testing nullable int with null null constant" . PHP_EOL;
+var_dump(nullable_int_val_default_null(null));
 
 ?>
---EXPECT--
+--EXPECTF--
 Testing int val
 int(10)
 Testing float val
@@ -78,6 +96,10 @@ float(10.7)
 Testing string add val
 string(14) "this is a test"
 Testing int with default null constant
-NULL
+Argument 1 passed to int_val_default_null() must be of the type int, null given, called in %s on line %d
 Testing int with null null constant
+Argument 1 passed to int_val_default_null() must be of the type int, null given, called in %s on line %d
+Testing nullable int with default null constant
+NULL
+Testing nullable int with null null constant
 NULL

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5198,7 +5198,7 @@ ZEND_VM_HOT_HANDLER(63, ZEND_RECV, NUM, UNUSED|CACHE_SLOT)
 		zval *param = EX_VAR(opline->result.var);
 
 		SAVE_OPLINE();
-		if (UNEXPECTED(!zend_verify_recv_arg_type(EX(func), arg_num, param, NULL, CACHE_ADDR(opline->op2.num)) || EG(exception))) {
+		if (UNEXPECTED(!zend_verify_recv_arg_type(EX(func), arg_num, param, CACHE_ADDR(opline->op2.num)) || EG(exception))) {
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -5243,10 +5243,8 @@ ZEND_VM_HOT_HANDLER(64, ZEND_RECV_INIT, NUM, CONST, CACHE_SLOT)
 	}
 
 	if (UNEXPECTED((EX(func)->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) != 0)) {
-		zval *default_value = RT_CONSTANT(opline, opline->op2);
-
 		SAVE_OPLINE();
-		if (UNEXPECTED(!zend_verify_recv_arg_type(EX(func), arg_num, param, default_value, CACHE_ADDR(opline->extended_value)) || EG(exception))) {
+		if (UNEXPECTED(!zend_verify_recv_arg_type(EX(func), arg_num, param, CACHE_ADDR(opline->extended_value)) || EG(exception))) {
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -5275,7 +5273,7 @@ ZEND_VM_HANDLER(164, ZEND_RECV_VARIADIC, NUM, UNUSED|CACHE_SLOT)
 			param = EX_VAR_NUM(EX(func)->op_array.last_var + EX(func)->op_array.T);
 			if (UNEXPECTED((EX(func)->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) != 0)) {
 				do {
-					zend_verify_variadic_arg_type(EX(func), arg_num, param, NULL, CACHE_ADDR(opline->op2.num));
+					zend_verify_variadic_arg_type(EX(func), arg_num, param, CACHE_ADDR(opline->op2.num));
 					if (Z_OPT_REFCOUNTED_P(param)) Z_ADDREF_P(param);
 					ZEND_HASH_FILL_ADD(param);
 					param++;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3046,10 +3046,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RECV_INIT_SPEC_CON
 	}
 
 	if (UNEXPECTED((EX(func)->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) != 0)) {
-		zval *default_value = RT_CONSTANT(opline, opline->op2);
-
 		SAVE_OPLINE();
-		if (UNEXPECTED(!zend_verify_recv_arg_type(EX(func), arg_num, param, default_value, CACHE_ADDR(opline->extended_value)) || EG(exception))) {
+		if (UNEXPECTED(!zend_verify_recv_arg_type(EX(func), arg_num, param, CACHE_ADDR(opline->extended_value)) || EG(exception))) {
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -3127,7 +3125,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RECV_SPEC_UNUSED_H
 		zval *param = EX_VAR(opline->result.var);
 
 		SAVE_OPLINE();
-		if (UNEXPECTED(!zend_verify_recv_arg_type(EX(func), arg_num, param, NULL, CACHE_ADDR(opline->op2.num)) || EG(exception))) {
+		if (UNEXPECTED(!zend_verify_recv_arg_type(EX(func), arg_num, param, CACHE_ADDR(opline->op2.num)) || EG(exception))) {
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -3155,7 +3153,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RECV_VARIADIC_SPEC_UNUSED_HAND
 			param = EX_VAR_NUM(EX(func)->op_array.last_var + EX(func)->op_array.T);
 			if (UNEXPECTED((EX(func)->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) != 0)) {
 				do {
-					zend_verify_variadic_arg_type(EX(func), arg_num, param, NULL, CACHE_ADDR(opline->op2.num));
+					zend_verify_variadic_arg_type(EX(func), arg_num, param, CACHE_ADDR(opline->op2.num));
 					if (Z_OPT_REFCOUNTED_P(param)) Z_ADDREF_P(param);
 					ZEND_HASH_FILL_ADD(param);
 					param++;

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -3104,11 +3104,6 @@ static int zend_update_type_info(const zend_op_array *op_array,
 			ce = NULL;
 			if (arg_info) {
 				tmp = zend_fetch_arg_info_type(script, arg_info, &ce);
-				if (opline->opcode == ZEND_RECV_INIT &&
-				           Z_TYPE_P(CRT_CONSTANT_EX(op_array, opline, opline->op2, ssa->rt_constants)) == IS_CONSTANT_AST) {
-					/* The constant may resolve to NULL */
-					tmp |= MAY_BE_NULL;
-				}
 				if (arg_info->pass_by_reference) {
 					tmp |= MAY_BE_REF;
 				}

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -9021,16 +9021,13 @@ static int zend_jit_recv(dasm_State **Dst, const zend_op *opline, zend_op_array 
 					|	mov CARG3, arg_num
 					|	LOAD_ADDR CARG4, (ptrdiff_t)arg_info
 					|	mov aword A5, r0
-					|	mov aword A6, 0
 					|	EXT_CALL zend_jit_verify_arg_slow, r0
 				|.elif X64
 					|	mov CARG3, arg_num
 					|	LOAD_ADDR CARG4, (ptrdiff_t)arg_info
 					|	mov CARG5, r0
-					|	xor CARG6, CARG6
 					|	EXT_CALL zend_jit_verify_arg_slow, r0
 				|.else
-					|	push 0
 					|	push r0
 					|	push (ptrdiff_t)arg_info
 					|	push arg_num
@@ -9190,16 +9187,13 @@ static int zend_jit_recv_init(dasm_State **Dst, const zend_op *opline, zend_op_a
 		|	mov CARG3, arg_num
 		|	LOAD_ADDR CARG4, (ptrdiff_t)arg_info
 		|	mov aword A5, r0
-		|	ADDR_OP2_2 mov, aword A6, zv, r0
 		|	EXT_CALL zend_jit_verify_arg_slow, r0
 	|.elif X64
 		|	mov CARG3, arg_num
 		|	LOAD_ADDR CARG4, (ptrdiff_t)arg_info
 		|	mov CARG5, r0
-		|	LOAD_ADDR CARG6, zv
 		|	EXT_CALL zend_jit_verify_arg_slow, r0
 	|.else
-		|	push zv
 		|	push r0
 		|	push (ptrdiff_t)arg_info
 		|	push arg_num


### PR DESCRIPTION
This removes a hack that was added in PHP 5.6 (iirc) prior to the introduction of nullable types. The issue are cases like:

```php
function foo(int $a = SOME_CONSTANT) {}
```

where `SOME_CONSTANT` evaluates to `null` at runtime. In this case, we will allow `null` as a value for the parameter, implicitly promoting the type to `?int`. There are multiple problems with this magic:

 * The type may change at runtime, for example:
```php
<?php
namespace Foo;
function test(int $foo = SOME_CONST) { return $foo; }

define('SOME_CONST', null);
var_dump(test(null)); // works
define('Foo\SOME_CONST', 42);
var_dump(test(null)); // TypeError
```
 * Reflection does not understand this. It will always report the type as non-nullable.
 * This breaks our LSP/variance checks. For example, this code is permitted, but shouldn't be, because it changes a `?int` parameter to an `int` parameter (effectively).
```php
<?php
class A {
    public function test(int $foo = SOME_CONST1) {}
}

class B extends A {
    public function test(int $foo = SOME_CONST2) {}
}

const SOME_CONST1 = null;
const SOME_CONST2 = 42;
```

I think we should remove this hack in master. Instead, people can use an explicit nullable type:
```php
function foo(?int $a = SOME_CONSTANT) {}
```

It should be noted that this does not affect the case where a compile-time null value is used. So
```php
function foo(int $a = null) {}
```
continues working the same. Keeping this is not a problem, because we determine at compile-time that the real type is `?int`, so all the above issues don't apply.

@dstogov Does this change look okay to you?