### PR TITLE
Fix Bug #79296 ZipArchive::open fails on empty file

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1487,6 +1487,21 @@ static ZIPARCHIVE_METHOD(open)
 		ze_obj->filename = NULL;
 	}
 
+#if LIBZIP_VERSION_MAJOR > 1 || LIBZIP_VERSION_MAJOR == 1 && LIBZIP_VERSION_MINOR >= 6
+	/* reduce BC break introduce in libzip 1.6.0
+	   "Do not accept empty files as valid zip archives any longer" */
+
+	/* open for write without option to empty the archive */
+	if ((flags & (ZIP_TRUNCATE | ZIP_RDONLY)) == 0) {
+		zend_stat_t st;
+
+		/* exists and is empty */
+		if (VCWD_STAT(resolved_path, &st) == 0 && st.st_size == 0) {
+			flags |= ZIP_TRUNCATE;
+		}
+	}
+#endif
+
 	intern = zip_open(resolved_path, flags, &err);
 	if (!intern || err) {
 		efree(resolved_path);

--- a/ext/zip/tests/bug53885.phpt
+++ b/ext/zip/tests/bug53885.phpt
@@ -3,7 +3,6 @@ Bug #53885 (ZipArchive segfault with FL_UNCHANGED on empty archive)
 --SKIPIF--
 <?php
 if(!extension_loaded('zip')) die('skip');
-if(version_compare(ZipArchive::LIBZIP_VERSION, '1.6', '>=')) die('skip libzip too recent');
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Try to reduce the minor  BC break introduce in libzip 1.6.0

See https://bugs.php.net/bug.php?id=79296

Above code seems quite ok...

```
$f = tempnam(sys_get_temp_dir(), 'xxx');
$zip = new ZipArchive();
$success = $zip->open($f);
```

Open for discussion, don't know if we should even try to fix this