### PR TITLE
Use ZEND_UNREACHABLE() instead of ZEND_ASSERT(0)

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -529,7 +529,7 @@ static void zend_get_windows_version_info(OSVERSIONINFOEX *osvi) /* {{{ */
 	ZeroMemory(osvi, sizeof(OSVERSIONINFOEX));
 	osvi->dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
 	if(!GetVersionEx((OSVERSIONINFO *) osvi)) {
-		ZEND_ASSERT(0); /* Should not happen as sizeof is used. */
+		ZEND_UNREACHABLE(); /* Should not happen as sizeof is used. */
 	}
 }
 /* }}} */
@@ -1718,7 +1718,7 @@ ZEND_API void *zend_map_ptr_new(void)
 	if (CG(map_ptr_last) >= CG(map_ptr_size)) {
 #if ZEND_MAP_PTR_KIND == ZEND_MAP_PTR_KIND_PTR
 		// TODO: error ???
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 #elif ZEND_MAP_PTR_KIND == ZEND_MAP_PTR_KIND_PTR_OR_OFFSET
 		/* Grow map_ptr table */
 		CG(map_ptr_size) = ZEND_MM_ALIGNED_SIZE_EX(CG(map_ptr_last) + 1, 4096);
@@ -1747,7 +1747,7 @@ ZEND_API void zend_map_ptr_extend(size_t last)
 		if (last >= CG(map_ptr_size)) {
 #if ZEND_MAP_PTR_KIND == ZEND_MAP_PTR_KIND_PTR
 			/* This may never happen */
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 #elif ZEND_MAP_PTR_KIND == ZEND_MAP_PTR_KIND_PTR_OR_OFFSET
 			/* Grow map_ptr table */
 			CG(map_ptr_size) = ZEND_MM_ALIGNED_SIZE_EX(last, 4096);

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1465,7 +1465,7 @@ tail_call:
 			break;
 		case ZEND_AST_ZNODE:
 			/* This AST kind is only used for temporary nodes during compilation */
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 			break;
 
 		/* declaration nodes */

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1903,7 +1903,7 @@ zend_ast *zend_negate_num_string(zend_ast *ast) /* {{{ */
 		memmove(Z_STRVAL_P(zv) + 1, Z_STRVAL_P(zv), orig_len + 1);
 		Z_STRVAL_P(zv)[0] = '-';
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 	return ast;
 }
@@ -2258,7 +2258,7 @@ static void zend_compile_memoized_expr(znode *result, zend_ast *expr) /* {{{ */
 			Z_TRY_ADDREF(result->u.constant);
 		}
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 }
 /* }}} */

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -68,7 +68,7 @@ static void _zend_is_inconsistent(const HashTable *ht, const char *file, int lin
 			zend_output_debug_string(1, "%s(%d) : ht=%p is inconsistent", file, line, ht);
 			break;
 	}
-	ZEND_ASSERT(0);
+	ZEND_UNREACHABLE();
 }
 #define IS_CONSISTENT(a) _zend_is_inconsistent(a, __FILE__, __LINE__);
 #define SET_INCONSISTENT(n) do { \

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1280,7 +1280,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 				zend_class_init_statics(parent_ce);
 			}
 			if (UNEXPECTED(zend_update_class_constants(parent_ce) != SUCCESS)) {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 			}
 			src = CE_STATIC_MEMBERS(parent_ce) + parent_ce->default_static_members_count;
 			do {

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1757,7 +1757,7 @@ ZEND_API HashTable *zend_std_get_properties_for(zend_object *obj, zend_prop_purp
 			}
 			return ht;
 		default:
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 			return NULL;
 	}
 }

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -631,7 +631,7 @@ static void emit_live_range(
 		case ZEND_ADD_ARRAY_ELEMENT:
 		case ZEND_ADD_ARRAY_UNPACK:
 		case ZEND_ROPE_ADD:
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 			return;
 		/* Result is boolean, it doesn't have to be destroyed. */
 		case ZEND_JMPZ_EX:
@@ -1131,7 +1131,7 @@ ZEND_API binary_op_type get_binary_op(int opcode)
 		case ZEND_BOOL_XOR:
 			return (binary_op_type) boolean_xor_function;
 		default:
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 			return (binary_op_type) NULL;
 	}
 }

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2089,7 +2089,7 @@ ZEND_API int ZEND_FASTCALL zend_compare(zval *op1, zval *op2) /* {{{ */
 				} else if (Z_TYPE_P(op2)==IS_ARRAY) {
 					return -1;
 				} else {
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 					zend_throw_error(NULL, "Unsupported operand types");
 					return 1;
 				}

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -107,13 +107,15 @@
 # define ZEND_ASSERT(c) ZEND_ASSUME(c)
 #endif
 
