### PR TITLE
Add Attributes based on attributes_v2 RFC.

### DIFF
--- a/Zend/tests/attributes/001_placement.phpt
+++ b/Zend/tests/attributes/001_placement.phpt
@@ -1,0 +1,134 @@
+--TEST--
+Attributes can be placed on all supported elements.
+--FILE--
+<?php
+
+<<A1(1)>>
+class Foo
+{
+    <<A1(2)>>
+    public const FOO = 'foo';
+    
+    <<A1(3)>>
+    public $x;
+    
+    <<A1(4)>>
+    public function foo(<<A1(5)>> $a, <<A1(6)>> $b) { }
+}
+
+$object = new <<A1(7)>> class () { };
+
+<<A1(8)>>
+function f1() { }
+
+$f2 = <<A1(9)>> function () { };
+
+$f3 = <<A1(10)>> fn () => 1;
+
+$ref = new \ReflectionClass(Foo::class);
+
+$sources = [
+    $ref,
+    $ref->getReflectionConstant('FOO'),
+    $ref->getProperty('x'),
+    $ref->getMethod('foo'),
+    $ref->getMethod('foo')->getParameters()[0],
+    $ref->getMethod('foo')->getParameters()[1],
+    new \ReflectionObject($object),
+    new \ReflectionFunction('f1'),
+    new \ReflectionFunction($f2),
+    new \ReflectionFunction($f3)
+];
+
+foreach ($sources as $r) {
+	$attr = $r->getAttributes();
+	var_dump(get_class($r), count($attr));
+	
+    foreach ($attr as $a) {
+        var_dump($a->getName(), $a->getArguments());
+    }
+    
+    echo "\n";
+}
+
+?>
+--EXPECT--
+string(15) "ReflectionClass"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(1)
+}
+
+string(23) "ReflectionClassConstant"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(2)
+}
+
+string(18) "ReflectionProperty"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(3)
+}
+
+string(16) "ReflectionMethod"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(4)
+}
+
+string(19) "ReflectionParameter"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(5)
+}
+
+string(19) "ReflectionParameter"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(6)
+}
+
+string(16) "ReflectionObject"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(7)
+}
+
+string(18) "ReflectionFunction"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(8)
+}
+
+string(18) "ReflectionFunction"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(9)
+}
+
+string(18) "ReflectionFunction"
+int(1)
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(10)
+}

--- a/Zend/tests/attributes/002_rfcexample.phpt
+++ b/Zend/tests/attributes/002_rfcexample.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Attributes: Example from Attributes RFC
+--FILE--
+<?php
+// https://wiki.php.net/rfc/attributes_v2#attribute_syntax
+namespace My\Attributes {
+    use PhpAttribute;
+
+    <<PhpAttribute>>
+    class SingleArgument {
+        public $argumentValue;
+
+        public function __construct($argumentValue) {
+             $this->argumentValue = $argumentValue;
+        }
+    }
+}
+
+namespace {
+    use My\Attributes\SingleArgument;
+
+    <<SingleArgument("Hello World")>>
+    class Foo {
+    }
+
+    $reflectionClass = new \ReflectionClass(Foo::class);
+    $attributes = $reflectionClass->getAttributes();
+
+    var_dump($attributes[0]->getName());
+    var_dump($attributes[0]->getArguments());
+    var_dump($attributes[0]->newInstance());
+}
+?>
+--EXPECTF--
+string(28) "My\Attributes\SingleArgument"
+array(1) {
+  [0]=>
+  string(11) "Hello World"
+}
+object(My\Attributes\SingleArgument)#3 (1) {
+  ["argumentValue"]=>
+  string(11) "Hello World"
+}

--- a/Zend/tests/attributes/003_ast_nodes.phpt
+++ b/Zend/tests/attributes/003_ast_nodes.phpt
@@ -1,0 +1,109 @@
+--TEST--
+Attributes can deal with AST nodes.
+--FILE--
+<?php
+
+define('V1', strtoupper(php_sapi_name()));
+
+<<A1([V1 => V1])>>
+class C1
+{
+	public const BAR = 'bar';
+}
+
+$ref = new \ReflectionClass(C1::class);
+$attr = $ref->getAttributes();
+var_dump(count($attr));
+
+$args = $attr[0]->getArguments();
+var_dump(count($args), $args[0][V1] === V1);
+
+echo "\n";
+
+<<A1(V1, 1 + 2, C1::class)>>
+class C2 { }
+
+$ref = new \ReflectionClass(C2::class);
+$attr = $ref->getAttributes();
+var_dump(count($attr));
+
+$args = $attr[0]->getArguments();
+var_dump(count($args));
+var_dump($args[0] === V1);
+var_dump($args[1] === 3);
+var_dump($args[2] === C1::class);
+
+echo "\n";
+
+<<A1(self::FOO, C1::BAR)>>
+class C3
+{
+	private const FOO = 'foo';
+}
+
+$ref = new \ReflectionClass(C3::class);
+$attr = $ref->getAttributes();
+var_dump(count($attr));
+
+$args = $attr[0]->getArguments();
+var_dump(count($args));
+var_dump($args[0] === 'foo');
+var_dump($args[1] === C1::BAR);
+
+echo "\n";
+
+<<ExampleWithShift(4 >> 1)>>
+class C4 {}
+$ref = new \ReflectionClass(C4::class);
+var_dump($ref->getAttributes()[0]->getArguments());
+
+echo "\n";
+
+<<PhpAttribute>>
+class C5
+{
+	public function __construct() { }
+}
+
+$ref = new \ReflectionFunction(<<C5(MissingClass::SOME_CONST)>> function () { });
+$attr = $ref->getAttributes();
+var_dump(count($attr));
+
+try {
+	$attr[0]->getArguments();
+} catch (\Error $e) {
+	var_dump($e->getMessage());
+}
+
+try {
+	$attr[0]->newInstance();
+} catch (\Error $e) {
+	var_dump($e->getMessage());
+}
+
+?>
+--EXPECT--
+int(1)
+int(1)
+bool(true)
+
+int(1)
+int(3)
+bool(true)
+bool(true)
+bool(true)
+
+int(1)
+int(2)
+bool(true)
+bool(true)
+
+array(1) {
+  [0]=>
+  int(2)
+}
+
+int(1)
+string(30) "Class 'MissingClass' not found"
+string(30) "Class 'MissingClass' not found"
+

--- a/Zend/tests/attributes/004_name_resolution.phpt
+++ b/Zend/tests/attributes/004_name_resolution.phpt
@@ -15,14 +15,21 @@ namespace Doctrine\ORM\Mapping {
     }
 }
 
+namespace Doctrine\ORM\Attributes {
+    class Table {
+    }
+}
+
 namespace Foo {
     use Doctrine\ORM\Mapping\Entity;
     use Doctrine\ORM\Mapping as ORM;
+    use Doctrine\ORM\Attributes;
 
     <<Entity("imported class")>>
     <<ORM\Entity("imported namespace")>>
     <<\Doctrine\ORM\Mapping\Entity("absolute from namespace")>>
     <<\Entity("import absolute from global")>>
+    <<Attributes\Table()>>
     function foo() {
     }
 }
@@ -34,7 +41,7 @@ namespace {
 }
 ?>
 --EXPECTF--
-array(4) {
+array(5) {
   [0]=>
   array(2) {
     ["name"]=>
@@ -73,6 +80,14 @@ array(4) {
     array(1) {
       [0]=>
       string(27) "import absolute from global"
+    }
+  }
+  [4]=>
+  array(2) {
+    ["name"]=>
+    string(29) "Doctrine\ORM\Attributes\Table"
+    ["args"]=>
+    array(0) {
     }
   }
 }

--- a/Zend/tests/attributes/004_name_resolution.phpt
+++ b/Zend/tests/attributes/004_name_resolution.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Resolve attribute names
+--FILE--
+<?php
+function dump_attributes($attributes) {
+    $arr = [];
+    foreach ($attributes as $attribute) {
+        $arr[] = ['name' => $attribute->getName(), 'args' => $attribute->getArguments()];
+    }
+    var_dump($arr);
+}
+
+namespace Doctrine\ORM\Mapping {
+    class Entity {
+    }
+}
+
+namespace Foo {
+    use Doctrine\ORM\Mapping\Entity;
+    use Doctrine\ORM\Mapping as ORM;
+
+    <<Entity("imported class")>>
+    <<ORM\Entity("imported namespace")>>
+    <<\Doctrine\ORM\Mapping\Entity("absolute from namespace")>>
+    <<\Entity("import absolute from global")>>
+    function foo() {
+    }
+}
+
+namespace {
+    class Entity {}
+
+    dump_attributes((new ReflectionFunction('Foo\foo'))->getAttributes());
+}
+?>
+--EXPECTF--
+array(4) {
+  [0]=>
+  array(2) {
+    ["name"]=>
+    string(27) "Doctrine\ORM\Mapping\Entity"
+    ["args"]=>
+    array(1) {
+      [0]=>
+      string(14) "imported class"
+    }
+  }
+  [1]=>
+  array(2) {
+    ["name"]=>
+    string(27) "Doctrine\ORM\Mapping\Entity"
+    ["args"]=>
+    array(1) {
+      [0]=>
+      string(18) "imported namespace"
+    }
+  }
+  [2]=>
+  array(2) {
+    ["name"]=>
+    string(27) "Doctrine\ORM\Mapping\Entity"
+    ["args"]=>
+    array(1) {
+      [0]=>
+      string(23) "absolute from namespace"
+    }
+  }
+  [3]=>
+  array(2) {
+    ["name"]=>
+    string(6) "Entity"
+    ["args"]=>
+    array(1) {
+      [0]=>
+      string(27) "import absolute from global"
+    }
+  }
+}

--- a/Zend/tests/attributes/005_objects.phpt
+++ b/Zend/tests/attributes/005_objects.phpt
@@ -1,0 +1,120 @@
+--TEST--
+Attributes can be converted into objects.
+--FILE--
+<?php
+
+<<PhpAttribute>>
+class A1
+{
+	public string $name;
+	public int $ttl;
+
+	public function __construct(string $name, int $ttl = 50)
+	{
+		$this->name = $name;
+		$this->ttl = $ttl;
+	}
+}
+
+$ref = new \ReflectionFunction(<<A1('test')>> function () { });
+
+foreach ($ref->getAttributes() as $attr) {
+	$obj = $attr->newInstance();
+
+	var_dump(get_class($obj), $obj->name, $obj->ttl);
+}
+
+echo "\n";
+
+$ref = new \ReflectionFunction(<<A1>> function () { });
+
+try {
+	$ref->getAttributes()[0]->newInstance();
+} catch (\ArgumentCountError $e) {
+	var_dump('ERROR 1', $e->getMessage());
+}
+
+echo "\n";
+
+$ref = new \ReflectionFunction(<<A1([])>> function () { });
+
+try {
+	$ref->getAttributes()[0]->newInstance();
+} catch (\TypeError $e) {
+	var_dump('ERROR 2', $e->getMessage());
+}
+
+echo "\n";
+
+$ref = new \ReflectionFunction(<<A2>> function () { });
+
+try {
+	$ref->getAttributes()[0]->newInstance();
+} catch (\Error $e) {
+	var_dump('ERROR 3', $e->getMessage());
+}
+
+echo "\n";
+
+<<PhpAttribute>>
+class A3
+{
+	private function __construct() { }
+}
+
+$ref = new \ReflectionFunction(<<A3>> function () { });
+
+try {
+	$ref->getAttributes()[0]->newInstance();
+} catch (\Error $e) {
+	var_dump('ERROR 4', $e->getMessage());
+}
+
+echo "\n";
+
+<<PhpAttribute>>
+class A4 { }
+
+$ref = new \ReflectionFunction(<<A4(1)>> function () { });
+
+try {
+	$ref->getAttributes()[0]->newInstance();
+} catch (\Error $e) {
+	var_dump('ERROR 5', $e->getMessage());
+}
+
+echo "\n";
+
+class A5 { }
+
+$ref = new \ReflectionFunction(<<A5>> function () { });
+
+try {
+	$ref->getAttributes()[0]->newInstance();
+} catch (\Error $e) {
+	var_dump('ERROR 6', $e->getMessage());
+}
+
+?>
+--EXPECT--
+string(2) "A1"
+string(4) "test"
+int(50)
+
+string(7) "ERROR 1"
+string(81) "Too few arguments to function A1::__construct(), 0 passed and at least 1 expected"
+
+string(7) "ERROR 2"
+string(74) "A1::__construct(): Argument #1 ($name) must be of type string, array given"
+
+string(7) "ERROR 3"
+string(30) "Attribute class 'A2' not found"
+
+string(7) "ERROR 4"
+string(50) "Attribute constructor of class 'A3' must be public"
+
+string(7) "ERROR 5"
+string(71) "Attribute class 'A4' does not have a constructor, cannot pass arguments"
+
+string(7) "ERROR 6"
+string(78) "Attempting to use class 'A5' as attribute that does not have <<PhpAttribute>>."

--- a/Zend/tests/attributes/006_filter.phpt
+++ b/Zend/tests/attributes/006_filter.phpt
@@ -1,0 +1,112 @@
+--TEST--
+Attributes can be filtered by name and base type.
+--FILE--
+<?php
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> function () { });
+$attr = $ref->getAttributes(A3::class);
+
+var_dump(count($attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> function () { });
+$attr = $ref->getAttributes(A2::class);
+
+var_dump(count($attr), $attr[0]->getName());
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> <<A2>> function () { });
+$attr = $ref->getAttributes(A2::class);
+
+var_dump(count($attr), $attr[0]->getName(), $attr[1]->getName());
+
+echo "\n";
+
+interface Base { }
+class A1 implements Base { }
+class A2 implements Base { }
+class A3 extends A2 { }
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> <<A5>> function () { });
+$attr = $ref->getAttributes(\stdClass::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> function () { });
+$attr = $ref->getAttributes(A1::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> function () { });
+$attr = $ref->getAttributes(Base::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> <<A3>> function () { });
+$attr = $ref->getAttributes(A2::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> <<A3>> function () { });
+$attr = $ref->getAttributes(Base::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+echo "\n";
+
+$ref = new \ReflectionFunction(function () { });
+
+try {
+	$ref->getAttributes(A1::class, 3);
+} catch (\Error $e) {
+	var_dump('ERROR 1', $e->getMessage());
+}
+
+$ref = new \ReflectionFunction(function () { });
+
+try {
+	$ref->getAttributes(SomeMissingClass::class, \ReflectionAttribute::IS_INSTANCEOF);
+} catch (\Error $e) {
+	var_dump('ERROR 2', $e->getMessage());
+}
+
+?>
+--EXPECT--
+int(0)
+int(1)
+string(2) "A2"
+int(2)
+string(2) "A2"
+string(2) "A2"
+
+int(0)
+Array
+(
+)
+int(1)
+Array
+(
+    [0] => A1
+)
+int(2)
+Array
+(
+    [0] => A1
+    [1] => A2
+)
+int(2)
+Array
+(
+    [0] => A2
+    [1] => A3
+)
+int(3)
+Array
+(
+    [0] => A1
+    [1] => A2
+    [2] => A3
+)
+
+string(7) "ERROR 1"
+string(39) "Invalid attribute filter flag specified"
+string(7) "ERROR 2"
+string(34) "Class 'SomeMissingClass' not found"

--- a/Zend/tests/attributes/006_filter.phpt
+++ b/Zend/tests/attributes/006_filter.phpt
@@ -107,6 +107,6 @@ Array
 )
 
 string(7) "ERROR 1"
