### PR TITLE
Fixed bug #78950: Preloading trait method with static variables

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1005,9 +1005,16 @@ ZEND_API void function_add_ref(zend_function *function) /* {{{ */
 				GC_ADDREF(op_array->static_variables);
 			}
 		}
-		ZEND_MAP_PTR_INIT(op_array->static_variables_ptr, &op_array->static_variables);
-		ZEND_MAP_PTR_INIT(op_array->run_time_cache, zend_arena_alloc(&CG(arena), sizeof(void*)));
-		ZEND_MAP_PTR_SET(op_array->run_time_cache, NULL);
+
+		if (CG(compiler_options) & ZEND_COMPILE_PRELOAD) {
+			ZEND_ASSERT(op_array->fn_flags & ZEND_ACC_PRELOADED);
+			ZEND_MAP_PTR_NEW(op_array->run_time_cache);
+			ZEND_MAP_PTR_NEW(op_array->static_variables_ptr);
+		} else {
+			ZEND_MAP_PTR_INIT(op_array->static_variables_ptr, &op_array->static_variables);
+			ZEND_MAP_PTR_INIT(op_array->run_time_cache, zend_arena_alloc(&CG(arena), sizeof(void*)));
+			ZEND_MAP_PTR_SET(op_array->run_time_cache, NULL);
+		}
 	} else if (function->type == ZEND_INTERNAL_FUNCTION) {
 		if (function->common.function_name) {
 			zend_string_addref(function->common.function_name);

--- a/ext/opcache/tests/preload_trait_static.inc
+++ b/ext/opcache/tests/preload_trait_static.inc
@@ -1,0 +1,12 @@
+<?php
+
+trait Foo {
+    public function test() {
+        static $bar;
+        var_dump($bar);
+    }
+}
+
+class Bar {
+    use Foo;
+}

--- a/ext/opcache/tests/preload_trait_static.phpt
+++ b/ext/opcache/tests/preload_trait_static.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Preload trait with static variables in method
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.preload={PWD}/preload_trait_static.inc
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$bar = new Bar;
+$bar->test();
+?>
+--EXPECT--
+NULL


### PR DESCRIPTION
We need to make sure that trait methods with static variables
allocate a separate MAP slot for the static variables pointer,
rather than working in-place.