### PR TITLE
Promote notice to Exception for base_convert errors

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -21,6 +21,7 @@
 #include "php_math.h"
 #include "zend_multiply.h"
 #include "zend_exceptions.h"
+#include "ext/spl/spl_exceptions.h"
 #include "zend_portability.h"
 
 #include <math.h>
@@ -812,7 +813,7 @@ PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret)
 	}
 
 	if (invalidchars > 0) {
-		zend_error(E_DEPRECATED, "Invalid characters passed for attempted conversion, these have been ignored");
+		zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0, "Invalid characters passed for base conversion");
 	}
 
 	if (mode == 1) {

--- a/ext/standard/tests/math/base_convert_basic.phpt
+++ b/ext/standard/tests/math/base_convert_basic.phpt
@@ -22,256 +22,130 @@ for ($f= 0; $f < count($frombase); $f++) {
 	for ($t= 0; $t < count($tobase); $t++) {
 		echo "......to base is ", $tobase[$t], "\n";
 		for ($i =0; $i < count($values); $i++){
-			$res = base_convert($values[$i],$frombase[$f],$tobase[$t]);
+            try {
+                $res = base_convert($values[$i],$frombase[$f],$tobase[$t]);
+            } catch (InvalidArgumentException $e) {
+                $res = 'INVALID';
+            }
 			echo ".........value= ", $values[$i], " res = ", $res, "\n";
 		}
 	}
 }
 ?>
---EXPECTF--
+--EXPECT--
 ...from base is 2
 ......to base is 2
 .........value= 10 res = 10
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 3 res = INVALID
+.........value= 95 res = INVALID
 .........value= 10 res = 10
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 8
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 3 res = INVALID
+.........value= 95 res = INVALID
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 10
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 3 res = INVALID
+.........value= 95 res = INVALID
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 16
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 3 res = INVALID
+.........value= 95 res = INVALID
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 36
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 3 res = INVALID
+.........value= 95 res = INVALID
 .........value= 10 res = 2
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 27 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 0
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 0
+.........value= 27 res = INVALID
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 
 ...from base is 8
 ......to base is 2
 .........value= 10 res = 1000
 .........value= 27 res = 10111
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 11
+.........value= 39 res = INVALID
 .........value= 3 res = 11
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 101
+.........value= 95 res = INVALID
 .........value= 10 res = 1000
 .........value= 27 res = 10111
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 11
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 101
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 11
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 8
 .........value= 10 res = 10
 .........value= 27 res = 27
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
+.........value= 39 res = INVALID
 .........value= 3 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 5
+.........value= 95 res = INVALID
 .........value= 10 res = 10
 .........value= 27 res = 27
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 10
 .........value= 10 res = 8
 .........value= 27 res = 23
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
+.........value= 39 res = INVALID
 .........value= 3 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 5
+.........value= 95 res = INVALID
 .........value= 10 res = 8
 .........value= 27 res = 23
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 16
 .........value= 10 res = 8
 .........value= 27 res = 17
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
+.........value= 39 res = INVALID
 .........value= 3 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 5
+.........value= 95 res = INVALID
 .........value= 10 res = 8
 .........value= 27 res = 17
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 36
 .........value= 10 res = 8
 .........value= 27 res = n
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
+.........value= 39 res = INVALID
 .........value= 3 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 95 res = 5
+.........value= 95 res = INVALID
 .........value= 10 res = 8
 .........value= 27 res = n
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 39 res = 3
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 39 res = INVALID
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 
 ...from base is 10
 ......to base is 2
@@ -283,12 +157,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = 1010
 .........value= 27 res = 11011
 .........value= 39 res = 100111
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 101
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 11
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 8
 .........value= 10 res = 12
 .........value= 27 res = 33
@@ -298,12 +168,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = 12
 .........value= 27 res = 33
 .........value= 39 res = 47
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 10
 .........value= 10 res = 10
 .........value= 27 res = 27
@@ -313,12 +179,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = 10
 .........value= 27 res = 27
 .........value= 39 res = 39
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 16
 .........value= 10 res = a
 .........value= 27 res = 1b
@@ -328,12 +190,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = a
 .........value= 27 res = 1b
 .........value= 39 res = 27
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 ......to base is 36
 .........value= 10 res = a
 .........value= 27 res = r
@@ -343,12 +201,8 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 10 res = a
 .........value= 27 res = r
 .........value= 39 res = 13
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 5F res = 5
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 5F res = INVALID
+.........value= 3XYZ res = INVALID
 
 ...from base is 16
 ......to base is 2
@@ -361,9 +215,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 100111
 .........value= 39 res = 111001
 .........value= 5F res = 1011111
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 11
+.........value= 3XYZ res = INVALID
 ......to base is 8
 .........value= 10 res = 20
 .........value= 27 res = 47
@@ -374,9 +226,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 47
 .........value= 39 res = 71
 .........value= 5F res = 137
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 3XYZ res = INVALID
 ......to base is 10
 .........value= 10 res = 16
 .........value= 27 res = 39
@@ -387,9 +237,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 39
 .........value= 39 res = 57
 .........value= 5F res = 95
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 3XYZ res = INVALID
 ......to base is 16
 .........value= 10 res = 10
 .........value= 27 res = 27
@@ -400,9 +248,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 27
 .........value= 39 res = 39
 .........value= 5F res = 5f
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 3XYZ res = INVALID
 ......to base is 36
 .........value= 10 res = g
 .........value= 27 res = 13
@@ -413,9 +259,7 @@ Deprecated: Invalid characters passed for attempted conversion, these have been 
 .........value= 27 res = 13
 .........value= 39 res = 1l
 .........value= 5F res = 2n
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-.........value= 3XYZ res = 3
+.........value= 3XYZ res = INVALID
 
 ...from base is 36
 ......to base is 2

--- a/ext/standard/tests/math/base_convert_improvements.phpt
+++ b/ext/standard/tests/math/base_convert_improvements.phpt
@@ -15,14 +15,22 @@ echo base_convert("0b1010" , 2, 10) . "\n";
 echo "=======================================";
 
 // These should fail
-echo base_convert('fg', 16, 10);
-echo base_convert('f 0xff ', 16, 10);
-echo base_convert('1xff ', 16, 10);
-echo base_convert(chr(0), 16, 10);
-echo base_convert("0o7" , 9, 10);
-echo base_convert("0 0" , 9, 10) . "\n";
+echo base_convert_with_catch('fg', 16, 10);
+echo base_convert_with_catch('f 0xff ', 16, 10);
+echo base_convert_with_catch('1xff ', 16, 10);
+echo base_convert_with_catch(chr(0), 16, 10);
+echo base_convert_with_catch("0o7" , 9, 10);
+echo base_convert_with_catch("0 0" , 9, 10) . "\n";
+
+function base_convert_with_catch($original, $fromBase, $toBase) {
+    try {
+        return base_convert($original, $fromBase, $toBase);
+    } catch (InvalidArgumentException $e) {
+        return "Invalid\n";
+    }
+}
 ?>
---EXPECTF--
+--EXPECT--
 255
 16
 255
@@ -32,16 +40,9 @@ echo base_convert("0 0" , 9, 10) . "\n";
 255
 7
 10
-=======================================
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-15
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-61695
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-511
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-0
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-7
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-0
+=======================================Invalid
+Invalid
+Invalid
+Invalid
+Invalid
+Invalid

--- a/ext/standard/tests/math/base_convert_variation1.phpt
+++ b/ext/standard/tests/math/base_convert_variation1.phpt
@@ -71,7 +71,12 @@ $inputs = array(
 $iterator = 1;
 foreach($inputs as $input) {
 	echo "\n-- Iteration $iterator --\n";
-	var_dump(base_convert($input, 10, 8));
+    try {
+        $output = base_convert($input, 10, 8);
+    } catch (InvalidArgumentException $e) {
+        $output = 'INVALID';
+    }
+	var_dump($output);
 	$iterator++;
 };
 fclose($fp);
@@ -89,37 +94,25 @@ string(1) "1"
 string(2) "14"
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(2) "14"
+string(7) "INVALID"
 
 -- Iteration 5 --
 string(11) "17777777777"
 
 -- Iteration 6 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(3) "151"
+string(7) "INVALID"
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(3) "151"
+string(7) "INVALID"
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(7) "4553207"
+string(7) "INVALID"
 
 -- Iteration 9 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(7) "4553207"
+string(7) "INVALID"
 
 -- Iteration 10 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "5"
+string(7) "INVALID"
 
 -- Iteration 11 --
 string(1) "0"
@@ -148,24 +141,16 @@ string(1) "0"
 -- Iteration 19 --
 
 Warning: Array to string conversion in %s on line %d
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "0"
+string(7) "INVALID"
 
 -- Iteration 20 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "0"
+string(7) "INVALID"
 
 -- Iteration 21 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "0"
+string(7) "INVALID"
 
 -- Iteration 22 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "0"
+string(7) "INVALID"
 
 -- Iteration 23 --
 string(1) "0"
@@ -174,6 +159,4 @@ string(1) "0"
 string(1) "0"
 
 -- Iteration 25 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-string(1) "5"
+string(7) "INVALID"

--- a/ext/standard/tests/math/bindec_basic_64bit.phpt
+++ b/ext/standard/tests/math/bindec_basic_64bit.phpt
@@ -29,49 +29,31 @@ $values = array(111000111,
 				null);
 
 for ($i = 0; $i < count($values); $i++) {
-	$res = bindec($values[$i]);
+    try {
+        $res = bindec($values[$i]);
+    } catch (InvalidArgumentException $e) {
+        $res = 'INVALID';
+    }
 	var_dump($res);
 }
 ?>
---EXPECTF--
+--EXPECT--
 int(455)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(32766)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(5)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(129)
+string(7) "INVALID"
+string(7) "INVALID"
+string(7) "INVALID"
+string(7) "INVALID"
 int(455)
 int(224)
 int(2147483647)
 int(2147483648)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(129)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(13)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(13)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(26)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(6)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+string(7) "INVALID"
+string(7) "INVALID"
+string(7) "INVALID"
+string(7) "INVALID"
+string(7) "INVALID"
+string(7) "INVALID"
+string(7) "INVALID"
 int(1)
 int(0)
 int(0)

--- a/ext/standard/tests/math/bindec_variation1.phpt
+++ b/ext/standard/tests/math/bindec_variation1.phpt
@@ -77,7 +77,9 @@ foreach($inputs as $input) {
 		var_dump(bindec($input));
 	} catch (TypeError $e) {
 		echo $e->getMessage(), "\n";
-	}
+	} catch (InvalidArgumentException $e) {
+        echo "INVALID\n";
+    }
 	$iterator++;
 };
 fclose($fp);

