### PR TITLE
[POC] Add support for immutable objects

### DIFF
--- a/Zend/tests/immutable/clone/clone_error.phpt
+++ b/Zend/tests/immutable/clone/clone_error.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test that immutable classes can't be modified after cloning
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public int $property1;
+    public string $property2 = "";
+    protected $property3;
+    private $property4;
+}
+
+$foo = new Foo();
+$foo->property1 = 1;
+$bar = clone $foo;
+
+try {
+    $bar->property1 = 2;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $bar->property2 = "Baz";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $var = &$foo->property2;
+    $var = "Bazinga";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Cannot assign value to property Foo::$property1 of an immutable class more than once
+Cannot assign value to property Foo::$property2 of an immutable class more than once

--- a/Zend/tests/immutable/clone/clone_success.phpt
+++ b/Zend/tests/immutable/clone/clone_success.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Test that immutable classes can be cloned
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public int $property1;
+    public string $property2 = "";
+    protected $property4;
+    private $property;
+}
+
+$foo = new Foo();
+$foo->property1 = 1;
+var_dump($foo);
+$bar = clone $foo;
+var_dump($bar);
+
+?>
+--EXPECTF--
+object(Foo)#1 (4) {
+  ["property1"]=>
+  int(1)
+  ["property2"]=>
+  string(0) ""
+  ["property4":protected]=>
+  NULL
+  ["property":"Foo":private]=>
+  NULL
+}
+object(Foo)#2 (4) {
+  ["property1"]=>
+  int(1)
+  ["property2"]=>
+  string(0) ""
+  ["property4":protected]=>
+  NULL
+  ["property":"Foo":private]=>
+  NULL
+}

--- a/Zend/tests/immutable/constructor/constructor.phpt
+++ b/Zend/tests/immutable/constructor/constructor.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Test the constructor of immutable classes
+--FILE--
+<?php
+
+// Instantiating an immutable class without a constructor
+
+immutable class Foo
+{
+}
+
+$foo = new Foo();
+
+// Instantiating an immutable class with a constructor
+
+immutable class Bar
+{
+    public function __construct()
+    {
+    }
+}
+
+// Instantiating an immutable class that calls parent::__construct() during instantiation
+
+$bar = new Bar();
+
+immutable class Baz extends Bar
+{
+    public function __construct()
+    {
+        parent::__construct();
+        parent::__construct();
+    }
+}
+
+$baz = new Bar();
+
+?>
+--EXPECT--

