### PR TITLE
Check Serialization magic methods structure

### DIFF
--- a/Zend/tests/magic_methods_serialize.phpt
+++ b/Zend/tests/magic_methods_serialize.phpt
@@ -1,0 +1,12 @@
+--TEST--
+__serialize declaration
+--FILE--
+<?php
+class Foo {
+	static function __serialize($arguments) {}
+}
+?>
+--EXPECTF--
+Warning: The magic method Foo::__serialize() must have public visibility and cannot be static in %s on line %d
+
+Fatal error: Method Foo::__serialize() cannot take arguments in %s on line %d

--- a/Zend/tests/magic_methods_unserialize.phpt
+++ b/Zend/tests/magic_methods_unserialize.phpt
@@ -1,0 +1,12 @@
+--TEST--
+__unserialize declaration
+--FILE--
+<?php
+class Foo {
+	static function __unserialize($data, $value) {}
+}
+?>
+--EXPECTF--
+Warning: The magic method Foo::__unserialize() must have public visibility and cannot be static in %s on line %d
+
+Fatal error: Method Foo::__unserialize() must take exactly 1 argument in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2023,6 +2023,18 @@ ZEND_API void zend_check_magic_method_implementation(const zend_class_entry *ce,
 	} else if (name_len == sizeof(ZEND_DEBUGINFO_FUNC_NAME) - 1 &&
 		!memcmp(lcname, ZEND_DEBUGINFO_FUNC_NAME, sizeof(ZEND_DEBUGINFO_FUNC_NAME)-1) && fptr->common.num_args != 0) {
 		zend_error(error_type, "Method %s::__debugInfo() cannot take arguments", ZSTR_VAL(ce->name));
+	} else if (
+		name_len == sizeof("__serialize") - 1
+		&& !memcmp(lcname, "__serialize", sizeof("__serialize") - 1)
+		&& fptr->common.num_args != 0
+	) {
+		zend_error(error_type, "Method %s::__serialize() cannot take arguments", ZSTR_VAL(ce->name));
+	} else if (
+		name_len == sizeof("__unserialize") - 1
+		&& !memcmp(lcname, "__unserialize", sizeof("__unserialize") - 1)
+		&& fptr->common.num_args != 1
+	) {
+		zend_error(error_type, "Method %s::__unserialize() must take exactly 1 argument", ZSTR_VAL(ce->name));
 	}
 }
 /* }}} */

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6173,6 +6173,10 @@ void zend_begin_method_decl(zend_op_array *op_array, zend_string *name, zend_boo
 	} else if (zend_string_equals_literal(lcname, ZEND_DEBUGINFO_FUNC_NAME)) {
 		zend_check_magic_method_attr(fn_flags, ce, "__debugInfo", 0);
 		ce->__debugInfo = (zend_function *) op_array;
+	} else if (zend_string_equals_literal(lcname, "__serialize")) {
+		zend_check_magic_method_attr(fn_flags, ce, "__serialize", 0);
+	} else if (zend_string_equals_literal(lcname, "__unserialize")) {
+		zend_check_magic_method_attr(fn_flags, ce, "__unserialize", 0);
 	}
 
 	zend_string_release_ex(lcname, 0);


### PR DESCRIPTION
Noticed that we don't check these methods' structures while working on #4177.