### PR TITLE
Use pkg-config for DBA libraries

### DIFF
--- a/azure/apt.yml
+++ b/azure/apt.yml
@@ -3,6 +3,18 @@ parameters:
 
 steps:
   - script: |
+      if ! grep -r -E '^deb.*xenial-backports.*' /etc/apt/sources.list* > /dev/null; then
+      cat <<EOT > /etc/apt/sources.list.d/xenial-backports.list
+      deb http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+      EOT
+      fi
+
+      cat <<EOT > /etc/apt/preferences.d/xenial-backports-lmdb
+      Package: liblmdb-dev liblmdb0 lmdb-doc
+      Pin: release a=xenial-backports
+      Pin-Priority: 500
+      EOT
+
       sudo apt-get update -y | true
       sudo apt install bison \
                        re2c \
@@ -34,5 +46,8 @@ steps:
                        postgresql \
                        postgresql-contrib \
                        llvm \
+                       liblmdb-dev \
+                       libqdbm-dev \
+                       libtokyocabinet-dev \
                        ${{ parameters.packages }}
     displayName: 'APT'

--- a/azure/apt.yml
+++ b/azure/apt.yml
@@ -4,12 +4,12 @@ parameters:
 steps:
   - script: |
       if ! grep -r -E '^deb.*xenial-backports.*' /etc/apt/sources.list* > /dev/null; then
-      cat <<EOT > /etc/apt/sources.list.d/xenial-backports.list
+      cat <<EOT | sudo tee /etc/apt/sources.list.d/xenial-backports.list > /dev/null
       deb http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
       EOT
       fi
 
-      cat <<EOT > /etc/apt/preferences.d/xenial-backports-lmdb
+      cat <<EOT | sudo tee /etc/apt/preferences.d/xenial-backports-lmdb > /dev/null
       Package: liblmdb-dev liblmdb0 lmdb-doc
       Pin: release a=xenial-backports
       Pin-Priority: 500

--- a/azure/configure.yml
+++ b/azure/configure.yml
@@ -56,6 +56,10 @@ steps:
         --with-password-argon2 \
         --with-mhash \
         --enable-werror \
+        --enable-dba \
+        --with-lmdb  \
+        --with-qdbm \
+        --with-tcadb \
         --with-config-file-path=/etc \
         --with-config-file-scan-dir=/etc/php.d
   displayName: 'Configure Build'

--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -140,10 +140,10 @@ if test "$PHP_QDBM" != "no"; then
   PHP_EVAL_INCLINE($QDBM_CFLAGS)
   PHP_EVAL_LIBLINE($QDBM_LIBS, DBA_SHARED_LIBADD)
 
-    AC_DEFINE(HAVE_DBA, 1, [ ])
-    AC_DEFINE(HAVE_QDBM, 1, [ ])
-        AC_DEFINE(DBA_QDBM, 1, [ ])
-      fi
+  AC_DEFINE(HAVE_DBA, 1, [ ])
+  AC_DEFINE(HAVE_QDBM, 1, [ ])
+  AC_DEFINE(DBA_QDBM, 1, [ ])
+fi
 
 
 dnl GDBM
@@ -215,10 +215,10 @@ if test "$PHP_TCADB" != "no"; then
   PHP_EVAL_INCLINE($TCADB_CFLAGS)
   PHP_EVAL_LIBLINE($TCADB_LIBS, DBA_SHARED_LIBADD)
 
-    AC_DEFINE(HAVE_DBA, 1, [ ])
-    AC_DEFINE(HAVE_TCADB, 1, [ ])
-		AC_DEFINE(DBA_TCADB, 1, [ ])
-	  fi
+  AC_DEFINE(HAVE_DBA, 1, [ ])
+  AC_DEFINE(HAVE_TCADB, 1, [ ])
+  AC_DEFINE(DBA_TCADB, 1, [ ])
+fi
 
 dnl LMDB
 if test "$PHP_LMDB" != "no"; then
@@ -227,9 +227,9 @@ if test "$PHP_LMDB" != "no"; then
   PHP_EVAL_INCLINE($LMDB_CFLAGS)
   PHP_EVAL_LIBLINE($LMDB_LIBS, DBA_SHARED_LIBADD)
 
