### PR TITLE
assert passes 3rd arg to callback (as stated in documentation)

### DIFF
--- a/Zend/tests/assert/expect_002.phpt
+++ b/Zend/tests/assert/expect_002.phpt
@@ -11,6 +11,6 @@ var_dump(true);
 --EXPECTF--
 Fatal error: Uncaught AssertionError: assert(false) in %sexpect_002.php:%d
 Stack trace:
-#0 %sexpect_002.php(%d): assert(false, 'assert(false)')
+#0 %sexpect_002.php(%d): assert(false, 'assert(false)', 'false')
 #1 {main}
   thrown in %sexpect_002.php on line %d

--- a/Zend/tests/assert/expect_009.phpt
+++ b/Zend/tests/assert/expect_009.phpt
@@ -19,7 +19,7 @@ new Two();
 --EXPECTF--
 Fatal error: Uncaught AssertionError: assert(false) in %sexpect_009.php:%d
 Stack trace:
-#0 %sexpect_009.php(%d): assert(false, 'assert(false)')
+#0 %sexpect_009.php(%d): assert(false, 'assert(false)', 'false')
 #1 %sexpect_009.php(%d): Two->__construct()
 #2 {main}
   thrown in %sexpect_009.php on line %d

--- a/Zend/tests/assert/expect_010.phpt
+++ b/Zend/tests/assert/expect_010.phpt
@@ -17,7 +17,7 @@ new Two();
 --EXPECTF--
 Fatal error: Uncaught AssertionError: assert(false) in %sexpect_010.php:%d
 Stack trace:
-#0 %sexpect_010.php(%d): assert(false, 'assert(false)')
+#0 %sexpect_010.php(%d): assert(false, 'assert(false)', 'false')
 #1 %sexpect_010.php(%d): One->__construct()
 #2 {main}
   thrown in %sexpect_010.php on line %d

--- a/Zend/tests/assert/expect_011.phpt
+++ b/Zend/tests/assert/expect_011.phpt
@@ -24,7 +24,7 @@ new Two();
 --EXPECTF--
 Fatal error: Uncaught AssertionError: [Message]: MyExpectations in %sexpect_011.php:%d
 Stack trace:
-#0 %sexpect_011.php(%d): assert(false, '[Message]: MyEx...')
+#0 %sexpect_011.php(%d): assert(false, '[Message]: MyEx...', 'false')
 #1 %sexpect_011.php(%d): One->__construct()
 #2 {main}
   thrown in %sexpect_011.php on line %d

--- a/Zend/tests/assert/expect_021.phpt
+++ b/Zend/tests/assert/expect_021.phpt
@@ -1,0 +1,40 @@
+--TEST--
+test use of assert_handler callback
+--INI--
+zend.assertions=1
+assert.exception=0
+assert.warning=0
+assert.bail=0
+--FILE--
+<?php
+class CustomError extends AssertionError {}
+
+assert_options(ASSERT_CALLBACK, "assert_handler");
+
+function assert_handler($file, $line, $assertion, $description="")
+{
+  echo "file: $file\nline: $line\nassertion: $assertion\ndescription: $description\n\n";
+  return true;
+}
+
+assert(10 < 5);
+assert(3 == 4, 'Assertion Description');
+assert(5 * 5 < 25, new CustomError('Assertion Exception'));
+?>
+--EXPECTF--
+file: %sexpect_021.php
+line: %d
+assertion: 10 < 5
+description: assert(10 < 5)
+
+file: %sexpect_021.php
+line: %d
+assertion: 3 == 4
+description: Assertion Description
+
+file: %sexpect_021.php
+line: %d
+assertion: 5 * 5 < 25
+description: CustomError: Assertion Exception in %sexpect_021.php:%d
+Stack trace:
+#0 {main}

--- a/Zend/tests/exception_011.phpt
+++ b/Zend/tests/exception_011.phpt
@@ -15,6 +15,6 @@ Content-type: text/html; charset=UTF-8
 --EXPECTF--
 Fatal error: Uncaught AssertionError: assert(false) in %sexception_011.php:%d
 Stack trace:
-#0 %sexception_011.php(%d): assert(false, 'assert(false)')
+#0 %sexception_011.php(%d): assert(false, 'assert(false)', 'false')
 #1 {main}
   thrown in %sexception_011.php on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3704,10 +3704,8 @@ static void zend_compile_assert(znode *result, zend_ast_list *args, zend_string 
 		}
 		opline->result.num = zend_alloc_cache_slot();
 
-		if (args->children == 1 &&
-		    (args->child[0]->kind != ZEND_AST_ZVAL ||
-		     Z_TYPE_P(zend_ast_get_zval(args->child[0])) != IS_STRING)) {
-			/* add "assert(condition) as assertion message */
+		if (args->children == 1) {
+			/* add "assert(condition)" as default assertion description */
 			zend_ast_list_add((zend_ast*)args,
 				zend_ast_create_zval_from_str(
 					zend_ast_export("assert(", args->child[0], ")")));

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3710,6 +3710,12 @@ static void zend_compile_assert(znode *result, zend_ast_list *args, zend_string 
 				zend_ast_create_zval_from_str(
 					zend_ast_export("assert(", args->child[0], ")")));
 		}
+		if (args->children == 2) {
+			/* may be used as the 3rd argument to an assert callback if one is set */
+			zend_ast_list_add((zend_ast*)args,
+				zend_ast_create_zval_from_str(
+					zend_ast_export("", args->child[0], "")));
+		}
 
 		zend_compile_call_common(result, (zend_ast*)args, fbc);
 

--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -177,16 +177,12 @@ PHP_FUNCTION(assert)
 		/* XXX do we want to check for error here? */
 		if (!desc_or_throwable) {
 			call_user_function(NULL, NULL, &ASSERTG(callback), &retval, 3, args);
-			zval_ptr_dtor(&(args[2]));
-			zval_ptr_dtor(&(args[0]));
 		} else {
 			ZVAL_STR(&args[3], zval_get_string(desc_or_throwable));
 			call_user_function(NULL, NULL, &ASSERTG(callback), &retval, 4, args);
 			zval_ptr_dtor(&(args[3]));
-			zval_ptr_dtor(&(args[2]));
-			zval_ptr_dtor(&(args[0]));
 		}
-
+		zval_ptr_dtor(&(args[0]));
 		zval_ptr_dtor(&retval);
 	}
 


### PR DESCRIPTION
This is an attempt to fix [Bug #79602](https://bugs.php.net/bug.php?id=79602). The solution is a bit hacky; not sure if you will like it or not.

If this is not accepted, then I would like to suggest the docs for `assert` can be amended instead, because they have not correctly described the behavior of `assert` since 2015.

I would like to ask @dstogov to check a08f9f1; he wrote the `if` condition which is amended here, and maybe there could be a good reason for the way it was originally written.