### PR TITLE
Fixed run-tests.php for PHP 7.2

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2748,7 +2748,7 @@ COMMAND $cmd
         }
 
         // write .sh
-        if (strpos($log_format, 'S') !== false && file_put_contents($sh_filename, <<<SH
+        if (strpos($log_format, 'S') !== false && file_put_contents($sh_filename, '
 #!/bin/sh
 
 case "$1" in
@@ -2765,7 +2765,7 @@ case "$1" in
     {$cmd}
     ;;
 esac
-SH, FILE_BINARY) === false) {
+', FILE_BINARY) === false) {
             error("Cannot create test shell script - $sh_filename");
         }
         chmod($sh_filename, 0755);

--- a/run-tests.php
+++ b/run-tests.php
@@ -2748,7 +2748,7 @@ COMMAND $cmd
         }
 
         // write .sh
-        if (strpos($log_format, 'S') !== false && file_put_contents($sh_filename, '
+        $sh_script = <<<SH
 #!/bin/sh
 
 case "$1" in
@@ -2765,7 +2765,8 @@ case "$1" in
     {$cmd}
     ;;
 esac
-', FILE_BINARY) === false) {
+SH;
+        if (strpos($log_format, 'S') !== false && file_put_contents($sh_filename, $sh_script, FILE_BINARY) === false) {
             error("Cannot create test shell script - $sh_filename");
         }
         chmod($sh_filename, 0755);


### PR DESCRIPTION
This PR fixes a syntax error in `run-tests.php` when executed using PHP 7.2 series.

The error:
```bash
$ php -v
PHP 7.2.29 (cli) (built: Apr 23 2020 22:10:25) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
$ php -lf run-tests.php 
PHP Parse error:  syntax error, unexpected '"', expecting '-' or identifier (T_STRING) or variable (T_VARIABLE) or number (T_NUM_STRING) in run-tests.php on line 2786

Parse error: syntax error, unexpected '"', expecting '-' or identifier (T_STRING) or variable (T_VARIABLE) or number (T_NUM_STRING) in run-tests.php on line 2786
Errors parsing run-tests.php
```