### PR TITLE
Properly handle non resources passed to socket_select()

### DIFF
--- a/ext/sockets/tests/socket_select_error.phpt
+++ b/ext/sockets/tests/socket_select_error.phpt
@@ -1,0 +1,17 @@
+--TEST--
+socket_select() error conditions
+--SKIPIF--
+<?php
+if (!extension_loaded('sockets')) die('skip socket extension not available');
+?>
+--FILE--
+<?php
+$r = $w = $e = ['no resource'];
+try {
+    socket_select($r, $w, $e, 1);
+} catch (TypeError $ex) {
+    echo $ex->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+socket_select(): supplied argument is not a valid Socket resource


### PR DESCRIPTION
As of PHP 8.0.0, failing `zend_fetch_resource_ex()` throws a TypeError,
so we cannot simply skip non resources in the `$read`, `$write` and
`$except` arrays.  Instead we bail out.  Since these arrays are already
checked in `php_sock_array_to_fd_set()`, we remove the additional check
in `php_sock_array_from_fd_set()`.