### PR TITLE
fix #78624: session_gc return value for user-defined session handlers

### DIFF
--- a/ext/session/mod_user.c
+++ b/ext/session/mod_user.c
@@ -192,14 +192,15 @@ PS_GC_FUNC(user)
 
 	if (Z_TYPE(retval) == IS_LONG) {
 		convert_to_long(&retval);
-		return Z_LVAL(retval);
+		*nrdels = Z_LVAL(retval);
+	} else if (Z_TYPE(retval) == IS_TRUE) {
+		/* This is for older API compatibility */
+		*nrdels = 1;
+	} else {
+		/* Anything else is some kind of error */
+		*nrdels = -1; // Error
 	}
-	/* This is for older API compatibility */
-	if (Z_TYPE(retval) == IS_TRUE) {
-		return 1;
-	}
-	/* Anything else is some kind of error */
-	return -1; // Error
+	return *nrdels;
 }
 
 PS_CREATE_SID_FUNC(user)

--- a/ext/session/tests/bug78624.phpt
+++ b/ext/session/tests/bug78624.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Test session_set_save_handler() : session_gc() returns the number of deleted records.
+--INI--
+session.name=PHPSESSID
+session.save_handler=files
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+
+ob_start();
+
+/*
+ * Prototype : bool session_set_save_handler(SessionHandler $handler [, bool $register_shutdown_function = true])
+ * Description : Sets user-level session storage functions
+ * Source code : ext/session/session.c
+ */
+
+echo "*** Test session_set_save_handler() : session_gc() returns the number of deleted records. ***\n";
+
+class MySession implements SessionHandlerInterface {
+    public function open($path, $name) {
+        echo 'Open', "\n";
+        return true;
+    }
+    public function read($key) {
+        echo 'Read ', session_id(), "\n";
+        return '';
+    }
+    public function write($key, $data) {
+        echo 'Write ', session_id(), "\n";
+        return true;
+    }
+    public function close() {
+        echo 'Close ', session_id(), "\n";
+        return true;
+    }
+    public function destroy($key) {
+        echo 'Destroy ', session_id(), "\n";
+        return true;
+    }
+    public function gc($ts) {
+        echo 'Garbage collect', "\n";
+        return 1;
+    }
+}
+
+$handler = new MySession;
+session_set_save_handler($handler);
+session_start();
+var_dump(session_gc());
+session_write_close();
+
+--EXPECTF--
+*** Test session_set_save_handler() : session_gc() returns the number of deleted records. ***
+Open
+Read %s
+Garbage collect
+int(1)
+Write %s
+Close %s

--- a/ext/session/tests/session_set_save_handler_basic.phpt
+++ b/ext/session/tests/session_set_save_handler_basic.phpt
@@ -49,6 +49,12 @@ var_dump($_SESSION);
 $_SESSION['Bar'] = 'Foo';
 session_write_close();
 
+echo "Garbage collection..\n";
+session_id($session_id);
+session_start();
+var_dump(session_gc());
+session_write_close();
+
 echo "Cleanup..\n";
 session_id($session_id);
 session_start();
@@ -99,6 +105,12 @@ array(3) {
   ["Guff"]=>
   int(1234567890)
 }
+Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;Bar|s:3:"Foo";]
+Close [%s,PHPSESSID]
+Garbage collection..
+Open [%s,PHPSESSID]
+Read [%s,%s]
+int(0)
 Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;Bar|s:3:"Foo";]
 Close [%s,PHPSESSID]
 Cleanup..


### PR DESCRIPTION
`session_gc` returns `false` for all user-defined session handlers.

It should return the number of deleted records, OR `1`, when the user-defined session handler returns `true`.

[repro case](https://gist.github.com/bshaffer/31d6e1c9efc369a27fa5bf7be61e9f4c)

Fixes https://bugs.php.net/bug.php?id=78624