### PR TITLE
Fix #70078: XSL callbacks with nodes as parameter leak memory

### DIFF
--- a/ext/xsl/tests/bug70078.phpt
+++ b/ext/xsl/tests/bug70078.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Bug #70078 (XSL callbacks with nodes as parameter leak memory)
+--SKIPIF--
+<?php
+if (!extension_loaded('xsl')) die('skip xsl extension not available');
+?>
+--FILE--
+<?php
+// create big dummy document:
+$dom = new \DOMDocument();
+$rootNode = $dom->appendChild($dom->createElement('root'));
+for ($i = 0; $i <= 100; $i++) {
+    $level1Node = $rootNode->appendChild($dom->createElement('level1'));
+    for ($j = 0; $j <= 100; $j++) {
+        $level2Node = $level1Node->appendChild($dom->createElement('level2'));
+        for ($k = 0; $k <= 10; $k++) {
+            $level3Node = $level2Node->appendChild($dom->createElement('level3', 'test'));
+        }
+    }
+}
+
+function testPhpFunction($node) {
+    return 'test2';
+}
+
+$xslStr = <<<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:php="http://php.net/xsl">
+    <xsl:template match="root">
+        <output>
+            <xsl:for-each select="level1">
+                <node>
+                    <xsl:value-of select="php:function('testPhpFunction', .)" />
+                </node>
+            </xsl:for-each>
+        </output>
+    </xsl:template>
+</xsl:stylesheet>
+EOF;
+
+$xsl = new \DOMDocument();
+$xsl->loadXML($xslStr);
+$xslt = new \XSLTProcessor();
+$xslt->registerPHPFunctions('testPhpFunction');
+$xslt->importStyleSheet($xsl);
+
+echo $xslt->transformToXML($dom);
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<output xmlns:php="http://php.net/xsl"><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node><node>test2</node></output>

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -274,7 +274,7 @@ static void xsl_ext_function_php(xmlXPathParserContextPtr ctxt, int nargs, int t
 								node->parent = nsparent;
 								node->ns = curns;
 							} else {
-								node = xmlDocCopyNodeList(domintern->document->ptr, node);
+								node = xmlDocCopyNode(node, domintern->document->ptr, 1);
 							}
 
 							php_dom_create_object(node, &child, domintern);


### PR DESCRIPTION
The fix for bug #49634 solved a double-free by copying the node with
`xmlDocCopyNodeList()`, but the copied node is later freed by calling
`xmlFreeNode()` instead of `xmlFreeNodeList()`, thus leaking memory.
However, there is no need to treat the node as node list, i.e. to copy
also the node's siblings; just creating a recursive copy of the node
with `xmlDocCopyNode()` is sufficient, while that also avoids the leak.