--- a/ext/standard/tests/math/bindec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/bindec_variation1_64bit.phpt
@@ -77,12 +77,14 @@ foreach($inputs as $input) {
 		var_dump(bindec($input));
 	} catch (TypeError $e) {
 		echo $e->getMessage(), "\n";
-	}
+	} catch (InvalidArgumentException $e) {
+        echo "INVALID\n";
+    }
 	$iterator++;
 };
 fclose($fp);
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing bindec() : usage variations ***
 
 -- Iteration 1 --
@@ -92,39 +94,25 @@ int(0)
 int(1)
 
 -- Iteration 3 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1)
+INVALID
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+INVALID
 
 -- Iteration 5 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2)
+INVALID
 
 -- Iteration 6 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2)
+INVALID
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(8)
+INVALID
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1)
+INVALID
 
 -- Iteration 9 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+INVALID
 
 -- Iteration 10 --
 int(0)
@@ -154,19 +142,13 @@ int(0)
 bindec() expects parameter 1 to be string, array given
 
 -- Iteration 19 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+INVALID
 
 -- Iteration 20 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+INVALID
 
 -- Iteration 21 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+INVALID
 
 -- Iteration 22 --
 int(0)

--- a/ext/standard/tests/math/hexdec.phpt
+++ b/ext/standard/tests/math/hexdec.phpt
@@ -7,24 +7,30 @@ precision=14
 
 var_dump(hexdec("012345"));
 var_dump(hexdec("12345"));
