### PR TITLE
Avoid branches in ZEND_BOOL/ZEND_BOOL_NOT

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -937,22 +937,21 @@ ZEND_VM_COLD_CONST_HANDLER(14, ZEND_BOOL_NOT, CONST|TMPVAR|CV, ANY)
 	zval *val;
 
 	val = GET_OP1_ZVAL_PTR_UNDEF(BP_VAR_R);
-	if (Z_TYPE_INFO_P(val) == IS_TRUE) {
-		ZVAL_FALSE(EX_VAR(opline->result.var));
-	} else if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
-		ZVAL_TRUE(EX_VAR(opline->result.var));
+	if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
 		if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(val) == IS_UNDEF)) {
+			ZVAL_TRUE(EX_VAR(opline->result.var));
 			SAVE_OPLINE();
 			ZVAL_UNDEFINED_OP1();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
+		ZVAL_BOOL(EX_VAR(opline->result.var), Z_TYPE_INFO_P(val) < IS_TRUE);
+		ZEND_VM_NEXT_OPCODE();
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), !i_zend_is_true(val));
 		FREE_OP1();
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
-	ZEND_VM_NEXT_OPCODE();
 }
 
 ZEND_VM_COLD_HELPER(zend_this_not_in_object_context_helper, ANY, ANY)
@@ -1496,7 +1495,7 @@ ZEND_VM_HELPER(zend_pre_dec_helper, VAR|CV, ANY)
 
 	SAVE_OPLINE();
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);		
+		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
 	}
 
@@ -2234,7 +2233,7 @@ ZEND_VM_C_LABEL(fetch_obj_is_fast_copy):
 		}
 
 		retval = zobj->handlers->read_property(zobj, name, BP_VAR_IS, cache_slot, EX_VAR(opline->result.var));
- 
+
 		if (OP2_TYPE != IS_CONST) {
 			zend_tmp_string_release(tmp_name);
 		}
@@ -5118,22 +5117,21 @@ ZEND_VM_COLD_CONST_HANDLER(52, ZEND_BOOL, CONST|TMPVAR|CV, ANY)
 	zval *val;
 
 	val = GET_OP1_ZVAL_PTR_UNDEF(BP_VAR_R);
-	if (Z_TYPE_INFO_P(val) == IS_TRUE) {
-		ZVAL_TRUE(EX_VAR(opline->result.var));
-	} else if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
-		ZVAL_FALSE(EX_VAR(opline->result.var));
+	if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
 		if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(val) == IS_UNDEF)) {
+			ZVAL_FALSE(EX_VAR(opline->result.var));
 			SAVE_OPLINE();
 			ZVAL_UNDEFINED_OP1();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
+		ZVAL_BOOL(EX_VAR(opline->result.var), Z_TYPE_INFO_P(val) == IS_TRUE);
+		ZEND_VM_NEXT_OPCODE();
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), i_zend_is_true(val));
 		FREE_OP1();
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
-	ZEND_VM_NEXT_OPCODE();
 }
 
 ZEND_VM_HELPER(zend_case_helper, ANY, ANY, zval *op_1, zval *op_2)
@@ -5528,10 +5526,10 @@ ZEND_VM_HANDLER(147, ZEND_ADD_ARRAY_UNPACK, ANY, ANY)
 {
 	USE_OPLINE
 	zval *op1;
-	
+
 	SAVE_OPLINE();
 	op1 = GET_OP1_ZVAL_PTR(BP_VAR_R);
-	
+
 ZEND_VM_C_LABEL(add_unpack_again):
 	if (EXPECTED(Z_TYPE_P(op1) == IS_ARRAY)) {
 		HashTable *ht = Z_ARRVAL_P(op1);
@@ -5572,11 +5570,11 @@ ZEND_VM_C_LABEL(add_unpack_again):
 				}
 				HANDLE_EXCEPTION();
 			}
