### PR TITLE
Make `ReflectionProperty` and `ReflectionMethod` access `private`/`protected` symbols by default

### DIFF
--- a/Zend/tests/bug63762.phpt
+++ b/Zend/tests/bug63762.phpt
@@ -5,7 +5,6 @@ Bug #63762 - Sigsegv when Exception::$trace is changed by user
 $e = new Exception();
 
 $ref = new ReflectionProperty($e, 'trace');
-$ref->setAccessible(TRUE);
 
 echo "Array of NULL:\n";
 $ref->setValue($e, array(NULL));

--- a/Zend/tests/bug72177.phpt
+++ b/Zend/tests/bug72177.phpt
@@ -21,7 +21,6 @@ class Parnt
         $this->child = new Child();
 
         $prop = new \ReflectionProperty($this, 'child');
-        $prop->setAccessible(true);
         $prop->setValue($this, null);
     }
 }

--- a/Zend/tests/bug72177_2.phpt
+++ b/Zend/tests/bug72177_2.phpt
@@ -27,7 +27,6 @@ class Bar extends Foo
 
 $r = new ReflectionProperty(Foo::class, 'bar');
 
-$r->setAccessible(true);
 echo "OK\n";
 ?>
 --EXPECT--

--- a/Zend/tests/bug78921.phpt
+++ b/Zend/tests/bug78921.phpt
@@ -27,7 +27,6 @@ class OtherClass
 
 $reflectionClass = new ReflectionClass('OtherClass');
 $reflectionProperty = $reflectionClass->getProperty('prop');
-$reflectionProperty->setAccessible(true);
 $value = $reflectionProperty->getValue();
 echo "Value is $value\n";
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1259,7 +1259,7 @@ static void reflection_property_factory(zend_class_entry *ce, zend_string *name,
 	intern->ptr = reference;
 	intern->ref_type = REF_TYPE_PROPERTY;
 	intern->ce = ce;
-	intern->ignore_visibility = 0;
+	intern->ignore_visibility = 1;
 	ZVAL_STR_COPY(reflection_prop_name(object), name);
 	ZVAL_STR_COPY(reflection_prop_class(object), prop ? prop->ce->name : ce->name);
 }
@@ -1282,7 +1282,7 @@ static void reflection_class_constant_factory(zend_string *name_str, zend_class_
 	intern->ptr = constant;
 	intern->ref_type = REF_TYPE_CLASS_CONSTANT;
 	intern->ce = constant->ce;
-	intern->ignore_visibility = 0;
+	intern->ignore_visibility = 1;
 
 	ZVAL_STR_COPY(reflection_prop_name(object), name_str);
 	ZVAL_STR_COPY(reflection_prop_class(object), constant->ce->name);
@@ -3472,7 +3472,7 @@ ZEND_METHOD(ReflectionClassConstant, __construct)
 	intern->ptr = constant;
 	intern->ref_type = REF_TYPE_CLASS_CONSTANT;
 	intern->ce = constant->ce;
-	intern->ignore_visibility = 0;
+	intern->ignore_visibility = 1;
 	ZVAL_STR_COPY(reflection_prop_name(object), constname);
 	ZVAL_STR_COPY(reflection_prop_class(object), constant->ce->name);
 }
@@ -5188,7 +5188,7 @@ ZEND_METHOD(ReflectionProperty, __construct)
 	intern->ptr = reference;
 	intern->ref_type = REF_TYPE_PROPERTY;
 	intern->ce = ce;
-	intern->ignore_visibility = 0;
+	intern->ignore_visibility = 1;
 }
 /* }}} */
 

--- a/ext/reflection/tests/ReflectionMethod_invoke_on_abstract_method_after_setAccessible.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invoke_on_abstract_method_after_setAccessible.phpt
@@ -1,5 +1,5 @@
 --TEST--
-ReflectionMethod::invoke() on an abstract method should fail even after calling setAccessible(true)
+ReflectionMethod::invoke() on an abstract method should fail
 --FILE--
 <?php
 
@@ -8,7 +8,6 @@ abstract class Test {
 }
 
 $rm = new ReflectionMethod('Test', 'foo');
