### PR TITLE
remove deprecated call and deprecate function to be removed in libenc…

### DIFF
--- a/ext/enchant/config.m4
+++ b/ext/enchant/config.m4
@@ -4,7 +4,7 @@ PHP_ARG_WITH([enchant],
     [Include Enchant support])])
 
 if test "$PHP_ENCHANT" != "no"; then
-  PKG_CHECK_MODULES([ENCHANT], [enchant])
+  PKG_CHECK_MODULES([ENCHANT], [enchant >= 1.4.2])
 
   PHP_EVAL_INCLINE($ENCHANT_CFLAGS)
   PHP_EVAL_LIBLINE($ENCHANT_LIBS, ENCHANT_SHARED_LIBADD)
@@ -13,14 +13,14 @@ if test "$PHP_ENCHANT" != "no"; then
 
   PHP_CHECK_LIBRARY(enchant, enchant_get_version,
   [
-    AC_DEFINE(HAVE_ENCHANT_GET_VERSION, 1, [ ])
+    AC_DEFINE(HAVE_ENCHANT_GET_VERSION, 1, [ enchant_get_version since 1.6.0 ])
   ], [ ], [
     $ENCHANT_LIBS
   ])
 
   PHP_CHECK_LIBRARY(enchant, enchant_broker_set_param,
   [
-    AC_DEFINE(HAVE_ENCHANT_BROKER_SET_PARAM, 1, [ ])
+    AC_DEFINE(HAVE_ENCHANT_BROKER_SET_PARAM, 1, [ enchant_broker_set_param since 1.5.0 and removed in 2.x ])
   ], [ ], [
     $ENCHANT_LIBS
   ])

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -650,7 +650,7 @@ PHP_FUNCTION(enchant_dict_quick_check)
 			for (i = 0; i < n_sugg; i++) {
 				add_next_index_string(sugg, suggs[i]);
 			}
-			enchant_dict_free_suggestions(pdict->pdict, suggs);
+			enchant_dict_free_string_list(pdict->pdict, suggs);
 		}
 
 
@@ -705,14 +705,14 @@ PHP_FUNCTION(enchant_dict_suggest)
 			add_next_index_string(return_value, suggs[i]);
 		}
 
-		enchant_dict_free_suggestions(pdict->pdict, suggs);
+		enchant_dict_free_string_list(pdict->pdict, suggs);
 	}
 }
 /* }}} */
 
-/* {{{ proto void enchant_dict_add_to_personal(resource dict, string word)
+/* {{{ proto void enchant_dict_add(resource dict, string word)
      add 'word' to personal word list */
-PHP_FUNCTION(enchant_dict_add_to_personal)
+PHP_FUNCTION(enchant_dict_add)
 {
 	zval *dict;
 	char *word;
@@ -725,7 +725,7 @@ PHP_FUNCTION(enchant_dict_add_to_personal)
 
 	PHP_ENCHANT_GET_DICT;
 
-	enchant_dict_add_to_personal(pdict->pdict, word, wordlen);
+	enchant_dict_add(pdict->pdict, word, wordlen);
 }
 /* }}} */
 
@@ -748,9 +748,9 @@ PHP_FUNCTION(enchant_dict_add_to_session)
 }
 /* }}} */
 
-/* {{{ proto bool enchant_dict_is_in_session(resource dict, string word)
+/* {{{ proto bool enchant_dict_is_added(resource dict, string word)
    whether or not 'word' exists in this spelling-session */
