### PR TITLE
Allow fpm tests to be run with long socket paths

### DIFF
--- a/sapi/fpm/tests/bug68391-conf-include-order.phpt
+++ b/sapi/fpm/tests/bug68391-conf-include-order.phpt
@@ -3,6 +3,7 @@ FPM: bug68391 - Configuration inclusion in alphabetical order
 --SKIPIF--
 <?php
 include "skipif.inc";
+FPM\Tester::skipIfRoot();
 ?>
 --FILE--
 <?php

--- a/sapi/fpm/tests/proc-user-ignored.phpt
+++ b/sapi/fpm/tests/proc-user-ignored.phpt
@@ -3,6 +3,7 @@ FPM: Process user setting ignored when FPM is not running as root
 --SKIPIF--
 <?php
 include "skipif.inc";
+FPM\Tester::skipIfRoot();
 ?>
 --FILE--
 <?php

--- a/sapi/fpm/tests/socket-uds-numeric-ugid-nonroot.phpt
+++ b/sapi/fpm/tests/socket-uds-numeric-ugid-nonroot.phpt
@@ -3,6 +3,7 @@ FPM: UNIX socket owner and group settings can be numeric
 --SKIPIF--
 <?php
 include "skipif.inc";
+FPM\Tester::skipIfRoot();
 FPM\Tester::skipIfPosixNotLoaded();
 ?>
 --FILE--

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -856,7 +856,17 @@ class Tester
     {
         $port = $this->getPort($type, $pool, true);
         if ($type === 'uds') {
-            return $this->getFile($port . '.sock');
+            $address = $this->getFile($port . '.sock');
+
+            // Socket max path length is 108 on Linux and 104 on BSD,
+            // so we use the latter
+            if (strlen($address) <= 104) {
+                return $address;
+            }
+
+            return sys_get_temp_dir().'/'.
+                hash('crc32', dirname($address)).'-'.
+                basename($address);
         }
 
         return $this->getHost($type) . ':' . $port;

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -279,6 +279,16 @@ class Tester
     }
 
     /**
+     * Skip if running as root.
+     */
+    static public function skipIfRoot()
+    {
+        if (getmyuid() == 0) {
+            die('skip running as root');
+        }
+    }
+
+    /**
      * Skip if posix extension not loaded.
      */
     static public function skipIfPosixNotLoaded()


### PR DESCRIPTION
Socket path is restricted to about 100 bytes (precisely 104 on *BSD, 108 on Linux), so we can use the system temp dir if the path ends up too long.