### PR TITLE
Fix #79311: enchant_dict_suggest() fails on big endian architecture

### DIFF
--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -723,18 +723,16 @@ PHP_FUNCTION(enchant_dict_quick_check)
 	PHP_ENCHANT_GET_DICT;
 
 	if (enchant_dict_check(pdict->pdict, word, wordlen) > 0) {
-		int n_sugg;
-		size_t n_sugg_st;
+		size_t n_sugg;
 		char **suggs;
 
 		if (!sugg && ZEND_NUM_ARGS() == 2) {
 			RETURN_FALSE;
 		}
 
-		suggs = enchant_dict_suggest(pdict->pdict, word, wordlen, &n_sugg_st);
-		memcpy(&n_sugg, &n_sugg_st, sizeof(n_sugg));
+		suggs = enchant_dict_suggest(pdict->pdict, word, wordlen, &n_sugg);
 		if (suggs && n_sugg) {
-			int i;
+			size_t i;
 			for (i = 0; i < n_sugg; i++) {
 				add_next_index_string(sugg, suggs[i]);
 			}
@@ -776,8 +774,7 @@ PHP_FUNCTION(enchant_dict_suggest)
 	size_t wordlen;
 	char **suggs;
 	enchant_dict *pdict;
-	int n_sugg;
-	size_t n_sugg_st;
+	size_t n_sugg;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &dict, &word, &wordlen) == FAILURE) {
 		RETURN_FALSE;
@@ -785,10 +782,9 @@ PHP_FUNCTION(enchant_dict_suggest)
 
 	PHP_ENCHANT_GET_DICT;
 
-	suggs = enchant_dict_suggest(pdict->pdict, word, wordlen, &n_sugg_st);
-	memcpy(&n_sugg, &n_sugg_st, sizeof(n_sugg));
+	suggs = enchant_dict_suggest(pdict->pdict, word, wordlen, &n_sugg);
 	if (suggs && n_sugg) {
-		int i;
+		size_t i;
 
 		array_init(return_value);
 		for (i = 0; i < n_sugg; i++) {


### PR DESCRIPTION
For obvious reasons, we must not assign a `size_t` value to an `int`
variable using memcpy().  However, there is actually no need for the
intermediate `n_sugg_st` here, if we use the proper types in the first
place.

A regression test is not necessary, because dict_suggest.phpt already
exhibits the erroneous behavior on big endian architectures.