### PR TITLE
Use extern inline on some duplicated string and gc functions

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -33,6 +33,13 @@
 #include "zend_smart_string.h"
 #include "zend_cpuinfo.h"
 
+ZEND_API extern inline uint32_t zend_gc_addref(zend_refcounted_h *p);
+ZEND_API extern inline uint32_t zend_gc_delref(zend_refcounted_h *p);
+ZEND_API extern inline uint32_t zval_gc_flags(uint32_t gc_type_info);
+ZEND_API extern inline uint32_t zend_gc_refcount(const zend_refcounted_h *p);
+ZEND_API extern inline uint32_t zend_gc_set_refcount(zend_refcounted_h *p, uint32_t rc);
+ZEND_API extern inline zend_uchar zval_get_type(const zval* pz);
+
 static size_t global_map_ptr_last = 0;
 
 #ifdef ZTS

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -23,6 +23,25 @@
 # include "valgrind/callgrind.h"
 #endif
 
+ZEND_API extern inline uint32_t zend_string_addref(zend_string *s);
+ZEND_API extern inline zend_string *zend_string_alloc(size_t len, int persistent);
+ZEND_API extern inline zend_string *zend_string_copy(zend_string *s);
+ZEND_API extern inline uint32_t zend_string_delref(zend_string *s);
+ZEND_API extern inline zend_string *zend_string_dup(zend_string *s, int persistent);
+ZEND_API extern inline void zend_string_efree(zend_string *s);
+ZEND_API extern inline zend_bool zend_string_equal_content(zend_string *s1, zend_string *s2);
+ZEND_API extern inline zend_bool zend_string_equals(zend_string *s1, zend_string *s2);
+ZEND_API extern inline zend_string *zend_string_extend(zend_string *s, size_t len, int persistent);
+ZEND_API extern inline void zend_string_free(zend_string *s);
+ZEND_API extern inline void zend_string_forget_hash_val(zend_string *s);
+ZEND_API extern inline zend_ulong zend_string_hash_val(zend_string *s);
+ZEND_API extern inline zend_string *zend_string_init(const char *str, size_t len, int persistent);
+ZEND_API extern inline void zend_string_release(zend_string *s);
+ZEND_API extern inline zend_string *zend_string_realloc(zend_string *s, size_t len, int persistent);
+ZEND_API extern inline void zend_string_release_ex(zend_string *s, int persistent);
+ZEND_API extern inline zend_string *zend_string_safe_alloc(size_t n, size_t m, size_t l, int persistent);
+ZEND_API extern inline zend_string *zend_string_truncate(zend_string *s, size_t len, int persistent);
+
 ZEND_API zend_new_interned_string_func_t zend_new_interned_string;
 ZEND_API zend_string_init_interned_func_t zend_string_init_interned;
 

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -478,7 +478,8 @@ ZEND_API zend_bool ZEND_FASTCALL I_WRAP_SONAME_FNNAME_ZU(NONE,zend_string_equal_
 	return ret;
 }
 #endif
