### PR TITLE
Add static return type

### DIFF
--- a/Zend/tests/type_declarations/static_type_in_final_class.phpt
+++ b/Zend/tests/type_declarations/static_type_in_final_class.phpt
@@ -1,0 +1,17 @@
+--TEST--
+While it may not be very useful, static is also permitted in final classes
+--FILE--
+<?php
+
+final class Test {
+    public static function create(): static {
+        return new static;
+    }
+}
+
+var_dump(Test::create());
+
+?>
+--EXPECT--
+object(Test)#1 (0) {
+}

--- a/Zend/tests/type_declarations/static_type_outside_class.phpt
+++ b/Zend/tests/type_declarations/static_type_outside_class.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Static type outside class generates compile error
+--FILE--
+<?php
+
+function test(): static {}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use "static" when no class scope is active in %s on line %d

--- a/Zend/tests/type_declarations/static_type_param.phpt
+++ b/Zend/tests/type_declarations/static_type_param.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Static type is not allowed in parameters
+--FILE--
+<?php
+
+// TODO: We could prohibit this case in the compiler instead.
+
+class Test {
+    public function test(static $param) {
+    }
+}
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected 'static' (T_STATIC), expecting variable (T_VARIABLE) in %s on line %d

--- a/Zend/tests/type_declarations/static_type_property.phpt
+++ b/Zend/tests/type_declarations/static_type_property.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Static type is not allowed in properties
+--FILE--
+<?php
+
+// Testing ?static here, to avoid ambiguity with static properties.
+class Test {
+    public ?static $foo;
+}
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected 'static' (T_STATIC) in %s on line %d

--- a/Zend/tests/type_declarations/static_type_return.phpt
+++ b/Zend/tests/type_declarations/static_type_return.phpt
@@ -75,7 +75,7 @@ object(B)#3 (0) {
 
 object(A)#3 (0) {
 }
-Return value of A::test2() must be an instance of static, instance of A returned
+Return value of A::test2() must be an instance of B, instance of A returned
 
 object(A)#3 (0) {
 }
@@ -84,7 +84,7 @@ object(C)#3 (0) {
 
 object(A)#3 (0) {
 }
-Return value of A::test4() must be of type static|array, instance of A returned
+Return value of A::test4() must be of type B|array, instance of A returned
 
 Return value of {closure}() must be an instance of static, instance of stdClass returned
 object(A)#1 (0) {

--- a/Zend/tests/type_declarations/static_type_return.phpt
+++ b/Zend/tests/type_declarations/static_type_return.phpt
@@ -26,10 +26,6 @@ class B extends A {
 
 class C extends B {}
 
-function test(): static {
-    return new stdClass;
-}
-
 $a = new A;
 $b = new B;
 
@@ -57,11 +53,18 @@ try {
 }
 
 echo "\n";
+$test = function($x): static {
+    return $x;
+};
+
 try {
-    var_dump(test());
+    var_dump($test(new stdClass));
 } catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
+
+$test = $test->bindTo($a);
+var_dump($test($a));
 
 ?>
 --EXPECT--
@@ -83,4 +86,6 @@ object(A)#3 (0) {
 }
 Return value of A::test4() must be of type static|array, instance of A returned
 
-Return value of test() must be an instance of static, instance of stdClass returned
+Return value of {closure}() must be an instance of static, instance of stdClass returned
+object(A)#1 (0) {
+}

--- a/Zend/tests/type_declarations/static_type_return.phpt
+++ b/Zend/tests/type_declarations/static_type_return.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Static return type
+--FILE--
+<?php
+
+class A {
+    public function test1(): static {
+        return new static;
+    }
+    public function test2(): static {
+        return new self;
+    }
+    public function test3(): static {
+        return new static;
+    }
+    public function test4(): static|array {
+        return new self;
+    }
+}
+
+class B extends A {
+    public function test3(): static {
+        return new C;
+    }
+}
+
+class C extends B {}
+
+$a = new A;
+$b = new B;
+
+var_dump($a->test1());
+var_dump($b->test1());
+
+echo "\n";
+var_dump($a->test2());
+try {
+    var_dump($b->test2());
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "\n";
+var_dump($a->test3());
+var_dump($b->test3());
+
+echo "\n";
+var_dump($a->test4());
+try {
+    var_dump($b->test4());
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+object(A)#3 (0) {
+}
+object(B)#3 (0) {
+}
+
+object(A)#3 (0) {
+}
+Return value of A::test2() must be an instance of static, instance of A returned
+
+object(A)#3 (0) {
+}
+object(C)#3 (0) {
+}
+
+object(A)#3 (0) {
+}
+Return value of A::test4() must be of type static|array, instance of A returned

