### PR TITLE
Make numeric operations on resources, arrays and objects type errors

### DIFF
--- a/Zend/tests/add_003.phpt
+++ b/Zend/tests/add_003.phpt
@@ -20,11 +20,7 @@ var_dump($c);
 echo "Done\n";
 ?>
 --EXPECTF--
-Notice: Object of class stdClass could not be converted to number in %sadd_003.php on line %d
-
 Exception: Unsupported operand types: object + array
-
-Notice: Object of class stdClass could not be converted to number in %s on line %d
 
 Fatal error: Uncaught TypeError: Unsupported operand types: object + array in %s:%d
 Stack trace:

--- a/Zend/tests/bug54305.phpt
+++ b/Zend/tests/bug54305.phpt
@@ -9,14 +9,11 @@ class TestClass {
 abstract class AbstractClass {
 }
 $methodWithArgs = new ReflectionMethod('TestClass', 'methodWithArgs');
-echo $methodWithArgs++;
-?>
---EXPECTF--
-Method [ <user> public method methodWithArgs ] {
-  @@ %sbug54305.php %d - %d
-
-  - Parameters [2] {
-    Parameter #0 [ <required> $a ]
-    Parameter #1 [ <required> $b ]
-  }
+try {
+    echo $methodWithArgs++;
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
 }
+?>
+--EXPECT--
+Cannot increment object

--- a/Zend/tests/bug73337.phpt
+++ b/Zend/tests/bug73337.phpt
@@ -5,8 +5,5 @@ Bug #73337 (try/catch not working with two exceptions inside a same operation)
 class d { function __destruct() { throw new Exception; } }
 try { new d + new d; } catch (Exception $e) { print "Exception properly caught\n"; }
 ?>
---EXPECTF--
-Notice: Object of class d could not be converted to number in %sbug73337.php on line 3
-
-Notice: Object of class d could not be converted to number in %sbug73337.php on line 3
+--EXPECT--
 Exception properly caught

--- a/Zend/tests/compound_assign_failure.phpt
+++ b/Zend/tests/compound_assign_failure.phpt
@@ -34,167 +34,167 @@ try {
 
 $x = new stdClass;
 try { $x += 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x += new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x += new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x -= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x -= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x -= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x *= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x *= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x *= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x /= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x /= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x /= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x %= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x %= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x %= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x **= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x **= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x **= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x ^= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x ^= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x ^= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x &= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x &= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x &= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x |= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x |= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x |= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x <<= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x <<= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x <<= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = new stdClass;
 try { $x >>= 1; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = 1;
 try { $x >>= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 $x = "foo";
 try { $x >>= new stdClass; }
-catch (Exception $e) {}
+catch (Throwable $e) {}
 var_dump($x);
 
 ?>

--- a/Zend/tests/decrement_001.phpt
+++ b/Zend/tests/decrement_001.phpt
@@ -26,13 +26,18 @@ $a = array(
 );
 
 foreach ($a as $var) {
-    $var--;
+    try {
+        $var--;
+    } catch (TypeError $e) {
+        echo $e->getMessage(), "\n";
+    }
     var_dump($var);
 }
 
 echo "Done\n";
 ?>
 --EXPECTF--
+Cannot decrement array
 array(3) {
   [0]=>
   int(1)
@@ -51,8 +56,10 @@ float(1.5)
 NULL
 bool(true)
 bool(false)
+Cannot decrement object
 object(stdClass)#%d (0) {
 }
+Cannot decrement array
 array(0) {
 }
 float(-2147483649)

--- a/Zend/tests/decrement_001_64bit.phpt
+++ b/Zend/tests/decrement_001_64bit.phpt
@@ -26,13 +26,18 @@ $a = array(
 );
 
 foreach ($a as $var) {
-    $var--;
+    try {
+        $var--;
+    } catch (TypeError $e) {
+        echo $e->getMessage(), "\n";
+    }
     var_dump($var);
 }
 
 echo "Done\n";
 ?>
---EXPECTF--
+--EXPECT--
+Cannot decrement array
 array(3) {
   [0]=>
   int(1)
@@ -51,8 +56,10 @@ float(1.5)
 NULL
 bool(true)
 bool(false)
-object(stdClass)#%d (0) {
+Cannot decrement object
+object(stdClass)#1 (0) {
 }
+Cannot decrement array
 array(0) {
 }
 float(-9.223372036854776E+18)

--- a/Zend/tests/gc_038.phpt
+++ b/Zend/tests/gc_038.phpt
@@ -6,8 +6,10 @@ zend.enable_gc = 1
 <?php
 function test_add() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x += 5;
+    $x->x = $x;
+    try {
+        $x += 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "+=\t$n\n";
 }
@@ -15,8 +17,10 @@ test_add();
 
 function test_sub() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x -= 5;
+    $x->x = $x;
+    try {
+        $x -= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "-=\t$n\n";
 }
@@ -24,8 +28,10 @@ test_sub();
 
 function test_mul() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x *= 5;
+    $x->x = $x;
+    try {
+        $x *= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "*=\t$n\n";
 }
@@ -33,8 +39,10 @@ test_mul();
 
 function test_div() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x /= 5;
+    $x->x = $x;
+    try {
+        $x /= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "/=\t$n\n";
 }
@@ -42,8 +50,10 @@ test_div();
 
 function test_mod() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x %= 5;
+    $x->x = $x;
+    try {
+        $x %= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "%=\t$n\n";
 }
@@ -51,8 +61,10 @@ test_mod();
 
 function test_sl() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x <<= 5;
+    $x->x = $x;
+    try {
+        $x <<= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "<<=\t$n\n";
 }
@@ -60,8 +72,10 @@ test_sl();
 
 function test_sr() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x >>= 5;
+    $x->x = $x;
+    try {
+        $x >>= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo ">>=\t$n\n";
 }
@@ -69,8 +83,10 @@ test_sr();
 
 function test_or() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x |= 1;
+    $x->x = $x;
+    try {
+        $x |= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "|=\t$n\n";
 }
@@ -78,8 +94,10 @@ test_or();
 
 function test_and() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x &= 1;
+    $x->x = $x;
+    try {
+        $x &= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "&=\t$n\n";
 }
@@ -87,8 +105,10 @@ test_and();
 
 function test_xor() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x ^= 1;
+    $x->x = $x;
+    try {
+        $x ^= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "^=\t$n\n";
 }
@@ -96,8 +116,10 @@ test_xor();
 
 function test_pow() {
     $x = new stdClass;
-    $x->x= $x;
-    @$x **= 1;
+    $x->x = $x;
+    try {
+        $x **= 5;
+    } catch (TypeError $e) { unset($x); }
     $n = gc_collect_cycles();
     echo "**=\t$n\n";
 }
@@ -117,7 +139,7 @@ function test_concat() {
 }
 test_concat();
 ?>
---EXPECT--
+--EXPECTF--
 +=	1
 -=	1
 *=	1

--- a/Zend/tests/increment_001.phpt
+++ b/Zend/tests/increment_001.phpt
@@ -26,13 +26,18 @@ $a = array(
 );
 
 foreach ($a as $var) {
-    $var++;
+    try {
+        $var++;
+    } catch (TypeError $e) {
+        echo $e->getMessage(), "\n";
+    }
     var_dump($var);
 }
 
 echo "Done\n";
 ?>
 --EXPECTF--
+Cannot decrement array
 array(3) {
   [0]=>
   int(1)
@@ -51,8 +56,10 @@ float(3.5)
 int(1)
 bool(true)
 bool(false)
+Cannot decrement object
 object(stdClass)#%d (0) {
 }
+Cannot decrement array
 array(0) {
 }
 float(2147483648)

--- a/Zend/tests/increment_001.phpt
+++ b/Zend/tests/increment_001.phpt
@@ -37,7 +37,7 @@ foreach ($a as $var) {
 echo "Done\n";
 ?>
 --EXPECTF--
-Cannot decrement array
+Cannot increment array
 array(3) {
   [0]=>
   int(1)
@@ -56,10 +56,10 @@ float(3.5)
 int(1)
 bool(true)
 bool(false)
-Cannot decrement object
+Cannot increment object
 object(stdClass)#%d (0) {
 }
-Cannot decrement array
+Cannot increment array
 array(0) {
 }
 float(2147483648)

--- a/Zend/tests/mod_001.phpt
+++ b/Zend/tests/mod_001.phpt
@@ -9,12 +9,12 @@ $b = array();
 try {
     $c = $a % $b;
     var_dump($c);
-} catch (DivisionByZeroError $e) {
+} catch (TypeError $e) {
     echo "Exception: " . $e->getMessage() . "\n";
 }
 
 echo "Done\n";
 ?>
---EXPECT--
-Exception: Modulo by zero
+--EXPECTF--
+Exception: Unsupported operand types: array % array
 Done

--- a/Zend/tests/not_002.phpt
+++ b/Zend/tests/not_002.phpt
@@ -18,9 +18,9 @@ var_dump($a);
 echo "Done\n";
 ?>
 --EXPECTF--
-Exception: Unsupported operand types
+Exception: Cannot perform bitwise not on array
 
-Fatal error: Uncaught Error: Unsupported operand types in %s:%d
+Fatal error: Uncaught TypeError: Cannot perform bitwise not on array in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/operator_unsupported_types.phpt
+++ b/Zend/tests/operator_unsupported_types.phpt
@@ -1,0 +1,860 @@
+--TEST--
+Using unsupported types with operators
+--FILE--
+<?php
+
+$binops = [
+    '+',
+    '-',
+    '*',
+    '/',
+    '%',
+    '**',
+    '<<',
+    '>>',
+    '&',
+    '|',
+    '^',
+    // Works on booleans, never errors.
+    'xor',
+    // Only generates errors that string conversion emits.
+    '.',
+];
+$illegalValues = [
+    '[]',
+    'new stdClass',
+    'STDOUT',
+];
+$legalValues = [
+    'null',
+    'true',
+    'false',
+    '2',
+    '3.5',
+    '"123"',
+    '"foo"', // Semi-legal.
+];
+
+function evalBinOp(string $op, string $value1, string $value2) {
+    try {
+        eval("return $value1 $op $value2;");
+        echo "No error for $value1 $op $value2\n";
+    } catch (Throwable $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+echo "BINOP:\n";
+foreach ($binops as $op) {
+    foreach ($illegalValues as $illegalValue1) {
+        foreach ($illegalValues as $illegalValue2) {
+            evalBinOp($op, $illegalValue1, $illegalValue2);
+        }
+    }
+    foreach ($illegalValues as $illegalValue) {
+        foreach ($legalValues as $legalValue) {
+            evalBinOp($op, $illegalValue, $legalValue);
+            evalBinOp($op, $legalValue, $illegalValue);
+        }
+    }
+}
+
+echo "\n\nUNOP:\n";
+foreach ($illegalValues as $illegalValue) {
+    try {
+        eval("return ~$illegalValue;");
+        echo "No error for ~$copy\n";
+    } catch (TypeError $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+echo "\n\nINCDEC:\n";
+foreach ($illegalValues as $illegalValue) {
+    $copy = eval("return $illegalValue;");
+    try {
+        $copy++;
+        echo "No error for $copy++\n";
+    } catch (TypeError $e) {
+        echo $e->getMessage() . "\n";
+    }
+    $copy = eval("return $illegalValue;");
+    try {
+        $copy--;
+        echo "No error for $copy--\n";
+    } catch (TypeError $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+?>
+--EXPECTF--
+BINOP:
+No error for [] + []
+Unsupported operand types: array + object
+Unsupported operand types: array + resource
+Unsupported operand types: object + array
+Unsupported operand types: object + object
+Unsupported operand types: object + resource
+Unsupported operand types: resource + array
+Unsupported operand types: resource + object
+Unsupported operand types: resource + resource
+Unsupported operand types: array + null
+Unsupported operand types: null + array
+Unsupported operand types: array + bool
+Unsupported operand types: bool + array
+Unsupported operand types: array + bool
+Unsupported operand types: bool + array
+Unsupported operand types: array + int
+Unsupported operand types: int + array
+Unsupported operand types: array + float
+Unsupported operand types: float + array
+Unsupported operand types: array + string
+Unsupported operand types: string + array
+Unsupported operand types: array + string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string + array
+Unsupported operand types: object + null
+Unsupported operand types: null + object
+Unsupported operand types: object + bool
+Unsupported operand types: bool + object
+Unsupported operand types: object + bool
+Unsupported operand types: bool + object
+Unsupported operand types: object + int
+Unsupported operand types: int + object
+Unsupported operand types: object + float
+Unsupported operand types: float + object
+Unsupported operand types: object + string
+Unsupported operand types: string + object
+Unsupported operand types: object + string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string + object
+Unsupported operand types: resource + null
+Unsupported operand types: null + resource
+Unsupported operand types: resource + bool
+Unsupported operand types: bool + resource
+Unsupported operand types: resource + bool
+Unsupported operand types: bool + resource
+Unsupported operand types: resource + int
+Unsupported operand types: int + resource
+Unsupported operand types: resource + float
+Unsupported operand types: float + resource
+Unsupported operand types: resource + string
+Unsupported operand types: string + resource
+Unsupported operand types: resource + string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string + resource
+Unsupported operand types: array - array
+Unsupported operand types: array - object
+Unsupported operand types: array - resource
+Unsupported operand types: object - array
+Unsupported operand types: object - object
+Unsupported operand types: object - resource
+Unsupported operand types: resource - array
+Unsupported operand types: resource - object
+Unsupported operand types: resource - resource
+Unsupported operand types: array - null
+Unsupported operand types: null - array
+Unsupported operand types: array - bool
+Unsupported operand types: bool - array
+Unsupported operand types: array - bool
+Unsupported operand types: bool - array
+Unsupported operand types: array - int
+Unsupported operand types: int - array
+Unsupported operand types: array - float
+Unsupported operand types: float - array
+Unsupported operand types: array - string
+Unsupported operand types: string - array
+Unsupported operand types: array - string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string - array
+Unsupported operand types: object - null
+Unsupported operand types: null - object
+Unsupported operand types: object - bool
+Unsupported operand types: bool - object
+Unsupported operand types: object - bool
+Unsupported operand types: bool - object
+Unsupported operand types: object - int
+Unsupported operand types: int - object
+Unsupported operand types: object - float
+Unsupported operand types: float - object
+Unsupported operand types: object - string
+Unsupported operand types: string - object
+Unsupported operand types: object - string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string - object
+Unsupported operand types: resource - null
+Unsupported operand types: null - resource
+Unsupported operand types: resource - bool
+Unsupported operand types: bool - resource
+Unsupported operand types: resource - bool
+Unsupported operand types: bool - resource
+Unsupported operand types: resource - int
+Unsupported operand types: int - resource
+Unsupported operand types: resource - float
+Unsupported operand types: float - resource
+Unsupported operand types: resource - string
+Unsupported operand types: string - resource
+Unsupported operand types: resource - string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string - resource
+Unsupported operand types: array * array
+Unsupported operand types: object * array
+Unsupported operand types: resource * array
+Unsupported operand types: object * array
+Unsupported operand types: object * object
+Unsupported operand types: object * resource
+Unsupported operand types: resource * array
+Unsupported operand types: object * resource
+Unsupported operand types: resource * resource
+Unsupported operand types: array * null
+Unsupported operand types: null * array
+Unsupported operand types: array * bool
+Unsupported operand types: bool * array
+Unsupported operand types: array * bool
+Unsupported operand types: bool * array
+Unsupported operand types: array * int
+Unsupported operand types: int * array
+Unsupported operand types: array * float
+Unsupported operand types: float * array
+Unsupported operand types: array * string
+Unsupported operand types: string * array
+Unsupported operand types: array * string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string * array
+Unsupported operand types: object * null
+Unsupported operand types: object * null
+Unsupported operand types: object * bool
+Unsupported operand types: object * bool
+Unsupported operand types: object * bool
+Unsupported operand types: object * bool
+Unsupported operand types: object * int
+Unsupported operand types: object * int
+Unsupported operand types: object * float
+Unsupported operand types: object * float
+Unsupported operand types: object * string
+Unsupported operand types: object * string
+Unsupported operand types: object * string
+Unsupported operand types: object * string
+Unsupported operand types: resource * null
+Unsupported operand types: resource * null
+Unsupported operand types: resource * bool
+Unsupported operand types: resource * bool
+Unsupported operand types: resource * bool
+Unsupported operand types: resource * bool
+Unsupported operand types: resource * int
+Unsupported operand types: resource * int
+Unsupported operand types: resource * float
+Unsupported operand types: resource * float
+Unsupported operand types: resource * string
+Unsupported operand types: resource * string
+Unsupported operand types: resource * string
+Unsupported operand types: resource * string
+Unsupported operand types: array / array
+Unsupported operand types: array / object
+Unsupported operand types: array / resource
+Unsupported operand types: object / array
+Unsupported operand types: object / object
+Unsupported operand types: object / resource
+Unsupported operand types: resource / array
+Unsupported operand types: resource / object
+Unsupported operand types: resource / resource
+Unsupported operand types: array / null
+Unsupported operand types: null / array
+Unsupported operand types: array / bool
+Unsupported operand types: bool / array
+Unsupported operand types: array / bool
+Unsupported operand types: bool / array
+Unsupported operand types: array / int
+Unsupported operand types: int / array
+Unsupported operand types: array / float
+Unsupported operand types: float / array
+Unsupported operand types: array / string
+Unsupported operand types: string / array
+Unsupported operand types: array / string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string / array
+Unsupported operand types: object / null
+Unsupported operand types: null / object
+Unsupported operand types: object / bool
+Unsupported operand types: bool / object
+Unsupported operand types: object / bool
+Unsupported operand types: bool / object
+Unsupported operand types: object / int
+Unsupported operand types: int / object
+Unsupported operand types: object / float
+Unsupported operand types: float / object
+Unsupported operand types: object / string
+Unsupported operand types: string / object
+Unsupported operand types: object / string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string / object
+Unsupported operand types: resource / null
+Unsupported operand types: null / resource
+Unsupported operand types: resource / bool
+Unsupported operand types: bool / resource
+Unsupported operand types: resource / bool
+Unsupported operand types: bool / resource
+Unsupported operand types: resource / int
+Unsupported operand types: int / resource
+Unsupported operand types: resource / float
+Unsupported operand types: float / resource
+Unsupported operand types: resource / string
+Unsupported operand types: string / resource
+Unsupported operand types: resource / string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string / resource
+Unsupported operand types: array % array
+Unsupported operand types: array % object
+Unsupported operand types: array % resource
+Unsupported operand types: object % array
+Unsupported operand types: object % object
+Unsupported operand types: object % resource
+Unsupported operand types: resource % array
+Unsupported operand types: resource % object
+Unsupported operand types: resource % resource
+Unsupported operand types: array % null
+Unsupported operand types: null % array
+Unsupported operand types: array % bool
+Unsupported operand types: bool % array
+Unsupported operand types: array % bool
+Unsupported operand types: bool % array
+Unsupported operand types: array % int
+Unsupported operand types: int % array
+Unsupported operand types: array % float
+Unsupported operand types: float % array
+Unsupported operand types: array % string
+Unsupported operand types: string % array
+Unsupported operand types: array % string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string % array
+Unsupported operand types: object % null
+Unsupported operand types: null % object
+Unsupported operand types: object % bool
+Unsupported operand types: bool % object
+Unsupported operand types: object % bool
+Unsupported operand types: bool % object
+Unsupported operand types: object % int
+Unsupported operand types: int % object
+Unsupported operand types: object % float
+Unsupported operand types: float % object
+Unsupported operand types: object % string
+Unsupported operand types: string % object
+Unsupported operand types: object % string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string % object
+Unsupported operand types: resource % null
+Unsupported operand types: null % resource
+Unsupported operand types: resource % bool
+Unsupported operand types: bool % resource
+Unsupported operand types: resource % bool
+Unsupported operand types: bool % resource
+Unsupported operand types: resource % int
+Unsupported operand types: int % resource
+Unsupported operand types: resource % float
+Unsupported operand types: float % resource
+Unsupported operand types: resource % string
+Unsupported operand types: string % resource
+Unsupported operand types: resource % string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string % resource
+Unsupported operand types: array ** array
+Unsupported operand types: array ** object
+Unsupported operand types: array ** resource
+Unsupported operand types: object ** array
+Unsupported operand types: object ** object
+Unsupported operand types: object ** resource
+Unsupported operand types: resource ** array
+Unsupported operand types: resource ** object
+Unsupported operand types: resource ** resource
+Unsupported operand types: array ** null
+Unsupported operand types: null ** array
+Unsupported operand types: array ** bool
+Unsupported operand types: bool ** array
+Unsupported operand types: array ** bool
+Unsupported operand types: bool ** array
+Unsupported operand types: array ** int
+Unsupported operand types: int ** array
+Unsupported operand types: array ** float
+Unsupported operand types: float ** array
+Unsupported operand types: array ** string
+Unsupported operand types: string ** array
+Unsupported operand types: array ** string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ** array
+Unsupported operand types: object ** null
+Unsupported operand types: null ** object
+Unsupported operand types: object ** bool
+Unsupported operand types: bool ** object
+Unsupported operand types: object ** bool
+Unsupported operand types: bool ** object
+Unsupported operand types: object ** int
+Unsupported operand types: int ** object
+Unsupported operand types: object ** float
+Unsupported operand types: float ** object
+Unsupported operand types: object ** string
+Unsupported operand types: string ** object
+Unsupported operand types: object ** string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ** object
+Unsupported operand types: resource ** null
+Unsupported operand types: null ** resource
+Unsupported operand types: resource ** bool
+Unsupported operand types: bool ** resource
+Unsupported operand types: resource ** bool
+Unsupported operand types: bool ** resource
+Unsupported operand types: resource ** int
+Unsupported operand types: int ** resource
+Unsupported operand types: resource ** float
+Unsupported operand types: float ** resource
+Unsupported operand types: resource ** string
+Unsupported operand types: string ** resource
+Unsupported operand types: resource ** string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ** resource
+Unsupported operand types: array << array
+Unsupported operand types: array << object
+Unsupported operand types: array << resource
+Unsupported operand types: object << array
+Unsupported operand types: object << object
+Unsupported operand types: object << resource
+Unsupported operand types: resource << array
+Unsupported operand types: resource << object
+Unsupported operand types: resource << resource
+Unsupported operand types: array << null
+Unsupported operand types: null << array
+Unsupported operand types: array << bool
+Unsupported operand types: bool << array
+Unsupported operand types: array << bool
+Unsupported operand types: bool << array
+Unsupported operand types: array << int
+Unsupported operand types: int << array
+Unsupported operand types: array << float
+Unsupported operand types: float << array
+Unsupported operand types: array << string
+Unsupported operand types: string << array
+Unsupported operand types: array << string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string << array
+Unsupported operand types: object << null
+Unsupported operand types: null << object
+Unsupported operand types: object << bool
+Unsupported operand types: bool << object
+Unsupported operand types: object << bool
+Unsupported operand types: bool << object
+Unsupported operand types: object << int
+Unsupported operand types: int << object
+Unsupported operand types: object << float
+Unsupported operand types: float << object
+Unsupported operand types: object << string
+Unsupported operand types: string << object
+Unsupported operand types: object << string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string << object
+Unsupported operand types: resource << null
+Unsupported operand types: null << resource
+Unsupported operand types: resource << bool
+Unsupported operand types: bool << resource
+Unsupported operand types: resource << bool
+Unsupported operand types: bool << resource
+Unsupported operand types: resource << int
+Unsupported operand types: int << resource
+Unsupported operand types: resource << float
+Unsupported operand types: float << resource
+Unsupported operand types: resource << string
+Unsupported operand types: string << resource
+Unsupported operand types: resource << string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string << resource
+Unsupported operand types: array >> array
+Unsupported operand types: array >> object
+Unsupported operand types: array >> resource
+Unsupported operand types: object >> array
+Unsupported operand types: object >> object
+Unsupported operand types: object >> resource
+Unsupported operand types: resource >> array
+Unsupported operand types: resource >> object
+Unsupported operand types: resource >> resource
+Unsupported operand types: array >> null
+Unsupported operand types: null >> array
+Unsupported operand types: array >> bool
+Unsupported operand types: bool >> array
+Unsupported operand types: array >> bool
+Unsupported operand types: bool >> array
+Unsupported operand types: array >> int
+Unsupported operand types: int >> array
+Unsupported operand types: array >> float
+Unsupported operand types: float >> array
+Unsupported operand types: array >> string
+Unsupported operand types: string >> array
+Unsupported operand types: array >> string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string >> array
+Unsupported operand types: object >> null
+Unsupported operand types: null >> object
+Unsupported operand types: object >> bool
+Unsupported operand types: bool >> object
+Unsupported operand types: object >> bool
+Unsupported operand types: bool >> object
+Unsupported operand types: object >> int
+Unsupported operand types: int >> object
+Unsupported operand types: object >> float
+Unsupported operand types: float >> object
+Unsupported operand types: object >> string
+Unsupported operand types: string >> object
+Unsupported operand types: object >> string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string >> object
+Unsupported operand types: resource >> null
+Unsupported operand types: null >> resource
+Unsupported operand types: resource >> bool
+Unsupported operand types: bool >> resource
+Unsupported operand types: resource >> bool
+Unsupported operand types: bool >> resource
+Unsupported operand types: resource >> int
+Unsupported operand types: int >> resource
+Unsupported operand types: resource >> float
+Unsupported operand types: float >> resource
+Unsupported operand types: resource >> string
+Unsupported operand types: string >> resource
+Unsupported operand types: resource >> string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string >> resource
+Unsupported operand types: array & array
+Unsupported operand types: object & array
+Unsupported operand types: resource & array
+Unsupported operand types: object & array
+Unsupported operand types: object & object
+Unsupported operand types: object & resource
+Unsupported operand types: resource & array
+Unsupported operand types: object & resource
+Unsupported operand types: resource & resource
+Unsupported operand types: array & null
+Unsupported operand types: null & array
+Unsupported operand types: array & bool
+Unsupported operand types: bool & array
+Unsupported operand types: array & bool
+Unsupported operand types: bool & array
+Unsupported operand types: array & int
+Unsupported operand types: int & array
+Unsupported operand types: array & float
+Unsupported operand types: float & array
+Unsupported operand types: array & string
+Unsupported operand types: string & array
+Unsupported operand types: array & string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string & array
+Unsupported operand types: object & null
+Unsupported operand types: object & null
+Unsupported operand types: object & bool
+Unsupported operand types: object & bool
+Unsupported operand types: object & bool
+Unsupported operand types: object & bool
+Unsupported operand types: object & int
+Unsupported operand types: object & int
+Unsupported operand types: object & float
+Unsupported operand types: object & float
+Unsupported operand types: object & string
+Unsupported operand types: object & string
+Unsupported operand types: object & string
+Unsupported operand types: object & string
+Unsupported operand types: resource & null
+Unsupported operand types: resource & null
+Unsupported operand types: resource & bool
+Unsupported operand types: resource & bool
+Unsupported operand types: resource & bool
+Unsupported operand types: resource & bool
+Unsupported operand types: resource & int
+Unsupported operand types: resource & int
+Unsupported operand types: resource & float
+Unsupported operand types: resource & float
+Unsupported operand types: resource & string
+Unsupported operand types: resource & string
+Unsupported operand types: resource & string
+Unsupported operand types: resource & string
+Unsupported operand types: array | array
+Unsupported operand types: object | array
+Unsupported operand types: resource | array
+Unsupported operand types: object | array
+Unsupported operand types: object | object
+Unsupported operand types: object | resource
+Unsupported operand types: resource | array
+Unsupported operand types: object | resource
+Unsupported operand types: resource | resource
+Unsupported operand types: array | null
+Unsupported operand types: null | array
+Unsupported operand types: array | bool
+Unsupported operand types: bool | array
+Unsupported operand types: array | bool
+Unsupported operand types: bool | array
+Unsupported operand types: array | int
+Unsupported operand types: int | array
+Unsupported operand types: array | float
+Unsupported operand types: float | array
+Unsupported operand types: array | string
+Unsupported operand types: string | array
+Unsupported operand types: array | string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string | array
+Unsupported operand types: object | null
+Unsupported operand types: object | null
+Unsupported operand types: object | bool
+Unsupported operand types: object | bool
+Unsupported operand types: object | bool
+Unsupported operand types: object | bool
+Unsupported operand types: object | int
+Unsupported operand types: object | int
+Unsupported operand types: object | float
+Unsupported operand types: object | float
+Unsupported operand types: object | string
+Unsupported operand types: object | string
+Unsupported operand types: object | string
+Unsupported operand types: object | string
+Unsupported operand types: resource | null
+Unsupported operand types: resource | null
+Unsupported operand types: resource | bool
+Unsupported operand types: resource | bool
+Unsupported operand types: resource | bool
+Unsupported operand types: resource | bool
+Unsupported operand types: resource | int
+Unsupported operand types: resource | int
+Unsupported operand types: resource | float
+Unsupported operand types: resource | float
+Unsupported operand types: resource | string
+Unsupported operand types: resource | string
+Unsupported operand types: resource | string
+Unsupported operand types: resource | string
+Unsupported operand types: array ^ array
+Unsupported operand types: object ^ array
+Unsupported operand types: resource ^ array
+Unsupported operand types: object ^ array
+Unsupported operand types: object ^ object
+Unsupported operand types: object ^ resource
+Unsupported operand types: resource ^ array
+Unsupported operand types: object ^ resource
+Unsupported operand types: resource ^ resource
+Unsupported operand types: array ^ null
+Unsupported operand types: null ^ array
+Unsupported operand types: array ^ bool
+Unsupported operand types: bool ^ array
+Unsupported operand types: array ^ bool
+Unsupported operand types: bool ^ array
+Unsupported operand types: array ^ int
+Unsupported operand types: int ^ array
+Unsupported operand types: array ^ float
+Unsupported operand types: float ^ array
+Unsupported operand types: array ^ string
+Unsupported operand types: string ^ array
+Unsupported operand types: array ^ string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ^ array
+Unsupported operand types: object ^ null
+Unsupported operand types: object ^ null
+Unsupported operand types: object ^ bool
+Unsupported operand types: object ^ bool
+Unsupported operand types: object ^ bool
+Unsupported operand types: object ^ bool
+Unsupported operand types: object ^ int
+Unsupported operand types: object ^ int
+Unsupported operand types: object ^ float
+Unsupported operand types: object ^ float
+Unsupported operand types: object ^ string
+Unsupported operand types: object ^ string
+Unsupported operand types: object ^ string
+Unsupported operand types: object ^ string
+Unsupported operand types: resource ^ null
+Unsupported operand types: resource ^ null
+Unsupported operand types: resource ^ bool
+Unsupported operand types: resource ^ bool
+Unsupported operand types: resource ^ bool
+Unsupported operand types: resource ^ bool
+Unsupported operand types: resource ^ int
+Unsupported operand types: resource ^ int
+Unsupported operand types: resource ^ float
+Unsupported operand types: resource ^ float
+Unsupported operand types: resource ^ string
+Unsupported operand types: resource ^ string
+Unsupported operand types: resource ^ string
+Unsupported operand types: resource ^ string
+No error for [] xor []
+No error for [] xor new stdClass
+No error for [] xor STDOUT
+No error for new stdClass xor []
+No error for new stdClass xor new stdClass
+No error for new stdClass xor STDOUT
+No error for STDOUT xor []
+No error for STDOUT xor new stdClass
+No error for STDOUT xor STDOUT
+No error for [] xor null
+No error for null xor []
+No error for [] xor true
+No error for true xor []
+No error for [] xor false
+No error for false xor []
+No error for [] xor 2
+No error for 2 xor []
+No error for [] xor 3.5
+No error for 3.5 xor []
+No error for [] xor "123"
+No error for "123" xor []
+No error for [] xor "foo"
+No error for "foo" xor []
+No error for new stdClass xor null
+No error for null xor new stdClass
+No error for new stdClass xor true
+No error for true xor new stdClass
+No error for new stdClass xor false
+No error for false xor new stdClass
+No error for new stdClass xor 2
+No error for 2 xor new stdClass
+No error for new stdClass xor 3.5
+No error for 3.5 xor new stdClass
+No error for new stdClass xor "123"
+No error for "123" xor new stdClass
+No error for new stdClass xor "foo"
+No error for "foo" xor new stdClass
+No error for STDOUT xor null
+No error for null xor STDOUT
+No error for STDOUT xor true
+No error for true xor STDOUT
+No error for STDOUT xor false
+No error for false xor STDOUT
+No error for STDOUT xor 2
+No error for 2 xor STDOUT
+No error for STDOUT xor 3.5
+No error for 3.5 xor STDOUT
+No error for STDOUT xor "123"
+No error for "123" xor STDOUT
+No error for STDOUT xor "foo"
+No error for "foo" xor STDOUT
+
+Warning: Array to string conversion in %s on line %d
+
+Warning: Array to string conversion in %s on line %d
+No error for [] . []
+
+Warning: Array to string conversion in %s on line %d
+Object of class stdClass could not be converted to string
+
+Warning: Array to string conversion in %s on line %d
+No error for [] . STDOUT
+
+Warning: Array to string conversion in %s on line %d
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+
+Warning: Array to string conversion in %s on line %d
+No error for STDOUT . []
+Object of class stdClass could not be converted to string
+No error for STDOUT . STDOUT
+
+Warning: Array to string conversion in %s on line %d
+No error for [] . null
+
+Warning: Array to string conversion in %s on line %d
+No error for null . []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] . true
+
+Warning: Array to string conversion in %s on line %d
+No error for true . []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] . false
+
+Warning: Array to string conversion in %s on line %d
+No error for false . []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] . 2
+
+Warning: Array to string conversion in %s on line %d
+No error for 2 . []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] . 3.5
+
+Warning: Array to string conversion in %s on line %d
+No error for 3.5 . []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] . "123"
+
+Warning: Array to string conversion in %s on line %d
+No error for "123" . []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] . "foo"
+
+Warning: Array to string conversion in %s on line %d
+No error for "foo" . []
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+No error for STDOUT . null
+No error for null . STDOUT
+No error for STDOUT . true
+No error for true . STDOUT
+No error for STDOUT . false
+No error for false . STDOUT
+No error for STDOUT . 2
+No error for 2 . STDOUT
+No error for STDOUT . 3.5
+No error for 3.5 . STDOUT
+No error for STDOUT . "123"
+No error for "123" . STDOUT
+No error for STDOUT . "foo"
+No error for "foo" . STDOUT
+
+
+UNOP:
+Cannot perform bitwise not on array
+Cannot perform bitwise not on object
+Cannot perform bitwise not on resource
+
+
+INCDEC:
+Cannot increment array
+Cannot decrement array
+Cannot increment object
+Cannot decrement object
+Cannot increment resource
+Cannot decrement resource

--- a/Zend/tests/operator_unsupported_types.phpt
+++ b/Zend/tests/operator_unsupported_types.phpt
@@ -44,7 +44,20 @@ function evalBinOp(string $op, string $value1, string $value2) {
     }
 }
 
-echo "BINOP:\n";
+function evalAssignOp(string $op, string $value1, string $value2) {
+    $x = $origX = eval("return $value1;");
+    try {
+        eval("\$x $op= $value2;");
+        echo "No error for $value1 $op= $value2\n";
+    } catch (Throwable $e) {
+        echo $e->getMessage() . "\n";
+        if ($x !== $origX) {
+            die("Value corrupted!");
+        }
+    }
+}
+
+echo "BINARY OP:\n";
 foreach ($binops as $op) {
     foreach ($illegalValues as $illegalValue1) {
         foreach ($illegalValues as $illegalValue2) {
@@ -59,7 +72,24 @@ foreach ($binops as $op) {
     }
 }
 
-echo "\n\nUNOP:\n";
+echo "\n\nASSIGN OP:\n";
+foreach ($binops as $op) {
+    if ($op === 'xor') continue;
+
+    foreach ($illegalValues as $illegalValue1) {
+        foreach ($illegalValues as $illegalValue2) {
+            evalAssignOp($op, $illegalValue1, $illegalValue2);
+        }
+    }
+    foreach ($illegalValues as $illegalValue) {
+        foreach ($legalValues as $legalValue) {
+            evalAssignOp($op, $illegalValue, $legalValue);
+            evalAssignOp($op, $legalValue, $illegalValue);
+        }
+    }
+}
+
+echo "\n\nUNARY OP:\n";
 foreach ($illegalValues as $illegalValue) {
     try {
         eval("return ~$illegalValue;");
@@ -89,7 +119,7 @@ foreach ($illegalValues as $illegalValue) {
 
 ?>
 --EXPECTF--
-BINOP:
+BINARY OP:
 No error for [] + []
 Unsupported operand types: array + object
 Unsupported operand types: array + resource
@@ -845,7 +875,726 @@ No error for STDOUT . "foo"
 No error for "foo" . STDOUT
 
 
-UNOP:
+ASSIGN OP:
+No error for [] += []
+Unsupported operand types: array + object
+Unsupported operand types: array + resource
+Unsupported operand types: object + array
+Unsupported operand types: object + object
+Unsupported operand types: object + resource
+Unsupported operand types: resource + array
+Unsupported operand types: resource + object
+Unsupported operand types: resource + resource
+Unsupported operand types: array + null
+Unsupported operand types: null + array
+Unsupported operand types: array + bool
+Unsupported operand types: bool + array
+Unsupported operand types: array + bool
+Unsupported operand types: bool + array
+Unsupported operand types: array + int
+Unsupported operand types: int + array
+Unsupported operand types: array + float
+Unsupported operand types: float + array
+Unsupported operand types: array + string
+Unsupported operand types: string + array
+Unsupported operand types: array + string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string + array
+Unsupported operand types: object + null
+Unsupported operand types: null + object
+Unsupported operand types: object + bool
+Unsupported operand types: bool + object
+Unsupported operand types: object + bool
+Unsupported operand types: bool + object
+Unsupported operand types: object + int
+Unsupported operand types: int + object
+Unsupported operand types: object + float
+Unsupported operand types: float + object
+Unsupported operand types: object + string
+Unsupported operand types: string + object
+Unsupported operand types: object + string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string + object
+Unsupported operand types: resource + null
+Unsupported operand types: null + resource
+Unsupported operand types: resource + bool
+Unsupported operand types: bool + resource
+Unsupported operand types: resource + bool
+Unsupported operand types: bool + resource
+Unsupported operand types: resource + int
+Unsupported operand types: int + resource
+Unsupported operand types: resource + float
+Unsupported operand types: float + resource
+Unsupported operand types: resource + string
+Unsupported operand types: string + resource
+Unsupported operand types: resource + string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string + resource
+Unsupported operand types: array - array
+Unsupported operand types: array - object
+Unsupported operand types: array - resource
+Unsupported operand types: object - array
+Unsupported operand types: object - object
+Unsupported operand types: object - resource
+Unsupported operand types: resource - array
+Unsupported operand types: resource - object
+Unsupported operand types: resource - resource
+Unsupported operand types: array - null
+Unsupported operand types: null - array
+Unsupported operand types: array - bool
+Unsupported operand types: bool - array
+Unsupported operand types: array - bool
+Unsupported operand types: bool - array
+Unsupported operand types: array - int
+Unsupported operand types: int - array
+Unsupported operand types: array - float
+Unsupported operand types: float - array
+Unsupported operand types: array - string
+Unsupported operand types: string - array
+Unsupported operand types: array - string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string - array
+Unsupported operand types: object - null
+Unsupported operand types: null - object
+Unsupported operand types: object - bool
+Unsupported operand types: bool - object
+Unsupported operand types: object - bool
+Unsupported operand types: bool - object
+Unsupported operand types: object - int
+Unsupported operand types: int - object
+Unsupported operand types: object - float
+Unsupported operand types: float - object
+Unsupported operand types: object - string
+Unsupported operand types: string - object
+Unsupported operand types: object - string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string - object
+Unsupported operand types: resource - null
+Unsupported operand types: null - resource
+Unsupported operand types: resource - bool
+Unsupported operand types: bool - resource
+Unsupported operand types: resource - bool
+Unsupported operand types: bool - resource
+Unsupported operand types: resource - int
+Unsupported operand types: int - resource
+Unsupported operand types: resource - float
+Unsupported operand types: float - resource
+Unsupported operand types: resource - string
+Unsupported operand types: string - resource
+Unsupported operand types: resource - string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string - resource
+Unsupported operand types: array * array
+Unsupported operand types: array * object
+Unsupported operand types: array * resource
+Unsupported operand types: object * array
+Unsupported operand types: object * object
+Unsupported operand types: object * resource
+Unsupported operand types: resource * array
+Unsupported operand types: resource * object
+Unsupported operand types: resource * resource
+Unsupported operand types: array * null
+Unsupported operand types: null * array
+Unsupported operand types: array * bool
+Unsupported operand types: bool * array
+Unsupported operand types: array * bool
+Unsupported operand types: bool * array
+Unsupported operand types: array * int
+Unsupported operand types: int * array
+Unsupported operand types: array * float
+Unsupported operand types: float * array
+Unsupported operand types: array * string
+Unsupported operand types: string * array
+Unsupported operand types: array * string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string * array
+Unsupported operand types: object * null
+Unsupported operand types: null * object
+Unsupported operand types: object * bool
+Unsupported operand types: bool * object
+Unsupported operand types: object * bool
+Unsupported operand types: bool * object
+Unsupported operand types: object * int
+Unsupported operand types: int * object
+Unsupported operand types: object * float
+Unsupported operand types: float * object
+Unsupported operand types: object * string
+Unsupported operand types: string * object
+Unsupported operand types: object * string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string * object
+Unsupported operand types: resource * null
+Unsupported operand types: null * resource
+Unsupported operand types: resource * bool
+Unsupported operand types: bool * resource
+Unsupported operand types: resource * bool
+Unsupported operand types: bool * resource
+Unsupported operand types: resource * int
+Unsupported operand types: int * resource
+Unsupported operand types: resource * float
+Unsupported operand types: float * resource
+Unsupported operand types: resource * string
+Unsupported operand types: string * resource
+Unsupported operand types: resource * string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string * resource
+Unsupported operand types: array / array
+Unsupported operand types: array / object
+Unsupported operand types: array / resource
+Unsupported operand types: object / array
+Unsupported operand types: object / object
+Unsupported operand types: object / resource
+Unsupported operand types: resource / array
+Unsupported operand types: resource / object
+Unsupported operand types: resource / resource
+Unsupported operand types: array / null
+Unsupported operand types: null / array
+Unsupported operand types: array / bool
+Unsupported operand types: bool / array
+Unsupported operand types: array / bool
+Unsupported operand types: bool / array
+Unsupported operand types: array / int
+Unsupported operand types: int / array
+Unsupported operand types: array / float
+Unsupported operand types: float / array
+Unsupported operand types: array / string
+Unsupported operand types: string / array
+Unsupported operand types: array / string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string / array
+Unsupported operand types: object / null
+Unsupported operand types: null / object
+Unsupported operand types: object / bool
+Unsupported operand types: bool / object
+Unsupported operand types: object / bool
+Unsupported operand types: bool / object
+Unsupported operand types: object / int
+Unsupported operand types: int / object
+Unsupported operand types: object / float
+Unsupported operand types: float / object
+Unsupported operand types: object / string
+Unsupported operand types: string / object
+Unsupported operand types: object / string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string / object
+Unsupported operand types: resource / null
+Unsupported operand types: null / resource
+Unsupported operand types: resource / bool
+Unsupported operand types: bool / resource
+Unsupported operand types: resource / bool
+Unsupported operand types: bool / resource
+Unsupported operand types: resource / int
+Unsupported operand types: int / resource
+Unsupported operand types: resource / float
+Unsupported operand types: float / resource
+Unsupported operand types: resource / string
+Unsupported operand types: string / resource
+Unsupported operand types: resource / string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string / resource
+Unsupported operand types: array % array
+Unsupported operand types: array % object
+Unsupported operand types: array % resource
+Unsupported operand types: object % array
+Unsupported operand types: object % object
+Unsupported operand types: object % resource
+Unsupported operand types: resource % array
+Unsupported operand types: resource % object
+Unsupported operand types: resource % resource
+Unsupported operand types: array % null
+Unsupported operand types: null % array
+Unsupported operand types: array % bool
+Unsupported operand types: bool % array
+Unsupported operand types: array % bool
+Unsupported operand types: bool % array
+Unsupported operand types: array % int
+Unsupported operand types: int % array
+Unsupported operand types: array % float
+Unsupported operand types: float % array
+Unsupported operand types: array % string
+Unsupported operand types: string % array
+Unsupported operand types: array % string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string % array
+Unsupported operand types: object % null
+Unsupported operand types: null % object
+Unsupported operand types: object % bool
+Unsupported operand types: bool % object
+Unsupported operand types: object % bool
+Unsupported operand types: bool % object
+Unsupported operand types: object % int
+Unsupported operand types: int % object
+Unsupported operand types: object % float
+Unsupported operand types: float % object
+Unsupported operand types: object % string
+Unsupported operand types: string % object
+Unsupported operand types: object % string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string % object
+Unsupported operand types: resource % null
+Unsupported operand types: null % resource
+Unsupported operand types: resource % bool
+Unsupported operand types: bool % resource
+Unsupported operand types: resource % bool
+Unsupported operand types: bool % resource
+Unsupported operand types: resource % int
+Unsupported operand types: int % resource
+Unsupported operand types: resource % float
+Unsupported operand types: float % resource
+Unsupported operand types: resource % string
+Unsupported operand types: string % resource
+Unsupported operand types: resource % string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string % resource
+Unsupported operand types: array ** array
+Unsupported operand types: array ** object
+Unsupported operand types: array ** resource
+Unsupported operand types: object ** array
+Unsupported operand types: object ** object
+Unsupported operand types: object ** resource
+Unsupported operand types: resource ** array
+Unsupported operand types: resource ** object
+Unsupported operand types: resource ** resource
+Unsupported operand types: array ** null
+Unsupported operand types: null ** array
+Unsupported operand types: array ** bool
+Unsupported operand types: bool ** array
+Unsupported operand types: array ** bool
+Unsupported operand types: bool ** array
+Unsupported operand types: array ** int
+Unsupported operand types: int ** array
+Unsupported operand types: array ** float
+Unsupported operand types: float ** array
+Unsupported operand types: array ** string
+Unsupported operand types: string ** array
+Unsupported operand types: array ** string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ** array
+Unsupported operand types: object ** null
+Unsupported operand types: null ** object
+Unsupported operand types: object ** bool
+Unsupported operand types: bool ** object
+Unsupported operand types: object ** bool
+Unsupported operand types: bool ** object
+Unsupported operand types: object ** int
+Unsupported operand types: int ** object
+Unsupported operand types: object ** float
+Unsupported operand types: float ** object
+Unsupported operand types: object ** string
+Unsupported operand types: string ** object
+Unsupported operand types: object ** string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ** object
+Unsupported operand types: resource ** null
+Unsupported operand types: null ** resource
+Unsupported operand types: resource ** bool
+Unsupported operand types: bool ** resource
+Unsupported operand types: resource ** bool
+Unsupported operand types: bool ** resource
+Unsupported operand types: resource ** int
+Unsupported operand types: int ** resource
+Unsupported operand types: resource ** float
+Unsupported operand types: float ** resource
+Unsupported operand types: resource ** string
+Unsupported operand types: string ** resource
+Unsupported operand types: resource ** string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ** resource
+Unsupported operand types: array << array
+Unsupported operand types: array << object
+Unsupported operand types: array << resource
+Unsupported operand types: object << array
+Unsupported operand types: object << object
+Unsupported operand types: object << resource
+Unsupported operand types: resource << array
+Unsupported operand types: resource << object
+Unsupported operand types: resource << resource
+Unsupported operand types: array << null
+Unsupported operand types: null << array
+Unsupported operand types: array << bool
+Unsupported operand types: bool << array
+Unsupported operand types: array << bool
+Unsupported operand types: bool << array
+Unsupported operand types: array << int
+Unsupported operand types: int << array
+Unsupported operand types: array << float
+Unsupported operand types: float << array
+Unsupported operand types: array << string
+Unsupported operand types: string << array
+Unsupported operand types: array << string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string << array
+Unsupported operand types: object << null
+Unsupported operand types: null << object
+Unsupported operand types: object << bool
+Unsupported operand types: bool << object
+Unsupported operand types: object << bool
+Unsupported operand types: bool << object
+Unsupported operand types: object << int
+Unsupported operand types: int << object
+Unsupported operand types: object << float
+Unsupported operand types: float << object
+Unsupported operand types: object << string
+Unsupported operand types: string << object
+Unsupported operand types: object << string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string << object
+Unsupported operand types: resource << null
+Unsupported operand types: null << resource
+Unsupported operand types: resource << bool
+Unsupported operand types: bool << resource
+Unsupported operand types: resource << bool
+Unsupported operand types: bool << resource
+Unsupported operand types: resource << int
+Unsupported operand types: int << resource
+Unsupported operand types: resource << float
+Unsupported operand types: float << resource
+Unsupported operand types: resource << string
+Unsupported operand types: string << resource
+Unsupported operand types: resource << string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string << resource
+Unsupported operand types: array >> array
+Unsupported operand types: array >> object
+Unsupported operand types: array >> resource
+Unsupported operand types: object >> array
+Unsupported operand types: object >> object
+Unsupported operand types: object >> resource
+Unsupported operand types: resource >> array
+Unsupported operand types: resource >> object
+Unsupported operand types: resource >> resource
+Unsupported operand types: array >> null
+Unsupported operand types: null >> array
+Unsupported operand types: array >> bool
+Unsupported operand types: bool >> array
+Unsupported operand types: array >> bool
+Unsupported operand types: bool >> array
+Unsupported operand types: array >> int
+Unsupported operand types: int >> array
+Unsupported operand types: array >> float
+Unsupported operand types: float >> array
+Unsupported operand types: array >> string
+Unsupported operand types: string >> array
+Unsupported operand types: array >> string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string >> array
+Unsupported operand types: object >> null
+Unsupported operand types: null >> object
+Unsupported operand types: object >> bool
+Unsupported operand types: bool >> object
+Unsupported operand types: object >> bool
+Unsupported operand types: bool >> object
+Unsupported operand types: object >> int
+Unsupported operand types: int >> object
+Unsupported operand types: object >> float
+Unsupported operand types: float >> object
+Unsupported operand types: object >> string
+Unsupported operand types: string >> object
+Unsupported operand types: object >> string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string >> object
+Unsupported operand types: resource >> null
+Unsupported operand types: null >> resource
+Unsupported operand types: resource >> bool
+Unsupported operand types: bool >> resource
+Unsupported operand types: resource >> bool
+Unsupported operand types: bool >> resource
+Unsupported operand types: resource >> int
+Unsupported operand types: int >> resource
+Unsupported operand types: resource >> float
+Unsupported operand types: float >> resource
+Unsupported operand types: resource >> string
+Unsupported operand types: string >> resource
+Unsupported operand types: resource >> string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string >> resource
+Unsupported operand types: array & array
+Unsupported operand types: array & object
+Unsupported operand types: array & resource
+Unsupported operand types: object & array
+Unsupported operand types: object & object
+Unsupported operand types: object & resource
+Unsupported operand types: resource & array
+Unsupported operand types: resource & object
+Unsupported operand types: resource & resource
+Unsupported operand types: array & null
+Unsupported operand types: null & array
+Unsupported operand types: array & bool
+Unsupported operand types: bool & array
+Unsupported operand types: array & bool
+Unsupported operand types: bool & array
+Unsupported operand types: array & int
+Unsupported operand types: int & array
+Unsupported operand types: array & float
+Unsupported operand types: float & array
+Unsupported operand types: array & string
+Unsupported operand types: string & array
+Unsupported operand types: array & string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string & array
+Unsupported operand types: object & null
+Unsupported operand types: null & object
+Unsupported operand types: object & bool
+Unsupported operand types: bool & object
+Unsupported operand types: object & bool
+Unsupported operand types: bool & object
+Unsupported operand types: object & int
+Unsupported operand types: int & object
+Unsupported operand types: object & float
+Unsupported operand types: float & object
+Unsupported operand types: object & string
+Unsupported operand types: string & object
+Unsupported operand types: object & string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string & object
+Unsupported operand types: resource & null
+Unsupported operand types: null & resource
+Unsupported operand types: resource & bool
+Unsupported operand types: bool & resource
+Unsupported operand types: resource & bool
+Unsupported operand types: bool & resource
+Unsupported operand types: resource & int
+Unsupported operand types: int & resource
+Unsupported operand types: resource & float
+Unsupported operand types: float & resource
+Unsupported operand types: resource & string
+Unsupported operand types: string & resource
+Unsupported operand types: resource & string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string & resource
+Unsupported operand types: array | array
+Unsupported operand types: array | object
+Unsupported operand types: array | resource
+Unsupported operand types: object | array
+Unsupported operand types: object | object
+Unsupported operand types: object | resource
+Unsupported operand types: resource | array
+Unsupported operand types: resource | object
+Unsupported operand types: resource | resource
+Unsupported operand types: array | null
+Unsupported operand types: null | array
+Unsupported operand types: array | bool
+Unsupported operand types: bool | array
+Unsupported operand types: array | bool
+Unsupported operand types: bool | array
+Unsupported operand types: array | int
+Unsupported operand types: int | array
+Unsupported operand types: array | float
+Unsupported operand types: float | array
+Unsupported operand types: array | string
+Unsupported operand types: string | array
+Unsupported operand types: array | string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string | array
+Unsupported operand types: object | null
+Unsupported operand types: null | object
+Unsupported operand types: object | bool
+Unsupported operand types: bool | object
+Unsupported operand types: object | bool
+Unsupported operand types: bool | object
+Unsupported operand types: object | int
+Unsupported operand types: int | object
+Unsupported operand types: object | float
+Unsupported operand types: float | object
+Unsupported operand types: object | string
+Unsupported operand types: string | object
+Unsupported operand types: object | string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string | object
+Unsupported operand types: resource | null
+Unsupported operand types: null | resource
+Unsupported operand types: resource | bool
+Unsupported operand types: bool | resource
+Unsupported operand types: resource | bool
+Unsupported operand types: bool | resource
+Unsupported operand types: resource | int
+Unsupported operand types: int | resource
+Unsupported operand types: resource | float
+Unsupported operand types: float | resource
+Unsupported operand types: resource | string
+Unsupported operand types: string | resource
+Unsupported operand types: resource | string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string | resource
+Unsupported operand types: array ^ array
+Unsupported operand types: array ^ object
+Unsupported operand types: array ^ resource
+Unsupported operand types: object ^ array
+Unsupported operand types: object ^ object
+Unsupported operand types: object ^ resource
+Unsupported operand types: resource ^ array
+Unsupported operand types: resource ^ object
+Unsupported operand types: resource ^ resource
+Unsupported operand types: array ^ null
+Unsupported operand types: null ^ array
+Unsupported operand types: array ^ bool
+Unsupported operand types: bool ^ array
+Unsupported operand types: array ^ bool
+Unsupported operand types: bool ^ array
+Unsupported operand types: array ^ int
+Unsupported operand types: int ^ array
+Unsupported operand types: array ^ float
+Unsupported operand types: float ^ array
+Unsupported operand types: array ^ string
+Unsupported operand types: string ^ array
+Unsupported operand types: array ^ string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ^ array
+Unsupported operand types: object ^ null
+Unsupported operand types: null ^ object
+Unsupported operand types: object ^ bool
+Unsupported operand types: bool ^ object
+Unsupported operand types: object ^ bool
+Unsupported operand types: bool ^ object
+Unsupported operand types: object ^ int
+Unsupported operand types: int ^ object
+Unsupported operand types: object ^ float
+Unsupported operand types: float ^ object
+Unsupported operand types: object ^ string
+Unsupported operand types: string ^ object
+Unsupported operand types: object ^ string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ^ object
+Unsupported operand types: resource ^ null
+Unsupported operand types: null ^ resource
+Unsupported operand types: resource ^ bool
+Unsupported operand types: bool ^ resource
+Unsupported operand types: resource ^ bool
+Unsupported operand types: bool ^ resource
+Unsupported operand types: resource ^ int
+Unsupported operand types: int ^ resource
+Unsupported operand types: resource ^ float
+Unsupported operand types: float ^ resource
+Unsupported operand types: resource ^ string
+Unsupported operand types: string ^ resource
+Unsupported operand types: resource ^ string
+
+Warning: A non-numeric value encountered in %s on line %d
+Unsupported operand types: string ^ resource
+
+Warning: Array to string conversion in %s on line %d
+
+Warning: Array to string conversion in %s on line %d
+No error for [] .= []
+
+Warning: Array to string conversion in %s on line %d
+Object of class stdClass could not be converted to string
+
+Warning: Array to string conversion in %s on line %d
+No error for [] .= STDOUT
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+
+Warning: Array to string conversion in %s on line %d
+No error for STDOUT .= []
+Object of class stdClass could not be converted to string
+No error for STDOUT .= STDOUT
+
+Warning: Array to string conversion in %s on line %d
+No error for [] .= null
+
+Warning: Array to string conversion in %s on line %d
+No error for null .= []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] .= true
+
+Warning: Array to string conversion in %s on line %d
+No error for true .= []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] .= false
+
+Warning: Array to string conversion in %s on line %d
+No error for false .= []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] .= 2
+
+Warning: Array to string conversion in %s on line %d
+No error for 2 .= []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] .= 3.5
+
+Warning: Array to string conversion in %s on line %d
+No error for 3.5 .= []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] .= "123"
+
+Warning: Array to string conversion in %s on line %d
+No error for "123" .= []
+
+Warning: Array to string conversion in %s on line %d
+No error for [] .= "foo"
+
+Warning: Array to string conversion in %s on line %d
+No error for "foo" .= []
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+No error for STDOUT .= null
+No error for null .= STDOUT
+No error for STDOUT .= true
+No error for true .= STDOUT
+No error for STDOUT .= false
+No error for false .= STDOUT
+No error for STDOUT .= 2
+No error for 2 .= STDOUT
+No error for STDOUT .= 3.5
+No error for 3.5 .= STDOUT
+No error for STDOUT .= "123"
+No error for "123" .= STDOUT
+No error for STDOUT .= "foo"
+No error for "foo" .= STDOUT
+
+
+UNARY OP:
 Cannot perform bitwise not on array
 Cannot perform bitwise not on object
 Cannot perform bitwise not on resource

--- a/Zend/tests/operator_unsupported_types.phpt
+++ b/Zend/tests/operator_unsupported_types.phpt
@@ -35,6 +35,11 @@ $legalValues = [
     '"foo"', // Semi-legal.
 ];
 
+set_error_handler(function($errno, $errstr) {
+    assert($errno == E_WARNING);
+    echo "Warning: $errstr\n";
+});
+
 function evalBinOp(string $op, string $value1, string $value2) {
     try {
         eval("return $value1 $op $value2;");
@@ -118,7 +123,7 @@ foreach ($illegalValues as $illegalValue) {
 }
 
 ?>
---EXPECTF--
+--EXPECT--
 BINARY OP:
 No error for [] + []
 Unsupported operand types: array + object
@@ -142,8 +147,7 @@ Unsupported operand types: float + array
 Unsupported operand types: array + string
 Unsupported operand types: string + array
 Unsupported operand types: array + string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string + array
 Unsupported operand types: object + null
 Unsupported operand types: null + object
@@ -158,8 +162,7 @@ Unsupported operand types: float + object
 Unsupported operand types: object + string
 Unsupported operand types: string + object
 Unsupported operand types: object + string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string + object
 Unsupported operand types: resource + null
 Unsupported operand types: null + resource
@@ -174,8 +177,7 @@ Unsupported operand types: float + resource
 Unsupported operand types: resource + string
 Unsupported operand types: string + resource
 Unsupported operand types: resource + string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string + resource
 Unsupported operand types: array - array
 Unsupported operand types: array - object
@@ -199,8 +201,7 @@ Unsupported operand types: float - array
 Unsupported operand types: array - string
 Unsupported operand types: string - array
 Unsupported operand types: array - string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string - array
 Unsupported operand types: object - null
 Unsupported operand types: null - object
@@ -215,8 +216,7 @@ Unsupported operand types: float - object
 Unsupported operand types: object - string
 Unsupported operand types: string - object
 Unsupported operand types: object - string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string - object
 Unsupported operand types: resource - null
 Unsupported operand types: null - resource
@@ -231,8 +231,7 @@ Unsupported operand types: float - resource
 Unsupported operand types: resource - string
 Unsupported operand types: string - resource
 Unsupported operand types: resource - string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string - resource
 Unsupported operand types: array * array
 Unsupported operand types: object * array
@@ -256,8 +255,7 @@ Unsupported operand types: float * array
 Unsupported operand types: array * string
 Unsupported operand types: string * array
 Unsupported operand types: array * string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string * array
 Unsupported operand types: object * null
 Unsupported operand types: object * null
@@ -309,8 +307,7 @@ Unsupported operand types: float / array
 Unsupported operand types: array / string
 Unsupported operand types: string / array
 Unsupported operand types: array / string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string / array
 Unsupported operand types: object / null
 Unsupported operand types: null / object
@@ -325,8 +322,7 @@ Unsupported operand types: float / object
 Unsupported operand types: object / string
 Unsupported operand types: string / object
 Unsupported operand types: object / string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string / object
 Unsupported operand types: resource / null
 Unsupported operand types: null / resource
@@ -341,8 +337,7 @@ Unsupported operand types: float / resource
 Unsupported operand types: resource / string
 Unsupported operand types: string / resource
 Unsupported operand types: resource / string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string / resource
 Unsupported operand types: array % array
 Unsupported operand types: array % object
@@ -366,8 +361,7 @@ Unsupported operand types: float % array
 Unsupported operand types: array % string
 Unsupported operand types: string % array
 Unsupported operand types: array % string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string % array
 Unsupported operand types: object % null
 Unsupported operand types: null % object
@@ -382,8 +376,7 @@ Unsupported operand types: float % object
 Unsupported operand types: object % string
 Unsupported operand types: string % object
 Unsupported operand types: object % string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string % object
 Unsupported operand types: resource % null
 Unsupported operand types: null % resource
@@ -398,8 +391,7 @@ Unsupported operand types: float % resource
 Unsupported operand types: resource % string
 Unsupported operand types: string % resource
 Unsupported operand types: resource % string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string % resource
 Unsupported operand types: array ** array
 Unsupported operand types: array ** object
@@ -423,8 +415,7 @@ Unsupported operand types: float ** array
 Unsupported operand types: array ** string
 Unsupported operand types: string ** array
 Unsupported operand types: array ** string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ** array
 Unsupported operand types: object ** null
 Unsupported operand types: null ** object
@@ -439,8 +430,7 @@ Unsupported operand types: float ** object
 Unsupported operand types: object ** string
 Unsupported operand types: string ** object
 Unsupported operand types: object ** string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ** object
 Unsupported operand types: resource ** null
 Unsupported operand types: null ** resource
@@ -455,8 +445,7 @@ Unsupported operand types: float ** resource
 Unsupported operand types: resource ** string
 Unsupported operand types: string ** resource
 Unsupported operand types: resource ** string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ** resource
 Unsupported operand types: array << array
 Unsupported operand types: array << object
@@ -480,8 +469,7 @@ Unsupported operand types: float << array
 Unsupported operand types: array << string
 Unsupported operand types: string << array
 Unsupported operand types: array << string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string << array
 Unsupported operand types: object << null
 Unsupported operand types: null << object
@@ -496,8 +484,7 @@ Unsupported operand types: float << object
 Unsupported operand types: object << string
 Unsupported operand types: string << object
 Unsupported operand types: object << string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string << object
 Unsupported operand types: resource << null
 Unsupported operand types: null << resource
@@ -512,8 +499,7 @@ Unsupported operand types: float << resource
 Unsupported operand types: resource << string
 Unsupported operand types: string << resource
 Unsupported operand types: resource << string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string << resource
 Unsupported operand types: array >> array
 Unsupported operand types: array >> object
@@ -537,8 +523,7 @@ Unsupported operand types: float >> array
 Unsupported operand types: array >> string
 Unsupported operand types: string >> array
 Unsupported operand types: array >> string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string >> array
 Unsupported operand types: object >> null
 Unsupported operand types: null >> object
@@ -553,8 +538,7 @@ Unsupported operand types: float >> object
 Unsupported operand types: object >> string
 Unsupported operand types: string >> object
 Unsupported operand types: object >> string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string >> object
 Unsupported operand types: resource >> null
 Unsupported operand types: null >> resource
@@ -569,8 +553,7 @@ Unsupported operand types: float >> resource
 Unsupported operand types: resource >> string
 Unsupported operand types: string >> resource
 Unsupported operand types: resource >> string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string >> resource
 Unsupported operand types: array & array
 Unsupported operand types: object & array
@@ -594,8 +577,7 @@ Unsupported operand types: float & array
 Unsupported operand types: array & string
 Unsupported operand types: string & array
 Unsupported operand types: array & string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string & array
 Unsupported operand types: object & null
 Unsupported operand types: object & null
@@ -647,8 +629,7 @@ Unsupported operand types: float | array
 Unsupported operand types: array | string
 Unsupported operand types: string | array
 Unsupported operand types: array | string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string | array
 Unsupported operand types: object | null
 Unsupported operand types: object | null
@@ -700,8 +681,7 @@ Unsupported operand types: float ^ array
 Unsupported operand types: array ^ string
 Unsupported operand types: string ^ array
 Unsupported operand types: array ^ string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ^ array
 Unsupported operand types: object ^ null
 Unsupported operand types: object ^ null
@@ -782,68 +762,48 @@ No error for STDOUT xor "123"
 No error for "123" xor STDOUT
 No error for STDOUT xor "foo"
 No error for "foo" xor STDOUT
-
-Warning: Array to string conversion in %s on line %d
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
+Warning: Array to string conversion
 No error for [] . []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 Object of class stdClass could not be converted to string
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] . STDOUT
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 Object of class stdClass could not be converted to string
 Object of class stdClass could not be converted to string
 Object of class stdClass could not be converted to string
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for STDOUT . []
 Object of class stdClass could not be converted to string
 No error for STDOUT . STDOUT
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] . null
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for null . []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] . true
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for true . []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] . false
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for false . []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] . 2
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for 2 . []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] . 3.5
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for 3.5 . []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] . "123"
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for "123" . []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] . "foo"
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for "foo" . []
 Object of class stdClass could not be converted to string
 Object of class stdClass could not be converted to string
