### PR TITLE
Simplify `_crypt_extended_init_r`, and fix redundant initialization on Win32/Solaris

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -643,13 +643,6 @@ if test "$ac_cv_func_getaddrinfo" = yes; then
   AC_DEFINE(HAVE_GETADDRINFO,1,[Define if you have the getaddrinfo function])
 fi
 
-dnl Check for the __sync_fetch_and_add builtin.
-AC_CACHE_CHECK([for __sync_fetch_and_add], ac_cv_func_sync_fetch_and_add,
-[AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[int x;__sync_fetch_and_add(&x,1);]])],[ac_cv_func_sync_fetch_and_add=yes],[ac_cv_func_sync_fetch_and_add=no])])
-if test "$ac_cv_func_sync_fetch_and_add" = yes; then
-  AC_DEFINE(HAVE_SYNC_FETCH_AND_ADD,1,[Define if you have the __sync_fetch_and_add function])
-fi
-
 AC_REPLACE_FUNCS(strlcat strlcpy explicit_bzero getopt)
 AC_FUNC_ALLOCA
 PHP_TIME_R_TYPE

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -389,11 +389,6 @@ if test "$ac_cv_strptime_decl_fails" = "yes"; then
 fi
 
 dnl
-dnl Check for atomic operation API availability in Solaris
-dnl
-AC_CHECK_HEADERS([atomic.h])
-
-dnl
 dnl Check for arc4random on BSD systems
 dnl
 AC_CHECK_DECLS([arc4random_buf])


### PR DESCRIPTION
Some more code cleanup here...

Looking at the history of this function, the original implementation had a bug where
it would return from the middle of the function without unlocking the mutex first.
The author attempted to fix this by incrementing the `initialized` flag atomically,
which is not necessary, since the section which modifies the flag is protected by a
mutex.

Coincidentally, at the same time that all this unnecessary 'atomic' machinery was
introduced, the code was also changed so that it didn't return without unlocking the
mutex. So it looks like the bug was fixed by accident.

It's not necessary to declare the flag as `volatile` either, since it is protected
by a mutex.

Further, the 'fixed' implementation was also wrong in another respect: on Windows
and Solaris, the `initialized` flag was not even declared as `static`!! So the
initialization of the static tables for S-boxes, P-boxes, etc. was repeated on
each call to `php_crypt`, completely defeating the purpose of this function.