### PR TITLE
Fix #78666 mysqli_options generates Warning on var_dump()

### DIFF
--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -69,7 +69,7 @@ zend_class_entry *mysqli_warning_class_entry;
 zend_class_entry *mysqli_exception_class_entry;
 
 
-typedef zval *(*mysqli_read_t)(mysqli_object *obj, zval *rv);
+typedef int (*mysqli_read_t)(mysqli_object *obj, zval *rv, zend_bool quiet);
 typedef int (*mysqli_write_t)(mysqli_object *obj, zval *newval);
 
 typedef struct _mysqli_prop_handler {
@@ -281,10 +281,11 @@ static void mysqli_warning_free_storage(zend_object *object)
 /* }}} */
 
 /* {{{ mysqli_read_na */
-static zval *mysqli_read_na(mysqli_object *obj, zval *retval)
+static int mysqli_read_na(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
 	zend_throw_error(NULL, "Cannot read property");
-	return NULL;
+
+	return FAILURE;
 }
 /* }}} */
 
@@ -292,6 +293,7 @@ static zval *mysqli_read_na(mysqli_object *obj, zval *retval)
 static int mysqli_write_na(mysqli_object *obj, zval *newval)
 {
 	zend_throw_error(NULL, "Cannot write property");
+
 	return FAILURE;
 }
 /* }}} */
@@ -320,9 +322,14 @@ zval *mysqli_read_property(zval *object, zval *member, int type, void **cache_sl
 	}
 
 	if (hnd) {
-		retval = hnd->read_func(obj, rv);
-		if (retval == NULL) {
-			retval = &EG(uninitialized_zval);
+		if (hnd->read_func(obj, rv, type == BP_VAR_IS) == SUCCESS && rv != NULL) {
+			retval = rv;
+		} else {
+			if (type == BP_VAR_IS || rv == NULL) {
+				retval = &EG(uninitialized_zval);
+			} else {
+				retval = rv;
+			}
 		}
 	} else {
 		retval = zend_std_read_property(object, member, type, cache_slot, rv);
@@ -435,6 +442,7 @@ HashTable *mysqli_object_get_debug_info(zval *object, int *is_temp)
 		zval rv, member;
 		zval *value;
 		ZVAL_STR(&member, entry->name);
+
 		value = mysqli_read_property(object, &member, BP_VAR_IS, 0, &rv);
 		if (value != &EG(uninitialized_zval)) {
 			zend_hash_add(retval, Z_STR(member), value);

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -283,7 +283,9 @@ static void mysqli_warning_free_storage(zend_object *object)
 /* {{{ mysqli_read_na */
 static int mysqli_read_na(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
-	zend_throw_error(NULL, "Cannot read property");
+	if (!quiet) {
+		zend_throw_error(NULL, "Cannot read property");
+	}
 
 	return FAILURE;
 }
@@ -322,14 +324,10 @@ zval *mysqli_read_property(zval *object, zval *member, int type, void **cache_sl
 	}
 
 	if (hnd) {
-		if (hnd->read_func(obj, rv, type == BP_VAR_IS) == SUCCESS && rv != NULL) {
+		if (hnd->read_func(obj, rv, type == BP_VAR_IS) == SUCCESS || type != BP_VAR_IS) {
 			retval = rv;
 		} else {
-			if (type == BP_VAR_IS || rv == NULL) {
-				retval = &EG(uninitialized_zval);
-			} else {
-				retval = rv;
-			}
+			retval = &EG(uninitialized_zval);
 		}
 	} else {
 		retval = zend_std_read_property(object, member, type, cache_slot, rv);

--- a/ext/mysqli/mysqli_driver.c
+++ b/ext/mysqli/mysqli_driver.c
@@ -30,10 +30,10 @@
 #include "mysqli_fe.h"
 
 #define MAP_PROPERTY_MYG_BOOL_READ(name, value) \
-static zval *name(mysqli_object *obj, zval *retval) \
+static int name(mysqli_object *obj, zval *retval, zend_bool quiet) \
 { \
 	ZVAL_BOOL(retval, MyG(value)); \
-	return retval; \
+	return SUCCESS; \
 } \
 
 #define MAP_PROPERTY_MYG_BOOL_WRITE(name, value) \
@@ -44,10 +44,10 @@ static int name(mysqli_object *obj, zval *value) \
 } \
 
 #define MAP_PROPERTY_MYG_LONG_READ(name, value) \
-static zval *name(mysqli_object *obj, zval *retval) \
+static int name(mysqli_object *obj, zval *retval, zend_bool quiet) \
 { \
 	ZVAL_LONG(retval, MyG(value)); \
-	return retval; \
+	return SUCCESS; \
 } \
 
 #define MAP_PROPERTY_MYG_LONG_WRITE(name, value) \
@@ -58,10 +58,10 @@ static int name(mysqli_object *obj, zval *value) \
 } \
 
 #define MAP_PROPERTY_MYG_STRING_READ(name, value) \
-static zval *name(mysqli_object *obj, zval *retval) \
+static int name(mysqli_object *obj, zval *retval, zend_bool quiet) \
 { \
 	ZVAL_STRING(retval, MyG(value)); \
-	return retval; \
+	return SUCESS; \
 } \
 
 #define MAP_PROPERTY_MYG_STRING_WRITE(name, value) \
@@ -82,34 +82,38 @@ static int driver_report_write(mysqli_object *obj, zval *value)
 /* }}} */
 
 /* {{{ property driver_embedded_read */
-static zval *driver_embedded_read(mysqli_object *obj, zval *retval)
+static int driver_embedded_read(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
 	ZVAL_FALSE(retval);
-	return retval;
+
+	return SUCCESS;
 }
 /* }}} */
 
 /* {{{ property driver_client_version_read */
-static zval *driver_client_version_read(mysqli_object *obj, zval *retval)
+static int driver_client_version_read(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
 	ZVAL_LONG(retval, MYSQL_VERSION_ID);
-	return retval;
+
+	return SUCCESS;
 }
 /* }}} */
 
 /* {{{ property driver_client_info_read */
-static zval *driver_client_info_read(mysqli_object *obj, zval *retval)
+static int driver_client_info_read(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
 	ZVAL_STRING(retval, (char *)mysql_get_client_info());
-	return retval;
+
+	return SUCCESS;
 }
 /* }}} */
 
 /* {{{ property driver_driver_version_read */
-static zval *driver_driver_version_read(mysqli_object *obj, zval *retval)
+static int driver_driver_version_read(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
 	ZVAL_LONG(retval, MYSQLI_VERSION_ID);
-	return retval;
+
+	return SUCCESS;
 }
 /* }}} */
 

--- a/ext/mysqli/mysqli_driver.c
+++ b/ext/mysqli/mysqli_driver.c
@@ -61,7 +61,7 @@ static int name(mysqli_object *obj, zval *value) \
 static int name(mysqli_object *obj, zval *retval, zend_bool quiet) \
 { \
 	ZVAL_STRING(retval, MyG(value)); \
-	return SUCESS; \
+	return SUCCESS; \
 } \
 
 #define MAP_PROPERTY_MYG_STRING_WRITE(name, value) \

--- a/ext/mysqli/mysqli_warning.c
+++ b/ext/mysqli/mysqli_warning.c
@@ -199,49 +199,50 @@ PHP_METHOD(mysqli_warning, next)
 /* }}} */
 
 /* {{{ property mysqli_warning_message */
-static
-zval *mysqli_warning_message(mysqli_object *obj, zval *retval)
+static int mysqli_warning_message(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
 	MYSQLI_WARNING *w;
 
 	if (!obj->ptr || !((MYSQLI_RESOURCE *)(obj->ptr))->ptr) {
-		return NULL;
+		return FAILURE;
 	}
 
 	w = (MYSQLI_WARNING *)((MYSQLI_RESOURCE *)(obj->ptr))->ptr;
 	ZVAL_COPY(retval, &w->reason);
-	return retval;
+
+	return SUCCESS;
 }
 /* }}} */
 
 /* {{{ property mysqli_warning_sqlstate */
-static
-zval *mysqli_warning_sqlstate(mysqli_object *obj, zval *retval)
+static int mysqli_warning_sqlstate(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
 	MYSQLI_WARNING *w;
 
 	if (!obj->ptr || !((MYSQLI_RESOURCE *)(obj->ptr))->ptr) {
-		return NULL;
+		return FAILURE;
 	}
 
 	w = (MYSQLI_WARNING *)((MYSQLI_RESOURCE *)(obj->ptr))->ptr;
 	ZVAL_COPY(retval, &w->sqlstate);
-	return retval;
+
+	return SUCCESS;
 }
 /* }}} */
 
 /* {{{ property mysqli_warning_error */
-static
-zval *mysqli_warning_errno(mysqli_object *obj, zval *retval)
+static int mysqli_warning_errno(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
 	MYSQLI_WARNING *w;
 
 	if (!obj->ptr || !((MYSQLI_RESOURCE *)(obj->ptr))->ptr) {
-		return NULL;
+		return FAILURE;
 	}
+
 	w = (MYSQLI_WARNING *)((MYSQLI_RESOURCE *)(obj->ptr))->ptr;
 	ZVAL_LONG(retval, w->errorno);
-	return retval;
+
+	return SUCCESS;
 }
 /* }}} */
 

--- a/ext/mysqli/mysqli_warning.c
+++ b/ext/mysqli/mysqli_warning.c
@@ -204,6 +204,11 @@ static int mysqli_warning_message(mysqli_object *obj, zval *retval, zend_bool qu
 	MYSQLI_WARNING *w;
 
 	if (!obj->ptr || !((MYSQLI_RESOURCE *)(obj->ptr))->ptr) {
+		if (!quiet) {
+			php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", ZSTR_VAL(obj->zo.ce->name));
+		}
+		ZVAL_NULL(retval);
+
 		return FAILURE;
 	}
 
@@ -220,6 +225,11 @@ static int mysqli_warning_sqlstate(mysqli_object *obj, zval *retval, zend_bool q
 	MYSQLI_WARNING *w;
 
 	if (!obj->ptr || !((MYSQLI_RESOURCE *)(obj->ptr))->ptr) {
+		if (!quiet) {
+			php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", ZSTR_VAL(obj->zo.ce->name));
+		}
+		ZVAL_NULL(retval);
+
 		return FAILURE;
 	}
 
@@ -236,6 +246,11 @@ static int mysqli_warning_errno(mysqli_object *obj, zval *retval, zend_bool quie
 	MYSQLI_WARNING *w;
 
 	if (!obj->ptr || !((MYSQLI_RESOURCE *)(obj->ptr))->ptr) {
+		if (!quiet) {
+			php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", ZSTR_VAL(obj->zo.ce->name));
+		}
+		ZVAL_NULL(retval);
+
 		return FAILURE;
 	}
 

--- a/ext/mysqli/php_mysqli_structs.h
+++ b/ext/mysqli/php_mysqli_structs.h
@@ -158,7 +158,7 @@ struct st_mysqli_warning {
 typedef struct _mysqli_property_entry {
 	const char *pname;
 	size_t pname_length;
-	zval *(*r_func)(mysqli_object *obj, zval *retval);
+	int (*r_func)(mysqli_object *obj, zval *retval, zend_bool quiet);
 	int (*w_func)(mysqli_object *obj, zval *value);
 } mysqli_property_entry;
 

--- a/ext/mysqli/tests/bug28817.phpt
+++ b/ext/mysqli/tests/bug28817.phpt
@@ -22,7 +22,7 @@ require_once('skipifconnectfailure.inc');
 	$mysql = new my_mysql();
 
 	var_dump($mysql->p_test);
-	@var_dump($mysql->errno);
+	var_dump($mysql->errno);
 
 	$mysql->connect($host, $user, $passwd, $db, $port, $socket);
 	$mysql->select_db("nonexistingdb");
@@ -38,5 +38,7 @@ array(2) {
   [1]=>
   %s(3) "bar"
 }
+
+Warning: main(): Couldn't fetch my_mysql in %s on line %d
 bool(false)
 bool(true)

--- a/ext/mysqli/tests/bug34810.phpt
+++ b/ext/mysqli/tests/bug34810.phpt
@@ -16,8 +16,7 @@ class DbConnection {
 		var_dump($link);
 
 		$link = mysqli_init();
-		/* @ is to suppress 'Property access is not allowed yet' */
-		@var_dump($link);
+        var_dump($link);
 
 		$mysql = new my_mysqli($host, $user, $passwd, $db, $port, $socket);
 		$mysql->query("DROP TABLE IF EXISTS test_warnings");
@@ -36,8 +35,6 @@ class DbConnection {
 
 			if ("" == $warning->message)
 				printf("[004] Message string must not be empty\n");
-
-
 		} else {
 			printf("[002] Empty error message!\n");
 			var_dump($warning);
@@ -102,8 +99,6 @@ object(mysqli)#%d (%d) {
   int(0)
 }
 object(mysqli)#%d (%d) {
-  ["affected_rows"]=>
-  bool(false)
   ["client_info"]=>
   string(%d) "%s"
   ["client_version"]=>
@@ -116,27 +111,5 @@ object(mysqli)#%d (%d) {
   int(0)
   ["error"]=>
   string(0) ""
-  ["error_list"]=>
-  bool(false)
-  ["field_count"]=>
-  bool(false)
-  ["host_info"]=>
-  bool(false)
-  ["info"]=>
-  bool(false)
-  ["insert_id"]=>
-  bool(false)
-  ["server_info"]=>
-  bool(false)
-  ["server_version"]=>
-  bool(false)
-  ["sqlstate"]=>
-  bool(false)
-  ["protocol_version"]=>
-  bool(false)
-  ["thread_id"]=>
-  bool(false)
-  ["warning_count"]=>
-  bool(false)
 }
 Done

--- a/ext/mysqli/tests/mysqli_real_connect.phpt
+++ b/ext/mysqli/tests/mysqli_real_connect.phpt
@@ -138,7 +138,7 @@ mysqli.allow_local_infile=1
 	}
 
 	mysqli_close($link);
-	@var_dump($link);
+	var_dump($link);
 
 	if ($IS_MYSQLND) {
 		ini_set('mysqli.default_host', 'p:' . $host);
@@ -179,42 +179,12 @@ mysqli.allow_local_infile=1
 --EXPECTF--
 Warning: mysqli_real_connect(): (%s/%d): Access denied for user '%s'@'%s' (using password: YES) in %s on line %d
 object(mysqli)#%d (%d) {
-  ["affected_rows"]=>
-  bool(false)
-  ["client_info"]=>
-  %s
   ["client_version"]=>
   int(%d)
   ["connect_errno"]=>
   int(%d)
   ["connect_error"]=>
   NULL
-  ["errno"]=>
-  %s
-  ["error"]=>
-  %s
-  ["error_list"]=>
-  bool(false)
-  ["field_count"]=>
-  bool(false)
-  ["host_info"]=>
-  bool(false)
-  ["info"]=>
-  bool(false)
-  ["insert_id"]=>
-  bool(false)
-  ["server_info"]=>
-  bool(false)
-  ["server_version"]=>
-  bool(false)
-  ["sqlstate"]=>
-  bool(false)
-  ["protocol_version"]=>
-  bool(false)
-  ["thread_id"]=>
-  bool(false)
-  ["warning_count"]=>
-  bool(false)
 }
 
 Warning: mysqli_real_connect(): Couldn't fetch mysqli in %s on line %d

--- a/ext/mysqli/tests/mysqli_result_references.phpt
+++ b/ext/mysqli/tests/mysqli_result_references.phpt
@@ -129,17 +129,7 @@ array(7) refcount(2){
     &int(4)
   }
   [6]=>
-  &object(mysqli_result)#%d (5) refcount(%d){
-    ["current_field"]=>
-    NULL
-    ["field_count"]=>
-    NULL
-    ["lengths"]=>
-    bool(false)
-    ["num_rows"]=>
-    NULL
-    ["type"]=>
-    bool(false)
+  &object(mysqli_result)#%d (0) refcount(%d){
   }
 }
 array(1) refcount(2){

--- a/ext/mysqli/tests/mysqli_result_references.phpt
+++ b/ext/mysqli/tests/mysqli_result_references.phpt
@@ -59,7 +59,7 @@ require_once('skipifconnectfailure.inc');
 
 	$references[$idx++] = &$res;
 	mysqli_free_result($res);
-	@debug_zval_dump($references);
+	debug_zval_dump($references);
 
 	if (!(mysqli_real_query($link, "SELECT id, label FROM test ORDER BY id ASC LIMIT 1")) ||
 			!($res = mysqli_use_result($link)))


### PR DESCRIPTION
Split off from https://github.com/php/php-src/pull/5058

If changing the signature of mysqli functions is too late for PHP 7.4, I can switch the base branch to master.

There is one test that fails (bug54221.phpt), but I can't find out exactly why...