### PR TITLE
[RFC] Always enable JSON support in php 8.0

### DIFF
--- a/ext/json/config.m4
+++ b/ext/json/config.m4
@@ -1,19 +1,11 @@
-PHP_ARG_ENABLE([json],
-  [whether to enable JavaScript Object Serialization support],
-  [AS_HELP_STRING([--disable-json],
-    [Disable JavaScript Object Serialization support])],
-  [yes])
-
-if test "$PHP_JSON" != "no"; then
-  AC_DEFINE([HAVE_JSON],1 ,[whether to enable JavaScript Object Serialization support])
-
+dnl HAVE_JSON is always 1 as of php 8.0 and the constant will be removed in the future.
+dnl Note that HAVE_JSON was never defined for Windows builds (see config.w32)
+AC_DEFINE([HAVE_JSON],1 ,[whether to enable JavaScript Object Serialization support])
 PHP_NEW_EXTENSION(json,
 	  json.c \
 	  json_encoder.c \
 	  json_parser.tab.c \
 	  json_scanner.c,
 	  $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  PHP_INSTALL_HEADERS([ext/json], [php_json.h php_json_parser.h php_json_scanner.h])
-  PHP_ADD_MAKEFILE_FRAGMENT()
-  PHP_SUBST(JSON_SHARED_LIBADD)
-fi
+PHP_INSTALL_HEADERS([ext/json], [php_json.h php_json_parser.h php_json_scanner.h])
+PHP_ADD_MAKEFILE_FRAGMENT()

--- a/ext/json/config.w32
+++ b/ext/json/config.w32
@@ -1,22 +1,18 @@
 // vim:ft=javascript
 
-ARG_ENABLE("json", "JavaScript Object Serialization support", "yes");
+EXTENSION('json', 'json.c', false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
-if (PHP_JSON != "no") {
-	EXTENSION('json', 'json.c', PHP_JSON_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-
-	if (!FSO.FileExists("ext/json/json_scanner.c")) {
-		STDOUT.WriteLine("Generating ext/json/json_scanner.c");
-		STDOUT.WriteLine(execute(PATH_PROG("re2c") + " -t ext/json/php_json_scanner_defs.h --no-generation-date -bci -o ext/json/json_scanner.c ext/json/json_scanner.re"));
-	}
-	if (!FSO.FileExists("ext/json/json_parser.tab.c")) {
-		STDOUT.WriteLine("Generating ext/json/json_parser.tab.c");
-		STDOUT.WriteLine(execute(PATH_PROG("bison") + " --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c"));
-	}
-
-	ADD_SOURCES(configure_module_dirname, "json_encoder.c json_parser.tab.c json_scanner.c", "json");
-
-	ADD_MAKEFILE_FRAGMENT();
-
-	PHP_INSTALL_HEADERS("ext/json/", "php_json.h php_json_parser.h php_json_scanner.h");
+if (!FSO.FileExists("ext/json/json_scanner.c")) {
+    STDOUT.WriteLine("Generating ext/json/json_scanner.c");
+    STDOUT.WriteLine(execute(PATH_PROG("re2c") + " -t ext/json/php_json_scanner_defs.h --no-generation-date -bci -o ext/json/json_scanner.c ext/json/json_scanner.re"));
 }
+if (!FSO.FileExists("ext/json/json_parser.tab.c")) {
+    STDOUT.WriteLine("Generating ext/json/json_parser.tab.c");
+    STDOUT.WriteLine(execute(PATH_PROG("bison") + " --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c"));
+}
+
+ADD_SOURCES(configure_module_dirname, "json_encoder.c json_parser.tab.c json_scanner.c", "json");
+
+ADD_MAKEFILE_FRAGMENT();
+
+PHP_INSTALL_HEADERS("ext/json/", "php_json.h php_json_parser.h php_json_scanner.h");


### PR DESCRIPTION
Currently, it's possible to disable the json extension with
`./configure --disable-json` (for historical reasons that no longer apply).
However, JSON is widely used in many use cases - web sites, logging output,
and as a data format that can be used to share data with many applications
and programming languages,
so I'd personally find it useful if it was always enabled.

Examples of where this would be useful:

- For internal classes to be able to implement `JsonSerializable`
  which currently requires a hard dependency on the JSON extension.
  (e.g. DateTime has custom JSON serialization behavior, but is unable to implement JsonSerializable normally)
- For PHP users to publish single-file scripts that use json_encode and
  json_decode and don't require polyfills or less readable var_export output.
  (polyfills are less efficient and may have issues with recursive data
  structures)
- So that php-src's own modules, tools and test cases can start using JSON
  if it's a good choice for encoding a value. (same for PECLs)

https://wiki.php.net/rfc/jsond mentions that in PHP 5,

> The current Json Parser in the json extension does not have a free license
> which is a problem for many Linux distros.
> This has been referenced at Bug #63520.
> That results in not packaging json extension in the many Linux distributions.

Starting in php 7.0 with the switch to jsond,
It looks like licensing is no longer an issue.

Changes:

- After feedback, `HAVE_JSON` will not be removed in this PR, and will always be `1`.
  (Except on Windows, where it seems like it was never defined in any previous PHP release)
- Remove all flags related to JSON such as `configure --disable-json`
- Require that JSON be compiled statically instead of as a shared library

Examples of uses of JSON in various distros
(backwards incompatible changes such as changing packaging are typically
reserved for major versions, and 8.0 is a major version)

- ~~JSON is compiled statically into PHP in Ubuntu 20?.~~ (mentioned by someone else on an email thread but I'm not able to confirm this, I may be looking at the wrong repository since I see php-json in https://packages.ubuntu.com/focal/php/)
- The php-json package has to be installed separately
  from the PHP binary in Fedora repos.
- The zips on windows.php.net have json compiled statically already
- Building php from source (`./buildconf --force; ./configure; make`) compiles JSON statically by default

Mentioned in https://externals.io/message/109783 (Moving json extension to core?)
https://wiki.php.net/rfc/always_enable_json (draft)

-------

It turns out that php-json is still a separate package in https://packages.ubuntu.com/focal/php/

https://github.com/php/php-src/blob/master/ext/json/json.c is licensed under the PHP License 3.01, like php's core.

In an Ubuntu 20.04 image, installing `php7.4-cli` or `php` pulls in `php7.4-json` as a shared library during the installation.

```
root@66a2a72e1e85:/# apt-get install php7.4-cli
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  file libargon2-1 libbsd0 libedit2 libicu66 libmagic-mgc libmagic1 libsodium23 libssl1.1 libxml2
  mime-support php-common php7.4-common php7.4-json php7.4-opcache php7.4-readline psmisc tzdata ucf
  xz-utils
```