### PR TITLE
Infer value is not undef within foreach

### DIFF
--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -3285,7 +3285,7 @@ static int zend_update_type_info(const zend_op_array *op_array,
 			break;
 		case ZEND_FE_FETCH_R:
 		case ZEND_FE_FETCH_RW:
-			tmp = t2;
+			tmp = t2 & MAY_BE_REF;
 			if (t1 & MAY_BE_OBJECT) {
 				if (opline->opcode == ZEND_FE_FETCH_RW) {
 					tmp |= MAY_BE_REF | MAY_BE_ANY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_ANY | MAY_BE_ARRAY_OF_REF;


### PR DESCRIPTION
I discovered that opcache infers that the variable can be undefined
within the loop body (or any types prior to the loop)

This seems to be unnecessary - the sources of blocks outside of the loop body
include both FE_FETCH_R and FE_FETCH_RW.
