### PR TITLE
Fix #75673: SplStack::unserialize() behavior

### DIFF
--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -1185,6 +1185,12 @@ SPL_METHOD(SplDoublyLinkedList, unserialize)
 		return;
 	}
 
+	while (intern->llist->count > 0) {
+		zval tmp;
+		spl_ptr_llist_pop(intern->llist, &tmp);
+		zval_ptr_dtor(&tmp);
+	}
+
 	s = p = (const unsigned char*)buf;
 	PHP_VAR_UNSERIALIZE_INIT(var_hash);
 

--- a/ext/spl/tests/bug75673.phpt
+++ b/ext/spl/tests/bug75673.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #75673 (SplStack::unserialize() behavior)
+--FILE--
+<?php
+$stack = new SplStack();
+$stack->push("one");
+$stack->push("two");
+
+$serialized = $stack->serialize();
+var_dump($stack->count());
+$stack->unserialize($serialized);
+var_dump($stack->count());
+$stack->unserialize($serialized);
+var_dump($stack->count());
+?>
+--EXPECT--
+int(2)
+int(2)
+int(2)


### PR DESCRIPTION
Even though `SplStack::unserialize()` is not supposed to be called on
an already constructed instance, it is probably better if the method
clears the stack before actually unserializing.

---

It's certainly debatable whether the current behavior is a bug at all, but still might be worth to fix/improve; maybe for master only, though.