### PR TITLE
Add/fix -W-jump-misses-init compiler warnings

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -221,7 +221,7 @@ else
   AC_DEFINE(ZEND_DEBUG,0,[ ])
 fi
 
-test -n "$GCC" && CFLAGS="$CFLAGS -Wall -Wextra -Wno-strict-aliasing -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-sign-compare"
+test -n "$GCC" && CFLAGS="$CFLAGS -Wall -Wextra -Wjump-misses-init -Wno-strict-aliasing -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-sign-compare"
 dnl Check if compiler supports -Wno-clobbered (only GCC)
 AX_CHECK_COMPILE_FLAG([-Wno-clobbered], CFLAGS="$CFLAGS -Wno-clobbered", , [-Werror])
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2378,12 +2378,7 @@ ZEND_VM_C_LABEL(assign_object):
 					}
 					ZEND_VM_C_GOTO(free_and_exit_assign_obj);
 				} else {
-ZEND_VM_C_LABEL(fast_assign_obj):
-					value = zend_assign_to_variable(property_val, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					ZEND_VM_C_GOTO(exit_assign_obj);
+					ZEND_VM_C_GOTO(fast_assign_obj);
 				}
 			}
 		} else {
@@ -2396,7 +2391,12 @@ ZEND_VM_C_LABEL(fast_assign_obj):
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					ZEND_VM_C_GOTO(fast_assign_obj);
+ZEND_VM_C_LABEL(fast_assign_obj):
+					value = zend_assign_to_variable(property_val, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					ZEND_VM_C_GOTO(exit_assign_obj);
 				}
 			}
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -21534,12 +21534,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -21552,7 +21547,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -21679,12 +21679,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -21697,7 +21692,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -21824,12 +21824,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -21842,7 +21837,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -21969,12 +21969,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -21987,7 +21982,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -23804,12 +23804,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -23822,7 +23817,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -23949,12 +23949,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -23967,7 +23962,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -24094,12 +24094,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -24112,7 +24107,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -24239,12 +24239,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -24257,7 +24252,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -27255,12 +27255,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -27273,7 +27268,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -27400,12 +27400,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -27418,7 +27413,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -27545,12 +27545,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -27563,7 +27558,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -27690,12 +27690,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -27708,7 +27703,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -29752,12 +29752,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -29770,7 +29765,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -29897,12 +29897,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -29915,7 +29910,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -30042,12 +30042,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -30060,7 +30055,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -30187,12 +30187,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -30205,7 +30200,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -31619,12 +31619,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -31637,7 +31632,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -31764,12 +31764,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -31782,7 +31777,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -31909,12 +31909,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -31927,7 +31922,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -32054,12 +32054,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -32072,7 +32067,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -34014,12 +34014,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -34032,7 +34027,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -34159,12 +34159,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -34177,7 +34172,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -34304,12 +34304,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -34322,7 +34317,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -34449,12 +34449,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -34467,7 +34462,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -38326,12 +38326,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -38344,7 +38339,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -38471,12 +38471,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -38489,7 +38484,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -38616,12 +38616,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -38634,7 +38629,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -38761,12 +38761,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -38779,7 +38774,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -41803,12 +41803,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -41821,7 +41816,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -41948,12 +41948,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -41966,7 +41961,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -42093,12 +42093,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -42111,7 +42106,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -42238,12 +42238,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -42256,7 +42251,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -46611,12 +46611,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -46629,7 +46624,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CONST, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -46756,12 +46756,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -46774,7 +46769,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -46901,12 +46901,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -46919,7 +46914,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_VAR, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 
@@ -47046,12 +47046,7 @@ assign_object:
 					}
 					goto free_and_exit_assign_obj;
 				} else {
-fast_assign_obj:
-					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
-					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-						ZVAL_COPY(EX_VAR(opline->result.var), value);
-					}
-					goto exit_assign_obj;
+					goto fast_assign_obj;
 				}
 			}
 		} else {
@@ -47064,7 +47059,12 @@ fast_assign_obj:
 				}
 				property_val = zend_hash_find_ex(zobj->properties, Z_STR_P(property), 1);
 				if (property_val) {
-					goto fast_assign_obj;
+fast_assign_obj:
+					value = zend_assign_to_variable(property_val, value, IS_CV, EX_USES_STRICT_TYPES());
+					if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+						ZVAL_COPY(EX_VAR(opline->result.var), value);
+					}
+					goto exit_assign_obj;
 				}
 			}
 

--- a/azure/configure.yml
+++ b/azure/configure.yml
@@ -56,7 +56,6 @@ steps:
         --with-password-argon2 \
         --with-mhash \
         --with-sodium \
-        --enable-werror \
         --with-config-file-path=/etc \
         --with-config-file-scan-dir=/etc/php.d
   displayName: 'Configure Build'

--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -66,7 +66,8 @@ else
   pcre2lib/pcre2_string_utils.c pcre2lib/pcre2_study.c pcre2lib/pcre2_substitute.c  pcre2lib/pcre2_substring.c \
   pcre2lib/pcre2_tables.c pcre2lib/pcre2_ucd.c pcre2lib/pcre2_valid_utf.c pcre2lib/pcre2_xclass.c \
   pcre2lib/pcre2_find_bracket.c pcre2lib/pcre2_convert.c pcre2lib/pcre2_extuni.c pcre2lib/pcre2_script_run.c"
-  PHP_PCRE_CFLAGS="-DHAVE_CONFIG_H -I@ext_srcdir@/pcre2lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  dnl Suppress [-Wjump-misses-init] warnings in bundled PCRE lib.
+  PHP_PCRE_CFLAGS="-Wno-jump-misses-init -DHAVE_CONFIG_H -I@ext_srcdir@/pcre2lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
   PHP_NEW_EXTENSION(pcre, $pcrelib_sources php_pcre.c, no,,$PHP_PCRE_CFLAGS)
   PHP_ADD_BUILD_DIR($ext_builddir/pcre2lib)
   PHP_INSTALL_HEADERS([ext/pcre], [php_pcre.h pcre2lib/])

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -83,7 +83,6 @@ $S390X_CONFIG \
 --with-ffi \
 --with-sodium \
 --enable-zend-test=shared \
---enable-werror \
 --with-pear
 
 make "-j${MAKE_JOBS}" $MAKE_QUIET


### PR DESCRIPTION
Fixing some -W-jump-misses-init (at least for all extensions available on Travis)

There are 2 known limitations:
 - The bundled PCRE emits some of these warnings, and I tried suppressing via autoconf but I've failed apparently
 - Compiling PHP in Debug mode, the definition of the ``should_throw`` variable makes it emit this warning, and when I tried moving it to the block where it is used two calls to ``extract()`` failed due to *apparently* ZPP mismatch, but that's probably due to the change being invalid in the first place...

Another change which may be controversial is moving the logic about the fast assign to object properties around to prevent this warning to be emitted (due to the fact that it's skipping the ``zend_property_info *prop_info = (zend_property_info*) CACHED_PTR_EX(cache_slot + 2);`` declaration).

Moreover, I'm not 100% we should enable the warning as apparently GCC 9 emits some false positives, but I haven't tried this locally yet.