### PR TITLE
Implement "Constructor Promotion"

### DIFF
--- a/Zend/tests/ctor_promotion_abstract.phpt
+++ b/Zend/tests/ctor_promotion_abstract.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Constructor promotion cannot be used inside an abstract constructor
+--FILE--
+<?php
+
+abstract class Test {
+    abstract public function __construct(public int $x);
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot declare promoted property in an abstract constructor in %s on line %d

--- a/Zend/tests/ctor_promotion_additional_modifiers.phpt
+++ b/Zend/tests/ctor_promotion_additional_modifiers.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Constructor promotion only permits visibility modifiers
+--FILE--
+<?php
+
+class Test {
+    public function __construct(public static $x) {}
+}
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected 'static' (T_STATIC), expecting variable (T_VARIABLE) in %s on line %d

--- a/Zend/tests/ctor_promotion_attributes.phpt
+++ b/Zend/tests/ctor_promotion_attributes.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Attributes on promoted properties are assigned to both the property and parameter
+--FILE--
+<?php
+
+class Test {
+    public function __construct(
+        <<NonNegative>>
+        public int $num,
+    ) {}
+}
+
+$prop = new ReflectionProperty(Test::class, 'num');
+var_dump($prop->getAttributes()[0]->getName());
+
+$param = new ReflectionParameter([Test::class, '__construct'], 'num');
+var_dump($param->getAttributes()[0]->getName());
+
+?>
+--EXPECT--
+string(11) "NonNegative"
+string(11) "NonNegative"

--- a/Zend/tests/ctor_promotion_basic.phpt
+++ b/Zend/tests/ctor_promotion_basic.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Constructor promotion (basic example)
+--FILE--
+<?php
+
+class Point {
+    public function __construct(public int $x, public int $y, public int $z) {}
+}
+
+$point = new Point(1, 2, 3);
+
+// Check that properties really are typed.
+try {
+    $point->x = "foo";
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Cannot assign string to property Point::$x of type int

--- a/Zend/tests/ctor_promotion_by_ref.phpt
+++ b/Zend/tests/ctor_promotion_by_ref.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Constructor promotion of by-ref parameter
+--FILE--
+<?php
+
+class Ary {
+    public function __construct(public array &$array) {}
+}
+
+$array = [];
+$ary = new Ary($array);
+$array[] = 42;
+var_dump($ary->array);
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(42)
+}

--- a/Zend/tests/ctor_promotion_callable_type.phpt
+++ b/Zend/tests/ctor_promotion_callable_type.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Type of promoted property may not be callable
+--FILE--
+<?php
+
+class Test {
+    public function __construct(public callable $callable) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Property Test::$callable cannot have type callable in %s on line %d

--- a/Zend/tests/ctor_promotion_defaults.phpt
+++ b/Zend/tests/ctor_promotion_defaults.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Constructor promotion with default values
+--FILE--
+<?php
+
+class Point {
+    public function __construct(
+        public float $x = 0.0,
+        public float $y = 1.0,
+        public float $z = 2.0
+    ) {}
+}
+
+var_dump(new Point(10.0));
+var_dump(new Point(10.0, 11.0));
+var_dump(new Point(10.0, 11.0, 12.0));
+
+?>
+--EXPECT--
+object(Point)#1 (3) {
+  ["x"]=>
+  float(10)
+  ["y"]=>
+  float(1)
+  ["z"]=>
+  float(2)
+}
+object(Point)#1 (3) {
+  ["x"]=>
+  float(10)
+  ["y"]=>
+  float(11)
+  ["z"]=>
+  float(2)
+}
+object(Point)#1 (3) {
+  ["x"]=>
+  float(10)
+  ["y"]=>
+  float(11)
+  ["z"]=>
+  float(12)
+}

--- a/Zend/tests/ctor_promotion_free_function.phpt
+++ b/Zend/tests/ctor_promotion_free_function.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Constructor promotion cannot be used in a free function
+--FILE--
+<?php
+
+function __construct(public $prop) {}
+
+?>
+--EXPECTF--
+Fatal error: Cannot declare promoted property outside a constructor in %s on line %d

