### PR TITLE
Add get_resource_id() function

### DIFF
--- a/Zend/tests/get_resource_id.phpt
+++ b/Zend/tests/get_resource_id.phpt
@@ -1,0 +1,18 @@
+--TEST--
+get_resource_id() function
+--FILE--
+<?php
+
+$file = fopen(__FILE__, 'r');
+
+// get_resource_id() is equivalent to an integer cast.
+var_dump(get_resource_id($file) === (int) $file);
+
+// Also works with closed resources.
+fclose($file);
+var_dump(get_resource_id($file) === (int) $file);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1505,6 +1505,20 @@ ZEND_FUNCTION(get_resource_type)
 }
 /* }}} */
 
+/* {{{ proto int get_resource_id(resource res)
+   Get the resource ID for a given resource */
+ZEND_FUNCTION(get_resource_id)
+{
+	zval *resource;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_RESOURCE(resource)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_LONG(Z_RES_HANDLE_P(resource));
+}
+/* }}} */
+
 /* {{{ proto array get_resources([string resouce_type])
    Get an array with all active resources */
 ZEND_FUNCTION(get_resources)

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -91,6 +91,8 @@ function get_defined_vars(): array {}
 
 function get_resource_type($res): string {}
 
+function get_resource_id($res): int {}
+
 function get_resources(string $type = UNKNOWN): array {}
 
 function get_loaded_extensions(bool $zend_extensions = false): array {}

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -155,6 +155,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_resource_type, 0, 1, IS_STRI
 	ZEND_ARG_INFO(0, res)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_resource_id, 0, 1, IS_LONG, 0)
+	ZEND_ARG_INFO(0, res)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_resources, 0, 0, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, type, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -244,6 +248,7 @@ ZEND_FUNCTION(get_declared_interfaces);
 ZEND_FUNCTION(get_defined_functions);
 ZEND_FUNCTION(get_defined_vars);
 ZEND_FUNCTION(get_resource_type);
+ZEND_FUNCTION(get_resource_id);
 ZEND_FUNCTION(get_resources);
 ZEND_FUNCTION(get_loaded_extensions);
 ZEND_FUNCTION(get_defined_constants);
@@ -305,6 +310,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(get_defined_functions, arginfo_get_defined_functions)
 	ZEND_FE(get_defined_vars, arginfo_get_defined_vars)
 	ZEND_FE(get_resource_type, arginfo_get_resource_type)
+	ZEND_FE(get_resource_id, arginfo_get_resource_id)
 	ZEND_FE(get_resources, arginfo_get_resources)
 	ZEND_FE(get_loaded_extensions, arginfo_get_loaded_extensions)
 	ZEND_FE(get_defined_constants, arginfo_get_defined_constants)


### PR DESCRIPTION
This is a more obvious and type-safe form of `(int) $resource`.