### PR TITLE
Promote warnings to error in DOM ext

### DIFF
--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -50,14 +50,14 @@ PHP_METHOD(DOMAttr, __construct)
 	name_valid = xmlValidateName((xmlChar *) name, 0);
 	if (name_valid != 0) {
 		php_dom_throw_error(INVALID_CHARACTER_ERR, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	nodep = xmlNewProp(NULL, (xmlChar *) name, (xmlChar *) value);
 
 	if (!nodep) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	oldnode = dom_object_get_node(intern);

--- a/ext/dom/cdatasection.c
+++ b/ext/dom/cdatasection.c
@@ -46,7 +46,7 @@ PHP_METHOD(DOMCdataSection, __construct)
 
 	if (!nodep) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
-		return;
+		RETURN_THROWS();
 	}
 
 	intern = Z_DOMOBJ_P(ZEND_THIS);

--- a/ext/dom/comment.c
+++ b/ext/dom/comment.c
@@ -46,7 +46,7 @@ PHP_METHOD(DOMComment, __construct)
 
 	if (!nodep) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
-		return;
+		RETURN_THROWS();
 	}
 
 	intern = Z_DOMOBJ_P(ZEND_THIS);

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -161,6 +161,7 @@ int dom_document_encoding_write(dom_object *obj, zval *newval)
 		}
 		docp->encoding = xmlStrdup((const xmlChar *) ZSTR_VAL(str));
     } else {
+    	// Todo convert to error?
 		php_error_docref(NULL, E_WARNING, "Invalid Document Encoding");
     }
 

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -161,7 +161,7 @@ zend_result dom_document_encoding_write(dom_object *obj, zval *newval)
 		}
 		docp->encoding = xmlStrdup((const xmlChar *) ZSTR_VAL(str));
     } else {
-		zend_value_error("Invalid Document Encoding");
+		zend_value_error("Invalid document encoding");
 		return FAILURE;
     }
 

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -136,7 +136,7 @@ int dom_document_encoding_read(dom_object *obj, zval *retval)
 	return SUCCESS;
 }
 
-int dom_document_encoding_write(dom_object *obj, zval *newval)
+zend_result dom_document_encoding_write(dom_object *obj, zval *newval)
 {
 	xmlDoc *docp = (xmlDocPtr) dom_object_get_node(obj);
 	zend_string *str;
@@ -161,8 +161,8 @@ int dom_document_encoding_write(dom_object *obj, zval *newval)
 		}
 		docp->encoding = xmlStrdup((const xmlChar *) ZSTR_VAL(str));
     } else {
-    	// Todo convert to error?
-		php_error_docref(NULL, E_WARNING, "Invalid Document Encoding");
+		zend_value_error("Invalid Document Encoding");
+		return FAILURE;
     }
 
 	zend_string_release_ex(str, 0);

--- a/ext/dom/documentfragment.c
+++ b/ext/dom/documentfragment.c
@@ -44,7 +44,7 @@ PHP_METHOD(DOMDocumentFragment, __construct)
 
 	if (!nodep) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
-		return;
+		RETURN_THROWS();
 	}
 
 	intern = Z_DOMOBJ_P(ZEND_THIS);
@@ -109,6 +109,7 @@ PHP_METHOD(DOMDocumentFragment, appendXML) {
 	DOM_GET_OBJ(nodep, id, xmlNodePtr, intern);
 
 	if (dom_node_is_read_only(nodep) == SUCCESS) {
+		// Should always be in strict mode?
 		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(intern->document));
 		RETURN_FALSE;
 	}

--- a/ext/dom/documentfragment.c
+++ b/ext/dom/documentfragment.c
@@ -109,7 +109,6 @@ PHP_METHOD(DOMDocumentFragment, appendXML) {
 	DOM_GET_OBJ(nodep, id, xmlNodePtr, intern);
 
 	if (dom_node_is_read_only(nodep) == SUCCESS) {
-		// Should always be in strict mode?
 		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(intern->document));
 		RETURN_FALSE;
 	}

--- a/ext/dom/domimplementation.c
+++ b/ext/dom/domimplementation.c
@@ -67,8 +67,8 @@ PHP_METHOD(DOMImplementation, createDocumentType)
 	}
 
 	if (name_len == 0) {
-		php_error_docref(NULL, E_WARNING, "qualifiedName is required");
-		RETURN_FALSE;
+		zend_argument_value_error(1, "cannot be empty");
+		RETURN_THROWS();
 	}
 
 	if (publicid_len > 0) {
@@ -134,12 +134,12 @@ PHP_METHOD(DOMImplementation, createDocument)
 	if (node != NULL) {
 		DOM_GET_OBJ(doctype, node, xmlDtdPtr, doctobj);
 		if (doctype->type == XML_DOCUMENT_TYPE_NODE) {
-			php_error_docref(NULL, E_WARNING, "Invalid DocumentType object");
-			RETURN_FALSE;
+			zend_argument_value_error(3, "is an invalid DocumentType object");
+			RETURN_THROWS();
 		}
 		if (doctype->doc != NULL) {
 			php_dom_throw_error(WRONG_DOCUMENT_ERR, 1);
-			RETURN_FALSE;
+			RETURN_THROWS();
 		}
 	} else {
 		doctobj = NULL;
@@ -163,7 +163,7 @@ PHP_METHOD(DOMImplementation, createDocument)
 			xmlFree(localname);
 		}
 		php_dom_throw_error(errorcode, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	/* currently letting libxml2 set the version string */
@@ -195,9 +195,9 @@ PHP_METHOD(DOMImplementation, createDocument)
 			}
 			xmlFreeDoc(docp);
 			xmlFree(localname);
-			/* Need some type of error here */
-			php_error_docref(NULL, E_WARNING, "Unexpected Error");
-			RETURN_FALSE;
+			/* Need some better type of error here */
+			php_dom_throw_error(PHP_ERR, 1);
+			RETURN_THROWS();
 		}
 
 		nodep->nsDef = nsptr;

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -295,9 +295,8 @@ PHP_METHOD(DOMElement, setAttribute)
 		attr = (xmlNodePtr)xmlSetProp(nodep, (xmlChar *) name, (xmlChar *)value);
 	}
 	if (!attr) {
-		// TODO Convert to error?
-		php_error_docref(NULL, E_WARNING, "No such attribute '%s'", name);
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must be a valid XML attribute");
+		RETURN_THROWS();
 	}
 
 	DOM_RET_OBJ(attr, &ret, intern);
