### PR TITLE
Remove custom 'v' spprintf format and 'I' length modifier

### DIFF
--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -312,25 +312,6 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 					fmt++;
 					modifier = LM_LONG_DOUBLE;
 					break;
-				case 'I':
-					fmt++;
-#if SIZEOF_LONG_LONG
-					if (*fmt == '6' && *(fmt+1) == '4') {
-						fmt += 2;
-						modifier = LM_LONG_LONG;
-					} else
-#endif
-						if (*fmt == '3' && *(fmt+1) == '2') {
-							fmt += 2;
-							modifier = LM_LONG;
-						} else {
-#ifdef _WIN64
-							modifier = LM_LONG_LONG;
-#else
-							modifier = LM_LONG;
-#endif
-						}
-					break;
 				case 'l':
 					fmt++;
 #if SIZEOF_LONG_LONG

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -587,7 +587,6 @@ static void xbuf_format_converter(void *xbuf, zend_bool is_char, const char *fmt
 
 
 				case 's':
-				case 'v':
 					s = va_arg(ap, char *);
 					if (s != NULL) {
 						if (!adjust_precision) {


### PR DESCRIPTION
Mimicking from the changes made to `snprintf`

Grep search: https://gist.github.com/Girgias/f03ae14ffa5f2f8bc8ae81ef66b06743