### PR TITLE
Test XSLTProcessor::importStylesheet() with invalid stylesheet.

### DIFF
--- a/ext/xsl/tests/xsltprocessor_importStylesheet-invalidparam.phpt
+++ b/ext/xsl/tests/xsltprocessor_importStylesheet-invalidparam.phpt
@@ -1,0 +1,19 @@
+--TEST--
+XSLTProcessor::importStylesheet() - Test with invalid stylesheet
+--SKIPIF--
+<?php
+if (!extension_loaded('xsl')) {
+    exit('Skip - XSL extension not loaded');
+}
+?>
+--FILE--
+<?php
+
+$xslt = new XSLTProcessor();
+$dummy = new stdClass();
+var_dump($xslt->importStylesheet($dummy));
+
+?>
+--EXPECTF--
+Warning: Invalid Document in %s on line %d
+bool(false) 


### PR DESCRIPTION
Test verifies that the parser returns the E_WARNING-level message "Invalid Document". This case is, as of now, not being tested.