### PR TITLE
Use `%define parse.error verbose` instead of `YYERROR_VERBOSE`

### DIFF
--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -1,3 +1,4 @@
+%require "3.0"
 %{
 /*
    +----------------------------------------------------------------------+
@@ -31,7 +32,6 @@
 #include "win32/syslog.h"
 #endif
 
-#define YYERROR_VERBOSE
 #define YYSTYPE zval
 
 int ini_parse(void);
@@ -290,6 +290,7 @@ static void zval_ini_dtor(zval *zv)
 
 %expect 0
 %define api.pure full
+%define parse.error verbose
 
 %token TC_SECTION
 %token TC_RAW

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1,3 +1,4 @@
+%require "3.0"
 %{
 /*
    +----------------------------------------------------------------------+
@@ -32,7 +33,6 @@
 #define yytnamerr zend_yytnamerr
 static YYSIZE_T zend_yytnamerr(char*, const char*);
 
-#define YYERROR_VERBOSE
 #define YYSTYPE zend_parser_stack_elem
 
 #ifdef _MSC_VER
@@ -43,6 +43,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %}
 
 %define api.pure full
+%define parse.error verbose
 %expect 0
 
 %code requires {


### PR DESCRIPTION
The `YYERROR_VERBOSE` macro will no longer be supported in Bison 3.6.
It was superseded by the `%error-verbose` directive in Bison 1.875 (2003-01-01).  Bison 2.6 (2012-07-19) clearly announced that support for `YYERROR_VERBOSE` would be removed.  Note that since Bison 3.0 (2013-07-25), `%error-verbose` is deprecated in favor of `%define parse.error verbose`.