### PR TITLE
Fix #71417: fread() does not report zlib.inflate errors

### DIFF
--- a/ext/standard/tests/filters/filter_errors_zlib_inflate.phpt
+++ b/ext/standard/tests/filters/filter_errors_zlib_inflate.phpt
@@ -10,5 +10,9 @@ filter_errors_test('zlib.inflate', gzencode('42'));
 --EXPECTF--
 test filtering of buffered data
 
+Notice: stream_filter_append(): zlib: data error in %s on line %d
+
 Warning: stream_filter_append(): Filter failed to process pre-buffered data in %s
 test filtering of non buffered data
+
+Notice: stream_get_contents(): zlib: data error in %s on line %d

--- a/ext/zlib/tests/bug71417.phpt
+++ b/ext/zlib/tests/bug71417.phpt
@@ -70,7 +70,7 @@ gzdecode():
 Warning: gzdecode(): data error in %s on line %d
 
 
-Notice: fread(): zlib inflate failed in %s on line %d
+Notice: fread(): zlib: data error in %s on line %d
 read: bool(false)
 gzdecode(): 
 Warning: gzdecode(): data error in %s on line %d
@@ -80,11 +80,11 @@ gzdecode():
 Warning: gzdecode(): data error in %s on line %d
 
 
-Notice: fread(): zlib inflate failed in %s on line %d
+Notice: fread(): zlib: data error in %s on line %d
 read: bool(false)
 gzdecode(): 
 Warning: gzdecode(): data error in %s on line %d
 
 
-Notice: fread(): zlib inflate failed in %s on line %d
+Notice: fread(): zlib: data error in %s on line %d
 read: bool(false)

--- a/ext/zlib/tests/bug71417.phpt
+++ b/ext/zlib/tests/bug71417.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #71417: fread() does not detect decoding errors from filter zlib.inflate
+Bug #71417: fread() does not report zlib.inflate errors
 --SKIPIF--
 <?php if (!extension_loaded('zlib')) die ('skip zlib extension not available in this build'); ?>
 --FILE--
@@ -69,6 +69,8 @@ test(4);
 gzdecode(): 
 Warning: gzdecode(): data error in %s on line %d
 
+
+Notice: fread(): zlib inflate failed in %s on line %d
 read: bool(false)
 gzdecode(): 
 Warning: gzdecode(): data error in %s on line %d
@@ -77,8 +79,12 @@ read: string(32) "The quick brown fox jumps over t"
 gzdecode(): 
 Warning: gzdecode(): data error in %s on line %d
 
+
+Notice: fread(): zlib inflate failed in %s on line %d
 read: bool(false)
 gzdecode(): 
 Warning: gzdecode(): data error in %s on line %d
 
+
+Notice: fread(): zlib inflate failed in %s on line %d
 read: bool(false)

--- a/ext/zlib/tests/bug_52944.phpt
+++ b/ext/zlib/tests/bug_52944.phpt
@@ -20,7 +20,7 @@ fclose($fp);
 echo "Done.\n";
 ?>
 --EXPECTF--
-Notice: fread(): zlib inflate failed in %s on line %d
+Notice: fread(): zlib: data error in %s on line %d
 bool(false)
 string(0) ""
 Done.

--- a/ext/zlib/tests/bug_52944.phpt
+++ b/ext/zlib/tests/bug_52944.phpt
@@ -18,7 +18,9 @@ var_dump(fread($fp,1));
 var_dump(fread($fp,1));
 fclose($fp);
 echo "Done.\n";
---EXPECT--
+?>
+--EXPECTF--
+Notice: fread(): zlib inflate failed in %s on line %d
 bool(false)
 string(0) ""
 Done.

--- a/ext/zlib/tests/zlib_filter_inflate2.phpt
+++ b/ext/zlib/tests/zlib_filter_inflate2.phpt
@@ -34,7 +34,7 @@ fclose($fp);
 @unlink(__DIR__ . '/test.txt.gz');
 ?>
 --EXPECTF--
-Notice: fread(): zlib inflate failed in %s on line %d
+Notice: fread(): zlib: data error in %s on line %d
 1
 2
 This is quite the thing ain't it

--- a/ext/zlib/tests/zlib_filter_inflate2.phpt
+++ b/ext/zlib/tests/zlib_filter_inflate2.phpt
@@ -33,7 +33,8 @@ fclose($fp);
 <?php
 @unlink(__DIR__ . '/test.txt.gz');
 ?>
---EXPECT--
+--EXPECTF--
+Notice: fread(): zlib inflate failed in %s on line %d
 1
 2
 This is quite the thing ain't it

--- a/ext/zlib/zlib_filter.c
+++ b/ext/zlib/zlib_filter.c
@@ -90,6 +90,7 @@ static php_stream_filter_status_t php_zlib_inflate_filter(
 				exit_status = PSFS_PASS_ON;
 			} else if (status != Z_OK) {
 				/* Something bad happened */
+				php_error_docref(NULL, E_NOTICE, "zlib inflate failed");
 				php_stream_bucket_delref(bucket);
 				/* reset these because despite the error the filter may be used again */
 				data->strm.next_in = data->inbuf;

--- a/ext/zlib/zlib_filter.c
+++ b/ext/zlib/zlib_filter.c
@@ -90,7 +90,7 @@ static php_stream_filter_status_t php_zlib_inflate_filter(
 				exit_status = PSFS_PASS_ON;
 			} else if (status != Z_OK) {
 				/* Something bad happened */
-				php_error_docref(NULL, E_NOTICE, "zlib inflate failed");
+				php_error_docref(NULL, E_NOTICE, "zlib: %s", zError(status));
 				php_stream_bucket_delref(bucket);
 				/* reset these because despite the error the filter may be used again */
 				data->strm.next_in = data->inbuf;


### PR DESCRIPTION
If the zlib.inflate filter fails to decompress the stream, we raise a
notice instead of failing silently.

--- 

This is basically the same as PR #5406, but there has been a separate bug report.