### PR TITLE
Fix useless tests

### DIFF
--- a/ext/standard/tests/array/arsort_object1.phpt
+++ b/ext/standard/tests/array/arsort_object1.phpt
@@ -45,17 +45,17 @@ class for_string_arsort
 
 // array of integer objects
 $unsorted_int_obj = array (
-  1 => new for_integer_arsort(11), 2 =>  new for_integer_asort(66),
-  3 => new for_integer_arsort(23), 4 => new for_integer_asort(-5),
-  5 => new for_integer_arsort(0.001), 6 => new for_integer_asort(0)
+  1 => new for_integer_arsort(11), 2 =>  new for_integer_arsort(66),
+  3 => new for_integer_arsort(23), 4 => new for_integer_arsort(-5),
+  5 => new for_integer_arsort(0.001), 6 => new for_integer_arsort(0)
 );
 
 // array of string objects
 $unsorted_str_obj = array (
-  "a" => new for_string_arsort("axx"), "b" => new for_string_asort("t"),
-  "c" => new for_string_arsort("w"), "d" => new for_string_asort("py"),
-  "e" => new for_string_arsort("apple"), "f" => new for_string_asort("Orange"),
-  "g" => new for_string_arsort("Lemon"), "h" => new for_string_asort("aPPle")
+  "a" => new for_string_arsort("axx"), "b" => new for_string_arsort("t"),
+  "c" => new for_string_arsort("w"), "d" => new for_string_arsort("py"),
+  "e" => new for_string_arsort("apple"), "f" => new for_string_arsort("Orange"),
+  "g" => new for_string_arsort("Lemon"), "h" => new for_string_arsort("aPPle")
 );
 
 
@@ -84,10 +84,162 @@ var_dump($temp_array);
 
 echo "Done\n";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing arsort() : object functionality ***
 
-Fatal error: Uncaught Error: Class 'for_integer_asort' not found in %sarsort_object1.php:%d
-Stack trace:
-#0 {main}
-  thrown in %sarsort_object1.php on line %d
+-- Testing arsort() by supplying various object arrays, 'flag' value is defualt --
+bool(true)
+array(6) {
+  [2]=>
+  object(for_integer_arsort)#2 (1) {
+    ["class_value"]=>
+    int(66)
+  }
+  [3]=>
+  object(for_integer_arsort)#3 (1) {
+    ["class_value"]=>
+    int(23)
+  }
+  [1]=>
+  object(for_integer_arsort)#1 (1) {
+    ["class_value"]=>
+    int(11)
+  }
+  [5]=>
+  object(for_integer_arsort)#5 (1) {
+    ["class_value"]=>
+    float(0.001)
+  }
+  [6]=>
+  object(for_integer_arsort)#6 (1) {
+    ["class_value"]=>
+    int(0)
+  }
+  [4]=>
+  object(for_integer_arsort)#4 (1) {
+    ["class_value"]=>
+    int(-5)
+  }
+}
+bool(true)
+array(8) {
+  ["c"]=>
+  object(for_string_arsort)#9 (1) {
+    ["class_value"]=>
+    string(1) "w"
+  }
+  ["b"]=>
+  object(for_string_arsort)#8 (1) {
+    ["class_value"]=>
+    string(1) "t"
+  }
+  ["d"]=>
+  object(for_string_arsort)#10 (1) {
+    ["class_value"]=>
+    string(2) "py"
+  }
+  ["a"]=>
+  object(for_string_arsort)#7 (1) {
+    ["class_value"]=>
+    string(3) "axx"
+  }
+  ["e"]=>
+  object(for_string_arsort)#11 (1) {
+    ["class_value"]=>
+    string(5) "apple"
+  }
+  ["h"]=>
+  object(for_string_arsort)#14 (1) {
+    ["class_value"]=>
+    string(5) "aPPle"
+  }
+  ["f"]=>
+  object(for_string_arsort)#12 (1) {
+    ["class_value"]=>
+    string(6) "Orange"
+  }
+  ["g"]=>
+  object(for_string_arsort)#13 (1) {
+    ["class_value"]=>
+    string(5) "Lemon"
+  }
+}
+
+-- Testing arsort() by supplying various object arrays, 'flag' value is SORT_REGULAR --
+bool(true)
+array(6) {
+  [2]=>
+  object(for_integer_arsort)#2 (1) {
+    ["class_value"]=>
+    int(66)
+  }
+  [3]=>
+  object(for_integer_arsort)#3 (1) {
+    ["class_value"]=>
+    int(23)
+  }
+  [1]=>
+  object(for_integer_arsort)#1 (1) {
+    ["class_value"]=>
+    int(11)
+  }
+  [5]=>
+  object(for_integer_arsort)#5 (1) {
+    ["class_value"]=>
+    float(0.001)
+  }
+  [6]=>
+  object(for_integer_arsort)#6 (1) {
+    ["class_value"]=>
+    int(0)
+  }
+  [4]=>
+  object(for_integer_arsort)#4 (1) {
+    ["class_value"]=>
+    int(-5)
+  }
+}
+bool(true)
+array(8) {
+  ["c"]=>
+  object(for_string_arsort)#9 (1) {
+    ["class_value"]=>
+    string(1) "w"
+  }
+  ["b"]=>
+  object(for_string_arsort)#8 (1) {
+    ["class_value"]=>
+    string(1) "t"
+  }
+  ["d"]=>
+  object(for_string_arsort)#10 (1) {
+    ["class_value"]=>
+    string(2) "py"
+  }
+  ["a"]=>
+  object(for_string_arsort)#7 (1) {
+    ["class_value"]=>
+    string(3) "axx"
+  }
+  ["e"]=>
+  object(for_string_arsort)#11 (1) {
+    ["class_value"]=>
+    string(5) "apple"
+  }
+  ["h"]=>
+  object(for_string_arsort)#14 (1) {
+    ["class_value"]=>
+    string(5) "aPPle"
+  }
+  ["f"]=>
+  object(for_string_arsort)#12 (1) {
+    ["class_value"]=>
+    string(6) "Orange"
+  }
+  ["g"]=>
+  object(for_string_arsort)#13 (1) {
+    ["class_value"]=>
+    string(5) "Lemon"
+  }
+}
+Done

