### PR TITLE
Fix php_get_args function info return type

### DIFF
--- a/Zend/tests/bug72107.phpt
+++ b/Zend/tests/bug72107.phpt
@@ -13,4 +13,4 @@ try {
 }
 ?>
 --EXPECT--
-Cannot call func_get_args() dynamically
+func_get_args() expects exactly 0 parameters, 4 given

--- a/Zend/tests/func_get_arg_signature.phpt
+++ b/Zend/tests/func_get_arg_signature.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test func_get_args signature
+--FILE--
+<?php
+
+(function () {
+    // Pass null to avoid zend_try_compile_special_func and trigger the func_info check
+    var_dump(func_get_args(null));
+})();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ArgumentCountError: func_get_args() expects exactly 0 parameters, 1 given in %s:5
+Stack trace:
+#0 %s(5): func_get_args(NULL)
+#1 %s(6): {closure}()
+#2 {main}
+  thrown in %s on line 5

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -231,6 +231,8 @@ ZEND_FUNCTION(func_get_args)
 	uint32_t i;
 	zend_execute_data *ex = EX(prev_execute_data);
 
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	if (ZEND_CALL_INFO(ex) & ZEND_CALL_CODE) {
 		zend_throw_error(NULL, "func_get_args() cannot be called from the global scope");
 		RETURN_THROWS();

--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -94,7 +94,7 @@ static const func_info_t func_infos[] = {
 	/* zend */
 	F1("zend_version",            MAY_BE_STRING),
 	FN("func_get_arg",            UNKNOWN_INFO),
-	FN("func_get_args",           MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_OF_ANY),
+	FN("func_get_args",           MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_LONG | MAY_BE_ARRAY_OF_ANY),
 	F1("get_class_vars",          MAY_BE_FALSE | MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_ANY | MAY_BE_ARRAY_OF_REF),
 	FN("get_object_vars",         MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_ANY | MAY_BE_ARRAY_OF_REF),
 	FN("get_mangled_object_vars", MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_ANY | MAY_BE_ARRAY_OF_REF),


### PR DESCRIPTION
The test would previously output the following warning:

> Inaccurate func info for func_get_args()