### PR TITLE
New instrumentation API

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2061,6 +2061,7 @@ ZEND_API int zend_register_functions(zend_class_entry *scope, const zend_functio
 	}
 	internal_function->type = ZEND_INTERNAL_FUNCTION;
 	internal_function->module = EG(current_module);
+	ZEND_MAP_PTR_NEW(internal_function->instrument_cache);
 	memset(internal_function->reserved, 0, ZEND_MAX_RESERVED_RESOURCES * sizeof(void*));
 
 	if (scope) {

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -310,8 +310,8 @@ static int zend_create_closure_from_callable(zval *return_value, zval *callable,
 		call.scope = mptr->common.scope;
 
 		// TODO: Is this correct???
-		static const zend_instrument_cache *dummy_handlers = ZEND_NOT_INSTRUMENTED;
-		ZEND_MAP_PTR_INIT(call.instrument_cache, (zend_instrument_cache **) &dummy_handlers);
+		static const zend_instrument_fcall_cache *dummy_handlers = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handlers);
 
 		zend_free_trampoline(mptr);
 		mptr = (zend_function *) &call;
@@ -401,8 +401,8 @@ ZEND_API zend_function *zend_get_closure_invoke_method(zend_object *object) /* {
 	invoke->internal_function.function_name = ZSTR_KNOWN(ZEND_STR_MAGIC_INVOKE);
 
 	// TODO: Is this correct???
-	static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
-	ZEND_MAP_PTR_INIT(invoke->internal_function.instrument_cache, (zend_instrument_cache **) &dummy_handler);
+	static const zend_instrument_fcall_cache *dummy_handler = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+	ZEND_MAP_PTR_INIT(invoke->internal_function.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handler);
 	return invoke;
 }
 /* }}} */

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -309,6 +309,10 @@ static int zend_create_closure_from_callable(zval *return_value, zval *callable,
 		call.function_name = mptr->common.function_name;
 		call.scope = mptr->common.scope;
 
+		// TODO: Is this correct???
+		static const zend_instrument_cache *dummy_handlers = ZEND_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call.instrument_cache, (zend_instrument_cache **) &dummy_handlers);
+
 		zend_free_trampoline(mptr);
 		mptr = (zend_function *) &call;
 	}
@@ -395,6 +399,10 @@ ZEND_API zend_function *zend_get_closure_invoke_method(zend_object *object) /* {
 	invoke->internal_function.module = 0;
 	invoke->internal_function.scope = zend_ce_closure;
 	invoke->internal_function.function_name = ZSTR_KNOWN(ZEND_STR_MAGIC_INVOKE);
+
+	// TODO: Is this correct???
+	static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
+	ZEND_MAP_PTR_INIT(invoke->internal_function.instrument_cache, (zend_instrument_cache **) &dummy_handler);
 	return invoke;
 }
 /* }}} */

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6258,9 +6258,14 @@ void zend_compile_func_decl(znode *result, zend_ast *ast, zend_bool toplevel) /*
 		op_array->fn_flags |= ZEND_ACC_PRELOADED;
 		ZEND_MAP_PTR_NEW(op_array->run_time_cache);
 		ZEND_MAP_PTR_NEW(op_array->static_variables_ptr);
+		ZEND_MAP_PTR_NEW(op_array->instrument_cache);
 	} else {
 		ZEND_MAP_PTR_INIT(op_array->run_time_cache, zend_arena_alloc(&CG(arena), sizeof(void*)));
 		ZEND_MAP_PTR_SET(op_array->run_time_cache, NULL);
+
+		ZEND_MAP_PTR_INIT(op_array->instrument_cache,
+			zend_arena_alloc(&CG(arena), sizeof(void*)));
+		ZEND_MAP_PTR_SET(op_array->instrument_cache, NULL);
 	}
 
 	op_array->fn_flags |= (orig_op_array->fn_flags & ZEND_ACC_STRICT_TYPES);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -403,6 +403,7 @@ struct _zend_op_array {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_arg_info *arg_info;
+	ZEND_MAP_PTR_DEF(struct zend_instrument_cache *, instrument_cache);
 	/* END of common elements */
 
 	int cache_size;     /* number of run_time_cache_slots * sizeof(void*) */
