### PR TITLE
New way to print a COM class

### DIFF
--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -773,7 +773,7 @@ PHP_FUNCTION(com_print_typeinfo)
 
 	typeinfo = php_com_locate_typeinfo(typelibname, obj, ifacename, wantsink ? 1 : 0);
 	if (typeinfo) {
-		php_com_process_typeinfo(typeinfo, NULL, 1, NULL, obj ? obj->code_page : COMG(code_page));
+		php_com_print_typeinfo(typeinfo, obj ? obj->code_page : COMG(code_page));
 		ITypeInfo_Release(typeinfo);
 		RETURN_TRUE;
 	} else {

--- a/ext/com_dotnet/com_typeinfo.c
+++ b/ext/com_dotnet/com_typeinfo.c
@@ -672,17 +672,16 @@ int php_com_print_typeinfo(ITypeInfo* typeinfo, int codepage)
 {
 	TYPEATTR* attr;
 	FUNCDESC* func;
-	FUNCDESC* nextFunc;
+	FUNCDESC* next_func;
 	int i;
 	OLECHAR* olename;
-	OLECHAR* docString;
+	OLECHAR* doc_str;
 	char* ansiname = NULL;
 	size_t ansinamelen;
 	char* guidstring;
 	char* class_name = NULL;
 	DISPID lastid = 0;	/* for props */
 	int isprop;
-
 	int j;
 	char* funcdesc;
 	char* param;
@@ -712,14 +711,14 @@ int php_com_print_typeinfo(ITypeInfo* typeinfo, int codepage)
 		{
 			char* propReadOnly = "";
 			lastid = func->memid;
-			ITypeInfo_GetDocumentation(typeinfo, func->memid, &olename, &docString, NULL, NULL);
+			ITypeInfo_GetDocumentation(typeinfo, func->memid, &olename, &doc_str, NULL, NULL);
 			ansiname = php_com_olestring_to_string(olename, &ansinamelen, codepage);
 			SysFreeString(olename);
 
 			char* funcdesc;
 			size_t funcdesclen;
 
-			if (!FAILED(ITypeInfo_GetFuncDesc(typeinfo, i + 1, &nextFunc)) && func->memid != nextFunc->memid)
+			if (!FAILED(ITypeInfo_GetFuncDesc(typeinfo, i + 1, &next_func)) && func->memid != next_func->memid)
 			{
 				propReadOnly = "-read";
 			}
@@ -731,10 +730,10 @@ int php_com_print_typeinfo(ITypeInfo* typeinfo, int codepage)
 			);
 			efree(ansiname);
 
-			if (docString) {
-				funcdesc = php_com_olestring_to_string(docString, &funcdesclen, codepage);
+			if (doc_str) {
+				funcdesc = php_com_olestring_to_string(doc_str, &funcdesclen, codepage);
 				php_printf(" %s", funcdesc);
-				SysFreeString(docString);
+				SysFreeString(doc_str);
 				efree(funcdesc);
 			}
 			php_printf("\n");
@@ -753,7 +752,7 @@ int php_com_print_typeinfo(ITypeInfo* typeinfo, int codepage)
 		isprop = (func->invkind & DISPATCH_PROPERTYGET || func->invkind & DISPATCH_PROPERTYPUT);
 		if (!isprop || lastid != func->memid) {
 			lastid = func->memid;
-			ITypeInfo_GetDocumentation(typeinfo, func->memid, &olename, &docString, NULL, NULL);
+			ITypeInfo_GetDocumentation(typeinfo, func->memid, &olename, &doc_str, NULL, NULL);
 			ansiname = php_com_olestring_to_string(olename, &ansinamelen, codepage);
 			SysFreeString(olename);
 
@@ -770,10 +769,10 @@ int php_com_print_typeinfo(ITypeInfo* typeinfo, int codepage)
 					ansiname,
 					func->elemdescFunc.tdesc.vt
 				);
-				if (docString) {
-					funcdesc = php_com_olestring_to_string(docString, &funcdesclen, codepage);
+				if (doc_str) {
+					funcdesc = php_com_olestring_to_string(doc_str, &funcdesclen, codepage);
 					php_printf(" %s", funcdesc);
-					SysFreeString(docString);
+					SysFreeString(doc_str);
 					efree(funcdesc);
 				}
 				php_printf("\n\t*/\n");
@@ -807,9 +806,9 @@ int php_com_print_typeinfo(ITypeInfo* typeinfo, int codepage)
 					vt_to_string(func->elemdescFunc.tdesc.vt)
 				);
 
-				if (docString) {
-					funcdesc = php_com_olestring_to_string(docString, &funcdesclen, codepage);
-					SysFreeString(docString);
+				if (doc_str) {
+					funcdesc = php_com_olestring_to_string(doc_str, &funcdesclen, codepage);
+					SysFreeString(doc_str);
 					php_printf("\t * %s\n", funcdesc);
 					efree(funcdesc);
 				}

--- a/ext/com_dotnet/php_com_dotnet_internal.h
+++ b/ext/com_dotnet/php_com_dotnet_internal.h
@@ -170,6 +170,7 @@ PHP_COM_DOTNET_API int php_com_import_typelib(ITypeLib *TL, int mode,
 void php_com_typelibrary_dtor(zval *pDest);
 ITypeInfo *php_com_locate_typeinfo(char *typelibname, php_com_dotnet_object *obj, char *dispname, int sink);
 int php_com_process_typeinfo(ITypeInfo *typeinfo, HashTable *id_to_name, int printdef, GUID *guid, int codepage);
+int php_com_print_typeinfo(ITypeInfo *typeinfo, int codepage);
 ITypeLib *php_com_cache_typelib(ITypeLib* TL, char *cache_key, zend_long cache_key_len);
 PHP_MINIT_FUNCTION(com_typeinfo);
 PHP_MSHUTDOWN_FUNCTION(com_typeinfo);


### PR DESCRIPTION
I would like to propose a more complete way to print a COM class, something that helps the IDE.
Added doc blocks to functions and properties.
Does this require an RFC?

[example.zip](https://github.com/php/php-src/files/4246275/example.zip)

