### PR TITLE
Syntax tweaks

### DIFF
--- a/Zend/tests/varSyntax/class_constant_static_deref.phpt
+++ b/Zend/tests/varSyntax/class_constant_static_deref.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Class constants can be used as a class name
+--FILE--
+<?php
+
+class Test {
+    const NAME = 'Test2';
+}
+
+class Test2 {
+    const FOO = 42;
+    public static $foo = 42;
+
+    public static function foo() {
+        return 42;
+    }
+}
+
+var_dump(Test::NAME::FOO);
+var_dump(Test::NAME::$foo);
+var_dump(Test::NAME::foo());
+
+?>
+--EXPECT--
+int(42)
+int(42)
+int(42)

--- a/Zend/tests/varSyntax/constant_object_deref.phpt
+++ b/Zend/tests/varSyntax/constant_object_deref.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Constants can be dereferenced as objects (even though they can't be objects)
+--FILE--
+<?php
+
+const FOO = "foo";
+class Bar { const FOO = "foo"; }
+
+try {
+    FOO->length();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    Bar::FOO->length();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Call to a member function length() on string
+Call to a member function length() on string

--- a/Zend/tests/varSyntax/encapsed_string_deref.phpt
+++ b/Zend/tests/varSyntax/encapsed_string_deref.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Dereferencing operations on an encapsed string
+--FILE--
+<?php
+
+$bar = "bar";
+var_dump("foo$bar"[0]);
+var_dump("foo$bar"->prop);
+try {
+    var_dump("foo$bar"->method());
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+class FooBar { public static $prop = 42; }
+var_dump("foo$bar"::$prop);
+
+function foobar() { return 42; }
+var_dump("foo$bar"());
+
+?>
+--EXPECTF--
+string(1) "f"
+
+Warning: Trying to get property 'prop' of non-object in %s on line %d
+NULL
+Call to a member function method() on string
+int(42)
+int(42)

--- a/Zend/tests/varSyntax/magic_const_deref.phpt
+++ b/Zend/tests/varSyntax/magic_const_deref.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Dereferencing of magic constants
+--FILE--
+<?php
+
+function test() {
+    var_dump(__FUNCTION__[0]);
+    var_dump(__FUNCTION__->prop);
+    try {
+        __FUNCTION__->method();
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+test();
+
+?>
+--EXPECTF--
+string(1) "t"
+
+Warning: Trying to get property 'prop' of non-object in %s on line %d
+NULL
+Call to a member function method() on string

--- a/Zend/tests/varSyntax/new_instanceof_expr.phpt
+++ b/Zend/tests/varSyntax/new_instanceof_expr.phpt
@@ -1,0 +1,18 @@
+--TEST--
+new with an arbitrary expression
+--FILE--
+<?php
+
+$class = 'class';
+var_dump(new ('std'.$class));
+var_dump(new ('std'.$class)());
+$obj = new stdClass;
+var_dump($obj instanceof ('std'.$class));
+
+?>
+--EXPECT--
+object(stdClass)#1 (0) {
+}
+object(stdClass)#1 (0) {
+}
+bool(true)

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -242,7 +242,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> internal_functions_in_yacc
 %type <ast> exit_expr scalar backticks_expr lexical_var function_call member_name property_name
 %type <ast> variable_class_name dereferencable_scalar constant class_constant
-%type <ast> fully_dereferencable array_dereferencable
+%type <ast> fully_dereferencable array_object_dereferencable
 %type <ast> callable_expr callable_variable static_member new_variable
 %type <ast> encaps_var encaps_var_offset isset_variables
 %type <ast> top_statement_list use_declarations const_list inner_statement_list if_stmt
@@ -1152,7 +1152,7 @@ fully_dereferencable:
 	|	dereferencable_scalar	{ $$ = $1; }
 ;
 
-array_dereferencable:
+array_object_dereferencable:
 		fully_dereferencable	{ $$ = $1; }
 	|	constant				{ $$ = $1; }
 	|	class_constant			{ $$ = $1; }
@@ -1167,11 +1167,11 @@ callable_expr:
 callable_variable:
 		simple_variable
 			{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
-	|	array_dereferencable '[' optional_expr ']'
+	|	array_object_dereferencable '[' optional_expr ']'
 			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
-	|	array_dereferencable '{' expr '}'
+	|	array_object_dereferencable '{' expr '}'
 			{ $$ = zend_ast_create_ex(ZEND_AST_DIM, ZEND_DIM_ALTERNATIVE_SYNTAX, $1, $3); }
-	|	fully_dereferencable T_OBJECT_OPERATOR property_name argument_list
+	|	array_object_dereferencable T_OBJECT_OPERATOR property_name argument_list
 			{ $$ = zend_ast_create(ZEND_AST_METHOD_CALL, $1, $3, $4); }
 	|	function_call { $$ = $1; }
 ;
@@ -1181,7 +1181,7 @@ variable:
 			{ $$ = $1; }
 	|	static_member
 			{ $$ = $1; }
-	|	fully_dereferencable T_OBJECT_OPERATOR property_name
+	|	array_object_dereferencable T_OBJECT_OPERATOR property_name
 			{ $$ = zend_ast_create(ZEND_AST_PROP, $1, $3); }
 ;
 

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1078,6 +1078,7 @@ class_name:
 class_name_reference:
 		class_name		{ $$ = $1; }
 	|	new_variable	{ $$ = $1; }
+	|	'(' expr ')'	{ $$ = $2; }
 ;
 
 exit_expr:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1109,14 +1109,6 @@ dereferencable_scalar:
 scalar:
 		T_LNUMBER 	{ $$ = $1; }
 	|	T_DNUMBER 	{ $$ = $1; }
-	|	T_LINE 		{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_LINE); }
-	|	T_FILE 		{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_FILE); }
-	|	T_DIR   	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_DIR); }
-	|	T_TRAIT_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_TRAIT_C); }
-	|	T_METHOD_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_METHOD_C); }
-	|	T_FUNC_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_FUNC_C); }
-	|	T_NS_C		{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_NS_C); }
-	|	T_CLASS_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_CLASS_C); }
 	|	T_START_HEREDOC T_ENCAPSED_AND_WHITESPACE T_END_HEREDOC { $$ = $2; }
 	|	T_START_HEREDOC T_END_HEREDOC
 			{ $$ = zend_ast_create_zval_from_str(ZSTR_EMPTY_ALLOC()); }
