### PR TITLE
Add fdiv() function

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1143,6 +1143,11 @@ ZEND_BEGIN_ARG_INFO(arginfo_fmod, 0)
 	ZEND_ARG_INFO(0, y)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_fdiv, 0)
+	ZEND_ARG_INFO(0, x)
+	ZEND_ARG_INFO(0, y)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_intdiv, 0)
 	ZEND_ARG_INFO(0, dividend)
 	ZEND_ARG_INFO(0, divisor)
@@ -2287,6 +2292,7 @@ static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(base_convert,													arginfo_base_convert)
 	PHP_FE(number_format,													arginfo_number_format)
 	PHP_FE(fmod,															arginfo_fmod)
+	PHP_FE(fdiv,															arginfo_fdiv)
 	PHP_FE(intdiv,															arginfo_intdiv)
 #ifdef HAVE_INET_NTOP
 	PHP_RAW_NAMED_FE(inet_ntop,		zif_inet_ntop,								arginfo_inet_ntop)

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1144,8 +1144,8 @@ ZEND_BEGIN_ARG_INFO(arginfo_fmod, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_fdiv, 0)
-	ZEND_ARG_INFO(0, x)
-	ZEND_ARG_INFO(0, y)
+	ZEND_ARG_INFO(0, dividend)
+	ZEND_ARG_INFO(0, divisor)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_intdiv, 0)

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1296,21 +1296,22 @@ PHP_FUNCTION(fmod)
 }
 /* }}} */
 
-/* {{{ proto float fdiv(float x, float y)
-   Perform floating-point division of x / y with IEEE-754 semantics for division by zero. */
+/* {{{ proto float fdiv(float dividend, float divisor)
+   Perform floating-point division of dividend / divisor
+   with IEEE-754 semantics for division by zero. */
 #ifdef __clang__
 __attribute__((no_sanitize("float-divide-by-zero")))
 #endif
 PHP_FUNCTION(fdiv)
 {
-	double num1, num2;
+	double dividend, divisor;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_DOUBLE(num1)
-		Z_PARAM_DOUBLE(num2)
+		Z_PARAM_DOUBLE(dividend)
+		Z_PARAM_DOUBLE(divisor)
 	ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_DOUBLE(num1 / num2);
+	RETURN_DOUBLE(dividend / divisor);
 }
 /* }}} */
 

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1296,6 +1296,24 @@ PHP_FUNCTION(fmod)
 }
 /* }}} */
 
+/* {{{ proto float fdiv(float x, float y)
+   Perform floating-point division of x / y with IEEE-754 semantics for division by zero. */
+#ifdef __clang__
+__attribute__((no_sanitize("float-divide-by-zero")))
+#endif
+PHP_FUNCTION(fdiv)
+{
+	double num1, num2;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_DOUBLE(num1)
+		Z_PARAM_DOUBLE(num2)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_DOUBLE(num1 / num2);
+}
+/* }}} */
+
 /* {{{ proto int intdiv(int dividend, int divisor)
    Returns the integer quotient of the division of dividend by divisor */
 PHP_FUNCTION(intdiv)

--- a/ext/standard/php_math.h
+++ b/ext/standard/php_math.h
@@ -59,6 +59,7 @@ PHP_FUNCTION(octdec);
 PHP_FUNCTION(base_convert);
 PHP_FUNCTION(number_format);
 PHP_FUNCTION(fmod);
+PHP_FUNCTION(fdiv);
 PHP_FUNCTION(deg2rad);
 PHP_FUNCTION(rad2deg);
 PHP_FUNCTION(intdiv);

--- a/ext/standard/tests/math/fdiv.phpt
+++ b/ext/standard/tests/math/fdiv.phpt
@@ -1,0 +1,78 @@
+--TEST--
+fdiv() function
+--FILE--
+<?php
+
+var_dump(fdiv(10, 3));
+var_dump(fdiv(10., 3.));
+var_dump(fdiv(-10., 2.5));
+var_dump(fdiv(10., -2.5));
+echo "\n";
+var_dump(fdiv(10., 0.));
+var_dump(fdiv(10., -0.));
+var_dump(fdiv(-10., 0.));
+var_dump(fdiv(-10., -0.));
+echo "\n";
+var_dump(fdiv(INF, 0.));
+var_dump(fdiv(INF, -0.));
+var_dump(fdiv(-INF, 0.));
+var_dump(fdiv(-INF, -0.));
+echo "\n";
+var_dump(fdiv(0., 0.));
+var_dump(fdiv(0., -0.));
+var_dump(fdiv(-0., 0.));
+var_dump(fdiv(-0., -0.));
+echo "\n";
+var_dump(fdiv(INF, INF));
+var_dump(fdiv(INF, -INF));
+var_dump(fdiv(-INF, INF));
+var_dump(fdiv(-INF, -INF));
+echo "\n";
+var_dump(fdiv(0., INF));
+var_dump(fdiv(0., -INF));
+var_dump(fdiv(-0., INF));
+var_dump(fdiv(-0., -INF));
+echo "\n";
+var_dump(fdiv(NAN, NAN));
+var_dump(fdiv(INF, NAN));
+var_dump(fdiv(0., NAN));
+var_dump(fdiv(NAN, INF));
+var_dump(fdiv(NAN, 0.));
+
+?>
+--EXPECT--
+float(3.3333333333333)
+float(3.3333333333333)
+float(-4)
+float(-4)
+
+float(INF)
+float(-INF)
+float(-INF)
+float(INF)
+
+float(INF)
+float(-INF)
+float(-INF)
+float(INF)
+
+float(NAN)
+float(NAN)
+float(NAN)
+float(NAN)
+
+float(NAN)
+float(NAN)
+float(NAN)
+float(NAN)
+
+float(0)
+float(-0)
+float(-0)
+float(0)
+
+float(NAN)
+float(NAN)
+float(NAN)
+float(NAN)
+float(NAN)


### PR DESCRIPTION
The fdiv() function is part of the fmod() / intdiv() family. It implements a floating-point division with IEEE-754 semantics. That is, division by zero is considered well-defined and does not trigger any kind of diagnostic. Instead one of INF, -INF or NAN will be returned, depending on the case.

This is in preparation for throwing DivisionByZeroError from the standard division operator.