### PR TITLE
Remove custom 'p' length modifier from custom snprintf implementation

### DIFF
--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -742,10 +742,6 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 					modifier = LM_SIZE_T;
 #endif
 					break;
-				case 'p':
-					fmt++;
-					modifier = LM_PHP_INT_T;
-					break;
 				case 'h':
 					fmt++;
 					if (*fmt == 'h') {
@@ -810,9 +806,6 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 							i_num = (wide_int) va_arg(ap, ptrdiff_t);
 							break;
 #endif
-						case LM_PHP_INT_T:
-							i_num = (wide_int) va_arg(ap, zend_ulong);
-							break;
 					}
 					/*
 					 * The rest also applies to other integer formats, so fall
@@ -855,9 +848,6 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 								i_num = (wide_int) va_arg(ap, ptrdiff_t);
 								break;
 #endif
-							case LM_PHP_INT_T:
-								i_num = (wide_int) va_arg(ap, zend_long);
-								break;
 						}
 					}
 					s = ap_php_conv_10(i_num, (*fmt) == 'u', &is_negative,
@@ -904,9 +894,6 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 							ui_num = (u_wide_int) va_arg(ap, ptrdiff_t);
 							break;
 #endif
-						case LM_PHP_INT_T:
-							ui_num = (u_wide_int) va_arg(ap, zend_ulong);
-							break;
 					}
 					s = ap_php_conv_p2(ui_num, 3, *fmt, &num_buf[NUM_BUF_SIZE], &s_len);
 					FIX_PRECISION(adjust_precision, precision, s, s_len);
@@ -946,9 +933,6 @@ static int format_converter(register buffy * odp, const char *fmt, va_list ap) /
 							ui_num = (u_wide_int) va_arg(ap, ptrdiff_t);
 							break;
 #endif
-						case LM_PHP_INT_T:
-							ui_num = (u_wide_int) va_arg(ap, zend_ulong);
-							break;
 					}
 					s = ap_php_conv_p2(ui_num, 4, *fmt, &num_buf[NUM_BUF_SIZE], &s_len);
 					FIX_PRECISION(adjust_precision, precision, s, s_len);

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -361,16 +361,6 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 					modifier = LM_SIZE_T;
 #endif
 					break;
-				case 'p': {
-						char __next = *(fmt+1);
-						if ('d' == __next || 'u' == __next || 'x' == __next || 'o' == __next) {
-							fmt++;
-							modifier = LM_PHP_INT_T;
-						} else {
-							modifier = LM_STD;
-						}
-					}
-					break;
 				case 'h':
 					fmt++;
 					if (*fmt == 'h') {
@@ -435,9 +425,6 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 							i_num = (wide_int) va_arg(ap, ptrdiff_t);
 							break;
 #endif
-						case LM_PHP_INT_T:
-							i_num = (wide_int) va_arg(ap, zend_ulong);
-							break;
 					}
 					/*
 					 * The rest also applies to other integer formats, so fall
@@ -480,9 +467,6 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 								i_num = (wide_int) va_arg(ap, ptrdiff_t);
 								break;
 #endif
-							case LM_PHP_INT_T:
-								i_num = (wide_int) va_arg(ap, zend_long);
-								break;
 						}
 					}
 					s = ap_php_conv_10(i_num, (*fmt) == 'u', &is_negative,
@@ -528,9 +512,6 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 							ui_num = (u_wide_int) va_arg(ap, ptrdiff_t);
 							break;
 #endif
-						case LM_PHP_INT_T:
-							ui_num = (u_wide_int) va_arg(ap, zend_ulong);
-							break;
 					}
 					s = ap_php_conv_p2(ui_num, 3, *fmt,
 								&num_buf[NUM_BUF_SIZE], &s_len);
@@ -571,9 +552,6 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 							ui_num = (u_wide_int) va_arg(ap, ptrdiff_t);
 							break;
 #endif
-						case LM_PHP_INT_T:
-							ui_num = (u_wide_int) va_arg(ap, zend_ulong);
-							break;
 					}
 					s = ap_php_conv_p2(ui_num, 4, *fmt,
 								&num_buf[NUM_BUF_SIZE], &s_len);


### PR DESCRIPTION
From my understanding this gives a ``zend_long`` representation, however it seems to be unused going from this grep search: https://gist.github.com/Girgias/06253c18fde29af25ed50b29c0d8da38

Possibly because the long format macros also take care of this modifier? Or maybe it's just mostly used in conjunction with ``spprintf`` (which I'll need to make a separate search for).

(Drive by the mysqlnd usage seems to suggest to output a pointer which we don't really support fully from my understanding).