### PR TITLE
Fix #79596: MySQL FLOAT truncates to int some locales

### DIFF
--- a/ext/mysqlnd/mysql_float_to_double.h
+++ b/ext/mysqlnd/mysql_float_to_double.h
@@ -31,7 +31,7 @@
 
 /*
  * Convert from a 4-byte float to a 8-byte decimal by first converting
- * the float to a string (Iinoring localization), and then the string to a double.
+ * the float to a string (ignoring localization), and then the string to a double.
  * The decimals argument specifies the precision of the output. If decimals
  * is less than zero, then a gcvt(3) like logic is used with the significant
  * digits set to FLT_DIG i.e. 6.

--- a/ext/mysqlnd/mysql_float_to_double.h
+++ b/ext/mysqlnd/mysql_float_to_double.h
@@ -31,7 +31,7 @@
 
 /*
  * Convert from a 4-byte float to a 8-byte decimal by first converting
- * the float to a string, and then the string to a double.
+ * the float to a string (Iinoring localization), and then the string to a double.
  * The decimals argument specifies the precision of the output. If decimals
  * is less than zero, then a gcvt(3) like logic is used with the significant
  * digits set to FLT_DIG i.e. 6.
@@ -42,7 +42,7 @@ static inline double mysql_float_to_double(float fp4, int decimals) {
 	if (decimals < 0) {
 		php_gcvt(fp4, FLT_DIG, '.', 'e', num_buf);
 	} else {
-		php_sprintf(num_buf, "%.*f", decimals, fp4);
+		snprintf(num_buf, MAX_CHAR_BUF_LEN, "%.*F", decimals, fp4);
 	}
 
 	return zend_strtod(num_buf, NULL);

--- a/ext/pdo_mysql/tests/bug79596.phpt
+++ b/ext/pdo_mysql/tests/bug79596.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #79596 (MySQL FLOAT truncates to int some locales)
+--SKIPIF--
+<?php
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'skipif.inc');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+MySQLPDOTest::skip();
+if (!setlocale(LC_ALL, 'de_DE', 'de-DE')) die('skip German locale not available');
+?>
+--FILE--
+<?php
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+
+setlocale(LC_ALL, 'de_DE', 'de-DE');
+
+$pdo = MySQLPDOTest::factory();
+$pdo->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
+$pdo->query('CREATE TABLE bug79596 (broken FLOAT(2,1))');
+$pdo->query('INSERT INTO bug79596 VALUES(4.9)');
+var_dump($pdo->query('SELECT broken FROM bug79596')->fetchColumn(0));
+?>
+--CLEAN--
+<?php
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+
+setlocale(LC_ALL, 'de_DE', 'de-DE');
+
+$pdo = MySQLPDOTest::factory();
+$pdo->exec("DROP TABLE IF EXISTS bug79596");
+?>
+--EXPECT--
+float(4,9)


### PR DESCRIPTION
We must not do locale aware float to string conversion here; instead
we using our `snprintf()` implementation with the `F` specifier.