### PR TITLE
Add CURLOPT CURLOPT_HTTP09_ALLOWED available since 7.64.0

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2262,7 +2262,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 		case CURLOPT_DISALLOW_USERNAME_IN_URL:
 #endif
 #if LIBCURL_VERSION_NUM >= 0x074000 /* Available since 7.64.0 */
-		case CURLOPT_DISALLOW_USERNAME_IN_URL:
+		case CURLOPT_HTTP09_ALLOWED:
 #endif
 			lval = zval_get_long(zvalue);
 			if ((option == CURLOPT_PROTOCOLS || option == CURLOPT_REDIR_PROTOCOLS) &&

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1192,6 +1192,10 @@ PHP_MINIT_FUNCTION(curl)
 	REGISTER_CURL_CONSTANT(CURLOPT_TLS13_CIPHERS);
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x074000 /* Available since 7.64.0 */
+	REGISTER_CURL_CONSTANT(CURLOPT_HTTP09_ALLOWED);
+#endif
+
 #if LIBCURL_VERSION_NUM >= 0x074001 /* Available since 7.64.1 */
 	REGISTER_CURL_CONSTANT(CURL_VERSION_ALTSVC);
 #endif
@@ -2255,6 +2259,9 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 		case CURLOPT_HAPROXYPROTOCOL:
 #endif
 #if LIBCURL_VERSION_NUM >= 0x073d00 /* Available since 7.61.0 */
+		case CURLOPT_DISALLOW_USERNAME_IN_URL:
+#endif
+#if LIBCURL_VERSION_NUM >= 0x074000 /* Available since 7.64.0 */
 		case CURLOPT_DISALLOW_USERNAME_IN_URL:
 #endif
 			lval = zval_get_long(zvalue);


### PR DESCRIPTION
Without this change it's no longer possible to connect to HTTP/0.9 services when using curl >= 7.64.0