### PR TITLE
Convert enchant resources to opaque objects

### DIFF
--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -22,38 +22,62 @@
 #include "php.h"
 #include "php_ini.h"
 #include "ext/standard/info.h"
+#include "Zend/zend_interfaces.h"
+#include "Zend/zend_exceptions.h"
+#include "../spl/spl_exceptions.h"
 #include <enchant.h>
 #include "php_enchant.h"
 #include "enchant_arginfo.h"
 
-typedef EnchantBroker * EnchantBrokerPtr;
-typedef struct _broker_struct enchant_broker;
-typedef struct _dict_struct enchant_dict;
-
-typedef enchant_broker * enchant_brokerPtr;
-typedef enchant_dict * enchant_dictPtr;
-
 typedef struct _broker_struct {
-	EnchantBroker	*pbroker;
-	enchant_dict	**dict;
-	unsigned int	dictcnt;
-	zend_resource	*rsrc;
-} _enchant_broker;
+	EnchantBroker  *pbroker;
+	int             nb_dict;
+	zend_object     std;
+} enchant_broker;
 
 typedef struct _dict_struct {
-	unsigned int	id;
-	EnchantDict		*pdict;
-	enchant_broker	*pbroker;
-	zend_resource	*rsrc;
-} _enchant_dict;
+	EnchantDict	   *pdict;
+	zval            zbroker;
+	zend_object     std;
+} enchant_dict;
 
+zend_class_entry *enchant_broker_ce;
+static zend_object_handlers enchant_broker_handlers;
 
-/* True global resources - no need for thread safety here */
-static int le_enchant_broker;
-static int le_enchant_dict;
+static inline enchant_broker *enchant_broker_from_obj(zend_object *obj) {
+	return (enchant_broker *)((char *)(obj) - XtOffsetOf(enchant_broker, std));
+}
 
-/* If you declare any globals in php_enchant.h uncomment this:*/
-/*ZEND_DECLARE_MODULE_GLOBALS(enchant)*/
+#define Z_ENCHANT_BROKER_P(zv) enchant_broker_from_obj(Z_OBJ_P(zv))
+
+static zend_object *enchant_broker_create_object(zend_class_entry *class_type) {
+	enchant_broker *intern = zend_object_alloc(sizeof(enchant_broker), class_type);
+
+	zend_object_std_init(&intern->std, class_type);
+	object_properties_init(&intern->std, class_type);
+	intern->std.handlers = &enchant_broker_handlers;
+
+	return &intern->std;
+}
+
+zend_class_entry *enchant_dict_ce;
+static zend_object_handlers enchant_dict_handlers;
+
+static inline enchant_dict *enchant_dict_from_obj(zend_object *obj) {
+	return (enchant_dict *)((char *)(obj) - XtOffsetOf(enchant_dict, std));
+}
+
+#define Z_ENCHANT_DICT_P(zv) enchant_dict_from_obj(Z_OBJ_P(zv))
+
+static zend_object *enchant_dict_create_object(zend_class_entry *class_type) {
+	enchant_dict *intern = zend_object_alloc(sizeof(enchant_dict), class_type);
+
+	zend_object_std_init(&intern->std, class_type);
+	object_properties_init(&intern->std, class_type);
+	intern->std.handlers = &enchant_dict_handlers;
+
+	return &intern->std;
+}
 
 #define PHP_ENCHANT_MYSPELL 1
 #define PHP_ENCHANT_ISPELL 2
@@ -129,54 +153,34 @@ static void php_enchant_list_dicts_fn( const char * const lang_tag,
 }
 /* }}} */
 
