### PR TITLE
Add support for the number and scalar types

### DIFF
--- a/Zend/tests/type_declarations/number/casting/number_cast_error.phpt
+++ b/Zend/tests/type_declarations/number/casting/number_cast_error.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test that a number casting is not supported
+--FILE--
+<?php
+
+$foo = (number) 12;
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected '12' (T_LNUMBER) in %s on line %d

--- a/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_error1.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_error1.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test that a number parameter type can't be narrowed
+--FILE--
+<?php
+
+class Foo
+{
+    public function method(number $a) {}
+}
+
+class Bar extends Foo
+{
+    public function method(int $a) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of Bar::method(int $a) must be compatible with Foo::method(number $a) in %s on line %d

--- a/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_success1.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_success1.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test that a number parameter type supports invariance
+--FILE--
+<?php
+
+class Foo
+{
+    public function method(number $a) {}
+}
+
+class Bar extends Foo
+{
+    public function method(number $a) {}
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_success2.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_success2.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test that a number parameter type supports invariance
+--FILE--
+<?php
+
+class Foo
+{
+    public function method(number $a) {}
+}
+
+class Bar extends Foo
+{
+    public function method(int|float $a) {}
+}
+
+class Baz extends Foo
+{
+    public function method(number $a) {}
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_success3.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_success3.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test that a narrower type can be overridden by the number type
+--FILE--
+<?php
+
+class Foo
+{
+    public function method(int $a) {}
+}
+
+class Bar extends Foo
+{
+    public function method(number $a) {}
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_success4.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_parameter_inheritance_success4.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test that a parameter of a nullable int type can be overridden by the nullable number type
+--FILE--
+<?php
+
+class Foo
+{
+    public function method(?int $a) {}
+}
+
+class Bar extends Foo
+{
+    public function method(?number $a) {}
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/inheritance/number_property_inheritance_error1.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_property_inheritance_error1.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test that a property of number type can't be overridden by a property of any other type
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1;
+}
+
+class Bar extends Foo
+{
+    public int $property1;
+}
+
+?>
+--EXPECTF--
+Fatal error: Type of Bar::$property1 must be number (as in class Foo) in %s on line %d

--- a/Zend/tests/type_declarations/number/inheritance/number_property_inheritance_error2.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_property_inheritance_error2.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test that a property of number type can't be overridden by a property of any other type type
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1;
+}
+
+class Bar extends Foo
+{
+    public float $property1;
+}
+
+?>
+--EXPECTF--
+Fatal error: Type of Bar::$property1 must be number (as in class Foo) in %s on line %d

--- a/Zend/tests/type_declarations/number/inheritance/number_property_inheritance_error3.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_property_inheritance_error3.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test that a property of number type can't be overridden by a property of any other type type
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1;
+}
+
+class Bar extends Foo
+{
+    public ?number $property1;
+}
+
+?>
+--EXPECTF--
+Fatal error: Type of Bar::$property1 must be number (as in class Foo) in %s on line %d

--- a/Zend/tests/type_declarations/number/inheritance/number_return_inheritance_error1.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_return_inheritance_error1.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test that a number return type can't be widened
+--FILE--
+<?php
+
+class Foo
+{
+    public function method(): number {}
+}
+
+class Bar extends Foo
+{
+    public function method(): int|float|null {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of Bar::method(): int|float|null must be compatible with Foo::method(): number in %s on line %d

--- a/Zend/tests/type_declarations/number/inheritance/number_return_inheritance_error2.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_return_inheritance_error2.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test that a number return type can't be widened
+--FILE--
+<?php
+
+class Foo
+{
+    public function method(): number {}
+}
+
+class Bar extends Foo
+{
+    public function method(): ?number {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of Bar::method(): int|float|null must be compatible with Foo::method(): number in %s on line %d

--- a/Zend/tests/type_declarations/number/inheritance/number_return_inheritance_success1.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_return_inheritance_success1.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test that a number return value supports invariance
+--FILE--
+<?php
+
+class Foo
+{
+    public function method(): number {}
+}
+
+class Bar extends Foo
+{
+    public function method(): int|float {}
+}
+
+class Baz extends Bar
+{
+    public function method(): number {}
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/inheritance/number_return_inheritance_success2.phpt
+++ b/Zend/tests/type_declarations/number/inheritance/number_return_inheritance_success2.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test that a number return type can be overridden by any subtype
+--FILE--
+<?php
+
+class Foo
+{
+    public function method(): number {}
+}
+
+class Bar extends Foo
+{
+    public function method(): int {}
+}
+
+class Baz extends Foo
+{
+    public function method(): float {}
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/syntax/nullable_number_parameter_success.phpt
+++ b/Zend/tests/type_declarations/number/syntax/nullable_number_parameter_success.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test that the nullable number parameter type is valid
+--FILE--
+<?php
+
+function foo(?number $a)
+{
+}
+
+?>
+--EXPECTF--

--- a/Zend/tests/type_declarations/number/syntax/nullable_number_property_success.phpt
+++ b/Zend/tests/type_declarations/number/syntax/nullable_number_property_success.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test that the nullable number property type is valid
+--FILE--
+<?php
+
+class Foo
+{
+    public ?number $property1;
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/syntax/nullable_number_return_success.phpt
+++ b/Zend/tests/type_declarations/number/syntax/nullable_number_return_success.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test that the nullable number return type is valid
+--FILE--
+<?php
+
+function foo(): ?number
+{
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/syntax/number_parameter_error.phpt
+++ b/Zend/tests/type_declarations/number/syntax/number_parameter_error.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test that the number parameter type can't be used together with any other numeric type
+--FILE--
+<?php
+
+function foo(number|int $a)
+{
+}
+
+?>
+--EXPECTF--
+Fatal error: Duplicate type int is redundant in %s on line %d

--- a/Zend/tests/type_declarations/number/syntax/number_parameter_success.phpt
+++ b/Zend/tests/type_declarations/number/syntax/number_parameter_success.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test that number is a valid parameter type
+--FILE--
+<?php
+
+function foo(number $a)
+{
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/syntax/number_return_error.phpt
+++ b/Zend/tests/type_declarations/number/syntax/number_return_error.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test that the number return type can't be used together with any other numeric type
+--FILE--
+<?php
+
+function foo(): number|float|null
+{
+}
+
+?>
+--EXPECTF--
+Fatal error: Duplicate type float is redundant in %s on line %d

--- a/Zend/tests/type_declarations/number/syntax/number_return_success.phpt
+++ b/Zend/tests/type_declarations/number/syntax/number_return_success.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test that number is a valid return type
+--FILE--
+<?php
+
+function foo(): number
+{
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/syntax/number_void_return_error.phpt
+++ b/Zend/tests/type_declarations/number/syntax/number_void_return_error.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test that the number|void return type is not valid
+--FILE--
+<?php
+
+function foo(): number|void
+{
+}
+
+?>
+--EXPECTF--
+Fatal error: Void can only be used as a standalone type in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_parameter_strict_error.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_parameter_strict_error.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Test that the number parameter type doesn't accept non-numeric types in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+function foo(number $a)
+{
+}
+
+try {
+    foo(null);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo("0");
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo([]);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(new stdClass());
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(fopen(__FILE__, "r"));
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECTF--
+foo(): Argument #1 ($a) must be of type number, null given, called in %s on line %d
+foo(): Argument #1 ($a) must be of type number, string given, called in %s on line %d
+foo(): Argument #1 ($a) must be of type number, array given, called in %s on line %d
+foo(): Argument #1 ($a) must be of type number, object given, called in %s on line %d
+foo(): Argument #1 ($a) must be of type number, resource given, called in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_parameter_strict_success.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_parameter_strict_success.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test that the number parameter type accepts integer and float arguments in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+function foo(number $a)
+{
+    var_dump($a);
+}
+
+foo(1);
+foo(3.14);
+
+?>
+--EXPECT--
+int(1)
+float(3.14)

--- a/Zend/tests/type_declarations/number/validation/number_parameter_weak_error.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_parameter_weak_error.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Test that the number parameter type doesn't accept any kind of non-numeric value in weak mode
+--FILE--
+<?php
+
+function foo(number $a)
+{
+}
+
+try {
+    foo("foo");
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo([]);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(new stdClass());
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(fopen(__FILE__, "r"));
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECTF--
+foo(): Argument #1 ($a) must be of type number, string given, called in %s on line %d
+foo(): Argument #1 ($a) must be of type number, array given, called in %s on line %d
+foo(): Argument #1 ($a) must be of type number, object given, called in %s on line %d
+foo(): Argument #1 ($a) must be of type number, resource given, called in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_parameter_weak_success.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_parameter_weak_success.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test that the number parameter type accepts any kind of numeric argument in weak mode
+--FILE--
+<?php
+
+function foo(number $a)
+{
+    var_dump($a);
+}
+
+foo(false);
+foo(true);
+foo(1);
+foo(3.14);
+foo("0");
+foo("12foo");
+
+?>
+--EXPECTF--
+int(0)
+int(1)
+int(1)
+float(3.14)
+int(0)
+
+Notice: A non well formed numeric value encountered in %s on line %d
+int(12)

--- a/Zend/tests/type_declarations/number/validation/number_property_strict_error1.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_strict_error1.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric type in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+class Foo
+{
+    public number $property1 = null;
+}
+
+?>
+--EXPECTF--
+Fatal error: Default value for property of type number may not be null. Use the nullable type ?number to allow null default value in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_strict_error2.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_strict_error2.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric type in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+class Foo
+{
+    public number $property1 = false;
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use bool as default value for property Foo::$property1 of type number in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_strict_error3.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_strict_error3.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric type in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+class Foo
+{
+    public number $property1 = true;
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use bool as default value for property Foo::$property1 of type number in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_strict_error4.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_strict_error4.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric type in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+class Foo
+{
+    public number $property1 = "0";
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use string as default value for property Foo::$property1 of type number in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_strict_error5.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_strict_error5.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric type in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+class Foo
+{
+    public number $property1 = [];
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use array as default value for property Foo::$property1 of type number in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_strict_error6.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_strict_error6.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric type in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+class Foo
+{
+    public number $property1;
+
+    public function __construct()
+    {
+        $this->property1 = new stdClass();
+    }
+}
+
+$foo = new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Cannot assign stdClass to property Foo::$property1 of type number in %s:%d
+Stack trace:
+#0 %s(%d): Foo->__construct()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_strict_error7.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_strict_error7.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric type in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+class Foo
+{
+    public number $property1;
+
+    public function __construct()
+    {
+        $this->property1 = fopen(__FILE__, "r");
+    }
+}
+
+$foo = new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Cannot assign resource to property Foo::$property1 of type number in %s:%d
+Stack trace:
+#0 %s(%d): Foo->__construct()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_strict_success.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_strict_success.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test that the number property type accepts integer and float types in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+class Foo
+{
+    public number $property1 = 1;
+    public number $property2 = 3.14;
+}
+
+$foo = new Foo();
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/validation/number_property_weak_error1.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_weak_error1.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric value in weak mode
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1 = null;
+}
+
+$foo = new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Default value for property of type number may not be null. Use the nullable type ?number to allow null default value in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_weak_error2.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_weak_error2.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric value in weak mode
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1 = false;
+}
+
+$foo = new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Cannot use bool as default value for property Foo::$property1 of type number in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_weak_error3.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_weak_error3.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric value in weak mode
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1 = true;
+}
+
+$foo = new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Cannot use bool as default value for property Foo::$property1 of type number in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_weak_error4.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_weak_error4.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric value in weak mode
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1 = "0";
+}
+
+$foo = new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Cannot use string as default value for property Foo::$property1 of type number in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_weak_error5.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_weak_error5.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric value in weak mode
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1 = [];
+}
+
+$foo = new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Cannot use array as default value for property Foo::$property1 of type number in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_weak_error6.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_weak_error6.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric value in weak mode
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1;
+
+    public function __construct()
+    {
+        $this->property1 = new stdClass();
+    }
+}
+
+$foo = new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Cannot assign stdClass to property Foo::$property1 of type number in %s:%d
+Stack trace:
+#0 %s(%d): Foo->__construct()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_weak_error7.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_weak_error7.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test that the number property type doesn't accept any non-numeric value in weak mode
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property1;
+
+    public function __construct()
+    {
+        $this->property1 = fopen(__FILE__, "r");
+    }
+}
+
+$foo = new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Cannot assign resource to property Foo::$property1 of type number in %s:%d
+Stack trace:
+#0 %s(%d): Foo->__construct()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/type_declarations/number/validation/number_property_weak_success.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_property_weak_success.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test that the number property type accepts any numeric value in weak mode
+--FILE--
+<?php
+
+class Foo
+{
+    public number $property3 = 1;
+    public number $property4 = 3.14;
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/validation/number_return_strict_error1.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_return_strict_error1.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test that the number return type is not compatible with a void return value in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+function foo($value): number
+{
+}
+
+?>
+--EXPECT--
+

--- a/Zend/tests/type_declarations/number/validation/number_return_strict_error2.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_return_strict_error2.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Test that the number return type is not compatible with a void return value in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+function foo($value): number
+{
+    return $value;
+}
+
+try {
+    foo(null);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(false);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(true);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo("0");
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo([]);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(new stdClass());
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(fopen(__FILE__, "r"));
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Return value of foo() must be of type number, null returned
+Return value of foo() must be of type number, bool returned
+Return value of foo() must be of type number, bool returned
+Return value of foo() must be of type number, string returned
+Return value of foo() must be of type number, array returned
+Return value of foo() must be of type number, object returned
+Return value of foo() must be of type number, resource returned

--- a/Zend/tests/type_declarations/number/validation/number_return_strict_success.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_return_strict_success.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test that the number return type is compatible with any kind of numeric type in strict mode
+--FILE--
+<?php
+declare(strict_types=1);
+
+function foo($a): number
+{
+    return $a;
+}
+
+foo(1);
+foo(3.14);
+
+?>
+--EXPECT--

--- a/Zend/tests/type_declarations/number/validation/number_return_weak_error1.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_return_weak_error1.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test that the number return type is not compatible with a void return value
+--FILE--
+<?php
+
+function foo(): number
+{
+}
+
+try {
+    foo();
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Return value of foo() must be of type number, none returned

--- a/Zend/tests/type_declarations/number/validation/number_return_weak_error2.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_return_weak_error2.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test that the number return type is not compatible with non-numeric return values
+--FILE--
+<?php
+
+function foo($a): number
+{
+    return $a;
+}
+
+try {
+    foo(null);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo([]);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(new stdClass());
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    foo(fopen(__FILE__, "r"));
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Return value of foo() must be of type number, null returned
+Return value of foo() must be of type number, array returned
+Return value of foo() must be of type number, object returned
+Return value of foo() must be of type number, resource returned

--- a/Zend/tests/type_declarations/number/validation/number_return_weak_success.phpt
+++ b/Zend/tests/type_declarations/number/validation/number_return_weak_success.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test that the number return type is compatible with any numeric value in weak mode
+--FILE--
+<?php
+
+function foo($a): number
+{
+    return $a;
+}
+
+var_dump(foo(false));
+var_dump(foo(true));
+var_dump(foo(1));
+var_dump(foo(3.14));
+var_dump(foo("0foo"));
+
+?>
+--EXPECTF--
+int(0)
+int(1)
+int(1)
+float(3.14)
+
+Notice: A non well formed numeric value encountered in %s on line %d
+int(0)

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -123,8 +123,10 @@ ZEND_API const char *zend_get_type_by_const(int type) /* {{{ */
 			return "array";
 		case IS_VOID:
 			return "void";
-		case _IS_NUMBER:
+		case IS_NUMBER:
 			return "number";
+		case IS_SCALAR:
+			return "scalar";
 		default:
 			return "unknown";
 	}

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1572,6 +1572,8 @@ simple_list:
 				case IS_ARRAY:    APPEND_STR("array");
 				case IS_CALLABLE: APPEND_STR("callable");
 				case IS_STATIC:   APPEND_STR("static");
+				case IS_NUMBER:   APPEND_STR("number");
+				case IS_SCALAR:   APPEND_STR("scalar");
 				EMPTY_SWITCH_DEFAULT_CASE();
 			}
 			break;

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -181,7 +181,7 @@ try_again:
 			{
 				zval dst;
 
-				convert_object_to_type(op, &dst, _IS_NUMBER);
+				convert_object_to_type(op, &dst, IS_NUMBER);
 				zval_ptr_dtor(op);
 
 				if (Z_TYPE(dst) == IS_LONG || Z_TYPE(dst) == IS_DOUBLE) {
@@ -215,7 +215,7 @@ static zend_never_inline zval* ZEND_FASTCALL _zendi_convert_scalar_to_number_sil
 			ZVAL_LONG(holder, Z_RES_HANDLE_P(op));
 			return holder;
 		case IS_OBJECT:
-			convert_object_to_type(op, holder, _IS_NUMBER);
+			convert_object_to_type(op, holder, IS_NUMBER);
 			if (UNEXPECTED(EG(exception)) ||
 			    UNEXPECTED(Z_TYPE_P(holder) != IS_LONG && Z_TYPE_P(holder) != IS_DOUBLE)) {
 				ZVAL_LONG(holder, 1);
@@ -252,7 +252,7 @@ static zend_never_inline int ZEND_FASTCALL _zendi_try_convert_scalar_to_number(z
 			ZVAL_LONG(holder, Z_RES_HANDLE_P(op));
 			return SUCCESS;
 		case IS_OBJECT:
-			convert_object_to_type(op, holder, _IS_NUMBER);
+			convert_object_to_type(op, holder, IS_NUMBER);
 			if (UNEXPECTED(EG(exception))) {
 				return FAILURE;
 			}

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -522,6 +522,7 @@ EMPTY_SWITCH_DEFAULT_CASE()
 	_(ZEND_STR_VOID,                   "void") \
 	_(ZEND_STR_FALSE,                  "false") \
 	_(ZEND_STR_NULL_LOWERCASE,         "null") \
+	_(ZEND_STR_NUMBER,                 "number") \
 
 
 typedef enum _zend_known_string_id {

--- a/Zend/zend_type_info.h
+++ b/Zend/zend_type_info.h
@@ -41,6 +41,8 @@
 #define MAY_BE_ITERABLE             (1 << IS_ITERABLE)
 #define MAY_BE_VOID                 (1 << IS_VOID)
 #define MAY_BE_STATIC               (1 << IS_STATIC)
+#define MAY_BE_NUMBER               (MAY_BE_LONG|MAY_BE_DOUBLE)
+#define MAY_BE_SCALAR               (MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_STRING)
 
 #define MAY_BE_ARRAY_SHIFT          (IS_REFERENCE)
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -257,7 +257,7 @@ typedef struct {
 	{ NULL, (_type_mask) }
 
 #define ZEND_TYPE_INIT_CODE(code, allow_null, extra_flags) \
-	ZEND_TYPE_INIT_MASK(((code) == _IS_BOOL ? MAY_BE_BOOL : (1 << (code))) \
+	ZEND_TYPE_INIT_MASK(((code) == _IS_BOOL ? MAY_BE_BOOL : ((code) == IS_NUMBER ? MAY_BE_NUMBER : (1 << (code)))) \
 		| ((allow_null) ? _ZEND_TYPE_NULLABLE_BIT : 0) | (extra_flags))
 
 #define ZEND_TYPE_INIT_PTR(ptr, type_kind, allow_null, extra_flags) \
@@ -534,6 +534,8 @@ struct _zend_ast_ref {
 #define IS_ITERABLE					13
 #define IS_VOID						14
 #define IS_STATIC					15
+#define IS_NUMBER					16
+#define IS_SCALAR					17
 
 /* internal types */
 #define IS_INDIRECT             	12
@@ -542,8 +544,7 @@ struct _zend_ast_ref {
 #define _IS_ERROR					15
 
 /* used for casts */
-#define _IS_BOOL					16
-#define _IS_NUMBER					17
+#define _IS_BOOL					18
 
 static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 	return pz->u1.v.type;

--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -451,7 +451,7 @@ static int com_object_cast(zend_object *readobj, zval *writeobj, int type)
 
 	switch(type) {
 		case IS_LONG:
-		case _IS_NUMBER:
+		case IS_NUMBER:
 			vt = VT_INT;
 			break;
 		case IS_DOUBLE:

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -289,7 +289,7 @@ static int gmp_cast_object(zend_object *readobj, zval *writeobj, int type) /* {{
 		gmpnum = GET_GMP_OBJECT_FROM_OBJ(readobj)->num;
 		ZVAL_DOUBLE(writeobj, mpz_get_d(gmpnum));
 		return SUCCESS;
-	case _IS_NUMBER:
+	case IS_NUMBER:
 		gmpnum = GET_GMP_OBJECT_FROM_OBJ(readobj)->num;
 		if (mpz_fits_slong_p(gmpnum)) {
 			ZVAL_LONG(writeobj, mpz_get_si(gmpnum));

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1874,7 +1874,7 @@ static int cast_object(zval *object, int type, char *contents)
 		case IS_DOUBLE:
 			convert_to_double(object);
 			break;
-		case _IS_NUMBER:
+		case IS_NUMBER:
 			convert_scalar_to_number(object);
 			break;
 		default:

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -523,7 +523,7 @@ static int tidy_doc_cast_handler(zend_object *in, zval *out, int type)
 
 	switch (type) {
 		case IS_LONG:
-		case _IS_NUMBER:
+		case IS_NUMBER:
 			ZVAL_LONG(out, 0);
 			break;
 
@@ -561,7 +561,7 @@ static int tidy_node_cast_handler(zend_object *in, zval *out, int type)
 
 	switch(type) {
 		case IS_LONG:
-		case _IS_NUMBER:
+		case IS_NUMBER:
 			ZVAL_LONG(out, 0);
 			break;
 


### PR DESCRIPTION
`number` is an alias of `int|float`, `scalar` is an alias of `bool|int|string|float`.