--- a/Zend/tests/type_declarations/static_type_return.phpt
+++ b/Zend/tests/type_declarations/static_type_return.phpt
@@ -26,6 +26,10 @@ class B extends A {
 
 class C extends B {}
 
+function test(): static {
+    return new stdClass;
+}
+
 $a = new A;
 $b = new B;
 
@@ -52,6 +56,13 @@ try {
     echo $e->getMessage(), "\n";
 }
 
+echo "\n";
+try {
+    var_dump(test());
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
 ?>
 --EXPECT--
 object(A)#3 (0) {
@@ -71,3 +82,5 @@ object(C)#3 (0) {
 object(A)#3 (0) {
 }
 Return value of A::test4() must be of type static|array, instance of A returned
+
+Return value of test() must be an instance of static, instance of stdClass returned

--- a/Zend/tests/type_declarations/static_type_trait.phpt
+++ b/Zend/tests/type_declarations/static_type_trait.phpt
@@ -1,0 +1,38 @@
+--TEST--
+static type in trait
+--FILE--
+<?php
+
+trait T {
+    public function test($arg): static {
+        return $arg;
+    }
+}
+
+class C {
+    use T;
+}
+class P extends C {
+}
+
+$c = new C;
+$p = new P;
+var_dump($c->test($c));
+var_dump($c->test($p));
+var_dump($p->test($p));
+var_dump($p->test($c));
+
+?>
+--EXPECTF--
+object(C)#1 (0) {
+}
+object(P)#2 (0) {
+}
+object(P)#2 (0) {
+}
+
+Fatal error: Uncaught TypeError: Return value of C::test() must be an instance of P, instance of C returned in %s:%d
+Stack trace:
+#0 %s(%d): C->test(Object(C))
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/type_declarations/union_types/redundant_types/object_and_static.phpt
+++ b/Zend/tests/type_declarations/union_types/redundant_types/object_and_static.phpt
@@ -1,0 +1,12 @@
+--TEST--
+object and static are redundant
+--FILE--
+<?php
+
+class Test {
+    public function foo(): static|object {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Type static|object contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/tests/type_declarations/variance/static_variance_failure.phpt
+++ b/Zend/tests/type_declarations/variance/static_variance_failure.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Failure case for static variance: Replace static with self
+--FILE--
+<?php
+
+class A {
+    public function test(): static {}
+}
+class B extends A {
+    public function test(): self {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of B::test(): B must be compatible with A::test(): static in %s on line %d

--- a/Zend/tests/type_declarations/variance/static_variance_success.phpt
+++ b/Zend/tests/type_declarations/variance/static_variance_success.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Success cases for static variance
+--FILE--
+<?php
+
+class A {
+    public function test1(): self {}
+    public function test2(): B {}
+    public function test3(): object {}
+    public function test4(): X|Y|self {}
+    public function test5(): ?static {}
+}
+
+class B extends A {
+    public function test1(): static {}
+    public function test2(): static {}
+    public function test3(): static {}
+    public function test4(): X|Y|static {}
+    public function test5(): static {}
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1196,6 +1196,9 @@ zend_string *zend_type_to_string_resolved(zend_type type, zend_class_entry *scop
 	}
 
 	uint32_t type_mask = ZEND_TYPE_FULL_MASK(type);
+	if (type_mask & MAY_BE_STATIC) {
+		str = add_type_string(str, ZSTR_KNOWN(ZEND_STR_STATIC));
+	}
 	if (type_mask & MAY_BE_CALLABLE) {
 		str = add_type_string(str, ZSTR_KNOWN(ZEND_STR_CALLABLE));
 	}
@@ -5657,7 +5660,7 @@ static zend_type zend_compile_typename(
 			ZSTR_VAL(type_str));
 	}
 
-	if ((type_mask & MAY_BE_OBJECT) && ZEND_TYPE_HAS_CLASS(type)) {
+	if ((type_mask & MAY_BE_OBJECT) && (ZEND_TYPE_HAS_CLASS(type) || (type_mask & MAY_BE_STATIC))) {
 		zend_string *type_str = zend_type_to_string(type);
 		zend_error_noreturn(E_COMPILE_ERROR,
 			"Type %s contains both object and a class type, which is redundant",

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1197,7 +1197,14 @@ zend_string *zend_type_to_string_resolved(zend_type type, zend_class_entry *scop
 
 	uint32_t type_mask = ZEND_TYPE_FULL_MASK(type);
 	if (type_mask & MAY_BE_STATIC) {
-		str = add_type_string(str, ZSTR_KNOWN(ZEND_STR_STATIC));
+		zend_string *name = ZSTR_KNOWN(ZEND_STR_STATIC);
+		if (scope) {
+			zend_class_entry *called_scope = zend_get_called_scope(EG(current_execute_data));
+			if (called_scope) {
+				name = called_scope->name;
+			}
+		}
+		str = add_type_string(str, name);
 	}
 	if (type_mask & MAY_BE_CALLABLE) {
 		str = add_type_string(str, ZSTR_KNOWN(ZEND_STR_CALLABLE));

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5505,6 +5505,10 @@ static zend_type zend_compile_single_typename(zend_ast *ast)
 {
 	ZEND_ASSERT(!(ast->attr & ZEND_TYPE_NULLABLE));
 	if (ast->kind == ZEND_AST_TYPE) {
+		if (ast->attr == IS_STATIC && !CG(active_class_entry) && zend_is_scope_known()) {
+			zend_error_noreturn(E_COMPILE_ERROR,
+				"Cannot use \"static\" when no class scope is active");
+		}
 		return (zend_type) ZEND_TYPE_INIT_CODE(ast->attr, 0, 0);
 	} else {
 		zend_string *class_name = zend_ast_get_str(ast);

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -714,6 +714,9 @@ static ZEND_COLD void zend_verify_type_error_common(
 			case MAY_BE_ITERABLE:
 				smart_str_appends(&str, "be iterable");
 				break;
+			case MAY_BE_STATIC:
+				smart_str_appends(&str, "be an instance of static");
+				break;
 			default:
 			{
 				/* Hack to print the type without null */
@@ -735,7 +738,9 @@ static ZEND_COLD void zend_verify_type_error_common(
 	*need_msg = smart_str_extract(&str);
 
 	if (value) {
-		if (ZEND_TYPE_HAS_CLASS(arg_info->type) && Z_TYPE_P(value) == IS_OBJECT) {
+		zend_bool has_class = ZEND_TYPE_HAS_CLASS(arg_info->type)
+			|| (ZEND_TYPE_FULL_MASK(arg_info->type) & MAY_BE_STATIC);
+		if (has_class && Z_TYPE_P(value) == IS_OBJECT) {
 			*given_msg = "instance of ";
 			*given_kind = ZSTR_VAL(Z_OBJCE_P(value)->name);
 		} else {
@@ -988,11 +993,12 @@ static zend_always_inline zend_bool i_zend_check_property_type(zend_property_inf
 		return 1;
 	}
 
-	ZEND_ASSERT(!(ZEND_TYPE_FULL_MASK(info->type) & MAY_BE_CALLABLE));
-	if ((ZEND_TYPE_FULL_MASK(info->type) & MAY_BE_ITERABLE) && zend_is_iterable(property)) {
+	uint32_t type_mask = ZEND_TYPE_FULL_MASK(info->type);
+	ZEND_ASSERT(!(type_mask & (MAY_BE_CALLABLE|MAY_BE_STATIC)));
+	if ((type_mask & MAY_BE_ITERABLE) && zend_is_iterable(property)) {
 		return 1;
 	}
-	return zend_verify_scalar_type_hint(ZEND_TYPE_FULL_MASK(info->type), property, strict, 0);
+	return zend_verify_scalar_type_hint(type_mask, property, strict, 0);
 }
 
 static zend_always_inline zend_bool i_zend_verify_property_type(zend_property_info *info, zval *property, zend_bool strict)
@@ -1023,6 +1029,19 @@ static zend_never_inline zval* zend_assign_to_typed_prop(zend_property_info *inf
 
 	return zend_assign_to_variable(property_val, &tmp, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 }
+
+ZEND_API zend_bool zend_value_instanceof_static(zval *zv) {
+	if (Z_TYPE_P(zv) != IS_OBJECT) {
+		return 0;
+	}
+
+	zend_class_entry *called_scope = zend_get_called_scope(EG(current_execute_data));
+	if (!called_scope) {
+		return 0;
+	}
+	return instanceof_function(Z_OBJCE_P(zv), called_scope);
+}
+
 
 static zend_always_inline zend_bool zend_check_type_slow(
 		zend_type type, zval *arg, zend_reference *ref, void **cache_slot, zend_class_entry *scope,
@@ -1072,6 +1091,9 @@ builtin_types:
 		return 1;
 	}
 	if ((type_mask & MAY_BE_ITERABLE) && zend_is_iterable(arg)) {
+		return 1;
+	}
+	if ((type_mask & MAY_BE_STATIC) && zend_value_instanceof_static(arg)) {
 		return 1;
 	}
 	if (ref && ZEND_REF_HAS_TYPE_SOURCES(ref)) {
@@ -3046,7 +3068,7 @@ static zend_always_inline int i_zend_verify_type_assignable_zval(
 	}
 
 	type_mask = ZEND_TYPE_FULL_MASK(type);
-	ZEND_ASSERT(!(type_mask & MAY_BE_CALLABLE));
+	ZEND_ASSERT(!(type_mask & (MAY_BE_CALLABLE|MAY_BE_STATIC)));
 	if (type_mask & MAY_BE_ITERABLE) {
 		return zend_is_iterable(zv);
 	}

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -67,6 +67,8 @@ ZEND_API ZEND_COLD void zend_verify_arg_error(
 ZEND_API ZEND_COLD void zend_verify_return_error(
 		const zend_function *zf, void **cache_slot, zval *value);
 ZEND_API zend_bool zend_verify_ref_array_assignable(zend_reference *ref);
+ZEND_API zend_bool zend_value_instanceof_static(zval *zv);
+
 
 #define ZEND_REF_TYPE_SOURCES(ref) \
 	(ref)->sources

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -342,22 +342,16 @@ static zend_bool zend_type_permits_self(
 	/* Any types that may satisfy self must have already been loaded at this point
 	 * (as a parent or interface), so we never need to register delayed variance obligations
 	 * for this case. */
-	if (ZEND_TYPE_HAS_LIST(type)) {
-		void *entry;
-		ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(type), entry) {
-		zend_string *name = resolve_class_name(scope, ZEND_TYPE_LIST_GET_NAME(entry));
+	zend_type *single_type;
+	ZEND_TYPE_FOREACH(type, single_type) {
+		if (ZEND_TYPE_HAS_NAME(*single_type)) {
+			zend_string *name = resolve_class_name(scope, ZEND_TYPE_NAME(*single_type));
 			zend_class_entry *ce = lookup_class(self, name, /* register_unresolved */ 0);
 			if (ce && unlinked_instanceof(self, ce)) {
 				return 1;
 			}
-		} ZEND_TYPE_LIST_FOREACH_END();
-		return 0;
-	}
-	if (ZEND_TYPE_HAS_NAME(type)) {
-		zend_string *name = resolve_class_name(scope, ZEND_TYPE_NAME(type));
-		zend_class_entry *ce = lookup_class(self, name, /* register_unresolved */ 0);
-		return ce && unlinked_instanceof(self, ce);
-	}
+		}
+	} ZEND_TYPE_FOREACH_END();
 	return 0;
 }
 

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -333,6 +333,34 @@ static zend_bool zend_type_contains_traversable(zend_type type) {
 	return 0;
 }
 
+static zend_bool zend_type_permits_self(
+		zend_type type, zend_class_entry *scope, zend_class_entry *self) {
+	if (ZEND_TYPE_FULL_MASK(type) & MAY_BE_OBJECT) {
+		return 1;
+	}
+
+	/* Any types that may satisfy self must have already been loaded at this point
+	 * (as a parent or interface), so we never need to register delayed variance obligations
+	 * for this case. */
+	if (ZEND_TYPE_HAS_LIST(type)) {
+		void *entry;
+		ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(type), entry) {
+		zend_string *name = resolve_class_name(scope, ZEND_TYPE_LIST_GET_NAME(entry));
+			zend_class_entry *ce = lookup_class(self, name, /* register_unresolved */ 0);
+			if (ce && unlinked_instanceof(self, ce)) {
+				return 1;
+			}
+		} ZEND_TYPE_LIST_FOREACH_END();
+		return 0;
+	}
+	if (ZEND_TYPE_HAS_NAME(type)) {
+		zend_string *name = resolve_class_name(scope, ZEND_TYPE_NAME(type));
+		zend_class_entry *ce = lookup_class(self, name, /* register_unresolved */ 0);
+		return ce && unlinked_instanceof(self, ce);
+	}
+	return 0;
+}
+
 /* Unresolved means that class declarations that are currently not available are needed to
  * determine whether the inheritance is valid or not. At runtime UNRESOLVED should be treated
  * as an ERROR. */
@@ -406,13 +434,22 @@ static inheritance_status zend_perform_covariant_type_check(
 	if (added_types) {
 		// TODO: Make "iterable" an alias of "array|Traversable" instead,
 		// so these special cases will be handled automatically.
-		if (added_types == MAY_BE_ITERABLE
+		if ((added_types & MAY_BE_ITERABLE)
 				&& (proto_type_mask & MAY_BE_ARRAY)
 				&& zend_type_contains_traversable(proto_type)) {
 			/* Replacing array|Traversable with iterable is okay */
-		} else if (added_types == MAY_BE_ARRAY && (proto_type_mask & MAY_BE_ITERABLE)) {
+			added_types &= ~MAY_BE_ITERABLE;
+		}
+		if ((added_types & MAY_BE_ARRAY) && (proto_type_mask & MAY_BE_ITERABLE)) {
 			/* Replacing iterable with array is okay */
-		} else {
+			added_types &= ~MAY_BE_ARRAY;
+		}
+		if ((added_types & MAY_BE_STATIC)
+				&& zend_type_permits_self(proto_type, proto_scope, fe_scope)) {
+			/* Replacing type that accepts self with static is okay */
+			added_types &= ~MAY_BE_STATIC;
+		}
+		if (added_types) {
 			/* Otherwise adding new types is illegal */
 			return INHERITANCE_ERROR;
 		}

--- a/Zend/zend_type_info.h
+++ b/Zend/zend_type_info.h
@@ -40,6 +40,7 @@
 #define MAY_BE_CALLABLE             (1 << IS_CALLABLE)
 #define MAY_BE_ITERABLE             (1 << IS_ITERABLE)
 #define MAY_BE_VOID                 (1 << IS_VOID)
+#define MAY_BE_STATIC               (1 << IS_STATIC)
 
 #define MAY_BE_ARRAY_SHIFT          (IS_REFERENCE)
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -533,6 +533,7 @@ struct _zend_ast_ref {
 #define IS_CALLABLE					12
 #define IS_ITERABLE					13
 #define IS_VOID						14
+#define IS_STATIC					15
 
 /* internal types */
 #define IS_INDIRECT             	12

--- a/ext/opcache/Optimizer/dfa_pass.c
+++ b/ext/opcache/Optimizer/dfa_pass.c
@@ -307,7 +307,7 @@ static inline zend_bool can_elide_return_type_check(
 	}
 
 	/* These types are not represented exactly */
-	if (ZEND_TYPE_FULL_MASK(info->type) & (MAY_BE_CALLABLE|MAY_BE_ITERABLE)) {
+	if (ZEND_TYPE_FULL_MASK(info->type) & (MAY_BE_CALLABLE|MAY_BE_ITERABLE|MAY_BE_STATIC)) {
 		return 0;
 	}
 

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -2223,6 +2223,9 @@ static uint32_t zend_convert_type_declaration_mask(uint32_t type_mask) {
 	if (type_mask & MAY_BE_ITERABLE) {
 		result_mask |= MAY_BE_OBJECT|MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_ANY|MAY_BE_ARRAY_OF_ANY|MAY_BE_ARRAY_OF_REF;
 	}
+	if (type_mask & MAY_BE_STATIC) {
+		result_mask |= MAY_BE_OBJECT;
+	}
 	if (type_mask & MAY_BE_ARRAY) {
 		result_mask |= MAY_BE_ARRAY_KEY_ANY|MAY_BE_ARRAY_OF_ANY|MAY_BE_ARRAY_OF_REF;
 	}

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -1191,7 +1191,7 @@ builtin_types:
 		return 1;
 	}
 	if ((type_mask & MAY_BE_STATIC) && zend_value_instanceof_static(arg)) {
-		return;
+		return 1;
 	}
 	if (zend_verify_scalar_type_hint(type_mask, arg, ZEND_ARG_USES_STRICT_TYPES(), /* is_internal */ 0)) {
 		return 1;

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -1190,6 +1190,9 @@ builtin_types:
 	if ((type_mask & MAY_BE_ITERABLE) && zend_is_iterable(arg)) {
 		return 1;
 	}
+	if ((type_mask & MAY_BE_STATIC) && zend_value_instanceof_static(arg)) {
+		return;
+	}
 	if (zend_verify_scalar_type_hint(type_mask, arg, ZEND_ARG_USES_STRICT_TYPES(), /* is_internal */ 0)) {
 		return 1;
 	}

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2909,7 +2909,9 @@ ZEND_METHOD(reflection_named_type, isBuiltin)
 	}
 	GET_REFLECTION_OBJECT_PTR(param);
 
-	RETVAL_BOOL(ZEND_TYPE_IS_ONLY_MASK(param->type));
+	/* Treat "static" as a class type for the purposes of reflection. */
+	RETVAL_BOOL(ZEND_TYPE_IS_ONLY_MASK(param->type)
+		&& !(ZEND_TYPE_FULL_MASK(param->type) & MAY_BE_STATIC));
 }
 /* }}} */
 

--- a/ext/reflection/tests/static_type.phpt
+++ b/ext/reflection/tests/static_type.phpt
@@ -1,0 +1,23 @@
+--TEST--
+ReflectionType for static types
+--FILE--
+<?php
+
+class A {
+    public function test(): static {
+        return new static;
+    }
+}
+
+$rm = new ReflectionMethod(A::class, 'test');
+$rt = $rm->getReturnType();
+// TODO: Should it be considered a builtin or not?
+var_dump($rt->isBuiltin());
+var_dump($rt->getName());
+var_dump((string) $rt);
+
+?>
+--EXPECT--
+bool(true)
+string(6) "static"
+string(6) "static"

--- a/ext/reflection/tests/static_type.phpt
+++ b/ext/reflection/tests/static_type.phpt
@@ -11,13 +11,12 @@ class A {
 
 $rm = new ReflectionMethod(A::class, 'test');
 $rt = $rm->getReturnType();
-// TODO: Should it be considered a builtin or not?
 var_dump($rt->isBuiltin());
 var_dump($rt->getName());
 var_dump((string) $rt);
 
 ?>
 --EXPECT--
-bool(true)
+bool(false)
 string(6) "static"
 string(6) "static"


### PR DESCRIPTION
Implementation for https://wiki.php.net/rfc/static_return_type.

The type is only supported in covariant contexts (i.e. only return types right now), because it would be unsound anywhere else. `static` is considered a subtype of `self`.

Because the `static` type conflicts syntactically with `static` properties, it is excluded from property types on the grammar level.

~~The `static` is internally implemented as a builtin type because it has lots of magic semantics. Currently it is also exposed via `ReflectionType::isBuiltin()` as `true`. However, `static` is usually considered a class in userland, so it might make sense to hack that to return `false`?~~ Now returns `false`.