### PR TITLE
Firebird PDO preprocessing sql

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -362,7 +362,7 @@ int preprocess(const char* sql, int sql_len, char* sql_out, HashTable* named_par
 				++pindex;
 				unsigned int l = p - start;
 				/* check the length of the identifier */
-			    /* in Firebird 4.0 it is 63 characters, in previous versions 31 bytes */
+				/* in Firebird 4.0 it is 63 characters, in previous versions 31 bytes */
 				/* + symbol ":" */
 				if (l > 253) {
 					return 0;
@@ -435,8 +435,6 @@ void _firebird_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, char const *file, zend_lo
 /* }}} */
 
 #define RECORD_ERROR(dbh) _firebird_error(dbh, NULL, __FILE__, __LINE__)
-
-
 
 /* called by PDO to close a db handle */
 static int firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */

--- a/ext/pdo_firebird/tests/execute_block.phpt
+++ b/ext/pdo_firebird/tests/execute_block.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PDO_Firebird: support 1 sql dialect
+PDO_Firebird: support EXECUTE BLOCK
 --SKIPIF--
 <?php require('skipif.inc'); 	
 ?>

--- a/ext/pdo_firebird/tests/execute_block.phpt
+++ b/ext/pdo_firebird/tests/execute_block.phpt
@@ -1,0 +1,41 @@
+--TEST--
+PDO_Firebird: support 1 sql dialect
+--SKIPIF--
+<?php require('skipif.inc'); 	
+?>
+--FILE--
+<?php
+	require("testdb.inc");
+
+	$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+
+	$sql = '
+execute block (a int = :e, b int = :d)
+returns (N int, M int)
+as
+declare z int;
+begin
+  select 10
+  from rdb$database
+  into :z;
+  
+  n = a + b + z;
+  m = z * a;
+  suspend;
+end	
+';
+	$query = $dbh->prepare($sql);
+	$query->execute(['d' => 1, 'e' => 2]);
+	$row = $query->fetch(\PDO::FETCH_OBJ);
+	var_dump($row->N);
+	var_dump($row->M);
+
+	unset($query);
+	unset($dbh);
+	echo "done\n";
+
+?>
+--EXPECT--
+int(13)
+int(20)
+done

--- a/ext/pdo_firebird/tests/ignore_parammarks.phpt
+++ b/ext/pdo_firebird/tests/ignore_parammarks.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PDO_Firebird: support 1 sql dialect
+PDO_Firebird: ingnore parameter marks in comments
 --SKIPIF--
 <?php require('skipif.inc'); 	
 ?>

--- a/ext/pdo_firebird/tests/ignore_parammarks.phpt
+++ b/ext/pdo_firebird/tests/ignore_parammarks.phpt
@@ -1,0 +1,42 @@
+--TEST--
+PDO_Firebird: support 1 sql dialect
+--SKIPIF--
+<?php require('skipif.inc'); 	
+?>
+--FILE--
+<?php
+	require("testdb.inc");
+
+	$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+
+	$sql = '
+select 1 as n
+-- :f
+from rdb$database 
+where 1=:d and 2=:e	
+';
+	$query = $dbh->prepare($sql);
+	$query->execute(['d' => 1, 'e' => 2]);
+	$row = $query->fetch(\PDO::FETCH_OBJ);
+	var_dump($row->N);
+	unset($query);
+
+	$sql = '
+select 1 as n
+from rdb$database 
+where 1=:d /* and :f = 5 */ and 2=:e	
+';
+	$query = $dbh->prepare($sql);
+	$query->execute(['d' => 1, 'e' => 2]);
+	$row = $query->fetch(\PDO::FETCH_OBJ);
+	var_dump($row->N);
+	unset($query);	
+	
+	unset($dbh);
+	echo "done\n";
+
+?>
+--EXPECT--
+int(1)
+int(1)
+done


### PR DESCRIPTION
This patch fixes some problems with preprocessing SQL queries.

1. The new algorithm takes into account single-line and multi-line comments and ignores the ":" and "?" Parameter markers in them.
2. The algorithm allows the EXECUTE BLOCK statement to be processed correctly. For this statement, it is necessary to search for parameter markers between EXECUTE BLOCK and AS, the rest should be left as is.

These problems are also described in https://bugs.php.net/bug.php?id=64937

The code below clearly shows the problems described.

```php
<?php

$sqls = [
    [
	[
	'sql' => '
select 1 as n
-- :f
from rdb$database 
where 1=:d and 2=:e /* and 3=:c */
',
    'params' => ['d' => 1, 'e' => 2]
	],

	[
	'sql' => '
execute block (a int = :e, b int = :d)
returns (n int)
as
declare z int;
begin
  select 10
  from rdb$database
  into :z;
  
  n = a + b + z;
  suspend;
end
',

    'params' => ['d' => 1, 'e' => 2]
	]	
];

try {
	$dsn = 'firebird:dbname=localhost:test';
	$user = 'SYSDBA';
	$password = 'masterkey';
	$att = new \PDO($dsn, $user, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
	
	foreach($sqls as $info) {
	   $sql = $info['sql'];
	   $query = $att->prepare($sql);
	   $query->execute($info['params']);	
	
	
	   $rows = $query->fetchAll(\PDO::FETCH_OBJ);
	   $json = json_encode($rows, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
	   echo "<pre>$json</pre>";
	}
}
catch(\Throwable $e) {
	echo $e->getMessage() . '<br>';
	echo '<pre>' . $e->getTraceAsString() . '</pre>';
}
```

The SQL preprocessing code has been ported from Firebird to handle EXECUTE STATEMENT. See Statement::preprocess() and getToken() https://github.com/FirebirdSQL/firebird/blob/master/src/jrd/extds/ExtDS.cpp#L1928 to 2166