### PR TITLE
Fix #79271: DOMDocumentType::$childNodes is NULL

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -428,13 +428,9 @@ int dom_node_child_nodes_read(dom_object *obj, zval *retval)
 		return FAILURE;
 	}
 
-	if (dom_node_children_valid(nodep) == FAILURE) {
-		ZVAL_NULL(retval);
-	} else {
-		php_dom_create_interator(retval, DOM_NODELIST);
-		intern = Z_DOMOBJ_P(retval);
-		dom_namednode_iter(obj, XML_ELEMENT_NODE, intern, NULL, NULL, NULL);
-	}
+	php_dom_create_interator(retval, DOM_NODELIST);
+	intern = Z_DOMOBJ_P(retval);
+	dom_namednode_iter(obj, XML_ELEMENT_NODE, intern, NULL, NULL, NULL);
 
 	return SUCCESS;
 }

--- a/ext/dom/tests/bug69846.phpt
+++ b/ext/dom/tests/bug69846.phpt
@@ -50,7 +50,7 @@ object(DOMText)#%d (19) {
   ["parentNode"]=>
   NULL
   ["childNodes"]=>
-  NULL
+  string(22) "(object value omitted)"
   ["firstChild"]=>
   NULL
   ["lastChild"]=>
@@ -140,7 +140,7 @@ object(DOMText)#%d (19) {
   ["parentNode"]=>
   NULL
   ["childNodes"]=>
-  NULL
+  string(22) "(object value omitted)"
   ["firstChild"]=>
   NULL
   ["lastChild"]=>

--- a/ext/dom/tests/bug79271.phpt
+++ b/ext/dom/tests/bug79271.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #79271 (DOMDocumentType::$childNodes is NULL)
+--SKIPIF--
+<?php
+if (!extension_loaded('dom')) die('skip dom extension not available');
+?>
+--FILE--
+<?php
+$dom = new DOMImplementation();
+$type = $dom->createDocumentType('html');
+var_dump($type->childNodes);
+?>
+--EXPECTF--
+object(DOMNodeList)#%d (1) {
+  ["length"]=>
+  int(0)
+}


### PR DESCRIPTION
Dom level 2 core, DOM level 3 core and the DOM living standard agree
that `childNodes` always return a `NodeList`, and never `null`.