### PR TITLE
Clean up remaining opcodes for foreach([] as $x)

### DIFF
--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -4391,6 +4391,7 @@ int zend_may_throw_ex(const zend_op *opline, const zend_ssa_op *ssa_op, const ze
 		case ZEND_BEGIN_SILENCE:
 		case ZEND_END_SILENCE:
 		case ZEND_FREE:
+		case ZEND_FE_FREE:
 		case ZEND_SEPARATE:
 		case ZEND_TYPE_CHECK:
 		case ZEND_DEFINED:

--- a/ext/opcache/tests/opt/dce_009.phpt
+++ b/ext/opcache/tests/opt/dce_009.phpt
@@ -1,0 +1,71 @@
+--TEST--
+DFA 001: Foreach over empty array is a no-op
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+class Loop {
+    const VALUES = [];
+    public static function test() {
+        echo "Start\n";
+        $y = [];
+        foreach ($y as $x) {
+        }
+        echo "Done\n";
+    }
+    public static function test2() {
+        foreach (self::VALUES as $x) {
+        }
+    }
+    public static function test3() {
+        foreach ([] as $k => &$v) {
+        }
+    }
+}
+Loop::test();
+Loop::test2();
+Loop::test3();
+--EXPECTF--
+$_main:
+     ; (lines=7, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %sdce_009.php:1-23
+0000 INIT_STATIC_METHOD_CALL 0 string("Loop") string("test")
+0001 DO_UCALL
+0002 INIT_STATIC_METHOD_CALL 0 string("Loop") string("test2")
+0003 DO_UCALL
+0004 INIT_STATIC_METHOD_CALL 0 string("Loop") string("test3")
+0005 DO_UCALL
+0006 RETURN int(1)
+
+Loop::test:
+     ; (lines=3, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %sdce_009.php:4-10
+0000 ECHO string("Start
+")
+0001 ECHO string("Done
+")
+0002 RETURN null
+
+Loop::test2:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %sdce_009.php:11-14
+0000 RETURN null
+
+Loop::test3:
+     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %sdce_009.php:15-18
+0000 V0 = FE_RESET_RW array(...) 0001
+0001 FE_FREE V0
+0002 RETURN null
+Start
+Done


### PR DESCRIPTION
I'm not familiar with the data structures involved in the passes after dfa,
so I'm not sure how to safely improve on this (removing NOPs).

Two useless FE_RESET_R and FE_FREE would be left over whether the empty array
was from a literal, a variable, or a class constant.