### PR TITLE
Cleanup SPL autoload implementation

### DIFF
--- a/Zend/tests/bug49908.phpt
+++ b/Zend/tests/bug49908.phpt
@@ -29,9 +29,7 @@ string(3) "Bar"
 
 Fatal error: Uncaught Exception: Bar in %s:%d
 Stack trace:
-#0 [internal function]: {closure}('Bar')
-#1 %s(%d): spl_autoload_call('Bar')
-#2 [internal function]: {closure}('Foo')
-#3 %s(%d): spl_autoload_call('Foo')
-#4 {main}
+#0 %s(%d): {closure}('Bar')
+#1 %s(%d): {closure}('Foo')
+#2 {main}
   thrown in %s on line %d

--- a/Zend/tests/generators/bug65161.phpt
+++ b/Zend/tests/generators/bug65161.phpt
@@ -19,8 +19,7 @@ foreach (testGenerator() as $i);
 --EXPECTF--
 Fatal error: Uncaught Error: Call to undefined function foo() in %s:%d
 Stack trace:
-#0 [internal function]: autoload('SyntaxError')
-#1 %s(%d): spl_autoload_call('SyntaxError')
-#2 %s(%d): testGenerator()
-#3 {main}
+#0 %s(%d): autoload('SyntaxError')
+#1 %s(%d): testGenerator()
+#2 {main}
   thrown in %s on line %d

--- a/Zend/tests/type_declarations/variance/loading_exception1.phpt
+++ b/Zend/tests/type_declarations/variance/loading_exception1.phpt
@@ -44,6 +44,5 @@ Class A does not exist
 
 Fatal error: During inheritance of B with variance dependencies: Uncaught Exception: Class A does not exist in %s:%d
 Stack trace:
-#0 [internal function]: {closure}('A')
-#1 %s(%d): spl_autoload_call('A')
-#2 {main} in %s on line %d
+#0 %s(%d): {closure}('A')
+#1 {main} in %s on line %d

--- a/Zend/tests/type_declarations/variance/loading_exception2.phpt
+++ b/Zend/tests/type_declarations/variance/loading_exception2.phpt
@@ -46,6 +46,5 @@ Class I does not exist
 
 Fatal error: During inheritance of B with variance dependencies: Uncaught Exception: Class I does not exist in %s:%d
 Stack trace:
-#0 [internal function]: {closure}('I')
-#1 %s(%d): spl_autoload_call('I')
-#2 {main} in %s on line %d
+#0 %s(%d): {closure}('I')
+#1 {main} in %s on line %d

--- a/Zend/tests/use_unlinked_class.phpt
+++ b/Zend/tests/use_unlinked_class.phpt
@@ -15,7 +15,6 @@ class A implements I {
 Fatal error: Uncaught ReflectionException: Class A does not exist in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->__construct('A')
-#1 [internal function]: {closure}('I')
-#2 %s(%d): spl_autoload_call('I')
-#3 {main}
+#1 %s(%d): {closure}('I')
+#2 {main}
   thrown in %s on line %d

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -31,6 +31,9 @@ struct _zend_fcall_info;
 ZEND_API extern void (*zend_execute_ex)(zend_execute_data *execute_data);
 ZEND_API extern void (*zend_execute_internal)(zend_execute_data *execute_data, zval *return_value);
 
+/* The lc_name may be stack allocated! */
+ZEND_API extern zend_class_entry *(*zend_autoload)(zend_string *name, zend_string *lc_name);
+
 void init_executor(void);
 void shutdown_executor(void);
 void shutdown_destructors(void);

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -176,7 +176,6 @@ struct _zend_executor_globals {
 	uint32_t persistent_classes_count;
 
 	HashTable *in_autoload;
-	zend_function *autoload_func;
 	zend_bool full_tables_cleanup;
 
 	/* for extended information support */

--- a/ext/spl/php_spl.stub.php
+++ b/ext/spl/php_spl.stub.php
@@ -10,12 +10,11 @@ function class_uses($what, bool $autoload = true): array|false {}
 
 function spl_autoload(string $class_name, ?string $file_extensions = null): void {}
 
-// This silently ignores non-string class names
-function spl_autoload_call($class_name): void {}
+function spl_autoload_call(string $class_name): void {}
 
 function spl_autoload_extensions(?string $file_extensions = null): string {}
 
-function spl_autoload_functions(): array|false {}
+function spl_autoload_functions(): array {}
 
 function spl_autoload_register(?callable $autoload_function = null, bool $throw = true, bool $prepend = false): bool {}
 

--- a/ext/spl/php_spl_arginfo.h
+++ b/ext/spl/php_spl_arginfo.h
@@ -18,14 +18,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload, 0, 1, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_call, 0, 1, IS_VOID, 0)
-	ZEND_ARG_INFO(0, class_name)
+	ZEND_ARG_TYPE_INFO(0, class_name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_extensions, 0, 0, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, file_extensions, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_spl_autoload_functions, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_functions, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_register, 0, 0, _IS_BOOL, 0)
@@ -38,8 +38,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_autoload_unregister, 0, 1, _
 	ZEND_ARG_INFO(0, autoload_function)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_classes, 0, 0, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_spl_classes arginfo_spl_autoload_functions
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_spl_object_hash, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, obj, IS_OBJECT, 0)

