### PR TITLE
Fix #78808: [LMDB] MDB_MAP_FULL: Environment mapsize limit reached

### DIFF
--- a/ext/dba/tests/bug78808.phpt
+++ b/ext/dba/tests/bug78808.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug #78808 ([LMDB] MDB_MAP_FULL: Environment mapsize limit reached)
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+$handler = 'lmdb';
+require_once __DIR__ .'/skipif.inc';
+?>
+--FILE--
+<?php
+$handler = 'lmdb';
+require_once __DIR__ .'/test.inc';
+$lmdb_h = dba_open($db_filename, 'c', 'lmdb', 0644, 5*1048576);
+for ($i = 0; $i < 50000; $i++) {
+    dba_insert('key' . $i, 'value '. $i, $lmdb_h);
+}
+dba_close($lmdb_h);
+echo "done\n";
+?>
+--EXPECT--
+done
+--CLEAN--
+<?php
+require_once dirname(__FILE__) .'/clean.inc';
+?>


### PR DESCRIPTION
We implement support for a fifth parameter, which allows to specify the
mapsize.  The parameter defaults to zero, in which case the compiled in
default mapsize (usually 1048576) will be used.  The mapsize should be
a multiple of the page size of the OS.

---

I'm not really happy with this solution. I would have preferred to introduce an option array, but all driver specific parameters are converted to string (why?), so that's not possible, even though it might bite us when we may want to add support for further `mdb_env_set_*()` functions.

Furthermore, I'm not sure which version to target. I think not being able to specify the mapsize is a bug, because the default mapsize is pretty small, but am uncomfortable to fix it this late for PHP 7.2, so I've targeted 7.3.