### PR TITLE
Deprecate required param after optional

### DIFF
--- a/Zend/tests/bug71428.3.phpt
+++ b/Zend/tests/bug71428.3.phpt
@@ -7,4 +7,6 @@ class B           {  public function m(A $a = NULL, $n) { echo "B.m";} };
 class C extends B {  public function m(A $a       , $n) { echo "C.m";} };
 ?>
 --EXPECTF--
+Deprecated: Required parameter $n follows optional parameter in %s on line %d
+
 Fatal error: Declaration of C::m(A $a, $n) must be compatible with B::m(?A $a, $n) in %sbug71428.3.php on line 4

--- a/Zend/tests/bug71428.3.phpt
+++ b/Zend/tests/bug71428.3.phpt
@@ -7,6 +7,4 @@ class B           {  public function m(A $a = NULL, $n) { echo "B.m";} };
 class C extends B {  public function m(A $a       , $n) { echo "C.m";} };
 ?>
 --EXPECTF--
-Deprecated: Required parameter $n follows optional parameter in %s on line %d
-
 Fatal error: Declaration of C::m(A $a, $n) must be compatible with B::m(?A $a, $n) in %sbug71428.3.php on line 4

--- a/Zend/tests/call_user_func_005.phpt
+++ b/Zend/tests/call_user_func_005.phpt
@@ -18,6 +18,7 @@ var_dump(call_user_func(array('foo', 'teste')));
 
 ?>
 --EXPECTF--
