### PR TITLE
Convert zend_parse_parameters_none() to fast ZPP

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -190,9 +190,7 @@ int zend_startup_builtin_functions(void) /* {{{ */
    Get the version of the Zend Engine */
 ZEND_FUNCTION(zend_version)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_STRINGL(ZEND_VERSION, sizeof(ZEND_VERSION)-1);
 }
@@ -203,9 +201,7 @@ ZEND_FUNCTION(zend_version)
    Returns number of freed bytes */
 ZEND_FUNCTION(gc_mem_caches)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(zend_mm_gc(zend_mm_get_heap()));
 }
@@ -216,9 +212,7 @@ ZEND_FUNCTION(gc_mem_caches)
    Returns number of freed zvals */
 ZEND_FUNCTION(gc_collect_cycles)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(gc_collect_cycles());
 }
@@ -228,9 +222,7 @@ ZEND_FUNCTION(gc_collect_cycles)
    Returns status of the circular reference collector */
 ZEND_FUNCTION(gc_enabled)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_BOOL(gc_enabled());
 }
@@ -242,9 +234,7 @@ ZEND_FUNCTION(gc_enable)
 {
 	zend_string *key;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	key = zend_string_init("zend.enable_gc", sizeof("zend.enable_gc")-1, 0);
 	zend_alter_ini_entry_chars(key, "1", sizeof("1")-1, ZEND_INI_USER, ZEND_INI_STAGE_RUNTIME);
@@ -258,9 +248,7 @@ ZEND_FUNCTION(gc_disable)
 {
 	zend_string *key;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	key = zend_string_init("zend.enable_gc", sizeof("zend.enable_gc")-1, 0);
 	zend_alter_ini_entry_chars(key, "0", sizeof("0")-1, ZEND_INI_USER, ZEND_INI_STAGE_RUNTIME);
@@ -274,9 +262,7 @@ ZEND_FUNCTION(gc_status)
 {
 	zend_gc_status status;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	zend_gc_get_status(&status);
 
@@ -295,9 +281,7 @@ ZEND_FUNCTION(func_num_args)
 {
 	zend_execute_data *ex = EX(prev_execute_data);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (ZEND_CALL_INFO(ex) & ZEND_CALL_CODE) {
 		zend_error(E_WARNING, "func_num_args():  Called from the global scope - no function context");
@@ -759,9 +743,7 @@ ZEND_FUNCTION(get_called_class)
 {
 	zend_class_entry *called_scope;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	called_scope = zend_get_called_scope(execute_data);
 	if (called_scope) {
@@ -1352,9 +1334,7 @@ ZEND_FUNCTION(get_included_files)
 {
 	zend_string *entry;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 	ZEND_HASH_FOREACH_STR_KEY(&EG(included_files), entry) {
@@ -1436,9 +1416,7 @@ ZEND_FUNCTION(set_error_handler)
    Restores the previously defined error handler function */
 ZEND_FUNCTION(restore_error_handler)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (Z_TYPE(EG(user_error_handler)) != IS_UNDEF) {
 		zval zeh;
@@ -1501,9 +1479,7 @@ ZEND_FUNCTION(set_exception_handler)
    Restores the previously defined exception handler function */
 ZEND_FUNCTION(restore_exception_handler)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
 		zval_ptr_dtor(&EG(user_exception_handler));
@@ -1534,9 +1510,7 @@ static inline void get_declared_class_impl(INTERNAL_FUNCTION_PARAMETERS, int fla
 	zend_string *key;
 	zend_class_entry *ce;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 	ZEND_HASH_FOREACH_STR_KEY_PTR(EG(class_table), key, ce) {

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -391,11 +391,6 @@ ZEND_METHOD(error_exception, __construct)
 }
 /* }}} */
 
-#define DEFAULT_0_PARAMS \
-	if (zend_parse_parameters_none() == FAILURE) { \
-		return; \
-	}
-
 #define GET_PROPERTY(object, id) \
 	zend_read_property_ex(i_get_exception_base(object), (object), ZSTR_KNOWN(id), 0, &rv)
 #define GET_PROPERTY_SILENT(object, id) \
@@ -407,7 +402,7 @@ ZEND_METHOD(exception, getFile)
 {
 	zval *prop, rv;
 
-	DEFAULT_0_PARAMS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	prop = GET_PROPERTY(ZEND_THIS, ZEND_STR_FILE);
 	ZVAL_DEREF(prop);
@@ -421,7 +416,7 @@ ZEND_METHOD(exception, getLine)
 {
 	zval *prop, rv;
 
-	DEFAULT_0_PARAMS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	prop = GET_PROPERTY(ZEND_THIS, ZEND_STR_LINE);
 	ZVAL_DEREF(prop);
@@ -435,7 +430,7 @@ ZEND_METHOD(exception, getMessage)
 {
 	zval *prop, rv;
 
-	DEFAULT_0_PARAMS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	prop = GET_PROPERTY(ZEND_THIS, ZEND_STR_MESSAGE);
 	ZVAL_DEREF(prop);
@@ -449,7 +444,7 @@ ZEND_METHOD(exception, getCode)
 {
 	zval *prop, rv;
 
-	DEFAULT_0_PARAMS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	prop = GET_PROPERTY(ZEND_THIS, ZEND_STR_CODE);
 	ZVAL_DEREF(prop);
@@ -463,7 +458,7 @@ ZEND_METHOD(exception, getTrace)
 {
 	zval *prop, rv;
 
-	DEFAULT_0_PARAMS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	prop = GET_PROPERTY(ZEND_THIS, ZEND_STR_TRACE);
 	ZVAL_DEREF(prop);
@@ -477,7 +472,7 @@ ZEND_METHOD(error_exception, getSeverity)
 {
 	zval *prop, rv;
 
-	DEFAULT_0_PARAMS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	prop = GET_PROPERTY(ZEND_THIS, ZEND_STR_SEVERITY);
 	ZVAL_DEREF(prop);
@@ -625,7 +620,7 @@ ZEND_METHOD(exception, getTraceAsString)
 	smart_str str = {0};
 	uint32_t num = 0;
 
-	DEFAULT_0_PARAMS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	object = ZEND_THIS;
 	base_ce = i_get_exception_base(object);
@@ -659,7 +654,7 @@ ZEND_METHOD(exception, getPrevious)
 {
 	zval rv;
 
-	DEFAULT_0_PARAMS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	ZVAL_COPY(return_value, GET_PROPERTY_SILENT(ZEND_THIS, ZEND_STR_PREVIOUS));
 } /* }}} */
@@ -675,7 +670,7 @@ ZEND_METHOD(exception, __toString)
 	zval rv, tmp;
 	zend_string *fname;
 
-	DEFAULT_0_PARAMS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	str = ZSTR_EMPTY_ALLOC();
 

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -895,9 +895,7 @@ ZEND_METHOD(Generator, rewind)
 {
 	zend_generator *generator;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	generator = (zend_generator *) Z_OBJ_P(ZEND_THIS);
 
@@ -911,9 +909,7 @@ ZEND_METHOD(Generator, valid)
 {
 	zend_generator *generator;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	generator = (zend_generator *) Z_OBJ_P(ZEND_THIS);
 
@@ -931,9 +927,7 @@ ZEND_METHOD(Generator, current)
 {
 	zend_generator *generator, *root;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	generator = (zend_generator *) Z_OBJ_P(ZEND_THIS);
 
@@ -954,9 +948,7 @@ ZEND_METHOD(Generator, key)
 {
 	zend_generator *generator, *root;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	generator = (zend_generator *) Z_OBJ_P(ZEND_THIS);
 
@@ -977,9 +969,7 @@ ZEND_METHOD(Generator, next)
 {
 	zend_generator *generator;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	generator = (zend_generator *) Z_OBJ_P(ZEND_THIS);
 
@@ -1070,9 +1060,7 @@ ZEND_METHOD(Generator, getReturn)
 {
 	zend_generator *generator;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	generator = (zend_generator *) Z_OBJ_P(ZEND_THIS);
 

--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -339,9 +339,7 @@ static PHP_FUNCTION(json_decode)
    Returns the error code of the last json_encode() or json_decode() call. */
 static PHP_FUNCTION(json_last_error)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(JSON_G(error_code));
 }
@@ -351,9 +349,7 @@ static PHP_FUNCTION(json_last_error)
    Returns the error string of the last json_encode() or json_decode() call. */
 static PHP_FUNCTION(json_last_error_msg)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_STRING(php_json_get_error_msg(JSON_G(error_code)));
 }

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -979,9 +979,7 @@ static PHP_FUNCTION(libxml_get_last_error)
 {
 	xmlErrorPtr error;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	error = xmlGetLastError();
 
@@ -1014,9 +1012,7 @@ static PHP_FUNCTION(libxml_get_errors)
 
 	xmlErrorPtr error;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (LIBXML(error_list)) {
 
@@ -1055,9 +1051,7 @@ static PHP_FUNCTION(libxml_get_errors)
    Clear last error from libxml */
 static PHP_FUNCTION(libxml_clear_errors)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	xmlResetLastError();
 	if (LIBXML(error_list)) {

--- a/ext/pdo/pdo.c
+++ b/ext/pdo/pdo.c
@@ -85,9 +85,7 @@ PHP_FUNCTION(pdo_drivers)
 {
 	pdo_driver_t *pdriver;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -560,9 +560,8 @@ static PHP_METHOD(PDO, beginTransaction)
 {
 	pdo_dbh_t *dbh = Z_PDO_DBH_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	PDO_CONSTRUCT_CHECK;
 
 	if (dbh->in_txn) {
@@ -593,9 +592,8 @@ static PHP_METHOD(PDO, commit)
 {
 	pdo_dbh_t *dbh = Z_PDO_DBH_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	PDO_CONSTRUCT_CHECK;
 
 	if (!dbh->in_txn) {
@@ -619,9 +617,8 @@ static PHP_METHOD(PDO, rollBack)
 {
 	pdo_dbh_t *dbh = Z_PDO_DBH_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	PDO_CONSTRUCT_CHECK;
 
 	if (!dbh->in_txn) {
@@ -645,9 +642,8 @@ static PHP_METHOD(PDO, inTransaction)
 {
 	pdo_dbh_t *dbh = Z_PDO_DBH_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	PDO_CONSTRUCT_CHECK;
 
 	if (!dbh->methods->in_transaction) {
@@ -969,9 +965,8 @@ static PHP_METHOD(PDO, errorCode)
 {
 	pdo_dbh_t *dbh = Z_PDO_DBH_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	PDO_CONSTRUCT_CHECK;
 
 	if (dbh->query_stmt) {
@@ -1000,9 +995,7 @@ static PHP_METHOD(PDO, errorInfo)
 
 	pdo_dbh_t *dbh = Z_PDO_DBH_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	PDO_CONSTRUCT_CHECK;
 
@@ -1160,9 +1153,7 @@ static PHP_METHOD(PDO, getAvailableDrivers)
 {
 	pdo_driver_t *pdriver;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1569,9 +1569,7 @@ static PHP_METHOD(PDOStatement, errorCode)
 {
 	PHP_STMT_GET_OBJ;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (stmt->error_code[0] == '\0') {
 		RETURN_NULL();
@@ -1591,9 +1589,7 @@ static PHP_METHOD(PDOStatement, errorInfo)
 
 	PHP_STMT_GET_OBJ;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 	add_next_index_string(return_value, stmt->error_code);
@@ -1704,9 +1700,9 @@ static PHP_METHOD(PDOStatement, getAttribute)
 static PHP_METHOD(PDOStatement, columnCount)
 {
 	PHP_STMT_GET_OBJ;
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	RETURN_LONG(stmt->column_count);
 }
 /* }}} */

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -268,10 +268,8 @@ ZEND_TSRMLS_CACHE_DEFINE()
 ZEND_GET_MODULE(posix)
 #endif
 
-#define PHP_POSIX_NO_ARGS	if (zend_parse_parameters_none() == FAILURE) RETURN_THROWS();
-
 #define PHP_POSIX_RETURN_LONG_FUNC(func_name)	\
-	PHP_POSIX_NO_ARGS	\
+	ZEND_PARSE_PARAMETERS_NONE();	\
 	RETURN_LONG(func_name());
 
 #define PHP_POSIX_SINGLE_ARG_FUNC(func_name)	\
@@ -399,7 +397,7 @@ PHP_FUNCTION(posix_getgroups)
 	int    result;
 	int    i;
 
-	PHP_POSIX_NO_ARGS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if ((result = getgroups(NGROUPS_MAX, gidlist)) < 0) {
 		POSIX_G(last_error) = errno;
@@ -422,7 +420,7 @@ PHP_FUNCTION(posix_getlogin)
 {
 	char *p;
 
-	PHP_POSIX_NO_ARGS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (NULL == (p = getlogin())) {
 		POSIX_G(last_error) = errno;
@@ -518,7 +516,7 @@ PHP_FUNCTION(posix_uname)
 {
 	struct utsname u;
 
-	PHP_POSIX_NO_ARGS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (uname(&u) < 0) {
 		POSIX_G(last_error) = errno;
@@ -550,7 +548,7 @@ PHP_FUNCTION(posix_times)
 	struct tms t;
 	clock_t    ticks;
 
-	PHP_POSIX_NO_ARGS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if ((ticks = times(&t)) == -1) {
 		POSIX_G(last_error) = errno;
@@ -578,7 +576,7 @@ PHP_FUNCTION(posix_ctermid)
 {
 	char  buffer[L_ctermid];
 
-	PHP_POSIX_NO_ARGS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (NULL == ctermid(buffer)) {
 		/* Found no documentation how the defined behaviour is when this
@@ -709,7 +707,7 @@ PHP_FUNCTION(posix_getcwd)
 	char  buffer[MAXPATHLEN];
 	char *p;
 
-	PHP_POSIX_NO_ARGS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	p = VCWD_GETCWD(buffer, MAXPATHLEN);
 	if (!p) {
@@ -1226,7 +1224,7 @@ PHP_FUNCTION(posix_getrlimit)
 {
 	const struct limitlist *l = NULL;
 
-	PHP_POSIX_NO_ARGS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 
@@ -1274,7 +1272,7 @@ PHP_FUNCTION(posix_setrlimit)
    Retrieve the error number set by the last posix function which failed. */
 PHP_FUNCTION(posix_get_last_error)
 {
-	PHP_POSIX_NO_ARGS;
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(POSIX_G(last_error));
 }


### PR DESCRIPTION
I've done the conversion in those extensions/modules where fast ZPP is already predominant:
- `Zend`
- `JSON`
- `libxml`
- `PDO`
- `posix`

Additionally, I'd like to suggest the conversion of the `reflection` and `session` extensions, because they are very widely used, and they contain fairly many `zend_parse_parameters_none()` invocations:
- `reflection`: 127 (out of 176 ZPP invocations, from which 3 is already fast ZPP)
- `session`: 11 out of 33 ZPP invocations, from which 2 is already fast ZPP)

EDIT: OK, now I see why there isn't much difference between `zend_parse_parameters_none()` and `ZEND_PARSE_PARAMETERS_NONE()` performance-wise, so I'll leave them alone for now.