### PR TITLE
Fix #79679: Constructor can not return any value (always void)

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6902,7 +6902,8 @@ void zend_compile_class_decl(znode *result, zend_ast *ast, zend_bool toplevel) /
 			zend_error_noreturn(E_COMPILE_ERROR, "Constructor %s::%s() cannot be static",
 				ZSTR_VAL(ce->name), ZSTR_VAL(ce->constructor->common.function_name));
 		}
-		if (ce->constructor->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
+		if (ce->constructor->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE
+			&& ZEND_TYPE_PURE_MASK(ce->constructor->common.arg_info[-1].type) != MAY_BE_VOID) {
 			zend_error_noreturn(E_COMPILE_ERROR,
 				"Constructor %s::%s() cannot declare a return type",
 				ZSTR_VAL(ce->name), ZSTR_VAL(ce->constructor->common.function_name));
@@ -6912,7 +6913,8 @@ void zend_compile_class_decl(znode *result, zend_ast *ast, zend_bool toplevel) /
 		if (ce->destructor->common.fn_flags & ZEND_ACC_STATIC) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Destructor %s::%s() cannot be static",
 				ZSTR_VAL(ce->name), ZSTR_VAL(ce->destructor->common.function_name));
-		} else if (ce->destructor->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
+		} else if (ce->destructor->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE
+			&& ZEND_TYPE_PURE_MASK(ce->destructor->common.arg_info[-1].type) != MAY_BE_VOID) {
 			zend_error_noreturn(E_COMPILE_ERROR,
 				"Destructor %s::%s() cannot declare a return type",
 				ZSTR_VAL(ce->name), ZSTR_VAL(ce->destructor->common.function_name));

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6464,8 +6464,16 @@ void zend_compile_func_decl(znode *result, zend_ast *ast, zend_bool toplevel) /*
 		zend_stack_push(&CG(loop_var_stack), (void *) &dummy_var);
 	}
 
-	zend_compile_params(params_ast, return_type_ast,
-		is_method && zend_string_equals_literal_ci(decl->name, "__toString") ? IS_STRING : 0);
+	uint32_t fallback_return_type = 0;
+	if (is_method) {
+		if (zend_string_equals_literal_ci(decl->name, "__toString")) {
+			fallback_return_type = IS_STRING;
+		} else if (zend_string_equals_literal_ci(decl->name, "__construct")) {
+			fallback_return_type = IS_VOID;
+		}
+	}
+	zend_compile_params(params_ast, return_type_ast, fallback_return_type);
+
 	if (CG(active_op_array)->fn_flags & ZEND_ACC_GENERATOR) {
 		zend_mark_function_as_generator();
 		zend_emit_op(NULL, ZEND_GENERATOR_CREATE, NULL, NULL);

--- a/tests/classes/bug79679.phpt
+++ b/tests/classes/bug79679.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #79679: Constructor can not return any value (always void).
+--FILE--
+<?php
+
+class A {
+    public function __construct() {
+        return 5;
+    }
+}
+
+?>
+--EXPECTF--
+Fatal error: A void function must not return a value in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
test for https://bugs.php.net/bug.php?id=79679

current situation with `__construct()` is:
- documented as void
- void can not be declared
- but return value is allowed

it seems like a bug to me

Please help with impl.

As it introduces a small BC break probably for PHP8 only.

`__destruct` can be declared with void (thus not clear bug like this) so it should be probably solved in this PR/RFC https://github.com/php/php-src/pull/4177