-    AC_DEFINE(HAVE_DBA, 1, [ ])
-		AC_DEFINE(DBA_LMDB, 1, [ ])
-	  fi
+  AC_DEFINE(HAVE_DBA, 1, [ ])
+  AC_DEFINE(DBA_LMDB, 1, [ ])
+fi
 
 dnl Berkeley specific (library and version test)
 dnl parameters(version, library list, function)
@@ -581,7 +581,7 @@ dnl CDB
 if test "$PHP_CDB" = "yes"; then
   AC_DEFINE(DBA_CDB_BUILTIN, 1, [ ])
   AC_DEFINE(DBA_CDB_MAKE, 1, [ ])
-        AC_DEFINE(DBA_CDB, 1, [ ])
+  AC_DEFINE(DBA_CDB, 1, [ ])
   cdb_sources="libcdb/cdb.c libcdb/cdb_make.c libcdb/uint32.c"
   THIS_RESULT="builtin"
 elif test "$PHP_CDB" != "no"; then
@@ -591,7 +591,7 @@ elif test "$PHP_CDB" != "no"; then
       THIS_PREFIX=$i
       THIS_INCLUDE=$i/include/cdb.h
       break
-fi
+    fi
   done
 
   if test -n "$THIS_INCLUDE"; then
@@ -610,7 +610,7 @@ fi
   PHP_DBA_STD_ASSIGN
   PHP_DBA_STD_CHECK
   PHP_DBA_STD_ATTACH
-      fi
+fi
 PHP_DBA_STD_RESULT(cdb)
 
 dnl INIFILE

--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -140,14 +140,9 @@ if test "$PHP_QDBM" != "no"; then
   PHP_EVAL_INCLINE($QDBM_CFLAGS)
   PHP_EVAL_LIBLINE($QDBM_LIBS, DBA_SHARED_LIBADD)
 
-  PHP_CHECK_LIBRARY(qdbm, dpopen,
-  [
     AC_DEFINE(HAVE_DBA, 1, [ ])
     AC_DEFINE(HAVE_QDBM, 1, [ ])
         AC_DEFINE(DBA_QDBM, 1, [ ])
-  ], [ ], [
-    $QDBM_LIBS
-  ])
       fi
 
 
@@ -220,14 +215,9 @@ if test "$PHP_TCADB" != "no"; then
   PHP_EVAL_INCLINE($TCADB_CFLAGS)
   PHP_EVAL_LIBLINE($TCADB_LIBS, DBA_SHARED_LIBADD)
 
-  PHP_CHECK_LIBRARY(tokyocabinet, tcadbopen,
-  [
     AC_DEFINE(HAVE_DBA, 1, [ ])
     AC_DEFINE(HAVE_TCADB, 1, [ ])
 		AC_DEFINE(DBA_TCADB, 1, [ ])
-  ], [ ], [
-    $TCADB_LIBS
-  ])
 	  fi
 
 dnl LMDB
@@ -237,13 +227,8 @@ if test "$PHP_LMDB" != "no"; then
   PHP_EVAL_INCLINE($LMDB_CFLAGS)
   PHP_EVAL_LIBLINE($LMDB_LIBS, DBA_SHARED_LIBADD)
 
-  PHP_CHECK_LIBRARY(lmdb, mdb_env_open,
-  [
     AC_DEFINE(HAVE_DBA, 1, [ ])
 		AC_DEFINE(DBA_LMDB, 1, [ ])
-  ], [ ], [
-    $LMDB_LIBS
-  ])
 	  fi
 
 dnl Berkeley specific (library and version test)
@@ -568,15 +553,20 @@ PHP_DBA_STD_RESULT(dbm)
 
 dnl Bundled modules that should be enabled by default if any other option is
 dnl enabled
-if test "$PHP_DBA" != "no" || test "$HAVE_DBA" = "1" || test "$with_cdb" = "yes" || test "$enable_inifile" = "yes" || test "$enable_flatfile" = "yes"; then
+if test "$PHP_DBA" != "no" || test "$HAVE_DBA" = "1" || test "$with_cdb" = "yes" || test "$with_cdb_external" = "yes" || test "$enable_inifile" = "yes" || test "$enable_flatfile" = "yes"; then
   php_dba_enable=yes
 else
   php_dba_enable=no
 fi
 
 PHP_ARG_WITH([cdb],,
-  [AS_HELP_STRING([[--without-cdb[=DIR]]],
-    [DBA: CDB support (bundled)])],
+  [AS_HELP_STRING([[--without-cdb]],
+    [DBA: Disable CDB support (bundled)])],
+  [$php_dba_enable],
+  [no])
+PHP_ARG_WITH([cdb_external],,
+  [AS_HELP_STRING([[--with-external-cdb]],
+    [DBA: CDB support (external)])],
   [$php_dba_enable],
   [no])
 
