### PR TITLE
#61877: Make SimpleXMLElement respect PHP's array rule

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -249,7 +249,12 @@ static zval *sxe_prop_dim_read(zval *object, zval *member, zend_bool elements, z
 		goto long_dim;
 	} else {
 		ZVAL_DEREF(member);
-		if (Z_TYPE_P(member) == IS_LONG) {
+		if (Z_TYPE_P(member) == IS_LONG || Z_TYPE_P(member) == IS_DOUBLE) {
+			if (Z_TYPE_P(member) == IS_DOUBLE) {
+				ZVAL_LONG(&tmp_zv, (long) Z_DVAL_P(member));
+				member = &tmp_zv;
+			}
+
 			if (sxe->iter.type != SXE_ITER_ATTRLIST) {
 long_dim:
 				attribs = 0;
@@ -447,7 +452,12 @@ static int sxe_prop_dim_write(zval *object, zval *member, zval *value, zend_bool
 		goto long_dim;
 	} else {
 		ZVAL_DEREF(member);
-		if (Z_TYPE_P(member) == IS_LONG) {
+		if (Z_TYPE_P(member) == IS_LONG || Z_TYPE_P(member) == IS_DOUBLE) {
+			if (Z_TYPE_P(member) == IS_DOUBLE) {
+				ZVAL_LONG(&tmp_zv, (long) Z_DVAL_P(member));
+				member = &tmp_zv;
+			}
+
 			if (sxe->iter.type != SXE_ITER_ATTRLIST) {
 long_dim:
 				attribs = 0;

--- a/ext/simplexml/tests/bug61877.phpt
+++ b/ext/simplexml/tests/bug61877.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #61597: SimpleXMLElement does not respect PHP's array keys cast rule
+--SKIPIF--
+<?php
+if (!extension_loaded('simplexml')) die('skip simplexml extension not available');
+?>
+--FILE--
+<?php
+$simpleXMLElement = simplexml_load_string("<xml><number>0</number><number>1</number></xml>");
+
+$int = 1;
+$float = 1.0;
+
+$simpleXMLElement->number[$float] = 999;
+
+echo $simpleXMLElement->number[$float] . ', ' . $simpleXMLElement->number[$int];
+?>
+--EXPECT--
+999, 999


### PR DESCRIPTION
From the [manual](https://www.php.net/types.array):

> Additionally the following key casts will occur:
> * Floats are also cast to integers, which means that the fractional part will be truncated. E.g. the key 8.7 will actually be stored under 8.