-			
+
 			if (iter->funcs->rewind) {
 				iter->funcs->rewind(iter);
 			}
-			
+
 			for (; iter->funcs->valid(iter) == SUCCESS; ) {
 				zval *val;
 
@@ -5625,7 +5623,7 @@ ZEND_VM_C_LABEL(add_unpack_again):
 	} else {
 		zend_throw_error(NULL, "Only arrays and Traversables can be unpacked");
 	}
-	
+
 	FREE_OP1();
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3181,22 +3181,21 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_BOOL_NOT_SPEC_CON
 	zval *val;
 
 	val = RT_CONSTANT(opline, opline->op1);
-	if (Z_TYPE_INFO_P(val) == IS_TRUE) {
-		ZVAL_FALSE(EX_VAR(opline->result.var));
-	} else if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
-		ZVAL_TRUE(EX_VAR(opline->result.var));
+	if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
 		if (IS_CONST == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(val) == IS_UNDEF)) {
+			ZVAL_TRUE(EX_VAR(opline->result.var));
 			SAVE_OPLINE();
 			ZVAL_UNDEFINED_OP1();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
+		ZVAL_BOOL(EX_VAR(opline->result.var), Z_TYPE_INFO_P(val) < IS_TRUE);
+		ZEND_VM_NEXT_OPCODE();
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), !i_zend_is_true(val));
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
-	ZEND_VM_NEXT_OPCODE();
 }
 
 static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ECHO_SPEC_CONST_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
@@ -3750,22 +3749,21 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_BOOL_SPEC_CONST_H
 	zval *val;
 
 	val = RT_CONSTANT(opline, opline->op1);
-	if (Z_TYPE_INFO_P(val) == IS_TRUE) {
-		ZVAL_TRUE(EX_VAR(opline->result.var));
-	} else if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
-		ZVAL_FALSE(EX_VAR(opline->result.var));
+	if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
 		if (IS_CONST == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(val) == IS_UNDEF)) {
+			ZVAL_FALSE(EX_VAR(opline->result.var));
 			SAVE_OPLINE();
 			ZVAL_UNDEFINED_OP1();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
+		ZVAL_BOOL(EX_VAR(opline->result.var), Z_TYPE_INFO_P(val) == IS_TRUE);
+		ZEND_VM_NEXT_OPCODE();
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), i_zend_is_true(val));
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
-	ZEND_VM_NEXT_OPCODE();
 }
 
 static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CLONE_SPEC_CONST_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
@@ -12641,22 +12639,21 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_BOOL_NOT_SPEC_TMPVAR_HANDLER(Z
 	zval *val;
 
 	val = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
-	if (Z_TYPE_INFO_P(val) == IS_TRUE) {
-		ZVAL_FALSE(EX_VAR(opline->result.var));
-	} else if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
-		ZVAL_TRUE(EX_VAR(opline->result.var));
+	if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
 		if ((IS_TMP_VAR|IS_VAR) == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(val) == IS_UNDEF)) {
+			ZVAL_TRUE(EX_VAR(opline->result.var));
 			SAVE_OPLINE();
 			ZVAL_UNDEFINED_OP1();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
+		ZVAL_BOOL(EX_VAR(opline->result.var), Z_TYPE_INFO_P(val) < IS_TRUE);
+		ZEND_VM_NEXT_OPCODE();
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), !i_zend_is_true(val));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
-	ZEND_VM_NEXT_OPCODE();
 }
 
 static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ECHO_SPEC_TMPVAR_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
