### PR TITLE
Refactored some ZPP calls in OCI8.

### DIFF
--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -1556,14 +1556,14 @@ PHP_FUNCTION(oci_close)
 	zval *z_connection;
 	php_oci_connection *connection;
 
-	if (OCI_G(old_oci_close_semantics)) {
-		/* do nothing to keep BC */
-		return;
-	}
-
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_RESOURCE(z_connection)
 	ZEND_PARSE_PARAMETERS_END();
+
+	if (OCI_G(old_oci_close_semantics)) {
+		/* do nothing to keep BC */
+		RETURN_NULL();
+	}
 
 	PHP_OCI_ZVAL_TO_CONNECTION(z_connection, connection);
 	if (GC_REFCOUNT(connection->id) == 2) { /* CHANGED VERSION::PHP7
@@ -2255,7 +2255,6 @@ PHP_FUNCTION(oci_collection_element_get)
 	zval *tmp, *z_collection;
 	php_oci_collection *collection;
 	zend_long element_index;
-	zval value;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_collection, oci_coll_class_entry_ptr, &element_index) == FAILURE) {
 		RETURN_THROWS();

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -285,23 +285,16 @@ PHP_FUNCTION(oci_free_descriptor)
    Saves a large object */
 PHP_FUNCTION(oci_lob_save)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	char *data;
 	size_t data_len;
 	zend_long offset = 0;
 	ub4 bytes_written;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &data, &data_len, &offset) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &offset) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &offset) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -326,21 +319,14 @@ PHP_FUNCTION(oci_lob_save)
    Loads file into a LOB */
 PHP_FUNCTION(oci_lob_import)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	char *filename;
 	size_t filename_len;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "p", &filename, &filename_len) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Op", &z_descriptor, oci_lob_class_entry_ptr, &filename, &filename_len) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Op", &z_descriptor, oci_lob_class_entry_ptr, &filename, &filename_len) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -360,16 +346,14 @@ PHP_FUNCTION(oci_lob_import)
    Loads a large object */
 PHP_FUNCTION(oci_lob_load)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	char *buffer = NULL;
 	ub4 buffer_len;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -397,22 +381,15 @@ PHP_FUNCTION(oci_lob_load)
    Reads particular part of a large object */
 PHP_FUNCTION(oci_lob_read)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	zend_long length;
 	char *buffer;
 	ub4 buffer_len;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &length) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ol", &z_descriptor, oci_lob_class_entry_ptr, &length) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_descriptor, oci_lob_class_entry_ptr, &length) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -444,15 +421,13 @@ PHP_FUNCTION(oci_lob_read)
    Checks if EOF is reached */
 PHP_FUNCTION(oci_lob_eof)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	ub4 lob_length;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -474,14 +449,12 @@ PHP_FUNCTION(oci_lob_eof)
    Tells LOB pointer position */
 PHP_FUNCTION(oci_lob_tell)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -498,14 +471,12 @@ PHP_FUNCTION(oci_lob_tell)
    Rewind pointer of a LOB */
 PHP_FUNCTION(oci_lob_rewind)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -524,21 +495,14 @@ PHP_FUNCTION(oci_lob_rewind)
    Moves the pointer of a LOB */
 PHP_FUNCTION(oci_lob_seek)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	zend_long offset, whence = PHP_OCI_SEEK_SET;
 	ub4 lob_length;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &offset, &whence) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ol|l", &z_descriptor, oci_lob_class_entry_ptr, &offset, &whence) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol|l", &z_descriptor, oci_lob_class_entry_ptr, &offset, &whence) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -580,15 +544,13 @@ PHP_FUNCTION(oci_lob_seek)
    Returns size of a large object */
 PHP_FUNCTION(oci_lob_size)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	ub4 lob_length;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -608,31 +570,24 @@ PHP_FUNCTION(oci_lob_size)
    Writes data to current position of a LOB */
 PHP_FUNCTION(oci_lob_write)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	size_t data_len;
 	zend_long write_len = 0;
 	ub4 bytes_written;
 	char *data;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &data, &data_len, &write_len) == FAILURE) {
-			RETURN_THROWS();
-		}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &write_len) == FAILURE) {
+        RETURN_THROWS();
+    }
 
