### PR TITLE
Enable UBSan in addition to ASan

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -327,7 +327,7 @@ if (CLANG_TOOLSET) {
 		"-Wno-unused-command-line-argument -Wno-unused-function -Wno-ignored-pragma-optimize");
 	}
 
-	ARG_ENABLE("sanitizer", "Enable address sanitizer extension", "no");
+	ARG_ENABLE("sanitizer", "Enable ASan and UBSan extensions", "no");
 	if (PHP_SANITIZER == "yes") {
 		if (COMPILER_NUMERIC_VERSION < 500) {
 			ERROR("Clang at least 5.0.0 required for sanitation plugins");

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3701,7 +3701,7 @@ function add_asan_opts(cflags_name, libs_name, ldflags_name)
 	}
 
 	if (!!cflags_name) {
-		ADD_FLAG(cflags_name, "-fsanitize=address");
+		ADD_FLAG(cflags_name, "-fsanitize=address,undefined");
 	}
 	if (!!libs_name) {
 		if (X64) {


### PR DESCRIPTION
UBSan is a useful tool, so we enable it for `--enable-sanitizer` in
addition to ASan.

---

An obvious alternative would be to allow to choose which sanitizers to enable. However, other sanitizer (LeakSanitizer, MemorySanititer) are not (yet) available on Windows, and since UBSan and ASan don't conflict, and UBSan is rather lightweight, I think we can keep it simple here.