--- a/ext/standard/tests/array/arsort_object2.phpt
+++ b/ext/standard/tests/array/arsort_object2.phpt
@@ -52,14 +52,14 @@ class for_string_arsort
 
 // array of integer objects
 $unsorted_int_obj = array (
-  1 => new for_integer_arsort(11, 33,2), 2 =>  new for_integer_asort(44, 66,3),
-  3 => new for_integer_arsort(23, 32,6), 4 => new for_integer_asort(-88, -5,-4),
+  1 => new for_integer_arsort(11, 33,2), 2 =>  new for_integer_arsort(44, 66,3),
+  3 => new for_integer_arsort(23, 32,6), 4 => new for_integer_arsort(-88, -5,-4),
 );
 
 // array of string objects
 $unsorted_str_obj = array (
-  "a" => new for_string_arsort("axx","AXX","d"), "b" => new for_string_asort("T", "t","q"),
-  "c" => new for_string_arsort("w", "W","c"), "d" => new for_string_asort("PY", "py","s"),
+  "a" => new for_string_arsort("axx","AXX","d"), "b" => new for_string_arsort("T", "t","q"),
+  "c" => new for_string_arsort("w", "W","c"), "d" => new for_string_arsort("PY", "py","s"),
 );
 
 
@@ -88,10 +88,166 @@ var_dump($temp_array);
 
 echo "Done\n";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing arsort() : object functionality ***
 
