### PR TITLE
Fix #78609: mb_check_encoding() no longer supports stringable objects

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -5027,27 +5027,15 @@ PHP_FUNCTION(mb_check_encoding)
 		RETURN_FALSE;
 	}
 
-	switch(Z_TYPE_P(input)) {
-		case IS_LONG:
-		case IS_DOUBLE:
-		case IS_NULL:
-		case IS_TRUE:
-		case IS_FALSE:
-			RETURN_TRUE;
-			break;
-		case IS_STRING:
-			if (!php_mb_check_encoding(Z_STRVAL_P(input), Z_STRLEN_P(input), enc ? ZSTR_VAL(enc): NULL)) {
-				RETURN_FALSE;
-			}
-			break;
-		case IS_ARRAY:
-			if (!php_mb_check_encoding_recursive(HASH_OF(input), enc)) {
-				RETURN_FALSE;
-			}
-			break;
-		default:
-			php_error_docref(NULL, E_WARNING, "Input is something other than scalar or array");
+	if (Z_TYPE_P(input) == IS_ARRAY) {
+		if (!php_mb_check_encoding_recursive(HASH_OF(input), enc)) {
 			RETURN_FALSE;
+		}
+	} else {
+		convert_to_string(input);
+		if (!php_mb_check_encoding(Z_STRVAL_P(input), Z_STRLEN_P(input), enc ? ZSTR_VAL(enc): NULL)) {
+			RETURN_FALSE;
+		}
 	}
 	RETURN_TRUE;
 }

--- a/ext/mbstring/tests/bug78609.phpt
+++ b/ext/mbstring/tests/bug78609.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #78609 (mb_check_encoding() no longer supports stringable objects)
+--SKIPIF--
+<?php
+if (!extension_loaded('mbstring')) die('skip mbstring extension not available');
+?>
+--FILE--
+<?php
+class Foo
+{
+    public function __toString()
+    {
+        return 'string_representation';
+    }
+}
+
+var_dump(mb_check_encoding(new Foo, 'UTF-8'));
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
We apply type juggling for other types than array.

---

For PHP 7.4+ we have to `try_convert_to_string()` instead.