### PR TITLE
Elevate warnings to ValueErrors in ext/calendar

### DIFF
--- a/ext/calendar/cal_unix.c
+++ b/ext/calendar/cal_unix.c
@@ -35,7 +35,8 @@ PHP_FUNCTION(unixtojd)
 	if (!ts) {
 		ts = time(NULL);
 	} else if (ts < 0) {
-		RETURN_FALSE;
+		zend_value_error("timestamp must not be negative");
+		return;
 	}
 
 	if (!(ta = php_localtime_r(&ts, &tmbuf))) {
@@ -57,8 +58,9 @@ PHP_FUNCTION(jdtounix)
 	}
 	uday -= 2440588 /* J.D. of 1.1.1970 */;
 
-	if (uday < 0 || uday > 24755) { /* before beginning of unix epoch or behind end of unix epoch */
-		RETURN_FALSE;
+	if (uday < 0 || uday > 24755) {
+		zend_value_error("jday must be within the Unix epoch");
+		return;
 	}
 
 	RETURN_LONG(uday * 24 * 3600);

--- a/ext/calendar/calendar.c
+++ b/ext/calendar/calendar.c
@@ -218,8 +218,8 @@ PHP_FUNCTION(cal_info)
 
 
 	if (cal != -1 && (cal < 0 || cal >= CAL_NUM_CALS)) {
-		php_error_docref(NULL, E_WARNING, "invalid calendar ID " ZEND_LONG_FMT, cal);
-		RETURN_FALSE;
+		zend_value_error("invalid calendar ID " ZEND_LONG_FMT, cal);
+		return;
 	}
 
 	_php_cal_info(cal, return_value);
@@ -240,8 +240,8 @@ PHP_FUNCTION(cal_days_in_month)
 	}
 
 	if (cal < 0 || cal >= CAL_NUM_CALS) {
-		php_error_docref(NULL, E_WARNING, "invalid calendar ID " ZEND_LONG_FMT, cal);
-		RETURN_FALSE;
+		zend_value_error("invalid calendar ID " ZEND_LONG_FMT, cal);
+		return;
 	}
 
 	calendar = &cal_conversion_table[cal];
@@ -249,8 +249,8 @@ PHP_FUNCTION(cal_days_in_month)
 	sdn_start = calendar->to_jd(year, month, 1);
 
 	if (sdn_start == 0) {
-		php_error_docref(NULL, E_WARNING, "invalid date");
-		RETURN_FALSE;
+		zend_value_error("invalid date");
+		return;
 	}
 
 	sdn_next = calendar->to_jd(year, 1 + month, 1);
@@ -286,8 +286,8 @@ PHP_FUNCTION(cal_to_jd)
 	}
 
 	if (cal < 0 || cal >= CAL_NUM_CALS) {
-		php_error_docref(NULL, E_WARNING, "invalid calendar ID " ZEND_LONG_FMT, cal);
-		RETURN_FALSE;
+		zend_value_error("invalid calendar ID " ZEND_LONG_FMT, cal);
+		return;
 	}
 
 	RETURN_LONG(cal_conversion_table[cal].to_jd(year, month, day));
@@ -307,8 +307,8 @@ PHP_FUNCTION(cal_from_jd)
 	}
 
 	if (cal < 0 || cal >= CAL_NUM_CALS) {
-		php_error_docref(NULL, E_WARNING, "invalid calendar ID " ZEND_LONG_FMT, cal);
-		RETURN_FALSE;
+		zend_value_error("invalid calendar ID " ZEND_LONG_FMT, cal);
+		return;
 	}
 	calendar = &cal_conversion_table[cal];
 
