### PR TITLE
Deprecate the procedural API of ext/zip

### DIFF
--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -2,44 +2,66 @@
 
 /** @generate-function-entries */
 
-/** @return resource|int|false */
+/**
+ * @return resource|int|false
+ * @deprecated
+ */
 function zip_open(string $filename) {}
 
 /**
  * @param resource $zip
+ * @deprecated
  */
 function zip_close($zip): void {}
 
 /**
  * @param resource $zip
  * @return resource|false
+ * @deprecated
  */
 function zip_read($zip) {}
 
 /**
  * @param resource $zip_dp
  * @param resource $zip_entry
+ * @deprecated
  */
 function zip_entry_open($zip_dp, $zip_entry, string $mode = 'rb'): bool {}
 
 /**
  * @param resource $zip_ent
+ * @deprecated
  */
 function zip_entry_close($zip_ent): bool {}
 
-/** @param resource $zip_entry */
+/**
+ * @param resource $zip_entry
+ * @deprecated
+ */
 function zip_entry_read($zip_entry, int $len = 1024): string|false {}
 
-/** @param resource $zip_entry */
+/**
+ * @param resource $zip_entry
+ * @deprecated
+ */
 function zip_entry_name($zip_entry): string|false {}
 
-/** @param resource $zip_entry */
+/**
+ * @param resource $zip_entry
+ * @deprecated
+ */
 function zip_entry_compressedsize($zip_entry): int|false {}
 
-/** @param resource $zip_entry */
+/**
+ * @param resource $zip_entry
+ * @deprecated
+ */
 function zip_entry_filesize($zip_entry): int|false {}
 
-/** @param resource $zip_entry */
+/**
+ * @param resource $zip_entry
+ * @deprecated
+ */
 function zip_entry_compressionmethod($zip_entry): string|false {}
 
 class ZipArchive

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -366,16 +366,16 @@ ZEND_METHOD(ZipArchive, isEncryptionMethodSupported);
 
 
 static const zend_function_entry ext_functions[] = {
-	ZEND_FE(zip_open, arginfo_zip_open)
-	ZEND_FE(zip_close, arginfo_zip_close)
-	ZEND_FE(zip_read, arginfo_zip_read)
-	ZEND_FE(zip_entry_open, arginfo_zip_entry_open)
-	ZEND_FE(zip_entry_close, arginfo_zip_entry_close)
-	ZEND_FE(zip_entry_read, arginfo_zip_entry_read)
-	ZEND_FE(zip_entry_name, arginfo_zip_entry_name)
-	ZEND_FE(zip_entry_compressedsize, arginfo_zip_entry_compressedsize)
-	ZEND_FE(zip_entry_filesize, arginfo_zip_entry_filesize)
-	ZEND_FE(zip_entry_compressionmethod, arginfo_zip_entry_compressionmethod)
+	ZEND_DEP_FE(zip_open, arginfo_zip_open)
+	ZEND_DEP_FE(zip_close, arginfo_zip_close)
+	ZEND_DEP_FE(zip_read, arginfo_zip_read)
+	ZEND_DEP_FE(zip_entry_open, arginfo_zip_entry_open)
+	ZEND_DEP_FE(zip_entry_close, arginfo_zip_entry_close)
+	ZEND_DEP_FE(zip_entry_read, arginfo_zip_entry_read)
+	ZEND_DEP_FE(zip_entry_name, arginfo_zip_entry_name)
+	ZEND_DEP_FE(zip_entry_compressedsize, arginfo_zip_entry_compressedsize)
+	ZEND_DEP_FE(zip_entry_filesize, arginfo_zip_entry_filesize)
+	ZEND_DEP_FE(zip_entry_compressionmethod, arginfo_zip_entry_compressionmethod)
 	ZEND_FE_END
 };
 