@@ -898,8 +858,7 @@ Unsupported operand types: float + array
 Unsupported operand types: array + string
 Unsupported operand types: string + array
 Unsupported operand types: array + string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string + array
 Unsupported operand types: object + null
 Unsupported operand types: null + object
@@ -914,8 +873,7 @@ Unsupported operand types: float + object
 Unsupported operand types: object + string
 Unsupported operand types: string + object
 Unsupported operand types: object + string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string + object
 Unsupported operand types: resource + null
 Unsupported operand types: null + resource
@@ -930,8 +888,7 @@ Unsupported operand types: float + resource
 Unsupported operand types: resource + string
 Unsupported operand types: string + resource
 Unsupported operand types: resource + string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string + resource
 Unsupported operand types: array - array
 Unsupported operand types: array - object
@@ -955,8 +912,7 @@ Unsupported operand types: float - array
 Unsupported operand types: array - string
 Unsupported operand types: string - array
 Unsupported operand types: array - string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string - array
 Unsupported operand types: object - null
 Unsupported operand types: null - object
@@ -971,8 +927,7 @@ Unsupported operand types: float - object
 Unsupported operand types: object - string
 Unsupported operand types: string - object
 Unsupported operand types: object - string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string - object
 Unsupported operand types: resource - null
 Unsupported operand types: null - resource
