### PR TITLE
Fix and undeprecate ReflectionType::__toString()

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2818,7 +2818,7 @@ ZEND_METHOD(reflection_type, __toString)
 	}
 	GET_REFLECTION_OBJECT_PTR(param);
 
-	RETURN_STR(zend_type_to_string(ZEND_TYPE_WITHOUT_NULL(param->type)));
+	RETURN_STR(zend_type_to_string(param->type));
 }
 /* }}} */
 
@@ -6621,7 +6621,7 @@ static const zend_function_entry reflection_parameter_functions[] = {
 static const zend_function_entry reflection_type_functions[] = {
 	ZEND_ME(reflection, __clone, arginfo_reflection__void, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
 	ZEND_ME(reflection_type, allowsNull, arginfo_reflection__void, 0)
-	ZEND_ME(reflection_type, __toString, arginfo_reflection__void, ZEND_ACC_DEPRECATED)
+	ZEND_ME(reflection_type, __toString, arginfo_reflection__void, 0)
 	PHP_FE_END
 };
 

--- a/ext/reflection/tests/ReflectionNamedType.phpt
+++ b/ext/reflection/tests/ReflectionNamedType.phpt
@@ -30,20 +30,12 @@ var_dump($return->getName());
 var_dump((string) $return);
 
 ?>
---EXPECTF--
+--EXPECT--
 string(11) "Traversable"
-
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
-string(11) "Traversable"
+string(12) "?Traversable"
 string(6) "string"
-
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
-string(6) "string"
+string(7) "?string"
 string(4) "Test"
-
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
+string(5) "?Test"
 string(4) "Test"
-string(4) "Test"
-
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
-string(4) "Test"
+string(5) "?Test"

--- a/ext/reflection/tests/bug72661.phpt
+++ b/ext/reflection/tests/bug72661.phpt
@@ -6,6 +6,5 @@ function test(iterable $arg) { }
 
 var_dump((string)(new ReflectionParameter("test", 0))->getType());
 ?>
---EXPECTF--
-Deprecated: Function ReflectionType::__toString() is deprecated in %s on line %d
+--EXPECT--
 string(8) "iterable"


### PR DESCRIPTION
As we finally managed to get a proper deprecation for `ReflectionType::__toString()` out in 7.4...

This fixes the behavior of `ReflectionType::__toString()` to return the full type representation including nullability, so you'll get `"?Type"` instead of `"Type"` for a nullable type. It also undeprecates the `__toString()` method, as it is no longer completely and utterly broken.

I believe this is in line with what we had originally planned here, right? @morrisonlevi @bwoebi 