### PR TITLE
Use "%empty" in the parsers, instead of comments

### DIFF
--- a/Zend/Makefile.frag
+++ b/Zend/Makefile.frag
@@ -13,7 +13,7 @@ $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
 # Tweak zendparse to be exported through ZEND_API. This has to be revisited once
 # bison supports foreign skeletons and that bison version is used. Read
 # https://git.savannah.gnu.org/cgit/bison.git/tree/data/README.md for more.
-	@$(YACC) -p zend -v -d $(srcdir)/zend_language_parser.y -o $@
+	@$(YACC) $(YFLAGS) -p zend -v -d $(srcdir)/zend_language_parser.y -o $@
 	@$(SED) -e 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' < $@ \
 	> $@.tmp && \
 	mv $@.tmp $@
@@ -27,7 +27,7 @@ $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
 
 $(srcdir)/zend_ini_parser.h: $(srcdir)/zend_ini_parser.c
 $(srcdir)/zend_ini_parser.c: $(srcdir)/zend_ini_parser.y
-	@$(YACC) -p ini_ -v -d $(srcdir)/zend_ini_parser.y -o $@
+	@$(YACC) $(YFLAGS) -p ini_ -v -d $(srcdir)/zend_ini_parser.y -o $@
 
 $(srcdir)/zend_ini_scanner.c: $(srcdir)/zend_ini_scanner.l
 	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l)

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -317,7 +317,7 @@ static void zval_ini_dtor(zval *zv)
 
 statement_list:
 		statement_list statement
-	|	/* empty */
+	|	%empty
 ;
 
 statement:
@@ -351,7 +351,7 @@ statement:
 
 section_string_or_value:
 		var_string_list_section			{ $$ = $1; }
-	|	/* empty */						{ zend_ini_init_string(&$$); }
+	|	%empty						{ zend_ini_init_string(&$$); }
 ;
 
 string_or_value:
@@ -364,13 +364,13 @@ string_or_value:
 
 option_offset:
 		var_string_list					{ $$ = $1; }
-	|	/* empty */						{ zend_ini_init_string(&$$); }
+	|	%empty						{ zend_ini_init_string(&$$); }
 ;
 
 encapsed_list:
 		encapsed_list cfg_var_ref		{ zend_ini_add_string(&$$, &$1, &$2); zend_string_free(Z_STR($2)); }
 	|	encapsed_list TC_QUOTED_STRING	{ zend_ini_add_string(&$$, &$1, &$2); zend_string_free(Z_STR($2)); }
-	|	/* empty */						{ zend_ini_init_string(&$$); }
+	|	%empty						{ zend_ini_init_string(&$$); }
 ;
 
 var_string_list_section:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -297,7 +297,7 @@ identifier:
 
 top_statement_list:
 		top_statement_list top_statement { $$ = zend_ast_list_add($1, $2); }
-	|	/* empty */ { $$ = zend_ast_create_list(0, ZEND_AST_STMT_LIST); }
+	|	%empty { $$ = zend_ast_create_list(0, ZEND_AST_STMT_LIST); }
 ;
 
 namespace_name:
@@ -357,7 +357,7 @@ mixed_group_use_declaration:
 ;
 
 possible_comma:
-		/* empty */
+		%empty
 	|	','
 ;
 
@@ -407,7 +407,7 @@ const_list:
 inner_statement_list:
 		inner_statement_list inner_statement
 			{ $$ = zend_ast_list_add($1, $2); }
-	|	/* empty */
+	|	%empty
 			{ $$ = zend_ast_create_list(0, ZEND_AST_STMT_LIST); }
 ;
 
@@ -463,7 +463,7 @@ statement:
 ;
 
 catch_list:
-		/* empty */
+		%empty
 			{ $$ = zend_ast_create_list(0, ZEND_AST_CATCH_LIST); }
 	|	catch_list T_CATCH '(' catch_name_list T_VARIABLE ')' '{' inner_statement_list '}'
 			{ $$ = zend_ast_list_add($1, zend_ast_create(ZEND_AST_CATCH, $4, $5, $8)); }
@@ -475,7 +475,7 @@ catch_name_list:
 ;
 
 finally_statement:
-		/* empty */ { $$ = NULL; }
+		%empty { $$ = NULL; }
 	|	T_FINALLY '{' inner_statement_list '}' { $$ = $3; }
 ;
 
@@ -496,12 +496,12 @@ function_declaration_statement:
 ;
 
 is_reference:
-		/* empty */	{ $$ = 0; }
+		%empty	{ $$ = 0; }
 	|	'&'			{ $$ = ZEND_PARAM_REF; }
 ;
 
 is_variadic:
-		/* empty */ { $$ = 0; }
+		%empty { $$ = 0; }
 	|	T_ELLIPSIS  { $$ = ZEND_PARAM_VARIADIC; }
 ;
 
