### PR TITLE
Fix #76999: mb-regex-set-options return current options

### DIFF
--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -1691,8 +1691,8 @@ static void _php_mb_regex_set_options(OnigOptionType options, OnigSyntaxType *sy
    Set or get the default options for mbregex functions */
 PHP_FUNCTION(mb_regex_set_options)
 {
-	OnigOptionType opt;
-	OnigSyntaxType *syntax;
+	OnigOptionType opt, prev_opt;
+	OnigSyntaxType *syntax, *prev_syntax;
 	char *string = NULL;
 	size_t string_len;
 	char buf[16];
@@ -1705,7 +1705,9 @@ PHP_FUNCTION(mb_regex_set_options)
 		opt = 0;
 		syntax = NULL;
 		_php_mb_regex_init_options(string, string_len, &opt, &syntax, NULL);
-		_php_mb_regex_set_options(opt, syntax, NULL, NULL);
+		_php_mb_regex_set_options(opt, syntax, &prev_opt, &prev_syntax);
+		opt = prev_opt;
+		syntax = prev_syntax;
 	} else {
 		opt = MBREX(regex_default_options);
 		syntax = MBREX(regex_default_syntax);

--- a/ext/mbstring/tests/bug76999.phpt
+++ b/ext/mbstring/tests/bug76999.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #76999 (mb-regex-set-options return current options)
+--SKIPIF--
+<?php
+if (!extension_loaded('mbstring')) die('skip mbstring extension not available');
+if (!function_exists('mb_regex_set_options')) die('skip mb_regex_set_options() not available');
+?>
+--FILE--
+<?php
+mb_regex_set_options("pr");
+var_dump(mb_regex_set_options("m"));
+var_dump(mb_regex_set_options("mdi"));
+var_dump(mb_regex_set_options("m"));
+var_dump(mb_regex_set_options("a"));
+var_dump(mb_regex_set_options());
+?>
+--EXPECT--
+string(2) "pr"
+string(2) "mr"
+string(3) "imd"
+string(2) "mr"
+string(1) "r"


### PR DESCRIPTION
When setting new options, `mb_regex_set_options()` is supposed to
return the *previous* options.