### PR TITLE
Require non-absolute trait method refs to be unambiguous

### DIFF
--- a/Zend/tests/bug62069.phpt
+++ b/Zend/tests/bug62069.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #62069: binding wrong traits if they have same name methods
+--FILE--
+<?php
+
+trait T1 {
+    public function func() {
+        echo "From T1\n";
+    }
+}
+
+trait T2 {
+    public function func() {
+        echo "From T2\n";
+    }
+}
+
+class Bar {
+    public function func() {
+        echo "From Bar\n";
+    }
+    use T1, T2 {
+        func as f1;
+    }
+}
+
+$b = new Bar();
+$b->f2();
+
+?>
+--EXPECTF--
+Fatal error: An alias was defined for method func(), which exists in both T1 and T2. Use T1::func or T2::func to resolve the ambiguity in %s on line %d

--- a/Zend/tests/bug62069_2.phpt
+++ b/Zend/tests/bug62069_2.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug #62069: binding wrong traits if they have same name methods (variation 2)
+--FILE--
+<?php
+
+trait T1 {
+    public function func() {
+        echo "From T1\n";
+    }
+}
+
+trait T2 {
+    public function func() {
+        echo "From T2\n";
+    }
+}
+
+class Bar {
+    public function func() {
+        echo "From Bar\n";
+    }
+    use T1 {
+        func as f1;
+    }
+    use T2 {
+        func as f2;
+    }
+}
+
+$b = new Bar();
+$b->f2();
+
+?>
+--EXPECTF--
+Fatal error: An alias was defined for method func(), which exists in both T1 and T2. Use T1::func or T2::func to resolve the ambiguity in %s on line %d

--- a/Zend/tests/traits/language011.phpt
+++ b/Zend/tests/traits/language011.phpt
@@ -18,7 +18,7 @@ trait World {
 
 
 class MyClass {
-   use Hello, World { sayHello as sayWorld; }
+   use Hello, World { World::sayHello as sayWorld; }
 }
 
 $o = new MyClass();

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1870,8 +1870,12 @@ static void zend_traits_init_trait_structures(zend_class_entry *ce, zend_class_e
 								continue;
 							}
 
-							// TODO: This is ambiguous! The first trait is assumed.
-							break;
+							zend_error_noreturn(E_COMPILE_ERROR,
+								"An alias was defined for method %s(), which exists in both %s and %s. Use %s::%s or %s::%s to resolve the ambiguity",
+								ZSTR_VAL(cur_method_ref->method_name),
+								ZSTR_VAL(trait->name), ZSTR_VAL(traits[j]->name),
+								ZSTR_VAL(trait->name), ZSTR_VAL(cur_method_ref->method_name),
+								ZSTR_VAL(traits[j]->name), ZSTR_VAL(cur_method_ref->method_name));
 						}
 					}
 				}


### PR DESCRIPTION
Currently, when writing something like

```
class X {
    use T1, T2 {
       func as otherFunc;
    }
    function func() {}
}
```

where both `T1::func()` and `T2::func()` exist, we will simply assume that `func` refers to `T1::func()`. This is surprising, and it doesn't really make sense that this particular method gets picked.

This PR validates that non-absolute method references are unambiguous, i.e. refer to exactly one method. If there is ambiguity, it is required to write `T1::func as otherFunc` or similar.

I think the backwards-compatibility impact here is very low. I did not find any affected code in top 2k packages.