@@ -593,27 +583,22 @@ PHP_ARG_ENABLE([flatfile],,
   [no])
 
 dnl CDB
-if test "$PHP_CDB" = "yes"; then
-  AC_DEFINE(DBA_CDB_BUILTIN, 1, [ ])
-  AC_DEFINE(DBA_CDB_MAKE, 1, [ ])
-  AC_DEFINE(DBA_CDB, 1, [ ])
-  cdb_sources="libcdb/cdb.c libcdb/cdb_make.c libcdb/uint32.c"
-  THIS_RESULT="builtin"
-  PHP_DBA_STD_RESULT
-elif test "$PHP_CDB" != "no"; then
-  PKG_CHECK_MODULES([CDB], [cdb])
+if test "$PHP_CDB_EXTERNAL" != "no"; then
+  PKG_CHECK_MODULES([CDB], [libcdb])
 
   PHP_EVAL_INCLINE($CDB_CFLAGS)
   PHP_EVAL_LIBLINE($CDB_LIBS, DBA_SHARED_LIBADD)
 
-  PHP_CHECK_LIBRARY(cdb, cdb_read,
-  [
     AC_DEFINE(HAVE_DBA, 1, [ ])
     AC_DEFINE(HAVE_CDB, 1, [ ])
+  AC_DEFINE(DBA_CDB, 1, [ ])
+elif test "$PHP_CDB" = "yes"; then
+  AC_DEFINE(DBA_CDB_BUILTIN, 1, [ ])
+  AC_DEFINE(DBA_CDB_MAKE, 1, [ ])
         AC_DEFINE(DBA_CDB, 1, [ ])
-  ], [ ], [
-    $CDB_LIBS
-  ])
+  cdb_sources="libcdb/cdb.c libcdb/cdb_make.c libcdb/uint32.c"
+  THIS_RESULT="builtin"
+  PHP_DBA_STD_RESULT
       fi
 
 dnl INIFILE

--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -135,37 +135,21 @@ dnl
 
 dnl QDBM
 if test "$PHP_QDBM" != "no"; then
-  PHP_DBA_STD_BEGIN
-  for i in $PHP_QDBM /usr/local /usr; do
-    if test -f "$i/include/depot.h"; then
-      THIS_PREFIX=$i
-      THIS_INCLUDE=$i/include/depot.h
-      break
-    elif test -f "$i/include/qdbm/depot.h"; then
-      THIS_PREFIX=$i
-      THIS_INCLUDE=$i/include/qdbm/depot.h
-      break
-    fi
-  done
+  PKG_CHECK_MODULES([QDBM], [qdbm])
 
-  if test -n "$THIS_INCLUDE"; then
-    for LIB in qdbm; do
-      PHP_CHECK_LIBRARY($LIB, dpopen, [
-        AC_DEFINE_UNQUOTED(QDBM_INCLUDE_FILE, "$THIS_INCLUDE", [ ])
+  PHP_EVAL_INCLINE($QDBM_CFLAGS)
+  PHP_EVAL_LIBLINE($QDBM_LIBS, DBA_SHARED_LIBADD)
+
+  PHP_CHECK_LIBRARY(qdbm, dpopen,
+  [
+    AC_DEFINE(HAVE_DBA, 1, [ ])
+    AC_DEFINE(HAVE_QDBM, 1, [ ])
         AC_DEFINE(DBA_QDBM, 1, [ ])
-        THIS_LIBS=$LIB
-      ], [], [-L$THIS_PREFIX/$PHP_LIBDIR])
-      if test -n "$THIS_LIBS"; then
-        break
+  ], [ ], [
+    $QDBM_LIBS
+  ])
       fi
-    done
-  fi
 
-  PHP_DBA_STD_ASSIGN
-  PHP_DBA_STD_CHECK
-  PHP_DBA_STD_ATTACH
-fi
-PHP_DBA_STD_RESULT(qdbm)
 
 dnl GDBM
 if test "$PHP_GDBM" != "no"; then
