### PR TITLE
Make opcache infer array_key_exists is non-null bool

### DIFF
--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -2480,14 +2480,8 @@ static int zend_update_type_info(const zend_op_array *op_array,
 		case ZEND_ISSET_ISEMPTY_STATIC_PROP:
 		case ZEND_ASSERT_CHECK:
 		case ZEND_IN_ARRAY:
-			UPDATE_SSA_TYPE(MAY_BE_FALSE|MAY_BE_TRUE, ssa_ops[i].result_def);
-			break;
 		case ZEND_ARRAY_KEY_EXISTS:
-			tmp = MAY_BE_FALSE|MAY_BE_TRUE;
-			if (t2 & ((MAY_BE_ANY|MAY_BE_UNDEF) - (MAY_BE_ARRAY|MAY_BE_OBJECT))) {
-				tmp |= MAY_BE_NULL;
-			}
-			UPDATE_SSA_TYPE(tmp, ssa_ops[i].result_def);
+			UPDATE_SSA_TYPE(MAY_BE_FALSE|MAY_BE_TRUE, ssa_ops[i].result_def);
 			break;
 		case ZEND_CAST:
 			if (ssa_ops[i].op1_def >= 0) {


### PR DESCRIPTION
array_key_exists now throws a TypeError instead of returning null
for invalid arguments after 14bdb0cfc7b62205c75f6d5c783e343259796776

Split out of GH-4925