### PR TITLE
When two datetime have same timezone to diff don't convert to gmt

### DIFF
--- a/ext/date/lib/interval.c
+++ b/ext/date/lib/interval.c
@@ -60,8 +60,11 @@ timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two)
 	memcpy(&one_backup, one, sizeof(one_backup));
 	memcpy(&two_backup, two, sizeof(two_backup));
 
-    timelib_apply_localtime(one, 0);
-    timelib_apply_localtime(two, 0);
+	/* Time to gmt when tz is different */
+    if(one->z != two->z){
+        timelib_apply_localtime(one, 0);
+        timelib_apply_localtime(two, 0);
+    }
 
 	rt->y = two->y - one->y;
 	rt->m = two->m - one->m;

--- a/ext/date/tests/016.phpt
+++ b/ext/date/tests/016.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Datetime diff with timezone
+--FILE--
+<?php
+
+$tz    = new DateTimeZone('Asia/Shanghai');
+$date1 = new DateTime('2020-03-01', $tz);
+$date2 = new DateTime('2020-02-01', $tz);
+var_dump($date1->diff($date2)->m);
+echo "Done\n";
+?>
+--EXPECT--
+int(1)
+Done


### PR DESCRIPTION
```php
<?php

$tz    = new DateTimeZone('Asia/Shanghai');
$date1 = new DateTime('2020-03-01', $tz);
$date2 = new DateTime('2020-02-01', $tz);
var_dump($date1->diff($date2)->m); // current php will output 0
```