@@ -987,8 +942,7 @@ Unsupported operand types: float - resource
 Unsupported operand types: resource - string
 Unsupported operand types: string - resource
 Unsupported operand types: resource - string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string - resource
 Unsupported operand types: array * array
 Unsupported operand types: array * object
@@ -1012,8 +966,7 @@ Unsupported operand types: float * array
 Unsupported operand types: array * string
 Unsupported operand types: string * array
 Unsupported operand types: array * string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string * array
 Unsupported operand types: object * null
 Unsupported operand types: null * object
@@ -1028,8 +981,7 @@ Unsupported operand types: float * object
 Unsupported operand types: object * string
 Unsupported operand types: string * object
 Unsupported operand types: object * string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string * object
 Unsupported operand types: resource * null
 Unsupported operand types: null * resource
@@ -1044,8 +996,7 @@ Unsupported operand types: float * resource
 Unsupported operand types: resource * string
 Unsupported operand types: string * resource
 Unsupported operand types: resource * string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string * resource
 Unsupported operand types: array / array
 Unsupported operand types: array / object
@@ -1069,8 +1020,7 @@ Unsupported operand types: float / array
 Unsupported operand types: array / string
 Unsupported operand types: string / array
 Unsupported operand types: array / string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string / array
 Unsupported operand types: object / null
 Unsupported operand types: null / object
