### PR TITLE
Allow casting CurlHandle to int

### DIFF
--- a/ext/curl/tests/curl_int_cast.phpt
+++ b/ext/curl/tests/curl_int_cast.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Casting CurlHandle to int returns object ID
+--FILE--
+<?php
+
+$handle1 = curl_init();
+var_dump((int) $handle1);
+$handle2 = curl_init();
+var_dump((int) $handle2);
+
+// NB: Unlike resource IDs, object IDs are reused.
+unset($handle2);
+$handle3 = curl_init();
+var_dump((int) $handle3);
+
+?>
+--EXPECT--
+int(1)
+int(2)
+int(2)


### PR DESCRIPTION
It's common to cast curl resources to integer to get the resource ID. This allows casting the new CurlHandle object to int as well, returning the object ID. This seems like a simple way to improve compatibility with PHP 7.

Something to keep in mind is that unlike resource IDs, object IDs are reused.

I'm only doing this for CurlHandle, not CurlMultiHandle or CurlShareHandle. Do those need this as well?

cc @kocsismate @nicolas-grekas 