### PR TITLE
Fix #79514: Memory leaks while including unexistent file

### DIFF
--- a/Zend/tests/bug79514.phpt
+++ b/Zend/tests/bug79514.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #79514 (Memory leaks while including unexistent file)
+--FILE--
+<?php
+$mem1 = memory_get_usage(true);
+for ($i = 0; $i < 100000; $i++) {
+    @include __DIR__ . '/bug79514.doesnotexist';
+}
+$mem2 = memory_get_usage(true);
+var_dump($mem2 - $mem1 < 100000);
+?>
+--EXPECT--
+bool(true)

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -518,8 +518,10 @@ ZEND_API int open_file_for_scanning(zend_file_handle *file_handle)
 	zend_string *compiled_filename;
 
 	if (zend_stream_fixup(file_handle, &buf, &size) == FAILURE) {
-		/* Still add it to open_files to make destroy_file_handle work */
-		zend_llist_add_element(&CG(open_files), file_handle);
+		if (file_handle->type != ZEND_HANDLE_FILENAME || file_handle->handle.fp != NULL) {
+			/* Still add it to open_files to make destroy_file_handle work */
+			zend_llist_add_element(&CG(open_files), file_handle);
+		}
 		return FAILURE;
 	}
 

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -518,10 +518,8 @@ ZEND_API int open_file_for_scanning(zend_file_handle *file_handle)
 	zend_string *compiled_filename;
 
 	if (zend_stream_fixup(file_handle, &buf, &size) == FAILURE) {
-		if (file_handle->type != ZEND_HANDLE_FILENAME || file_handle->handle.fp != NULL) {
-			/* Still add it to open_files to make destroy_file_handle work */
-			zend_llist_add_element(&CG(open_files), file_handle);
-		}
+		/* Still add it to open_files to make destroy_file_handle work */
+		zend_llist_add_element(&CG(open_files), file_handle);
 		return FAILURE;
 	}
 

--- a/Zend/zend_stream.c
+++ b/Zend/zend_stream.c
@@ -238,6 +238,8 @@ ZEND_API int zend_compare_file_handles(zend_file_handle *fh1, zend_file_handle *
 		return 0;
 	}
 	switch (fh1->type) {
+		case ZEND_HANDLE_FILENAME:
+			return strcmp(fh1->filename, fh2->filename) == 0;
 		case ZEND_HANDLE_FP:
 			return fh1->handle.fp == fh2->handle.fp;
 		case ZEND_HANDLE_STREAM:


### PR DESCRIPTION
We must not add files to `open_files` that have not been opened.