### PR TITLE
Fix #78969 PASSWORD_DEFAULT should match PASSWORD_BCRYPT instead of being null

### DIFF
--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -496,7 +496,7 @@ const php_password_algo php_password_algo_argon2id = {
 PHP_MINIT_FUNCTION(password) /* {{{ */
 {
 	zend_hash_init(&php_password_algos, 4, NULL, ZVAL_PTR_DTOR, 1);
-	REGISTER_NULL_CONSTANT("PASSWORD_DEFAULT", CONST_CS | CONST_PERSISTENT);
+	REGISTER_STRING_CONSTANT("PASSWORD_DEFAULT", "2y", CONST_CS | CONST_PERSISTENT);
 
 	if (FAILURE == php_password_algo_register("2y", &php_password_algo_bcrypt)) {
 		return FAILURE;

--- a/ext/standard/tests/password/password_default.phpt
+++ b/ext/standard/tests/password/password_default.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Test that the value of PASSWORD_DEFAULT matches PASSWORD_BCRYPT
+--FILE--
+<?php
+echo PASSWORD_DEFAULT . "\n";
+echo PASSWORD_BCRYPT . "\n";
+--EXPECT--
+2y
+2y


### PR DESCRIPTION
This is to supersede #5104 in order to fix the real issue.