-		if (ZEND_NUM_ARGS() == 2) {
-			data_len = MIN((zend_long) data_len, write_len);
-		}
+	if (getThis() && ZEND_NUM_ARGS() == 2) {
+        data_len = MIN((zend_long) data_len, write_len);
 	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &write_len) == FAILURE) {
-			RETURN_THROWS();
-		}
 
-		if (ZEND_NUM_ARGS() == 3) {
-			data_len = MIN((zend_long) data_len, write_len);
-		}
-	}
+    if (! getThis() && ZEND_NUM_ARGS() == 3) {
+        data_len = MIN((zend_long) data_len, write_len);
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -656,19 +611,12 @@ PHP_FUNCTION(oci_lob_write)
    Appends data from a LOB to another LOB */
 PHP_FUNCTION(oci_lob_append)
 {
-	zval *tmp_dest, *tmp_from, *z_descriptor_dest = getThis(), *z_descriptor_from;
+	zval *tmp_dest, *tmp_from, *z_descriptor_dest, *z_descriptor_from;
 	php_oci_descriptor *descriptor_dest, *descriptor_from;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_descriptor_from, oci_lob_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "OO", &z_descriptor_dest, oci_lob_class_entry_ptr, &z_descriptor_from, oci_lob_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OO", &z_descriptor_dest, oci_lob_class_entry_ptr, &z_descriptor_from, oci_lob_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_dest), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property. The first argument should be valid descriptor object");
@@ -695,21 +643,14 @@ PHP_FUNCTION(oci_lob_append)
    Truncates a LOB */
 PHP_FUNCTION(oci_lob_truncate)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	zend_long trim_length = 0;
 	ub4 ub_trim_length;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &trim_length) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|l", &z_descriptor, oci_lob_class_entry_ptr, &trim_length) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|l", &z_descriptor, oci_lob_class_entry_ptr, &trim_length) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -735,41 +676,34 @@ PHP_FUNCTION(oci_lob_truncate)
    Erases a specified portion of the internal LOB, starting at a specified offset */
 PHP_FUNCTION(oci_lob_erase)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	ub4 bytes_erased;
 	zend_long offset = -1, length = -1;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "|ll", &offset, &length) == FAILURE) {
-			RETURN_THROWS();
-		}
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|ll", &z_descriptor, oci_lob_class_entry_ptr, &offset, &length) == FAILURE) {
+        RETURN_THROWS();
+    }
 
-		if (ZEND_NUM_ARGS() > 0 && offset < 0) {
-			php_error_docref(NULL, E_WARNING, "Offset must be greater than or equal to 0");
-			RETURN_FALSE;
-		}
+    if (getThis() && ZEND_NUM_ARGS() > 0 && offset < 0) {
+        php_error_docref(NULL, E_WARNING, "Offset must be greater than or equal to 0");
+        RETURN_FALSE;
+    }
 
-		if (ZEND_NUM_ARGS() > 1 && length < 0) {
-			php_error_docref(NULL, E_WARNING, "Length must be greater than or equal to 0");
-			RETURN_FALSE;
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|ll", &z_descriptor, oci_lob_class_entry_ptr, &offset, &length) == FAILURE) {
-			RETURN_THROWS();
-		}
+    if (getThis() && ZEND_NUM_ARGS() > 1 && length < 0) {
+        php_error_docref(NULL, E_WARNING, "Length must be greater than or equal to 0");
+        RETURN_FALSE;
+    }
 
-		if (ZEND_NUM_ARGS() > 1 && offset < 0) {
-			php_error_docref(NULL, E_WARNING, "Offset must be greater than or equal to 0");
-			RETURN_FALSE;
-		}
+    if (! getThis() && ZEND_NUM_ARGS() > 1 && offset < 0) {
+        php_error_docref(NULL, E_WARNING, "Offset must be greater than or equal to 0");
+        RETURN_FALSE;
+    }
 