-static void php_enchant_broker_free(zend_resource *rsrc) /* {{{ */
+static void php_enchant_broker_free(zend_object *object) /* {{{ */
 {
-	if (rsrc->ptr) {
-		enchant_broker *broker = (enchant_broker *)rsrc->ptr;
-		if (broker) {
-			if (broker->pbroker) {
-				if (broker->dictcnt && broker->dict) {
-					if (broker->dict) {
-						int total;
-						total = broker->dictcnt-1;
-						do {
-							if (broker->dict[total]) {
-								enchant_dict *pdict = broker->dict[total];
-								broker->dict[total] = NULL;
-								zend_list_free(pdict->rsrc);
-								efree(pdict);
-							}
-							total--;
-						} while (total>=0);
-					}
-					efree(broker->dict);
-					broker->dict = NULL;
-				}
-				enchant_broker_free(broker->pbroker);
-			}
-			efree(broker);
-		}
+	enchant_broker *broker = enchant_broker_from_obj(object);
+
+	if (broker->pbroker) {  /* may have been freed by enchant_broker_free */
+		enchant_broker_free(broker->pbroker);
+		broker->pbroker = NULL;
 	}
+	zend_object_std_dtor(object);
 }
 /* }}} */
 
-static void php_enchant_dict_free(zend_resource *rsrc) /* {{{ */
+static void php_enchant_dict_free(zend_object *object) /* {{{ */
 
 {
-	if (rsrc->ptr) {
-		enchant_dict *pdict = (enchant_dict *)rsrc->ptr;
-		if (pdict) {
-			enchant_broker *pbroker = pdict->pbroker;
+	enchant_dict *dict = enchant_dict_from_obj(object);
 
-			if (pdict->pdict && pbroker) {
-				enchant_broker_free_dict(pbroker->pbroker, pdict->pdict);
-			}
+	if (dict->pdict) { /* may have been freed by enchant_broker_free_dict */
+		enchant_broker *broker = Z_ENCHANT_BROKER_P(&dict->zbroker);
 
-			pbroker->dict[pdict->id] = NULL;
-			efree(pdict);
-			zend_list_delete(pbroker->rsrc);
+		if (broker && broker->pbroker) {
+			enchant_broker_free_dict(broker->pbroker, dict->pdict);
+			broker->nb_dict--;
+			zval_ptr_dtor(&dict->zbroker);
 		}
+		dict->pdict = NULL;
 	}
+	zend_object_std_dtor(object);
 }
 /* }}} */
 
@@ -184,10 +188,34 @@ static void php_enchant_dict_free(zend_resource *rsrc) /* {{{ */
  */
 PHP_MINIT_FUNCTION(enchant)
 {
-	le_enchant_broker = zend_register_list_destructors_ex(php_enchant_broker_free, NULL, "enchant_broker", module_number);
-	le_enchant_dict = zend_register_list_destructors_ex(php_enchant_dict_free, NULL, "enchant_dict", module_number);
-	REGISTER_LONG_CONSTANT("ENCHANT_MYSPELL", PHP_ENCHANT_MYSPELL, CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("ENCHANT_ISPELL", PHP_ENCHANT_ISPELL, CONST_CS | CONST_PERSISTENT);
+	zend_class_entry bce, dce;
+
+	INIT_CLASS_ENTRY(bce, "EnchantBroker", class_EnchantBroker_methods);
+	enchant_broker_ce = zend_register_internal_class(&bce);
+	enchant_broker_ce->ce_flags |= ZEND_ACC_FINAL;
+	enchant_broker_ce->create_object = enchant_broker_create_object;
+	enchant_broker_ce->serialize = zend_class_serialize_deny;
+	enchant_broker_ce->unserialize = zend_class_unserialize_deny;
+
+	memcpy(&enchant_broker_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+	enchant_broker_handlers.offset = XtOffsetOf(enchant_broker, std);
+	enchant_broker_handlers.free_obj = php_enchant_broker_free;
+	enchant_broker_handlers.clone_obj = NULL;
+
+	INIT_CLASS_ENTRY(dce, "EnchantDict", class_EnchantDict_methods);
+	enchant_dict_ce = zend_register_internal_class(&dce);
+	enchant_dict_ce->ce_flags |= ZEND_ACC_FINAL;
+	enchant_dict_ce->create_object = enchant_dict_create_object;
+	enchant_dict_ce->serialize = zend_class_serialize_deny;
+	enchant_dict_ce->unserialize = zend_class_unserialize_deny;
+
+	memcpy(&enchant_dict_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+	enchant_dict_handlers.offset = XtOffsetOf(enchant_dict, std);
+	enchant_dict_handlers.free_obj = php_enchant_dict_free;
+	enchant_dict_handlers.clone_obj = NULL;
+
+	REGISTER_LONG_CONSTANT("ENCHANT_MYSPELL", PHP_ENCHANT_MYSPELL, CONST_CS | CONST_PERSISTENT | CONST_DEPRECATED);
+	REGISTER_LONG_CONSTANT("ENCHANT_ISPELL",  PHP_ENCHANT_ISPELL,  CONST_CS | CONST_PERSISTENT | CONST_DEPRECATED);
 #ifdef HAVE_ENCHANT_GET_VERSION
 	REGISTER_STRING_CONSTANT("LIBENCHANT_VERSION", enchant_get_version(), CONST_CS | CONST_PERSISTENT);
 #endif
@@ -236,17 +264,17 @@ PHP_MINFO_FUNCTION(enchant)
 /* }}} */
 
 #define PHP_ENCHANT_GET_BROKER	\
-	pbroker = (enchant_broker *)zend_fetch_resource(Z_RES_P(broker), "enchant_broker", le_enchant_broker); \
-	if (!pbroker || !pbroker->pbroker) {	\
-		php_error_docref(NULL, E_WARNING, "Resource broker invalid");	\
-		RETURN_FALSE;	\
+	pbroker = Z_ENCHANT_BROKER_P(broker); \
+	if (!pbroker->pbroker) {	\
+		zend_value_error("Invalid or uninitialized EnchantBroker object"); \
+		RETURN_THROWS(); \
 	}
 
 #define PHP_ENCHANT_GET_DICT	\
-	pdict = (enchant_dict *)zend_fetch_resource(Z_RES_P(dict), "enchant_dict", le_enchant_dict); \
-	if (!pdict || !pdict->pdict) {	\
-		php_error_docref(NULL, E_WARNING, "Invalid dictionary resource.");	\
-		RETURN_FALSE;	\
+	pdict = Z_ENCHANT_DICT_P(dict); \
+	if (!pdict->pdict) {	\
+		zend_value_error("Invalid or uninitialized EnchantDict object"); \
+		RETURN_THROWS(); \
 	}
 
 /* {{{ proto resource enchant_broker_init()
@@ -261,14 +289,11 @@ PHP_FUNCTION(enchant_broker_init)
 	}
 
 	pbroker = enchant_broker_init();
-
 	if (pbroker) {
-		broker = (enchant_broker *) emalloc(sizeof(enchant_broker));
+		object_init_ex(return_value, enchant_broker_ce);
+		broker = Z_ENCHANT_BROKER_P(return_value);
 		broker->pbroker = pbroker;
-		broker->dict = NULL;
-		broker->dictcnt = 0;
-		broker->rsrc = zend_register_resource(broker, le_enchant_broker);
-		RETURN_RES(broker->rsrc);
+		broker->nb_dict = 0;
 	} else {
 		RETURN_FALSE;
 	}
@@ -282,12 +307,19 @@ PHP_FUNCTION(enchant_broker_free)
 	zval *broker;
 	enchant_broker *pbroker;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &broker) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &broker, enchant_broker_ce) == FAILURE) {
 		RETURN_THROWS();
 	}
 	PHP_ENCHANT_GET_BROKER;
 
-	zend_list_close(Z_RES_P(broker));
+	if (pbroker->nb_dict > 0) {
+		php_error_docref(NULL, E_WARNING, "Cannot free EnchantBroker object with open EnchantDict objects");
+		RETURN_FALSE;
+	}
+	if (pbroker->pbroker) {
+		enchant_broker_free(pbroker->pbroker);
+		pbroker->pbroker = NULL;
+	}
 	RETURN_TRUE;
 }
 /* }}} */
@@ -300,7 +332,7 @@ PHP_FUNCTION(enchant_broker_get_error)
 	enchant_broker *pbroker;
 	const char *msg;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &broker) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &broker, enchant_broker_ce) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -325,7 +357,7 @@ PHP_FUNCTION(enchant_broker_set_dict_path)
 	char *value;
 	size_t value_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rls", &broker, &dict_type, &value, &value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ols", &broker, enchant_broker_ce, &dict_type, &value, &value_len) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -364,7 +396,7 @@ PHP_FUNCTION(enchant_broker_get_dict_path)
 	zend_long dict_type;
 	char *value;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &broker, &dict_type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ol", &broker, enchant_broker_ce, &dict_type) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -419,7 +451,7 @@ PHP_FUNCTION(enchant_broker_list_dicts)
 	zval *broker;
 	enchant_broker *pbroker;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &broker) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &broker, enchant_broker_ce) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -438,12 +470,11 @@ PHP_FUNCTION(enchant_broker_request_dict)
 	zval *broker;
 	enchant_broker *pbroker;
 	enchant_dict *dict;
-	EnchantDict *d;
+	EnchantDict *pdict;
 	char *tag;
 	size_t taglen;
-	int pos;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &broker, &tag, &taglen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &broker, enchant_broker_ce, &tag, &taglen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -454,25 +485,14 @@ PHP_FUNCTION(enchant_broker_request_dict)
 		RETURN_FALSE;
 	}
 
-	d = enchant_broker_request_dict(pbroker->pbroker, (const char *)tag);
-	if (d) {
-		pos = pbroker->dictcnt++;
-		if (pbroker->dictcnt) {
-			pbroker->dict = (enchant_dict **)erealloc(pbroker->dict, sizeof(enchant_dict *) * pbroker->dictcnt);
-		} else {
-			pbroker->dict = (enchant_dict **)emalloc(sizeof(enchant_dict *));
-			pos = 0;
-		}
+	pdict = enchant_broker_request_dict(pbroker->pbroker, (const char *)tag);
+	if (pdict) {
+		pbroker->nb_dict++;
 
-		dict = pbroker->dict[pos] = (enchant_dict *)emalloc(sizeof(enchant_dict));
-		dict->id = pos;
-		dict->pbroker = pbroker;
-		dict->pdict = d;
-		pbroker->dict[pos] = dict;
-
-		dict->rsrc = zend_register_resource(dict, le_enchant_dict);
-		GC_ADDREF(pbroker->rsrc);
-		RETURN_RES(dict->rsrc);
+		object_init_ex(return_value, enchant_dict_ce);
+		dict = Z_ENCHANT_DICT_P(return_value);
+		dict->pdict =pdict;
+		ZVAL_COPY(&dict->zbroker, broker);
 	} else {
 		RETURN_FALSE;
 	}
@@ -486,12 +506,11 @@ PHP_FUNCTION(enchant_broker_request_pwl_dict)
 	zval *broker;
 	enchant_broker *pbroker;
 	enchant_dict *dict;
-	EnchantDict *d;
-	char *pwl;
+	EnchantDict *pdict;
+	const char *pwl;
 	size_t pwllen;
-	int pos;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rp", &broker, &pwl, &pwllen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Op", &broker, enchant_broker_ce, &pwl, &pwllen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -501,25 +520,14 @@ PHP_FUNCTION(enchant_broker_request_pwl_dict)
 
 	PHP_ENCHANT_GET_BROKER;
 
-	d = enchant_broker_request_pwl_dict(pbroker->pbroker, (const char *)pwl);
-	if (d) {
-		pos = pbroker->dictcnt++;
-		if (pbroker->dictcnt) {
-			pbroker->dict = (enchant_dict **)erealloc(pbroker->dict, sizeof(enchant_dict *) * pbroker->dictcnt);
-		} else {
-			pbroker->dict = (enchant_dict **)emalloc(sizeof(enchant_dict *));
-			pos = 0;
-		}
+	pdict = enchant_broker_request_pwl_dict(pbroker->pbroker, pwl);
+	if (pdict) {
+		pbroker->nb_dict++;
 
-		dict = pbroker->dict[pos] = (enchant_dict *)emalloc(sizeof(enchant_dict));
-		dict->id = pos;
-		dict->pbroker = pbroker;
-		dict->pdict = d;
-		pbroker->dict[pos] = dict;
-
-		dict->rsrc = zend_register_resource(dict, le_enchant_dict);
-		GC_ADDREF(pbroker->rsrc);
-		RETURN_RES(dict->rsrc);
+		object_init_ex(return_value, enchant_dict_ce);
+		dict = Z_ENCHANT_DICT_P(return_value);
+		dict->pdict = pdict;
+		ZVAL_COPY(&dict->zbroker, broker);
 	} else {
 		RETURN_FALSE;
 	}
@@ -533,13 +541,23 @@ PHP_FUNCTION(enchant_broker_free_dict)
 	zval *dict;
 	enchant_dict *pdict;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &dict) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &dict, enchant_dict_ce) == FAILURE) {
 		RETURN_THROWS();
 	}
 
 	PHP_ENCHANT_GET_DICT;
 
-	zend_list_close(Z_RES_P(dict));
+	if (pdict->pdict) {
+		enchant_broker *broker = Z_ENCHANT_BROKER_P(&pdict->zbroker);
+
+		if (broker && broker->pbroker) {
+			enchant_broker_free_dict(broker->pbroker, pdict->pdict);
+			broker->nb_dict--;
+			zval_ptr_dtor(&pdict->zbroker);
+		}
+		pdict->pdict = NULL;
+	}
+
 	RETURN_TRUE;
 }
 /* }}} */
@@ -553,7 +571,7 @@ PHP_FUNCTION(enchant_broker_dict_exists)
 	size_t taglen;
 	enchant_broker * pbroker;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &broker, &tag, &taglen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &broker, enchant_broker_ce,  &tag, &taglen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -579,7 +597,7 @@ PHP_FUNCTION(enchant_broker_set_ordering)
 	size_t ptaglen;
 	enchant_broker * pbroker;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss", &broker, &ptag, &ptaglen, &pordering, &porderinglen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oss", &broker, enchant_broker_ce, &ptag, &ptaglen, &pordering, &porderinglen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -598,7 +616,7 @@ PHP_FUNCTION(enchant_broker_describe)
 	zval *broker;
 	enchant_broker * pbroker;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &broker) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &broker, enchant_broker_ce) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -619,7 +637,7 @@ PHP_FUNCTION(enchant_dict_quick_check)
 	size_t wordlen;
 	enchant_dict *pdict;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs|z", &dict, &word, &wordlen, &sugg) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os|z", &dict, enchant_dict_ce, &word, &wordlen, &sugg) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -665,7 +683,7 @@ PHP_FUNCTION(enchant_dict_check)
 	size_t wordlen;
 	enchant_dict *pdict;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &dict, &word, &wordlen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &dict, enchant_dict_ce, &word, &wordlen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -686,7 +704,7 @@ PHP_FUNCTION(enchant_dict_suggest)
 	enchant_dict *pdict;
 	size_t n_sugg;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &dict, &word, &wordlen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &dict, enchant_dict_ce, &word, &wordlen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -715,7 +733,7 @@ PHP_FUNCTION(enchant_dict_add)
 	size_t wordlen;
 	enchant_dict *pdict;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &dict, &word, &wordlen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &dict, enchant_dict_ce, &word, &wordlen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -734,7 +752,7 @@ PHP_FUNCTION(enchant_dict_add_to_session)
 	size_t wordlen;
 	enchant_dict *pdict;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &dict, &word, &wordlen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &dict, enchant_dict_ce, &word, &wordlen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -753,7 +771,7 @@ PHP_FUNCTION(enchant_dict_is_added)
 	size_t wordlen;
 	enchant_dict *pdict;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &dict, &word, &wordlen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &dict, enchant_dict_ce, &word, &wordlen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -776,7 +794,7 @@ PHP_FUNCTION(enchant_dict_store_replacement)
 
 	enchant_dict *pdict;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss", &dict, &mis, &mislen, &cor, &corlen) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oss", &dict, enchant_dict_ce, &mis, &mislen, &cor, &corlen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -794,7 +812,7 @@ PHP_FUNCTION(enchant_dict_get_error)
 	enchant_dict *pdict;
 	const char *msg;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &dict) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &dict, enchant_dict_ce) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -816,7 +834,7 @@ PHP_FUNCTION(enchant_dict_describe)
 	zval *dict;
 	enchant_dict *pdict;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &dict) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &dict, enchant_dict_ce) == FAILURE) {
 		RETURN_THROWS();
 	}
 

