### PR TITLE
Drop MYSQLND_DEBUG_MEMORY as it is always true

### DIFF
--- a/ext/mysqlnd/mysqlnd_alloc.c
+++ b/ext/mysqlnd/mysqlnd_alloc.c
@@ -22,8 +22,6 @@
 #include "mysqlnd_wireprotocol.h"
 #include "mysqlnd_statistics.h"
 
-#define MYSQLND_DEBUG_MEMORY 1
-
 static const char mysqlnd_emalloc_name[]	= "_mysqlnd_emalloc";
 static const char mysqlnd_pemalloc_name[]	= "_mysqlnd_pemalloc";
 static const char mysqlnd_ecalloc_name[]	= "_mysqlnd_ecalloc";
@@ -59,15 +57,6 @@ PHPAPI const char * mysqlnd_debug_std_no_trace_funcs[] =
 	mysqlnd_read_body_name,
 	NULL /* must be always last */
 };
-
-#if MYSQLND_DEBUG_MEMORY
-
-
-#if ZEND_DEBUG
-#else
-#define __zend_orig_filename "/unknown/unknown"
-#define __zend_orig_lineno   0
-#endif
 
 #define REAL_SIZE(s) (collect_memory_statistics? (s) + sizeof(size_t) : (s))
 #define REAL_PTR(p) (collect_memory_statistics && (p)? (((char *)(p)) - sizeof(size_t)) : (p))
@@ -611,11 +600,6 @@ static char * _mysqlnd_pestrdup(const char * const ptr, zend_bool persistent MYS
 }
 /* }}} */
 
-
-
-
-#endif /* MYSQLND_DEBUG_MEMORY */
-
 /* {{{ _mysqlnd_sprintf_free */
 static void _mysqlnd_sprintf_free(char * p)
 {
@@ -644,138 +628,8 @@ static int _mysqlnd_vsprintf(char ** pbuf, size_t max_len, const char * format, 
 /* }}} */
 
 
-
-#if MYSQLND_DEBUG_MEMORY == 0
-
-/* {{{ mysqlnd_zend_mm_emalloc */
-static void * mysqlnd_zend_mm_emalloc(size_t size MYSQLND_MEM_D)
-{
-	return emalloc_rel(size);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_pemalloc */
-static void * mysqlnd_zend_mm_pemalloc(size_t size, zend_bool persistent MYSQLND_MEM_D)
-{
-	return pemalloc_rel(size, persistent);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_ecalloc */
-static void * mysqlnd_zend_mm_ecalloc(unsigned int nmemb, size_t size MYSQLND_MEM_D)
-{
-	return ecalloc_rel(nmemb, size);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_pecalloc */
-static void * mysqlnd_zend_mm_pecalloc(unsigned int nmemb, size_t size, zend_bool persistent MYSQLND_MEM_D)
-{
-	return pecalloc_rel(nmemb, size, persistent);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_erealloc */
-static void * mysqlnd_zend_mm_erealloc(void *ptr, size_t new_size MYSQLND_MEM_D)
-{
-	return erealloc_rel(ptr, new_size);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_perealloc */
-static void * mysqlnd_zend_mm_perealloc(void *ptr, size_t new_size, zend_bool persistent MYSQLND_MEM_D)
-{
-	return perealloc_rel(ptr, new_size, persistent);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_efree */
-static void mysqlnd_zend_mm_efree(void * ptr MYSQLND_MEM_D)
-{
-	efree_rel(ptr);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_pefree */
-static void mysqlnd_zend_mm_pefree(void * ptr, zend_bool persistent MYSQLND_MEM_D)
-{
-	pefree_rel(ptr, persistent);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_malloc */
-static void * mysqlnd_zend_mm_malloc(size_t size MYSQLND_MEM_D)
-{
-	return malloc(size);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_calloc */
-static void * mysqlnd_zend_mm_calloc(unsigned int nmemb, size_t size MYSQLND_MEM_D)
-{
-	return calloc(nmemb, size);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_realloc */
-static void * mysqlnd_zend_mm_realloc(void * ptr, size_t new_size MYSQLND_MEM_D)
-{
-	return realloc(ptr, new_size);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_free */
-static void mysqlnd_zend_mm_free(void * ptr MYSQLND_MEM_D)
-{
-	free(ptr);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_pememdup */
-static char * mysqlnd_zend_mm_pememdup(const char * const ptr, size_t length, zend_bool persistent MYSQLND_MEM_D)
-{
-	char * dest = pemalloc_rel(length, persistent);
-	if (dest) {
-		memcpy(dest, ptr, length);
-	}
-	return dest;
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_pestrndup */
-static char * mysqlnd_zend_mm_pestrndup(const char * const ptr, size_t length, zend_bool persistent MYSQLND_MEM_D)
-{
-	return persistent? zend_strndup(ptr, length ) : estrndup_rel(ptr, length);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_zend_mm_pestrdup */
-static char * mysqlnd_zend_mm_pestrdup(const char * const ptr, zend_bool persistent MYSQLND_MEM_D)
-{
-	return pestrdup_rel(ptr, persistent);
-}
-/* }}} */
-
-#endif
-
-
 PHPAPI struct st_mysqlnd_allocator_methods mysqlnd_allocator =
 {
-#if MYSQLND_DEBUG_MEMORY == 1
 	_mysqlnd_emalloc,
 	_mysqlnd_pemalloc,
 	_mysqlnd_ecalloc,
@@ -794,24 +648,4 @@ PHPAPI struct st_mysqlnd_allocator_methods mysqlnd_allocator =
 	_mysqlnd_sprintf,
 	_mysqlnd_vsprintf,
 	_mysqlnd_sprintf_free
-#else
-	mysqlnd_zend_mm_emalloc,
-	mysqlnd_zend_mm_pemalloc,
-	mysqlnd_zend_mm_ecalloc,
-	mysqlnd_zend_mm_pecalloc,
-	mysqlnd_zend_mm_erealloc,
-	mysqlnd_zend_mm_perealloc,
-	mysqlnd_zend_mm_efree,
-	mysqlnd_zend_mm_pefree,
-	mysqlnd_zend_mm_malloc,
-	mysqlnd_zend_mm_calloc,
-	mysqlnd_zend_mm_realloc,
-	mysqlnd_zend_mm_free,
-	mysqlnd_zend_mm_pememdup,
-	mysqlnd_zend_mm_pestrndup,
-	mysqlnd_zend_mm_pestrdup,
-	_mysqlnd_sprintf,
-	_mysqlnd_vsprintf,
-	_mysqlnd_sprintf_free,
-#endif
 };


### PR DESCRIPTION
Also change one ZEND_DEBUG to PHP_DEBUG to be more consistent with the rest of the file

Another approach would be to change the ``#if MYSQLND_DEBUG_MEMORY`` to ``#if PHP_DEBUG`` which could then clean-up some other preprocessor macros which enable more behaviour if we are in a debug build.