### PR TITLE
Improve "unsupported operands" error

### DIFF
--- a/Zend/tests/add_002.phpt
+++ b/Zend/tests/add_002.phpt
@@ -20,9 +20,9 @@ var_dump($c);
 echo "Done\n";
 ?>
 --EXPECTF--
-Exception: Unsupported operand types
+Exception: Unsupported operand types: array + object
 
-Fatal error: Uncaught Error: Unsupported operand types in %s:%d
+Fatal error: Uncaught TypeError: Unsupported operand types: array + object in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/add_003.phpt
+++ b/Zend/tests/add_003.phpt
@@ -22,11 +22,11 @@ echo "Done\n";
 --EXPECTF--
 Notice: Object of class stdClass could not be converted to number in %sadd_003.php on line %d
 
-Exception: Unsupported operand types
+Exception: Unsupported operand types: object + array
 
 Notice: Object of class stdClass could not be converted to number in %s on line %d
 
-Fatal error: Uncaught Error: Unsupported operand types in %s:%d
+Fatal error: Uncaught TypeError: Unsupported operand types: object + array in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/add_004.phpt
+++ b/Zend/tests/add_004.phpt
@@ -17,9 +17,9 @@ var_dump($c);
 echo "Done\n";
 ?>
 --EXPECTF--
-Exception: Unsupported operand types
+Exception: Unsupported operand types: array + int
 
-Fatal error: Uncaught Error: Unsupported operand types in %s:%d
+Fatal error: Uncaught TypeError: Unsupported operand types: array + int in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/add_007.phpt
+++ b/Zend/tests/add_007.phpt
@@ -19,9 +19,9 @@ var_dump($c);
 echo "Done\n";
 ?>
 --EXPECTF--
-Exception: Unsupported operand types
+Exception: Unsupported operand types: array + string
 
-Fatal error: Uncaught Error: Unsupported operand types in %s:%d
+Fatal error: Uncaught TypeError: Unsupported operand types: array + string in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug74084.phpt
+++ b/Zend/tests/bug74084.phpt
@@ -31,7 +31,7 @@ try {
 }
 ?>
 --EXPECT--
-Unsupported operand types
-Unsupported operand types
-Unsupported operand types
-Unsupported operand types
+Unsupported operand types: array - array
+Unsupported operand types: array * array
+Unsupported operand types: array / array
+Unsupported operand types: array ** array

--- a/Zend/tests/constant_expressions_exceptions_001.phpt
+++ b/Zend/tests/constant_expressions_exceptions_001.phpt
@@ -3,5 +3,8 @@ Constant Expressions with unsupported operands 001
 --FILE--
 <?php
 const T = array(1,2) - array(0);
---EXPECTF--
-Fatal error: Unsupported operand types in %sconstant_expressions_exceptions_001.php on line 2
+--EXPECT--
+Fatal error: Uncaught TypeError: Unsupported operand types: array - array in [no active file]:0
+Stack trace:
+#0 {main}
+  thrown in [no active file] on line 0