--- a/ext/enchant/enchant.stub.php
+++ b/ext/enchant/enchant.stub.php
@@ -2,94 +2,70 @@
 
 /** @generate-function-entries */
 
-/** @return resource|false */
-function enchant_broker_init() {}
+final class EnchantBroker
+{
+}
 
-/** @param resource $broker */
-function enchant_broker_free($broker): bool {}
+final class EnchantDict
+{
+}
 
-/**
-* @param resource $broker
-* @return string|false
-*/
-function enchant_broker_get_error($broker) {}
+function enchant_broker_init(): EnchantBroker|false {}
 
-/**
-* @param resource $broker
-* @deprecated
-*/
-function enchant_broker_set_dict_path($broker, int $name, string $value): bool {}
+/** @deprecated */
+function enchant_broker_free(EnchantBroker $broker): bool {}
 
-/**
-* @param resource $broker
-* @deprecated
-*/
-function enchant_broker_get_dict_path($broker, int $name): string|false {}
+function enchant_broker_get_error(EnchantBroker $broker): string|false {}
 
-/** @param resource $broker */
-function enchant_broker_list_dicts($broker): array {}
+/** @deprecated */
+function enchant_broker_set_dict_path(EnchantBroker $broker, int $name, string $value): bool {}
 
-/**
- * @param resource $broker
- * @return resource|false
- */
-function enchant_broker_request_dict($broker, string $tag) {}
+/** @deprecated */
+function enchant_broker_get_dict_path(EnchantBroker $broker, int $name): string|false {}
 
