### PR TITLE
Fixed compilation warnings on big endian system

### DIFF
--- a/ext/intl/collator/collator_is_numeric.c
+++ b/ext/intl/collator/collator_is_numeric.c
@@ -69,7 +69,7 @@ static double collator_u_strtod(const UChar *nptr, UChar **endptr) /* {{{ */
 		char buf[64], *numbuf, *bufpos;
 		size_t length = u - nstart;
 		double value;
-		ALLOCA_FLAG(use_heap);
+		ALLOCA_FLAG(use_heap = 0);
 
 		if (length < sizeof(buf)) {
 			numbuf = buf;


### PR DESCRIPTION
This PR is related to [bug-79431](https://bugs.php.net/bug.php?id=79431)

Following changes were added as `make` command fails on big endian architecture(s390x). These changes work fine for little endian architecture too. More details about the same are mentioned in the [bug-79431](https://bugs.php.net/bug.php?id=79431).