### PR TITLE
Fix #78296: is_file fails to detect file

### DIFF
--- a/ext/standard/tests/file/bug78296.phpt
+++ b/ext/standard/tests/file/bug78296.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #78296 (is_file fails to detect file)
+--FILE--
+<?php
+$dir = str_pad(__DIR__ . '/bug78296', 250, '_');
+var_dump(mkdir($dir));
+var_dump(is_dir($dir));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+--CLEAN--
+<?php
+$dir = str_pad(__DIR__ . '/bug78296', 250, '_');
+rmdir($dir);
+?>

--- a/win32/ioutil.c
+++ b/win32/ioutil.c
@@ -320,6 +320,7 @@ PW32IO int php_win32_ioutil_mkdir_w(const wchar_t *path, mode_t mode)
 
 		if (!PHP_WIN32_IOUTIL_IS_LONG_PATHW(tmp, path_len)) {
 			wchar_t *_tmp = (wchar_t *) malloc((path_len + PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW + 1) * sizeof(wchar_t));
+			wchar_t *src, *dst;
 			if (!_tmp) {
 				SET_ERRNO_FROM_WIN32_CODE(ERROR_NOT_ENOUGH_MEMORY);
 				free(tmp);
@@ -327,6 +328,16 @@ PW32IO int php_win32_ioutil_mkdir_w(const wchar_t *path, mode_t mode)
 			}
 			memmove(_tmp, PHP_WIN32_IOUTIL_LONG_PATH_PREFIXW, PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW * sizeof(wchar_t));
 			memmove(_tmp+PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW, tmp, path_len * sizeof(wchar_t));
+			src = tmp;
+			dst = _tmp + PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW;
+			while (src < tmp + path_len) {
+				if (*src == PHP_WIN32_IOUTIL_FW_SLASHW) {
+					*dst++ = PHP_WIN32_IOUTIL_DEFAULT_SLASHW;
+					src++;
+				} else {
+					*dst++ = *src++;
+				}
+			}
 			path_len += PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW;
 			_tmp[path_len] = L'\0';
 			free(tmp);

--- a/win32/ioutil.c
+++ b/win32/ioutil.c
@@ -327,7 +327,6 @@ PW32IO int php_win32_ioutil_mkdir_w(const wchar_t *path, mode_t mode)
 				return -1;
 			}
 			memmove(_tmp, PHP_WIN32_IOUTIL_LONG_PATH_PREFIXW, PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW * sizeof(wchar_t));
-			memmove(_tmp+PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW, tmp, path_len * sizeof(wchar_t));
 			src = tmp;
 			dst = _tmp + PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW;
 			while (src < tmp + path_len) {

--- a/win32/ioutil.h
+++ b/win32/ioutil.h
@@ -215,8 +215,16 @@ __forceinline static wchar_t *php_win32_ioutil_conv_any_to_w(const char* in, siz
 			memmove(ret, mb, mb_len * sizeof(wchar_t));
 			ret[mb_len] = L'\0';
 		} else {
+			wchar_t *src = mb, *dst = ret + PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW;
 			memmove(ret, PHP_WIN32_IOUTIL_LONG_PATH_PREFIXW, PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW * sizeof(wchar_t));
-			memmove(ret+PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW, mb, mb_len * sizeof(wchar_t));
+			while (src < mb + mb_len) {
+				if (*src == PHP_WIN32_IOUTIL_FW_SLASHW) {
+					*dst++ = PHP_WIN32_IOUTIL_DEFAULT_SLASHW;
+					src++;
+				} else {
+					*dst++ = *src++;
+				}
+			}
 			ret[mb_len + PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW] = L'\0';
 
 			mb_len += PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW;


### PR DESCRIPTION
If we're constructing extended-length paths (i.e. paths prefixed with
`\\?\`), we have to replace all forward slashes with backward slashes,
because the former are not supported by Windows for extended-length
paths.

The more efficient and likely cleaner alternative solution would be to
cater to this in `php_win32_ioutil_normalize_path_w()` by always
replacing forward slashes, but that might break existing code.  It
might be sensible to change that for `master`, though.