### PR TITLE
Make zend_argument_error_variadic static

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -263,7 +263,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(int num, char *e
 }
 /* }}} */
 
-ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_entry *error_ce, uint32_t arg_num, const char *format, va_list va) /* {{{ */
+static ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_entry *error_ce, uint32_t arg_num, const char *format, va_list va) /* {{{ */
 {
 	const char *space;
 	const char *class_name;


### PR DESCRIPTION
no declaration in the header file and it also doesn't have to be an API