### PR TITLE
Add ReflectionProperty::getDefaultValue and ReflectionProperty::hasDefaultValue

### DIFF
--- a/ext/reflection/reflection.stub.php
+++ b/ext/reflection/reflection.stub.php
@@ -425,6 +425,11 @@ class ReflectionProperty implements Reflector
 
     /** @return bool */
     public function hasType() {}
+
+    public function hasDefaultValue(): bool {}
+
+    /** @return mixed */
+    public function getDefaultValue() {}
 }
 
 class ReflectionClassConstant implements Reflector

--- a/ext/reflection/reflection_arginfo.h
+++ b/ext/reflection/reflection_arginfo.h
@@ -343,6 +343,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionProperty_hasType arginfo_class_Reflector___toString
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionProperty_hasDefaultValue, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ReflectionProperty_getDefaultValue arginfo_class_Reflector___toString
+
 #define arginfo_class_ReflectionClassConstant___clone arginfo_class_Reflector___toString
 
 #define arginfo_class_ReflectionClassConstant_export arginfo_class_ReflectionMethod_export

--- a/ext/reflection/tests/ReflectionProperty_getDefaultValue.phpt
+++ b/ext/reflection/tests/ReflectionProperty_getDefaultValue.phpt
@@ -1,0 +1,73 @@
+--TEST--
+reflection: ReflectionProperty::getDefaultValue
+--FILE--
+<?php
+
+define('FOO', 42);
+
+class TestClass
+{
+    public $foo;
+    public $bar = 'baz';
+
+    public static $static1;
+    public static $static2 = 1234;
+
+    public int $val1;
+    public int $val2 = 1234;
+
+    public ?int $nullable;
+    public ?int $nullable2 = null;
+
+    public $constantAst = 2 * 2;
+    public $constantRuntimeAst = FOO;
+}
+
+$property = new ReflectionProperty(TestClass::class, 'foo');
+var_dump($property->getDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'bar');
+var_dump($property->getDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'static1');
+var_dump($property->getDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'static2');
+var_dump($property->getDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'val1');
+var_dump($property->getDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'val2');
+var_dump($property->getDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'nullable');
+var_dump($property->getDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'nullable2');
+var_dump($property->getDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'constantAst');
+var_dump($property->getDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'constantRuntimeAst');
+var_dump($property->getDefaultValue());
+
+$test = new TestClass;
+$test->dynamic = null;
+$property = new ReflectionProperty($test, 'dynamic');
+var_dump($property->getDefaultValue());
+
+?>
+--EXPECT--
+NULL
+string(3) "baz"
+NULL
+int(1234)
+NULL
+int(1234)
+NULL
+NULL
+int(4)
+int(42)
+NULL

--- a/ext/reflection/tests/ReflectionProperty_hasDefaultValue.phpt
+++ b/ext/reflection/tests/ReflectionProperty_hasDefaultValue.phpt
@@ -1,0 +1,60 @@
+--TEST--
+reflection: ReflectionProperty::hasDefaultValue
+--FILE--
+<?php
+
+class TestClass
+{
+    public $foo;
+    public $bar = 'baz';
+
+    public static $static1;
+    public static $static2 = 1234;
+
+    public int $val1;
+    public int $val2 = 1234;
+
+    public ?int $nullable;
+    public ?int $nullable2 = null;
+}
+
+$property = new ReflectionProperty(TestClass::class, 'foo');
+var_dump($property->hasDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'bar');
+var_dump($property->hasDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'static1');
+var_dump($property->hasDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'static2');
+var_dump($property->hasDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'val1');
+var_dump($property->hasDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'val2');
+var_dump($property->hasDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'nullable');
+var_dump($property->hasDefaultValue());
+
+$property = new ReflectionProperty(TestClass::class, 'nullable2');
+var_dump($property->hasDefaultValue());
+
+$test = new TestClass;
+$test->dynamic = null;
+$property = new ReflectionProperty($test, 'dynamic');
+var_dump($property->hasDefaultValue());
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)


### PR DESCRIPTION
This circumvents the current "workaround" to find out default values for a property, which is:

```php
$reflectionClass = new ReflectionClass(TestClass::class);
if (array_key_exists($propertyName, $refletionClass->getDefaultProperties())) {
    echo "$propertyName has default value: " . $reflectionClass->getDefaultProperties()[$propertyName];
} else {
    echo "$propertyName does not have default value\n";
}
```

now:

```php
$reflectionClass = new ReflectionClass(TestClass::class);
$reflectionProperty = $reflectionClass->getProperty($propertyName);

if ($reflectionProperty->hasDefaultValue()) {
    echo "$propertyName has default value: " . $reflectionProperty->getDefaultValue();
}
```

This can theoretically also be achieved when you have an instance available by doing `isset($testClass->$propertyName);` but this instance is not always available.

Clarfication about the implementation:

NULL is also considered a default value in this PR, if its implicitly declared as default null via:

```php
private $foo;
```

Only the case where the variable is typed and not nullable would be considered as "not having a 
default value":

```php
private int $foo;
```