### PR TITLE
zend_parse_parameters_throw() is obsolete

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -930,20 +930,6 @@ ZEND_API int zend_parse_parameters(int num_args, const char *type_spec, ...) /* 
 }
 /* }}} */
 
-ZEND_API int zend_parse_parameters_throw(int num_args, const char *type_spec, ...) /* {{{ */
-{
-	va_list va;
-	int retval;
-	int flags = 0;
-
-	va_start(va, type_spec);
-	retval = zend_parse_va_args(num_args, type_spec, &va, flags);
-	va_end(va);
-
-	return retval;
-}
-/* }}} */
-
 ZEND_API int zend_parse_method_parameters(int num_args, zval *this_ptr, const char *type_spec, ...) /* {{{ */
 {
 	va_list va;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -258,7 +258,8 @@ ZEND_API int zend_copy_parameters_array(int param_count, zval *argument_array);
 #define ZEND_PARSE_PARAMS_QUIET (1<<1)
 ZEND_API int zend_parse_parameters(int num_args, const char *type_spec, ...);
 ZEND_API int zend_parse_parameters_ex(int flags, int num_args, const char *type_spec, ...);
-ZEND_API int zend_parse_parameters_throw(int num_args, const char *type_spec, ...);
+#define zend_parse_parameters_throw(num_args, type_spec, ...) \
+	zend_parse_parameters(num_args, type_spec, __VA_ARGS__)
 ZEND_API const char *zend_zval_type_name(const zval *arg);
 ZEND_API zend_string *zend_zval_get_type(const zval *arg);
 

--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -57,7 +57,7 @@ PHP_METHOD(domattr, __construct)
 	char *name, *value = NULL;
 	size_t name_len, value_len, name_valid;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|s", &name, &name_len, &value, &value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s", &name, &name_len, &value, &value_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/cdatasection.c
+++ b/ext/dom/cdatasection.c
@@ -50,7 +50,7 @@ PHP_METHOD(domcdatasection, __construct)
 	char *value = NULL;
 	size_t value_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s", &value, &value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &value, &value_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/comment.c
+++ b/ext/dom/comment.c
@@ -50,7 +50,7 @@ PHP_METHOD(domcomment, __construct)
 	char *value = NULL;
 	size_t value_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|s", &value, &value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s", &value, &value_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1262,7 +1262,7 @@ PHP_METHOD(domdocument, __construct)
 	size_t encoding_len = 0, version_len = 0;
 	int refcount;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|ss", &version, &version_len, &encoding, &encoding_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|ss", &version, &version_len, &encoding, &encoding_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -158,7 +158,7 @@ PHP_METHOD(domelement, __construct)
 	int name_valid;
 	xmlNsPtr nsptr = NULL;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|s!s", &name, &name_len, &value, &value_len, &uri, &uri_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s!s", &name, &name_len, &value, &value_len, &uri, &uri_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/entityreference.c
+++ b/ext/dom/entityreference.c
@@ -50,7 +50,7 @@ PHP_METHOD(domentityreference, __construct)
 	char *name;
 	size_t name_len, name_valid;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/processinginstruction.c
+++ b/ext/dom/processinginstruction.c
@@ -52,7 +52,7 @@ PHP_METHOD(domprocessinginstruction, __construct)
 	size_t name_len, value_len;
 	int name_valid;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|s", &name, &name_len, &value, &value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s", &name, &name_len, &value, &value_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/text.c
+++ b/ext/dom/text.c
@@ -60,7 +60,7 @@ PHP_METHOD(domtext, __construct)
 	char *value = NULL;
 	size_t value_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|s", &value, &value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s", &value, &value_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -256,7 +256,7 @@ PHP_METHOD(domxpath, __construct)
 	dom_xpath_object *intern;
 	xmlXPathContextPtr ctx, oldctx;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O|b", &doc, dom_document_class_entry, &register_node_ns) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|b", &doc, dom_document_class_entry, &register_node_ns) == FAILURE) {
 		return;
 	}
 

