### PR TITLE
Add max_depth option to unserialize()

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -3667,6 +3667,7 @@ PHP_MINIT_FUNCTION(basic) /* {{{ */
 	register_html_constants(INIT_FUNC_ARGS_PASSTHRU);
 	register_string_constants(INIT_FUNC_ARGS_PASSTHRU);
 
+	BASIC_MINIT_SUBMODULE(var)
 	BASIC_MINIT_SUBMODULE(file)
 	BASIC_MINIT_SUBMODULE(pack)
 	BASIC_MINIT_SUBMODULE(browscap)

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -235,6 +235,7 @@ typedef struct _php_basic_globals {
 #endif
 
 	int umask;
+	zend_long unserialize_max_depth;
 } php_basic_globals;
 
 #ifdef ZTS

--- a/ext/standard/php_var.h
+++ b/ext/standard/php_var.h
@@ -22,6 +22,7 @@
 #include "ext/standard/basic_functions.h"
 #include "zend_smart_str_public.h"
 
+PHP_MINIT_FUNCTION(var);
 PHP_FUNCTION(var_dump);
 PHP_FUNCTION(var_export);
 PHP_FUNCTION(debug_zval_dump);

--- a/ext/standard/php_var.h
+++ b/ext/standard/php_var.h
@@ -53,6 +53,8 @@ PHPAPI HashTable *php_var_unserialize_get_allowed_classes(php_unserialize_data_t
 PHPAPI void php_var_unserialize_set_allowed_classes(php_unserialize_data_t d, HashTable *classes);
 PHPAPI void php_var_unserialize_set_max_depth(php_unserialize_data_t d, zend_long max_depth);
 PHPAPI zend_long php_var_unserialize_get_max_depth(php_unserialize_data_t d);
+PHPAPI void php_var_unserialize_set_cur_depth(php_unserialize_data_t d, zend_long cur_depth);
+PHPAPI zend_long php_var_unserialize_get_cur_depth(php_unserialize_data_t d);
 
 #define PHP_VAR_SERIALIZE_INIT(d) \
 	(d) = php_var_serialize_init()

--- a/ext/standard/php_var.h
+++ b/ext/standard/php_var.h
@@ -50,6 +50,8 @@ PHPAPI php_unserialize_data_t php_var_unserialize_init(void);
 PHPAPI void php_var_unserialize_destroy(php_unserialize_data_t d);
 PHPAPI HashTable *php_var_unserialize_get_allowed_classes(php_unserialize_data_t d);
 PHPAPI void php_var_unserialize_set_allowed_classes(php_unserialize_data_t d, HashTable *classes);
+PHPAPI void php_var_unserialize_set_max_depth(php_unserialize_data_t d, zend_long max_depth);
+PHPAPI zend_long php_var_unserialize_get_max_depth(php_unserialize_data_t d);
 
 #define PHP_VAR_SERIALIZE_INIT(d) \
 	(d) = php_var_serialize_init()

--- a/ext/standard/tests/serialize/max_depth.phpt
+++ b/ext/standard/tests/serialize/max_depth.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Bug #78549: Stack overflow due to nested serialized input
+--FILE--
+<?php
+
+function create_nested_data($depth, $prefix, $suffix) {
+    return str_repeat($prefix, $depth) . 'i:0;' . str_repeat($suffix, $depth);
+}
+
+var_dump(unserialize('i:0;', ['max_depth' => 'foo']));
+var_dump(unserialize('i:0;', ['max_depth' => -1]));
+
+var_dump(unserialize(
+    create_nested_data(128, 'a:1:{i:0;', '}'),
+    ['max_depth' => 128]
+) !== false);
+var_dump(unserialize(
+    create_nested_data(129, 'a:1:{i:0;', '}'),
+    ['max_depth' => 128]
+));
+
+var_dump(unserialize(
+    create_nested_data(128, 'O:8:"stdClass":1:{i:0;', '}'),
+    ['max_depth' => 128]
+) !== false);
+var_dump(unserialize(
+    create_nested_data(129, 'O:8:"stdClass":1:{i:0;', '}'),
+    ['max_depth' => 128]
+));
+
+// Default depth is 4096
+var_dump(unserialize(create_nested_data(4096, 'a:1:{i:0;', '}')) !== false);
+var_dump(unserialize(create_nested_data(4097, 'a:1:{i:0;', '}')));
+
+?>
+--EXPECTF--
+Warning: unserialize(): max_depth should be int in %s on line %d
+bool(false)
+
+Warning: unserialize(): max_depth cannot be negative in %s on line %d
+bool(false)
+bool(true)
+
+Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth option in %s on line %d
+
+Notice: unserialize(): Error at offset 1157 of 1294 bytes in %s on line %d
+bool(false)
+bool(true)
+
+Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth option in %s on line %d
+
+Notice: unserialize(): Error at offset 2834 of 2971 bytes in %s on line %d
+bool(false)
+bool(true)
+
+Warning: unserialize(): Maximum depth of 4096 exceeded. The depth limit can be changed using the max_depth option in %s on line %d
+
+Notice: unserialize(): Error at offset 36869 of 40974 bytes in %s on line %d
+bool(false)

--- a/ext/standard/tests/serialize/max_depth.phpt
+++ b/ext/standard/tests/serialize/max_depth.phpt
@@ -3,13 +3,15 @@ Bug #78549: Stack overflow due to nested serialized input
 --FILE--
 <?php
 
-function create_nested_data($depth, $prefix, $suffix) {
-    return str_repeat($prefix, $depth) . 'i:0;' . str_repeat($suffix, $depth);
+function create_nested_data($depth, $prefix, $suffix, $inner = 'i:0;') {
+    return str_repeat($prefix, $depth) . $inner . str_repeat($suffix, $depth);
 }
 
+echo "Invalid max_depth:\n";
 var_dump(unserialize('i:0;', ['max_depth' => 'foo']));
 var_dump(unserialize('i:0;', ['max_depth' => -1]));
 
+echo "Array:\n";
 var_dump(unserialize(
     create_nested_data(128, 'a:1:{i:0;', '}'),
     ['max_depth' => 128]
@@ -19,6 +21,7 @@ var_dump(unserialize(
     ['max_depth' => 128]
 ));
 
+echo "Object:\n";
 var_dump(unserialize(
     create_nested_data(128, 'O:8:"stdClass":1:{i:0;', '}'),
     ['max_depth' => 128]
@@ -29,15 +32,18 @@ var_dump(unserialize(
 ));
 
 // Default depth is 4096
+echo "Default depth:\n";
 var_dump(unserialize(create_nested_data(4096, 'a:1:{i:0;', '}')) !== false);
 var_dump(unserialize(create_nested_data(4097, 'a:1:{i:0;', '}')));
 
 // Depth can also be adjusted using ini setting
+echo "Ini setting:\n";
 ini_set("unserialize.max_depth", 128);
 var_dump(unserialize(create_nested_data(128, 'a:1:{i:0;', '}')) !== false);
 var_dump(unserialize(create_nested_data(129, 'a:1:{i:0;', '}')));
 
 // But an explicitly specified depth still takes precedence
+echo "Ini setting overridden:\n";
 var_dump(unserialize(
     create_nested_data(256, 'a:1:{i:0;', '}'),
     ['max_depth' => 256]
@@ -47,40 +53,107 @@ var_dump(unserialize(
     ['max_depth' => 256]
 ));
 
+// Reset ini setting to a large value,
+// so it's clear that it won't be used in the following.
+ini_set("unserialize.max_depth", 4096);
+
+class Test implements Serializable {
+    public function serialize() {
+        return '';
+    }
+    public function unserialize($str) {
+        // Should fail, due to combined nesting level
+        var_dump(unserialize(create_nested_data(129, 'a:1:{i:0;', '}')));
+        // Should succeeed, below combined nesting level
+        var_dump(unserialize(create_nested_data(128, 'a:1:{i:0;', '}')) !== false);
+    }
+}
+echo "Nested unserialize combined depth limit:\n";
+var_dump(is_array(unserialize(
+    create_nested_data(128, 'a:1:{i:0;', '}', 'C:4:"Test":0:{}'),
+    ['max_depth' => 256]
+)));
+
+class Test2 implements Serializable {
+    public function serialize() {
+        return '';
+    }
+    public function unserialize($str) {
+        // If depth limit is overridden, the depth should be counted
+        // from zero again.
+        var_dump(unserialize(
+            create_nested_data(257, 'a:1:{i:0;', '}'),
+            ['max_depth' => 256]
+        ));
+        var_dump(unserialize(
+            create_nested_data(256, 'a:1:{i:0;', '}'),
+            ['max_depth' => 256]
+        ) !== false);
+    }
+}
+echo "Nested unserialize overridden depth limit:\n";
+var_dump(is_array(unserialize(
+    create_nested_data(64, 'a:1:{i:0;', '}', 'C:5:"Test2":0:{}'),
+    ['max_depth' => 128]
+)));
+
 ?>
 --EXPECTF--
+Invalid max_depth:
+
 Warning: unserialize(): max_depth should be int in %s on line %d
 bool(false)
 
 Warning: unserialize(): max_depth cannot be negative in %s on line %d
 bool(false)
+Array:
 bool(true)
 
 Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 1157 of 1294 bytes in %s on line %d
 bool(false)
+Object:
 bool(true)
 
 Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 2834 of 2971 bytes in %s on line %d
 bool(false)
+Default depth:
 bool(true)
 
 Warning: unserialize(): Maximum depth of 4096 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 36869 of 40974 bytes in %s on line %d
 bool(false)
+Ini setting:
 bool(true)
 
 Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 1157 of 1294 bytes in %s on line %d
 bool(false)
+Ini setting overridden:
 bool(true)
 
 Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 2309 of 2574 bytes in %s on line %d
 bool(false)
+Nested unserialize combined depth limit:
+
+Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+
+Notice: unserialize(): Error at offset 1157 of 1294 bytes in %s on line %d
+bool(false)
+bool(true)
+bool(true)
+Nested unserialize overridden depth limit:
+
+Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+
+Notice: unserialize(): Error at offset 2309 of 2574 bytes in %s on line %d
+bool(false)
+bool(true)
+bool(true)

--- a/ext/standard/tests/serialize/max_depth.phpt
+++ b/ext/standard/tests/serialize/max_depth.phpt
@@ -38,7 +38,7 @@ var_dump(unserialize(create_nested_data(4097, 'a:1:{i:0;', '}')));
 
 // Depth can also be adjusted using ini setting
 echo "Ini setting:\n";
-ini_set("unserialize.max_depth", 128);
+ini_set("unserialize_max_depth", 128);
 var_dump(unserialize(create_nested_data(128, 'a:1:{i:0;', '}')) !== false);
 var_dump(unserialize(create_nested_data(129, 'a:1:{i:0;', '}')));
 
@@ -55,7 +55,7 @@ var_dump(unserialize(
 
 // Reset ini setting to a large value,
 // so it's clear that it won't be used in the following.
-ini_set("unserialize.max_depth", 4096);
+ini_set("unserialize_max_depth", 4096);
 
 class Test implements Serializable {
     public function serialize() {
@@ -109,41 +109,41 @@ bool(false)
 Array:
 bool(true)
 
-Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 1157 of 1294 bytes in %s on line %d
 bool(false)
 Object:
 bool(true)
 
-Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 2834 of 2971 bytes in %s on line %d
 bool(false)
 Default depth:
 bool(true)
 
-Warning: unserialize(): Maximum depth of 4096 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+Warning: unserialize(): Maximum depth of 4096 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 36869 of 40974 bytes in %s on line %d
 bool(false)
 Ini setting:
 bool(true)
 
-Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 1157 of 1294 bytes in %s on line %d
 bool(false)
 Ini setting overridden:
 bool(true)
 
-Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 2309 of 2574 bytes in %s on line %d
 bool(false)
 Nested unserialize combined depth limit:
 
-Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 1157 of 1294 bytes in %s on line %d
 bool(false)
@@ -151,7 +151,7 @@ bool(true)
 bool(true)
 Nested unserialize overridden depth limit:
 
-Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 2309 of 2574 bytes in %s on line %d
 bool(false)

--- a/ext/standard/tests/serialize/max_depth.phpt
+++ b/ext/standard/tests/serialize/max_depth.phpt
@@ -32,6 +32,21 @@ var_dump(unserialize(
 var_dump(unserialize(create_nested_data(4096, 'a:1:{i:0;', '}')) !== false);
 var_dump(unserialize(create_nested_data(4097, 'a:1:{i:0;', '}')));
 
+// Depth can also be adjusted using ini setting
+ini_set("unserialize.max_depth", 128);
+var_dump(unserialize(create_nested_data(128, 'a:1:{i:0;', '}')) !== false);
+var_dump(unserialize(create_nested_data(129, 'a:1:{i:0;', '}')));
+
+// But an explicitly specified depth still takes precedence
+var_dump(unserialize(
+    create_nested_data(256, 'a:1:{i:0;', '}'),
+    ['max_depth' => 256]
+) !== false);
+var_dump(unserialize(
+    create_nested_data(257, 'a:1:{i:0;', '}'),
+    ['max_depth' => 256]
+));
+
 ?>
 --EXPECTF--
 Warning: unserialize(): max_depth should be int in %s on line %d
@@ -41,19 +56,31 @@ Warning: unserialize(): max_depth cannot be negative in %s on line %d
 bool(false)
 bool(true)
 
-Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth option in %s on line %d
+Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 1157 of 1294 bytes in %s on line %d
 bool(false)
 bool(true)
 
-Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth option in %s on line %d
+Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 2834 of 2971 bytes in %s on line %d
 bool(false)
 bool(true)
 
-Warning: unserialize(): Maximum depth of 4096 exceeded. The depth limit can be changed using the max_depth option in %s on line %d
+Warning: unserialize(): Maximum depth of 4096 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
 
 Notice: unserialize(): Error at offset 36869 of 40974 bytes in %s on line %d
+bool(false)
+bool(true)
+
+Warning: unserialize(): Maximum depth of 128 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+
+Notice: unserialize(): Error at offset 1157 of 1294 bytes in %s on line %d
+bool(false)
+bool(true)
+
+Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize.max_depth ini setting in %s on line %d
+
+Notice: unserialize(): Error at offset 2309 of 2574 bytes in %s on line %d
 bool(false)

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1315,3 +1315,13 @@ PHP_FUNCTION(memory_get_peak_usage) {
 	RETURN_LONG(zend_memory_peak_usage(real_usage));
 }
 /* }}} */
+
+PHP_INI_BEGIN()
+	STD_PHP_INI_ENTRY("unserialize.max_depth", "4096", PHP_INI_ALL, OnUpdateLong, unserialize_max_depth, php_basic_globals, basic_globals)
+PHP_INI_END()
+
+PHP_MINIT_FUNCTION(var)
+{
+	REGISTER_INI_ENTRIES();
+	return SUCCESS;
+}

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1326,7 +1326,7 @@ PHP_FUNCTION(memory_get_peak_usage) {
 /* }}} */
 
 PHP_INI_BEGIN()
-	STD_PHP_INI_ENTRY("unserialize.max_depth", "4096", PHP_INI_ALL, OnUpdateLong, unserialize_max_depth, php_basic_globals, basic_globals)
+	STD_PHP_INI_ENTRY("unserialize_max_depth", "4096", PHP_INI_ALL, OnUpdateLong, unserialize_max_depth, php_basic_globals, basic_globals)
 PHP_INI_END()
 
 PHP_MINIT_FUNCTION(var)

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -461,7 +461,7 @@ static zend_always_inline int process_nested_data(UNSERIALIZE_PARAMETER, HashTab
 			php_error_docref(NULL, E_WARNING,
 				"Maximum depth of " ZEND_LONG_FMT " exceeded. "
 				"The depth limit can be changed using the max_depth unserialize() option "
-				"or the unserialize.max_depth ini setting",
+				"or the unserialize_max_depth ini setting",
 				(*var_hash)->max_depth);
 			return 0;
 		}

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -31,8 +31,6 @@
 #define VAR_WAKEUP_FLAG 1
 #define VAR_UNSERIALIZE_FLAG 2
 
-#define DEFAULT_MAX_DEPTH 4096
-
 typedef struct {
 	zend_long used_slots;
 	void *next;
@@ -66,7 +64,7 @@ PHPAPI php_unserialize_data_t php_var_unserialize_init() {
 		d->allowed_classes = NULL;
 		d->ref_props = NULL;
 		d->cur_depth = 0;
-		d->max_depth = DEFAULT_MAX_DEPTH;
+		d->max_depth = BG(unserialize_max_depth);
 		d->entries.used_slots = 0;
 		d->entries.next = NULL;
 		if (!BG(serialize_lock)) {
@@ -455,7 +453,8 @@ static zend_always_inline int process_nested_data(UNSERIALIZE_PARAMETER, HashTab
 		if ((*var_hash)->max_depth > 0 && ++(*var_hash)->cur_depth > (*var_hash)->max_depth) {
 			php_error_docref(NULL, E_WARNING,
 				"Maximum depth of " ZEND_LONG_FMT " exceeded. "
-				"The depth limit can be changed using the max_depth option",
+				"The depth limit can be changed using the max_depth unserialize() option "
+				"or the unserialize.max_depth ini setting",
 				(*var_hash)->max_depth);
 			return 0;
 		}

--- a/php.ini-development
+++ b/php.ini-development
@@ -284,11 +284,12 @@ implicit_flush = Off
 ; callback-function.
 unserialize_callback_func =
 
-; The unserialize.max_depth specified the default depth limit for unserialized
+; The unserialize_max_depth specifies the default depth limit for unserialized
 ; structures. Setting the depth limit too high may result in stack overflows
-; during unserialization. The unserialize.max_depth ini setting can be
+; during unserialization. The unserialize_max_depth ini setting can be
 ; overridden by the max_depth option on individual unserialize() calls.
-;unserialize.max_depth = 4096
+; A value of 0 disables the depth limit.
+;unserialize_max_depth = 4096
 
 ; When floats & doubles are serialized, store serialize_precision significant
 ; digits after the floating point. The default value ensures that when floats

--- a/php.ini-development
+++ b/php.ini-development
@@ -284,6 +284,12 @@ implicit_flush = Off
 ; callback-function.
 unserialize_callback_func =
 
+; The unserialize.max_depth specified the default depth limit for unserialized
+; structures. Setting the depth limit too high may result in stack overflows
+; during unserialization. The unserialize.max_depth ini setting can be
+; overridden by the max_depth option on individual unserialize() calls.
+;unserialize.max_depth = 4096
+
 ; When floats & doubles are serialized, store serialize_precision significant
 ; digits after the floating point. The default value ensures that when floats
 ; are decoded with unserialize, the data will remain the same.

--- a/php.ini-production
+++ b/php.ini-production
@@ -284,11 +284,12 @@ implicit_flush = Off
 ; callback-function.
 unserialize_callback_func =
 
-; The unserialize.max_depth specified the default depth limit for unserialized
+; The unserialize_max_depth specifies the default depth limit for unserialized
 ; structures. Setting the depth limit too high may result in stack overflows
-; during unserialization. The unserialize.max_depth ini setting can be
+; during unserialization. The unserialize_max_depth ini setting can be
 ; overridden by the max_depth option on individual unserialize() calls.
-;unserialize.max_depth = 4096
+; A value of 0 disables the depth limit.
+;unserialize_max_depth = 4096
 
 ; When floats & doubles are serialized, store serialize_precision significant
 ; digits after the floating point. The default value ensures that when floats

--- a/php.ini-production
+++ b/php.ini-production
@@ -284,6 +284,12 @@ implicit_flush = Off
 ; callback-function.
 unserialize_callback_func =
 
+; The unserialize.max_depth specified the default depth limit for unserialized
+; structures. Setting the depth limit too high may result in stack overflows
+; during unserialization. The unserialize.max_depth ini setting can be
+; overridden by the max_depth option on individual unserialize() calls.
+;unserialize.max_depth = 4096
+
 ; When floats & doubles are serialized, store serialize_precision significant
 ; digits after the floating point. The default value ensures that when floats
 ; are decoded with unserialize, the data will remain the same.


### PR DESCRIPTION
Fixes [bug #78549](https://bugs.php.net/bug.php?id=78549). It should also address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17584, https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17589 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17664.

This adds a new `max_depth` option to `unserialize()`, which limits the depth of nested data and prevents stack overflows during unserialization. The default value is 4096, which is not far from the stack overflow limit for debug builds. I think this depth limit is large enough that we can safely enable it by default.