### PR TITLE
Fix #79177 Check for undefined result in zend_ffi_callback_trampoline.

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -878,7 +878,7 @@ static void zend_ffi_callback_trampoline(ffi_cif* cif, void* ret, void** args, v
 	free_alloca(fci.params, use_heap);
 
 	ret_type = ZEND_FFI_TYPE(callback_data->type->func.ret_type);
-	if (ret_type->kind != ZEND_FFI_TYPE_VOID) {
+	if (ret_type->kind != ZEND_FFI_TYPE_VOID && Z_TYPE(retval) != IS_UNDEF) {
 		zend_ffi_zval_to_cdata(ret, ret_type, &retval);
 	}
 }

--- a/ext/ffi/tests/bug79177.phpt
+++ b/ext/ffi/tests/bug79177.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #79177 (FFI doesn't handle well PHP exceptions within callback body)
+--SKIPIF--
+<?php require_once('skipif.inc');?>
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+
+use FFI\CData;
+
+$php = FFI::cdef("
+typedef unsigned int fake_struct;
+typedef fake_struct* (*zend_write_func_t)(const char *str, size_t str_length);
+extern zend_write_func_t zend_write;
+");
+
+$originalHandler = clone $php->zend_write;
+$php->zend_write = function($str, $len): CData {
+    throw new \RuntimeException('Not allowed');
+};
+try {
+    echo "After", PHP_EOL;
+} catch (\Throwable $exception) {
+    // Do not output anything here, as handler is overridden
+} finally {
+    $php->zend_write = $originalHandler;
+}
+echo get_class($exception), ': ', $exception->getMessage(), PHP_EOL;
+?>
+--EXPECT--
+RuntimeException: Not allowed


### PR DESCRIPTION
This situation can happen when userland exception is thrown within callback body.