### PR TITLE
Don't enable sanitizer by default for Windows snapshot builds

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -442,7 +442,8 @@ can be built that way. \
 		 'pcre-regex', 'fastcgi', 'force-cgi-redirect',
 		 'path-info-check', 'zts', 'ipv6', 'memory-limit',
 		 'zend-multibyte', 'fd-setsize', 'memory-manager',
-		 'pgi', 'pgo', 'all-shared', 'config-profile'
+		 'pgi', 'pgo', 'all-shared', 'config-profile',
+		 'sanitizer'
 		);
 	var force;
 


### PR DESCRIPTION
Snapshot builds are release builds, and therefore enabling sanitizers
is undesireable.