### PR TITLE
PDO and driver specific methods

### DIFF
--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -463,7 +463,7 @@ static PHP_METHOD(PDO, connect)
 		return;
 	}
 
-	// Now the driver has been identified, this is where it should be doing `new PDOSQLite()`
+	// Now the driver has been identified, this is where we should be doing `new PDOSQLite()` for sqlite datasources
 
 	// Somehow return the new object...
 }

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -37,6 +37,9 @@
 
 static int pdo_dbh_attribute_set(pdo_dbh_t *dbh, zend_long attr, zval *value);
 
+/* Class entry pointers */
+PHPAPI zend_class_entry *pdo_dbh_ce;
+
 void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *sqlstate, const char *supp) /* {{{ */
 {
 	pdo_error_type *pdo_err = &dbh->error_code;

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -464,8 +464,13 @@ static PHP_METHOD(PDO, connect)
 	}
 
 	// Now the driver has been identified, this is where we should be doing `new PDOSQLite()` for sqlite datasources
+	if (driver->driver_name == 'sqlite') {
+	    thingtoreturn = new PDOSQLite(data_source, username, password, options)
+	}
+	// @TODO Add a catch-all for drivers without this implemented
 
 	// Somehow return the new object...
+    ZVAL_OBJ(return_value, thingtoreturn); // Or pointer to *thingtoreturn?
 }
 /* }}} */
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -37,9 +37,6 @@
 
 static int pdo_dbh_attribute_set(pdo_dbh_t *dbh, zend_long attr, zval *value);
 
-/* Class entry pointers */
-PHPAPI zend_class_entry *pdo_dbh_ce;
-
 void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *sqlstate, const char *supp) /* {{{ */
 {
 	pdo_error_type *pdo_err = &dbh->error_code;

--- a/ext/pdo/php_pdo.h
+++ b/ext/pdo/php_pdo.h
@@ -27,6 +27,14 @@ extern zend_module_entry pdo_module_entry;
 #include "php_version.h"
 #define PHP_PDO_VERSION PHP_VERSION
 
+// Copied from php_reflection.h
+BEGIN_EXTERN_C()
+
+/* Class entry pointers */
+extern PHPAPI zend_class_entry *pdo_dbh_ce;
+
+END_EXTERN_C()
+
 #ifdef PHP_WIN32
 #	if defined(PDO_EXPORTS) || (!defined(COMPILE_DL_PDO))
 #		define PDO_API __declspec(dllexport)

--- a/ext/pdo/php_pdo.h
+++ b/ext/pdo/php_pdo.h
@@ -27,14 +27,6 @@ extern zend_module_entry pdo_module_entry;
 #include "php_version.h"
 #define PHP_PDO_VERSION PHP_VERSION
 
-// Copied from php_reflection.h
-BEGIN_EXTERN_C()
-
-/* Class entry pointers */
-extern PHPAPI zend_class_entry *pdo_dbh_ce;
-
-END_EXTERN_C()
-
 #ifdef PHP_WIN32
 #	if defined(PDO_EXPORTS) || (!defined(COMPILE_DL_PDO))
 #		define PDO_API __declspec(dllexport)

--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -87,7 +87,7 @@ PHP_MINIT_FUNCTION(pdo_sqlite)
     // The Reflection extension manges to set serialize and unserialize *before* calling
     // zend_register_internal_class(). I couldn't make that work (something to do with
     // pointers/references?) so have had to put them after.
-    pdo_dbh_sqlite_ptr = zend_register_internal_class(&ce_sqlite); // @TODO Add a second parameter with name of PDO ptr
+    pdo_dbh_sqlite_ptr = zend_register_internal_class(&ce_sqlite, pdo_pdh_ce); // @TODO Second parameter doesn't resolve
     pdo_dbh_sqlite_ptr->serialize = zend_class_serialize_deny;
     pdo_dbh_sqlite_ptr->unserialize = zend_class_unserialize_deny;
     zend_declare_property_string(pdo_dbh_sqlite_ptr, "name", sizeof("name")-1, "", ZEND_ACC_PUBLIC);
@@ -114,3 +114,20 @@ PHP_MINFO_FUNCTION(pdo_sqlite)
 	php_info_print_table_end();
 }
 /* }}} */