@@ -1085,8 +1035,7 @@ Unsupported operand types: float / object
 Unsupported operand types: object / string
 Unsupported operand types: string / object
 Unsupported operand types: object / string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string / object
 Unsupported operand types: resource / null
 Unsupported operand types: null / resource
@@ -1101,8 +1050,7 @@ Unsupported operand types: float / resource
 Unsupported operand types: resource / string
 Unsupported operand types: string / resource
 Unsupported operand types: resource / string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string / resource
 Unsupported operand types: array % array
 Unsupported operand types: array % object
@@ -1126,8 +1074,7 @@ Unsupported operand types: float % array
 Unsupported operand types: array % string
 Unsupported operand types: string % array
 Unsupported operand types: array % string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string % array
 Unsupported operand types: object % null
 Unsupported operand types: null % object
@@ -1142,8 +1089,7 @@ Unsupported operand types: float % object
 Unsupported operand types: object % string
 Unsupported operand types: string % object
 Unsupported operand types: object % string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string % object
 Unsupported operand types: resource % null
 Unsupported operand types: null % resource
@@ -1158,8 +1104,7 @@ Unsupported operand types: float % resource
 Unsupported operand types: resource % string
 Unsupported operand types: string % resource
 Unsupported operand types: resource % string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string % resource
 Unsupported operand types: array ** array
 Unsupported operand types: array ** object
