### PR TITLE
Enclose contents of CLEAN sections in PHP tags

### DIFF
--- a/ext/openssl/tests/bug76296.phpt
+++ b/ext/openssl/tests/bug76296.phpt
@@ -14,8 +14,10 @@ ini_set('open_basedir', $dir);
 
 var_dump(openssl_pkey_get_public($pem));
 ?>
+--CLEAN--
+<?php
+@rmdir(__DIR__ . '/bug76296_openbasedir');
+?>
 --EXPECTF--
 Warning: openssl_pkey_get_public(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (%s) in %s on line %d
 bool(false)
---CLEAN--
-@rmdir(__DIR__ . '/bug76296_openbasedir');

--- a/ext/phar/tests/bug66960.phpt
+++ b/ext/phar/tests/bug66960.phpt
@@ -15,8 +15,10 @@ var_dump(file_exists("phar://$file/". str_repeat('a', PHP_MAXPATHLEN+1)));
 echo 'done';
 ?>
 --CLEAN--
+<?php
 $file = __DIR__ . DIRECTORY_SEPARATOR . 'bug66960.phar';
 unlink($file);
+?>
 --EXPECT--
 bool(false)
 bool(false)

--- a/ext/session/tests/session_save_path_variation4.phpt
+++ b/ext/session/tests/session_save_path_variation4.phpt
@@ -42,10 +42,12 @@ echo "Done";
 ob_end_flush();
 ?>
 --CLEAN--
+<?php
 $initdir = __DIR__;
 $sessions = ($initdir."/sessions");
 chdir($initdir);
 var_dump(rmdir($sessions));
+?>
 --EXPECTF--
 *** Testing session_save_path() : variation ***
 bool(true)

--- a/ext/session/tests/session_save_path_variation4.phpt
+++ b/ext/session/tests/session_save_path_variation4.phpt
@@ -45,7 +45,6 @@ ob_end_flush();
 <?php
 $initdir = __DIR__;
 $sessions = ($initdir."/sessions");
-chdir($initdir);
 var_dump(rmdir($sessions));
 ?>
 --EXPECTF--

--- a/ext/session/tests/session_save_path_variation5.phpt
+++ b/ext/session/tests/session_save_path_variation5.phpt
@@ -40,9 +40,11 @@ echo "Done";
 ob_end_flush();
 ?>
 --CLEAN--
+<?php
 $directory = __DIR__;
 $sessions = ($directory."/sessions");
 var_dump(rmdir($sessions));
+?>
 --EXPECTF--
 *** Testing session_save_path() : variation ***
 bool(true)

--- a/ext/standard/tests/array/end_64bit.phpt
+++ b/ext/standard/tests/array/end_64bit.phpt
@@ -109,12 +109,6 @@ var_dump( current($resources) );
 echo "Done\n";
 
 ?>
---CLEAN--
-<?php
-/* cleaning resource handles */
-fclose( $file_handle );  //file resource handle deleted
-closedir( $dir_handle );  //dir resource handle deleted
-?>
 --EXPECTF--
 *** Testing end() on different arrays ***
 -- Iteration 1 --

--- a/ext/standard/tests/array/end_64bit.phpt
+++ b/ext/standard/tests/array/end_64bit.phpt
@@ -110,9 +110,11 @@ echo "Done\n";
 
 ?>
 --CLEAN--
+<?php
 /* cleaning resource handles */
 fclose( $file_handle );  //file resource handle deleted
 closedir( $dir_handle );  //dir resource handle deleted
+?>
 --EXPECTF--
 *** Testing end() on different arrays ***
 -- Iteration 1 --

--- a/ext/standard/tests/streams/proc_open_bug60120.phpt
+++ b/ext/standard/tests/streams/proc_open_bug60120.phpt
@@ -88,10 +88,12 @@ var_dump(
 fclose($pipes[1]);
 fclose($pipes[2]);
 ?>
+--CLEAN--
+<?php
+unlink($file);
+?>
 --EXPECTF--
 string(10000) "%s"
 string(10000) "%s"
 string(0) ""
 string(0) ""
---CLEAN--
-unlink($file);

--- a/ext/standard/tests/streams/proc_open_bug60120.phpt
+++ b/ext/standard/tests/streams/proc_open_bug60120.phpt
@@ -90,6 +90,7 @@ fclose($pipes[2]);
 ?>
 --CLEAN--
 <?php
+$file = preg_replace("~\.clean\.php$~", ".io.php", __FILE__);
 unlink($file);
 ?>
 --EXPECTF--


### PR DESCRIPTION
We also place the CLEAN sections before EXPECT(F).