### PR TITLE
Make `ReflectionProperty#setAccessible()` and `ReflectionMethod#setAccessible()` no-op

### DIFF
--- a/Zend/tests/bug63762.phpt
+++ b/Zend/tests/bug63762.phpt
@@ -5,7 +5,6 @@ Bug #63762 - Sigsegv when Exception::$trace is changed by user
 $e = new Exception();
 
 $ref = new ReflectionProperty($e, 'trace');
-$ref->setAccessible(TRUE);
 
 echo "Array of NULL:\n";
 $ref->setValue($e, array(NULL));

--- a/Zend/tests/bug72177.phpt
+++ b/Zend/tests/bug72177.phpt
@@ -21,7 +21,6 @@ class Parnt
         $this->child = new Child();
 
         $prop = new \ReflectionProperty($this, 'child');
-        $prop->setAccessible(true);
         $prop->setValue($this, null);
     }
 }

--- a/Zend/tests/bug72177_2.phpt
+++ b/Zend/tests/bug72177_2.phpt
@@ -27,7 +27,6 @@ class Bar extends Foo
 
 $r = new ReflectionProperty(Foo::class, 'bar');
 
-$r->setAccessible(true);
 echo "OK\n";
 ?>
 --EXPECT--

--- a/Zend/tests/bug78921.phpt
+++ b/Zend/tests/bug78921.phpt
@@ -27,7 +27,6 @@ class OtherClass
 
 $reflectionClass = new ReflectionClass('OtherClass');
 $reflectionProperty = $reflectionClass->getProperty('prop');
-$reflectionProperty->setAccessible(true);
 $value = $reflectionProperty->getValue();
 echo "Value is $value\n";
 

--- a/ext/reflection/tests/ReflectionClass_getProperty_003.phpt
+++ b/ext/reflection/tests/ReflectionClass_getProperty_003.phpt
@@ -49,13 +49,9 @@ function showInfo($name) {
         echo $e->getMessage() . "\n";
         return;
     }
-    try {
-        var_dump($rp);
-        var_dump($rp->getValue($myC));
-    } catch (Exception $e) {
-        echo $e->getMessage() . "\n";
-        return;
-    }
+
+    var_dump($rp);
+    var_dump($rp->getValue($myC));
 }
 
 
@@ -110,7 +106,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "A"
 }
-Cannot access non-public property C::$protA
+string(10) "protA in A"
 --- (Reflecting on privA) ---
 Property C::$privA does not exist
 --- (Reflecting on pubB) ---
@@ -128,7 +124,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "B"
 }
-Cannot access non-public property C::$protB
+string(10) "protB in B"
 --- (Reflecting on privB) ---
 Property C::$privB does not exist
 --- (Reflecting on pubC) ---
@@ -146,7 +142,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "C"
 }
-Cannot access non-public property C::$protC
+string(10) "protC in C"
 --- (Reflecting on privC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -154,7 +150,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "C"
 }
-Cannot access non-public property C::$privC
+string(10) "privC in C"
 --- (Reflecting on doesNotExist) ---
 Property C::$doesNotExist does not exist
 --- (Reflecting on A::pubC) ---
@@ -172,7 +168,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "A"
 }
-Cannot access non-public property A::$protC
+string(10) "protC in A"
 --- (Reflecting on A::privC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -180,7 +176,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "A"
 }
-Cannot access non-public property A::$privC
+string(10) "privC in A"
 --- (Reflecting on B::pubC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -196,7 +192,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "B"
 }
-Cannot access non-public property B::$protC
+string(10) "protC in B"
 --- (Reflecting on B::privC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -204,7 +200,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "B"
 }
-Cannot access non-public property B::$privC
+string(10) "privC in B"
 --- (Reflecting on c::pubC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -230,7 +226,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "C"
 }
-Cannot access non-public property C::$protC
+string(10) "protC in C"
 --- (Reflecting on C::privC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -238,7 +234,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "C"
 }
-Cannot access non-public property C::$privC
+string(10) "privC in C"
 --- (Reflecting on X::pubC) ---
 Fully qualified property name X::$pubC does not specify a base class of C
 --- (Reflecting on X::protC) ---

--- a/ext/reflection/tests/ReflectionClass_getProperty_004.phpt
+++ b/ext/reflection/tests/ReflectionClass_getProperty_004.phpt
@@ -110,7 +110,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "A"
 }
