### PR TITLE
better fix for #72374

### DIFF
--- a/ext/zip/tests/bug72374.phpt
+++ b/ext/zip/tests/bug72374.phpt
@@ -9,16 +9,19 @@ if(!extension_loaded('zip')) die('skip');
 $dirname = dirname(__FILE__) . '/';
 include $dirname . 'utils.inc';
 
-$dirname = $dirname . 'bug72374/';
+$dirname = $dirname . 'bug72374';
 mkdir($dirname);
-$file = $dirname . 'some-foo.txt';
-touch($file);
+$file1 = $dirname . '/some-foo.txt';
+touch($file1);
+$file2 = $dirname . '/some-bar.txt';
+touch($file2);
 
 $zip = new ZipArchive();
-$zip->open($dirname . 'test.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
-$zip->addGlob($file, 0, array('remove_path' => $dirname . 'some-'));
-$zip->addGlob($file, 0, array('remove_path' => $dirname));
-verify_entries($zip, ['foo.txt', '/some-foo.txt']);
+$zip->open($dirname . '/test.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addGlob($file1, 0, array('remove_path' => $dirname . '/some-'));
+$zip->addGlob($file1, 0, array('remove_path' => $dirname . '/'));
+$zip->addGlob($file2, 0, array('remove_path' => $dirname));
+verify_entries($zip, ['foo.txt', 'some-foo.txt', 'some-bar.txt']);
 $zip->close();
 ?>
 --CLEAN--
@@ -26,7 +29,7 @@ $zip->close();
 $dirname = dirname(__FILE__) . '/';
 include $dirname . 'utils.inc';
 
-$dirname = $dirname . 'bug72374/';
+$dirname = $dirname . 'bug72374';
 rmdir_rf($dirname);
 ?>
 --EXPECT--

--- a/ext/zip/tests/oo_addpattern.phpt
+++ b/ext/zip/tests/oo_addpattern.phpt
@@ -25,7 +25,7 @@ if (!$zip->open($file)) {
         exit('failed');
 }
 $dir = realpath($dirname);
-$options = array('add_path' => 'baz', 'remove_path' => $dir);
+$options = array('add_path' => 'baz/', 'remove_path' => $dir);
 if (!$zip->addPattern('/\.txt$/', $dir, $options)) {
 	echo "failed 1\n";
 }

--- a/ext/zip/tests/oo_addpattern.phpt
+++ b/ext/zip/tests/oo_addpattern.phpt
@@ -44,8 +44,8 @@ if ($zip->status == ZIPARCHIVE::ER_OK) {
             "foobar/",
             "foobar/baz",
             "entry1.txt",
-            "baz" . DIRECTORY_SEPARATOR . "foo.txt",
-            "baz" . DIRECTORY_SEPARATOR . "bar.txt"
+            "baz/foo.txt",
+            "baz/bar.txt"
         ])) {
             echo "failed\n";
         } else {


### PR DESCRIPTION
Trying to avoid BC break introduce in fix for #72734

Test:
```
<?php
$file = '/tmp/foo.zip';

$zip = new ZipArchive();

$zip->open($file, ZipArchive::CREATE | ZipArchive::OVERWRITE);

$zip->addGlob('ext/zip/php_zip.c', 0, ['remove_path' => 'ext/zip']);
$zip->addGlob('ext/zip/zip*.c', 0, ['remove_path' => 'ext/zip/']);
$zip->addGlob('ext/zip/tests/bug723*.phpt', 0, ['remove_path' => 'ext/zip/tests/bug']);

$zip->close();

$zip->open($file);
for($i=0; $i<$zip->numFiles; $i++) {
    $sb = $zip->statIndex($i);
    echo $i . ' ' . $sb['name'] . "\n";
}
$zip->close();

```
**Old behavior** (before fix)
```
0 php_zip.c
1 ip_stream.c
2 2374.phpt

```
So 1 and 2 are broken

**Current behavior**
```
0 /php_zip.c
1 /zip_stream.c
2 72374.phpt
```
2 is fixed, but 0 have a big BC break

**Proposal**
```
0 php_zip.c
1 zip_stream.c
2 72374.phpt
```
0 is unchanged, this was the old official way to do
2 is fixed

ping @cmb69 (commitor) and @tyage (author)


This commit also revert change to `oo_addpattern.phpt` related to the BC break.


Minor BC break perhaps still exists if some file `/foo/bar42 `match a removed directory `/foo/bar` but don't know if this is even possible to raise.

