### PR TITLE
Fix #78761: Zend memory heap corruption with preload and casting

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -3340,6 +3340,7 @@ static zend_ffi *zend_ffi_load(const char *filename, zend_bool preload) /* {{{ *
 	efree(code);
 	FFI_G(symbols) = NULL;
 	FFI_G(tags) = NULL;
+	FFI_G(persistent) = 0;
 
 	return ffi;
 

--- a/ext/ffi/tests/bug78761.phpt
+++ b/ext/ffi/tests/bug78761.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #78761 (Zend memory heap corruption with preload and casting)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--INI--
+opcache.enable_cli=1
+opcache.preload={PWD}/bug78761_preload.php
+--FILE--
+<?php
+try {
+    FFI::cast('char[10]', FFI::new('char[1]'));
+} catch (FFI\Exception $ex) {
+    echo $ex->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+attempt to cast to larger type

--- a/ext/ffi/tests/bug78761_preload.php
+++ b/ext/ffi/tests/bug78761_preload.php
@@ -1,0 +1,3 @@
+<?php
+
+FFI::load(__DIR__ . '/bug78761_preload.h');


### PR DESCRIPTION
We have to reset `FFI_G(persistent)` back to zero when preloading has
finished.