### PR TITLE
Optimize out impossible IS_IDENTICAL checks in infer phase

### DIFF
--- a/ext/opcache/tests/opt/infer_001.phpt
+++ b/ext/opcache/tests/opt/infer_001.phpt
@@ -1,0 +1,75 @@
+--TEST--
+infer 001: '==='/'!==' optimizations
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+function foo(int $a, ?int $nullable = null) {
+    if ($a === $undef) {
+        echo "Impossible\n";
+    } else {
+        echo "Always reached\n";
+    }
+    if ($nullable === $undef2) {
+        echo "Possible\n";
+    } else {
+        echo "Null\n";
+    }
+
+}
+foo(1);
+foo(1, 1);
+?>
+--EXPECTF--
+$_main:
+     ; (lines=8, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %sinfer_001.php:1-18
+0000 INIT_FCALL 1 160 string("foo")
+0001 SEND_VAL int(1) 1
+0002 DO_UCALL
+0003 INIT_FCALL 2 160 string("foo")
+0004 SEND_VAL int(1) 1
+0005 SEND_VAL int(1) 2
+0006 DO_UCALL
+0007 RETURN int(1)
+
+foo:
+     ; (lines=13, args=2, vars=4, tmps=1)
+     ; (after optimizer)
+     ; %sinfer_001.php:2-14
+0000 CV0($a) = RECV 1
+0001 CV1($nullable) = RECV_INIT 2 null
+0002 T4 = IS_IDENTICAL CV0($a) CV2($undef)
+0003 JMP 0006
+0004 ECHO string("Impossible
+")
+0005 JMP 0007
+0006 ECHO string("Always reached
+")
+0007 T4 = IS_IDENTICAL CV1($nullable) CV3($undef2)
+0008 JMPZ T4 0011
+0009 ECHO string("Possible
+")
+0010 RETURN null
+0011 ECHO string("Null
+")
+0012 RETURN null
+
+Warning: Undefined variable $undef in %sinfer_001.php on line 3
+Always reached
+
+Warning: Undefined variable $undef2 in %sinfer_001.php on line 8
+Possible
+
+Warning: Undefined variable $undef in %sinfer_001.php on line 3
+Always reached
+
+Warning: Undefined variable $undef2 in %sinfer_001.php on line 8
+Null

--- a/ext/opcache/tests/opt/infer_002.phpt
+++ b/ext/opcache/tests/opt/infer_002.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Infer 002: '==='/'!==' optimizations
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+function foo(int $a, object $b) {
+    for ($i = 0; $i < 2; $i++) {
+        if ($a !== $b) {
+            $a = $b;
+        }
+    }
+    return [$a === '2', $b !== 2];  // TODO: Merge the INIT_ARRAY and ADD_ARRAY_ELEMENT?
+}
+var_export(foo(1, new stdClass()));
+?>
+--EXPECTF--
+$_main:
+     ; (lines=10, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s:1-12
+0000 INIT_FCALL 1 %d string("var_export")
+0001 INIT_FCALL 2 %d string("foo")
+0002 SEND_VAL int(1) 1
+0003 V0 = NEW 0 string("stdClass")
+0004 DO_FCALL
+0005 SEND_VAR V0 2
+0006 V0 = DO_UCALL
+0007 SEND_VAR V0 1
+0008 DO_ICALL
+0009 RETURN int(1)
+LIVE RANGES:
+     0: 0004 - 0005 (new)
+
+foo:
+     ; (lines=13, args=2, vars=3, tmps=1)
+     ; (after optimizer)
+     ; %s:2-9
+0000 CV0($a) = RECV 1
+0001 CV1($b) = RECV 2
+0002 CV2($i) = QM_ASSIGN int(0)
+0003 JMP 0008
+0004 T3 = IS_NOT_IDENTICAL CV0($a) CV1($b)
+0005 JMPZ T3 0007
+0006 ASSIGN CV0($a) CV1($b)
+0007 PRE_INC CV2($i)
+0008 T3 = IS_SMALLER CV2($i) int(2)
+0009 JMPNZ T3 0004
+0010 T3 = INIT_ARRAY 2 (packed) bool(false) NEXT
+0011 T3 = ADD_ARRAY_ELEMENT bool(true) NEXT
+0012 RETURN T3
+LIVE RANGES:
+     3: 0011 - 0012 (tmp/var)
+array (
+  0 => false,
+  1 => true,
+)

--- a/ext/opcache/tests/opt/infer_003.phpt
+++ b/ext/opcache/tests/opt/infer_003.phpt
@@ -1,0 +1,90 @@
+--TEST--
+Infer 003: '==='/'!==' optimizations
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+class X {
+    public static function create_string(int $i): string {
+        return "a$i";
+    }
+    public static function foo(int $a) {
+        for ($i = 0; $i < 2; $i++) {
+            if (self::create_string($i) === $a) {
+                echo "Impossible\n";
+            }
+            if (self::create_string($i) === []) {
+                echo "Impossible\n";
+            }
+            if (self::create_string($i) === self::create_string(1)) {
+                echo "Success for $i\n";
+            }
+        }
+    }
+}
+X::foo(1);
+?>
+--EXPECTF--
+$_main:
+     ; (lines=4, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s:1-22
+0000 INIT_STATIC_METHOD_CALL 1 string("X") string("foo")
+0001 SEND_VAL int(1) 1
+0002 DO_UCALL
+0003 RETURN int(1)
+
+X::create_string:
+     ; (lines=3, args=1, vars=1, tmps=1)
+     ; (after optimizer)
+     ; %s:3-5
+0000 CV0($i) = RECV 1
+0001 T1 = FAST_CONCAT string("a") CV0($i)
+0002 RETURN T1
+
+X::foo:
+     ; (lines=29, args=1, vars=2, tmps=3)
+     ; (after optimizer)
+     ; %s:6-18
+0000 CV0($a) = RECV 1
+0001 CV1($i) = QM_ASSIGN int(0)
+0002 JMP 0026
+0003 INIT_STATIC_METHOD_CALL 1 (self) (exception) string("create_string")
+0004 SEND_VAR CV1($i) 1
+0005 DO_UCALL
+0006 JMP 0008
+0007 ECHO string("Impossible
+")
+0008 INIT_STATIC_METHOD_CALL 1 (self) (exception) string("create_string")
+0009 SEND_VAR CV1($i) 1
+0010 DO_UCALL
+0011 JMP 0013
+0012 ECHO string("Impossible
+")
+0013 INIT_STATIC_METHOD_CALL 1 (self) (exception) string("create_string")
+0014 SEND_VAR CV1($i) 1
+0015 V3 = DO_UCALL
+0016 INIT_STATIC_METHOD_CALL 1 (self) (exception) string("create_string")
+0017 SEND_VAL int(1) 1
+0018 V4 = DO_UCALL
+0019 T2 = IS_IDENTICAL V3 V4
+0020 JMPZ T2 0025
+0021 T3 = ROPE_INIT 3 string("Success for ")
+0022 T3 = ROPE_ADD 1 T3 CV1($i)
+0023 T2 = ROPE_END 2 T3 string("
+")
+0024 ECHO T2
+0025 PRE_INC CV1($i)
+0026 T2 = IS_SMALLER CV1($i) int(2)
+0027 JMPNZ T2 0003
+0028 RETURN null
+LIVE RANGES:
+     3: 0016 - 0019 (tmp/var)
+     3: 0021 - 0023 (rope)
+Success for 1

--- a/ext/opcache/tests/opt/infer_004.phpt
+++ b/ext/opcache/tests/opt/infer_004.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Infer 004: '==='/'!==' optimizations
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+function foo(int $a, stdClass $b) {
+    return [$a === $b, $a !== $b, $b === 2];
+}
+var_export(foo(1, new stdClass()));
+?>
+--EXPECTF--
+$_main:
+     ; (lines=10, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s:1-7
+0000 INIT_FCALL 1 %d string("var_export")
+0001 INIT_FCALL 2 %d string("foo")
+0002 SEND_VAL int(1) 1
+0003 V0 = NEW 0 string("stdClass")
+0004 DO_FCALL
+0005 SEND_VAR V0 2
+0006 V0 = DO_UCALL
+0007 SEND_VAR V0 1
+0008 DO_ICALL
+0009 RETURN int(1)
+LIVE RANGES:
+     0: 0004 - 0005 (new)
+
+foo:
+     ; (lines=6, args=2, vars=2, tmps=1)
+     ; (after optimizer)
+     ; %s:2-4
+0000 CV0($a) = RECV 1
+0001 CV1($b) = RECV 2
+0002 T2 = INIT_ARRAY 3 (packed) bool(false) NEXT
+0003 T2 = ADD_ARRAY_ELEMENT bool(true) NEXT
+0004 T2 = ADD_ARRAY_ELEMENT bool(false) NEXT
+0005 RETURN T2
+LIVE RANGES:
+     2: 0003 - 0005 (tmp/var)
+array (
+  0 => false,
+  1 => true,
+  2 => false,
+)


### PR DESCRIPTION
Rule out impossible checks based on type information.
(e.g. an int can't be a float (1.0 !== 1))

- Code may check for impossible types in case of code written for older php versions,
  copied and pasted snippets, or platform dependent code.