### PR TITLE
Update Travis dist from Xenial to Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 git:
   quiet: true
 
-dist: xenial
+dist: bionic
 language: c
 os: linux
 addons:


### PR DESCRIPTION
Main reason is to have a more recent version of GCC (from 5.4.0 to 7.4.0) which doesn't spit out false positives on the ``-Wstrict-aliasing -fstrict-aliasing`` compiler flags meaning that we should be able to drop (expect if some extensions only tested on Azure have issues) the ``-Wno-strict-aliasing`` flag.