--- a/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
+++ b/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
@@ -39,7 +39,7 @@ static void _php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAMETERS)
 	UErrorCode	status		= U_ZERO_ERROR;
 	intl_error_reset(NULL);
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|b",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|b",
 			&rules, &rules_len, &compiled) == FAILURE) {
 		return;
 	}

--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -569,7 +569,7 @@ static PHP_METHOD(UConverter, __construct) {
 
 	intl_error_reset(NULL);
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|s!s!", &dest, &dest_len, &src, &src_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!s!", &dest, &dest_len, &src, &src_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -1145,11 +1145,11 @@ PHP_METHOD(Phar, __construct)
 	is_data = instanceof_function(Z_OBJCE_P(zobj), phar_ce_data);
 
 	if (is_data) {
-		if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "p|ls!l", &fname, &fname_len, &flags, &alias, &alias_len, &format) == FAILURE) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "p|ls!l", &fname, &fname_len, &flags, &alias, &alias_len, &format) == FAILURE) {
 			return;
 		}
 	} else {
-		if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "p|ls!", &fname, &fname_len, &flags, &alias, &alias_len) == FAILURE) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "p|ls!", &fname, &fname_len, &flags, &alias, &alias_len) == FAILURE) {
 			return;
 		}
 	}
@@ -4479,7 +4479,7 @@ PHP_METHOD(PharFileInfo, __construct)
 	phar_archive_data *phar_data;
 	zval *zobj = ZEND_THIS, arg1;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "p", &fname, &fname_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p", &fname, &fname_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1470,7 +1470,7 @@ ZEND_METHOD(reflection_function, __construct)
 	} else {
 		ALLOCA_FLAG(use_heap)
 
-		if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &fname) == FAILURE) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &fname) == FAILURE) {
 			return;
 		}
 
@@ -2051,7 +2051,7 @@ ZEND_METHOD(reflection_generator, __construct)
 	object = ZEND_THIS;
 	intern = Z_REFLECTION_P(object);
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &generator, zend_ce_generator) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &generator, zend_ce_generator) == FAILURE) {
 		return;
 	}
 
@@ -2231,7 +2231,7 @@ ZEND_METHOD(reflection_parameter, __construct)
 	zend_class_entry *ce = NULL;
 	zend_bool is_closure = 0;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zz", &reference, &parameter) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &reference, &parameter) == FAILURE) {
 		return;
 	}
 
@@ -2907,7 +2907,7 @@ ZEND_METHOD(reflection_method, __construct)
 	zval ztmp;
 
 	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "zs", &classname, &name_str, &name_len) == FAILURE) {
-		if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s", &name_str, &name_len) == FAILURE) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name_str, &name_len) == FAILURE) {
 			return;
 		}
 
@@ -3471,7 +3471,7 @@ ZEND_METHOD(reflection_class_constant, __construct)
 	zend_class_entry *ce;
 	zend_class_constant *constant = NULL;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zS", &classname, &constname) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zS", &classname, &constname) == FAILURE) {
 		return;
 	}
 
@@ -5207,7 +5207,7 @@ ZEND_METHOD(reflection_property, __construct)
 	zend_property_info *property_info = NULL;
 	property_reference *reference;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zS", &classname, &name) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zS", &classname, &name) == FAILURE) {
 		return;
 	}
 
@@ -5649,7 +5649,7 @@ ZEND_METHOD(reflection_extension, __construct)
 	size_t name_len;
 	ALLOCA_FLAG(use_heap)
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s", &name_str, &name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name_str, &name_len) == FAILURE) {
 		return;
 	}
 
@@ -6002,7 +6002,7 @@ ZEND_METHOD(reflection_zend_extension, __construct)
 	char *name_str;
 	size_t name_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s", &name_str, &name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name_str, &name_len) == FAILURE) {
 		return;
 	}
 