-		if (ZEND_NUM_ARGS() > 2 && length < 0) {
-			php_error_docref(NULL, E_WARNING, "Length must be greater than or equal to 0");
-			RETURN_FALSE;
-		}
-	}
+    if (! getThis() && ZEND_NUM_ARGS() > 2 && length < 0) {
+        php_error_docref(NULL, E_WARNING, "Length must be greater than or equal to 0");
+        RETURN_FALSE;
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -789,20 +723,13 @@ PHP_FUNCTION(oci_lob_erase)
    Flushes the LOB buffer */
 PHP_FUNCTION(oci_lob_flush)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	zend_long flush_flag = 0;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &flush_flag) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|l", &z_descriptor, oci_lob_class_entry_ptr, &flush_flag) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|l", &z_descriptor, oci_lob_class_entry_ptr, &flush_flag) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -827,20 +754,13 @@ PHP_FUNCTION(oci_lob_flush)
    Enables/disables buffering for a LOB */
 PHP_FUNCTION(ocisetbufferinglob)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	zend_bool flag;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &flag) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ob", &z_descriptor, oci_lob_class_entry_ptr, &flag) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ob", &z_descriptor, oci_lob_class_entry_ptr, &flag) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -860,14 +780,12 @@ PHP_FUNCTION(ocisetbufferinglob)
    Returns current state of buffering for a LOB */
 PHP_FUNCTION(ocigetbufferinglob)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -965,7 +883,7 @@ PHP_FUNCTION(oci_lob_is_equal)
    Writes a large object into a file */
 PHP_FUNCTION(oci_lob_export)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	char *filename;
 	char *buffer;
@@ -974,34 +892,29 @@ PHP_FUNCTION(oci_lob_export)
 	php_stream *stream;
 	ub4 lob_length;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "p|ll", &filename, &filename_len, &start, &length) == FAILURE) {
-			RETURN_THROWS();
-		}
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Op|ll", &z_descriptor, oci_lob_class_entry_ptr, &filename, &filename_len, &start, &length) == FAILURE) {
+        RETURN_THROWS();
+    }
 
-		if (ZEND_NUM_ARGS() > 1 && start < 0) {
-			php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
-			RETURN_FALSE;
-		}
-		if (ZEND_NUM_ARGS() > 2 && length < 0) {
-			php_error_docref(NULL, E_WARNING, "length parameter must be greater than or equal to 0");
-			RETURN_FALSE;
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Op|ll", &z_descriptor, oci_lob_class_entry_ptr, &filename, &filename_len, &start, &length) == FAILURE) {
-			RETURN_THROWS();
-		}
+    if (getThis() &&ZEND_NUM_ARGS() > 1 && start < 0) {
+        php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
+        RETURN_FALSE;
+    }
 
-		if (ZEND_NUM_ARGS() > 2 && start < 0) {
-			php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
-			RETURN_FALSE;
-		}
-		if (ZEND_NUM_ARGS() > 3 && length < 0) {
-			php_error_docref(NULL, E_WARNING, "length parameter must be greater than or equal to 0");
-			RETURN_FALSE;
-		}
-	}
+    if (getThis() && ZEND_NUM_ARGS() > 2 && length < 0) {
+        php_error_docref(NULL, E_WARNING, "length parameter must be greater than or equal to 0");
+        RETURN_FALSE;
+    }
+
+    if (! getThis() && ZEND_NUM_ARGS() > 2 && start < 0) {
+        php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
+        RETURN_FALSE;
+    }
+
+    if (! getThis() && ZEND_NUM_ARGS() > 3 && length < 0) {
+        php_error_docref(NULL, E_WARNING, "length parameter must be greater than or equal to 0");
+        RETURN_FALSE;
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -1076,22 +989,15 @@ PHP_FUNCTION(oci_lob_export)
    Writes temporary blob */
 PHP_FUNCTION(oci_lob_write_temporary)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 	char *data;
 	size_t data_len;
 	zend_long type = OCI_TEMP_CLOB;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &data, &data_len, &type) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &type) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &type) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -1111,14 +1017,12 @@ PHP_FUNCTION(oci_lob_write_temporary)
    Closes lob descriptor */
 PHP_FUNCTION(oci_lob_close)
 {
-	zval *tmp, *z_descriptor = getThis();
+	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -2298,14 +2202,12 @@ PHP_FUNCTION(oci_num_rows)
    Deletes collection object*/
 PHP_FUNCTION(oci_free_collection)
 {
-	zval *tmp, *z_collection = getThis();
+	zval *tmp, *z_collection;
 	php_oci_collection *collection;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2323,21 +2225,14 @@ PHP_FUNCTION(oci_free_collection)
    Append an object to the collection */
 PHP_FUNCTION(oci_collection_append)
 {
-	zval *tmp, *z_collection = getThis();
+	zval *tmp, *z_collection;
 	php_oci_collection *collection;
 	char *value;
 	size_t value_len;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &value, &value_len) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &z_collection, oci_coll_class_entry_ptr, &value, &value_len) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &z_collection, oci_coll_class_entry_ptr, &value, &value_len) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2357,21 +2252,14 @@ PHP_FUNCTION(oci_collection_append)
    Retrieve the value at collection index ndx */
 PHP_FUNCTION(oci_collection_element_get)
 {
-	zval *tmp, *z_collection = getThis();
+	zval *tmp, *z_collection;
 	php_oci_collection *collection;
 	zend_long element_index;
 	zval value;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &element_index) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ol", &z_collection, oci_coll_class_entry_ptr, &element_index) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_collection, oci_coll_class_entry_ptr, &element_index) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2390,19 +2278,12 @@ PHP_FUNCTION(oci_collection_element_get)
    Assign a collection from another existing collection */
 PHP_FUNCTION(oci_collection_assign)
 {
-	zval *tmp_dest, *tmp_from, *z_collection_dest = getThis(), *z_collection_from;
+	zval *tmp_dest, *tmp_from, *z_collection_dest, *z_collection_from;
 	php_oci_collection *collection_dest, *collection_from;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_collection_from, oci_coll_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "OO", &z_collection_dest, oci_coll_class_entry_ptr, &z_collection_from, oci_coll_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OO", &z_collection_dest, oci_coll_class_entry_ptr, &z_collection_from, oci_coll_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_collection_dest), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property. The first argument should be valid collection object");
