### PR TITLE
Make MSVCRT memory leak checking usable for the test suite

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -648,4 +648,12 @@ static zend_always_inline double _zend_get_nan(void) /* {{{ */
 # define ZEND_PREFER_RELOAD
 #endif
 
+#if defined(ZEND_WIN32) && defined(_DEBUG) && defined(PHP_WIN32_DEBUG_HEAP)
+# define ZEND_IGNORE_LEAKS_BEGIN() _CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) & ~_CRTDBG_ALLOC_MEM_DF)
+# define ZEND_IGNORE_LEAKS_END() _CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) | _CRTDBG_ALLOC_MEM_DF)
+#else
+# define ZEND_IGNORE_LEAKS_BEGIN()
+# define ZEND_IGNORE_LEAKS_END()
+#endif
+
 #endif /* ZEND_PORTABILITY_H */

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -61345,9 +61345,11 @@ static void init_opcode_serialiser(void)
 	int i;
 	zval tmp;
 
+	ZEND_IGNORE_LEAKS_BEGIN();
 	zend_handlers_table = malloc(sizeof(HashTable));
 	zend_hash_init_ex(zend_handlers_table, zend_handlers_count, NULL, NULL, 1, 0);
 	zend_hash_real_init(zend_handlers_table, 0);
+	ZEND_IGNORE_LEAKS_END();
 	Z_TYPE_INFO(tmp) = IS_LONG;
 	for (i = 0; i < zend_handlers_count; i++) {
 		Z_LVAL(tmp) = i;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -61333,23 +61333,25 @@ void zend_vm_init(void)
 	VM_TRACE_START();
 }
 
+static HashTable *zend_handlers_table = NULL;
+
 void zend_vm_dtor(void)
 {
 	VM_TRACE_END();
+	if (zend_handlers_table) {
+		zend_hash_destroy(zend_handlers_table);
+		free(zend_handlers_table);
+	}
 }
