### PR TITLE
Use ZPP callable check in spl_autoload_register

### DIFF
--- a/Zend/tests/bug78868.phpt
+++ b/Zend/tests/bug78868.phpt
@@ -21,7 +21,7 @@ function main_autoload($class_name) {
     eval("class B {const foo = 1;}");
 }
 
-spl_autoload_register('main_autoload', false);
+spl_autoload_register('main_autoload');
 
 $classA = new ReflectionClass("A");
 $props = $classA->getProperties();

--- a/ext/spl/php_spl.stub.php
+++ b/ext/spl/php_spl.stub.php
@@ -17,7 +17,7 @@ function spl_autoload_extensions(?string $file_extensions = null): string {}
 
 function spl_autoload_functions(): array|false {}
 
-function spl_autoload_register($autoload_function = null, bool $throw = true, bool $prepend = false): bool {}
+function spl_autoload_register(?callable $autoload_function = null, bool $throw = true, bool $prepend = false): bool {}
 
 function spl_autoload_unregister($autoload_function): bool {}
 

--- a/ext/spl/php_spl_arginfo.h
+++ b/ext/spl/php_spl_arginfo.h
@@ -29,7 +29,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_spl_autoload_functions, 0, 0, MA
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_register, 0, 0, _IS_BOOL, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, autoload_function, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload_function, IS_CALLABLE, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, throw, _IS_BOOL, 0, "true")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, prepend, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()

--- a/ext/spl/tests/spl_autoload_001.phpt
+++ b/ext/spl/tests/spl_autoload_001.phpt
@@ -64,13 +64,10 @@ var_dump(class_exists("TestClass", true));
 
 echo "===NOFUNCTION===\n";
 
-try
-{
+try {
     spl_autoload_register("unavailable_autoload_function");
-}
-catch(Exception $e)
-{
-    echo 'Exception: ' . $e->getMessage() . "\n";
+} catch(\TypeError $e) {
+    echo $e->getMessage() . \PHP_EOL;
 }
 
 ?>
@@ -103,4 +100,4 @@ TestFunc2(TestClass)
 %stestclass.class.inc
 bool(true)
 ===NOFUNCTION===
-Exception: Function 'unavailable_autoload_function' not found (function 'unavailable_autoload_function' not found or invalid function name)
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, function 'unavailable_autoload_function' not found or invalid function name

--- a/ext/spl/tests/spl_autoload_005.phpt
+++ b/ext/spl/tests/spl_autoload_005.phpt
@@ -19,13 +19,10 @@ class MyAutoLoader {
         }
 }
 
