### PR TITLE
Add API functions for zend_exception

### DIFF
--- a/Zend/tests/bug63762.phpt
+++ b/Zend/tests/bug63762.phpt
@@ -39,14 +39,14 @@ string(36) "#0 [internal function]: ()
 
 Array of array of NULL values:
 
-Warning: Function name is no string in %s on line %d
+Warning: Trace file is not a string in %s on line %d
 
-Warning: Value for class is no string in %s on line %d
+Warning: Trace class is not a string in %s on line %d
 
-Warning: Value for type is no string in %s on line %d
+Warning: Trace type is not a string in %s on line %d
 
-Warning: Value for function is no string in %s on line %d
+Warning: Trace function is not a string in %s on line %d
 
-Warning: args element is no array in %s on line %d
+Warning: Trace args is not an array in %s on line %d
 string(60) "#0 [unknown function][unknown][unknown][unknown]()
 #1 {main}"

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -68,6 +68,15 @@ extern ZEND_API void (*zend_throw_exception_hook)(zval *ex);
 /* show an exception using zend_error(severity,...), severity should be E_ERROR */
 ZEND_API ZEND_COLD void zend_exception_error(zend_object *exception, int severity);
 
+/* Note that codes are supposed to be integers, but MySQL uses strings so this
+ * returns a zval instead of zend_long. */
+ZEND_API zval *zend_exception_get_code(zend_object *exception, zend_bool silent);
+ZEND_API zend_string *zend_exception_get_file(zend_object *exception, zend_bool silent);
+ZEND_API zend_long *zend_exception_get_line(zend_object *exception, zend_bool silent);
+ZEND_API zend_string *zend_exception_get_message(zend_object *exception, zend_bool silent);
+ZEND_API HashTable *zend_exception_get_trace(zend_object *exception, zend_bool silent);
+ZEND_API zend_string *zend_exception_get_trace_as_string(zend_object *exception, zend_bool include_args, zend_bool silent);
+
 #include "zend_globals.h"
 
 static zend_always_inline void zend_rethrow_exception(zend_execute_data *execute_data)

--- a/ext/standard/tests/serialize/bug69152.phpt
+++ b/ext/standard/tests/serialize/bug69152.phpt
@@ -9,6 +9,6 @@ $x->test();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Trace is not an array in %s:%d
+Fatal error: Uncaught TypeError: Exception trace is not an array in %s:%d
 %a
   thrown in %s on line %d

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1074,12 +1074,9 @@ static int do_cli(int argc, char **argv) /* {{{ */
 					zend_call_method_with_1_params(Z_OBJ(ref), pce, &pce->constructor, "__construct", NULL, &arg);
 
 					if (EG(exception)) {
-						zval tmp, *msg, rv;
-
-						ZVAL_OBJ(&tmp, EG(exception));
-						msg = zend_read_property(zend_ce_exception, &tmp, "message", sizeof("message")-1, 0, &rv);
-						zend_printf("Exception: %s\n", Z_STRVAL_P(msg));
-						zval_ptr_dtor(&tmp);
+						zend_string *msg = zend_exception_get_message(EG(exception), 1);
+						zend_printf("Exception: %s\n", msg ? msg->val : "(exception message was not a string)");
+						OBJ_RELEASE(EG(exception));
 						EG(exception) = NULL;
 					} else {
 						zend_print_zval(&ref, 0);

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -734,10 +734,10 @@ static inline void phpdbg_handle_exception(void) /* {{{ */
 		EG(exception) = NULL;
 		msg = ZSTR_EMPTY_ALLOC();
 	} else {
-		zend_class_entry *ce = zend_get_exception_base(&zv);
-		zend_update_property_string(ce, &zv, ZEND_STRL("string"), Z_STRVAL(tmp));
+		zend_class_entry *base_ce = zend_get_exception_base(&zv);
+		zend_update_property_string(base_ce, &zv, ZEND_STRL("string"), Z_STRVAL(tmp));
 		zval_ptr_dtor(&tmp);
-		msg = zval_get_string(zend_read_property(zend_get_exception_base(&zv), &zv, ZEND_STRL("string"), 1, &rv));
+		msg = zval_get_string(zend_read_property(base_ce, &zv, ZEND_STRL("string"), 1, &rv));
 	}
 
 	phpdbg_error("exception",


### PR DESCRIPTION
Adds:
 - `zend_exception_get_code`
 - `zend_exception_get_file`
 - `zend_exception_get_line`
 - `zend_exception_get_message`
 - `zend_exception_get_trace`
 - `zend_exception_get_trace_as_string`. This accepts an arg for
   controlling whether the arguments will be included.

Also adds `zend_obj_read_property` and `zend_obj_read_property_ex`. These are just like `zend_read_property`/`zend_read_property_ex` except they take a `zend_object *` instead of a `zval *`.

I intended these to mostly be used by extensions, but with a quick look did find some places where they were useful in core too. 