### PR TITLE
Fix checksum calculation for opcache

### DIFF
--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -735,11 +735,11 @@ zend_op_array* zend_accel_load_script(zend_persistent_script *persistent_script,
 #define ADLER32_DO8(buf, i)     ADLER32_DO4(buf, i); ADLER32_DO4(buf, i + 4);
 #define ADLER32_DO16(buf)       ADLER32_DO8(buf, 0); ADLER32_DO8(buf, 8);
 
-unsigned int zend_adler32(unsigned int checksum, signed char *buf, uint32_t len)
+unsigned int zend_adler32(unsigned int checksum, unsigned char *buf, uint32_t len)
 {
 	unsigned int s1 = checksum & 0xffff;
 	unsigned int s2 = (checksum >> 16) & 0xffff;
-	signed char *end;
+	unsigned char *end;
 
 	while (len >= ADLER32_NMAX) {
 		len -= ADLER32_NMAX;
@@ -777,15 +777,15 @@ unsigned int zend_adler32(unsigned int checksum, signed char *buf, uint32_t len)
 
 unsigned int zend_accel_script_checksum(zend_persistent_script *persistent_script)
 {
-	signed char *mem = (signed char*)persistent_script->mem;
+	unsigned char *mem = (unsigned char*)persistent_script->mem;
 	size_t size = persistent_script->size;
 	size_t persistent_script_check_block_size = ((char *)&(persistent_script->dynamic_members)) - (char *)persistent_script;
 	unsigned int checksum = ADLER32_INIT;
 
-	if (mem < (signed char*)persistent_script) {
-		checksum = zend_adler32(checksum, mem, (signed char*)persistent_script - mem);
-		size -= (signed char*)persistent_script - mem;
-		mem  += (signed char*)persistent_script - mem;
+	if (mem < (unsigned char*)persistent_script) {
+		checksum = zend_adler32(checksum, mem, (unsigned char*)persistent_script - mem);
+		size -= (unsigned char*)persistent_script - mem;
+		mem  += (unsigned char*)persistent_script - mem;
 	}
 
 	zend_adler32(checksum, mem, persistent_script_check_block_size);

--- a/ext/opcache/zend_accelerator_util_funcs.h
+++ b/ext/opcache/zend_accelerator_util_funcs.h
@@ -37,7 +37,7 @@ zend_op_array* zend_accel_load_script(zend_persistent_script *persistent_script,
 
 #define ADLER32_INIT 1     /* initial Adler-32 value */
 
-unsigned int zend_adler32(unsigned int checksum, signed char *buf, uint32_t len);
+unsigned int zend_adler32(unsigned int checksum, unsigned char *buf, uint32_t len);
 
 unsigned int zend_accel_script_checksum(zend_persistent_script *persistent_script);
 


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=78654

The checksum can be incorrectly computed when a file to be cached contains non-ascii characters.  When the opcache computes the checksum before it writes the file it chains together two calls to zend_adler32. 

https://github.com/php/php-src/blob/PHP-7.2.24/ext/opcache/zend_file_cache.c#L870

When the bin file containing the opcache is loaded it computes the checksum with a single call to zend_adler32.

https://github.com/php/php-src/blob/PHP-7.2.24/ext/opcache/zend_file_cache.c#L1461

The zend_adler32 function uses signed chars instead of unsigned chars. As a result non-ascii characters can have negative values. This means the checksum is incorrectly computed and chained calls can result in different values than a single call to zend_adler32.

https://github.com/php/php-src/blob/PHP-7.2.24/ext/opcache/zend_accelerator_util_funcs.c#L738

Added two pieces of additional logging. The first is to show when the opcache is load from a file into to memory. The second is to show the expect and actual checksums when when a file does not fails the check. 