### PR TITLE
Avoid throw expression leaks

### DIFF
--- a/Zend/tests/throw/leaks.phpt
+++ b/Zend/tests/throw/leaks.phpt
@@ -1,0 +1,31 @@
+--TEST--
+throw expression should not leak temporaries
+--FILE--
+<?php
+
+try {
+    new stdClass(throw new Exception);
+} catch (Exception $e) {
+    echo "Caught\n";
+}
+
+try {
+    $a = [];
+    ($a + [1]) + throw new Exception;
+} catch (Exception $e) {
+    echo "Caught\n";
+}
+
+try {
+    @throw new Exception;
+} catch (Exception $e) {
+    echo "Caught\n";
+}
+var_dump(error_reporting());
+
+?>
+--EXPECT--
+Caught
+Caught
+Caught
+int(32767)

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4548,10 +4548,13 @@ void zend_compile_throw(znode *result, zend_ast *ast) /* {{{ */
 	znode expr_node;
 	zend_compile_expr(&expr_node, expr_ast);
 
-	zend_emit_op(NULL, ZEND_THROW, &expr_node, NULL);
-
-	result->op_type = IS_CONST;
-	ZVAL_BOOL(&result->u.constant, 1);
+	zend_op *opline = zend_emit_op(NULL, ZEND_THROW, &expr_node, NULL);
+	if (result) {
+		/* Mark this as an "expression throw" for opcache. */
+		opline->extended_value = ZEND_THROW_IS_EXPR;
+		result->op_type = IS_CONST;
+		ZVAL_BOOL(&result->u.constant, 1);
+	}
 }
 /* }}} */
 
@@ -8788,6 +8791,9 @@ void zend_compile_stmt(zend_ast *ast) /* {{{ */
 			break;
 		case ZEND_AST_HALT_COMPILER:
 			zend_compile_halt_compiler(ast);
+			break;
+		case ZEND_AST_THROW:
+			zend_compile_throw(NULL, ast);
 			break;
 		default:
 		{

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -927,6 +927,8 @@ ZEND_API zend_string *zend_type_to_string(zend_type type);
 #define ZEND_SEND_BY_REF     1u
 #define ZEND_SEND_PREFER_REF 2u
 
+#define ZEND_THROW_IS_EXPR 1u
+
 /* The send mode and is_variadic flag are stored as part of zend_type */
 #define _ZEND_SEND_MODE_SHIFT _ZEND_TYPE_EXTRA_FLAGS_SHIFT
 #define _ZEND_IS_VARIADIC_BIT (1 << (_ZEND_TYPE_EXTRA_FLAGS_SHIFT + 2))

--- a/ext/opcache/Optimizer/zend_cfg.c
+++ b/ext/opcache/Optimizer/zend_cfg.c
@@ -296,8 +296,14 @@ int zend_build_cfg(zend_arena **arena, const zend_op_array *op_array, uint32_t b
 			case ZEND_RETURN_BY_REF:
 			case ZEND_GENERATOR_RETURN:
 			case ZEND_EXIT:
-			case ZEND_THROW:
 				if (i + 1 < op_array->last) {
+					BB_START(i + 1);
+				}
+				break;
+			case ZEND_THROW:
+				/* Don't treat THROW as terminator if it's used in expression context,
+				 * as we may lose live ranges when eliminating unreachable code. */
+				if (opline->extended_value != ZEND_THROW_IS_EXPR && i + 1 < op_array->last) {
 					BB_START(i + 1);
 				}
 				break;


### PR DESCRIPTION
This uses the hack suggested by @TysonAndre. We mark `throw` if it is used in expression context, and don't treat it as a terminator in that case.

This gives us a bit less optimization opportunity, but avoids the complexity of #5448 or other "proper" solutions.