### PR TITLE
Fix #79403: DateTime::construct inconsistent results with "first day of"

### DIFF
--- a/ext/date/lib/parse_date.c
+++ b/ext/date/lib/parse_date.c
@@ -651,7 +651,13 @@ static void timelib_set_relative(char **ptr, timelib_sll amount, int behavior, S
 		case TIMELIB_MINUTE:   s->time->relative.i += amount * relunit->multiplier; break;
 		case TIMELIB_HOUR:     s->time->relative.h += amount * relunit->multiplier; break;
 		case TIMELIB_DAY:      s->time->relative.d += amount * relunit->multiplier; break;
-		case TIMELIB_MONTH:    s->time->relative.m += amount * relunit->multiplier; break;
+		case TIMELIB_MONTH:
+			s->time->relative.m += amount * relunit->multiplier;
+			if ((amount == 0 && behavior == 1) || (amount == 1 && behavior == 0)) {
+				/* "this month" or "next month" mean we now have the date */
+				s->time->have_date = 1;
+			}
+			break;
 		case TIMELIB_YEAR:     s->time->relative.y += amount * relunit->multiplier; break;
 
 		case TIMELIB_WEEKDAY:

--- a/ext/date/lib/parse_date.re
+++ b/ext/date/lib/parse_date.re
@@ -650,7 +650,13 @@ static void timelib_set_relative(char **ptr, timelib_sll amount, int behavior, S
 		case TIMELIB_MINUTE:   s->time->relative.i += amount * relunit->multiplier; break;
 		case TIMELIB_HOUR:     s->time->relative.h += amount * relunit->multiplier; break;
 		case TIMELIB_DAY:      s->time->relative.d += amount * relunit->multiplier; break;
-		case TIMELIB_MONTH:    s->time->relative.m += amount * relunit->multiplier; break;
+		case TIMELIB_MONTH:
+			s->time->relative.m += amount * relunit->multiplier;
+			if ((amount == 0 && behavior == 1) || (amount == 1 && behavior == 0)) {
+				/* "this month" or "next month" mean we now have the date */
+				s->time->have_date = 1;
+			}
+			break;
 		case TIMELIB_YEAR:     s->time->relative.y += amount * relunit->multiplier; break;
 
 		case TIMELIB_WEEKDAY:

--- a/ext/date/tests/bug79403.phpt
+++ b/ext/date/tests/bug79403.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #79403 (DateTime::construct inconsistent results with "first day of")
+--FILE--
+<?
+echo (new DateTime("first day of this month"))->format('H:i:s') . "\n";
+echo (new DateTime("last day of this month"))->format('H:i:s') . "\n";
+echo (new DateTime("first day of next month"))->format('H:i:s') . "\n";
+echo (new DateTime("last day of next month"))->format('H:i:s') . "\n";
+?>
+--EXPECT--
+00:00:00
+00:00:00
+00:00:00
+00:00:00


### PR DESCRIPTION
Dear PHP developers, this is my first patch on this project. Have read the Coding Standards and contributing guidelines; am sorry if I have missed out on anything. Please let me know how to improve.

The DateTime parser tracks whether a date has been specified or not. If so, it does not
fill in the hour/minute/second fields with the current time when finalizing the initialization
of a new DateTime object.

If the phrases "this month" or "next month" are found, this means the user has specified the
date, so for consistency, the hour/minute/second fields should not be automatically filled in
with the current time.

Normally, if a date is specified twice in a DateTime string, it results in an error. However,
if "this month" and "next month" are made to cause errors when a date appeared earlier in the
string, this could break existing callers. Therefore, be 'non-strict' and do not error out
in this case.

(Please let me know if it would be better to be strict!)

Link to PHP bug tracker: https://bugs.php.net/bug.php?id=79403