### PR TITLE
Fix php8 compile error using zend_parse_parameters_throw()

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -269,8 +269,9 @@ ZEND_API int zend_copy_parameters_array(int param_count, zval *argument_array);
 #define ZEND_PARSE_PARAMS_QUIET (1<<1)
 ZEND_API int zend_parse_parameters(int num_args, const char *type_spec, ...);
 ZEND_API int zend_parse_parameters_ex(int flags, int num_args, const char *type_spec, ...);
-#define zend_parse_parameters_throw(num_args, type_spec, ...) \
-	zend_parse_parameters(num_args, type_spec, __VA_ARGS__)
+/* NOTE: This must have at least one value in __VA_ARGS__ for the expression to be valid */
+#define zend_parse_parameters_throw(num_args, ...) \
+	zend_parse_parameters(num_args, __VA_ARGS__)
 ZEND_API const char *zend_zval_type_name(const zval *arg);
 ZEND_API zend_string *zend_zval_get_type(const zval *arg);
 


### PR DESCRIPTION
Fixes a bug introduced in 4008704f62

The trailing comma is followed by `)` when the varargs list
is empty in the macro, which is a syntax error in C

This fixes compilation of code such as the following

    PHP_FUNCTION(get_metadata) {
      if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "") == FAILURE) {
        return;
      }