### PR TITLE
Change behavior of strtr(["" => "x"])

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3024,8 +3024,8 @@ static void php_strtr_array(zval *return_value, zend_string *input, HashTable *p
 		} else {
 			len = ZSTR_LEN(str_key);
 			if (UNEXPECTED(len < 1)) {
-				efree(num_bitset);
-				RETURN_FALSE;
+				php_error_docref(NULL, E_WARNING, "Ignoring replacement of empty string");
+				continue;
 			} else if (UNEXPECTED(len > slen)) {
 				/* skip long patterns */
 				continue;
@@ -3499,6 +3499,7 @@ PHP_FUNCTION(strtr)
 				}
 				replace = zval_get_tmp_string(entry, &tmp_replace);
 				if (ZSTR_LEN(str_key) < 1) {
+					php_error_docref(NULL, E_WARNING, "Ignoring replacement of empty string");
 					RETVAL_STR_COPY(str);
 				} else if (ZSTR_LEN(str_key) == 1) {
 					RETVAL_STR(php_char_to_str_ex(str,

--- a/ext/standard/tests/strings/strtr_empty_search_string.phpt
+++ b/ext/standard/tests/strings/strtr_empty_search_string.phpt
@@ -1,0 +1,15 @@
+--TEST--
+strtr() trying to replace an empty string
+--FILE--
+<?php
+
+var_dump(strtr("foo", ["" => "bar"]));
+var_dump(strtr("foo", ["" => "bar", "x" => "y"]));
+
+?>
+--EXPECTF--
+Warning: strtr(): Ignoring replacement of empty string in %s on line %d
+string(3) "foo"
+
+Warning: strtr(): Ignoring replacement of empty string in %s on line %d
+string(3) "foo"


### PR DESCRIPTION
Previously:
 * If only ["" => "x"] was present, the original string was returned
   without warning.
 * If both ["" => "x"] and at least one more element was present,
   false was returned without warning.

New behavior:
 * Ignore "" keys in the replacement array (and perform any remaining
   replacement).
 * Throw a warning indicating that an empty string replacement has
   been ignored.

For reference: str_replace() ignores "" replacements, but silently.

cc @theodorejb 