### PR TITLE
Fixed bug #78563 - XML Parser Cloning / Extension

### DIFF
--- a/ext/xml/tests/bug78563.phpt
+++ b/ext/xml/tests/bug78563.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #78563: parsers should not be clonable
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+	$parser = xml_parser_create();
+	clone $parser;
+
+?>
+===DONE===
+--EXPECTF--
+Fatal error: Uncaught Error: Trying to clone an uncloneable object of class XmlParser in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/xml/tests/bug78563.phpt
+++ b/ext/xml/tests/bug78563.phpt
@@ -5,8 +5,8 @@ Bug #78563: parsers should not be clonable
 --FILE--
 <?php
 
-	$parser = xml_parser_create();
-	clone $parser;
+$parser = xml_parser_create();
+clone $parser;
 
 ?>
 ===DONE===

--- a/ext/xml/tests/bug78563_final.phpt
+++ b/ext/xml/tests/bug78563_final.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #78563: parsers should not be extendable
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+class Dummy extends Xmlparser {
+
+}
+
+?>
+===DONE===
+--EXPECTF--
+Fatal error: Class Dummy may not inherit from final class (XmlParser) in %s on line %d

--- a/ext/xml/tests/bug78563_final.phpt
+++ b/ext/xml/tests/bug78563_final.phpt
@@ -1,4 +1,4 @@
---TEST--
+--TEST--/
 Bug #78563: parsers should not be extendable
 --SKIPIF--
 <?php include("skipif.inc"); ?>

--- a/ext/xml/tests/bug78563_final.phpt
+++ b/ext/xml/tests/bug78563_final.phpt
@@ -1,4 +1,4 @@
---TEST--/
+--TEST--
 Bug #78563: parsers should not be extendable
 --SKIPIF--
 <?php include("skipif.inc"); ?>

--- a/ext/xml/tests/bug78563_serialize.phpt
+++ b/ext/xml/tests/bug78563_serialize.phpt
@@ -5,8 +5,8 @@ Bug #78563: parsers should not be serializable
 --FILE--
 <?php
 
-	$parser = xml_parser_create();
-	serialize($parser);
+$parser = xml_parser_create();
+serialize($parser);
 
 ?>
 ===DONE===

--- a/ext/xml/tests/bug78563_serialize.phpt
+++ b/ext/xml/tests/bug78563_serialize.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #78563: parsers should not be clonable
+Bug #78563: parsers should not be serializable
 --SKIPIF--
 <?php include("skipif.inc"); ?>
 --FILE--

--- a/ext/xml/tests/bug78563_serialize.phpt
+++ b/ext/xml/tests/bug78563_serialize.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #78563: parsers should not be clonable
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+	$parser = xml_parser_create();
+	serialize($parser);
+
+?>
+===DONE===
+--EXPECTF--
+Fatal error: Uncaught Exception: Serialization of 'XmlParser' is not allowed in %s:%d
+Stack trace:
+#0 %s(%d): serialize(Object(XmlParser))
+#1 {main}
+  thrown in %s on line %d

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -26,6 +26,7 @@
 #include "ext/standard/php_string.h"
 #include "ext/standard/info.h"
 #include "ext/standard/html.h"
+#include "zend_interfaces.h"
 
 #if HAVE_XML
 
@@ -308,15 +309,18 @@ PHP_MINIT_FUNCTION(xml)
 {
 	zend_class_entry ce;
 	INIT_CLASS_ENTRY(ce, "XmlParser", xml_parser_methods);
-	ce.create_object = xml_parser_create_object;
-	ce.ce_flags |= ZEND_ACC_FINAL;
 	xml_parser_ce = zend_register_internal_class(&ce);
+	xml_parser_ce->create_object = xml_parser_create_object;
+	xml_parser_ce->ce_flags |= ZEND_ACC_FINAL;
+	xml_parser_ce->serialize = zend_class_serialize_deny;
+	xml_parser_ce->unserialize = zend_class_unserialize_deny;
 
 	memcpy(&xml_parser_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	xml_parser_object_handlers.offset = XtOffsetOf(xml_parser, std);
 	xml_parser_object_handlers.free_obj = xml_parser_free_obj;
 	xml_parser_object_handlers.get_gc = xml_parser_get_gc;
 	xml_parser_object_handlers.get_constructor = xml_parser_get_constructor;
+	xml_parser_object_handlers.clone_obj = NULL;
 
 	REGISTER_LONG_CONSTANT("XML_ERROR_NONE", XML_ERROR_NONE, CONST_CS|CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("XML_ERROR_NO_MEMORY", XML_ERROR_NO_MEMORY, CONST_CS|CONST_PERSISTENT);


### PR DESCRIPTION
Sets final flags and disables cloning + serialization. 