### PR TITLE
Fix #78090: test 3408/14609 of make test takes forever to finish

### DIFF
--- a/ext/curl/tests/bug45161.phpt
+++ b/ext/curl/tests/bug45161.phpt
@@ -12,6 +12,11 @@ $curl_version = curl_version();
 if ($curl_version['version_number'] < 0x071100) {
 	exit("skip: test works only with curl >= 7.17.0");
 }
+$socket = fsockopen('127.0.0.1', 9, $errno, $errstr, 1);
+if ($socket === false) {
+	exit("skip discard protocol unsupported");
+}
+fclose($socket);
 ?>
 --FILE--
 <?php

--- a/ext/curl/tests/bug45161.phpt
+++ b/ext/curl/tests/bug45161.phpt
@@ -7,11 +7,6 @@ $curl_version = curl_version();
 if ($curl_version['version_number'] < 0x071100) {
 	exit("skip: test works only with curl >= 7.17.0");
 }
-$ch = curl_init('http://127.0.0.1:9/');
-curl_exec($ch);
-if (curl_error() === CURLE_OPERATION_TIMEDOUT) {
-	die("skip discard protocol unsupported");
-} 
 ?>
 --FILE--
 <?php

--- a/ext/curl/tests/bug45161.phpt
+++ b/ext/curl/tests/bug45161.phpt
@@ -2,12 +2,7 @@
 Bug #45161 (Reusing a curl handle leaks memory)
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-	exit("skip not for Windows");
-}
-if (!extension_loaded("curl")) {
-	exit("skip curl extension not loaded");
-}
+include 'skipif.inc';
 $curl_version = curl_version();
 if ($curl_version['version_number'] < 0x071100) {
 	exit("skip: test works only with curl >= 7.17.0");
@@ -20,10 +15,12 @@ if (curl_error() === CURLE_OPERATION_TIMEDOUT) {
 ?>
 --FILE--
 <?php
+include 'server.inc';
+$host = curl_cli_server_start();
 
 // Fill memory for test
 $ch = curl_init();
-$fp = fopen('/dev/null', 'w');
+$fp = fopen(PHP_OS_FAMILY === 'Windows' ? 'nul' : '/dev/null', 'w');
 
 /*
 $i = $start = $end = 100000.00;
@@ -37,7 +34,7 @@ for ($i = 0; $i < 100; $i++) {
 // Start actual test
 $start = memory_get_usage() + 1024;
 for($i = 0; $i < 1024; $i++) {
-	curl_setopt($ch, CURLOPT_URL, 'http://127.0.0.1:9/');
+	curl_setopt($ch, CURLOPT_URL, "{$host}/get.inc");
 	curl_setopt($ch, CURLOPT_FILE, $fp);
 	curl_exec($ch);
 }

--- a/ext/curl/tests/bug45161.phpt
+++ b/ext/curl/tests/bug45161.phpt
@@ -12,11 +12,11 @@ $curl_version = curl_version();
 if ($curl_version['version_number'] < 0x071100) {
 	exit("skip: test works only with curl >= 7.17.0");
 }
-$socket = fsockopen('127.0.0.1', 9, $errno, $errstr, 1);
-if ($socket === false) {
-	exit("skip discard protocol unsupported");
-}
-fclose($socket);
+$ch = curl_init('http://127.0.0.1:9/');
+curl_exec($ch);
+if (curl_error() === CURLE_OPERATION_TIMEDOUT) {
+	die("skip discard protocol unsupported");
+} 
 ?>
 --FILE--
 <?php

--- a/ext/curl/tests/bug46739.phpt
+++ b/ext/curl/tests/bug46739.phpt
@@ -2,13 +2,14 @@
 Bug #46739 (array returned by curl_getinfo should contain content_type key)
 --SKIPIF--
 <?php
-if (!extension_loaded("curl")) {
-	exit("skip curl extension not loaded");
-}
+include 'skipif.inc';
 ?>
 --FILE--
 <?php
-$ch = curl_init('http://127.0.0.1:9/');
+include 'server.inc';
+$host = curl_cli_server_start();
+$ch = curl_init("{$host}/get.inc");
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
 curl_exec($ch);
 $info = curl_getinfo($ch);


### PR DESCRIPTION
Not all systems support the discard protocol (TCP port 9), so we skip
this test, if the system does not.