### PR TITLE
Optimize $a = !is_string($x) in opcache

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -503,6 +503,19 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 								MAKE_NOP(opline);
 								++(*opt_count);
 								break;
+							case ZEND_TYPE_CHECK:
+								if (opline->opcode == ZEND_BOOL_NOT) {
+									if (src->extended_value == MAY_BE_RESOURCE || src->extended_value == (MAY_BE_ANY - MAY_BE_RESOURCE)) {
+										/* is_resource() is a special case - it returns false if the resource is closed. Don't convert to/from it. */
+										break;
+									}
+									src->extended_value = MAY_BE_ANY - src->extended_value;
+								}
+								COPY_NODE(src->result, opline->result);
+								SET_VAR_SOURCE(src);
+								MAKE_NOP(opline);
+								++(*opt_count);
+								break;
 							case ZEND_IS_SMALLER:
 								if (opline->opcode == ZEND_BOOL_NOT) {
 									zend_uchar tmp_type;
@@ -545,7 +558,6 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 							case ZEND_ISSET_ISEMPTY_PROP_OBJ:
 							case ZEND_ISSET_ISEMPTY_STATIC_PROP:
 							case ZEND_INSTANCEOF:
-							case ZEND_TYPE_CHECK:
 							case ZEND_DEFINED:
 							case ZEND_IN_ARRAY:
 							case ZEND_ARRAY_KEY_EXISTS:

--- a/Zend/Optimizer/sccp.c
+++ b/Zend/Optimizer/sccp.c
@@ -1003,7 +1003,7 @@ static void sccp_visit_instr(scdf_ctx *scdf, zend_op *opline, zend_ssa_op *ssa_o
 					SET_RESULT(result, &zv);
 					return;
 				} else if (!(type & ((MAY_BE_ANY|MAY_BE_UNDEF) - expected_type_mask))
-						   && !(expected_type_mask & MAY_BE_RESOURCE)) {
+						   && !(type & expected_type_mask & MAY_BE_RESOURCE)) {
 					ZVAL_TRUE(&zv);
 					SET_RESULT(result, &zv);
 					return;

--- a/ext/opcache/tests/opt/sccp_026.phpt
+++ b/ext/opcache/tests/opt/sccp_026.phpt
@@ -30,8 +30,8 @@ test:
      ; (after optimizer)
      ; %s:2-8
 0000 CV0($var) = RECV 1
-0001 T2 = TYPE_CHECK (string) CV0($var)
-0002 JMPZ T2 0004
+0001 T2 = TYPE_CHECK TYPE [null, bool, long, double, array, object, resource] CV0($var)
+0002 JMPNZ T2 0004
 0003 JMP 0005
 0004 RETURN null
 0005 INIT_FCALL 1 %d string("var_dump")


### PR DESCRIPTION
This will also optimize `return is_int($x) == false`

This replaces the bit set of TYPE_CHECK with the opposite when it is
safe to do so. This is related to 36afe4e39ec724eab19c54c1492db030721d0ec1

This does not optimize `is_string($x) === false` (IS_IDENTICAL)
- A followup commit could be made to optimize that case. (two consecutive TYPE_CHECKs, the latter for false)
- I don't know which other opcodes would definitely only return booleans. ( I guess the block of case statements where TYPE_CHECK was would be a good start)

A contrived example demonstrating the improvement:

    function loop_is_float($a, $b) {
      $values = [];
      for ($i = $a; $i < $b; $i++) {
	  $values[!is_float($i)] = true;
      }
      return $values;
    }
    loop_is_float(0, 20000000);
    // runtime decreases from 0.346 to 0.316 with opcache.enable_cli=1