-
+#else
+ZEND_API extern inline zend_bool zend_string_equal_val(zend_string *s1, zend_string *s2);
 #endif
 
 ZEND_API zend_string *zend_string_concat2(

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -101,12 +101,12 @@ END_EXTERN_C()
 
 /*---*/
 
-static zend_always_inline zend_ulong zend_string_hash_val(zend_string *s)
+ZEND_API zend_always_inline zend_ulong zend_string_hash_val(zend_string *s)
 {
 	return ZSTR_H(s) ? ZSTR_H(s) : zend_string_hash_func(s);
 }
 
-static zend_always_inline void zend_string_forget_hash_val(zend_string *s)
+ZEND_API zend_always_inline void zend_string_forget_hash_val(zend_string *s)
 {
 	ZSTR_H(s) = 0;
 	GC_DEL_FLAGS(s, IS_STR_VALID_UTF8);
@@ -120,7 +120,7 @@ static zend_always_inline uint32_t zend_string_refcount(const zend_string *s)
 	return 1;
 }
 
-static zend_always_inline uint32_t zend_string_addref(zend_string *s)
+ZEND_API zend_always_inline uint32_t zend_string_addref(zend_string *s)
 {
 	if (!ZSTR_IS_INTERNED(s)) {
 		return GC_ADDREF(s);
@@ -128,7 +128,7 @@ static zend_always_inline uint32_t zend_string_addref(zend_string *s)
 	return 1;
 }
 
-static zend_always_inline uint32_t zend_string_delref(zend_string *s)
+ZEND_API zend_always_inline uint32_t zend_string_delref(zend_string *s)
 {
 	if (!ZSTR_IS_INTERNED(s)) {
 		return GC_DELREF(s);
@@ -136,7 +136,7 @@ static zend_always_inline uint32_t zend_string_delref(zend_string *s)
 	return 1;
 }
 
-static zend_always_inline zend_string *zend_string_alloc(size_t len, int persistent)
+ZEND_API zend_always_inline zend_string *zend_string_alloc(size_t len, int persistent)
 {
 	zend_string *ret = (zend_string *)pemalloc(ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(len)), persistent);
 
@@ -147,7 +147,7 @@ static zend_always_inline zend_string *zend_string_alloc(size_t len, int persist
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_safe_alloc(size_t n, size_t m, size_t l, int persistent)
+ZEND_API zend_always_inline zend_string *zend_string_safe_alloc(size_t n, size_t m, size_t l, int persistent)
 {
 	zend_string *ret = (zend_string *)safe_pemalloc(n, m, ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(l)), persistent);
 
@@ -158,7 +158,7 @@ static zend_always_inline zend_string *zend_string_safe_alloc(size_t n, size_t m
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_init(const char *str, size_t len, int persistent)
+ZEND_API zend_always_inline zend_string *zend_string_init(const char *str, size_t len, int persistent)
 {
 	zend_string *ret = zend_string_alloc(len, persistent);
 
@@ -167,7 +167,7 @@ static zend_always_inline zend_string *zend_string_init(const char *str, size_t 
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_copy(zend_string *s)
+ZEND_API zend_always_inline zend_string *zend_string_copy(zend_string *s)
 {
 	if (!ZSTR_IS_INTERNED(s)) {
 		GC_ADDREF(s);
@@ -175,7 +175,7 @@ static zend_always_inline zend_string *zend_string_copy(zend_string *s)
 	return s;
 }
 
-static zend_always_inline zend_string *zend_string_dup(zend_string *s, int persistent)
+ZEND_API zend_always_inline zend_string *zend_string_dup(zend_string *s, int persistent)
 {
 	if (ZSTR_IS_INTERNED(s)) {
 		return s;
@@ -184,7 +184,7 @@ static zend_always_inline zend_string *zend_string_dup(zend_string *s, int persi
 	}
 }
 
-static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_t len, int persistent)
+ZEND_API zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_t len, int persistent)
 {
 	zend_string *ret;
 
@@ -203,7 +203,7 @@ static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_extend(zend_string *s, size_t len, int persistent)
+ZEND_API zend_always_inline zend_string *zend_string_extend(zend_string *s, size_t len, int persistent)
 {
 	zend_string *ret;
 
@@ -223,7 +223,7 @@ static zend_always_inline zend_string *zend_string_extend(zend_string *s, size_t
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_truncate(zend_string *s, size_t len, int persistent)
+ZEND_API zend_always_inline zend_string *zend_string_truncate(zend_string *s, size_t len, int persistent)
 {
 	zend_string *ret;
 
@@ -262,7 +262,7 @@ static zend_always_inline zend_string *zend_string_safe_realloc(zend_string *s, 
 	return ret;
 }
 
-static zend_always_inline void zend_string_free(zend_string *s)
+ZEND_API zend_always_inline void zend_string_free(zend_string *s)
 {
 	if (!ZSTR_IS_INTERNED(s)) {
 		ZEND_ASSERT(GC_REFCOUNT(s) <= 1);
@@ -270,7 +270,7 @@ static zend_always_inline void zend_string_free(zend_string *s)
 	}
 }
 
-static zend_always_inline void zend_string_efree(zend_string *s)
+ZEND_API zend_always_inline void zend_string_efree(zend_string *s)
 {
 	ZEND_ASSERT(!ZSTR_IS_INTERNED(s));
 	ZEND_ASSERT(GC_REFCOUNT(s) <= 1);
@@ -278,7 +278,7 @@ static zend_always_inline void zend_string_efree(zend_string *s)
 	efree(s);
 }
 
-static zend_always_inline void zend_string_release(zend_string *s)
+ZEND_API zend_always_inline void zend_string_release(zend_string *s)
 {
 	if (!ZSTR_IS_INTERNED(s)) {
 		if (GC_DELREF(s) == 0) {
@@ -287,7 +287,7 @@ static zend_always_inline void zend_string_release(zend_string *s)
 	}
 }
 
-static zend_always_inline void zend_string_release_ex(zend_string *s, int persistent)
+ZEND_API zend_always_inline void zend_string_release_ex(zend_string *s, int persistent)
 {
 	if (!ZSTR_IS_INTERNED(s)) {
 		if (GC_DELREF(s) == 0) {
@@ -313,12 +313,12 @@ static zend_always_inline zend_bool zend_string_equal_val(zend_string *s1, zend_
 }
 #endif
 
-static zend_always_inline zend_bool zend_string_equal_content(zend_string *s1, zend_string *s2)
+ZEND_API zend_always_inline zend_bool zend_string_equal_content(zend_string *s1, zend_string *s2)
 {
 	return ZSTR_LEN(s1) == ZSTR_LEN(s2) && zend_string_equal_val(s1, s2);
 }
 
-static zend_always_inline zend_bool zend_string_equals(zend_string *s1, zend_string *s2)
+ZEND_API zend_always_inline zend_bool zend_string_equals(zend_string *s1, zend_string *s2)
 {
 	return s1 == s2 || zend_string_equal_content(s1, s2);
 }

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -307,7 +307,7 @@ BEGIN_EXTERN_C()
 ZEND_API zend_bool ZEND_FASTCALL zend_string_equal_val(zend_string *s1, zend_string *s2);
 END_EXTERN_C()
 #else
-static zend_always_inline zend_bool zend_string_equal_val(zend_string *s1, zend_string *s2)
+ZEND_API zend_always_inline zend_bool zend_string_equal_val(zend_string *s1, zend_string *s2)
 {
 	return !memcmp(ZSTR_VAL(s1), ZSTR_VAL(s2), ZSTR_LEN(s1));
 }

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -545,7 +545,7 @@ struct _zend_ast_ref {
 #define _IS_BOOL					16
 #define _IS_NUMBER					17
 
-static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
+ZEND_API zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 	return pz->u1.v.type;
 }
 
@@ -619,7 +619,8 @@ static zend_always_inline zend_uchar zval_gc_type(uint32_t gc_type_info) {
 	return (gc_type_info & GC_TYPE_MASK);
 }
 
-static zend_always_inline uint32_t zval_gc_flags(uint32_t gc_type_info) {
+ZEND_API zend_always_inline uint32_t zval_gc_flags(uint32_t gc_type_info)
+{
 	return (gc_type_info >> GC_FLAGS_SHIFT) & (GC_FLAGS_MASK >> GC_FLAGS_SHIFT);
 }
 
@@ -1129,21 +1130,21 @@ extern ZEND_API zend_bool zend_rc_debug;
 	do { } while (0)
 #endif
 
-static zend_always_inline uint32_t zend_gc_refcount(const zend_refcounted_h *p) {
+ZEND_API zend_always_inline uint32_t zend_gc_refcount(const zend_refcounted_h *p) {
 	return p->refcount;
 }
 
-static zend_always_inline uint32_t zend_gc_set_refcount(zend_refcounted_h *p, uint32_t rc) {
+ZEND_API zend_always_inline uint32_t zend_gc_set_refcount(zend_refcounted_h *p, uint32_t rc) {
 	p->refcount = rc;
 	return p->refcount;
 }
 
-static zend_always_inline uint32_t zend_gc_addref(zend_refcounted_h *p) {
+ZEND_API zend_always_inline uint32_t zend_gc_addref(zend_refcounted_h *p) {
 	ZEND_RC_MOD_CHECK(p);
 	return ++(p->refcount);
 }
 
-static zend_always_inline uint32_t zend_gc_delref(zend_refcounted_h *p) {
+ZEND_API zend_always_inline uint32_t zend_gc_delref(zend_refcounted_h *p) {
 	ZEND_ASSERT(p->refcount > 0);
 	ZEND_RC_MOD_CHECK(p);
 	return --(p->refcount);


### PR DESCRIPTION
Updated with latest changes:

This reduced the final sapi/cli/php binary by 1047720 bytes, or 5.628%, for a ndebug-nts build on Mac OS X.

Note that this should not affect performance; the function will still
inline, but each compilation that uses it will no longer have a local
copy of the function.

Prior to this change, these were the functions with over 100 copies:

- 105 zend_gc_addref 
- 122 zend_string_release_ex
- 133 zend_string_init
- 145 zend_gc_delref
- 148 zend_string_alloc
- 152 zend_gc_set_refcount
- 158 zval_gc_flags
- 179 zval_get_type

The extern inline feature is standard C99.

-----

Note that I did not move every function to this idiom; only high duplicate offenders from string and gc sections.