### PR TITLE
Fix MSVC level 1 (severe) warnings

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -103,7 +103,7 @@ TSRM_API void tsrm_win32_shutdown(void)
 #endif
 }/*}}}*/
 
-char * tsrm_win32_get_path_sid_key(const char *pathname, size_t pathname_len, size_t *key_len)
+const char * tsrm_win32_get_path_sid_key(const char *pathname, size_t pathname_len, size_t *key_len)
 {/*{{{*/
 	PSID pSid = TWG(impersonation_token_sid);
 	char *ptcSid = NULL;

--- a/TSRM/tsrm_win32.h
+++ b/TSRM/tsrm_win32.h
@@ -89,7 +89,7 @@ TSRMLS_CACHE_EXTERN()
 #define	SHM_RND		FILE_MAP_WRITE
 #define	SHM_REMAP	FILE_MAP_COPY
 
-char * tsrm_win32_get_path_sid_key(const char *pathname, size_t pathname_len, size_t *key_len);
+const char * tsrm_win32_get_path_sid_key(const char *pathname, size_t pathname_len, size_t *key_len);
 
 TSRM_API void tsrm_win32_startup(void);
 TSRM_API void tsrm_win32_shutdown(void);

--- a/Zend/zend_llist.c
+++ b/Zend/zend_llist.c
@@ -49,7 +49,7 @@ ZEND_API void zend_llist_add_element(zend_llist *l, const void *element)
 }
 
 
