### PR TITLE
Require all internal functions to have arginfo

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2042,9 +2042,9 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 		} else {
 			internal_function->fn_flags = ZEND_ACC_PUBLIC;
 		}
+
 		if (ptr->arg_info) {
 			zend_internal_function_info *info = (zend_internal_function_info*)ptr->arg_info;
-
 			internal_function->arg_info = (zend_internal_arg_info*)ptr->arg_info+1;
 			internal_function->num_args = ptr->num_args;
 			/* Currently you cannot denote that the function can accept less arguments than num_args */
@@ -2072,10 +2072,14 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 				internal_function->fn_flags |= ZEND_ACC_HAS_RETURN_TYPE;
 			}
 		} else {
+			zend_error(E_CORE_WARNING, "Missing arginfo for %s%s%s()",
+				 scope ? ZSTR_VAL(scope->name) : "", scope ? "::" : "", ptr->fname);
+
 			internal_function->arg_info = NULL;
 			internal_function->num_args = 0;
 			internal_function->required_num_args = 0;
 		}
+
 		zend_set_function_arg_flags((zend_function*)internal_function);
 		if (ptr->flags & ZEND_ACC_ABSTRACT) {
 			if (scope) {

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -530,14 +530,6 @@ static inheritance_status zend_do_perform_implementation_check(
 	inheritance_status status, local_status;
 	zend_bool proto_is_variadic, fe_is_variadic;
 
-	/* If it's a user function then arg_info == NULL means we don't have any parameters but
-	 * we still need to do the arg number checks.  We are only willing to ignore this for internal
-	 * functions because extensions don't always define arg_info.
-	 */
-	if (!proto->common.arg_info && proto->common.type != ZEND_USER_FUNCTION) {
-		return INHERITANCE_SUCCESS;
-	}
-
 	/* Checks for constructors only if they are declared in an interface,
 	 * or explicitly marked as abstract
 	 */


### PR DESCRIPTION
All internal functions are now required to specify arg_info.

Note that zf->common.arg_info can still be NULL, but only if num_args==0.