### PR TITLE
Improve FFI test suite for Windows

### DIFF
--- a/ext/ffi/tests/100.phpt
+++ b/ext/ffi/tests/100.phpt
@@ -2,9 +2,10 @@
 FFI 100: PHP symbols
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
+<?php require_once('utils.inc'); ?>
 <?php
 try {
-	FFI::cdef("extern void *zend_printf;");
+	ffi_cdef("extern void *zend_printf;", ffi_get_php_dll_name());
 } catch (Throwable $e) {
 	die('skip PHP symbols not available');
 }
@@ -13,14 +14,9 @@ try {
 ffi.enable=1
 --FILE--
 <?php
-// Check if target supports "fastcall" calling convention
-try {
-	FFI::cdef("extern size_t __attribute__((fastcall)) (*zend_printf)(const char *format);");
-	$fastcall = "__attribute__((fastcall)) ";
-} catch (Throwable $e) {
-	$fastcall = "";
-}
-$zend = FFI::cdef("
+require_once('utils.inc');
+$fastcall = ffi_get_fastcall_specifier();
+$zend = ffi_cdef("
 	const char *get_zend_version(void);
 	//char *get_zend_version(void);
 	extern size_t (*zend_printf)(const char *format, ...);
@@ -29,7 +25,7 @@ $zend = FFI::cdef("
 
 	void $fastcall zend_str_tolower(char *str, size_t length);
 
-");
+", ffi_get_php_dll_name());
 var_dump(trim(explode("\n",$zend->get_zend_version())[0]));
 //var_dump(trim(FFI::string($zend->get_zend_version())));
 var_dump($zend->zend_printf);

--- a/ext/ffi/tests/101.phpt
+++ b/ext/ffi/tests/101.phpt
@@ -2,9 +2,10 @@
 FFI 101: PHP symbols (function address)
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
+<?php require_once('utils.inc'); ?>
 <?php
 try {
-	FFI::cdef("extern void *zend_printf;");
+	ffi_cdef("extern void *zend_printf;", ffi_get_php_dll_name());
 } catch (Throwable $e) {
 	die('skip PHP symbols not available');
 }
@@ -13,14 +14,9 @@ try {
 ffi.enable=1
 --FILE--
 <?php
-// Check if target supports "fastcall" calling convention
-try {
-	FFI::cdef("extern size_t __attribute__((fastcall)) (*zend_printf)(const char *format);");
-	$fastcall = "__attribute__((fastcall)) ";
-} catch (Throwable $e) {
-	$fastcall = "";
-}
-$zend = FFI::cdef("
+require_once('utils.inc');
+$fastcall = ffi_get_fastcall_specifier();
+$zend = ffi_cdef("
 	const char *get_zend_version(void);
 	//char *get_zend_version(void);
 	extern size_t (*zend_printf)(const char *format, ...);
@@ -29,7 +25,7 @@ $zend = FFI::cdef("
 
 	void $fastcall zend_str_tolower(char *str, size_t length);
 
-");
+", ffi_get_php_dll_name());
 $f = $zend->get_zend_version;
 var_dump(trim(explode("\n",$f())[0]));
 //var_dump(trim(FFI::string($zend->get_zend_version())));

--- a/ext/ffi/tests/200.phpt
+++ b/ext/ffi/tests/200.phpt
@@ -2,9 +2,10 @@
 FFI 200: PHP callbacks
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
+<?php require_once('utils.inc'); ?>
 <?php
 try {
-	FFI::cdef("void* zend_write;");
+	FFI::cdef("void* zend_write;", ffi_get_php_dll_name());
 } catch (Throwable $e) {
 	die('skip PHP symbols not available');
 }
@@ -13,10 +14,11 @@ try {
 ffi.enable=1
 --FILE--
 <?php
+require_once('utils.inc');
 $zend = FFI::cdef("
 	typedef int (*zend_write_func_t)(const char *str, size_t str_length);
 	extern zend_write_func_t zend_write;
-");
+", ffi_get_php_dll_name());
 
 echo "Hello World!\n";
 

--- a/ext/ffi/tests/301-win32.phpt
+++ b/ext/ffi/tests/301-win32.phpt
@@ -7,10 +7,11 @@ FFI 301: FFI loading on Windows
 ffi.enable=1
 --FILE--
 <?php
+require_once('utils.inc');
 $fn = __DIR__ . "/300-win32.h";
 $cont = str_replace(
 		"PHP_DLL_NAME",
-		"php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . (PHP_DEBUG ? "_debug" : "") . ".dll",
+		ffi_get_php_dll_name(),
 		file_get_contents("$fn.in")
 	);
 file_put_contents($fn, $cont);

--- a/ext/ffi/tests/bug77632b.phpt
+++ b/ext/ffi/tests/bug77632b.phpt
@@ -3,8 +3,9 @@ Bug #77632 (FFI function pointers with variadics)
 --SKIPIF--
 <?php
 require_once('skipif.inc');
+require_once('utils.inc');
 try {
-	FFI::cdef("extern void *zend_printf;");
+	FFI::cdef("extern void *zend_printf;", ffi_get_php_dll_name());
 } catch (Throwable $_) {
 	die('skip PHP symbols not available');
 }
@@ -13,7 +14,8 @@ try {
 ffi.enable=1
 --FILE--
 <?php
-$libc = FFI::cdef("extern size_t (*zend_printf)(const char *format, ...);");
+require_once('utils.inc');
+$libc = FFI::cdef("extern size_t (*zend_printf)(const char *format, ...);", ffi_get_php_dll_name());
 $args = ["test from zend_printf\n"];
 ($libc->zend_printf)(...$args);
 $args2 = ["Hello, %s from zend_printf\n", "world"];

--- a/ext/ffi/tests/bug78270_1.phpt
+++ b/ext/ffi/tests/bug78270_1.phpt
@@ -5,26 +5,26 @@ FR #78270 (Usage of __vectorcall convention with FFI)
 require_once('skipif.inc');
 if (substr(PHP_OS, 0, 3) != 'WIN') die("skip this test is for Windows platforms only");
 
+require_once('utils.inc');
 ob_start();
 phpinfo(INFO_GENERAL);
 $info = ob_get_clean();
 if (preg_match('/Compiler => .*clang.*/', $info)) die("skip not for clang");
 
-$dll = 'php7' . (PHP_ZTS ? 'ts' : '') . (PHP_DEBUG ? '_debug' : '') . '.dll';
 try {
     FFI::cdef(<<<EOC
         __vectorcall int zend_atoi(const char *str, size_t str_len);
-        EOC, $dll);
+        EOC, ffi_get_php_dll_name());
 } catch (FFI\ParserException $ex) {
     die('skip __vectorcall not supported');
 }
 ?>
 --FILE--
 <?php
-$dll = 'php7' . (PHP_ZTS ? 'ts' : '') . (PHP_DEBUG ? '_debug' : '') . '.dll';
+require_once('utils.inc');
 $ffi = FFI::cdef(<<<EOC
     __vectorcall int zend_atoi(const char *str, size_t str_len);
-EOC, $dll);
+EOC, ffi_get_php_dll_name());
 var_dump($ffi->zend_atoi("17.4", 4));
 ?>
 --EXPECT--

--- a/ext/ffi/tests/bug78270_2.phpt
+++ b/ext/ffi/tests/bug78270_2.phpt
@@ -5,11 +5,11 @@ FR #78270 (Usage of __vectorcall convention with FFI)
 require_once('skipif.inc');
 if (substr(PHP_OS, 0, 3) != 'WIN') die("skip this test is for Windows platforms only");
 
-$dll = 'php7' . (PHP_ZTS ? 'ts' : '') . (PHP_DEBUG ? '_debug' : '') . '.dll';
+require_once('utils.inc');
 try {
     FFI::cdef(<<<EOC
         __vectorcall int zend_atoi(const char *str, size_t str_len);
-        EOC, $dll);
+        EOC, ffi_get_php_dll_name());
 } catch (FFI\ParserException $ex) {
     die('skip __vectorcall not supported');
 }

--- a/ext/ffi/tests/bug78714.phpt
+++ b/ext/ffi/tests/bug78714.phpt
@@ -6,13 +6,9 @@ Bug #78714 (funcs returning pointer can't use call convention spec)
 ffi.enable=1
 --FILE--
 <?php
+require_once('utils.inc');
 $def = 'char * __cdecl get_zend_version(void);';
-if (substr(PHP_OS, 0, 3) != 'WIN') {
-    $ffi = FFI::cdef($def);
-} else {
-    $dll = 'php7' . (PHP_ZTS ? 'ts' : '') . (PHP_DEBUG ? '_debug' : '') . '.dll';
-    $ffi = FFI::cdef($def, $dll);
-}
+$ffi = ffi_cdef($def, ffi_get_php_dll_name());
 echo substr(FFI::string($ffi->get_zend_version()), 0, 4) . "\n";
 ?>
 --EXPECT--

--- a/ext/ffi/tests/bug79096.phpt
+++ b/ext/ffi/tests/bug79096.phpt
@@ -7,6 +7,7 @@ if (!extension_loaded('zend-test')) die('skip zend-test extension not available'
 ?>
 --FILE--
 <?php
+require_once('utils.inc');
 $header = <<<HEADER
 struct bug79096 {
 	uint64_t a;
@@ -22,8 +23,7 @@ if (PHP_OS_FAMILY !== 'Windows') {
     try {
         $ffi = FFI::cdef($header, 'php_zend_test.dll');
     } catch (FFI\Exception $ex) {
-        $dll = $dll = 'php7' . (PHP_ZTS ? 'ts' : '') . (PHP_DEBUG ? '_debug' : '') . '.dll';
-        $ffi = FFI::cdef($header, $dll);
+        $ffi = FFI::cdef($header, ffi_get_php_dll_name());
     }
 }
 

--- a/ext/ffi/tests/preload.inc
+++ b/ext/ffi/tests/preload.inc
@@ -1,14 +1,3 @@
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-	$fn = __DIR__ . "/300-win32.h";
-	$cont = str_replace(
-			"PHP_DLL_NAME",
-			"php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . (PHP_DEBUG ? "_debug" : "") . ".dll",
-			file_get_contents("$fn.in")
-		);
-	file_put_contents($fn, $cont);
-	$ffi = FFI::load($fn);
-	/* Test should cleanup this. */
-} else {
-	FFI::load(__DIR__ . "/300.h");
-}
+
+FFI::load(__DIR__ . "/300.h");

--- a/ext/ffi/tests/utils.inc
+++ b/ext/ffi/tests/utils.inc
@@ -1,0 +1,30 @@
+<?php
+
+function ffi_cdef($code, $lib)
+{
+    if (isset($lib)) {
+        return FFI::cdef($code, $lib);
+    } else {
+        return FFI::cdef($code);
+    }
+}
+
+function ffi_get_php_dll_name()
+{
+    if (PHP_OS_FAMILY === 'Windows') {
+        return "php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . (PHP_DEBUG ? "_debug" : "") . ".dll";
+    } else {
+        return null;
+    }
+}
+
+function ffi_get_fastcall_specifier()
+{
+    foreach (['__attribute__((fastcall))', '__fastcall', '__vectorcall'] as $spec) {
+        try {
+            ffi_cdef("extern size_t $spec zend_list_insert(void *ptr, int type);", ffi_get_php_dll_name());
+            return "$spec ";
+        } catch (Throwable $e) {}
+    }
+    return "";
+}


### PR DESCRIPTION
We add Windows support to four existing test cases, extract some useful
utility functions, and use them to simplify further test cases.

We also remove the Windows specific code from preload.inc, since
preloading isn't supported on Windows anyway.