-ZEND_API void zend_llist_prepend_element(zend_llist *l, void *element)
+ZEND_API void zend_llist_prepend_element(zend_llist *l, const void *element)
 {
 	zend_llist_element *tmp = pemalloc(sizeof(zend_llist_element)+l->size-1, l->persistent);
 

--- a/Zend/zend_llist.c
+++ b/Zend/zend_llist.c
@@ -31,7 +31,7 @@ ZEND_API void zend_llist_init(zend_llist *l, size_t size, llist_dtor_func_t dtor
 	l->persistent = persistent;
 }
 
-ZEND_API void zend_llist_add_element(zend_llist *l, void *element)
+ZEND_API void zend_llist_add_element(zend_llist *l, const void *element)
 {
 	zend_llist_element *tmp = pemalloc(sizeof(zend_llist_element)+l->size-1, l->persistent);
 

--- a/Zend/zend_llist.h
+++ b/Zend/zend_llist.h
@@ -46,7 +46,7 @@ typedef zend_llist_element* zend_llist_position;
 
 BEGIN_EXTERN_C()
 ZEND_API void zend_llist_init(zend_llist *l, size_t size, llist_dtor_func_t dtor, unsigned char persistent);
-ZEND_API void zend_llist_add_element(zend_llist *l, void *element);
+ZEND_API void zend_llist_add_element(zend_llist *l, const void *element);
 ZEND_API void zend_llist_prepend_element(zend_llist *l, void *element);
 ZEND_API void zend_llist_del_element(zend_llist *l, void *element, int (*compare)(void *element1, void *element2));
 ZEND_API void zend_llist_destroy(zend_llist *l);

--- a/Zend/zend_llist.h
+++ b/Zend/zend_llist.h
@@ -47,7 +47,7 @@ typedef zend_llist_element* zend_llist_position;
 BEGIN_EXTERN_C()
 ZEND_API void zend_llist_init(zend_llist *l, size_t size, llist_dtor_func_t dtor, unsigned char persistent);
 ZEND_API void zend_llist_add_element(zend_llist *l, const void *element);
-ZEND_API void zend_llist_prepend_element(zend_llist *l, void *element);
+ZEND_API void zend_llist_prepend_element(zend_llist *l, const void *element);
 ZEND_API void zend_llist_del_element(zend_llist *l, void *element, int (*compare)(void *element1, void *element2));
 ZEND_API void zend_llist_destroy(zend_llist *l);
 ZEND_API void zend_llist_clean(zend_llist *l);

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -621,4 +621,11 @@ extern "C++" {
 # define ZEND_IGNORE_LEAKS_END()
 #endif
 
+/* MSVC yields C4090 when a (const T **) is passed to a (void *); ZEND_VOIDP works around that */
+#ifdef _MSC_VER
+# define ZEND_VOIDP(ptr) ((void *) ptr)
+#else
+# define ZEND_VOIDP(ptr) (ptr)
+#endif
+
 #endif /* ZEND_PORTABILITY_H */

--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -303,8 +303,8 @@ static inline zend_ulong realpath_cache_key(const char *path, size_t path_len) /
 {
 	register zend_ulong h;
 	size_t bucket_key_len;
-	char *bucket_key_start = tsrm_win32_get_path_sid_key(path, path_len, &bucket_key_len);
-	char *bucket_key = (char *)bucket_key_start;
+	const char *bucket_key_start = tsrm_win32_get_path_sid_key(path, path_len, &bucket_key_len);
+	const char *bucket_key = bucket_key_start;
 	const char *e;
 
 	if (!bucket_key) {

--- a/appveyor/build_task.bat
+++ b/appveyor/build_task.bat
@@ -54,6 +54,8 @@ if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INT
 set EXT_EXCLUDE_FROM_TEST=snmp,oci8_12c,pdo_oci,pdo_firebird,ldap,imap,ftp
 if "%OPCACHE%" equ "0" set EXT_EXCLUDE_FROM_TEST=%EXT_EXCLUDE_FROM_TEST%,opcache
 
+set CFLAGS=/W1 /WX
+
 cmd /c configure.bat ^
 	--enable-snapshot-build ^
 	--disable-debug-pack ^

--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -177,7 +177,7 @@ static void com_write_dimension(zend_object *object, zval *offset, zval *value)
 	}
 }
 
-static zval *com_get_property_ptr_ptr(zval *object, zval *member, int type, void **cache_slot)
+static zval *com_get_property_ptr_ptr(zend_object *object, zend_string *member, int type, void **cache_slot)
 {
 	return NULL;
 }
@@ -224,10 +224,10 @@ static HashTable *com_properties_get(zend_object *object)
 	 * infinite recursion when the hash is displayed via var_dump().
 	 * Perhaps it is best to leave it un-implemented.
 	 */
-	return &zend_empty_array;
+	return (HashTable *) &zend_empty_array;
 }
 
-static HashTable *com_get_gc(zval *object, zval **table, int *n)
+static HashTable *com_get_gc(zend_object *object, zval **table, int *n)
 {
 	*table = NULL;
 	*n = 0;

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -365,7 +365,7 @@ static int php_mb_parse_encoding_list(const char *value, size_t value_length,
 						zend_argument_value_error(arg_num, "contains invalid encoding \"%s\"", p1);
 					}
 					efree(tmpstr);
-					pefree(list, persistent);
+					pefree((void *) list, persistent);
 					return FAILURE;
 				}
 
@@ -400,7 +400,7 @@ static int php_mb_parse_encoding_array(HashTable *target_hash, const mbfl_encodi
 	ZEND_HASH_FOREACH_VAL(target_hash, hash_entry) {
 		zend_string *encoding_str = zval_try_get_string(hash_entry);
 		if (UNEXPECTED(!encoding_str)) {
-			efree(list);
+			efree((void *) list);
 			return FAILURE;
 		}
 
@@ -424,7 +424,7 @@ static int php_mb_parse_encoding_array(HashTable *target_hash, const mbfl_encodi
 			} else {
 				zend_argument_value_error(arg_num, "contains invalid encoding \"%s\"", ZSTR_VAL(encoding_str));
 				zend_string_release(encoding_str);
-				efree(list);
+				efree((void *) list);
 				return FAILURE;
 			}
 		}
@@ -809,7 +809,7 @@ static PHP_INI_MH(OnUpdate_mbstring_detect_order)
 
 	if (!new_value) {
 		if (MBSTRG(detect_order_list)) {
-			pefree(MBSTRG(detect_order_list), 1);
+			pefree((void *) MBSTRG(detect_order_list), 1);
 		}
 		MBSTRG(detect_order_list) = NULL;
 		MBSTRG(detect_order_list_size) = 0;
@@ -821,7 +821,7 @@ static PHP_INI_MH(OnUpdate_mbstring_detect_order)
 	}
 
 	if (MBSTRG(detect_order_list)) {
-		pefree(MBSTRG(detect_order_list), 1);
+		pefree((void *) MBSTRG(detect_order_list), 1);
 	}
 	MBSTRG(detect_order_list) = list;
 	MBSTRG(detect_order_list_size) = size;
@@ -836,7 +836,7 @@ static int _php_mb_ini_mbstring_http_input_set(const char *new_value, size_t new
 		return FAILURE;
 	}
 	if (MBSTRG(http_input_list)) {
-		pefree(MBSTRG(http_input_list), 1);
+		pefree((void *) MBSTRG(http_input_list), 1);
 	}
 	MBSTRG(http_input_list) = list;
 	MBSTRG(http_input_list_size) = size;
@@ -1128,10 +1128,10 @@ ZEND_TSRMLS_CACHE_UPDATE();
 static PHP_GSHUTDOWN_FUNCTION(mbstring)
 {
 	if (mbstring_globals->http_input_list) {
-		free(mbstring_globals->http_input_list);
+		free((void *) mbstring_globals->http_input_list);
 	}
 	if (mbstring_globals->detect_order_list) {
-		free(mbstring_globals->detect_order_list);
+		free((void *) mbstring_globals->detect_order_list);
 	}
 	if (mbstring_globals->http_output_conv_mimetypes) {
 		_php_mb_free_regex(mbstring_globals->http_output_conv_mimetypes);
@@ -1236,7 +1236,7 @@ PHP_RINIT_FUNCTION(mbstring)
 PHP_RSHUTDOWN_FUNCTION(mbstring)
 {
 	if (MBSTRG(current_detect_order_list) != NULL) {
-		efree(MBSTRG(current_detect_order_list));
+		efree((void *) MBSTRG(current_detect_order_list));
 		MBSTRG(current_detect_order_list) = NULL;
 		MBSTRG(current_detect_order_list_size) = 0;
 	}
@@ -1510,13 +1510,13 @@ PHP_FUNCTION(mb_detect_order)
 		}
 
 		if (size == 0) {
-			efree(list);
+			efree((void *) list);
 			zend_argument_value_error(1, "must specify at least one encoding");
 			RETURN_THROWS();
 		}
 
 		if (MBSTRG(current_detect_order_list)) {
-			efree(MBSTRG(current_detect_order_list));
+			efree((void *) MBSTRG(current_detect_order_list));
 		}
 		MBSTRG(current_detect_order_list) = list;
 		MBSTRG(current_detect_order_list_size) = size;
@@ -2632,7 +2632,7 @@ PHP_FUNCTION(mb_convert_encoding)
 	}
 
 	if (!num_from_encodings) {
-		efree(from_encodings);
+		efree((void *) from_encodings);
 		zend_argument_value_error(3, "must specify at least one encoding");
 		RETURN_THROWS();
 	}
@@ -2658,7 +2658,7 @@ PHP_FUNCTION(mb_convert_encoding)
 	}
 
 	if (free_from_encodings) {
-		efree(from_encodings);
+		efree((void *) from_encodings);
 	}
 }
 /* }}} */
@@ -2811,7 +2811,7 @@ PHP_FUNCTION(mb_detect_encoding)
 	}
 
 	if (size == 0) {
-		efree(elist);
+		efree((void *) elist);
 		zend_argument_value_error(2, "must specify at least one encoding");
 		RETURN_THROWS();
 	}
@@ -2826,7 +2826,7 @@ PHP_FUNCTION(mb_detect_encoding)
 	ret = mbfl_identify_encoding(&string, elist, size, strict);
 
 	if (free_elist) {
-		efree(elist);
+		efree((void *) elist);
 	}
 
 	if (ret == NULL) {
@@ -3191,7 +3191,7 @@ PHP_FUNCTION(mb_convert_variables)
 	}
 
 	if (elistsz == 0) {
-		efree(elist);
+		efree((void *) elist);
 		zend_argument_value_error(2, "must specify at least one encoding");
 		RETURN_THROWS();
 	}
@@ -3213,7 +3213,7 @@ PHP_FUNCTION(mb_convert_variables)
 			from_encoding = mbfl_encoding_detector_judge(identd);
 			mbfl_encoding_detector_delete(identd);
 			if (recursion_error) {
-				efree(elist);
+				efree((void *) elist);
 				php_error_docref(NULL, E_WARNING, "Cannot handle recursive references");
 				RETURN_FALSE;
 			}
@@ -3221,12 +3221,12 @@ PHP_FUNCTION(mb_convert_variables)
 
 		if (!from_encoding) {
 			php_error_docref(NULL, E_WARNING, "Unable to detect encoding");
-			efree(elist);
+			efree((void *) elist);
 			RETURN_FALSE;
 		}
 	}
 
