### PR TITLE
Disable optimizations for ASan instrumented builds

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -289,7 +289,7 @@ char *alloca();
 	(_default)
 #endif
 
-#if ZEND_DEBUG
+#if ZEND_DEBUG || defined(ZEND_WIN32_NEVER_INLINE)
 # define zend_always_inline inline
 # define zend_never_inline
 #else

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3426,8 +3426,8 @@ function toolset_setup_build_mode()
 			ADD_FLAG("LDFLAGS", "/incremental:no /debug /opt:ref,icf");
 		}
 		ADD_FLAG("CFLAGS", "/LD /MD /W3");
-		if (PHP_SANITIZER == "yes") {
-			ADD_FLAG("CFLAGS", "/Od /D NDebug /D NDEBUG /D ZEND_DEBUG=1");
+		if (PHP_SANITIZER == "yes" && CLANG_TOOLSET) {
+			ADD_FLAG("CFLAGS", "/Od /D NDebug /D NDEBUG /D ZEND_WIN32_NEVER_INLINE /D ZEND_DEBUG=0");
 		} else {
 			// Equivalent to Release_TSInline build -> best optimization
 			ADD_FLAG("CFLAGS", "/Ox /D NDebug /D NDEBUG /D ZEND_WIN32_FORCE_INLINE /GF /D ZEND_DEBUG=0");

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3425,8 +3425,13 @@ function toolset_setup_build_mode()
 			ADD_FLAG("CFLAGS", "/Zi");
 			ADD_FLAG("LDFLAGS", "/incremental:no /debug /opt:ref,icf");
 		}
-		// Equivalent to Release_TSInline build -> best optimization
-		ADD_FLAG("CFLAGS", "/LD /MD /W3 /Ox /D NDebug /D NDEBUG /D ZEND_WIN32_FORCE_INLINE /GF /D ZEND_DEBUG=0");
+		ADD_FLAG("CFLAGS", "/LD /MD /W3");
+		if (PHP_SANITIZER == "yes") {
+			ADD_FLAG("CFLAGS", "/Od /D NDebug /D NDEBUG /D ZEND_DEBUG=1");
+		} else {
+			// Equivalent to Release_TSInline build -> best optimization
+			ADD_FLAG("CFLAGS", "/Ox /D NDebug /D NDEBUG /D ZEND_WIN32_FORCE_INLINE /GF /D ZEND_DEBUG=0");
+		}
 
 		// if you have VS.Net /GS hardens the binary against buffer overruns
 		// ADD_FLAG("CFLAGS", "/GS");


### PR DESCRIPTION
ASan instrumentation does not support the MSVC debug runtime, but still
it does not make sense to enable optimizations for such builds, since
they are not meant for production usage anyway, and although memory
corruption issues are still found in optimized builds, the generated
diagnostics are close to being useless, and apparently sometimes even
outright wrong.  Therefore, we disable all optimizations for ASan
instrumented builds, and also enable `ZEND_DEBUG`, particularly to
suppress `__forceinline` to get even more useful diagnostics, but also
to possibly catch further issues.

---

To show the different behavior with and without this patch, a trivial
heap-use-after-free issue can be introduced:

````diff
 ext/standard/array.c | 4 ++++
 1 file changed, 4 insertions(+)

diff --git a/ext/standard/array.c b/ext/standard/array.c
index ec0890478a..12c5273a06 100644
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3802,6 +3802,10 @@ static zend_always_inline void php_array_merge_wrapper(INTERNAL_FUNCTION_PARAMET
 	zval *src_entry;
 	HashTable *src, *dest;
 	uint32_t count = 0;
+	char *buf = malloc(16);
+
+	free(buf);
+	printf("%s\n", buf);
 
 	ZEND_PARSE_PARAMETERS_START(0, -1)
 		Z_PARAM_VARIADIC('+', args, argc)
````

Without the patch:
````
C:\php-sdk\phpdev\vc15\x64\php-src-7.4
$ nmake test TESTS="--asan ext\standard\tests\array\001.phpt"

Microsoft (R) Program Maintenance Utility, Version 14.16.27034.0
Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.

          "C:\php-sdk\phpdev\vc15\x64\php-src-7.4\x64\Release_TS\php.exe" -n -d open_basedir= -d output_buffering=0 -d memory_limit=-1 run-tests.php -p "C:\php-sdk\phpdev\vc15\x64\php-src-7.4\x64\Release_TS\php.exe" -n -c "C:\php-sdk\phpdev\vc15\x64\php-src-7.4\x64\Release_TS\tmp-php.ini" --asan ext\standard\tests\array\001.phpt
=================================================================
==1988==ERROR: AddressSanitizer: heap-use-after-free on address 0x114858d03b50 at pc 0x7ffd125008ac bp 0x002fcd7fbf00 sp 0x002fcd7fbf40
READ of size 1 at 0x114858d03b50 thread T0
    #0 0x7ffd125008d4  (C:\Program Files\LLVM\lib\clang\9.0.0\lib\windows\clang_rt.asan_dynamic-x86_64.dll+0x1800308d4)
    #1 0x7ffd4ca380da  (C:\WINDOWS\System32\ucrtbase.dll+0x1800080da)
    #2 0x7ffd4cab0815  (C:\WINDOWS\System32\ucrtbase.dll+0x180080815)
    #3 0x7ffd4cab078a  (C:\WINDOWS\System32\ucrtbase.dll+0x18008078a)
    #4 0x7ffd4cab097c  (C:\WINDOWS\System32\ucrtbase.dll+0x18008097c)
    #5 0x7ffd0a601b4b in zif_array_merge C:\php-sdk\phpdev\vc15\x64\php-src-7.4\ext\standard\array.c:3911
    #6 0x7ffd09f03b6c in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:1314
    #7 0x7ffd09dface9 in execute_ex C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:53611
    #8 0x7ffd09dfb709 in zend_execute C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:57913
    #9 0x7ffd09cabb78 in zend_execute_scripts C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend.c:1665
    #10 0x7ffd0a11492d in php_execute_script C:\php-sdk\phpdev\vc15\x64\php-src-7.4\main\main.c:2617
    #11 0x7ff63fb8470b in do_cli C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:961
    #12 0x7ff63fb81dbb in main C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:1352
    #13 0x7ff63fba2553 in __scrt_common_main_seh d:\agent\_work\2\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #14 0x7ffd4dca7bd3  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017bd3)
    #15 0x7ffd4fb0ced0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18006ced0)

0x114858d03b50 is located 0 bytes inside of 16-byte region [0x114858d03b50,0x114858d03b60)
freed by thread T0 here:
    #0 0x7ffd12504ae4  (C:\Program Files\LLVM\lib\clang\9.0.0\lib\windows\clang_rt.asan_dynamic-x86_64.dll+0x180034ae4)
    #1 0x7ffd0a601b43 in zif_array_merge C:\php-sdk\phpdev\vc15\x64\php-src-7.4\ext\standard\array.c:3911
    #2 0x7ffd09f03b6c in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:1314
    #3 0x7ffd09dface9 in execute_ex C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:53611
    #4 0x7ffd09dfb709 in zend_execute C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:57913
    #5 0x7ffd09cabb78 in zend_execute_scripts C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend.c:1665
    #6 0x7ffd0a11492d in php_execute_script C:\php-sdk\phpdev\vc15\x64\php-src-7.4\main\main.c:2617
    #7 0x7ff63fb8470b in do_cli C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:961
    #8 0x7ff63fb81dbb in main C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:1352
    #9 0x7ff63fba2553 in __scrt_common_main_seh d:\agent\_work\2\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #10 0x7ffd4dca7bd3  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017bd3)
    #11 0x7ffd4fb0ced0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18006ced0)

previously allocated by thread T0 here:
    #0 0x7ffd12504bf4  (C:\Program Files\LLVM\lib\clang\9.0.0\lib\windows\clang_rt.asan_dynamic-x86_64.dll+0x180034bf4)
    #1 0x7ffd0a601b37 in zif_array_merge C:\php-sdk\phpdev\vc15\x64\php-src-7.4\ext\standard\array.c:3911
    #2 0x7ffd09f03b6c in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:1314
    #3 0x7ffd09dface9 in execute_ex C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:53611
    #4 0x7ffd09dfb709 in zend_execute C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:57913
    #5 0x7ffd09cabb78 in zend_execute_scripts C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend.c:1665
    #6 0x7ffd0a11492d in php_execute_script C:\php-sdk\phpdev\vc15\x64\php-src-7.4\main\main.c:2617
    #7 0x7ff63fb8470b in do_cli C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:961
    #8 0x7ff63fb81dbb in main C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:1352
    #9 0x7ff63fba2553 in __scrt_common_main_seh d:\agent\_work\2\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #10 0x7ffd4dca7bd3  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017bd3)
    #11 0x7ffd4fb0ced0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18006ced0)

SUMMARY: AddressSanitizer: heap-use-after-free (C:\Program Files\LLVM\lib\clang\9.0.0\lib\windows\clang_rt.asan_dynamic-x86_64.dll+0x1800308d4)
Shadow bytes around the buggy address:
  0x036d63ea0710: fa fa 03 fa fa fa 03 fa fa fa 03 fa fa fa 07 fa
  0x036d63ea0720: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x036d63ea0730: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x036d63ea0740: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x036d63ea0750: fa fa fd fa fa fa fd fa fa fa fd fd fa fa fd fa
=>0x036d63ea0760: fa fa fd fa fa fa fd fd fa fa[fd]fd fa fa fa fa
  0x036d63ea0770: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x036d63ea0780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x036d63ea0790: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x036d63ea07a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x036d63ea07b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==1988==ABORTING
NMAKE : fatal error U1077: "C:\php-sdk\phpdev\vc15\x64\php-src-7.4\x64\Release_TS\php.exe": Rückgabe-Code "0x1"
Stop.
````

While the issue is detected, the diagnostics not really helpful.

But with the patch, the diagnostics are dead on:
````
C:\php-sdk\phpdev\vc15\x64\php-src-7.4
$ nmake test TESTS="--asan ext\standard\tests\array\001.phpt"

Microsoft (R) Program Maintenance Utility, Version 14.16.27034.0
Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.

          "C:\php-sdk\phpdev\vc15\x64\php-src-7.4\x64\Release_TS\php.exe" -n -d open_basedir= -d output_buffering=0 -d memory_limit=-1 run-tests.php -p "C:\php-sdk\phpdev\vc15\x64\php-src-7.4\x64\Release_TS\php.exe" -n -c "C:\php-sdk\phpdev\vc15\x64\php-src-7.4\x64\Release_TS\tmp-php.ini" ext\standard\tests\array\001.phpt
=================================================================
==8976==ERROR: AddressSanitizer: heap-use-after-free on address 0x11b497203b50 at pc 0x7ffd124fe2a9 bp 0x0012e07fa860 sp 0x0012e07fa8a0
READ of size 2 at 0x11b497203b50 thread T0
    #0 0x7ffd124fe2d1  (C:\Program Files\LLVM\lib\clang\9.0.0\lib\windows\clang_rt.asan_dynamic-x86_64.dll+0x18002e2d1)
    #1 0x7ffd4caaf316  (C:\WINDOWS\System32\ucrtbase.dll+0x18007f316)
    #2 0x7ffd4ca7f27d  (C:\WINDOWS\System32\ucrtbase.dll+0x18004f27d)
    #3 0x7ffd4ca52595  (C:\WINDOWS\System32\ucrtbase.dll+0x180022595)
    #4 0x7ffd4ca527b9  (C:\WINDOWS\System32\ucrtbase.dll+0x1800227b9)
    #5 0x7ffd4ca528f6  (C:\WINDOWS\System32\ucrtbase.dll+0x1800228f6)
    #6 0x7ffd4ca52993  (C:\WINDOWS\System32\ucrtbase.dll+0x180022993)
    #7 0x7ffcf74ad950 in _vfprintf_l C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt\stdio.h:643
    #8 0x7ffcf7c731e4 in printf C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt\stdio.h:958
    #9 0x7ffcf87653eb in php_array_merge_wrapper C:\php-sdk\phpdev\vc15\x64\php-src-7.4\ext\standard\array.c:3808
    #10 0x7ffcf876534f in zif_array_merge C:\php-sdk\phpdev\vc15\x64\php-src-7.4\ext\standard\array.c:3911
    #11 0x7ffcf779a33e in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:1314
    #12 0x7ffcf75b5724 in execute_ex C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:53611
    #13 0x7ffcf75b6347 in zend_execute C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:57913
    #14 0x7ffcf744104f in zend_execute_scripts C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend.c:1665
    #15 0x7ffcf7b42e70 in php_execute_script C:\php-sdk\phpdev\vc15\x64\php-src-7.4\main\main.c:2617
    #16 0x7ff6f4fa5b3c in do_cli C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:961
    #17 0x7ff6f4fa2b22 in main C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:1352
    #18 0x7ff6f4fdbc33 in __scrt_common_main_seh d:\agent\_work\2\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #19 0x7ffd4dca7bd3  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017bd3)
    #20 0x7ffd4fb0ced0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18006ced0)

0x11b497203b50 is located 0 bytes inside of 16-byte region [0x11b497203b50,0x11b497203b60)
freed by thread T0 here:
    #0 0x7ffd12504ae4  (C:\Program Files\LLVM\lib\clang\9.0.0\lib\windows\clang_rt.asan_dynamic-x86_64.dll+0x180034ae4)
    #1 0x7ffcf87653d7 in php_array_merge_wrapper C:\php-sdk\phpdev\vc15\x64\php-src-7.4\ext\standard\array.c:3807
    #2 0x7ffcf876534f in zif_array_merge C:\php-sdk\phpdev\vc15\x64\php-src-7.4\ext\standard\array.c:3911
    #3 0x7ffcf779a33e in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:1314
    #4 0x7ffcf75b5724 in execute_ex C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:53611
    #5 0x7ffcf75b6347 in zend_execute C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:57913
    #6 0x7ffcf744104f in zend_execute_scripts C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend.c:1665
    #7 0x7ffcf7b42e70 in php_execute_script C:\php-sdk\phpdev\vc15\x64\php-src-7.4\main\main.c:2617
    #8 0x7ff6f4fa5b3c in do_cli C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:961
    #9 0x7ff6f4fa2b22 in main C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:1352
    #10 0x7ff6f4fdbc33 in __scrt_common_main_seh d:\agent\_work\2\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #11 0x7ffd4dca7bd3  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017bd3)
    #12 0x7ffd4fb0ced0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18006ced0)

previously allocated by thread T0 here:
    #0 0x7ffd12504bf4  (C:\Program Files\LLVM\lib\clang\9.0.0\lib\windows\clang_rt.asan_dynamic-x86_64.dll+0x180034bf4)
    #1 0x7ffcf87653c1 in php_array_merge_wrapper C:\php-sdk\phpdev\vc15\x64\php-src-7.4\ext\standard\array.c:3805
    #2 0x7ffcf876534f in zif_array_merge C:\php-sdk\phpdev\vc15\x64\php-src-7.4\ext\standard\array.c:3911
    #3 0x7ffcf779a33e in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:1314
    #4 0x7ffcf75b5724 in execute_ex C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:53611
    #5 0x7ffcf75b6347 in zend_execute C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend_vm_execute.h:57913
    #6 0x7ffcf744104f in zend_execute_scripts C:\php-sdk\phpdev\vc15\x64\php-src-7.4\Zend\zend.c:1665
    #7 0x7ffcf7b42e70 in php_execute_script C:\php-sdk\phpdev\vc15\x64\php-src-7.4\main\main.c:2617
    #8 0x7ff6f4fa5b3c in do_cli C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:961
    #9 0x7ff6f4fa2b22 in main C:\php-sdk\phpdev\vc15\x64\php-src-7.4\sapi\cli\php_cli.c:1352
    #10 0x7ff6f4fdbc33 in __scrt_common_main_seh d:\agent\_work\2\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #11 0x7ffd4dca7bd3  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017bd3)
    #12 0x7ffd4fb0ced0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18006ced0)

SUMMARY: AddressSanitizer: heap-use-after-free (C:\Program Files\LLVM\lib\clang\9.0.0\lib\windows\clang_rt.asan_dynamic-x86_64.dll+0x18002e2d1)
Shadow bytes around the buggy address:
  0x03e72a040710: fa fa 00 00 fa fa 00 06 fa fa 03 fa fa fa 03 fa
  0x03e72a040720: fa fa 03 fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x03e72a040730: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fd
  0x03e72a040740: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x03e72a040750: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fa
=>0x03e72a040760: fa fa fd fa fa fa fd fd fa fa[fd]fd fa fa fa fa
  0x03e72a040770: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x03e72a040780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x03e72a040790: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x03e72a0407a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x03e72a0407b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==8976==ABORTING
NMAKE : fatal error U1077: "C:\php-sdk\phpdev\vc15\x64\php-src-7.4\x64\Release_TS\php.exe": Rückgabe-Code "0x1"
Stop.
````
