### PR TITLE
openssl: Fix openssl_pkcs12_export_to_file extracerts test

### DIFF
--- a/ext/openssl/tests/openssl_pkcs12_export_to_file_basic.phpt
+++ b/ext/openssl/tests/openssl_pkcs12_export_to_file_basic.phpt
@@ -25,7 +25,7 @@ var_dump(openssl_pkcs12_export_to_file($cert_path, $pkcsfile, $priv_path, $pass)
 var_dump(openssl_pkcs12_read(file_get_contents($pkcsfile), $opts, $pass));
 var_dump(openssl_pkcs12_export_to_file($cert_res, $pkcsfile, $priv_res, $pass));
 var_dump(openssl_pkcs12_read(file_get_contents($pkcsfile), $opts, $pass));
-var_dump(openssl_pkcs12_export_to_file($cert_res, $pkcsfile, $priv_res, $pass, array($cert)));
+var_dump(openssl_pkcs12_export_to_file($cert_res, $pkcsfile, $priv_res, $pass, array('extracerts' => $cert)));
 var_dump(openssl_pkcs12_read(file_get_contents($pkcsfile), $opts, $pass));
 
 var_dump(openssl_pkcs12_export_to_file($invalid, $pkcsfile, $invalid, $pass));


### PR DESCRIPTION
Hi,

this PR is basically the same as https://github.com/php/php-src/pull/2681/files but for `openssl_pkcs12_export_to_file` this time (the fix was only applied on `openssl_pkcs12_export`).