### PR TITLE
Fix #79650: php-win.exe 100% cpu lockup

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -279,6 +279,9 @@ PHP_CLI_API ssize_t sapi_cli_single_write(const char *str, size_t str_length) /*
 	} while (ret <= 0 && errno == EAGAIN && sapi_cli_select(STDOUT_FILENO));
 #else
 	ret = fwrite(str, 1, MIN(str_length, 16384), stdout);
+	if (ret == 0 && ferror(stdout)) {
+		return -1;
+	}
 #endif
 	return ret;
 }


### PR DESCRIPTION
As of PHP 7.3.0, `sapi_cli_single_write()` is supposed to return `< 0`
on failure, but `fwrite()` returns a `size_t`, and signals error by
setting the stream's error indicator.  We have to cater to that.