-	efree(elist);
+	efree((void *) elist);
 
 	convd = mbfl_buffer_converter_new(from_encoding, to_encoding, 0);
 	/* If this assertion fails this means some memory allocation failure which is a bug */
@@ -4338,7 +4338,7 @@ static void php_mb_populate_current_detect_order_list(void)
 	if (MBSTRG(detect_order_list) && MBSTRG(detect_order_list_size)) {
 		nentries = MBSTRG(detect_order_list_size);
 		entry = (const mbfl_encoding **)safe_emalloc(nentries, sizeof(mbfl_encoding*), 0);
-		memcpy(entry, MBSTRG(detect_order_list), sizeof(mbfl_encoding*) * nentries);
+		memcpy((void *) entry, MBSTRG(detect_order_list), sizeof(mbfl_encoding*) * nentries);
 	} else {
 		const enum mbfl_no_encoding *src = MBSTRG(default_detect_order_list);
 		size_t i;

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -365,7 +365,7 @@ static int php_mb_parse_encoding_list(const char *value, size_t value_length,
 						zend_argument_value_error(arg_num, "contains invalid encoding \"%s\"", p1);
 					}
 					efree(tmpstr);
-					pefree((void *) list, persistent);
+					pefree(ZEND_VOIDP(list), persistent);
 					return FAILURE;
 				}
 