-Cannot access non-public property C::$protA
+string(10) "protA in A"
 --- (Reflecting on privA) ---
 Property C::$privA does not exist
 --- (Reflecting on pubB) ---
@@ -128,7 +128,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "B"
 }
-Cannot access non-public property C::$protB
+string(10) "protB in B"
 --- (Reflecting on privB) ---
 Property C::$privB does not exist
 --- (Reflecting on pubC) ---
@@ -146,7 +146,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "C"
 }
-Cannot access non-public property C::$protC
+string(10) "protC in C"
 --- (Reflecting on privC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -154,7 +154,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "C"
 }
-Cannot access non-public property C::$privC
+string(10) "privC in C"
 --- (Reflecting on doesNotExist) ---
 Property C::$doesNotExist does not exist
 --- (Reflecting on A::pubC) ---
@@ -172,7 +172,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "A"
 }
-Cannot access non-public property A::$protC
+string(10) "protC in C"
 --- (Reflecting on A::privC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -180,7 +180,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "A"
 }
-Cannot access non-public property A::$privC
+string(10) "privC in A"
 --- (Reflecting on B::pubC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -196,7 +196,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "B"
 }
-Cannot access non-public property B::$protC
+string(10) "protC in C"
 --- (Reflecting on B::privC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -204,7 +204,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "B"
 }
-Cannot access non-public property B::$privC
+string(10) "privC in B"
 --- (Reflecting on c::pubC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -230,7 +230,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "C"
 }
-Cannot access non-public property C::$protC
+string(10) "protC in C"
 --- (Reflecting on C::privC) ---
 object(ReflectionProperty)#%d (2) {
   ["name"]=>
@@ -238,7 +238,7 @@ object(ReflectionProperty)#%d (2) {
   ["class"]=>
   string(1) "C"
 }
-Cannot access non-public property C::$privC
+string(10) "privC in C"
 --- (Reflecting on X::pubC) ---
 Fully qualified property name X::$pubC does not specify a base class of C
 --- (Reflecting on X::protC) ---

--- a/ext/reflection/tests/ReflectionMethod_invokeArgs_error3.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invokeArgs_error3.phpt
@@ -49,11 +49,7 @@ echo "\nStatic method:\n";
 var_dump($staticMethod->invokeArgs(null, array()));
 
 echo "\nPrivate method:\n";
-try {
-    var_dump($privateMethod->invokeArgs($testClassInstance, array()));
-} catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
+var_dump($privateMethod->invokeArgs($testClassInstance, array()));
 
 echo "\nAbstract method:\n";
 $abstractMethod = new ReflectionMethod("AbstractClass::foo");
@@ -79,7 +75,8 @@ Exception: Using $this when not in object context
 NULL
 
 Private method:
-string(86) "Trying to invoke private method TestClass::privateMethod() from scope ReflectionMethod"
+Called privateMethod()
+NULL
 
 Abstract method:
 string(53) "Trying to invoke abstract method AbstractClass::foo()"

--- a/ext/reflection/tests/ReflectionMethod_invoke_error1.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invoke_error1.phpt
@@ -42,11 +42,7 @@ try {
 }
 
 echo "\nPrivate method:\n";
-try {
-    var_dump($privateMethod->invoke($testClassInstance));
-} catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
+var_dump($privateMethod->invoke($testClassInstance));
 
 echo "\nAbstract method:\n";
 $abstractMethod = new ReflectionMethod("AbstractClass::foo");
@@ -65,7 +61,8 @@ invoke() on a non-instance:
 string(72) "Given object is not an instance of the class this method was declared in"
 
 Private method:
-string(86) "Trying to invoke private method TestClass::privateMethod() from scope ReflectionMethod"
+Called privateMethod()
+NULL
 
 Abstract method:
 string(53) "Trying to invoke abstract method AbstractClass::foo()"

--- a/ext/reflection/tests/ReflectionMethod_invoke_on_abstract_method_after_setAccessible.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invoke_on_abstract_method_after_setAccessible.phpt
@@ -1,5 +1,5 @@
 --TEST--
-ReflectionMethod::invoke() on an abstract method should fail even after calling setAccessible(true)
+ReflectionMethod::invoke() on an abstract method should fail
 --FILE--
 <?php
 
@@ -8,7 +8,6 @@ abstract class Test {
 }
 
 $rm = new ReflectionMethod('Test', 'foo');