@@ -426,9 +425,8 @@ PHP_METHOD(DOMElement, setAttributeNode)
 	DOM_GET_OBJ(attrp, node, xmlAttrPtr, attrobj);
 
 	if (attrp->type != XML_ATTRIBUTE_NODE) {
-		// Todo convert to a ValueError?
-		php_error_docref(NULL, E_WARNING, "Attribute node is required");
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must have the node attribute");
+		RETURN_THROWS();
 	}
 
 	if (!(attrp->doc == NULL || attrp->doc == nodep->doc)) {
@@ -878,9 +876,8 @@ PHP_METHOD(DOMElement, setAttributeNodeNS)
 	DOM_GET_OBJ(attrp, node, xmlAttrPtr, attrobj);
 
 	if (attrp->type != XML_ATTRIBUTE_NODE) {
-		// Todo convert to error?
-		php_error_docref(NULL, E_WARNING, "Attribute node is required");
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must have node attribute");
+		RETURN_THROWS();
 	}
 
 	if (!(attrp->doc == NULL || attrp->doc == nodep->doc)) {

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -268,7 +268,6 @@ PHP_METHOD(DOMElement, setAttribute)
 	DOM_GET_OBJ(nodep, id, xmlNodePtr, intern);
 
 	if (dom_node_is_read_only(nodep) == SUCCESS) {
-		// Todo make it always strict?
 		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(intern->document));
 		RETURN_FALSE;
 	}
@@ -642,7 +641,6 @@ PHP_METHOD(DOMElement, setAttributeNS)
 		RETURN_NULL();
 	}
 
-	// Todo should always be strict?
 	errorcode = dom_check_qname(name, &localname, &prefix, uri_len, name_len);
 
 	if (errorcode == 0) {

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -49,7 +49,7 @@ PHP_METHOD(DOMElement, __construct)
 	name_valid = xmlValidateName((xmlChar *) name, 0);
 	if (name_valid != 0) {
 		php_dom_throw_error(INVALID_CHARACTER_ERR, 1);
-		return;
+		RETURN_THROWS();
 	}
 
 	/* Namespace logic is separate and only when uri passed in to insure no BC breakage */
@@ -71,7 +71,7 @@ PHP_METHOD(DOMElement, __construct)
 				xmlFreeNode(nodep);
 			}
 			php_dom_throw_error(errorcode, 1);
-			return;
+			RETURN_THROWS();
 		}
 	} else {
 	    /* If you don't pass a namespace uri, then you can't set a prefix */
@@ -80,14 +80,14 @@ PHP_METHOD(DOMElement, __construct)
 			xmlFree(localname);
 			xmlFree(prefix);
 	        php_dom_throw_error(NAMESPACE_ERR, 1);
-	        return;
+	        RETURN_THROWS();
 	    }
 		nodep = xmlNewNode(NULL, (xmlChar *) name);
 	}
 
 	if (!nodep) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
-		return;
+		RETURN_THROWS();
 	}
 
 	if (value_len > 0) {
@@ -255,19 +255,20 @@ PHP_METHOD(DOMElement, setAttribute)
 	}
 
 	if (name_len == 0) {
-		php_error_docref(NULL, E_WARNING, "Attribute Name is required");
-		RETURN_FALSE;
+		zend_argument_value_error(1, "cannot be empty");
+		RETURN_THROWS();
 	}
 
 	name_valid = xmlValidateName((xmlChar *) name, 0);
 	if (name_valid != 0) {
 		php_dom_throw_error(INVALID_CHARACTER_ERR, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	DOM_GET_OBJ(nodep, id, xmlNodePtr, intern);
 
 	if (dom_node_is_read_only(nodep) == SUCCESS) {
+		// Todo make it always strict?
 		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, dom_get_strict_error(intern->document));
 		RETURN_FALSE;
 	}
@@ -294,6 +295,7 @@ PHP_METHOD(DOMElement, setAttribute)
 		attr = (xmlNodePtr)xmlSetProp(nodep, (xmlChar *) name, (xmlChar *)value);
 	}
 	if (!attr) {
+		// TODO Convert to error?
 		php_error_docref(NULL, E_WARNING, "No such attribute '%s'", name);
 		RETURN_FALSE;
 	}
@@ -424,6 +426,7 @@ PHP_METHOD(DOMElement, setAttributeNode)
 	DOM_GET_OBJ(attrp, node, xmlAttrPtr, attrobj);
 
 	if (attrp->type != XML_ATTRIBUTE_NODE) {
+		// Todo convert to a ValueError?
 		php_error_docref(NULL, E_WARNING, "Attribute node is required");
 		RETURN_FALSE;
 	}
@@ -628,8 +631,8 @@ PHP_METHOD(DOMElement, setAttributeNS)
 	}
 
 	if (name_len == 0) {
-		php_error_docref(NULL, E_WARNING, "Attribute Name is required");
-		RETURN_FALSE;
+		zend_argument_value_error(2, "cannot be empty");
+		RETURN_THROWS();
 	}
 
 	DOM_GET_OBJ(elemp, id, xmlNodePtr, intern);
