### PR TITLE
Remove leftover ZEND_CAST code for (unset) cast.

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5730,12 +5730,6 @@ ZEND_VM_COLD_CONST_HANDLER(51, ZEND_CAST, CONST|TMP|VAR|CV, ANY, TYPE)
 	expr = GET_OP1_ZVAL_PTR(BP_VAR_R);
 
 	switch (opline->extended_value) {
-		case IS_NULL:
-			ZVAL_NULL(result);
-			break;
-		case _IS_BOOL:
-			ZVAL_BOOL(result, zend_is_true(expr));
-			break;
 		case IS_LONG:
 			ZVAL_LONG(result, zval_get_long(expr));
 			break;
@@ -5746,6 +5740,7 @@ ZEND_VM_COLD_CONST_HANDLER(51, ZEND_CAST, CONST|TMP|VAR|CV, ANY, TYPE)
 			ZVAL_STR(result, zval_get_string(expr));
 			break;
 		default:
+			ZEND_ASSERT(opline->extended_value != _IS_BOOL && "Must use ZEND_BOOL instead");
 			if (OP1_TYPE & (IS_VAR|IS_CV)) {
 				ZVAL_DEREF(expr);
 			}
@@ -5789,6 +5784,7 @@ ZEND_VM_COLD_CONST_HANDLER(51, ZEND_CAST, CONST|TMP|VAR|CV, ANY, TYPE)
 					}
 				}
 			} else {
+				ZEND_ASSERT(opline->extended_value == IS_OBJECT);
 				ZVAL_OBJ(result, zend_objects_new(zend_standard_class_def));
 				if (Z_TYPE_P(expr) == IS_ARRAY) {
 					ht = zend_symtable_to_proptable(Z_ARR_P(expr));

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3882,12 +3882,6 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_CONST_H
 	expr = RT_CONSTANT(opline, opline->op1);
 
 	switch (opline->extended_value) {
-		case IS_NULL:
-			ZVAL_NULL(result);
-			break;
-		case _IS_BOOL:
-			ZVAL_BOOL(result, zend_is_true(expr));
-			break;
 		case IS_LONG:
 			ZVAL_LONG(result, zval_get_long(expr));
 			break;
@@ -3898,6 +3892,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_CONST_H
 			ZVAL_STR(result, zval_get_string(expr));
 			break;
 		default:
+			ZEND_ASSERT(opline->extended_value != _IS_BOOL && "Must use ZEND_BOOL instead");
 			if (IS_CONST & (IS_VAR|IS_CV)) {
 				ZVAL_DEREF(expr);
 			}
@@ -3940,6 +3935,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_CONST_H
 					}
 				}
 			} else {
+				ZEND_ASSERT(opline->extended_value == IS_OBJECT);
 				ZVAL_OBJ(result, zend_objects_new(zend_standard_class_def));
 				if (Z_TYPE_P(expr) == IS_ARRAY) {
 					ht = zend_symtable_to_proptable(Z_ARR_P(expr));
@@ -17489,12 +17485,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_TMP_HANDLER(ZEND_OPC
 	expr = _get_zval_ptr_tmp(opline->op1.var EXECUTE_DATA_CC);
 
 	switch (opline->extended_value) {
-		case IS_NULL:
-			ZVAL_NULL(result);
-			break;
-		case _IS_BOOL:
-			ZVAL_BOOL(result, zend_is_true(expr));
-			break;
 		case IS_LONG:
 			ZVAL_LONG(result, zval_get_long(expr));
 			break;
@@ -17505,6 +17495,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_TMP_HANDLER(ZEND_OPC
 			ZVAL_STR(result, zval_get_string(expr));
 			break;
 		default:
+			ZEND_ASSERT(opline->extended_value != _IS_BOOL && "Must use ZEND_BOOL instead");
 			if (IS_TMP_VAR & (IS_VAR|IS_CV)) {
 				ZVAL_DEREF(expr);
 			}
@@ -17547,6 +17538,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_TMP_HANDLER(ZEND_OPC
 					}
 				}
 			} else {
+				ZEND_ASSERT(opline->extended_value == IS_OBJECT);
 				ZVAL_OBJ(result, zend_objects_new(zend_standard_class_def));
 				if (Z_TYPE_P(expr) == IS_ARRAY) {
 					ht = zend_symtable_to_proptable(Z_ARR_P(expr));
@@ -20150,12 +20142,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_VAR_HANDLER(ZEND_OPC
 	expr = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
 	switch (opline->extended_value) {
-		case IS_NULL:
-			ZVAL_NULL(result);
-			break;
-		case _IS_BOOL:
-			ZVAL_BOOL(result, zend_is_true(expr));
-			break;
 		case IS_LONG:
 			ZVAL_LONG(result, zval_get_long(expr));
 			break;
@@ -20166,6 +20152,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_VAR_HANDLER(ZEND_OPC
 			ZVAL_STR(result, zval_get_string(expr));
 			break;
 		default:
+			ZEND_ASSERT(opline->extended_value != _IS_BOOL && "Must use ZEND_BOOL instead");
 			if (IS_VAR & (IS_VAR|IS_CV)) {
 				ZVAL_DEREF(expr);
 			}
@@ -20209,6 +20196,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_VAR_HANDLER(ZEND_OPC
 					}
 				}
 			} else {
+				ZEND_ASSERT(opline->extended_value == IS_OBJECT);
 				ZVAL_OBJ(result, zend_objects_new(zend_standard_class_def));
 				if (Z_TYPE_P(expr) == IS_ARRAY) {
 					ht = zend_symtable_to_proptable(Z_ARR_P(expr));
@@ -36083,12 +36071,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_CV_HANDLER(ZEND_OPCO
 	expr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 
 	switch (opline->extended_value) {
-		case IS_NULL:
-			ZVAL_NULL(result);
-			break;
-		case _IS_BOOL:
-			ZVAL_BOOL(result, zend_is_true(expr));
-			break;
 		case IS_LONG:
 			ZVAL_LONG(result, zval_get_long(expr));
 			break;
@@ -36099,6 +36081,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_CV_HANDLER(ZEND_OPCO
 			ZVAL_STR(result, zval_get_string(expr));
 			break;
 		default:
+			ZEND_ASSERT(opline->extended_value != _IS_BOOL && "Must use ZEND_BOOL instead");
 			if (IS_CV & (IS_VAR|IS_CV)) {
 				ZVAL_DEREF(expr);
 			}
@@ -36141,6 +36124,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CAST_SPEC_CV_HANDLER(ZEND_OPCO
 					}
 				}
 			} else {
+				ZEND_ASSERT(opline->extended_value == IS_OBJECT);
 				ZVAL_OBJ(result, zend_objects_new(zend_standard_class_def));
 				if (Z_TYPE_P(expr) == IS_ARRAY) {
 					ht = zend_symtable_to_proptable(Z_ARR_P(expr));

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -1030,23 +1030,7 @@ int zend_inference_calc_range(const zend_op_array *op_array, zend_ssa *ssa, int 
 					}
 				}
 			} else if (ssa->ops[line].result_def == var) {
-				if (opline->extended_value == IS_NULL) {
-					tmp->min = 0;
-					tmp->max = 0;
-					return 1;
-				} else if (opline->extended_value == _IS_BOOL) {
-					if (OP1_HAS_RANGE()) {
-						op1_min = OP1_MIN_RANGE();
-						op1_max = OP1_MAX_RANGE();
-						tmp->min = (op1_min > 0 || op1_max < 0);
-						tmp->max = (op1_min != 0 || op1_max != 0);
-						return 1;
-					} else {
-						tmp->min = 0;
-						tmp->max = 1;
-						return 1;
-					}
-				} else if (opline->extended_value == IS_LONG) {
+				if (opline->extended_value == IS_LONG) {
 					if (OP1_HAS_RANGE()) {
 						tmp->min = OP1_MIN_RANGE();
 						tmp->max = OP1_MAX_RANGE();
@@ -2499,24 +2483,19 @@ static int zend_update_type_info(const zend_op_array *op_array,
 				UPDATE_SSA_TYPE(tmp, ssa_ops[i].op1_def);
 				COPY_SSA_OBJ_TYPE(ssa_ops[i].op1_use, ssa_ops[i].op1_def);
 			}
-			tmp = 0;
-			if (opline->extended_value == _IS_BOOL) {
-				tmp |= MAY_BE_TRUE|MAY_BE_FALSE;
-			} else {
-				tmp |= 1 << opline->extended_value;
-				if (tmp & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) {
-					if ((tmp & MAY_BE_ANY) == (t1 & MAY_BE_ANY)) {
-						tmp |= (t1 & MAY_BE_RC1) | MAY_BE_RCN;
-					} else if ((opline->extended_value == IS_ARRAY ||
-					            opline->extended_value == IS_OBJECT) &&
-					           (t1 & (MAY_BE_ARRAY|MAY_BE_OBJECT))) {
-							tmp |= MAY_BE_RC1 | MAY_BE_RCN;
-					} else if (opline->extended_value == IS_STRING &&
-					           (t1 & (MAY_BE_STRING|MAY_BE_OBJECT))) {
+			tmp = 1 << opline->extended_value;
+			if (tmp & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) {
+				if ((tmp & MAY_BE_ANY) == (t1 & MAY_BE_ANY)) {
+					tmp |= (t1 & MAY_BE_RC1) | MAY_BE_RCN;
+				} else if ((opline->extended_value == IS_ARRAY ||
+							opline->extended_value == IS_OBJECT) &&
+						   (t1 & (MAY_BE_ARRAY|MAY_BE_OBJECT))) {
 						tmp |= MAY_BE_RC1 | MAY_BE_RCN;
-					} else {
-						tmp |= MAY_BE_RC1;
-					}
+				} else if (opline->extended_value == IS_STRING &&
+						   (t1 & (MAY_BE_STRING|MAY_BE_OBJECT))) {
+					tmp |= MAY_BE_RC1 | MAY_BE_RCN;
+				} else {
+					tmp |= MAY_BE_RC1;
 				}
 			}
 			if (opline->extended_value == IS_ARRAY) {
@@ -4618,10 +4597,6 @@ int zend_may_throw(const zend_op *opline, const zend_op_array *op_array, zend_ss
 			return (t1 & MAY_BE_OBJECT) || (t2 & (MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
 		case ZEND_CAST:
 			switch (opline->extended_value) {
-				case IS_NULL:
-					return 0;
-				case _IS_BOOL:
-					return (t1 & MAY_BE_OBJECT);
 				case IS_LONG:
 				case IS_DOUBLE:
 					return (t1 & MAY_BE_OBJECT);
@@ -4630,9 +4605,8 @@ int zend_may_throw(const zend_op *opline, const zend_op_array *op_array, zend_ss
 				case IS_ARRAY:
 					return (t1 & MAY_BE_OBJECT);
 				case IS_OBJECT:
-					return (t1 & MAY_BE_ARRAY);
-				default:
-					return 1;
+					return 0;
+				EMPTY_SWITCH_DEFAULT_CASE()
 			}
 		case ZEND_ARRAY_KEY_EXISTS:
 			if ((t2 & MAY_BE_ANY) != MAY_BE_ARRAY) {


### PR DESCRIPTION
Followup for d74d3922ce6f9ea07c1226b0cb2a94fc333f7a02

Attempting to require a file with (unset) casts results in an E_COMPILE_ERROR
that can't be caught or handled by set_exception_handler/set_error_handler.

Also remove the `_IS_BOOL` handlers, because the ZEND_BOOL opcode handles that (emitted by zend_compile.c).

Remove inference that array -> object cast can throw.
It was added in 2a286ad5991 - I don't know how creating an stdClass would throw.
(numeric keys, references, etc. don't cause it to throw, and out of memory would be a fatal error)

- It looks like a separate opcode would free the original arg, even for `$x = (object)$x`. (ZEND_CAST then ZEND_ASSIGN).