### PR TITLE
Fix #62890: default_socket_timeout=-1 causes connection to timeout

### DIFF
--- a/ext/openssl/tests/bug62890.phpt
+++ b/ext/openssl/tests/bug62890.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #62890 (default_socket_timeout=-1 causes connection to timeout)
+--SKIPIF--
+<?php
+if (!extension_loaded('openssl')) die('skip openssl extension not available');
+if (getenv('SKIP_ONLINE_TESTS')) die('skip online test');
+?>
+--INI--
+default_socket_timeout=-1
+--FILE--
+<?php
+var_dump((bool) file_get_contents('https://php.net'));
+?>
+--EXPECT--
+bool(true)

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1912,7 +1912,7 @@ static int php_openssl_enable_crypto(php_stream *stream,
 		}
 
 		timeout = sslsock->is_client ? &sslsock->connect_timeout : &sslsock->s.timeout;
-		has_timeout = !sslsock->s.is_blocked && (timeout->tv_sec || timeout->tv_usec);
+		has_timeout = !sslsock->s.is_blocked && (timeout->tv_sec > 0 || (timeout->tv_sec == 0 && timeout->tv_usec));
 		/* gettimeofday is not monotonic; using it here is not strictly correct */
 		if (has_timeout) {
 			gettimeofday(&start_time, NULL);
@@ -2064,7 +2064,7 @@ static size_t php_openssl_sockop_io(int read, php_stream *stream, char *buf, siz
 			sslsock->s.is_blocked = 0;
 		}
 
-		if (!sslsock->s.is_blocked && timeout && (timeout->tv_sec || timeout->tv_usec)) {
+		if (!sslsock->s.is_blocked && timeout && (timeout->tv_sec > 0 || (timeout->tv_sec == 0 && timeout->tv_usec))) {
 			has_timeout = 1;
 			/* gettimeofday is not monotonic; using it here is not strictly correct */
 			gettimeofday(&start_time, NULL);


### PR DESCRIPTION
While unencrypted connections ignore negative timeouts, SSL/TLS
connections did not special case that, and so always failed due to
timeout.

---

I'm not sure whether this is the correct approach, since the behavior of negative timeouts is not documented.