### PR TITLE
Extend CURLFile to support streams

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1852,6 +1852,14 @@ static void curl_free_post(void **post)
 }
 /* }}} */
 
+/* {{{ curl_free_stream
+ */
+static void curl_free_stream(void **post)
+{
+	php_stream_close((php_stream *)*post);
+}
+/* }}} */
+
 /* {{{ curl_free_slist
  */
 static void curl_free_slist(zval *el)
@@ -1943,6 +1951,7 @@ php_curl *alloc_curl_handle()
 
 	zend_llist_init(&ch->to_free->str,   sizeof(char *),          (llist_dtor_func_t)curl_free_string, 0);
 	zend_llist_init(&ch->to_free->post,  sizeof(struct HttpPost *), (llist_dtor_func_t)curl_free_post,   0);
+	zend_llist_init(&ch->to_free->stream, sizeof(php_stream *),   (llist_dtor_func_t)curl_free_stream, 0);
 
 	ch->to_free->slist = emalloc(sizeof(HashTable));
 	zend_hash_init(ch->to_free->slist, 4, NULL, curl_free_slist, 0);
@@ -2169,6 +2178,32 @@ PHP_FUNCTION(curl_copy_handle)
 	dupch->res = Z_RES_P(return_value);
 }
 /* }}} */
