### PR TITLE
Fix #78823: add zlib library to mysqlnd

### DIFF
--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -24,6 +24,9 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
 
 
   if test "$PHP_MYSQLND_COMPRESSION_SUPPORT" != "no"; then
+    PKG_CHECK_MODULES([ZLIB], [zlib])
+    PHP_EVAL_LIBLINE($ZLIB_LIBS, MYSQLND_SHARED_LIBADD)
+    PHP_EVAL_INCLINE($ZLIB_CFLAGS)
     AC_DEFINE([MYSQLND_COMPRESSION_WANTED], 1, [Enable compressed protocol support])
   fi
 


### PR DESCRIPTION
The problem is newer binutils will no longer default to --copy-dt-needed-entries but use --no-copy-dt-needed-entries instead. So all libraries needed *must* be provided.

Workarounds (either one works)
1) Add "-Wl,--copy-dt-needed-entries" to LDFLAGS to bring back the old behavior of the linker
2) Add "-lz" to list of libraries to be added

In "ext/mysqlnd/mysqlnd_protocol_frame_codec.c" when the "zlib.h" header is included should also trigger adding '-lz' to the list of libraries.