### PR TITLE
Drop I length modifier from snprintf as it is unused

### DIFF
--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -712,25 +712,6 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 					fmt++;
 					modifier = LM_LONG_DOUBLE;
 					break;
-				case 'I':
-					fmt++;
-#if SIZEOF_LONG_LONG
-					if (*fmt == '6' && *(fmt+1) == '4') {
-						fmt += 2;
-						modifier = LM_LONG_LONG;
-					} else
-#endif
-						if (*fmt == '3' && *(fmt+1) == '2') {
-							fmt += 2;
-							modifier = LM_LONG;
-						} else {
-#ifdef _WIN64
-							modifier = LM_LONG_LONG;
-#else
-							modifier = LM_LONG;
-#endif
-						}
-					break;
 				case 'l':
 					fmt++;
 #if SIZEOF_LONG_LONG


### PR DESCRIPTION
Basing myself from the results of: https://gist.github.com/Girgias/b9a2b9926190630d433c84da0ef1b002 which indicate that the I (capital i) length modifier is unused, moreover it's not a C99 length modifier.