--- a/Zend/tests/immutable/constructor/constructor_error.phpt
+++ b/Zend/tests/immutable/constructor/constructor_error.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test that the constructor of immutable classes can't be invoked after instantiation
+--FILE--
+<?php
+
+// Explicitly calling __construct() that is not defined
+
+immutable class Foo
+{
+}
+
+$foo = new Foo();
+try {
+    $foo->__construct();
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+// Explicitly calling __construct() that is defined
+
+immutable class Bar
+{
+    public function __construct()
+    {
+    }
+}
+
+$bar = new Bar();
+try {
+    $bar->__construct();
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Call to undefined method Foo::__construct()
+Cannot call the constructor of an immutable class Bar

--- a/Zend/tests/immutable/inheritance/inheritance_error.phpt
+++ b/Zend/tests/immutable/inheritance/inheritance_error.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test that immutable classes can only be extended by immutable classes
+--FILE--
+<?php
+
+immutable class Foo
+{
+}
+
+immutable class Bar extends Foo
+{
+}
+
+class Baz extends Bar
+{
+}
+
+?>
+--EXPECTF--
+Fatal error: Non-immutable class Baz may not inherit from immutable class (Bar) in %s on line %d

--- a/Zend/tests/immutable/inheritance/inheritance_success1.phpt
+++ b/Zend/tests/immutable/inheritance/inheritance_success1.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test that immutable classes can extend non-immutable classes
+--FILE--
+<?php
+
+class Foo
+{
+}
+
+immutable class Bar extends Foo
+{
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/immutable/inheritance/inheritance_success2.phpt
+++ b/Zend/tests/immutable/inheritance/inheritance_success2.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test that immutable classes can only be extended by immutable classes
+--FILE--
+<?php
+
+immutable class Foo
+{
+}
+
+immutable class Bar extends Foo
+{
+}
+
+immutable class Baz extends Bar
+{
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/immutable/properties/property_array_access1.phpt
+++ b/Zend/tests/immutable/properties/property_array_access1.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Test that ArrayAccess works for immutable classes as expected
+--FILE--
+<?php
+
+immutable class Foo implements ArrayAccess
+{
+    private $property1;
+    private $property2 = "";
+    private string $property3;
+    private string $property4 = "";
+
+    function offsetExists($offset)
+    {
+        return isset($this->$offset);
+    }
+
+    function offsetGet($offset)
+    {
+        return $this->$offset ?? null;
+    }
+
+    function offsetSet($offset, $value)
+    {
+        throw new Exception("offsetSet() is not supported!");
+    }
+
+    function offsetUnset($offset){
+        unset($this->$offset);
+    }
+}
+
+$foo = new Foo();
+
+try {
+    $foo["property1"] = "foo";
+} catch (Exception $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo["property2"] = "foo";
+} catch (Exception $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo["property3"] = "foo";
+} catch (Exception $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo["property4"] = "foo";
+} catch (Exception $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo["property5"] = "foo";
+} catch (Exception $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+offsetSet() is not supported!
+offsetSet() is not supported!
+offsetSet() is not supported!
+offsetSet() is not supported!
+offsetSet() is not supported!

--- a/Zend/tests/immutable/properties/property_array_access2.phpt
+++ b/Zend/tests/immutable/properties/property_array_access2.phpt
@@ -1,0 +1,66 @@
+--TEST--
+Test that ArrayAccess works for immutable classes as expected
+--FILE--
+<?php
+
+immutable class Foo implements ArrayAccess
+{
+    private $property1;
+    private $property2 = "";
+    private string $property3;
+    private string $property4 = "";
+
+    function offsetExists($offset)
+    {
+        return isset($this->$offset);
+    }
+
+    function offsetGet($offset)
+    {
+        return $this->$offset ?? null;
+    }
+
+    function offsetSet($offset, $value)
+    {
+        $this->$offset = $value;
+    }
+
+    function offsetUnset($offset){
+        unset($this->$offset);
+    }
+}
+
+$foo = new Foo();
+
+try {
+    $foo["property1"] = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo["property2"] = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+$foo["property3"] = "foo";
+
+try {
+    $foo["property4"] = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo["property5"] = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Cannot assign value to property Foo::$property1 of an immutable class more than once
+Cannot assign value to property Foo::$property2 of an immutable class more than once
+Cannot assign value to property Foo::$property4 of an immutable class more than once
+Cannot declare dynamic property Foo:$property5 of an immutable class

--- a/Zend/tests/immutable/properties/property_dynamic_definition.phpt
+++ b/Zend/tests/immutable/properties/property_dynamic_definition.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test that properties of immutable classes cannot be declared dynamically
+--FILE--
+<?php
+
+immutable class Foo
+{
+}
+
+$foo = new Foo();
+
+try {
+    $foo->property1 = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    Foo::$property1 = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Cannot declare dynamic property Foo:$property1 of an immutable class
+Access to undeclared static property: Foo::$property1

--- a/Zend/tests/immutable/properties/property_incrementing_decrementing.phpt
+++ b/Zend/tests/immutable/properties/property_incrementing_decrementing.phpt
@@ -1,0 +1,127 @@
+--TEST--
+Test that properties of immutable classes can't be incremented/decremented
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public $property1;
+    public $property2 = 2;
+    public int $property3;
+    public int $property4 = 4;
+
+    public function __construct()
+    {
+        //$this->property1 = 1;
+        $this->property3 = 3;
+    }
+}
+
+$foo = new Foo();
+
+try {
+    ++$foo->property1;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    ++$foo->property2;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    ++$foo->property3;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    ++$foo->property4;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property1++;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property2++;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property3++;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property4++;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    --$foo->property1;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    --$foo->property2;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    --$foo->property3;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    --$foo->property4;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property1--;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property2--;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property3--;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property4--;
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Cannot increment property Foo::$property3 of an immutable class
+Cannot increment property Foo::$property4 of an immutable class
+Cannot increment property Foo::$property3 of an immutable class
+Cannot increment property Foo::$property4 of an immutable class
+Cannot decrement property Foo::$property3 of an immutable class
+Cannot decrement property Foo::$property4 of an immutable class
+Cannot decrement property Foo::$property3 of an immutable class
+Cannot decrement property Foo::$property4 of an immutable class

--- a/Zend/tests/immutable/properties/property_incrementing_decrementing_by_ref.phpt
+++ b/Zend/tests/immutable/properties/property_incrementing_decrementing_by_ref.phpt
@@ -1,0 +1,113 @@
+--TEST--
+Test that properties of immutable classes can't be incremented/decremented by reference
+--XFAIL--
+There is an issue on 32-bit which I haven't figured out yet
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public $property1;
+    public $property2 = 2;
+    public int $property3;
+    public int $property4 = 4;
+
+    public function __construct()
+    {
+        //$this->property1 = 1;
+        $this->property3 = 3;
+    }
+}
+
+$foo = new Foo();
+foreach ($foo as &$property) {
+    try {
+        ++$property;
+    } catch (Error $exception) {
+        echo $exception->getMessage() . "\n";
+    }
+}
+
+var_dump($foo);
+
+$foo = new Foo();
+foreach ($foo as &$property) {
+    try {
+        $property++;
+    } catch (Error $exception) {
+        echo $exception->getMessage() . "\n";
+    }
+}
+
+var_dump($foo);
+
+foreach ($foo as &$property) {
+    try {
+        --$property;
+    } catch (Error $exception) {
+        echo $exception->getMessage() . "\n";
+    }
+}
+
+var_dump($foo);
+
+foreach ($foo as &$property) {
+    try {
+        $property--;
+    } catch (Error $exception) {
+        echo $exception->getMessage() . "\n";
+    }
+}
+
+var_dump($foo);
+
+?>
+--EXPECTF--
+Cannot increment a reference held by property Foo::$property3 of an immutable class
+Cannot increment a reference held by property Foo::$property4 of an immutable class
+object(Foo)#1 (4) {
+  ["property1"]=>
+  int(1)
+  ["property2"]=>
+  int(3)
+  ["property3"]=>
+  int(%d)
+  ["property4"]=>
+  &int(%d)
+}
+Cannot increment a reference held by property Foo::$property3 of an immutable class
+Cannot increment a reference held by property Foo::$property4 of an immutable class
+object(Foo)#2 (4) {
+  ["property1"]=>
+  int(1)
+  ["property2"]=>
+  int(3)
+  ["property3"]=>
+  int(%d)
+  ["property4"]=>
+  &int(%d)
+}
+Cannot decrement a reference held by property Foo::$property3 of an immutable class
+Cannot decrement a reference held by property Foo::$property4 of an immutable class
+object(Foo)#2 (4) {
+  ["property1"]=>
+  int(0)
+  ["property2"]=>
+  int(2)
+  ["property3"]=>
+  int(-%d)
+  ["property4"]=>
+  &int(-%d)
+}
+Cannot decrement a reference held by property Foo::$property3 of an immutable class
+Cannot decrement a reference held by property Foo::$property4 of an immutable class
+object(Foo)#2 (4) {
+  ["property1"]=>
+  int(-1)
+  ["property2"]=>
+  int(1)
+  ["property3"]=>
+  int(-%d)
+  ["property4"]=>
+  &int(-%d)
+}

--- a/Zend/tests/immutable/properties/property_magic_get.phpt
+++ b/Zend/tests/immutable/properties/property_magic_get.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test that the __get() magic method works for immutable classes
+--FILE--
+<?php
+
+immutable class Foo
+{
+    private array $properties = [
+        "property1" => "foo",
+        "property2" => null,
+    ];
+
+    public function __isset($name): bool
+    {
+        return isset($this->properties[$name]);
+    }
+
+    public function __get($name)
+    {
+        return $this->properties[$name] ?? null;
+    }
+}
+
+$foo = new Foo();
+
+var_dump(isset($foo->property1));
+var_dump($foo->property1);
+
+var_dump(isset($foo->property2));
+var_dump($foo->property2);
+
+var_dump(isset($foo->property3));
+var_dump($foo->property3);
+
+?>
+--EXPECT--
+bool(true)
+string(3) "foo"
+bool(false)
+NULL
+bool(false)
+NULL

--- a/Zend/tests/immutable/properties/property_magic_set1.phpt
+++ b/Zend/tests/immutable/properties/property_magic_set1.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test that the __set() magic method can be invoked
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public function __set($name, $value): void
+    {
+       throw new Exception("__set() is not supported!");
+    }
+}
+
+$foo = new Foo();
+
+try {
+    $foo->property1 = "foo";
+} catch (Exception $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+__set() is not supported!

--- a/Zend/tests/immutable/properties/property_magic_set2.phpt
+++ b/Zend/tests/immutable/properties/property_magic_set2.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Test that the __set() magic method works as expected for immutable classes
+--XFAIL--
+The restriction haven't been implemented yet
+--FILE--
+<?php
+
+immutable class Foo
+{
+    private array $properties = [
+        "property1" => "foo",
+        "property2" => null,
+        "property3" => [],
+    ];
+
+    public function __set($name, $value): void
+    {
+        $this->properties[$name] = $value;
+    }
+}
+
+$foo = new Foo();
+
+try {
+    $foo->property1 = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property2 = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property3[] = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property4 = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/immutable/properties/property_magic_set3.phpt
+++ b/Zend/tests/immutable/properties/property_magic_set3.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Test that the __set() magic method works as expected for immutable classes
+--FILE--
+<?php
+
+immutable class Foo
+{
+    private $property1 = "";
+    private string $property2;
+    private string $property3 = "";
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+}
+
+$foo = new Foo();
+
+try {
+    $foo->property1 = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+$foo->property2 = "foo";
+
+try {
+    $foo->property3 = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->property4 = "foo";
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Cannot assign value to property Foo::$property1 of an immutable class more than once
+Cannot assign value to property Foo::$property3 of an immutable class more than once
+Cannot declare dynamic property Foo:$property4 of an immutable class

--- a/Zend/tests/immutable/properties/property_mutation.phpt
+++ b/Zend/tests/immutable/properties/property_mutation.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Test that declared properties of immutable classes can't be mutated
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public int $property1;
+    protected $property2 = "Foo";
+    protected string $property3 = "Bar";
+    public array $property4;
+    public stdclass $property5;
+
+    public function __construct()
+    {
+        $this->property1 = 1;
+        $this->property5 = new stdclass();
+    }
+
+    public function getProperty1(): int
+    {
+        return $this->property1;
+    }
+
+    public function withProperty1(int $property): Foo
+    {
+        $this->property1 = $property;
+
+        return $this;
+    }
+
+    public function getProperty2(): string
+    {
+        return $this->property2;
+    }
+
+    public function withProperty2(string $property): Foo
+    {
+        $this->property2 = $property;
+
+        return $this;
+    }
+
+    public function getProperty3(): string
+    {
+        return $this->property3;
+    }
+
+    public function withProperty3(string $property3): Foo
+    {
+        $this->property3 = $property3;
+
+        return $this;
+    }
+}
+
+$foo = new Foo();
+
+try {
+    $foo = $foo->withProperty1(1);
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo = $foo->withProperty2("Bar");
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo = $foo->withProperty3("Foo");
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+$foo->property4[] = 1;
+$foo->property5->foo = "foo";
+
+?>
+--EXPECT--
+Cannot assign value to property Foo::$property1 of an immutable class more than once
+Cannot assign value to property Foo::$property2 of an immutable class more than once
+Cannot assign value to property Foo::$property3 of an immutable class more than once

--- a/Zend/tests/immutable/properties/property_mutation_by_ref.phpt
+++ b/Zend/tests/immutable/properties/property_mutation_by_ref.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Test that declared properties of immutable classes can't be mutated by reference
+--XFAIL--
+Not yet implemented.
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public int $property1;
+    public $property2 = 2;
+    public int $property3 = 3;
+    public int $property4 = 4;
+
+    public function __construct()
+    {
+        $this->property1 = 1;
+    }
+}
+
+$foo = new Foo();
+
+foreach ($foo as &$property) {
+    try {
+        $property = 5;
+    } catch (Error $exception) {
+        echo $exception->getMessage() . "\n";
+    }
+}
+
+var_dump($foo);
+
+?>
+--EXPECT--
+object(Foo)#1 (4) {
+  ["property1"]=>
+  int(1)
+  ["property2"]=>
+  int(2)
+  ["property3"]=>
+  int(3)
+  ["property4"]=>
+  &int(4)
+}

--- a/Zend/tests/immutable/properties/property_read.phpt
+++ b/Zend/tests/immutable/properties/property_read.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test that properties of immutable classes can be read
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public $property1;
+    public string $property2 = "Bar";
+    public static $property3 = "Baz";
+    public static int $property4;
+}
+
+$foo = new Foo();
+
+var_dump($foo->property1);
+var_dump($foo->property2);
+var_dump(Foo::$property3);
+
+$var = &$foo->property2;
+var_dump($var);
+
+?>
+--EXPECT--
+NULL
+string(3) "Bar"
+string(3) "Baz"
+string(3) "Bar"

--- a/Zend/tests/immutable/syntax/anonymous_class_syntax_error.phpt
+++ b/Zend/tests/immutable/syntax/anonymous_class_syntax_error.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test invalid syntax of immutable anonymous classes
+--FILE--
+<?php
+
+new immutable class() {
+};
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected 'immutable' (T_IMMUTABLE) in %s on line %d

--- a/Zend/tests/immutable/syntax/class_syntax_error.phpt
+++ b/Zend/tests/immutable/syntax/class_syntax_error.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test invalid syntax of immutable classes
+--FILE--
+<?php
+
+immutable immutable class Foo
+{
+}
+
+?>
+--EXPECTF--
+Fatal error: Multiple immutable modifiers are not allowed in %s on line %d

--- a/Zend/tests/immutable/syntax/class_syntax_valid.phpt
+++ b/Zend/tests/immutable/syntax/class_syntax_valid.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test valid syntax of immutable classes
+--FILE--
+<?php
+
+immutable class Foo
+{
+}
+
+IMMUTABLE class CapitalFoo
+{
+}
+
+final immutable class Foo2
+{
+}
+
+abstract immutable class Foo3
+{
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/immutable/syntax/interface_syntax_error1.phpt
+++ b/Zend/tests/immutable/syntax/interface_syntax_error1.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test invalid syntax of traits with the immutable modifier
+--FILE--
+<?php
+
+immutable interface Foo
+{
+}
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected 'interface' (T_INTERFACE), expecting abstract (T_ABSTRACT) or final (T_FINAL) or immutable (T_IMMUTABLE) or class (T_CLASS) in %s on line %d

--- a/Zend/tests/immutable/syntax/interface_syntax_error2.phpt
+++ b/Zend/tests/immutable/syntax/interface_syntax_error2.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test invalid syntax of interfaces with the immutable modifier
+--FILE--
+<?php
+
+immutable immutable interface Foo
+{
+}
+
+?>
+--EXPECTF--
+Fatal error: Multiple immutable modifiers are not allowed in %s on line %d

--- a/Zend/tests/immutable/syntax/trait_syntax_error1.phpt
+++ b/Zend/tests/immutable/syntax/trait_syntax_error1.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test invalid syntax of traits with the immutable modifier
+--FILE--
+<?php
+
+immutable trait Foo
+{
+}
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected 'trait' (T_TRAIT), expecting abstract (T_ABSTRACT) or final (T_FINAL) or immutable (T_IMMUTABLE) or class (T_CLASS) in %s on line %d

--- a/Zend/tests/immutable/syntax/trait_syntax_error2.phpt
+++ b/Zend/tests/immutable/syntax/trait_syntax_error2.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test invalid syntax of traits with the immutable modifier
+--FILE--
+<?php
+
+immutable immutable trait Foo
+{
+}
+
+?>
+--EXPECTF--
+Fatal error: Multiple immutable modifiers are not allowed in %s on line %d

--- a/Zend/tests/immutable/unset/declared_unset_error.phpt
+++ b/Zend/tests/immutable/unset/declared_unset_error.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Test that declared properties of immutable classes can't be unset
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public $property1 = "foo";
+    public string $property2;
+
+    protected $property3 = "foo";
+    protected string $property4 = "foo";
+
+    public function unsetProperty3(): void
+    {
+        unset($this->property3);
+    }
+
+    public function unsetProperty4(): void
+    {
+        unset($this->property4);
+    }
+}
+
+$foo = new Foo();
+
+try {
+    unset($foo->property1);
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+// Uninitialized typed properties can't be unset anyway
+unset($foo->property2);
+unset($foo->property2);
+
+try {
+    $foo->unsetProperty3();
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $foo->unsetProperty4();
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+
+?>
+--EXPECT--
+Cannot unset a property of an immutable class Foo
+Cannot unset a property of an immutable class Foo
+Cannot unset a property of an immutable class Foo

--- a/Zend/tests/immutable/unset/dynamic_unset.phpt
+++ b/Zend/tests/immutable/unset/dynamic_unset.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test that unsetting dynamic properties of immutable classes doesn't have any effect
+--FILE--
+<?php
+
+immutable class Foo
+{
+}
+
+$foo = new Foo();
+
+unset($foo->property1);
+
+?>
+--EXPECT--

--- a/Zend/tests/immutable/unset/magic_unset_error.phpt
+++ b/Zend/tests/immutable/unset/magic_unset_error.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Test that the __unset() magic method results in an exception
+--FILE--
+<?php
+
+immutable class Foo
+{
+    private array $properties = [];
+
+    public function __isset($name): bool
+    {
+        return isset($this->properties[$name]);
+    }
+
+    public function __get($name)
+    {
+        return $this->properties[$name] ?? null;
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->properties[$name] = $value;
+    }
+
+    public function __unset($name): void
+    {
+        unset($this->properties[$name]);
+    }
+}
+
+$foo = new Foo();
+
+try {
+    unset($foo->property1);
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Cannot unset a property of an immutable class Foo

--- a/Zend/tests/immutable/unset/static_declared_unset_error.phpt
+++ b/Zend/tests/immutable/unset/static_declared_unset_error.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Test that unsetting declared properties of immutable classes is not possible
+--FILE--
+<?php
+
+immutable class Foo
+{
+    public static $property1 = "foo";
+    public static string $property2;
+
+    protected static $property3 = "foo";
+    protected static string $property4 = "foo";
+
+    public static function unsetProperty3(): void
+    {
+        unset(self::$property3);
+    }
+
+    public static function unsetProperty4(): void
+    {
+        unset(self::$property4);
+    }
+}
+
+try {
+    unset(Foo::$property1);
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    unset(Foo::$property2);
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    Foo::unsetProperty3();
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    Foo::unsetProperty4();
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Attempt to unset static property Foo::$property1
+Attempt to unset static property Foo::$property2
+Attempt to unset static property Foo::$property3
+Attempt to unset static property Foo::$property4

--- a/Zend/tests/immutable/unset/static_dynamic_unset_error.phpt
+++ b/Zend/tests/immutable/unset/static_dynamic_unset_error.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test that unsetting dynamic static properties of immutable classes is still not possible
+--FILE--
+<?php
+
+immutable class Foo
+{
+}
+
+try {
+    unset(Foo::$property1);
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Attempt to unset static property Foo::$property1

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3551,7 +3551,7 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 			case IS_ARRAY:
 			case IS_OBJECT:
 			case IS_RESOURCE:
-				zend_error_noreturn(E_CORE_ERROR, "Internal zval's can't be arrays, objects or resources");
+				zend_error_noreturn(E_CORE_ERROR, "Internal ZVALs can't be arrays, objects or resources");
 				break;
 			default:
 				break;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -819,6 +819,11 @@ uint32_t zend_add_class_modifier(uint32_t flags, uint32_t new_flag) /* {{{ */
 			"Cannot use the final modifier on an abstract class", 0);
 		return 0;
 	}
+	if ((flags & ZEND_ACC_EXPLICIT_IMMUTABLE_CLASS) && (new_flag & ZEND_ACC_EXPLICIT_IMMUTABLE_CLASS)) {
+		zend_throw_exception(zend_ce_compile_error, "Multiple immutable modifiers are not allowed", 0);
+		return 0;
+	}
+
 	return new_flags;
 }
 /* }}} */
@@ -6397,6 +6402,8 @@ static void zend_check_const_and_trait_alias_attr(uint32_t attr, const char* ent
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot use 'abstract' as %s modifier", entity);
 	} else if (attr & ZEND_ACC_FINAL) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot use 'final' as %s modifier", entity);
+	} else if (attr & ZEND_ACC_EXPLICIT_IMMUTABLE_CLASS) {
+		zend_error_noreturn(E_COMPILE_ERROR, "Cannot use 'immutable' as %s modifier", entity);
 	}
 }
 /* }}} */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -229,13 +229,14 @@ typedef struct _zend_oparray_context {
 /* op_array or class is preloaded                         |     |     |     */
 #define ZEND_ACC_PRELOADED               (1 << 10) /*  X  |  X  |     |     */
 /*                                                        |     |     |     */
-/* Class Flags (unused: 13, 14, 15, 24...)                |     |     |     */
+/* Class Flags (unused: 14, 15, 24...)                    |     |     |     */
 /* ===========                                            |     |     |     */
 /*                                                        |     |     |     */
 /* Special class types                                    |     |     |     */
 #define ZEND_ACC_INTERFACE               (1 <<  0) /*  X  |     |     |     */
 #define ZEND_ACC_TRAIT                   (1 <<  1) /*  X  |     |     |     */
 #define ZEND_ACC_ANON_CLASS              (1 <<  2) /*  X  |     |     |     */
+#define ZEND_ACC_EXPLICIT_IMMUTABLE_CLASS (1 << 13)/*  X  |     |     |     */
 /*                                                        |     |     |     */
 /* Class linked with parent, interfaces and traits        |     |     |     */
 #define ZEND_ACC_LINKED                  (1 <<  3) /*  X  |     |     |     */

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1139,7 +1139,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 		if (UNEXPECTED(!(parent_ce->ce_flags & ZEND_ACC_INTERFACE))) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Interface %s may not inherit from class (%s)", ZSTR_VAL(ce->name), ZSTR_VAL(parent_ce->name));
 		}
-	} else if (UNEXPECTED(parent_ce->ce_flags & (ZEND_ACC_INTERFACE|ZEND_ACC_TRAIT|ZEND_ACC_FINAL))) {
+	} else if (UNEXPECTED(parent_ce->ce_flags & (ZEND_ACC_INTERFACE|ZEND_ACC_TRAIT|ZEND_ACC_FINAL|ZEND_ACC_EXPLICIT_IMMUTABLE_CLASS))) {
 		/* Class declaration must not extend traits or interfaces */
 		if (parent_ce->ce_flags & ZEND_ACC_INTERFACE) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Class %s cannot extend from interface %s", ZSTR_VAL(ce->name), ZSTR_VAL(parent_ce->name));
@@ -1150,6 +1150,11 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 		/* Class must not extend a final class */
 		if (parent_ce->ce_flags & ZEND_ACC_FINAL) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Class %s may not inherit from final class (%s)", ZSTR_VAL(ce->name), ZSTR_VAL(parent_ce->name));
+		}
+
+		/* Non-immutable class must not extend an immutable class */
+		if (!(ce->ce_flags & ZEND_ACC_EXPLICIT_IMMUTABLE_CLASS) && parent_ce->ce_flags & ZEND_ACC_EXPLICIT_IMMUTABLE_CLASS) {
+			zend_error_noreturn(E_COMPILE_ERROR, "Non-immutable class %s may not inherit from immutable class (%s)", ZSTR_VAL(ce->name), ZSTR_VAL(parent_ce->name));
 		}
 	}
 

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -179,6 +179,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %token T_STATIC     "static (T_STATIC)"
 %token T_ABSTRACT   "abstract (T_ABSTRACT)"
 %token T_FINAL      "final (T_FINAL)"
+%token T_IMMUTABLE  "immutable (T_IMMUTABLE)"
 %token T_PRIVATE    "private (T_PRIVATE)"
 %token T_PROTECTED  "protected (T_PROTECTED)"
 %token T_PUBLIC     "public (T_PUBLIC)"
@@ -282,7 +283,7 @@ reserved_non_modifiers:
 
 semi_reserved:
 	  reserved_non_modifiers
-	| T_STATIC | T_ABSTRACT | T_FINAL | T_PRIVATE | T_PROTECTED | T_PUBLIC
+	| T_STATIC | T_ABSTRACT | T_FINAL | T_IMMUTABLE | T_PRIVATE | T_PROTECTED | T_PUBLIC
 ;
 
 identifier:
@@ -522,6 +523,7 @@ class_modifiers:
 class_modifier:
 		T_ABSTRACT 		{ $$ = ZEND_ACC_EXPLICIT_ABSTRACT_CLASS; }
 	|	T_FINAL 		{ $$ = ZEND_ACC_FINAL; }
+	|	T_IMMUTABLE		{ $$ = ZEND_ACC_EXPLICIT_IMMUTABLE_CLASS; }
 ;
 
 trait_declaration_statement:

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1581,6 +1581,10 @@ NEWLINE ("\r"|"\n"|"\r\n")
 	RETURN_TOKEN(T_FINAL);
 }
 
