### PR TITLE
 Bison : clean up

### DIFF
--- a/Zend/Makefile.frag
+++ b/Zend/Makefile.frag
@@ -13,7 +13,7 @@ $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
 # Tweak zendparse to be exported through ZEND_API. This has to be revisited once
 # bison supports foreign skeletons and that bison version is used. Read
 # https://git.savannah.gnu.org/cgit/bison.git/tree/data/README.md for more.
-	@$(YACC) $(YFLAGS) -p zend -v -d $(srcdir)/zend_language_parser.y -o $@
+	@$(YACC) $(YFLAGS) -v -d $(srcdir)/zend_language_parser.y -o $@
 	@$(SED) -e 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' < $@ \
 	> $@.tmp && \
 	mv $@.tmp $@
@@ -27,7 +27,7 @@ $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
 
 $(srcdir)/zend_ini_parser.h: $(srcdir)/zend_ini_parser.c
 $(srcdir)/zend_ini_parser.c: $(srcdir)/zend_ini_parser.y
-	@$(YACC) $(YFLAGS) -p ini_ -v -d $(srcdir)/zend_ini_parser.y -o $@
+	$(YACC) $(YFLAGS) -v -d $(srcdir)/zend_ini_parser.y -o $@
 
 $(srcdir)/zend_ini_scanner.c: $(srcdir)/zend_ini_scanner.l
 	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l)

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -309,7 +309,7 @@ static void zval_ini_dtor(zval *zv)
 %token END_OF_LINE
 %token '=' ':' ',' '.' '"' '\'' '^' '+' '-' '/' '*' '%' '$' '~' '<' '>' '?' '@' '{' '}'
 %left '|' '&' '^'
-%right '~' '!'
+%precedence '~' '!'
 
 %destructor { zval_ini_dtor(&$$); } TC_RAW TC_CONSTANT TC_NUMBER TC_STRING TC_WHITESPACE TC_LABEL TC_OFFSET TC_VARNAME BOOL_TRUE BOOL_FALSE NULL_NULL cfg_var_ref constant_literal constant_string encapsed_list expr option_offset section_string_or_value string_or_value var_string_list var_string_list_section
 

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -32,8 +32,6 @@
 #include "win32/syslog.h"
 #endif
 
-#define YYSTYPE zval
-
 int ini_parse(void);
 
 #define ZEND_INI_PARSER_CB	(CG(ini_parser_param))->ini_parser_cb
@@ -289,7 +287,9 @@ static void zval_ini_dtor(zval *zv)
 %}
 
 %expect 0
+%define api.prefix {ini_}
 %define api.pure full
+%define api.value.type {zval}
 %define parse.error verbose
 
 %token TC_SECTION

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -78,7 +78,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %precedence T_INSTANCEOF
 %precedence '~' T_INT_CAST T_DOUBLE_CAST T_STRING_CAST T_ARRAY_CAST T_OBJECT_CAST T_BOOL_CAST T_UNSET_CAST '@'
 %right T_POW
-%precedence T_NEW T_CLONE
+%precedence T_CLONE
 
 /* Resolve danging else conflict */
 %precedence T_NOELSE

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1,5 +1,4 @@
 %require "3.0"
-%{
 /*
    +----------------------------------------------------------------------+
    | Zend Engine                                                          |
@@ -20,7 +19,7 @@
    +----------------------------------------------------------------------+
 */
 
-#include "zend_compile.h"
+%code top {
 #include "zend.h"
 #include "zend_list.h"
 #include "zend_globals.h"
@@ -33,21 +32,21 @@
 #define yytnamerr zend_yytnamerr
 static YYSIZE_T zend_yytnamerr(char*, const char*);
 
-#define YYSTYPE zend_parser_stack_elem
-
 #ifdef _MSC_VER
 #define YYMALLOC malloc
 #define YYFREE free
 #endif
-
-%}
-
-%define api.pure full
-%define parse.error verbose
-%expect 0
+}
 
 %code requires {
+#include "zend_compile.h"
 }
