### PR TITLE
Make quoting of cmd execution functions consistent

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -478,12 +478,12 @@ TSRM_API FILE *popen_ex(const char *command, const char *type, const char *cwd, 
 		return NULL;
 	}
 
-	cmd = (char*)malloc(strlen(command)+strlen(TWG(comspec))+sizeof(" /c ")+2);
+	cmd = (char*)malloc(strlen(command)+strlen(TWG(comspec))+sizeof(" /s /c ")+2);
 	if (!cmd) {
 		return NULL;
 	}
 
-	sprintf(cmd, "%s /c \"%s\"", TWG(comspec), command);
+	sprintf(cmd, "%s /s /c \"%s\"", TWG(comspec), command);
 	cmdw = php_win32_cp_any_to_w(cmd);
 	if (!cmdw) {
 		free(cmd);

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -943,13 +943,13 @@ PHP_FUNCTION(proc_open)
 		wchar_t *cmdw2;
 
 
-		len = (sizeof(COMSPEC_NT) + sizeof(" /c ") + tmp_len + 1);
+		len = (sizeof(COMSPEC_NT) + sizeof(" /s /c ") + tmp_len + 3);
 		cmdw2 = (wchar_t *)malloc(len * sizeof(wchar_t));
 		if (!cmdw2) {
 			php_error_docref(NULL, E_WARNING, "Command conversion failed");
 			goto exit_fail;
 		}
-		ret = _snwprintf(cmdw2, len, L"%hs /c %s", COMSPEC_NT, cmdw);
+		ret = _snwprintf(cmdw2, len, L"%hs /s /c \"%s\"", COMSPEC_NT, cmdw);
 
 		if (-1 == ret) {
 			free(cmdw2);


### PR DESCRIPTION
While the `$command` passed to `proc_open()` had to be wrapped in
double-quotes manually, that was implicitly done for all other
program execution functions.  This could easily introduce bugs and
even security issues when switching from one to another program
execution function.

Furthermore we ensure that the additional quotes are always
unwrapped regardless of what is passed as `$command` by passing
the `/s` flag to cmd.exe.  As it was, `shell_exec('path with
spaces/program.exe')` did execute program.exe, but adding an
argument (`shell_exec('path with spaces/program.exe -h)`) failed
to execute program.exe, because cmd.exe stripped the additional
quotes.

While these changes obviously can cause BC breaks, we feel that in
the long run the benefits of having consistent behavior for all
program execution functions outweighs the drawbacks of potentially
breaking some code now.