@@ -452,6 +453,7 @@ typedef struct _zend_internal_function {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_internal_arg_info *arg_info;
+	ZEND_MAP_PTR_DEF(struct zend_instrument_cache *, instrument_cache);
 	/* END of common elements */
 
 	zif_handler handler;
@@ -475,6 +477,7 @@ union _zend_function {
 		uint32_t num_args;
 		uint32_t required_num_args;
 		zend_arg_info *arg_info;  /* index -1 represents the return value info, if any */
+		ZEND_MAP_PTR_DEF(struct zend_instrument_cache *, instrument_cache);
 	} common;
 
 	zend_op_array op_array;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -403,7 +403,7 @@ struct _zend_op_array {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_arg_info *arg_info;
-	ZEND_MAP_PTR_DEF(struct zend_instrument_cache *, instrument_cache);
+	ZEND_MAP_PTR_DEF(struct zend_instrument_fcall_cache *, instrument_cache);
 	/* END of common elements */
 
 	int cache_size;     /* number of run_time_cache_slots * sizeof(void*) */
@@ -453,7 +453,7 @@ typedef struct _zend_internal_function {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_internal_arg_info *arg_info;
-	ZEND_MAP_PTR_DEF(struct zend_instrument_cache *, instrument_cache);
+	ZEND_MAP_PTR_DEF(struct zend_instrument_fcall_cache *, instrument_cache);
 	/* END of common elements */
 
 	zif_handler handler;
@@ -477,7 +477,7 @@ union _zend_function {
 		uint32_t num_args;
 		uint32_t required_num_args;
 		zend_arg_info *arg_info;  /* index -1 represents the return value info, if any */
-		ZEND_MAP_PTR_DEF(struct zend_instrument_cache *, instrument_cache);
+		ZEND_MAP_PTR_DEF(struct zend_instrument_fcall_cache *, instrument_cache);
 	} common;
 
 	zend_op_array op_array;

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3508,7 +3508,7 @@ ZEND_API zend_function * ZEND_FASTCALL zend_fetch_function(zend_string *name) /*
 			init_func_run_time_cache_i(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		return fbc;
 	}
@@ -3526,7 +3526,7 @@ ZEND_API zend_function * ZEND_FASTCALL zend_fetch_function_str(const char *name,
 			init_func_run_time_cache_i(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		return fbc;
 	}
@@ -3564,7 +3564,7 @@ static zend_always_inline void i_init_code_execute_data(zend_execute_data *execu
 		ZEND_MAP_PTR_INIT(op_array->instrument_cache,
 			zend_arena_alloc(&CG(arena), sizeof(void*)));
 		ZEND_MAP_PTR_SET(op_array->instrument_cache, NULL);
-		zend_instrument_install_handlers((zend_function *) op_array);
+		zend_instrument_fcall_install((zend_function *)op_array);
 	}
 	EX(run_time_cache) = RUN_TIME_CACHE(op_array);
 
@@ -3591,7 +3591,7 @@ ZEND_API void zend_init_func_execute_data(zend_execute_data *ex, zend_op_array *
 		init_func_run_time_cache(op_array);
 	}
 	if (UNEXPECTED(!ZEND_MAP_PTR_GET(op_array->instrument_cache))) {
-		zend_instrument_install_handlers((zend_function *) op_array);
+		zend_instrument_fcall_install((zend_function *)op_array);
 	}
 	i_init_func_execute_data(op_array, return_value, 1 EXECUTE_DATA_CC);
 
@@ -3945,7 +3945,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_string(zend_s
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	} else {
 		if (ZSTR_VAL(function)[0] == '\\') {
@@ -3966,7 +3966,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_string(zend_s
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		called_scope = NULL;
 	}
@@ -4013,7 +4013,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_object(zend_o
 		init_func_run_time_cache(&fbc->op_array);
 	}
 	if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-		zend_instrument_install_handlers(fbc);
+		zend_instrument_fcall_install(fbc);
 	}
 
 	return zend_vm_stack_push_call_frame(call_info,
@@ -4101,7 +4101,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_array(zend_ar
 		init_func_run_time_cache(&fbc->op_array);
 	}
 	if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-		zend_instrument_install_handlers(fbc);
+		zend_instrument_fcall_install(fbc);
 	}
 
 	return zend_vm_stack_push_call_frame(call_info,

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -41,14 +41,13 @@ ZEND_API void zend_init_code_execute_data(zend_execute_data *execute_data, zend_
 ZEND_API void zend_execute(zend_op_array *op_array, zval *return_value);
 ZEND_API void execute_ex(zend_execute_data *execute_data);
 
-ZEND_API inline void execute_internal(zend_execute_data *execute_data, zval *return_value)
-{
-	zend_instrument_cache *cache = (zend_instrument_cache *)
+ZEND_API inline void execute_internal(zend_execute_data *execute_data, zval *return_value) {
+	zend_instrument_fcall_cache *cache = (zend_instrument_fcall_cache *)
 		ZEND_MAP_PTR_GET(execute_data->func->common.instrument_cache);
-	if (UNEXPECTED(cache != ZEND_NOT_INSTRUMENTED)) {
-		zend_instrument_call_begin_handlers(execute_data, cache);
+	if (UNEXPECTED(cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED)) {
+		zend_instrument_fcall_call_begin(cache, execute_data);
 		execute_data->func->internal_function.handler(execute_data, return_value);
-		zend_instrument_call_end_handlers(execute_data, cache);
+		zend_instrument_fcall_call_end(cache, execute_data, return_value);
 	} else {
 		execute_data->func->internal_function.handler(execute_data, return_value);
 	}

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -797,9 +797,9 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 		const zend_op *current_opline_before_exception = EG(opline_before_exception);
 
 		zend_init_func_execute_data(call, &func->op_array, fci->retval);
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 		zend_execute_ex(call);
 		EG(opline_before_exception) = current_opline_before_exception;
@@ -813,7 +813,7 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 		ZEND_ASSERT(func->type == ZEND_INTERNAL_FUNCTION);
 
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
-			zend_instrument_install_handlers(func);
+			zend_instrument_fcall_install(func);
 		}
 
 		ZVAL_NULL(fci->retval);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -797,6 +797,10 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 		const zend_op *current_opline_before_exception = EG(opline_before_exception);
 
 		zend_init_func_execute_data(call, &func->op_array, fci->retval);
+		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_NOT_INSTRUMENTED) {
+			zend_instrument_call_begin_handlers(call, cache);
+		}
 		zend_execute_ex(call);
 		EG(opline_before_exception) = current_opline_before_exception;
 		if (call_via_handler) {
@@ -807,12 +811,16 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 		int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
 
 		ZEND_ASSERT(func->type == ZEND_INTERNAL_FUNCTION);
+
+		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
+			zend_instrument_install_handlers(func);
+		}
+
 		ZVAL_NULL(fci->retval);
 		call->prev_execute_data = EG(current_execute_data);
 		EG(current_execute_data) = call;
 		if (EXPECTED(zend_execute_internal == NULL)) {
-			/* saves one function call if zend_execute_internal is not used */
-			func->internal_function.handler(call, fci->retval);
+			execute_internal(call, fci->retval);
 		} else {
 			zend_execute_internal(call, fci->retval);
 		}

--- a/Zend/zend_instrument.c
+++ b/Zend/zend_instrument.c
@@ -1,0 +1,131 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend Engine                                                          |
+   +----------------------------------------------------------------------+
+   | Copyright (c) Zend Technologies Ltd. (http://www.zend.com)           |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+   | Authors: Levi Morrison <levim@php.net>                               |
+   |          Sammy Kaye Powers <sammyk@php.net>                          |
+   +----------------------------------------------------------------------+
+*/
+
+#include "zend.h"
+#include "zend_API.h"
+#include "zend_instrument.h"
+
+struct zend_instruments_list {
+	struct zend_instruments_list *prev;
+	zend_instrument instrument;
+};
+typedef struct zend_instruments_list zend_instruments_list;
+
+static zend_instruments_list *_zend_instruments;
+
+ZEND_API void zend_instrument_init(void)
+{
+	_zend_instruments = NULL;
+}
+
+ZEND_API void zend_instrument_shutdown(void)
+{
+	zend_instruments_list *curr, *prev;
+	for (curr = _zend_instruments; curr; curr = prev) {
+		prev = curr->prev;
+		free(curr);
+	}
+}
+
+ZEND_API void zend_instrument_register(zend_instrument instrument)
+{
+	zend_instruments_list *node = malloc(sizeof(zend_instruments_list));
+	node->instrument = instrument;
+	node->prev = _zend_instruments;
+	_zend_instruments = node;
+}
+
+struct zend_instrument_handlers_list {
+	struct zend_instrument_handlers_list *prev;
+	zend_instrument_handlers handlers;
+	size_t count;
+};
+typedef struct zend_instrument_handlers_list zend_instrument_handlers_list;
+
+
+extern inline void zend_instrument_call_begin_handlers(
+	zend_execute_data *execute_data, zend_instrument_cache *cache);
+extern inline void zend_instrument_call_end_handlers(
+	zend_execute_data *execute_data, zend_instrument_cache *cache);
+
+static zend_instrument_handlers_list *_instrument_add(
+	zend_instrument_handlers_list *instruments,
+	zend_instrument_handlers handlers)
+{
+	if (!handlers.begin && !handlers.end) {
+		return instruments;
+	}
+
+	zend_instrument_handlers_list *n =
+		emalloc(sizeof(zend_instrument_handlers_list));
+	if (instruments) {
+		n->prev = instruments;
+		n->count = instruments->count + 1;
+	} else {
+		n->prev = NULL;
+		n->count = 1;
+	}
+	n->handlers = handlers;
+	return n;
+}
+
+static zend_instrument_cache *_instrument_attach_handler(
+	zend_function *function,
+	zend_instrument_handlers_list *handlers_list)
+{
+	zend_instrument_cache *cache =
+		malloc(sizeof(zend_instrument_cache));
+	cache->instruments_len = handlers_list->count;
+	cache->handlers =
+		calloc(handlers_list->count, sizeof(zend_instrument_handlers));
+
+	zend_instrument_handlers *handlers = cache->handlers;
+	zend_instrument_handlers_list *curr;
+	for (curr = handlers_list; curr; curr = curr->prev) {
+		*handlers++ = curr->handlers;
+	}
+
+	ZEND_MAP_PTR_SET(function->common.instrument_cache, cache);
+
+	return cache;
+}
+
+ZEND_API void zend_instrument_install_handlers(zend_function *function)
+{
+	zend_instrument_handlers_list *handlers_list = NULL;
+	zend_instruments_list *elem;
+
+	for (elem = _zend_instruments; elem; elem = elem->prev) {
+		zend_instrument_handlers handlers = elem->instrument(function);
+		handlers_list = _instrument_add(handlers_list, handlers);
+	}
+
+	if (handlers_list) {
+		_instrument_attach_handler(function, handlers_list);
+
+		// cleanup handlers_list
+		zend_instrument_handlers_list *curr, *prev;
+		for (curr = handlers_list; curr; curr = prev) {
+			prev = curr->prev;
+			efree(curr);
+		}
+	} else {
+		ZEND_MAP_PTR_SET(function->common.instrument_cache, ZEND_NOT_INSTRUMENTED);
+	}
+}

--- a/Zend/zend_instrument.h
+++ b/Zend/zend_instrument.h
@@ -1,0 +1,91 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend Engine                                                          |
+   +----------------------------------------------------------------------+
+   | Copyright (c) Zend Technologies Ltd. (http://www.zend.com)           |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+   | Authors: Levi Morrison <levim@php.net>                               |
+   |          Sammy Kaye Powers <sammyk@php.net>                          |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef ZEND_INSTRUMENT_H
+#define ZEND_INSTRUMENT_H
+
+BEGIN_EXTERN_C()
+
+typedef void (*zend_instrument_begin_handler)(zend_execute_data *ex);
+typedef void (*zend_instrument_end_handler)(zend_execute_data *ex/*, zval *return_value*/);
+
+struct zend_instrument_handlers {
+	zend_instrument_begin_handler begin;
+
+	/* todo: need to figure out how to tell end that it is exiting normally
+	 * or not; checking for EG(exception) is not enough (unclean shutdown).
+	 */
+	zend_instrument_end_handler end;
+};
+typedef struct zend_instrument_handlers zend_instrument_handlers;
+
+struct zend_instrument_cache {
+	// todo: use arena
+	size_t instruments_len;
+	zend_instrument_handlers *handlers;
+};
+typedef struct zend_instrument_cache zend_instrument_cache;
+
+/* If the fn should not be instrumented then return {NULL, NULL} */
+typedef zend_instrument_handlers (*zend_instrument)(zend_function *func);
+
+#define ZEND_NOT_INSTRUMENTED ((void *) 1)
+
+// Call during minit/startup ONLY
+ZEND_API void zend_instrument_register(zend_instrument cb);
+
+// Called by engine before MINITs
+ZEND_API void zend_instrument_init(void);
+ZEND_API void zend_instrument_shutdown(void);
+
+ZEND_API void zend_instrument_install_handlers(zend_function *function);
+
+inline void zend_instrument_call_begin_handlers(
+	zend_execute_data *execute_data, zend_instrument_cache *cache)
+{
+	zend_instrument_handlers *handler;
+	zend_instrument_handlers *stop =
+		cache->handlers + cache->instruments_len;
+
+	for (handler = cache->handlers; handler != stop; ++handler) {
+		if (handler->begin) {
+			handler->begin(execute_data);
+		}
+	}
+}
+
+inline void zend_instrument_call_end_handlers(
+	zend_execute_data *execute_data, zend_instrument_cache *cache)
+{
+	zend_instrument_handlers *handler =
+		cache->handlers + cache->instruments_len;
+	zend_instrument_handlers *stop = cache->handlers;
+
+	// todo: send return_value to end, maybe protected via zval copy
+	// todo: decide if this should run in reverse order or not
+	while (handler-- != stop) {
+		if (handler->end) {
+			handler->end(execute_data);
+		}
+	}
+}
+
+END_EXTERN_C()
+
+#endif /* ZEND_INSTRUMENT_H */

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1204,7 +1204,8 @@ ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend
 	 * The low bit must be zero, to not be interpreted as a MAP_PTR offset.
 	 */
 	static const void *dummy = (void*)(intptr_t)2;
-	static const zend_instrument_cache *dummy_handlers = ZEND_NOT_INSTRUMENTED;
+	static const zend_instrument_fcall_cache *dummy_handlers =
+		ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
 
 	ZEND_ASSERT(fbc);
 
@@ -1224,7 +1225,7 @@ ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend
 	}
 	func->opcodes = &EG(call_trampoline_op);
 	ZEND_MAP_PTR_INIT(func->run_time_cache, (void***)&dummy);
-	ZEND_MAP_PTR_INIT(func->instrument_cache, (zend_instrument_cache **) &dummy_handlers);
+	ZEND_MAP_PTR_INIT(func->instrument_cache, (zend_instrument_fcall_cache **) &dummy_handlers);
 	func->scope = fbc->common.scope;
 	/* reserve space for arguments, local and temporary variables */
 	func->T = (fbc->type == ZEND_USER_FUNCTION)? MAX(fbc->op_array.last_var + fbc->op_array.T, 2) : 2;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1204,6 +1204,7 @@ ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend
 	 * The low bit must be zero, to not be interpreted as a MAP_PTR offset.
 	 */
 	static const void *dummy = (void*)(intptr_t)2;
+	static const zend_instrument_cache *dummy_handlers = ZEND_NOT_INSTRUMENTED;
 
 	ZEND_ASSERT(fbc);
 
@@ -1223,6 +1224,7 @@ ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend
 	}
 	func->opcodes = &EG(call_trampoline_op);
 	ZEND_MAP_PTR_INIT(func->run_time_cache, (void***)&dummy);
+	ZEND_MAP_PTR_INIT(func->instrument_cache, (zend_instrument_cache **) &dummy_handlers);
 	func->scope = fbc->common.scope;
 	/* reserve space for arguments, local and temporary variables */
 	func->T = (fbc->type == ZEND_USER_FUNCTION)? MAX(fbc->op_array.last_var + fbc->op_array.T, 2) : 2;

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -67,6 +67,7 @@ void init_op_array(zend_op_array *op_array, zend_uchar type, int initial_ops_siz
 	op_array->arg_info = NULL;
 	op_array->num_args = 0;
 	op_array->required_num_args = 0;
+	ZEND_MAP_PTR_INIT(op_array->instrument_cache, NULL);
 
 	op_array->scope = NULL;
 	op_array->prototype = NULL;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1333,9 +1333,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_UCALL_SPEC_RETV
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-	zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-	if (cache != ZEND_NOT_INSTRUMENTED) {
-		zend_instrument_call_begin_handlers(call, cache);
+	zend_instrument_fcall_cache *cache =
+		ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+	if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+		zend_instrument_fcall_call_begin(cache, call);
 	}
 
 	LOAD_OPLINE_EX();
@@ -1362,9 +1363,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_UCALL_SPEC_RETV
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-	zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-	if (cache != ZEND_NOT_INSTRUMENTED) {
-		zend_instrument_call_begin_handlers(call, cache);
+	zend_instrument_fcall_cache *cache =
+		ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+	if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+		zend_instrument_fcall_call_begin(cache, call);
 	}
 
 	LOAD_OPLINE_EX();
@@ -1392,9 +1394,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		LOAD_OPLINE_EX();
@@ -1479,9 +1482,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		LOAD_OPLINE_EX();
@@ -1566,9 +1570,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
@@ -1669,9 +1674,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
@@ -2557,9 +2563,12 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try
 
 	if (execute_data->func) {
 		zend_function *func = execute_data->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(execute_data, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zval undef;
+			ZVAL_UNDEF(&undef);
+			zend_instrument_fcall_call_end(cache, execute_data, &undef);
 		}
 	}
 
@@ -2790,7 +2799,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_HANDLER(Z
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
@@ -2909,7 +2918,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_FCALL_BY_NAME
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -2998,7 +3007,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_NS_FCALL_BY_N
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -3031,7 +3040,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_FCALL_SPEC_CO
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -3580,9 +3589,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -5744,7 +5754,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -5870,7 +5880,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CONST != IS_CONST) {
 
@@ -5889,7 +5899,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -5970,7 +5980,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_USER_CALL_SPEC_CONST_CONS
 			init_func_run_time_cache(&func->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
-			zend_instrument_install_handlers(func);
+			zend_instrument_fcall_install(func);
 		}
 	} else {
 		zend_type_error("%s(): Argument #1 ($function) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
@@ -7931,7 +7941,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -8057,7 +8067,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
@@ -8076,7 +8086,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -8158,7 +8168,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_USER_CALL_SPEC_CONST_TMPV
 			init_func_run_time_cache(&func->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
-			zend_instrument_install_handlers(func);
+			zend_instrument_fcall_install(func);
 		}
 	} else {
 		zend_type_error("%s(): Argument #1 ($function) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
@@ -8809,7 +8819,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_UNUSED != IS_CONST) {
 
@@ -8828,7 +8838,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -8973,14 +8983,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NEW_SPEC_CONST_UNUSED_HANDLER(
 		call = zend_vm_stack_push_call_frame(
 			ZEND_CALL_FUNCTION, (zend_function *) &zend_pass_function,
 			opline->extended_value, NULL);
-		static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
-		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_cache **) &dummy_handler);
+		static const zend_instrument_fcall_cache *dummy_handler = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handler);
 	} else {
 		if (EXPECTED(constructor->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&constructor->op_array))) {
 			init_func_run_time_cache(&constructor->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(constructor->common.instrument_cache))) {
-			zend_instrument_install_handlers(constructor);
+			zend_instrument_fcall_install(constructor);
 		}
 		/* We are not handling overloaded classes right now */
 		call = zend_vm_stack_push_call_frame(
@@ -10210,7 +10220,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -10336,7 +10346,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CV != IS_CONST) {
 
@@ -10355,7 +10365,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -10436,7 +10446,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_USER_CALL_SPEC_CONST_CV_H
 			init_func_run_time_cache(&func->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
-			zend_instrument_install_handlers(func);
+			zend_instrument_fcall_install(func);
 		}
 	} else {
 		zend_type_error("%s(): Argument #1 ($function) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
@@ -14512,7 +14522,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -15896,7 +15906,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_T
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -17174,7 +17184,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -17499,9 +17509,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -19930,9 +19941,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -22854,7 +22866,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CONST != IS_CONST) {
 
@@ -22873,7 +22885,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -25090,7 +25102,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
@@ -25109,7 +25121,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -26368,7 +26380,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_UNUSED != IS_CONST) {
 
@@ -26387,7 +26399,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -26532,14 +26544,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NEW_SPEC_VAR_UNUSED_HANDLER(ZE
 		call = zend_vm_stack_push_call_frame(
 			ZEND_CALL_FUNCTION, (zend_function *) &zend_pass_function,
 			opline->extended_value, NULL);
-		static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
-		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_cache **) &dummy_handler);
+		static const zend_instrument_fcall_cache *dummy_handler = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handler);
 	} else {
 		if (EXPECTED(constructor->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&constructor->op_array))) {
 			init_func_run_time_cache(&constructor->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(constructor->common.instrument_cache))) {
-			zend_instrument_install_handlers(constructor);
+			zend_instrument_fcall_install(constructor);
 		}
 		/* We are not handling overloaded classes right now */
 		call = zend_vm_stack_push_call_frame(
@@ -28632,7 +28644,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CV != IS_CONST) {
 
@@ -28651,7 +28663,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -30700,7 +30712,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_S
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -30826,7 +30838,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CONST != IS_CONST) {
 
@@ -30845,7 +30857,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -32577,7 +32589,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_T
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -32703,7 +32715,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
@@ -32722,7 +32734,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -33125,7 +33137,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_UNUSED != IS_CONST) {
 
@@ -33144,7 +33156,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -33289,14 +33301,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NEW_SPEC_UNUSED_UNUSED_HANDLER
 		call = zend_vm_stack_push_call_frame(
 			ZEND_CALL_FUNCTION, (zend_function *) &zend_pass_function,
 			opline->extended_value, NULL);
-		static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
-		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_cache **) &dummy_handler);
+		static const zend_instrument_fcall_cache *dummy_handler = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handler);
 	} else {
 		if (EXPECTED(constructor->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&constructor->op_array))) {
 			init_func_run_time_cache(&constructor->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(constructor->common.instrument_cache))) {
-			zend_instrument_install_handlers(constructor);
+			zend_instrument_fcall_install(constructor);
 		}
 		/* We are not handling overloaded classes right now */
 		call = zend_vm_stack_push_call_frame(
@@ -34991,7 +35003,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -35117,7 +35129,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CV != IS_CONST) {
 
@@ -35136,7 +35148,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -35939,9 +35951,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -39857,7 +39870,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_S
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -43297,7 +43310,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_TMPVA
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -48182,7 +48195,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CV_HA
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -52522,9 +52535,10 @@ zend_leave_helper_SPEC_LABEL:
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -54016,9 +54030,10 @@ zend_leave_helper_SPEC_LABEL:
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -54302,9 +54317,10 @@ zend_leave_helper_SPEC_LABEL:
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -55376,9 +55392,10 @@ zend_leave_helper_SPEC_LABEL:
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 

--- a/configure.ac
+++ b/configure.ac
@@ -1462,7 +1462,8 @@ PHP_ADD_SOURCES(Zend, \
     zend_iterators.c zend_interfaces.c zend_exceptions.c zend_strtod.c zend_gc.c \
     zend_closures.c zend_weakrefs.c zend_float.c zend_string.c zend_signal.c zend_generators.c \
     zend_virtual_cwd.c zend_ast.c zend_objects.c zend_object_handlers.c zend_objects_API.c \
-    zend_default_classes.c zend_inheritance.c zend_smart_str.c zend_cpuinfo.c zend_gdb.c, \
+    zend_default_classes.c zend_inheritance.c zend_smart_str.c zend_cpuinfo.c zend_gdb.c \
+    zend_instrument.c, \
 	-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 
 dnl Selectively disable optimization due to high RAM usage during compiling the

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -202,6 +202,9 @@ static void zend_hash_clone_methods(HashTable *ht)
 			if (IN_ARENA(ZEND_MAP_PTR(new_entry->run_time_cache))) {
 				ZEND_MAP_PTR_INIT(new_entry->run_time_cache, ARENA_REALLOC(ZEND_MAP_PTR(new_entry->run_time_cache)));
 			}
+			if (IN_ARENA(ZEND_MAP_PTR(new_entry->instrument_cache))) {
+				ZEND_MAP_PTR_INIT(new_entry->instrument_cache, ARENA_REALLOC(ZEND_MAP_PTR(new_entry->instrument_cache)));
+			}
 			ZEND_MAP_PTR_INIT(new_entry->static_variables_ptr, &new_entry->static_variables);
 		}
 	}

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -584,6 +584,7 @@ static void zend_persist_op_array(zval *zv)
 	if (!ZCG(current_persistent_script)->corrupted) {
 		op_array->fn_flags |= ZEND_ACC_IMMUTABLE;
 		ZEND_MAP_PTR_NEW(op_array->run_time_cache);
+		ZEND_MAP_PTR_NEW(op_array->instrument_cache);
 		if (op_array->static_variables) {
 			ZEND_MAP_PTR_NEW(op_array->static_variables_ptr);
 		}
@@ -591,6 +592,8 @@ static void zend_persist_op_array(zval *zv)
 		ZEND_MAP_PTR_INIT(op_array->run_time_cache, ZCG(arena_mem));
 		ZCG(arena_mem) = (void*)(((char*)ZCG(arena_mem)) + ZEND_ALIGNED_SIZE(sizeof(void*)));
 		ZEND_MAP_PTR_SET(op_array->run_time_cache, NULL);
+		ZCG(arena_mem) = (void*)(((char*)ZCG(arena_mem)) + ZEND_ALIGNED_SIZE(sizeof(void*)));
+		ZEND_MAP_PTR_SET(op_array->instrument_cache, NULL);
 	}
 }
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1238,6 +1238,10 @@ int pdo_hash_methods(pdo_dbh_object_t *dbh_obj, int kind)
 			func.num_args = 0;
 			func.required_num_args = 0;
 		}