--- a/Zend/tests/ctor_promotion_interface.phpt
+++ b/Zend/tests/ctor_promotion_interface.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Constructor promotion cannot be used inside an abstract constructor (interface variant)
+--FILE--
+<?php
+
+interface Test {
+    public function __construct(public int $x);
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot declare promoted property in an abstract constructor in %s on line %d

--- a/Zend/tests/ctor_promotion_mixing.phpt
+++ b/Zend/tests/ctor_promotion_mixing.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Constructor promotiong mixed with other properties, parameters and code
+--FILE--
+<?php
+
+class Test {
+    public string $prop2;
+
+    public function __construct(public string $prop1 = "", $param2 = "") {
+        $this->prop2 = $prop1 . $param2;
+    }
+}
+
+var_dump(new Test("Foo", "Bar"));
+echo "\n";
+echo new ReflectionClass(Test::class), "\n";
+
+?>
+--EXPECTF--
+object(Test)#1 (2) {
+  ["prop2"]=>
+  string(6) "FooBar"
+  ["prop1"]=>
+  string(3) "Foo"
+}
+
+Class [ <user> class Test ] {
+  @@ %s
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [2] {
+    Property [ <default> public $prop2 ]
+    Property [ <default> public $prop1 ]
+  }
+
+  - Methods [1] {
+    Method [ <user, ctor> public method __construct ] {
+      @@ %s
+
+      - Parameters [2] {
+        Parameter #0 [ <optional> string $prop1 = '' ]
+        Parameter #1 [ <optional> $param2 = '' ]
+      }
+    }
+  }
+}