+#if ZEND_DEBUG
+# define ZEND_UNREACHABLE() do {ZEND_ASSERT(0); ZEND_ASSUME(0);} while (0)
+#else
+# define ZEND_UNREACHABLE() ZEND_ASSUME(0)
+#endif
+
 /* Only use this macro if you know for sure that all of the switches values
    are covered by its case statements */
-#if ZEND_DEBUG
-# define EMPTY_SWITCH_DEFAULT_CASE() default: ZEND_ASSERT(0); break;
-#else
-# define EMPTY_SWITCH_DEFAULT_CASE() default: ZEND_ASSUME(0); break;
-#endif
+#define EMPTY_SWITCH_DEFAULT_CASE() default: ZEND_UNREACHABLE(); break;
 
 #if defined(__GNUC__) && __GNUC__ >= 4
 # define ZEND_IGNORE_VALUE(x) (({ __typeof__ (x) __x = (x); (void) __x; }))

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -1504,7 +1504,7 @@ static int zend_ffi_ctype_name(zend_ffi_ctype_name_buf *buf, const zend_ffi_type
 				}
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 		if (name) {
 			break;
@@ -1992,7 +1992,7 @@ static HashTable *zend_ffi_cdata_get_debug_info(zend_object *obj, int *is_temp) 
 			return ht;
 			break;
 		default:
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 			break;
 	}
 	return NULL;
@@ -5364,7 +5364,7 @@ void zend_ffi_resolve_const(const char *name, size_t name_len, zend_ffi_val *val
 					val->kind = ZEND_FFI_VAL_UINT64;
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 			return;
 		}
@@ -6185,7 +6185,7 @@ void zend_ffi_declare_tag(const char *name, size_t name_len, zend_ffi_dcl *dcl, 
 				return;
 			}
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 			return;
 		}
 		dcl->type = type;
@@ -6212,7 +6212,7 @@ void zend_ffi_declare_tag(const char *name, size_t name_len, zend_ffi_dcl *dcl, 
 			type = ZEND_FFI_TYPE(dcl->type);
 			type->enumeration.tag_name = zend_string_copy(tag_name);
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 		tag->type = ZEND_FFI_TYPE_MAKE_OWNED(dcl->type);
 		dcl->type = ZEND_FFI_TYPE(dcl->type);
@@ -6511,7 +6511,7 @@ static int zend_ffi_nested_type(zend_ffi_type *type, zend_ffi_type *nested_type)
 			}
 			break;
 		default:
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 	}
 }
 /* }}} */

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -1872,7 +1872,7 @@ static void _php_image_output(INTERNAL_FUNCTION_PARAMETERS, int image_type, char
 				(*func_p)(im, fp, q, t);
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 		fflush(fp);
 		fclose(fp);
@@ -1899,7 +1899,7 @@ static void _php_image_output(INTERNAL_FUNCTION_PARAMETERS, int image_type, char
 				(*func_p)(im, tmp, q, t);
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 
 		fseek(tmp, 0, SEEK_SET);

--- a/ext/opcache/Optimizer/optimize_func_calls.c
+++ b/ext/opcache/Optimizer/optimize_func_calls.c
@@ -214,7 +214,7 @@ void zend_optimize_func_calls(zend_op_array *op_array, zend_optimizer_ctx *ctx)
 							|| fcall->opcode == ZEND_NEW) {
 						/* We don't have specialized opcodes for this, do nothing */
 					} else {
-						ZEND_ASSERT(0);
+						ZEND_UNREACHABLE();
 					}
 
 					if ((ZEND_OPTIMIZER_PASS_16 & ctx->optimization_level)

--- a/ext/opcache/Optimizer/sccp.c
+++ b/ext/opcache/Optimizer/sccp.c
@@ -267,7 +267,7 @@ static zend_bool can_replace_op1(
 				(opline - 1)->opcode != ZEND_ASSIGN_STATIC_PROP_REF;
 		default:
 			if (ssa_op->op1_def != -1) {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 				return 0;
 			}
 	}

--- a/ext/opcache/Optimizer/scdf.h
+++ b/ext/opcache/Optimizer/scdf.h
@@ -86,7 +86,7 @@ static inline uint32_t scdf_edge(zend_cfg *cfg, int from, int to) {
 			return edge;
 		}
 	}
-	ZEND_ASSERT(0);
+	ZEND_UNREACHABLE();
 }
 
 static inline zend_bool scdf_is_edge_feasible(scdf_ctx *scdf, int from, int to) {

--- a/ext/opcache/Optimizer/zend_inference.c
+++ b/ext/opcache/Optimizer/zend_inference.c
@@ -3510,7 +3510,7 @@ static zend_always_inline int _zend_update_type_info(
 		case ZEND_CATCH:
 		case ZEND_INCLUDE_OR_EVAL:
 			/* Forbidden opcodes */
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 			break;
 		default:
 unknown_opcode:

--- a/ext/opcache/Optimizer/zend_optimizer.c
+++ b/ext/opcache/Optimizer/zend_optimizer.c
@@ -615,7 +615,7 @@ int zend_optimizer_replace_by_const(zend_op_array *op_array,
 								ZEND_ASSERT(opline->extended_value == ZEND_FREE_ON_RETURN);
 								MAKE_NOP(opline);
 							} else {
-								ZEND_ASSERT(0);
+								ZEND_UNREACHABLE();
 							}
 						}
 						opline++;

--- a/ext/opcache/Optimizer/zend_ssa.c
+++ b/ext/opcache/Optimizer/zend_ssa.c
@@ -1189,7 +1189,7 @@ int zend_ssa_unlink_use_chain(zend_ssa *ssa, int op, int var) /* {{{ */
 			}
 		}
 		/* something wrong */
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 		return 0;
 	}
 }