@@ -522,8 +522,8 @@ PHP_FUNCTION(jdtojewish)
 		RETURN_NEW_STR(zend_strpprintf(0, "%i/%i/%i", month, day, year));
 	} else {
 		if (year <= 0 || year > 9999) {
-			php_error_docref(NULL, E_WARNING, "Year out of range (0-9999)");
-			RETURN_FALSE;
+			zend_value_error("Year out of range (0-9999)");
+			return;
 		}
 
 		RETVAL_NEW_STR(zend_strpprintf(0, "%s %s %s", heb_number_to_chars(day, fl, &dayp), JEWISH_HEB_MONTH_NAME(year)[month], heb_number_to_chars(year, fl, &yearp)));

--- a/ext/calendar/calendar.stub.php
+++ b/ext/calendar/calendar.stub.php
@@ -1,19 +1,14 @@
 <?php
 
-/** @return int|false */
-function cal_days_in_month(int $calendar, int $month, int $year) {}
+function cal_days_in_month(int $calendar, int $month, int $year): int {}
 
-/** @return array|false */
-function cal_from_jd(int $jd, int $calendar) {}
+function cal_from_jd(int $jd, int $calendar): array {}
 
-/** @return array|false */
-function cal_info(?int $calendar = UNKNOWN) {}
+function cal_info(?int $calendar = UNKNOWN): array {}
 
-/** @return int|false */
-function cal_to_jd(int $calendar, int $month, int $day, int $year) {}
+function cal_to_jd(int $calendar, int $month, int $day, int $year): int {}
 
-/** @return int|false */
-function easter_date(int $year = UNKNOWN, int $method = CAL_EASTER_DEFAULT) {}
+function easter_date(int $year = UNKNOWN, int $method = CAL_EASTER_DEFAULT): int {}
 
 function easter_days(int $year = UNKNOWN, int $method = CAL_EASTER_DEFAULT): int {}
 
@@ -30,13 +25,11 @@ function jdtofrench(int $juliandaycount): string {}
 
 function jdtogregorian(int $juliandaycount): string {}
 
-/** @return string|false */
-function jdtojewish(int $juliandaycount, bool $hebrew = false, int $fl = 0) {}
+function jdtojewish(int $juliandaycount, bool $hebrew = false, int $fl = 0): string {}
 
 function jdtojulian(int $juliandaycount): string {}
 
-/** @return int|false */
-function jdtounix(int $jday) {}
+function jdtounix(int $jday): int {}
 
 function jewishtojd(int $month, int $day, int $year): int {}
 

--- a/ext/calendar/calendar_arginfo.h
+++ b/ext/calendar/calendar_arginfo.h
@@ -1,36 +1,33 @@
 /* This is a generated file, edit the .stub.php file instead. */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_cal_days_in_month, 0, 0, 3)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_cal_days_in_month, 0, 3, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, calendar, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_cal_from_jd, 0, 0, 2)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_cal_from_jd, 0, 2, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, jd, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, calendar, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_cal_info, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_cal_info, 0, 0, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, calendar, IS_LONG, 1)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_cal_to_jd, 0, 0, 4)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_cal_to_jd, 0, 4, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, calendar, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, day, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_easter_date, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_easter_date, 0, 0, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_easter_days, 0, 0, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_easter_days arginfo_easter_date
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frenchtojd, 0, 3, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
@@ -56,7 +53,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_jdtogregorian arginfo_jdtofrench
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_jdtojewish, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_jdtojewish, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, juliandaycount, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, hebrew, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, fl, IS_LONG, 0)
@@ -64,7 +61,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_jdtojulian arginfo_jdtofrench
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_jdtounix, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_jdtounix, 0, 1, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, jday, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/calendar/easter.c
+++ b/ext/calendar/easter.c
@@ -49,8 +49,8 @@ static void _cal_easter(INTERNAL_FUNCTION_PARAMETERS, zend_long gm)
 	}
 
 	if (gm && (year<1970 || year>2037)) {				/* out of range for timestamps */
-		php_error_docref(NULL, E_WARNING, "This function is only valid for years between 1970 and 2037 inclusive");
-		RETURN_FALSE;
+		zend_value_error("This function is only valid for years between 1970 and 2037 inclusive");
+		return;
 	}
 
 	golden = (year % 19) + 1;					/* the Golden number */

--- a/ext/calendar/tests/cal_days_in_month_error1.phpt
+++ b/ext/calendar/tests/cal_days_in_month_error1.phpt
@@ -6,12 +6,17 @@ edgarsandi - <edgar.r.sandi@gmail.com>
 <?php include 'skipif.inc'; ?>
 --FILE--
 <?php
-var_dump(cal_days_in_month(-1, 4, 2017));
-var_dump(cal_days_in_month(CAL_GREGORIAN,0, 2009));
+try {
+    cal_days_in_month(-1, 4, 2017);
+} catch (ValueError $ex) {
+    echo "{$ex->getMessage()}\n";
+}
+try{
+    cal_days_in_month(CAL_GREGORIAN,0, 2009);
+} catch (ValueError $ex) {
+    echo "{$ex->getMessage()}\n";
+}
 ?>
---EXPECTF--
-Warning: cal_days_in_month(): invalid calendar ID -1 in %s on line %d
-bool(false)
-
-Warning: cal_days_in_month(): invalid date in %s on line %d
-bool(false)
+--EXPECT--
+invalid calendar ID -1
+invalid date

--- a/ext/calendar/tests/cal_from_jd_error1.phpt
+++ b/ext/calendar/tests/cal_from_jd_error1.phpt
@@ -6,8 +6,11 @@ edgarsandi - <edgar.r.sandi@gmail.com>
 <?php include 'skipif.inc'; ?>
 --FILE--
 <?php
-var_dump(cal_from_jd(1748326, -1));
+try {
+    cal_from_jd(1748326, -1);
+} catch (ValueError $ex) {
+    echo "{$ex->getMessage()}\n";
+}
 ?>
---EXPECTF--
-Warning: cal_from_jd(): invalid calendar ID -1 in %s on line %d
-bool(false)
+--EXPECT--
+invalid calendar ID -1

