### PR TITLE
Don't protect GC while destroying zvals

### DIFF
--- a/Zend/tests/bug78589.phpt
+++ b/Zend/tests/bug78589.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #78589: Memory leak with GC + __destruct()
+--FILE--
+<?php
+
+class Test {
+    public function __destruct() {}
+}
+
+$test = new Test;
+$test->foo = [&$test->foo];
+$ary = [&$ary, $test];
+unset($ary, $test);
+gc_collect_cycles();
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -1549,7 +1549,6 @@ ZEND_API int zend_gc_collect_cycles(void)
 
 		/* Destroy zvals */
 		GC_TRACE("Destroying zvals");
-		GC_G(gc_protected) = 1;
 		current = GC_IDX2PTR(GC_FIRST_ROOT);
 		last = GC_IDX2PTR(GC_G(first_unused));
 		while (current != last) {
@@ -1600,7 +1599,6 @@ ZEND_API int zend_gc_collect_cycles(void)
 
 		GC_TRACE("Collection finished");
 		GC_G(collected) += count;
-		GC_G(gc_protected) = 0;
 		GC_G(gc_active) = 0;
 	}
 


### PR DESCRIPTION
Don't protect GC while destroying zvals, because we may need to add new GC roots during this phase. This may happen if an object had __destruct invoked (and nested data removed), but then ends up being destroyed in the same GC run, because all holding structures are destroyed. In this case nested data roots may be added back to the root buffer.

With our current GC design, I don't think there is a problem with adding GC roots during destroy zval phase -- they are not marked garbage, so will be ignored, and we no longer do nested GCs either.