### PR TITLE
Test xml_error_string() and xml_get_error_code()

### DIFF
--- a/ext/xml/tests/xml_error_string_basic.phpt
+++ b/ext/xml/tests/xml_error_string_basic.phpt
@@ -1,5 +1,5 @@
 --TEST--
-xml_parser_get_option() - Test parameter not set
+xml_error_string() - Basic test on 5 error codes
 --SKIPIF--
 <?php
 if (!extension_loaded('xml')) {
@@ -8,16 +8,31 @@ if (!extension_loaded('xml')) {
 ?>
 --FILE--
 <?php
+$xmls = array(
+    '<?xml version="1.0"?><element>',
+    '<?xml>',
+    '<?xml version="dummy">',
+    '<?xml?>',
+    '<?xml version="1.0"?><elem></element>',
+);
 
-$xml = '<?xml?>';
-
-$xml_parser = xml_parser_create();
-
-if (!xml_parse($xml_parser, $xml, true)) {
-    var_dump(xml_get_error_code($xml_parser));
-    var_dump(xml_error_string(xml_get_error_code($xml_parser)));
+foreach ($xmls as $xml) {
+    $xml_parser = xml_parser_create();
+    if (!xml_parse($xml_parser, $xml, true)) {
+        var_dump(xml_get_error_code($xml_parser));
+        var_dump(xml_error_string(xml_get_error_code($xml_parser)));
+    }
+    xml_parser_free($xml_parser);
 }
 ?>
 --EXPECTF--
+int(5)
+string(20) "Invalid document end"
+int(47)
+string(35) "Processing Instruction not finished"
+int(57)
+string(28) "XML declaration not finished"
 int(64)
 string(17) "Reserved XML Name"
+int(76)
+string(14) "Mismatched tag"

--- a/ext/xml/tests/xml_error_string_basic.phpt
+++ b/ext/xml/tests/xml_error_string_basic.phpt
@@ -1,0 +1,23 @@
+--TEST--
+xml_parser_get_option() - Test parameter not set
+--SKIPIF--
+<?php
+if (!extension_loaded('xml')) {
+    exit('Skip - XML extension not loaded');
+}
+?>
+--FILE--
+<?php
+
+$xml = '<?xml?>';
+
+$xml_parser = xml_parser_create();
+
+if (!xml_parse($xml_parser, $xml, true)) {
+    var_dump(xml_get_error_code($xml_parser));
+    var_dump(xml_error_string(xml_get_error_code($xml_parser)));
+}
+?>
+--EXPECTF--
+int(64)
+string(17) "Reserved XML Name"

--- a/ext/xml/tests/xml_error_string_basic.phpt
+++ b/ext/xml/tests/xml_error_string_basic.phpt
@@ -25,7 +25,7 @@ foreach ($xmls as $xml) {
     xml_parser_free($xml_parser);
 }
 ?>
---EXPECTF--
+--EXPECT--
 int(5)
 string(20) "Invalid document end"
 int(47)


### PR DESCRIPTION
The former is, as of yet, not being tested. The latter is included in other tests but never called. Essentially, both functions are tested here, but on only 5 of the dozens of possible error codes.