### PR TITLE
Promote write "use scalar as array" warning to Error

### DIFF
--- a/Zend/tests/arg_unpack/invalid_type.phpt
+++ b/Zend/tests/arg_unpack/invalid_type.phpt
@@ -7,53 +7,37 @@ function test(...$args) {
     var_dump($args);
 }
 
-test(...null);
-test(...42);
-test(...new stdClass);
+try {
+    test(...null);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    test(...42);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    test(...new stdClass);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
-test(1, 2, 3, ..."foo", ...[4, 5]);
-test(1, 2, 3, ...new StdClass, ...3.14, ...[4, 5]);
+try {
+    test(1, 2, 3, ..."foo", ...[4, 5]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    test(1, 2, 3, ...new StdClass, ...3.14, ...[4, 5]);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
---EXPECTF--
-Warning: Only arrays and Traversables can be unpacked in %s on line %d
-array(0) {
-}
-
-Warning: Only arrays and Traversables can be unpacked in %s on line %d
-array(0) {
-}
-
-Warning: Only arrays and Traversables can be unpacked in %s on line %d
-array(0) {
-}
-
-Warning: Only arrays and Traversables can be unpacked in %s on line %d
-array(5) {
-  [0]=>
-  int(1)
-  [1]=>
-  int(2)
-  [2]=>
-  int(3)
-  [3]=>
-  int(4)
-  [4]=>
-  int(5)
-}
-
-Warning: Only arrays and Traversables can be unpacked in %s on line %d
-
-Warning: Only arrays and Traversables can be unpacked in %s on line %d
-array(5) {
-  [0]=>
-  int(1)
-  [1]=>
-  int(2)
-  [2]=>
-  int(3)
-  [3]=>
-  int(4)
-  [4]=>
-  int(5)
-}
+--EXPECT--
+Only arrays and Traversables can be unpacked
+Only arrays and Traversables can be unpacked
+Only arrays and Traversables can be unpacked
+Only arrays and Traversables can be unpacked
+Only arrays and Traversables can be unpacked

--- a/Zend/tests/assign_dim_obj_null_return.phpt
+++ b/Zend/tests/assign_dim_obj_null_return.phpt
@@ -24,7 +24,12 @@ function test() {
     } catch (Error $e) {
         echo $e->getMessage(), "\n";
     }
-    var_dump($true[123] = 456);
+
+    try {
+        var_dump($true[123] = 456);
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
 
     try {
         var_dump($array[] += 123);
@@ -43,7 +48,12 @@ function test() {
     } catch (Error $e) {
         echo $e->getMessage(), "\n";
     }
-    var_dump($true[123] += 456);
+
+    try {
+        var_dump($true[123] += 456);
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
 
     try {
         var_dump($true->foo = 123);
@@ -60,18 +70,14 @@ function test() {
 test();
 
 ?>
---EXPECTF--
+--EXPECT--
 Cannot add element to the array as the next element is already occupied
 Illegal offset type
 Illegal offset type
-
-Warning: Cannot use a scalar value as an array in %s on line %d
-NULL
+Cannot use a scalar value as an array
 Cannot add element to the array as the next element is already occupied
 Illegal offset type
 Illegal offset type
-
-Warning: Cannot use a scalar value as an array in %s on line %d
-NULL
+Cannot use a scalar value as an array
 Attempt to assign property 'foo' of non-object
 Attempt to assign property 'foo' of non-object

--- a/Zend/tests/indexing_001.phpt
+++ b/Zend/tests/indexing_001.phpt
@@ -7,32 +7,48 @@ $array=array(1);
 $testvalues=array(null, 0, 1, true, false,'',' ',0.1,array());
 
 foreach ($testvalues as $testvalue) {
-	$testvalue['foo']=$array;
-	var_dump ($testvalue);
+    try {
+        $testvalue['foo']=$array;
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+    var_dump($testvalue);
 }
 echo "\n*** Indexing - Testing reference assignment with key ***\n";
 
 $testvalues=array(null, 0, 1, true, false,0.1,array());
 
 foreach ($testvalues as $testvalue) {
-	$testvalue['foo']=&$array;
-	var_dump ($testvalue);
+    try {
+        $testvalue['foo']=&$array;
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+    var_dump($testvalue);
 }
 echo "*** Indexing - Testing value assignment no key ***\n";
 $array=array(1);
 $testvalues=array(null, 0, 1, true, false,0.1,array());
 
 foreach ($testvalues as $testvalue) {
-	$testvalue[]=$array;
-	var_dump ($testvalue);
+    try {
+        $testvalue[]=$array;
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+    var_dump ($testvalue);
 }
 echo "\n*** Indexing - Testing reference assignment no key ***\n";
 
 $testvalues=array(null, 0, 1, true, false,0.1,array());
 
 foreach ($testvalues as $testvalue) {
-	$testvalue[]=&$array;
-	var_dump ($testvalue);
+    try {
+        $testvalue[]=&$array;
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+    var_dump ($testvalue);
 }
 
 
@@ -47,14 +63,11 @@ array(1) {
     int(1)
   }
 }
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 int(0)
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 int(1)
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 bool(true)
 array(1) {
   ["foo"]=>
@@ -73,8 +86,7 @@ Warning: Illegal string offset 'foo' in %s on line %d
 
 Notice: Array to string conversion in %s on line %d
 string(1) "A"
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 float(0.1)
 array(1) {
   ["foo"]=>
@@ -92,14 +104,11 @@ array(1) {
     int(1)
   }
 }
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 int(0)
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 int(1)
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 bool(true)
 array(1) {
   ["foo"]=>
@@ -108,8 +117,7 @@ array(1) {
     int(1)
   }
 }
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 float(0.1)
 array(1) {
   ["foo"]=>
@@ -126,14 +134,11 @@ array(1) {
     int(1)
   }
 }
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 int(0)
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 int(1)
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 bool(true)
 array(1) {
   [0]=>
@@ -142,8 +147,7 @@ array(1) {
     int(1)
   }
 }
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 float(0.1)
 array(1) {
   [0]=>
@@ -161,14 +165,11 @@ array(1) {
     int(1)
   }
 }
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 int(0)
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 int(1)
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 bool(true)
 array(1) {
   [0]=>
@@ -177,8 +178,7 @@ array(1) {
     int(1)
   }
 }
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 float(0.1)
 array(1) {
   [0]=>

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1887,7 +1887,7 @@ static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_param_must_be_ref(con
 
 static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_use_scalar_as_array(void)
 {
-	zend_error(E_WARNING, "Cannot use a scalar value as an array");
+	zend_throw_error(NULL, "Cannot use a scalar value as an array");
 }
 
 static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_cannot_add_element(void)
@@ -2172,7 +2172,7 @@ return_null:
 			ZVAL_ERROR(result);
 		} else {
 			if (type == BP_VAR_UNSET) {
-				zend_error(E_WARNING, "Cannot unset offset in a non-array variable");
+				zend_throw_error(NULL, "Cannot unset offset in a non-array variable");
 				ZVAL_NULL(result);
 			} else {
 				zend_use_scalar_as_array();

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4969,7 +4969,7 @@ ZEND_VM_C_LABEL(send_again):
 		zend_object_iterator *iter;
 
 		if (!ce || !ce->get_iterator) {
-			zend_error(E_WARNING, "Only arrays and Traversables can be unpacked");
+			zend_type_error("Only arrays and Traversables can be unpacked");
 		} else {
 
 			iter = ce->get_iterator(ce, args, 0);
@@ -5046,7 +5046,7 @@ ZEND_VM_C_LABEL(send_again):
 		if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(args) == IS_UNDEF)) {
 			ZVAL_UNDEFINED_OP1();
 		}
-		zend_error(E_WARNING, "Only arrays and Traversables can be unpacked");
+		zend_type_error("Only arrays and Traversables can be unpacked");
 	}
 
 	FREE_OP1();
@@ -5752,7 +5752,7 @@ ZEND_VM_C_LABEL(add_unpack_again):
 		zend_object_iterator *iter;
 
 		if (!ce || !ce->get_iterator) {
-			zend_throw_error(NULL, "Only arrays and Traversables can be unpacked");
+			zend_type_error("Only arrays and Traversables can be unpacked");
 		} else {
 			iter = ce->get_iterator(ce, op1, 0);
 			if (UNEXPECTED(!iter)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1928,7 +1928,7 @@ send_again:
 		zend_object_iterator *iter;
 
 		if (!ce || !ce->get_iterator) {
-			zend_error(E_WARNING, "Only arrays and Traversables can be unpacked");
+			zend_type_error("Only arrays and Traversables can be unpacked");
 		} else {
 
 			iter = ce->get_iterator(ce, args, 0);
@@ -2005,7 +2005,7 @@ send_again:
 		if (opline->op1_type == IS_CV && UNEXPECTED(Z_TYPE_P(args) == IS_UNDEF)) {
 			ZVAL_UNDEFINED_OP1();
 		}
-		zend_error(E_WARNING, "Only arrays and Traversables can be unpacked");
+		zend_type_error("Only arrays and Traversables can be unpacked");
 	}
 
 	FREE_OP(opline->op1_type, opline->op1.var);
@@ -2184,7 +2184,7 @@ add_unpack_again:
 		zend_object_iterator *iter;
 
 		if (!ce || !ce->get_iterator) {
-			zend_throw_error(NULL, "Only arrays and Traversables can be unpacked");
+			zend_type_error("Only arrays and Traversables can be unpacked");
 		} else {
 			iter = ce->get_iterator(ce, op1, 0);
 			if (UNEXPECTED(!iter)) {

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -931,10 +931,10 @@ static void ZEND_FASTCALL zend_jit_assign_dim_helper(zval *object_ptr, zval *dim
 		}
 	} else {
 //???		if (OP1_TYPE != IS_VAR || EXPECTED(!Z_ISERROR_P(object_ptr))) {
-			zend_error(E_WARNING, "Cannot use a scalar value as an array");
+			zend_throw_error(NULL, "Cannot use a scalar value as an array");
 //???		}
 		if (result) {
-			ZVAL_NULL(result);
+			ZVAL_UNDEF(result);
 		}
 	}
 }
@@ -978,7 +978,7 @@ static void ZEND_FASTCALL zend_jit_assign_dim_op_helper(zval *container, zval *d
 //???			ZEND_VM_C_GOTO(assign_dim_op_convert_to_array);
 		} else {
 //???			if (UNEXPECTED(OP1_TYPE != IS_VAR || EXPECTED(!Z_ISERROR_P(container)))) {
-				zend_error(E_WARNING, "Cannot use a scalar value as an array");
+				zend_throw_error(NULL, "Cannot use a scalar value as an array");
 //???			}
 //???			if (retval) {
 //???				ZVAL_NULL(retval);

--- a/ext/opcache/tests/jit/assign_dim_002.phpt
+++ b/ext/opcache/tests/jit/assign_dim_002.phpt
@@ -71,9 +71,13 @@ function foo4() {
 foo4();
 
 function foo5() {
-   $a = 1;
-   $a[2] = 1;
-   return $a;
+    $a = 1;
+    try {
+        $a[2] = 1;
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+    return $a;
 }
 var_dump(foo5());
 
@@ -129,6 +133,5 @@ array(1) {
     int(1)
   }
 }
-
-Warning: Cannot use a scalar value as an array in %sassign_dim_002.php on line 65
+Cannot use a scalar value as an array
 int(1)

--- a/tests/lang/bug29893.phpt
+++ b/tests/lang/bug29893.phpt
@@ -3,9 +3,11 @@ Bug #29893 (segfault when using array as index)
 --FILE--
 <?php
 $base = 50;
-$base[$base] -= 0;
+try {
+    $base[$base] -= 0;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
-===DONE===
---EXPECTF--
-Warning: Cannot use a scalar value as an array in %sbug29893.php on line %d
-===DONE===
+--EXPECT--
+Cannot use a scalar value as an array

--- a/tests/lang/engine_assignExecutionOrder_002.phpt
+++ b/tests/lang/engine_assignExecutionOrder_002.phpt
@@ -10,7 +10,11 @@ echo "A=$a B=$b\n";
 
 
 // Warning: Cannot use a scalar value as an array in %s on line %d
-$c[$c=1] = 1;
+try {
+    $c[$c=1] = 1;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 // i++ evaluated first, so $d[0] is 10
 $d = array(0,10);
@@ -90,8 +94,7 @@ print_r($ee);
 ?>
 --EXPECTF--
 A=hello B=bye
-
-Warning: Cannot use a scalar value as an array in %s on line %d
+Cannot use a scalar value as an array
 array(2) {
   [0]=>
   int(10)


### PR DESCRIPTION
Also convert "Only arrays and Traversables can be unpacked" into Error.