### PR TITLE
Exif optimizations

### DIFF
--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -1912,15 +1912,28 @@ typedef struct {
 	int             read_thumbnail;
 	int             read_all;
 	int             ifd_nesting_level;
+	int             num_errors;
 	/* internal */
 	file_section_list 	file;
 } image_info_type;
 /* }}} */
 
+#define EXIF_MAX_ERRORS 10
+
 /* {{{ exif_error_docref */
-static void exif_error_docref(const char *docref EXIFERR_DC, const image_info_type *ImageInfo, int type, const char *format, ...)
+static void exif_error_docref(const char *docref EXIFERR_DC, image_info_type *ImageInfo, int type, const char *format, ...)
 {
 	va_list args;
+
+	if (ImageInfo) {
+		if (++ImageInfo->num_errors > EXIF_MAX_ERRORS) {
+			if (ImageInfo->num_errors == EXIF_MAX_ERRORS+1) {
+				php_error_docref(docref, type,
+					"Further exif parsing errors have been suppressed");
+			}
+			return;
+		}
+	}
 
 	va_start(args, format);
 #ifdef EXIF_DEBUG
@@ -4310,6 +4323,7 @@ static int exif_read_from_impl(image_info_type *ImageInfo, php_stream *stream, i
 
 
 	ImageInfo->ifd_nesting_level = 0;
+	ImageInfo->num_errors = 0;
 
 	/* Scan the headers */
 	ret = exif_scan_FILE_header(ImageInfo);

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -1369,34 +1369,30 @@ static HashTable *exif_get_tag_ht(tag_info_type *tag_table)
 
 /* {{{ exif_get_tagname
 	Get headername for tag_num or NULL if not defined */
-static char * exif_get_tagname(int tag_num, char *ret, int len, tag_table_type tag_table)
+static char *exif_get_tagname(int tag_num, tag_table_type tag_table)
 {
-	char tmp[32];
-	char *desc = zend_hash_index_find_ptr(exif_get_tag_ht(tag_table), tag_num);
-	if (desc) {
-		if (ret && len)  {
-			strlcpy(ret, desc, abs(len));
-			if (len < 0) {
-				memset(ret + strlen(ret), ' ', -len - strlen(ret) - 1);
-				ret[-len - 1] = '\0';
-			}
-			return ret;
-		}
-		return desc;
-	}
-
-	if (ret && len) {
-		snprintf(tmp, sizeof(tmp), "UndefinedTag:0x%04X", tag_num);
-		strlcpy(ret, tmp, abs(len));
-		if (len < 0) {
-			memset(ret + strlen(ret), ' ', -len - strlen(ret) - 1);
-			ret[-len - 1] = '\0';
-		}
-		return ret;
-	}
-	return "";
+	return zend_hash_index_find_ptr(exif_get_tag_ht(tag_table), tag_num);
 }
 /* }}} */
+
+static char *exif_get_tagname_debug(int tag_num, tag_table_type tag_table)
+{
+	char *desc = zend_hash_index_find_ptr(exif_get_tag_ht(tag_table), tag_num);
+	if (desc) {
+		return desc;
+	}
+	return "UndefinedTag";
+}
+
+static char *exif_get_tagname_key(int tag_num, char *buf, size_t buf_size, tag_table_type tag_table)
+{
+	char *desc = zend_hash_index_find_ptr(exif_get_tag_ht(tag_table), tag_num);
+	if (desc) {
+		return desc;
+	}
+	snprintf(buf, buf_size, "UndefinedTag:0x%04X", tag_num);
+	return buf;
+}
 
 /* {{{ exif_char_dump
  * Do not use! This is a debug function... */
@@ -2389,7 +2385,7 @@ static void add_assoc_image_info(zval *value, int sub_array, image_info_type *im
 				name = uname;
 			}
 #ifdef EXIF_DEBUG
-/*		php_error_docref(NULL, E_NOTICE, "Adding infos: tag(0x%04X,%12s,L=0x%04X): %s", info_tag, exif_get_tagname(info_tag, buffer, -12, exif_get_tag_table(section_index)), info_data->length, info_data->format==TAG_FMT_STRING?(info_value&&info_value->s?info_value->s:"<no data>"):exif_get_tagformat(info_data->format));*/
+/*		php_error_docref(NULL, E_NOTICE, "Adding infos: tag(0x%04X,%12s,L=0x%04X): %s", info_tag, exif_get_tagname_debug(info_tag, exif_get_tag_table(section_index)), info_data->length, info_data->format==TAG_FMT_STRING?(info_value&&info_value->s?info_value->s:"<no data>"):exif_get_tagformat(info_data->format));*/
 #endif
 			if (info_data->length==0) {
 				add_assoc_null(&tmpi, name);
@@ -2709,9 +2705,8 @@ PHP_FUNCTION(exif_tagname)
 		return;
 	}
 
-	szTemp = exif_get_tagname(tag, NULL, 0, tag_table_IFD);
-
-	if (tag < 0 || !szTemp || !szTemp[0]) {
+	szTemp = exif_get_tagname(tag, tag_table_IFD);
+	if (tag < 0 || !szTemp) {
 		RETURN_FALSE;
 	}
 
@@ -2852,7 +2847,7 @@ static void exif_thumbnail_build(image_info_type *ImageInfo) {
 				info_data  = &info_list->list[i];
 				byte_count = php_tiff_bytes_per_format[info_data->format] * info_data->length;
 #ifdef EXIF_DEBUG
-				exif_error_docref(NULL EXIFERR_CC, ImageInfo, E_NOTICE, "Thumbnail: process tag(x%04X=%s): %s%s (%d bytes)", info_data->tag, exif_get_tagname(info_data->tag, tagname, -12, tag_table_IFD), (info_data->length>1)&&info_data->format!=TAG_FMT_UNDEFINED&&info_data->format!=TAG_FMT_STRING?"ARRAY OF ":"", exif_get_tagformat(info_data->format), byte_count);
+				exif_error_docref(NULL EXIFERR_CC, ImageInfo, E_NOTICE, "Thumbnail: process tag(x%04X=%s): %s%s (%d bytes)", info_data->tag, exif_get_tagname_debug(info_data->tag, tag_table_IFD), (info_data->length>1)&&info_data->format!=TAG_FMT_UNDEFINED&&info_data->format!=TAG_FMT_STRING?"ARRAY OF ":"", exif_get_tagformat(info_data->format), byte_count);
 #endif
 				if (info_data->tag==TAG_STRIP_OFFSETS || info_data->tag==TAG_JPEG_INTERCHANGE_FORMAT) {
 					php_ifd_set16u(new_data + 0, info_data->tag,    ImageInfo->motorola_intel);
@@ -3197,7 +3192,7 @@ static int exif_process_IFD_in_MAKERNOTE(image_info_type *ImageInfo, char * valu
 
 #define REQUIRE_NON_EMPTY() do { \
 	if (byte_count == 0) { \
-		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Cannot be empty", tag, exif_get_tagname(tag, tagname, -12, tag_table)); \
+		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Cannot be empty", tag, exif_get_tagname_debug(tag, tag_table)); \
 		return FALSE; \
 	} \
 } while (0)
@@ -3231,7 +3226,7 @@ static int exif_process_IFD_TAG(image_info_type *ImageInfo, char *dir_entry, cha
 
 	if (!format || format > NUM_FORMATS) {
 		/* (-1) catches illegal zero case as unsigned underflows to positive large. */
-		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal format code 0x%04X, suppose BYTE", tag, exif_get_tagname(tag, tagname, -12, tag_table), format);
+		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal format code 0x%04X, suppose BYTE", tag, exif_get_tagname_debug(tag, tag_table), format);
 		format = TAG_FMT_BYTE;
 		/*return TRUE;*/
 	}
@@ -3239,7 +3234,7 @@ static int exif_process_IFD_TAG(image_info_type *ImageInfo, char *dir_entry, cha
 	byte_count_signed = (int64_t)components * php_tiff_bytes_per_format[format];
 
 	if (byte_count_signed < 0 || (byte_count_signed > INT32_MAX)) {
-		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal byte_count", tag, exif_get_tagname(tag, tagname, -12, tag_table));
+		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal byte_count", tag, exif_get_tagname_debug(tag, tag_table));
 		return FALSE;
 	}
 
@@ -3262,11 +3257,11 @@ static int exif_process_IFD_TAG(image_info_type *ImageInfo, char *dir_entry, cha
 				if (value_ptr < dir_entry) {
 					/* we can read this if offset_val > 0 */
 					/* some files have their values in other parts of the file */
-					exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal pointer offset(x%04X < x%04X)", tag, exif_get_tagname(tag, tagname, -12, tag_table), offset_val, dir_entry);
+					exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal pointer offset(x%04X < x%04X)", tag, exif_get_tagname_debug(tag, tag_table), offset_val, dir_entry);
 				} else {
 					/* this is for sure not allowed */
 					/* exception are IFD pointers */
-					exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal pointer offset(x%04X + x%04X = x%04X > x%04X)", tag, exif_get_tagname(tag, tagname, -12, tag_table), offset_val, byte_count, offset_val+byte_count, IFDlength);
+					exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Illegal pointer offset(x%04X + x%04X = x%04X > x%04X)", tag, exif_get_tagname_debug(tag, tag_table), offset_val, byte_count, offset_val+byte_count, IFDlength);
 				}
 				return FALSE;
 			}
@@ -3309,7 +3304,7 @@ static int exif_process_IFD_TAG(image_info_type *ImageInfo, char *dir_entry, cha
 	ImageInfo->sections_found |= FOUND_ANY_TAG;
 #ifdef EXIF_DEBUG
 	dump_data = exif_dump_data(&dump_free, format, components, length, ImageInfo->motorola_intel, value_ptr);
-	exif_error_docref(NULL EXIFERR_CC, ImageInfo, E_NOTICE, "Process tag(x%04X=%s,@x%04X + x%04X(=%d)): %s%s %s", tag, exif_get_tagname(tag, tagname, -12, tag_table), offset_val+displacement, byte_count, byte_count, (components>1)&&format!=TAG_FMT_UNDEFINED&&format!=TAG_FMT_STRING?"ARRAY OF ":"", exif_get_tagformat(format), dump_data);
+	exif_error_docref(NULL EXIFERR_CC, ImageInfo, E_NOTICE, "Process tag(x%04X=%s,@x%04X + x%04X(=%d)): %s%s %s", tag, exif_get_tagname_debug(tag, tag_table), offset_val+displacement, byte_count, byte_count, (components>1)&&format!=TAG_FMT_UNDEFINED&&format!=TAG_FMT_STRING?"ARRAY OF ":"", exif_get_tagformat(format), dump_data);
 	if (dump_free) {
 		efree(dump_data);
 	}
@@ -3538,7 +3533,7 @@ static int exif_process_IFD_TAG(image_info_type *ImageInfo, char *dir_entry, cha
 				}
 		}
 	}
-	exif_iif_add_tag(ImageInfo, section_index, exif_get_tagname(tag, tagname, sizeof(tagname), tag_table), tag, format, components, value_ptr, byte_count);
+	exif_iif_add_tag(ImageInfo, section_index, exif_get_tagname_key(tag, tagname, sizeof(tagname), tag_table), tag, format, components, value_ptr, byte_count);
 	EFREE_IF(outside);
 	return TRUE;
 }
@@ -3976,7 +3971,6 @@ static int exif_process_IFD_in_TIFF(image_info_type *ImageInfo, size_t dir_offse
 {
 	int i, sn, num_entries, sub_section_index = 0;
 	unsigned char *dir_entry;
-	char tagname[64];
 	size_t ifd_size, dir_size, entry_offset, next_offset, entry_length, entry_value=0, fgot;
 	int entry_tag , entry_type;
 	tag_table_type tag_table = exif_get_tag_table(section_index);
@@ -4014,7 +4008,7 @@ static int exif_process_IFD_in_TIFF(image_info_type *ImageInfo, size_t dir_offse
 				entry_tag    = php_ifd_get16u(dir_entry+0, ImageInfo->motorola_intel);
 				entry_type   = php_ifd_get16u(dir_entry+2, ImageInfo->motorola_intel);
 				if (entry_type > NUM_FORMATS) {
-					exif_error_docref(NULL EXIFERR_CC, ImageInfo, E_NOTICE, "Read from TIFF: tag(0x%04X,%12s): Illegal format code 0x%04X, switching to BYTE", entry_tag, exif_get_tagname(entry_tag, tagname, -12, tag_table), entry_type);
+					exif_error_docref(NULL EXIFERR_CC, ImageInfo, E_NOTICE, "Read from TIFF: tag(0x%04X,%12s): Illegal format code 0x%04X, switching to BYTE", entry_tag, exif_get_tagname_debug(entry_tag, tag_table), entry_type);
 					/* Since this is repeated in exif_process_IFD_TAG make it a notice here */
 					/* and make it a warning in the exif_process_IFD_TAG which is called    */
 					/* elsewhere. */
@@ -4571,7 +4565,7 @@ PHP_FUNCTION(exif_read_data)
 	exif_iif_add_str(&ImageInfo, SECTION_COMPUTED, "Copyright.Editor",       ImageInfo.CopyrightEditor);
 
 	for (i=0; i<ImageInfo.xp_fields.count; i++) {
-		exif_iif_add_str(&ImageInfo, SECTION_WINXP, exif_get_tagname(ImageInfo.xp_fields.list[i].tag, NULL, 0, exif_get_tag_table(SECTION_WINXP)), ImageInfo.xp_fields.list[i].value);
+		exif_iif_add_str(&ImageInfo, SECTION_WINXP, exif_get_tagname_debug(ImageInfo.xp_fields.list[i].tag, exif_get_tag_table(SECTION_WINXP)), ImageInfo.xp_fields.list[i].value);
 	}
 	if (ImageInfo.Thumbnail.size) {
 		if (read_thumbnail) {

--- a/ext/exif/tests/bug54002.phpt
+++ b/ext/exif/tests/bug54002.phpt
@@ -11,6 +11,6 @@ exif_read_data(__DIR__ . '/bug54002_2.jpg');
 
 ?>
 --EXPECTF--
-Warning: exif_read_data(bug54002_1.jpg): Process tag(x0205=UndefinedTa): Illegal byte_count in %sbug54002.php on line %d
+Warning: exif_read_data(bug54002_1.jpg): Process tag(x0205=UndefinedTag): Illegal byte_count in %sbug54002.php on line %d
 
-Warning: exif_read_data(bug54002_2.jpg): Process tag(x0205=UndefinedTa): Illegal byte_count in %sbug54002.php on line %d
+Warning: exif_read_data(bug54002_2.jpg): Process tag(x0205=UndefinedTag): Illegal byte_count in %sbug54002.php on line %d

--- a/ext/exif/tests/bug60150.phpt
+++ b/ext/exif/tests/bug60150.phpt
@@ -12,7 +12,7 @@ var_dump(exif_read_data($infile));
 ?>
 ===DONE===
 --EXPECTF--
-Warning: exif_read_data(bug60150.jpg): Process tag(x9003=DateTimeOri): Illegal pointer offset(%s) in %s on line %d
+Warning: exif_read_data(bug60150.jpg): Process tag(x9003=DateTimeOriginal): Illegal pointer offset(%s) in %s on line %d
 
 Warning: exif_read_data(bug60150.jpg): Error reading from file: got=x%x(=%d) != itemlen-%d=x%x(=%d) in %s on line %d
 

--- a/ext/exif/tests/bug72094.phpt
+++ b/ext/exif/tests/bug72094.phpt
@@ -11,17 +11,17 @@ print_r(exif_read_data(__DIR__ . '/bug72094_4.jpg'));
 ?>
 DONE
 --EXPECTF--
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_1.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_1.jpg): Process tag(x8298=Copyright  ): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_1.jpg): Process tag(x8298=Copyright): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
 Warning: exif_read_data(bug72094_1.jpg): Illegal IFD offset in %sbug72094.php on line %d
 
@@ -35,17 +35,17 @@ Warning: exif_read_data(bug72094_2.jpg): File structure corrupted in %s%ebug7209
 
 Warning: exif_read_data(bug72094_2.jpg): Invalid JPEG file in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
-Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
+Warning: exif_read_data(bug72094_3.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %s%ebug72094.php on line %d
 
 Warning: exif_read_data(bug72094_3.jpg): Illegal IFD size in %s%ebug72094.php on line %d
 

--- a/ext/exif/tests/bug73737.phpt
+++ b/ext/exif/tests/bug73737.phpt
@@ -8,7 +8,7 @@ Bug #73737 (Crash when parsing a tag format)
 	var_dump($exif);
 ?>
 --EXPECTF--
-Warning: exif_thumbnail(bug73737.tiff): Process tag(x0100=ImageWidth ): Cannot be empty in %s on line %d
+Warning: exif_thumbnail(bug73737.tiff): Process tag(x0100=ImageWidth): Cannot be empty in %s on line %d
 
 Warning: exif_thumbnail(bug73737.tiff): Error in TIFF: filesize(x0030) less than start of IFD dir(x10102) in %s line %d
 bool(false)

--- a/ext/exif/tests/bug76557.phpt
+++ b/ext/exif/tests/bug76557.phpt
@@ -28,52 +28,6 @@ Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal f
 
 Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x8769=Exif_IFD_Po): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x927C=MakerNote  ): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal pointer offset(%s) in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): File structure corrupted in %sbug76557.php on line %d
-
-Warning: exif_read_data(bug76557.jpg): Invalid JPEG file in %sbug76557.php on line %d
+Warning: exif_read_data(): Further exif parsing errors have been suppressed in %s on line %d
 bool(false)
 DONE

--- a/ext/exif/tests/bug76557.phpt
+++ b/ext/exif/tests/bug76557.phpt
@@ -8,25 +8,25 @@ var_dump(exif_read_data(__DIR__ . "/bug76557.jpg"));
 ?>
 DONE
 --EXPECTF--
-Warning: exif_read_data(bug76557.jpg): Process tag(x010F=Make       ): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x010F=Make): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
-Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTa): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
+Warning: exif_read_data(bug76557.jpg): Process tag(x3030=UndefinedTag): Illegal format code 0x3030, suppose BYTE in %sbug76557.php on line %d
 
 Warning: exif_read_data(): Further exif parsing errors have been suppressed in %s on line %d
 bool(false)

--- a/ext/exif/tests/bug77753.phpt
+++ b/ext/exif/tests/bug77753.phpt
@@ -4,13 +4,9 @@ Bug #77753 (Heap-buffer-overflow in php_ifd_get32s)
 <?php if (!extension_loaded('exif')) print 'skip exif extension not available';?>
 --FILE--
 <?php
-var_dump(exif_read_data(__DIR__."/bug77753.tiff"));
+@var_dump(exif_read_data(__DIR__."/bug77753.tiff"));
 ?>
 DONE
 --EXPECTF--
-%A
-Warning: exif_read_data(bug77753.tiff): Illegal IFD size: 0x006A > 0x0065 in %sbug77753.php on line %d
-
-Warning: exif_read_data(bug77753.tiff): Invalid TIFF file in %sbug77753.php on line %d
 bool(false)
 DONE

--- a/ext/exif/tests/tag_with_illegal_zero_components.phpt
+++ b/ext/exif/tests/tag_with_illegal_zero_components.phpt
@@ -13,7 +13,7 @@ var_dump(exif_read_data(__DIR__ . '/tag_with_illegal_zero_components.jpeg'));
 
 ?>
 --EXPECTF--
-Warning: exif_read_data(tag_with_illegal_zero_components.jpeg): Process tag(x0202=JPEGInterch): Cannot be empty in %s on line %d
+Warning: exif_read_data(tag_with_illegal_zero_components.jpeg): Process tag(x0202=JPEGInterchangeFormatLength): Cannot be empty in %s on line %d
 
 Warning: exif_read_data(tag_with_illegal_zero_components.jpeg): File structure corrupted in %s on line %d
 


### PR DESCRIPTION
We're still seeing fuzzing timeouts (> 25s) with relatively small (256K) files. While part of this is the instrumentation overhead, release builds still needs something like 2s, which is still pretty bad.

The main contributors to the slowdown are:
 * Printing errors. We print an error for every invalid tag. If you have a few thousand tags, just formatting those errors is going to take a lot of time. I've added a limit of max 10 errors per call, because I don't think anything more than that is really useful to anyone anyway.
 * Fetching the tag name. This was previously done with a simple linear search through a table. Especially if there are a lot of unknown tags, that means we're going to look through hundreds of tag entries for every unknown tag. I've added a cache that will convert the tag table into a hash table (kept between requests), so subsequent lookups are fast.
 * Printing the "UnknownTag:0xHHHH" is still quite expensive and more important unnecessary in nearly all cases. I've split up the exif_get_tagname function into three functions that are used as appropriate. As a side effect this also fixes the weird cut off tag names in error messages.

@KalleZ 