### PR TITLE
Allow empty needles in mbstring functions

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfilter.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.c
@@ -817,6 +817,7 @@ mbfl_strpos(
     int reverse)
 {
 	size_t result;
+	size_t haystack_length;
 	mbfl_string _haystack_u8, _needle_u8;
 	const mbfl_string *haystack_u8, *needle_u8 = NULL;
 	const unsigned char *u8_tbl;
@@ -855,29 +856,31 @@ mbfl_strpos(
 		needle_u8 = needle;
 	}
 
+	/* Check if offset is out of bound */
+	haystack_length = mbfl_strlen(haystack_u8);
+	if (
+		(offset > 0 && offset > haystack_length)
+		|| (offset < 0 && -offset > haystack_length)
+	) {
+		result = -16;
+		goto out;
+	}
+
 	result = (size_t) -1;
 	if (haystack_u8->len < needle_u8->len) {
 		goto out;
 	}
 
 	if (needle_u8->len == 0) {
-		/* Out of bound offset */
-		if (
-			(offset > 0 && offset > mbfl_strlen(haystack_u8))
-			|| (offset < 0 && -offset > mbfl_strlen(haystack_u8))
-		) {
-			return -16;
-		}
-
 		if (reverse) {
 			if (offset < 0) {
 				result = (size_t) -offset;
 			} else {
-				result = mbfl_strlen(haystack_u8) - offset;;
+				result = haystack_length - offset;;
 			}
 		} else {
 			if (offset < 0) {
-				result = mbfl_strlen(haystack_u8) + offset;
+				result = haystack_length + offset;
 			} else {
 				result = (size_t) offset;
 			}

--- a/ext/mbstring/libmbfl/mbfl/mbfilter.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.c
@@ -656,7 +656,7 @@ filter_count_output(int c, void *data)
 }
 
 size_t
-mbfl_strlen(mbfl_string *string)
+mbfl_strlen(const mbfl_string *string)
 {
 	size_t len, n, k;
 	unsigned char *p;
@@ -855,13 +855,33 @@ mbfl_strpos(
 		needle_u8 = needle;
 	}
 
-	if (needle_u8->len < 1) {
-		result = (size_t) -8;
+	result = (size_t) -1;
+	if (haystack_u8->len < needle_u8->len) {
 		goto out;
 	}
 
-	result = (size_t) -1;
-	if (haystack_u8->len < needle_u8->len) {
+	if (needle_u8->len == 0) {
+		/* Out of bound offset */
+		if (
+			(offset > 0 && offset > mbfl_strlen(haystack_u8))
+			|| (offset < 0 && -offset > mbfl_strlen(haystack_u8))
+		) {
+			return -16;
+		}
+
+		if (reverse) {
+			if (offset < 0) {
+				result = (size_t) -offset;
+			} else {
+				result = mbfl_strlen(haystack_u8) - offset;;
+			}
+		} else {
+			if (offset < 0) {
+				result = mbfl_strlen(haystack_u8) + offset;
+			} else {
+				result = (size_t) offset;
+			}
+		}
 		goto out;
 	}
 

--- a/ext/mbstring/libmbfl/mbfl/mbfilter.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.c
@@ -817,7 +817,6 @@ mbfl_strpos(
     int reverse)
 {
 	size_t result;
-	size_t haystack_length;
 	mbfl_string _haystack_u8, _needle_u8;
 	const mbfl_string *haystack_u8, *needle_u8 = NULL;
 	const unsigned char *u8_tbl;
@@ -856,27 +855,27 @@ mbfl_strpos(
 		needle_u8 = needle;
 	}
 
-	/* Check if offset is out of bound */
-	haystack_length = mbfl_strlen(haystack_u8);
-	if (
-		(offset > 0 && offset > haystack_length)
-		|| (offset < 0 && -offset > haystack_length)
-	) {
-		result = -16;
-		goto out;
-	}
-
 	result = (size_t) -1;
 	if (haystack_u8->len < needle_u8->len) {
 		goto out;
 	}
 
 	if (needle_u8->len == 0) {
+		size_t haystack_length = mbfl_strlen(haystack_u8);
+		/* Check if offset is out of bound */
+		if (
+			(offset > 0 && offset > haystack_length)
+			|| (offset < 0 && -offset > haystack_length)
+		) {
+			result = -16;
+			goto out;
+		}
+
 		if (reverse) {
 			if (offset < 0) {
-				result = (size_t) -offset;
+				result = haystack_length + offset;
 			} else {
-				result = haystack_length - offset;;
+				result = haystack_length;
 			}
 		} else {
 			if (offset < 0) {

--- a/ext/mbstring/libmbfl/mbfl/mbfilter.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.h
@@ -193,7 +193,7 @@ static inline int mbfl_is_error(size_t len) {
  * strlen
  */
 MBFLAPI extern size_t
-mbfl_strlen(mbfl_string *string);
+mbfl_strlen(const mbfl_string *string);
 
 /*
  * oddlen

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2110,11 +2110,6 @@ PHP_FUNCTION(mb_strpos)
 		}
 	}
 
-	if (needle.len == 0) {
-		php_error_docref(NULL, E_WARNING, "Empty delimiter");
-		RETURN_FALSE;
-	}
-
 	n = mbfl_strpos(&haystack, &needle, offset, reverse);
 	if (!mbfl_is_error(n)) {
 		RETVAL_LONG(n);
@@ -2189,11 +2184,6 @@ PHP_FUNCTION(mb_stripos)
 		RETURN_THROWS();
 	}
 
-	if (needle.len == 0) {
-		php_error_docref(NULL, E_WARNING, "Empty delimiter");
-		RETURN_FALSE;
-	}
-
 	n = php_mb_stripos(0, (char *)haystack.val, haystack.len, (char *)needle.val, needle.len, offset, from_encoding);
 
 	if (!mbfl_is_error(n)) {
@@ -2243,11 +2233,6 @@ PHP_FUNCTION(mb_strstr)
 	haystack.no_language = needle.no_language = MBSTRG(language);
 	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name);
 	if (!haystack.encoding) {
-		RETURN_FALSE;
-	}
-
-	if (needle.len == 0) {
-		php_error_docref(NULL, E_WARNING, "Empty delimiter");
 		RETURN_FALSE;
 	}
 
@@ -2347,11 +2332,6 @@ PHP_FUNCTION(mb_stristr)
 	haystack.no_language = needle.no_language = MBSTRG(language);
 	haystack.encoding = needle.encoding = php_mb_get_encoding(from_encoding);
 	if (!haystack.encoding) {
-		RETURN_FALSE;
-	}
-
-	if (!needle.len) {
-		php_error_docref(NULL, E_WARNING, "Empty delimiter");
 		RETURN_FALSE;
 	}
 
@@ -4846,10 +4826,6 @@ MBSTRING_API size_t php_mb_stripos(int mode, const char *old_haystack, size_t ol
 		needle.len = len;
 
 		if (!needle.val) {
-			break;
-		}
-
-		if (needle.len == 0) {
 			break;
 		}
 

--- a/ext/mbstring/tests/mb_stripos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_stripos_empty_needle.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Test mb_stripos() function :  with empty needle
+--SKIPIF--
+<?php
+extension_loaded('mbstring') or die('skip');
+function_exists('mb_stripos') or die("skip mb_stripos() is not available in this build");
+?>
+--FILE--
+<?php
+
+mb_internal_encoding('UTF-8');
+
+$string_ascii = 'abc def';
+// Japanese string in UTF-8
+$string_mb = "日本語テキストです。01234５６７８９。";
+
+echo "\n-- ASCII string without offset --\n";
+var_dump(mb_stripos($string_ascii, ''));
+
+echo "\n-- ASCII string with in range positive offset --\n";
+var_dump(mb_stripos($string_ascii, '', 2));
+
+echo "\n-- ASCII string with in range negative offset --\n";
+var_dump(mb_stripos($string_ascii, '', -2));
+
+echo "\n-- ASCII string with out of bound positive offset --\n";
+var_dump(mb_stripos($string_ascii, '', 150));
+
+echo "\n-- ASCII string with out of bound negative offset --\n";
+var_dump(mb_stripos($string_ascii, '', -150));
+
+
+echo "\n-- Multi-byte string without offset --\n";
+var_dump(mb_stripos($string_mb, ''));
+
+echo "\n-- Multi-byte string with in range positive offset --\n";
+var_dump(mb_stripos($string_mb, '', 2));
+
+echo "\n-- Multi-byte string with in range negative offset --\n";
+var_dump(mb_stripos($string_mb, '', -2));
+
+echo "\n-- Multi-byte string with out of bound positive offset --\n";
+var_dump(mb_stripos($string_mb, '', 150));
+
+echo "\n-- Multi-byte string with out of bound negative offset --\n";
+var_dump(mb_stripos($string_mb, '', -150));
+
+?>
+--EXPECTF--
+-- ASCII string without offset --
+int(0)
+
+-- ASCII string with in range positive offset --
+int(2)
+
+-- ASCII string with in range negative offset --
+int(5)
+
+-- ASCII string with out of bound positive offset --
+
+Warning: mb_stripos(): Offset not contained in string in %s on line %d
+bool(false)
+
+-- ASCII string with out of bound negative offset --
+
+Warning: mb_stripos(): Offset not contained in string in %s on line %d
+bool(false)
+
+-- Multi-byte string without offset --
+int(0)
+
+-- Multi-byte string with in range positive offset --
+int(2)
+
+-- Multi-byte string with in range negative offset --
+int(19)
+
+-- Multi-byte string with out of bound positive offset --
+
+Warning: mb_stripos(): Offset not contained in string in %s on line %d
+bool(false)
+
+-- Multi-byte string with out of bound negative offset --
+
+Warning: mb_stripos(): Offset not contained in string in %s on line %d
+bool(false)

--- a/ext/mbstring/tests/mb_stristr_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_stristr_empty_needle.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test mb_stristr() function : with empty needle
+--SKIPIF--
+<?php
+extension_loaded('mbstring') or die('skip');
+function_exists('mb_stristr') or die("skip mb_stristr() is not available in this build");
+?>
+--FILE--
+<?php
+
+mb_internal_encoding('UTF-8');
+
+$string_ascii = 'abc def';
+// Japanese string in UTF-8
+$string_mb = "日本語テキストです。01234５６７８９。";
+
+echo "\n-- ASCII string --\n";
+var_dump(mb_stristr($string_ascii, '', false, 'ISO-8859-1'));
+var_dump(mb_stristr($string_ascii, ''));
+var_dump(mb_stristr($string_ascii, '', true));
+
+echo "\n-- Multibyte string --\n";
+var_dump(mb_stristr($string_mb, ''));
+var_dump(mb_stristr($string_mb, '', false, 'utf-8'));
+var_dump(mb_stristr($string_mb, '', true));
+
+?>
+--EXPECT--
+-- ASCII string --
+string(7) "abc def"
+string(7) "abc def"
+string(0) ""
+
+-- Multibyte string --
+string(53) "日本語テキストです。01234５６７８９。"
+string(53) "日本語テキストです。01234５６７８９。"
+string(0) ""

--- a/ext/mbstring/tests/mb_strpos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strpos_empty_needle.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Test mb_strpos() function : with empty needle
+--SKIPIF--
+<?php
+extension_loaded('mbstring') or die('skip');
+function_exists('mb_strpos') or die("skip mb_strpos() is not available in this build");
+?>
+--FILE--
+<?php
+
+mb_internal_encoding('UTF-8');
+
+$string_ascii = 'abc def';
+// Japanese string in UTF-8
+$string_mb = "日本語テキストです。01234５６７８９。";
+
+echo "\n-- ASCII string without offset --\n";
+var_dump(mb_strpos($string_ascii, ''));
+
+echo "\n-- ASCII string with in range positive offset --\n";
+var_dump(mb_strpos($string_ascii, '', 2));
+
+echo "\n-- ASCII string with in range negative offset --\n";
+var_dump(mb_strpos($string_ascii, '', -2));
+
+echo "\n-- ASCII string with out of bound positive offset --\n";
+var_dump(mb_strpos($string_ascii, '', 15));
+
+echo "\n-- ASCII string with out of bound negative offset --\n";
+var_dump(mb_strpos($string_ascii, '', -15));
+
+
+echo "\n-- Multi-byte string without offset --\n";
+var_dump(mb_strpos($string_mb, ''));
+
+echo "\n-- Multi-byte string with in range positive offset --\n";
+var_dump(mb_strpos($string_mb, '', 2));
+
+echo "\n-- Multi-byte string with in range negative offset --\n";
+var_dump(mb_strpos($string_mb, '', -2));
+
+echo "\n-- Multi-byte string with out of bound positive offset --\n";
+var_dump(mb_strpos($string_mb, '', 150));
+
+echo "\n-- Multi-byte string with out of bound negative offset --\n";
+var_dump(mb_strpos($string_mb, '', -150));
+
+?>
+--EXPECTF--
+-- ASCII string without offset --
+int(0)
+
+-- ASCII string with in range positive offset --
+int(2)
+
+-- ASCII string with in range negative offset --
+int(5)
+
+-- ASCII string with out of bound positive offset --
+
+Warning: mb_strpos(): Offset not contained in string in %s on line %d
+bool(false)
+
+-- ASCII string with out of bound negative offset --
+
+Warning: mb_strpos(): Offset not contained in string in %s on line %d
+bool(false)
+
+-- Multi-byte string without offset --
+int(0)
+
+-- Multi-byte string with in range positive offset --
+int(2)
+
+-- Multi-byte string with in range negative offset --
+int(19)
+
+-- Multi-byte string with out of bound positive offset --
+
+Warning: mb_strpos(): Offset not contained in string in %s on line %d
+bool(false)
+
+-- Multi-byte string with out of bound negative offset --
+
+Warning: mb_strpos(): Offset not contained in string in %s on line %d
+bool(false)

--- a/ext/mbstring/tests/mb_strrchr_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strrchr_empty_needle.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test mb_strrchr() function : with empty needle
+--SKIPIF--
+<?php
+extension_loaded('mbstring') or die('skip');
+function_exists('mb_strrchr') or die("skip mb_strrchr() is not available in this build");
+?>
+--FILE--
+<?php
+
+mb_internal_encoding('UTF-8');
+
+$string_ascii = 'abc def';
+// Japanese string in UTF-8
+$string_mb = "日本語テキストです。01234５６７８９。";
+
+echo "\n-- ASCII string --\n";
+var_dump(bin2hex(mb_strrchr($string_ascii, '', false, 'ISO-8859-1')));
+var_dump(bin2hex(mb_strrchr($string_ascii, '')));
+var_dump(bin2hex(mb_strrchr($string_ascii, '', true)));
+
+echo "\n-- Multibyte string --\n";
+var_dump(bin2hex(mb_strrchr($string_mb, '')));
+var_dump(bin2hex(mb_strrchr($string_mb, '', false, 'utf-8')));
+var_dump(bin2hex(mb_strrchr($string_mb, '', true)));
+
+?>
+--EXPECT--
+-- ASCII string --
+string(0) ""
+string(0) ""
+string(0) ""
+
+-- Multibyte string --
+string(0) ""
+string(0) ""
+string(0) ""

--- a/ext/mbstring/tests/mb_strripos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strripos_empty_needle.phpt
@@ -51,10 +51,10 @@ var_dump(mb_strripos($string_mb, '', -150));
 int(7)
 
 -- ASCII string with in range positive offset --
-int(5)
+int(7)
 
 -- ASCII string with in range negative offset --
-int(2)
+int(5)
 
 -- ASCII string with out of bound positive offset --
 
@@ -70,10 +70,10 @@ bool(false)
 int(21)
 
 -- Multi-byte string with in range positive offset --
-int(19)
+int(21)
 
 -- Multi-byte string with in range negative offset --
-int(2)
+int(19)
 
 -- Multi-byte string with out of bound positive offset --
 

--- a/ext/mbstring/tests/mb_strripos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strripos_empty_needle.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Test mb_strripos() function : with empty needle
+--SKIPIF--
+<?php
+extension_loaded('mbstring') or die('skip');
+function_exists('mb_strripos') or die("skip mb_strripos() is not available in this build");
+?>
+--FILE--
+<?php
+
+mb_internal_encoding('UTF-8');
+
+$string_ascii = 'abc def';
+// Japanese string in UTF-8
+$string_mb = "日本語テキストです。01234５６７８９。";
+
+echo "\n-- ASCII string without offset --\n";
+var_dump(mb_strripos($string_ascii, ''));
+
+echo "\n-- ASCII string with in range positive offset --\n";
+var_dump(mb_strripos($string_ascii, '', 2));
+
+echo "\n-- ASCII string with in range negative offset --\n";
+var_dump(mb_strripos($string_ascii, '', -2));
+
+echo "\n-- ASCII string with out of bound positive offset --\n";
+var_dump(mb_strripos($string_ascii, '', 15));
+
+echo "\n-- ASCII string with out of bound negative offset --\n";
+var_dump(mb_strripos($string_ascii, '', -15));
+
+
+echo "\n-- Multi-byte string without offset --\n";
+var_dump(mb_strripos($string_mb, ''));
+
+echo "\n-- Multi-byte string with in range positive offset --\n";
+var_dump(mb_strripos($string_mb, '', 2));
+
+echo "\n-- Multi-byte string with in range negative offset --\n";
+var_dump(mb_strripos($string_mb, '', -2));
+
+echo "\n-- Multi-byte string with out of bound positive offset --\n";
+var_dump(mb_strripos($string_mb, '', 150));
+
+echo "\n-- Multi-byte string with out of bound negative offset --\n";
+var_dump(mb_strripos($string_mb, '', -150));
+
+?>
+--EXPECTF--
+-- ASCII string without offset --
+int(7)
+
+-- ASCII string with in range positive offset --
+int(5)
+
+-- ASCII string with in range negative offset --
+int(2)
+
+-- ASCII string with out of bound positive offset --
+
+Warning: mb_strripos(): Offset is greater than the length of haystack string in %s on line %d
+bool(false)
+
+-- ASCII string with out of bound negative offset --
+
+Warning: mb_strripos(): Offset is greater than the length of haystack string in %s on line %d
+bool(false)
+
+-- Multi-byte string without offset --
+int(21)
+
+-- Multi-byte string with in range positive offset --
+int(19)
+
+-- Multi-byte string with in range negative offset --
+int(2)
+
+-- Multi-byte string with out of bound positive offset --
+
+Warning: mb_strripos(): Offset is greater than the length of haystack string in %s on line %d
+bool(false)
+
+-- Multi-byte string with out of bound negative offset --
+
+Warning: mb_strripos(): Offset is greater than the length of haystack string in %s on line %d
+bool(false)

--- a/ext/mbstring/tests/mb_strrpos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strrpos_empty_needle.phpt
@@ -51,10 +51,10 @@ var_dump(mb_strrpos($string_mb, '', -150));
 int(7)
 
 -- ASCII string with in range positive offset --
-int(5)
+int(7)
 
 -- ASCII string with in range negative offset --
-int(2)
+int(5)
 
 -- ASCII string with out of bound positive offset --
 
@@ -70,10 +70,10 @@ bool(false)
 int(21)
 
 -- Multi-byte string with in range positive offset --
-int(19)
+int(21)
 
 -- Multi-byte string with in range negative offset --
-int(2)
+int(19)
 
 -- Multi-byte string with out of bound positive offset --
 

--- a/ext/mbstring/tests/mb_strrpos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strrpos_empty_needle.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Test mb_strrpos() function :  with empty needle
+--SKIPIF--
+<?php
+extension_loaded('mbstring') or die('skip');
+function_exists('mb_strrpos') or die("skip mb_strrpos() is not available in this build");
+?>
+--FILE--
+<?php
+
+mb_internal_encoding('UTF-8');
+
+$string_ascii = 'abc def';
+// Japanese string in UTF-8
+$string_mb = "日本語テキストです。01234５６７８９。";
+
+echo "\n-- ASCII string without offset --\n";
+var_dump(mb_strrpos($string_ascii, ''));
+
+echo "\n-- ASCII string with in range positive offset --\n";
+var_dump(mb_strrpos($string_ascii, '', 2));
+
+echo "\n-- ASCII string with in range negative offset --\n";
+var_dump(mb_strrpos($string_ascii, '', -2));
+
+echo "\n-- ASCII string with out of bound positive offset --\n";
+var_dump(mb_strrpos($string_ascii, '', 15));
+
+echo "\n-- ASCII string with out of bound negative offset --\n";
+var_dump(mb_strrpos($string_ascii, '', -15));
+
+
+echo "\n-- Multi-byte string without offset --\n";
+var_dump(mb_strrpos($string_mb, ''));
+
+echo "\n-- Multi-byte string with in range positive offset --\n";
+var_dump(mb_strrpos($string_mb, '', 2));
+
+echo "\n-- Multi-byte string with in range negative offset --\n";
+var_dump(mb_strrpos($string_mb, '', -2));
+
+echo "\n-- Multi-byte string with out of bound positive offset --\n";
+var_dump(mb_strrpos($string_mb, '', 150));
+
+echo "\n-- Multi-byte string with out of bound negative offset --\n";
+var_dump(mb_strrpos($string_mb, '', -150));
+
+?>
+--EXPECTF--
+-- ASCII string without offset --
+int(7)
+
+-- ASCII string with in range positive offset --
+int(5)
+
+-- ASCII string with in range negative offset --
+int(2)
+
+-- ASCII string with out of bound positive offset --
+
+Warning: mb_strrpos(): Offset is greater than the length of haystack string in %s on line %d
+bool(false)
+
+-- ASCII string with out of bound negative offset --
+
+Warning: mb_strrpos(): Offset is greater than the length of haystack string in %s on line %d
+bool(false)
+
+-- Multi-byte string without offset --
+int(21)
+
+-- Multi-byte string with in range positive offset --
+int(19)
+
+-- Multi-byte string with in range negative offset --
+int(2)
+
+-- Multi-byte string with out of bound positive offset --
+
+Warning: mb_strrpos(): Offset is greater than the length of haystack string in %s on line %d
+bool(false)
+
+-- Multi-byte string with out of bound negative offset --
+
+Warning: mb_strrpos(): Offset is greater than the length of haystack string in %s on line %d
+bool(false)

--- a/ext/mbstring/tests/mb_strstr_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strstr_empty_needle.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test mb_strstr() function : with empty needle
+--SKIPIF--
+<?php
+extension_loaded('mbstring') or die('skip');
+function_exists('mb_strstr') or die("skip mb_strstr() is not available in this build");
+?>
+--FILE--
+<?php
+
+mb_internal_encoding('UTF-8');
+
+$string_ascii = 'abc def';
+// Japanese string in UTF-8
+$string_mb = "日本語テキストです。01234５６７８９。";
+
+echo "\n-- ASCII string --\n";
+var_dump(mb_strstr($string_ascii, '', false, 'ISO-8859-1'));
+var_dump(mb_strstr($string_ascii, ''));
+var_dump(mb_strstr($string_ascii, '', true));
+
+echo "\n-- Multibyte string --\n";
+var_dump(mb_strstr($string_mb, ''));
+var_dump(mb_strstr($string_mb, '', false, 'utf-8'));
+var_dump(mb_strstr($string_mb, '', true));
+
+?>
+--EXPECT--
+-- ASCII string --
+string(7) "abc def"
+string(7) "abc def"
+string(0) ""
+
+-- Multibyte string --
+string(53) "日本語テキストです。01234５６７８９。"
+string(53) "日本語テキストです。01234５６７８９。"
+string(0) ""


### PR DESCRIPTION
These pass on my machine without any test fixes ... So I don't know what to think about this.