### PR TITLE
Respect --program-suffix when installing phar

### DIFF
--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -42,9 +42,9 @@ $(builddir)/phar.phar: $(builddir)/phar.php $(builddir)/phar/phar.inc $(srcdir)/
 
 install-pharcmd: pharcmd
 	-@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
-	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)
+	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)/phar.phar$(program_suffix)
 	-@rm -f $(INSTALL_ROOT)$(bindir)/phar
-	$(LN_S) -f phar.phar $(INSTALL_ROOT)$(bindir)/phar
+	$(LN_S) -f phar.phar$(program_suffix) $(INSTALL_ROOT)$(bindir)/phar$(program_suffix)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1
 	@$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.1
 	@$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.phar.1


### PR DESCRIPTION
Currently ./configure --enable-phar --program-suffix="7.4" will result in binaries named php7.4 and phar but should instead result in php7.4 and phar7.4