-var_dump(hexdec("q12345"));
-var_dump(hexdec("12345+?!"));
-var_dump(hexdec("12345q"));
+try {
+    var_dump(hexdec("q12345"));
+} catch (InvalidArgumentException $e) {
+    echo "INVALID\n";
+}
+try {
+    var_dump(hexdec("12345+?!"));
+} catch (InvalidArgumentException $e) {
+    echo "INVALID\n";
+}
+try {
+    var_dump(hexdec("12345q"));
+} catch (InvalidArgumentException $e) {
+    echo "INVALID\n";
+}
 var_dump((float)hexdec("1234500001"));
 var_dump((float)hexdec("17fffffff"));
 
 ?>
---EXPECTF--
+--EXPECT--
 int(74565)
 int(74565)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(74565)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(74565)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(74565)
+INVALID
+INVALID
+INVALID
 float(78187069441)
 float(6442450943)

--- a/ext/standard/tests/math/hexdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_basic_64bit.phpt
@@ -29,11 +29,16 @@ $values = array(0x123abc,
 
 foreach($values as $value) {
 	echo "\n-- hexdec $value --\n";
-	var_dump(hexdec($value));
+    try {
+        $output = hexdec($value);
+    } catch (InvalidArgumentException $e) {
+        $output = 'INVALID';
+    }
+	var_dump($output);
 };
 
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing hexdec() : basic functionality ***
 
 -- hexdec 1194684 --
@@ -61,9 +66,7 @@ int(2147483647)
 int(2147483648)
 
 -- hexdec 0x123XYZABC --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1194684)
