### PR TITLE
Improve SSA representation of FE_FETCH

### DIFF
--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -3285,7 +3285,7 @@ static int zend_update_type_info(const zend_op_array *op_array,
 			break;
 		case ZEND_FE_FETCH_R:
 		case ZEND_FE_FETCH_RW:
-			tmp = t2;
+			tmp = t2 & MAY_BE_REF;
 			if (t1 & MAY_BE_OBJECT) {
 				if (opline->opcode == ZEND_FE_FETCH_RW) {
 					tmp |= MAY_BE_REF | MAY_BE_ANY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_ANY | MAY_BE_ARRAY_OF_REF;

--- a/ext/opcache/Optimizer/zend_ssa.h
+++ b/ext/opcache/Optimizer/zend_ssa.h
@@ -215,10 +215,9 @@ static zend_always_inline zend_bool zend_ssa_is_no_val_use(const zend_op *opline
 	if (opline->opcode == ZEND_ASSIGN || opline->opcode == ZEND_UNSET_CV) {
 		return ssa_op->op1_use == var && ssa_op->op2_use != var;
 	}
-	// TODO: Reenable this after changing the SSA structure.
-	/*if (opline->opcode == ZEND_FE_FETCH_R) {
+	if (opline->opcode == ZEND_FE_FETCH_R || opline->opcode == ZEND_FE_FETCH_RW) {
 		return ssa_op->op2_use == var && ssa_op->op1_use != var;
-	}*/
+	}
 	if (ssa_op->result_use == var
 			&& opline->opcode != ZEND_ADD_ARRAY_ELEMENT
 			&& opline->opcode != ZEND_ADD_ARRAY_UNPACK) {


### PR DESCRIPTION
The op2 of FE_FETCH is only written if the loop edge is taken.
Fix up the SSA form to use the pre-assignment value if the exit
edge is taken.

This allows us to properly infer the type of the loop variable,
without letting the pre-loop type leak in.