### PR TITLE
Wrap php_random.h in C++ portability macros

### DIFF
--- a/ext/standard/hrtime.h
+++ b/ext/standard/hrtime.h
@@ -20,8 +20,6 @@
 #ifndef HRTIME_H
 #define HRTIME_H
 
-#include <Zend/zend_portability.h>
-
 #define PHP_HRTIME_PLATFORM_POSIX   0
 #define PHP_HRTIME_PLATFORM_WINDOWS 0
 #define PHP_HRTIME_PLATFORM_APPLE   0

--- a/ext/standard/php_random.h
+++ b/ext/standard/php_random.h
@@ -19,6 +19,10 @@
 #ifndef PHP_RANDOM_H
 #define PHP_RANDOM_H
 
+#include <Zend/zend_portability.h>
+
+BEGIN_EXTERN_C()
+
 PHP_FUNCTION(random_bytes);
 PHP_FUNCTION(random_int);
 
@@ -47,6 +51,8 @@ extern PHPAPI int random_globals_id;
 # define RANDOM_G(v) random_globals.v
 extern PHPAPI php_random_globals random_globals;
 #endif
+
+END_EXTERN_C()
 
 #endif
 

--- a/ext/standard/php_random.h
+++ b/ext/standard/php_random.h
@@ -19,8 +19,6 @@
 #ifndef PHP_RANDOM_H
 #define PHP_RANDOM_H
 
-#include <Zend/zend_portability.h>
-
 BEGIN_EXTERN_C()
 
 PHP_FUNCTION(random_bytes);


### PR DESCRIPTION
Notably, C++ extensions may be interested in the `php_random_bytes` and `php_random_int` functions.