@@ -1183,8 +1128,7 @@ Unsupported operand types: float ** array
 Unsupported operand types: array ** string
 Unsupported operand types: string ** array
 Unsupported operand types: array ** string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ** array
 Unsupported operand types: object ** null
 Unsupported operand types: null ** object
@@ -1199,8 +1143,7 @@ Unsupported operand types: float ** object
 Unsupported operand types: object ** string
 Unsupported operand types: string ** object
 Unsupported operand types: object ** string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ** object
 Unsupported operand types: resource ** null
 Unsupported operand types: null ** resource
@@ -1215,8 +1158,7 @@ Unsupported operand types: float ** resource
 Unsupported operand types: resource ** string
 Unsupported operand types: string ** resource
 Unsupported operand types: resource ** string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ** resource
 Unsupported operand types: array << array
 Unsupported operand types: array << object
@@ -1240,8 +1182,7 @@ Unsupported operand types: float << array
 Unsupported operand types: array << string
 Unsupported operand types: string << array
 Unsupported operand types: array << string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string << array
 Unsupported operand types: object << null
 Unsupported operand types: null << object
@@ -1256,8 +1197,7 @@ Unsupported operand types: float << object
 Unsupported operand types: object << string
 Unsupported operand types: string << object
 Unsupported operand types: object << string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string << object
 Unsupported operand types: resource << null
 Unsupported operand types: null << resource
