### PR TITLE
Fix #79467: data:// wrappers are writable

### DIFF
--- a/ext/standard/tests/streams/bug79467.phpt
+++ b/ext/standard/tests/streams/bug79467.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug #79467 (data:// wrappers are writable)
+--FILE--
+<?php
+var_dump(file_put_contents('data://text/plain,cccc', 'data'));
+?>
+--EXPECTF--
+Notice: file_put_contents(): Stream is not writable in %s on line %d
+bool(false)

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -619,7 +619,7 @@ PHPAPI php_stream *_php_stream_temp_open(int mode, size_t max_memory_usage, char
 /* }}} */
 
 PHPAPI const php_stream_ops php_stream_rfc2397_ops = {
-	php_stream_temp_write, php_stream_temp_read,
+	NULL, php_stream_temp_read,
 	php_stream_temp_close, php_stream_temp_flush,
 	"RFC2397",
 	php_stream_temp_seek,


### PR DESCRIPTION
Despite the docs claiming that data: wrappers would not be writable[1],
they are implemented as writing to a memory stream.  That does not seem
to be particularly sensible, so we disallow writing altogether.

[1] <https://www.php.net/manual/en/wrappers.data.php#refsect1-wrappers.data-options>