### PR TITLE
Remove unnecessary C99< checks for maths functions

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -148,8 +148,6 @@ _LT_AC_TRY_DLOPEN_SELF([
 dnl Checks for library functions.
 AC_CHECK_FUNCS(getpid kill finite sigsetjmp)
 
-AC_CHECK_DECLS([isfinite, isnan, isinf], [], [], [[#include <math.h>]])
-
 ZEND_CHECK_FLOAT_PRECISION
 
 dnl Test whether double cast to long preserves least significant bits.
@@ -393,13 +391,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <math.h>
 #include <stdlib.h>
 
-#ifdef HAVE_ISNAN
 #define zend_isnan(a) isnan(a)
-#elif defined(HAVE_FPCLASS)
-#define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
-#else
-#define zend_isnan(a) 0
-#endif
 
 int main(int argc, char** argv)
 {
@@ -422,16 +414,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <math.h>
 #include <stdlib.h>
 
-#ifdef HAVE_ISINF
 #define zend_isinf(a) isinf(a)
-#elif defined(INFINITY)
-/* Might not work, but is required by ISO C99 */
-#define zend_isinf(a) (((a)==INFINITY)?1:0)
-#elif defined(HAVE_FPCLASS)
-#define zend_isinf(a) ((fpclass(a) == FP_PINF) || (fpclass(a) == FP_NINF))
-#else
-#define zend_isinf(a) 0
-#endif
 
 int main(int argc, char** argv)
 {
@@ -454,16 +437,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <math.h>
 #include <stdlib.h>
 
-#ifdef HAVE_ISINF
 #define zend_isinf(a) isinf(a)
-#elif defined(INFINITY)
-/* Might not work, but is required by ISO C99 */
-#define zend_isinf(a) (((a)==INFINITY)?1:0)
-#elif defined(HAVE_FPCLASS)
-#define zend_isinf(a) ((fpclass(a) == FP_PINF) || (fpclass(a) == FP_NINF))
-#else
-#define zend_isinf(a) 0
-#endif
 
 int main(int argc, char** argv)
 {
@@ -487,13 +461,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <math.h>
 #include <stdlib.h>
 
-#ifdef HAVE_ISNAN
 #define zend_isnan(a) isnan(a)
-#elif defined(HAVE_FPCLASS)
-#define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
-#else
-#define zend_isnan(a) 0
-#endif
 
 int main(int argc, char** argv)
 {

--- a/configure.ac
+++ b/configure.ac
@@ -72,35 +72,11 @@ extern "C++" {
 #include <math.h>
 
 #ifndef zend_isnan
-#if HAVE_DECL_ISNAN
 #define zend_isnan(a) isnan(a)
-#elif defined(HAVE_FPCLASS)
-#define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
-#else
-#define zend_isnan(a) ((a) != (a))
-#endif
 #endif
 
-#if HAVE_DECL_ISINF
 #define zend_isinf(a) isinf(a)
-#elif defined(INFINITY)
-/* Might not work, but is required by ISO C99 */
-#define zend_isinf(a) (((a)==INFINITY || (a)==-INFINITY)?1:0)
-#elif defined(HAVE_FPCLASS)
-#define zend_isinf(a) ((fpclass(a) == FP_PINF) || (fpclass(a) == FP_NINF))
-#else
-#define zend_isinf(a) 0
-#endif
-
-#if HAVE_DECL_ISFINITE
 #define zend_finite(a) isfinite(a)
-#elif defined(HAVE_FINITE)
-#define zend_finite(a) finite(a)
-#elif defined(fpclassify)
-#define zend_finite(a) ((fpclassify((a))!=FP_INFINITE&&fpclassify((a))!=FP_NAN)?1:0)
-#else
-#define zend_finite(a) (zend_isnan(a) ? 0 : zend_isinf(a) ? 0 : 1)
-#endif
 
 #endif
 #endif /* ifndef ZEND_ACCONFIG_H_NO_C_PROTOS */

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -304,14 +304,6 @@ if test "$ac_cv_attribute_aligned" = "yes"; then
 fi
 
 dnl
-dnl Check for available functions
-dnl
-dnl log2 could be used to improve the log function, however it requires C99. The
-dnl check for log2 should be turned on, as soon as we support C99.
-AC_CHECK_FUNCS(asinh acosh atanh log1p hypot)
-AC_FUNC_FNMATCH
-
-dnl
 dnl Check if there is a support means of creating a new process and defining
 dnl which handles it receives
 dnl

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -204,83 +204,6 @@ PHPAPI double _php_math_round(double value, int places, int mode) {
 }
 /* }}} */
 
-/* {{{ php_asinh
-*/
-static double php_asinh(double z)
-{
-#ifdef HAVE_ASINH
-	return(asinh(z));
-#else
-# ifdef _WIN64
-	if (z >= 0) {
-		return log(z + sqrt(z * z + 1));
-	}
-	else {
-		return -log(-z + sqrt(z * z + 1));
-	}
-# else
-	return(log(z + sqrt(1 + pow(z, 2))) / log(M_E));
-# endif
-#endif
-}
-/* }}} */
-
-/* {{{ php_acosh
-*/
-static double php_acosh(double x)
-{
-#ifdef HAVE_ACOSH
-	return(acosh(x));
-#else
-# ifdef _WIN64
-	if (x >= 1) {
-		return log(x + sqrt(x * x - 1));
-	} else {
-		return ZEND_NAN;
-	}
-# else
-	return(log(x + sqrt(x * x - 1)));
-# endif
-#endif
-}
-/* }}} */
-
-/* {{{ php_atanh
-*/
-static double php_atanh(double z)
-{
-#ifdef HAVE_ATANH
-	return(atanh(z));
-#else
-	return(0.5 * log((1 + z) / (1 - z)));
-#endif
-}
-/* }}} */
-
-/* {{{ php_log1p
-*/
-static double php_log1p(double x)
-{
-#ifdef HAVE_LOG1P
-	return(log1p(x));
-#else
-	return(log(1 + x));
-#endif
-}
-/* }}} */
-
-/* {{{ php_expm1
-*/
-static double php_expm1(double x)
-{
-#ifndef PHP_WIN32
-	return(expm1(x));
-#else
-	return(exp(x) - 1);
-#endif
-}
-/* }}}*/
-
 /* {{{ proto int|float abs(int|float number)
    Return the absolute value of the number */
 PHP_FUNCTION(abs)
@@ -533,7 +456,7 @@ PHP_FUNCTION(asinh)
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_DOUBLE(num)
 	ZEND_PARSE_PARAMETERS_END();
-	RETURN_DOUBLE(php_asinh(num));
+	RETURN_DOUBLE(asinh(num));
 }
 /* }}} */
 
@@ -546,7 +469,7 @@ PHP_FUNCTION(acosh)
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_DOUBLE(num)
 	ZEND_PARSE_PARAMETERS_END();
-	RETURN_DOUBLE(php_acosh(num));
+	RETURN_DOUBLE(acosh(num));
 }
 /* }}} */
 
@@ -559,7 +482,7 @@ PHP_FUNCTION(atanh)
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_DOUBLE(num)
 	ZEND_PARSE_PARAMETERS_END();
-	RETURN_DOUBLE(php_atanh(num));
+	RETURN_DOUBLE(atanh(num));
 }
 /* }}} */
 
@@ -644,10 +567,7 @@ PHP_FUNCTION(exp)
 /* }}} */
 
 /* {{{ proto float expm1(float number)
-   Returns exp(number) - 1, computed in a way that accurate even when the value of number is close to zero */
-/*
-   WARNING: this function is experimental: it could change its name or
-   disappear in the next version of PHP!
+   Returns exp(number) - 1, computed in a way that accurate even when the value of number is close to zero
 */
 PHP_FUNCTION(expm1)
 {
@@ -657,15 +577,12 @@ PHP_FUNCTION(expm1)
 		Z_PARAM_DOUBLE(num)
 	ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_DOUBLE(php_expm1(num));
+	RETURN_DOUBLE(expm1(num));
 }
 /* }}} */
 
 /* {{{ proto float log1p(float number)
-   Returns log(1 + number), computed in a way that accurate even when the value of number is close to zero */
-/*
-   WARNING: this function is experimental: it could change its name or
-   disappear in the next version of PHP!
+   Returns log(1 + number), computed in a way that accurate even when the value of number is close to zero
 */
 PHP_FUNCTION(log1p)
 {
@@ -675,7 +592,7 @@ PHP_FUNCTION(log1p)
 		Z_PARAM_DOUBLE(num)
 	ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_DOUBLE(php_log1p(num));
+	RETURN_DOUBLE(log1p(num));
 }
 /* }}} */
 
@@ -695,11 +612,9 @@ PHP_FUNCTION(log)
 		RETURN_DOUBLE(log(num));
 	}
 
-#ifdef HAVE_LOG2
 	if (base == 2.0) {
 		RETURN_DOUBLE(log2(num));
 	}
-#endif
 
 	if (base == 10.0) {
 		RETURN_DOUBLE(log10(num));
@@ -757,13 +672,7 @@ PHP_FUNCTION(hypot)
 		Z_PARAM_DOUBLE(num2)
 	ZEND_PARSE_PARAMETERS_END();
 
-#if HAVE_HYPOT
 	RETURN_DOUBLE(hypot(num1, num2));
-#elif defined(_MSC_VER)
-	RETURN_DOUBLE(_hypot(num1, num2));
-#else
-	RETURN_DOUBLE(sqrt((num1 * num1) + (num2 * num2)));
-#endif
 }
 /* }}} */
 

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2300,19 +2300,6 @@ function generate_config_h()
 		outfile.WriteLine("#define " + keys[i] + " " + pieces);
 	}
 
-	if (VS_TOOLSET) {
-		if (VCVERS >= 1800) {
-			outfile.WriteLine("");
-			outfile.WriteLine("#define HAVE_ACOSH 1");
-			outfile.WriteLine("#define HAVE_ASINH 1");
-			outfile.WriteLine("#define HAVE_ATANH 1");
-		}
-		if (VCVERS >= 1900) {
-			outfile.WriteLine("#define HAVE_LOG1P 1");
-		}
-	}
-
-
 	outfile.Close();
 }
 


### PR DESCRIPTION
As I'm not sure if we are moving to C99 in master/PHP 8 so I'm putting this up for review.