### PR TITLE
Use zend_type inside type lists

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -983,20 +983,14 @@ static void zend_resolve_property_types(void) /* {{{ */
 
 		if (UNEXPECTED(ZEND_CLASS_HAS_TYPE_HINTS(ce))) {
 			ZEND_HASH_FOREACH_PTR(&ce->properties_info, prop_info) {
-				if (ZEND_TYPE_HAS_LIST(prop_info->type)) {
-					void **entry;
-					ZEND_TYPE_LIST_FOREACH_PTR(ZEND_TYPE_LIST(prop_info->type), entry) {
-						if (ZEND_TYPE_LIST_IS_NAME(*entry)) {
-							zend_string *type_name = ZEND_TYPE_LIST_GET_NAME(*entry);
-							*entry = ZEND_TYPE_LIST_ENCODE_CE(resolve_type_name(type_name));
-							zend_string_release(type_name);
-						}
-					} ZEND_TYPE_LIST_FOREACH_END();
-				} else if (ZEND_TYPE_HAS_NAME(prop_info->type)) {
-					zend_string *type_name = ZEND_TYPE_NAME(prop_info->type);
-					ZEND_TYPE_SET_CE(prop_info->type, resolve_type_name(type_name));
-					zend_string_release(type_name);
-				}
+				zend_type *single_type;
+				ZEND_TYPE_FOREACH(prop_info->type, single_type) {
+					if (ZEND_TYPE_HAS_NAME(*single_type)) {
+						zend_string *type_name = ZEND_TYPE_NAME(*single_type);
+						ZEND_TYPE_SET_CE(*single_type, resolve_type_name(type_name));
+						zend_string_release(type_name);
+					}
+				} ZEND_TYPE_FOREACH_END();
 			} ZEND_HASH_FOREACH_END();
 		}
 		ce->ce_flags |= ZEND_ACC_PROPERTY_TYPES_RESOLVED;

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -600,10 +600,10 @@ static void function_copy_ctor(zval *zv) /* {{{ */
 				memcpy(new_list, old_list, ZEND_TYPE_LIST_SIZE(old_list->num_types));
 				ZEND_TYPE_SET_PTR(new_arg_info[i].type, new_list);
 
