### PR TITLE
Promote unknown encoding warning to ValueError in Mbstring extension

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -323,7 +323,7 @@ static const sapi_post_entry mbstr_post_entries[] = {
 };
 /* }}} */
 
-static const mbfl_encoding *php_mb_get_encoding(zend_string *encoding_name) {
+static const mbfl_encoding *php_mb_get_encoding(zend_string *encoding_name, uint32_t arg_num) {
 	if (encoding_name) {
 		const mbfl_encoding *encoding;
 		zend_string *last_encoding_name = MBSTRG(last_used_encoding_name);
@@ -334,7 +334,7 @@ static const mbfl_encoding *php_mb_get_encoding(zend_string *encoding_name) {
 
 		encoding = mbfl_name2encoding(ZSTR_VAL(encoding_name));
 		if (!encoding) {
-			php_error_docref(NULL, E_WARNING, "Unknown encoding \"%s\"", ZSTR_VAL(encoding_name));
+			zend_argument_value_error(arg_num, "must be a valid encoding, \"%s\" given", ZSTR_VAL(encoding_name));
 			return NULL;
 		}
 
@@ -1390,8 +1390,8 @@ PHP_FUNCTION(mb_internal_encoding)
 	} else {
 		encoding = mbfl_name2encoding(name);
 		if (!encoding) {
-			php_error_docref(NULL, E_WARNING, "Unknown encoding \"%s\"", name);
-			RETURN_FALSE;
+			zend_argument_value_error(1, "must be a valid encoding, \"%s\" given", name);
+			RETURN_THROWS();
 		} else {
 			MBSTRG(current_internal_encoding) = encoding;
 			MBSTRG(internal_encoding_set) = 1;
@@ -1515,8 +1515,8 @@ PHP_FUNCTION(mb_http_output)
 	} else {
 		encoding = mbfl_name2encoding(name);
 		if (!encoding) {
-			php_error_docref(NULL, E_WARNING, "Unknown encoding \"%s\"", name);
-			RETURN_FALSE;
+			zend_argument_value_error(1, "must be a valid encoding, \"%s\" given", name);
+			RETURN_THROWS();
 		} else {
 			MBSTRG(http_output_set) = 1;
 			MBSTRG(current_http_output_encoding) = encoding;
@@ -1666,8 +1666,8 @@ PHP_FUNCTION(mb_preferred_mime_name)
 	} else {
 		no_encoding = mbfl_name2no_encoding(name);
 		if (no_encoding == mbfl_no_encoding_invalid) {
-			php_error_docref(NULL, E_WARNING, "Unknown encoding \"%s\"", name);
-			RETVAL_FALSE;
+			zend_argument_value_error(1, "must be a valid encoding, \"%s\" given", name);
+			RETURN_THROWS();
 		} else {
 			const char *preferred_name = mbfl_no2preferred_mime_name(no_encoding);
 			if (preferred_name == NULL || *preferred_name == '\0') {
@@ -1887,9 +1887,9 @@ PHP_FUNCTION(mb_str_split)
 	string.val = (unsigned char *) ZSTR_VAL(str);
 	string.len = ZSTR_LEN(str);
 	string.no_language = MBSTRG(language);
-	string.encoding = php_mb_get_encoding(encoding);
+	string.encoding = php_mb_get_encoding(encoding, 3);
 	if (!string.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	p = ZSTR_VAL(str); /* string cursor pointer */
@@ -2017,9 +2017,9 @@ PHP_FUNCTION(mb_strlen)
 	string.val = (unsigned char *) str;
 	string.len = str_len;
 	string.no_language = MBSTRG(language);
-	string.encoding = php_mb_get_encoding(enc_name);
+	string.encoding = php_mb_get_encoding(enc_name, 2);
 	if (!string.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = mbfl_strlen(&string);
@@ -2062,9 +2062,9 @@ PHP_FUNCTION(mb_strpos)
 	}
 
 	haystack.no_language = needle.no_language = MBSTRG(language);
-	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name);
+	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name, 4);
 	if (!haystack.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = mbfl_strpos(&haystack, &needle, offset, reverse);
@@ -2090,9 +2090,9 @@ PHP_FUNCTION(mb_strrpos)
 	}
 
 	haystack.no_language = needle.no_language = MBSTRG(language);
-	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name);
+	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name, 4);
 	if (!haystack.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = mbfl_strpos(&haystack, &needle, offset, 1);
@@ -2119,9 +2119,9 @@ PHP_FUNCTION(mb_stripos)
 		RETURN_THROWS();
 	}
 
-	enc = php_mb_get_encoding(from_encoding);
+	enc = php_mb_get_encoding(from_encoding, 4);
 	if (!enc) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = php_mb_stripos(0, (char *)haystack.val, haystack.len, (char *)needle.val, needle.len, offset, enc);
@@ -2149,9 +2149,9 @@ PHP_FUNCTION(mb_strripos)
 		RETURN_THROWS();
 	}
 
-	enc = php_mb_get_encoding(from_encoding);
+	enc = php_mb_get_encoding(from_encoding, 4);
 	if (!enc) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = php_mb_stripos(1, (char *)haystack.val, haystack.len, (char *)needle.val, needle.len, offset, enc);
@@ -2179,9 +2179,9 @@ PHP_FUNCTION(mb_strstr)
 	}
 
 	haystack.no_language = needle.no_language = MBSTRG(language);
-	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name);
+	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name, 4);
 	if (!haystack.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = mbfl_strpos(&haystack, &needle, 0, 0);
@@ -2225,9 +2225,9 @@ PHP_FUNCTION(mb_strrchr)
 	}
 
 	haystack.no_language = needle.no_language = MBSTRG(language);
-	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name);
+	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name, 4);
 	if (!haystack.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = mbfl_strpos(&haystack, &needle, 0, 1);
@@ -2271,9 +2271,9 @@ PHP_FUNCTION(mb_stristr)
 	}
 
 	haystack.no_language = needle.no_language = MBSTRG(language);
-	haystack.encoding = needle.encoding = php_mb_get_encoding(from_encoding);
+	haystack.encoding = needle.encoding = php_mb_get_encoding(from_encoding, 4);
 	if (!haystack.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = php_mb_stripos(0, (char *)haystack.val, haystack.len, (char *)needle.val, needle.len, 0, needle.encoding);
@@ -2317,9 +2317,9 @@ PHP_FUNCTION(mb_strrichr)
 	}
 
 	haystack.no_language = needle.no_language = MBSTRG(language);
