### PR TITLE
Optimize ZEND_COUNT opcodes on arrays in the jit

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3210,6 +3210,15 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 							goto jit_failure;
 						}
 						goto done;
+					case ZEND_COUNT:
+						op1_info = OP1_INFO();
+						if ((op1_info & (MAY_BE_UNDEF|MAY_BE_ANY|MAY_BE_REF)) != MAY_BE_ARRAY) {
+							break;
+						}
+						if (!zend_jit_count(&dasm_state, opline, op1_info, OP1_REG_ADDR(), zend_may_throw(opline, ssa_op, op_array, ssa))) {
+							goto jit_failure;
+						}
+						goto done;
 					case ZEND_FETCH_THIS:
 						if (!zend_jit_fetch_this(&dasm_state, opline, op_array, 0)) {
 							goto jit_failure;

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -9197,7 +9197,7 @@ static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t
 #endif
 		/* load constant address later */
 	} else if (func && op_array == &func->op_array) {
-		/* recursive call */		
+		/* recursive call */
 		if (!(func->op_array.fn_flags & ZEND_ACC_IMMUTABLE) ||
 		    (sizeof(void*) == 8 && !IS_SIGNED_32BIT(func))) {
 			|	mov r0, EX->func
@@ -14236,6 +14236,38 @@ static int zend_jit_strlen(dasm_State **Dst, const zend_op *opline, uint32_t op1
 		|	SET_ZVAL_LVAL res_addr, r0
 		|	SET_ZVAL_TYPE_INFO res_addr, IS_LONG
 		|	FREE_OP opline->op1_type, opline->op1, op1_info, 0, opline
+	}
+	return 1;
+}
+
+static int zend_jit_count(dasm_State **Dst, const zend_op *opline, uint32_t op1_info, zend_jit_addr op1_addr, int may_throw)
+{
+	zend_jit_addr res_addr = RES_ADDR();
+
+	if (opline->op1_type == IS_CONST) {
+		zval *zv;
+		zend_long count;
+
+		zv = RT_CONSTANT(opline, opline->op1);
+		ZEND_ASSERT(Z_TYPE_P(zv) == IS_ARRAY);
+		count = zend_hash_num_elements(Z_ARRVAL_P(zv));
+
+		|	SET_ZVAL_LVAL res_addr, count
+		|	SET_ZVAL_TYPE_INFO res_addr, IS_LONG
+	} else {
+		ZEND_ASSERT((op1_info & (MAY_BE_UNDEF|MAY_BE_ANY|MAY_BE_REF)) == MAY_BE_ARRAY);
+		// Note: See the implementation of ZEND_COUNT in Zend/zend_vm_def.h - arrays do not contain IS_UNDEF starting in php 8.1+.
+
+		|	GET_ZVAL_PTR r0, op1_addr
+		// Sign-extend the 32-bit value to a potentially 64-bit zend_long
+		|	mov eax, dword [r0 + offsetof(HashTable, nNumOfElements)]
+		|	SET_ZVAL_LVAL res_addr, r0
+		|	SET_ZVAL_TYPE_INFO res_addr, IS_LONG
+		|	FREE_OP opline->op1_type, opline->op1, op1_info, 0, opline
+	}
+
+	if (may_throw) {
+		return zend_jit_check_exception(Dst);
 	}
 	return 1;
 }

--- a/ext/opcache/tests/jit/count_001.phpt
+++ b/ext/opcache/tests/jit/count_001.phpt
@@ -1,0 +1,68 @@
+--TEST--
+JIT COUNT: 001
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+;opcache.jit_debug=1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+class ThrowsInDestructor {
+    public function __destruct() {
+        throw new RuntimeException("In destructor");
+    }
+}
+class C {
+    public static function create_array(int $i): array {
+        return array_fill(0, $i, new stdClass());
+    }
+
+    public static function foo() {
+        $x = [self::create_array(5)];
+        echo count(self::create_array(0)), "\n";
+        echo count(self::create_array(1)), "\n";
+        echo count($x[0]), "\n";
+        $a = [];
+        for ($i = 0; $i < 4; $i++) {
+            $a[] = $i;
+            echo count($a) . "\n";
+        }
+    }
+    public static function count_ref(array &$ref): int {
+        return count($ref);
+    }
+
+    public static function count_throws(): int {
+        $result = count([new ThrowsInDestructor()]);
+        echo "Unreachable\n";
+        return $result;
+    }
+}
+C::foo();
+$x = ['x', 'y', 'z', 'a', new stdClass()];
+echo C::count_ref($x), "\n";
+for ($i = 0; $i < 5; $i++) {
+    try {
+        echo C::count_throws(), "\n";
+    } catch (RuntimeException $e) {
+        printf("Caught %s\n", $e->getMessage());
+    }
+}
+
+--EXPECT--
+0
+1
+5
+1
+2
+3
+4
+5
+Caught In destructor
+Caught In destructor
+Caught In destructor
+Caught In destructor
+Caught In destructor


### PR DESCRIPTION
Avoid the overhead of a call and checking types
when the argument is definitely an array.
Avoid the overhead of gc when `__destruct` won't get called.

This seemed cheap enough to check for in the jit.

EDIT: Because of https://wiki.php.net/rfc/restrict_globals_usage
we can be sure in the ZEND_COUNT handler that the array count does not have to
be recomputed in php 8.1.

The below example took 0.854 seconds before the optimization,
and 0.564 seconds after the optimization, giving the same result

```php
<?php
/** @jit */
function bench_count(int $n): int {
    $total = 0;
    $arr = [];
    for ($i = 0; $i < $n; $i++) {
        $arr[] = $i;
        $total += count($arr);
    }
    return $total;
}

function main() {
    $n = 1000;
    $iterations = 50000;
    $start = microtime(true);
    $result = 0;
    for ($i = 0; $i < $iterations; $i++) {
        $result += bench_count($n);
    }
    $elapsed = microtime(true) - $start;

    printf("Total for n=%d, iterations=%d = %d, elapsed=%.3f\n", $n, $iterations, $result, $elapsed);
}
main();
```

Before

```asm
mov $0x7feb8cf8a858, %r15
mov $ZEND_COUNT_SPEC_CV_UNUSED_HANDLER, %rax
call *%rax
```

After (much faster without a function call)

```asm
mov 0x70(%r14), %rdi - Copy the count from the `zend_array*` pointer
mov %rdi, (%rax)     - Store the count in the destination's value
mov $0x4, 0x8(%rax)  - Store IS_LONG(4) in the destination's type
```
