### PR TITLE
Add -Wextra compiler flag exclude some of the major offender

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -221,7 +221,10 @@ else
   AC_DEFINE(ZEND_DEBUG,0,[ ])
 fi
 
-test -n "$GCC" && CFLAGS="$CFLAGS -Wall -Wno-strict-aliasing"
+test -n "$GCC" && CFLAGS="$CFLAGS -Wall -Wextra -Wno-strict-aliasing -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-sign-compare"
+dnl Check if compiler supports -Wno-clobbered (only GCC)
+AX_CHECK_COMPILE_FLAG([-Wno-clobbered], CFLAGS="$CFLAGS -Wno-clobbered", , [-Werror])
+
 test -n "$DEBUG_CFLAGS" && CFLAGS="$CFLAGS $DEBUG_CFLAGS"
 
 if test "$ZEND_ZTS" = "yes"; then

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -11,6 +11,8 @@ if test "$PHP_SODIUM" != "no"; then
 
   AC_DEFINE(HAVE_LIBSODIUMLIB, 1, [ ])
 
-  PHP_NEW_EXTENSION(sodium, libsodium.c sodium_pwhash.c, $ext_shared)
+  dnl Add -Wno-type-limits as this may arise on 32bits platforms
+  SODIUM_COMPILER_FLAGS="$LIBSODIUM_CFLAGS -Wno-type-limits"
+  PHP_NEW_EXTENSION(sodium, libsodium.c sodium_pwhash.c, $ext_shared, , $SODIUM_COMPILER_FLAGS)
   PHP_SUBST(SODIUM_SHARED_LIBADD)
 fi

--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -65,8 +65,9 @@ if test "$PHP_TIDY" != "no"; then
   PHP_ADD_LIBRARY_WITH_PATH($TIDY_LIB_NAME, $TIDY_LIBDIR, TIDY_SHARED_LIBADD)
   PHP_ADD_INCLUDE($TIDY_INCDIR)
 
-
-  PHP_NEW_EXTENSION(tidy, tidy.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+  dnl Add -Wno-empty-body as this is an issue upstream
+  TIDY_COMPILER_FLAGS="$TIDY_CFLAGS -Wno-ignored-qualifiers -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  PHP_NEW_EXTENSION(tidy, tidy.c, $ext_shared,, $TIDY_COMPILER_FLAGS)
   PHP_SUBST(TIDY_SHARED_LIBADD)
   AC_DEFINE(HAVE_TIDY,1,[ ])
 fi


### PR DESCRIPTION
Although I don't think we will be able to add the  ``-Wextra`` flag without disabling some of the warnings which are enabled within this short cut. It seems better to be aware that these issues exist within the codebase.

Currently I've disabled ~~5~~4 flags from ``-Wextra``:

- ``-Wclobbered`` which arises a lot within the Opcache extensions and the SAPI.
- ``-Wimplicit-fallthrough`` even with ``-W-implicit-fallthrough=1`` there are still a large amount of them and a lot in the JIT/Opcache which may be generated files?
- ``-Wunused-parameter`` this one happens a lot in macros and ZEND/PHP_API functions for extensions BC
- ``-Wsign-compare`` if someone wants to tackle it, the compiler output for ``-W-sign-compare`` is a bit more than 1000 lines: https://gist.github.com/Girgias/8c7aefc9687515a31efce589e95fc942
- ~~``-Wmissing-field-initializers`` only has seven offender but five of them are in PHPDBG, compiler output: https://gist.github.com/Girgias/74251f0a2a2fb08e2262186cc0ec925d~~