### PR TITLE
Fixing issue with setTime during DST jump

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3562,6 +3562,7 @@ static void php_date_time_set(zval *object, zend_long h, zend_long i, zend_long 
 	dateobj->time->s = s;
 	dateobj->time->us = ms;
 	timelib_update_ts(dateobj->time, NULL);
+	timelib_update_from_sse(dateobj->time);
 } /* }}} */
 
 /* {{{ proto DateTime date_time_set(DateTime object, int hour, int minute[, int second[, int microseconds]])

--- a/ext/date/tests/bug79396-forward-transition-settime.phpt
+++ b/ext/date/tests/bug79396-forward-transition-settime.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test for setting Date/Time during a forward DST transition
+--FILE--
+<?php
+date_default_timezone_set('America/Chicago');
+
+$date = new DateTime('2020-03-08 01:30:00');
+echo $date->setTime(2, 0)->format('Y-m-d H:i:s T/e - U') . "\n";
+
+$date = new DateTime('2020-03-08 01:30:00');
+echo $date->setTime(2, 30)->format('Y-m-d H:i:s T/e - U') . "\n";
+
+$date = new DateTime('2020-03-08 01:30:00');
+echo $date->setTime(3, 0)->format('Y-m-d H:i:s T/e - U') . "\n";
+
+$date = new DateTime('2020-03-08 01:30:00');
+echo $date->setTime(1, 59, 59)->format('Y-m-d H:i:s T/e - U') . "\n";
+
+?>
+--EXPECT--
+2020-03-08 03:00:00 CDT/America/Chicago - 1583654400
+2020-03-08 03:30:00 CDT/America/Chicago - 1583656200
+2020-03-08 03:00:00 CDT/America/Chicago - 1583654400
+2020-03-08 01:59:59 CST/America/Chicago - 1583654399


### PR DESCRIPTION
When you attempt to set the time to a non-existent time occuring during
a DST jump forward, the hour does not move forward correctly.

https://bugs.php.net/bug.php?id=79396