### PR TITLE
Convert shmop resources to opaque objects

### DIFF
--- a/ext/shmop/php_shmop.h
+++ b/ext/shmop/php_shmop.h
@@ -32,7 +32,7 @@ PHP_MINFO_FUNCTION(shmop);
 # include "win32/ipc.h"
 #endif
 
-struct php_shmop
+typedef struct php_shmop
 {
 	int shmid;
 	key_t key;
@@ -40,17 +40,8 @@ struct php_shmop
 	int shmatflg;
 	char *addr;
 	zend_long size;
-};
-
-typedef struct {
-	int le_shmop;
-} php_shmop_globals;
-
-#ifdef ZTS
-#define SHMOPG(v) TSRMG(shmop_globals_id, php_shmop_globals *, v)
-#else
-#define SHMOPG(v) (shmop_globals.v)
-#endif
+  zend_object std;
+} php_shmop;
 
 #else
 

--- a/ext/shmop/php_shmop.h
+++ b/ext/shmop/php_shmop.h
@@ -32,17 +32,6 @@ PHP_MINFO_FUNCTION(shmop);
 # include "win32/ipc.h"
 #endif
 
-typedef struct php_shmop
-{
-	int shmid;
-	key_t key;
-	int shmflg;
-	int shmatflg;
-	char *addr;
-	zend_long size;
-  zend_object std;
-} php_shmop;
-
 #else
 
 #define phpext_shmop_ptr NULL

--- a/ext/shmop/shmop.c
+++ b/ext/shmop/shmop.c
@@ -59,6 +59,17 @@ zend_module_entry shmop_module_entry = {
 ZEND_GET_MODULE(shmop)
 #endif
 
+typedef struct php_shmop
+{
+	int shmid;
+	key_t key;
+	int shmflg;
+	int shmatflg;
+	char *addr;
+	zend_long size;
+  zend_object std;
+} php_shmop;
+
 zend_class_entry *shmop_ce;
 static zend_object_handlers shmop_object_handlers;
 

--- a/ext/shmop/shmop.stub.php
+++ b/ext/shmop/shmop.stub.php
@@ -2,20 +2,17 @@
 
 /** @generate-function-entries */
 
-/** @return resource|false */
-function shmop_open(int $key, string $flags, int $mode, int $size) {}
+final class Shmop {}
 
-/** @param resource $shmid */
-function shmop_read($shmid, int $start, int $count): string|false {}
+function shmop_open(int $key, string $flags, int $mode, int $size): Shmop|false {}
 
-/** @param resource $shmid */
-function shmop_close($shmid): void {}
+function shmop_read(Shmop $shmid, int $start, int $count): string|false {}
 
-/** @param resource $shmid */
-function shmop_size($shmid): int {}
+/** @deprecated */
+function shmop_close(Shmop $shmid): void {}
 
-/** @param resource $shmid */
-function shmop_write($shmid, string $data, int $offset): int|false {}
+function shmop_size(Shmop $shmid): int {}
 
-/** @param resource $shmid */
-function shmop_delete($shmid): bool {}
+function shmop_write(Shmop $shmid, string $data, int $offset): int|false {}
+
+function shmop_delete(Shmop $shmid): bool {}

--- a/ext/shmop/shmop_arginfo.h
+++ b/ext/shmop/shmop_arginfo.h
@@ -1,6 +1,6 @@
 /* This is a generated file, edit the .stub.php file instead. */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_shmop_open, 0, 0, 4)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_shmop_open, 0, 4, Shmop, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
@@ -8,27 +8,27 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_shmop_open, 0, 0, 4)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_shmop_read, 0, 3, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_INFO(0, shmid)
+	ZEND_ARG_OBJ_INFO(0, shmid, Shmop, 0)
 	ZEND_ARG_TYPE_INFO(0, start, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, count, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_shmop_close, 0, 1, IS_VOID, 0)
-	ZEND_ARG_INFO(0, shmid)
+	ZEND_ARG_OBJ_INFO(0, shmid, Shmop, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_shmop_size, 0, 1, IS_LONG, 0)
-	ZEND_ARG_INFO(0, shmid)
+	ZEND_ARG_OBJ_INFO(0, shmid, Shmop, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_shmop_write, 0, 3, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_INFO(0, shmid)
+	ZEND_ARG_OBJ_INFO(0, shmid, Shmop, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_shmop_delete, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, shmid)
+	ZEND_ARG_OBJ_INFO(0, shmid, Shmop, 0)
 ZEND_END_ARG_INFO()
 
 
@@ -43,9 +43,14 @@ ZEND_FUNCTION(shmop_delete);
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(shmop_open, arginfo_shmop_open)
 	ZEND_FE(shmop_read, arginfo_shmop_read)
-	ZEND_FE(shmop_close, arginfo_shmop_close)
+	ZEND_DEP_FE(shmop_close, arginfo_shmop_close)
 	ZEND_FE(shmop_size, arginfo_shmop_size)
 	ZEND_FE(shmop_write, arginfo_shmop_write)
 	ZEND_FE(shmop_delete, arginfo_shmop_delete)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_Shmop_methods[] = {
 	ZEND_FE_END
 };

--- a/ext/shmop/tests/001.phpt
+++ b/ext/shmop/tests/001.phpt
@@ -32,8 +32,6 @@ shmop extension test
 
     echo "data in memory is: " . shmop_read($shm_id, 0, $written) . "\n";
 
-    shmop_close($shm_id);
-
     echo "shm open for read only: ";
     $shm_id = shmop_open($hex_shm_id, "a", 0644, 1024);
     if (!$shm_id) {
@@ -46,8 +44,6 @@ shmop extension test
 
     /* try to append data to the shared memory segment, this should fail */
     shmop_write($shm_id, $write_d1, $written);
-
-    shmop_close($shm_id);
 
     echo "shm open for read only: ";
     $shm_id = shmop_open($hex_shm_id, "w", 0644, 1024);
@@ -73,8 +69,6 @@ shmop extension test
     } else {
         echo "ok\n";
     }
-
-    shmop_close($shm_id);
 ?>
 --EXPECTF--
 shm open for create: ok

--- a/ext/shmop/tests/shmop_open_private.phpt
+++ b/ext/shmop/tests/shmop_open_private.phpt
@@ -15,9 +15,6 @@ $shm2 = shmop_open(0, 'c', 0777, 1024);
 $read = shmop_read($shm2, 0, 4);
 
 var_dump(is_string($read) && $read !== $write);
-
-shmop_close($shm1);
-shmop_close($shm2);
 ?>
 --EXPECT--
 bool(true)


### PR DESCRIPTION
We make `shmop_close()` a NOP, and deprecate the function right away;
detaching from SHM now happens when the wrapper object is freed.