-PHP_FUNCTION(enchant_dict_is_in_session)
+PHP_FUNCTION(enchant_dict_is_added)
 {
 	zval *dict;
 	char *word;
@@ -763,7 +763,7 @@ PHP_FUNCTION(enchant_dict_is_in_session)
 
 	PHP_ENCHANT_GET_DICT;
 
-	RETURN_BOOL(enchant_dict_is_in_session(pdict->pdict, word, wordlen));
+	RETURN_BOOL(enchant_dict_is_added(pdict->pdict, word, wordlen));
 }
 /* }}} */
 

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -304,7 +304,7 @@ PHP_FUNCTION(enchant_broker_get_error)
 {
 	zval *broker;
 	enchant_broker *pbroker;
-	char *msg;
+	const char *msg;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &broker) == FAILURE) {
 		RETURN_THROWS();
@@ -796,7 +796,7 @@ PHP_FUNCTION(enchant_dict_get_error)
 {
 	zval *dict;
 	enchant_dict *pdict;
-	char *msg;
+	const char *msg;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &dict) == FAILURE) {
 		RETURN_THROWS();

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -197,6 +197,9 @@ PHP_MINIT_FUNCTION(enchant)
 	le_enchant_dict = zend_register_list_destructors_ex(php_enchant_dict_free, NULL, "enchant_dict", module_number);
 	REGISTER_LONG_CONSTANT("ENCHANT_MYSPELL", PHP_ENCHANT_MYSPELL, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("ENCHANT_ISPELL", PHP_ENCHANT_ISPELL, CONST_CS | CONST_PERSISTENT);
+#ifdef HAVE_ENCHANT_GET_VERSION
+	REGISTER_STRING_CONSTANT("LIBENCHANT_VERSION", enchant_get_version(), CONST_CS | CONST_PERSISTENT);
+#endif
 	return SUCCESS;
 }
 /* }}} */

--- a/ext/enchant/enchant.stub.php
+++ b/ext/enchant/enchant.stub.php
@@ -14,10 +14,16 @@ function enchant_broker_free($broker): bool {}
 */
 function enchant_broker_get_error($broker) {}
 
-/** @param resource $broker */
+/**
+* @param resource $broker
+* @deprecated
+*/
 function enchant_broker_set_dict_path($broker, int $name, string $value): bool {}
 
-/** @param resource $broker */
+/**
+* @param resource $broker
+* @deprecated
+*/
 function enchant_broker_get_dict_path($broker, int $name): string|false {}
 
 /** @param resource $broker */
@@ -57,12 +63,26 @@ function enchant_dict_check($dict, string $word): bool {}
 function enchant_dict_suggest($dict, string $word): ?array {}
 
 /** @param resource $dict */
+function enchant_dict_add($dict, string $word): void {}
+
+/**
+* @param resource $dict
+* @alias enchant_dict_add
+* @deprecated
+*/
 function enchant_dict_add_to_personal($dict, string $word): void {}
 
 /** @param resource $dict */
 function enchant_dict_add_to_session($dict, string $word): void {}
 
 /** @param resource $dict */
+function enchant_dict_is_added($dict, string $word): bool {}
+
+/**
+* @param resource $dict
+* @alias enchant_dict_add
+* @deprecated
+*/
 function enchant_dict_is_in_session($dict, string $word): bool {}
 
 /** @param resource $dict */

--- a/ext/enchant/enchant.stub.php
+++ b/ext/enchant/enchant.stub.php
@@ -80,7 +80,7 @@ function enchant_dict_is_added($dict, string $word): bool {}
 
 /**
 * @param resource $dict
-* @alias enchant_dict_add
+* @alias enchant_dict_is_added
 * @deprecated
 */
 function enchant_dict_is_in_session($dict, string $word): bool {}

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -140,7 +140,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_DEP_FALIAS(enchant_dict_add_to_personal, enchant_dict_add, arginfo_enchant_dict_add_to_personal)
 	ZEND_FE(enchant_dict_add_to_session, arginfo_enchant_dict_add_to_session)
 	ZEND_FE(enchant_dict_is_added, arginfo_enchant_dict_is_added)
-	ZEND_DEP_FALIAS(enchant_dict_is_in_session, enchant_dict_add, arginfo_enchant_dict_is_in_session)
+	ZEND_DEP_FALIAS(enchant_dict_is_in_session, enchant_dict_is_added, arginfo_enchant_dict_is_in_session)
 	ZEND_FE(enchant_dict_store_replacement, arginfo_enchant_dict_store_replacement)
 	ZEND_FE(enchant_dict_get_error, arginfo_enchant_dict_get_error)
 	ZEND_FE(enchant_dict_describe, arginfo_enchant_dict_describe)

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -69,12 +69,16 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_suggest, 0, 2, IS_A
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_add_to_personal, 0, 2, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_add, 0, 2, IS_VOID, 0)
 	ZEND_ARG_INFO(0, dict)
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_enchant_dict_add_to_session arginfo_enchant_dict_add_to_personal
+#define arginfo_enchant_dict_add_to_personal arginfo_enchant_dict_add
+
+#define arginfo_enchant_dict_add_to_session arginfo_enchant_dict_add
+
+#define arginfo_enchant_dict_is_added arginfo_enchant_dict_check
 
 #define arginfo_enchant_dict_is_in_session arginfo_enchant_dict_check
 
