### PR TITLE
Use RETURN_THROWS() macro when an exception is thrown

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -674,6 +674,7 @@ END_EXTERN_C()
 #define RETURN_ZVAL(zv, copy, dtor)		do { RETVAL_ZVAL(zv, copy, dtor); return; } while (0)
 #define RETURN_FALSE  					do { RETVAL_FALSE; return; } while (0)
 #define RETURN_TRUE   					do { RETVAL_TRUE; return; } while (0)
+#define RETURN_THROWS()					do { ZEND_ASSERT(EG(exception)); (void) return_value; return; } while (0)
 
 #define HASH_OF(p) (Z_TYPE_P(p)==IS_ARRAY ? Z_ARRVAL_P(p) : ((Z_TYPE_P(p)==IS_OBJECT ? Z_OBJ_HT_P(p)->get_properties(Z_OBJ_P(p)) : NULL)))
 #define ZVAL_IS_NULL(z) (Z_TYPE_P(z) == IS_NULL)

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -1264,7 +1264,7 @@ PHP_FUNCTION(min)
 				ZVAL_COPY_DEREF(return_value, result);
 			} else {
 				zend_value_error("Array must contain at least one element");
-				return;
+				RETURN_THROWS();
 			}
 		}
 	} else {
@@ -1311,7 +1311,7 @@ PHP_FUNCTION(max)
 				ZVAL_COPY_DEREF(return_value, result);
 			} else {
 				zend_value_error("Array must contain at least one element");
-				return;
+				RETURN_THROWS();
 			}
 		}
 	} else {
@@ -2452,18 +2452,18 @@ PHP_FUNCTION(extract)
 
 	if (extract_type < EXTR_OVERWRITE || extract_type > EXTR_IF_EXISTS) {
 		zend_value_error("Invalid extract type");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (extract_type > EXTR_SKIP && extract_type <= EXTR_PREFIX_IF_EXISTS && ZEND_NUM_ARGS() < 3) {
 		zend_value_error("Specified extract type requires the prefix parameter");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (prefix) {
 		if (ZSTR_LEN(prefix) && !php_valid_var_name(ZSTR_VAL(prefix), ZSTR_LEN(prefix))) {
 			zend_value_error("Prefix is not a valid identifier");
-			return;
+			RETURN_THROWS();
 		}
 	}
 
@@ -2620,10 +2620,10 @@ PHP_FUNCTION(array_fill)
 	if (EXPECTED(num > 0)) {
 		if (sizeof(num) > 4 && UNEXPECTED(EXPECTED(num > 0x7fffffff))) {
 			zend_value_error("Too many elements");
-			return;
+			RETURN_THROWS();
 		} else if (UNEXPECTED(start_key > ZEND_LONG_MAX - num + 1)) {
 			zend_throw_error(NULL, "Cannot add element to the array as the next element is already occupied");
-			return;
+			RETURN_THROWS();
 		} else if (EXPECTED(start_key >= 0) && EXPECTED(start_key < num)) {
 			/* create packed array */
 			Bucket *p;
@@ -2669,7 +2669,7 @@ PHP_FUNCTION(array_fill)
 		RETURN_EMPTY_ARRAY();
 	} else {
 		zend_value_error("Number of elements can't be negative");
-		return;
+		RETURN_THROWS();
 	}
 }
 /* }}} */
@@ -2708,7 +2708,7 @@ PHP_FUNCTION(array_fill_keys)
 		if (__calc_size >= (double)HT_MAX_SIZE) { \
 			zend_value_error(\
 					"The supplied range exceeds the maximum array size: start=%0.0f end=%0.0f", end, start); \
-			return; \
+			RETURN_THROWS(); \
 		} \
 		size = (uint32_t)_php_math_round(__calc_size, 0, PHP_ROUND_HALF_UP); \
 		array_init_size(return_value, size); \
@@ -2720,7 +2720,7 @@ PHP_FUNCTION(array_fill_keys)
 		if (__calc_size >= HT_MAX_SIZE - 1) { \
 			zend_value_error(\
 					"The supplied range exceeds the maximum array size: start=" ZEND_LONG_FMT " end=" ZEND_LONG_FMT, end, start); \
-			return; \
+			RETURN_THROWS(); \
 		} \
 		size = (uint32_t)(__calc_size + 1); \
 		array_init_size(return_value, size); \
@@ -2817,7 +2817,7 @@ double_str:
 
 		if (zend_isinf(high) || zend_isinf(low)) {
 			zend_value_error("Invalid range supplied: start=%0.0f end=%0.0f", low, high);
-			return;
+			RETURN_THROWS();
 		}
 
 		if (low > high) { 		/* Negative steps */
@@ -2910,7 +2910,7 @@ long_str:
 err:
 	if (err) {
 		zend_value_error("Step exceeds the specified range");
-		return;
+		RETURN_THROWS();
 	}
 }
 /* }}} */
@@ -4390,7 +4390,7 @@ PHP_FUNCTION(array_pad)
 	pad_size_abs = ZEND_ABS(pad_size);
 	if (pad_size_abs < 0 || pad_size_abs - input_size > Z_L(1048576)) {
 		zend_value_error("You may only pad up to 1048576 elements at a time");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (input_size >= pad_size_abs) {
@@ -4715,7 +4715,7 @@ static void php_array_intersect_key(INTERNAL_FUNCTION_PARAMETERS, int data_compa
 	}
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), param_spec, &args, &argc, &BG(user_compare_fci), &BG(user_compare_fci_cache)) == FAILURE) {
-		return;
+		RETURN_THROWS();
 	}
 
 	for (i = 0; i < argc; i++) {
@@ -4809,7 +4809,7 @@ static void php_array_intersect(INTERNAL_FUNCTION_PARAMETERS, int behavior, int 
 		}
 
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), param_spec, &args, &arr_argc, &fci1, &fci1_cache) == FAILURE) {
-			return;
+			RETURN_THROWS();
 		}
 		fci_data = &fci1;
 		fci_data_cache = &fci1_cache;
