### PR TITLE
Allow empty needle in mb_strrchr()

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2266,13 +2266,6 @@ PHP_FUNCTION(mb_strrchr)
 		RETURN_FALSE;
 	}
 
-	if (haystack.len == 0) {
-		RETURN_FALSE;
-	}
-	if (needle.len == 0) {
-		RETURN_FALSE;
-	}
-
 	n = mbfl_strpos(&haystack, &needle, 0, 1);
 	if (!mbfl_is_error(n)) {
 		if (part) {

--- a/ext/mbstring/tests/mb_strrchr_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strrchr_empty_needle.phpt
@@ -15,23 +15,23 @@ $string_ascii = 'abc def';
 $string_mb = "日本語テキストです。01234５６７８９。";
 
 echo "\n-- ASCII string --\n";
-var_dump(bin2hex(mb_strrchr($string_ascii, '', false, 'ISO-8859-1')));
-var_dump(bin2hex(mb_strrchr($string_ascii, '')));
-var_dump(bin2hex(mb_strrchr($string_ascii, '', true)));
+var_dump(mb_strrchr($string_ascii, '', false, 'ISO-8859-1'));
+var_dump(mb_strrchr($string_ascii, ''));
+var_dump(mb_strrchr($string_ascii, '', true));
 
 echo "\n-- Multibyte string --\n";
-var_dump(bin2hex(mb_strrchr($string_mb, '')));
-var_dump(bin2hex(mb_strrchr($string_mb, '', false, 'utf-8')));
-var_dump(bin2hex(mb_strrchr($string_mb, '', true)));
+var_dump(mb_strrchr($string_mb, ''));
+var_dump(mb_strrchr($string_mb, '', false, 'utf-8'));
+var_dump(mb_strrchr($string_mb, '', true));
 
 ?>
 --EXPECT--
 -- ASCII string --
 string(0) ""
 string(0) ""
-string(0) ""
+string(7) "abc def"
 
 -- Multibyte string --
 string(0) ""
 string(0) ""
-string(0) ""
+string(53) "日本語テキストです。01234５６７８９。"


### PR DESCRIPTION
Just as a sanity check this is the expected result for ``mb_strrchr`` with an empty needle @nikic ?