### PR TITLE
[jit] Split up opcache.jit bitmask into four distinct INI settings.

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3010,10 +3010,15 @@ static int accel_post_startup(void)
 
 		zend_shared_alloc_lock();
 #ifdef HAVE_JIT
+		zend_long jit_flags = ZCG(accel_directives).jit_optimization_level * 1 +
+			ZCG(accel_directives).jit_trigger * 10 +
+			ZCG(accel_directives).jit_register_allocation * 100 +
+			ZCG(accel_directives).jit_cpu_flags * 1000;
+
 		if (ZCG(accel_directives).jit &&
 		    ZCG(accel_directives).jit_buffer_size &&
 		    ZSMMG(reserved) &&
-			zend_jit_startup(ZCG(accel_directives).jit, ZSMMG(reserved), jit_size, reattached) == SUCCESS) {
+			zend_jit_startup(jit_flags, ZSMMG(reserved), jit_size, reattached) == SUCCESS) {
 			ZCG(jit_enabled) = 1;
 		} else {
 			ZCG(jit_enabled) = 0;

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -192,7 +192,11 @@ typedef struct _zend_accel_directives {
 	char *cache_id;
 #endif
 #ifdef HAVE_JIT
-	zend_long      jit;
+	zend_bool      jit;
+	zend_long      jit_optimization_level;
+	zend_long      jit_trigger;
+	zend_long      jit_register_allocation;
+	zend_long      jit_cpu_flags;
 	zend_long      jit_buffer_size;
 	zend_long      jit_debug;
 	zend_long      jit_bisect_limit;

--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -48,9 +48,6 @@
 #define ZEND_JIT_CPU_FLAGS(n)      (((n) / 1000) % 10)
 
 
-#define ZEND_JIT_DEFAULT           "1205"
-
-
 /* Makes profile based JIT (opcache.jit=2*) to generate code only for most
  * often called functions (above the threshold).
  * TODO: this setting should be configurable

--- a/ext/opcache/tests/jit/defined_001.phpt
+++ b/ext/opcache/tests/jit/defined_001.phpt
@@ -5,7 +5,8 @@ opcache.enable=1
 opcache.enable_cli=1
 opcache.file_update_protection=0
 opcache.jit_buffer_size=1M
-opcache.jit=1235
+opcache.jit=1
+opcache.jit_trigger=3
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
 --FILE--

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -251,7 +251,11 @@ ZEND_INI_BEGIN()
 	STD_PHP_INI_ENTRY("opcache.cache_id"                      , ""    , PHP_INI_SYSTEM, OnUpdateString,           accel_directives.cache_id,               zend_accel_globals, accel_globals)
 #endif
 #ifdef HAVE_JIT
-	STD_PHP_INI_ENTRY("opcache.jit"                           , ZEND_JIT_DEFAULT, PHP_INI_SYSTEM, OnUpdateLong, accel_directives.jit,                      zend_accel_globals, accel_globals)
+	STD_PHP_INI_ENTRY("opcache.jit"                           , "1"   , PHP_INI_SYSTEM, OnUpdateBool,      accel_directives.jit,                      zend_accel_globals, accel_globals)
+	STD_PHP_INI_ENTRY("opcache.jit_optimization_level"        , "5"   , PHP_INI_SYSTEM, OnUpdateLong,      accel_directives.jit_optimization_level,        zend_accel_globals, accel_globals)
+	STD_PHP_INI_ENTRY("opcache.jit_trigger"                   , "0"   , PHP_INI_SYSTEM, OnUpdateLong,      accel_directives.jit_trigger,                   zend_accel_globals, accel_globals)
+	STD_PHP_INI_ENTRY("opcache.jit_register_allocation"       , "2"   , PHP_INI_SYSTEM, OnUpdateLong,      accel_directives.jit_register_allocation,       zend_accel_globals, accel_globals)
+	STD_PHP_INI_ENTRY("opcache.jit_cpu_flags"                 , "1"   , PHP_INI_SYSTEM,	OnUpdateLong,      accel_directives.jit_cpu_flags,                 zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.jit_buffer_size"               , "0"   , PHP_INI_SYSTEM, OnUpdateLong,	   accel_directives.jit_buffer_size,               zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.jit_debug"                     , "0"   , PHP_INI_SYSTEM, OnUpdateLong,	   accel_directives.jit_debug,                     zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.jit_bisect_limit"              , "0"   , PHP_INI_SYSTEM, OnUpdateLong,      accel_directives.jit_bisect_limit,              zend_accel_globals, accel_globals)
@@ -722,7 +726,11 @@ ZEND_FUNCTION(opcache_get_configuration)
 	add_assoc_string(&directives, "opcache.cache_id", STRING_NOT_NULL(ZCG(accel_directives).cache_id));
 #endif
 #ifdef HAVE_JIT
-	add_assoc_long(&directives,   "opcache.jit", ZCG(accel_directives).jit);
+	add_assoc_bool(&directives,   "opcache.jit", ZCG(accel_directives).jit);
+	add_assoc_long(&directives,   "opcache.jit_optimization_level", ZCG(accel_directives).jit_optimization_level);
+	add_assoc_long(&directives,   "opcache.jit_trigger", ZCG(accel_directives).jit_trigger);
+	add_assoc_long(&directives,   "opcache.jit_register_allocation", ZCG(accel_directives).jit_register_allocation);
+	add_assoc_long(&directives,   "opcache.jit_cpu_flags", ZCG(accel_directives).jit_cpu_flags);
 	add_assoc_long(&directives,   "opcache.jit_buffer_size", ZCG(accel_directives).jit_buffer_size);
 	add_assoc_long(&directives,   "opcache.jit_debug", ZCG(accel_directives).jit_debug);
 	add_assoc_long(&directives,   "opcache.jit_bisect_limit", ZCG(accel_directives).jit_bisect_limit);


### PR DESCRIPTION
To improve developer experience the opcache.jit bitmask was split up into these four settings:

- opcache.jit_optimization_level=5
- opcache.jit_trigger=0
- opcache.jit_register_allocation=2
- opcache.jit_cpu_flags=1

Immediate future todos:

- We now have a bool `opcache.jit` and the "implicit" flag `opcache.jit_buffer_size` which is 0 by default and leads to disabling the JIT. Maybe we should turn these around and set `opcache.jit=0` and `opcache.jit_buffer_size=16M` (or whatever is a good default).
- The default for `opcache.jit_trigger` should be changed to 3 (profile and jit hot functions only). This is suggested in the RFC as well.