### PR TITLE
Drop 'v' format from custom snprintf

### DIFF
--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -961,7 +961,6 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 
 
 				case 's':
-				case 'v':
 					s = va_arg(ap, char *);
 					if (s != NULL) {
 						s_len = strlen(s);


### PR DESCRIPTION
Basing myself on: https://gist.github.com/Girgias/b9a2b9926190630d433c84da0ef1b002

For extensions relying on this format the ``v`` must be changed to the standard ``s`` format.