### PR TITLE
Use ZPP string|array check for PCRE extension

### DIFF
--- a/ext/pcre/php_pcre.stub.php
+++ b/ext/pcre/php_pcre.stub.php
@@ -12,8 +12,7 @@ function preg_filter(string|array $regex, string|array $replace, string|array $s
 
 function preg_replace_callback(string|array $regex, callable $callback, string|array $subject, int $limit = -1, &$count = null, int $flags = 0): string|array|null {}
 
-/** @param string|array $subject */
-function preg_replace_callback_array(array $pattern, $subject, int $limit = -1, &$count = null, int $flags = 0): string|array|null {}
+function preg_replace_callback_array(array $pattern, string|array $subject, int $limit = -1, &$count = null, int $flags = 0): string|array|null {}
 
 function preg_split(string $pattern, string $subject, int $limit = -1, int $flags = 0): array|false {}
 

--- a/ext/pcre/php_pcre_arginfo.h
+++ b/ext/pcre/php_pcre_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 88e664fe3f4714ab7760a99bffef5c11eafcf0aa */
+ * Stub hash: 2e7402e33a485cd3c1a74c0d6210214b3e7c4e9a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_preg_match, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
@@ -38,7 +38,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_preg_replace_callback_array, 0, 2, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_NULL)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_ARRAY, 0)
-	ZEND_ARG_INFO(0, subject)
+	ZEND_ARG_TYPE_MASK(0, subject, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limit, IS_LONG, 0, "-1")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, count, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")

--- a/sapi/cli/tests/006.phpt
+++ b/sapi/cli/tests/006.phpt
@@ -125,7 +125,7 @@ string(%d) "Extension [ <persistent> extension #%d pcre version %s ] {
 
       - Parameters [5] {
         Parameter #0 [ <required> array $pattern ]
-        Parameter #1 [ <required> $subject ]
+        Parameter #1 [ <required> array|string $subject ]
         Parameter #2 [ <optional> int $limit = -1 ]
         Parameter #3 [ <optional> &$count = null ]
         Parameter #4 [ <optional> int $flags = 0 ]


### PR DESCRIPTION
This allows for the same rules for type-coercion as userland in case of strict_types.

Most of the work is done except that I can't figure out a way to mimic the ZVAL replacement behaviour that ``preg_replace_callback_array()`` uses, but most of the preliminary work for it is done.

Another point I'm unsure about is if it is necessary to duplicate the ``zend_string`` or if a simple copy (i.e. ref number increment) would suffice.