### PR TITLE
Don't call __set() on uninitialized typed properties (Z_EXTRA variant)

### DIFF
--- a/Zend/tests/type_declarations/typed_properties_magic_set.phpt
+++ b/Zend/tests/type_declarations/typed_properties_magic_set.phpt
@@ -1,0 +1,25 @@
+--TEST--
+__set() should not be invoked when setting an uninitialized typed property
+--FILE--
+<?php
+class Test {
+    public int $foo;
+    public function __set($name, $value) {
+        echo "__set ", $name, " = ", $value, "\n";
+    }
+}
+$test = new Test;
+$test->foo = 42;
+var_dump($test->foo);
+// __set will be called after unset()
+unset($test->foo);
+$test->foo = 42;
+// __set will be called after unset() without prior initialization
+$test = new Test;
+unset($test->foo);
+$test->foo = 42;
+?>
+--EXPECT--
+int(42)
+__set foo = 42
+__set foo = 42

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1264,12 +1264,14 @@ static zend_always_inline void _object_properties_init(zend_object *object, zend
 		if (UNEXPECTED(class_type->type == ZEND_INTERNAL_CLASS)) {
 			do {
 				ZVAL_COPY_OR_DUP(dst, src);
+				Z_EXTRA_P(dst) = Z_EXTRA_P(src);
 				src++;
 				dst++;
 			} while (src != end);
 		} else {
 			do {
 				ZVAL_COPY(dst, src);
+				Z_EXTRA_P(dst) = Z_EXTRA_P(src);
 				src++;
 				dst++;
 			} while (src != end);
@@ -3683,6 +3685,7 @@ static zend_always_inline zend_bool is_persistent_class(zend_class_entry *ce) {
 ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type) /* {{{ */
 {
 	zend_property_info *property_info, *property_info_ptr;
+	zval *property_default_ptr;
 
 	if (ZEND_TYPE_IS_SET(type)) {
 		ce->ce_flags |= ZEND_ACC_HAS_TYPE_HINTS;
@@ -3714,7 +3717,7 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 			property_info->offset = ce->default_static_members_count++;
 			ce->default_static_members_table = perealloc(ce->default_static_members_table, sizeof(zval) * ce->default_static_members_count, ce->type == ZEND_INTERNAL_CLASS);
 		}
-		ZVAL_COPY_VALUE(&ce->default_static_members_table[property_info->offset], property);
+		property_default_ptr = &ce->default_static_members_table[property_info->offset];
 		if (!ZEND_MAP_PTR(ce->static_members_table)) {
 			ZEND_ASSERT(ce->type == ZEND_INTERNAL_CLASS);
 			if (!EG(current_execute_data)) {
@@ -3745,7 +3748,7 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 				ce->properties_info_table[ce->default_properties_count - 1] = property_info;
 			}
 		}
-		ZVAL_COPY_VALUE(&ce->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)], property);
+		property_default_ptr = &ce->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)];
 	}
 	if (ce->type & ZEND_INTERNAL_CLASS) {
 		switch(Z_TYPE_P(property)) {
@@ -3761,6 +3764,9 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 		/* Must be interned to avoid ZTS data races */
 		name = zend_new_interned_string(zend_string_copy(name));
 	}
+
+	ZVAL_COPY_VALUE(property_default_ptr, property);
+	Z_EXTRA_P(property_default_ptr) = Z_ISUNDEF_P(property) ? IS_PROP_UNINIT : 0;
 
 	if (access_type & ZEND_ACC_PUBLIC) {
 		property_info->name = zend_string_copy(name);

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1167,7 +1167,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 			do {
 				dst--;
 				src--;
-				*dst = *src; /* Copy Z_EXTRA as well */
+				ZVAL_COPY_VALUE_PROP(dst, src);
 			} while (dst != end);
 			pefree(src, ce->type == ZEND_INTERNAL_CLASS);
 			end = ce->default_properties_table;
@@ -1182,9 +1182,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 			do {
 				dst--;
 				src--;
-				*dst = *src; /* Copy Z_EXTRA as well */
-				ZVAL_COPY_OR_DUP(dst, src);
-				Z_EXTRA_P(dst) = Z_EXTRA_P(src);
+				ZVAL_COPY_OR_DUP_PROP(dst, src);
 				if (Z_OPT_TYPE_P(dst) == IS_CONSTANT_AST) {
 					ce->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
 				}
@@ -1194,8 +1192,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 			do {
 				dst--;
 				src--;
-				ZVAL_COPY(dst, src);
-				Z_EXTRA_P(dst) = Z_EXTRA_P(src);
+				ZVAL_COPY_PROP(dst, src);
 				if (Z_OPT_TYPE_P(dst) == IS_CONSTANT_AST) {
 					ce->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
 				}

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1167,7 +1167,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 			do {
 				dst--;
 				src--;
-				ZVAL_COPY_VALUE(dst, src);
+				*dst = *src; /* Copy Z_EXTRA as well */
 			} while (dst != end);
 			pefree(src, ce->type == ZEND_INTERNAL_CLASS);
 			end = ce->default_properties_table;
@@ -1182,7 +1182,9 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 			do {
 				dst--;
 				src--;
+				*dst = *src; /* Copy Z_EXTRA as well */
 				ZVAL_COPY_OR_DUP(dst, src);
+				Z_EXTRA_P(dst) = Z_EXTRA_P(src);
 				if (Z_OPT_TYPE_P(dst) == IS_CONSTANT_AST) {
 					ce->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
 				}
@@ -1193,6 +1195,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 				dst--;
 				src--;
 				ZVAL_COPY(dst, src);
+				Z_EXTRA_P(dst) = Z_EXTRA_P(src);
 				if (Z_OPT_TYPE_P(dst) == IS_CONSTANT_AST) {
 					ce->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
 				}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -836,6 +836,11 @@ found:
 			zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EG(current_execute_data) && ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)));
 			goto exit;
 		}
+		if (Z_EXTRA_P(variable_ptr) == IS_PROP_UNINIT) {
+			/* Writes to uninitializde typed properties bypass __set(). */
+			Z_EXTRA_P(variable_ptr) = 0;
+			goto write_std_property;
+		}
 	} else if (EXPECTED(IS_DYNAMIC_PROPERTY_OFFSET(property_offset))) {
 		if (EXPECTED(zobj->properties != NULL)) {
 			if (UNEXPECTED(GC_REFCOUNT(zobj->properties) > 1)) {
@@ -1113,6 +1118,8 @@ ZEND_API void zend_std_unset_property(zval *object, zval *member, void **cache_s
 			}
 			goto exit;
 		}
+		/* Reset the IS_PROP_UNINIT flag, if it exists. */
+		Z_EXTRA_P(slot) = 0;
 	} else if (EXPECTED(IS_DYNAMIC_PROPERTY_OFFSET(property_offset))
 	 && EXPECTED(zobj->properties != NULL)) {
 		if (UNEXPECTED(GC_REFCOUNT(zobj->properties) > 1)) {

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -836,9 +836,9 @@ found:
 			zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EG(current_execute_data) && ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)));
 			goto exit;
 		}