+
+///* {{{ spl_register_sub_class */
+//PHPAPI void spl_register_sub_class(zend_class_entry ** ppce, zend_class_entry * parent_ce, char * class_name, void *obj_ctor, const zend_function_entry * function_list)
+//{
+//    zend_class_entry ce;
+//
+//    INIT_CLASS_ENTRY_EX(ce, class_name, strlen(class_name), function_list);
+//    *ppce = zend_register_internal_class_ex(&ce, parent_ce);
+//
+//    /* entries changed by initialize */
+//    if (obj_ctor) {
+//        (*ppce)->create_object = obj_ctor;
+//    } else {
+//        (*ppce)->create_object = parent_ce->create_object;
+//    }
+//}
+///* }}} */

--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -32,6 +32,7 @@
 
 /* Class entry pointers */
 PHPAPI zend_class_entry *pdo_dbh_sqlite_ptr;
+PHPAPI zend_class_entry *ce_pdo;
 
 /* {{{ pdo_sqlite_functions[] */
 static const zend_function_entry pdo_sqlite_functions[] = {
@@ -82,12 +83,19 @@ PHP_MINIT_FUNCTION(pdo_sqlite)
 	REGISTER_PDO_CLASS_CONST_LONG("SQLITE_ATTR_READONLY_STATEMENT", (zend_long)PDO_SQLITE_ATTR_READONLY_STATEMENT);
 	REGISTER_PDO_CLASS_CONST_LONG("SQLITE_ATTR_EXTENDED_RESULT_CODES", (zend_long)PDO_SQLITE_ATTR_EXTENDED_RESULT_CODES);
 
+    zend_class_entry *pce;
     zend_class_entry ce_sqlite;
+
+    if ((pce = zend_hash_str_find_ptr(CG(class_table), "pdo", sizeof("PDO") - 1)) == NULL) {
+        return SUCCESS; /* SimpleXML must be initialized before */
+    }
+
+    ce_pdo = pce;
     INIT_CLASS_ENTRY(ce_sqlite, "PDOSQLite", pdo_sqlite_functions);
     // The Reflection extension manges to set serialize and unserialize *before* calling
     // zend_register_internal_class(). I couldn't make that work (something to do with
     // pointers/references?) so have had to put them after.
-    pdo_dbh_sqlite_ptr = zend_register_internal_class(&ce_sqlite, pdo_pdh_ce); // @TODO Second parameter doesn't resolve
+    pdo_dbh_sqlite_ptr = zend_register_internal_class_ex(&ce_sqlite, ce_pdo); // @TODO Second parameter doesn't resolve
     pdo_dbh_sqlite_ptr->serialize = zend_class_serialize_deny;
     pdo_dbh_sqlite_ptr->unserialize = zend_class_unserialize_deny;
     zend_declare_property_string(pdo_dbh_sqlite_ptr, "name", sizeof("name")-1, "", ZEND_ACC_PUBLIC);
@@ -114,20 +122,3 @@ PHP_MINFO_FUNCTION(pdo_sqlite)
 	php_info_print_table_end();
 }
 /* }}} */
-
-///* {{{ spl_register_sub_class */
-//PHPAPI void spl_register_sub_class(zend_class_entry ** ppce, zend_class_entry * parent_ce, char * class_name, void *obj_ctor, const zend_function_entry * function_list)
-//{
-//    zend_class_entry ce;
-//
-//    INIT_CLASS_ENTRY_EX(ce, class_name, strlen(class_name), function_list);
-//    *ppce = zend_register_internal_class_ex(&ce, parent_ce);
-//
-//    /* entries changed by initialize */
-//    if (obj_ctor) {
-//        (*ppce)->create_object = obj_ctor;
-//    } else {
-//        (*ppce)->create_object = parent_ce->create_object;
-//    }
-//}
-///* }}} */

--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -28,6 +28,10 @@
 #include "php_pdo_sqlite.h"
 #include "php_pdo_sqlite_int.h"
 #include "zend_exceptions.h"
