### PR TITLE
Allow optional trailing comma in parameter list

### DIFF
--- a/Zend/tests/func_sig_trailing_comma.phpt
+++ b/Zend/tests/func_sig_trailing_comma.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Trailing comma in function signatures
+--FILE--
+<?php
+
+function test(
+    $there,
+    $are,
+    $many,
+    $params,
+) {
+    echo "Foo\n";
+}
+
+class Test {
+    public function method(
+        $there,
+        $are,
+        $many,
+        $params,
+    ) {
+        echo "Foo\n";
+    }
+}
+
+$func = function(
+    $there,
+    $are,
+    $many,
+    $params,
+) {
+    echo "Foo\n";
+};
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -633,7 +633,7 @@ alt_if_stmt:
 ;
 
 parameter_list:
-		non_empty_parameter_list { $$ = $1; }
+		non_empty_parameter_list possible_comma { $$ = $1; }
 	|	%empty	{ $$ = zend_ast_create_list(0, ZEND_AST_PARAM_LIST); }
 ;
 


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/trailing_comma_in_parameter_list