### PR TITLE
Fix #71263: fread() does not report bzip2.decompress errors

### DIFF
--- a/ext/bz2/bz2_filter.c
+++ b/ext/bz2/bz2_filter.c
@@ -123,6 +123,7 @@ static php_stream_filter_status_t php_bz2_decompress_filter(
 				}
 			} else if (status != BZ_OK) {
 				/* Something bad happened */
+				php_error_docref(NULL, E_NOTICE, "bzip2 decompression failed");
 				php_stream_bucket_delref(bucket);
 				return PSFS_ERR_FATAL;
 			}

--- a/ext/bz2/tests/bug71263.phpt
+++ b/ext/bz2/tests/bug71263.phpt
@@ -1,11 +1,9 @@
 --TEST--
-Bug #71263: fread() does not detects decoding errors from filter bzip2.decompress
+Bug #71263: fread() does not report bzip2.decompress errors
 --SKIPIF--
 <?php if (!extension_loaded("bz2")) print "skip bz2 extension not loaded"; ?>
 --FILE--
 <?php
-
-// Should notices be generated?
 
 function test($case) {
     $plain = "The quick brown fox jumps over the lazy dog.";
@@ -46,10 +44,14 @@ test(1);
 test(2);
 test(3);
 ?>
---EXPECT--
+--EXPECTF--
 Compressed len = 81
+
+Notice: fread(): bzip2 decompression failed in %s on line %d
 read: bool(false)
 Compressed len = 81
 read: string(0) ""
 Compressed len = 81
+
+Notice: fread(): bzip2 decompression failed in %s on line %d
 read: bool(false)


### PR DESCRIPTION
If the bzip2.decompress filter fails to decompress the stream, we raise
a notice instead of failing silently.

---

@nikic, since you already had added bug71263.phpt, what do you think about raising a notice here? If we do that, we should also raise a respective notice for the zlib.inflate filter.