### PR TITLE
Evaluate str_starts_with and str_ends_with on constants at compile time

### DIFF
--- a/ext/opcache/Optimizer/sccp.c
+++ b/ext/opcache/Optimizer/sccp.c
@@ -955,6 +955,8 @@ static inline int ct_eval_func_call(
 			/* pass */
 		} else if (zend_string_equals_literal(name, "strpos")
 				|| zend_string_equals_literal(name, "str_contains")
+				|| zend_string_equals_literal(name, "str_starts_with")
+				|| zend_string_equals_literal(name, "str_ends_with")
 				|| zend_string_equals_literal(name, "version_compare")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING
 					|| Z_TYPE_P(args[1]) != IS_STRING) {


### PR DESCRIPTION
When both arguments are strings,
this is guaranteed not to emit notices.