-string(39) "Invalid attribute filter flag specified"
+string(103) "ReflectionFunctionAbstract::getAttributes(): Argument #2 ($flags) must be a valid attribute filter flag"
 string(7) "ERROR 2"
 string(34) "Class 'SomeMissingClass' not found"

--- a/Zend/tests/attributes/007_self_reflect_attribute.phpt
+++ b/Zend/tests/attributes/007_self_reflect_attribute.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Attributes: attributes on PhpAttribute return itself
+--FILE--
+<?php
+
+$reflection = new \ReflectionClass(PhpAttribute::class);
+$attributes = $reflection->getAttributes();
+
+foreach ($attributes as $attribute) {
+    var_dump($attribute->getName());
+    var_dump($attribute->getArguments());
+    var_dump($attribute->newInstance());
+}
+--EXPECTF--
+string(12) "PhpAttribute"
+array(0) {
+}
+object(PhpAttribute)#3 (0) {
+}

--- a/Zend/tests/attributes/008_wrong_attribution.phpt
+++ b/Zend/tests/attributes/008_wrong_attribution.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Attributes: Prevent PhpAttribute on non classes
+--FILE--
+<?php
+
+<<PhpAttribute>>
+function foo() {}
+--EXPECTF--
+Fatal error: Only classes can be marked with <<PhpAttribute>> in %s

--- a/Zend/tests/attributes/009_doctrine_annotations_example.phpt
+++ b/Zend/tests/attributes/009_doctrine_annotations_example.phpt
@@ -1,0 +1,159 @@
+--TEST--
+Doctrine-like attributes usage
+--FILE--
+<?php
+
+namespace Doctrine\ORM\Attributes {
+    class Annotation { public $values; public function construct() { $this->values = func_get_args(); } }
+    class Entity extends Annotation {}
+    class Id extends Annotation {}
+    class Column extends Annotation { const UNIQUE = 'unique'; const T_INTEGER = 'integer'; }
+    class GeneratedValue extends Annotation {}
+    class JoinTable extends Annotation {}
+    class ManyToMany extends Annotation {}
+    class JoinColumn extends Annotation { const UNIQUE = 'unique'; }
+    class InverseJoinColumn extends Annotation {}
+}
+
+namespace Symfony\Component\Validator\Constraints {
+    class Annotation { public $values; public function construct() { $this->values = func_get_args(); } }
+    class Email extends Annotation {}
+    class Range extends Annotation {}
+}
+
+namespace {
+use Doctrine\ORM\Attributes as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+<<ORM\Entity>>
+/** @ORM\Entity */
+class User
+{
+    /** @ORM\Id @ORM\Column(type="integer"*) @ORM\GeneratedValue */
+    <<ORM\Id>><<ORM\Column("integer")>><<ORM\GeneratedValue>>
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", unique=true)
+     * @Assert\Email(message="The email '{{ value }}' is not a valid email.")
+     */
+    <<ORM\Column("string", ORM\Column::UNIQUE)>>
+    <<Assert\Email(array("message" => "The email '{{ value }}' is not a valid email."))>>
+    private $email;
+
+    /**
+     * @ORM\Column(type="integer")
+     * @Assert\Range(
+     *      min = 120,
+     *      max = 180,
+     *      minMessage = "You must be at least {{ limit }}cm tall to enter",
+     *      maxMessage = "You cannot be taller than {{ limit }}cm to enter"
+     * )
+     */
+    <<Assert\Range(["min" => 120, "max" => 180, "minMessage" => "You must be at least {{ limit }}cm tall to enter"])>>
+    <<ORM\Column(ORM\Column::T_INTEGER)>>
+    protected $height;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Phonenumber")
+     * @ORM\JoinTable(name="users_phonenumbers",
+     *      joinColumns={@ORM\JoinColumn(name="user_id", referencedColumnName="id")},
+     *      inverseJoinColumns={@ORM\JoinColumn(name="phonenumber_id", referencedColumnName="id", unique=true)}
+     *      )
+     */
+    <<ORM\ManyToMany(Phonenumber::class)>>
+    <<ORM\JoinTable("users_phonenumbers")>>
+    <<ORM\JoinColumn("user_id", "id")>>
+    <<ORM\InverseJoinColumn("phonenumber_id", "id", ORM\JoinColumn::UNIQUE)>>
+    private $phonenumbers;
+}
+
+$class = new ReflectionClass(User::class);
+$attributes = $class->getAttributes();
+
+foreach ($attributes as $attribute) {
+    var_dump($attribute->getName(), $attribute->getArguments());
+}
+
+foreach ($class->getProperties() as $property) {
+    $attributes = $property->getAttributes();
+
+    foreach ($attributes as $attribute) {
+        var_dump($attribute->getName(), $attribute->getArguments());
+    }
+}
+}
+?>
+--EXPECT--
+string(30) "Doctrine\ORM\Attributes\Entity"
+array(0) {
+}
+string(26) "Doctrine\ORM\Attributes\Id"
+array(0) {
+}
+string(30) "Doctrine\ORM\Attributes\Column"
+array(1) {
+  [0]=>
+  string(7) "integer"
+}
+string(38) "Doctrine\ORM\Attributes\GeneratedValue"
+array(0) {
+}
+string(30) "Doctrine\ORM\Attributes\Column"
+array(2) {
+  [0]=>
+  string(6) "string"
+  [1]=>
+  string(6) "unique"
+}
+string(45) "Symfony\Component\Validator\Constraints\Email"
+array(1) {
+  [0]=>
+  array(1) {
+    ["message"]=>
+    string(45) "The email '{{ value }}' is not a valid email."
+  }
+}
+string(45) "Symfony\Component\Validator\Constraints\Range"
+array(1) {
+  [0]=>
+  array(3) {
+    ["min"]=>
+    int(120)
+    ["max"]=>
+    int(180)
+    ["minMessage"]=>
+    string(48) "You must be at least {{ limit }}cm tall to enter"
+  }
+}
+string(30) "Doctrine\ORM\Attributes\Column"
+array(1) {
+  [0]=>
+  string(7) "integer"
+}
+string(34) "Doctrine\ORM\Attributes\ManyToMany"
+array(1) {
+  [0]=>
+  string(11) "Phonenumber"
+}
+string(33) "Doctrine\ORM\Attributes\JoinTable"
+array(1) {
+  [0]=>
+  string(18) "users_phonenumbers"
+}
+string(34) "Doctrine\ORM\Attributes\JoinColumn"
+array(2) {
+  [0]=>
+  string(7) "user_id"
+  [1]=>
+  string(2) "id"
+}
+string(41) "Doctrine\ORM\Attributes\InverseJoinColumn"
+array(3) {
+  [0]=>
+  string(14) "phonenumber_id"
+  [1]=>
+  string(2) "id"
+  [2]=>
+  string(6) "unique"
+}

--- a/Zend/tests/attributes/010_unsupported_const_expression.phpt
+++ b/Zend/tests/attributes/010_unsupported_const_expression.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Attribute arguments support only const expressions.
+--FILE--
+<?php
+
+<<A1(foo())>>
+class C1 { }
+
+?>
+--EXPECTF--
+Fatal error: Constant expression contains invalid operations in %s

--- a/Zend/tests/attributes/011-inheritance.phpt
+++ b/Zend/tests/attributes/011-inheritance.phpt
@@ -1,0 +1,99 @@
+--TEST--
+Attributes comply with inheritance rules.
+--FILE--
+<?php
+
+<<A2>>
+class C1
+{
+	<<A1>>
+	public function foo() { }
+}
+
+class C2 extends C1
+{
+	public function foo() { }
+}
+
+class C3 extends C1
+{
+	<<A1>>
+	public function bar() { }
+}
+
+$ref = new \ReflectionClass(C1::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getAttributes()));
+print_r(array_map(fn ($a) => $a->getName(), $ref->getMethod('foo')->getAttributes()));
+
+$ref = new \ReflectionClass(C2::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getAttributes()));
+print_r(array_map(fn ($a) => $a->getName(), $ref->getMethod('foo')->getAttributes()));
+
+$ref = new \ReflectionClass(C3::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getAttributes()));
+print_r(array_map(fn ($a) => $a->getName(), $ref->getMethod('foo')->getAttributes()));
+
+echo "\n";
+
+trait T1
+{
+	<<A2>>
+	public $a;
+}
+
+class C4
+{
+	use T1;
+}
+
+class C5
+{
+	use T1;
+	
+	public $a;
+}
+
+$ref = new \ReflectionClass(T1::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getProperty('a')->getAttributes()));
+
+$ref = new \ReflectionClass(C4::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getProperty('a')->getAttributes()));
+
+$ref = new \ReflectionClass(C5::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getProperty('a')->getAttributes()));
+
+?>
+--EXPECT--
+Array
+(
+    [0] => A2
+)
+Array
+(
+    [0] => A1
+)
+Array
+(
+)
+Array
+(
+)
+Array
+(
+)
+Array
+(
+    [0] => A1
+)
+
+Array
+(
+    [0] => A2
+)
+Array
+(
+    [0] => A2
+)
+Array
+(
+)

