### PR TITLE
Check for sys/auxv.h before using it.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -397,6 +397,7 @@ resolv.h \
 strings.h \
 syslog.h \
 sysexits.h \
+sys/auxv.h \
 sys/ioctl.h \
 sys/file.h \
 sys/mman.h \

--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -18,7 +18,7 @@
 #include "basic_functions.h"
 #include "crc32.h"
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) && defined(HAVE_SYS_AUXV_H)
 # include <arm_acle.h>
 # if defined(__linux__)
 #  include <sys/auxv.h>
@@ -83,7 +83,7 @@ PHP_FUNCTION(crc32)
 
 	crc = crcinit^0xFFFFFFFF;
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) && defined(HAVE_SYS_AUXV_H)
 	if (has_crc32_insn()) {
 		crc = crc32_aarch64(crc, p, nr);
 		RETURN_LONG(crc^0xFFFFFFFF);


### PR DESCRIPTION
Fixes aarch64 compile with uclibc-ng (does not provide
sys/auxv.h header file).

Signed-off-by: Peter Seiderer <ps.report@gmx.net>