@@ -1272,8 +1212,7 @@ Unsupported operand types: float << resource
 Unsupported operand types: resource << string
 Unsupported operand types: string << resource
 Unsupported operand types: resource << string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string << resource
 Unsupported operand types: array >> array
 Unsupported operand types: array >> object
@@ -1297,8 +1236,7 @@ Unsupported operand types: float >> array
 Unsupported operand types: array >> string
 Unsupported operand types: string >> array
 Unsupported operand types: array >> string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string >> array
 Unsupported operand types: object >> null
 Unsupported operand types: null >> object
@@ -1313,8 +1251,7 @@ Unsupported operand types: float >> object
 Unsupported operand types: object >> string
 Unsupported operand types: string >> object
 Unsupported operand types: object >> string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string >> object
 Unsupported operand types: resource >> null
 Unsupported operand types: null >> resource
@@ -1329,8 +1266,7 @@ Unsupported operand types: float >> resource
 Unsupported operand types: resource >> string
 Unsupported operand types: string >> resource
 Unsupported operand types: resource >> string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string >> resource
 Unsupported operand types: array & array
 Unsupported operand types: array & object
@@ -1354,8 +1290,7 @@ Unsupported operand types: float & array
 Unsupported operand types: array & string
 Unsupported operand types: string & array
 Unsupported operand types: array & string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string & array
 Unsupported operand types: object & null
 Unsupported operand types: null & object
