### PR TITLE
Respect script execution time limit when invoking shutdown functions

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -830,6 +830,17 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 			/* We must re-initialize function again */
 			fci_cache->function_handler = NULL;
 		}
+
+		/* This flag is regularly checked while running user functions, but not internal
+		 * So see whether interrupt flag was set while the function was running... */
+		if (EG(vm_interrupt)) {
+			EG(vm_interrupt) = 0;
+			if (EG(timed_out)) {
+				zend_timeout();
+			} else if (zend_interrupt_function) {
+				zend_interrupt_function(EG(current_execute_data));
+			}
+		}
 	}
 
 	zend_vm_stack_free_call_frame(call);

--- a/ext/pcntl/tests/async_signals_2.phpt
+++ b/ext/pcntl/tests/async_signals_2.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Async signals in zend_call_function
+--SKIPIF--
+<?php
+if (!extension_loaded("pcntl")) print "skip";
+if (getenv("SKIP_SLOW_TESTS")) print "skip slow test";
+?>
+--FILE--
+<?php
+
+pcntl_async_signals(1);
+pcntl_signal(SIGALRM, function($signo) {
+    throw new Exception("Alarm!");
+});
+
+pcntl_alarm(1);
+try {
+    array_map(
+        'time_nanosleep',
+        array_fill(0, 360, 1),
+        array_fill(0, 360, 0)
+    );
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Alarm!

--- a/tests/basic/timeout_variation_10.phpt
+++ b/tests/basic/timeout_variation_10.phpt
@@ -5,8 +5,6 @@ Timeout within shutdown function, variation
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 if (PHP_OS_FAMILY !== "Windows") die("skip Windows only test");
 ?>
---XFAIL--
-Missing timeout check in call_user_function
 --FILE--
 <?php
 
@@ -19,4 +17,5 @@ register_shutdown_function("sleep", 1);
 shutdown happens after here
 --EXPECTF--
 shutdown happens after here
+
 Fatal error: Maximum execution time of 1 second exceeded in %s on line %d

--- a/tests/basic/timeout_variation_9.phpt
+++ b/tests/basic/timeout_variation_9.phpt
@@ -5,8 +5,6 @@ Timeout within shutdown function
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 if (PHP_OS_FAMILY !== "Windows") die("skip Windows only test");
 ?>
---XFAIL--
-Missing timeout check in call_user_function
 --FILE--
 <?php
 


### PR DESCRIPTION
A time limit can be set on PHP script execution via `set_time_limit()` (or .ini file). When the time limit is reached, the OS will notify PHP and a `timed_out` flag is set. While this flag is regularly checked when executing PHP code, once the end of the script is reached, it is not checked while invoking shutdown functions (registered via `register_shutdown_function`).

Of course, if the shutdown functions are implemented *in* PHP, then the script time limit will be checked while they are running and will take effect. But if the shutdown functions are built-in (implemented in C), it will not.

Since the shutdown functions are invoked through call_user_function_ex, add a check of the `timed_out` flag there. Then, the script time limit will be respected when *entering* each shutdown function. The fact still remains that if a shutdown function is built-in and runs for a long time, script execution will not time out until it finishes and the interpreter tries to invoke the next one.

Still, the behavior of scripts with execution time limits will be more consistent after this patch. To make the execution time-out feature work even more precisely, it would be necessary to scrutinize all the built-in functions and add checks of the `timed_out` flag in any which can run for a long time. That might not be worth the effort, though.