@@ -108,9 +112,9 @@ ZEND_FUNCTION(enchant_broker_describe);
 ZEND_FUNCTION(enchant_dict_quick_check);
 ZEND_FUNCTION(enchant_dict_check);
 ZEND_FUNCTION(enchant_dict_suggest);
-ZEND_FUNCTION(enchant_dict_add_to_personal);
+ZEND_FUNCTION(enchant_dict_add);
 ZEND_FUNCTION(enchant_dict_add_to_session);
-ZEND_FUNCTION(enchant_dict_is_in_session);
+ZEND_FUNCTION(enchant_dict_is_added);
 ZEND_FUNCTION(enchant_dict_store_replacement);
 ZEND_FUNCTION(enchant_dict_get_error);
 ZEND_FUNCTION(enchant_dict_describe);
@@ -120,8 +124,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(enchant_broker_init, arginfo_enchant_broker_init)
 	ZEND_FE(enchant_broker_free, arginfo_enchant_broker_free)
 	ZEND_FE(enchant_broker_get_error, arginfo_enchant_broker_get_error)
-	ZEND_FE(enchant_broker_set_dict_path, arginfo_enchant_broker_set_dict_path)
-	ZEND_FE(enchant_broker_get_dict_path, arginfo_enchant_broker_get_dict_path)
+	ZEND_DEP_FE(enchant_broker_set_dict_path, arginfo_enchant_broker_set_dict_path)
+	ZEND_DEP_FE(enchant_broker_get_dict_path, arginfo_enchant_broker_get_dict_path)
 	ZEND_FE(enchant_broker_list_dicts, arginfo_enchant_broker_list_dicts)
 	ZEND_FE(enchant_broker_request_dict, arginfo_enchant_broker_request_dict)
 	ZEND_FE(enchant_broker_request_pwl_dict, arginfo_enchant_broker_request_pwl_dict)
@@ -132,9 +136,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(enchant_dict_quick_check, arginfo_enchant_dict_quick_check)
 	ZEND_FE(enchant_dict_check, arginfo_enchant_dict_check)
 	ZEND_FE(enchant_dict_suggest, arginfo_enchant_dict_suggest)
-	ZEND_FE(enchant_dict_add_to_personal, arginfo_enchant_dict_add_to_personal)
+	ZEND_FE(enchant_dict_add, arginfo_enchant_dict_add)
+	ZEND_DEP_FALIAS(enchant_dict_add_to_personal, enchant_dict_add, arginfo_enchant_dict_add_to_personal)
 	ZEND_FE(enchant_dict_add_to_session, arginfo_enchant_dict_add_to_session)
-	ZEND_FE(enchant_dict_is_in_session, arginfo_enchant_dict_is_in_session)
+	ZEND_FE(enchant_dict_is_added, arginfo_enchant_dict_is_added)
+	ZEND_DEP_FALIAS(enchant_dict_is_in_session, enchant_dict_add, arginfo_enchant_dict_is_in_session)
 	ZEND_FE(enchant_dict_store_replacement, arginfo_enchant_dict_store_replacement)
 	ZEND_FE(enchant_dict_get_error, arginfo_enchant_dict_get_error)
 	ZEND_FE(enchant_dict_describe, arginfo_enchant_dict_describe)

