### PR TITLE
[skip ci] Document change to ReflectionMethod->isConstructor/isDestructor

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -192,7 +192,7 @@ PHP 8.0 UPGRADE NOTES
 - dom:
   . Remove unimplemented classes from ext/dom that had no behavior and contained
     test data. These classes have also been removed in the latest version of DOM
-	standard:
+    standard:
 
      * DOMNameList
      * DomImplementationList
@@ -325,6 +325,9 @@ PHP 8.0 UPGRADE NOTES
         ReflectionParameter::getDefaultValue()
         ReflectionParameter::isDefaultValueConstant()
         ReflectionParameter::getDefaultValueConstantName()
+  . ReflectionMethod::isConstructor() and ReflectionMethod::isDestructor() now
+    also return true for `__construct` and `__destruct` in methods of interfaces.
+    Previously, this would only be true in methods of classes and traits.
 
 - Socket:
   . The deprecated AI_IDN_ALLOW_UNASSIGNED and AI_IDN_USE_STD3_ASCII_RULES

--- a/ext/reflection/tests/ReflectionMethod_basic1.phpt
+++ b/ext/reflection/tests/ReflectionMethod_basic1.phpt
@@ -49,6 +49,14 @@ class DerivedClass extends TestClass {}
 
 interface TestInterface {
     public function int();
+    public function __construct($arg);
+    public function __destruct();
+}
+
+trait TestTrait {
+    public abstract function __construct();
+    public function __destruct() {
+    }
 }
 
 reflectMethod("DerivedClass", "foo");
@@ -59,6 +67,10 @@ reflectMethod("DerivedClass", "prot");
 reflectMethod("TestInterface", "int");
 reflectMethod("ReflectionProperty", "__construct");
 reflectMethod("TestClass", "__destruct");
+reflectMethod("TestInterface", "__construct");
+reflectMethod("TestInterface", "__destruct");
+reflectMethod("TestTrait", "__construct");
+reflectMethod("TestTrait", "__destruct");
 
 ?>
 --EXPECT--
@@ -267,6 +279,122 @@ bool(false)
 **********************************
 **********************************
 Reflecting on method TestClass::__destruct()
+
+
+isFinal():
+bool(false)
+
+isAbstract():
+bool(false)
+
+isPublic():
+bool(true)
+
+isPrivate():
+bool(false)
+
+isProtected():
+bool(false)
+
+isStatic():
+bool(false)
+
+isConstructor():
+bool(false)
+
+isDestructor():
+bool(true)
+
+**********************************
+**********************************
+Reflecting on method TestInterface::__construct()
+
+
+isFinal():
+bool(false)
+
+isAbstract():
+bool(true)
+
+isPublic():
+bool(true)
+
+isPrivate():
+bool(false)
+
+isProtected():
+bool(false)
+
+isStatic():
+bool(false)
+
+isConstructor():
+bool(true)
+
+isDestructor():
+bool(false)
+
+**********************************
+**********************************
+Reflecting on method TestInterface::__destruct()
+
+
+isFinal():
+bool(false)
+
+isAbstract():
+bool(true)
+
+isPublic():
+bool(true)
+
+isPrivate():
+bool(false)
+
+isProtected():
+bool(false)
+
+isStatic():
+bool(false)
+
+isConstructor():
+bool(false)
+
+isDestructor():
+bool(true)
+
+**********************************
+**********************************
+Reflecting on method TestTrait::__construct()
+
+
+isFinal():
+bool(false)
+
+isAbstract():
+bool(true)
+
+isPublic():
+bool(true)
+
+isPrivate():
+bool(false)
+
+isProtected():
+bool(false)
+
+isStatic():
+bool(false)
+
+isConstructor():
+bool(true)
+
+isDestructor():
+bool(false)
+
+**********************************
+**********************************
+Reflecting on method TestTrait::__destruct()
 
 
 isFinal():


### PR DESCRIPTION
See https://externals.io/message/109377
This prevented PHPUnit's test doubles from being created for interfaces.

The reason this changed is
https://github.com/php/php-src/pull/3846/files#diff-3a8139128d4026ce0cb0c86beba4e6b9L5549-R5605
(ReflectionMethod::isConstruct checks if the method is the zend_class_entry's
constructor, etc.)