### PR TITLE
Add PTY support to proc_open (again after 16 long years)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -392,6 +392,7 @@ malloc.h \
 monetary.h \
 netdb.h \
 poll.h \
+pty.h \
 pwd.h \
 resolv.h \
 strings.h \
@@ -560,7 +561,6 @@ getgrnam_r \
 getpwuid_r \
 getwd \
 glob \
-grantpt \
 inet_ntoa \
 inet_ntop \
 inet_pton \
@@ -572,7 +572,6 @@ mmap \
 nice \
 nl_langinfo \
 poll \
-ptsname \
 putenv \
 scandir \
 setitimer \
@@ -588,7 +587,6 @@ strptime \
 strtok_r \
 symlink \
 tzset \
-unlockpt \
 unsetenv \
 usleep \
 utime \
@@ -706,6 +704,9 @@ if test "$PHP_VALGRIND" != "no"; then
     fi
   fi
 fi
+
+dnl Check for openpty. It may require linking against libutil.
+PHP_CHECK_FUNC(openpty, util)
 
 dnl General settings.
 dnl ----------------------------------------------------------------------------

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -57,10 +57,10 @@
 static int le_proc_open;
 
 /* {{{ _php_array_to_envp */
-static php_process_env_t _php_array_to_envp(zval *environment)
+static php_process_env _php_array_to_envp(zval *environment)
 {
 	zval *element;
-	php_process_env_t env;
+	php_process_env env;
 	zend_string *key, *str;
 #ifndef PHP_WIN32
 	char **ep;
@@ -140,7 +140,7 @@ static php_process_env_t _php_array_to_envp(zval *environment)
 /* }}} */
 
 /* {{{ _php_free_envp */
-static void _php_free_envp(php_process_env_t env)
+static void _php_free_envp(php_process_env env)
 {
 #ifndef PHP_WIN32
 	if (env.envarray) {
@@ -156,7 +156,7 @@ static void _php_free_envp(php_process_env_t env)
 /* {{{ proc_open_rsrc_dtor */
 static void proc_open_rsrc_dtor(zend_resource *rsrc)
 {
-	struct php_process_handle *proc = (struct php_process_handle*)rsrc->ptr;
+	php_process_handle *proc = (php_process_handle*)rsrc->ptr;
 #ifdef PHP_WIN32
 	DWORD wstatus;
 #elif HAVE_SYS_WAIT_H
@@ -227,7 +227,7 @@ PHP_MINIT_FUNCTION(proc_open)
 PHP_FUNCTION(proc_terminate)
 {
 	zval *zproc;
-	struct php_process_handle *proc;
+	php_process_handle *proc;
 	zend_long sig_no = SIGTERM;
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
@@ -236,7 +236,7 @@ PHP_FUNCTION(proc_terminate)
 		Z_PARAM_LONG(sig_no)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if ((proc = (struct php_process_handle *)zend_fetch_resource(Z_RES_P(zproc), "process", le_proc_open)) == NULL) {
+	if ((proc = (php_process_handle*)zend_fetch_resource(Z_RES_P(zproc), "process", le_proc_open)) == NULL) {
 		RETURN_THROWS();
 	}
 
@@ -261,13 +261,13 @@ PHP_FUNCTION(proc_terminate)
 PHP_FUNCTION(proc_close)
 {
 	zval *zproc;
-	struct php_process_handle *proc;
+	php_process_handle *proc;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_RESOURCE(zproc)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if ((proc = (struct php_process_handle *)zend_fetch_resource(Z_RES_P(zproc), "process", le_proc_open)) == NULL) {
+	if ((proc = (php_process_handle*)zend_fetch_resource(Z_RES_P(zproc), "process", le_proc_open)) == NULL) {
 		RETURN_THROWS();
 	}
 
@@ -283,7 +283,7 @@ PHP_FUNCTION(proc_close)
 PHP_FUNCTION(proc_get_status)
 {
 	zval *zproc;
-	struct php_process_handle *proc;
+	php_process_handle *proc;
 #ifdef PHP_WIN32
 	DWORD wstatus;
 #elif HAVE_SYS_WAIT_H
@@ -297,7 +297,7 @@ PHP_FUNCTION(proc_get_status)
 		Z_PARAM_RESOURCE(zproc)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if ((proc = (struct php_process_handle *)zend_fetch_resource(Z_RES_P(zproc), "process", le_proc_open)) == NULL) {
+	if ((proc = (php_process_handle*)zend_fetch_resource(Z_RES_P(zproc), "process", le_proc_open)) == NULL) {
 		RETURN_THROWS();
 	}
 
@@ -841,7 +841,7 @@ PHP_FUNCTION(proc_open)
 	zval *pipes;
 	zval *environment = NULL;
 	zval *other_options = NULL;
-	php_process_env_t env;
+	php_process_env env;
 	int ndesc = 0;
 	int i;
 	zval *descitem = NULL;
@@ -868,7 +868,7 @@ PHP_FUNCTION(proc_open)
 #endif
 	int pty_master_fd = -1, pty_slave_fd = -1;
 	php_process_id_t child;
-	struct php_process_handle *proc;
+	php_process_handle *proc;
 
 	ZEND_PARSE_PARAMETERS_START(3, 6)
 		Z_PARAM_ZVAL(command_zv)
@@ -1088,7 +1088,7 @@ PHP_FUNCTION(proc_open)
 		goto exit_fail;
 	}
 
-	proc = (struct php_process_handle*) emalloc(sizeof(struct php_process_handle));
+	proc = (php_process_handle*) emalloc(sizeof(php_process_handle));
 	proc->command = command;
 	proc->pipes = emalloc(sizeof(zend_resource *) * ndesc);
 	proc->npipes = ndesc;

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -933,11 +933,13 @@ PHP_FUNCTION(proc_open)
 
 		if (Z_TYPE_P(descitem) == IS_RESOURCE) {
 			/* should be a stream - try and dup the descriptor */
-			php_stream *stream;
+			php_stream *stream = (php_stream*)zend_fetch_resource(Z_RES_P(descitem), "stream", php_file_le_stream());
+			if (stream == NULL) {
+				goto exit_fail;
+			}
+
 			php_socket_t fd;
 			php_file_descriptor_t desc;
-
-			php_stream_from_zval(stream, descitem);
 
 			if (FAILURE == php_stream_cast(stream, PHP_STREAM_AS_FD, (void **)&fd, REPORT_ERRORS)) {
 				goto exit_fail;

--- a/ext/standard/proc_open.h
+++ b/ext/standard/proc_open.h
@@ -24,18 +24,17 @@ typedef pid_t php_process_id_t;
 # define PHP_INVALID_FD (-1)
 #endif
 
-/* Environment block under win32 is a NUL terminated sequence of NUL terminated
- * name=value strings.
- * Under unix, it is an argv style array.
- * */
+/* Environment block under Win32 is a NUL terminated sequence of NUL terminated
+ *   name=value strings.
+ * Under Unix, it is an argv style array. */
 typedef struct _php_process_env {
 	char *envp;
 #ifndef PHP_WIN32
 	char **envarray;
 #endif
-} php_process_env_t;
+} php_process_env;
 
-struct php_process_handle {
+typedef struct _php_process_handle {
 	php_process_id_t	child;
 #ifdef PHP_WIN32
 	HANDLE childHandle;
@@ -43,5 +42,5 @@ struct php_process_handle {
 	int npipes;
 	zend_resource **pipes;
 	char *command;
-	php_process_env_t env;
-};
+	php_process_env env;
+} php_process_handle;

--- a/ext/standard/tests/file/bug69442.phpt
+++ b/ext/standard/tests/file/bug69442.phpt
@@ -17,7 +17,7 @@ EOC;
     $output = join("\n", $output);
     unlink($tmpFile);
 
-    if (strstr($output, "PTY pseudo terminal not supported on this system") !== false) {
+    if (strstr($output, "PTY (pseudoterminal) not supported on this system") !== false) {
         die("skip PTY pseudo terminals are not supported");
     }
 --FILE--
@@ -28,17 +28,31 @@ $pipes = array();
 
 $process = proc_open($cmd, $descriptors, $pipes);
 
-foreach ($pipes as $type => $pipe) {
-    $data = fread($pipe, 999);
-    echo 'type ' . $type . ' ';
-    var_dump($data);
-    fclose($pipe);
+function read_from_pipe($pipe) {
+    $result = fread($pipe, 1000);
+    /* We can't guarantee that everything written to the pipe will be returned by a single call
+     *   to fread(), even if it was written with a single syscall and the number of bytes written
+     *   was small */
+    $again  = @fread($pipe, 1000);
+    if ($again) {
+        $result .= $again;
+    }
+    return $result;
 }
+
+$data0 = read_from_pipe($pipes[0]);
+echo 'read from pipe 0: ';
+var_dump($data0);
+fclose($pipes[0]);
+
+$data3 = read_from_pipe($pipes[3]);
+echo 'read from pipe 3: ';
+var_dump($data3);
+fclose($pipes[3]);
+
 proc_close($process);
 --EXPECT--
-type 0 string(5) "foo
+read from pipe 0: string(5) "foo
 "
-type 1 string(0) ""
-type 2 string(0) ""
-type 3 string(3) "42
+read from pipe 3: string(3) "42
 "

--- a/ext/standard/tests/file/proc_open_with_wrong_resource_type.phpt
+++ b/ext/standard/tests/file/proc_open_with_wrong_resource_type.phpt
@@ -1,0 +1,14 @@
+--TEST--
+proc_open does not leak memory when called with wrong resource type in descriptorspec
+--FILE--
+<?php
+    $context = stream_context_create();
+    try {
+      proc_open('not_a_real_command_but_I_dont_care', array(0 => $context), $pipes);
+      echo "Not reached";
+    } catch (TypeError $e) {
+      echo $e->getMessage(), "\n";
+    }
+?>
+--EXPECT--
+proc_open(): supplied resource is not a valid stream resource

--- a/ext/standard/tests/general_functions/proc_open_pipes3.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes3.phpt
@@ -32,7 +32,7 @@ echo "END\n";
 ?>
 --EXPECTF--
 Warning: proc_open(): pi is not a valid descriptor spec/mode in %s on line %d
-proc_open(): Argument #2 ($descriptorspec) must only contain arrays and File-Handles
+proc_open(): Argument #2 ($descriptorspec) must only contain arrays and streams
 array(4) {
   [3]=>
   resource(%d) of type (Unknown)


### PR DESCRIPTION
Back in 2004, a feature was added to proc_open which allowed it to open a PTY, connecting specific FDs in the child process to the slave end of the PTY and returning the master end of the PTY (wrapped as a PHP stream) in the `$pipes` array. However, this feature was disabled just about a month later. Little information is available about why this was done, but from talking to the original implementer, it seems there were portability problems with some rare flavors of Unix.

Re-enable this feature with a simplified implementation which uses `openpty()`. No attempt is made to support PTYs if the platform does not have `openpty()`. The configure script checks if linking with `-lutil` is necessary to use `openpty()`, but if anything else is required, like including some special header or linking with some other library, PTY support will be disabled.

The original PTY support for `proc_open` automatically daemonized the child process (disassociating it from the TTY session and process group of the parent). However, I don't think this is a good idea. Just because a user opens a child process in a PTY, it doesn't mean they want it to continue running even when the parent process is killed. Of course, if the child process is some kind of server, it will likely daemonize itself; but we have no reason to preempt that decision.

It turns out that since 2015, there has been one test case for PTY support in proc_open() in the test suite. This test was added in GitHub PR #1588. That PR mentioned that the PHP binary in the Debian/Ubuntu repositories is patched to *enable* PTY support. Checking the Debian PHP repository (https://salsa.debian.org/php-team/php.git) shows that this is still true. Debian's patch does not modify the implementation from 2004 in any way; it just removes the `#if 0` line which disables it.

Naturally, the test case is skipped if PTY support is not enabled. This means that ever since it was added, every test run against the 'vanilla' PHP codebase has skipped it.

Interestingly, the test case which was added in 2015 fails on my Linux Mint PC... both with this simplified implementation *and* when enabling the original implementation. Investigation reveals the reason: when the child process using the slave end of the PTY exits and its FDs are all closed, and all buffered data is read from the master end of the PTY, any further attempt to read from the master end fails with EIO. The test case seems to expect that reading from the master end will always return an empty string if no data is available.

Could this mean that on the platform where this test case was originally developed, the PHP parent process ran *faster* than the child process, so that all the calls to fread() complete before the child process exits and closes its FDs? Or could something else about the platform have been different, such that read() in the parent does not fail with EIO even after the child process exits? Another question: Are the Debian packagers even running this test case every time they build PHP binaries? Intriguing questions, these!

There may be another way out of this sticky dilemma: IF at least one FD referring to the slave end of the PTY is kept open *in the parent process*, the failure with EIO will not occur even after the child process exits. This might be a good approach, though we would need a way to ensure the FD will be closed eventually in long-running programs. Perhaps associate it with the proc resource and close it when the proc is freed or explicitly closed with proc_close?

And the rabbit hole goes deeper. Although (for now) the test case from 2015 has been updated so it does not attempt to fread() multiple times from the PTY, it still fails intermittently. The reason? When the child process writes `"foo\n"` to the PTY, the parent sometimes receives `"foo"` (3 bytes) and sometimes `"foo\r\n"` (5 bytes). The "\r" is obviously from the TTY line discipline converting `"\n"` to `"\r\n"`, but why on earth would the parent sometimes read the newline and sometimes not? What is more, strace clearly shows that this is happening *in the kernel*. The child process always executes a single `write("foo\n")` syscall, but when the blocking `read()` syscall issued by the parent process returns, sometimes it returns `"foo"` and sometimes `"foo\r\n"`. This doesn't happen when I extract the test code and run it directly from the PHP CLI, only when the test case is run by run-tests.php.

Thanks to Nikita Popov for suggesting that we should just use openpty() rather than grantpt(), unlockpt(), etc.