### PR TITLE
Remove value from comment in php.ini files

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -402,7 +402,7 @@ max_input_time = 60
 ; How many GET/POST/COOKIE input variables may be accepted
 ;max_input_vars = 1000
 
-; Maximum amount of memory a script may consume (128MB)
+; Maximum amount of memory a script may consume
 ; http://php.net/memory-limit
 memory_limit = 128M
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -404,7 +404,7 @@ max_input_time = 60
 ; How many GET/POST/COOKIE input variables may be accepted
 ;max_input_vars = 1000
 
-; Maximum amount of memory a script may consume (128MB)
+; Maximum amount of memory a script may consume
 ; http://php.net/memory-limit
 memory_limit = 128M
 


### PR DESCRIPTION
Remove value from comment in php.ini files, otherwise when the actual value is changed, the comment may be unclear.