### PR TITLE
Export ext/curl's primary header

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -83,4 +83,5 @@ int main(int argc, char *argv[])
 
   PHP_NEW_EXTENSION(curl, interface.c multi.c share.c curl_file.c, $ext_shared)
   PHP_SUBST(CURL_SHARED_LIBADD)
+  PHP_INSTALL_HEADERS([ext/curl], php_curl.h)
 fi

--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -33,4 +33,5 @@ if (PHP_CURL != "no") {
 	} else {
 		WARNING("curl not enabled; libraries and headers not found");
 	}
+	PHP_INSTALL_HEADERS('ext/curl/', 'php_curl.h')
 }


### PR DESCRIPTION
This makes it more accessible to extensions.

Disclaimer: I have no idea if this is helpful or correct on Windows builds.