### PR TITLE
Generate method entries from stubs for a couple of extensions

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -73,19 +73,20 @@ typedef struct _zend_fcall_info_cache {
 #define ZEND_RAW_FENTRY(zend_name, name, arg_info, flags)   { zend_name, name, arg_info, (uint32_t) (sizeof(arg_info)/sizeof(struct _zend_internal_arg_info)-1), flags },
 
 /* Same as ZEND_NAMED_FE */
-#define ZEND_RAW_NAMED_FE(zend_name, name, arg_info) ZEND_RAW_FENTRY(#zend_name, name, arg_info, 0)
+#define ZEND_RAW_NAMED_FE(zend_name, name, arg_info) 				ZEND_RAW_FENTRY(#zend_name, name, arg_info, 0)
 
-#define ZEND_NAMED_FE(zend_name, name, arg_info)	ZEND_RAW_FENTRY(#zend_name, name, arg_info, 0)
-#define ZEND_FE(name, arg_info)						ZEND_RAW_FENTRY(#name, zif_##name, arg_info, 0)
-#define ZEND_DEP_FE(name, arg_info)                 ZEND_RAW_FENTRY(#name, zif_##name, arg_info, ZEND_ACC_DEPRECATED)
-#define ZEND_FALIAS(name, alias, arg_info)			ZEND_RAW_FENTRY(#name, zif_##alias, arg_info, 0)
-#define ZEND_DEP_FALIAS(name, alias, arg_info)		ZEND_RAW_FENTRY(#name, zif_##alias, arg_info, ZEND_ACC_DEPRECATED)
-#define ZEND_NAMED_ME(zend_name, name, arg_info, flags)	ZEND_FENTRY(zend_name, name, arg_info, flags)
-#define ZEND_ME(classname, name, arg_info, flags)	ZEND_RAW_FENTRY(#name, zim_##classname##_##name, arg_info, flags)
-#define ZEND_DEP_ME(classname, name, arg_info, flags) ZEND_RAW_FENTRY(#name, zim_##classname##_##name, arg_info, flags | ZEND_ACC_DEPRECATED)
-#define ZEND_ABSTRACT_ME(classname, name, arg_info)	ZEND_RAW_FENTRY(#name, NULL, arg_info, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-#define ZEND_MALIAS(classname, name, alias, arg_info, flags) ZEND_RAW_FENTRY(#name, zim_##classname##_##alias, arg_info, flags)
-#define ZEND_ME_MAPPING(name, func_name, arg_info, flags) ZEND_RAW_FENTRY(#name, zif_##func_name, arg_info, flags)
+#define ZEND_NAMED_FE(zend_name, name, arg_info)						ZEND_RAW_FENTRY(#zend_name, name, arg_info, 0)
+#define ZEND_FE(name, arg_info)											ZEND_RAW_FENTRY(#name, zif_##name, arg_info, 0)
+#define ZEND_DEP_FE(name, arg_info)										ZEND_RAW_FENTRY(#name, zif_##name, arg_info, ZEND_ACC_DEPRECATED)
+#define ZEND_FALIAS(name, alias, arg_info)								ZEND_RAW_FENTRY(#name, zif_##alias, arg_info, 0)
+#define ZEND_DEP_FALIAS(name, alias, arg_info)							ZEND_RAW_FENTRY(#name, zif_##alias, arg_info, ZEND_ACC_DEPRECATED)
+#define ZEND_NAMED_ME(zend_name, name, arg_info, flags)					ZEND_FENTRY(zend_name, name, arg_info, flags)
+#define ZEND_ME(classname, name, arg_info, flags)						ZEND_RAW_FENTRY(#name, zim_##classname##_##name, arg_info, flags)
+#define ZEND_DEP_ME(classname, name, arg_info, flags)					ZEND_RAW_FENTRY(#name, zim_##classname##_##name, arg_info, flags | ZEND_ACC_DEPRECATED)
+#define ZEND_ABSTRACT_ME(classname, name, arg_info)						ZEND_RAW_FENTRY(#name, NULL, arg_info, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#define ZEND_ABSTRACT_ME_WITH_FLAGS(classname, name, arg_info, flags)	ZEND_RAW_FENTRY(#name, NULL, arg_info, flags)
+#define ZEND_MALIAS(classname, name, alias, arg_info, flags)			ZEND_RAW_FENTRY(#name, zim_##classname##_##alias, arg_info, flags)
+#define ZEND_ME_MAPPING(name, func_name, arg_info, flags)				ZEND_RAW_FENTRY(#name, zif_##func_name, arg_info, flags)
 
 #define ZEND_NS_FENTRY(ns, zend_name, name, arg_info, flags)		ZEND_RAW_FENTRY(ZEND_NS_NAME(ns, #zend_name), name, arg_info, flags)
 

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -447,8 +447,8 @@ class FuncInfo {
             } else {
                 if ($this->flags & Class_::MODIFIER_ABSTRACT) {
                     return sprintf(
-                        "\tZEND_ABSTRACT_ME(%s, %s, %s)\n",
-                        $this->name->className, $this->name->name, $this->getArgInfoName()
+                        "\tZEND_ABSTRACT_ME_WITH_FLAGS(%s, %s, %s, %s)\n",
+                        $this->name->className, $this->name->name, $this->getArgInfoName(), $this->getFlagsAsString()
                     );
                 }
 
@@ -797,8 +797,8 @@ function parseStubFile(string $fileName): FileInfo {
                     $flags |= Class_::MODIFIER_ABSTRACT;
                 }
 
-                if ($flags & Class_::MODIFIER_ABSTRACT && !($flags & Class_::MODIFIER_PUBLIC)) {
-                    throw new Exception("Abstract non-public methods are not supported");
+                if (!($flags & Class_::VISIBILITY_MODIFIER_MASK)) {
+                    throw new Exception("Method visibility modifier is required");
                 }
 
                 $methodInfos[] = parseFunctionLike(
@@ -984,9 +984,9 @@ function generateArgInfoCode(FileInfo $fileInfo): string {
             }
         );
 
-        $code .= "\n\n";
-
-        $code .= generateFunctionEntries(null, $fileInfo->funcInfos);
+        if (empty($fileInfo->funcInfos) === false) {
+            $code .= generateFunctionEntries(null, $fileInfo->funcInfos);
+        }
 
         foreach ($fileInfo->classInfos as $classInfo) {
             $code .= generateFunctionEntries($classInfo->name, $classInfo->funcInfos);

--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -37,21 +37,6 @@ zend_class_entry
    	*php_com_exception_class_entry,
 	*php_com_saproxy_class_entry;
 
-static const zend_function_entry com_variant_funcs[] = {
-	PHP_ME(variant, __construct, arginfo_class_variant___construct, ZEND_ACC_PUBLIC)
-	PHP_FE_END
-};
-
-static const zend_function_entry com_com_funcs[] = {
-	PHP_ME(com, __construct, arginfo_class_com___construct, ZEND_ACC_PUBLIC)
-	PHP_FE_END
-};
-
-static const zend_function_entry com_dotnet_funcs[] = {
-	PHP_ME(dotnet, __construct, arginfo_class_dotnet___construct, ZEND_ACC_PUBLIC)
-	PHP_FE_END
-};
-
 /* {{{ com_dotnet_module_entry
  */
 zend_module_entry com_dotnet_module_entry = {
@@ -196,14 +181,14 @@ PHP_MINIT_FUNCTION(com_dotnet)
 /*	php_com_saproxy_class_entry->constructor->common.fn_flags |= ZEND_ACC_PROTECTED; */
 	php_com_saproxy_class_entry->get_iterator = php_com_saproxy_iter_get;
 
-	INIT_CLASS_ENTRY(ce, "variant", com_variant_funcs);
+	INIT_CLASS_ENTRY(ce, "variant", class_variant_methods);
 	ce.create_object = php_com_object_new;
 	php_com_variant_class_entry = zend_register_internal_class(&ce);
 	php_com_variant_class_entry->get_iterator = php_com_iter_get;
 	php_com_variant_class_entry->serialize = zend_class_serialize_deny;
 	php_com_variant_class_entry->unserialize = zend_class_unserialize_deny;
 
-	INIT_CLASS_ENTRY(ce, "com", com_com_funcs);
+	INIT_CLASS_ENTRY(ce, "com", class_com_methods);
 	ce.create_object = php_com_object_new;
 	tmp = zend_register_internal_class_ex(&ce, php_com_variant_class_entry);
 	tmp->get_iterator = php_com_iter_get;
@@ -211,7 +196,7 @@ PHP_MINIT_FUNCTION(com_dotnet)
 	tmp->unserialize = zend_class_unserialize_deny;
 
 #if HAVE_MSCOREE_H
-	INIT_CLASS_ENTRY(ce, "dotnet", com_dotnet_funcs);
+	INIT_CLASS_ENTRY(ce, "dotnet", class_dotnet_methods);
 	ce.create_object = php_com_object_new;
 	tmp = zend_register_internal_class_ex(&ce, php_com_variant_class_entry);
 	tmp->get_iterator = php_com_iter_get;

--- a/ext/com_dotnet/com_extension_arginfo.h
+++ b/ext/com_dotnet/com_extension_arginfo.h
@@ -163,6 +163,11 @@ ZEND_FUNCTION(com_event_sink);
 ZEND_FUNCTION(com_print_typeinfo);
 ZEND_FUNCTION(com_message_pump);
 ZEND_FUNCTION(com_load_typelib);
+ZEND_METHOD(variant, __construct);
+ZEND_METHOD(com, __construct);
+#if HAVE_MSCOREE_H
+ZEND_METHOD(dotnet, __construct);
+#endif
 
 
 static const zend_function_entry ext_functions[] = {
@@ -198,5 +203,25 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(com_print_typeinfo, arginfo_com_print_typeinfo)
 	ZEND_FE(com_message_pump, arginfo_com_message_pump)
 	ZEND_FE(com_load_typelib, arginfo_com_load_typelib)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_variant_methods[] = {
+	ZEND_ME(variant, __construct, arginfo_class_variant___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_com_methods[] = {
+	ZEND_ME(com, __construct, arginfo_class_com___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_dotnet_methods[] = {
+#if HAVE_MSCOREE_H
+	ZEND_ME(dotnet, __construct, arginfo_class_dotnet___construct, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_FE_END
 };

--- a/ext/com_dotnet/com_persist.stub.php
+++ b/ext/com_dotnet/com_persist.stub.php
@@ -1,21 +1,23 @@
 <?php
 
-final class COMPersistHelper {
-    public function __construct(?VARIANT $com_object);
 
-    public function GetCurFileName(): string|false;
+final class COMPersistHelper
+{
+    public function __construct(?VARIANT $com_object) {}
 
-    public function SaveToFile(?string $filename, bool $remember = true): bool;
+    public function GetCurFileName(): string|false {}
 
-    public function LoadFromFile(string $path, int $flags = 0): bool;
+    public function SaveToFile(?string $filename, bool $remember = true): bool {}
 
-    public function GetMaxStreamSize(): int;
+    public function LoadFromFile(string $path, int $flags = 0): bool {}
 
-    public function InitNew(): bool;
+    public function GetMaxStreamSize(): int {}
+
+    public function InitNew(): bool {}
 
     /** @param resource $stream */
-    public function LoadFromStream($stream): bool;
+    public function LoadFromStream($stream): bool {}
 
     /** @param resource $stream */
-    public function SaveToStream($stream): bool;
+    public function SaveToStream($stream): bool {}
 }

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -504,8 +504,6 @@ ZEND_METHOD(DatePeriod, __wakeup);
 ZEND_METHOD(DatePeriod, __set_state);
 
 
-
-
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(strtotime, arginfo_strtotime)
 	ZEND_FE(date, arginfo_date)
@@ -560,12 +558,12 @@ static const zend_function_entry ext_functions[] = {
 
 
 static const zend_function_entry class_DateTimeInterface_methods[] = {
-	ZEND_ABSTRACT_ME(DateTimeInterface, format, arginfo_class_DateTimeInterface_format)
-	ZEND_ABSTRACT_ME(DateTimeInterface, getTimezone, arginfo_class_DateTimeInterface_getTimezone)
-	ZEND_ABSTRACT_ME(DateTimeInterface, getOffset, arginfo_class_DateTimeInterface_getOffset)
-	ZEND_ABSTRACT_ME(DateTimeInterface, getTimestamp, arginfo_class_DateTimeInterface_getTimestamp)
-	ZEND_ABSTRACT_ME(DateTimeInterface, diff, arginfo_class_DateTimeInterface_diff)
-	ZEND_ABSTRACT_ME(DateTimeInterface, __wakeup, arginfo_class_DateTimeInterface___wakeup)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, format, arginfo_class_DateTimeInterface_format, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, getTimezone, arginfo_class_DateTimeInterface_getTimezone, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, getOffset, arginfo_class_DateTimeInterface_getOffset, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, getTimestamp, arginfo_class_DateTimeInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, diff, arginfo_class_DateTimeInterface_diff, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, __wakeup, arginfo_class_DateTimeInterface___wakeup, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_FE_END
 };
 

--- a/ext/dom/documenttype.c
+++ b/ext/dom/documenttype.c
@@ -23,17 +23,6 @@
 #if HAVE_LIBXML && HAVE_DOM
 #include "php_dom.h"
 
-/*
-* class DOMDocumentType extends DOMNode
-*
-* URL: https://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-412266927
-* Since:
-*/
-
-const zend_function_entry php_dom_documenttype_class_functions[] = {
-	PHP_FE_END
-};
-
 /* {{{ name	string
 readonly=yes
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-1844763134

--- a/ext/dom/dom_arginfo.h
+++ b/ext/dom/dom_arginfo.h
@@ -12,3 +12,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(dom_import_simplexml, arginfo_dom_import_simplexml)
 	ZEND_FE_END
 };
+
+
+static const zend_function_entry class_DOMDocumentType_methods[] = {
+	ZEND_FE_END
+};

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -33,7 +33,6 @@ extern const zend_function_entry php_dom_element_class_functions[];
 extern const zend_function_entry php_dom_text_class_functions[];
 extern const zend_function_entry php_dom_comment_class_functions[];
 extern const zend_function_entry php_dom_cdatasection_class_functions[];
-extern const zend_function_entry php_dom_documenttype_class_functions[];
 extern const zend_function_entry php_dom_notation_class_functions[];
 extern const zend_function_entry php_dom_entity_class_functions[];
 extern const zend_function_entry php_dom_entityreference_class_functions[];

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -737,7 +737,7 @@ PHP_MINIT_FUNCTION(dom)
 	REGISTER_DOM_CLASS(ce, "DOMCdataSection", dom_text_class_entry, php_dom_cdatasection_class_functions, dom_cdatasection_class_entry);
 	zend_hash_add_ptr(&classes, ce.name, &dom_text_prop_handlers);
 
-	REGISTER_DOM_CLASS(ce, "DOMDocumentType", dom_node_class_entry, php_dom_documenttype_class_functions, dom_documenttype_class_entry);
+	REGISTER_DOM_CLASS(ce, "DOMDocumentType", dom_node_class_entry, class_DOMDocumentType_methods, dom_documenttype_class_entry);
 
 	zend_hash_init(&dom_documenttype_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
 	dom_register_prop_handler(&dom_documenttype_prop_handlers, "name", sizeof("name")-1, dom_documenttype_name_read, NULL);

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -107,17 +107,6 @@ PHP_FILEINFO_API zend_object *finfo_objects_new(zend_class_entry *class_type)
 }
 /* }}} */
 
-/* {{{ finfo_class_functions
- */
-static const zend_function_entry finfo_class_functions[] = {
-	ZEND_ME_MAPPING(__construct,    finfo_open,     arginfo_class_finfo___construct, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(set_flags,      finfo_set_flags,arginfo_class_finfo_set_flags, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(file,           finfo_file,     arginfo_class_finfo_file, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(buffer,         finfo_buffer,   arginfo_class_finfo_buffer, ZEND_ACC_PUBLIC)
-	PHP_FE_END
-};
-/* }}} */
-
 #define FINFO_SET_OPTION(magic, options) \
 	if (magic_setflags(magic, options) == -1) { \
 		php_error_docref(NULL, E_WARNING, "Failed to set option '" ZEND_LONG_FMT "' %d:%s", \
@@ -145,7 +134,7 @@ void finfo_resource_destructor(zend_resource *rsrc) /* {{{ */
 PHP_MINIT_FUNCTION(finfo)
 {
 	zend_class_entry _finfo_class_entry;
-	INIT_CLASS_ENTRY(_finfo_class_entry, "finfo", finfo_class_functions);
+	INIT_CLASS_ENTRY(_finfo_class_entry, "finfo", class_finfo_methods);
 	_finfo_class_entry.create_object = finfo_objects_new;
 	finfo_class_entry = zend_register_internal_class(&_finfo_class_entry);
 

--- a/ext/fileinfo/fileinfo.stub.php
+++ b/ext/fileinfo/fileinfo.stub.php
@@ -4,21 +4,27 @@
 
 class finfo
 {
+    /** @alias finfo_open */
     public function __construct(int $options = FILEINFO_NONE, string $arg = "") {}
 
     /**
      * @param ?resource $context
      * @return string|false
+     * @alias finfo_file
      */
     public function file(string $file_name, int $options = FILEINFO_NONE, $context = null) {}
 
     /**
      * @param ?resource $context
      * @return string|false
+     * @alias finfo_buffer
      */
     public function buffer(string $string, int $options = FILEINFO_NONE, $context = null) {}
 
-    /** @return bool */
+    /**
+     * @return bool
+     * @alias finfo_set_flags
+     */
     public function set_flags(int $options) {}
 }
 

--- a/ext/fileinfo/fileinfo_arginfo.h
+++ b/ext/fileinfo/fileinfo_arginfo.h
@@ -68,3 +68,12 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mime_content_type, arginfo_mime_content_type)
 	ZEND_FE_END
 };
+
+
+static const zend_function_entry class_finfo_methods[] = {
+	ZEND_ME_MAPPING(__construct, finfo_open, arginfo_class_finfo___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(file, finfo_file, arginfo_class_finfo_file, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(buffer, finfo_buffer, arginfo_class_finfo_buffer, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(set_flags, finfo_set_flags, arginfo_class_finfo_set_flags, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -887,16 +887,11 @@ PHP_FUNCTION(hash_equals)
 /* }}} */
 
 /* {{{ proto HashContext::__construct() */
-static PHP_METHOD(HashContext, __construct) {
+PHP_METHOD(HashContext, __construct) {
 	/* Normally unreachable as private/final */
 	zend_throw_exception(zend_ce_error, "Illegal call to private/final constructor", 0);
 }
 /* }}} */
-
-static const zend_function_entry php_hashcontext_methods[] = {
-	PHP_ME(HashContext, __construct, arginfo_class_HashContext___construct, ZEND_ACC_PRIVATE)
-	PHP_FE_END
-};
 
 /* Module Housekeeping */
 
@@ -1242,7 +1237,7 @@ PHP_MINIT_FUNCTION(hash)
 
 	REGISTER_LONG_CONSTANT("HASH_HMAC",		PHP_HASH_HMAC,	CONST_CS | CONST_PERSISTENT);
 
-	INIT_CLASS_ENTRY(ce, "HashContext", php_hashcontext_methods);
+	INIT_CLASS_ENTRY(ce, "HashContext", class_HashContext_methods);
 	php_hashcontext_ce = zend_register_internal_class(&ce);
 	php_hashcontext_ce->ce_flags |= ZEND_ACC_FINAL;
 	php_hashcontext_ce->create_object = php_hashcontext_create;

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -148,6 +148,7 @@ ZEND_FUNCTION(mhash_count);
 #if defined(PHP_MHASH_BC)
 ZEND_FUNCTION(mhash);
 #endif
+ZEND_METHOD(HashContext, __construct);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -181,5 +182,11 @@ static const zend_function_entry ext_functions[] = {
 #if defined(PHP_MHASH_BC)
 	ZEND_FE(mhash, arginfo_mhash)
 #endif
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_HashContext_methods[] = {
+	ZEND_ME(HashContext, __construct, arginfo_class_HashContext___construct, ZEND_ACC_PRIVATE)
 	ZEND_FE_END
 };

--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -37,13 +37,6 @@ PHP_JSON_API zend_class_entry *php_json_exception_ce;
 
 PHP_JSON_API ZEND_DECLARE_MODULE_GLOBALS(json)
 
-/* {{{ JsonSerializable methods */
-static const zend_function_entry json_serializable_interface[] = {
-	PHP_ABSTRACT_ME(JsonSerializable, jsonSerialize, arginfo_class_JsonSerializable_jsonSerialize)
-	PHP_FE_END
-};
-/* }}} */
-
 /* Register constant for options and errors */
 #define PHP_JSON_REGISTER_CONSTANT(_name, _value) \
 	REGISTER_LONG_CONSTANT(_name,  _value, CONST_CS | CONST_PERSISTENT);
@@ -53,7 +46,7 @@ static PHP_MINIT_FUNCTION(json)
 {
 	zend_class_entry ce;
 
-	INIT_CLASS_ENTRY(ce, "JsonSerializable", json_serializable_interface);
+	INIT_CLASS_ENTRY(ce, "JsonSerializable", class_JsonSerializable_methods);
 	php_json_serializable_ce = zend_register_internal_interface(&ce);
 
 	INIT_CLASS_ENTRY(ce, "JsonException", NULL);

--- a/ext/json/json_arginfo.h
+++ b/ext/json/json_arginfo.h
@@ -36,3 +36,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(json_last_error_msg, arginfo_json_last_error_msg)
 	ZEND_FE_END
 };
+
+
+static const zend_function_entry class_JsonSerializable_methods[] = {
+	ZEND_ABSTRACT_ME_WITH_FLAGS(JsonSerializable, jsonSerialize, arginfo_class_JsonSerializable_jsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_FE_END
+};

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -181,32 +181,21 @@ static zend_function *zend_test_class_static_method_get(zend_class_entry *ce, ze
 }
 /* }}} */
 
-static ZEND_METHOD(_ZendTestClass, __toString) /* {{{ */ {
+ZEND_METHOD(_ZendTestClass, __toString) /* {{{ */ {
 	RETURN_EMPTY_STRING();
 }
 /* }}} */
 
 /* Internal function returns bool, we return int. */
-static ZEND_METHOD(_ZendTestClass, is_object) /* {{{ */ {
+ZEND_METHOD(_ZendTestClass, is_object) /* {{{ */ {
 	RETURN_LONG(42);
 }
 /* }}} */
 
-static ZEND_METHOD(_ZendTestTrait, testMethod) /* {{{ */ {
+ZEND_METHOD(_ZendTestTrait, testMethod) /* {{{ */ {
 	RETURN_TRUE;
 }
 /* }}} */
-
-static const zend_function_entry zend_test_class_methods[] = {
-	ZEND_ME(_ZendTestClass, is_object, arginfo_class__ZendTestClass_is_object, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	ZEND_ME(_ZendTestClass, __toString, arginfo_class__ZendTestClass___toString, ZEND_ACC_DEPRECATED)
-	ZEND_FE_END
-};
-
-static const zend_function_entry zend_test_trait_methods[] = {
-    ZEND_ME(_ZendTestTrait, testMethod, arginfo_class__ZendTestTrait_testMethod, ZEND_ACC_PUBLIC)
-    ZEND_FE_END
-};
 
 PHP_MINIT_FUNCTION(zend_test)
 {
@@ -215,7 +204,7 @@ PHP_MINIT_FUNCTION(zend_test)
 	INIT_CLASS_ENTRY(class_entry, "_ZendTestInterface", NULL);
 	zend_test_interface = zend_register_internal_interface(&class_entry);
 	zend_declare_class_constant_long(zend_test_interface, ZEND_STRL("DUMMY"), 0);
-	INIT_CLASS_ENTRY(class_entry, "_ZendTestClass", zend_test_class_methods);
+	INIT_CLASS_ENTRY(class_entry, "_ZendTestClass", class__ZendTestClass_methods);
 	zend_test_class = zend_register_internal_class(&class_entry);
 	zend_class_implements(zend_test_class, 1, zend_test_interface);
 	zend_test_class->create_object = zend_test_class_new;
@@ -275,7 +264,7 @@ PHP_MINIT_FUNCTION(zend_test)
 	memcpy(&zend_test_class_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	zend_test_class_handlers.get_method = zend_test_class_method_get;
 
-	INIT_CLASS_ENTRY(class_entry, "_ZendTestTrait", zend_test_trait_methods);
+	INIT_CLASS_ENTRY(class_entry, "_ZendTestTrait", class__ZendTestTrait_methods);
 	zend_test_trait = zend_register_internal_class(&class_entry);
 	zend_test_trait->ce_flags |= ZEND_ACC_TRAIT;
 	zend_declare_property_null(zend_test_trait, "testProp", sizeof("testProp")-1, ZEND_ACC_PUBLIC);

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -3,13 +3,14 @@
 /** @generate-function-entries */
 
 class _ZendTestClass {
-    public static function is_object(): int;
+    public static function is_object(): int {}
 
-    public function __toString(): string;
+    /** @deprecated */
+    public function __toString(): string {}
 }
 
 trait _ZendTestTrait {
-    public function testMethod(): bool;
+    public function testMethod(): bool {}
 }
 
 function zend_test_array_return(): array {}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -45,6 +45,9 @@ ZEND_FUNCTION(zend_create_unterminated_string);
 ZEND_FUNCTION(zend_terminate_string);
 ZEND_FUNCTION(zend_leak_variable);
 ZEND_FUNCTION(zend_leak_bytes);
+ZEND_METHOD(_ZendTestClass, is_object);
+ZEND_METHOD(_ZendTestClass, __toString);
+ZEND_METHOD(_ZendTestTrait, testMethod);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -56,5 +59,18 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_terminate_string, arginfo_zend_terminate_string)
 	ZEND_FE(zend_leak_variable, arginfo_zend_leak_variable)
 	ZEND_FE(zend_leak_bytes, arginfo_zend_leak_bytes)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class__ZendTestClass_methods[] = {
+	ZEND_ME(_ZendTestClass, is_object, arginfo_class__ZendTestClass_is_object, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(_ZendTestClass, __toString, arginfo_class__ZendTestClass___toString, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class__ZendTestTrait_methods[] = {
+	ZEND_ME(_ZendTestTrait, testMethod, arginfo_class__ZendTestTrait_testMethod, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };


### PR DESCRIPTION
There are only 2 notable changes:
- I'd like to make method visibility modifiers required
- Made it possible to generate entries for abstract non-public methods (there is one example for it in SPL which used `ZEND_RAW_FENTRY`)