### PR TITLE
Fix bug #79257

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -1272,19 +1272,27 @@ matched:
 					if (subpat_names) {
 						if (offset_capture) {
 							for (i = 0; i < count; i++) {
-								add_offset_pair(subpats, subject + offsets[i<<1],
-												offsets[(i<<1)+1] - offsets[i<<1],
-												offsets[i<<1], subpat_names[i], unmatched_as_null);
+                                if (PCRE2_UNSET != offsets[i<<1] || !zend_hash_str_exists(HASH_OF(subpats), subpat_names[i], strlen(subpat_names[i]))) {
+                                    add_offset_pair(subpats, subject + offsets[i<<1],
+                                                    offsets[(i<<1)+1] - offsets[i<<1],
+                                                    offsets[i<<1], subpat_names[i], unmatched_as_null);
+                                } else {
+                                    add_offset_pair(subpats, subject + offsets[i<<1],
+                                                    offsets[(i<<1)+1] - offsets[i<<1],
+                                                    offsets[i<<1], NULL, unmatched_as_null);
+                                }
 							}
 						} else {
 							for (i = 0; i < count; i++) {
 								if (subpat_names[i]) {
 									if (PCRE2_UNSET == offsets[i<<1]) {
-										if (unmatched_as_null) {
-											add_assoc_null(subpats, subpat_names[i]);
-										} else {
-											add_assoc_str(subpats, subpat_names[i], ZSTR_EMPTY_ALLOC());
-										}
+                                        if (!zend_hash_str_exists(HASH_OF(subpats), subpat_names[i], strlen(subpat_names[i]))) {
+                                            if (unmatched_as_null) {
+                                                add_assoc_null(subpats, subpat_names[i]);
+                                            } else {
+                                                add_assoc_str(subpats, subpat_names[i], ZSTR_EMPTY_ALLOC());
+                                            }
+                                        }
 									} else {
 										add_assoc_stringl(subpats, subpat_names[i], subject + offsets[i<<1],
 														  offsets[(i<<1)+1] - offsets[i<<1]);

--- a/ext/pcre/tests/bug79257.phpt
+++ b/ext/pcre/tests/bug79257.phpt
@@ -1,0 +1,117 @@
+--TEST--
+Bug #79257: Duplicate named capture return last alternative even if unmatched
+--FILE--
+<?php
+
+preg_match('/(?J)(?:(?<g>foo)|(?<g>bar))(geez)/', 'foogeez', $matches);
+var_dump($matches);
+
+preg_match('/(?J)(?:(?<g>foo)|(?<g>bar))(geez)/', 'foogeez', $matches, PREG_OFFSET_CAPTURE);
+var_dump($matches);
+
+preg_match('/(?J)(?:(?<g>foo)|(?<g>bar))(geez)/', 'foogeez', $matches, PREG_UNMATCHED_AS_NULL);
+var_dump($matches);
+
+preg_match('/(?J)(?:(?<g>foo)|(?<g>bar))(geez)/', 'foogeez', $matches, PREG_UNMATCHED_AS_NULL | PREG_OFFSET_CAPTURE);
+var_dump($matches);
+
+?>
+--EXPECT--
+array(5) {
+  [0]=>
+  string(7) "foogeez"
+  ["g"]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "foo"
+  [2]=>
+  string(0) ""
+  [3]=>
+  string(4) "geez"
+}
+array(5) {
+  [0]=>
+  array(2) {
+    [0]=>
+    string(7) "foogeez"
+    [1]=>
+    int(0)
+  }
+  ["g"]=>
+  array(2) {
+    [0]=>
+    string(3) "foo"
+    [1]=>
+    int(0)
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    string(3) "foo"
+    [1]=>
+    int(0)
+  }
+  [2]=>
+  array(2) {
+    [0]=>
+    string(0) ""
+    [1]=>
+    int(-1)
+  }
+  [3]=>
+  array(2) {
+    [0]=>
+    string(4) "geez"
+    [1]=>
+    int(3)
+  }
+}
+array(5) {
+  [0]=>
+  string(7) "foogeez"
+  ["g"]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "foo"
+  [2]=>
+  NULL
+  [3]=>
+  string(4) "geez"
+}
+array(5) {
+  [0]=>
+  array(2) {
+    [0]=>
+    string(7) "foogeez"
+    [1]=>
+    int(0)
+  }
+  ["g"]=>
+  array(2) {
+    [0]=>
+    string(3) "foo"
+    [1]=>
+    int(0)
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    string(3) "foo"
+    [1]=>
+    int(0)
+  }
+  [2]=>
+  array(2) {
+    [0]=>
+    NULL
+    [1]=>
+    int(-1)
+  }
+  [3]=>
+  array(2) {
+    [0]=>
+    string(4) "geez"
+    [1]=>
+    int(3)
+  }
+}


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=79257.

After the fix, duplicate named group should return last *matched* alternative, so if any of alternatives matched, it should never return unset entries.

Needs some attention.

Currently it simply avoids re-assigning named group to an indexed group which is unset. So, once the name is assigned (to any indexed group - set or unset), it can't be re-assigned to an unset indexed group, only capture groups that actualy matched their substrings can contribute.

The risk is that this may introduce backward-incompatible changes when ``PREG_OFFSET_CAPTURE`` is on (unset named groups can return different offsets after the change).