--- a/Zend/tests/ctor_promotion_mixing.phpt
+++ b/Zend/tests/ctor_promotion_mixing.phpt
@@ -37,8 +37,8 @@ Class [ <user> class Test ] {
   }
 
   - Properties [2] {
-    Property [ <default> public $prop2 ]
-    Property [ <default> public $prop1 ]
+    Property [ public string $prop2 ]
+    Property [ public string $prop1 ]
   }
 
   - Methods [1] {

--- a/Zend/tests/ctor_promotion_not_a_ctor.phpt
+++ b/Zend/tests/ctor_promotion_not_a_ctor.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Constructor promotion can only be used in constructors ... duh
+--FILE--
+<?php
+
+class Test {
+    public function foobar(public int $x, public int $y) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot declare promoted property outside a constructor in %s on line %d

--- a/Zend/tests/ctor_promotion_null_default.phpt
+++ b/Zend/tests/ctor_promotion_null_default.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Constructor promotion with null default, requires an explicitly nullable type
+--FILE--
+<?php
+
+class Test {
+    public function __construct(public int $x = null) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use null as default value for parameter $x of type int in %s on line %d

--- a/Zend/tests/ctor_promotion_repeated_prop.phpt
+++ b/Zend/tests/ctor_promotion_repeated_prop.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Clash between promoted and explicit property
+--FILE--
+<?php
+
+class Test {
+    public $prop;
+
+    public function __construct(public $prop) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot redeclare Test::$prop in %s on line %d

--- a/Zend/tests/ctor_promotion_trait.phpt
+++ b/Zend/tests/ctor_promotion_trait.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Constructor promotion can be used inside a trait
+--FILE--
+<?php
+
+trait Test {
+    public function __construct(public $prop) {}
+}
+
+class Test2 {
+    use Test;
+}
+
+var_dump(new Test2(42));
+
+?>
+--EXPECT--
+object(Test2)#1 (1) {
+  ["prop"]=>
+  int(42)
+}

--- a/Zend/tests/ctor_promotion_variadic.phpt
+++ b/Zend/tests/ctor_promotion_variadic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Cannot use constructor promotion with variadic parameter
+--FILE--
+<?php
+
+class Test {
+    public function __construct(public string ...$strings) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot declare variadic promoted property in %s on line %d

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -244,6 +244,37 @@ ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_4(zend_ast_kind kind, zend_ast
 	return ast;
 }
 
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_5(zend_ast_kind kind, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4, zend_ast *child5) {
+	zend_ast *ast;
+	uint32_t lineno;
+
+	ZEND_ASSERT(kind >> ZEND_AST_NUM_CHILDREN_SHIFT == 5);
+	ast = zend_ast_alloc(zend_ast_size(5));
+	ast->kind = kind;
+	ast->attr = 0;
+	ast->child[0] = child1;
+	ast->child[1] = child2;
+	ast->child[2] = child3;
+	ast->child[3] = child4;
+	ast->child[4] = child5;
+	if (child1) {
+		lineno = zend_ast_get_lineno(child1);
+	} else if (child2) {
+		lineno = zend_ast_get_lineno(child2);
+	} else if (child3) {
+		lineno = zend_ast_get_lineno(child3);
+	} else if (child4) {
+		lineno = zend_ast_get_lineno(child4);
+	} else if (child5) {
+		lineno = zend_ast_get_lineno(child5);
+	} else {
+		lineno = CG(zend_lineno);
+	}
+	ast->lineno = lineno;
+
+	return ast;
+}
+
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_list_0(zend_ast_kind kind) {
 	zend_ast *ast;
 	zend_ast_list *list;

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -214,12 +214,12 @@ ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_class_const_or_name(zend_ast *
 
 #if ZEND_AST_SPEC
 # define ZEND_AST_SPEC_CALL(name, ...) \
-	ZEND_EXPAND_VA(ZEND_AST_SPEC_CALL_(name, __VA_ARGS__, _4, _3, _2, _1, _0)(__VA_ARGS__))
-# define ZEND_AST_SPEC_CALL_(name, _, _4, _3, _2, _1, suffix, ...) \
+	ZEND_EXPAND_VA(ZEND_AST_SPEC_CALL_(name, __VA_ARGS__, _5, _4, _3, _2, _1, _0)(__VA_ARGS__))
+# define ZEND_AST_SPEC_CALL_(name, _, _5, _4, _3, _2, _1, suffix, ...) \
 	name ## suffix
 # define ZEND_AST_SPEC_CALL_EX(name, ...) \
-	ZEND_EXPAND_VA(ZEND_AST_SPEC_CALL_EX_(name, __VA_ARGS__, _4, _3, _2, _1, _0)(__VA_ARGS__))
-# define ZEND_AST_SPEC_CALL_EX_(name, _, _5, _4, _3, _2, _1, suffix, ...) \
+	ZEND_EXPAND_VA(ZEND_AST_SPEC_CALL_EX_(name, __VA_ARGS__, _5, _4, _3, _2, _1, _0)(__VA_ARGS__))
+# define ZEND_AST_SPEC_CALL_EX_(name, _, _6, _5, _4, _3, _2, _1, suffix, ...) \
 	name ## suffix
 
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_0(zend_ast_kind kind);
@@ -227,6 +227,7 @@ ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_1(zend_ast_kind kind, zend_ast
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_2(zend_ast_kind kind, zend_ast *child1, zend_ast *child2);
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_3(zend_ast_kind kind, zend_ast *child1, zend_ast *child2, zend_ast *child3);
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_4(zend_ast_kind kind, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4);
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_5(zend_ast_kind kind, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4, zend_ast *child5);
 
 static zend_always_inline zend_ast * zend_ast_create_ex_0(zend_ast_kind kind, zend_ast_attr attr) {
 	zend_ast *ast = zend_ast_create_0(kind);
@@ -250,6 +251,11 @@ static zend_always_inline zend_ast * zend_ast_create_ex_3(zend_ast_kind kind, ze
 }
 static zend_always_inline zend_ast * zend_ast_create_ex_4(zend_ast_kind kind, zend_ast_attr attr, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4) {
 	zend_ast *ast = zend_ast_create_4(kind, child1, child2, child3, child4);
+	ast->attr = attr;
+	return ast;
+}
+static zend_always_inline zend_ast * zend_ast_create_ex_5(zend_ast_kind kind, zend_ast_attr attr, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4, zend_ast *child5) {
+	zend_ast *ast = zend_ast_create_5(kind, child1, child2, child3, child4, child5);
 	ast->attr = attr;
 	return ast;
 }

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -156,7 +156,9 @@ enum _zend_ast_kind {
 	/* 4 child nodes */
 	ZEND_AST_FOR = 4 << ZEND_AST_NUM_CHILDREN_SHIFT,
 	ZEND_AST_FOREACH,
-	ZEND_AST_PARAM,
+
+	/* 5 child nodes */
+	ZEND_AST_PARAM = 5 << ZEND_AST_NUM_CHILDREN_SHIFT,
 };
 
 typedef uint16_t zend_ast_kind;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5894,7 +5894,9 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast, uint32_t fall
 				zend_alloc_cache_slots(zend_type_get_num_classes(arg_info->type));
 		}
 
-		ZEND_TYPE_FULL_MASK(arg_info->type) |= _ZEND_ARG_INFO_FLAGS(is_ref, is_variadic);
+		uint32_t arg_info_flags = _ZEND_ARG_INFO_FLAGS(is_ref, is_variadic)
+			| (visibility ? _ZEND_IS_PROMOTED_BIT : 0);
+		ZEND_TYPE_FULL_MASK(arg_info->type) |= arg_info_flags;
 		if (opcode == ZEND_RECV) {
 			opline->op2.num = type_ast ?
 				ZEND_TYPE_FULL_MASK(arg_info->type) : MAY_BE_ANY;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5941,8 +5941,12 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast, uint32_t fall
 
 			zend_string *doc_comment =
 				doc_comment_ast ? zend_string_copy(zend_ast_get_str(doc_comment_ast)) : NULL;
-			zend_declare_typed_property(
+			zend_property_info *prop = zend_declare_typed_property(
 				scope, name, &default_value, visibility, doc_comment, type);
+			if (attributes_ast) {
+				zend_compile_attributes(
+					&prop->attributes, attributes_ast, 0, ZEND_ATTRIBUTE_TARGET_PROPERTY);
+			}
 		}
 	}
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5787,6 +5787,7 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast, uint32_t fall
 		zend_ast *var_ast = param_ast->child[1];
 		zend_ast *default_ast = param_ast->child[2];
 		zend_ast *attributes_ast = param_ast->child[3];
+		zend_ast *doc_comment_ast = param_ast->child[4];
 		zend_string *name = zval_make_interned_string(zend_ast_get_zval(var_ast));
 		zend_bool is_ref = (param_ast->attr & ZEND_PARAM_REF) != 0;
 		zend_bool is_variadic = (param_ast->attr & ZEND_PARAM_VARIADIC) != 0;
@@ -5938,8 +5939,10 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast, uint32_t fall
 				type = zend_compile_typename(type_ast, /* force_allow_null */ 0, /* use_arena */ 1);
 			}
 
+			zend_string *doc_comment =
+				doc_comment_ast ? zend_string_copy(zend_ast_get_str(doc_comment_ast)) : NULL;
 			zend_declare_typed_property(
-				scope, name, &default_value, visibility, /* doc_comment */ NULL, type);
+				scope, name, &default_value, visibility, doc_comment, type);
 		}
 	}
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5942,7 +5942,7 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast, uint32_t fall
 			zend_string *doc_comment =
 				doc_comment_ast ? zend_string_copy(zend_ast_get_str(doc_comment_ast)) : NULL;
 			zend_property_info *prop = zend_declare_typed_property(
-				scope, name, &default_value, visibility, doc_comment, type);
+				scope, name, &default_value, visibility | ZEND_ACC_PROMOTED, doc_comment, type);
 			if (attributes_ast) {
 				zend_compile_attributes(
 					&prop->attributes, attributes_ast, 0, ZEND_ATTRIBUTE_TARGET_PROPERTY);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -209,6 +209,9 @@ typedef struct _zend_oparray_context {
 /* Static method or property                              |     |     |     */
 #define ZEND_ACC_STATIC                  (1 <<  4) /*     |  X  |  X  |     */
 /*                                                        |     |     |     */
+/* Promoted property / parameter                          |     |     |     */
+#define ZEND_ACC_PROMOTED                (1 <<  5) /*     |     |  X  |  X  */
+/*                                                        |     |     |     */
 /* Final class or method                                  |     |     |     */
 #define ZEND_ACC_FINAL                   (1 <<  5) /*  X  |  X  |     |     */
 /*                                                        |     |     |     */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -941,10 +941,13 @@ ZEND_API zend_string *zend_type_to_string(zend_type type);
 /* The send mode and is_variadic flag are stored as part of zend_type */
 #define _ZEND_SEND_MODE_SHIFT _ZEND_TYPE_EXTRA_FLAGS_SHIFT
 #define _ZEND_IS_VARIADIC_BIT (1 << (_ZEND_TYPE_EXTRA_FLAGS_SHIFT + 2))
+#define _ZEND_IS_PROMOTED_BIT (1 << (_ZEND_TYPE_EXTRA_FLAGS_SHIFT + 3))
 #define ZEND_ARG_SEND_MODE(arg_info) \
 	((ZEND_TYPE_FULL_MASK((arg_info)->type) >> _ZEND_SEND_MODE_SHIFT) & 3)
 #define ZEND_ARG_IS_VARIADIC(arg_info) \
 	((ZEND_TYPE_FULL_MASK((arg_info)->type) & _ZEND_IS_VARIADIC_BIT) != 0)
+#define ZEND_ARG_IS_PROMOTED(arg_info) \
+	((ZEND_TYPE_FULL_MASK((arg_info)->type) & _ZEND_IS_PROMOTED_BIT) != 0)
 
 #define ZEND_DIM_IS					(1 << 0) /* isset fetch needed for null coalesce */
 #define ZEND_DIM_ALTERNATIVE_SYNTAX	(1 << 1) /* deprecated curly brace usage */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -873,8 +873,9 @@ ZEND_API zend_string *zend_type_to_string(zend_type type);
 #define ZEND_FETCH_CLASS_ALLOW_UNLINKED 0x0400
 #define ZEND_FETCH_CLASS_ALLOW_NEARLY_LINKED 0x0800
 
-#define ZEND_PARAM_REF      (1<<0)
-#define ZEND_PARAM_VARIADIC (1<<1)
+/* These should not clash with ZEND_ACC_(PUBLIC|PROTECTED|PRIVATE) */
+#define ZEND_PARAM_REF      (1<<3)
+#define ZEND_PARAM_VARIADIC (1<<4)
 
 #define ZEND_NAME_FQ       0
 #define ZEND_NAME_NOT_FQ   1

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -693,11 +693,13 @@ optional_visibility_modifier:
 
 parameter:
 		optional_visibility_modifier optional_type_without_static
-		is_reference is_variadic T_VARIABLE
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $1 | $3 | $4, $2, $5, NULL); }
+		is_reference is_variadic T_VARIABLE backup_doc_comment
+			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $1 | $3 | $4, $2, $5, NULL,
+					NULL, $6 ? zend_ast_create_zval_from_str($6) : NULL); }
 	|	optional_visibility_modifier optional_type_without_static
