### PR TITLE
Fix #79668: get_defined_functions(true) may miss functions

### DIFF
--- a/Zend/tests/bug79668.phpt
+++ b/Zend/tests/bug79668.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #79668 (get_defined_functions(true) may miss functions)
+--INI--
+disable_functions=sha1_file,password_hash
+--FILE--
+<?php
+$df = get_defined_functions(true);
+foreach (['sha1', 'sha1_file', 'hash', 'password_hash'] as $funcname) {
+    var_dump(in_array($funcname, $df['internal'], true));
+}
+?>
+--EXPECT--
+bool(true)
+bool(false)
+bool(true)
+bool(false)

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1836,20 +1836,6 @@ ZEND_FUNCTION(get_declared_interfaces)
 }
 /* }}} */
 
-static inline zend_bool is_name_in_list(zend_string *name, const char *list)
-{
-	char *p = list;
-	size_t len = ZSTR_LEN(name);
-
-	while ((p = strstr(p, ZSTR_VAL(name))) != NULL
-		&& ((p != list && *(p-1) != ' ' && *(p-1) != ',')
-		|| (*(p+len) != '\0' && *(p+len) != ' ' && *(p+len) != ','))
-	) {
-		p++;
-	}
-	return p != NULL;
-}
-
 static int copy_function_name(zval *zv, int num_args, va_list args, zend_hash_key *hash_key) /* {{{ */
 {
 	zend_function *func = Z_PTR_P(zv);
@@ -1865,7 +1851,7 @@ static int copy_function_name(zval *zv, int num_args, va_list args, zend_hash_ke
 		char *disable_functions = INI_STR("disable_functions");
 
 		if ((*exclude_disabled == 1) && (disable_functions != NULL)) {
-			if (!is_name_in_list(func->common.function_name, disable_functions)) {
+			if (func->internal_function.handler != ZEND_FN(display_disabled_function)) {
 				add_next_index_str(internal_ar, zend_string_copy(hash_key->key));
 			}
 		} else {

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1836,6 +1836,20 @@ ZEND_FUNCTION(get_declared_interfaces)
 }
 /* }}} */
 
+static inline zend_bool is_name_in_list(zend_string *name, const char *list)
+{
+	char *p = list;
+	size_t len = ZSTR_LEN(name);
+
+	while ((p = strstr(p, ZSTR_VAL(name))) != NULL
+		&& ((p != list && *(p-1) != ' ' && *(p-1) != ',')
+		|| (*(p+len) != '\0' && *(p+len) != ' ' && *(p+len) != ','))
+	) {
+		p++;
+	}
+	return p != NULL;
+}
+
 static int copy_function_name(zval *zv, int num_args, va_list args, zend_hash_key *hash_key) /* {{{ */
 {
 	zend_function *func = Z_PTR_P(zv);
@@ -1851,7 +1865,7 @@ static int copy_function_name(zval *zv, int num_args, va_list args, zend_hash_ke
 		char *disable_functions = INI_STR("disable_functions");
 
 		if ((*exclude_disabled == 1) && (disable_functions != NULL)) {
-			if (strstr(disable_functions, func->common.function_name->val) == NULL) {
+			if (!is_name_in_list(func->common.function_name, disable_functions)) {
 				add_next_index_str(internal_ar, zend_string_copy(hash_key->key));
 			}
 		} else {

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1847,16 +1847,9 @@ static int copy_function_name(zval *zv, int num_args, va_list args, zend_hash_ke
 		return 0;
 	}
 
-	if (func->type == ZEND_INTERNAL_FUNCTION) {
-		char *disable_functions = INI_STR("disable_functions");
-
-		if ((*exclude_disabled == 1) && (disable_functions != NULL)) {
-			if (func->internal_function.handler != ZEND_FN(display_disabled_function)) {
-				add_next_index_str(internal_ar, zend_string_copy(hash_key->key));
-			}
-		} else {
-			add_next_index_str(internal_ar, zend_string_copy(hash_key->key));
-		}
+	if (func->type == ZEND_INTERNAL_FUNCTION
+		&& (!*exclude_disabled || func->internal_function.handler != ZEND_FN(display_disabled_function))) {
+		add_next_index_str(internal_ar, zend_string_copy(hash_key->key));
 	} else if (func->type == ZEND_USER_FUNCTION) {
 		add_next_index_str(user_ar, zend_string_copy(hash_key->key));
 	}


### PR DESCRIPTION
The mere matching of a substring of disable_functions is insufficient;
we also have to make sure that it is a complete function name.