### PR TITLE
Fix #78840: imploding $GLOBALS crashes

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1216,14 +1216,14 @@ PHPAPI void php_implode(const zend_string *glue, zval *pieces, zval *return_valu
 		RETURN_EMPTY_STRING();
 	} else if (numelems == 1) {
 		/* loop to search the first not undefined element... */
-		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(pieces), tmp) {
+		ZEND_HASH_FOREACH_VAL_IND(Z_ARRVAL_P(pieces), tmp) {
 			RETURN_STR(zval_get_string(tmp));
 		} ZEND_HASH_FOREACH_END();
 	}
 
 	ptr = strings = do_alloca((sizeof(*strings)) * numelems, use_heap);
 
-	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(pieces), tmp) {
+	ZEND_HASH_FOREACH_VAL_IND(Z_ARRVAL_P(pieces), tmp) {
 		if (EXPECTED(Z_TYPE_P(tmp) == IS_STRING)) {
 			ptr->str = Z_STR_P(tmp);
 			len += ZSTR_LEN(ptr->str);

--- a/ext/standard/tests/strings/bug78840.phpt
+++ b/ext/standard/tests/strings/bug78840.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #78840 (imploding $GLOBALS crashes)
+--FILE--
+<?php
+$glue = '';
+@implode($glue, $GLOBALS);
+echo "done\n";
+?>
+--EXPECT--
+done


### PR DESCRIPTION
We add support for IS_INDIRECT zvals to implode().