### PR TITLE
Reference runtime-defined functions from literals

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1071,21 +1071,11 @@ static zend_never_inline ZEND_COLD ZEND_NORETURN void do_bind_function_error(zen
 	}
 }
 
-ZEND_API int do_bind_function(zval *lcname) /* {{{ */
+ZEND_API int do_bind_function(zend_function *func, zval *lcname) /* {{{ */
 {
-	zend_function *function;
-	zval *rtd_key, *zv;
-
-	rtd_key = lcname + 1;
-	zv = zend_hash_find_ex(EG(function_table), Z_STR_P(rtd_key), 1);
-	if (UNEXPECTED(!zv)) {
-		do_bind_function_error(Z_STR_P(lcname), NULL, 0);
-		return FAILURE;
-	}
-	function = (zend_function*)Z_PTR_P(zv);
-	zv = zend_hash_set_bucket_key(EG(function_table), (Bucket*)zv, Z_STR_P(lcname));
-	if (UNEXPECTED(!zv)) {
-		do_bind_function_error(Z_STR_P(lcname), &function->op_array, 0);
+	zend_function *added_func = zend_hash_add_ptr(EG(function_table), Z_STR_P(lcname), func);
+	if (UNEXPECTED(!added_func)) {
+		do_bind_function_error(Z_STR_P(lcname), &func->op_array, 0);
 		return FAILURE;
 	}
 	return SUCCESS;
@@ -6176,7 +6166,7 @@ zend_string *zend_begin_method_decl(zend_op_array *op_array, zend_string *name, 
 
 static void zend_begin_func_decl(znode *result, zend_op_array *op_array, zend_ast_decl *decl, zend_bool toplevel) /* {{{ */
 {
-	zend_string *unqualified_name, *name, *lcname, *key;
+	zend_string *unqualified_name, *name, *lcname;
 	zend_op *opline;
 
 	unqualified_name = decl->name;
@@ -6212,24 +6202,16 @@ static void zend_begin_func_decl(znode *result, zend_op_array *op_array, zend_as
 		return;
 	}
 
-	key = zend_build_runtime_definition_key(lcname, decl->start_lineno);
-	if (!zend_hash_add_ptr(CG(function_table), key, op_array)) {
-		zend_error_noreturn(E_ERROR,
-			"Runtime definition key collision for function %s. This is a bug", ZSTR_VAL(name));
-	}
+	znode func_node;
+	func_node.op_type = IS_CONST;
+	ZVAL_NEW_FUNC_REF(&func_node.u.constant, (zend_function *) op_array);
 
 	if (op_array->fn_flags & ZEND_ACC_CLOSURE) {
-		opline = zend_emit_op_tmp(result, ZEND_DECLARE_LAMBDA_FUNCTION, NULL, NULL);
-		opline->extended_value = zend_alloc_cache_slot();
-		opline->op1_type = IS_CONST;
-		LITERAL_STR(opline->op1, key);
+		zend_emit_op_tmp(result, ZEND_DECLARE_LAMBDA_FUNCTION, &func_node, NULL);
 	} else {
-		opline = get_next_op();
-		opline->opcode = ZEND_DECLARE_FUNCTION;
-		opline->op1_type = IS_CONST;
-		LITERAL_STR(opline->op1, zend_string_copy(lcname));
-		/* RTD key is placed after lcname literal in op1 */
-		zend_add_literal_string(&key);
+		opline = zend_emit_op(NULL, ZEND_DECLARE_FUNCTION, &func_node, NULL);
+		opline->op2_type = IS_CONST;
+		LITERAL_STR(opline->op2, zend_string_copy(lcname));
 	}
 	zend_string_release_ex(lcname, 0);
 }

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -746,7 +746,7 @@ zend_bool zend_handle_encoding_declaration(zend_ast *ast);
 /* parser-driven code generators */
 void zend_do_free(znode *op1);
 
-ZEND_API int do_bind_function(zval *lcname);
+ZEND_API int do_bind_function(zend_function *func, zval *lcname);
 ZEND_API int do_bind_class(zval *lcname, zend_string *lc_parent_name);
 ZEND_API uint32_t zend_build_delayed_early_binding_list(const zend_op_array *op_array);
 ZEND_API void zend_do_delayed_early_binding(zend_op_array *op_array, uint32_t first_early_binding_opline);

--- a/Zend/zend_type_info.h
+++ b/Zend/zend_type_info.h
@@ -60,6 +60,7 @@
 #define MAY_BE_ARRAY_KEY_STRING     (1<<22)
 #define MAY_BE_ARRAY_KEY_ANY        (MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_KEY_STRING)
 
-#define MAY_BE_CLASS                (1<<23)
+#define MAY_BE_SPECIAL              (1<<23)
+#define MAY_BE_CLASS                MAY_BE_SPECIAL
 
 #endif /* ZEND_TYPE_INFO_H */

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7188,7 +7188,9 @@ ZEND_VM_HANDLER(141, ZEND_DECLARE_FUNCTION, ANY, ANY)
 	USE_OPLINE
 
 	SAVE_OPLINE();
-	do_bind_function(RT_CONSTANT(opline, opline->op1));
+	do_bind_function(
+		Z_FUNC_REF_P(RT_CONSTANT(opline, opline->op1))->func,
+		RT_CONSTANT(opline, opline->op2));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -7451,19 +7453,9 @@ ZEND_VM_HANDLER(143, ZEND_DECLARE_CONST, CONST, CONST)
 ZEND_VM_HANDLER(142, ZEND_DECLARE_LAMBDA_FUNCTION, CONST, UNUSED, CACHE_SLOT)
 {
 	USE_OPLINE
-	zend_function *func;
-	zval *zfunc;
+	zend_function *func = Z_FUNC_REF_P(RT_CONSTANT(opline, opline->op1))->func;
 	zval *object;
 	zend_class_entry *called_scope;
-
-	func = CACHED_PTR(opline->extended_value);
-	if (UNEXPECTED(func == NULL)) {
-		zfunc = zend_hash_find_ex(EG(function_table), Z_STR_P(RT_CONSTANT(opline, opline->op1)), 1);
-		ZEND_ASSERT(zfunc != NULL);
-		func = Z_FUNC_P(zfunc);
-		ZEND_ASSERT(func->type == ZEND_USER_FUNCTION);
-		CACHE_PTR(opline->extended_value, func);
-	}
 
 	if (Z_TYPE(EX(This)) == IS_OBJECT) {
 		called_scope = Z_OBJCE(EX(This));

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2439,7 +2439,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DECLARE_FUNCTION_SPEC_HANDLER(
 	USE_OPLINE
 
 	SAVE_OPLINE();
-	do_bind_function(RT_CONSTANT(opline, opline->op1));
+	do_bind_function(
+		Z_FUNC_REF_P(RT_CONSTANT(opline, opline->op1))->func,
+		RT_CONSTANT(opline, opline->op2));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -9100,19 +9102,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_CONST_U
 static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DECLARE_LAMBDA_FUNCTION_SPEC_CONST_UNUSED_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
 {
 	USE_OPLINE
-	zend_function *func;
-	zval *zfunc;
+	zend_function *func = Z_FUNC_REF_P(RT_CONSTANT(opline, opline->op1))->func;
 	zval *object;
 	zend_class_entry *called_scope;
-
-	func = CACHED_PTR(opline->extended_value);
-	if (UNEXPECTED(func == NULL)) {
-		zfunc = zend_hash_find_ex(EG(function_table), Z_STR_P(RT_CONSTANT(opline, opline->op1)), 1);
-		ZEND_ASSERT(zfunc != NULL);
-		func = Z_FUNC_P(zfunc);
-		ZEND_ASSERT(func->type == ZEND_USER_FUNCTION);
-		CACHE_PTR(opline->extended_value, func);
-	}
 
 	if (Z_TYPE(EX(This)) == IS_OBJECT) {
 		called_scope = Z_OBJCE(EX(This));

--- a/ext/opcache/Optimizer/compact_literals.c
+++ b/ext/opcache/Optimizer/compact_literals.c
@@ -238,9 +238,6 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 				case ZEND_RECV_INIT:
 					LITERAL_INFO(opline->op2.constant, LITERAL_VALUE, 1);
 					break;
-				case ZEND_DECLARE_FUNCTION:
-					LITERAL_INFO(opline->op1.constant, LITERAL_VALUE, 2);
-					break;
 				case ZEND_DECLARE_CLASS:
 				case ZEND_DECLARE_CLASS_DELAYED:
 					LITERAL_INFO(opline->op1.constant, LITERAL_VALUE, 2);
@@ -773,7 +770,6 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 						bind_var_slot[opline->op2.constant] = opline->extended_value;
 					}
 					break;
-				case ZEND_DECLARE_LAMBDA_FUNCTION:
 				case ZEND_DECLARE_ANON_CLASS:
 				case ZEND_DECLARE_CLASS_DELAYED:
 					opline->extended_value = cache_size;

--- a/ext/opcache/Optimizer/zend_dump.c
+++ b/ext/opcache/Optimizer/zend_dump.c
@@ -72,6 +72,9 @@ void zend_dump_const(const zval *zv)
 		case IS_ARRAY:
 			fprintf(stderr, " array(...)");
 			break;
+		case IS_FUNC_REF:
+			fprintf(stderr, " func(%p)", Z_FUNC_REF_P(zv)->func);
+			break;
 		default:
 			fprintf(stderr, " zval(type=%d)", Z_TYPE_P(zv));
 			break;

--- a/ext/opcache/Optimizer/zend_inference.h
+++ b/ext/opcache/Optimizer/zend_inference.h
@@ -157,6 +157,8 @@ DEFINE_SSA_OP_RANGE_OVERFLOW(op2)
 static zend_always_inline uint32_t _const_op_type(const zval *zv) {
 	if (Z_TYPE_P(zv) == IS_CONSTANT_AST) {
 		return MAY_BE_RC1 | MAY_BE_RCN | MAY_BE_ANY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_ANY;
+	} else if (Z_TYPE_P(zv) == IS_FUNC_REF) {
+		return MAY_BE_RC1 | MAY_BE_RCN | MAY_BE_SPECIAL;
 	} else if (Z_TYPE_P(zv) == IS_ARRAY) {
 		HashTable *ht = Z_ARRVAL_P(zv);
 		uint32_t tmp = MAY_BE_ARRAY;

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -438,20 +438,7 @@ static void zend_accel_function_hash_copy(HashTable *target, HashTable *source)
 		ZEND_ASSERT(p->key);
 		t = zend_hash_find_ex(target, p->key, 1);
 		if (UNEXPECTED(t != NULL)) {
-			if (EXPECTED(ZSTR_LEN(p->key) > 0) && EXPECTED(ZSTR_VAL(p->key)[0] == 0)) {
-				/* Runtime definition key. There are two circumstances under which the key can
-				 * already be defined:
-				 *  1. The file has been re-included without being changed in the meantime. In
-				 *     this case we can keep the old value, because we know that the definition
-				 *     hasn't changed.
-				 *  2. The file has been changed in the meantime, but the RTD key ends up colliding.
-				 *     This would be a bug.
-				 * As we can't distinguish these cases, we assume that it is 1. and keep the old
-				 * value. */
-				continue;
-			} else {
-				goto failure;
-			}
+			goto failure;
 		} else {
 			_zend_hash_append_ptr(target, p->key, Z_PTR(p->val));
 		}
@@ -490,12 +477,7 @@ static void zend_accel_function_hash_copy_from_shm(HashTable *target, HashTable 
 		ZEND_ASSERT(p->key);
 		t = zend_hash_find_ex(target, p->key, 1);
 		if (UNEXPECTED(t != NULL)) {
-			if (EXPECTED(ZSTR_LEN(p->key) > 0) && EXPECTED(ZSTR_VAL(p->key)[0] == 0)) {
-				/* See comment in zend_accel_function_hash_copy(). */
-				continue;
-			} else {
-				goto failure;
-			}
+			goto failure;
 		} else {
 			_zend_hash_append_ptr_ex(target, p->key, Z_PTR(p->val), 1);
 		}
@@ -534,7 +516,15 @@ static void zend_accel_class_hash_copy(HashTable *target, HashTable *source)
 		t = zend_hash_find_ex(target, p->key, 1);
 		if (UNEXPECTED(t != NULL)) {
 			if (EXPECTED(ZSTR_LEN(p->key) > 0) && EXPECTED(ZSTR_VAL(p->key)[0] == 0)) {
-				/* See comment in zend_accel_function_hash_copy(). */
+				/* Runtime definition key. There are two circumstances under which the key can
+				 * already be defined:
+				 *  1. The file has been re-included without being changed in the meantime. In
+				 *     this case we can keep the old value, because we know that the definition
+				 *     hasn't changed.
+				 *  2. The file has been changed in the meantime, but the RTD key ends up colliding.
+				 *     This would be a bug.
+				 * As we can't distinguish these cases, we assume that it is 1. and keep the old
+				 * value. */
 				continue;
 			} else if (UNEXPECTED(!ZCG(accel_directives).ignore_dups)) {
 				zend_class_entry *ce1 = Z_PTR(p->val);
@@ -571,7 +561,7 @@ static void zend_accel_class_hash_copy_from_shm(HashTable *target, HashTable *so
 		t = zend_hash_find_ex(target, p->key, 1);
 		if (UNEXPECTED(t != NULL)) {
 			if (EXPECTED(ZSTR_LEN(p->key) > 0) && EXPECTED(ZSTR_VAL(p->key)[0] == 0)) {
-				/* See comment in zend_accel_function_hash_copy(). */
+				/* See comment in zend_accel_class_hash_copy(). */
 				continue;
 			} else if (UNEXPECTED(!ZCG(accel_directives).ignore_dups)) {
 				zend_class_entry *ce1 = Z_PTR(p->val);

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -54,6 +54,7 @@
 	} while (0)
 
 static void zend_persist_zval_calc(zval *z);
+static void zend_persist_op_array_calc(zval *zv);
 
 static void zend_hash_persist_calc(HashTable *ht)
 {
@@ -141,6 +142,14 @@ static void zend_persist_zval_calc(zval *z)
 				zend_persist_ast_calc(Z_ASTVAL_P(z));
 			}
 			break;
+		case IS_FUNC_REF:
+			size = zend_shared_memdup_size(Z_FUNC_REF_P(z), sizeof(zend_func_ref));
+			if (size) {
+				zval tmp;
+				ZVAL_PTR(&tmp, Z_FUNC_REF_P(z)->func);
+				zend_persist_op_array_calc(&tmp);
+				ADD_SIZE(size);
+			}
 		default:
 			ZEND_ASSERT(Z_TYPE_P(z) != IS_OBJECT);
 			ZEND_ASSERT(Z_TYPE_P(z) != IS_RESOURCE);


### PR DESCRIPTION
Currently, we handle closures and conditionally defined functions by inserting them into the function table with an RTD key. There are two issues with this:

1. RTD key collisions. It is hard to ensure that RTD keys unique if opcache is involved. Our changes in 7.4 were insufficient, see https://bugs.php.net/bug.php?id=79603.
2. Leaks. Function templates that end up being unused or not used anymore are never released and leak, see https://bugs.php.net/bug.php?id=76982. This is not much of a problem in web scenarios, but may result in huge leaks in unit tests for example.

This patch addresses this by storing a direct reference to the function as CONST opcode literal. We add a small `zend_func_ref` wrapper to allow zval storage in a way that is integrated with the existing refcounting system.

This naturally avoids RTD key collisions, because we no longer use an RTD key for this purpose. It partially avoids the memory leak as well. Most of the function structures will now get freed and we only leak the arena allocated parts. Avoiding arena-allocated parts for runtime-defined functions would be a followup.

There are still two problems here:

 * [ ] As the functions are no longer part of the function_table, they'll get skipped by the optimizer.
 * [ ] This only works if the function is immutable in opcache. I think this is currently not fully guaranteed, but I'm not sure under what circumstances free functions can be non-immutable in opcache.

Unfortunately this approach will not extend to classes, because those are often not immutable...

@dstogov What do you think about this?