### PR TITLE
Haiku build fix proposal.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -601,6 +601,9 @@ AX_FUNC_WHICH_GETHOSTBYNAME_R
 dnl Some systems (like OpenSolaris) do not have nanosleep in libc.
 PHP_CHECK_FUNC_LIB(nanosleep, rt)
 
+dnl Haiku does not have network api in libc.
+PHP_CHECK_FUNC_LIB(setsockopt, network)
+
 dnl Check for getaddrinfo, should be a better way, but... Also check for working
 dnl getaddrinfo.
 AC_CACHE_CHECK([for getaddrinfo], ac_cv_func_getaddrinfo,

--- a/ext/opcache/jit/zend_jit_perf_dump.c
+++ b/ext/opcache/jit/zend_jit_perf_dump.c
@@ -22,9 +22,10 @@
 #include <unistd.h>
 #include <time.h>
 #include <sys/mman.h>
-#include <sys/syscall.h>
 
-#if defined(__darwin__)
+#if defined(__linux__)
+#include <sys/syscall.h>
+#elif defined(__darwin__)
 # include <pthread.h>
 #elif defined(__FreeBSD__)
 # include <sys/thr.h>

--- a/ext/standard/microtime.c
+++ b/ext/standard/microtime.c
@@ -128,7 +128,7 @@ PHP_FUNCTION(getrusage)
 #ifdef PHP_WIN32 /* Windows only implements a limited amount of fields from the rusage struct */
 	PHP_RUSAGE_PARA(ru_majflt);
 	PHP_RUSAGE_PARA(ru_maxrss);
-#elif !defined(_OSD_POSIX)
+#elif !defined(_OSD_POSIX) && !defined(__HAIKU__)
 	PHP_RUSAGE_PARA(ru_oublock);
 	PHP_RUSAGE_PARA(ru_inblock);
 	PHP_RUSAGE_PARA(ru_msgsnd);

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1683,6 +1683,9 @@ phpdbg_main:
 			}
 
 #ifndef _WIN32
+# ifndef SIGIO
+#  define SIGIO SIGPOLL
+# endif
 			zend_sigaction(SIGIO, &sigio_struct, NULL);
 #endif
 


### PR DESCRIPTION
getrusage supports only two fields. The network api sits in the network lib.