### PR TITLE
Add support for replaying warnings in opcache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,22 +12,26 @@ trigger:
       - UPGRADING.INTERNALS
 
 jobs:
-  - template: azure/job.yml
+  - template: azure/file_cache_job.yml
     parameters:
-      configurationName: DEBUG_NTS
+      configurationName: DEBUG_NTS_FILE_CACHE
       configurationParameters: '--enable-debug --disable-zts'
-  - template: azure/job.yml
-    parameters:
-      configurationName: RELEASE_ZTS
-      configurationParameters: '--disable-debug --enable-zts'
-  - template: azure/i386/job.yml
-    parameters:
-      configurationName: I386_DEBUG_ZTS
-      configurationParameters: '--enable-debug --enable-zts'
-  - template: azure/macos/job.yml
-    parameters:
-      configurationName: MACOS_DEBUG_NTS
-      configurationParameters: '--enable-debug --disable-zts'
+      #  - template: azure/job.yml
+      #    parameters:
+      #      configurationName: DEBUG_NTS
+      #      configurationParameters: '--enable-debug --disable-zts'
+      #  - template: azure/job.yml
+      #    parameters:
+      #      configurationName: RELEASE_ZTS
+      #      configurationParameters: '--disable-debug --enable-zts'
+      #  - template: azure/i386/job.yml
+      #    parameters:
+      #      configurationName: I386_DEBUG_ZTS
+      #      configurationParameters: '--enable-debug --enable-zts'
+      #  - template: azure/macos/job.yml
+      #    parameters:
+      #      configurationName: MACOS_DEBUG_NTS
+      #      configurationParameters: '--enable-debug --disable-zts'
   - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
     - template: azure/job.yml
       parameters:

