### PR TITLE
ext/dom: Add global registerNodeNS flag on DOMXPath.

### DIFF
--- a/ext/dom/dom_properties.h
+++ b/ext/dom/dom_properties.h
@@ -130,6 +130,8 @@ int dom_text_whole_text_read(dom_object *obj, zval *retval);
 #if defined(LIBXML_XPATH_ENABLED)
 /* xpath properties */
 int dom_xpath_document_read(dom_object *obj, zval *retval);
+int dom_xpath_register_node_ns_read(dom_object *obj, zval *retval);
+int dom_xpath_register_node_ns_write(dom_object *obj, zval *newval);
 #endif
 
 #endif /* DOM_PROPERTIERS_H */

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -770,6 +770,7 @@ PHP_MINIT_FUNCTION(dom)
 
 	zend_hash_init(&dom_xpath_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
 	dom_register_prop_handler(&dom_xpath_prop_handlers, "document", sizeof("document")-1, dom_xpath_document_read, NULL);
+	dom_register_prop_handler(&dom_xpath_prop_handlers, "registerNodeNamespaces", sizeof("registerNodeNamespaces")-1, dom_xpath_register_node_ns_read, dom_xpath_register_node_ns_write);
 	zend_hash_add_ptr(&classes, ce.name, &dom_xpath_prop_handlers);
 #endif
 
@@ -1019,6 +1020,7 @@ zend_object *dom_xpath_objects_new(zend_class_entry *class_type)
 	dom_xpath_object *intern = zend_object_alloc(sizeof(dom_xpath_object), class_type);
 
 	intern->registered_phpfunctions = zend_new_array(0);
+	intern->register_node_ns = 1;
 
 	intern->dom.prop_handler = &dom_xpath_prop_handlers;
 	intern->dom.std.handlers = &dom_xpath_object_handlers;

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -67,6 +67,7 @@ extern zend_module_entry dom_module_entry;
 
 typedef struct _dom_xpath_object {
 	int registerPhpFunctions;
+	int register_node_ns;
 	HashTable *registered_phpfunctions;
 	HashTable *node_list;
 	dom_object dom;

--- a/ext/dom/tests/bug55700.phpt
+++ b/ext/dom/tests/bug55700.phpt
@@ -23,6 +23,8 @@ $xp->registerNodeNamespaces = true;
 var_dump($xp->registerNodeNamespaces);
 
 echo($xp->query('//prefix:root')->length . "\n");
+
+var_dump($xp);
 ?>
 --EXPECT--
 1
@@ -30,3 +32,9 @@ echo($xp->query('//prefix:root')->length . "\n");
 bool(false)
 bool(true)
 1
+object(DOMXPath)#4 (2) {
+  ["document"]=>
+  string(22) "(object value omitted)"
+  ["registerNodeNamespaces"]=>
+  bool(true)
+}

--- a/ext/dom/tests/bug55700.phpt
+++ b/ext/dom/tests/bug55700.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #55700 (XPath namespace prefix conflict, global registerNodeNS flag)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$doc = new DOMDocument();
+$doc->loadXML('<prefix:root xmlns:prefix="urn:a" />');
+
+$xp = new DOMXPath($doc, true);
+$xp->registerNamespace('prefix', 'urn:b');
+
+echo($xp->query('//prefix:root')->length . "\n");
+
+$xp = new DOMXPath($doc, false);
+$xp->registerNamespace('prefix', 'urn:b');
+
+echo($xp->query('//prefix:root')->length . "\n");
+
+?>
+--EXPECT--
+1
+0

--- a/ext/dom/tests/bug55700.phpt
+++ b/ext/dom/tests/bug55700.phpt
@@ -17,7 +17,16 @@ $xp->registerNamespace('prefix', 'urn:b');
 
 echo($xp->query('//prefix:root')->length . "\n");
 
+var_dump($xp->registerNodeNamespaces);
+$xp->registerNodeNamespaces = true;
+
+var_dump($xp->registerNodeNamespaces);
+
+echo($xp->query('//prefix:root')->length . "\n");
 ?>
 --EXPECT--
 1
 0
+bool(false)
+bool(true)
+1

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -37,6 +37,7 @@
 /* {{{ arginfo */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_xpath_construct, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, doc, DOMDocument, 0)
+	ZEND_ARG_INFO(0, registerNodeNS)
 ZEND_END_ARG_INFO();
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_xpath_register_ns, 0, 0, 2)

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -308,6 +308,26 @@ int dom_xpath_document_read(dom_object *obj, zval *retval)
 }
 /* }}} */
 
+/* {{{ registerNodeNamespaces bool*/
+static inline dom_xpath_object *php_xpath_obj_from_dom_obj(dom_object *obj) {
+	return (dom_xpath_object*)((char*)(obj) - XtOffsetOf(dom_xpath_object, dom));
+}
+
+int dom_xpath_register_node_ns_read(dom_object *obj, zval *retval)
+{
+	ZVAL_BOOL(retval, php_xpath_obj_from_dom_obj(obj)->register_node_ns);
+
+	return SUCCESS;
+}
+
+int dom_xpath_register_node_ns_write(dom_object *obj, zval *newval)
+{
+	php_xpath_obj_from_dom_obj(obj)->register_node_ns = zend_is_true(newval);
+
+	return SUCCESS;
+}
+/* }}} */
+
 /* {{{ proto bool dom_xpath_register_ns(string prefix, string uri) */
 PHP_FUNCTION(dom_xpath_register_ns)
 {


### PR DESCRIPTION
PHP's `DOMXpath` automatically registers namespaces for xpath, which can be disabled with arguments `$registerNodeNS` to `evaluate()` and `query()` that defaults to true.

With this PR you can set this flag on the constructor as second argument of the xpath object globally for all evaluate/query calls: :laughing: 

```php
$xpath = new DOMXPath($doc, false);
```

In addition you can also use a property to read and write this value :rocket: 

```php
$xpath = new DOMXPath($doc);
$xpath->registerNodeNamespaces = true;
```
Both approaches are needed, because the option is reasonably important to be set directly in the constructor, but also code that is "downstream" of the actual construction of DOMXPath may need to inspect or modify the setting before use. Without knowing which value this property has at the call site of query/evaluate it would cause problems.

Setting the `$registerNodeNS` argument on query/evaluate methods will overwrite the default options.

Fixes https://bugs.php.net/bug.php?id=55700