### PR TITLE
Fix #79472: ext/ffi/tests/040.phpt TC fails on Big endian arch

### DIFF
--- a/ext/ffi/tests/040.phpt
+++ b/ext/ffi/tests/040.phpt
@@ -1,7 +1,12 @@
 --TEST--
 FFI 040: Support for scalar types
 --SKIPIF--
-<?php require_once('skipif.inc'); ?>
+<?php
+require_once('skipif.inc');
+if (pack('S', 0xABCD) !== pack('v', 0xABCD)) {
+    die('skip for little-endian architectures only');
+}
+?>
 --INI--
 ffi.enable=1
 --FILE--


### PR DESCRIPTION
For now we are choosing the simplest solution, namely to skip the test
on big-endian architectures.