-Fatal error: Uncaught Error: Class 'for_integer_asort' not found in %sarsort_object2.php:%d
-Stack trace:
-#0 {main}
-  thrown in %sarsort_object2.php on line %d
+-- Testing arsort() by supplying various object arrays, 'flag' value is default --
+bool(true)
+array(4) {
+  [2]=>
+  object(for_integer_arsort)#2 (3) {
+    ["public_class_value"]=>
+    int(44)
+    ["private_class_value":"for_integer_arsort":private]=>
+    int(66)
+    ["protected_class_value":protected]=>
+    int(3)
+  }
+  [3]=>
+  object(for_integer_arsort)#3 (3) {
+    ["public_class_value"]=>
+    int(23)
+    ["private_class_value":"for_integer_arsort":private]=>
+    int(32)
+    ["protected_class_value":protected]=>
+    int(6)
+  }
+  [1]=>
+  object(for_integer_arsort)#1 (3) {
+    ["public_class_value"]=>
+    int(11)
+    ["private_class_value":"for_integer_arsort":private]=>
+    int(33)
+    ["protected_class_value":protected]=>
+    int(2)
+  }
+  [4]=>
+  object(for_integer_arsort)#4 (3) {
+    ["public_class_value"]=>
+    int(-88)
+    ["private_class_value":"for_integer_arsort":private]=>
+    int(-5)
+    ["protected_class_value":protected]=>
+    int(-4)
+  }
+}
+bool(true)
+array(4) {
+  ["c"]=>
+  object(for_string_arsort)#7 (3) {
+    ["public_class_value"]=>
+    string(1) "w"
+    ["private_class_value":"for_string_arsort":private]=>
+    string(1) "W"
+    ["protected_class_value":protected]=>
+    string(1) "c"
+  }
+  ["a"]=>
+  object(for_string_arsort)#5 (3) {
+    ["public_class_value"]=>
+    string(3) "axx"
+    ["private_class_value":"for_string_arsort":private]=>
+    string(3) "AXX"
+    ["protected_class_value":protected]=>
+    string(1) "d"
+  }
+  ["b"]=>
+  object(for_string_arsort)#6 (3) {
+    ["public_class_value"]=>
+    string(1) "T"
+    ["private_class_value":"for_string_arsort":private]=>
+    string(1) "t"
+    ["protected_class_value":protected]=>
+    string(1) "q"
+  }
+  ["d"]=>
+  object(for_string_arsort)#8 (3) {
+    ["public_class_value"]=>
+    string(2) "PY"
+    ["private_class_value":"for_string_arsort":private]=>
+    string(2) "py"
+    ["protected_class_value":protected]=>
+    string(1) "s"
+  }
+}
+
+-- Testing arsort() by supplying various object arrays, 'flag' value is SORT_REGULAR --
+bool(true)
+array(4) {
+  [2]=>
+  object(for_integer_arsort)#2 (3) {
+    ["public_class_value"]=>
+    int(44)
+    ["private_class_value":"for_integer_arsort":private]=>
+    int(66)
+    ["protected_class_value":protected]=>
+    int(3)
+  }
+  [3]=>
+  object(for_integer_arsort)#3 (3) {
+    ["public_class_value"]=>
+    int(23)
+    ["private_class_value":"for_integer_arsort":private]=>
+    int(32)
+    ["protected_class_value":protected]=>
+    int(6)
+  }
+  [1]=>
+  object(for_integer_arsort)#1 (3) {
+    ["public_class_value"]=>
+    int(11)
+    ["private_class_value":"for_integer_arsort":private]=>
+    int(33)
+    ["protected_class_value":protected]=>
+    int(2)
+  }
+  [4]=>
+  object(for_integer_arsort)#4 (3) {
+    ["public_class_value"]=>
+    int(-88)
+    ["private_class_value":"for_integer_arsort":private]=>
+    int(-5)
+    ["protected_class_value":protected]=>
+    int(-4)
+  }
+}
+bool(true)
+array(4) {
+  ["c"]=>
+  object(for_string_arsort)#7 (3) {
+    ["public_class_value"]=>
+    string(1) "w"
+    ["private_class_value":"for_string_arsort":private]=>
+    string(1) "W"
+    ["protected_class_value":protected]=>
+    string(1) "c"
+  }
+  ["a"]=>
+  object(for_string_arsort)#5 (3) {
+    ["public_class_value"]=>
+    string(3) "axx"
+    ["private_class_value":"for_string_arsort":private]=>
+    string(3) "AXX"
+    ["protected_class_value":protected]=>
+    string(1) "d"
+  }
+  ["b"]=>
+  object(for_string_arsort)#6 (3) {
+    ["public_class_value"]=>
+    string(1) "T"
+    ["private_class_value":"for_string_arsort":private]=>
+    string(1) "t"
+    ["protected_class_value":protected]=>
+    string(1) "q"
+  }
+  ["d"]=>
+  object(for_string_arsort)#8 (3) {
+    ["public_class_value"]=>
+    string(2) "PY"
+    ["private_class_value":"for_string_arsort":private]=>
+    string(2) "py"
+    ["protected_class_value":protected]=>
+    string(1) "s"
+  }
+}
+Done


### PR DESCRIPTION
These tests are certainly not supposed to fail due to a typo in the
class names, but expect this failure.  We fix the typos and the
expectations.

--- 
To be honest, these tests still make not too much sense (e.g. `SORT_REGULAR` is the default), but with this PR they are no longer completely useless.