### PR TITLE
fix length of key passed to call correct function for SCM_CREDENTIALS socket message for Big Endian platform (s390x)

### DIFF
--- a/ext/sockets/sendrecvmsg.c
+++ b/ext/sockets/sendrecvmsg.c
@@ -106,7 +106,7 @@ static void init_ancillary_registry(void)
 	entry.to_array		= to; \
 	key.cmsg_level		= level; \
 	key.cmsg_type		= type; \
-	zend_hash_str_update_mem(&ancillary_registry.ht, (char*)&key, sizeof(key) - 1, (void*)&entry, sizeof(entry))
+	zend_hash_str_update_mem(&ancillary_registry.ht, (char*)&key, sizeof(key), (void*)&entry, sizeof(entry))
 
 #if defined(IPV6_PKTINFO) && HAVE_IPV6
 	PUT_ENTRY(sizeof(struct in6_pktinfo), 0, 0, from_zval_write_in6_pktinfo,
@@ -156,7 +156,7 @@ ancillary_reg_entry *get_ancillary_reg_entry(int cmsg_level, int msg_type)
 	tsrm_mutex_unlock(ancillary_mutex);
 #endif
 
-	if ((entry = zend_hash_str_find_ptr(&ancillary_registry.ht, (char*)&key, sizeof(key) - 1)) != NULL) {
+	if ((entry = zend_hash_str_find_ptr(&ancillary_registry.ht, (char*)&key, sizeof(key))) != NULL) {
 		return entry;
 	} else {
 		return NULL;


### PR DESCRIPTION
TEST case failure: ext/sockets/tests/socket_cmsg_credentials.phpt
Cause: Incorrect entry in hash table called due to hash key being cut off.
Fix: Correct the key length being passed in.

Works fine for little endian systems, the byte cut off is always zero, but for big endian, the byte cut off is the distinguishing byte for the entry. GDB images attached showing memory map for key in both little endian and big endian.

Big endian:
<img width="863" alt="s390x" src="https://user-images.githubusercontent.com/35280047/65350168-1afe1980-dbb3-11e9-8012-0e307fd390be.png">

Little endian:
<img width="863" alt="intel" src="https://user-images.githubusercontent.com/35280047/65350128-fe61e180-dbb2-11e9-9099-e76c1840841f.png">
