### PR TITLE
Use make to detect when to regen the VM files

### DIFF
--- a/Zend/Makefile.frag
+++ b/Zend/Makefile.frag
@@ -34,4 +34,16 @@ $(srcdir)/zend_ini_scanner.c: $(srcdir)/zend_ini_scanner.l
 
 $(builddir)/zend_highlight.lo $(builddir)/zend_compile.lo: $(srcdir)/zend_language_parser.h
 
+$(srcdir)/zend_vm_execute.h $(srcdir)/zend_vm_opcodes.h $(srcdir)/zend_vm_opcodes.c: vm.gen.intermediate ;
+
+.INTERMEDIATE: vm.gen.intermediate
+vm.gen.intermediate: $(srcdir)/zend_vm_def.h $(srcdir)/zend_vm_execute.skl $(srcdir)/zend_vm_gen.php
+	@if test ! -z "$(PHP_EXECUTABLE)" && test -x "$(PHP_EXECUTABLE)"; then \
+		$(PHP_EXECUTABLE) $(srcdir)/zend_vm_gen.php; \
+	elif type php >/dev/null 2>/dev/null; then \
+		if test `php -v | head -n1 | cut -d" " -f 2 | sed "s/$$/\n7.0.99/" | sort -rV | head -n1` != "7.0.99"; then \
+			php $(srcdir)/zend_vm_gen.php; \
+		fi; \
+	fi;
+
 Zend/zend_execute.lo: $(srcdir)/zend_vm_execute.h $(srcdir)/zend_vm_opcodes.h

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -43,8 +43,9 @@ const HEADER_TEXT = <<< DATA
 DATA;
 
 /*
-    This script creates zend_vm_execute.h and zend_vm_opcodes.h
-    from existing zend_vm_def.h and zend_vm_execute.skl
+    This script creates zend_vm_execute.h, zend_vm_opcodes.h
+    and zend_vm_opcodes.c from existing zend_vm_def.h and 
+    zend_vm_execute.skl
 */
 
 error_reporting(E_ALL);


### PR DESCRIPTION
To make it a nicer developer experience, these targets ensure that the `zend_vm_gen.php` script is called if there are any changes to `zend_vm_def.h`, `zend_vm_execute.skl` or `zend_vm_gen.php`