### PR TITLE
Drop '#if 0' in mysqlnd_debug() from the MySQLnd extension

### DIFF
--- a/ext/mysqli/tests/mysqli_debug_control_string.phpt
+++ b/ext/mysqli/tests/mysqli_debug_control_string.phpt
@@ -73,5 +73,62 @@ if (!$IS_MYSQLND)
         print "libmysql/DBUG package prints some debug info here."
 ?>
 --EXPECTF--
+Warning: mysqli_debug(): Unrecognized format ',' in %s on line %d
+
+Warning: mysqli_debug(): Consecutive semicolons at position 0 in %s on line %d
 [023][control string '%s'] Trace file has not been written.
+
+Warning: mysqli_debug(): Colon expected, 'b' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, 'c' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, 'B' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, 'C' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, ',' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, '1' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, '2' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, '3' found in %s on line %d
+
+Warning: mysqli_debug(): Unrecognized format 'b' in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, 'B' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, 'C' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, ',' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, '1' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, '2' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, '3' found in %s on line %d
+
+Warning: mysqli_debug(): Unrecognized format 'b' in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, ';' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, ';' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, 'B' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, 'C' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, ',' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, '1' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, '2' found in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, '3' found in %s on line %d
+
+Warning: mysqli_debug(): Unrecognized format 'b' in %s on line %d
+
+Warning: mysqli_debug(): Colon expected, ';' found in %s on line %d
+
+Warning: mysqli_debug(): Unrecognized format 'z' in %s on line %d
 done%s

--- a/ext/mysqlnd/mysqlnd_debug.c
+++ b/ext/mysqlnd/mysqlnd_debug.c
@@ -543,11 +543,9 @@ MYSQLND_METHOD(mysqlnd_debug, set_mode)(MYSQLND_DEBUG * self, const char * const
 				state = PARSER_WAIT_COLON;
 				break;
 			case ':':
-#if 0
 				if (state != PARSER_WAIT_COLON) {
 					php_error_docref(NULL, E_WARNING, "Consecutive semicolons at position %u", i);
 				}
-#endif
 				state = PARSER_WAIT_MODIFIER;
 				break;
 			case 'f': /* limit output to these functions */
@@ -581,10 +579,8 @@ MYSQLND_METHOD(mysqlnd_debug, set_mode)(MYSQLND_DEBUG * self, const char * const
 					}
 					i = j;
 				} else {
-#if 0
 					php_error_docref(NULL, E_WARNING,
 									 "Expected list of functions for '%c' found none", mode[i]);
-#endif
 				}
 				state = PARSER_WAIT_COLON;
 				break;
@@ -661,9 +657,7 @@ MYSQLND_METHOD(mysqlnd_debug, set_mode)(MYSQLND_DEBUG * self, const char * const
 				break;
 			default:
 				if (state == PARSER_WAIT_MODIFIER) {
-#if 0
 					php_error_docref(NULL, E_WARNING, "Unrecognized format '%c'", mode[i]);
-#endif
 					if (i+1 < mode_len && mode[i+1] == ',') {
 						i+= 2;
 						while (i < mode_len) {
@@ -675,9 +669,7 @@ MYSQLND_METHOD(mysqlnd_debug, set_mode)(MYSQLND_DEBUG * self, const char * const
 					}
 					state = PARSER_WAIT_COLON;
 				} else if (state == PARSER_WAIT_COLON) {
-#if 0
 					php_error_docref(NULL, E_WARNING, "Colon expected, '%c' found", mode[i]);
-#endif
 				}
 				break;
 		}


### PR DESCRIPTION
I'm pretty confused as to why this part was being excluded as this seems to be valuable debug information.

We may want to drop the ``#if`` checks completely.