### PR TITLE
ext/zip: don't use gl_pathc after call to globfree (#79424)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,8 @@ PHP                                                                        NEWS
 
 - Zip:
   . Fixed Bug #79296 (ZipArchive::open fails on empty file). (Remi)
+  . Fixed bug #79424 (php_zip_glob uses gl_pathc after call to globfree).
+    (Max Rees)
 
 19 Mar 2020, PHP 7.3.16
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -606,8 +606,9 @@ int php_zip_glob(char *pattern, int pattern_len, zend_long flags, zval *return_v
 		add_next_index_string(return_value, globbuf.gl_pathv[n]+cwd_skip);
 	}
 
+	ret = globbuf.gl_pathc;
 	globfree(&globbuf);
-	return globbuf.gl_pathc;
+	return ret;
 #else
 	zend_throw_error(NULL, "Glob support is not available");
 	return 0;


### PR DESCRIPTION
This was introduced by b734bf4b97f ("- sync with PECL HEAD"), so 7.2, 7.3, 7.4, and master are affected. I based it against 7.3 per the CONTRIBUTING recommendations.

However, there is still a minor problem here - there is a discrepancy between the types of `globbuf.gl_pathc` (`size_t`) and the return value of `php_zip_glob` (`int`). I wasn't sure how best to correct this so I leave that to the maintainers.