### PR TITLE
Fix #79664: PDOStatement::getColumnMeta fails on empty result set

### DIFF
--- a/ext/pdo_sqlite/sqlite_statement.c
+++ b/ext/pdo_sqlite/sqlite_statement.c
@@ -337,7 +337,7 @@ static int pdo_sqlite_stmt_col_meta(pdo_stmt_t *stmt, zend_long colno, zval *ret
 	if (!S->stmt) {
 		return FAILURE;
 	}
-	if(colno >= sqlite3_data_count(S->stmt)) {
+	if(colno >= sqlite3_column_count(S->stmt)) {
 		/* error invalid column */
 		pdo_sqlite_error_stmt(stmt);
 		return FAILURE;

--- a/ext/pdo_sqlite/tests/bug79664.phpt
+++ b/ext/pdo_sqlite/tests/bug79664.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #79664 (PDOStatement::getColumnMeta fails on empty result set)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_sqlite')) print 'skip not loaded';
+?>
+--FILE--
+<?php
+$pdo = new PDO('sqlite::memory:', null, null, [
+	PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+]);
+$stmt = $pdo->query('select 1 where 0');
+if ($stmt->columnCount()) {
+    var_dump($stmt->getColumnMeta(0));
+}
+?>
+--EXPECT--
+array(6) {
+  ["native_type"]=>
+  string(4) "null"
+  ["flags"]=>
+  array(0) {
+  }
+  ["name"]=>
+  string(1) "1"
+  ["len"]=>
+  int(4294967295)
+  ["precision"]=>
+  int(0)
+  ["pdo_type"]=>
+  int(2)
+}


### PR DESCRIPTION
As its name suggests, `sqlite3_data_count` returns the number of
columns in the current row of the result set; we are interested in the
number of columns regardless of the current row, so we have to use
`sqlite3_column_count` instead.