### PR TITLE
Add support for Namespace in stub files

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -601,7 +601,9 @@ class MethodInfo extends AbstractFunction {
 
         $name = $this->alias ?? $this->name;
 
-        if ($name instanceof AliasInterface) {
+        if ($name instanceof FunctionAlias) {
+            return sprintf("ZEND_FUNCTION(%s);\n", $name->getFullyQualifiedName());
+        } elseif ($name instanceof MethodAlias) {
             return null;
         }
 

--- a/build/gen_stub_test.php
+++ b/build/gen_stub_test.php
@@ -1,0 +1,53 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+if($argc < 3) {
+    echo "Usage: $argv[0] new original\n";
+    exit(1);
+}
+
+if (!is_dir($argv[1]) ) {
+    echo "$argv[1] is not a directory.\n";
+    exit(1);
+}
+
+if (!is_dir($argv[2])) {
+    echo "$argv[2] is not a directory.\n";
+    exit(1);
+}
+
+$path1 = realpath($argv[1]);
+$path2 = realpath($argv[2]);
+
+$dir1 = glob($path1 . DIRECTORY_SEPARATOR. '*_arginfo.h');
+$dir2 = glob($path2 . DIRECTORY_SEPARATOR. '*_arginfo.h');
+
+$files1 = [];
+$files2 = [];
+
+array_walk($dir1, function (&$file) use (&$files1){
+    $file = pathinfo($file);
+    $files1[$file['basename']] = $file['dirname'];
+});
+
+array_walk($dir2, function (&$file) use (&$files2){
+    $file = pathinfo($file);
+    $files2[$file['basename']] = $file['dirname'];
+});
+
+foreach ($files1 as $filename => $path) {
+
+    if (!isset($files2[$filename])) {
+        echo "\e[0;31m${filename}\e[0m not exists in ${path2}";
+        continue;
+    }
+
+    exec(sprintf('diff %s %s', $path.DIRECTORY_SEPARATOR.$filename, $path2.DIRECTORY_SEPARATOR.$filename), $output, $ret);
+    if ($ret !== 0) {
+        echo "\e[1;33m${filename}\e[0m not equal".PHP_EOL;
+        array_walk($output, function (&$line) { $line = "\t".$line; });
+        echo "\e[1;37m" . join(PHP_EOL, $output)."\e[0m".PHP_EOL;
+    }
+}
+
+?>

--- a/build/gen_stub_test.php
+++ b/build/gen_stub_test.php
@@ -2,7 +2,7 @@
 <?php declare(strict_types=1);
 
 if($argc < 3) {
-    echo "Usage: $argv[0] new original\n";
+    echo "Usage: $argv[0] original new\n";
     exit(1);
 }
 
@@ -45,7 +45,10 @@ foreach ($files1 as $filename => $path) {
     exec(sprintf('diff %s %s', $path.DIRECTORY_SEPARATOR.$filename, $path2.DIRECTORY_SEPARATOR.$filename), $output, $ret);
     if ($ret !== 0) {
         echo "\e[1;33m${filename}\e[0m not equal".PHP_EOL;
-        array_walk($output, function (&$line) { $line = "\t".$line; });
+        array_walk($output, function (&$line) {
+            $color = (substr($line, 0, 1) == '<')? "0;32":"0;31";
+            $line = "\t\e[${color}m${line}\e[0m";
+        });
         echo "\e[1;37m" . join(PHP_EOL, $output)."\e[0m".PHP_EOL;
     }
 }

--- a/build/gen_stub_test.php
+++ b/build/gen_stub_test.php
@@ -38,7 +38,7 @@ array_walk($dir2, function (&$file) use (&$files2){
 foreach ($files1 as $filename => $path) {
 
     if (!isset($files2[$filename])) {
-        echo "\e[0;31m${filename}\e[0m not exists in ${path2}";
+        echo "\e[0;31m${filename}\e[0m not exists in ${path2}".PHP_EOL;
         continue;
     }
 

--- a/build/namespace_test.stub.php
+++ b/build/namespace_test.stub.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @generate-function-entries
+ */
+
+namespace NSMrSpoocy {
+
+    interface InterfaceInNamespace
+    {
+        /** @return int */
+        public function interfaceMethod(): int;
+
+        public static function staticInterfaceMethod(string $packet): void;
+    }
+
+    function functionInNamespace(): void  {
+
+    }
+
+    /**
+     * @deprecated
+     */
+    function deprecatedFunctionInNamespace(): void  {
+
+    }
+
+    class ClassInNamespace {
+
+        public function classMethodInNamespace(): string {}
+
+        /**
+         * @return bool
+         * @deprecated
+         */
+        public function deprecatedClassMethodInNamespace(): string {}
+    }
+}
+
+namespace {
+
+    function functionInGlobalNamespace(): void  {
+
+    }
+
+    /**
+     * @return bool
+     * @deprecated
+     */
+    function deprecatedFunctionInGlobalNamespace(): bool {}
+
+    class ClassInGlobalNamespace {
+
+        public function classMethodInGlobalNamespace(): void {}
+
+        public function classMethodInGlobalNamespaceWithParam(): bool {}
+    }
+
+}
+
+namespace NSMrSpoocy\NSAnother {
+
+
+    class NestedNamespaceClass
+    {
+
+        public function classMethodInNestedNamespace(): bool {}
+    }
+
+    function functionInNestedNamespace(): bool {}
+
+    function functionInNestedNamespaceWithParam(string $param): bool {}
+}
+
+?>

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -457,7 +457,6 @@ ZEND_END_ARG_INFO()
 
 
 ZEND_METHOD(Reflection, getModifierNames);
-ZEND_METHOD(ReflectionClass, __clone);
 ZEND_METHOD(ReflectionFunctionAbstract, inNamespace);
 ZEND_METHOD(ReflectionFunctionAbstract, isClosure);
 ZEND_METHOD(ReflectionFunctionAbstract, isDeprecated);
@@ -513,6 +512,7 @@ ZEND_METHOD(ReflectionMethod, invokeArgs);
 ZEND_METHOD(ReflectionMethod, getDeclaringClass);
 ZEND_METHOD(ReflectionMethod, getPrototype);
 ZEND_METHOD(ReflectionMethod, setAccessible);
+ZEND_METHOD(ReflectionClass, __clone);
 ZEND_METHOD(ReflectionClass, __construct);
 ZEND_METHOD(ReflectionClass, __toString);
 ZEND_METHOD(ReflectionClass, getName);


### PR DESCRIPTION
Dear PHP developers

With this pull reuqest, `gen_stub.php` now also supports namespaces.
It is completely rewritten and still supports php7.1. So that the pull can be merged faster, I have added the test file `gen_stub_test.php`.

I have already compared **all _arginfo.h** after rebuilding with the one from the repository.
~There is currently only 1 error. In the file  `php_reflection_arginfo.h` the declaration `ZEND_METHOD(ReflectionClass, __clone);` is missing. I'm trying to find the problem and solve it. Maybe you can help to figure out the problem.~

`namespace_test.stub.php` shows how to use namespaces and its also used for my test.

@kocsismate @nikic @TysonAndre @remicollet convince yourself with the help of gen_stub_test.php, that it only comes to the one error and can be merged as fast as possible.

MrSpoocy