### PR TITLE
Call error handler for E_COMPILE_WARNING

### DIFF
--- a/Zend/tests/compile_warning_error_handler.phpt
+++ b/Zend/tests/compile_warning_error_handler.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Error handler is invoked for E_COMPILE_WARNING
+--FILE--
+<?php
+
+set_error_handler(function($errno, $errstr) {
+    echo $errstr, "\n";
+});
+
+eval("\1 echo 'Foo\n'; \1;");
+
+set_error_handler(function($errno, $errstr) {
+    throw new Exception($errstr);
+});
+
+try {
+    eval("\1 echo 'Foo'; \1;");
+} catch (Exception $e) {
+    echo $e, "\n";
+}
+
+?>
+--EXPECTF--
+Unexpected character in input:  '%s' (ASCII=1) state=0
+Unexpected character in input:  '%s' (ASCII=1) state=0
+Foo
+Exception: Unexpected character in input:  '%s' (ASCII=1) state=0 in %s:%d
+Stack trace:
+#0 %s(%d): {closure}(%s)
+#1 %s(%d): eval()
+#2 {main}

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1312,7 +1312,6 @@ static ZEND_COLD void zend_error_va_list(
 		case E_CORE_ERROR:
 		case E_CORE_WARNING:
 		case E_COMPILE_ERROR:
-		case E_COMPILE_WARNING:
 			/* The error may not be safe to handle in user-space */
 			zend_error_cb(type, error_filename, error_lineno, format, args);
 			break;

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -882,7 +882,7 @@ ZEND_API void zend_multibyte_yyinput_again(zend_encoding_filter old_input_filter
 		ZVAL_STRINGL(zendlval, yytext, yyleng); \
 	}
 
-static int zend_scan_escape_string(zval *zendlval, char *str, int len, char quote_type)
+static int zend_scan_escape_string(zval *zendlval, char *str, int len, char quote_type, zend_bool throw)
 {
 	register char *s, *t;
 	char *end;
@@ -1018,8 +1018,10 @@ static int zend_scan_escape_string(zval *zendlval, char *str, int len, char quot
 						}
 
 						if (!valid) {
-							zend_throw_exception(zend_ce_parse_error,
-								"Invalid UTF-8 codepoint escape sequence", 0);
+							if (throw) {
+								zend_throw_exception(zend_ce_parse_error,
+									"Invalid UTF-8 codepoint escape sequence", 0);
+							}
 							zval_ptr_dtor(zendlval);
 							ZVAL_UNDEF(zendlval);
 							return FAILURE;
@@ -1030,8 +1032,10 @@ static int zend_scan_escape_string(zval *zendlval, char *str, int len, char quot
 
 						/* per RFC 3629, UTF-8 can only represent 21 bits */
 						if (codepoint > 0x10FFFF || errno) {
-							zend_throw_exception(zend_ce_parse_error,
-								"Invalid UTF-8 codepoint escape sequence: Codepoint too large", 0);
+							if (throw) {
+								zend_throw_exception(zend_ce_parse_error,
+									"Invalid UTF-8 codepoint escape sequence: Codepoint too large", 0);
+							}
 							zval_ptr_dtor(zendlval);
 							ZVAL_UNDEF(zendlval);
 							return FAILURE;
@@ -1822,9 +1826,9 @@ NEWLINE ("\r"|"\n"|"\r\n")
 		size_t i;
 		for (i = 0; i < len; i++) {
 			if (lnum[i] == '8' || lnum[i] == '9') {
-				zend_throw_exception(zend_ce_parse_error, "Invalid numeric literal", 0);
 				ZVAL_UNDEF(zendlval);
 				if (PARSER_MODE()) {
+					zend_throw_exception(zend_ce_parse_error, "Invalid numeric literal", 0);
 					RETURN_TOKEN(T_ERROR);
 				}
 				RETURN_TOKEN_WITH_VAL(T_LNUMBER);
@@ -2310,7 +2314,7 @@ skip_escape_conversion:
 		switch (*YYCURSOR++) {
 			case '"':
 				yyleng = YYCURSOR - SCNG(yy_text);
-				if (EXPECTED(zend_scan_escape_string(zendlval, yytext+bprefix+1, yyleng-bprefix-2, '"') == SUCCESS)
+				if (EXPECTED(zend_scan_escape_string(zendlval, yytext+bprefix+1, yyleng-bprefix-2, '"', PARSER_MODE()) == SUCCESS)
 				 || !PARSER_MODE()) {
 					RETURN_TOKEN_WITH_VAL(T_CONSTANT_ENCAPSED_STRING);
 				} else {
@@ -2403,7 +2407,7 @@ skip_escape_conversion:
 	/* Check for ending label on the next line */
 	if (heredoc_label->length < YYLIMIT - YYCURSOR && !memcmp(YYCURSOR, s, heredoc_label->length)) {
 		if (!IS_LABEL_SUCCESSOR(YYCURSOR[heredoc_label->length])) {
-			if (spacing == (HEREDOC_USING_SPACES | HEREDOC_USING_TABS)) {
+			if (spacing == (HEREDOC_USING_SPACES | HEREDOC_USING_TABS) && PARSER_MODE()) {
 				zend_throw_exception(zend_ce_parse_error, "Invalid indentation - tabs and spaces cannot be mixed", 0);
 			}
 
@@ -2431,6 +2435,7 @@ skip_escape_conversion:
 
 		zend_ptr_stack_reverse_apply(&current_state.heredoc_label_stack, copy_heredoc_label_stack);
 
+		// TODO: Exception logic should no longer be needed!
 		zend_exception_save();
 		while (heredoc_nesting_level) {
 			zval zv;
@@ -2466,7 +2471,7 @@ skip_escape_conversion:
 		    (first_token == T_VARIABLE
 		     || first_token == T_DOLLAR_OPEN_CURLY_BRACES
 		     || first_token == T_CURLY_OPEN
-		    ) && SCNG(heredoc_indentation)) {
+		    ) && SCNG(heredoc_indentation) && PARSER_MODE()) {
 			zend_throw_exception_ex(zend_ce_parse_error, 0, "Invalid body indentation level (expecting an indentation level of at least %d)", SCNG(heredoc_indentation));
 		}
 
@@ -2565,7 +2570,7 @@ skip_escape_conversion:
 double_quotes_scan_done:
 	yyleng = YYCURSOR - SCNG(yy_text);
 
-	if (EXPECTED(zend_scan_escape_string(zendlval, yytext, yyleng, '"') == SUCCESS)
+	if (EXPECTED(zend_scan_escape_string(zendlval, yytext, yyleng, '"', PARSER_MODE()) == SUCCESS)
 	 || !PARSER_MODE()) {
 		RETURN_TOKEN_WITH_VAL(T_ENCAPSED_AND_WHITESPACE);
 	} else {
@@ -2611,7 +2616,7 @@ double_quotes_scan_done:
 
 	yyleng = YYCURSOR - SCNG(yy_text);
 
-	if (EXPECTED(zend_scan_escape_string(zendlval, yytext, yyleng, '`') == SUCCESS)
+	if (EXPECTED(zend_scan_escape_string(zendlval, yytext, yyleng, '`', PARSER_MODE()) == SUCCESS)
 	 || !PARSER_MODE()) {
 		RETURN_TOKEN_WITH_VAL(T_ENCAPSED_AND_WHITESPACE);
 	} else {
@@ -2663,7 +2668,7 @@ double_quotes_scan_done:
 						continue;
 					}
 
-					if (spacing == (HEREDOC_USING_SPACES | HEREDOC_USING_TABS)) {
+					if (spacing == (HEREDOC_USING_SPACES | HEREDOC_USING_TABS) && PARSER_MODE()) {
 						zend_throw_exception(zend_ce_parse_error, "Invalid indentation - tabs and spaces cannot be mixed", 0);
 					}
 
@@ -2727,7 +2732,7 @@ heredoc_scan_done:
 			RETURN_TOKEN(T_ERROR);
 		}
 
-		if (UNEXPECTED(zend_scan_escape_string(zendlval, ZSTR_VAL(copy), ZSTR_LEN(copy), 0) != SUCCESS)) {
+		if (UNEXPECTED(zend_scan_escape_string(zendlval, ZSTR_VAL(copy), ZSTR_LEN(copy), 0, PARSER_MODE()) != SUCCESS)) {
 			zend_string_efree(copy);
 			RETURN_TOKEN(T_ERROR);
 		}
@@ -2784,7 +2789,7 @@ heredoc_scan_done:
 						continue;
 					}
 
-					if (spacing == (HEREDOC_USING_SPACES | HEREDOC_USING_TABS)) {
+					if (spacing == (HEREDOC_USING_SPACES | HEREDOC_USING_TABS) && PARSER_MODE()) {
 						zend_throw_exception(zend_ce_parse_error, "Invalid indentation - tabs and spaces cannot be mixed", 0);
 					}
 

--- a/ext/tokenizer/tests/compile_warning_error_handler.phpt
+++ b/ext/tokenizer/tests/compile_warning_error_handler.phpt
@@ -14,11 +14,19 @@ set_error_handler(function($errno, $errstr) {
 });
 
 // The exceptions get eaten
-var_dump(count(token_get_all("<?php \1 echo 'Foo'; \1;")));
+try {
+    var_dump(count(token_get_all("<?php \1 echo 'Foo'; \1;")));
+} catch (Exception $e) {
+    echo $e, "\n";
+}
 
 ?>
---EXPECT--
-Unexpected character in input:  '' (ASCII=1) state=0
-Unexpected character in input:  '' (ASCII=1) state=0
+--EXPECTF--
+Unexpected character in input:  '%s' (ASCII=1) state=0
+Unexpected character in input:  '%s' (ASCII=1) state=0
 int(10)
-int(10)
+Exception: Unexpected character in input:  '%s' (ASCII=1) state=0 in %s:%d
+Stack trace:
+#0 [internal function]: {closure}(%s)
+#1 %s(%d): token_get_all(%s)
+#2 {main}

--- a/ext/tokenizer/tests/compile_warning_error_handler.phpt
+++ b/ext/tokenizer/tests/compile_warning_error_handler.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Error handler is invoked for E_COMPILE_WARNING
+--FILE--
+<?php
+
+set_error_handler(function($errno, $errstr) {
+    echo $errstr, "\n";
+});
+
+var_dump(count(token_get_all("<?php \1 echo 'Foo\n'; \1;")));
+
+set_error_handler(function($errno, $errstr) {
+    throw new Exception($errstr);
+});
+
+// The exceptions get eaten
+var_dump(count(token_get_all("<?php \1 echo 'Foo'; \1;")));
+
+?>
+--EXPECT--
+Unexpected character in input:  '' (ASCII=1) state=0
+Unexpected character in input:  '' (ASCII=1) state=0
+int(10)
+int(10)

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -282,8 +282,6 @@ PHP_FUNCTION(token_get_all)
 		success = tokenize_parse(return_value, source);
 	} else {
 		success = tokenize(return_value, source);
-		/* Normal token_get_all() should not throw. */
-		zend_clear_exception();
 	}
 
 	if (!success) RETURN_FALSE;


### PR DESCRIPTION
Fixes [bug #78537](https://bugs.php.net/bug.php?id=78537). Calling error handler from the compiler is considered safe nowadays.

The main complication is that token_get_all() currently discards exceptions thrown during lexing. However, if an error handler throws an exception, we wouldn't want to discard that. So instead this changes the lexer to only throw exceptions if PARSER_MODE() is enabled.

cc @TysonAndre 