### PR TITLE
Fix #78790: mysqli_get_client_info() expects exactly 0 parameters, 1 …

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1374,8 +1374,16 @@ PHP_FUNCTION(mysqli_free_result)
    Get MySQL client info */
 PHP_FUNCTION(mysqli_get_client_info)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
+	if (getThis()) {
+		if (zend_parse_parameters_none() == FAILURE) {
+			return;
+		}
+	} else {
+		zval *mysql_link;
+
+		if (zend_parse_parameters(ZEND_NUM_ARGS(), "|O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+			return;
+		}
 	}
 
 	const char * info = mysql_get_client_info();

--- a/ext/mysqli/mysqli_fe.c
+++ b/ext/mysqli/mysqli_fe.c
@@ -74,6 +74,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_mysqli_only_link, 0, 0, 1)
 	MYSQLI_ZEND_ARG_OBJ_INFO_LINK()
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_mysqli_optional_link, 0, 0, 0)
+	MYSQLI_ZEND_ARG_OBJ_INFO_LINK()
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_mysqli_autocommit, 0, 0, 2)
 	MYSQLI_ZEND_ARG_OBJ_INFO_LINK()
 	ZEND_ARG_INFO(0, mode)
@@ -445,7 +449,7 @@ const zend_function_entry mysqli_functions[] = {
 #ifdef HAVE_MYSQLI_GET_CHARSET
 	PHP_FE(mysqli_get_charset,							arginfo_mysqli_only_link)
 #endif
-	PHP_FE(mysqli_get_client_info,						arginfo_mysqli_no_options)
+	PHP_FE(mysqli_get_client_info,						arginfo_mysqli_optional_link)
 	PHP_FE(mysqli_get_client_version,					arginfo_mysqli_no_options)
 	PHP_FE(mysqli_get_links_stats,						arginfo_mysqli_no_options)
 	PHP_FE(mysqli_get_host_info,						arginfo_mysqli_only_link)

--- a/ext/mysqli/tests/bug74737.phpt
+++ b/ext/mysqli/tests/bug74737.phpt
@@ -13,5 +13,5 @@ echo PHP_EOL;
 echo $rf->getNumberOfRequiredParameters();
 ?>
 --EXPECT--
-0
+1
 0


### PR DESCRIPTION
…given

Although the `mysqli` parameter is unused, it had been accepted so far,
and the documentation even claims that parameter would be required.  To
not break BC, we allow it again.