### PR TITLE
Fix #78833: Integer overflow in pack causes out-of-bound access

### DIFF
--- a/ext/standard/pack.c
+++ b/ext/standard/pack.c
@@ -343,10 +343,13 @@ PHP_FUNCTION(pack)
 				if (arg < 0) {
 					arg = num_args - currentarg;
 				}
-
+				if (currentarg > INT_MAX - arg) {
+					goto too_few_args;
+				}
 				currentarg += arg;
 
 				if (currentarg > num_args) {
+too_few_args:
 					efree(formatcodes);
 					efree(formatargs);
 					php_error_docref(NULL, E_WARNING, "Type %c: too few arguments", code);

--- a/ext/standard/tests/strings/bug78833.phpt
+++ b/ext/standard/tests/strings/bug78833.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug #78833 (Integer overflow in pack causes out-of-bound access)
+--FILE--
+<?php
+var_dump(pack("E2E2147483647H*", 0x0, 0x0, 0x0));
+?>
+--EXPECTF--
+Warning: pack(): Type E: too few arguments in %s on line %d
+bool(false)


### PR DESCRIPTION
We check for potential signed integer overflow, and bail out
gracefully, in that case.