### PR TITLE
Pass zend_string message to zend_error_cb

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -300,6 +300,7 @@ ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_noreturn(int type, const char *
 /* If filename is NULL the default filename is used. */
 ZEND_API ZEND_COLD void zend_error_at(int type, const char *filename, uint32_t lineno, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 4, 5);
 ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_at_noreturn(int type, const char *filename, uint32_t lineno, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 4, 5);
+ZEND_API ZEND_COLD void zend_error_zstr(int type, zend_string *message);
 
 ZEND_API ZEND_COLD void zend_throw_error(zend_class_entry *exception_ce, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
 ZEND_API ZEND_COLD void zend_type_error(const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 1, 2);

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -186,7 +186,7 @@ struct _zend_class_entry {
 };
 
 typedef struct _zend_utility_functions {
-	void (*error_function)(int type, const char *error_filename, const uint32_t error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
+	void (*error_function)(int type, const char *error_filename, const uint32_t error_lineno, zend_string *message);
 	size_t (*printf_function)(const char *format, ...) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 1, 2);
 	size_t (*write_function)(const char *str, size_t str_length);
 	FILE *(*fopen_function)(const char *filename, zend_string **opened_path);
@@ -280,7 +280,7 @@ extern ZEND_API zend_write_func_t zend_write;
 extern ZEND_API FILE *(*zend_fopen)(const char *filename, zend_string **opened_path);
 extern ZEND_API void (*zend_ticks_function)(int ticks);
 extern ZEND_API void (*zend_interrupt_function)(zend_execute_data *execute_data);
-extern ZEND_API void (*zend_error_cb)(int type, const char *error_filename, const uint32_t error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
+extern ZEND_API void (*zend_error_cb)(int type, const char *error_filename, const uint32_t error_lineno, zend_string *message);
 extern ZEND_API void (*zend_on_timeout)(int seconds);
 extern ZEND_API int (*zend_stream_open_function)(const char *filename, zend_file_handle *handle);
 extern void (*zend_printf_to_smart_string)(smart_string *buf, const char *format, va_list ap);

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -61,7 +61,7 @@ ZEND_API ZEND_COLD zend_object *zend_throw_exception_ex(zend_class_entry *except
 ZEND_API ZEND_COLD void zend_throw_exception_object(zval *exception);
 ZEND_API void zend_clear_exception(void);
 
-ZEND_API zend_object *zend_throw_error_exception(zend_class_entry *exception_ce, const char *message, zend_long code, int severity);
+ZEND_API zend_object *zend_throw_error_exception(zend_class_entry *exception_ce, zend_string *message, zend_long code, int severity);
 
 extern ZEND_API void (*zend_throw_exception_hook)(zval *ex);
 

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1533,7 +1533,8 @@ PHP_FUNCTION(error_get_last)
 	if (PG(last_error_message)) {
 		array_init(return_value);
 		add_assoc_long_ex(return_value, "type", sizeof("type")-1, PG(last_error_type));
-		add_assoc_string_ex(return_value, "message", sizeof("message")-1, PG(last_error_message));
+		add_assoc_str_ex(return_value, "message", sizeof("message")-1,
+			zend_string_copy(PG(last_error_message)));
 		add_assoc_string_ex(return_value, "file", sizeof("file")-1, PG(last_error_file)?PG(last_error_file):"-");
 		add_assoc_long_ex(return_value, "line", sizeof("line")-1, PG(last_error_lineno));
 	}
@@ -1550,7 +1551,7 @@ PHP_FUNCTION(error_clear_last)
 		PG(last_error_type) = 0;
 		PG(last_error_lineno) = 0;
 
-		free(PG(last_error_message));
+		zend_string_release(PG(last_error_message));
 		PG(last_error_message) = NULL;
 
 		if (PG(last_error_file)) {

--- a/main/main.c
+++ b/main/main.c
@@ -960,7 +960,7 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int typ
 	const char *function;
 	int origin_len;
 	char *origin;
-	char *message;
+	zend_string *message;
 	int is_function = 0;
 
 	/* get error text into buffer and escape for html if necessary */
@@ -1095,15 +1095,15 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int typ
 		}
 		/* display html formatted or only show the additional links */
 		if (PG(html_errors)) {
-			spprintf(&message, 0, "%s [<a href='%s%s%s'>%s</a>]: %s", origin, docref_root, docref, docref_target, docref, buffer);
+			message = zend_strpprintf(0, "%s [<a href='%s%s%s'>%s</a>]: %s", origin, docref_root, docref, docref_target, docref, buffer);
 		} else {
-			spprintf(&message, 0, "%s [%s%s%s]: %s", origin, docref_root, docref, docref_target, buffer);
+			message = zend_strpprintf(0, "%s [%s%s%s]: %s", origin, docref_root, docref, docref_target, buffer);
 		}
 		if (target) {
 			efree(target);
 		}
 	} else {
-		spprintf(&message, 0, "%s: %s", origin, buffer);
+		message = zend_strpprintf(0, "%s: %s", origin, buffer);
 	}
 	if (replace_origin) {
 		zend_string_free(replace_origin);
@@ -1120,8 +1120,8 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int typ
 		efree(buffer);
 	}
 
-	php_error(type, "%s", message);
-	efree(message);
+	zend_error_zstr(type, message);
+	zend_string_release(message);
 }
 /* }}} */
 

--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -133,7 +133,7 @@ struct _php_core_globals {
 	zend_bool report_zend_debug;
 
 	int last_error_type;
-	char *last_error_message;
+	zend_string *last_error_message;
 	char *last_error_file;
 	int  last_error_lineno;
 

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1214,7 +1214,8 @@ static void php_cli_server_log_response(php_cli_server_client *client, int statu
 
 	/* error */
 	if (append_error_message) {
-		spprintf(&error_buf, 0, " - %s in %s on line %d", PG(last_error_message), PG(last_error_file), PG(last_error_lineno));
+		spprintf(&error_buf, 0, " - %s in %s on line %d",
+			ZSTR_VAL(PG(last_error_message)), PG(last_error_file), PG(last_error_lineno));
 		if (!error_buf) {
 			efree(basic_buf);
 			if (message) {


### PR DESCRIPTION
Instead of passing format and va_args, pass a preformatted zend_string. This saves every user from doing the formatting themselves, often multiple times. It also allows reusing the same message, instead of duplicating it in various places.

cc @beberlei. This is inspired by #4555, as I really don't like that adding another place where we pass format/args and force people do another formatted print.