### PR TITLE
Add -std=GNU99 compiler flag

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -221,7 +221,7 @@ else
   AC_DEFINE(ZEND_DEBUG,0,[ ])
 fi
 
-test -n "$GCC" && CFLAGS="$CFLAGS -Wall -Wextra -Wno-strict-aliasing -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-sign-compare"
+test -n "$GCC" && CFLAGS="$CFLAGS -std=gnu99 -Wall -Wextra -Wno-strict-aliasing -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-sign-compare"
 dnl Check if compiler supports -Wno-clobbered (only GCC)
 AX_CHECK_COMPILE_FLAG([-Wno-clobbered], CFLAGS="$CFLAGS -Wno-clobbered", , [-Werror])
 


### PR DESCRIPTION
GCC defaults to GNU11 corresponding to the C11 standard with GNU extensions.

We can't use the -std=C99 flag as POSIX signal handling is not present.

Moreover we use the "Labels as Values" GNU extension in the VM making
us non ISO C99 compliant.