### PR TITLE
Wrap hrtime in C++ portability macros

### DIFF
--- a/ext/standard/hrtime.h
+++ b/ext/standard/hrtime.h
@@ -20,6 +20,8 @@
 #ifndef HRTIME_H
 #define HRTIME_H
 
+#include <Zend/zend_portability.h>
+
 #define PHP_HRTIME_PLATFORM_POSIX   0
 #define PHP_HRTIME_PLATFORM_WINDOWS 0
 #define PHP_HRTIME_PLATFORM_APPLE   0
@@ -45,6 +47,8 @@
 
 #define HRTIME_AVAILABLE (PHP_HRTIME_PLATFORM_POSIX || PHP_HRTIME_PLATFORM_WINDOWS || PHP_HRTIME_PLATFORM_APPLE || PHP_HRTIME_PLATFORM_HPUX || PHP_HRTIME_PLATFORM_AIX)
 
+BEGIN_EXTERN_C()
+	
 typedef uint64_t php_hrtime_t;
 
 PHPAPI php_hrtime_t php_hrtime_current(void);
@@ -52,5 +56,7 @@ PHPAPI php_hrtime_t php_hrtime_current(void);
 PHP_MINIT_FUNCTION(hrtime);
 
 PHP_FUNCTION(hrtime);
+
+END_EXTERN_C()
 
 #endif /* HRTIME_H */


### PR DESCRIPTION
This allows hrtime to be used by C++ extensions without them having to do their own forward declares.