### PR TITLE
Fix #78402: pcntl_signal() misleading error message

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1005,6 +1005,7 @@ PHP_FUNCTION(pcntl_signal)
 	zval *handle;
 	zend_long signo;
 	zend_bool restart_syscalls = 1;
+	char *error = NULL;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lz|b", &signo, &handle, &restart_syscalls) == FAILURE) {
 		return;
@@ -1043,13 +1044,15 @@ PHP_FUNCTION(pcntl_signal)
 		RETURN_TRUE;
 	}
 
-	if (!zend_is_callable(handle, 0, NULL)) {
+	if (!zend_is_callable_ex(handle, NULL, 0, NULL, NULL, &error)) {
 		zend_string *func_name = zend_get_callable_name(handle);
 		PCNTL_G(last_error) = EINVAL;
-		php_error_docref(NULL, E_WARNING, "%s is not a callable function name error", ZSTR_VAL(func_name));
+		php_error_docref(NULL, E_WARNING, "Specified handler \"%s\" is not callable (%s)", ZSTR_VAL(func_name), error);
 		zend_string_release_ex(func_name, 0);
+		efree(error);
 		RETURN_FALSE;
 	}
+	ZEND_ASSERT(!error);
 
 	/* Add the function name to our signal table */
 	handle = zend_hash_index_update(&PCNTL_G(php_signal_table), signo, handle);

--- a/ext/pcntl/tests/pcntl_signal.phpt
+++ b/ext/pcntl/tests/pcntl_signal.phpt
@@ -42,6 +42,6 @@ bool(false)
 Warning: pcntl_signal(): Invalid signal %s
 bool(false)
 
-Warning: pcntl_signal(): not callable is not a callable function name error in %s
+Warning: pcntl_signal(): Specified handler "not callable" is not callable (%s) in %s
 bool(false)
 ok


### PR DESCRIPTION
An error message can be misleading when a handler
passed to pcntl_signal() is not callable.

(originally Bug #78402 | Converting null to string in error message is bad DX)