### PR TITLE
Make exit() unwind properly

### DIFF
--- a/Zend/tests/exit_exception_handler.phpt
+++ b/Zend/tests/exit_exception_handler.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Exception handler should not be invoked for exit()
+--FILE--
+<?php
+
+set_exception_handler(function($e) {
+    var_dump($e);
+});
+
+exit("Exit\n");
+
+?>
+--EXPECT--
+Exit

--- a/Zend/tests/exit_finally_1.phpt
+++ b/Zend/tests/exit_finally_1.phpt
@@ -1,0 +1,18 @@
+--TEST--
+exit() and finally (1)
+--FILE--
+<?php
+
+try {
+    exit("Exit\n");
+} catch (Throwable $e) {
+    echo "Not caught\n";
+} finally {
+    echo "Finally\n";
+}
+echo "Not executed\n";
+
+?>
+--EXPECT--
+Finally
+Exit

--- a/Zend/tests/exit_finally_2.phpt
+++ b/Zend/tests/exit_finally_2.phpt
@@ -1,0 +1,21 @@
+--TEST--
+exit() and finally (2)
+--FILE--
+<?php
+
+try {
+    try {
+        exit("Exit\n");
+    } catch (Throwable $e) {
+        echo "Not caught\n";
+    } finally {
+        throw new Exception("Finally exception");
+    }
+    echo "Not executed\n";
+} catch (Exception $e) {
+    echo "Caught {$e->getMessage()}\n";
+}
+
+?>
+--EXPECT--
+Caught Finally exception

--- a/Zend/tests/exit_finally_3.phpt
+++ b/Zend/tests/exit_finally_3.phpt
@@ -1,0 +1,17 @@
+--TEST--
+exit() and finally (3)
+--FILE--
+<?php
+
+function test() {
+    try {
+        exit("Exit\n");
+    } finally {
+        return 42;
+    }
+}
+var_dump(test());
+
+?>
+--EXPECT--
+int(42)

--- a/Zend/tests/generators/bug75396.phpt
+++ b/Zend/tests/generators/bug75396.phpt
@@ -19,4 +19,5 @@ $gen->send("x");
 ?>
 --EXPECT--
 Try
+Finally
 Exit

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1621,6 +1621,11 @@ ZEND_API ZEND_COLD void zend_user_exception_handler(void) /* {{{ */
 	zval orig_user_exception_handler;
 	zval params[1], retval2;
 	zend_object *old_exception;
+
+	if (zend_is_unwind_exit(EG(exception))) {
+		return;
+	}
+
 	old_exception = EG(exception);
 	EG(exception) = NULL;
 	ZVAL_OBJ(&params[0], old_exception);
