### PR TITLE
Improve the default value format in incompatible signature error messages

### DIFF
--- a/Zend/tests/argument_restriction_001.phpt
+++ b/Zend/tests/argument_restriction_001.phpt
@@ -13,4 +13,4 @@ class Sub extends Base {
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of & Sub::test() must be compatible with & Base::test($foo, array $bar, $option = NULL, $extra = 'llllllllll...') in %s on line %d
+Fatal error: Declaration of & Sub::test() must be compatible with & Base::test($foo, array $bar, $option = null, $extra = 'llllllllll...') in %s on line %d

--- a/Zend/tests/argument_restriction_002.phpt
+++ b/Zend/tests/argument_restriction_002.phpt
@@ -13,4 +13,4 @@ class Sub extends Base {
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of Sub::test($foo, array &$bar) must be compatible with Base::test($foo, array &$bar, $option = NULL, $extra = 3.1415926535898) in %sargument_restriction_002.php on line %d
+Fatal error: Declaration of Sub::test($foo, array &$bar) must be compatible with Base::test($foo, array &$bar, $option = null, $extra = 3.1415926535898) in %s on line %d

--- a/Zend/tests/argument_restriction_003.phpt
+++ b/Zend/tests/argument_restriction_003.phpt
@@ -16,4 +16,4 @@ class Sub extends Base {
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of Sub::test() must be compatible with Base::test(Foo $foo, array $bar, $option = NULL, $extra = 'llllllllll...') in %s on line %d
+Fatal error: Declaration of Sub::test() must be compatible with Base::test(Foo $foo, array $bar, $option = null, $extra = 'llllllllll...') in %s on line %d

--- a/Zend/tests/argument_restriction_006.phpt
+++ b/Zend/tests/argument_restriction_006.phpt
@@ -13,4 +13,4 @@ class Sub extends Base {
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of Sub::test($foo, $extra) must be compatible with Base::test($foo, $extra = Array) in %s on line %d
+Fatal error: Declaration of Sub::test($foo, $extra) must be compatible with Base::test($foo, $extra = [...]) in %s on line %d

--- a/Zend/tests/bug64988.phpt
+++ b/Zend/tests/bug64988.phpt
@@ -26,4 +26,4 @@ $o = new Smooth1();
 echo "okey";
 ?>
 --EXPECTF--
-Fatal error: Declaration of Smooth1::insert(array $data) must be compatible with Noisy1::insert(array $data, $option1 = NULL) in %s on line %d
+Fatal error: Declaration of Smooth1::insert(array $data) must be compatible with Noisy1::insert(array $data, $option1 = null) in %s on line %d

--- a/Zend/tests/bug71428.1.phpt
+++ b/Zend/tests/bug71428.1.phpt
@@ -9,4 +9,4 @@ class B extends A {
     public function m(array $a = []) {}
 }
 --EXPECTF--
-Fatal error: Declaration of B::m(array $a = Array) must be compatible with A::m(?array $a = NULL) in %s on line %d
+Fatal error: Declaration of B::m(array $a = []) must be compatible with A::m(?array $a = null) in %s on line %d

--- a/Zend/tests/bug72119.phpt
+++ b/Zend/tests/bug72119.phpt
@@ -15,4 +15,4 @@ class Hello implements Foo {
 echo "OK\n";
 ?>
 --EXPECTF--
-Fatal error: Declaration of Hello::bar(array $baz = Array) must be compatible with Foo::bar(?array $baz = NULL) in %s on line %d
+Fatal error: Declaration of Hello::bar(array $baz = []) must be compatible with Foo::bar(?array $baz = null) in %s on line %d

--- a/Zend/tests/bug73987.phpt
+++ b/Zend/tests/bug73987.phpt
@@ -15,4 +15,4 @@ class B extends A {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of B::example($a, $b, $c = NULL) must be compatible with A::example($a, $b = NULL, $c = NULL) in %s on line %d
+Fatal error: Declaration of B::example($a, $b, $c = null) must be compatible with A::example($a, $b = null, $c = null) in %s on line %d

--- a/Zend/tests/bug73987_2.phpt
+++ b/Zend/tests/bug73987_2.phpt
@@ -17,4 +17,4 @@ class C extends B {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of C::example($a, $b, $c = NULL) must be compatible with B::example($a, $b = NULL, $c = NULL) in %s on line %d
+Fatal error: Declaration of C::example($a, $b, $c = null) must be compatible with B::example($a, $b = null, $c = null) in %s on line %d

--- a/Zend/tests/objects_006.phpt
+++ b/Zend/tests/objects_006.phpt
@@ -19,4 +19,4 @@ class test3 extends test {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of test3::foo($arg, $arg2) must be compatible with test::foo($arg, $arg2 = NULL) in %s on line %d
+Fatal error: Declaration of test3::foo($arg, $arg2) must be compatible with test::foo($arg, $arg2 = null) in %s on line %d

--- a/Zend/tests/objects_007.phpt
+++ b/Zend/tests/objects_007.phpt
@@ -19,4 +19,4 @@ class test3 extends test {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of test3::foo($arg, &$arg2) must be compatible with test::foo($arg, &$arg2 = NULL) in %s on line %d
+Fatal error: Declaration of test3::foo($arg, &$arg2) must be compatible with test::foo($arg, &$arg2 = null) in %s on line %d

--- a/Zend/tests/type_declarations/variance/internal_parent.phpt
+++ b/Zend/tests/type_declarations/variance/internal_parent.phpt
@@ -9,4 +9,4 @@ class Test extends DateTime {
 
 ?>
 --EXPECTF--
-Fatal error: Could not check compatibility between Test::createFromFormat($format, $time, ?Wrong $timezone = NULL) and DateTime::createFromFormat(string $format, string $time, ?DateTimeZone $timezone = null), because class Wrong is not available in %s on line %d
+Fatal error: Could not check compatibility between Test::createFromFormat($format, $time, ?Wrong $timezone = null) and DateTime::createFromFormat(string $format, string $time, ?DateTimeZone $timezone = null), because class Wrong is not available in %s on line %d

--- a/Zend/tests/variadic/adding_additional_optional_parameter_error.phpt
+++ b/Zend/tests/variadic/adding_additional_optional_parameter_error.phpt
@@ -13,4 +13,4 @@ class MySQL implements DB {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of MySQL::query($query, ?int $extraParam = NULL, string ...$params) must be compatible with DB::query($query, string ...$params) in %s on line %d
+Fatal error: Declaration of MySQL::query($query, ?int $extraParam = null, string ...$params) must be compatible with DB::query($query, string ...$params) in %s on line %d

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -710,7 +710,7 @@ static ZEND_COLD zend_string *zend_get_function_declaration(const zend_function 
 						} else if (Z_TYPE_P(zv) == IS_TRUE) {
 							smart_str_appends(&str, "true");
 						} else if (Z_TYPE_P(zv) == IS_NULL) {
-							smart_str_appends(&str, "NULL");
+							smart_str_appends(&str, "null");
 						} else if (Z_TYPE_P(zv) == IS_STRING) {
 							smart_str_appendc(&str, '\'');
 							smart_str_appendl(&str, Z_STRVAL_P(zv), MIN(Z_STRLEN_P(zv), 10));
@@ -719,7 +719,11 @@ static ZEND_COLD zend_string *zend_get_function_declaration(const zend_function 
 							}
 							smart_str_appendc(&str, '\'');
 						} else if (Z_TYPE_P(zv) == IS_ARRAY) {
-							smart_str_appends(&str, "Array");
+							if (zend_hash_num_elements(Z_ARRVAL_P(zv)) == 0) {
+								smart_str_appends(&str, "[]");
+							} else {
+								smart_str_appends(&str, "[...]");
+							}
 						} else if (Z_TYPE_P(zv) == IS_CONSTANT_AST) {
 							zend_ast *ast = Z_ASTVAL_P(zv);
 							if (ast->kind == ZEND_AST_CONSTANT) {


### PR DESCRIPTION
As a follow up to https://github.com/php/php-src/pull/5353, the changes are related to parameter default values of user-land functions:
- lowercased `NULL` to `null`
- `Array` is now shown as `<array>`

I'm not 100% sure about the second change, but I like its consistency with `<expression>` and `<default>`. That said, I'm interested in other solutions as well to make `Array` consistent with the other placeholders.