+
+#if LIBCURL_VERSION_NUM >= 0x073800
+static size_t read_cb(char *buffer, size_t size, size_t nitems, void *arg) /* {{{ */
+{
+	php_stream *stream = (php_stream *) arg;
+	size_t numread = php_stream_read(stream, buffer, nitems * size);
+
+	if (numread == (size_t)-1) {
+		return CURL_READFUNC_ABORT;
+	}
+	return numread;
+}
+/* }}} */
+
+static int seek_cb(void *arg, curl_off_t offset, int origin) /* {{{ */
+{
+	php_stream *stream = (php_stream *) arg;
+	int res = php_stream_seek(stream, offset, origin);
+
+	if (res) {
+		return CURL_SEEKFUNC_CANTSEEK;
+	}
+	return CURL_SEEKFUNC_OK;
+}
+/* }}} */
+#endif
 
 static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{ */
 {
@@ -2805,6 +2840,9 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 						/* new-style file upload */
 						zval *prop, rv;
 						char *type = NULL, *filename = NULL;
+#if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+						php_stream *stream;
+#endif
 
 						prop = zend_read_property(curl_CURLFile_class, current, "name", sizeof("name")-1, 0, &rv);
 						if (Z_TYPE_P(prop) != IS_STRING) {
@@ -2826,17 +2864,24 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 							}
 
 #if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+							if (!(stream = php_stream_open_wrapper(ZSTR_VAL(postval), "rb", IGNORE_PATH, NULL))) {
+								zend_string_release_ex(string_key, 0);
+								return FAILURE;
+							}
 							part = curl_mime_addpart(mime);
 							if (part == NULL) {
+								php_stream_close(stream);
 								zend_string_release_ex(string_key, 0);
 								return FAILURE;
 							}
 							if ((form_error = curl_mime_name(part, ZSTR_VAL(string_key))) != CURLE_OK
-								|| (form_error = curl_mime_filedata(part, ZSTR_VAL(postval))) != CURLE_OK
+								|| (form_error = curl_mime_data_cb(part, -1, read_cb, seek_cb, NULL, stream)) != CURLE_OK
 								|| (form_error = curl_mime_filename(part, filename ? filename : ZSTR_VAL(postval))) != CURLE_OK
 								|| (form_error = curl_mime_type(part, type ? type : "application/octet-stream")) != CURLE_OK) {
+								php_stream_close(stream);
 								error = form_error;
 							}
+							zend_llist_add_element(&ch->to_free->stream, &stream);
 #else
 							form_error = curl_formadd(&first, &last,
 											CURLFORM_COPYNAME, ZSTR_VAL(string_key),
@@ -3566,6 +3611,7 @@ static void _php_curl_close_ex(php_curl *ch)
 	if (--(*ch->clone) == 0) {
 		zend_llist_clean(&ch->to_free->str);
 		zend_llist_clean(&ch->to_free->post);
+		zend_llist_clean(&ch->to_free->stream);
 		zend_hash_destroy(ch->to_free->slist);
 		efree(ch->to_free->slist);
 		efree(ch->to_free);

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1844,7 +1844,11 @@ static void curl_free_string(void **string)
  */
 static void curl_free_post(void **post)
 {
+#if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+	curl_mime_free((curl_mime *)*post);
+#else
 	curl_formfree((struct HttpPost *)*post);
+#endif
 }
 /* }}} */
 
@@ -2764,15 +2768,27 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 				HashTable *postfields;
 				zend_string *string_key;
 				zend_ulong  num_key;
+#if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+				curl_mime *mime;
+				curl_mimepart *part;
+				CURLcode form_error;
+#else
 				struct HttpPost *first = NULL;
 				struct HttpPost *last  = NULL;
 				CURLFORMcode form_error;
-
+#endif
 				postfields = HASH_OF(zvalue);
 				if (!postfields) {
 					php_error_docref(NULL, E_WARNING, "Couldn't get HashTable in CURLOPT_POSTFIELDS");
 					return FAILURE;
 				}
+
+#if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+				mime = curl_mime_init(ch->cp);
+				if (mime == NULL) {
+					return FAILURE;
+				}
+#endif
 
 				ZEND_HASH_FOREACH_KEY_VAL(postfields, num_key, string_key, current) {
 					zend_string *postval, *tmp_postval;
@@ -2808,6 +2824,20 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 							if (Z_TYPE_P(prop) == IS_STRING && Z_STRLEN_P(prop) > 0) {
 								filename = Z_STRVAL_P(prop);
 							}
+
+#if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+							part = curl_mime_addpart(mime);
+							if (part == NULL) {
+								zend_string_release_ex(string_key, 0);
+								return FAILURE;
+							}
+							if ((form_error = curl_mime_name(part, ZSTR_VAL(string_key))) != CURLE_OK
+								|| (form_error = curl_mime_filedata(part, ZSTR_VAL(postval))) != CURLE_OK
+								|| (form_error = curl_mime_filename(part, filename ? filename : ZSTR_VAL(postval))) != CURLE_OK
+								|| (form_error = curl_mime_type(part, type ? type : "application/octet-stream")) != CURLE_OK) {
+								error = form_error;
+							}
+#else
 							form_error = curl_formadd(&first, &last,
 											CURLFORM_COPYNAME, ZSTR_VAL(string_key),
 											CURLFORM_NAMELENGTH, ZSTR_LEN(string_key),
@@ -2819,6 +2849,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 								/* Not nice to convert between enums but we only have place for one error type */
 								error = (CURLcode)form_error;
 							}
+#endif
 						}
 
 						zend_string_release_ex(string_key, 0);
@@ -2827,6 +2858,18 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 
 					postval = zval_get_tmp_string(current, &tmp_postval);
 
+#if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+					part = curl_mime_addpart(mime);
+					if (part == NULL) {
+						zend_tmp_string_release(tmp_postval);
+						zend_string_release_ex(string_key, 0);
+						return FAILURE;
+					}
+					if ((form_error = curl_mime_name(part, ZSTR_VAL(string_key))) != CURLE_OK
+						|| (form_error = curl_mime_data(part, ZSTR_VAL(postval), ZSTR_LEN(postval))) != CURLE_OK) {
+						error = form_error;
+					}
+#else
 					/* The arguments after _NAMELENGTH and _CONTENTSLENGTH
 					 * must be explicitly cast to long in curl_formadd
 					 * use since curl needs a long not an int. */
@@ -2841,6 +2884,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 						/* Not nice to convert between enums but we only have place for one error type */
 						error = (CURLcode)form_error;
 					}
+#endif
 					zend_tmp_string_release(tmp_postval);
 					zend_string_release_ex(string_key, 0);
 				} ZEND_HASH_FOREACH_END();
@@ -2853,8 +2897,13 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 				if ((*ch->clone) == 1) {
 					zend_llist_clean(&ch->to_free->post);
 				}
+#if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+				zend_llist_add_element(&ch->to_free->post, &mime);
+				error = curl_easy_setopt(ch->cp, CURLOPT_MIMEPOST, mime);
+#else
 				zend_llist_add_element(&ch->to_free->post, &first);
 				error = curl_easy_setopt(ch->cp, CURLOPT_HTTPPOST, first);
+#endif
 			} else {
 #if LIBCURL_VERSION_NUM >= 0x071101
 				zend_string *tmp_str;

--- a/ext/curl/php_curl.h
+++ b/ext/curl/php_curl.h
@@ -169,6 +169,7 @@ struct _php_curl_send_headers {
 struct _php_curl_free {
 	zend_llist str;
 	zend_llist post;
+	zend_llist stream;
 	HashTable *slist;
 };
 

--- a/ext/curl/tests/bug77711.phpt
+++ b/ext/curl/tests/bug77711.phpt
@@ -1,0 +1,32 @@
+--TEST--
+FR #77711 (CURLFile should support UNICODE filenames)
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_SAFE_UPLOAD, 1);
+curl_setopt($ch, CURLOPT_URL, "{$host}/get.php?test=file");
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+$filename = __DIR__ . '/АБВ.txt';
+file_put_contents($filename, "Test.");
+$file = curl_file_create($filename);
+$params = array('file' => $file);
+var_dump(curl_setopt($ch, CURLOPT_POSTFIELDS, $params));
+
+var_dump(curl_exec($ch));
+curl_close($ch);
+?>
+===DONE===
+--EXPECTF--
+bool(true)
+string(%d) "АБВ.txt|application/octet-stream"
+===DONE===
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/АБВ.txt');
+?>

--- a/ext/curl/tests/curl_copy_handle_variation3.phpt
+++ b/ext/curl/tests/curl_copy_handle_variation3.phpt
@@ -1,0 +1,38 @@
+--TEST--
+curl_copy_handle() allows to post CURLFile multiple times
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$ch1 = curl_init();
+curl_setopt($ch1, CURLOPT_SAFE_UPLOAD, 1);
+curl_setopt($ch1, CURLOPT_URL, "{$host}/get.php?test=file");
+curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
+
+$filename = __DIR__ . '/АБВ.txt';
+file_put_contents($filename, "Test.");
+$file = curl_file_create($filename);
+$params = array('file' => $file);
+var_dump(curl_setopt($ch1, CURLOPT_POSTFIELDS, $params));
+
+$ch2 = curl_copy_handle($ch1);
+
+var_dump(curl_exec($ch1));
+curl_close($ch1);
+
+var_dump(curl_exec($ch2));
+curl_close($ch2);
+?>
+===DONE===
+--EXPECTF--
+bool(true)
+string(%d) "АБВ.txt|application/octet-stream"
+string(%d) "АБВ.txt|application/octet-stream"
+===DONE===
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/АБВ.txt');
+?>

--- a/ext/curl/tests/curl_file_upload_stream.phpt
+++ b/ext/curl/tests/curl_file_upload_stream.phpt
@@ -1,0 +1,28 @@
+--TEST--
+CURL file uploading from stream
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+<?php
+if (curl_version()['version_number'] < 0x73800) die('skip requires curl >= 7.56.0');
+--FILE--
+<?php
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_SAFE_UPLOAD, 1);
+curl_setopt($ch, CURLOPT_URL, "{$host}/get.inc?test=file");
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+$file = curl_file_create('data://text/plain;base64,SSBsb3ZlIFBIUAo=', 'text/plain', 'i-love-php');
+$params = array('file' => $file);
+var_dump(curl_setopt($ch, CURLOPT_POSTFIELDS, $params));
+
+var_dump(curl_exec($ch));
+curl_close($ch);
+?>
+===DONE===
+--EXPECT--
+bool(true)
+string(21) "i-love-php|text/plain"
+===DONE===


### PR DESCRIPTION
Due to former restrictions of the libcurl API, curl multipart/formdata
file uploads supported only proper files.  However, as of curl 7.56.0
the new `curl_mime_*()` API is available (and already supported by
PHP[1]), which allows us to support arbitrary *seekable* streams, which
is generally desirable, and particularly resolves issues with the
transparent Unicode and long part support on Windows (see bug #77711).

Note that older curl versions are still supported, but CURLFile is
still restricted to proper files in this case.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=a83b68ba56714bfa06737a61af795460caa4a105>

---

The two commits have been cherry-picked from PHP-7.4, where there are available as of April, i.e. they are contained in 7.4.0alpha1 and up. To my knowledge, no issues regarding this have been reported so far, so that it could make sense to backport the stream support to PHP-7.3 (for PHP-7.2 it's likely too late, since this could only make it into the ultimate bugfix release).