### PR TITLE
Ensure ctype_string is NULL for C locale

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -595,8 +595,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, in
 	zend_string 		*key;
 	pcre_cache_entry *ret;
 
-	if (locale_aware && BG(ctype_string) &&
-		(ZSTR_LEN(BG(ctype_string)) != 1 && ZSTR_VAL(BG(ctype_string))[0] != 'C')) {
+	if (locale_aware && BG(ctype_string)) {
 		key = zend_string_concat2(
 			ZSTR_VAL(BG(ctype_string)), ZSTR_LEN(BG(ctype_string)),
 			ZSTR_VAL(regex), ZSTR_LEN(regex));

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1462,7 +1462,7 @@ PHPAPI zend_string *php_string_tolower(zend_string *s)
 	unsigned char *c;
 	const unsigned char *e;
 
-	if (EXPECTED(!BG(locale_changed))) {
+	if (EXPECTED(!BG(ctype_string))) {
 		return zend_string_tolower(s);
 	} else {
 		c = (unsigned char *)ZSTR_VAL(s);
@@ -4801,7 +4801,12 @@ PHP_FUNCTION(setlocale)
 					if (BG(ctype_string)) {
 						zend_string_release_ex(BG(ctype_string), 0);
 					}
-					if (len == ZSTR_LEN(loc) && !memcmp(ZSTR_VAL(loc), retval, len)) {
+					if (len == 1 && *retval == 'C') {
+						/* C locale is represented as NULL. */
+						BG(ctype_string) = NULL;
+						zend_string_release_ex(loc, 0);
+						RETURN_INTERNED_STR(ZSTR_CHAR('C'));
+					} else if (len == ZSTR_LEN(loc) && !memcmp(ZSTR_VAL(loc), retval, len)) {
 						BG(ctype_string) = zend_string_copy(loc);
 						RETURN_STR(BG(ctype_string));
 					} else {


### PR DESCRIPTION
We already document that `BG(ctype_locale)` is NULL for C locale: https://github.com/php/php-src/blob/3f769473038509212bbed7cb49d6b7e21009311f/ext/standard/basic_functions.h#L65

This change makes sure that this is always the case, even if `setlocale()` is explicitly called with `"C"` locale. Now `BG(ctype_local) != NULL` can be used as a quick check whether the C locale is used.