### PR TITLE
Forbid accessing typed static properties on traits

### DIFF
--- a/Zend/tests/type_declarations/typed_properties_043.phpt
+++ b/Zend/tests/type_declarations/typed_properties_043.phpt
@@ -25,9 +25,6 @@ try {
     echo $e->getMessage(), "\n";
 }
 
-Test::$selfNullProp = null;
-var_dump(Test::$selfNullProp);
-
 class Foo {}
 class Bar extends Foo {
     use Test;
@@ -41,10 +38,9 @@ var_dump(Bar::$selfProp, Bar::$selfNullProp, Bar::$parentProp);
 
 ?>
 --EXPECT--
-Cannot write a value to a 'self' typed static property of a trait
-Cannot write a non-null value to a 'self' typed static property of a trait
-Cannot access parent:: when current class scope has no parent
-NULL
+Cannot access typed static property Test::$selfProp on a trait, it may only be used as part of a class
+Cannot access typed static property Test::$selfNullProp on a trait, it may only be used as part of a class
+Cannot access typed static property Test::$parentProp on a trait, it may only be used as part of a class
 object(Bar)#3 (0) {
 }
 object(Bar)#2 (0) {

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -927,14 +927,10 @@ static zend_bool zend_resolve_class_type(zend_type *type, zend_class_entry *self
 	zend_class_entry *ce;
 	zend_string *name = ZEND_TYPE_NAME(*type);
 	if (zend_string_equals_literal_ci(name, "self")) {
-		/* We need to explicitly check for this here, to avoid updating the type in the trait and
-		 * later using the wrong "self" when the trait is used in a class. */
-		if (UNEXPECTED((self_ce->ce_flags & ZEND_ACC_TRAIT) != 0)) {
-			zend_throw_error(NULL, "Cannot write a%s value to a 'self' typed static property of a trait", ZEND_TYPE_ALLOW_NULL(*type) ? " non-null" : "");
-			return 0;
-		}
+		ZEND_ASSERT(!(self_ce->ce_flags & ZEND_ACC_TRAIT));
 		ce = self_ce;
 	} else if (zend_string_equals_literal_ci(name, "parent")) {
+		ZEND_ASSERT(!(self_ce->ce_flags & ZEND_ACC_TRAIT));
 		if (UNEXPECTED(!self_ce->parent)) {
 			zend_throw_error(NULL, "Cannot access parent:: when current class scope has no parent");
 			return 0;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1512,6 +1512,15 @@ undeclared_property:
 	ret = CE_STATIC_MEMBERS(ce) + property_info->offset;
 	ZVAL_DEINDIRECT(ret);
 
+	/* TODO: Always make this an error, not just for typed properties. */
+	if (UNEXPECTED((ce->ce_flags & ZEND_ACC_TRAIT) && ZEND_TYPE_IS_SET(property_info->type))) {
+		zend_throw_error(NULL,
+			"Cannot access typed static property %s::$%s on a trait, "
+			"it may only be used as part of a class",
+			ZSTR_VAL(property_info->ce->name), zend_get_unmangled_property_name(property_name));
+		return NULL;
+	}
+
 	if (UNEXPECTED((type == BP_VAR_R || type == BP_VAR_RW)
 				&& Z_TYPE_P(ret) == IS_UNDEF && property_info->type != 0)) {
 		zend_throw_error(NULL, "Typed static property %s::$%s must not be accessed before initialization",


### PR DESCRIPTION
This forbids directly accessing static properties on traits -- these should only be used after the trait has been used in some class!

This PR targets PHP 7.4 and only forbids it for typed properties, as these are new and as such cause no backwards compatibility issues. In PHP 8 we should forbid this entirely instead, and the same for static methods. This was simply an oversight in the original trait implementation.

My particular motivation here is to avoid the special issues that `self` types in traits cause, and which will get more complicated with union types.

@bwoebi 