### PR TITLE
Add support for params of specific resource to FastZPP

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -223,6 +223,30 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_type_error(int num, z
 }
 /* }}} */
 
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_resource_error(int num, int resource_type, zval *arg) /* {{{ */
+{
+	const char *space;
+	const char *class_name, *function_name;
+
+	if (EG(exception)) {
+		return;
+	}
+	class_name = get_active_class_name(&space);
+	function_name = get_active_function_name();
+	if (Z_TYPE_P(arg) != IS_RESOURCE) {
+		zend_type_error("%s%s%s() expects parameter %d to be resource, %s given",
+			class_name, space, function_name, num, zend_zval_type_name(arg));
+	} else {
+		const char *expected_type = zend_rsrc_list_get_rsrc_type_from_id(resource_type);
+		const char *given_type = zend_rsrc_list_get_rsrc_type(Z_RES_P(arg));
+		zend_type_error("%s%s%s() expects parameter %d to be %s resource, %s resource given",
+			class_name, space, function_name, num,
+			expected_type ? expected_type : "UNKNOWN",
+			given_type ? given_type : "closed");
+	}
+}
+/* }}} */
+
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_error(int num, const char *name, zval *arg) /* {{{ */
 {
 	const char *space;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1476,6 +1476,14 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(int num, char *e
 #define Z_PARAM_RESOURCE(dest) \
 	Z_PARAM_RESOURCE_EX(dest, 0, 0)
 
+#define Z_PARAM_RESOURCE_TYPE(dest, type) \
+	Z_PARAM_PROLOGUE(0, 0); \
+	if (UNEXPECTED(!zend_parse_arg_resource_type(_arg, (void **) &dest, type))) { \
+		_expected_type = Z_EXPECTED_RESOURCE; \
+		_error_code = ZPP_ERROR_WRONG_ARG; \
+		break; \
+	}
+
 /* old "s" */
 #define Z_PARAM_STRING_EX2(dest, dest_len, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \

--- a/Zend/zend_list.c
+++ b/Zend/zend_list.c
@@ -328,6 +328,18 @@ const char *zend_rsrc_list_get_rsrc_type(zend_resource *res)
 	}
 }
 
+const char *zend_rsrc_list_get_rsrc_type_from_id(int resource_type)
+{
+	zend_rsrc_list_dtors_entry *lde;
+
+	lde = zend_hash_index_find_ptr(&list_destructors, resource_type);
+	if (lde) {
+		return lde->type_name;
+	} else {
+		return NULL;
+	}
+}
+
 ZEND_API zend_resource* zend_register_persistent_resource_ex(zend_string *key, void *rsrc_pointer, int rsrc_type)
 {
 	zval *zv;

--- a/Zend/zend_list.h
+++ b/Zend/zend_list.h
@@ -64,6 +64,7 @@ ZEND_API void *zend_fetch_resource_ex(zval *res, const char *resource_type_name,
 ZEND_API void *zend_fetch_resource2_ex(zval *res, const char *resource_type_name, int resource_type, int resource_type2);
 
 ZEND_API const char *zend_rsrc_list_get_rsrc_type(zend_resource *res);
+ZEND_API const char *zend_rsrc_list_get_rsrc_type_from_id(int resource_type);
 ZEND_API int zend_fetch_list_dtor_id(const char *type_name);
 
 ZEND_API zend_resource* zend_register_persistent_resource(const char *key, size_t key_len, void *rsrc_pointer, int rsrc_type);

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1955,7 +1955,7 @@ PHP_FUNCTION(curl_copy_handle)
 	php_curl	*ch, *dupch;
 
 	ZEND_PARSE_PARAMETERS_START(1,1)
-		Z_PARAM_RESOURCE_TYPE(zid, le_curl)
+		Z_PARAM_RESOURCE(zid)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if ((ch = (php_curl*)zend_fetch_resource(Z_RES_P(zid), le_curl_name, le_curl)) == NULL) {
@@ -2916,19 +2916,15 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
    Set an option for a cURL transfer */
 PHP_FUNCTION(curl_setopt)
 {
-	zval       *zid, *zvalue;
-	zend_long        options;
+	zval       *zvalue;
+	zend_long   options;
 	php_curl   *ch;
 
 	ZEND_PARSE_PARAMETERS_START(3, 3)
-		Z_PARAM_RESOURCE(zid)
+		Z_PARAM_RESOURCE_TYPE(ch, le_curl)
 		Z_PARAM_LONG(options)
 		Z_PARAM_ZVAL(zvalue)
 	ZEND_PARSE_PARAMETERS_END();
-
-	if ((ch = (php_curl*)zend_fetch_resource(Z_RES_P(zid), le_curl_name, le_curl)) == NULL) {
-		return;
-	}
 
 	if (options <= 0 && options != CURLOPT_SAFE_UPLOAD) {
 		php_error_docref(NULL, E_WARNING, "Invalid curl configuration option");

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1955,7 +1955,7 @@ PHP_FUNCTION(curl_copy_handle)
 	php_curl	*ch, *dupch;
 
 	ZEND_PARSE_PARAMETERS_START(1,1)
-		Z_PARAM_RESOURCE(zid)
+		Z_PARAM_RESOURCE_TYPE(zid, le_curl)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if ((ch = (php_curl*)zend_fetch_resource(Z_RES_P(zid), le_curl_name, le_curl)) == NULL) {


### PR DESCRIPTION
@kocsismate @cmb69 I think it would be pretty nice to integrate the resource type handling and ptr fetching directly in zpp, rather than doing a separate check. What do you think?

I've added one sample usage in curl.