+#include "zend_interfaces.h"
+
+/* Class entry pointers */
+PHPAPI zend_class_entry *pdo_dbh_sqlite_ptr;
 
 /* {{{ pdo_sqlite_functions[] */
 static const zend_function_entry pdo_sqlite_functions[] = {
@@ -77,6 +81,16 @@ PHP_MINIT_FUNCTION(pdo_sqlite)
 	REGISTER_PDO_CLASS_CONST_LONG("SQLITE_OPEN_CREATE", (zend_long)SQLITE_OPEN_CREATE);
 	REGISTER_PDO_CLASS_CONST_LONG("SQLITE_ATTR_READONLY_STATEMENT", (zend_long)PDO_SQLITE_ATTR_READONLY_STATEMENT);
 	REGISTER_PDO_CLASS_CONST_LONG("SQLITE_ATTR_EXTENDED_RESULT_CODES", (zend_long)PDO_SQLITE_ATTR_EXTENDED_RESULT_CODES);
+
+    zend_class_entry ce_sqlite;
+    INIT_CLASS_ENTRY(ce_sqlite, "PDOSQLite", pdo_sqlite_functions);
+    // The Reflection extension manges to set serialize and unserialize *before* calling
+    // zend_register_internal_class(). I couldn't make that work (something to do with
+    // pointers/references?) so have had to put them after.
+    pdo_dbh_sqlite_ptr = zend_register_internal_class(&ce_sqlite); // @TODO Add a second parameter with name of PDO ptr
+    pdo_dbh_sqlite_ptr->serialize = zend_class_serialize_deny;
+    pdo_dbh_sqlite_ptr->unserialize = zend_class_unserialize_deny;
+    zend_declare_property_string(pdo_dbh_sqlite_ptr, "name", sizeof("name")-1, "", ZEND_ACC_PUBLIC);
 
 	return php_pdo_register_driver(&pdo_sqlite_driver);
 }

--- a/ext/pdo_sqlite/php_pdo_sqlite.h
+++ b/ext/pdo_sqlite/php_pdo_sqlite.h
@@ -36,5 +36,3 @@ PHP_RSHUTDOWN_FUNCTION(pdo_sqlite);
 PHP_MINFO_FUNCTION(pdo_sqlite);
 
 #endif	/* PHP_PDO_SQLITE_H */
-
-void spl_register_sub_class(zend_class_entry ** ppce, zend_class_entry * parent_ce, char * class_name, create_object_func_t ctor, const zend_function_entry * function_list);

--- a/ext/pdo_sqlite/php_pdo_sqlite.h
+++ b/ext/pdo_sqlite/php_pdo_sqlite.h
@@ -36,3 +36,5 @@ PHP_RSHUTDOWN_FUNCTION(pdo_sqlite);
 PHP_MINFO_FUNCTION(pdo_sqlite);
 
 #endif	/* PHP_PDO_SQLITE_H */
+
+void spl_register_sub_class(zend_class_entry ** ppce, zend_class_entry * parent_ce, char * class_name, create_object_func_t ctor, const zend_function_entry * function_list);


### PR DESCRIPTION
This pull request is a spin-off from https://externals.io/message/110578.

## What is it trying to achieve?

To provide full functionality there is a need to add driver-specific methods to PDO. 

I discovered that I cannot load [SQLite extensions](https://github.com/php/php-src/pull/3368) such as GIS functions when using PDO-SQLite, and raised this on the mailing list. Rightly, no one wants to add driver-specific functionality to PDO - what's in PDO should be portable. 

The consensus is that adding driver-specific subclassing of PDO is the way to go, and driver-specific functionality should be added here.

## Why a Pull Request now?
I last wrote C 2 decades ago, and those were simple programs. I'm enjoying the challenge of digging into the PHP source code and doing copy&paste development but I don't know enough to complete this. I'm getting stuck and I need help.

I've been using SQLite as my testbed; if taken forward the work would need scaling to all drivers.

## Preliminary plans

- [x] Add a PDOSQLite class
- [x] Make it extend PDO
- [x] Add a new `PDO::connect()` method
    - [ ] Make `PDO::connect()` do the same as `new PDO()` but return the right driver-instance (PDOSQLite in this case)
- [ ] Expose a driver-specific method and constant
- [ ] Confirm this approach is feasible and the PHP community approves of it

## Far-Future plans
- [ ] Migrate driver-specific functionality to the new driver-classes
- [ ] Add a shim layer so current driver-specific calls on `PDO` continue to work
- [ ] Check it's thread-safe (my code is simpler than https://github.com/ThomasWeinert/php-extension-sample/tree/class_method)
- [ ] Extend to all drivers