-		if (Z_EXTRA_P(variable_ptr) == IS_PROP_UNINIT) {
+		if (Z_PROP_FLAG_P(variable_ptr) == IS_PROP_UNINIT) {
 			/* Writes to uninitializde typed properties bypass __set(). */
-			Z_EXTRA_P(variable_ptr) = 0;
+			Z_PROP_FLAG_P(variable_ptr) = 0;
 			goto write_std_property;
 		}
 	} else if (EXPECTED(IS_DYNAMIC_PROPERTY_OFFSET(property_offset))) {
@@ -1119,7 +1119,7 @@ ZEND_API void zend_std_unset_property(zval *object, zval *member, void **cache_s
 			goto exit;
 		}
 		/* Reset the IS_PROP_UNINIT flag, if it exists. */
-		Z_EXTRA_P(slot) = 0;
+		Z_PROP_FLAG_P(slot) = 0;
 	} else if (EXPECTED(IS_DYNAMIC_PROPERTY_OFFSET(property_offset))
 	 && EXPECTED(zobj->properties != NULL)) {
 		if (UNEXPECTED(GC_REFCOUNT(zobj->properties) > 1)) {

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -209,7 +209,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 
 		do {
 			i_zval_ptr_dtor(dst);
-			*dst = *src; /* Copy Z_EXTRA as well */
+			ZVAL_COPY_VALUE_PROP(dst, src);
 			zval_add_ref(dst);
 			if (UNEXPECTED(Z_ISREF_P(dst)) &&
 					(ZEND_DEBUG || ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(dst)))) {

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -209,7 +209,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 
 		do {
 			i_zval_ptr_dtor(dst);
-			ZVAL_COPY_VALUE(dst, src);
+			*dst = *src; /* Copy Z_EXTRA as well */
 			zval_add_ref(dst);
 			if (UNEXPECTED(Z_ISREF_P(dst)) &&
 					(ZEND_DEBUG || ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(dst)))) {

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -593,6 +593,9 @@ static zend_always_inline uint32_t zval_gc_info(uint32_t gc_type_info) {
 
 #define OBJ_FLAGS(obj)              GC_FLAGS(obj)
 
+/* Property flag stores in Z_EXTRA */
+#define IS_PROP_UNINIT				1
+
 /* Recursion protection macros must be used only for arrays and objects */
 #define GC_IS_RECURSIVE(p) \
 	(GC_FLAGS(p) & GC_PROTECTED)

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -270,7 +270,7 @@ static void zend_class_copy_ctor(zend_class_entry **pce)
 		end = src + ce->default_properties_count;
 		ce->default_properties_table = dst;
 		for (; src != end; src++, dst++) {
-			*dst = *src;
+			ZVAL_COPY_VALUE_PROP(dst, src);
 		}
 	}
 

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -270,7 +270,7 @@ static void zend_class_copy_ctor(zend_class_entry **pce)
 		end = src + ce->default_properties_count;
 		ce->default_properties_table = dst;
 		for (; src != end; src++, dst++) {
-			ZVAL_COPY_VALUE(dst, src);
+			*dst = *src;
 		}
 	}
 


### PR DESCRIPTION
Same as #4854 but based on Z_EXTRA rather than TYPE_FLAG.