@@ -641,6 +644,7 @@ PHP_METHOD(DOMElement, setAttributeNS)
 		RETURN_NULL();
 	}
 
+	// Todo should always be strict?
 	errorcode = dom_check_qname(name, &localname, &prefix, uri_len, name_len);
 
 	if (errorcode == 0) {
@@ -874,6 +878,7 @@ PHP_METHOD(DOMElement, setAttributeNodeNS)
 	DOM_GET_OBJ(attrp, node, xmlAttrPtr, attrobj);
 
 	if (attrp->type != XML_ATTRIBUTE_NODE) {
+		// Todo convert to error?
 		php_error_docref(NULL, E_WARNING, "Attribute node is required");
 		RETURN_FALSE;
 	}

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -873,10 +873,10 @@ PHP_METHOD(DOMElement, setAttributeNodeNS)
 
 	DOM_GET_OBJ(attrp, node, xmlAttrPtr, attrobj);
 
-	if (attrp->type != XML_ATTRIBUTE_NODE) {
-		zend_argument_value_error(1, "must have node attribute");
-		RETURN_THROWS();
-	}
+	/* ZPP Guarantees that a DOMAttr class is given, as it is converted to a xmlAttr
+	 * to pass to libxml (see http://www.xmlsoft.org/html/libxml-tree.html#xmlAttr)
+	 * if it is not of type XML_ATTRIBUTE_NODE it indicates a bug somewhere */
+	ZEND_ASSERT(attrp->type == XML_ATTRIBUTE_NODE);
 
 	if (!(attrp->doc == NULL || attrp->doc == nodep->doc)) {
 		php_dom_throw_error(WRONG_DOCUMENT_ERR, dom_get_strict_error(intern->document));

--- a/ext/dom/entityreference.c
+++ b/ext/dom/entityreference.c
@@ -46,14 +46,14 @@ PHP_METHOD(DOMEntityReference, __construct)
 	name_valid = xmlValidateName((xmlChar *) name, 0);
 	if (name_valid != 0) {
 		php_dom_throw_error(INVALID_CHARACTER_ERR, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	node = xmlNewReference(NULL, (xmlChar *) name);
 
 	if (!node) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	intern = Z_DOMOBJ_P(ZEND_THIS);

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1594,7 +1594,7 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 					xmlXPathFreeObject(xpathobjp);
 				}
 				xmlXPathFreeContext(ctxp);
-				zend_throw_error(NULL, "XPath query did not return a nodeset.");
+				zend_throw_error(NULL, "XPath query did not return a nodeset");
 				RETURN_THROWS();
 			}
 		}
@@ -1606,12 +1606,11 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 
 		tmp = zend_hash_str_find(ht, "query", sizeof("query")-1);
 		if (!tmp) {
-			// TODO Use argument version after checking which num arg it is
-			zend_value_error("\"query\" option must be in XPath array");
+			zend_argument_value_error(3, "\"query\" option must be in XPath array");
 			RETURN_THROWS();
 		}
 		if (Z_TYPE_P(tmp) != IS_STRING) {
-			zend_type_error("\"query\" option must be a string, %s given", zend_zval_type_name(tmp));
+			zend_argument_type_error(3, "\"query\" option must be a string, %s given", zend_zval_type_name(tmp));
 			RETURN_THROWS();
 		}
 		xquery = Z_STRVAL_P(tmp);

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -35,7 +35,7 @@ readonly=yes
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-F68D095
 Since:
 */
-zend_result dom_node_node_name_read(dom_object *obj, zval *retval)
+int dom_node_node_name_read(dom_object *obj, zval *retval)
 {
 	xmlNode *nodep;
 	xmlNsPtr ns;
@@ -97,9 +97,7 @@ zend_result dom_node_node_name_read(dom_object *obj, zval *retval)
 		case XML_TEXT_NODE:
 			str = "#text";
 			break;
-		default:
-			zend_value_error("XML Node type must be one of XML_*_NODE");
-			return FAILURE;
+		EMPTY_SWITCH_DEFAULT_CASE();
 	}
 
 	if (str != NULL) {
@@ -1603,11 +1601,13 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 
 		tmp = zend_hash_str_find(ht, "query", sizeof("query")-1);
 		if (!tmp) {
-			zend_argument_value_error(3, "\"query\" option must be in XPath array");
+			/* if mode == 0 then $xpath arg is 3, if mode == 1 then $xpath is 4 */
+			zend_argument_value_error(3 + mode, "must have a \"query\" key");
 			RETURN_THROWS();
 		}
 		if (Z_TYPE_P(tmp) != IS_STRING) {
-			zend_argument_type_error(3, "\"query\" option must be a string, %s given", zend_zval_type_name(tmp));
+			/* if mode == 0 then $xpath arg is 3, if mode == 1 then $xpath is 4 */
+			zend_argument_type_error(3 + mode, "\"query\" option must be a string, %s given", zend_zval_type_name(tmp));
 			RETURN_THROWS();
 		}
 		xquery = Z_STRVAL_P(tmp);
@@ -1638,8 +1638,8 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 				xmlXPathFreeObject(xpathobjp);
 			}
 			xmlXPathFreeContext(ctxp);
-			php_error_docref(NULL, E_WARNING, "XPath query did not return a nodeset.");
-			RETURN_FALSE;
+			zend_throw_error(NULL, "XPath query did not return a nodeset");
+			RETURN_THROWS();
 		}
 	}
 

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -98,6 +98,7 @@ int dom_node_node_name_read(dom_object *obj, zval *retval)
 			str = "#text";
 			break;
 		default:
+			// Todo convert to error?
 			php_error_docref(NULL, E_WARNING, "Invalid Node Type");
 	}
 
@@ -856,6 +857,7 @@ PHP_METHOD(DOMNode, insertBefore)
 
 	new_child = NULL;
 
+	// Todo should always be strict?
 	stricterror = dom_get_strict_error(intern->document);
 
 	if (dom_node_is_read_only(parentp) == SUCCESS ||
@@ -875,6 +877,7 @@ PHP_METHOD(DOMNode, insertBefore)
 	}
 
 	if (child->type == XML_DOCUMENT_FRAG_NODE && child->children == NULL) {
+		// Todo convert to Error?
 		php_error_docref(NULL, E_WARNING, "Document Fragment is empty");
 		RETURN_FALSE;
 	}
@@ -981,6 +984,7 @@ PHP_METHOD(DOMNode, insertBefore)
 	}
 
 	if (NULL == new_child) {
+		// Todo convert to error?
 		php_error_docref(NULL, E_WARNING, "Couldn't add newnode as the previous sibling of refnode");
 		RETURN_FALSE;
 	}
@@ -1023,6 +1027,7 @@ PHP_METHOD(DOMNode, replaceChild)
 		RETURN_FALSE;
 	}
 
+	// Todo make alway strict?
 	stricterror = dom_get_strict_error(intern->document);
 
 	if (dom_node_is_read_only(nodep) == SUCCESS ||
@@ -1074,7 +1079,7 @@ PHP_METHOD(DOMNode, replaceChild)
 		DOM_RET_OBJ(oldchild, &ret, intern);
 		return;
 	} else {
-		php_dom_throw_error(NOT_FOUND_ERR, dom_get_strict_error(intern->document));
+		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
 		RETURN_FALSE;
 	}
 }
@@ -1173,6 +1178,7 @@ PHP_METHOD(DOMNode, appendChild)
 	}
 
 	if (child->type == XML_DOCUMENT_FRAG_NODE && child->children == NULL) {
+		// Todo convert to error?
 		php_error_docref(NULL, E_WARNING, "Document Fragment is empty");
 		RETURN_FALSE;
 	}
@@ -1462,6 +1468,7 @@ PHP_METHOD(DOMNode, lookupPrefix)
 		}
 	}
 
+	// Todo return empty string?
 	RETURN_NULL();
 }
 /* }}} end dom_node_lookup_prefix */
@@ -1570,6 +1577,7 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 	docp = nodep->doc;
 
 	if (! docp) {
+		// TOdo convert to error?
 		php_error_docref(NULL, E_WARNING, "Node must be associated with a document");
 		RETURN_FALSE;
 	}
@@ -1587,6 +1595,7 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 					xmlXPathFreeObject(xpathobjp);
 				}
 				xmlXPathFreeContext(ctxp);
+				// Todo convert to error?
 				php_error_docref(NULL, E_WARNING, "XPath query did not return a nodeset.");
 				RETURN_FALSE;
 			}
@@ -1601,6 +1610,7 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 		if (tmp && Z_TYPE_P(tmp) == IS_STRING) {
 			xquery = Z_STRVAL_P(tmp);
 		} else {
+			// Todo convert to error?
 			php_error_docref(NULL, E_WARNING, "'query' missing from xpath array or is not a string");
 			RETURN_FALSE;
 		}
@@ -1738,6 +1748,7 @@ PHP_METHOD(DOMNode, getNodePath)
 
 	value = (char *) xmlGetNodePath(nodep);
 	if (value == NULL) {
+		// Todo return empty string?
 		RETURN_NULL();
 	} else {
 		RETVAL_STRING(value);

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -857,7 +857,6 @@ PHP_METHOD(DOMNode, insertBefore)
 
 	new_child = NULL;
 
-	// Todo should always be strict?
 	stricterror = dom_get_strict_error(intern->document);
 
 	if (dom_node_is_read_only(parentp) == SUCCESS ||
@@ -877,7 +876,7 @@ PHP_METHOD(DOMNode, insertBefore)
 	}
 
 	if (child->type == XML_DOCUMENT_FRAG_NODE && child->children == NULL) {
-		// Todo convert to Error?
+		/* TODO Drop Warning? */
 		php_error_docref(NULL, E_WARNING, "Document Fragment is empty");
 		RETURN_FALSE;
 	}
@@ -1026,7 +1025,6 @@ PHP_METHOD(DOMNode, replaceChild)
 		RETURN_FALSE;
 	}
 
-	// Todo make alway strict?
 	stricterror = dom_get_strict_error(intern->document);
 
 	if (dom_node_is_read_only(nodep) == SUCCESS ||
@@ -1177,7 +1175,7 @@ PHP_METHOD(DOMNode, appendChild)
 	}
 
 	if (child->type == XML_DOCUMENT_FRAG_NODE && child->children == NULL) {
-		// Todo convert to error?
+		/* TODO Drop Warning? */
 		php_error_docref(NULL, E_WARNING, "Document Fragment is empty");
 		RETURN_FALSE;
 	}
@@ -1468,7 +1466,6 @@ PHP_METHOD(DOMNode, lookupPrefix)
 		}
 	}
 
-	// Todo return empty string?
 	RETURN_NULL();
 }
 /* }}} end dom_node_lookup_prefix */
