### PR TITLE
Show diffs for failed tests on i386/Mac OS CI

### DIFF
--- a/azure/i386/test.yml
+++ b/azure/i386/test.yml
@@ -17,6 +17,7 @@ steps:
           -j$(/usr/bin/nproc) \
           -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP \
           --offline \
+          --show-diff \
           --show-slow 1000 \
           --set-timeout 120 \
           ${{ parameters.runTestsParameters }}

--- a/azure/macos/test.yml
+++ b/azure/macos/test.yml
@@ -13,6 +13,7 @@ steps:
           -j$(sysctl -n hw.ncpu) \
           -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP \
           --offline \
+          --show-diff \
           --show-slow 1000 \
           --set-timeout 120 \
           ${{ parameters.runTestsParameters }}

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -18,6 +18,7 @@ steps:
           -j$(/usr/bin/nproc) \
           -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP \
           --offline \
+          --show-diff \
           --show-slow 1000 \
           --set-timeout 120 \
           ${{ parameters.runTestsParameters }}


### PR DESCRIPTION
Seeing the diffs for failed tests in CI is very helpful, especially for developers who do not have a Mac (or other test platform in question).