@@ -6164,7 +6164,7 @@ ZEND_METHOD(reflection_reference, fromArrayElement)
 	zval *key, *item;
 	reflection_object *intern;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "hz", &ht, &key) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "hz", &ht, &key) == FAILURE) {
 		return;
 	}
 

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2277,7 +2277,7 @@ SXE_METHOD(__construct)
 	zend_long            options = 0;
 	zend_bool       is_url = 0, isprefix = 0;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|lbsb", &data, &data_len, &options, &is_url, &ns, &ns_len, &isprefix) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|lbsb", &data, &data_len, &options, &is_url, &ns, &ns_len, &isprefix) == FAILURE) {
 		return;
 	}
 

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1530,7 +1530,7 @@ PHP_METHOD(snmp, __construct)
 
 	snmp_object = Z_SNMP_P(object);
 
-	if (zend_parse_parameters_throw(argc, "lss|ll", &version, &a1, &a1_len, &a2, &a2_len, &timeout, &retries) == FAILURE) {
+	if (zend_parse_parameters(argc, "lss|ll", &version, &a1, &a1_len, &a2, &a2_len, &timeout, &retries) == FAILURE) {
 		return;
 	}
 

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -646,7 +646,7 @@ PHP_METHOD(SoapParam, __construct)
 	size_t name_length;
 	zval *this_ptr;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zs", &data, &name, &name_length) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zs", &data, &name, &name_length) == FAILURE) {
 		return;
 	}
 	if (name_length == 0) {
@@ -671,7 +671,7 @@ PHP_METHOD(SoapHeader, __construct)
 	zend_bool must_understand = 0;
 	zval *this_ptr;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss|zbz", &ns, &ns_len, &name, &name_len, &data, &must_understand, &actor) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss|zbz", &ns, &ns_len, &name, &name_len, &data, &must_understand, &actor) == FAILURE) {
 		return;
 	}
 	if (ns_len == 0) {
@@ -712,7 +712,7 @@ PHP_METHOD(SoapFault, __construct)
 	size_t fault_string_len, fault_actor_len = 0, name_len = 0, fault_code_len = 0;
 	zval *code = NULL, *details = NULL, *headerfault = NULL, *this_ptr;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zs|s!z!s!z!",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zs|s!z!s!z!",
 		&code,
 		&fault_string, &fault_string_len,
 		&fault_actor, &fault_actor_len,
@@ -815,7 +815,7 @@ PHP_METHOD(SoapVar, __construct)
 	char *stype = NULL, *ns = NULL, *name = NULL, *namens = NULL;
 	size_t stype_len = 0, ns_len = 0, name_len = 0, namens_len = 0;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z!z|ssss", &data, &type, &stype, &stype_len, &ns, &ns_len, &name, &name_len, &namens, &namens_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z!z|ssss", &data, &type, &stype, &stype_len, &ns, &ns_len, &name, &name_len, &namens, &namens_len) == FAILURE) {
 		return;
 	}
 

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -492,7 +492,7 @@ PHP_FUNCTION(sodium_memzero)
 {
 	zval      *buf_zv;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(),
+	if (zend_parse_parameters(ZEND_NUM_ARGS(),
 									"z", &buf_zv) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -518,7 +518,7 @@ PHP_FUNCTION(sodium_increment)
 	unsigned char *val;
 	size_t         val_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(),
+	if (zend_parse_parameters(ZEND_NUM_ARGS(),
 									"z", &val_zv) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -543,7 +543,7 @@ PHP_FUNCTION(sodium_add)
 	size_t         val_len;
 	size_t         addv_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(),
+	if (zend_parse_parameters(ZEND_NUM_ARGS(),
 									"zs", &val_zv, &addv, &addv_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -571,7 +571,7 @@ PHP_FUNCTION(sodium_memcmp)
 	size_t     len1;
 	size_t     len2;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&buf1, &len1,
 									&buf2, &len2) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -592,7 +592,7 @@ PHP_FUNCTION(sodium_crypto_shorthash)
 	size_t         key_len;
 	size_t         msg_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&msg, &msg_len,
 									&key, &key_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -626,7 +626,7 @@ PHP_FUNCTION(sodium_crypto_secretbox)
 	size_t         msg_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
 									&msg, &msg_len,
 									&nonce, &nonce_len,
 									&key, &key_len) == FAILURE) {
@@ -672,7 +672,7 @@ PHP_FUNCTION(sodium_crypto_secretbox_open)
 	size_t         ciphertext_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
 									&ciphertext, &ciphertext_len,
 									&nonce, &nonce_len,
 									&key, &key_len) == FAILURE) {
@@ -716,7 +716,7 @@ PHP_FUNCTION(sodium_crypto_generichash)
 	size_t         key_len = 0;
 	size_t         msg_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|sl",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|sl",
 									&msg, &msg_len,
 									&key, &key_len,
 									&hash_len) == FAILURE) {
@@ -756,7 +756,7 @@ PHP_FUNCTION(sodium_crypto_generichash_init)
 	zend_long                 hash_len = crypto_generichash_BYTES;
 	size_t                    key_len = 0;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|sl",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|sl",
 									&key, &key_len,
 									&hash_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -796,7 +796,7 @@ PHP_FUNCTION(sodium_crypto_generichash_update)
 	size_t                    msg_len;
 	size_t                    state_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zs",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zs",
 									&state_zv, &msg, &msg_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -835,7 +835,7 @@ PHP_FUNCTION(sodium_crypto_generichash_final)
 	size_t                    state_len;
 	zend_long                 hash_len = crypto_generichash_BYTES;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z|l",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|l",
 									&state_zv, &hash_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -904,7 +904,7 @@ PHP_FUNCTION(sodium_crypto_box_seed_keypair)
 	size_t         keypair_len;
 	size_t         seed_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&seed, &seed_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -939,7 +939,7 @@ PHP_FUNCTION(sodium_crypto_box_keypair_from_secretkey_and_publickey)
 	size_t       publickey_len;
 	size_t       secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&secretkey, &secretkey_len,
 									&publickey, &publickey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -973,7 +973,7 @@ PHP_FUNCTION(sodium_crypto_box_secretkey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&keypair, &keypair_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -998,7 +998,7 @@ PHP_FUNCTION(sodium_crypto_box_publickey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&keypair, &keypair_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -1024,7 +1024,7 @@ PHP_FUNCTION(sodium_crypto_box_publickey_from_secretkey)
 	unsigned char *secretkey;
 	size_t         secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&secretkey, &secretkey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -1058,7 +1058,7 @@ PHP_FUNCTION(sodium_crypto_box)
 	size_t         msg_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
 									&msg, &msg_len,
 									&nonce, &nonce_len,
 									&keypair, &keypair_len) == FAILURE) {
@@ -1108,7 +1108,7 @@ PHP_FUNCTION(sodium_crypto_box_open)
 	size_t         keypair_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
 									&ciphertext, &ciphertext_len,
 									&nonce, &nonce_len,
 									&keypair, &keypair_len) == FAILURE) {
@@ -1152,7 +1152,7 @@ PHP_FUNCTION(sodium_crypto_box_seal)
 	size_t         msg_len;
 	size_t         publickey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&msg, &msg_len,
 									&publickey, &publickey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1190,7 +1190,7 @@ PHP_FUNCTION(sodium_crypto_box_seal_open)
 	size_t         ciphertext_len;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&ciphertext, &ciphertext_len,
 									&keypair, &keypair_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1248,7 +1248,7 @@ PHP_FUNCTION(sodium_crypto_sign_seed_keypair)
 	size_t         keypair_len;
 	size_t         seed_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&seed, &seed_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -1283,7 +1283,7 @@ PHP_FUNCTION(sodium_crypto_sign_keypair_from_secretkey_and_publickey)
 	size_t       publickey_len;
 	size_t       secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&secretkey, &secretkey_len,
 									&publickey, &publickey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1317,7 +1317,7 @@ PHP_FUNCTION(sodium_crypto_sign_publickey_from_secretkey)
 	char        *secretkey;
 	size_t       secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&secretkey, &secretkey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -1347,7 +1347,7 @@ PHP_FUNCTION(sodium_crypto_sign_secretkey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&keypair, &keypair_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -1372,7 +1372,7 @@ PHP_FUNCTION(sodium_crypto_sign_publickey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&keypair, &keypair_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -1402,7 +1402,7 @@ PHP_FUNCTION(sodium_crypto_sign)
 	size_t              msg_signed_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&msg, &msg_len,
 									&secretkey, &secretkey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1448,7 +1448,7 @@ PHP_FUNCTION(sodium_crypto_sign_open)
 	size_t              msg_signed_len;
 	size_t              publickey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&msg_signed, &msg_signed_len,
 									&publickey, &publickey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1492,7 +1492,7 @@ PHP_FUNCTION(sodium_crypto_sign_detached)
 	size_t              msg_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&msg, &msg_len,
 									&secretkey, &secretkey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1533,7 +1533,7 @@ PHP_FUNCTION(sodium_crypto_sign_verify_detached)
 	size_t         publickey_len;
 	size_t         signature_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
 									&signature, &signature_len,
 									&msg, &msg_len,
 									&publickey, &publickey_len) == FAILURE) {
@@ -1569,7 +1569,7 @@ PHP_FUNCTION(sodium_crypto_stream)
 	size_t         key_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "lss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lss",
 									&ciphertext_len,
 									&nonce, &nonce_len,
 									&key, &key_len) == FAILURE) {
@@ -1611,7 +1611,7 @@ PHP_FUNCTION(sodium_crypto_stream_xor)
 	size_t         msg_len;
 	size_t         nonce_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
 									&msg, &msg_len,
 									&nonce, &nonce_len,
 									&key, &key_len) == FAILURE) {
@@ -1654,7 +1654,7 @@ PHP_FUNCTION(sodium_crypto_pwhash)
 	int            ret;
 
 	alg = (zend_long) crypto_pwhash_ALG_DEFAULT;
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "lssll|l",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lssll|l",
 									&hash_len,
 									&passwd, &passwd_len,
 									&salt, &salt_len,
@@ -1737,7 +1737,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str)
 	size_t       passwd_len;
 	size_t       len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sll",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sll",
 									&passwd, &passwd_len,
 									&opslimit, &memlimit) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1790,7 +1790,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str_needs_rehash)
 	zend_long  opslimit;
 	size_t     hash_str_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sll",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sll",
 									&hash_str, &hash_str_len, &opslimit, &memlimit) == FAILURE) {
 		zend_throw_exception(sodium_exception_ce, "a PHP string is required", 0);
 		return;
@@ -1809,7 +1809,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_str_verify)
 	size_t     hash_str_len;
 	size_t     passwd_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&hash_str, &hash_str_len,
 									&passwd, &passwd_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1843,7 +1843,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256)
 	size_t         passwd_len;
 	size_t         salt_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "lssll",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lssll",
 									&hash_len,
 									&passwd, &passwd_len,
 									&salt, &salt_len,
