### PR TITLE
proc_open refactoring (1)

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -486,6 +486,18 @@ static int set_proc_descriptor_to_blackhole(struct php_proc_open_descriptor_item
 	return SUCCESS;
 }
 
+static void efree_argv(char **argv)
+{
+	if (argv) {
+		char **arg = argv;
+		while (*arg != NULL) {
+			efree(*arg);
+			arg++;
+		}
+		efree(argv);
+	}
+}
+
 /* {{{ proto resource|false proc_open(string|array command, array descriptorspec, array &pipes [, string cwd [, array env [, array other_options]]])
    Run a process with more control over it's file descriptors */
 PHP_FUNCTION(proc_open)
@@ -1163,14 +1175,7 @@ PHP_FUNCTION(proc_open)
 	}
 
 #ifndef PHP_WIN32
-	if (argv) {
-		char **arg = argv;
-		while (*arg != NULL) {
-			efree(*arg);
-			arg++;
-		}
-		efree(argv);
-	}
+	efree_argv(argv);
 #endif
 
 	efree(descriptors);
@@ -1190,14 +1195,7 @@ exit_fail:
 	free(cmdw);
 	free(envpw);
 #else
-	if (argv) {
-		char **arg = argv;
-		while (*arg != NULL) {
-			efree(*arg);
-			arg++;
-		}
-		efree(argv);
-	}
+	efree_argv(argv);
 #endif
 #if PHP_CAN_DO_PTS
 	if (dev_ptmx >= 0) {

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -1093,7 +1093,9 @@ PHP_FUNCTION(proc_open)
 			}
 		}
 
