### PR TITLE
Handle reallocated root buffer during GC destroy phase (v2)

### DIFF
--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -1561,7 +1561,7 @@ ZEND_API int zend_gc_collect_cycles(void)
 					EG(objects_store).object_buckets[obj->handle] = SET_OBJ_INVALID(obj);
 					GC_TYPE_INFO(obj) = IS_NULL |
 						(GC_TYPE_INFO(obj) & ~GC_TYPE_MASK);
-					/* Modify current before calling free_obj(bug #78811: free_obj() can cause the root buffer (with current) to be reallocated.) */
+					/* Modify current before calling free_obj (bug #78811: free_obj() can cause the root buffer (with current) to be reallocated.) */
 					current->ref = GC_MAKE_GARBAGE(((char*)obj) - obj->handlers->offset);
 					if (!(OBJ_FLAGS(obj) & IS_OBJ_FREE_CALLED)) {
 						GC_ADD_FLAGS(obj, IS_OBJ_FREE_CALLED);

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -1561,6 +1561,8 @@ ZEND_API int zend_gc_collect_cycles(void)
 					EG(objects_store).object_buckets[obj->handle] = SET_OBJ_INVALID(obj);
 					GC_TYPE_INFO(obj) = IS_NULL |
 						(GC_TYPE_INFO(obj) & ~GC_TYPE_MASK);
+					/* Modify current before calling free_obj(bug #78811: free_obj() can cause the root buffer (with current) to be reallocated.) */
+					current->ref = GC_MAKE_GARBAGE(((char*)obj) - obj->handlers->offset);
 					if (!(OBJ_FLAGS(obj) & IS_OBJ_FREE_CALLED)) {
 						GC_ADD_FLAGS(obj, IS_OBJ_FREE_CALLED);
 						GC_ADDREF(obj);
@@ -1569,7 +1571,6 @@ ZEND_API int zend_gc_collect_cycles(void)
 					}
 
 					ZEND_OBJECTS_STORE_ADD_TO_FREE_LIST(obj->handle);
-					current->ref = GC_MAKE_GARBAGE(((char*)obj) - obj->handlers->offset);
 				} else if (GC_TYPE(p) == IS_ARRAY) {
 					zend_array *arr = (zend_array*)p;
 


### PR DESCRIPTION
We no longer protect GC during the destroy phase, so we need to
deal with buffer reallocation.

Note that the implementation of spl_SplObjectStorage_free_storage
will call the destructor of SplObjectStorage, and free the instance properties,
which I think is what caused the root buffer to be reallocated.

This fixes bug #78811 for me.

I needed both of the lines - the crash still happened before `current = GC_IDX2PTR(idx)` was added (gdb said that current->ptr was invalid memory)

The build failure is spurious

```
========DIFF========
130+ [0494] Expecting string/00:50:01, got string/00:50:00 resp. string/00:50:00. [0]
========DONE========
FAIL mysqli_fetch_all() [C:\projects\php-src\ext\mysqli\tests\mysqli_fetch_all.phpt] 
```