@@ -1902,7 +1902,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str)
 	zend_long    opslimit;
 	size_t       passwd_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sll",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sll",
 									&passwd, &passwd_len,
 									&opslimit, &memlimit) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1948,7 +1948,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str_verify)
 	size_t     hash_str_len;
 	size_t     passwd_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&hash_str, &hash_str_len,
 									&passwd, &passwd_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -1996,7 +1996,7 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_encrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
 									&msg, &msg_len,
 									&ad, &ad_len,
 									&npub, &npub_len,
@@ -2062,7 +2062,7 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_decrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
 									&ciphertext, &ciphertext_len,
 									&ad, &ad_len,
 									&npub, &npub_len,
@@ -2130,7 +2130,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_encrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
 									&msg, &msg_len,
 									&ad, &ad_len,
 									&npub, &npub_len,
@@ -2192,7 +2192,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_decrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
 									&ciphertext, &ciphertext_len,
 									&ad, &ad_len,
 									&npub, &npub_len,
@@ -2255,7 +2255,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_encrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
 									&msg, &msg_len,
 									&ad, &ad_len,
 									&npub, &npub_len,
@@ -2321,7 +2321,7 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_decrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
 									&ciphertext, &ciphertext_len,
 									&ad, &ad_len,
 									&npub, &npub_len,
