### PR TITLE
Use CONTEXT_DOCUMENT_ROOT for scanning dir tree

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -913,9 +913,12 @@ static int sapi_cgi_activate(void)
 			if (fcgi_is_fastcgi()) {
 				fcgi_request *request = (fcgi_request*) SG(server_context);
 
-				doc_root = FCGI_GETENV(request, "DOCUMENT_ROOT");
+				/* Prefer CONTEXT_DOCUMENT_ROOT if set */
+				doc_root = FCGI_GETENV(request, "CONTEXT_DOCUMENT_ROOT");
+				doc_root = doc_root ? doc_root : FCGI_GETENV(request, "DOCUMENT_ROOT");
 			} else {
-				doc_root = getenv("DOCUMENT_ROOT");
+				doc_root = getenv("CONTEXT_DOCUMENT_ROOT");
+				doc_root = doc_root ? doc_root : getenv("DOCUMENT_ROOT");
 			}
 			/* DOCUMENT_ROOT should also be defined at this stage..but better check it anyway */
 			if (doc_root) {

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -733,7 +733,10 @@ static int sapi_cgi_activate(void) /* {{{ */
 
 		/* Load and activate user ini files in path starting from DOCUMENT_ROOT */
 		if (PG(user_ini_filename) && *PG(user_ini_filename)) {
-			doc_root = FCGI_GETENV(request, "DOCUMENT_ROOT");
+			/* Prefer CONTEXT_DOCUMENT_ROOT if set */
+			doc_root = FCGI_GETENV(request, "CONTEXT_DOCUMENT_ROOT");
+			doc_root = doc_root ? doc_root : FCGI_GETENV(request, "DOCUMENT_ROOT");
+
 			/* DOCUMENT_ROOT should also be defined at this stage..but better check it anyway */
 			if (doc_root) {
 				doc_root_len = strlen(doc_root);


### PR DESCRIPTION
This allows people to use the `CONTEXT_DOCUMENT_ROOT` variable to scan recursively for .user.ini files.

There is a bug report open here https://bugs.php.net/bug.php?id=64865 and plenty of other references to this issue on stackoverflow and other forums.

I'm not sure if this should be an RFC or not. So I just created a pull request to start the process.