### PR TITLE
RFC: modernize the generation of syntax errors

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1104,8 +1104,6 @@ void zend_set_utility_values(zend_utility_values *utility_values) /* {{{ */
 /* this should be compatible with the standard zenderror */
 ZEND_COLD void zenderror(const char *error) /* {{{ */
 {
-	CG(parse_error) = 0;
-
 	if (EG(exception)) {
 		/* An exception was thrown in the lexer, don't throw another in the parser. */
 		return;

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -81,7 +81,6 @@ struct _zend_compiler_globals {
 
 	HashTable *auto_globals;
 
-	zend_bool parse_error;
 	zend_bool in_compilation;
 	zend_bool short_tags;
 

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -188,7 +188,6 @@ static void yy_scan_buffer(char *str, unsigned int len)
 
 void startup_scanner(void)
 {
-	CG(parse_error) = 0;
 	CG(doc_comment) = NULL;
 	CG(extra_fn_flags) = 0;
 	zend_stack_init(&SCNG(state_stack), sizeof(int));
@@ -203,7 +202,6 @@ static void heredoc_label_dtor(zend_heredoc_label *heredoc_label) {
 
 void shutdown_scanner(void)
 {
-	CG(parse_error) = 0;
 	RESET_DOC_COMMENT();
 	zend_stack_destroy(&SCNG(state_stack));
 	zend_stack_destroy(&SCNG(nest_location_stack));


### PR DESCRIPTION
Hi,

This is not (yet) a genuine PR.  Bison 3.6 will include means for the developers to forge the syntax error messages, and I meant to see how to use these news features in a project such as PHP.

Of course it would make no sense to require Bison 3.6 just yet (given that it does not exist yet, there's only a [beta](https://alpha.gnu.org/gnu/bison/bison-3.5.90.tar.xz) available), but I would like to get a feeling from the maintainers.

Maybe there are more possible simplifications, for instance now that `CG(parse_error)` is no longer useful, but I have not looked into it.