### PR TITLE
Fix #79539: during CI, drop table if it exists

### DIFF
--- a/ext/mysqli/tests/mysqli_insert_packet_overflow.phpt
+++ b/ext/mysqli/tests/mysqli_insert_packet_overflow.phpt
@@ -71,6 +71,9 @@ memory_limit=256M
         printf("[011] Failed to change max_allowed_packet");
     }
 
+    if (!mysqli_query($link, 'DROP TABLE IF EXISTS test'))
+        printf("[012] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
     if (!mysqli_query($link, "CREATE TABLE test(col_blob LONGBLOB) ENGINE=" . $engine))
         printf("[012] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 


### PR DESCRIPTION
CI fails on mysqli_insert_packet_overflow.phpt based on what mysqli
tests are run, because the test db sometimes lingers.  This fix drops
the table if it exists, as most tests do.