### PR TITLE
Fix #79497:  issue with php_openssl_subtract_timeval() causing ssl connection errors

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2189,8 +2189,8 @@ static struct timeval php_openssl_subtract_timeval(struct timeval a, struct time
 	difference.tv_usec = a.tv_usec - b.tv_usec;
 
 	if (a.tv_usec < b.tv_usec) {
-	  	b.tv_sec  -= 1L;
-	   	b.tv_usec += 1000000L;
+	  	difference.tv_sec  -= 1L;
+	   	difference.tv_usec += 1000000L;
 	}
 
 	return difference;


### PR DESCRIPTION
I stumbled upon this while debugging a strange issue with `stream_socket_client()` where it randomly throws out errors when the connection timeout is set to below 1s. The logic to calculate time difference in `php_openssl_subtract_timeval()` is wrong when `a.tv_usec < b.tv_usec`, causing connection errors before the timeout is reached.

I have created a script to reproduce the issue - https://gist.github.com/joec4i/ef1b1156ed79e23487400c68a5f693cb 

### Before the patch
```
$ php socket_test.php 2000 0.9 | grep error
failed in 0.0037751197814941s, error.no=0, errstr=
failed in 0.0031719207763672s, error.no=0, errstr=
failed in 0.0026381015777588s, error.no=0, errstr=
failed in 0.0029230117797852s, error.no=0, errstr=
failed in 0.0027728080749512s, error.no=0, errstr=
Tested 2000 connections(timeout=0.9) with in 6.1318738460541s with 5 errors
```
The number of errors may vary but as you can see, connection failures happened way before the 0.9s timeout.

### After the patch
```
$ php socket_test.php 10000 0.1 | grep error
Tested 10000 connections(timeout=0.1) with in 28.441427946091s with 0 errors
```

Please review. Thanks!