### PR TITLE
Fix #63206: Fully support error/exception_handler stacking

### DIFF
--- a/Zend/tests/bug63206.phpt
+++ b/Zend/tests/bug63206.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Bug #63206 Fully support error_handler stacking, even inside the error_handler
+--FILE--
+<?php
+
+set_error_handler(function() {
+    echo 'First handler' . PHP_EOL;
+});
+
+set_error_handler(function() {
+    echo 'Second handler' . PHP_EOL;
+
+    set_error_handler(function() {
+        echo 'Internal handler' . PHP_EOL;
+    });
+
+    $triggerInternalNotice++; // warnings while handling the error should go into internal handler
+
+    restore_error_handler();
+});
+
+$triggerNotice1++;
+$triggerNotice2++;
+?>
+--EXPECTF--
+Second handler
+Internal handler
+Second handler
+Internal handler

--- a/Zend/tests/bug63206_1.phpt
+++ b/Zend/tests/bug63206_1.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #63206 Fully support error_handler stacking, even with null
+--FILE--
+<?php
+
+set_error_handler(function() {
+    echo 'First handler' . PHP_EOL;
+});
+
+set_error_handler(function() {
+    echo 'Second handler' . PHP_EOL;
+});
+
+set_error_handler(null);
+
+set_error_handler(function() {
+    echo 'Fourth handler' . PHP_EOL;
+});
+
+restore_error_handler();
+restore_error_handler();
+
+$triggerNotice++;
+?>
+--EXPECTF--
+Second handler

--- a/Zend/tests/bug63206_2.phpt
+++ b/Zend/tests/bug63206_2.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #63206 Fully support exception_handler stacking, even with null
+--FILE--
+<?php
+
+set_exception_handler(function() {
+    echo 'First handler' . PHP_EOL;
+});
+
+set_exception_handler(function() {
+    echo 'Second handler' . PHP_EOL;
+});
+
+set_exception_handler(null);
+
+set_exception_handler(function() {
+    echo 'Fourth handler' . PHP_EOL;
+});
+
+restore_exception_handler();
+restore_exception_handler();
+
+throw new Exception();
+?>
+--EXPECTF--
+Second handler

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1665,10 +1665,10 @@ ZEND_FUNCTION(set_error_handler)
 
 	if (Z_TYPE(EG(user_error_handler)) != IS_UNDEF) {
 		ZVAL_COPY(return_value, &EG(user_error_handler));
-
-		zend_stack_push(&EG(user_error_handlers_error_reporting), &EG(user_error_handler_error_reporting));
-		zend_stack_push(&EG(user_error_handlers), &EG(user_error_handler));
 	}
+
+	zend_stack_push(&EG(user_error_handlers_error_reporting), &EG(user_error_handler_error_reporting));
+	zend_stack_push(&EG(user_error_handlers), &EG(user_error_handler));
 
 	if (Z_TYPE_P(error_handler) == IS_NULL) { /* unset user-defined handler */
 		ZVAL_UNDEF(&EG(user_error_handler));
@@ -1732,9 +1732,9 @@ ZEND_FUNCTION(set_exception_handler)
 
 	if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
 		ZVAL_COPY(return_value, &EG(user_exception_handler));
-
-		zend_stack_push(&EG(user_exception_handlers), &EG(user_exception_handler));
 	}
+
+	zend_stack_push(&EG(user_exception_handlers), &EG(user_exception_handler));
 
 	if (Z_TYPE_P(exception_handler) == IS_NULL) { /* unset user-defined handler */
 		ZVAL_UNDEF(&EG(user_exception_handler));


### PR DESCRIPTION
... even with `null` or inside the handler.

Always push the current user_error/exception_handler to the stack,
even when it is empty, so `restore_error_handler()` always works as
expected.

The `user_error_handler` is especially temporarily empty when we are inside
the error handler, which caused inconsistent behaviour before.

See attached test-cases for details.

PHP-Bug: https://bugs.php.net/bug.php?id=63206