### PR TITLE
Change __sleep serialization for uninitialized typed properties

### DIFF
--- a/ext/standard/tests/serialize/sleep_undefined_declared_many_typed_properties.phpt
+++ b/ext/standard/tests/serialize/sleep_undefined_declared_many_typed_properties.phpt
@@ -1,0 +1,117 @@
+--TEST--
+__sleep() returning undefined declared typed properties
+--FILE--
+<?php
+
+class Test {
+    public int $a;
+    public int $b;
+    public int $c;
+    public int $d;
+    public int $e;
+    public ?int $f;
+    public int $g;
+    public iterable $h;
+    public ?ArrayObject $i;
+    public stdClass $j;
+
+    public function __construct() {
+        unset($this->a,$this->b,$this->c,$this->d,$this->e,$this->f,$this->g,$this->h,$this->i,$this->j);
+    }
+
+    public function __sleep() {
+        return ['a','b','c','d','e','f','g','h','i','j'];
+    }
+}
+
+var_dump($s = serialize(new Test));
+var_dump(unserialize($s));
+$t = new Test();
+$t->a = 1234;
+$t->f = null;
+var_dump($s = serialize($t));
+var_dump(unserialize($s));
+
+?>
+--EXPECTF--
+Notice: serialize(): "a" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "b" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "c" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "d" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "e" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "f" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "g" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "h" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "i" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "j" returned as member variable from __sleep() but does not exist in %s on line %d
+string(16) "O:4:"Test":00:{}"
+object(Test)#1 (0) {
+  ["a"]=>
+  uninitialized(int)
+  ["b"]=>
+  uninitialized(int)
+  ["c"]=>
+  uninitialized(int)
+  ["d"]=>
+  uninitialized(int)
+  ["e"]=>
+  uninitialized(int)
+  ["f"]=>
+  uninitialized(?int)
+  ["g"]=>
+  uninitialized(int)
+  ["h"]=>
+  uninitialized(iterable)
+  ["i"]=>
+  uninitialized(?ArrayObject)
+  ["j"]=>
+  uninitialized(stdClass)
+}
+
+Notice: serialize(): "b" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "c" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "d" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "e" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "g" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "h" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "i" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "j" returned as member variable from __sleep() but does not exist in %s on line %d
+string(41) "O:4:"Test":02:{s:1:"a";i:1234;s:1:"f";N;}"
+object(Test)#2 (2) {
+  ["a"]=>
+  int(1234)
+  ["b"]=>
+  uninitialized(int)
+  ["c"]=>
+  uninitialized(int)
+  ["d"]=>
+  uninitialized(int)
+  ["e"]=>
+  uninitialized(int)
+  ["f"]=>
+  NULL
+  ["g"]=>
+  uninitialized(int)
+  ["h"]=>
+  uninitialized(iterable)
+  ["i"]=>
+  uninitialized(?ArrayObject)
+  ["j"]=>
+  uninitialized(stdClass)
+}

--- a/ext/standard/tests/serialize/sleep_undefined_declared_typed_properties.phpt
+++ b/ext/standard/tests/serialize/sleep_undefined_declared_typed_properties.phpt
@@ -1,0 +1,38 @@
+--TEST--
+__sleep() returning undefined declared typed properties
+--FILE--
+<?php
+
+class Test {
+    public int $pub;
+    protected ?int $prot;
+    private stdClass $priv;
+
+    public function __construct() {
+        unset($this->pub, $this->prot, $this->priv);
+    }
+
+    public function __sleep() {
+        return ['pub', 'prot', 'priv'];
+    }
+}
+
+var_dump($s = serialize(new Test));
+var_dump(unserialize($s));
+
+?>
+--EXPECTF--
+Notice: serialize(): "pub" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "prot" returned as member variable from __sleep() but does not exist in %s on line %d
+
+Notice: serialize(): "priv" returned as member variable from __sleep() but does not exist in %s on line %d
+string(15) "O:4:"Test":0:{}"
+object(Test)#1 (0) {
+  ["pub"]=>
+  uninitialized(int)
+  ["prot":protected]=>
+  uninitialized(?int)
+  ["priv":"Test":private]=>
+  uninitialized(stdClass)
+}


### PR DESCRIPTION
Proposed fix for https://bugs.php.net/79002

**This will change the behavior of php 7.4 applications that use __sleep
with uninitialized typed properties.**

I think this is an improvement, because if `serialize()` returned a string,
I'd expect unserialize() to return equivalent data unless
wakeup/unserialize/__unserialize threw or misbehaved.


Previously, a TypeError would be thrown on unserialize if the property couldn't be null.
Additionally, if a typed property was nullable, then the unserialized data would be null instead of undefined if there was no default.

- Aside: this does not check what the defaults of the properties are. But that doesn't happen even when there's no `__sleep` method (handling this seems out of scope).

PHP 7.0 is able to handle leading 0s in the number of properties of an object.
I haven't tested earlier versions.