### PR TITLE
New function `pcre_get_compiled_regex_cache_ex` is introduced which …

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -322,7 +322,7 @@ static zend_always_inline int calculate_unit_length(pcre_cache_entry *pce, char 
 
 /* {{{ pcre_get_compiled_regex_cache
  */
-PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
+PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, int locale_aware)
 {
 	pcre				*re = NULL;
 	pcre_extra			*extra;
@@ -344,7 +344,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 	zend_string 		*key;
 
 #if HAVE_SETLOCALE
-	if (BG(locale_string) &&
+	if (locale_aware && BG(locale_string) &&
 		(ZSTR_LEN(BG(locale_string)) != 1 && ZSTR_VAL(BG(locale_string))[0] != 'C')) {
 		key = zend_string_alloc(ZSTR_LEN(regex) + ZSTR_LEN(BG(locale_string)) + 1, 0);
 		memcpy(ZSTR_VAL(key), ZSTR_VAL(BG(locale_string)), ZSTR_LEN(BG(locale_string)) + 1);
@@ -633,6 +633,14 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
 	}
 
 	return pce;
+}
+/* }}} */
+
+/* {{{ pcre_get_compiled_regex_cache
+ */
+PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex)
+{
+	return pcre_get_compiled_regex_cache_ex(regex, 1);
 }
 /* }}} */
 

--- a/ext/pcre/php_pcre.h
+++ b/ext/pcre/php_pcre.h
@@ -57,6 +57,7 @@ typedef struct {
 } pcre_cache_entry;
 
 PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache(zend_string *regex);
+PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, int locale_aware);
 
 PHPAPI void  php_pcre_match_impl(  pcre_cache_entry *pce, char *subject, int subject_len, zval *return_value,
 	zval *subpats, int global, int use_flags, zend_long flags, zend_long start_offset);


### PR DESCRIPTION
…allows to compile regexp pattern using the "C" locale instead of a current locale.

This function is needed to implement PR #4645. Code reviewer (@nikic)
of that PR originally suggested that we need an extended version of
`pcre_get_compiled_regex_cache` that will accept the locale string as a parameter
so that one can do regexp matching using "C" locale explicitly.

Unfortunately this cannot be easily done (without hurting performance and complexity
of code) because `pcre_get_compiled_regex_cache` needs to build character tables
(with `pcre_maketables`) when compiling for any locale other than "C". And to do that,
the target locale must be set as a current locale. Should I pursue the original
suggestion for that new function, I would have to set that locale as current/save
previous and then restored back the locale that was previously active (with `setlocale` being fundamentally not thread-safe, the less we call it the better).
Besides, the only envisioned usage of that function would be with "C" locale.

So I think a boolean flag (`locale_aware`) is a simplier solution.