### PR TITLE
WIP: DateInterval improvements

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2186,6 +2186,7 @@ static HashTable *date_object_get_properties_interval(zend_object *object) /* {{
 	PHP_DATE_INTERVAL_ADD_PROPERTY("h", h);
 	PHP_DATE_INTERVAL_ADD_PROPERTY("i", i);
 	PHP_DATE_INTERVAL_ADD_PROPERTY("s", s);
+	PHP_DATE_INTERVAL_ADD_PROPERTY("u", us);
 	ZVAL_DOUBLE(&zv, (double)intervalobj->diff->us / 1000000.0);
 	zend_hash_str_update(props, "f", sizeof("f") - 1, &zv);
 	PHP_DATE_INTERVAL_ADD_PROPERTY("weekday", weekday);
@@ -3937,6 +3938,7 @@ static zval *date_interval_read_property(zend_object *object, zend_string *name,
 		GET_VALUE_FROM_STRUCT(h, "h");
 		GET_VALUE_FROM_STRUCT(i, "i");
 		GET_VALUE_FROM_STRUCT(s, "s");
+		GET_VALUE_FROM_STRUCT(us, "u");
 		if (strcmp(ZSTR_VAL(name), "f") == 0) {
 			fvalue = obj->diff->us / 1000000.0;
 			break;
@@ -3987,6 +3989,7 @@ static zval *date_interval_write_property(zend_object *object, zend_string *name
 		SET_VALUE_FROM_STRUCT(h, "h");
 		SET_VALUE_FROM_STRUCT(i, "i");
 		SET_VALUE_FROM_STRUCT(s, "s");
+		SET_VALUE_FROM_STRUCT(us, "u");
 		if (strcmp(ZSTR_VAL(name), "f") == 0) {
 			obj->diff->us = zval_get_double(value) * 1000000;
 			break;
@@ -4011,6 +4014,7 @@ static zval *date_interval_get_property_ptr_ptr(zend_object *object, zend_string
 		zend_binary_strcmp("h", sizeof("h") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
 		zend_binary_strcmp("i", sizeof("i") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
 		zend_binary_strcmp("s", sizeof("s") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
+		zend_binary_strcmp("u", sizeof("u") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
 		zend_binary_strcmp("f", sizeof("f") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
 		zend_binary_strcmp("days", sizeof("days") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
 		zend_binary_strcmp("invert", sizeof("invert") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0) {

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4011,16 +4011,16 @@ static zval *date_interval_get_property_ptr_ptr(zend_object *object, zend_string
 {
 	zval *ret;
 
-	if (zend_binary_strcmp("y", sizeof("y") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
-		zend_binary_strcmp("m", sizeof("m") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
-		zend_binary_strcmp("d", sizeof("d") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
-		zend_binary_strcmp("h", sizeof("h") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
-		zend_binary_strcmp("i", sizeof("i") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
-		zend_binary_strcmp("s", sizeof("s") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
-		zend_binary_strcmp("u", sizeof("u") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
-		zend_binary_strcmp("f", sizeof("f") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
-		zend_binary_strcmp("days", sizeof("days") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0 ||
-		zend_binary_strcmp("invert", sizeof("invert") - 1, ZSTR_VAL(name), ZSTR_LEN(name)) == 0) {
+	if (zend_string_equals_literal(name, "y") ||
+		zend_string_equals_literal(name, "m") ||
+		zend_string_equals_literal(name, "d") ||
+		zend_string_equals_literal(name, "h") ||
+		zend_string_equals_literal(name, "i") ||
+		zend_string_equals_literal(name, "s") ||
+		zend_string_equals_literal(name, "u") ||
+		zend_string_equals_literal(name, "f") ||
+		zend_string_equals_literal(name, "days") ||
+		zend_string_equals_literal(name, "invert")) {
 		/* Fallback to read_property. */
 		ret = NULL;
 	} else {

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4098,16 +4098,6 @@ static int php_date_interval_initialize_from_hash(zval **return_value, php_inter
 		} \
 	} while (0);
 