-/**
- * @param resource $broker
- * @return resource|false
- */
-function enchant_broker_request_pwl_dict($broker, string $filename) {}
+function enchant_broker_list_dicts(EnchantBroker $broker): array {}
 
-/** @param resource $dict */
-function enchant_broker_free_dict($dict): bool {}
+function enchant_broker_request_dict(EnchantBroker $broker, string $tag): EnchantDict|false {}
 
-/** @param resource $broker */
-function enchant_broker_dict_exists($broker, string $tag): bool {}
+function enchant_broker_request_pwl_dict(EnchantBroker $broker, string $filename): EnchantDict|false {}
 
-/** @param resource $broker */
-function enchant_broker_set_ordering($broker, string $tag, string $ordering): bool {}
+/** @deprecated */
+function enchant_broker_free_dict(EnchantDict $dict): bool {}
 
-/** @param resource $broker */
-function enchant_broker_describe($broker): array {}
+function enchant_broker_dict_exists(EnchantBroker $broker, string $tag): bool {}
 
-/** @param resource $dict */
-function enchant_dict_quick_check($dict, string $word, &$suggestions = null): bool {}
+function enchant_broker_set_ordering(EnchantBroker $broker, string $tag, string $ordering): bool {}
 
-/** @param resource $dict */
-function enchant_dict_check($dict, string $word): bool {}
+function enchant_broker_describe(EnchantBroker $broker): array {}
 
