### PR TITLE
Drop duplicate definitions of zend_isnan and friends

### DIFF
--- a/Zend/zend_config.w32.h
+++ b/Zend/zend_config.w32.h
@@ -47,18 +47,6 @@
 #endif
 #define strcasecmp(s1, s2) _stricmp(s1, s2)
 #define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
-#if defined(__cplusplus) && __cplusplus >= 201103L
-extern "C++" {
-#include <cmath>
-#define zend_isnan std::isnan
-#define zend_isinf std::isinf
-#define zend_finite std::isfinite
-}
-#else
-#define zend_isinf(a)	((_fpclass(a) == _FPCLASS_PINF) || (_fpclass(a) == _FPCLASS_NINF))
-#define zend_finite(x)	_finite(x)
-#define zend_isnan(x)	_isnan(x)
-#endif
 
 #ifndef __cplusplus
 /* This will cause the compilation process to be MUCH longer, but will generate


### PR DESCRIPTION
Following up on commit 1c4ad17[1], we remove these definitions from
zend_config.w32.h, since they would be overridden by those in
zend_portability.h anyway.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=1c4ad17cc1e483201a36b027f20aab1f91d19628>