### PR TITLE
pdo_oci: Fix PARAM_NULL handling and test updates.

### DIFF
--- a/ext/pdo/tests/bug_71885.phpt
+++ b/ext/pdo/tests/bug_71885.phpt
@@ -7,6 +7,7 @@ $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
 if (!strncasecmp(getenv('PDOTEST_DSN'), 'pgsql', strlen('pgsql'))) die('skip not relevant for pgsql driver');
 if (!strncasecmp(getenv('PDOTEST_DSN'), 'odbc', strlen('odbc'))) die('skip inconsistent error message with odbc');
+if (!strncasecmp(getenv('PDOTEST_DSN'), 'oci', strlen('oci'))) die('skip different error message with oci');
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
 ?>

--- a/ext/pdo_oci/oci_statement.c
+++ b/ext/pdo_oci/oci_statement.c
@@ -327,6 +327,11 @@ static int oci_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *pa
 						value_sz = (sb4) sizeof(OCILobLocator*);
 						break;
 
+					case PDO_PARAM_NULL:
+						P->oci_type = SQLT_CHR;
+						value_sz = 0;
+						break;
+
 					case PDO_PARAM_STR:
 					default:
 						P->oci_type = SQLT_CHR;

--- a/ext/pdo_oci/oci_statement.c
+++ b/ext/pdo_oci/oci_statement.c
@@ -329,6 +329,7 @@ static int oci_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *pa
 
 					case PDO_PARAM_NULL:
 						P->oci_type = SQLT_CHR;
+						P->indicator = -1;
 						value_sz = 0;
 						break;
 

--- a/ext/pdo_oci/tests/pdo_oci_stmt_getcolumnmeta.phpt
+++ b/ext/pdo_oci/tests/pdo_oci_stmt_getcolumnmeta.phpt
@@ -39,22 +39,37 @@ SQL
         printf("[002] Expecting false got %s\n", var_export($tmp, true));
 
     $stmt->execute();
-    // Warning: PDOStatement::getColumnMeta() expects exactly 1 parameter, 0 given in
-    if (false !== ($tmp = @$stmt->getColumnMeta()))
-        printf("[003] Expecting false got %s\n", var_export($tmp, true));
 
+    echo "Test 1.1\n";
+    try {
+        $tmp = $stmt->getColumnMeta();
+    } catch (Throwable $e) {
+        echo get_class($e) . "\n";
+        echo $e->getMessage() . "\n";
+    }
+
+    echo "Test 1.2\n";
     // invalid offset
     if (false !== ($tmp = @$stmt->getColumnMeta(-1)))
         printf("[004] Expecting false got %s\n", var_export($tmp, true));
 
-    // Warning: PDOStatement::getColumnMeta(): Argument #1 must be of type int, array given in
-    if (false !== ($tmp = @$stmt->getColumnMeta(array())))
-        printf("[005] Expecting false got %s\n", var_export($tmp, true));
+    echo "Test 1.3\n";
+    try {
+        $stmt->getColumnMeta([]);
+    } catch (Throwable $e) {
+        echo get_class($e) . "\n";
+        echo $e->getMessage() . "\n";
+    }
 
-    // Warning: PDOStatement::getColumnMeta() expects exactly 1 parameter, 2 given in
-    if (false !== ($tmp = @$stmt->getColumnMeta(1, 1)))
-        printf("[006] Expecting false got %s\n", var_export($tmp, true));
+    echo "Test 1.4\n";
+    try {
+        $stmt->getColumnMeta(1, 1);
+    } catch (Throwable $e) {
+        echo get_class($e) . "\n";
+        echo $e->getMessage() . "\n";
+    }
 
+    echo "Test 1.5\n";
     // invalid offset
     if (false !== ($tmp = $stmt->getColumnMeta(1)))
         printf("[007] Expecting false because of invalid offset got %s\n", var_export($tmp, true));
@@ -290,6 +305,17 @@ print "done!";
 --EXPECT--
 Preparations before the test
 Test 1. calling function with invalid parameters
+Test 1.1
+ArgumentCountError
+PDOStatement::getColumnMeta() expects exactly 1 parameter, 0 given
+Test 1.2
+Test 1.3
+TypeError
+PDOStatement::getColumnMeta(): Argument #1 ($column) must be of type int, array given
+Test 1.4
+ArgumentCountError
+PDOStatement::getColumnMeta() expects exactly 1 parameter, 2 given
+Test 1.5
 Test 2. testing return values
 Test 2.1 testing array returned
 Test 2.2 testing numeric columns


### PR DESCRIPTION
Fixes running PDO test bug_73234 with OCI by implementing PARAM_NULL. Add a skip of test bug_71885 because the error messages are not consistent with other drivers and an
additional warning is generated when using a `SELECT` statement with
`PDO::exec()`. Update the `getColumnMeta` tests for pdo_oci to handle the
promotion of warnings to `ArgumentCountError` and `TypeError`.