### PR TITLE
Implements check_liveness for pdo_firebird

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -1012,7 +1012,7 @@ static void pdo_firebird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval
 /* }}} */
 
 /* Check if connection is liveness */
-static int pdo_firebird_check_liveness(pdo_dbh_t *dbh){
+static zend_result pdo_firebird_check_liveness(pdo_dbh_t *dbh){
 	ISC_STATUS status[20];
 	static char info[] = { isc_info_base_level, isc_info_end };
 	char result[8];

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -1011,6 +1011,21 @@ static void pdo_firebird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval
 }
 /* }}} */
 
+/* Check if connection is liveness */
+static int pdo_firebird_check_liveness(pdo_dbh_t *dbh){
+	ISC_STATUS status[20];
+	static char info[] = { isc_info_base_level, isc_info_end };
+	char result[8];
+
+	pdo_firebird_db_handle *H = (pdo_firebird_db_handle *)dbh->driver_data;
+
+	if(!isc_database_info(status, &H->db, sizeof(info), info, sizeof(result), result)){
+		return SUCCESS;
+	}
+	return FAILURE;
+}
+/* }}} */
+
 static const struct pdo_dbh_methods firebird_methods = { /* {{{ */
 	firebird_handle_closer,
 	firebird_handle_preparer,
@@ -1023,7 +1038,7 @@ static const struct pdo_dbh_methods firebird_methods = { /* {{{ */
 	NULL, /* last_id not supported */
 	pdo_firebird_fetch_error_func,
 	firebird_handle_get_attribute,
-	NULL, /* check_liveness */
+	pdo_firebird_check_liveness, /* check_liveness */
 	NULL, /* get driver methods */
 	NULL, /* request shutdown */
 	NULL, /* in transaction, use PDO's internal tracking mechanism */

--- a/ext/pdo_firebird/tests/liveness.phpt
+++ b/ext/pdo_firebird/tests/liveness.phpt
@@ -1,0 +1,47 @@
+--TEST--
+PDO_Firebird: Check persistent conection is alive
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--FILE--
+<?php
+    require("testdb.inc");
+
+    @$dbh->exec('DROP TABLE testz');
+    $dbh->exec('CREATE TABLE testz (A VARCHAR(10))');
+    $dbh->exec("INSERT INTO testz VALUES ('A')");
+    $dbh->commit();
+
+    $dsn = getenv('PDO_FIREBIRD_TEST_DSN');
+    $user = getenv('PDO_FIREBIRD_TEST_USER');
+    $pass = getenv('PDO_FIREBIRD_TEST_PASS');
+
+    //first query is to make php create and hold a connection
+    $dbh_p = new pdo($dsn, $user, $pass, array(PDO::ATTR_PERSISTENT => true));
+
+    //execute a query for check if the connection is alive
+    $stmt = $dbh_p->prepare('SELECT * FROM testz');
+    $stmt->execute();
+    $stmt->fetchAll();
+
+    //close the connection
+    $dbh_p = null;
+    gc_collect_cycles();
+
+    //Force firebird close all connection in database execept the $dbh
+    $dbh->query('DELETE FROM MON$ATTACHMENTS WHERE MON$ATTACHMENT_ID <> CURRENT_CONNECTION');
+
+    //pick connectin again
+    $dbh_p2 = new pdo($dsn, $user, $pass, array(PDO::ATTR_PERSISTENT => true));
+
+    //run a query to make php raiser the error
+    $stmt2 = $dbh_p2->prepare('SELECT * FROM testz');
+    $stmt2->execute();
+    $result = $stmt2->fetchAll();
+
+    //check
+    //var_dump($result);
+    echo "done";
+    // firebird:dbname=ffirebird3/3050:/firebird/data/TAREFAS.FDB  
+    ?>
+--EXPECT--
+done

--- a/ext/pdo_firebird/tests/liveness.phpt
+++ b/ext/pdo_firebird/tests/liveness.phpt
@@ -1,5 +1,7 @@
 --TEST--
 PDO_Firebird: Check persistent conection is alive
+--EXTENSIONS--
+pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
 --FILE--

--- a/ext/pdo_firebird/tests/liveness.phpt
+++ b/ext/pdo_firebird/tests/liveness.phpt
@@ -38,10 +38,7 @@ PDO_Firebird: Check persistent conection is alive
     $stmt2->execute();
     $result = $stmt2->fetchAll();
 
-    //check
-    //var_dump($result);
     echo "done";
-    // firebird:dbname=ffirebird3/3050:/firebird/data/TAREFAS.FDB  
     ?>
 --EXPECT--
 done


### PR DESCRIPTION
the PDO-firebird does not check if the connection is alive when persistent connections are used and that was generating the error: 
**SQLSTATE [HY000]: General error: -902 Error writing data to the connection.**