### PR TITLE
Proposal: Run the Control Flow Graph pass twice

### DIFF
--- a/ext/opcache/Optimizer/block_pass.c
+++ b/ext/opcache/Optimizer/block_pass.c
@@ -973,7 +973,7 @@ static void assemble_code_blocks(zend_cfg *cfg, zend_op_array *op_array, zend_op
 	}
 
 	new_opcodes = emalloc(len * sizeof(zend_op));
-	opline_delta = (void*)new_opcodes - (void*)op_array->opcodes;
+	opline_delta = ((uint8_t *)new_opcodes) - ((uint8_t *)op_array->opcodes);
 	opline = new_opcodes;
 
 	/* Copy code of reachable blocks into a single buffer */
@@ -1104,8 +1104,8 @@ static void assemble_code_blocks(zend_cfg *cfg, zend_op_array *op_array, zend_op
 	if (func_info) {
 		zend_call_info *call_info = func_info->callee_info;
 		while (call_info) {
-			call_info->caller_init_opline = ((void*)call_info->caller_init_opline) + opline_delta;
-			call_info->caller_call_opline = ((void*)call_info->caller_call_opline) + opline_delta;
+			call_info->caller_init_opline = (zend_op *)(((uint8_t *)call_info->caller_init_opline) + opline_delta);
+			call_info->caller_call_opline = (zend_op *)(((uint8_t *)call_info->caller_call_opline) + opline_delta);
 			call_info = call_info->next_callee;
 		}
 	}

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -1427,10 +1427,12 @@ int zend_optimize_script(zend_script *script, zend_long optimization_level, zend
 			}
 		}
 