-				void **entry;
-				ZEND_TYPE_LIST_FOREACH_PTR(new_list, entry) {
-					zend_string *name = zend_string_dup(ZEND_TYPE_LIST_GET_NAME(*entry), 1);
-					*entry = ZEND_TYPE_LIST_ENCODE_NAME(name);
+				zend_type *list_type;
+				ZEND_TYPE_LIST_FOREACH(new_list, list_type) {
+					zend_string *name = zend_string_dup(ZEND_TYPE_NAME(*list_type), 1);
+					ZEND_TYPE_SET_PTR(*list_type, name);
 				} ZEND_TYPE_LIST_FOREACH_END();
 			} else if (ZEND_TYPE_HAS_NAME(arg_info[i].type)) {
 				zend_string *name = zend_string_dup(ZEND_TYPE_NAME(arg_info[i].type), 1);

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -941,18 +941,18 @@ static zend_bool zend_check_and_resolve_property_class_type(
 		zend_property_info *info, zend_class_entry *object_ce) {
 	zend_class_entry *ce;
 	if (ZEND_TYPE_HAS_LIST(info->type)) {
-		void **entry;
-		ZEND_TYPE_LIST_FOREACH_PTR(ZEND_TYPE_LIST(info->type), entry) {
-			if (ZEND_TYPE_LIST_IS_NAME(*entry)) {
-				zend_string *name = ZEND_TYPE_LIST_GET_NAME(*entry);
+		zend_type *list_type;
+		ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(info->type), list_type) {
+			if (ZEND_TYPE_HAS_NAME(*list_type)) {
+				zend_string *name = ZEND_TYPE_NAME(*list_type);
 				ce = resolve_single_class_type(name, info->ce);
 				if (!ce) {
 					continue;
 				}
 				zend_string_release(name);
-				*entry = ZEND_TYPE_LIST_ENCODE_CE(ce);
+				ZEND_TYPE_SET_CE(*list_type, ce);
 			} else {
-				ce = ZEND_TYPE_LIST_GET_CE(*entry);
+				ce = ZEND_TYPE_CE(*list_type);
 			}
 			if (instanceof_function(object_ce, ce)) {
 				return 1;
@@ -1032,12 +1032,12 @@ static zend_always_inline zend_bool zend_check_type_slow(
 	if (ZEND_TYPE_HAS_CLASS(type) && Z_TYPE_P(arg) == IS_OBJECT) {
 		zend_class_entry *ce;
 		if (ZEND_TYPE_HAS_LIST(type)) {
-			void *entry;
-			ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(type), entry) {
+			zend_type *list_type;
+			ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(type), list_type) {
 				if (*cache_slot) {
 					ce = *cache_slot;
 				} else {
-					ce = zend_fetch_class(ZEND_TYPE_LIST_GET_NAME(entry),
+					ce = zend_fetch_class(ZEND_TYPE_NAME(*list_type),
 						(ZEND_FETCH_CLASS_AUTO | ZEND_FETCH_CLASS_NO_AUTOLOAD));
 					if (!ce) {
 						cache_slot++;

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -104,10 +104,10 @@ ZEND_API void destroy_zend_function(zend_function *function)
 
 ZEND_API void zend_type_release(zend_type type, zend_bool persistent) {
 	if (ZEND_TYPE_HAS_LIST(type)) {
-		void *entry;
-		ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(type), entry) {
-			if (ZEND_TYPE_LIST_IS_NAME(entry)) {
-				zend_string_release(ZEND_TYPE_LIST_GET_NAME(entry));
+		zend_type *list_type;
+		ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(type), list_type) {
+			if (ZEND_TYPE_HAS_NAME(*list_type)) {
+				zend_string_release(ZEND_TYPE_NAME(*list_type));
 			}
 		} ZEND_TYPE_LIST_FOREACH_END();
 		if (!ZEND_TYPE_USES_ARENA(type)) {

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -1148,12 +1148,12 @@ static void ZEND_FASTCALL zend_jit_verify_arg_slow(zval *arg, const zend_op_arra
 	if (ZEND_TYPE_HAS_CLASS(arg_info->type) && Z_TYPE_P(arg) == IS_OBJECT) {
 		zend_class_entry *ce;
 		if (ZEND_TYPE_HAS_LIST(arg_info->type)) {
-			void *entry;
-			ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(arg_info->type), entry) {
+			zend_type *list_type;
+			ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(arg_info->type), list_type) {
 				if (*cache_slot) {
 					ce = *cache_slot;
 				} else {
-					ce = zend_fetch_class(ZEND_TYPE_LIST_GET_NAME(entry),
+					ce = zend_fetch_class(ZEND_TYPE_NAME(*list_type),
 						(ZEND_FETCH_CLASS_AUTO | ZEND_FETCH_CLASS_NO_AUTOLOAD));
 					if (!ce) {
 						cache_slot++;

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -239,13 +239,13 @@ static void zend_hash_clone_prop_info(HashTable *ht)
 					list = ARENA_REALLOC(list);
 					ZEND_TYPE_SET_PTR(prop_info->type, list);
 
-					void **entry;
-					ZEND_TYPE_LIST_FOREACH_PTR(ZEND_TYPE_LIST(prop_info->type), entry) {
-						if (ZEND_TYPE_LIST_IS_CE(*entry)) {
-							zend_class_entry *ce = ZEND_TYPE_LIST_GET_CE(*entry);
+					zend_type *list_type;
+					ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(prop_info->type), list_type) {
+						if (ZEND_TYPE_HAS_CE(*list_type)) {
+							zend_class_entry *ce = ZEND_TYPE_CE(*list_type);
 							if (IN_ARENA(ce)) {
 								ce = ARENA_REALLOC(ce);
-								*entry = ZEND_TYPE_LIST_ENCODE_CE(ce);
+								ZEND_TYPE_SET_PTR(*list_type, ce);
 							}
 						}
 					} ZEND_TYPE_LIST_FOREACH_END();

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -380,17 +380,9 @@ static void zend_file_cache_serialize_type(
 		ZEND_TYPE_SET_PTR(*type, list);
 		UNSERIALIZE_PTR(list);
 
-		void **entry;
-		ZEND_TYPE_LIST_FOREACH_PTR(list, entry) {
-			if (ZEND_TYPE_LIST_IS_NAME(*entry)) {
-				zend_string *name = ZEND_TYPE_LIST_GET_NAME(*entry);
-				SERIALIZE_STR(name);
-				*entry = ZEND_TYPE_LIST_ENCODE_NAME(name);
-			} else {
-				zend_class_entry *ce = ZEND_TYPE_LIST_GET_CE(*entry);
-				SERIALIZE_PTR(ce);
-				*entry = ZEND_TYPE_LIST_ENCODE_CE(ce);
-			}
+		zend_type *list_type;
+		ZEND_TYPE_LIST_FOREACH(list, list_type) {
+			zend_file_cache_serialize_type(list_type, script, info, buf);
 		} ZEND_TYPE_LIST_FOREACH_END();
 	} else if (ZEND_TYPE_HAS_NAME(*type)) {
 		zend_string *type_name = ZEND_TYPE_NAME(*type);
@@ -1108,17 +1100,9 @@ static void zend_file_cache_unserialize_type(
 		UNSERIALIZE_PTR(list);
 		ZEND_TYPE_SET_PTR(*type, list);
 
-		void **entry;
-		ZEND_TYPE_LIST_FOREACH_PTR(list, entry) {
-			if (ZEND_TYPE_LIST_IS_NAME(*entry)) {
-				zend_string *name = ZEND_TYPE_LIST_GET_NAME(*entry);
-				UNSERIALIZE_STR(name);
-				*entry = ZEND_TYPE_LIST_ENCODE_NAME(name);
-			} else {
-				zend_class_entry *ce = ZEND_TYPE_LIST_GET_CE(*entry);
-				UNSERIALIZE_PTR(ce);
-				*entry = ZEND_TYPE_LIST_ENCODE_CE(ce);
-			}
+		zend_type *list_type;
+		ZEND_TYPE_LIST_FOREACH(list, list_type) {
+			zend_file_cache_unserialize_type(list_type, script, buf);
 		} ZEND_TYPE_LIST_FOREACH_END();
 	} else if (ZEND_TYPE_HAS_NAME(*type)) {
 		zend_string *type_name = ZEND_TYPE_NAME(*type);

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -260,7 +260,7 @@ static void zend_persist_zval(zval *z)
 
 static void zend_persist_type(zend_type *type) {
 	if (ZEND_TYPE_HAS_LIST(*type)) {
-		void **entry;
+		zend_type *list_type;
 		zend_type_list *list = ZEND_TYPE_LIST(*type);
 		if (ZEND_TYPE_USES_ARENA(*type)) {
 			if (!ZCG(is_immutable_class)) {
@@ -275,10 +275,10 @@ static void zend_persist_type(zend_type *type) {
 		}
 		ZEND_TYPE_SET_PTR(*type, list);
 
-		ZEND_TYPE_LIST_FOREACH_PTR(list, entry) {
-			zend_string *type_name = ZEND_TYPE_LIST_GET_NAME(*entry);
+		ZEND_TYPE_LIST_FOREACH(list, list_type) {
+			zend_string *type_name = ZEND_TYPE_NAME(*list_type);
 			zend_accel_store_interned_string(type_name);
-			*entry = ZEND_TYPE_LIST_ENCODE_NAME(type_name);
+			ZEND_TYPE_SET_PTR(*list_type, type_name);
 		} ZEND_TYPE_LIST_FOREACH_END();
 	} else if (ZEND_TYPE_HAS_NAME(*type)) {
 		zend_string *type_name = ZEND_TYPE_NAME(*type);
@@ -963,28 +963,18 @@ static void zend_update_parent_ce(zend_class_entry *ce)
 	if (ce->ce_flags & ZEND_ACC_HAS_TYPE_HINTS) {
 		zend_property_info *prop;
 		ZEND_HASH_FOREACH_PTR(&ce->properties_info, prop) {
-			if (ZEND_TYPE_HAS_LIST(prop->type)) {
-				void **entry;
-				ZEND_TYPE_LIST_FOREACH_PTR(ZEND_TYPE_LIST(prop->type), entry) {
-					if (ZEND_TYPE_LIST_IS_CE(*entry)) {
-						zend_class_entry *ce = ZEND_TYPE_LIST_GET_CE(*entry);
-						if (ce->type == ZEND_USER_CLASS) {
-							ce = zend_shared_alloc_get_xlat_entry(ce);
-							if (ce) {
-								*entry = ZEND_TYPE_LIST_ENCODE_CE(ce);
-							}
+			zend_type *single_type;
+			ZEND_TYPE_FOREACH(prop->type, single_type) {
+				if (ZEND_TYPE_HAS_CE(*single_type)) {
+					zend_class_entry *ce = ZEND_TYPE_CE(*single_type);
+					if (ce->type == ZEND_USER_CLASS) {
+						ce = zend_shared_alloc_get_xlat_entry(ce);
+						if (ce) {
+							ZEND_TYPE_SET_PTR(*single_type, ce);
 						}
 					}
-				} ZEND_TYPE_LIST_FOREACH_END();
-			} else if (ZEND_TYPE_HAS_CE(prop->type)) {
-				zend_class_entry *ce = ZEND_TYPE_CE(prop->type);
-				if (ce->type == ZEND_USER_CLASS) {
-					ce = zend_shared_alloc_get_xlat_entry(ce);
-					if (ce) {
-						ZEND_TYPE_SET_PTR(prop->type, ce);
-					}
 				}
-			}
+			} ZEND_TYPE_FOREACH_END();
 		} ZEND_HASH_FOREACH_END();
 	}
 

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -151,16 +151,16 @@ static void zend_persist_zval_calc(zval *z)
 static void zend_persist_type_calc(zend_type *type)
 {
 	if (ZEND_TYPE_HAS_LIST(*type)) {
-		void **entry;
+		zend_type *list_type;
 		if (ZEND_TYPE_USES_ARENA(*type) && !ZCG(is_immutable_class)) {
 			ADD_ARENA_SIZE(ZEND_TYPE_LIST_SIZE(ZEND_TYPE_LIST(*type)->num_types));
 		} else {
 			ADD_SIZE(ZEND_TYPE_LIST_SIZE(ZEND_TYPE_LIST(*type)->num_types));
 		}
-		ZEND_TYPE_LIST_FOREACH_PTR(ZEND_TYPE_LIST(*type), entry) {
-			zend_string *type_name = ZEND_TYPE_LIST_GET_NAME(*entry);
+		ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(*type), list_type) {
+			zend_string *type_name = ZEND_TYPE_NAME(*list_type);
 			ADD_INTERNED_STRING(type_name);
-			*entry = ZEND_TYPE_LIST_ENCODE_NAME(type_name);
+			ZEND_TYPE_SET_PTR(*list_type, type_name);
 		} ZEND_TYPE_LIST_FOREACH_END();
 	} else if (ZEND_TYPE_HAS_NAME(*type)) {
 		zend_string *type_name = ZEND_TYPE_NAME(*type);
@@ -349,16 +349,12 @@ static void check_property_type_resolution(zend_class_entry *ce) {
 
 	if (ce->ce_flags & ZEND_ACC_HAS_TYPE_HINTS) {
 		ZEND_HASH_FOREACH_PTR(&ce->properties_info, prop) {
-			if (ZEND_TYPE_HAS_LIST(prop->type)) {
-				void *entry;
-				ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(prop->type), entry) {
-					if (ZEND_TYPE_LIST_IS_NAME(entry)) {
-						return;
-					}
-				} ZEND_TYPE_LIST_FOREACH_END();
-			} else if (ZEND_TYPE_HAS_NAME(prop->type)) {
-				return;
-			}
+			zend_type *single_type;
+			ZEND_TYPE_FOREACH(prop->type, single_type) {
+				if (ZEND_TYPE_HAS_NAME(*single_type)) {
+					return;
+				}
+			} ZEND_TYPE_FOREACH_END();
 		} ZEND_HASH_FOREACH_END();
 	}
 	ce->ce_flags |= ZEND_ACC_PROPERTY_TYPES_RESOLVED;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2938,15 +2938,9 @@ ZEND_METHOD(reflection_union_type, getTypes)
 
 	array_init(return_value);
 	if (ZEND_TYPE_HAS_LIST(param->type)) {
-		void *entry;
-		ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(param->type), entry) {
-			if (ZEND_TYPE_LIST_IS_NAME(entry)) {
-				append_type(return_value,
-					(zend_type) ZEND_TYPE_INIT_CLASS(ZEND_TYPE_LIST_GET_NAME(entry), 0, 0));
-			} else {
-				append_type(return_value,
-					(zend_type) ZEND_TYPE_INIT_CE(ZEND_TYPE_LIST_GET_CE(entry), 0, 0));
-			}
+		zend_type *list_type;
+		ZEND_TYPE_LIST_FOREACH(ZEND_TYPE_LIST(param->type), list_type) {
+			append_type(return_value, *list_type);
 		} ZEND_TYPE_LIST_FOREACH_END();
 	} else if (ZEND_TYPE_HAS_NAME(param->type)) {
 		append_type(return_value,

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -270,8 +270,8 @@ PHP_MINIT_FUNCTION(zend_test)
 		zend_string *class_name2 = zend_string_init("Iterator", sizeof("Iterator") - 1, 1);
 		zend_type_list *type_list = malloc(ZEND_TYPE_LIST_SIZE(2));
 		type_list->num_types = 2;
-		type_list->types[0] = ZEND_TYPE_LIST_ENCODE_NAME(class_name1);
-		type_list->types[1] = ZEND_TYPE_LIST_ENCODE_NAME(class_name2);
+		type_list->types[0] = (zend_type) ZEND_TYPE_INIT_CLASS(class_name1, 0, 0);
+		type_list->types[1] = (zend_type) ZEND_TYPE_INIT_CLASS(class_name2, 0, 0);
 		zend_type type = ZEND_TYPE_INIT_PTR(type_list, _ZEND_TYPE_LIST_BIT, 1, 0);
 		zval val;
 		ZVAL_NULL(&val);


### PR DESCRIPTION
Instead of having a completely independent encoding for type list
entries. This is going to use more memory, but I'm not particularly
concerned about that, as type unions that contain multiple classes
should be uncommon. On the other hand, this allows us to treat
top-level types and types inside lists mostly the same.

A new ZEND_TYPE_FOREACH macros allows to transparently treat list
and non-list types the same way. I'm not using it everywhere it could be
used for now, just the places that seemed most obvious.

Of course, this will make any future type system changes much simpler,
as it will not be necessary to duplicate all logic two times.