### PR TITLE
Added missing call to ZipArchive::close() to tests

### DIFF
--- a/ext/zip/tests/oo_unchangeIndex.phpt
+++ b/ext/zip/tests/oo_unchangeIndex.phpt
@@ -28,6 +28,8 @@ $zip->unchangeIndex(0);
 var_dump($zip->getNameIndex(0));
 var_dump($zip->getCommentIndex(0));
 
+$zip->close();
+
 var_dump(md5_file($file));
 ?>
 --CLEAN--

--- a/ext/zip/tests/oo_unchangeName.phpt
+++ b/ext/zip/tests/oo_unchangeName.phpt
@@ -28,6 +28,8 @@ $zip->unchangeName('baz filename');
 var_dump($zip->getNameIndex(0));
 var_dump($zip->getCommentIndex(0));
 
+$zip->close();
+
 var_dump(md5_file($file));
 ?>
 --CLEAN--


### PR DESCRIPTION
This pull requests adds the missing calls to `$zip->close()` to the tests. Without calling `close()` in the test, the ZIP file is not written to disk before the new `md5()` call is done, so the test is not working as intended ;-)