### PR TITLE
Forbid direct access to static members on traits

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -116,6 +116,10 @@ PHP 8.0 UPGRADE NOTES
     warning.
   . Uncaught exceptions now go through "clean shutdown", which means that
     destructors will be called after an uncaught exception.
+  . Directly accessing a static property or calling a static method on a trait
+    will now result in an Error exception. Trait members can only be used as
+    part of a class in which the trait is used, but direct access was previously
+    permitted due to an implementation oversight.
 
 - COM:
   . Removed the ability to import case-insensitive constants from type

--- a/Zend/tests/traits/direct_static_member_access.phpt
+++ b/Zend/tests/traits/direct_static_member_access.phpt
@@ -5,6 +5,9 @@ Cannot directly access static members on a trait
 
 trait T {
     public static $foo;
+    public static function foo() {
+        echo "Foo\n";
+    }
 }
 
 class C {
@@ -18,10 +21,20 @@ try {
     echo $e->getMessage(), "\n";
 }
 
+try {
+    T::foo();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
 C::$foo = 42;
 var_dump(C::$foo);
+
+C::foo();
 
 ?>
 --EXPECT--
 Cannot access static property T::$foo on a trait, it may only be used as part of a class
+Cannot call static method T::foo() on a trait, it may only be used as part of a class
 int(42)
+Foo

--- a/Zend/tests/traits/direct_static_member_access.phpt
+++ b/Zend/tests/traits/direct_static_member_access.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Cannot directly access static members on a trait
+--FILE--
+<?php
+
+trait T {
+    public static $foo;
+}
+
+class C {
+    use T;
+}
+
+try {
+    T::$foo = 42;
+    var_dump(T::$foo);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+C::$foo = 42;
+var_dump(C::$foo);
+
+?>
+--EXPECT--
+Cannot access static property T::$foo on a trait, it may only be used as part of a class
+int(42)

--- a/Zend/tests/type_declarations/typed_properties_043.phpt
+++ b/Zend/tests/type_declarations/typed_properties_043.phpt
@@ -25,9 +25,6 @@ try {
     echo $e->getMessage(), "\n";
 }
 
-Test::$selfNullProp = null;
-var_dump(Test::$selfNullProp);
-
 class Foo {}
 class Bar extends Foo {
     use Test;
@@ -41,10 +38,9 @@ var_dump(Bar::$selfProp, Bar::$selfNullProp, Bar::$parentProp);
 
 ?>
 --EXPECT--
-Cannot write a value to a 'self' typed static property of a trait
-Cannot write a non-null value to a 'self' typed static property of a trait
-Cannot access parent:: when current class scope has no parent
-NULL
+Cannot access static property Test::$selfProp on a trait, it may only be used as part of a class
+Cannot access static property Test::$selfNullProp on a trait, it may only be used as part of a class
+Cannot access static property Test::$parentProp on a trait, it may only be used as part of a class
 object(Bar)#3 (0) {
 }
 object(Bar)#2 (0) {

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -884,14 +884,10 @@ static zend_bool zend_resolve_class_type(zend_type *type, zend_class_entry *self
 	zend_class_entry *ce;
 	zend_string *name = ZEND_TYPE_NAME(*type);
 	if (zend_string_equals_literal_ci(name, "self")) {
-		/* We need to explicitly check for this here, to avoid updating the type in the trait and
-		 * later using the wrong "self" when the trait is used in a class. */
-		if (UNEXPECTED((self_ce->ce_flags & ZEND_ACC_TRAIT) != 0)) {
-			zend_throw_error(NULL, "Cannot write a%s value to a 'self' typed static property of a trait", ZEND_TYPE_ALLOW_NULL(*type) ? " non-null" : "");
-			return 0;
-		}
+		ZEND_ASSERT(!(self_ce->ce_flags & ZEND_ACC_TRAIT));
 		ce = self_ce;
 	} else if (zend_string_equals_literal_ci(name, "parent")) {
+		ZEND_ASSERT(!(self_ce->ce_flags & ZEND_ACC_TRAIT));
 		if (UNEXPECTED(!self_ce->parent)) {
 			zend_throw_error(NULL, "Cannot access parent:: when current class scope has no parent");
 			return 0;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1480,6 +1480,14 @@ undeclared_property:
 		}
 	}
 
+	if (UNEXPECTED(ce->ce_flags & ZEND_ACC_TRAIT)) {
+		zend_throw_error(NULL,
+			"Cannot access static property %s::$%s on a trait, "
+			"it may only be used as part of a class",
+			ZSTR_VAL(property_info->ce->name), zend_get_unmangled_property_name(property_name));
+		return NULL;
+	}
+
 	ret = CE_STATIC_MEMBERS(ce) + property_info->offset;
 	ZVAL_DEINDIRECT(ret);
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1392,9 +1392,17 @@ ZEND_API zend_function *zend_std_get_static_method(zend_class_entry *ce, zend_st
 		}
 	}
 
-	if (fbc && UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_ABSTRACT)) {
-		zend_abstract_method_call(fbc);
-		fbc = NULL;
+	if (fbc) {
+		if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_ABSTRACT)) {
+			zend_abstract_method_call(fbc);
+			fbc = NULL;
+		} else if (UNEXPECTED(fbc->common.scope->ce_flags & ZEND_ACC_TRAIT)) {
+			zend_throw_error(NULL,
+				"Cannot call static method %s::%s() on a trait, "
+				"it may only be used as part of a class",
+				ZSTR_VAL(fbc->common.scope->name), ZSTR_VAL(fbc->common.function_name));
+			fbc = NULL;
+		}
 	}
 
 	if (UNEXPECTED(!key)) {


### PR DESCRIPTION
This forbids directly accessing static properties and static methods on traits. Trait members in general can only be used through the class in which the trait was used, but due to an implementation oversight access to static members was still allowed. This change remedies this.