### PR TITLE
Fix intermittent test failure on AppVeyor

### DIFF
--- a/ext/mysqli/tests/mysqli_insert_packet_overflow.phpt
+++ b/ext/mysqli/tests/mysqli_insert_packet_overflow.phpt
@@ -71,6 +71,10 @@ memory_limit=256M
         printf("[011] Failed to change max_allowed_packet");
     }
 
+    if (!mysqli_query($link, 'DROP TABLE IF EXISTS test')) {
+        printf("[clean] Failed to drop old test table: [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    }
+
     if (!mysqli_query($link, "CREATE TABLE test(col_blob LONGBLOB) ENGINE=" . $engine))
         printf("[012] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 


### PR DESCRIPTION
For several days this test case is often failing on AppVeyor, because
the table already exists.  Thus, we add a cleanup step just before
creating the table.

---

I have no idea why this test suddenly started to fail that often. It seems that only happens on master, and might be caused by enabling JIT, although I can't see why that would cause just this test to fail. This fix is not nice; actually it's more a hacky workaround. I'm also not sure what to do with the error message numbering.