### PR TITLE
Fix an undefined class error running gen_stub in php8

### DIFF
--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -142,7 +142,7 @@ prof-clean:
 prof-use:
 	CCACHE_DISABLE=1 $(MAKE) PROF_FLAGS=-fprofile-use all
 
-# olny php above 7.1.0 supports nullable return type
+# only php above 7.1.0 supports nullable return type
 %_arginfo.h: %.stub.php
 	@if test -e "$(top_srcdir)/build/gen_stub.php"; then \
 		if test ! -z "$(PHP_EXECUTABLE)" && test -x "$(PHP_EXECUTABLE)"; then \

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -26,21 +26,6 @@ class CustomPrettyPrinter extends Standard
     }
 }
 
-if ($argc >= 2) {
-    if (is_file($argv[1])) {
-        // Generate single file.
-        processStubFile($argv[1]);
-    } else if (is_dir($argv[1])) {
-        processDirectory($argv[1]);
-    } else {
-        echo "$argv[1] is neither a file nor a directory.\n";
-        exit(1);
-    }
-} else {
-    // Regenerate all stub files we can find.
-    processDirectory('.');
-}
-
 function processDirectory(string $dir) {
     $it = new RecursiveIteratorIterator(
         new RecursiveDirectoryIterator($dir),
@@ -1043,4 +1028,19 @@ function initPhpParser() {
             require $fileName;
         }
     });
+}
+
+if ($argc >= 2) {
+    if (is_file($argv[1])) {
+        // Generate single file.
+        processStubFile($argv[1]);
+    } else if (is_dir($argv[1])) {
+        processDirectory($argv[1]);
+    } else {
+        echo "$argv[1] is neither a file nor a directory.\n";
+        exit(1);
+    }
+} else {
+    // Regenerate all stub files we can find.
+    processDirectory('.');
 }


### PR DESCRIPTION
For whatever reason, php 8 would not have loaded the subsequent classes when
running `php build/gen_stub.php path/to/filename.php`.
I assume it didn't load the classes immediately because there's a possibility
the code before it would throw. (newly added class?)

Also, fix a typo