--- a/ext/enchant/tests/broker_free_02.phpt
+++ b/ext/enchant/tests/broker_free_02.phpt
@@ -21,7 +21,7 @@ if (is_resource($broker)) {
     if ($requestDict) {
         echo("OK\n");
         for($x=0;$x<count($newWord);$x++) {
-            $AddtoPersonalDict = enchant_dict_add_to_personal($requestDict,$newWord[$x]);
+            $AddtoPersonalDict = enchant_dict_add($requestDict,$newWord[$x]);
         }
 
         if (NULL === $AddtoPersonalDict) {

--- a/ext/enchant/tests/broker_free_dict.phpt
+++ b/ext/enchant/tests/broker_free_dict.phpt
@@ -19,7 +19,7 @@ if (is_resource($broker)) {
 
     if ($requestDict) {
         echo("OK\n");
-        $AddtoPersonalDict = enchant_dict_add_to_personal($requestDict, $newWord);
+        $AddtoPersonalDict = enchant_dict_add($requestDict, $newWord);
 
         if (NULL === $AddtoPersonalDict) {
             var_dump($AddtoPersonalDict);

--- a/ext/enchant/tests/bug53070.phpt
+++ b/ext/enchant/tests/bug53070.phpt
@@ -4,6 +4,7 @@ Bug #53070 (enchant_broker_get_path crashes if no path is set)
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
 if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (defined("LIBENCHANT_VERSION") && version_compare(LIBENCHANT_VERSION, "2", ">")) die('skip libenchant v1 only');
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/bug53070.phpt
+++ b/ext/enchant/tests/bug53070.phpt
@@ -12,8 +12,12 @@ var_dump(enchant_broker_get_dict_path($broker, ENCHANT_MYSPELL));
 var_dump(enchant_broker_get_dict_path($broker, ENCHANT_ISPELL));
 ?>
 --EXPECTF--
+Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
+
 Warning: enchant_broker_get_dict_path(): dict_path not set in %s on line %d
 bool(false)
+
+Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
 
 Warning: enchant_broker_get_dict_path(): dict_path not set in %s on line %d
 bool(false)

--- a/ext/enchant/tests/dict_add_to_personal.phpt
+++ b/ext/enchant/tests/dict_add_to_personal.phpt
@@ -1,5 +1,5 @@
 --TEST--
-enchant_dict_add_to_personal() function
+enchant_dict_add() function
 --CREDITS--
 marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
@@ -20,7 +20,7 @@ if (is_resource($broker)) {
 
     if ($requestDict) {
         echo("OK\n");
-        $AddtoPersonalDict = enchant_dict_add_to_personal($requestDict,$newWord);
+        $AddtoPersonalDict = enchant_dict_add($requestDict,$newWord);
 
         if (NULL === $AddtoPersonalDict) {
             var_dump($AddtoPersonalDict);

--- a/ext/enchant/tests/dict_check.phpt
+++ b/ext/enchant/tests/dict_check.phpt
@@ -20,7 +20,7 @@ if (is_resource($broker)) {
 
     if ($requestDict) {
         echo("OK\n");
-        enchant_dict_add_to_personal($requestDict, $newWord);
+        enchant_dict_add($requestDict, $newWord);
 
         if (enchant_dict_check($requestDict, $newWord)) {
             echo("OK\n");

--- a/ext/enchant/tests/dict_is_in_session.phpt
+++ b/ext/enchant/tests/dict_is_in_session.phpt
@@ -20,10 +20,10 @@ if (is_resource($broker)) {
 
     if ($requestDict) {
         echo("OK\n");
-        $AddtoPersonalDict = enchant_dict_add_to_personal($requestDict,$newWord);
+        $AddtoPersonalDict = enchant_dict_add($requestDict,$newWord);
 
         if (NULL === $AddtoPersonalDict) {
-            var_dump(enchant_dict_is_in_session($requestDict,$newWord));
+            var_dump(enchant_dict_is_added($requestDict,$newWord));
         } else {
             echo("dict add to personal failed\n");
         }

--- a/ext/enchant/tests/enchant_broker_set_dict_path.phpt
+++ b/ext/enchant/tests/enchant_broker_set_dict_path.phpt
@@ -8,6 +8,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
 if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (defined("LIBENCHANT_VERSION") && version_compare(LIBENCHANT_VERSION, "2", ">")) die('skip libenchant v1 only');
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/enchant_broker_set_dict_path.phpt
+++ b/ext/enchant/tests/enchant_broker_set_dict_path.phpt
@@ -46,8 +46,16 @@ if (is_resource($broker)) {
     echo("broker is not a resource; failed; \n");
 }
 ?>
---EXPECT--
+--EXPECTF--
 OK
+
+Deprecated: Function enchant_broker_set_dict_path() is deprecated in %s
 OK
+
+Deprecated: Function enchant_broker_set_dict_path() is deprecated in %s
 OK
+
+Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
+
+Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
 OK


### PR DESCRIPTION
…hant v2

Remove deprecated calls
* enchant_dict_free_suggestions
* enchant_dict_add_to_personal
* enchant_dict_add_to_pwl
* enchant_dict_is_in_session

Rename 2 functions to match new upstream and deprecate previous
* enchant_dict_add_to_personal => enchant_dict_add
* enchant_dict_is_in_session => enchant_dict_is_added

Deprecate optional functions which will be removed in v 2
* enchant_broker_set_dict_path
* enchant_broker_get_dict_path

Raise dependency on v1.4.2 (May 2008)
all distro seems to have v 1.6 (April 2010)

Add LIBENCHANT_VERSION macro