-$rm->setAccessible(true);
 try {
     var_dump($rm->invoke(null));
 } catch (ReflectionException $e) {

--- a/ext/reflection/tests/ReflectionMethod_setAccessible.phpt
+++ b/ext/reflection/tests/ReflectionMethod_setAccessible.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test ReflectionMethod::setAccessible().
+Test that ReflectionMethod::setAccessible() has no effects
 --FILE--
 <?php
 class A {
@@ -14,74 +14,19 @@ $privateStatic   = new ReflectionMethod('A', 'aPrivateStatic');
 $protected       = new ReflectionMethod('A', 'aProtected');
 $protectedStatic = new ReflectionMethod('A', 'aProtectedStatic');
 
-try {
-    $private->invoke(new A, NULL);
-}
+$private->invoke(new A, NULL);
+$private->invokeArgs(new A, array(NULL));
+$privateStatic->invoke(NULL, NULL);
+$privateStatic->invokeArgs(NULL, array(NULL));
+$protected->invoke(new A, NULL);
+$protected->invokeArgs(new A, array(NULL));
+$protectedStatic->invoke(NULL, NULL);
+$protectedStatic->invokeArgs(NULL, array(NULL));
 
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    $private->invokeArgs(new A, array(NULL));
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    $privateStatic->invoke(NULL, NULL);
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    $privateStatic->invokeArgs(NULL, array(NULL));
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    $protected->invoke(new A, NULL);
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    $protected->invokeArgs(new A, array(NULL));
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    $protectedStatic->invoke(NULL, NULL);
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    $protectedStatic->invokeArgs(NULL, array(NULL));
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-$private->setAccessible(TRUE);
-$privateStatic->setAccessible(TRUE);
-$protected->setAccessible(TRUE);
-$protectedStatic->setAccessible(TRUE);
+$private->setAccessible(FALSE);
+$privateStatic->setAccessible(FALSE);
+$protected->setAccessible(FALSE);
+$protectedStatic->setAccessible(FALSE);
 
 $private->invoke(new A, NULL);
 $private->invokeArgs(new A, array(NULL));
@@ -93,14 +38,14 @@ $protectedStatic->invoke(NULL, NULL);
 $protectedStatic->invokeArgs(NULL, array(NULL));
 ?>
 --EXPECT--
-string(73) "Trying to invoke private method A::aPrivate() from scope ReflectionMethod"
-string(73) "Trying to invoke private method A::aPrivate() from scope ReflectionMethod"
-string(79) "Trying to invoke private method A::aPrivateStatic() from scope ReflectionMethod"
-string(79) "Trying to invoke private method A::aPrivateStatic() from scope ReflectionMethod"
-string(77) "Trying to invoke protected method A::aProtected() from scope ReflectionMethod"
-string(77) "Trying to invoke protected method A::aProtected() from scope ReflectionMethod"
-string(83) "Trying to invoke protected method A::aProtectedStatic() from scope ReflectionMethod"
-string(83) "Trying to invoke protected method A::aProtectedStatic() from scope ReflectionMethod"
+A::aPrivate
+A::aPrivate
+A::aPrivateStatic
+A::aPrivateStatic
+A::aProtected
+A::aProtected
+A::aProtectedStatic
+A::aProtectedStatic
 A::aPrivate
 A::aPrivate
 A::aPrivateStatic

--- a/ext/reflection/tests/ReflectionProperty_getValue_error.phpt
+++ b/ext/reflection/tests/ReflectionProperty_getValue_error.phpt
@@ -29,13 +29,8 @@ try {
 }
 
 echo "\nProtected property:\n";
-try {
-    $propInfo = new ReflectionProperty('TestClass', 'prot');
-    var_dump($propInfo->getValue($instance));
-}
-catch(Exception $exc) {
-    echo $exc->getMessage();
-}
+$propInfo = new ReflectionProperty('TestClass', 'prot');
+var_dump($propInfo->getValue($instance));
 
 echo "\n\nInvalid instance:\n";
 $propInfo = new ReflectionProperty('TestClass', 'pub2');
@@ -60,7 +55,8 @@ Static property / too many args:
 ReflectionProperty::getValue() expects at most 1 argument, 2 given
 
 Protected property:
-Cannot access non-public property TestClass::$prot
+int(4)
+
 
 Invalid instance:
 Given object is not an instance of the class this property was declared in

--- a/ext/reflection/tests/ReflectionProperty_isInitialized.phpt
+++ b/ext/reflection/tests/ReflectionProperty_isInitialized.phpt
@@ -44,12 +44,7 @@ var_dump($rp->isInitialized($a));
 
 echo "Visibility handling:\n";
 $rp = new ReflectionProperty('A', 'p');
-try {
-    var_dump($rp->isInitialized($a));
-} catch (ReflectionException $e) {
-    echo $e->getMessage(), "\n";
-}
-$rp->setAccessible(true);
+var_dump($rp->isInitialized($a));
 var_dump($rp->isInitialized($a));
 
 echo "Object type:\n";
@@ -109,7 +104,7 @@ Dynamic properties:
 bool(true)
 bool(false)
 Visibility handling:
-Cannot access non-public property A::$p
+bool(false)
 bool(false)
 Object type:
 bool(false)

--- a/ext/reflection/tests/ReflectionProperty_setAccessible.phpt
+++ b/ext/reflection/tests/ReflectionProperty_setAccessible.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test ReflectionProperty::setAccessible().
+Test that ReflectionProperty::setAccessible() has no effects
 --FILE--
 <?php
 class A {
@@ -17,43 +17,6 @@ $protectedStatic = new ReflectionProperty('A', 'protectedStatic');
 $private         = new ReflectionProperty($a, 'private');
 $privateStatic   = new ReflectionProperty('A', 'privateStatic');
 
-try {
-    var_dump($protected->getValue($a));
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    var_dump($protectedStatic->getValue());
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    var_dump($private->getValue($a));
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    var_dump($privateStatic->getValue());
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-$protected->setAccessible(TRUE);
-$protectedStatic->setAccessible(TRUE);
-$private->setAccessible(TRUE);
-$privateStatic->setAccessible(TRUE);
-
 var_dump($protected->getValue($a));
 var_dump($protectedStatic->getValue());
 var_dump($private->getValue($a));
@@ -69,39 +32,31 @@ var_dump($protectedStatic->getValue());
 var_dump($private->getValue($a));
 var_dump($privateStatic->getValue());
 
+$protected->setAccessible(FALSE);
+$protectedStatic->setAccessible(FALSE);
+$private->setAccessible(FALSE);
+$privateStatic->setAccessible(FALSE);
+
+var_dump($protected->getValue($a));
+var_dump($protectedStatic->getValue());
+var_dump($private->getValue($a));
+var_dump($privateStatic->getValue());
+
+$protected->setValue($a, 'i');
+$protectedStatic->setValue('j');
+$private->setValue($a, 'k');
+$privateStatic->setValue('l');
+
+var_dump($protected->getValue($a));
+var_dump($protectedStatic->getValue());
+var_dump($private->getValue($a));
+var_dump($privateStatic->getValue());
+
 $a               = new A;
 $b               = new B;
 $protected       = new ReflectionProperty($b, 'protected');
 $protectedStatic = new ReflectionProperty('B', 'protectedStatic');
 $private         = new ReflectionProperty($a, 'private');
-
-try {
-    var_dump($protected->getValue($b));
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    var_dump($protectedStatic->getValue());
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-try {
-    var_dump($private->getValue($b));
-}
-
-catch (ReflectionException $e) {
-    var_dump($e->getMessage());
-}
-
-$protected->setAccessible(TRUE);
-$protectedStatic->setAccessible(TRUE);
-$private->setAccessible(TRUE);
 
 var_dump($protected->getValue($b));
 var_dump($protectedStatic->getValue());
@@ -114,12 +69,24 @@ $private->setValue($b, 'g');
 var_dump($protected->getValue($b));
 var_dump($protectedStatic->getValue());
 var_dump($private->getValue($b));
+
+$protected->setAccessible(FALSE);
+$protectedStatic->setAccessible(FALSE);
+$private->setAccessible(FALSE);
+
+var_dump($protected->getValue($b));
+var_dump($protectedStatic->getValue());
+var_dump($private->getValue($b));
+
+$protected->setValue($b, 'h');
+$protectedStatic->setValue('i');
+$private->setValue($b, 'j');
+
+var_dump($protected->getValue($b));
+var_dump($protectedStatic->getValue());
+var_dump($private->getValue($b));
 ?>
 --EXPECT--
-string(47) "Cannot access non-public property A::$protected"
-string(53) "Cannot access non-public property A::$protectedStatic"
-string(45) "Cannot access non-public property A::$private"
-string(51) "Cannot access non-public property A::$privateStatic"
 string(1) "a"
 string(1) "b"
 string(1) "c"
@@ -128,12 +95,23 @@ string(1) "e"
 string(1) "f"
 string(1) "g"
 string(1) "h"
-string(47) "Cannot access non-public property B::$protected"
-string(53) "Cannot access non-public property B::$protectedStatic"
-string(45) "Cannot access non-public property A::$private"
-string(1) "a"
+string(1) "e"
 string(1) "f"
+string(1) "g"
+string(1) "h"
+string(1) "i"
+string(1) "j"
+string(1) "k"
+string(1) "l"
+string(1) "a"
+string(1) "j"
 string(1) "c"
 string(1) "e"
 string(1) "f"
 string(1) "g"
+string(1) "e"
+string(1) "f"
+string(1) "g"
+string(1) "h"
+string(1) "i"
+string(1) "j"

--- a/ext/reflection/tests/ReflectionProperty_setValue_error.phpt
+++ b/ext/reflection/tests/ReflectionProperty_setValue_error.phpt
@@ -19,13 +19,10 @@ $instanceWithNoProperties = new AnotherClass();
 $propInfo = new ReflectionProperty('TestClass', 'pub2');
 
 echo "\nProtected property:\n";
-try {
-    $propInfo = new ReflectionProperty('TestClass', 'prot');
-    var_dump($propInfo->setValue($instance, "NewValue"));
-}
-catch(Exception $exc) {
-    echo $exc->getMessage();
-}
+
+$propInfo = new ReflectionProperty('TestClass', 'prot');
+$propInfo->setValue($instance, "NewValue");
+var_dump($propInfo->getValue($instance));
 
 echo "\n\nInstance without property:\n";
 $propInfo = new ReflectionProperty('TestClass', 'pub2');
@@ -34,7 +31,8 @@ var_dump($instanceWithNoProperties->pub2);
 ?>
 --EXPECT--
 Protected property:
-Cannot access non-public property TestClass::$prot
+string(8) "NewValue"
+
 
 Instance without property:
 NULL

--- a/ext/reflection/tests/bug37816.phpt
+++ b/ext/reflection/tests/bug37816.phpt
@@ -12,15 +12,8 @@ $o = new TestClass;
 
 $r = new ReflectionProperty($o, 'p');
 
-try
-{
-    $x = $r->getValue($o);
-}
-catch (Exception $e)
-{
-    echo 'Caught: ' . $e->getMessage() . "\n";
-}
+var_dump($r->getValue($o));
 
 ?>
 --EXPECT--
-Caught: Cannot access non-public property TestClass::$p
+int(2)

--- a/ext/reflection/tests/bug49719.phpt
+++ b/ext/reflection/tests/bug49719.phpt
@@ -32,7 +32,6 @@ class B2 extends A2 {
 
 $b2 = new ReflectionClass('B2');
 $prop = $b2->getProperty('a');
-$prop->setAccessible(true);
 var_dump($prop->getValue(new b2));
 
 ?>

--- a/ext/reflection/tests/bug72174.phpt
+++ b/ext/reflection/tests/bug72174.phpt
@@ -27,7 +27,6 @@ class Foo
 
 $instance = new Foo();
 $reflectionBar = (new ReflectionProperty(Foo::class, 'bar'));
-$reflectionBar->setAccessible(true);
 var_dump($reflectionBar->getValue($instance));
 
 ?>


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/make-reflection-setaccessible-no-op

Follow-up to #5411: also removes the `ReflectionProperty#setAccessible(false)` and `ReflectionMethod#setAccessible(false)`.

Make `ReflectionProperty#setAccessible()` and `ReflectionMethod#setAccessible()` no-op

With this patch, it is no longer required to call `ReflectionProperty#setAccessible()` or
`ReflectionMethod#setAccessible()` at all: calling these methods will no longer have any
effect on the behavior of `ReflectionMethod` and `ReflectionProperty`.

If a userland consumer already got to the point of accessing object/class information via reflection,
it makes little sense for `ext/reflection` to disallow accessing `private`/`protected` symbols ever.

## TODOs

 * [x] squash
 * [x] add full RFC text to commit message