### PR TITLE
Always delete tempfile created by ftruncate test.

### DIFF
--- a/ext/standard/tests/file/ftruncate_bug76422.phpt
+++ b/ext/standard/tests/file/ftruncate_bug76422.phpt
@@ -23,6 +23,8 @@ $truncate_offset = 2 * 1024 * 1024 * 1024;
 $ftruncate_result = ftruncate($file_handle, $truncate_offset);
 if (false === $ftruncate_result) {
     var_dump(true);
+    fclose($file_handle);
+    unlink($fn);
     return;
 }
 
@@ -30,11 +32,17 @@ $truncate_offset = 4 * 1024 * 1024 * 1024 + 1;
 $ftruncate_result = ftruncate($file_handle, $truncate_offset);
 
 if (false === $ftruncate_result) {
+    // NOTE: unlink() is deliberately repeated - If this test runs out of disk space attempting to reserve space for this temporary file,
+    // then the --CLEAN-- script can't be run (if we don't delete the file),
+    // because there wouldn't be any free disk space to save a new php file.
+    fclose($file_handle);
+    unlink($fn);
     die('Truncate has failed :/');
 }
 
 fclose($file_handle);
 var_dump(filesize($fn) >= $truncate_offset);
+unlink($fn);
 ?>
 --CLEAN--
 <?php


### PR DESCRIPTION
The ftruncate() test will fill up the disk when the disk has less than
2GB of space left, on some systems.
I think it expands the file to less than 2GB, then returns an error code,
and the file remains at the larger size.

Because the disk is full, the `--CLEAN--` script can't be saved to
`ftruncate_bug76422.clean.php` to be executed, and the cleanup can't be run.
Subsequent tests also fail to run.

https://www.php.net/manual/en/function.disk-free-space.php is also worth considering for the --SKIP-- section, but lower priority than reclaiming the space if needed.