### PR TITLE
mysqlnd: Remove unnecessary check for HAVE_ZLIB

### DIFF
--- a/ext/mysqlnd/mysqlnd.h
+++ b/ext/mysqlnd/mysqlnd.h
@@ -46,7 +46,7 @@
 #define MYSQLND_DBG_ENABLED 0
 #endif
 
-#if defined(MYSQLND_COMPRESSION_WANTED) && defined(HAVE_ZLIB)
+#if defined(MYSQLND_COMPRESSION_WANTED)
 #define MYSQLND_COMPRESSION_ENABLED 1
 #endif
 


### PR DESCRIPTION
Since ee4295b4ce421003c2e1d2af98066826deb23319, the `zlib` package is explicitly checked for and configuration will fail without it. However, `HAVE_ZLIB`, which isn't defined by the configuration script, still has to be defined in `mysqlnd.h` for compression support to be turned on. This removes this requirement, which seems like a leftover. It probably only succeeds when building `mysqlnd` as a part of PHP because `HAVE_ZLIB` gets defined by the `zlib` extension.

In the NixOS project, we build the extensions separately, for maximal flexibility, and so we ran into this problem: NixOS/nixpkgs#89266

Related PR: #5655