### PR TITLE
Rerun GC if destructors encountered

### DIFF
--- a/Zend/tests/gc_011.phpt
+++ b/Zend/tests/gc_011.phpt
@@ -15,7 +15,6 @@ $a->a = $a;
 var_dump($a);
 unset($a);
 var_dump(gc_collect_cycles());
-var_dump(gc_collect_cycles());
 echo "ok\n"
 ?>
 --EXPECTF--
@@ -24,6 +23,5 @@ object(Foo)#%d (1) {
   *RECURSION*
 }
 __destruct
-int(0)
 int(1)
 ok

--- a/Zend/tests/gc_016.phpt
+++ b/Zend/tests/gc_016.phpt
@@ -18,11 +18,9 @@ $a = new Foo();
 $a->a = $a;
 unset($a);
 var_dump(gc_collect_cycles());
-var_dump(gc_collect_cycles());
 echo "ok\n"
 ?>
 --EXPECT--
 -> int(0)
-int(0)
 int(2)
 ok

--- a/Zend/tests/gc_017.phpt
+++ b/Zend/tests/gc_017.phpt
@@ -32,13 +32,11 @@ unset($a);
 unset($b);
 unset($c);
 var_dump(gc_collect_cycles());
-var_dump(gc_collect_cycles());
 echo "ok\n"
 ?>
 --EXPECTF--
 string(1) "%s"
 string(1) "%s"
 string(1) "%s"
-int(0)
 int(1)
 ok

--- a/Zend/tests/gc_028.phpt
+++ b/Zend/tests/gc_028.phpt
@@ -28,8 +28,6 @@ $bar->foo = $foo;
 unset($foo);
 unset($bar);
 var_dump(gc_collect_cycles());
-var_dump(gc_collect_cycles());
 ?>
 --EXPECT--
-int(0)
 int(1)

--- a/Zend/tests/gc_029.phpt
+++ b/Zend/tests/gc_029.phpt
@@ -30,8 +30,6 @@ $bar->foo = $foo;
 unset($foo);
 unset($bar);
 var_dump(gc_collect_cycles());
-var_dump(gc_collect_cycles());
 ?>
 --EXPECT--
-int(0)
 int(1)

--- a/Zend/tests/gc_035.phpt
+++ b/Zend/tests/gc_035.phpt
@@ -19,9 +19,7 @@ $a->x[] = $a;
 var_dump(gc_collect_cycles());
 unset($a);
 var_dump(gc_collect_cycles());
-var_dump(gc_collect_cycles());
 ?>
 --EXPECT--
-int(0)
 int(0)
 int(2)

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -1430,7 +1430,10 @@ static void zend_get_gc_buffer_release(void);
 ZEND_API int zend_gc_collect_cycles(void)
 {
 	int count = 0;
+	zend_bool should_rerun_gc = 0;
+	zend_bool did_rerun_gc = 0;
 
+rerun_gc:
 	if (GC_G(num_roots)) {
 		gc_root_buffer *current, *last;
 		zend_refcounted *p;
@@ -1475,8 +1478,8 @@ ZEND_API int zend_gc_collect_cycles(void)
 			 * be introduced. These references can be introduced in a way that does not
 			 * modify any refcounts, so we have no real way to detect this situation
 			 * short of rerunning full GC tracing. What we do instead is to only run
-			 * destructors at this point, and leave the actual freeing of the objects
-			 * until the next GC run. */
+			 * destructors at this point and automatically re-run GC afterwards. */
+			should_rerun_gc = 1;
 
 			/* Mark all roots for which a dtor will be invoked as DTOR_GARBAGE. Additionally
 			 * color them purple. This serves a double purpose: First, they should be
@@ -1609,6 +1612,15 @@ ZEND_API int zend_gc_collect_cycles(void)
 	}
 
 	gc_compact();
+
+	/* Objects with destructors were removed from this GC run. Rerun GC right away to clean them
+	 * up. We do this only once: If we encounter more destructors on the second run, we'll not
+	 * run GC another time. */
+	if (should_rerun_gc && !did_rerun_gc) {
+		did_rerun_gc = 1;
+		goto rerun_gc;
+	}
+
 	zend_get_gc_buffer_release();
 	return count;
 }


### PR DESCRIPTION
Since PHP 7.4 objects that have a destructor require two GC runs to be collected. Currently the collection is delayed to the next automatic GC run. However, in some cases this may result in a large increase in memory usage, as in one of the cases of https://bugs.php.net/bug.php?id=79519. I have also had some reports (though I don't remember from where) there code depended on gc_collect_cycles() destroying everything in one call.

This patch will automatically rerun GC if destructors were encountered. I think this should not have much cost, because it is very likely that objects on which the destructor has been called really are garbage, so the extra GC run should not be doing wasted work.