@@ -1127,7 +1119,15 @@ scalar:
 ;
 
 constant:
-		name { $$ = zend_ast_create(ZEND_AST_CONST, $1); }
+		name		{ $$ = zend_ast_create(ZEND_AST_CONST, $1); }
+	|	T_LINE 		{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_LINE); }
+	|	T_FILE 		{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_FILE); }
+	|	T_DIR   	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_DIR); }
+	|	T_TRAIT_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_TRAIT_C); }
+	|	T_METHOD_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_METHOD_C); }
+	|	T_FUNC_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_FUNC_C); }
+	|	T_NS_C		{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_NS_C); }
+	|	T_CLASS_C	{ $$ = zend_ast_create_ex(ZEND_AST_MAGIC_CONST, T_CLASS_C); }
 ;
 
 class_constant:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1150,12 +1150,12 @@ fully_dereferencable:
 		variable				{ $$ = $1; }
 	|	'(' expr ')'			{ $$ = $2; }
 	|	dereferencable_scalar	{ $$ = $1; }
+	|	class_constant			{ $$ = $1; }
 ;
 
 array_object_dereferencable:
 		fully_dereferencable	{ $$ = $1; }
 	|	constant				{ $$ = $1; }
-	|	class_constant			{ $$ = $1; }
 ;
 
 callable_expr:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1102,6 +1102,7 @@ dereferencable_scalar:
 		T_ARRAY '(' array_pair_list ')'	{ $$ = $3; $$->attr = ZEND_ARRAY_SYNTAX_LONG; }
 	|	'[' array_pair_list ']'			{ $$ = $2; $$->attr = ZEND_ARRAY_SYNTAX_SHORT; }
 	|	T_CONSTANT_ENCAPSED_STRING		{ $$ = $1; }
+	|	'"' encaps_list '"'			 	{ $$ = $2; }
 ;
 
 scalar:
@@ -1118,7 +1119,6 @@ scalar:
 	|	T_START_HEREDOC T_ENCAPSED_AND_WHITESPACE T_END_HEREDOC { $$ = $2; }
 	|	T_START_HEREDOC T_END_HEREDOC
 			{ $$ = zend_ast_create_zval_from_str(ZSTR_EMPTY_ALLOC()); }
-	|	'"' encaps_list '"' 	{ $$ = $2; }
 	|	T_START_HEREDOC encaps_list T_END_HEREDOC { $$ = $2; }
 	|	dereferencable_scalar	{ $$ = $1; }
 	|	constant			{ $$ = $1; }

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -241,7 +241,8 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> new_expr anonymous_class class_name class_name_reference simple_variable
 %type <ast> internal_functions_in_yacc
 %type <ast> exit_expr scalar backticks_expr lexical_var function_call member_name property_name
-%type <ast> variable_class_name dereferencable_scalar constant class_constant dereferencable
+%type <ast> variable_class_name dereferencable_scalar constant class_constant
+%type <ast> fully_dereferencable array_dereferencable
 %type <ast> callable_expr callable_variable static_member new_variable
 %type <ast> encaps_var encaps_var_offset isset_variables
 %type <ast> top_statement_list use_declarations const_list inner_statement_list if_stmt