@@ -400,7 +400,7 @@ static int php_mb_parse_encoding_array(HashTable *target_hash, const mbfl_encodi
 	ZEND_HASH_FOREACH_VAL(target_hash, hash_entry) {
 		zend_string *encoding_str = zval_try_get_string(hash_entry);
 		if (UNEXPECTED(!encoding_str)) {
-			efree((void *) list);
+			efree(ZEND_VOIDP(list));
 			return FAILURE;
 		}
 
@@ -424,7 +424,7 @@ static int php_mb_parse_encoding_array(HashTable *target_hash, const mbfl_encodi
 			} else {
 				zend_argument_value_error(arg_num, "contains invalid encoding \"%s\"", ZSTR_VAL(encoding_str));
 				zend_string_release(encoding_str);
-				efree((void *) list);
+				efree(ZEND_VOIDP(list));
 				return FAILURE;
 			}
 		}
@@ -809,7 +809,7 @@ static PHP_INI_MH(OnUpdate_mbstring_detect_order)
 
 	if (!new_value) {
 		if (MBSTRG(detect_order_list)) {
-			pefree((void *) MBSTRG(detect_order_list), 1);
+			pefree(ZEND_VOIDP(MBSTRG(detect_order_list)), 1);
 		}
 		MBSTRG(detect_order_list) = NULL;
 		MBSTRG(detect_order_list_size) = 0;
@@ -821,7 +821,7 @@ static PHP_INI_MH(OnUpdate_mbstring_detect_order)
 	}
 
 	if (MBSTRG(detect_order_list)) {
-		pefree((void *) MBSTRG(detect_order_list), 1);
+		pefree(ZEND_VOIDP(MBSTRG(detect_order_list)), 1);
 	}
 	MBSTRG(detect_order_list) = list;
 	MBSTRG(detect_order_list_size) = size;
@@ -836,7 +836,7 @@ static int _php_mb_ini_mbstring_http_input_set(const char *new_value, size_t new
 		return FAILURE;
 	}
 	if (MBSTRG(http_input_list)) {
-		pefree((void *) MBSTRG(http_input_list), 1);
+		pefree(ZEND_VOIDP(MBSTRG(http_input_list)), 1);
 	}
 	MBSTRG(http_input_list) = list;
 	MBSTRG(http_input_list_size) = size;
@@ -1128,10 +1128,10 @@ ZEND_TSRMLS_CACHE_UPDATE();
 static PHP_GSHUTDOWN_FUNCTION(mbstring)
 {
 	if (mbstring_globals->http_input_list) {
-		free((void *) mbstring_globals->http_input_list);
+		free(ZEND_VOIDP(mbstring_globals->http_input_list));
 	}
 	if (mbstring_globals->detect_order_list) {
-		free((void *) mbstring_globals->detect_order_list);
+		free(ZEND_VOIDP(mbstring_globals->detect_order_list));
 	}
 	if (mbstring_globals->http_output_conv_mimetypes) {
 		_php_mb_free_regex(mbstring_globals->http_output_conv_mimetypes);
@@ -1236,7 +1236,7 @@ PHP_RINIT_FUNCTION(mbstring)
 PHP_RSHUTDOWN_FUNCTION(mbstring)
 {
 	if (MBSTRG(current_detect_order_list) != NULL) {
-		efree((void *) MBSTRG(current_detect_order_list));
+		efree(ZEND_VOIDP(MBSTRG(current_detect_order_list)));
 		MBSTRG(current_detect_order_list) = NULL;
 		MBSTRG(current_detect_order_list_size) = 0;
 	}
@@ -1510,13 +1510,13 @@ PHP_FUNCTION(mb_detect_order)
 		}
 
 		if (size == 0) {
-			efree((void *) list);
+			efree(ZEND_VOIDP(list));
 			zend_argument_value_error(1, "must specify at least one encoding");
 			RETURN_THROWS();
 		}
 
 		if (MBSTRG(current_detect_order_list)) {
-			efree((void *) MBSTRG(current_detect_order_list));
+			efree(ZEND_VOIDP(MBSTRG(current_detect_order_list)));
 		}
 		MBSTRG(current_detect_order_list) = list;
 		MBSTRG(current_detect_order_list_size) = size;
@@ -2632,7 +2632,7 @@ PHP_FUNCTION(mb_convert_encoding)
 	}
 
 	if (!num_from_encodings) {
-		efree((void *) from_encodings);
+		efree(ZEND_VOIDP(from_encodings));
 		zend_argument_value_error(3, "must specify at least one encoding");
 		RETURN_THROWS();
 	}
@@ -2658,7 +2658,7 @@ PHP_FUNCTION(mb_convert_encoding)
 	}
 
 	if (free_from_encodings) {
-		efree((void *) from_encodings);
+		efree(ZEND_VOIDP(from_encodings));
 	}
 }
 /* }}} */
@@ -2811,7 +2811,7 @@ PHP_FUNCTION(mb_detect_encoding)
 	}
 
 	if (size == 0) {
-		efree((void *) elist);
+		efree(ZEND_VOIDP(elist));
 		zend_argument_value_error(2, "must specify at least one encoding");
 		RETURN_THROWS();
 	}
@@ -2826,7 +2826,7 @@ PHP_FUNCTION(mb_detect_encoding)
 	ret = mbfl_identify_encoding(&string, elist, size, strict);
 
 	if (free_elist) {
-		efree((void *) elist);
+		efree(ZEND_VOIDP(elist));
 	}
 
 	if (ret == NULL) {
@@ -3191,7 +3191,7 @@ PHP_FUNCTION(mb_convert_variables)
 	}
 
 	if (elistsz == 0) {
-		efree((void *) elist);
+		efree(ZEND_VOIDP(elist));
 		zend_argument_value_error(2, "must specify at least one encoding");
 		RETURN_THROWS();
 	}
@@ -3213,7 +3213,7 @@ PHP_FUNCTION(mb_convert_variables)
 			from_encoding = mbfl_encoding_detector_judge(identd);
 			mbfl_encoding_detector_delete(identd);
 			if (recursion_error) {
-				efree((void *) elist);
+				efree(ZEND_VOIDP(elist));
 				php_error_docref(NULL, E_WARNING, "Cannot handle recursive references");
 				RETURN_FALSE;
 			}
@@ -3221,12 +3221,12 @@ PHP_FUNCTION(mb_convert_variables)
 
 		if (!from_encoding) {
 			php_error_docref(NULL, E_WARNING, "Unable to detect encoding");
-			efree((void *) elist);
+			efree(ZEND_VOIDP(elist));
 			RETURN_FALSE;
 		}
 	}
 
-	efree((void *) elist);
+	efree(ZEND_VOIDP(elist));
 
 	convd = mbfl_buffer_converter_new(from_encoding, to_encoding, 0);
 	/* If this assertion fails this means some memory allocation failure which is a bug */
