### PR TITLE
Use standard boolean type as zend_bool typedef

### DIFF
--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -81,7 +81,8 @@ struct _zend_compiler_globals {
 
 	HashTable *auto_globals;
 
-	zend_bool parse_error;
+	/* Refer to zend_yytnamerr() in zend_language_parser.y for meaning of values */
+	zend_uchar parse_error;
 	zend_bool in_compilation;
 	zend_bool short_tags;
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -24,6 +24,7 @@
 
 #include "zend_portability.h"
 #include "zend_long.h"
+#include <stdbool.h>
 
 #ifdef __SSE2__
 # include <mmintrin.h>
@@ -46,7 +47,7 @@
 # define ZEND_ENDIAN_LOHI_C_4(a, b, c, d)  a, b, c, d
 #endif
 
-typedef unsigned char zend_bool;
+typedef bool zend_bool;
 typedef unsigned char zend_uchar;
 
 typedef enum {

--- a/main/main.c
+++ b/main/main.c
@@ -480,7 +480,7 @@ static zend_uchar php_get_display_errors_mode(char *value, size_t value_length)
  */
 static PHP_INI_MH(OnUpdateDisplayErrors)
 {
-	PG(display_errors) = (zend_bool) php_get_display_errors_mode(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+	PG(display_errors) = php_get_display_errors_mode(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
 
 	return SUCCESS;
 }

--- a/main/main.c
+++ b/main/main.c
@@ -447,9 +447,9 @@ static PHP_INI_MH(OnUpdateTimeout)
 
 /* {{{ php_get_display_errors_mode() helper function
  */
-static int php_get_display_errors_mode(char *value, size_t value_length)
+static zend_uchar php_get_display_errors_mode(char *value, size_t value_length)
 {
-	int mode;
+	zend_uchar mode;
 
 	if (!value) {
 		return PHP_DISPLAY_ERRORS_STDOUT;
@@ -490,7 +490,8 @@ static PHP_INI_MH(OnUpdateDisplayErrors)
  */
 static PHP_INI_DISP(display_errors_mode)
 {
-	int mode, cgi_or_cli;
+	zend_uchar mode;
+	bool cgi_or_cli;
 	size_t tmp_value_length;
 	char *tmp_value;
 

--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -65,7 +65,7 @@ struct _php_core_globals {
 	zend_long memory_limit;
 	zend_long max_input_time;
 
-	zend_bool display_errors;
+	zend_uchar display_errors;
 	zend_bool display_startup_errors;
 	zend_bool log_errors;
 	zend_long      log_errors_max_len;


### PR DESCRIPTION
As we are now using C99 and ``bool`` is always defined in the ``stdbool.h`` header, make zend_bool a typedef of a standard boolean.

This catches some funky usages of `zend_bool` which I still have trouble debugging.

Things which need to be handled/fixed:

- [x] Parser being confused about the short hand syntax ``[]`` for nested lists (fails with ``Fatal error: Cannot mix [] and list()``:\
I.e. ``[$a, [$b]] = array(new stdclass, array(new stdclass));``\
See ``Zend/tests/list_001.phpt`` (or ``Zend/tests/list/list_reference_001.phpt`` and ``Zend/tests/list/list_reference_009.phpt``\
Fixed by: baa285881fbdef24d5a737774d94bd76f422bf9f
- [x] JIT related failures (mostly type declarations and GC)