### PR TITLE
[RFC] Rigid Properties

### DIFF
--- a/Zend/tests/rigidproperties_basic.phpt
+++ b/Zend/tests/rigidproperties_basic.phpt
@@ -4,11 +4,14 @@ Test that a userland class with rigid properties cannot have additional properti
 <?php
 
 class Foo implements RigidProperties {
-    public int $x = 0;
+    public int $x;
+
+    public int $y = 1;
 }
 
 $foo = new Foo();
-$foo->x = 123;
+$foo->x = 123; // uninitialized check
+$foo->y = 123; // initialized check
 
 try {
     $foo->bar = 123;

--- a/Zend/tests/rigidproperties_basic.phpt
+++ b/Zend/tests/rigidproperties_basic.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Test that a userland class with rigid properties cannot have additional properties written
+--FILE--
+<?php
+
+class Foo implements RigidProperties {
+    public int $x = 0;
+}
+
+$foo = new Foo();
+$foo->x = 123;
+
+try {
+    $foo->bar = 123;
+}
+catch (\Error $e) {
+    echo (string)$e . "\n\n";
+}
+
+try {
+    $foo->bar2 = "abc";
+}
+catch (\Error $e) {
+    echo (string)$e . "\n\n";
+}
+
+--EXPECTF--
+Error: Cannot add additional property 'bar' to a class with rigid properties in %s:%d
+Stack trace:
+#0 {main}
+
+Error: Cannot add additional property 'bar2' to a class with rigid properties in %s:%d
+Stack trace:
+#0 {main}

--- a/Zend/tests/rigidproperties_basic.phpt
+++ b/Zend/tests/rigidproperties_basic.phpt
@@ -9,6 +9,13 @@ class Foo implements RigidProperties {
     public int $y = 1;
 }
 
+class NotRigid {
+
+}
+
+$nr = new NotRigid();
+$nr->x = 1234;
+
 $foo = new Foo();
 $foo->x = 123; // uninitialized check
 $foo->y = 123; // initialized check
@@ -26,6 +33,8 @@ try {
 catch (\Error $e) {
     echo (string)$e . "\n\n";
 }
+
+
 
 --EXPECTF--
 Error: Cannot add additional property 'bar' to a class with rigid properties in %s:%d

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -126,6 +126,8 @@ struct _zend_class_entry {
 	HashTable function_table;
 	HashTable properties_info;
 	HashTable constants_table;
+	
+	int rigid_properties;
 
 	struct _zend_property_info **properties_info_table;
 

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -127,8 +127,6 @@ struct _zend_class_entry {
 	HashTable properties_info;
 	HashTable constants_table;
 	
-	int rigid_properties;
-
 	struct _zend_property_info **properties_info_table;
 
 	zend_function *constructor;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1806,6 +1806,8 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, zend_bool nullify
 
 	ce->default_properties_table = NULL;
 	ce->default_static_members_table = NULL;
+	ce->rigid_properties = 0;
+	
 	zend_hash_init_ex(&ce->properties_info, 8, NULL, (persistent_hashes ? zend_destroy_property_info_internal : NULL), persistent_hashes, 0);
 	zend_hash_init_ex(&ce->constants_table, 8, NULL, NULL, persistent_hashes, 0);
 	zend_hash_init_ex(&ce->function_table, 8, NULL, ZEND_FUNCTION_DTOR, persistent_hashes, 0);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1806,7 +1806,6 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, zend_bool nullify
 
 	ce->default_properties_table = NULL;
 	ce->default_static_members_table = NULL;
-	ce->rigid_properties = 0;
 	
 	zend_hash_init_ex(&ce->properties_info, 8, NULL, (persistent_hashes ? zend_destroy_property_info_internal : NULL), persistent_hashes, 0);
 	zend_hash_init_ex(&ce->constants_table, 8, NULL, NULL, persistent_hashes, 0);

--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -28,6 +28,7 @@ ZEND_API zend_class_entry *zend_ce_iterator;
 ZEND_API zend_class_entry *zend_ce_arrayaccess;
 ZEND_API zend_class_entry *zend_ce_serializable;
 ZEND_API zend_class_entry *zend_ce_countable;
+ZEND_API zend_class_entry *zend_ce_rigidproperties;
 
 /* {{{ zend_call_method
  Only returns the returned zval if retval_ptr != NULL */
@@ -532,6 +533,14 @@ static int zend_implement_countable(zend_class_entry *interface, zend_class_entr
 }
 /* }}}*/
 
+/* {{{ zend_implement_rigidproperties */
+static int zend_implement_rigidproperties(zend_class_entry *interface, zend_class_entry *class_type)
+{
+	return SUCCESS;
+}
+/* }}}*/
+
+
 /* {{{ function tables */
 static const zend_function_entry zend_funcs_aggregate[] = {
 	ZEND_ABSTRACT_ME(iterator, getIterator, arginfo_class_IteratorAggregate_getIterator)
@@ -567,6 +576,11 @@ static const zend_function_entry zend_funcs_countable[] = {
 	ZEND_ABSTRACT_ME(Countable, count, arginfo_class_Countable_count)
 	ZEND_FE_END
 };
+
+static const zend_function_entry zend_funcs_rigidproperties[] = {
+	ZEND_FE_END
+};
+
 /* }}} */
 
 /* {{{ zend_register_interfaces */
@@ -585,5 +599,7 @@ ZEND_API void zend_register_interfaces(void)
 	REGISTER_MAGIC_INTERFACE(serializable, Serializable);
 
 	REGISTER_MAGIC_INTERFACE(countable, Countable);
+	
+	REGISTER_MAGIC_INTERFACE(rigidproperties, RigidProperties);
 }
 /* }}} */

--- a/Zend/zend_interfaces.h
+++ b/Zend/zend_interfaces.h
@@ -30,6 +30,7 @@ extern ZEND_API zend_class_entry *zend_ce_iterator;
 extern ZEND_API zend_class_entry *zend_ce_arrayaccess;
 extern ZEND_API zend_class_entry *zend_ce_serializable;
 extern ZEND_API zend_class_entry *zend_ce_countable;
+extern ZEND_API zend_class_entry *zend_ce_rigidproperties;
 
 typedef struct _zend_user_iterator {
 	zend_object_iterator     it;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -801,7 +801,7 @@ ZEND_API zval *zend_std_write_property(zend_object *zobj, zend_string *name, zva
 	zend_property_info *prop_info = NULL;
 	ZEND_ASSERT(!Z_ISREF_P(value));
 	zend_class_entry *ce;
-
+	
 	property_offset = zend_get_property_offset(zobj->ce, name, (zobj->ce->__set != NULL), cache_slot, &prop_info);
 	
 	if (EXPECTED(IS_VALID_PROPERTY_OFFSET(property_offset))) {
@@ -826,7 +826,7 @@ found:
 		if (Z_PROP_FLAG_P(variable_ptr) == IS_PROP_UNINIT) {
 			/* Writes to uninitializde typed properties bypass __set(). */
 			Z_PROP_FLAG_P(variable_ptr) = 0;
-			goto write_std_property;
+			goto write_std_property_beyond_check;
 		}
 	} else if (EXPECTED(IS_DYNAMIC_PROPERTY_OFFSET(property_offset))) {
 		if (EXPECTED(zobj->properties != NULL)) {
@@ -881,7 +881,8 @@ write_std_property:
 			variable_ptr = &EG(error_zval);
 			goto exit;
 		}
-
+		
+write_std_property_beyond_check:
 		Z_TRY_ADDREF_P(value);
 		if (EXPECTED(IS_VALID_PROPERTY_OFFSET(property_offset))) {
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -800,9 +800,10 @@ ZEND_API zval *zend_std_write_property(zend_object *zobj, zend_string *name, zva
 	uintptr_t property_offset;
 	zend_property_info *prop_info = NULL;
 	ZEND_ASSERT(!Z_ISREF_P(value));
+	zend_class_entry *ce;
 
 	property_offset = zend_get_property_offset(zobj->ce, name, (zobj->ce->__set != NULL), cache_slot, &prop_info);
-
+	
 	if (EXPECTED(IS_VALID_PROPERTY_OFFSET(property_offset))) {
 		variable_ptr = OBJ_PROP(zobj, property_offset);
 		if (Z_TYPE_P(variable_ptr) != IS_UNDEF) {
@@ -867,7 +868,20 @@ found:
 		}
 	} else {
 		ZEND_ASSERT(!IS_WRONG_PROPERTY_OFFSET(property_offset));
+		
 write_std_property:
+		/* implementing RigidProperties prevents the creation of new properties on an object  */
+		ce = zobj->ce;
+		if (ce->rigid_properties == 0) {
+			ce->rigid_properties = instanceof_function(ce, zend_ce_rigidproperties) ? 1 : 2;
+		}
+
+		if (ce->rigid_properties == 1) {
+			zend_throw_error(NULL, "Cannot add additional property '%s' to a class with rigid properties", ZSTR_VAL(name));
+			variable_ptr = &EG(error_zval);
+			goto exit;
+		}
+
 		Z_TRY_ADDREF_P(value);
 		if (EXPECTED(IS_VALID_PROPERTY_OFFSET(property_offset))) {
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -800,7 +800,6 @@ ZEND_API zval *zend_std_write_property(zend_object *zobj, zend_string *name, zva
 	uintptr_t property_offset;
 	zend_property_info *prop_info = NULL;
 	ZEND_ASSERT(!Z_ISREF_P(value));
-	zend_class_entry *ce;
 	
 	property_offset = zend_get_property_offset(zobj->ce, name, (zobj->ce->__set != NULL), cache_slot, &prop_info);
 	
@@ -871,12 +870,7 @@ found:
 		
 write_std_property:
 		/* implementing RigidProperties prevents the creation of new properties on an object  */
-		ce = zobj->ce;
-		if (ce->rigid_properties == 0) {
-			ce->rigid_properties = instanceof_function(ce, zend_ce_rigidproperties) ? 1 : 2;
-		}
-
-		if (ce->rigid_properties == 1) {
+		if (instanceof_function(zobj->ce, zend_ce_rigidproperties)) {
 			zend_throw_error(NULL, "Cannot add additional property '%s' to a class with rigid properties", ZSTR_VAL(name));
 			variable_ptr = &EG(error_zval);
 			goto exit;


### PR DESCRIPTION
Userland class properties are extensible by default, which is probably not a decision that would be repeated if it were being made today.

This PR offers a RigidProperties interface that prevents adding additional properties (instead of a userland trait).

CC: @kocsismate 