### PR TITLE
ext/dom: Cleanup PHP_FALIAS=>PHP_ME + PHP_FUNCTOIN=>PHP_METHOD

### DIFF
--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -34,7 +34,7 @@
 */
 
 const zend_function_entry php_dom_attr_class_functions[] = {
-	PHP_FALIAS(isId, dom_attr_is_id, arginfo_class_DOMAttr_isId)
+	PHP_ME(domattr, isId, arginfo_class_DOMAttr_isId, ZEND_ACC_PUBLIC)
 	PHP_ME(domattr, __construct, arginfo_class_DOMAttr___construct, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
@@ -209,11 +209,11 @@ int dom_attr_schema_type_info_read(dom_object *obj, zval *retval)
 
 /* }}} */
 
-/* {{{ proto bool dom_attr_is_id()
+/* {{{ proto bool domattr::isId()
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#Attr-isId
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_attr_is_id)
+PHP_METHOD(domattr, isId)
 {
 	zval *id;
 	dom_object *intern;

--- a/ext/dom/characterdata.c
+++ b/ext/dom/characterdata.c
@@ -32,11 +32,11 @@
 */
 
 const zend_function_entry php_dom_characterdata_class_functions[] = {
-	PHP_FALIAS(substringData, dom_characterdata_substring_data, arginfo_class_DOMCharacterData_substringData)
-	PHP_FALIAS(appendData, dom_characterdata_append_data, arginfo_class_DOMCharacterData_appendData)
-	PHP_FALIAS(insertData, dom_characterdata_insert_data, arginfo_class_DOMCharacterData_insertData)
-	PHP_FALIAS(deleteData, dom_characterdata_delete_data, arginfo_class_DOMCharacterData_deleteData)
-	PHP_FALIAS(replaceData, dom_characterdata_replace_data, arginfo_class_DOMCharacterData_replaceData)
+	PHP_ME(domcharacterdata, substringData, arginfo_class_DOMCharacterData_substringData, ZEND_ACC_PUBLIC)
+	PHP_ME(domcharacterdata, appendData, arginfo_class_DOMCharacterData_appendData, ZEND_ACC_PUBLIC)
+	PHP_ME(domcharacterdata, insertData, arginfo_class_DOMCharacterData_insertData, ZEND_ACC_PUBLIC)
+	PHP_ME(domcharacterdata, deleteData, arginfo_class_DOMCharacterData_deleteData, ZEND_ACC_PUBLIC)
+	PHP_ME(domcharacterdata, replaceData, arginfo_class_DOMCharacterData_replaceData, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -122,7 +122,7 @@ int dom_characterdata_length_read(dom_object *obj, zval *retval)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-6531BCCF
 Since:
 */
-PHP_FUNCTION(dom_characterdata_substring_data)
+PHP_METHOD(domcharacterdata, substringData)
 {
 	zval       *id;
 	xmlChar    *cur;
@@ -172,7 +172,7 @@ PHP_FUNCTION(dom_characterdata_substring_data)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-32791A2F
 Since:
 */
-PHP_FUNCTION(dom_characterdata_append_data)
+PHP_METHOD(domcharacterdata, appendData)
 {
 	zval *id;
 	xmlNode *nodep;
@@ -195,7 +195,7 @@ PHP_FUNCTION(dom_characterdata_append_data)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-3EDB695F
 Since:
 */
-PHP_FUNCTION(dom_characterdata_insert_data)
+PHP_METHOD(domcharacterdata, insertData)
 {
 	zval *id;
 	xmlChar		*cur, *first, *second;
@@ -245,7 +245,7 @@ PHP_FUNCTION(dom_characterdata_insert_data)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-7C603781
 Since:
 */
-PHP_FUNCTION(dom_characterdata_delete_data)
+PHP_METHOD(domcharacterdata, deleteData)
 {
 	zval *id;
 	xmlChar    *cur, *substring, *second;
@@ -301,7 +301,7 @@ PHP_FUNCTION(dom_characterdata_delete_data)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-E5CBA7FB
 Since:
 */
-PHP_FUNCTION(dom_characterdata_replace_data)
+PHP_METHOD(domcharacterdata, replaceData)
 {
 	zval *id;
 	xmlChar		*cur, *substring, *second = NULL;

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -46,40 +46,40 @@ struct _idsIterator {
 */
 
 const zend_function_entry php_dom_document_class_functions[] = { /* {{{ */
-	PHP_FALIAS(createElement, dom_document_create_element, arginfo_class_DOMDocument_createElement)
-	PHP_FALIAS(createDocumentFragment, dom_document_create_document_fragment, arginfo_class_DOMDocument_createDocumentFragment)
-	PHP_FALIAS(createTextNode, dom_document_create_text_node, arginfo_class_DOMDocument_createTextNode)
-	PHP_FALIAS(createComment, dom_document_create_comment, arginfo_class_DOMDocument_createComment)
-	PHP_FALIAS(createCDATASection, dom_document_create_cdatasection, arginfo_class_DOMDocument_createCDATASection)
-	PHP_FALIAS(createProcessingInstruction, dom_document_create_processing_instruction, arginfo_class_DOMDocument_createProcessingInstruction)
-	PHP_FALIAS(createAttribute, dom_document_create_attribute, arginfo_class_DOMDocument_createAttribute)
-	PHP_FALIAS(createEntityReference, dom_document_create_entity_reference, arginfo_class_DOMDocument_createEntityReference)
-	PHP_FALIAS(getElementsByTagName, dom_document_get_elements_by_tag_name, arginfo_class_DOMDocument_getElementsByTagName)
-	PHP_FALIAS(importNode, dom_document_import_node, arginfo_class_DOMDocument_importNode)
-	PHP_FALIAS(createElementNS, dom_document_create_element_ns, arginfo_class_DOMDocument_createElementNS)
-	PHP_FALIAS(createAttributeNS, dom_document_create_attribute_ns, arginfo_class_DOMDocument_createAttributeNS)
-	PHP_FALIAS(getElementsByTagNameNS, dom_document_get_elements_by_tag_name_ns, arginfo_class_DOMDocument_getElementsByTagNameNS)
-	PHP_FALIAS(getElementById, dom_document_get_element_by_id, arginfo_class_DOMDocument_getElementById)
-	PHP_FALIAS(adoptNode, dom_document_adopt_node, arginfo_class_DOMDocument_adoptNode)
-	PHP_FALIAS(normalizeDocument, dom_document_normalize_document, arginfo_class_DOMDocument_normalizeDocument)
+	PHP_ME(domdocument, createElement, arginfo_class_DOMDocument_createElement, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, createDocumentFragment, arginfo_class_DOMDocument_createDocumentFragment, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, createTextNode, arginfo_class_DOMDocument_createTextNode, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, createComment, arginfo_class_DOMDocument_createComment, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, createCDATASection, arginfo_class_DOMDocument_createCDATASection, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, createProcessingInstruction, arginfo_class_DOMDocument_createProcessingInstruction, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, createAttribute, arginfo_class_DOMDocument_createAttribute, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, createEntityReference, arginfo_class_DOMDocument_createEntityReference, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, getElementsByTagName, arginfo_class_DOMDocument_getElementsByTagName, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, importNode, arginfo_class_DOMDocument_importNode, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, createElementNS, arginfo_class_DOMDocument_createElementNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, createAttributeNS, arginfo_class_DOMDocument_createAttributeNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, getElementsByTagNameNS, arginfo_class_DOMDocument_getElementsByTagNameNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, getElementById, arginfo_class_DOMDocument_getElementById, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, adoptNode, arginfo_class_DOMDocument_adoptNode, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, normalizeDocument, arginfo_class_DOMDocument_normalizeDocument, ZEND_ACC_PUBLIC)
 	PHP_ME(domdocument, load, arginfo_class_DOMDocument_load, ZEND_ACC_PUBLIC)
-	PHP_FALIAS(save, dom_document_save, arginfo_class_DOMDocument_save)
+	PHP_ME(domdocument, save, arginfo_class_DOMDocument_save, ZEND_ACC_PUBLIC)
 	PHP_ME(domdocument, loadXML, arginfo_class_DOMDocument_loadXML, ZEND_ACC_PUBLIC)
-	PHP_FALIAS(saveXML, dom_document_savexml, arginfo_class_DOMDocument_saveXML)
+	PHP_ME(domdocument, saveXML, arginfo_class_DOMDocument_saveXML, ZEND_ACC_PUBLIC)
 	PHP_ME(domdocument, __construct, arginfo_class_DOMDocument___construct, ZEND_ACC_PUBLIC)
-	PHP_FALIAS(validate, dom_document_validate, arginfo_class_DOMDocument_validate)
-	PHP_FALIAS(xinclude, dom_document_xinclude, arginfo_class_DOMDocument_xinclude)
+	PHP_ME(domdocument, validate, arginfo_class_DOMDocument_validate, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, xinclude, arginfo_class_DOMDocument_xinclude, ZEND_ACC_PUBLIC)
 #if defined(LIBXML_HTML_ENABLED)
 	PHP_ME(domdocument, loadHTML, arginfo_class_DOMDocument_loadHTML, ZEND_ACC_PUBLIC)
 	PHP_ME(domdocument, loadHTMLFile, arginfo_class_DOMDocument_loadHTMLFile, ZEND_ACC_PUBLIC)
-	PHP_FALIAS(saveHTML, dom_document_save_html, arginfo_class_DOMDocument_saveHTML)
-	PHP_FALIAS(saveHTMLFile, dom_document_save_html_file, arginfo_class_DOMDocument_saveHTMLFile)
+	PHP_ME(domdocument, saveHTML, arginfo_class_DOMDocument_saveHTML, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, saveHTMLFile, arginfo_class_DOMDocument_saveHTMLFile, ZEND_ACC_PUBLIC)
 #endif  /* defined(LIBXML_HTML_ENABLED) */
 #if defined(LIBXML_SCHEMAS_ENABLED)
-	PHP_FALIAS(schemaValidate, dom_document_schema_validate_file, arginfo_class_DOMDocument_schemaValidate)
-	PHP_FALIAS(schemaValidateSource, dom_document_schema_validate_xml, arginfo_class_DOMDocument_schemaValidateSource)
-	PHP_FALIAS(relaxNGValidate, dom_document_relaxNG_validate_file, arginfo_class_DOMDocument_relaxNGValidate)
-	PHP_FALIAS(relaxNGValidateSource, dom_document_relaxNG_validate_xml, arginfo_class_DOMDocument_relaxNGValidateSource)
+	PHP_ME(domdocument, schemaValidate, arginfo_class_DOMDocument_schemaValidate, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, schemaValidateSource, arginfo_class_DOMDocument_schemaValidateSource, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, relaxNGValidate, arginfo_class_DOMDocument_relaxNGValidate, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, relaxNGValidateSource, arginfo_class_DOMDocument_relaxNGValidateSource, ZEND_ACC_PUBLIC)
 #endif
 	PHP_ME(domdocument, registerNodeClass, arginfo_class_DOMDocument_registerNodeClass, ZEND_ACC_PUBLIC)
 	PHP_FE_END
@@ -551,7 +551,7 @@ int dom_document_config_read(dom_object *obj, zval *retval)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-2141741547
 Since:
 */
-PHP_FUNCTION(dom_document_create_element)
+PHP_METHOD(domdocument, createElement)
 {
 	zval *id;
 	xmlNode *node;
@@ -586,7 +586,7 @@ PHP_FUNCTION(dom_document_create_element)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-35CB04B5
 Since:
 */
-PHP_FUNCTION(dom_document_create_document_fragment)
+PHP_METHOD(domdocument, createDocumentFragment)
 {
 	zval *id;
 	xmlNode *node;
@@ -614,7 +614,7 @@ PHP_FUNCTION(dom_document_create_document_fragment)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-1975348127
 Since:
 */
-PHP_FUNCTION(dom_document_create_text_node)
+PHP_METHOD(domdocument, createTextNode)
 {
 	zval *id;
 	xmlNode *node;
@@ -644,7 +644,7 @@ PHP_FUNCTION(dom_document_create_text_node)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-1334481328
 Since:
 */
-PHP_FUNCTION(dom_document_create_comment)
+PHP_METHOD(domdocument, createComment)
 {
 	zval *id;
 	xmlNode *node;
@@ -674,7 +674,7 @@ PHP_FUNCTION(dom_document_create_comment)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-D26C0AF8
 Since:
 */
-PHP_FUNCTION(dom_document_create_cdatasection)
+PHP_METHOD(domdocument, createCDATASection)
 {
 	zval *id;
 	xmlNode *node;
@@ -704,7 +704,7 @@ PHP_FUNCTION(dom_document_create_cdatasection)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-135944439
 Since:
 */
-PHP_FUNCTION(dom_document_create_processing_instruction)
+PHP_METHOD(domdocument, createProcessingInstruction)
 {
 	zval *id;
 	xmlNode *node;
@@ -741,7 +741,7 @@ PHP_FUNCTION(dom_document_create_processing_instruction)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-1084891198
 Since:
 */
-PHP_FUNCTION(dom_document_create_attribute)
+PHP_METHOD(domdocument, createAttribute)
 {
 	zval *id;
 	xmlAttrPtr node;
@@ -777,7 +777,7 @@ PHP_FUNCTION(dom_document_create_attribute)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-392B75AE
 Since:
 */
-PHP_FUNCTION(dom_document_create_entity_reference)
+PHP_METHOD(domdocument, createEntityReference)
 {
 	zval *id;
 	xmlNode *node;
@@ -812,7 +812,7 @@ PHP_FUNCTION(dom_document_create_entity_reference)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-A6C9094
 Since:
 */
-PHP_FUNCTION(dom_document_get_elements_by_tag_name)
+PHP_METHOD(domdocument, getElementsByTagName)
 {
 	zval *id;
 	xmlDocPtr docp;
@@ -839,7 +839,7 @@ PHP_FUNCTION(dom_document_get_elements_by_tag_name)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#Core-Document-importNode
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_document_import_node)
+PHP_METHOD(domdocument, importNode)
 {
 	zval *id, *node;
 	xmlDocPtr docp;
@@ -895,7 +895,7 @@ PHP_FUNCTION(dom_document_import_node)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-DocCrElNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_document_create_element_ns)
+PHP_METHOD(domdocument, createElementNS)
 {
 	zval *id;
 	xmlDocPtr docp;
@@ -960,7 +960,7 @@ PHP_FUNCTION(dom_document_create_element_ns)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-DocCrAttrNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_document_create_attribute_ns)
+PHP_METHOD(domdocument, createAttributeNS)
 {
 	zval *id;
 	xmlDocPtr docp;
@@ -1027,7 +1027,7 @@ PHP_FUNCTION(dom_document_create_attribute_ns)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-getElBTNNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_document_get_elements_by_tag_name_ns)
+PHP_METHOD(domdocument, getElementsByTagNameNS)
 {
 	zval *id;
 	xmlDocPtr docp;
@@ -1055,7 +1055,7 @@ PHP_FUNCTION(dom_document_get_elements_by_tag_name_ns)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-getElBId
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_document_get_element_by_id)
+PHP_METHOD(domdocument, getElementById)
 {
 	zval *id;
 	xmlDocPtr docp;
@@ -1087,7 +1087,7 @@ PHP_FUNCTION(dom_document_get_element_by_id)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-Document3-adoptNode
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_document_adopt_node)
+PHP_METHOD(domdocument, adoptNode)
 {
 	zval *nodep = NULL;
 
@@ -1103,7 +1103,7 @@ PHP_FUNCTION(dom_document_adopt_node)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-Document3-normalizeDocument
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_document_normalize_document)
+PHP_METHOD(domdocument, normalizeDocument)
 {
 	zval *id;
 	xmlDocPtr docp;
@@ -1428,7 +1428,7 @@ PHP_METHOD(domdocument, loadXML)
 /* {{{ proto int dom_document_save(string file)
 Convenience method to save to file
 */
-PHP_FUNCTION(dom_document_save)
+PHP_METHOD(domdocument, save)
 {
 	zval *id;
 	xmlDoc *docp;
@@ -1474,7 +1474,7 @@ PHP_FUNCTION(dom_document_save)
 URL: http://www.w3.org/TR/DOM-Level-3-LS/load-save.html#LS-DocumentLS-saveXML
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_document_savexml)
+PHP_METHOD(domdocument, saveXML)
 {
 	zval *id, *nodep = NULL;
 	xmlDoc *docp;
@@ -1585,7 +1585,7 @@ static void php_dom_remove_xinclude_nodes(xmlNodePtr cur) /* {{{ */
 
 /* {{{ proto int dom_document_xinclude([int options])
    Substitutues xincludes in a DomDocument */
-PHP_FUNCTION(dom_document_xinclude)
+PHP_METHOD(domdocument, xinclude)
 {
 	zval *id;
 	xmlDoc *docp;
@@ -1632,7 +1632,7 @@ PHP_FUNCTION(dom_document_xinclude)
 /* {{{ proto bool dom_document_validate()
 Since: DOM extended
 */
-PHP_FUNCTION(dom_document_validate)
+PHP_METHOD(domdocument, validate)
 {
 	zval *id;
 	xmlDoc *docp;
@@ -1752,14 +1752,14 @@ static void _dom_document_schema_validate(INTERNAL_FUNCTION_PARAMETERS, int type
 /* }}} */
 
 /* {{{ proto bool dom_document_schema_validate_file(string filename, int flags); */
-PHP_FUNCTION(dom_document_schema_validate_file)
+PHP_METHOD(domdocument, schemaValidate)
 {
 	_dom_document_schema_validate(INTERNAL_FUNCTION_PARAM_PASSTHRU, DOM_LOAD_FILE);
 }
 /* }}} end dom_document_schema_validate_file */
 
 /* {{{ proto bool dom_document_schema_validate(string source, int flags); */
-PHP_FUNCTION(dom_document_schema_validate_xml)
+PHP_METHOD(domdocument, schemaValidateSource)
 {
 	_dom_document_schema_validate(INTERNAL_FUNCTION_PARAM_PASSTHRU, DOM_LOAD_STRING);
 }
@@ -1846,14 +1846,14 @@ static void _dom_document_relaxNG_validate(INTERNAL_FUNCTION_PARAMETERS, int typ
 /* }}} */
 
 /* {{{ proto bool dom_document_relaxNG_validate_file(string filename); */
-PHP_FUNCTION(dom_document_relaxNG_validate_file)
+PHP_METHOD(domdocument, relaxNGValidate)
 {
 	_dom_document_relaxNG_validate(INTERNAL_FUNCTION_PARAM_PASSTHRU, DOM_LOAD_FILE);
 }
 /* }}} end dom_document_relaxNG_validate_file */
 
 /* {{{ proto bool dom_document_relaxNG_validate_xml(string source); */
-PHP_FUNCTION(dom_document_relaxNG_validate_xml)
+PHP_METHOD(domdocument, relaxNGValidateSource)
 {
 	_dom_document_relaxNG_validate(INTERNAL_FUNCTION_PARAM_PASSTHRU, DOM_LOAD_STRING);
 }
@@ -1978,7 +1978,7 @@ PHP_METHOD(domdocument, loadHTML)
 /* {{{ proto int dom_document_save_html_file(string file)
 Convenience method to save to file as html
 */
-PHP_FUNCTION(dom_document_save_html_file)
+PHP_METHOD(domdocument, saveHTMLFile)
 {
 	zval *id;
 	xmlDoc *docp;
@@ -2018,7 +2018,7 @@ PHP_FUNCTION(dom_document_save_html_file)
 /* {{{ proto string dom_document_save_html()
 Convenience method to output as html
 */
-PHP_FUNCTION(dom_document_save_html)
+PHP_METHOD(domdocument, saveHTML)
 {
 	zval *id, *nodep = NULL;
 	xmlDoc *docp;

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -77,121 +77,111 @@ PHP_METHOD(domdocumentfragment, __construct);
 PHP_METHOD(domdocumentfragment, appendXML);
 
 /* domdocument methods */
-PHP_FUNCTION(dom_document_create_element);
-PHP_FUNCTION(dom_document_create_document_fragment);
-PHP_FUNCTION(dom_document_create_text_node);
-PHP_FUNCTION(dom_document_create_comment);
-PHP_FUNCTION(dom_document_create_cdatasection);
-PHP_FUNCTION(dom_document_create_processing_instruction);
-PHP_FUNCTION(dom_document_create_attribute);
-PHP_FUNCTION(dom_document_create_entity_reference);
-PHP_FUNCTION(dom_document_get_elements_by_tag_name);
-PHP_FUNCTION(dom_document_import_node);
-PHP_FUNCTION(dom_document_create_element_ns);
-PHP_FUNCTION(dom_document_create_attribute_ns);
-PHP_FUNCTION(dom_document_get_elements_by_tag_name_ns);
-PHP_FUNCTION(dom_document_get_element_by_id);
-PHP_FUNCTION(dom_document_adopt_node);
-PHP_FUNCTION(dom_document_normalize_document);
-PHP_FUNCTION(dom_document_rename_node);
+PHP_METHOD(domdocument, createElement);
+PHP_METHOD(domdocument, createDocumentFragment);
+PHP_METHOD(domdocument, createTextNode);
+PHP_METHOD(domdocument, createComment);
+PHP_METHOD(domdocument, createCDATASection);
+PHP_METHOD(domdocument, createProcessingInstruction);
+PHP_METHOD(domdocument, createAttribute);
+PHP_METHOD(domdocument, createEntityReference);
+PHP_METHOD(domdocument, getElementsByTagName);
+PHP_METHOD(domdocument, importNode);
+PHP_METHOD(domdocument, createElementNS);
+PHP_METHOD(domdocument, createAttributeNS);
+PHP_METHOD(domdocument, getElementsByTagNameNS);
+PHP_METHOD(domdocument, getElementById);
+PHP_METHOD(domdocument, adoptNode);
+PHP_METHOD(domdocument, normalizeDocument);
 PHP_METHOD(domdocument, __construct);
 	/* convienience methods */
 PHP_METHOD(domdocument, load);
-PHP_FUNCTION(dom_document_save);
+PHP_METHOD(domdocument, save);
 PHP_METHOD(domdocument, loadXML);
-PHP_FUNCTION(dom_document_savexml);
-PHP_FUNCTION(dom_document_validate);
-PHP_FUNCTION(dom_document_xinclude);
+PHP_METHOD(domdocument, saveXML);
+PHP_METHOD(domdocument, validate);
+PHP_METHOD(domdocument, xinclude);
 PHP_METHOD(domdocument, registerNodeClass);
 
 #if defined(LIBXML_HTML_ENABLED)
 PHP_METHOD(domdocument, loadHTML);
 PHP_METHOD(domdocument, loadHTMLFile);
-PHP_FUNCTION(dom_document_save_html);
-PHP_FUNCTION(dom_document_save_html_file);
+PHP_METHOD(domdocument, saveHTML);
+PHP_METHOD(domdocument, saveHTMLFile);
 #endif  /* defined(LIBXML_HTML_ENABLED) */
 
 #if defined(LIBXML_SCHEMAS_ENABLED)
-PHP_FUNCTION(dom_document_schema_validate_file);
-PHP_FUNCTION(dom_document_schema_validate_xml);
-PHP_FUNCTION(dom_document_relaxNG_validate_file);
-PHP_FUNCTION(dom_document_relaxNG_validate_xml);
+PHP_METHOD(domdocument, schemaValidate);
+PHP_METHOD(domdocument, schemaValidateSource);
+PHP_METHOD(domdocument, relaxNGValidate);
+PHP_METHOD(domdocument, relaxNGValidateSource);
 #endif
 
 /* domnode methods */
-PHP_FUNCTION(dom_node_insert_before);
-PHP_FUNCTION(dom_node_replace_child);
-PHP_FUNCTION(dom_node_remove_child);
-PHP_FUNCTION(dom_node_append_child);
-PHP_FUNCTION(dom_node_has_child_nodes);
-PHP_FUNCTION(dom_node_clone_node);
-PHP_FUNCTION(dom_node_normalize);
-PHP_FUNCTION(dom_node_is_supported);
-PHP_FUNCTION(dom_node_has_attributes);
-PHP_FUNCTION(dom_node_compare_document_position);
-PHP_FUNCTION(dom_node_is_same_node);
-PHP_FUNCTION(dom_node_lookup_prefix);
-PHP_FUNCTION(dom_node_is_default_namespace);
-PHP_FUNCTION(dom_node_lookup_namespace_uri);
-PHP_FUNCTION(dom_node_is_equal_node);
-PHP_FUNCTION(dom_node_get_feature);
-PHP_FUNCTION(dom_node_set_user_data);
-PHP_FUNCTION(dom_node_get_user_data);
+PHP_METHOD(domnode, insertBefore);
+PHP_METHOD(domnode, replaceChild);
+PHP_METHOD(domnode, removeChild);
+PHP_METHOD(domnode, appendChild);
+PHP_METHOD(domnode, hasChildNodes);
+PHP_METHOD(domnode, cloneNode);
+PHP_METHOD(domnode, normalize);
+PHP_METHOD(domnode, isSupported);
+PHP_METHOD(domnode, hasAttributes);
+PHP_METHOD(domnode, isSameNode);
+PHP_METHOD(domnode, lookupPrefix);
+PHP_METHOD(domnode, isDefaultNamespace);
+PHP_METHOD(domnode, lookupNamespaceURI);
 PHP_METHOD(domnode, C14N);
 PHP_METHOD(domnode, C14NFile);
 PHP_METHOD(domnode, getNodePath);
 PHP_METHOD(domnode, getLineNo);
 
 /* domnodelist methods */
-PHP_FUNCTION(dom_nodelist_item);
-PHP_FUNCTION(dom_nodelist_count);
+PHP_METHOD(domnodelist, item);
+PHP_METHOD(domnodelist, count);
 
 /* domnamednodemap methods */
-PHP_FUNCTION(dom_namednodemap_get_named_item);
-PHP_FUNCTION(dom_namednodemap_set_named_item);
-PHP_FUNCTION(dom_namednodemap_remove_named_item);
-PHP_FUNCTION(dom_namednodemap_item);
-PHP_FUNCTION(dom_namednodemap_get_named_item_ns);
-PHP_FUNCTION(dom_namednodemap_set_named_item_ns);
-PHP_FUNCTION(dom_namednodemap_remove_named_item_ns);
-PHP_FUNCTION(dom_namednodemap_count);
+PHP_METHOD(domnamednodemap, getNamedItem);
+PHP_METHOD(domnamednodemap, item);
+PHP_METHOD(domnamednodemap, getNamedItemNS);
+PHP_METHOD(domnamednodemap, count);
 
 /* domcharacterdata methods */
-PHP_FUNCTION(dom_characterdata_substring_data);
-PHP_FUNCTION(dom_characterdata_append_data);
-PHP_FUNCTION(dom_characterdata_insert_data);
-PHP_FUNCTION(dom_characterdata_delete_data);
-PHP_FUNCTION(dom_characterdata_replace_data);
+PHP_METHOD(domcharacterdata, substringData);
+PHP_METHOD(domcharacterdata, appendData);
+PHP_METHOD(domcharacterdata, insertData);
+PHP_METHOD(domcharacterdata, deleteData);
+PHP_METHOD(domcharacterdata, replaceData);
 
 /* domattr methods */
-PHP_FUNCTION(dom_attr_is_id);
+PHP_METHOD(domattr, isId);
 PHP_METHOD(domattr, __construct);
 
 /* domelement methods */
-PHP_FUNCTION(dom_element_get_attribute);
-PHP_FUNCTION(dom_element_set_attribute);
-PHP_FUNCTION(dom_element_remove_attribute);
-PHP_FUNCTION(dom_element_get_attribute_node);
-PHP_FUNCTION(dom_element_set_attribute_node);
-PHP_FUNCTION(dom_element_remove_attribute_node);
-PHP_FUNCTION(dom_element_get_elements_by_tag_name);
-PHP_FUNCTION(dom_element_get_attribute_ns);
-PHP_FUNCTION(dom_element_set_attribute_ns);
-PHP_FUNCTION(dom_element_remove_attribute_ns);
-PHP_FUNCTION(dom_element_get_attribute_node_ns);
-PHP_FUNCTION(dom_element_set_attribute_node_ns);
-PHP_FUNCTION(dom_element_get_elements_by_tag_name_ns);
-PHP_FUNCTION(dom_element_has_attribute);
-PHP_FUNCTION(dom_element_has_attribute_ns);
-PHP_FUNCTION(dom_element_set_id_attribute);
-PHP_FUNCTION(dom_element_set_id_attribute_ns);
-PHP_FUNCTION(dom_element_set_id_attribute_node);
+PHP_METHOD(domelement, getAttribute);
+PHP_METHOD(domelement, setAttribute);
+PHP_METHOD(domelement, removeAttribute);
+PHP_METHOD(domelement, getAttributeNode);
+PHP_METHOD(domelement, setAttributeNode);
+PHP_METHOD(domelement, removeAttributeNode);
+PHP_METHOD(domelement, getElementsByTagName);
+PHP_METHOD(domelement, getAttributeNS);
+PHP_METHOD(domelement, setAttributeNS);
+PHP_METHOD(domelement, removeAttributeNS);
+PHP_METHOD(domelement, getAttributeNodeNS);
+PHP_METHOD(domelement, setAttributeNodeNS);
+PHP_METHOD(domelement, getElementsByTagNameNS);
+PHP_METHOD(domelement, hasAttribute);
+PHP_METHOD(domelement, hasAttributeNS);
+PHP_METHOD(domelement, setIdAttribute);
+PHP_METHOD(domelement, setIdAttributeNS);
+PHP_METHOD(domelement, setIdAttributeNode);
 PHP_METHOD(domelement, __construct);
 
 /* domtext methods */
-PHP_FUNCTION(dom_text_split_text);
-PHP_FUNCTION(dom_text_is_whitespace_in_element_content);
-PHP_FUNCTION(dom_text_replace_whole_text);
+PHP_METHOD(domtext, splitText);
+PHP_METHOD(domtext, isWhitespaceInElementContent);
+PHP_METHOD(domtext, replaceWholeText);
 PHP_METHOD(domtext, __construct);
 
 /* domcomment methods */
@@ -215,10 +205,10 @@ PHP_METHOD(domprocessinginstruction, __construct);
 #if defined(LIBXML_XPATH_ENABLED)
 /* xpath methods */
 PHP_METHOD(domxpath, __construct);
-PHP_FUNCTION(dom_xpath_register_ns);
-PHP_FUNCTION(dom_xpath_query);
-PHP_FUNCTION(dom_xpath_evaluate);
-PHP_FUNCTION(dom_xpath_register_php_functions);
+PHP_METHOD(domxpath, registerNamespace);
+PHP_METHOD(domxpath, query);
+PHP_METHOD(domxpath, evaluate);
+PHP_METHOD(domxpath, registerPhpFunctions);
 #endif
 
 #endif /* DOM_FE_H */

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -32,24 +32,24 @@
 */
 
 const zend_function_entry php_dom_element_class_functions[] = { /* {{{ */
-	PHP_FALIAS(getAttribute, dom_element_get_attribute, arginfo_class_DOMElement_getAttribute)
-	PHP_FALIAS(setAttribute, dom_element_set_attribute, arginfo_class_DOMElement_setAttribute)
-	PHP_FALIAS(removeAttribute, dom_element_remove_attribute, arginfo_class_DOMElement_removeAttribute)
-	PHP_FALIAS(getAttributeNode, dom_element_get_attribute_node, arginfo_class_DOMElement_getAttributeNode)
-	PHP_FALIAS(setAttributeNode, dom_element_set_attribute_node, arginfo_class_DOMElement_setAttributeNode)
-	PHP_FALIAS(removeAttributeNode, dom_element_remove_attribute_node, arginfo_class_DOMElement_removeAttributeNode)
-	PHP_FALIAS(getElementsByTagName, dom_element_get_elements_by_tag_name, arginfo_class_DOMElement_getElementsByTagName)
-	PHP_FALIAS(getAttributeNS, dom_element_get_attribute_ns, arginfo_class_DOMElement_getAttributeNS)
-	PHP_FALIAS(setAttributeNS, dom_element_set_attribute_ns, arginfo_class_DOMElement_setAttributeNS)
-	PHP_FALIAS(removeAttributeNS, dom_element_remove_attribute_ns, arginfo_class_DOMElement_removeAttributeNS)
-	PHP_FALIAS(getAttributeNodeNS, dom_element_get_attribute_node_ns, arginfo_class_DOMElement_getAttributeNodeNS)
-	PHP_FALIAS(setAttributeNodeNS, dom_element_set_attribute_node_ns, arginfo_class_DOMElement_setAttributeNodeNS)
-	PHP_FALIAS(getElementsByTagNameNS, dom_element_get_elements_by_tag_name_ns, arginfo_class_DOMElement_getElementsByTagNameNS)
-	PHP_FALIAS(hasAttribute, dom_element_has_attribute, arginfo_class_DOMElement_hasAttribute)
-	PHP_FALIAS(hasAttributeNS, dom_element_has_attribute_ns, arginfo_class_DOMElement_hasAttributeNS)
-	PHP_FALIAS(setIdAttribute, dom_element_set_id_attribute, arginfo_class_DOMElement_setIdAttribute)
-	PHP_FALIAS(setIdAttributeNS, dom_element_set_id_attribute_ns, arginfo_class_DOMElement_setIdAttributeNS)
-	PHP_FALIAS(setIdAttributeNode, dom_element_set_id_attribute_node, arginfo_class_DOMElement_setIdAttributeNode)
+	PHP_ME(domelement, getAttribute, arginfo_class_DOMElement_getAttribute, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, setAttribute, arginfo_class_DOMElement_setAttribute, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, removeAttribute, arginfo_class_DOMElement_removeAttribute, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, getAttributeNode, arginfo_class_DOMElement_getAttributeNode, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, setAttributeNode, arginfo_class_DOMElement_setAttributeNode, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, removeAttributeNode, arginfo_class_DOMElement_removeAttributeNode, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, getElementsByTagName, arginfo_class_DOMElement_getElementsByTagName, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, getAttributeNS, arginfo_class_DOMElement_getAttributeNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, setAttributeNS, arginfo_class_DOMElement_setAttributeNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, removeAttributeNS, arginfo_class_DOMElement_removeAttributeNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, getAttributeNodeNS, arginfo_class_DOMElement_getAttributeNodeNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, setAttributeNodeNS, arginfo_class_DOMElement_setAttributeNodeNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, getElementsByTagNameNS, arginfo_class_DOMElement_getElementsByTagNameNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, hasAttribute, arginfo_class_DOMElement_hasAttribute, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, hasAttributeNS, arginfo_class_DOMElement_hasAttributeNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, setIdAttribute, arginfo_class_DOMElement_setIdAttribute, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, setIdAttributeNS, arginfo_class_DOMElement_setIdAttributeNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, setIdAttributeNode, arginfo_class_DOMElement_setIdAttributeNode, ZEND_ACC_PUBLIC)
 	PHP_ME(domelement, __construct, arginfo_class_DOMElement___construct, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
@@ -222,7 +222,7 @@ static xmlNodePtr dom_get_dom1_attribute(xmlNodePtr elem, xmlChar *name) /* {{{ 
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-666EE0F9
 Since:
 */
-PHP_FUNCTION(dom_element_get_attribute)
+PHP_METHOD(domelement, getAttribute)
 {
 	zval *id;
 	xmlNode *nodep;
@@ -266,7 +266,7 @@ PHP_FUNCTION(dom_element_get_attribute)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-F68F082
 Since:
 */
-PHP_FUNCTION(dom_element_set_attribute)
+PHP_METHOD(domelement, setAttribute)
 {
 	zval *id;
 	xmlNode *nodep;
@@ -334,7 +334,7 @@ PHP_FUNCTION(dom_element_set_attribute)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-6D6AC0F9
 Since:
 */
-PHP_FUNCTION(dom_element_remove_attribute)
+PHP_METHOD(domelement, removeAttribute)
 {
 	zval *id;
 	xmlNodePtr nodep, attrp;
@@ -383,7 +383,7 @@ PHP_FUNCTION(dom_element_remove_attribute)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-217A91B8
 Since:
 */
-PHP_FUNCTION(dom_element_get_attribute_node)
+PHP_METHOD(domelement, getAttributeNode)
 {
 	zval *id;
 	xmlNodePtr nodep, attrp;
@@ -431,7 +431,7 @@ PHP_FUNCTION(dom_element_get_attribute_node)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-887236154
 Since:
 */
-PHP_FUNCTION(dom_element_set_attribute_node)
+PHP_METHOD(domelement, setAttributeNode)
 {
 	zval *id, *node;
 	xmlNode *nodep;
@@ -498,7 +498,7 @@ PHP_FUNCTION(dom_element_set_attribute_node)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-D589198
 Since:
 */
-PHP_FUNCTION(dom_element_remove_attribute_node)
+PHP_METHOD(domelement, removeAttributeNode)
 {
 	zval *id, *node;
 	xmlNode *nodep;
@@ -536,7 +536,7 @@ PHP_FUNCTION(dom_element_remove_attribute_node)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-1938918D
 Since:
 */
-PHP_FUNCTION(dom_element_get_elements_by_tag_name)
+PHP_METHOD(domelement, getElementsByTagName)
 {
 	zval *id;
 	xmlNodePtr elemp;
@@ -563,7 +563,7 @@ PHP_FUNCTION(dom_element_get_elements_by_tag_name)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElGetAttrNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_element_get_attribute_ns)
+PHP_METHOD(domelement, getAttributeNS)
 {
 	zval *id;
 	xmlNodePtr elemp;
@@ -644,7 +644,7 @@ static xmlNsPtr _dom_new_reconNs(xmlDocPtr doc, xmlNodePtr tree, xmlNsPtr ns) /*
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElSetAttrNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_element_set_attribute_ns)
+PHP_METHOD(domelement, setAttributeNS)
 {
 	zval *id;
 	xmlNodePtr elemp, nodep = NULL;
@@ -773,7 +773,7 @@ PHP_FUNCTION(dom_element_set_attribute_ns)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElRemAtNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_element_remove_attribute_ns)
+PHP_METHOD(domelement, removeAttributeNS)
 {
 	zval *id;
 	xmlNode *nodep;
@@ -831,7 +831,7 @@ PHP_FUNCTION(dom_element_remove_attribute_ns)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElGetAtNodeNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_element_get_attribute_node_ns)
+PHP_METHOD(domelement, getAttributeNodeNS)
 {
 	zval *id;
 	xmlNodePtr elemp, fakeAttrp;
@@ -887,7 +887,7 @@ PHP_FUNCTION(dom_element_get_attribute_node_ns)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElSetAtNodeNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_element_set_attribute_node_ns)
+PHP_METHOD(domelement, setAttributeNodeNS)
 {
 	zval *id, *node;
 	xmlNode *nodep;
@@ -961,7 +961,7 @@ PHP_FUNCTION(dom_element_set_attribute_node_ns)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-A6C90942
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_element_get_elements_by_tag_name_ns)
+PHP_METHOD(domelement, getElementsByTagNameNS)
 {
 	zval *id;
 	xmlNodePtr elemp;
@@ -990,7 +990,7 @@ PHP_FUNCTION(dom_element_get_elements_by_tag_name_ns)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElHasAttr
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_element_has_attribute)
+PHP_METHOD(domelement, hasAttribute)
 {
 	zval *id;
 	xmlNode *nodep;
@@ -1019,7 +1019,7 @@ PHP_FUNCTION(dom_element_has_attribute)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElHasAttrNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_element_has_attribute_ns)
+PHP_METHOD(domelement, hasAttributeNS)
 {
 	zval *id;
 	xmlNodePtr elemp;
@@ -1077,7 +1077,7 @@ static void php_set_attribute_id(xmlAttrPtr attrp, zend_bool is_id) /* {{{ */
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElSetIdAttr
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_element_set_id_attribute)
+PHP_METHOD(domelement, setIdAttribute)
 {
 	zval *id;
 	xmlNode *nodep;
@@ -1114,7 +1114,7 @@ PHP_FUNCTION(dom_element_set_id_attribute)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElSetIdAttrNS
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_element_set_id_attribute_ns)
+PHP_METHOD(domelement, setIdAttributeNS)
 {
 	zval *id;
 	xmlNodePtr elemp;
@@ -1151,7 +1151,7 @@ PHP_FUNCTION(dom_element_set_id_attribute_ns)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-ElSetIdAttrNode
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_element_set_id_attribute_node)
+PHP_METHOD(domelement, setIdAttributeNode)
 {
 	zval *id, *node;
 	xmlNode *nodep;

--- a/ext/dom/namednodemap.c
+++ b/ext/dom/namednodemap.c
@@ -32,10 +32,10 @@
 */
 
 const zend_function_entry php_dom_namednodemap_class_functions[] = { /* {{{ */
-	PHP_FALIAS(getNamedItem, dom_namednodemap_get_named_item, arginfo_class_DOMNamedNodeMap_getNamedItem)
-	PHP_FALIAS(item, dom_namednodemap_item, arginfo_class_DOMNamedNodeMap_item)
-	PHP_FALIAS(getNamedItemNS, dom_namednodemap_get_named_item_ns, arginfo_class_DOMNamedNodeMap_getNamedItemNS)
-	PHP_FALIAS(count, dom_namednodemap_count, arginfo_class_DOMNamedNodeMap_count)
+	PHP_ME(domnamednodemap, getNamedItem, arginfo_class_DOMNamedNodeMap_getNamedItem, ZEND_ACC_PUBLIC)
+	PHP_ME(domnamednodemap, item, arginfo_class_DOMNamedNodeMap_item, ZEND_ACC_PUBLIC)
+	PHP_ME(domnamednodemap, getNamedItemNS, arginfo_class_DOMNamedNodeMap_getNamedItemNS, ZEND_ACC_PUBLIC)
+	PHP_ME(domnamednodemap, count, arginfo_class_DOMNamedNodeMap_count, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 /* }}} */
@@ -85,7 +85,7 @@ int dom_namednodemap_length_read(dom_object *obj, zval *retval)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-1074577549
 Since:
 */
-PHP_FUNCTION(dom_namednodemap_get_named_item)
+PHP_METHOD(domnamednodemap, getNamedItem)
 {
 	zval *id;
 	int ret;
@@ -141,7 +141,7 @@ PHP_FUNCTION(dom_namednodemap_get_named_item)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-349467F9
 Since:
 */
-PHP_FUNCTION(dom_namednodemap_item)
+PHP_METHOD(domnamednodemap, item)
 {
 	zval *id;
 	zend_long index;
@@ -205,7 +205,7 @@ PHP_FUNCTION(dom_namednodemap_item)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-getNamedItemNS
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_namednodemap_get_named_item_ns)
+PHP_METHOD(domnamednodemap, getNamedItemNS)
 {
 	zval *id;
 	int ret;
@@ -259,7 +259,7 @@ PHP_FUNCTION(dom_namednodemap_get_named_item_ns)
 
 /* {{{ proto int|bool dom_namednodemap_count();
 */
-PHP_FUNCTION(dom_namednodemap_count)
+PHP_METHOD(domnamednodemap, count)
 {
 	zval *id;
 	dom_object *intern;

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -32,19 +32,19 @@
 */
 
 const zend_function_entry php_dom_node_class_functions[] = { /* {{{ */
-	PHP_FALIAS(insertBefore, dom_node_insert_before, arginfo_class_DOMNode_insertBefore)
-	PHP_FALIAS(replaceChild, dom_node_replace_child, arginfo_class_DOMNode_replaceChild)
-	PHP_FALIAS(removeChild, dom_node_remove_child, arginfo_class_DOMNode_removeChild)
-	PHP_FALIAS(appendChild, dom_node_append_child, arginfo_class_DOMNode_appendChild)
-	PHP_FALIAS(hasChildNodes, dom_node_has_child_nodes, arginfo_class_DOMNode_hasChildNodes)
-	PHP_FALIAS(cloneNode, dom_node_clone_node, arginfo_class_DOMNode_cloneNode)
-	PHP_FALIAS(normalize, dom_node_normalize, arginfo_class_DOMNode_normalize)
-	PHP_FALIAS(isSupported, dom_node_is_supported, arginfo_class_DOMNode_isSupported)
-	PHP_FALIAS(hasAttributes, dom_node_has_attributes, arginfo_class_DOMNode_hasAttributes)
-	PHP_FALIAS(isSameNode, dom_node_is_same_node, arginfo_class_DOMNode_isSameNode)
-	PHP_FALIAS(lookupPrefix, dom_node_lookup_prefix, arginfo_class_DOMNode_lookupPrefix)
-	PHP_FALIAS(isDefaultNamespace, dom_node_is_default_namespace, arginfo_class_DOMNode_isDefaultNamespace)
-	PHP_FALIAS(lookupNamespaceUri, dom_node_lookup_namespace_uri, arginfo_class_DOMNode_lookupNamespaceUri)
+	PHP_ME(domnode, insertBefore, arginfo_class_DOMNode_insertBefore, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, replaceChild, arginfo_class_DOMNode_replaceChild, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, removeChild, arginfo_class_DOMNode_removeChild, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, appendChild, arginfo_class_DOMNode_appendChild, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, hasChildNodes, arginfo_class_DOMNode_hasChildNodes, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, cloneNode, arginfo_class_DOMNode_cloneNode, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, normalize, arginfo_class_DOMNode_normalize, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, isSupported, arginfo_class_DOMNode_isSupported, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, hasAttributes, arginfo_class_DOMNode_hasAttributes, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, isSameNode, arginfo_class_DOMNode_isSameNode, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, lookupPrefix, arginfo_class_DOMNode_lookupPrefix, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, isDefaultNamespace, arginfo_class_DOMNode_isDefaultNamespace, ZEND_ACC_PUBLIC)
+	PHP_ME(domnode, lookupNamespaceURI, arginfo_class_DOMNode_lookupNamespaceUri, ZEND_ACC_PUBLIC)
 	PHP_ME(domnode, getNodePath, arginfo_class_DOMNode_getNodePath, ZEND_ACC_PUBLIC)
 	PHP_ME(domnode, getLineNo, arginfo_class_DOMNode_getLineNo, ZEND_ACC_PUBLIC)
 	PHP_ME(domnode, C14N, arginfo_class_DOMNode_C14N, ZEND_ACC_PUBLIC)
@@ -829,7 +829,7 @@ static xmlNodePtr _php_dom_insert_fragment(xmlNodePtr nodep, xmlNodePtr prevsib,
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-952280727
 Since:
 */
-PHP_FUNCTION(dom_node_insert_before)
+PHP_METHOD(domnode, insertBefore)
 {
 	zval *id, *node, *ref = NULL;
 	xmlNodePtr child, new_child, parentp, refp;
@@ -991,7 +991,7 @@ PHP_FUNCTION(dom_node_insert_before)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-785887307
 Since:
 */
-PHP_FUNCTION(dom_node_replace_child)
+PHP_METHOD(domnode, replaceChild)
 {
 	zval *id, *newnode, *oldnode;
 	xmlNodePtr children, newchild, oldchild, nodep;
@@ -1080,7 +1080,7 @@ PHP_FUNCTION(dom_node_replace_child)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-1734834066
 Since:
 */
-PHP_FUNCTION(dom_node_remove_child)
+PHP_METHOD(domnode, removeChild)
 {
 	zval *id, *node;
 	xmlNodePtr children, child, nodep;
@@ -1132,7 +1132,7 @@ PHP_FUNCTION(dom_node_remove_child)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-184E7107
 Since:
 */
-PHP_FUNCTION(dom_node_append_child)
+PHP_METHOD(domnode, appendChild)
 {
 	zval *id, *node;
 	xmlNodePtr child, nodep, new_child = NULL;
@@ -1234,7 +1234,7 @@ PHP_FUNCTION(dom_node_append_child)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-810594187
 Since:
 */
-PHP_FUNCTION(dom_node_has_child_nodes)
+PHP_METHOD(domnode, hasChildNodes)
 {
 	zval *id;
 	xmlNode *nodep;
@@ -1263,7 +1263,7 @@ PHP_FUNCTION(dom_node_has_child_nodes)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-3A0ED0A4
 Since:
 */
-PHP_FUNCTION(dom_node_clone_node)
+PHP_METHOD(domnode, cloneNode)
 {
 	zval *id;
 	xmlNode *n, *node;
@@ -1325,7 +1325,7 @@ PHP_FUNCTION(dom_node_clone_node)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-normalize
 Since:
 */
-PHP_FUNCTION(dom_node_normalize)
+PHP_METHOD(domnode, normalize)
 {
 	zval *id;
 	xmlNode *nodep;
@@ -1347,7 +1347,7 @@ PHP_FUNCTION(dom_node_normalize)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-Level-2-Core-Node-supports
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_node_is_supported)
+PHP_METHOD(domnode, isSupported)
 {
 	size_t feature_len, version_len;
 	char *feature, *version;
@@ -1368,7 +1368,7 @@ PHP_FUNCTION(dom_node_is_supported)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-NodeHasAttrs
 Since: DOM Level 2
 */
-PHP_FUNCTION(dom_node_has_attributes)
+PHP_METHOD(domnode, hasAttributes)
 {
 	zval *id;
 	xmlNode *nodep;
@@ -1396,7 +1396,7 @@ PHP_FUNCTION(dom_node_has_attributes)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#Node3-isSameNode
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_node_is_same_node)
+PHP_METHOD(domnode, isSameNode)
 {
 	zval *id, *node;
 	xmlNodePtr nodeotherp, nodep;
@@ -1423,7 +1423,7 @@ PHP_FUNCTION(dom_node_is_same_node)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#Node3-lookupNamespacePrefix
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_node_lookup_prefix)
+PHP_METHOD(domnode, lookupPrefix)
 {
 	zval *id;
 	xmlNodePtr nodep, lookupp = NULL;
@@ -1475,7 +1475,7 @@ PHP_FUNCTION(dom_node_lookup_prefix)
 URL: http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-isDefaultNamespace
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_node_is_default_namespace)
+PHP_METHOD(domnode, isDefaultNamespace)
 {
 	zval *id;
 	xmlNodePtr nodep;
@@ -1509,7 +1509,7 @@ PHP_FUNCTION(dom_node_is_default_namespace)
 URL: http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-lookupNamespaceURI
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_node_lookup_namespace_uri)
+PHP_METHOD(domnode, lookupNamespaceURI)
 {
 	zval *id;
 	xmlNodePtr nodep;

--- a/ext/dom/nodelist.c
+++ b/ext/dom/nodelist.c
@@ -32,8 +32,8 @@
 */
 
 const zend_function_entry php_dom_nodelist_class_functions[] = {
-	PHP_FALIAS(item, dom_nodelist_item, arginfo_class_DOMNodeList_item)
-	PHP_FALIAS(count, dom_nodelist_count, arginfo_class_DOMNodeList_count)
+	PHP_ME(domnodelist, item, arginfo_class_DOMNodeList_item, ZEND_ACC_PUBLIC)
+	PHP_ME(domnodelist, count, arginfo_class_DOMNodeList_count, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -91,7 +91,7 @@ int dom_nodelist_length_read(dom_object *obj, zval *retval)
 
 /* {{{ proto int|bool dom_nodelist_count();
 */
-PHP_FUNCTION(dom_nodelist_count)
+PHP_METHOD(domnodelist, count)
 {
 	zval *id;
 	dom_object *intern;
@@ -114,7 +114,7 @@ PHP_FUNCTION(dom_nodelist_count)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#ID-844377136
 Since:
 */
-PHP_FUNCTION(dom_nodelist_item)
+PHP_METHOD(domnodelist, item)
 {
 	zval *id;
 	zend_long index;

--- a/ext/dom/text.c
+++ b/ext/dom/text.c
@@ -33,9 +33,9 @@
 */
 
 const zend_function_entry php_dom_text_class_functions[] = {
-	PHP_FALIAS(splitText, dom_text_split_text, arginfo_class_DOMText_splitText)
-	PHP_FALIAS(isWhitespaceInElementContent, dom_text_is_whitespace_in_element_content, arginfo_class_DOMText_isWhitespaceInElementContent)
-	PHP_FALIAS(isElementContentWhitespace, dom_text_is_whitespace_in_element_content, arginfo_class_DOMText_isElementContentWhitespace)
+	PHP_ME(domtext, splitText, arginfo_class_DOMText_splitText, ZEND_ACC_PUBLIC)
+	PHP_ME(domtext, isWhitespaceInElementContent, arginfo_class_DOMText_isWhitespaceInElementContent, ZEND_ACC_PUBLIC)
+	PHP_MALIAS(domtext, isElementContentWhitespace, isWhitespaceInElementContent, arginfo_class_DOMText_isElementContentWhitespace, ZEND_ACC_PUBLIC)
 	PHP_ME(domtext, __construct, arginfo_class_DOMText___construct, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
@@ -114,7 +114,7 @@ int dom_text_whole_text_read(dom_object *obj, zval *retval)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-38853C1D
 Since:
 */
-PHP_FUNCTION(dom_text_split_text)
+PHP_METHOD(domtext, splitText)
 {
 	zval       *id;
 	xmlChar    *cur;
@@ -176,7 +176,7 @@ PHP_FUNCTION(dom_text_split_text)
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-Text3-isWhitespaceInElementContent
 Since: DOM Level 3
 */
-PHP_FUNCTION(dom_text_is_whitespace_in_element_content)
+PHP_METHOD(domtext, isWhitespaceInElementContent)
 {
 	zval       *id;
 	xmlNodePtr  node;

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -35,10 +35,10 @@
 
 const zend_function_entry php_dom_xpath_class_functions[] = {
 	PHP_ME(domxpath, __construct, arginfo_class_DOMXPath___construct, ZEND_ACC_PUBLIC)
-	PHP_FALIAS(registerNamespace, dom_xpath_register_ns, arginfo_class_DOMXPath_registerNamespace)
-	PHP_FALIAS(query, dom_xpath_query, arginfo_class_DOMXPath_query)
-	PHP_FALIAS(evaluate, dom_xpath_evaluate, arginfo_class_DOMXPath_evaluate)
-	PHP_FALIAS(registerPhpFunctions, dom_xpath_register_php_functions, arginfo_class_DOMXPath_registerPhpFunctions)
+	PHP_ME(domxpath, registerNamespace, arginfo_class_DOMXPath_registerNamespace, ZEND_ACC_PUBLIC)
+	PHP_ME(domxpath, query, arginfo_class_DOMXPath_query, ZEND_ACC_PUBLIC)
+	PHP_ME(domxpath, evaluate, arginfo_class_DOMXPath_evaluate, ZEND_ACC_PUBLIC)
+	PHP_ME(domxpath, registerPhpFunctions, arginfo_class_DOMXPath_registerPhpFunctions, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -302,7 +302,7 @@ int dom_xpath_register_node_ns_write(dom_object *obj, zval *newval)
 /* }}} */
 
 /* {{{ proto bool dom_xpath_register_ns(string prefix, string uri) */
-PHP_FUNCTION(dom_xpath_register_ns)
+PHP_METHOD(domxpath, registerNamespace)
 {
 	zval *id;
 	xmlXPathContextPtr ctxp;
@@ -487,21 +487,21 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type) /* {{{ */
 /* }}} */
 
 /* {{{ proto DOMNodeList dom_xpath_query(string expr [,DOMNode context [, bool registerNodeNS]]) */
-PHP_FUNCTION(dom_xpath_query)
+PHP_METHOD(domxpath, query)
 {
 	php_xpath_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_DOM_XPATH_QUERY);
 }
 /* }}} end dom_xpath_query */
 
 /* {{{ proto mixed dom_xpath_evaluate(string expr [,DOMNode context [, bool registerNodeNS]]) */
-PHP_FUNCTION(dom_xpath_evaluate)
+PHP_METHOD(domxpath, evaluate)
 {
 	php_xpath_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_DOM_XPATH_EVALUATE);
 }
 /* }}} end dom_xpath_evaluate */
 
 /* {{{ proto void dom_xpath_register_php_functions() */
-PHP_FUNCTION(dom_xpath_register_php_functions)
+PHP_METHOD(domxpath, registerPhpFunctions)
 {
 	zval *id;
 	dom_xpath_object *intern;


### PR DESCRIPTION
This is a cleanup as ext/dom uses PHP_FALIAS before and declared functions that were not visible to userland via the exported functions of dom extension.