### PR TITLE
Remove unused proc_open code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -594,7 +594,6 @@ strptime \
 strtok_r \
 symlink \
 tzset \
-unlockpt \
 unsetenv \
 usleep \
 utime \

--- a/configure.ac
+++ b/configure.ac
@@ -566,7 +566,6 @@ getgrnam_r \
 getpwuid_r \
 getwd \
 glob \
-grantpt \
 inet_ntoa \
 inet_ntop \
 inet_pton \

--- a/configure.ac
+++ b/configure.ac
@@ -578,7 +578,6 @@ mmap \
 nice \
 nl_langinfo \
 poll \
-ptsname \
 putenv \
 scandir \
 setitimer \

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -14,13 +14,6 @@
    +----------------------------------------------------------------------+
  */
 
-#if 0 && (defined(__linux__) || defined(sun) || defined(__IRIX__))
-# define _BSD_SOURCE 		/* linux wants this when XOPEN mode is on */
-# define _BSD_COMPAT		/* irix: uint32_t */
-# define _XOPEN_SOURCE 500  /* turn on Unix98 */
-# define __EXTENSIONS__	1	/* Solaris: uint32_t */
-#endif
-
 #include "php.h"
 #include <stdio.h>
 #include <ctype.h>
@@ -52,12 +45,6 @@
  * around the alternate code.
  * */
 #ifdef PHP_CAN_SUPPORT_PROC_OPEN
-
-#if 0 && HAVE_PTSNAME && HAVE_GRANTPT && HAVE_UNLOCKPT && HAVE_SYS_IOCTL_H && HAVE_TERMIOS_H
-# include <sys/ioctl.h>
-# include <termios.h>
-# define PHP_CAN_DO_PTS	1
-#endif
 
 #include "proc_open.h"
 


### PR DESCRIPTION
In April 2004, Wez Furlong (@wez) added some code to `proc_open.c` which allowed `proc_open` to be called like:

```
proc_open("command", array(0 => array('pty')), $pipes)
```

...And the subprocess would be opened with FD 0 connected to a pseudoterminal (`/dev/ptys/N`).

In May 2004, @wez disabled this code in bd818c0118b with the comment: "Turn this off then". Since then, the code has remained in the codebase but is not doing anything.

If @wez is still accessible, can he confirm why this code was disabled? If not, it may be better just to remove it rather than leave it sitting around for another 16 years.