### PR TITLE
Control VCRT leak reporting via environment variable in debug builds

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -613,7 +613,7 @@ extern "C++" {
 # define ZEND_PREFER_RELOAD
 #endif
 
-#if defined(ZEND_WIN32) && defined(_DEBUG) && defined(PHP_WIN32_DEBUG_HEAP)
+#if defined(ZEND_WIN32) && defined(_DEBUG)
 # define ZEND_IGNORE_LEAKS_BEGIN() _CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) & ~_CRTDBG_ALLOC_MEM_DF)
 # define ZEND_IGNORE_LEAKS_END() _CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) | _CRTDBG_ALLOC_MEM_DF)
 #else

--- a/ext/libxml/config.w32
+++ b/ext/libxml/config.w32
@@ -16,9 +16,6 @@ if (PHP_LIBXML == "yes") {
 			ADD_DEF_FILE("ext\\libxml\\php_libxml2.def");
 		}
 		PHP_INSTALL_HEADERS("ext/libxml/", "php_libxml.h");
-		if (PHP_CRT_DEBUG == "yes") {
-			ADD_FLAG("CFLAGS_LIBXML", "/D PHP_WIN32_DEBUG_HEAP");
-		}
 	} else {
 		WARNING("libxml support can't be enabled, iconv or libxml are missing")
 		PHP_LIBXML = "no"

--- a/sapi/cli/config.w32
+++ b/sapi/cli/config.w32
@@ -1,16 +1,12 @@
 // vim:ft=javascript
 
 ARG_ENABLE('cli', 'Build CLI version of PHP', 'yes');
-ARG_ENABLE('crt-debug', 'Enable CRT memory dumps for debugging sent to STDERR', 'no');
 ARG_ENABLE('cli-win32', 'Build console-less CLI version of PHP', 'no');
 
 if (PHP_CLI == "yes") {
 	SAPI('cli', 'php_cli.c php_http_parser.c php_cli_server.c php_cli_process_title.c ps_title.c', 'php.exe', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
 	ADD_FLAG("LIBS_CLI", "ws2_32.lib");
 	ADD_FLAG("LIBS_CLI", "shell32.lib");
-	if (PHP_CRT_DEBUG == "yes") {
-		ADD_FLAG("CFLAGS_CLI", "/D PHP_WIN32_DEBUG_HEAP");
-	}
 	ADD_FLAG("LDFLAGS_CLI", "/stack:67108864");
 
 	if (CHECK_LIB("edit_a.lib;edit.lib", "cli", PHP_CLI) &&

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1180,20 +1180,23 @@ int main(int argc, char *argv[])
 
 	cli_sapi_module.additional_functions = additional_functions;
 
-#if defined(PHP_WIN32) && defined(_DEBUG) && defined(PHP_WIN32_DEBUG_HEAP)
+#if defined(PHP_WIN32) && defined(_DEBUG)
 	{
-		int tmp_flag;
-		_CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
-		_CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
-		_CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-		_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
-		_CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-		_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
-		tmp_flag = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
-		tmp_flag |= _CRTDBG_DELAY_FREE_MEM_DF;
-		tmp_flag |= _CRTDBG_LEAK_CHECK_DF;
+		char *tmp = getenv("PHP_WIN32_DEBUG_HEAP");
+		if (tmp && zend_atoi(tmp, 0)) {
+			int tmp_flag;
+			_CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+			_CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+			_CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+			_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+			_CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+			_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+			tmp_flag = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
+			tmp_flag |= _CRTDBG_DELAY_FREE_MEM_DF;
+			tmp_flag |= _CRTDBG_LEAK_CHECK_DF;
 
-		_CrtSetDbgFlag(tmp_flag);
+			_CrtSetDbgFlag(tmp_flag);
+		}
 	}
 #endif
 

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -437,7 +437,7 @@ can be built that way. \
 	}
 
 	var snapshot_build_exclusions = new Array(
-		'debug', 'crt-debug', 'lzf-better-compression',
+		'debug', 'lzf-better-compression',
 		 'php-build', 'snapshot-template', 'ereg',
 		 'pcre-regex', 'fastcgi', 'force-cgi-redirect',
 		 'path-info-check', 'zts', 'ipv6', 'memory-limit',


### PR DESCRIPTION
Formerly, this had to be enabled by passing the configuration flag
`--enable-crt-debug`; now it can be enabled by setting the environment
variable `PHP_WIN32_DEBUG_HEAP`.  The advantage is that it is no longer
necessary to do separate builds, at the cost of a very minor
performance penalty during process startup.

---

The name `PHP_WIN32_DEBUG_HEAP` appears to be improvable, and maybe its value should be used to call `_CrtSetBreakAlloc()`. Suggestions welcome!