### PR TITLE
SOAP Extension: tests re Invalid fault code warnings.

### DIFF
--- a/ext/soap/tests/fault001.phpt
+++ b/ext/soap/tests/fault001.phpt
@@ -1,0 +1,10 @@
+--TEST--
+is_soap_fault 1: test against null
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+echo (int) is_soap_fault(null);
+?>
+--EXPECT--
+0

--- a/ext/soap/tests/fault002.phpt
+++ b/ext/soap/tests/fault002.phpt
@@ -1,0 +1,11 @@
+--TEST--
+is_soap_fault 2: test against constructed SoapFault instance.
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$fault = new SoapFault("code", "message");
+echo (int) is_soap_fault($fault);
+?>
+--EXPECT--
+1

--- a/ext/soap/tests/fault003.phpt
+++ b/ext/soap/tests/fault003.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Invalid Fault code - if an empty string
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$fault = new SoapFault("", "message");
+?>
+--EXPECTF--
+Warning: SoapFault::SoapFault(): Invalid fault code in %s on line %d

--- a/ext/soap/tests/fault_warning.phpt
+++ b/ext/soap/tests/fault_warning.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Invalid Fault code warning given? Can't be an empty string, an array of not 2 elements etc.
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$fault = new SoapFault("", "message"); // Can't be an empty string
+$fault = new SoapFault(0, "message");  // Can't be a non-string (except for null)
+$fault = new SoapFault("Sender", "message");
+echo get_class($fault) . "\n";
+$fault = new SoapFault(null, "message");
+echo get_class($fault) . "\n";
+$fault = new SoapFault(["more"], "message");  // two elements in array required
+$fault = new SoapFault(["m", "more", "superflous"], "message"); // two required
+$fault = new SoapFault(["more-ns", "Sender"], "message");  // two given
+echo get_class($fault);
+?>
+--EXPECTF--
+Warning: SoapFault::SoapFault(): Invalid fault code in %s on line %d
+
+Warning: SoapFault::SoapFault(): Invalid fault code in %s on line %d
+SoapFault
+SoapFault
+
+Warning: SoapFault::SoapFault(): Invalid fault code in %s on line %d
+
+Warning: SoapFault::SoapFault(): Invalid fault code in %s on line %d
+SoapFault


### PR DESCRIPTION
SOAP Extension: test 'invalid fault code' message/condition.

SOAP Extension: test is_soap_fault function.