### PR TITLE
Don't return null from enchant array APIs

### DIFF
--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -116,11 +116,6 @@ enumerate_providers_fn (const char * const name,
 	add_assoc_string(&tmp_array, "name", (char *)name);
 	add_assoc_string(&tmp_array, "desc", (char *)desc);
 	add_assoc_string(&tmp_array, "file", (char *)file);
-
-	if (Z_TYPE_P(zdesc)!=IS_ARRAY) {
-		array_init(zdesc);
-	}
-
 	add_next_index_zval(zdesc, &tmp_array);
 }
 /* }}} */
@@ -153,10 +148,6 @@ static void php_enchant_list_dicts_fn( const char * const lang_tag,
 	add_assoc_string(&tmp_array, "provider_name", (char *)provider_name);
 	add_assoc_string(&tmp_array, "provider_desc", (char *)provider_desc);
 	add_assoc_string(&tmp_array, "provider_file", (char *)provider_file);
-
-	if (Z_TYPE_P(zdesc) != IS_ARRAY) {
-		array_init(zdesc);
-	}
 	add_next_index_zval(zdesc, &tmp_array);
 
 }
@@ -473,6 +464,7 @@ PHP_FUNCTION(enchant_broker_list_dicts)
 
 	PHP_ENCHANT_GET_BROKER;
 
+	array_init(return_value);
 	enchant_broker_list_dicts(pbroker->pbroker, php_enchant_list_dicts_fn, (void *)return_value);
 }
 /* }}} */
@@ -687,6 +679,7 @@ PHP_FUNCTION(enchant_broker_describe)
 
 	PHP_ENCHANT_GET_BROKER;
 
+	array_init(return_value);
 	enchant_broker_describe(pbroker->pbroker, describetozval, (void *)return_value);
 }
 /* }}} */
@@ -773,12 +766,12 @@ PHP_FUNCTION(enchant_dict_suggest)
 	}
 
 	PHP_ENCHANT_GET_DICT;
+	array_init(return_value);
 
 	suggs = enchant_dict_suggest(pdict->pdict, word, wordlen, &n_sugg);
 	if (suggs && n_sugg) {
 		size_t i;
 
-		array_init(return_value);
 		for (i = 0; i < n_sugg; i++) {
 			add_next_index_string(return_value, suggs[i]);
 		}

--- a/ext/enchant/enchant.stub.php
+++ b/ext/enchant/enchant.stub.php
@@ -11,7 +11,7 @@ final class EnchantBroker
 	public function getError(): string|false {}
 
 	/** @alias enchant_broker_list_dicts */
-	public function listDicts(): ?array {}
+	public function listDicts(): array {}
 
 	/** @alias enchant_broker_request_dict */
 	public function requestDict(string $tag): EnchantDict|false {}
@@ -26,7 +26,7 @@ final class EnchantBroker
 	public function setOrdering(string $tag, string $ordering): bool {}
 
 	/** @alias enchant_broker_describe */
-	public function describe(): ?array {}
+	public function describe(): array {}
 }
 
 final class EnchantDict
@@ -40,7 +40,7 @@ final class EnchantDict
 	public function check(string $word): bool {}
 
 	/** @alias enchant_dict_suggest */
-	public function suggest(string $word): ?array {}
+	public function suggest(string $word): array {}
 
 	/** @alias enchant_dict_add */
 	public function add(string $word): void {}
@@ -80,7 +80,7 @@ function enchant_broker_set_dict_path(EnchantBroker $broker, int $name, string $
 */
 function enchant_broker_get_dict_path(EnchantBroker $broker, int $name): string|false {}
 
-function enchant_broker_list_dicts(EnchantBroker $broker): ?array {}
+function enchant_broker_list_dicts(EnchantBroker $broker): array {}
 
 function enchant_broker_request_dict(EnchantBroker $broker, string $tag): EnchantDict|false {}
 
@@ -95,13 +95,13 @@ function enchant_broker_dict_exists(EnchantBroker $broker, string $tag): bool {}
 
 function enchant_broker_set_ordering(EnchantBroker $broker, string $tag, string $ordering): bool {}
 
-function enchant_broker_describe(EnchantBroker $broker): ?array {}
+function enchant_broker_describe(EnchantBroker $broker): array {}
 
 function enchant_dict_quick_check(EnchantDict $dict, string $word, &$suggestions = null): bool {}
 
 function enchant_dict_check(EnchantDict $dict, string $word): bool {}
 
-function enchant_dict_suggest(EnchantDict $dict, string $word): ?array {}
+function enchant_dict_suggest(EnchantDict $dict, string $word): array {}
 
 function enchant_dict_add(EnchantDict $dict, string $word): void {}
 

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -22,7 +22,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_enchant_broker_get_dict_path, 0,
 	ZEND_ARG_TYPE_INFO(0, name, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_list_dicts, 0, 1, IS_ARRAY, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_list_dicts, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 ZEND_END_ARG_INFO()
 
@@ -64,7 +64,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_check, 0, 2, _IS_BO
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_suggest, 0, 2, IS_ARRAY, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_suggest, 0, 2, IS_ARRAY, 0)
 	ZEND_ARG_OBJ_INFO(0, dict, EnchantDict, 0)
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -102,7 +102,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_EnchantBroker_getError, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_EnchantBroker_listDicts, 0, 0, IS_ARRAY, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_EnchantBroker_listDicts, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_EnchantBroker_requestDict, 0, 1, EnchantDict, MAY_BE_FALSE)
@@ -139,7 +139,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_EnchantDict_check, 0, 1, _
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_EnchantDict_suggest, 0, 1, IS_ARRAY, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_EnchantDict_suggest, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -158,8 +158,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_EnchantDict_getError arginfo_class_EnchantBroker_getError
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_EnchantDict_describe, 0, 0, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_EnchantDict_describe arginfo_class_EnchantBroker_listDicts
 
 
 ZEND_FUNCTION(enchant_broker_init);


### PR DESCRIPTION
Followup to #5500, which makes sure all array returns are initialized, so the default "null" value does not get returned.

cc @cmb69 @remicollet 