+<ST_IN_SCRIPTING>"immutable" {
+	RETURN_TOKEN(T_IMMUTABLE);
+}
+
 <ST_IN_SCRIPTING>"private" {
 	RETURN_TOKEN(T_PRIVATE);
 }

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -218,6 +218,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 					ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(dst), prop_info);
 				}
 			}
+
 			src++;
 			dst++;
 		} while (src != end);


### PR DESCRIPTION
This PR tries to add support for immutable objects.

### Definition of immutable objects
- All objects are mutable by default, except for those ones that have the `immutable` class modifier
- An immutable class can only be extended by another immutable class
- The constructor of immutable objects can be invoked only once - during instantiation
- All properties of an immutable object are immutable (even when modified via reference)
- An immutable property can only be initialized once, but not modified afterwards, somewhat similarily how Java's `final` property modifier works (except for the fact that there is no obligation to initialize immutable properties according to this PR)
- There is no restriction about object properties of immutable classes - it's up to implementors to protect immutability in this case
- Existing properties of immutable objects can't be unset
- New properties can't be dynamically declared for immutable objects
- Magic methods continue to work, but they also can't change/add/remove properties of immutable objects
- Immutable objects are clonable - the resulting object will be also immutable

### Work in Progress parts
- [ ] Untyped properties that are only implicitly initialized should be possible to initialize explicitly
- [ ] Array properties should also be immutable
- [ ] Adding support for mutation during cloning (a la `with...()` style)
