### PR TITLE
Fix #74267: segfault with streams and invalid data

### DIFF
--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -1113,8 +1113,7 @@ static php_conv_err_t php_conv_qprint_decode_convert(php_conv_qprint_decode *ins
 					*ps == (unsigned char)inst->lbchars[lb_cnt]) {
 					lb_cnt++;
 					scan_stat = 5;
-				}
-				if (*ps != '\t' && *ps != ' ') {
+				} else if (*ps != '\t' && *ps != ' ') {
 					err = PHP_CONV_ERR_INVALID_SEQ;
 					goto out;
 				}

--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -788,7 +788,7 @@ static php_conv_err_t php_conv_qprint_encode_convert(php_conv_qprint_encode *ins
 	lb_ptr = inst->lb_ptr;
 	lb_cnt = inst->lb_cnt;
 
-	if ((in_pp == NULL || in_left_p == NULL) && (lb_ptr >=lb_cnt)) {
+	if (in_pp == NULL || in_left_p == NULL) {
 		return PHP_CONV_ERR_SUCCESS;
 	}
 
@@ -1016,7 +1016,7 @@ static php_conv_err_t php_conv_qprint_decode_convert(php_conv_qprint_decode *ins
 	lb_ptr = inst->lb_ptr;
 	lb_cnt = inst->lb_cnt;
 
-	if ((in_pp == NULL || in_left_p == NULL) && lb_cnt == lb_ptr) {
+	if (in_pp == NULL || in_left_p == NULL) {
 		if (inst->scan_stat != 0) {
 			return PHP_CONV_ERR_UNEXPECTED_EOS;
 		}

--- a/ext/standard/tests/filters/bug74267.phpt
+++ b/ext/standard/tests/filters/bug74267.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #74267 (segfault with streams and invalid data)
+--FILE--
+<?php
+$stream = fopen('php://memory', 'w');
+stream_filter_append($stream, 'convert.quoted-printable-decode', STREAM_FILTER_WRITE, ['line-break-chars' => "\r\n"]);
+
+$lines = [
+	"\r\n",
+	" -=()\r\n",
+	" -=\r\n",
+	"\r\n"
+	];
+
+foreach ($lines as $line) {
+	fwrite($stream, $line);
+}
+
+fclose($stream);
+echo "done\n";
+?>
+--EXPECTF--
+Warning: fwrite(): stream filter (convert.quoted-printable-decode): invalid byte sequence in %s on line %d
+
+Warning: fwrite(): stream filter (convert.quoted-printable-decode): invalid byte sequence in %s on line %d
+done


### PR DESCRIPTION
If the current character is a line break character, it cannot be a tab
or space character, so we would always fail with an invalid sequence
error.  Obviously, these conditions are meant to be exclusive.