### PR TITLE
Introduce a type check cache (TCC)

### DIFF
--- a/Zend/tests/type_check_cache/cache_reads.phpt
+++ b/Zend/tests/type_check_cache/cache_reads.phpt
@@ -1,0 +1,70 @@
+--TEST--
+Test if type checks work when TCC is warmed up
+--FILE--
+<?php
+
+class A {}
+class B {
+    public A $prop;
+}
+
+function test1(A $arg) {
+    return $arg;
+}
+
+function test2($arg): A {
+    return $arg;
+}
+
+foreach ([1,2] as $iteration) {
+    echo "Passing valid object:\n";
+    test1(new A);
+    echo "Passing invalid object:\n";
+    try {
+        test1(new B);
+    } catch (TypeError $e) {
+        echo "TypeError\n";
+    }
+
+    echo "Returning valid object:\n";
+    test2(new A);
+    echo "Returning invalid object:\n";
+    try {
+        test2(new B);
+    } catch (TypeError $e) {
+        echo "TypeError\n";
+    }
+
+    echo "Writing valid property value\n";
+    $b = new B;
+    $b->prop = new A;
+    echo "Writing invalid property value\n";
+    try {
+        $b->prop = new B;
+    } catch (TypeError $e) {
+        echo "TypeError\n";
+    }
+}
+
+echo "Done\n";
+?>
+--EXPECTF--
+Passing valid object:
+Passing invalid object:
+TypeError
+Returning valid object:
+Returning invalid object:
+TypeError
+Writing valid property value
+Writing invalid property value
+TypeError
+Passing valid object:
+Passing invalid object:
+TypeError
+Returning valid object:
+Returning invalid object:
+TypeError
+Writing valid property value
+Writing invalid property value
+TypeError
+Done

--- a/Zend/tests/type_check_cache/zero_cache_row_size.phpt
+++ b/Zend/tests/type_check_cache/zero_cache_row_size.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test if type checks work when TCC row size is zero
+--INI--
+tcc_class_slots=0
+--FILE--
+<?php
+
+class A {}
+class B {}
+
+function test(A $arg) {
+    is_object($arg);
+}
+
+echo "Passing valid object:\n";
+test(new A);
+echo "Passing invalid object:\n";
+try {
+    test(new B);
+} catch (TypeError $e) {
+    echo "TypeError\n";
+}
+
+echo "Done\n";
+?>
+--EXPECTF--
+Passing valid object:
+Passing invalid object:
+TypeError
+Done

--- a/Zend/tests/type_check_cache/zero_cache_size.phpt
+++ b/Zend/tests/type_check_cache/zero_cache_size.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test if type checks work when TCC has no available memory
+--INI--
+tcc_memory_limit=0
+--FILE--
+<?php
+
+class A {}
+class B {}
+
+function test(A $arg) {
+    is_object($arg);
+}
+
+echo "Passing valid object:\n";
+test(new A);
+echo "Passing invalid object:\n";
+try {
+    test(new B);
+} catch (TypeError $e) {
+    echo "TypeError\n";
+}
+echo "Done\n";
+?>
+--EXPECTF--
+Passing valid object:
+Passing invalid object:
+TypeError
+Done

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -116,6 +116,7 @@ struct _zend_class_entry {
 		zend_string *parent_name;
 	};
 	int refcount;
+	int tcc_column_index; /* Assigned column in type check cache */
 	uint32_t ce_flags;
 
 	int default_properties_count;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1075,7 +1075,7 @@ ZEND_API int zend_update_class_constants(zend_class_entry *class_type) /* {{{ */
 								return FAILURE;
 							}
 							/* property initializers must always be evaluated with strict types */;
-							if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, /* strict */ 1))) {
+							if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, /* strict */ 1, NULL))) {
 								zval_ptr_dtor(&tmp);
 								return FAILURE;
 							}