@@ -1370,8 +1305,7 @@ Unsupported operand types: float & object
 Unsupported operand types: object & string
 Unsupported operand types: string & object
 Unsupported operand types: object & string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string & object
 Unsupported operand types: resource & null
 Unsupported operand types: null & resource
@@ -1386,8 +1320,7 @@ Unsupported operand types: float & resource
 Unsupported operand types: resource & string
 Unsupported operand types: string & resource
 Unsupported operand types: resource & string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string & resource
 Unsupported operand types: array | array
 Unsupported operand types: array | object
@@ -1411,8 +1344,7 @@ Unsupported operand types: float | array
 Unsupported operand types: array | string
 Unsupported operand types: string | array
 Unsupported operand types: array | string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string | array
 Unsupported operand types: object | null
 Unsupported operand types: null | object
@@ -1427,8 +1359,7 @@ Unsupported operand types: float | object
 Unsupported operand types: object | string
 Unsupported operand types: string | object
 Unsupported operand types: object | string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string | object
 Unsupported operand types: resource | null
 Unsupported operand types: null | resource
@@ -1443,8 +1374,7 @@ Unsupported operand types: float | resource
 Unsupported operand types: resource | string
 Unsupported operand types: string | resource
 Unsupported operand types: resource | string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string | resource
 Unsupported operand types: array ^ array
 Unsupported operand types: array ^ object
@@ -1468,8 +1398,7 @@ Unsupported operand types: float ^ array
 Unsupported operand types: array ^ string
 Unsupported operand types: string ^ array
 Unsupported operand types: array ^ string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ^ array
 Unsupported operand types: object ^ null
 Unsupported operand types: null ^ object
@@ -1484,8 +1413,7 @@ Unsupported operand types: float ^ object
 Unsupported operand types: object ^ string
 Unsupported operand types: string ^ object
 Unsupported operand types: object ^ string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ^ object
 Unsupported operand types: resource ^ null
 Unsupported operand types: null ^ resource
@@ -1500,69 +1428,49 @@ Unsupported operand types: float ^ resource
 Unsupported operand types: resource ^ string
 Unsupported operand types: string ^ resource
 Unsupported operand types: resource ^ string
-
-Warning: A non-numeric value encountered in %s on line %d
+Warning: A non-numeric value encountered
 Unsupported operand types: string ^ resource