--- a/Zend/tests/constant_expressions_exceptions_002.phpt
+++ b/Zend/tests/constant_expressions_exceptions_002.phpt
@@ -10,4 +10,5 @@ try {
 ?>
 DONE
 --EXPECTF--
-Fatal error: Unsupported operand types in %sconstant_expressions_exceptions.inc on line 2
+Exception: Unsupported operand types: array - array in %s on line %d
+DONE

--- a/Zend/tests/div_002.phpt
+++ b/Zend/tests/div_002.phpt
@@ -18,9 +18,9 @@ var_dump($c);
 echo "Done\n";
 ?>
 --EXPECTF--
-Exception: Unsupported operand types
+Exception: Unsupported operand types: array / array
 
-Fatal error: Uncaught Error: Unsupported operand types in %s:%d
+Fatal error: Uncaught TypeError: Unsupported operand types: array / array in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/mul_001.phpt
+++ b/Zend/tests/mul_001.phpt
@@ -18,9 +18,9 @@ var_dump($c);
 echo "Done\n";
 ?>
 --EXPECTF--
-Exception: Unsupported operand types
+Exception: Unsupported operand types: array * array
 
-Fatal error: Uncaught Error: Unsupported operand types in %s:%d
+Fatal error: Uncaught TypeError: Unsupported operand types: array * array in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/pow_array_leak.phpt
+++ b/Zend/tests/pow_array_leak.phpt
@@ -21,12 +21,12 @@ var_dump($x);
 
 ?>
 --EXPECT--
-Unsupported operand types
+Unsupported operand types: array ** int
 array(1) {
   [0]=>
   int(0)
 }
-Unsupported operand types
+Unsupported operand types: array ** array
 array(1) {
   [0]=>
   int(0)

--- a/Zend/tests/runtime_compile_time_binary_operands.phpt
+++ b/Zend/tests/runtime_compile_time_binary_operands.phpt
@@ -153,5 +153,8 @@ if($c === 0) {
 $fl = __DIR__ . DIRECTORY_SEPARATOR . 'compare_binary_operands_temp.php';
 @unlink($fl);
 ?>
---EXPECT--
-Failed: 0
+--EXPECTF--
+Fatal error: Uncaught TypeError: Unsupported operand types: int + array in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/sub_001.phpt
+++ b/Zend/tests/sub_001.phpt
@@ -18,9 +18,9 @@ var_dump($c);
 echo "Done\n";
 ?>
 --EXPECTF--
-Exception: Unsupported operand types
+Exception: Unsupported operand types: array - array
 
-Fatal error: Uncaught Error: Unsupported operand types in %s:%d
+Fatal error: Uncaught TypeError: Unsupported operand types: array - array in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -939,6 +939,16 @@ ZEND_API zend_string* ZEND_FASTCALL zval_try_get_string_func(zval *op) /* {{{ */
 }
 /* }}} */
 
+static ZEND_COLD zend_never_inline void ZEND_FASTCALL zend_binop_error(
+		const char *operator, zval *op1, zval *op2) {
+	if (EG(exception)) {
+		return;
+	}
+
+	zend_type_error("Unsupported operand types: %s %s %s",
+		zend_get_type_by_const(Z_TYPE_P(op1)), operator, zend_get_type_by_const(Z_TYPE_P(op2)));
+}
+
 static zend_never_inline void ZEND_FASTCALL add_function_array(zval *result, zval *op1, zval *op2) /* {{{ */
 {
 	if ((result == op1) && (result == op2)) {
@@ -991,9 +1001,7 @@ static zend_never_inline int ZEND_FASTCALL add_function_slow(zval *result, zval 
 	zval op1_copy, op2_copy;
 	if (UNEXPECTED(zendi_try_convert_scalar_to_number(op1, &op1_copy) == FAILURE)
 			|| UNEXPECTED(zendi_try_convert_scalar_to_number(op2, &op2_copy) == FAILURE)) {
-		if (!EG(exception)) {
-			zend_throw_error(NULL, "Unsupported operand types");
-		}
+		zend_binop_error("+", op1, op2);
 		if (result != op1) {
 			ZVAL_UNDEF(result);
 		}
@@ -1056,9 +1064,7 @@ static zend_never_inline int ZEND_FASTCALL sub_function_slow(zval *result, zval 
 	zval op1_copy, op2_copy;
 	if (UNEXPECTED(zendi_try_convert_scalar_to_number(op1, &op1_copy) == FAILURE)
 			|| UNEXPECTED(zendi_try_convert_scalar_to_number(op2, &op2_copy) == FAILURE)) {
-		if (!EG(exception)) {
-			zend_throw_error(NULL, "Unsupported operand types");
-		}
+		zend_binop_error("-", op1, op2);
 		if (result != op1) {
 			ZVAL_UNDEF(result);
 		}
@@ -1125,9 +1131,7 @@ static zend_never_inline int ZEND_FASTCALL mul_function_slow(zval *result, zval 
 	zval op1_copy, op2_copy;
 	if (UNEXPECTED(zendi_try_convert_scalar_to_number(op1, &op1_copy) == FAILURE)
 			|| UNEXPECTED(zendi_try_convert_scalar_to_number(op2, &op2_copy) == FAILURE)) {
-		if (!EG(exception)) {
-			zend_throw_error(NULL, "Unsupported operand types");
-		}
+		zend_binop_error("*", op1, op2);
 		if (result != op1) {
 			ZVAL_UNDEF(result);
 		}
@@ -1226,9 +1230,7 @@ ZEND_API int ZEND_FASTCALL pow_function(zval *result, zval *op1, zval *op2) /* {
 	zval op1_copy, op2_copy;
 	if (UNEXPECTED(zendi_try_convert_scalar_to_number(op1, &op1_copy) == FAILURE)
 			|| UNEXPECTED(zendi_try_convert_scalar_to_number(op2, &op2_copy) == FAILURE)) {
-		if (!EG(exception)) {
-			zend_throw_error(NULL, "Unsupported operand types");
-		}
+		zend_binop_error("**", op1, op2);
 		if (result != op1) {
 			ZVAL_UNDEF(result);
 		}
@@ -1306,9 +1308,7 @@ ZEND_API int ZEND_FASTCALL div_function(zval *result, zval *op1, zval *op2) /* {
 	zval op1_copy, op2_copy;
 	if (UNEXPECTED(zendi_try_convert_scalar_to_number(op1, &op1_copy) == FAILURE)
 			|| UNEXPECTED(zendi_try_convert_scalar_to_number(op2, &op2_copy) == FAILURE)) {
-		if (!EG(exception)) {
-			zend_throw_error(NULL, "Unsupported operand types");
-		}
+		zend_binop_error("/", op1, op2);
 		if (result != op1) {
 			ZVAL_UNDEF(result);
 		}

--- a/ext/standard/tests/math/pow_variation1_64bit.phpt
+++ b/ext/standard/tests/math/pow_variation1_64bit.phpt
@@ -156,7 +156,7 @@ Warning: A non-numeric value encountered in %s on line %d
 int(0)
 
 -- Iteration 19 --
-Unsupported operand types
+Unsupported operand types: array ** int
 
 -- Iteration 20 --
 

--- a/ext/standard/tests/math/pow_variation2.phpt
+++ b/ext/standard/tests/math/pow_variation2.phpt
@@ -152,7 +152,7 @@ Warning: A non-numeric value encountered in %s on line %d
 float(1)
 
 -- Iteration 19 --
-Unsupported operand types
+Unsupported operand types: float ** array
 
 -- Iteration 20 --
 


### PR DESCRIPTION
By mentioning the operand types. We can do that now, as the original operand types now remain available.