### PR TITLE
Fix typo of IteratorAggregateImpl

### DIFF
--- a/ext/reflection/tests/ReflectionClass_isIterateable_001.phpt
+++ b/ext/reflection/tests/ReflectionClass_isIterateable_001.phpt
@@ -16,18 +16,18 @@ Class IteratorImpl implements Iterator {
     public function current() {}
     public function valid() {}
 }
-Class IterarorAggregateImpl implements IteratorAggregate {
+Class IteratorAggregateImpl implements IteratorAggregate {
     public function getIterator() {}
 }
 Class ExtendsIteratorImpl extends IteratorImpl {
 }
-Class ExtendsIteratorAggregateImpl extends IterarorAggregateImpl {
+Class ExtendsIteratorAggregateImpl extends IteratorAggregateImpl {
 }
 Class A {
 }
 
 $classes = array('Traversable', 'Iterator', 'IteratorAggregate', 'ExtendsIterator', 'ExtendsIteratorAggregate',
-      'IteratorImpl', 'IterarorAggregateImpl', 'ExtendsIteratorImpl', 'ExtendsIteratorAggregateImpl', 'A');
+      'IteratorImpl', 'IteratorAggregateImpl', 'ExtendsIteratorImpl', 'ExtendsIteratorAggregateImpl', 'A');
 
 foreach($classes as $class) {
     $rc = new ReflectionClass($class);
@@ -46,7 +46,7 @@ Is IteratorAggregate iterable? bool(false)
 Is ExtendsIterator iterable? bool(false)
 Is ExtendsIteratorAggregate iterable? bool(false)
 Is IteratorImpl iterable? bool(true)
-Is IterarorAggregateImpl iterable? bool(true)
+Is IteratorAggregateImpl iterable? bool(true)
 Is ExtendsIteratorImpl iterable? bool(true)
 Is ExtendsIteratorAggregateImpl iterable? bool(true)
 Is A iterable? bool(false)


### PR DESCRIPTION
Just a little typo in a class name in a test. Nothing is broken!

I only noticed because these test cases are being used in downstream projects like https://github.com/Roave/BetterReflection that do some "reflection-like" static analysis and so want to re-use tests like this.