@@ -538,17 +538,17 @@ interface_declaration_statement:
 ;
 
 extends_from:
-		/* empty */				{ $$ = NULL; }
+		%empty				{ $$ = NULL; }
 	|	T_EXTENDS class_name	{ $$ = $2; }
 ;
 
 interface_extends_list:
-		/* empty */			        { $$ = NULL; }
+		%empty			        { $$ = NULL; }
 	|	T_EXTENDS class_name_list	{ $$ = $2; }
 ;
 
 implements_list:
-		/* empty */		        		{ $$ = NULL; }
+		%empty		        		{ $$ = NULL; }
 	|	T_IMPLEMENTS class_name_list	{ $$ = $2; }
 ;
 
@@ -582,7 +582,7 @@ switch_case_list:
 ;
 
 case_list:
-		/* empty */ { $$ = zend_ast_create_list(0, ZEND_AST_SWITCH_LIST); }
+		%empty { $$ = zend_ast_create_list(0, ZEND_AST_SWITCH_LIST); }
 	|	case_list T_CASE expr case_separator inner_statement_list
 			{ $$ = zend_ast_list_add($1, zend_ast_create(ZEND_AST_SWITCH_CASE, $3, $5)); }
 	|	case_list T_DEFAULT case_separator inner_statement_list
@@ -634,7 +634,7 @@ alt_if_stmt:
 
 parameter_list:
 		non_empty_parameter_list { $$ = $1; }
-	|	/* empty */	{ $$ = zend_ast_create_list(0, ZEND_AST_PARAM_LIST); }
+	|	%empty	{ $$ = zend_ast_create_list(0, ZEND_AST_PARAM_LIST); }
 ;
 
 
@@ -654,7 +654,7 @@ parameter:
 
 
 optional_type:
-		/* empty */	{ $$ = NULL; }
+		%empty	{ $$ = NULL; }
 	|	type_expr	{ $$ = $1; }
 ;
 
@@ -676,7 +676,7 @@ union_type:
 ;
 
 return_type:
-		/* empty */	{ $$ = NULL; }
+		%empty	{ $$ = NULL; }
 	|	':' type_expr	{ $$ = $2; }
 ;
 
@@ -722,7 +722,7 @@ static_var:
 class_statement_list:
 		class_statement_list class_statement
 			{ $$ = zend_ast_list_add($1, $2); }
-	|	/* empty */
+	|	%empty
 			{ $$ = zend_ast_create_list(0, ZEND_AST_STMT_LIST); }
 ;
 
@@ -802,7 +802,7 @@ variable_modifiers:
 ;
 
 method_modifiers:
-		/* empty */						{ $$ = ZEND_ACC_PUBLIC; }
+		%empty						{ $$ = ZEND_ACC_PUBLIC; }
 	|	non_empty_member_modifiers
 			{ $$ = $1; if (!($$ & ZEND_ACC_PPP_MASK)) { $$ |= ZEND_ACC_PUBLIC; } }
 ;
@@ -856,7 +856,7 @@ echo_expr:
 ;
 
 for_exprs:
-		/* empty */			{ $$ = NULL; }
+		%empty			{ $$ = NULL; }
 	|	non_empty_for_exprs	{ $$ = $1; }
 ;
 
@@ -1026,24 +1026,24 @@ function:
 ;
 
 backup_doc_comment:
-	/* empty */ { $$ = CG(doc_comment); CG(doc_comment) = NULL; }
+	%empty { $$ = CG(doc_comment); CG(doc_comment) = NULL; }
 ;
 
 backup_fn_flags:
-	%prec PREC_ARROW_FUNCTION /* empty */ { $$ = CG(extra_fn_flags); CG(extra_fn_flags) = 0; }
+	%prec PREC_ARROW_FUNCTION %empty { $$ = CG(extra_fn_flags); CG(extra_fn_flags) = 0; }
 ;
 
 backup_lex_pos:
-	/* empty */ { $$ = LANG_SCNG(yy_text); }
+	%empty { $$ = LANG_SCNG(yy_text); }
 ;
 
 returns_ref:
-		/* empty */	{ $$ = 0; }
+		%empty	{ $$ = 0; }
 	|	'&'			{ $$ = ZEND_ACC_RETURN_REFERENCE; }
 ;
 
 lexical_vars:
-		/* empty */ { $$ = NULL; }
+		%empty { $$ = NULL; }
 	|	T_USE '(' lexical_var_list ')' { $$ = $3; }
 ;
 
@@ -1081,12 +1081,12 @@ class_name_reference:
 ;
 
 exit_expr:
-		/* empty */				{ $$ = NULL; }
+		%empty				{ $$ = NULL; }
 	|	'(' optional_expr ')'	{ $$ = $2; }
 ;
 
 backticks_expr:
