### PR TITLE
Update php.ini-development to add missing FTP extension

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -899,6 +899,7 @@ default_socket_timeout = 60
 ;extension=bz2
 ;extension=curl
 ;extension=ffi
+;extension=ftp
 ;extension=fileinfo
 ;extension=gd2
 ;extension=gettext

--- a/php.ini-production
+++ b/php.ini-production
@@ -901,6 +901,7 @@ default_socket_timeout = 60
 ;extension=bz2
 ;extension=curl
 ;extension=ffi
+;extension=ftp
 ;extension=fileinfo
 ;extension=gd2
 ;extension=gettext


### PR DESCRIPTION
Surprisingly, FTP isn't listed as disabled extension in the `php.ini-development` and `php.ini-production` files.

This should spare a few googles and checks to the `ext` path for anyone looking to use FTP with PHP.