### PR TITLE
Remove custom (v)snprintf as it's always available since C99

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -798,7 +798,8 @@ static zend_string *date_format(char *format, size_t format_len, timelib_time *t
 			offset->abbr = timelib_malloc(9); /* GMT±xxxx\0 */
 			snprintf(offset->abbr, 9, "GMT%c%02d%02d",
 			                          (offset->offset < 0) ? '-' : '+',
-			                          abs(offset->offset / 3600),
+			                          /* Module 100 000 as 24 * 3600 = 86400 */
+			                          abs((offset->offset % 100000) / 3600),
 			                          abs((offset->offset % 3600) / 60));
 		} else {
 			offset = timelib_get_time_zone_info(t->sse, t->tz_info);
@@ -1010,7 +1011,8 @@ PHPAPI int php_idate(char format, time_t ts, int localtime)
 			offset->abbr = timelib_malloc(9); /* GMT±xxxx\0 */
 			snprintf(offset->abbr, 9, "GMT%c%02d%02d",
 			                          (offset->offset < 0) ? '-' : '+',
-			                          abs(offset->offset / 3600),
+			                          /* Module 100 000 as 24 * 3600 = 86400 */
+			                          abs((offset->offset % 100000) / 3600),
 			                          abs((offset->offset % 3600) / 60));
 		} else {
 			offset = timelib_get_time_zone_info(t->sse, t->tz_info);

--- a/ext/mysqlnd/mysqlnd_debug.c
+++ b/ext/mysqlnd/mysqlnd_debug.c
@@ -53,7 +53,7 @@ MYSQLND_METHOD(mysqlnd_debug, log)(MYSQLND_DEBUG * self,
 	unsigned int message_line_len;
 	unsigned int flags = self->flags;
 	char pid_buffer[10], time_buffer[30], file_buffer[200],
-		 line_buffer[6], level_buffer[7];
+		 line_buffer[13], level_buffer[13];
 
 	if (!self->stream && FAIL == self->m->open(self, FALSE)) {
 		return FAIL;
@@ -150,7 +150,7 @@ MYSQLND_METHOD(mysqlnd_debug, log_va)(MYSQLND_DEBUG *self,
 	va_list args;
 	unsigned int flags = self->flags;
 	char pid_buffer[10], time_buffer[30], file_buffer[200],
-		 line_buffer[6], level_buffer[7];
+		 line_buffer[13], level_buffer[13];
 
 	if (!self->stream && FAIL == self->m->open(self, FALSE)) {
 		return FAIL;

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -2837,7 +2837,7 @@ static xmlNodePtr to_xml_datetime_ex(encodeTypePtr type, zval *data, char *forma
 	int max_reallocs = 5;
 	size_t buf_len=64, real_len;
 	char *buf;
-	char tzbuf[8];
+	char tzbuf[21];
 
 	xmlNodePtr xmlParam;
 

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -1719,7 +1719,7 @@ PHP_FUNCTION(socket_sendto)
 		case AF_UNIX:
 			memset(&s_un, 0, sizeof(s_un));
 			s_un.sun_family = AF_UNIX;
-			snprintf(s_un.sun_path, 108, "%s", addr);
+			snprintf(s_un.sun_path, sizeof(s_un.sun_path), "%s", addr);
 
 			retval = sendto(php_sock->bsd_socket, buf, ((size_t)len > buf_len) ? buf_len : (size_t)len,	flags, (struct sockaddr *) &s_un, SUN_LEN(&s_un));
 			break;

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -640,7 +640,7 @@ void php_get_windows_cpu(char *buf, int bufsize)
 PHPAPI zend_string *php_get_uname(char mode)
 {
 	char *php_uname;
-	char tmp_uname[256];
+	char tmp_uname[325];
 #ifdef PHP_WIN32
 	DWORD dwBuild=0;
 	DWORD dwVersion = GetVersion();

--- a/ext/xmlrpc/libxmlrpc/xml_to_xmlrpc.c
+++ b/ext/xmlrpc/libxmlrpc/xml_to_xmlrpc.c
@@ -224,7 +224,7 @@ xml_element* XMLRPC_to_xml_element_worker(XMLRPC_VALUE current_vector, XMLRPC_VA
          case xmlrpc_double:
             {
                                 elem_val->name = estrdup(ELEM_DOUBLE);
-                ap_php_snprintf(buf, BUF_SIZE, "%.*G", (int) EG(precision), XMLRPC_GetValueDouble(node));
+                snprintf(buf, BUF_SIZE, "%.*G", (int) EG(precision), XMLRPC_GetValueDouble(node));
                 simplestring_add(&elem_val->text, buf);
             }
             break;

--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -1273,29 +1273,20 @@ PHPAPI int ap_php_vslprintf(char *buf, size_t len, const char *format, va_list a
 }
 /* }}} */
 
-PHPAPI int ap_php_vsnprintf(char *buf, size_t len, const char *format, va_list ap) /* {{{ */
-{
-	int cc;
-
-	strx_printv(&cc, buf, len, format, ap);
-	return (cc);
-}
-/* }}} */
-
 PHPAPI int ap_php_vasprintf(char **buf, const char *format, va_list ap) /* {{{ */
 {
 	va_list ap2;
 	int cc;
 
 	va_copy(ap2, ap);
-	cc = ap_php_vsnprintf(NULL, 0, format, ap2);
+	cc = vsnprintf(NULL, 0, format, ap2);
 	va_end(ap2);
 
 	*buf = NULL;
 
 	if (cc >= 0) {
 		if ((*buf = malloc(++cc)) != NULL) {
-			if ((cc = ap_php_vsnprintf(*buf, cc, format, ap)) < 0) {
+			if ((cc = vsnprintf(*buf, cc, format, ap)) < 0) {
 				free(*buf);
 				*buf = NULL;
 			}

--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -1273,18 +1273,6 @@ PHPAPI int ap_php_vslprintf(char *buf, size_t len, const char *format, va_list a
 }
 /* }}} */
 
-PHPAPI int ap_php_snprintf(char *buf, size_t len, const char *format,...) /* {{{ */
-{
-	int cc;
-	va_list ap;
-
-	va_start(ap, format);
-	strx_printv(&cc, buf, len, format, ap);
-	va_end(ap);
-	return (cc);
-}
-/* }}} */
-
 PHPAPI int ap_php_vsnprintf(char *buf, size_t len, const char *format, va_list ap) /* {{{ */
 {
 	int cc;

--- a/main/snprintf.h
+++ b/main/snprintf.h
@@ -76,7 +76,6 @@ typedef enum {
 BEGIN_EXTERN_C()
 PHPAPI int ap_php_slprintf(char *buf, size_t len, const char *format,...) ZEND_ATTRIBUTE_FORMAT(printf, 3, 4);
 PHPAPI int ap_php_vslprintf(char *buf, size_t len, const char *format, va_list ap);
-PHPAPI int ap_php_snprintf(char *, size_t, const char *, ...) ZEND_ATTRIBUTE_FORMAT(printf, 3, 4);
 PHPAPI int ap_php_vsnprintf(char *, size_t, const char *, va_list ap);
 PHPAPI int ap_php_vasprintf(char **buf, const char *format, va_list ap);
 PHPAPI int ap_php_asprintf(char **buf, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
@@ -96,11 +95,6 @@ END_EXTERN_C()
 #undef vslprintf
 #endif
 #define vslprintf ap_php_vslprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf ap_php_snprintf
 
 #ifdef vsnprintf
 #undef vsnprintf

--- a/main/snprintf.h
+++ b/main/snprintf.h
@@ -76,7 +76,6 @@ typedef enum {
 BEGIN_EXTERN_C()
 PHPAPI int ap_php_slprintf(char *buf, size_t len, const char *format,...) ZEND_ATTRIBUTE_FORMAT(printf, 3, 4);
 PHPAPI int ap_php_vslprintf(char *buf, size_t len, const char *format, va_list ap);
-PHPAPI int ap_php_vsnprintf(char *, size_t, const char *, va_list ap);
 PHPAPI int ap_php_vasprintf(char **buf, const char *format, va_list ap);
 PHPAPI int ap_php_asprintf(char **buf, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
 PHPAPI char * php_gcvt(double value, int ndigit, char dec_point, char exponent, char *buf);
@@ -95,11 +94,6 @@ END_EXTERN_C()
 #undef vslprintf
 #endif
 #define vslprintf ap_php_vslprintf
-
-#ifdef vsnprintf
-#undef vsnprintf
-#endif
-#define vsnprintf ap_php_vsnprintf
 
 #ifndef HAVE_VASPRINTF
 #define vasprintf ap_php_vasprintf


### PR DESCRIPTION
I suppose we maybe could also get rid of our custom format conversion implementation ``format_converter()`` in ``snprintf.c`` (which would give us support for ``a`` and ``A`` modifier) by relying on the system one.