@@ -1238,7 +1238,7 @@ static inline zend_ssa_phi **zend_ssa_next_use_phi_ptr(zend_ssa *ssa, int var, z
 			}
 		}
 	}
-	ZEND_ASSERT(0);
+	ZEND_UNREACHABLE();
 	return NULL;
 }
 /* }}} */

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3373,7 +3373,7 @@ ZEND_EXT_API int zend_jit_op_array(zend_op_array *op_array, zend_script *script)
 			return SUCCESS;
 		}
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 }
 
@@ -3485,7 +3485,7 @@ ZEND_EXT_API int zend_jit_script(zend_script *script)
 			ZEND_SET_FUNC_INFO(call_graph.op_arrays[i], NULL);
 		}
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 
 	zend_arena_release(&CG(arena), checkpoint);

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -451,10 +451,10 @@ static zend_always_inline const zend_op* zend_jit_trace_get_exit_opline(zend_jit
 			*exit_if_true = opline->opcode == ZEND_JMPZ;
 			return opline + 1;
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	} else  {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 	*exit_if_true = 0;
 	return NULL;
@@ -476,7 +476,7 @@ static zend_always_inline zend_bool zend_jit_may_be_polymorphic_call(const zend_
 	} else if (opline->opcode == ZEND_NEW) {
 		return (opline->op1_type != IS_CONST);
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 		return 0;
 	}
 }

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -41,7 +41,7 @@ static zend_always_inline const char *zend_jit_trace_star_desc(uint8_t trace_fla
 	} else if (trace_flags & ZEND_JIT_TRACE_START_RETURN) {
 		return "return";
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 		return "???";
 	}
 }
@@ -212,7 +212,7 @@ static uint32_t zend_jit_find_trace(const void *addr)
 			return i;
 		}
 	}
-	ZEND_ASSERT(0);
+	ZEND_UNREACHABLE();
 	return 0;
 }
 
