### PR TITLE
[skip ci] Skip 2 tokenizer tests if tokenizer isn't loaded

### DIFF
--- a/ext/tokenizer/tests/invalid_large_octal_with_underscores.phpt
+++ b/ext/tokenizer/tests/invalid_large_octal_with_underscores.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Large invalid octal number with underscores
+--SKIPIF--
+<?php if (!extension_loaded("tokenizer")) print "skip tokenizer extension not enabled"; ?>
 --FILE--
 <?php
 

--- a/ext/tokenizer/tests/invalid_octal_dnumber.phpt
+++ b/ext/tokenizer/tests/invalid_octal_dnumber.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Invalid octal number that overflows to double
+--SKIPIF--
+<?php if (!extension_loaded("tokenizer")) print "skip tokenizer extension not enabled"; ?>
 --FILE--
 <?php
 echo token_name(token_get_all('<?php 0177777777777777777777787')[1][0]), "\n";


### PR DESCRIPTION
`./configure --disable-tokenizer` can disable tokenizer