### PR TITLE
Fix #78939 - Windows relative path with drive letter

### DIFF
--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -79,10 +79,12 @@ typedef unsigned short mode_t;
 /* COPY_WHEN_ABSOLUTE is 2 under Win32 because by chance both regular absolute paths
    in the file system and UNC paths need copying of two characters */
 #define COPY_WHEN_ABSOLUTE(path) 2
+#define IS_ABSOLUTE_WIN32_LOCAL_PATH(path, len) \
+	(len >= 3 && isalpha(path[0]) && path[1] == ':' && IS_SLASH(path[2]))
 #define IS_UNC_PATH(path, len) \
 	(len >= 2 && IS_SLASH(path[0]) && IS_SLASH(path[1]))
 #define IS_ABSOLUTE_PATH(path, len) \
-	(len >= 2 && (/* is local */isalpha(path[0]) && path[1] == ':' || /* is UNC */IS_SLASH(path[0]) && IS_SLASH(path[1])))
+	(IS_ABSOLUTE_WIN32_LOCAL_PATH(path, len) || IS_UNC_PATH(path, len))
 
 #else
 #ifdef HAVE_DIRENT_H

--- a/ext/standard/tests/file/bug78939.phpt
+++ b/ext/standard/tests/file/bug78939.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Bug #78939 (Windows relative path with drive letter)
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) !== 'WIN') die('skip test is for Windows only');
+?>
+--FILE--
+<?php
+list($drive, $dirA, $dirB) = explode('\\', __FILE__, 4);
+var_dump(file_exists($drive . '\\'));
+var_dump(file_exists($drive . '\\' . $dirA));
+var_dump(file_exists($drive . '\\' . $dirA . '\\' . $dirB));
+var_dump(is_dir($drive . '\\' . $dirA . '\\' . $dirB));
+echo "\n";
+
+var_dump(chdir($drive . '\\'));
+var_dump(file_exists($drive . $dirA));
+var_dump(is_dir($drive . $dirA));
+var_dump(file_exists($drive . $dirB));
+var_dump(is_dir($drive . $dirB));
+var_dump(file_exists($drive . $dirA . '/' . $dirB));
+var_dump(is_dir($drive . $dirA . '/' . $dirB));
+echo "\n";
+
+var_dump(chdir($drive . '\\' . $dirA));
+var_dump(file_exists($drive . $dirA));
+var_dump(is_dir($drive . $dirA));
+var_dump(file_exists($drive . $dirB));
+var_dump(is_dir($drive . $dirB));
+var_dump(file_exists($drive . $dirA . '/' . $dirB));
+var_dump(is_dir($drive . $dirA . '/' . $dirB));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+bool(true)
+bool(true)
+
+bool(true)
+bool(false)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+bool(false)

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -1315,7 +1315,11 @@ static int php_plain_files_mkdir(php_stream_wrapper *wrapper, const char *dir, i
 		}
 		else {
 			/* find a top level directory we need to create */
-			while ( (p = strrchr(buf + offset, DEFAULT_SLASH)) || (offset != 1 && (p = strrchr(buf, DEFAULT_SLASH))) ) {
+			while ( (p = strrchr(buf + offset, DEFAULT_SLASH)) || (!(offset == 1
+#ifdef PHP_WIN32
+			 || (offset == 3 && IS_ABSOLUTE_WIN32_LOCAL_PATH(buf, offset))
+#endif
+			) && (p = strrchr(buf, DEFAULT_SLASH))) ) {
 				int n = 0;
 
 				*p = '\0';


### PR DESCRIPTION
Fix # 78939, paths like "C:x.txt" are relative, see https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats

Please note that path like "C:" is not absolute too (tested in Windows command line by `cd C:` - cwd did not changed).