### PR TITLE
Fix #63575: Root elements are not properly cloned

### DIFF
--- a/ext/simplexml/tests/bug39662.phpt
+++ b/ext/simplexml/tests/bug39662.phpt
@@ -23,7 +23,9 @@ object(SimpleXMLElement)#%d (0) {
 }
 object(SimpleXMLElement)#%d (0) {
 }
-string(15) "<test>
+string(%d) "<?xml version="1.0" encoding="utf-8"?>
+<test>
 
-</test>"
+</test>
+"
 Done

--- a/ext/simplexml/tests/bug63575.phpt
+++ b/ext/simplexml/tests/bug63575.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #63575 (Root elements are not properly cloned)
+--SKIPIF--
+<?php
+if (!extension_loaded('simplexml')) die('skip simplexml extension not available');
+?>
+--FILE--
+<?php
+$xml = '<a><b></b></a>';
+
+$o1 = new SimpleXMlElement($xml);
+$o2 = clone $o1;
+
+$r = current($o2->xpath('/a'));
+$r->addChild('c', new SimpleXMlElement('<c></c>'));
+
+echo $o1->asXML(), PHP_EOL, $o2->asXML();
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<a><b/></a>
+
+<?xml version="1.0"?>
+<a><b/><c/></a>


### PR DESCRIPTION
Cloning of root elements has to preserve that property, so they require
some special treatment.