+Deprecated: Required parameter $b follows optional parameter in %s on line %d
 string(1) "x"
 array(1) {
   [0]=>

--- a/Zend/tests/call_user_func_005.phpt
+++ b/Zend/tests/call_user_func_005.phpt
@@ -18,7 +18,7 @@ var_dump(call_user_func(array('foo', 'teste')));
 
 ?>
 --EXPECTF--
-Deprecated: Required parameter $b follows optional parameter in %s on line %d
+Deprecated: Required parameter $b follows optional parameter $a in %s on line %d
 string(1) "x"
 array(1) {
   [0]=>

--- a/Zend/tests/required_param_after_optional.phpt
+++ b/Zend/tests/required_param_after_optional.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Required parameter after optional is deprecated
+--FILE--
+<?php
+
+function test($testA = null, $testB = null, $testC) {}
+function test2(Type $test2A = null, $test2B = null, $test2C) {}
+function test3(Type $test3A = null, Type2 $test3B = null, $test3C) {}
+
+?>
+--EXPECTF--
+Deprecated: Required parameter $testC follows optional parameter $testA in %s on line %d
+
+Deprecated: Required parameter $test2C follows optional parameter $test2B in %s on line %d

--- a/Zend/tests/traits/bug60717.phpt
+++ b/Zend/tests/traits/bug60717.phpt
@@ -9,7 +9,7 @@ namespace HTML
     {
         function text($text);
         function attributes(array $attributes = null);
-        function textArea(array $attributes = null, $value);
+        function textArea(?array $attributes, $value);
     }
 
     trait TextUTF8
@@ -19,7 +19,7 @@ namespace HTML
 
     trait TextArea
     {
-        function textArea(array $attributes = null, $value) {}
+        function textArea(?array $attributes, $value) {}
         abstract function attributes(array $attributes = null);
         abstract function text($text);
     }

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5679,6 +5679,7 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 	uint32_t i;
 	zend_op_array *op_array = CG(active_op_array);
 	zend_arg_info *arg_infos;
+	zend_bool have_optional_param = 0;
 
 	if (return_type_ast) {
 		/* Use op_array->arg_info[-1] for return type */
@@ -5747,10 +5748,15 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast) /* {{{ */
 			default_node.op_type = IS_CONST;
 			zend_const_expr_to_zval(&default_node.u.constant, default_ast);
 			CG(compiler_options) = cops;
+			have_optional_param = 1;
 		} else {
 			opcode = ZEND_RECV;
 			default_node.op_type = IS_UNUSED;
 			op_array->required_num_args = i + 1;
+			if (have_optional_param) {
+				zend_error(E_DEPRECATED, "Required parameter $%s follows optional parameter",
+					ZSTR_VAL(name));
+			}
 		}
 
 		arg_info = &arg_infos[i];

--- a/ext/reflection/tests/ReflectionClass_isArray.phpt
+++ b/ext/reflection/tests/ReflectionClass_isArray.phpt
@@ -4,7 +4,8 @@ public bool ReflectionParameter::isArray ( void );
 marcosptf - <marcosptf@yahoo.com.br> - @phpsp - sao paulo - br
 --FILE--
 <?php
-function testReflectionIsArray($a = null, $b = 0, array $c, $d=true, array $e, $f=1.5, $g="", array $h, $i="#F989898") {}
+
+function testReflectionIsArray(array $a, ?array $b, iterable $c, array|string $d) {}
 
 $reflection = new ReflectionFunction('testReflectionIsArray');
 
@@ -13,12 +14,7 @@ foreach ($reflection->getParameters() as $parameter) {
 }
 ?>
 --EXPECT--
-bool(false)
-bool(false)
+bool(true)
 bool(true)
 bool(false)
-bool(true)
-bool(false)
-bool(false)
-bool(true)
 bool(false)

--- a/ext/reflection/tests/ReflectionType_001.phpt
+++ b/ext/reflection/tests/ReflectionType_001.phpt
@@ -2,7 +2,7 @@
 ReflectionParameter::get/hasType and ReflectionType tests
 --FILE--
 <?php
-function foo(stdClass $a, array $b, callable $c, stdClass $d = null, $e = null, string $f, bool $g, int $h, float $i, NotExisting $j) { }
+function foo(stdClass $a, array $b, callable $c, string $f, bool $g, int $h, float $i, NotExisting $j, stdClass $d = null, $e = null) { }
 
 function bar(): stdClass { return new stdClass; }
 
@@ -120,36 +120,36 @@ bool(true)
 string(8) "callable"
 ** Function 0 - Parameter 3
 bool(true)
-bool(true)
-bool(false)
-string(8) "stdClass"
-** Function 0 - Parameter 4
-bool(false)
-** Function 0 - Parameter 5
-bool(true)
 bool(false)
 bool(true)
 string(6) "string"
-** Function 0 - Parameter 6
+** Function 0 - Parameter 4
 bool(true)
 bool(false)
 bool(true)
 string(4) "bool"
-** Function 0 - Parameter 7
+** Function 0 - Parameter 5
 bool(true)
 bool(false)
 bool(true)
 string(3) "int"
-** Function 0 - Parameter 8
+** Function 0 - Parameter 6
 bool(true)
 bool(false)
 bool(true)
 string(5) "float"
-** Function 0 - Parameter 9
+** Function 0 - Parameter 7
 bool(true)
 bool(false)
 bool(false)
 string(11) "NotExisting"
+** Function 0 - Parameter 8
+bool(true)
+bool(true)
+bool(false)
+string(8) "stdClass"
+** Function 0 - Parameter 9
+bool(false)
 ** Function 1 - Parameter 0
 bool(true)
 bool(false)

--- a/ext/reflection/tests/bug62715.phpt
+++ b/ext/reflection/tests/bug62715.phpt
@@ -16,7 +16,8 @@ foreach ($r->getParameters() as $p) {
     }
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Required parameter $c follows optional parameter in %s on line %d
 bool(true)
 bool(true)
 bool(false)

--- a/ext/reflection/tests/bug62715.phpt
+++ b/ext/reflection/tests/bug62715.phpt
@@ -17,7 +17,7 @@ foreach ($r->getParameters() as $p) {
 }
 ?>
 --EXPECTF--
-Deprecated: Required parameter $c follows optional parameter in %s on line %d
+Deprecated: Required parameter $c follows optional parameter $b in %s on line %d
 bool(true)
 bool(true)
 bool(false)


### PR DESCRIPTION
This addresses https://bugs.php.net/bug.php?id=53399.

Historically, having an "optional" parameter before a required one was useful for poor man's nullable types. That is, one could write `function test(FooBar $param = null, $param2)` to get an effective `?FooBar` typehint on PHP versions that did not natively support it.

Since we've had nullable types since PHP 7.1 now, having a required parameter after an optional one is increasingly likely a bug rather than an intentional workaround, so we should throw a warning for this case.