### PR TITLE
Some cleanup in OCI8 extension for PHP 8

### DIFF
--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -33,7 +33,7 @@
 #include "php_ini.h"
 #include "zend_smart_str.h"
 
-#if HAVE_OCI8
+#ifdef HAVE_OCI8
 
 /* PHP 5.2 is the minimum supported version for OCI8 2.0 */
 #if PHP_MAJOR_VERSION < 5 || (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION <= 1)
@@ -1289,10 +1289,6 @@ php_oci_connection *php_oci_do_connect_ex(char *username, int username_len, char
 
 	/* add to the appropriate hash */
 	if (connection->is_persistent) {
-#if PHP_VERSION_ID < 70300
-		new_le.ptr = connection;
-		new_le.type = le_pconnection;
-#endif
 		connection->used_this_request = 1;
 		PHP_OCI_REGISTER_RESOURCE(connection, le_pconnection);
 
@@ -1303,11 +1299,7 @@ php_oci_connection *php_oci_do_connect_ex(char *username, int username_len, char
 		if (OCI_G(old_oci_close_semantics)) {
 			GC_ADDREF(connection->id);
 		}
-#if PHP_VERSION_ID < 70300
-		zend_hash_update_mem(&EG(persistent_list), connection->hash_key, (void *)&new_le, sizeof(zend_resource));
-#else
 		zend_register_persistent_resource_ex(connection->hash_key, connection, le_pconnection);
-#endif
 		OCI_G(num_persistent)++;
 		OCI_G(num_links)++;
 	} else if (!exclusive) {
@@ -2135,9 +2127,6 @@ static php_oci_spool *php_oci_get_spool(char *username, int username_len, char *
 {
 	smart_str spool_hashed_details = {0};
 	php_oci_spool *session_pool = NULL;
-#if PHP_VERSION_ID < 70300
-	zend_resource spool_le = {{0}};
-#endif
 	zend_resource *spool_out_le = NULL;
 	zend_bool iserror = 0;
 	zval *spool_out_zv = NULL;
@@ -2184,14 +2173,7 @@ static php_oci_spool *php_oci_get_spool(char *username, int username_len, char *
 			iserror = 1;
 			goto exit_get_spool;
 		}
-#if PHP_VERSION_ID < 70300
-		spool_le.ptr  = session_pool;
-		spool_le.type = le_psessionpool;
-		PHP_OCI_REGISTER_RESOURCE(session_pool, le_psessionpool);
-		zend_hash_update_mem(&EG(persistent_list), session_pool->spool_hash_key, (void *)&spool_le, sizeof(zend_resource));
-#else
 		zend_register_persistent_resource_ex(session_pool->spool_hash_key, session_pool, le_psessionpool);
-#endif
 	} else if (spool_out_le->type == le_psessionpool &&
 		ZSTR_LEN(((php_oci_spool *)(spool_out_le->ptr))->spool_hash_key) == ZSTR_LEN(spool_hashed_details.s) &&
 		memcmp(ZSTR_VAL(((php_oci_spool *)(spool_out_le->ptr))->spool_hash_key), ZSTR_VAL(spool_hashed_details.s), ZSTR_LEN(spool_hashed_details.s)) == 0) {

--- a/ext/oci8/oci8.stub.php
+++ b/ext/oci8/oci8.stub.php
@@ -614,9 +614,8 @@ function ocinewcollection($connection_resource, string $type_name, string $schem
 
 /**
  * @param resource $connection_resource
- * @param callable|null $function_name
  */
-function oci_register_taf_callback($connection_resource, $function_name): bool {}
+function oci_register_taf_callback($connection_resource, ?callable $function_name): bool {}
 
 /**
  * @param resource $connection_resource

--- a/ext/oci8/oci8_arginfo.h
+++ b/ext/oci8/oci8_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 157a4128645b816f23fb0bcbbb5860362f446cb3 */
+ * Stub hash: 4a4e86dc175542bbf0bc29c9a957c5dfec834f93 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_define_by_name, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, statement_resource)
@@ -433,7 +433,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_register_taf_callback, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, connection_resource)
-	ZEND_ARG_INFO(0, function_name)
+	ZEND_ARG_TYPE_INFO(0, function_name, IS_CALLABLE, 1)
 ZEND_END_ARG_INFO()
 
 #define arginfo_oci_unregister_taf_callback arginfo_oci_rollback

--- a/ext/oci8/oci8_collection.c
+++ b/ext/oci8/oci8_collection.c
@@ -31,7 +31,7 @@
 #include "ext/standard/info.h"
 #include "php_ini.h"
 
-#if HAVE_OCI8
+#ifdef HAVE_OCI8
 
 #include "php_oci8.h"
 #include "php_oci8_int.h"
@@ -50,11 +50,7 @@ php_oci_collection *php_oci_collection_create(php_oci_connection *connection, ch
 
 	collection->connection = connection;
 	collection->collection = NULL;
-#if PHP_VERSION_ID < 70300
-	++GC_REFCOUNT(collection->connection->id);
-#else
 	GC_ADDREF(collection->connection->id);
-#endif
 
 	/* get type handle by name */
 	PHP_OCI_CALL_RETURN(errstatus, OCITypeByName,

--- a/ext/oci8/oci8_failover.c
+++ b/ext/oci8/oci8_failover.c
@@ -33,7 +33,7 @@
 #include "ext/standard/info.h"
 #include "php_ini.h"
 
-#if HAVE_OCI8
+#ifdef HAVE_OCI8
 
 #include "php_oci8.h"
 #include "php_oci8_int.h"

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -45,24 +45,20 @@ PHP_FUNCTION(oci_register_taf_callback)
 {
 	zval *z_connection;
 	php_oci_connection *connection;
-	zval *callback;
-	zend_string *callback_name;
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+	zval *callback = NULL;
 
-	/* TODO Use ZPP callable */
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|z!", &z_connection, &callback) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|f!", &z_connection, &fci, &fcc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	if (callback) {
-		if (!zend_is_callable(callback, 0, 0)) {
-			callback_name = zend_get_callable_name(callback);
-			php_error_docref(NULL, E_WARNING, "Function '%s' is not callable", ZSTR_VAL(callback_name));
-			zend_string_release(callback_name);
-			RETURN_FALSE;
-		}
-	}
-
 	PHP_OCI_ZVAL_TO_CONNECTION(z_connection, connection);
+
+	/* If callable passed, assign callback zval so that it can be passed to php_oci_register_taf_callback() */
+	if (ZEND_FCI_INITIALIZED(fci)) {
+		callback = &fci.function_name;
+	}
 
 	if (php_oci_register_taf_callback(connection, callback) == 0) {
 		RETURN_TRUE;

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -31,7 +31,7 @@
 #include "ext/standard/info.h"
 #include "php_ini.h"
 
-#if HAVE_OCI8
+#ifdef HAVE_OCI8
 
 #include "php_oci8.h"
 #include "php_oci8_int.h"
@@ -48,38 +48,18 @@ PHP_FUNCTION(oci_register_taf_callback)
 	zval *callback;
 	zend_string *callback_name;
 
+	/* TODO Use ZPP callable */
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|z!", &z_connection, &callback) == FAILURE) {
 		RETURN_THROWS();
 	}
 
 	if (callback) {
-#if PHP_MAJOR_VERSION > 7 || (PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION >= 2)
 		if (!zend_is_callable(callback, 0, 0)) {
 			callback_name = zend_get_callable_name(callback);
 			php_error_docref(NULL, E_WARNING, "Function '%s' is not callable", ZSTR_VAL(callback_name));
-#if PHP_VERSION_ID < 70300
 			zend_string_release(callback_name);
-#else
-			zend_string_release_ex(callback_name, 0);
-#endif
 			RETURN_FALSE;
 		}
-#else
-		if (!zend_is_callable(callback, 0, &callback_name)) {
-			php_error_docref(NULL, E_WARNING, "Function '%s' is not callable", ZSTR_VAL(callback_name));
-#if PHP_VERSION_ID < 70300
-			zend_string_release(callback_name);
-#else
-			zend_string_release_ex(callback_name, 0);
-#endif
-			RETURN_FALSE;
-		}
-#if PHP_VERSION_ID < 70300
-		zend_string_release(callback_name);
-#else
-		zend_string_release_ex(callback_name, 0);
-#endif
-#endif
 	}
 
 	PHP_OCI_ZVAL_TO_CONNECTION(z_connection, connection);
@@ -152,18 +132,10 @@ PHP_FUNCTION(oci_define_by_name)
 	/* if (zend_hash_add(statement->defines, name, name_len, define, sizeof(php_oci_define), (void **)&tmp_define) == SUCCESS) { */
 	zvtmp = zend_string_init(name, name_len, 0);
 	if ((define = zend_hash_add_new_ptr(statement->defines, zvtmp, define)) != NULL) {
-#if PHP_VERSION_ID < 70300
-		zend_string_release(zvtmp);
-#else
 		zend_string_release_ex(zvtmp, 0);
-#endif
 	} else {
 		efree(define);
-#if PHP_VERSION_ID < 70300
-		zend_string_release(zvtmp);
-#else
 		zend_string_release_ex(zvtmp, 0);
-#endif
 		RETURN_FALSE;
 	}
 
@@ -1365,11 +1337,7 @@ PHP_FUNCTION(oci_fetch_all)
 					zend_string *zvtmp;
 					zvtmp = zend_string_init(columns[ i ]->name, columns[ i ]->name_len, 0);
 					zend_symtable_update(Z_ARRVAL(row), zvtmp, &element);
-#if PHP_VERSION_ID < 70300
-					zend_string_release(zvtmp);
-#else
 					zend_string_release_ex(zvtmp, 0);
-#endif
 				}
 			}
 
@@ -1408,11 +1376,7 @@ PHP_FUNCTION(oci_fetch_all)
 				array_init(&tmp);
 				zvtmp = zend_string_init(columns[ i ]->name, columns[ i ]->name_len, 0);
 				outarrs[ i ] = zend_symtable_update(Z_ARRVAL_P(array), zvtmp, &tmp);
-#if PHP_VERSION_ID < 70300
-				zend_string_release(zvtmp);
-#else
 				zend_string_release_ex(zvtmp, 0);
-#endif
 			}
 		}
 

--- a/ext/oci8/oci8_lob.c
+++ b/ext/oci8/oci8_lob.c
@@ -31,7 +31,7 @@
 #include "ext/standard/info.h"
 #include "php_ini.h"
 
-#if HAVE_OCI8
+#ifdef HAVE_OCI8
 
 #include "php_oci8.h"
 #include "php_oci8_int.h"

--- a/ext/oci8/oci8_statement.c
+++ b/ext/oci8/oci8_statement.c
@@ -31,7 +31,7 @@
 #include "ext/standard/info.h"
 #include "php_ini.h"
 
-#if HAVE_OCI8
+#ifdef HAVE_OCI8
 
 #include "php_oci8.h"
 #include "php_oci8_int.h"
@@ -995,12 +995,7 @@ int php_oci_bind_post_exec(zval *data)
 		 * binds, php_oci_bind_out_callback() should have allocated a
 		 * new string that we can modify here.
 		 */
-#if PHP_VERSION_ID < 70300
-		SEPARATE_STRING(zv);
-		Z_STR_P(zv) = zend_string_extend(Z_STR_P(zv), Z_STRLEN_P(zv)+1, 0);
-#else
 		ZVAL_NEW_STR(zv, zend_string_extend(Z_STR_P(zv), Z_STRLEN_P(zv)+1, 0));
-#endif
 		Z_STRVAL_P(zv)[ Z_STRLEN_P(zv) ] = '\0';
 	} else if (Z_TYPE_P(zv) == IS_ARRAY) {
 		int i;
@@ -1265,11 +1260,7 @@ int php_oci_bind_by_name(php_oci_statement *statement, char *name, size_t name_l
 		zvtmp = zend_string_init(name, name_len, 0);
 		bindp = (php_oci_bind *) ecalloc(1, sizeof(php_oci_bind));
 		bindp = zend_hash_update_ptr(statement->binds, zvtmp, bindp);
-#if PHP_VERSION_ID < 70300
-		zend_string_release(zvtmp);
-#else
 		zend_string_release_ex(zvtmp, 0);
-#endif
 	}
 
 	/* Make sure the minimum of value_sz is 1 to avoid ORA-3149
@@ -1717,11 +1708,7 @@ int php_oci_bind_array_by_name(php_oci_statement *statement, char *name, size_t 
 
 	zvtmp = zend_string_init(name, name_len, 0);
 	zend_hash_update_ptr(statement->binds, zvtmp, bind);
-#if PHP_VERSION_ID < 70300
-	zend_string_release(zvtmp);
-#else
 	zend_string_release_ex(zvtmp, 0);
-#endif
 
 	statement->errcode = 0; /* retain backwards compat with OCI8 1.4 */
 	return 0;

--- a/ext/oci8/php_oci8.h
+++ b/ext/oci8/php_oci8.h
@@ -23,7 +23,7 @@
    +----------------------------------------------------------------------+
 */
 
-#if HAVE_OCI8
+#ifdef HAVE_OCI8
 # ifndef PHP_OCI8_H
 #  define PHP_OCI8_H
 

--- a/ext/oci8/php_oci8_int.h
+++ b/ext/oci8/php_oci8_int.h
@@ -23,7 +23,7 @@
    +----------------------------------------------------------------------+
 */
 
-#if HAVE_OCI8
+#ifdef HAVE_OCI8
 # ifndef PHP_OCI8_INT_H
 #  define PHP_OCI8_INT_H
 


### PR DESCRIPTION
While working on #5526 I saw there was some version handling which stems from the PECL version.

Except if I'm mistaken, this shouldn't be needed any more as it lies within php-src