--- a/ext/zip/tests/bug7214.phpt
+++ b/ext/zip/tests/bug7214.phpt
@@ -18,5 +18,14 @@ if (strlen($contents) == zip_entry_filesize($entry)) {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
 Ok

--- a/ext/zip/tests/doubleclose.phpt
+++ b/ext/zip/tests/doubleclose.phpt
@@ -39,7 +39,13 @@ if ($zip->status == ZIPARCHIVE::ER_OK) {
 Done
 --EXPECTF--
 Procedural
+
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d
 NULL
+
+Deprecated: Function zip_close() is deprecated in %s on line %d
 zip_close(): supplied resource is not a valid Zip Directory resource
 Object
 bool(true)

--- a/ext/zip/tests/oo_setcompression.phpt
+++ b/ext/zip/tests/oo_setcompression.phpt
@@ -55,17 +55,65 @@ zip_close($zip);
 $tmpfile = __DIR__ . '/oo_setcompression.zip';
 unlink($tmpfile);
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 bool(true)
 bool(true)
 bool(true)
 bool(true)
 bool(true)
+
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 entry1.txt: deflated
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 entry2.txt: deflated
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 dir/entry3.txt: stored
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 entry4.txt: deflated
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 entry5.txt: stored
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 entry6.txt: deflated
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 entry7.txt: deflated
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d

--- a/ext/zip/tests/zip_close.phpt
+++ b/ext/zip/tests/zip_close.phpt
@@ -12,5 +12,8 @@ zip_close($zip);
 echo "OK";
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d
 OK

--- a/ext/zip/tests/zip_entry_close.phpt
+++ b/ext/zip/tests/zip_entry_close.phpt
@@ -18,8 +18,19 @@ try {
 zip_close($zip);
 ?>
 Done
---EXPECT--
-entry_open:  bool(true)
-entry_close: bool(true)
-entry_close: zip_entry_close(): supplied resource is not a valid Zip Entry resource
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+entry_open:  
+Deprecated: Function zip_entry_open() is deprecated in %s on line %d
+bool(true)
+entry_close: 
+Deprecated: Function zip_entry_close() is deprecated in %s on line %d
+bool(true)
+entry_close: 
+Deprecated: Function zip_entry_close() is deprecated in %s on line %d
+zip_entry_close(): supplied resource is not a valid Zip Entry resource
+
+Deprecated: Function zip_close() is deprecated in %s on line %d
 Done

--- a/ext/zip/tests/zip_entry_compressedsize.phpt
+++ b/ext/zip/tests/zip_entry_compressedsize.phpt
@@ -15,8 +15,29 @@ while ($entry = zip_read($zip)) {
 zip_close($zip);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressedsize() is deprecated in %s on line %d
 5
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressedsize() is deprecated in %s on line %d
 4
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressedsize() is deprecated in %s on line %d
 0
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressedsize() is deprecated in %s on line %d
 24
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d

--- a/ext/zip/tests/zip_entry_compressionmethod.phpt
+++ b/ext/zip/tests/zip_entry_compressionmethod.phpt
@@ -15,8 +15,29 @@ while ($entry = zip_read($zip)) {
 zip_close($zip);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 stored
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 stored
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 stored
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
 deflated
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d

--- a/ext/zip/tests/zip_entry_filesize.phpt
+++ b/ext/zip/tests/zip_entry_filesize.phpt
@@ -15,8 +15,29 @@ while ($entry = zip_read($zip)) {
 zip_close($zip);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
 5
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
 4
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
 0
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
 27
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d

--- a/ext/zip/tests/zip_entry_name.phpt
+++ b/ext/zip/tests/zip_entry_name.phpt
@@ -15,8 +15,29 @@ while ($entry = zip_read($zip)) {
 zip_close($zip);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
 foo
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
 bar
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
 foobar/
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
 foobar/baz
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d

--- a/ext/zip/tests/zip_entry_open.phpt
+++ b/ext/zip/tests/zip_entry_open.phpt
@@ -13,5 +13,13 @@ zip_entry_close($entry);
 zip_close($zip);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_open() is deprecated in %s on line %d
 OK
+Deprecated: Function zip_entry_close() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d

--- a/ext/zip/tests/zip_entry_read.phpt
+++ b/ext/zip/tests/zip_entry_read.phpt
@@ -14,5 +14,17 @@ zip_entry_close($entry);
 zip_close($zip);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_read() is deprecated in %s on line %d
 foo
+
+
+Deprecated: Function zip_entry_close() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d

--- a/ext/zip/tests/zip_open.phpt
+++ b/ext/zip/tests/zip_open.phpt
@@ -11,5 +11,6 @@ $zip = zip_open(__DIR__."/test_procedural.zip");
 echo is_resource($zip) ? "OK" : "Failure";
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
 OK

--- a/ext/zip/tests/zip_open_error.phpt
+++ b/ext/zip/tests/zip_open_error.phpt
@@ -18,6 +18,10 @@ echo is_resource($zip) ? "OK" : "Failure";
 ?>
 --EXPECTF--
 Test case 1:
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
 Warning: zip_open(): Empty string as source in %s on line %d
 Test case 2:
+
+Deprecated: Function zip_open() is deprecated in %s on line %d
 Failure

--- a/ext/zip/tests/zip_read.phpt
+++ b/ext/zip/tests/zip_read.phpt
@@ -16,5 +16,18 @@ zip_close($zip);
 echo "$entries entries";
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_close() is deprecated in %s on line %d
 4 entries


### PR DESCRIPTION
As discussed in https://github.com/php/php-src/pull/5601#issuecomment-631681185 this seems to be the most sensible approach to get rid of resources.