### PR TITLE
Fix #79106: PDO may fetch wrong column indexes with PDO::FETCH_BOTH

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1031,7 +1031,7 @@ static int do_fetch(pdo_stmt_t *stmt, int do_bind, zval *return_value, enum pdo_
 					if (Z_REFCOUNTED(val)) {
 						Z_ADDREF(val);
 					}
-					zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &val);
+					zend_hash_index_add(Z_ARRVAL_P(return_value), i, &val);
 					break;
 
 				case PDO_FETCH_NAMED:

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1028,10 +1028,9 @@ static int do_fetch(pdo_stmt_t *stmt, int do_bind, zval *return_value, enum pdo_
 				case PDO_FETCH_USE_DEFAULT:
 				case PDO_FETCH_BOTH:
 					zend_symtable_update(Z_ARRVAL_P(return_value), stmt->columns[i].name, &val);
-					if (Z_REFCOUNTED(val)) {
-						Z_ADDREF(val);
+					if (zend_hash_index_add(Z_ARRVAL_P(return_value), i, &val) != NULL) {
+						Z_TRY_ADDREF(val);
 					}
-					zend_hash_index_add(Z_ARRVAL_P(return_value), i, &val);
 					break;
 
 				case PDO_FETCH_NAMED:

--- a/ext/pdo/tests/bug_79106.phpt
+++ b/ext/pdo/tests/bug_79106.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Bug #79106 (PDO may fetch wrong column indexes with PDO::FETCH_BOTH)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip pdo extension not available');
+$dir = getenv('REDIR_TEST_DIR');
+if (!$dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR=' . dirname(__FILE__) . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+$db = PDOTest::factory();
+
+$stmt = $db->query("SELECT 0 as `2007`, 0 as `2008`, 0 as `2020`");
+var_dump($stmt->fetchAll());
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(6) {
+    [2007]=>
+    string(1) "0"
+    [0]=>
+    string(1) "0"
+    [2008]=>
+    string(1) "0"
+    [1]=>
+    string(1) "0"
+    [2020]=>
+    string(1) "0"
+    [2]=>
+    string(1) "0"
+  }
+}

--- a/ext/pdo/tests/bug_79106.phpt
+++ b/ext/pdo/tests/bug_79106.phpt
@@ -6,7 +6,14 @@ if (!extension_loaded('pdo')) die('skip pdo extension not available');
 $dir = getenv('REDIR_TEST_DIR');
 if (!$dir) die('skip no driver');
 require_once $dir . 'pdo_test.inc';
-PDOTest::skip();
+try {
+    $db = PDOTest::factory();
+} catch (PDOException $e) {
+    die('skip ' . $e->getMessage());
+}
+if ($db->query('SELECT 1 as "1"') === false) {
+    die('skip driver does not support quoted numeric identifiers');
+}
 ?>
 --FILE--
 <?php
@@ -14,7 +21,7 @@ if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR=' . dirname(__FIL
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
 
-$stmt = $db->query("SELECT 0 as `2007`, 0 as `2008`, 0 as `2020`");
+$stmt = $db->query('SELECT 0 as "2007", 0 as "2008", 0 as "2020"');
 var_dump($stmt->fetchAll());
 ?>
 --EXPECT--

--- a/ext/pdo/tests/bug_79106_collision.phpt
+++ b/ext/pdo/tests/bug_79106_collision.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Bug #79106 (PDO may fetch wrong column indexes with PDO::FETCH_BOTH) - collision
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip pdo extension not available');
+$dir = getenv('REDIR_TEST_DIR');
+if (!$dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+try {
+    $db = PDOTest::factory();
+} catch (PDOException $e) {
+    die('skip ' . $e->getMessage());
+}
+if ($db->query('SELECT 1 as "1"') === false) {
+    die('skip driver does not support quoted numeric identifiers');
+}
+?>
+--FILE--
+<?php
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR=' . dirname(__FILE__) . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+$db = PDOTest::factory();
+
+$stmt = $db->query('SELECT 11111 as "1", 22222 as "2"');
+var_dump($stmt->fetchAll());
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(3) {
+    [1]=>
+    string(5) "11111"
+    [0]=>
+    string(5) "11111"
+    [2]=>
+    string(5) "22222"
+  }
+}

--- a/ext/pdo_mysql/tests/bug_61411.phpt
+++ b/ext/pdo_mysql/tests/bug_61411.phpt
@@ -47,7 +47,7 @@ print "done!";
 array(2) {
   [1]=>
   int(1)
-  [2]=>
+  [0]=>
   int(1)
 }
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_fetch_both.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_fetch_both.phpt
@@ -59,30 +59,4 @@ $db = MySQLPDOTest::factory();
 	print "done!";
 ?>
 --EXPECT--
-[002] Suspicious FETCH_BOTH result, dumping
-array(2) {
-  [0]=>
-  string(1) "1"
-  [1]=>
-  string(1) "1"
-}
-array(2) {
-  [1]=>
-  string(1) "1"
-  [2]=>
-  string(1) "1"
-}
-[002] Expected differes from returned data, dumping
-array(2) {
-  [0]=>
-  string(1) "1"
-  [1]=>
-  string(1) "1"
-}
-array(2) {
-  [1]=>
-  string(1) "1"
-  [2]=>
-  string(1) "1"
-}
 done!


### PR DESCRIPTION
Column names can be numeric strings, so we have to make sure to insert
the column values with the appropriate numeric keys, instead of adding
them.