### PR TITLE
Improve error message when the first argument of `__state_state` isn'…

### DIFF
--- a/Zend/tests/magic_methods_set_state_args.phpt
+++ b/Zend/tests/magic_methods_set_state_args.phpt
@@ -1,0 +1,10 @@
+--TEST--
+__set_state first argument must be an array
+--FILE--
+<?php
+class Foo {
+	public function __set_state(string $name) {}
+}
+?>
+--EXPECTF--
+Fatal error: Type of first argument of Foo::__set_state() must be array in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2035,6 +2035,14 @@ ZEND_API void zend_check_magic_method_implementation(const zend_class_entry *ce,
 		&& fptr->common.num_args != 1
 	) {
 		zend_error(error_type, "Method %s::__unserialize() must take exactly 1 argument", ZSTR_VAL(ce->name));
+	} else if (
+		name_len == sizeof("__set_state") - 1
+		&& !memcmp(lcname, "__set_state", sizeof("__set_state") - 1)
+		&& fptr->common.num_args == 1
+		&& ZEND_TYPE_IS_SET(fptr->common.arg_info[0].type)
+		&& ZEND_TYPE_FULL_MASK(fptr->common.arg_info[1].type) != MAY_BE_ARRAY
+	) {
+		zend_error(error_type, "Type of first argument of %s::__set_state() must be array", ZSTR_VAL(ce->name));
 	}
 }
 /* }}} */


### PR DESCRIPTION
…t typed as array

Currently, the error message shown to the user is:

```
Argument 1 passed to A::__set_state() must be of the type string, array given
```

Which isn't necessary that. The problem is before that: the type that is actually wrong. With this patch,
the error message now is:

```
Type of first argument of Foo::__set_state() must be array
```

------------

This is proposed separately from #4177 as I believe is an improvement, not a BC.
