### PR TITLE
Allow defining of uname value for reproducible builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1291,7 +1291,8 @@ PHP_BUILD_DATE=`date -u +%Y-%m-%d`
 fi
 AC_DEFINE_UNQUOTED(PHP_BUILD_DATE,"$PHP_BUILD_DATE",[PHP build date])
 
-PHP_UNAME=`uname -a | xargs`
+UNAME=`uname -a | xargs`
+PHP_UNAME=${PHP_UNAME:-$UNAME}
 AC_DEFINE_UNQUOTED(PHP_UNAME,"$PHP_UNAME",[uname -a output])
 PHP_OS=`uname | xargs`
 AC_DEFINE_UNQUOTED(PHP_OS,"$PHP_OS",[uname output])


### PR DESCRIPTION
Extend configure.ac to accept PHP_UNAME as env variable to set the value of the
PHP_UNAME define in a reproducible manner. This allows distributions to set a
fixed value for php_uname and keep the default behaviour if PHP_UNAME is not
set.

Motivation: https://reproducible-builds.org/