@@ -231,65 +215,36 @@ PHP_DBA_STD_RESULT(ndbm)
 
 dnl TCADB
 if test "$PHP_TCADB" != "no"; then
-  PHP_DBA_STD_BEGIN
-  for i in $PHP_TCADB /usr/local /usr; do
-	if test -f "$i/include/tcadb.h"; then
-	  THIS_PREFIX=$i
-	  PHP_ADD_INCLUDE($THIS_PREFIX/include)
-	  THIS_INCLUDE=$i/include/tcadb.h
-	  break
-	fi
-  done
+  PKG_CHECK_MODULES([TCADB], [tokyocabinet])
 
-  if test -n "$THIS_INCLUDE"; then
-	for LIB in tokyocabinet; do
-	  PHP_CHECK_LIBRARY($LIB, tcadbopen, [
-		AC_DEFINE_UNQUOTED(TCADB_INCLUDE_FILE, "$THIS_INCLUDE", [ ])
+  PHP_EVAL_INCLINE($TCADB_CFLAGS)
+  PHP_EVAL_LIBLINE($TCADB_LIBS, DBA_SHARED_LIBADD)
+
+  PHP_CHECK_LIBRARY(tokyocabinet, tcadbopen,
+  [
+    AC_DEFINE(HAVE_DBA, 1, [ ])
+    AC_DEFINE(HAVE_TCADB, 1, [ ])
 		AC_DEFINE(DBA_TCADB, 1, [ ])
-		THIS_LIBS=$LIB
-	  ], [], [-L$THIS_PREFIX/$PHP_LIBDIR])
-	  if test -n "$THIS_LIBS"; then
-		break
+  ], [ ], [
+    $TCADB_LIBS
+  ])
 	  fi
-	done
-  fi
-
-  PHP_DBA_STD_ASSIGN
-  PHP_DBA_STD_CHECK
-  PHP_DBA_STD_ATTACH
-fi
-PHP_DBA_STD_RESULT(tcadb)
 
 dnl LMDB
 if test "$PHP_LMDB" != "no"; then
-  PHP_DBA_STD_BEGIN
-  for i in $PHP_LMDB /usr/local /usr; do
-	if test -f "$i/include/lmdb.h"; then
-	  THIS_PREFIX=$i
-	  PHP_ADD_INCLUDE($THIS_PREFIX/include)
-	  THIS_INCLUDE=$i/include/lmdb.h
-	  break
-	fi
-  done
+  PKG_CHECK_MODULES([LMDB], [lmdb])
 
-  if test -n "$THIS_INCLUDE"; then
-	for LIB in lmdb; do
-	  PHP_CHECK_LIBRARY($LIB, mdb_env_open, [
-		AC_DEFINE_UNQUOTED(LMDB_INCLUDE_FILE, "$THIS_INCLUDE", [ ])
+  PHP_EVAL_INCLINE($LMDB_CFLAGS)
+  PHP_EVAL_LIBLINE($LMDB_LIBS, DBA_SHARED_LIBADD)
+
+  PHP_CHECK_LIBRARY(lmdb, mdb_env_open,
+  [
+    AC_DEFINE(HAVE_DBA, 1, [ ])
 		AC_DEFINE(DBA_LMDB, 1, [ ])
-		THIS_LIBS=$LIB
-	  ], [], [-L$THIS_PREFIX/$PHP_LIBDIR])
-	  if test -n "$THIS_LIBS"; then
-		break
+  ], [ ], [
+    $LMDB_LIBS
+  ])
 	  fi
-	done
-  fi
-
-  PHP_DBA_STD_ASSIGN
-  PHP_DBA_STD_CHECK
-  PHP_DBA_STD_ATTACH
-fi
-PHP_DBA_STD_RESULT(lmdb)
 
 dnl Berkeley specific (library and version test)
 dnl parameters(version, library list, function)
@@ -644,34 +599,22 @@ if test "$PHP_CDB" = "yes"; then
   AC_DEFINE(DBA_CDB, 1, [ ])
   cdb_sources="libcdb/cdb.c libcdb/cdb_make.c libcdb/uint32.c"
   THIS_RESULT="builtin"
+  PHP_DBA_STD_RESULT
 elif test "$PHP_CDB" != "no"; then