-#define PHP_DATE_INTERVAL_READ_PROPERTY_DOUBLE(element, member, def) \
-	do { \
-		zval *z_arg = zend_hash_str_find(myht, element, sizeof(element) - 1); \
-		if (z_arg) { \
-			(*intobj)->diff->member = (double)zval_get_double(z_arg); \
-		} else { \
-			(*intobj)->diff->member = (double)def; \
-		} \
-	} while (0);
-
 	PHP_DATE_INTERVAL_READ_PROPERTY("y", y, timelib_sll, -1)
 	PHP_DATE_INTERVAL_READ_PROPERTY("m", m, timelib_sll, -1)
 	PHP_DATE_INTERVAL_READ_PROPERTY("d", d, timelib_sll, -1)

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3865,6 +3865,12 @@ static int date_interval_initialize(timelib_rel_time **rt, /*const*/ char *forma
 	int               retval = 0;
 	timelib_error_container *errors;
 
+	if (format_length == 0) {
+		#define DATE_INTERVAL_DEFAULT_FORMAT "PT0S"
+		format = DATE_INTERVAL_DEFAULT_FORMAT;
+		format_length = sizeof(DATE_INTERVAL_DEFAULT_FORMAT) - 1;
+	}
+
 	timelib_strtointerval(format, format_length, &b, &e, &p, &r, &errors);
 
 	if (errors->error_count > 0) {
@@ -4023,16 +4029,18 @@ static zval *date_interval_get_property_ptr_ptr(zend_object *object, zend_string
 */
 PHP_METHOD(DateInterval, __construct)
 {
-	zend_string *interval_string = NULL;
+	char *interval_str = NULL;
+	size_t interval_str_len = 0;
 	timelib_rel_time *reltime;
 	zend_error_handling error_handling;
 
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_STR(interval_string)
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STRING_OR_NULL(interval_str, interval_str_len)
 	ZEND_PARSE_PARAMETERS_END();
 
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling);
-	if (date_interval_initialize(&reltime, ZSTR_VAL(interval_string), ZSTR_LEN(interval_string)) == SUCCESS) {
+	if (date_interval_initialize(&reltime, interval_str, interval_str_len) == SUCCESS) {
 		php_interval_obj *diobj = Z_PHPINTERVAL_P(ZEND_THIS);
 		diobj->diff = reltime;
 		diobj->initialized = 1;

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -366,8 +366,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeZone___set_state arginfo_class_DateTime___set_state
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateInterval___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, interval_spec, IS_STRING, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateInterval___construct, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO(0, interval_spec, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateInterval_createFromDateString, 0, 0, 1)

--- a/ext/date/tests/DateInterval_construct_spec_default.phpt
+++ b/ext/date/tests/DateInterval_construct_spec_default.phpt
@@ -1,0 +1,26 @@
+--TEST--
+DateInterval::__construct() default arg value (arg not supplied)
+--FILE--
+<?php
+
+$interval = new DateInterval();
+
+var_dump(
+    $interval->y,
+    $interval->m,
+    $interval->d,
+    $interval->h,
+    $interval->i,
+    $interval->s,
+    $interval->f
+);
+
+?>
+--EXPECT--
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)
+float(0)

--- a/ext/date/tests/DateInterval_construct_spec_null.phpt
+++ b/ext/date/tests/DateInterval_construct_spec_null.phpt
@@ -1,0 +1,26 @@
+--TEST--
+DateInterval::__construct() default arg value (arg not supplied)
+--FILE--
+<?php
+
+$interval = new DateInterval(null);
+
+var_dump(
+    $interval->y,
+    $interval->m,
+    $interval->d,
+    $interval->h,
+    $interval->i,
+    $interval->s,
+    $interval->f
+);
+
+?>
+--EXPECT--
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)
+float(0)

--- a/ext/date/tests/DateInterval_prop_u.phpt
+++ b/ext/date/tests/DateInterval_prop_u.phpt
@@ -1,0 +1,50 @@
+--TEST--
+DateInterval::$u behavior
+--FILE--
+<?php
+
+function dump_usecs(DateInterval $interval): void
+{
+    var_dump(
+        $interval->u,
+        sprintf("%.6F", $interval->f),
+        $interval->format("%f"),
+        $interval->format("%F")
+    );
+    echo "\n";
+}
+
+$interval = new DateInterval('PT0S');
+dump_usecs($interval);
+
+$interval->u = 123;
+dump_usecs($interval);
+
+$interval->f = 0.456;
+dump_usecs($interval);
+
+$interval->u = 987654;
+dump_usecs($interval);
+
+?>
+--EXPECT--
+int(0)
+string(8) "0.000000"
+string(1) "0"
+string(6) "000000"
+
+int(123)
+string(8) "0.000123"
+string(3) "123"
+string(6) "000123"
+
+int(456000)
+string(8) "0.456000"
+string(6) "456000"
+string(6) "456000"
+
+int(987654)
+string(8) "0.987654"
+string(6) "987654"
+string(6) "987654"
+

--- a/ext/date/tests/DatePeriod_set_state.phpt
+++ b/ext/date/tests/DatePeriod_set_state.phpt
@@ -34,7 +34,7 @@ object(DatePeriod)#%d (6) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (16) {
+  object(DateInterval)#%d (17) {
     ["y"]=>
     int(0)
     ["m"]=>
@@ -46,6 +46,8 @@ object(DatePeriod)#%d (6) {
     ["i"]=>
     int(30)
     ["s"]=>
+    int(0)
+    ["u"]=>
     int(0)
     ["f"]=>
     float(0)

--- a/ext/date/tests/bug45682.phpt
+++ b/ext/date/tests/bug45682.phpt
@@ -12,7 +12,7 @@ $diff = date_diff($date, $other);
 
 var_dump($diff);
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (17) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -24,6 +24,8 @@ object(DateInterval)#%d (16) {
   ["i"]=>
   int(0)
   ["s"]=>
+  int(0)
+  ["u"]=>
   int(0)
   ["f"]=>
   float(0)

--- a/ext/date/tests/bug48678.phpt
+++ b/ext/date/tests/bug48678.phpt
@@ -15,6 +15,7 @@ DateInterval Object
     [h] => 12
     [i] => 30
     [s] => 5
+    [u] => 0
     [f] => 0
     [weekday] => 0
     [weekday_behavior] => 0
@@ -34,6 +35,7 @@ DateInterval Object
     [h] => 12
     [i] => 30
     [s] => 5
+    [u] => 0
     [f] => 0
     [weekday] => 0
     [weekday_behavior] => 0

--- a/ext/date/tests/bug49081.phpt
+++ b/ext/date/tests/bug49081.phpt
@@ -17,6 +17,7 @@ DateInterval Object
     [h] => 4
     [i] => 0
     [s] => 0
+    [u] => 0
     [f] => 0
     [weekday] => 0
     [weekday_behavior] => 0

--- a/ext/date/tests/bug49778.phpt
+++ b/ext/date/tests/bug49778.phpt
@@ -8,7 +8,7 @@ echo $i->format("%d"), "\n";
 echo $i->format("%a"), "\n";
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (17) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -20,6 +20,8 @@ object(DateInterval)#%d (16) {
   ["i"]=>
   int(0)
   ["s"]=>
+  int(0)
+  ["u"]=>
   int(0)
   ["f"]=>
   float(0)


### PR DESCRIPTION
- Make `$interval_spec` parameter of `DateInterval::__construct()` optional, defaulting to an empty interval (all elements zero). Allow passing `null` to get default behaviour.
- Add `DateInterval::$u` property to provide access to microseconds component as an integer.
- Miscellaneous minor code cleanup.