### PR TITLE
Clean section of test not working due to short open tags

### DIFF
--- a/ext/phar/tests/bug79082.phpt
+++ b/ext/phar/tests/bug79082.phpt
@@ -34,7 +34,7 @@ foreach([Phar::TAR => 'tar', Phar::ZIP => 'zip'] as $mode => $ext) {
 }
 ?>
 --CLEAN--
-<?
+<?php
 unlink(__DIR__ . '/test79082.tar');
 unlink(__DIR__ . '/test79082.zip');
 unlink(__DIR__ . '/test79082-d.tar');


### PR DESCRIPTION
💡: We could test it during CI, checking if, after the tests been run, there's nothing pending to be added.