### PR TITLE
[RFC] Allow to declare protected methods and constants in interfaces

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3820,8 +3820,8 @@ ZEND_API zend_class_constant *zend_declare_class_constant_ex(zend_class_entry *c
 	zend_class_constant *c;
 
 	if (ce->ce_flags & ZEND_ACC_INTERFACE) {
-		if (access_type != ZEND_ACC_PUBLIC) {
-			zend_error_noreturn(E_COMPILE_ERROR, "Access type for interface constant %s::%s must be public", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+		if (access_type = ZEND_ACC_PRIVATE) {
+			zend_error_noreturn(E_COMPILE_ERROR, "Access type for interface constant %s::%s can not be private", ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		}
 	}
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3820,7 +3820,7 @@ ZEND_API zend_class_constant *zend_declare_class_constant_ex(zend_class_entry *c
 	zend_class_constant *c;
 
 	if (ce->ce_flags & ZEND_ACC_INTERFACE) {
-		if (access_type = ZEND_ACC_PRIVATE) {
+		if (access_type == ZEND_ACC_PRIVATE) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Access type for interface constant %s::%s can not be private", ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		}
 	}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6221,7 +6221,7 @@ zend_string *zend_begin_method_decl(zend_op_array *op_array, zend_string *name, 
 	zend_string *lcname;
 
 	if (in_interface) {
-		if (!(fn_flags & ZEND_ACC_PUBLIC) || (fn_flags & (ZEND_ACC_FINAL|ZEND_ACC_ABSTRACT))) {
+		if ((fn_flags & ZEND_ACC_PRIVATE) || (fn_flags & (ZEND_ACC_FINAL|ZEND_ACC_ABSTRACT))) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Access type for interface method "
 				"%s::%s() must be omitted", ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		}

--- a/tests/classes/interface_constant_inheritance_006.phpt
+++ b/tests/classes/interface_constant_inheritance_006.phpt
@@ -1,9 +1,12 @@
 --TEST--
-Ensure a interface can not have protected constants
+Ensure a interface can have protected constants
 --FILE--
 <?php
-interface A {
+interface IA {
     protected const FOO = 10;
 }
---EXPECTF--
-Fatal error: Access type for interface constant A::FOO must be public in %s on line 3
+
+echo "Done\n";
+?>
+--EXPECT--
+Done

--- a/tests/classes/interface_constant_inheritance_006.phpt
+++ b/tests/classes/interface_constant_inheritance_006.phpt
@@ -1,8 +1,8 @@
 --TEST--
-Ensure a interface can have protected constants
+Ensure an interface can have protected constants
 --FILE--
 <?php
-interface IA {
+interface I {
     protected const FOO = 10;
 }
 

--- a/tests/classes/interface_constant_inheritance_007.phpt
+++ b/tests/classes/interface_constant_inheritance_007.phpt
@@ -6,4 +6,4 @@ interface A {
     private const FOO = 10;
 }
 --EXPECTF--
-Fatal error: Access type for interface constant A::FOO must be public in %s on line 3
+Fatal error: Access type for interface constant A::FOO can not be private in %s on line 3

--- a/tests/classes/interface_method_protected.phpt
+++ b/tests/classes/interface_method_protected.phpt
@@ -4,6 +4,15 @@ Ensure an interface can have protected methods
 <?php
 interface I {
     protected function x();
+    protected static function y();
+}
+
+class Cl implements I {
+    protected function x() {
+    }
+
+    protected static function y() {
+    }
 }
 
 echo "Done\n";

--- a/tests/classes/interface_method_protected.phpt
+++ b/tests/classes/interface_method_protected.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Ensure an interface can have protected methods
+--FILE--
+<?php
+interface I {
+    protected function x;
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+Done

--- a/tests/classes/interface_method_protected.phpt
+++ b/tests/classes/interface_method_protected.phpt
@@ -3,7 +3,7 @@ Ensure an interface can have protected methods
 --FILE--
 <?php
 interface I {
-    protected function x;
+    protected function x();
 }
 
 echo "Done\n";


### PR DESCRIPTION
This PR adds support of non-`private` access type members for interfaces.

`Protected` access type (and possibly other access types in the future) are fully valid access types to be declared in interfaces to enforce some class functionality from the object context.