### PR TITLE
Omit some opcodes before returning boolean expression (or both branches return same const).

### DIFF
--- a/ext/opcache/Optimizer/ssa_integrity.c
+++ b/ext/opcache/Optimizer/ssa_integrity.c
@@ -150,7 +150,7 @@ int ssa_verify_integrity(zend_op_array *op_array, zend_ssa *ssa, const char *ext
 				return status;
 			}
 			if (!is_used_by_op(ssa, use, i)) {
-				fprintf(stderr, "var " VARFMT " not in uses of op %d\n", VAR(i), use);
+				FAIL("var " VARFMT " not in uses of op %d\n", VAR(i), use);
 			}
 		} FOREACH_USE_END();
 

--- a/ext/opcache/tests/bool_optimizations.phpt
+++ b/ext/opcache/tests/bool_optimizations.phpt
@@ -1,0 +1,75 @@
+--TEST--
+Test result of various optimizations
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+function testAlwaysReturnsTrue(array $values) {
+    if (count($values) > 0) {
+        return true;
+    }
+    return true;
+}
+
+function testJmpzOptimization(array $values) : bool {
+    if (count($values) == 0) {
+        return true;
+    }
+    return false;
+}
+
+function testJmpnzOptimization(bool $i) : bool {
+    if (!$i) {
+        return false;
+    }
+    return true;
+}
+
+function testJmpzNotOptimizedCast(array $values) : int {
+    if (count($values) > 0) {
+        return true;
+    }
+    return false;
+}
+
+function testJmpzNotOptimizedThrow(array $values) : int {
+    if (count($values) > 0) {
+        return [];
+    }
+    return new stdClass();
+}
+
+var_dump(testAlwaysReturnsTrue([]));
+var_dump(testAlwaysReturnsTrue([2]));
+var_dump(testJmpnzOptimization(false));
+var_dump(testJmpnzOptimization(true));
+var_dump(testJmpzOptimization([]));
+var_dump(testJmpzOptimization([2]));
+echo "Testing cases without optimization\n";
+foreach ([[], [[]]] as $x) {
+    try {
+        var_dump(testJmpzNotOptimizedCast($x));
+    } catch (TypeError $e) {
+        echo "TypeError at line {$e->getLine()}: {$e->getMessage()}\n";
+    }
+}
+foreach ([[], [[]]] as $x) {
+    try {
+        var_dump(testJmpzNotOptimizedThrow($x));
+    } catch (TypeError $e) {
+        echo "TypeError at line {$e->getLine()}: {$e->getMessage()}\n";
+    }
+}
+
+--EXPECT--
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+Testing cases without optimization
+int(0)
+int(1)
+TypeError at line 34: Return value of testJmpzNotOptimizedThrow() must be of the type int, object returned
+TypeError at line 32: Return value of testJmpzNotOptimizedThrow() must be of the type int, array returned


### PR DESCRIPTION
Convert `if (non_refcounted_expr) { return CONST1; } return CONST1;`
to `return CONST1;`

Convert `if (bool_expr) { return true; } return false;`
to `return bool_expr`

I considered optimizing returning the negation of a boolean expression,
but I'm not familiar with how to increase the number of oplines during a pass
or how to check for other oplines using the ZEND_RETURN.
(since other oplines might `goto` the oplines being overwritten)

Those examples might be used in certain code styles,
along with comments/descriptive variable names.

Note that if there is a runtime type check (ZEND_TYPE_CHECK),
this optimization won't be run,
because it's checking for `ZEND_RETURN`.