### PR TITLE
Fix #79212: NumberFormatter::format() may detect wrong type

### DIFF
--- a/ext/intl/formatter/formatter_format.c
+++ b/ext/intl/formatter/formatter_format.c
@@ -53,7 +53,11 @@ PHP_FUNCTION( numfmt_format )
 	/* Fetch the object. */
 	FORMATTER_METHOD_FETCH_OBJECT;
 
-	convert_scalar_to_number_ex(number);
+	if(Z_TYPE_P(number) != IS_ARRAY) {
+		convert_scalar_to_number_ex(number);
+	} else {
+		convert_to_long(number);
+	}
 
 	if(type == FORMAT_TYPE_DEFAULT) {
 		switch(Z_TYPE_P(number)) {

--- a/ext/intl/formatter/formatter_format.c
+++ b/ext/intl/formatter/formatter_format.c
@@ -53,23 +53,19 @@ PHP_FUNCTION( numfmt_format )
 	/* Fetch the object. */
 	FORMATTER_METHOD_FETCH_OBJECT;
 
+	convert_scalar_to_number_ex(number);
+
 	if(type == FORMAT_TYPE_DEFAULT) {
-		if(Z_TYPE_P(number) == IS_STRING) {
-			convert_scalar_to_number_ex(number);
+		switch(Z_TYPE_P(number)) {
+			case IS_LONG:
+				/* take INT32 on 32-bit, int64 on 64-bit */
+				type = (sizeof(zend_long) == 8)?FORMAT_TYPE_INT64:FORMAT_TYPE_INT32;
+				break;
+			case IS_DOUBLE:
+				type = FORMAT_TYPE_DOUBLE;
+				break;
+			EMPTY_SWITCH_DEFAULT_CASE();
 		}
-
-		if(Z_TYPE_P(number) == IS_LONG) {
-			/* take INT32 on 32-bit, int64 on 64-bit */
-			type = (sizeof(zend_long) == 8)?FORMAT_TYPE_INT64:FORMAT_TYPE_INT32;
-		} else if(Z_TYPE_P(number) == IS_DOUBLE) {
-			type = FORMAT_TYPE_DOUBLE;
-		} else {
-			type = FORMAT_TYPE_INT32;
-		}
-	}
-
-	if(Z_TYPE_P(number) != IS_DOUBLE && Z_TYPE_P(number) != IS_LONG) {
-		convert_scalar_to_number(number );
 	}
 
 	switch(type) {

--- a/ext/intl/tests/bug79212.phpt
+++ b/ext/intl/tests/bug79212.phpt
@@ -9,6 +9,10 @@ if (!extension_loaded('gmp')) die('skip gmp extension not available');
 <?php
 $fmt = new NumberFormatter('en_US', NumberFormatter::PATTERN_DECIMAL);
 var_dump($fmt->format(gmp_init('823749273428379492374')));
+
+$fmt = new NumberFormatter('en_US', NumberFormatter::PATTERN_DECIMAL);
+var_dump($fmt->format([1], NumberFormatter::TYPE_INT64));
 ?>
 --EXPECT--
 string(21) "823749273428379400000"
+string(1) "1"

--- a/ext/intl/tests/bug79212.phpt
+++ b/ext/intl/tests/bug79212.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #79212 (NumberFormatter::format() may detect wrong type)
+--SKIPIF--
+<?php
+if (!extension_loaded('intl')) die('skip intl extension not available');
+if (!extension_loaded('gmp')) die('skip gmp extension not available');
+?>
+--FILE--
+<?php
+$fmt = new NumberFormatter('en_US', NumberFormatter::PATTERN_DECIMAL);
+var_dump($fmt->format(gmp_init('823749273428379492374')));
+?>
+--EXPECT--
+string(21) "823749273428379400000"


### PR DESCRIPTION
We have to convert to number *before* detecting the type, to cater to
internal objects implementing `cast_object`.

We also get rid of the fallback behavior of using `FORMAT_TYPE_INT32`,
because that can no longer happen; after `convert_to_numer()` the type
is either `IS_LONG` or `IS_DOUBLE`.