### PR TITLE
Properly handle serialization locking

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -909,7 +909,6 @@ static void basic_globals_ctor(php_basic_globals *basic_globals_p) /* {{{ */
 	BG(left) = -1;
 	BG(user_tick_functions) = NULL;
 	BG(user_filter_map) = NULL;
-	BG(serialize_lock) = 0;
 
 	memset(&BG(serialize), 0, sizeof(BG(serialize)));
 	memset(&BG(unserialize), 0, sizeof(BG(unserialize)));
@@ -1160,7 +1159,6 @@ PHP_RINIT_FUNCTION(basic) /* {{{ */
 {
 	memset(BG(strtok_table), 0, 256);
 
-	BG(serialize_lock) = 0;
 	memset(&BG(serialize), 0, sizeof(BG(serialize)));
 	memset(&BG(unserialize), 0, sizeof(BG(unserialize)));
 

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -202,14 +202,15 @@ typedef struct _php_basic_globals {
 
 	/* var.c */
 	zend_class_entry *incomplete_class;
-	unsigned serialize_lock; /* whether to use the locally supplied var_hash instead (__sleep/__wakeup) */
 	struct {
 		struct php_serialize_data *data;
 		unsigned level;
+		unsigned lock_level;
 	} serialize;
 	struct {
 		struct php_unserialize_data *data;
 		unsigned level;
+		unsigned lock_level;
 	} unserialize;
 
 	/* url_scanner_ex.re */

--- a/ext/standard/php_var.h
+++ b/ext/standard/php_var.h
@@ -66,6 +66,26 @@ PHPAPI zend_long php_var_unserialize_get_cur_depth(php_unserialize_data_t d);
 #define PHP_VAR_UNSERIALIZE_DESTROY(d) \
 	php_var_unserialize_destroy(d)
 
+#define PHP_VAR_SERIALIZE_LOCK(prev_data, prev_lock_level) \
+	prev_data = BG(serialize).data; \
+	prev_lock_level = BG(serialize).lock_level; \
+	BG(serialize).data = NULL; \
+	BG(serialize).lock_level = BG(serialize).level;
+
+#define PHP_VAR_SERIALIZE_UNLOCK(prev_data, prev_lock_level) \
+	BG(serialize).data = prev_data; \
+	BG(serialize).lock_level = prev_lock_level;
+
+#define PHP_VAR_UNSERIALIZE_LOCK(prev_data, prev_lock_level) \
+	prev_data = BG(unserialize).data; \
+	prev_lock_level = BG(unserialize).lock_level; \
+	BG(unserialize).data = NULL; \
+	BG(unserialize).lock_level = BG(unserialize).level;
+
+#define PHP_VAR_UNSERIALIZE_UNLOCK(prev_data, prev_lock_level) \
+	BG(unserialize).data = prev_data; \
+	BG(unserialize).lock_level = prev_lock_level;
+
 PHPAPI void var_replace(php_unserialize_data_t *var_hash, zval *ozval, zval *nzval);
 PHPAPI void var_push_dtor(php_unserialize_data_t *var_hash, zval *val);
 PHPAPI zval *var_tmp_var(php_unserialize_data_t *var_hashx);

--- a/ext/standard/tests/serialize/bug70219_1.phpt
+++ b/ext/standard/tests/serialize/bug70219_1.phpt
@@ -18,6 +18,7 @@ class obj implements Serializable {
     }
     function unserialize($data) {
         session_decode($data);
+        return null;
     }
 }
 
@@ -33,20 +34,18 @@ for ($i = 0; $i < 5; $i++) {
 var_dump($data);
 var_dump($_SESSION);
 ?>
---EXPECTF--
+--EXPECT--
 array(2) {
   [0]=>
-  object(obj)#%d (1) {
+  object(obj)#1 (1) {
     ["data"]=>
     NULL
   }
   [1]=>
-  object(obj)#%d (1) {
+  object(obj)#2 (1) {
     ["data"]=>
     NULL
   }
 }
-object(obj)#1 (1) {
-  ["data"]=>
-  NULL
+array(0) {
 }

--- a/ext/standard/tests/serialize/nested_serialize_under_lock.phpt
+++ b/ext/standard/tests/serialize/nested_serialize_under_lock.phpt
@@ -1,0 +1,64 @@
+--TEST--
+Check that nested serialization/unserialization still works correctly while under lock
+--FILE--
+<?php
+
+class SerializableClass implements Serializable {
+    public $sharedProp;
+    public function __construct($prop)
+    {
+        $this->sharedProp = $prop;
+    }
+    public function __set($key, $value)
+    {
+        $this->$key = $value;
+    }
+    public function serialize()
+    {
+        return serialize(get_object_vars($this));
+    }
+    public function unserialize($data)
+    {
+        $ar = unserialize($data);
+        if ($ar === false) {
+            return;
+        }
+        foreach ($ar as $k => $v) {
+            $this->__set($k, $v);
+        }
+    }
+}
+
+// Going through spl_autoload_register() to lock serialization
+spl_autoload_register(function($class) {
+    $testPropertyObj = new stdClass();
+    $testPropertyObj->name = 'test';
+    $array = [
+        'obj1' => new SerializableClass($testPropertyObj),
+        'obj2' => new SerializableClass($testPropertyObj),
+    ];
+    var_dump(unserialize(serialize($array)));
+    class X {}
+});
+
+unserialize('O:1:"X":0:{}');
+?>
+--EXPECT--
+array(2) {
+  ["obj1"]=>
+  object(SerializableClass)#5 (1) {
+    ["sharedProp"]=>
+    object(stdClass)#6 (1) {
+      ["name"]=>
+      string(4) "test"
+    }
+  }
+  ["obj2"]=>
+  object(SerializableClass)#7 (1) {
+    ["sharedProp"]=>
+    object(stdClass)#6 (1) {
+      ["name"]=>
+      string(4) "test"
+    }
+  }
+}


### PR DESCRIPTION
Convert serialize_lock into a lock_level, so that a new context is
created if lock_level == level, but the context is reused if
lock_level < level. This makes serialization behavior consistent
independently of whether locking is active or not: It only prevents
a context reuse at a specific level.

This is a proper fix for https://bugs.php.net/bug.php?id=79031.