### PR TITLE
run-tests: echo message and exit if no tests found

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -667,8 +667,8 @@ NO_PROC_OPEN_ERROR;
     }
 
     if ($selected_tests && count($test_files) === 0) {
-        echo 'No tests found.' . PHP_EOL;
-        exit;
+        echo "No tests found.\n";
+        return;
     }
 
     // Default to PHP_BINARY as executable

--- a/run-tests.php
+++ b/run-tests.php
@@ -394,6 +394,7 @@ NO_PROC_OPEN_ERROR;
     $temp_urlbase = null;
     $conf_passed = null;
     $no_clean = false;
+    $selected_tests = false;
     $slow_min_ms = INF;
     $preload = false;
     $file_cache = null;
@@ -634,6 +635,7 @@ NO_PROC_OPEN_ERROR;
         }
 
         if (!$is_switch) {
+            $selected_tests = true;
             $testfile = realpath($argv[$i]);
 
             if (!$testfile && strpos($argv[$i], '*') !== false && function_exists('glob')) {
@@ -662,6 +664,11 @@ NO_PROC_OPEN_ERROR;
                 }
             }
         }
+    }
+
+    if ($selected_tests && count($test_files) === 0) {
+        echo 'No tests found.' . PHP_EOL;
+        exit;
     }
 
     // Default to PHP_BINARY as executable


### PR DESCRIPTION
The test runner currently defaults to running the entire test suite if
no selected tests can be found. This can be unexpected.

For example the ext/mysqlnd/ directory has no tests, if you specify that
directory when testing the entire test suite will be run.

    run-tests.php [options] ext/mysqlnd/