### PR TITLE
Introduce abstraction for error display callbacks.

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -814,6 +814,8 @@ int zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	fpsetmask(0);
 #endif
 
+	zend_startup_error_display_functions();
+
 	zend_startup_strtod();
 	zend_startup_extensions_mechanism();
 
@@ -1077,6 +1079,7 @@ void zend_shutdown(void) /* {{{ */
 	free(GLOBAL_AUTO_GLOBALS_TABLE);
 
 	zend_shutdown_extensions();
+	zend_shutdown_error_display_functions();
 	free(zend_version_info);
 
 	free(GLOBAL_FUNCTION_TABLE);

--- a/Zend/zend_errors.c
+++ b/Zend/zend_errors.c
@@ -1,0 +1,105 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend Engine                                                          |
+   +----------------------------------------------------------------------+
+   | Copyright (c) Zend Technologies Ltd. (http://www.zend.com)           |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+   | Authors: Benjamin Eberlei <beberlei@php.net>                         |
+   +----------------------------------------------------------------------+
+*/
+
+#include "zend.h"
+
+/**
+ * A display callback is responsible for rendering an error. Extensions can
+ * append to the list of core error handlers. Callbacks are triggered from the
+ * tail of the list going to head.
+ */
+zend_llist zend_error_display_callbacks;
+
+char *zend_error_get_type_string(int type)
+{
+	char *error_type_str;
+
+	switch (type) {
+		case E_ERROR:
+		case E_CORE_ERROR:
+		case E_COMPILE_ERROR:
+		case E_USER_ERROR:
+			error_type_str = "Fatal error";
+			break;
+		case E_RECOVERABLE_ERROR:
+			error_type_str = "Recoverable fatal error";
+			break;
+		case E_WARNING:
+		case E_CORE_WARNING:
+		case E_COMPILE_WARNING:
+		case E_USER_WARNING:
+			error_type_str = "Warning";
+			break;
+		case E_PARSE:
+			error_type_str = "Parse error";
+			break;
+		case E_NOTICE:
+		case E_USER_NOTICE:
+			error_type_str = "Notice";
+			break;
+		case E_STRICT:
+			error_type_str = "Strict Standards";
+			break;
+		case E_DEPRECATED:
+		case E_USER_DEPRECATED:
+			error_type_str = "Deprecated";
+			break;
+		default:
+			error_type_str = "Unknown error";
+			break;
+	}
+
+	return error_type_str;
+}
+
+void zend_startup_error_display_functions(void)
+{
+	zend_llist_init(&zend_error_display_callbacks, sizeof(zend_error_display_callback), NULL, 1);
+}
+
+void zend_shutdown_error_display_functions(void)
+{
+	zend_llist_destroy(&zend_error_display_callbacks);
+}
+
+void zend_register_error_display_callback(zend_error_display_cb cb)
+{
+	zend_error_display_callback callback;
+
+	callback.display_callback = cb;
+
+	zend_llist_add_element(&zend_error_display_callbacks, &callback);
+}
+
+int zend_error_display_handle(int type, const char *error_filename, const uint32_t error_lineno, char *buffer, int buffer_len)
+{
+	zend_llist_element *element;
+	zend_error_display_callback *callback;
+	int handled = 0;
+
+	for (element = zend_error_display_callbacks.tail; element; element = element->prev) {
+		callback = (zend_error_display_callback*) element->data;
+		handled = callback->display_callback(type, error_filename, error_lineno, buffer, buffer_len);
+
+		if (handled == 1) {
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/Zend/zend_errors.h
+++ b/Zend/zend_errors.h
@@ -47,4 +47,18 @@
 
 #define E_HAS_ONLY_FATAL_ERRORS(mask) !((mask) & ~E_FATAL_ERRORS)
 
+typedef int (*zend_error_display_cb)(int type, const char *error_filename, const uint32_t error_lineno, char *buffer, int buffer_len);
+
+BEGIN_EXTERN_C()
+typedef struct {
+	zend_error_display_cb display_callback;
+} zend_error_display_callback;
+
+char *zend_error_get_type_string(int type);
+void zend_register_error_display_callback(zend_error_display_cb callback);
+void zend_startup_error_display_functions(void);
+void zend_shutdown_error_display_functions(void);
+int zend_error_display_handle(int type, const char *error_filename, const uint32_t error_lineno, char *buffer, int buffer_len);
+END_EXTERN_C()
+
 #endif /* ZEND_ERRORS_H */

--- a/configure.ac
+++ b/configure.ac
@@ -1456,7 +1456,7 @@ PHP_ADD_SOURCES(Zend, \
     zend_execute_API.c zend_highlight.c zend_llist.c \
     zend_vm_opcodes.c zend_opcode.c zend_operators.c zend_ptr_stack.c zend_stack.c \
     zend_variables.c zend.c zend_API.c zend_extensions.c zend_hash.c \
-    zend_list.c zend_builtin_functions.c \
+    zend_list.c zend_builtin_functions.c zend_errors.c \
     zend_ini.c zend_sort.c zend_multibyte.c zend_ts_hash.c zend_stream.c \
     zend_iterators.c zend_interfaces.c zend_exceptions.c zend_strtod.c zend_gc.c \
     zend_closures.c zend_weakrefs.c zend_float.c zend_string.c zend_signal.c zend_generators.c \

--- a/ext/soap/tests/bugs/bug70469.phpt
+++ b/ext/soap/tests/bugs/bug70469.phpt
@@ -4,17 +4,26 @@ Bug #70469 (SoapClient should not generate E_ERROR if exceptions enabled)
 <?php require_once('skipif.inc'); ?>
 --FILE--
 <?php
-try {
-    $x = new SoapClient('http://i_dont_exist.com/some.wsdl');
-} catch (SoapFault $e) {
-    echo "caught\n";
-}
+set_error_handler(function($a,$b,$c,$d) { throw new ErrorException($b,0,$a,$c,$d); }, -1);
 
-$error = error_get_last();
-if ($error === null) {
-    echo "ok\n";
+try {
+    new SoapClient('http://i_dont_exist.com/some.wsdl');
 }
+catch (SoapFault $e) {
+	echo "SoapFault\n";
+}
+catch (ErrorException $e) {
+	echo "ErrorException\n";
+}
+catch (Exception $e) {
+	echo "Exception\n";
+}
+echo "I survived\n";
+register_shutdown_function(function() {
+	echo 'Shutdown';
+});
 ?>
 --EXPECT--
-caught
-ok
+SoapFault
+I survived
+Shutdown

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -230,7 +230,7 @@ ADD_SOURCES("Zend", "zend_language_parser.c zend_language_scanner.c \
 	zend_execute_API.c zend_highlight.c \
 	zend_llist.c zend_vm_opcodes.c zend_opcode.c zend_operators.c zend_ptr_stack.c \
 	zend_stack.c zend_variables.c zend.c zend_API.c zend_extensions.c \
-	zend_hash.c zend_list.c zend_builtin_functions.c \
+	zend_hash.c zend_list.c zend_builtin_functions.c zend_errors.c \
 	zend_ini.c zend_sort.c zend_multibyte.c zend_ts_hash.c \
 	zend_stream.c zend_iterators.c zend_interfaces.c zend_objects.c \
 	zend_object_handlers.c zend_objects_API.c \


### PR DESCRIPTION
Follow up to #4555 - this replaces the hardcoded display logic for errors in main/main.c `php_error_cb` with a list of callbacks that are iterated from the tail to the head. The first callback to render the error returns 1 and all further callbacks are skipped then.

### Todo

- [ ] Move `xmlrpc_errors` and `xmlrpc_error_number` INI settings from core into ext/xmlrpc. While this is a BC break to require the extension, this feature was added in 2001 and never changed afterwards, especially it also has no tests. Google and DDG search could lead to the assumption that nobody uses it.
- [ ] Move soap_error_cb to this API.

/cc @cmb69 @derickr 