### PR TITLE
Re-enable Symfony test on PHP 8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,83 +12,10 @@ trigger:
       - UPGRADING.INTERNALS
 
 jobs:
-  - template: azure/job.yml
+  - template: azure/community_job.yml
     parameters:
-      configurationName: DEBUG_NTS
-      configurationParameters: '--enable-debug --disable-zts'
-  - template: azure/job.yml
-    parameters:
-      configurationName: RELEASE_ZTS
-      configurationParameters: '--disable-debug --enable-zts'
-  - template: azure/i386/job.yml
-    parameters:
-      configurationName: I386_DEBUG_ZTS
-      configurationParameters: '--enable-debug --enable-zts'
-  - template: azure/macos/job.yml
-    parameters:
-      configurationName: MACOS_DEBUG_NTS
-      configurationParameters: '--enable-debug --disable-zts'
-  - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
-    - template: azure/job.yml
-      parameters:
-        configurationName: DEBUG_ZTS
-        configurationParameters: '--enable-debug --enable-zts'
-    - template: azure/job.yml
-      parameters:
-        configurationName: RELEASE_NTS
-        configurationParameters: '--disable-debug --disable-zts'
-    - template: azure/i386/job.yml
-      parameters:
-        configurationName: I386_DEBUG_NTS
-        configurationParameters: '--enable-debug --disable-zts'
-    - template: azure/i386/job.yml
-      parameters:
-        configurationName: I386_RELEASE_NTS
-        configurationParameters: '--disable-debug --disable-zts'
-    - template: azure/i386/job.yml
-      parameters:
-        configurationName: I386_RELEASE_ZTS
-        configurationParameters: '--disable-debug --enable-zts'
-    - template: azure/macos/job.yml
-      parameters:
-        configurationName: MACOS_DEBUG_ZTS
-        configurationParameters: '--enable-debug --enable-zts'
-    - template: azure/macos/job.yml
-      parameters:
-        configurationName: MACOS_RELEASE_NTS
-        configurationParameters: '--disable-debug --disable-zts'
-    - template: azure/macos/job.yml
-      parameters:
-        configurationName: MACOS_RELEASE_ZTS
-        configurationParameters: '--disable-debug --enable-zts'
-    - template: azure/job.yml
-      parameters:
-        configurationName: DEBUG_ZTS_ASAN_UBSAN
-        configurationParameters: >-
-            --enable-debug --enable-zts
-            CFLAGS='-fsanitize=undefined,address -DZEND_TRACK_ARENA_ALLOC'
-            LDFLAGS='-fsanitize=undefined,address'
-        runTestsParameters: --asan
-        timeoutInMinutes: 180
-    - template: azure/msan_job.yml
-      parameters:
-        configurationName: DEBUG_ZTS_MSAN
-        configurationParameters: '--enable-debug --enable-zts'
-        runTestsParameters: --asan
-        timeoutInMinutes: 90
-    - template: azure/community_job.yml
-      parameters:
-        configurationName: COMMUNITY
-        configurationParameters: >-
-            --enable-debug --enable-zts
-            CFLAGS='-fsanitize=undefined,address -fno-sanitize-recover -DZEND_TRACK_ARENA_ALLOC'
-            LDFLAGS='-fsanitize=undefined,address'
-    - template: azure/coverage_job.yml
-      parameters:
-        configurationName: COVERAGE_DEBUG_ZTS
-        configurationParameters: '--enable-debug --disable-zts'
-        timeoutInMinutes: 90
-    - template: azure/file_cache_job.yml
-      parameters:
-        configurationName: DEBUG_NTS_FILE_CACHE
-        configurationParameters: '--enable-debug --disable-zts'
+      configurationName: COMMUNITY
+      configurationParameters: >-
+          --enable-debug --enable-zts
+          CFLAGS='-fsanitize=undefined,address -fno-sanitize-recover -DZEND_TRACK_ARENA_ALLOC'
+          LDFLAGS='-fsanitize=undefined,address'

--- a/azure/community_job.yml
+++ b/azure/community_job.yml
@@ -71,10 +71,15 @@ jobs:
         export USE_ZEND_ALLOC=0
         export USE_TRACKED_ALLOC=1
         export ASAN_OPTIONS=exitcode=139
-        php ./phpunit --exclude-group tty,benchmark,intl-data,transient
-        if [ $? -gt 128 ]; then
-          exit 1
-        fi
+        export SYMFONY_DEPRECATIONS_HELPER=max[total]=999
+        X=0
+        for component in $(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h\n'); do
+          php ./phpunit $component --exclude-group tty,benchmark,intl-data,transient;
+          if [ $? -gt 128 ]; then
+            X=1;
+          fi
+        done
+        exit $X
       displayName: 'Test Symfony'
       condition: or(succeeded(), failed())
     - script: |

--- a/azure/community_job.yml
+++ b/azure/community_job.yml
@@ -61,22 +61,22 @@ jobs:
         sed -i 's/function query()/function query($statement = null)/' vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php
         php vendor/bin/phpunit
       displayName: 'Test Laravel'
-#    - script: |
-#        git clone https://github.com/symfony/symfony.git --branch=master --depth=1
-#        cd symfony
-#        php7.3 /usr/bin/composer install --no-progress
-#        php7.3 ./phpunit install
-#        # Work around PHP 8 incompatibility in Doctrine
-#        sed -i 's/function query()/function query($statement = null)/' vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php
-#        export USE_ZEND_ALLOC=0
-#        export USE_TRACKED_ALLOC=1
-#        export ASAN_OPTIONS=exitcode=139
-#        php ./phpunit --exclude-group tty,benchmark,intl-data,transient
-#        if [ $? -gt 128 ]; then
-#          exit 1
-#        fi
-#      displayName: 'Test Symfony'
-#      condition: or(succeeded(), failed())
+    - script: |
+        git clone https://github.com/symfony/symfony.git --branch=master --depth=1
+        cd symfony
+        php7.3 /usr/bin/composer install --no-progress
+        php7.3 ./phpunit install
+        # Work around PHP 8 incompatibility in Doctrine
+        sed -i 's/function query()/function query($statement = null)/' vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php
+        export USE_ZEND_ALLOC=0
+        export USE_TRACKED_ALLOC=1
+        export ASAN_OPTIONS=exitcode=139
+        php ./phpunit --exclude-group tty,benchmark,intl-data,transient
+        if [ $? -gt 128 ]; then
+          exit 1
+        fi
+      displayName: 'Test Symfony'
+      condition: or(succeeded(), failed())
     - script: |
         git clone https://github.com/amphp/amp.git --branch=master --depth=1
         cd amp


### PR DESCRIPTION
Following https://github.com/symfony/symfony/issues/36872, Symfony is now green on PHP 8.