### PR TITLE
Add missing 'skip' to bug79332.phpt skip message

### DIFF
--- a/ext/com_dotnet/tests/bug79332.phpt
+++ b/ext/com_dotnet/tests/bug79332.phpt
@@ -2,7 +2,7 @@
 Bug #79332 (php_istreams are never freed)
 --SKIPIF--
 <?php
-if (!extension_loaded('com_dotnet')) die('com_dotnet extension not available');
+if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
The skip message must start with the word 'skip', otherwise the test will not be skipped.

**Before:**
Running selected tests.
TEST 1/1 [ext/com_dotnet/tests/bug79332.phpt]
========DIFF========
001+ Fatal error: Uncaught Error: Class 'COMPersistHelper' not found in /srv/php/ext/com_dotnet/tests/bug79332.php:2
001- A com_exception has been thrown
002+ Stack trace:
003+ #0 {main}
004+   thrown in /srv/php/ext/com_dotnet/tests/bug79332.php on line 2
========DONE========
FAIL Bug #79332 (php_istreams are never freed) [ext/com_dotnet/tests/bug79332.phpt]

**After:**
Running selected tests.
SKIP Bug #79332 (php_istreams are never freed) [ext/com_dotnet/tests/bug79332.phpt] reason: com_dotnet extension not available