@@ -1142,13 +1143,19 @@ optional_expr:
 ;
 
 variable_class_name:
-	dereferencable { $$ = $1; }
+		fully_dereferencable { $$ = $1; }
 ;
 
-dereferencable:
+fully_dereferencable:
 		variable				{ $$ = $1; }
 	|	'(' expr ')'			{ $$ = $2; }
 	|	dereferencable_scalar	{ $$ = $1; }
+;
+
+array_dereferencable:
+		fully_dereferencable	{ $$ = $1; }
+	|	constant				{ $$ = $1; }
+	|	class_constant			{ $$ = $1; }
 ;
 
 callable_expr:
@@ -1160,15 +1167,11 @@ callable_expr:
 callable_variable:
 		simple_variable
 			{ $$ = zend_ast_create(ZEND_AST_VAR, $1); }
-	|	dereferencable '[' optional_expr ']'
+	|	array_dereferencable '[' optional_expr ']'
 			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
-	|	constant '[' optional_expr ']'
-			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
-	|	class_constant '[' optional_expr ']'
-			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
-	|	dereferencable '{' expr '}'
+	|	array_dereferencable '{' expr '}'
 			{ $$ = zend_ast_create_ex(ZEND_AST_DIM, ZEND_DIM_ALTERNATIVE_SYNTAX, $1, $3); }
-	|	dereferencable T_OBJECT_OPERATOR property_name argument_list
+	|	fully_dereferencable T_OBJECT_OPERATOR property_name argument_list
 			{ $$ = zend_ast_create(ZEND_AST_METHOD_CALL, $1, $3, $4); }
 	|	function_call { $$ = $1; }
 ;
@@ -1178,7 +1181,7 @@ variable:
 			{ $$ = $1; }
 	|	static_member
 			{ $$ = $1; }
-	|	dereferencable T_OBJECT_OPERATOR property_name
+	|	fully_dereferencable T_OBJECT_OPERATOR property_name
 			{ $$ = zend_ast_create(ZEND_AST_PROP, $1, $3); }
 ;
 

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -241,7 +241,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> new_expr anonymous_class class_name class_name_reference simple_variable
 %type <ast> internal_functions_in_yacc
 %type <ast> exit_expr scalar backticks_expr lexical_var function_call member_name property_name
-%type <ast> variable_class_name dereferencable_scalar constant dereferencable
+%type <ast> variable_class_name dereferencable_scalar constant class_constant dereferencable
 %type <ast> callable_expr callable_variable static_member new_variable
 %type <ast> encaps_var encaps_var_offset isset_variables
 %type <ast> top_statement_list use_declarations const_list inner_statement_list if_stmt
@@ -1121,12 +1121,16 @@ scalar:
 			{ $$ = zend_ast_create_zval_from_str(ZSTR_EMPTY_ALLOC()); }
 	|	T_START_HEREDOC encaps_list T_END_HEREDOC { $$ = $2; }
 	|	dereferencable_scalar	{ $$ = $1; }
-	|	constant			{ $$ = $1; }
+	|	constant				{ $$ = $1; }
+	|	class_constant			{ $$ = $1; }
 ;
 
 constant:
 		name { $$ = zend_ast_create(ZEND_AST_CONST, $1); }
-	|	class_name T_PAAMAYIM_NEKUDOTAYIM identifier
+;
+
+class_constant:
+		class_name T_PAAMAYIM_NEKUDOTAYIM identifier
 			{ $$ = zend_ast_create_class_const_or_name($1, $3); }
 	|	variable_class_name T_PAAMAYIM_NEKUDOTAYIM identifier
 			{ $$ = zend_ast_create_class_const_or_name($1, $3); }
@@ -1159,6 +1163,8 @@ callable_variable:
 	|	dereferencable '[' optional_expr ']'
 			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
 	|	constant '[' optional_expr ']'
+			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
+	|	class_constant '[' optional_expr ']'
 			{ $$ = zend_ast_create(ZEND_AST_DIM, $1, $3); }
 	|	dereferencable '{' expr '}'
 			{ $$ = zend_ast_create_ex(ZEND_AST_DIM, ZEND_DIM_ALTERNATIVE_SYNTAX, $1, $3); }


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/variable_syntax_tweaks

This is a collection of minor syntactic extensions that cover holes left by the original uniform variable syntax RFC:

 * `"foo$bar"` is now treated the same ways as `"foobar"`, e.g. you can write `"foo$bar"[0]`.
 * Magic constants are treated the same as normal constants, e.g. `__FUNCTION__[0]` becomes legal.
 * Class constants become fully dereferencable, in particular `Foo::CLASS_NAME::$bar` becomes legal.
 * `new (expr)` is now accepted. Previously it was not possible to use arbitrary expressions with `new`.
 * Similarly `$var instanceof (expr)` is now accepted.

These are all edge cases, but things I've received complaints about over the years.