@@ -2711,7 +2711,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 			} else if (i < parent_vars_count
 			 && STACK_TYPE(parent_stack, i) != IS_UNKNOWN) {
 				/* This must be already handled by trace type inference */
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 				SET_STACK_TYPE(stack, i, STACK_TYPE(parent_stack, i));
 			} else if ((info & MAY_BE_GUARD) != 0
 			 && trace_buffer->stop == ZEND_JIT_TRACE_STOP_LOOP
@@ -2729,7 +2729,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 			 && op_array->function_name
 			 && i >= op_array->num_args) {
 				/* This must be already handled by trace type inference */
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 				SET_STACK_TYPE(stack, i, IS_UNDEF);
 			} else {
 				SET_STACK_TYPE(stack, i, IS_UNKNOWN);
@@ -3557,7 +3557,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 								smart_branch_opcode = opline->opcode;
 								exit_opline = OP_JMP_ADDR(opline, opline->op2);
 							} else {
-								ZEND_ASSERT(0);
+								ZEND_UNREACHABLE();
 							}
 							if (ra) {
 								zend_jit_trace_clenup_stack(stack, opline, ssa_op, ssa, ra);
@@ -3568,7 +3568,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 								goto jit_failure;
 							}
 						} else  {
-							ZEND_ASSERT(0);
+							ZEND_UNREACHABLE();
 						}
 						if (opline->result_type == IS_UNDEF) {
 							res_addr = 0;
@@ -4202,7 +4202,7 @@ done:
 				frame->call = call->prev;
 			}
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	}
 
@@ -5246,7 +5246,7 @@ int ZEND_FASTCALL zend_jit_trace_exit(uint32_t exit_num, zend_jit_registers_buf 
 				} else if (STACK_REG(stack, i) == ZREG_LONG_MAX) {
 					val = ZEND_LONG_MAX;
 				} else {
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 				}
 				ZVAL_LONG(EX_VAR_NUM(i), val);
 			} else if (STACK_TYPE(stack, i) == IS_DOUBLE) {
@@ -5259,11 +5259,11 @@ int ZEND_FASTCALL zend_jit_trace_exit(uint32_t exit_num, zend_jit_registers_buf 
 				} else if (STACK_REG(stack, i) == ZREG_LONG_MAX_PLUS_1) {
 					val = (double)ZEND_LONG_MAX + 1.0;
 				} else {
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 				}
 				ZVAL_DOUBLE(EX_VAR_NUM(i), val);
 			} else {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 			}
 		}
 	}

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -454,7 +454,7 @@ static void* dasm_labels[zend_lb_MAX];
 ||	} else if (Z_MODE(addr) == IS_MEM_ZVAL) {
 |		LOAD_BASE_ADDR reg, Z_REG(addr), Z_OFFSET(addr)
 ||	} else {
-||		ZEND_ASSERT(0);
+||		ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -464,7 +464,7 @@ static void* dasm_labels[zend_lb_MAX];
 ||	} else if (Z_MODE(addr) == IS_MEM_ZVAL) {
 |		PUSH_BASE_ADDR Z_REG(addr), Z_OFFSET(addr), tmp_reg
 ||	} else {
-||		ZEND_ASSERT(0);
+||		ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -548,7 +548,7 @@ static void* dasm_labels[zend_lb_MAX];
 ||	} else if (Z_MODE(addr) == IS_REG) {
 |		sse_ins xmm(reg-ZREG_XMM0), xmm(Z_REG(addr)-ZREG_XMM0)
 ||	} else {
-||		ZEND_ASSERT(0);
+||		ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -569,7 +569,7 @@ static void* dasm_labels[zend_lb_MAX];
 ||	} else if (Z_MODE(addr) == IS_REG) {
 |		SSE_AVX_INS sse_ins, avx_ins, xmm(reg-ZREG_XMM0), xmm(Z_REG(addr)-ZREG_XMM0)
 ||	} else {
-||		ZEND_ASSERT(0);
+||		ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -614,7 +614,7 @@ static void* dasm_labels[zend_lb_MAX];
 |			cvtsi2sd xmm(reg-ZREG_XMM0), Ra(Z_REG(addr))
 ||		}
 ||	} else {
-||		ZEND_ASSERT(0);
+||		ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -636,7 +636,7 @@ static void* dasm_labels[zend_lb_MAX];
 ||		} else if (Z_MODE(addr) == IS_REG) {
 |			SSE_AVX_INS movsd, vmovaps, xmm(reg-ZREG_XMM0), xmm(Z_REG(addr)-ZREG_XMM0)
 ||		} else {
-||			ZEND_ASSERT(0);
+||			ZEND_UNREACHABLE();
 ||		}
 ||	}
 |.endmacro
