### PR TITLE
Pass worker ID to clean scripts

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2473,15 +2473,9 @@ COMMAND $cmd
             save_text($test_clean, trim($section_text['CLEAN']), $temp_clean);
 
             if (!$no_clean) {
-                $clean_params = array();
-                settings2array($ini_overwrites, $clean_params);
-                $clean_params = settings2params($clean_params);
-                if (substr(PHP_OS, 0, 3) === "WIN" && $workerID) {
-                    $clean_params .= " -d opcache.cache_id=worker$workerID";
-                }
                 $extra = substr(PHP_OS, 0, 3) !== "WIN" ?
                     "unset REQUEST_METHOD; unset QUERY_STRING; unset PATH_TRANSLATED; unset SCRIPT_FILENAME; unset REQUEST_METHOD;" : "";
-                system_with_timeout("$extra $php $pass_options $extra_options -q $clean_params $no_file_cache \"$test_clean\"", $env);
+                system_with_timeout("$extra $php $pass_options $extra_options -q $orig_ini_settings $no_file_cache \"$test_clean\"", $env);
             }
 
             if (!$cfg['keep']['clean']) {

--- a/run-tests.php
+++ b/run-tests.php
@@ -2476,6 +2476,9 @@ COMMAND $cmd
                 $clean_params = array();
                 settings2array($ini_overwrites, $clean_params);
                 $clean_params = settings2params($clean_params);
+                if (substr(PHP_OS, 0, 3) === "WIN" && $workerID) {
+                    $clean_params .= " -d opcache.cache_id=worker$workerID";
+                }
                 $extra = substr(PHP_OS, 0, 3) !== "WIN" ?
                     "unset REQUEST_METHOD; unset QUERY_STRING; unset PATH_TRANSLATED; unset SCRIPT_FILENAME; unset REQUEST_METHOD;" : "";
                 system_with_timeout("$extra $php $pass_options $extra_options -q $clean_params $no_file_cache \"$test_clean\"", $env);


### PR DESCRIPTION
On Windows, reusing/sharing of OPcache instances with different
configuration is not necessarily supported, so we have to make that it
does not happen for the clean scripts.