### PR TITLE
Fix #79146: cscript can fail to run on some systems

### DIFF
--- a/buildconf.bat
+++ b/buildconf.bat
@@ -1,5 +1,5 @@
 @echo off
-cscript /nologo win32\build\buildconf.js %*
+cscript /nologo /e:jscript win32\build\buildconf.js %*
 SET PHP_BUILDCONF_PATH=%~dp0
 copy %PHP_BUILDCONF_PATH%\win32\build\configure.bat %PHP_BUILDCONF_PATH% > nul
 SET PHP_SDK_SCRIPT_PATH=

--- a/win32/build/buildconf.js
+++ b/win32/build/buildconf.js
@@ -256,4 +256,4 @@ C.WriteBlankLines(1);
 C.Write(file_get_contents("win32/build/configure.tail"));
 
 B.WriteLine("@echo off");
-B.WriteLine("cscript /nologo configure.js %*");
+B.WriteLine("cscript /nologo /e:jscript configure.js %*");

--- a/win32/build/configure.bat
+++ b/win32/build/configure.bat
@@ -1,2 +1,2 @@
 @echo off
-cscript /nologo configure.js %*
+cscript /nologo /e:jscript configure.js %*

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -319,7 +319,7 @@ function conf_process_args()
 	var i, j;
 	var configure_help_mode = false;
 	var analyzed = false;
-	var nice = "cscript /nologo configure.js ";
+	var nice = "cscript /nologo /e:jscript configure.js ";
 	var disable_all = false;
 
 	args = WScript.Arguments;

--- a/win32/build/phpize.bat
+++ b/win32/build/phpize.bat
@@ -1,6 +1,6 @@
 @echo off
 SET PHP_BUILDCONF_PATH=%~dp0
-cscript /nologo %PHP_BUILDCONF_PATH%\script\phpize.js %*
+cscript /nologo /e:jscript %PHP_BUILDCONF_PATH%\script\phpize.js %*
 IF NOT EXIST configure.bat (
 	echo Error generating configure script, configure script was not copied
 	exit /b 3

--- a/win32/build/phpize.js.in
+++ b/win32/build/phpize.js.in
@@ -258,6 +258,6 @@ C.WriteBlankLines(1);
 C.Write(file_get_contents(PHP_DIR + "\\script\\configure.tail"));
 
 B.WriteLine("@echo off");
-B.WriteLine("cscript /nologo configure.js %*");
+B.WriteLine("cscript /nologo /e:jscript configure.js %*");
 
 FSO.CopyFile(PHP_DIR + "\\script\\run-tests.php", "run-tests.php", true);


### PR DESCRIPTION
In the buildconf and configure batch files, Windows' cscript utility was being
run without the /e:jscript flag. This works on systems that have not had the
default .js file association changed, but if .js has been re-associated to
(say) an IDE, the batch files fail with the error message:

Input Error: There is no script engine for file extension ".js".

This PR fixes the issue by inserting the neccessary flag.