### PR TITLE
Fix #69264: __debugInfo() ignored while extending SPL classes

### DIFF
--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -500,6 +500,11 @@ static HashTable* spl_dllist_object_get_debug_info(zval *obj, int *is_temp) /* {
 	zend_string *pnstr;
 	int  i = 0;
 	HashTable *debug_info;
+
+	if (Z_OBJCE_P(obj)->__debugInfo) {
+		return zend_std_get_debug_info(obj, is_temp);
+	}
+
 	*is_temp = 1;
 
 	if (!intern->std.properties) {

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -289,6 +289,10 @@ static HashTable* spl_object_storage_debug_info(zval *obj, int *is_temp) /* {{{ 
 	zend_string *zname;
 	HashTable *debug_info;
 
+	if (Z_OBJCE_P(obj)->__debugInfo) {
+		return zend_std_get_debug_info(obj, is_temp);
+	}
+
 	*is_temp = 1;
 
 	props = Z_OBJPROP_P(obj);

--- a/ext/spl/tests/bug69264.phpt
+++ b/ext/spl/tests/bug69264.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #69264 (__debugInfo() ignored while extending SPL classes)
+--FILE--
+<?php
+class foo extends SplStack {
+    public function __debugInfo() { return ['foo']; }
+}
+
+class bar extends foo {
+    public function __debugInfo() { return ['bar']; }
+}
+
+class bar2 extends SplObjectStorage {
+    public function __debugInfo() { return ['bar2']; }
+}
+
+var_dump((new bar), (new bar2));
+?>
+--EXPECTF--
+object(bar)#%d (1) {
+  [0]=>
+  string(3) "bar"
+}
+object(bar2)#%d (1) {
+  [0]=>
+  string(4) "bar2"
+}


### PR DESCRIPTION
We have to call `::__debugInfo()`, if defined for SPL descendants.

---

I have some doubts regarding the BC break, particularly since it would be no longer possible to call the inherited `::__debugInfo()`, because it is actually not inherited; only the `get_debug_info` handlers are implemented.

Thoughts?

