### PR TITLE
PDO_OCI: Add test of the phpinfo output

### DIFF
--- a/ext/pdo_oci/tests/pdo_oci_phpinfo.phpt
+++ b/ext/pdo_oci/tests/pdo_oci_phpinfo.phpt
@@ -1,0 +1,27 @@
+--TEST--
+PDO_OCI: phpinfo() output
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_oci')) die('skip not loaded');
+require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+PDOTest::skip();
+?>
+--FILE--
+<?php
+	require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+	$db = PDOTest::factory();
+
+	ob_start();
+	phpinfo();
+	$tmp = ob_get_contents();
+	ob_end_clean();
+
+	$reg = 'PDO Driver for OCI 8 and later => enabled';
+	if (!preg_match("/$reg/", $tmp)) {
+		printf("[001] Cannot find OCI PDO driver line in phpinfo() output\n");
+	}
+
+	print "done!";
+?>
+--EXPECT--
+done!


### PR DESCRIPTION
Adds a test of the `phpinfo()` output for the information provided by the PDO_OCI driver, matching other drivers that have a similar test.