### PR TITLE
Fixes #79265: Improper injection of Host header when using fopen for http requests

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -460,41 +460,69 @@ finish:
 				strip_header(user_headers, t, "content-type:");
 			}
 
-			if ((s = strstr(t, "user-agent:")) &&
-			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
-			                 *(s-1) == '\t' || *(s-1) == ' ')) {
-				 have_header |= HTTP_HEADER_USER_AGENT;
-			}
-			if ((s = strstr(t, "host:")) &&
-			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
-			                 *(s-1) == '\t' || *(s-1) == ' ')) {
-				 have_header |= HTTP_HEADER_HOST;
-			}
-			if ((s = strstr(t, "from:")) &&
-			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
-			                 *(s-1) == '\t' || *(s-1) == ' ')) {
-				 have_header |= HTTP_HEADER_FROM;
+			s = t;
+			while ((s = strstr(s, "user-agent:"))) {
+				if (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+				                 *(s-1) == '\t' || *(s-1) == ' ') {
+					 have_header |= HTTP_HEADER_USER_AGENT;
 				}
-			if ((s = strstr(t, "authorization:")) &&
-			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
-			                 *(s-1) == '\t' || *(s-1) == ' ')) {
-				 have_header |= HTTP_HEADER_AUTH;
+				s++;
 			}
-			if ((s = strstr(t, "content-length:")) &&
-			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
-			                 *(s-1) == '\t' || *(s-1) == ' ')) {
-				 have_header |= HTTP_HEADER_CONTENT_LENGTH;
+
+			s = t;
+			while ((s = strstr(s, "host:"))) {
+				if (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+				                 *(s-1) == '\t' || *(s-1) == ' ') {
+					 have_header |= HTTP_HEADER_HOST;
+				}
+				s++;
 			}
-			if ((s = strstr(t, "content-type:")) &&
-			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
-			                 *(s-1) == '\t' || *(s-1) == ' ')) {
-				 have_header |= HTTP_HEADER_TYPE;
+
+			s = t;
+			while ((s = strstr(s, "from:"))) {
+				if (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+				                 *(s-1) == '\t' || *(s-1) == ' ') {
+					 have_header |= HTTP_HEADER_FROM;
+				}
+				s++;
 			}
-			if ((s = strstr(t, "connection:")) &&
-			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
-			                 *(s-1) == '\t' || *(s-1) == ' ')) {
-				 have_header |= HTTP_HEADER_CONNECTION;
+
+			s = t;
+			while ((s = strstr(s, "authorization:"))) {
+				if (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+				                 *(s-1) == '\t' || *(s-1) == ' ') {
+					 have_header |= HTTP_HEADER_AUTH;
+				}
+				s++;
 			}
+
+			s = t;
+			while ((s = strstr(s, "content-length:"))) {
+				if (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+				                 *(s-1) == '\t' || *(s-1) == ' ') {
+					 have_header |= HTTP_HEADER_CONTENT_LENGTH;
+				}
+				s++;
+			}
+
+			s = t;
+			while ((s = strstr(s, "content-type:"))) {
+				if (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+				                 *(s-1) == '\t' || *(s-1) == ' ') {
+					 have_header |= HTTP_HEADER_TYPE;
+				}
+				s++;
+			}
+
+			s = t;
+			while ((s = strstr(s, "connection:"))) {
+				if (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+				                 *(s-1) == '\t' || *(s-1) == ' ') {
+					 have_header |= HTTP_HEADER_CONNECTION;
+				}
+				s++;
+			}
+
 			/* remove Proxy-Authorization header */
 			if (use_proxy && use_ssl && (s = strstr(t, "proxy-authorization:")) &&
 			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||

--- a/ext/standard/tests/http/bug79265.phpt
+++ b/ext/standard/tests/http/bug79265.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Bug #79265 (Improper injection of Host header when using fopen for http requests)
+--INI--
+allow_url_fopen=1
+--SKIPIF--
+
+--FILE--
+<?php
+require 'server.inc';
+
+$responses = array(
+    "data://text/plain,HTTP/1.0 200 OK\r\n\r\n",
+);
+
+$pid = http_server("tcp://127.0.0.1:12342", $responses, $output);
+
+$opts = array(
+  'http'=>array(
+    'method'=>"GET",
+    'header'=>"RandomHeader: localhost:8080\r\n" .
+              "Cookie: foo=bar\r\n" .
+              "Host: userspecifiedvalue\r\n"
+  )
+);
+$context = stream_context_create($opts);
+$fd = fopen('http://127.0.0.1:12342/', 'rb', false, $context);
+fseek($output, 0, SEEK_SET);
+echo stream_get_contents($output);
+fclose($fd);
+
+http_server_kill($pid);
+
+?>
+--EXPECT--
+GET / HTTP/1.0
+Connection: close
+RandomHeader: localhost:8080
+Cookie: foo=bar
+Host: userspecifiedvalue


### PR DESCRIPTION
fopen currently only looks at the first instance of a string on the request headers when setting the flag if that header is present or not. That causes some problems as malformed requests with two instances of the Host: header. This patch checks every instance of the string to set up the flags correctly.