### PR TITLE
Cleanup return values when parameter parsing is unsuccessful for the rest of the extensions

### DIFF
--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -792,7 +792,7 @@ PHP_FUNCTION(com_message_pump)
 	DWORD result;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &timeoutms) == FAILURE)
-		RETURN_FALSE;
+		return;
 
 	php_com_initialize();
 	result = MsgWaitForMultipleObjects(0, NULL, FALSE, (DWORD)timeoutms, QS_ALLINPUT);

--- a/ext/curl/curl_file.c
+++ b/ext/curl/curl_file.c
@@ -73,9 +73,7 @@ static void curlfile_get_property(char *name, size_t name_len, INTERNAL_FUNCTION
 {
 	zval *res, rv;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 	res = zend_read_property(curl_CURLFile_class, ZEND_THIS, name, name_len, 1, &rv);
 	ZVAL_COPY_DEREF(return_value, res);
 }

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -53,9 +53,7 @@ PHP_FUNCTION(curl_multi_init)
 {
 	php_curlm *mh;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	mh = ecalloc(1, sizeof(php_curlm));
 	mh->multi = curl_multi_init();

--- a/ext/curl/share.c
+++ b/ext/curl/share.c
@@ -36,9 +36,7 @@ PHP_FUNCTION(curl_share_init)
 {
 	php_curlsh *sh;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	sh = ecalloc(1, sizeof(php_curlsh));
 

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1424,9 +1424,7 @@ PHP_FUNCTION(gmstrftime)
    Return current UNIX timestamp */
 PHP_FUNCTION(time)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG((zend_long)php_time());
 }
@@ -4321,9 +4319,7 @@ PHP_METHOD(DatePeriod, getStartDate)
 	php_period_obj   *dpobj;
 	php_date_obj     *dateobj;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	dpobj = Z_PHPPERIOD_P(ZEND_THIS);
 
@@ -4348,9 +4344,7 @@ PHP_METHOD(DatePeriod, getEndDate)
         php_period_obj   *dpobj;
         php_date_obj     *dateobj;
 
-        if (zend_parse_parameters_none() == FAILURE) {
-                return;
-        }
+        ZEND_PARSE_PARAMETERS_NONE();
 
         dpobj = Z_PHPPERIOD_P(ZEND_THIS);
 
@@ -4379,9 +4373,7 @@ PHP_METHOD(DatePeriod, getDateInterval)
 	php_period_obj   *dpobj;
 	php_interval_obj *diobj;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	dpobj = Z_PHPPERIOD_P(ZEND_THIS);
 
@@ -4399,9 +4391,7 @@ PHP_METHOD(DatePeriod, getRecurrences)
 {
 	php_period_obj   *dpobj;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	dpobj = Z_PHPPERIOD_P(ZEND_THIS);
 
@@ -4546,9 +4536,7 @@ PHP_FUNCTION(date_default_timezone_set)
 PHP_FUNCTION(date_default_timezone_get)
 {
 	timelib_tzinfo *default_tz;
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	default_tz = get_timezone_info();
 	RETVAL_STRING(default_tz->name);

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -1048,7 +1048,7 @@ PHP_FUNCTION(dba_key_split)
 		}
 	}
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
-		RETURN_BOOL(0);
+		return;
 	}
 	array_init(return_value);
 	if (key[0] == '[' && (name = strchr(key, ']')) != NULL) {
@@ -1204,7 +1204,7 @@ PHP_FUNCTION(dba_handlers)
 	zend_bool full_info = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &full_info) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	array_init(return_value);
@@ -1231,7 +1231,7 @@ PHP_FUNCTION(dba_list)
 	dba_info *info;
 
 	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	array_init(return_value);

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -243,7 +243,7 @@ PHP_FUNCTION(finfo_open)
 	zend_error_handling zeh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|lp", &options, &file, &file_len) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (object) {

--- a/ext/filter/filter.c
+++ b/ext/filter/filter.c
@@ -531,7 +531,7 @@ PHP_FUNCTION(filter_has_var)
 	zval        *array_ptr = NULL;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lS", &arg, &var) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	array_ptr = php_filter_get_storage(arg);

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -353,7 +353,7 @@ PHP_FUNCTION(hash_init)
 	php_hashcontext_object *hash;
 
 	if (zend_parse_parameters(argc, "S|lS", &algo, &options, &key) == FAILURE) {
-		RETURN_NULL();
+		return;
 	}
 
 	ops = php_hash_fetch_ops(ZSTR_VAL(algo), ZSTR_LEN(algo));

--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -2119,7 +2119,7 @@ PHP_FUNCTION(imap_savebody)
 	zend_long msgno, flags = 0;
 
 	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "rzl|Sl", &stream, &out, &msgno, &section, &flags)) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if ((imap_ptr = (pils *)zend_fetch_resource(Z_RES_P(stream), "imap", le_imap)) == NULL) {
@@ -4420,7 +4420,7 @@ PHP_FUNCTION(imap_timeout)
 	int timeout_type;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &ttype, &timeout) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (timeout == -1) {

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -3420,7 +3420,7 @@ PHP_FUNCTION(ldap_parse_exop)
 	int rc, myargcount = ZEND_NUM_ARGS();
 
 	if (zend_parse_parameters(myargcount, "rr|zz", &link, &result, &retdata, &retoid) != SUCCESS) {
-		WRONG_PARAM_COUNT;
+		return;
 	}
 
 	if ((ld = (ldap_linkdata *)zend_fetch_resource(Z_RES_P(link), "ldap link", le_link)) == NULL) {
@@ -4316,7 +4316,7 @@ PHP_FUNCTION(ldap_exop_whoami)
 	int rc;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &link) == FAILURE) {
-		WRONG_PARAM_COUNT;
+		return;
 	}
 
 	if ((ld = (ldap_linkdata *)zend_fetch_resource(Z_RES_P(link), "ldap link", le_link)) == NULL) {
@@ -4354,7 +4354,7 @@ PHP_FUNCTION(ldap_exop_refresh)
 	int rc;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsz", &link, &ldn.bv_val, &ldn.bv_len, &ttl) != SUCCESS) {
-		WRONG_PARAM_COUNT;
+		return;
 	}
 
 	if ((ld = (ldap_linkdata *)zend_fetch_resource(Z_RES_P(link), "ldap link", le_link)) == NULL) {

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -717,7 +717,7 @@ static ZEND_FUNCTION(opcache_get_configuration)
 	zval directives, version, blacklist;
 
 	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (!validate_api_restriction()) {
@@ -809,7 +809,7 @@ static ZEND_FUNCTION(opcache_get_configuration)
 static ZEND_FUNCTION(opcache_reset)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (!validate_api_restriction()) {

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5021,7 +5021,7 @@ PHP_FUNCTION(openssl_pkey_derive)
 	zend_string *result;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz|l", &peer_pub_key, &priv_key, &key_len) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 	if (key_len < 0) {
 		php_error_docref(NULL, E_WARNING, "keylen < 0, assuming NULL");

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1279,7 +1279,7 @@ PHP_FUNCTION(pcntl_setpriority)
 	zend_long pri;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|ll", &pri, &pid, &who) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (setpriority(who, pid, pri)) {

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1051,12 +1051,12 @@ static PHP_METHOD(PDO, query)
 	/* Return a meaningful error when no parameters were passed */
 	if (!ZEND_NUM_ARGS()) {
 		zend_parse_parameters(0, "z|z", NULL, NULL);
-		RETURN_FALSE;
+		return;
 	}
 
 	if (FAILURE == zend_parse_parameters(1, "s", &statement,
 			&statement_len)) {
-		RETURN_FALSE;
+		return;
 	}
 
 	PDO_DBH_CLEAR_ERR();

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1578,7 +1578,7 @@ static PHP_METHOD(PDOStatement, bindValue)
 			"lz|l", &param.paramno, &parameter, &param_type)) {
 		if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|l", &param.name,
 				&parameter, &param_type)) {
-			RETURN_FALSE;
+			return;
 		}
 	}
 

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -956,7 +956,7 @@ static PHP_METHOD(PDO, pgsqlLOBOpen)
 
 	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "s|s",
 				&oidstr, &oidstrlen, &modestr, &modestrlen)) {
-		RETURN_FALSE;
+		return;
 	}
 
 	oid = (Oid)strtoul(oidstr, &end_ptr, 10);