-$rm->setAccessible(true);
 try {
     var_dump($rm->invoke(null));
 } catch (ReflectionException $e) {

--- a/ext/reflection/tests/ReflectionMethod_setAccessible.phpt
+++ b/ext/reflection/tests/ReflectionMethod_setAccessible.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test ReflectionMethod::setAccessible().
+Test ReflectionMethod::setAccessible()
 --FILE--
 <?php
 class A {
@@ -13,6 +13,20 @@ $private         = new ReflectionMethod('A', 'aPrivate');
 $privateStatic   = new ReflectionMethod('A', 'aPrivateStatic');
 $protected       = new ReflectionMethod('A', 'aProtected');
 $protectedStatic = new ReflectionMethod('A', 'aProtectedStatic');
+
+$private->invoke(new A, NULL);
+$private->invokeArgs(new A, array(NULL));
+$privateStatic->invoke(NULL, NULL);
+$privateStatic->invokeArgs(NULL, array(NULL));
+$protected->invoke(new A, NULL);
+$protected->invokeArgs(new A, array(NULL));
+$protectedStatic->invoke(NULL, NULL);
+$protectedStatic->invokeArgs(NULL, array(NULL));
+
+$private->setAccessible(FALSE);
+$privateStatic->setAccessible(FALSE);
+$protected->setAccessible(FALSE);
+$protectedStatic->setAccessible(FALSE);
 
 try {
     $private->invoke(new A, NULL);
@@ -77,30 +91,8 @@ try {
 catch (ReflectionException $e) {
     var_dump($e->getMessage());
 }
-
-$private->setAccessible(TRUE);
-$privateStatic->setAccessible(TRUE);
-$protected->setAccessible(TRUE);
-$protectedStatic->setAccessible(TRUE);
-
-$private->invoke(new A, NULL);
-$private->invokeArgs(new A, array(NULL));
-$privateStatic->invoke(NULL, NULL);
-$privateStatic->invokeArgs(NULL, array(NULL));
-$protected->invoke(new A, NULL);
-$protected->invokeArgs(new A, array(NULL));
-$protectedStatic->invoke(NULL, NULL);
-$protectedStatic->invokeArgs(NULL, array(NULL));
 ?>
 --EXPECT--
-string(73) "Trying to invoke private method A::aPrivate() from scope ReflectionMethod"
-string(73) "Trying to invoke private method A::aPrivate() from scope ReflectionMethod"
-string(79) "Trying to invoke private method A::aPrivateStatic() from scope ReflectionMethod"
-string(79) "Trying to invoke private method A::aPrivateStatic() from scope ReflectionMethod"
-string(77) "Trying to invoke protected method A::aProtected() from scope ReflectionMethod"
-string(77) "Trying to invoke protected method A::aProtected() from scope ReflectionMethod"
-string(83) "Trying to invoke protected method A::aProtectedStatic() from scope ReflectionMethod"
-string(83) "Trying to invoke protected method A::aProtectedStatic() from scope ReflectionMethod"
 A::aPrivate
 A::aPrivate
 A::aPrivateStatic
@@ -109,3 +101,11 @@ A::aProtected
 A::aProtected
 A::aProtectedStatic
 A::aProtectedStatic
+string(73) "Trying to invoke private method A::aPrivate() from scope ReflectionMethod"
+string(73) "Trying to invoke private method A::aPrivate() from scope ReflectionMethod"
+string(79) "Trying to invoke private method A::aPrivateStatic() from scope ReflectionMethod"
+string(79) "Trying to invoke private method A::aPrivateStatic() from scope ReflectionMethod"
+string(77) "Trying to invoke protected method A::aProtected() from scope ReflectionMethod"
+string(77) "Trying to invoke protected method A::aProtected() from scope ReflectionMethod"
+string(83) "Trying to invoke protected method A::aProtectedStatic() from scope ReflectionMethod"
+string(83) "Trying to invoke protected method A::aProtectedStatic() from scope ReflectionMethod"

--- a/ext/reflection/tests/ReflectionProperty_isInitialized.phpt
+++ b/ext/reflection/tests/ReflectionProperty_isInitialized.phpt
@@ -49,7 +49,6 @@ try {
 } catch (ReflectionException $e) {
     echo $e->getMessage(), "\n";
 }
-$rp->setAccessible(true);
 var_dump($rp->isInitialized($a));
 
 echo "Object type:\n";

--- a/ext/reflection/tests/ReflectionProperty_setAccessible.phpt
+++ b/ext/reflection/tests/ReflectionProperty_setAccessible.phpt
@@ -17,6 +17,26 @@ $protectedStatic = new ReflectionProperty('A', 'protectedStatic');
 $private         = new ReflectionProperty($a, 'private');
 $privateStatic   = new ReflectionProperty('A', 'privateStatic');
 
+var_dump($protected->getValue($a));
+var_dump($protectedStatic->getValue());
+var_dump($private->getValue($a));
+var_dump($privateStatic->getValue());
+
+$protected->setValue($a, 'e');
+$protectedStatic->setValue('f');
+$private->setValue($a, 'g');
+$privateStatic->setValue('h');
+
+var_dump($protected->getValue($a));
+var_dump($protectedStatic->getValue());
+var_dump($private->getValue($a));
+var_dump($privateStatic->getValue());
+
+$protected->setAccessible(FALSE);
+$protectedStatic->setAccessible(FALSE);
+$private->setAccessible(FALSE);
+$privateStatic->setAccessible(FALSE);
+
 try {
     var_dump($protected->getValue($a));
 }
@@ -49,31 +69,27 @@ catch (ReflectionException $e) {
     var_dump($e->getMessage());
 }
 
-$protected->setAccessible(TRUE);
-$protectedStatic->setAccessible(TRUE);
-$private->setAccessible(TRUE);
-$privateStatic->setAccessible(TRUE);
-
-var_dump($protected->getValue($a));
-var_dump($protectedStatic->getValue());
-var_dump($private->getValue($a));
-var_dump($privateStatic->getValue());
-
-$protected->setValue($a, 'e');
-$protectedStatic->setValue('f');
-$private->setValue($a, 'g');
-$privateStatic->setValue('h');
-
-var_dump($protected->getValue($a));
-var_dump($protectedStatic->getValue());
-var_dump($private->getValue($a));
-var_dump($privateStatic->getValue());
-
 $a               = new A;
 $b               = new B;
 $protected       = new ReflectionProperty($b, 'protected');
 $protectedStatic = new ReflectionProperty('B', 'protectedStatic');
 $private         = new ReflectionProperty($a, 'private');
+
+var_dump($protected->getValue($b));
+var_dump($protectedStatic->getValue());
+var_dump($private->getValue($b));
+
+$protected->setValue($b, 'e');
+$protectedStatic->setValue('f');
+$private->setValue($b, 'g');
+
+var_dump($protected->getValue($b));
+var_dump($protectedStatic->getValue());
+var_dump($private->getValue($b));
+
+$protected->setAccessible(FALSE);
+$protectedStatic->setAccessible(FALSE);
+$private->setAccessible(FALSE);
 
 try {
     var_dump($protected->getValue($b));
@@ -98,28 +114,8 @@ try {
 catch (ReflectionException $e) {
     var_dump($e->getMessage());
 }
-
-$protected->setAccessible(TRUE);
-$protectedStatic->setAccessible(TRUE);
-$private->setAccessible(TRUE);
-
-var_dump($protected->getValue($b));
-var_dump($protectedStatic->getValue());
-var_dump($private->getValue($b));
-
-$protected->setValue($b, 'e');
-$protectedStatic->setValue('f');
-$private->setValue($b, 'g');
-
-var_dump($protected->getValue($b));
-var_dump($protectedStatic->getValue());
-var_dump($private->getValue($b));
 ?>
 --EXPECT--
-string(45) "Cannot access non-public member A::$protected"
-string(51) "Cannot access non-public member A::$protectedStatic"
-string(43) "Cannot access non-public member A::$private"
-string(49) "Cannot access non-public member A::$privateStatic"
 string(1) "a"
 string(1) "b"
 string(1) "c"
@@ -128,12 +124,16 @@ string(1) "e"
 string(1) "f"
 string(1) "g"
 string(1) "h"
-string(45) "Cannot access non-public member B::$protected"
-string(51) "Cannot access non-public member B::$protectedStatic"
+string(45) "Cannot access non-public member A::$protected"
+string(51) "Cannot access non-public member A::$protectedStatic"
 string(43) "Cannot access non-public member A::$private"
+string(49) "Cannot access non-public member A::$privateStatic"
 string(1) "a"
 string(1) "f"
 string(1) "c"
 string(1) "e"
 string(1) "f"
 string(1) "g"
+string(45) "Cannot access non-public member B::$protected"
+string(51) "Cannot access non-public member B::$protectedStatic"
+string(43) "Cannot access non-public member A::$private"

--- a/ext/reflection/tests/bug49719.phpt
+++ b/ext/reflection/tests/bug49719.phpt
@@ -32,7 +32,6 @@ class B2 extends A2 {
 
 $b2 = new ReflectionClass('B2');
 $prop = $b2->getProperty('a');
-$prop->setAccessible(true);
 var_dump($prop->getValue(new b2));
 
 ?>

--- a/ext/reflection/tests/bug72174.phpt
+++ b/ext/reflection/tests/bug72174.phpt
@@ -27,7 +27,6 @@ class Foo
 
 $instance = new Foo();
 $reflectionBar = (new ReflectionProperty(Foo::class, 'bar'));
-$reflectionBar->setAccessible(true);
 var_dump($reflectionBar->getValue($instance));
 
 ?>


### PR DESCRIPTION
Note: pending RFC.

With this patch, it is no longer required to call `ReflectionProperty#setAccessible()` or
`ReflectionMethod#setAccessible()` with `true`.

If a userland consumer already got to the point of accessing object/class information via reflection,
it makes little sense for `ext/reflection` to disallow accessing `private`/`protected` symbols by
default.

After this patch, calling `ReflectionProperty#setAccessible(true)` or
`ReflectionMethod#setAccessible(true)` on newly instantiated `ReflectionProperty` or
`ReflectionMethod` respectively will have no effect.