### PR TITLE
Allow generators to have a real return type of `mixed`

### DIFF
--- a/Zend/tests/return_types/generators001.phpt
+++ b/Zend/tests/return_types/generators001.phpt
@@ -14,12 +14,33 @@ function test3() : Traversable {
     yield 3;
 }
 
+function test4() : mixed {
+    yield 4;
+}
+
+function test5() : object {
+    yield 5;
+}
+
+function test6() : object|callable {
+    yield 6;
+}
+
 var_dump(
     test1(),
     test2(),
-    test3()
+    test3(),
+    test4(),
+    test5(),
+    test6(),
 );
 --EXPECTF--
+object(Generator)#%d (%d) {
+}
+object(Generator)#%d (%d) {
+}
+object(Generator)#%d (%d) {
+}
 object(Generator)#%d (%d) {
 }
 object(Generator)#%d (%d) {

--- a/Zend/tests/return_types/generators002.phpt
+++ b/Zend/tests/return_types/generators002.phpt
@@ -1,9 +1,9 @@
 --TEST--
-Generator return type must be Generator, Iterator or Traversable
+Generator return type must be a supertype of Generator
 --FILE--
 <?php
 function test1() : StdClass {
     yield 1;
 }
 --EXPECTF--
-Fatal error: Generators may only declare a return type containing Generator, Iterator, Traversable, or iterable, StdClass is not permitted in %s on line %d
+Fatal error: Generator return type must be a supertype of Generator, StdClass given in %s on line %d

--- a/Zend/tests/return_types/generators006.phpt
+++ b/Zend/tests/return_types/generators006.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Generator return type must be a supertype of Generator (with union types)
+--FILE--
+<?php
+function test1() : StdClass|ArrayObject|array {
+    yield 1;
+}
+--EXPECTF--
+Fatal error: Generator return type must be a supertype of Generator, StdClass|ArrayObject|array given in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1263,7 +1263,7 @@ static void zend_mark_function_as_generator() /* {{{ */
 
 	if (CG(active_op_array)->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
 		zend_type return_type = CG(active_op_array)->arg_info[-1].type;
-		zend_bool valid_type = (ZEND_TYPE_FULL_MASK(return_type) & MAY_BE_ITERABLE) != 0;
+		zend_bool valid_type = (ZEND_TYPE_FULL_MASK(return_type) & (MAY_BE_ITERABLE | MAY_BE_OBJECT)) != 0;
 		if (!valid_type) {
 			zend_type *single_type;
 			ZEND_TYPE_FOREACH(return_type, single_type) {
@@ -1278,8 +1278,7 @@ static void zend_mark_function_as_generator() /* {{{ */
 		if (!valid_type) {
 			zend_string *str = zend_type_to_string(return_type);
 			zend_error_noreturn(E_COMPILE_ERROR,
-				"Generators may only declare a return type containing " \
-				"Generator, Iterator, Traversable, or iterable, %s is not permitted",
+				"Generator return type must be a supertype of Generator, %s given",
 				ZSTR_VAL(str));
 		}
 	}


### PR DESCRIPTION
Fixes an edge case overlooked in
https://github.com/php/php-src/pull/5313