--- a/Zend/tests/attributes/012-ast-export.phpt
+++ b/Zend/tests/attributes/012-ast-export.phpt
@@ -21,13 +21,10 @@ assert(0 && ($a = function () {
 
 ?>
 --EXPECTF--
-Warning: assert(): assert(0 && ($a = <<A1>>
-<<A2>>
-function ($a, <<A3(1)>> $b) {
+Warning: assert(): assert(0 && ($a = <<A1>> <<A2>> function ($a, <<A3(1)>> $b) {
 })) failed in %s on line %d
 
-Warning: assert(): assert(0 && ($a = <<A1(1, 2, 1 + 2)>>
-fn() => 1)) failed in %s on line %d
+Warning: assert(): assert(0 && ($a = <<A1(1, 2, 1 + 2)>> fn() => 1)) failed in %s on line %d
 
 Warning: assert(): assert(0 && ($a = new <<A1>> class {
     <<A1>>
@@ -35,7 +32,8 @@ Warning: assert(): assert(0 && ($a = new <<A1>> class {
     const FOO = 'foo';
     <<A2>>
     public $x;
-    <<A3>> public function a() {
+    <<A3>>
+    public function a() {
     }
 
 })) failed in %s on line %d

--- a/Zend/tests/attributes/012-ast-export.phpt
+++ b/Zend/tests/attributes/012-ast-export.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Attributes AST can be exported.
+--FILE--
+<?php
+
+assert(0 && ($a = <<A1>><<A2>> function ($a, <<A3(1)>> $b) { }));
+
+assert(0 && ($a = <<A1(1, 2, 1 + 2)>> fn () => 1));
+
+assert(0 && ($a = new <<A1>> class() {
+	<<A1>><<A2>> const FOO = 'foo';
+	<<A2>> public $x;
+	<<A3>> function a() { }
+}));
+
+assert(0 && ($a = function () {
+	<<A1>> class Test1 { }
+	<<A2>> interface Test2 { }
+	<<A3>> trait Test3 { }
+}));
+
+?>
+--EXPECTF--
+Warning: assert(): assert(0 && ($a = <<A1>> <<A2>> function ($a, <<A3(1)>> $b) {
+})) failed in %s on line %d
+
+Warning: assert(): assert(0 && ($a = <<A1(1, 2, 1 + 2)>> fn() => 1)) failed in %s on line %d
+
+Warning: assert(): assert(0 && ($a = new <<A1>> class {
+    <<A1>>
+    <<A2>>
+    const FOO = 'foo';
+    <<A2>>
+    public $x;
+    <<A3>>
+    public function a() {
+    }
+
+})) failed in %s on line %d
+
+Warning: assert(): assert(0 && ($a = function () {
+    <<A1>>
+    class Test1 {
+    }
+
+    <<A2>>
+    interface Test2 {
+    }
+
+    <<A3>>
+    trait Test3 {
+    }
+
+})) failed in %s on line %d

--- a/Zend/tests/attributes/012-ast-export.phpt
+++ b/Zend/tests/attributes/012-ast-export.phpt
@@ -21,10 +21,13 @@ assert(0 && ($a = function () {
 
 ?>
 --EXPECTF--
-Warning: assert(): assert(0 && ($a = <<A1>> <<A2>> function ($a, <<A3(1)>> $b) {
+Warning: assert(): assert(0 && ($a = <<A1>>
+<<A2>>
+function ($a, <<A3(1)>> $b) {
 })) failed in %s on line %d
 
-Warning: assert(): assert(0 && ($a = <<A1(1, 2, 1 + 2)>> fn() => 1)) failed in %s on line %d
+Warning: assert(): assert(0 && ($a = <<A1(1, 2, 1 + 2)>>
+fn() => 1)) failed in %s on line %d
 
 Warning: assert(): assert(0 && ($a = new <<A1>> class {
     <<A1>>
@@ -32,8 +35,7 @@ Warning: assert(): assert(0 && ($a = new <<A1>> class {
     const FOO = 'foo';
     <<A2>>
     public $x;
-    <<A3>>
-    public function a() {
+    <<A3>> public function a() {
     }
 
 })) failed in %s on line %d

--- a/Zend/tests/attributes/013_class_scope.phpt
+++ b/Zend/tests/attributes/013_class_scope.phpt
@@ -40,6 +40,16 @@ class C2
 
 $ref = new \ReflectionClass(C2::class);
 print_r($ref->getMethod('foo')->getAttributes()[0]->getArguments());
+
+$ref = new \ReflectionClass(T1::class);
+$attr = $ref->getMethod('foo')->getAttributes()[0];
+
+try {
+	$attr->getArguments();
+} catch (\Error $e) {
+    var_dump('ERROR 1', $e->getMessage());
+}
+
 echo "\n";
 
 class C3
@@ -98,6 +108,8 @@ Array
     [0] => C2
     [1] => bar
 )
+string(7) "ERROR 1"
+string(36) "Undefined class constant 'self::FOO'"
 
 bool(true)
 string(3) "bar"

--- a/Zend/tests/attributes/013_class_scope.phpt
+++ b/Zend/tests/attributes/013_class_scope.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Attributes make use of correct scope.
+Attributes make use of class scope.
 --FILE--
 <?php
 
@@ -25,20 +25,21 @@ print_r($ref->getMethod('bar')->getParameters()[0]->getAttributes()[0]->getArgum
 
 echo "\n";
 
-class C2
+trait T1
 {
-	private const FOO = 'foo';
-
-	public static function foo()
-	{
-		return <<A1(self::class, self::FOO)>> function (<<A1(self::class, self::FOO)>> $p) { };
-	}
+	<<A1(self::class, self::FOO)>>
+	public function foo() { }
 }
 
-$ref = new \ReflectionFunction(C2::foo());
-print_r($ref->getAttributes()[0]->getArguments());
-print_r($ref->getParameters()[0]->getAttributes()[0]->getArguments());
+class C2
+{
+	use T1;
+	
+	private const FOO = 'bar';
+}
 
+$ref = new \ReflectionClass(C2::class);
+print_r($ref->getMethod('foo')->getAttributes()[0]->getArguments());
 echo "\n";
 
 class C3
@@ -56,13 +57,13 @@ class C3
 	}
 }
 
-$obj = C3::foo();
-$ref = new \ReflectionObject($obj);
-$name = $ref->getMethod('bar')->getAttributes()[0]->getArguments()[0];
+$ref = new \ReflectionObject(C3::foo());
 
-print_r($ref->getAttributes()[0]->getArguments());
-var_dump($name == get_class($obj));
-var_dump($ref->getMethod('bar')->getAttributes()[0]->getArguments()[1]);
+$args = $ref->getAttributes()[0]->getArguments();
+var_dump($args[0] == $ref->getName(), $args[1]);
+
+$args = $ref->getMethod('bar')->getAttributes()[0]->getArguments();
+var_dump($args[0] == $ref->getName(), $args[1]);
 
 ?>
 --EXPECT--
@@ -95,18 +96,10 @@ Array
 Array
 (
     [0] => C2
-    [1] => foo
-)
-Array
-(
-    [0] => C2
-    [1] => foo
+    [1] => bar
 )
 
-Array
-(
-    [0] => C3
-    [1] => foo
-)
+bool(true)
+string(3) "bar"
 bool(true)
 string(3) "bar"

--- a/Zend/tests/attributes/013_scope_resolution.phpt
+++ b/Zend/tests/attributes/013_scope_resolution.phpt
@@ -8,10 +8,10 @@ class C1
 {
 	<<A1(self::class, self::FOO)>>
 	private const FOO = 'foo';
-	
+
 	<<A1(self::class, self::FOO)>>
 	public $a;
-	
+
 	<<A1(self::class, self::FOO)>>
 	public function bar(<<A1(self::class, self::FOO)>> $p) { }
 }
@@ -28,7 +28,7 @@ echo "\n";
 class C2
 {
 	private const FOO = 'foo';
-	
+
 	public static function foo()
 	{
 		return <<A1(self::class, self::FOO)>> function (<<A1(self::class, self::FOO)>> $p) { };
@@ -44,12 +44,12 @@ echo "\n";
 class C3
 {
 	private const FOO = 'foo';
-	
+
 	public static function foo()
 	{
 		return new <<A1(self::class, self::FOO)>> class() {
 			private const FOO = 'bar';
-			
+
 			<<A1(self::class, self::FOO)>>
 			public function bar() { }
 		};

--- a/Zend/tests/attributes/013_scope_resolution.phpt
+++ b/Zend/tests/attributes/013_scope_resolution.phpt
@@ -1,0 +1,112 @@
+--TEST--
+Attributes make use of correct scope.
+--FILE--
+<?php
+
+<<A1(self::class, self::FOO)>>
+class C1
+{
+	<<A1(self::class, self::FOO)>>
+	private const FOO = 'foo';
+	
+	<<A1(self::class, self::FOO)>>
+	public $a;
+	
+	<<A1(self::class, self::FOO)>>
+	public function bar(<<A1(self::class, self::FOO)>> $p) { }
+}
+
+$ref = new \ReflectionClass(C1::class);
+print_r($ref->getAttributes()[0]->getArguments());
+print_r($ref->getReflectionConstant('FOO')->getAttributes()[0]->getArguments());
+print_r($ref->getProperty('a')->getAttributes()[0]->getArguments());
+print_r($ref->getMethod('bar')->getAttributes()[0]->getArguments());
+print_r($ref->getMethod('bar')->getParameters()[0]->getAttributes()[0]->getArguments());
+
+echo "\n";
+
+class C2
+{
+	private const FOO = 'foo';
+	
+	public static function foo()
+	{
+		return <<A1(self::class, self::FOO)>> function (<<A1(self::class, self::FOO)>> $p) { };
+	}
+}
+
+$ref = new \ReflectionFunction(C2::foo());
+print_r($ref->getAttributes()[0]->getArguments());
+print_r($ref->getParameters()[0]->getAttributes()[0]->getArguments());
+
+echo "\n";
+
+class C3
+{
+	private const FOO = 'foo';
+	
+	public static function foo()
+	{
+		return new <<A1(self::class, self::FOO)>> class() {
+			private const FOO = 'bar';
+			
+			<<A1(self::class, self::FOO)>>
+			public function bar() { }
+		};
+	}
+}
+
+$obj = C3::foo();
+$ref = new \ReflectionObject($obj);
+$name = $ref->getMethod('bar')->getAttributes()[0]->getArguments()[0];
+
+print_r($ref->getAttributes()[0]->getArguments());
+var_dump($name == get_class($obj));
+var_dump($ref->getMethod('bar')->getAttributes()[0]->getArguments()[1]);
+
+?>
+--EXPECT--
+Array
+(
+    [0] => C1
+    [1] => foo
+)
+Array
+(
+    [0] => C1
+    [1] => foo
+)
+Array
+(
+    [0] => C1
+    [1] => foo
+)
+Array
+(
+    [0] => C1
+    [1] => foo
+)
+Array
+(
+    [0] => C1
+    [1] => foo
+)
+
+Array
+(
+    [0] => C2
+    [1] => foo
+)
+Array
+(
+    [0] => C2
+    [1] => foo
+)
+
+Array
+(
+    [0] => C3
+    [1] => foo
+)
+bool(true)
+string(3) "bar"

--- a/Zend/tests/attributes/014_class_const_group.phpt
+++ b/Zend/tests/attributes/014_class_const_group.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Attributes cannot be applied to groups of class constants.
+--FILE--
+<?php
+
+class C1
+{
+	<<A1>>
+	public const A = 1, B = 2;
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot apply attributes to a group of constants in %s

--- a/Zend/tests/attributes/015_property_group.phpt
+++ b/Zend/tests/attributes/015_property_group.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Attributes cannot be applied to groups of properties.
+--FILE--
+<?php
+
+class C1
+{
+	<<A1>>
+	public $x, $y;
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot apply attributes to a group of properties in %s

--- a/Zend/tests/attributes/016_target_resolution_compiler_attributes.phpt
+++ b/Zend/tests/attributes/016_target_resolution_compiler_attributes.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Attributes: Compiler Attributes can check for target declarations
+--SKIPIF--
+<?php
+if (!extension_loaded('zend-test')) {
+    echo "skip requires zend-test extension\n";
+}
+--FILE--
+<?php
+
+<<ZendTestAttribute>>
+function foo() {
+}
+--EXPECTF--
+Fatal error: Only classes can be marked with <<ZendTestAttribute>> in %s

--- a/Zend/tests/attributes/017_closure_scope.phpt
+++ b/Zend/tests/attributes/017_closure_scope.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Attributes make use of closure scope.
+--FILE--
+<?php
+
+class Test1
+{
+	private const FOO = 'bar';
+}
+
+class C1
+{
+	private const FOO = 'foo';
+
+	public static function foo()
+	{
+		return <<A1(self::class, self::FOO)>> function (<<A1(self::class, self::FOO)>> $p) { };
+	}
+}
+
+$ref = new \ReflectionFunction(C1::foo());
+print_r($ref->getAttributes()[0]->getArguments());
+print_r($ref->getParameters()[0]->getAttributes()[0]->getArguments());
+
+echo "\n";
+
+$ref = new \ReflectionFunction(C1::foo()->bindTo(null, Test1::class));
+print_r($ref->getAttributes()[0]->getArguments());
+print_r($ref->getParameters()[0]->getAttributes()[0]->getArguments());
+
+?>
+--EXPECT--
+Array
+(
+    [0] => C1
+    [1] => foo
+)
+Array
+(
+    [0] => C1
+    [1] => foo
+)
+
+Array
+(
+    [0] => Test1
+    [1] => bar
+)
+Array
+(
+    [0] => Test1
+    [1] => bar
+)

--- a/Zend/tests/varSyntax/globalNonSimpleVariableError.phpt
+++ b/Zend/tests/varSyntax/globalNonSimpleVariableError.phpt
@@ -7,4 +7,4 @@ global $$foo->bar;
 
 ?>
 --EXPECTF--
-Parse error: syntax error, unexpected '->' (T_OBJECT_OPERATOR), expecting ';' or ',' in %s on line %d
+Parse error: syntax error, unexpected '->' (T_OBJECT_OPERATOR), expecting ',' or ';' in %s on line %d

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -170,6 +170,7 @@ struct _zend_class_entry {
 	zend_class_name *trait_names;
 	zend_trait_alias **trait_aliases;
 	zend_trait_precedence **trait_precedences;
+	HashTable *attributes;
 
 	union {
 		struct {

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2596,7 +2596,6 @@ static zend_class_entry *do_register_internal_class(zend_class_entry *orig_class
 	zend_initialize_class_data(class_entry, 0);
 	class_entry->ce_flags = ce_flags | ZEND_ACC_CONSTANTS_UPDATED | ZEND_ACC_LINKED | ZEND_ACC_RESOLVED_PARENT | ZEND_ACC_RESOLVED_INTERFACES;
 	class_entry->info.internal.module = EG(current_module);
-	class_entry->attributes = NULL;
 
 	if (class_entry->info.internal.builtin_functions) {
 		zend_register_functions(class_entry, class_entry->info.internal.builtin_functions, &class_entry->function_table, EG(current_module)->type);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -351,9 +351,9 @@ ZEND_API zend_bool zend_make_callable(zval *callable, zend_string **callable_nam
 ZEND_API const char *zend_get_module_version(const char *module_name);
 ZEND_API int zend_get_module_started(const char *module_name);
 
-ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type);
+ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes, zend_type type);
 
-ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment);
+ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes);
 ZEND_API int zend_declare_property(zend_class_entry *ce, const char *name, size_t name_length, zval *property, int access_type);
 ZEND_API int zend_declare_property_null(zend_class_entry *ce, const char *name, size_t name_length, int access_type);
 ZEND_API int zend_declare_property_bool(zend_class_entry *ce, const char *name, size_t name_length, zend_long value, int access_type);
@@ -362,7 +362,7 @@ ZEND_API int zend_declare_property_double(zend_class_entry *ce, const char *name
 ZEND_API int zend_declare_property_string(zend_class_entry *ce, const char *name, size_t name_length, const char *value, int access_type);
 ZEND_API int zend_declare_property_stringl(zend_class_entry *ce, const char *name, size_t name_length, const char *value, size_t value_len, int access_type);
 
-ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment);
+ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment, HashTable *attributes);
 ZEND_API int zend_declare_class_constant(zend_class_entry *ce, const char *name, size_t name_length, zval *value);
 ZEND_API int zend_declare_class_constant_null(zend_class_entry *ce, const char *name, size_t name_length);
 ZEND_API int zend_declare_class_constant_long(zend_class_entry *ce, const char *name, size_t name_length, zend_long value);

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1325,7 +1325,7 @@ static ZEND_COLD void zend_ast_export_attributes(smart_str *str, zend_ast *ast, 
 		zend_ast *attr = list->child[i];
 
 		smart_str_appends(str, "<<");
-		smart_str_append(str, zend_ast_get_str(attr->child[0]));
+		zend_ast_export_ns_name(str, attr->child[0], 0, indent);
 
 		if (attr->child[1]) {
 			zend_ast_list *args = zend_ast_get_list(attr->child[1]);
@@ -1446,7 +1446,7 @@ tail_call:
 		case ZEND_AST_METHOD:
 			decl = (zend_ast_decl *) ast;
 			if (decl->attributes) {
-				zend_bool newlines = (ast->kind == ZEND_AST_CLOSURE || ast->kind == ZEND_AST_ARROW_FUNC) ? 0 : 1;
+				zend_bool newlines = (ast->kind == ZEND_AST_CLOSURE || ast->kind == ZEND_AST_ARROW_FUNC);
 				zend_ast_export_attributes(str, decl->attributes, indent, newlines);
 			}
 			if (decl->flags & ZEND_ACC_PUBLIC) {

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -126,6 +126,7 @@ ZEND_API zend_ast *zend_ast_create_decl(
 	ast->flags = flags;
 	ast->lex_pos = LANG_SCNG(yy_text);
 	ast->doc_comment = doc_comment;
+	ast->attributes = NULL;
 	ast->name = name;
 	ast->child[0] = child0;
 	ast->child[1] = child1;
@@ -857,6 +858,9 @@ tail_call:
 		if (decl->doc_comment) {
 			zend_string_release_ex(decl->doc_comment, 0);
 		}
+		if (decl->attributes) {
+			zend_ast_destroy(decl->attributes);
+		}
 		zend_ast_destroy(decl->child[0]);
 		zend_ast_destroy(decl->child[1]);
 		zend_ast_destroy(decl->child[2]);
@@ -1313,6 +1317,41 @@ static ZEND_COLD void zend_ast_export_class_no_header(smart_str *str, zend_ast_d
 	smart_str_appends(str, "}");
 }
 
+static ZEND_COLD void zend_ast_export_attributes(smart_str *str, zend_ast *ast, int indent, zend_bool newlines) {
+	zend_ast_list *list = zend_ast_get_list(ast);
+	uint32_t i;
+
+	for (i = 0; i < list->children; i++) {
+		zend_ast *attr = list->child[i];
+
+		smart_str_appends(str, "<<");
+		smart_str_append(str, zend_ast_get_str(attr->child[0]));
+
+		if (attr->child[1]) {
+			zend_ast_list *args = zend_ast_get_list(attr->child[1]);
+			uint32_t j;
+
+			smart_str_appendc(str, '(');
+			for (j = 0; j < args->children; j++) {
+				if (j) {
+					smart_str_appends(str, ", ");
+				}
+				zend_ast_export_ex(str, args->child[j], 0, indent);
+			}
+			smart_str_appendc(str, ')');
+		}
+
+		smart_str_appends(str, ">>");
+
+		if (newlines) {
+			smart_str_appendc(str, '\n');
+			zend_ast_export_indent(str, indent);
+		} else {
+			smart_str_appendc(str, ' ');
+		}
+	}
+}
+
 static ZEND_COLD void zend_ast_export_type(smart_str *str, zend_ast *ast, int indent) {
 	if (ast->kind == ZEND_AST_TYPE_UNION) {
 		zend_ast_list *list = zend_ast_get_list(ast);
@@ -1406,6 +1445,10 @@ tail_call:
 		case ZEND_AST_ARROW_FUNC:
 		case ZEND_AST_METHOD:
 			decl = (zend_ast_decl *) ast;
+			if (decl->attributes) {
+				zend_bool newlines = (ast->kind == ZEND_AST_CLOSURE || ast->kind == ZEND_AST_ARROW_FUNC) ? 0 : 1;
+				zend_ast_export_attributes(str, decl->attributes, indent, newlines);
+			}
 			if (decl->flags & ZEND_ACC_PUBLIC) {
 				smart_str_appends(str, "public ");
 			} else if (decl->flags & ZEND_ACC_PROTECTED) {
@@ -1462,6 +1505,9 @@ tail_call:
 			break;
 		case ZEND_AST_CLASS:
 			decl = (zend_ast_decl *) ast;
+			if (decl->attributes) {
+				zend_ast_export_attributes(str, decl->attributes, indent, 1);
+			}
 			if (decl->flags & ZEND_ACC_INTERFACE) {
 				smart_str_appends(str, "interface ");
 			} else if (decl->flags & ZEND_ACC_TRAIT) {
@@ -1517,6 +1563,9 @@ simple_list:
 			zend_ast *type_ast = ast->child[0];
 			zend_ast *prop_ast = ast->child[1];
 
+			if (ast->child[2]) {
+				zend_ast_export_attributes(str, ast->child[2], indent, 1);
+			}
 			if (ast->attr & ZEND_ACC_PUBLIC) {
 				smart_str_appends(str, "public ");
 			} else if (ast->attr & ZEND_ACC_PROTECTED) {
@@ -1541,6 +1590,12 @@ simple_list:
 		case ZEND_AST_CLASS_CONST_DECL:
 			smart_str_appends(str, "const ");
 			goto simple_list;
+		case ZEND_AST_CLASS_CONST_GROUP:
+			if (ast->child[1]) {
+				zend_ast_export_attributes(str, ast->child[1], indent, 1);
+			}
+			zend_ast_export_ex(str, ast->child[0], 0, indent);
+			break;
 		case ZEND_AST_NAME_LIST:
 			zend_ast_export_name_list(str, (zend_ast_list*)ast, indent);
 			break;
@@ -1783,13 +1838,17 @@ simple_list:
 		case ZEND_AST_NEW:
 			smart_str_appends(str, "new ");
 			if (ast->child[0]->kind == ZEND_AST_CLASS) {
+				zend_ast_decl *decl = (zend_ast_decl *) ast->child[0];
+				if (decl->attributes) {
+					zend_ast_export_attributes(str, decl->attributes, indent, 0);
+				}
 				smart_str_appends(str, "class");
 				if (zend_ast_get_list(ast->child[1])->children) {
 					smart_str_appendc(str, '(');
 					zend_ast_export_ex(str, ast->child[1], 0, indent);
 					smart_str_appendc(str, ')');
 				}
-				zend_ast_export_class_no_header(str, (zend_ast_decl *) ast->child[0], indent);
+				zend_ast_export_class_no_header(str, decl, indent);
 			} else {
 				zend_ast_export_ns_name(str, ast->child[0], 0, indent);
 				smart_str_appendc(str, '(');
@@ -2002,6 +2061,9 @@ simple_list:
 			zend_ast_export_indent(str, indent);
 			break;
 		case ZEND_AST_PARAM:
+			if (ast->child[3]) {
+				zend_ast_export_attributes(str, ast->child[3], indent, 0);
+			}
 			if (ast->child[0]) {
 				zend_ast_export_type(str, ast->child[0], indent);
 				smart_str_appendc(str, ' ');
@@ -2113,4 +2175,31 @@ ZEND_API ZEND_COLD zend_string *zend_ast_export(const char *prefix, zend_ast *as
 	smart_str_appends(&str, suffix);
 	smart_str_0(&str);
 	return str.s;
+}
+
+zend_ast * ZEND_FASTCALL zend_ast_with_attributes(zend_ast *ast, zend_ast *attr)
+{
+	ZEND_ASSERT(attr->kind == ZEND_AST_ATTRIBUTE_LIST);
+
+	switch (ast->kind) {
+	case ZEND_AST_FUNC_DECL:
+	case ZEND_AST_CLOSURE:
+	case ZEND_AST_METHOD:
+	case ZEND_AST_CLASS:
+	case ZEND_AST_ARROW_FUNC:
+		((zend_ast_decl *) ast)->attributes = attr;
+		break;
+	case ZEND_AST_PROP_GROUP:
+		ast->child[2] = attr;
+		break;
+	case ZEND_AST_PARAM:
+		ast->child[3] = attr;
+		break;
+	case ZEND_AST_CLASS_CONST_GROUP:
+		ast->child[1] = attr;
+		break;
+	EMPTY_SWITCH_DEFAULT_CASE()
+	}
+
+	return ast;
 }

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1446,7 +1446,7 @@ tail_call:
 		case ZEND_AST_METHOD:
 			decl = (zend_ast_decl *) ast;
 			if (decl->attributes) {
-				zend_bool newlines = (ast->kind == ZEND_AST_CLOSURE || ast->kind == ZEND_AST_ARROW_FUNC);
+				zend_bool newlines = !(ast->kind == ZEND_AST_CLOSURE || ast->kind == ZEND_AST_ARROW_FUNC);
 				zend_ast_export_attributes(str, decl->attributes, indent, newlines);
 			}
 			if (decl->flags & ZEND_ACC_PUBLIC) {

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -194,9 +194,8 @@ typedef struct _zend_ast_decl {
 	uint32_t flags;
 	unsigned char *lex_pos;
 	zend_string *doc_comment;
-	zend_ast *attributes;
 	zend_string *name;
-	zend_ast *child[4];
+	zend_ast *child[5];
 } zend_ast_decl;
 
 typedef void (*zend_ast_process_t)(zend_ast *ast);
@@ -274,7 +273,7 @@ ZEND_API zend_ast * ZEND_FASTCALL zend_ast_list_add(zend_ast *list, zend_ast *op
 
 ZEND_API zend_ast *zend_ast_create_decl(
 	zend_ast_kind kind, uint32_t flags, uint32_t start_lineno, zend_string *doc_comment,
-	zend_string *name, zend_ast *child0, zend_ast *child1, zend_ast *child2, zend_ast *child3
+	zend_string *name, zend_ast *child0, zend_ast *child1, zend_ast *child2, zend_ast *child3, zend_ast *child4
 );
 
 ZEND_API int ZEND_FASTCALL zend_ast_evaluate(zval *result, zend_ast *ast, zend_class_entry *scope);

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -315,12 +315,6 @@ static zend_always_inline zend_string *zend_ast_get_constant_name(zend_ast *ast)
 	return Z_STR(((zend_ast_zval *) ast)->val);
 }
 
-static zend_always_inline HashTable *zend_ast_get_hash(zend_ast *ast) {
-	zval *zv = zend_ast_get_zval(ast);
-	ZEND_ASSERT(Z_TYPE_P(zv) == IS_ARRAY);
-	return Z_ARR_P(zv);
-}
-
 static zend_always_inline uint32_t zend_ast_get_num_children(zend_ast *ast) {
 	ZEND_ASSERT(!zend_ast_is_list(ast));
 	return ast->kind >> ZEND_AST_NUM_CHILDREN_SHIFT;
@@ -332,12 +326,6 @@ static zend_always_inline uint32_t zend_ast_get_lineno(zend_ast *ast) {
 	} else {
 		return ast->lineno;
 	}
-}
-
-static zend_always_inline zend_ast *zend_ast_create_zval_from_hash(HashTable *hash) {
-	zval zv;
-	ZVAL_ARR(&zv, hash);
-	return zend_ast_create_zval(&zv);
 }
 
 static zend_always_inline zend_ast *zend_ast_create_binary_op(uint32_t opcode, zend_ast *op0, zend_ast *op1) {

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -1,0 +1,131 @@
+#include "zend.h"
+#include "zend_API.h"
+#include "zend_attributes.h"
+
+ZEND_API zend_class_entry *zend_ce_php_attribute;
+
+static HashTable internal_validators;
+
+void zend_attribute_validate_phpattribute(zend_attribute *attr, int target)
+{
+	if (target != ZEND_ATTRIBUTE_TARGET_CLASS) {
+		zend_error(E_COMPILE_ERROR, "Only classes can be marked with <<PhpAttribute>>");
+	}
+}
+
+ZEND_API zend_attributes_internal_validator zend_attribute_get_validator(zend_string *lcname)
+{
+	return zend_hash_find_ptr(&internal_validators, lcname);
+}
+
+ZEND_API void zend_attribute_free(zend_attribute *attr)
+{
+	uint32_t i;
+
+	zend_string_release(attr->name);
+	zend_string_release(attr->lcname);
+
+	for (i = 0; i < attr->argc; i++) {
+		zval_ptr_dtor(&attr->argv[i]);
+	}
+
+	efree(attr);
+}
+
+static zend_attribute *get_attribute(HashTable *attributes, zend_string *lcname, uint32_t offset)
+{
+	if (attributes) {
+		zend_attribute *attr;
+
+		ZEND_HASH_FOREACH_PTR(attributes, attr) {
+			if (attr->offset == offset && zend_string_equals(attr->lcname, lcname)) {
+				return attr;
+			}
+		} ZEND_HASH_FOREACH_END();
+	}
+
+	return NULL;
+}
+
+static zend_attribute *get_attribute_str(HashTable *attributes, const char *str, size_t len, uint32_t offset)
+{
+	if (attributes) {
+		zend_attribute *attr;
+
+		ZEND_HASH_FOREACH_PTR(attributes, attr) {
+			if (attr->offset == offset && ZSTR_LEN(attr->lcname) == len) {
+				if (0 == memcmp(ZSTR_VAL(attr->lcname), str, len)) {
+					return attr;
+				}
+			}
+		} ZEND_HASH_FOREACH_END();
+	}
+
+	return NULL;
+}
+
+ZEND_API zend_attribute *zend_get_attribute(HashTable *attributes, zend_string *lcname)
+{
+	return get_attribute(attributes, lcname, 0);
+}
+
+ZEND_API zend_attribute *zend_get_attribute_str(HashTable *attributes, const char *str, size_t len)
+{
+	return get_attribute_str(attributes, str, len, 0);
+}
+
+ZEND_API zend_attribute *zend_get_parameter_attribute(HashTable *attributes, zend_string *lcname, uint32_t offset)
+{
+	return get_attribute(attributes, lcname, offset + 1);
+}
+
+ZEND_API zend_attribute *zend_get_parameter_attribute_str(HashTable *attributes, const char *str, size_t len, uint32_t offset)
+{
+	return get_attribute_str(attributes, str, len, offset + 1);
+}
+
+static void attribute_ptr_dtor(zval *v)
+{
+	zend_attribute_free((zend_attribute *) Z_PTR_P(v));
+}
+
+ZEND_API void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator)
+{
+	if (ce->type != ZEND_INTERNAL_CLASS) {
+		zend_error_noreturn(E_ERROR, "Only internal classes can be registered as compiler attribute");
+	}
+
+	zend_string *lcname = zend_string_tolower_ex(ce->name, 1);
+	zval tmp;
+
+	zend_hash_update_ptr(&internal_validators, lcname, validator);
+	zend_string_release(lcname);
+
+	if (ce->attributes == NULL) {
+		ce->attributes = pemalloc(sizeof(HashTable), 1);
+		zend_hash_init(ce->attributes, 8, NULL, attribute_ptr_dtor, 1);
+	}
+
+	zend_attribute *attr = pemalloc(ZEND_ATTRIBUTE_SIZE(0), 1);
+
+	attr->name = zend_string_copy(zend_ce_php_attribute->name);
+	attr->lcname = zend_string_tolower_ex(attr->name, 1);
+	attr->offset = 0;
+	attr->argc = 0;
+
+	ZVAL_PTR(&tmp, attr);
+	zend_hash_next_index_insert(ce->attributes, &tmp);
+}
+
+void zend_register_attribute_ce(void)
+{
+	zend_hash_init(&internal_validators, 8, NULL, NULL, 1);
+
+	zend_class_entry ce;
+
+	INIT_CLASS_ENTRY(ce, "PhpAttribute", NULL);
+	zend_ce_php_attribute = zend_register_internal_class(&ce);
+	zend_ce_php_attribute->ce_flags |= ZEND_ACC_FINAL;
+
+	zend_compiler_attribute_register(zend_ce_php_attribute, zend_attribute_validate_phpattribute);
+}

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -1,13 +1,13 @@
 #ifndef ZEND_ATTRIBUTES_H
 #define ZEND_ATTRIBUTES_H
 
-#define ZEND_ATTRIBUTE_TARGET_CLASS			1
-#define ZEND_ATTRIBUTE_TARGET_FUNCTION		2
-#define ZEND_ATTRIBUTE_TARGET_METHOD		4
-#define ZEND_ATTRIBUTE_TARGET_PROPERTY		8
-#define ZEND_ATTRIBUTE_TARGET_CLASS_CONST	16
-#define ZEND_ATTRIBUTE_TARGET_PARAMETER		32
-#define ZEND_ATTRIBUTE_TARGET_ALL			63
+#define ZEND_ATTRIBUTE_TARGET_CLASS			(1<<0)
+#define ZEND_ATTRIBUTE_TARGET_FUNCTION		(1<<1)
+#define ZEND_ATTRIBUTE_TARGET_METHOD		(1<<2)
+#define ZEND_ATTRIBUTE_TARGET_PROPERTY		(1<<3)
+#define ZEND_ATTRIBUTE_TARGET_CLASS_CONST	(1<<4)
+#define ZEND_ATTRIBUTE_TARGET_PARAMETER		(1<<5)
+#define ZEND_ATTRIBUTE_TARGET_ALL			(1<<6)
 
 #define ZEND_ATTRIBUTE_SIZE(argc) (sizeof(zend_attribute) + sizeof(zval) * (argc) - sizeof(zval))
 
@@ -26,7 +26,7 @@ typedef struct _zend_attribute {
 
 typedef void (*zend_attributes_internal_validator)(zend_attribute *attr, int target);
 
-ZEND_API void zend_attribute_free(zend_attribute *attr);
+ZEND_API void zend_attribute_free(zend_attribute *attr, int persistent);
 
 ZEND_API zend_attribute *zend_get_attribute(HashTable *attributes, zend_string *lcname);
 ZEND_API zend_attribute *zend_get_attribute_str(HashTable *attributes, const char *str, size_t len);

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -1,0 +1,44 @@
+#ifndef ZEND_ATTRIBUTES_H
+#define ZEND_ATTRIBUTES_H
+
+#define ZEND_ATTRIBUTE_TARGET_CLASS			1
+#define ZEND_ATTRIBUTE_TARGET_FUNCTION		2
+#define ZEND_ATTRIBUTE_TARGET_METHOD		4
+#define ZEND_ATTRIBUTE_TARGET_PROPERTY		8
+#define ZEND_ATTRIBUTE_TARGET_CLASS_CONST	16
+#define ZEND_ATTRIBUTE_TARGET_PARAMETER		32
+#define ZEND_ATTRIBUTE_TARGET_ALL			63
+
+#define ZEND_ATTRIBUTE_SIZE(argc) (sizeof(zend_attribute) + sizeof(zval) * (argc) - sizeof(zval))
+
+BEGIN_EXTERN_C()
+
+extern ZEND_API zend_class_entry *zend_ce_php_attribute;
+
+typedef struct _zend_attribute {
+	zend_string *name;
+	zend_string *lcname;
+	/* Parameter offsets start at 1, everything else uses 0. */
+	uint32_t offset;
+	uint32_t argc;
+	zval argv[1];
+} zend_attribute;
+
+typedef void (*zend_attributes_internal_validator)(zend_attribute *attr, int target);
+
+ZEND_API void zend_attribute_free(zend_attribute *attr);
+
+ZEND_API zend_attribute *zend_get_attribute(HashTable *attributes, zend_string *lcname);
+ZEND_API zend_attribute *zend_get_attribute_str(HashTable *attributes, const char *str, size_t len);
+
+ZEND_API zend_attribute *zend_get_parameter_attribute(HashTable *attributes, zend_string *lcname, uint32_t offset);
+ZEND_API zend_attribute *zend_get_parameter_attribute_str(HashTable *attributes, const char *str, size_t len, uint32_t offset);
+
+ZEND_API void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator);
+ZEND_API zend_attributes_internal_validator zend_attribute_get_validator(zend_string *lcname);
+
+void zend_register_attribute_ce(void);
+
+END_EXTERN_C()
+
+#endif

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6370,14 +6370,14 @@ void zend_compile_func_decl(znode *result, zend_ast *ast, zend_bool toplevel) /*
 	if (decl->doc_comment) {
 		op_array->doc_comment = zend_string_copy(decl->doc_comment);
 	}
-	if (decl->attributes) {
+	if (decl->child[4]) {
 		int target = ZEND_ATTRIBUTE_TARGET_FUNCTION;
 
 		if (is_method) {
 			target = ZEND_ATTRIBUTE_TARGET_METHOD;
 		}
 		op_array->attributes = create_attribute_array();
-		zend_compile_attributes(op_array->attributes, decl->attributes, 0, target);
+		zend_compile_attributes(op_array->attributes, decl->child[4], 0, target);
 	}
 	if (decl->kind == ZEND_AST_CLOSURE || decl->kind == ZEND_AST_ARROW_FUNC) {
 		op_array->fn_flags |= ZEND_ACC_CLOSURE;
@@ -6823,9 +6823,9 @@ void zend_compile_class_decl(znode *result, zend_ast *ast, zend_bool toplevel) /
 	if (decl->doc_comment) {
 		ce->info.user.doc_comment = zend_string_copy(decl->doc_comment);
 	}
-	if (decl->attributes) {
+	if (decl->child[4]) {
 		ce->attributes = create_attribute_array();
-		zend_compile_attributes(ce->attributes, decl->attributes, 0, ZEND_ATTRIBUTE_TARGET_CLASS);
+		zend_compile_attributes(ce->attributes, decl->child[4], 0, ZEND_ATTRIBUTE_TARGET_CLASS);
 	}
 
 	if (UNEXPECTED((decl->flags & ZEND_ACC_ANON_CLASS))) {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1821,12 +1821,12 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, zend_bool nullify
 	} else {
 		ZEND_MAP_PTR_INIT(ce->static_members_table, &ce->default_static_members_table);
 		ce->info.user.doc_comment = NULL;
-		ce->attributes = NULL;
 	}
 
 	ce->default_properties_count = 0;
 	ce->default_static_members_count = 0;
 	ce->properties_info_table = NULL;
+	ce->attributes = NULL;
 
 	if (nullify_handlers) {
 		ce->constructor = NULL;
@@ -5750,7 +5750,7 @@ static zend_attribute *zend_compile_attribute(zend_ast *ast, uint32_t offset) /*
 
 static void attribute_ptr_dtor(zval *v) /* {{{ */
 {
-	zend_attribute_free((zend_attribute *) Z_PTR_P(v));
+	zend_attribute_free((zend_attribute *) Z_PTR_P(v), 0);
 }
 /* }}} */
 
@@ -5770,8 +5770,6 @@ static void zend_compile_attributes(HashTable *attributes, zend_ast *ast, uint32
 	zend_ast_list *list = zend_ast_get_list(ast);
 	uint32_t i;
 
-	zval tmp;
-
 	ZEND_ASSERT(ast->kind == ZEND_AST_ATTRIBUTE_LIST);
 
 	for (i = 0; i < list->children; i++) {
@@ -5784,8 +5782,7 @@ static void zend_compile_attributes(HashTable *attributes, zend_ast *ast, uint32
 			validator(attr, target);
 		}
 
-		ZVAL_PTR(&tmp, attr);
-		zend_hash_next_index_insert(attributes, &tmp);
+		zend_hash_next_index_insert_ptr(attributes, attr);
 	}
 }
 /* }}} */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -120,6 +120,7 @@ typedef struct _zend_file_context {
 typedef union _zend_parser_stack_elem {
 	zend_ast *ast;
 	zend_string *str;
+	HashTable *hash;
 	zend_ulong num;
 	unsigned char *ptr;
 } zend_parser_stack_elem;
@@ -348,6 +349,7 @@ typedef struct _zend_property_info {
 	uint32_t flags;
 	zend_string *name;
 	zend_string *doc_comment;
+	HashTable *attributes;
 	zend_class_entry *ce;
 	zend_type type;
 } zend_property_info;
@@ -364,6 +366,7 @@ typedef struct _zend_property_info {
 typedef struct _zend_class_constant {
 	zval value; /* access flags are stored in reserved: zval.u2.access_flags */
 	zend_string *doc_comment;
+	HashTable *attributes;
 	zend_class_entry *ce;
 } zend_class_constant;
 
@@ -403,6 +406,7 @@ struct _zend_op_array {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_arg_info *arg_info;
+	HashTable   *attributes;
 	/* END of common elements */
 
 	int cache_size;     /* number of run_time_cache_slots * sizeof(void*) */
@@ -452,6 +456,7 @@ typedef struct _zend_internal_function {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_internal_arg_info *arg_info;
+	HashTable   *attributes;
 	/* END of common elements */
 
 	zif_handler handler;
@@ -475,6 +480,7 @@ union _zend_function {
 		uint32_t num_args;
 		uint32_t required_num_args;
 		zend_arg_info *arg_info;  /* index -1 represents the return value info, if any */
+		HashTable   *attributes;
 	} common;
 
 	zend_op_array op_array;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -120,7 +120,6 @@ typedef struct _zend_file_context {
 typedef union _zend_parser_stack_elem {
 	zend_ast *ast;
 	zend_string *str;
-	HashTable *hash;
 	zend_ulong num;
 	unsigned char *ptr;
 } zend_parser_stack_elem;
@@ -406,7 +405,7 @@ struct _zend_op_array {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_arg_info *arg_info;
-	HashTable   *attributes;
+	HashTable *attributes;
 	/* END of common elements */
 
 	int cache_size;     /* number of run_time_cache_slots * sizeof(void*) */
@@ -456,7 +455,7 @@ typedef struct _zend_internal_function {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_internal_arg_info *arg_info;
-	HashTable   *attributes;
+	HashTable *attributes;
 	/* END of common elements */
 
 	zif_handler handler;

--- a/Zend/zend_default_classes.c
+++ b/Zend/zend_default_classes.c
@@ -19,6 +19,7 @@
 
 #include "zend.h"
 #include "zend_API.h"
+#include "zend_attributes.h"
 #include "zend_builtin_functions.h"
 #include "zend_interfaces.h"
 #include "zend_exceptions.h"
@@ -34,4 +35,5 @@ ZEND_API void zend_register_default_classes(void)
 	zend_register_closure_ce();
 	zend_register_generator_ce();
 	zend_register_weakref_ce();
+	zend_register_attribute_ce();
 }

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -137,6 +137,7 @@ ZEND_API const zend_internal_function zend_pass_function = {
 	0,                      /* num_args          */
 	0,                      /* required_num_args */
 	NULL,                   /* arg_info          */
+	NULL,                   /* attributes        */
 	ZEND_FN(pass),          /* handler           */
 	NULL,                   /* module            */
 	{NULL,NULL,NULL,NULL}   /* reserved          */

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1973,6 +1973,7 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 	zval* prop_value;
 	uint32_t flags;
 	zend_string *doc_comment;
+	HashTable *attributes = NULL;
 
 	/* In the following steps the properties are inserted into the property table
 	 * for that, a very strict approach is applied:
@@ -2072,8 +2073,15 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 
 			Z_TRY_ADDREF_P(prop_value);
 			doc_comment = property_info->doc_comment ? zend_string_copy(property_info->doc_comment) : NULL;
+			if (property_info->attributes) {
+				attributes = property_info->attributes;
+
+				if (!(GC_FLAGS(attributes) & IS_ARRAY_IMMUTABLE)) {
+					GC_ADDREF(attributes);
+				}
+			}
 			zend_type_copy_ctor(&property_info->type, /* persistent */ 0);
-			zend_declare_typed_property(ce, prop_name, prop_value, flags, doc_comment, property_info->type);
+			zend_declare_typed_property(ce, prop_name, prop_value, flags, doc_comment, attributes, property_info->type);
 			zend_string_release_ex(prop_name, 0);
 		} ZEND_HASH_FOREACH_END();
 	}

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -526,7 +526,7 @@ function_declaration_statement:
 	function returns_ref T_STRING backup_doc_comment '(' parameter_list ')' return_type
 	backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
 		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2 | $13, $1, $4,
-		      zend_ast_get_str($3), $6, NULL, $11, $8); CG(extra_fn_flags) = $9; }
+		      zend_ast_get_str($3), $6, NULL, $11, $8, NULL); CG(extra_fn_flags) = $9; }
 ;
 
 is_reference:
@@ -542,10 +542,10 @@ is_variadic:
 class_declaration_statement:
 		class_modifiers T_CLASS { $<num>$ = CG(zend_lineno); }
 		T_STRING extends_from implements_list backup_doc_comment '{' class_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, $1, $<num>3, $7, zend_ast_get_str($4), $5, $6, $9, NULL); }
+			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, $1, $<num>3, $7, zend_ast_get_str($4), $5, $6, $9, NULL, NULL); }
 	|	T_CLASS { $<num>$ = CG(zend_lineno); }
 		T_STRING extends_from implements_list backup_doc_comment '{' class_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, 0, $<num>2, $6, zend_ast_get_str($3), $4, $5, $8, NULL); }
+			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, 0, $<num>2, $6, zend_ast_get_str($3), $4, $5, $8, NULL, NULL); }
 ;
 
 class_modifiers:
@@ -562,13 +562,13 @@ class_modifier:
 trait_declaration_statement:
 		T_TRAIT { $<num>$ = CG(zend_lineno); }
 		T_STRING backup_doc_comment '{' class_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_TRAIT, $<num>2, $4, zend_ast_get_str($3), NULL, NULL, $6, NULL); }
+			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_TRAIT, $<num>2, $4, zend_ast_get_str($3), NULL, NULL, $6, NULL, NULL); }
 ;
 
 interface_declaration_statement:
 		T_INTERFACE { $<num>$ = CG(zend_lineno); }
 		T_STRING interface_extends_list backup_doc_comment '{' class_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_INTERFACE, $<num>2, $5, zend_ast_get_str($3), NULL, $4, $7, NULL); }
+			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_INTERFACE, $<num>2, $5, zend_ast_get_str($3), NULL, $4, $7, NULL, NULL); }
 ;
 
 extends_from:
@@ -795,7 +795,7 @@ attributed_class_statement:
 	|	method_modifiers function returns_ref identifier backup_doc_comment '(' parameter_list ')'
 		return_type backup_fn_flags method_body backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_METHOD, $3 | $1 | $12, $2, $5,
-				  zend_ast_get_str($4), $7, NULL, $11, $9); CG(extra_fn_flags) = $10; }
+				  zend_ast_get_str($4), $7, NULL, $11, $9, NULL); CG(extra_fn_flags) = $10; }
 
 class_statement:
 		attributed_class_statement { $$ = $1; }
@@ -933,7 +933,7 @@ anonymous_class:
 		extends_from implements_list backup_doc_comment '{' class_statement_list '}' {
 			zend_ast *decl = zend_ast_create_decl(
 				ZEND_AST_CLASS, ZEND_ACC_ANON_CLASS, $<num>2, $6, NULL,
-				$4, $5, $8, NULL);
+				$4, $5, $8, NULL, NULL);
 			$$ = zend_ast_create(ZEND_AST_NEW, decl, $3);
 		}
 ;
@@ -1077,11 +1077,11 @@ inline_function:
 		backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $2 | $13, $1, $3,
 				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0),
-				  $5, $7, $11, $8); CG(extra_fn_flags) = $9; }
+				  $5, $7, $11, $8, NULL); CG(extra_fn_flags) = $9; }
 	|	fn returns_ref '(' parameter_list ')' return_type backup_doc_comment T_DOUBLE_ARROW backup_fn_flags backup_lex_pos expr backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_ARROW_FUNC, $2 | $12, $1, $7,
 				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0), $4, NULL,
-				  zend_ast_create(ZEND_AST_RETURN, $11), $6);
+				  zend_ast_create(ZEND_AST_RETURN, $11), $6, NULL);
 				  ((zend_ast_decl *) $$)->lex_pos = $10;
 				  CG(extra_fn_flags) = $9; }
 ;

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -258,6 +258,8 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> isset_variable type return_type type_expr type_without_static
 %type <ast> identifier type_expr_without_static union_type_without_static
 %type <ast> inline_function union_type
+%type <ast> attributed_statement attributed_class_statement attributed_parameter
+%type <ast> attribute_arguments attribute_decl attribute attributes
 
 %type <num> returns_ref function fn is_reference is_variadic variable_modifiers
 %type <num> method_modifiers non_empty_member_modifiers member_modifier
@@ -312,12 +314,41 @@ name:
 	|	T_NS_SEPARATOR namespace_name				{ $$ = $2; $$->attr = ZEND_NAME_FQ; }
 ;
 
-top_statement:
-		statement							{ $$ = $1; }
-	|	function_declaration_statement		{ $$ = $1; }
+attribute_arguments:
+		expr
+			{ $$ = zend_ast_create_list(1, ZEND_AST_ARG_LIST, $1); }
+	|	attribute_arguments ',' expr
+			{ $$ = zend_ast_list_add($1, $3); }
+;
+
+attribute_decl:
+		class_name_reference
+			{ $$ = zend_ast_create(ZEND_AST_ATTRIBUTE, $1, NULL); }
+	|	class_name_reference '(' ')'
+			{ $$ = zend_ast_create(ZEND_AST_ATTRIBUTE, $1, NULL); }
+	|	class_name_reference '(' attribute_arguments ')'
+			{ $$ = zend_ast_create(ZEND_AST_ATTRIBUTE, $1, $3); }
+;
+
+attribute:
+		T_SL attribute_decl T_SR	{ $$ = $2; }
+;
+
+attributes:
+		attribute				{ $$ = zend_ast_create_list(1, ZEND_AST_ATTRIBUTE_LIST, $1); }
+	|	attributes attribute	{ $$ = zend_ast_list_add($1, $2); }
+;
+
+attributed_statement:
+		function_declaration_statement		{ $$ = $1; }
 	|	class_declaration_statement			{ $$ = $1; }
 	|	trait_declaration_statement			{ $$ = $1; }
 	|	interface_declaration_statement		{ $$ = $1; }
+
+top_statement:
+		statement							{ $$ = $1; }
+	|	attributed_statement					{ $$ = $1; }
+	|	attributes attributed_statement		{ $$ = zend_ast_with_attributes($2, $1); }
 	|	T_HALT_COMPILER '(' ')' ';'
 			{ $$ = zend_ast_create(ZEND_AST_HALT_COMPILER,
 			      zend_ast_create_zval_from_long(zend_get_scanned_file_offset()));
@@ -415,10 +446,8 @@ inner_statement_list:
 
 inner_statement:
 		statement { $$ = $1; }
-	|	function_declaration_statement 		{ $$ = $1; }
-	|	class_declaration_statement 		{ $$ = $1; }
-	|	trait_declaration_statement			{ $$ = $1; }
-	|	interface_declaration_statement		{ $$ = $1; }
+	|	attributed_statement					{ $$ = $1; }
+	|	attributes attributed_statement		{ $$ = zend_ast_with_attributes($2, $1); }
 	|	T_HALT_COMPILER '(' ')' ';'
 			{ $$ = NULL; zend_throw_exception(zend_ce_compile_error,
 			      "__HALT_COMPILER() can only be used from the outermost scope", 0); YYERROR; }
@@ -644,17 +673,22 @@ parameter_list:
 
 
 non_empty_parameter_list:
-		parameter
+		attributed_parameter
 			{ $$ = zend_ast_create_list(1, ZEND_AST_PARAM_LIST, $1); }
-	|	non_empty_parameter_list ',' parameter
+	|	non_empty_parameter_list ',' attributed_parameter
 			{ $$ = zend_ast_list_add($1, $3); }
+;
+
+attributed_parameter:
+		attributes parameter	{ $$ = zend_ast_with_attributes($2, $1); }
+	|	parameter				{ $$ = $1; }
 ;
 
 parameter:
 		optional_type_without_static is_reference is_variadic T_VARIABLE
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2 | $3, $1, $4, NULL); }
+			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2 | $3, $1, $4, NULL, NULL); }
 	|	optional_type_without_static is_reference is_variadic T_VARIABLE '=' expr
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2 | $3, $1, $4, $6); }
+			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2 | $3, $1, $4, $6, NULL); }
 ;
 
 