-		/* empty */
+		%empty
 			{ $$ = zend_ast_create_zval_from_str(ZSTR_EMPTY_ALLOC()); }
 	|	T_ENCAPSED_AND_WHITESPACE { $$ = $1; }
 	|	encaps_list { $$ = $1; }
@@ -1094,7 +1094,7 @@ backticks_expr:
 
 
 ctor_arguments:
-		/* empty */	{ $$ = zend_ast_create_list(0, ZEND_AST_ARG_LIST); }
+		%empty	{ $$ = zend_ast_create_list(0, ZEND_AST_ARG_LIST); }
 	|	argument_list { $$ = $1; }
 ;
 
@@ -1134,7 +1134,7 @@ constant:
 ;
 
 optional_expr:
-		/* empty */	{ $$ = NULL; }
+		%empty	{ $$ = NULL; }
 	|	expr		{ $$ = $1; }
 ;
 
@@ -1223,7 +1223,7 @@ array_pair_list:
 ;
 
 possible_array_pair:
-		/* empty */ { $$ = NULL; }
+		%empty { $$ = NULL; }
 	|	array_pair  { $$ = $1; }
 ;
 

--- a/build/php.m4
+++ b/build/php.m4
@@ -1815,6 +1815,7 @@ AC_DEFUN([PHP_PROG_BISON], [
     done
 
     if test "$php_bison_check" != "invalid"; then
+      AC_SUBST([YFLAGS], [-Wempty-rule])
       AC_MSG_RESULT([$php_bison_version (ok)])
     else
       AC_MSG_RESULT([$php_bison_version])

--- a/ext/json/Makefile.frag
+++ b/ext/json/Makefile.frag
@@ -2,4 +2,4 @@ $(srcdir)/json_scanner.c: $(srcdir)/json_scanner.re
 	@$(RE2C) $(RE2C_FLAGS) -t $(srcdir)/php_json_scanner_defs.h --no-generation-date -bci -o $@ $(srcdir)/json_scanner.re
 
 $(srcdir)/json_parser.tab.c: $(srcdir)/json_parser.y
-	@$(YACC) --defines -l $(srcdir)/json_parser.y -o $@
+	@$(YACC) $(YFLAGS) --defines -l $(srcdir)/json_parser.y -o $@

--- a/ext/json/json_parser.y
+++ b/ext/json/json_parser.y
@@ -1,3 +1,4 @@
+%require "3.0"
 %code top {
 /*
   +----------------------------------------------------------------------+
@@ -118,7 +119,7 @@ object_end:
 ;
 
 members:
-		/* empty */
+		%empty
 			{
 				if ((parser->scanner.options & PHP_JSON_OBJECT_AS_ARRAY) && parser->methods.object_create == php_json_parser_object_create) {
 					ZVAL_EMPTY_ARRAY(&$$);
@@ -182,7 +183,7 @@ array_end:
 ;
 
 elements:
-		/* empty */
+		%empty
 			{
 				if (parser->methods.array_create == php_json_parser_array_create) {
 					ZVAL_EMPTY_ARRAY(&$$);

--- a/sapi/phpdbg/Makefile.frag
+++ b/sapi/phpdbg/Makefile.frag
@@ -18,7 +18,7 @@ $(srcdir)/phpdbg_lexer.c: $(srcdir)/phpdbg_lexer.l
 
 $(srcdir)/phpdbg_parser.h: $(srcdir)/phpdbg_parser.c
 $(srcdir)/phpdbg_parser.c: $(srcdir)/phpdbg_parser.y
-	@$(YACC) -p phpdbg_ -v -d $(srcdir)/phpdbg_parser.y -o $@
+	@$(YACC) $(YFLAGS) -p phpdbg_ -v -d $(srcdir)/phpdbg_parser.y -o $@
 
 install-phpdbg: $(BUILD_BINARY)
 	@echo "Installing phpdbg binary:         $(INSTALL_ROOT)$(bindir)/"

--- a/sapi/phpdbg/phpdbg_parser.y
+++ b/sapi/phpdbg/phpdbg_parser.y
@@ -1,3 +1,4 @@
+%require "3.0"
 %{
 
 /*
@@ -65,7 +66,7 @@ typedef void* yyscan_t;
 input
 	: command { $$ = $1; }
 	| input T_SEPARATOR command { phpdbg_stack_separate($1.top); $$ = $3; }
-	| /* empty */
+	| %empty
 	;
 
 command
@@ -143,7 +144,7 @@ parameter
 
 req_id
 	: T_REQ_ID { PHPDBG_G(req_id) = $1.num; }
-	| /* empty */
+	| %empty
 ;
 
 full_expression


### PR DESCRIPTION
The annotation `%empty` is properly enforced: warnings when it's missing, and errors when it's inappropriate.  Support for `%empty` was introduced in Bison 3.0.

Pass `-Wempty-rule` to Bison.