@@ -4338,7 +4338,7 @@ static void php_mb_populate_current_detect_order_list(void)
 	if (MBSTRG(detect_order_list) && MBSTRG(detect_order_list_size)) {
 		nentries = MBSTRG(detect_order_list_size);
 		entry = (const mbfl_encoding **)safe_emalloc(nentries, sizeof(mbfl_encoding*), 0);
-		memcpy((void *) entry, MBSTRG(detect_order_list), sizeof(mbfl_encoding*) * nentries);
+		memcpy(ZEND_VOIDP(entry), MBSTRG(detect_order_list), sizeof(mbfl_encoding*) * nentries);
 	} else {
 		const enum mbfl_no_encoding *src = MBSTRG(default_detect_order_list);
 		size_t i;

--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -752,7 +752,7 @@ static mysqlnd_rsa_t
 mysqlnd_sha256_get_rsa_from_pem(const char *buf, size_t len)
 {
 	BCRYPT_KEY_HANDLE ret = 0;
-	LPCSTR der_buf = NULL;
+	LPSTR der_buf = NULL;
 	DWORD der_len;
 	CERT_PUBLIC_KEY_INFO *key_info = NULL;
 	DWORD key_info_len;

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -1843,7 +1843,7 @@ static zend_lifetime_interval** zend_jit_trace_allocate_registers(zend_jit_trace
 
 	memset(start, -1, sizeof(int) * ssa->vars_count * 2);
 	memset(flags, 0, sizeof(uint8_t) * ssa->vars_count);
-	memset(vars_op_array, 0, sizeof(zend_op_array*) * ssa->vars_count);
+	memset((void *) vars_op_array, 0, sizeof(zend_op_array*) * ssa->vars_count);
 
 	op_array = trace_buffer->op_array;
 	jit_extension =
@@ -5161,7 +5161,7 @@ static int zend_jit_setup_hot_trace_counters(zend_op_array *op_array)
 
 static void zend_jit_trace_init_caches(void)
 {
-	memset(JIT_G(bad_root_cache_opline), 0, sizeof(JIT_G(bad_root_cache_opline)));
+	memset((void *) JIT_G(bad_root_cache_opline), 0, sizeof(JIT_G(bad_root_cache_opline)));
 	memset(JIT_G(bad_root_cache_count), 0, sizeof(JIT_G(bad_root_cache_count)));
 	memset(JIT_G(bad_root_cache_stop), 0, sizeof(JIT_G(bad_root_cache_count)));
 	JIT_G(bad_root_slot) = 0;

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -1843,7 +1843,7 @@ static zend_lifetime_interval** zend_jit_trace_allocate_registers(zend_jit_trace
 
 	memset(start, -1, sizeof(int) * ssa->vars_count * 2);
 	memset(flags, 0, sizeof(uint8_t) * ssa->vars_count);
-	memset((void *) vars_op_array, 0, sizeof(zend_op_array*) * ssa->vars_count);
+	memset(ZEND_VOIDP(vars_op_array), 0, sizeof(zend_op_array*) * ssa->vars_count);
 
 	op_array = trace_buffer->op_array;
 	jit_extension =
@@ -5161,7 +5161,7 @@ static int zend_jit_setup_hot_trace_counters(zend_op_array *op_array)
 
 static void zend_jit_trace_init_caches(void)
 {
-	memset((void *) JIT_G(bad_root_cache_opline), 0, sizeof(JIT_G(bad_root_cache_opline)));
+	memset(ZEND_VOIDP(JIT_G(bad_root_cache_opline)), 0, sizeof(JIT_G(bad_root_cache_opline)));
 	memset(JIT_G(bad_root_cache_count), 0, sizeof(JIT_G(bad_root_cache_count)));
 	memset(JIT_G(bad_root_cache_stop), 0, sizeof(JIT_G(bad_root_cache_count)));
 	JIT_G(bad_root_slot) = 0;

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -183,7 +183,7 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_profile_helper(ZEND_OPCODE_HANDLE
 {
 	zend_op_array *op_array = (zend_op_array*)EX(func);
 	zend_jit_op_array_extension *jit_extension = (zend_jit_op_array_extension*)ZEND_FUNC_INFO(op_array);
-	zend_vm_opcode_handler_t handler = jit_extension->orig_handler;
+	zend_vm_opcode_handler_t handler = (zend_vm_opcode_handler_t) jit_extension->orig_handler;
 	++*(uintptr_t*)(EX(run_time_cache) + zend_jit_profile_counter_rid);
 	++zend_jit_profile_counter;
 	ZEND_OPCODE_TAIL_CALL(handler);

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -2601,7 +2601,7 @@ static int zend_jit_setup(void)
 	/* To find offset of "_tsrm_ls_cache" in TLS segment we perform a linear scan of local TLS memory */
 	/* Probably, it might be better solution */
 	do {
-		void ***tls_mem = ((void***)__readgsqword(0x58))[_tls_index];
+		void ***tls_mem = ((void**)__readgsqword(0x58))[_tls_index];
 		void *val = _tsrm_ls_cache;
 		size_t offset = 0;
 		size_t size = (char*)&_tls_end - (char*)&_tls_start;

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -420,7 +420,7 @@ static int pdo_odbc_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ 
 	}
 
 	rc = SQLSetConnectAttr(H->dbc, SQL_ATTR_AUTOCOMMIT,
-		(SQLPOINTER)(dbh->auto_commit ? SQL_AUTOCOMMIT_ON : SQL_AUTOCOMMIT_OFF), SQL_IS_INTEGER);
+		(SQLPOINTER)(intptr_t)(dbh->auto_commit ? SQL_AUTOCOMMIT_ON : SQL_AUTOCOMMIT_OFF), SQL_IS_INTEGER);
 	if (rc != SQL_SUCCESS) {
 		pdo_odbc_drv_error("SQLSetConnectAttr AUTOCOMMIT");
 		goto fail;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2821,7 +2821,7 @@ static PHP_MSHUTDOWN_FUNCTION(session) /* {{{ */
 	}
 
 	ps_serializers[PREDEFINED_SERIALIZERS].name = NULL;
-	memset(&ps_modules[PREDEFINED_MODULES], 0, (MAX_MODULES-PREDEFINED_MODULES)*sizeof(ps_module *));
+	memset((void *) &ps_modules[PREDEFINED_MODULES], 0, (MAX_MODULES-PREDEFINED_MODULES)*sizeof(ps_module *));
 
 	return SUCCESS;
 }

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2821,7 +2821,7 @@ static PHP_MSHUTDOWN_FUNCTION(session) /* {{{ */
 	}
 
 	ps_serializers[PREDEFINED_SERIALIZERS].name = NULL;
-	memset((void *) &ps_modules[PREDEFINED_MODULES], 0, (MAX_MODULES-PREDEFINED_MODULES)*sizeof(ps_module *));
+	memset(ZEND_VOIDP(&ps_modules[PREDEFINED_MODULES]), 0, (MAX_MODULES-PREDEFINED_MODULES)*sizeof(ps_module *));
 
 	return SUCCESS;
 }

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1507,7 +1507,7 @@ PHP_METHOD(SNMP, __construct)
 		case SNMP_VERSION_3:
 			break;
 		default:
-			zend_argument_value_error(zend_ce_exception, 1, "must be a valid SNMP protocol version");
+			zend_argument_value_error(1, "must be a valid SNMP protocol version");
 			RETURN_THROWS();
 	}
 

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -711,7 +711,7 @@ static void from_zval_write_sockaddr_aux(const zval *container,
 	if ((elem = zend_hash_str_find(Z_ARRVAL_P(container), "family", sizeof("family") - 1)) != NULL
 			&& Z_TYPE_P(elem) != IS_NULL) {
 		const char *node = "family";
-		zend_llist_add_element(&ctx->keys, &node);
+		zend_llist_add_element(&ctx->keys, (void *) &node);
 		from_zval_write_int(elem, (char*)&family, ctx);
 		zend_llist_remove_tail(&ctx->keys);
 	} else {
@@ -1454,7 +1454,7 @@ void *from_zval_run_conversions(const zval			*container,
 
 	structure = ecalloc(1, struct_size);
 
-	zend_llist_add_element(&ctx.keys, &top_name);
+	zend_llist_add_element(&ctx.keys, (void *) &top_name);
 	zend_llist_add_element(&ctx.allocations, &structure);
 
 	/* main call */
@@ -1489,7 +1489,7 @@ zval *to_zval_run_conversions(const char *structure,
 
 	memset(&ctx, 0, sizeof(ctx));
 	zend_llist_init(&ctx.keys, sizeof(const char *), NULL, 0);
-	zend_llist_add_element(&ctx.keys, &top_name);
+	zend_llist_add_element(&ctx.keys, (void *) &top_name);
 
 	zend_hash_init(&ctx.params, 8, NULL, NULL, 0);
 	for (kv = key_value_pairs; kv->key != NULL; kv++) {

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -711,7 +711,7 @@ static void from_zval_write_sockaddr_aux(const zval *container,
 	if ((elem = zend_hash_str_find(Z_ARRVAL_P(container), "family", sizeof("family") - 1)) != NULL
 			&& Z_TYPE_P(elem) != IS_NULL) {
 		const char *node = "family";
-		zend_llist_add_element(&ctx->keys, (void *) &node);
+		zend_llist_add_element(&ctx->keys, &node);
 		from_zval_write_int(elem, (char*)&family, ctx);
 		zend_llist_remove_tail(&ctx->keys);
 	} else {
@@ -1454,7 +1454,7 @@ void *from_zval_run_conversions(const zval			*container,
 
 	structure = ecalloc(1, struct_size);
 
-	zend_llist_add_element(&ctx.keys, (void *) &top_name);
+	zend_llist_add_element(&ctx.keys, &top_name);
 	zend_llist_add_element(&ctx.allocations, &structure);
 
 	/* main call */
@@ -1489,7 +1489,7 @@ zval *to_zval_run_conversions(const char *structure,
 
 	memset(&ctx, 0, sizeof(ctx));
 	zend_llist_init(&ctx.keys, sizeof(const char *), NULL, 0);
-	zend_llist_add_element(&ctx.keys, (void *) &top_name);
+	zend_llist_add_element(&ctx.keys, &top_name);
 
 	zend_hash_init(&ctx.params, 8, NULL, NULL, 0);
 	for (kv = key_value_pairs; kv->key != NULL; kv++) {

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -36,6 +36,10 @@
 #include <fcntl.h>
 #endif
 
+#ifdef PHP_WIN32
+# pragma warning(disable: 4024 4047)
+#endif
+
 /* This symbol is defined in ext/standard/config.m4.
  * Essentially, it is set if you HAVE_FORK || PHP_WIN32
  * Other platforms may modify that configure check and add suitable #ifdefs

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -36,10 +36,6 @@
 #include <fcntl.h>
 #endif
 
-#ifdef PHP_WIN32
-# pragma warning(disable: 4024 4047)
-#endif
-
 /* This symbol is defined in ext/standard/config.m4.
  * Essentially, it is set if you HAVE_FORK || PHP_WIN32
  * Other platforms may modify that configure check and add suitable #ifdefs
@@ -844,6 +840,7 @@ static int set_proc_descriptor_from_resource(zval *resource, descriptorspec_item
 	return SUCCESS;
 }
 
+#ifndef PHP_WIN32
 static int close_parentends_of_pipes(descriptorspec_item *descriptors, int ndesc)
 {
 	/* We are running in child process
@@ -866,6 +863,7 @@ static int close_parentends_of_pipes(descriptorspec_item *descriptors, int ndesc
 
 	return SUCCESS;
 }
+#endif
 
 static void close_all_descriptors(descriptorspec_item *descriptors, int ndesc)
 {

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1109,7 +1109,7 @@ PHPAPI void php_explode_negative_limit(const zend_string *delim, zend_string *st
 		do {
 			if (found >= allocated) {
 				allocated = found + EXPLODE_ALLOC_STEP;/* make sure we have enough memory */
-				positions = erealloc((void *) positions, allocated*sizeof(char *));
+				positions = erealloc(ZEND_VOIDP(positions), allocated*sizeof(char *));
 			}
 			positions[found++] = p1 = p2 + ZSTR_LEN(delim);
 			p2 = php_memnstr(p1, ZSTR_VAL(delim), ZSTR_LEN(delim), endp);

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1109,7 +1109,7 @@ PHPAPI void php_explode_negative_limit(const zend_string *delim, zend_string *st
 		do {
 			if (found >= allocated) {
 				allocated = found + EXPLODE_ALLOC_STEP;/* make sure we have enough memory */
-				positions = erealloc(positions, allocated*sizeof(char *));
+				positions = erealloc((void *) positions, allocated*sizeof(char *));
 			}
 			positions[found++] = p1 = p2 + ZSTR_LEN(delim);
 			p2 = php_memnstr(p1, ZSTR_VAL(delim), ZSTR_LEN(delim), endp);

--- a/ext/zend_test/config.w32
+++ b/ext/zend_test/config.w32
@@ -4,4 +4,5 @@ ARG_ENABLE("zend-test", "enable zend-test extension", "no");
 
 if (PHP_ZEND_TEST != "no") {
 	EXTENSION("zend_test", "test.c", PHP_ZEND_TEST_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	ADD_FLAG("CFLAGS_ZEND_TEST", "/D PHP_ZEND_TEST_EXPORTS ");
 }

--- a/ext/zend_test/php_test.h
+++ b/ext/zend_test/php_test.h
@@ -35,7 +35,17 @@ struct bug79096 {
 	uint64_t b;
 };
 
-ZEND_API struct bug79096 bug79096(void);
-ZEND_API void bug79532(off_t *array, size_t elems);
+#ifdef PHP_WIN32
+#	ifdef PHP_ZEND_TEST_EXPORTS
+#		define PHP_ZEND_TEST_API __declspec(dllexport)
+#	else
+#		define PHP_ZEND_TEST_API __declspec(dllimport)
+#	endif
+#else
+#	define PHP_ZEND_TEST_API ZEND_API
+#endif
+
+PHP_ZEND_TEST_API struct bug79096 bug79096(void);
+PHP_ZEND_TEST_API void bug79532(off_t *array, size_t elems);
 
 #endif

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -320,7 +320,7 @@ ZEND_TSRMLS_CACHE_DEFINE()
 ZEND_GET_MODULE(zend_test)
 #endif
 
-struct bug79096 bug79096(void)
+PHP_ZEND_TEST_API struct bug79096 bug79096(void)
 {
   struct bug79096 b;
 
@@ -329,7 +329,7 @@ struct bug79096 bug79096(void)
   return b;
 }
 
-void bug79532(off_t *array, size_t elems)
+PHP_ZEND_TEST_API void bug79532(off_t *array, size_t elems)
 {
 	int i;
 	for (i = 0; i < elems; i++) {

--- a/sapi/apache2handler/apache_config.c
+++ b/sapi/apache2handler/apache_config.c
@@ -17,6 +17,12 @@
 #define ZEND_INCLUDE_FULL_WINDOWS_HEADERS
 
 #include "php.h"
+#ifdef strcasecmp
+# undef strcasecmp
+#endif
+#ifdef strncasecmp
+# undef strncasecmp
+#endif
 #include "php_ini.h"
 #include "php_apache.h"
 

--- a/sapi/apache2handler/mod_php.c
+++ b/sapi/apache2handler/mod_php.c
@@ -19,6 +19,12 @@
 #define ZEND_INCLUDE_FULL_WINDOWS_HEADERS
 
 #include "php.h"
+#ifdef strcasecmp
+# undef strcasecmp
+#endif
+#ifdef strncasecmp
+# undef strncasecmp
+#endif
 #include "php_apache.h"
 
 AP_MODULE_DECLARE_DATA module php_module = {

--- a/sapi/apache2handler/php_functions.c
+++ b/sapi/apache2handler/php_functions.c
@@ -17,6 +17,12 @@
 #define ZEND_INCLUDE_FULL_WINDOWS_HEADERS
 
 #include "php.h"
+#ifdef strcasecmp
+# undef strcasecmp
+#endif
+#ifdef strncasecmp
+# undef strncasecmp
+#endif
 #include "zend_smart_str.h"
 #include "ext/standard/info.h"
 #include "ext/standard/head.h"

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -19,6 +19,12 @@
 #define ZEND_INCLUDE_FULL_WINDOWS_HEADERS
 
 #include "php.h"
+#ifdef strcasecmp
+# undef strcasecmp
+#endif
+#ifdef strncasecmp
+# undef strncasecmp
+#endif
 #include "php_main.h"
 #include "php_ini.h"
 #include "php_variables.h"

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -2067,7 +2067,7 @@ phpdbg_out:
 			settings->oplog = PHPDBG_G(oplog);
 			settings->prompt[0] = PHPDBG_G(prompt)[0];
 			settings->prompt[1] = PHPDBG_G(prompt)[1];
-			memcpy(settings->colors, PHPDBG_G(colors), sizeof(settings->colors));
+			memcpy((void *) settings->colors, PHPDBG_G(colors), sizeof(settings->colors));
 			settings->eol = PHPDBG_G(eol);
 			settings->input_buflen = PHPDBG_G(input_buflen);
 			memcpy(settings->input_buffer, PHPDBG_G(input_buffer), settings->input_buflen);

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -2067,7 +2067,7 @@ phpdbg_out:
 			settings->oplog = PHPDBG_G(oplog);
 			settings->prompt[0] = PHPDBG_G(prompt)[0];
 			settings->prompt[1] = PHPDBG_G(prompt)[1];
-			memcpy((void *) settings->colors, PHPDBG_G(colors), sizeof(settings->colors));
+			memcpy(ZEND_VOIDP(settings->colors), PHPDBG_G(colors), sizeof(settings->colors));
 			settings->eol = PHPDBG_G(eol);
 			settings->input_buflen = PHPDBG_G(input_buflen);
 			memcpy(settings->input_buffer, PHPDBG_G(input_buffer), settings->input_buflen);

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -1707,7 +1707,7 @@ void phpdbg_execute_ex(zend_execute_data *execute_data) /* {{{ */
 
 #ifdef ZEND_WIN32
 		if (EG(timed_out)) {
-			zend_timeout(0);
+			zend_timeout();
 		}
 #endif
 

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3207,7 +3207,7 @@ function toolset_setup_common_cflags()
 
 	// General CFLAGS for building objects
 	DEFINE("CFLAGS", "/nologo $(BASE_INCLUDES) /D _WINDOWS /D WINDOWS=1 \
-		/D ZEND_WIN32=1 /D PHP_WIN32=1 /D WIN32 /D _MBCS /W3 \
+		/D ZEND_WIN32=1 /D PHP_WIN32=1 /D WIN32 /D _MBCS \
 		/D _USE_MATH_DEFINES");
 
 	if (envCFLAGS) {
@@ -3399,7 +3399,7 @@ function toolset_setup_common_libs()
 function toolset_setup_build_mode()
 {
 	if (PHP_DEBUG == "yes") {
-		ADD_FLAG("CFLAGS", "/LDd /MDd /W3 /Od /D _DEBUG /D ZEND_DEBUG=1 " +
+		ADD_FLAG("CFLAGS", "/LDd /MDd /Od /D _DEBUG /D ZEND_DEBUG=1 " +
 			(X64?"/Zi":"/ZI"));
 		ADD_FLAG("LDFLAGS", "/debug");
 		// Avoid problems when linking to release libraries that use the release
@@ -3411,7 +3411,7 @@ function toolset_setup_build_mode()
 			ADD_FLAG("CFLAGS", "/Zi");
 			ADD_FLAG("LDFLAGS", "/incremental:no /debug /opt:ref,icf");
 		}
-		ADD_FLAG("CFLAGS", "/LD /MD /W3");
+		ADD_FLAG("CFLAGS", "/LD /MD");
 		if (PHP_SANITIZER == "yes" && CLANG_TOOLSET) {
 			ADD_FLAG("CFLAGS", "/Od /D NDebug /D NDEBUG /D ZEND_WIN32_NEVER_INLINE /D ZEND_DEBUG=0");
 		} else {

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -439,7 +439,7 @@ PHP_WINUTIL_API char *php_win32_get_username(void)
 static zend_always_inline BOOL is_compatible(const char *name, BOOL is_smaller, char *format, char **err)
 {/*{{{*/
 	/* work around ImageLoad() issue */
-	char *name_stripped = name;
+	const char *name_stripped = name;
 	if (name[0] == '.' && IS_SLASH(name[1])) {
 		name_stripped += 2;
 	}


### PR DESCRIPTION
We fix (hopefully) all instances of:

* <https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4005>
* <https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4024>
* <https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4028>
* <https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4047>
* <https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4087>
* <https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4090>
* <https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4273>
* <https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4312>

PS: proc_open.c has some C4024 and C4047 warnings which I suppressed for now. This should be revised; it might be beneficial to define [`php_file_descriptor_t`](https://github.com/php/php-src/blob/cf3b133a86e45fddf862d3d0dc579d51d661afa8/ext/standard/proc_open.h#L18) as (unnamed) union.