### PR TITLE
Fixed bug #78434

### DIFF
--- a/Zend/tests/generators/bug78434.phpt
+++ b/Zend/tests/generators/bug78434.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug #78434: Generator yields no items after valid() call
+--FILE--
+<?php
+
+$function = function () {
+    yield 0;
+};
+
+$wrapper = function () use ($function) {
+    $generator = $function();
+    $generator->valid();
+    yield from $generator;
+    
+    $generator = $function();
+    // Comment out this line to get the correct result.
+    $generator->valid();
+    yield from $generator;
+};
+
+foreach ($wrapper() as $value) {
+    echo $value, "\n";
+}
+
+?>
+--EXPECT--
+0
+0

--- a/Zend/tests/generators/gc_with_root_parent_mismatch.phpt
+++ b/Zend/tests/generators/gc_with_root_parent_mismatch.phpt
@@ -24,4 +24,4 @@ gc_collect_cycles();
 ?>
 --EXPECT--
 int(1)
-int(2)
+int(1)

--- a/Zend/tests/generators/gc_with_root_parent_mismatch.phpt
+++ b/Zend/tests/generators/gc_with_root_parent_mismatch.phpt
@@ -24,4 +24,4 @@ gc_collect_cycles();
 ?>
 --EXPECT--
 int(1)
-int(1)
+int(2)

--- a/Zend/tests/generators/yield_from_multi_tree.phpt
+++ b/Zend/tests/generators/yield_from_multi_tree.phpt
@@ -10,9 +10,6 @@ function from($levels) {
 }
 
 function gen($gen, $level) {
-    if ($level % 2) {
-        yield $gen->current();
-    }
     yield from $gen;
 }
 

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -610,6 +610,7 @@ void zend_generator_yield_from(zend_generator *generator, zend_generator *from)
 	generator->node.parent = from;
 	zend_generator_get_current(generator);
 	GC_DELREF(&from->std);
+	generator->flags |= ZEND_GENERATOR_DO_INIT;
 }
 
 ZEND_API zend_generator *zend_generator_update_current(zend_generator *generator, zend_generator *leaf)
@@ -784,9 +785,12 @@ try_again:
 		return;
 	}
 
-	if (UNEXPECTED((orig_generator->flags & ZEND_GENERATOR_DO_INIT) != 0 && !Z_ISUNDEF(generator->value))) {
-		/* We must not advance Generator if we yield from a Generator being currently run */
-		return;
+	if (UNEXPECTED(orig_generator->flags & ZEND_GENERATOR_DO_INIT)) {
+		orig_generator->flags &= ~ZEND_GENERATOR_DO_INIT;
+		if (!Z_ISUNDEF(generator->value)) {
+			/* We must not advance Generator if we yield from a Generator being currently run */
+			return;
+		}
 	}
 
 	if (UNEXPECTED(!Z_ISUNDEF(generator->values))) {
@@ -871,9 +875,7 @@ try_again:
 static inline void zend_generator_ensure_initialized(zend_generator *generator) /* {{{ */
 {
 	if (UNEXPECTED(Z_TYPE(generator->value) == IS_UNDEF) && EXPECTED(generator->execute_data) && EXPECTED(generator->node.parent == NULL)) {
-		generator->flags |= ZEND_GENERATOR_DO_INIT;
 		zend_generator_resume(generator);
-		generator->flags &= ~ZEND_GENERATOR_DO_INIT;
 		generator->flags |= ZEND_GENERATOR_AT_FIRST_YIELD;
 	}
 }

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -785,12 +785,10 @@ try_again:
 		return;
 	}
 
-	if (UNEXPECTED(orig_generator->flags & ZEND_GENERATOR_DO_INIT)) {
+	if (UNEXPECTED((orig_generator->flags & ZEND_GENERATOR_DO_INIT) != 0 && !Z_ISUNDEF(generator->value))) {
+		/* We must not advance Generator if we yield from a Generator being currently run */
 		orig_generator->flags &= ~ZEND_GENERATOR_DO_INIT;
-		if (!Z_ISUNDEF(generator->value)) {
-			/* We must not advance Generator if we yield from a Generator being currently run */
-			return;
-		}
+		return;
 	}
 
 	if (UNEXPECTED(!Z_ISUNDEF(generator->values))) {
@@ -869,6 +867,8 @@ try_again:
 			goto try_again;
 		}
 	}
+
+	orig_generator->flags &= ~ZEND_GENERATOR_DO_INIT;
 }
 /* }}} */
 


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=78434. Set the `ZEND_GENERATOR_DO_INIT` flag whenever we perform a `yield from`, not when while performing "ensure initialized".

The intention here is that we should take the `current()` value of the generator before we advance it, unless the generator is before first yield, in which case we do need to advance it.

I'm not really sure if the implementation is right, or even if the semantics are right... Especially not sure if the change in `Zend/tests/generators/gc_with_root_parent_mismatch.phpt` makes sense.