### PR TITLE
Add funcinfo for spl global functions

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -1049,12 +1049,9 @@ static const func_info_t func_infos[] = {
 	F1("class_implements",						MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
 	F1("class_parents",							MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
 	F1("class_uses",							MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
-	F0("iterator_apply",						MAY_BE_NULL | MAY_BE_LONG),
-	F0("iterator_count",						MAY_BE_FALSE | MAY_BE_LONG),
-	F1("iterator_to_array",						MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_REF | MAY_BE_ARRAY_OF_ANY),
-	F1("spl_classes",							MAY_BE_NULL | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
-	F1("spl_object_hash",						MAY_BE_NULL | MAY_BE_STRING),
-	F0("spl_object_id",							MAY_BE_NULL | MAY_BE_LONG),
+	F1("iterator_to_array",						MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_REF | MAY_BE_ARRAY_OF_ANY),
+	F1("spl_classes",							MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_STRING),
+	F1("spl_object_hash",						MAY_BE_STRING),
 
 };
 

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -23,6 +23,7 @@
 #include "php_main.h"
 #include "ext/standard/info.h"
 #include "php_spl.h"
+#include "php_spl_arginfo.h"
 #include "spl_functions.h"
 #include "spl_engine.h"
 #include "spl_array.h"
@@ -892,76 +893,6 @@ PHP_MINFO_FUNCTION(spl)
 }
 /* }}} */
 
-/* {{{ arginfo */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_iterator_to_array, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, iterator, Traversable, 0)
-	ZEND_ARG_INFO(0, use_keys)
-ZEND_END_ARG_INFO();
-
-ZEND_BEGIN_ARG_INFO(arginfo_iterator, 0)
-	ZEND_ARG_OBJ_INFO(0, iterator, Traversable, 0)
-ZEND_END_ARG_INFO();
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_iterator_apply, 0, 0, 2)
-	ZEND_ARG_OBJ_INFO(0, iterator, Traversable, 0)
-	ZEND_ARG_INFO(0, function)
-	ZEND_ARG_ARRAY_INFO(0, args, 1)
-ZEND_END_ARG_INFO();
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_parents, 0, 0, 1)
-	ZEND_ARG_INFO(0, instance)
-	ZEND_ARG_INFO(0, autoload)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_implements, 0, 0, 1)
-	ZEND_ARG_INFO(0, what)
-	ZEND_ARG_INFO(0, autoload)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_uses, 0, 0, 1)
-	ZEND_ARG_INFO(0, what)
-	ZEND_ARG_INFO(0, autoload)
-ZEND_END_ARG_INFO()
-
-
-ZEND_BEGIN_ARG_INFO(arginfo_spl_classes, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_spl_autoload_functions, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_autoload, 0, 0, 1)
-	ZEND_ARG_INFO(0, class_name)
-	ZEND_ARG_INFO(0, file_extensions)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_autoload_extensions, 0, 0, 0)
-	ZEND_ARG_INFO(0, file_extensions)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_autoload_call, 0, 0, 1)
-	ZEND_ARG_INFO(0, class_name)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_autoload_register, 0, 0, 0)
-	ZEND_ARG_INFO(0, autoload_function)
-	ZEND_ARG_INFO(0, throw)
-	ZEND_ARG_INFO(0, prepend)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_autoload_unregister, 0, 0, 1)
-	ZEND_ARG_INFO(0, autoload_function)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_object_hash, 0, 0, 1)
-	ZEND_ARG_INFO(0, obj)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_object_id, 0, 0, 1)
-	ZEND_ARG_INFO(0, obj)
-ZEND_END_ARG_INFO()
-/* }}} */
-
 /* {{{ spl_functions
  */
 static const zend_function_entry spl_functions[] = {
@@ -978,7 +909,7 @@ static const zend_function_entry spl_functions[] = {
 	PHP_FE(spl_object_hash,         arginfo_spl_object_hash)
 	PHP_FE(spl_object_id,           arginfo_spl_object_id)
 	PHP_FE(iterator_to_array,       arginfo_iterator_to_array)
-	PHP_FE(iterator_count,          arginfo_iterator)
+	PHP_FE(iterator_count,          arginfo_iterator_count)
 	PHP_FE(iterator_apply,          arginfo_iterator_apply)
 	PHP_FE_END
 };

--- a/ext/spl/php_spl.stub.php
+++ b/ext/spl/php_spl.stub.php
@@ -1,0 +1,35 @@
+<?php
+
+/* ext/spl/php_spl.c */
+
+function class_implements($what, bool $autoload = true) : array|false { }
+
+function class_parents($instance, bool $autoload = true) : array|false {}
+
+function class_uses($what, bool $autoload = true) : array|false {}
+
+function spl_autoload(string $class_name, string $file_extensions = '.inc,.php') : void {}
+
+// This silently ignores non-string class names
+function spl_autoload_call($class_name) : void {}
+
+function spl_autoload_extensions(string $file_extensions = '') : string {}
+
+function spl_autoload_functions() : array|false {}
+
+function spl_autoload_register($autoload_function = null, bool $throw = true, bool $prepend = false) : bool {}
+
+function spl_autoload_unregister($autoload_function) : bool {}
+
+function spl_classes() : array {}
+
+function spl_object_hash(object $obj) : string {}
+
+function spl_object_id(object $obj) : int {}
+
+/* ext/spl/spl_iterators.c */
+function iterator_apply(Traversable $iterator, $function, ?array $args = null) : int {}
+
+function iterator_count(Traversable $iterator) : int {}
+
+function iterator_to_array(Traversable $iterator, bool $use_keys = true) : array { }

--- a/ext/spl/php_spl.stub.php
+++ b/ext/spl/php_spl.stub.php
@@ -2,34 +2,34 @@
 
 /* ext/spl/php_spl.c */
 
-function class_implements($what, bool $autoload = true) : array|false { }
+function class_implements($what, bool $autoload = true): array|false {}
 
-function class_parents($instance, bool $autoload = true) : array|false {}
+function class_parents($instance, bool $autoload = true): array|false {}
 
-function class_uses($what, bool $autoload = true) : array|false {}
+function class_uses($what, bool $autoload = true): array|false {}
 
-function spl_autoload(string $class_name, string $file_extensions = '.inc,.php') : void {}
+function spl_autoload(string $class_name, string $file_extensions = UNKNOWN): void {}
 
 // This silently ignores non-string class names
-function spl_autoload_call($class_name) : void {}
+function spl_autoload_call($class_name): void {}
 
-function spl_autoload_extensions(string $file_extensions = '') : string {}
+function spl_autoload_extensions(string $file_extensions = UNKNOWN): string {}
 
-function spl_autoload_functions() : array|false {}
+function spl_autoload_functions(): array|false {}
 
-function spl_autoload_register($autoload_function = null, bool $throw = true, bool $prepend = false) : bool {}
+function spl_autoload_register($autoload_function = null, bool $throw = true, bool $prepend = false): bool {}
 
-function spl_autoload_unregister($autoload_function) : bool {}
+function spl_autoload_unregister($autoload_function): bool {}
 
-function spl_classes() : array {}
+function spl_classes(): array {}
 
-function spl_object_hash(object $obj) : string {}
+function spl_object_hash(object $obj): string {}
 
-function spl_object_id(object $obj) : int {}
+function spl_object_id(object $obj): int {}
 
 /* ext/spl/spl_iterators.c */
-function iterator_apply(Traversable $iterator, $function, ?array $args = null) : int {}
+function iterator_apply(Traversable $iterator, callable $function, ?array $args = null): int {}
 
-function iterator_count(Traversable $iterator) : int {}
+function iterator_count(Traversable $iterator): int {}
 
-function iterator_to_array(Traversable $iterator, bool $use_keys = true) : array { }
+function iterator_to_array(Traversable $iterator, bool $use_keys = true): array {}

--- a/ext/spl/php_spl_arginfo.h
+++ b/ext/spl/php_spl_arginfo.h
@@ -51,7 +51,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterator_apply, 0, 2, IS_LONG, 0)
 	ZEND_ARG_OBJ_INFO(0, iterator, Traversable, 0)
