### PR TITLE
Remove no-op check for 'use strict;'

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6830,11 +6830,6 @@ void zend_compile_use(zend_ast *ast) /* {{{ */
 				new_name = zend_string_copy(old_name);
 
 				if (!current_ns) {
-					if (type == T_CLASS && zend_string_equals_literal(new_name, "strict")) {
-						zend_error_noreturn(E_COMPILE_ERROR,
-							"You seem to be trying to use a different language...");
-					}
-
 					zend_error(E_WARNING, "The use statement with non-compound name '%s' "
 						"has no effect", ZSTR_VAL(new_name));
 				}


### PR DESCRIPTION
This should be checking for ZEND_SYMBOL_CLASS, not T_CLASS.

This was first added in 37ac1b96ed1

Alternately, if this bug is fixed instead, this should be added to "Backwards Incompatible Changes" for 8.0 (It seems surprising that this valid class name would be a fatal compile error instead of a compile warning, but code doing this should be rare)