@@ -1748,7 +1745,7 @@ PHP_METHOD(DOMNode, getNodePath)
 
 	value = (char *) xmlGetNodePath(nodep);
 	if (value == NULL) {
-		// Todo return empty string?
+		/* TODO Research if can return empty string */
 		RETURN_NULL();
 	} else {
 		RETVAL_STRING(value);

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -151,6 +151,7 @@ xmlNode* dom_zvals_to_fragment(php_libxml_ref_obj *document, xmlNode *contextNod
 		return NULL;
 	}
 
+	// Todo always strict mode?
 	stricterror = dom_get_strict_error(document);
 
 	for (i = 0; i < nodesc; i++) {
@@ -378,6 +379,7 @@ void dom_child_node_remove(dom_object *context)
 		return;
 	}
 
+	// Todo always strict?
 	stricterror = dom_get_strict_error(context->document);
 
 	if (dom_node_is_read_only(child) == SUCCESS ||

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -151,7 +151,6 @@ xmlNode* dom_zvals_to_fragment(php_libxml_ref_obj *document, xmlNode *contextNod
 		return NULL;
 	}
 
-	// Todo always strict mode?
 	stricterror = dom_get_strict_error(document);
 
 	for (i = 0; i < nodesc; i++) {
@@ -379,7 +378,6 @@ void dom_child_node_remove(dom_object *context)
 		return;
 	}
 
-	// Todo always strict?
 	stricterror = dom_get_strict_error(context->document);
 
 	if (dom_node_is_read_only(child) == SUCCESS ||

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -317,8 +317,9 @@ zval *dom_read_property(zend_object *object, zend_string *name, int type, void *
 	if (obj->prop_handler != NULL) {
 		hnd = zend_hash_find_ptr(obj->prop_handler, name);
 	} else if (instanceof_function(obj->std.ce, dom_node_class_entry)) {
-		// Should this be an error?
-		php_error(E_WARNING, "Couldn't fetch %s. Node no longer exists", ZSTR_VAL(obj->std.ce->name));
+		zend_throw_error(NULL, "Couldn't fetch %s. Node no longer exists", ZSTR_VAL(obj->std.ce->name));
+		retval = &EG(uninitialized_zval);
+		return retval;
 	}
 
 	if (hnd) {
@@ -467,9 +468,8 @@ PHP_FUNCTION(dom_import_simplexml)
 	if (nodep && nodeobj && (nodep->type == XML_ELEMENT_NODE || nodep->type == XML_ATTRIBUTE_NODE)) {
 		DOM_RET_OBJ((xmlNodePtr) nodep, &ret, (dom_object *)nodeobj);
 	} else {
-		// Should this be an error?
-		php_error_docref(NULL, E_WARNING, "Invalid Nodetype to import");
-		RETURN_NULL();
+		zend_argument_value_error(1, "cannot import invalid node type");
+		RETURN_THROWS();
 	}
 }
 /* }}} */
@@ -1210,8 +1210,8 @@ PHP_DOM_EXPORT zend_bool php_dom_create_object(xmlNodePtr obj, zval *return_valu
 			break;
 		}
 		default:
-			// Todo convert to value error?
-			php_error_docref(NULL, E_WARNING, "Unsupported node type: %d", obj->type);
+			/* TODO Convert to a ZEND assertion? */
+			zend_throw_error(NULL, "Unsupported node type: %d", obj->type);
 			ZVAL_NULL(return_value);
 			return 0;
 	}

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -317,6 +317,7 @@ zval *dom_read_property(zend_object *object, zend_string *name, int type, void *
 	if (obj->prop_handler != NULL) {
 		hnd = zend_hash_find_ptr(obj->prop_handler, name);
 	} else if (instanceof_function(obj->std.ce, dom_node_class_entry)) {
+		// Should this be an error?
 		php_error(E_WARNING, "Couldn't fetch %s. Node no longer exists", ZSTR_VAL(obj->std.ce->name));
 	}
 
@@ -466,6 +467,7 @@ PHP_FUNCTION(dom_import_simplexml)
 	if (nodep && nodeobj && (nodep->type == XML_ELEMENT_NODE || nodep->type == XML_ATTRIBUTE_NODE)) {
 		DOM_RET_OBJ((xmlNodePtr) nodep, &ret, (dom_object *)nodeobj);
 	} else {
+		// Should this be an error?
 		php_error_docref(NULL, E_WARNING, "Invalid Nodetype to import");
 		RETURN_NULL();
 	}
@@ -1208,6 +1210,7 @@ PHP_DOM_EXPORT zend_bool php_dom_create_object(xmlNodePtr obj, zval *return_valu
 			break;
 		}
 		default:
+			// Todo convert to value error?
 			php_error_docref(NULL, E_WARNING, "Unsupported node type: %d", obj->type);
 			ZVAL_NULL(return_value);
 			return 0;

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -468,7 +468,7 @@ PHP_FUNCTION(dom_import_simplexml)
 	if (nodep && nodeobj && (nodep->type == XML_ELEMENT_NODE || nodep->type == XML_ATTRIBUTE_NODE)) {
 		DOM_RET_OBJ((xmlNodePtr) nodep, &ret, (dom_object *)nodeobj);
 	} else {
-		zend_argument_value_error(1, "cannot import invalid node type");
+		zend_argument_value_error(1, "is not a valid node type");
 		RETURN_THROWS();
 	}
 }

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -150,10 +150,9 @@ entry = zend_register_internal_class_ex(&ce, parent_ce);
 		RETURN_THROWS(); \
 	}
 
-// Make this an error?
 #define DOM_NOT_IMPLEMENTED() \
-	php_error_docref(NULL, E_WARNING, "Not yet implemented"); \
-	return;
+	zend_throw_error(NULL, "Not yet implemented"); \
+	RETURN_THROWS();
 
 #define DOM_NODELIST 0
 #define DOM_NAMEDNODEMAP 1

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -150,6 +150,7 @@ entry = zend_register_internal_class_ex(&ce, parent_ce);
 		RETURN_THROWS(); \
 	}
 
+// Make this an error?
 #define DOM_NOT_IMPLEMENTED() \
 	php_error_docref(NULL, E_WARNING, "Not yet implemented"); \
 	return;

--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -201,7 +201,7 @@ class DOMElement implements DOMParentNode, DOMChildNode
     /** @return bool */
     public function removeAttribute(string $qualifiedName) {}
 
-    /** @return DOMAttr|false */
+    /** @return void */
     public function removeAttributeNS(?string $namespace, string $localName) {}
 
     /** @return DOMAttr|false */
@@ -210,7 +210,7 @@ class DOMElement implements DOMParentNode, DOMChildNode
     /** @return DOMAttr|bool */
     public function setAttribute(string $qualifiedName, string $value) {}
 
-    /** @return bool|null */
+    /** @return void */
     public function setAttributeNS(?string $namespace, string $qualifiedName, string $value) {}
 
     /** @return DOMAttr|null|false */

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8ac9356f9b19b84e98d335bc9d091b022a0f549d */
+ * Stub hash: 128108b08807ce0b125fc7b963bf3c5b77e6987a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 1)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)