@@ -2390,7 +2390,7 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_encrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
 									&msg, &msg_len,
 									&ad, &ad_len,
 									&npub, &npub_len,
@@ -2452,7 +2452,7 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_decrypt)
 	size_t              npub_len;
 	size_t              secretkey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ssss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssss",
 									&ciphertext, &ciphertext_len,
 									&ad, &ad_len,
 									&npub, &npub_len,
@@ -2514,7 +2514,7 @@ PHP_FUNCTION(sodium_bin2hex)
 	size_t         bin_len;
 	size_t         hex_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&bin, &bin_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -2542,7 +2542,7 @@ PHP_FUNCTION(sodium_hex2bin)
 	size_t         hex_len;
 	size_t         ignore_len = 0;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s|s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s",
 									&hex, &hex_len,
 									&ignore, &ignore_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -2577,7 +2577,7 @@ PHP_FUNCTION(sodium_bin2base64)
 	size_t         bin_len;
 	size_t         b64_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sl",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl",
 									&bin, &bin_len, &variant) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -2610,7 +2610,7 @@ PHP_FUNCTION(sodium_base642bin)
 	size_t         b64_len;
 	size_t         ignore_len = 0;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sl|s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl|s",
 									&b64, &b64_len, &variant,
 									&ignore, &ignore_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -2651,7 +2651,7 @@ PHP_FUNCTION(sodium_crypto_scalarmult)
 	size_t         n_len;
 	size_t         p_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&n, &n_len, &p, &p_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -2682,7 +2682,7 @@ PHP_FUNCTION(sodium_crypto_kx_seed_keypair)
 	size_t         seed_len;
 	zend_string   *keypair;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&seed, &seed_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -2732,7 +2732,7 @@ PHP_FUNCTION(sodium_crypto_kx_secretkey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&keypair, &keypair_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -2757,7 +2757,7 @@ PHP_FUNCTION(sodium_crypto_kx_publickey)
 	unsigned char *keypair;
 	size_t         keypair_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&keypair, &keypair_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -2789,7 +2789,7 @@ PHP_FUNCTION(sodium_crypto_kx_client_session_keys)
 	size_t         keypair_len;
 	size_t         server_pk_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&keypair, &keypair_len,
 									&server_pk, &server_pk_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -2839,7 +2839,7 @@ PHP_FUNCTION(sodium_crypto_kx_server_session_keys)
 	size_t         keypair_len;
 	size_t         client_pk_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&keypair, &keypair_len,
 									&client_pk, &client_pk_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -2885,7 +2885,7 @@ PHP_FUNCTION(sodium_crypto_auth)
 	size_t       msg_len;
 	size_t       key_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&msg, &msg_len,
 									&key, &key_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -2916,7 +2916,7 @@ PHP_FUNCTION(sodium_crypto_auth_verify)
 	size_t     msg_len;
 	size_t     key_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss",
 									&mac, &mac_len,
 									&msg, &msg_len,
 									&key, &key_len) == FAILURE) {
@@ -2945,7 +2945,7 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_sk_to_curve25519)
 	char        *eddsakey;
 	size_t       eddsakey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&eddsakey, &eddsakey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -2974,7 +2974,7 @@ PHP_FUNCTION(sodium_crypto_sign_ed25519_pk_to_curve25519)
 	char        *eddsakey;
 	size_t       eddsakey_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&eddsakey, &eddsakey_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -3004,7 +3004,7 @@ PHP_FUNCTION(sodium_compare)
 	size_t     len1;
 	size_t     len2;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&buf1, &len1,
 									&buf2, &len2) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -3147,7 +3147,7 @@ PHP_FUNCTION(sodium_crypto_kdf_derive_from_key)
 	size_t         ctx_len;
 	size_t         key_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "llss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llss",
 									&subkey_len,
 									&subkey_id,
 									&ctx, &ctx_len,
