### PR TITLE
Fix #78814: strip_tags allows / in tag name => whitelist bypass

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4663,7 +4663,7 @@ int php_tag_find(char *tag, size_t len, const char *set) {
 					if (state == 0) {
 						state=1;
 					}
-					if (c != '/') {
+					if (c != '/' || (*(t-1) != '<' && *(t+1) != '>')) {
 						*(n++) = c;
 					}
 				} else {

--- a/ext/standard/tests/strings/bug78814.phpt
+++ b/ext/standard/tests/strings/bug78814.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Bug #78814 (strip_tags allows / in tag name => whitelist bypass)
+--FILE--
+<?php
+echo strip_tags("<s/trong>b</strong>", "<strong>");
+?>
+--EXPECT--
+b</strong>


### PR DESCRIPTION
When normalizing tags to check whether they are contained in the set
of allowable tags, we must not strip slashes, unless they come
immediately after the opening `<`, or immediately before the closing
`>`.