### PR TITLE
Reduce default serialize depth limit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,73 +12,8 @@ trigger:
       - UPGRADING.INTERNALS
 
 jobs:
-  - template: azure/job.yml
+  - template: azure/msan_job.yml
     parameters:
-      configurationName: DEBUG_NTS
-      configurationParameters: '--enable-debug --disable-maintainer-zts'
-  - template: azure/job.yml
-    parameters:
-      configurationName: RELEASE_ZTS
+      configurationName: RELEASE_ZTS_MSAN
       configurationParameters: '--disable-debug --enable-maintainer-zts'
-  - template: azure/i386/job.yml
-    parameters:
-      configurationName: I386_DEBUG_ZTS
-      configurationParameters: '--enable-debug --enable-maintainer-zts'
-  - template: azure/macos/job.yml
-    parameters:
-      configurationName: MACOS_DEBUG_NTS
-      configurationParameters: '--enable-debug --disable-maintainer-zts'
-  - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
-    - template: azure/job.yml
-      parameters:
-        configurationName: DEBUG_ZTS
-        configurationParameters: '--enable-debug --enable-maintainer-zts'
-    - template: azure/job.yml
-      parameters:
-        configurationName: RELEASE_NTS
-        configurationParameters: '--disable-debug --disable-maintainer-zts'
-    - template: azure/i386/job.yml
-      parameters:
-        configurationName: I386_DEBUG_NTS
-        configurationParameters: '--enable-debug --disable-maintainer-zts'
-    - template: azure/i386/job.yml
-      parameters:
-        configurationName: I386_RELEASE_NTS
-        configurationParameters: '--disable-debug --disable-maintainer-zts'
-    - template: azure/i386/job.yml
-      parameters:
-        configurationName: I386_RELEASE_ZTS
-        configurationParameters: '--disable-debug --enable-maintainer-zts'
-    - template: azure/macos/job.yml
-      parameters:
-        configurationName: MACOS_DEBUG_ZTS
-        configurationParameters: '--enable-debug --enable-maintainer-zts'
-    - template: azure/macos/job.yml
-      parameters:
-        configurationName: MACOS_RELEASE_NTS
-        configurationParameters: '--disable-debug --disable-maintainer-zts'
-    - template: azure/macos/job.yml
-      parameters:
-        configurationName: MACOS_RELEASE_ZTS
-        configurationParameters: '--disable-debug --enable-maintainer-zts'
-    - template: azure/job.yml
-      parameters:
-        configurationName: DEBUG_ZTS_ASAN_UBSAN
-        configurationParameters: >-
-            --enable-debug --enable-maintainer-zts
-            CFLAGS='-fsanitize=undefined,address -DZEND_TRACK_ARENA_ALLOC'
-            LDFLAGS='-fsanitize=undefined,address'
-        runTestsParameters: --asan
-        timeoutInMinutes: 120
-    - template: azure/msan_job.yml
-      parameters:
-        configurationName: RELEASE_ZTS_MSAN
-        configurationParameters: '--disable-debug --enable-maintainer-zts'
-        runTestsParameters: --asan
-    - template: azure/community_job.yml
-      parameters:
-        configurationName: COMMUNITY
-        configurationParameters: >-
-            --enable-debug --enable-maintainer-zts
-            CFLAGS='-fsanitize=undefined,address -fno-sanitize-recover -DZEND_TRACK_ARENA_ALLOC'
-            LDFLAGS='-fsanitize=undefined,address'
+      runTestsParameters: --asan

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,8 +72,8 @@ jobs:
         timeoutInMinutes: 120
     - template: azure/msan_job.yml
       parameters:
-        configurationName: DEBUG_ZTS_MSAN
-        configurationParameters: '--enable-debug --enable-maintainer-zts'
+        configurationName: RELEASE_ZTS_MSAN
+        configurationParameters: '--disable-debug --enable-maintainer-zts'
         runTestsParameters: --asan
     - template: azure/community_job.yml
       parameters:

--- a/azure/msan_job.yml
+++ b/azure/msan_job.yml
@@ -14,7 +14,7 @@ jobs:
     - script: |
         export CC=clang
         export CXX=clang++
-        export CFLAGS="-fsanitize=memory -DZEND_TRACK_ARENA_ALLOC"
+        export CFLAGS="-fsanitize=memory -DZEND_TRACK_ARENA_ALLOC -gline-tables-only"
         export LDFLAGS="-fsanitize=memory"
         ./buildconf --force
         # msan requires all used libraries to be instrumented,

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1326,7 +1326,7 @@ PHP_FUNCTION(memory_get_peak_usage) {
 /* }}} */
 
 PHP_INI_BEGIN()
-	STD_PHP_INI_ENTRY("unserialize_max_depth", "4096", PHP_INI_ALL, OnUpdateLong, unserialize_max_depth, php_basic_globals, basic_globals)
+	STD_PHP_INI_ENTRY("unserialize_max_depth", "3000", PHP_INI_ALL, OnUpdateLong, unserialize_max_depth, php_basic_globals, basic_globals)
 PHP_INI_END()
 
 PHP_MINIT_FUNCTION(var)

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1326,7 +1326,7 @@ PHP_FUNCTION(memory_get_peak_usage) {
 /* }}} */
 
 PHP_INI_BEGIN()
-	STD_PHP_INI_ENTRY("unserialize_max_depth", "2000", PHP_INI_ALL, OnUpdateLong, unserialize_max_depth, php_basic_globals, basic_globals)
+	STD_PHP_INI_ENTRY("unserialize_max_depth", "1000", PHP_INI_ALL, OnUpdateLong, unserialize_max_depth, php_basic_globals, basic_globals)
 PHP_INI_END()
 
 PHP_MINIT_FUNCTION(var)

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1326,7 +1326,7 @@ PHP_FUNCTION(memory_get_peak_usage) {
 /* }}} */
 
 PHP_INI_BEGIN()
-	STD_PHP_INI_ENTRY("unserialize_max_depth", "3000", PHP_INI_ALL, OnUpdateLong, unserialize_max_depth, php_basic_globals, basic_globals)
+	STD_PHP_INI_ENTRY("unserialize_max_depth", "2000", PHP_INI_ALL, OnUpdateLong, unserialize_max_depth, php_basic_globals, basic_globals)
 PHP_INI_END()
 
 PHP_MINIT_FUNCTION(var)


### PR DESCRIPTION
Let's see if this avoids a stack overflow in the msan configuration.