+string(7) "INVALID"
 
 -- hexdec 311015 --
 int(3215381)
@@ -72,9 +75,7 @@ int(3215381)
 int(3215381)
 
 -- hexdec 31101.3 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(3215379)
+string(7) "INVALID"
 
 -- hexdec 3110130 --
 int(51446064)

--- a/ext/standard/tests/math/hexdec_variation1_64bit.phpt
+++ b/ext/standard/tests/math/hexdec_variation1_64bit.phpt
@@ -81,12 +81,14 @@ foreach($inputs as $input) {
 		var_dump(hexdec($input));
 	} catch (TypeError $e) {
 		echo $e->getMessage(), "\n";
+	} catch (InvalidArgumentException $e) {
+		echo "INVALID\n";
 	}
 	$iterator++;
 };
 fclose($fp);
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing hexdec() : usage variations ***
 
 -- Iteration 1 --
@@ -99,9 +101,7 @@ int(1)
 int(74565)
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(9029)
+INVALID
 
 -- Iteration 5 --
 int(285960729237)
@@ -110,27 +110,19 @@ int(285960729237)
 int(285960729238)
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(261)
+INVALID
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(261)
+INVALID
 
 -- Iteration 9 --
 int(20015998341120)
 
 -- Iteration 10 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1250999896553)
+INVALID
 
 -- Iteration 11 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(5)
+INVALID
 
 -- Iteration 12 --
 int(0)
@@ -160,19 +152,13 @@ int(0)
 hexdec() expects parameter 1 to be string, array given
 
 -- Iteration 21 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2748)
+INVALID
 
 -- Iteration 22 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2748)
+INVALID
 
 -- Iteration 23 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(2748)
+INVALID
 
 -- Iteration 24 --
 int(0)

--- a/ext/standard/tests/math/octdec_basic_64bit.phpt
+++ b/ext/standard/tests/math/octdec_basic_64bit.phpt
@@ -28,37 +28,29 @@ $values = array(01234567,
 				null);
 
 for ($i = 0; $i < count($values); $i++) {
-	$res = octdec($values[$i]);
+    try {
+        $res = octdec($values[$i]);
+    } catch (InvalidArgumentException $e) {
+        $res = 'INVALID';
+    }
 	var_dump($res);
 }
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing octdec() : basic functionality ***
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(14489)
+string(7) "INVALID"
 int(253)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(36947879)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(4618484)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(4104)
+string(7) "INVALID"
+string(7) "INVALID"
+string(7) "INVALID"
 int(5349)
 int(342391)
 int(375)
 int(2147483647)
 int(2147483648)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(668)
+string(7) "INVALID"
 int(5349)
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(102923)
+string(7) "INVALID"
 int(823384)
 int(1)
 int(0)

--- a/ext/standard/tests/math/octdec_variation1.phpt
+++ b/ext/standard/tests/math/octdec_variation1.phpt
@@ -77,13 +77,15 @@ foreach($inputs as $input) {
 		var_dump(octdec($input));
 	} catch (TypeError $e) {
 		echo $e->getMessage(), "\n";
-	}
+	} catch (InvalidArgumentException $e) {
+        echo "INVALID\n";
+    }
 	$iterator++;
 };
 fclose($fp);
 ?>
 ---Done---
---EXPECTF--
+--EXPECT--
 *** Testing octdec() : usage variations ***
 
 -- Iteration 1 --
@@ -96,44 +98,28 @@ int(1)
 int(5349)
 
 -- Iteration 4 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1253)
+INVALID
 
 -- Iteration 5 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1134037)
+INVALID
 
 -- Iteration 6 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(1134038)
+INVALID
 
 -- Iteration 7 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(69)
+INVALID
 
 -- Iteration 8 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(69)
+INVALID
 
 -- Iteration 9 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(175304192)
+INVALID
 
 -- Iteration 10 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(342391)
+INVALID
 
 -- Iteration 11 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(5)
+INVALID
 
 -- Iteration 12 --
 int(0)
@@ -163,19 +149,13 @@ int(0)
 octdec() expects parameter 1 to be string, array given
 
 -- Iteration 21 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+INVALID
 
 -- Iteration 22 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+INVALID
 
 -- Iteration 23 --
-
-Deprecated: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-int(0)
+INVALID
 
 -- Iteration 24 --
 int(0)


### PR DESCRIPTION
As discussed in https://wiki.php.net/rfc/base_convert_improvements

The notice will be upgraded to an exception in php8