### PR TITLE
Bring back test case support for older MySQL versions

### DIFF
--- a/ext/mysqli/tests/mysqli_expire_password.phpt
+++ b/ext/mysqli/tests/mysqli_expire_password.phpt
@@ -61,7 +61,6 @@ if (!mysqli_query($link, sprintf("GRANT SELECT ON TABLE %s.test TO expiretest@'%
 		$link->query("SELECT id FROM test WHERE id = 1");
 		printf("[002] Connect should fail, [%d] %s\n", $link->errno, $link->error);
 	}
-
 	/* explicitly requesting default */
 	$link = mysqli_init();
 	$link->options(MYSQLI_OPT_CAN_HANDLE_EXPIRED_PASSWORDS, 0);
@@ -92,7 +91,9 @@ if (!mysqli_query($link, sprintf("GRANT SELECT ON TABLE %s.test TO expiretest@'%
 		printf("[007] Cannot connect [%d] %s\n",
 			mysqli_connect_errno(), mysqli_connect_error());
 	} else {
-		$link->query("SET PASSWORD='expiretest'");
+		if (!$link->query("SET PASSWORD='expiretest'")) {
+			$link->query("SET PASSWORD=PASSWORD('expiretest')");
+		}
 		printf("[008] Connect allowed, pw set, [%d] %s\n", $link->errno, $link->error);
 		if ($res = $link->query("SELECT id FROM test WHERE id = 1"))
 			var_dump($res->fetch_assoc());

--- a/ext/mysqli/tests/mysqli_pconn_max_links.phpt
+++ b/ext/mysqli/tests/mysqli_pconn_max_links.phpt
@@ -92,12 +92,14 @@ mysqli.rollback_on_cached_plink=1
 	var_dump($row);
 
 	// change the password for the second DB user and kill the persistent connection
-	if (!mysqli_query($link, 'SET PASSWORD FOR pcontest = "newpass"') ||
+	if ((!mysqli_query($link, 'SET PASSWORD FOR pcontest = "newpass"') &&
+			!mysqli_query($link, 'SET PASSWORD FOR pcontest = PASSWORD("newpass")'))||
 			!mysqli_query($link, 'FLUSH PRIVILEGES'))
 		printf("[005] Cannot change PW of second DB user, [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
         // change the password for the second DB user and kill the persistent connection
-	if (!mysqli_query($link, 'SET PASSWORD FOR pcontest@localhost = "newpass"') ||
+	if ((!mysqli_query($link, 'SET PASSWORD FOR pcontest@localhost = "newpass"') &&
+		!mysqli_query($link, 'SET PASSWORD FOR pcontest@localhost = PASSWORD("newpass")')) ||
 			!mysqli_query($link, 'FLUSH PRIVILEGES'))
 		printf("[006] Cannot change PW of second DB user, [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 


### PR DESCRIPTION
These test cases have recently been adjusted to work with MySQL 8[1],
but some older, but still supported database versions, such as MySQL
5.6, still need the password to be sent hashed, so we fall back to
using `PASSWORD()`, if the `SET PASSWORD` query fails without it.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=b0efd18f7844da29931737b8a1cf461c7493e168>.