--- a/ext/calendar/tests/cal_info.phpt
+++ b/ext/calendar/tests/cal_info.phpt
@@ -8,9 +8,13 @@ date.timezone=UTC
 <?php
   print_r(cal_info());
   print_r(cal_info(1));
-  print_r(cal_info(99999));
+  try {
+      cal_info(99999);
+  } catch (ValueError $ex) {
+      echo "{$ex->getMessage()}\n";
+  }
 ?>
---EXPECTF--
+--EXPECT--
 Array
 (
     [0] => Array
@@ -212,5 +216,4 @@ Array
     [calname] => Julian
     [calsymbol] => CAL_JULIAN
 )
-
-Warning: cal_info(): invalid calendar ID 99999 in %s on line %d
+invalid calendar ID 99999

--- a/ext/calendar/tests/cal_to_jd_error1.phpt
+++ b/ext/calendar/tests/cal_to_jd_error1.phpt
@@ -6,8 +6,11 @@ edgarsandi - <edgar.r.sandi@gmail.com>
 <?php include 'skipif.inc'; ?>
 --FILE--
 <?php
-var_dump(cal_to_jd(-1, 8, 26, 74));
+try {
+    cal_to_jd(-1, 8, 26, 74);
+} catch (ValueError $ex) {
+    echo "{$ex->getMessage()}\n";
+}
 ?>
---EXPECTF--
-Warning: cal_to_jd(): invalid calendar ID -1 in %s on line %d
-bool(false)
+--EXPECT--
+invalid calendar ID -1

--- a/ext/calendar/tests/easter_date.phpt
+++ b/ext/calendar/tests/easter_date.phpt
@@ -10,12 +10,14 @@ putenv('TZ=UTC');
 echo date("Y-m-d", easter_date(2000))."\n";
 echo date("Y-m-d", easter_date(2001))."\n";
 echo date("Y-m-d", easter_date(2002))."\n";
-echo date("Y-m-d", easter_date(1492))."\n";
+try {
+    easter_date(1492);
+} catch (ValueError $ex) {
+    echo "{$ex->getMessage()}\n";
+}
 ?>
---EXPECTF--
+--EXPECT--
 2000-04-23
 2001-04-15
 2002-03-31
-
-Warning: easter_date(): This function is only valid for years between 1970 and 2037 inclusive in %s on line %d
-1970-01-01
+This function is only valid for years between 1970 and 2037 inclusive

--- a/ext/calendar/tests/jdtojewish.phpt
+++ b/ext/calendar/tests/jdtojewish.phpt
@@ -20,7 +20,11 @@ var_dump(jdtojewish(gregoriantojd(10,28,2002))."\r\n".
 echo jdtojewish(gregoriantojd(11,5,2002)) . "\n";
 echo jdtojewish(gregoriantojd(11,29,2004)) . "\n";
 echo jdtojewish(gregoriantojd(1,1,9998)) . "\n";
-echo jdtojewish(gregoriantojd(1,1,9998),true) . "\n";
+try {
+	jdtojewish(gregoriantojd(1,1,9998),true);
+} catch (ValueError $ex) {
+	echo "{$ex->getMessage()}\n";
+}
 ?>
 --EXPECTF--
 string(%d) "2/22/5763
@@ -38,5 +42,4 @@ string(%d) "2/22/5763
 2/30/5763
 3/16/5765
 3/8/13758
-
-Warning: jdtojewish(): Year out of range (0-9999) in %s on line %d
+Year out of range (0-9999)

--- a/ext/calendar/tests/jdtounix_error1.phpt
+++ b/ext/calendar/tests/jdtounix_error1.phpt
@@ -8,7 +8,11 @@ date.timezone=UTC
 <?php include 'skipif.inc'; ?>
 --FILE--
 <?php
-var_dump(jdtounix(2440579)) . PHP_EOL;
+try {
+    jdtounix(2440579);
+} catch (ValueError $ex) {
+    echo $ex->getMessage(), PHP_EOL;
+}
 ?>
 --EXPECT--
-bool(false)
+jday must be within the Unix epoch

--- a/ext/calendar/tests/unixtojd_error1.phpt
+++ b/ext/calendar/tests/unixtojd_error1.phpt
@@ -10,13 +10,17 @@ date.timezone=UTC
 <?php
 putenv('TZ=UTC');
 
-var_dump(unixtojd(-1)) . PHP_EOL;
+try {
+    unixtojd(-1);
+} catch (ValueError $ex) {
+    echo $ex->getMessage(), PHP_EOL;
+}
 var_dump(unixtojd(false)) . PHP_EOL;
 var_dump(unixtojd(null)) . PHP_EOL;
 var_dump(unixtojd(time())) . PHP_EOL;
 ?>
 --EXPECTF--
-bool(false)
+timestamp must not be negative
 int(%d)
 int(%d)
 int(%d)


### PR DESCRIPTION
All of these warnings/ValueErrors are due to programming errors, i.e.
calling a function with unsupported arguments.