### PR TITLE
Rename run-test.php to run-tests.php in the test packs

### DIFF
--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -496,7 +496,7 @@ $dirs = array(
 foreach ($dirs as $dir) {
 	copy_test_dir($dir, $test_dir);
 }
-copy('run-tests.php', $test_dir . '/run-test.php');
+copy('run-tests.php', $test_dir . '/run-tests.php');
 
 /* change this next line to true to use good-old
  * hand-assembled go-pear-bundle from the snapshot template */


### PR DESCRIPTION
In the php-src repository, the test runner is named run-tests.php, but
when it is copied to the tests packs, it is renamed to run-test.php.
This renaming does not make sense, and is actually somewhat confusing.
Although changing the name back to run-tests.php constitutes a BC
break, we think the benefit of having a single name outweights the
disadvantages in the long run.