### PR TITLE
Respect --program-prefix and --program-suffix when installing phar

### DIFF
--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -46,5 +46,5 @@ install-pharcmd: pharcmd
 	-@rm -f $(INSTALL_ROOT)$(bindir)/phar
 	$(LN_S) -f phar$(program_suffix).phar $(INSTALL_ROOT)$(bindir)/phar$(program_suffix)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1
-	@$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.1
-	@$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.phar.1
+	@$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar$(program_suffix).1
+	@$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar$(program_suffix).phar.1

--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -42,9 +42,9 @@ $(builddir)/phar.phar: $(builddir)/phar.php $(builddir)/phar/phar.inc $(srcdir)/
 
 install-pharcmd: pharcmd
 	-@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
-	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)/phar.phar$(program_suffix)
+	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)/phar$(program_suffix).phar
 	-@rm -f $(INSTALL_ROOT)$(bindir)/phar
-	$(LN_S) -f phar.phar$(program_suffix) $(INSTALL_ROOT)$(bindir)/phar$(program_suffix)
+	$(LN_S) -f phar$(program_suffix).phar $(INSTALL_ROOT)$(bindir)/phar$(program_suffix)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1
 	@$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.1
 	@$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.phar.1

--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -42,9 +42,9 @@ $(builddir)/phar.phar: $(builddir)/phar.php $(builddir)/phar/phar.inc $(srcdir)/
 
 install-pharcmd: pharcmd
 	-@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
-	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)/phar$(program_suffix).phar
-	-@rm -f $(INSTALL_ROOT)$(bindir)/phar
-	$(LN_S) -f phar$(program_suffix).phar $(INSTALL_ROOT)$(bindir)/phar$(program_suffix)
+	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)/$(program_prefix)phar$(program_suffix).phar
+	-@rm -f $(INSTALL_ROOT)$(bindir)/$(program_prefix)phar$(program_suffix)
+	$(LN_S) -f $(program_prefix)phar$(program_suffix).phar $(INSTALL_ROOT)$(bindir)/$(program_prefix)phar$(program_suffix)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1
-	@$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar$(program_suffix).1
-	@$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar$(program_suffix).phar.1
+	@$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)phar$(program_suffix).1
+	@$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)phar$(program_suffix).phar.1

--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -42,9 +42,9 @@ $(builddir)/phar.phar: $(builddir)/phar.php $(builddir)/phar/phar.inc $(srcdir)/
 
 install-pharcmd: pharcmd
 	-@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
-	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)
+	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)/phar.phar$(program_suffix)
 	-@rm -f $(INSTALL_ROOT)$(bindir)/phar
-	$(LN_S) -f phar.phar $(INSTALL_ROOT)$(bindir)/phar
+	$(LN_S) -f phar.phar$(program_suffix) $(INSTALL_ROOT)$(bindir)/phar$(program_suffix)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1
 	@$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.1
 	@$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/phar.phar.1


### PR DESCRIPTION
Currently `./configure --enable-phar --program-suffix=7.4` will result in files named `php7.4` and `phar`

This change would instead result in files named `php7.4` and `phar7.4`

This improves consistency and improves the ability to maintain clearly separate binary names in multi-version environments