### PR TITLE
FR #79344: xmlwriter_write_attribute_ns: $prefix should be nullable

### DIFF
--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -307,7 +307,7 @@ PHP_FUNCTION(xmlwriter_start_attribute_ns)
 	int retval;
 	zval *self;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Osss!", &self, xmlwriter_class_entry_ce,
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os!ss!", &self, xmlwriter_class_entry_ce,
 		&prefix, &prefix_len, &name, &name_len, &uri, &uri_len) == FAILURE) {
 		RETURN_THROWS();
 	}
@@ -365,7 +365,7 @@ PHP_FUNCTION(xmlwriter_write_attribute_ns)
 	int retval;
 	zval *self;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Osss!s", &self, xmlwriter_class_entry_ce,
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os!ss!s", &self, xmlwriter_class_entry_ce,
 		&prefix, &prefix_len, &name, &name_len, &uri, &uri_len, &content, &content_len) == FAILURE) {
 		RETURN_THROWS();
 	}

--- a/ext/xmlwriter/php_xmlwriter.stub.php
+++ b/ext/xmlwriter/php_xmlwriter.stub.php
@@ -20,9 +20,9 @@ function xmlwriter_end_attribute(XMLWriter $xmlwriter): bool {}
 
 function xmlwriter_write_attribute(XMLWriter $xmlwriter, string $name, string $value): bool {}
 
-function xmlwriter_start_attribute_ns(XMLWriter $xmlwriter, string $prefix, string $name, ?string $uri): bool {}
+function xmlwriter_start_attribute_ns(XMLWriter $xmlwriter, ?string $prefix, string $name, ?string $uri): bool {}
 
-function xmlwriter_write_attribute_ns(XMLWriter $xmlwriter, string $prefix, string $name, ?string $uri, string $content): bool {}
+function xmlwriter_write_attribute_ns(XMLWriter $xmlwriter, ?string $prefix, string $name, ?string $uri, string $content): bool {}
 
 function xmlwriter_start_element(XMLWriter $xmlwriter, string $name): bool {}
 
@@ -116,10 +116,10 @@ class XMLWriter
     public function writeAttribute(string $name, string $value): bool {}
 
     /** @alias xmlwriter_start_attribute_ns */
-    public function startAttributeNs(string $prefix, string $name, ?string $uri): bool {}
+    public function startAttributeNs(?string $prefix, string $name, ?string $uri): bool {}
 
     /** @alias xmlwriter_write_attribute_ns */
-    public function writeAttributeNs(string $prefix, string $name, ?string $uri, string $content): bool {}
+    public function writeAttributeNs(?string $prefix, string $name, ?string $uri, string $content): bool {}
 
     /** @alias xmlwriter_start_element */
     public function startElement(string $name): bool {}

--- a/ext/xmlwriter/php_xmlwriter_arginfo.h
+++ b/ext/xmlwriter/php_xmlwriter_arginfo.h
@@ -38,14 +38,14 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_attribute_ns, 0, 4, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
-	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_attribute_ns, 0, 5, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
-	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
@@ -57,12 +57,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_xmlwriter_full_end_element arginfo_xmlwriter_start_comment
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_start_element_ns, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
-	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
-ZEND_END_ARG_INFO()
+#define arginfo_xmlwriter_start_element_ns arginfo_xmlwriter_start_attribute_ns
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xmlwriter_write_element, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, xmlwriter, XMLWriter, 0)
@@ -210,13 +205,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeAttribute, 
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_startAttributeNs, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeAttributeNs, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
@@ -228,11 +223,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_fullEndElement arginfo_class_XMLWriter_openMemory
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_startElementNs, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 1)
-ZEND_END_ARG_INFO()
+#define arginfo_class_XMLWriter_startElementNs arginfo_class_XMLWriter_startAttributeNs
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeElement, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)

--- a/ext/xmlwriter/tests/bug79344.phpt
+++ b/ext/xmlwriter/tests/bug79344.phpt
@@ -1,0 +1,23 @@
+--TEST--
+FR #79344 (xmlwriter_write_attribute_ns: $prefix should be nullable)
+--SKIPIF--
+<?php
+if (!extension_loaded('xmlwriter')) die('skip xmlwriter extension not available');
+?>
+--FILE--
+<?php
+$writer = new XMLWriter;
+$writer->openMemory();
+$writer->setIndent(true);
+$writer->startElement('foo');
+
+$writer->writeAttributeNS(null, 'test1', null, 'test1');
+$writer->startAttributeNS(null, 'test2', null);
+$writer->text('test2');
+$writer->endAttribute();
+
+$writer->endElement();
+echo $writer->outputMemory();
+?>
+--EXPECT--
+<foo test1="test1" test2="test2"/>


### PR DESCRIPTION
The `$prefix` parameter of `xmlwriter_write_element_ns()` and
`xmlwriter_start_element_ns()` is nullable, what allows these functions
to be used instead of their non NS variants.  Consequently, we make the
`$prefix` parameter of `xmlwriter_write_attribute_ns()` and
`xmlwriter_start_attribute_ns()` nullable as well.