### PR TITLE
Add type error on filename which contain null bytes in bzopen

### DIFF
--- a/ext/bz2/bz2.c
+++ b/ext/bz2/bz2.c
@@ -379,7 +379,8 @@ static PHP_FUNCTION(bzopen)
 		}
 
 		if (CHECK_ZVAL_NULL_PATH(file)) {
-			RETURN_FALSE;
+			zend_type_error("filename must not contain null bytes");
+			return;
 		}
 
 		stream = php_stream_bz2open(NULL, Z_STRVAL_P(file), mode, REPORT_ERRORS, NULL);

--- a/ext/bz2/tests/bzopen_string_filename_with_null_bytes.phpt
+++ b/ext/bz2/tests/bzopen_string_filename_with_null_bytes.phpt
@@ -1,0 +1,23 @@
+--TEST--
+bzopen(): throw TypeError if filename contains null bytes
+--SKIPIF--
+<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--FILE--
+<?php
+
+try {
+    bzopen("file\0", "w");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    bzopen("file\0", "r");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+?>
+--EXPECT--
+filename must not contain null bytes
+filename must not contain null bytes


### PR DESCRIPTION
As discussed in #4984 

I made it a type error like GD [1] does but I can change that to a normal warning if needed.

[1] https://php-lxr.adamharvey.name/source/xref/master/ext/gd/gd.c#4285