### PR TITLE
Add `pkg-config` to the build list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For a minimal PHP build from Git, you will need autoconf, bison, and re2c. For
 a default build, you will additionally need libxml2 and libsqlite3. On Ubuntu,
 you can install these using:
 
-    sudo apt install -y build-essential autoconf bison re2c \
+    sudo apt install -y pkg-config build-essential autoconf bison re2c \
                         libxml2-dev libsqlite3-dev
 
 Generate configure:


### PR DESCRIPTION

When trying to build PHP from Git on Ubuntu 20.04 (and also on Ubuntu 19.10) the following error message was being generated:

```bash
configure: error: The pkg-config script could not be found or is too old.  Make sure it
is in your PATH or set the PKG_CONFIG environment variable to the full
path to pkg-config.

Alternatively, you may set the environment variables LIBXML_CFLAGS
and LIBXML_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.

To get pkg-config, see <http://pkg-config.freedesktop.org/>.
See `config.log' for more details
```

After issuing the command `apt install -y pkg-config`, then `./configure` was executed without any errors. 

Because of that, it seems to make sense to also add `pkg-config` to the build list, just in case.