-		is_reference is_variadic T_VARIABLE '=' expr
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $1 | $3 | $4, $2, $5, $7); }
+		is_reference is_variadic T_VARIABLE backup_doc_comment '=' expr
+			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $1 | $3 | $4, $2, $5, $8,
+					NULL, $6 ? zend_ast_create_zval_from_str($6) : NULL); }
 ;
 
 

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -262,7 +262,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> attribute_arguments attribute_decl attribute attributes
 
 %type <num> returns_ref function fn is_reference is_variadic variable_modifiers
-%type <num> method_modifiers non_empty_member_modifiers member_modifier
+%type <num> method_modifiers non_empty_member_modifiers member_modifier optional_visibility_modifier
 %type <num> class_modifiers class_modifier use_type backup_fn_flags
 
 %type <ptr> backup_lex_pos
@@ -684,11 +684,20 @@ attributed_parameter:
 	|	parameter				{ $$ = $1; }
 ;
 
+optional_visibility_modifier:
+		%empty					{ $$ = 0; }
+	|	T_PUBLIC				{ $$ = ZEND_ACC_PUBLIC; }
+	|	T_PROTECTED				{ $$ = ZEND_ACC_PROTECTED; }
+	|	T_PRIVATE				{ $$ = ZEND_ACC_PRIVATE; }
+;
+
 parameter:
