### PR TITLE
Fix #79487: ::getStaticProperties() ignores property modifications

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3781,21 +3781,24 @@ ZEND_METHOD(reflection_class, getStaticProperties)
 	array_init(return_value);
 
 	ZEND_HASH_FOREACH_STR_KEY_PTR(&ce->properties_info, key, prop_info) {
+		zval *members;
+
 		if (((prop_info->flags & ZEND_ACC_PRIVATE) &&
 		     prop_info->ce != ce)) {
 			continue;
 		}
-		prop = NULL;
-		if ((prop_info->flags & ZEND_ACC_STATIC) != 0) {
-			zval *members;
-			if ((members = CE_STATIC_MEMBERS(ce))) {
-				prop = &members[prop_info->offset];
-			} else {
-				prop = &ce->default_static_members_table[prop_info->offset];
-			}
-			ZVAL_DEINDIRECT(prop);
+		if ((prop_info->flags & ZEND_ACC_STATIC) == 0) {
+			continue;
 		}
-		if (!prop || (prop_info->type && Z_ISUNDEF_P(prop))) {
+
+		if ((members = CE_STATIC_MEMBERS(ce))) {
+			prop = &members[prop_info->offset];
+		} else {
+			prop = &ce->default_static_members_table[prop_info->offset];
+		}
+		ZVAL_DEINDIRECT(prop);
+
+		if (prop_info->type && Z_ISUNDEF_P(prop)) {
 			continue;
 		}
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3726,9 +3726,7 @@ static void add_class_vars(zend_class_entry *ce, int statics, zval *return_value
 	zend_string *key;
 
 	ZEND_HASH_FOREACH_STR_KEY_PTR(&ce->properties_info, key, prop_info) {
-		if (((prop_info->flags & ZEND_ACC_PROTECTED) &&
-		     !zend_check_protected(prop_info->ce, ce)) ||
-		    ((prop_info->flags & ZEND_ACC_PRIVATE) &&
+		if (((prop_info->flags & ZEND_ACC_PRIVATE) &&
 		     prop_info->ce != ce)) {
 			continue;
 		}
@@ -3783,9 +3781,7 @@ ZEND_METHOD(reflection_class, getStaticProperties)
 	array_init(return_value);
 
 	ZEND_HASH_FOREACH_STR_KEY_PTR(&ce->properties_info, key, prop_info) {
-		if (((prop_info->flags & ZEND_ACC_PROTECTED) &&
-		     !zend_check_protected(prop_info->ce, ce)) ||
-		    ((prop_info->flags & ZEND_ACC_PRIVATE) &&
+		if (((prop_info->flags & ZEND_ACC_PRIVATE) &&
 		     prop_info->ce != ce)) {
 			continue;
 		}

--- a/ext/reflection/tests/bug79487.phpt
+++ b/ext/reflection/tests/bug79487.phpt
@@ -9,9 +9,26 @@ class Foo {
 Foo::$bar = 'new';
 $rc = new ReflectionClass('Foo');
 var_dump($rc->getStaticProperties());
+
+class A {
+  public static $a = 'A old';
+}
+class B extends A {
+  public static $b = 'B old';
+}
+
+$rc = new ReflectionClass(B::class);
+A::$a = 'A new';
+var_dump($rc->getStaticProperties());
 ?>
 --EXPECT--
 array(1) {
   ["bar"]=>
   string(3) "new"
+}
+array(2) {
+  ["b"]=>
+  string(5) "B old"
+  ["a"]=>
+  string(5) "A new"
 }

--- a/ext/reflection/tests/bug79487.phpt
+++ b/ext/reflection/tests/bug79487.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #79487 (::getStaticProperties() ignores property modifications)
+--FILE--
+<?php
+class Foo {
+    public static $bar = 'orig';
+}
+
+Foo::$bar = 'new';
+$rc = new ReflectionClass('Foo');
+var_dump($rc->getStaticProperties());
+?>
+--EXPECT--
+array(1) {
+  ["bar"]=>
+  string(3) "new"
+}


### PR DESCRIPTION
When retrieving the static class properties via reflection, we have to
cater to possible modifications.