@@ -2428,22 +2309,15 @@ PHP_FUNCTION(oci_collection_assign)
    Assign element val to collection at index ndx */
 PHP_FUNCTION(oci_collection_element_assign)
 {
-	zval *tmp, *z_collection = getThis();
+	zval *tmp, *z_collection;
 	php_oci_collection *collection;
 	size_t value_len;
 	zend_long element_index;
 	char *value;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "ls", &element_index, &value, &value_len) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ols", &z_collection, oci_coll_class_entry_ptr, &element_index, &value, &value_len) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ols", &z_collection, oci_coll_class_entry_ptr, &element_index, &value, &value_len) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2463,15 +2337,13 @@ PHP_FUNCTION(oci_collection_element_assign)
    Return the size of a collection */
 PHP_FUNCTION(oci_collection_size)
 {
-	zval *tmp, *z_collection = getThis();
+	zval *tmp, *z_collection;
 	php_oci_collection *collection;
 	sb4 size = 0;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2491,15 +2363,13 @@ PHP_FUNCTION(oci_collection_size)
    Return the max value of a collection. For a varray this is the maximum length of the array */
 PHP_FUNCTION(oci_collection_max)
 {
-	zval *tmp, *z_collection = getThis();
+	zval *tmp, *z_collection;
 	php_oci_collection *collection;
 	zend_long max;
 
-	if (!getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2519,20 +2389,13 @@ PHP_FUNCTION(oci_collection_max)
    Trim num elements from the end of a collection */
 PHP_FUNCTION(oci_collection_trim)
 {
-	zval *tmp, *z_collection = getThis();
+	zval *tmp, *z_collection;
 	php_oci_collection *collection;
 	zend_long trim_size;
 
-	if (getThis()) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &trim_size) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
-	else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ol", &z_collection, oci_coll_class_entry_ptr, &trim_size) == FAILURE) {
-			RETURN_THROWS();
-		}
-	}
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_collection, oci_coll_class_entry_ptr, &trim_size) == FAILURE) {
+        RETURN_THROWS();
+    }
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -292,9 +292,9 @@ PHP_FUNCTION(oci_lob_save)
 	zend_long offset = 0;
 	ub4 bytes_written;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &offset) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &offset) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -325,8 +325,8 @@ PHP_FUNCTION(oci_lob_import)
 	size_t filename_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Op", &z_descriptor, oci_lob_class_entry_ptr, &filename, &filename_len) == FAILURE) {
