### PR TITLE
Fix #79557: extension_dir = ./ext now use current directory for base

### DIFF
--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -440,7 +440,13 @@ PHP_WINUTIL_API char *php_win32_get_username(void)
 
 static zend_always_inline BOOL is_compatible(const char *name, BOOL is_smaller, char *format, char **err)
 {/*{{{*/
-	PLOADED_IMAGE img = ImageLoad(name, NULL);
+	/* work around ImageLoad() issue */
+	char *name_stripped = name;
+	if (name[0] == '.' && IS_SLASH(name[1])) {
+		name_stripped += 2;
+	}
+
+	PLOADED_IMAGE img = ImageLoad(name_stripped, NULL);
 
 	if (!img) {
 		DWORD _err = GetLastError();


### PR DESCRIPTION
For some reason, `ImageLoad()` fails to load images with a relative
path starting with `.\`  or `./`.  We work around this issue by
stripping those leading characters.