### PR TITLE
fix incorrect free for last_message

### DIFF
--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -507,7 +507,7 @@ mysqlnd_auth_change_user(MYSQLND_CONN_DATA * const conn,
 		conn->password.s = tmp;
 
 		if (conn->last_message.s) {
-			mnd_pefree(conn->last_message.s, conn->persistent);
+			mnd_efree(conn->last_message.s);
 			conn->last_message.s = NULL;
 		}
 		UPSERT_STATUS_RESET(conn->upsert_status);


### PR DESCRIPTION
In commit 
https://github.com/php/php-src/commit/a7305eb539596e175bd6c3ae9a20953358c5d677
the last_message field of the connection object was changed to be always non-persistent. But there is  a place on change_user path that still treats it depending on conn->persistent flag. This will cause PHP crash after com_change_user success when there is last_message set 
