### PR TITLE
Don't check directory atime in lstat_stat_variation10.phpt test

### DIFF
--- a/ext/standard/tests/file/lstat_stat_variation10.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation10.phpt
@@ -38,8 +38,14 @@ $new_stat = stat($dirname);
 // compare self stats
 var_dump( compare_self_stat($old_stat) );
 var_dump( compare_self_stat($new_stat) );
+// activity from background processes may unexpectedly update the atime
+// so don't include "atime" (or 8, which also means atime)
+$compare_keys = array(0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12,
+                      "dev", "ino", "mode", "nlink", "uid", "gid",
+                      "rdev", "size", "mtime", "ctime",
+                      "blksize", "blocks");
 // compare the stat
-var_dump( compare_stats($old_stat, $new_stat, $all_stat_keys) );
+var_dump( compare_stats($old_stat, $new_stat, $compare_keys) );
 
 echo "\n--- Done ---";
 ?>


### PR DESCRIPTION
This is a funny one. I discovered that `lstat_stat_variation10.phpt` was failing every now and again when the PHP test suite was run on my dev PC. The output from the failing test showed that the atime (access time) of the directory created in the test was changing between these lines:

    $old_stat = stat($dirname);
    clearstatcache();
    sleep(1);
    var_dump( is_dir($dirname) );
    $new_stat = stat($dirname);

Could `is_dir()` be accessing the directory and changing the atime? strace showed that `is_dir` was only issuing a single `stat()` syscall. Could `stat()` change the atime? No, no, that would just be perverse. Nobody would be stupid enough to implement the kernel in that way.

Checked the kernel source, found that the function called when atime needs to be updated appears to be `touch_atime()`. Broke out the BCC kernel tracing tools and ran this one while running the flaky test case in a loop:

    sudo trace -I<kernel src dir>/include/linux/path.h -I<same>/include/linux/dcache.h 'touch_atime(struct path *path) "%s", path->dentry->d_name.name'

Inspecting the results showed that something called "git_thread" was occcasionally updating
the atime on the directory in question!! What on earth...???

The PID shown by trace revealed that this was a background thread for Sublime Text 3.
Sublime now has git integration and shows when there are untracked or modified files. It
seems that it uses a background thread to regularly scan the project directory and look
for new and modified files. This was causing the atime to change.

Even though other developers may not be running ST3, there are any number of reasons why
a background process might recurse through various directories and could cause the atime
to change unexpectedly. Therefore, update the test case so it doesn't fail in such cases.