### PR TITLE
Do constant evaluation for str_contains in opcache

### DIFF
--- a/ext/opcache/Optimizer/sccp.c
+++ b/ext/opcache/Optimizer/sccp.c
@@ -954,6 +954,7 @@ static inline int ct_eval_func_call(
 			}
 			/* pass */
 		} else if (zend_string_equals_literal(name, "strpos")
+				|| zend_string_equals_literal(name, "str_contains")
 				|| zend_string_equals_literal(name, "version_compare")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING
 					|| Z_TYPE_P(args[1]) != IS_STRING) {


### PR DESCRIPTION
Both arguments must be strings.  Unlike strpos,
str_contains deliberately does not emit a warning for an empty needle.

Validated locally that this converted the calls to a constant:

```
php run-tests.php -d zend_extension=opcache.so -d opcache.enable_cli=1 -d opcache.opt_debug_level=0x20000 ext/standard/tests/strings/str_contains.phpt --show-diff
....
035+ 0030 INIT_FCALL 1 96 string("var_dump")
036+ 0031 SEND_VAL bool(false) 1
037+ 0032 DO_ICALL
038+ 0033 INIT_FCALL 1 96 string("var_dump")
039+ 0034 SEND_VAL bool(true) 1
040+ 0035 DO_ICALL
...
```