### PR TITLE
Repair ext_skel.php to create the basic framework for a PHP extension

### DIFF
--- a/ext/ext_skel.php
+++ b/ext/ext_skel.php
@@ -331,7 +331,8 @@ function copy_sources() {
     $files = [
             'skeleton.c'		=> $options['ext'] . '.c',
             'skeleton.stub.php'	=> $options['ext'] . '.stub.php',
-            'php_skeleton.h'	=> 'php_' . $options['ext'] . '.h'
+            'php_skeleton.h'	=> 'php_' . $options['ext'] . '.h',
+            'skeleton_arginfo.h' => $options['ext'] . '_arginfo.h'
             ];
 
     foreach ($files as $src_file => $dst_file) {

--- a/ext/skeleton/skeleton.c
+++ b/ext/skeleton/skeleton.c
@@ -26,9 +26,9 @@ PHP_FUNCTION(test1)
 }
 /* }}} */
 
-/* {{{ string %EXTNAME%_test2( [ string $var ] )
+/* {{{ string test2( [ string $var ] )
  */
-PHP_FUNCTION(%EXTNAME%_test2)
+PHP_FUNCTION(test2)
 {
 	char *var = "World";
 	size_t var_len = sizeof("World") - 1;


### PR DESCRIPTION
Add script to copy the arginfo stubs file, and drop the %EXTNAME%_ to make things line up.