### PR TITLE
Add unit test for bug #78902

### DIFF
--- a/ext/standard/tests/streams/bug78902.phpt
+++ b/ext/standard/tests/streams/bug78902.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Bug #78902: Memory leak when using stream_filter_append
+--FILE--
+<?php
+ini_set('memory_limit','512k');
+
+/** create temporary file 2mb file */
+$tmp_file_name = tempnam(sys_get_temp_dir(), 'test_');
+$fp = fopen($tmp_file_name, 'w+');
+$size = 1024 * 1024 * 2; // 2mb
+$chunk = 1024;
+while ($size > 0) {
+    fputs($fp, str_pad('', min($chunk,$size)));
+    $size -= $chunk;
+}
+fclose($fp);
+
+$fp = fopen($tmp_file_name, 'r');
+stream_filter_append($fp, "string.toupper");
+while (!feof($fp)) {
+    fread($fp, 1);
+}
+fclose($fp);
+var_dump(true);
+?>
+--XFAIL--
+This bug was introduce in PHP 7.3.11 an is still open
+--EXPECT--
+bool(true)


### PR DESCRIPTION
As seen in https://bugs.php.net/bug.php?id=78902 PHP 7.3.11 introduced a bug that was not covered with unit test.