### PR TITLE
Added opcache extension to ini's

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -934,6 +934,8 @@ default_socket_timeout = 60
 ;extension=xmlrpc
 ;extension=xsl
 
+;zend_extension=opcache
+
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;
 ;;;;;;;;;;;;;;;;;;;

--- a/php.ini-production
+++ b/php.ini-production
@@ -936,6 +936,8 @@ default_socket_timeout = 60
 ;extension=xmlrpc
 ;extension=xsl
 
+;zend_extension=opcache
+
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;
 ;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Added opcache to the default extension lists (`zend_extension=opcache`). Extension is not loaded by default (commented out).