@@ -744,7 +778,6 @@ static_var:
 	|	T_VARIABLE '=' expr	{ $$ = zend_ast_create(ZEND_AST_STATIC, $1, $3); }
 ;
 
-
 class_statement_list:
 		class_statement_list class_statement
 			{ $$ = zend_ast_list_add($1, $2); }
@@ -753,18 +786,22 @@ class_statement_list:
 ;
 
 
-class_statement:
+attributed_class_statement:
 		variable_modifiers optional_type_without_static property_list ';'
-			{ $$ = zend_ast_create(ZEND_AST_PROP_GROUP, $2, $3);
+			{ $$ = zend_ast_create(ZEND_AST_PROP_GROUP, $2, $3, NULL);
 			  $$->attr = $1; }
 	|	method_modifiers T_CONST class_const_list ';'
-			{ $$ = $3; $$->attr = $1; }
-	|	T_USE class_name_list trait_adaptations
-			{ $$ = zend_ast_create(ZEND_AST_USE_TRAIT, $2, $3); }
+			{ $$ = zend_ast_create(ZEND_AST_CLASS_CONST_GROUP, $3, NULL); $3->attr = $1; }
 	|	method_modifiers function returns_ref identifier backup_doc_comment '(' parameter_list ')'
 		return_type backup_fn_flags method_body backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_METHOD, $3 | $1 | $12, $2, $5,
 				  zend_ast_get_str($4), $7, NULL, $11, $9); CG(extra_fn_flags) = $10; }
