### PR TITLE
Remove XFAIL from tests for 'bug' 48770

### DIFF
--- a/Zend/tests/bug48770.phpt
+++ b/Zend/tests/bug48770.phpt
@@ -1,53 +1,34 @@
 --TEST--
 Bug #48770 (call_user_func_array() fails to call parent from inheriting class)
---XFAIL--
-See Bug #48770
 --FILE--
 <?php
 
 class A {
-    public function func($str) {
-        var_dump(__METHOD__ .': '. $str);
-    }
-    private function func2($str) {
-        var_dump(__METHOD__ .': '. $str);
-    }
-    protected function func3($str) {
-        var_dump(__METHOD__ .': '. $str);
-    }
-    private function func22($str) {
-        var_dump(__METHOD__ .': '. $str);
+    public function func($arg) {
+        echo "A::func called\n";
     }
 }
 
 class B extends A {
-    public function func($str) {
-        static $avoid_crash = 0;
-
-        if ($avoid_crash++ == 1) {
-            print "This method shouldn't be called when using parent::func!\n";
-            return;
-        }
-
-        call_user_func_array(array($this, 'parent::func'), array($str));
+    public function func($arg) {
+        echo "B::func called\n";
     }
-    private function func2($str) {
-        var_dump(__METHOD__ .': '. $str);
-    }
-    protected function func3($str) {
-        var_dump(__METHOD__ .': '. $str);
+
+    public function callFuncInParent($arg) {
+        call_user_func_array(array($this, 'parent::func'), array($arg));
     }
 }
 
 class C extends B {
-    public function func($str) {
+    public function func($arg) {
+        echo "C::func called\n";
         parent::func($str);
     }
 }
 
 $c = new C;
-$c->func('This should work!');
+$c->callFuncInParent('Which function will be called??');
 
 ?>
 --EXPECT--
-string(26) "A::func: This should work!"
+B::func called

--- a/Zend/tests/bug48770_2.phpt
+++ b/Zend/tests/bug48770_2.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Bug #48770 (call_user_func_array() fails to call parent from inheriting class)
---XFAIL--
-See Bug #48770
 --FILE--
 <?php
 
@@ -56,7 +54,7 @@ $c->func('This should work!');
 
 ?>
 --EXPECT--
-string(27) "A::func2: This should work!"
-string(27) "A::func3: This should work!"
-call_user_func_array(): Argument #1 ($function) must be a valid callback, cannot access private method A::func22()
-call_user_func_array(): Argument #1 ($function) must be a valid callback, class 'A' does not have a method 'inexistent'
+string(27) "B::func2: This should work!"
+string(27) "B::func3: This should work!"
+call_user_func_array(): Argument #1 ($function) must be a valid callback, cannot access private method B::func22()
+call_user_func_array(): Argument #1 ($function) must be a valid callback, class 'B' does not have a method 'inexistent'

--- a/Zend/tests/bug48770_3.phpt
+++ b/Zend/tests/bug48770_3.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Bug #48770 (call_user_func_array() fails to call parent from inheriting class)
---XFAIL--
-See Bug #48770
 --FILE--
 <?php
 
@@ -13,9 +11,6 @@ class A {
         var_dump(__METHOD__ .': '. $str);
     }
     protected function func3($str) {
-        var_dump(__METHOD__ .': '. $str);
-    }
-    private function func22($str) {
         var_dump(__METHOD__ .': '. $str);
     }
 }
@@ -52,4 +47,4 @@ $c->func('This should work!');
 --EXPECT--
 string(27) "B::func2: This should work!"
 string(27) "B::func3: This should work!"
-call_user_func_array(): Argument #1 ($function) must be a valid callback, class 'B' does not have a method 'inexistent'
+call_user_func_array(): Argument #1 ($function) must be a valid callback, class 'C' does not have a method 'inexistent'


### PR DESCRIPTION
Bug 48770 was opened due to conflicting expectations about the behavior of:

    call_user_func_array(array($this, 'parent::methodName'), array($arg1,$arg2))

The one reporting the 'bug' seemed to think that since the method name was prefixed with
`parent::`, it should call the method in the superclass of the *class where this code appears*.
However, `$this` might be an instance of a subclass. If so, then it is quite reasonable that
`call_user_func_array` will call the method as defined in the superclass of *the receiver*.

So the 'bug' is not really a bug. Therefore, there is no need for an XFAIL in the tests. They
should just pass.

Amend tests to reflect the actual expected behavior of `call_user_func_array`, not what the
person who reported bug 48770 thought it should be.

The fact that the PHP interpreter crashes with an error message on the test code is not
really an issue either. The test code is essentially no different from:

    function infinite_loop() {
      infinite_loop();
    }
    infinite_loop();

If anything, perhaps the error message which PHP displays on a stack overflow could be
improved.