@@ -4861,7 +4861,7 @@ static void php_array_intersect(INTERNAL_FUNCTION_PARAMETERS, int behavior, int 
 		}
 
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), param_spec, &args, &arr_argc, &fci1, &fci1_cache, &fci2, &fci2_cache) == FAILURE) {
-			return;
+			RETURN_THROWS();
 		}
 
 	} else {
@@ -5107,7 +5107,7 @@ static void php_array_diff_key(INTERNAL_FUNCTION_PARAMETERS, int data_compare_ty
 			return;
 		}
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "+f", &args, &argc, &BG(user_compare_fci), &BG(user_compare_fci_cache)) == FAILURE) {
-			return;
+			RETURN_THROWS();
 		}
 		diff_data_compare_func = zval_user_compare;
 	} else {
@@ -5116,7 +5116,7 @@ static void php_array_diff_key(INTERNAL_FUNCTION_PARAMETERS, int data_compare_ty
 			return;
 		}
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
-			return;
+			RETURN_THROWS();
 		}
 		if (data_compare_type == DIFF_COMP_DATA_INTERNAL) {
 			diff_data_compare_func = zval_compare;
@@ -5214,7 +5214,7 @@ static void php_array_diff(INTERNAL_FUNCTION_PARAMETERS, int behavior, int data_
 		}
 
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), param_spec, &args, &arr_argc, &fci1, &fci1_cache) == FAILURE) {
-			return;
+			RETURN_THROWS();
 		}
 		fci_data = &fci1;
 		fci_data_cache = &fci1_cache;
