### PR TITLE
Canonicalize bison error during ini parsing (macos build fix)

### DIFF
--- a/Zend/tests/bug70748.phpt
+++ b/Zend/tests/bug70748.phpt
@@ -15,6 +15,6 @@ var_dump(parse_ini_file($ini_file));
 unlink(__DIR__ . "/bug70748.ini");
 ?>
 --EXPECTF--
-Warning: syntax error, unexpected $end, expecting '}' in %sbug70748.ini on line %d
+Warning: syntax error, unexpected end of file, expecting '}' in %sbug70748.ini on line %d
  in %sbug70748.php on line %d
 bool(false)

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -292,6 +292,7 @@ static void zval_ini_dtor(zval *zv)
 %define api.value.type {zval}
 %define parse.error verbose
 
+%token END 0 "end of file"
 %token TC_SECTION
 %token TC_RAW
 %token TC_CONSTANT

--- a/ext/standard/tests/general_functions/parse_ini_string_error.phpt
+++ b/ext/standard/tests/general_functions/parse_ini_string_error.phpt
@@ -5,6 +5,6 @@ Ini parsing errors should not result in memory leaks
 var_dump(parse_ini_string('a="b'));
 ?>
 --EXPECTF--
-Warning: syntax error, unexpected $end, expecting TC_DOLLAR_CURLY or TC_QUOTED_STRING or '"' in Unknown on line 1
+Warning: syntax error, unexpected end of file, expecting TC_DOLLAR_CURLY or TC_QUOTED_STRING or '"' in Unknown on line 1
  in %s on line %d
 bool(false)


### PR DESCRIPTION
Bison 3.6 seems to use "end of file" rather than "$end" for this.
Force the same on older bison versions to be consistent.