### PR TITLE
Fix #78210: Invalid pointer address

### DIFF
--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -366,7 +366,7 @@ PHP_FUNCTION(stream_socket_sendto)
 		}
 	}
 
-	RETURN_LONG(php_stream_xport_sendto(stream, data, datalen, (int)flags, target_addr ? &sa : NULL, sl));
+	RETURN_LONG(php_stream_xport_sendto(stream, data, datalen, (int)flags, target_addr_len ? &sa : NULL, sl));
 }
 /* }}} */
 

--- a/main/network.c
+++ b/main/network.c
@@ -515,7 +515,7 @@ PHPAPI int php_network_parse_network_address_with_port(const char *addr, zend_lo
 
 	memset(in6, 0, sizeof(struct sockaddr_in6));
 #else
-	memset(sa, 0, sizeof(struct sockaddr));
+	memset(in4, 0, sizeof(struct sockaddr_in));
 #endif
 
 	if (*addr == '[') {

--- a/main/network.c
+++ b/main/network.c
@@ -512,9 +512,11 @@ PHPAPI int php_network_parse_network_address_with_port(const char *addr, zend_lo
 	zend_string *errstr = NULL;
 #if HAVE_IPV6
 	struct sockaddr_in6 *in6 = (struct sockaddr_in6*)sa;
-#endif
 
+	memset(in6, 0, sizeof(struct sockaddr_in6));
+#else
 	memset(sa, 0, sizeof(struct sockaddr));
+#endif
 
 	if (*addr == '[') {
 		colon = memchr(addr + 1, ']', addrlen-1);

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -401,7 +401,6 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
 							xparam->inputs.addr,
 							xparam->inputs.addrlen);
 					if (xparam->outputs.returncode == -1) {
-						fprintf(stderr, "sockerr %d\n", WSAGetLastError());
 						char *err = php_socket_strerror(php_socket_errno(), NULL, 0);
 						php_error_docref(NULL, E_WARNING,
 						   	"%s\n", err);


### PR DESCRIPTION
This is actually about three distinct issues:

* If an empty string is passed as $address to `stream_socket_sendto()`,
  the `sa` is not initialized, so we must not pass it as `addr` to
  `php_stream_xport_sendto()`.

* On POSIX, `recvfrom()` truncates messages which are too long to fit
  into the specified buffer (unless `MSG_PEEK` is given), discards the
  excessive bytes, and returns the buffer length.  On Windows, the same
  happens, but `recvfrom()` returns `SOCKET_ERROR` with the error code
  `WSAEMSGSIZE`.  We have to catch this for best POSIX compatibility.

* In `php_network_parse_network_address_with_port()`, we have to zero
  `in6` (not only its alias `sa`) to properly support IPv6.