@@ -5266,7 +5266,7 @@ static void php_array_diff(INTERNAL_FUNCTION_PARAMETERS, int behavior, int data_
 		}
 
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), param_spec, &args, &arr_argc, &fci1, &fci1_cache, &fci2, &fci2_cache) == FAILURE) {
-			return;
+			RETURN_THROWS();
 		}
 
 	} else {
@@ -5854,7 +5854,7 @@ PHP_FUNCTION(array_rand)
 
 	if (num_avail == 0) {
 		zend_value_error("Array is empty");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (num_req == 1) {
@@ -5895,7 +5895,7 @@ PHP_FUNCTION(array_rand)
 
 	if (num_req <= 0 || num_req > num_avail) {
 		zend_value_error("Second argument has to be between 1 and the number of elements in the array");
-		return;
+		RETURN_THROWS();
 	}
 
 	/* Make the return value an array only if we need to pass back more than one result. */

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1561,7 +1561,7 @@ PHP_FUNCTION(putenv)
 
 	if (setting_len == 0 || setting[0] == '=') {
 		zend_value_error("Invalid parameter syntax");
-		return;
+		RETURN_THROWS();
 	}
 
 	pe.putenv_string = estrndup(setting, setting_len);
@@ -1944,7 +1944,7 @@ PHP_FUNCTION(sleep)
 
 	if (num < 0) {
 		zend_value_error("Number of seconds must be greater than or equal to 0");
-		return;
+		RETURN_THROWS();
 	}
 
 	RETURN_LONG(php_sleep((unsigned int)num));
@@ -1964,7 +1964,7 @@ PHP_FUNCTION(usleep)
 
 	if (num < 0) {
 		zend_value_error("Number of microseconds must be greater than or equal to 0");
-		return;
+		RETURN_THROWS();
 	}
 	if (usleep((unsigned int)num) < 0) {
 #if ZEND_DEBUG
@@ -1991,11 +1991,11 @@ PHP_FUNCTION(time_nanosleep)
 
 	if (tv_sec < 0) {
 		zend_value_error("The seconds value must be greater than 0");
-		return;
+		RETURN_THROWS();
 	}
 	if (tv_nsec < 0) {
 		zend_value_error("The nanoseconds value must be greater than 0");
-		return;
+		RETURN_THROWS();
 	}
 
 	php_req.tv_sec = (time_t) tv_sec;
@@ -2009,7 +2009,7 @@ PHP_FUNCTION(time_nanosleep)
 		return;
 	} else if (errno == EINVAL) {
 		zend_value_error("Nanoseconds was not in the range 0 to 999 999 999 or seconds was negative");
-		return;
+		RETURN_THROWS();
 	}
 
 	RETURN_FALSE;

--- a/ext/standard/dir.c
+++ b/ext/standard/dir.c
@@ -560,7 +560,7 @@ PHP_FUNCTION(scandir)
 
 	if (dirn_len < 1) {
 		zend_value_error("Directory name cannot be empty");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (zcontext) {

--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -384,7 +384,7 @@ PHP_FUNCTION(dns_check_record)
 
 	if (hostname_len == 0) {
 		zend_value_error("Host cannot be empty");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (rectype) {

--- a/ext/standard/dns_win32.c
+++ b/ext/standard/dns_win32.c
@@ -49,7 +49,7 @@ PHP_FUNCTION(dns_get_mx) /* {{{ */
 	PDNS_RECORD     pResult, pRec;          /* Pointer to DNS_RECORD structure */
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sz|z", &hostname, &hostname_len, &mx_list, &weight_list) == FAILURE) {
-		return;
+		RETURN_THROWS();
 	}
 
 	status = DnsQuery_A(hostname, DNS_TYPE_MX, DNS_QUERY_STANDARD, NULL, &pResult, NULL);
@@ -103,12 +103,12 @@ PHP_FUNCTION(dns_check_record)
 	PDNS_RECORD     pResult;          /* Pointer to DNS_RECORD structure */
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s", &hostname, &hostname_len, &rectype, &rectype_len) == FAILURE) {
-		return;
+		RETURN_THROWS();
 	}
 
 	if (hostname_len == 0) {
 		zend_value_error("Host cannot be empty");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (rectype) {
@@ -357,7 +357,7 @@ PHP_FUNCTION(dns_get_record)
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|lz!z!b",
 			&hostname, &hostname_len, &type_param, &authns, &addtl, &raw) == FAILURE) {
-		return;
+		RETURN_THROWS();
 	}
 
 	if (authns) {

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -544,7 +544,7 @@ PHP_FUNCTION(file_get_contents)
 
 	if (ZEND_NUM_ARGS() == 5 && maxlen < 0) {
 		zend_value_error("Length must be greater than or equal to zero");
-		return;
+		RETURN_THROWS();
 	}
 
 	context = php_stream_context_from_zval(zcontext, 0);

--- a/ext/standard/levenshtein.c
+++ b/ext/standard/levenshtein.c
@@ -99,21 +99,21 @@ PHP_FUNCTION(levenshtein)
 	switch (argc) {
 		case 2: /* just two strings: use maximum performance version */
 			if (zend_parse_parameters(2, "ss", &str1, &str1_len, &str2, &str2_len) == FAILURE) {
-				return;
+				RETURN_THROWS();
 			}
 			distance = reference_levdist(str1, str1_len, str2, str2_len, 1, 1, 1);
 			break;
 
 		case 5: /* more general version: calc cost by ins/rep/del weights */
 			if (zend_parse_parameters(5, "sslll", &str1, &str1_len, &str2, &str2_len, &cost_ins, &cost_rep, &cost_del) == FAILURE) {
-				return;
+				RETURN_THROWS();
 			}
 			distance = reference_levdist(str1, str1_len, str2, str2_len, cost_ins, cost_rep, cost_del);
 			break;
 
 		case 3: /* most general version: calc cost by user-supplied function */
 			if (zend_parse_parameters(3, "sss", &str1, &str1_len, &str2, &str2_len, &callback_name, &callback_len) == FAILURE) {
-				return;
+				RETURN_THROWS();
 			}
 			distance = custom_levdist(str1, str2, callback_name);
 			break;

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -626,7 +626,7 @@ PHP_FUNCTION(log)
 
 	if (base <= 0.0) {
 		zend_value_error("Base must be greater than 0");
-		return;
+		RETURN_THROWS();
 	}
 
 	RETURN_DOUBLE(log(num) / log(base));
@@ -1008,11 +1008,11 @@ PHP_FUNCTION(base_convert)
 
 	if (frombase < 2 || frombase > 36) {
 		zend_value_error("Invalid `from base' (" ZEND_LONG_FMT ")", frombase);
-		return;
+		RETURN_THROWS();
 	}
 	if (tobase < 2 || tobase > 36) {
 		zend_value_error("Invalid `to base' (" ZEND_LONG_FMT ")", tobase);
-		return;
+		RETURN_THROWS();
 	}
 
 	_php_math_basetozval(Z_STR_P(number), (int)frombase, &temp);

--- a/ext/standard/mt_rand.c
+++ b/ext/standard/mt_rand.c
@@ -326,7 +326,7 @@ PHP_FUNCTION(mt_rand)
 
 	if (UNEXPECTED(max < min)) {
 		zend_value_error("max (" ZEND_LONG_FMT ") is smaller than min (" ZEND_LONG_FMT ")", max, min);
-		return;
+		RETURN_THROWS();
 	}
 
 	RETURN_LONG(php_mt_rand_common(min, max));

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -671,7 +671,7 @@ PHP_FUNCTION(password_hash)
 		zend_string *algostr = zval_get_string(zalgo);
 		zend_value_error("Unknown password hashing algorithm: %s", ZSTR_VAL(algostr));
 		zend_string_release(algostr);
-		return;
+		RETURN_THROWS();
 	}
 
 	digest = algo->hash(password, options);
@@ -679,7 +679,7 @@ PHP_FUNCTION(password_hash)
 		if (!EG(exception)) {
 			zend_throw_error(NULL, "Password hashing failed for unknown reason");
 		}
-		return;
+		RETURN_THROWS();
 	}
 
 	RETURN_NEW_STR(digest);

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -529,7 +529,7 @@ PHP_FUNCTION(proc_open)
 		uint32_t num_elems = zend_hash_num_elements(Z_ARRVAL_P(command_zv));
 		if (num_elems == 0) {
 			zend_value_error("Command array must have at least one element");
-			return;
+			RETURN_THROWS();
 		}
 
 #ifdef PHP_WIN32

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -384,7 +384,7 @@ PHP_FUNCTION(stream_socket_recvfrom)
 
 	if (to_read <= 0) {
 		zend_value_error("Length parameter must be greater than 0");
-		return;
+		RETURN_THROWS();
 	}
 
 	read_buf = zend_string_alloc(to_read, 0);
@@ -785,7 +785,7 @@ PHP_FUNCTION(stream_select)
 
 	if (!sets) {
 		zend_value_error("No stream arrays were passed");
-		return;
+		RETURN_THROWS();
 	}
 
 	PHP_SAFE_MAX_FD(max_fd, max_set_count);
@@ -794,10 +794,10 @@ PHP_FUNCTION(stream_select)
 	if (!secnull) {
 		if (sec < 0) {
 			zend_value_error("The seconds parameter must be greater than 0");
-			return;
+			RETURN_THROWS();
 		} else if (usec < 0) {
 			zend_value_error("The microseconds parameter must be greater than 0");
-			return;
+			RETURN_THROWS();
 		}
 
 		/* Windows, Solaris and BSD do not like microsecond values which are >= 1 sec */
@@ -1299,7 +1299,7 @@ PHP_FUNCTION(stream_get_line)
 
 	if (max_length < 0) {
 		zend_value_error("The maximum allowed length must be greater than or equal to zero");
-		return;
+		RETURN_THROWS();
 	}
 	if (!max_length) {
 		max_length = PHP_SOCK_CHUNK_SIZE;
@@ -1435,7 +1435,7 @@ PHP_FUNCTION(stream_set_chunk_size)
 
 	if (csize <= 0) {
 		zend_value_error("The chunk size must be a positive integer, " ZEND_LONG_FMT " given", csize);
-		return;
+		RETURN_THROWS();
 	}
 	/* stream.chunk_size is actually a size_t, but php_stream_set_option
 	 * can only use an int to accept the new value and return the old one.
@@ -1443,7 +1443,7 @@ PHP_FUNCTION(stream_set_chunk_size)
 	 */
 	if (csize > INT_MAX) {
 		zend_value_error("The chunk size cannot be larger than %d", INT_MAX);
-		return;
+		RETURN_THROWS();
 	}
 
 	php_stream_from_zval(stream, zstream);
@@ -1510,7 +1510,7 @@ PHP_FUNCTION(stream_socket_enable_crypto)
 
 			if (!GET_CTX_OPT(stream, "ssl", "crypto_method", val)) {
 				zend_value_error("When enabling encryption you must specify the crypto type");
-				return;
+				RETURN_THROWS();
 			}
 
 			cryptokind = Z_LVAL_P(val);

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -932,12 +932,12 @@ PHP_FUNCTION(wordwrap)
 
 	if (breakchar_len == 0) {
 		zend_value_error("Break string cannot be empty");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (linelength == 0 && docut) {
 		zend_value_error("Can't force cut when width is zero");
-		return;
+		RETURN_THROWS();
 	}
 
 	/* Special case for a single-character break as it needs no
@@ -1144,7 +1144,7 @@ PHP_FUNCTION(explode)
 
 	if (ZSTR_LEN(delim) == 0) {
 		zend_value_error("Empty delimiter");
-		return;
+		RETURN_THROWS();
 	}
 
 	array_init(return_value);
@@ -1635,7 +1635,7 @@ PHP_FUNCTION(dirname)
 	} else if (levels < 1) {
 		zend_value_error("Invalid argument, levels must be >= 1");
 		zend_string_efree(ret);
-		return;
+		RETURN_THROWS();
 	} else {
 		/* Some levels up */
 		do {
@@ -1875,7 +1875,7 @@ PHP_FUNCTION(strpos)
 	}
 	if (offset < 0 || (size_t)offset > ZSTR_LEN(haystack)) {
 		zend_value_error("Offset not contained in string");
-		return;
+		RETURN_THROWS();
 	}
 
 	found = (char*)php_memnstr(ZSTR_VAL(haystack) + offset,
@@ -1911,7 +1911,7 @@ PHP_FUNCTION(stripos)
 	}
 	if (offset < 0 || (size_t)offset > ZSTR_LEN(haystack)) {
 		zend_value_error("Offset not contained in string");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (ZSTR_LEN(needle) > ZSTR_LEN(haystack)) {
@@ -1953,14 +1953,14 @@ PHP_FUNCTION(strrpos)
 	if (offset >= 0) {
 		if ((size_t)offset > ZSTR_LEN(haystack)) {
 			zend_value_error("Offset not contained in string");
-			return;
+			RETURN_THROWS();
 		}
 		p = ZSTR_VAL(haystack) + (size_t)offset;
 		e = ZSTR_VAL(haystack) + ZSTR_LEN(haystack);
 	} else {
 		if (offset < -ZEND_LONG_MAX || (size_t)(-offset) > ZSTR_LEN(haystack)) {
 			zend_value_error("Offset not contained in string");
-			return;
+			RETURN_THROWS();
 		}
 
 		p = ZSTR_VAL(haystack);
@@ -2003,7 +2003,7 @@ PHP_FUNCTION(strripos)
 		if (offset >= 0) {
 			if ((size_t)offset > ZSTR_LEN(haystack)) {
 				zend_value_error("Offset not contained in string");
-				return;
+				RETURN_THROWS();
 			}
 			p = ZSTR_VAL(haystack) + (size_t)offset;
 			e = ZSTR_VAL(haystack) + ZSTR_LEN(haystack) - 1;
@@ -2011,7 +2011,7 @@ PHP_FUNCTION(strripos)
 			p = ZSTR_VAL(haystack);
 			if (offset < -ZEND_LONG_MAX || (size_t)(-offset) > ZSTR_LEN(haystack)) {
 				zend_value_error("Offset not contained in string");
-				return;
+				RETURN_THROWS();
 			}
 			e = ZSTR_VAL(haystack) + (ZSTR_LEN(haystack) + (size_t)offset);
 		}
@@ -2031,7 +2031,7 @@ PHP_FUNCTION(strripos)
 		if ((size_t)offset > ZSTR_LEN(haystack)) {
 			zend_string_release_ex(haystack_dup, 0);
 			zend_value_error("Offset not contained in string");
-			return;
+			RETURN_THROWS();
 		}
 		p = ZSTR_VAL(haystack_dup) + offset;
 		e = ZSTR_VAL(haystack_dup) + ZSTR_LEN(haystack);
@@ -2039,7 +2039,7 @@ PHP_FUNCTION(strripos)
 		if (offset < -ZEND_LONG_MAX || (size_t)(-offset) > ZSTR_LEN(haystack)) {
 			zend_string_release_ex(haystack_dup, 0);
 			zend_value_error("Offset not contained in string");
-			return;
+			RETURN_THROWS();
 		}
 
 		p = ZSTR_VAL(haystack_dup);
@@ -2147,7 +2147,7 @@ PHP_FUNCTION(chunk_split)
 
 	if (chunklen <= 0) {
 		zend_value_error("Chunk length should be greater than zero");
-		return;
+		RETURN_THROWS();
 	}
 
 	if ((size_t)chunklen > ZSTR_LEN(str)) {
@@ -5276,7 +5276,7 @@ PHP_FUNCTION(str_repeat)
 
 	if (mult < 0) {
 		zend_value_error("Second argument has to be greater than or equal to 0");
-		return;
+		RETURN_THROWS();
 	}
 
 	/* Don't waste our time if it's empty */
@@ -5334,7 +5334,7 @@ PHP_FUNCTION(count_chars)
 
 	if (mymode < 0 || mymode > 4) {
 		zend_value_error("Unknown mode");
-		return;
+		RETURN_THROWS();
 	}
 
 	buf = (const unsigned char *) ZSTR_VAL(input);
@@ -5523,7 +5523,7 @@ PHP_FUNCTION(substr_count)
 
 	if (needle_len == 0) {
 		zend_value_error("Empty substring");
-		return;
+		RETURN_THROWS();
 	}
 
 	p = haystack;
@@ -5534,7 +5534,7 @@ PHP_FUNCTION(substr_count)
 	}
 	if ((offset < 0) || ((size_t)offset > haystack_len)) {
 		zend_value_error("Offset not contained in string");
-		return;
+		RETURN_THROWS();
 	}
 	p += offset;
 
@@ -5600,12 +5600,12 @@ PHP_FUNCTION(str_pad)
 
 	if (pad_str_len == 0) {
 		zend_value_error("Padding string cannot be empty");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (pad_type_val < STR_PAD_LEFT || pad_type_val > STR_PAD_BOTH) {
 		zend_value_error("Padding type has to be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH");
-		return;
+		RETURN_THROWS();
 	}
 
 	num_pad_chars = pad_length - ZSTR_LEN(input);
@@ -5865,7 +5865,7 @@ PHP_FUNCTION(str_word_count)
 			break;
 		default:
 			zend_value_error("Invalid format value " ZEND_LONG_FMT, type);
-			return;
+			RETURN_THROWS();
 	}
 
 	if (char_list) {
@@ -5930,7 +5930,7 @@ PHP_FUNCTION(str_split)
 
 	if (split_length <= 0) {
 		zend_value_error("The length of each segment must be greater than zero");
-		return;
+		RETURN_THROWS();
 	}
 
 
@@ -5970,7 +5970,7 @@ PHP_FUNCTION(strpbrk)
 
 	if (!ZSTR_LEN(char_list)) {
 		zend_value_error("The character list cannot be empty");
-		return;
+		RETURN_THROWS();
 	}
 
 	for (haystack_ptr = ZSTR_VAL(haystack); haystack_ptr < (ZSTR_VAL(haystack) + ZSTR_LEN(haystack)); ++haystack_ptr) {
@@ -6009,7 +6009,7 @@ PHP_FUNCTION(substr_compare)
 			RETURN_LONG(0L);
 		} else {
 			zend_value_error("The length must be greater than or equal to zero");
-			return;
+			RETURN_THROWS();
 		}
 	}
 

--- a/ext/standard/type.c
+++ b/ext/standard/type.c
@@ -86,7 +86,7 @@ PHP_FUNCTION(settype)
 		} else {
 			zend_value_error("Invalid type");
 		}
-		return;
+		RETURN_THROWS();
 	}
 
 	if (ptr == &tmp) {

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -424,7 +424,7 @@ static void php_stream_bucket_attach(int append, INTERNAL_FUNCTION_PARAMETERS)
 
 	if (NULL == (pzbucket = zend_hash_str_find(Z_OBJPROP_P(zobject), "bucket", sizeof("bucket")-1))) {
 		zend_value_error("Object has no bucket property");
-		return;
+		RETURN_THROWS();
 	}
 
 	if ((brigade = (php_stream_bucket_brigade*)zend_fetch_resource(
@@ -521,9 +521,7 @@ PHP_FUNCTION(stream_get_filters)
 	zend_string *filter_name;
 	HashTable *filters_hash;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 
@@ -554,12 +552,12 @@ PHP_FUNCTION(stream_filter_register)
 
 	if (!ZSTR_LEN(filtername)) {
 		zend_value_error("Filter name cannot be empty");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (!ZSTR_LEN(classname)) {
 		zend_value_error("Class name cannot be empty");
-		return;
+		RETURN_THROWS();
 	}
 
 	if (!BG(user_filter_map)) {


### PR DESCRIPTION
Let's introduce a macro in order to indicate that an exception was thrown previously as proposed by Nikita in https://github.com/php/php-src/pull/4994#pullrequestreview-329931912 (Click "Show resolved").

It made sense for me to use this macro even when the exception was thrown one line before, but I can also change them back to normal `return`s.