### PR TITLE
Fix #78221: DOMNode::normalize() doesn't remove empty text nodes

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1383,6 +1383,14 @@ void dom_normalize (xmlNodePtr nodep)
 						break;
 					}
 				}
+				strContent = xmlNodeGetContent(child);
+				if (*strContent == '\0') {
+					nextp = child->next;
+					xmlUnlinkNode(child);
+					php_libxml_node_free_resource(child);
+					child = nextp;
+					continue;
+				}
 				break;
 			case XML_ELEMENT_NODE:
 				dom_normalize (child);

--- a/ext/dom/tests/bug78221.phpt
+++ b/ext/dom/tests/bug78221.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #78221 (DOMNode::normalize() doesn't remove empty text nodes)
+--SKIPIF--
+<?php
+if (!extension_loaded('dom')) die('skip dom extension not available');
+?>
+--FILE--
+<?php
+$doc = new DOMDocument();
+$doc->loadHTML('<p id=x>foo</p>');
+$p = $doc->getElementById('x');
+$p->childNodes[0]->textContent = '';
+$p->normalize();
+var_dump($p->childNodes->length);
+?>
+--EXPECT--
+int(0)


### PR DESCRIPTION
If a text node is not followed by another text node, we remove it, if
its textContent is empty.