@@ -1003,7 +1003,7 @@ static PHP_METHOD(PDO, pgsqlLOBUnlink)
 
 	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 				&oidstr, &oidlen)) {
-		RETURN_FALSE;
+		return;
 	}
 
 	oid = (Oid)strtoul(oidstr, &end_ptr, 10);
@@ -1039,7 +1039,7 @@ static PHP_METHOD(PDO, pgsqlGetNotify)
 
 	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "|ll",
 				&result_type, &ms_timeout)) {
-		RETURN_FALSE;
+		return;
 	}
 
 	dbh = Z_PDO_DBH_P(ZEND_THIS);

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -2944,7 +2944,7 @@ PHP_FUNCTION(pg_fetch_all_columns)
 	size_t num_fields;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|l", &result, &colno) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if ((pg_result = (pgsql_result_handle *)zend_fetch_resource(Z_RES_P(result), "PostgreSQL result", le_result)) == NULL) {

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -1316,7 +1316,7 @@ PHP_METHOD(Phar, unlinkArchive)
 	phar_archive_data *phar;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p", &fname, &fname_len) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (!fname_len) {
@@ -1736,7 +1736,7 @@ PHP_METHOD(Phar, buildFromDirectory)
 	}
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p|s", &dir, &dir_len, &regex, &regex_len) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (ZEND_SIZE_T_UINT_OVFL(dir_len)) {
@@ -1872,7 +1872,7 @@ PHP_METHOD(Phar, buildFromIterator)
 	}
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|s", &obj, zend_ce_traversable, &base, &base_len) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (ZEND_SIZE_T_UINT_OVFL(base_len)) {
@@ -1921,7 +1921,7 @@ PHP_METHOD(Phar, count)
 	PHAR_ARCHIVE_OBJECT();
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &mode) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	RETURN_LONG(zend_hash_num_elements(&phar_obj->archive->manifest));
@@ -1938,7 +1938,7 @@ PHP_METHOD(Phar, isFileFormat)
 	PHAR_ARCHIVE_OBJECT();
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &type) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	switch (type) {
@@ -2641,7 +2641,7 @@ PHP_METHOD(Phar, delete)
 	}
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p", &fname, &fname_len) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (phar_obj->archive->is_persistent && FAILURE == phar_copy_on_write(&(phar_obj->archive))) {
@@ -2985,7 +2985,7 @@ PHP_METHOD(Phar, setDefaultStub)
 	}
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!s", &index, &index_len, &webindex, &webindex_len) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (ZEND_NUM_ARGS() > 0 && (phar_obj->archive->is_tar || phar_obj->archive->is_zip)) {

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -160,7 +160,7 @@ PHP_FUNCTION(readline)
 	char *result;
 
 	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "|s!", &prompt, &prompt_len)) {
-		RETURN_FALSE;
+		return;
 	}
 
 	result = readline(prompt);