@@ -3215,7 +3215,7 @@ PHP_FUNCTION(sodium_pad)
 	size_t          xpadlen;
 	size_t          xpadded_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sl",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl",
 									&unpadded, &unpadded_len, &blocksize) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -3288,7 +3288,7 @@ PHP_FUNCTION(sodium_unpad)
 	zend_long    blocksize;
 	int          ret;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "sl",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl",
 									&padded, &padded_len, &blocksize) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -3362,7 +3362,7 @@ PHP_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_init_push)
 	unsigned char                               *key;
 	size_t                                       key_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
 									&key, &key_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
@@ -3397,7 +3397,7 @@ PHP_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_push)
 	size_t              msg_len;
 	size_t              state_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zs|sl",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zs|sl",
 									&state_zv,
 									&msg, &msg_len, &ad, &ad_len, &tag) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -3453,7 +3453,7 @@ PHP_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_init_pull)
 	size_t                                       header_len;
 	size_t                                       key_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "ss",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss",
 									&header, &header_len,
 									&key, &key_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -3493,7 +3493,7 @@ PHP_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_pull)
 	size_t              state_len;
 	unsigned char       tag;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "zs|s",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zs|s",
 									&state_zv,
 									&c, &c_len, &ad, &ad_len) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
@@ -3540,7 +3540,7 @@ PHP_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_rekey)
 	unsigned char *state;
 	size_t         state_len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z", &state_zv) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &state_zv) == FAILURE) {
 		sodium_remove_param_values_from_backtrace(EG(exception));
 		return;
 	}

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1197,7 +1197,7 @@ SPL_METHOD(Array, __construct)
 		return; /* nothing to do */
 	}
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z|lC", &array, &ar_flags, &ce_get_iterator) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|lC", &array, &ar_flags, &ce_get_iterator) == FAILURE) {
 		return;
 	}
 
