### PR TITLE
Convert zend_parse_parameters_none() to fast ZPP in standard lib

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1924,9 +1924,7 @@ PHP_FUNCTION(getopt)
    Flush the output buffer */
 PHP_FUNCTION(flush)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	sapi_flush();
 }
@@ -2063,9 +2061,7 @@ PHP_FUNCTION(time_sleep_until)
    Get the name of the owner of the current PHP script */
 PHP_FUNCTION(get_current_user)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_STRING(php_get_current_user());
 }
@@ -2243,9 +2239,7 @@ PHPAPI int _php_error_log_ex(int opt_err, char *message, size_t message_len, cha
    Get the last occurred error as associative array. Returns NULL if there hasn't been an error yet. */
 PHP_FUNCTION(error_get_last)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (PG(last_error_message)) {
 		array_init(return_value);
@@ -2261,9 +2255,7 @@ PHP_FUNCTION(error_get_last)
    Clear the last occurred error. */
 PHP_FUNCTION(error_clear_last)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (PG(last_error_message)) {
 		PG(last_error_type) = 0;
@@ -2977,9 +2969,7 @@ PHP_FUNCTION(get_include_path)
 {
 	char *str;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	str = zend_ini_string("include_path", sizeof("include_path") - 1, 0);
 
@@ -2997,9 +2987,8 @@ PHP_FUNCTION(restore_include_path)
 {
 	zend_string *key;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	key = zend_string_init("include_path", sizeof("include_path")-1, 0);
 	zend_restore_ini_entry(key, PHP_INI_STAGE_RUNTIME);
 	zend_string_efree(key);
@@ -3032,9 +3021,7 @@ PHP_FUNCTION(print_r)
    Returns true if client disconnected */
 PHP_FUNCTION(connection_aborted)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(PG(connection_status) & PHP_CONNECTION_ABORTED);
 }
@@ -3044,9 +3031,7 @@ PHP_FUNCTION(connection_aborted)
    Returns the connection status bitfield */
 PHP_FUNCTION(connection_status)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(PG(connection_status));
 }
@@ -3536,9 +3521,7 @@ PHP_FUNCTION(sys_getloadavg)
 {
 	double load[3];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (getloadavg(load, 3) == -1) {
 		RETURN_FALSE;

--- a/ext/standard/dir.c
+++ b/ext/standard/dir.c
@@ -347,9 +347,7 @@ PHP_FUNCTION(getcwd)
 	char path[MAXPATHLEN];
 	char *ret=NULL;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 #if HAVE_GETCWD
 	ret = VCWD_GETCWD(path, MAXPATHLEN);

--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -124,9 +124,7 @@ PHP_FUNCTION(gethostname)
 {
 	char buf[HOST_NAME_MAX + 1];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (gethostname(buf, sizeof(buf))) {
 		php_error_docref(NULL, E_WARNING, "unable to fetch host [%d]: %s", errno, strerror(errno));

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -854,9 +854,7 @@ PHP_NAMED_FUNCTION(php_if_tmpfile)
 {
 	php_stream *stream;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	stream = php_stream_fopen_tmpfile();
 
@@ -2467,9 +2465,8 @@ PHP_FUNCTION(fnmatch)
    Returns directory path used for temporary files */
 PHP_FUNCTION(sys_get_temp_dir)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	RETURN_STRING((char *)php_get_temporary_directory());
 }
 /* }}} */

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -1086,9 +1086,8 @@ FileFunction(php_if_stat, FS_STAT)
    Get current size of realpath cache */
 PHP_FUNCTION(realpath_cache_size)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	RETURN_LONG(realpath_cache_size());
 }
 
@@ -1098,9 +1097,7 @@ PHP_FUNCTION(realpath_cache_get)
 {
 	realpath_cache_bucket **buckets = realpath_cache_get_buckets(), **end = buckets + realpath_cache_max_buckets();
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 	while(buckets < end) {

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -388,9 +388,7 @@ static void php_head_apply_header_list_to_hash(void *data, void *arg)
    Return list of headers to be sent / already sent */
 PHP_FUNCTION(headers_list)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 	zend_llist_apply_with_argument(&SG(sapi_headers).headers, php_head_apply_header_list_to_hash, return_value);

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -1309,9 +1309,7 @@ PHP_FUNCTION(phpcredits)
    Return the current SAPI module name */
 PHP_FUNCTION(php_sapi_name)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (sapi_module.name) {
 		RETURN_STRING(sapi_module.name);
@@ -1343,9 +1341,7 @@ PHP_FUNCTION(php_uname)
    Return comma-separated string of .ini files parsed from the additional ini dir */
 PHP_FUNCTION(php_ini_scanned_files)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (php_ini_scanned_files) {
 		RETURN_STRING(php_ini_scanned_files);
@@ -1359,9 +1355,7 @@ PHP_FUNCTION(php_ini_scanned_files)
    Return the actual loaded ini filename */
 PHP_FUNCTION(php_ini_loaded_file)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (php_ini_opened_path) {
 		RETURN_STRING(php_ini_opened_path);

--- a/ext/standard/lcg.c
+++ b/ext/standard/lcg.c
@@ -114,9 +114,8 @@ PHP_MINIT_FUNCTION(lcg) /* {{{ */
    Returns a value from the combined linear congruential generator */
 PHP_FUNCTION(lcg_value)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	RETURN_DOUBLE(php_combined_lcg());
 }
 /* }}} */

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -490,9 +490,7 @@ PHP_FUNCTION(atanh)
    Returns an approximation of pi */
 PHP_FUNCTION(pi)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_DOUBLE(M_PI);
 }

--- a/ext/standard/mt_rand.c
+++ b/ext/standard/mt_rand.c
@@ -337,9 +337,7 @@ PHP_FUNCTION(mt_rand)
    Returns the maximum value a random number from Mersenne Twister can have */
 PHP_FUNCTION(mt_getrandmax)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	/*
 	 * Melo: it could be 2^^32 but we only use 2^^31 to maintain

--- a/ext/standard/pageinfo.c
+++ b/ext/standard/pageinfo.c
@@ -94,9 +94,7 @@ PHP_FUNCTION(getmyuid)
 {
 	zend_long uid;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	uid = php_getuid();
 	if (uid < 0) {
@@ -113,9 +111,7 @@ PHP_FUNCTION(getmygid)
 {
 	zend_long gid;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	gid = php_getgid();
 	if (gid < 0) {
@@ -132,9 +128,7 @@ PHP_FUNCTION(getmypid)
 {
 	zend_long pid;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	pid = getpid();
 	if (pid < 0) {
@@ -149,9 +143,7 @@ PHP_FUNCTION(getmypid)
    Get the inode of the current script being parsed */
 PHP_FUNCTION(getmyinode)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	php_statpage();
 	if (BG(page_inode) < 0) {
@@ -174,9 +166,7 @@ PHP_FUNCTION(getlastmod)
 {
 	zend_long lm;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	lm = php_getlastmod();
 	if (lm < 0) {

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -557,9 +557,7 @@ PHP_FUNCTION(stream_get_transports)
 	HashTable *stream_xport_hash;
 	zend_string *stream_xport;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if ((stream_xport_hash = php_stream_xport_get_hash())) {
 		array_init(return_value);
@@ -579,9 +577,7 @@ PHP_FUNCTION(stream_get_wrappers)
 	HashTable *url_stream_wrappers_hash;
 	zend_string *stream_protocol;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if ((url_stream_wrappers_hash = php_stream_get_url_stream_wrappers_hash())) {
 		array_init(return_value);

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5442,10 +5442,7 @@ PHP_FUNCTION(localeconv)
 	zval grouping, mon_grouping;
 	int len, i;
 
-	/* We don't need no stinkin' parameters... */
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 	array_init(&grouping);

--- a/ext/standard/syslog.c
+++ b/ext/standard/syslog.c
@@ -162,9 +162,7 @@ PHP_FUNCTION(openlog)
    Close connection to system logger */
 PHP_FUNCTION(closelog)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	closelog();
 	if (BG(syslog_device)) {

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -521,9 +521,7 @@ PHP_FUNCTION(stream_get_filters)
 	zend_string *filter_name;
 	HashTable *filters_hash;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 


### PR DESCRIPTION
These were the only occurrences of `zend_parse_parameters_none()` in the standard extension.