### PR TITLE
Fix #79413: session_create_id() fails for active sessions

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2285,7 +2285,7 @@ static PHP_FUNCTION(session_create_id)
 				break;
 			} else {
 				/* Detect collision and retry */
-				if (PS(mod)->s_validate_sid(&PS(mod_data), new_id) == FAILURE) {
+				if (PS(mod)->s_validate_sid(&PS(mod_data), new_id) == SUCCESS) {
 					zend_string_release_ex(new_id, 0);
                     new_id = NULL;
 					continue;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2223,7 +2223,7 @@ static PHP_FUNCTION(session_regenerate_id)
 		RETURN_FALSE;
 	}
 	if (PS(use_strict_mode) && PS(mod)->s_validate_sid &&
-		PS(mod)->s_validate_sid(&PS(mod_data), PS(id)) == FAILURE) {
+		PS(mod)->s_validate_sid(&PS(mod_data), PS(id)) == SUCCESS) {
 		zend_string_release_ex(PS(id), 0);
 		PS(id) = PS(mod)->s_create_sid(&PS(mod_data));
 		if (!PS(id)) {

--- a/ext/session/tests/bug79091.phpt
+++ b/ext/session/tests/bug79091.phpt
@@ -50,7 +50,7 @@ class MySessionHandler implements SessionHandlerInterface, SessionIdInterface, S
 
     public function validateId($key)
     {
-        return false;
+        return true;
     }
 }
 

--- a/ext/session/tests/bug79413.phpt
+++ b/ext/session/tests/bug79413.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #79413 (session_create_id() fails for active sessions)
+--SKIPIF--
+<?php
+if (!extension_loaded('session')) die('skip session extension not available');
+?>
+--FILE--
+<?php
+session_start();
+$old = session_id();
+$new = session_create_id();
+var_dump($new !== $old);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
The comment on `PS_VALIDATE_SID_FUNC(files)` is very clear that the
function is supposed to return `SUCCESS` if the session already exists.
So to detect a collision, we have to check for `SUCCESS`, not
`FAILURE`.