### PR TITLE
Don't set the locale_changed flag if changing to "C"

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4794,7 +4794,9 @@ PHP_FUNCTION(setlocale)
 				/* Remember if locale was changed */
 				size_t len = strlen(retval);
 
-				BG(locale_changed) = 1;
+				if (!zend_string_equals_literal(loc, "C")) {
+					BG(locale_changed) = 1;
+				}
 				if (cat == LC_CTYPE || cat == LC_ALL) {
 					if (BG(locale_string)) {
 						zend_string_release_ex(BG(locale_string), 0);


### PR DESCRIPTION
Related to https://github.com/php/php-src/pull/5488
which makes php-src start out with the C locale for all locales, including
LC_CTYPE in php 8.

Example: An application sets `setlocale(LC_CTYPE, "C")` to work around
issues with strtolower not working on turkish, and unexpectedly gets slightly
worse performance.

(Not 100% sure about windows)