### PR TITLE
Properly detect CRC32 APIs on aarch64 from configure.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -668,6 +668,12 @@ if test "x$php_crypt_r" = "x1"; then
   PHP_CRYPT_R_STYLE
 fi
 
+AC_CACHE_CHECK([for aarch64 CRC32 API], ac_cv_func___crc32d,
+[AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <arm_acle.h>]],[[__crc32d(0, 0);]])],[ac_cv_func___crc32d=yes],[ac_cv_func___crc32d="no"])])
+if test "$ac_cv_func___crc32d" = "yes"; then
+  AC_DEFINE([HAVE_AARCH64_CRC32], [1], [Define when aarch64 CRC32 API is available.])
+fi
+
 dnl Check for asm goto support.
 AC_CACHE_CHECK([for asm goto], ac_cv__asm_goto,
 [AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -18,7 +18,7 @@
 #include "basic_functions.h"
 #include "crc32.h"
 
-#if defined(__aarch64__) && defined(HAVE_SYS_AUXV_H)
+#if HAVE_AARCH64_CRC32
 # include <arm_acle.h>
 # if defined(__linux__)
 #  include <sys/auxv.h>
@@ -83,7 +83,7 @@ PHP_FUNCTION(crc32)
 
 	crc = crcinit^0xFFFFFFFF;
 
-#if defined(__aarch64__) && defined(HAVE_SYS_AUXV_H)
+#if HAVE_AARCH64_CRC32
 	if (has_crc32_insn()) {
 		crc = crc32_aarch64(crc, p, nr);
 		RETURN_LONG(crc^0xFFFFFFFF);


### PR DESCRIPTION
The CRC32 APIs are optional for armv8-a. They became mandatory since
armv8.1-a.