-		optional_type_without_static is_reference is_variadic T_VARIABLE
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2 | $3, $1, $4, NULL, NULL); }
-	|	optional_type_without_static is_reference is_variadic T_VARIABLE '=' expr
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2 | $3, $1, $4, $6, NULL); }
+		optional_visibility_modifier optional_type_without_static
+		is_reference is_variadic T_VARIABLE
+			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $1 | $3 | $4, $2, $5, NULL); }
+	|	optional_visibility_modifier optional_type_without_static
+		is_reference is_variadic T_VARIABLE '=' expr
+			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $1 | $3 | $4, $2, $5, $7); }
 ;
 
 

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1089,10 +1089,11 @@ inline_function:
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $2 | $13, $1, $3,
 				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0),
 				  $5, $7, $11, $8, NULL); CG(extra_fn_flags) = $9; }
-	|	fn returns_ref '(' parameter_list ')' return_type backup_doc_comment T_DOUBLE_ARROW backup_fn_flags backup_lex_pos expr backup_fn_flags
-			{ $$ = zend_ast_create_decl(ZEND_AST_ARROW_FUNC, $2 | $12, $1, $7,
-				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0), $4, NULL,
-				  zend_ast_create(ZEND_AST_RETURN, $11), $6, NULL);
+	|	fn returns_ref backup_doc_comment '(' parameter_list ')' return_type
+		T_DOUBLE_ARROW backup_fn_flags backup_lex_pos expr backup_fn_flags
+			{ $$ = zend_ast_create_decl(ZEND_AST_ARROW_FUNC, $2 | $12, $1, $3,
+				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0), $5, NULL,
+				  zend_ast_create(ZEND_AST_RETURN, $11), $7, NULL);
 				  ((zend_ast_decl *) $$)->lex_pos = $10;
 				  CG(extra_fn_flags) = $9; }
 ;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2870,6 +2870,22 @@ ZEND_METHOD(ReflectionParameter, isVariadic)
 }
 /* }}} */
 
