### PR TITLE
Speed up unserializing object properties

### DIFF
--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -559,10 +559,13 @@ string_key:
 
 				if ((old_data = zend_hash_find(ht, Z_STR(key))) != NULL) {
 					if (Z_TYPE_P(old_data) == IS_INDIRECT) {
+						/* This is a property with a declaration */
 						old_data = Z_INDIRECT_P(old_data);
 						info = zend_get_typed_property_info_for_slot(obj, old_data);
 						var_push_dtor(var_hash, old_data);
-						data = zend_hash_update_ind(ht, Z_STR(key), &d);
+						Z_TRY_DELREF_P(old_data);
+						ZVAL_COPY_VALUE(old_data, &d);
+						data = old_data;
 
 						if (UNEXPECTED(info)) {
 							/* Remember to which property this slot belongs, so we can add a


### PR DESCRIPTION
Hash table lookups are slow.
Don't do one a second time to update the property,
if absolutely sure that the hash table won't change.

The vast majority of property defaults aren't refcounted.
With opcache enabled, most arrays are also immutable instead of refcounted. 

The call to zend_hash_update_ind goes back to 8b0deb8cd2d

Background: Properties are IS_INDIRECT when they're a declared property,
and point to properties_table.
See https://nikic.github.io/2015/06/19/Internal-value-representation-in-PHP-7-part-2.html#objects-in-php-7

Unserialization tests fail without the IS_REFCOUNTABLE check,
because the hash table's element destructor (called by `zend_hash_update*`)
has side effects.

```
<?php

class Obj {
	private $foo = 10;
	public $bar = "test";
	public $i;
}

$array = array();
for ($i = 0; $i < 1000; $i++) {
	$o = new Obj();
	$o->i = $i;

	$array[] = $o;
}
$ser = serialize($array);

/*
Before: 0.413 or more
After: 0.404 or less (3% speedup)
 */
for ($i = 0; $i < 40; $i++) {
	$start = microtime(true);
	for ($j = 0; $j < 540; $j++) {
		$array = unserialize($ser);
	}
    printf("For 540*1000 objects: %.4f\n", microtime(true) - $start);
}
```