### PR TITLE
Mark unterminated INIT_CALL and SEND_VAL instructions as NOP when removing unreachable basic blocks

### DIFF
--- a/ext/opcache/tests/unterminated_init_call_bug.phpt
+++ b/ext/opcache/tests/unterminated_init_call_bug.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Mark unterminated INIT_CALL and SEND_VAL instructions as NOP when removing basic blocks
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.opt_debug_level=0x20000
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+var_dump(
+    var_dump('foo'),
+    exit()
+);
+
+--EXPECTF--
+$_main:
+     ; (lines=6, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 NOP
+0001 INIT_FCALL 1 96 string("var_dump")
+0002 SEND_VAL string("foo") 1
+0003 V0 = DO_ICALL
+0004 NOP
+0005 EXIT
+string(3) "foo"


### PR DESCRIPTION
@nikic @dstogov

**DISCLAIMER**: This is a "fix" for the memory leak in #5279. I don't expect this PR to be usable but maybe it can demonstrate the problem so you can point me to the right solution. But it does indeed solve the problem.

```php
try {
    throw new Exception(throw new Exception('foo'));
} catch (Exception $ex) {}
```

generates these opcodes:

```
$_main:
     ; (lines=11, args=0, vars=1, tmps=4)
     ; (before optimizer)
     ; /tmp/php-src/Zend/tests/throw/001.php:1-124
     ; return  [] RANGE[0..0]
0000 V1 = NEW 1 string("Exception")
0001 V2 = NEW 1 string("Exception")
0002 SEND_VAL_EX string("foo") 1
0003 DO_FCALL
0004 THROW V2
0005 SEND_VAL_EX bool(true) 1
0006 DO_FCALL
0007 THROW V1
0008 JMP 0010
0009 CV0($e) = CATCH string("Exception")
0010 RETURN int(1)
LIVE RANGES:
     1: 0001 - 0007 (new)
     2: 0002 - 0004 (new)
EXCEPTION TABLE:
     0000, 0009, -, -
```

which are then optimized to:

```
$_main:
     ; (lines=7, args=0, vars=1, tmps=1)
     ; (after optimizer)
     ; /tmp/php-src/Zend/tests/throw/001.php:1-124
0000 V1 = NEW 1 string("Exception")
0001 V1 = NEW 1 string("Exception")
0002 SEND_VAL_EX string("foo") 1
0003 DO_FCALL
0004 THROW V1
0005 CV0($e) = CATCH string("Exception")
0006 RETURN int(1)
LIVE RANGES:
     1: 0002 - 0004 (new)
EXCEPTION TABLE:
     0000, 0005, -, -
```

The problem here is that the instruction 0000 isn't removed. `zend_default_exception_new` assumes that `DO_FCALL` will be called at some point to release memory it has allocated which is never does. Here is a different example:

```php
var_dump(
    var_dump('foo'),
    exit()
);
```

Unoptimized:

```
$_main:
     ; (lines=9, args=0, vars=0, tmps=2)
     ; (before optimizer)
     ; /Users/ilijatovilo/Developer/php-src/ext/opcache/tests/unterminated_init_fn_bug.php:1-8
     ; return  [] RANGE[0..0]
0000 INIT_FCALL 2 112 string("var_dump")
0001 INIT_FCALL 1 96 string("var_dump")
0002 SEND_VAL string("foo") 1
0003 V0 = DO_ICALL
0004 SEND_VAR V0 1
0005 EXIT
0006 SEND_VAL bool(true) 2
0007 DO_ICALL
0008 RETURN int(1)
string(3) "foo"
```

Optimized:

```
$_main:
     ; (lines=6, args=0, vars=0, tmps=1)
     ; (after optimizer)
     ; /Users/ilijatovilo/Developer/php-src/ext/opcache/tests/unterminated_init_fn_bug.php:1-8
0000 INIT_FCALL 2 112 string("var_dump")
0001 INIT_FCALL 1 96 string("var_dump")
0002 SEND_VAL string("foo") 1
0003 V0 = DO_ICALL
0004 SEND_VAL null 1
0005 EXIT
string(3) "foo"
```

The instructions 0000 and 0004 should be removed, This doesn't cause any problems but they are useless. This PR marks unterminated `INIT_CALL`s and `SEND_VAL`s of previous building blocks as NOPs.