@@ -12943,22 +12940,21 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_BOOL_SPEC_TMPVAR_HANDLER(ZEND_
 	zval *val;
 
 	val = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
-	if (Z_TYPE_INFO_P(val) == IS_TRUE) {
-		ZVAL_TRUE(EX_VAR(opline->result.var));
-	} else if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
-		ZVAL_FALSE(EX_VAR(opline->result.var));
+	if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
 		if ((IS_TMP_VAR|IS_VAR) == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(val) == IS_UNDEF)) {
+			ZVAL_FALSE(EX_VAR(opline->result.var));
 			SAVE_OPLINE();
 			ZVAL_UNDEFINED_OP1();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
+		ZVAL_BOOL(EX_VAR(opline->result.var), Z_TYPE_INFO_P(val) == IS_TRUE);
+		ZEND_VM_NEXT_OPCODE();
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), i_zend_is_true(val));
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
-	ZEND_VM_NEXT_OPCODE();
 }
 
 static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CLONE_SPEC_TMPVAR_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
@@ -34894,22 +34890,21 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_BOOL_NOT_SPEC_CV_HANDLER(ZEND_
 	zval *val;
 
 	val = EX_VAR(opline->op1.var);
-	if (Z_TYPE_INFO_P(val) == IS_TRUE) {
-		ZVAL_FALSE(EX_VAR(opline->result.var));
-	} else if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
-		ZVAL_TRUE(EX_VAR(opline->result.var));
+	if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
 		if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(val) == IS_UNDEF)) {
+			ZVAL_TRUE(EX_VAR(opline->result.var));
 			SAVE_OPLINE();
 			ZVAL_UNDEFINED_OP1();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
+		ZVAL_BOOL(EX_VAR(opline->result.var), Z_TYPE_INFO_P(val) < IS_TRUE);
+		ZEND_VM_NEXT_OPCODE();
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), !i_zend_is_true(val));
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
-	ZEND_VM_NEXT_OPCODE();
 }
 
 static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_inc_helper_SPEC_CV(ZEND_OPCODE_HANDLER_ARGS)
@@ -35730,22 +35725,21 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_BOOL_SPEC_CV_HANDLER(ZEND_OPCO
 	zval *val;
 
 	val = EX_VAR(opline->op1.var);
-	if (Z_TYPE_INFO_P(val) == IS_TRUE) {
-		ZVAL_TRUE(EX_VAR(opline->result.var));
-	} else if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
-		ZVAL_FALSE(EX_VAR(opline->result.var));
+	if (EXPECTED(Z_TYPE_INFO_P(val) <= IS_TRUE)) {
 		if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(val) == IS_UNDEF)) {
+			ZVAL_FALSE(EX_VAR(opline->result.var));
 			SAVE_OPLINE();
 			ZVAL_UNDEFINED_OP1();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
+		ZVAL_BOOL(EX_VAR(opline->result.var), Z_TYPE_INFO_P(val) == IS_TRUE);
+		ZEND_VM_NEXT_OPCODE();
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), i_zend_is_true(val));
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
-	ZEND_VM_NEXT_OPCODE();
 }
 
 static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CLONE_SPEC_CV_HANDLER(ZEND_OPCODE_HANDLER_ARGS)


### PR DESCRIPTION
gcc 5/9 will add 2 (IS_FALSE) to the boolean result of 1/0 to compute
the value to store for the ZVAL_BOOL call.

Additionally, this puts all of the reads of Z_TYPE_INFO_P before writes
to memory (ZVAL_BOOL),
so that php doesn't have to load from memory into a register again.

(gcc 5 would use branches for evaluating ZVAL_BOOL if ZVAL_BOOL was
executed before comparing against IS_UNDEF)

A contrived example heavily using ZVAL_BOOL with poor branch prediction

```php
// With gcc 9, cpufreq 2.5GZ
// before: 0.305 seconds with 1000, 10000
// after   0.286 seconds with 1000, 10000
function loop_bool_not(int $a, int $b) {
  srand($a);
  $values = [];
  for ($i = 0; $i < $a; $i++) {
    $values[] = (bool)(\rand() & 1);
  }
  $count = [];
  for ($i = 0; $i < $b; $i++) {
    foreach ($values as $v) {
      $count[!$v]++;
    }
  }
  return $count;
}
```