@@ -522,7 +522,7 @@ PHP_FUNCTION(readline_completion_function)
 	zval *arg;
 
 	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "z", &arg)) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (!zend_is_callable(arg, 0, NULL)) {

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1952,7 +1952,7 @@ static PHP_FUNCTION(session_set_save_handler)
 		zend_bool register_shutdown = 1;
 
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|b", &obj, php_session_iface_entry, &register_shutdown) == FAILURE) {
-			RETURN_FALSE;
+			return;
 		}
 
 		/* For compatibility reason, implemented interface is not checked */
@@ -2452,7 +2452,7 @@ static PHP_FUNCTION(session_start)
 	zend_long read_and_close = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|a", &options) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (PS(session_status) == php_session_active) {

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -2368,7 +2368,7 @@ PHP_FUNCTION(socket_addrinfo_lookup)
 	memset(&hints, 0, sizeof(hints));
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|sa", &hostname, &service, &service_len, &zhints) == FAILURE) {
-		RETURN_NULL();
+		return;
 	}
 
 	if (zhints) {

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -88,7 +88,7 @@ PHP_FUNCTION(class_parents)
 	zend_bool autoload = 1;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|b", &obj, &autoload) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (Z_TYPE_P(obj) != IS_OBJECT && Z_TYPE_P(obj) != IS_STRING) {
@@ -122,7 +122,7 @@ PHP_FUNCTION(class_implements)
 	zend_class_entry *ce;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|b", &obj, &autoload) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 	if (Z_TYPE_P(obj) != IS_OBJECT && Z_TYPE_P(obj) != IS_STRING) {
 		php_error_docref(NULL, E_WARNING, "object or string expected");
@@ -151,7 +151,7 @@ PHP_FUNCTION(class_uses)
 	zend_class_entry *ce;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|b", &obj, &autoload) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 	if (Z_TYPE_P(obj) != IS_OBJECT && Z_TYPE_P(obj) != IS_STRING) {
 		php_error_docref(NULL, E_WARNING, "object or string expected");
@@ -312,7 +312,7 @@ PHP_FUNCTION(spl_autoload)
 	zend_string *class_name, *lc_name, *file_exts = SPL_G(autoload_extensions);
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|S", &class_name, &file_exts) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (file_exts == NULL) { /* autoload_extensions is not initialized, set to defaults */

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -3526,7 +3526,7 @@ PHP_FUNCTION(iterator_to_array)
 	zend_bool use_keys = 1;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|b", &obj, zend_ce_traversable, &use_keys) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	array_init(return_value);
@@ -3548,7 +3548,7 @@ PHP_FUNCTION(iterator_count)
 	zend_long  count = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &obj, zend_ce_traversable) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (spl_iterator_apply(obj, spl_iterator_count_apply, (void*)&count) == FAILURE) {

--- a/ext/sysvsem/sysvsem.c
+++ b/ext/sysvsem/sysvsem.c
@@ -181,7 +181,7 @@ PHP_FUNCTION(sem_get)
 	sysvsem_sem *sem_ptr;
 
 	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "l|lll", &key, &max_acquire, &perm, &auto_release)) {
-		RETURN_FALSE;
+		return;
 	}
 
 	/* Get/create the semaphore.  Note that we rely on the semaphores

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -403,7 +403,7 @@ PHP_FUNCTION(xsl_xsltprocessor_import_stylesheet)
 
 	id = ZEND_THIS;
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "o", &docp) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	nodep = php_libxml_import_node(docp);
@@ -630,7 +630,7 @@ PHP_FUNCTION(xsl_xsltprocessor_transform_to_doc)
 	sheetp = (xsltStylesheetPtr) intern->ptr;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "o|S!", &docp, &ret_class) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	newdocp = php_xsl_apply_stylesheet(id, intern, sheetp, docp);
@@ -687,7 +687,7 @@ PHP_FUNCTION(xsl_xsltprocessor_transform_to_uri)
 	sheetp = (xsltStylesheetPtr) intern->ptr;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "op", &docp, &uri, &uri_len) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	newdocp = php_xsl_apply_stylesheet(id, intern, sheetp, docp);
@@ -719,7 +719,7 @@ PHP_FUNCTION(xsl_xsltprocessor_transform_to_xml)
 	sheetp = (xsltStylesheetPtr) intern->ptr;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "o", &docp) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 
 	newdocp = php_xsl_apply_stylesheet(id, intern, sheetp, docp);
@@ -800,7 +800,7 @@ PHP_FUNCTION(xsl_xsltprocessor_get_parameter)
 	DOM_GET_THIS(id);
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sS", &namespace, &namespace_len, &name) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 	intern = Z_XSL_P(id);
 	if ((value = zend_hash_find(intern->parameter, name)) != NULL) {
@@ -824,7 +824,7 @@ PHP_FUNCTION(xsl_xsltprocessor_remove_parameter)
 	DOM_GET_THIS(id);
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sS", &namespace, &namespace_len, &name) == FAILURE) {
-		RETURN_FALSE;
+		return;
 	}
 	intern = Z_XSL_P(id);
 	if (zend_hash_del(intern->parameter, name) == SUCCESS) {

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -489,7 +489,7 @@ static PHP_FUNCTION(ob_gzhandler)
 	 * - we have to mess around with php_output_context */
 
 	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "sl", &in_str, &in_len, &flags)) {
-		RETURN_FALSE;
+		return;
 	}
 
 	if (!(encoding = php_zlib_output_encoding())) {
@@ -1028,7 +1028,7 @@ PHP_FUNCTION(inflate_get_status)
 
 	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "r", &res))
 	{
-		RETURN_NULL();
+		return;
 	}
 
 	if (!(ctx = zend_fetch_resource_ex(res, NULL, le_inflate))) {
@@ -1049,7 +1049,7 @@ PHP_FUNCTION(inflate_get_read_len)
 
 	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "r", &res))
 	{
-		RETURN_NULL();
+		return;
 	}
 
 	if (!(ctx = zend_fetch_resource_ex(res, NULL, le_inflate))) {


### PR DESCRIPTION
I also got the courage to upgrade some functions in the date and curl extensions to the fast parameter parsing API, because I saw that mainly fast ZPP is used there. If it wasn't a good idea, I'll revert these changes.

P.S.: I am aware that fast ZPP has its drawbacks too, but I am wondering if I could make the upgrade for those functions/methods in the date, curl, json, PDO, session, and standard extensions that haven't been transformed yet? Or it should be evaluated on a case by case basis if the upgrade of a function/method is worth?