--- a/ext/dom/processinginstruction.c
+++ b/ext/dom/processinginstruction.c
@@ -46,14 +46,14 @@ PHP_METHOD(DOMProcessingInstruction, __construct)
 	name_valid = xmlValidateName((xmlChar *) name, 0);
 	if (name_valid != 0) {
 		php_dom_throw_error(INVALID_CHARACTER_ERR, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	nodep = xmlNewPI((xmlChar *) name, (xmlChar *) value);
 
 	if (!nodep) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	intern = Z_DOMOBJ_P(ZEND_THIS);

--- a/ext/dom/tests/DOMAttr_ownerElement_error_001.phpt
+++ b/ext/dom/tests/DOMAttr_ownerElement_error_001.phpt
@@ -14,10 +14,11 @@ $document->appendChild($root);
 $attr = $root->setAttribute('category', 'books');
 $document->removeChild($root);
 $root = null;
-var_dump($attr->ownerElement);
+try {
+    var_dump($attr->ownerElement);
+} catch (\Error $e) {
+    echo get_class($e) . ': ' . $e->getMessage() . \PHP_EOL;
+}
 ?>
---EXPECTF--
-Warning: Couldn't fetch DOMAttr. Node no longer exists in %s on line %d
-
-Warning: Undefined property: DOMAttr::$ownerElement in %s on line %d
-NULL
+--EXPECT--
+Error: Couldn't fetch DOMAttr. Node no longer exists

--- a/ext/dom/tests/DOMDocument_adoptNode.phpt
+++ b/ext/dom/tests/DOMDocument_adoptNode.phpt
@@ -10,7 +10,11 @@ require_once('skipif.inc');
 $dom = new DOMDocument();
 $dom->loadXML("<root />");
 
-$dom->adoptNode($dom->documentElement);
+try {
+    $dom->adoptNode($dom->documentElement);
+} catch (\Error $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 ?>
---EXPECTF--
-Warning: DOMDocument::adoptNode(): Not yet implemented in %s
+--EXPECT--
+Not yet implemented

--- a/ext/dom/tests/DOMDocument_encoding_basic.phpt
+++ b/ext/dom/tests/DOMDocument_encoding_basic.phpt
@@ -44,7 +44,7 @@ echo "UTF-16 Encoding Read: {$dom->encoding}\n";
 ?>
 --EXPECT--
 Empty Encoding Read: ''
-Invalid Document Encoding
+Invalid document encoding
 Adding ISO-8859-1 encoding: ISO-8859-1
 ISO-8859-1 Encoding Read: ISO-8859-1
 Adding UTF-8 encoding: UTF-8

--- a/ext/dom/tests/DOMDocument_encoding_basic.phpt
+++ b/ext/dom/tests/DOMDocument_encoding_basic.phpt
@@ -19,10 +19,14 @@ if( !$dom )
     exit;
 }
 
-echo "Empty Encoding Read: {$dom->encoding}\n";
+echo "Empty Encoding Read: '{$dom->encoding}'\n";
 
-$ret = $dom->encoding = 'NYPHP DOMinatrix';
-echo "Adding invalid encoding: $ret\n";
+try {
+    $ret = $dom->encoding = 'NYPHP DOMinatrix';
+    echo "Adding invalid encoding: $ret\n";
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 
 $ret = $dom->encoding = 'ISO-8859-1';
 echo "Adding ISO-8859-1 encoding: $ret\n";
@@ -38,11 +42,9 @@ echo "UTF-16 Encoding Read: {$dom->encoding}\n";
 
 
 ?>
---EXPECTF--
-Empty Encoding Read: 
-
-Warning: main(): Invalid Document Encoding in %s on line %d
-Adding invalid encoding: NYPHP DOMinatrix
+--EXPECT--
+Empty Encoding Read: ''
+Invalid Document Encoding
 Adding ISO-8859-1 encoding: ISO-8859-1
 ISO-8859-1 Encoding Read: ISO-8859-1
 Adding UTF-8 encoding: UTF-8

--- a/ext/dom/tests/DOMNode_C14NFile_basic.phpt
+++ b/ext/dom/tests/DOMNode_C14NFile_basic.phpt
@@ -27,6 +27,16 @@ $node = $doc->getElementsByTagName('title')->item(0);
 var_dump($node->C14NFile($output));
 $content = file_get_contents($output);
 var_dump($content);
+try {
+    var_dump($node->C14NFile($output, false, false, []));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump($node->C14NFile($output, false, false, ['query' => []]));
+} catch (\TypeError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 ?>
 --CLEAN--
 <?php
@@ -36,3 +46,5 @@ unlink($output);
 --EXPECT--
 int(34)
 string(34) "<title>The Grapes of Wrath</title>"
+DOMNode::C14NFile(): Argument #4 ($xpath) must have a "query" key
+DOMNode::C14NFile(): Argument #4 ($xpath) "query" option must be a string, array given

--- a/ext/dom/tests/DOMNode_C14N_basic.phpt
+++ b/ext/dom/tests/DOMNode_C14N_basic.phpt
@@ -24,6 +24,19 @@ $doc = new DOMDocument();
 $doc->loadXML($xml);
 $node = $doc->getElementsByTagName('title')->item(0);
 var_dump($node->C14N());
+
+try {
+    var_dump($node->C14N(false, false, []));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    var_dump($node->C14N(false, false, ['query' => []]));
+} catch (\TypeError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 ?>
 --EXPECT--
 string(34) "<title>The Grapes of Wrath</title>"
+DOMNode::C14N(): Argument #3 ($xpath) must have a "query" key
+DOMNode::C14N(): Argument #3 ($xpath) "query" option must be a string, array given

--- a/ext/dom/tests/bug36756.phpt
+++ b/ext/dom/tests/bug36756.phpt
@@ -13,7 +13,6 @@ $node = $xpath->query('/root')->item(0);
 echo $node->nodeName . "\n";
 $dom->removeChild($GLOBALS['dom']->firstChild);
 echo "nodeType: " . $node->nodeType . "\n";
-
 /* Node gets destroyed during removeChild */
 $dom->loadXML('<root><child/></root>');
 $xpath = new DOMXpath($dom);
@@ -21,15 +20,15 @@ $node = $xpath->query('//child')->item(0);
 echo $node->nodeName . "\n";
 $GLOBALS['dom']->removeChild($GLOBALS['dom']->firstChild);
 
-echo "nodeType: " . $node->nodeType . "\n";
+try {
+    echo "nodeType: " . $node->nodeType . "\n";
+} catch (\Error $e) {
+    echo get_class($e) . ': ' . $e->getMessage() .\PHP_EOL;
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 root
 nodeType: 1
 child
-
-Warning: Couldn't fetch DOMElement. Node no longer exists in %sbug36756.php on line %d
-
-Warning: Undefined property: DOMElement::$nodeType in %s on line %d
-nodeType:
+Error: Couldn't fetch DOMElement. Node no longer exists

--- a/ext/dom/tests/bug77569.phpt
+++ b/ext/dom/tests/bug77569.phpt
@@ -15,4 +15,4 @@ try {
 }
 ?>
 --EXPECT--
-Invalid Document Encoding
+Invalid document encoding

--- a/ext/dom/tests/bug77569.phpt
+++ b/ext/dom/tests/bug77569.phpt
@@ -8,7 +8,11 @@ if (!extension_loaded('dom')) die('skip dom extension not available');
 <?php
 $imp = new DOMImplementation;
 $dom = $imp->createDocument("", "");
-$dom->encoding = null;
+try {
+    $dom->encoding = null;
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 ?>
---EXPECTF--
-Warning: main(): Invalid Document Encoding in %s on line %d
+--EXPECT--
+Invalid Document Encoding

--- a/ext/dom/tests/domxpath.phpt
+++ b/ext/dom/tests/domxpath.phpt
@@ -57,10 +57,17 @@ try {
 } catch (\Error $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
+try {
+    $xpath->registerPhpFunctions(['non_existant']);
+    $avg = $xpath->evaluate('number(php:function("non_existent", //def:testnode))');
+} catch (\Error $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 ?>
 --EXPECT--
 myval
 float(1)
 bool(true)
 float(4)
+Unable to call handler non_existent()
 Unable to call handler non_existent()

--- a/ext/dom/tests/domxpath.phpt
+++ b/ext/dom/tests/domxpath.phpt
@@ -50,9 +50,17 @@ $root->appendChild($dom->createElementNS("urn::default", "testnode", 5));
 
 $avg = $xpath->evaluate('number(php:function("MyAverage", //def:testnode))');
 var_dump($avg);
+
+try {
+    $xpath->registerPHPFunctions('non_existent');
+    $avg = $xpath->evaluate('number(php:function("non_existent", //def:testnode))');
+} catch (\Error $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
 ?>
 --EXPECT--
 myval
 float(1)
 bool(true)
 float(4)
+Unable to call handler non_existent()

--- a/ext/dom/text.c
+++ b/ext/dom/text.c
@@ -47,7 +47,7 @@ PHP_METHOD(DOMText, __construct)
 
 	if (!nodep) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	intern = Z_DOMOBJ_P(ZEND_THIS);
@@ -123,16 +123,19 @@ PHP_METHOD(DOMText, splitText)
 	DOM_GET_OBJ(node, id, xmlNodePtr, intern);
 
 	if (node->type != XML_TEXT_NODE && node->type != XML_CDATA_SECTION_NODE) {
+		// Todo make this throw an error?
 		RETURN_FALSE;
 	}
 
 	cur = xmlNodeGetContent(node);
 	if (cur == NULL) {
+		// Todo make this throw an error?
 		RETURN_FALSE;
 	}
 	length = xmlUTF8Strlen(cur);
 
 	if (ZEND_LONG_INT_OVFL(offset) || (int)offset > length || offset < 0) {
+		// Todo make this throw an error?
 		xmlFree(cur);
 		RETURN_FALSE;
 	}
@@ -149,6 +152,7 @@ PHP_METHOD(DOMText, splitText)
 	xmlFree(second);
 
 	if (nnode == NULL) {
+		// Todo make this throw an error?
 		RETURN_FALSE;
 	}
 

--- a/ext/dom/text.c
+++ b/ext/dom/text.c
@@ -122,20 +122,25 @@ PHP_METHOD(DOMText, splitText)
 	}
 	DOM_GET_OBJ(node, id, xmlNodePtr, intern);
 
+	if (offset < 0) {
+		zend_argument_value_error(1, "must be greater than or equal to 0");
+		RETURN_THROWS();
+	}
+
 	if (node->type != XML_TEXT_NODE && node->type != XML_CDATA_SECTION_NODE) {
-		// Todo make this throw an error?
+		/* TODO Add warning? */
 		RETURN_FALSE;
 	}
 
 	cur = xmlNodeGetContent(node);
 	if (cur == NULL) {
-		// Todo make this throw an error?
+		/* TODO Add warning? */
 		RETURN_FALSE;
 	}
 	length = xmlUTF8Strlen(cur);
 
-	if (ZEND_LONG_INT_OVFL(offset) || (int)offset > length || offset < 0) {
-		// Todo make this throw an error?
+	if (ZEND_LONG_INT_OVFL(offset) || (int)offset > length) {
+		/* TODO Add warning? */
 		xmlFree(cur);
 		RETURN_FALSE;
 	}
@@ -152,7 +157,7 @@ PHP_METHOD(DOMText, splitText)
 	xmlFree(second);
 
 	if (nnode == NULL) {
-		// Todo make this throw an error?
+		/* TODO Add warning? */
 		RETURN_FALSE;
 	}
 

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -136,6 +136,7 @@ static void dom_xpath_ext_function_php(xmlXPathParserContextPtr ctxt, int nargs,
 
 	obj = valuePop(ctxt);
 	if (obj->stringval == NULL) {
+		// Todo convert to type error?
 		php_error_docref(NULL, E_WARNING, "Handler name must be a string");
 		xmlXPathFreeObject(obj);
 		if (fci.param_count > 0) {
@@ -154,8 +155,10 @@ static void dom_xpath_ext_function_php(xmlXPathParserContextPtr ctxt, int nargs,
 	fci.retval = &retval;
 
 	if (!zend_make_callable(&fci.function_name, &callable)) {
+		// TODO make this an error?
 		php_error_docref(NULL, E_WARNING, "Unable to call handler %s()", ZSTR_VAL(callable));
 	} else if (intern->registerPhpFunctions == 2 && zend_hash_exists(intern->registered_phpfunctions, callable) == 0) {
+		// TODO make this an error?
 		php_error_docref(NULL, E_WARNING, "Not allowed to call handler '%s()'.", ZSTR_VAL(callable));
 		/* Push an empty string, so that we at least have an xslt result... */
 		valuePush(ctxt, xmlXPathNewString((xmlChar *)""));
@@ -176,6 +179,7 @@ static void dom_xpath_ext_function_php(xmlXPathParserContextPtr ctxt, int nargs,
 			} else if (Z_TYPE(retval) == IS_FALSE || Z_TYPE(retval) == IS_TRUE) {
 				valuePush(ctxt, xmlXPathNewBoolean(Z_TYPE(retval) == IS_TRUE));
 			} else if (Z_TYPE(retval) == IS_OBJECT) {
+				// TODO make this an error?
 				php_error_docref(NULL, E_WARNING, "A PHP Object cannot be converted to a XPath-string");
 				valuePush(ctxt, xmlXPathNewString((xmlChar *)""));
 			} else {
@@ -228,7 +232,7 @@ PHP_METHOD(DOMXPath, __construct)
 	ctx = xmlXPathNewContext(docp);
 	if (ctx == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 
 	intern = Z_XPATHOBJ_P(ZEND_THIS);
@@ -308,6 +312,7 @@ PHP_METHOD(DOMXPath, registerNamespace)
 
 	ctxp = (xmlXPathContextPtr) intern->dom.ptr;
 	if (ctxp == NULL) {
+		// Todo convert to error?
 		php_error_docref(NULL, E_WARNING, "Invalid XPath Context");
 		RETURN_FALSE;
 	}
@@ -352,12 +357,14 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type) /* {{{ */
 
 	ctxp = (xmlXPathContextPtr) intern->dom.ptr;
 	if (ctxp == NULL) {
+		// Todo convert to error?
 		php_error_docref(NULL, E_WARNING, "Invalid XPath Context");
 		RETURN_FALSE;
 	}
 
 	docp = (xmlDocPtr) ctxp->doc;
 	if (docp == NULL) {
+		// Todo convert to error?
 		php_error_docref(NULL, E_WARNING, "Invalid XPath Document Pointer");
 		RETURN_FALSE;
 	}
@@ -371,6 +378,7 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type) /* {{{ */
 	}
 
 	if (nodep && docp != nodep->doc) {
+		// Todo convert to error?
 		php_error_docref(NULL, E_WARNING, "Node From Wrong Document");
 		RETURN_FALSE;
 	}
@@ -401,6 +409,7 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type) /* {{{ */
 	}
 
 	if (! xpathobjp) {
+		// Make this an error state?
 		RETURN_FALSE;
 	}
 

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -353,7 +353,6 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type) /* {{{ */
 
 	docp = (xmlDocPtr) ctxp->doc;
 	if (docp == NULL) {
-		// Todo convert to error?
 		php_error_docref(NULL, E_WARNING, "Invalid XPath Document Pointer");
 		RETURN_FALSE;
 	}
@@ -397,7 +396,7 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type) /* {{{ */
 	}
 
 	if (! xpathobjp) {
-		// Make this an error state?
+		/* TODO Add Warning? */
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
@beberlei you may want to give your opinion if the ones I marked with TODO should be converted.

Moreover, I wonder if all those using the ``php_dom_throw_error()`` function should actually throw instead of using a flag to sometimes emit a warning instead. But I think those are because they work with a file stream?