### PR TITLE
Cleanup & fix openssl handling in configure

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1917,13 +1917,7 @@ dnl
 AC_DEFUN([PHP_SETUP_OPENSSL],[
   found_openssl=no
 
-  dnl Empty variable means 'no'.
-  test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
-  test -z "$PHP_IMAP_SSL" && PHP_IMAP_SSL=no
-
-  if test "$PHP_OPENSSL" != "no"; then
-    PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.0.1], [found_openssl=yes])
-  fi
+  PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.0.1], [found_openssl=yes])
 
   if test "$found_openssl" = "yes"; then
     PHP_EVAL_LIBLINE($OPENSSL_LIBS, $1)

--- a/ext/ftp/config.m4
+++ b/ext/ftp/config.m4
@@ -3,6 +3,14 @@ PHP_ARG_ENABLE([ftp],
   [AS_HELP_STRING([--enable-ftp],
     [Enable FTP support])])
 
+dnl TODO: Rename this option for master.
+PHP_ARG_WITH([openssl-dir],
+  [whether to explicitly enable FTP SSL support],
+  [AS_HELP_STRING([[--with-openssl-dir]],
+    [FTP: Whether to enable FTP SSL support without ext/openssl])],
+  [no],
+  [no])
+
 if test "$PHP_FTP" = "yes"; then
   AC_DEFINE(HAVE_FTP,1,[Whether you want FTP support])
   PHP_NEW_EXTENSION(ftp, php_ftp.c ftp.c, $ext_shared)
@@ -10,7 +18,7 @@ if test "$PHP_FTP" = "yes"; then
   dnl Empty variable means 'no'
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
 
-  if test "$PHP_OPENSSL" != "no"; then
+  if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
     PHP_SETUP_OPENSSL(FTP_SHARED_LIBADD)
     PHP_SUBST(FTP_SHARED_LIBADD)
     AC_DEFINE(HAVE_FTP_SSL,1,[Whether FTP over SSL is supported])

--- a/ext/ftp/config.m4
+++ b/ext/ftp/config.m4
@@ -3,13 +3,6 @@ PHP_ARG_ENABLE([ftp],
   [AS_HELP_STRING([--enable-ftp],
     [Enable FTP support])])
 
-PHP_ARG_WITH([openssl-dir],
-  [OpenSSL dir for FTP],
-  [AS_HELP_STRING([[--with-openssl-dir[=DIR]]],
-    [FTP: openssl install prefix])],
-  [no],
-  [no])
-
 if test "$PHP_FTP" = "yes"; then
   AC_DEFINE(HAVE_FTP,1,[Whether you want FTP support])
   PHP_NEW_EXTENSION(ftp, php_ftp.c ftp.c, $ext_shared)
@@ -17,7 +10,7 @@ if test "$PHP_FTP" = "yes"; then
   dnl Empty variable means 'no'
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
 
-  if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
+  if test "$PHP_OPENSSL" != "no"; then
     PHP_SETUP_OPENSSL(FTP_SHARED_LIBADD)
     PHP_SUBST(FTP_SHARED_LIBADD)
     AC_DEFINE(HAVE_FTP_SSL,1,[Whether FTP over SSL is supported])

--- a/ext/imap/config.m4
+++ b/ext/imap/config.m4
@@ -73,7 +73,7 @@ AC_DEFUN([PHP_IMAP_SSL_CHK], [
     ], [
       AC_MSG_ERROR([OpenSSL libraries not found.
 
-      Check the path given to --with-openssl-dir and output in config.log)
+      Check whether openssl is on your PKG_CONFIG_PATH and the output in config.log)
       ])
     ])
   elif test -f "$IMAP_INC_DIR/linkage.c"; then
@@ -100,8 +100,8 @@ PHP_ARG_WITH([kerberos],
 
 PHP_ARG_WITH([imap-ssl],
   [for IMAP SSL support],
-  [AS_HELP_STRING([[--with-imap-ssl[=DIR]]],
-    [IMAP: Include SSL support. DIR is the OpenSSL install prefix])],
+  [AS_HELP_STRING([[--with-imap-ssl]],
+    [IMAP: Include SSL support])],
   [no],
   [no])
 

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -34,7 +34,7 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
 
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
 
-  if test "$PHP_OPENSSL" != "no"; then
+  if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
     PHP_SETUP_OPENSSL(MYSQLND_SHARED_LIBADD, [AC_DEFINE(MYSQLND_HAVE_SSL,1,[Enable mysqlnd code that uses OpenSSL directly])])
   fi
 

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -34,7 +34,7 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
 
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
 
-  if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
+  if test "$PHP_OPENSSL" != "no"; then
     PHP_SETUP_OPENSSL(MYSQLND_SHARED_LIBADD, [AC_DEFINE(MYSQLND_HAVE_SSL,1,[Enable mysqlnd code that uses OpenSSL directly])])
   fi
 

--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -3,13 +3,6 @@ PHP_ARG_WITH([snmp],
   [AS_HELP_STRING([[--with-snmp[=DIR]]],
     [Include SNMP support])])
 
-PHP_ARG_WITH([openssl-dir],
-  [OpenSSL dir for SNMP],
-  [AS_HELP_STRING([[--with-openssl-dir[=DIR]]],
-    [SNMP: openssl install prefix])],
-  [no],
-  [no])
-
 if test "$PHP_SNMP" != "no"; then
 
   if test "$PHP_SNMP" = "yes"; then


### PR DESCRIPTION
Remove leftover references to `--with-openssl-dir`, which is not used, as the openssl path is now determined by pkg-config.

Also remove the check of `PHP_OPENSSL` inside `SETUP_OPENSSL`. It's the responsibility of the caller to determine whether they want to enable openssl or not. This should also make IMAP with SSL work, which uses a different option.