### PR TITLE
Convert the example skeleton extension to use arginfo stubs

### DIFF
--- a/ext/ext_skel.php
+++ b/ext/ext_skel.php
@@ -330,6 +330,7 @@ function copy_sources() {
 
 	$files = [
 			'skeleton.c'		=> $options['ext'] . '.c',
+			'skeleton.stub'		=> $options['ext'] . '.stub.php',
 			'php_skeleton.h'	=> 'php_' . $options['ext'] . '.h'
 			];
 

--- a/ext/skeleton/skeleton.c
+++ b/ext/skeleton/skeleton.c
@@ -7,6 +7,7 @@
 #include "php.h"
 #include "ext/standard/info.h"
 #include "php_%EXTNAME%.h"
+#include "%EXTNAME%_arginfo.h"
 
 /* For compatibility with older PHP versions */
 #ifndef ZEND_PARSE_PARAMETERS_NONE
@@ -64,16 +65,6 @@ PHP_MINFO_FUNCTION(%EXTNAME%)
 	php_info_print_table_header(2, "%EXTNAME% support", "enabled");
 	php_info_print_table_end();
 }
-/* }}} */
-
-/* {{{ arginfo
- */
-ZEND_BEGIN_ARG_INFO(arginfo_%EXTNAME%_test1, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_%EXTNAME%_test2, 0)
-	ZEND_ARG_INFO(0, str)
-ZEND_END_ARG_INFO()
 /* }}} */
 
 /* {{{ %EXTNAME%_functions[]

--- a/ext/skeleton/skeleton.stub
+++ b/ext/skeleton/skeleton.stub
@@ -1,0 +1,5 @@
+<?php
+
+function %EXTNAME%_test1(): void {}
+
+function %EXTNAME%_test2(string $str = ""): string {}


### PR DESCRIPTION
I named the stub file `skeleton.stub` instead of `skeleton.stub.php` so that the make file doesn't try to generate stubs for it.

I've tested generating a new extension for it and it appears to generate a valid stub file and the appropriate includes in the extension code