### PR TITLE
[POC] Support calling functions from constant expressions

### DIFF
--- a/Zend/tests/call_in_const/backticks_forbidden.phpt
+++ b/Zend/tests/call_in_const/backticks_forbidden.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Cannot use backtick shorthand for shell_exec in constant expressions
+--FILE--
+<?php
+// Make sure that this is not accidentally allowed by future changes to PHP.
+// During compilation, this gets converted to a regular function call opcode.
+class Example {
+    const TEST_CONST = [`echo test`];
+}
+?>
+--EXPECTF--
+Fatal error: Constant expression contains invalid operations in %s on line 5

--- a/Zend/tests/call_in_const/class_const01.phpt
+++ b/Zend/tests/call_in_const/class_const01.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Can call internal functions from class constants
+--FILE--
+<?php
+class Example {
+    const X = sprintf("Hello, %s\n", "World");
+
+    public static function main() {
+        echo "X is " . self::X . "\n";
+    }
+}
+Example::main();
+?>
+--EXPECT--
+X is Hello, World

--- a/Zend/tests/call_in_const/class_const01.phpt
+++ b/Zend/tests/call_in_const/class_const01.phpt
@@ -3,7 +3,7 @@ Can call internal functions from class constants
 --FILE--
 <?php
 class Example {
-    const X = sprintf("Hello, %s\n", "World");
+    const X = cos(0);
 
     public static function main() {
         echo "X is " . self::X . "\n";
@@ -12,4 +12,4 @@ class Example {
 Example::main();
 ?>
 --EXPECT--
-X is Hello, World
+X is 1

--- a/Zend/tests/call_in_const/class_const02.phpt
+++ b/Zend/tests/call_in_const/class_const02.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Can call internal functions from class constants
+--FILE--
+<?php
+function normalize_keys(array $x) {
+    // Should only invoke normalize_keys once
+    echo "Normalizing the keys\n";
+    $result = [];
+    foreach ($x as $k => $value) {
+        $result["prefix_$k"] = $value;
+    }
+    return $result;
+}
+class Example {
+    const X = [
+        'key1' => 'value1',
+        'key2' => 'value2',
+    ];
+    const Y = array_flip(self::X);
+    const Z = normalize_keys(self::Y);
+}
+var_export(Example::Z);
+var_export(Example::Z);
+var_export(Example::Y);
+?>
+--EXPECT--
+Normalizing the keys
+array (
+  'prefix_value1' => 'key1',
+  'prefix_value2' => 'key2',
+)array (
+  'prefix_value1' => 'key1',
+  'prefix_value2' => 'key2',
+)array (
+  'value1' => 'key1',
+  'value2' => 'key2',
+)

--- a/Zend/tests/call_in_const/class_const02.phpt
+++ b/Zend/tests/call_in_const/class_const02.phpt
@@ -2,35 +2,25 @@
 Can call internal functions from class constants
 --FILE--
 <?php
-function normalize_keys(array $x) {
-    // Should only invoke normalize_keys once
-    echo "Normalizing the keys\n";
-    $result = [];
-    foreach ($x as $k => $value) {
-        $result["prefix_$k"] = $value;
-    }
-    return $result;
-}
 class Example {
     const X = [
         'key1' => 'value1',
         'key2' => 'value2',
     ];
     const Y = array_flip(self::X);
-    const Z = normalize_keys(self::Y);
+    const Z = array_flip(self::Y);
 }
 var_export(Example::Z);
 var_export(Example::Z);
 var_export(Example::Y);
 ?>
 --EXPECT--
-Normalizing the keys
 array (
-  'prefix_value1' => 'key1',
-  'prefix_value2' => 'key2',
+  'key1' => 'value1',
+  'key2' => 'value2',
 )array (
-  'prefix_value1' => 'key1',
-  'prefix_value2' => 'key2',
+  'key1' => 'value1',
+  'key2' => 'value2',
 )array (
   'value1' => 'key1',
   'value2' => 'key2',

--- a/Zend/tests/call_in_const/class_const03.phpt
+++ b/Zend/tests/call_in_const/class_const03.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Cannot call functions accessing the variable scope in class constants
+--FILE--
+<?php
+class Example {
+    const X = func_get_args();
+
+    public static function main($value) {
+        try {
+            var_export(self::X);
+        } catch (Error $e) {
+            printf("Caught %s on line %d\n", $e->getMessage(), $e->getLine());
+        }
+        try {
+            var_export(self::X);
+        } catch (Error $e) {
+            printf("Caught %s on line %d\n", $e->getMessage(), $e->getLine());
+        }
+    }
+}
+Example::main('test');
+?>
+--EXPECT--
+Caught Cannot call func_get_args() dynamically on line 7
+Caught Cannot call func_get_args() dynamically on line 12

--- a/Zend/tests/call_in_const/class_const03.phpt
+++ b/Zend/tests/call_in_const/class_const03.phpt
@@ -20,6 +20,5 @@ class Example {
 }
 Example::main('test');
 ?>
---EXPECT--
-Caught Cannot call func_get_args() dynamically on line 7
-Caught Cannot call func_get_args() dynamically on line 12
+--EXPECTF--
+Fatal error: Constant expression uses function func_get_args() which is not in get_const_expr_functions() in %s on line 3

--- a/Zend/tests/call_in_const/class_const04.phpt
+++ b/Zend/tests/call_in_const/class_const04.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Handling call_user_func and static in class constants.
+--FILE--
+<?php
+class MyClass {
+    // There's only one constant declaration that gets shared by all of the classes.
+    // So act as though the class scope is MyClass no matter where it gets called.
+    const X = call_user_func('static::example');
+
+    public static function example() {
+        return static::class;
+    }
+    public static function main() {
+        echo static::X . "\n";
+    }
+}
+class SubClass extends MyClass {
+    public static function example() {
+        return "Other\n";
+    }
+}
+// This wouldn't work without further updates to the implementation.
+echo MyClass::X;
+SubClass::main();
+MyClass::main();
+
+?>
+--EXPECTF--
+Fatal error: Constant expression uses function call_user_func() which is not in get_const_expr_functions() in %s on line 5

--- a/Zend/tests/call_in_const/global_const01.phpt
+++ b/Zend/tests/call_in_const/global_const01.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Can call internal functions from global constants
+--FILE--
+<?php
+const NIL = var_export(null, true);
+
+echo "NIL is " . NIL . "\n";
+?>
+--EXPECT--
+NIL is NULL

--- a/Zend/tests/call_in_const/global_const01.phpt
+++ b/Zend/tests/call_in_const/global_const01.phpt
@@ -2,9 +2,10 @@
 Can call internal functions from global constants
 --FILE--
 <?php
-const NIL = var_export(null, true);
+const VALUES = RANGE(1, 100);
+const SUM = array_sum(VALUES);
 
-echo "NIL is " . NIL . "\n";
+echo "SUM is " . SUM . "\n";
 ?>
 --EXPECT--
-NIL is NULL
+SUM is 5050

--- a/Zend/tests/call_in_const/global_const02.phpt
+++ b/Zend/tests/call_in_const/global_const02.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Cannot declare constants with function calls that contain objects
+--FILE--
+<?php
+function make_object_array() {
+    return [new stdClass()];
+}
+const OBJECT_VALUES = make_object_array();
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Calls in constants may only evaluate to scalar values, arrays or resources in %s:5
+Stack trace:
+#0 {main}
+  thrown in %s on line 5

--- a/Zend/tests/call_in_const/global_const02.phpt
+++ b/Zend/tests/call_in_const/global_const02.phpt
@@ -8,7 +8,4 @@ function make_object_array() {
 const OBJECT_VALUES = make_object_array();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Calls in constants may only evaluate to scalar values, arrays or resources in %s:5
-Stack trace:
-#0 {main}
-  thrown in %s on line 5
+Fatal error: Constant expression uses function make_object_array() which is not in get_const_expr_functions() in %s on line 5

--- a/Zend/tests/call_in_const/methods_forbidden.phpt
+++ b/Zend/tests/call_in_const/methods_forbidden.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Cannot call methods in constant expressions
+--FILE--
+<?php
+// Currently, php will evaluate all of the instance property defaults at once and cache them
+// the first time a class gets instantiated, in _object_and_properties_init.
+//
+// Authors of future RFCs may wish to change PHP
+// to allow `count()` or `generate_unique_id()` or `public $fields = new stdClass();`
+// as the defaults of instance properties.
+class MyClass {
+    public static function example() {
+        return 'value';
+    }
+    const X = 'MyClass::example'();
+}
+?>
+--EXPECTF--
+Fatal error: Constant expression contains invalid name for function call in %s on line 12

--- a/Zend/tests/call_in_const/param_defaults01.phpt
+++ b/Zend/tests/call_in_const/param_defaults01.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Can call internal functions from parameter default
+--FILE--
+<?php
+function evaluated_user_function() {
+    // NOTE: PHP only caches non-refcounted values in the RECV_INIT value,
+    // meaning that if the returned value is dynamic, this will get called every time.
+    // TODO: Would it be worth it to convert refcounted values to immutable values?
+    echo "Evaluating default\n";
+    return sprintf("%s default", "Dynamic");
+}
+function test_default($x = evaluated_user_function()) {
+    echo "x is $x\n";
+}
+test_default();
+test_default(2);
+test_default();
+?>
+--EXPECT--
+Evaluating default
+x is Dynamic default
+x is 2
+Evaluating default
+x is Dynamic default

--- a/Zend/tests/call_in_const/param_defaults01.phpt
+++ b/Zend/tests/call_in_const/param_defaults01.phpt
@@ -2,14 +2,9 @@
 Can call internal functions from parameter default
 --FILE--
 <?php
-function evaluated_user_function() {
-    // NOTE: PHP only caches non-refcounted values in the RECV_INIT value,
-    // meaning that if the returned value is dynamic, this will get called every time.
-    // TODO: Would it be worth it to convert refcounted values to immutable values?
-    echo "Evaluating default\n";
-    return sprintf("%s default", "Dynamic");
-}
-function test_default($x = evaluated_user_function()) {
+namespace NS;
+use function max;
+function test_default($x = max(1, 3, 2)) {
     echo "x is $x\n";
 }
 test_default();
@@ -17,8 +12,6 @@ test_default(2);
 test_default();
 ?>
 --EXPECT--
-Evaluating default
-x is Dynamic default
+x is 3
 x is 2
-Evaluating default
-x is Dynamic default
+x is 3

--- a/Zend/tests/call_in_const/param_defaults02.phpt
+++ b/Zend/tests/call_in_const/param_defaults02.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Cannot access variable scope in parameter defaults
+--FILE--
+<?php
+
+namespace NS;
+
+use Error;
+
+function test_default($x = func_get_args()) {
+    var_dump($x);
+}
+try {
+    test_default();
+} catch (Error $e) {
+    printf("Caught %s on line %d\n", $e->getMessage(), $e->getLine());
+}
+test_default('overriding the default');
+try {
+    test_default();
+} catch (Error $e) {
+    printf("Caught %s on line %d\n", $e->getMessage(), $e->getLine());
+}
+?>
+--EXPECT--
+Caught Cannot call func_get_args() dynamically on line 7
+string(22) "overriding the default"
+Caught Cannot call func_get_args() dynamically on line 7

--- a/Zend/tests/call_in_const/param_defaults02.phpt
+++ b/Zend/tests/call_in_const/param_defaults02.phpt
@@ -22,7 +22,5 @@ try {
     printf("Caught %s on line %d\n", $e->getMessage(), $e->getLine());
 }
 ?>
---EXPECT--
-Caught Cannot call func_get_args() dynamically on line 7
-string(22) "overriding the default"
-Caught Cannot call func_get_args() dynamically on line 7
+--EXPECTF--
+Fatal error: Constant expression uses function NS\func_get_args() which is not in get_const_expr_functions() in %s on line 7

--- a/Zend/tests/call_in_const/param_defaults03.phpt
+++ b/Zend/tests/call_in_const/param_defaults03.phpt
@@ -1,5 +1,5 @@
 --TEST--
-User-defined functions are evaluated every time in param defaults
+User-defined functions are evaluated every time in param defaults (not callable)
 --FILE--
 <?php
 
@@ -16,7 +16,5 @@ test_id();
 test_id(-1);
 test_id();
 ?>
---EXPECT--
-id is 101
-id is -1
-id is 102
+--EXPECTF--
+Fatal error: Constant expression uses function generate_new_id() which is not in get_const_expr_functions() in %s on line 9

--- a/Zend/tests/call_in_const/param_defaults03.phpt
+++ b/Zend/tests/call_in_const/param_defaults03.phpt
@@ -1,0 +1,22 @@
+--TEST--
+User-defined functions are evaluated every time in param defaults
+--FILE--
+<?php
+
+function generate_new_id() : int {
+    static $id = 100;
+    ++$id;
+    return $id;
+}
+
+function test_id(int $id = generate_new_id()) {
+    echo "id is $id\n";
+}
+test_id();
+test_id(-1);
+test_id();
+?>
+--EXPECT--
+id is 101
+id is -1
+id is 102

--- a/Zend/tests/call_in_const/param_defaults04.phpt
+++ b/Zend/tests/call_in_const/param_defaults04.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Functions must be unambiguously in the whitelist
+--FILE--
+<?php
+namespace NS;
+function test_default($x = max(1, 3, 2)) {
+    echo "x is $x\n";
+}
+test_default();
+test_default(2);
+test_default();
+?>
+--EXPECTF--
+Fatal error: Constant expression uses function NS\max() which is not in get_const_expr_functions() in %s on line 3

--- a/Zend/tests/call_in_const/param_ref.phpt
+++ b/Zend/tests/call_in_const/param_ref.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Warn when calling function expecting a reference as an argument
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+class Example {
+    const VALUES = [];
+    const IS_MATCH = preg_match('/test/', 'testing');
+    const IS_MATCH_V2 = preg_match('/test/', 'testing', self::VALUES);
+
+    public static function main() {
+        echo "X is " . self::X . "\n";
+    }
+}
+var_dump(Example::IS_MATCH);
+var_dump(Example::IS_MATCH_V2);
+var_dump(Example::VALUES);
+--EXPECTF--
+int(1)
+
+Warning: Parameter 3 to preg_match() expected to be a reference, value given in %s on line 12
+int(1)
+array(0) {
+}

--- a/Zend/tests/call_in_const/param_ref.phpt
+++ b/Zend/tests/call_in_const/param_ref.phpt
@@ -17,9 +17,4 @@ var_dump(Example::IS_MATCH);
 var_dump(Example::IS_MATCH_V2);
 var_dump(Example::VALUES);
 --EXPECTF--
-int(1)
-
-Warning: Parameter 3 to preg_match() expected to be a reference, value given in %s on line 12
-int(1)
-array(0) {
-}
+Fatal error: Constant expression uses function preg_match() which is not in get_const_expr_functions() in %s on line 4

--- a/Zend/tests/call_in_const/property_default01.phpt
+++ b/Zend/tests/call_in_const/property_default01.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Can call user-defined functions from defaults of static properties
+--FILE--
+<?php
+namespace NS;
+
+function log_call($arg) {
+    echo "log_call(" . var_export($arg, true) . ")\n";
+    return $arg;
+}
+
+class MyClass {
+    public static $DEBUG = log_call(true);
+    public static $DEBUG2 = namespace\log_call(range(1,2));
+}
+echo "Start\n";
+var_export(MyClass::$DEBUG); echo "\n";
+var_export(MyClass::$DEBUG2); echo "\n";
+var_export(MyClass::$DEBUG); echo "\n";
+MyClass::$DEBUG = "New value";
+echo MyClass::$DEBUG . "\n";
+?>
+--EXPECT--
+Start
+log_call(true)
+log_call(array (
+  0 => 1,
+  1 => 2,
+))
+true
+array (
+  0 => 1,
+  1 => 2,
+)
+true
+New value

--- a/Zend/tests/call_in_const/property_default01.phpt
+++ b/Zend/tests/call_in_const/property_default01.phpt
@@ -3,12 +3,10 @@ Can call user-defined functions from defaults of static properties
 --FILE--
 <?php
 namespace NS;
-
 function log_call($arg) {
     echo "log_call(" . var_export($arg, true) . ")\n";
     return $arg;
 }
-
 class MyClass {
     public static $DEBUG = log_call(true);
     public static $DEBUG2 = namespace\log_call(range(1,2));
@@ -20,17 +18,5 @@ var_export(MyClass::$DEBUG); echo "\n";
 MyClass::$DEBUG = "New value";
 echo MyClass::$DEBUG . "\n";
 ?>
---EXPECT--
-Start
-log_call(true)
-log_call(array (
-  0 => 1,
-  1 => 2,
-))
-true
-array (
-  0 => 1,
-  1 => 2,
-)
-true
-New value
+--EXPECTF--
+Fatal error: Constant expression uses function NS\log_call() which is not in get_const_expr_functions() in %s on line 8

--- a/Zend/tests/call_in_const/property_default02.phpt
+++ b/Zend/tests/call_in_const/property_default02.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Cannot call functions from defaults of instance properties
+--FILE--
+<?php
+// Currently, php will evaluate all of the instance property defaults at once and cache them
+// the first time a class gets instantiated, in _object_and_properties_init.
+//
+// Authors of future RFCs may wish to change PHP
+// to allow `count()` or `generate_unique_id()` or `public $fields = new stdClass();`
+// as the defaults of instance properties.
+class MyClass {
+    public $v1 = count([]);
+}
+?>
+--EXPECTF--
+Fatal error: Default value for instance property MyClass::$v1 cannot contain function calls in %s on line 9

--- a/Zend/tests/call_in_const/recursion.phpt
+++ b/Zend/tests/call_in_const/recursion.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Recursion in calls in class constants causes an error
+--FILE--
+<?php
+function x_plus_1() {
+    echo "Computing X + 1\n";
+    return Recursion::X + 1;
+}
+class Recursion {
+    const X = x_plus_1();
+    const MISSING = MISSING_GLOBAL + 1;
+}
+try {
+    echo "Recursion::X=" . Recursion::X . "\n";
+} catch (Error $e) {
+    printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+}
+try {
+    echo "Recursion::X=" . Recursion::X . "\n";
+} catch (Error $e) {
+    printf("Second call caught %s: %s\n", get_class($e), $e->getMessage());
+}
+try {
+    echo "Recursion::MISSING=" . Recursion::MISSING;
+} catch (Error $e) {
+    printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+}
+try {
+    echo "Recursion::MISSING=" . Recursion::MISSING;
+} catch (Error $e) {
+    printf("Second call caught %s: %s\n", get_class($e), $e->getMessage());
+}
+?>
+--EXPECT--
+Computing X + 1
+Caught Error: Unrecoverable error calling x_plus_1() in recursive constant definition
+Computing X + 1
+Second call caught Error: Unrecoverable error calling x_plus_1() in recursive constant definition
+Caught Error: Undefined constant 'MISSING_GLOBAL'
+Second call caught Error: Undefined constant 'MISSING_GLOBAL'

--- a/Zend/tests/call_in_const/recursion.phpt
+++ b/Zend/tests/call_in_const/recursion.phpt
@@ -32,9 +32,4 @@ try {
 }
 ?>
 --EXPECT--
-Computing X + 1
-Caught Error: Unrecoverable error calling x_plus_1() in recursive constant definition
-Computing X + 1
-Second call caught Error: Unrecoverable error calling x_plus_1() in recursive constant definition
-Caught Error: Undefined constant 'MISSING_GLOBAL'
-Second call caught Error: Undefined constant 'MISSING_GLOBAL'
+Fatal error: Constant expression uses function x_plus_1() which is not in get_const_expr_functions() in /home/tyson/programming/php-src/Zend/tests/call_in_const/recursion.php on line 7

--- a/Zend/tests/call_in_const/recursion.phpt
+++ b/Zend/tests/call_in_const/recursion.phpt
@@ -31,5 +31,5 @@ try {
     printf("Second call caught %s: %s\n", get_class($e), $e->getMessage());
 }
 ?>
---EXPECT--
-Fatal error: Constant expression uses function x_plus_1() which is not in get_const_expr_functions() in /home/tyson/programming/php-src/Zend/tests/call_in_const/recursion.php on line 7
+--EXPECTF--
+Fatal error: Constant expression uses function x_plus_1() which is not in get_const_expr_functions() in %s on line 7

--- a/Zend/tests/call_in_const/static_default01.phpt
+++ b/Zend/tests/call_in_const/static_default01.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Can call internal functions from defaults of static variables
+--FILE--
+<?php
+function main() {
+    static $call = SPRINTF("%s!", sprintf("Hello, %s", "World"));
+    echo "$call\n";
+}
+main();
+main();
+?>
+--EXPECT--
+Hello, World!
+Hello, World!

--- a/Zend/tests/call_in_const/static_default01.phpt
+++ b/Zend/tests/call_in_const/static_default01.phpt
@@ -8,7 +8,7 @@ function main() {
 }
 main();
 main();
+// Note: It may be possible to allowing literally any call or value in static variables, but this is outside of the scope of this RFC.
 ?>
---EXPECT--
-Hello, World!
-Hello, World!
+--EXPECTF--
+Fatal error: Constant expression uses function SPRINTF() which is not in get_const_expr_functions() in %s on line 3

--- a/Zend/tests/call_in_const/static_default02.phpt
+++ b/Zend/tests/call_in_const/static_default02.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Can call user-defined functions from defaults of static variables
+--FILE--
+<?php
+function log_call(string $arg) {
+    echo "log_call('$arg')\n";
+    return $arg;
+}
+
+$f = function () {
+    static $call = log_call(sprintf("Hello, %s", "World"));
+    echo "$call\n";
+};
+$f();
+$f();
+?>
+--EXPECT--
+log_call('Hello, World')
+Hello, World
+Hello, World

--- a/Zend/tests/call_in_const/static_default02.phpt
+++ b/Zend/tests/call_in_const/static_default02.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Can call user-defined functions from defaults of static variables
+Cannot call user-defined functions from defaults of static variables
 --FILE--
 <?php
 function log_call(string $arg) {
@@ -14,7 +14,5 @@ $f = function () {
 $f();
 $f();
 ?>
---EXPECT--
-log_call('Hello, World')
-Hello, World
-Hello, World
+--EXPECTF--
+Fatal error: Constant expression uses function log_call() which is not in get_const_expr_functions() in %s on line 8

--- a/Zend/tests/call_in_const/static_default03.phpt
+++ b/Zend/tests/call_in_const/static_default03.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Can call internal functions from defaults of static variables
+--FILE--
+<?php
+function main() {
+    static $call = missing_sprintf("%s!", sprintf("Hello, %s", "World"));
+    echo "$call\n";
+}
+for ($i = 0; $i < 2; $i++) {
+    try {
+        main();
+    } catch (Error $e) {
+        printf("Caught %s: %s at line %d\n", get_class($e), $e->getMessage(), $e->getLine());
+    }
+}
+?>
+--EXPECT--
+Caught Error: Call to undefined function missing_sprintf() at line 3
+Caught Error: Call to undefined function missing_sprintf() at line 3

--- a/Zend/tests/call_in_const/static_default03.phpt
+++ b/Zend/tests/call_in_const/static_default03.phpt
@@ -14,6 +14,5 @@ for ($i = 0; $i < 2; $i++) {
     }
 }
 ?>
---EXPECT--
-Caught Error: Call to undefined function missing_sprintf() at line 3
-Caught Error: Call to undefined function missing_sprintf() at line 3
+--EXPECTF--
+Fatal error: Constant expression uses function missing_sprintf() which is not in get_const_expr_functions() in %s on line 3

--- a/Zend/tests/call_in_const/strict_types01.phpt
+++ b/Zend/tests/call_in_const/strict_types01.phpt
@@ -1,0 +1,14 @@
+--TEST--
+strict_types settings are respected
+--FILE--
+<?php
+declare(strict_types=1);
+// zend_call_function currently always adds a fake frame with strict_types,
+// because the current opcode is an possibly error handler.
+// This needs to be fixed.
+const X = "100";
+const RESULT = intdiv(X, 2);
+echo "Result is " . RESULT . "\n";
+?>
+--EXPECT--
+TODO: Throw

--- a/Zend/tests/call_in_const/too_few.phpt
+++ b/Zend/tests/call_in_const/too_few.phpt
@@ -1,0 +1,22 @@
+--TEST--
+ArgumentCountError thrown if constant contains call with too few arguments
+--FILE--
+<?php
+class Example {
+    const X = sprintf();
+
+    public static function main() {
+        echo "X is " . self::X . "\n";
+    }
+}
+for ($i = 0; $i < 2; $i++) {
+    try {
+        Example::main();
+    } catch (ArgumentCountError $e) {
+        printf("Caught %s on line %d\n", $e->getMessage(), $e->getLine());
+    }
+}
+?>
+--EXPECT--
+Caught sprintf() expects at least 1 parameter, 0 given on line 6
+Caught sprintf() expects at least 1 parameter, 0 given on line 6

--- a/Zend/tests/call_in_const/too_few.phpt
+++ b/Zend/tests/call_in_const/too_few.phpt
@@ -3,7 +3,7 @@ ArgumentCountError thrown if constant contains call with too few arguments
 --FILE--
 <?php
 class Example {
-    const X = sprintf();
+    const X = intdiv();
 
     public static function main() {
         echo "X is " . self::X . "\n";
@@ -18,5 +18,5 @@ for ($i = 0; $i < 2; $i++) {
 }
 ?>
 --EXPECT--
-Caught sprintf() expects at least 1 parameter, 0 given on line 6
-Caught sprintf() expects at least 1 parameter, 0 given on line 6
+Caught intdiv() expects exactly 2 parameters, 0 given on line 6
+Caught intdiv() expects exactly 2 parameters, 0 given on line 6

--- a/Zend/tests/call_in_const/varargs.phpt
+++ b/Zend/tests/call_in_const/varargs.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Allow varargs in calls in constants
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+const ARGS = ['Hello, %s', 'World'];
+const RESULT = sprintf(...ARGS);
+const RESULT_LINE = sprintf("%s\n", ...[RESULT]);
+echo RESULT_LINE;
+echo RESULT_LINE;
+--EXPECTF--
+Hello, World
+Hello, World

--- a/Zend/tests/call_in_const/varargs.phpt
+++ b/Zend/tests/call_in_const/varargs.phpt
@@ -4,11 +4,21 @@ Allow varargs in calls in constants
 error_reporting=E_ALL
 --FILE--
 <?php
-const ARGS = ['Hello, %s', 'World'];
-const RESULT = sprintf(...ARGS);
-const RESULT_LINE = sprintf("%s\n", ...[RESULT]);
-echo RESULT_LINE;
-echo RESULT_LINE;
+const ARGS = [[100], [2]];
+const RESULT = array_merge(...ARGS);
+const RESULT_LINE = ARRAY_MERGE([600], ...[RESULT]);
+var_export(RESULT_LINE);
+echo "\n";
+var_export(RESULT_LINE);
+echo "\n";
 --EXPECTF--
-Hello, World
-Hello, World
+array (
+  0 => 600,
+  1 => 100,
+  2 => 2,
+)
+array (
+  0 => 600,
+  1 => 100,
+  2 => 2,
+)

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -927,6 +927,9 @@ int zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 #endif
 	EG(error_reporting) = E_ALL & ~E_NOTICE;
 
+	CG(active_calls_in_constants) = (HashTable *)malloc(sizeof(HashTable));
+	zend_hash_init_ex(CG(active_calls_in_constants), 8, NULL, NULL, 1, 0);
+
 	zend_interned_strings_init();
 	zend_startup_builtin_functions();
 	zend_register_standard_constants();
@@ -1083,6 +1086,8 @@ void zend_shutdown(void) /* {{{ */
 
 	zend_hash_destroy(GLOBAL_CONSTANTS_TABLE);
 	free(GLOBAL_CONSTANTS_TABLE);
+	zend_hash_destroy(CG(active_calls_in_constants));
+	free(CG(active_calls_in_constants));
 	zend_shutdown_strtod();
 
 #ifdef ZTS

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -590,7 +590,7 @@ static int validate_constant_array(HashTable *ht) /* {{{ */
 }
 /* }}} */
 
-static void copy_constant_array(zval *dst, zval *src) /* {{{ */
+void copy_constant_array(zval *dst, zval *src) /* {{{ */
 {
 	zend_string *key;
 	zend_ulong idx;

--- a/Zend/zend_builtin_functions.h
+++ b/Zend/zend_builtin_functions.h
@@ -21,6 +21,7 @@
 #define ZEND_BUILTIN_FUNCTIONS_H
 
 int zend_startup_builtin_functions(void);
+void copy_constant_array(zval *dst, zval *src);
 
 BEGIN_EXTERN_C()
 ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int options, int limit);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8571,6 +8571,113 @@ void zend_compile_const_expr_magic_const(zend_ast **ast_ptr) /* {{{ */
 }
 /* }}} */
 
+static void assert_is_constant_function_name(zend_string *function_name, uint16_t ast_attr) { /* {{{ */
+	zend_string *fn = zend_string_tolower(function_name);
+	// FIXME: Optimize, Check length first, then strings of that length.
+	// This is written this way to make it easier to keep in sync with the RFC.
+	zend_bool in_whitelist =
+		zend_string_equals_literal(fn, "abs") ||
+		zend_string_equals_literal(fn, "acosh") ||
+		zend_string_equals_literal(fn, "acos") ||
+		zend_string_equals_literal(fn, "array_chunk") ||
+		zend_string_equals_literal(fn, "array_column") ||
+		zend_string_equals_literal(fn, "array_count_values") ||
+		zend_string_equals_literal(fn, "array_diff_assoc") ||
+		zend_string_equals_literal(fn, "array_diff_key") ||
+		zend_string_equals_literal(fn, "array_diff") ||
+		zend_string_equals_literal(fn, "array_fill_keys") ||
+		zend_string_equals_literal(fn, "array_fill") ||
+		zend_string_equals_literal(fn, "array_flip") ||
+		zend_string_equals_literal(fn, "array_intersect_assoc") ||
+		zend_string_equals_literal(fn, "array_intersect_key") ||
+		zend_string_equals_literal(fn, "array_intersect") ||
+		zend_string_equals_literal(fn, "array_key_exists") ||
+		zend_string_equals_literal(fn, "array_key_first") ||
+		zend_string_equals_literal(fn, "array_key_last") ||
+		zend_string_equals_literal(fn, "array_keys") ||
+		zend_string_equals_literal(fn, "array_merge_recursive") ||
+		zend_string_equals_literal(fn, "array_merge") ||
+		zend_string_equals_literal(fn, "array_pad") ||
+		zend_string_equals_literal(fn, "array_product") ||
+		zend_string_equals_literal(fn, "array_replace_recursive") ||
+		zend_string_equals_literal(fn, "array_replace") ||
+		zend_string_equals_literal(fn, "array_reverse") ||
+		zend_string_equals_literal(fn, "array_search") ||
+		zend_string_equals_literal(fn, "array_slice") ||
+		zend_string_equals_literal(fn, "array_sum") ||
+		zend_string_equals_literal(fn, "array_unique") ||
+		zend_string_equals_literal(fn, "array_values") ||
+		zend_string_equals_literal(fn, "asinh") ||
+		zend_string_equals_literal(fn, "asin") ||
+		zend_string_equals_literal(fn, "atan2") ||
+		zend_string_equals_literal(fn, "atanh") ||
+		zend_string_equals_literal(fn, "atan") ||
+		zend_string_equals_literal(fn, "boolval") ||
+		zend_string_equals_literal(fn, "ceil") ||
+		zend_string_equals_literal(fn, "checkdate") ||
+		zend_string_equals_literal(fn, "chr") ||
+		zend_string_equals_literal(fn, "cosh") ||
+		zend_string_equals_literal(fn, "cos") ||
+		zend_string_equals_literal(fn, "count") ||
+		zend_string_equals_literal(fn, "decbin") ||
+		zend_string_equals_literal(fn, "dechex") ||
+		zend_string_equals_literal(fn, "decoct") ||
+		zend_string_equals_literal(fn, "deg2rad") ||
+		zend_string_equals_literal(fn, "doubleval") ||
+		zend_string_equals_literal(fn, "expm1") ||
+		zend_string_equals_literal(fn, "exp") ||
+		zend_string_equals_literal(fn, "floatval") ||
+		zend_string_equals_literal(fn, "floor") ||
+		zend_string_equals_literal(fn, "fmod") ||
+		zend_string_equals_literal(fn, "gettype") ||
+		zend_string_equals_literal(fn, "gmmktime") ||
+		zend_string_equals_literal(fn, "hash_algos") ||
+		zend_string_equals_literal(fn, "hypot") ||
+		zend_string_equals_literal(fn, "in_array") ||
+		zend_string_equals_literal(fn, "intdiv") ||
+		zend_string_equals_literal(fn, "intval") ||
+		zend_string_equals_literal(fn, "is_array") ||
+		zend_string_equals_literal(fn, "is_bool") ||
+		zend_string_equals_literal(fn, "is_countable") ||
+		zend_string_equals_literal(fn, "is_double") ||
+		zend_string_equals_literal(fn, "is_finite") ||
+		zend_string_equals_literal(fn, "is_float") ||
+		zend_string_equals_literal(fn, "is_infinite") ||
+		zend_string_equals_literal(fn, "is_integer") ||
+		zend_string_equals_literal(fn, "is_int") ||
+		zend_string_equals_literal(fn, "is_iterable") ||
+		zend_string_equals_literal(fn, "is_long") ||
+		zend_string_equals_literal(fn, "is_nan") ||
+		zend_string_equals_literal(fn, "is_null") ||
+		zend_string_equals_literal(fn, "is_numeric") ||
+		zend_string_equals_literal(fn, "is_object") ||
+		zend_string_equals_literal(fn, "is_real") ||
+		zend_string_equals_literal(fn, "is_resource") ||
+		zend_string_equals_literal(fn, "is_scalar") ||
+		zend_string_equals_literal(fn, "is_string") ||
+		zend_string_equals_literal(fn, "log10") ||
+		zend_string_equals_literal(fn, "log1p") ||
+		zend_string_equals_literal(fn, "log") ||
+		zend_string_equals_literal(fn, "max") ||
+		zend_string_equals_literal(fn, "min") ||
+		zend_string_equals_literal(fn, "pi") ||
+		zend_string_equals_literal(fn, "pow") ||
+		zend_string_equals_literal(fn, "rad2deg") ||
+		zend_string_equals_literal(fn, "range") ||
+		zend_string_equals_literal(fn, "round") ||
+		zend_string_equals_literal(fn, "sinh") ||
+		zend_string_equals_literal(fn, "sin") ||
+		zend_string_equals_literal(fn, "sizeof") ||
+		zend_string_equals_literal(fn, "sqrt") ||
+		zend_string_equals_literal(fn, "tanh") ||
+		zend_string_equals_literal(fn, "tan");
+	zend_string_release(fn);
+	if (!in_whitelist) {
+		zend_error_noreturn(E_COMPILE_ERROR, "Constant expression uses function %s() which is not in get_const_expr_functions()", ZSTR_VAL(function_name));
+	}
+}
+/* }}} */
+
 void zend_compile_const_expr(zend_ast **ast_ptr) /* {{{ */
 {
 	zend_ast *ast = *ast_ptr;
@@ -8613,8 +8720,9 @@ void zend_compile_const_expr(zend_ast **ast_ptr) /* {{{ */
 				zend_error_noreturn(E_COMPILE_ERROR, "Constant expression contains invalid name for function call");
 			}
 			resolved_name = zend_resolve_function_name(original_name, func_name_ast->attr, &is_fully_qualified);
+			assert_is_constant_function_name(resolved_name, func_name_ast->attr);
 			// fprintf(stderr, "original_name=%s resolved_name=%s attr=%d is_fully_qualified=%d\n", ZSTR_VAL(original_name), ZSTR_VAL(resolved_name), (int)ast->child[0]->attr, (int)is_fully_qualified);
-			Z_STR_P(original_zv) = resolved_name;
+			ZVAL_STR(original_zv, resolved_name);
 			zend_string_release(original_name);
 			func_name_ast->attr = is_fully_qualified ? ZEND_NAME_FQ : ZEND_NAME_NOT_FQ;
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -130,6 +130,7 @@ void zend_compile_expr(znode *node, zend_ast *ast);
 zend_op *zend_compile_var(znode *node, zend_ast *ast, uint32_t type, int by_ref);
 void zend_eval_const_expr(zend_ast **ast_ptr);
 void zend_const_expr_to_zval(zval *result, zend_ast *ast);
+zend_bool ast_contains_call(zend_ast *ast);
 
 typedef int (*user_opcode_handler_t) (zend_execute_data *execute_data);
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -129,6 +129,7 @@ struct _zend_compiler_globals {
 	HashTable *delayed_autoloads;
 
 	uint32_t rtd_key_counter;
+	HashTable *active_calls_in_constants;	/* avoid recursive function calls */
 };
 
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5124,7 +5124,7 @@ ZEND_VM_HOT_HANDLER(64, ZEND_RECV_INIT, NUM, CONST, CACHE_SLOT)
 					ZVAL_UNDEF(param);
 					HANDLE_EXCEPTION();
 				}
-				if (!Z_REFCOUNTED_P(param)) {
+				if (!Z_REFCOUNTED_P(param) && !ast_contains_call(Z_ASTVAL_P(default_value))) {
 					ZVAL_COPY_VALUE(cache_val, param);
 				}
 			}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3013,7 +3013,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RECV_INIT_SPEC_CON
 					ZVAL_UNDEF(param);
 					HANDLE_EXCEPTION();
 				}
-				if (!Z_REFCOUNTED_P(param)) {
+				if (!Z_REFCOUNTED_P(param) && !ast_contains_call(Z_ASTVAL_P(default_value))) {
+					/* Could put the result of ast_contains_call in one of the high bits of extended_value instead, if it wouldn't conflict with the type? */
 					ZVAL_COPY_VALUE(cache_val, param);
 				}
 			}


### PR DESCRIPTION
I can think of two main approaches to adding function call
support to PHP. This implements the latter.

1. Only allow functions that are actually deterministic and don't depend on ini
   settings to be used in constant declarations.

   For example, allow `\count()`, `\strlen()`, `\array_merge()`, and `\in_array()`,
   but possibly don't allow functions such as
   `strtolower()` (different in Turkish locale),
   sprintf() (Depends on `ini_get('precision')`, but so does `(string)EXPR`),
   `json_encode()` (The `json` extension can be disabled),
   or calls which aren't unambiguously resolved with `\` or `use function`.

2. Allow any function (user-defined or internal) to be called,
   leave it to coding practice guidelines to assert that constants are only
   used in safe ways.

I'd imagine most developers would want many of the functions in the former,
though there are many arguments for/against supporting the latter.

The draft RFC is https://wiki.php.net/rfc/calls_in_constant_expressions

-------

- This POC can handle fully qualified, namespace relative, and not-FQ calls.
- Argument unpacking is supported
- Parameter defaults are evaluated every time if the expression
  contains function calls.
- This handles recursive definitions.
  It throws if a function call being evaluated ends up reaching the same call.
- Static method calls with known classes (other than static::)
  are probably easy to implement, but omitted from this RFC.
- This also constrains function return values to be valid constants,
  (i.e. they can be the same values that define() would accept)
  and throws an Error otherwise.

  In the future, `const X = [my_call()->x];` may be possible,
  but returning an object in any call is forbidden here.
- Variables and functions such as `func_get_args()` aren't supported,
  because they depend on the declaration's scope. They throw an Error at runtime.

-------

It turns out that function calls can already be invoked when evaluating a
constant, e.g. from php's error handler.
So it seems viable for PHP's engine to support regular calls,
which this POC does

(Imagine an error handler defining SOME_DYNAMIC_CONST123 to be a dynamic
value if a notice is emitted for the expression
`const X = [[]['undefined_index'], SOME_DYNAMIC_CONST123][1];`)

Function calls are allowed in the following types of constant expressions

- Defaults of static properties, but not instance properties,
  due to changes required to the PHP internals expanding the scope
  of this RFC too much.
- Parameter defaults
- Global constants and class constants
- Defaults of static variables