--- a/ext/spl/tests/bug71236.phpt
+++ b/ext/spl/tests/bug71236.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #71236: Second call of spl_autoload_register() does nothing if it has no arguments
+--FILE--
+<?php
+
+spl_autoload_register(function ($class) {});
+spl_autoload_register();
+var_dump(spl_autoload_functions());
+
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  object(Closure)#1 (1) {
+    ["parameter"]=>
+    array(1) {
+      ["$class"]=>
+      string(10) "<required>"
+    }
+  }
+  [1]=>
+  string(12) "spl_autoload"
+}

--- a/ext/spl/tests/spl_autoload_002.phpt
+++ b/ext/spl/tests/spl_autoload_002.phpt
@@ -1,9 +1,5 @@
 --TEST--
 SPL: spl_autoload_functions()
---SKIPIF--
-<?php
-if (spl_autoload_functions() !== false) die('skip __autoload() registered by php.ini');
-?>
 --FILE--
 <?php
 
@@ -40,7 +36,8 @@ var_dump(spl_autoload_functions());
 
 ?>
 --EXPECT--
-bool(false)
+array(0) {
+}
 array(1) {
   [0]=>
   string(12) "spl_autoload"
@@ -59,9 +56,11 @@ array(2) {
   [1]=>
   string(16) "SplAutoloadTest2"
 }
-bool(false)
+array(0) {
+}
 array(1) {
   [0]=>
   string(12) "spl_autoload"
 }
-bool(false)
+array(0) {
+}

--- a/ext/spl/tests/spl_autoload_012.phpt
+++ b/ext/spl/tests/spl_autoload_012.phpt
@@ -47,7 +47,6 @@ autoload_first
 Fatal error: Uncaught Exception: first in %sspl_autoload_012.php:%d
 Stack trace:
 #0 [internal function]: autoload_first('ThisClassDoesNo...')
-#1 [internal function]: spl_autoload_call('ThisClassDoesNo...')
-#2 %sspl_autoload_012.php(%d): class_exists('ThisClassDoesNo...')
-#3 {main}
+#1 %sspl_autoload_012.php(%d): class_exists('ThisClassDoesNo...')
+#2 {main}
   thrown in %s on line %d


### PR DESCRIPTION
This removes one level of indirection from the autoloading implementation. Instead of calling `spl_autoload_call()`, which then calls the registered autoloaders, we introduce a direct `zend_autoload` hook.

Additionally, we simplify handling by dropping special-casing of `spl_autoload`, and instead registering the default autoloader just like any other one.

This also fixes https://bugs.php.net/bug.php?id=71236 as a side-effect.