### PR TITLE
Display nullability in type error messages for internal functions

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -230,6 +230,16 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_error(int num, 
 }
 /* }}} */
 
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_or_null_error(int num, const char *name, zval *arg) /* {{{ */
+{
+	if (EG(exception)) {
+		return;
+	}
+
+	zend_argument_type_error(num, "must be of type ?%s, %s given", name, zend_zval_type_name(arg));
+}
+/* }}} */
+
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(int num, char *error) /* {{{ */
 {
 	if (EG(exception)) {

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1126,17 +1126,28 @@ static zend_always_inline zval *zend_try_array_init(zval *zv)
 #define FAST_ZPP 1
 
 #define Z_EXPECTED_TYPES(_) \
-	_(Z_EXPECTED_LONG,		"of type int") \
-	_(Z_EXPECTED_BOOL,		"of type bool") \
-	_(Z_EXPECTED_STRING,	"of type string") \
-	_(Z_EXPECTED_ARRAY,		"of type array") \
-	_(Z_EXPECTED_FUNC,		"a valid callback") \
-	_(Z_EXPECTED_RESOURCE,	"of type resource") \
-	_(Z_EXPECTED_PATH,		"a valid path") \
-	_(Z_EXPECTED_OBJECT,	"of type object") \
-	_(Z_EXPECTED_DOUBLE,	"of type float") \
-	_(Z_EXPECTED_NUMBER,	"of type int|float") \
-	_(Z_EXPECTED_STRING_OR_ARRAY, "of type string|array") \
+	_(Z_EXPECTED_LONG,				"of type int") \
+	_(Z_EXPECTED_LONG_OR_NULL,		"of type ?int") \
+	_(Z_EXPECTED_BOOL,				"of type bool") \
+	_(Z_EXPECTED_BOOL_OR_NULL,		"of type ?bool") \
+	_(Z_EXPECTED_STRING,			"of type string") \
+	_(Z_EXPECTED_STRING_OR_NULL,	"of type ?string") \
+	_(Z_EXPECTED_ARRAY,				"of type array") \
+	_(Z_EXPECTED_ARRAY_OR_NULL,		"of type ?array") \
+	_(Z_EXPECTED_FUNC,				"a valid callback") \
+	_(Z_EXPECTED_FUNC_OR_NULL,		"a valid callback or null") \
+	_(Z_EXPECTED_RESOURCE,			"of type resource") \
+	_(Z_EXPECTED_RESOURCE_OR_NULL,	"of type resource or null") \
+	_(Z_EXPECTED_PATH,				"a valid path") \
+	_(Z_EXPECTED_PATH_OR_NULL,		"a valid path or null") \
+	_(Z_EXPECTED_OBJECT,			"of type object") \
+	_(Z_EXPECTED_OBJECT_OR_NULL,	"of type ?object") \
+	_(Z_EXPECTED_DOUBLE,			"of type float") \
+	_(Z_EXPECTED_DOUBLE_OR_NULL,	"of type ?float") \
+	_(Z_EXPECTED_NUMBER,			"of type int|float") \
+	_(Z_EXPECTED_NUMBER_OR_NULL,	"of type int|float|null") \
+	_(Z_EXPECTED_STRING_OR_ARRAY,	"of type string|array") \
+	_(Z_EXPECTED_STRING_OR_ARRAY_OR_NULL, "of type string|array|null") \
 
 #define Z_EXPECTED_TYPE
 
@@ -1152,17 +1163,19 @@ ZEND_API ZEND_COLD int  ZEND_FASTCALL zend_wrong_parameters_none_error(void);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameters_count_error(int min_num_args, int max_num_args);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_type_error(int num, zend_expected_type expected_type, zval *arg);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_error(int num, const char *name, zval *arg);
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_or_null_error(int num, const char *name, zval *arg);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(int num, char *error);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error(zend_class_entry *error_ce, uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_type_error(uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num, const char *format, ...);
 
-#define ZPP_ERROR_OK             0
-#define ZPP_ERROR_FAILURE        1
-#define ZPP_ERROR_WRONG_CALLBACK 2
-#define ZPP_ERROR_WRONG_CLASS    3
-#define ZPP_ERROR_WRONG_ARG      4
-#define ZPP_ERROR_WRONG_COUNT    5
+#define ZPP_ERROR_OK					0
+#define ZPP_ERROR_FAILURE				1
+#define ZPP_ERROR_WRONG_CALLBACK		2
+#define ZPP_ERROR_WRONG_CLASS			3
+#define ZPP_ERROR_WRONG_CLASS_OR_NULL	4
+#define ZPP_ERROR_WRONG_ARG				5
+#define ZPP_ERROR_WRONG_COUNT			6
 
 #define ZEND_PARSE_PARAMETERS_START_EX(flags, min_num_args, max_num_args) do { \
 		const int _flags = (flags); \
@@ -1214,6 +1227,8 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 					zend_wrong_callback_error(_i, _error); \
 				} else if (_error_code == ZPP_ERROR_WRONG_CLASS) { \
 					zend_wrong_parameter_class_error(_i, _error, _arg); \
+				} else if (_error_code == ZPP_ERROR_WRONG_CLASS_OR_NULL) { \
+					zend_wrong_parameter_class_or_null_error(_i, _error, _arg); \
 				} else if (_error_code == ZPP_ERROR_WRONG_ARG) { \
 					zend_wrong_parameter_type_error(_i, _expected_type, _arg); \
 				} \
@@ -1251,7 +1266,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_ARRAY_EX2(dest, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_array(_arg, &dest, check_null, 0))) { \
-			_expected_type = Z_EXPECTED_ARRAY; \
+			_expected_type = check_null ? Z_EXPECTED_ARRAY_OR_NULL : Z_EXPECTED_ARRAY; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1269,7 +1284,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_ARRAY_OR_OBJECT_EX2(dest, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_array(_arg, &dest, check_null, 1))) { \
-			_expected_type = Z_EXPECTED_ARRAY; \
+			_expected_type = check_null ? Z_EXPECTED_ARRAY_OR_NULL : Z_EXPECTED_ARRAY; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1284,7 +1299,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_BOOL_EX2(dest, is_null, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_bool(_arg, &dest, &is_null, check_null))) { \
-			_expected_type = Z_EXPECTED_BOOL; \
+			_expected_type = check_null ? Z_EXPECTED_BOOL_OR_NULL : Z_EXPECTED_BOOL; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1313,7 +1328,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_DOUBLE_EX2(dest, is_null, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_double(_arg, &dest, &is_null, check_null))) { \
-			_expected_type = Z_EXPECTED_DOUBLE; \
+			_expected_type = check_null ? Z_EXPECTED_DOUBLE_OR_NULL : Z_EXPECTED_DOUBLE; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1329,7 +1344,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_func(_arg, &dest_fci, &dest_fcc, check_null, &_error))) { \
 			if (!_error) { \
-				_expected_type = Z_EXPECTED_FUNC; \
+				_expected_type = check_null ? Z_EXPECTED_FUNC_OR_NULL : Z_EXPECTED_FUNC; \
 				_error_code = ZPP_ERROR_WRONG_ARG; \
 			} else { \
 				_error_code = ZPP_ERROR_WRONG_CALLBACK; \
@@ -1347,7 +1362,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_ARRAY_HT_EX2(dest, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_array_ht(_arg, &dest, check_null, 0, separate))) { \
-			_expected_type = Z_EXPECTED_ARRAY; \
+			_expected_type = check_null ? Z_EXPECTED_ARRAY_OR_NULL : Z_EXPECTED_ARRAY; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1362,7 +1377,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_ARRAY_OR_OBJECT_HT_EX2(dest, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_array_ht(_arg, &dest, check_null, 1, separate))) { \
-			_expected_type = Z_EXPECTED_ARRAY; \
+			_expected_type = check_null ? Z_EXPECTED_ARRAY_OR_NULL : Z_EXPECTED_ARRAY; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1377,7 +1392,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_LONG_EX2(dest, is_null, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_long(_arg, &dest, &is_null, check_null))) { \
-			_expected_type = Z_EXPECTED_LONG; \
+			_expected_type = check_null ? Z_EXPECTED_LONG_OR_NULL : Z_EXPECTED_LONG; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1395,7 +1410,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_NUMBER_EX(dest, check_null) \
 	Z_PARAM_PROLOGUE(0, 0); \
 	if (UNEXPECTED(!zend_parse_arg_number(_arg, &dest, check_null))) { \
-		_expected_type = Z_EXPECTED_NUMBER; \
+		_expected_type = check_null ? Z_EXPECTED_NUMBER_OR_NULL : Z_EXPECTED_NUMBER; \
 		_error_code = ZPP_ERROR_WRONG_ARG; \
 		break; \
 	}
@@ -1410,7 +1425,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_OBJECT_EX2(dest, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_object(_arg, &dest, NULL, check_null))) { \
-			_expected_type = Z_EXPECTED_OBJECT; \
+			_expected_type = check_null ? Z_EXPECTED_OBJECT_OR_NULL : Z_EXPECTED_OBJECT; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1427,10 +1442,10 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 		if (UNEXPECTED(!zend_parse_arg_object(_arg, &dest, _ce, check_null))) { \
 			if (_ce) { \
 				_error = ZSTR_VAL((_ce)->name); \
-				_error_code = ZPP_ERROR_WRONG_CLASS; \
+				_error_code = check_null ? ZPP_ERROR_WRONG_CLASS_OR_NULL : ZPP_ERROR_WRONG_CLASS; \
 				break; \
 			} else { \
-				_expected_type = Z_EXPECTED_OBJECT; \
+				_expected_type = check_null ? Z_EXPECTED_OBJECT_OR_NULL : Z_EXPECTED_OBJECT; \
 				_error_code = ZPP_ERROR_WRONG_ARG; \
 				break; \
 			} \
@@ -1446,7 +1461,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_PATH_EX2(dest, dest_len, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_path(_arg, &dest, &dest_len, check_null))) { \
-			_expected_type = Z_EXPECTED_PATH; \
+			_expected_type = check_null ? Z_EXPECTED_PATH_OR_NULL : Z_EXPECTED_PATH; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1461,7 +1476,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_PATH_STR_EX2(dest, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_path_str(_arg, &dest, check_null))) { \
-			_expected_type = Z_EXPECTED_PATH; \
+			_expected_type = check_null ? Z_EXPECTED_PATH_OR_NULL : Z_EXPECTED_PATH; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1476,7 +1491,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_RESOURCE_EX2(dest, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_resource(_arg, &dest, check_null))) { \
-			_expected_type = Z_EXPECTED_RESOURCE; \
+			_expected_type = check_null ? Z_EXPECTED_RESOURCE_OR_NULL : Z_EXPECTED_RESOURCE; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1491,7 +1506,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_STRING_EX2(dest, dest_len, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_string(_arg, &dest, &dest_len, check_null))) { \
-			_expected_type = Z_EXPECTED_STRING; \
+			_expected_type = check_null ? Z_EXPECTED_STRING_OR_NULL : Z_EXPECTED_STRING; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1509,7 +1524,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_STR_EX2(dest, check_null, deref, separate) \
 		Z_PARAM_PROLOGUE(deref, separate); \
 		if (UNEXPECTED(!zend_parse_arg_str(_arg, &dest, check_null))) { \
-			_expected_type = Z_EXPECTED_STRING; \
+			_expected_type = check_null ? Z_EXPECTED_STRING_OR_NULL : Z_EXPECTED_STRING; \
 			_error_code = ZPP_ERROR_WRONG_ARG; \
 			break; \
 		}
@@ -1551,7 +1566,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define Z_PARAM_STR_OR_ARRAY_HT_EX(dest_str, dest_ht, allow_null) \
 	Z_PARAM_PROLOGUE(0, 0); \
 	if (UNEXPECTED(!zend_parse_arg_str_or_array_ht(_arg, &dest_str, &dest_ht, allow_null))) { \
-		_expected_type = Z_EXPECTED_STRING_OR_ARRAY; \
+		_expected_type = allow_null ? Z_EXPECTED_STRING_OR_ARRAY_OR_NULL : Z_EXPECTED_STRING_OR_ARRAY; \
 		_error_code = ZPP_ERROR_WRONG_ARG; \
 		break; \
 	}

--- a/ext/gd/tests/imagexbm_nullbyte_injection.phpt
+++ b/ext/gd/tests/imagexbm_nullbyte_injection.phpt
@@ -14,4 +14,4 @@ try {
 }
 ?>
 --EXPECTF--
-imagexbm(): Argument #2 ($filename) must be a valid path, string given
+imagexbm(): Argument #2 ($filename) must be a valid path or null, string given

--- a/ext/intl/tests/bug48227.phpt
+++ b/ext/intl/tests/bug48227.phpt
@@ -16,7 +16,7 @@ foreach (['', 1, NULL, $x] as $value) {
 
 ?>
 --EXPECT--
-NumberFormatter::format(): Argument #1 ($value) must be of type number, string given
+NumberFormatter::format(): Argument #1 ($value) must be of type int|float, string given
 string(1) "1"
 string(1) "0"
-NumberFormatter::format(): Argument #1 ($value) must be of type number, object given
+NumberFormatter::format(): Argument #1 ($value) must be of type int|float, object given

--- a/ext/phar/tests/badparameters.phpt
+++ b/ext/phar/tests/badparameters.phpt
@@ -246,7 +246,7 @@ Cannot change stub, phar is read-only
 A Phar stub cannot be set in a plain tar archive
 Phar::setStub(): Argument #1 ($newstub) must be of type string, array given
 A Phar stub cannot be set in a plain tar archive
-Phar::setDefaultStub(): Argument #1 ($index) must be of type string, array given
+Phar::setDefaultStub(): Argument #1 ($index) must be of type ?string, array given
 Cannot change stub: phar.readonly=1
 Cannot set signature algorithm, phar is read-only
 Phar::compress(): Argument #1 ($compression_type) must be of type int, array given

--- a/ext/reflection/tests/ReflectionMethod_invoke_basic.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invoke_basic.phpt
@@ -103,7 +103,7 @@ NULL
 
 Static method:
 ReflectionMethod::invoke() expects at least 1 parameter, 0 given
-ReflectionMethod::invoke(): Argument #1 ($object) must be of type object, bool given
+ReflectionMethod::invoke(): Argument #1 ($object) must be of type ?object, bool given
 Called staticMethod()
 Exception: Using $this when not in object context
 NULL

--- a/ext/reflection/tests/ReflectionMethod_invoke_error1.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invoke_error1.phpt
@@ -59,7 +59,7 @@ try {
 ?>
 --EXPECT--
 invoke() on a non-object:
-string(84) "ReflectionMethod::invoke(): Argument #1 ($object) must be of type object, bool given"
+string(85) "ReflectionMethod::invoke(): Argument #1 ($object) must be of type ?object, bool given"
 
 invoke() on a non-instance:
 string(72) "Given object is not an instance of the class this method was declared in"

--- a/ext/reflection/tests/request38992.phpt
+++ b/ext/reflection/tests/request38992.phpt
@@ -23,5 +23,5 @@ try {
 }
 ?>
 --EXPECT--
-ReflectionMethod::invoke(): Argument #1 ($object) must be of type object, string given
-ReflectionMethod::invokeArgs(): Argument #1 ($object) must be of type object, string given
+ReflectionMethod::invoke(): Argument #1 ($object) must be of type ?object, string given
+ReflectionMethod::invokeArgs(): Argument #1 ($object) must be of type ?object, string given

--- a/ext/spl/tests/spl_004.phpt
+++ b/ext/spl/tests/spl_004.phpt
@@ -84,6 +84,6 @@ int(5)
 int(6)
 int(4)
 ===ERRORS===
-iterator_apply(): Argument #3 ($args) must be of type array, int given
+iterator_apply(): Argument #3 ($args) must be of type ?array, int given
 iterator_apply(): Argument #2 ($function) must be a valid callback, function 'non_existing_function' not found or invalid function name
 iterator_apply() expects at most 3 parameters, 4 given

--- a/ext/standard/tests/array/array_slice_variation1.phpt
+++ b/ext/standard/tests/array/array_slice_variation1.phpt
@@ -61,6 +61,6 @@ array(1) {
   [2]=>
   int(3)
 }
-array_slice(): Argument #3 ($length) must be of type int, string given
-array_slice(): Argument #3 ($length) must be of type int, string given
+array_slice(): Argument #3 ($length) must be of type ?int, string given
+array_slice(): Argument #3 ($length) must be of type ?int, string given
 string(3) "foo"


### PR DESCRIPTION
As found by Nikita, so far, type error messages for internal functions didn't include whether a parameter was nullable. This patch fixes it so that for example calling `mb_substr("abc", 1, []);` will result in a `TypeError` with the following message:

`mb_substr(): Argument #3 ($length) must be of type ?int, array given`

instead of

`mb_substr(): Argument #3 ($length) must be of type int, array given`