-		/* Show errors from exec!! */
+		/* If execvp/execle/execl are successful, we will never reach here
+		 * Display error and exit with non-zero (error) status code */
+		php_error_docref(NULL, E_WARNING, "Exec failed - %s", strerror(errno));
 		_exit(127);
 	} else if (child < 0) {
 		/* failed to fork() */

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -868,8 +868,7 @@ PHP_FUNCTION(proc_open)
 				}
 			} else if (strcmp(Z_STRVAL_P(ztype), "redirect") == 0) {
 				zval *ztarget = zend_hash_index_find_deref(Z_ARRVAL_P(descitem), 1);
-				struct php_proc_open_descriptor_item *target = NULL;
-				php_file_descriptor_t childend;
+				php_file_descriptor_t childend = -1;
 
 				if (!ztarget) {
 					zend_value_error("Missing redirection target");
@@ -882,13 +881,12 @@ PHP_FUNCTION(proc_open)
 
 				for (i = 0; i < ndesc; i++) {
 					if (descriptors[i].index == Z_LVAL_P(ztarget)) {
-						target = &descriptors[i];
+						childend = descriptors[i].childend;
 						break;
 					}
 				}
-				if (target) {
-					childend = target->childend;
-				} else {
+
+				if (childend == -1) {
 					if (Z_LVAL_P(ztarget) < 0 || Z_LVAL_P(ztarget) > 2) {
 						php_error_docref(NULL, E_WARNING,
 							"Redirection target " ZEND_LONG_FMT " not found", Z_LVAL_P(ztarget));

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -1017,13 +1017,6 @@ PHP_FUNCTION(proc_open)
 	newprocok = CreateProcessW(NULL, cmdw, &php_proc_open_security, &php_proc_open_security,
 		TRUE, dwCreateFlags, envpw, cwdw, &si, &pi);
 
-	free(cwdw);
-	cwdw = NULL;
-	free(cmdw);
-	cmdw = NULL;
-	free(envpw);
-	envpw = NULL;
-
 	if (suppress_errors) {
 		SetErrorMode(old_error_mode);
 	}
@@ -1185,7 +1178,11 @@ PHP_FUNCTION(proc_open)
 		}
 	}
 
-#ifndef PHP_WIN32
+#ifdef PHP_WIN32
+	free(cwdw);
+	free(cmdw);
+	free(envpw);
+#else
 	efree_argv(argv);
 #endif
 

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -39,9 +39,6 @@
 #endif
 #include <signal.h>
 
-#if HAVE_SYS_STAT_H
-#include <sys/stat.h>
-#endif
 #if HAVE_FCNTL_H
 #include <fcntl.h>
 #endif

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -462,7 +462,7 @@ static char *create_win_command_from_args(HashTable *args)
 
 static int get_option(zval *other_options, char *option_name)
 {
-	zval *item = zend_hash_str_find(Z_ARRVAL_P(other_options), option_name, strlen(option_name));
+	zval *item = zend_hash_str_find_deref(Z_ARRVAL_P(other_options), option_name, strlen(option_name));
 	if (item != NULL) {
 		if (Z_TYPE_P(item) == IS_TRUE || ((Z_TYPE_P(item) == IS_LONG) && Z_LVAL_P(item))) {
 			return 1;

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -14,13 +14,6 @@
    +----------------------------------------------------------------------+
  */
 
-#if 0 && (defined(__linux__) || defined(sun) || defined(__IRIX__))
-# define _BSD_SOURCE 		/* linux wants this when XOPEN mode is on */
-# define _BSD_COMPAT		/* irix: uint32_t */
-# define _XOPEN_SOURCE 500  /* turn on Unix98 */
-# define __EXTENSIONS__	1	/* Solaris: uint32_t */
-#endif
-
 #include "php.h"
 #include <stdio.h>
 #include <ctype.h>

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -464,6 +464,27 @@ static char *create_win_command_from_args(HashTable *args) {
 }
 #endif
 
+static int set_proc_descriptor_to_blackhole(struct php_proc_open_descriptor_item *desc)
+{
+#ifdef PHP_WIN32
+	desc->childend = CreateFileA(
+		"nul", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+		NULL, OPEN_EXISTING, 0, NULL);
+	if (desc->childend == NULL) {
+		php_error_docref(NULL, E_WARNING, "Failed to open nul");
+		return FAILURE;
+	}
+#else
+	desc->childend = open("/dev/null", O_RDWR);
+	if (desc->childend < 0) {
+		php_error_docref(NULL, E_WARNING, "Failed to open /dev/null - %s", strerror(errno));
+		return FAILURE;
+	}
+#endif
+	desc->mode = DESC_FILE;
+	return SUCCESS;
+}
+
 /* {{{ proto resource|false proc_open(string|array command, array descriptorspec, array &pipes [, string cwd [, array env [, array other_options]]])
    Run a process with more control over it's file descriptors */
 PHP_FUNCTION(proc_open)
@@ -818,23 +839,9 @@ PHP_FUNCTION(proc_open)
 #endif
 				descriptors[ndesc].mode = DESC_REDIRECT;
 			} else if (strcmp(Z_STRVAL_P(ztype), "null") == 0) {
-#ifndef PHP_WIN32
-				descriptors[ndesc].childend = open("/dev/null", O_RDWR);
-				if (descriptors[ndesc].childend < 0) {
-					php_error_docref(NULL, E_WARNING,
-						"Failed to open /dev/null - %s", strerror(errno));
+				if (set_proc_descriptor_to_blackhole(&descriptors[ndesc]) == FAILURE) {
 					goto exit_fail;
 				}
-#else
-				descriptors[ndesc].childend = CreateFileA(
-					"nul", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
-					NULL, OPEN_EXISTING, 0, NULL);
-				if (descriptors[ndesc].childend == NULL) {
-					php_error_docref(NULL, E_WARNING, "Failed to open nul");
-					goto exit_fail;
-				}
-#endif
-				descriptors[ndesc].mode = DESC_FILE;
 			} else if (strcmp(Z_STRVAL_P(ztype), "pty") == 0) {
 #if PHP_CAN_DO_PTS
 				if (dev_ptmx == -1) {

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -463,6 +463,17 @@ static char *create_win_command_from_args(HashTable *args)
 	smart_string_0(&str);
 	return str.c;
 }
+
+static int get_option(zval *other_options, char *option_name)
+{
+	zval *item = zend_hash_str_find(Z_ARRVAL_P(other_options), option_name, strlen(option_name));
+	if (item != NULL) {
+		if (Z_TYPE_P(item) == IS_TRUE || ((Z_TYPE_P(item) == IS_LONG) && Z_LVAL_P(item))) {
+			return 1;
+		}
+	}
+	return 0;
+}
 #endif
 
 static int set_proc_descriptor_to_blackhole(struct php_proc_open_descriptor_item *desc)
@@ -598,41 +609,12 @@ PHP_FUNCTION(proc_open)
 
 #ifdef PHP_WIN32
 	if (other_options) {
-		zval *item = zend_hash_str_find(Z_ARRVAL_P(other_options), "suppress_errors", sizeof("suppress_errors") - 1);
-		if (item != NULL) {
-			if (Z_TYPE_P(item) == IS_TRUE || ((Z_TYPE_P(item) == IS_LONG) && Z_LVAL_P(item))) {
-				suppress_errors = 1;
-			}
-		}
-
+		suppress_errors      = get_option(other_options, "suppress_errors");
 		/* TODO Deprecate in favor of array command? */
-		item = zend_hash_str_find(Z_ARRVAL_P(other_options), "bypass_shell", sizeof("bypass_shell") - 1);
-		if (item != NULL) {
-			if (Z_TYPE_P(item) == IS_TRUE || ((Z_TYPE_P(item) == IS_LONG) && Z_LVAL_P(item))) {
-				bypass_shell = 1;
-			}
-		}
-
-		item = zend_hash_str_find(Z_ARRVAL_P(other_options), "blocking_pipes", sizeof("blocking_pipes") - 1);
-		if (item != NULL) {
-			if (Z_TYPE_P(item) == IS_TRUE || ((Z_TYPE_P(item) == IS_LONG) && Z_LVAL_P(item))) {
-				blocking_pipes = 1;
-			}
-		}
-
-		item = zend_hash_str_find(Z_ARRVAL_P(other_options), "create_process_group", sizeof("create_process_group") - 1);
-		if (item != NULL) {
-			if (Z_TYPE_P(item) == IS_TRUE || ((Z_TYPE_P(item) == IS_LONG) && Z_LVAL_P(item))) {
-				create_process_group = 1;
-			}
-		}
-
-		item = zend_hash_str_find(Z_ARRVAL_P(other_options), "create_new_console", sizeof("create_new_console") - 1);
-		if (item != NULL) {
-			if (Z_TYPE_P(item) == IS_TRUE || ((Z_TYPE_P(item) == IS_LONG) && Z_LVAL_P(item))) {
-				create_new_console = 1;
-			}
-		}
+		bypass_shell         = bypass_shell || get_option(other_options, "bypass_shell");
+		blocking_pipes       = get_option(other_options, "blocking_pipes");
+		create_process_group = get_option(other_options, "create_process_group");
+		create_new_console   = get_option(other_options, "create_new_console");
 	}
 #endif
 

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -476,6 +476,12 @@ static int get_option(zval *other_options, char *option_name)
 }
 #endif
 
+static struct php_proc_open_descriptor_item* alloc_descriptor_array(zval *descriptorspec)
+{
+	int ndescriptors = zend_hash_num_elements(Z_ARRVAL_P(descriptorspec));
+	return ecalloc(sizeof(struct php_proc_open_descriptor_item), ndescriptors);
+}
+
 static int set_proc_descriptor_to_blackhole(struct php_proc_open_descriptor_item *desc)
 {
 #ifdef PHP_WIN32
@@ -527,7 +533,6 @@ PHP_FUNCTION(proc_open)
 	zend_string *str_index;
 	zend_ulong nindex;
 	struct php_proc_open_descriptor_item *descriptors = NULL;
-	int ndescriptors_array;
 #ifdef PHP_WIN32
 	PROCESS_INFORMATION pi;
 	HANDLE childHandle;
@@ -622,11 +627,7 @@ PHP_FUNCTION(proc_open)
 		env = _php_array_to_envp(environment);
 	}
 
-	ndescriptors_array = zend_hash_num_elements(Z_ARRVAL_P(descriptorspec));
-
-	descriptors = safe_emalloc(sizeof(struct php_proc_open_descriptor_item), ndescriptors_array, 0);
-
-	memset(descriptors, 0, sizeof(struct php_proc_open_descriptor_item) * ndescriptors_array);
+	descriptors = alloc_descriptor_array(descriptorspec);
 
 #ifdef PHP_WIN32
 	/* we use this to allow the child to inherit handles */

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -509,6 +509,11 @@ static void init_startup_info(STARTUPINFOW *si, struct php_proc_open_descriptor_
 	}
 }
 
+static void init_process_info(PROCESS_INFORMATION *pi)
+{
+	memset(&pi, 0, sizeof(pi));
+}
+
 static int convert_command_to_use_shell(wchar_t **cmdw, size_t cmdw_len)
 {
 	size_t len = sizeof(COMSPEC_NT) + sizeof(" /s /c ") + cmdw_len + 3;
@@ -962,8 +967,7 @@ PHP_FUNCTION(proc_open)
 	}
 
 	init_startup_info(&si, descriptors, ndesc);
-
-	memset(&pi, 0, sizeof(pi));
+	init_process_info(&pi);
 
 	if (suppress_errors) {
 		old_error_mode = SetErrorMode(SEM_FAILCRITICALERRORS|SEM_NOGPFAULTERRORBOX);

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -914,7 +914,7 @@ PHP_FUNCTION(proc_open)
 					goto exit_fail;
 				}
 				if (Z_TYPE_P(ztarget) != IS_LONG) {
-					zend_value_error("Redirection target must be an integer");
+					zend_value_error("Redirection target must be of type int; got %s", zend_get_type_by_const(Z_TYPE_P(ztarget)));
 					goto exit_fail;
 				}
 				if (redirect_proc_descriptor(&descriptors[ndesc], Z_LVAL_P(ztarget), descriptors, ndesc, nindex) == FAILURE) {

--- a/ext/standard/proc_open.h
+++ b/ext/standard/proc_open.h
@@ -17,9 +17,11 @@
 #ifdef PHP_WIN32
 typedef HANDLE php_file_descriptor_t;
 typedef DWORD php_process_id_t;
+# define PHP_INVALID_FD INVALID_HANDLE_VALUE
 #else
 typedef int php_file_descriptor_t;
 typedef pid_t php_process_id_t;
+# define PHP_INVALID_FD (-1)
 #endif
 
 /* Environment block under win32 is a NUL terminated sequence of NUL terminated

--- a/ext/standard/tests/general_functions/proc_open_redirect.phpt
+++ b/ext/standard/tests/general_functions/proc_open_redirect.phpt
@@ -53,7 +53,7 @@ proc_close($proc);
 ?>
 --EXPECTF--
 Missing redirection target
-Redirection target must be an integer
+Redirection target must be of type int; got string
 
 Warning: proc_open(): Redirection target 42 not found in %s
 


### PR DESCRIPTION
Code cleanup and reorganization in `proc_open.c`, in readiness to implement PTY support.

Code review will be easier if you look through commit by commit. However, if you want them squashed together before actually merging, that is fine.