### PR TITLE
Explicitly declare the char as signed in zend_ffi_val.

### DIFF
--- a/ext/ffi/php_ffi.h
+++ b/ext/ffi/php_ffi.h
@@ -198,7 +198,7 @@ typedef struct _zend_ffi_val {
 		uint64_t        u64;
 		int64_t         i64;
 		zend_ffi_double d;
-		char            ch;
+		signed char     ch;
 		struct {
 			const char *str;
 			size_t      len;


### PR DESCRIPTION
This causes issues down the line as char are unsigned on some platforms,
e.g. ARM and cause a [-Wtype-limits] warning to be emitted.

I believe this would fix the FFI compilation warning on ARM presented in #5151 