### PR TITLE
Fix lcov genhtml: ERROR: cannot read [file]

### DIFF
--- a/build/Makefile.gcov
+++ b/build/Makefile.gcov
@@ -14,7 +14,9 @@ LCOV_EXCLUDES = \
 	'$(top_srcdir)/ext/mbstring/libmbfl/*' \
 	'$(top_srcdir)/ext/opcache/jit/libudis86/*' \
 	'$(top_srcdir)/ext/pcre/pcre2lib/*' \
-	'$(top_srcdir)/ext/xmlrpc/libxmlrpc/*'
+	'$(top_srcdir)/ext/xmlrpc/libxmlrpc/*' \
+	'$(top_srcdir)/parse_date.re' \
+	'$(top_srcdir)/parse_iso_intervals.re'
 
 GCOVR_EXCLUDES = \
 	'ext/bcmath/libbcmath/.*' \


### PR DESCRIPTION
lcov is emitting several errors for generated regex files that have no code
coverage data. The fix is to add the files to the lcov exlusion list.

This is not an issue for CI because it uses gcovr to generate code coverage.

The errors:

    Processing ext/date/lib/parse_date.gcda
    geninfo: WARNING: could not open /home/code/vendor/php/php-src/parse_date.re
    geninfo: WARNING: could not open /home/code/vendor/php/php-src/<stdout>
    geninfo: WARNING: some exclusion markers may be ignored
    Processing ext/date/lib/parse_tz.gcda
    Processing ext/date/lib/tm2unixtime.gcda
    Processing ext/date/lib/parse_iso_intervals.gcda
    geninfo: WARNING: could not open /home/code/vendor/php/php-src/<stdout>
    geninfo: WARNING: could not open /home/code/vendor/php/php-src/parse_iso_intervals.re
    geninfo: WARNING: some exclusion markers may be ignored
    ...
    genhtml: ERROR: cannot read /home/code/vendor/php/php-src/parse_date.re
    Processing file /home/code/vendor/php/php-src/parse_date.re
    make: *** [Makefile:443: lcov-html] Error 2