### PR TITLE
Use ICU's CXXFLAGS when using pkg-config

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2219,7 +2219,8 @@ AC_DEFUN([PHP_SETUP_ICU],[
 
       ICU_LIBS=`$PKG_CONFIG --libs icu-uc icu-io icu-i18n`
       ICU_INCS=`$PKG_CONFIG --cflags-only-I icu-uc icu-io icu-i18n`
-      ICU_CXXFLAGS="-DU_USING_ICU_NAMESPACE=1"
+      ICU_CXXFLAGS=`$PKG_CONFIG --variable=CXXFLAGS icu-uc icu-io icu-i18n`
+      ICU_CXXFLAGS="$ICU_CXXFLAGS -DU_USING_ICU_NAMESPACE=1"
 
       AC_MSG_RESULT([found $ICU_VERSION])
 


### PR DESCRIPTION
This PR makes the build use ICU's CXXFLAGS when ICU was found using pkg-config. This mirrors how ICU's CXXFLAGS are already used when ICU was found using icu-config.

Using ICU's CXXFLAGS is required, because newer versions of ICU require C++11, and specify `-std=c++11` in CXXFLAGS. The build will fail without this, unless using an extremely new compiler that defaults to C++11 or newer. 