### PR TITLE
Replace port already used

### DIFF
--- a/ext/sockets/tests/socket_import_stream-2.phpt
+++ b/ext/sockets/tests/socket_import_stream-2.phpt
@@ -14,7 +14,7 @@ try {
 } catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
-$s = stream_socket_server("udp://127.0.0.1:58392", $errno, $errstr, STREAM_SERVER_BIND);
+$s = stream_socket_server("udp://127.0.0.1:58394", $errno, $errstr, STREAM_SERVER_BIND);
 var_dump($s);
 var_dump(fclose($s));
 try {


### PR DESCRIPTION
`./ext/sockets/tests/socket_import_stream-2.phpt` and `./ext/sockets/tests/socket_export_stream-2.phpt` use the same port (58392).
So sometimes they fail with this message: `unable to connect to udp://127.0.0.1:58392 (Address already in use)`

Example : https://dev.azure.com/phpazuredevops/PHP/_build/results?buildId=3164&view=ms.vss-test-web.build-test-results-tab&runId=66410&resultId=109620&paneView=debug