### PR TITLE
Remove restore_include_path()

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -434,7 +434,6 @@ static const zend_function_entry basic_functions[] = { /* {{{ */
 	PHP_FE(ini_restore,														arginfo_ini_restore)
 	PHP_FE(get_include_path,												arginfo_get_include_path)
 	PHP_FE(set_include_path,												arginfo_set_include_path)
-	PHP_DEP_FE(restore_include_path,											arginfo_restore_include_path)
 
 	PHP_FE(setcookie,														arginfo_setcookie)
 	PHP_FE(setrawcookie,													arginfo_setrawcookie)
@@ -2975,20 +2974,6 @@ PHP_FUNCTION(get_include_path)
 	}
 
 	RETURN_STRING(str);
-}
-/* }}} */
-
-/* {{{ proto void restore_include_path()
-   Restore the value of the include_path configuration option */
-PHP_FUNCTION(restore_include_path)
-{
-	zend_string *key;
-
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	key = zend_string_init("include_path", sizeof("include_path")-1, 0);
-	zend_restore_ini_entry(key, PHP_INI_STAGE_RUNTIME);
-	zend_string_efree(key);
 }
 /* }}} */
 

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -94,7 +94,6 @@ PHP_FUNCTION(ini_set);
 PHP_FUNCTION(ini_restore);
 PHP_FUNCTION(get_include_path);
 PHP_FUNCTION(set_include_path);
-PHP_FUNCTION(restore_include_path);
 
 PHP_FUNCTION(print_r);
 PHP_FUNCTION(fprintf);

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -336,8 +336,6 @@ function set_include_path(string $include_path): string|false {}
 
 function get_include_path(): string|false {}
 
-function restore_include_path(): void {}
-
 /** @param mixed $var */
 function print_r($var, bool $return = false): string|bool {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -508,8 +508,6 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_get_include_path arginfo_ob_get_flush
 
-#define arginfo_restore_include_path arginfo_flush
-
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_print_r, 0, 1, MAY_BE_STRING|MAY_BE_BOOL)
 	ZEND_ARG_INFO(0, var)
 	ZEND_ARG_TYPE_INFO(0, return, _IS_BOOL, 0)

--- a/ext/standard/tests/general_functions/include_path.phpt
+++ b/ext/standard/tests/general_functions/include_path.phpt
@@ -6,58 +6,46 @@ include_path=.
 <?php
 
 var_dump(get_include_path());
-
-var_dump(restore_include_path());
+var_dump(ini_restore("include_path"));
 
 var_dump(set_include_path("var"));
 var_dump(get_include_path());
 
-var_dump(restore_include_path());
+var_dump(ini_restore("include_path"));
 var_dump(get_include_path());
 
 var_dump(set_include_path(".:/path/to/dir"));
 var_dump(get_include_path());
 
-var_dump(restore_include_path());
+var_dump(ini_restore("include_path"));
 var_dump(get_include_path());
 
 var_dump(set_include_path(""));
 var_dump(get_include_path());
 
-var_dump(restore_include_path());
+var_dump(ini_restore("include_path"));
 var_dump(get_include_path());
 
-var_dump(restore_include_path());
+var_dump(ini_restore("include_path"));
 var_dump(get_include_path());
-
 
 echo "Done\n";
 ?>
 --EXPECTF--
 string(1) "."
-
-Deprecated: Function restore_include_path() is deprecated in %s on line %d
 NULL
 string(1) "."
 string(3) "var"
-
-Deprecated: Function restore_include_path() is deprecated in %s on line %d
 NULL
 string(1) "."
 string(1) "."
 string(14) ".:/path/to/dir"
-
-Deprecated: Function restore_include_path() is deprecated in %s on line %d
 NULL
 string(1) "."
 bool(false)
 string(1) "."
-
-Deprecated: Function restore_include_path() is deprecated in %s on line %d
 NULL
 string(1) "."
-
-Deprecated: Function restore_include_path() is deprecated in %s on line %d
 NULL
 string(1) "."
 Done


### PR DESCRIPTION
As part of https://wiki.php.net/rfc/deprecations_php_7_4

P.S. The last pending item to remove is the `allow_url_include` ini directive.