-try
-{
+try {
     spl_autoload_register(array('MyAutoLoader', 'autoLoad'), true);
-}
-catch(Exception $e)
-{
-    echo 'Exception: ' . $e->getMessage() . "\n";
+} catch(\TypeError $e) {
+    echo $e->getMessage() . \PHP_EOL;
 }
 
 // and
@@ -46,7 +43,7 @@ catch(Exception $e)
 
 ?>
 --EXPECT--
-Exception: Passed array specifies a non static method but no object (non-static method MyAutoLoader::autoLoad() cannot be called statically)
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, non-static method MyAutoLoader::autoLoad() cannot be called statically
 MyAutoLoader::autoLoad(TestClass)
 MyAutoLoader::autoThrow(TestClass)
 Exception: Unavailable

--- a/ext/spl/tests/spl_autoload_007.phpt
+++ b/ext/spl/tests/spl_autoload_007.phpt
@@ -40,31 +40,28 @@ $funcs = array(
 foreach($funcs as $idx => $func)
 {
     if ($idx) echo "\n";
-    try
-    {
+    try {
         var_dump($func);
         spl_autoload_register($func);
         echo "ok\n";
-    }
-    catch (Exception $e)
-    {
-        echo $e->getMessage() . "\n";
+    } catch(\TypeError $e) {
+        echo $e->getMessage() . \PHP_EOL;
     }
 }
 
 ?>
 --EXPECTF--
 string(22) "MyAutoLoader::notExist"
-Function 'MyAutoLoader::notExist' not found (class 'MyAutoLoader' does not have a method 'notExist')
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, class 'MyAutoLoader' does not have a method 'notExist'
 
 string(22) "MyAutoLoader::noAccess"
-Function 'MyAutoLoader::noAccess' not callable (cannot access protected method MyAutoLoader::noAccess())
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, cannot access protected method MyAutoLoader::noAccess()
 
 string(22) "MyAutoLoader::autoLoad"
 ok
 
 string(22) "MyAutoLoader::dynaLoad"
-Function 'MyAutoLoader::dynaLoad' not callable (non-static method MyAutoLoader::dynaLoad() cannot be called statically)
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, non-static method MyAutoLoader::dynaLoad() cannot be called statically
 
 array(2) {
   [0]=>
@@ -72,7 +69,7 @@ array(2) {
   [1]=>
   string(8) "notExist"
 }
-Passed array does not specify an existing static method (class 'MyAutoLoader' does not have a method 'notExist')
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, class 'MyAutoLoader' does not have a method 'notExist'
 
 array(2) {
   [0]=>
@@ -80,7 +77,7 @@ array(2) {
   [1]=>
   string(8) "noAccess"
 }
-Passed array does not specify a callable static method (cannot access protected method MyAutoLoader::noAccess())
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, cannot access protected method MyAutoLoader::noAccess()
 
 array(2) {
   [0]=>
@@ -96,7 +93,7 @@ array(2) {
   [1]=>
   string(8) "dynaLoad"
 }
-Passed array specifies a non static method but no object (non-static method MyAutoLoader::dynaLoad() cannot be called statically)
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, non-static method MyAutoLoader::dynaLoad() cannot be called statically
 
 array(2) {
   [0]=>
@@ -105,7 +102,7 @@ array(2) {
   [1]=>
   string(8) "notExist"
 }
-Passed array does not specify an existing method (class 'MyAutoLoader' does not have a method 'notExist')
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, class 'MyAutoLoader' does not have a method 'notExist'
 
 array(2) {
   [0]=>
@@ -114,7 +111,7 @@ array(2) {
   [1]=>
   string(8) "noAccess"
 }
-Passed array does not specify a callable static method (cannot access protected method MyAutoLoader::noAccess())
+spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, cannot access protected method MyAutoLoader::noAccess()
 
 array(2) {
   [0]=>

--- a/ext/spl/tests/spl_autoload_008.phpt
+++ b/ext/spl/tests/spl_autoload_008.phpt
@@ -52,10 +52,8 @@ foreach($funcs as $idx => $func)
 
             var_dump(class_exists("NoExistingTestClass", true));
         }
-    }
-    catch (Exception $e)
-    {
-        echo get_class($e) . ": " . $e->getMessage() . "\n";
+    } catch(\TypeError|\Exception $e) {
+        echo get_class($e) . ': ' . $e->getMessage() . \PHP_EOL;
     }
 
     spl_autoload_unregister($func);
@@ -78,7 +76,7 @@ Exception: Bla
 int(0)
 ====2====
 string(22) "MyAutoLoader::dynaLoad"
-LogicException: Function 'MyAutoLoader::dynaLoad' not callable (non-static method MyAutoLoader::dynaLoad() cannot be called statically)
+TypeError: spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, non-static method MyAutoLoader::dynaLoad() cannot be called statically
 int(0)
 ====3====
 array(2) {
@@ -98,7 +96,7 @@ array(2) {
   [1]=>
   string(8) "dynaLoad"
 }
-LogicException: Passed array specifies a non static method but no object (non-static method MyAutoLoader::dynaLoad() cannot be called statically)
+TypeError: spl_autoload_register(): Argument #1 ($autoload_function) must be a valid callback, non-static method MyAutoLoader::dynaLoad() cannot be called statically
 int(0)
 ====5====
 array(2) {

--- a/ext/spl/tests/spl_autoload_throw_with_spl_autoloader_call_as_autoloader.phpt
+++ b/ext/spl/tests/spl_autoload_throw_with_spl_autoloader_call_as_autoloader.phpt
@@ -1,0 +1,14 @@
+--TEST--
+spl_autoload_register() function - warn when using spl_autoload_call() as the autoloading function
+--FILE--
+<?php
+
+try {
+    spl_autoload_register('spl_autoload_call');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+?>
+--EXPECT--
+spl_autoload_register(): Argument #1 ($autoload_function) must not be the spl_autoload_call() function

--- a/ext/spl/tests/spl_autoload_warn_on_false_do_throw.phpt
+++ b/ext/spl/tests/spl_autoload_warn_on_false_do_throw.phpt
@@ -1,0 +1,16 @@
+--TEST--
+spl_autoload_register() function - warn when using false as second argument for spl_autoload_register()
+--FILE--
+<?php
+function customAutolader($class) {
+    require_once __DIR__ . '/testclass.class.inc';
+}
+spl_autoload_register('customAutolader', false);
+
+spl_autoload_call('TestClass');
+var_dump(class_exists('TestClass', false));
+?>
+--EXPECTF--
+Notice: spl_autoload_register(): Argument #2 ($do_throw) has been ignored, spl_autoload_register() will always throw in %s on line %d
+%stestclass.class.inc
+bool(true)


### PR DESCRIPTION
This also provides more useful information as to why the callable is invalid.

Adds a warning mentioning that the second parameter is ignored when passed false.