### PR TITLE
SessionUpdateTimestampHandler class was never implemented

### DIFF
--- a/ext/session/mod_user_class.c
+++ b/ext/session/mod_user_class.c
@@ -176,37 +176,3 @@ PHP_METHOD(SessionHandler, create_sid)
 	RETURN_STR(id);
 }
 /* }}} */
-
-/* {{{ proto char SessionUpdateTimestampHandler::validateId(string id)
-   Simply return TRUE */
-PHP_METHOD(SessionHandler, validateId)
-{
-	zend_string *key;
-
-	PS_SANITY_CHECK_IS_OPEN;
-
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &key) == FAILURE) {
-		RETURN_THROWS();
-	}
-
-	/* Legacy save handler may not support validate_sid API. Return TRUE. */
-	RETURN_TRUE;
-}
-/* }}} */
-
-/* {{{ proto bool SessionUpdateTimestampHandler::updateTimestamp(string id, string data)
-   Simply call update_timestamp */
-PHP_METHOD(SessionHandler, updateTimestamp)
-{
-	zend_string *key, *val;
-
-	PS_SANITY_CHECK_IS_OPEN;
-
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS", &key, &val) == FAILURE) {
-		RETURN_THROWS();
-	}
-
-	/* Legacy save handler may not support update_timestamp API. Just write. */
-	RETVAL_BOOL(SUCCESS == PS(default_mod)->s_write(&PS(mod_data), key, val, PS(gc_maxlifetime)));
-}
-/* }}} */

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -325,7 +325,5 @@ extern PHP_METHOD(SessionHandler, write);
 extern PHP_METHOD(SessionHandler, destroy);
 extern PHP_METHOD(SessionHandler, gc);
 extern PHP_METHOD(SessionHandler, create_sid);
-extern PHP_METHOD(SessionHandler, validateId);
-extern PHP_METHOD(SessionHandler, updateTimestamp);
 
 #endif

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -70,9 +70,6 @@ zend_class_entry *php_session_iface_entry;
 /* SessionIdInterface */
 zend_class_entry *php_session_id_iface_entry;
 
-/* SessionUpdateTimestampHandler class */
-zend_class_entry *php_session_update_timestamp_class_entry;
-
 /* SessionUpdateTimestampInterface */
 zend_class_entry *php_session_update_timestamp_iface_entry;
 


### PR DESCRIPTION
It seems that in 2015, work was being done so that users could add their own custom session handlers. The implementer intended to add a class called `SessionUpdateTimestampHandler`, but never did so. The variable which was intended to point to its class entry is never initialized.

The implementer also coded two methods for this class. Strangely, the method bodies are declared with `PHP_METHOD(SessionHandler, ...)` rather than `PHP(SessionUpdateTimestampHandler, ...)`. However, these method implementations are not added to the method table of any class or interface. They are just dead code.