### PR TITLE
Promote some warnings to exceptions in standard lib

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -28,6 +28,7 @@
 #include "php_getopt.h"
 #include "ext/standard/info.h"
 #include "ext/session/php_session.h"
+#include "zend_exceptions.h"
 #include "zend_operators.h"
 #include "ext/standard/php_dns.h"
 #include "ext/standard/php_uuencode.h"
@@ -2599,8 +2600,8 @@ PHP_FUNCTION(putenv)
 	ZEND_PARSE_PARAMETERS_END();
 
     if(setting_len == 0 || setting[0] == '=') {
-    	php_error_docref(NULL, E_WARNING, "Invalid parameter syntax");
-    	RETURN_FALSE;
+    	zend_value_error("Invalid parameter syntax");
+    	return;
     }
 
 	pe.putenv_string = estrndup(setting, setting_len);
@@ -2982,8 +2983,8 @@ PHP_FUNCTION(sleep)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (num < 0) {
-		php_error_docref(NULL, E_WARNING, "Number of seconds must be greater than or equal to 0");
-		RETURN_FALSE;
+		zend_value_error("Number of seconds must be greater than or equal to 0");
+		return;
 	}
 #ifdef PHP_SLEEP_NON_VOID
 	RETURN_LONG(php_sleep((unsigned int)num));
@@ -3006,8 +3007,8 @@ PHP_FUNCTION(usleep)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (num < 0) {
-		php_error_docref(NULL, E_WARNING, "Number of microseconds must be greater than or equal to 0");
-		RETURN_FALSE;
+		zend_value_error("Number of microseconds must be greater than or equal to 0");
+		return;
 	}
 	if (usleep((unsigned int)num) < 0) {
 #if ZEND_DEBUG
@@ -3033,12 +3034,12 @@ PHP_FUNCTION(time_nanosleep)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (tv_sec < 0) {
-		php_error_docref(NULL, E_WARNING, "The seconds value must be greater than 0");
-		RETURN_FALSE;
+		zend_value_error("The seconds value must be greater than 0");
+		return;
 	}
 	if (tv_nsec < 0) {
-		php_error_docref(NULL, E_WARNING, "The nanoseconds value must be greater than 0");
-		RETURN_FALSE;
+		zend_value_error("The nanoseconds value must be greater than 0");
+		return;
 	}
 
 	php_req.tv_sec = (time_t) tv_sec;
@@ -3051,7 +3052,8 @@ PHP_FUNCTION(time_nanosleep)
 		add_assoc_long_ex(return_value, "nanoseconds", sizeof("nanoseconds")-1, php_rem.tv_nsec);
 		return;
 	} else if (errno == EINVAL) {
-		php_error_docref(NULL, E_WARNING, "nanoseconds was not in the range 0 to 999 999 999 or seconds was negative");
+		zend_value_error("Nanoseconds was not in the range 0 to 999 999 999 or seconds was negative");
+		return;
 	}
 
 	RETURN_FALSE;