+
+class_statement:
+		attributed_class_statement { $$ = $1; }
+	|	attributes attributed_class_statement { $$ = zend_ast_with_attributes($2, $1); }
+	|	T_USE class_name_list trait_adaptations
+			{ $$ = zend_ast_create(ZEND_AST_USE_TRAIT, $2, $3); }
 ;
 
 class_name_list:
@@ -906,6 +943,8 @@ new_expr:
 			{ $$ = zend_ast_create(ZEND_AST_NEW, $2, $3); }
 	|	T_NEW anonymous_class
 			{ $$ = $2; }
+	|	T_NEW attributes anonymous_class
+			{ zend_ast_with_attributes($3->child[0], $2); $$ = $3; }
 ;
 
 expr:
@@ -1026,7 +1065,10 @@ expr:
 	|	T_YIELD_FROM expr { $$ = zend_ast_create(ZEND_AST_YIELD_FROM, $2); CG(extra_fn_flags) |= ZEND_ACC_GENERATOR; }
 	|	T_THROW expr { $$ = zend_ast_create(ZEND_AST_THROW, $2); }
 	|	inline_function { $$ = $1; }
+	|	attributes inline_function { $$ = zend_ast_with_attributes($2, $1); }
 	|	T_STATIC inline_function { $$ = $2; ((zend_ast_decl *) $$)->flags |= ZEND_ACC_STATIC; }