-	haystack.encoding = needle.encoding = php_mb_get_encoding(from_encoding);
+	haystack.encoding = needle.encoding = php_mb_get_encoding(from_encoding, 4);
 	if (!haystack.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = php_mb_stripos(1, (char *)haystack.val, haystack.len, (char *)needle.val, needle.len, 0, needle.encoding);
@@ -2362,9 +2362,9 @@ PHP_FUNCTION(mb_substr_count)
 	}
 
 	haystack.no_language = needle.no_language = MBSTRG(language);
-	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name);
+	haystack.encoding = needle.encoding = php_mb_get_encoding(enc_name, 3);
 	if (!haystack.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	if (needle.len == 0) {
@@ -2398,9 +2398,9 @@ PHP_FUNCTION(mb_substr)
 	}
 
 	string.no_language = MBSTRG(language);
-	string.encoding = php_mb_get_encoding(encoding);
+	string.encoding = php_mb_get_encoding(encoding, 4);
 	if (!string.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	string.val = (unsigned char *)str;
@@ -2461,9 +2461,9 @@ PHP_FUNCTION(mb_strcut)
 	}
 
 	string.no_language = MBSTRG(language);
-	string.encoding = php_mb_get_encoding(encoding);
+	string.encoding = php_mb_get_encoding(encoding, 4);
 	if (!string.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	if (len_is_null) {
@@ -2518,9 +2518,9 @@ PHP_FUNCTION(mb_strwidth)
 	}
 
 	string.no_language = MBSTRG(language);
-	string.encoding = php_mb_get_encoding(enc_name);
+	string.encoding = php_mb_get_encoding(enc_name, 2);
 	if (!string.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	n = mbfl_strwidth(&string);
@@ -2547,9 +2547,9 @@ PHP_FUNCTION(mb_strimwidth)
 	}
 
 	string.no_language = marker.no_language = MBSTRG(language);
-	string.encoding = marker.encoding = php_mb_get_encoding(encoding);
+	string.encoding = marker.encoding = php_mb_get_encoding(encoding, 5);
 	if (!string.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	string.val = (unsigned char *)str;
@@ -2784,9 +2784,9 @@ PHP_FUNCTION(mb_convert_encoding)
 		Z_PARAM_STR_OR_ARRAY_HT(from_encodings_str, from_encodings_ht)
 	ZEND_PARSE_PARAMETERS_END();
 
-	to_encoding = php_mb_get_encoding(to_encoding_name);
+	to_encoding = php_mb_get_encoding(to_encoding_name, 2);
 	if (!to_encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	if (from_encodings_ht) {
@@ -2863,9 +2863,9 @@ PHP_FUNCTION(mb_convert_case)
 		RETURN_THROWS();
 	}
 
-	enc = php_mb_get_encoding(from_encoding);
+	enc = php_mb_get_encoding(from_encoding, 3);
 	if (!enc) {
-		return;
+		RETURN_THROWS();
 	}
 
 	if (case_mode < 0 || case_mode > PHP_UNICODE_CASE_MODE_MAX) {
@@ -2900,9 +2900,9 @@ PHP_FUNCTION(mb_strtoupper)
 		RETURN_THROWS();
 	}
 
-	enc = php_mb_get_encoding(from_encoding);
+	enc = php_mb_get_encoding(from_encoding, 2);
 	if (!enc) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	newstr = mbstring_convert_case(PHP_UNICODE_CASE_UPPER, str, str_len, &ret_len, enc);
@@ -2934,9 +2934,9 @@ PHP_FUNCTION(mb_strtolower)
 		RETURN_THROWS();
 	}
 
-	enc = php_mb_get_encoding(from_encoding);
+	enc = php_mb_get_encoding(from_encoding, 2);
 	if (!enc) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	newstr = mbstring_convert_case(PHP_UNICODE_CASE_LOWER, str, str_len, &ret_len, enc);
@@ -3054,8 +3054,8 @@ PHP_FUNCTION(mb_encoding_aliases)
 
 	encoding = mbfl_name2encoding(name);
 	if (!encoding) {
-		php_error_docref(NULL, E_WARNING, "Unknown encoding \"%s\"", name);
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must be a valid encoding, \"%s\" given", name);
+		RETURN_THROWS();
 	}
 
 	array_init(return_value);
@@ -3095,8 +3095,8 @@ PHP_FUNCTION(mb_encode_mimeheader)
 	if (charset_name != NULL) {
 		charset = mbfl_name2encoding(charset_name);
 		if (!charset) {
-			php_error_docref(NULL, E_WARNING, "Unknown encoding \"%s\"", charset_name);
-			RETURN_FALSE;
+			zend_argument_value_error(2, "must be a valid encoding, \"%s\" given", charset_name);
+			RETURN_THROWS();
 		}
 	} else {
 		const mbfl_language *lang = mbfl_no2language(MBSTRG(language));
@@ -3232,9 +3232,9 @@ PHP_FUNCTION(mb_convert_kana)
 
 	/* encoding */
 	string.no_language = MBSTRG(language);
-	string.encoding = php_mb_get_encoding(encname);
+	string.encoding = php_mb_get_encoding(encname, 3);
 	if (!string.encoding) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	ret = mbfl_ja_jp_hantozen(&string, &result, opt);
@@ -3369,8 +3369,8 @@ PHP_FUNCTION(mb_convert_variables)
 	/* new encoding */
 	to_encoding = mbfl_name2encoding(to_enc);
 	if (!to_encoding) {
-		php_error_docref(NULL, E_WARNING, "Unknown encoding \"%s\"", to_enc);
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must be a valid encoding, \"%s\" given", to_enc);
+		RETURN_THROWS();
 	}
 
 	/* initialize string */
@@ -3503,8 +3503,8 @@ php_mb_numericentity_exec(INTERNAL_FUNCTION_PARAMETERS, int type)
 	if (encoding && encoding_len > 0) {
 		string.encoding = mbfl_name2encoding(encoding);
 		if (!string.encoding) {
-			php_error_docref(NULL, E_WARNING, "Unknown encoding \"%s\"", encoding);
-			RETURN_FALSE;
+			zend_argument_value_error(3, "must be a valid encoding, \"%s\" given", encoding);
+			RETURN_THROWS();
 		}
 	}
 
@@ -4353,14 +4353,15 @@ PHP_FUNCTION(mb_check_encoding)
 /* }}} */
 
 
-static inline zend_long php_mb_ord(const char *str, size_t str_len, zend_string *enc_name)
+static inline zend_long php_mb_ord(const char *str, size_t str_len, zend_string *enc_name,
+	const uint32_t enc_name_arg_num)
 {
 	const mbfl_encoding *enc;
 	enum mbfl_no_encoding no_enc;
 
-	enc = php_mb_get_encoding(enc_name);
+	enc = php_mb_get_encoding(enc_name, enc_name_arg_num);
 	if (!enc) {
-		return -1;
+		return -2;
 	}
 
 	no_enc = enc->no_encoding;
@@ -4419,9 +4420,12 @@ PHP_FUNCTION(mb_ord)
 		Z_PARAM_STR(enc)
 	ZEND_PARSE_PARAMETERS_END();
 
-	cp = php_mb_ord(str, str_len, enc);
+	cp = php_mb_ord(str, str_len, enc, 2);
 
 	if (0 > cp) {
+		if (cp == -2) {
+			RETURN_THROWS();
+		}
 		RETURN_FALSE;
 	}
 
@@ -4430,7 +4434,7 @@ PHP_FUNCTION(mb_ord)
 /* }}} */
 
 
-static inline zend_string *php_mb_chr(zend_long cp, zend_string *enc_name)
+static inline zend_string *php_mb_chr(zend_long cp, zend_string *enc_name, uint32_t enc_name_arg_num)
 {
 	const mbfl_encoding *enc;
 	enum mbfl_no_encoding no_enc;
@@ -4438,7 +4442,7 @@ static inline zend_string *php_mb_chr(zend_long cp, zend_string *enc_name)
 	char* buf;
 	size_t buf_len;
 
-	enc = php_mb_get_encoding(enc_name);
+	enc = php_mb_get_encoding(enc_name, enc_name_arg_num);
 	if (!enc) {
 		return NULL;
 	}
@@ -4527,7 +4531,7 @@ PHP_FUNCTION(mb_chr)
 		Z_PARAM_STR(enc)
 	ZEND_PARSE_PARAMETERS_END();
 
-	ret = php_mb_chr(cp, enc);
+	ret = php_mb_chr(cp, enc, 2);
 	if (ret == NULL) {
 		RETURN_FALSE;
 	}
@@ -4559,9 +4563,9 @@ PHP_FUNCTION(mb_scrub)
 		Z_PARAM_STR(enc_name)
 	ZEND_PARSE_PARAMETERS_END();
 
-	enc = php_mb_get_encoding(enc_name);
+	enc = php_mb_get_encoding(enc_name, 2);
 	if (!enc) {
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	ret = php_mb_scrub(str, str_len, enc, &ret_len);

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -855,8 +855,8 @@ PHP_FUNCTION(mb_regex_encoding)
 		mbctype = _php_mb_regex_name2mbctype(encoding);
 
 		if (mbctype == ONIG_ENCODING_UNDEF) {
-			php_error_docref(NULL, E_WARNING, "Unknown encoding \"%s\"", encoding);
-			RETURN_FALSE;
+			zend_argument_value_error(1, "must be a valid encoding, \"%s\" given", encoding);
+			RETURN_THROWS();
 		}
 
 		MBREX(current_mbctype) = mbctype;

--- a/ext/mbstring/tests/bug43998.phpt
+++ b/ext/mbstring/tests/bug43998.phpt
@@ -22,49 +22,38 @@ $sourcestring = 'Hello, World';
 $inputs = array(12345, 12.3456789000E-10, true, false, "");
 $iterator = 1;
 foreach($inputs as $input) {
-  echo "\n-- Iteration $iterator --\n";
-  var_dump( mb_strtolower($sourcestring, $input) );
-  var_dump( mb_strtoupper($sourcestring, $input) );
+    echo "\n-- Iteration $iterator --\n";
+        try {
+            var_dump( mb_strtolower($sourcestring, $input) );
+        } catch (\ValueError $e) {
+            echo $e->getMessage() . \PHP_EOL;
+        }
+        try {
+            var_dump( mb_strtoupper($sourcestring, $input) );
+        } catch (\ValueError $e) {
+            echo $e->getMessage() . \PHP_EOL;
+        }
   $iterator++;
-};
+}
+
 ?>
---EXPECTF--
+--EXPECT--
 -- Iteration 1 --
-
-Warning: mb_strtolower(): Unknown encoding "12345" in %s on line %d
-bool(false)
-
-Warning: mb_strtoupper(): Unknown encoding "12345" in %s on line %d
-bool(false)
+mb_strtolower(): Argument #2 ($encoding) must be a valid encoding, "12345" given
+mb_strtoupper(): Argument #2 ($encoding) must be a valid encoding, "12345" given
 
 -- Iteration 2 --
-
-Warning: mb_strtolower(): Unknown encoding "1.23456789E-9" in %s on line %d
-bool(false)
-
-Warning: mb_strtoupper(): Unknown encoding "1.23456789E-9" in %s on line %d
-bool(false)
+mb_strtolower(): Argument #2 ($encoding) must be a valid encoding, "1.23456789E-9" given
+mb_strtoupper(): Argument #2 ($encoding) must be a valid encoding, "1.23456789E-9" given
 
 -- Iteration 3 --
-
-Warning: mb_strtolower(): Unknown encoding "1" in %s on line %d
-bool(false)
-
-Warning: mb_strtoupper(): Unknown encoding "1" in %s on line %d
-bool(false)
+mb_strtolower(): Argument #2 ($encoding) must be a valid encoding, "1" given
+mb_strtoupper(): Argument #2 ($encoding) must be a valid encoding, "1" given
 
 -- Iteration 4 --
-
-Warning: mb_strtolower(): Unknown encoding "" in %s on line %d
-bool(false)
-
-Warning: mb_strtoupper(): Unknown encoding "" in %s on line %d
-bool(false)
+mb_strtolower(): Argument #2 ($encoding) must be a valid encoding, "" given
+mb_strtoupper(): Argument #2 ($encoding) must be a valid encoding, "" given
 
 -- Iteration 5 --
-
-Warning: mb_strtolower(): Unknown encoding "" in %s on line %d
-bool(false)
-
-Warning: mb_strtoupper(): Unknown encoding "" in %s on line %d
-bool(false)
+mb_strtolower(): Argument #2 ($encoding) must be a valid encoding, "" given
+mb_strtoupper(): Argument #2 ($encoding) must be a valid encoding, "" given

--- a/ext/mbstring/tests/bug79149.phpt
+++ b/ext/mbstring/tests/bug79149.phpt
@@ -6,9 +6,22 @@ if (!extension_loaded('mbstring')) die('skip mbstring extension not available');
 ?>
 --FILE--
 <?php
-var_dump(mb_convert_encoding("", "UTF-8", [0]));
-var_dump(mb_convert_encoding('foo', 'UTF-8', array(['bar'], ['baz'])));
-var_dump(mb_convert_encoding('foo', 'UTF-8', array("foo\0bar")));
+try {
+    var_dump(mb_convert_encoding("", "UTF-8", [0]));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump(mb_convert_encoding('foo', 'UTF-8', array(['bar'], ['baz'])));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump(mb_convert_encoding('foo', 'UTF-8', array("foo\0bar")));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 Warning: mb_convert_encoding(): Unknown encoding "0" in %s on line %d

--- a/ext/mbstring/tests/mb_chr.phpt
+++ b/ext/mbstring/tests/mb_chr.phpt
@@ -12,31 +12,48 @@ var_dump(
 );
 
 // Invalid
-var_dump(
-    mb_chr(0xd800, "typo"),
-    mb_chr(0xd800, "pass"),
-    mb_chr(0xd800, "jis"),
-    mb_chr(0xd800, "cp50222"),
-    mb_chr(0xd800, "utf-7")
-);
+try {
+    var_dump( mb_chr(0xd800, "typo") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump( mb_chr(0xd800, "pass") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump( mb_chr(0xd800, "jis") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump( mb_chr(0xd800, "cp50222") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump( mb_chr(0xd800, "utf-7") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
 bool(true)
 bool(true)
 bool(true)
-
-Warning: mb_chr(): Unknown encoding "typo" in %s on line %d
+mb_chr(): Argument #2 ($encoding) must be a valid encoding, "typo" given
 
 Warning: mb_chr(): Unsupported encoding "pass" in %s on line %d
+bool(false)
 
 Warning: mb_chr(): Unsupported encoding "jis" in %s on line %d
+bool(false)
 
 Warning: mb_chr(): Unsupported encoding "cp50222" in %s on line %d
+bool(false)
 
 Warning: mb_chr(): Unsupported encoding "utf-7" in %s on line %d
-bool(false)
-bool(false)
-bool(false)
-bool(false)
 bool(false)

--- a/ext/mbstring/tests/mb_convert_encoding.phpt
+++ b/ext/mbstring/tests/mb_convert_encoding.phpt
@@ -96,11 +96,14 @@ $s = mb_convert_encoding('', 'EUC-JP');
 print("EUC-JP: $s\n");  // SJIS
 
 $s = $euc_jp;
-$s = mb_convert_encoding($s, 'BAD');
-print("BAD: $s\n"); // BAD
+try {
+    var_dump( mb_convert_encoding($s, 'BAD') );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 == BASIC TEST ==
 EUC-JP: 日本語テキストです。01234５６７８９。
 EUC-JP: 日本語テキストです。01234５６７８９。
@@ -121,6 +124,4 @@ JIS: GyRCRnxLXDhsJUYlLSU5JUgkRyQ5ISMbKEIwMTIzNBskQiM1IzYjNyM4IzkhIxsoQg==
 == INVALID PARAMETER ==
 INT: 1234
 EUC-JP: 
-
-Warning: mb_convert_encoding(): Unknown encoding "BAD" in %s on line %d
-BAD: 
+mb_convert_encoding(): Argument #2 ($to) must be a valid encoding, "BAD" given

--- a/ext/mbstring/tests/mb_encoding_aliases.phpt
+++ b/ext/mbstring/tests/mb_encoding_aliases.phpt
@@ -9,9 +9,14 @@ sort($list);
 var_dump($list);
 var_dump(mb_encoding_aliases("7bit"));
 var_dump(mb_encoding_aliases("8bit"));
-var_dump(mb_encoding_aliases("BAD"));
+
+try {
+    var_dump(mb_encoding_aliases("BAD"));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 ?>
---EXPECTF--
+--EXPECT--
 array(11) {
   [0]=>
   string(14) "ANSI_X3.4-1968"
@@ -42,6 +47,4 @@ array(1) {
   [0]=>
   string(6) "binary"
 }
-
-Warning: mb_encoding_aliases(): Unknown encoding "BAD" in %s on line %d
-bool(false)
+mb_encoding_aliases(): Argument #1 ($encoding) must be a valid encoding, "BAD" given

--- a/ext/mbstring/tests/mb_http_output.phpt
+++ b/ext/mbstring/tests/mb_http_output.phpt
@@ -41,14 +41,18 @@ print "$enc\n";
 // Invalid parameters
 print "== INVALID PARAMETER ==\n";
 
-// Note: Bad string raise Warning. Bad Type raise Notice (Type Conversion) and Warning....
-$r = mb_http_output('BAD_NAME');
-($r === FALSE) ? print "OK_BAD_SET\n" : print "NG_BAD_SET\n";
+// Note: Bad string raise ValueError. Bad Type raise Notice (Type Conversion) and ValueError
+try {
+    $r = mb_http_output('BAD_NAME');
+    print 'NG_BAD_SET' . \PHP_EOL;
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 $enc = mb_http_output();
 print "$enc\n";
 
 ?>
---EXPECTF--
+--EXPECT--
 OK_ASCII_SET
 ASCII
 OK_SJIS_SET
@@ -60,7 +64,5 @@ UTF-8
 OK_EUC-JP_SET
 EUC-JP
 == INVALID PARAMETER ==
-
-Warning: mb_http_output(): Unknown encoding "BAD_NAME" in %s on line %d
-OK_BAD_SET
+mb_http_output(): Argument #1 ($encoding) must be a valid encoding, "BAD_NAME" given
 EUC-JP

--- a/ext/mbstring/tests/mb_internal_encoding.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding.phpt
@@ -30,13 +30,18 @@ print "$enc\n";
 print "== INVALID PARAMETER ==\n";
 
 // Note: Other than string type, PHP raises Warning
-$r = mb_internal_encoding('BAD');
-($r === false) ? print "OK_BAD_SET\n" : print "NG_BAD_SET\n";
+try {
+    $r = mb_internal_encoding('BAD_NAME');
+    print 'NG_BAD_SET' . \PHP_EOL;
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
 $enc = mb_internal_encoding();
 print "$enc\n";
 
 ?>
---EXPECTF--
+--EXPECT--
 OK_EUC-JP_SET
 EUC-JP
 OK_UTF-8_SET
@@ -44,7 +49,5 @@ UTF-8
 OK_ASCII_SET
 ASCII
 == INVALID PARAMETER ==
-
-Warning: mb_internal_encoding(): Unknown encoding "BAD" in %s on line %d
-OK_BAD_SET
+mb_internal_encoding(): Argument #1 ($encoding) must be a valid encoding, "BAD_NAME" given
 ASCII

--- a/ext/mbstring/tests/mb_internal_encoding_error2.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_error2.phpt
@@ -19,13 +19,13 @@ function_exists('mb_internal_encoding') or die("skip mb_internal_encoding() is n
 
 echo "*** Testing mb_internal_encoding() : error conditions ***\n";
 
-var_dump(mb_internal_encoding('unknown-encoding'));
+try {
+    var_dump(mb_internal_encoding('unknown-encoding'));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_internal_encoding() : error conditions ***
-
-Warning: mb_internal_encoding(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
-Done
+mb_internal_encoding(): Argument #1 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_internal_encoding_ini_invalid_encoding.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_ini_invalid_encoding.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test INI mbstring.internal_encoding basic - invalid encoding specified in INI
+--SKIPIF--
+<?php
+extension_loaded('mbstring') or die('skip');
+function_exists('mb_stripos') or die("skip mb_stripos() is not available in this build");
+?>
+--INI--
+mbstring.internal_encoding=BAD
+--FILE--
+<?php
+
+echo "*** Testing INI mbstring.internal_encoding: invalid encoding specified in INI ***\n";
+
+echo mb_internal_encoding()."\n";
+echo ini_get('mbstring.internal_encoding')."\n";
+mb_internal_encoding('UTF-8');
+echo mb_internal_encoding()."\n";
+echo ini_get('mbstring.internal_encoding')."\n";
+
+?>
+--EXPECT--
+PHP Deprecated:  PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
+
+Deprecated: PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
+*** Testing INI mbstring.internal_encoding: invalid encoding specified in INI ***
+UTF-8
+BAD
+UTF-8
+BAD

--- a/ext/mbstring/tests/mb_ord.phpt
+++ b/ext/mbstring/tests/mb_ord.phpt
@@ -11,14 +11,36 @@ var_dump(
 );
 
 // Invalid
-var_dump(
-    mb_ord("\u{d800}", "typo"),
-    mb_ord("\u{d800}", "pass"),
-    mb_ord("\u{d800}", "jis"),
-    mb_ord("\u{d800}", "cp50222"),
-    mb_ord("\u{d800}", "utf-7"),
-    mb_ord("")
-);
+try {
+    var_dump( mb_ord("\u{d800}", "typo") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump( mb_ord("\u{d800}", "pass") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump( mb_ord("\u{d800}", "jis") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump( mb_ord("\u{d800}", "cp50222") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump( mb_ord("\u{d800}", "utf-7") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump( mb_ord("") );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 mb_internal_encoding("utf-7");
 mb_ord("");
@@ -27,23 +49,21 @@ mb_ord("");
 bool(true)
 bool(true)
 bool(true)
+mb_ord(): Argument #2 ($encoding) must be a valid encoding, "typo" given
 
-Warning: mb_ord(): Unknown encoding "typo" %s 10
-
-Warning: mb_ord(): Unsupported encoding "pass" %s 11
+Warning: mb_ord(): Unsupported encoding "pass" in %s on line %d
+bool(false)
 
 Warning: mb_ord(): Unsupported encoding "JIS" in %s on line %d
+bool(false)
 
 Warning: mb_ord(): Unsupported encoding "CP50222" in %s on line %d
+bool(false)
 
 Warning: mb_ord(): Unsupported encoding "UTF-7" in %s on line %d
+bool(false)
 
 Warning: mb_ord(): Empty string in %s on line %d
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
 bool(false)
 
 Warning: mb_ord(): Unsupported encoding "UTF-7" in %s on line %d

--- a/ext/mbstring/tests/mb_preferred_mime_name.phpt
+++ b/ext/mbstring/tests/mb_preferred_mime_name.phpt
@@ -34,8 +34,12 @@ $str = mb_preferred_mime_name('UCS4');
 echo "$str\n";
 
 echo "== INVALID PARAMETER ==\n";
-// Invalid name
-var_dump(mb_preferred_mime_name('BAD_NAME'));
+// Invalid encoding
+try {
+    var_dump(mb_preferred_mime_name('BAD_NAME'));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 // No preferred name
 var_dump(mb_preferred_mime_name('pass'));
@@ -51,9 +55,7 @@ ISO-8859-1
 UCS-2
 UCS-4
 == INVALID PARAMETER ==
-
-Warning: mb_preferred_mime_name(): Unknown encoding "BAD_NAME" in %s on line %d
-bool(false)
+mb_preferred_mime_name(): Argument #1 ($encoding) must be a valid encoding, "BAD_NAME" given
 
 Warning: mb_preferred_mime_name(): No MIME preferred name corresponding to "pass" in %s on line %d
 bool(false)

--- a/ext/mbstring/tests/mb_regex_encoding_error2.phpt
+++ b/ext/mbstring/tests/mb_regex_encoding_error2.phpt
@@ -18,14 +18,13 @@ function_exists('mb_regex_encoding') or die("skip mb_regex_encoding() is not ava
 
 echo "*** Testing mb_regex_encoding() : error conditions ***\n";
 
-var_dump(mb_regex_encoding('unknown'));
+try {
+    var_dump(mb_regex_encoding('unknown'));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-
-echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_regex_encoding() : error conditions ***
-
-Warning: mb_regex_encoding(): Unknown encoding "unknown" in %s on line %d
-bool(false)
-Done
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "unknown" given

--- a/ext/mbstring/tests/mb_regex_encoding_variation2.phpt
+++ b/ext/mbstring/tests/mb_regex_encoding_variation2.phpt
@@ -81,25 +81,27 @@ $iterator = 1;
 foreach($encoding as $enc) {
     echo "\n-- Iteration $iterator --\n";
     var_dump(mb_regex_encoding());
-    var_dump(mb_regex_encoding($enc));
+    try {
+        var_dump(mb_regex_encoding($enc));
+    } catch (\ValueError $e) {
+        echo $e->getMessage() . \PHP_EOL;
+    }
     var_dump(mb_regex_encoding());
     $iterator++;
 }
 echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_regex_encoding() : usage variations ***
 
 -- Iteration 1 --
-string(%d) "%s"
+string(5) "UTF-8"
 bool(true)
 string(5) "UCS-4"
 
 -- Iteration 2 --
 string(5) "UCS-4"
-
-Warning: mb_regex_encoding(): Unknown encoding "UCS-4BE" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "UCS-4BE" given
 string(5) "UCS-4"
 
 -- Iteration 3 --
@@ -109,23 +111,17 @@ string(7) "UCS-4LE"
 
 -- Iteration 4 --
 string(7) "UCS-4LE"
-
-Warning: mb_regex_encoding(): Unknown encoding "UCS-2" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "UCS-2" given
 string(7) "UCS-4LE"
 
 -- Iteration 5 --
 string(7) "UCS-4LE"
-
-Warning: mb_regex_encoding(): Unknown encoding "UCS-2BE" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "UCS-2BE" given
 string(7) "UCS-4LE"
 
 -- Iteration 6 --
 string(7) "UCS-4LE"
-
-Warning: mb_regex_encoding(): Unknown encoding "UCS-2LE" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "UCS-2LE" given
 string(7) "UCS-4LE"
 
 -- Iteration 7 --
@@ -160,16 +156,12 @@ string(8) "UTF-16LE"
 
 -- Iteration 13 --
 string(8) "UTF-16LE"
-
-Warning: mb_regex_encoding(): Unknown encoding "UTF-7" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "UTF-7" given
 string(8) "UTF-16LE"
 
 -- Iteration 14 --
 string(8) "UTF-16LE"
-
-Warning: mb_regex_encoding(): Unknown encoding "UTF7-IMAP" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "UTF7-IMAP" given
 string(8) "UTF-16LE"
 
 -- Iteration 15 --
@@ -204,16 +196,12 @@ string(4) "SJIS"
 
 -- Iteration 21 --
 string(4) "SJIS"
-
-Warning: mb_regex_encoding(): Unknown encoding "ISO-2022-JP" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "ISO-2022-JP" given
 string(4) "SJIS"
 
 -- Iteration 22 --
 string(4) "SJIS"
-
-Warning: mb_regex_encoding(): Unknown encoding "JIS" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "JIS" given
 string(4) "SJIS"
 
 -- Iteration 23 --
@@ -283,58 +271,42 @@ string(11) "ISO-8859-15"
 
 -- Iteration 36 --
 string(11) "ISO-8859-15"
-
-Warning: mb_regex_encoding(): Unknown encoding "byte2be" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "byte2be" given
 string(11) "ISO-8859-15"
 
 -- Iteration 37 --
 string(11) "ISO-8859-15"
-
-Warning: mb_regex_encoding(): Unknown encoding "byte2le" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "byte2le" given
 string(11) "ISO-8859-15"
 
 -- Iteration 38 --
 string(11) "ISO-8859-15"
-
-Warning: mb_regex_encoding(): Unknown encoding "byte4be" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "byte4be" given
 string(11) "ISO-8859-15"
 
 -- Iteration 39 --
 string(11) "ISO-8859-15"
-
-Warning: mb_regex_encoding(): Unknown encoding "byte4le" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "byte4le" given
 string(11) "ISO-8859-15"
 
 -- Iteration 40 --
 string(11) "ISO-8859-15"
-
-Warning: mb_regex_encoding(): Unknown encoding "BASE64" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "BASE64" given
 string(11) "ISO-8859-15"
 
 -- Iteration 41 --
 string(11) "ISO-8859-15"
-
-Warning: mb_regex_encoding(): Unknown encoding "HTML-ENTITIES" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "HTML-ENTITIES" given
 string(11) "ISO-8859-15"
 
 -- Iteration 42 --
 string(11) "ISO-8859-15"
-
-Warning: mb_regex_encoding(): Unknown encoding "7bit" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "7bit" given
 string(11) "ISO-8859-15"
 
 -- Iteration 43 --
 string(11) "ISO-8859-15"
-
-Warning: mb_regex_encoding(): Unknown encoding "8bit" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "8bit" given
 string(11) "ISO-8859-15"
 
 -- Iteration 44 --
@@ -344,16 +316,12 @@ string(6) "EUC-CN"
 
 -- Iteration 45 --
 string(6) "EUC-CN"
-
-Warning: mb_regex_encoding(): Unknown encoding "CP936" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "CP936" given
 string(6) "EUC-CN"
 
 -- Iteration 46 --
 string(6) "EUC-CN"
-
-Warning: mb_regex_encoding(): Unknown encoding "HZ" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "HZ" given
 string(6) "EUC-CN"
 
 -- Iteration 47 --
@@ -363,9 +331,7 @@ string(6) "EUC-TW"
 
 -- Iteration 48 --
 string(6) "EUC-TW"
-
-Warning: mb_regex_encoding(): Unknown encoding "CP950" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "CP950" given
 string(6) "EUC-TW"
 
 -- Iteration 49 --
@@ -380,37 +346,27 @@ string(6) "EUC-KR"
 
 -- Iteration 51 --
 string(6) "EUC-KR"
-
-Warning: mb_regex_encoding(): Unknown encoding "UHC" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "UHC" given
 string(6) "EUC-KR"
 
 -- Iteration 52 --
 string(6) "EUC-KR"
-
-Warning: mb_regex_encoding(): Unknown encoding "ISO-2022-KR" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "ISO-2022-KR" given
 string(6) "EUC-KR"
 
 -- Iteration 53 --
 string(6) "EUC-KR"
-
-Warning: mb_regex_encoding(): Unknown encoding "Windows-1251" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "Windows-1251" given
 string(6) "EUC-KR"
 
 -- Iteration 54 --
 string(6) "EUC-KR"
-
-Warning: mb_regex_encoding(): Unknown encoding "Windows-1252" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "Windows-1252" given
 string(6) "EUC-KR"
 
 -- Iteration 55 --
 string(6) "EUC-KR"
-
-Warning: mb_regex_encoding(): Unknown encoding "CP866" in %s on line %d
-bool(false)
+mb_regex_encoding(): Argument #1 ($encoding) must be a valid encoding, "CP866" given
 string(6) "EUC-KR"
 
 -- Iteration 56 --

--- a/ext/mbstring/tests/mb_str_unknown_encoding.phpt
+++ b/ext/mbstring/tests/mb_str_unknown_encoding.phpt
@@ -7,70 +7,161 @@ User Group: PHP-WVL & PHPGent #PHPTestFest
 <?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
 --FILE--
 <?php
-mb_chr(1, 'UTF-0');
-mb_convert_case('coudenys', MB_CASE_UPPER, 'UTF-0');
-mb_convert_encoding('coudenys', 'UTF-8', 'UTF-0');
-mb_convert_kana('coudenys', 'KV', 'UTF-0');
-mb_decode_numericentity('coudenys', [], 'UTF-0');
-mb_ord('coudenys', 'UTF-0');
-mb_strcut('coudenys', 0, 4, 'UTF-0');
-mb_strimwidth('coudenys', 0, 4, '', 'UTF-0');
-mb_stripos('coudenys', 'cou', 0, 'UTF-0');
-mb_stristr('coudenys', 'cou', false, 'UTF-0');
-mb_strlen('coudenys', 'UTF-0');
-mb_strpos('coudenys', 'cou', 0, 'UTF-0');
-mb_strrchr('coudenys', 'cou', false, 'UTF-0');
-mb_strrichr('coudenys', 'cou', false, 'UTF-0');
-mb_strripos('coudenys', 'cou', 0, 'UTF-0');
-mb_strrpos('coudenys', 'cou', 0, 'UTF-0');
-mb_strstr('coudenys', 'cou', false, 'UTF-0');
-mb_strtolower('coudenys', 'UTF-0');
-mb_strtoupper('coudenys', 'UTF-0');
-mb_strwidth('coudenys', 'UTF-0');
-mb_substr('coudenys', 0, null, 'UTF-0');
-mb_substr_count('coudenys', 'c', 'UTF-0');
+
+try {
+    mb_chr(1, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_convert_case('coudenys', MB_CASE_UPPER, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_convert_encoding('coudenys', 'UTF-8', 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_convert_kana('coudenys', 'KV', 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_decode_numericentity('coudenys', [], 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_ord('coudenys', 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strcut('coudenys', 0, 4, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strimwidth('coudenys', 0, 4, '', 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_stripos('coudenys', 'cou', 0, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_stristr('coudenys', 'cou', false, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strlen('coudenys', 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strpos('coudenys', 'cou', 0, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strrchr('coudenys', 'cou', false, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strrichr('coudenys', 'cou', false, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strripos('coudenys', 'cou', 0, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strrpos('coudenys', 'cou', 0, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strstr('coudenys', 'cou', false, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strtolower('coudenys', 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strtoupper('coudenys', 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_strwidth('coudenys', 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_substr('coudenys', 0, null, 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+try {
+    mb_substr_count('coudenys', 'c', 'UTF-0');
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
 ?>
 --EXPECTF--
-Warning: mb_chr(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_convert_case(): Unknown encoding "UTF-0" in %s on line %d
+mb_chr(): Argument #2 ($encoding) must be a valid encoding, "UTF-0" given
+mb_convert_case(): Argument #3 ($encoding) must be a valid encoding, "UTF-0" given
 
 Warning: mb_convert_encoding(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_convert_kana(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_decode_numericentity(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_ord(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strcut(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strimwidth(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_stripos(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_stristr(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strlen(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strpos(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strrchr(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strrichr(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strripos(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strrpos(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strstr(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strtolower(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strtoupper(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_strwidth(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_substr(): Unknown encoding "UTF-0" in %s on line %d
-
-Warning: mb_substr_count(): Unknown encoding "UTF-0" in %s on line %d
+mb_convert_kana(): Argument #3 ($encoding) must be a valid encoding, "UTF-0" given
+mb_decode_numericentity(): Argument #3 ($encoding) must be a valid encoding, "UTF-0" given
+mb_ord(): Argument #2 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strcut(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strimwidth(): Argument #5 ($encoding) must be a valid encoding, "UTF-0" given
+mb_stripos(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_stristr(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strlen(): Argument #2 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strpos(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strrchr(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strrichr(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strripos(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strrpos(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strstr(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strtolower(): Argument #2 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strtoupper(): Argument #2 ($encoding) must be a valid encoding, "UTF-0" given
+mb_strwidth(): Argument #2 ($encoding) must be a valid encoding, "UTF-0" given
+mb_substr(): Argument #4 ($encoding) must be a valid encoding, "UTF-0" given
+mb_substr_count(): Argument #3 ($encoding) must be a valid encoding, "UTF-0" given

--- a/ext/mbstring/tests/mb_stripos_error2.phpt
+++ b/ext/mbstring/tests/mb_stripos_error2.phpt
@@ -23,13 +23,13 @@ $needle = 'world';
 $offset = 2;
 $encoding = 'unknown-encoding';
 
-var_dump( mb_stripos($haystack, $needle, $offset, $encoding) );
+try {
+    var_dump( mb_stripos($haystack, $needle, $offset, $encoding) );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_stripos() : error conditions ***
-
-Warning: mb_stripos(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
-Done
+mb_stripos(): Argument #4 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_stristr_error2.phpt
+++ b/ext/mbstring/tests/mb_stristr_error2.phpt
@@ -21,13 +21,16 @@ $haystack = 'Hello, world';
 $needle = 'world';
 $encoding = 'unknown-encoding';
 $part = true;
-var_dump( mb_stristr($haystack, $needle, $part, $encoding) );
+
+try {
+    var_dump( mb_stristr($haystack, $needle, $part, $encoding) );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_stristr() : error conditions ***
 
 -- Testing mb_stristr() with unknown encoding --
-
-Warning: mb_stristr(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
+mb_stristr(): Argument #4 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_strlen.phpt
+++ b/ext/mbstring/tests/mb_strlen.phpt
@@ -55,12 +55,14 @@ print  strlen($utf8) . "\n";
 echo "== WRONG PARAMETERS ==\n";
 // Wrong encoding
 mb_internal_encoding('EUC-JP');
-$r = mb_strlen($euc_jp, 'BAD_NAME');
-echo $r."\n";
-
+try {
+    var_dump( mb_strlen($euc_jp, 'BAD_NAME') );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 == ASCII ==
 40
 40
@@ -77,5 +79,4 @@ echo $r."\n";
 43
 101
 == WRONG PARAMETERS ==
-
-Warning: mb_strlen(): Unknown encoding "BAD_NAME" in %s on line %d
+mb_strlen(): Argument #2 ($encoding) must be a valid encoding, "BAD_NAME" given

--- a/ext/mbstring/tests/mb_strlen_error2.phpt
+++ b/ext/mbstring/tests/mb_strlen_error2.phpt
@@ -22,13 +22,13 @@ $string = 'abcdef';
 
 $encoding = 'unknown-encoding';
 
-var_dump(mb_strlen($string, $encoding));
+try {
+    var_dump(mb_strlen($string, $encoding));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_strlen() : error ***
-
-Warning: mb_strlen(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
-Done
+mb_strlen(): Argument #2 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_strpos_error2.phpt
+++ b/ext/mbstring/tests/mb_strpos_error2.phpt
@@ -22,13 +22,13 @@ $needle = 'world';
 $offset = 2;
 $encoding = 'unknown-encoding';
 
-var_dump( mb_strpos($haystack, $needle, $offset, $encoding) );
+try {
+    var_dump( mb_strpos($haystack, $needle, $offset, $encoding) );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_strpos() : error conditions ***
-
-Warning: mb_strpos(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
-Done
+mb_strpos(): Argument #4 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_strrchr_error2.phpt
+++ b/ext/mbstring/tests/mb_strrchr_error2.phpt
@@ -21,13 +21,16 @@ $haystack = 'Hello, world';
 $needle = 'world';
 $encoding = 'unknown-encoding';
 $part = true;
-var_dump( mb_strrchr($haystack, $needle, $part, $encoding) );
+
+try {
+    var_dump( mb_strrchr($haystack, $needle, $part, $encoding) );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_strrchr() : error conditions ***
 
 -- Testing mb_strrchr() with unknown encoding --
-
-Warning: mb_strrchr(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
+mb_strrchr(): Argument #4 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_strrichr_error2.phpt
+++ b/ext/mbstring/tests/mb_strrichr_error2.phpt
@@ -21,13 +21,16 @@ $haystack = 'Hello, world';
 $needle = 'world';
 $encoding = 'unknown-encoding';
 $part = true;
-var_dump( mb_strrichr($haystack, $needle, $part, $encoding) );
+
+try {
+    var_dump( mb_strrichr($haystack, $needle, $part, $encoding) );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_strrichr() : error conditions ***
 
 -- Testing mb_strrichr() with unknown encoding --
-
-Warning: mb_strrichr(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
+mb_strrichr(): Argument #4 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_strripos_error2.phpt
+++ b/ext/mbstring/tests/mb_strripos_error2.phpt
@@ -23,13 +23,13 @@ $needle = 'world';
 $offset = 2;
 $encoding = 'unknown-encoding';
 
-var_dump( mb_strripos($haystack, $needle, $offset, $encoding) );
+try {
+    var_dump( mb_strripos($haystack, $needle, $offset, $encoding) );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_strripos() : error conditions ***
-
-Warning: mb_strripos(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
-Done
+mb_strripos(): Argument #4 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_strrpos_error2.phpt
+++ b/ext/mbstring/tests/mb_strrpos_error2.phpt
@@ -23,13 +23,13 @@ $needle = '123';
 $offset = 5;
 $encoding = 'unknown-encoding';
 
-var_dump(mb_strrpos($haystack, $needle , $offset, $encoding));
+try {
+    var_dump(mb_strrpos($haystack, $needle , $offset, $encoding));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_strrpos() : error conditions ***
-
-Warning: mb_strrpos(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
-Done
+mb_strrpos(): Argument #4 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_strstr_error2.phpt
+++ b/ext/mbstring/tests/mb_strstr_error2.phpt
@@ -21,13 +21,16 @@ $haystack = 'Hello, world';
 $needle = 'world';
 $encoding = 'unknown-encoding';
 $part = true;
-var_dump( mb_strstr($haystack, $needle, $part, $encoding) );
+
+try {
+    var_dump( mb_strstr($haystack, $needle, $part, $encoding) );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_strstr() : error conditions ***
 
 -- Testing mb_strstr() with unknown encoding --
-
-Warning: mb_strstr(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
+mb_strstr(): Argument #4 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_strtolower_error2.phpt
+++ b/ext/mbstring/tests/mb_strtolower_error2.phpt
@@ -21,10 +21,13 @@ echo "*** Testing mb_strtolower() : error conditions***\n";
 $sourcestring = 'hello, world';
 $encoding = 'unknown-encoding';
 
-var_dump( mb_strtolower($sourcestring, $encoding) );
-?>
---EXPECTF--
-*** Testing mb_strtolower() : error conditions***
+try {
+    var_dump( mb_strtolower($sourcestring, $encoding) );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-Warning: mb_strtolower(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
+?>
+--EXPECT--
+*** Testing mb_strtolower() : error conditions***
+mb_strtolower(): Argument #2 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_strtoupper_error2.phpt
+++ b/ext/mbstring/tests/mb_strtoupper_error2.phpt
@@ -21,13 +21,13 @@ echo "*** Testing mb_strtoupper() : error conditions ***\n";
 $sourcestring = 'hello, world';
 $encoding = 'unknown-encoding';
 
-var_dump( mb_strtoupper($sourcestring, $encoding) );
+try {
+    var_dump( mb_strtoupper($sourcestring, $encoding) );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_strtoupper() : error conditions ***
-
-Warning: mb_strtoupper(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
-Done
+mb_strtoupper(): Argument #2 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_substr_count_error2.phpt
+++ b/ext/mbstring/tests/mb_substr_count_error2.phpt
@@ -23,15 +23,16 @@ $needle = 'Hello';
 $encoding = 'unknown-encoding';
 
 echo "\n-- Testing mb_substr_count() function with an unknown encoding --\n";
-var_dump(mb_substr_count($haystack, $needle, $encoding));
 
-echo "Done";
+try {
+    var_dump(mb_substr_count($haystack, $needle, $encoding));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_substr_count() : error conditions ***
 
 -- Testing mb_substr_count() function with an unknown encoding --
-
-Warning: mb_substr_count(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
-Done
+mb_substr_count(): Argument #3 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_substr_error2.phpt
+++ b/ext/mbstring/tests/mb_substr_error2.phpt
@@ -23,13 +23,13 @@ $start = 1;
 $length = 5;
 $encoding = 'unknown-encoding';
 
-var_dump( mb_substr($str, $start, $length, $encoding));
+try {
+    var_dump( mb_substr($str, $start, $length, $encoding));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
-echo "Done";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mb_substr() : error conditions ***
-
-Warning: mb_substr(): Unknown encoding "unknown-encoding" in %s on line %d
-bool(false)
-Done
+mb_substr(): Argument #4 ($encoding) must be a valid encoding, "unknown-encoding" given


### PR DESCRIPTION
This promotes and standardizes the various invalid/unknown encoding warnings to ValueErrors.

I needed to change a couple of the internal API to allow the pass through of the argument position.

I didn't touch the ``Unsupported encoding`` warnings which appear in ``mb_ord()`` and ``mb_chr()`` functions yet as I'm not sure what to do with them because I think it would make more sense to integrate them in the main check and dispatch the ``Unsupported encoding`` consistently.