### PR TITLE
Build fix for newer versions of NetBSD.

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -48,6 +48,10 @@
 # elif defined(__FreeBSD__)
 /* FreeBSD defines `openpty` in <libutil.h> */
 #  include <libutil.h>
+# elif defined(__NetBSD__)
+/* On recent NetBSD releases the emalloc, estrdup ... calls had been introduced in libutil */
+#  include <sys/termios.h>
+extern int openpty(int *, int *, char *, struct termios *, struct winsize *);
 # else
 /* Mac OS X (and some BSDs) define `openpty` in <util.h> */
 #  include <util.h>


### PR DESCRIPTION
its libutil contains newer conflicting apis as estrdup, emalloc.