### PR TITLE
#75958: Make `always true` SPL method return void

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -329,9 +329,15 @@ PHP 8.0 UPGRADE NOTES
   . SplHeap::compare($a, $b) now specifies a method signature. Inheriting
     classes implementing this method will now have to use a compatible
     method signature.
-  . SplDoublyLinkedList::push() now returns void instead of true
-  . SplDoublyLinkedList::unshift() now returns void instead of true
-  . SplQueue::enqueue() now returns void instead of true
+  . The following methods now return void instead of true
+
+        SplDoublyLinkedList::push()
+        SplDoublyLinkedList::unshift()
+        SplFixedArray::setSize()
+        SplHeap::insert()
+        SplHeap::recoverFromCorruption()
+        SplPriorityQueue::insert()
+        SplQueue::enqueue()
 
 - Standard:
   . assert() will no longer evaluate string arguments, instead they will be

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -702,7 +702,7 @@ SPL_METHOD(SplFixedArray, getSize)
 }
 /* }}} */
 
-/* {{{ proto bool SplFixedArray::setSize(int size)
+/* {{{ proto void SplFixedArray::setSize(int size)
 */
 SPL_METHOD(SplFixedArray, setSize)
 {
@@ -722,7 +722,6 @@ SPL_METHOD(SplFixedArray, setSize)
 	intern = Z_SPLFIXEDARRAY_P(object);
 
 	spl_fixedarray_resize(&intern->array, size);
-	RETURN_TRUE;
 }
 /* }}} */
 

--- a/ext/spl/spl_fixedarray.stub.php
+++ b/ext/spl/spl_fixedarray.stub.php
@@ -19,7 +19,7 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable
     /** @return int */
     public function getSize() {}
 
-    /** @return bool */
+    /** @return void */
     public function setSize(int $size) {}
 
     /**

--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -602,7 +602,7 @@ SPL_METHOD(SplHeap, isEmpty)
 }
 /* }}} */
 
-/* {{{ proto bool SplHeap::insert(mixed value)
+/* {{{ proto void SplHeap::insert(mixed value)
 	   Push $value on the heap */
 SPL_METHOD(SplHeap, insert)
 {
@@ -622,8 +622,6 @@ SPL_METHOD(SplHeap, insert)
 
 	Z_TRY_ADDREF_P(value);
 	spl_ptr_heap_insert(intern->heap, value, ZEND_THIS);
-
-	RETURN_TRUE;
 }
 /* }}} */
 
@@ -651,7 +649,7 @@ SPL_METHOD(SplHeap, extract)
 }
 /* }}} */
 
-/* {{{ proto bool SplPriorityQueue::insert(mixed value, mixed priority)
+/* {{{ proto void SplPriorityQueue::insert(mixed value, mixed priority)
 	   Push $value with the priority $priodiry on the priorityqueue */
 SPL_METHOD(SplPriorityQueue, insert)
 {
@@ -674,8 +672,6 @@ SPL_METHOD(SplPriorityQueue, insert)
 	ZVAL_COPY(&elem.priority, priority);
 
 	spl_ptr_heap_insert(intern->heap, &elem, ZEND_THIS);
-
-	RETURN_TRUE;
 }
 /* }}} */
 
@@ -776,7 +772,7 @@ SPL_METHOD(SplPriorityQueue, getExtractFlags)
 }
 /* }}} */
 
-/* {{{ proto int SplHeap::recoverFromCorruption()
+/* {{{ proto void SplHeap::recoverFromCorruption()
  Recover from a corrupted state*/
 SPL_METHOD(SplHeap, recoverFromCorruption)
 {
@@ -789,8 +785,6 @@ SPL_METHOD(SplHeap, recoverFromCorruption)
 	intern = Z_SPLHEAP_P(ZEND_THIS);
 
 	intern->heap->flags = intern->heap->flags & ~SPL_HEAP_CORRUPTED;
-
-	RETURN_TRUE;
 }
 /* }}} */
 

--- a/ext/spl/spl_heap.stub.php
+++ b/ext/spl/spl_heap.stub.php
@@ -12,7 +12,7 @@ class SplPriorityQueue implements Iterator, Countable
     /**
      * @param mixed $value
      * @param mixed $priority
-     * @return bool
+     * @return void
      */
     public function insert($value, $priority) {}
 
@@ -63,7 +63,7 @@ abstract class SplHeap implements Iterator, Countable
 
     /**
      * @param mixed $value
-     * @return bool
+     * @return void
      */
     public function insert($value) {}
 
@@ -91,7 +91,7 @@ abstract class SplHeap implements Iterator, Countable
     /** @return bool */
     public function valid() {}
 
-    /** @return bool */
+    /** @return void */
     public function recoverFromCorruption() {}
 
     /**


### PR DESCRIPTION
Motivation: if a method always return true, it's pointless to check if it's gonna succeed or fail someday.