### PR TITLE
Fix #79254: getenv() w/o arguments not showing changes

### DIFF
--- a/ext/standard/tests/general_functions/bug79254.phpt
+++ b/ext/standard/tests/general_functions/bug79254.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #79254 (getenv() w/o arguments not showing changes)
+--FILE--
+<?php
+
+$old = getenv();
+var_dump(getenv("PHP_BUG_79254", true));
+
+putenv("PHP_BUG_79254=BAR");
+
+$new = getenv();
+var_dump(array_diff($new, $old));
+var_dump(getenv("PHP_BUG_79254", true));
+
+?>
+--EXPECT--
+bool(false)
+array(1) {
+  ["PHP_BUG_79254"]=>
+  string(3) "BAR"
+}
+string(3) "BAR"

--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -541,47 +541,55 @@ static zend_always_inline int valid_environment_name(const char *name, const cha
 	return 1;
 }
 
-void _php_import_environment_variables(zval *array_ptr)
+static zend_always_inline void import_environment_variable(HashTable *ht, char *env)
 {
-	char **env, *ep, *p;
-#ifdef PHP_WIN32
-	char *envir;
-#endif
+	char *p;
 	size_t name_len, len;
 	zval val;
 	zend_ulong idx;
 
-#ifndef PHP_WIN32
-	for (env = environ; env != NULL && (ep = *env) != NULL; env++) {
-#else
-	envir = GetEnvironmentStringsA();
-	for (ep = envir; ep != NULL && *ep; ep += strlen(ep) + 1) {
-#endif
-		p = strchr(ep, '=');
-		if (!p
-		 || p == ep
-		 || !valid_environment_name(ep, p)) {
-			/* malformed entry? */
-			continue;
-		}
-		name_len = p - ep;
-		p++;
-		len = strlen(p);
-		if (len == 0) {
-			ZVAL_EMPTY_STRING(&val);
-		} else if (len == 1) {
-			ZVAL_INTERNED_STR(&val, ZSTR_CHAR((zend_uchar)*p));
-		} else {
-			ZVAL_NEW_STR(&val, zend_string_init(p, len, 0));
-		}
-		if (ZEND_HANDLE_NUMERIC_STR(ep, name_len, idx)) {
-			zend_hash_index_update(Z_ARRVAL_P(array_ptr), idx, &val);
-		} else {
-			php_register_variable_quick(ep, name_len, &val, Z_ARRVAL_P(array_ptr));
-		}
+	p = strchr(env, '=');
+	if (!p
+		|| p == env
+		|| !valid_environment_name(env, p)) {
+		/* malformed entry? */
+		return;
 	}
-#ifdef PHP_WIN32
-	FreeEnvironmentStringsA(envir);
+	name_len = p - env;
+	p++;
+	len = strlen(p);
+	if (len == 0) {
+		ZVAL_EMPTY_STRING(&val);
+	} else if (len == 1) {
+		ZVAL_INTERNED_STR(&val, ZSTR_CHAR((zend_uchar)*p));
+	} else {
+		ZVAL_NEW_STR(&val, zend_string_init(p, len, 0));
+	}
+	if (ZEND_HANDLE_NUMERIC_STR(env, name_len, idx)) {
+		zend_hash_index_update(ht, idx, &val);
+	} else {
+		php_register_variable_quick(env, name_len, &val, ht);
+	}
+}
+
+void _php_import_environment_variables(zval *array_ptr)
+{
+#ifndef PHP_WIN32
+	char **env;
+#else
+	char *environment, *env;
+#endif
+
+#ifndef PHP_WIN32
+	for (env = environ; env != NULL && *env != NULL; env++) {
+		import_environment_variable(Z_ARRVAL_P(array_ptr), *env);
+	}
+#else
+	environment = GetEnvironmentStringsA();
+	for (env = environment; env != NULL && *env; env += strlen(env) + 1) {
+		import_environment_variable(Z_ARRVAL_P(array_ptr), env);
+	}
+	FreeEnvironmentStringsA(environment);
 #endif
 }
 


### PR DESCRIPTION
To be able to see changes done only with `SetEnvironmentVariable()`, we
have to use `GetEnvironmentStrings()` instead of `environ`, because the
latter sees only changes done with `putenv()`.

For best backward compatibility we're using `GetEnvironmentStringsA()`;
switching to the wide string version likely makes sense for master,
though.
