### PR TITLE
Make sure that (self::class)::method() is not forwarding LSB

### DIFF
--- a/Zend/tests/lsb_021.phpt
+++ b/Zend/tests/lsb_021.phpt
@@ -27,7 +27,7 @@ class B extends A {
         
         (self::class)::test();
         call_user_func(self::class . "::test");
-        call_user_func(array("self::class", "test"));
+        call_user_func(array(self::class, "test"));
     }
 }
 

--- a/Zend/tests/lsb_021.phpt
+++ b/Zend/tests/lsb_021.phpt
@@ -26,7 +26,7 @@ class B extends A {
         call_user_func(array("B", "test"));
         
         (self::class)::test();
-        call_user_func("(self::class)::test");
+        call_user_func(self::class . "::test");
         call_user_func(array("self::class", "test"));
     }
 }

--- a/Zend/tests/lsb_021.phpt
+++ b/Zend/tests/lsb_021.phpt
@@ -24,6 +24,10 @@ class B extends A {
         B::test();
         call_user_func("B::test");
         call_user_func(array("B", "test"));
+        
+        (self::class)::test();
+        call_user_func("(self::class)::test");
+        call_user_func(array("self::class", "test"));
     }
 }
 
@@ -45,6 +49,9 @@ C
 A
 A
 A
+B
+B
+B
 B
 B
 B


### PR DESCRIPTION
Related with Bug #79419

No new functionality introduced, make only sure PHP behave how it is expected - can catch mistakes in future optimalizations/JIT.