### PR TITLE
Fix #79096: FFI Struct Segfault

### DIFF
--- a/ext/ffi/tests/bug79096.phpt
+++ b/ext/ffi/tests/bug79096.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Bug #79096 (FFI Struct Segfault)
+--SKIPIF--
+<?php
+if (!extension_loaded('ffi')) die('skip ffi extension not available');
+if (!extension_loaded('zend-test')) die('skip zend-test extension not available');
+?>
+--FILE--
+<?php
+$header = <<<HEADER
+struct bug79096 {
+	uint64_t a;
+	uint64_t b;
+};
+
+struct bug79096 bug79096(void);
+HEADER;
+
+if (PHP_OS_FAMILY !== 'Windows') {
+    $ffi = FFI::cdef($header);
+} else {
+    try {
+        $ffi = FFI::cdef($header, 'php_zend_test.dll');
+    } catch (FFI\Exception $ex) {
+        $dll = $dll = 'php7' . (PHP_ZTS ? 'ts' : '') . (PHP_DEBUG ? '_debug' : '') . '.dll';
+        $ffi = FFI::cdef($header, $dll);
+    }
+}
+
+$struct = $ffi->bug79096();
+var_dump($struct);
+?>
+--EXPECTF--
+object(FFI\CData:struct bug79096)#%d (2) {
+  ["a"]=>
+  int(1)
+  ["b"]=>
+  int(1)
+}

--- a/ext/zend_test/php_test.h
+++ b/ext/zend_test/php_test.h
@@ -32,4 +32,11 @@ extern zend_module_entry zend_test_module_entry;
 ZEND_TSRMLS_CACHE_EXTERN()
 #endif
 
+struct bug79096 {
+	uint64_t a;
+	uint64_t b;
+};
+
+ZEND_API struct bug79096 bug79096(void);
+
 #endif

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -319,3 +319,12 @@ ZEND_TSRMLS_CACHE_DEFINE()
 #endif
 ZEND_GET_MODULE(zend_test)
 #endif
+
+struct bug79096 bug79096(void)
+{
+  struct bug79096 b;
+
+  b.a = 1;
+  b.b = 1;
+  return b;
+}


### PR DESCRIPTION
We must not assume that the size of a function's return value is at
most `sizeof(ffi_arg)`, but rather have to use the size which already
has been determined for the return type if it is larger than
`sizeof(ffi_arg)`.

---

I'm having trouble to come up with a portable regression test using some widely available API; maybe it's worthwhile to integrate building of supportive libs for tests into `configure`/`make`? Or maybe it's not really relevant to support oversized return types (and maybe not even fully supported by libffi?), and to disallow them altogether?