### PR TITLE
Cast values during array destructuring

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -427,6 +427,8 @@ PHP 8.0 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/variable_syntax_tweaks
   . Added Stringable.
     RFC: https://wiki.php.net/rfc/stringable
+  . Added type casting in array destructuring expressions.
+    RFC: https://wiki.php.net/rfc/typecast_array_desctructuring
 
 - Date:
   . Added DateTime::createFromInterface() and

--- a/Zend/tests/list/list_casting_001.phpt
+++ b/Zend/tests/list/list_casting_001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+"Cast during unpacking - general" list()
+--FILE--
+<?php
+$arr = [1, 2, 3, 4];
+
+list((string) $a, (bool) $b, (float) $c, $d) = $arr;
+var_dump($a, $b, $c, $d);
+
+[(string) $a, (bool) $b, (float) $c, $d] = $arr;
+var_dump($a, $b, $c, $d);
+?>
+--EXPECT--
+string(1) "1"
+bool(true)
+float(3)
+int(4)
+string(1) "1"
+bool(true)
+float(3)
+int(4)

--- a/Zend/tests/list/list_casting_002.phpt
+++ b/Zend/tests/list/list_casting_002.phpt
@@ -1,0 +1,21 @@
+--TEST--
+"Cast during unpacking - non existing values" list()
+--FILE--
+<?php
+$arr = [];
+
+@list((string) $a, (bool) $b, (float) $c, $d) = $arr;
+var_dump($a, $b, $c, $d);
+
+@[(string) $a, (bool) $b, (float) $c, $d] = $arr;
+var_dump($a, $b, $c, $d);
+?>
+--EXPECT--
+string(0) ""
+bool(false)
+float(0)
+NULL
+string(0) ""
+bool(false)
+float(0)
+NULL

--- a/Zend/tests/list/list_casting_003.phpt
+++ b/Zend/tests/list/list_casting_003.phpt
@@ -1,0 +1,21 @@
+--TEST--
+"Cast during unpacking - nested unpacking" list()
+--FILE--
+<?php
+$arr = [1, [2, 3], 4];
+
+list((string) $a, list((bool) $b, (float) $c), $d) = $arr;
+var_dump($a, $b, $c, $d);
+
+[(string) $a, [(bool) $b, (float) $c], $d] = $arr;
+var_dump($a, $b, $c, $d);
+?>
+--EXPECT--
+string(1) "1"
+bool(true)
+float(3)
+int(4)
+string(1) "1"
+bool(true)
+float(3)
+int(4)

--- a/Zend/tests/list/list_casting_004.phpt
+++ b/Zend/tests/list/list_casting_004.phpt
@@ -1,0 +1,21 @@
+--TEST--
+"Cast during unpacking - associative unpacking" list()
+--FILE--
+<?php
+$arr = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4];
+
+list('a' => (string) $a, 'b' => (bool) $b, 'c' => (float) $c, 'd' => $d) = $arr;
+var_dump($a, $b, $c, $d);
+
+['a' => (string) $a, 'b' => (bool) $b, 'c' => (float) $c, 'd' => $d] = $arr;
+var_dump($a, $b, $c, $d);
+?>
+--EXPECT--
+string(1) "1"
+bool(true)
+float(3)
+int(4)
+string(1) "1"
+bool(true)
+float(3)
+int(4)

--- a/Zend/tests/list/list_casting_005.phpt
+++ b/Zend/tests/list/list_casting_005.phpt
@@ -1,0 +1,21 @@
+--TEST--
+"Cast during unpacking - nested associative unpacking" list()
+--FILE--
+<?php
+$arr = ['a' => 1, 'b' => ['b1' => 2, 'b2' => 3], 'c' => 4];
+
+list('a' => (string) $a, 'b' => list('b1' => (bool) $b, 'b2' => (float) $c), 'c' => $d) = $arr;
+var_dump($a, $b, $c, $d);
+
+['a' => (string) $a, 'b' => ['b1' => (bool) $b, 'b2' => (float) $c], 'c' => $d] = $arr;
+var_dump($a, $b, $c, $d);
+?>
+--EXPECT--
+string(1) "1"
+bool(true)
+float(3)
+int(4)
+string(1) "1"
+bool(true)
+float(3)
+int(4)

--- a/Zend/tests/list/list_casting_006.phpt
+++ b/Zend/tests/list/list_casting_006.phpt
@@ -1,0 +1,27 @@
+--TEST--
+"Cast during unpacking - foreach loop" list()
+--FILE--
+<?php
+$arr = [[1, 2, 3], [4, 5, 6]];
+
+foreach ($arr as list((string) $a, (bool) $b, $c)) {
+    var_dump($a, $b, $c);
+}
+
+foreach ($arr as [(string) $a, (bool) $b, $c]) {
+    var_dump($a, $b, $c);
+}
+?>
+--EXPECT--
+string(1) "1"
+bool(true)
+int(3)
+string(1) "4"
+bool(true)
+int(6)
+string(1) "1"
+bool(true)
+int(3)
+string(1) "4"
+bool(true)
+int(6)


### PR DESCRIPTION
Adds the possibility to cast values while using array or list destructuring expressions.

RFC can be found at: https://wiki.php.net/rfc/typecast_array_desctructuring