### PR TITLE
Fix #73927: phpdbg fails with windows error prompt at "watch array"

### DIFF
--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -473,11 +473,7 @@ PHPDBG_API int phpdbg_parse_variable_with_arg(char *input, size_t len, HashTable
 		if (new_index && index_len == 0) {
 			zend_ulong numkey;
 			zend_string *strkey;
-			ZEND_HASH_FOREACH_KEY_VAL(parent, numkey, strkey, zv) {
-				while (Z_TYPE_P(zv) == IS_INDIRECT) {
-					zv = Z_INDIRECT_P(zv);
-				}
-
+			ZEND_HASH_FOREACH_KEY_VAL_IND(parent, numkey, strkey, zv) {
 				if (i == len || (i == len - 1 && input[len - 1] == ']')) {
 					char *key, *propkey;
 					size_t namelen, keylen;

--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -473,7 +473,7 @@ PHPDBG_API int phpdbg_parse_variable_with_arg(char *input, size_t len, HashTable
 		if (new_index && index_len == 0) {
 			zend_ulong numkey;
 			zend_string *strkey;
-			ZEND_HASH_FOREACH_KEY_PTR(parent, numkey, strkey, zv) {
+			ZEND_HASH_FOREACH_KEY_VAL(parent, numkey, strkey, zv) {
 				while (Z_TYPE_P(zv) == IS_INDIRECT) {
 					zv = Z_INDIRECT_P(zv);
 				}

--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -713,9 +713,8 @@ void phpdbg_automatic_dequeue_free(phpdbg_watch_element *element) {
 		child = child->child;
 	}
 	PHPDBG_G(watchpoint_hit) = 1;
-	if (zend_hash_index_find(&PHPDBG_G(watch_elements), child->id)) {
+	if (zend_hash_index_del(&PHPDBG_G(watch_elements), child->id) == SUCCESS) {
 		phpdbg_notice("watchdelete", "variable=\"%.*s\" recursive=\"%s\"", "%.*s has been removed, removing watchpoint%s", (int) ZSTR_LEN(child->str), ZSTR_VAL(child->str), (child->flags & PHPDBG_WATCH_RECURSIVE_ROOT) ? " recursively" : "");
-		zend_hash_index_del(&PHPDBG_G(watch_elements), child->id);
 	}
 	phpdbg_free_watch_element_tree(element);
 }

--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -713,8 +713,10 @@ void phpdbg_automatic_dequeue_free(phpdbg_watch_element *element) {
 		child = child->child;
 	}
 	PHPDBG_G(watchpoint_hit) = 1;
-	phpdbg_notice("watchdelete", "variable=\"%.*s\" recursive=\"%s\"", "%.*s has been removed, removing watchpoint%s", (int) ZSTR_LEN(child->str), ZSTR_VAL(child->str), (child->flags & PHPDBG_WATCH_RECURSIVE_ROOT) ? " recursively" : "");
-	zend_hash_index_del(&PHPDBG_G(watch_elements), child->id);
+	if (zend_hash_index_find(&PHPDBG_G(watch_elements), child->id)) {
+		phpdbg_notice("watchdelete", "variable=\"%.*s\" recursive=\"%s\"", "%.*s has been removed, removing watchpoint%s", (int) ZSTR_LEN(child->str), ZSTR_VAL(child->str), (child->flags & PHPDBG_WATCH_RECURSIVE_ROOT) ? " recursively" : "");
+		zend_hash_index_del(&PHPDBG_G(watch_elements), child->id);
+	}
 	phpdbg_free_watch_element_tree(element);
 }
 

--- a/sapi/phpdbg/tests/bug73927.phpt
+++ b/sapi/phpdbg/tests/bug73927.phpt
@@ -21,7 +21,6 @@ prompt> [Breakpoint #0 at %s:%d, hits: 2]
 prompt> [Added watchpoint #0 for $value]
 prompt> [Added watchpoint #1 for $lower[0]]
 prompt> [$lower[0] has been removed, removing watchpoint]
-[$lower[0] has been removed, removing watchpoint]
 [$value has been removed, removing watchpoint]
 --FILE--
 <?php

--- a/sapi/phpdbg/tests/bug73927.phpt
+++ b/sapi/phpdbg/tests/bug73927.phpt
@@ -7,14 +7,14 @@ c
 w $value
 w $lower[]
 q
---EXPECT--
-[Successful compilation of C:\php-sdk\phpdev\vc15\x64\php-src-pr5599\sapi\phpdbg\tests\bug73927.php]
-prompt> [Breakpoint #0 added at C:\php-sdk\phpdev\vc15\x64\php-src-pr5599\sapi\phpdbg\tests\bug73927.php:19]
-prompt> [Breakpoint #0 at C:\php-sdk\phpdev\vc15\x64\php-src-pr5599\sapi\phpdbg\tests\bug73927.php:19, hits: 1]
+--EXPECTF--
+[Successful compilation of %s]
+prompt> [Breakpoint #0 added at %s:%d]
+prompt> [Breakpoint #0 at %s:%d, hits: 1]
 >00019:     if ($value < 100) {
  00020:         $lower[] = $value;
  00021:     } else {
-prompt> [Breakpoint #0 at C:\php-sdk\phpdev\vc15\x64\php-src-pr5599\sapi\phpdbg\tests\bug73927.php:19, hits: 2]
+prompt> [Breakpoint #0 at %s:%d, hits: 2]
 >00019:     if ($value < 100) {
  00020:         $lower[] = $value;
  00021:     } else {

--- a/sapi/phpdbg/tests/bug73927.phpt
+++ b/sapi/phpdbg/tests/bug73927.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Bug #73927 (phpdbg fails with windows error prompt at "watch array")
+--PHPDBG--
+b 19
+r
+c
+w $value
+w $lower[]
+q
+--EXPECT--
+[Successful compilation of C:\php-sdk\phpdev\vc15\x64\php-src-pr5599\sapi\phpdbg\tests\bug73927.php]
+prompt> [Breakpoint #0 added at C:\php-sdk\phpdev\vc15\x64\php-src-pr5599\sapi\phpdbg\tests\bug73927.php:19]
+prompt> [Breakpoint #0 at C:\php-sdk\phpdev\vc15\x64\php-src-pr5599\sapi\phpdbg\tests\bug73927.php:19, hits: 1]
+>00019:     if ($value < 100) {
+ 00020:         $lower[] = $value;
+ 00021:     } else {
+prompt> [Breakpoint #0 at C:\php-sdk\phpdev\vc15\x64\php-src-pr5599\sapi\phpdbg\tests\bug73927.php:19, hits: 2]
+>00019:     if ($value < 100) {
+ 00020:         $lower[] = $value;
+ 00021:     } else {
+prompt> [Added watchpoint #0 for $value]
+prompt> [Added watchpoint #1 for $lower[0]]
+prompt> [$lower[0] has been removed, removing watchpoint]
+[$lower[0] has been removed, removing watchpoint]
+[$value has been removed, removing watchpoint]
+--FILE--
+<?php
+
+// Generate some mock data
+$example = [1, 23, 23423, 256436, 3463, 4363, 457];
+foreach (range(1, 1000) as $val) {
+    $example[] = mt_rand(1, 10000);
+}
+
+// Stuff to debug
+function doCoolStuff($value)
+{
+    $value++;
+
+    return mt_rand(1, 1000);
+}
+
+$lower = [];
+foreach ($example as $key => $value) {
+    if ($value < 100) {
+        $lower[] = $value;
+    } else {
+        doCoolStuff($value);
+    }
+}
+
+?>


### PR DESCRIPTION
We expect zvals, so we should request zvals.