### PR TITLE
Fix #79038: PDOStatement::nextRowset() leaks column values

### DIFF
--- a/ext/pdo_odbc/php_pdo_odbc_int.h
+++ b/ext/pdo_odbc/php_pdo_odbc_int.h
@@ -151,7 +151,8 @@ typedef struct {
 	zend_ulong convbufsize;
 	unsigned going_long:1;
 	unsigned assume_utf8:1;
-	unsigned _spare:30;
+	signed col_count:16;
+	unsigned _spare:14;
 } pdo_odbc_stmt;
 
 typedef struct {


### PR DESCRIPTION
Firstly, we must not rely on `stmt->column_count` when freeing the
driver specific column values, but rather store the column count in
the driver data.  Since the column count is a `short`, 16 bit are
sufficient, so we can store it in reserved bits of `pdo_odbc_stmt`.

Furthermore, we must not allocate new column value storage when the
statement is not executed, but rather when the column value storage has
not been allocated.

Finally, we have to introduce a driver specific `cursor_closer` to
avoid that `::closeCursor()` calls `odbc_stmt_next_rowset()` which then
frees the column value storage, because it may be still needed for
bound columns.