### PR TITLE
Fix #79199: curl_copy_handle() memory leak

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2167,8 +2167,6 @@ PHP_FUNCTION(curl_copy_handle)
 
 	_php_setup_easy_copy_handlers(dupch, ch);
 
-	Z_ADDREF_P(zid);
-
 	ZVAL_RES(return_value, zend_register_resource(dupch, le_curl));
 	dupch->res = Z_RES_P(return_value);
 }

--- a/ext/curl/tests/bug79199.phpt
+++ b/ext/curl/tests/bug79199.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #79199 (curl_copy_handle() memory leak)
+--SKIPIF--
+<?php
+if (!extension_loaded('curl')) die('skip curl extension not available');
+?>
+--FILE--
+<?php
+$mem_old = 0;
+for($i = 0; $i < 50; ++$i) {
+    $c1 = curl_init();
+    $c2 = curl_copy_handle($c1);
+    curl_close($c2);
+    curl_close($c1);
+    $mem_new = memory_get_usage();
+    if ($mem_new <= $mem_old) {
+        break;
+    }
+    $mem_old = $mem_new;
+}
+echo $i < 50 ? "okay" : "leak", PHP_EOL;
+?>
+--EXPECT--
+okay


### PR DESCRIPTION
We must not increase the refcount of the resource; we only have to make
sure that the actual CURL handle is not freed prematurely, but this is
already catered to in `_php_setup_easy_copy_handlers()`.