### PR TITLE
Skip uninitialized typed properties when serializing objects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug #78434 (Generator yields no items after valid() call). (Nikita)
   . Fixed bug #79477 (casting object into array creates references). (Nikita)
+  . Fixed bug #79447 (Serializing uninitialized typed properties with __sleep should not throw). (nicolas-grekas)
 
 - DOM:
   . Fixed bug #78221 (DOMNode::normalize() doesn't remove empty text nodes).

--- a/ext/standard/tests/serialize/sleep_uninitialized_typed_prop.phpt
+++ b/ext/standard/tests/serialize/sleep_uninitialized_typed_prop.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Referencing an uninitialized typed property in __sleep() should result in Error
+Referencing an uninitialized typed property in __sleep() should be skipped
 --FILE--
 <?php
 
@@ -18,39 +18,27 @@ class Test {
 }
 
 $t = new Test;
-try {
-    serialize($t);
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
+var_dump(serialize($t));
+var_dump(unserialize(serialize($t)) == $t);
 
 $t->x = 1;
-try {
-    serialize($t);
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
+var_dump(unserialize(serialize($t)) == $t);
 
 $t->y = 2;
-try {
-    serialize($t);
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
+var_dump(unserialize(serialize($t)) == $t);
 
 $t->z = 3;
-try {
-    var_dump(unserialize(serialize($t)));
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
+var_dump(unserialize(serialize($t)) == $t);
 
+var_dump($t);
 ?>
 --EXPECT--
-Typed property Test::$x must not be accessed before initialization (in __sleep)
-Typed property Test::$y must not be accessed before initialization (in __sleep)
-Typed property Test::$z must not be accessed before initialization (in __sleep)
-object(Test)#3 (3) {
+string(15) "O:4:"Test":0:{}"
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+object(Test)#1 (3) {
   ["x"]=>
   int(1)
   ["y":protected]=>

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -784,9 +784,7 @@ static int php_var_serialize_try_add_sleep_prop(
 		if (Z_TYPE_P(val) == IS_UNDEF) {
 			zend_property_info *info = zend_get_typed_property_info_for_slot(Z_OBJ_P(struc), val);
 			if (info) {
-				zend_throw_error(NULL,
-					"Typed property %s::$%s must not be accessed before initialization (in __sleep)",
-					ZSTR_VAL(Z_OBJCE_P(struc)->name), ZSTR_VAL(error_name));
+				return SUCCESS;
 			}
 			return FAILURE;
 		}


### PR DESCRIPTION
Partially reverts 846b6479537a112d1ded725e6484e46462048b35: instead of throwing, this skips uninitialized typed properties when serializing objects.

This preserves the `unserialize(serialize($obj)) == $obj` identity.

Fixes bug https://bugs.php.net/79447