### PR TITLE
Request #78656	Parse errors classified as highest log-level

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -1309,7 +1309,7 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
 				break;
 			case E_PARSE:
 				error_type_str = "Parse error";
-				syslog_type_int = LOG_EMERG;
+				syslog_type_int = LOG_ERR;
 				break;
 			case E_NOTICE:
 			case E_USER_NOTICE:


### PR DESCRIPTION
Description:
------------
Parse errors are classified as the highest log level (LOG_EMERG). This is problem since Centos/Fedora writes LOG_EMERG messages to all users:

https://src.fedoraproject.org/rpms/rsyslog/blob/master/f/rsyslog.conf#_59

LOG_EMERG is described as: "system is unusable". A php-script with a parse error would not in most cases render the system unstable. At most LOG_ERR or LOG_CRIT would be more suitable. Fatal errors are classified as LOG_ERR. Why not make parse errors the same level?

The source:
https://github.com/php/php-src/blob/PHP-7.3/main/main.c#L1300

The commit that changed this:

https://github.com/php/php-src/commit/3edf7d960cb14f2ee45944e7c567af92af25bda1

Bug url:
https://bugs.php.net/bug.php?id=78656