+	|	attributes T_STATIC inline_function
+			{ $$ = zend_ast_with_attributes($3, $1); ((zend_ast_decl *) $$)->flags |= ZEND_ACC_STATIC; }
 ;
 
 

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -63,6 +63,7 @@ void init_op_array(zend_op_array *op_array, zend_uchar type, int initial_ops_siz
 	op_array->function_name = NULL;
 	op_array->filename = zend_get_compiled_filename();
 	op_array->doc_comment = NULL;
+	op_array->attributes = NULL;
 
 	op_array->arg_info = NULL;
 	op_array->num_args = 0;
@@ -317,6 +318,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 					if (prop_info->doc_comment) {
 						zend_string_release_ex(prop_info->doc_comment, 0);
 					}
+					if (prop_info->attributes) {
+						zend_array_release(prop_info->attributes);
+					}
 					zend_type_release(prop_info->type, /* persistent */ 0);
 				}
 			} ZEND_HASH_FOREACH_END();
@@ -331,6 +335,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 						zval_ptr_dtor_nogc(&c->value);
 						if (c->doc_comment) {
 							zend_string_release_ex(c->doc_comment, 0);
+						}
+						if (c->attributes) {
+							zend_array_release(c->attributes);
 						}
 					}
 				} ZEND_HASH_FOREACH_END();
@@ -349,6 +356,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 			}
 			if (ce->info.user.doc_comment) {
 				zend_string_release_ex(ce->info.user.doc_comment, 0);
+			}
+			if (ce->attributes) {
+				zend_array_release(ce->attributes);
 			}
 
 			if (ce->num_traits > 0) {
@@ -400,6 +410,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 						zval_internal_ptr_dtor(&c->value);
 						if (c->doc_comment) {
 							zend_string_release_ex(c->doc_comment, 1);
+						}
+						if (c->attributes) {
+							zend_array_release(c->attributes);
 						}
 					}
 					free(c);
