### PR TITLE
Fix #79084: mysqlnd may fetch wrong column indexes with MYSQLI_BOTH

### DIFF
--- a/ext/mysqli/tests/bug79084.phpt
+++ b/ext/mysqli/tests/bug79084.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Bug #79084 (mysqlnd may fetch wrong column indexes with MYSQLI_BOTH)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnectfailure.inc');
+?>
+--FILE--
+<?php
+require_once('connect.inc');
+$sql = "SELECT 0 as `2007`, 0 as `2008`, 0 as `2020`";
+
+// unbuffered
+$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
+$link->real_query($sql);
+$res = $link->use_result();
+$row = $res->fetch_array();
+var_dump($row);
+$link->close();
+
+// buffered
+ini_set('mysqlnd.fetch_data_copy', false);
+$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
+$res = $link->query($sql);
+$row = $res->fetch_array();
+var_dump($row);
+$link->close();
+
+// buffered copies
+ini_set('mysqlnd.fetch_data_copy', true);
+$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
+$res = $link->query($sql);
+$row = $res->fetch_array();
+var_dump($row);
+$link->close();
+?>
+--EXPECT--
+array(6) {
+  [0]=>
+  string(1) "0"
+  [2007]=>
+  string(1) "0"
+  [1]=>
+  string(1) "0"
+  [2008]=>
+  string(1) "0"
+  [2]=>
+  string(1) "0"
+  [2020]=>
+  string(1) "0"
+}
+array(6) {
+  [0]=>
+  string(1) "0"
+  [2007]=>
+  string(1) "0"
+  [1]=>
+  string(1) "0"
+  [2008]=>
+  string(1) "0"
+  [2]=>
+  string(1) "0"
+  [2020]=>
+  string(1) "0"
+}
+array(6) {
+  [0]=>
+  string(1) "0"
+  [2007]=>
+  string(1) "0"
+  [1]=>
+  string(1) "0"
+  [2008]=>
+  string(1) "0"
+  [2]=>
+  string(1) "0"
+  [2020]=>
+  string(1) "0"
+}

--- a/ext/mysqli/tests/bug79084_collision.phpt
+++ b/ext/mysqli/tests/bug79084_collision.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Bug #79084 (mysqlnd may fetch wrong column indexes with MYSQLI_BOTH) - collision
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnectfailure.inc');
+?>
+--FILE--
+<?php
+require_once('connect.inc');
+$sql = "SELECT 11111 as `1`, 22222 as `2`";
+
+// unbuffered
+$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
+$link->real_query($sql);
+$res = $link->use_result();
+$row = $res->fetch_array();
+var_dump($row);
+$link->close();
+
+// buffered
+ini_set('mysqlnd.fetch_data_copy', false);
+$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
+$res = $link->query($sql);
+$row = $res->fetch_array();
+var_dump($row);
+$link->close();
+
+// buffered copies
+ini_set('mysqlnd.fetch_data_copy', true);
+$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
+$res = $link->query($sql);
+$row = $res->fetch_array();
+var_dump($row);
+$link->close();
+?>
+--EXPECT--
+array(3) {
+  [0]=>
+  string(5) "11111"
+  [1]=>
+  string(5) "11111"
+  [2]=>
+  string(5) "22222"
+}
+array(3) {
+  [0]=>
+  string(5) "11111"
+  [1]=>
+  string(5) "11111"
+  [2]=>
+  string(5) "22222"
+}
+array(3) {
+  [0]=>
+  string(5) "11111"
+  [1]=>
+  string(5) "11111"
+  [2]=>
+  string(5) "22222"
+}

