### PR TITLE
Fix #47983: mixed LF and CRLF line endings in mail()

### DIFF
--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -486,7 +486,7 @@ PHPAPI int php_mail(char *to, char *subject, char *message, char *headers, char 
 		f = php_basename(tmp, strlen(tmp), NULL, 0);
 
 		if (headers != NULL && *headers) {
-			spprintf(&hdr, 0, "X-PHP-Originating-Script: " ZEND_LONG_FMT ":%s\n%s", php_getuid(), ZSTR_VAL(f), headers);
+			spprintf(&hdr, 0, "X-PHP-Originating-Script: " ZEND_LONG_FMT ":%s\r\n%s", php_getuid(), ZSTR_VAL(f), headers);
 		} else {
 			spprintf(&hdr, 0, "X-PHP-Originating-Script: " ZEND_LONG_FMT ":%s", php_getuid(), ZSTR_VAL(f));
 		}
@@ -559,12 +559,12 @@ PHPAPI int php_mail(char *to, char *subject, char *message, char *headers, char 
 			MAIL_RET(0);
 		}
 #endif
-		fprintf(sendmail, "To: %s\n", to);
-		fprintf(sendmail, "Subject: %s\n", subject);
+		fprintf(sendmail, "To: %s\r\n", to);
+		fprintf(sendmail, "Subject: %s\r\n", subject);
 		if (hdr != NULL) {
-			fprintf(sendmail, "%s\n", hdr);
+			fprintf(sendmail, "%s\r\n", hdr);
 		}
-		fprintf(sendmail, "\n%s\n", message);
+		fprintf(sendmail, "\r\n%s\r\n", message);
 		ret = pclose(sendmail);
 
 #if PHP_SIGCHILD

--- a/ext/standard/tests/mail/bug47983.phpt
+++ b/ext/standard/tests/mail/bug47983.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #47983 (mixed LF and CRLF line endings in mail())
+--INI--
+sendmail_path={MAIL:bug47983.out}
+--FILE--
+<?php
+var_dump(mail('user@example.com', 'Test Subject', 'A Message', 'KHeaders'));
+$mail = file_get_contents('bug47983.out');
+var_dump(preg_match_all('/(?<!\r)\n/', $mail));
+?>
+--CLEAN--
+<?php
+unlink('bug47983.out');
+?>
+--EXPECT--
+bool(true)
+int(0)


### PR DESCRIPTION
Email headers are supposed to be separated with CRLF.  Period.