### PR TITLE
Update azure pipelines to Ubuntu 20.04

### DIFF
--- a/azure/job.yml
+++ b/azure/job.yml
@@ -8,7 +8,7 @@ jobs:
   - job: ${{ parameters.configurationName }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     steps:
     - template: apt.yml
     - template: configure.yml


### PR DESCRIPTION
I fixed the local failures, let's see if it works on Azure... It was recently added as a preview: https://docs.microsoft.com/en-us/azure/devops/release-notes/2020/pipelines/sprint-170-update#ubuntu-2004-in-preview-for-azure-pipelines-hosted-pools