### PR TITLE
support 1 dialect

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -415,7 +415,7 @@ static int firebird_alloc_prepare_stmt(pdo_dbh_t *dbh, const char *sql, size_t s
 	}
 
 	/* prepare the statement */
-	if (isc_dsql_prepare(H->isc_status, &H->tr, s, 0, new_sql, PDO_FB_DIALECT, out_sqlda)) {
+	if (isc_dsql_prepare(H->isc_status, &H->tr, s, 0, new_sql, H->sql_dialect, out_sqlda)) {
 		RECORD_ERROR(dbh);
 		efree(new_sql);
 		return 0;
@@ -622,6 +622,7 @@ static int pdo_firebird_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* 
 		{ "dbname", NULL, 0 },
 		{ "charset",  NULL,	0 },
 		{ "role", NULL,	0 },
+		{ "dialect", "3", 0 },
 		{ "user", NULL, 0 },
 		{ "password", NULL, 0 }
 	};
@@ -630,14 +631,14 @@ static int pdo_firebird_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* 
 
 	pdo_firebird_db_handle *H = dbh->driver_data = pecalloc(1,sizeof(*H),dbh->is_persistent);
 
-	php_pdo_parse_data_source(dbh->data_source, dbh->data_source_len, vars, 5);
+	php_pdo_parse_data_source(dbh->data_source, dbh->data_source_len, vars, 6);
 
-	if (!dbh->username && vars[3].optval) {
-		dbh->username = pestrdup(vars[3].optval, dbh->is_persistent);
+	if (!dbh->username && vars[4].optval) {
+		dbh->username = pestrdup(vars[4].optval, dbh->is_persistent);
 	}
 
-	if (!dbh->password && vars[4].optval) {
-		dbh->password = pestrdup(vars[4].optval, dbh->is_persistent);
+	if (!dbh->password && vars[5].optval) {
+		dbh->password = pestrdup(vars[5].optval, dbh->is_persistent);
 	}
 
 	do {
@@ -656,6 +657,11 @@ static int pdo_firebird_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* 
 				dpb += dpb_len;
 				buf_len -= dpb_len;
 			}
+		}
+		
+		H->sql_dialect = PDO_FB_DIALECT;
+		if (vars[3].optval) {
+			H->sql_dialect = atoi(vars[3].optval);
 		}
 
 		/* fire it up baby! */

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -372,7 +372,9 @@ static int firebird_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr,  /* {{
 
 			*ptr = FETCH_BUF(S->fetch_buf[colno], char, CHAR_BUF_LEN, NULL);
 
-			if (n >= 0) {
+			if((var->sqltype & ~1)==SQL_DOUBLE) {
+				*len = slprintf(*ptr, CHAR_BUF_LEN, "%.*F", -var->sqlscale, *(double*)var->sqldata);
+			} else if (n >= 0) {
 				*len = slprintf(*ptr, CHAR_BUF_LEN, "%" LL_MASK "d.%0*" LL_MASK "d",
 					n / f, -var->sqlscale, n % f);
 			} else if (n <= -f) {

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -372,7 +372,7 @@ static int firebird_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr,  /* {{
 
 			*ptr = FETCH_BUF(S->fetch_buf[colno], char, CHAR_BUF_LEN, NULL);
 
-			if((var->sqltype & ~1)==SQL_DOUBLE) {
+			if ((var->sqltype & ~1) == SQL_DOUBLE) {
 				*len = slprintf(*ptr, CHAR_BUF_LEN, "%.*F", -var->sqlscale, *(double*)var->sqldata);
 			} else if (n >= 0) {
 				*len = slprintf(*ptr, CHAR_BUF_LEN, "%" LL_MASK "d.%0*" LL_MASK "d",

--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -84,12 +84,12 @@ typedef struct {
 	char *time_format;
 	char *timestamp_format;
 	
-	unsigned sql_dialect;	
+	unsigned sql_dialect:2;	
 
 	/* prepend table names on column names in fetch */
 	unsigned fetch_table_names:1;
 
-	unsigned _reserved:31;
+	unsigned _reserved:29;
 
 } pdo_firebird_db_handle;
 

--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -83,6 +83,8 @@ typedef struct {
 	char *date_format;
 	char *time_format;
 	char *timestamp_format;
+	
+	unsigned sql_dialect;	
 
 	/* prepend table names on column names in fetch */
 	unsigned fetch_table_names:1;

--- a/ext/pdo_firebird/tests/dialect_1.phpt
+++ b/ext/pdo_firebird/tests/dialect_1.phpt
@@ -18,7 +18,7 @@ if (strpos(getenv('PDO_FIREBIRD_TEST_DSN'), 'dialect=1')===false) {
 	  1 as N, 
 	  2.0 as F, 
 	  cast(0.76 as numeric(15, 2)) as K,
-      cast(\'2019-06-12\' as date) as DT	  
+	  cast(\'2019-06-12\' as date) as DT	  
 	FROM RDB$DATABASE';
 	$query = $dbh->prepare($sql);
 	$query->execute();
@@ -29,6 +29,21 @@ if (strpos(getenv('PDO_FIREBIRD_TEST_DSN'), 'dialect=1')===false) {
 	var_dump($row->DT);
 
 	unset($query);
+	
+	$dbh->exec('RECREATE TABLE test_d1(K numeric(15, 2), DT date)');
+	$sql='INSERT INTO test_d1(K, DT) values(?, ?)';
+	$query = $dbh->prepare($sql);
+	$query->execute([0.76, '2019-06-12']);
+	unset($query);
+	
+	$sql='SELECT * FROM test_d1';
+	$query = $dbh->prepare($sql);
+	$query->execute();
+	$row = $query->fetch(\PDO::FETCH_OBJ);
+	var_dump($row->K);
+	var_dump($row->DT);
+	
+	unset($query);
 	unset($dbh);
 	echo "done\n";
 
@@ -36,6 +51,8 @@ if (strpos(getenv('PDO_FIREBIRD_TEST_DSN'), 'dialect=1')===false) {
 --EXPECT--
 int(1)
 string(8) "2.000000"
+string(3) "0.76"
+string(19) "2019-06-12 00:00:00"
 string(3) "0.76"
 string(19) "2019-06-12 00:00:00"
 done

--- a/ext/pdo_firebird/tests/dialect_1.phpt
+++ b/ext/pdo_firebird/tests/dialect_1.phpt
@@ -51,8 +51,8 @@ if (strpos(getenv('PDO_FIREBIRD_TEST_DSN'), 'dialect=1')===false) {
 --EXPECT--
 int(1)
 string(8) "2.000000"
-string(3) "0.76"
+string(4) "0.76"
 string(19) "2019-06-12 00:00:00"
-string(3) "0.76"
+string(4) "0.76"
 string(19) "2019-06-12 00:00:00"
 done

--- a/ext/pdo_firebird/tests/dialect_1.phpt
+++ b/ext/pdo_firebird/tests/dialect_1.phpt
@@ -1,0 +1,41 @@
+--TEST--
+PDO_Firebird: support 1 sql dialect
+--SKIPIF--
+<?php require('skipif.inc'); 
+if (strpos(getenv('PDO_FIREBIRD_TEST_DSN'), 'dialect=1')===false) {
+    die('skip: PDO_FIREBIRD_TEST_DSN must contain a string "dialect=1"');	
+}	
+?>
+--FILE--
+<?php
+	require("testdb.inc");
+
+	$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+	$dbh->setAttribute(PDO::FB_ATTR_TIMESTAMP_FORMAT, '%Y-%m-%d %H:%M:%S');
+
+	$sql = 
+	'SELECT 
+	  1 as N, 
+	  2.0 as F, 
+	  cast(0.76 as numeric(15, 2)) as K,
+      cast(\'2019-06-12\' as date) as DT	  
+	FROM RDB$DATABASE';
+	$query = $dbh->prepare($sql);
+	$query->execute();
+	$row = $query->fetch(\PDO::FETCH_OBJ);
+	var_dump($row->N);
+	var_dump($row->F);
+	var_dump($row->K);
+	var_dump($row->DT);
+
+	unset($query);
+	unset($dbh);
+	echo "done\n";
+
+?>
+--EXPECT--
+int(1)
+string(8) "2.000000"
+string(3) "0.76"
+string(19) "2019-06-12 00:00:00"
+done


### PR DESCRIPTION
This change adds support for databases created in 1 dialect. It also fixes bugs https://bugs.php.net/bug.php?id=71652 and https://bugs.php.net/bug.php?id=65690.
Added dialect parameter to DSN. By default, it is 3.

```php
try {
	$dsn = 'firebird:dbname=localhost/3053:test;charset=utf-8;dialect=1';
	$user = 'SYSDBA';
	$password = 'masterkey';
	$att = new \PDO($dsn, $user, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
	$sql = 
	'SELECT 
	  1 as n, 
	  2.0 as f, 
	  cast(0.76 as numeric(15, 2)) as k,
      cast(\'2019-06-12\' as date) as dt	  
	FROM RDB$DATABASE';
	$query = $att->prepare($sql);
	$query->execute();
	
	$rows = $query->fetchAll(\PDO::FETCH_OBJ);
	$json = json_encode($rows, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
	echo "<pre>$json</pre>";
}
catch(\Throwable $e) {
	echo $e->getMessage() . '<br>';
	echo '<pre>' . $e->getTraceAsString() . '</pre>';
}
```