-        RETURN_THROWS();
-    }
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -351,9 +351,9 @@ PHP_FUNCTION(oci_lob_load)
 	char *buffer = NULL;
 	ub4 buffer_len;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -366,7 +366,7 @@ PHP_FUNCTION(oci_lob_load)
 		RETURN_FALSE;
 	}
 	if (buffer_len > 0) {
-        zend_string *ret = zend_string_init(buffer, buffer_len, 0);
+		zend_string *ret = zend_string_init(buffer, buffer_len, 0);
 		if (buffer)
 			efree(buffer);
 		RETURN_STR(ret);
@@ -387,9 +387,9 @@ PHP_FUNCTION(oci_lob_read)
 	char *buffer;
 	ub4 buffer_len;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_descriptor, oci_lob_class_entry_ptr, &length) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_descriptor, oci_lob_class_entry_ptr, &length) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -426,8 +426,8 @@ PHP_FUNCTION(oci_lob_eof)
 	ub4 lob_length;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -452,9 +452,9 @@ PHP_FUNCTION(oci_lob_tell)
 	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -474,9 +474,9 @@ PHP_FUNCTION(oci_lob_rewind)
 	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -500,9 +500,9 @@ PHP_FUNCTION(oci_lob_seek)
 	zend_long offset, whence = PHP_OCI_SEEK_SET;
 	ub4 lob_length;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol|l", &z_descriptor, oci_lob_class_entry_ptr, &offset, &whence) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol|l", &z_descriptor, oci_lob_class_entry_ptr, &offset, &whence) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -548,9 +548,9 @@ PHP_FUNCTION(oci_lob_size)
 	php_oci_descriptor *descriptor;
 	ub4 lob_length;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -577,17 +577,17 @@ PHP_FUNCTION(oci_lob_write)
 	ub4 bytes_written;
 	char *data;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &write_len) == FAILURE) {
-        RETURN_THROWS();
-    }
-
-	if (getThis() && ZEND_NUM_ARGS() == 2) {
-        data_len = MIN((zend_long) data_len, write_len);
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &write_len) == FAILURE) {
+		RETURN_THROWS();
 	}
 
-    if (! getThis() && ZEND_NUM_ARGS() == 3) {
-        data_len = MIN((zend_long) data_len, write_len);
-    }
+	if (getThis() && ZEND_NUM_ARGS() == 2) {
+		data_len = MIN((zend_long) data_len, write_len);
+	}
+
+	if (! getThis() && ZEND_NUM_ARGS() == 3) {
+		data_len = MIN((zend_long) data_len, write_len);
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -614,9 +614,9 @@ PHP_FUNCTION(oci_lob_append)
 	zval *tmp_dest, *tmp_from, *z_descriptor_dest, *z_descriptor_from;
 	php_oci_descriptor *descriptor_dest, *descriptor_from;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OO", &z_descriptor_dest, oci_lob_class_entry_ptr, &z_descriptor_from, oci_lob_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OO", &z_descriptor_dest, oci_lob_class_entry_ptr, &z_descriptor_from, oci_lob_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_dest), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property. The first argument should be valid descriptor object");
@@ -648,9 +648,9 @@ PHP_FUNCTION(oci_lob_truncate)
 	zend_long trim_length = 0;
 	ub4 ub_trim_length;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|l", &z_descriptor, oci_lob_class_entry_ptr, &trim_length) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|l", &z_descriptor, oci_lob_class_entry_ptr, &trim_length) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -682,28 +682,28 @@ PHP_FUNCTION(oci_lob_erase)
 	zend_long offset = -1, length = -1;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|ll", &z_descriptor, oci_lob_class_entry_ptr, &offset, &length) == FAILURE) {
-        RETURN_THROWS();
-    }
+		RETURN_THROWS();
+	}
 
-    if (getThis() && ZEND_NUM_ARGS() > 0 && offset < 0) {
-        php_error_docref(NULL, E_WARNING, "Offset must be greater than or equal to 0");
-        RETURN_FALSE;
-    }
+	if (getThis() && ZEND_NUM_ARGS() > 0 && offset < 0) {
+		php_error_docref(NULL, E_WARNING, "Offset must be greater than or equal to 0");
+		RETURN_FALSE;
+	}
 
-    if (getThis() && ZEND_NUM_ARGS() > 1 && length < 0) {
-        php_error_docref(NULL, E_WARNING, "Length must be greater than or equal to 0");
-        RETURN_FALSE;
-    }
+	if (getThis() && ZEND_NUM_ARGS() > 1 && length < 0) {
+		php_error_docref(NULL, E_WARNING, "Length must be greater than or equal to 0");
+		RETURN_FALSE;
+	}
 