@@ -1226,7 +1226,7 @@ SPL_METHOD(ArrayIterator, __construct)
 		return; /* nothing to do */
 	}
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z|l", &array, &ar_flags) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|l", &array, &ar_flags) == FAILURE) {
 		return;
 	}
 
@@ -1864,7 +1864,7 @@ SPL_METHOD(Array, __unserialize)
 	zval *flags_zv, *storage_zv, *members_zv;
 	zend_long flags;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "h", &data) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &data) == FAILURE) {
 		return;
 	}
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1131,7 +1131,7 @@ SPL_METHOD(SplFileInfo, __construct)
 	char *path;
 	size_t len;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "p", &path, &len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p", &path, &len) == FAILURE) {
 		return;
 	}
 
@@ -2252,7 +2252,7 @@ SPL_METHOD(SplFileObject, __construct)
 	intern->u.file.open_mode = NULL;
 	intern->u.file.open_mode_len = 0;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "p|sbr!",
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p|sbr!",
 			&intern->file_name, &intern->file_name_len,
 			&intern->u.file.open_mode, &intern->u.file.open_mode_len,
 			&use_include_path, &intern->u.file.zcontext) == FAILURE) {
@@ -2307,7 +2307,7 @@ SPL_METHOD(SplTempFileObject, __construct)
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 	zend_error_handling error_handling;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|l", &max_memory) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &max_memory) == FAILURE) {
 		return;
 	}
 