-		for (i = 0; i < call_graph.op_arrays_count; i++) {
-			zend_optimize_cfg(call_graph.op_arrays[i], &ctx);
-			if (debug_level & ZEND_DUMP_AFTER_PASS_5) {
-				zend_dump_op_array(call_graph.op_arrays[i], 0, "after pass 5 (again)", NULL);
+		if (ZEND_OPTIMIZER_PASS_5 & optimization_level) {
+			for (i = 0; i < call_graph.op_arrays_count; i++) {
+				zend_optimize_cfg(call_graph.op_arrays[i], &ctx);
+				if (debug_level & ZEND_DUMP_AFTER_PASS_5) {
+					zend_dump_op_array(call_graph.op_arrays[i], 0, "after repeating pass 5", NULL);
+				}
 			}
 		}
 

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -1300,6 +1300,16 @@ static void zend_optimize_op_array(zend_op_array      *op_array,
 	/* Redo pass_two() */
 	zend_redo_pass_two(op_array);
 
+	/* pass 5:
+	 * - CFG optimization (again) after converting code to no-ops.
+	 */
+	if (ZEND_OPTIMIZER_PASS_5 & ctx->optimization_level) {
+		zend_optimize_cfg(op_array, ctx);
+		if (ctx->debug_level & ZEND_DUMP_AFTER_PASS_5) {
+			zend_dump_op_array(op_array, 0, "after repeating pass 5", NULL);
+		}
+	}
+
 	if (op_array->live_range) {
 		zend_recalc_live_ranges(op_array, NULL);
 	}
@@ -1414,6 +1424,13 @@ int zend_optimize_script(zend_script *script, zend_long optimization_level, zend
 		if (debug_level & ZEND_DUMP_AFTER_PASS_7) {
 			for (i = 0; i < call_graph.op_arrays_count; i++) {
 				zend_dump_op_array(call_graph.op_arrays[i], 0, "after pass 7", NULL);
+			}
+		}
+
+		for (i = 0; i < call_graph.op_arrays_count; i++) {
+			zend_optimize_cfg(call_graph.op_arrays[i], &ctx);
+			if (debug_level & ZEND_DUMP_AFTER_PASS_5) {
+				zend_dump_op_array(call_graph.op_arrays[i], 0, "after pass 5 (again)", NULL);
 			}
 		}
 

--- a/ext/opcache/tests/opt/sccp_002.phpt
+++ b/ext/opcache/tests/opt/sccp_002.phpt
@@ -28,10 +28,9 @@ $_main: ; (lines=1, args=0, vars=0, tmps=0)
     ; %ssccp_002.php:1-14
 L0 (14):    RETURN int(1)
 
-foo: ; (lines=4, args=1, vars=1, tmps=0)
+foo: ; (lines=3, args=1, vars=1, tmps=0)
     ; (after optimizer)
     ; %ssccp_002.php:2-12
 L0 (2):     CV0($x) = RECV 1
-L1 (9):     ECHO int(1)
-L2 (11):    ECHO int(1)
-L3 (12):    RETURN null
+L1 (11):    ECHO string("11")
+L2 (12):    RETURN null

--- a/ext/opcache/tests/opt/sccp_003.phpt
+++ b/ext/opcache/tests/opt/sccp_003.phpt
@@ -28,9 +28,8 @@ $_main: ; (lines=1, args=0, vars=0, tmps=0)
     ; %ssccp_003.php:1-14
 L0 (14):    RETURN int(1)
 
-foo: ; (lines=3, args=0, vars=0, tmps=0)
+foo: ; (lines=2, args=0, vars=0, tmps=0)
     ; (after optimizer)
     ; %ssccp_003.php:2-12
-L0 (9):     ECHO int(1)
-L1 (11):    ECHO int(1)
-L2 (12):    RETURN null
+L0 (11):    ECHO string("11")
+L1 (12):    RETURN null

--- a/ext/opcache/tests/opt/sccp_004.phpt
+++ b/ext/opcache/tests/opt/sccp_004.phpt
@@ -31,10 +31,9 @@ $_main: ; (lines=1, args=0, vars=0, tmps=0)
     ; %ssccp_004.php:1-17
 L0 (17):    RETURN int(1)
 
-foo: ; (lines=4, args=1, vars=1, tmps=0)
+foo: ; (lines=3, args=1, vars=1, tmps=0)
     ; (after optimizer)
     ; %ssccp_004.php:2-15
 L0 (2):     CV0($x) = RECV 1
-L1 (11):    ECHO bool(true)
-L2 (14):    ECHO int(1)
-L3 (15):    RETURN null
+L1 (14):    ECHO string("11")
+L2 (15):    RETURN null

--- a/ext/opcache/tests/opt/sccp_010.phpt
+++ b/ext/opcache/tests/opt/sccp_010.phpt
@@ -29,9 +29,8 @@ $_main: ; (lines=1, args=0, vars=0, tmps=0)
     ; %ssccp_010.php:1-15
 L0 (15):    RETURN int(1)
 
-foo: ; (lines=3, args=0, vars=0, tmps=0)
+foo: ; (lines=2, args=0, vars=0, tmps=0)
     ; (after optimizer)
     ; %ssccp_010.php:2-13
-L0 (10):    ECHO int(1)
-L1 (12):    ECHO int(1)
-L2 (13):    RETURN null
+L0 (12):    ECHO string("11")
+L1 (13):    RETURN null

--- a/ext/opcache/tests/opt/sccp_012.phpt
+++ b/ext/opcache/tests/opt/sccp_012.phpt
@@ -31,9 +31,8 @@ $_main: ; (lines=1, args=0, vars=0, tmps=0)
     ; %ssccp_012.php:1-17
 L0 (17):    RETURN int(1)
 
-foo: ; (lines=3, args=0, vars=0, tmps=0)
+foo: ; (lines=2, args=0, vars=0, tmps=0)
     ; (after optimizer)
     ; %ssccp_012.php:2-15
-L0 (10):    ECHO int(1)
-L1 (14):    ECHO int(4)
-L2 (15):    RETURN null
+L0 (14):    ECHO string("14")
+L1 (15):    RETURN null

--- a/ext/opcache/tests/opt/sccp_026.phpt
+++ b/ext/opcache/tests/opt/sccp_026.phpt
@@ -15,7 +15,7 @@ function test($var) {
         return;
     }
 
-    var_dump($username); 
+    var_dump($username);
 }
 ?>
 --EXPECTF--
@@ -24,15 +24,14 @@ $_main: ; (lines=1, args=0, vars=0, tmps=0)
     ; %s:1-10
 L0 (10):    RETURN int(1)
 
-test: ; (lines=9, args=1, vars=2, tmps=1)
+test: ; (lines=8, args=1, vars=2, tmps=1)
     ; (after optimizer)
     ; %s:2-8
 L0 (2):     CV0($var) = RECV 1
 L1 (3):     T2 = TYPE_CHECK (string) CV0($var)
-L2 (3):     JMPZ T2 L4
-L3 (3):     JMP L5
-L4 (4):     RETURN null
-L5 (7):     INIT_FCALL 1 %d string("var_dump")
-L6 (7):     SEND_VAR CV1($username) 1
-L7 (7):     DO_ICALL
-L8 (8):     RETURN null
+L2 (3):     JMPNZ T2 L4
+L3 (4):     RETURN null
+L4 (7):     INIT_FCALL 1 96 string("var_dump")
+L5 (7):     SEND_VAR CV1($username) 1
+L6 (7):     DO_ICALL
+L7 (8):     RETURN null


### PR DESCRIPTION
Run the Control Flow Graph optimizations again,
**after all of the type inference steps and optimizations (e.g. SCCP) have run.**

Passes run after CFG eliminate various redundant conditions,
infer types and constants for values,
and can also change or remove opcodes,
ensuring that the Control Flow Graph optimizations
can optimize code further,
and lets those passes do transformations
relying on the subsequent optimizations
implemented in the Control Flow Graph code.
(without duplicating the implementation)

This is meant as a proof of concept,
- I'm not sure of the best way to make the debug output
  (e.g. pass numbers) follow conventions.
- I'm not familiar with the data structures used.
  I'm assuming it's safe to run pass 5 at that point.
- There are at most 3 passes on the first run of CFG.
  (see `#define PASSES 3` in block_pass.c)

  Maybe the second run of CFG should have a lower limit.
- I'm not sure if the passes are done only once for a different reason (e.g. correctness, reduce startup time, etc).
  Hopefully, that's not the case (e.g. opcache shared memory cache and file cache help with performance).
  I didn't see any similar proposals after a quick search of PRs/issue trackers for "opcache"/"pass"/"cfg"

Tests were updated:
- CFG can eliminate unnecessary jumps (left over after SCCP removes impossible conditions)
- CFG optimized the calls to ECHO into a single call with a string.

**EDIT: INIT_FCALL seems to have the wrong stack size after this patch, investigating** (https://ci.appveyor.com/project/php/php-src/builds/30241892/job/1swrsqwxnxkcuhkd/tests)
It was previously 192 and 144, and now it's wrong.

```
317+ L2 (126):   INIT_FCALL 1 96 string("test_open_basedir_before")
318+ L3 (126):   SEND_VAR CV0($function) 1
319+ L4 (126):   DO_UCALL
320+ L5 (127):   INIT_FCALL 1 432 string("test_open_basedir_error")
```