### PR TITLE
Refactor mb_substitute_character() after bugfix 79448.

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2077,6 +2077,7 @@ PHP_FUNCTION(mb_substitute_character)
 		}
 	} else {
 		if (Z_TYPE_P(arg1) == IS_STRING) {
+			/* This also covers the empty string case */
 			if (strncasecmp("none", Z_STRVAL_P(arg1), Z_STRLEN_P(arg1)) == 0) {
 				MBSTRG(current_filter_illegal_mode) = MBFL_OUTPUTFILTER_ILLEGAL_MODE_NONE;
 				RETURN_TRUE;
@@ -2088,14 +2089,6 @@ PHP_FUNCTION(mb_substitute_character)
 			if (strncasecmp("entity", Z_STRVAL_P(arg1), Z_STRLEN_P(arg1)) == 0) {
 				MBSTRG(current_filter_illegal_mode) = MBFL_OUTPUTFILTER_ILLEGAL_MODE_ENTITY;
 				RETURN_TRUE;
-			}
-			/* TODO Figure out why literal empty strings don't this code path */
-			/* As white space strings are considered valid numeric strings
-			 * Only do the empty case as it seems the most likely to happen */
-			if (Z_STRLEN_P(arg1) < 1) {
-				php_error_docref(NULL, E_WARNING,
-					"Substitute character must not be empty");
-				RETURN_FALSE;
 			}
 			if (!is_numeric_string(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1), NULL, NULL, 0)) {
 				php_error_docref(NULL, E_WARNING,

--- a/ext/mbstring/tests/mb_substitute_character.phpt
+++ b/ext/mbstring/tests/mb_substitute_character.phpt
@@ -4,9 +4,6 @@ mb_substitute_character()
 <?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
 --FILE--
 <?php
-//$debug = true;
-ini_set('include_path', dirname(__FILE__));
-include_once('common.inc');
 
 // Note: It does not return TRUE/FALSE for setting char
 
@@ -28,7 +25,7 @@ var_dump(bin2hex(mb_convert_encoding("\xe2\x99\xa0\xe3\x81\x82", "CP932", "UTF-8
 
 var_dump(mb_substitute_character('BAD_NAME'));
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 int(12356)
 string(8) "82a282a0"
@@ -41,4 +38,6 @@ string(4) "82a0"
 bool(true)
 string(6) "entity"
 string(20) "262378323636303b82a0"
-bool(true)
+
+Warning: mb_substitute_character(): Substitute character must be 'none'|'entity'|'long' or a valid numeric string in %s on line %d
+bool(false)

--- a/ext/mbstring/tests/mb_substitute_character_basic.phpt
+++ b/ext/mbstring/tests/mb_substitute_character_basic.phpt
@@ -28,7 +28,7 @@ var_dump( mb_substitute_character("b") );
 
 ?>
 ===DONE===
---EXPECT--
+--EXPECTF--
 *** Testing mb_substitute_character() : basic functionality ***
 int(63)
 bool(true)
@@ -37,5 +37,7 @@ bool(true)
 int(1234)
 bool(true)
 string(4) "none"
-bool(true)
+
+Warning: mb_substitute_character(): Substitute character must be 'none'|'entity'|'long' or a valid numeric string in %s on line %d
+bool(false)
 ===DONE===

--- a/ext/mbstring/tests/mb_substitute_character_variation1.phpt
+++ b/ext/mbstring/tests/mb_substitute_character_variation1.phpt
@@ -87,7 +87,6 @@ $inputs = array(
       'uppercase FALSE' =>FALSE,
 
       // empty data
-      // FIXME Return true as they skip the IS_STRING code path
       'empty string DQ' => "",
       'empty string SQ' => '',
 

--- a/ext/mbstring/tests/mb_substitute_character_variation1.phpt
+++ b/ext/mbstring/tests/mb_substitute_character_variation1.phpt
@@ -87,6 +87,7 @@ $inputs = array(
       'uppercase FALSE' =>FALSE,
 
       // empty data
+      // FIXME Return true as they skip the IS_STRING code path
       'empty string DQ' => "",
       'empty string SQ' => '',
 
@@ -190,16 +191,20 @@ bool(true)
 bool(true)
 
 --string DQ--
-bool(true)
+Error: 2 - mb_substitute_character(): Substitute character must be 'none'|'entity'|'long' or a valid numeric string, %s(%d)
+bool(false)
 
 --string SQ--
-bool(true)
+Error: 2 - mb_substitute_character(): Substitute character must be 'none'|'entity'|'long' or a valid numeric string, %s(%d)
+bool(false)
 
 --mixed case string--
-bool(true)
+Error: 2 - mb_substitute_character(): Substitute character must be 'none'|'entity'|'long' or a valid numeric string, %s(%d)
+bool(false)
 
 --heredoc--
-bool(true)
+Error: 2 - mb_substitute_character(): Substitute character must be 'none'|'entity'|'long' or a valid numeric string, %s(%d)
+bool(false)
 
 --instance of classWithToString--
 Error: 8 - Object of class classWithToString could not be converted to int, %s(%d)


### PR DESCRIPTION
Due to how this function was coded it naively converts whatever value to integer.
As strings always get converted to 0 (and the warnings are suppressed) any string which does not fit the 3 pre-established values assigns the NUL byte as the substitution character.

This refactoring restores the previous sane behaviour of returning false and emitting a warning on non-numeric strings.
See 656eac74fa6074aebc087bb73d2e4651f7dc8c9e which ammended the tests after the bugfix for a comparison of the new insane shotgun behaviour and the previously sane but incorrect behaviour.

We may also want to use ZPP in master to automatically handle non integer/string values.