### PR TITLE
Fix #79019: Copied cURL handles upload empty file

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1809,7 +1809,7 @@ static void curl_free_cb_arg(void **cb_arg_p)
 	struct mime_data_cb_arg *cb_arg = (struct mime_data_cb_arg *) *cb_arg_p;
 
 	if (cb_arg->ch) {
-		Z_DELREF(cb_arg->postfields);
+		zval_ptr_dtor(&cb_arg->postfields);
 	} else {
 		ZEND_ASSERT(cb_arg->stream == NULL);
 		zend_string_release(cb_arg->filename);

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2139,9 +2139,7 @@ static int seek_cb(void *arg, curl_off_t offset, int origin) /* {{{ */
 	ZEND_ASSERT(!cb_arg->ch);
 
 	if (cb_arg->stream == NULL) {
-		if (!(cb_arg->stream = php_stream_open_wrapper(ZSTR_VAL(cb_arg->filename), "rb", IGNORE_PATH, NULL))) {
-			return CURL_SEEKFUNC_CANTSEEK;
-		}
+		return CURL_SEEKFUNC_CANTSEEK;
 	}
 	res = php_stream_seek(cb_arg->stream, offset, origin);
 	return res == SUCCESS ? CURL_SEEKFUNC_OK : CURL_SEEKFUNC_CANTSEEK;

--- a/ext/curl/php_curl.h
+++ b/ext/curl/php_curl.h
@@ -183,6 +183,9 @@ typedef struct {
 	struct _php_curl_error        err;
 	zend_bool                     in_callback;
 	uint32_t*                     clone;
+#if LIBCURL_VERSION_NUM >= 0x073800 /* 7.56.0 */
+	zval                          postfields;
+#endif
 } php_curl;
 
 #define CURLOPT_SAFE_UPLOAD -1

--- a/ext/curl/tests/bug27023.phpt
+++ b/ext/curl/tests/bug27023.phpt
@@ -38,7 +38,7 @@ var_dump(curl_exec($ch));
 curl_close($ch);
 ?>
 --EXPECTF--
-string(%d) "curl_testdata1.txt|application/octet-stream"
-string(%d) "curl_testdata1.txt|text/plain"
-string(%d) "foo.txt|application/octet-stream"
-string(%d) "foo.txt|text/plain"
+string(%d) "curl_testdata1.txt|application/octet-stream|6"
+string(%d) "curl_testdata1.txt|text/plain|6"
+string(%d) "foo.txt|application/octet-stream|6"
+string(%d) "foo.txt|text/plain|6"

--- a/ext/curl/tests/bug77711.phpt
+++ b/ext/curl/tests/bug77711.phpt
@@ -24,7 +24,7 @@ curl_close($ch);
 ===DONE===
 --EXPECTF--
 bool(true)
-string(%d) "АБВ.txt|application/octet-stream"
+string(%d) "АБВ.txt|application/octet-stream|5"
 ===DONE===
 --CLEAN--
 <?php

--- a/ext/curl/tests/curl_copy_handle_variation4.phpt
+++ b/ext/curl/tests/curl_copy_handle_variation4.phpt
@@ -1,0 +1,46 @@
+--TEST--
+curl_copy_handle() allows to post CURLFile multiple times with curl_multi_exec()
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$ch1 = curl_init();
+curl_setopt($ch1, CURLOPT_SAFE_UPLOAD, 1);
+curl_setopt($ch1, CURLOPT_URL, "{$host}/get.php?test=file");
+// curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
+
+$filename = __DIR__ . '/АБВ.txt';
+file_put_contents($filename, "Test.");
+$file = curl_file_create($filename);
+$params = array('file' => $file);
+var_dump(curl_setopt($ch1, CURLOPT_POSTFIELDS, $params));
+
+$ch2 = curl_copy_handle($ch1);
+$ch3 = curl_copy_handle($ch1);
+
+$mh = curl_multi_init();
+curl_multi_add_handle($mh, $ch1);
+curl_multi_add_handle($mh, $ch2);
+do {
+    $status = curl_multi_exec($mh, $active);
+    if ($active) {
+        curl_multi_select($mh);
+    }
+} while ($active && $status == CURLM_OK);
+
+curl_multi_remove_handle($mh, $ch1);
+curl_multi_remove_handle($mh, $ch2);
+curl_multi_remove_handle($mh, $ch3);
+curl_multi_close($mh);
+?>
+===DONE===
+--EXPECTF--
+bool(true)
+АБВ.txt|application/octet-stream|5АБВ.txt|application/octet-stream|5===DONE===
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/АБВ.txt');
+?>

--- a/ext/curl/tests/curl_copy_handle_variation5.phpt
+++ b/ext/curl/tests/curl_copy_handle_variation5.phpt
@@ -1,5 +1,5 @@
 --TEST--
-curl_copy_handle() allows to post CURLFile multiple times
+curl_copy_handle() allows to post CURLFile multiple times if postfields change
 --SKIPIF--
 <?php include 'skipif.inc'; ?>
 --FILE--
@@ -12,7 +12,7 @@ curl_setopt($ch1, CURLOPT_SAFE_UPLOAD, 1);
 curl_setopt($ch1, CURLOPT_URL, "{$host}/get.php?test=file");
 curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
 
-$filename = __DIR__ . '/АБВ.txt';
+$filename = __DIR__ . '/abc.txt';
 file_put_contents($filename, "Test.");
 $file = curl_file_create($filename);
 $params = array('file' => $file);
@@ -20,19 +20,33 @@ var_dump(curl_setopt($ch1, CURLOPT_POSTFIELDS, $params));
 
 $ch2 = curl_copy_handle($ch1);
 
+$filename = __DIR__ . '/def.txt';
+file_put_contents($filename, "Other test.");
+$file = curl_file_create($filename);
+$params = array('file' => $file);
+var_dump(curl_setopt($ch2, CURLOPT_POSTFIELDS, $params));
+
+$ch3 = curl_copy_handle($ch2);
+
 var_dump(curl_exec($ch1));
 curl_close($ch1);
 
 var_dump(curl_exec($ch2));
 curl_close($ch2);
+
+var_dump(curl_exec($ch3));
+curl_close($ch3);
 ?>
 ===DONE===
 --EXPECTF--
 bool(true)
-string(%d) "АБВ.txt|application/octet-stream|5"
-string(%d) "АБВ.txt|application/octet-stream|5"
+bool(true)
+string(%d) "abc.txt|application/octet-stream|5"
+string(%d) "def.txt|application/octet-stream|11"
+string(%d) "def.txt|application/octet-stream|11"
 ===DONE===
 --CLEAN--
 <?php
-@unlink(__DIR__ . '/АБВ.txt');
+@unlink(__DIR__ . '/abc.txt');
+@unlink(__DIR__ . '/def.txt');
 ?>

--- a/ext/curl/tests/curl_file_upload.phpt
+++ b/ext/curl/tests/curl_file_upload.phpt
@@ -60,15 +60,15 @@ var_dump(curl_exec($ch));
 curl_close($ch);
 ?>
 --EXPECTF--
-string(%d) "curl_testdata1.txt|application/octet-stream"
-string(%d) "curl_testdata1.txt|text/plain"
-string(%d) "foo.txt|application/octet-stream"
-string(%d) "foo.txt|text/plain"
+string(%d) "curl_testdata1.txt|application/octet-stream|6"
+string(%d) "curl_testdata1.txt|text/plain|6"
+string(%d) "foo.txt|application/octet-stream|6"
+string(%d) "foo.txt|text/plain|6"
 string(%d) "text/plain"
 string(%d) "%s/curl_testdata1.txt"
-string(%d) "curl_testdata1.txt|text/plain"
+string(%d) "curl_testdata1.txt|text/plain|6"
 string(%d) "foo.txt"
-string(%d) "foo.txt|application/octet-stream"
+string(%d) "foo.txt|application/octet-stream|6"
 
 Warning: curl_setopt(): Disabling safe uploads is no longer supported in %s on line %d
 string(0) ""

--- a/ext/curl/tests/curl_file_upload_stream.phpt
+++ b/ext/curl/tests/curl_file_upload_stream.phpt
@@ -24,5 +24,5 @@ curl_close($ch);
 ===DONE===
 --EXPECT--
 bool(true)
-string(21) "i-love-php|text/plain"
+string(24) "i-love-php|text/plain|11"
 ===DONE===

--- a/ext/curl/tests/responder/get.inc
+++ b/ext/curl/tests/responder/get.inc
@@ -28,7 +28,7 @@
       break;
     case 'file':
       if (isset($_FILES['file'])) {
-          echo $_FILES['file']['name'] . '|' . $_FILES['file']['type'];
+          echo $_FILES['file']['name'] . '|' . $_FILES['file']['type'] . '|' . $_FILES['file']['size'];
       }
       break;
     case 'method':


### PR DESCRIPTION
To cater to `curl_copy_handle()` of cURL handles with attached
`CURLFile`s, we must not attach the opened stream, because the stream
may not be seekable, so that we could rewind, when the same stream is
going to be uploaded multiple times.  Instead, we're opening the stream
lazily in the read or seek callback, and close it when reading finished
(either successfully or not) and when seeking failed, respectively.

This behavior is basically the same as for libcurl < 7.56.0, where we
attach the file name, and libcurl reads and uploads the file contents.

To be able to test this behavior, we extend the test responder to print
the size of the upload, and patch the existing tests accordingly.

---

I have targeted PHP-7.4, although the CURLFile stream support has recently been back-ported to PHP-7.3, so this branch is affected by bug 79019 as well. However, particularly after this patch, I don't think that we could reasonably fix [bug 79013](https://bugs.php.net/79013), so I suggest to revert commit 17a9f1401aeb35fe1e3657b38102a410d151d42f (note that this commit has not yet been released) but keep e1202733a50eada07c1b0b934f626aaf2d3179dc, and stick with the chunked upload for PHP-7.4+ and change bug 79013 to documentation problem.