### PR TITLE
Fix #78883: fgets(STDIN) fails on Windows

### DIFF
--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -254,6 +254,9 @@ static void detect_is_pipe(php_stdio_stream_data *self) {
 		DWORD file_type = GetFileType((HANDLE)handle);
 
 		self->is_pipe = file_type == FILE_TYPE_PIPE || file_type == FILE_TYPE_CHAR;
+		if (file_type == FILE_TYPE_CHAR) {
+			self->is_pipe_blocking = 1;
+		}
 	}
 #endif
 }


### PR DESCRIPTION
If a character file is detected as pipe, we have to set the Windows
only flag `is_pipe_blocking`.