### PR TITLE
Fix #36365: scandir duplicates file name at every 65535th file

### DIFF
--- a/ext/standard/tests/file/bug36365.phpt
+++ b/ext/standard/tests/file/bug36365.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #36365 (scandir duplicates file name at every 65535th file)
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) die('skip slow test');
+?>
+--FILE--
+<?php
+$testdir = __DIR__ . '/bug36365';
+
+mkdir($testdir);
+for ($i = 0; $i < 70000; $i++) {
+    touch(sprintf("$testdir/%05d.txt", $i));
+}
+
+var_dump(count(scandir($testdir)));
+?>
+--CLEAN--
+<?php
+$testdir = __DIR__ . '/bug36365';
+for ($i = 0; $i < 70000; $i++) {
+    unlink(sprintf("$testdir/%05d.txt", $i));
+}
+rmdir($testdir);
+?>
+--EXPECT--
+int(70002)

--- a/win32/readdir.h
+++ b/win32/readdir.h
@@ -26,7 +26,7 @@ struct dirent {
 /* typedef DIR - not the same as Unix */
 struct DIR_W32 {
 	HANDLE handle;			/* _findfirst/_findnext handle */
-	uint16_t offset;		/* offset into directory */
+	uint32_t offset;		/* offset into directory */
 	uint8_t finished;		/* 1 if there are not more files */
 	WIN32_FIND_DATAW fileinfo;	/* from _findfirst/_findnext */
 	wchar_t *dirw;			/* the dir we are reading */


### PR DESCRIPTION
Since DIR_W32.offset is declared as `uint16_t`, we have an overflow for
directories with many entries.  This patch changes the field to
`uint32_t`.

---

The test is slow, but if commit 4e8f01c had a respective test case, we wouldn't have had that regression.

Note that there might be room for optimization on 32bit architectures, namely by merging `offset` and `finished` in a `uint32_t` bitfield; not sure if that worth it.