-    if (! getThis() && ZEND_NUM_ARGS() > 1 && offset < 0) {
-        php_error_docref(NULL, E_WARNING, "Offset must be greater than or equal to 0");
-        RETURN_FALSE;
-    }
+	if (! getThis() && ZEND_NUM_ARGS() > 1 && offset < 0) {
+		php_error_docref(NULL, E_WARNING, "Offset must be greater than or equal to 0");
+		RETURN_FALSE;
+	}
 
-    if (! getThis() && ZEND_NUM_ARGS() > 2 && length < 0) {
-        php_error_docref(NULL, E_WARNING, "Length must be greater than or equal to 0");
-        RETURN_FALSE;
-    }
+	if (! getThis() && ZEND_NUM_ARGS() > 2 && length < 0) {
+		php_error_docref(NULL, E_WARNING, "Length must be greater than or equal to 0");
+		RETURN_FALSE;
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -727,9 +727,9 @@ PHP_FUNCTION(oci_lob_flush)
 	php_oci_descriptor *descriptor;
 	zend_long flush_flag = 0;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|l", &z_descriptor, oci_lob_class_entry_ptr, &flush_flag) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|l", &z_descriptor, oci_lob_class_entry_ptr, &flush_flag) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -758,9 +758,9 @@ PHP_FUNCTION(ocisetbufferinglob)
 	php_oci_descriptor *descriptor;
 	zend_bool flag;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ob", &z_descriptor, oci_lob_class_entry_ptr, &flag) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ob", &z_descriptor, oci_lob_class_entry_ptr, &flag) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -783,9 +783,9 @@ PHP_FUNCTION(ocigetbufferinglob)
 	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -893,28 +893,28 @@ PHP_FUNCTION(oci_lob_export)
 	ub4 lob_length;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Op|ll", &z_descriptor, oci_lob_class_entry_ptr, &filename, &filename_len, &start, &length) == FAILURE) {
-        RETURN_THROWS();
-    }
+		RETURN_THROWS();
+	}
 
-    if (getThis() &&ZEND_NUM_ARGS() > 1 && start < 0) {
-        php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
-        RETURN_FALSE;
-    }
+	if (getThis() &&ZEND_NUM_ARGS() > 1 && start < 0) {
+		php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
+		RETURN_FALSE;
+	}
 
-    if (getThis() && ZEND_NUM_ARGS() > 2 && length < 0) {
-        php_error_docref(NULL, E_WARNING, "length parameter must be greater than or equal to 0");
-        RETURN_FALSE;
-    }
+	if (getThis() && ZEND_NUM_ARGS() > 2 && length < 0) {
+		php_error_docref(NULL, E_WARNING, "length parameter must be greater than or equal to 0");
+		RETURN_FALSE;
+	}
 
-    if (! getThis() && ZEND_NUM_ARGS() > 2 && start < 0) {
-        php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
-        RETURN_FALSE;
-    }
+	if (! getThis() && ZEND_NUM_ARGS() > 2 && start < 0) {
+		php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
+		RETURN_FALSE;
+	}
 
-    if (! getThis() && ZEND_NUM_ARGS() > 3 && length < 0) {
-        php_error_docref(NULL, E_WARNING, "length parameter must be greater than or equal to 0");
-        RETURN_FALSE;
-    }
+	if (! getThis() && ZEND_NUM_ARGS() > 3 && length < 0) {
+		php_error_docref(NULL, E_WARNING, "length parameter must be greater than or equal to 0");
+		RETURN_FALSE;
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -995,9 +995,9 @@ PHP_FUNCTION(oci_lob_write_temporary)
 	size_t data_len;
 	zend_long type = OCI_TEMP_CLOB;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &type) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|l", &z_descriptor, oci_lob_class_entry_ptr, &data, &data_len, &type) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -1020,9 +1020,9 @@ PHP_FUNCTION(oci_lob_close)
 	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_descriptor, oci_lob_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
