### PR TITLE
Allow retries on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,8 @@ before_script:
 
 # Run PHPs run-tests.php
 script:
-    - ./sapi/cli/php run-tests.php -P -d extension=`pwd`/modules/zend_test.so $(if [ $ENABLE_DEBUG == 0 ]; then echo "-d opcache.enable_cli=1 -d opcache.protect_memory=1 -d opcache.jit_buffer_size=16M -d zend_extension=`pwd`/modules/opcache.so"; fi) -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --offline --show-diff --show-slow 1000 --set-timeout 120 -j$(nproc)
-    - sapi/cli/php -d extension_dir=`pwd`/modules -r 'dl("zend_test");'
+    - travis_retry ./sapi/cli/php run-tests.php -P -d extension=`pwd`/modules/zend_test.so $(if [ $ENABLE_DEBUG == 0 ]; then echo "-d opcache.enable_cli=1 -d opcache.protect_memory=1 -d opcache.jit_buffer_size=16M -d zend_extension=`pwd`/modules/opcache.so"; fi) -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --offline --show-diff --show-slow 1000 --set-timeout 120 -j$(nproc)
+    - travis_retry sapi/cli/php -d extension_dir=`pwd`/modules -r 'dl("zend_test");'
 
 after_success:
     - ccache --show-stats


### PR DESCRIPTION
We often have CI failures that a simple retry "fix it". Let's automate it with [`travis_retry`](https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies) for Travis CI:

> For commands which do not have a built-in retry feature, use the `travis_retry` function to retry it up to three times, if the return code is non-zero: