### PR TITLE
fix array length passed to zend_hash_str_find_ptr

### DIFF
--- a/ext/intl/msgformat/msgformat_helpers.cpp
+++ b/ext/intl/msgformat/msgformat_helpers.cpp
@@ -191,10 +191,10 @@ static HashTable *umsg_parse_format(MessageFormatter_object *mfo,
 
 		if (name_part.getType() == UMSGPAT_PART_TYPE_ARG_NAME) {
 			UnicodeString argName = mp.getSubstring(name_part);
-			if ((storedType = (Formattable::Type*)zend_hash_str_find_ptr(ret, (char*)argName.getBuffer(), argName.length())) == NULL) {
+			if ((storedType = (Formattable::Type*)zend_hash_str_find_ptr(ret, (char*)argName.getBuffer(), argName.length() * sizeof(UChar))) == NULL) {
 				/* not found already; create new entry in HT */
 				Formattable::Type bogusType = Formattable::kObject;
-				storedType = (Formattable::Type*)zend_hash_str_update_mem(ret, (char*)argName.getBuffer(), argName.length(),
+				storedType = (Formattable::Type*)zend_hash_str_update_mem(ret, (char*)argName.getBuffer(), argName.length() * sizeof(UChar),
 						(void*)&bogusType, sizeof(bogusType));
 			}
 		} else if (name_part.getType() == UMSGPAT_PART_TYPE_ARG_NUMBER) {
@@ -450,7 +450,7 @@ U_CFUNC void umsg_format_helper(MessageFormatter_object *mfo,
 				continue;
 			}
 
-			storedArgType = (Formattable::Type*)zend_hash_str_find_ptr(types, (char*)key.getBuffer(), key.length());
+			storedArgType = (Formattable::Type*)zend_hash_str_find_ptr(types, (char*)key.getBuffer(), key.length() * sizeof(UChar));
 		}
 
 		if (storedArgType != NULL) {


### PR DESCRIPTION
Test case failing: ext/intl/tests/msgfmt_format_simple_types_numeric_strings.phpt
The buffer is of type UChar where each element is 2 bytes each, the function takes in a char array which is a single byte. Casting requires multiplication of length by sizeof(UChar)

For big endian machines, test case produces: `Inconsistent types declared for an argument`.
This is because the byte passed in as the hash key is always 0.

For little endian machines, test case passes, but will fail with the same error if `a` argument is changed to `aa` and `b` is changed to `ab` in the format string. The byte passed in is the actual argument name, but when using `aa` and `ab`, it will only pass in `a`, and produce same error.

GDB images attached:
Big endian:
![s390x - bug 2](https://user-images.githubusercontent.com/35280047/65536490-83aa0680-ded1-11e9-92d0-c89bbb59fe17.png)

Little endian:
![intel - bug 2](https://user-images.githubusercontent.com/35280047/65536485-80af1600-ded1-11e9-8a3d-bd17064cc889.png)

