### PR TITLE
Replaced deprecated `hw.ncpu` with `hm. logicalcpu`

### DIFF
--- a/azure/macos/job.yml
+++ b/azure/macos/job.yml
@@ -72,7 +72,7 @@ jobs:
       displayName: 'Configure Build'
     - script: |
         export PATH="/usr/local/opt/bison/bin:$PATH"
-        make -j$(sysctl -n hw.ncpu) >/dev/null
+        make -j$(sysctl -n hw.logicalcpu) >/dev/null
       displayName: 'Make Build'
     - script: |
         sudo make install


### PR DESCRIPTION
Found that at ziglang/zig#1252 and https://gitlab.haskell.org/ghc/ghc/issues/8594.