+/* {{{ proto public bool ReflectionParameter::isPromoted()
+   Returns this constructor parameter has been promoted to a property */
+ZEND_METHOD(ReflectionParameter, isPromoted)
+{
+	reflection_object *intern;
+	parameter_reference *param;
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_THROWS();
+	}
+	GET_REFLECTION_OBJECT_PTR(param);
+
+	RETVAL_BOOL(ZEND_ARG_IS_PROMOTED(param->arg_info));
+}
+/* }}} */
+
 /* {{{ proto public bool ReflectionType::allowsNull()
   Returns whether parameter MAY be null */
 ZEND_METHOD(ReflectionType, allowsNull)

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -5461,6 +5461,14 @@ ZEND_METHOD(ReflectionProperty, isDefault)
 }
 /* }}} */
 
+/* {{{ proto public bool ReflectionProperty::isPromoted()
+   Returns whether this property has been promoted from a constructor */
+ZEND_METHOD(ReflectionProperty, isPromoted)
+{
+	_property_check_flag(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_ACC_PROMOTED);
+}
+/* }}} */
+
 /* {{{ proto public int ReflectionProperty::getModifiers()
    Returns a bitfield of the access modifiers for this property */
 ZEND_METHOD(ReflectionProperty, getModifiers)

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -413,6 +413,8 @@ class ReflectionProperty implements Reflector
     /** @return bool */
     public function isDefault() {}
 
+    public function isPromoted(): bool {}
+
     /** @return int */
     public function getModifiers() {}
 

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -555,6 +555,8 @@ class ReflectionParameter implements Reflector
     /** @return bool */
     public function isVariadic() {}
 
+    public function isPromoted(): bool {}
+
     /** @return ReflectionAttribute[] */
     public function getAttributes(?string $name = null, int $flags = 0): array {}
 }

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -402,6 +402,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionParameter_isVariadic arginfo_class_ReflectionFunctionAbstract___clone
 
+#define arginfo_class_ReflectionParameter_isPromoted arginfo_class_ReflectionProperty_isPromoted
+
 #define arginfo_class_ReflectionParameter_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
 
 #define arginfo_class_ReflectionType___clone arginfo_class_ReflectionFunctionAbstract___clone
@@ -647,6 +649,7 @@ ZEND_METHOD(ReflectionParameter, getDefaultValue);
 ZEND_METHOD(ReflectionParameter, isDefaultValueConstant);
 ZEND_METHOD(ReflectionParameter, getDefaultValueConstantName);
 ZEND_METHOD(ReflectionParameter, isVariadic);