--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -1252,7 +1252,7 @@ SPL_METHOD(SplDoublyLinkedList, __unserialize) {
 	HashTable *data;
 	zval *flags_zv, *storage_zv, *members_zv, *elem;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "h", &data) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &data) == FAILURE) {
 		return;
 	}
 

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -545,7 +545,7 @@ SPL_METHOD(SplFixedArray, __construct)
 	spl_fixedarray_object *intern;
 	zend_long size = 0;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|l", &size) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &size) == FAILURE) {
 		return;
 	}
 

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -1404,7 +1404,7 @@ static spl_dual_it_object* spl_dual_it_construct(INTERNAL_FUNCTION_PARAMETERS, z
 		case DIT_LimitIterator: {
 			intern->u.limit.offset = 0; /* start at beginning */
 			intern->u.limit.count = -1; /* get all */
-			if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O|ll", &zobject, ce_inner, &intern->u.limit.offset, &intern->u.limit.count) == FAILURE) {
+			if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|ll", &zobject, ce_inner, &intern->u.limit.offset, &intern->u.limit.count) == FAILURE) {
 				return NULL;
 			}
 			if (intern->u.limit.offset < 0) {
@@ -1420,7 +1420,7 @@ static spl_dual_it_object* spl_dual_it_construct(INTERNAL_FUNCTION_PARAMETERS, z
 		case DIT_CachingIterator:
 		case DIT_RecursiveCachingIterator: {
 			zend_long flags = CIT_CALL_TOSTRING;
-			if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O|l", &zobject, ce_inner, &flags) == FAILURE) {
+			if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|l", &zobject, ce_inner, &flags) == FAILURE) {
 				return NULL;
 			}
 			if (spl_cit_check_flags(flags) != SUCCESS) {
@@ -1435,7 +1435,7 @@ static spl_dual_it_object* spl_dual_it_construct(INTERNAL_FUNCTION_PARAMETERS, z
 			zend_class_entry *ce_cast;
 			zend_string *class_name;
 
-			if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O|S", &zobject, ce_inner, &class_name) == FAILURE) {
+			if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|S", &zobject, ce_inner, &class_name) == FAILURE) {
 				return NULL;
 			}
 			ce = Z_OBJCE_P(zobject);
@@ -1482,7 +1482,7 @@ static spl_dual_it_object* spl_dual_it_construct(INTERNAL_FUNCTION_PARAMETERS, z
 			intern->u.regex.use_flags = ZEND_NUM_ARGS() >= 5;
 			intern->u.regex.flags = 0;
 			intern->u.regex.preg_flags = 0;
-			if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "OS|lll", &zobject, ce_inner, &regex, &mode, &intern->u.regex.flags, &intern->u.regex.preg_flags) == FAILURE) {
+			if (zend_parse_parameters(ZEND_NUM_ARGS(), "OS|lll", &zobject, ce_inner, &regex, &mode, &intern->u.regex.flags, &intern->u.regex.preg_flags) == FAILURE) {
 				return NULL;
 			}
 			if (mode < 0 || mode >= REGIT_MODE_MAX) {
@@ -1507,7 +1507,7 @@ static spl_dual_it_object* spl_dual_it_construct(INTERNAL_FUNCTION_PARAMETERS, z
 		case DIT_RecursiveCallbackFilterIterator: {
 			_spl_cbfilter_it_intern *cfi = emalloc(sizeof(*cfi));
 			cfi->fci.object = NULL;
-			if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Of", &zobject, ce_inner, &cfi->fci, &cfi->fcc) == FAILURE) {
+			if (zend_parse_parameters(ZEND_NUM_ARGS(), "Of", &zobject, ce_inner, &cfi->fci, &cfi->fcc) == FAILURE) {
 				efree(cfi);
 				return NULL;
 			}
@@ -1518,7 +1518,7 @@ static spl_dual_it_object* spl_dual_it_construct(INTERNAL_FUNCTION_PARAMETERS, z
 			break;
 		}
 		default:
-			if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &zobject, ce_inner) == FAILURE) {
+			if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &zobject, ce_inner) == FAILURE) {
 				return NULL;
 			}
 			break;

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -906,7 +906,7 @@ SPL_METHOD(SplObjectStorage, __unserialize)
 	HashTable *data;
 	zval *storage_zv, *members_zv, *key, *val;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "h", &data) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &data) == FAILURE) {
 		return;
 	}
 
@@ -1018,7 +1018,7 @@ SPL_METHOD(MultipleIterator, __construct)
 	spl_SplObjectStorage   *intern;
 	zend_long               flags = MIT_NEED_ALL|MIT_KEYS_NUMERIC;
 
-	if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|l", &flags) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &flags) == FAILURE) {
 		return;
 	}
 


### PR DESCRIPTION
Since `zend_parse_parameters()` throws now, there is no reason to
explicitly call `zend_parse_parameters_throw()` anymore, and since both
have actually the same implementation, we redefine the latter as macro.