### PR TITLE
Fix bug #78770: Incorrect callability check inside internal methods

### DIFF
--- a/Zend/tests/bug78770.phpt
+++ b/Zend/tests/bug78770.phpt
@@ -10,6 +10,7 @@ if (!extension_loaded("intl") die("skip requires intl");
 class Test {
     public function method() {
         IntlChar::enumCharTypes([$this, 'privateMethod']);
+        IntlChar::enumCharTypes('self::privateMethod');
     }
 
     private function privateMethod($start, $end, $name) {

--- a/Zend/tests/bug78770.phpt
+++ b/Zend/tests/bug78770.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #78770: Incorrect callability check inside internal methods
+--SKIPIF--
+<?php
+if (!extension_loaded("intl") die("skip requires intl");
+?>
+--FILE--
+<?php
+
+class Test {
+    public function method() {
+        IntlChar::enumCharTypes([$this, 'privateMethod']);
+    }
+
+    private function privateMethod($start, $end, $name) {
+    }
+}
+
+(new Test)->method();
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2906,10 +2906,10 @@ static int zend_is_callable_check_class(zend_string *name, zend_class_entry *sco
 		if (!scope) {
 			if (error) *error = estrdup("cannot access self:: when no class scope is active");
 		} else {
-			fcc->called_scope = zend_get_called_scope(EG(current_execute_data));
+			fcc->called_scope = zend_get_called_user_scope(EG(current_execute_data));
 			fcc->calling_scope = scope;
 			if (!fcc->object) {
-				fcc->object = zend_get_this_object(EG(current_execute_data));
+				fcc->object = zend_get_user_this_object(EG(current_execute_data));
 			}
 			ret = 1;
 		}
@@ -2919,16 +2919,16 @@ static int zend_is_callable_check_class(zend_string *name, zend_class_entry *sco
 		} else if (!scope->parent) {
 			if (error) *error = estrdup("cannot access parent:: when current class scope has no parent");
 		} else {
-			fcc->called_scope = zend_get_called_scope(EG(current_execute_data));
+			fcc->called_scope = zend_get_called_user_scope(EG(current_execute_data));
 			fcc->calling_scope = scope->parent;
 			if (!fcc->object) {
-				fcc->object = zend_get_this_object(EG(current_execute_data));
+				fcc->object = zend_get_user_this_object(EG(current_execute_data));
 			}
 			*strict_class = 1;
 			ret = 1;
 		}
 	} else if (zend_string_equals_literal(lcname, "static")) {
-		zend_class_entry *called_scope = zend_get_called_scope(EG(current_execute_data));
+		zend_class_entry *called_scope = zend_get_called_user_scope(EG(current_execute_data));
 
 		if (!called_scope) {
 			if (error) *error = estrdup("cannot access static:: when no class scope is active");
@@ -2936,7 +2936,7 @@ static int zend_is_callable_check_class(zend_string *name, zend_class_entry *sco
 			fcc->called_scope = called_scope;
 			fcc->calling_scope = called_scope;
 			if (!fcc->object) {
-				fcc->object = zend_get_this_object(EG(current_execute_data));
+				fcc->object = zend_get_user_this_object(EG(current_execute_data));
 			}
 			*strict_class = 1;
 			ret = 1;
@@ -2951,7 +2951,7 @@ static int zend_is_callable_check_class(zend_string *name, zend_class_entry *sco
 		scope = ex ? ex->func->common.scope : NULL;
 		fcc->calling_scope = ce;
 		if (scope && !fcc->object) {
-			zend_object *object = zend_get_this_object(EG(current_execute_data));
+			zend_object *object = zend_get_user_this_object(EG(current_execute_data));
 
 			if (object &&
 			    instanceof_function(object->ce, scope) &&
@@ -3160,7 +3160,7 @@ get_function_via_handler:
 				retval = 1;
 				call_via_handler = (fcc->function_handler->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
 				if (call_via_handler && !fcc->object) {
-					zend_object *object = zend_get_this_object(EG(current_execute_data));
+					zend_object *object = zend_get_user_this_object(EG(current_execute_data));
 					if (object &&
 					    instanceof_function(object->ce, fcc->calling_scope)) {
 						fcc->object = object;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3053,7 +3053,7 @@ static zend_always_inline int zend_is_callable_check_func(int check_flags, zval 
 		if (ce_org) {
 			scope = ce_org;
 		} else {
-			scope = zend_get_executed_scope();
+			scope = zend_get_executed_user_scope();
 		}
 
 		cname = zend_string_init(Z_STRVAL_P(callable), clen, 0);
@@ -3096,7 +3096,7 @@ static zend_always_inline int zend_is_callable_check_func(int check_flags, zval 
 		retval = 1;
 		if ((fcc->function_handler->op_array.fn_flags & ZEND_ACC_CHANGED) &&
 		    !strict_class) {
-			scope = zend_get_executed_scope();
+			scope = zend_get_executed_user_scope();
 			if (scope &&
 			    instanceof_function(fcc->function_handler->common.scope, scope)) {
 
@@ -3116,7 +3116,7 @@ static zend_always_inline int zend_is_callable_check_func(int check_flags, zval 
 		    (fcc->calling_scope &&
 		     ((fcc->object && fcc->calling_scope->__call) ||
 		      (!fcc->object && fcc->calling_scope->__callstatic)))) {
-			scope = zend_get_executed_scope();
+			scope = zend_get_executed_user_scope();
 			if (fcc->function_handler->common.scope != scope
 			 || !zend_check_protected(zend_get_function_root_class(fcc->function_handler), scope)) {
 				retval = 0;
@@ -3207,7 +3207,7 @@ get_function_via_handler:
 			if (retval
 			 && !(fcc->function_handler->common.fn_flags & ZEND_ACC_PUBLIC)
 			 && !(check_flags & IS_CALLABLE_CHECK_NO_ACCESS)) {
-				scope = zend_get_executed_scope();
+				scope = zend_get_executed_user_scope();
 				if (fcc->function_handler->common.scope != scope) {
 					if ((fcc->function_handler->common.fn_flags & ZEND_ACC_PRIVATE)
 					 || (!zend_check_protected(zend_get_function_root_class(fcc->function_handler), scope))) {
@@ -3382,7 +3382,7 @@ check_func:
 							return 1;
 						}
 
-						if (!zend_is_callable_check_class(Z_STR_P(obj), zend_get_executed_scope(), fcc, &strict_class, error)) {
+						if (!zend_is_callable_check_class(Z_STR_P(obj), zend_get_executed_user_scope(), fcc, &strict_class, error)) {
 							return 0;
 						}
 

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -344,11 +344,7 @@ ZEND_METHOD(Closure, fromCallable)
 		RETURN_ZVAL(callable, 1, 0);
 	}
 
-	/* create closure as if it were called from parent scope */
-	EG(current_execute_data) = EX(prev_execute_data);
 	success = zend_create_closure_from_callable(return_value, callable, &error);
-	EG(current_execute_data) = execute_data;
-
 	if (success == FAILURE || error) {
 		if (error) {
 			zend_type_error("Failed to create closure from callable: %s", error);

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -43,7 +43,9 @@ ZEND_API void execute_internal(zend_execute_data *execute_data, zval *return_val
 ZEND_API zend_class_entry *zend_lookup_class(zend_string *name);
 ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *lcname, uint32_t flags);
 ZEND_API zend_class_entry *zend_get_called_scope(zend_execute_data *ex);
+ZEND_API zend_class_entry *zend_get_called_user_scope(zend_execute_data *ex);
 ZEND_API zend_object *zend_get_this_object(zend_execute_data *ex);
+ZEND_API zend_object *zend_get_user_this_object(zend_execute_data *ex);
 ZEND_API int zend_eval_string(char *str, zval *retval_ptr, char *string_name);
 ZEND_API int zend_eval_stringl(char *str, size_t str_len, zval *retval_ptr, char *string_name);
 ZEND_API int zend_eval_string_ex(char *str, zval *retval_ptr, char *string_name, int handle_exceptions);

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -301,6 +301,7 @@ ZEND_API const char *zend_get_executed_filename(void);
 ZEND_API zend_string *zend_get_executed_filename_ex(void);
 ZEND_API uint32_t zend_get_executed_lineno(void);
 ZEND_API zend_class_entry *zend_get_executed_scope(void);
+ZEND_API zend_class_entry *zend_get_executed_user_scope(void);
 ZEND_API zend_bool zend_is_executing(void);
 
 ZEND_API void zend_set_timeout(zend_long seconds, int reset_signals);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1045,6 +1045,25 @@ ZEND_API zend_class_entry *zend_get_called_scope(zend_execute_data *ex) /* {{{ *
 }
 /* }}} */
 
+ZEND_API zend_class_entry *zend_get_called_user_scope(zend_execute_data *ex) /* {{{ */
+{
+	while (ex) {
+		if (ex->func) {
+			if (ex->func->type != ZEND_INTERNAL_FUNCTION) {
+				if (Z_TYPE(ex->This) == IS_OBJECT) {
+					return Z_OBJCE(ex->This);
+				} else if (Z_CE(ex->This)) {
+					return Z_CE(ex->This);
+				}
+				return NULL;
+			}
+		}
+		ex = ex->prev_execute_data;
+	}
+	return NULL;
+}
+/* }}} */
+
 ZEND_API zend_object *zend_get_this_object(zend_execute_data *ex) /* {{{ */
 {
 	while (ex) {
@@ -1052,6 +1071,23 @@ ZEND_API zend_object *zend_get_this_object(zend_execute_data *ex) /* {{{ */
 			return Z_OBJ(ex->This);
 		} else if (ex->func) {
 			if (ex->func->type != ZEND_INTERNAL_FUNCTION || ex->func->common.scope) {
+				return NULL;
+			}
+		}
+		ex = ex->prev_execute_data;
+	}
+	return NULL;
+}
+/* }}} */
+
+ZEND_API zend_object *zend_get_user_this_object(zend_execute_data *ex) /* {{{ */
+{
+	while (ex) {
+		if (ex->func) {
+			if (ex->func->type != ZEND_INTERNAL_FUNCTION) {
+				if (Z_TYPE(ex->This) == IS_OBJECT) {
+					return Z_OBJ(ex->This);
+				}
 				return NULL;
 			}
 		}

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -553,6 +553,21 @@ ZEND_API zend_class_entry *zend_get_executed_scope(void) /* {{{ */
 }
 /* }}} */
 
+ZEND_API zend_class_entry *zend_get_executed_user_scope(void) /* {{{ */
+{
+	zend_execute_data *ex = EG(current_execute_data);
+
+	while (1) {
+		if (!ex) {
+			return NULL;
+		} else if (ex->func && ZEND_USER_CODE(ex->func->type)) {
+			return ex->func->common.scope;
+		}
+		ex = ex->prev_execute_data;
+	}
+}
+/* }}} */
+
 ZEND_API zend_bool zend_is_executing(void) /* {{{ */
 {
 	return EG(current_execute_data) != 0;

--- a/ext/pdo_sqlite/tests/pdo_fetch_func_001.phpt
+++ b/ext/pdo_sqlite/tests/pdo_fetch_func_001.phpt
@@ -102,7 +102,7 @@ bool(false)
 Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error: no array or string given in %s on line %d
 bool(false)
 
-Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error: class 'PDOStatement' does not have a method 'foo' in %s on line %d
+Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error: cannot access self:: when no class scope is active in %s on line %d
 bool(false)
 array(2) {
   [0]=>


### PR DESCRIPTION
Fixes [bug #78770](https://bugs.php.net/bug.php?id=78770).

Inside the is_callable() implementation, always use the next user scope, even if there is an internal scope.