-	ZEND_ARG_INFO(0, function)
+	ZEND_ARG_TYPE_INFO(0, function, IS_CALLABLE, 0)
 	ZEND_ARG_TYPE_INFO(0, args, IS_ARRAY, 1)
 ZEND_END_ARG_INFO()
 

--- a/ext/spl/php_spl_arginfo.h
+++ b/ext/spl/php_spl_arginfo.h
@@ -1,0 +1,65 @@
+/* This is a generated file, edit the .stub.php file instead. */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_implements, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_INFO(0, what)
+	ZEND_ARG_TYPE_INFO(0, autoload, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_parents, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_INFO(0, instance)
+	ZEND_ARG_TYPE_INFO(0, autoload, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_uses arginfo_class_implements
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, class_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, file_extensions, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_call, 0, 1, IS_VOID, 0)
+	ZEND_ARG_INFO(0, class_name)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_extensions, 0, 0, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, file_extensions, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_spl_autoload_functions, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_register, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, autoload_function)
+	ZEND_ARG_TYPE_INFO(0, throw, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, prepend, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_unregister, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, autoload_function)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_classes, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_object_hash, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, obj, IS_OBJECT, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_object_id, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, obj, IS_OBJECT, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterator_apply, 0, 2, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, iterator, Traversable, 0)
+	ZEND_ARG_INFO(0, function)
+	ZEND_ARG_TYPE_INFO(0, args, IS_ARRAY, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterator_count, 0, 1, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, iterator, Traversable, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterator_to_array, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_OBJ_INFO(0, iterator, Traversable, 0)
+	ZEND_ARG_TYPE_INFO(0, use_keys, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -33,6 +33,7 @@
 #include "ext/standard/php_dns.h"
 #include "ext/standard/php_uuencode.h"
 #include "ext/standard/php_mt_rand.h"
+#include "basic_functions_arginfo.h"
 
 #ifdef PHP_WIN32
 #include "win32/php_win32_globals.h"
@@ -524,8 +525,6 @@ ZEND_END_ARG_INFO()
 #endif
 /* }}} */
 /* }}} */
-
-#include "basic_functions_arginfo.h"
 
 static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(constant,														arginfo_constant)


### PR DESCRIPTION
This assumes that `iterator_*` will now always throw or abort on failure.