### PR TITLE
Check abstract method signatures coming from traits

### DIFF
--- a/Zend/tests/traits/abstract_method_1.phpt
+++ b/Zend/tests/traits/abstract_method_1.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Abstract method from trait enforced in class
+--FILE--
+<?php
+
+trait T {
+    abstract function neededByTheTrait(int $a, string $b);
+}
+
+class C {
+    use T;
+
+    function neededByTheTrait(array $a, object $b) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of C::neededByTheTrait(array $a, object $b) must be compatible with T::neededByTheTrait(int $a, string $b) in %s on line %d

--- a/Zend/tests/traits/abstract_method_2.phpt
+++ b/Zend/tests/traits/abstract_method_2.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Mutually incompatible methods from traits are fine as long as the final method is compatible
+--FILE--
+<?php
+
+trait T1 {
+    abstract public function test();
+}
+trait T2 {
+    abstract public function test(): int;
+}
+
+class C {
+    use T1, T2;
+
+    function test(): int {}
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/traits/abstract_method_2.phpt
+++ b/Zend/tests/traits/abstract_method_2.phpt
@@ -13,7 +13,7 @@ trait T2 {
 class C {
     use T1, T2;
 
-    function test(): int {}
+    public function test(): int {}
 }
 
 ?>

--- a/Zend/tests/traits/abstract_method_3.phpt
+++ b/Zend/tests/traits/abstract_method_3.phpt
@@ -1,16 +1,16 @@
 --TEST--
-Abstract method from trait enforced in class
+Private abstract method from trait enforced in class
 --FILE--
 <?php
 
 trait T {
-    abstract public function neededByTheTrait(int $a, string $b);
+    abstract private function neededByTheTrait(int $a, string $b);
 }
 
 class C {
     use T;
 
-    public function neededByTheTrait(array $a, object $b) {}
+    private function neededByTheTrait(array $a, object $b) {}
 }
 
 ?>

--- a/Zend/tests/traits/abstract_method_4.phpt
+++ b/Zend/tests/traits/abstract_method_4.phpt
@@ -10,9 +10,11 @@ trait T {
 class C {
     use T;
 
+    /* For backwards-compatiblity reasons, visibility is not enforced here. */
     private function method(int $a, string $b) {}
 }
 
 ?>
---EXPECTF--
-Fatal error: Access level to C::method() must be public (as in class T) in %s on line %d
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/traits/abstract_method_4.phpt
+++ b/Zend/tests/traits/abstract_method_4.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Visibility enforcement on abstract trait methods
+--FILE--
+<?php
+
+trait T {
+    abstract public function method(int $a, string $b);
+}
+
+class C {
+    use T;
+
+    private function method(int $a, string $b) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Access level to C::method() must be public (as in class T) in %s on line %d

--- a/Zend/tests/traits/abstract_method_5.phpt
+++ b/Zend/tests/traits/abstract_method_5.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Staticness enforcement on abstract trait methods
+--FILE--
+<?php
+
+trait T {
+    abstract static public function method(int $a, string $b);
+}
+
+class C {
+    use T;
+
+    public function method(int $a, string $b) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot make static method T::method() non static in class C in %s on line %d

--- a/Zend/tests/traits/abstract_method_6.phpt
+++ b/Zend/tests/traits/abstract_method_6.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Abstract private trait method not implemented
+--FILE--
+<?php
+
+trait T {
+    abstract private function method(int $a, string $b);
+}
+
+abstract class C {
+    use T;
+}
+
+class D extends C {
+    private function method(int $a, string $b) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Class C must implement 1 abstract private method (C::method) in %s on line %d

--- a/Zend/tests/traits/abstract_method_7.phpt
+++ b/Zend/tests/traits/abstract_method_7.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Abstract private trait method forwarded as abstract protected method
+--FILE--
+<?php
+
+trait T {
+    abstract private function method(int $a, string $b);
+}
+
+abstract class C {
+    use T;
+
+    abstract protected function method(int $a, string $b);
+}
+
+class D extends C {
+    protected function method(int $a, string $b) {}
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/traits/bug60217b.phpt
+++ b/Zend/tests/traits/bug60217b.phpt
@@ -22,4 +22,4 @@ class CBroken {
 $o = new CBroken;
 $o->foo(1);
 --EXPECTF--
-Fatal error: Declaration of TBroken1::foo($a) must be compatible with TBroken2::foo($a, $b = 0) in %s
+Fatal error: Declaration of CBroken::foo($a) must be compatible with TBroken2::foo($a, $b = 0) in %s on line %d

--- a/Zend/tests/traits/bug60217c.phpt
+++ b/Zend/tests/traits/bug60217c.phpt
@@ -22,4 +22,4 @@ class CBroken {
 $o = new CBroken;
 $o->foo(1);
 --EXPECTF--
-Fatal error: Declaration of TBroken2::foo($a) must be compatible with TBroken1::foo($a, $b = 0) in %s on line %d
+Fatal error: Declaration of CBroken::foo($a) must be compatible with TBroken1::foo($a, $b = 0) in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6101,7 +6101,7 @@ void zend_begin_method_decl(zend_op_array *op_array, zend_string *name, zend_boo
 	}
 
 	if (op_array->fn_flags & ZEND_ACC_ABSTRACT) {
-		if (op_array->fn_flags & ZEND_ACC_PRIVATE) {
+		if ((op_array->fn_flags & ZEND_ACC_PRIVATE) && !(ce->ce_flags & ZEND_ACC_TRAIT)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "%s function %s::%s() cannot be declared private",
 				in_interface ? "Interface" : "Abstract", ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		}

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -868,7 +868,7 @@ static zend_always_inline inheritance_status do_inheritance_check_on_method_ex(z
 		parent = proto;
 	}
 
-	if (!check_only && child->common.prototype != proto) {
+	if (!check_only && child->common.prototype != proto && child_zv) {
 		do {
 			if (child->common.scope != ce
 			 && child->type == ZEND_USER_FUNCTION
@@ -876,7 +876,7 @@ static zend_always_inline inheritance_status do_inheritance_check_on_method_ex(z
 				if (ce->ce_flags & ZEND_ACC_INTERFACE) {
 					/* Few parent interfaces contain the same method */
 					break;
-				} else if (child_zv) {
+				} else {
 					/* op_array wasn't duplicated yet */
 					zend_function *new_function = zend_arena_alloc(&CG(arena), sizeof(zend_op_array));
 					memcpy(new_function, child, sizeof(zend_op_array));
@@ -1593,7 +1593,6 @@ static void zend_add_trait_method(zend_class_entry *ce, zend_string *name, zend_
 		/* Abstract method signatures from the trait must be satisfied. */
 		if (fn->common.fn_flags & ZEND_ACC_ABSTRACT) {
 			do_inheritance_check_on_method(existing_fn, fn, ce, NULL);
-			fn->common.prototype = NULL;
 			return;
 		}
 
@@ -1616,7 +1615,6 @@ static void zend_add_trait_method(zend_class_entry *ce, zend_string *name, zend_
 			/* inherited members are overridden by members inserted by traits */
 			/* check whether the trait method fulfills the inheritance requirements */
 			do_inheritance_check_on_method(fn, existing_fn, ce, NULL);
-			fn->common.prototype = NULL;
 		}
 	}
 


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/abstract_trait_method_validation

Abstract method signatures coming from traits are currently not being validated, or at least not in the most common case where the abstract method is implemented directly by the using class. If it is implemented by a parent class, or by a child class, then the method is already validated.

This fixes the behavior to always validate abstract methods from traits. Additionally it removes the requirement that abstract methods in multiple traits must be bidirectionally compatible. That is, the code from https://3v4l.org/VrpaV will now compile without error.