### PR TITLE
Fix INI setting member name

### DIFF
--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -71,7 +71,7 @@ static PHP_INI_MH(OnUpdateEol)
 
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("phpdbg.path", "", PHP_INI_SYSTEM | PHP_INI_PERDIR, OnUpdateString, socket_path, zend_phpdbg_globals, phpdbg_globals)
-	STD_PHP_INI_ENTRY("phpdbg.eol", "2", PHP_INI_ALL, OnUpdateEol, socket_path, zend_phpdbg_globals, phpdbg_globals)
+	STD_PHP_INI_ENTRY("phpdbg.eol", "2", PHP_INI_ALL, OnUpdateEol, eol, zend_phpdbg_globals, phpdbg_globals)
 PHP_INI_END()
 
 static zend_bool phpdbg_booted = 0;


### PR DESCRIPTION
Since the member is not used in `OnUpdateEol()` that's not really an
issue, but still it's confusing to apparently have two INI settings
targeting the same member.