### PR TITLE
Skip non-existing properties returned by __sleep()

### DIFF
--- a/ext/standard/tests/serialize/bug14293.phpt
+++ b/ext/standard/tests/serialize/bug14293.phpt
@@ -27,10 +27,8 @@ var_dump($t);
 __sleep called
 
 Notice: serialize(): "b" returned as member variable from __sleep() but does not exist in %sbug14293.php on line %d
-O:1:"t":2:{s:1:"a";s:5:"hello";s:1:"b";N;}
-object(t)#%d (2) {
+O:1:"t":1:{s:1:"a";s:5:"hello";}
+object(t)#%d (1) {
   ["a"]=>
   string(5) "hello"
-  ["b"]=>
-  NULL
 }

--- a/ext/standard/tests/serialize/bug69210.phpt
+++ b/ext/standard/tests/serialize/bug69210.phpt
@@ -35,17 +35,13 @@ var_dump(unserialize($ss));
 var_dump(unserialize($si));
 ?>
 --EXPECT--
-O:10:"testString":2:{s:1:"a";b:1;s:1:"1";N;}
-O:11:"testInteger":2:{s:1:"a";b:1;s:1:"1";N;}
-object(testString)#3 (2) {
+O:10:"testString":1:{s:1:"a";b:1;}
+O:11:"testInteger":1:{s:1:"a";b:1;}
+object(testString)#3 (1) {
   ["a"]=>
   bool(true)
-  ["1"]=>
-  NULL
 }
-object(testInteger)#3 (2) {
+object(testInteger)#3 (1) {
   ["a"]=>
   bool(true)
-  ["1"]=>
-  NULL
 }

--- a/ext/standard/tests/serialize/sleep_undefined_declared_properties.phpt
+++ b/ext/standard/tests/serialize/sleep_undefined_declared_properties.phpt
@@ -26,4 +26,4 @@ Notice: serialize(): "pub" returned as member variable from __sleep() but does n
 Notice: serialize(): "prot" returned as member variable from __sleep() but does not exist in %s on line %d
 
 Notice: serialize(): "priv" returned as member variable from __sleep() but does not exist in %s on line %d
-string(53) "O:4:"Test":3:{s:3:"pub";N;s:4:"prot";N;s:4:"priv";N;}"
+string(15) "O:4:"Test":0:{}"

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -861,7 +861,6 @@ static int php_var_serialize_get_sleep_props(
 
 		php_error_docref(NULL, E_NOTICE,
 			"\"%s\" returned as member variable from __sleep() but does not exist", ZSTR_VAL(name));
-		zend_hash_add(ht, name, &EG(uninitialized_zval));
 		zend_tmp_string_release(tmp_name);
 	} ZEND_HASH_FOREACH_END();
 

--- a/tests/classes/bug26737.phpt
+++ b/tests/classes/bug26737.phpt
@@ -19,4 +19,4 @@ var_dump(str_replace("\0", '\0', $data));
 ?>
 --EXPECTF--
 Notice: serialize(): "no_such" returned as member variable from __sleep() but does not exist in %s on line %d
-string(130) "O:3:"foo":4:{s:12:"\0foo\0private";s:7:"private";s:12:"\0*\0protected";s:9:"protected";s:6:"public";s:6:"public";s:7:"no_such";N;}"
+string(114) "O:3:"foo":3:{s:12:"\0foo\0private";s:7:"private";s:12:"\0*\0protected";s:9:"protected";s:6:"public";s:6:"public";}"


### PR DESCRIPTION
Serializing a `null` for properties that don't exist makes no sense.
Better skip them.

I think this old behavior was due to a pure side effect of the implementation, which has been fixed in https://github.com/php/php-src/commit/90fea675462252c668b8c0c8b5b94ece8d4f24a7 and can now be fixed.