### PR TITLE
Fix enchant stub

### DIFF
--- a/ext/enchant/enchant.stub.php
+++ b/ext/enchant/enchant.stub.php
@@ -27,7 +27,7 @@ function enchant_broker_set_dict_path($broker, int $name, string $value): bool {
 function enchant_broker_get_dict_path($broker, int $name): string|false {}
 
 /** @param resource $broker */
-function enchant_broker_list_dicts($broker): array {}
+function enchant_broker_list_dicts($broker): ?array {}
 
 /**
  * @param resource $broker
@@ -51,7 +51,7 @@ function enchant_broker_dict_exists($broker, string $tag): bool {}
 function enchant_broker_set_ordering($broker, string $tag, string $ordering): bool {}
 
 /** @param resource $broker */
-function enchant_broker_describe($broker): array {}
+function enchant_broker_describe($broker): ?array {}
 
 /** @param resource $dict */
 function enchant_dict_quick_check($dict, string $word, &$suggestions = UNKNOWN): bool {}

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -22,7 +22,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_enchant_broker_get_dict_path, 0,
 	ZEND_ARG_TYPE_INFO(0, name, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_list_dicts, 0, 1, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_list_dicts, 0, 1, IS_ARRAY, 1)
 	ZEND_ARG_INFO(0, broker)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
`enchant_broker_list_dicts()` and `enchant_broker_describe()` return
`null` if no broker is available.

---

Alternatively, we could change the implementation to return an empty array in this case.