### PR TITLE
Update array access syntax deprecated

### DIFF
--- a/ext/ext_skel.php
+++ b/ext/ext_skel.php
@@ -172,7 +172,7 @@ function process_args($argv, $argc) {
 	{
 		$val = $argv[$i];
 
-		if($val{0} != '-' || $val{1} != '-')
+		if($val[0] != '-' || $val[1] != '-')
 		{
 			continue;
 		}
@@ -201,7 +201,7 @@ function process_args($argv, $argc) {
 			case 'ext':
 			case 'dir':
 			case 'author': {
-				if (!isset($argv[$i + 1]) || ($argv[$i + 1]{0} == '-' && $argv[$i + 1]{1} == '-')) {
+				if (!isset($argv[$i + 1]) || ($argv[$i + 1][0] == '-' && $argv[$i + 1][1] == '-')) {
 					error('Argument "' . $val . '" expects a value, none passed');
 				} else if ($opt == 'dir' && empty($argv[$i + 1])) {
 					continue 2;


### PR DESCRIPTION
Update array access syntax deprecated in line 175 and 204 
Deprecated: Array and string offset access syntax with curly braces is deprecated in /home/alex/php/hello/ext_skel.php on line 175
Deprecated: Array and string offset access syntax with curly braces is deprecated in /home/alex/php/hello/ext_skel.php on line 204