### PR TITLE
Remove NDEBUG constant

### DIFF
--- a/ext/fileinfo/libmagic.patch
+++ b/ext/fileinfo/libmagic.patch
@@ -1062,7 +1062,7 @@ diff -u libmagic.orig/buffer.c libmagic/buffer.c
  
 diff -u libmagic.orig/cdf.c libmagic/cdf.c
 --- libmagic.orig/cdf.c	2019-02-20 03:35:27.000000000 +0100
-+++ libmagic/cdf.c	2020-04-07 22:25:10.517321000 +0200
++++ libmagic/cdf.c	2020-05-05 18:42:24.973318200 +0200
 @@ -43,7 +43,17 @@
  #include <err.h>
  #endif
@@ -1138,7 +1138,7 @@ diff -u libmagic.orig/cdf.c libmagic/cdf.c
  static size_t
  cdf_check_stream(const cdf_stream_t *sst, const cdf_header_t *h)
  {
-+#ifndef NDEBUG
++#if PHP_DEBUG
  	size_t ss = sst->sst_dirlen < h->h_min_size_standard_stream ?
  	    CDF_SHORT_SEC_SIZE(h) : CDF_SEC_SIZE(h);
  	assert(ss == sst->sst_ss);
@@ -1636,7 +1636,7 @@ diff -u libmagic.orig/encoding.c libmagic/encoding.c
  }
 diff -u libmagic.orig/file.h libmagic/file.h
 --- libmagic.orig/file.h	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/file.h	2020-04-22 20:15:46.790840100 +0200
++++ libmagic/file.h	2020-05-05 18:41:04.309311200 +0200
 @@ -33,18 +33,9 @@
  #ifndef __file_h__
  #define __file_h__
@@ -2212,7 +2212,7 @@ diff -u libmagic.orig/fsmagic.c libmagic/fsmagic.c
  	case S_IFSOCK:
 diff -u libmagic.orig/funcs.c libmagic/funcs.c
 --- libmagic.orig/funcs.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/funcs.c	2020-04-14 17:15:50.737587100 +0200
++++ libmagic/funcs.c	2020-05-05 18:41:04.309311200 +0200
 @@ -31,87 +31,80 @@
  #endif	/* lint */
  
@@ -3048,7 +3048,7 @@ diff -u libmagic.orig/magic.c libmagic/magic.c
  public const char *
  magic_error(struct magic_set *ms)
 diff -u libmagic.orig/magic.h libmagic/magic.h
---- libmagic.orig/magic.h	2020-04-22 20:17:15.432186600 +0200
+--- libmagic.orig/magic.h	2020-05-05 18:42:44.544159800 +0200
 +++ libmagic/magic.h	2020-04-07 22:25:10.548560600 +0200
 @@ -124,6 +124,7 @@
  
@@ -3253,7 +3253,7 @@ diff -u libmagic.orig/readcdf.c libmagic/readcdf.c
  	if (i != -1)
 diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
 --- libmagic.orig/softmagic.c	2019-05-17 04:24:59.000000000 +0200
-+++ libmagic/softmagic.c	2020-04-07 22:25:10.548560600 +0200
++++ libmagic/softmagic.c	2020-04-26 00:43:35.734037100 +0200
 @@ -43,6 +43,10 @@
  #include <time.h>
  #include "der.h"

--- a/ext/fileinfo/libmagic/cdf.c
+++ b/ext/fileinfo/libmagic/cdf.c
@@ -297,7 +297,7 @@ cdf_zero_stream(cdf_stream_t *scn)
 static size_t
 cdf_check_stream(const cdf_stream_t *sst, const cdf_header_t *h)
 {
-#ifndef NDEBUG
+#if PHP_DEBUG
 	size_t ss = sst->sst_dirlen < h->h_min_size_standard_stream ?
 	    CDF_SHORT_SEC_SIZE(h) : CDF_SEC_SIZE(h);
 	assert(ss == sst->sst_ss);


### PR DESCRIPTION
It was only used in our patched libmagic in a very convoluted way.

The PHP_DEBUG and ZEND_DEBUG constants are always defined and should be used instead.

I came across this while working on #5526 