+
+%define api.prefix {zend}
+%define api.pure full
+%define api.value.type {zend_parser_stack_elem}
+%define parse.error verbose
+%expect 0
 
 %destructor { zend_ast_destroy($$); } <ast>
 %destructor { if ($$) zend_string_release_ex($$, 0); } <str>

--- a/build/php.m4
+++ b/build/php.m4
@@ -81,7 +81,7 @@ AC_DEFUN([PHP_DEFINE],[
 dnl
 dnl PHP_SUBST(varname)
 dnl
-dnl Adds variable with it's value into Makefile, e.g.:
+dnl Adds variable with its value into Makefile, e.g.:
 dnl CC = gcc
 dnl
 AC_DEFUN([PHP_SUBST],[
@@ -89,14 +89,14 @@ AC_DEFUN([PHP_SUBST],[
 ])
 
 dnl
-dnl PHP_SUBST_OLD(varname)
+dnl PHP_SUBST_OLD(varname, [VALUE])
 dnl
 dnl Same as PHP_SUBST() but also substitutes all @VARNAME@ instances in every
 dnl file passed to AC_OUTPUT.
 dnl
 AC_DEFUN([PHP_SUBST_OLD],[
-  PHP_SUBST($1)
-  AC_SUBST($1)
+  AC_SUBST($@)
+  PHP_SUBST([$1])
 ])
 
 dnl
@@ -1815,7 +1815,7 @@ AC_DEFUN([PHP_PROG_BISON], [
     done
 
     if test "$php_bison_check" != "invalid"; then
-      AC_SUBST([YFLAGS], [-Wempty-rule])
+      PHP_SUBST_OLD([YFLAGS], [-Wall])
       AC_MSG_RESULT([$php_bison_version (ok)])
     else
       AC_MSG_RESULT([$php_bison_version])

--- a/ext/json/json_parser.y
+++ b/ext/json/json_parser.y
@@ -41,10 +41,9 @@ int json_yydebug = 1;
 
 }
 
-%define api.pure full
 %define api.prefix {php_json_yy}
-%lex-param  { php_json_parser *parser  }
-%parse-param { php_json_parser *parser }
+%define api.pure full
+%param  { php_json_parser *parser  }
 
 %union {
 	zval value;

--- a/sapi/phpdbg/Makefile.frag
+++ b/sapi/phpdbg/Makefile.frag
@@ -18,7 +18,7 @@ $(srcdir)/phpdbg_lexer.c: $(srcdir)/phpdbg_lexer.l
 
 $(srcdir)/phpdbg_parser.h: $(srcdir)/phpdbg_parser.c
 $(srcdir)/phpdbg_parser.c: $(srcdir)/phpdbg_parser.y
-	@$(YACC) $(YFLAGS) -p phpdbg_ -v -d $(srcdir)/phpdbg_parser.y -o $@
+	@$(YACC) $(YFLAGS) -v -d $(srcdir)/phpdbg_parser.y -o $@
 
 install-phpdbg: $(BUILD_BINARY)
 	@echo "Installing phpdbg binary:         $(INSTALL_ROOT)$(bindir)/"

--- a/sapi/phpdbg/phpdbg_cmd.h
+++ b/sapi/phpdbg/phpdbg_cmd.h
@@ -81,10 +81,6 @@ struct _phpdbg_param {
 	(v)->top = NULL; \
 } while(0)
 
-#ifndef YYSTYPE
-#define YYSTYPE phpdbg_param_t
-#endif
-
 #define PHPDBG_ASYNC_SAFE 1
 
 typedef int (*phpdbg_command_handler_t)(const phpdbg_param_t*);

--- a/sapi/phpdbg/phpdbg_parser.y
+++ b/sapi/phpdbg/phpdbg_parser.y
@@ -1,18 +1,23 @@
 %require "3.0"
-%{
-
 /*
  * phpdbg_parser.y
  * (from php-src root)
  */
 
+%code requires {
 #include "phpdbg.h"
+#ifndef YY_TYPEDEF_YY_SCANNER_T
+#define YY_TYPEDEF_YY_SCANNER_T
+typedef void* yyscan_t;
+#endif
+}
+
+%code {
+
 #include "phpdbg_cmd.h"
 #include "phpdbg_utils.h"
 #include "phpdbg_cmd.h"
 #include "phpdbg_prompt.h"
-
-#define YYSTYPE phpdbg_param_t
 
 #include "phpdbg_parser.h"
 #include "phpdbg_lexer.h"
@@ -27,18 +32,12 @@ ZEND_EXTERN_MODULE_GLOBALS(phpdbg)
 #define YYFREE free
 #endif
 
-%}
-
-%define api.pure full
-%define parse.error verbose
-
-%code requires {
-#include "phpdbg.h"
-#ifndef YY_TYPEDEF_YY_SCANNER_T
-#define YY_TYPEDEF_YY_SCANNER_T
-typedef void* yyscan_t;
-#endif
 }
+
+%define api.prefix {phpdbg_}
+%define api.pure full
+%define api.value.type {phpdbg_param_t}
+%define parse.error verbose
 
 %token T_EVAL       "eval"
 %token T_RUN        "run"

--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -75,16 +75,16 @@ $(BUILD_DIR)\$(PHPDLL).def: $(PHP_DLL_DEF_SOURCES)
 	type $(PHP_DLL_DEF_SOURCES) > $(BUILD_DIR)\$(PHPDLL).def
 
 Zend\zend_ini_parser.c Zend\zend_ini_parser.h: Zend\zend_ini_parser.y
-	$(BISON) --output=Zend/zend_ini_parser.c -v -d -p ini_ Zend/zend_ini_parser.y
+	$(BISON) --output=Zend/zend_ini_parser.c -v -d Zend/zend_ini_parser.y
 
 Zend\zend_language_parser.c Zend\zend_language_parser.h: Zend\zend_language_parser.y
-	$(BISON) --output=Zend/zend_language_parser.c -v -d -p zend Zend/zend_language_parser.y
+	$(BISON) --output=Zend/zend_language_parser.c -v -d Zend/zend_language_parser.y
 	@if "$(SED)" neq "" $(SED) -i "s,^int zendparse\(.*\),ZEND_API int zendparse\1,g" Zend/zend_language_parser.c
 	@if "$(SED)" neq "" $(SED) -i "s,^int zendparse\(.*\),ZEND_API int zendparse\1,g" Zend/zend_language_parser.h
 	@if "$(SED)" neq "" $(SED) -i "s,^#ifndef YYTOKENTYPE,#include \"zend.h\"\n#ifndef YYTOKENTYPE,g" Zend/zend_language_parser.h
 
 sapi\phpdbg\phpdbg_parser.c sapi\phpdbg\phpdbg_parser.h: sapi\phpdbg\phpdbg_parser.y
-	$(BISON) --output=sapi/phpdbg/phpdbg_parser.c -v -d -p phpdbg_ sapi/phpdbg/phpdbg_parser.y
+	$(BISON) --output=sapi/phpdbg/phpdbg_parser.c -v -d sapi/phpdbg/phpdbg_parser.y
 
 !if $(RE2C) != ""
 Zend\zend_ini_scanner.c: Zend\zend_ini_scanner.l


### PR DESCRIPTION
## Clean up the generation of the parsers

Prefer `%define api.value.type` to `#define YYSTYPE`, so that Bison know the type.

Use `%code requires` to declare what is needed to define the api.value.type (that code is output in the generated header before the generated definition of `YYSTYPE`).

Prefer `%define api.prefix` inside the grammar file to `-p` outside, as anyway the functions defined in the file actually use this prefix.

## Bison: enable all the warnings and fix them

First, fix 5547d361208d90e12d53bb62bb2ffbbff9b93ca0: the definition of YFLAGS was not passed into the Makefile: `AC_SUBST` does not suffice, we need `PHP_SUBST_OLD`.  While at it, allow to pass variable and value at the same time.

Then pass `-Wall` to bison, rather than only `-Wempty-rules`.

Use `%precedence` where associativity is useless.

Remove useless `%precedence`.
