### PR TITLE
Fixed bug #78577

### DIFF
--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -499,9 +499,7 @@ PHP_FUNCTION(dom_element_get_attribute_node)
 
 	if (attrp->type == XML_NAMESPACE_DECL) {
 		xmlNsPtr curns;
-		xmlNodePtr nsparent;
 
-		nsparent = attrp->_private;
 		curns = xmlNewNs(NULL, attrp->name, NULL);
 		if (attrp->children) {
 			curns->prefix = xmlStrdup((xmlChar *) attrp->children);
@@ -512,7 +510,7 @@ PHP_FUNCTION(dom_element_get_attribute_node)
 			attrp = xmlNewDocNode(nodep->doc, NULL, (xmlChar *)"xmlns", attrp->name);
 		}
 		attrp->type = XML_NAMESPACE_DECL;
-		attrp->parent = nsparent;
+		attrp->parent = nodep;
 		attrp->ns = curns;
 	}
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -498,16 +498,17 @@ PHP_FUNCTION(dom_element_get_attribute_node)
 	}
 
 	if (attrp->type == XML_NAMESPACE_DECL) {
+		// attrp is an xmlNodePtr but must be casted to xmlNsPtr in this branch based on type
 		xmlNsPtr curns;
 
-		curns = xmlNewNs(NULL, attrp->name, NULL);
+		curns = xmlNewNs(NULL, ((xmlNsPtr)attrp)->href, NULL);
 		if (attrp->children) {
-			curns->prefix = xmlStrdup((xmlChar *) attrp->children);
+			curns->prefix = xmlStrdup(((xmlNsPtr)attrp)-> prefix);
 		}
 		if (attrp->children) {
-			attrp = xmlNewDocNode(nodep->doc, NULL, (xmlChar *) attrp->children, attrp->name);
+			attrp = xmlNewDocNode(nodep->doc, NULL, ((xmlNsPtr)attrp)->prefix, attrp->name);
 		} else {
-			attrp = xmlNewDocNode(nodep->doc, NULL, (xmlChar *)"xmlns", attrp->name);
+			attrp = xmlNewDocNode(nodep->doc, NULL, (xmlChar *)"xmlns", ((xmlNsPtr)attrp)->href);
 		}
 		attrp->type = XML_NAMESPACE_DECL;
 		attrp->parent = nodep;

--- a/ext/dom/tests/bug78577.phpt
+++ b/ext/dom/tests/bug78577.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Bug #78577 DOMNameSpaceNode::parentNode on xmlns segfaults
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$doc = new DOMDocument();
+$doc->loadXML(<<<XML
+    <foo xmlns="http://php.net/test" xmlns:foo="urn:foo" foo="bar">
+        <bar baz="boing" />
+    </foo>
+XML
+);
+
+$attr1 = $doc->documentElement->getAttributeNode("foo");
+$element = $doc->documentElement->getElementsByTagName("bar")[0];
+$attr2 = $element->getAttributeNode("baz");
+$attrXmlnsFoo = $doc->documentElement->getAttributeNode("xmlns:foo");
+$attrXmlns = $doc->documentElement->getAttributeNode('xmlns');
+
+if ($attr1->parentNode === $doc->documentElement) {
+    echo "attr1\n";
+}
+
+if ($attr2->parentNode === $element) {
+    echo "attr2\n";
+}
+
+if ($attrXmlnsFoo->parentNode === $doc->documentElement) {
+    echo "attrXmlnsFoo\n";
+}
+
+if ($attrXmlns->parentNode === $doc->documentElement) {
+    echo "attrXmlns\n";
+}
+
+var_dump($attrXmlns);
+
+--EXPECTF--
+attr1
+attr2
+attrXmlnsFoo
+attrXmlns
+object(DOMNameSpaceNode)#7 (8) {
+  ["nodeName"]=>
+  string(5) "xmlns"
+  ["nodeValue"]=>
+  string(19) "http://php.net/test"
+  ["nodeType"]=>
+  int(18)
+  ["prefix"]=>
+  string(0) ""
+  ["localName"]=>
+  string(5) "xmlns"
+  ["namespaceURI"]=>
+  string(19) "http://php.net/test"
+  ["ownerDocument"]=>
+  string(22) "(object value omitted)"
+  ["parentNode"]=>
+  string(22) "(object value omitted)"
+}


### PR DESCRIPTION
The `nsparent` should actually be the `nodep` already from the `DOMElement#getAttributeNode()` call.

Fixes https://bugs.php.net/bug.php?id=78577