The true then falsey check was first added in
e6180ebb640408c7ded804f5f65282122a059ddb

Miscellaneous thoughts:
- extremely predictable loops might perform worse due to extra instructions - real use cases are hopefully not like that
- this should benefit non-bool cases such as `return !$int` slightly due to one less comparison (SCCP and opcache help remove this opcode for obvious booleans such as `(bool)is_string($x)`)

Before:
```asm
00000000006b1600 <ZEND_BOOL_SPEC_CV_HANDLER>:
  6b1600:	53                   	push   rbx
  6b1601:	49 63 7f 08          	movsxd rdi,DWORD PTR [r15+0x8]
  6b1605:	4c 01 f7             	add    rdi,r14
  6b1608:	83 7f 08 03          	cmp    DWORD PTR [rdi+0x8],0x3 -- This loads Z_TYPE_INFO_P the first time
  6b160c:	74 22                	je     6b1630 <ZEND_BOOL_SPEC_CV_HANDLER+0x30> -- this compares == IS_TRUE and jumps
  6b160e:	77 30                	ja     6b1640 <ZEND_BOOL_SPEC_CV_HANDLER+0x40> -- this jumps for > IS_TRUE
  6b1610:	49 63 47 10          	movsxd rax,DWORD PTR [r15+0x10]
  6b1614:	41 c7 44 06 08 02 00 	mov    DWORD PTR [r14+rax*1+0x8],0x2 -- This stores IS_FALSE into the return value
  6b161b:	00 00 
  6b161d:	8b 4f 08             	mov    ecx,DWORD PTR [rdi+0x8] -- This loads Z_TYPE_INFO_P from RAM a second time
  6b1620:	85 c9                	test   ecx,ecx
  6b1622:	74 44                	je     6b1668 <ZEND_BOOL_SPEC_CV_HANDLER+0x68>
  6b1624:	49 83 c7 20          	add    r15,0x20
  6b1628:	5b                   	pop    rbx
  6b1629:	c3                   	ret 
... the rest of the instructions are left out - 
```

After:
```asm
00000000006b1660 <ZEND_BOOL_SPEC_CV_HANDLER>:
  6b1660:	55                   	push   rbp
  6b1661:	53                   	push   rbx
  6b1662:	48 83 ec 08          	sub    rsp,0x8
  6b1666:	49 63 7f 08          	movsxd rdi,DWORD PTR [r15+0x8]
  6b166a:	4c 01 f7             	add    rdi,r14
  6b166d:	8b 47 08             	mov    eax,DWORD PTR [rdi+0x8]
  6b1670:	83 f8 03             	cmp    eax,0x3
  6b1673:	77 2b                	ja     6b16a0 <ZEND_BOOL_SPEC_CV_HANDLER+0x40>  -- this jumps for > IS_BOOL
  6b1675:	85 c0                	test   eax,eax
  6b1677:	74 4f                	je     6b16c8 <ZEND_BOOL_SPEC_CV_HANDLER+0x68> -- this jumps for IS_UNDEF
  6b1679:	49 63 4f 10          	movsxd rcx,DWORD PTR [r15+0x10]
  6b167d:	83 f8 03             	cmp    eax,0x3 -- this computes IS_FALSE or IS_TRUE without branching
  6b1680:	be 02 00 00 00       	mov    esi,0x2
  6b1685:	0f 45 c6             	cmovne eax,esi
  6b1688:	4d 8d 7f 20          	lea    r15,[r15+0x20]
  6b168c:	41 89 44 0e 08       	mov    DWORD PTR [r14+rcx*1+0x8],eax
  6b1691:	48 83 c4 08          	add    rsp,0x8
  6b1695:	5b                   	pop    rbx
  6b1696:	5d                   	pop    rbp
  6b1697:	c3                   	ret    
... the rest of the instructions are left out - 
```