### PR TITLE
Fix #79462: method_exists and property_exists incoherent behavior

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1107,7 +1107,8 @@ ZEND_FUNCTION(method_exists)
 			RETURN_FALSE;
 		}
 	} else {
-		RETURN_FALSE;
+		zend_argument_type_error(1, "must be of type object|string, %s given", zend_zval_type_name(klass));
+		RETURN_THROWS();
 	}
 
 	lcname = zend_string_tolower(method_name);

--- a/ext/standard/tests/class_object/method_exists_variation_001.phpt
+++ b/ext/standard/tests/class_object/method_exists_variation_001.phpt
@@ -78,7 +78,11 @@ $values = array(
 
 foreach($values as $value) {
       echo "\nArg value $value \n";
-      var_dump( method_exists($value, $method) );
+      try {
+        var_dump( method_exists($value, $method) );
+      } catch (TypeError $e) {
+        echo $e->getMessage(), PHP_EOL;
+      }
 };
 
 echo "Done";
@@ -89,69 +93,69 @@ Error: 2 - Undefined variable $undefined_var
 Error: 2 - Undefined variable $unset_var
 
 Arg value 0 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, int given
 
 Arg value 1 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, int given
 
 Arg value 12345 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, int given
 
 Arg value -2345 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, int given
 
 Arg value 10.5 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, float given
 
 Arg value -10.5 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, float given
 
 Arg value 101234567000 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, float given
 
 Arg value 1.07654321E-9 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, float given
 
 Arg value 0.5 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, float given
 Error: 2 - Array to string conversion
 
 Arg value Array 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given
 Error: 2 - Array to string conversion
 
 Arg value Array 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given
 Error: 2 - Array to string conversion
 
 Arg value Array 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given
 Error: 2 - Array to string conversion
 
 Arg value Array 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given
 Error: 2 - Array to string conversion
 
 Arg value Array 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given
 
 Arg value  
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given
 
 Arg value  
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given
 
 Arg value 1 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, bool given
 
 Arg value  
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, bool given
 
 Arg value 1 
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, bool given
 
 Arg value  
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, bool given
 
 Arg value  
 bool(false)
@@ -168,8 +172,8 @@ In autoload(String)
 bool(false)
 
 Arg value  
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given
 
 Arg value  
-bool(false)
+method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given
 Done


### PR DESCRIPTION
Both functions are closely related, so should behave the same for wrong
input types, i.e. both should throw a TypeError.