### PR TITLE
Add VM reentry limit

### DIFF
--- a/Zend/tests/vm_reentry_limit.phpt
+++ b/Zend/tests/vm_reentry_limit.phpt
@@ -1,0 +1,84 @@
+--TEST--
+VM reentry limit
+--INI--
+zend.vm_reentry_limit=20
+--FILE--
+<?php
+
+class Test1 {
+    public function __destruct() {
+        new Test1;
+    }
+}
+
+class Test2 {
+    public function __clone() {
+        clone $this;
+    }
+}
+
+try {
+    new Test1;
+} catch (Error $e) {
+    echo $e, "\n";
+}
+
+echo "\n";
+
+try {
+    clone new Test2;
+} catch (Error $e) {
+    echo $e, "\n";
+}
+
+?>
+--EXPECTF--
+Error: VM reentry limit of 20 reached. Infinite recursion? in %s:%d
+Stack trace:
+#0 %s(%d): Test1->__destruct()
+#1 %s(%d): Test1->__destruct()
+#2 %s(%d): Test1->__destruct()
+#3 %s(%d): Test1->__destruct()
+#4 %s(%d): Test1->__destruct()
+#5 %s(%d): Test1->__destruct()
+#6 %s(%d): Test1->__destruct()
+#7 %s(%d): Test1->__destruct()
+#8 %s(%d): Test1->__destruct()
+#9 %s(%d): Test1->__destruct()
+#10 %s(%d): Test1->__destruct()
+#11 %s(%d): Test1->__destruct()
+#12 %s(%d): Test1->__destruct()
+#13 %s(%d): Test1->__destruct()
+#14 %s(%d): Test1->__destruct()
+#15 %s(%d): Test1->__destruct()
+#16 %s(%d): Test1->__destruct()
+#17 %s(%d): Test1->__destruct()
+#18 %s(%d): Test1->__destruct()
+#19 %s(%d): Test1->__destruct()
+#20 %s(%d): Test1->__destruct()
+#21 {main}
+
+Error: VM reentry limit of 20 reached. Infinite recursion? in %s:%d
+Stack trace:
+#0 %s(%d): Test2->__clone()
+#1 %s(%d): Test2->__clone()
+#2 %s(%d): Test2->__clone()
+#3 %s(%d): Test2->__clone()
+#4 %s(%d): Test2->__clone()
+#5 %s(%d): Test2->__clone()
+#6 %s(%d): Test2->__clone()
+#7 %s(%d): Test2->__clone()
+#8 %s(%d): Test2->__clone()
+#9 %s(%d): Test2->__clone()
+#10 %s(%d): Test2->__clone()
+#11 %s(%d): Test2->__clone()
+#12 %s(%d): Test2->__clone()
+#13 %s(%d): Test2->__clone()
+#14 %s(%d): Test2->__clone()
+#15 %s(%d): Test2->__clone()
+#16 %s(%d): Test2->__clone()
+#17 %s(%d): Test2->__clone()
+#18 %s(%d): Test2->__clone()
+#19 %s(%d): Test2->__clone()
+#20 %s(%d): Test2->__clone()
+#21 {main}

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -192,6 +192,7 @@ ZEND_INI_BEGIN()
 #endif
 	STD_ZEND_INI_BOOLEAN("zend.exception_ignore_args",	"0",	ZEND_INI_ALL,		OnUpdateBool, exception_ignore_args, zend_executor_globals, executor_globals)
 	STD_ZEND_INI_ENTRY("zend.exception_string_param_max_len",	"15",	ZEND_INI_ALL,	OnSetExceptionStringParamMaxLen,	exception_string_param_max_len,		zend_executor_globals,	executor_globals)
+	STD_ZEND_INI_ENTRY("zend.vm_reentry_limit", "1000", ZEND_INI_ALL, OnUpdateLong, vm_reentry_limit, zend_executor_globals, executor_globals)
 ZEND_INI_END()
 
 ZEND_API size_t zend_vspprintf(char **pbuf, size_t max_len, const char *format, va_list ap) /* {{{ */

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2046,6 +2046,13 @@ static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_use_new_element_for_s
 	zend_throw_error(NULL, "[] operator not supported for strings");
 }
 
