### PR TITLE
Open opcache.error_log with 'a' flag

### DIFF
--- a/ext/opcache/zend_accelerator_debug.c
+++ b/ext/opcache/zend_accelerator_debug.c
@@ -47,7 +47,7 @@ void zend_accel_error(int type, const char *format, ...)
 
 		fLog = stderr;
 	} else {
-		fLog = fopen(ZCG(accel_directives).error_log, "a+");
+		fLog = fopen(ZCG(accel_directives).error_log, "a");
 		if (!fLog) {
 			fLog = stderr;
 		}


### PR DESCRIPTION
When opcache.error_log is set to log to file the read mode (+) is not needed and not used.