### PR TITLE
Fix Bug #79410 and add test for it

### DIFF
--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -158,7 +158,7 @@ PHPAPI int php_exec(int type, char *cmd, zval *array, zval *return_value)
 		}
 		if (bufl) {
 			/* output remaining data in buffer */
-			if (type == 1) {
+			if (type == 1 && buf != b) {
 				PHPWRITE(buf, bufl);
 				if (php_output_get_level() < 1) {
 					sapi_flush();

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -157,6 +157,13 @@ PHPAPI int php_exec(int type, char *cmd, zval *array, zval *return_value)
 			b = buf;
 		}
 		if (bufl) {
+			/* output remaining data in buffer */
+			if (type == 1) {
+				PHPWRITE(buf, bufl);
+				if (php_output_get_level() < 1) {
+					sapi_flush();
+				}
+			}
 			/* strip trailing whitespaces if we have not done so already */
 			if ((type == 2 && buf != b) || type != 2) {
 				l = bufl;

--- a/ext/standard/tests/bug79410.phpt
+++ b/ext/standard/tests/bug79410.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #79410 (system() swallows last chunk if it is exactly 4095 bytes without newline)
+--FILE--
+<?php
+    ob_start();
+    system(getenv('TEST_PHP_EXECUTABLE') . " -n -r 'echo str_repeat(\".\", 4095);'");
+    var_dump(strlen(ob_get_clean()));
+?>
+--EXPECT--
+int(4095)

--- a/ext/standard/tests/bug79410.phpt
+++ b/ext/standard/tests/bug79410.phpt
@@ -3,7 +3,7 @@ Bug #79410 (system() swallows last chunk if it is exactly 4095 bytes without new
 --FILE--
 <?php
     ob_start();
-    system(getenv('TEST_PHP_EXECUTABLE') . " -n -r 'echo str_repeat(\".\", 4095);'");
+    system(getenv('TEST_PHP_EXECUTABLE') . ' -n -r "echo str_repeat(\".\", 4095);"');
     var_dump(strlen(ob_get_clean()));
 ?>
 --EXPECT--


### PR DESCRIPTION
A fix for bug #79410 (system() swallows last chunk if it is exactly 4095 bytes without newline)