@@ -482,6 +495,9 @@ ZEND_API void destroy_op_array(zend_op_array *op_array)
 
 	if (op_array->doc_comment) {
 		zend_string_release_ex(op_array->doc_comment, 0);
+	}
+	if (op_array->attributes) {
+		zend_array_release(op_array->attributes);
 	}
 	if (op_array->live_range) {
 		efree(op_array->live_range);

--- a/configure.ac
+++ b/configure.ac
@@ -1469,7 +1469,7 @@ PHP_ADD_SOURCES(Zend, \
     zend_execute_API.c zend_highlight.c zend_llist.c \
     zend_vm_opcodes.c zend_opcode.c zend_operators.c zend_ptr_stack.c zend_stack.c \
     zend_variables.c zend.c zend_API.c zend_extensions.c zend_hash.c \
-    zend_list.c zend_builtin_functions.c \
+    zend_list.c zend_builtin_functions.c zend_attributes.c \
     zend_ini.c zend_sort.c zend_multibyte.c zend_ts_hash.c zend_stream.c \
     zend_iterators.c zend_interfaces.c zend_exceptions.c zend_strtod.c zend_gc.c \
     zend_closures.c zend_weakrefs.c zend_float.c zend_string.c zend_signal.c zend_generators.c \

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -411,13 +411,8 @@ static void zend_file_cache_serialize_attribute(zval                     *zv,
 	attr = Z_PTR_P(zv);
 	UNSERIALIZE_PTR(attr);
 
-	if (!IS_SERIALIZED(attr->name)) {
-		SERIALIZE_STR(attr->name);
-	}
-
-	if (!IS_SERIALIZED(attr->lcname)) {
-		SERIALIZE_STR(attr->lcname);
-	}
+	SERIALIZE_STR(attr->name);
+	SERIALIZE_STR(attr->lcname);
 
 	for (i = 0; i < attr->argc; i++) {
 		zend_file_cache_serialize_zval(&attr->argv[i], script, info, buf);
@@ -1179,13 +1174,8 @@ static void zend_file_cache_unserialize_attribute(zval *zv, zend_persistent_scri
 	UNSERIALIZE_PTR(Z_PTR_P(zv));
 	attr = Z_PTR_P(zv);
 
-	if (!IS_UNSERIALIZED(attr->name)) {
-		UNSERIALIZE_STR(attr->name);
-	}
-
-	if (!IS_UNSERIALIZED(attr->lcname)) {
-		UNSERIALIZE_STR(attr->lcname);
-	}
+	UNSERIALIZE_STR(attr->name);
+	UNSERIALIZE_STR(attr->lcname);
 
 	for (i = 0; i < attr->argc; i++) {
 		zend_file_cache_unserialize_zval(&attr->argv[i], script, buf);

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -404,25 +404,23 @@ static void zend_file_cache_serialize_attribute(zval                     *zv,
                                                 zend_file_cache_metainfo *info,
                                                 void                     *buf)
 {
-	if (!IS_SERIALIZED(Z_PTR_P(zv))) {
-		zend_attribute *attr = Z_PTR_P(zv);
-		uint32_t i;
+	zend_attribute *attr = Z_PTR_P(zv);
+	uint32_t i;
 
-		SERIALIZE_PTR(Z_PTR_P(zv));
-		attr = Z_PTR_P(zv);
-		UNSERIALIZE_PTR(attr);
+	SERIALIZE_PTR(Z_PTR_P(zv));
+	attr = Z_PTR_P(zv);
+	UNSERIALIZE_PTR(attr);
 
-		if (!IS_SERIALIZED(attr->name)) {
-			SERIALIZE_STR(attr->name);
-		}
+	if (!IS_SERIALIZED(attr->name)) {
+		SERIALIZE_STR(attr->name);
+	}
 
-		if (!IS_SERIALIZED(attr->lcname)) {
-			SERIALIZE_STR(attr->lcname);
-		}
+	if (!IS_SERIALIZED(attr->lcname)) {
+		SERIALIZE_STR(attr->lcname);
+	}
 
-		for (i = 0; i < attr->argc; i++) {
-			zend_file_cache_serialize_zval(&attr->argv[i], script, info, buf);
-		}
+	for (i = 0; i < attr->argc; i++) {
+		zend_file_cache_serialize_zval(&attr->argv[i], script, info, buf);
 	}
 }
 
@@ -1175,24 +1173,22 @@ static void zend_file_cache_unserialize_zval(zval                    *zv,
 
 static void zend_file_cache_unserialize_attribute(zval *zv, zend_persistent_script *script, void *buf)
 {
-	if (!IS_UNSERIALIZED(Z_PTR_P(zv))) {
-		zend_attribute *attr;
-		uint32_t i;
+	zend_attribute *attr;
+	uint32_t i;
 
-		UNSERIALIZE_PTR(Z_PTR_P(zv));
-		attr = Z_PTR_P(zv);
+	UNSERIALIZE_PTR(Z_PTR_P(zv));
+	attr = Z_PTR_P(zv);
 
-		if (!IS_UNSERIALIZED(attr->name)) {
-			UNSERIALIZE_STR(attr->name);
-		}
+	if (!IS_UNSERIALIZED(attr->name)) {
+		UNSERIALIZE_STR(attr->name);
+	}
 
-		if (!IS_UNSERIALIZED(attr->lcname)) {
-			UNSERIALIZE_STR(attr->lcname);
-		}
+	if (!IS_UNSERIALIZED(attr->lcname)) {
+		UNSERIALIZE_STR(attr->lcname);
+	}
 
-		for (i = 0; i < attr->argc; i++) {
-			zend_file_cache_unserialize_zval(&attr->argv[i], script, buf);
-		}
+	for (i = 0; i < attr->argc; i++) {
+		zend_file_cache_unserialize_zval(&attr->argv[i], script, buf);
 	}
 }
 

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -272,7 +272,7 @@ static HashTable *zend_persist_attributes(HashTable *attributes)
 
 		ZEND_HASH_FOREACH_VAL(attributes, v) {
 			zend_attribute *attr = Z_PTR_P(v);
-			zend_attribute *copy = zend_shared_memdup(attr, ZEND_ATTRIBUTE_SIZE(attr->argc));
+			zend_attribute *copy = zend_shared_memdup_put_free(attr, ZEND_ATTRIBUTE_SIZE(attr->argc));
 
 			zend_accel_store_interned_string(copy->name);
 			zend_accel_store_interned_string(copy->lcname);
@@ -282,7 +282,6 @@ static HashTable *zend_persist_attributes(HashTable *attributes)
 			}
 
 			ZVAL_PTR(v, copy);
-			efree(attr);
 		} ZEND_HASH_FOREACH_END();
 
 		ptr = zend_shared_memdup_put_free(attributes, sizeof(HashTable));

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1150,7 +1150,7 @@ static void reflect_attributes(INTERNAL_FUNCTION_PARAMETERS, HashTable *attribut
 	zend_long flags = 0;
 	zend_class_entry *base = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|Sl", &name, &flags) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|S!l", &name, &flags) == FAILURE) {
 		RETURN_THROWS();
 	}
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6410,15 +6410,12 @@ ZEND_METHOD(ReflectionAttribute, getName)
 
 static zend_always_inline int import_attribute_value(zval *ret, zval *val, zend_class_entry *scope) /* {{{ */
 {
+	ZVAL_COPY_OR_DUP(ret, val);
 	if (Z_TYPE_P(val) == IS_CONSTANT_AST) {
-		*ret = *val;
-		//ZVAL_COPY(ret, val);
-
 		if (FAILURE == zval_update_constant_ex(ret, scope)) {
+			zval_ptr_dtor(ret);
 			return FAILURE;
 		}
-	} else {
-		ZVAL_COPY_OR_DUP(ret, val);
 	}
 
 	return SUCCESS;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6411,8 +6411,9 @@ ZEND_METHOD(ReflectionAttribute, getName)
 static zend_always_inline int import_attribute_value(zval *ret, zval *val, zend_class_entry *scope) /* {{{ */
 {
 	ZVAL_COPY_OR_DUP(ret, val);
+
 	if (Z_TYPE_P(val) == IS_CONSTANT_AST) {
-		if (FAILURE == zval_update_constant_ex(ret, scope)) {
+		if (SUCCESS != zval_update_constant_ex(ret, scope)) {
 			zval_ptr_dtor(ret);
 			return FAILURE;
 		}

--- a/ext/reflection/php_reflection.h
+++ b/ext/reflection/php_reflection.h
@@ -42,6 +42,7 @@ extern PHPAPI zend_class_entry *reflection_property_ptr;
 extern PHPAPI zend_class_entry *reflection_extension_ptr;
 extern PHPAPI zend_class_entry *reflection_zend_extension_ptr;
 extern PHPAPI zend_class_entry *reflection_reference_ptr;
+extern PHPAPI zend_class_entry *reflection_attribute_ptr;
 
 PHPAPI void zend_reflection_class_factory(zend_class_entry *ce, zval *object);
 

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -97,7 +97,7 @@ abstract class ReflectionFunctionAbstract implements Reflector
     public function getReturnType() {}
 
     /** @return ReflectionAttribute[] */
-    public function getAttributes(?string $name = null, int $flags = 0) {}
+    public function getAttributes(?string $name = null, int $flags = 0): array {}
 }
 
 class ReflectionFunction extends ReflectionFunctionAbstract
@@ -368,7 +368,7 @@ class ReflectionClass implements Reflector
     public function getShortName() {}
 
     /** @return ReflectionAttribute[] */
-    public function getAttributes(?string $name = null, int $flags = 0) {}
+    public function getAttributes(?string $name = null, int $flags = 0): array {}
 }
 
 class ReflectionObject extends ReflectionClass
@@ -437,7 +437,7 @@ class ReflectionProperty implements Reflector
     public function getDefaultValue() {}
 
     /** @return ReflectionAttribute[] */
-    public function getAttributes(?string $name = null, int $flags = 0) {}
+    public function getAttributes(?string $name = null, int $flags = 0): array {}
 }
 
 class ReflectionClassConstant implements Reflector
@@ -475,7 +475,7 @@ class ReflectionClassConstant implements Reflector
     public function getDocComment() {}
 
     /** @return ReflectionAttribute[] */
-    public function getAttributes(?string $name = null, int $flags = 0) {}
+    public function getAttributes(?string $name = null, int $flags = 0): array {}
 }
 
 class ReflectionParameter implements Reflector
@@ -554,7 +554,7 @@ class ReflectionParameter implements Reflector
     public function isVariadic() {}
 
     /** @return ReflectionAttribute[] */
-    public function getAttributes(?string $name = null, int $flags = 0) {}
+    public function getAttributes(?string $name = null, int $flags = 0): array {}
 }
 
 abstract class ReflectionType implements Stringable

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -95,6 +95,9 @@ abstract class ReflectionFunctionAbstract implements Reflector
 
     /** @return ReflectionType|null */
     public function getReturnType() {}
+
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 class ReflectionFunction extends ReflectionFunctionAbstract
@@ -363,6 +366,9 @@ class ReflectionClass implements Reflector
 
     /** @return string */
     public function getShortName() {}
+
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 class ReflectionObject extends ReflectionClass
@@ -429,6 +435,9 @@ class ReflectionProperty implements Reflector
 
     /** @return mixed */
     public function getDefaultValue() {}
+
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 class ReflectionClassConstant implements Reflector
@@ -464,6 +473,9 @@ class ReflectionClassConstant implements Reflector
 
     /** @return string|false */
     public function getDocComment() {}
+
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 class ReflectionParameter implements Reflector
@@ -540,6 +552,9 @@ class ReflectionParameter implements Reflector
 
     /** @return bool */
     public function isVariadic() {}
+
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 abstract class ReflectionType implements Stringable
@@ -643,6 +658,17 @@ final class ReflectionReference
     public function getId(): string {}
 
     /** @alias ReflectionClass::__clone */
+    private function __clone() {}
+
+    private function __construct() {}
+}
+
+final class ReflectionAttribute
+{
+    public function getName(): string {}
+    public function getArguments(): array {}
+    public function newInstance(): object {}
+
     private function __clone() {}
 
     private function __construct() {}

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -57,7 +57,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionFunctionAbstract_getReturnType arginfo_class_ReflectionFunctionAbstract___clone
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionFunctionAbstract_getAttributes, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionFunctionAbstract_getAttributes, 0, 0, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -57,6 +57,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionFunctionAbstract_getReturnType arginfo_class_ReflectionFunctionAbstract___clone
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionFunctionAbstract_getAttributes, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionFunction___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
 ZEND_END_ARG_INFO()
@@ -269,6 +274,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionClass_getShortName arginfo_class_ReflectionFunctionAbstract___clone
 
+#define arginfo_class_ReflectionClass_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionObject___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, argument, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
@@ -322,6 +329,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionProperty_getDefaultValue arginfo_class_ReflectionFunctionAbstract___clone
 
+#define arginfo_class_ReflectionProperty_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
+
 #define arginfo_class_ReflectionClassConstant___clone arginfo_class_ReflectionFunctionAbstract___clone
 
 #define arginfo_class_ReflectionClassConstant___construct arginfo_class_ReflectionProperty___construct
@@ -343,6 +352,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_ReflectionClassConstant_getDeclaringClass arginfo_class_ReflectionFunctionAbstract___clone
 
 #define arginfo_class_ReflectionClassConstant_getDocComment arginfo_class_ReflectionFunctionAbstract___clone
+
+#define arginfo_class_ReflectionClassConstant_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
 
 #define arginfo_class_ReflectionParameter___clone arginfo_class_ReflectionFunctionAbstract___clone
 
@@ -388,6 +399,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_ReflectionParameter_getDefaultValueConstantName arginfo_class_ReflectionFunctionAbstract___clone
 
 #define arginfo_class_ReflectionParameter_isVariadic arginfo_class_ReflectionFunctionAbstract___clone
+
+#define arginfo_class_ReflectionParameter_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
 
 #define arginfo_class_ReflectionType___clone arginfo_class_ReflectionFunctionAbstract___clone
 
@@ -457,6 +470,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionReference___construct arginfo_class_ReflectionFunctionAbstract___clone
 
+#define arginfo_class_ReflectionAttribute_getName arginfo_class_ReflectionFunction___toString
+
+#define arginfo_class_ReflectionAttribute_getArguments arginfo_class_ReflectionUnionType_getTypes
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionAttribute_newInstance, 0, 0, IS_OBJECT, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ReflectionAttribute___clone arginfo_class_ReflectionFunctionAbstract___clone
+
+#define arginfo_class_ReflectionAttribute___construct arginfo_class_ReflectionFunctionAbstract___clone
+
 
 ZEND_METHOD(Reflection, getModifierNames);
 ZEND_METHOD(ReflectionClass, __clone);
@@ -485,6 +509,7 @@ ZEND_METHOD(ReflectionFunctionAbstract, getStaticVariables);
 ZEND_METHOD(ReflectionFunctionAbstract, returnsReference);
 ZEND_METHOD(ReflectionFunctionAbstract, hasReturnType);
 ZEND_METHOD(ReflectionFunctionAbstract, getReturnType);
+ZEND_METHOD(ReflectionFunctionAbstract, getAttributes);
 ZEND_METHOD(ReflectionFunction, __construct);
 ZEND_METHOD(ReflectionFunction, __toString);
 ZEND_METHOD(ReflectionFunction, isDisabled);
@@ -566,6 +591,7 @@ ZEND_METHOD(ReflectionClass, getExtensionName);
 ZEND_METHOD(ReflectionClass, inNamespace);
 ZEND_METHOD(ReflectionClass, getNamespaceName);
 ZEND_METHOD(ReflectionClass, getShortName);
+ZEND_METHOD(ReflectionClass, getAttributes);
 ZEND_METHOD(ReflectionObject, __construct);
 ZEND_METHOD(ReflectionProperty, __construct);
 ZEND_METHOD(ReflectionProperty, __toString);
@@ -586,6 +612,7 @@ ZEND_METHOD(ReflectionProperty, getType);
 ZEND_METHOD(ReflectionProperty, hasType);
 ZEND_METHOD(ReflectionProperty, hasDefaultValue);
 ZEND_METHOD(ReflectionProperty, getDefaultValue);
+ZEND_METHOD(ReflectionProperty, getAttributes);
 ZEND_METHOD(ReflectionClassConstant, __construct);
 ZEND_METHOD(ReflectionClassConstant, __toString);
 ZEND_METHOD(ReflectionClassConstant, getName);
@@ -596,6 +623,7 @@ ZEND_METHOD(ReflectionClassConstant, isProtected);
 ZEND_METHOD(ReflectionClassConstant, getModifiers);
 ZEND_METHOD(ReflectionClassConstant, getDeclaringClass);
 ZEND_METHOD(ReflectionClassConstant, getDocComment);
+ZEND_METHOD(ReflectionClassConstant, getAttributes);
 ZEND_METHOD(ReflectionParameter, __construct);
 ZEND_METHOD(ReflectionParameter, __toString);
 ZEND_METHOD(ReflectionParameter, getName);
@@ -616,6 +644,7 @@ ZEND_METHOD(ReflectionParameter, getDefaultValue);
 ZEND_METHOD(ReflectionParameter, isDefaultValueConstant);
 ZEND_METHOD(ReflectionParameter, getDefaultValueConstantName);
 ZEND_METHOD(ReflectionParameter, isVariadic);
+ZEND_METHOD(ReflectionParameter, getAttributes);
 ZEND_METHOD(ReflectionType, allowsNull);
 ZEND_METHOD(ReflectionType, __toString);
 ZEND_METHOD(ReflectionNamedType, getName);
@@ -644,6 +673,11 @@ ZEND_METHOD(ReflectionZendExtension, getCopyright);
 ZEND_METHOD(ReflectionReference, fromArrayElement);
 ZEND_METHOD(ReflectionReference, getId);
 ZEND_METHOD(ReflectionReference, __construct);
+ZEND_METHOD(ReflectionAttribute, getName);
+ZEND_METHOD(ReflectionAttribute, getArguments);
+ZEND_METHOD(ReflectionAttribute, newInstance);
+ZEND_METHOD(ReflectionAttribute, __clone);
+ZEND_METHOD(ReflectionAttribute, __construct);
 
 
 static const zend_function_entry class_ReflectionException_methods[] = {
@@ -689,6 +723,7 @@ static const zend_function_entry class_ReflectionFunctionAbstract_methods[] = {
 	ZEND_ME(ReflectionFunctionAbstract, returnsReference, arginfo_class_ReflectionFunctionAbstract_returnsReference, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionFunctionAbstract, hasReturnType, arginfo_class_ReflectionFunctionAbstract_hasReturnType, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionFunctionAbstract, getReturnType, arginfo_class_ReflectionFunctionAbstract_getReturnType, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionFunctionAbstract, getAttributes, arginfo_class_ReflectionFunctionAbstract_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -792,6 +827,7 @@ static const zend_function_entry class_ReflectionClass_methods[] = {
 	ZEND_ME(ReflectionClass, inNamespace, arginfo_class_ReflectionClass_inNamespace, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClass, getNamespaceName, arginfo_class_ReflectionClass_getNamespaceName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClass, getShortName, arginfo_class_ReflectionClass_getShortName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionClass, getAttributes, arginfo_class_ReflectionClass_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -823,6 +859,7 @@ static const zend_function_entry class_ReflectionProperty_methods[] = {
 	ZEND_ME(ReflectionProperty, hasType, arginfo_class_ReflectionProperty_hasType, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, hasDefaultValue, arginfo_class_ReflectionProperty_hasDefaultValue, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, getDefaultValue, arginfo_class_ReflectionProperty_getDefaultValue, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionProperty, getAttributes, arginfo_class_ReflectionProperty_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -839,6 +876,7 @@ static const zend_function_entry class_ReflectionClassConstant_methods[] = {
 	ZEND_ME(ReflectionClassConstant, getModifiers, arginfo_class_ReflectionClassConstant_getModifiers, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, getDeclaringClass, arginfo_class_ReflectionClassConstant_getDeclaringClass, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, getDocComment, arginfo_class_ReflectionClassConstant_getDocComment, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionClassConstant, getAttributes, arginfo_class_ReflectionClassConstant_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -865,6 +903,7 @@ static const zend_function_entry class_ReflectionParameter_methods[] = {
 	ZEND_ME(ReflectionParameter, isDefaultValueConstant, arginfo_class_ReflectionParameter_isDefaultValueConstant, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionParameter, getDefaultValueConstantName, arginfo_class_ReflectionParameter_getDefaultValueConstantName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionParameter, isVariadic, arginfo_class_ReflectionParameter_isVariadic, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionParameter, getAttributes, arginfo_class_ReflectionParameter_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -927,5 +966,15 @@ static const zend_function_entry class_ReflectionReference_methods[] = {
 	ZEND_ME(ReflectionReference, getId, arginfo_class_ReflectionReference_getId, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(ReflectionClass, __clone, __clone, arginfo_class_ReflectionReference___clone, ZEND_ACC_PRIVATE)
 	ZEND_ME(ReflectionReference, __construct, arginfo_class_ReflectionReference___construct, ZEND_ACC_PRIVATE)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ReflectionAttribute_methods[] = {
+	ZEND_ME(ReflectionAttribute, getName, arginfo_class_ReflectionAttribute_getName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionAttribute, getArguments, arginfo_class_ReflectionAttribute_getArguments, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionAttribute, newInstance, arginfo_class_ReflectionAttribute_newInstance, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionAttribute, __clone, arginfo_class_ReflectionAttribute___clone, ZEND_ACC_PRIVATE)
+	ZEND_ME(ReflectionAttribute, __construct, arginfo_class_ReflectionAttribute___construct, ZEND_ACC_PRIVATE)
 	ZEND_FE_END
 };

--- a/ext/reflection/tests/ReflectionClass_toString_001.phpt
+++ b/ext/reflection/tests/ReflectionClass_toString_001.phpt
@@ -372,6 +372,7 @@ Class [ <internal:Reflection> class ReflectionClass implements Reflector, String
         Parameter #0 [ <optional> ?string $name = null ]
         Parameter #1 [ <optional> int $flags = 0 ]
       }
+      - Return [ array ]
     }
   }
 }

--- a/ext/reflection/tests/ReflectionClass_toString_001.phpt
+++ b/ext/reflection/tests/ReflectionClass_toString_001.phpt
@@ -27,7 +27,7 @@ Class [ <internal:Reflection> class ReflectionClass implements Reflector, String
     Property [ public $name = '' ]
   }
 
-  - Methods [53] {
+  - Methods [54] {
     Method [ <internal:Reflection> final private method __clone ] {
 
       - Parameters [0] {
@@ -363,6 +363,14 @@ Class [ <internal:Reflection> class ReflectionClass implements Reflector, String
     Method [ <internal:Reflection> public method getShortName ] {
 
       - Parameters [0] {
+      }
+    }
+
+    Method [ <internal:Reflection> public method getAttributes ] {
+
+      - Parameters [2] {
+        Parameter #0 [ <optional> ?string $name = null ]
+        Parameter #1 [ <optional> int $flags = 0 ]
       }
     }
   }

--- a/ext/reflection/tests/ReflectionExtension_getClasses_basic.phpt
+++ b/ext/reflection/tests/ReflectionExtension_getClasses_basic.phpt
@@ -8,7 +8,7 @@ $ext = new ReflectionExtension('reflection');
 var_dump($ext->getClasses());
 ?>
 --EXPECT--
-array(18) {
+array(19) {
   ["ReflectionException"]=>
   object(ReflectionClass)#2 (1) {
     ["name"]=>
@@ -98,5 +98,10 @@ array(18) {
   object(ReflectionClass)#19 (1) {
     ["name"]=>
     string(19) "ReflectionReference"
+  }
+  ["ReflectionAttribute"]=>
+  object(ReflectionClass)#20 (1) {
+    ["name"]=>
+    string(19) "ReflectionAttribute"
   }
 }

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -266,22 +266,22 @@ PHP_MINIT_FUNCTION(tokenizer)
 	zend_class_implements(php_token_ce, 1, zend_ce_stringable);
 
 	name = zend_string_init("id", sizeof("id") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(name);
 
 	name = zend_string_init("text", sizeof("text") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(name);
 
 	name = zend_string_init("line", sizeof("line") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(name);
 
 	name = zend_string_init("pos", sizeof("pos") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(name);
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -23,11 +23,13 @@
 #include "ext/standard/info.h"
 #include "php_test.h"
 #include "test_arginfo.h"
+#include "zend_attributes.h"
 
 static zend_class_entry *zend_test_interface;
 static zend_class_entry *zend_test_class;
 static zend_class_entry *zend_test_child_class;
 static zend_class_entry *zend_test_trait;
+static zend_class_entry *zend_test_attribute;
 static zend_object_handlers zend_test_class_handlers;
 
 ZEND_FUNCTION(zend_test_func)
@@ -181,6 +183,13 @@ static zend_function *zend_test_class_static_method_get(zend_class_entry *ce, ze
 }
 /* }}} */
 
+void zend_attribute_validate_zendtestattribute(zend_attribute *attr, int target)
+{
+	if (target != ZEND_ATTRIBUTE_TARGET_CLASS) {
+		zend_error(E_COMPILE_ERROR, "Only classes can be marked with <<ZendTestAttribute>>");
+	}
+}
+
 ZEND_METHOD(_ZendTestClass, __toString) /* {{{ */ {
 	RETURN_EMPTY_STRING();
 }
@@ -217,7 +226,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zval val;
 		ZVAL_LONG(&val, 123);
 		zend_declare_typed_property(
-			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL,
+			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, NULL,
 			(zend_type) ZEND_TYPE_INIT_CODE(IS_LONG, 0, 0));
 		zend_string_release(name);
 	}
@@ -228,7 +237,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zval val;
 		ZVAL_NULL(&val);
 		zend_declare_typed_property(
-			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL,
+			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, NULL,
 			(zend_type) ZEND_TYPE_INIT_CLASS(class_name, 1, 0));
 		zend_string_release(name);
 	}
@@ -244,7 +253,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zend_type type = ZEND_TYPE_INIT_PTR(type_list, _ZEND_TYPE_LIST_BIT, 1, 0);
 		zval val;
 		ZVAL_NULL(&val);
-		zend_declare_typed_property(zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, type);
+		zend_declare_typed_property(zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, NULL, type);
 		zend_string_release(name);
 	}
 
@@ -253,7 +262,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zval val;
 		ZVAL_LONG(&val, 123);
 		zend_declare_typed_property(
-			zend_test_class, name, &val, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC, NULL,
+			zend_test_class, name, &val, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC, NULL, NULL,
 			(zend_type) ZEND_TYPE_INIT_CODE(IS_LONG, 0, 0));
 		zend_string_release(name);
 	}
@@ -272,6 +281,12 @@ PHP_MINIT_FUNCTION(zend_test)
 	zend_register_class_alias("_ZendTestClassAlias", zend_test_class);
 
 	REGISTER_LONG_CONSTANT("ZEND_TEST_DEPRECATED", 42, CONST_PERSISTENT | CONST_DEPRECATED);
+
+	INIT_CLASS_ENTRY(class_entry, "ZendTestAttribute", NULL);
+	zend_test_attribute = zend_register_internal_class(&class_entry);
+	zend_test_attribute->ce_flags |= ZEND_ACC_FINAL;
+
+	zend_compiler_attribute_register(zend_test_attribute, zend_attribute_validate_zendtestattribute);
 	return SUCCESS;
 }
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -819,7 +819,7 @@ static void php_zip_register_prop_handler(HashTable *prop_handler, char *name, z
 
 	/* Register for reflection */
 	ZVAL_NULL(&tmp);
-	zend_declare_property_ex(zip_class_entry, str, &tmp, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_property_ex(zip_class_entry, str, &tmp, ZEND_ACC_PUBLIC, NULL, NULL);
 	zend_string_release_ex(str, 1);
 }
 /* }}} */

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -231,7 +231,7 @@ ADD_SOURCES("Zend", "zend_language_parser.c zend_language_scanner.c \
 	zend_execute_API.c zend_highlight.c \
 	zend_llist.c zend_vm_opcodes.c zend_opcode.c zend_operators.c zend_ptr_stack.c \
 	zend_stack.c zend_variables.c zend.c zend_API.c zend_extensions.c \
-	zend_hash.c zend_list.c zend_builtin_functions.c \
+	zend_hash.c zend_list.c zend_builtin_functions.c zend_attributes.c \
 	zend_ini.c zend_sort.c zend_multibyte.c zend_ts_hash.c \
 	zend_stream.c zend_iterators.c zend_interfaces.c zend_objects.c \
 	zend_object_handlers.c zend_objects_API.c \


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/attributes_v2

References:
- PR with alternative smiley syntax `@:`: https://github.com/kooldev/php-src/pull/2
- Example for `Opcache\Jit` attribute: https://github.com/beberlei/php-src/pull/7