### PR TITLE
Fix default sendmail path when not found during build

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2084,7 +2084,7 @@ dnl Search for the sendmail binary
 dnl
 AC_DEFUN([PHP_PROG_SENDMAIL], [
   PHP_ALT_PATH=/usr/bin:/usr/sbin:/usr/etc:/etc:/usr/ucblib:/usr/lib
-  AC_PATH_PROG(PROG_SENDMAIL, sendmail,[], $PATH:$PHP_ALT_PATH)
+  AC_PATH_PROG(PROG_SENDMAIL, sendmail, /usr/sbin/sendmail, $PATH:$PHP_ALT_PATH)
   PHP_SUBST(PROG_SENDMAIL)
 ])
 

--- a/main/main.c
+++ b/main/main.c
@@ -697,10 +697,8 @@ PHP_INI_MH(OnChangeBrowscap);
  /* Windows use the internal mail */
 #if defined(PHP_WIN32)
 # define DEFAULT_SENDMAIL_PATH NULL
-#elif defined(PHP_PROG_SENDMAIL)
-# define DEFAULT_SENDMAIL_PATH PHP_PROG_SENDMAIL " -t -i "
 #else
-# define DEFAULT_SENDMAIL_PATH "/usr/sbin/sendmail -t -i"
+# define DEFAULT_SENDMAIL_PATH PHP_PROG_SENDMAIL " -t -i"
 #endif
 
 /* {{{ PHP_INI


### PR DESCRIPTION
This is my attempt to fix [Bug #78757](https://bugs.php.net/bug.php?id=78757) where the default `sendmail_path` was not correctly set if it was not found on the system. Without the fix the path to binary would be empty, resulting in not so useful `sendmail_path = -t -i` in case sendmail is installed later to the default path.

Since `PHP_PROG_SENDMAIL` is set unconditionally, it made sense to simply fill the fallback value in the autoconf script. However, this approach seems to have a drawback that now the configure script will report `checking for sendmail... /usr/sbin/sendmail` instead of the previous `checking for sendmail... no` if sendmail cannot be found. I'm open to suggestions on how to improve it if needed.