-/** @param resource $dict */
-function enchant_dict_suggest($dict, string $word): array {}
+function enchant_dict_quick_check(EnchantDict $dict, string $word, &$suggestions = null): bool {}
 
-/** @param resource $dict */
-function enchant_dict_add($dict, string $word): void {}
+function enchant_dict_check(EnchantDict $dict, string $word): bool {}
+
+function enchant_dict_suggest(EnchantDict $dict, string $word): array {}
+
+function enchant_dict_add(EnchantDict $dict, string $word): void {}
 
 /**
-* @param resource $dict
 * @alias enchant_dict_add
 * @deprecated
 */
-function enchant_dict_add_to_personal($dict, string $word): void {}
+function enchant_dict_add_to_personal(EnchantDict $dict, string $word): void {}
 
-/** @param resource $dict */
-function enchant_dict_add_to_session($dict, string $word): void {}
+function enchant_dict_add_to_session(EnchantDict $dict, string $word): void {}
 
-/** @param resource $dict */
-function enchant_dict_is_added($dict, string $word): bool {}
+function enchant_dict_is_added(EnchantDict $dict, string $word): bool {}
 
 /**
 * @param resource $dict
 * @alias enchant_dict_is_added
 * @deprecated
 */
-function enchant_dict_is_in_session($dict, string $word): bool {}
+function enchant_dict_is_in_session(EnchantDict $dict, string $word): bool {}
 
-/** @param resource $dict */
-function enchant_dict_store_replacement($dict, string $mis, string $cor): void {}
+function enchant_dict_store_replacement(EnchantDict $dict, string $mis, string $cor): void {}
 
-/** @param resource $dict */
-function enchant_dict_get_error($dict): string|false {}
+function enchant_dict_get_error(EnchantDict $dict): string|false {}
 
-/** @param resource $dict */
-function enchant_dict_describe($dict): array {}
+function enchant_dict_describe(EnchantDict $dict): array {}
+

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -1,52 +1,52 @@
 /* This is a generated file, edit the .stub.php file instead. */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_enchant_broker_init, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_enchant_broker_init, 0, 0, EnchantBroker, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_free, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, broker)
