### PR TITLE
Fix bug #78598

### DIFF
--- a/Zend/tests/bug70662.phpt
+++ b/Zend/tests/bug70662.phpt
@@ -14,5 +14,5 @@ var_dump($a);
 --EXPECT--
 array(1) {
   ["b"]=>
-  int(1)
+  int(2)
 }

--- a/Zend/tests/bug78598.phpt
+++ b/Zend/tests/bug78598.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Bug #78598: Changing array during undef index RW error segfaults
+--FILE--
+<?php
+
+$my_var = null;
+set_error_handler(function() use(&$my_var) {
+    $my_var = 0;
+});
+
+$my_var[0] .= "xyz";
+var_dump($my_var);
+
+$my_var = null;
+$my_var[0][0][0] .= "xyz";
+var_dump($my_var);
+
+$my_var = null;
+$my_var["foo"] .= "xyz";
+var_dump($my_var);
+
+$my_var = null;
+$my_var["foo"]["bar"]["baz"] .= "xyz";
+var_dump($my_var);
+
+?>
+--EXPECT--
+int(0)
+int(0)
+int(0)
+int(0)

--- a/Zend/tests/undef_index_to_exception.phpt
+++ b/Zend/tests/undef_index_to_exception.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Converting undefined index/offset notice to exception
+--FILE--
+<?php
+
+set_error_handler(function($_, $msg) {
+    throw new Exception($msg);
+});
+
+$test = [];
+try {
+    $test[0] .= "xyz";
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump($test);
+
+try {
+    $test["key"] .= "xyz";
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump($test);
+
+unset($test);
+try {
+    $GLOBALS["test"] .= "xyz";
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    var_dump($test);
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Undefined offset: 0
+array(0) {
+}
+Undefined index: key
+array(0) {
+}
+Undefined index: test
+Undefined variable: test

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1974,6 +1974,9 @@ static zend_never_inline ZEND_COLD int ZEND_FASTCALL zend_undefined_offset_write
 		zend_array_destroy(ht);
 		return FAILURE;
 	}
+	if (EG(exception)) {
+		return FAILURE;
+	}
 	return SUCCESS;
 }
 
@@ -1988,6 +1991,9 @@ static zend_never_inline ZEND_COLD int ZEND_FASTCALL zend_undefined_index_write(
 	zend_undefined_index(offset);
 	if (!(GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) && !GC_DELREF(ht)) {
 		zend_array_destroy(ht);
+		return FAILURE;
+	}
+	if (EG(exception)) {
 		return FAILURE;
 	}
 	return SUCCESS;

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2123,8 +2123,7 @@ num_undef:
 				if (UNEXPECTED(zend_undefined_offset_write(ht, hval) == FAILURE)) {
 					return NULL;
 				}
-				retval = zend_hash_index_update(ht, hval, &EG(uninitialized_zval));
-				break;
+				/* break missing intentionally */
 			case BP_VAR_W:
 				retval = zend_hash_index_add_new(ht, hval, &EG(uninitialized_zval));
 				break;
@@ -2175,8 +2174,7 @@ str_index:
 					if (UNEXPECTED(zend_undefined_index_write(ht, offset_key) == FAILURE)) {
 						return NULL;
 					}
-					retval = zend_hash_update(ht, offset_key, &EG(uninitialized_zval));
-					break;
+					/* break missing intentionally */
 				case BP_VAR_W:
 					retval = zend_hash_add_new(ht, offset_key, &EG(uninitialized_zval));
 					break;


### PR DESCRIPTION
Fix https://bugs.php.net/bug.php?id=78598 by temporarily increasing refcount while throwing the notice. If the original array is destroyed while the notice is thrown, abort the operation.