-
-Warning: Array to string conversion in %s on line %d
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
+Warning: Array to string conversion
 No error for [] .= []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 Object of class stdClass could not be converted to string
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] .= STDOUT
 Object of class stdClass could not be converted to string
 Object of class stdClass could not be converted to string
 Object of class stdClass could not be converted to string
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for STDOUT .= []
 Object of class stdClass could not be converted to string
 No error for STDOUT .= STDOUT
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] .= null
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for null .= []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] .= true
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for true .= []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] .= false
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for false .= []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] .= 2
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for 2 .= []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] .= 3.5
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for 3.5 .= []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] .= "123"
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for "123" .= []
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for [] .= "foo"
-
-Warning: Array to string conversion in %s on line %d
+Warning: Array to string conversion
 No error for "foo" .= []
 Object of class stdClass could not be converted to string
 Object of class stdClass could not be converted to string

--- a/Zend/tests/throw/001.phpt
+++ b/Zend/tests/throw/001.phpt
@@ -148,7 +148,7 @@ try {
 }
 
 ?>
---EXPECTF--
+--EXPECT--
 string(13) "true && throw"
 bool(false)
 string(14) "true and throw"
@@ -167,9 +167,7 @@ string(3) "bar"
 string(11) "exception 1"
 bool(true)
 string(20) "false ? true : throw"
-
-Notice: Object of class Exception could not be converted to number in %s on line %d
-string(22) "Can only throw objects"
+string(39) "Unsupported operand types: object + int"
 string(35) "throw $exception = new Exception();"
 string(37) "throw $exception ??= new Exception();"
 string(30) "throw null ?? new Exception();"

--- a/Zend/tests/xor_001.phpt
+++ b/Zend/tests/xor_001.phpt
@@ -6,11 +6,14 @@ XORing arrays
 $a = array(1,2,3);
 $b = array();
 
-$c = $a ^ $b;
-var_dump($c);
+try {
+    $c = $a ^ $b;
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
 
 echo "Done\n";
 ?>
 --EXPECT--
-int(1)
+Unsupported operand types: array ^ array
 Done

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7219,11 +7219,9 @@ ZEND_API zend_bool zend_binary_op_produces_error(uint32_t opcode, zval *op1, zva
 			/* Adding two arrays is allowed. */
 			return 0;
 		}
-		if (opcode == ZEND_ADD || opcode == ZEND_SUB || opcode == ZEND_MUL || opcode == ZEND_POW
-				|| opcode == ZEND_DIV) {
-			/* These operators throw when one of the operands is an array. */
-			return 1;
-		}
+
+		/* Numeric operators throw when one of the operands is an array. */
+		return 1;
 	}
 
 	/* While basic arithmetic operators always produce numeric string errors,

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -4354,8 +4354,8 @@ int zend_may_throw(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_
 			 && (t2 & MAY_BE_ANY) == MAY_BE_ARRAY) {
 				return 0;
 			}
-			return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
-				(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT));
+			return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
+				(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
 		case ZEND_DIV:
 		case ZEND_MOD:
 			if (!OP2_HAS_RANGE() ||
@@ -4367,12 +4367,12 @@ int zend_may_throw(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_
 		case ZEND_SUB:
 		case ZEND_MUL:
 		case ZEND_POW:
-			return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
-				(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT));
+			return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
+				(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
 		case ZEND_SL:
 		case ZEND_SR:
-			return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
-				(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
+			return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
+				(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
 				!OP2_HAS_RANGE() ||
 				OP2_MIN_RANGE() < 0;
 		case ZEND_CONCAT:
@@ -4386,15 +4386,16 @@ int zend_may_throw(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_
 			 && (t2 & MAY_BE_ANY) == MAY_BE_STRING) {
 				return 0;
 			}
-			return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
-				(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT));
+			return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
+				(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
 		case ZEND_BW_NOT:
 			return (t1 & (MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
-		case ZEND_BOOL_NOT:
 		case ZEND_PRE_INC:
 		case ZEND_POST_INC:
 		case ZEND_PRE_DEC:
 		case ZEND_POST_DEC:
+			return (t1 & (MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
+		case ZEND_BOOL_NOT:
 		case ZEND_JMPZ:
 		case ZEND_JMPNZ:
 		case ZEND_JMPZNZ:

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -4423,8 +4423,8 @@ int zend_may_throw(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_
 				 && (t2 & MAY_BE_ANY) == MAY_BE_ARRAY) {
 					return 0;
 				}
-				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
-					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT));
+				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
+					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
 			} else if (opline->extended_value == ZEND_DIV ||
 				opline->extended_value == ZEND_MOD) {
 				if (!OP2_HAS_RANGE() ||
@@ -4432,17 +4432,17 @@ int zend_may_throw(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_
 					/* Division by zero */
 					return 1;
 				}
-				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
-					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT));
+				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
+					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
 			} else if (opline->extended_value == ZEND_SUB ||
 				opline->extended_value == ZEND_MUL ||
 				opline->extended_value == ZEND_POW) {
-				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
-					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT));
+				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
+					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
 			} else if (opline->extended_value == ZEND_SL ||
 				opline->extended_value == ZEND_SR) {
-				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
-					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
+				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
+					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
 					!OP2_HAS_RANGE() ||
 					OP2_MIN_RANGE() < 0;
 			} else if (opline->extended_value == ZEND_CONCAT) {
@@ -4455,8 +4455,8 @@ int zend_may_throw(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_
 				 && (t2 & MAY_BE_ANY) == MAY_BE_STRING) {
 					return 0;
 				}
-				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT)) ||
-					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT));
+				return (t1 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE)) ||
+					(t2 & (MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_RESOURCE));
 			}
 			return 1;
 		case ZEND_ASSIGN:

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -2212,7 +2212,8 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 								op1_def_info, OP1_DEF_REG_ADDR(),
 								res_use_info, res_info,
 								res_addr,
-								(op1_def_info & MAY_BE_LONG) && (op1_def_info & MAY_BE_DOUBLE) && zend_may_overflow(opline, op_array, ssa))) {
+								(op1_def_info & MAY_BE_LONG) && (op1_def_info & MAY_BE_DOUBLE) && zend_may_overflow(opline, op_array, ssa),
+								zend_may_throw(opline, ssa_op, op_array, ssa))) {
 							goto jit_failure;
 						}
 						goto done;

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -2716,7 +2716,8 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 								op1_def_info, OP1_DEF_REG_ADDR(),
 								res_use_info, res_info,
 								res_addr,
-								(op1_def_info & MAY_BE_LONG) && (op1_def_info & (MAY_BE_DOUBLE|MAY_BE_GUARD)) && zend_may_overflow_ex(opline, ssa_op, op_array, ssa))) {
+								(op1_def_info & MAY_BE_LONG) && (op1_def_info & (MAY_BE_DOUBLE|MAY_BE_GUARD)) && zend_may_overflow_ex(opline, ssa_op, op_array, ssa),
+								zend_may_throw(opline, ssa_op, op_array, ssa))) {
 							goto jit_failure;
 						}
 						if ((op1_def_info & (MAY_BE_ANY|MAY_BE_GUARD)) == (MAY_BE_LONG|MAY_BE_GUARD)) {

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -3407,7 +3407,7 @@ static int zend_jit_update_regs(dasm_State **Dst, zend_jit_addr src, zend_jit_ad
 	return 1;
 }
 
-static int zend_jit_inc_dec(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr, uint32_t op1_def_info, zend_jit_addr op1_def_addr, uint32_t res_use_info, uint32_t res_info, zend_jit_addr res_addr, int may_overflow)
+static int zend_jit_inc_dec(dasm_State **Dst, const zend_op *opline, const zend_op_array *op_array, uint32_t op1_info, zend_jit_addr op1_addr, uint32_t op1_def_info, zend_jit_addr op1_def_addr, uint32_t res_use_info, uint32_t res_info, zend_jit_addr res_addr, int may_overflow, int may_throw)
 {
 	if (op1_info & ((MAY_BE_UNDEF|MAY_BE_ANY)-MAY_BE_LONG)) {
 		|	IF_NOT_ZVAL_TYPE op1_addr, IS_LONG, >2
@@ -3546,6 +3546,9 @@ static int zend_jit_inc_dec(dasm_State **Dst, const zend_op *opline, const zend_
 				} else {
 					|	EXT_CALL decrement_function, r0
 				}
+			}
+			if (may_throw) {
+				zend_jit_check_exception(Dst);
 			}
 		} else {
 			zend_reg tmp_reg;

--- a/ext/standard/tests/math/pow_variation1.phpt
+++ b/ext/standard/tests/math/pow_variation1.phpt
@@ -174,9 +174,7 @@ Warning: A non-numeric value encountered in %s on line %d
 int(0)
 
 -- Iteration 23 --
-
-Notice: Object of class classA could not be converted to number in %s on line %d
-int(1)
+Unsupported operand types: object ** int
 
 -- Iteration 24 --
 int(0)

--- a/ext/standard/tests/math/pow_variation1_64bit.phpt
+++ b/ext/standard/tests/math/pow_variation1_64bit.phpt
@@ -174,9 +174,7 @@ Warning: A non-numeric value encountered in %s on line %d
 int(0)
 
 -- Iteration 23 --
-
-Notice: Object of class classA could not be converted to number in %s on line %d
-int(1)
+Unsupported operand types: object ** int
 
 -- Iteration 24 --
 int(0)

--- a/ext/standard/tests/math/pow_variation2.phpt
+++ b/ext/standard/tests/math/pow_variation2.phpt
@@ -170,9 +170,7 @@ Warning: A non-numeric value encountered in %s on line %d
 float(1)
 
 -- Iteration 23 --
-
-Notice: Object of class classA could not be converted to number in %s on line %d
-float(20.3)
+Unsupported operand types: float ** object
 
 -- Iteration 24 --
 float(1)

--- a/scripts/dev/bless_tests.php
+++ b/scripts/dev/bless_tests.php
@@ -106,7 +106,8 @@ function generateMinimallyDifferingOutput(string $out, string $oldExpect) {
 
 function insertOutput(string $phpt, string $out): string {
     return preg_replace_callback('/--EXPECTF?--.*$/s', function($matches) use($out) {
-        $F = strpos($out, '%') !== false ? 'F' : '';
+        $hasWildcard = preg_match('/%[resSaAwidxfc]/', $out);
+        $F = $hasWildcard ? 'F' : '';
         return "--EXPECT$F--\n" . $out . "\n";
     }, $phpt);
 }


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/arithmetic_operator_type_checks

Using `array`, `resource` or `object` as an operand of `+`, `-`, `*`, `/`, `%`, `**`, `<<`, `>>`, `&`, `|`, `^`, `~`, `++`, `--` now results in a `TypeError`. As an exception, `array + array` remains supported. Of course, objects that define numeric coercions or overloaded operators also remain supported.

The behavior with scalar values of type null, bool, int, float and string is not affected.