### PR TITLE
Update documentation/comment for GH-4860

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -371,6 +371,6 @@ PHP 8.0 UPGRADE NOTES
 14. Performance Improvements
 ========================================
 
-- array_slice() on a packed array will no longer scan the whole array to find
+- array_slice() on an array without gaps will no longer scan the whole array to find
   the start offset. This may significantly reduce the runtime of the function
   with large offsets and small lengths.

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3480,6 +3480,7 @@ static inline Bucket* find_bucket_at_offset(HashTable* ht, zend_long offset)
 	/* Return a pointer to the end of the bucket array. */
 	return ht->arData + ht->nNumUsed;
 }
+/* }}} */
 
 /* {{{ proto array array_slice(array input, int offset [, int length [, bool preserve_keys]])
    Returns elements specified by offset and length */


### PR DESCRIPTION
Fix comment folding for the new helper method of array_slice.

Clarify comment in UPGRADING:
The performance on associative arrays would also improve,
as long as no offsets were unset (no gaps).
Packed arrays can have gaps.