### PR TITLE
Make test runner runnable without arguments

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -318,219 +318,217 @@ NO_PROC_OPEN_ERROR;
 		}
 	}
 
+	if (!isset($argc, $argv) || !$argc) {
+		$argv = array(__FILE__);
+		$argc = 1;
+	}
+
 	if (getenv('TEST_PHP_ARGS')) {
-
-		if (!isset($argc, $argv) || !$argc) {
-			$argv = array(__FILE__);
-		}
-
 		$argv = array_merge($argv, explode(' ', getenv('TEST_PHP_ARGS')));
 		$argc = count($argv);
 	}
 
-	if (isset($argc) && $argc > 1) {
+	for ($i = 1; $i < $argc; $i++) {
+		$is_switch = false;
+		$switch = substr($argv[$i], 1, 1);
+		$repeat = substr($argv[$i], 0, 1) == '-';
 
-		for ($i = 1; $i < $argc; $i++) {
-			$is_switch = false;
-			$switch = substr($argv[$i], 1, 1);
-			$repeat = substr($argv[$i], 0, 1) == '-';
+		while ($repeat) {
 
-			while ($repeat) {
+			if (!$is_switch) {
+				$switch = substr($argv[$i], 1, 1);
+			}
 
-				if (!$is_switch) {
-					$switch = substr($argv[$i], 1, 1);
-				}
+			$is_switch = true;
 
-				$is_switch = true;
-
-				if ($repeat) {
-					foreach ($cfgtypes as $type) {
-						if (strpos($switch, '--' . $type) === 0) {
-							foreach ($cfgfiles as $file) {
-								if ($switch == '--' . $type . '-' . $file) {
-									$cfg[$type][$file] = true;
-									$is_switch = false;
-									break;
-								}
+			if ($repeat) {
+				foreach ($cfgtypes as $type) {
+					if (strpos($switch, '--' . $type) === 0) {
+						foreach ($cfgfiles as $file) {
+							if ($switch == '--' . $type . '-' . $file) {
+								$cfg[$type][$file] = true;
+								$is_switch = false;
+								break;
 							}
 						}
 					}
 				}
+			}
 
-				if (!$is_switch) {
-					$is_switch = true;
+			if (!$is_switch) {
+				$is_switch = true;
+				break;
+			}
+
+			$repeat = false;
+
+			switch ($switch) {
+				case 'j':
+					$workers = substr($argv[$i], 2);
+					if (!preg_match('/^\d+$/', $workers) || $workers == 0) {
+						error("'$workers' is not a valid number of workers, try e.g. -j16 for 16 workers");
+					}
+					$workers = intval($workers, 10);
+					// Don't use parallel testing infrastructure if there is only one worker.
+					if ($workers === 1) {
+						$workers = null;
+					}
 					break;
-				}
-
-				$repeat = false;
-
-				switch ($switch) {
-					case 'j':
-						$workers = substr($argv[$i], 2);
-						if (!preg_match('/^\d+$/', $workers) || $workers == 0) {
-							error("'$workers' is not a valid number of workers, try e.g. -j16 for 16 workers");
-						}
-						$workers = intval($workers, 10);
-						// Don't use parallel testing infrastructure if there is only one worker.
-						if ($workers === 1) {
-							$workers = null;
-						}
-						break;
-					case 'r':
-					case 'l':
-						$test_list = file($argv[++$i]);
-						if ($test_list) {
-							foreach ($test_list as $test) {
-								$matches = array();
-								if (preg_match('/^#.*\[(.*)\]\:\s+(.*)$/', $test, $matches)) {
-									$redir_tests[] = array($matches[1], $matches[2]);
-								} else {
-									if (strlen($test)) {
-										$test_files[] = trim($test);
-									}
+				case 'r':
+				case 'l':
+					$test_list = file($argv[++$i]);
+					if ($test_list) {
+						foreach ($test_list as $test) {
+							$matches = array();
+							if (preg_match('/^#.*\[(.*)\]\:\s+(.*)$/', $test, $matches)) {
+								$redir_tests[] = array($matches[1], $matches[2]);
+							} else {
+								if (strlen($test)) {
+									$test_files[] = trim($test);
 								}
 							}
 						}
-						if ($switch != 'l') {
-							break;
-						}
-						$i--;
-					// break left intentionally
-					case 'w':
-						$failed_tests_file = fopen($argv[++$i], 'w+t');
+					}
+					if ($switch != 'l') {
 						break;
-					case 'a':
-						$failed_tests_file = fopen($argv[++$i], 'a+t');
-						break;
-					case 'W':
-						$result_tests_file = fopen($argv[++$i], 'w+t');
-						break;
-					case 'c':
-						$conf_passed = $argv[++$i];
-						break;
-					case 'd':
-						$ini_overwrites[] = $argv[++$i];
-						break;
-					case 'g':
-						$SHOW_ONLY_GROUPS = explode(",", $argv[++$i]);
-						break;
-					//case 'h'
-					case '--keep-all':
-						foreach ($cfgfiles as $file) {
-							$cfg['keep'][$file] = true;
-						}
-						break;
-					//case 'l'
-					case 'm':
-					$valgrind = new RuntestsValgrind($environment);
-						break;
-					case 'M':
-					$valgrind = new RuntestsValgrind($environment, $argv[++$i]);
-						break;
-					case 'n':
-						if (!$pass_option_n) {
-							$pass_options .= ' -n';
-						}
-						$pass_option_n = true;
-						break;
-					case 'e':
-						$pass_options .= ' -e';
-						break;
-					case '--preload':
-						$preload = true;
-						break;
-					case '--no-clean':
-						$no_clean = true;
-						break;
-					case 'p':
-						$php = $argv[++$i];
-						putenv("TEST_PHP_EXECUTABLE=$php");
-						$environment['TEST_PHP_EXECUTABLE'] = $php;
-						break;
-					case 'P':
-						$php = PHP_BINARY;
-						putenv("TEST_PHP_EXECUTABLE=$php");
-						$environment['TEST_PHP_EXECUTABLE'] = $php;
-						break;
-					case 'q':
-						putenv('NO_INTERACTION=1');
-						$environment['NO_INTERACTION'] = 1;
-						break;
-					//case 'r'
-					case 's':
-						$output_file = $argv[++$i];
-						$just_save_results = true;
-						break;
-					case '--set-timeout':
-						$environment['TEST_TIMEOUT'] = $argv[++$i];
-						break;
-					case '--show-all':
-						foreach ($cfgfiles as $file) {
-							$cfg['show'][$file] = true;
-						}
-						break;
-					case '--show-slow':
-						$slow_min_ms = $argv[++$i];
-						break;
-					case '--temp-source':
-						$temp_source = $argv[++$i];
-						break;
-					case '--temp-target':
-						$temp_target = $argv[++$i];
-						if ($temp_urlbase) {
-							$temp_urlbase = $temp_target;
-						}
-						break;
-					case '--temp-urlbase':
-						$temp_urlbase = $argv[++$i];
-						break;
-					case 'v':
-					case '--verbose':
-						$DETAILED = true;
-						break;
-					case 'x':
-						$environment['SKIP_SLOW_TESTS'] = 1;
-						break;
-					case '--offline':
-						$environment['SKIP_ONLINE_TESTS'] = 1;
-						break;
-					case '--shuffle':
-						$shuffle = true;
-						break;
-					case '--asan':
-						$environment['USE_ZEND_ALLOC'] = 0;
-						$environment['USE_TRACKED_ALLOC'] = 1;
-						$environment['SKIP_ASAN'] = 1;
-						$environment['SKIP_PERF_SENSITIVE'] = 1;
+					}
+					$i--;
+				// break left intentionally
+				case 'w':
+					$failed_tests_file = fopen($argv[++$i], 'w+t');
+					break;
+				case 'a':
+					$failed_tests_file = fopen($argv[++$i], 'a+t');
+					break;
+				case 'W':
+					$result_tests_file = fopen($argv[++$i], 'w+t');
+					break;
+				case 'c':
+					$conf_passed = $argv[++$i];
+					break;
+				case 'd':
+					$ini_overwrites[] = $argv[++$i];
+					break;
+				case 'g':
+					$SHOW_ONLY_GROUPS = explode(",", $argv[++$i]);
+					break;
+				//case 'h'
+				case '--keep-all':
+					foreach ($cfgfiles as $file) {
+						$cfg['keep'][$file] = true;
+					}
+					break;
+				//case 'l'
+				case 'm':
+				$valgrind = new RuntestsValgrind($environment);
+					break;
+				case 'M':
+				$valgrind = new RuntestsValgrind($environment, $argv[++$i]);
+					break;
+				case 'n':
+					if (!$pass_option_n) {
+						$pass_options .= ' -n';
+					}
+					$pass_option_n = true;
+					break;
+				case 'e':
+					$pass_options .= ' -e';
+					break;
+				case '--preload':
+					$preload = true;
+					break;
+				case '--no-clean':
+					$no_clean = true;
+					break;
+				case 'p':
+					$php = $argv[++$i];
+					putenv("TEST_PHP_EXECUTABLE=$php");
+					$environment['TEST_PHP_EXECUTABLE'] = $php;
+					break;
+				case 'P':
+					$php = PHP_BINARY;
+					putenv("TEST_PHP_EXECUTABLE=$php");
+					$environment['TEST_PHP_EXECUTABLE'] = $php;
+					break;
+				case 'q':
+					putenv('NO_INTERACTION=1');
+					$environment['NO_INTERACTION'] = 1;
+					break;
+				//case 'r'
+				case 's':
+					$output_file = $argv[++$i];
+					$just_save_results = true;
+					break;
+				case '--set-timeout':
+					$environment['TEST_TIMEOUT'] = $argv[++$i];
+					break;
+				case '--show-all':
+					foreach ($cfgfiles as $file) {
+						$cfg['show'][$file] = true;
+					}
+					break;
+				case '--show-slow':
+					$slow_min_ms = $argv[++$i];
+					break;
+				case '--temp-source':
+					$temp_source = $argv[++$i];
+					break;
+				case '--temp-target':
+					$temp_target = $argv[++$i];
+					if ($temp_urlbase) {
+						$temp_urlbase = $temp_target;
+					}
+					break;
+				case '--temp-urlbase':
+					$temp_urlbase = $argv[++$i];
+					break;
+				case 'v':
+				case '--verbose':
+					$DETAILED = true;
+					break;
+				case 'x':
+					$environment['SKIP_SLOW_TESTS'] = 1;
+					break;
+				case '--offline':
+					$environment['SKIP_ONLINE_TESTS'] = 1;
+					break;
+				case '--shuffle':
+					$shuffle = true;
+					break;
+				case '--asan':
+					$environment['USE_ZEND_ALLOC'] = 0;
+					$environment['USE_TRACKED_ALLOC'] = 1;
+					$environment['SKIP_ASAN'] = 1;
+					$environment['SKIP_PERF_SENSITIVE'] = 1;
 
-						$lsanSuppressions = __DIR__ . '/azure/lsan-suppressions.txt';
-						if (file_exists($lsanSuppressions)) {
-							$environment['LSAN_OPTIONS'] = 'suppressions=' . $lsanSuppressions
-								. ':print_suppressions=0';
-						}
-						break;
-					//case 'w'
-					case '-':
-						// repeat check with full switch
-						$switch = $argv[$i];
-						if ($switch != '-') {
-							$repeat = true;
-						}
-						break;
-					case '--html':
-						$html_file = fopen($argv[++$i], 'wt');
-						$html_output = is_resource($html_file);
-						break;
-					case '--version':
-						echo '$Id$' . "\n";
-						exit(1);
+					$lsanSuppressions = __DIR__ . '/azure/lsan-suppressions.txt';
+					if (file_exists($lsanSuppressions)) {
+						$environment['LSAN_OPTIONS'] = 'suppressions=' . $lsanSuppressions
+							. ':print_suppressions=0';
+					}
+					break;
+				//case 'w'
+				case '-':
+					// repeat check with full switch
+					$switch = $argv[$i];
+					if ($switch != '-') {
+						$repeat = true;
+					}
+					break;
+				case '--html':
+					$html_file = fopen($argv[++$i], 'wt');
+					$html_output = is_resource($html_file);
+					break;
+				case '--version':
+					echo '$Id$' . "\n";
+					exit(1);
 
-					default:
-						echo "Illegal switch '$switch' specified!\n";
-					case 'h':
-					case '-help':
-					case '--help':
-						echo <<<HELP
+				default:
+					echo "Illegal switch '$switch' specified!\n";
+				case 'h':
+				case '-help':
+				case '--help':
+					echo <<<HELP
 Synopsis:
     php run-tests.php [options] [files] [directories]
 
@@ -616,117 +614,116 @@ Options:
     --no-clean  Do not execute clean section if any.
 
 HELP;
-						exit(1);
-				}
+					exit(1);
 			}
+		}
 
-			if (!$is_switch) {
-				$testfile = realpath($argv[$i]);
+		if (!$is_switch) {
+			$testfile = realpath($argv[$i]);
 
-				if (!$testfile && strpos($argv[$i], '*') !== false && function_exists('glob')) {
+			if (!$testfile && strpos($argv[$i], '*') !== false && function_exists('glob')) {
 
-					if (substr($argv[$i], -5) == '.phpt') {
-						$pattern_match = glob($argv[$i]);
-					} else {
-						if (preg_match("/\*$/", $argv[$i])) {
-							$pattern_match = glob($argv[$i] . '.phpt');
-						} else {
-							die('Cannot find test file "' . $argv[$i] . '".' . PHP_EOL);
-						}
-					}
-
-					if (is_array($pattern_match)) {
-						$test_files = array_merge($test_files, $pattern_match);
-					}
-
+				if (substr($argv[$i], -5) == '.phpt') {
+					$pattern_match = glob($argv[$i]);
 				} else {
-					if (is_dir($testfile)) {
-						find_files($testfile);
+					if (preg_match("/\*$/", $argv[$i])) {
+						$pattern_match = glob($argv[$i] . '.phpt');
 					} else {
-						if (substr($testfile, -5) == '.phpt') {
-							$test_files[] = $testfile;
-						} else {
-							die('Cannot find test file "' . $argv[$i] . '".' . PHP_EOL);
-						}
+						die('Cannot find test file "' . $argv[$i] . '".' . PHP_EOL);
+					}
+				}
+
+				if (is_array($pattern_match)) {
+					$test_files = array_merge($test_files, $pattern_match);
+				}
+
+			} else {
+				if (is_dir($testfile)) {
+					find_files($testfile);
+				} else {
+					if (substr($testfile, -5) == '.phpt') {
+						$test_files[] = $testfile;
+					} else {
+						die('Cannot find test file "' . $argv[$i] . '".' . PHP_EOL);
 					}
 				}
 			}
 		}
+	}
 
-		// Default to PHP_BINARY as executable
-		if (!isset($environment['TEST_PHP_EXECUTABLE'])) {
-			$php = PHP_BINARY;
-			putenv("TEST_PHP_EXECUTABLE=$php");
-			$environment['TEST_PHP_EXECUTABLE'] = $php;
+	// Default to PHP_BINARY as executable
+	if (!isset($environment['TEST_PHP_EXECUTABLE'])) {
+		$php = PHP_BINARY;
+		putenv("TEST_PHP_EXECUTABLE=$php");
+		$environment['TEST_PHP_EXECUTABLE'] = $php;
+	}
+
+	if (strlen($conf_passed)) {
+		if (substr(PHP_OS, 0, 3) == "WIN") {
+			$pass_options .= " -c " . escapeshellarg($conf_passed);
+		} else {
+			$pass_options .= " -c '" . realpath($conf_passed) . "'";
+		}
+	}
+
+	$test_files = array_unique($test_files);
+	$test_files = array_merge($test_files, $redir_tests);
+
+	// Run selected tests.
+	$test_cnt = count($test_files);
+
+	if ($test_cnt) {
+		putenv('NO_INTERACTION=1');
+		verify_config();
+		write_information();
+		usort($test_files, "test_sort");
+		$start_time = time();
+
+		if (!$html_output) {
+			echo "Running selected tests.\n";
+		} else {
+			show_start($start_time);
 		}
 
-		if (strlen($conf_passed)) {
-			if (substr(PHP_OS, 0, 3) == "WIN") {
-				$pass_options .= " -c " . escapeshellarg($conf_passed);
-			} else {
-				$pass_options .= " -c '" . realpath($conf_passed) . "'";
-			}
+		$test_idx = 0;
+		run_all_tests($test_files, $environment);
+		$end_time = time();
+
+		if ($html_output) {
+			show_end($end_time);
 		}
 
-		$test_files = array_unique($test_files);
-		$test_files = array_merge($test_files, $redir_tests);
-
-		// Run selected tests.
-		$test_cnt = count($test_files);
-
-		if ($test_cnt) {
-			putenv('NO_INTERACTION=1');
-			verify_config();
-			write_information();
-			usort($test_files, "test_sort");
-			$start_time = time();
-
-			if (!$html_output) {
-				echo "Running selected tests.\n";
-			} else {
-				show_start($start_time);
-			}
-
-			$test_idx = 0;
-			run_all_tests($test_files, $environment);
-			$end_time = time();
-
-			if ($html_output) {
-				show_end($end_time);
-			}
-
-			if ($failed_tests_file) {
-				fclose($failed_tests_file);
-			}
-
-			if ($result_tests_file) {
-				fclose($result_tests_file);
-			}
-
-			compute_summary();
-			if ($html_output) {
-				fwrite($html_file, "<hr/>\n" . get_summary(false, true));
-			}
-			echo "=====================================================================";
-			echo get_summary(false, false);
-
-			if ($html_output) {
-				fclose($html_file);
-			}
-
-			if ($output_file != '' && $just_save_results) {
-				save_or_mail_results();
-			}
-
-			junit_save_xml();
-
-			if (getenv('REPORT_EXIT_STATUS') !== '0' &&
-				getenv('REPORT_EXIT_STATUS') !== 'no' && ($sum_results['FAILED'] || $sum_results['BORKED'] || $sum_results['LEAKED'])) {
-				exit(1);
-			}
-
-			return;
+		if ($failed_tests_file) {
+			fclose($failed_tests_file);
 		}
+
+		if ($result_tests_file) {
+			fclose($result_tests_file);
+		}
+
+		compute_summary();
+		if ($html_output) {
+			fwrite($html_file, "<hr/>\n" . get_summary(false, true));
+		}
+		echo "=====================================================================";
+		echo get_summary(false, false);
+
+		if ($html_output) {
+			fclose($html_file);
+		}
+
+		if ($output_file != '' && $just_save_results) {
+			save_or_mail_results();
+		}
+
+		junit_save_xml();
+
+		if (getenv('REPORT_EXIT_STATUS') !== '0' &&
+			getenv('REPORT_EXIT_STATUS') !== 'no' && ($sum_results['FAILED'] || $sum_results['BORKED'] || $sum_results['LEAKED'])) {
+			exit(1);
+		}
+
+		return;
 	}
 
 	verify_config();


### PR DESCRIPTION
The default PHP executable was not set when no args were provided.

Example of the previous behavior:
```sh
$ ./run-tests.php 
ERROR: environment variable TEST_PHP_EXECUTABLE must be set to specify PHP executable!
```

Hide whitespace changes to check what has really changed.