### PR TITLE
Add Windows support for caching_sha2_password

### DIFF
--- a/ext/mysqlnd/config.w32
+++ b/ext/mysqlnd/config.w32
@@ -36,6 +36,9 @@ if (PHP_MYSQLND != "no") {
 		{
 			AC_DEFINE("MYSQLND_COMPRESSION_ENABLED", 1, "Compression support");
 			AC_DEFINE("MYSQLND_SSL_SUPPORTED", 1, "SSL support");
+			if (SETUP_OPENSSL("mysqlnd", PHP_MYSQLND) >= 0) {
+				AC_DEFINE("MYSQLND_HAVE_SSL", 1, "Extended SSL support");
+			}
 		}
 		PHP_INSTALL_HEADERS("", "ext/mysqlnd");
 	}

--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -806,12 +806,8 @@ mysqlnd_sha256_auth_get_auth_data(struct st_mysqlnd_authentication_plugin * self
 
 		if (server_public_key) {
 			int server_public_key_len;
-#if HAVE_COMPILER_C99_VLA
-			char xor_str[passwd_len + 1];
-#else
 			ALLOCA_FLAG(use_heap)
 			char *xor_str = do_alloca(passwd_len + 1, use_heap);
-#endif
 			memcpy(xor_str, passwd, passwd_len);
 			xor_str[passwd_len] = '\0';
 			mysqlnd_xor_string(xor_str, passwd_len, (char *) auth_plugin_data, auth_plugin_data_len);
@@ -833,10 +829,7 @@ mysqlnd_sha256_auth_get_auth_data(struct st_mysqlnd_authentication_plugin * self
 			ret = malloc(*auth_data_len);
 			RSA_public_encrypt(passwd_len + 1, (zend_uchar *) xor_str, ret, server_public_key, RSA_PKCS1_OAEP_PADDING);
 			RSA_free(server_public_key);
-
-#if !HAVE_COMPILER_C99_VLA
 			free_alloca(xor_str, use_heap);
-#endif
 		}
 	}
 
@@ -1034,12 +1027,8 @@ mysqlnd_caching_sha2_get_and_use_key(MYSQLND_CONN_DATA *conn,
 
 	if (server_public_key) {
 		int server_public_key_len;
-#if HAVE_COMPILER_C99_VLA
-		char xor_str[passwd_len + 1];
-#else
 		ALLOCA_FLAG(use_heap)
 		char *xor_str = do_alloca(passwd_len + 1, use_heap);
-#endif
 		memcpy(xor_str, passwd, passwd_len);
 		xor_str[passwd_len] = '\0';
 		mysqlnd_xor_string(xor_str, passwd_len, (char *) auth_plugin_data, SCRAMBLE_LENGTH);
@@ -1059,9 +1048,7 @@ mysqlnd_caching_sha2_get_and_use_key(MYSQLND_CONN_DATA *conn,
 
 		*crypted = emalloc(server_public_key_len);
 		RSA_public_encrypt(passwd_len + 1, (zend_uchar *) xor_str, *crypted, server_public_key, RSA_PKCS1_OAEP_PADDING);
-#if !HAVE_COMPILER_C99_VLA
 		free_alloca(xor_str, use_heap);
-#endif
 		DBG_RETURN(server_public_key_len);
 	}
 	DBG_RETURN(0);

--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -806,7 +806,12 @@ mysqlnd_sha256_auth_get_auth_data(struct st_mysqlnd_authentication_plugin * self
 
 		if (server_public_key) {
 			int server_public_key_len;
+#if HAVE_COMPILER_C99_VLA
 			char xor_str[passwd_len + 1];
+#else
+			ALLOCA_FLAG(use_heap)
+			char *xor_str = do_alloca(passwd_len + 1, use_heap);
+#endif
 			memcpy(xor_str, passwd, passwd_len);
 			xor_str[passwd_len] = '\0';
 			mysqlnd_xor_string(xor_str, passwd_len, (char *) auth_plugin_data, auth_plugin_data_len);
@@ -828,6 +833,10 @@ mysqlnd_sha256_auth_get_auth_data(struct st_mysqlnd_authentication_plugin * self
 			ret = malloc(*auth_data_len);
 			RSA_public_encrypt(passwd_len + 1, (zend_uchar *) xor_str, ret, server_public_key, RSA_PKCS1_OAEP_PADDING);
 			RSA_free(server_public_key);
+
+#if !HAVE_COMPILER_C99_VLA
+			free_alloca(xor_str, use_heap);
+#endif
 		}
 	}
 
@@ -1025,7 +1034,12 @@ mysqlnd_caching_sha2_get_and_use_key(MYSQLND_CONN_DATA *conn,
 
 	if (server_public_key) {
 		int server_public_key_len;
+#if HAVE_COMPILER_C99_VLA
 		char xor_str[passwd_len + 1];
+#else
+		ALLOCA_FLAG(use_heap)
+		char *xor_str = do_alloca(passwd_len + 1, use_heap);
+#endif
 		memcpy(xor_str, passwd, passwd_len);
 		xor_str[passwd_len] = '\0';
 		mysqlnd_xor_string(xor_str, passwd_len, (char *) auth_plugin_data, SCRAMBLE_LENGTH);
@@ -1045,6 +1059,9 @@ mysqlnd_caching_sha2_get_and_use_key(MYSQLND_CONN_DATA *conn,
 
 		*crypted = emalloc(server_public_key_len);
 		RSA_public_encrypt(passwd_len + 1, (zend_uchar *) xor_str, *crypted, server_public_key, RSA_PKCS1_OAEP_PADDING);
+#if !HAVE_COMPILER_C99_VLA
+		free_alloca(xor_str, use_heap);
+#endif
 		DBG_RETURN(server_public_key_len);
 	}
 	DBG_RETURN(0);

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -2141,12 +2141,8 @@ size_t php_mysqlnd_cached_sha2_result_write(MYSQLND_CONN_DATA * conn, void * _pa
 	MYSQLND_PFC * pfc = conn->protocol_frame_codec;
 	MYSQLND_VIO * vio = conn->vio;
 	MYSQLND_STATS * stats = conn->stats;
-#if HAVE_COMPILER_C99_VLA
-	zend_uchar buffer[MYSQLND_HEADER_SIZE + packet->password_len + 1];
-#else
 	ALLOCA_FLAG(use_heap)
 	zend_uchar *buffer = do_alloca(MYSQLND_HEADER_SIZE + packet->password_len + 1, use_heap);
-#endif
 	size_t sent;
 
 	DBG_ENTER("php_mysqlnd_cached_sha2_result_write");
@@ -2158,10 +2154,7 @@ size_t php_mysqlnd_cached_sha2_result_write(MYSQLND_CONN_DATA * conn, void * _pa
 		memcpy(buffer + MYSQLND_HEADER_SIZE, packet->password, packet->password_len);
 		sent = pfc->data->m.send(pfc, vio, buffer, packet->password_len, stats, error_info);
 	}
-
-#if !HAVE_COMPILER_C99_VLA
 	free_alloca(buffer, use_heap);
-#endif
 
 	DBG_RETURN(sent);
 }


### PR DESCRIPTION
This requires OpenSSL to be linked to php*.dll.  We also add an
`alloca()` based fallback for MSVC (and potentially other compilers),
which does not support variable length arrays.