### PR TITLE
Improve error message

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3391,7 +3391,7 @@ static void get_unlinked_dependency(zend_class_entry *ce, const char **kind, con
 		}
 #ifdef ZEND_WIN32
 		if (p->type == ZEND_INTERNAL_CLASS) {
-			*kind = "Internal parent (Windows only limitation)";
+			*kind = "Windows can't link to internal parent ";
 			*name = ZSTR_VAL(ce->parent_name);
 			return;
 		}


### PR DESCRIPTION
Formerly, the error message was like:

| Can't preload unlinked class MyException: Internal parent (Windows
| only limitation)Exception

Now it's like:

| Can't preload unlinked class MyException: Windows can't link to
| internal parent Exception