@@ -4348,7 +4350,7 @@ PHP_FUNCTION(is_uploaded_file)
 	}
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_STRING(path, path_len)
+		Z_PARAM_PATH(path, path_len)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (zend_hash_str_exists(SG(rfc1867_uploaded_files), path, path_len)) {
@@ -4583,6 +4585,8 @@ PHP_FUNCTION(parse_ini_string)
  *  is not the same as ini_get_all() which returns only registered ini options. Only useful for devs to debug php.ini scanner/parser! */
 PHP_FUNCTION(config_get_hash) /* {{{ */
 {
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	HashTable *hash = php_ini_get_configuration_hash();
 
 	array_init(return_value);

--- a/ext/standard/tests/general_functions/putenv.phpt
+++ b/ext/standard/tests/general_functions/putenv.phpt
@@ -15,8 +15,17 @@ var_dump(getenv($var_name));
 var_dump(putenv($var_name));
 var_dump(getenv($var_name));
 
-var_dump(putenv("=123"));
-var_dump(putenv(""));
+try {
+    putenv("=123");
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    putenv("");
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 echo "Done\n";
 ?>
@@ -28,10 +37,6 @@ bool(true)
 string(0) ""
 bool(true)
 bool(false)
-
-Warning: putenv(): Invalid parameter syntax in %s on line %d
-bool(false)
-
-Warning: putenv(): Invalid parameter syntax in %s on line %d
-bool(false)
+Invalid parameter syntax
+Invalid parameter syntax
 Done

--- a/ext/standard/tests/general_functions/sleep_error.phpt
+++ b/ext/standard/tests/general_functions/sleep_error.phpt
@@ -2,25 +2,13 @@
 Test sleep() function : error conditions
 --FILE--
 <?php
-/* Prototype  : int sleep  ( int $seconds  )
- * Description: Delays the program execution for the given number of seconds .
- * Source code: ext/standard/basic_functions.c
- */
- set_time_limit(20);
 
-echo "*** Testing sleep() : error conditions ***\n";
-
-echo "\n-- Testing sleep() function with negative interval --\n";
-$seconds = -10;
-var_dump( sleep($seconds) );
+sleep(-10);
 
 ?>
-===DONE===
 --EXPECTF--
-*** Testing sleep() : error conditions ***
-
--- Testing sleep() function with negative interval --
-
-Warning: sleep(): Number of seconds must be greater than or equal to 0 in %s on line %d
-bool(false)
-===DONE===
+Fatal error: Uncaught ValueError: Number of seconds must be greater than or equal to 0 in %s
+Stack trace:
+#0 %s(%d): sleep(-10)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/standard/tests/general_functions/usleep_error.phpt
+++ b/ext/standard/tests/general_functions/usleep_error.phpt
@@ -2,26 +2,13 @@
 Test usleep() function : error conditions
 --FILE--
 <?php
-/* Prototype  : void usleep  ( int $micro_seconds  )
- * Description: Delays program execution for the given number of micro seconds.
- * Source code: ext/standard/basic_functions.c
- */
 
-set_time_limit(20);
-
-echo "*** Testing usleep() : error conditions ***\n";
-
-echo "\n-- Testing usleep() function with negative interval --\n";
-$seconds = -10;
-var_dump( usleep($seconds) );
+usleep(-10);
 
 ?>
-===DONE===
 --EXPECTF--
-*** Testing usleep() : error conditions ***
-
--- Testing usleep() function with negative interval --
-
-Warning: usleep(): Number of microseconds must be greater than or equal to 0 in %s on line %d
-bool(false)
-===DONE===
+Fatal error: Uncaught ValueError: Number of microseconds must be greater than or equal to 0 in %s
+Stack trace:
+#0 %s(%d): usleep(-10)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/standard/tests/misc/time_nanosleep_error3.phpt
+++ b/ext/standard/tests/misc/time_nanosleep_error3.phpt
@@ -9,8 +9,12 @@ if (!function_exists('time_nanosleep')) die("skip");
 --FILE--
 <?php
 
-$nano = time_nanosleep(-2, 1000);
+time_nanosleep(-2, 1000);
 
 ?>
 --EXPECTF--
-Warning: time_nanosleep(): The seconds value must be greater than 0 in %stime_nanosleep_error3.php on line %d
+Fatal error: Uncaught ValueError: The seconds value must be greater than 0 in %s:%d
+Stack trace:
+#0 %s(%d): time_nanosleep(-2, 1000)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/standard/tests/misc/time_nanosleep_error4.phpt
+++ b/ext/standard/tests/misc/time_nanosleep_error4.phpt
@@ -10,8 +10,12 @@ if (!function_exists('time_nanosleep')) die("skip");
 --FILE--
 <?php
 
-$nano = time_nanosleep(0, -10);
+time_nanosleep(0, -10);
 
 ?>
 --EXPECTF--
-Warning: time_nanosleep(): The nanoseconds value must be greater than 0 in %stime_nanosleep_error4.php on line %d
+Fatal error: Uncaught ValueError: The nanoseconds value must be greater than 0 in %s:%d
+Stack trace:
+#0 %s(%d): time_nanosleep(0, -10)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/standard/tests/misc/time_nanosleep_error5.phpt
+++ b/ext/standard/tests/misc/time_nanosleep_error5.phpt
@@ -7,8 +7,12 @@ time_nanosleep — Delay for a number of seconds and nanoseconds
 --FILE--
 <?php
 
-$nano = time_nanosleep(0, 1000000000);
+time_nanosleep(0, 1000000000);
 
 ?>
 --EXPECTF--
-Warning: time_nanosleep(): nanoseconds was not in the range 0 to 999 999 999 or seconds was negative in %s.php on line %d
+Fatal error: Uncaught ValueError: Nanoseconds was not in the range 0 to 999 999 999 or seconds was negative in %s:%d
+Stack trace:
+#0 %s(%d): time_nanosleep(0, 1000000000)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/standard/tests/time/bug60222.phpt
+++ b/ext/standard/tests/time/bug60222.phpt
@@ -2,14 +2,18 @@
 Bug #60222 (time_nanosleep() does validate input params)
 --FILE--
 <?php
-	var_dump(time_nanosleep(-1, 0));
-	var_dump(time_nanosleep(0, -1));
-?>
-===DONE===
---EXPECTF--
-Warning: time_nanosleep(): The seconds value must be greater than 0 in %s on line %d
-bool(false)
+    try {
+	    time_nanosleep(-1, 0);
+    } catch (ValueError $exception) {
+        echo $exception->getMessage() . "\n";
+    }
 
-Warning: time_nanosleep(): The nanoseconds value must be greater than 0 in %s on line %d
-bool(false)
-===DONE===
+    try {
+        time_nanosleep(0, -1);
+    } catch (ValueError $exception) {
+        echo $exception->getMessage() . "\n";
+    }
+?>
+--EXPECTF--
+The seconds value must be greater than 0
+The nanoseconds value must be greater than 0


### PR DESCRIPTION
I'd like to suggest promoting some warnings of the following functions to `ValueError`s:
- `putenv()`
- `sleep()`
- `usleep()`
- `time_nanosleep()`

Plus, I made a little bit of polishing in the neighbourhood.