### PR TITLE
[#79521] Check `__set_state` structure

### DIFF
--- a/Zend/tests/magic_methods_set_state.phpt
+++ b/Zend/tests/magic_methods_set_state.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Testing __set_state() declaration with wrong modifier
+--FILE--
+<?php
+
+class Foo {
+    function __set_state()
+    {
+    }
+}
+
+?>
+--EXPECTF--
+Warning: The magic method Foo::__set_state() must be static in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6170,6 +6170,8 @@ zend_string *zend_begin_method_decl(zend_op_array *op_array, zend_string *name, 
 		zend_check_magic_method_attr(fn_flags, ce, "__serialize", 0);
 	} else if (zend_string_equals_literal(lcname, "__unserialize")) {
 		zend_check_magic_method_attr(fn_flags, ce, "__unserialize", 0);
+	} else if (zend_string_equals_literal(lcname, "__set_state")) {
+        zend_check_magic_method_attr(fn_flags, ce, "__set_state", 1);
 	}
 
 	return lcname;

--- a/ext/reflection/tests/ReflectionMethod_getModifiers_basic.phpt
+++ b/ext/reflection/tests/ReflectionMethod_getModifiers_basic.phpt
@@ -52,7 +52,7 @@ class TestClass
 
     public function __wakeup() {}
 
-    public function __set_state() {}
+    public static function __set_state() {}
 
     public function __autoload() {}
 }
@@ -143,7 +143,7 @@ Modifiers for method TestClass::__wakeup():
 
 
 Modifiers for method TestClass::__set_state():
-0x00000001
+0x00000011
 
 
 Modifiers for method TestClass::__autoload():
@@ -207,7 +207,7 @@ Modifiers for method TestClass::__wakeup():
 
 
 Modifiers for method TestClass::__set_state():
-0x00000001
+0x00000011
 
 
 Modifiers for method TestClass::__autoload():


### PR DESCRIPTION
Found while working on #4177. This fixes two problems:

- missing `static`: doesn't work on PHP 8 as per 6c73b50cf6cf: https://3v4l.org/KCmJS/rfc#git-php-master
- missing `public`: `__set_state`'s functionality doesn't work: https://3v4l.org/l4sS9

Similar to #5441.