### PR TITLE
Fix bug #69180 (Reflection does not honor trait conflict resolution / method aliasing)

### DIFF
--- a/Zend/tests/bug65579.phpt
+++ b/Zend/tests/bug65579.phpt
@@ -25,5 +25,5 @@ array(2) {
   [0]=>
   string(10) "testMethod"
   [1]=>
-  string(25) "testmethodfromparenttrait"
+  string(25) "testMethodFromParentTrait"
 }

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4228,55 +4228,6 @@ ZEND_API void zend_restore_error_handling(zend_error_handling *saved) /* {{{ */
 }
 /* }}} */
 
-ZEND_API zend_string* zend_find_alias_name(zend_class_entry *ce, zend_string *name) /* {{{ */
-{
-	zend_trait_alias *alias, **alias_ptr;
-
-	if ((alias_ptr = ce->trait_aliases)) {
-		alias = *alias_ptr;
-		while (alias) {
-			if (alias->alias && zend_string_equals_ci(alias->alias, name)) {
-				return alias->alias;
-			}
-			alias_ptr++;
-			alias = *alias_ptr;
-		}
-	}
-
-	return name;
-}
-/* }}} */
-
-ZEND_API zend_string *zend_resolve_method_name(zend_class_entry *ce, zend_function *f) /* {{{ */
-{
-	zend_function *func;
-	HashTable *function_table;
-	zend_string *name;
-
-	if (f->common.type != ZEND_USER_FUNCTION ||
-	    (f->op_array.refcount && *(f->op_array.refcount) < 2) ||
-	    !f->common.scope ||
-	    !f->common.scope->trait_aliases) {
-		return f->common.function_name;
-	}
-
-	function_table = &ce->function_table;
-	ZEND_HASH_FOREACH_STR_KEY_PTR(function_table, name, func) {
-		if (func == f) {
-			if (!name) {
-				return f->common.function_name;
-			}
-			if (ZSTR_LEN(name) == ZSTR_LEN(f->common.function_name) &&
-			    !strncasecmp(ZSTR_VAL(name), ZSTR_VAL(f->common.function_name), ZSTR_LEN(f->common.function_name))) {
-				return f->common.function_name;
-			}
-			return zend_find_alias_name(f->common.scope, name);
-		}
-	} ZEND_HASH_FOREACH_END();
-	return f->common.function_name;
-}
-/* }}} */
-
 ZEND_API ZEND_COLD const char *zend_get_object_type(const zend_class_entry *ce) /* {{{ */
 {
 	if(ce->ce_flags & ZEND_ACC_TRAIT) {

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -575,9 +575,6 @@ static zend_always_inline int zend_forbid_dynamic_call(const char *func_name)
 	return SUCCESS;
 }
 
-ZEND_API zend_string *zend_find_alias_name(zend_class_entry *ce, zend_string *name);
-ZEND_API zend_string *zend_resolve_method_name(zend_class_entry *ce, zend_function *f);
-
 ZEND_API ZEND_COLD const char *zend_get_object_type(const zend_class_entry *ce);
 
 ZEND_API zend_bool zend_is_iterable(zval *iterable);

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -702,6 +702,7 @@ ZEND_API void zend_create_closure(zval *res, zend_function *func, zend_class_ent
 			}
 			memset(ptr, 0, func->op_array.cache_size);
 		}
+		zend_string_addref(closure->func.op_array.function_name);
 		if (closure->func.op_array.refcount) {
 			(*closure->func.op_array.refcount)++;
 		}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1063,10 +1063,10 @@ ZEND_API void function_add_ref(zend_function *function) /* {{{ */
 			ZEND_MAP_PTR_INIT(op_array->run_time_cache, zend_arena_alloc(&CG(arena), sizeof(void*)));
 			ZEND_MAP_PTR_SET(op_array->run_time_cache, NULL);
 		}
-	} else if (function->type == ZEND_INTERNAL_FUNCTION) {
-		if (function->common.function_name) {
-			zend_string_addref(function->common.function_name);
-		}
+	}
+
+	if (function->common.function_name) {
+		zend_string_addref(function->common.function_name);
 	}
 }
 /* }}} */

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -447,6 +447,10 @@ ZEND_API void destroy_op_array(zend_op_array *op_array)
 		efree(ZEND_MAP_PTR(op_array->run_time_cache));
 	}
 
+	if (op_array->function_name) {
+		zend_string_release_ex(op_array->function_name, 0);
+	}
+
 	if (!op_array->refcount || --(*op_array->refcount) > 0) {
 		return;
 	}
@@ -476,9 +480,6 @@ ZEND_API void destroy_op_array(zend_op_array *op_array)
 	}
 	efree(op_array->opcodes);
 
-	if (op_array->function_name) {
-		zend_string_release_ex(op_array->function_name, 0);
-	}
 	if (op_array->doc_comment) {
 		zend_string_release_ex(op_array->doc_comment, 0);
 	}

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1210,9 +1210,7 @@ static void reflection_method_factory(zend_class_entry *ce, zend_function *metho
 		ZVAL_OBJ(&intern->obj, Z_OBJ_P(closure_object));
 	}
 
-	ZVAL_STR_COPY(reflection_prop_name(object),
-		(method->common.scope && method->common.scope->trait_aliases)
-			? zend_resolve_method_name(ce, method) : method->common.function_name);
+	ZVAL_STR_COPY(reflection_prop_name(object), method->common.function_name);
 	ZVAL_STR_COPY(reflection_prop_class(object), method->common.scope->name);
 }
 /* }}} */

--- a/ext/reflection/tests/bug69180.phpt
+++ b/ext/reflection/tests/bug69180.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Bug #69180: Reflection does not honor trait conflict resolution / method aliasing
+--FILE--
+<?php
+
+trait T1
+{
+    public function foo()
+    {
+    }
+}
+
+trait T2
+{
+    use T1 { foo as bar; }
+
+    public function foo()
+    {
+    }
+}
+
+
+class C
+{
+    use T2;
+}
+
+$class = new ReflectionClass('C');
+
+foreach ($class->getMethods() as $method) {
+    var_dump($method->getName());
+}
+
+?>
+--EXPECT--
+string(3) "foo"
+string(3) "bar"


### PR DESCRIPTION
Currently, trait methods are aliased will continue to use the original function name. In a few places in the codebase, we will try to look up the actual method name instead. However, this does not work if an aliased method is used indirectly (https://bugs.php.net/bug.php?id=69180).

I think it would be better to instead actually change the method name to the alias. This is in principle easy: We have to allow function_name to be changed even if op array is otherwise shared (similar to static_variables). This means we need to addref/release the function_name separately, but I don't think there is a performance concern here (especially as everything is usually interned).

There is a bit of complication in opcache, where we need to make sure that the function name is released the correct number of times (interning may overwrite the name in the original op_array, but we need to release it as many times as the op_array is shared).