+
+		ZEND_MAP_PTR_INIT(func.instrument_cache, zend_arena_alloc(&CG(arena), sizeof(void*)));
+		ZEND_MAP_PTR_SET(func.instrument_cache, NULL);
+
 		zend_set_function_arg_flags((zend_function*)&func);
 		namelen = strlen(funcs->fname);
 		lc_name = emalloc(namelen+1);

--- a/main/main.c
+++ b/main/main.c
@@ -71,6 +71,7 @@
 #include "zend_highlight.h"
 #include "zend_extensions.h"
 #include "zend_ini.h"
+#include "zend_instrument.h"
 #include "zend_dtrace.h"
 
 #include "php_content_types.h"
@@ -2297,6 +2298,7 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 	   ahead of all other internals
 	 */
 	php_ini_register_extensions();
+	zend_instrument_init();
 	zend_startup_modules();
 
 	/* start Zend extensions */
@@ -2495,6 +2497,8 @@ void php_module_shutdown(void)
 		_set_invalid_parameter_handler(old_invalid_parameter_handler);
 	}
 #endif
+
+	zend_instrument_shutdown();
 }
 /* }}} */
 

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -236,7 +236,7 @@ ADD_SOURCES("Zend", "zend_language_parser.c zend_language_scanner.c \
 	zend_object_handlers.c zend_objects_API.c \
 	zend_default_classes.c zend_execute.c zend_strtod.c zend_gc.c zend_closures.c zend_weakrefs.c \
 	zend_float.c zend_string.c zend_generators.c zend_virtual_cwd.c zend_ast.c \
-	zend_inheritance.c zend_smart_str.c zend_cpuinfo.c");
+	zend_inheritance.c zend_smart_str.c zend_cpuinfo.c zend_instrument.c");
 
 ADD_FLAG("CFLAGS_BD_ZEND", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 if (VS_TOOLSET && VCVERS >= 1914) {


### PR DESCRIPTION
This is a new API that tries to get the benefits of `zend_execute_ex` without the C stack overflow issue. It allows extensions to register function-specific begin/end handlers when the function is called for the first time in a request. This is intended for use by deterministic profilers, tracers, debuggers, security auditing, etc.

An extension using the API can be found at [sammyk/observer](https://github.com/sammyk/observer).

We plan to do these changes:
- Split the API for userland and internal functions. It's reasonable to instrument only one or the other and the infrastructure itself is already split so it won't be hard to do.
- Move tests from sammyk/observer into the `zend_test` extension.

Some known limitations:
- The scope for this PR is limited to instrumenting function/method calls, but this can be extended to other areas such as instrumenting exception throw/catch monitoring or error tracking. A good rule of thumb is if `dtrace` does it then all extensions should also be able to do it.
- Bailouts such as `exit` or extensions that call `zend_bailout` will not trigger the function close handler yet. We are hoping `exit` will be [implemented via an exception](https://github.com/php/php-src/pull/5243) for PHP 8, but if not we will try handling this another way.
- JIT; we haven't attempted to handle this at all. Feedback on implementation strategy is welcome and we definitely want to support it.

