### PR TITLE
Fix #61597: SXE properties may lack attributes and content

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -964,7 +964,7 @@ static void _get_base_node_value(php_sxe_object *sxe_ref, xmlNodePtr node, zval 
 	php_sxe_object *subnode;
 	xmlChar        *contents;
 
-	if (node->children && node->children->type == XML_TEXT_NODE && !xmlIsBlankNode(node->children)) {
+	if ((!node->properties || node->type == XML_ENTITY_DECL) && node->children && node->children->type == XML_TEXT_NODE && !xmlIsBlankNode(node->children)) {
 		contents = xmlNodeListGetString(node->doc, node->children, 1);
 		if (contents) {
 			ZVAL_STRING(value, (char *)contents);

--- a/ext/simplexml/tests/000.phpt
+++ b/ext/simplexml/tests/000.phpt
@@ -51,7 +51,37 @@ object(SimpleXMLElement)#%d (3) {
   ["elem1"]=>
   array(2) {
     [0]=>
-    string(36) "There is some text.Here is some more"
+    object(SimpleXMLElement)#%d (3) {
+      ["@attributes"]=>
+      array(2) {
+        ["attr1"]=>
+        string(5) "first"
+        ["attr2"]=>
+        string(6) "second"
+      }
+      ["comment"]=>
+      object(SimpleXMLElement)#%d (0) {
+      }
+      ["elem2"]=>
+      object(SimpleXMLElement)#%d (2) {
+        ["@attributes"]=>
+        array(2) {
+          ["att25"]=>
+          string(2) "25"
+          ["att42"]=>
+          string(2) "42"
+        }
+        ["elem3"]=>
+        object(SimpleXMLElement)#%d (1) {
+          ["elem4"]=>
+          object(SimpleXMLElement)#%d (1) {
+            ["test"]=>
+            object(SimpleXMLElement)#%d (0) {
+            }
+          }
+        }
+      }
+    }
     [1]=>
     object(SimpleXMLElement)#%d (1) {
       ["@attributes"]=>

--- a/ext/simplexml/tests/009b.phpt
+++ b/ext/simplexml/tests/009b.phpt
@@ -28,8 +28,29 @@ object(SimpleXMLElement)#%d (3) {
     string(5) "elem1"
   }
   ["elem1"]=>
-  string(10) "Bla bla 1."
+  object(SimpleXMLElement)#%d (3) {
+    ["@attributes"]=>
+    array(1) {
+      ["attr1"]=>
+      string(5) "first"
+    }
+    ["comment"]=>
+    object(SimpleXMLElement)#%d (0) {
+    }
+    ["elem2"]=>
+    string(35) "
+   Here we have some text data.
+  "
+  }
   ["elem11"]=>
-  string(10) "Bla bla 2."
+  object(SimpleXMLElement)#%d (2) {
+    ["@attributes"]=>
+    array(1) {
+      ["attr2"]=>
+      string(6) "second"
+    }
+    [0]=>
+    string(10) "Bla bla 2."
+  }
 }
 ===DONE===

--- a/ext/simplexml/tests/bug51615.phpt
+++ b/ext/simplexml/tests/bug51615.phpt
@@ -22,7 +22,7 @@ foreach ($html->body->span as $obj) {
 Warning: DOMDocument::loadHTML(): error parsing attribute name in Entity, line: 1 in %s on line %d
 
 Warning: DOMDocument::loadHTML(): error parsing attribute name in Entity, line: 1 in %s on line %d
-object(SimpleXMLElement)#%d (3) {
+object(SimpleXMLElement)#5 (3) {
   ["@attributes"]=>
   array(2) {
     ["title"]=>
@@ -31,9 +31,29 @@ object(SimpleXMLElement)#%d (3) {
     string(0) ""
   }
   [0]=>
-  string(1) "x"
+  object(SimpleXMLElement)#4 (2) {
+    ["@attributes"]=>
+    array(2) {
+      ["title"]=>
+      string(0) ""
+      ["y"]=>
+      string(0) ""
+    }
+    [0]=>
+    string(1) "x"
+  }
   [1]=>
-  string(1) "x"
+  object(SimpleXMLElement)#6 (2) {
+    ["@attributes"]=>
+    array(2) {
+      ["title"]=>
+      string(0) ""
+      ["z"]=>
+      string(0) ""
+    }
+    [0]=>
+    string(1) "x"
+  }
 }
 string(0) ""
 string(0) ""

--- a/ext/simplexml/tests/bug61597.phpt
+++ b/ext/simplexml/tests/bug61597.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bug #61597 (SXE properties may lack attributes and content)
+--SKIPIF--
+<?php
+if (!extension_loaded('simplexml')) die('skip simplexml extension not available');
+?>
+--FILE--
+<?php
+$xml = <<<'EOX'
+<?xml version="1.0"?>
+<data>
+<datum file-key="8708124062829849862">corn</datum>
+</data>
+EOX;
+
+var_dump(simplexml_load_string($xml));
+?>
+--EXPECTF--
+object(SimpleXMLElement)#%d (1) {
+  ["datum"]=>
+  object(SimpleXMLElement)#%d (2) {
+    ["@attributes"]=>
+    array(1) {
+      ["file-key"]=>
+      string(19) "8708124062829849862"
+    }
+    [0]=>
+    string(4) "corn"
+  }
+}


### PR DESCRIPTION
We must not treat a node as string if it has attributes, unless it is
an entity declaration which is always treated as string by simplexml.