### PR TITLE
[ci skip] Also support absolute Windows filenames

### DIFF
--- a/scripts/dev/bless_tests.php
+++ b/scripts/dev/bless_tests.php
@@ -49,9 +49,9 @@ function getFiles(array $dirsOrFiles): \Iterator {
 }
 
 function normalizeOutput(string $out): string {
-    $out = preg_replace('/in \/.+ on line \d+$/m', 'in %s on line %d', $out);
-    $out = preg_replace('/in \/.+:\d+$/m', 'in %s:%d', $out);
-    $out = preg_replace('/^#(\d+) \/.+\(\d+\):/m', '#$1 %s(%d):', $out);
+    $out = preg_replace('/in (\/|[A-Z]:\\\\).+ on line \d+$/m', 'in %s on line %d', $out);
+    $out = preg_replace('/in (\/|[A-Z]:\\\\).+:\d+$/m', 'in %s:%d', $out);
+    $out = preg_replace('/^#(\d+) (\/|[A-Z]:\\\\).+\(\d+\):/m', '#$1 %s(%d):', $out);
     $out = preg_replace('/Resource id #\d+/', 'Resource id #%d', $out);
     $out = preg_replace('/resource\(\d+\) of type/', 'resource(%d) of type', $out);
     $out = preg_replace(


### PR DESCRIPTION
The output normalization of bless_tests.php only detected absolute Unix
filenames; we extend this for absolute Windows filenames, regardless of
the platform we're running on (tests may have been run on Windows, but
bless_tests.php may be run from WSL or a Linux VM, for instance).