### PR TITLE
Fix #54298: Using empty additional_headers adding extraneous CRLF

### DIFF
--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -372,7 +372,7 @@ PHP_FUNCTION(mail)
 		extra_cmd = php_escape_shell_cmd(ZSTR_VAL(extra_cmd));
 	}
 
-	if (php_mail(to_r, subject_r, message, str_headers ? ZSTR_VAL(str_headers) : NULL, extra_cmd ? ZSTR_VAL(extra_cmd) : NULL)) {
+	if (php_mail(to_r, subject_r, message, str_headers && ZSTR_LEN(str_headers) ? ZSTR_VAL(str_headers) : NULL, extra_cmd ? ZSTR_VAL(extra_cmd) : NULL)) {
 		RETVAL_TRUE;
 	} else {
 		RETVAL_FALSE;

--- a/ext/standard/tests/mail/bug54298.phpt
+++ b/ext/standard/tests/mail/bug54298.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #54298 (Using empty additional_headers adding extraneous CRLF)
+--INI--
+sendmail_path=tee bug54298.eml >/dev/null
+mail.add_x_header = Off
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows') die("skip Won't run on Windows");
+?>
+--FILE--
+<?php
+var_dump(mail('someuser@example.com', 'testsubj', 'Body part', ''));
+echo file_get_contents('bug54298.eml');
+?>
+--EXPECT--
+bool(true)
+To: someuser@example.com
+Subject: testsubj
+
+Body part
+--CLEAN--
+<?php
+unlink('bug54298.eml');
+?>


### PR DESCRIPTION
If the header string is empty, we pass `NULL` to `php_mail()` to avoid
further checks on the string length.