### PR TITLE
Fix #78969 Add password_default_algo() function

### DIFF
--- a/ext/sodium/sodium_pwhash.c
+++ b/ext/sodium/sodium_pwhash.c
@@ -113,7 +113,7 @@ static zend_bool php_sodium_argon2_needs_rehash(const zend_string *hash, zend_ar
 
 static int php_sodium_argon2_get_info(zval *return_value, const zend_string *hash) {
 	const char* p = NULL;
-	zend_long v = 0, threads = 1;
+	zend_long v = 0, threads = PHP_SODIUM_PWHASH_THREADS;
 	zend_long memory_cost = PHP_SODIUM_PWHASH_MEMLIMIT;
 	zend_long time_cost = PHP_SODIUM_PWHASH_OPSLIMIT;
 
@@ -140,6 +140,12 @@ static int php_sodium_argon2_get_info(zval *return_value, const zend_string *has
 	return SUCCESS;
 }
 
+static void php_sodium_argon2_get_default_options(zval *return_value) {
+	add_assoc_long(return_value, "memory_cost", PHP_SODIUM_PWHASH_MEMLIMIT);
+	add_assoc_long(return_value, "time_cost", PHP_SODIUM_PWHASH_OPSLIMIT);
+	add_assoc_long(return_value, "threads", PHP_SODIUM_PWHASH_THREADS);
+}
+
 /* argon2i specific methods */
 
 static zend_string *php_sodium_argon2i_hash(const zend_string *password, zend_array *options) {
@@ -148,11 +154,13 @@ static zend_string *php_sodium_argon2i_hash(const zend_string *password, zend_ar
 
 static const php_password_algo sodium_algo_argon2i = {
 	"argon2i",
+	"argon2i",
 	php_sodium_argon2i_hash,
 	php_sodium_argon2_verify,
 	php_sodium_argon2_needs_rehash,
 	php_sodium_argon2_get_info,
 	NULL,
+	php_sodium_argon2_get_default_options,
 };
 
 /* argon2id specific methods */
@@ -163,11 +171,13 @@ static zend_string *php_sodium_argon2id_hash(const zend_string *password, zend_a
 
 static const php_password_algo sodium_algo_argon2id = {
 	"argon2id",
+	"argon2id",
 	php_sodium_argon2id_hash,
 	php_sodium_argon2_verify,
 	php_sodium_argon2_needs_rehash,
 	php_sodium_argon2_get_info,
 	NULL,
+	php_sodium_argon2_get_default_options,
 };
 
 PHP_MINIT_FUNCTION(sodium_password_hash) /* {{{ */ {
@@ -180,12 +190,12 @@ PHP_MINIT_FUNCTION(sodium_password_hash) /* {{{ */ {
 	}
 	zend_string_release(argon2i);
 
-	if (FAILURE == php_password_algo_register("argon2i", &sodium_algo_argon2i)) {
+	if (FAILURE == php_password_algo_register(&sodium_algo_argon2i)) {
 		return FAILURE;
 	}
 	REGISTER_STRING_CONSTANT("PASSWORD_ARGON2I", "argon2i", CONST_CS | CONST_PERSISTENT);
 
-	if (FAILURE == php_password_algo_register("argon2id", &sodium_algo_argon2id)) {
+	if (FAILURE == php_password_algo_register(&sodium_algo_argon2id)) {
 		return FAILURE;
 	}
 	REGISTER_STRING_CONSTANT("PASSWORD_ARGON2ID", "argon2id", CONST_CS | CONST_PERSISTENT);

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -315,6 +315,7 @@ static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(password_needs_rehash,											arginfo_password_needs_rehash)
 	PHP_FE(password_verify,													arginfo_password_verify)
 	PHP_FE(password_algos,													arginfo_password_algos)
+	PHP_FE(password_default_algo,											arginfo_password_default_algo)
 	PHP_FE(convert_uuencode,												arginfo_convert_uuencode)
 	PHP_FE(convert_uudecode,												arginfo_convert_uudecode)
 

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1131,6 +1131,8 @@ function password_verify(string $password, string $hash): bool {}
 
 function password_algos(): array {}
 
+function password_default_algo(): array {}
+
 /* proc_open.c */
 
 #ifdef PHP_CAN_SUPPORT_PROC_OPEN

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1760,6 +1760,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_password_algos arginfo_ob_list_handlers
 
+#define arginfo_password_default_algo arginfo_ob_list_handlers
+
 #if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_proc_open, 0, 0, 3)
 	ZEND_ARG_INFO(0, cmd)

--- a/ext/standard/php_password.h
+++ b/ext/standard/php_password.h
@@ -23,6 +23,7 @@ PHP_FUNCTION(password_verify);
 PHP_FUNCTION(password_needs_rehash);
 PHP_FUNCTION(password_get_info);
 PHP_FUNCTION(password_algos);
+PHP_FUNCTION(password_default_algo);
 
 PHP_MINIT_FUNCTION(password);
 PHP_MSHUTDOWN_FUNCTION(password);
@@ -41,12 +42,14 @@ PHP_MSHUTDOWN_FUNCTION(password);
 #endif
 
 typedef struct _php_password_algo {
+	const char *id;
 	const char *name;
 	zend_string *(*hash)(const zend_string *password, zend_array *options);
 	zend_bool (*verify)(const zend_string *password, const zend_string *hash);
 	zend_bool (*needs_rehash)(const zend_string *password, zend_array *options);
 	int (*get_info)(zval *return_value, const zend_string *hash);
 	zend_bool (*valid)(const zend_string *hash);
+	void (*get_default_options)(zval *return_value);
 } php_password_algo;
 
 extern const php_password_algo php_password_algo_bcrypt;
@@ -55,7 +58,7 @@ extern const php_password_algo php_password_algo_argon2i;
 extern const php_password_algo php_password_algo_argon2id;
 #endif
 
-PHPAPI int php_password_algo_register(const char*, const php_password_algo*);
+PHPAPI int php_password_algo_register(const php_password_algo*);
 PHPAPI void php_password_algo_unregister(const char*);
 PHPAPI const php_password_algo* php_password_algo_default();
 PHPAPI zend_string *php_password_algo_extract_ident(const zend_string*);

--- a/ext/standard/tests/password/password_default_algo.phpt
+++ b/ext/standard/tests/password/password_default_algo.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test password_default_algo()
+--FILE--
+<?php
+// Test Bcrypt
+var_dump(password_default_algo());
+--EXPECT--
+array(3) {
+  ["algo"]=>
+  string(2) "2y"
+  ["algoName"]=>
+  string(6) "bcrypt"
+  ["options"]=>
+  array(1) {
+    ["cost"]=>
+    int(10)
+  }
+}


### PR DESCRIPTION
I think it makes sense adding a way for users to determine the actual default password hashing algorithm.

I chose `password_default_algo()` to return not just the algorithm's name, but the ID too (which are different in case of Bcrypt). I think it is worth to return the default options as well. This way, `password_default_algo()` will be in line with the data structure returned by `password_get_info()`.