@@ -1147,7 +1147,7 @@ ZEND_API void object_properties_init_ex(zend_object *object, HashTable *properti
 					zval tmp;
 
 					ZVAL_COPY_VALUE(&tmp, prop);
-					if (UNEXPECTED(!zend_verify_property_type(property_info, &tmp, 0))) {
+					if (UNEXPECTED(!zend_verify_property_type(property_info, &tmp, 0, NULL))) {
 						continue;
 					}
 					ZVAL_COPY_VALUE(slot, &tmp);
@@ -4032,7 +4032,7 @@ ZEND_API int zend_update_static_property_ex(zend_class_entry *scope, zend_string
 	Z_TRY_ADDREF_P(value);
 	if (ZEND_TYPE_IS_SET(prop_info->type)) {
 		ZVAL_COPY_VALUE(&tmp, value);
-		if (!zend_verify_property_type(prop_info, &tmp, /* strict */ 0)) {
+		if (!zend_verify_property_type(prop_info, &tmp, /* strict */ 0, NULL)) {
 			Z_TRY_DELREF_P(value);
 			return FAILURE;
 		}

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -28,6 +28,7 @@
 #include "zend_variables.h"
 #include "zend_execute.h"
 #include "zend_type_info.h"
+#include "zend_type_check_cache.h"
 
 
 BEGIN_EXTERN_C()

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -396,7 +396,7 @@ ZEND_API void zend_cleanup_unfinished_execution(zend_execute_data *execute_data,
 
 #define ZEND_CLASS_HAS_TYPE_HINTS(ce) ((ce->ce_flags & ZEND_ACC_HAS_TYPE_HINTS) == ZEND_ACC_HAS_TYPE_HINTS)
 
-zend_bool zend_verify_property_type(zend_property_info *info, zval *property, zend_bool strict);
+zend_bool zend_verify_property_type(zend_property_info *info, zval *property, zend_bool strict, void **tcc_cache_row);
 ZEND_COLD void zend_verify_property_type_error(zend_property_info *info, zval *property);
 
 #define ZEND_REF_ADD_TYPE_SOURCE(ref, source) \

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -77,6 +77,23 @@ struct _zend_compiler_globals {
 	HashTable *function_table;	/* function symbol table */
 	HashTable *class_table;		/* class table */
 
+	/* Lookup table for the type check cache (TCC). It is a matrix
+	 * having columns corresponding to class entries and rows
+	 * corresponding to type names like "array|Traversable". Only
+	 * type names for which using the cache is profitable are
+	 * included. The number of columns is limited and configurable
+	 * by means of the tcc_class_slots config variable. Class entries
+	 * are assigned columns while loading them. Rows are added at
+	 * run time whenever new type names are encountered. The total
+	 * size of the matrix is limited to the maximum size controlled
+	 * by the tcc_memory_limit config variable.
+	 */
+	uint8_t **type_check_cache;
+
+	uint8_t *tcc_dummy_row;			/* TCC cache row for generating cache misses */
+	int last_assigned_tcc_column;	/* Last TCC column assigned to any CE */
+	HashTable *type_names_table;	/* List of type names corresponding to rows in type_check_cache */
+
 	HashTable filenames_table;
 
 	HashTable *auto_globals;
@@ -167,6 +184,9 @@ struct _zend_executor_globals {
 	zend_long precision;
 
 	int ticks_count;
+
+	zend_long tcc_memory_limit;    /* Memory limit for TCC matrix in bytes */
+	zend_long tcc_num_class_slots; /* Number of columns in TCC matrix */
 
 	uint32_t persistent_constants_count;
 	uint32_t persistent_functions_count;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -803,6 +803,11 @@ ZEND_API zval *zend_std_write_property(zend_object *zobj, zend_string *name, zva
 
 	property_offset = zend_get_property_offset(zobj->ce, name, (zobj->ce->__set != NULL), cache_slot, &prop_info);
 
+	if (cache_slot) {
+		// Jump to slot containing TCC row
+		cache_slot += 3;
+	}
+
 	if (EXPECTED(IS_VALID_PROPERTY_OFFSET(property_offset))) {
 		variable_ptr = OBJ_PROP(zobj, property_offset);
 		if (Z_TYPE_P(variable_ptr) != IS_UNDEF) {
@@ -810,7 +815,7 @@ ZEND_API zval *zend_std_write_property(zend_object *zobj, zend_string *name, zva
 
 			if (UNEXPECTED(prop_info)) {
 				ZVAL_COPY_VALUE(&tmp, value);
-				if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, EG(current_execute_data) && ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data))))) {
+				if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, EG(current_execute_data) && ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)), cache_slot))) {
 					Z_TRY_DELREF_P(value);
 					variable_ptr = &EG(error_zval);
 					goto exit;
@@ -875,7 +880,7 @@ write_std_property:
 
 			if (UNEXPECTED(prop_info)) {
 				ZVAL_COPY_VALUE(&tmp, value);
-				if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data))))) {
+				if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)), cache_slot))) {
 					zval_ptr_dtor(value);
 					goto exit;
 				}

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -26,6 +26,7 @@
 #include "zend_extensions.h"
 #include "zend_API.h"
 #include "zend_sort.h"