-
-static HashTable *zend_handlers_table = NULL;
 
 static void init_opcode_serialiser(void)
 {
 	int i;
 	zval tmp;
 
-	ZEND_IGNORE_LEAKS_BEGIN();
 	zend_handlers_table = malloc(sizeof(HashTable));
 	zend_hash_init_ex(zend_handlers_table, zend_handlers_count, NULL, NULL, 1, 0);
 	zend_hash_real_init(zend_handlers_table, 0);
-	ZEND_IGNORE_LEAKS_END();
 	Z_TYPE_INFO(tmp) = IS_LONG;
 	for (i = 0; i < zend_handlers_count; i++) {
 		Z_LVAL(tmp) = i;

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -67,23 +67,25 @@ void {%INITIALIZER_NAME%}(void)
 	VM_TRACE_START();
 }
 
+static HashTable *zend_handlers_table = NULL;
+
 void zend_vm_dtor(void)
 {
 	VM_TRACE_END();
+	if (zend_handlers_table) {
+		zend_hash_destroy(zend_handlers_table);
+		free(zend_handlers_table);
+	}
 }
-
-static HashTable *zend_handlers_table = NULL;
 
 static void init_opcode_serialiser(void)
 {
 	int i;
 	zval tmp;
 
-	ZEND_IGNORE_LEAKS_BEGIN();
 	zend_handlers_table = malloc(sizeof(HashTable));
 	zend_hash_init_ex(zend_handlers_table, zend_handlers_count, NULL, NULL, 1, 0);
 	zend_hash_real_init(zend_handlers_table, 0);
-	ZEND_IGNORE_LEAKS_END();
 	Z_TYPE_INFO(tmp) = IS_LONG;
 	for (i = 0; i < zend_handlers_count; i++) {
 		Z_LVAL(tmp) = i;

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -79,9 +79,11 @@ static void init_opcode_serialiser(void)
 	int i;
 	zval tmp;
 
+	ZEND_IGNORE_LEAKS_BEGIN();
 	zend_handlers_table = malloc(sizeof(HashTable));
 	zend_hash_init_ex(zend_handlers_table, zend_handlers_count, NULL, NULL, 1, 0);
 	zend_hash_real_init(zend_handlers_table, 0);
+	ZEND_IGNORE_LEAKS_END();
 	Z_TYPE_INFO(tmp) = IS_LONG;
 	for (i = 0; i < zend_handlers_count; i++) {
 		Z_LVAL(tmp) = i;

--- a/ext/libxml/config.w32
+++ b/ext/libxml/config.w32
@@ -16,6 +16,9 @@ if (PHP_LIBXML == "yes") {
 			ADD_DEF_FILE("ext\\libxml\\php_libxml2.def");
 		}
 		PHP_INSTALL_HEADERS("ext/libxml/", "php_libxml.h");
+		if (PHP_CRT_DEBUG == "yes") {
+			ADD_FLAG("CFLAGS_LIBXML", "/D PHP_WIN32_DEBUG_HEAP");
+		}
 	} else {
 		WARNING("libxml support can't be enabled, iconv or libxml are missing")
 		PHP_LIBXML = "no"

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -752,7 +752,9 @@ PHP_LIBXML_API void php_libxml_initialize(void)
 {
 	if (!_php_libxml_initialized) {
 		/* we should be the only one's to ever init!! */
+		ZEND_IGNORE_LEAKS_BEGIN();
 		xmlInitParser();
+		ZEND_IGNORE_LEAKS_END();
 
 		_php_libxml_default_entity_loader = xmlGetExternalEntityLoader();
 		xmlSetExternalEntityLoader(_php_libxml_pre_ext_ent_loader);

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1160,9 +1160,6 @@ int main(int argc, char *argv[])
 	wchar_t **argv_wide;
 	char **argv_save = argv;
 	BOOL using_wide_argv = 0;
-# if defined(_DEBUG) && defined(PHP_WIN32_DEBUG_HEAP)
-	int unclean_shutdown;
-# endif
 #endif
 
 	int c;
@@ -1200,6 +1197,7 @@ int main(int argc, char *argv[])
 		_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 		tmp_flag = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
 		tmp_flag |= _CRTDBG_DELAY_FREE_MEM_DF;
+		tmp_flag |= _CRTDBG_LEAK_CHECK_DF;
 
 		_CrtSetDbgFlag(tmp_flag);
 	}
@@ -1371,9 +1369,6 @@ out:
 	if (sapi_started) {
 		sapi_shutdown();
 	}
-#if defined(PHP_WIN32) && defined(_DEBUG) && defined(PHP_WIN32_DEBUG_HEAP)
-	unclean_shutdown = CG(unclean_shutdown);
-#endif
 #ifdef ZTS
 	tsrm_shutdown();
 #endif
@@ -1392,11 +1387,6 @@ out:
 	 * exiting.
 	 */
 	cleanup_ps_args(argv);
-#if defined(PHP_WIN32) && defined(_DEBUG) && defined(PHP_WIN32_DEBUG_HEAP)
-	if (!unclean_shutdown) {
-		_CrtDumpMemoryLeaks();
-	}
-#endif
 	exit(exit_status);
 }
 /* }}} */

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1160,6 +1160,9 @@ int main(int argc, char *argv[])
 	wchar_t **argv_wide;
 	char **argv_save = argv;
 	BOOL using_wide_argv = 0;
+# if defined(_DEBUG) && defined(PHP_WIN32_DEBUG_HEAP)
+	int unclean_shutdown;
+# endif
 #endif
 
 	int c;
@@ -1197,7 +1200,6 @@ int main(int argc, char *argv[])
 		_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 		tmp_flag = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
 		tmp_flag |= _CRTDBG_DELAY_FREE_MEM_DF;
-		tmp_flag |= _CRTDBG_LEAK_CHECK_DF;
 
 		_CrtSetDbgFlag(tmp_flag);
 	}
@@ -1369,6 +1371,9 @@ out:
 	if (sapi_started) {
 		sapi_shutdown();
 	}
+#if defined(PHP_WIN32) && defined(_DEBUG) && defined(PHP_WIN32_DEBUG_HEAP)
+	unclean_shutdown = CG(unclean_shutdown);
+#endif
 #ifdef ZTS
 	tsrm_shutdown();
 #endif
@@ -1387,6 +1392,11 @@ out:
 	 * exiting.
 	 */
 	cleanup_ps_args(argv);
+#if defined(PHP_WIN32) && defined(_DEBUG) && defined(PHP_WIN32_DEBUG_HEAP)
+	if (!unclean_shutdown) {
+		_CrtDumpMemoryLeaks();
+	}
+#endif
 	exit(exit_status);
 }
 /* }}} */


### PR DESCRIPTION
While basic support for MSVCRT debugging has been added long
ago[1], the leak checking is not usable for the test suite due to
frequently occuring false positives.  One issue is that in case of
unclean shutdown loads of bogus leaks are reported.  Another issue
is that we are no longer calling `xmlCleanupParser()` on RSHUTDOWN
of ext/libxml[2], and therefore a few bogus leaks are reported
whenever ext/libxml is unloaded.  Yet another issue are bogus leaks
related to `zend_handlers_table`, which is lazily allocated in
persistent memory, and as such never needs to be freed.

We therefore only dump memory leaks on clean shutdown, and also
ignore memory leaks for the mentioned cases.  We introduce
`ZEND_IGNORE_LEAKS_BEGIN()` and `ZEND_IGNORE_LEAKS_END()` to keep
those ignores better readable, and also because these *might* be
useful for other leak checkers as well.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=d756e1db2324c1f4ab6f9b52e329959ce6a02bc3>
[2] <http://git.php.net/?p=php-src.git;a=commit;h=8742276eb3905eb97a585417000c7b8df85006d4>
