### PR TITLE
Create a new console for each test worker on Windows

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -504,6 +504,7 @@ PHP_FUNCTION(proc_open)
 	int bypass_shell = 0;
 	int blocking_pipes = 0;
 	int create_process_group = 0;
+	int create_new_console = 0;
 #else
 	char **argv = NULL;
 #endif
@@ -596,6 +597,13 @@ PHP_FUNCTION(proc_open)
 		if (item != NULL) {
 			if (Z_TYPE_P(item) == IS_TRUE || ((Z_TYPE_P(item) == IS_LONG) && Z_LVAL_P(item))) {
 				create_process_group = 1;
+			}
+		}
+
+		item = zend_hash_str_find(Z_ARRVAL_P(other_options), "create_new_console", sizeof("create_new_console") - 1);
+		if (item != NULL) {
+			if (Z_TYPE_P(item) == IS_TRUE || ((Z_TYPE_P(item) == IS_LONG) && Z_LVAL_P(item))) {
+				create_new_console = 1;
 			}
 		}
 	}
@@ -921,7 +929,9 @@ PHP_FUNCTION(proc_open)
 	if (create_process_group) {
 		dwCreateFlags |= CREATE_NEW_PROCESS_GROUP;
 	}
-
+	if (create_new_console) {
+		dwCreateFlags |= CREATE_NEW_CONSOLE;
+	}
 	envpw = php_win32_cp_env_any_to_w(env.envp);
 	if (envpw) {
 		dwCreateFlags |= CREATE_UNICODE_ENVIRONMENT;

--- a/ext/standard/tests/file/windows_mb_path/CONFLICTS
+++ b/ext/standard/tests/file/windows_mb_path/CONFLICTS
@@ -1,3 +1,0 @@
-# These tests depend on the console codepage, which is shared across all parallel workers.
-# Force these tests to run sequentially to make sure the codepage isn't change by another process.
-all

--- a/run-tests.php
+++ b/run-tests.php
@@ -1424,7 +1424,8 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
                 "TEST_PHP_URI" => $sockUri,
             ],
             [
-                "suppress_errors" => TRUE
+                "suppress_errors" => TRUE,
+                'create_new_console' => TRUE,
             ]
         );
         if ($proc === FALSE) {


### PR DESCRIPTION
The primary motivation to have each test worker running its own console
is to allow the windows_mb_path tests to run in parallel.  A nice side
effect is that this also prevents changing the code page of the
tester's console window (which can even cause its font to be changed).

To be able to do so, we introduce the `create_new_console` option for
`proc_open()`, which might occasionally be useful for other purposes
than testing.

---

This could be considered for PHP-7.4 as well.