### PR TITLE
Enclose INI values containing {TMP} in quotes

### DIFF
--- a/ext/mysqli/tests/mysqli_store_result_buffered_c.phpt
+++ b/ext/mysqli/tests/mysqli_store_result_buffered_c.phpt
@@ -7,7 +7,7 @@ require_once('skipifemb.inc');
 require_once('skipifconnectfailure.inc');
 ?>
 --INI--
-mysqlnd.debug=d:t:O,{TMP}/mysqlnd.trace
+mysqlnd.debug="d:t:O,{TMP}/mysqlnd.trace"
 --FILE--
 <?php
 	require_once("connect.inc");

--- a/ext/mysqli/tests/mysqli_store_result_copy.phpt
+++ b/ext/mysqli/tests/mysqli_store_result_copy.phpt
@@ -10,7 +10,7 @@ if (!$IS_MYSQLND) {
 }
 ?>
 --INI--
-mysqlnd.debug=d:t:O,{TMP}/mysqlnd.trace
+mysqlnd.debug="d:t:O,{TMP}/mysqlnd.trace"
 mysqlnd.net_read_buffer_size=1
 mysqlnd.mempool_default_size=1
 mysqlnd.fetch_data_copy=0

--- a/ext/opcache/tests/bug71443.phpt
+++ b/ext/opcache/tests/bug71443.phpt
@@ -3,7 +3,7 @@ Bug #71443 (Segfault using built-in webserver with intl using symfony)
 --INI--
 opcache.enable=1
 opcache.enable_cli=1
-opcache.file_cache={TMP}
+opcache.file_cache="{TMP}"
 opcache.file_cache_only=1
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>

--- a/ext/opcache/tests/bug76275.phpt
+++ b/ext/opcache/tests/bug76275.phpt
@@ -3,7 +3,7 @@ Bug #76275: Assertion failure in file cache when unserializing empty try_catch_a
 --INI--
 opcache.enabled=1
 opcache.enable_cli=1
-opcache.file_cache={TMP}
+opcache.file_cache="{TMP}"
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
 --FILE--

--- a/ext/opcache/tests/bug78189.phpt
+++ b/ext/opcache/tests/bug78189.phpt
@@ -8,7 +8,7 @@ if (substr(PHP_OS, 0, 3) !== 'WIN') die('skip this test is for Windows platforms
 --INI--
 opcache.enable_cli=1
 opcache.optimization_level=-1
-opcache.file_cache={TMP}
+opcache.file_cache="{TMP}"
 opcache.file_cache_only=1
 --FILE--
 <?php

--- a/ext/readline/tests/bug69054.phpt
+++ b/ext/readline/tests/bug69054.phpt
@@ -3,7 +3,7 @@ Bug #69054 (Null dereference in readline_(read|write)_history() without paramete
 --SKIPIF--
 <?php if (!extension_loaded("readline") || !function_exists('readline_add_history')) die("skip"); ?>
 --INI--
-open_basedir={TMP}
+open_basedir="{TMP}"
 --FILE--
 <?php readline_read_history(); ?>
 ==DONE==

--- a/ext/session/tests/bug32330.phpt
+++ b/ext/session/tests/bug32330.phpt
@@ -6,7 +6,7 @@ Bug #32330 (session_destroy, "Failed to initialize storage module", custom sessi
 session.use_trans_sid=0
 session.use_cookies=1
 session.name=sid
-session.save_path={TMP}
+session.save_path="{TMP}"
 session.gc_probability=1
 session.gc_divisor=1
 session.save_handler=files

--- a/ext/session/tests/session_set_save_handler_sid_002.phpt
+++ b/ext/session/tests/session_set_save_handler_sid_002.phpt
@@ -3,7 +3,7 @@ Test session_set_save_handler() function: create_sid
 --INI--
 session.save_handler=files
 session.name=PHPSESSID
-session.save_path={TMP}
+session.save_path="{TMP}"
 --SKIPIF--
 <?php include('skipif.inc'); ?>
 --FILE--

--- a/ext/sqlite3/tests/sqlite3_33_load_extension_param.phpt
+++ b/ext/sqlite3/tests/sqlite3_33_load_extension_param.phpt
@@ -4,7 +4,7 @@ SQLite3::loadExtension with empty extension test
 Jelle Lampaert
 #Belgian Testfest 2009
 --INI--
-sqlite3.extension_dir={TMP}
+sqlite3.extension_dir="{TMP}"
 --SKIPIF--
 <?php require_once(__DIR__ . '/skipif.inc'); ?>
 --FILE--

--- a/ext/standard/tests/file/bug41655_1-win32.phpt
+++ b/ext/standard/tests/file/bug41655_1-win32.phpt
@@ -9,7 +9,7 @@ if (substr(PHP_OS, 0, 3) != 'WIN') {
 --CREDITS--
 Dave Kelsey <d_kelsey@uk.ibm.com>
 --INI--
-open_basedir={TMP}
+open_basedir="{TMP}"
 --FILE--
 <?php
 $a=glob("./*.jpeg");

--- a/ext/standard/tests/file/bug41655_1.phpt
+++ b/ext/standard/tests/file/bug41655_1.phpt
@@ -9,7 +9,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 --CREDITS--
 Dave Kelsey <d_kelsey@uk.ibm.com>
 --INI--
-open_basedir={TMP}
+open_basedir="{TMP}"
 --FILE--
 <?php
 $a=glob("./*.jpeg");


### PR DESCRIPTION
At least on Windows, the temporary directory may contain tilde signs,
which would result in an INI parse error.