### PR TITLE
Use ptrdiff_t instead of int in GC

### DIFF
--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -581,7 +581,7 @@ static HashTable *zend_closure_get_debug_info(zend_object *object, int *is_temp)
 }
 /* }}} */
 
-static HashTable *zend_closure_get_gc(zend_object *obj, zval **table, int *n) /* {{{ */
+static HashTable *zend_closure_get_gc(zend_object *obj, zval **table, ptrdiff_t *n) /* {{{ */
 {
 	zend_closure *closure = (zend_closure *)obj;
 

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -700,7 +700,7 @@ tail_call:
 		zend_object *obj = (zend_object*)ref;
 
 		if (EXPECTED(!(OBJ_FLAGS(ref) & IS_OBJ_FREE_CALLED))) {
-			int n;
+			ptrdiff_t n;
 			zval *zv, *end;
 
 			ht = obj->handlers->get_gc(obj, &zv, &n);
@@ -818,7 +818,7 @@ static void gc_mark_grey(zend_refcounted *ref, gc_stack *stack)
 			zend_object *obj = (zend_object*)ref;
 
 			if (EXPECTED(!(OBJ_FLAGS(ref) & IS_OBJ_FREE_CALLED))) {
-				int n;
+				ptrdiff_t n;
 				zval *zv, *end;
 
 				ht = obj->handlers->get_gc(obj, &zv, &n);
@@ -1002,7 +1002,7 @@ tail_call:
 				zend_object *obj = (zend_object*)ref;
 
 				if (EXPECTED(!(OBJ_FLAGS(ref) & IS_OBJ_FREE_CALLED))) {
-					int n;
+					ptrdiff_t n;
 					zval *zv, *end;
 
 					ht = obj->handlers->get_gc(obj, &zv, &n);
@@ -1163,7 +1163,7 @@ static int gc_collect_white(zend_refcounted *ref, uint32_t *flags, gc_stack *sta
 			zend_object *obj = (zend_object*)ref;
 
 			if (EXPECTED(!(OBJ_FLAGS(ref) & IS_OBJ_FREE_CALLED))) {
-				int n;
+				ptrdiff_t n;
 				zval *zv, *end;
 
 				/* optimization: color is GC_BLACK (0) */
@@ -1347,7 +1347,7 @@ tail_call:
 			zend_object *obj = (zend_object*)ref;
 
 			if (EXPECTED(!(OBJ_FLAGS(ref) & IS_OBJ_FREE_CALLED))) {
-				int n;
+				ptrdiff_t n;
 				zval *zv, *end;
 
 				ht = obj->handlers->get_gc(obj, &zv, &n);

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -118,9 +118,9 @@ static zend_always_inline void zend_get_gc_buffer_add_obj(
 }
 
 static zend_always_inline void zend_get_gc_buffer_use(
-		zend_get_gc_buffer *gc_buffer, zval **table, int *n) {
+		zend_get_gc_buffer *gc_buffer, zval **table, ptrdiff_t *gc_data_count) {
 	*table = gc_buffer->start;
-	*n = gc_buffer->cur - gc_buffer->start;
+	*gc_data_count = gc_buffer->cur - gc_buffer->start;
 }
 
 #endif /* ZEND_GC_H */

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -273,7 +273,7 @@ static void zend_generator_free_storage(zend_object *object) /* {{{ */
 }
 /* }}} */
 
-static HashTable *zend_generator_get_gc(zend_object *object, zval **table, int *n) /* {{{ */
+static HashTable *zend_generator_get_gc(zend_object *object, zval **table, ptrdiff_t *n) /* {{{ */
 {
 	zend_generator *generator = (zend_generator*)object;
 	zend_execute_data *execute_data = generator->execute_data;

--- a/Zend/zend_iterators.c
+++ b/Zend/zend_iterators.c
@@ -24,7 +24,7 @@ static zend_class_entry zend_iterator_class_entry;
 
 static void iter_wrapper_free(zend_object *object);
 static void iter_wrapper_dtor(zend_object *object);
-static HashTable *iter_wrapper_get_gc(zend_object *object, zval **table, int *n);
+static HashTable *iter_wrapper_get_gc(zend_object *object, zval **table, ptrdiff_t *n);
 
 static const zend_object_handlers iterator_object_handlers = {
 	0,
@@ -69,7 +69,7 @@ static void iter_wrapper_dtor(zend_object *object)
 {
 }
 
-static HashTable *iter_wrapper_get_gc(zend_object *object, zval **table, int *n) {
+static HashTable *iter_wrapper_get_gc(zend_object *object, zval **table, ptrdiff_t *n) {
 	/* TODO: We need a get_gc iterator handler */
 	*table = NULL;
 	*n = 0;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -113,7 +113,7 @@ ZEND_API HashTable *zend_std_get_properties(zend_object *zobj) /* {{{ */
 }
 /* }}} */
 
-ZEND_API HashTable *zend_std_get_gc(zend_object *zobj, zval **table, int *n) /* {{{ */
+ZEND_API HashTable *zend_std_get_gc(zend_object *zobj, zval **table, ptrdiff_t *n) /* {{{ */
 {
 	if (zobj->handlers->get_properties != zend_std_get_properties) {
 		*table = NULL;

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -134,7 +134,7 @@ typedef int (*zend_object_count_elements_t)(zend_object *object, zend_long *coun
 
 typedef int (*zend_object_get_closure_t)(zend_object *obj, zend_class_entry **ce_ptr, zend_function **fptr_ptr, zend_object **obj_ptr, zend_bool check_only);
 
-typedef HashTable *(*zend_object_get_gc_t)(zend_object *object, zval **table, int *n);
+typedef HashTable *(*zend_object_get_gc_t)(zend_object *object, zval **table, ptrdiff_t *n);
 
 typedef int (*zend_object_do_operation_t)(zend_uchar opcode, zval *result, zval *op1, zval *op2);
 
@@ -189,7 +189,7 @@ ZEND_API ZEND_COLD zend_bool zend_std_unset_static_property(zend_class_entry *ce
 ZEND_API zend_function *zend_std_get_constructor(zend_object *object);
 ZEND_API struct _zend_property_info *zend_get_property_info(zend_class_entry *ce, zend_string *member, int silent);
 ZEND_API HashTable *zend_std_get_properties(zend_object *object);
-ZEND_API HashTable *zend_std_get_gc(zend_object *object, zval **table, int *n);
+ZEND_API HashTable *zend_std_get_gc(zend_object *object, zval **table, ptrdiff_t *n);
 ZEND_API HashTable *zend_std_get_debug_info(zend_object *object, int *is_temp);
 ZEND_API int zend_std_cast_object_tostring(zend_object *object, zval *writeobj, int type);
 ZEND_API zval *zend_std_get_property_ptr_ptr(zend_object *object, zend_string *member, int type, void **cache_slot);

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -445,7 +445,7 @@ static HashTable *zend_weakmap_get_properties_for(zend_object *object, zend_prop
 	return ht;
 }
 
-static HashTable *zend_weakmap_get_gc(zend_object *object, zval **table, int *n)
+static HashTable *zend_weakmap_get_gc(zend_object *object, zval **table, ptrdiff_t *n)
 {
 	zend_weakmap *wm = zend_weakmap_from(object);
 	*table = NULL;

--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -227,7 +227,7 @@ static HashTable *com_properties_get(zend_object *object)
 	return &zend_empty_array;
 }
 
-static HashTable *com_get_gc(zval *object, zval **table, int *n)
+static HashTable *com_get_gc(zval *object, zval **table, ptrdiff_t *n)
 {
 	*table = NULL;
 	*n = 0;

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -170,14 +170,14 @@ static zend_object *date_object_clone_interval(zend_object *this_ptr);
 static zend_object *date_object_clone_period(zend_object *this_ptr);
 
 static int date_object_compare_date(zval *d1, zval *d2);
-static HashTable *date_object_get_gc(zend_object *object, zval **table, int *n);
+static HashTable *date_object_get_gc(zend_object *object, zval **table, ptrdiff_t *n);
 static HashTable *date_object_get_properties_for(zend_object *object, zend_prop_purpose purpose);
-static HashTable *date_object_get_gc_interval(zend_object *object, zval **table, int *n);
+static HashTable *date_object_get_gc_interval(zend_object *object, zval **table, ptrdiff_t *n);
 static HashTable *date_object_get_properties_interval(zend_object *object);
-static HashTable *date_object_get_gc_period(zend_object *object, zval **table, int *n);
+static HashTable *date_object_get_gc_period(zend_object *object, zval **table, ptrdiff_t *n);
 static HashTable *date_object_get_properties_period(zend_object *object);
 static HashTable *date_object_get_properties_for_timezone(zend_object *object, zend_prop_purpose purpose);
-static HashTable *date_object_get_gc_timezone(zend_object *object, zval **table, int *n);
+static HashTable *date_object_get_gc_timezone(zend_object *object, zval **table, ptrdiff_t *n);
 static HashTable *date_object_get_debug_info_timezone(zend_object *object, int *is_temp);
 static void php_timezone_to_string(php_timezone_obj *tzobj, zval *zv);
 
@@ -1772,14 +1772,14 @@ static int date_object_compare_date(zval *d1, zval *d2) /* {{{ */
 	return timelib_time_compare(o1->time, o2->time);
 } /* }}} */
 
-static HashTable *date_object_get_gc(zend_object *object, zval **table, int *n) /* {{{ */
+static HashTable *date_object_get_gc(zend_object *object, zval **table, ptrdiff_t *n) /* {{{ */
 {
 	*table = NULL;
 	*n = 0;
 	return zend_std_get_properties(object);
 } /* }}} */
 
-static HashTable *date_object_get_gc_timezone(zend_object *object, zval **table, int *n) /* {{{ */
+static HashTable *date_object_get_gc_timezone(zend_object *object, zval **table, ptrdiff_t *n) /* {{{ */
 {
        *table = NULL;
        *n = 0;
@@ -2013,7 +2013,7 @@ static zend_object *date_object_clone_interval(zend_object *this_ptr) /* {{{ */
 	return &new_obj->std;
 } /* }}} */
 
-static HashTable *date_object_get_gc_interval(zend_object *object, zval **table, int *n) /* {{{ */
+static HashTable *date_object_get_gc_interval(zend_object *object, zval **table, ptrdiff_t *n) /* {{{ */
 {
 
 	*table = NULL;
@@ -4729,7 +4729,7 @@ PHP_FUNCTION(date_sun_info)
 }
 /* }}} */
 
-static HashTable *date_object_get_gc_period(zend_object *object, zval **table, int *n) /* {{{ */
+static HashTable *date_object_get_gc_period(zend_object *object, zval **table, ptrdiff_t *n) /* {{{ */
 {
 	*table = NULL;
 	*n = 0;

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4631,7 +4631,7 @@ static HashTable *zend_fake_get_properties(zend_object *obj) /* {{{ */
 }
 /* }}} */
 
-static HashTable *zend_fake_get_gc(zend_object *ob, zval **table, int *n) /* {{{ */
+static HashTable *zend_fake_get_gc(zend_object *ob, zval **table, ptrdiff_t *n) /* {{{ */
 {
 	*table = NULL;
 	*n = 0;

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1281,7 +1281,7 @@ static int dbh_compare(zval *object1, zval *object2)
 	return ZEND_UNCOMPARABLE;
 }
 
-static HashTable *dbh_get_gc(zend_object *object, zval **gc_data, int *gc_count)
+static HashTable *dbh_get_gc(zend_object *object, zval **gc_data, ptrdiff_t *gc_count)
 {
 	pdo_dbh_t *dbh = php_pdo_dbh_fetch_inner(object);
 	*gc_data = &dbh->def_stmt_ctor_args;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -250,7 +250,7 @@ static void reflection_free_objects_storage(zend_object *object) /* {{{ */
 }
 /* }}} */
 
-static HashTable *reflection_get_gc(zend_object *obj, zval **gc_data, int *gc_data_count) /* {{{ */
+static HashTable *reflection_get_gc(zend_object *obj, zval **gc_data, ptrdiff_t *gc_data_count) /* {{{ */
 {
 	reflection_object *intern = reflection_object_from_obj(obj);
 	*gc_data = &intern->obj;

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1258,7 +1258,7 @@ next_iter:
 }
 /* }}} */
 
-static HashTable *sxe_get_gc(zend_object *object, zval **table, int *n) /* {{{ */ {
+static HashTable *sxe_get_gc(zend_object *object, zval **table, ptrdiff_t *n) /* {{{ */ {
 	php_sxe_object *sxe;
 	sxe = php_sxe_fetch_object(object);
 

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1746,7 +1746,7 @@ static int php_snmp_has_property(zend_object *object, zend_string *name, int has
 }
 /* }}} */
 
-static HashTable *php_snmp_get_gc(zend_object *object, zval **gc_data, int *gc_data_count) /* {{{ */
+static HashTable *php_snmp_get_gc(zend_object *object, zval **gc_data, ptrdiff_t *gc_data_count) /* {{{ */
 {
 	*gc_data = NULL;
 	*gc_data_count = 0;

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -855,7 +855,7 @@ static inline HashTable* spl_array_get_debug_info(zend_object *obj) /* {{{ */
 }
 /* }}} */
 
-static HashTable *spl_array_get_gc(zend_object *obj, zval **gc_data, int *gc_data_count) /* {{{ */
+static HashTable *spl_array_get_gc(zend_object *obj, zval **gc_data, ptrdiff_t *gc_data_count) /* {{{ */
 {
 	spl_array_object *intern = spl_array_from_obj(obj);
 	*gc_data = &intern->array;

--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -523,7 +523,7 @@ static inline HashTable* spl_dllist_object_get_debug_info(zend_object *obj) /* {
 }
 /* }}}} */
 
-static HashTable *spl_dllist_object_get_gc(zend_object *obj, zval **gc_data, int *gc_data_count) /* {{{ */
+static HashTable *spl_dllist_object_get_gc(zend_object *obj, zval **gc_data, ptrdiff_t *gc_data_count) /* {{{ */
 {
 	spl_dllist_object *intern = spl_dllist_from_obj(obj);
 	zend_get_gc_buffer *gc_buffer = zend_get_gc_buffer_create();

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -146,7 +146,7 @@ static void spl_fixedarray_copy(spl_fixedarray *to, spl_fixedarray *from) /* {{{
 }
 /* }}} */
 
-static HashTable* spl_fixedarray_object_get_gc(zend_object *obj, zval **table, int *n) /* {{{{ */
+static HashTable* spl_fixedarray_object_get_gc(zend_object *obj, zval **table, ptrdiff_t *n) /* {{{{ */
 {
 	spl_fixedarray_object *intern = spl_fixed_array_from_obj(obj);
 	HashTable *ht = zend_std_get_properties(obj);

--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -535,7 +535,7 @@ static inline HashTable* spl_heap_object_get_debug_info(zend_class_entry *ce, ze
 }
 /* }}} */
 
-static HashTable *spl_heap_object_get_gc(zend_object *obj, zval **gc_data, int *gc_data_count) /* {{{ */
+static HashTable *spl_heap_object_get_gc(zend_object *obj, zval **gc_data, ptrdiff_t *gc_data_count) /* {{{ */
 {
 	spl_heap_object *intern = spl_heap_from_obj(obj);
 	*gc_data = (zval *) intern->heap->elements;
@@ -545,7 +545,7 @@ static HashTable *spl_heap_object_get_gc(zend_object *obj, zval **gc_data, int *
 }
 /* }}} */
 
-static HashTable *spl_pqueue_object_get_gc(zend_object *obj, zval **gc_data, int *gc_data_count) /* {{{ */
+static HashTable *spl_pqueue_object_get_gc(zend_object *obj, zval **gc_data, ptrdiff_t *gc_data_count) /* {{{ */
 {
 	spl_heap_object *intern = spl_heap_from_obj(obj);
 	*gc_data = (zval *) intern->heap->elements;

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -276,7 +276,7 @@ static inline HashTable* spl_object_storage_debug_info(zend_object *obj) /* {{{ 
 /* }}} */
 
 /* overridden for garbage collection */
-static HashTable *spl_object_storage_get_gc(zend_object *obj, zval **table, int *n) /* {{{ */
+static HashTable *spl_object_storage_get_gc(zend_object *obj, zval **table, ptrdiff_t *n) /* {{{ */
 {
 	spl_SplObjectStorage *intern = spl_object_storage_from_obj(obj);
 	spl_SplObjectStorageElement *element;

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -154,7 +154,7 @@ static PHP_GINIT_FUNCTION(xml);
 
 static zend_object *xml_parser_create_object(zend_class_entry *class_type);
 static void xml_parser_free_obj(zend_object *object);
-static HashTable *xml_parser_get_gc(zend_object *object, zval **table, int *n);
+static HashTable *xml_parser_get_gc(zend_object *object, zval **table, ptrdiff_t *n);
 static zend_function *xml_parser_get_constructor(zend_object *object);
 
 static zend_string *xml_utf8_decode(const XML_Char *, size_t, const XML_Char *);
@@ -414,7 +414,7 @@ static void xml_parser_free_obj(zend_object *object)
 	zend_object_std_dtor(&parser->std);
 }
 
-static HashTable *xml_parser_get_gc(zend_object *object, zval **table, int *n)
+static HashTable *xml_parser_get_gc(zend_object *object, zval **table, ptrdiff_t *n)
 {
 	xml_parser *parser = xml_parser_from_obj(object);
 	*table = &parser->object;

--- a/ext/xmlrpc/xmlrpc-epi-php.c
+++ b/ext/xmlrpc/xmlrpc-epi-php.c
@@ -211,7 +211,7 @@ static void xmlrpc_server_free_obj(zend_object *object)
 	zend_object_std_dtor(&server->std);
 }
 
-static HashTable *xmlrpc_server_get_gc(zend_object *object, zval **table, int *n)
+static HashTable *xmlrpc_server_get_gc(zend_object *object, zval **table, ptrdiff_t *n)
 {
 	xmlrpc_server_data *xmlrpc_server = xmlrpc_server_from_obj(object);
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -938,7 +938,7 @@ static int php_zip_has_property(zend_object *object, zend_string *name, int type
 }
 /* }}} */
 
-static HashTable *php_zip_get_gc(zend_object *object, zval **gc_data, int *gc_data_count) /* {{{ */
+static HashTable *php_zip_get_gc(zend_object *object, zval **gc_data, ptrdiff_t *gc_data_count) /* {{{ */
 {
 	*gc_data = NULL;
 	*gc_data_count = 0;


### PR DESCRIPTION
This fixes one major compiler complaint from MSVC but it impacts extensions pretty heavily.

One other positive may be that we get a tiny performance benefit for memory if I'm to believe this article: https://www.viva64.com/en/a/0050/

Any thoughts on this?