### PR TITLE
Replace "unexpected character" warning with ParseError

### DIFF
--- a/Zend/tests/warning_during_heredoc_scan_ahead.phpt
+++ b/Zend/tests/warning_during_heredoc_scan_ahead.phpt
@@ -4,15 +4,12 @@ No warnings should be thrown during heredoc scan-ahead
 <?php
 
 <<<TEST
-${x}
 \400
 ${/*}
 TEST;
 
 ?>
 --EXPECTF--
-Warning: Unexpected character in input:  '' (ASCII=1) state=0 in %s on line %d
-
 Warning: Octal escape sequence overflow \400 is greater than \377 in %s on line %d
 
 Warning: Unterminated comment starting line %d in %s on line %d

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -2834,14 +2834,7 @@ nowdoc_scan_done:
 		RETURN_TOKEN(END);
 	}
 
-	if (!SCNG(heredoc_scan_ahead)) {
-		zend_error(E_COMPILE_WARNING, "Unexpected character in input:  '%c' (ASCII=%d) state=%d", yytext[0], yytext[0], YYSTATE);
-	}
-	if (PARSER_MODE()) {
-		goto restart;
-	} else {
-		RETURN_TOKEN(T_BAD_CHARACTER);
-	}
+	RETURN_TOKEN(T_BAD_CHARACTER);
 }
 
 */

--- a/ext/tokenizer/tests/bad_character.phpt
+++ b/ext/tokenizer/tests/bad_character.phpt
@@ -19,27 +19,21 @@ foreach ($codes as $code) {
             echo $token, "\n";
         }
     }
+    echo "\n";
 }
 
 ?>
---EXPECTF--
-Warning: Unexpected character in input:  ' in %s on line %d
+--EXPECT--
 T_OPEN_TAG 6
 T_BAD_CHARACTER 1
 T_WHITESPACE 1
 T_STRING 3
 
-Warning: Unexpected character in input:  '%s' (ASCII=1) state=0 in %s on line %d
 T_OPEN_TAG 6
 T_BAD_CHARACTER 1
 T_WHITESPACE 1
 T_STRING 3
 
-Warning: Unexpected character in input:  '%s' (ASCII=1) state=0 in %s on line %d
-
-Warning: Unexpected character in input:  '%s' (ASCII=2) state=0 in %s on line %d
-
-Warning: Unexpected character in input:  '%s' (ASCII=3) state=0 in %s on line %d
 T_OPEN_TAG 6
 T_BAD_CHARACTER 1
 T_BAD_CHARACTER 1

--- a/tests/lang/bug71897.phpt
+++ b/tests/lang/bug71897.phpt
@@ -10,6 +10,4 @@ eval("
 
 ?>
 --EXPECTF--
-Warning: Unexpected character in input:  '%s' (ASCII=127) state=0 in %s(%d) : eval()'d code on line %d
-
-Parse error: syntax error, unexpected 'b' (T_STRING) in %s(%d) : eval()'d code on line %d
+Parse error: syntax error, unexpected '%s' (T_BAD_CHARACTER) in %s on line %d


### PR DESCRIPTION
Return T_BAD_CHARACTER and treat this as a normal ParseError.

cc @TysonAndre 