+	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_enchant_broker_get_error, 0, 0, 1)
-	ZEND_ARG_INFO(0, broker)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_enchant_broker_get_error, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_set_dict_path, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, broker)
+	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_enchant_broker_get_dict_path, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_INFO(0, broker)
+	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_list_dicts, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_INFO(0, broker)
+	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_enchant_broker_request_dict, 0, 0, 2)
-	ZEND_ARG_INFO(0, broker)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_enchant_broker_request_dict, 0, 2, EnchantDict, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 	ZEND_ARG_TYPE_INFO(0, tag, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_enchant_broker_request_pwl_dict, 0, 0, 2)
-	ZEND_ARG_INFO(0, broker)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_enchant_broker_request_pwl_dict, 0, 2, EnchantDict, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_free_dict, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, dict)
+	ZEND_ARG_OBJ_INFO(0, dict, EnchantDict, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_dict_exists, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, broker)
+	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 	ZEND_ARG_TYPE_INFO(0, tag, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_broker_set_ordering, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, broker)
+	ZEND_ARG_OBJ_INFO(0, broker, EnchantBroker, 0)
 	ZEND_ARG_TYPE_INFO(0, tag, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, ordering, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -54,23 +54,23 @@ ZEND_END_ARG_INFO()
 #define arginfo_enchant_broker_describe arginfo_enchant_broker_list_dicts
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_quick_check, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, dict)
+	ZEND_ARG_OBJ_INFO(0, dict, EnchantDict, 0)
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, suggestions, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_check, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, dict)
+	ZEND_ARG_OBJ_INFO(0, dict, EnchantDict, 0)
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_suggest, 0, 2, IS_ARRAY, 0)
-	ZEND_ARG_INFO(0, dict)
+	ZEND_ARG_OBJ_INFO(0, dict, EnchantDict, 0)
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_add, 0, 2, IS_VOID, 0)
-	ZEND_ARG_INFO(0, dict)
+	ZEND_ARG_OBJ_INFO(0, dict, EnchantDict, 0)
 	ZEND_ARG_TYPE_INFO(0, word, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -83,17 +83,17 @@ ZEND_END_ARG_INFO()
 #define arginfo_enchant_dict_is_in_session arginfo_enchant_dict_check
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_store_replacement, 0, 3, IS_VOID, 0)
-	ZEND_ARG_INFO(0, dict)
+	ZEND_ARG_OBJ_INFO(0, dict, EnchantDict, 0)
 	ZEND_ARG_TYPE_INFO(0, mis, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, cor, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_enchant_dict_get_error, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_INFO(0, dict)
+	ZEND_ARG_OBJ_INFO(0, dict, EnchantDict, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_enchant_dict_describe, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_INFO(0, dict)
+	ZEND_ARG_OBJ_INFO(0, dict, EnchantDict, 0)
 ZEND_END_ARG_INFO()
 
 
@@ -122,14 +122,14 @@ ZEND_FUNCTION(enchant_dict_describe);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(enchant_broker_init, arginfo_enchant_broker_init)
-	ZEND_FE(enchant_broker_free, arginfo_enchant_broker_free)
+	ZEND_DEP_FE(enchant_broker_free, arginfo_enchant_broker_free)
 	ZEND_FE(enchant_broker_get_error, arginfo_enchant_broker_get_error)
 	ZEND_DEP_FE(enchant_broker_set_dict_path, arginfo_enchant_broker_set_dict_path)
 	ZEND_DEP_FE(enchant_broker_get_dict_path, arginfo_enchant_broker_get_dict_path)
 	ZEND_FE(enchant_broker_list_dicts, arginfo_enchant_broker_list_dicts)
 	ZEND_FE(enchant_broker_request_dict, arginfo_enchant_broker_request_dict)
 	ZEND_FE(enchant_broker_request_pwl_dict, arginfo_enchant_broker_request_pwl_dict)
-	ZEND_FE(enchant_broker_free_dict, arginfo_enchant_broker_free_dict)
+	ZEND_DEP_FE(enchant_broker_free_dict, arginfo_enchant_broker_free_dict)
 	ZEND_FE(enchant_broker_dict_exists, arginfo_enchant_broker_dict_exists)
 	ZEND_FE(enchant_broker_set_ordering, arginfo_enchant_broker_set_ordering)
 	ZEND_FE(enchant_broker_describe, arginfo_enchant_broker_describe)
@@ -144,5 +144,15 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(enchant_dict_store_replacement, arginfo_enchant_dict_store_replacement)
 	ZEND_FE(enchant_dict_get_error, arginfo_enchant_dict_get_error)
 	ZEND_FE(enchant_dict_describe, arginfo_enchant_dict_describe)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_EnchantBroker_methods[] = {
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_EnchantDict_methods[] = {
 	ZEND_FE_END
 };

--- a/ext/enchant/tests/broker_describe.phpt
+++ b/ext/enchant/tests/broker_describe.phpt
@@ -17,12 +17,12 @@ if (!$broker) {
 }
 
 if (!enchant_broker_describe($broker)) {
-	enchant_broker_free($broker);
+	@enchant_broker_free($broker);
 
 	echo "skip: No broker providers found\n";
 }
 
-enchant_broker_free($broker);
+@enchant_broker_free($broker);
 ?>
 --FILE--
 <?php
@@ -47,7 +47,7 @@ if($broker) {
         echo "failed, brocker describe array \n";
     }
 
-    enchant_broker_free($broker);
+    @enchant_broker_free($broker);
 
 } else {
     echo("failed, broker_init failure\n");

--- a/ext/enchant/tests/broker_dict_exists.phpt
+++ b/ext/enchant/tests/broker_dict_exists.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--

--- a/ext/enchant/tests/broker_free_01.phpt
+++ b/ext/enchant/tests/broker_free_01.phpt
@@ -1,19 +1,19 @@
 --TEST--
-enchant_broker_free() function
+@enchant_broker_free() function
 --CREDITS--
 marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 ?>
 --FILE--
 <?php
 $broker = enchant_broker_init();
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
 
-    if (enchant_broker_free($broker)) {
+    if (@enchant_broker_free($broker)) {
         echo("OK\n");
     } else {
         echo("broker free failed\n");

--- a/ext/enchant/tests/broker_free_02.phpt
+++ b/ext/enchant/tests/broker_free_02.phpt
@@ -1,11 +1,11 @@
 --TEST--
-enchant_broker_free() function
+@enchant_broker_free() function
 --CREDITS--
 marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if(!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if(!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if(!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -14,7 +14,7 @@ $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 $newWord = array("iLoveJava","iLoveJavascript","iLoveRuby","iLovePerl","iLoveAwk","iLoveC");
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 
@@ -27,10 +27,10 @@ if (is_resource($broker)) {
         if (NULL === $AddtoPersonalDict) {
             var_dump($AddtoPersonalDict);
 
-            if (enchant_broker_free_dict($requestDict)) {
+            if (@enchant_broker_free_dict($requestDict)) {
                 echo("OK\n");
 
-                if (enchant_broker_free($broker)) {
+                if (@enchant_broker_free($broker)) {
                     echo("OK\n");
 
                 } else {

--- a/ext/enchant/tests/broker_free_dict.phpt
+++ b/ext/enchant/tests/broker_free_dict.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if(!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if(!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if(!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -13,7 +13,7 @@ if(!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no d
 $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 $newWord = "iLoveJava";
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 
@@ -44,9 +44,11 @@ if (is_resource($broker)) {
 }
 echo "OK\n";
 ?>
---EXPECT--
+--EXPECTF--
 OK
 OK
 NULL
+
+Deprecated: Function enchant_broker_free_dict() is deprecated in %s
 OK
 OK

--- a/ext/enchant/tests/broker_get_error.phpt
+++ b/ext/enchant/tests/broker_get_error.phpt
@@ -5,12 +5,12 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 ?>
 --FILE--
 <?php
 $broker = enchant_broker_init();
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $enchantErr = enchant_broker_get_error($broker);
 

--- a/ext/enchant/tests/broker_init.phpt
+++ b/ext/enchant/tests/broker_init.phpt
@@ -5,12 +5,12 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
  ?>
 --FILE--
 <?php
 $broker = enchant_broker_init();
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
 } else {
     echo("failure, its not a resource\n");

--- a/ext/enchant/tests/broker_list_dicts.phpt
+++ b/ext/enchant/tests/broker_list_dicts.phpt
@@ -17,17 +17,17 @@ if (!$broker) {
 }
 
 if (!enchant_broker_list_dicts($broker)) {
-	enchant_broker_free($broker);
+	@enchant_broker_free($broker);
 
 	echo "skip: No broker dicts installed\n";
 }
 
-enchant_broker_free($broker);
+@enchant_broker_free($broker);
 ?>
 --FILE--
 <?php
 $broker = enchant_broker_init();
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $brokerListDicts = enchant_broker_list_dicts($broker);
 

--- a/ext/enchant/tests/broker_request_dict.phpt
+++ b/ext/enchant/tests/broker_request_dict.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -17,7 +17,7 @@ if (is_array($dicts)) {
     if (count($dicts)) {
     $dict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 
-        if (is_resource($dict)) {
+        if (is_object($dict)) {
             echo "OK\n";
         } else {
             echo "fail to request " . $dicts[0]['lang_tag'];

--- a/ext/enchant/tests/broker_request_dict_01.phpt
+++ b/ext/enchant/tests/broker_request_dict_01.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -15,7 +15,7 @@ $dicts = enchant_broker_list_dicts($broker);
 
 if (is_array($dicts)) {
         $dict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
-        if (is_resource($dict)) {
+        if (is_object($dict)) {
             echo("OK\n");
         } else {
             echo("fail to request " . $dicts[0]['lang_tag']);

--- a/ext/enchant/tests/broker_request_pwl_dict.phpt
+++ b/ext/enchant/tests/broker_request_pwl_dict.phpt
@@ -5,18 +5,18 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if(!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if(!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 ?>
 --FILE--
 <?php
 $broker = enchant_broker_init();
 $pathPwlDict = __DIR__ . "/enchant_broker_request_pwl_dict.pwl";
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_pwl_dict($broker, $pathPwlDict);
 
-    if (is_resource($requestDict)) {
+    if (is_object($requestDict)) {
         echo("OK\n");
         $dictdescribe = enchant_dict_describe($requestDict);
 

--- a/ext/enchant/tests/broker_set_ordering.phpt
+++ b/ext/enchant/tests/broker_set_ordering.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -14,7 +14,7 @@ $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 $comma = ";";
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     if (enchant_broker_set_ordering($broker,$dicts[0]['lang_tag'],$comma)) {
         echo("OK\n");

--- a/ext/enchant/tests/bug13181.phpt
+++ b/ext/enchant/tests/bug13181.phpt
@@ -15,12 +15,12 @@ if (!$broker) {
 }
 
 if (!enchant_broker_list_dicts($broker)) {
-	enchant_broker_free($broker);
+	@enchant_broker_free($broker);
 
 	echo "skip: No broker dicts installed\n";
 }
 
-enchant_broker_free($broker);
+@enchant_broker_free($broker);
 ?>
 --FILE--
 <?php
@@ -52,9 +52,16 @@ $rDict = get_dict($rbroker);
 var_dump($rDict);
 ?>
 --EXPECTF--
-resource(%d) of type (enchant_dict)
-resource(%d) of type (enchant_dict)
-resource(%d) of type (enchant_broker)
-resource(%d) of type (enchant_broker)
-resource(%d) of type (enchant_dict)
-resource(%d) of type (enchant_dict)
+object(EnchantDict)#%d (0) {
+}
+object(EnchantDict)#%d (0) {
+}
+object(EnchantBroker)#%d (0) {
+}
+object(EnchantBroker)#%d (0) {
+}
+object(EnchantDict)#%d (0) {
+}
+object(EnchantDict)#%d (0) {
+}
+

--- a/ext/enchant/tests/bug53070.phpt
+++ b/ext/enchant/tests/bug53070.phpt
@@ -3,7 +3,7 @@ Bug #53070 (enchant_broker_get_path crashes if no path is set)
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (defined("LIBENCHANT_VERSION") && version_compare(LIBENCHANT_VERSION, "2", ">")) die('skip libenchant v1 only');
 ?>
 --FILE--
@@ -13,10 +13,14 @@ var_dump(enchant_broker_get_dict_path($broker, ENCHANT_MYSPELL));
 var_dump(enchant_broker_get_dict_path($broker, ENCHANT_ISPELL));
 ?>
 --EXPECTF--
+Deprecated: Constant ENCHANT_MYSPELL is deprecated in %s
+
 Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
 
 Warning: enchant_broker_get_dict_path(): dict_path not set in %s on line %d
 bool(false)
+
+Deprecated: Constant ENCHANT_ISPELL is deprecated in %s
 
 Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
 

--- a/ext/enchant/tests/dict_add_to_personal.phpt
+++ b/ext/enchant/tests/dict_add_to_personal.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -14,7 +14,7 @@ $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 $newWord = "iLoveJava";
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 

--- a/ext/enchant/tests/dict_add_to_session.phpt
+++ b/ext/enchant/tests/dict_add_to_session.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -14,7 +14,7 @@ $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 $newWord = "iLoveJavaScript";
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 

--- a/ext/enchant/tests/dict_check.phpt
+++ b/ext/enchant/tests/dict_check.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -14,7 +14,7 @@ $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 $newWord = "java";
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 

--- a/ext/enchant/tests/dict_describe.phpt
+++ b/ext/enchant/tests/dict_describe.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -13,7 +13,7 @@ if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no 
 $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 

--- a/ext/enchant/tests/dict_get_error.phpt
+++ b/ext/enchant/tests/dict_get_error.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -13,7 +13,7 @@ if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no 
 $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 

--- a/ext/enchant/tests/dict_is_in_session.phpt
+++ b/ext/enchant/tests/dict_is_in_session.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -14,7 +14,7 @@ $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 $newWord = "aspell";
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 

--- a/ext/enchant/tests/dict_quick_check.phpt
+++ b/ext/enchant/tests/dict_quick_check.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 
 $tag = 'en_US';

--- a/ext/enchant/tests/dict_quick_check_01.phpt
+++ b/ext/enchant/tests/dict_quick_check_01.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -14,7 +14,7 @@ $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 $word = "aspell";
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 

--- a/ext/enchant/tests/dict_store_replacement.phpt
+++ b/ext/enchant/tests/dict_store_replacement.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -15,7 +15,7 @@ $dicts = enchant_broker_list_dicts($broker);
 $wrongWord = "sava";
 $rightWord = "java";
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 

--- a/ext/enchant/tests/dict_suggest.phpt
+++ b/ext/enchant/tests/dict_suggest.phpt
@@ -5,7 +5,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 ?>
 --FILE--
@@ -14,7 +14,7 @@ $broker = enchant_broker_init();
 $dicts = enchant_broker_list_dicts($broker);
 $sugs = "soong";
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
     $requestDict = enchant_broker_request_dict($broker, $dicts[0]['lang_tag']);
 

--- a/ext/enchant/tests/enchant_broker_set_dict_path.phpt
+++ b/ext/enchant/tests/enchant_broker_set_dict_path.phpt
@@ -6,7 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
-if (!is_resource(enchant_broker_init())) {die("skip, resource dont load\n");}
+if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 if (defined("LIBENCHANT_VERSION") && version_compare(LIBENCHANT_VERSION, "2", ">")) die('skip libenchant v1 only');
 ?>
@@ -18,7 +18,7 @@ $backEndDictType2 = "ISPELL";
 $dictTypeValue1 = 1;
 $dictTypeValue2 = 2;
 
-if (is_resource($broker)) {
+if (is_object($broker)) {
     echo("OK\n");
 
     if (enchant_broker_set_dict_path($broker, $dictTypeValue1, $backEndDictType1)) {

--- a/ext/enchant/tests/invalidobj.phpt
+++ b/ext/enchant/tests/invalidobj.phpt
@@ -1,7 +1,5 @@
 --TEST--
-enchant_broker_free() function
---CREDITS--
-marcosptf - <marcosptf@yahoo.com.br>
+invalid object raise exception() function
 --SKIPIF--
 <?php
 if(!extension_loaded('enchant')) die('skip, enchant not loader');
@@ -11,16 +9,19 @@ if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 <?php
 $broker = enchant_broker_init();
 if (is_object($broker)) {
-    echo "OK\n";
-    enchant_broker_free($broker);
-
+	echo "OK\n";
+	@enchant_broker_free($broker);
+	try {
+		@enchant_broker_free($broker);
+	} catch (ValueError $e) {
+		echo $e->getMessage()."\n";
+	}
 } else {
-    exit("init failed\n");
+	exit("init failed\n");
 }
 echo "OK\n";
 ?>
 --EXPECTF--
 OK
-
-Deprecated: Function enchant_broker_free() is deprecated in %s
+Invalid or uninitialized EnchantBroker object
 OK


### PR DESCRIPTION
Additionally, deprecate ENCHANT_MYSPELL and ENCHANT_ISPELL constants.

This PR is essentially the same as the reverted https://github.com/php/php-src/commit/5318971bc50184eb35d658a6523ca95258869aa7 commit, minus the OO interface.