### PR TITLE
Fix #79700: Bad performance with namespaced nodes due to wrong libxml assumption

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1361,33 +1361,6 @@ void dom_normalize (xmlNodePtr nodep)
 }
 /* }}} end dom_normalize */
 
-
-/* {{{ void dom_set_old_ns(xmlDoc *doc, xmlNs *ns) */
-void dom_set_old_ns(xmlDoc *doc, xmlNs *ns) {
-	xmlNs *cur;
-
-	if (doc == NULL)
-		return;
-
-	if (doc->oldNs == NULL) {
-		doc->oldNs = (xmlNsPtr) xmlMalloc(sizeof(xmlNs));
-		if (doc->oldNs == NULL) {
-			return;
-		}
-		memset(doc->oldNs, 0, sizeof(xmlNs));
-		doc->oldNs->type = XML_LOCAL_NAMESPACE;
-		doc->oldNs->href = xmlStrdup(XML_XML_NAMESPACE);
-		doc->oldNs->prefix = xmlStrdup((const xmlChar *)"xml");
-	}
-
-	cur = doc->oldNs;
-	while (cur->next != NULL) {
-		cur = cur->next;
-	}
-	cur->next = ns;
-}
-/* }}} end dom_set_old_ns */
-
 void dom_reconcile_ns(xmlDocPtr doc, xmlNodePtr nodep) /* {{{ */
 {
 	xmlNsPtr nsptr, nsdftptr, curns, prevns = NULL;
@@ -1407,7 +1380,6 @@ void dom_reconcile_ns(xmlDocPtr doc, xmlNodePtr nodep) /* {{{ */
 						} else {
 							prevns->next = nsdftptr;
 						}
-						dom_set_old_ns(doc, curns);
 						curns = prevns;
 					}
 				}

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -108,7 +108,6 @@ void php_dom_throw_error_with_message(int error_code, char *error_message, int s
 void node_list_unlink(xmlNodePtr node);
 int dom_check_qname(char *qname, char **localname, char **prefix, int uri_len, int name_len);
 xmlNsPtr dom_get_ns(xmlNodePtr node, char *uri, int *errorcode, char *prefix);
-void dom_set_old_ns(xmlDoc *doc, xmlNs *ns);
 void dom_reconcile_ns(xmlDocPtr doc, xmlNodePtr nodep);
 xmlNsPtr dom_get_nsdecl(xmlNode *node, xmlChar *localName);
 void dom_normalize (xmlNodePtr nodep);

--- a/ext/dom/tests/bug79700.phpt
+++ b/ext/dom/tests/bug79700.phpt
@@ -1,0 +1,52 @@
+--TEST--
+dom: Can we go without dom_set_old_ns?
+--FILE--
+<?php
+
+$dom = new DOMDocument();
+$dom->appendChild($element = $dom->createElement('xml:xml'));
+$element->setAttribute('xmlns', 'http://www.w3.org/2000/xmlns/');
+$element->setAttribute('xmlns:xml', 'http://www.w3.org/XML/1998/namespace');
+echo $dom->saveXML();
+
+$html = new DOMDocument();
+$element->setAttribute('xmlns', 'http://www.w3.org/2000/xmlns/');
+$element->setAttribute('xmlns:xml', 'http://www.w3.org/XML/1998/namespace');
+$html->appendChild($element = $html->createElement('xml:html'));
+
+echo $html->saveHTML();
+
+$dom->documentElement->appendChild($dom->importNode($element));
+
+echo $dom->saveXML();
+
+// now test performance of 10000 namespaced elements. second run should not take more than 3x (safety margin) as long as first time.
+
+$dom = new DOMDocument();
+$root = $dom->createElementNS('http://www.w3.org/2000/xhtml', 'html');
+$dom->appendChild($root);
+
+$s = microtime(true);
+for ($i = 0; $i < 10000; $i++) {
+    $element = $dom->createElementNS('http://www.w3.org/2000/xhtml', 'p', 'Hello World');
+    $root->appendChild($element);
+}
+$firstRun = microtime(true) - $s;
+
+$s = microtime(true);
+for ($i = 0; $i < 10000; $i++) {
+    $element = $dom->createElementNS('http://www.w3.org/2000/xhtml', 'p', 'Hello World');
+    $root->appendChild($element);
+}
+$secondRun = microtime(true) - $s;
+
+if ($firstRun * 3 < $secondRun) {
+    echo "FAIL; second run took more than 3 times as long as first run. Performance should be linear\n";
+}
+
+--EXPECTF--
+<?xml version="1.0"?>
+<xml:xml xmlns="http://www.w3.org/2000/xmlns/" xmlns:xml="http://www.w3.org/XML/1998/namespace"/>
+<xml:html></xml:html>
+<?xml version="1.0"?>
+<xml:xml xmlns="http://www.w3.org/2000/xmlns/" xmlns:xml="http://www.w3.org/XML/1998/namespace"><xml:html/></xml:xml>


### PR DESCRIPTION
ext/dom was wrongly using xmlDoc->oldNs as a linked list of all namespaces, without deduplicating already existing namespaces in the document. This could lead to the oldNs linked list becoming extremely large and performance degrading exponentially in the number of nodes with namespaces.

The bug https://bugs.php.net/bug.php?id=79700 has a test script showing the performance loss.

libxml2 uses `oldNs` only to store the `xml` namespace property on, which is an implicit namespace that does not need to be declared on a node. It is only ever used when searching for the "xml" prefix or the "http://www.w3.org/XML/1998/namespace" namespace. When its being used, its automatically created by libxml and does not need to be created by ext/dom.

Removing the function `dom_set_old_ns` does not break any tests, including the newly created using the `xml` namespace. Performance of the test script gets each batch of 10000 elements roughly the same append performance.

Merge is suggested for master only, as i am a bit unsure about potential side effects that I can't see with oldNs, even after digging into libxml code for hours, I am not 100% sure about this.

/cc @cmb69 @thomasweinert