--- a/azure/file_cache_job.yml
+++ b/azure/file_cache_job.yml
@@ -1,0 +1,60 @@
+parameters:
+  configurationName: ''
+  configurationParameters: ''
+  runTestsParameters: ''
+  timeoutInMinutes: 60
+
+jobs:
+  - job: ${{ parameters.configurationName }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+    - template: apt.yml
+    - template: configure.yml
+      parameters:
+        configurationParameters: ${{ parameters.configurationParameters }}
+    - script: make -j$(/usr/bin/nproc) >/dev/null
+      displayName: 'Make Build'
+    - template: install.yml
+    - script: |
+        set -e
+        sudo service mysql start
+        mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS test"
+        sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+        sudo -u postgres psql -c "CREATE DATABASE test;"
+      displayName: 'Setup'
+    - template: test.yml
+      parameters:
+        configurationName: ${{ parameters.configurationName }}
+        runTestsName: 'File Cache (prime)'
+        runTestsParameters: >-
+          ${{ parameters.runTestsParameters }}
+          -d zend_extension=opcache.so
+          --file-cache-prime
+    - template: test.yml
+      parameters:
+        configurationName: ${{ parameters.configurationName }}
+        runTestsName: 'File Cache (use)'
+        runTestsParameters: >-
+          ${{ parameters.runTestsParameters }}
+          -d zend_extension=opcache.so
+          --file-cache-use
+    - template: test.yml
+      parameters:
+        configurationName: ${{ parameters.configurationName }}
+        runTestsName: 'File Cache Only (prime)'
+        runTestsParameters: >-
+          ${{ parameters.runTestsParameters }}
+          -d zend_extension=opcache.so
+          --file-cache-prime
+          -d opcache.file_cache_only=1
+    - template: test.yml
+      parameters:
+        configurationName: ${{ parameters.configurationName }}
+        runTestsName: 'File Cache Only (use)'
+        runTestsParameters: >-
+          ${{ parameters.runTestsParameters }}
+          -d zend_extension=opcache.so
+          --file-cache-use
+          -d opcache.file_cache_only=1

--- a/ext/ffi/tests/300.phpt
+++ b/ext/ffi/tests/300.phpt
@@ -10,6 +10,7 @@ opcache.enable=1
 opcache.enable_cli=1
 opcache.optimization_level=-1
 opcache.preload={PWD}/preload.inc
+opcache.file_cache_only=0
 --FILE--
 <?php
 $ffi = FFI::scope("TEST_300");

--- a/ext/phar/tests/create_new_and_modify.phpt
+++ b/ext/phar/tests/create_new_and_modify.phpt
@@ -5,6 +5,7 @@ Phar: create and modify phar
 --INI--
 phar.readonly=0
 phar.require_hash=1
+opcache.validate_timestamps=1
 --FILE--
 <?php
 

--- a/ext/phar/tests/delete_in_phar.phpt
+++ b/ext/phar/tests/delete_in_phar.phpt
@@ -5,6 +5,7 @@ Phar: delete a file within a .phar
 --INI--
 phar.readonly=0
 phar.require_hash=0
+opcache.validate_timestamps=1
 --FILE--
 <?php
 $fname = __DIR__ . '/' . basename(__FILE__, '.php') . '.phar.php';

--- a/ext/phar/tests/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/delete_in_phar_confirm.phpt
@@ -5,6 +5,7 @@ Phar: delete a file within a .phar (confirm disk file is changed)
 --INI--
 phar.readonly=0
 phar.require_hash=0
+opcache.validate_timestamps=1
 --FILE--
 <?php
 $fname = __DIR__ . '/' . basename(__FILE__, '.php') . '.phar.php';

--- a/ext/phar/tests/front.phar.phpt
+++ b/ext/phar/tests/front.phar.phpt
@@ -2,6 +2,7 @@
 Phar front controller with mounted external file
 --INI--
 default_charset=UTF-8
+opcache.validate_timestamps=1
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 --ENV--

--- a/ext/phar/tests/tar/create_new_and_modify.phpt
+++ b/ext/phar/tests/tar/create_new_and_modify.phpt
@@ -4,6 +4,7 @@ Phar: create and modify tar-based phar
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 --INI--
 phar.readonly=0
+opcache.validate_timestamps=1
 --FILE--
 <?php
 

--- a/ext/phar/tests/tar/delete_in_phar.phpt
+++ b/ext/phar/tests/tar/delete_in_phar.phpt
@@ -5,6 +5,7 @@ Phar: delete a file within a tar-based .phar
 --INI--
 phar.readonly=0
 phar.require_hash=0
+opcache.validate_timestamps=1
 --FILE--
 <?php
 

--- a/ext/phar/tests/tar/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/tar/delete_in_phar_confirm.phpt
@@ -5,6 +5,7 @@ Phar: delete a file within a tar-based .phar (confirm disk file is changed)
 --INI--
 phar.readonly=0
 phar.require_hash=0
+opcache.validate_timestamps=1
 --FILE--
 <?php
 

--- a/ext/phar/tests/tar/tar_004.phpt
+++ b/ext/phar/tests/tar/tar_004.phpt
@@ -7,6 +7,7 @@ if (!extension_loaded("phar")) die("skip");
 --INI--
 phar.readonly=0
 phar.require_hash=0
+opcache.validate_timestamps=1
 --FILE--
 <?php
 include __DIR__ . '/files/tarmaker.php.inc';

--- a/ext/phar/tests/zip/create_new_and_modify.phpt
+++ b/ext/phar/tests/zip/create_new_and_modify.phpt
@@ -4,6 +4,7 @@ Phar: create and modify zip-based phar
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 --INI--
 phar.readonly=0
+opcache.validate_timestamps=1
 --FILE--
 <?php
 

--- a/ext/phar/tests/zip/delete_in_phar.phpt
+++ b/ext/phar/tests/zip/delete_in_phar.phpt
@@ -5,6 +5,7 @@ Phar: delete a file within a zip-based .phar
 --INI--
 phar.readonly=0
 phar.require_hash=0
+opcache.validate_timestamps=1
 --FILE--
 <?php
 

--- a/ext/phar/tests/zip/delete_in_phar_confirm.phpt
+++ b/ext/phar/tests/zip/delete_in_phar_confirm.phpt
@@ -5,6 +5,7 @@ Phar: delete a file within a zip-based .phar (confirm disk file is changed)
 --INI--
 phar.readonly=0
 phar.require_hash=0
+opcache.validate_timestamps=1
 --FILE--
 <?php
 

--- a/sapi/phpdbg/tests/info_001.phpt
+++ b/sapi/phpdbg/tests/info_001.phpt
@@ -48,7 +48,7 @@ prompt> ------------------------------------------------
 Function Breakpoints:
 #0		foo
 prompt> [User-defined constants (0)]
-prompt> [Included files: 0]
+prompt> [Included files: %d]%A
 prompt> [No error found!]
 prompt> [Literal Constants in foo() (2)]
 |-------- C0 -------> [var_dump]


### PR DESCRIPTION
Collect warnings when the file is compiled and then replay them when it is included again. This fixes https://bugs.php.net/bug.php?id=76535.

With this, we should also be able to set up a job for testing file cache.