### PR TITLE
Change mbstring values from size_t to ptrdiff_t as that's what they return

### DIFF
--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -1390,7 +1390,8 @@ _php_mb_regex_ereg_search_exec(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	char *arg_pattern = NULL, *arg_options = NULL;
 	size_t arg_pattern_len, arg_options_len;
 	int err;
-	size_t n, i, pos, len, beg, end;
+	size_t n, i, pos, len;
+	ptrdiff_t beg, end;
 	OnigOptionType option;
 	OnigUChar *str;
 	OnigSyntaxType *syntax;
@@ -1585,7 +1586,8 @@ PHP_FUNCTION(mb_ereg_search_init)
    Get matched substring of the last time */
 PHP_FUNCTION(mb_ereg_search_getregs)
 {
-	size_t n, i, len, beg, end;
+	size_t n, i, len;
+	ptrdiff_t beg, end;
 	OnigUChar *str;
 
 	if (zend_parse_parameters_none() == FAILURE) {

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -1391,7 +1391,8 @@ _php_mb_regex_ereg_search_exec(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	size_t arg_pattern_len, arg_options_len;
 	int err;
 	size_t n, i, pos, len;
-	ptrdiff_t beg, end;
+	/* Stored as int* in the OnigRegion struct */
+	int beg, end;
 	OnigOptionType option;
 	OnigUChar *str;
 	OnigSyntaxType *syntax;
@@ -1587,7 +1588,8 @@ PHP_FUNCTION(mb_ereg_search_init)
 PHP_FUNCTION(mb_ereg_search_getregs)
 {
 	size_t n, i, len;
-	ptrdiff_t beg, end;
+	/* Stored as int* in the OnigRegion struct */
+	int beg, end;
 	OnigUChar *str;
 
 	if (zend_parse_parameters_none() == FAILURE) {


### PR DESCRIPTION
As this has emerged out of #5151 that this may be a bug.

Oniguruma is returning a ``ptrdiff_t`` but we were storing it in a ``size_t`` but a ``ptrdiff_t `` may be negative.