### PR TITLE
utime is always available on Windows

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -769,7 +769,6 @@ TSRM_API int shmctl(int key, int cmd, struct shmid_ds *buf)
 	}
 }/*}}}*/
 
-#if HAVE_UTIME
 static zend_always_inline void UnixTimeToFileTime(time_t t, LPFILETIME pft) /* {{{ */
 {
 	// Note that LONGLONG is a 64-bit value
@@ -823,5 +822,4 @@ TSRM_API int win32_utime(const char *filename, struct utimbuf *buf) /* {{{ */
 	return 1;
 }
 /* }}} */
-#endif
 #endif

--- a/TSRM/tsrm_win32.h
+++ b/TSRM/tsrm_win32.h
@@ -19,9 +19,7 @@
 
 #include "TSRM.h"
 #include <windows.h>
-#if HAVE_UTIME
-# include <sys/utime.h>
-#endif
+#include <sys/utime.h>
 #include "win32/ipc.h"
 
 struct ipc_perm {


### PR DESCRIPTION
Therefore drop useless preprocessor if check.

See https://heap.space/xref/php-src/win32/build/config.w32.h.in?r=67f9b0b7#71

@cmb69 can you confirm this is safe? Or am I missing something that makes these #if (which should be #ifdef in all regards) necessary?