@@ -1666,8 +1671,7 @@ ZEND_API int zend_execute_scripts(int type, zval *retval, int file_count, ...) /
 					zend_user_exception_handler();
 				}
 				if (EG(exception)) {
-					zend_exception_error(EG(exception), E_ERROR);
-					ret = FAILURE;
+					ret = zend_exception_error(EG(exception), E_ERROR);
 				}
 			}
 			destroy_op_array(op_array);

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -66,7 +66,10 @@ ZEND_API zend_object *zend_throw_error_exception(zend_class_entry *exception_ce,
 extern ZEND_API void (*zend_throw_exception_hook)(zval *ex);
 
 /* show an exception using zend_error(severity,...), severity should be E_ERROR */
-ZEND_API ZEND_COLD void zend_exception_error(zend_object *exception, int severity);
+ZEND_API ZEND_COLD int zend_exception_error(zend_object *exception, int severity);
+
+ZEND_API ZEND_COLD void zend_throw_unwind_exit(zend_string *message, int exit_status);
+ZEND_API zend_bool zend_is_unwind_exit(zend_object *ex);
 
 #include "zend_globals.h"
 

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1141,8 +1141,7 @@ ZEND_API int zend_eval_stringl_ex(const char *str, size_t str_len, zval *retval_
 
 	result = zend_eval_stringl(str, str_len, retval_ptr, string_name);
 	if (handle_exceptions && EG(exception)) {
-		zend_exception_error(EG(exception), E_ERROR);
-		result = FAILURE;
+		result = zend_exception_error(EG(exception), E_ERROR);
 	}
 	return result;
 }

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -6874,27 +6874,31 @@ ZEND_VM_COLD_HANDLER(79, ZEND_EXIT, ANY, ANY)
 	USE_OPLINE
 
 	SAVE_OPLINE();
+
+	zend_string *message = NULL;
+	int exit_status = 0;
 	if (OP1_TYPE != IS_UNUSED) {
 		zval *ptr = GET_OP1_ZVAL_PTR(BP_VAR_R);
 
 		do {
 			if (Z_TYPE_P(ptr) == IS_LONG) {
-				EG(exit_status) = Z_LVAL_P(ptr);
+				exit_status = Z_LVAL_P(ptr);
 			} else {
 				if ((OP1_TYPE & (IS_VAR|IS_CV)) && Z_ISREF_P(ptr)) {
 					ptr = Z_REFVAL_P(ptr);
 					if (Z_TYPE_P(ptr) == IS_LONG) {
-						EG(exit_status) = Z_LVAL_P(ptr);
+						exit_status = Z_LVAL_P(ptr);
 						break;
 					}
 				}
-				zend_print_zval(ptr, 0);
+				message = zval_get_string(ptr);
 			}
 		} while (0);
 		FREE_OP1();
 	}
-	zend_bailout();
-	ZEND_VM_NEXT_OPCODE(); /* Never reached */
+
+	zend_throw_unwind_exit(message, exit_status);
+	HANDLE_EXCEPTION();
 }
 
 ZEND_VM_HANDLER(57, ZEND_BEGIN_SILENCE, ANY, ANY)

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4484,9 +4484,10 @@ static int accel_preload(const char *config)
 					zend_user_exception_handler();
 				}
 				if (EG(exception)) {
-					zend_exception_error(EG(exception), E_ERROR);
-					CG(unclean_shutdown) = 1;
-					ret = FAILURE;
+					ret = zend_exception_error(EG(exception), E_ERROR);
+					if (ret == FAILURE) {
+						CG(unclean_shutdown) = 1;
+					}
 				}
 			}
 			destroy_op_array(op_array);

--- a/ext/session/tests/bug60634.phpt
+++ b/ext/session/tests/bug60634.phpt
@@ -40,20 +40,6 @@ session_start();
 session_write_close();
 echo "um, hi\n";
 
-/*
- * write() calls die(). This results in calling session_flush() which calls
- * write() in request shutdown. The code is inside save handler still and
- * calls save close handler.
- *
- * Because session_write_close() fails by die(), write() is called twice.
- * close() is still called at request shutdown since session is active.
- */
-
 ?>
 --EXPECT--
 write: goodbye cruel world
-
-Warning: Unknown: Cannot call session save handler in a recursive manner in Unknown on line 0
-
-Warning: Unknown: Failed to write session data using user defined save handler. (session.save_path: ) in Unknown on line 0
-close: goodbye cruel world

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -1711,6 +1711,11 @@ void phpdbg_execute_ex(zend_execute_data *execute_data) /* {{{ */
 		}
 #endif
 
+		if (exception && zend_is_unwind_exit(exception)) {
+			/* Restore bailout based exit. */
+			zend_bailout();
+		}
+
 		if (PHPDBG_G(flags) & PHPDBG_PREVENT_INTERACTIVE) {
 			phpdbg_print_opline_ex(execute_data, 0);
 			goto next;


### PR DESCRIPTION
Exit() is not internally modeled as an exception, but not exposed to userland. This means that the stack will be properly unwound and there will be no memory leaks.

Additionally, this enables running of finally blocks on exit:

```php
try {
    exit("Exit\n");
} finally {
    echo "Finally\n";
}

// Prints:
Finally
Exit
```

Note that the exit message is not printed immediately, but only once the exit reaches the top-most frame. I believe it has to work this way if we ever want to make exits catchable in some form (e.g. via a special `catch_exit` function).