### PR TITLE
Fix #79191: Error in SoapClient ctor disables DOMDocument::save()

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -265,11 +265,11 @@ void shutdown_executor(void) /* {{{ */
 		zend_close_rsrc_list(&EG(regular_list));
 	} zend_end_try();
 
-	zend_objects_store_free_object_storage(&EG(objects_store), fast_shutdown);
-
-	/* All resources and objects are destroyed. */
+	/* All resources are destroyed. */
 	/* No PHP callback functions may be called after this point. */
 	EG(active) = 0;
+
+	zend_objects_store_free_object_storage(&EG(objects_store), fast_shutdown);
 
 	zend_try {
 		zend_llist_apply(&zend_extensions, (llist_apply_func_t) zend_extension_deactivator);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -265,11 +265,11 @@ void shutdown_executor(void) /* {{{ */
 		zend_close_rsrc_list(&EG(regular_list));
 	} zend_end_try();
 
-	/* All resources are destroyed. */
+	zend_objects_store_free_object_storage(&EG(objects_store), fast_shutdown);
+
+	/* All resources and objects are destroyed. */
 	/* No PHP callback functions may be called after this point. */
 	EG(active) = 0;
-
-	zend_objects_store_free_object_storage(&EG(objects_store), fast_shutdown);
 
 	zend_try {
 		zend_llist_apply(&zend_extensions, (llist_apply_func_t) zend_extension_deactivator);

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -385,9 +385,6 @@ static int php_libxml_streams_IO_read(void *context, char *buffer, int len)
 
 static int php_libxml_streams_IO_write(void *context, const char *buffer, int len)
 {
-	if (CG(unclean_shutdown)) {
-		return -1;
-	}
 	return php_stream_write((php_stream*)context, buffer, len);
 }
 

--- a/ext/libxml/tests/bug79191.phpt
+++ b/ext/libxml/tests/bug79191.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #79191 (Error in SoapClient ctor disables DOMDocument::save())
+--SKIPIF--
+<?php
+if (!extension_loaded('soap')) die('skip soap extension not available');
+if (!extension_loaded('dom')) die('dom extension not available');
+?>
+--FILE--
+<?php
+try {
+    new \SoapClient('does-not-exist.wsdl');
+} catch (Throwable $t) {
+}#
+
+$dom = new DOMDocument;
+$dom->loadxml('<?xml version="1.0" ?><root />');
+var_dump($dom->save(__DIR__ . '/bug79191.xml'));
+?>
+--EXPECTF--
+int(%d)
+--CLEAN--
+<?php
+unlink(__DIR__ . '/bug79191.xml');
+?>

--- a/ext/libxml/tests/bug79191.phpt
+++ b/ext/libxml/tests/bug79191.phpt
@@ -10,15 +10,15 @@ if (!extension_loaded('dom')) die('dom extension not available');
 try {
     new \SoapClient('does-not-exist.wsdl');
 } catch (Throwable $t) {
-}#
+}
 
 $dom = new DOMDocument;
 $dom->loadxml('<?xml version="1.0" ?><root />');
 var_dump($dom->save(__DIR__ . '/bug79191.xml'));
 ?>
---EXPECTF--
-int(%d)
 --CLEAN--
 <?php
 unlink(__DIR__ . '/bug79191.xml');
 ?>
+--EXPECTF--
+int(%d)

--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -130,6 +130,7 @@ static void xmlwriter_object_dtor(zend_object *object)
 		xmlwriter_free_resource_ptr(intern->xmlwriter_ptr);
 	}
 	intern->xmlwriter_ptr = NULL;
+	zend_objects_destroy_object(object);
 }
 /* }}} */
 

--- a/ext/xmlwriter/tests/bug71536.phpt
+++ b/ext/xmlwriter/tests/bug71536.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #71536 (Access Violation crashes php-cgi.exe)
+--SKIPIF--
+<?php
+if (!extension_loaded('xmlwriter')) die('skip xmlwriter extension not available');
+?>
+--FILE--
+<?php
+class Test {
+    public static function init()
+    {
+        $xml = new \XMLWriter();
+        $xml->openUri('php://memory');
+        $xml->setIndent(false);
+        $xml->startDocument('1.0', 'UTF-8');
+        $xml->startElement('response');
+        die('now'); // crashed with die()
+    }
+}
+
+Test::init();
+?>
+--EXPECT--
+now

--- a/ext/xmlwriter/tests/bug79029.phpt
+++ b/ext/xmlwriter/tests/bug79029.phpt
@@ -11,13 +11,13 @@ $x = array( new XMLWriter() );
 $x[0]->openUri("bug79029_1.txt");
 $x[0]->startComment();
 
-$x = new XMLWriter();
-$x->openUri("bug79029_2.txt");
+$y = new XMLWriter();
+$y->openUri("bug79029_2.txt");
 fclose(@end(get_resources()));
 
 file_put_contents("bug79029_3.txt", "a");
-$x = new XMLReader();
-$x->open("bug79029_3.txt");
+$z = new XMLReader();
+$z->open("bug79029_3.txt");
 fclose(@end(get_resources()));
 ?>
 okey


### PR DESCRIPTION
The culprit is the too restrictive fix for bug #71536, which prevents
`php_libxml_streams_IO_write()` from properly executing when unclean
shutdown is flagged.  However, the fix for bug #79029 already prevents
that call during shutdown in the first place, so that it actually fixes
bug #71536 as well.  Thus, we can just revert the original fix for bug
#71536.

Thanks to bwoebi and daverandom for helping to investigate this issue.