### PR TITLE
Fix memory leaks due to throw expressions

### DIFF
--- a/Zend/tests/throw/003.phpt
+++ b/Zend/tests/throw/003.phpt
@@ -1,0 +1,31 @@
+--TEST--
+throw expression should not leak temporaries
+--FILE--
+<?php
+
+try {
+    new stdClass(throw new Exception);
+} catch (Exception $e) {
+    echo "Caught\n";
+}
+
+try {
+    $a = [];
+    ($a + [1]) + throw new Exception;
+} catch (Exception $e) {
+    echo "Caught\n";
+}
+
+try {
+    @throw new Exception;
+} catch (Exception $e) {
+    echo "Caught\n";
+}
+var_dump(error_reporting());
+
+?>
+--EXPECT--
+Caught
+Caught
+Caught
+int(32767)

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -182,7 +182,8 @@ typedef struct _zend_live_range {
 
 typedef struct _zend_unfreed_var {
 	uint32_t var;
-	uint32_t opline_offset;
+	uint8_t var_type;
+	uint8_t opcode;
 } zend_unfreed_var;
 
 /* Compilation context that is different for each op array. */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -180,6 +180,11 @@ typedef struct _zend_live_range {
 	uint32_t end;
 } zend_live_range;
 
+typedef struct _zend_unfreed_var {
+	uint32_t var;
+	uint32_t opline_offset;
+} zend_unfreed_var;
+
 /* Compilation context that is different for each op array. */
 typedef struct _zend_oparray_context {
 	uint32_t   opcodes_size;
@@ -191,6 +196,10 @@ typedef struct _zend_oparray_context {
 	int        last_brk_cont;
 	zend_brk_cont_element *brk_cont_array;
 	HashTable *labels;
+
+	uint32_t unfreed_vars_num;
+	uint32_t unfreed_vars_size;
+	zend_unfreed_var *unfreed_vars;
 } zend_oparray_context;
 
 /* Class, property and method flags                  class|meth.|prop.|const*/


### PR DESCRIPTION
This introduces accurate tracking in the compiler of all the variables that are currently live. There's some overlap with the loop_var stack, and both can probably be combined (and preferably should be).

This allows us to free all pending variables before compiling a throw expression.

While the tracking here works, the actual freeing is incorrect as-is. The issue is that this just unconditionally frees everything, but of course the throw itself will also free the same variables based on live ranges, if the live ranges are present (without opcache).

I'm not quite sure on how to best handle this yet.