@@ -694,7 +694,7 @@ static void* dasm_labels[zend_lb_MAX];
 ||	} else if (Z_MODE(addr) == IS_REG) {
 |		avx_ins xmm(reg-ZREG_XMM0), xmm(op1_reg-ZREG_XMM0), xmm(Z_REG(addr)-ZREG_XMM0)
 ||	} else {
-||		ZEND_ASSERT(0);
+||		ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -754,7 +754,7 @@ static void* dasm_labels[zend_lb_MAX];
 ||	} else if (Z_MODE(addr) == IS_REG) {
 |		long_ins Ra(reg), Ra(Z_REG(addr))
 ||	} else {
-||		ZEND_ASSERT(0);
+||		ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -782,7 +782,7 @@ static void* dasm_labels[zend_lb_MAX];
 |			long_ins Ra(Z_REG(op1_addr)), lval
 |		.endif
 ||	} else {
-||		ZEND_ASSERT(0);
+||		ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -808,7 +808,7 @@ static void* dasm_labels[zend_lb_MAX];
 |			mov Ra(reg), Ra(Z_REG(addr))
 ||		}
 ||	} else {
-||		ZEND_ASSERT(0);
+||		ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -833,7 +833,7 @@ static void* dasm_labels[zend_lb_MAX];
 |			LONG_OP xor, reg, addr
 ||			break;
 ||		default:
-||			ZEND_ASSERT(0);
+||			ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -858,7 +858,7 @@ static void* dasm_labels[zend_lb_MAX];
 |			xor dst_reg, src_reg
 ||			break;
 ||		default:
-||			ZEND_ASSERT(0);
+||			ZEND_UNREACHABLE();
 ||	}
 |.endmacro
 
@@ -2546,7 +2546,7 @@ static int zend_jit_context_threaded_call_stub(dasm_State **Dst)
 		|	add r4, SPAD // stack alignment
 		|	jmp aword [IP]
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 		// TODO: context threading can't work without GLOBAL REGS because we have to change
 		//       the value of execute_data in execute_ex()
 		|	mov FCARG1a, FP
@@ -3411,7 +3411,7 @@ static int zend_jit_spill_store(dasm_State **Dst, zend_jit_addr src, zend_jit_ad
 			|	SET_ZVAL_TYPE_INFO dst, IS_DOUBLE
 		}
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 	return 1;
 }
@@ -3426,7 +3426,7 @@ static int zend_jit_load_reg(dasm_State **Dst, zend_jit_addr src, zend_jit_addr 
 	} else if ((info & MAY_BE_ANY) == MAY_BE_DOUBLE) {
 		|	SSE_GET_ZVAL_DVAL Z_REG(dst), src
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 	return 1;
 }
@@ -3483,7 +3483,7 @@ static int zend_jit_update_regs(dasm_State **Dst, zend_jit_addr src, zend_jit_ad
 				} else if ((info & MAY_BE_ANY) == MAY_BE_DOUBLE) {
 					|	SSE_AVX_INS movsd, vmovaps, xmm(Z_REG(dst)-ZREG_XMM0), xmm(Z_REG(src)-ZREG_XMM0)
 				} else {
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 				}
 			} else if (Z_MODE(dst) == IS_MEM_ZVAL) {
 				if (!Z_LOAD(src) && !Z_STORE(src)) {
@@ -3492,7 +3492,7 @@ static int zend_jit_update_regs(dasm_State **Dst, zend_jit_addr src, zend_jit_ad
 					}
 				}
 			} else {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 			}
 		} else if (Z_MODE(src) == IS_MEM_ZVAL) {
 			if (Z_MODE(dst) == IS_REG) {
@@ -3500,10 +3500,10 @@ static int zend_jit_update_regs(dasm_State **Dst, zend_jit_addr src, zend_jit_ad
 					return 0;
 				}
 			} else {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 			}
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	}
 	return 1;
@@ -3548,7 +3548,7 @@ static int zend_jit_store_const(dasm_State **Dst, int var, zend_reg reg)
 		|.endif
 		|	SET_ZVAL_TYPE_INFO dst, IS_DOUBLE
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 	return 1;
 }
@@ -3702,7 +3702,7 @@ static int zend_jit_inc_dec(dasm_State **Dst, const zend_op *opline, const zend_
 				} else if (opline->opcode == ZEND_POST_DEC) {
 					|	EXT_CALL zend_jit_post_dec_typed_ref, r0
 				} else {
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 				}
 				|.if not(X64)
 					|	add r4, 12