+#include "zend_type_check_cache.h"
 
 #include "zend_vm.h"
 
@@ -1038,6 +1039,9 @@ ZEND_API int pass_two(zend_op_array *op_array)
 		ZEND_VM_SET_OPCODE_HANDLER(opline);
 		opline++;
 	}
+
+	// TODO: Should we re-assign CE columns in opcache after loading them from cache?
+	tcc_assign_ce_columns();
 
 	zend_calc_live_ranges(op_array, NULL);
 

--- a/Zend/zend_type_check_cache.c
+++ b/Zend/zend_type_check_cache.c
@@ -1,0 +1,178 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend Engine                                                          |
+   +----------------------------------------------------------------------+
+   | Copyright (c) Zend Technologies Ltd. (http://www.zend.com)           |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+   | Authors: Dik Takken <d.h.j.takken@freedom.nl>                        |
+   +----------------------------------------------------------------------+
+*/
+
+#include "zend.h"
+#include "zend_globals_macros.h"
+#include "zend_compile.h"
+
+/**
+ * Configures the type check cache to use no more than the
+ * specified amount of memory.
+ */
+ZEND_API int zend_set_tcc_memory_limit(zend_long memory_limit)
+{
+	EG(tcc_memory_limit) = memory_limit;
+	return SUCCESS;
+}
+
+/**
+ * Configures the length of the rows in the type check cache,
+ * determining how many class entries it can store.
+ *
+ * Note: Must not be changed at run time.
+ */
+ZEND_API int zend_set_tcc_class_slots(zend_long num_classes)
+{
+	EG(tcc_num_class_slots) = num_classes;
+	return SUCCESS;
+}
+
+/**
+ * Clears the type check cache
+ */
+ZEND_API void tcc_clear()
+{
+	for (int i=0; i<zend_array_count(CG(type_names_table)); i++) {
+		memset(CG(type_check_cache)[i], 0, EG(tcc_num_class_slots) * sizeof(uint8_t));
+	}
+}
+
+/**
+ * Returns a pointer to the row in the type check cache
+ * that corresponds with specified type. Each row is an
+ * array of bytes containing either one (match) or zero
+ * (unknown) for each of the class entries represented
+ * by the columns.
+ */
+ZEND_API uint8_t *tcc_get_row(zend_type *type)
+{
+	zval type_name_z;
+	zend_string *type_name;
+	zend_string *type_name_copy;
+
+	type_name = zend_type_to_string(*type);
+
+	ZVAL_STR(&type_name_z, type_name);
+
+	// Look up the type name in CG(type_names_table)
+
+	int exists = 0;
+	zval *entry;
+	zend_ulong index = 0;
+	ZEND_HASH_FOREACH_NUM_KEY_VAL(CG(type_names_table), index, entry) {
+		if (fast_is_identical_function(&type_name_z, entry)) {
+			// We found the type name.
+			exists = 1;
+			break;
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	if (!exists) {
+		// Type name not found. We should add it to the hash table.
+
+		if ((zend_array_count(CG(type_names_table)) + 1) * EG(tcc_num_class_slots) * sizeof(uint8_t) > EG(tcc_memory_limit)) {
+			// Adding the type name would exceed memory limits.
+			// We return the dummy cache row which yields a cache
+			// miss for any CE.
+			if (!CG(tcc_dummy_row)) {
+				CG(tcc_dummy_row) = calloc(EG(tcc_num_class_slots), sizeof(uint8_t));
+			}
+			zend_string_release(type_name);
+			return CG(tcc_dummy_row);
+		}
+
+		if (CG(type_names_table)->nNumOfElements > 0) {
+			index++;
+		}
+
+		type_name_copy = zend_string_dup(type_name, 0);
+		ZVAL_STR(&type_name_z, type_name_copy);
+		zend_hash_index_add(CG(type_names_table), index, &type_name_z);
+		zend_string_release(type_name_copy);
+
+		// Now that we have a new type name, we must also add
+		// a new row for it in the cache matrix.
+		CG(type_check_cache) = realloc(CG(type_check_cache), zend_array_count(CG(type_names_table)) * sizeof(uint8_t *));
+		CG(type_check_cache)[index] = calloc(EG(tcc_num_class_slots), sizeof(uint8_t));
+	}
+
+	zend_string_release(type_name);
+
+	return CG(type_check_cache)[index];
+}
+
+/**
+ * Assigns column indices to class entries. Classes that have
+ * been assigned an index before are skipped.
+ */
+ZEND_API void tcc_assign_ce_columns()
+{
+	// Below we assign type check cache column indices to
+	// the classes in the class table. Note that column index
+	// zero is special: It is assigned to classes which are
+	// not covered by the cache. This column contains zeros
+	// indicating a cache miss. It is special because it is
+	// not written in case of a cache miss and because it may
+	// be shared by multiple classes.
+	// Note that we traverse the class table in reverse order
+	// for efficiency.
+	zend_class_entry *ce;
+	ZEND_HASH_REVERSE_FOREACH_PTR(CG(class_table), ce) {
+		if (ce->tcc_column_index > 0) {
+			// We arrived at the classes that were
+			// assigned an index previously, we are done.
+			break;
+		}
+
+		// Below we skip interfaces, traits and abstract classes.
+		// We do not need to assign them a cache column because no
+		// object can ever be an instance of any of them.
+		if (ce->ce_flags & ZEND_ACC_INTERFACE) {
+			ce->tcc_column_index = 0;
+			continue;
+		}
+		if (ce->ce_flags & ZEND_ACC_TRAIT) {
+			ce->tcc_column_index = 0;
+			continue;
+		}
+		if (ce->ce_flags & ZEND_ACC_ABSTRACT) {
+			ce->tcc_column_index = 0;
+			continue;
+		}
+		if (ce->ce_flags & ZEND_ACC_EXPLICIT_ABSTRACT_CLASS) {
+			// TODO: This case is never hit in the tests. Remove?
+			ce->tcc_column_index = 0;
+			continue;
+		}
+
+		CG(last_assigned_tcc_column)++;
+		ce->tcc_column_index = CG(last_assigned_tcc_column);
+
+		// The cache has a fixed number of columns. In case
+		// there are more classes than there are columns we
+		// simply exclude them. This means that type
+		// checks involving objects of these classes will
+		// always result in a cache miss.
+		if (CG(last_assigned_tcc_column) > EG(tcc_num_class_slots)) {
+			CG(last_assigned_tcc_column) = EG(tcc_num_class_slots);
+			ce->tcc_column_index = 0;
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	tcc_clear();
+}

--- a/Zend/zend_type_check_cache.h
+++ b/Zend/zend_type_check_cache.h
@@ -1,0 +1,29 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend Engine                                                          |
+   +----------------------------------------------------------------------+
+   | Copyright (c) Zend Technologies Ltd. (http://www.zend.com)           |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+   | Authors: Dik Takken <d.h.j.takken@freedom.nl>                        |
+   +----------------------------------------------------------------------+
+*/
+
+ZEND_API int zend_set_tcc_memory_limit(zend_long memory_limit);
+ZEND_API int zend_set_tcc_class_slots(zend_long num_classes);
+ZEND_API uint8_t *tcc_get_row (zend_type *type);
+ZEND_API void tcc_assign_ce_columns();
+
+// Below macro encapsulates how type checks that are not covered
+// by the type check cache are identified: The row is the dummy
+// cache row or their column index is zero. This row / column
+// contains only zeros (no match) and must not be written into
+// in case of a cache miss. This macro is used to achieve that.
+#define TCC_CONTAINS(row, ce) (ce->tcc_column_index > 0 && row != CG(tcc_dummy_row))

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2374,7 +2374,7 @@ ZEND_VM_C_LABEL(assign_object):
 						orig_type = Z_TYPE_P(value);
 					}
 
-					value = zend_assign_to_typed_prop(prop_info, property_val, value EXECUTE_DATA_CC);
+					value = zend_assign_to_typed_prop(prop_info, property_val, value EXECUTE_DATA_CC, cache_slot + 3);
 
 					/* will remain valid, thus no need to check prop_info in future here */
 					if (OP_DATA_TYPE == IS_CONST && Z_TYPE_P(value) == orig_type) {
@@ -2493,7 +2493,7 @@ ZEND_VM_HANDLER(25, ZEND_ASSIGN_STATIC_PROP, ANY, ANY, CACHE_SLOT, SPEC(OP_DATA=
 	value = GET_OP_DATA_ZVAL_PTR(BP_VAR_R);
 
 	if (UNEXPECTED(ZEND_TYPE_IS_SET(prop_info->type))) {
-		value = zend_assign_to_typed_prop(prop_info, prop, value EXECUTE_DATA_CC);
+		value = zend_assign_to_typed_prop(prop_info, prop, value EXECUTE_DATA_CC, CACHE_ADDR(opline->extended_value) + 3);
 		FREE_OP_DATA();
 	} else {
 		value = zend_assign_to_variable(prop, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());
@@ -4139,7 +4139,7 @@ ZEND_VM_COLD_CONST_HANDLER(124, ZEND_VERIFY_RETURN_TYPE, CONST|TMP|VAR|UNUSED|CV
 		}
 
 		zend_reference *ref = NULL;
-		void *cache_slot = CACHE_ADDR(opline->op2.num);
+		void **cache_slot = CACHE_ADDR(opline->op2.num);
 		if (UNEXPECTED(retval_ref != retval_ptr)) {
 			if (UNEXPECTED(EX(func)->op_array.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 				ref = Z_REF_P(retval_ref);
@@ -4157,7 +4157,7 @@ ZEND_VM_COLD_CONST_HANDLER(124, ZEND_VERIFY_RETURN_TYPE, CONST|TMP|VAR|UNUSED|CV
 
 		SAVE_OPLINE();
 		if (UNEXPECTED(!zend_check_type_slow(ret_info->type, retval_ptr, ref, cache_slot, NULL, 1, 0))) {
-			zend_verify_return_error(EX(func), cache_slot, retval_ptr);
+			zend_verify_return_error(EX(func), cache_slot + 1, retval_ptr);
 			HANDLE_EXCEPTION();
 		}
 		ZEND_VM_NEXT_OPCODE();

--- a/configure.ac
+++ b/configure.ac
@@ -1444,7 +1444,7 @@ PHP_ADD_SOURCES(Zend, \
     zend_execute_API.c zend_highlight.c zend_llist.c \
     zend_vm_opcodes.c zend_opcode.c zend_operators.c zend_ptr_stack.c zend_stack.c \
     zend_variables.c zend.c zend_API.c zend_extensions.c zend_hash.c \
-    zend_list.c zend_builtin_functions.c \
+    zend_list.c zend_builtin_functions.c zend_type_check_cache.c \
     zend_ini.c zend_sort.c zend_multibyte.c zend_ts_hash.c zend_stream.c \
     zend_iterators.c zend_interfaces.c zend_exceptions.c zend_strtod.c zend_gc.c \
     zend_closures.c zend_weakrefs.c zend_float.c zend_string.c zend_signal.c zend_generators.c \

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -8643,18 +8643,46 @@ static int zend_jit_recv(dasm_State **Dst, const zend_op *opline, const zend_op_
 				if (is_power_of_two(type_mask)) {
 					uint32_t type_code = concrete_type(type_mask);
 					|	cmp byte [r0 + 8], type_code
-					|	jne >8
+					|	jne >7
 				} else {
 					|	mov edx, 1
 					|	mov cl, byte [r0 + 8]
 					|	shl edx, cl
 					|	test edx, type_mask
-					|	je >8
+					|	je >7
 				}
+				|	jmp >1
+
+				|7:
+
+				if (ZEND_TYPE_HAS_CLASS(type)) {
+					uint8_t *tcc_row = tcc_get_row(&type);
+					|	// Make sure that argument is an object.
+					|	IF_NOT_Z_TYPE r0, IS_OBJECT, >8
+					|	// Find the class entry of the value.
+					|	mov r0, [r0 + offsetof(zval, value.obj)]
+					|	mov r0, [r0 + offsetof(zend_object, ce)]
+					|	// Load the TCC column index. This is a 32-bit int value
+					|	// which we load into the a 32-bit register.
+					|	mov eax, [r0 + offsetof(zend_class_entry, tcc_column_index)]
+					|	// Load pointer to TCC row from run_time_cache
+					|	LOAD_ADDR r2, tcc_row
+					|	// When cache entry equals one, we have a hit and we're done.
+					|	// Else, we don't know and we will continue to do a full check.
+					|	cmp byte [r2 + eax], 1
+					|	je >1
+				}
+
+				|	jmp >8 // Jump into cold_code segment
 
 				|.cold_code
 				|8:
 				|	SAVE_VALID_OPLINE opline
+				|	LOAD_ZVAL_ADDR r0, res_addr
+				if (ZEND_ARG_SEND_MODE(arg_info)) {
+					|	GET_Z_PTR r0, r0
+					|	add r0, offsetof(zend_reference, val)
+				}
 				|	mov FCARG1a, r0
 				|	mov r0,	EX->run_time_cache
 				|	add r0, opline->extended_value

--- a/ext/opcache/tests/jit/tcc_cache_reads.phpt
+++ b/ext/opcache/tests/jit/tcc_cache_reads.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Test if type checks work when TCC is warmed up
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=1M
+opcache.jit=1205
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+class A {}
+class B {}
+
+function test1(A $arg) {
+    return $arg;
+}
+
+function test2($arg): A {
+    return $arg;
+}
+
+foreach ([1,2] as $iteration) {
+    echo "Passing valid object:\n";
+    test1(new A);
+    echo "Passing invalid object:\n";
+    try {
+        test1(new B);
+    } catch (TypeError $e) {
+        echo "TypeError\n";
+    }
+}
+
+echo "Done\n";
+?>
+--EXPECTF--
+Passing valid object:
+Passing invalid object:
+TypeError
+Passing valid object:
+Passing invalid object:
+TypeError
+Done

--- a/ext/opcache/tests/jit/tcc_zero_cache_row_size.phpt
+++ b/ext/opcache/tests/jit/tcc_zero_cache_row_size.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test if type checks work when TCC row size is zero
+--INI--
+tcc_class_slots=0
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=1M
+opcache.jit=1205
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+class A {}
+class B {}
+
+function test(A $arg) {
+    is_object($arg);
+}
+
+echo "Passing valid object:\n";
+test(new A);
+echo "Passing invalid object:\n";
+try {
+    test(new B);
+} catch (TypeError $e) {
+    echo "TypeError\n";
+}
+
+echo "Done\n";
+?>
+--EXPECTF--
+Passing valid object:
+Passing invalid object:
+TypeError
+Done

--- a/ext/opcache/tests/jit/tcc_zero_cache_size.phpt
+++ b/ext/opcache/tests/jit/tcc_zero_cache_size.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test if type checks work when TCC has no available memory
+--INI--
+tcc_memory_limit=0
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=1M
+opcache.jit=1205
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+class A {}
+class B {}
+
+function test(A $arg) {
+    is_object($arg);
+}
+
+echo "Passing valid object:\n";
+test(new A);
+echo "Passing invalid object:\n";
+try {
+    test(new B);
+} catch (TypeError $e) {
+    echo "TypeError\n";
+}
+
+echo "Done\n";
+?>
+--EXPECTF--
+Passing valid object:
+Passing invalid object:
+TypeError
+Done

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3943,7 +3943,7 @@ ZEND_METHOD(reflection_class, setStaticPropertyValue)
 		}
 	}
 
-	if (ZEND_TYPE_IS_SET(prop_info->type) && !zend_verify_property_type(prop_info, value, 0)) {
+	if (ZEND_TYPE_IS_SET(prop_info->type) && !zend_verify_property_type(prop_info, value, 0, NULL)) {
 		return;
 	}
 

--- a/main/main.c
+++ b/main/main.c
@@ -305,6 +305,37 @@ static PHP_INI_MH(OnChangeMemoryLimit)
 
 /* {{{ PHP_INI_MH
  */
+static PHP_INI_MH(OnChangeTccMemoryLimit)
+{
+	zend_long tcc_memory_limit;
+	if (new_value) {
+		tcc_memory_limit = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+	} else {
+		// TODO: Can new_value ever be NULL?
+		tcc_memory_limit = 1024 * 1024;
+	}
+	return zend_set_tcc_memory_limit(tcc_memory_limit);
+}
+/* }}} */
+
+/* {{{ PHP_INI_MH
+ */
+static PHP_INI_MH(OnChangeTccClassSlots)
+{
+	zend_long tcc_class_slots;
+	if (new_value) {
+		tcc_class_slots = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+	} else {
+		// TODO: Can new_value ever be NULL?
+		tcc_class_slots = 1024;
+	}
+
+	return zend_set_tcc_class_slots(tcc_class_slots);
+}
+/* }}} */
+
+/* {{{ PHP_INI_MH
+ */
 static PHP_INI_MH(OnSetLogFilter)
 {
 	const char *filter = ZSTR_VAL(new_value);
@@ -792,6 +823,8 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("mail.log",					NULL,		PHP_INI_SYSTEM|PHP_INI_PERDIR,		OnUpdateMailLog,			mail_log,			php_core_globals,	core_globals)
 	PHP_INI_ENTRY("browscap",					NULL,		PHP_INI_SYSTEM,		OnChangeBrowscap)
 	PHP_INI_ENTRY("memory_limit",				"128M",		PHP_INI_ALL,		OnChangeMemoryLimit)
+	PHP_INI_ENTRY("tcc_memory_limit",			"1M",		PHP_INI_SYSTEM,		OnChangeTccMemoryLimit)
+	PHP_INI_ENTRY("tcc_class_slots",			"1K",		PHP_INI_SYSTEM,		OnChangeTccClassSlots)
 	PHP_INI_ENTRY("precision",					"14",		PHP_INI_ALL,		OnSetPrecision)
 	PHP_INI_ENTRY("sendmail_from",				NULL,		PHP_INI_ALL,		NULL)
 	PHP_INI_ENTRY("sendmail_path",	DEFAULT_SENDMAIL_PATH,	PHP_INI_SYSTEM,		NULL)


### PR DESCRIPTION
This was an experiment I did while trying to learn more about PHP internals. When the union types feature was merged it raised some concerns regarding the cost of complex type checks. I was wondering if type checks were cached in some way. It turned out this was not the case. The same type check is redone over and over again, both simple and complex checks.

I also noticed that the JIT compiler does not generate efficient code for complex type checks. A cache would turn complex checks into simple lookups, probably simple enough to implement in the JIT compiler. A double gain.

So here it is, a type check cache for PHP. The PR also extends the JIT compiler to exploit the cache. Where the JIT generated code previously had to bail out to slow code paths it now keeps running at full jitty speed.

Some key characteristics:

* Only type checks involving classes are cached
* Cache is global, shared between all op arrays
* Cache size is dynamic, it grows on demand at run time
* Cache is limited to a configurable maximum size
* Argument type checks, return type checks and typed property writes are supported

An additional gain that having a cache may bring is that it might allow the PHP type system to continue to develop in directions that are currently not considered due to the performance cost involved.

Weaknesses
------------------

* When the cache hits the configured memory constraints some type checks will not be cached. Classes are assigned a cache slot on a first come first served basis. There is no guarantee that the classes that are most used in type checks get a cache slot. However, it is possible to re-assign cache slots at run time. It may be advantageous to keep track of cache hits and misses at run time and optimize the cache at some point. This could be implemented later.
* For reasons of simplicity the cache will typically contain a lot of entries for type / class combinations that are never actually checked in the application.
* Significant performance gains are only to be expected for hot, type check heavy code paths.
* This PR only extends the JIT compiler to exploit the cache for doing argument type checks, because handlers for these checks are already in place. Handling of return type checking and typed property writes appears to be missing in the JIT compiler at this time. Accelerating these using the cache will have to wait.


Things I am not sure about
---------------------------------------

* Sane defaults for cache capacity. Currently, the default is to have at most 1024 classes and 1024 type declarations. This means the cache can grow to 1MB of memory. Having 1024 classes (not counting interfaces, abstract classes and traits) and 1024 globally distinct type declarations sounds like a lot to me but I have no numbers of average real world code bases.
* Each entry in the TCC occupies one byte of memory to store a zero or a one, which is a bit wasteful. Using single bits is possible but this makes TCC lookups more expensive. In practice I do not expect the TCC to ever require much more than a couple of MB at most as it is, so I'm not sure if compressing it makes sense. There may be CPU caching effects to think about as well here.

Some numbers finally
--------------------------------

Using a benchmarking script I measured the performance difference relative to current master. The script is based on the script written by Dmitry Stogov to benchmark union type checks. It can be found here:

https://gist.github.com/dtakken/1539d64170921363dc8d1ed62effcd45

Below I placed the benchmark results I obtained of the master branch and the tcc branch side by side to compare the overall performance gain. The numbers in the leftmost columns are time spent doing a large number of operations that trigger type checks in a tight loop. Overhead of the loop itself is subtracted. First some numbers with JIT turned off:

```
                                   master tcc    speedup
Foo::$static_prop = ...            0.390  0.402  -3%
Foo::$class_union_static_prop = ...0.878  0.627  40%
$o->prop = ...                     0.375  0.384  -2%
$o->class_union_prop = ...         0.831  0.682  22%
func($x)                           0.814  0.817  0%
func($obj)                         1.049  0.948  11%
func(A|B|C|null $obj) (null)       0.784  0.890  -12%
func(A|B|C|null $obj) (A)          1.148  1.155  -1%
func(A|B|C|null $obj) (C)          1.427  1.157  23%
func(A|B|C|null $obj) (D)          1.526  1.154  32%
func(A|B|C|null $obj) (E)          1.608  1.153  39%
func(A|B|C|null $obj) (F)          1.599  1.159  38%
func($obj): A|B|C|null (A)         0.986  0.991  -1%
func($obj): A|B|C|null (C)         1.218  0.989  23%
func($obj): A|B|C|null (D)         1.302  1.002  30%
func($obj): A|B|C|null (E)         1.341  1.006  33%
func($obj): A|B|C|null (F)         1.451  0.995  46%
```

The numbers are slightly noisy. Still, the effect of the TCC shows nicely here. With the TCC enabled, the cost of simple and complex checks is similar.

Next, the same run with JIT enabled:

```
                                   master tcc    speedup
Foo::$static_prop = ...            0.608  0.641  -5%
Foo::$class_union_static_prop = ...1.341  0.888  51%
$o->prop = ...                     0.685  0.685  0%
$o->class_union_prop = ...         1.344  0.898  50%
func($x)                           0.305  0.349  -13%
func($obj)                         0.430  0.425  1%
func(A|B|C|null $obj) (null)       0.364  0.380  -4%
func(A|B|C|null $obj) (A)          0.731  0.471  55%
func(A|B|C|null $obj) (C)          1.747  0.472  270%
func(A|B|C|null $obj) (D)          2.255  0.472  378%
func(A|B|C|null $obj) (E)          2.388  0.471  407%
func(A|B|C|null $obj) (F)          2.508  0.472  431%
func($obj): A|B|C|null (A)         0.914  0.927  -1%
func($obj): A|B|C|null (C)         1.217  0.926  31%
func($obj): A|B|C|null (D)         1.392  0.931  50%
func($obj): A|B|C|null (E)         1.543  0.930  66%
func($obj): A|B|C|null (F)         1.627  0.927  76%
```

While these numbers look really nice, there are some important things to take into consideration here.

* The results of the argument type checks are a bit unfair because it partly compares static compiled code with fully JIT generated code. On the other hand, without the TCC where would not have been efficient JIT code to start with.
* Some operations like typed property assignments and return type checks have no JIT equivalent yet, which means that JIT slows things down. The observed gains will increase once support for these operations is added.

The final measurement compares the performance of the master branch to the performance of the tcc branch while setting the TCC capacity to zero. This shows the worst case scenario of having a cache in place while badly misconfiguring it:

```
                                   master tcc miss   speedup
Foo::$static_prop = ...            0.390  0.397      -2%
Foo::$class_union_static_prop = ...0.878  0.908      -3%
$o->prop = ...                     0.375  0.384      -2%
$o->class_union_prop = ...         0.831  0.889      -7%
func($x)                           0.814  0.827      -2%
func($obj)                         1.049  1.013      4%
func(A|B|C|null $obj) (null)       1.148  1.424      -19%
func(A|B|C|null $obj) (A)          1.427  1.612      -11%
func(A|B|C|null $obj) (C)          1.526  1.697      -10%
func(A|B|C|null $obj) (D)          1.608  1.82       -12%
func(A|B|C|null $obj) (E)          0.784  0.836      -6%
func(A|B|C|null $obj) (F)          1.599  2.027      -21%
func($obj): A|B|C|null (A)         0.986  1.204      -18%
func($obj): A|B|C|null (C)         1.218  1.457      -16%
func($obj): A|B|C|null (D)         1.302  1.532      -15%
func($obj): A|B|C|null (E)         1.341  1.655      -19%
func($obj): A|B|C|null (F)         1.451  1.701      -15%
```

Please note that this is my first significant contribution, I'm not familiar with the things I had to touch. Careful review is highly appreciated.
