### PR TITLE
Mark several phpdbg tests as xfail

### DIFF
--- a/sapi/phpdbg/tests/breakpoints_001.phpt
+++ b/sapi/phpdbg/tests/breakpoints_001.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Fundamental breakpoints functionality
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --PHPDBG--
 b 3
 r

--- a/sapi/phpdbg/tests/breakpoints_002.phpt
+++ b/sapi/phpdbg/tests/breakpoints_002.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Preserve breakpoints on restart
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --PHPDBG--
 b breakpoints_002.php:4
 r

--- a/sapi/phpdbg/tests/breakpoints_003.phpt
+++ b/sapi/phpdbg/tests/breakpoints_003.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Test deleting breakpoints
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --PHPDBG--
 b 4
 b del 0

--- a/sapi/phpdbg/tests/breakpoints_004.phpt
+++ b/sapi/phpdbg/tests/breakpoints_004.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Test opcode breakpoints
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --PHPDBG--
 b ZEND_ECHO
 r

--- a/sapi/phpdbg/tests/exceptions_003.phpt
+++ b/sapi/phpdbg/tests/exceptions_003.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Test breaks on HANDLE_EXCEPTION
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --PHPDBG--
 b 5
 r

--- a/sapi/phpdbg/tests/finish_leave_001.phpt
+++ b/sapi/phpdbg/tests/finish_leave_001.phpt
@@ -1,5 +1,11 @@
 --TEST--
 test finish and leave commands
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --INI--
 opcache.optimization_level=0
 --PHPDBG--

--- a/sapi/phpdbg/tests/info_002.phpt
+++ b/sapi/phpdbg/tests/info_002.phpt
@@ -1,5 +1,11 @@
 --TEST--
 info constants test
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --PHPDBG--
 b 10
 r

--- a/sapi/phpdbg/tests/next_001.phpt
+++ b/sapi/phpdbg/tests/next_001.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Test next command on function boundaries
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --PHPDBG--
 b 4
 r

--- a/sapi/phpdbg/tests/phpdbg_break_next.phpt
+++ b/sapi/phpdbg/tests/phpdbg_break_next.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Test phpdbg_break_next() function
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --PHPDBG--
 r
 c

--- a/sapi/phpdbg/tests/run_002.phpt
+++ b/sapi/phpdbg/tests/run_002.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Stdin and escaped args being passed to run command
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --CLEAN--
 <?php
 @unlink("run_002_tmp.fixture");

--- a/sapi/phpdbg/tests/set_exception_handler.phpt
+++ b/sapi/phpdbg/tests/set_exception_handler.phpt
@@ -1,5 +1,11 @@
 --TEST--
 set_exception_handler() in phpdbg
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
+?>
 --PHPDBG--
 r
 c

--- a/sapi/phpdbg/tests/watch_001.phpt
+++ b/sapi/phpdbg/tests/watch_001.phpt
@@ -5,6 +5,9 @@ Test simple recursive watchpoint
 if (PHP_INT_SIZE == 4) {
     die("xfail There may be flaws in the implementation of watchpoints that cause failures");
 }
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
 if (getenv('SKIP_ASAN')) {
     die("skip intentionally causes segfaults");
 }

--- a/sapi/phpdbg/tests/watch_002.phpt
+++ b/sapi/phpdbg/tests/watch_002.phpt
@@ -5,6 +5,9 @@ Test simple array watchpoint with replace
 if (PHP_INT_SIZE == 4) {
     die("xfail There may be flaws in the implementation of watchpoints that cause failures");
 }
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
 if (getenv('SKIP_ASAN')) {
     die("skip intentionally causes segfaults");
 }

--- a/sapi/phpdbg/tests/watch_003.phpt
+++ b/sapi/phpdbg/tests/watch_003.phpt
@@ -5,6 +5,9 @@ Test simple watchpoint with replace
 if (PHP_INT_SIZE == 4) {
     die("xfail There may be flaws in the implementation of watchpoints that cause failures");
 }
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
 if (getenv('SKIP_ASAN')) {
     die("skip intentionally causes segfaults");
 }

--- a/sapi/phpdbg/tests/watch_004.phpt
+++ b/sapi/phpdbg/tests/watch_004.phpt
@@ -5,6 +5,9 @@ Test detection of inline string manipulations on zval watch
 if (PHP_INT_SIZE == 4) {
     die("xfail There may be flaws in the implementation of watchpoints that cause failures");
 }
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
 if (getenv('SKIP_ASAN')) {
     die("skip intentionally causes segfaults");
 }

--- a/sapi/phpdbg/tests/watch_005.phpt
+++ b/sapi/phpdbg/tests/watch_005.phpt
@@ -5,6 +5,9 @@ Test proper watch comparisons when having multiple levels of indirection from a 
 if (PHP_INT_SIZE == 4) {
     die("xfail There may be flaws in the implementation of watchpoints that cause failures");
 }
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
 if (getenv('SKIP_ASAN')) {
     die("skip intentionally causes segfaults");
 }

--- a/sapi/phpdbg/tests/watch_006.phpt
+++ b/sapi/phpdbg/tests/watch_006.phpt
@@ -5,6 +5,9 @@ Test multiple watch elements pointing to the same watchpoint
 if (PHP_INT_SIZE == 4) {
     die("xfail There may be flaws in the implementation of watchpoints that cause failures");
 }
+if (PHP_OS_FAMILY === 'Windows' && ini_get('opcache.jit') && ini_get('opcache.jit_buffer_size')) {
+    die('xfail breakpoint/watchpoint issues with JIT on Windows');
+}
 if (getenv('SKIP_ASAN')) {
     die("skip intentionally causes segfaults");
 }


### PR DESCRIPTION
Apparently, breakpoints and watchpoints are practically disabled if
run with OPcache JIT under Windows, so we mark the affected tests as
xfail in that case for the time being.

---

I'm not sure about the check for OPcache JIT being disabled. Can that be improved?