### PR TITLE
Fix #79013: Content-Length missing when posting a curlFile with curl

### DIFF
--- a/ext/curl/tests/bug77711.phpt
+++ b/ext/curl/tests/bug77711.phpt
@@ -1,7 +1,10 @@
 --TEST--
 FR #77711 (CURLFile should support UNICODE filenames)
 --SKIPIF--
-<?php include 'skipif.inc'; ?>
+<?php
+include 'skipif.inc';
+if (!CURL_FILE_AS_STREAM) die('skip CURLFile does not support streams');
+?>
 --FILE--
 <?php
 include 'server.inc';

--- a/ext/curl/tests/curl_copy_handle_variation3.phpt
+++ b/ext/curl/tests/curl_copy_handle_variation3.phpt
@@ -1,7 +1,10 @@
 --TEST--
 curl_copy_handle() allows to post CURLFile multiple times
 --SKIPIF--
-<?php include 'skipif.inc'; ?>
+<?php
+include 'skipif.inc';
+if (!CURL_FILE_AS_STREAM) die('skip CURLFile does not support streams');
+?>
 --FILE--
 <?php
 include 'server.inc';

--- a/ext/curl/tests/curl_copy_handle_variation4.phpt
+++ b/ext/curl/tests/curl_copy_handle_variation4.phpt
@@ -1,7 +1,10 @@
 --TEST--
 curl_copy_handle() allows to post CURLFile multiple times with curl_multi_exec()
 --SKIPIF--
-<?php include 'skipif.inc'; ?>
+<?php
+include 'skipif.inc';
+if (!CURL_FILE_AS_STREAM) die('skip CURLFile does not support streams');
+?>
 --FILE--
 <?php
 include 'server.inc';

--- a/ext/curl/tests/curl_file_upload_stream.phpt
+++ b/ext/curl/tests/curl_file_upload_stream.phpt
@@ -1,9 +1,10 @@
 --TEST--
 CURL file uploading from stream
 --SKIPIF--
-<?php include 'skipif.inc'; ?>
 <?php
-if (curl_version()['version_number'] < 0x73800) die('skip requires curl >= 7.56.0');
+include 'skipif.inc';
+if (!CURL_FILE_AS_STREAM) die('skip CURLFile does not support streams');
+?>
 --FILE--
 <?php
 include 'server.inc';


### PR DESCRIPTION
Unfortunately, some Webservers (e.g. IIS) do not implement the (F)CGI
specifications correctly wrt. chunked uploads (i.e. Transfer-encoding:
chunked), but instead pass `-1` as CONTENT_LENGTH to the CGI
application.  However, our (F)CFI SAPIs (i.e. cgi and cgi-fcgi) do not
support this.

Therefore we do no longer do chunked uploads unless ext/curl has been
compiled with `CURL_FILE_AS_STREAM` for best interoperability.  We only
make minimal modifications to the code for simplicity, and also because
we consider this commit a mere work-around for broken (F)CGI servers/
applications which have to deal with HTTP/1.1 requests (HTTP/2 and
later do no longer support Transfer-encoding: chunked, anyway).

Users who are sure that they upload CURLFiles to servers which support
chunked uploads are encouraged to build with `CURL_FILE_AS_STREAM`; we
introduce the PHP constant `CURL_FILE_AS_STREAM` to be able to retrieve
this information during run-time.