### PR TITLE
Reduce memory used by token_get_all()

### DIFF
--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -110,7 +110,11 @@ static void add_token(zval *return_value, int token_type,
 		zval keyword;
 		array_init(&keyword);
 		add_next_index_long(&keyword, token_type);
-		add_next_index_stringl(&keyword, (char *) text, leng);
+		if (leng == 1) {
+			add_next_index_str(&keyword, ZSTR_CHAR(text[0]));
+		} else {
+			add_next_index_stringl(&keyword, (char *) text, leng);
+		}
 		add_next_index_long(&keyword, lineno);
 		add_next_index_zval(return_value, &keyword);
 	} else {


### PR DESCRIPTION
Around a quarter  of all tokens in files would have a string that's one
character long (e.g. ` `, `\`, `1`)

For parsing a large number of php files,
The memory increase dropped from 378374248 to 369535688 (2.5%) (other projects probably have less single-byte tokens)

Script used:

```php
<?php
// Pass the php files to tokenize as CLI args
function main(array $contents) {
    $tokens = [];
    $start = microtime(true);
    $start_mem_virtual = memory_get_usage();
    foreach ($contents as $file_contents) {
        $tokens[] = token_get_all($file_contents);
    }
    $end_mem_virtual = memory_get_usage();
    if (false) {
        $counts = [0,0];
        foreach (array_merge(...$tokens) as $token) {
            if (is_array($token)) {
                $counts[strlen($token[1]) == 1 ? 1 : 0]++;
            }
        }
        // [not_single_byte_count, single_byte_count], e.g. [1429745,628512]
        echo json_encode($counts) . "\n";
    }
    unset($tokens);
    // Count the time needed to create and free tokens.
    $end = microtime(true);
    // printf("Increase in memory:          %d bytes\n", $end_mem - $start_mem);
    printf("Increase in memory(virtual): %d bytes\n", $end_mem_virtual - $start_mem_virtual);
    printf("Time taken to call token_get_all: %.6f seconds\n", $end - $start);
    $n = [];
}
$contents = [];
foreach (array_slice($argv, 1) as $file) {
    $contents[] = file_get_contents($file);
}
for ($i = 0; $i < 10; $i++) {
    main($contents);
}
```