### PR TITLE
Convert phpdbg arginfo to php stubs

### DIFF
--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -28,6 +28,7 @@
 #include "phpdbg_eol.h"
 #include "phpdbg_print.h"
 #include "phpdbg_help.h"
+#include "phpdbg_arginfo.h"
 
 #include "ext/standard/basic_functions.h"
 
@@ -713,62 +714,18 @@ static PHP_FUNCTION(phpdbg_end_oplog)
 	}
 }
 
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_break_next_arginfo, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_break_file_arginfo, 0, 0, 2)
-	ZEND_ARG_INFO(0, file)
-	ZEND_ARG_INFO(0, line)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_break_method_arginfo, 0, 0, 2)
-	ZEND_ARG_INFO(0, class)
-	ZEND_ARG_INFO(0, method)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_break_function_arginfo, 0, 0, 1)
-	ZEND_ARG_INFO(0, function)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_color_arginfo, 0, 0, 2)
-	ZEND_ARG_INFO(0, element)
-	ZEND_ARG_INFO(0, color)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_prompt_arginfo, 0, 0, 1)
-	ZEND_ARG_INFO(0, string)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_exec_arginfo, 0, 0, 1)
-	ZEND_ARG_INFO(0, context)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_clear_arginfo, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_start_oplog_arginfo, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_end_oplog_arginfo, 0, 0, 0)
-	ZEND_ARG_INFO(0, options)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(phpdbg_get_executable_arginfo, 0, 0, 0)
-	ZEND_ARG_INFO(0, options)
-ZEND_END_ARG_INFO()
-
 static const zend_function_entry phpdbg_user_functions[] = {
-	PHP_FE(phpdbg_clear, phpdbg_clear_arginfo)
-	PHP_FE(phpdbg_break_next, phpdbg_break_next_arginfo)
-	PHP_FE(phpdbg_break_file, phpdbg_break_file_arginfo)
-	PHP_FE(phpdbg_break_method, phpdbg_break_method_arginfo)
-	PHP_FE(phpdbg_break_function, phpdbg_break_function_arginfo)
-	PHP_FE(phpdbg_exec,  phpdbg_exec_arginfo)
-	PHP_FE(phpdbg_color, phpdbg_color_arginfo)
-	PHP_FE(phpdbg_prompt, phpdbg_prompt_arginfo)
-	PHP_FE(phpdbg_start_oplog, phpdbg_start_oplog_arginfo)
-	PHP_FE(phpdbg_end_oplog, phpdbg_end_oplog_arginfo)
-	PHP_FE(phpdbg_get_executable, phpdbg_get_executable_arginfo)
+	PHP_FE(phpdbg_clear, arginfo_phpdbg_clear)
+	PHP_FE(phpdbg_break_next, arginfo_phpdbg_break_next)
+	PHP_FE(phpdbg_break_file, arginfo_phpdbg_break_file)
+	PHP_FE(phpdbg_break_method, arginfo_phpdbg_break_method)
+	PHP_FE(phpdbg_break_function, arginfo_phpdbg_break_function)
+	PHP_FE(phpdbg_exec, arginfo_phpdbg_exec)
+	PHP_FE(phpdbg_color, arginfo_phpdbg_color)
+	PHP_FE(phpdbg_prompt, arginfo_phpdbg_prompt)
+	PHP_FE(phpdbg_start_oplog, arginfo_phpdbg_start_oplog)
+	PHP_FE(phpdbg_end_oplog, arginfo_phpdbg_end_oplog)
+	PHP_FE(phpdbg_get_executable, arginfo_phpdbg_get_executable)
 #ifdef  PHP_FE_END
 	PHP_FE_END
 #else

--- a/sapi/phpdbg/phpdbg.stub.php
+++ b/sapi/phpdbg/phpdbg.stub.php
@@ -1,0 +1,24 @@
+<?php
+
+function phpdbg_break_next(): void {}
+
+function phpdbg_break_file(string $file, int $line): void {}
+
+function phpdbg_break_method(string $class, string $method): void {}
+
+function phpdbg_break_function(string $function): void {}
+
+function phpdbg_color(int $element, string $color): void {}
+
+function phpdbg_prompt(string $string): void {}
+
+/** @return string|bool */
+function phpdbg_exec(string $context) {}
+
+function phpdbg_clear(): void {}
+
+function phpdbg_start_oplog(): void {}
+
+function phpdbg_end_oplog(array $options = []): ?array {}
+
+function phpdbg_get_executable(array $options = []): array {}

--- a/sapi/phpdbg/phpdbg_arginfo.h
+++ b/sapi/phpdbg/phpdbg_arginfo.h
@@ -1,0 +1,43 @@
+/* This is a generated file, edit the .stub.php file instead. */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phpdbg_break_next, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phpdbg_break_file, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, file, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, line, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phpdbg_break_method, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, class, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, method, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phpdbg_break_function, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, function, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phpdbg_color, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, element, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, color, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phpdbg_prompt, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phpdbg_exec, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, context, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_phpdbg_clear arginfo_phpdbg_break_next
+
+#define arginfo_phpdbg_start_oplog arginfo_phpdbg_break_next
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phpdbg_end_oplog, 0, 0, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phpdbg_get_executable, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()


### PR DESCRIPTION
Pretty straight forward one, although the docs for `phpdbg_exec()` say the parameter is optional, the implementation doesn't look like it is