### PR TITLE
Remove mmap limit when performing stream copies

### DIFF
--- a/main/streams/mmap.c
+++ b/main/streams/mmap.c
@@ -27,12 +27,6 @@ PHPAPI char *_php_stream_mmap_range(php_stream *stream, size_t offset, size_t le
 	range.mode = mode;
 	range.mapped = NULL;
 
-	/* For now, we impose an arbitrary limit to avoid
-	 * runaway swapping when large files are passed through. */
-	if (length > 4 * 1024 * 1024) {
-		return NULL;
-	}
-
 	if (PHP_STREAM_OPTION_RETURN_OK == php_stream_set_option(stream, PHP_STREAM_OPTION_MMAP_API, PHP_STREAM_MMAP_MAP_RANGE, &range)) {
 		if (mapped_len) {
 			*mapped_len = range.length;


### PR DESCRIPTION
Based on the reasoning I provided in [bug #77930](https://bugs.php.net/bug.php?id=77930):

> First, the limitation already doesn't trigger if you copy the whole file (i.e. use copy() or stream_copy_to_stream() and don't specify a length). This happens because length will be 0 at the time of the check and only later calculated based on the file size. This means that we're already completely blowing the length limit for what is is likely the most common case, and it doesn't seem like anyone complained about that.
>
> Second, the premise of the code comment ("to avoid runaway swapping") seems incorrect to me. Because this performs a file-backed non-private mmap, no swap backing is needed for the mapping. Concerns over "memory usage" are also misplaced, as this is a virtual mapping.