### PR TITLE
[RFC] Autoload Classmap

### DIFF
--- a/Zend/tests/autoloading/Bar.php
+++ b/Zend/tests/autoloading/Bar.php
@@ -1,0 +1,7 @@
+<?php
+
+    class Bar {
+
+    }
+
+    

--- a/Zend/tests/autoloading/Foo.php
+++ b/Zend/tests/autoloading/Foo.php
@@ -1,0 +1,6 @@
+<?php
+
+    class Foo {
+
+    }
+

--- a/Zend/tests/autoloading/autoloading_classmap_001.phpt
+++ b/Zend/tests/autoloading/autoloading_classmap_001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Tests autoloading from a classmap
+--FILE--
+<?php
+
+    autoload_classmap([
+        Foo::class => __DIR__ . '/Foo.php'
+    ]);
+
+    autoload_classmap([
+        Bar::class => __DIR__ . '/Bar.php'
+    ]);
+
+    new Foo();
+    new Bar();
+
+    echo 'Done';
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/autoloading/autoloading_classmap_002.phpt
+++ b/Zend/tests/autoloading/autoloading_classmap_002.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Tests autoloading from a classmap still allows autoloader to run
+--FILE--
+<?php
+
+    autoload_classmap([
+        Foo::class => __DIR__ . '/Foo.php'
+    ]);
+
+    spl_autoload_register(function($class_id) {
+        if ($class_id === 'Bar') {
+            echo "Including Bar from autoloader\n";
+            require_once __DIR__ . '/Bar.php';
+        }
+    });
+
+    new Bar();
+
+    echo 'Done';
+
+?>
+--EXPECTF--
+Notice: Cannot find bar in the autoload classmap in %s on line %d
+Including Bar from autoloader
+Done

--- a/Zend/tests/autoloading/autoloading_classmap_003.phpt
+++ b/Zend/tests/autoloading/autoloading_classmap_003.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Tests autoloading from a classmap does not interupt autoloader if it is not ste
+--FILE--
+<?php
+
+    spl_autoload_register(function($class_id) {
+        if ($class_id === 'Bar') {
+            echo "Including Bar from autoloader\n";
+            require_once __DIR__ . '/Bar.php';
+        }
+    });
+
+    new Bar();
+
+    echo 'Done';
+
+?>
+--EXPECT--
+Including Bar from autoloader
+Done

--- a/Zend/tests/autoloading/autoloading_classmap_003.phpt
+++ b/Zend/tests/autoloading/autoloading_classmap_003.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Tests autoloading from a classmap does not interupt autoloader if it is not ste
+Tests autoloading from a classmap does not interupt autoloader if it is not set
 --FILE--
 <?php
 

--- a/Zend/tests/autoloading/autoloading_classmap_004.phpt
+++ b/Zend/tests/autoloading/autoloading_classmap_004.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Tests autoloading from a classmap where the keys have already been lowercased
+--FILE--
+<?php
+
+    autoload_classmap(['bar' => __DIR__ . '/Bar.php'], true);
+
+    new Bar();
+
+    echo 'Done';
+
+?>
+--EXPECT--
+Done

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -2367,21 +2367,30 @@ ZEND_FUNCTION(autoload_classmap)
 	zend_string *class_id;
 	zval *class_path;
 	zend_string *lc_name;
+	zend_bool skip_lowercasing = 0;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &map) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_ARRAY_HT(map)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(skip_lowercasing)
+	ZEND_PARSE_PARAMETERS_END();
 	
 	if (EG(autoload_classmap) == NULL) {
 		ALLOC_HASHTABLE(EG(autoload_classmap));
 		zend_hash_init(EG(autoload_classmap), map->nTableSize, NULL, NULL, 0);
 	}
 	
-	ZEND_HASH_FOREACH_STR_KEY_VAL(map, class_id, class_path) {
-		lc_name = zend_string_tolower(class_id);
-		zend_hash_add_or_update(EG(autoload_classmap), lc_name, class_path, HASH_ADD);
-		zend_string_release_ex(lc_name, 0);
-	} ZEND_HASH_FOREACH_END();
+	/* userland can save on processing by passing a lowercase list */
+	if (skip_lowercasing) {
+		zend_hash_merge(EG(autoload_classmap), map, NULL, 1);
+	}
+	else {
+		ZEND_HASH_FOREACH_STR_KEY_VAL(map, class_id, class_path) {
+			lc_name = zend_string_tolower(class_id);
+			zend_hash_add_or_update(EG(autoload_classmap), lc_name, class_path, HASH_ADD);
+			zend_string_release_ex(lc_name, 0);
+		} ZEND_HASH_FOREACH_END();
+	}
 	
 	RETURN_TRUE;
 }

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -99,6 +99,8 @@ function extension_loaded(string $extension_name): bool {}
 
 function get_extension_funcs(string $extension_name): array|false {}
 
