### PR TITLE
Fix format for tm member objects in ftp_fopen_wrapper.c

### DIFF
--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -844,7 +844,7 @@ static int php_stream_ftp_url_stat(php_stream_wrapper *wrapper, const char *url,
 			goto mdtm_error;
 		}
 
-		n = sscanf(p, "%4u%2u%2u%2u%2u%2u", &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec);
+		n = sscanf(p, "%4d%2d%2d%2d%2d%2d", &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec);
 		if (n != 6) {
 			goto mdtm_error;
 		}


### PR DESCRIPTION
They are all stored as integers