### PR TITLE
[RFC] Allow void return type on constructors/destructors

### DIFF
--- a/Zend/tests/return_types/014.phpt
+++ b/Zend/tests/return_types/014.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Constructors cannot declare a return type
+Constructors must return void
 --FILE--
 <?php
 
@@ -7,4 +7,4 @@ class Foo {
     function __construct() : Foo {}
 }
 --EXPECTF--
-Fatal error: Constructor %s::%s() cannot declare a return type in %s on line %d
+Fatal error: Constructor %s::%s() must return void in %s on line %d

--- a/Zend/tests/return_types/018.phpt
+++ b/Zend/tests/return_types/018.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Destructors cannot declare a return type
+Destructors must return void
 --FILE--
 <?php
 
@@ -7,4 +7,4 @@ class Foo {
     function __destruct() : Foo {}
 }
 --EXPECTF--
-Fatal error: Destructor %s::%s() cannot declare a return type in %s on line %d
+Fatal error: Destructor %s::%s() must return void in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6894,9 +6894,10 @@ void zend_compile_class_decl(znode *result, zend_ast *ast, zend_bool toplevel) /
 			zend_error_noreturn(E_COMPILE_ERROR, "Constructor %s::%s() cannot be static",
 				ZSTR_VAL(ce->name), ZSTR_VAL(ce->constructor->common.function_name));
 		}
-		if (ce->constructor->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
+		if (ce->constructor->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE
+			&& ZEND_TYPE_PURE_MASK(ce->constructor->common.arg_info[-1].type) != MAY_BE_VOID) {
 			zend_error_noreturn(E_COMPILE_ERROR,
-				"Constructor %s::%s() cannot declare a return type",
+				"Constructor %s::%s() must return void",
 				ZSTR_VAL(ce->name), ZSTR_VAL(ce->constructor->common.function_name));
 		}
 	}
@@ -6904,9 +6905,10 @@ void zend_compile_class_decl(znode *result, zend_ast *ast, zend_bool toplevel) /
 		if (ce->destructor->common.fn_flags & ZEND_ACC_STATIC) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Destructor %s::%s() cannot be static",
 				ZSTR_VAL(ce->name), ZSTR_VAL(ce->destructor->common.function_name));
-		} else if (ce->destructor->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
+		} else if (ce->destructor->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE
+			&& ZEND_TYPE_PURE_MASK(ce->destructor->common.arg_info[-1].type) != MAY_BE_VOID) {
 			zend_error_noreturn(E_COMPILE_ERROR,
-				"Destructor %s::%s() cannot declare a return type",
+				"Destructor %s::%s() must return void",
 				ZSTR_VAL(ce->name), ZSTR_VAL(ce->destructor->common.function_name));
 		}
 	}


### PR DESCRIPTION
TODO list:
- [x] RFC (https://wiki.php.net/rfc/constructor_return_type)
- [ ] Additional tests (type widening)