### PR TITLE
Tracing JIT

### DIFF
--- a/ext/opcache/Optimizer/zend_dfg.c
+++ b/ext/opcache/Optimizer/zend_dfg.c
@@ -62,7 +62,6 @@ add_op1_def:
 		case ZEND_ASSIGN_REF:
 			if (opline->op2_type == IS_CV) {
 				zend_bitset_incl(def, EX_VAR_TO_NUM(opline->op2.var));
-				//NEW_SSA_VAR(opline->op2.var)
 			}
 			if (opline->op1_type == IS_CV) {
 				goto add_op1_def;

--- a/ext/opcache/Optimizer/zend_dfg.c
+++ b/ext/opcache/Optimizer/zend_dfg.c
@@ -222,6 +222,7 @@ add_op1_def:
 		case ZEND_FE_FETCH_R:
 		case ZEND_FE_FETCH_RW:
 #if 0
+			/* This special case was handled above the switch */
 			if (opline->op2_type != IS_CV) {
 				op2_use = -1; /* not used */
 			}

--- a/ext/opcache/Optimizer/zend_dfg.h
+++ b/ext/opcache/Optimizer/zend_dfg.h
@@ -44,6 +44,7 @@ typedef struct _zend_dfg {
 BEGIN_EXTERN_C()
 
 int zend_build_dfg(const zend_op_array *op_array, const zend_cfg *cfg, zend_dfg *dfg, uint32_t build_flags);
+void zend_dfg_add_use_def_op(const zend_op_array *op_array, const zend_op *opline, uint32_t build_flags, zend_bitset use, zend_bitset def);
 
 END_EXTERN_C()
 

--- a/ext/opcache/Optimizer/zend_dump.c
+++ b/ext/opcache/Optimizer/zend_dump.c
@@ -721,7 +721,7 @@ void zend_dump_op(const zend_op_array *op_array, const zend_basic_block *b, cons
 static void zend_dump_op_line(const zend_op_array *op_array, const zend_basic_block *b, const zend_op *opline, uint32_t dump_flags, const void *data)
 {
 	int len = 0;
-	const zend_ssa *ssa =NULL;
+	const zend_ssa *ssa = NULL;
 	zend_ssa_op *ssa_op = NULL;
 
 	if (dump_flags & ZEND_DUMP_NUMERIC_OPLINES) {

--- a/ext/opcache/Optimizer/zend_dump.h
+++ b/ext/opcache/Optimizer/zend_dump.h
@@ -32,12 +32,13 @@
 BEGIN_EXTERN_C()
 
 void zend_dump_op_array(const zend_op_array *op_array, uint32_t dump_flags, const char *msg, const void *data);
-void zend_dump_op(const zend_op_array *op_array, const zend_basic_block *b, const zend_op *opline, uint32_t dump_flags, const void *data);
+void zend_dump_op(const zend_op_array *op_array, const zend_basic_block *b, const zend_op *opline, uint32_t dump_flags, const zend_ssa *ssa, const zend_ssa_op *ssa_op);
 void zend_dump_dominators(const zend_op_array *op_array, const zend_cfg *cfg);
 void zend_dump_dfg(const zend_op_array *op_array, const zend_cfg *cfg, const zend_dfg *dfg);
 void zend_dump_phi_placement(const zend_op_array *op_array, const zend_ssa *ssa);
 void zend_dump_variables(const zend_op_array *op_array);
 void zend_dump_ssa_variables(const zend_op_array *op_array, const zend_ssa *ssa, uint32_t dump_flags);
+void zend_dump_ssa_var(const zend_op_array *op_array, const zend_ssa *ssa, int ssa_var_num, zend_uchar var_type, int var_num, uint32_t dump_flags);
 void zend_dump_var(const zend_op_array *op_array, zend_uchar var_type, int var_num);
 void zend_dump_op_array_name(const zend_op_array *op_array);
 void zend_dump_const(const zval *zv);

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -1828,7 +1828,7 @@ static uint32_t get_ssa_alias_types(zend_ssa_alias_kind alias) {
 
 #define UPDATE_SSA_TYPE(_type, _var)									\
 	do {																\
-		uint32_t __type = (_type);										\
+		uint32_t __type = (_type) & ~MAY_BE_GUARD;						\
 		int __var = (_var);												\
 		if (__type & MAY_BE_REF) {										\
 			__type |= MAY_BE_RC1 | MAY_BE_RCN | MAY_BE_ANY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_ANY | MAY_BE_ARRAY_OF_REF; \

--- a/ext/opcache/Optimizer/zend_ssa.c
+++ b/ext/opcache/Optimizer/zend_ssa.c
@@ -537,6 +537,237 @@ static void place_essa_pis(
 }
 /* }}} */
 
+static zend_always_inline int _zend_ssa_rename_op(const zend_op_array *op_array, const zend_op *opline, uint32_t k, uint32_t build_flags, int ssa_vars_count, zend_ssa_op *ssa_ops, int *var) /* {{{ */
+{
+	const zend_op *next;
+
+	if (opline->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+		ssa_ops[k].op1_use = var[EX_VAR_TO_NUM(opline->op1.var)];
+		//USE_SSA_VAR(op_array->last_var + opline->op1.var)
+	}
+	if (opline->op2_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+		ssa_ops[k].op2_use = var[EX_VAR_TO_NUM(opline->op2.var)];
+		//USE_SSA_VAR(op_array->last_var + opline->op2.var)
+	}
+	if ((build_flags & ZEND_SSA_USE_CV_RESULTS)
+	 && opline->result_type == IS_CV
+	 && opline->opcode != ZEND_RECV) {
+		ssa_ops[k].result_use = var[EX_VAR_TO_NUM(opline->result.var)];
+		//USE_SSA_VAR(op_array->last_var + opline->result.var)
+	}
+
+	switch (opline->opcode) {
+		case ZEND_ASSIGN:
+			if ((build_flags & ZEND_SSA_RC_INFERENCE) && opline->op2_type == IS_CV) {
+				ssa_ops[k].op2_def = ssa_vars_count;
+				var[EX_VAR_TO_NUM(opline->op2.var)] = ssa_vars_count;
+				ssa_vars_count++;
+				//NEW_SSA_VAR(opline->op2.var)
+			}
+			if (opline->op1_type == IS_CV) {
+add_op1_def:
+				ssa_ops[k].op1_def = ssa_vars_count;
+				var[EX_VAR_TO_NUM(opline->op1.var)] = ssa_vars_count;
+				ssa_vars_count++;
+				//NEW_SSA_VAR(opline->op1.var)
+			}
+			break;
+		case ZEND_ASSIGN_REF:
+			if (opline->op2_type == IS_CV) {
+				ssa_ops[k].op2_def = ssa_vars_count;
+				var[EX_VAR_TO_NUM(opline->op2.var)] = ssa_vars_count;
+				ssa_vars_count++;
+				//NEW_SSA_VAR(opline->op2.var)
+			}
+			if (opline->op1_type == IS_CV) {
+				goto add_op1_def;
+			}
+			break;
+		case ZEND_ASSIGN_DIM:
+		case ZEND_ASSIGN_OBJ:
+			next = opline + 1;
+			if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+				ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
+				//USE_SSA_VAR(op_array->last_var + next->op1.var);
+				if (build_flags & ZEND_SSA_RC_INFERENCE && next->op1_type == IS_CV) {
+					ssa_ops[k + 1].op1_def = ssa_vars_count;
+					var[EX_VAR_TO_NUM(next->op1.var)] = ssa_vars_count;
+					ssa_vars_count++;
+					//NEW_SSA_VAR(next->op1.var)
+				}
+			}
+			if (opline->op1_type == IS_CV) {
+				goto add_op1_def;
+			}
+			break;
+		case ZEND_ASSIGN_OBJ_REF:
+			next = opline + 1;
+			if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+				ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
+				//USE_SSA_VAR(op_array->last_var + next->op1.var);
+				if (next->op1_type == IS_CV) {
+					ssa_ops[k + 1].op1_def = ssa_vars_count;
+					var[EX_VAR_TO_NUM(next->op1.var)] = ssa_vars_count;
+					ssa_vars_count++;
+					//NEW_SSA_VAR(next->op1.var)
+				}
+			}
+			if (opline->op1_type == IS_CV) {
+				goto add_op1_def;
+			}
+			break;
+		case ZEND_ASSIGN_STATIC_PROP:
+			next = opline + 1;
+			if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+				ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
+				//USE_SSA_VAR(op_array->last_var + next->op1.var);
+#if 0
+				if ((build_flags & ZEND_SSA_RC_INFERENCE) && next->op1_type == IS_CV) {
+					ssa_ops[k + 1].op1_def = ssa_vars_count;
+					var[EX_VAR_TO_NUM(next->op1.var)] = ssa_vars_count;
+					ssa_vars_count++;
+					//NEW_SSA_VAR(next->op1.var)
+				}
+#endif
+			}
+			break;
+		case ZEND_ASSIGN_STATIC_PROP_REF:
+			next = opline + 1;
+			if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+				ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
+				//USE_SSA_VAR(op_array->last_var + next->op1.var);
+				if (next->op1_type == IS_CV) {
+					ssa_ops[k + 1].op1_def = ssa_vars_count;
+					var[EX_VAR_TO_NUM(next->op1.var)] = ssa_vars_count;
+					ssa_vars_count++;
+					//NEW_SSA_VAR(next->op1.var)
+				}
+			}
+			break;
+		case ZEND_ASSIGN_STATIC_PROP_OP:
+			next = opline + 1;
+			if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+				ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
+				//USE_SSA_VAR(op_array->last_var + next->op1.var);
+			}
+			break;
+		case ZEND_ASSIGN_DIM_OP:
+		case ZEND_ASSIGN_OBJ_OP:
+			next = opline + 1;
+			if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+				ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
+				//USE_SSA_VAR(op_array->last_var + next->op1.var);
+			}
+			if (opline->op1_type == IS_CV) {
+				goto add_op1_def;
+			}
+			break;
+		case ZEND_ASSIGN_OP:
+		case ZEND_PRE_INC:
+		case ZEND_PRE_DEC:
+		case ZEND_POST_INC:
+		case ZEND_POST_DEC:
+		case ZEND_BIND_GLOBAL:
+		case ZEND_BIND_STATIC:
+		case ZEND_SEND_VAR_NO_REF:
+		case ZEND_SEND_VAR_NO_REF_EX:
+		case ZEND_SEND_VAR_EX:
+		case ZEND_SEND_FUNC_ARG:
+		case ZEND_SEND_REF:
+		case ZEND_SEND_UNPACK:
+		case ZEND_FE_RESET_RW:
+		case ZEND_MAKE_REF:
+		case ZEND_PRE_INC_OBJ:
+		case ZEND_PRE_DEC_OBJ:
+		case ZEND_POST_INC_OBJ:
+		case ZEND_POST_DEC_OBJ:
+		case ZEND_UNSET_DIM:
+		case ZEND_UNSET_OBJ:
+		case ZEND_FETCH_DIM_W:
+		case ZEND_FETCH_DIM_RW:
+		case ZEND_FETCH_DIM_FUNC_ARG:
+		case ZEND_FETCH_DIM_UNSET:
+		case ZEND_FETCH_LIST_W:
+			if (opline->op1_type == IS_CV) {
+				goto add_op1_def;
+			}
+			break;
+		case ZEND_SEND_VAR:
+		case ZEND_CAST:
+		case ZEND_QM_ASSIGN:
+		case ZEND_JMP_SET:
+		case ZEND_COALESCE:
+		case ZEND_FE_RESET_R:
+			if ((build_flags & ZEND_SSA_RC_INFERENCE) && opline->op1_type == IS_CV) {
+				goto add_op1_def;
+			}
+			break;
+		case ZEND_ADD_ARRAY_UNPACK:
+			ssa_ops[k].result_use = var[EX_VAR_TO_NUM(opline->result.var)];
+			break;
+		case ZEND_ADD_ARRAY_ELEMENT:
+			ssa_ops[k].result_use = var[EX_VAR_TO_NUM(opline->result.var)];
+			/* break missing intentionally */
+		case ZEND_INIT_ARRAY:
+			if (((build_flags & ZEND_SSA_RC_INFERENCE)
+						|| (opline->extended_value & ZEND_ARRAY_ELEMENT_REF))
+					&& opline->op1_type == IS_CV) {
+				goto add_op1_def;
+			}
+			break;
+		case ZEND_YIELD:
+			if (opline->op1_type == IS_CV
+					&& ((op_array->fn_flags & ZEND_ACC_RETURN_REFERENCE)
+						|| (build_flags & ZEND_SSA_RC_INFERENCE))) {
+				goto add_op1_def;
+			}
+			break;
+		case ZEND_UNSET_CV:
+			goto add_op1_def;
+		case ZEND_VERIFY_RETURN_TYPE:
+			if (opline->op1_type & (IS_TMP_VAR|IS_VAR|IS_CV)) {
+				goto add_op1_def;
+			}
+			break;
+		case ZEND_FE_FETCH_R:
+		case ZEND_FE_FETCH_RW:
+			if (opline->op2_type != IS_CV) {
+				ssa_ops[k].op2_use = -1; /* not used */
+			}
+			ssa_ops[k].op2_def = ssa_vars_count;
+			var[EX_VAR_TO_NUM(opline->op2.var)] = ssa_vars_count;
+			ssa_vars_count++;
+			//NEW_SSA_VAR(opline->op2.var)
+			break;
+		case ZEND_BIND_LEXICAL:
+			if ((opline->extended_value & ZEND_BIND_REF) || (build_flags & ZEND_SSA_RC_INFERENCE)) {
+				ssa_ops[k].op2_def = ssa_vars_count;
+				var[EX_VAR_TO_NUM(opline->op2.var)] = ssa_vars_count;
+				ssa_vars_count++;
+				//NEW_SSA_VAR(opline->op2.var)
+			}
+			break;
+		default:
+			break;
+	}
+
+	if (opline->result_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+		ssa_ops[k].result_def = ssa_vars_count;
+		var[EX_VAR_TO_NUM(opline->result.var)] = ssa_vars_count;
+		ssa_vars_count++;
+		//NEW_SSA_VAR(op_array->last_var + opline->result.var)
+	}
+
+	return ssa_vars_count;
+}
+/* }}} */
+
+int zend_ssa_rename_op(const zend_op_array *op_array, const zend_op *opline, uint32_t k, uint32_t build_flags, int ssa_vars_count, zend_ssa_op *ssa_ops, int *var) /* {{{ */
+{
+	return _zend_ssa_rename_op(op_array, opline, k, build_flags, ssa_vars_count, ssa_ops, var);
+}
+/* }}} */
+
 static int zend_ssa_rename(const zend_op_array *op_array, uint32_t build_flags, zend_ssa *ssa, int *var, int n) /* {{{ */
 {
 	zend_basic_block *blocks = ssa->cfg.blocks;
@@ -544,7 +775,7 @@ static int zend_ssa_rename(const zend_op_array *op_array, uint32_t build_flags, 
 	zend_ssa_op *ssa_ops = ssa->ops;
 	int ssa_vars_count = ssa->vars_count;
 	int i, j;
-	zend_op *opline, *end, *next;
+	zend_op *opline, *end;
 	int *tmp = NULL;
 	ALLOCA_FLAG(use_heap = 0);
 
@@ -574,223 +805,7 @@ static int zend_ssa_rename(const zend_op_array *op_array, uint32_t build_flags, 
 	for (; opline < end; opline++) {
 		uint32_t k = opline - op_array->opcodes;
 		if (opline->opcode != ZEND_OP_DATA) {
-
-			if (opline->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
-				ssa_ops[k].op1_use = var[EX_VAR_TO_NUM(opline->op1.var)];
-				//USE_SSA_VAR(op_array->last_var + opline->op1.var)
-			}
-			if (opline->op2_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
-				ssa_ops[k].op2_use = var[EX_VAR_TO_NUM(opline->op2.var)];
-				//USE_SSA_VAR(op_array->last_var + opline->op2.var)
-			}
-			if ((build_flags & ZEND_SSA_USE_CV_RESULTS)
-			 && opline->result_type == IS_CV
-			 && opline->opcode != ZEND_RECV) {
-				ssa_ops[k].result_use = var[EX_VAR_TO_NUM(opline->result.var)];
-				//USE_SSA_VAR(op_array->last_var + opline->result.var)
-			}
-
-			switch (opline->opcode) {
-				case ZEND_ASSIGN:
-					if ((build_flags & ZEND_SSA_RC_INFERENCE) && opline->op2_type == IS_CV) {
-						ssa_ops[k].op2_def = ssa_vars_count;
-						var[EX_VAR_TO_NUM(opline->op2.var)] = ssa_vars_count;
-						ssa_vars_count++;
-						//NEW_SSA_VAR(opline->op2.var)
-					}
-					if (opline->op1_type == IS_CV) {
-add_op1_def:
-						ssa_ops[k].op1_def = ssa_vars_count;
-						var[EX_VAR_TO_NUM(opline->op1.var)] = ssa_vars_count;
-						ssa_vars_count++;
-						//NEW_SSA_VAR(opline->op1.var)
-					}
-					break;
-				case ZEND_ASSIGN_REF:
-					if (opline->op2_type == IS_CV) {
-						ssa_ops[k].op2_def = ssa_vars_count;
-						var[EX_VAR_TO_NUM(opline->op2.var)] = ssa_vars_count;
-						ssa_vars_count++;
-						//NEW_SSA_VAR(opline->op2.var)
-					}
-					if (opline->op1_type == IS_CV) {
-						goto add_op1_def;
-					}
-					break;
-				case ZEND_ASSIGN_DIM:
-				case ZEND_ASSIGN_OBJ:
-					next = opline + 1;
-					if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
-						ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
-						//USE_SSA_VAR(op_array->last_var + next->op1.var);
-						if (build_flags & ZEND_SSA_RC_INFERENCE && next->op1_type == IS_CV) {
-							ssa_ops[k + 1].op1_def = ssa_vars_count;
-							var[EX_VAR_TO_NUM(next->op1.var)] = ssa_vars_count;
-							ssa_vars_count++;
-							//NEW_SSA_VAR(next->op1.var)
-						}
-					}
-					if (opline->op1_type == IS_CV) {
-						goto add_op1_def;
-					}
-					break;
-				case ZEND_ASSIGN_OBJ_REF:
-					next = opline + 1;
-					if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
-						ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
-						//USE_SSA_VAR(op_array->last_var + next->op1.var);
-						if (next->op1_type == IS_CV) {
-							ssa_ops[k + 1].op1_def = ssa_vars_count;
-							var[EX_VAR_TO_NUM(next->op1.var)] = ssa_vars_count;
-							ssa_vars_count++;
-							//NEW_SSA_VAR(next->op1.var)
-						}
-					}
-					if (opline->op1_type == IS_CV) {
-						goto add_op1_def;
-					}
-					break;
-				case ZEND_ASSIGN_STATIC_PROP:
-					next = opline + 1;
-					if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
-						ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
-						//USE_SSA_VAR(op_array->last_var + next->op1.var);
-#if 0
-						if ((build_flags & ZEND_SSA_RC_INFERENCE) && next->op1_type == IS_CV) {
-							ssa_ops[k + 1].op1_def = ssa_vars_count;
-							var[EX_VAR_TO_NUM(next->op1.var)] = ssa_vars_count;
-							ssa_vars_count++;
-							//NEW_SSA_VAR(next->op1.var)
-						}
-#endif
-					}
-					break;
-				case ZEND_ASSIGN_STATIC_PROP_REF:
-					next = opline + 1;
-					if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
-						ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
-						//USE_SSA_VAR(op_array->last_var + next->op1.var);
-						if (next->op1_type == IS_CV) {
-							ssa_ops[k + 1].op1_def = ssa_vars_count;
-							var[EX_VAR_TO_NUM(next->op1.var)] = ssa_vars_count;
-							ssa_vars_count++;
-							//NEW_SSA_VAR(next->op1.var)
-						}
-					}
-					break;
-				case ZEND_ASSIGN_STATIC_PROP_OP:
-					next = opline + 1;
-					if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
-						ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
-						//USE_SSA_VAR(op_array->last_var + next->op1.var);
-					}
-					break;
-				case ZEND_ASSIGN_DIM_OP:
-				case ZEND_ASSIGN_OBJ_OP:
-					next = opline + 1;
-					if (next->op1_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
-						ssa_ops[k + 1].op1_use = var[EX_VAR_TO_NUM(next->op1.var)];
-						//USE_SSA_VAR(op_array->last_var + next->op1.var);
-					}
-					if (opline->op1_type == IS_CV) {
-						goto add_op1_def;
-					}
-					break;
-				case ZEND_ASSIGN_OP:
-				case ZEND_PRE_INC:
-				case ZEND_PRE_DEC:
-				case ZEND_POST_INC:
-				case ZEND_POST_DEC:
-				case ZEND_BIND_GLOBAL:
-				case ZEND_BIND_STATIC:
-				case ZEND_SEND_VAR_NO_REF:
-				case ZEND_SEND_VAR_NO_REF_EX:
-				case ZEND_SEND_VAR_EX:
-				case ZEND_SEND_FUNC_ARG:
-				case ZEND_SEND_REF:
-				case ZEND_SEND_UNPACK:
-				case ZEND_FE_RESET_RW:
-				case ZEND_MAKE_REF:
-				case ZEND_PRE_INC_OBJ:
-				case ZEND_PRE_DEC_OBJ:
-				case ZEND_POST_INC_OBJ:
-				case ZEND_POST_DEC_OBJ:
-				case ZEND_UNSET_DIM:
-				case ZEND_UNSET_OBJ:
-				case ZEND_FETCH_DIM_W:
-				case ZEND_FETCH_DIM_RW:
-				case ZEND_FETCH_DIM_FUNC_ARG:
-				case ZEND_FETCH_DIM_UNSET:
-				case ZEND_FETCH_LIST_W:
-					if (opline->op1_type == IS_CV) {
-						goto add_op1_def;
-					}
-					break;
-				case ZEND_SEND_VAR:
-				case ZEND_CAST:
-				case ZEND_QM_ASSIGN:
-				case ZEND_JMP_SET:
-				case ZEND_COALESCE:
-				case ZEND_FE_RESET_R:
-					if ((build_flags & ZEND_SSA_RC_INFERENCE) && opline->op1_type == IS_CV) {
-						goto add_op1_def;
-					}
-					break;
-				case ZEND_ADD_ARRAY_UNPACK:
-					ssa_ops[k].result_use = var[EX_VAR_TO_NUM(opline->result.var)];
-					break;
-				case ZEND_ADD_ARRAY_ELEMENT:
-					ssa_ops[k].result_use = var[EX_VAR_TO_NUM(opline->result.var)];
-					/* break missing intentionally */
-				case ZEND_INIT_ARRAY:
-					if (((build_flags & ZEND_SSA_RC_INFERENCE)
-								|| (opline->extended_value & ZEND_ARRAY_ELEMENT_REF))
-							&& opline->op1_type == IS_CV) {
-						goto add_op1_def;
-					}
-					break;
-				case ZEND_YIELD:
-					if (opline->op1_type == IS_CV
-							&& ((op_array->fn_flags & ZEND_ACC_RETURN_REFERENCE)
-								|| (build_flags & ZEND_SSA_RC_INFERENCE))) {
-						goto add_op1_def;
-					}
-					break;
-				case ZEND_UNSET_CV:
-					goto add_op1_def;
-				case ZEND_VERIFY_RETURN_TYPE:
-					if (opline->op1_type & (IS_TMP_VAR|IS_VAR|IS_CV)) {
-						goto add_op1_def;
-					}
-					break;
-				case ZEND_FE_FETCH_R:
-				case ZEND_FE_FETCH_RW:
-					if (opline->op2_type != IS_CV) {
-						ssa_ops[k].op2_use = -1; /* not used */
-					}
-					ssa_ops[k].op2_def = ssa_vars_count;
-					var[EX_VAR_TO_NUM(opline->op2.var)] = ssa_vars_count;
-					ssa_vars_count++;
-					//NEW_SSA_VAR(opline->op2.var)
-					break;
-				case ZEND_BIND_LEXICAL:
-					if ((opline->extended_value & ZEND_BIND_REF) || (build_flags & ZEND_SSA_RC_INFERENCE)) {
-						ssa_ops[k].op2_def = ssa_vars_count;
-						var[EX_VAR_TO_NUM(opline->op2.var)] = ssa_vars_count;
-						ssa_vars_count++;
-						//NEW_SSA_VAR(opline->op2.var)
-					}
-					break;
-				default:
-					break;
-			}
-
-			if (opline->result_type & (IS_CV|IS_VAR|IS_TMP_VAR)) {
-				ssa_ops[k].result_def = ssa_vars_count;
-				var[EX_VAR_TO_NUM(opline->result.var)] = ssa_vars_count;
-				ssa_vars_count++;
-				//NEW_SSA_VAR(op_array->last_var + opline->result.var)
-			}
+			ssa_vars_count = _zend_ssa_rename_op(op_array, opline, k, build_flags, ssa_vars_count, ssa_ops, var);
 		}
 	}
 

--- a/ext/opcache/Optimizer/zend_ssa.h
+++ b/ext/opcache/Optimizer/zend_ssa.h
@@ -142,6 +142,7 @@ typedef struct _zend_ssa {
 BEGIN_EXTERN_C()
 
 int zend_build_ssa(zend_arena **arena, const zend_script *script, const zend_op_array *op_array, uint32_t build_flags, zend_ssa *ssa);
+int zend_ssa_rename_op(const zend_op_array *op_array, const zend_op *opline, uint32_t k, uint32_t build_flags, int ssa_vars_count, zend_ssa_op *ssa_ops, int *var);
 int zend_ssa_compute_use_def_chains(zend_arena **arena, const zend_op_array *op_array, zend_ssa *ssa);
 int zend_ssa_unlink_use_chain(zend_ssa *ssa, int op, int var);
 

--- a/ext/opcache/jit/Makefile.frag
+++ b/ext/opcache/jit/Makefile.frag
@@ -13,5 +13,6 @@ $(builddir)/jit/zend_jit.lo: \
 	$(srcdir)/jit/zend_jit_perf_dump.c \
 	$(srcdir)/jit/zend_jit_oprofile.c \
 	$(srcdir)/jit/zend_jit_vtune.c \
+	$(srcdir)/jit/zend_jit_trace.c \
 	$(srcdir)/jit/zend_elf.c
 

--- a/ext/opcache/jit/Makefile.frag.w32
+++ b/ext/opcache/jit/Makefile.frag.w32
@@ -13,4 +13,5 @@ $(BUILD_DIR)\opcache_jit\zend_jit.obj: \
 	ext/opcache/jit/zend_jit_gdb.c \
 	ext/opcache/jit/zend_jit_perf_dump.c \
 	ext/opcache/jit/zend_jit_oprofile.c \
+	ext/opcache/jit/zend_jit_trace.c \
 	ext/opcache/jit/zend_jit_vtune.c

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -2627,9 +2627,9 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 							if (!zend_jit_label(&dasm_state, jit_return_label)) {
 								goto jit_failure;
 							}
-						    if (!zend_jit_leave_frame(&dasm_state)) {
+							if (!zend_jit_leave_frame(&dasm_state)) {
 								goto jit_failure;
-						    }
+							}
 							for (j = 0 ; j < op_array->last_var; j++) {
 								uint32_t info = zend_ssa_cv_info(opline, op_array, ssa, j);
 

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -24,7 +24,6 @@
 #include "Zend/zend_constants.h"
 #include "zend_smart_str.h"
 #include "jit/zend_jit.h"
-#include "jit/zend_jit_internal.h"
 
 #ifdef HAVE_JIT
 
@@ -33,6 +32,14 @@
 #include "Optimizer/zend_inference.h"
 #include "Optimizer/zend_call_graph.h"
 #include "Optimizer/zend_dump.h"
+
+#include "jit/zend_jit_internal.h"
+
+#ifdef ZTS
+int zend_jit_globals_id;
+#else
+zend_jit_globals jit_globals;
+#endif
 
 //#define CONTEXT_THREADED_JIT
 #define ZEND_JIT_USE_RC_INFERENCE
@@ -49,6 +56,7 @@
 
 #define JIT_PREFIX      "JIT$"
 #define JIT_STUB_PREFIX "JIT$$"
+#define TRACE_PREFIX    "TRACE-"
 
 #define DASM_M_GROW(ctx, t, p, sz, need) \
   do { \
@@ -97,10 +105,16 @@ static zend_long jit_bisect_pos = 0;
 static const void *zend_jit_runtime_jit_handler = NULL;
 static const void *zend_jit_profile_jit_handler = NULL;
 static const void *zend_jit_func_counter_handler = NULL;
+static const void *zend_jit_ret_counter_handler = NULL;
 static const void *zend_jit_loop_counter_handler = NULL;
 
 static int zend_may_overflow(const zend_op *opline, const zend_op_array *op_array, zend_ssa *ssa);
 static void ZEND_FASTCALL zend_runtime_jit(void);
+
+static int zend_jit_trace_may_exit(const zend_op_array *op_array, const zend_op *opline, zend_jit_trace_rec *trace);
+static uint32_t zend_jit_trace_get_exit_point(const zend_op *from_opline, const zend_op *to_opline, zend_jit_trace_rec *trace);
+static const void *zend_jit_trace_get_exit_addr(uint32_t n);
+static void zend_jit_trace_add_code(const void *start, uint32_t size);
 
 static zend_bool zend_ssa_is_last_use(const zend_op_array *op_array, const zend_ssa *ssa, int var, int use)
 {
@@ -148,7 +162,6 @@ static zend_bool zend_long_is_power_of_two(zend_long x)
 #include "dynasm/dasm_x86.h"
 #include "jit/zend_jit_x86.h"
 #include "jit/zend_jit_helpers.c"
-#include "jit/zend_jit_x86.c"
 #include "jit/zend_jit_disasm_x86.c"
 #ifndef _WIN32
 #include "jit/zend_jit_gdb.c"
@@ -159,6 +172,8 @@ static zend_bool zend_long_is_power_of_two(zend_long x)
 #endif
 #include "jit/zend_jit_vtune.c"
 
+#include "jit/zend_jit_x86.c"
+
 #if _WIN32
 # include <Windows.h>
 #else
@@ -167,8 +182,6 @@ static zend_bool zend_long_is_power_of_two(zend_long x)
 #   define MAP_ANONYMOUS MAP_ANON
 # endif
 #endif
-
-#define DASM_ALIGNMENT 16
 
 ZEND_EXT_API void zend_jit_status(zval *ret)
 {
@@ -220,7 +233,8 @@ static void *dasm_link_and_encode(dasm_State             **dasm_state,
                                   zend_ssa                *ssa,
                                   const zend_op           *rt_opline,
                                   zend_lifetime_interval **ra,
-                                  const char              *name)
+                                  const char              *name,
+                                  zend_bool                is_trace)
 {
 	size_t size;
 	int ret;
@@ -289,6 +303,10 @@ static void *dasm_link_and_encode(dasm_State             **dasm_state,
 	entry = *dasm_ptr;
 	*dasm_ptr = (void*)((char*)*dasm_ptr + ZEND_MM_ALIGNED_SIZE_EX(size, DASM_ALIGNMENT));
 
+	if (is_trace) {
+		zend_jit_trace_add_code(entry, size);
+	}
+
 	if (op_array && ssa) {
 		int b;
 
@@ -339,7 +357,7 @@ static void *dasm_link_and_encode(dasm_State             **dasm_state,
 	} else {
 	    if (ZCG(accel_directives).jit_debug & (ZEND_JIT_DEBUG_ASM_STUBS|ZEND_JIT_DEBUG_ASM)) {
 			zend_jit_disasm_add_symbol(name, (uintptr_t)entry, size);
-		    if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_ASM_STUBS) {
+		    if (is_trace || (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_ASM_STUBS) != 0) {
 				zend_jit_disasm(
 					name,
 					(op_array && op_array->filename) ? ZSTR_VAL(op_array->filename) : NULL,
@@ -2417,7 +2435,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						goto done;
 					case ZEND_INIT_FCALL:
 					case ZEND_INIT_FCALL_BY_NAME:
-						if (!zend_jit_init_fcall(&dasm_state, opline, b, op_array, ssa, call_level)) {
+						if (!zend_jit_init_fcall(&dasm_state, opline, b, op_array, ssa, call_level, NULL)) {
 							goto jit_failure;
 						}
 						goto done;
@@ -2466,7 +2484,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 					case ZEND_DO_ICALL:
 					case ZEND_DO_FCALL_BY_NAME:
 					case ZEND_DO_FCALL:
-						if (!zend_jit_do_fcall(&dasm_state, opline, op_array, ssa, call_level, b + 1)) {
+						if (!zend_jit_do_fcall(&dasm_state, opline, op_array, ssa, call_level, b + 1, NULL)) {
 							goto jit_failure;
 						}
 						goto done;
@@ -2503,7 +2521,8 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 								OP2_INFO(), OP2_REG_ADDR(),
 								res_addr,
 								zend_may_throw(opline, op_array, ssa),
-								smart_branch_opcode, target_label, target_label2)) {
+								smart_branch_opcode, target_label, target_label2,
+								NULL)) {
 							goto jit_failure;
 						}
 						goto done;
@@ -2530,7 +2549,8 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 								OP2_INFO(), OP2_REG_ADDR(),
 								RES_REG_ADDR(),
 								zend_may_throw(opline, op_array, ssa),
-								smart_branch_opcode, target_label, target_label2)) {
+								smart_branch_opcode, target_label, target_label2,
+								NULL)) {
 							goto jit_failure;
 						}
 						goto done;
@@ -2550,7 +2570,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 							smart_branch_opcode = 0;
 							target_label = target_label2 = (uint32_t)-1;
 						}
-						if (!zend_jit_defined(&dasm_state, opline, op_array, smart_branch_opcode, target_label, target_label2)) {
+						if (!zend_jit_defined(&dasm_state, opline, op_array, smart_branch_opcode, target_label, target_label2, NULL)) {
 							goto jit_failure;
 						}
 						goto done;
@@ -2574,7 +2594,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 							smart_branch_opcode = 0;
 							target_label = target_label2 = (uint32_t)-1;
 						}
-						if (!zend_jit_type_check(&dasm_state, opline, op_array, OP1_INFO(), smart_branch_opcode, target_label, target_label2)) {
+						if (!zend_jit_type_check(&dasm_state, opline, op_array, OP1_INFO(), smart_branch_opcode, target_label, target_label2, NULL)) {
 							goto jit_failure;
 						}
 						goto done;
@@ -2589,9 +2609,38 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 							if (!zend_jit_tail_handler(&dasm_state, opline)) {
 								goto jit_failure;
 							}
-						} else if (!zend_jit_return(&dasm_state, opline, op_array, ssa,
-								op1_info, OP1_REG_ADDR())) {
-							goto jit_failure;
+						} else {
+							int j;
+
+							if (!zend_jit_return(&dasm_state, opline, op_array,
+									op1_info, OP1_REG_ADDR())) {
+								goto jit_failure;
+							}
+							if (jit_return_label >= 0) {
+								if (!zend_jit_jmp(&dasm_state, jit_return_label)) {
+									goto jit_failure;
+								}
+								goto done;
+							}
+							jit_return_label = ssa->cfg.blocks_count * 2;
+							if (!zend_jit_label(&dasm_state, jit_return_label)) {
+								goto jit_failure;
+							}
+						    if (!zend_jit_leave_frame(&dasm_state)) {
+								goto jit_failure;
+						    }
+							for (j = 0 ; j < op_array->last_var; j++) {
+								uint32_t info = zend_ssa_cv_info(opline, op_array, ssa, j);
+
+								if (info & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE|MAY_BE_REF)) {
+									if (!zend_jit_free_cv(&dasm_state, opline, op_array, info, j)) {
+										goto jit_failure;
+									}
+								}
+							}
+						    if (!zend_jit_leave_func(&dasm_state, opline, op_array, NULL)) {
+								goto jit_failure;
+						    }
 						}
 						goto done;
 					case ZEND_BOOL:
@@ -2599,7 +2648,8 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						if (!zend_jit_bool_jmpznz(&dasm_state, opline, op_array,
 								OP1_INFO(), OP1_REG_ADDR(), RES_REG_ADDR(),
 								-1, -1,
-								zend_may_throw(opline, op_array, ssa))) {
+								zend_may_throw(opline, op_array, ssa),
+								opline->opcode, NULL)) {
 							goto jit_failure;
 						}
 						goto done;
@@ -2625,7 +2675,8 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						if (!zend_jit_bool_jmpznz(&dasm_state, opline, op_array,
 								OP1_INFO(), OP1_REG_ADDR(), res_addr,
 								ssa->cfg.blocks[b].successors[0], ssa->cfg.blocks[b].successors[1],
-								zend_may_throw(opline, op_array, ssa))) {
+								zend_may_throw(opline, op_array, ssa),
+								opline->opcode, NULL)) {
 							goto jit_failure;
 						}
 						goto done;
@@ -2666,7 +2717,8 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						if (!zend_jit_isset_isempty_dim(&dasm_state, opline, op_array,
 								OP1_INFO(), OP2_INFO(),
 								zend_may_throw(opline, op_array, ssa),
-								smart_branch_opcode, target_label, target_label2)) {
+								smart_branch_opcode, target_label, target_label2,
+								NULL)) {
 							goto jit_failure;
 						}
 						goto done;
@@ -2895,7 +2947,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 								zend_jit_call(&dasm_state, next_opline, b + 1);
 								is_terminated = 1;
 							} else {
-								zend_jit_do_fcall(&dasm_state, next_opline, op_array, ssa, call_level, b + 1);
+								zend_jit_do_fcall(&dasm_state, next_opline, op_array, ssa, call_level, b + 1, NULL);
 							}
 						}
 					}
@@ -2916,7 +2968,7 @@ done:
 		}
 	}
 
-	handler = dasm_link_and_encode(&dasm_state, op_array, ssa, rt_opline, ra, NULL);
+	handler = dasm_link_and_encode(&dasm_state, op_array, ssa, rt_opline, ra, NULL, 0);
 	if (!handler) {
 		goto jit_failure;
 	}
@@ -3072,17 +3124,16 @@ void zend_jit_check_funcs(HashTable *function_table, zend_bool is_method) {
 void ZEND_FASTCALL zend_jit_hot_func(zend_execute_data *execute_data, const zend_op *opline)
 {
 	zend_op_array *op_array = &EX(func)->op_array;
-	zend_jit_op_array_extension *jit_extension;
+	zend_jit_op_array_hot_extension *jit_extension;
 	uint32_t i;
 
 	zend_shared_alloc_lock();
-	jit_extension = (zend_jit_op_array_extension*)ZEND_FUNC_INFO(op_array);
+	jit_extension = (zend_jit_op_array_hot_extension*)ZEND_FUNC_INFO(op_array);
 
 	if (jit_extension) {
 		SHM_UNPROTECT();
 		zend_jit_unprotect();
 
-		*(jit_extension->counter) = ZEND_JIT_HOT_COUNTER_INIT;
 		for (i = 0; i < op_array->last; i++) {
 			op_array->opcodes[i].handler = jit_extension->orig_handlers[i];
 		}
@@ -3103,7 +3154,7 @@ void ZEND_FASTCALL zend_jit_hot_func(zend_execute_data *execute_data, const zend
 static int zend_jit_setup_hot_counters(zend_op_array *op_array)
 {
 	zend_op *opline = op_array->opcodes;
-	zend_jit_op_array_extension *jit_extension;
+	zend_jit_op_array_hot_extension *jit_extension;
 	zend_cfg cfg;
 	uint32_t i;
 
@@ -3114,7 +3165,7 @@ static int zend_jit_setup_hot_counters(zend_op_array *op_array)
 		return FAILURE;
 	}
 
-	jit_extension = (zend_jit_op_array_extension*)zend_shared_alloc(sizeof(zend_jit_op_array_extension) + (op_array->last - 1) * sizeof(void*));
+	jit_extension = (zend_jit_op_array_hot_extension*)zend_shared_alloc(sizeof(zend_jit_op_array_hot_extension) + (op_array->last - 1) * sizeof(void*));
 	jit_extension->counter = &zend_jit_hot_counters[zend_jit_op_array_hash(op_array) & (ZEND_HOT_COUNTERS_COUNT - 1)];
 	for (i = 0; i < op_array->last; i++) {
 		jit_extension->orig_handlers[i] = op_array->opcodes[i].handler;
@@ -3158,6 +3209,8 @@ static int zend_needs_manual_jit(const zend_op_array *op_array)
 	return 0;
 }
 
+#include "jit/zend_jit_trace.c"
+
 ZEND_EXT_API int zend_jit_op_array(zend_op_array *op_array, zend_script *script)
 {
 	if (dasm_ptr == NULL) {
@@ -3195,6 +3248,8 @@ ZEND_EXT_API int zend_jit_op_array(zend_op_array *op_array, zend_script *script)
 		return SUCCESS;
 	} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_COUNTERS) {
 		return zend_jit_setup_hot_counters(op_array);
+	} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+		return zend_jit_setup_hot_trace_counters(op_array);
 	} else if (zend_jit_trigger == ZEND_JIT_ON_SCRIPT_LOAD) {
 		return zend_real_jit_func(op_array, script, NULL);
 	} else if (zend_jit_trigger == ZEND_JIT_ON_DOC_COMMENT) {
@@ -3230,7 +3285,8 @@ ZEND_EXT_API int zend_jit_script(zend_script *script)
 
 	if (zend_jit_trigger == ZEND_JIT_ON_FIRST_EXEC ||
 	    zend_jit_trigger == ZEND_JIT_ON_PROF_REQUEST ||
-	    zend_jit_trigger == ZEND_JIT_ON_HOT_COUNTERS) {
+	    zend_jit_trigger == ZEND_JIT_ON_HOT_COUNTERS ||
+	    zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
 		for (i = 0; i < call_graph.op_arrays_count; i++) {
 			ZEND_SET_FUNC_INFO(call_graph.op_arrays[i], NULL);
 			if (zend_jit_op_array(call_graph.op_arrays[i], script) != SUCCESS) {
@@ -3381,7 +3437,7 @@ static int zend_jit_make_stubs(void)
 		if (!zend_jit_stubs[i].stub(&dasm_state)) {
 			return 0;
 		}
-		if (!dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, zend_jit_stubs[i].name)) {
+		if (!dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, zend_jit_stubs[i].name, 0)) {
 			return 0;
 		}
 	}
@@ -3392,7 +3448,7 @@ static int zend_jit_make_stubs(void)
 			if (!zend_jit_hybrid_runtime_jit_stub(&dasm_state)) {
 				return 0;
 			}
-			zend_jit_runtime_jit_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_runtime_jit");
+			zend_jit_runtime_jit_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_runtime_jit", 0);
 			if (!zend_jit_runtime_jit_handler) {
 				return 0;
 			}
@@ -3401,7 +3457,7 @@ static int zend_jit_make_stubs(void)
 			if (!zend_jit_hybrid_profile_jit_stub(&dasm_state)) {
 				return 0;
 			}
-			zend_jit_profile_jit_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_profile_jit");
+			zend_jit_profile_jit_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_profile_jit", 0);
 			if (!zend_jit_profile_jit_handler) {
 				return 0;
 			}
@@ -3410,7 +3466,7 @@ static int zend_jit_make_stubs(void)
 			if (!zend_jit_hybrid_func_counter_stub(&dasm_state)) {
 				return 0;
 			}
-			zend_jit_func_counter_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_func_counter");
+			zend_jit_func_counter_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_func_counter", 0);
 			if (!zend_jit_func_counter_handler) {
 				return 0;
 			}
@@ -3419,25 +3475,72 @@ static int zend_jit_make_stubs(void)
 			if (!zend_jit_hybrid_loop_counter_stub(&dasm_state)) {
 				return 0;
 			}
-			zend_jit_loop_counter_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_loop_counter");
+			zend_jit_loop_counter_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_loop_counter", 0);
+			if (!zend_jit_loop_counter_handler) {
+				return 0;
+			}
+		} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+			dasm_setup(&dasm_state, dasm_actions);
+			if (!zend_jit_hybrid_func_trace_counter_stub(&dasm_state)) {
+				return 0;
+			}
+			zend_jit_func_counter_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_func_counter", 0);
+			if (!zend_jit_func_counter_handler) {
+				return 0;
+			}
+
+			dasm_setup(&dasm_state, dasm_actions);
+			if (!zend_jit_hybrid_ret_trace_counter_stub(&dasm_state)) {
+				return 0;
+			}
+			zend_jit_ret_counter_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_ret_counter", 0);
+			if (!zend_jit_ret_counter_handler) {
+				return 0;
+			}
+
+			dasm_setup(&dasm_state, dasm_actions);
+			if (!zend_jit_hybrid_loop_trace_counter_stub(&dasm_state)) {
+				return 0;
+			}
+			zend_jit_loop_counter_handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, "JIT$$hybrid_loop_counter", 0);
 			if (!zend_jit_loop_counter_handler) {
 				return 0;
 			}
 		}
 	} else {
-		zend_jit_runtime_jit_handler = (const void*)zend_runtime_jit;
-		zend_jit_profile_jit_handler = (const void*)zend_jit_profile_helper;
-		zend_jit_func_counter_handler = (const void*)zend_jit_func_counter_helper;
-		zend_jit_loop_counter_handler = (const void*)zend_jit_loop_counter_helper;
+		if (zend_jit_trigger == ZEND_JIT_ON_FIRST_EXEC) {
+			zend_jit_runtime_jit_handler = (const void*)zend_runtime_jit;
+		} else if (zend_jit_trigger == ZEND_JIT_ON_PROF_REQUEST) {
+			zend_jit_profile_jit_handler = (const void*)zend_jit_profile_helper;
+		} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_COUNTERS) {
+			zend_jit_func_counter_handler = (const void*)zend_jit_func_counter_helper;
+			zend_jit_loop_counter_handler = (const void*)zend_jit_loop_counter_helper;
+		} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+			zend_jit_func_counter_handler = (const void*)zend_jit_func_trace_helper;
+			zend_jit_ret_counter_handler = (const void*)zend_jit_ret_trace_helper;
+			zend_jit_loop_counter_handler = (const void*)zend_jit_loop_trace_helper;
+		}
 	}
 
 	dasm_free(&dasm_state);
 	return 1;
 }
 
+static void zend_jit_globals_ctor(zend_jit_globals *jit_globals)
+{
+	memset(jit_globals, 0, sizeof(zend_jit_globals));
+	zend_jit_trace_init_caches();
+}
+
 ZEND_EXT_API int zend_jit_startup(zend_long jit, void *buf, size_t size, zend_bool reattached)
 {
 	int ret;
+
+#ifdef ZTS
+	zend_jit_globals_id = ts_allocate_id(&zend_jit_globals_id, sizeof(zend_jit_globals), (ts_allocate_ctor) zend_jit_globals_ctor, NULL);
+#else
+	zend_jit_globals_ctor(&jit_globals);
+#endif
 
 	zend_jit_level = ZEND_JIT_LEVEL(jit);
 	zend_jit_trigger = ZEND_JIT_TRIGGER(jit);
@@ -3549,6 +3652,12 @@ ZEND_EXT_API int zend_jit_startup(zend_long jit, void *buf, size_t size, zend_bo
 #endif
 	}
 
+	if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+		if (zend_jit_trace_startup() != SUCCESS) {
+			return FAILURE;
+		}
+	}
+
 	return SUCCESS;
 }
 
@@ -3587,6 +3696,14 @@ ZEND_EXT_API void zend_jit_activate(void)
 		for (i = 0; i < ZEND_HOT_COUNTERS_COUNT; i++) {
 			zend_jit_hot_counters[i] = ZEND_JIT_HOT_COUNTER_INIT;
 		}
+	} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+		int i;
+
+		for (i = 0; i < ZEND_HOT_COUNTERS_COUNT; i++) {
+			zend_jit_hot_counters[i] = ZEND_JIT_TRACE_COUNTER_INIT;
+		}
+
+		zend_jit_trace_reset_caches();
 	}
 }
 

--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -33,6 +33,7 @@
 #define ZEND_JIT_ON_PROF_REQUEST   2     /* compile the most frequently caled on first request functions */
 #define ZEND_JIT_ON_HOT_COUNTERS   3     /* compile functions after N calls or loop iterations */
 #define ZEND_JIT_ON_DOC_COMMENT    4     /* compile functions with "@jit" tag in doc-comments */
+#define ZEND_JIT_ON_HOT_TRACE      5     /* trace functions after N calls or loop iterations */
 
 #define ZEND_JIT_TRIGGER(n)        (((n) / 10) % 10)
 
@@ -74,6 +75,14 @@
 #define ZEND_JIT_DEBUG_VTUNE     (1<<7)
 
 #define ZEND_JIT_DEBUG_GDB       (1<<8)
+
+#define ZEND_JIT_DEBUG_TRACE_START     (1<<12)
+#define ZEND_JIT_DEBUG_TRACE_STOP      (1<<13)
+#define ZEND_JIT_DEBUG_TRACE_COMPILED  (1<<14)
+#define ZEND_JIT_DEBUG_TRACE_EXIT      (1<<15)
+#define ZEND_JIT_DEBUG_TRACE_ABORT     (1<<16)
+#define ZEND_JIT_DEBUG_TRACE_BLACKLIST (1<<17)
+#define ZEND_JIT_DEBUG_TRACE_BYTECODE  (1<<18)
 
 ZEND_EXT_API int  zend_jit_op_array(zend_op_array *op_array, zend_script *script);
 ZEND_EXT_API int  zend_jit_script(zend_script *script);

--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -83,6 +83,7 @@
 #define ZEND_JIT_DEBUG_TRACE_ABORT     (1<<16)
 #define ZEND_JIT_DEBUG_TRACE_BLACKLIST (1<<17)
 #define ZEND_JIT_DEBUG_TRACE_BYTECODE  (1<<18)
+#define ZEND_JIT_DEBUG_TRACE_TSSA      (1<<19)
 
 ZEND_EXT_API int  zend_jit_op_array(zend_op_array *op_array, zend_script *script);
 ZEND_EXT_API int  zend_jit_script(zend_script *script);

--- a/ext/opcache/jit/zend_jit_disasm_x86.c
+++ b/ext/opcache/jit/zend_jit_disasm_x86.c
@@ -137,6 +137,10 @@ static void zend_jit_disasm_add_symbol(const char *name,
 				}
 			} else {
 				ZEND_ASSERT(sym->addr == node->addr);
+				if (strcmp(name, node->name) == 0 && sym->end < node->end) {
+					/* reduce size of the existing symbol */
+					node->end = sym->end;
+				}
 				free(sym);
 				return;
 			}
@@ -397,6 +401,7 @@ static int zend_jit_disasm_init(void)
 	REGISTER_HELPER(zend_jit_int_extend_stack_helper);
 	REGISTER_HELPER(zend_jit_leave_nested_func_helper);
 	REGISTER_HELPER(zend_jit_leave_top_func_helper);
+	REGISTER_HELPER(zend_jit_leave_func_helper);
 	REGISTER_HELPER(zend_jit_symtable_find);
 	REGISTER_HELPER(zend_jit_hash_index_lookup_rw);
 	REGISTER_HELPER(zend_jit_hash_index_lookup_w);
@@ -448,6 +453,7 @@ static int zend_jit_disasm_init(void)
 	REGISTER_HELPER(zend_jit_pre_dec);
 	REGISTER_HELPER(zend_runtime_jit);
 	REGISTER_HELPER(zend_jit_hot_func);
+	REGISTER_HELPER(zend_jit_check_constant);
 #undef  REGISTER_HELPER
 
 #ifndef _WIN32

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -267,9 +267,14 @@ typedef struct _zend_jit_trace_rec {
 			uint8_t op2_type;/* recorded zval op2_type for ZEND_JIT_TRACE_VM */
 			uint8_t op3_type;/* recorded zval for op_data.op1_type for ZEND_JIT_TRACE_VM */
 		};
-		uint8_t   recursive; /* part of recursive return sequence for ZEND_JIT_TRACE_BACK */
-		int8_t    return_value_used; /* for ZEND_JIT_TRACE_ENTER */
-		uint8_t   fake; /* for ZEND_JIT_TRACE_INIT_FCALL */
+		struct {
+			union {
+				uint8_t   recursive; /* part of recursive return sequence for ZEND_JIT_TRACE_BACK */
+				int8_t    return_value_used; /* for ZEND_JIT_TRACE_ENTER */
+				uint8_t   fake; /* for ZEND_JIT_TRACE_INIT_FCALL */
+			};
+			uint8_t first_ssa_var; /* may be used for ZEND_JIT_TRACE_ENTER and ZEND_JIT_TRACE_BACK */
+		};
 		struct {
 			uint8_t  start;  /* ZEND_JIT_TRACE_START_MASK for ZEND_JIT_TRACE_START/END */
 			uint8_t  stop;   /* zend_jit_trace_stop for ZEND_JIT_TRACE_START/END */

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -292,7 +292,6 @@ typedef struct _zend_jit_trace_start_rec {
 	uint8_t  level;  /* recursive return level for ZEND_JIT_TRACE_START */
 	const zend_op_array *op_array;
 	const zend_op *opline;
-	uint32_t len;
 } zend_jit_trace_start_rec;
 
 #define ZEND_JIT_TRACE_START_REC_SIZE 2
@@ -302,6 +301,8 @@ typedef struct _zend_jit_trace_exit_info {
 	uint32_t       stack_size;
 	uint32_t       stack_offset;
 } zend_jit_trace_exit_info;
+
+typedef int32_t zend_jit_trace_stack;
 
 typedef struct _zend_jit_trace_info {
 	uint32_t                  id;            /* trace id */
@@ -315,7 +316,7 @@ typedef struct _zend_jit_trace_info {
 	uint32_t                  stack_map_size;
 	const void               *code_start;    /* address of native code */
 	zend_jit_trace_exit_info *exit_info;     /* address of native code */
-	uint8_t                  *stack_map;
+	zend_jit_trace_stack     *stack_map;
 	//uint32_t    loop_offset;
 } zend_jit_trace_info;
 
@@ -325,8 +326,11 @@ struct _zend_jit_trace_stack_frame {
 	zend_jit_trace_stack_frame *call;
 	zend_jit_trace_stack_frame *prev;
 	const zend_function        *func;
-	int8_t                      return_value_used;
-	uint8_t                     stack[1];
+	union {
+		int8_t                  return_value_used;
+		int                     return_ssa_var;
+	};
+	zend_jit_trace_stack        stack[1];
 };
 
 typedef struct _zend_jit_globals {

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -33,18 +33,11 @@ extern int zend_jit_profile_counter_rid;
 
 extern int16_t zend_jit_hot_counters[ZEND_HOT_COUNTERS_COUNT];
 
-void ZEND_FASTCALL zend_jit_hot_func(zend_execute_data *execute_data, const zend_op *opline);
-
-typedef struct _zend_jit_op_array_extension {
-	int16_t    *counter;
-	const void *orig_handlers[1];
-} zend_jit_op_array_extension;
-
-static zend_always_inline zend_long zend_jit_op_array_hash(const zend_op_array *op_array)
+static zend_always_inline zend_long zend_jit_hash(const void *ptr)
 {
 	uintptr_t x;
 
-	x = (uintptr_t)op_array->opcodes >> 3;
+	x = (uintptr_t)ptr >> 3;
 #if SIZEOF_SIZE_T == 4
 	x = ((x >> 16) ^ x) * 0x45d9f3b;
 	x = ((x >> 16) ^ x) * 0x45d9f3b;
@@ -56,6 +49,16 @@ static zend_always_inline zend_long zend_jit_op_array_hash(const zend_op_array *
 #endif
 	return x;
 }
+
+void ZEND_FASTCALL zend_jit_hot_func(zend_execute_data *execute_data, const zend_op *opline);
+
+typedef struct _zend_jit_op_array_hot_extension {
+	int16_t    *counter;
+	const void *orig_handlers[1];
+} zend_jit_op_array_hot_extension;
+
+#define zend_jit_op_array_hash(op_array) \
+	zend_jit_hash((op_array)->opcodes)
 
 extern const zend_op *zend_jit_halt_op;
 
@@ -78,6 +81,10 @@ extern const zend_op *zend_jit_halt_op;
 		handler(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU); \
 		return; \
 	} while(0)
+# define ZEND_OPCODE_TAIL_CALL_EX(handler, arg) do { \
+		handler(arg ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC); \
+		return; \
+	} while(0)
 #else
 # define EXECUTE_DATA_D                       zend_execute_data* execute_data
 # define EXECUTE_DATA_C                       execute_data
@@ -96,6 +103,9 @@ extern const zend_op *zend_jit_halt_op;
 # define ZEND_OPCODE_TAIL_CALL(handler)       do { \
 		return handler(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU); \
 	} while(0)
+# define ZEND_OPCODE_TAIL_CALL_EX(handler, arg) do { \
+		return handler(arg ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_CC); \
+	} while(0)
 #endif
 
 /* VM handlers */
@@ -104,6 +114,7 @@ typedef ZEND_OPCODE_HANDLER_RET (ZEND_FASTCALL *zend_vm_opcode_handler_t)(ZEND_O
 /* VM helpers */
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_leave_nested_func_helper(uint32_t call_info EXECUTE_DATA_DC);
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_leave_top_func_helper(uint32_t call_info EXECUTE_DATA_DC);
+ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_leave_func_helper(uint32_t call_info EXECUTE_DATA_DC);
 
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_profile_helper(ZEND_OPCODE_HANDLER_ARGS);
 
@@ -115,5 +126,255 @@ void ZEND_FASTCALL zend_jit_deprecated_helper(OPLINE_D);
 
 void ZEND_FASTCALL zend_jit_get_constant(const zval *key, uint32_t flags);
 int  ZEND_FASTCALL zend_jit_check_constant(const zval *key);
+
+/* Tracer */
+#define zend_jit_opline_hash(opline) \
+	zend_jit_hash(opline)
+
+#define ZEND_JIT_TRACE_FUNC_COST      (1*250)
+#define ZEND_JIT_TRACE_RET_COST     (1*250-1)
+#define ZEND_JIT_TRACE_LOOP_COST      (2*250)
+#define ZEND_JIT_TRACE_COUNTER_INIT (127*250)
+
+#define ZEND_JIT_TRACE_MAX_TRACES        1024 /* max number of traces */
+#define ZEND_JIT_TRACE_MAX_LENGTH        1024 /* max length of single trace */
+#define ZEND_JIT_TRACE_MAX_EXITS          512 /* max number of side exits per trace */
+#define ZEND_JIT_TRACE_MAX_SIDE_TRACES    128 /* max number of side traces of a root trace */
+#define ZEND_JIT_TRACE_MAX_EXIT_COUNTERS 8192 /* max number of side exits for all trace */
+
+#define ZEND_JIT_TRACE_MAX_FUNCS           30 /* max number of different functions in a single trace */
+#define ZEND_JIT_TRACE_MAX_CALL_DEPTH      10 /* max depth of inlined calls */
+#define ZEND_JIT_TRACE_MAX_RET_DEPTH        4 /* max depth of inlined returns */
+#define ZEND_JIT_TRACE_MAX_RECURSION        2 /* max number of recursive inlined calls */
+#define ZEND_JIT_TRACE_MAX_UNROLL_LOOPS     8 /* max number of unrolled loops */
+
+#define ZEND_JIT_TRACE_HOT_SIDE_COUNT       8 /* number of exits before taking side trace */
+#define ZEND_JIT_TRACE_HOT_RETURN_COUNT     8 /* number of returns before taking continuation trace */
+
+#define ZEND_JIT_TRACE_MAX_ROOT_FAILURES   16 /* number of attemts to record/compile a root trace */
+#define ZEND_JIT_TRACE_MAX_SIDE_FAILURES    4 /* number of attemts to record/compile a side trace */
+
+#define ZEND_JIT_TRACE_BAD_ROOT_SLOTS      64 /* number of slots in bad root trace cache */
+
+#define ZEND_JIT_TRACE_STOP(_) \
+	_(LOOP,              "loop") \
+	_(RECURSIVE_CALL,    "recursive call") \
+	_(RECURSIVE_RET,     "recursive return") \
+	_(RETURN,            "return") \
+	_(LINK,              "link to another trace") \
+	/* comiplation and linking successful */ \
+	_(COMPILED,          "compiled") \
+	_(ALREADY_DONE,      "already prcessed") \
+	/* failures */ \
+	_(ERROR,             "error")                          /* not used */ \
+	_(NOT_SUPPORTED,     "not supported instructions") \
+	_(EXCEPTION,         "exception") \
+	_(TOO_LONG,          "trace too long") \
+	_(TOO_DEEP,          "trace too deep") \
+	_(TOO_DEEP_RET,      "trace too deep return") \
+	_(DEEP_RECURSION,    "deep recursion") \
+	_(LOOP_UNROLL,       "loop unroll limit reached") \
+	_(LOOP_EXIT,         "exit from loop") \
+	_(BLACK_LIST,        "trace blacklisted") \
+	_(INNER_LOOP,        "inner loop")                     /* trace it */ \
+	_(COMPILED_LOOP,     "compiled loop") \
+	_(TOPLEVEL,          "toplevel") \
+	_(TRAMPOLINE,        "trampoline call") \
+	_(BAD_FUNC,          "bad function call") \
+	_(HALT,              "exit from interpreter") \
+	_(COMPILER_ERROR,    "JIT compilation error") \
+	/* no recoverable error (blacklist innediately) */ \
+	_(NO_SHM,            "insufficient shared memory") \
+	_(TOO_MANY_TRACES,   "too many traces") \
+	_(TOO_MANY_CHILDREN, "too many side traces") \
+	_(TOO_MANY_EXITS,    "too many side exits") \
+
+#define ZEND_JIT_TRACE_STOP_NAME(name, description) \
+	ZEND_JIT_TRACE_STOP_ ## name,
+
+typedef enum _zend_jit_trace_stop {
+	ZEND_JIT_TRACE_STOP(ZEND_JIT_TRACE_STOP_NAME)
+} zend_jit_trace_stop;
+
+#define ZEND_JIT_TRACE_STOP_OK(ret) \
+	(ret < ZEND_JIT_TRACE_STOP_COMPILED)
+
+#define ZEND_JIT_TRACE_STOP_DONE(ret) \
+	(ret < ZEND_JIT_TRACE_STOP_ERROR)
+
+#define ZEND_JIT_TRACE_STOP_REPEAT(ret) \
+	(ret == ZEND_JIT_TRACE_STOP_INNER_LOOP)
+
+#define ZEND_JIT_TRACE_STOP_MAY_RECOVER(ret) \
+	(ret <= ZEND_JIT_TRACE_STOP_COMPILER_ERROR)
+
+#define ZEND_JIT_TRACE_START_MASK      0xf
+
+#define ZEND_JIT_TRACE_START_LOOP   (1<<0)
+#define ZEND_JIT_TRACE_START_ENTER  (1<<1)
+#define ZEND_JIT_TRACE_START_RETURN (1<<2)
+#define ZEND_JIT_TRACE_START_SIDE   (1<<3) /* used for side traces */
+
+#define ZEND_JIT_TRACE_JITED        (1<<4)
+#define ZEND_JIT_TRACE_BLACKLISTED  (1<<5)
+#define ZEND_JIT_TRACE_UNSUPPORTED  (1<<6)
+
+#define ZEND_JIT_TRACE_SUPPORTED    0
+
+#define ZEND_JIT_EXIT_JITED         (1<<0)
+#define ZEND_JIT_EXIT_BLACKLISTED   (1<<1)
+
+typedef union _zend_op_trace_info {
+	zend_op dummy; /* the size of this structure must be the same as zend_op */
+	struct {
+		const void *orig_handler;
+		const void *call_handler;
+		int16_t    *counter;
+		uint8_t     trace_flags;
+	};
+} zend_op_trace_info;
+
+typedef struct _zend_jit_op_array_trace_extension {
+	zend_func_info func_info;
+	size_t offset; /* offset from "zend_op" to corresponding "op_info" */
+	zend_op_trace_info trace_info[1];
+} zend_jit_op_array_trace_extension;
+
+#define ZEND_OP_TRACE_INFO(opline, offset) \
+	((zend_op_trace_info*)(((char*)opline) + offset))
+
+/* Recorder */
+typedef enum _zend_jit_trace_op {
+	ZEND_JIT_TRACE_VM,
+	ZEND_JIT_TRACE_OP1_TYPE,
+	ZEND_JIT_TRACE_OP2_TYPE,
+	ZEND_JIT_TRACE_INIT_CALL,
+	ZEND_JIT_TRACE_DO_ICALL,
+	ZEND_JIT_TRACE_ENTER,
+	ZEND_JIT_TRACE_BACK,
+	ZEND_JIT_TRACE_START,
+	ZEND_JIT_TRACE_END,
+} zend_jit_trace_op;
+
+#define IS_UNKNOWN 255 /* may be used for zend_jit_trace_rec.op?_type */
+#define IS_TRACE_REFERENCE (1<<5)
+
+typedef struct _zend_jit_trace_rec {
+	uint8_t   op;    /* zend_jit_trace_op */
+	union {
+		struct {
+			uint8_t op1_type;/* recorded zval op1_type for ZEND_JIT_TRACE_VM */
+			uint8_t op2_type;/* recorded zval op2_type for ZEND_JIT_TRACE_VM */
+			uint8_t op3_type;/* recorded zval for op_data.op1_type for ZEND_JIT_TRACE_VM */
+		};
+		uint8_t   recursive; /* part of recursive return sequence for ZEND_JIT_TRACE_BACK */
+		int8_t    return_value_used; /* for ZEND_JIT_TRACE_ENTER */
+		uint8_t   fake; /* for ZEND_JIT_TRACE_INIT_FCALL */
+		struct {
+			uint8_t  start;  /* ZEND_JIT_TRACE_START_MASK for ZEND_JIT_TRACE_START/END */
+			uint8_t  stop;   /* zend_jit_trace_stop for ZEND_JIT_TRACE_START/END */
+			uint8_t  level;  /* recursive return level for ZEND_JIT_TRACE_START */
+		};
+	};
+	union {
+		const void             *ptr;
+		const zend_function    *func;
+		const zend_op_array    *op_array;
+		const zend_op          *opline;
+		const zend_class_entry *ce;
+	};
+} zend_jit_trace_rec;
+
+typedef struct _zend_jit_trace_start_rec {
+	uint8_t  op;     /* zend_jit_trace_op */
+	uint8_t  start;  /* ZEND_JIT_TRACE_START_MASK for ZEND_JIT_TRACE_START/END */
+	uint8_t  stop;   /* zend_jit_trace_stop for ZEND_JIT_TRACE_START/END */
+	uint8_t  level;  /* recursive return level for ZEND_JIT_TRACE_START */
+	const zend_op_array *op_array;
+	const zend_op *opline;
+	uint32_t len;
+} zend_jit_trace_start_rec;
+
+#define ZEND_JIT_TRACE_START_REC_SIZE 2
+
+typedef struct _zend_jit_trace_exit_info {
+	const zend_op *opline;     /* opline where VM should continue execution */
+	uint32_t       stack_size;
+	uint32_t       stack_offset;
+} zend_jit_trace_exit_info;
+
+typedef struct _zend_jit_trace_info {
+	uint32_t                  id;            /* trace id */
+	uint32_t                  root;          /* root trace id or sekf id for root traces */
+	uint32_t                  parent;        /* parent trace id or 0 for root traces */
+	uint32_t                  link;          /* link trace id or self id for loop) */
+	uint32_t                  exit_count;    /* number of side exits */
+	uint32_t                  child_count;   /* number of side traces for root traces */
+	uint32_t                  code_size;     /* size of native code */
+	uint32_t                  exit_counters; /* offset in exit counters array */
+	uint32_t                  stack_map_size;
+	const void               *code_start;    /* address of native code */
+	zend_jit_trace_exit_info *exit_info;     /* address of native code */
+	uint8_t                  *stack_map;
+	//uint32_t    loop_offset;
+} zend_jit_trace_info;
+
+typedef struct _zend_jit_trace_stack_frame zend_jit_trace_stack_frame;
+
+struct _zend_jit_trace_stack_frame {
+	zend_jit_trace_stack_frame *call;
+	zend_jit_trace_stack_frame *prev;
+	const zend_function        *func;
+	int8_t                      return_value_used;
+	uint8_t                     stack[1];
+};
+
+typedef struct _zend_jit_globals {
+	zend_jit_trace_stack_frame *current_frame;
+
+	const zend_op *bad_root_cache_opline[ZEND_JIT_TRACE_BAD_ROOT_SLOTS];
+	uint8_t bad_root_cache_count[ZEND_JIT_TRACE_BAD_ROOT_SLOTS];
+	uint8_t bad_root_cache_stop[ZEND_JIT_TRACE_BAD_ROOT_SLOTS];
+	uint32_t bad_root_slot;
+
+	uint8_t  exit_counters[ZEND_JIT_TRACE_MAX_EXIT_COUNTERS];
+} zend_jit_globals;
+
+#ifdef ZTS
+# define JIT_G(v) ZEND_TSRMG(zend_jit_globals_id, zend_jit_globals *, v)
+extern int zend_jit_globals_id;
+#else
+# define JIT_G(v) (jit_globals.v)
+extern zend_jit_globals jit_globals;
+#endif
+
+ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_func_trace_helper(ZEND_OPCODE_HANDLER_ARGS);
+ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_ret_trace_helper(ZEND_OPCODE_HANDLER_ARGS);
+ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_loop_trace_helper(ZEND_OPCODE_HANDLER_ARGS);
+
+int ZEND_FASTCALL zend_jit_trace_hot_root(zend_execute_data *execute_data, const zend_op *opline);
+int ZEND_FASTCALL zend_jit_trace_exit(uint32_t trace_num, uint32_t exit_num);
+zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *execute_data, const zend_op *opline, zend_jit_trace_rec *trace_buffer, uint8_t start);
+
+static zend_always_inline const zend_op* zend_jit_trace_get_exit_opline(zend_jit_trace_rec *trace, const zend_op *opline, zend_bool *exit_if_true)
+{
+	if (trace->op == ZEND_JIT_TRACE_VM || trace->op == ZEND_JIT_TRACE_END) {
+		if (trace->opline == opline + 1) {
+			/* not taken branch */
+			*exit_if_true = opline->opcode == ZEND_JMPNZ;
+			return OP_JMP_ADDR(opline, opline->op2);
+		} else if (trace->opline == OP_JMP_ADDR(opline, opline->op2)) {
+			/* taken branch */
+			*exit_if_true = opline->opcode == ZEND_JMPZ;
+			return opline + 1;
+		} else {
+			ZEND_ASSERT(0);
+		}
+	} else  {
+		ZEND_ASSERT(0);
+	}
+	*exit_if_true = 0;
+	return NULL;
+}
 
 #endif /* ZEND_JIT_INTERNAL_H */

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -335,6 +335,7 @@ struct _zend_jit_trace_stack_frame {
 		struct {
 			int8_t              return_value_used;
 			int8_t              nested;
+			int8_t              num_args;
 		};
 		int                     return_ssa_var;
 	};

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -320,7 +320,7 @@ typedef struct _zend_jit_trace_info {
 	uint32_t                  exit_counters; /* offset in exit counters array */
 	uint32_t                  stack_map_size;
 	const void               *code_start;    /* address of native code */
-	zend_jit_trace_exit_info *exit_info;     /* address of native code */
+	zend_jit_trace_exit_info *exit_info;     /* info about side exits */
 	zend_jit_trace_stack     *stack_map;
 	//uint32_t    loop_offset;
 } zend_jit_trace_info;

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -332,7 +332,10 @@ struct _zend_jit_trace_stack_frame {
 	zend_jit_trace_stack_frame *prev;
 	const zend_function        *func;
 	union {
-		int8_t                  return_value_used;
+		struct {
+			int8_t              return_value_used;
+			int8_t              nested;
+		};
 		int                     return_ssa_var;
 	};
 	zend_jit_trace_stack        stack[1];

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -183,7 +183,7 @@ int  ZEND_FASTCALL zend_jit_check_constant(const zval *key);
 	_(BAD_FUNC,          "bad function call") \
 	_(HALT,              "exit from interpreter") \
 	_(COMPILER_ERROR,    "JIT compilation error") \
-	/* no recoverable error (blacklist innediately) */ \
+	/* no recoverable error (blacklist immediately) */ \
 	_(NO_SHM,            "insufficient shared memory") \
 	_(TOO_MANY_TRACES,   "too many traces") \
 	_(TOO_MANY_CHILDREN, "too many side traces") \

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -311,7 +311,7 @@ typedef int32_t zend_jit_trace_stack;
 
 typedef struct _zend_jit_trace_info {
 	uint32_t                  id;            /* trace id */
-	uint32_t                  root;          /* root trace id or sekf id for root traces */
+	uint32_t                  root;          /* root trace id or self id for root traces */
 	uint32_t                  parent;        /* parent trace id or 0 for root traces */
 	uint32_t                  link;          /* link trace id or self id for loop) */
 	uint32_t                  exit_count;    /* number of side exits */

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -162,7 +162,7 @@ int  ZEND_FASTCALL zend_jit_check_constant(const zval *key);
 	_(RECURSIVE_RET,     "recursive return") \
 	_(RETURN,            "return") \
 	_(LINK,              "link to another trace") \
-	/* comiplation and linking successful */ \
+	/* compilation and linking successful */ \
 	_(COMPILED,          "compiled") \
 	_(ALREADY_DONE,      "already prcessed") \
 	/* failures */ \

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -1,0 +1,2619 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend JIT                                                             |
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Dmitry Stogov <dmitry@php.net>                              |
+   +----------------------------------------------------------------------+
+*/
+
+static zend_jit_trace_info *zend_jit_traces = NULL;
+static const void **zend_jit_exit_groups = NULL;
+
+#define ZEND_JIT_COUNTER_NUM   zend_jit_traces[0].root
+#define ZEND_JIT_TRACE_NUM     zend_jit_traces[0].id
+#define ZEND_JIT_EXIT_NUM      zend_jit_traces[0].exit_count
+#define ZEND_JIT_EXIT_COUNTERS zend_jit_traces[0].exit_counters
+
+static int zend_jit_trace_startup(void)
+{
+	zend_jit_traces = (zend_jit_trace_info*)zend_shared_alloc(sizeof(zend_jit_trace_info) * ZEND_JIT_TRACE_MAX_TRACES);
+	if (!zend_jit_traces) {
+		return FAILURE;
+	}
+	zend_jit_exit_groups = (const void**)zend_shared_alloc(sizeof(void*) * (ZEND_JIT_TRACE_MAX_EXITS/ZEND_JIT_EXIT_POINTS_PER_GROUP));
+	if (!zend_jit_exit_groups) {
+		return FAILURE;
+	}
+	ZEND_JIT_TRACE_NUM = 1;
+	ZEND_JIT_COUNTER_NUM = 0;
+	ZEND_JIT_EXIT_NUM = 0;
+	ZEND_JIT_EXIT_COUNTERS = 0;
+	return SUCCESS;
+}
+
+static const void *zend_jit_trace_allocate_exit_group(uint32_t n)
+{
+	dasm_State* dasm_state = NULL;
+	const void *entry;
+	char name[32];
+
+	dasm_init(&dasm_state, DASM_MAXSECTION);
+	dasm_setupglobal(&dasm_state, dasm_labels, zend_lb_MAX);
+	dasm_setup(&dasm_state, dasm_actions);
+	zend_jit_trace_exit_group_stub(&dasm_state, n);
+
+	sprintf(name, "jit$$trace_exit_%d", n);
+	entry = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, name, 0);
+	dasm_free(&dasm_state);
+
+#ifdef HAVE_DISASM
+    if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_ASM) {
+		uint32_t i;
+
+		for (i = 0; i < ZEND_JIT_EXIT_POINTS_PER_GROUP; i++) {
+			sprintf(name, "jit$$trace_exit_%d", n + i);
+			zend_jit_disasm_add_symbol(name, (uintptr_t)entry + (i * ZEND_JIT_EXIT_POINTS_SPACING), ZEND_JIT_EXIT_POINTS_SPACING);
+		}
+	}
+#endif
+
+	return entry;
+}
+
+static const void *zend_jit_trace_allocate_exit_point(uint32_t n)
+{
+	const void *group = NULL;
+
+	if (UNEXPECTED(n >= ZEND_JIT_TRACE_MAX_EXITS)) {
+		return NULL;
+	}
+	do {
+		group = zend_jit_trace_allocate_exit_group(ZEND_JIT_EXIT_NUM);
+		if (!group) {
+			return NULL;
+		}
+		zend_jit_exit_groups[ZEND_JIT_EXIT_NUM / ZEND_JIT_EXIT_POINTS_PER_GROUP] =
+			group;
+		ZEND_JIT_EXIT_NUM += ZEND_JIT_EXIT_POINTS_PER_GROUP;
+	} while (n >= ZEND_JIT_EXIT_NUM);
+    return (const void*)
+		((const char*)group +
+		((n % ZEND_JIT_EXIT_POINTS_PER_GROUP) * ZEND_JIT_EXIT_POINTS_SPACING));
+}
+
+static const void *zend_jit_trace_get_exit_addr(uint32_t n)
+{
+	if (UNEXPECTED(n >= ZEND_JIT_EXIT_NUM)) {
+		return zend_jit_trace_allocate_exit_point(n);
+	}
+    return (const void*)
+		((const char*)zend_jit_exit_groups[n / ZEND_JIT_EXIT_POINTS_PER_GROUP] +
+		((n % ZEND_JIT_EXIT_POINTS_PER_GROUP) * ZEND_JIT_EXIT_POINTS_SPACING));
+}
+
+static uint32_t zend_jit_trace_get_exit_point(const zend_op *from_opline, const zend_op *to_opline, zend_jit_trace_rec *trace)
+{
+	zend_jit_trace_info *t = &zend_jit_traces[ZEND_JIT_TRACE_NUM];
+	uint32_t exit_point;
+	const zend_op_array *op_array = &JIT_G(current_frame)->func->op_array;
+	uint32_t stack_offset = (uint32_t)-1;
+	uint32_t stack_size = op_array->last_var + op_array->T;
+	uint8_t *stack = NULL;
+
+	if (stack_size) {
+		stack = JIT_G(current_frame)->stack;
+		do {
+			if (stack[stack_size-1] != IS_UNKNOWN) {
+				break;
+			}
+			stack_size--;
+		} while (stack_size);
+	}
+
+	/* Try to reuse exit points */
+	if (to_opline != NULL && t->exit_count > 0) {
+		uint32_t i = t->exit_count;
+
+		do {
+			i--;
+			if (stack_size == 0
+			 || (t->exit_info[i].stack_size >= stack_size
+			  && memcmp(t->stack_map + t->exit_info[i].stack_offset, stack, stack_size) == 0)) {
+				stack_offset = t->exit_info[i].stack_offset;
+				if (t->exit_info[i].opline == to_opline) {
+					return i;
+				}
+			}
+		} while (i > 0);
+	}
+
+	exit_point = t->exit_count;
+	if (exit_point < ZEND_JIT_TRACE_MAX_EXITS) {
+		if (stack_size != 0 && stack_offset == (uint32_t)-1) {
+			stack_offset = t->stack_map_size;
+			t->stack_map_size += stack_size;
+			// TODO: reduce number of reallocations ???
+			t->stack_map = erealloc(t->stack_map, t->stack_map_size);
+			memcpy(t->stack_map + stack_offset, stack, stack_size);
+		}
+		t->exit_count++;
+		t->exit_info[exit_point].opline = to_opline;
+		t->exit_info[exit_point].stack_size = stack_size;
+		t->exit_info[exit_point].stack_offset = stack_offset;
+	}
+
+	return exit_point;
+}
+
+static void zend_jit_trace_add_code(const void *start, uint32_t size)
+{
+	zend_jit_trace_info *t = &zend_jit_traces[ZEND_JIT_TRACE_NUM];
+
+	t->code_start = start;
+	t->code_size  = size;
+}
+
+static uint32_t zend_jit_find_trace(const void *addr)
+{
+	uint32_t i;
+
+	for (i = 1; i < ZEND_JIT_TRACE_NUM; i++) {
+		if (zend_jit_traces[i].code_start == addr) {
+			return i;
+		}
+	}
+	ZEND_ASSERT(0);
+	return 0;
+}
+
+static zend_string *zend_jit_trace_name(const zend_op_array *op_array, uint32_t lineno)
+{
+	smart_str buf = {0};
+
+	smart_str_appends(&buf, TRACE_PREFIX);
+	smart_str_append_long(&buf, (zend_long)ZEND_JIT_TRACE_NUM);
+	smart_str_appendc(&buf, '$');
+	if (op_array->function_name) {
+		if (op_array->scope) {
+			smart_str_appendl(&buf, ZSTR_VAL(op_array->scope->name), ZSTR_LEN(op_array->scope->name));
+			smart_str_appends(&buf, "::");
+			smart_str_appendl(&buf, ZSTR_VAL(op_array->function_name), ZSTR_LEN(op_array->function_name));
+		} else {
+			smart_str_appendl(&buf, ZSTR_VAL(op_array->function_name), ZSTR_LEN(op_array->function_name));
+		}
+	} else if (op_array->filename) {
+		smart_str_appendl(&buf, ZSTR_VAL(op_array->filename), ZSTR_LEN(op_array->filename));
+	}
+	smart_str_appendc(&buf, '$');
+	smart_str_append_long(&buf, (zend_long)lineno);
+	smart_str_0(&buf);
+	return buf.s;
+}
+
+static int zend_jit_trace_may_exit(const zend_op_array *op_array, const zend_op *opline, zend_jit_trace_rec *trace)
+{
+	switch (opline->opcode) {
+		case ZEND_IS_IDENTICAL:
+		case ZEND_IS_NOT_IDENTICAL:
+		case ZEND_IS_EQUAL:
+		case ZEND_IS_NOT_EQUAL:
+		case ZEND_IS_SMALLER:
+		case ZEND_IS_SMALLER_OR_EQUAL:
+		case ZEND_CASE:
+		case ZEND_ISSET_ISEMPTY_CV:
+		case ZEND_ISSET_ISEMPTY_VAR:
+		case ZEND_ISSET_ISEMPTY_DIM_OBJ:
+		case ZEND_ISSET_ISEMPTY_PROP_OBJ:
+		case ZEND_ISSET_ISEMPTY_STATIC_PROP:
+		case ZEND_INSTANCEOF:
+		case ZEND_TYPE_CHECK:
+		case ZEND_DEFINED:
+		case ZEND_IN_ARRAY:
+		case ZEND_ARRAY_KEY_EXISTS:
+			if (opline->result_type & (IS_SMART_BRANCH_JMPNZ | IS_SMART_BRANCH_JMPZ)) {
+				/* smart branch */
+				return 1;
+			}
+			break;
+		case ZEND_JMPZNZ:
+		case ZEND_JMPZ:
+		case ZEND_JMPNZ:
+		case ZEND_JMPZ_EX:
+		case ZEND_JMPNZ_EX:
+		case ZEND_JMP_SET:
+		case ZEND_COALESCE:
+		case ZEND_FE_RESET_R:
+		case ZEND_FE_RESET_RW:
+		case ZEND_ASSERT_CHECK:
+		case ZEND_FE_FETCH_R:
+		case ZEND_FE_FETCH_RW:
+		case ZEND_SWITCH_LONG:
+		case ZEND_SWITCH_STRING:
+			/* branch opcdoes */
+			return 1;
+		case ZEND_NEW:
+			if (opline->extended_value == 0 && (opline+1)->opcode == ZEND_DO_FCALL) {
+				/* NEW may skip constructor without argumnts */
+				return 1;
+			}
+			break;
+		case ZEND_CATCH:
+		case ZEND_FAST_CALL:
+		case ZEND_FAST_RET:
+		case ZEND_GENERATOR_CREATE:
+		case ZEND_GENERATOR_RETURN:
+		case ZEND_EXIT:
+		case ZEND_YIELD:
+		case ZEND_YIELD_FROM:
+		case ZEND_INCLUDE_OR_EVAL:
+			/* unsupported */
+			return 1;
+		case ZEND_DO_FCALL:
+			/* potentialy polimorhic call */
+			return 1;
+#if 0
+		case ZEND_DO_UCALL:
+		case ZEND_DO_FCALL_BY_NAME:
+			/* monomorthic call */
+			// TODO: recompilation may change traget ???
+			return 0;
+#endif
+		case ZEND_RETURN_BY_REF:
+		case ZEND_RETURN:
+			/* return */
+			return trace->op == ZEND_JIT_TRACE_BACK && trace->recursive;
+		default:
+			break;
+	}
+	return 0;
+}
+
+#define STACK_VAR_TYPE(_opline, op) \
+	stack[EX_VAR_TO_NUM((_opline)->op.var)]
+
+#if 1
+# define SET_STACK_VAR_TYPE(_opline, op, _type) do { \
+		STACK_VAR_TYPE(_opline, op) = _type; \
+	} while (0)
+# define CHECK_OP_TRACE_TYPE(_opline, op, op_info, op_type) do { \
+		if (op_type != IS_UNKNOWN) { \
+			if ((op_info & (MAY_BE_ANY|MAY_BE_UNDEF)) != (1 << op_type) \
+			 && op_type != STACK_VAR_TYPE(_opline, op)) { \
+				if (!zend_jit_type_guard(&dasm_state, opline, (_opline)->op.var, op_type)) { \
+					goto jit_failure; \
+				} \
+			} \
+			SET_STACK_VAR_TYPE(_opline, op, op_type); \
+			if (op_type < IS_STRING) { \
+				op_info = (1 << op_type); \
+			} else if (op_type != IS_ARRAY) { \
+				op_info = (1 << op_type) | (op_info & (MAY_BE_RC1|MAY_BE_RCN)); \
+			} else { \
+				op_info = MAY_BE_ARRAY | (op_info & (MAY_BE_ARRAY_OF_ANY|MAY_BE_ARRAY_OF_REF|MAY_BE_ARRAY_KEY_ANY|MAY_BE_RC1|MAY_BE_RCN)); \
+			} \
+		} \
+	} while (0)
+# define USE_OP_TRACE_TYPE(_opline, op, op_info) do { \
+		if ((_opline)->op ## _type & (IS_TMP_VAR|IS_VAR|IS_CV)) { \
+			uint8_t type = STACK_VAR_TYPE(_opline, op); \
+			if (type != IS_UNKNOWN \
+			 && (op_info & (MAY_BE_ANY|MAY_BE_UNDEF)) != (1 << type)) { \
+				if (type < IS_STRING) { \
+					op_info = (1 << type); \
+				} else if (type != IS_ARRAY) { \
+					op_info = (1 << type) | (op_info & (MAY_BE_RC1|MAY_BE_RCN)); \
+				} else { \
+					op_info = MAY_BE_ARRAY | (op_info & (MAY_BE_ARRAY_OF_ANY|MAY_BE_ARRAY_OF_REF|MAY_BE_ARRAY_KEY_ANY|MAY_BE_RC1|MAY_BE_RCN)); \
+				} \
+			} \
+		} \
+	} while (0)
+#else
+# define SET_STACK_VAR_TYPE(_var, _type)
+# define CHECK_OP_TRACE_TYPE(op)
+#endif
+
+#define CHECK_OP1_TRACE_TYPE() \
+	CHECK_OP_TRACE_TYPE(opline, op1, op1_info, op1_type)
+#define CHECK_OP2_TRACE_TYPE() \
+	CHECK_OP_TRACE_TYPE(opline, op2, op2_info, op2_type)
+#define CHECK_OP1_DATA_TRACE_TYPE() \
+	CHECK_OP_TRACE_TYPE(opline+1, op1, op1_data_info, op3_type)
+#define USE_OP1_TRACE_TYPE() \
+	USE_OP_TRACE_TYPE(opline, op1, op1_info)
+#define USE_OP2_TRACE_TYPE() \
+	USE_OP_TRACE_TYPE(opline, op2, op2_info)
+#define USE_OP1_DATA_TRACE_TYPE() \
+	USE_OP_TRACE_TYPE(opline+1, op1, op1_data_info)
+#define USE_RES_TRACE_TYPE() \
+	USE_OP_TRACE_TYPE(opline, result, res_use_info)
+#define SET_OP1_STACK_VAR_TYPE(_type) \
+	SET_STACK_VAR_TYPE(opline, op1, _type)
+#define SET_OP2_STACK_VAR_TYPE( _type) \
+	SET_STACK_VAR_TYPE(opline, op2, _type)
+#define SET_OP1_DATA_STACK_VAR_TYPE(_type) \
+	SET_STACK_VAR_TYPE(opline+1, op1, _type)
+#define SET_RES_STACK_VAR_TYPE(_type) \
+	SET_STACK_VAR_TYPE(opline, result, _type)
+#define RESET_OP1_STACK_VAR_TYPE() \
+	SET_OP1_STACK_VAR_TYPE(IS_UNKNOWN)
+#define RESET_OP2_STACK_VAR_TYPE() \
+	SET_OP2_STACK_VAR_TYPE(IS_UNKNOWN)
+#define RESET_RES_STACK_VAR_TYPE() \
+	SET_RES_STACK_VAR_TYPE(IS_UNKNOWN)
+
+static zend_always_inline size_t zend_jit_trace_frame_size(const zend_op_array *op_array)
+{
+	return offsetof(zend_jit_trace_stack_frame, stack) + ZEND_MM_ALIGNED_SIZE(op_array->last_var + op_array->T);
+}
+
+static zend_jit_trace_stack_frame* zend_jit_trace_allocate_stack(zend_jit_trace_rec *trace_buffer)
+{
+	int level, ret_level, call_level;
+	size_t stack_top, stack_size, stack_bottom;
+	zend_jit_trace_rec *p;
+	const zend_op_array *op_array;
+	uint8_t *stack;
+
+	p = trace_buffer;
+	ZEND_ASSERT(p->op == ZEND_JIT_TRACE_START);
+	op_array = p->op_array;
+	stack_size = stack_top = zend_jit_trace_frame_size(op_array);
+	stack_bottom = 0;
+	level = ret_level = call_level = 0;
+	p += ZEND_JIT_TRACE_START_REC_SIZE;
+	for (;;p++) {
+		if (p->op == ZEND_JIT_TRACE_INIT_CALL) {
+			if (p->func->type == ZEND_USER_FUNCTION) {
+				if (level == 0) {
+					call_level++;
+				}
+				level++;
+				stack_top += zend_jit_trace_frame_size(p->op_array);
+				if (stack_top > stack_size) {
+					stack_size = stack_top;
+				}
+			}
+		} else if (p->op == ZEND_JIT_TRACE_ENTER) {
+			op_array = p->op_array;
+			if (level == 0) {
+				if (call_level) {
+					call_level--;
+				} else {
+					level++;
+					stack_top += zend_jit_trace_frame_size(op_array);
+					if (stack_top > stack_size) {
+						stack_size = stack_top;
+					}
+				}
+			}
+		} else if (p->op == ZEND_JIT_TRACE_BACK) {
+			stack_top -= zend_jit_trace_frame_size(op_array);
+			if (level == 0) {
+				ZEND_ASSERT(stack_top == 0);
+				call_level = 0;
+				ret_level++;
+				op_array = p->op_array;
+				stack_top = zend_jit_trace_frame_size(op_array);
+				stack_bottom += stack_top;
+				if (stack_top > stack_size) {
+					stack_size = stack_top;
+				}
+			} else {
+				level--;
+				op_array = p->op_array;
+			}
+		} else if (p->op == ZEND_JIT_TRACE_END) {
+			break;
+		}
+	}
+
+	stack = zend_arena_alloc(&CG(arena), stack_bottom + stack_size);
+	return (zend_jit_trace_stack_frame*)(stack + stack_bottom);
+}
+
+static zend_jit_trace_stack_frame* zend_jit_trace_call_frame(zend_jit_trace_stack_frame *frame, const zend_op_array *op_array)
+{
+	return (zend_jit_trace_stack_frame*)((char*)frame + zend_jit_trace_frame_size(op_array));
+}
+
+static zend_jit_trace_stack_frame* zend_jit_trace_ret_frame(zend_jit_trace_stack_frame *frame, const zend_op_array *op_array)
+{
+	return (zend_jit_trace_stack_frame*)((char*)frame - zend_jit_trace_frame_size(op_array));
+}
+
+static void zend_jit_trace_send_type(const zend_op *opline, zend_jit_trace_stack_frame *call, zend_uchar type)
+{
+	uint8_t *stack = call->stack;
+	const zend_op_array *op_array = &call->func->op_array;
+	uint32_t arg_num = opline->op2.num;
+
+	if (arg_num > op_array->num_args) {
+		return;
+	}
+	if (op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS) {
+		zend_arg_info *arg_info;
+
+		ZEND_ASSERT(arg_num <= op_array->num_args);
+		arg_info = &op_array->arg_info[arg_num-1];
+
+		if (ZEND_TYPE_IS_SET(arg_info->type)) {
+			if (!(ZEND_TYPE_FULL_MASK(arg_info->type) & (1u << type))) {
+				return;
+			}
+		}
+	}
+	SET_STACK_VAR_TYPE(opline, result, type);
+}
+
+static zend_ssa *zend_jit_trace_build_ssa(const zend_op_array *op_array, zend_script *script)
+{
+	zend_jit_op_array_trace_extension *jit_extension;
+	zend_ssa *ssa;
+
+	jit_extension =
+		(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+
+	memset(&jit_extension->func_info, 0, sizeof(jit_extension->func_info));
+	jit_extension->func_info.num_args = -1;
+	jit_extension->func_info.return_value_used = -1;
+	ssa = &jit_extension->func_info.ssa;
+	if (zend_jit_op_array_analyze1(op_array, script, ssa) != SUCCESS) {
+		return NULL;
+	}
+
+	if (zend_jit_level >= ZEND_JIT_LEVEL_OPT_FUNC) {
+		if (zend_jit_level >= ZEND_JIT_LEVEL_OPT_FUNCS) {
+			if (zend_analyze_calls(&CG(arena), script, ZEND_CALL_TREE, (zend_op_array*)op_array, &jit_extension->func_info) != SUCCESS) {
+				return NULL;
+			}
+			jit_extension->func_info.call_map = zend_build_call_map(&CG(arena), &jit_extension->func_info, (zend_op_array*)op_array);
+			if (op_array->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
+				zend_init_func_return_info(op_array, script, &jit_extension->func_info.return_info);
+			}
+		}
+
+		if (zend_jit_op_array_analyze2(op_array, script, ssa) != SUCCESS) {
+			return NULL;
+		}
+
+		if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_SSA) {
+			zend_dump_op_array(op_array, ZEND_DUMP_HIDE_UNREACHABLE|ZEND_DUMP_RC_INFERENCE|ZEND_DUMP_SSA, "JIT", ssa);
+		}
+	}
+
+	return ssa;
+}
+
+static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t parent_trace, uint32_t exit_num)
+{
+	const void *handler = NULL;
+	dasm_State* dasm_state = NULL;
+	zend_script *script = NULL;
+	zend_lifetime_interval **ra = NULL;
+	zend_string *name = NULL;
+	void *checkpoint;
+	const zend_op_array *op_array;
+	zend_ssa *ssa;
+	zend_jit_trace_rec *p;
+	int call_level = -1; // TODO: proper support for inlined functions ???
+	zend_jit_op_array_trace_extension *jit_extension;
+	int num_op_arrays = 0;
+	zend_jit_trace_info *t;
+	const  zend_op_array *op_arrays[ZEND_JIT_TRACE_MAX_FUNCS];
+	zend_uchar smart_branch_opcode;
+	const void *exit_addr;
+	uint32_t op1_info, op1_def_info, op2_info, res_info, res_use_info, op1_data_info;
+	zend_bool send_result;
+	zend_jit_addr op1_addr, op1_def_addr, op2_addr, op2_def_addr, res_addr;
+	zend_class_entry *ce;
+	uint32_t i;
+	zend_jit_trace_stack_frame *frame, *top, *call;
+	uint8_t *stack;
+	zend_uchar res_type = IS_UNKNOWN;
+	const zend_op *opline;
+
+	checkpoint = zend_arena_checkpoint(CG(arena));
+
+	p = trace_buffer;
+	ZEND_ASSERT(p->op == ZEND_JIT_TRACE_START);
+	op_array = p->op_array;
+	JIT_G(current_frame) = frame = zend_jit_trace_allocate_stack(trace_buffer);
+	top = zend_jit_trace_call_frame(frame, op_array);
+	frame->call = NULL;
+	frame->prev = NULL;
+	frame->func = (const zend_function*)op_array;
+	frame->return_value_used = -1;
+	stack = frame->stack;
+	i = 0;
+	if (parent_trace) {
+		i = MIN(zend_jit_traces[parent_trace].exit_info[exit_num].stack_size,
+			op_array->last_var + op_array->T);
+		if (i) {
+			memcpy(stack,
+				zend_jit_traces[parent_trace].stack_map +
+				zend_jit_traces[parent_trace].exit_info[exit_num].stack_offset,
+				i);
+		}
+	}
+	while (i < op_array->last_var + op_array->T) {
+		stack[i] = IS_UNKNOWN;
+		i++;
+	}
+	opline = ((zend_jit_trace_start_rec*)p)->opline;
+	name = zend_jit_trace_name(op_array, opline->lineno);
+	p += ZEND_JIT_TRACE_START_REC_SIZE;
+
+	dasm_init(&dasm_state, DASM_MAXSECTION);
+	dasm_setupglobal(&dasm_state, dasm_labels, zend_lb_MAX);
+	dasm_setup(&dasm_state, dasm_actions);
+
+	/* Remember op_array to cleanup */
+	op_arrays[num_op_arrays++] = op_array;
+
+	/* Build SSA */
+	ssa = zend_jit_trace_build_ssa(op_array, script);
+	if (!ssa) {
+		goto jit_failure;
+	}
+
+	// TODO: register allocation ???
+
+	dasm_growpc(&dasm_state, 1); /* trace needs just one global lable for loop */
+
+	zend_jit_align_func(&dasm_state);
+	if (!parent_trace) {
+		zend_jit_prologue(&dasm_state);
+	}
+	zend_jit_trace_begin(&dasm_state, ZEND_JIT_TRACE_NUM);
+
+	if (!parent_trace) {
+		zend_jit_set_opline(&dasm_state, opline);
+	} else {
+		if (!((uintptr_t)zend_jit_traces[parent_trace].exit_info[exit_num].opline & ~(ZEND_JIT_EXIT_JITED|ZEND_JIT_EXIT_BLACKLISTED))) {
+			zend_jit_trace_opline_guard(&dasm_state, opline);
+			zend_jit_set_opline(&dasm_state, opline);
+		} else {
+			zend_jit_reset_opline(&dasm_state, opline);
+		}
+	}
+
+	if (trace_buffer->stop == ZEND_JIT_TRACE_STOP_LOOP
+	 || trace_buffer->stop == ZEND_JIT_TRACE_STOP_RECURSIVE_CALL
+	 || trace_buffer->stop == ZEND_JIT_TRACE_STOP_RECURSIVE_RET) {
+		zend_jit_label(&dasm_state, 0); /* start of of trace loop */
+		if (trace_buffer->stop != ZEND_JIT_TRACE_STOP_RECURSIVE_RET) {
+			// TODO: interupt exit may require deoptimization through side exit ???
+			zend_jit_check_timeout(&dasm_state, opline);
+		}
+	}
+
+	for (;;p++) {
+		if (p->op == ZEND_JIT_TRACE_VM) {
+			uint8_t op1_type = p->op1_type;
+			uint8_t op2_type = p->op2_type;
+			uint8_t op3_type = p->op3_type;
+
+			opline = p->opline;
+			if (op1_type & IS_TRACE_REFERENCE) {
+				op1_type = IS_UNKNOWN;
+			}
+			if (op2_type & IS_TRACE_REFERENCE) {
+				op2_type = IS_UNKNOWN;
+			}
+			if (op3_type & IS_TRACE_REFERENCE) {
+				op3_type = IS_UNKNOWN;
+			}
+
+			if ((p+1)->op == ZEND_JIT_TRACE_OP1_TYPE) {
+				// TODO: support for recorded classes ???
+				p++;
+			}
+			if ((p+1)->op == ZEND_JIT_TRACE_OP2_TYPE) {
+				// TODO: support for recorded classes ???
+				p++;
+			}
+
+#if 0
+			// TODO: call level calculation doesn't work for traces ???
+			switch (opline->opcode) {
+				case ZEND_INIT_FCALL:
+				case ZEND_INIT_FCALL_BY_NAME:
+				case ZEND_INIT_NS_FCALL_BY_NAME:
+				case ZEND_INIT_METHOD_CALL:
+				case ZEND_INIT_DYNAMIC_CALL:
+				case ZEND_INIT_STATIC_METHOD_CALL:
+				case ZEND_INIT_USER_CALL:
+				case ZEND_NEW:
+					call_level++;
+			}
+#endif
+
+			if (zend_jit_level >= ZEND_JIT_LEVEL_INLINE) {
+				switch (opline->opcode) {
+					case ZEND_PRE_INC:
+					case ZEND_PRE_DEC:
+					case ZEND_POST_INC:
+					case ZEND_POST_DEC:
+						if (opline->op1_type != IS_CV) {
+							break;
+						}
+						op1_info = OP1_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						stack[EX_VAR_TO_NUM(opline->op1.var)] = IS_UNKNOWN;
+						if (!(op1_info & MAY_BE_LONG)) {
+							break;
+						}
+						if (opline->result_type != IS_UNUSED) {
+							res_use_info = RES_USE_INFO();
+							USE_RES_TRACE_TYPE();
+							res_info = RES_INFO();
+							res_addr = RES_REG_ADDR();
+						} else {
+							res_use_info = -1;
+							res_info = -1;
+							res_addr = 0;
+						}
+						op1_def_info = OP1_DEF_INFO();
+						if (!zend_jit_inc_dec(&dasm_state, opline, op_array,
+								op1_info, OP1_REG_ADDR(),
+								op1_def_info, OP1_DEF_REG_ADDR(),
+								res_use_info, res_info,
+								res_addr,
+								(op1_def_info & MAY_BE_LONG) && (op1_def_info & MAY_BE_DOUBLE) && zend_may_overflow(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_BW_OR:
+					case ZEND_BW_AND:
+					case ZEND_BW_XOR:
+					case ZEND_SL:
+					case ZEND_SR:
+					case ZEND_MOD:
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						if ((op1_info & MAY_BE_UNDEF) || (op2_info & MAY_BE_UNDEF)) {
+							break;
+						}
+						if (!(op1_info & MAY_BE_LONG)
+						 || !(op2_info & MAY_BE_LONG)) {
+							break;
+						}
+						if (opline->result_type == IS_TMP_VAR
+						 && (p+1)->op == ZEND_JIT_TRACE_VM
+						 && (p+1)->opline == opline + 1
+						 && (opline+1)->opcode == ZEND_SEND_VAL
+						 && (opline+1)->op1_type == IS_TMP_VAR
+						 && (opline+1)->op1.var == opline->result.var) {
+							p++;
+							if (frame->call) {
+								uint8_t res_type = p->op1_type;
+								if (res_type & IS_TRACE_REFERENCE) {
+									res_type = IS_UNKNOWN;;
+								}
+								if (res_type != IS_UNKNOWN) {
+									zend_jit_trace_send_type(opline+1, frame->call, res_type);
+								}
+							}
+							while ((p+1)->op == ZEND_JIT_TRACE_OP1_TYPE ||
+							      (p+1)->op == ZEND_JIT_TRACE_OP2_TYPE) {
+								p++;
+							}
+							send_result = 1;
+							res_use_info = -1;
+							res_addr = 0; /* set inside backend */
+						} else {
+							send_result = 0;
+							res_use_info = RES_USE_INFO();
+							USE_RES_TRACE_TYPE();
+							res_addr = RES_REG_ADDR();
+						}
+						res_info = RES_INFO();
+						if (!zend_jit_long_math(&dasm_state, opline, op_array,
+								op1_info, OP1_RANGE(), OP1_REG_ADDR(),
+								op2_info, OP2_RANGE(), OP2_REG_ADDR(),
+								res_use_info, res_info, res_addr,
+								send_result,
+								zend_may_throw(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_ADD:
+					case ZEND_SUB:
+					case ZEND_MUL:
+//					case ZEND_DIV: // TODO: check for division by zero ???
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						if ((op1_info & MAY_BE_UNDEF) || (op2_info & MAY_BE_UNDEF)) {
+							break;
+						}
+						if (!(op1_info & (MAY_BE_LONG|MAY_BE_DOUBLE)) ||
+						    !(op2_info & (MAY_BE_LONG|MAY_BE_DOUBLE))) {
+							break;
+						}
+						if (opline->result_type == IS_TMP_VAR
+						 && (p+1)->op == ZEND_JIT_TRACE_VM
+						 && (p+1)->opline == opline + 1
+						 && (opline+1)->opcode == ZEND_SEND_VAL
+						 && (opline+1)->op1_type == IS_TMP_VAR
+						 && (opline+1)->op1.var == opline->result.var) {
+							p++;
+							if (frame->call
+							 && frame->call->func->type == ZEND_USER_FUNCTION) {
+								uint8_t res_type = p->op1_type;
+								if (res_type & IS_TRACE_REFERENCE) {
+									res_type = IS_UNKNOWN;;
+								}
+								if (res_type != IS_UNKNOWN) {
+									zend_jit_trace_send_type(opline+1, frame->call, res_type);
+								}
+							}
+							while ((p+1)->op == ZEND_JIT_TRACE_OP1_TYPE ||
+							      (p+1)->op == ZEND_JIT_TRACE_OP2_TYPE) {
+								p++;
+							}
+							send_result = 1;
+							res_use_info = -1;
+							res_addr = 0; /* set inside backend */
+						} else {
+							send_result = 0;
+							res_use_info = RES_USE_INFO();
+							USE_RES_TRACE_TYPE();
+							res_addr = RES_REG_ADDR();
+						}
+						res_info = RES_INFO();
+						if (!zend_jit_math(&dasm_state, opline, op_array,
+								op1_info, OP1_REG_ADDR(),
+								op2_info, OP2_REG_ADDR(),
+								res_use_info, res_info, res_addr,
+								send_result,
+								(res_info & MAY_BE_LONG) && (res_info & MAY_BE_DOUBLE) && zend_may_overflow(opline, op_array, ssa),
+								zend_may_throw(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_CONCAT:
+					case ZEND_FAST_CONCAT:
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						if ((op1_info & MAY_BE_UNDEF) || (op2_info & MAY_BE_UNDEF)) {
+							break;
+						}
+						if (!(op1_info & MAY_BE_STRING) ||
+						    !(op2_info & MAY_BE_STRING)) {
+							break;
+						}
+						if (opline->result_type == IS_TMP_VAR
+						 && (p+1)->op == ZEND_JIT_TRACE_VM
+						 && (p+1)->opline == opline + 1
+						 && (opline+1)->opcode == ZEND_SEND_VAL
+						 && (opline+1)->op1_type == IS_TMP_VAR
+						 && (opline+1)->op1.var == opline->result.var) {
+							p++;
+							if (frame->call
+							 && frame->call->func->type == ZEND_USER_FUNCTION) {
+								uint8_t res_type = p->op1_type;
+								if (res_type & IS_TRACE_REFERENCE) {
+									res_type = IS_UNKNOWN;;
+								}
+								if (res_type != IS_UNKNOWN) {
+									zend_jit_trace_send_type(opline+1, frame->call, res_type);
+								}
+							}
+							while ((p+1)->op == ZEND_JIT_TRACE_OP1_TYPE ||
+							      (p+1)->op == ZEND_JIT_TRACE_OP2_TYPE) {
+								p++;
+							}
+							send_result = 1;
+						} else {
+							send_result = 0;
+						}
+						res_info = RES_INFO();
+						if (!zend_jit_concat(&dasm_state, opline, op_array,
+								op1_info, op2_info, res_info, send_result,
+								zend_may_throw(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_ASSIGN_OP:
+						if (opline->extended_value == ZEND_POW
+						 || opline->extended_value == ZEND_DIV) {
+							// TODO: check for division by zero ???
+							break;
+						}
+						if (opline->op1_type != IS_CV || opline->result_type != IS_UNUSED) {
+							break;
+						}
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						if ((op1_info & MAY_BE_UNDEF) || (op2_info & MAY_BE_UNDEF)) {
+							break;
+						}
+						if (opline->extended_value == ZEND_ADD
+						 || opline->extended_value == ZEND_SUB
+						 || opline->extended_value == ZEND_MUL
+						 || opline->extended_value == ZEND_DIV) {
+							if (!(op1_info & (MAY_BE_LONG|MAY_BE_DOUBLE))
+							 || !(op2_info & (MAY_BE_LONG|MAY_BE_DOUBLE))) {
+								break;
+							}
+						} else if (opline->extended_value == ZEND_BW_OR
+						 || opline->extended_value == ZEND_BW_AND
+						 || opline->extended_value == ZEND_BW_XOR
+						 || opline->extended_value == ZEND_SL
+						 || opline->extended_value == ZEND_SR
+						 || opline->extended_value == ZEND_MOD) {
+							if (!(op1_info & MAY_BE_LONG)
+							 || !(op2_info & MAY_BE_LONG)) {
+								break;
+							}
+						} else if (opline->extended_value == ZEND_CONCAT) {
+							if (!(op1_info & MAY_BE_STRING)
+							 || !(op2_info & MAY_BE_STRING)) {
+								break;
+							}
+						}
+						op1_def_info = OP1_DEF_INFO();
+						if (!zend_jit_assign_op(&dasm_state, opline, op_array,
+								op1_info, op1_def_info, OP1_RANGE(),
+								op2_info, OP2_RANGE(),
+								(op1_def_info & MAY_BE_LONG) && (op1_def_info & MAY_BE_DOUBLE) && zend_may_overflow(opline, op_array, ssa),
+								zend_may_throw(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_ASSIGN_DIM_OP:
+						if (opline->extended_value == ZEND_POW
+						 || opline->extended_value == ZEND_DIV) {
+							// TODO: check for division by zero ???
+							break;
+						}
+						if (opline->op1_type != IS_CV || opline->result_type != IS_UNUSED) {
+							break;
+						}
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						op1_data_info = OP1_DATA_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						CHECK_OP1_DATA_TRACE_TYPE();
+						op1_def_info = OP1_DEF_INFO();
+						if (!zend_jit_assign_dim_op(&dasm_state, opline, op_array,
+								op1_info, op1_def_info, op2_info,
+								op1_data_info, OP1_DATA_RANGE(),
+								zend_may_throw(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_ASSIGN_DIM:
+						if (opline->op1_type != IS_CV) {
+							break;
+						}
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						op1_data_info = OP1_DATA_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						CHECK_OP1_DATA_TRACE_TYPE();
+						if (!zend_jit_assign_dim(&dasm_state, opline, op_array,
+								op1_info, op2_info, op1_data_info,
+								zend_may_throw(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_ASSIGN:
+						if (opline->op1_type != IS_CV) {
+							break;
+						}
+						if (opline->result_type == IS_UNUSED) {
+							res_addr = 0;
+							res_info = -1;
+						} else {
+							res_addr = RES_REG_ADDR();
+							res_info = RES_INFO();
+						}
+						op2_addr = OP2_REG_ADDR();
+						if (ra
+						 && ssa->ops[opline - op_array->opcodes].op2_def >= 0
+						 && !ssa->vars[ssa->ops[opline - op_array->opcodes].op2_def].no_val) {
+							op2_def_addr = OP2_DEF_REG_ADDR();
+						} else {
+							op2_def_addr = op2_addr;
+						}
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						op1_def_info = OP1_DEF_INFO();
+						USE_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						if (!zend_jit_assign(&dasm_state, opline, op_array,
+								op1_info, OP1_REG_ADDR(),
+								op1_def_info, OP1_DEF_REG_ADDR(),
+								op2_info, op2_addr, op2_def_addr,
+								res_info, res_addr,
+								zend_may_throw(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_QM_ASSIGN:
+						op1_addr = OP1_REG_ADDR();
+						if (ra
+						 && ssa->ops[opline - op_array->opcodes].op1_def >= 0
+						 && !ssa->vars[ssa->ops[opline - op_array->opcodes].op1_def].no_val) {
+							op1_def_addr = OP1_DEF_REG_ADDR();
+						} else {
+							op1_def_addr = op1_addr;
+						}
+						op1_info = OP1_INFO();
+						res_info = RES_INFO();
+						CHECK_OP1_TRACE_TYPE();//???USE_OP1_TRACE_TYPE();
+						if (!zend_jit_qm_assign(&dasm_state, opline, op_array,
+								op1_info, op1_addr, op1_def_addr,
+								res_info, RES_REG_ADDR())) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_INIT_FCALL:
+					case ZEND_INIT_FCALL_BY_NAME:
+						if (!zend_jit_init_fcall(&dasm_state, opline, ssa->cfg.map ? ssa->cfg.map[opline - op_array->opcodes] : -1, op_array, ssa, call_level, p + 1)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_SEND_VAL:
+					case ZEND_SEND_VAL_EX:
+						if (opline->opcode == ZEND_SEND_VAL_EX
+						 && opline->op2.num > MAX_ARG_FLAG_NUM) {
+							break;
+						}
+						op1_info = OP1_INFO();
+						CHECK_OP1_TRACE_TYPE(); //???USE_OP1_TRACE_TYPE();
+						if (!zend_jit_send_val(&dasm_state, opline, op_array,
+								op1_info, OP1_REG_ADDR())) {
+							goto jit_failure;
+						}
+						if (frame->call
+						 && frame->call->func->type == ZEND_USER_FUNCTION) {
+							if (opline->op1_type == IS_CONST) {
+								zend_jit_trace_send_type(opline, frame->call, Z_TYPE_P(RT_CONSTANT(opline, opline->op1)));
+							} else if (op1_type != IS_UNKNOWN) {
+								zend_jit_trace_send_type(opline, frame->call, op1_type);
+							}
+						}
+						goto done;
+					case ZEND_SEND_REF:
+						op1_info = OP1_INFO();
+						USE_OP1_TRACE_TYPE();
+						if (!zend_jit_send_ref(&dasm_state, opline, op_array,
+								op1_info, 0)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_SEND_VAR:
+					case ZEND_SEND_VAR_EX:
+					case ZEND_SEND_VAR_NO_REF:
+					case ZEND_SEND_VAR_NO_REF_EX:
+						if ((opline->opcode == ZEND_SEND_VAR_EX
+						  || opline->opcode == ZEND_SEND_VAR_NO_REF_EX)
+						 && opline->op2.num > MAX_ARG_FLAG_NUM) {
+							break;
+						}
+						op1_addr = OP1_REG_ADDR();
+						if (ra
+						 && ssa->ops[opline - op_array->opcodes].op1_def >= 0
+						 && !ssa->vars[ssa->ops[opline - op_array->opcodes].op1_def].no_val) {
+							op1_def_addr = OP1_DEF_REG_ADDR();
+						} else {
+							op1_def_addr = op1_addr;
+						}
+						op1_info = OP1_INFO();
+						CHECK_OP1_TRACE_TYPE(); //???USE_OP1_TRACE_TYPE();
+						if (!zend_jit_send_var(&dasm_state, opline, op_array,
+								op1_info, op1_addr, op1_def_addr)) {
+							goto jit_failure;
+						}
+						if (frame->call
+						 && frame->call->func->type == ZEND_USER_FUNCTION) {
+							if (opline->opcode == ZEND_SEND_VAR_EX
+							 && ARG_SHOULD_BE_SENT_BY_REF(frame->call->func, opline->op2.num)) {
+								// TODO: this may require invalidation, if caller is changed ???
+								goto done;
+							}
+							if (op1_type != IS_UNKNOWN) {
+								zend_jit_trace_send_type(opline, frame->call, op1_type);
+							}
+						}
+						goto done;
+					case ZEND_DO_UCALL:
+					case ZEND_DO_ICALL:
+					case ZEND_DO_FCALL_BY_NAME:
+					case ZEND_DO_FCALL:
+						if (!zend_jit_do_fcall(&dasm_state, opline, op_array, ssa, call_level, -1, p + 1)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_IS_EQUAL:
+					case ZEND_IS_NOT_EQUAL:
+					case ZEND_IS_SMALLER:
+					case ZEND_IS_SMALLER_OR_EQUAL:
+					case ZEND_CASE:
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						if ((opline->result_type & (IS_SMART_BRANCH_JMPZ|IS_SMART_BRANCH_JMPNZ)) != 0) {
+							zend_bool exit_if_true = 0;
+							const zend_op *exit_opline = zend_jit_trace_get_exit_opline(p + 1, opline + 1, &exit_if_true);
+							uint32_t exit_point = zend_jit_trace_get_exit_point(opline, exit_opline, p + 1);
+
+							exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+							if (!exit_addr) {
+								goto jit_failure;
+							}
+							smart_branch_opcode = exit_if_true ? ZEND_JMPNZ : ZEND_JMPZ;
+						} else {
+							smart_branch_opcode = 0;
+							exit_addr = NULL;
+						}
+						if (!zend_jit_cmp(&dasm_state, opline, op_array,
+								op1_info, OP1_REG_ADDR(),
+								op2_info, OP2_REG_ADDR(),
+								RES_REG_ADDR(),
+								zend_may_throw(opline, op_array, ssa),
+								smart_branch_opcode, -1, -1, exit_addr)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_IS_IDENTICAL:
+					case ZEND_IS_NOT_IDENTICAL:
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						if ((opline->result_type & (IS_SMART_BRANCH_JMPZ|IS_SMART_BRANCH_JMPNZ)) != 0) {
+							zend_bool exit_if_true = 0;
+							const zend_op *exit_opline = zend_jit_trace_get_exit_opline(p + 1, opline + 1, &exit_if_true);
+							uint32_t exit_point = zend_jit_trace_get_exit_point(opline, exit_opline, p + 1);
+
+							exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+							if (!exit_addr) {
+								goto jit_failure;
+							}
+							if (opline->opcode == ZEND_IS_NOT_IDENTICAL) {
+								exit_if_true = !exit_if_true;
+							}
+							smart_branch_opcode = exit_if_true ? ZEND_JMPNZ : ZEND_JMPZ;
+						} else {
+							smart_branch_opcode = 0;
+							exit_addr = NULL;
+						}
+						if (!zend_jit_identical(&dasm_state, opline, op_array,
+								op1_info, OP1_REG_ADDR(),
+								op2_info, OP2_REG_ADDR(),
+								RES_REG_ADDR(),
+								zend_may_throw(opline, op_array, ssa),
+								smart_branch_opcode, -1, -1, exit_addr)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_DEFINED:
+						if ((opline->result_type & (IS_SMART_BRANCH_JMPZ|IS_SMART_BRANCH_JMPNZ)) != 0) {
+							zend_bool exit_if_true = 0;
+							const zend_op *exit_opline = zend_jit_trace_get_exit_opline(p + 1, opline + 1, &exit_if_true);
+							uint32_t exit_point = zend_jit_trace_get_exit_point(opline, exit_opline, p + 1);
+
+							exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+							if (!exit_addr) {
+								goto jit_failure;
+							}
+							smart_branch_opcode = exit_if_true ? ZEND_JMPNZ : ZEND_JMPZ;
+						} else {
+							smart_branch_opcode = 0;
+							exit_addr = NULL;
+						}
+						if (!zend_jit_defined(&dasm_state, opline, op_array, smart_branch_opcode, -1, -1, exit_addr)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_TYPE_CHECK:
+						if (opline->extended_value == MAY_BE_RESOURCE) {
+							// TODO: support for is_resource() ???
+							break;
+						}
+						op1_info = OP1_INFO();
+						USE_OP1_TRACE_TYPE();
+						if ((opline->result_type & (IS_SMART_BRANCH_JMPZ|IS_SMART_BRANCH_JMPNZ)) != 0) {
+							zend_bool exit_if_true = 0;
+							const zend_op *exit_opline = zend_jit_trace_get_exit_opline(p + 1, opline + 1, &exit_if_true);
+							uint32_t exit_point = zend_jit_trace_get_exit_point(opline, exit_opline, p + 1);
+
+							exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+							if (!exit_addr) {
+								goto jit_failure;
+							}
+							smart_branch_opcode = exit_if_true ? ZEND_JMPNZ : ZEND_JMPZ;
+						} else {
+							smart_branch_opcode = 0;
+							exit_addr = NULL;
+						}
+						if (!zend_jit_type_check(&dasm_state, opline, op_array, op1_info, smart_branch_opcode, -1, -1, exit_addr)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_RETURN:
+						op1_info = OP1_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						if (opline->op1_type == IS_CONST) {
+							res_type = Z_TYPE_P(RT_CONSTANT(opline, opline->op1));
+						} else if (op1_type != IS_UNKNOWN) {
+							res_type = op1_type;
+						}
+						if (op_array->type == ZEND_EVAL_CODE
+						 // TODO: support for top-level code
+						 || !op_array->function_name
+						 // TODO: support for IS_UNDEF ???
+						 || (op1_info & MAY_BE_UNDEF)) {
+							if (!zend_jit_tail_handler(&dasm_state, opline)) {
+								goto jit_failure;
+							}
+						} else {
+							int j;
+
+							if (!zend_jit_return(&dasm_state, opline, op_array,
+									op1_info, OP1_REG_ADDR())) {
+								goto jit_failure;
+							}
+						    if (!zend_jit_leave_frame(&dasm_state)) {
+								goto jit_failure;
+						    }
+							for (j = 0 ; j < op_array->last_var; j++) {
+								uint32_t info = zend_ssa_cv_info(opline, op_array, ssa, j);
+								zend_uchar type = stack[j];
+
+								if (type != IS_UNKNOWN) {
+									if (type < IS_STRING) {
+										info = (1 << type);
+									} else if (type != IS_ARRAY) {
+										info = (1 << type) | (info & (MAY_BE_RC1|MAY_BE_RCN));
+									} else {
+										info = MAY_BE_ARRAY | (info & (MAY_BE_ARRAY_OF_ANY|MAY_BE_ARRAY_OF_REF|MAY_BE_ARRAY_KEY_ANY|MAY_BE_RC1|MAY_BE_RCN));
+									}
+								}
+								if (info & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE|MAY_BE_REF)) {
+									if (!zend_jit_free_cv(&dasm_state, opline, op_array, info, j)) {
+										goto jit_failure;
+									}
+								}
+							}
+							if (!zend_jit_leave_func(&dasm_state, opline, op_array, p + 1)) {
+								goto jit_failure;
+							}
+						}
+						goto done;
+					case ZEND_BOOL:
+					case ZEND_BOOL_NOT:
+						op1_info = OP1_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						if (!zend_jit_bool_jmpznz(&dasm_state, opline, op_array,
+								op1_info, OP1_REG_ADDR(), RES_REG_ADDR(),
+								-1, -1,
+								zend_may_throw(opline, op_array, ssa),
+								opline->opcode, NULL)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_JMPZ:
+					case ZEND_JMPNZ:
+						if (/*opline > op_array->opcodes + ssa->cfg.blocks[b].start && ??? */
+						    opline->op1_type == IS_TMP_VAR &&
+						    ((opline-1)->result_type & (IS_SMART_BRANCH_JMPZ|IS_SMART_BRANCH_JMPNZ)) != 0) {
+							/* smart branch */
+							break;
+						}
+						/* break missing intentionally */
+					case ZEND_JMPZNZ:
+					case ZEND_JMPZ_EX:
+					case ZEND_JMPNZ_EX:
+						if (opline->result_type == IS_UNDEF) {
+							res_addr = 0;
+						} else {
+							res_addr = RES_REG_ADDR();
+						}
+						op1_info = OP1_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						if ((p+1)->op == ZEND_JIT_TRACE_VM || (p+1)->op == ZEND_JIT_TRACE_END) {
+							const zend_op *exit_opline = NULL;
+							uint32_t exit_point;
+
+							if ((p+1)->opline == OP_JMP_ADDR(opline, opline->op2)) {
+								/* taken branch */
+								if (opline->opcode == ZEND_JMPNZ_EX) {
+									smart_branch_opcode = ZEND_JMPZ_EX;
+								} else if (opline->opcode == ZEND_JMPZ_EX) {
+									smart_branch_opcode = ZEND_JMPNZ_EX;
+								} else if (opline->opcode == ZEND_JMPNZ) {
+									smart_branch_opcode = ZEND_JMPZ;
+								} else {
+									smart_branch_opcode = ZEND_JMPNZ;
+								}
+								exit_opline = (opline->opcode == ZEND_JMPZNZ) ?
+									ZEND_OFFSET_TO_OPLINE(opline, opline->extended_value) :
+									opline + 1;
+							} else if (opline->opcode == ZEND_JMPZNZ) {
+								ZEND_ASSERT((p+1)->opline == ZEND_OFFSET_TO_OPLINE(opline, opline->extended_value));
+								smart_branch_opcode = ZEND_JMPZ;
+								exit_opline = OP_JMP_ADDR(opline, opline->op2);
+							} else if ((p+1)->opline == opline + 1) {
+								/* not taken branch */
+								smart_branch_opcode = opline->opcode;
+								exit_opline = OP_JMP_ADDR(opline, opline->op2);
+							} else {
+								ZEND_ASSERT(0);
+							}
+							exit_point = zend_jit_trace_get_exit_point(opline, exit_opline, p+1);
+							exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+							if (!exit_addr) {
+								goto jit_failure;
+							}
+						} else  {
+							ZEND_ASSERT(0);
+						}
+						if (!zend_jit_bool_jmpznz(&dasm_state, opline, op_array,
+								op1_info, OP1_REG_ADDR(), res_addr,
+								-1, -1,
+								zend_may_throw(opline, op_array, ssa),
+								smart_branch_opcode, exit_addr)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_FETCH_DIM_R:
+					case ZEND_FETCH_DIM_IS:
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						res_info = RES_INFO();
+						if (!zend_jit_fetch_dim_read(&dasm_state, opline, op_array,
+								op1_info, op2_info, res_info,
+								(
+									(op1_info & MAY_BE_ANY) != MAY_BE_ARRAY ||
+									(op2_info & (MAY_BE_ANY - (MAY_BE_LONG|MAY_BE_STRING))) != 0 ||
+									((op1_info & MAY_BE_UNDEF) != 0 &&
+										opline->opcode == ZEND_FETCH_DIM_R) ||
+									((opline->op1_type & (IS_TMP_VAR|IS_VAR)) != 0 &&
+										(op1_info & (MAY_BE_OBJECT|MAY_BE_RESOURCE|MAY_BE_ARRAY_OF_OBJECT|MAY_BE_ARRAY_OF_RESOURCE|MAY_BE_ARRAY_OF_ARRAY)) != 0) ||
+									(op2_info & MAY_BE_UNDEF) != 0 ||
+									((opline->op2_type & (IS_TMP_VAR|IS_VAR)) != 0 &&
+										(op2_info & (MAY_BE_OBJECT|MAY_BE_RESOURCE|MAY_BE_ARRAY_OF_OBJECT|MAY_BE_ARRAY_OF_RESOURCE|MAY_BE_ARRAY_OF_ARRAY)) != 0)))) {
+							goto jit_failure;
+						}
+						goto done;
+						goto done;
+					case ZEND_ISSET_ISEMPTY_DIM_OBJ:
+						if ((opline->extended_value & ZEND_ISEMPTY)) {
+							// TODO: support for empty() ???
+							break;
+						}
+						op1_info = OP1_INFO();
+						op2_info = OP2_INFO();
+						CHECK_OP1_TRACE_TYPE();
+						CHECK_OP2_TRACE_TYPE();
+						if ((opline->result_type & (IS_SMART_BRANCH_JMPZ|IS_SMART_BRANCH_JMPNZ)) != 0) {
+							zend_bool exit_if_true = 0;
+							const zend_op *exit_opline = zend_jit_trace_get_exit_opline(p + 1, opline + 1, &exit_if_true);
+							uint32_t exit_point = zend_jit_trace_get_exit_point(opline, exit_opline, p + 1);
+
+							exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+							if (!exit_addr) {
+								goto jit_failure;
+							}
+							smart_branch_opcode = exit_if_true ? ZEND_JMPNZ : ZEND_JMPZ;
+						} else {
+							smart_branch_opcode = 0;
+							exit_addr = NULL;
+						}
+						if (!zend_jit_isset_isempty_dim(&dasm_state, opline, op_array,
+								op1_info, op2_info,
+								zend_may_throw(opline, op_array, ssa),
+								smart_branch_opcode, -1, -1,
+								exit_addr)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_FETCH_OBJ_R:
+					case ZEND_FETCH_OBJ_IS:
+						if (opline->op2_type != IS_CONST
+						 || Z_TYPE_P(RT_CONSTANT(opline, opline->op2)) != IS_STRING
+						 || Z_STRVAL_P(RT_CONSTANT(opline, opline->op2))[0] == '\0') {
+							break;
+						}
+						ce = NULL;
+						if (opline->op1_type == IS_UNUSED) {
+							op1_info = MAY_BE_OBJECT|MAY_BE_RC1|MAY_BE_RCN;
+							ce = op_array->scope;
+						} else {
+							op1_info = OP1_INFO();
+							if (ssa->var_info && ssa->ops) {
+								zend_ssa_op *ssa_op = &ssa->ops[opline - op_array->opcodes];
+								if (ssa_op->op1_use >= 0) {
+									zend_ssa_var_info *op1_ssa = ssa->var_info + ssa_op->op1_use;
+									if (op1_ssa->ce && !op1_ssa->is_instanceof && !op1_ssa->ce->create_object) {
+										ce = op1_ssa->ce;
+									}
+								}
+							}
+						}
+						if (!(op1_info & MAY_BE_OBJECT)) {
+							break;
+						}
+						if (!zend_jit_fetch_obj_read(&dasm_state, opline, op_array,
+								op1_info, ce,
+								zend_may_throw(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_BIND_GLOBAL:
+						while (1) {
+							if (!ssa->ops || !ssa->var_info) {
+								op1_info = MAY_BE_ANY|MAY_BE_REF;
+							} else {
+								op1_info = OP1_INFO();
+							}
+							if (!zend_jit_bind_global(&dasm_state, opline, op_array, op1_info)) {
+								goto jit_failure;
+							}
+							if ((opline+1)->opcode == ZEND_BIND_GLOBAL) {
+								opline++;
+							} else {
+								break;
+							}
+						}
+						goto done;
+					case ZEND_RECV:
+						if (!zend_jit_recv(&dasm_state, opline, op_array)) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_RECV_INIT:
+						while (1) {
+							if (!zend_jit_recv_init(&dasm_state, opline, op_array,
+									(opline + 1)->opcode != ZEND_RECV_INIT,
+									zend_may_throw(opline, op_array, ssa))) {
+								goto jit_failure;
+							}
+							if ((opline+1)->opcode == ZEND_RECV_INIT) {
+								opline++;
+							} else {
+								break;
+							}
+						}
+						goto done;
+					case ZEND_FREE:
+					case ZEND_FE_FREE:
+						op1_info = OP1_INFO();
+						USE_OP1_TRACE_TYPE();
+						if (!zend_jit_free(&dasm_state, opline, op_array, op1_info,
+								zend_may_throw(opline, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
+					case ZEND_ECHO:
+						if (opline->op1_type != IS_CONST
+						 || Z_TYPE_P(RT_CONSTANT(opline, opline->op1)) != IS_STRING) {
+							break;
+						}
+						if (!zend_jit_echo(&dasm_state, opline, op_array)) {
+							goto jit_failure;
+						}
+						goto done;
+#if 0
+					case ZEND_SWITCH_LONG:
+					case ZEND_SWITCH_STRING:
+						if (!zend_jit_switch(&dasm_state, opline, op_array, ssa)) {
+							goto jit_failure;
+						}
+						goto done;
+#endif
+					default:
+						break;
+				}
+			}
+
+			if (opline->opcode != ZEND_NOP && opline->opcode != ZEND_JMP) {
+				if (!zend_jit_trace_handler(&dasm_state, op_array, opline, zend_may_throw(opline, op_array, ssa), p + 1)) {
+					goto jit_failure;
+				}
+			}
+done:
+			/* TODO: reset types on abstract stack,
+			   this should be replaced by type inference */
+			if (opline->result_type & (IS_TMP_VAR|IS_VAR|IS_CV)) {
+				if (opline->opcode == ZEND_QM_ASSIGN) {
+					if (opline->op1_type == IS_CONST) {
+						SET_RES_STACK_VAR_TYPE(Z_TYPE_P(RT_CONSTANT(opline, opline->op1)));
+					} else {
+						zend_uchar type = STACK_VAR_TYPE(opline, op1);
+						if (type != IS_UNKNOWN) {
+							SET_RES_STACK_VAR_TYPE(type);
+						} else {
+							RESET_RES_STACK_VAR_TYPE();
+						}
+					}
+				} else if (opline->opcode == ZEND_ASSIGN) {
+					if (opline->op2_type == IS_CONST) {
+						SET_RES_STACK_VAR_TYPE(Z_TYPE_P(RT_CONSTANT(opline, opline->op2)));
+					} else {
+						zend_uchar type = STACK_VAR_TYPE(opline, op2);
+						if (type != IS_UNKNOWN) {
+							SET_RES_STACK_VAR_TYPE(type);
+						} else {
+							RESET_RES_STACK_VAR_TYPE();
+						}
+					}
+				} else if ((opline->opcode == ZEND_POST_INC
+				         || opline->opcode == ZEND_POST_DEC)
+				        && p->op == ZEND_JIT_TRACE_VM) {
+					zend_uchar type = p->op1_type;
+					if (type & IS_TRACE_REFERENCE) {
+						type = IS_UNKNOWN;
+					}
+					if (type != IS_UNKNOWN) {
+						SET_RES_STACK_VAR_TYPE(type);
+					} else {
+						RESET_RES_STACK_VAR_TYPE();
+					}
+				} else {
+					RESET_RES_STACK_VAR_TYPE();
+				}
+			}
+			if (opline->op1_type == IS_CV) {
+				if (opline->opcode == ZEND_ASSIGN) {
+					if (!(OP1_INFO() & MAY_BE_REF)
+					 || STACK_VAR_TYPE(opline, op1) != IS_UNKNOWN) {
+						if (opline->op2_type == IS_CONST) {
+							SET_OP1_STACK_VAR_TYPE(Z_TYPE_P(RT_CONSTANT(opline, opline->op2)));
+						} else {
+							zend_uchar type = STACK_VAR_TYPE(opline, op2);
+							if (type != IS_UNKNOWN) {
+								SET_OP1_STACK_VAR_TYPE(type);
+							} else {
+								RESET_OP1_STACK_VAR_TYPE();
+							}
+						}
+					} else {
+						RESET_OP1_STACK_VAR_TYPE();
+					}
+				} else if (opline->opcode == ZEND_ASSIGN_REF
+				 || opline->opcode == ZEND_ASSIGN_DIM
+				 || opline->opcode == ZEND_ASSIGN_OBJ
+				 || opline->opcode == ZEND_ASSIGN_STATIC_PROP
+				 || opline->opcode == ZEND_ASSIGN_OBJ_REF
+				 || opline->opcode == ZEND_ASSIGN_STATIC_PROP_REF
+				 || opline->opcode == ZEND_ASSIGN_OP
+				 || opline->opcode == ZEND_ASSIGN_DIM_OP
+				 || opline->opcode == ZEND_ASSIGN_OBJ_OP
+				 || opline->opcode == ZEND_ASSIGN_STATIC_PROP_OP
+				 || opline->opcode == ZEND_PRE_INC
+				 || opline->opcode == ZEND_PRE_DEC
+				 || opline->opcode == ZEND_POST_INC
+				 || opline->opcode == ZEND_POST_DEC
+				 || opline->opcode == ZEND_PRE_INC_OBJ
+				 || opline->opcode == ZEND_PRE_DEC_OBJ
+				 || opline->opcode == ZEND_POST_INC_OBJ
+				 || opline->opcode == ZEND_POST_DEC_OBJ
+				 || opline->opcode == ZEND_UNSET_CV
+				 || opline->opcode == ZEND_UNSET_DIM
+				 || opline->opcode == ZEND_UNSET_OBJ
+				 || opline->opcode == ZEND_FETCH_DIM_W
+				 || opline->opcode == ZEND_FETCH_DIM_RW
+				 || opline->opcode == ZEND_FETCH_DIM_FUNC_ARG
+				 || opline->opcode == ZEND_FETCH_DIM_UNSET
+				 || opline->opcode == ZEND_FETCH_LIST_W
+				 || opline->opcode == ZEND_SEND_VAR_EX
+				 || opline->opcode == ZEND_SEND_FUNC_ARG
+				 || opline->opcode == ZEND_SEND_REF
+				 || opline->opcode == ZEND_SEND_UNPACK
+				 || opline->opcode == ZEND_FE_RESET_RW
+				 || opline->opcode == ZEND_MAKE_REF
+				 || opline->opcode == ZEND_BIND_GLOBAL
+				 || opline->opcode == ZEND_BIND_STATIC) {
+					RESET_OP1_STACK_VAR_TYPE();
+				} else if (opline->opcode == ZEND_ADD_ARRAY_ELEMENT
+				 || opline->opcode == ZEND_INIT_ARRAY) {
+					if (opline->extended_value & ZEND_ARRAY_ELEMENT_REF) {
+						RESET_OP1_STACK_VAR_TYPE();
+					}
+				}
+			}
+			if (opline->op2_type == IS_CV) {
+				if (opline->opcode == ZEND_ASSIGN_REF) {
+					RESET_OP2_STACK_VAR_TYPE();
+				} else if (opline->opcode == ZEND_BIND_LEXICAL) {
+					if (opline->extended_value & ZEND_BIND_REF) {
+						RESET_OP2_STACK_VAR_TYPE();
+					}
+				}
+			}
+#if 0
+			// TODO: call level calculation doesn't work for traces ???
+			switch (opline->opcode) {
+				case ZEND_DO_FCALL:
+				case ZEND_DO_ICALL:
+				case ZEND_DO_UCALL:
+				case ZEND_DO_FCALL_BY_NAME:
+					call_level--;
+			}
+#endif
+		} else if (p->op == ZEND_JIT_TRACE_ENTER) {
+			op_array = (zend_op_array*)p->op_array;
+			jit_extension =
+				(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+			ssa = &jit_extension->func_info.ssa;
+			if (ssa->cfg.blocks_count) {
+				/* pass */
+			} else if (num_op_arrays == ZEND_JIT_TRACE_MAX_FUNCS) {
+				/* Too many functions in single trace */
+				goto jit_failure;
+			} else {
+				/* Remember op_array to cleanup */
+				op_arrays[num_op_arrays++] = op_array;
+
+				/* Build SSA */
+				ssa = zend_jit_trace_build_ssa(op_array, script);
+				if (!ssa) {
+					goto jit_failure;
+				}
+			}
+			call = frame->call;
+			if (!call) {
+				/* Trace missed INIT_FCALL opcode */
+				call = top;
+				call->call = NULL;
+				call->prev = NULL;
+				call->func = (const zend_function*)op_array;
+				top = zend_jit_trace_call_frame(top, op_array);
+				for (i = 0; i < op_array->last_var + op_array->T; i++) {
+					call->stack[i] = IS_UNKNOWN;
+				}
+			} else {
+				ZEND_ASSERT(&call->func->op_array == op_array);
+			}
+			frame->call = call->prev;
+			call->prev = frame;
+			call->return_value_used = p->return_value_used;
+			JIT_G(current_frame) = frame = call;
+			stack = frame->stack;
+			zend_jit_set_opline(&dasm_state, (p+1)->opline);
+		} else if (p->op == ZEND_JIT_TRACE_BACK) {
+			op_array = (zend_op_array*)p->op_array;
+			jit_extension =
+				(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+			ssa = &jit_extension->func_info.ssa;
+			if (ssa->cfg.blocks_count) {
+				/* pass */
+			} else if (num_op_arrays == ZEND_JIT_TRACE_MAX_FUNCS) {
+				/* Too many functions in single trace */
+				goto jit_failure;
+			} else {
+				/* Remember op_array to cleanup */
+				op_arrays[num_op_arrays++] = op_array;
+
+				/* Build SSA */
+				ssa = zend_jit_trace_build_ssa(op_array, script);
+				if (!ssa) {
+					goto jit_failure;
+				}
+			}
+			top = frame;
+			if (frame->prev) {
+				frame = frame->prev;
+				stack = frame->stack;
+				ZEND_ASSERT(&frame->func->op_array == op_array);
+			} else {
+				frame = zend_jit_trace_ret_frame(frame, op_array);
+				frame->call = NULL;
+				frame->prev = NULL;
+				frame->func = (const zend_function*)op_array;
+				frame->return_value_used = -1;
+				stack = frame->stack;
+				for (i = 0; i < op_array->last_var + op_array->T; i++) {
+					stack[i] = IS_UNKNOWN;
+				}
+			}
+			JIT_G(current_frame) = frame;
+			if (res_type != IS_UNKNOWN
+			 && (p+1)->op == ZEND_JIT_TRACE_VM) {
+				const zend_op *opline = (p+1)->opline - 1;
+				if (opline->result_type != IS_UNUSED) {
+				    SET_RES_STACK_VAR_TYPE(res_type);
+				}
+			}
+			res_type = IS_UNKNOWN;
+		} else if (p->op == ZEND_JIT_TRACE_END) {
+			break;
+		} else if (p->op == ZEND_JIT_TRACE_INIT_CALL) {
+			call = top;
+			call->call = NULL;
+			call->prev = frame->call;
+			call->func = p->func;
+			frame->call = call;
+			if (p->func->type == ZEND_USER_FUNCTION) {
+				top = zend_jit_trace_call_frame(top, p->op_array);
+				for (i = 0; i < p->op_array->last_var +p-> op_array->T; i++) {
+					call->stack[i] = IS_UNKNOWN;
+				}
+			} else {
+				top++;
+			}
+		} else if (p->op == ZEND_JIT_TRACE_DO_ICALL) {
+			call = frame->call;
+			if (call) {
+				top = call;
+				frame->call = call->prev;
+			}
+		} else {
+			ZEND_ASSERT(0);
+		}
+	}
+
+	ZEND_ASSERT(p->op == ZEND_JIT_TRACE_END);
+
+	t = &zend_jit_traces[ZEND_JIT_TRACE_NUM];
+
+	if (p->stop == ZEND_JIT_TRACE_STOP_LOOP
+	 || p->stop == ZEND_JIT_TRACE_STOP_RECURSIVE_CALL
+	 || p->stop == ZEND_JIT_TRACE_STOP_RECURSIVE_RET) {
+		if (p->stop == ZEND_JIT_TRACE_STOP_LOOP) {
+			if (!zend_jit_set_valid_ip(&dasm_state, p->opline)) {
+				goto jit_failure;
+			}
+		}
+		t->link = ZEND_JIT_TRACE_NUM;
+		zend_jit_jmp(&dasm_state, 0); /* jump back to start of the trace loop */
+	} else if (p->stop == ZEND_JIT_TRACE_STOP_LINK) {
+		if (!zend_jit_set_valid_ip(&dasm_state, p->opline)) {
+			goto jit_failure;
+		}
+		t->link = zend_jit_find_trace(p->opline->handler);
+		zend_jit_trace_link_to_root(&dasm_state, p->opline->handler);
+	} else if (p->stop == ZEND_JIT_TRACE_STOP_RETURN) {
+		zend_jit_trace_return(&dasm_state);
+	} else {
+		// TODO: not implemented ???
+		ZEND_ASSERT(0 && p->stop);
+	}
+
+	if (ZEND_JIT_EXIT_COUNTERS + t->exit_count >= ZEND_JIT_TRACE_MAX_EXIT_COUNTERS) {
+		goto jit_failure;
+	}
+
+	handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, ZSTR_VAL(name), 1);
+
+jit_failure:
+	dasm_free(&dasm_state);
+
+	if (name) {
+		zend_string_release(name);
+	}
+
+	/* Clenup used op_arrays */
+	while (num_op_arrays > 0) {
+		op_array = op_arrays[--num_op_arrays];
+		jit_extension =
+			(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+
+		memset(&jit_extension->func_info, 0, sizeof(jit_extension->func_info));
+		jit_extension->func_info.num_args = -1;
+		jit_extension->func_info.return_value_used = -1;
+	}
+
+	zend_arena_release(&CG(arena), checkpoint);
+
+	JIT_G(current_frame) = NULL;
+
+	return handler;
+}
+
+static int zend_jit_trace_exit_needs_deoptimization(uint32_t trace_num, uint32_t exit_num)
+{
+	const zend_op *opline = zend_jit_traces[trace_num].exit_info[exit_num].opline;
+
+	opline = (const zend_op*)((uintptr_t)opline & ~(ZEND_JIT_EXIT_JITED|ZEND_JIT_EXIT_BLACKLISTED));
+	if (opline) {
+		return 1;
+	}
+
+	return 0;
+}
+
+static const void *zend_jit_trace_exit_to_vm(uint32_t trace_num, uint32_t exit_num)
+{
+	const void *handler = NULL;
+	dasm_State* dasm_state = NULL;
+	void *checkpoint;
+	char name[32];
+	const zend_op *opline;
+
+	if (!zend_jit_trace_exit_needs_deoptimization(trace_num, exit_num)) {
+		return dasm_labels[zend_lbtrace_escape];
+	}
+
+	checkpoint = zend_arena_checkpoint(CG(arena));;
+
+	sprintf(name, "ESCAPE-%d-%d", trace_num, exit_num);
+
+	dasm_init(&dasm_state, DASM_MAXSECTION);
+	dasm_setupglobal(&dasm_state, dasm_labels, zend_lb_MAX);
+	dasm_setup(&dasm_state, dasm_actions);
+	dasm_growpc(&dasm_state, 0);
+
+	zend_jit_align_func(&dasm_state);
+
+	// TODO: Generate deoptimization code ???
+
+	opline = zend_jit_traces[trace_num].exit_info[exit_num].opline;
+	opline = (const zend_op*)((uintptr_t)opline & ~(ZEND_JIT_EXIT_JITED|ZEND_JIT_EXIT_BLACKLISTED));
+	if (opline) {
+		zend_jit_set_ip(&dasm_state, opline);
+	}
+
+	zend_jit_trace_return(&dasm_state);
+
+	handler = dasm_link_and_encode(&dasm_state, NULL, NULL, NULL, NULL, name, 1);
+
+	dasm_free(&dasm_state);
+
+	zend_arena_release(&CG(arena), checkpoint);
+
+	return handler;
+}
+
+static zend_jit_trace_stop zend_jit_compile_root_trace(zend_jit_trace_rec *trace_buffer, const zend_op *opline, size_t offset)
+{
+	zend_jit_trace_stop ret;
+	const void *handler;
+	zend_jit_trace_info *t;
+	zend_jit_trace_exit_info exit_info[ZEND_JIT_TRACE_MAX_EXITS];
+
+	zend_shared_alloc_lock();
+
+	/* Checks under lock */
+	if ((ZEND_OP_TRACE_INFO(opline, offset)->trace_flags & ZEND_JIT_TRACE_JITED)) {
+		ret = ZEND_JIT_TRACE_STOP_ALREADY_DONE;
+	} else if (ZEND_JIT_TRACE_NUM >= ZEND_JIT_TRACE_MAX_TRACES) {
+		ret = ZEND_JIT_TRACE_STOP_TOO_MANY_TRACES;
+	} else {
+		SHM_UNPROTECT();
+		zend_jit_unprotect();
+
+		t = &zend_jit_traces[ZEND_JIT_TRACE_NUM];
+
+		t->id = ZEND_JIT_TRACE_NUM;
+		t->root = ZEND_JIT_TRACE_NUM;
+		t->parent = 0;
+		t->link = 0;
+		t->exit_count = 0;
+		t->child_count = 0;
+		t->stack_map_size = 0;
+		t->exit_info = exit_info;
+		t->stack_map = NULL;
+
+		handler = zend_jit_trace(trace_buffer, 0, 0);
+
+		if (handler) {
+			zend_jit_trace_exit_info *shared_exit_info = NULL;
+
+			t->exit_info = NULL;
+			if (t->exit_count) {
+				/* reallocate exit_info into shared memory */
+				shared_exit_info = (zend_jit_trace_exit_info*)zend_shared_alloc(
+					sizeof(zend_jit_trace_exit_info) * t->exit_count);
+
+				if (!shared_exit_info) {
+				    if (t->stack_map) {
+						efree(t->stack_map);
+						t->stack_map = NULL;
+					}
+					ret = ZEND_JIT_TRACE_STOP_NO_SHM;
+					goto exit;
+				}
+				memcpy(shared_exit_info, exit_info,
+					sizeof(zend_jit_trace_exit_info) * t->exit_count);
+				t->exit_info = shared_exit_info;
+			}
+
+		    if (t->stack_map_size) {
+				uint8_t *shared_stack_map = (uint8_t*)zend_shared_alloc(t->stack_map_size);
+				if (!shared_stack_map) {
+					ret = ZEND_JIT_TRACE_STOP_NO_SHM;
+					goto exit;
+				}
+				memcpy(shared_stack_map, t->stack_map, t->stack_map_size);
+				efree(t->stack_map);
+				t->stack_map = shared_stack_map;
+		    }
+
+			t->exit_counters = ZEND_JIT_EXIT_COUNTERS;
+			ZEND_JIT_EXIT_COUNTERS += t->exit_count;
+
+			((zend_op*)opline)->handler = handler;
+
+			ZEND_JIT_TRACE_NUM++;
+			ZEND_OP_TRACE_INFO(opline, offset)->trace_flags |= ZEND_JIT_TRACE_JITED;
+
+			ret = ZEND_JIT_TRACE_STOP_COMPILED;
+		} else if (t->exit_count >= ZEND_JIT_TRACE_MAX_EXITS ||
+		           ZEND_JIT_EXIT_COUNTERS + t->exit_count >= ZEND_JIT_TRACE_MAX_EXIT_COUNTERS) {
+		    if (t->stack_map) {
+				efree(t->stack_map);
+				t->stack_map = NULL;
+			}
+			ret = ZEND_JIT_TRACE_STOP_TOO_MANY_EXITS;
+		} else {
+		    if (t->stack_map) {
+				efree(t->stack_map);
+				t->stack_map = NULL;
+			}
+			ret = ZEND_JIT_TRACE_STOP_COMPILER_ERROR;
+		}
+
+exit:
+		zend_jit_protect();
+		SHM_PROTECT();
+	}
+
+	zend_shared_alloc_unlock();
+
+	return ret;
+}
+
+static void zend_jit_blacklist_root_trace(const zend_op *opline, size_t offset)
+{
+	zend_shared_alloc_lock();
+
+	if (!(ZEND_OP_TRACE_INFO(opline, offset)->trace_flags & ZEND_JIT_TRACE_BLACKLISTED)) {
+		SHM_UNPROTECT();
+		zend_jit_unprotect();
+
+		((zend_op*)opline)->handler =
+			ZEND_OP_TRACE_INFO(opline, offset)->orig_handler;
+
+		ZEND_OP_TRACE_INFO(opline, offset)->trace_flags |= ZEND_JIT_TRACE_BLACKLISTED;
+
+		zend_jit_protect();
+		SHM_PROTECT();
+	}
+
+	zend_shared_alloc_unlock();
+}
+
+static zend_bool zend_jit_trace_is_bad_root(const zend_op *opline, zend_jit_trace_stop stop, size_t offset)
+{
+	const zend_op **cache_opline = JIT_G(bad_root_cache_opline);
+	uint8_t *cache_count = JIT_G(bad_root_cache_count);
+	uint8_t *cache_stop = JIT_G(bad_root_cache_stop);
+	uint32_t cache_slot = JIT_G(bad_root_slot);
+	uint32_t i;
+
+	for (i = 0; i < ZEND_JIT_TRACE_BAD_ROOT_SLOTS; i++) {
+		if (cache_opline[i] == opline) {
+			if (cache_count[i] >= ZEND_JIT_TRACE_MAX_ROOT_FAILURES - 1) {
+				cache_opline[i] = NULL;
+				return 1;
+			} else {
+#if 0
+				if (ZEND_OP_TRACE_INFO(opline, offset)->counter) {
+					*ZEND_OP_TRACE_INFO(opline, offset)->counter =
+						random() % ZEND_JIT_TRACE_COUNTER_MAX;
+				}
+#endif
+				cache_count[i]++;
+				cache_stop[i] = stop;
+				return 0;
+			}
+		}
+	}
+	i = cache_slot;
+	cache_opline[i] = opline;
+	cache_count[i] = 1;
+	cache_stop[i] = stop;
+	cache_slot = (i + 1) % ZEND_JIT_TRACE_BAD_ROOT_SLOTS;
+	JIT_G(bad_root_slot) = cache_slot;
+	return 0;
+}
+
+#define ZEND_JIT_TRACE_STOP_DESCRIPTION(name, description) \
+	description,
+
+static const char * zend_jit_trace_stop_description[] = {
+	ZEND_JIT_TRACE_STOP(ZEND_JIT_TRACE_STOP_DESCRIPTION)
+};
+
+static void zend_jit_dump_trace(zend_jit_trace_rec *trace_buffer)
+{
+	zend_jit_trace_rec *p = trace_buffer;
+	const zend_op_array *op_array;
+	uint32_t level = 1 + trace_buffer[0].level;
+
+	ZEND_ASSERT(p->op == ZEND_JIT_TRACE_START);
+	op_array = p->op_array;
+	p += ZEND_JIT_TRACE_START_REC_SIZE;
+
+	while (1) {
+		if (p->op == ZEND_JIT_TRACE_VM) {
+			uint8_t op1_type, op2_type, op3_type;
+
+			fprintf(stderr, "%04d%*c",
+				(int)(p->opline - op_array->opcodes),
+				level, ' ');
+			zend_dump_op(op_array, NULL, p->opline, ZEND_DUMP_NUMERIC_OPLINES, NULL);
+
+			op1_type = p->op1_type;
+			op2_type = p->op2_type;
+			op3_type = p->op3_type;
+			if (op1_type != IS_UNKNOWN || op2_type != IS_UNKNOWN || op3_type != IS_UNKNOWN) {
+				fprintf(stderr, " ;");
+				if (op1_type != IS_UNKNOWN) {
+					const char *ref = (op1_type & IS_TRACE_REFERENCE) ? "&" : "";
+					if ((p+1)->op == ZEND_JIT_TRACE_OP1_TYPE) {
+						p++;
+						fprintf(stderr, " op1(%sobject of class %s)", ref,
+							ZSTR_VAL(p->ce->name));
+					} else {
+						const char *type = (op1_type == 0) ? "undef" : zend_get_type_by_const(op1_type & ~IS_TRACE_REFERENCE);
+						fprintf(stderr, " op1(%s%s)", ref, type);
+					}
+				}
+				if (op2_type != IS_UNKNOWN) {
+					const char *ref = (op2_type & IS_TRACE_REFERENCE) ? "&" : "";
+					if ((p+1)->op == ZEND_JIT_TRACE_OP2_TYPE) {
+						p++;
+						fprintf(stderr, " op2(%sobject of class %s)", ref,
+							ZSTR_VAL(p->ce->name));
+					} else {
+						const char *type = (op2_type == 0) ? "undef" : zend_get_type_by_const(op2_type & ~IS_TRACE_REFERENCE);
+						fprintf(stderr, " op2(%s%s)", ref, type);
+					}
+				}
+				if (op3_type != IS_UNKNOWN) {
+					const char *ref = (op3_type & IS_TRACE_REFERENCE) ? "&" : "";
+					const char *type = (op3_type == 0) ? "undef" : zend_get_type_by_const(op3_type & ~IS_TRACE_REFERENCE);
+					fprintf(stderr, " op3(%s%s)", ref, type);
+				}
+			}
+			fprintf(stderr, "\n");
+
+			if ((p->opline->result_type & (IS_SMART_BRANCH_JMPNZ | IS_SMART_BRANCH_JMPZ)) != 0
+			 || p->opline->opcode == ZEND_ASSIGN_DIM
+			 || p->opline->opcode == ZEND_ASSIGN_OBJ
+			 || p->opline->opcode == ZEND_ASSIGN_STATIC_PROP
+			 || p->opline->opcode == ZEND_ASSIGN_DIM_OP
+			 || p->opline->opcode == ZEND_ASSIGN_OBJ_OP
+			 || p->opline->opcode == ZEND_ASSIGN_STATIC_PROP_OP
+			 || p->opline->opcode == ZEND_ASSIGN_OBJ_REF
+			 || p->opline->opcode == ZEND_ASSIGN_STATIC_PROP_REF) {
+				fprintf(stderr, "%04d%*c;",
+					(int)((p->opline + 1) - op_array->opcodes),
+					level, ' ');
+				zend_dump_op(op_array, NULL, (p->opline + 1), ZEND_DUMP_NUMERIC_OPLINES, NULL);
+				fprintf(stderr, "\n");
+			}
+		} else if (p->op == ZEND_JIT_TRACE_ENTER) {
+			op_array = p->op_array;
+			fprintf(stderr, "    %*c>enter %s%s%s\n",
+				level, ' ',
+				op_array->scope ? ZSTR_VAL(op_array->scope->name) : "",
+				op_array->scope ? "::" : "",
+				op_array->function_name ?
+					ZSTR_VAL(op_array->function_name) :
+					ZSTR_VAL(op_array->filename));
+			level++;
+		} else if (p->op == ZEND_JIT_TRACE_BACK) {
+			op_array = p->op_array;
+			level--;
+			fprintf(stderr, "    %*c<back %s%s%s\n",
+				level, ' ',
+				op_array->scope ? ZSTR_VAL(op_array->scope->name) : "",
+				op_array->scope ? "::" : "",
+				op_array->function_name ?
+					ZSTR_VAL(op_array->function_name) :
+					ZSTR_VAL(op_array->filename));
+		} else if (p->op == ZEND_JIT_TRACE_INIT_CALL) {
+			if (p->func != (zend_function*)&zend_pass_function) {
+				fprintf(stderr, p->fake ? "    %*c>fake_init %s%s%s\n" : "    %*c>init %s%s%s\n",
+					level, ' ',
+					p->func->common.scope ? ZSTR_VAL(p->func->common.scope->name) : "",
+					p->func->common.scope ? "::" : "",
+					ZSTR_VAL(p->func->common.function_name));
+			} else {
+				fprintf(stderr, "    %*c>skip\n",
+					level, ' ');
+			}
+		} else if (p->op == ZEND_JIT_TRACE_DO_ICALL) {
+			if (p->func != (zend_function*)&zend_pass_function) {
+				fprintf(stderr, "    %*c>call %s%s%s\n",
+					level, ' ',
+					p->func->common.scope ? ZSTR_VAL(p->func->common.scope->name) : "",
+					p->func->common.scope ? "::" : "",
+					ZSTR_VAL(p->func->common.function_name));
+			} else {
+				fprintf(stderr, "    %*c>skip\n",
+					level, ' ');
+			}
+		} else if (p->op == ZEND_JIT_TRACE_END) {
+			break;
+		}
+		p++;
+	}
+}
+
+static zend_always_inline const char *zend_jit_trace_star_desc(uint8_t trace_flags)
+{
+	if (trace_flags & ZEND_JIT_TRACE_START_LOOP) {
+		return "loop";
+	} else if (trace_flags & ZEND_JIT_TRACE_START_ENTER) {
+		return "enter";
+	} else if (trace_flags & ZEND_JIT_TRACE_START_RETURN) {
+		return "return";
+	} else {
+		ZEND_ASSERT(0);
+		return "???";
+	}
+}
+
+int ZEND_FASTCALL zend_jit_trace_hot_root(zend_execute_data *execute_data, const zend_op *opline)
+{
+	const zend_op *orig_opline;
+	zend_jit_trace_stop stop;
+	zend_op_array *op_array;
+	zend_jit_op_array_trace_extension *jit_extension;
+	size_t offset;
+	uint32_t trace_num;
+	zend_jit_trace_rec trace_buffer[ZEND_JIT_TRACE_MAX_LENGTH];
+
+	ZEND_ASSERT(EX(func)->type == ZEND_USER_FUNCTION);
+	ZEND_ASSERT(opline >= EX(func)->op_array.opcodes &&
+		opline < EX(func)->op_array.opcodes + EX(func)->op_array.last);
+
+repeat:
+	trace_num = ZEND_JIT_TRACE_NUM;
+	orig_opline = opline;
+	op_array = &EX(func)->op_array;
+	jit_extension = (zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+	offset = jit_extension->offset;
+
+	EX(opline) = opline;
+
+	/* Lock-free check if the root trace was already JIT-ed or blacklist-ed in another process */
+	if (ZEND_OP_TRACE_INFO(opline, offset)->trace_flags & (ZEND_JIT_TRACE_JITED|ZEND_JIT_TRACE_BLACKLISTED)) {
+		return 0;
+	}
+
+	if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_START) {
+		fprintf(stderr, "---- TRACE %d start (%s) %s() %s:%d\n",
+			trace_num,
+			zend_jit_trace_star_desc(ZEND_OP_TRACE_INFO(opline, offset)->trace_flags),
+			EX(func)->op_array.function_name ?
+				ZSTR_VAL(EX(func)->op_array.function_name) : "$main",
+			ZSTR_VAL(EX(func)->op_array.filename),
+			opline->lineno);
+	}
+
+	if (ZEND_JIT_TRACE_NUM >= ZEND_JIT_TRACE_MAX_TRACES) {
+		stop = ZEND_JIT_TRACE_STOP_TOO_MANY_TRACES;
+		goto abort;
+	}
+
+	stop = zend_jit_trace_execute(execute_data, opline, trace_buffer,
+		ZEND_OP_TRACE_INFO(opline, offset)->trace_flags & ZEND_JIT_TRACE_START_MASK);
+
+	if (stop == ZEND_JIT_TRACE_STOP_TOPLEVEL) {
+		/* op_array may be already deallocated */
+		if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_ABORT) {
+			fprintf(stderr, "---- TRACE %d abort (%s)\n",
+				trace_num,
+				zend_jit_trace_stop_description[stop]);
+		}
+		goto blacklist;
+	}
+
+	if (UNEXPECTED(ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_BYTECODE)) {
+		zend_jit_dump_trace(trace_buffer);
+	}
+
+	if (ZEND_JIT_TRACE_STOP_OK(stop)) {
+		if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_STOP) {
+			if (stop == ZEND_JIT_TRACE_STOP_LINK) {
+				uint32_t link_to = zend_jit_find_trace(EG(current_execute_data)->opline->handler);;
+				fprintf(stderr, "---- TRACE %d stop (link to %d)\n",
+					trace_num,
+					link_to);
+			} else {
+				fprintf(stderr, "---- TRACE %d stop (%s)\n",
+					trace_num,
+					zend_jit_trace_stop_description[stop]);
+			}
+		}
+		stop = zend_jit_compile_root_trace(trace_buffer, orig_opline, offset);
+		if (EXPECTED(ZEND_JIT_TRACE_STOP_DONE(stop))) {
+			if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_COMPILED) {
+				fprintf(stderr, "---- TRACE %d %s\n",
+					trace_num,
+					zend_jit_trace_stop_description[stop]);
+			}
+		} else {
+			goto abort;
+		}
+	} else {
+abort:
+		if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_ABORT) {
+			fprintf(stderr, "---- TRACE %d abort (%s)\n",
+				trace_num,
+				zend_jit_trace_stop_description[stop]);
+		}
+blacklist:
+		if (!ZEND_JIT_TRACE_STOP_MAY_RECOVER(stop)
+		 || zend_jit_trace_is_bad_root(orig_opline, stop, offset)) {
+			if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_BLACKLIST) {
+				fprintf(stderr, "---- TRACE %d blacklisted\n",
+					trace_num);
+			}
+			zend_jit_blacklist_root_trace(orig_opline, offset);
+		}
+		if (ZEND_JIT_TRACE_STOP_REPEAT(stop)) {
+			execute_data = EG(current_execute_data);
+			opline = EX(opline);
+			goto repeat;
+		}
+	}
+
+	if (ZCG(accel_directives).jit_debug & (ZEND_JIT_DEBUG_TRACE_STOP|ZEND_JIT_DEBUG_TRACE_ABORT|ZEND_JIT_DEBUG_TRACE_COMPILED|ZEND_JIT_DEBUG_TRACE_BLACKLIST)) {
+		fprintf(stderr, "\n");
+	}
+
+	return (stop == ZEND_JIT_TRACE_STOP_HALT) ? -1 : 0;
+}
+
+static void zend_jit_blacklist_trace_exit(uint32_t trace_num, uint32_t exit_num)
+{
+	const void *handler;
+
+	zend_shared_alloc_lock();
+
+	if (!((uintptr_t)zend_jit_traces[trace_num].exit_info[exit_num].opline & ZEND_JIT_EXIT_BLACKLISTED)) {
+		SHM_UNPROTECT();
+		zend_jit_unprotect();
+
+		handler = zend_jit_trace_exit_to_vm(trace_num, exit_num);
+
+		if (handler) {
+			zend_jit_link_side_trace(
+				zend_jit_traces[trace_num].code_start,
+				zend_jit_traces[trace_num].code_size,
+				exit_num,
+				handler);
+		}
+
+		zend_jit_traces[trace_num].exit_info[exit_num].opline = (const zend_op*)
+		    ((uintptr_t)zend_jit_traces[trace_num].exit_info[exit_num].opline | ZEND_JIT_EXIT_BLACKLISTED);
+
+		zend_jit_protect();
+		SHM_PROTECT();
+	}
+
+	zend_shared_alloc_unlock();
+}
+
+static zend_bool zend_jit_trace_exit_is_bad(uint32_t trace_num, uint32_t exit_num)
+{
+	uint8_t *counter = JIT_G(exit_counters) +
+		zend_jit_traces[trace_num].exit_counters + exit_num;
+
+	if (*counter + 1 >= ZEND_JIT_TRACE_HOT_SIDE_COUNT + ZEND_JIT_TRACE_MAX_SIDE_FAILURES) {
+		return 1;
+	}
+	(*counter)++;
+	return 0;
+}
+
+static zend_bool zend_jit_trace_exit_is_hot(uint32_t trace_num, uint32_t exit_num)
+{
+	uint8_t *counter = JIT_G(exit_counters) +
+		zend_jit_traces[trace_num].exit_counters + exit_num;
+
+	if (*counter + 1 >= ZEND_JIT_TRACE_HOT_SIDE_COUNT) {
+		return 1;
+	}
+	(*counter)++;
+	return 0;
+}
+
+static zend_jit_trace_stop zend_jit_compile_side_trace(zend_jit_trace_rec *trace_buffer, uint32_t parent_num, uint32_t exit_num)
+{
+	zend_jit_trace_stop ret;
+	const void *handler;
+	zend_jit_trace_info *t;
+	zend_jit_trace_exit_info exit_info[ZEND_JIT_TRACE_MAX_EXITS];
+
+	zend_shared_alloc_lock();
+
+	/* Checks under lock */
+	if (((uintptr_t)zend_jit_traces[parent_num].exit_info[exit_num].opline & ZEND_JIT_EXIT_JITED)) {
+		ret = ZEND_JIT_TRACE_STOP_ALREADY_DONE;
+	} else if (ZEND_JIT_TRACE_NUM >= ZEND_JIT_TRACE_MAX_TRACES) {
+		ret = ZEND_JIT_TRACE_STOP_TOO_MANY_TRACES;
+	} else if (zend_jit_traces[zend_jit_traces[parent_num].root].child_count >= ZEND_JIT_TRACE_MAX_SIDE_TRACES) {
+		ret = ZEND_JIT_TRACE_STOP_TOO_MANY_CHILDREN;
+	} else {
+		SHM_UNPROTECT();
+		zend_jit_unprotect();
+
+		t = &zend_jit_traces[ZEND_JIT_TRACE_NUM];
+
+		t->id = ZEND_JIT_TRACE_NUM;
+		t->root = zend_jit_traces[parent_num].root;
+		t->parent = parent_num;
+		t->link = 0;
+		t->exit_count = 0;
+		t->child_count = 0;
+		t->stack_map_size = 0;
+		t->exit_info = exit_info;
+		t->stack_map = NULL;
+
+		handler = zend_jit_trace(trace_buffer, parent_num, exit_num);
+
+		if (handler) {
+			zend_jit_trace_exit_info *shared_exit_info = NULL;
+
+			t->exit_info = NULL;
+			if (t->exit_count) {
+				/* reallocate exit_info into shared memory */
+				shared_exit_info = (zend_jit_trace_exit_info*)zend_shared_alloc(
+					sizeof(zend_jit_trace_exit_info) * t->exit_count);
+
+				if (!shared_exit_info) {
+				    if (t->stack_map) {
+						efree(t->stack_map);
+						t->stack_map = NULL;
+					}
+					ret = ZEND_JIT_TRACE_STOP_NO_SHM;
+					goto exit;
+				}
+				memcpy(shared_exit_info, exit_info,
+					sizeof(zend_jit_trace_exit_info) * t->exit_count);
+				t->exit_info = shared_exit_info;
+			}
+
+		    if (t->stack_map_size) {
+				uint8_t *shared_stack_map = (uint8_t*)zend_shared_alloc(t->stack_map_size);
+				if (!shared_stack_map) {
+					efree(t->stack_map);
+					ret = ZEND_JIT_TRACE_STOP_NO_SHM;
+					goto exit;
+				}
+				memcpy(shared_stack_map, t->stack_map, t->stack_map_size);
+				efree(t->stack_map);
+				t->stack_map = shared_stack_map;
+		    }
+
+			zend_jit_link_side_trace(
+				zend_jit_traces[parent_num].code_start,
+				zend_jit_traces[parent_num].code_size,
+				exit_num,
+				handler);
+
+			t->exit_counters = ZEND_JIT_EXIT_COUNTERS;
+			ZEND_JIT_EXIT_COUNTERS += t->exit_count;
+
+			zend_jit_traces[zend_jit_traces[parent_num].root].child_count++;
+			ZEND_JIT_TRACE_NUM++;
+			zend_jit_traces[parent_num].exit_info[exit_num].opline = (const zend_op*)
+			    ((uintptr_t)zend_jit_traces[parent_num].exit_info[exit_num].opline | ZEND_JIT_EXIT_JITED);
+
+			ret = ZEND_JIT_TRACE_STOP_COMPILED;
+		} else if (t->exit_count >= ZEND_JIT_TRACE_MAX_EXITS ||
+		           ZEND_JIT_EXIT_COUNTERS + t->exit_count >= ZEND_JIT_TRACE_MAX_EXIT_COUNTERS) {
+		    if (t->stack_map) {
+				efree(t->stack_map);
+				t->stack_map = NULL;
+			}
+			ret = ZEND_JIT_TRACE_STOP_TOO_MANY_EXITS;
+		} else {
+		    if (t->stack_map) {
+				efree(t->stack_map);
+				t->stack_map = NULL;
+			}
+			ret = ZEND_JIT_TRACE_STOP_COMPILER_ERROR;
+		}
+
+exit:
+		zend_jit_protect();
+		SHM_PROTECT();
+	}
+
+	zend_shared_alloc_unlock();
+
+	return ret;
+}
+
+int ZEND_FASTCALL zend_jit_trace_hot_side(zend_execute_data *execute_data, uint32_t parent_num, uint32_t exit_num)
+{
+	zend_jit_trace_stop stop;
+	uint32_t trace_num;
+	zend_jit_trace_rec trace_buffer[ZEND_JIT_TRACE_MAX_LENGTH];
+
+	trace_num = ZEND_JIT_TRACE_NUM;
+
+	/* Lock-free check if the side trace was already JIT-ed or blacklist-ed in another process */
+	if ((uintptr_t)zend_jit_traces[parent_num].exit_info[exit_num].opline & (ZEND_JIT_EXIT_JITED|ZEND_JIT_EXIT_BLACKLISTED)) {
+		return 0;
+	}
+
+	if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_START) {
+		fprintf(stderr, "---- TRACE %d start (side trace %d/%d) %s() %s:%d\n",
+			trace_num, parent_num, exit_num,
+			EX(func)->op_array.function_name ?
+				ZSTR_VAL(EX(func)->op_array.function_name) : "$main",
+			ZSTR_VAL(EX(func)->op_array.filename),
+			EX(opline)->lineno);
+	}
+
+	if (ZEND_JIT_TRACE_NUM >= ZEND_JIT_TRACE_MAX_TRACES) {
+		stop = ZEND_JIT_TRACE_STOP_TOO_MANY_TRACES;
+		goto abort;
+	}
+
+	if (zend_jit_traces[zend_jit_traces[parent_num].root].child_count >= ZEND_JIT_TRACE_MAX_SIDE_TRACES) {
+		stop = ZEND_JIT_TRACE_STOP_TOO_MANY_CHILDREN;
+		goto abort;
+	}
+
+	stop = zend_jit_trace_execute(execute_data, EX(opline), trace_buffer, ZEND_JIT_TRACE_START_SIDE);
+
+	if (stop == ZEND_JIT_TRACE_STOP_TOPLEVEL) {
+		/* op_array may be already deallocated */
+		if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_ABORT) {
+			fprintf(stderr, "---- TRACE %d abort (%s)\n",
+				trace_num,
+				zend_jit_trace_stop_description[stop]);
+		}
+		goto blacklist;
+	}
+
+	if (UNEXPECTED(ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_BYTECODE)) {
+		zend_jit_dump_trace(trace_buffer);
+	}
+
+	if (ZEND_JIT_TRACE_STOP_OK(stop)) {
+		if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_STOP) {
+			if (stop == ZEND_JIT_TRACE_STOP_LINK) {
+				uint32_t link_to = zend_jit_find_trace(EG(current_execute_data)->opline->handler);;
+				fprintf(stderr, "---- TRACE %d stop (link to %d)\n",
+					trace_num,
+					link_to);
+			} else {
+				fprintf(stderr, "---- TRACE %d stop (%s)\n",
+					trace_num,
+					zend_jit_trace_stop_description[stop]);
+			}
+		}
+		if (EXPECTED(stop != ZEND_JIT_TRACE_STOP_LOOP)) {
+			stop = zend_jit_compile_side_trace(trace_buffer, parent_num, exit_num);
+		} else {
+			const zend_op_array *op_array = trace_buffer[0].op_array;
+			zend_jit_op_array_trace_extension *jit_extension =
+				(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+			const zend_op *opline = trace_buffer[1].opline;
+
+			stop = zend_jit_compile_root_trace(trace_buffer, opline, jit_extension->offset);
+		}
+		if (EXPECTED(ZEND_JIT_TRACE_STOP_DONE(stop))) {
+			if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_COMPILED) {
+				fprintf(stderr, "---- TRACE %d %s\n",
+					trace_num,
+					zend_jit_trace_stop_description[stop]);
+			}
+		} else {
+			goto abort;
+		}
+	} else {
+abort:
+		if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_ABORT) {
+			fprintf(stderr, "---- TRACE %d abort (%s)\n",
+				trace_num,
+				zend_jit_trace_stop_description[stop]);
+		}
+blacklist:
+		if (!ZEND_JIT_TRACE_STOP_MAY_RECOVER(stop)
+		 || zend_jit_trace_exit_is_bad(parent_num, exit_num)) {
+			zend_jit_blacklist_trace_exit(parent_num, exit_num);
+			if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_BLACKLIST) {
+				fprintf(stderr, "---- EXIT %d/%d blacklisted\n",
+					parent_num, exit_num);
+			}
+		}
+	}
+
+	if (ZCG(accel_directives).jit_debug & (ZEND_JIT_DEBUG_TRACE_STOP|ZEND_JIT_DEBUG_TRACE_ABORT|ZEND_JIT_DEBUG_TRACE_COMPILED|ZEND_JIT_DEBUG_TRACE_BLACKLIST)) {
+		fprintf(stderr, "\n");
+	}
+
+	return (stop == ZEND_JIT_TRACE_STOP_HALT) ? -1 : 0;
+}
+
+int ZEND_FASTCALL zend_jit_trace_exit(uint32_t trace_num, uint32_t exit_num)
+{
+	zend_execute_data *execute_data = EG(current_execute_data);
+	const zend_op *opline;
+	zend_jit_trace_info *t = &zend_jit_traces[trace_num];
+
+	// TODO: Deoptimizatoion of VM stack state ???
+
+	/* Lock-free check if the side trace was already JIT-ed or blacklist-ed in another process */
+	// TODO: We may remoive this, becaus of the same check in zend_jit_trace_hot_side() ???
+	opline = t->exit_info[exit_num].opline;
+	if ((uintptr_t)opline & (ZEND_JIT_EXIT_JITED|ZEND_JIT_EXIT_BLACKLISTED)) {
+		opline = (const zend_op*)((uintptr_t)opline & ~(ZEND_JIT_EXIT_JITED|ZEND_JIT_EXIT_BLACKLISTED));
+		if (opline) {
+			/* Set VM opline to continue interpretation */
+			EX(opline) = opline;
+		}
+		return 0;
+	}
+
+	if (opline) {
+		/* Set VM opline to continue interpretation */
+		EX(opline) = opline;
+	}
+
+	ZEND_ASSERT(EX(func)->type == ZEND_USER_FUNCTION);
+	ZEND_ASSERT(EX(opline) >= EX(func)->op_array.opcodes &&
+		EX(opline) < EX(func)->op_array.opcodes + EX(func)->op_array.last);
+
+	if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_TRACE_EXIT) {
+		fprintf(stderr, "     TRACE %d exit %d %s() %s:%d\n",
+			trace_num,
+			exit_num,
+			EX(func)->op_array.function_name ?
+				ZSTR_VAL(EX(func)->op_array.function_name) : "$main",
+			ZSTR_VAL(EX(func)->op_array.filename),
+			EX(opline)->lineno);
+	}
+
+	if (zend_jit_trace_exit_is_hot(trace_num, exit_num)) {
+		return zend_jit_trace_hot_side(execute_data, trace_num, exit_num);
+	}
+
+	return 0;
+}
+
+static zend_always_inline uint8_t zend_jit_trace_supported(const zend_op *opline)
+{
+	switch (opline->opcode) {
+		case ZEND_CATCH:
+		case ZEND_FAST_CALL:
+		case ZEND_FAST_RET:
+		case ZEND_GENERATOR_CREATE:
+		case ZEND_GENERATOR_RETURN:
+		case ZEND_EXIT:
+		case ZEND_YIELD:
+		case ZEND_YIELD_FROM:
+		case ZEND_INCLUDE_OR_EVAL:
+			return ZEND_JIT_TRACE_UNSUPPORTED;
+		default:
+			return ZEND_JIT_TRACE_SUPPORTED;
+	}
+}
+
+static int zend_jit_setup_hot_trace_counters(zend_op_array *op_array)
+{
+	zend_op *opline;
+	zend_jit_op_array_trace_extension *jit_extension;
+	zend_cfg cfg;
+	uint32_t i;
+
+	ZEND_ASSERT(zend_jit_func_counter_handler != NULL);
+	ZEND_ASSERT(zend_jit_ret_counter_handler != NULL);
+	ZEND_ASSERT(zend_jit_loop_counter_handler != NULL);
+	ZEND_ASSERT(sizeof(zend_op_trace_info) == sizeof(zend_op));
+
+	if (zend_jit_build_cfg(op_array, &cfg) != SUCCESS) {
+		return FAILURE;
+	}
+
+	jit_extension = (zend_jit_op_array_trace_extension*)zend_shared_alloc(sizeof(zend_jit_op_array_trace_extension) + (op_array->last - 1) * sizeof(zend_op_trace_info));
+	memset(&jit_extension->func_info, 0, sizeof(jit_extension->func_info));
+	jit_extension->func_info.num_args = -1;
+	jit_extension->func_info.return_value_used = -1;
+	jit_extension->offset = (char*)jit_extension->trace_info - (char*)op_array->opcodes;
+	for (i = 0; i < op_array->last; i++) {
+		jit_extension->trace_info[i].orig_handler = op_array->opcodes[i].handler;
+		jit_extension->trace_info[i].call_handler = zend_get_opcode_handler_func(&op_array->opcodes[i]);
+		jit_extension->trace_info[i].counter = NULL;
+		jit_extension->trace_info[i].trace_flags =
+			zend_jit_trace_supported(&op_array->opcodes[i]);
+	}
+	ZEND_SET_FUNC_INFO(op_array, (void*)jit_extension);
+
+	opline = op_array->opcodes;
+	if (!(op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
+		while (opline->opcode == ZEND_RECV || opline->opcode == ZEND_RECV_INIT) {
+			opline++;
+		}
+	}
+
+	if (!(ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_UNSUPPORTED)) {
+		/* function entry */
+		opline->handler = (const void*)zend_jit_func_counter_handler;
+		ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->counter =
+			&zend_jit_hot_counters[ZEND_JIT_COUNTER_NUM];
+		ZEND_JIT_COUNTER_NUM = (ZEND_JIT_COUNTER_NUM + 1) % ZEND_HOT_COUNTERS_COUNT;
+		ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags |=
+			ZEND_JIT_TRACE_START_ENTER;
+	}
+
+	for (i = 0; i < cfg.blocks_count; i++) {
+		if (cfg.blocks[i].flags & ZEND_BB_REACHABLE) {
+			if (cfg.blocks[i].flags & ZEND_BB_ENTRY) {
+				/* continuation after return from function call */
+				opline = op_array->opcodes + cfg.blocks[i].start;
+				if (!(ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_UNSUPPORTED)) {
+					opline->handler = (const void*)zend_jit_ret_counter_handler;
+					if (!ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->counter) {
+						ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->counter =
+							&zend_jit_hot_counters[ZEND_JIT_COUNTER_NUM];
+						ZEND_JIT_COUNTER_NUM = (ZEND_JIT_COUNTER_NUM + 1) % ZEND_HOT_COUNTERS_COUNT;
+					}
+					ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags |=
+						ZEND_JIT_TRACE_START_RETURN;
+				}
+			}
+			if (cfg.blocks[i].flags & ZEND_BB_LOOP_HEADER) {
+				/* loop header */
+				opline = op_array->opcodes + cfg.blocks[i].start;
+				if (!(ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_UNSUPPORTED)) {
+					opline->handler = (const void*)zend_jit_loop_counter_handler;
+					if (!ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->counter) {
+						ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->counter =
+							&zend_jit_hot_counters[ZEND_JIT_COUNTER_NUM];
+						ZEND_JIT_COUNTER_NUM = (ZEND_JIT_COUNTER_NUM + 1) % ZEND_HOT_COUNTERS_COUNT;
+					}
+					ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags |=
+						ZEND_JIT_TRACE_START_LOOP;
+				}
+			}
+		}
+	}
+
+	return SUCCESS;
+}
+
+static void zend_jit_trace_init_caches(void)
+{
+	memset(JIT_G(bad_root_cache_opline), 0, sizeof(JIT_G(bad_root_cache_opline)));
+	memset(JIT_G(bad_root_cache_count), 0, sizeof(JIT_G(bad_root_cache_count)));
+	memset(JIT_G(bad_root_cache_stop), 0, sizeof(JIT_G(bad_root_cache_count)));
+	JIT_G(bad_root_slot) = 0;
+
+	memset(JIT_G(exit_counters), 0, sizeof(JIT_G(exit_counters)));
+}
+
+static void zend_jit_trace_reset_caches(void)
+{
+}

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2794,8 +2794,13 @@ done:
 				top = zend_jit_trace_call_frame(top, op_array);
 				i = 0;
 				while (i < p->op_array->num_args) {
-					// TODO: initialize using SSA ???
-					call->stack[i] = IS_UNKNOWN;
+					/* Initialize abstract stack using SSA */
+					if (!(ssa->var_info[p->first_ssa_var + i].type & MAY_BE_GUARD)
+					 && has_concrete_type(ssa->var_info[p->first_ssa_var + i].type)) {
+						call->stack[i] = concrete_type(ssa->var_info[p->first_ssa_var + i].type);
+					} else {
+						call->stack[i] = IS_UNKNOWN;
+					}
 					i++;
 				}
 				while (i < p->op_array->last_var) {
@@ -2833,8 +2838,13 @@ done:
 				frame->return_value_used = -1;
 				stack = frame->stack;
 				for (i = 0; i < op_array->last_var + op_array->T; i++) {
-					// TODO: initialize using SSA ???
-					stack[i] = IS_UNKNOWN;
+					/* Initialize abstract stack using SSA */
+					if (!(ssa->var_info[p->first_ssa_var + i].type & MAY_BE_GUARD)
+					 && has_concrete_type(ssa->var_info[p->first_ssa_var + i].type)) {
+						stack[i] = concrete_type(ssa->var_info[p->first_ssa_var + i].type);
+					} else {
+						stack[i] = IS_UNKNOWN;
+					}
 				}
 			}
 			JIT_G(current_frame) = frame;
@@ -2858,7 +2868,7 @@ done:
 			if (p->func->type == ZEND_USER_FUNCTION) {
 				i = 0;
 				while (i < p->op_array->num_args) {
-					// TODO: initialize using SSA ???
+					/* Types of arguments are going to be stored in abstract stack when proseccin SEV onstruction */
 					call->stack[i] = IS_UNKNOWN;
 					i++;
 				}

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2806,6 +2806,11 @@ done:
 					call->stack[i] = IS_UNKNOWN;
 				}
 			}
+			if (p->fake) {
+				if (!zend_jit_init_fcall_guard(&dasm_state, NULL, p->func)) {
+					goto jit_failure;
+				}
+			}
 		} else if (p->op == ZEND_JIT_TRACE_DO_ICALL) {
 			call = frame->call;
 			if (call) {

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2800,9 +2800,18 @@ done:
 				call->func = (const zend_function*)op_array;
 				top = zend_jit_trace_call_frame(top, op_array);
 				i = 0;
-				// TODO: ???
-				for (i = 0; i < op_array->last_var + op_array->T; i++) {
+				while (i < p->op_array->num_args) {
+					// TODO: initialize using SSA ???
 					call->stack[i] = IS_UNKNOWN;
+					i++;
+				}
+				while (i < p->op_array->last_var) {
+					call->stack[i] = IS_UNDEF;
+					i++;
+				}
+				while (i < p->op_array->last_var + p->op_array->T) {
+					call->stack[i] = IS_UNKNOWN;
+					i++;
 				}
 			} else {
 				ZEND_ASSERT(&call->func->op_array == op_array);
@@ -2830,8 +2839,8 @@ done:
 				frame->func = (const zend_function*)op_array;
 				frame->return_value_used = -1;
 				stack = frame->stack;
-				// TODO: ???
 				for (i = 0; i < op_array->last_var + op_array->T; i++) {
+					// TODO: initialize using SSA ???
 					stack[i] = IS_UNKNOWN;
 				}
 			}
@@ -2854,9 +2863,19 @@ done:
 			frame->call = call;
 			top = zend_jit_trace_call_frame(top, p->op_array);
 			if (p->func->type == ZEND_USER_FUNCTION) {
-				// TODO: ???
-				for (i = 0; i < p->op_array->last_var + p->op_array->T; i++) {
+				i = 0;
+				while (i < p->op_array->num_args) {
+					// TODO: initialize using SSA ???
 					call->stack[i] = IS_UNKNOWN;
+					i++;
+				}
+				while (i < p->op_array->last_var) {
+					call->stack[i] = IS_UNDEF;
+					i++;
+				}
+				while (i < p->op_array->last_var + p->op_array->T) {
+					call->stack[i] = IS_UNKNOWN;
+					i++;
 				}
 			}
 			if (p->fake) {

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2556,6 +2556,52 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 						}
 						goto done;
 #endif
+//					case ZEND_INIT_NS_FCALL_BY_NAME:
+					case ZEND_INIT_METHOD_CALL:
+					case ZEND_INIT_DYNAMIC_CALL:
+						if (!zend_jit_trace_handler(&dasm_state, op_array, opline, zend_may_throw_ex(opline, ssa_op, op_array, ssa), p + 1)) {
+							goto jit_failure;
+						}
+						if ((p+1)->op == ZEND_JIT_TRACE_INIT_CALL) {
+							if (!zend_jit_init_fcall_guard(&dasm_state, opline, (p+1)->func)) {
+								goto jit_failure;
+							}
+						}
+						goto done;
+					case ZEND_INIT_STATIC_METHOD_CALL:
+						if (!zend_jit_trace_handler(&dasm_state, op_array, opline, zend_may_throw_ex(opline, ssa_op, op_array, ssa), p + 1)) {
+							goto jit_failure;
+						}
+						if ((opline->op1_type != IS_CONST
+						  || opline->op2_type != IS_CONST)
+						 && (p+1)->op == ZEND_JIT_TRACE_INIT_CALL) {
+							if (!zend_jit_init_fcall_guard(&dasm_state, opline, (p+1)->func)) {
+								goto jit_failure;
+							}
+						}
+						goto done;
+					case ZEND_INIT_USER_CALL:
+						if (!zend_jit_trace_handler(&dasm_state, op_array, opline, zend_may_throw_ex(opline, ssa_op, op_array, ssa), p + 1)) {
+							goto jit_failure;
+						}
+						if (opline->op2_type != IS_CONST
+						 && (p+1)->op == ZEND_JIT_TRACE_INIT_CALL) {
+							if (!zend_jit_init_fcall_guard(&dasm_state, opline, (p+1)->func)) {
+								goto jit_failure;
+							}
+						}
+						goto done;
+					case ZEND_NEW:
+						if (!zend_jit_trace_handler(&dasm_state, op_array, opline, zend_may_throw_ex(opline, ssa_op, op_array, ssa), p + 1)) {
+							goto jit_failure;
+						}
+						if (opline->op1_type != IS_CONST
+						 && (p+1)->op == ZEND_JIT_TRACE_INIT_CALL) {
+							if (!zend_jit_init_fcall_guard(&dasm_state, opline, (p+1)->func)) {
+								goto jit_failure;
+							}
+						}
+						goto done;
 					default:
 						break;
 				}

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -1616,6 +1616,15 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 				i * sizeof(zend_jit_trace_stack));
 		}
 	}
+	while (i < op_array->last_var) {
+		if (!(ssa->var_info[i].type & MAY_BE_GUARD)
+		 && has_concrete_type(ssa->var_info[i].type)) {
+			stack[i] = concrete_type(ssa->var_info[i].type);
+		} else {
+			stack[i] = IS_UNKNOWN;
+		}
+		i++;
+	}
 	while (i < op_array->last_var + op_array->T) {
 		stack[i] = IS_UNKNOWN;
 		i++;
@@ -1676,6 +1685,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 							goto jit_failure;
 						}
 						ssa->var_info[i].type = info & ~MAY_BE_GUARD;
+						stack[i] = concrete_type(info);
 					}
 				}
 			}
@@ -1691,6 +1701,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 						goto jit_failure;
 					}
 					ssa->var_info[phi->sources[0]].type = info & ~MAY_BE_GUARD;
+					stack[i] = concrete_type(info);
 				}
 				phi = phi->next;
 			}

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -708,7 +708,7 @@ static int find_return_ssa_var(zend_jit_trace_rec *p, zend_ssa_op *ssa_op)
 			if (p->opline->opcode == ZEND_DO_UCALL
 			 || p->opline->opcode == ZEND_DO_FCALL_BY_NAME
 			 || p->opline->opcode == ZEND_DO_FCALL) {
-				if (p->opline->result_type == IS_UNUSED) {
+				if (p->opline->result_type != IS_UNUSED) {
 					return ssa_op->result_def;
 				}
 			}

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -243,7 +243,7 @@ static int zend_jit_trace_may_exit(const zend_op_array *op_array, const zend_op 
 			return 1;
 		case ZEND_NEW:
 			if (opline->extended_value == 0 && (opline+1)->opcode == ZEND_DO_FCALL) {
-				/* NEW may skip constructor without argumnts */
+				/* NEW may skip constructor without arguments */
 				return 1;
 			}
 			break;

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -1318,9 +1318,14 @@ static zend_ssa *zend_jit_trace_build_tssa(zend_jit_trace_rec *trace_buffer, uin
 					}
 				}
 			}
-			if (zend_update_type_info(op_array, tssa, script, (zend_op*)opline, ssa_ops + idx, ssa_opcodes, optimization_level) == FAILURE) {
-				// TODO:
-				assert(0);
+			if (opline->opcode == ZEND_RECV_INIT) {
+				/* RECV_INIT always copy the constant */
+				ssa_var_info[ssa_ops[idx].result_def].type = zend_jit_trace_type_to_info(Z_TYPE_P(RT_CONSTANT(opline, opline->op2)));
+			} else {
+				if (zend_update_type_info(op_array, tssa, script, (zend_op*)opline, ssa_ops + idx, ssa_opcodes, optimization_level) == FAILURE) {
+					// TODO:
+					assert(0);
+				}
 			}
 			if (ssa->var_info) {
 				/* Add statically inferred restrictions */
@@ -1366,9 +1371,14 @@ static zend_ssa *zend_jit_trace_build_tssa(zend_jit_trace_rec *trace_buffer, uin
 							zend_jit_trace_copy_ssa_var_range(op_array, ssa, ssa_opcodes, tssa, ssa_ops[idx].result_def);
 						}
 					}
-					if (zend_update_type_info(op_array, tssa, script, (zend_op*)opline, ssa_ops + idx, ssa_opcodes, optimization_level) == FAILURE) {
-						// TODO:
-						assert(0);
+					if (opline->opcode == ZEND_RECV_INIT) {
+						/* RECV_INIT always copy the constant */
+						ssa_var_info[ssa_ops[idx].result_def].type = zend_jit_trace_type_to_info(Z_TYPE_P(RT_CONSTANT(opline, opline->op2)));
+					} else {
+						if (zend_update_type_info(op_array, tssa, script, (zend_op*)opline, ssa_ops + idx, ssa_opcodes, optimization_level) == FAILURE) {
+							// TODO:
+							assert(0);
+						}
 					}
 				}
 				if (ssa->var_info) {

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -264,7 +264,7 @@ static int zend_jit_trace_may_exit(const zend_op_array *op_array, const zend_op 
 #if 0
 		case ZEND_DO_UCALL:
 		case ZEND_DO_FCALL_BY_NAME:
-			/* monomorthic call */
+			/* monomorphic call */
 			// TODO: recompilation may change traget ???
 			return 0;
 #endif

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -1628,6 +1628,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 	frame->prev = NULL;
 	frame->func = (const zend_function*)op_array;
 	frame->return_value_used = -1;
+	frame->nested = 0;
 	stack = frame->stack;
 
 	if (trace_buffer->start == ZEND_JIT_TRACE_START_ENTER) {
@@ -2820,6 +2821,7 @@ done:
 				call->call = NULL;
 				call->prev = NULL;
 				call->func = (const zend_function*)op_array;
+				call->nested = 0;
 				top = zend_jit_trace_call_frame(top, op_array);
 				i = 0;
 				while (i < p->op_array->num_args) {
@@ -2865,6 +2867,7 @@ done:
 				frame->prev = NULL;
 				frame->func = (const zend_function*)op_array;
 				frame->return_value_used = -1;
+				frame->nested = 0;
 				stack = frame->stack;
 				for (i = 0; i < op_array->last_var + op_array->T; i++) {
 					/* Initialize abstract stack using SSA */
@@ -2892,6 +2895,7 @@ done:
 			call->call = NULL;
 			call->prev = frame->call;
 			call->func = p->func;
+			call->nested = 1;
 			frame->call = call;
 			top = zend_jit_trace_call_frame(top, p->op_array);
 			if (p->func->type == ZEND_USER_FUNCTION) {

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2265,7 +2265,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 							break;
 						}
 						op1_info = OP1_INFO_EX();
-						CHECK_OP1_TRACE_TYPE();//USE_OP1_TRACE_TYPE();
+						USE_OP1_TRACE_TYPE();
 						if ((opline->result_type & (IS_SMART_BRANCH_JMPZ|IS_SMART_BRANCH_JMPNZ)) != 0) {
 							zend_bool exit_if_true = 0;
 							const zend_op *exit_opline = zend_jit_trace_get_exit_opline(p + 1, opline + 1, &exit_if_true);

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2561,6 +2561,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 						goto done;
 #endif
 //					case ZEND_INIT_NS_FCALL_BY_NAME:
+						// TODO: we may need a guard after INIT_NS_FCALL???
 					case ZEND_INIT_METHOD_CALL:
 					case ZEND_INIT_DYNAMIC_CALL:
 						if (!zend_jit_trace_handler(&dasm_state, op_array, opline, zend_may_throw_ex(opline, ssa_op, op_array, ssa), p + 1)) {

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -722,9 +722,9 @@ static int find_return_ssa_var(zend_jit_trace_rec *p, zend_ssa_op *ssa_op)
 	}
 }
 
-static int is_checked_guard(const zend_ssa *tssa, const zend_op **ssa_opcodes, uint32_t var)
+static int is_checked_guard(const zend_ssa *tssa, const zend_op **ssa_opcodes, uint32_t var, uint32_t phi_var)
 {
-	if ((tssa->var_info[var].type & MAY_BE_ANY) == MAY_BE_LONG) {
+	if ((tssa->var_info[phi_var].type & MAY_BE_ANY) == MAY_BE_LONG) {
 		uint32_t idx = tssa->vars[var].definition;
 
 		if (idx >= 0) {
@@ -737,7 +737,7 @@ static int is_checked_guard(const zend_ssa *tssa, const zend_op **ssa_opcodes, u
 					return 1;
 				}
 			}
-			if (tssa->ops[idx].op1_def == var) {
+			if (tssa->ops[idx].result_def == var) {
 				const zend_op *opline = ssa_opcodes[idx];
 				if (opline->opcode == ZEND_ADD
 				 || opline->opcode == ZEND_SUB
@@ -1539,8 +1539,8 @@ static zend_ssa *zend_jit_trace_build_tssa(zend_jit_trace_rec *trace_buffer, uin
 						ssa_var_info[phi->sources[0]].type = MAY_BE_GUARD | (t & t0);
 					}
 					if ((t1 & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) != (t & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF))) {
-						ssa_var_info[phi->sources[1]].type = MAY_BE_GUARD | (t & t1);
-						if (is_checked_guard(tssa, ssa_opcodes, phi->sources[1])) {
+						if (is_checked_guard(tssa, ssa_opcodes, phi->sources[1], phi->ssa_var)) {
+							ssa_var_info[phi->sources[1]].type = MAY_BE_GUARD | (t & t1);
 							ssa_var_info[phi->ssa_var].type = t & ~MAY_BE_GUARD;
 						}
 					}

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -259,7 +259,7 @@ static int zend_jit_trace_may_exit(const zend_op_array *op_array, const zend_op 
 			/* unsupported */
 			return 1;
 		case ZEND_DO_FCALL:
-			/* potentialy polimorhic call */
+			/* potentially polymorphic call */
 			return 1;
 #if 0
 		case ZEND_DO_UCALL:

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -1318,7 +1318,8 @@ static zend_ssa *zend_jit_trace_build_tssa(zend_jit_trace_rec *trace_buffer, uin
 					}
 				}
 			}
-			if (opline->opcode == ZEND_RECV_INIT) {
+			if (opline->opcode == ZEND_RECV_INIT
+			 && !(op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
 				/* RECV_INIT always copy the constant */
 				ssa_var_info[ssa_ops[idx].result_def].type = zend_jit_trace_type_to_info(Z_TYPE_P(RT_CONSTANT(opline, opline->op2)));
 			} else {
@@ -1371,7 +1372,8 @@ static zend_ssa *zend_jit_trace_build_tssa(zend_jit_trace_rec *trace_buffer, uin
 							zend_jit_trace_copy_ssa_var_range(op_array, ssa, ssa_opcodes, tssa, ssa_ops[idx].result_def);
 						}
 					}
-					if (opline->opcode == ZEND_RECV_INIT) {
+					if (opline->opcode == ZEND_RECV_INIT
+					 && !(op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
 						/* RECV_INIT always copy the constant */
 						ssa_var_info[ssa_ops[idx].result_def].type = zend_jit_trace_type_to_info(Z_TYPE_P(RT_CONSTANT(opline, opline->op2)));
 					} else {

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2265,7 +2265,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 							break;
 						}
 						op1_info = OP1_INFO_EX();
-						USE_OP1_TRACE_TYPE();
+						CHECK_OP1_TRACE_TYPE();//USE_OP1_TRACE_TYPE();
 						if ((opline->result_type & (IS_SMART_BRANCH_JMPZ|IS_SMART_BRANCH_JMPNZ)) != 0) {
 							zend_bool exit_if_true = 0;
 							const zend_op *exit_opline = zend_jit_trace_get_exit_opline(p + 1, opline + 1, &exit_if_true);

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -620,24 +620,24 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *ex, 
 				op2_type = Z_TYPE_P(Z_REFVAL_P(zv)) | IS_TRACE_REFERENCE;
 			}
 		}
-		if ((
-			opline->opcode == ZEND_ASSIGN_DIM ||
+		if (opline->opcode == ZEND_ASSIGN_DIM ||
 			opline->opcode == ZEND_ASSIGN_OBJ ||
 			opline->opcode == ZEND_ASSIGN_STATIC_PROP ||
 			opline->opcode == ZEND_ASSIGN_DIM_OP ||
 			opline->opcode == ZEND_ASSIGN_OBJ_OP ||
 			opline->opcode == ZEND_ASSIGN_STATIC_PROP_OP ||
 			opline->opcode == ZEND_ASSIGN_OBJ_REF ||
-			opline->opcode == ZEND_ASSIGN_STATIC_PROP_REF) &&
-				((opline+1)->op1_type & (IS_TMP_VAR|IS_VAR|IS_CV))) {
-			zval *zv = EX_VAR((opline+1)->op1.var);
-			op3_type = Z_TYPE_P(zv);
-			if (op3_type == IS_INDIRECT) {
-				zv = Z_INDIRECT_P(zv);
+			opline->opcode == ZEND_ASSIGN_STATIC_PROP_REF) {
+			if ((opline+1)->op1_type & (IS_TMP_VAR|IS_VAR|IS_CV)) {
+				zval *zv = EX_VAR((opline+1)->op1.var);
 				op3_type = Z_TYPE_P(zv);
-			}
-			if (op3_type == IS_REFERENCE) {
-				op3_type = Z_TYPE_P(Z_REFVAL_P(zv)) | IS_TRACE_REFERENCE;
+				if (op3_type == IS_INDIRECT) {
+					zv = Z_INDIRECT_P(zv);
+					op3_type = Z_TYPE_P(zv);
+				}
+				if (op3_type == IS_REFERENCE) {
+					op3_type = Z_TYPE_P(Z_REFVAL_P(zv)) | IS_TRACE_REFERENCE;
+				}
 			}
 		}
 
@@ -868,7 +868,6 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *ex, 
 	}
 
 	TRACE_END(ZEND_JIT_TRACE_END, stop, opline);
-	((zend_jit_trace_start_rec*)trace_buffer)->len = idx;
 
 #ifdef HAVE_GCC_GLOBAL_REGS
 	if (stop != ZEND_JIT_TRACE_STOP_HALT) {

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -26,6 +26,7 @@
 
 #include <ZendAccelerator.h>
 #include "Optimizer/zend_func_info.h"
+#include "Optimizer/zend_call_graph.h"
 #include "zend_jit.h"
 #include "zend_jit_internal.h"
 
@@ -96,6 +97,15 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_leave_top_func_helper(uint32_t ca
 #else
 	return -1; // ZEND_VM_RETURN
 #endif
+}
+
+ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_leave_func_helper(uint32_t call_info EXECUTE_DATA_DC)
+{
+	if (call_info & ZEND_CALL_TOP) {
+		ZEND_OPCODE_TAIL_CALL_EX(zend_jit_leave_top_func_helper, call_info);
+	} else {
+		ZEND_OPCODE_TAIL_CALL_EX(zend_jit_leave_nested_func_helper, call_info);
+	}
 }
 
 void ZEND_FASTCALL zend_jit_copy_extra_args_helper(EXECUTE_DATA_D)
@@ -182,8 +192,8 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_profile_helper(ZEND_OPCODE_HANDLE
 
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_func_counter_helper(ZEND_OPCODE_HANDLER_ARGS)
 {
-	zend_jit_op_array_extension *jit_extension =
-		(zend_jit_op_array_extension*)ZEND_FUNC_INFO(&EX(func)->op_array);
+	zend_jit_op_array_hot_extension *jit_extension =
+		(zend_jit_op_array_hot_extension*)ZEND_FUNC_INFO(&EX(func)->op_array);
 #ifndef HAVE_GCC_GLOBAL_REGS
 	const zend_op *opline = EX(opline);
 #endif
@@ -191,6 +201,7 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_func_counter_helper(ZEND_OPCODE_H
 	*(jit_extension->counter) -= ZEND_JIT_HOT_FUNC_COST;
 
 	if (UNEXPECTED(*(jit_extension->counter) <= 0)) {
+		*(jit_extension->counter) = ZEND_JIT_HOT_COUNTER_INIT;
 		zend_jit_hot_func(execute_data, opline);
 		ZEND_OPCODE_RETURN();
 	} else {
@@ -201,8 +212,8 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_func_counter_helper(ZEND_OPCODE_H
 
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_loop_counter_helper(ZEND_OPCODE_HANDLER_ARGS)
 {
-	zend_jit_op_array_extension *jit_extension =
-		(zend_jit_op_array_extension*)ZEND_FUNC_INFO(&EX(func)->op_array);
+	zend_jit_op_array_hot_extension *jit_extension =
+		(zend_jit_op_array_hot_extension*)ZEND_FUNC_INFO(&EX(func)->op_array);
 #ifndef HAVE_GCC_GLOBAL_REGS
 	const zend_op *opline = EX(opline);
 #endif
@@ -210,6 +221,7 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_loop_counter_helper(ZEND_OPCODE_H
 	*(jit_extension->counter) -= ZEND_JIT_HOT_LOOP_COST;
 
 	if (UNEXPECTED(*(jit_extension->counter) <= 0)) {
+		*(jit_extension->counter) = ZEND_JIT_HOT_COUNTER_INIT;
 		zend_jit_hot_func(execute_data, opline);
 		ZEND_OPCODE_RETURN();
 	} else {
@@ -265,4 +277,609 @@ void ZEND_FASTCALL zend_jit_get_constant(const zval *key, uint32_t flags)
 int ZEND_FASTCALL zend_jit_check_constant(const zval *key)
 {
 	return _zend_quick_get_constant(key, 0, 1);
+}
+
+static zend_always_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_trace_counter_helper(uint32_t cost ZEND_OPCODE_HANDLER_ARGS_DC)
+{
+	zend_jit_op_array_trace_extension *jit_extension =
+		(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(&EX(func)->op_array);
+	size_t offset = jit_extension->offset;
+#ifndef HAVE_GCC_GLOBAL_REGS
+	const zend_op *opline = EX(opline);
+#endif
+
+	*(ZEND_OP_TRACE_INFO(opline, offset)->counter) -= ZEND_JIT_TRACE_FUNC_COST;
+
+	if (UNEXPECTED(*(ZEND_OP_TRACE_INFO(opline, offset)->counter) <= 0)) {
+		*(ZEND_OP_TRACE_INFO(opline, offset)->counter) = ZEND_JIT_TRACE_COUNTER_INIT;
+		if (UNEXPECTED(zend_jit_trace_hot_root(execute_data, opline) < 0)) {
+#ifndef HAVE_GCC_GLOBAL_REGS
+			return -1;
+#endif
+		}
+#ifdef HAVE_GCC_GLOBAL_REGS
+		execute_data = EG(current_execute_data);
+		opline = EX(opline);
+		return;
+#else
+		return 1;
+#endif
+	} else {
+		zend_vm_opcode_handler_t handler = (zend_vm_opcode_handler_t)ZEND_OP_TRACE_INFO(opline, offset)->orig_handler;
+		ZEND_OPCODE_TAIL_CALL(handler);
+	}
+}
+
+ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_func_trace_helper(ZEND_OPCODE_HANDLER_ARGS)
+{
+	ZEND_OPCODE_TAIL_CALL_EX(zend_jit_trace_counter_helper, ZEND_JIT_TRACE_FUNC_COST);
+}
+
+ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_ret_trace_helper(ZEND_OPCODE_HANDLER_ARGS)
+{
+	ZEND_OPCODE_TAIL_CALL_EX(zend_jit_trace_counter_helper, ZEND_JIT_TRACE_RET_COST);
+}
+
+ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_loop_trace_helper(ZEND_OPCODE_HANDLER_ARGS)
+{
+	ZEND_OPCODE_TAIL_CALL_EX(zend_jit_trace_counter_helper, ZEND_JIT_TRACE_LOOP_COST);
+}
+
+#define TRACE_RECORD(_op, _ptr) \
+	trace_buffer[idx].op = _op; \
+	trace_buffer[idx].ptr = _ptr; \
+	idx++; \
+	if (idx >= ZEND_JIT_TRACE_MAX_LENGTH - 1) { \
+		stop = ZEND_JIT_TRACE_STOP_TOO_LONG; \
+		break; \
+	}
+
+#define TRACE_RECORD_VM(_op, _ptr, _op1_type, _op2_type, _op3_type) \
+	trace_buffer[idx].op = _op; \
+	trace_buffer[idx].op1_type = _op1_type; \
+	trace_buffer[idx].op2_type = _op2_type; \
+	trace_buffer[idx].op3_type = _op3_type; \
+	trace_buffer[idx].ptr = _ptr; \
+	idx++; \
+	if (idx >= ZEND_JIT_TRACE_MAX_LENGTH - 1) { \
+		stop = ZEND_JIT_TRACE_STOP_TOO_LONG; \
+		break; \
+	}
+
+#define TRACE_RECORD_ENTER(_op, _return_value_used, _ptr) \
+	trace_buffer[idx].op = _op; \
+	trace_buffer[idx].return_value_used = _return_value_used; \
+	trace_buffer[idx].ptr = _ptr; \
+	idx++; \
+	if (idx >= ZEND_JIT_TRACE_MAX_LENGTH - 1) { \
+		stop = ZEND_JIT_TRACE_STOP_TOO_LONG; \
+		break; \
+	}
+
+#define TRACE_RECORD_INIT(_op, _fake, _ptr) \
+	trace_buffer[idx].op = _op; \
+	trace_buffer[idx].fake = _fake; \
+	trace_buffer[idx].ptr = _ptr; \
+	idx++; \
+	if (idx >= ZEND_JIT_TRACE_MAX_LENGTH - 1) { \
+		stop = ZEND_JIT_TRACE_STOP_TOO_LONG; \
+		break; \
+	}
+
+#define TRACE_RECORD_BACK(_op, _recursive, _ptr) \
+	trace_buffer[idx].op = _op; \
+	trace_buffer[idx].recursive = _recursive; \
+	trace_buffer[idx].ptr = _ptr; \
+	idx++; \
+	if (idx >= ZEND_JIT_TRACE_MAX_LENGTH - 1) { \
+		stop = ZEND_JIT_TRACE_STOP_TOO_LONG; \
+		break; \
+	}
+
+#define TRACE_RECORD_TYPE(_op, _ptr) \
+	trace_buffer[idx].op = _op; \
+	trace_buffer[idx].ptr = _ptr; \
+	idx++; \
+	if (idx >= ZEND_JIT_TRACE_MAX_LENGTH - 1) { \
+		stop = ZEND_JIT_TRACE_STOP_TOO_LONG; \
+		break; \
+	}
+
+#define TRACE_START(_op, _start, _ptr) \
+	trace_buffer[0].op = _op; \
+	trace_buffer[0].start = _start; \
+	trace_buffer[0].level = 0; \
+	trace_buffer[0].ptr = _ptr; \
+	idx = ZEND_JIT_TRACE_START_REC_SIZE;
+
+#define TRACE_END(_op, _stop, _ptr) \
+	trace_buffer[idx].op   = _op; \
+	trace_buffer[idx].start = trace_buffer[idx].start; \
+	trace_buffer[idx].stop = trace_buffer[0].stop = _stop; \
+	trace_buffer[idx].level = trace_buffer[0].level = ret_level ? ret_level + 1 : 0; \
+	trace_buffer[idx].ptr  = _ptr;
+
+#ifndef ZEND_JIT_RECORD_RECURSIVE_RETURN
+# define ZEND_JIT_RECORD_RECURSIVE_RETURN 1
+#endif
+
+static int zend_jit_trace_recursive_call_count(const zend_op_array *op_array, const zend_op_array **unrolled_calls, int ret_level, int level)
+{
+	int i;
+	int count = 0;
+
+	for (i = ret_level; i < level; i++) {
+		count += (unrolled_calls[i] == op_array);
+	}
+	return count;
+}
+
+static int zend_jit_trace_recursive_ret_count(const zend_op_array *op_array, const zend_op_array **unrolled_calls, int ret_level)
+{
+	int i;
+	int count = 0;
+
+	for (i = 0; i < ret_level; i++) {
+		count += (unrolled_calls[i] == op_array);
+	}
+	return count;
+}
+
+static int zend_jit_trace_has_recursive_ret(zend_execute_data *ex, const zend_op_array *orig_op_array, const zend_op *orig_opline, int ret_level)
+{
+	while (ex != NULL && ret_level < ZEND_JIT_TRACE_MAX_RET_DEPTH) {
+		if (&ex->func->op_array == orig_op_array && ex->opline + 1 == orig_opline) {
+			return 1;
+		}
+		ex = ex->prev_execute_data;
+		ret_level++;
+	}
+	return 0;
+}
+
+static int zend_jit_trace_bad_inner_loop(const zend_op *opline)
+{
+	const zend_op **cache_opline = JIT_G(bad_root_cache_opline);
+	uint8_t *cache_count = JIT_G(bad_root_cache_count);
+	uint8_t *cache_stop = JIT_G(bad_root_cache_stop);
+	uint32_t i;
+
+	for (i = 0; i < ZEND_JIT_TRACE_BAD_ROOT_SLOTS; i++) {
+		if (cache_opline[i] == opline) {
+			if ((cache_stop[i] == ZEND_JIT_TRACE_STOP_INNER_LOOP
+			  || cache_stop[i] == ZEND_JIT_TRACE_STOP_LOOP_EXIT)
+			 && cache_count[i] > ZEND_JIT_TRACE_MAX_ROOT_FAILURES / 2) {
+				return 1;
+			}
+			break;
+		}
+	}
+	return 0;
+}
+
+static int zend_jit_trace_bad_compiled_loop(const zend_op *opline)
+{
+	const zend_op **cache_opline = JIT_G(bad_root_cache_opline);
+	uint8_t *cache_count = JIT_G(bad_root_cache_count);
+	uint8_t *cache_stop = JIT_G(bad_root_cache_stop);
+	uint32_t i;
+
+	for (i = 0; i < ZEND_JIT_TRACE_BAD_ROOT_SLOTS; i++) {
+		if (cache_opline[i] == opline) {
+			if (cache_stop[i] == ZEND_JIT_TRACE_STOP_COMPILED_LOOP
+			 && cache_count[i] >= ZEND_JIT_TRACE_MAX_ROOT_FAILURES - 1) {
+				return 1;
+			}
+			break;
+		}
+	}
+	return 0;
+}
+
+static int zend_jit_trace_bad_loop_exit(const zend_op *opline)
+{
+	const zend_op **cache_opline = JIT_G(bad_root_cache_opline);
+	uint8_t *cache_count = JIT_G(bad_root_cache_count);
+	uint8_t *cache_stop = JIT_G(bad_root_cache_stop);
+	uint32_t i;
+
+	for (i = 0; i < ZEND_JIT_TRACE_BAD_ROOT_SLOTS; i++) {
+		if (cache_opline[i] == opline) {
+			if (cache_stop[i] == ZEND_JIT_TRACE_STOP_LOOP_EXIT
+			 && cache_count[i] >= ZEND_JIT_TRACE_MAX_ROOT_FAILURES - 1) {
+				return 1;
+			}
+			break;
+		}
+	}
+	return 0;
+}
+
+static int zend_jit_trace_record_fake_init_call(zend_execute_data *call, zend_jit_trace_rec *trace_buffer, int idx)
+{
+	zend_jit_trace_stop stop ZEND_ATTRIBUTE_UNUSED = ZEND_JIT_TRACE_STOP_ERROR;
+
+	do {
+		if (call->prev_execute_data) {
+			idx = zend_jit_trace_record_fake_init_call(call->prev_execute_data, trace_buffer, idx);
+		}
+		TRACE_RECORD_INIT(ZEND_JIT_TRACE_INIT_CALL, 1, call->func);
+	} while (0);
+	return idx;
+}
+
+/*
+ *  Trace Linking Rules
+ *  ===================
+ *
+ *                                          flags
+ *          +----------+----------+----------++----------+----------+----------+
+ *          |                                ||              JIT               |
+ *          +----------+----------+----------++----------+----------+----------+
+ *   start  |   LOOP   |  ENTER   |  RETURN  ||   LOOP   |  ENTER   |  RETURN  |
+ * +========+==========+==========+==========++==========+==========+==========+
+ * | LOOP   |   loop   |          | loop-ret || COMPILED |   LINK   |   LINK   |
+ * +--------+----------+----------+----------++----------+----------+----------+
+ * | ENTER  |INNER_LOOP| rec-call |  return  ||   LINK   |   LINK   |   LINK   |
+ * +--------+----------+----------+----------++----------+----------+----------+
+ * | RETURN |INNER_LOOP|          |  rec-ret ||   LINK   |          |   LINK   |
+ * +--------+----------+----------+----------++----------+----------+----------+
+ * | SIDE   |  unroll  |          |  return  ||   LINK   |   LINK   |   LINK   |
+ * +--------+----------+----------+----------++----------+----------+----------+
+ *
+ * loop:       LOOP if "cycle" and level == 0, otherwise INNER_LOOP
+ * INNER_LOOP: abort recording and start new one (wit for loop)
+ * COMPILED:   abort recording (wait while side exit creates outer loop)
+ * unroll:     continue recording while unroll limit reached
+ * rec-call:   RECURSIVE_CALL if "cycle" and level > N, otherwise continue
+ * loop-ret:   LOOP_EXIT if level == 0, otherwise continue (wait for loop)
+ * return:     RETURN if level == 0
+ * rec_ret:    RECURSIVE_RET if "cycle" and ret_level > N, otherwise continue
+ *
+ */
+
+zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *ex, const zend_op *op, zend_jit_trace_rec *trace_buffer, uint8_t start)
+{
+#ifdef HAVE_GCC_GLOBAL_REGS
+	zend_execute_data *save_execute_data = execute_data;
+	const zend_op *save_opline = opline;
+#endif
+	const zend_op *orig_opline;
+	zend_jit_trace_stop stop = ZEND_JIT_TRACE_STOP_ERROR;
+	int level = 0;
+	int ret_level = 0;
+	zend_vm_opcode_handler_t handler;
+	zend_jit_op_array_trace_extension *jit_extension;
+	size_t offset;
+	int idx, count;
+	uint8_t  trace_flags, op1_type, op2_type, op3_type;
+	int backtrack_recursion = -1;
+	int backtrack_ret_recursion = -1;
+	int backtrack_ret_recursion_level = 0;
+	int loop_unroll_limit = 0;
+	const zend_op_array *unrolled_calls[ZEND_JIT_TRACE_MAX_CALL_DEPTH + ZEND_JIT_TRACE_MAX_RET_DEPTH];
+#if ZEND_JIT_DETECT_UNROLLED_LOOPS
+	uint32_t unrolled_loops[ZEND_JIT_TRACE_MAX_UNROLL_LOOPS];
+#endif
+	zend_bool is_toplevel;
+#ifdef HAVE_GCC_GLOBAL_REGS
+	zend_execute_data *prev_execute_data = ex;
+
+	execute_data = ex;
+	opline = EX(opline) = op;
+#else
+	int rc;
+	zend_execute_data *execute_data = ex;
+	const zend_op *opline = EX(opline);
+#endif
+	zend_execute_data *prev_call = EX(call);
+
+	orig_opline = opline;
+
+	jit_extension =
+		(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(&EX(func)->op_array);
+	offset = jit_extension->offset;
+
+	TRACE_START(ZEND_JIT_TRACE_START, start, &EX(func)->op_array);
+	((zend_jit_trace_start_rec*)trace_buffer)->opline = opline;
+	is_toplevel = EX(func)->op_array.function_name == NULL;
+
+
+	if (prev_call) {
+		idx = zend_jit_trace_record_fake_init_call(prev_call, trace_buffer, idx);
+	}
+
+	while (1) {
+		if (UNEXPECTED(opline->opcode == ZEND_HANDLE_EXCEPTION)) {
+			/* Abort trace because of exception */
+			stop = ZEND_JIT_TRACE_STOP_EXCEPTION;
+			break;
+		}
+
+		op1_type = op2_type = op3_type = IS_UNKNOWN;
+		if ((opline->op1_type & (IS_TMP_VAR|IS_VAR|IS_CV))
+		 &&	(opline->opcode != ZEND_ROPE_ADD && opline->opcode != ZEND_ROPE_END)) {
+			zval *zv = EX_VAR(opline->op1.var);
+			op1_type = Z_TYPE_P(zv);
+			if (op1_type == IS_INDIRECT) {
+				zv = Z_INDIRECT_P(zv);
+				op1_type = Z_TYPE_P(zv);
+			}
+			if (op1_type == IS_REFERENCE) {
+				op1_type = Z_TYPE_P(Z_REFVAL_P(zv)) | IS_TRACE_REFERENCE;
+			}
+		}
+		if (opline->op2_type & (IS_TMP_VAR|IS_VAR|IS_CV)) {
+			zval *zv = EX_VAR(opline->op2.var);
+			op2_type = Z_TYPE_P(zv);
+			if (op2_type == IS_INDIRECT) {
+				zv = Z_INDIRECT_P(zv);
+				op2_type = Z_TYPE_P(zv);
+			}
+			if (op2_type == IS_REFERENCE) {
+				op2_type = Z_TYPE_P(Z_REFVAL_P(zv)) | IS_TRACE_REFERENCE;
+			}
+		}
+		if ((
+			opline->opcode == ZEND_ASSIGN_DIM ||
+			opline->opcode == ZEND_ASSIGN_OBJ ||
+			opline->opcode == ZEND_ASSIGN_STATIC_PROP ||
+			opline->opcode == ZEND_ASSIGN_DIM_OP ||
+			opline->opcode == ZEND_ASSIGN_OBJ_OP ||
+			opline->opcode == ZEND_ASSIGN_STATIC_PROP_OP ||
+			opline->opcode == ZEND_ASSIGN_OBJ_REF ||
+			opline->opcode == ZEND_ASSIGN_STATIC_PROP_REF) &&
+				((opline+1)->op1_type & (IS_TMP_VAR|IS_VAR|IS_CV))) {
+			zval *zv = EX_VAR((opline+1)->op1.var);
+			op3_type = Z_TYPE_P(zv);
+			if (op3_type == IS_INDIRECT) {
+				zv = Z_INDIRECT_P(zv);
+				op3_type = Z_TYPE_P(zv);
+			}
+			if (op3_type == IS_REFERENCE) {
+				op3_type = Z_TYPE_P(Z_REFVAL_P(zv)) | IS_TRACE_REFERENCE;
+			}
+		}
+
+		TRACE_RECORD_VM(ZEND_JIT_TRACE_VM, opline, op1_type, op2_type, op3_type);
+
+		if (opline->op1_type & (IS_TMP_VAR|IS_VAR|IS_CV)) {
+			zval *var = EX_VAR(opline->op1.var);
+			uint8_t type = Z_TYPE_P(var);
+
+			if (type == IS_OBJECT) {
+				TRACE_RECORD_TYPE(ZEND_JIT_TRACE_OP1_TYPE, Z_OBJCE_P(var));
+			}
+		}
+
+		if (opline->op2_type & (IS_TMP_VAR|IS_VAR|IS_CV)) {
+			zval *var = EX_VAR(opline->op2.var);
+			uint8_t type = Z_TYPE_P(var);
+
+			if (type == IS_OBJECT) {
+				TRACE_RECORD_TYPE(ZEND_JIT_TRACE_OP2_TYPE, Z_OBJCE_P(var));
+			}
+		}
+
+		switch (opline->opcode) {
+			case ZEND_DO_FCALL:
+			case ZEND_DO_ICALL:
+			case ZEND_DO_UCALL:
+			case ZEND_DO_FCALL_BY_NAME:
+				if (EX(call)->func->type == ZEND_INTERNAL_FUNCTION) {
+					TRACE_RECORD(ZEND_JIT_TRACE_DO_ICALL, EX(call)->func);
+				}
+				break;
+			default:
+				break;
+		}
+
+		handler = (zend_vm_opcode_handler_t)ZEND_OP_TRACE_INFO(opline, offset)->call_handler;
+#ifdef HAVE_GCC_GLOBAL_REGS
+		handler();
+		if (UNEXPECTED(opline == zend_jit_halt_op)) {
+			stop = ZEND_JIT_TRACE_STOP_HALT;
+			break;
+		}
+		if (UNEXPECTED(execute_data != prev_execute_data)) {
+			if (execute_data->prev_execute_data == prev_execute_data) {
+#else
+		rc = handler(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);
+		if (rc != 0) {
+			if (rc < 0) {
+				stop = ZEND_JIT_TRACE_STOP_HALT;
+				break;
+			}
+			execute_data = EG(current_execute_data);
+			opline = EX(opline);
+			if (rc == 1) {
+#endif
+				/* Enter into function */
+				if (level > ZEND_JIT_TRACE_MAX_CALL_DEPTH) {
+					stop = ZEND_JIT_TRACE_STOP_TOO_DEEP;
+					break;
+				}
+
+				if (EX(func)->op_array.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
+					/* TODO: Can we continue recording ??? */
+					stop = ZEND_JIT_TRACE_STOP_TRAMPOLINE;
+					break;
+				}
+
+				TRACE_RECORD_ENTER(ZEND_JIT_TRACE_ENTER, EX(return_value) != NULL, &EX(func)->op_array);
+
+				count = zend_jit_trace_recursive_call_count(&EX(func)->op_array, unrolled_calls, ret_level, level);
+
+				if (opline == orig_opline) {
+					if (count + 1 >= ZEND_JIT_TRACE_MAX_RECURSION) {
+						stop = ZEND_JIT_TRACE_STOP_RECURSIVE_CALL;
+						break;
+					}
+					backtrack_recursion = idx;
+				} else if (count >= ZEND_JIT_TRACE_MAX_RECURSION) {
+					stop = ZEND_JIT_TRACE_STOP_DEEP_RECURSION;
+					break;
+				}
+
+				unrolled_calls[ret_level + level] = &EX(func)->op_array;
+				level++;
+			} else {
+				/* Return from function */
+				if (level == 0) {
+					if (is_toplevel) {
+						stop = ZEND_JIT_TRACE_STOP_TOPLEVEL;
+						break;
+#if ZEND_JIT_RECORD_RECURSIVE_RETURN
+					} else if (start == ZEND_JIT_TRACE_START_RETURN
+					        && execute_data->prev_execute_data
+					        && execute_data->prev_execute_data->func
+					        && execute_data->prev_execute_data->func->type == ZEND_USER_FUNCTION
+					        && zend_jit_trace_has_recursive_ret(execute_data, trace_buffer[0].op_array, orig_opline, ret_level)) {
+						if (ret_level > ZEND_JIT_TRACE_MAX_RET_DEPTH) {
+							stop = ZEND_JIT_TRACE_STOP_TOO_DEEP_RET;
+							break;
+						}
+						TRACE_RECORD_BACK(ZEND_JIT_TRACE_BACK, 1, &EX(func)->op_array);
+						count = zend_jit_trace_recursive_ret_count(&EX(func)->op_array, unrolled_calls, ret_level);
+						if (opline == orig_opline) {
+							if (count + 1 >= ZEND_JIT_TRACE_MAX_RECURSION) {
+								stop = ZEND_JIT_TRACE_STOP_RECURSIVE_RET;
+								break;
+							}
+							backtrack_ret_recursion = idx;
+							backtrack_ret_recursion_level = ret_level;
+						} else if (count >= ZEND_JIT_TRACE_MAX_RECURSION) {
+							stop = ZEND_JIT_TRACE_STOP_DEEP_RECURSION;
+							break;
+						}
+
+						unrolled_calls[ret_level] = &EX(func)->op_array;
+						ret_level++;
+						is_toplevel = EX(func)->op_array.function_name == NULL;
+#endif
+					} else if (start & ZEND_JIT_TRACE_START_LOOP
+					 && !zend_jit_trace_bad_loop_exit(orig_opline)) {
+						/* Fail to try close the loop.
+						   If this doesn't work terminate it. */
+						stop = ZEND_JIT_TRACE_STOP_LOOP_EXIT;
+						break;
+					} else {
+						stop = ZEND_JIT_TRACE_STOP_RETURN;
+						break;
+					}
+				} else {
+					level--;
+					TRACE_RECORD_BACK(ZEND_JIT_TRACE_BACK, 0, &EX(func)->op_array);
+				}
+			}
+#ifdef HAVE_GCC_GLOBAL_REGS
+			prev_execute_data = execute_data;
+#endif
+			jit_extension =
+				(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(&EX(func)->op_array);
+			if (UNEXPECTED(!jit_extension)) {
+				stop = ZEND_JIT_TRACE_STOP_BAD_FUNC;
+				break;
+			}
+			offset = jit_extension->offset;
+		}
+		if (EX(call) != prev_call) {
+			if (trace_buffer[idx-1].op != ZEND_JIT_TRACE_BACK
+			 && EX(call)
+			 && EX(call)->prev_execute_data == prev_call) {
+				if (EX(call)->func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
+					/* TODO: Can we continue recording ??? */
+					stop = ZEND_JIT_TRACE_STOP_TRAMPOLINE;
+					break;
+				}
+				TRACE_RECORD_INIT(ZEND_JIT_TRACE_INIT_CALL, 0, EX(call)->func);
+			}
+			prev_call = EX(call);
+		}
+
+#ifndef HAVE_GCC_GLOBAL_REGS
+		opline = EX(opline);
+#endif
+
+		trace_flags = ZEND_OP_TRACE_INFO(opline, offset)->trace_flags;
+		if (trace_flags) {
+			if (trace_flags & ZEND_JIT_TRACE_JITED) {
+				if (trace_flags & ZEND_JIT_TRACE_START_LOOP) {
+					if ((start & ZEND_JIT_TRACE_START_LOOP) != 0
+					 && level + ret_level == 0
+					 && !zend_jit_trace_bad_compiled_loop(orig_opline)) {
+						/* Fail to try close outer loop throgh side exit.
+						   If this doesn't work just link. */
+						stop = ZEND_JIT_TRACE_STOP_COMPILED_LOOP;
+						break;
+					} else {
+						stop = ZEND_JIT_TRACE_STOP_LINK;
+						break;
+					}
+				} else if (trace_flags & ZEND_JIT_TRACE_START_ENTER) {
+					if (start != ZEND_JIT_TRACE_START_RETURN) {
+						// TODO: We may try to inline function ???
+						stop = ZEND_JIT_TRACE_STOP_LINK;
+						break;
+					}
+				} else {
+					stop = ZEND_JIT_TRACE_STOP_LINK;
+					break;
+				}
+			} else if (trace_flags & ZEND_JIT_TRACE_BLACKLISTED) {
+				stop = ZEND_JIT_TRACE_STOP_BLACK_LIST;
+				break;
+			} else if (trace_flags & ZEND_JIT_TRACE_START_LOOP) {
+				if (start != ZEND_JIT_TRACE_START_SIDE) {
+					if (opline == orig_opline && level + ret_level == 0) {
+						stop = ZEND_JIT_TRACE_STOP_LOOP;
+						break;
+					}
+					/* Fail to try creating a trace for inner loop first.
+					   If this doesn't work try unroling loop. */
+					if (!zend_jit_trace_bad_inner_loop(opline)) {
+						stop = ZEND_JIT_TRACE_STOP_INNER_LOOP;
+						break;
+					}
+				}
+				if (loop_unroll_limit < ZEND_JIT_TRACE_MAX_UNROLL_LOOPS) {
+					loop_unroll_limit++;
+				} else {
+					stop = ZEND_JIT_TRACE_STOP_LOOP_UNROLL;
+					break;
+				}
+			} else if (trace_flags & ZEND_JIT_TRACE_UNSUPPORTED) {
+				TRACE_RECORD(ZEND_JIT_TRACE_VM, opline);
+				stop = ZEND_JIT_TRACE_STOP_NOT_SUPPORTED;
+				break;
+			}
+		}
+	}
+
+	if (!ZEND_JIT_TRACE_STOP_OK(stop)) {
+		if (backtrack_recursion > 0) {
+			idx = backtrack_recursion;
+			stop = ZEND_JIT_TRACE_STOP_RECURSIVE_CALL;
+		} else if (backtrack_ret_recursion > 0) {
+			idx = backtrack_ret_recursion;
+			ret_level = backtrack_ret_recursion_level;
+			stop = ZEND_JIT_TRACE_STOP_RECURSIVE_RET;
+		}
+	}
+
+	TRACE_END(ZEND_JIT_TRACE_END, stop, opline);
+	((zend_jit_trace_start_rec*)trace_buffer)->len = idx;
+
+#ifdef HAVE_GCC_GLOBAL_REGS
+	if (stop != ZEND_JIT_TRACE_STOP_HALT) {
+		EX(opline) = opline;
+	}
+#endif
+
+#ifdef HAVE_GCC_GLOBAL_REGS
+	execute_data = save_execute_data;
+	opline = save_opline;
+#endif
+
+	return stop;
 }

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -5644,9 +5644,15 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 					}
 					break;
 				case ZEND_IS_NOT_EQUAL:
-				case ZEND_IS_NOT_IDENTICAL:
 					if (exit_addr) {
 						| je &exit_addr
+					} else {
+						| je => target_label
+					}
+					break;
+				case ZEND_IS_NOT_IDENTICAL:
+					if (exit_addr) {
+						| jne &exit_addr
 					} else {
 						| je => target_label
 					}
@@ -5697,9 +5703,15 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 					}
 					break;
 				case ZEND_IS_NOT_EQUAL:
-				case ZEND_IS_NOT_IDENTICAL:
 					if (exit_addr) {
 						| jne &exit_addr
+					} else {
+						| jne => target_label
+					}
+					break;
+				case ZEND_IS_NOT_IDENTICAL:
+					if (exit_addr) {
+						| je &exit_addr
 					} else {
 						| jne => target_label
 					}
@@ -5822,7 +5834,6 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 					}
 					break;
 				case ZEND_IS_NOT_EQUAL:
-				case ZEND_IS_NOT_IDENTICAL:
 					| jp >1
 					if (exit_addr) {
 						| je &exit_addr
@@ -5830,6 +5841,16 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 						| je => target_label
 					}
 					|1:
+					break;
+				case ZEND_IS_NOT_IDENTICAL:
+					if (exit_addr) {
+						| jne &exit_addr
+						| jp &exit_addr
+					} else {
+						| jp >1
+						| je => target_label
+						|1:
+					}
 					break;
 				case ZEND_IS_SMALLER:
 					if (swap) {
@@ -5882,10 +5903,19 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 					|1:
 					break;
 				case ZEND_IS_NOT_EQUAL:
-				case ZEND_IS_NOT_IDENTICAL:
 					if (exit_addr) {
 						| jne &exit_addr
 						| jp &exit_addr
+					} else {
+						| jne => target_label
+						| jp => target_label
+					}
+					break;
+				case ZEND_IS_NOT_IDENTICAL:
+					if (exit_addr) {
+						|1:
+						| je &exit_addr
+						|1:
 					} else {
 						| jne => target_label
 						| jp => target_label

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -91,6 +91,8 @@
 
 |.define HYBRID_SPAD, 16     // padding for stack alignment
 
+#define DASM_ALIGNMENT 16
+
 /* According to x86 and x86_64 ABI, CPU stack has to be 16 byte aligned to
  * guarantee proper alignment of 128-bit SSE data allocated on stack.
  * With broken alignment any execution of SSE code, including calls to
@@ -99,6 +101,10 @@
 
 #include "Zend/zend_cpuinfo.h"
 #include "jit/zend_jit_x86.h"
+
+#ifdef HAVE_VALGRIND
+# include <valgrind/valgrind.h>
+#endif
 
 /* The generated code may contain tautological comparisons, ignore them. */
 #if defined(__clang__)
@@ -1555,6 +1561,7 @@ static zend_bool delayed_call_chain;
 static uint32_t  delayed_call_level;
 static const zend_op *last_valid_opline;
 static int jit_return_label;
+static uint32_t current_trace_num;
 
 /* bit helpers */
 
@@ -2198,6 +2205,7 @@ static int zend_jit_hybrid_func_counter_stub(dasm_State **Dst)
 	|		jmp aword [r1+r2*4+4]
 	|	.endif
 	|1:
+	|	mov word [r2], ZEND_JIT_HOT_COUNTER_INIT
 	|	mov FCARG1a, FP
 	|	GET_IP FCARG2a
 	|	EXT_CALL zend_jit_hot_func, r0
@@ -2230,10 +2238,154 @@ static int zend_jit_hybrid_loop_counter_stub(dasm_State **Dst)
 	|		jmp aword [r1+r2*4+4]
 	|	.endif
 	|1:
+	|	mov word [r2], ZEND_JIT_HOT_COUNTER_INIT
 	|	mov FCARG1a, FP
 	|	GET_IP FCARG2a
 	|	EXT_CALL zend_jit_hot_func, r0
 	|	JMP_IP
+	return 1;
+}
+
+static int zend_jit_hybrid_trace_counter_stub(dasm_State **Dst, uint32_t cost)
+{
+	|	mov r0, EX->func
+	|	mov r1, aword [r0 + offsetof(zend_op_array, reserved[zend_func_info_rid])]
+	|	mov r1, aword [r1 + offsetof(zend_jit_op_array_trace_extension, offset)]
+	|	mov	r2, aword [IP + r1 + offsetof(zend_op_trace_info, counter)]
+	|	sub word [r2], cost
+	|	jle >1
+	|	jmp aword [IP + r1]
+	|1:
+	|	mov word [r2], ZEND_JIT_TRACE_COUNTER_INIT
+	|	mov FCARG1a, FP
+	|	GET_IP FCARG2a
+	|	EXT_CALL zend_jit_trace_hot_root, r0
+	|	test eax, eax // TODO : remove this check at least for HYBRID VM ???
+	|	jl >1
+	|	MEM_OP2_2_ZTS mov, FP, aword, executor_globals, current_execute_data, r0
+	|	LOAD_OPLINE
+	|	JMP_IP
+	|1:
+	|	EXT_JMP zend_jit_halt_op->handler, r0
+	return 1;
+}
+
+static int zend_jit_hybrid_func_trace_counter_stub(dasm_State **Dst)
+{
+	|->hybrid_func_counter:
+
+	return zend_jit_hybrid_trace_counter_stub(Dst, ZEND_JIT_TRACE_FUNC_COST);
+}
+
+static int zend_jit_hybrid_ret_trace_counter_stub(dasm_State **Dst)
+{
+	|->hybrid_ret_counter:
+
+	return zend_jit_hybrid_trace_counter_stub(Dst, ZEND_JIT_TRACE_RET_COST);
+}
+
+static int zend_jit_hybrid_loop_trace_counter_stub(dasm_State **Dst)
+{
+	|->hybrid_loop_counter:
+
+	return zend_jit_hybrid_trace_counter_stub(Dst, ZEND_JIT_TRACE_LOOP_COST);
+}
+
+static int zend_jit_trace_halt_stub(dasm_State **Dst)
+{
+	|->trace_halt:
+	if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+		|	add r4, HYBRID_SPAD
+		|	EXT_JMP zend_jit_halt_op->handler, r0
+	} else if (GCC_GLOBAL_REGS) {
+		|	add r4, SPAD // stack alignment
+		|	ret // PC must be zero
+	} else {
+		|	mov FP, aword T2 // restore FP
+		|	mov RX, aword T3 // restore IP
+		|	add r4, NR_SPAD // stack alignment
+		|	mov r0, -1 // ZEND_VM_RETURN
+		|	ret
+	}
+	return 1;
+}
+
+static int zend_jit_trace_exit_stub(dasm_State **Dst)
+{
+	|->trace_exit:
+	|
+	|	// TODO: Save CPU registers ???
+	|
+	|	// trace_num = EG(reserved)[zend_func_info_rid]
+	|	MEM_OP2_2_ZTS mov, FCARG1a, aword, executor_globals, reserved[zend_func_info_rid], r0
+	|	// exit_num = POP
+	|	pop FCARG2a
+	|	// EX(opline) = opline
+	|	SAVE_OPLINE
+	|	// zend_jit_trace_exit(trace_num, exit_num)
+	|	EXT_CALL zend_jit_trace_exit, r0
+	|	// execute_data = EG(current_excute_data)
+	|	MEM_OP2_2_ZTS mov, FP, aword, executor_globals, current_execute_data, r0
+	|	test eax, eax
+	|	jl ->trace_halt
+	|	// opline = EX(opline)
+	|	LOAD_OPLINE
+
+	if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+		|	add r4, HYBRID_SPAD
+		|	JMP_IP
+	} else if (GCC_GLOBAL_REGS) {
+		|	add r4, SPAD // stack alignment
+		|	JMP_IP
+	} else {
+		|	mov FP, aword T2 // restore FP
+		|	mov RX, aword T3 // restore IP
+		|	add r4, NR_SPAD // stack alignment
+		|	mov r0, 1 // ZEND_VM_ENTER
+		|	ret
+	}
+
+	return 1;
+}
+
+static int zend_jit_trace_escape_stub(dasm_State **Dst)
+{
+	|->trace_escape:
+	|
+	if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+		|	add r4, HYBRID_SPAD
+		|	JMP_IP
+	} else if (GCC_GLOBAL_REGS) {
+		|	add r4, SPAD // stack alignment
+		|	JMP_IP
+	} else {
+		|	mov FP, aword T2 // restore FP
+		|	mov RX, aword T3 // restore IP
+		|	add r4, NR_SPAD // stack alignment
+		|	mov r0, 1 // ZEND_VM_ENTER
+		|	ret
+	}
+
+	return 1;
+}
+
+/* Keep 32 exit points in a single code block */
+#define ZEND_JIT_EXIT_POINTS_SPACING   4  // push byte + short jmp = bytes
+#define ZEND_JIT_EXIT_POINTS_PER_GROUP 32 // number of continuous exit points
+
+static int zend_jit_trace_exit_group_stub(dasm_State **Dst, uint32_t n)
+{
+	uint32_t i;
+
+	for (i = 0; i < ZEND_JIT_EXIT_POINTS_PER_GROUP - 1; i++) {
+		|	push byte i
+		|	.byte 0xeb, (4*(ZEND_JIT_EXIT_POINTS_PER_GROUP-i)-6) // jmp >1
+	}
+	|	push byte i
+	|// 1:
+	|	.byte 0x81, 0x04, 0x24; .dword n // add aword [r4], n
+	|	jmp ->trace_exit
+
 	return 1;
 }
 
@@ -2280,6 +2432,9 @@ static const zend_jit_stub zend_jit_stubs[] = {
 	JIT_STUB(undefined_function),
 	JIT_STUB(negative_shift),
 	JIT_STUB(mod_by_zero),
+	JIT_STUB(trace_halt),
+	JIT_STUB(trace_exit),
+	JIT_STUB(trace_escape),
 	JIT_STUB(double_one),
 #ifdef CONTEXT_THREADED_JIT
 	JIT_STUB(context_threaded_call),
@@ -2415,6 +2570,12 @@ static int zend_jit_setup(void)
 	return SUCCESS;
 }
 
+static ZEND_ATTRIBUTE_UNUSED int zend_jit_trap(dasm_State **Dst)
+{
+	|	int3
+	return 1;
+}
+
 static int zend_jit_align_func(dasm_State **Dst)
 {
 	reuse_ip = 0;
@@ -2531,6 +2692,379 @@ static int zend_jit_check_exception_undef_result(dasm_State **Dst, const zend_op
 		return 1;
 	}
 	return zend_jit_check_exception(Dst);
+}
+
+static int zend_jit_trace_begin(dasm_State **Dst, uint32_t trace_num)
+{
+	current_trace_num = trace_num;
+
+	|	//EG(reserved)[zend_func_info_rid] = trace_num;
+	|	MEM_OP2_1_ZTS mov, aword, executor_globals, reserved[zend_func_info_rid], trace_num, r0
+
+	return 1;
+}
+
+static int zend_jit_trace_opline_guard(dasm_State **Dst, const zend_op *opline)
+{
+	uint32_t exit_point = zend_jit_trace_get_exit_point(NULL, NULL, NULL);
+	const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+
+	if (!exit_addr) {
+		return 0;
+	}
+	|	CMP_IP opline
+	|	jne &exit_addr
+
+	return 1;
+}
+
+/* This taken from LuaJIT. Thanks to Mike Pall. */
+static uint32_t _asm_x86_inslen(const uint8_t* p)
+{
+	static const uint8_t map_op1[256] = {
+		0x92,0x92,0x92,0x92,0x52,0x45,0x51,0x51,0x92,0x92,0x92,0x92,0x52,0x45,0x51,0x20,
+		0x92,0x92,0x92,0x92,0x52,0x45,0x51,0x51,0x92,0x92,0x92,0x92,0x52,0x45,0x51,0x51,
+		0x92,0x92,0x92,0x92,0x52,0x45,0x10,0x51,0x92,0x92,0x92,0x92,0x52,0x45,0x10,0x51,
+		0x92,0x92,0x92,0x92,0x52,0x45,0x10,0x51,0x92,0x92,0x92,0x92,0x52,0x45,0x10,0x51,
+#if defined(__x86_64__) || defined(_M_X64)
+		0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x14,0x14,0x14,0x14,0x14,0x14,0x14,0x14,
+#else
+		0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,
+#endif
+		0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,
+		0x51,0x51,0x92,0x92,0x10,0x10,0x12,0x11,0x45,0x86,0x52,0x93,0x51,0x51,0x51,0x51,
+		0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,
+		0x93,0x86,0x93,0x93,0x92,0x92,0x92,0x92,0x92,0x92,0x92,0x92,0x92,0x92,0x92,0x92,
+		0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x51,0x47,0x51,0x51,0x51,0x51,0x51,
+#if defined(__x86_64__) || defined(_M_X64)
+		0x59,0x59,0x59,0x59,0x51,0x51,0x51,0x51,0x52,0x45,0x51,0x51,0x51,0x51,0x51,0x51,
+#else
+		0x55,0x55,0x55,0x55,0x51,0x51,0x51,0x51,0x52,0x45,0x51,0x51,0x51,0x51,0x51,0x51,
+#endif
+		0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x05,0x05,0x05,0x05,0x05,0x05,0x05,0x05,
+		0x93,0x93,0x53,0x51,0x70,0x71,0x93,0x86,0x54,0x51,0x53,0x51,0x51,0x52,0x51,0x51,
+		0x92,0x92,0x92,0x92,0x52,0x52,0x51,0x51,0x92,0x92,0x92,0x92,0x92,0x92,0x92,0x92,
+		0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x45,0x45,0x47,0x52,0x51,0x51,0x51,0x51,
+		0x10,0x51,0x10,0x10,0x51,0x51,0x63,0x66,0x51,0x51,0x51,0x51,0x51,0x51,0x92,0x92
+	};
+	static const uint8_t map_op2[256] = {
+		0x93,0x93,0x93,0x93,0x52,0x52,0x52,0x52,0x52,0x52,0x51,0x52,0x51,0x93,0x52,0x94,
+		0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,
+		0x53,0x53,0x53,0x53,0x53,0x53,0x53,0x53,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,
+		0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x34,0x51,0x35,0x51,0x51,0x51,0x51,0x51,
+		0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,
+		0x53,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,
+		0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,
+		0x94,0x54,0x54,0x54,0x93,0x93,0x93,0x52,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,
+		0x46,0x46,0x46,0x46,0x46,0x46,0x46,0x46,0x46,0x46,0x46,0x46,0x46,0x46,0x46,0x46,
+		0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,
+		0x52,0x52,0x52,0x93,0x94,0x93,0x51,0x51,0x52,0x52,0x52,0x93,0x94,0x93,0x93,0x93,
+		0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x94,0x93,0x93,0x93,0x93,0x93,
+		0x93,0x93,0x94,0x93,0x94,0x94,0x94,0x93,0x52,0x52,0x52,0x52,0x52,0x52,0x52,0x52,
+		0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,
+		0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,
+		0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x93,0x52
+	};
+	uint32_t result = 0;
+	uint32_t prefixes = 0;
+	uint32_t x = map_op1[*p];
+
+	for (;;) {
+		switch (x >> 4) {
+			case 0:
+				return result + x + (prefixes & 4);
+			case 1:
+				prefixes |= x;
+				x = map_op1[*++p];
+				result++;
+				break;
+			case 2:
+				x = map_op2[*++p];
+				break;
+			case 3:
+				p++;
+				goto mrm;
+			case 4:
+				result -= (prefixes & 2);
+				/* fallthrough */
+			case 5:
+				return result + (x & 15);
+			case 6: /* Group 3. */
+				if (p[1] & 0x38) {
+					x = 2;
+				} else if ((prefixes & 2) && (x == 0x66)) {
+					x = 4;
+				}
+				goto mrm;
+			case 7: /* VEX c4/c5. */
+#if !defined(__x86_64__) && !defined(_M_X64)
+				if (p[1] < 0xc0) {
+					x = 2;
+					goto mrm;
+				}
+#endif
+				if (x == 0x70) {
+					x = *++p & 0x1f;
+					result++;
+					if (x >= 2) {
+						p += 2;
+						result += 2;
+						goto mrm;
+					}
+				}
+				p++;
+				result++;
+				x = map_op2[*++p];
+				break;
+			case 8:
+				result -= (prefixes & 2);
+				/* fallthrough */
+			case 9:
+mrm:
+				/* ModR/M and possibly SIB. */
+				result += (x & 15);
+				x = *++p;
+				switch (x >> 6) {
+					case 0:
+						if ((x & 7) == 5) {
+							return result + 4;
+						}
+						break;
+					case 1:
+						result++;
+						break;
+					case 2:
+						result += 4;
+						break;
+					case 3:
+						return result;
+				}
+				if ((x & 7) == 4) {
+					result++;
+					if (x < 0x40 && (p[1] & 7) == 5) {
+						result += 4;
+					}
+				}
+				return result;
+		}
+	}
+}
+
+static int zend_jit_patch(const void *code, size_t size, const void *from_addr, const void *to_addr)
+{
+	int ret = 0;
+	uint8_t *p = (uint8_t*)code;
+	uint8_t *end = p + size - 5;
+
+	while (p < end) {
+		if ((*(uint16_t*)p & 0xf0ff) == 0x800f && p + *(int32_t*)(p+2) == (uint8_t*)from_addr - 6) {
+			*(int32_t*)(p+2) = ((uint8_t*)to_addr - (p + 6));
+			ret++;
+		} else if (*p == 0xe9 && p + *(int32_t*)(p+1) == (uint8_t*)from_addr - 5) {
+			*(int32_t*)(p+1) = ((uint8_t*)to_addr - (p + 5));
+			ret++;
+		}
+		p += _asm_x86_inslen(p);
+	}
+#ifdef HAVE_VALGRIND
+	VALGRIND_DISCARD_TRANSLATIONS(code, size);
+#endif
+	return ret;
+}
+
+static int zend_jit_link_side_trace(const void *code, size_t size, uint32_t exit_num, const void *addr)
+{
+	return zend_jit_patch(code, size, zend_jit_trace_get_exit_addr(exit_num), addr);
+}
+
+static int zend_jit_trace_link_to_root(dasm_State **Dst, const void *code)
+{
+	const void *exit_addr;
+	size_t prologue_size;
+
+	/* Skip prologue. */
+	// TODO: don't hardcode this ???
+	if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+		// sub r4, HYBRID_SPAD
+#if defined(__x86_64__) || defined(_M_X64)
+		prologue_size = 4;
+#else
+		prologue_size = 3;
+#endif
+	} else if (GCC_GLOBAL_REGS) {
+		// sub r4, SPAD // stack alignment
+#if defined(__x86_64__) || defined(_M_X64)
+		prologue_size = 4;
+#else
+		prologue_size = 3;
+#endif
+	} else {
+		// sub r4, NR_SPAD // stack alignment
+		// mov aword T2, FP // save FP
+		// mov aword T3, RX // save IP
+		// mov FP, FCARG1a
+#if defined(__x86_64__) || defined(_M_X64)
+		prologue_size = 17;
+#else
+		prologue_size = 12;
+#endif
+	}
+	exit_addr = (const void*)((const char*)code + prologue_size);
+
+	|	jmp &exit_addr
+	return 1;
+}
+
+static int zend_jit_trace_return(dasm_State **Dst)
+{
+#if 0
+	|	jmp ->trace_escape
+#else
+	if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+		|	add r4, HYBRID_SPAD
+		|	JMP_IP
+	} else if (GCC_GLOBAL_REGS) {
+		|	add r4, SPAD // stack alignment
+		|	JMP_IP
+	} else {
+		|	mov FP, aword T2 // restore FP
+		|	mov RX, aword T3 // restore IP
+		|	add r4, NR_SPAD // stack alignment
+		|	mov r0, 2 // ZEND_VM_LEAVE
+		|	ret
+	}
+#endif
+	return 1;
+}
+
+static int zend_jit_type_guard(dasm_State **Dst, const zend_op *opline, uint32_t var, uint8_t type)
+{
+	int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+	const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+
+	if (!exit_addr) {
+		return 0;
+	}
+	|	IF_NOT_Z_TYPE FP + var, type, &exit_addr
+
+	return 1;
+}
+
+static int zend_jit_trace_handler(dasm_State **Dst, const zend_op_array *op_array, const zend_op *opline, int may_throw, zend_jit_trace_rec *trace)
+{
+	zend_jit_op_array_trace_extension *jit_extension =
+		(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+	size_t offset = jit_extension->offset;
+	const void *handler =
+		(zend_vm_opcode_handler_t)ZEND_OP_TRACE_INFO(opline, offset)->call_handler;
+
+	if (!zend_jit_set_valid_ip(Dst, opline)) {
+		return 0;
+	}
+	if (!GCC_GLOBAL_REGS) {
+		|	mov FCARG1a, FP
+	}
+	|	EXT_CALL handler, r0
+	if (may_throw) {
+		zend_jit_check_exception(Dst);
+	}
+
+	if (!GCC_GLOBAL_REGS) {
+		if (opline->opcode == ZEND_RETURN ||
+		    opline->opcode == ZEND_DO_UCALL ||
+		    opline->opcode == ZEND_DO_FCALL_BY_NAME ||
+		    opline->opcode == ZEND_DO_FCALL) {
+			|	MEM_OP2_2_ZTS mov, FP, aword, executor_globals, current_execute_data, r0
+		}
+	}
+
+	if (zend_jit_trace_may_exit(op_array, opline, trace)) {
+		// TODO: try to avoid this check ???
+		if (opline->opcode == ZEND_RETURN) {
+			if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+				|	cmp IP, zend_jit_halt_op
+				|	je ->trace_halt
+			} else if (GCC_GLOBAL_REGS) {
+				|	test IP, IP
+				|	je ->trace_halt
+			} else {
+				|	test eax, eax
+				|	jl ->trace_halt
+			}
+		}
+		while (trace->op != ZEND_JIT_TRACE_VM && trace->op != ZEND_JIT_TRACE_END) {
+			trace++;
+		}
+		if (trace->op != ZEND_JIT_TRACE_END || trace->stop != ZEND_JIT_TRACE_STOP_RETURN) {
+			const zend_op *next_opline = trace->opline;
+			const zend_op *exit_opline = NULL;
+			uint32_t exit_point;
+			const void *exit_addr;
+
+			if (zend_is_smart_branch(opline)) {
+				zend_bool exit_if_true = 0;
+				exit_opline = zend_jit_trace_get_exit_opline(trace, opline + 1, &exit_if_true);
+			} else {
+				switch (opline->opcode) {
+					case ZEND_JMPZ:
+					case ZEND_JMPNZ:
+					case ZEND_JMPZ_EX:
+					case ZEND_JMPNZ_EX:
+					case ZEND_JMP_SET:
+					case ZEND_COALESCE:
+					case ZEND_FE_RESET_R:
+					case ZEND_FE_RESET_RW:
+						exit_opline = (trace->opline == opline + 1) ?
+							OP_JMP_ADDR(opline, opline->op2) :
+							opline + 1;
+						break;
+					case ZEND_JMPZNZ:
+						exit_opline = (trace->opline == OP_JMP_ADDR(opline, opline->op2)) ?
+							ZEND_OFFSET_TO_OPLINE(opline, opline->extended_value) :
+							OP_JMP_ADDR(opline, opline->op2);
+						break;
+					case ZEND_FE_FETCH_R:
+					case ZEND_FE_FETCH_RW:
+						exit_opline = (trace->opline == opline + 1) ?
+							ZEND_OFFSET_TO_OPLINE(opline, opline->extended_value) :
+							opline + 1;
+						break;
+
+				}
+			}
+			exit_point = zend_jit_trace_get_exit_point(opline, exit_opline, trace);
+			exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+
+			if (!exit_addr) {
+				return 0;
+			}
+			|	CMP_IP next_opline
+			|	jne &exit_addr
+		}
+	} else {
+		while (trace->op != ZEND_JIT_TRACE_VM && trace->op != ZEND_JIT_TRACE_END) {
+			trace++;
+		}
+		// TODO: remove this ???
+		if (opline->opcode == ZEND_RETURN
+		 && trace->op == ZEND_JIT_TRACE_END
+		 && trace->stop == ZEND_JIT_TRACE_STOP_RETURN) {
+			if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+				|	cmp IP, zend_jit_halt_op
+				|	je ->trace_halt
+			} else if (GCC_GLOBAL_REGS) {
+				|	test IP, IP
+				|	je ->trace_halt
+			} else {
+				|	test eax, eax
+				|	jl ->trace_halt
+			}
+		}
+	}
+
+	last_valid_opline = trace->opline;
+
+	return 1;
 }
 
 static int zend_jit_handler(dasm_State **Dst, const zend_op *opline, int may_throw)
@@ -3908,6 +4442,15 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 {
 	zend_jit_addr op2_addr = OP2_ADDR();
 	zend_jit_addr res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FP, opline->result.var);
+	const void *exit_addr = NULL;
+
+	if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE && type == BP_VAR_R) {
+		int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+		exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+		if (!exit_addr) {
+			return 0;
+		}
+	}
 
 	if (op2_info & MAY_BE_LONG) {
 		if (op2_info & ((MAY_BE_ANY|MAY_BE_UNDEF) - MAY_BE_LONG)) {
@@ -3936,6 +4479,8 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 					|.endif
 					if (type == BP_JIT_IS) {
 						|	jbe >9 // NOT_FOUND
+					} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE && (type == BP_VAR_R || type == BP_VAR_RW)) {
+						|	jbe &exit_addr
 					} else {
 						|	jbe >2 // NOT_FOUND
 					}
@@ -3963,6 +4508,8 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 				|.endif
 				if (type == BP_JIT_IS) {
 					|	jbe >9 // NOT_FOUND
+				} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE && (type == BP_VAR_R || type == BP_VAR_RW)) {
+					|	jbe &exit_addr
 				} else {
 					|	jbe >2 // NOT_FOUND
 				}
@@ -4000,8 +4547,14 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 					if (Z_MODE(op2_addr) == IS_CONST_ZVAL) {
 						zend_long val = Z_LVAL_P(Z_ZV(op2_addr));
 						if (val >= 0 && val < HT_MAX_SIZE) {
-							|	jmp >2 // NOT_FOUND
+							if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE && type == BP_VAR_R) {
+								|	jmp &exit_addr
+							} else {
+								|	jmp >2 // NOT_FOUND
+							}
 						}
+					} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE && type == BP_VAR_R) {
+						|	jmp &exit_addr
 					} else {
 						|	jmp >2 // NOT_FOUND
 					}
@@ -4009,15 +4562,21 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 				}
 				|	EXT_CALL zend_hash_index_find, r0
 				|	test r0, r0
-				|	jz >2 // NOT_FOUND
+				if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE && type == BP_VAR_R) {
+					|	jz &exit_addr
+				} else {
+					|	jz >2 // NOT_FOUND
+				}
 				|.cold_code
 				|2:
 				switch (type) {
 					case BP_VAR_R:
-						|	// zend_error(E_NOTICE,"Undefined offset: " ZEND_LONG_FMT, hval);
-						|	// retval = &EG(uninitialized_zval);
-						|	UNDEFINED_OFFSET opline
-						|	jmp >9
+						if (zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE) {
+							|	// zend_error(E_NOTICE,"Undefined offset: " ZEND_LONG_FMT, hval);
+							|	// retval = &EG(uninitialized_zval);
+							|	UNDEFINED_OFFSET opline
+							|	jmp >9
+						}
 						break;
 					case BP_VAR_IS:
 					case BP_VAR_UNSET:
@@ -4032,12 +4591,16 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 				break;
 			case BP_VAR_RW:
 				|2:
-				|	SAVE_VALID_OPLINE opline
-				|	// zend_error(E_NOTICE,"Undefined offset: " ZEND_LONG_FMT, hval);
-				|	//retval = zend_hash_index_update(ht, hval, &EG(uninitialized_zval));
-				|	EXT_CALL zend_jit_fetch_dimension_rw_long_helper, r0
+				if (zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE) {
+					|	SAVE_VALID_OPLINE opline
+					|	// zend_error(E_NOTICE,"Undefined offset: " ZEND_LONG_FMT, hval);
+					|	//retval = zend_hash_index_update(ht, hval, &EG(uninitialized_zval));
+					|	EXT_CALL zend_jit_fetch_dimension_rw_long_helper, r0
+				}
 				if (op1_info & MAY_BE_ARRAY_KEY_LONG) {
-					|	jmp >8
+					if (zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE) {
+						|	jmp >8
+					}
 					|4:
 					|	SAVE_VALID_OPLINE opline
 					|	EXT_CALL zend_jit_hash_index_lookup_rw, r0
@@ -4119,7 +4682,11 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 					|	EXT_CALL _zend_hash_find_known_hash, r0
 				}
 				|	test r0, r0
-				|	jz >2 // NOT_FOUND
+				if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE && type == BP_VAR_R) {
+					|	jz &exit_addr
+				} else {
+					|	jz >2 // NOT_FOUND
+				}
 				|	// if (UNEXPECTED(Z_TYPE_P(retval) == IS_INDIRECT))
 				|	IF_Z_TYPE r0, IS_INDIRECT, >1 // SLOW
 				|.cold_code
@@ -4130,9 +4697,11 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 				|2:
 				switch (type) {
 					case BP_VAR_R:
-						//	zend_error(E_NOTICE, "Undefined index: %s", ZSTR_VAL(offset_key));
-						|	UNDEFINED_INDEX opline
-						|	jmp >9
+						if (zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE) {
+							//	zend_error(E_NOTICE, "Undefined index: %s", ZSTR_VAL(offset_key));
+							|	UNDEFINED_INDEX opline
+							|	jmp >9
+						}
 						break;
 					case BP_VAR_IS:
 					case BP_VAR_UNSET:
@@ -4978,7 +5547,7 @@ static int zend_jit_assign_op(dasm_State **Dst, const zend_op *opline, const zen
 	return result;
 }
 
-static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_jit_addr op1_addr, zend_jit_addr op2_addr, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_jit_addr op1_addr, zend_jit_addr op2_addr, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	zend_bool swap = 0;
 
@@ -5050,24 +5619,48 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 				case ZEND_IS_EQUAL:
 				case ZEND_IS_IDENTICAL:
 				case ZEND_CASE:
-					| jne => target_label
+					if (exit_addr) {
+						| jne &exit_addr
+					} else {
+						| jne => target_label
+					}
 					break;
 				case ZEND_IS_NOT_EQUAL:
 				case ZEND_IS_NOT_IDENTICAL:
-					| je => target_label
+					if (exit_addr) {
+						| je &exit_addr
+					} else {
+						| je => target_label
+					}
 					break;
 				case ZEND_IS_SMALLER:
 					if (swap) {
-						| jle => target_label
+						if (exit_addr) {
+							| jle &exit_addr
+						} else {
+							| jle => target_label
+						}
 					} else {
-						| jge => target_label
+						if (exit_addr) {
+							| jge &exit_addr
+						} else {
+							| jge => target_label
+						}
 					}
 					break;
 				case ZEND_IS_SMALLER_OR_EQUAL:
 					if (swap) {
-						| jl => target_label
+						if (exit_addr) {
+							| jl &exit_addr
+						} else {
+							| jl => target_label
+						}
 					} else {
-						| jg => target_label
+						if (exit_addr) {
+							| jg &exit_addr
+						} else {
+							| jg => target_label
+						}
 					}
 					break;
 				default:
@@ -5079,24 +5672,48 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 				case ZEND_IS_EQUAL:
 				case ZEND_IS_IDENTICAL:
 				case ZEND_CASE:
-					| je => target_label
+					if (exit_addr) {
+						| je &exit_addr
+					} else {
+						| je => target_label
+					}
 					break;
 				case ZEND_IS_NOT_EQUAL:
 				case ZEND_IS_NOT_IDENTICAL:
-					| jne => target_label
+					if (exit_addr) {
+						| jne &exit_addr
+					} else {
+						| jne => target_label
+					}
 					break;
 				case ZEND_IS_SMALLER:
 					if (swap) {
-						| jg => target_label
+						if (exit_addr) {
+							| jg &exit_addr
+						} else {
+							| jg => target_label
+						}
 					} else {
-						| jl => target_label
+						if (exit_addr) {
+							| jl &exit_addr
+						} else {
+							| jl => target_label
+						}
 					}
 					break;
 				case ZEND_IS_SMALLER_OR_EQUAL:
 					if (swap) {
-						| jge => target_label
+						if (exit_addr) {
+							| jge &exit_addr
+						} else {
+							| jge => target_label
+						}
 					} else {
-						| jle => target_label
+						if (exit_addr) {
+							| jle &exit_addr
+						} else {
+							| jle => target_label
+						}
 					}
 					break;
 				default:
@@ -5170,7 +5787,7 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 	return 1;
 }
 
-static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, zend_jit_addr res_addr, zend_bool swap, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, zend_jit_addr res_addr, zend_bool swap, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	if (smart_branch_opcode) {
 		if (smart_branch_opcode == ZEND_JMPZ) {
@@ -5178,29 +5795,56 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 				case ZEND_IS_EQUAL:
 				case ZEND_IS_IDENTICAL:
 				case ZEND_CASE:
-					| jne => target_label
-					| jp => target_label
+					if (exit_addr) {
+						| jne &exit_addr
+						| jp &exit_addr
+					} else {
+						| jne => target_label
+						| jp => target_label
+					}
 					break;
 				case ZEND_IS_NOT_EQUAL:
 				case ZEND_IS_NOT_IDENTICAL:
 					| jp >1
-					| je => target_label
+					if (exit_addr) {
+						| je &exit_addr
+					} else {
+						| je => target_label
+					}
 					|1:
 					break;
 				case ZEND_IS_SMALLER:
 					if (swap) {
-						| jbe => target_label
+						if (exit_addr) {
+							| jbe &exit_addr
+						} else {
+							| jbe => target_label
+						}
 					} else {
-						| jae => target_label
-						| jp => target_label
+						if (exit_addr) {
+							| jae &exit_addr
+							| jp &exit_addr
+						} else {
+							| jae => target_label
+							| jp => target_label
+						}
 					}
 					break;
 				case ZEND_IS_SMALLER_OR_EQUAL:
 					if (swap) {
-						| jb => target_label
+						if (exit_addr) {
+							| jb &exit_addr
+						} else {
+							| jb => target_label
+						}
 					} else {
-						| ja => target_label
-						| jp => target_label
+						if (exit_addr) {
+							| ja &exit_addr
+							| jp &exit_addr
+						} else {
+							| ja => target_label
+							| jp => target_label
+						}
 					}
 					break;
 				default:
@@ -5212,29 +5856,54 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 				case ZEND_IS_IDENTICAL:
 				case ZEND_CASE:
 					| jp >1
-					| je => target_label
+					if (exit_addr) {
+						| je &exit_addr
+					} else {
+						| je => target_label
+					}
 					|1:
 					break;
 				case ZEND_IS_NOT_EQUAL:
 				case ZEND_IS_NOT_IDENTICAL:
-					| jne => target_label
-					| jp => target_label
+					if (exit_addr) {
+						| jne &exit_addr
+						| jp &exit_addr
+					} else {
+						| jne => target_label
+						| jp => target_label
+					}
 					break;
 				case ZEND_IS_SMALLER:
 					if (swap) {
-						| ja => target_label
+						if (exit_addr) {
+							| ja &exit_addr
+						} else {
+							| ja => target_label
+						}
 					} else {
 						| jp >1
-						| jb => target_label
+						if (exit_addr) {
+							| jb &exit_addr
+						} else {
+							| jb => target_label
+						}
 						|1:
 					}
 					break;
 				case ZEND_IS_SMALLER_OR_EQUAL:
 					if (swap) {
-						| jae => target_label
+						if (exit_addr) {
+							| jae &exit_addr
+						} else {
+							| jae => target_label
+						}
 					} else {
 						| jp >1
-						| jbe => target_label
+						if (exit_addr) {
+							| jbe &exit_addr
+						} else {
+							| jbe => target_label
+						}
 						|1:
 					}
 					break;
@@ -5431,27 +6100,27 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 	return 1;
 }
 
-static int zend_jit_cmp_long_double(dasm_State **Dst, const zend_op *opline, zend_jit_addr op1_addr, zend_jit_addr op2_addr, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_cmp_long_double(dasm_State **Dst, const zend_op *opline, zend_jit_addr op1_addr, zend_jit_addr op2_addr, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	zend_reg tmp_reg = ZREG_XMM0;
 
 	|	SSE_GET_ZVAL_LVAL tmp_reg, op1_addr
 	|	SSE_AVX_OP ucomisd, vucomisd, tmp_reg, op2_addr
 
-	return zend_jit_cmp_double_common(Dst, opline, res_addr, 0, smart_branch_opcode, target_label, target_label2);
+	return zend_jit_cmp_double_common(Dst, opline, res_addr, 0, smart_branch_opcode, target_label, target_label2, exit_addr);
 }
 
-static int zend_jit_cmp_double_long(dasm_State **Dst, const zend_op *opline, zend_jit_addr op1_addr, zend_jit_addr op2_addr, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_cmp_double_long(dasm_State **Dst, const zend_op *opline, zend_jit_addr op1_addr, zend_jit_addr op2_addr, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	zend_reg tmp_reg = ZREG_XMM0;
 
 	|	SSE_GET_ZVAL_LVAL tmp_reg, op2_addr
 	|	SSE_AVX_OP ucomisd, vucomisd, tmp_reg, op1_addr
 
-	return zend_jit_cmp_double_common(Dst, opline, res_addr, /* swap */ 1, smart_branch_opcode, target_label, target_label2);
+	return zend_jit_cmp_double_common(Dst, opline, res_addr, /* swap */ 1, smart_branch_opcode, target_label, target_label2, exit_addr);
 }
 
-static int zend_jit_cmp_double_double(dasm_State **Dst, const zend_op *opline, zend_jit_addr op1_addr, zend_jit_addr op2_addr, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_cmp_double_double(dasm_State **Dst, const zend_op *opline, zend_jit_addr op1_addr, zend_jit_addr op2_addr, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	zend_bool swap = 0;
 
@@ -5467,10 +6136,10 @@ static int zend_jit_cmp_double_double(dasm_State **Dst, const zend_op *opline, z
 		|	SSE_AVX_OP ucomisd, vucomisd, tmp_reg, op2_addr
 	}
 
-	return zend_jit_cmp_double_common(Dst, opline, res_addr, swap, smart_branch_opcode, target_label, target_label2);
+	return zend_jit_cmp_double_common(Dst, opline, res_addr, swap, smart_branch_opcode, target_label, target_label2, exit_addr);
 }
 
-static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_addr res_addr, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	|	LONG_OP_WITH_CONST cmp, res_addr, Z_L(0)
 	if (smart_branch_opcode) {
@@ -5502,16 +6171,32 @@ static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_a
 			switch (opline->opcode) {
 				case ZEND_IS_EQUAL:
 				case ZEND_CASE:
-					| jne => target_label
+					if (exit_addr) {
+						| jne &exit_addr
+					} else {
+						| jne => target_label
+					}
 					break;
 				case ZEND_IS_NOT_EQUAL:
-					| je => target_label
+					if (exit_addr) {
+						| je &exit_addr
+					} else {
+						| je => target_label
+					}
 					break;
 				case ZEND_IS_SMALLER:
-					| jge => target_label
+					if (exit_addr) {
+						| jge &exit_addr
+					} else {
+						| jge => target_label
+					}
 					break;
 				case ZEND_IS_SMALLER_OR_EQUAL:
-					| jg => target_label
+					if (exit_addr) {
+						| jg &exit_addr
+					} else {
+						| jg => target_label
+					}
 					break;
 				default:
 					ZEND_ASSERT(0);
@@ -5521,16 +6206,32 @@ static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_a
 			switch (opline->opcode) {
 				case ZEND_IS_EQUAL:
 				case ZEND_CASE:
-					| je => target_label
+					if (exit_addr) {
+						| je &exit_addr
+					} else {
+						| je => target_label
+					}
 					break;
 				case ZEND_IS_NOT_EQUAL:
-					| jne => target_label
+					if (exit_addr) {
+						| jne &exit_addr
+					} else {
+						| jne => target_label
+					}
 					break;
 				case ZEND_IS_SMALLER:
-					| jl => target_label
+					if (exit_addr) {
+						| jl &exit_addr
+					} else {
+						| jl => target_label
+					}
 					break;
 				case ZEND_IS_SMALLER_OR_EQUAL:
-					| jle => target_label
+					if (exit_addr) {
+						| jle &exit_addr
+					} else {
+						| jle => target_label
+					}
 					break;
 				default:
 					ZEND_ASSERT(0);
@@ -5583,7 +6284,7 @@ static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_a
 	return 1;
 }
 
-static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr, uint32_t op2_info, zend_jit_addr op2_addr, zend_jit_addr res_addr, int may_throw, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr, uint32_t op2_info, zend_jit_addr op2_addr, zend_jit_addr res_addr, int may_throw, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	zend_bool same_ops = (opline->op1_type == opline->op2_type) && (opline->op1.var == opline->op2.var);
 	zend_bool has_slow;
@@ -5610,7 +6311,7 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 				if (op2_info & (MAY_BE_ANY-(MAY_BE_LONG|MAY_BE_DOUBLE))) {
 					|	IF_NOT_ZVAL_TYPE op2_addr, IS_DOUBLE, >9
 				}
-				if (!zend_jit_cmp_long_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+				if (!zend_jit_cmp_long_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 					return 0;
 				}
 				|	jmp >6
@@ -5619,7 +6320,7 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 				|	IF_NOT_ZVAL_TYPE op2_addr, IS_LONG, >9
 			}
 		}
-		if (!zend_jit_cmp_long_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+		if (!zend_jit_cmp_long_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 			return 0;
 		}
 		if (op1_info & MAY_BE_DOUBLE) {
@@ -5636,7 +6337,7 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 						|	IF_NOT_ZVAL_TYPE op2_addr, IS_DOUBLE, >9
 					}
 				}
-				if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+				if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 					return 0;
 				}
 				|	jmp >6
@@ -5646,7 +6347,7 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 				if (op2_info & (MAY_BE_ANY-(MAY_BE_LONG|MAY_BE_DOUBLE))) {
 					|	IF_NOT_ZVAL_TYPE op2_addr, IS_LONG, >9
 				}
-				if (!zend_jit_cmp_double_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+				if (!zend_jit_cmp_double_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 					return 0;
 				}
 				|	jmp >6
@@ -5667,7 +6368,7 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 					|	IF_NOT_ZVAL_TYPE op2_addr, IS_DOUBLE, >9
 				}
 			}
-			if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+			if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 				return 0;
 			}
 		}
@@ -5679,7 +6380,7 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 			if (op2_info & (MAY_BE_ANY-(MAY_BE_DOUBLE|MAY_BE_LONG))) {
 				|	IF_NOT_ZVAL_TYPE op2_addr, IS_LONG, >9
 			}
-			if (!zend_jit_cmp_double_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+			if (!zend_jit_cmp_double_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 				return 0;
 			}
 			if (op2_info & MAY_BE_DOUBLE) {
@@ -5701,7 +6402,7 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 					|	IF_NOT_ZVAL_TYPE op1_addr, IS_DOUBLE, >9
 				}
 			}
-			if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+			if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 				return 0;
 			}
 		}
@@ -5713,7 +6414,7 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 			if (op1_info & (MAY_BE_ANY-(MAY_BE_DOUBLE|MAY_BE_LONG))) {
 				|	IF_NOT_ZVAL_TYPE op1_addr, IS_LONG, >9
 			}
-			if (!zend_jit_cmp_long_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+			if (!zend_jit_cmp_long_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 				return 0;
 			}
 			if (op1_info & MAY_BE_DOUBLE) {
@@ -5794,7 +6495,7 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 		if (may_throw) {
 			zend_jit_check_exception_undef_result(Dst, opline);
 		}
-		if (!zend_jit_cmp_slow(Dst, opline, res_addr, smart_branch_opcode, target_label, target_label2)) {
+		if (!zend_jit_cmp_slow(Dst, opline, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 			return 0;
 		}
 		if (has_slow) {
@@ -5808,12 +6509,12 @@ static int zend_jit_cmp(dasm_State **Dst, const zend_op *opline, const zend_op_a
 	return 1;
 }
 
-static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr, uint32_t op2_info, zend_jit_addr op2_addr, zend_jit_addr res_addr, int may_throw, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr, uint32_t op2_info, zend_jit_addr op2_addr, zend_jit_addr res_addr, int may_throw, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	uint32_t identical_label = (uint32_t)-1;
 	uint32_t not_identical_label = (uint32_t)-1;
 
-	if (smart_branch_opcode) {
+	if (smart_branch_opcode && !exit_addr) {
 		if (opline->opcode == ZEND_IS_IDENTICAL) {
 			if (smart_branch_opcode == ZEND_JMPZ) {
 				not_identical_label = target_label;
@@ -5956,7 +6657,11 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 		}
 		if (smart_branch_opcode) {
 			zend_jit_check_exception_undef_result(Dst, opline);
-			if (not_identical_label != (uint32_t)-1) {
+			if (exit_addr) {
+				if (smart_branch_opcode == ZEND_JMPZ) {
+					|	jmp &exit_addr
+				}
+			} else if (not_identical_label != (uint32_t)-1) {
 				|	jmp =>not_identical_label
 			}
 		} else {
@@ -5968,7 +6673,11 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 	           concrete_type(op1_info) == concrete_type(op2_info) &&
 	           concrete_type(op1_info) <= IS_TRUE) {
 		if (smart_branch_opcode) {
-			if (identical_label != (uint32_t)-1) {
+			if (exit_addr) {
+				if (smart_branch_opcode == ZEND_JMPNZ) {
+					|	jmp &exit_addr
+				}
+			} else if (identical_label != (uint32_t)-1) {
 				|	jmp =>identical_label
 			}
 		} else {
@@ -5977,7 +6686,11 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 	} else if (Z_MODE(op1_addr) == IS_CONST_ZVAL && Z_MODE(op2_addr) == IS_CONST_ZVAL) {
 		if (zend_is_identical(Z_ZV(op1_addr), Z_ZV(op2_addr))) {
 			if (smart_branch_opcode) {
-				if (identical_label != (uint32_t)-1) {
+				if (exit_addr) {
+					if (smart_branch_opcode == ZEND_JMPNZ) {
+						|	jmp &exit_addr
+					}
+				} else if (identical_label != (uint32_t)-1) {
 					|	jmp =>identical_label
 				}
 			} else {
@@ -5985,7 +6698,11 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 			}
 		} else {
 			if (smart_branch_opcode) {
-				if (not_identical_label != (uint32_t)-1) {
+				if (exit_addr) {
+					if (smart_branch_opcode == ZEND_JMPZ) {
+						|	jmp &exit_addr
+					}
+				} else if (not_identical_label != (uint32_t)-1) {
 					|	jmp =>not_identical_label
 				}
 			} else {
@@ -6002,12 +6719,16 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 				|	SAVE_VALID_OPLINE opline
 				|	FREE_OP opline->op2_type, opline->op2, op2_info, 1, op_array, opline
 				zend_jit_check_exception_undef_result(Dst, opline);
-				if (identical_label != (uint32_t)-1) {
+				if (exit_addr && smart_branch_opcode == ZEND_JMPNZ) {
+					|	jmp &exit_addr
+				} else if (identical_label != (uint32_t)-1) {
 					|	jmp =>identical_label
 				} else {
 					|	jmp >9
 				}
 				|8:
+			} else if (exit_addr && smart_branch_opcode == ZEND_JMPNZ) {
+				|	je &exit_addr
 			} else if (identical_label != (uint32_t)-1) {
 				|	je =>identical_label
 			} else {
@@ -6029,7 +6750,11 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 			|	FREE_OP opline->op2_type, opline->op2, op2_info, 1, op_array, opline
 			zend_jit_check_exception_undef_result(Dst, opline);
 		}
-		if (smart_branch_opcode && not_identical_label != (uint32_t)-1) {
+		if (exit_addr) {
+			if (smart_branch_opcode == ZEND_JMPZ) {
+				|	jmp &exit_addr
+			}
+		} else if (smart_branch_opcode && not_identical_label != (uint32_t)-1) {
 			|	jmp =>not_identical_label
 		}
 	} else if (Z_MODE(op2_addr) == IS_CONST_ZVAL && Z_TYPE_P(Z_ZV(op2_addr)) <= IS_TRUE) {
@@ -6042,12 +6767,16 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 				|	SAVE_VALID_OPLINE opline
 				|	FREE_OP opline->op1_type, opline->op1, op1_info, 1, op_array, opline
 				zend_jit_check_exception_undef_result(Dst, opline);
-				if (identical_label != (uint32_t)-1) {
+				if (exit_addr && smart_branch_opcode == ZEND_JMPNZ) {
+					|	jmp &exit_addr
+				} else if (identical_label != (uint32_t)-1) {
 					|	jmp =>identical_label
 				} else {
 					|	jmp >9
 				}
 				|8:
+			} else if (exit_addr && smart_branch_opcode == ZEND_JMPNZ) {
+				|	je &exit_addr
 			} else if (identical_label != (uint32_t)-1) {
 				|	je =>identical_label
 			} else {
@@ -6069,17 +6798,23 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 			|	FREE_OP opline->op1_type, opline->op1, op1_info, 1, op_array, opline
 			zend_jit_check_exception_undef_result(Dst, opline);
 		}
-		if (smart_branch_opcode && not_identical_label != (uint32_t)-1) {
-			|	jmp =>not_identical_label
+		if (smart_branch_opcode) {
+			if (exit_addr) {
+				if (smart_branch_opcode == ZEND_JMPZ) {
+					|	jmp &exit_addr
+				}
+			} else if (not_identical_label != (uint32_t)-1) {
+				|	jmp =>not_identical_label
+			}
 		}
 	} else if ((op1_info & MAY_BE_ANY) == MAY_BE_LONG &&
 	           (op2_info & MAY_BE_ANY) == MAY_BE_LONG) {
-		if (!zend_jit_cmp_long_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+		if (!zend_jit_cmp_long_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 			return 0;
 		}
 	} else if ((op1_info & MAY_BE_ANY) == MAY_BE_DOUBLE &&
 	           (op2_info & MAY_BE_ANY) == MAY_BE_DOUBLE) {
-		if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2)) {
+		if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
 			return 0;
 		}
 	} else {
@@ -6103,7 +6838,13 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 			}
 		if (smart_branch_opcode) {
 			|	test al, al
-			if (not_identical_label != (uint32_t)-1) {
+			if (exit_addr) {
+				if (smart_branch_opcode == ZEND_JMPNZ) {
+					|	jnz &exit_addr
+				} else {
+					|	jz &exit_addr
+				}
+			} else if (not_identical_label != (uint32_t)-1) {
 				|	jz =>not_identical_label
 				if (identical_label != (uint32_t)-1) {
 					|	jmp =>identical_label
@@ -6127,11 +6868,10 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 	if (may_throw) {
 		zend_jit_check_exception(Dst);
 	}
-
 	return 1;
 }
 
-static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr, zend_jit_addr res_addr, uint32_t target_label, uint32_t target_label2, int may_throw)
+static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr, zend_jit_addr res_addr, uint32_t target_label, uint32_t target_label2, int may_throw, zend_uchar branch_opcode, const void *exit_addr)
 {
 	uint32_t true_label = -1;
 	uint32_t false_label = -1;
@@ -6139,22 +6879,22 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 	zend_bool set_bool_not = 0;
 	zend_bool jmp_done = 0;
 
-	if (opline->opcode == ZEND_JMPZ) {
-		false_label = target_label;
-	} else if (opline->opcode == ZEND_JMPNZ) {
-		true_label = target_label;
-	} else if (opline->opcode == ZEND_JMPZNZ) {
-		true_label = target_label2;
-		false_label = target_label;
-	} else if (opline->opcode == ZEND_BOOL) {
+	if (branch_opcode == ZEND_BOOL) {
 		set_bool = 1;
-	} else if (opline->opcode == ZEND_BOOL_NOT) {
+	} else if (branch_opcode == ZEND_BOOL_NOT) {
 		set_bool = 1;
 		set_bool_not = 1;
-	} else if (opline->opcode == ZEND_JMPZ_EX) {
+	} else if (branch_opcode == ZEND_JMPZ) {
+		false_label = target_label;
+	} else if (branch_opcode == ZEND_JMPNZ) {
+		true_label = target_label;
+	} else if (branch_opcode == ZEND_JMPZNZ) {
+		true_label = target_label2;
+		false_label = target_label;
+	} else if (branch_opcode == ZEND_JMPZ_EX) {
 		set_bool = 1;
 		false_label = target_label;
-	} else if (opline->opcode == ZEND_JMPNZ_EX) {
+	} else if (branch_opcode == ZEND_JMPNZ_EX) {
 		set_bool = 1;
 		true_label = target_label;
 	} else {
@@ -6225,7 +6965,13 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 				    if ((op1_info & MAY_BE_LONG) &&
 				        !(op1_info & MAY_BE_UNDEF) &&
 				        !set_bool) {
-						if (false_label != (uint32_t)-1) {
+						if (exit_addr) {
+							if (branch_opcode == ZEND_JMPNZ) {
+								|	jl >9
+							} else {
+								|	jl &exit_addr
+							}
+						} else if (false_label != (uint32_t)-1) {
 							|	jl =>false_label
 						} else {
 							|	jl >9
@@ -6245,7 +6991,32 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 						}
 					}
 				} else {
-					if (true_label != (uint32_t)-1 || false_label != (uint32_t)-1) {
+					if (exit_addr) {
+						if (set_bool) {
+							|	jne >1
+							|	SET_ZVAL_TYPE_INFO res_addr, IS_TRUE
+							if (branch_opcode == ZEND_JMPNZ || branch_opcode == ZEND_JMPNZ_EX) {
+								|	jmp &exit_addr
+							} else {
+								|	jmp >9
+							}
+							|1:
+							|	SET_ZVAL_TYPE_INFO res_addr, IS_FALSE
+							if (branch_opcode == ZEND_JMPZ || branch_opcode == ZEND_JMPZ_EX) {
+								if (!(op1_info & (MAY_BE_UNDEF|MAY_BE_LONG))) {
+									|	jne &exit_addr
+								}
+							}
+						} else {
+							if (branch_opcode == ZEND_JMPNZ || branch_opcode == ZEND_JMPNZ_EX) {
+								|	je &exit_addr
+							} else if (!(op1_info & (MAY_BE_UNDEF|MAY_BE_LONG))) {
+								|	jne &exit_addr
+							} else {
+								|	je >9
+							}
+						}
+					} else if (true_label != (uint32_t)-1 || false_label != (uint32_t)-1) {
 						if (set_bool) {
 							|	jne >1
 							|	SET_ZVAL_TYPE_INFO res_addr, IS_TRUE
@@ -6297,11 +7068,19 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 					}
 				}
 
-				if (false_label != (uint32_t)-1) {
+				if (exit_addr) {
+					if (branch_opcode == ZEND_JMPZ || branch_opcode == ZEND_JMPZ_EX) {
+						|	jmp &exit_addr
+					}
+				} else if (false_label != (uint32_t)-1) {
 					|	jmp =>false_label
 				}
 				if (op1_info & MAY_BE_ANY) {
-					if (false_label == (uint32_t)-1) {
+					if (exit_addr) {
+						if (branch_opcode == ZEND_JMPNZ || branch_opcode == ZEND_JMPNZ_EX) {
+							|	jmp >9
+						}
+					} else if (false_label == (uint32_t)-1) {
 						|	jmp >9
 					}
 					|.code
@@ -6309,7 +7088,13 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 			}
 
 			if (!jmp_done) {
-				if (false_label != (uint32_t)-1) {
+				if (exit_addr) {
+					if (branch_opcode == ZEND_JMPNZ || branch_opcode == ZEND_JMPNZ_EX) {
+						|	jmp >9
+					} else if (op1_info & MAY_BE_LONG) {
+						|	jmp &exit_addr
+					}
+				} else if (false_label != (uint32_t)-1) {
 					|	jmp =>false_label
 				} else if (op1_info & MAY_BE_LONG) {
 					|	jmp >9
@@ -6339,7 +7124,13 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 			}
 			|	SET_ZVAL_TYPE_INFO res_addr, eax
 		}
-		if (true_label != (uint32_t)-1 || false_label != (uint32_t)-1) {
+		if (exit_addr) {
+			if (branch_opcode == ZEND_JMPNZ || branch_opcode == ZEND_JMPNZ_EX) {
+				|	jne &exit_addr
+			} else {
+				|	je &exit_addr
+			}
+		} else if (true_label != (uint32_t)-1 || false_label != (uint32_t)-1) {
 			if (true_label != (uint32_t)-1) {
 				|	jne =>true_label
 				if (false_label != (uint32_t)-1) {
@@ -6360,7 +7151,20 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 		|	SSE_AVX_OP ucomisd, vucomisd, ZREG_XMM0, op1_addr
 
 		if (set_bool) {
-			if (false_label != (uint32_t)-1) { // JMPZ_EX
+			if (exit_addr) {
+				if (branch_opcode == ZEND_JMPNZ || branch_opcode == ZEND_JMPNZ_EX) {
+					|	jp >1
+					|	SET_ZVAL_TYPE_INFO res_addr, IS_TRUE
+					|	jne &exit_addr
+					|1:
+					|	SET_ZVAL_TYPE_INFO res_addr, IS_FALSE
+				} else {
+					|	SET_ZVAL_TYPE_INFO res_addr, IS_FALSE
+					|	jp &exit_addr
+					|	je &exit_addr
+					|	SET_ZVAL_TYPE_INFO res_addr, IS_TRUE
+				}
+			} else if (false_label != (uint32_t)-1) { // JMPZ_EX
 				|	SET_ZVAL_TYPE_INFO res_addr, IS_FALSE
 				|	jp >1
 				|	je => false_label
@@ -6391,20 +7195,31 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 			}
 		} else {
 			ZEND_ASSERT(true_label != (uint32_t)-1 || false_label != (uint32_t)-1);
-			if (false_label != (uint32_t)-1) {
-				|	jp =>false_label
-			} else {
-				|	jp >1
-			}
-			if (true_label != (uint32_t)-1) {
-				|	jne =>true_label
-				if (false_label != (uint32_t)-1) {
-					|	jmp =>false_label
+			if (exit_addr) {
+				if (branch_opcode == ZEND_JMPNZ || branch_opcode == ZEND_JMPNZ_EX) {
+					|	jp >1
+					|	jne &exit_addr
+					|1:
+				} else {
+					|	jp &exit_addr
+					|	je &exit_addr
 				}
 			} else {
-				|	je =>false_label
+				if (false_label != (uint32_t)-1) {
+					|	jp =>false_label
+				} else {
+					|	jp >1
+				}
+				if (true_label != (uint32_t)-1) {
+					|	jne =>true_label
+					if (false_label != (uint32_t)-1) {
+						|	jmp =>false_label
+					}
+				} else {
+					|	je =>false_label
+				}
+				|1:
 			}
-			|1:
 		}
 	} else if (op1_info & (MAY_BE_ANY - (MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG))) {
 		if (op1_info & (MAY_BE_UNDEF|MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG)) {
@@ -6443,7 +7258,14 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 				|	add eax, 2
 			}
 			|	SET_ZVAL_TYPE_INFO res_addr, eax
-			if (true_label != (uint32_t)-1 || false_label != (uint32_t)-1) {
+			if (exit_addr) {
+				|	CMP_ZVAL_TYPE res_addr, IS_FALSE
+				if (branch_opcode == ZEND_JMPNZ || branch_opcode == ZEND_JMPNZ_EX) {
+					|	jne &exit_addr
+				} else {
+					|	je &exit_addr
+				}
+			} else if (true_label != (uint32_t)-1 || false_label != (uint32_t)-1) {
 				|	CMP_ZVAL_TYPE res_addr, IS_FALSE
 				if (true_label != (uint32_t)-1) {
 					|	jne =>true_label
@@ -6462,7 +7284,19 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 			}
 		} else {
 			|	test r0, r0
-			if (true_label != (uint32_t)-1) {
+			if (exit_addr) {
+				if (branch_opcode == ZEND_JMPNZ || branch_opcode == ZEND_JMPNZ_EX) {
+					|	jne &exit_addr
+					if (op1_info & (MAY_BE_UNDEF|MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG)) {
+						|	jmp >9
+					}
+				} else {
+					|	je &exit_addr
+					if (op1_info & (MAY_BE_UNDEF|MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG)) {
+						|	jmp >9
+					}
+				}
+			} else if (true_label != (uint32_t)-1) {
 				|	jne =>true_label
 				if (false_label != (uint32_t)-1) {
 					|	jmp =>false_label
@@ -6533,7 +7367,7 @@ static int zend_jit_assign(dasm_State **Dst, const zend_op *opline, const zend_o
 	return 1;
 }
 
-static int zend_jit_push_call_frame(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_function *func)
+static int zend_jit_push_call_frame(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_function *func, const void *exit_addr)
 {
 	uint32_t used_stack;
 
@@ -6572,27 +7406,32 @@ static int zend_jit_push_call_frame(dasm_State **Dst, const zend_op *opline, con
 	} else {
 		|	cmp r2, FCARG1a
 	}
-	|	jb >1
-	|	// EG(vm_stack_top) = (zval*)((char*)call + used_stack);
-	|.cold_code
-	|1:
-	|	SAVE_VALID_OPLINE opline
-	if (func) {
-		|	mov FCARG1d, used_stack
-	}
-#ifdef _WIN32
-	if (0) {
-#else
-	if (func && func->type == ZEND_INTERNAL_FUNCTION) {
-#endif
-		|	EXT_CALL zend_jit_int_extend_stack_helper, r0
+
+	if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+		|	jb &exit_addr
 	} else {
-		|	mov FCARG2a, r0
-		|	EXT_CALL zend_jit_extend_stack_helper, r0
+		|	jb >1
+		|	// EG(vm_stack_top) = (zval*)((char*)call + used_stack);
+		|.cold_code
+		|1:
+		|	SAVE_VALID_OPLINE opline
+		if (func) {
+			|	mov FCARG1d, used_stack
+		}
+#ifdef _WIN32
+		if (0) {
+#else
+		if (func && func->type == ZEND_INTERNAL_FUNCTION) {
+#endif
+			|	EXT_CALL zend_jit_int_extend_stack_helper, r0
+		} else {
+			|	mov FCARG2a, r0
+			|	EXT_CALL zend_jit_extend_stack_helper, r0
+		}
+		|	mov RX, r0
+		|	jmp >1
+		|.code
 	}
-	|	mov RX, r0
-	|	jmp >1
-	|.code
 
 	if (func) {
 		|	MEM_OP2_1_ZTS add, aword, executor_globals, vm_stack_top, used_stack, r2
@@ -6730,11 +7569,20 @@ static int zend_jit_needs_call_chain(zend_call_info *call_info, uint32_t b, cons
 	}
 }
 
-static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t b, const zend_op_array *op_array, zend_ssa *ssa, int call_level)
+static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t b, const zend_op_array *op_array, zend_ssa *ssa, int call_level, zend_jit_trace_rec *trace)
 {
 	zend_func_info *info = ZEND_FUNC_INFO(op_array);
 	zend_call_info *call_info = NULL;
 	zend_function *func = NULL;
+	const void *exit_addr = NULL;
+
+	if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+		int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+		exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+		if (!exit_addr) {
+			return 0;
+		}
+	}
 
 	if (delayed_call_chain) {
 		if (!zend_jit_save_call_chain(Dst, delayed_call_level)) {
@@ -6750,6 +7598,14 @@ static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t
 		if (call_info && call_info->callee_func) {
 			func = call_info->callee_func;
 		}
+	}
+
+	if (!func
+	 && trace
+	 && trace->op == ZEND_JIT_TRACE_INIT_CALL
+	 && (opline->opcode == ZEND_INIT_FCALL || opline->opcode == ZEND_INIT_FCALL_BY_NAME)) {
+		/* TODO: add guard ??? */
+		func = (zend_function*)trace->func;
 	}
 
 #ifdef _WIN32
@@ -6791,19 +7647,23 @@ static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t
 			|	mov aword [r1 + opline->result.num], r0
 			|	test r0, r0
 			|	jnz >3
-			|	// SAVE_OPLINE();
-			|	SAVE_VALID_OPLINE opline
-			|	jmp ->undefined_function
+			if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+				|	jmp &exit_addr
+			} else {
+				|	// SAVE_OPLINE();
+				|	SAVE_VALID_OPLINE opline
+				|	jmp ->undefined_function
+			}
 		}
 		|.code
 		|3:
 	}
 
-	if (!zend_jit_push_call_frame(Dst, opline, op_array, func)) {
+	if (!zend_jit_push_call_frame(Dst, opline, op_array, func, exit_addr)) {
 		return 0;
 	}
 
-	if (zend_jit_needs_call_chain(call_info, b, op_array, ssa, opline)) {
+	if (trace || zend_jit_needs_call_chain(call_info, b, op_array, ssa, opline)) {
 		if (!zend_jit_save_call_chain(Dst, call_level)) {
 			return 0;
 		}
@@ -6815,7 +7675,7 @@ static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t
 	return 1;
 }
 
-static uint32_t skip_valid_arguments(const zend_op_array *op_array, zend_ssa *ssa, zend_call_info *call_info)
+static uint32_t skip_valid_arguments(const zend_op_array *op_array, zend_ssa *ssa, const zend_call_info *call_info)
 {
 	uint32_t num_args = 0;
 	zend_function *func = call_info->callee_func;
@@ -6839,11 +7699,11 @@ static uint32_t skip_valid_arguments(const zend_op_array *op_array, zend_ssa *ss
 	return num_args;
 }
 
-static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_ssa *ssa, int call_level, unsigned int next_block)
+static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_ssa *ssa, int call_level, unsigned int next_block, zend_jit_trace_rec *trace)
 {
 	zend_func_info *info = ZEND_FUNC_INFO(op_array);
 	zend_call_info *call_info = NULL;
-	zend_function *func = NULL;
+	const zend_function *func = NULL;
 	uint32_t i;
 	zend_jit_addr res_addr;
 
@@ -6891,6 +7751,56 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		ZEND_ASSERT(0);
 	}
 
+	if (trace && !func) {
+		if (trace->op == ZEND_JIT_TRACE_DO_ICALL) {
+			ZEND_ASSERT(trace->func->type == ZEND_INTERNAL_FUNCTION);
+#ifdef ZEND_WIN32
+			// TODO: ASLR may cause different addresses in different workers ???
+			goto fallback;
+#else
+			func = trace->func;
+#endif
+		} else if (trace->op == ZEND_JIT_TRACE_ENTER) {
+			ZEND_ASSERT(trace->func->type == ZEND_USER_FUNCTION);
+			if (!(trace->func->common.fn_flags & ZEND_ACC_IMMUTABLE)) {
+				// TODO: We don't have op_array to insert a guard ???
+				goto fallback;
+			}
+		} else {
+			ZEND_ASSERT(0);
+			return 0;
+		}
+
+		if (opline->opcode == ZEND_DO_FCALL) {
+			// TODO: This guard should be checked early !!! (in INIT_FCALL) ???
+			intptr_t fbc = (intptr_t)(void*)trace->func;
+			uint32_t exit_point = zend_jit_trace_get_exit_point(opline, NULL, trace);
+			const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+
+			if (!exit_addr) {
+				return 0;
+			}
+
+			// TODO: Avoid regster reloading ???
+			zend_jit_stop_reuse_ip();
+			|	LOAD_IP_ADDR opline
+
+			|	// call = EX(call);
+			|	mov r1, EX->call
+			|   .if X64
+			|| 		if (!IS_SIGNED_32BIT(fbc)) {
+			|  			mov64 r0, fbc
+			|			cmp aword EX:r1->func, r0
+			||		} else {
+			|  			cmp aword EX:r1->func, fbc
+			||		}
+			|	.else
+			|		cmp aword EX:r1->func, fbc
+			|	.endif
+			|	jne &exit_addr
+		}
+	}
+
 	if (!reuse_ip) {
 		zend_jit_start_reuse_ip();
 		|	// call = EX(call);
@@ -6923,20 +7833,31 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 
 	if (opline->opcode == ZEND_DO_FCALL) {
 		if (!func) {
-			|	test dword [r0 + offsetof(zend_op_array, fn_flags)], ZEND_ACC_DEPRECATED
-			|	jnz >1
-			|.cold_code
-			|1:
-			if (!GCC_GLOBAL_REGS) {
-				|	mov FCARG1a, RX
+			if (trace) {
+				uint32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+				const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+
+				if (!exit_addr) {
+					return 0;
+				}
+				|	test dword [r0 + offsetof(zend_op_array, fn_flags)], ZEND_ACC_DEPRECATED
+				|	jnz &exit_addr
+			} else {
+				|	test dword [r0 + offsetof(zend_op_array, fn_flags)], ZEND_ACC_DEPRECATED
+				|	jnz >1
+				|.cold_code
+				|1:
+				if (!GCC_GLOBAL_REGS) {
+					|	mov FCARG1a, RX
+				}
+				|	EXT_CALL zend_jit_deprecated_helper, r0
+				|	MEM_OP2_1_ZTS cmp, aword, executor_globals, exception, 0, r0
+				|	jne ->exception_handler
+				|	mov r0, EX:RX->func // reload
+				|	jmp >1
+				|.code
+				|1:
 			}
-			|	EXT_CALL zend_jit_deprecated_helper, r0
-			|	MEM_OP2_1_ZTS cmp, aword, executor_globals, exception, 0, r0
-			|	jne ->exception_handler
-			|	mov r0, EX:RX->func // reload
-			|	jmp >1
-			|.code
-			|1:
 		} else if (func->common.fn_flags & ZEND_ACC_DEPRECATED) {
 			if (!GCC_GLOBAL_REGS) {
 				|	mov FCARG1a, RX
@@ -6980,7 +7901,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		if (!func || func->op_array.cache_size) {
 			if (func && op_array == &func->op_array) {
 				/* recursive call */
-				if (func->op_array.cache_size > sizeof(void*)) {
+				if (trace || func->op_array.cache_size > sizeof(void*)) {
 					|	mov r2, EX->run_time_cache
 					|	mov EX:RX->run_time_cache, r2
 				}
@@ -7037,7 +7958,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 				}
 			}
 
-			if (op_array == &func->op_array) {
+			if (!trace && op_array == &func->op_array) {
 				/* recursive call */
 #ifdef CONTEXT_THREADED_JIT
 				|	call >1
@@ -7106,24 +8027,34 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			|3:
 		}
 
-#ifdef CONTEXT_THREADED_JIT
-		|	call ->context_threaded_call
-		if (!func && (opline->opcode != ZEND_DO_UCALL)) {
-			|	jmp >9
-		}
-#else
-		if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
-			|	add r4, HYBRID_SPAD
-			|	JMP_IP
-		} else if (GCC_GLOBAL_REGS) {
-			|	add r4, SPAD // stack alignment
-			|	JMP_IP
+		if (trace) {
+			if (!func && (opline->opcode != ZEND_DO_UCALL)) {
+				|	jmp >9
+			}
 		} else {
-			|	mov FP, aword T2 // restore FP
-			|	mov RX, aword T3 // restore IP
-			|	add r4, NR_SPAD // stack alignment
-			|	mov r0, 1 // ZEND_VM_ENTER
-			|	ret
+#ifdef CONTEXT_THREADED_JIT
+			|	call ->context_threaded_call
+			if (!func && (opline->opcode != ZEND_DO_UCALL)) {
+				|	jmp >9
+			}
+			|	call ->context_threaded_call
+			if (!func) {
+				|	jmp >9
+			}
+#else
+			if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+				|	add r4, HYBRID_SPAD
+				|	JMP_IP
+			} else if (GCC_GLOBAL_REGS) {
+				|	add r4, SPAD // stack alignment
+				|	JMP_IP
+			} else {
+				|	mov FP, aword T2 // restore FP
+				|	mov RX, aword T3 // restore IP
+				|	add r4, NR_SPAD // stack alignment
+				|	mov r0, 1 // ZEND_VM_ENTER
+				|	ret
+			}
 		}
 #endif
 	}
@@ -7135,20 +8066,31 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		}
 		if (opline->opcode == ZEND_DO_FCALL_BY_NAME) {
 			if (!func) {
-				|	test dword [r0 + offsetof(zend_op_array, fn_flags)], ZEND_ACC_DEPRECATED
-				|	jnz >1
-				|.cold_code
-				|1:
-				if (!GCC_GLOBAL_REGS) {
-					|	mov FCARG1a, RX
+				if (trace) {
+					uint32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+					const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+
+					if (!exit_addr) {
+						return 0;
+					}
+					|	test dword [r0 + offsetof(zend_op_array, fn_flags)], ZEND_ACC_DEPRECATED
+					|	jnz &exit_addr
+				} else {
+					|	test dword [r0 + offsetof(zend_op_array, fn_flags)], ZEND_ACC_DEPRECATED
+					|	jnz >1
+						|.cold_code
+					|1:
+					if (!GCC_GLOBAL_REGS) {
+						|	mov FCARG1a, RX
+					}
+					|	EXT_CALL zend_jit_deprecated_helper, r0
+					|	MEM_OP2_1_ZTS cmp, aword, executor_globals, exception, 0, r0
+					|	jne ->exception_handler
+					|	mov r0, EX:RX->func // reload
+					|	jmp >1
+					|.code
+					|1:
 				}
-				|	EXT_CALL zend_jit_deprecated_helper, r0
-				|	MEM_OP2_1_ZTS cmp, aword, executor_globals, exception, 0, r0
-				|	jne ->exception_handler
-				|	mov r0, EX:RX->func // reload
-				|	jmp >1
-				|.code
-				|1:
 			} else if (func->common.fn_flags & ZEND_ACC_DEPRECATED) {
 				if (!GCC_GLOBAL_REGS) {
 					|	mov FCARG1a, RX
@@ -7183,11 +8125,22 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			|	call aword [r0 + offsetof(zend_internal_function, handler)]
 		}
 
+		if (trace) {
+			// TODO: This is a qucik dirty fix ??????
+			//
+			// Internal function may call another trace that,
+			// replaces EG(trace_id) and the following side exit
+			// from this trace is going to be mad !!!!!!
+			//
+			// Lets set EG(trace_id) once again...
+			zend_jit_trace_begin(Dst, current_trace_num);
+		}
+
 		|	// EG(current_execute_data) = execute_data;
 		|	MEM_OP2_1_ZTS mov, aword, executor_globals, current_execute_data, FP, r0
 
 		|	// zend_vm_stack_free_args(call);
-		if (func) {
+		if (func && call_info) {
 			for (i = 0; i < call_info->num_args; i++ ) {
 				uint32_t offset = EX_NUM_TO_VAR(i);
 				|	ZVAL_PTR_DTOR ZEND_ADDR_MEM_ZVAL(ZREG_RX, offset), MAY_BE_ANY|MAY_BE_RC1|MAY_BE_RCN, 0, 1, 0, opline
@@ -7264,6 +8217,9 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 
 fallback:
 	/* fallback to subroutine threading */
+	if (trace) {
+		return zend_jit_trace_handler(Dst, op_array, opline, zend_may_throw(opline, op_array, ssa), trace);
+	}
 	if (opline->opcode == ZEND_DO_FCALL ||
 	    opline->opcode == ZEND_DO_UCALL ||
 	    opline->opcode == ZEND_DO_FCALL_BY_NAME ){
@@ -7289,18 +8245,27 @@ static int zend_jit_send_val(dasm_State **Dst, const zend_op *opline, const zend
 	if (opline->opcode == ZEND_SEND_VAL_EX) {
 		uint32_t mask = ZEND_SEND_BY_REF << ((arg_num + 3) * 2);
 
+		ZEND_ASSERT(arg_num <= MAX_ARG_FLAG_NUM);
+
 		|	mov r0, EX:RX->func
-		if (arg_num <= MAX_ARG_FLAG_NUM) {
-			|	test dword [r0 + offsetof(zend_function, quick_arg_flags)], mask
-			|	jnz	>1
+		|	test dword [r0 + offsetof(zend_function, quick_arg_flags)], mask
+
+		if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+			int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+			const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+			if (!exit_addr) {
+				return 0;
+			}
+			|	jnz	&exit_addr
 		} else {
-			ZEND_ASSERT(0);
+			|	jnz	>1
+			|.cold_code
+			|1:
+			|	SAVE_VALID_OPLINE opline
+			|	jmp ->throw_cannot_pass_by_ref
+			|.code
+
 		}
-		|.cold_code
-		|1:
-		|	SAVE_VALID_OPLINE opline
-		|	jmp ->throw_cannot_pass_by_ref
-		|.code
 	}
 
 	arg_addr = ZEND_ADDR_MEM_ZVAL(ZREG_RX, opline->result.var);
@@ -7436,6 +8401,7 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 			if (!zend_jit_send_ref(Dst, opline, op_array, op1_info, 1)) {
 				return 0;
 			}
+			|	jmp >7
 		} else if (opline->opcode == ZEND_SEND_VAR_NO_REF_EX) {
 			mask = ZEND_SEND_PREFER_REF << ((arg_num + 3) * 2);
 
@@ -7446,17 +8412,26 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 			}
 			|	test dword [r0 + offsetof(zend_function, quick_arg_flags)], mask
 			|	jnz >7
-			|	SAVE_VALID_OPLINE opline
-			|	LOAD_ZVAL_ADDR FCARG1a, arg_addr
-			|	EXT_CALL zend_jit_only_vars_by_reference, r0
-			if (!zend_jit_check_exception(Dst)) {
-				return 0;
+			if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+				int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+				const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+				if (!exit_addr) {
+					return 0;
+				}
+				|	jmp &exit_addr
+			} else {
+				|	SAVE_VALID_OPLINE opline
+				|	LOAD_ZVAL_ADDR FCARG1a, arg_addr
+				|	EXT_CALL zend_jit_only_vars_by_reference, r0
+				if (!zend_jit_check_exception(Dst)) {
+					return 0;
+				}
+				|	jmp >7
 			}
 		} else {
 			ZEND_ASSERT(0);
 		}
 
-		|	jmp >7
 		|.code
 	}
 
@@ -7484,11 +8459,20 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 			|	cmp cl, IS_REFERENCE
 			|	je >7
 		}
-		|	SAVE_VALID_OPLINE opline
-		|	LOAD_ZVAL_ADDR FCARG1a, arg_addr
-		|	EXT_CALL zend_jit_only_vars_by_reference, r0
-		if (!zend_jit_check_exception(Dst)) {
-			return 0;
+		if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+			int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+			const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+			if (!exit_addr) {
+				return 0;
+			}
+			|	jmp &exit_addr
+		} else {
+			|	SAVE_VALID_OPLINE opline
+			|	LOAD_ZVAL_ADDR FCARG1a, arg_addr
+			|	EXT_CALL zend_jit_only_vars_by_reference, r0
+			if (!zend_jit_check_exception(Dst)) {
+				return 0;
+			}
 		}
 	} else if (op1_info & (MAY_BE_ANY|MAY_BE_REF)) {
 		if (op1_info & MAY_BE_REF) {
@@ -7593,14 +8577,14 @@ static int zend_jit_smart_false(dasm_State **Dst, const zend_op *opline, int jmp
 	return 1;
 }
 
-static int zend_jit_defined(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_defined(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	uint32_t defined_label = (uint32_t)-1;
 	uint32_t undefined_label = (uint32_t)-1;
 	zval *zv = RT_CONSTANT(opline, opline->op1);
-	zend_jit_addr res_addr;
+	zend_jit_addr res_addr = 0;
 
-	if (smart_branch_opcode) {
+	if (smart_branch_opcode && !exit_addr) {
 		if (smart_branch_opcode == ZEND_JMPZ) {
 			undefined_label = target_label;
 		} else if (smart_branch_opcode == ZEND_JMPNZ) {
@@ -7625,8 +8609,15 @@ static int zend_jit_defined(dasm_State **Dst, const zend_op *opline, const zend_
 	|	MEM_OP2_2_ZTS mov, FCARG1a, aword, executor_globals, zend_constants, FCARG1a
 	|	shr	r0, 1
 	|	cmp dword [FCARG1a + offsetof(HashTable, nNumOfElements)], eax
+
 	if (smart_branch_opcode) {
-		if (undefined_label != (uint32_t)-1) {
+		if (exit_addr) {
+			if (smart_branch_opcode == ZEND_JMPZ) {
+				|	jz &exit_addr
+			} else {
+				|	jz >3
+			}
+		} else if (undefined_label != (uint32_t)-1) {
 			|	jz =>undefined_label
 		} else {
 			|	jz >3
@@ -7639,7 +8630,14 @@ static int zend_jit_defined(dasm_State **Dst, const zend_op *opline, const zend_
 	|	LOAD_ADDR FCARG1a, zv
 	|	EXT_CALL zend_jit_check_constant, r0
 	|	test r0, r0
-	if (smart_branch_opcode) {
+	if (exit_addr) {
+		if (smart_branch_opcode == ZEND_JMPNZ) {
+			|	jnz >3
+		} else {
+			|	jz >3
+		}
+		|	jmp &exit_addr
+	} else if (smart_branch_opcode) {
 		if (undefined_label != (uint32_t)-1) {
 			|	jnz =>undefined_label
 		} else {
@@ -7659,7 +8657,11 @@ static int zend_jit_defined(dasm_State **Dst, const zend_op *opline, const zend_
 	}
 	|.code
 	if (smart_branch_opcode) {
-		if (defined_label != (uint32_t)-1) {
+		if (exit_addr) {
+			if (smart_branch_opcode == ZEND_JMPNZ) {
+				|	jmp &exit_addr
+			}
+		} else if (defined_label != (uint32_t)-1) {
 			|	jmp =>defined_label
 		}
 	} else {
@@ -7671,7 +8673,7 @@ static int zend_jit_defined(dasm_State **Dst, const zend_op *opline, const zend_
 	return 1;
 }
 
-static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	uint32_t  mask;
 	zend_uchar type;
@@ -7691,11 +8693,23 @@ static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const ze
 		|	EXT_CALL zend_jit_undefined_op_helper, r0
 		zend_jit_check_exception_undef_result(Dst, opline);
 		if (opline->extended_value & MAY_BE_NULL) {
-			if (!zend_jit_smart_true(Dst, opline, (op1_info & (MAY_BE_ANY|MAY_BE_REF)) != 0, smart_branch_opcode, target_label, target_label2)) {
+			if (exit_addr) {
+				if (smart_branch_opcode == ZEND_JMPNZ) {
+					|	jmp &exit_addr
+				} else if ((op1_info & (MAY_BE_ANY|MAY_BE_REF)) != 0) {
+					|	jmp >7
+				}
+			} else if (!zend_jit_smart_true(Dst, opline, (op1_info & (MAY_BE_ANY|MAY_BE_REF)) != 0, smart_branch_opcode, target_label, target_label2)) {
 				return 0;
 			}
 		} else {
-			if (!zend_jit_smart_false(Dst, opline, (op1_info & (MAY_BE_ANY|MAY_BE_REF)) != 0, smart_branch_opcode, target_label)) {
+			if (exit_addr) {
+				if (smart_branch_opcode == ZEND_JMPZ) {
+					|	jmp &exit_addr
+				} else if ((op1_info & (MAY_BE_ANY|MAY_BE_REF)) != 0) {
+					|	jmp >7
+				}
+			} else if (!zend_jit_smart_false(Dst, opline, (op1_info & (MAY_BE_ANY|MAY_BE_REF)) != 0, smart_branch_opcode, target_label)) {
 				return 0;
 			}
 		}
@@ -7721,12 +8735,20 @@ static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const ze
 
 		if (!(op1_info & (MAY_BE_ANY - mask))) {
 			|	FREE_OP opline->op1_type, opline->op1, op1_info, 1, op_array, opline
-			if (!zend_jit_smart_true(Dst, opline, 0, smart_branch_opcode, target_label, target_label2)) {
+			if (exit_addr) {
+				if (smart_branch_opcode == ZEND_JMPNZ) {
+					|	jmp &exit_addr
+				}
+			} else if (!zend_jit_smart_true(Dst, opline, 0, smart_branch_opcode, target_label, target_label2)) {
 				return 0;
 			}
 	    } else if (!(op1_info & mask)) {
 			|	FREE_OP opline->op1_type, opline->op1, op1_info, 1, op_array, opline
-			if (!zend_jit_smart_false(Dst, opline, 0, smart_branch_opcode, target_label)) {
+			if (exit_addr) {
+				if (smart_branch_opcode == ZEND_JMPZ) {
+					|	jmp &exit_addr
+				}
+			} else if (!zend_jit_smart_false(Dst, opline, 0, smart_branch_opcode, target_label)) {
 				return 0;
 			}
 		} else {
@@ -7785,7 +8807,13 @@ static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const ze
 				|	mov eax, 1
 				|	shl eax, cl
 				|	test eax, mask
-				if (smart_branch_opcode) {
+				if (exit_addr) {
+					if (smart_branch_opcode == ZEND_JMPNZ) {
+						|	jne &exit_addr
+					} else {
+						|	je &exit_addr
+					}
+				} else if (smart_branch_opcode) {
 					if (smart_branch_opcode == ZEND_JMPZ) {
 						| 	je =>target_label
 					} else if (smart_branch_opcode == ZEND_JMPNZ) {
@@ -7854,7 +8882,13 @@ static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const ze
 						|	cmp byte [FP + opline->op1.var + 8], type
 					}
 				}
-				if (smart_branch_opcode) {
+				if (exit_addr) {
+					if (smart_branch_opcode == ZEND_JMPNZ) {
+						|	je &exit_addr
+					} else {
+						|	jne &exit_addr
+					}
+				} else if (smart_branch_opcode) {
 					if (smart_branch_opcode == ZEND_JMPZ) {
 						| 	jne =>target_label
 					} else if (smart_branch_opcode == ZEND_JMPNZ) {
@@ -7883,75 +8917,93 @@ static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const ze
 	return 1;
 }
 
-static int zend_jit_free_compiled_variables(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_ssa *ssa)
+static uint32_t zend_ssa_cv_info(const zend_op *opline, const zend_op_array *op_array, zend_ssa *ssa, uint32_t var)
 {
-    uint32_t i, j, info;
+    uint32_t j, info;
 
-	// Use type inference to avoid useless zval_ptr_dtor()
-	for (i = 0 ; i < op_array->last_var; i++) {
-		if (ssa->vars && ssa->var_info) {
-			info = ssa->var_info[i].type;
-			for (j = op_array->last_var; j < ssa->vars_count; j++) {
-				if (ssa->vars[j].var == i) {
-					info |= ssa->var_info[j].type;
-				}
+	if (ssa->vars && ssa->var_info) {
+		info = ssa->var_info[var].type;
+		for (j = op_array->last_var; j < ssa->vars_count; j++) {
+			if (ssa->vars[j].var == var) {
+				info |= ssa->var_info[j].type;
 			}
-		} else {
-			info = MAY_BE_RC1 | MAY_BE_RCN | MAY_BE_REF | MAY_BE_ANY | MAY_BE_UNDEF;
 		}
+	} else {
+		info = MAY_BE_RC1 | MAY_BE_RCN | MAY_BE_REF | MAY_BE_ANY | MAY_BE_UNDEF;
+	}
 
 #ifdef ZEND_JIT_USE_RC_INFERENCE
-		/* Refcount may be increased by RETURN opcode */
-		if ((info & MAY_BE_RC1) && !(info & MAY_BE_RCN)) {
-			for (j = 0; j < ssa->cfg.blocks_count; j++) {
-				if ((ssa->cfg.blocks[j].flags & ZEND_BB_REACHABLE) &&
-				    ssa->cfg.blocks[j].len > 0) {
-					const zend_op *opline = op_array->opcodes + ssa->cfg.blocks[j].start + ssa->cfg.blocks[j].len - 1;
+	/* Refcount may be increased by RETURN opcode */
+	if ((info & MAY_BE_RC1) && !(info & MAY_BE_RCN)) {
+		for (j = 0; j < ssa->cfg.blocks_count; j++) {
+			if ((ssa->cfg.blocks[j].flags & ZEND_BB_REACHABLE) &&
+			    ssa->cfg.blocks[j].len > 0) {
+				const zend_op *opline = op_array->opcodes + ssa->cfg.blocks[j].start + ssa->cfg.blocks[j].len - 1;
 
-					if (opline->opcode == ZEND_RETURN) {
-						if (opline->op1_type == IS_CV && opline->op1.var == EX_NUM_TO_VAR(i)) {
-							info |= MAY_BE_RCN;
-							break;
-						}
+				if (opline->opcode == ZEND_RETURN) {
+					if (opline->op1_type == IS_CV && opline->op1.var == EX_NUM_TO_VAR(var)) {
+						info |= MAY_BE_RCN;
+						break;
 					}
 				}
 			}
 		}
+	}
 #endif
 
-		if (info & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE|MAY_BE_REF)) {
-			uint32_t offset = EX_NUM_TO_VAR(i);
-			| ZVAL_PTR_DTOR ZEND_ADDR_MEM_ZVAL(ZREG_FP, offset), info, 1, 1, 0, opline
-		}
+	return info;
+}
+
+static int zend_jit_leave_frame(dasm_State **Dst)
+{
+	|	// EG(current_execute_data) = EX(prev_execute_data);
+	|	mov r0, EX->prev_execute_data
+	|	MEM_OP2_1_ZTS mov, aword, executor_globals, current_execute_data, r0, r2
+	return 1;
+}
+
+static int zend_jit_free_cv(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t info, uint32_t var)
+{
+	if (info & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE|MAY_BE_REF)) {
+		uint32_t offset = EX_NUM_TO_VAR(var);
+		| ZVAL_PTR_DTOR ZEND_ADDR_MEM_ZVAL(ZREG_FP, offset), info, 1, 1, 0, opline
 	}
 	return 1;
 }
 
-static int zend_jit_leave_func(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_ssa *ssa)
+static int zend_jit_leave_func(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_jit_trace_rec *trace)
 {
-	// Avoid multiple leave sequences
-	if (jit_return_label >= 0) {
-		| jmp =>jit_return_label
-		return 1;
-	}
-
-	jit_return_label = ssa->cfg.blocks_count * 2;
-
-	|=>jit_return_label:
-
-	|	// EG(current_execute_data) = EX(prev_execute_data);
-	|	mov r0, EX->prev_execute_data
-	|	MEM_OP2_1_ZTS mov, aword, executor_globals, current_execute_data, r0, r2
-
-	// i_free_compiled_variables(execute_data);
-	if (!zend_jit_free_compiled_variables(Dst, opline, op_array, ssa)) {
-		return 0;
-	}
-
 	/* ZEND_CALL_FAKE_CLOSURE handled on slow path to eliminate check for ZEND_CALL_CLOSURE on fast path */
 	|	mov FCARG1d, dword [FP + offsetof(zend_execute_data, This.u1.type_info)]
 	|	test FCARG1d, (ZEND_CALL_TOP|ZEND_CALL_HAS_SYMBOL_TABLE|ZEND_CALL_FREE_EXTRA_ARGS|ZEND_CALL_ALLOCATED|ZEND_CALL_FAKE_CLOSURE)
-	|	jnz ->leave_function_handler
+	if (trace && trace->op != ZEND_JIT_TRACE_END) {
+		|	jnz >1
+		|.cold_code
+		|1:
+		if (!GCC_GLOBAL_REGS) {
+			|	mov FCARG2a, FP
+		}
+		|	EXT_CALL zend_jit_leave_func_helper, r0
+		// TODO: try to avoid this check ???
+		if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+			|	cmp IP, zend_jit_halt_op
+			|	je ->trace_halt
+		} else if (GCC_GLOBAL_REGS) {
+			|	test IP, IP
+			|	je ->trace_halt
+		} else {
+			|	test eax, eax
+			|	jl ->trace_halt
+		}
+		if (!GCC_GLOBAL_REGS) {
+			|	// execute_data = EG(current_execute_data)
+			|	MEM_OP2_2_ZTS mov, FP, aword, executor_globals, current_execute_data, r0
+		}
+		|	jmp >8
+		|.code
+	} else {
+		|	jnz ->leave_function_handler
+	}
 
 	if ((op_array->scope && !(op_array->fn_flags & ZEND_ACC_STATIC)) ||
 	    (op_array->fn_flags & ZEND_ACC_CLOSURE)) {
@@ -7975,12 +9027,53 @@ static int zend_jit_leave_func(dasm_State **Dst, const zend_op *opline, const ze
 	|	MEM_OP2_1_ZTS mov, aword, executor_globals, vm_stack_top, FP, r0
 	|	// execute_data = EX(prev_execute_data);
 	|	mov FP, EX->prev_execute_data
-	|	// if (EG(exception))
-	|	MEM_OP2_1_ZTS cmp, aword, executor_globals, exception, 0, r0
-	|	LOAD_OPLINE
-	|	jne ->leave_throw_handler
-	|	// opline = EX(opline) + 1
-	|	ADD_IP sizeof(zend_op)
+
+	|9:
+	if (trace) {
+		if (trace->op != ZEND_JIT_TRACE_END
+		 && (trace->op != ZEND_JIT_TRACE_BACK || !trace->recursive)) {
+			zend_jit_reset_opline(Dst, NULL);
+		} else {
+			// TODO: exception handling for tracing JIT ???
+			|	LOAD_OPLINE
+			|	ADD_IP sizeof(zend_op)
+		}
+
+		|8:
+
+		if (opline->opcode == ZEND_RETURN
+		 && trace->op == ZEND_JIT_TRACE_BACK
+		 && trace->recursive) {
+			const zend_op *next_opline = trace->opline;
+			uint32_t exit_point = zend_jit_trace_get_exit_point(opline, NULL, trace);
+			const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+
+			trace++;
+			ZEND_ASSERT(trace->op == ZEND_JIT_TRACE_VM || trace->op == ZEND_JIT_TRACE_END);
+			next_opline = trace->opline;
+			exit_point = zend_jit_trace_get_exit_point(opline, NULL, trace);
+			exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+			if (!exit_addr) {
+				return 0;
+			}
+			|	// TODO: exception handling ???
+			|	CMP_IP next_opline
+			|	jne &exit_addr
+
+			last_valid_opline = trace->opline;
+
+			return 1;
+		}
+		return 1;
+	} else {
+		|	// if (EG(exception))
+		|	MEM_OP2_1_ZTS cmp, aword, executor_globals, exception, 0, r0
+		|	LOAD_OPLINE
+		|	jne ->leave_throw_handler
+		|	// opline = EX(opline) + 1
+		|	ADD_IP sizeof(zend_op)
+	}
+
 	if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
 		|	add r4, HYBRID_SPAD
 #ifdef CONTEXT_THREADED_JIT
@@ -8021,61 +9114,86 @@ static int zend_jit_leave_func(dasm_State **Dst, const zend_op *opline, const ze
 	return 1;
 }
 
-static int zend_jit_return(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, zend_ssa *ssa, uint32_t op1_info, zend_jit_addr op1_addr)
+static int zend_jit_return(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr)
 {
 	zend_jit_addr ret_addr;
+	int8_t return_value_used;
 
 	ZEND_ASSERT(op_array->type != ZEND_EVAL_CODE && op_array->function_name);
 	ZEND_ASSERT(!(op1_info & MAY_BE_UNDEF));
 
+	if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE && JIT_G(current_frame)) {
+		return_value_used = JIT_G(current_frame)->return_value_used;
+	} else {
+		return_value_used = -1;
+	}
+
 	// if (!EX(return_value))
 	if (Z_MODE(op1_addr) == IS_REG && Z_REG(op1_addr) == ZREG_R1) {
-		|	mov r2, EX->return_value
-		|	test r2, r2
+		if (return_value_used != 0) {
+			|	mov r2, EX->return_value
+		}
+		if (return_value_used == -1) {
+			|	test r2, r2
+		}
 		ret_addr = ZEND_ADDR_MEM_ZVAL(ZREG_R2, 0);
 	} else {
-		|	mov r1, EX->return_value
-		|	test r1, r1
+		if (return_value_used != 0) {
+			|	mov r1, EX->return_value
+		}
+		if (return_value_used == -1) {
+			|	test r1, r1
+		}
 		ret_addr = ZEND_ADDR_MEM_ZVAL(ZREG_R1, 0);
 	}
 	if ((opline->op1_type & (IS_VAR|IS_TMP_VAR)) &&
 	    (op1_info & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE))) {
-		|	jz >1
-		|.cold_code
-		|1:
-		if (op1_info & ((MAY_BE_UNDEF|MAY_BE_ANY|MAY_BE_REF)-(MAY_BE_OBJECT|MAY_BE_RESOURCE))) {
-			if (jit_return_label >= 0) {
-				|	IF_NOT_ZVAL_REFCOUNTED op1_addr, =>jit_return_label
-			} else {
-				|	IF_NOT_ZVAL_REFCOUNTED op1_addr, >9
-			}
+		if (return_value_used == -1) {
+			|	jz >1
+			|.cold_code
+			|1:
 		}
-		|	GET_ZVAL_PTR FCARG1a, op1_addr
-		|	GC_DELREF FCARG1a
-		if (RC_MAY_BE_1(op1_info)) {
-			if (RC_MAY_BE_N(op1_info)) {
+		if (return_value_used != 1) {
+			if (op1_info & ((MAY_BE_UNDEF|MAY_BE_ANY|MAY_BE_REF)-(MAY_BE_OBJECT|MAY_BE_RESOURCE))) {
 				if (jit_return_label >= 0) {
-					|	jnz =>jit_return_label
+					|	IF_NOT_ZVAL_REFCOUNTED op1_addr, =>jit_return_label
 				} else {
-					|	jnz >9
+					|	IF_NOT_ZVAL_REFCOUNTED op1_addr, >9
 				}
 			}
-			|	//SAVE_OPLINE()
-			|	ZVAL_DTOR_FUNC op1_info, opline
-			|	//????mov r1, EX->return_value // reload ???
+			|	GET_ZVAL_PTR FCARG1a, op1_addr
+			|	GC_DELREF FCARG1a
+			if (RC_MAY_BE_1(op1_info)) {
+				if (RC_MAY_BE_N(op1_info)) {
+					if (jit_return_label >= 0) {
+						|	jnz =>jit_return_label
+					} else {
+						|	jnz >9
+					}
+				}
+				|	//SAVE_OPLINE()
+				|	ZVAL_DTOR_FUNC op1_info, opline
+				|	//????mov r1, EX->return_value // reload ???
+			}
+			if (return_value_used == -1) {
+				if (jit_return_label >= 0) {
+					|	jmp =>jit_return_label
+				} else {
+					|	jmp >9
+				}
+				|.code
+			}
 		}
-		if (jit_return_label >= 0) {
-			|	jmp =>jit_return_label
-		} else {
-			|	jmp >9
-		}
-		|.code
-	} else {
+	} else if (return_value_used == -1) {
 		if (jit_return_label >= 0) {
 			|	jz =>jit_return_label
 		} else {
 			|	jz >9
 		}
+	}
+
+	if (return_value_used == 0) {
+		return 1;
 	}
 
 	if (opline->op1_type == IS_CONST) {
@@ -8135,8 +9253,7 @@ static int zend_jit_return(dasm_State **Dst, const zend_op *opline, const zend_o
 	}
 
 	|9:
-	//JIT: ZEND_VM_DISPATCH_TO_HELPER(zend_leave_helper);
-	return zend_jit_leave_func(Dst, opline, op_array, ssa);
+	return 1;
 }
 
 static int zend_jit_fetch_dim_read(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, uint32_t op2_info, uint32_t res_info, int may_throw)
@@ -8316,7 +9433,7 @@ static int zend_jit_fetch_dim_read(dasm_State **Dst, const zend_op *opline, cons
 	return 1;
 }
 
-static int zend_jit_isset_isempty_dim(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, uint32_t op2_info, int may_throw, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2)
+static int zend_jit_isset_isempty_dim(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, uint32_t op2_info, int may_throw, zend_uchar smart_branch_opcode, uint32_t target_label, uint32_t target_label2, const void *exit_addr)
 {
 	zend_jit_addr op1_addr, op2_addr, res_addr;
 
@@ -8385,7 +9502,13 @@ static int zend_jit_isset_isempty_dim(dasm_State **Dst, const zend_op *opline, c
 		}
 	}
 	if (!(opline->extended_value & ZEND_ISEMPTY)) {
-		if (smart_branch_opcode) {
+		if (exit_addr) {
+			if (smart_branch_opcode == ZEND_JMPNZ) {
+				|	jmp &exit_addr
+			} else {
+				|	jmp >8
+			}
+		} else if (smart_branch_opcode) {
 			if (smart_branch_opcode == ZEND_JMPZ) {
 				|	jmp =>target_label2
 			} else if (smart_branch_opcode == ZEND_JMPNZ) {
@@ -8413,7 +9536,11 @@ static int zend_jit_isset_isempty_dim(dasm_State **Dst, const zend_op *opline, c
 		}
 	}
 	if (!(opline->extended_value & ZEND_ISEMPTY)) {
-		if (smart_branch_opcode) {
+		if (exit_addr) {
+			if (smart_branch_opcode == ZEND_JMPZ) {
+				|	jmp &exit_addr
+			}
+		} else if (smart_branch_opcode) {
 			if (smart_branch_opcode == ZEND_JMPZ) {
 				|	jmp =>target_label
 			} else if (smart_branch_opcode == ZEND_JMPNZ) {
@@ -8890,7 +10017,7 @@ static zend_bool zend_may_be_dynamic_property(zend_class_entry *ce, zend_string 
 	return 0;
 }
 
-static int zend_jit_fetch_obj_read(dasm_State **Dst, zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_class_entry *ce, int may_throw)
+static int zend_jit_fetch_obj_read(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_class_entry *ce, int may_throw)
 {
 	zval *member;
 	uint32_t offset;
@@ -8917,7 +10044,17 @@ static int zend_jit_fetch_obj_read(dasm_State **Dst, zend_op *opline, const zend
 			op1_addr = ZEND_ADDR_MEM_ZVAL(ZREG_R0, 0);
 		}
 		if (op1_info & ((MAY_BE_UNDEF|MAY_BE_ANY)- MAY_BE_OBJECT)) {
-			|	IF_NOT_ZVAL_TYPE op1_addr, IS_OBJECT, >7
+			if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+				int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+				const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+
+				if (!exit_addr) {
+					return 0;
+				}
+				|	IF_NOT_ZVAL_TYPE op1_addr, IS_OBJECT, &exit_addr
+			} else {
+				|	IF_NOT_ZVAL_TYPE op1_addr, IS_OBJECT, >7
+			}
 		}
 		|	GET_ZVAL_PTR FCARG1a, op1_addr
 	}
@@ -8995,7 +10132,7 @@ static int zend_jit_fetch_obj_read(dasm_State **Dst, zend_op *opline, const zend
 		|	jmp >9
 	}
 
-	if (op1_info & ((MAY_BE_UNDEF|MAY_BE_ANY|MAY_BE_REF)- MAY_BE_OBJECT)) {
+	if ((op1_info & ((MAY_BE_UNDEF|MAY_BE_ANY|MAY_BE_REF)- MAY_BE_OBJECT))  && zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE) {
 		|7:
 		if (opline->opcode == ZEND_FETCH_OBJ_R) {
 			|	SAVE_VALID_OPLINE opline

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -909,10 +909,10 @@ static void* dasm_labels[zend_lb_MAX];
 ||	}
 ||	if (Z_MODE(dst_addr) == IS_MEM_ZVAL) {
 ||		if (dst_def_info == MAY_BE_DOUBLE) {
-||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF)) != MAY_BE_DOUBLE) {
+||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != MAY_BE_DOUBLE) {
 |				SET_ZVAL_TYPE_INFO dst_addr, IS_DOUBLE
 ||			}
-||		} else if (((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF)) != (1<<Z_TYPE_P(zv))) || (dst_info & (MAY_BE_STRING|MAY_BE_ARRAY)) != 0) {
+||		} else if (((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != (1<<Z_TYPE_P(zv))) || (dst_info & (MAY_BE_STRING|MAY_BE_ARRAY)) != 0) {
 |			SET_ZVAL_TYPE_INFO dst_addr, Z_TYPE_INFO_P(zv)
 ||		}
 ||	}
@@ -999,10 +999,10 @@ static void* dasm_labels[zend_lb_MAX];
 ||	}
 ||	if (Z_MODE(dst_addr) == IS_MEM_ZVAL) {
 ||		if (dst_def_info == MAY_BE_DOUBLE) {
-||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF)) != MAY_BE_DOUBLE) {
+||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != MAY_BE_DOUBLE) {
 |				SET_ZVAL_TYPE_INFO dst_addr, IS_DOUBLE
 ||			}
-||		} else if (((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF)) != (1<<Z_TYPE_P(zv))) || (dst_info & (MAY_BE_STRING|MAY_BE_ARRAY)) != 0) {
+||		} else if (((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != (1<<Z_TYPE_P(zv))) || (dst_info & (MAY_BE_STRING|MAY_BE_ARRAY)) != 0) {
 |			SET_ZVAL_TYPE_INFO dst_addr, Z_TYPE_INFO_P(zv)
 ||		}
 ||	}
@@ -1063,7 +1063,7 @@ static void* dasm_labels[zend_lb_MAX];
 ||	if ((src_info & (MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG|MAY_BE_DOUBLE)) &&
 ||    	has_concrete_type(src_info & MAY_BE_ANY)) {
 ||		if (Z_MODE(dst_addr) == IS_MEM_ZVAL) {
-||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF)) != (src_info & (MAY_BE_ANY|MAY_BE_UNDEF))) {
+||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != (src_info & (MAY_BE_ANY|MAY_BE_UNDEF))) {
 ||				zend_uchar type = concrete_type(src_info);
 |				SET_ZVAL_TYPE_INFO dst_addr, type
 ||			}
@@ -1144,7 +1144,7 @@ static void* dasm_labels[zend_lb_MAX];
 ||	    has_concrete_type(src_info & MAY_BE_ANY)) {
 ||		zend_uchar type = concrete_type(src_info);
 ||		if (Z_MODE(dst_addr) == IS_MEM_ZVAL) {
-||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF)) != (src_info & (MAY_BE_ANY|MAY_BE_UNDEF))) {
+||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != (src_info & (MAY_BE_ANY|MAY_BE_UNDEF))) {
 |				SET_ZVAL_TYPE_INFO dst_addr, type
 ||			}
 ||		}
@@ -2332,8 +2332,16 @@ static int zend_jit_trace_exit_stub(dasm_State **Dst)
 	|	LOAD_OPLINE
 
 	if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+#if 1
+		//TODO: this doesn't work for exit from first instruction ???
 		|	add r4, HYBRID_SPAD
 		|	JMP_IP
+#else
+		|	mov r0, EX->func
+		|	mov r1, aword [r0 + offsetof(zend_op_array, reserved[zend_func_info_rid])]
+		|	mov r1, aword [r1 + offsetof(zend_jit_op_array_trace_extension, offset)]
+		|	jmp aword [IP + r1]
+#endif
 	} else if (GCC_GLOBAL_REGS) {
 		|	add r4, SPAD // stack alignment
 		|	JMP_IP
@@ -3344,7 +3352,11 @@ static int zend_jit_inc_dec(dasm_State **Dst, const zend_op *opline, const zend_
 		|	LONG_OP_WITH_CONST sub, op1_def_addr, Z_L(1)
 	}
 
-	if (may_overflow) {
+	if (may_overflow && (op1_def_info & MAY_BE_GUARD)) {
+		int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+		const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+		|	jo &exit_addr
+	} else if (may_overflow) {
 		|	jo >1
 		if ((opline->opcode == ZEND_PRE_INC || opline->opcode == ZEND_PRE_DEC) &&
 		    opline->result_type != IS_UNUSED) {
@@ -3558,19 +3570,25 @@ static int zend_jit_math_long_long(dasm_State    **Dst,
 		}
 	}
 	if (may_overflow) {
-		|	jo >1
+		if (res_info & MAY_BE_GUARD) {
+			int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+			const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+			|	jo &exit_addr
+		} else {
+			|	jo >1
+		}
 	}
 
 	if (Z_MODE(res_addr) == IS_MEM_ZVAL) {
 		|	SET_ZVAL_LVAL res_addr, Ra(result_reg)
 		if (Z_MODE(op1_addr) != IS_MEM_ZVAL || Z_REG(op1_addr) != Z_REG(res_addr) || Z_OFFSET(op1_addr) != Z_OFFSET(res_addr)) {
-			if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) != MAY_BE_LONG) {
+			if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF|MAY_BE_GUARD)) != MAY_BE_LONG) {
 				|	SET_ZVAL_TYPE_INFO res_addr, IS_LONG
 			}
 		}
 	}
 
-	if (may_overflow) {
+	if (may_overflow && !(res_info & MAY_BE_GUARD)) {
 		zend_reg tmp_reg1 = ZREG_XMM0;
 		zend_reg tmp_reg2 = ZREG_XMM1;
 
@@ -3611,7 +3629,7 @@ static int zend_jit_math_long_long(dasm_State    **Dst,
 			|	SSE_SET_ZVAL_DVAL res_addr, tmp_reg1
 		} while (0);
 
-		if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) != MAY_BE_DOUBLE) {
+		if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF|MAY_BE_GUARD)) != MAY_BE_DOUBLE) {
 			|	SET_ZVAL_TYPE_INFO res_addr, IS_DOUBLE
 		}
 		|	jmp >2
@@ -3641,7 +3659,7 @@ static int zend_jit_math_long_double(dasm_State    **Dst,
 	|	SSE_SET_ZVAL_DVAL res_addr, result_reg
 
 	if (Z_MODE(res_addr) == IS_MEM_ZVAL) {
-		if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) != MAY_BE_DOUBLE) {
+		if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF|MAY_BE_GUARD)) != MAY_BE_DOUBLE) {
 			|	SET_ZVAL_TYPE_INFO res_addr, IS_DOUBLE
 		}
 	}
@@ -3704,7 +3722,7 @@ static int zend_jit_math_double_long(dasm_State    **Dst,
 
 	if (Z_MODE(res_addr) == IS_MEM_ZVAL) {
 		if (Z_MODE(op1_addr) != IS_MEM_ZVAL || Z_REG(op1_addr) != Z_REG(res_addr) || Z_OFFSET(op1_addr) != Z_OFFSET(res_addr)) {
-			if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) != MAY_BE_DOUBLE) {
+			if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF|MAY_BE_GUARD)) != MAY_BE_DOUBLE) {
 				|	SET_ZVAL_TYPE_INFO res_addr, IS_DOUBLE
 			}
 		}
@@ -3775,7 +3793,7 @@ static int zend_jit_math_double_double(dasm_State    **Dst,
 
 	if (Z_MODE(res_addr) == IS_MEM_ZVAL) {
 		if (Z_MODE(op1_addr) != IS_MEM_ZVAL || Z_REG(op1_addr) != Z_REG(res_addr) || Z_OFFSET(op1_addr) != Z_OFFSET(res_addr)) {
-			if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) != MAY_BE_DOUBLE) {
+			if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF|MAY_BE_GUARD)) != MAY_BE_DOUBLE) {
 				|	SET_ZVAL_TYPE_INFO res_addr, IS_DOUBLE
 			}
 		}
@@ -4220,7 +4238,7 @@ static int zend_jit_long_math_helper(dasm_State    **Dst,
 	|	SET_ZVAL_LVAL res_addr, Ra(result_reg)
 	if (Z_MODE(res_addr) == IS_MEM_ZVAL) {
 		if (Z_MODE(op1_addr) != IS_MEM_ZVAL || Z_REG(op1_addr) != Z_REG(res_addr) || Z_OFFSET(op1_addr) != Z_OFFSET(res_addr)) {
-			if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF)) != MAY_BE_LONG) {
+			if ((res_use_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_REF|MAY_BE_GUARD)) != MAY_BE_LONG) {
 				|	SET_ZVAL_TYPE_INFO res_addr, IS_LONG
 			}
 		}
@@ -8273,12 +8291,12 @@ static int zend_jit_send_val(dasm_State **Dst, const zend_op *opline, const zend
 	if (opline->op1_type == IS_CONST) {
 		zval *zv = RT_CONSTANT(opline, opline->op1);
 
-		|	ZVAL_COPY_CONST arg_addr, -1, -1, zv, r0
+		|	ZVAL_COPY_CONST arg_addr, MAY_BE_ANY, MAY_BE_ANY, zv, r0
 		if (Z_REFCOUNTED_P(zv)) {
 			|	ADDREF_CONST zv, r0
 		}
 	} else {
-		|	ZVAL_COPY_VALUE arg_addr, -1, op1_addr, op1_info, ZREG_R0, ZREG_R2
+		|	ZVAL_COPY_VALUE arg_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R0, ZREG_R2
 	}
 
 	return 1;
@@ -8347,11 +8365,11 @@ static int zend_jit_send_ref(dasm_State **Dst, const zend_op *opline, const zend
 			zend_jit_addr val_addr = ZEND_ADDR_MEM_ZVAL(ZREG_R1, 0);
 
 			|	mov r1, aword T1 // restore
-			|	ZVAL_COPY_VALUE ref_addr, -1, val_addr, op1_info, ZREG_R2, ZREG_R2
+			|	ZVAL_COPY_VALUE ref_addr, MAY_BE_ANY, val_addr, op1_info, ZREG_R2, ZREG_R2
 			|	SET_ZVAL_PTR val_addr, r0
 			|	SET_ZVAL_TYPE_INFO val_addr, IS_REFERENCE_EX
 		} else {
-			|	ZVAL_COPY_VALUE ref_addr, -1, op1_addr, op1_info, ZREG_R1, ZREG_R2
+			|	ZVAL_COPY_VALUE ref_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R1, ZREG_R2
 			|	SET_ZVAL_PTR op1_addr, r0
 			|	SET_ZVAL_TYPE_INFO op1_addr, IS_REFERENCE_EX
 		}
@@ -8405,7 +8423,7 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 		} else if (opline->opcode == ZEND_SEND_VAR_NO_REF_EX) {
 			mask = ZEND_SEND_PREFER_REF << ((arg_num + 3) * 2);
 
-			|	ZVAL_COPY_VALUE arg_addr, -1, op1_addr, op1_info, ZREG_R1, ZREG_R2
+			|	ZVAL_COPY_VALUE arg_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R1, ZREG_R2
 			if (op1_info & MAY_BE_REF) {
 				|	cmp cl, IS_REFERENCE
 				|	je >7
@@ -8454,7 +8472,7 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 	}
 
 	if (opline->opcode == ZEND_SEND_VAR_NO_REF) {
-		|	ZVAL_COPY_VALUE arg_addr, -1, op1_addr, op1_info, ZREG_R1, ZREG_R2
+		|	ZVAL_COPY_VALUE arg_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R1, ZREG_R2
 		if (op1_info & MAY_BE_REF) {
 			|	cmp cl, IS_REFERENCE
 			|	je >7
@@ -8481,7 +8499,7 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 
 				|	LOAD_ZVAL_ADDR FCARG1a, op1_addr
 				|	ZVAL_DEREF FCARG1a, op1_info
-				|	ZVAL_COPY_VALUE arg_addr, -1, val_addr, op1_info, ZREG_R0, ZREG_R2
+				|	ZVAL_COPY_VALUE arg_addr, MAY_BE_ANY, val_addr, op1_info, ZREG_R0, ZREG_R2
 				|	TRY_ADDREF op1_info, ah, r2
 			} else {
 				zend_jit_addr ref_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FCARG1a, 8);
@@ -8492,7 +8510,7 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 				|	// zend_refcounted *ref = Z_COUNTED_P(retval_ptr);
 				|	GET_ZVAL_PTR FCARG1a, op1_addr
 				|	// ZVAL_COPY_VALUE(return_value, &ref->value);
-				|	ZVAL_COPY_VALUE arg_addr, -1, ref_addr, op1_info, ZREG_R0, ZREG_R2
+				|	ZVAL_COPY_VALUE arg_addr, MAY_BE_ANY, ref_addr, op1_info, ZREG_R0, ZREG_R2
 				|	GC_DELREF FCARG1a
 				|	je >1
 				|	IF_NOT_REFCOUNTED ah, >2
@@ -8502,7 +8520,7 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 				|	EFREE_REG_24 op_array, opline
 				|	jmp >2
 				|.code
-				|	ZVAL_COPY_VALUE arg_addr, -1, op1_addr, op1_info, ZREG_R0, ZREG_R2
+				|	ZVAL_COPY_VALUE arg_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R0, ZREG_R2
 				|2:
 			}
 		} else {
@@ -8514,7 +8532,7 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 					op1_addr= op1_def_addr;
 				}
 			}
-			|	ZVAL_COPY_VALUE arg_addr, -1, op1_addr, op1_info, ZREG_R0, ZREG_R2
+			|	ZVAL_COPY_VALUE arg_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R0, ZREG_R2
 			if (opline->op1_type == IS_CV) {
 				|	TRY_ADDREF op1_info, ah, r2
 			}
@@ -8733,7 +8751,7 @@ static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const ze
 				type = 0;
 		}
 
-		if (!(op1_info & (MAY_BE_ANY - mask))) {
+		if (!(op1_info & MAY_BE_GUARD) && !(op1_info & (MAY_BE_ANY - mask))) {
 			|	FREE_OP opline->op1_type, opline->op1, op1_info, 1, op_array, opline
 			if (exit_addr) {
 				if (smart_branch_opcode == ZEND_JMPNZ) {
@@ -8742,7 +8760,7 @@ static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const ze
 			} else if (!zend_jit_smart_true(Dst, opline, 0, smart_branch_opcode, target_label, target_label2)) {
 				return 0;
 			}
-	    } else if (!(op1_info & mask)) {
+	    } else if (!(op1_info & MAY_BE_GUARD) && !(op1_info & mask)) {
 			|	FREE_OP opline->op1_type, opline->op1, op1_info, 1, op_array, opline
 			if (exit_addr) {
 				if (smart_branch_opcode == ZEND_JMPZ) {
@@ -9198,19 +9216,19 @@ static int zend_jit_return(dasm_State **Dst, const zend_op *opline, const zend_o
 
 	if (opline->op1_type == IS_CONST) {
 		zval *zv = RT_CONSTANT(opline, opline->op1);
-		|	ZVAL_COPY_CONST ret_addr, -1, -1, zv, r0
+		|	ZVAL_COPY_CONST ret_addr, MAY_BE_ANY, MAY_BE_ANY, zv, r0
 		if (Z_REFCOUNTED_P(zv)) {
 			|	ADDREF_CONST zv, r0
 		}
 	} else if (opline->op1_type == IS_TMP_VAR) {
-		|	ZVAL_COPY_VALUE ret_addr, -1, op1_addr, op1_info, ZREG_R0, ZREG_R2
+		|	ZVAL_COPY_VALUE ret_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R0, ZREG_R2
 	} else if (opline->op1_type == IS_CV) {
 		if (op1_info & MAY_BE_REF) {
 			|	LOAD_ZVAL_ADDR r0, op1_addr
 			|	ZVAL_DEREF r0, op1_info
 			op1_addr = ZEND_ADDR_MEM_ZVAL(ZREG_R0, 0);
 		}
-		|	ZVAL_COPY_VALUE ret_addr, -1, op1_addr, op1_info, ZREG_R0, ZREG_R2
+		|	ZVAL_COPY_VALUE ret_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R0, ZREG_R2
 		|	// TODO: JIT: if (EXPECTED(!(EX_CALL_INFO() & ZEND_CALL_CODE))) ZVAL_NULL(retval_ptr); ???
 		|	TRY_ADDREF op1_info, ah, r2
 	} else {
@@ -9223,7 +9241,7 @@ static int zend_jit_return(dasm_State **Dst, const zend_op *opline, const zend_o
 			|	// zend_refcounted *ref = Z_COUNTED_P(retval_ptr);
 			|	GET_ZVAL_PTR r0, op1_addr
 			|	// ZVAL_COPY_VALUE(return_value, &ref->value);
-			|	ZVAL_COPY_VALUE ret_addr, -1, ref_addr, op1_info, ZREG_R2, ZREG_R2
+			|	ZVAL_COPY_VALUE ret_addr, MAY_BE_ANY, ref_addr, op1_info, ZREG_R2, ZREG_R2
 			|	GC_DELREF r0
 			|	je >2
 			|	// if (IS_REFCOUNTED())
@@ -9249,7 +9267,7 @@ static int zend_jit_return(dasm_State **Dst, const zend_op *opline, const zend_o
 			}
 			|.code
 		}
-		|	ZVAL_COPY_VALUE ret_addr, -1, op1_addr, op1_info, ZREG_R0, ZREG_R2
+		|	ZVAL_COPY_VALUE ret_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R0, ZREG_R2
 	}
 
 	|9:

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -7587,6 +7587,53 @@ static int zend_jit_needs_call_chain(zend_call_info *call_info, uint32_t b, cons
 	}
 }
 
+static int zend_jit_init_fcall_guard(dasm_State **Dst, const zend_op *opline, const zend_function *func)
+{
+	int32_t exit_point;
+	const void *exit_addr;
+
+	if (func->type == ZEND_INTERNAL_FUNCTION) {
+#ifdef ZEND_WIN32
+		// TODO: ASLR may cause different addresses in different workers ???
+		return 0
+#endif
+	} else if (func->type == ZEND_USER_FUNCTION) {
+		if (!(func->common.fn_flags & ZEND_ACC_IMMUTABLE)) {
+			// TODO: We don't have op_array to insert a guard ???
+			return 0;
+		}
+	} else {
+		ZEND_ASSERT(0);
+		return 0;
+	}
+
+//	exit_point = zend_jit_trace_get_exit_point(opline+1, opline+1, NULL);
+	exit_point = zend_jit_trace_get_exit_point(opline, NULL, NULL);
+	exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+	if (!exit_addr) {
+		return 0;
+	}
+
+//	zend_jit_stop_reuse_ip();
+//	|	LOAD_IP_ADDR opline
+
+	|	// call = EX(call);
+	|	mov r1, EX->call
+	|   .if X64
+	|| 		if (!IS_SIGNED_32BIT(fbc)) {
+	|  			mov64 r0, func
+	|			cmp aword EX:r1->func, r0
+	||		} else {
+	|  			cmp aword EX:r1->func, func
+	||		}
+	|	.else
+	|		cmp aword EX:r1->func, func
+	|	.endif
+	|	jne &exit_addr
+
+	return 1;
+}
+
 static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t b, const zend_op_array *op_array, zend_ssa *ssa, int call_level, zend_jit_trace_rec *trace)
 {
 	zend_func_info *info = ZEND_FUNC_INFO(op_array);

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -7628,8 +7628,8 @@ static int zend_jit_init_fcall_guard(dasm_State **Dst, const zend_op *opline, co
 		return 0
 #endif
 	} else if (func->type == ZEND_USER_FUNCTION) {
-		if (!(func->common.fn_flags & ZEND_ACC_IMMUTABLE)) {
-			// TODO: We don't have op_array to insert a guard ???
+		if (!zend_accel_in_shm(func->op_array.opcodes)) {
+			/* op_array and op_array->opcodes are not persistent. We can't link. */
 			return 0;
 		}
 	} else {
@@ -7637,29 +7637,45 @@ static int zend_jit_init_fcall_guard(dasm_State **Dst, const zend_op *opline, co
 		return 0;
 	}
 
-//	exit_point = zend_jit_trace_get_exit_point(opline+1, opline+1, NULL);
-	exit_point = zend_jit_trace_get_exit_point(opline, NULL, NULL);
+	exit_point = zend_jit_trace_get_exit_point(opline, opline ? (opline+1) : NULL, NULL);
 	exit_addr = zend_jit_trace_get_exit_addr(exit_point);
 	if (!exit_addr) {
 		return 0;
 	}
 
-//	zend_jit_stop_reuse_ip();
-//	|	LOAD_IP_ADDR opline
+	if (func->type == ZEND_USER_FUNCTION
+	 && !(func->common.fn_flags & ZEND_ACC_IMMUTABLE)) {
+		const zend_op *opcodes = func->op_array.opcodes;
 
-	|	// call = EX(call);
-	|	mov r1, EX->call
-	|   .if X64
-	|| 		if (!IS_SIGNED_32BIT(fbc)) {
-	|  			mov64 r0, func
-	|			cmp aword EX:r1->func, r0
-	||		} else {
-	|  			cmp aword EX:r1->func, func
-	||		}
-	|	.else
-	|		cmp aword EX:r1->func, func
-	|	.endif
-	|	jne &exit_addr
+		|	// call = EX(call);
+		|	mov r1, EX->call
+		|	mov r1, aword EX:r1->func
+		|   .if X64
+		|| 		if (!IS_SIGNED_32BIT(opcodes)) {
+		|  			mov64 r0, opcodes
+		|			cmp aword [r1 + offsetof(zend_op_array, opcodes)], r0
+		||		} else {
+		|  			cmp aword [r1 + offsetof(zend_op_array, opcodes)], opcodes
+		||		}
+		|	.else
+		|		cmp aword [r1 + offsetof(zend_op_array, opcodes)], opcodes
+		|	.endif
+		|	jne &exit_addr
+	} else {
+		|	// call = EX(call);
+		|	mov r1, EX->call
+		|   .if X64
+		|| 		if (!IS_SIGNED_32BIT(fbc)) {
+		|  			mov64 r0, func
+		|			cmp aword EX:r1->func, r0
+		||		} else {
+		|  			cmp aword EX:r1->func, func
+		||		}
+		|	.else
+		|		cmp aword EX:r1->func, func
+		|	.endif
+		|	jne &exit_addr
+	}
 
 	return 1;
 }
@@ -7849,50 +7865,16 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 	if (trace && !func) {
 		if (trace->op == ZEND_JIT_TRACE_DO_ICALL) {
 			ZEND_ASSERT(trace->func->type == ZEND_INTERNAL_FUNCTION);
-#ifdef ZEND_WIN32
+#ifndef ZEND_WIN32
 			// TODO: ASLR may cause different addresses in different workers ???
-			goto fallback;
-#else
 			func = trace->func;
 #endif
-		} else if (trace->op == ZEND_JIT_TRACE_ENTER) {
-			ZEND_ASSERT(trace->func->type == ZEND_USER_FUNCTION);
-			if (!(trace->func->common.fn_flags & ZEND_ACC_IMMUTABLE)) {
-				// TODO: We don't have op_array to insert a guard ???
-				goto fallback;
-			}
-		} else {
-			ZEND_ASSERT(0);
-			return 0;
-		}
-
-		if (opline->opcode == ZEND_DO_FCALL) {
-			// TODO: This guard should be checked early !!! (in INIT_FCALL) ???
-			intptr_t fbc = (intptr_t)(void*)trace->func;
-			uint32_t exit_point = zend_jit_trace_get_exit_point(opline, NULL, trace);
-			const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
-
-			if (!exit_addr) {
-				return 0;
-			}
-
-			// TODO: Avoid regster reloading ???
-			zend_jit_stop_reuse_ip();
-			|	LOAD_IP_ADDR opline
-
-			|	// call = EX(call);
-			|	mov r1, EX->call
-			|   .if X64
-			|| 		if (!IS_SIGNED_32BIT(fbc)) {
-			|  			mov64 r0, fbc
-			|			cmp aword EX:r1->func, r0
-			||		} else {
-			|  			cmp aword EX:r1->func, fbc
-			||		}
-			|	.else
-			|		cmp aword EX:r1->func, fbc
-			|	.endif
-			|	jne &exit_addr
+// TODO: it should be possible to reuse known user function as well ???
+//		} else if (trace->op == ZEND_JIT_TRACE_ENTER) {
+//			ZEND_ASSERT(trace->func->type == ZEND_USER_FUNCTION);
+//			if (zend_accel_in_shm(trace->func)) {
+//				func = trace->func;
+//			}
 		}
 	}
 

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -8324,17 +8324,26 @@ static int zend_jit_send_val(dasm_State **Dst, const zend_op *opline, const zend
 
 		ZEND_ASSERT(arg_num <= MAX_ARG_FLAG_NUM);
 
-		|	mov r0, EX:RX->func
-		|	test dword [r0 + offsetof(zend_function, quick_arg_flags)], mask
-
-		if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
+		if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE
+		 && JIT_G(current_frame)
+		 && JIT_G(current_frame)->call
+		 && JIT_G(current_frame)->call->func) {
+			if (ARG_MUST_BE_SENT_BY_REF(JIT_G(current_frame)->call->func, arg_num)) {
+				/* Don't generate code that always throws exception */
+				return 0;
+			}
+		} else if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE) {
 			int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
 			const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
 			if (!exit_addr) {
 				return 0;
 			}
+			|	mov r0, EX:RX->func
+			|	test dword [r0 + offsetof(zend_function, quick_arg_flags)], mask
 			|	jnz	&exit_addr
 		} else {
+			|	mov r0, EX:RX->func
+			|	test dword [r0 + offsetof(zend_function, quick_arg_flags)], mask
 			|	jnz	>1
 			|.cold_code
 			|1:
@@ -8460,26 +8469,65 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 		|	mov RX, EX->call
 	}
 
-	if (opline->opcode == ZEND_SEND_VAR_EX || opline->opcode == ZEND_SEND_VAR_NO_REF_EX) {
-		uint32_t mask = (ZEND_SEND_BY_REF|ZEND_SEND_PREFER_REF) << ((arg_num + 3) * 2);
+	if (opline->opcode == ZEND_SEND_VAR_EX) {
+		if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE
+		 && JIT_G(current_frame)
+		 && JIT_G(current_frame)->call
+		 && JIT_G(current_frame)->call->func) {
+			if (ARG_SHOULD_BE_SENT_BY_REF(JIT_G(current_frame)->call->func, arg_num)) {
+				if (!zend_jit_send_ref(Dst, opline, op_array, op1_info, 0)) {
+					return 0;
+				}
+				return 1;
+			}
+		} else {
+			uint32_t mask = (ZEND_SEND_BY_REF|ZEND_SEND_PREFER_REF) << ((arg_num + 3) * 2);
 
-		|	mov r0, EX:RX->func
-		if (arg_num <= MAX_ARG_FLAG_NUM) {
+			|	mov r0, EX:RX->func
 			|	test dword [r0 + offsetof(zend_function, quick_arg_flags)], mask
 			|	jnz	>1
-		} else {
-			ZEND_ASSERT(0);
-		}
-
-		|.cold_code
-		|1:
-
-		if (opline->opcode == ZEND_SEND_VAR_EX) {
+			|.cold_code
+			|1:
 			if (!zend_jit_send_ref(Dst, opline, op_array, op1_info, 1)) {
 				return 0;
 			}
 			|	jmp >7
-		} else if (opline->opcode == ZEND_SEND_VAR_NO_REF_EX) {
+			|.code
+		}
+	} else if (opline->opcode == ZEND_SEND_VAR_NO_REF_EX) {
+		if (zend_jit_trigger == ZEND_JIT_ON_HOT_TRACE
+		 && JIT_G(current_frame)
+		 && JIT_G(current_frame)->call
+		 && JIT_G(current_frame)->call->func) {
+			if (ARG_SHOULD_BE_SENT_BY_REF(JIT_G(current_frame)->call->func, arg_num)) {
+
+				|	ZVAL_COPY_VALUE arg_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R1, ZREG_R2
+
+				if (!ARG_MAY_BE_SENT_BY_REF(JIT_G(current_frame)->call->func, arg_num)) {
+					if (!(op1_info & MAY_BE_REF)) {
+						/* Don't generate code that always throws exception */
+						return 0;
+					} else {
+						int32_t exit_point = zend_jit_trace_get_exit_point(opline, opline, NULL);
+						const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+						if (!exit_addr) {
+							return 0;
+						}
+						|	cmp cl, IS_REFERENCE
+						|	jne &exit_addr
+					}
+				}
+				return 1;
+			}
+		} else {
+			uint32_t mask = (ZEND_SEND_BY_REF|ZEND_SEND_PREFER_REF) << ((arg_num + 3) * 2);
+
+			|	mov r0, EX:RX->func
+			|	test dword [r0 + offsetof(zend_function, quick_arg_flags)], mask
+			|	jnz	>1
+			|.cold_code
+			|1:
+
 			mask = ZEND_SEND_PREFER_REF << ((arg_num + 3) * 2);
 
 			|	ZVAL_COPY_VALUE arg_addr, MAY_BE_ANY, op1_addr, op1_info, ZREG_R1, ZREG_R2
@@ -8505,11 +8553,9 @@ static int zend_jit_send_var(dasm_State **Dst, const zend_op *opline, const zend
 				}
 				|	jmp >7
 			}
-		} else {
-			ZEND_ASSERT(0);
-		}
 
-		|.code
+			|.code
+		}
 	}
 
 	if (op1_info & MAY_BE_UNDEF) {

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -7821,6 +7821,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 	const zend_function *func = NULL;
 	uint32_t i;
 	zend_jit_addr res_addr;
+	uint32_t call_num_args = 0;
 	zend_bool unknown_num_args = 0;
 
 	if (RETURN_VALUE_USED(opline)) {
@@ -7852,11 +7853,10 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		/* resolve function ar run time */
 	} else if (func->type == ZEND_USER_FUNCTION) {
 		ZEND_ASSERT(opline->opcode != ZEND_DO_ICALL);
-		if (call_info->num_args > func->op_array.num_args) {
-			unknown_num_args = 1;
-		}
+		call_num_args = call_info->num_args;
 	} else if (func->type == ZEND_INTERNAL_FUNCTION) {
 		ZEND_ASSERT(opline->opcode != ZEND_DO_UCALL);
+		call_num_args = call_info->num_args;
 #if ZEND_DEBUG
 		if (func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
 			// TODO: Mow most internal functions have type hints ???
@@ -7873,14 +7873,26 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 #ifndef ZEND_WIN32
 			// TODO: ASLR may cause different addresses in different workers ???
 			func = trace->func;
-			unknown_num_args = 1;
+			if (JIT_G(current_frame) &&
+			    JIT_G(current_frame)->call &&
+			    JIT_G(current_frame)->call->num_args >= 0) {
+				call_num_args = JIT_G(current_frame)->call->num_args;
+			} else {
+				unknown_num_args = 1;
+			}
 #endif
 // TODO: it should be possible to reuse known user function as well ???
 		} else if (trace->op == ZEND_JIT_TRACE_ENTER) {
 			ZEND_ASSERT(trace->func->type == ZEND_USER_FUNCTION);
 			if (zend_accel_in_shm(trace->func->op_array.opcodes)) {
 				func = trace->func;
-				unknown_num_args = 1;
+				if (JIT_G(current_frame) &&
+				    JIT_G(current_frame)->call &&
+				    JIT_G(current_frame)->call->num_args >= 0) {
+					call_num_args = JIT_G(current_frame)->call->num_args;
+				} else {
+					unknown_num_args = 1;
+				}
 			}
 		}
 	}
@@ -7973,8 +7985,10 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			|	mov aword EX:RX->return_value, 0
 		}
 
-		if (func && !unknown_num_args) {
-			for (i = call_info->num_args; i < func->op_array.last_var; i++) {
+		if (func
+		 && !unknown_num_args
+		 && call_num_args <= func->op_array.num_args) {
+			for (i = call_num_args; i < func->op_array.last_var; i++) {
 				uint32_t n = EX_NUM_TO_VAR(i);
 				|	SET_Z_TYPE_INFO RX + n, IS_UNDEF
 			}
@@ -8013,13 +8027,16 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		|	mov FP, RX
 
 		|	// opline = op_array->opcodes;
-		if (func && !unknown_num_args) {
+		if (func
+		 && !unknown_num_args
+		 && call_num_args <= func->op_array.num_args) {
 			uint32_t num_args;
 
-			if (func->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) {
+			if ((func->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) != 0
+			  && call_info) {
 				num_args = skip_valid_arguments(op_array, ssa, call_info);
 			} else {
-				num_args = call_info->num_args;
+				num_args = call_num_args;
 			}
 			if (func && zend_accel_in_shm(func->op_array.opcodes)) {
 				|	LOAD_IP_ADDR (func->op_array.opcodes + num_args)
@@ -8054,6 +8071,25 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 				|	jmp =>num_args
 #endif
 				return 1;
+			}
+		} else if (func
+		 && !unknown_num_args
+		 && call_num_args > func->op_array.num_args) {
+			if (func && zend_accel_in_shm(func->op_array.opcodes)) {
+				|	LOAD_IP_ADDR (func->op_array.opcodes)
+			} else if (GCC_GLOBAL_REGS) {
+				|	mov IP, aword [r0 + offsetof(zend_op_array, opcodes)]
+			} else {
+				|	mov FCARG1a, aword [r0 + offsetof(zend_op_array, opcodes)]
+				|	mov aword EX->opline, FCARG1a
+			}
+			if (!GCC_GLOBAL_REGS) {
+				|	mov FCARG1a, FP
+			}
+			|	EXT_CALL zend_jit_copy_extra_args_helper, r0
+			for (i = call_num_args; i < func->op_array.last_var; i++) {
+				uint32_t n = EX_NUM_TO_VAR(i);
+				|	SET_Z_TYPE_INFO FP + n, IS_UNDEF
 			}
 		} else {
 			|	// opline = op_array->opcodes
@@ -8243,7 +8279,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 
 		|	// zend_vm_stack_free_args(call);
 		if (func && call_info && !unknown_num_args) {
-			for (i = 0; i < call_info->num_args; i++ ) {
+			for (i = 0; i < call_num_args; i++ ) {
 				uint32_t offset = EX_NUM_TO_VAR(i);
 				|	ZVAL_PTR_DTOR ZEND_ADDR_MEM_ZVAL(ZREG_RX, offset), MAY_BE_ANY|MAY_BE_RC1|MAY_BE_RCN, 0, 1, 0, opline
 			}

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -9945,8 +9945,10 @@ static int zend_jit_recv_init(dasm_State **Dst, const zend_op *opline, const zen
 	zval *zv = RT_CONSTANT(opline, opline->op2);
 	zend_jit_addr res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FP, opline->result.var);
 
-	|	cmp dword EX->This.u2.num_args, arg_num
-	|	jae >5
+	if (zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE) {
+		|	cmp dword EX->This.u2.num_args, arg_num
+		|	jae >5
+	}
 	|	ZVAL_COPY_CONST res_addr, -1, -1, zv, r0
 	if (Z_REFCOUNTED_P(zv)) {
 	|	ADDREF_CONST zv, r0

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -6590,6 +6590,20 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 		}
 	}
 
+	if ((op1_info & (MAY_BE_REF|MAY_BE_ANY|MAY_BE_UNDEF)) == MAY_BE_LONG &&
+	    (op2_info & (MAY_BE_REF|MAY_BE_ANY|MAY_BE_UNDEF)) == MAY_BE_LONG) {
+		if (!zend_jit_cmp_long_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
+			return 0;
+		}
+		return 1;
+	} else if ((op1_info & (MAY_BE_REF|MAY_BE_ANY|MAY_BE_UNDEF)) == MAY_BE_DOUBLE &&
+	           (op2_info & (MAY_BE_REF|MAY_BE_ANY|MAY_BE_UNDEF)) == MAY_BE_DOUBLE) {
+		if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
+			return 0;
+		}
+		return 1;
+	}
+
 	if ((op1_info & MAY_BE_UNDEF) && (op2_info & MAY_BE_UNDEF)) {
 		op1_info |= MAY_BE_NULL;
 		op2_info |= MAY_BE_NULL;
@@ -6854,16 +6868,6 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 			} else if (not_identical_label != (uint32_t)-1) {
 				|	jmp =>not_identical_label
 			}
-		}
-	} else if ((op1_info & MAY_BE_ANY) == MAY_BE_LONG &&
-	           (op2_info & MAY_BE_ANY) == MAY_BE_LONG) {
-		if (!zend_jit_cmp_long_long(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
-			return 0;
-		}
-	} else if ((op1_info & MAY_BE_ANY) == MAY_BE_DOUBLE &&
-	           (op2_info & MAY_BE_ANY) == MAY_BE_DOUBLE) {
-		if (!zend_jit_cmp_double_double(Dst, opline, op1_addr, op2_addr, res_addr, smart_branch_opcode, target_label, target_label2, exit_addr)) {
-			return 0;
 		}
 	} else {
 		if (opline->op1_type == IS_CONST) {

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -7817,6 +7817,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 	const zend_function *func = NULL;
 	uint32_t i;
 	zend_jit_addr res_addr;
+	zend_bool unknown_num_args = 0;
 
 	if (RETURN_VALUE_USED(opline)) {
 		res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FP, opline->result.var);
@@ -7828,6 +7829,10 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		/* CPU stack allocated temporary zval */
 		res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_R4, 8);
 #endif
+	}
+
+	if ((opline-1)->opcode == ZEND_SEND_UNPACK|| (opline-1)->opcode == ZEND_SEND_ARRAY) {
+		unknown_num_args = 1;
 	}
 
 	if (info) {
@@ -7843,21 +7848,17 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		/* resolve function ar run time */
 	} else if (func->type == ZEND_USER_FUNCTION) {
 		ZEND_ASSERT(opline->opcode != ZEND_DO_ICALL);
-		if (call_info->num_args > func->op_array.num_args ||
-		    (opline-1)->opcode == ZEND_SEND_UNPACK ||
-		    (opline-1)->opcode == ZEND_SEND_ARRAY) {
-			goto fallback;
+		if (call_info->num_args > func->op_array.num_args) {
+			unknown_num_args = 1;
 		}
 	} else if (func->type == ZEND_INTERNAL_FUNCTION) {
 		ZEND_ASSERT(opline->opcode != ZEND_DO_UCALL);
 #if ZEND_DEBUG
 		if (func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
-			goto fallback;
+			// TODO: Mow most internal functions have type hints ???
+//???			goto fallback;
 		}
 #endif
-		if ((opline-1)->opcode == ZEND_SEND_UNPACK || (opline-1)->opcode == ZEND_SEND_ARRAY) {
-			goto fallback;
-		}
 	} else {
 		ZEND_ASSERT(0);
 	}
@@ -7868,13 +7869,15 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 #ifndef ZEND_WIN32
 			// TODO: ASLR may cause different addresses in different workers ???
 			func = trace->func;
+			unknown_num_args = 1;
 #endif
 // TODO: it should be possible to reuse known user function as well ???
-//		} else if (trace->op == ZEND_JIT_TRACE_ENTER) {
-//			ZEND_ASSERT(trace->func->type == ZEND_USER_FUNCTION);
-//			if (zend_accel_in_shm(trace->func)) {
-//				func = trace->func;
-//			}
+		} else if (trace->op == ZEND_JIT_TRACE_ENTER) {
+			ZEND_ASSERT(trace->func->type == ZEND_USER_FUNCTION);
+			if (zend_accel_in_shm(trace->func->op_array.opcodes)) {
+				func = trace->func;
+				unknown_num_args = 1;
+			}
 		}
 	}
 
@@ -7942,7 +7945,6 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			|	EXT_CALL zend_jit_deprecated_helper, r0
 			|	MEM_OP2_1_ZTS cmp, aword, executor_globals, exception, 0, r0
 			|	jne ->exception_handler
-			|	mov r0, EX:RX->func // reload
 		}
 	}
 
@@ -7967,7 +7969,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			|	mov aword EX:RX->return_value, 0
 		}
 
-		if (func) {
+		if (func && !unknown_num_args) {
 			for (i = call_info->num_args; i < func->op_array.last_var; i++) {
 				uint32_t n = EX_NUM_TO_VAR(i);
 				|	SET_Z_TYPE_INFO RX + n, IS_UNDEF
@@ -8007,7 +8009,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		|	mov FP, RX
 
 		|	// opline = op_array->opcodes;
-		if (func) {
+		if (func && !unknown_num_args) {
 			uint32_t num_args;
 
 			if (func->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) {
@@ -8051,43 +8053,62 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			}
 		} else {
 			|	// opline = op_array->opcodes
-			if (GCC_GLOBAL_REGS) {
+			if (func && zend_accel_in_shm(func->op_array.opcodes)) {
+				|	LOAD_IP_ADDR (func->op_array.opcodes)
+			} else if (GCC_GLOBAL_REGS) {
 				|	mov IP, aword [r0 + offsetof(zend_op_array, opcodes)]
 			} else {
 				|	mov FCARG1a, aword [r0 + offsetof(zend_op_array, opcodes)]
 				|	mov aword EX->opline, FCARG1a
 			}
-			|	// first_extra_arg = op_array->num_args;
-			|	mov edx, dword [r0 + offsetof(zend_op_array, num_args)]
-			|	// num_args = EX_NUM_ARGS();
-			|	mov ecx, dword [FP + offsetof(zend_execute_data, This.u2.num_args)]
-			|	// 	if (UNEXPECTED(num_args > first_extra_arg))
-			|	cmp edx, ecx
-			|	jl >1
+			if (func) {
+				|	// num_args = EX_NUM_ARGS();
+				|	mov ecx, dword [FP + offsetof(zend_execute_data, This.u2.num_args)]
+				|	// 	if (UNEXPECTED(num_args > first_extra_arg))
+				|	cmp ecx, (func->op_array.num_args)
+			} else {
+				|	// first_extra_arg = op_array->num_args;
+				|	mov edx, dword [r0 + offsetof(zend_op_array, num_args)]
+				|	// num_args = EX_NUM_ARGS();
+				|	mov ecx, dword [FP + offsetof(zend_execute_data, This.u2.num_args)]
+				|	// 	if (UNEXPECTED(num_args > first_extra_arg))
+				|	cmp ecx, edx
+			}
+			|	jg >1
 			|.cold_code
 			|1:
 			if (!GCC_GLOBAL_REGS) {
 				|	mov FCARG1a, FP
 			}
 			|	EXT_CALL zend_jit_copy_extra_args_helper, r0
-			|	mov r0, EX->func // reload
+			if (!func) {
+				|	mov r0, EX->func // reload
+			}
 			|	mov ecx, dword [FP + offsetof(zend_execute_data, This.u2.num_args)] // reload
 			|	jmp >1
 			|.code
-			|	// if (EXPECTED((op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS) == 0))
-			|	test dword [r0 + offsetof(zend_op_array, fn_flags)], ZEND_ACC_HAS_TYPE_HINTS
-			|	jnz >1
-			|	// opline += num_args;
-			|.if X64
-				|	movsxd r2, ecx
-				|	imul r2, r2, sizeof(zend_op)
-			|.else
-				|	imul r2, ecx, sizeof(zend_op)
-			|.endif
-			|	ADD_IP r2
+			if (!func || (func->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) == 0) {
+				if (!func) {
+					|	// if (EXPECTED((op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS) == 0))
+					|	test dword [r0 + offsetof(zend_op_array, fn_flags)], ZEND_ACC_HAS_TYPE_HINTS
+					|	jnz >1
+				}
+				|	// opline += num_args;
+				|.if X64
+					|	movsxd r2, ecx
+					|	imul r2, r2, sizeof(zend_op)
+				|.else
+					|	imul r2, ecx, sizeof(zend_op)
+				|.endif
+				|	ADD_IP r2
+			}
 			|1:
 			|	// if (EXPECTED((int)num_args < op_array->last_var)) {
-			|	mov edx, dword [r0 + offsetof(zend_op_array, last_var)]
+			if (func) {
+				|	mov edx, (func->op_array.last_var)
+			} else {
+				|	mov edx, dword [r0 + offsetof(zend_op_array, last_var)]
+			}
 			|	sub edx, ecx
 			|	jle >3 //???
 			|	// zval *var = EX_VAR_NUM(num_args);
@@ -8217,7 +8238,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		|	MEM_OP2_1_ZTS mov, aword, executor_globals, current_execute_data, FP, r0
 
 		|	// zend_vm_stack_free_args(call);
-		if (func && call_info) {
+		if (func && call_info && !unknown_num_args) {
 			for (i = 0; i < call_info->num_args; i++ ) {
 				uint32_t offset = EX_NUM_TO_VAR(i);
 				|	ZVAL_PTR_DTOR ZEND_ADDR_MEM_ZVAL(ZREG_RX, offset), MAY_BE_ANY|MAY_BE_RC1|MAY_BE_RCN, 0, 1, 0, opline
@@ -8291,7 +8312,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 	}
 
 	return 1;
-
+#if 0
 fallback:
 	/* fallback to subroutine threading */
 	if (trace) {
@@ -8304,6 +8325,7 @@ fallback:
 	} else {
 		return zend_jit_handler(Dst, opline, zend_may_throw(opline, op_array, ssa));
 	}
+#endif
 }
 
 static int zend_jit_send_val(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr)

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -7652,7 +7652,7 @@ static int zend_jit_init_fcall_guard(dasm_State **Dst, const zend_op *opline, co
 		|	mov r1, aword EX:r1->func
 		|   .if X64
 		|| 		if (!IS_SIGNED_32BIT(opcodes)) {
-		|  			mov64 r0, opcodes
+		|  			mov64 r0, ((ptrdiff_t)opcodes)
 		|			cmp aword [r1 + offsetof(zend_op_array, opcodes)], r0
 		||		} else {
 		|  			cmp aword [r1 + offsetof(zend_op_array, opcodes)], opcodes
@@ -7665,8 +7665,8 @@ static int zend_jit_init_fcall_guard(dasm_State **Dst, const zend_op *opline, co
 		|	// call = EX(call);
 		|	mov r1, EX->call
 		|   .if X64
-		|| 		if (!IS_SIGNED_32BIT(fbc)) {
-		|  			mov64 r0, func
+		|| 		if (!IS_SIGNED_32BIT(func)) {
+		|  			mov64 r0, ((ptrdiff_t)func)
 		|			cmp aword EX:r1->func, r0
 		||		} else {
 		|  			cmp aword EX:r1->func, func

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -7629,7 +7629,7 @@ static int zend_jit_init_fcall_guard(dasm_State **Dst, const zend_op *opline, co
 	if (func->type == ZEND_INTERNAL_FUNCTION) {
 #ifdef ZEND_WIN32
 		// TODO: ASLR may cause different addresses in different workers ???
-		return 0
+		return 0;
 #endif
 	} else if (func->type == ZEND_USER_FUNCTION) {
 		if (!zend_accel_in_shm(func->op_array.opcodes)) {

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -9945,7 +9945,8 @@ static int zend_jit_recv_init(dasm_State **Dst, const zend_op *opline, const zen
 	zval *zv = RT_CONSTANT(opline, opline->op2);
 	zend_jit_addr res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FP, opline->result.var);
 
-	if (zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE) {
+	if (zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE ||
+	    (op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
 		|	cmp dword EX->This.u2.num_args, arg_num
 		|	jae >5
 	}

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -9139,17 +9139,23 @@ static int zend_jit_leave_func(dasm_State **Dst, const zend_op *opline, const ze
 			|	mov FCARG2a, FP
 		}
 		|	EXT_CALL zend_jit_leave_func_helper, r0
-		// TODO: try to avoid this check ???
-		if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
-			|	cmp IP, zend_jit_halt_op
-			|	je ->trace_halt
-		} else if (GCC_GLOBAL_REGS) {
-			|	test IP, IP
-			|	je ->trace_halt
-		} else {
-			|	test eax, eax
-			|	jl ->trace_halt
+
+		if (zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE ||
+		    !JIT_G(current_frame) ||
+		    !JIT_G(current_frame)->nested) {
+			// TODO: try to avoid this check ???
+			if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+				|	cmp IP, zend_jit_halt_op
+				|	je ->trace_halt
+			} else if (GCC_GLOBAL_REGS) {
+				|	test IP, IP
+				|	je ->trace_halt
+			} else {
+				|	test eax, eax
+				|	jl ->trace_halt
+			}
 		}
+
 		if (!GCC_GLOBAL_REGS) {
 			|	// execute_data = EG(current_execute_data)
 			|	MEM_OP2_2_ZTS mov, FP, aword, executor_globals, current_execute_data, r0

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -8268,15 +8268,21 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			|2:
 		}
 
-		|	// zend_vm_stack_free_call_frame(call);
-		|	test byte [RX + offsetof(zend_execute_data, This.u1.type_info) + 2], (ZEND_CALL_ALLOCATED >> 16)
-		|	jnz >1
-		|.cold_code
-		|1:
-		|	mov FCARG1a, RX
-		|	EXT_CALL zend_jit_free_call_frame, r0
-		|	jmp >1
-		|.code
+		if (zend_jit_trigger != ZEND_JIT_ON_HOT_TRACE ||
+		    !JIT_G(current_frame) ||
+		    !JIT_G(current_frame)->call ||
+		    !JIT_G(current_frame)->call->nested) {
+
+			|	// zend_vm_stack_free_call_frame(call);
+			|	test byte [RX + offsetof(zend_execute_data, This.u1.type_info) + 2], (ZEND_CALL_ALLOCATED >> 16)
+			|	jnz >1
+			|.cold_code
+			|1:
+			|	mov FCARG1a, RX
+			|	EXT_CALL zend_jit_free_call_frame, r0
+			|	jmp >1
+			|.code
+		}
 		|	MEM_OP2_1_ZTS mov, aword, executor_globals, vm_stack_top, RX, r0
 		|1:
 

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -7860,7 +7860,9 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 #if ZEND_DEBUG
 		if (func->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
 			// TODO: Mow most internal functions have type hints ???
-//???			goto fallback;
+			if (!trace) {
+				goto fallback;
+			}
 		}
 #endif
 	} else {
@@ -7881,7 +7883,6 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 				unknown_num_args = 1;
 			}
 #endif
-// TODO: it should be possible to reuse known user function as well ???
 		} else if (trace->op == ZEND_JIT_TRACE_ENTER) {
 			ZEND_ASSERT(trace->func->type == ZEND_USER_FUNCTION);
 			if (zend_accel_in_shm(trace->func->op_array.opcodes)) {
@@ -8358,7 +8359,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 	}
 
 	return 1;
-#if 0
+#if ZEND_DEBUG
 fallback:
 	/* fallback to subroutine threading */
 	if (trace) {


### PR DESCRIPTION
This PR adds tracing JIT in addition to existing method-based JIT.
It can be enabled using "opcache.jit=1255" (the third digit 5 really matters).
A lot of debugging output specific for tracing JIT may be collected running with opcache.jit_debug=0xff001.

The work on tracing JIT is incomplete. It misses support for register allocator and deoptimization. Not all the new optimization opportunities are implemented yet.