### PR TITLE
Fix compilation error on mac with -Wshift-negative-value

### DIFF
--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -352,7 +352,7 @@ struct _zend_jit_trace_stack_frame {
 		_frame->call = NULL; \
 		_frame->prev = NULL; \
 		_frame->func = (const zend_function*)_func; \
-		_frame->_info = (uint32_t)((((int)(num_args)) << TRACE_FRAME_SHIFT_NUM_ARGS) & TRACE_FRAME_MASK_NUM_ARGS); \
+		_frame->_info = (((uint32_t)(num_args)) << TRACE_FRAME_SHIFT_NUM_ARGS) & TRACE_FRAME_MASK_NUM_ARGS; \
 		if (nested) { \
 			_frame->_info |= TRACE_FRAME_MASK_NESTED; \
 		}; \


### PR DESCRIPTION
Fix for mac OS build error seen in ccc49ead681add7bdf6a021c7a3420aff543bc1e
when shifting -1 (max argument count?)

```
ext/opcache/jit/zend_jit_trace.c:1668:2:
error: shifting a negative signed value is undefined
[-Werror,-Wshift-negative-value]
        TRACE_FRAME_INIT(frame, op_array, 0, -1);
```

EDIT: Should be `unsigned int`, not `uint`, I've spent too much time with golang