### PR TITLE
Fix #64032: mysqli reports different client_version

### DIFF
--- a/ext/mysqli/mysqli_driver.c
+++ b/ext/mysqli/mysqli_driver.c
@@ -96,7 +96,7 @@ static zval *driver_embedded_read(mysqli_object *obj, zval *retval)
 /* {{{ property driver_client_version_read */
 static zval *driver_client_version_read(mysqli_object *obj, zval *retval)
 {
-	ZVAL_LONG(retval, MYSQL_VERSION_ID);
+	ZVAL_LONG(retval, mysql_get_client_version());
 	return retval;
 }
 /* }}} */


### PR DESCRIPTION
While `mysqli_get_client_version()` calls `mysql_get_client_version()`
to retrieve the client version, `mysql::$client_version` is initialized
to `MYSQL_VERSION_ID`.  Both should match though, and since the former
is the more useful information, we fix `mysql::$client_version`.

We do not add a regression test, because it would usually succeed
anyway, and we already have several tests with respective `assert()`s.