### PR TITLE
run-tests: remove use of FILE_BINARY constant

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -966,8 +966,8 @@ function save_or_mail_results()
             if ($sum_results['FAILED']) {
                 foreach ($PHP_FAILED_TESTS['FAILED'] as $test_info) {
                     $failed_tests_data .= $sep . $test_info['name'] . $test_info['info'];
-                    $failed_tests_data .= $sep . file_get_contents(realpath($test_info['output']), FILE_BINARY);
-                    $failed_tests_data .= $sep . file_get_contents(realpath($test_info['diff']), FILE_BINARY);
+                    $failed_tests_data .= $sep . file_get_contents(realpath($test_info['output']));
+                    $failed_tests_data .= $sep . file_get_contents(realpath($test_info['diff']));
                     $failed_tests_data .= $sep . "\n\n";
                 }
                 $status = "failed";
@@ -1163,12 +1163,12 @@ function save_text($filename, $text, $filename_copy = null)
     global $DETAILED;
 
     if ($filename_copy && $filename_copy != $filename) {
-        if (file_put_contents($filename_copy, $text, FILE_BINARY) === false) {
+        if (file_put_contents($filename_copy, $text) === false) {
             error("Cannot open file '" . $filename_copy . "' (save_text)");
         }
     }
 
-    if (file_put_contents($filename, $text, FILE_BINARY) === false) {
+    if (file_put_contents($filename, $text) === false) {
         error("Cannot open file '" . $filename . "' (save_text)");
     }
 
@@ -1890,7 +1890,7 @@ TEST $file
                     $section_text[$key] = dirname($file) . '/' . trim(str_replace('..', '', $section_text[$key]));
 
                     if (file_exists($section_text[$key])) {
-                        $section_text[$prefix] = file_get_contents($section_text[$key], FILE_BINARY);
+                        $section_text[$prefix] = file_get_contents($section_text[$key]);
                         unset($section_text[$key]);
                     } else {
                         $bork_info = "could not load --" . $key . "-- " . dirname($file) . '/' . trim($section_text[$key]);
@@ -2724,12 +2724,12 @@ COMMAND $cmd
     if (!$passed) {
 
         // write .exp
-        if (strpos($log_format, 'E') !== false && file_put_contents($exp_filename, $wanted, FILE_BINARY) === false) {
+        if (strpos($log_format, 'E') !== false && file_put_contents($exp_filename, $wanted) === false) {
             error("Cannot create expected test output - $exp_filename");
         }
 
         // write .out
-        if (strpos($log_format, 'O') !== false && file_put_contents($output_filename, $output, FILE_BINARY) === false) {
+        if (strpos($log_format, 'O') !== false && file_put_contents($output_filename, $output) === false) {
             error("Cannot create test output - $output_filename");
         }
 
@@ -2740,7 +2740,7 @@ COMMAND $cmd
             $diff = "# original source file: $orig_shortname\n" . $diff;
         }
         show_file_block('diff', $diff);
-        if (strpos($log_format, 'D') !== false && file_put_contents($diff_filename, $diff, FILE_BINARY) === false) {
+        if (strpos($log_format, 'D') !== false && file_put_contents($diff_filename, $diff) === false) {
             error("Cannot create test diff - $diff_filename");
         }
 
@@ -2763,7 +2763,7 @@ case "$1" in
     ;;
 esac
 SH;
-        if (strpos($log_format, 'S') !== false && file_put_contents($sh_filename, $sh_script, FILE_BINARY) === false) {
+        if (strpos($log_format, 'S') !== false && file_put_contents($sh_filename, $sh_script) === false) {
             error("Cannot create test shell script - $sh_filename");
         }
         chmod($sh_filename, 0755);
@@ -2775,7 +2775,7 @@ $wanted
 ---- ACTUAL OUTPUT
 $output
 ---- FAILED
-", FILE_BINARY) === false) {
+") === false) {
             error("Cannot create test log - $log_filename");
             error_report($file, $log_filename, $tested);
         }


### PR DESCRIPTION
The FILE_BINARY (and FILE_TEXT) constants are not really valid or useful
constants. It looks like they were added in 5.2.7 and have "no effect,
and are only available for forward compatibility."

See: https://www.php.net/manual/en/filesystem.constants.php

The default value of the file_put_contents() flags parameter is 0 and
FILE_BINARY is set to 0, so removing it doesn't change functionality.

P.S. Maybe those constants should be deprecated or removed in 8.0.