### PR TITLE
Fix #79687: Sony picture - PHP Warning - Make, Model, MakerNotes

### DIFF
--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -3147,7 +3147,7 @@ static int exif_process_IFD_in_MAKERNOTE(image_info_type *ImageInfo, char * valu
 	if (value_len < 2 || maker_note->offset >= value_len - 1) {
 		/* Do not go past the value end */
 		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "IFD data too short: 0x%04X offset 0x%04X", value_len, maker_note->offset);
-		return FALSE;
+		return TRUE;
 	}
 
 	dir_start = value_ptr + maker_note->offset;

--- a/ext/exif/tests/bug77563.phpt
+++ b/ext/exif/tests/bug77563.phpt
@@ -10,6 +10,8 @@ DONE
 --EXPECTF--
 Warning: exif_thumbnail(bug77563.jpg): IFD data too short: 0x0009 offset 0x0008 in %s%ebug77563.php on line %d
 
+Warning: exif_thumbnail(bug77563.jpg): Illegal IFD offset in %s%ebug77563.php on line %d
+
 Warning: exif_thumbnail(bug77563.jpg): File structure corrupted in %s%ebug77563.php on line %d
 
 Warning: exif_thumbnail(bug77563.jpg): Invalid JPEG file in %s%ebug77563.php on line %d

--- a/ext/exif/tests/bug78910.phpt
+++ b/ext/exif/tests/bug78910.phpt
@@ -13,5 +13,32 @@ Warning: exif_read_data(): Process tag(x927C=MakerNote  ): Illegal format code 0
 
 Warning: exif_read_data(): IFD data too short: 0x0000 offset 0x000C in %s on line %d
 
-Warning: exif_read_data(): Invalid TIFF file in %s on line %d
-bool(false)
+Warning: exif_read_data(): Error in TIFF: filesize(x002A) less than start of IFD dir(x46494C4F) in %s on line %d
+array(8) {
+  ["FileDateTime"]=>
+  int(0)
+  ["FileSize"]=>
+  int(42)
+  ["FileType"]=>
+  int(8)
+  ["MimeType"]=>
+  string(10) "image/tiff"
+  ["SectionsFound"]=>
+  string(13) "ANY_TAG, IFD0"
+  ["COMPUTED"]=>
+  array(2) {
+    ["IsColor"]=>
+    int(0)
+    ["ByteOrderMotorola"]=>
+    int(1)
+  }
+  ["Make"]=>
+  array(2) {
+    [0]=>
+    int(1179994697)
+    [1]=>
+    int(1179208781)
+  }
+  ["MakerNote"]=>
+  NULL
+}


### PR DESCRIPTION
Even if the length of a maker note does not match our expectations
(either because the maker note is corrupted, or because our
expectations do not quite match reality), there is no need to let
parsing fail; we can still go on parsing the other meta information.