@@ -2205,9 +2205,9 @@ PHP_FUNCTION(oci_free_collection)
 	zval *tmp, *z_collection;
 	php_oci_collection *collection;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2230,9 +2230,9 @@ PHP_FUNCTION(oci_collection_append)
 	char *value;
 	size_t value_len;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &z_collection, oci_coll_class_entry_ptr, &value, &value_len) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &z_collection, oci_coll_class_entry_ptr, &value, &value_len) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2257,9 +2257,9 @@ PHP_FUNCTION(oci_collection_element_get)
 	zend_long element_index;
 	zval value;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_collection, oci_coll_class_entry_ptr, &element_index) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_collection, oci_coll_class_entry_ptr, &element_index) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2281,9 +2281,9 @@ PHP_FUNCTION(oci_collection_assign)
 	zval *tmp_dest, *tmp_from, *z_collection_dest, *z_collection_from;
 	php_oci_collection *collection_dest, *collection_from;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OO", &z_collection_dest, oci_coll_class_entry_ptr, &z_collection_from, oci_coll_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OO", &z_collection_dest, oci_coll_class_entry_ptr, &z_collection_from, oci_coll_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_collection_dest), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property. The first argument should be valid collection object");
@@ -2315,9 +2315,9 @@ PHP_FUNCTION(oci_collection_element_assign)
 	zend_long element_index;
 	char *value;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ols", &z_collection, oci_coll_class_entry_ptr, &element_index, &value, &value_len) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ols", &z_collection, oci_coll_class_entry_ptr, &element_index, &value, &value_len) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2341,9 +2341,9 @@ PHP_FUNCTION(oci_collection_size)
 	php_oci_collection *collection;
 	sb4 size = 0;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2367,9 +2367,9 @@ PHP_FUNCTION(oci_collection_max)
 	php_oci_collection *collection;
 	zend_long max;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &z_collection, oci_coll_class_entry_ptr) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
@@ -2393,9 +2393,9 @@ PHP_FUNCTION(oci_collection_trim)
 	php_oci_collection *collection;
 	zend_long trim_size;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_collection, oci_coll_class_entry_ptr, &trim_size) == FAILURE) {
-        RETURN_THROWS();
-    }
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &z_collection, oci_coll_class_entry_ptr, &trim_size) == FAILURE) {
+		RETURN_THROWS();
+	}
 
 	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -585,7 +585,7 @@ PHP_FUNCTION(oci_lob_write)
 		data_len = MIN((zend_long) data_len, write_len);
 	}
 
-	if (! getThis() && ZEND_NUM_ARGS() == 3) {
+	if (!getThis() && ZEND_NUM_ARGS() == 3) {
 		data_len = MIN((zend_long) data_len, write_len);
 	}
 
@@ -695,12 +695,12 @@ PHP_FUNCTION(oci_lob_erase)
 		RETURN_FALSE;
 	}
 
-	if (! getThis() && ZEND_NUM_ARGS() > 1 && offset < 0) {
+	if (!getThis() && ZEND_NUM_ARGS() > 1 && offset < 0) {
 		php_error_docref(NULL, E_WARNING, "Offset must be greater than or equal to 0");
 		RETURN_FALSE;
 	}
 
-	if (! getThis() && ZEND_NUM_ARGS() > 2 && length < 0) {
+	if (!getThis() && ZEND_NUM_ARGS() > 2 && length < 0) {
 		php_error_docref(NULL, E_WARNING, "Length must be greater than or equal to 0");
 		RETURN_FALSE;
 	}
@@ -896,7 +896,7 @@ PHP_FUNCTION(oci_lob_export)
 		RETURN_THROWS();
 	}
 
-	if (getThis() &&ZEND_NUM_ARGS() > 1 && start < 0) {
+	if (getThis() && ZEND_NUM_ARGS() > 1 && start < 0) {
 		php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
 		RETURN_FALSE;
 	}
@@ -906,12 +906,12 @@ PHP_FUNCTION(oci_lob_export)
 		RETURN_FALSE;
 	}
 
-	if (! getThis() && ZEND_NUM_ARGS() > 2 && start < 0) {
+	if (!getThis() && ZEND_NUM_ARGS() > 2 && start < 0) {
 		php_error_docref(NULL, E_WARNING, "Start parameter must be greater than or equal to 0");
 		RETURN_FALSE;
 	}
 
-	if (! getThis() && ZEND_NUM_ARGS() > 3 && length < 0) {
+	if (!getThis() && ZEND_NUM_ARGS() > 3 && length < 0) {
 		php_error_docref(NULL, E_WARNING, "length parameter must be greater than or equal to 0");
 		RETURN_FALSE;
 	}


### PR DESCRIPTION
Thanks to the comments of @kocsismate on #5701 i refactored some ZPP calls to the "zend_parse_method_parameters" variant, which ensures ZPP is always called on method/function invocation.

I also moved the "old_oci_close_semantics" check beneath the ZPP check.