### PR TITLE
Fix phpdbg on Windows and enable test suite

### DIFF
--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -61350,6 +61350,7 @@ void zend_vm_dtor(void)
 	if (zend_handlers_table) {
 		zend_hash_destroy(zend_handlers_table);
 		free(zend_handlers_table);
+		zend_handlers_table = NULL;
 	}
 }
 

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -75,6 +75,7 @@ void zend_vm_dtor(void)
 	if (zend_handlers_table) {
 		zend_hash_destroy(zend_handlers_table);
 		free(zend_handlers_table);
+		zend_handlers_table = NULL;
 	}
 }
 

--- a/appveyor/test_task.bat
+++ b/appveyor/test_task.bat
@@ -91,6 +91,10 @@ if not exist "%PHP_BUILD_CACHE_ENCHANT_DICT_DIR%\en_US.aff" (
 mkdir %USERPROFILE%\enchant\myspell
 copy %PHP_BUILD_CACHE_ENCHANT_DICT_DIR%\* %USERPROFILE%\enchant\myspell
 
+set TEST_PHPDBG_EXECUTABLE=%PHP_BUILD_OBJ_DIR%\Release
+if "%THREAD_SAFE%" equ "1" set TEST_PHPDBG_EXECUTABLE=%TEST_PHPDBG_EXECUTABLE%_TS
+set TEST_PHPDBG_EXECUTABLE=%TEST_PHPDBG_EXECUTABLE%\phpdbg.exe
+
 mkdir c:\tests_tmp
 
 set TEST_PHP_JUNIT=c:\junit.out.xml

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1341,10 +1341,12 @@ php_stream *phpdbg_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *
 	if (!strncasecmp(path, "stdin", 6) && PHPDBG_G(stdin_file)) {
 		php_stream *stream = php_stream_fopen_from_fd(dup(fileno(PHPDBG_G(stdin_file))), "r", NULL);
 #ifdef PHP_WIN32
-		zval *blocking_pipes = php_stream_context_get_option(context, "pipe", "blocking");
-		if (blocking_pipes) {
-			convert_to_long(blocking_pipes);
-			php_stream_set_option(stream, PHP_STREAM_OPTION_PIPE_BLOCKING, Z_LVAL_P(blocking_pipes), NULL);
+		if (context != NULL) {
+			zval *blocking_pipes = php_stream_context_get_option(context, "pipe", "blocking");
+			if (blocking_pipes) {
+				convert_to_long(blocking_pipes);
+				php_stream_set_option(stream, PHP_STREAM_OPTION_PIPE_BLOCKING, Z_LVAL_P(blocking_pipes), NULL);
+			}
 		}
 #endif
 		return stream;
@@ -2058,6 +2060,8 @@ phpdbg_out:
 	}
 phpdbg_out:
 #endif
+
+		phpdbg_purge_watchpoint_tree();
 
 		if (first_command) {
 			free(first_command);

--- a/sapi/phpdbg/phpdbg_cmd.c
+++ b/sapi/phpdbg/phpdbg_cmd.c
@@ -823,7 +823,7 @@ PHPDBG_API int phpdbg_ask_user_permission(const char *question) {
 
 		while (1) {
 			phpdbg_consume_stdin_line(buf);
-			if (buf[1] == '\n' && (buf[0] == 'y' || buf[0] == 'n')) {
+			if ((buf[1] == '\n' || (buf[1] == '\r' && buf[2] == '\n')) && (buf[0] == 'y' || buf[0] == 'n')) {
 				if (buf[0] == 'y') {
 					return SUCCESS;
 				}

--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -357,8 +357,11 @@ PHPDBG_API int phpdbg_get_terminal_height(void) /* {{{ */
 #ifdef _WIN32
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
 
-	GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-	lines = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+	if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi)) {
+		lines = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+	} else {
+		lines = 40;
+	}
 #elif defined(HAVE_SYS_IOCTL_H) && defined(TIOCGWINSZ)
 	struct winsize w;
 

--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -1406,6 +1406,8 @@ void phpdbg_setup_watchpoints(void) {
 	zend_hash_init(PHPDBG_G(watchlist_mem), phpdbg_pagesize / (sizeof(Bucket) + sizeof(uint32_t)), NULL, NULL, 1);
 	PHPDBG_G(watchlist_mem_backup) = malloc(phpdbg_pagesize > sizeof(HashTable) ? phpdbg_pagesize : sizeof(HashTable));
 	zend_hash_init(PHPDBG_G(watchlist_mem_backup), phpdbg_pagesize / (sizeof(Bucket) + sizeof(uint32_t)), NULL, NULL, 1);
+
+	PHPDBG_G(watch_tmp) = NULL;
 }
 
 void phpdbg_destroy_watchpoints(void) {
@@ -1432,4 +1434,14 @@ void phpdbg_destroy_watchpoints(void) {
 	free(PHPDBG_G(watchlist_mem));
 	zend_hash_destroy(PHPDBG_G(watchlist_mem_backup));
 	free(PHPDBG_G(watchlist_mem_backup));
+}
+
+void phpdbg_purge_watchpoint_tree(void) {
+	phpdbg_btree_position pos;
+	phpdbg_btree_result *res;
+
+	pos = phpdbg_btree_find_between(&PHPDBG_G(watchpoint_tree), 0, -1);
+	while ((res = phpdbg_btree_next(&pos))) {
+		phpdbg_deactivate_watchpoint(res->ptr);
+	}
 }

--- a/sapi/phpdbg/phpdbg_watch.h
+++ b/sapi/phpdbg/phpdbg_watch.h
@@ -119,6 +119,7 @@ typedef struct {
 
 void phpdbg_setup_watchpoints(void);
 void phpdbg_destroy_watchpoints(void);
+void phpdbg_purge_watchpoint_tree(void);
 
 #ifndef _WIN32
 int phpdbg_watchpoint_segfault_handler(siginfo_t *info, void *context);

--- a/sapi/phpdbg/tests/phpdbg_get_executable_stream_wrapper.phpt
+++ b/sapi/phpdbg/tests/phpdbg_get_executable_stream_wrapper.phpt
@@ -70,7 +70,7 @@ stream_wrapper_register('wrapper', StreamWrapper::class);
  * Next, we include a PHP file that contains executable lines, via the stream
  * wrapper.
  */
-$filename = __DIR__ . '/phpdbg_get_executable_stream_wrapper.inc';
+$filename = __DIR__ . DIRECTORY_SEPARATOR . 'phpdbg_get_executable_stream_wrapper.inc';
 require 'wrapper://' . $filename;
 
 /**


### PR DESCRIPTION
I've fixed some Windows only phpdbg bugs and test issues, and enabled the phpdbg test suite on AppVeyor. For now, only if OPcache is disabled, because that causes a lot of assertion faillures locally under PHP 7.4 (master doesn't seem to have these issues). Actually, the bug fixes should target PHP-7.3, which is affected as well, but I get several other test failures there. So that needs further investigation.