-  PHP_DBA_STD_BEGIN
-  for i in $PHP_CDB /usr/local /usr; do
-    if test -f "$i/include/cdb.h"; then
-      THIS_PREFIX=$i
-      THIS_INCLUDE=$i/include/cdb.h
-      break
-    fi
-  done
+  PKG_CHECK_MODULES([CDB], [cdb])
 
-  if test -n "$THIS_INCLUDE"; then
-    for LIB in cdb c; do
-      PHP_CHECK_LIBRARY($LIB, cdb_read, [
-        AC_DEFINE_UNQUOTED(CDB_INCLUDE_FILE, "$THIS_INCLUDE", [ ])
+  PHP_EVAL_INCLINE($CDB_CFLAGS)
+  PHP_EVAL_LIBLINE($CDB_LIBS, DBA_SHARED_LIBADD)
+
+  PHP_CHECK_LIBRARY(cdb, cdb_read,
+  [
+    AC_DEFINE(HAVE_DBA, 1, [ ])
+    AC_DEFINE(HAVE_CDB, 1, [ ])
         AC_DEFINE(DBA_CDB, 1, [ ])
-        THIS_LIBS=$LIB
-      ], [], [-L$THIS_PREFIX/$PHP_LIBDIR])
-      if test -n "$THIS_LIBS"; then
-        break
+  ], [ ], [
+    $CDB_LIBS
+  ])
       fi
-    done
-  fi
-
-  PHP_DBA_STD_ASSIGN
-  PHP_DBA_STD_CHECK
-  PHP_DBA_STD_ATTACH
-fi
-PHP_DBA_STD_RESULT(cdb)
 
 dnl INIFILE
 if test "$PHP_INIFILE" != "no"; then

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -35,9 +35,7 @@
 # include "libcdb/cdb_make.h"
 # include "libcdb/uint32.h"
 #else
-# ifdef CDB_INCLUDE_FILE
-#  include CDB_INCLUDE_FILE
-# endif
+#include "cdb.h"
 #endif
 
 #define CDB_INFO \

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -35,7 +35,9 @@
 # include "libcdb/cdb_make.h"
 # include "libcdb/uint32.h"
 #else
-#include "cdb.h"
+# ifdef CDB_INCLUDE_FILE
+#  include CDB_INCLUDE_FILE
+# endif
 #endif
 
 #define CDB_INFO \

--- a/ext/dba/dba_lmdb.c
+++ b/ext/dba/dba_lmdb.c
@@ -22,10 +22,7 @@
 
 #if DBA_LMDB
 #include "php_lmdb.h"
-
-#ifdef LMDB_INCLUDE_FILE
-#include LMDB_INCLUDE_FILE
-#endif
+#include "lmdb.h"
 
 struct php_lmdb_info {
 	MDB_env *env;

--- a/ext/dba/dba_qdbm.c
+++ b/ext/dba/dba_qdbm.c
@@ -22,10 +22,7 @@
 
 #if DBA_QDBM
 #include "php_qdbm.h"
-
-#ifdef QDBM_INCLUDE_FILE
-#include QDBM_INCLUDE_FILE
-#endif
+#include "depot.h"
 
 #define QDBM_DATA dba_qdbm_data *dba = info->dbf
 

--- a/ext/dba/dba_tcadb.c
+++ b/ext/dba/dba_tcadb.c
@@ -22,10 +22,7 @@
 
 #if DBA_TCADB
 #include "php_tcadb.h"
-
-#ifdef TCADB_INCLUDE_FILE
-#include TCADB_INCLUDE_FILE
-#endif
+#include "tcadb.h"
 
 #define TCADB_DATA dba_tcadb_data *dba = info->dbf
 

--- a/ext/dba/tests/dba_tcadb.phpt
+++ b/ext/dba/tests/dba_tcadb.phpt
@@ -7,6 +7,7 @@ DBA TCADB handler test
 ?>
 --FILE--
 <?php
+	$handler = 'tcadb';
     $lock_flag = 'l';
     $db_filename = $db_file = __DIR__ .'/test0.tch';
     @unlink($db_filename);


### PR DESCRIPTION
- LMDB, QDBM, CDB and TokyoCabinet now use `pkg-config`
- Fixed failing TokyoCabinet test due to undefined handler var

This is a follow-up to #4735 