+ZEND_METHOD(ReflectionParameter, isPromoted);
 ZEND_METHOD(ReflectionParameter, getAttributes);
 ZEND_METHOD(ReflectionType, allowsNull);
 ZEND_METHOD(ReflectionType, __toString);
@@ -907,6 +910,7 @@ static const zend_function_entry class_ReflectionParameter_methods[] = {
 	ZEND_ME(ReflectionParameter, isDefaultValueConstant, arginfo_class_ReflectionParameter_isDefaultValueConstant, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionParameter, getDefaultValueConstantName, arginfo_class_ReflectionParameter_getDefaultValueConstantName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionParameter, isVariadic, arginfo_class_ReflectionParameter_isVariadic, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionParameter, isPromoted, arginfo_class_ReflectionParameter_isPromoted, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionParameter, getAttributes, arginfo_class_ReflectionParameter_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -312,6 +312,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionProperty_isDefault arginfo_class_ReflectionFunctionAbstract___clone
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionProperty_isPromoted, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_ReflectionProperty_getModifiers arginfo_class_ReflectionFunctionAbstract___clone
 
 #define arginfo_class_ReflectionProperty_getDeclaringClass arginfo_class_ReflectionFunctionAbstract___clone
@@ -324,8 +327,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionProperty_hasType arginfo_class_ReflectionFunctionAbstract___clone
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionProperty_hasDefaultValue, 0, 0, _IS_BOOL, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_ReflectionProperty_hasDefaultValue arginfo_class_ReflectionProperty_isPromoted
 
 #define arginfo_class_ReflectionProperty_getDefaultValue arginfo_class_ReflectionFunctionAbstract___clone
 
@@ -604,6 +606,7 @@ ZEND_METHOD(ReflectionProperty, isPrivate);
 ZEND_METHOD(ReflectionProperty, isProtected);
 ZEND_METHOD(ReflectionProperty, isStatic);
 ZEND_METHOD(ReflectionProperty, isDefault);
+ZEND_METHOD(ReflectionProperty, isPromoted);
 ZEND_METHOD(ReflectionProperty, getModifiers);
 ZEND_METHOD(ReflectionProperty, getDeclaringClass);
 ZEND_METHOD(ReflectionProperty, getDocComment);
@@ -851,6 +854,7 @@ static const zend_function_entry class_ReflectionProperty_methods[] = {
 	ZEND_ME(ReflectionProperty, isProtected, arginfo_class_ReflectionProperty_isProtected, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isStatic, arginfo_class_ReflectionProperty_isStatic, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isDefault, arginfo_class_ReflectionProperty_isDefault, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionProperty, isPromoted, arginfo_class_ReflectionProperty_isPromoted, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, getModifiers, arginfo_class_ReflectionProperty_getModifiers, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, getDeclaringClass, arginfo_class_ReflectionProperty_getDeclaringClass, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, getDocComment, arginfo_class_ReflectionProperty_getDocComment, ZEND_ACC_PUBLIC)

--- a/ext/reflection/tests/bug71767.phpt
+++ b/ext/reflection/tests/bug71767.phpt
@@ -27,17 +27,26 @@ $func = function(
 ) {
 };
 
+/** Correct docblock */
+$func2 = fn(
+    /** wrong docblock */
+    $arg
+) => null;
+
 $reflectionFunction = new ReflectionFunction('foo');
 $reflectionClass = new ReflectionClass(Foo::class);
 $reflectionClosure = new ReflectionFunction($func);
+$reflectionArrowFn = new ReflectionFunction($func2);
 
 echo $reflectionFunction->getDocComment() . PHP_EOL;
 echo $reflectionClass->getMethod('bar')->getDocComment() . PHP_EOL;
 echo $reflectionClosure->getDocComment() . PHP_EOL;
+echo $reflectionArrowFn->getDocComment() . PHP_EOL;
 
 echo "Done\n";
 ?>
 --EXPECT--
+/** Correct docblock */
 /** Correct docblock */
 /** Correct docblock */
 /** Correct docblock */

--- a/ext/reflection/tests/constructor_promotion.phpt
+++ b/ext/reflection/tests/constructor_promotion.phpt
@@ -15,6 +15,7 @@ $rc = new ReflectionClass(Test::class);
 echo $rc, "\n";
 
 $y = $rc->getProperty('y');
+var_dump($y->isPromoted());
 var_dump($y->getDocComment());
 
 ?>
@@ -48,4 +49,5 @@ Class [ <user> class Test ] {
   }
 }
 
+bool(true)
 string(24) "/** @SomeAnnotation() */"

--- a/ext/reflection/tests/constructor_promotion.phpt
+++ b/ext/reflection/tests/constructor_promotion.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Using Reflection on promoted properties
+--FILE--
+<?php
+
+class Test {
+    public function __construct(
+        public int $x,
+        /** @SomeAnnotation() */
+        public string $y = "123"
+    ) {}
+}
+
+$rc = new ReflectionClass(Test::class);
+echo $rc, "\n";
+
+$y = $rc->getProperty('y');
+var_dump($y->getDocComment());
+
+?>
+--EXPECTF--
+Class [ <user> class Test ] {
+  @@ %s 3-9
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [2] {
+    Property [ public int $x ]
+    Property [ public string $y ]
+  }
+
+  - Methods [1] {
+    Method [ <user, ctor> public method __construct ] {
+      @@ %s 4 - 8
+
+      - Parameters [2] {
+        Parameter #0 [ <required> int $x ]
+        Parameter #1 [ <optional> string $y = '123' ]
+      }
+    }
+  }
+}
+
+bool(false)

--- a/ext/reflection/tests/constructor_promotion.phpt
+++ b/ext/reflection/tests/constructor_promotion.phpt
@@ -4,10 +4,12 @@ Using Reflection on promoted properties
 <?php
 
 class Test {
+    public $z;
     public function __construct(
         public int $x,
         /** @SomeAnnotation() */
-        public string $y = "123"
+        public string $y = "123",
+        string $z = "abc",
     ) {}
 }
 
@@ -17,11 +19,20 @@ echo $rc, "\n";
 $y = $rc->getProperty('y');
 var_dump($y->isPromoted());
 var_dump($y->getDocComment());
+$z = $rc->getProperty('z');
+var_dump($z->isPromoted());
+
+echo "\n";
+
+$rp = new ReflectionParameter([Test::class, '__construct'], 'y');
+var_dump($rp->isPromoted());
+$rp = new ReflectionParameter([Test::class, '__construct'], 'z');
+var_dump($rp->isPromoted());
 
 ?>
 --EXPECTF--
 Class [ <user> class Test ] {
-  @@ %s 3-9
+  @@ %s 3-11
 
   - Constants [0] {
   }
@@ -32,18 +43,20 @@ Class [ <user> class Test ] {
   - Static methods [0] {
   }
 
-  - Properties [2] {
+  - Properties [3] {
+    Property [ public $z = NULL ]
     Property [ public int $x ]
     Property [ public string $y ]
   }
 
   - Methods [1] {
     Method [ <user, ctor> public method __construct ] {
-      @@ %s 4 - 8
+      @@ %s 5 - 10
 
-      - Parameters [2] {
+      - Parameters [3] {
         Parameter #0 [ <required> int $x ]
         Parameter #1 [ <optional> string $y = '123' ]
+        Parameter #2 [ <optional> string $z = 'abc' ]
       }
     }
   }
@@ -51,3 +64,7 @@ Class [ <user> class Test ] {
 
 bool(true)
 string(24) "/** @SomeAnnotation() */"
+bool(false)
+
+bool(true)
+bool(false)

--- a/ext/reflection/tests/constructor_promotion.phpt
+++ b/ext/reflection/tests/constructor_promotion.phpt
@@ -48,4 +48,4 @@ Class [ <user> class Test ] {
   }
 }
 
-bool(false)
+string(24) "/** @SomeAnnotation() */"


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/constructor_promotion

As recently discussed on list, this implements the following short hand syntax:

```php
class Point {
    public function __construct(
        public float $x = 0.0,
        public float $y = 0.0,
        public float $z = 0.0,
    ) {}
}
```

This desugars to:

```php
class Point {
    public float $x;
    public float $y;
    public float $z;

    public function __construct(
        float $x = 0.0,
        float $y = 0.0,
        float $z = 0.0
    ) {
        $this->x = $x;
        $this->y = $y;
        $this->z = $z;
    }
}
```