### PR TITLE
Fix #79491: Search for .user.ini extends up to root dir

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -789,7 +789,7 @@ static void sapi_cgi_log_message(char *message, int syslog_type_int)
 
 /* {{{ php_cgi_ini_activate_user_config
  */
-static void php_cgi_ini_activate_user_config(char *path, size_t path_len, const char *doc_root, size_t doc_root_len, int start)
+static void php_cgi_ini_activate_user_config(char *path, size_t path_len, const char *doc_root, size_t doc_root_len)
 {
 	user_config_cache_entry *new_entry, *entry;
 	time_t request_time = (time_t)sapi_get_request_time();
@@ -842,7 +842,7 @@ static void php_cgi_ini_activate_user_config(char *path, size_t path_len, const 
 #else
 		if (strncmp(s1, s2, s_len) == 0) {
 #endif
-			char *ptr = s2 + start;  /* start is the point where doc_root ends! */
+			char *ptr = s2 + doc_root_len;
 			while ((ptr = strchr(ptr, DEFAULT_SLASH)) != NULL) {
 				*ptr = 0;
 				php_parse_user_ini_file(path, PG(user_ini_filename), entry->user_config);
@@ -938,7 +938,7 @@ static int sapi_cgi_activate(void)
 				doc_root = estrndup(doc_root, doc_root_len);
 				zend_str_tolower(doc_root, doc_root_len);
 #endif
-				php_cgi_ini_activate_user_config(path, path_len, doc_root, doc_root_len, (doc_root_len > 0 && (doc_root_len - 1)));
+				php_cgi_ini_activate_user_config(path, path_len, doc_root, doc_root_len);
 
 #ifdef PHP_WIN32
 				efree(doc_root);


### PR DESCRIPTION
The `start` parameter of `php_cgi_ini_activate_user_config` is supposed
to hold the byte offset of the doc root in the given `path`.  However,
the current expression which fixes a potential type incompatibility
will ever only evaluate to zero or one, because it uses the *logical*
and operator (`&&`).  Furthermore we notice that subtracting one from
`doc_root_len` is not necessary, so there is even no need for the
`start` parameter at all.

---

Someone working on Linux may want to review the respective code in fpm_main.c; passing `doc_root_len - 1` seems equally superfluous there. Contrary to the code in cgi_main.c, that doesn't look like a real bug, though.