### PR TITLE
Fix #79393: Null coalescing operator failing with SplFixedArray

### DIFF
--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -342,8 +342,7 @@ static zval *spl_fixedarray_object_read_dimension(zval *object, zval *offset, in
 
 	intern = Z_SPLFIXEDARRAY_P(object);
 
-	if (type == BP_VAR_IS && !spl_fixedarray_object_has_dimension(object, offset, 1)) {
-		ZVAL_UNDEF(rv);
+	if (type == BP_VAR_IS && !spl_fixedarray_object_has_dimension(object, offset, 0)) {
 		return &EG(uninitialized_zval);
 	}
 

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -342,19 +342,9 @@ static zval *spl_fixedarray_object_read_dimension(zval *object, zval *offset, in
 
 	intern = Z_SPLFIXEDARRAY_P(object);
 
-	if (type == BP_VAR_IS && intern->fptr_offset_has) {
-		SEPARATE_ARG_IF_REF(offset);
-		zend_call_method_with_1_params(object, intern->std.ce, &intern->fptr_offset_has, "offsetexists", rv, offset);
-		if (UNEXPECTED(Z_ISUNDEF_P(rv))) {
-			zval_ptr_dtor(offset);
-			return NULL;
-		}
-		if (!i_zend_is_true(rv)) {
-			zval_ptr_dtor(offset);
-			zval_ptr_dtor(rv);
-			return &EG(uninitialized_zval);
-		}
-		zval_ptr_dtor(rv);
+	if (type == BP_VAR_IS && !spl_fixedarray_object_has_dimension(object, offset, 1)) {
+		ZVAL_UNDEF(rv);
+		return &EG(uninitialized_zval);
 	}
 
 	if (intern->fptr_offset_get) {

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -336,6 +336,8 @@ static inline zval *spl_fixedarray_object_read_dimension_helper(spl_fixedarray_o
 }
 /* }}} */
 
+static int spl_fixedarray_object_has_dimension(zval *object, zval *offset, int check_empty);
+
 static zval *spl_fixedarray_object_read_dimension(zval *object, zval *offset, int type, zval *rv) /* {{{ */
 {
 	spl_fixedarray_object *intern;

--- a/ext/spl/tests/bug79393.phpt
+++ b/ext/spl/tests/bug79393.phpt
@@ -2,15 +2,24 @@
 Bug #79393 (Null coalescing operator failing with SplFixedArray)
 --FILE--
 <?php
-$foo = new SplFixedArray(2);
+$foo = new SplFixedArray(5);
 $foo[0] = 'bar1';
 $foo[1] = 'bar2';
+$foo[2] = 0;
+$foo[3] = false;
+$foo[4] = '';
 
 var_dump($foo[0] ?? null);
 var_dump($foo[1] ?? null);
 var_dump($foo[2] ?? null);
+var_dump($foo[3] ?? null);
+var_dump($foo[4] ?? null);
+var_dump($foo[5] ?? null);
 ?>
 --EXPECT--
 string(4) "bar1"
 string(4) "bar2"
+int(0)
+bool(false)
+string(0) ""
 NULL

--- a/ext/spl/tests/bug79393.phpt
+++ b/ext/spl/tests/bug79393.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #79393 (Null coalescing operator failing with SplFixedArray)
+--FILE--
+<?php
+$foo = new SplFixedArray(2);
+$foo[0] = 'bar1';
+$foo[1] = 'bar2';
+
+var_dump($foo[0] ?? null);
+var_dump($foo[1] ?? null);
+var_dump($foo[2] ?? null);
+?>
+--EXPECT--
+string(4) "bar1"
+string(4) "bar2"
+NULL


### PR DESCRIPTION
We favor the KISS principle over optimization[1] – SPL is already
special enough.

[1] <https://github.com/php/php-src/pull/2489/commits/352f3d4476a79bb86136b431719df7394e5a8d4e#r112498098>ff