+function autoload_classmap(array $map): bool { }
+
 #if ZEND_DEBUG && defined(ZTS)
 function zend_thread_id(): int {}
 #endif

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -99,7 +99,7 @@ function extension_loaded(string $extension_name): bool {}
 
 function get_extension_funcs(string $extension_name): array|false {}
 
-function autoload_classmap(array $map): bool { }
+function autoload_classmap(array $map, bool $skip_lowercasing = false): bool { }
 
 #if ZEND_DEBUG && defined(ZTS)
 function zend_thread_id(): int {}

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -179,6 +179,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_get_extension_funcs, 0, 1, MAY_B
 	ZEND_ARG_TYPE_INFO(0, extension_name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_autoload_classmap, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, map, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 #if ZEND_DEBUG && defined(ZTS)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_thread_id, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -181,6 +181,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_autoload_classmap, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, map, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, skip_lowercasing, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 #if ZEND_DEBUG && defined(ZTS)

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4080,7 +4080,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_array(zend_ar
 
 #define ZEND_FAKE_OP_ARRAY ((zend_op_array*)(zend_intptr_t)-1)
 
-static zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval *inc_filename, int type) /* {{{ */
+zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval *inc_filename, int type) /* {{{ */
 {
 	zend_op_array *new_op_array = NULL;
 	zval tmp_inc_filename;

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -48,6 +48,7 @@ ZEND_API int zend_eval_string(const char *str, zval *retval_ptr, const char *str
 ZEND_API int zend_eval_stringl(const char *str, size_t str_len, zval *retval_ptr, const char *string_name);
 ZEND_API int zend_eval_string_ex(const char *str, zval *retval_ptr, const char *string_name, int handle_exceptions);
 ZEND_API int zend_eval_stringl_ex(const char *str, size_t str_len, zval *retval_ptr, const char *string_name, int handle_exceptions);
+zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval *inc_filename, int type);
 
 /* export zend_pass_function to allow comparisons against it */
 extern ZEND_API const zend_internal_function zend_pass_function;

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -915,7 +915,9 @@ ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *
 
 		if (classmap_found != NULL) {
 			zend_include_or_eval(classmap_found, ZEND_REQUIRE_ONCE);
-			return zend_hash_find_ptr(EG(class_table), lc_name);
+			ce = zend_hash_find_ptr(EG(class_table), lc_name);
+			zend_string_release_ex(lc_name, 0);
+			return ce;
 		}
 		else {
 			zend_error(E_NOTICE, "Cannot find %s in the autoload classmap", ZSTR_VAL(lc_name));

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -174,6 +174,7 @@ struct _zend_executor_globals {
 
 	HashTable *in_autoload;
 	zend_function *autoload_func;
+	HashTable *autoload_classmap;
 	zend_bool full_tables_cleanup;
 
 	/* for extended information support */

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -1142,7 +1142,7 @@ void php_mysqli_fetch_into_hash_aux(zval *return_value, MYSQL_RES * result, zend
 				my_ulonglong llval;
 				char tmp[22];
 				switch (field_len[i]) {
-					case 8:llvaal = (my_ulonglong)  bit_uint8korr(row[i]);break;
+					case 8:llval = (my_ulonglong)  bit_uint8korr(row[i]);break;
 					case 7:llval = (my_ulonglong)  bit_uint7korr(row[i]);break;
 					case 6:llval = (my_ulonglong)  bit_uint6korr(row[i]);break;
 					case 5:llval = (my_ulonglong)  bit_uint5korr(row[i]);break;

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -1142,7 +1142,7 @@ void php_mysqli_fetch_into_hash_aux(zval *return_value, MYSQL_RES * result, zend
 				my_ulonglong llval;
 				char tmp[22];
 				switch (field_len[i]) {
-					case 8:llval = (my_ulonglong)  bit_uint8korr(row[i]);break;
+					case 8:llvaal = (my_ulonglong)  bit_uint8korr(row[i]);break;
 					case 7:llval = (my_ulonglong)  bit_uint7korr(row[i]);break;
 					case 6:llval = (my_ulonglong)  bit_uint6korr(row[i]);break;
 					case 5:llval = (my_ulonglong)  bit_uint5korr(row[i]);break;


### PR DESCRIPTION
Tools such as composer automatically generate a classmap mapping class names to their file paths. Rather than repeatedly call a user function for each class, why not provide a way to just inject that array into the autoloader?