### PR TITLE
Promote warnings to Errors in sockets's extension.

### DIFF
--- a/ext/sockets/multicast.c
+++ b/ext/sockets/multicast.c
@@ -87,14 +87,11 @@ static int php_get_if_index_from_zval(zval *val, unsigned *out)
 
 	if (Z_TYPE_P(val) == IS_LONG) {
 		if (Z_LVAL_P(val) < 0 || (zend_ulong)Z_LVAL_P(val) > UINT_MAX) {
-			php_error_docref(NULL, E_WARNING,
-				"The interface index cannot be negative or larger than %u;"
-				" given " ZEND_LONG_FMT, UINT_MAX, Z_LVAL_P(val));
-			ret = FAILURE;
-		} else {
-			*out = Z_LVAL_P(val);
-			ret = SUCCESS;
+			zend_value_error("Index must be between 0 and %u", UINT_MAX);
+			return FAILURE;
 		}
+		*out = Z_LVAL_P(val);
+		ret = SUCCESS;
 	} else {
 		zend_string *tmp_str;
 		zend_string *str = zval_get_tmp_string(val, &tmp_str);
@@ -127,7 +124,7 @@ static int php_get_address_from_array(const HashTable *ht, const char *key,
 	zend_string *str, *tmp_str;
 
 	if ((val = zend_hash_str_find(ht, key, strlen(key))) == NULL) {
-		php_error_docref(NULL, E_WARNING, "No key \"%s\" passed in optval", key);
+		zend_value_error("No key \"%s\" passed in optval", key);
 		return FAILURE;
 	}
 	str = zval_get_tmp_string(val, &tmp_str);
@@ -282,8 +279,7 @@ int php_do_setsockopt_ip_mcast(php_socket *php_sock,
 	case IP_MULTICAST_TTL:
 		convert_to_long_ex(arg4);
 		if (Z_LVAL_P(arg4) < 0L || Z_LVAL_P(arg4) > 255L) {
-			php_error_docref(NULL, E_WARNING,
-					"Expected a value between 0 and 255");
+			zend_argument_value_error(4, "must be between 0 and 255");
 			return FAILURE;
 		}
 		ipv4_mcast_ttl_lback = (unsigned char) Z_LVAL_P(arg4);
@@ -347,8 +343,7 @@ int php_do_setsockopt_ipv6_mcast(php_socket *php_sock,
 	case IPV6_MULTICAST_HOPS:
 		convert_to_long_ex(arg4);
 		if (Z_LVAL_P(arg4) < -1L || Z_LVAL_P(arg4) > 255L) {
-			php_error_docref(NULL, E_WARNING,
-					"Expected a value between -1 and 255");
+			zend_argument_value_error(4, "must be between -1 and 255");
 			return FAILURE;
 		}
 		ov = (int) Z_LVAL_P(arg4);
@@ -496,8 +491,7 @@ static int _php_mcast_join_leave(
 	}
 #endif
 	else {
-		php_error_docref(NULL, E_WARNING,
-			"Option %s is inapplicable to this socket type",
+		zend_value_error("Option %s is inapplicable to this socket type",
 			join ? "MCAST_JOIN_GROUP" : "MCAST_LEAVE_GROUP");
 		return -2;
 	}

--- a/ext/sockets/tests/mcast_ipv4_send_error.phpt
+++ b/ext/sockets/tests/mcast_ipv4_send_error.phpt
@@ -38,8 +38,12 @@ echo "\n";
 
 echo "Setting IP_MULTICAST_TTL with 256\n";
 //if we had a simple cast to unsigned char, this would be the same as 0
-$r = socket_set_option($s, $level, IP_MULTICAST_TTL, 256);
-var_dump($r);
+try {
+    $r = socket_set_option($s, $level, IP_MULTICAST_TTL, 256);
+    var_dump($r);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 $r = socket_get_option($s, $level, IP_MULTICAST_TTL);
 var_dump($r);
 echo "\n";
@@ -53,12 +57,16 @@ echo "\n";
 
 echo "Setting IP_MULTICAST_TTL with -1\n";
 //should give error, not be the same as 255
-$r = socket_set_option($s, $level, IP_MULTICAST_TTL, -1);
-var_dump($r);
+try {
+    $r = socket_set_option($s, $level, IP_MULTICAST_TTL, -1);
+    var_dump($r);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 $r = socket_get_option($s, $level, IP_MULTICAST_TTL);
 var_dump($r);
 echo "\n";
---EXPECTF--
+--EXPECT--
 Setting IP_MULTICAST_LOOP with 256
 bool(true)
 int(1)
@@ -68,9 +76,7 @@ bool(true)
 int(0)
 
 Setting IP_MULTICAST_TTL with 256
-
-Warning: socket_set_option(): Expected a value between 0 and 255 in %s on line %d
-bool(false)
+socket_set_option(): Argument #4 ($optval) must be between 0 and 255
 int(1)
 
 Setting IP_MULTICAST_TTL with "254"
@@ -78,7 +84,5 @@ bool(true)
 int(254)
 
 Setting IP_MULTICAST_TTL with -1
-
-Warning: socket_set_option(): Expected a value between 0 and 255 in %s on line %d
-bool(false)
+socket_set_option(): Argument #4 ($optval) must be between 0 and 255
 int(254)

--- a/ext/sockets/tests/socket_connect_params.phpt
+++ b/ext/sockets/tests/socket_connect_params.phpt
@@ -18,10 +18,14 @@ socket_getsockname($s_c, $addr, $port);
 // wrong parameter count
 try {
     $s_w = socket_connect($s_c);
-} catch (TypeError $e) {
-    echo $e->getMessage(), "\n";
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage() . \PHP_EOL;
 }
-$s_w = socket_connect($s_c, '0.0.0.0');
+try {
+    $s_w = socket_connect($s_c, '0.0.0.0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 $s_w = socket_connect($s_c, '0.0.0.0', $port);
 
 socket_close($s_c);
@@ -29,7 +33,6 @@ socket_close($s_c);
 ?>
 --EXPECTF--
 socket_connect() expects at least 2 parameters, 1 given
-
-Warning: socket_connect(): Socket of type AF_INET requires 3 arguments in %s on line %d
+socket_connect(): Argument #3 ($port) must be specified for the AF_INET socket type
 
 Warning: socket_connect(): unable to connect [%i]: %a in %s on line %d

--- a/ext/sockets/tests/socket_create_pair-wrongparams-win32.phpt
+++ b/ext/sockets/tests/socket_create_pair-wrongparams-win32.phpt
@@ -13,17 +13,21 @@ if (!extension_loaded('sockets')) {
 
 var_dump(socket_create_pair(AF_INET, null, null, $sockets));
 
-var_dump(socket_create_pair(31337, null, null, $sockets));
+try {
+    var_dump(socket_create_pair(31337, null, null, $sockets));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-var_dump(socket_create_pair(AF_INET, 31337, 0, $sockets));
---EXPECTF--
+try {
+    var_dump(socket_create_pair(AF_INET, 31337, 0, $sockets));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+--EXPECT--
 bool(true)
-
-Warning: socket_create_pair(): Invalid socket domain [31337] specified for argument 1, assuming AF_INET in %s on line %d
-bool(true)
-
-Warning: socket_create_pair(): Invalid socket type [31337] specified for argument 2, assuming SOCK_STREAM in %s on line %d
-bool(true)
+socket_create_pair(): Argument #1 ($domain) must be either AF_UNIX, AF_INET6 or AF_INET
+socket_create_pair(): Argument #2 ($type) must be either SOCK_STREAM, SOCK_DGRAM, SOCK_SEQPACKET, SOCK_RAW, or SOCK_RDM
 --CREDITS--
 Till Klampaeckel, till@php.net
 Berlin TestFest 2009

--- a/ext/sockets/tests/socket_create_pair-wrongparams.phpt
+++ b/ext/sockets/tests/socket_create_pair-wrongparams.phpt
@@ -13,24 +13,24 @@ if (!extension_loaded('sockets')) {
 
 var_dump(socket_create_pair(AF_INET, null, null, $sockets));
 
-var_dump(socket_create_pair(31337, null, null, $sockets));
+try {
+    var_dump(socket_create_pair(31337, null, null, $sockets));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-var_dump(socket_create_pair(AF_INET, 31337, 0, $sockets));
+try {
+    var_dump(socket_create_pair(AF_INET, 31337, 0, $sockets));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 ?>
 --EXPECTF--
 Warning: socket_create_pair(): Unable to create socket pair [%d]: %s not supported in %s on line %d
 bool(false)
-
-Warning: socket_create_pair(): Invalid socket domain [31337] specified for argument 1, assuming AF_INET in %s on line %d
-
-Warning: socket_create_pair(): Unable to create socket pair [%d]: %s not supported in %s on line %d
-bool(false)
-
-Warning: socket_create_pair(): Invalid socket type [31337] specified for argument 2, assuming SOCK_STREAM in %s on line %d
-
-Warning: socket_create_pair(): Unable to create socket pair [%d]: %s not supported %s on line %d
-bool(false)
+socket_create_pair(): Argument #1 ($domain) must be either AF_UNIX, AF_INET6 or AF_INET
+socket_create_pair(): Argument #2 ($type) must be either SOCK_STREAM, SOCK_DGRAM, SOCK_SEQPACKET, SOCK_RAW, or SOCK_RDM
 --CREDITS--
 Till Klampaeckel, till@php.net
 Berlin TestFest 2009

--- a/ext/sockets/tests/socket_export_stream-4-win.phpt
+++ b/ext/sockets/tests/socket_export_stream-4-win.phpt
@@ -73,8 +73,6 @@ socket_bind($sock4, '0.0.0.0', 0);
 $stream4 = socket_export_stream($sock4);
 socket_close($sock4);
 test($stream4, $sock4);
-
-echo "Done.\n";
 --EXPECTF--
 normal
 stream_set_blocking 1
@@ -99,7 +97,7 @@ Warning: socket_set_block(): unable to set blocking mode [%d]: An operation was 
  in %s on line %d
 
 socket_get_option 
-Warning: socket_get_option(): unable to retrieve socket option [%d]: An operation was attempted on something that is not a socket.
+Warning: socket_get_option(): Unable to retrieve socket option [%d]: An operation was attempted on something that is not a socket.
  in %s on line %d
 
 
@@ -110,6 +108,3 @@ stream_set_blocking stream_set_blocking(): supplied resource is not a valid stre
 socket_set_block socket_set_block(): supplied resource is not a valid Socket resource
 
 socket_get_option socket_get_option(): supplied resource is not a valid Socket resource
-
-
-Done.

--- a/ext/sockets/tests/socket_export_stream-4.phpt
+++ b/ext/sockets/tests/socket_export_stream-4.phpt
@@ -98,7 +98,7 @@ socket_set_block
 Warning: socket_set_block(): unable to set blocking mode [%d]: %s in %s on line %d
 
 socket_get_option 
-Warning: socket_get_option(): unable to retrieve socket option [%d]: %s in %s on line %d
+Warning: socket_get_option(): Unable to retrieve socket option [%d]: %s in %s on line %d
 
 
 

--- a/ext/sockets/tests/socket_import_stream-4-win.phpt
+++ b/ext/sockets/tests/socket_import_stream-4-win.phpt
@@ -68,8 +68,6 @@ $stream4 = stream_socket_server("udp://0.0.0.0:0", $errno, $errstr, STREAM_SERVE
 $sock4 = socket_import_stream($stream4);
 socket_close($sock4);
 test($stream4, $sock4);
-
-echo "Done.\n";
 --EXPECTF--
 normal
 stream_set_blocking 1
@@ -94,7 +92,7 @@ Warning: socket_set_block(): unable to set blocking mode [10038]: %s
  in %ssocket_import_stream-4-win.php on line %d
 
 socket_get_option 
-Warning: socket_get_option(): unable to retrieve socket option [10038]: %s
+Warning: socket_get_option(): Unable to retrieve socket option [10038]: %s
  in %ssocket_import_stream-4-win.php on line %d
 
 
@@ -105,6 +103,3 @@ stream_set_blocking stream_set_blocking(): supplied resource is not a valid stre
 socket_set_block socket_set_block(): supplied resource is not a valid Socket resource
 
 socket_get_option socket_get_option(): supplied resource is not a valid Socket resource
-
-
-Done.

--- a/ext/sockets/tests/socket_import_stream-4.phpt
+++ b/ext/sockets/tests/socket_import_stream-4.phpt
@@ -93,7 +93,7 @@ socket_set_block
 Warning: socket_set_block(): unable to set blocking mode [%d]: %s in %s on line %d
 
 socket_get_option 
-Warning: socket_get_option(): unable to retrieve socket option [%d]: %s in %s on line %d
+Warning: socket_get_option(): Unable to retrieve socket option [%d]: %s in %s on line %d
 
 
 

--- a/ext/sockets/tests/socket_send_params.phpt
+++ b/ext/sockets/tests/socket_send_params.phpt
@@ -9,8 +9,12 @@ ext/sockets - socket_send - test with incorrect parameters
 --FILE--
 <?php
     $s_c = socket_create_listen(0);
-    $s_w = socket_send($s_c, "foo", -1, MSG_OOB);
+    try {
+        $s_w = socket_send($s_c, "foo", -1, MSG_OOB);
+    } catch (\ValueError $e) {
+        echo $e->getMessage() . \PHP_EOL;
+    }
     socket_close($s_c);
 ?>
---EXPECTF--
-Warning: socket_send(): Length cannot be negative in %s on line %i
+--EXPECT--
+socket_send(): Argument #3 ($len) must be greater than or equal to 0

--- a/ext/sockets/tests/socket_sendto_params.phpt
+++ b/ext/sockets/tests/socket_sendto_params.phpt
@@ -9,8 +9,12 @@ ext/sockets - socket_sendto - test with incorrect parameters
 --FILE--
 <?php
     $s_c = socket_create_listen(0);
-    $s_w = socket_sendto($s_c, "foo", -1, MSG_OOB, '127.0.0.1');
+    try {
+        $s_w = socket_sendto($s_c, "foo", -1, MSG_OOB, '127.0.0.1');
+    } catch (\ValueError $e) {
+        echo $e->getMessage() . \PHP_EOL;
+    }
     socket_close($s_c);
 ?>
---EXPECTF--
-Warning: socket_sendto(): Length cannot be negative in %s on line %i
+--EXPECT--
+socket_sendto(): Argument #3 ($len) must be greater than or equal to 0

--- a/ext/sockets/tests/socket_set_option_error_socket_option.phpt
+++ b/ext/sockets/tests/socket_set_option_error_socket_option.phpt
@@ -28,7 +28,7 @@ socket_set_option( $socket, SOL_SOCKET, 1, 1);
 socket_close($socket);
 ?>
 --EXPECTF--
-Warning: socket_set_option(): unable to set socket option [%d]: Permission denied in %s on line %d
+Warning: socket_set_option(): Unable to set socket option [%d]: Permission denied in %s on line %d
 --CREDITS--
 Moritz Neuhaeuser, info@xcompile.net
 PHP Testfest Berlin 2009-05-10

--- a/ext/sockets/tests/socket_set_option_rcvtimeo.phpt
+++ b/ext/sockets/tests/socket_set_option_rcvtimeo.phpt
@@ -18,7 +18,11 @@ if (!$socket) {
 socket_set_block($socket);
 
 //wrong params
-$retval_1 = socket_set_option( $socket, SOL_SOCKET, SO_RCVTIMEO, array());
+try {
+    $retval_1 = socket_set_option($socket, SOL_SOCKET, SO_RCVTIMEO, []);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 //set/get comparison
 $options = array("sec" => 1, "usec" => 0);
@@ -29,8 +33,8 @@ var_dump($retval_2);
 var_dump($retval_3 === $options);
 socket_close($socket);
 ?>
---EXPECTF--
-Warning: socket_set_option(): No key "sec" passed in optval in %s on line %d
+--EXPECT--
+socket_set_option(): Argument #4 ($optval) must have key "sec"
 bool(true)
 bool(true)
 --CREDITS--

--- a/ext/sockets/tests/socket_set_option_seolinger.phpt
+++ b/ext/sockets/tests/socket_set_option_seolinger.phpt
@@ -18,7 +18,11 @@ if (!$socket) {
         die('Unable to create AF_INET socket [socket]');
 }
 // wrong params
-$retval_1 = socket_set_option( $socket, SOL_SOCKET, SO_LINGER, array());
+try {
+    $retval_1 = socket_set_option( $socket, SOL_SOCKET, SO_LINGER, []);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 // set/get comparison
 $options = array("l_onoff" => 1, "l_linger" => 1);
@@ -27,7 +31,11 @@ $retval_3 = socket_get_option( $socket, SOL_SOCKET, SO_LINGER);
 
 //l_linger not given
 $options_2 = array("l_onoff" => 1);
-var_dump(socket_set_option( $socket, SOL_SOCKET, SO_LINGER, $options_2));
+try {
+    var_dump(socket_set_option( $socket, SOL_SOCKET, SO_LINGER, $options_2));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 var_dump($retval_2);
 var_dump($retval_3["l_linger"] === $options["l_linger"]);
@@ -36,11 +44,9 @@ var_dump((bool)$retval_3["l_onoff"] === (bool)$options["l_onoff"]);
 
 socket_close($socket);
 ?>
---EXPECTF--
-Warning: socket_set_option(): No key "l_onoff" passed in optval in %s on line %d
-
-Warning: socket_set_option(): No key "l_linger" passed in optval in %s on line %d
-bool(false)
+--EXPECT--
+socket_set_option(): Argument #4 ($optval) must have key "l_onoff"
+socket_set_option(): Argument #4 ($optval) must have key "l_linger"
 bool(true)
 bool(true)
 bool(true)

--- a/ext/sockets/tests/socket_set_option_sndtimeo.phpt
+++ b/ext/sockets/tests/socket_set_option_sndtimeo.phpt
@@ -18,7 +18,11 @@ if (!$socket) {
 socket_set_block($socket);
 
 //wrong params
-$retval_1 = socket_set_option( $socket, SOL_SOCKET, SO_SNDTIMEO, array());
+try {
+    $retval_1 = socket_set_option( $socket, SOL_SOCKET, SO_SNDTIMEO, []);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 //set/get comparison
 $options = array("sec" => 1, "usec" => 0);
@@ -29,8 +33,8 @@ var_dump($retval_2);
 var_dump($retval_3 === $options);
 socket_close($socket);
 ?>
---EXPECTF--
-Warning: socket_set_option(): No key "sec" passed in optval in %s on line %d
+--EXPECT--
+socket_set_option(): Argument #4 ($optval) must have key "sec"
 bool(true)
 bool(true)
 --CREDITS--

--- a/ext/sockets/tests/socket_shutdown-win32.phpt
+++ b/ext/sockets/tests/socket_shutdown-win32.phpt
@@ -50,10 +50,10 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: socket_shutdown(): unable to shutdown socket [%d]: A request to send or receive data was disallowed because the socket is not connected and (when sending on a datagram socket using a sendto call) no address was supplied.
+Warning: socket_shutdown(): Unable to shutdown socket [%d]: A request to send or receive data was disallowed because the socket is not connected and (when sending on a datagram socket using a sendto call) no address was supplied.
  in %s on line %d
 bool(false)
 
-Warning: socket_shutdown(): unable to shutdown socket [%d]: An invalid argument was supplied.
+Warning: socket_shutdown(): Unable to shutdown socket [%d]: An invalid argument was supplied.
  in %s on line %d
 bool(false)

--- a/ext/sockets/tests/socket_shutdown.phpt
+++ b/ext/sockets/tests/socket_shutdown.phpt
@@ -51,8 +51,8 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: socket_shutdown(): unable to shutdown socket [%d]: Transport endpoint is not connected in %s on line %d
+Warning: socket_shutdown(): Unable to shutdown socket [%d]: Transport endpoint is not connected in %s on line %d
 bool(false)
 
-Warning: socket_shutdown(): unable to shutdown socket [%d]: Invalid argument in %s on line %d
+Warning: socket_shutdown(): Unable to shutdown socket [%d]: Invalid argument in %s on line %d
 bool(false)


### PR DESCRIPTION
There are a bunch of expected array warnings, a better way is too probably ask for a HashTable param instead of a zval.