### PR TITLE
Add CapabilityBoundingSet to systemd unit file

### DIFF
--- a/sapi/fpm/php-fpm.service.in
+++ b/sapi/fpm/php-fpm.service.in
@@ -32,6 +32,9 @@ NoNewPrivileges=true
 # but no physical devices such as /dev/sda.
 PrivateDevices=true
 
+# Required for dropping privileges for running as a different user and changin owner and root.
+CapabilityBoundingSet=CAP_CHOWN CAP_SETGID CAP_SETUID CAP_SYS_CHROOT
+
 # Explicit module loading will be denied. This allows to turn off module load and unload
 # operations on modular kernels. It is recommended to turn this on for most services that
 # do not need special file systems or extra kernel modules to work.


### PR DESCRIPTION
Re-introduced CapabilityBoundingSet that got removed in 7.4: https://github.com/php/php-src/commit/67cd4271e922ee3082b416a7563598274d13a1e5 as it was breaking apps. It looks that chroot has been also omitted and it needs to be verified again what is actually needed by FPM. As such this targets master only.

Any feedback for additional capabilities is welcomed.