### PR TITLE
Fix #79178 parse_url check control chars on host

### DIFF
--- a/ext/standard/tests/url/bug79178.phpt
+++ b/ext/standard/tests/url/bug79178.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #79178	[parse_url] underscore at end of host
+--FILE--
+<?php
+
+// Should return false because HOST contains a control character (PHP_EOL)
+var_dump(parse_url('https://php.net' . PHP_EOL, PHP_URL_HOST));
+
+?>
+--EXPECT--
+bool(false)

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -280,7 +280,21 @@ PHPAPI php_url *php_url_parse_ex(char const *str, size_t length)
 	}
 
 	ret->host = zend_string_init(s, (p-s), 0);
-	php_replace_controlchars_ex(ZSTR_VAL(ret->host), ZSTR_LEN(ret->host));
+	char *host_str = ZSTR_VAL(ret->host);
+	size_t host_len = ZSTR_LEN(ret->host);
+
+	/* check for control characters and marks host as invalid if present */
+	unsigned char *current = (unsigned char *)host_str;
+	unsigned char *last = current + host_len;
+	while (current < last) {
+		if (iscntrl(*current)) {
+			php_url_free(ret);
+			return NULL;
+		}
+		current++;
+	}
+
+	php_replace_controlchars_ex(host_str, host_len);
 
 	if (e == ue) {
 		return ret;


### PR DESCRIPTION
This PR aims to fix the [bug ticket #79178](https://bugs.php.net/bug.php?id=79178).

**There's something bothering me though:**
`php_replace_controlchars_ex` seems to replace every control char with `_` instead of panicking. 

Meanwhile, [RFC 1738](https://tools.ietf.org/html/rfc1738#section-2.2) says the following:
> URLs are written only with the graphic printable characters of the US-ASCII coded character set. The octets 80-FF hexadecimal are not used in US-ASCII, and the octets 00-1F and 7F hexadecimal represent control characters; these must be encoded.

The above states that characters like `new line` should be encoded. PHP, for some reason I couldn't figure out so far, replaces them with underscores.

**Even though this fixes the bug on PHP_URL_HOST, the same issue still happens on other URL parts**.

```php
<?php

// There's no backslash after .net and before PHP_EOL!!
var_dump(parse_url('https://php.net' . PHP_EOL));
// bool(false)

// There IS a backslash after .net and before PHP_EOL!!
var_dump(parse_url('https://php.net/' . PHP_EOL));
// array(3) {
//   ["scheme"]=>
//   string(5) "https"
//   ["host"]=>
//   string(7) "php.net"
//   ["path"]=>
//   string(2) "/_"
// }
```

Path seems to be still wrong in my opinion.

Shall we discuss a better solution for this maybe?