### PR TITLE
Remove old ARG_COUNT() macro

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -408,7 +408,6 @@ ZEND_API const char *zend_get_type_by_const(int type);
 
 #define WRONG_PARAM_COUNT					ZEND_WRONG_PARAM_COUNT()
 #define WRONG_PARAM_COUNT_WITH_RETVAL(ret)	ZEND_WRONG_PARAM_COUNT_WITH_RETVAL(ret)
-#define ARG_COUNT(dummy)					EX_NUM_ARGS()
 #define ZEND_NUM_ARGS()						EX_NUM_ARGS()
 #define ZEND_WRONG_PARAM_COUNT()					{ zend_wrong_param_count(); return; }
 #define ZEND_WRONG_PARAM_COUNT_WITH_RETVAL(ret)		{ zend_wrong_param_count(); return ret; }


### PR DESCRIPTION
As ``ZEND_NUM_ARGS()`` is the one which should be used nowadays.