### PR TITLE
Fix #78620: Out of memory error

### DIFF
--- a/ext/standard/tests/strings/wordwrap_memory_limit_win32.phpt
+++ b/ext/standard/tests/strings/wordwrap_memory_limit_win32.phpt
@@ -2,7 +2,7 @@
 No overflow should occur during the memory_limit check for wordwrap()
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN' && PHP_INT_SIZE == 4) die("skip this test is not for 32bit Windows platforms");
+if (substr(PHP_OS, 0, 3) != 'WIN' || PHP_INT_SIZE != 4) die("skip this test is for 32bit Windows platforms only");
 if (getenv("USE_ZEND_ALLOC") === "0") die("skip Zend MM disabled");
 ?>
 --INI--
@@ -16,4 +16,4 @@ wordwrap($str, 1, $str2);
 
 ?>
 --EXPECTF--
-Fatal error: Allowed memory size of 134217728 bytes exhausted%s(tried to allocate %d bytes) in %s on line %d
+Fatal error: Possible integer overflow in memory allocation (4294901777 + %d) in %s on line %d


### PR DESCRIPTION
The integer addition in `ZEND_MM_ALIGNED_SIZE_EX` can overflow, what we
have to catch early.

PS: this PR superseedes #4766, see https://github.com/php/php-src/pull/4766#discussion_r330658679