### PR TITLE
Fix #55857: ftp_size on large files

### DIFF
--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1133,6 +1133,8 @@ bail:
 zend_long
 ftp_size(ftpbuf_t *ftp, const char *path, const size_t path_len)
 {
+	zend_long res;
+
 	if (ftp == NULL) {
 		return -1;
 	}
@@ -1145,7 +1147,8 @@ ftp_size(ftpbuf_t *ftp, const char *path, const size_t path_len)
 	if (!ftp_getresp(ftp) || ftp->resp != 213) {
 		return -1;
 	}
-	return atol(ftp->inbuf);
+	ZEND_ATOL(res, ftp->inbuf);
+	return res;
 }
 /* }}} */
 


### PR DESCRIPTION
`atol()` returns a `long` which is not the same as `zend_long` on
LLP64; we use `ZEND_ATOL()` instead.

There is no need for a new test case, since filesize_large.phpt already
tests for that behavior; unfortunately, the FTP test suite relies on
`pcntl_fork()` and therefore cannot be run on Windows.