### PR TITLE
Make Exception::$trace typed array property

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3586,19 +3586,13 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 		Z_PROP_FLAG_P(property_default_ptr) = Z_ISUNDEF_P(property) ? IS_PROP_UNINIT : 0;
 	}
 	if (ce->type & ZEND_INTERNAL_CLASS) {
-		switch(Z_TYPE_P(property)) {
-			case IS_ARRAY:
-			case IS_OBJECT:
-			case IS_RESOURCE:
-				zend_error_noreturn(E_CORE_ERROR, "Internal zval's can't be arrays, objects or resources");
-				break;
-			default:
-				break;
-		}
-
 		/* Must be interned to avoid ZTS data races */
 		if (is_persistent_class(ce)) {
 			name = zend_new_interned_string(zend_string_copy(name));
+		}
+
+		if (Z_REFCOUNTED_P(property)) {
+			zend_error_noreturn(E_CORE_ERROR, "Internal zvals cannot be refcounted");
 		}
 	}
 

--- a/ext/standard/tests/serialize/bug69152.phpt
+++ b/ext/standard/tests/serialize/bug69152.phpt
@@ -9,6 +9,8 @@ $x->test();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Trace is not an array in %s:%d
-%a
+Fatal error: Uncaught TypeError: Cannot assign string to property Exception::$trace of type array in %s:%d
+Stack trace:
+#0 %s(%d): unserialize('O:9:"exception"...')
+#1 {main}
   thrown in %s on line %d

--- a/ext/standard/tests/serialize/bug70963.phpt
+++ b/ext/standard/tests/serialize/bug70963.phpt
@@ -6,25 +6,8 @@ var_dump(unserialize('a:2:{i:0;O:9:"exception":1:{s:16:"'."\0".'Exception'."\0".
 var_dump(unserialize('a:2:{i:0;O:9:"exception":1:{s:16:"'."\0".'Exception'."\0".'trace";s:4:"test";}i:1;r:3;}'));
 ?>
 --EXPECTF--
-array(2) {
-  [0]=>
-  object(Exception)#%d (6) {
-    ["message":protected]=>
-    string(0) ""
-    ["string":"Exception":private]=>
-    string(0) ""
-    ["code":protected]=>
-    int(0)
-    ["file":protected]=>
-    string(%d) "%s"
-    ["line":protected]=>
-    int(2)
-    ["previous":"Exception":private]=>
-    NULL
-  }
-  [1]=>
-  string(4) "test"
-}
-
-Notice: unserialize(): Error at offset %d of %d bytes in %sbug70963.php on line 3
-bool(false)
+Fatal error: Uncaught TypeError: Cannot assign string to property Exception::$trace of type array in %s:%d
+Stack trace:
+#0 %s(%d): unserialize('a:2:{i:0;O:9:"e...')
+#1 {main}
+  thrown in %s on line %d

--- a/sapi/cli/tests/005.phpt
+++ b/sapi/cli/tests/005.phpt
@@ -37,7 +37,7 @@ string(183) "Class [ <internal:Core> class stdClass ] {
 }
 
 "
-string(2159) "Class [ <internal:Core> class Exception implements Throwable, Stringable ] {
+string(2166) "Class [ <internal:Core> class Exception implements Throwable, Stringable ] {
 
   - Constants [0] {
   }
@@ -54,7 +54,7 @@ string(2159) "Class [ <internal:Core> class Exception implements Throwable, Stri
     Property [ protected $code = 0 ]
     Property [ protected $file = NULL ]
     Property [ protected $line = NULL ]
-    Property [ private $trace = NULL ]
+    Property [ private array $trace = Array ]
     Property [ private $previous = NULL ]
   }
 


### PR DESCRIPTION
This is a private property, so we are allowed to add a type. The new declaration of the property is

```
private array $trace = [];
```

This ensures that `Exception::getTrace()` does indeed return an array.

Userland code that was removing the trace by assigning null via reflection needs to be updated to assign `[]` instead.