### PR TITLE
Repair ext_skel.php to create the basic framework for a PHP extension

### DIFF
--- a/ext/ext_skel.php
+++ b/ext/ext_skel.php
@@ -331,7 +331,8 @@ function copy_sources() {
     $files = [
             'skeleton.c'		=> $options['ext'] . '.c',
             'skeleton.stub.php'	=> $options['ext'] . '.stub.php',
-            'php_skeleton.h'	=> 'php_' . $options['ext'] . '.h'
+            'php_skeleton.h'	=> 'php_' . $options['ext'] . '.h',
+            'skeleton_arginfo.h' => $options['ext'] . '_arginfo.h'
             ];
 
     foreach ($files as $src_file => $dst_file) {

--- a/ext/skeleton/skeleton.c
+++ b/ext/skeleton/skeleton.c
@@ -71,7 +71,7 @@ PHP_MINFO_FUNCTION(%EXTNAME%)
  */
 static const zend_function_entry %EXTNAME%_functions[] = {
 	PHP_FE(test1,		arginfo_test1)
-	PHP_FE(test2,		arginfo_test2)
+	PHP_FE(%EXTNAME%_test2,		arginfo_test2)
 	PHP_FE_END
 };
 /* }}} */


### PR DESCRIPTION
Add script to copy the arginfo stubs file, and add alias for the example skeleton extension