### PR TITLE
Fix #79364: When copy empty array, next key is unspecified

### DIFF
--- a/Zend/tests/bug79364.phpt
+++ b/Zend/tests/bug79364.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #79364 (When copy empty array, next key is unspecified)
+--FILE--
+<?php
+$a = [1, 2];
+unset($a[1], $a[0]);
+$b = $a;
+
+$a[] = 3;
+$b[] = 4;
+
+var_dump($a, $b);
+?>
+--EXPECT--
+array(1) {
+  [2]=>
+  int(3)
+}
+array(1) {
+  [2]=>
+  int(4)
+}

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1934,7 +1934,7 @@ ZEND_API HashTable* ZEND_FASTCALL zend_array_dup(HashTable *source)
 		target->nTableMask = HT_MIN_MASK;
 		target->nNumUsed = 0;
 		target->nNumOfElements = 0;
-		target->nNextFreeElement = 0;
+		target->nNextFreeElement = source->nNextFreeElement;
 		target->nInternalPointer = 0;
 		HT_SET_DATA_ADDR(target, &uninitialized_bucket);
 	} else if (GC_FLAGS(source) & IS_ARRAY_IMMUTABLE) {


### PR DESCRIPTION
We must not forget to keep the `nNextFreeElement` when duplicating
empty arrays.