### PR TITLE
Avoid unnecessary linking of Windows DLLs

### DIFF
--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -32,13 +32,13 @@ if (PHP_OPCACHE != "no") {
 
 			ADD_MAKEFILE_FRAGMENT(configure_module_dirname + "\\jit\\Makefile.frag.w32");
 
-			ADD_SOURCES(configure_module_dirname + "\\jit", "zend_jit.c zend_jit_vm_helpers.c", "opcache", "opcache_jit");
+			ADD_SOURCES(configure_module_dirname + "\\jit", "zend_jit.c zend_jit_vm_helpers.c", "opcache", "ext\\opcache\\jit");
 		} else {
 			WARNING("JIT not enabled, headers not found");
 		}
 	}
 
-	ADD_SOURCES(configure_module_dirname + "/Optimizer", "zend_optimizer.c pass1.c pass3.c optimize_func_calls.c block_pass.c optimize_temp_vars_5.c nop_removal.c compact_literals.c zend_cfg.c zend_dfg.c dfa_pass.c zend_ssa.c zend_inference.c zend_func_info.c zend_call_graph.c zend_dump.c escape_analysis.c compact_vars.c dce.c sccp.c scdf.c", "opcache", "OptimizerObj");
+	ADD_SOURCES(configure_module_dirname + "/Optimizer", "zend_optimizer.c pass1.c pass3.c optimize_func_calls.c block_pass.c optimize_temp_vars_5.c nop_removal.c compact_literals.c zend_cfg.c zend_dfg.c dfa_pass.c zend_ssa.c zend_inference.c zend_func_info.c zend_call_graph.c zend_dump.c escape_analysis.c compact_vars.c dce.c sccp.c scdf.c", "opcache", "ext\\opcache\\Optimizer");
 
 	ADD_FLAG('CFLAGS_OPCACHE', "/I " + configure_module_dirname);
 

--- a/ext/opcache/jit/Makefile.frag.w32
+++ b/ext/opcache/jit/Makefile.frag.w32
@@ -6,7 +6,7 @@ ext\opcache\jit\zend_jit_x86.c: ext\opcache\jit\zend_jit_x86.dasc $(BUILD_DIR)\\
 	@if exist ext\opcache\jit\zend_jit_x86.c del ext\opcache\jit\zend_jit_x86.c
 	$(BUILD_DIR)\\minilua.exe ext/opcache/jit/dynasm/dynasm.lua $(DASM_FLAGS) -o $@ ext/opcache/jit/zend_jit_x86.dasc
 
-$(BUILD_DIR)\opcache_jit\zend_jit.obj: \
+$(BUILD_DIR)\ext\opcache\jit\zend_jit.obj: \
 	ext/opcache/jit/zend_jit_x86.c \
 	ext/opcache/jit/zend_jit_helpers.c \
 	ext/opcache/jit/zend_jit_disasm_x86.c \


### PR DESCRIPTION
For snapshot builds (`--enable-snapshot-build`), after the build has
been completely finished, running `nmake` causes a lot of DLLs to be
rebuilt.  The problem is that the build folders OptimizerObj and
opcache_jit are dependencies of the main PHP DLL, but these folders do
not exists in the source tree, so nmake assumes it has to re-link the
main PHP DLL, and that makes several other DLLs stale.

We solve that by mirroring the folder structure of the respective
source folders.