### PR TITLE
Improve performance of ZEND_IS_IDENTICAL

### DIFF
--- a/Zend/tests/bug70785.phpt
+++ b/Zend/tests/bug70785.phpt
@@ -24,6 +24,11 @@ try  {
 	undefined_function();
 } catch (Exception $e) {
 }
+try  {
+	$h !== $g; // ZEND_VM_NEXT_OPCODE
+	undefined_function();
+} catch (Exception $e) {
+}
 ?>
 okey
 --EXPECT--

--- a/Zend/tests/bug70785.phpt
+++ b/Zend/tests/bug70785.phpt
@@ -19,6 +19,11 @@ try  {
 	undefined_function();
 } catch (Exception $e) {
 }
+try  {
+	$d === $f; // ZEND_VM_NEXT_OPCODE
+	undefined_function();
+} catch (Exception $e) {
+}
 ?>
 okey
 --EXPECT--

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2118,6 +2118,12 @@ ZEND_API zend_bool ZEND_FASTCALL zend_is_identical(zval *op1, zval *op2) /* {{{ 
 }
 /* }}} */
 
+ZEND_API zend_bool ZEND_FASTCALL zend_is_identical_array(HashTable *h1, HashTable *h2) /* {{{ */
+{
+    return (h1 == h2 ||
+        zend_hash_compare(h1, h2, (compare_func_t) hash_zval_identical_function, 1) == 0);
+}
+
 ZEND_API int ZEND_FASTCALL is_identical_function(zval *result, zval *op1, zval *op2) /* {{{ */
 {
 	ZVAL_BOOL(result, zend_is_identical(op1, op2));

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -55,6 +55,7 @@ ZEND_API int ZEND_FASTCALL shift_right_function(zval *result, zval *op1, zval *o
 ZEND_API int ZEND_FASTCALL concat_function(zval *result, zval *op1, zval *op2);
 
 ZEND_API zend_bool ZEND_FASTCALL zend_is_identical(zval *op1, zval *op2);
+ZEND_API zend_bool ZEND_FASTCALL zend_is_identical_array(HashTable *h1, HashTable *h2);
 
 ZEND_API int ZEND_FASTCALL is_equal_function(zval *result, zval *op1, zval *op2);
 ZEND_API int ZEND_FASTCALL is_identical_function(zval *result, zval *op1, zval *op2);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -484,7 +484,6 @@ ZEND_VM_C_LABEL(compare_values_any_type):
 		FREE_OP1();
 		FREE_OP2();
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 ZEND_VM_C_LABEL(compare_values):
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -493,14 +492,12 @@ ZEND_VM_C_LABEL(compare_values):
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		FREE_OP1();
 		FREE_OP2();
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -588,7 +585,6 @@ ZEND_VM_C_LABEL(compare_values_any_type):
 		FREE_OP1();
 		FREE_OP2();
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 ZEND_VM_C_LABEL(compare_values):
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -597,14 +593,12 @@ ZEND_VM_C_LABEL(compare_values):
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		FREE_OP1();
 		FREE_OP2();
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -487,7 +487,7 @@ ZEND_VM_C_LABEL(compare_values_any_type):
 	}
 ZEND_VM_C_LABEL(compare_values):
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((OP1_TYPE & IS_CV) || (OP2_TYPE & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((OP1_TYPE & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((OP2_TYPE & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -588,7 +588,7 @@ ZEND_VM_C_LABEL(compare_values_any_type):
 	}
 ZEND_VM_C_LABEL(compare_values):
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((OP1_TYPE & IS_CV) || (OP2_TYPE & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((OP1_TYPE & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((OP2_TYPE & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -4796,7 +4796,6 @@ compare_values_any_type:
 
 
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -4805,14 +4804,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -4900,7 +4897,6 @@ compare_values_any_type:
 
 
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -4909,14 +4905,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -18010,7 +18004,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -18019,14 +18012,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -18114,7 +18105,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -18123,14 +18113,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -18989,7 +18977,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -18998,14 +18985,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -19093,7 +19078,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -19102,14 +19086,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -21376,7 +21358,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -21385,14 +21366,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -21480,7 +21459,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -21489,14 +21467,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -25925,7 +25901,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -25934,14 +25909,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -26029,7 +26002,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -26038,14 +26010,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -26173,7 +26143,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -26182,14 +26151,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -26277,7 +26244,6 @@ compare_values_any_type:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -26286,14 +26252,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -37830,7 +37794,6 @@ compare_values_any_type:
 
 
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -37839,14 +37802,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -37934,7 +37895,6 @@ compare_values_any_type:
 
 
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -37943,14 +37903,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -44486,7 +44444,6 @@ compare_values_any_type:
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -44495,14 +44452,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -44590,7 +44545,6 @@ compare_values_any_type:
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -44599,14 +44553,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -44734,7 +44686,6 @@ compare_values_any_type:
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -44743,14 +44694,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -44838,7 +44787,6 @@ compare_values_any_type:
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -44847,14 +44795,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -46567,7 +46513,6 @@ compare_values_any_type:
 
 
 		ZEND_VM_SMART_BRANCH(0, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -46576,14 +46521,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(1, 1);
-			return;
 		}
 		/* They are identical, return true */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 
 		ZEND_VM_SMART_BRANCH(1, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:
@@ -46671,7 +46614,6 @@ compare_values_any_type:
 
 
 		ZEND_VM_SMART_BRANCH(1, 1);
-		return;
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
@@ -46680,14 +46622,12 @@ compare_values:
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
 			ZEND_VM_SMART_BRANCH(0, 1);
-			return;
 		}
 		/* They are identical, return false. */
 		/* This has to check for undefined variable errors when IS_UNDEF is possible. (only warns for IS_CV) */
 
 
 		ZEND_VM_SMART_BRANCH(0, 0);
-		return;
 	}
 	switch (Z_TYPE_P(op1)) {
 		case IS_LONG:

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -4799,7 +4799,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CONST & IS_CV) || (IS_CONST & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -4900,7 +4900,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CONST & IS_CV) || (IS_CONST & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -18007,7 +18007,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_TMP_VAR & IS_CV) || (IS_CONST & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -18108,7 +18108,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_TMP_VAR & IS_CV) || (IS_CONST & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -18980,7 +18980,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_TMP_VAR & IS_CV) || (IS_TMP_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -19081,7 +19081,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_TMP_VAR & IS_CV) || (IS_TMP_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -21361,7 +21361,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_VAR & IS_CV) || (IS_CONST & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -21462,7 +21462,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_VAR & IS_CV) || (IS_CONST & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -25904,7 +25904,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_VAR & IS_CV) || (IS_TMP_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -26005,7 +26005,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_VAR & IS_CV) || (IS_TMP_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -26146,7 +26146,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_VAR & IS_CV) || (IS_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -26247,7 +26247,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_VAR & IS_CV) || (IS_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -37797,7 +37797,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CV & IS_CV) || (IS_CONST & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -37898,7 +37898,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CV & IS_CV) || (IS_CONST & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CONST & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -44447,7 +44447,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CV & IS_CV) || (IS_TMP_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -44548,7 +44548,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CV & IS_CV) || (IS_TMP_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_TMP_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -44689,7 +44689,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CV & IS_CV) || (IS_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -44790,7 +44790,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CV & IS_CV) || (IS_VAR & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_VAR & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -46516,7 +46516,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CV & IS_CV) || (IS_CV & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();
@@ -46617,7 +46617,7 @@ compare_values_any_type:
 	}
 compare_values:
 	if (Z_TYPE_P(op1) <= IS_TRUE) {
-		if (((IS_CV & IS_CV) || (IS_CV & IS_CV)) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) {
+		if (((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op1) == IS_UNDEF)) || ((IS_CV & IS_CV) && UNEXPECTED(Z_TYPE_P(op2) == IS_UNDEF))) {
 			/* They are both undefined - fetch them to emit the undefined variable warnings. */
 			op1 = ZVAL_UNDEFINED_OP1();
 			op2 = ZVAL_UNDEFINED_OP2();


### PR DESCRIPTION
And for ZEND_IS_NOT_IDENTICAL.

- Take advantage of branch prediction in cases that are false/true
- Avoid function call and duplicate fetches of Z_TYPE_P in common use cases
- Avoid checking for EG(exception) when it's impossible.

  I think that the zval would always be IS_NULL or lower for an exception,
  but may be wrong.

Aside 1: I see that ZEND_IS_EQUAL does have the `SMART_BRANCH` in the
`SPEC`, generating optimized implementations based on what type of smart
branch is used. Is excluding SMART_BRANCH from ZEND_IS_IDENTICAL deliberate,
and if so, what's the reasoning?

Aside 2: The function pointer for ZEND_IS_EQUAL_LONG can probably be used
directly for ZEND_IS_IDENTICAL_LONG. I'm not sure how to generate that.
(and DOUBLE)

The amount of time for nestedloop_ni(20) decreased from 0.726s to
0.593s due to this change.
This is still worse than `!=` (0.434) and `<` (0.375), which
have implementations that take advantage of branch prediction for
IS_LONG (i.e. `EXPECTED` blocks)

- Still 0.593 after the latest patch

```php
function nestedloop_ni($n) {
  $x = 0;
  for ($a=0; $a!==$n; $a++)
    for ($b=0; $b!==$n; $b++)
      for ($c=0; $c!==$n; $c++)
        for ($d=0; $d!==$n; $d++)
          for ($e=0; $e!==$n; $e++)
            for ($f=0; $f!==$n; $f++)
             $x++;
  print "$x\n";
}
```