### PR TITLE
Fix macro redifinition warnings in debug builds

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -38,7 +38,6 @@
 #ifdef PHP_WIN32
 #include <string.h>
 #include "config.w32.h"
-#define strdup _strdup
 #undef WINDOWS
 #undef strcasecmp
 #undef strncasecmp

--- a/win32/readdir.c
+++ b/win32/readdir.c
@@ -1,10 +1,9 @@
-#define _CRTDBG_MAP_ALLOC
+#include "php.h"
 
 #include <malloc.h>
 #include <string.h>
 #include <errno.h>
 
-#include "php.h"
 #include "readdir.h"
 #include "win32/ioutil.h"
 

--- a/win32/readdir.c
+++ b/win32/readdir.c
@@ -1,3 +1,5 @@
+#define _CRTDBG_MAP_ALLOC
+
 #include <malloc.h>
 #include <string.h>
 #include <errno.h>


### PR DESCRIPTION
MSVC considers these warnings[1] to be severe (level 1), so we better
fix the respective code.

[1] <https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4005?view=vs-2019>