### PR TITLE
Improve the error message in timeout tests

### DIFF
--- a/tests/basic/timeout_variation_10.phpt
+++ b/tests/basic/timeout_variation_10.phpt
@@ -14,7 +14,10 @@ set_time_limit($t);
 function f()
 {
 	echo "call";
+	$startTime = microtime(true);
 	busy_wait(5);
+	$diff = microtime(true) - $startTime;
+	echo "\ntime spent waiting: $diff\n";
 }
 
 register_shutdown_function("f");

--- a/tests/basic/timeout_variation_2.phpt
+++ b/tests/basic/timeout_variation_2.phpt
@@ -16,9 +16,13 @@ function cb(&$i, $k, $p)
 	busy_wait(1);
 }
 
+$startTime = microtime(true);
+
 $a = array(1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1);
 array_walk($a, "cb", "junk");
 
+$diff = microtime(true) - $startTime;
+echo "time spent waiting: $diff\n";
 ?>
 never reached here
 --EXPECTF--

--- a/tests/basic/timeout_variation_3.phpt
+++ b/tests/basic/timeout_variation_3.phpt
@@ -13,7 +13,10 @@ set_time_limit($t);
 
 function hello ($t) {
 	echo "call", PHP_EOL;
+	$startTime = microtime(true);
 	busy_wait($t*2);
+	$diff = microtime(true) - $startTime;
+	echo "time spent waiting: $diff\n";
 }
 
 eval('hello($t);');

--- a/tests/basic/timeout_variation_4.phpt
+++ b/tests/basic/timeout_variation_4.phpt
@@ -13,7 +13,10 @@ set_time_limit($t);
 
 function hello ($t) {
 	echo "call", PHP_EOL;
+	$startTime = microtime(true);
 	busy_wait($t*2);
+	$diff = microtime(true) - $startTime;
+	echo "time spent waiting: $diff\n";
 }
 
 call_user_func('hello', $t);

--- a/tests/basic/timeout_variation_5.phpt
+++ b/tests/basic/timeout_variation_5.phpt
@@ -13,8 +13,10 @@ set_time_limit($t);
 
 function f($t) {
 	echo "call";
+	$startTime = microtime(true);
 	busy_wait($t*2);
-	throw new Exception("never reached here");
+	$diff = microtime(true) - $startTime;
+	throw new Exception("never reached here (time spent waiting: $diff)");
 }
 
 f($t);

--- a/tests/basic/timeout_variation_7.phpt
+++ b/tests/basic/timeout_variation_7.phpt
@@ -11,9 +11,14 @@ include __DIR__ . DIRECTORY_SEPARATOR . "timeout_config.inc";
 
 set_time_limit($t);
 
+$startTime = microtime(true);
+
 for ($i = 0; $i < 42; $i++) {
 	busy_wait(1);
 }
+
+$diff = microtime(true) - $startTime;
+echo "time spent waiting: $diff\n";
 
 ?>
 never reached here

--- a/tests/basic/timeout_variation_8.phpt
+++ b/tests/basic/timeout_variation_8.phpt
@@ -11,9 +11,14 @@ include __DIR__ . DIRECTORY_SEPARATOR . "timeout_config.inc";
 
 set_time_limit($t);
 
+$startTime = microtime(true);
+
 foreach (range(0, 42) as $i) {
 	busy_wait(1);
 }
+
+$diff = microtime(true) - $startTime;
+echo "time spent waiting: $diff\n";
 
 ?>
 never reached here

--- a/tests/basic/timeout_variation_9.phpt
+++ b/tests/basic/timeout_variation_9.phpt
@@ -14,7 +14,10 @@ set_time_limit($t);
 function f()
 {
 	echo "call";
+	$startTime = microtime(true);
 	busy_wait(5);
+	$diff = microtime(true) - $startTime;
+	echo "\ntime spent waiting: $diff\n";
 }
 
 register_shutdown_function("f");


### PR DESCRIPTION
From time to time this test fails: https://dev.azure.com/phpazuredevops/PHP/_build/results?buildId=3301&view=ms.vss-test-web.build-test-results-tab
The new error message will be a bit more informative.