### PR TITLE
Fix possibly unsupported timercmp() usage

### DIFF
--- a/main/network.c
+++ b/main/network.c
@@ -919,7 +919,7 @@ skip_bind:
 			if (timeout) {
 				gettimeofday(&time_now, NULL);
 
-				if (timercmp(&time_now, &limit_time, >=)) {
+				if (!timercmp(&time_now, &limit_time, <)) {
 					/* time limit expired; don't attempt any further connections */
 					fatal = 1;
 				} else {


### PR DESCRIPTION
The `timercmp()` manpage[1] points out that some systems have a broken
implementation which does not support `>=`.  This is definitely the
case for the Windows SDK, which only supports `<` and `>`.

[1] <https://linux.die.net/man/3/timercmp>