### PR TITLE
Fix #66937: transformToDoc() removes DTD of source document

### DIFF
--- a/ext/xsl/tests/bug66937.phpt
+++ b/ext/xsl/tests/bug66937.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Bug #66937 (transformToDoc() removes DTD of source document)
+--SKIPIF--
+<?php
+if (!extension_loaded('xsl')) die('skip xsl extension not loaded');
+?>
+--FILE--
+<?php
+$stylesheet = new DOMDocument;
+$stylesheet->loadXML('<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"/>');
+
+$processor = new XSLTProcessor;
+$processor->importStylesheet($stylesheet);
+
+$doc = new DOMDocument;
+$doc->loadXML('<?xml version="1.0"?>
+<!DOCTYPE article PUBLIC "-//example//EN" "http://example.org/dtd">
+<article/>');
+
+printf("Doctype ID: %s\n", $doc->doctype->publicId);
+printf("Next sibling: %s\n", $doc->doctype->nextSibling->nodeName);
+echo $doc->saveXML();
+
+$output = $processor->transformToDoc($doc);
+
+printf("\nDoctype ID: %s\n", $doc->doctype->publicId);
+printf("Next sibling: %s\n", $doc->doctype->nextSibling->nodeName);
+echo $doc->saveXML();
+?>
+--EXPECT--
+Doctype ID: -//example//EN
+Next sibling: article
+<?xml version="1.0"?>
+<!DOCTYPE article PUBLIC "-//example//EN" "http://example.org/dtd">
+<article/>
+
+Doctype ID: -//example//EN
+Next sibling: article
+<?xml version="1.0"?>
+<!DOCTYPE article PUBLIC "-//example//EN" "http://example.org/dtd">
+<article/>

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -576,6 +576,14 @@ static xmlDocPtr php_xsl_apply_stylesheet(zval *id, xsl_object *intern, xsltStyl
 		php_error_docref(NULL, E_WARNING, "Can't set libxslt security properties, not doing transformation for security reasons");
 	} else {
 		newdocp = xsltApplyStylesheetUser(style, doc, (const char**) params,  NULL, f, ctxt);
+		/* work around libxslt dropping the DTD */
+		if (doc->intSubset) {
+			if (doc->children == NULL) {
+				xmlAddChild((xmlNodePtr) doc, (xmlNodePtr) doc->intSubset);
+			} else {
+				xmlAddPrevSibling(doc->children, (xmlNodePtr) doc->intSubset);
+			} 
+		}
 	}
 	if (f) {
 		fclose(f);


### PR DESCRIPTION
xsltApplyStylesheetUser() removes the DTD from the given document; we
counteract this by adding it back after the function returned.

---

Given that this bug has been reported more than 6 years ago, targeting master may be more reasonable. And maybe we just want to close the ticket as WONTFIX.