--- a/ext/mysqlnd/mysqlnd_result.c
+++ b/ext/mysqlnd/mysqlnd_result.c
@@ -843,7 +843,7 @@ MYSQLND_METHOD(mysqlnd_result_unbuffered, fetch_row)(MYSQLND_RES * result, void 
 
 					if (flags & MYSQLND_FETCH_NUM) {
 						Z_TRY_ADDREF_P(data);
-						zend_hash_next_index_insert(row_ht, data);
+						zend_hash_index_add(row_ht, i, data);
 					}
 					if (flags & MYSQLND_FETCH_ASSOC) {
 						/* zend_hash_quick_update needs length + trailing zero */
@@ -1100,7 +1100,7 @@ MYSQLND_METHOD(mysqlnd_result_buffered_zval, fetch_row)(MYSQLND_RES * result, vo
 
 			if (flags & MYSQLND_FETCH_NUM) {
 				Z_TRY_ADDREF_P(data);
-				zend_hash_next_index_insert(Z_ARRVAL_P(row), data);
+				zend_hash_index_add(Z_ARRVAL_P(row), i, data);
 			}
 			if (flags & MYSQLND_FETCH_ASSOC) {
 				/* zend_hash_quick_update needs length + trailing zero */
@@ -1196,7 +1196,7 @@ MYSQLND_METHOD(mysqlnd_result_buffered_c, fetch_row)(MYSQLND_RES * result, void 
 
 			if (flags & MYSQLND_FETCH_NUM) {
 				Z_TRY_ADDREF_P(data);
-				zend_hash_next_index_insert(Z_ARRVAL_P(row), data);
+				zend_hash_index_add(Z_ARRVAL_P(row), i, data);
 			}
 			if (flags & MYSQLND_FETCH_ASSOC) {
 				/* zend_hash_quick_update needs length + trailing zero */

--- a/ext/mysqlnd/mysqlnd_result.c
+++ b/ext/mysqlnd/mysqlnd_result.c
@@ -842,8 +842,9 @@ MYSQLND_METHOD(mysqlnd_result_unbuffered, fetch_row)(MYSQLND_RES * result, void 
 					const size_t len = (Z_TYPE_P(data) == IS_STRING)? Z_STRLEN_P(data) : 0;
 
 					if (flags & MYSQLND_FETCH_NUM) {
-						Z_TRY_ADDREF_P(data);
-						zend_hash_index_add(row_ht, i, data);
+						if (zend_hash_index_add(row_ht, i, data) != NULL) {
+							Z_TRY_ADDREF_P(data);
+						}
 					}
 					if (flags & MYSQLND_FETCH_ASSOC) {
 						/* zend_hash_quick_update needs length + trailing zero */
@@ -1099,8 +1100,9 @@ MYSQLND_METHOD(mysqlnd_result_buffered_zval, fetch_row)(MYSQLND_RES * result, vo
 			set->lengths[i] = (Z_TYPE_P(data) == IS_STRING)? Z_STRLEN_P(data) : 0;
 
 			if (flags & MYSQLND_FETCH_NUM) {
-				Z_TRY_ADDREF_P(data);
-				zend_hash_index_add(Z_ARRVAL_P(row), i, data);
+				if (zend_hash_index_add(Z_ARRVAL_P(row), i, data) != NULL) {
+					Z_TRY_ADDREF_P(data);
+				}
 			}
 			if (flags & MYSQLND_FETCH_ASSOC) {
 				/* zend_hash_quick_update needs length + trailing zero */
@@ -1195,8 +1197,9 @@ MYSQLND_METHOD(mysqlnd_result_buffered_c, fetch_row)(MYSQLND_RES * result, void 
 			set->lengths[i] = (Z_TYPE_P(data) == IS_STRING)? Z_STRLEN_P(data) : 0;
 
 			if (flags & MYSQLND_FETCH_NUM) {
-				Z_TRY_ADDREF_P(data);
-				zend_hash_index_add(Z_ARRVAL_P(row), i, data);
+				if (zend_hash_index_add(Z_ARRVAL_P(row), i, data)) {
+					Z_TRY_ADDREF_P(data);
+				}
 			}
 			if (flags & MYSQLND_FETCH_ASSOC) {
 				/* zend_hash_quick_update needs length + trailing zero */


### PR DESCRIPTION
Column names can be numeric strings, so we have to make sure to insert
the column values with the appropriate numeric keys, instead of adding
them.