@@ -4279,7 +4279,7 @@ static int zend_jit_math_helper(dasm_State    **Dst,
 		} else if (opcode == ZEND_DIV) {
 			|	EXT_CALL div_function, r0
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 		|.if not(X64)
 		|	add r4, 12
@@ -4592,7 +4592,7 @@ static int zend_jit_long_math_helper(dasm_State    **Dst,
 		} else if (opcode == ZEND_MOD) {
 			|	EXT_CALL mod_function, r0
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 		|.if not(X64)
 		|	add r4, 12
@@ -4903,7 +4903,7 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 						|	jmp >9
 						break;
 					default:
-						ZEND_ASSERT(0);
+						ZEND_UNREACHABLE();
 				}
 				|.code
 				break;
@@ -4944,7 +4944,7 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 				}
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 
 		if (type != BP_JIT_IS && (op2_info & MAY_BE_STRING)) {
@@ -5028,7 +5028,7 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 						|	jmp >9
 						break;
 					default:
-						ZEND_ASSERT(0);
+						ZEND_UNREACHABLE();
 				}
 				|.code
 				break;
@@ -5048,7 +5048,7 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 				}
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 	}
 
@@ -5115,7 +5115,7 @@ static int zend_jit_fetch_dimension_address_inner(dasm_State **Dst, const zend_o
 				|	jmp >9
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 		if (op2_info & (MAY_BE_LONG|MAY_BE_STRING)) {
 			|.code
@@ -5298,7 +5298,7 @@ static int zend_jit_assign_to_variable(dasm_State    **Dst,
 		} else if (val_type == IS_CV) {
 			|	EXT_CALL zend_jit_assign_cv_to_typed_ref, r0
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 		|	jmp >8
 		|.code
@@ -5753,7 +5753,7 @@ static int zend_jit_assign_dim_op(dasm_State **Dst, const zend_op *opline, const
 				}
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 	}
 
@@ -5867,7 +5867,7 @@ static int zend_jit_assign_op(dasm_State **Dst, const zend_op *opline, const zen
 			result = zend_jit_concat_helper(Dst, opline, op_array, opline->op1_type, opline->op1, op1_addr, op1_info, opline->op2_type, opline->op2, op2_addr, op2_info, op1_addr, op1_def_info, may_throw);
 			break;
 		default:
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 	}
 	|9:
 	return result;
@@ -5933,7 +5933,7 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 			|	movzx eax, al
 			|	lea eax, [eax + 2]
@@ -5996,7 +5996,7 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 		} else if (smart_branch_opcode == ZEND_JMPNZ ||
 		           smart_branch_opcode == ZEND_JMPNZ_EX) {
@@ -6055,7 +6055,7 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 		} else if (smart_branch_opcode == ZEND_JMPZNZ) {
 			switch (opline->opcode) {
@@ -6083,11 +6083,11 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 			| jmp => target_label2
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	} else {
 		switch (opline->opcode) {
@@ -6115,7 +6115,7 @@ static int zend_jit_cmp_long_long(dasm_State **Dst, const zend_op *opline, zend_
 				}
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 		|	movzx eax, al
 		|	add eax, 2
@@ -6195,7 +6195,7 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 		} else if (smart_branch_opcode == ZEND_JMPNZ) {
 			switch (opline->opcode) {
@@ -6264,7 +6264,7 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 		} else if (smart_branch_opcode == ZEND_JMPZNZ) {
 			switch (opline->opcode) {
@@ -6296,7 +6296,7 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 			| jmp => target_label2
 		} else if (smart_branch_opcode == ZEND_JMPZ_EX) {
@@ -6342,7 +6342,7 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 		} else if (smart_branch_opcode == ZEND_JMPNZ_EX) {
 			switch (opline->opcode) {
@@ -6393,10 +6393,10 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	} else {
 		switch (opline->opcode) {
@@ -6448,7 +6448,7 @@ static int zend_jit_cmp_double_common(dasm_State **Dst, const zend_op *opline, z
 				}
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 		|	SET_ZVAL_TYPE_INFO res_addr, eax
 	}
@@ -6516,7 +6516,7 @@ static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_a
 					|	setle al
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 			|	movzx eax, al
 			|	lea eax, [eax + 2]
@@ -6555,7 +6555,7 @@ static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_a
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 		} else if (smart_branch_opcode == ZEND_JMPNZ ||
 		           smart_branch_opcode == ZEND_JMPNZ_EX) {
@@ -6590,7 +6590,7 @@ static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_a
 					}
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 		} else if (smart_branch_opcode == ZEND_JMPZNZ) {
 			switch (opline->opcode) {
@@ -6608,11 +6608,11 @@ static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_a
 					| jg => target_label
 					break;
 				default:
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 			}
 			| jmp => target_label2
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	} else {
 		switch (opline->opcode) {
@@ -6630,7 +6630,7 @@ static int zend_jit_cmp_slow(dasm_State **Dst, const zend_op *opline, zend_jit_a
 				|	setle al
 				break;
 			default:
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 		}
 		|	movzx eax, al
 		|	add eax, 2
@@ -6880,7 +6880,7 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 				not_identical_label = target_label;
 				identical_label = target_label2;
 			} else {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 			}
 		} else if (opline->opcode == ZEND_IS_NOT_IDENTICAL) {
 			if (smart_branch_opcode == ZEND_JMPZ) {
@@ -6891,10 +6891,10 @@ static int zend_jit_identical(dasm_State **Dst, const zend_op *opline, const zen
 				identical_label = target_label;
 				not_identical_label = target_label2;
 			} else {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 			}
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	}
 
@@ -7259,7 +7259,7 @@ static int zend_jit_bool_jmpznz(dasm_State **Dst, const zend_op *opline, const z
 		set_bool = 1;
 		true_label = target_label;
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 
 	if (Z_MODE(op1_addr) == IS_CONST_ZVAL) {
@@ -8034,7 +8034,7 @@ static int zend_jit_init_fcall_guard(dasm_State **Dst, const zend_op *opline, co
 			return 0;
 		}
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 		return 0;
 	}
 
@@ -8159,7 +8159,7 @@ static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t
 				|	LOAD_ADDR FCARG1a, zv;
 				|	EXT_CALL zend_jit_find_ns_func_helper, r0
 			} else {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 			}
 			|	// CACHE_PTR(opline->result.num, fbc);
 			|	mov r1, EX->run_time_cache
@@ -8310,7 +8310,7 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		}
 #endif
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 
 	if (trace && !func) {
@@ -8941,7 +8941,7 @@ static int zend_jit_send_ref(dasm_State **Dst, const zend_op *opline, const zend
 			op1_info |= MAY_BE_NULL;
 		}
 	} else {
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 	}
 
 	if (op1_info & (MAY_BE_UNDEF|MAY_BE_ANY|MAY_BE_REF)) {
@@ -9281,7 +9281,7 @@ static int zend_jit_smart_true(dasm_State **Dst, const zend_op *opline, int jmp,
 		} else if (smart_branch_opcode == ZEND_JMPZNZ) {
 			|	jmp =>target_label2
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	} else {
 		zend_jit_addr res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FP, opline->result.var);
@@ -9307,7 +9307,7 @@ static int zend_jit_smart_false(dasm_State **Dst, const zend_op *opline, int jmp
 		} else if (smart_branch_opcode == ZEND_JMPZNZ) {
 			|	jmp =>target_label
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	} else {
 		zend_jit_addr res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FP, opline->result.var);
@@ -9337,7 +9337,7 @@ static int zend_jit_defined(dasm_State **Dst, const zend_op *opline, const zend_
 			undefined_label = target_label;
 			defined_label = target_label2;
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	}
 
@@ -9566,7 +9566,7 @@ static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const ze
 						|	je =>target_label
 						|	jmp =>target_label2
 					} else {
-						ZEND_ASSERT(0);
+						ZEND_UNREACHABLE();
 					}
 				} else {
 					zend_jit_addr res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FP, opline->result.var);
@@ -9641,7 +9641,7 @@ static int zend_jit_type_check(dasm_State **Dst, const zend_op *opline, const ze
 						|	jne =>target_label
 						|	jmp =>target_label2
 					} else {
-						ZEND_ASSERT(0);
+						ZEND_UNREACHABLE();
 					}
 				} else {
 					zend_jit_addr res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FP, opline->result.var);
@@ -9856,7 +9856,7 @@ static int zend_jit_leave_func(dasm_State **Dst, const zend_op *opline, const ze
 #endif
 	} else {
 #ifdef CONTEXT_THREADED_JIT
-		ZEND_ASSERT(0);
+		ZEND_UNREACHABLE();
 		// TODO: context threading can't work without GLOBAL REGS because we have to change
 		//       the value of execute_data in execute_ex()
 		|	mov FCARG1a, FP
@@ -10346,7 +10346,7 @@ static int zend_jit_isset_isempty_dim(dasm_State **Dst, const zend_op *opline, c
 			} else if (smart_branch_opcode == ZEND_JMPZNZ) {
 				|	jmp =>target_label2
 			} else {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 			}
 		} else {
 			|	SET_ZVAL_TYPE_INFO res_addr, IS_TRUE
@@ -10377,7 +10377,7 @@ static int zend_jit_isset_isempty_dim(dasm_State **Dst, const zend_op *opline, c
 			} else if (smart_branch_opcode == ZEND_JMPZNZ) {
 				|	jmp =>target_label
 			} else {
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 			}
 		} else {
 			|	SET_ZVAL_TYPE_INFO res_addr, IS_FALSE
@@ -11143,7 +11143,7 @@ static int zend_jit_switch(dasm_State **Dst, const zend_op *opline, const zend_o
 				|	jmp =>b
 			}
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	} else {
 		zend_ssa_op *ssa_op = &ssa->ops[opline - op_array->opcodes];
@@ -11293,7 +11293,7 @@ static int zend_jit_switch(dasm_State **Dst, const zend_op *opline, const zend_o
 				|.code
 			}
 		} else {
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 		}
 	}
 	return 1;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -283,7 +283,7 @@ static void bin_to_readable(unsigned char *in, size_t inlen, char *out, size_t o
 				have += 8;
 			} else {
 				/* Should never happen. Input must be large enough. */
-				ZEND_ASSERT(0);
+				ZEND_UNREACHABLE();
 				break;
 			}
 		}

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -376,7 +376,7 @@ static zend_object *spl_filesystem_object_clone(zend_object *old_object)
 			intern->u.dir.index = index;
 			break;
 		case SPL_FS_FILE:
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 	}
 
 	intern->file_class = source->file_class;

