### PR TITLE
fix cross compilation failure due to size_t typecast in define

### DIFF
--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -27,12 +27,12 @@
 #include "zend.h"
 
 #ifndef ZEND_MM_ALIGNMENT
-# define ZEND_MM_ALIGNMENT ((size_t) 8)
+# define ZEND_MM_ALIGNMENT Z_L(8)
 # define ZEND_MM_ALIGNMENT_LOG2 Z_L(3)
 #elif ZEND_MM_ALIGNMENT < 4
 # undef ZEND_MM_ALIGNMENT
 # undef ZEND_MM_ALIGNMENT_LOG2
-# define ZEND_MM_ALIGNMENT ((size_t) 4)
+# define ZEND_MM_ALIGNMENT Z_L(4)
 # define ZEND_MM_ALIGNMENT_LOG2 Z_L(2)
 #endif
 


### PR DESCRIPTION
The following commit introduces a cross-compilation failure:

   93c728b77cfb47f5cfdd1863f8982ea59d344205
  "Try to control ZEND_MM_ALIGNED_SIZE type"

```
br-arm-full/build/php-7.4.2/Zend/zend_alloc.h:30:38:
error: missing binary operator before token "8"
 # define ZEND_MM_ALIGNMENT ((size_t) 8)
                                      ^
br-arm-full/build/php-7.4.2/ext/opcache/ZendAccelerator.c:1380:7:
note: in expansion of macro ‘ZEND_MM_ALIGNMENT’
 #elif ZEND_MM_ALIGNMENT < 8
```