### PR TITLE
Skip ftruncate_bug76422 if disk_free_space() <= 4GB

### DIFF
--- a/ext/standard/tests/file/ftruncate_bug76422.phpt
+++ b/ext/standard/tests/file/ftruncate_bug76422.phpt
@@ -5,6 +5,10 @@ Bug #76422 ftruncate fails on files > 2GB
 if (PHP_INT_SIZE < 8) {
     die('skip.. only valid for 64-bit');
 }
+if (disk_free_space(__DIR__) <= 4.1 * 1024 * 1024 * 1024 ) {
+    // Add a bit of extra overhead for other processes, temporary files created while running tests, etc.
+    die('skip.. This test requires over 4GB of free disk space on this disk partition');
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Followup to https://github.com/php/php-src/pull/5043

In the middle of running this test with TESTS=-j9,
run-tests.php stopped the test suite because the partition started
with 3.5GB of free disk space and new test files couldn't be created.

Reclaiming the disk space of that file also took a while.