### PR TITLE
Remove weird object creation in SimpleXML

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -346,8 +346,7 @@ long_dim:
 					_node_as_zval(sxe, node, rv, SXE_ITER_NONE, NULL, sxe->iter.nsprefix, sxe->iter.isprefix);
 				}
 			} else {
-				/* In BP_VAR_IS mode only return a proper node if it actually exists. */
-				if (type != BP_VAR_IS || sxe_find_element_by_name(sxe, node->children, (xmlChar *) name)) {
+				if (sxe_find_element_by_name(sxe, node->children, (xmlChar *) name)) {
 					_node_as_zval(sxe, node, rv, SXE_ITER_ELEMENT, name, sxe->iter.nsprefix, sxe->iter.isprefix);
 				}
 			}

--- a/ext/simplexml/tests/000.phpt
+++ b/ext/simplexml/tests/000.phpt
@@ -166,8 +166,7 @@ object(SimpleXMLElement)#%d (2) {
 ===sxe->elem1[0]->elem2->bla
 bool(false)
 bool(false)
-object(SimpleXMLElement)#%d (0) {
-}
+NULL
 ===sxe->elem1[0]["attr1"]
 bool(true)
 bool(true)
@@ -179,8 +178,7 @@ object(SimpleXMLElement)#%d (1) {
 ===sxe->elem1[0]->attr1
 bool(false)
 bool(false)
-object(SimpleXMLElement)#%d (0) {
-}
+NULL
 ===sxe->elem1[1]
 bool(true)
 bool(true)
@@ -228,17 +226,28 @@ object(SimpleXMLElement)#%d (0) {
 ===sxe->elem22
 bool(false)
 bool(false)
-object(SimpleXMLElement)#%d (0) {
-}
+NULL
 ===sxe->elem22->elem222
 bool(false)
+
+Warning: Trying to get property 'elem222' of non-object in %s on line %d
 bool(false)
+
+Warning: Trying to get property 'elem222' of non-object in %s on line %d
 NULL
 ===sxe->elem22->attr22
 bool(false)
+
+Warning: Trying to get property 'attr22' of non-object in %s on line %d
 bool(false)
+
+Warning: Trying to get property 'attr22' of non-object in %s on line %d
 NULL
 ===sxe->elem22["attr22"]
 bool(false)
+
+Warning: Trying to access array offset on value of type null in %s on line %d
 bool(false)
+
+Warning: Trying to access array offset on value of type null in %s on line %d
 NULL

--- a/ext/simplexml/tests/bug38347.phpt
+++ b/ext/simplexml/tests/bug38347.phpt
@@ -20,9 +20,7 @@ iterate($xml->unknown);
 echo "Done\n";
 ?>
 --EXPECTF--
-SimpleXMLElement Object
-(
-)
+Warning: Trying to get property 'item' of non-object in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %sbug38347.php on line 6
 Done

--- a/ext/simplexml/tests/bug40451.phpt
+++ b/ext/simplexml/tests/bug40451.phpt
@@ -19,4 +19,7 @@ $add->Host->addAttribute('enable', 'true');
 
 ?>
 --EXPECTF--
-Warning: SimpleXMLElement::addAttribute(): Unable to locate parent Element in %s on line %d
+Fatal error: Uncaught Error: Call to a member function addAttribute() on null in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/simplexml/tests/profile11.phpt
+++ b/ext/simplexml/tests/profile11.phpt
@@ -29,5 +29,4 @@ object(SimpleXMLElement)#%d (1) {
 }
 string(5) "Hello"
 string(5) "World"
-object(SimpleXMLElement)#%d (0) {
-}
+NULL


### PR DESCRIPTION
Currently SXE optimizes for maximum WTF per minute:

```
$xml = new SimpleXMLElement('<root><elem>Text</elem></root>');
var_dump(isset($xml->doesNotExist)); // bool(false)
var_dump($xml->doesNotExist); // object(SimpleXMLElement)
var_dump($xml->doesNotExist->alsoDoesntExist); // null
```

There was a partial fix in https://bugs.php.net/bug.php?id=72957 to at least treat this correctly in BP_VAR_IS mode.

I think we should make use of the chance in PHP 8, and stop returning a dummy object if the node does not exist:

```
$xml = new SimpleXMLElement('<root><elem>Text</elem></root>');
var_dump(isset($xml->doesNotExist)); // bool(false)
var_dump($xml->doesNotExist); // null
var_dump($xml->doesNotExist->alsoDoesntExist); // null + warning
```

However, I'm not entirely clear on whether this is a small or a large BC break. Any thoughts?