### PR TITLE
Don't include trailing newline in comment token

### DIFF
--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -2150,12 +2150,8 @@ inline_char_handler:
 	while (YYCURSOR < YYLIMIT) {
 		switch (*YYCURSOR++) {
 			case '\r':
-				if (*YYCURSOR == '\n') {
-					YYCURSOR++;
-				}
-				/* fall through */
 			case '\n':
-				CG(zend_lineno)++;
+				YYCURSOR--;
 				break;
 			case '?':
 				if (*YYCURSOR == '>') {

--- a/ext/tokenizer/tests/token_get_all_variation9.phpt
+++ b/ext/tokenizer/tests/token_get_all_variation9.phpt
@@ -45,7 +45,7 @@ echo "Done"
 ?>
 --EXPECTF--
 *** Testing token_get_all() : 'source' string with different comments ***
-array(50) {
+array(52) {
   [0]=>
   array(3) {
     [0]=>
@@ -83,8 +83,7 @@ array(50) {
     [0]=>
     int(%d)
     [1]=>
-    string(13) "// int value
-"
+    string(12) "// int value"
     [2]=>
     int(6)
   }
@@ -93,22 +92,21 @@ array(50) {
     [0]=>
     int(%d)
     [1]=>
-    string(2) "$a"
+    string(1) "
+"
     [2]=>
-    int(7)
+    int(6)
   }
   [5]=>
   array(3) {
     [0]=>
     int(%d)
     [1]=>
-    string(1) " "
+    string(2) "$a"
     [2]=>
     int(7)
   }
   [6]=>
-  string(1) "="
-  [7]=>
   array(3) {
     [0]=>
     int(%d)
@@ -117,7 +115,18 @@ array(50) {
     [2]=>
     int(7)
   }
+  [7]=>
+  string(1) "="
   [8]=>
+  array(3) {
+    [0]=>
+    int(%d)
+    [1]=>
+    string(1) " "
+    [2]=>
+    int(7)
+  }
+  [9]=>
   array(3) {
     [0]=>
     int(%d)
@@ -126,9 +135,9 @@ array(50) {
     [2]=>
     int(7)
   }
-  [9]=>
-  string(1) ";"
   [10]=>
+  string(1) ";"
+  [11]=>
   array(3) {
     [0]=>
     int(%d)
@@ -138,7 +147,7 @@ array(50) {
     [2]=>
     int(7)
   }
-  [11]=>
+  [12]=>
   array(3) {
     [0]=>
     int(%d)
@@ -147,18 +156,7 @@ array(50) {
     [2]=>
     int(8)
   }
-  [12]=>
-  array(3) {
-    [0]=>
-    int(%d)
-    [1]=>
-    string(1) " "
-    [2]=>
-    int(8)
-  }
   [13]=>
-  string(1) "="
-  [14]=>
   array(3) {
     [0]=>
     int(%d)
@@ -167,7 +165,18 @@ array(50) {
     [2]=>
     int(8)
   }
+  [14]=>
+  string(1) "="
   [15]=>
+  array(3) {
+    [0]=>
+    int(%d)
+    [1]=>
+    string(1) " "
+    [2]=>
+    int(8)
+  }
+  [16]=>
   array(3) {
     [0]=>
     int(%d)
@@ -176,9 +185,9 @@ array(50) {
     [2]=>
     int(8)
   }
-  [16]=>
-  string(1) ";"
   [17]=>
+  string(1) ";"
+  [18]=>
   array(3) {
     [0]=>
     int(%d)
@@ -188,7 +197,7 @@ array(50) {
     [2]=>
     int(8)
   }
-  [18]=>
+  [19]=>
   array(3) {
     [0]=>
     int(%d)
@@ -197,18 +206,7 @@ array(50) {
     [2]=>
     int(9)
   }
-  [19]=>
-  array(3) {
-    [0]=>
-    int(%d)
-    [1]=>
-    string(1) " "
-    [2]=>
-    int(9)
-  }
   [20]=>
-  string(1) "="
-  [21]=>
   array(3) {
     [0]=>
     int(%d)
@@ -217,7 +215,18 @@ array(50) {
     [2]=>
     int(9)
   }
+  [21]=>
+  string(1) "="
   [22]=>
+  array(3) {
+    [0]=>
+    int(%d)
+    [1]=>
+    string(1) " "
+    [2]=>
+    int(9)
+  }
+  [23]=>
   array(3) {
     [0]=>
     int(%d)
@@ -226,9 +235,9 @@ array(50) {
     [2]=>
     int(9)
   }
-  [23]=>
-  string(1) ";"
   [24]=>
+  string(1) ";"
+  [25]=>
   array(3) {
     [0]=>
     int(%d)
@@ -237,27 +246,27 @@ array(50) {
     [2]=>
     int(9)
   }
-  [25]=>
-  array(3) {
-    [0]=>
-    int(%d)
-    [1]=>
-    string(14) "// bool value
-"
-    [2]=>
-    int(9)
-  }
   [26]=>
   array(3) {
     [0]=>
     int(%d)
     [1]=>
-    string(1) "
-"
+    string(13) "// bool value"
     [2]=>
-    int(10)
+    int(9)
   }
   [27]=>
+  array(3) {
+    [0]=>
+    int(%d)
+    [1]=>
+    string(2) "
+
+"
+    [2]=>
+    int(9)
+  }
+  [28]=>
   array(3) {
     [0]=>
     int(%d)
@@ -269,7 +278,7 @@ array(50) {
     [2]=>
     int(11)
   }
-  [28]=>
+  [29]=>
   array(3) {
     [0]=>
     int(%d)
@@ -279,7 +288,7 @@ array(50) {
     [2]=>
     int(14)
   }
-  [29]=>
+  [30]=>
   array(3) {
     [0]=>
     int(%d)
@@ -288,18 +297,7 @@ array(50) {
     [2]=>
     int(15)
   }
-  [30]=>
-  array(3) {
-    [0]=>
-    int(%d)
-    [1]=>
-    string(1) " "
-    [2]=>
-    int(15)
-  }
   [31]=>
-  string(1) "="
-  [32]=>
   array(3) {
     [0]=>
     int(%d)
@@ -308,12 +306,14 @@ array(50) {
     [2]=>
     int(15)
   }
+  [32]=>
+  string(1) "="
   [33]=>
   array(3) {
     [0]=>
     int(%d)
     [1]=>
-    string(2) "$a"
+    string(1) " "
     [2]=>
     int(15)
   }
@@ -322,13 +322,11 @@ array(50) {
     [0]=>
     int(%d)
     [1]=>
-    string(1) " "
+    string(2) "$a"
     [2]=>
     int(15)
   }
   [35]=>
-  string(1) "+"
-  [36]=>
   array(3) {
     [0]=>
     int(%d)
@@ -337,7 +335,18 @@ array(50) {
     [2]=>
     int(15)
   }
+  [36]=>
+  string(1) "+"
   [37]=>
+  array(3) {
+    [0]=>
+    int(%d)
+    [1]=>
+    string(1) " "
+    [2]=>
+    int(15)
+  }
+  [38]=>
   array(3) {
     [0]=>
     int(%d)
@@ -346,9 +355,9 @@ array(50) {
     [2]=>
     int(15)
   }
-  [38]=>
-  string(1) ";"
   [39]=>
+  string(1) ";"
+  [40]=>
   array(3) {
     [0]=>
     int(%d)
@@ -358,7 +367,7 @@ array(50) {
     [2]=>
     int(15)
   }
-  [40]=>
+  [41]=>
   array(3) {
     [0]=>
     int(%d)
@@ -367,9 +376,9 @@ array(50) {
     [2]=>
     int(16)
   }
-  [41]=>
-  string(1) "("
   [42]=>
+  string(1) "("
+  [43]=>
   array(3) {
     [0]=>
     int(%d)
@@ -378,11 +387,11 @@ array(50) {
     [2]=>
     int(16)
   }
-  [43]=>
-  string(1) ")"
   [44]=>
-  string(1) ";"
+  string(1) ")"
   [45]=>
+  string(1) ";"
+  [46]=>
   array(3) {
     [0]=>
     int(%d)
@@ -391,17 +400,36 @@ array(50) {
     [2]=>
     int(16)
   }
-  [46]=>
+  [47]=>
   array(3) {
     [0]=>
     int(%d)
     [1]=>
-    string(20) "# expected: int(%d)
+    string(19) "# expected: int(30)"
+    [2]=>
+    int(16)
+  }
+  [48]=>
+  array(3) {
+    [0]=>
+    int(%d)
+    [1]=>
+    string(2) "
+
 "
     [2]=>
     int(16)
   }
-  [47]=>
+  [49]=>
+  array(3) {
+    [0]=>
+    int(%d)
+    [1]=>
+    string(16) "# end of program"
+    [2]=>
+    int(18)
+  }
+  [50]=>
   array(3) {
     [0]=>
     int(%d)
@@ -409,19 +437,9 @@ array(50) {
     string(1) "
 "
     [2]=>
-    int(17)
-  }
-  [48]=>
-  array(3) {
-    [0]=>
-    int(%d)
-    [1]=>
-    string(17) "# end of program
-"
-    [2]=>
     int(18)
   }
-  [49]=>
+  [51]=>
   array(3) {
     [0]=>
     int(%d)


### PR DESCRIPTION
Don't include trailing newline for `#` and `//` style comments in `T_COMMENT` tokens. Instead leave it to the following `T_WHITESPACE`.

Logically the newline doesn't belong to the comment, and having it there adds the need for ugly special-cases in tooling (as pretty much nothing else includes a trailing newline -- the opening tag and heredocs do, but due to the way they work it's less problematic there.)