### PR TITLE
[WIP][RFC] spread operator in list

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2648,7 +2648,8 @@ static void zend_compile_list_assign(
 	zend_bool has_elems = 0;
 	zend_bool has_spread_operator = 0;
 	zend_bool is_keyed =
-		list->children > 0 && list->child[0] != NULL && list->child[0]->child[1] != NULL;
+		list->children > 0 && list->child[0] != NULL && list->child[0]->kind != ZEND_AST_UNPACK 
+		&& list->child[0]->child[1] != NULL;
 
 	if (list->children && expr_node->op_type == IS_CONST && Z_TYPE(expr_node->u.constant) == IS_STRING) {
 		zval_make_interned_string(&expr_node->u.constant);


### PR DESCRIPTION
This is a POC of spread operator in `list`. I haven't start working on the RFC and tests yet, but I got some questions during implementing this feature. so I decided to create this PR first so we can have some discussion.

0. `list` was a syntax sugar, I want to keep it as a syntax after adding support of spread operator.
```php
list($a, $b) = $arr;
//is equivalent to
$a = $arr[0];
$b = $arr[1];

//so
list($a, ...$b) = $arr;
//will be equivalent to
$a = $arr[0];
$b = [];
foreach($arr as $k => $v) {
  if($k <= 0) continue;
  $b[] = $v;
}
```
the reason I choose to implement it in this way is I don't want to any new opcode at this stage. 

1. the first problem is `null`.
Although we passed a [RFC](https://wiki.php.net/rfc/notice-for-non-valid-array-container) to deal with reading from null, we still have some arguments in PR(#2031). Nikita provided #4386 which excluded list in the implementation. (More background about this decision can be found in these two PR).

current this PR still generator warnings if spread operator runs into null, because `foreach` will generator warnings if it's used with `null`. I don't know if it's a good idea to keep this warning or omit it.

~~2. internal pointer of array
previously `list` will not modify the array to be unpacked because all the index can be determined during compile time. unfortunately, spread operator is dealing with variable-length array that only can be processed during runtime. Thus internal pointer of the hashtable is used / modified. 
This should not be considered as a BC break since everything remains same as long as you don't use spread operator, but I'm still worring if this side-effect is something we can bear.~~