### PR TITLE
Support shmget(IPC_PRIVATE, …) on Windows

### DIFF
--- a/ext/shmop/tests/shmop_open_private.phpt
+++ b/ext/shmop/tests/shmop_open_private.phpt
@@ -1,0 +1,23 @@
+--TEST--
+shmop_open with IPC_PRIVATE creates private SHM
+--SKIPIF--
+<?php
+if (!extension_loaded('shmop')) die('skip shmop extension not available');
+?>
+--FILE--
+<?php
+$write = 'test';
+
+$shm1 = shmop_open(0, 'c', 0777, 1024);
+shmop_write($shm1, $write, 0);
+
+$shm2 = shmop_open(0, 'c', 0777, 1024);
+$read = shmop_read($shm2, 0, 4);
+
+var_dump(is_string($read) && $read !== $write);
+
+shmop_close($shm1);
+shmop_close($shm2);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
We map the POSIX semantics of `IPC_PRIVATE` by creating unnamed file
mapping objects on Windows.  While that is not particularly useful for
ext/shmop, which is the only bundled extension which uses `shmget()`,
and even constitutes a potential BC break for `shmop_open()`, it may
be useful for external extensions.