### PR TITLE
Fix phpdbg watchpoints wrt. negative_array_index RFC

### DIFF
--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -1249,10 +1249,10 @@ static int phpdbg_watchpoint_parse_wrapper(char *name, size_t namelen, char *key
 		if (element->child) {
 			element = element->child;
 		}
-		element->id = PHPDBG_G(watch_elements).nNextFreeElement;
-		zend_hash_index_add_ptr(&PHPDBG_G(watch_elements), element->id, element);
+		zend_hash_next_index_insert_ptr(&PHPDBG_G(watch_elements), element);
+		element->id = PHPDBG_G(watch_elements).nNextFreeElement - 1;
 
-		phpdbg_notice("watchadd", "index=\"%d\" variable=\"%.*s\"", "Added%s watchpoint #%d for %.*s", (element->flags & PHPDBG_WATCH_RECURSIVE_ROOT) ? " recursive" : "", element->id, (int) ZSTR_LEN(element->str), ZSTR_VAL(element->str));
+		phpdbg_notice("watchadd", "index=\"%d\" variable=\"%.*s\"", "Added%s watchpoint #%u for %.*s", (element->flags & PHPDBG_WATCH_RECURSIVE_ROOT) ? " recursive" : "", element->id, (int) ZSTR_LEN(element->str), ZSTR_VAL(element->str));
 	}
 
 	PHPDBG_G(watch_tmp) = NULL;


### PR DESCRIPTION
The implementation of that RFC changed the initial value of
`zend_array.nNextFreeElement` to `-1`; we work around that by inserting
first, and retrieving the index afterwards.

We also fix the erroneous printf specifier for the unsigned integer.