--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -160,7 +160,7 @@ static void spl_pqueue_extract_helper(zval *result, spl_pqueue_elem *elem, int f
 		return;
 	}
 
-	ZEND_ASSERT(0);
+	ZEND_UNREACHABLE();
 }
 /* }}} */
 

--- a/sapi/fpm/fpm/fpm_php_trace.c
+++ b/sapi/fpm/fpm/fpm_php_trace.c
@@ -100,7 +100,7 @@ static int fpm_php_trace_dump(struct fpm_child_s *child, FILE *slowlog) /* {{{ *
 				} else if (ZEND_CALL_KIND_EX(*call_info) == ZEND_CALL_NESTED_CODE) {
 					memcpy(buf, "[INCLUDE_OR_EVAL]", sizeof("[INCLUDE_OR_EVAL]"));
 				} else {
-					ZEND_ASSERT(0);
+					ZEND_UNREACHABLE();
 				}
 			} else {
 				if (0 > fpm_trace_get_strz(buf, buf_size, function_name + offsetof(zend_string, val))) {

--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -142,7 +142,7 @@ zend_bool phpdbg_check_watch_diff(phpdbg_watchtype type, void *oldPtr, void *new
 		case WATCH_ON_STR:
 			return memcmp(oldPtr, newPtr, *(size_t *) oldPtr + XtOffsetOf(zend_string, val) - XtOffsetOf(zend_string, len)) != 0;
 		case WATCH_ON_HASHDATA:
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 	}
 	return 0;
 }
@@ -210,7 +210,7 @@ void phpdbg_print_watch_diff(phpdbg_watchtype type, zend_string *name, void *old
 			break;
 
 		case WATCH_ON_HASHDATA:
-			ZEND_ASSERT(0);
+			ZEND_UNREACHABLE();
 	}
 
 	phpdbg_xml("</watchdata>");


### PR DESCRIPTION
Instead of marking unreachable code with `ZEND_ASSERT(0)`, we introduce
`ZEND_UNREACHABLE()`, so that MSVC which does not consider `assert(0)`
to mark unreachable code does no longer trigger C4715[1] warnings in
debug builds.  This may be useful for other compilers as well.

[1] <https://docs.microsoft.com/de-de/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4715?view=vs-2019>