+static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_vm_reentry_limit_error()
+{
+	zend_throw_error(NULL,
+		"VM reentry limit of " ZEND_ULONG_FMT " reached. Infinite recursion?",
+		EG(vm_reentry_limit));
+}
+
 static ZEND_COLD void zend_binary_assign_op_dim_slow(zval *container, zval *dim OPLINE_DC EXECUTE_DATA_DC)
 {
 	if (UNEXPECTED(Z_TYPE_P(container) == IS_STRING)) {

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -175,6 +175,7 @@ void init_executor(void) /* {{{ */
 
 	EG(fake_scope) = NULL;
 	EG(trampoline).common.function_name = NULL;
+	EG(vm_reentry_count) = 0;
 
 	EG(ht_iterators_count) = sizeof(EG(ht_iterators_slots)) / sizeof(HashTableIterator);
 	EG(ht_iterators_used) = 0;

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -249,6 +249,9 @@ struct _zend_executor_globals {
 
 	zend_get_gc_buffer get_gc_buffer;
 
+	zend_ulong vm_reentry_count;
+	zend_ulong vm_reentry_limit;
+
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };
 

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -16,6 +16,12 @@ ZEND_API void {%EXECUTOR_NAME%}_ex(zend_execute_data *ex)
 	LOAD_OPLINE();
 	ZEND_VM_LOOP_INTERRUPT_CHECK();
 
+	if (EG(vm_reentry_count)++ > EG(vm_reentry_limit)) {
+		zend_vm_reentry_limit_error();
+		LOAD_OPLINE();
+		/* Fall through to handle exception below. */
+	}
+
 	while (1) {
 		{%ZEND_VM_CONTINUE_LABEL%}
 		{%ZEND_VM_DISPATCH%} {

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -1787,6 +1787,7 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
             out($f,"#ifdef ZEND_VM_IP_GLOBAL_REG\n");
             out($f,"\t\t\t\topline = vm_stack_data.orig_opline;\n");
             out($f,"#endif\n");
+            out($f,"\t\t\t\tEG(vm_reentry_count)--;\n");
             out($f,"\t\t\t\treturn;\n");
             out($f,"\t\t\tHYBRID_DEFAULT:\n");
             out($f,"\t\t\t\tVM_TRACE(ZEND_NULL)\n");
@@ -1984,7 +1985,7 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                             out($f,"#define HANDLE_EXCEPTION() ZEND_ASSERT(EG(exception)); LOAD_OPLINE(); ZEND_VM_CONTINUE()\n");
                             out($f,"#define HANDLE_EXCEPTION_LEAVE() ZEND_ASSERT(EG(exception)); LOAD_OPLINE(); ZEND_VM_LEAVE()\n");
                             out($f,"#define ZEND_VM_CONTINUE() goto zend_vm_continue\n");
-                            out($f,"#define ZEND_VM_RETURN()   return\n");
+                            out($f,"#define ZEND_VM_RETURN()   EG(vm_reentry_count)--; return\n");
                             out($f,"#define ZEND_VM_ENTER_EX() ZEND_VM_INTERRUPT_CHECK(); ZEND_VM_CONTINUE()\n");
                             out($f,"#define ZEND_VM_ENTER()    execute_data = EG(current_execute_data); LOAD_OPLINE(); ZEND_VM_ENTER_EX()\n");
                             out($f,"#define ZEND_VM_LEAVE()    ZEND_VM_CONTINUE()\n");
@@ -2015,7 +2016,7 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                                 out($f,"#define HANDLE_EXCEPTION_LEAVE() ZEND_ASSERT(EG(exception)); goto ZEND_HANDLE_EXCEPTION_LABEL\n");
                             }
                             out($f,"#define ZEND_VM_CONTINUE() goto *(void**)(OPLINE->handler)\n");
-                            out($f,"#define ZEND_VM_RETURN()   return\n");
+                            out($f,"#define ZEND_VM_RETURN()   EG(vm_reentry_count)--; return\n");
                             out($f,"#define ZEND_VM_ENTER_EX() ZEND_VM_INTERRUPT_CHECK(); ZEND_VM_CONTINUE()\n");
                             out($f,"#define ZEND_VM_ENTER()    execute_data = EG(current_execute_data); LOAD_OPLINE(); ZEND_VM_ENTER_EX()\n");
                             out($f,"#define ZEND_VM_LEAVE()    ZEND_VM_CONTINUE()\n");
@@ -2184,6 +2185,7 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                                 "# ifdef ZEND_VM_IP_GLOBAL_REG\n" .
                                 $m[1]."opline = vm_stack_data.orig_opline;\n" .
                                 "# endif\n" .
+                                $m[1]."EG(vm_reentry_count)--;\n" .
                                 $m[1]."return;\n" .
                                 "#else\n" .
                                 $m[1]."if (EXPECTED(ret > 0)) {\n" .
@@ -2193,6 +2195,7 @@ function gen_executor($f, $skl, $spec, $kind, $executor_name, $initializer_name)
                                 "# ifdef ZEND_VM_IP_GLOBAL_REG\n" .
                                 $m[1]."\topline = vm_stack_data.orig_opline;\n" .
                                 "# endif\n".
+                                $m[1]."\tEG(vm_reentry_count)--;\n".
                                 $m[1]."\treturn;\n".
                                 $m[1]."}\n".
                                 "#endif\n");

--- a/php.ini-development
+++ b/php.ini-development
@@ -386,6 +386,12 @@ zend.exception_ignore_args = Off
 ; Production Value: 0
 zend.exception_string_param_max_len = 15
 
+; Limit for recursion via VM reentry, used to prevent stack overflow.
+; This only affects recursion through magic method calls and similar mechanisms.
+; Some profiling, debugging or APM extensions might make this limit apply to plain
+; recursion as well, in which case you may wish to raise it.
+;zend.vm_reentry_limit = 1000
+
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;
 ;;;;;;;;;;;;;;;;;

--- a/php.ini-production
+++ b/php.ini-production
@@ -388,6 +388,12 @@ zend.exception_ignore_args = On
 ; of sensitive information in stack traces.
 zend.exception_string_param_max_len = 0
 
+; Limit for recursion via VM reentry, used to prevent stack overflow.
+; This only affects recursion through magic method calls and similar mechanism.
+; Some profiling, debugging or APM extensions might make this limit apply to plain
+; recursion as well, in which case you may wish to raise it.
+;zend.vm_reentry_limit = 1000
+
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;
 ;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This adds a `zend.vm_reentry_limit` option to fix https://bugs.php.net/bug.php?id=64196 and the many linked related bugs.

The VM reentry limit is intentionally named somewhat obscurely: It is not a direct limit on recursion. It only counts the number of VM reentries, because that's what can eventually lead to a stack overflow.

This means that unbounded recursion is still supported just fine, and this affects only some specific cases, like recursion through `__destruct()`, where we don't support unbounded recursion for technical reasons. As such, applications should never actually hit this limit, even if they make heavy use of recursion (AST processing etc.)

The only exception are extension that for VM reentry for every single function call. Those extensions should probably either increase or disable this limit. Though there's also work underway from APM vendors to add the necessary engine support, so they don't need to force VM reentry anymore.