### PR TITLE
Fix for [-Wtype-limits] compiler warning on 32bits platforms in Sodium extension

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -1952,10 +1952,12 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_encrypt)
 		zend_throw_exception(sodium_exception_ce, "arithmetic overflow", 0);
 		RETURN_THROWS();
 	}
+#if SIZEOF_SIZE_T != 4
 	if ((unsigned long long) msg_len > (16ULL * ((1ULL << 32) - 2ULL)) - crypto_aead_aes256gcm_ABYTES) {
 		zend_throw_exception(sodium_exception_ce, "message too long for a single key", 0);
 		RETURN_THROWS();
 	}
+#endif
 	ciphertext_len = msg_len + crypto_aead_aes256gcm_ABYTES;
 	ciphertext = zend_string_alloc((size_t) ciphertext_len, 0);
 	if (crypto_aead_aes256gcm_encrypt
@@ -2011,10 +2013,12 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_decrypt)
 	if (ciphertext_len < crypto_aead_aes256gcm_ABYTES) {
 		RETURN_FALSE;
 	}
+#if SIZEOF_SIZE_T != 4
 	if (ciphertext_len - crypto_aead_aes256gcm_ABYTES > 16ULL * ((1ULL << 32) - 2ULL)) {
 		zend_argument_error(sodium_exception_ce, 1, "is too long");
 		RETURN_THROWS();
 	}
+#endif
 	msg_len = ciphertext_len;
 	if (msg_len >= SIZE_MAX) {
 		zend_throw_exception(sodium_exception_ce, "arithmetic overflow", 0);
@@ -2187,10 +2191,12 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_encrypt)
 		zend_throw_exception(sodium_exception_ce, "arithmetic overflow", 0);
 		RETURN_THROWS();
 	}
+#if SIZEOF_SIZE_T != 4
 	if ((unsigned long long) msg_len > 64ULL * (1ULL << 32) - 64ULL) {
 		zend_throw_exception(sodium_exception_ce, "message too long for a single key", 0);
 		RETURN_THROWS();
 	}
+#endif
 	ciphertext_len = msg_len + crypto_aead_chacha20poly1305_IETF_ABYTES;
 	ciphertext = zend_string_alloc((size_t) ciphertext_len, 0);
 	if (crypto_aead_chacha20poly1305_ietf_encrypt


### PR DESCRIPTION
To achieve this we use no-op operations which force the conversion to unsigned long long

This was flagged while working on #5151, just putting this up as a PR as a sanity check and see if someone else has a better idea how to go about it.