### PR TITLE
Fix #63208: BSTR to PHP string conversion not binary safe

### DIFF
--- a/ext/com_dotnet/com_olechar.c
+++ b/ext/com_dotnet/com_olechar.c
@@ -103,3 +103,23 @@ PHP_COM_DOTNET_API char *php_com_olestring_to_string(OLECHAR *olestring, size_t 
 
 	return string;
 }
+
+zend_string *php_com_bstr_to_string(BSTR bstr, int codepage)
+{
+	zend_string *string;
+	uint32_t length = SysStringLen(bstr);
+
+	string = zend_string_alloc(length, 0);
+	length = WideCharToMultiByte(codepage, 0, bstr, length + 1, ZSTR_VAL(string), length + 1, NULL, NULL);
+
+	if (length <= 0) {
+		char *msg = php_win32_error_to_msg(GetLastError());
+
+		php_error_docref(NULL, E_WARNING,
+			"Could not convert string from unicode: `%s'", msg);
+
+		LocalFree(msg);
+	}
+
+	return string;
+}

--- a/ext/com_dotnet/com_variant.c
+++ b/ext/com_dotnet/com_variant.c
@@ -96,7 +96,6 @@ bogus:
 
 PHP_COM_DOTNET_API void php_com_variant_from_zval(VARIANT *v, zval *z, int codepage)
 {
-	OLECHAR *olestring;
 	php_com_dotnet_object *obj;
 	zend_uchar ztype = IS_NULL;
 
@@ -164,13 +163,7 @@ PHP_COM_DOTNET_API void php_com_variant_from_zval(VARIANT *v, zval *z, int codep
 
 		case IS_STRING:
 			V_VT(v) = VT_BSTR;
-			olestring = php_com_string_to_olestring(Z_STRVAL_P(z), Z_STRLEN_P(z), codepage);
-			if (CP_UTF8 == codepage) {
-				V_BSTR(v) = SysAllocStringByteLen((char*)olestring, (UINT)(wcslen(olestring) * sizeof(OLECHAR)));
-			} else {
-				V_BSTR(v) = SysAllocStringByteLen((char*)olestring, (UINT)(Z_STRLEN_P(z) * sizeof(OLECHAR)));
-			}
-			efree(olestring);
+			V_BSTR(v) = php_com_string_to_bstr(Z_STR_P(z), codepage);
 			break;
 
 		case IS_RESOURCE:

--- a/ext/com_dotnet/com_variant.c
+++ b/ext/com_dotnet/com_variant.c
@@ -236,12 +236,8 @@ PHP_COM_DOTNET_API int php_com_zval_from_variant(zval *z, VARIANT *v, int codepa
 		case VT_BSTR:
 			olestring = V_BSTR(v);
 			if (olestring) {
-				size_t len;
-				char *str = php_com_olestring_to_string(olestring,
-					&len, codepage);
-				ZVAL_STRINGL(z, str, len);
-				// TODO: avoid reallocation???
-				efree(str);
+				zend_string *str = php_com_bstr_to_string(olestring, codepage);
+				ZVAL_STR(z, str);
 				olestring = NULL;
 			}
 			break;

--- a/ext/com_dotnet/php_com_dotnet_internal.h
+++ b/ext/com_dotnet/php_com_dotnet_internal.h
@@ -89,6 +89,7 @@ PHP_COM_DOTNET_API char *php_com_olestring_to_string(OLECHAR *olestring,
 		size_t *string_len, int codepage);
 PHP_COM_DOTNET_API OLECHAR *php_com_string_to_olestring(char *string,
 		size_t string_len, int codepage);
+zend_string *php_com_bstr_to_string(BSTR bstr, int codepage);
 
 
 /* com_com.c */

--- a/ext/com_dotnet/php_com_dotnet_internal.h
+++ b/ext/com_dotnet/php_com_dotnet_internal.h
@@ -89,6 +89,7 @@ PHP_COM_DOTNET_API char *php_com_olestring_to_string(OLECHAR *olestring,
 		size_t *string_len, int codepage);
 PHP_COM_DOTNET_API OLECHAR *php_com_string_to_olestring(char *string,
 		size_t string_len, int codepage);
+BSTR php_com_string_to_bstr(zend_string *string, int codepage);
 zend_string *php_com_bstr_to_string(BSTR bstr, int codepage);
 
 

--- a/ext/com_dotnet/tests/bug63208.phpt
+++ b/ext/com_dotnet/tests/bug63208.phpt
@@ -6,13 +6,12 @@ if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not availabl
 ?>
 --FILE--
 <?php
-$string = "ab\0cd";
-$variant = new VARIANT($string, VT_ARRAY | VT_UI1); // Array of bytes
+$string = "\u{0905}b\0cd";
+$variant = new VARIANT($string, VT_ARRAY | VT_UI1, CP_UTF8); // Array of bytes
 $converted = (string) $variant;
 var_dump(bin2hex($string));
 var_dump(bin2hex($converted));
 ?>
 --EXPECT--
-string(10) "6162006364"
-string(10) "6162006364"
-
+string(14) "e0a48562006364"
+string(14) "e0a48562006364"

--- a/ext/com_dotnet/tests/bug63208.phpt
+++ b/ext/com_dotnet/tests/bug63208.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #63208 (BSTR to PHP string conversion not binary safe)
+--SKIPIF--
+<?php
+if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
+?>
+--FILE--
+<?php
+$string = "ab\0cd";
+$variant = new VARIANT($string, VT_ARRAY | VT_UI1); // Array of bytes
+$converted = (string) $variant;
+var_dump(bin2hex($string));
+var_dump(bin2hex($converted));
+?>
+--EXPECT--
+string(10) "6162006364"
+string(10) "6162006364"
+


### PR DESCRIPTION
A `BSTR` is similar to a `zend_string`; it stores the length of the
string just before the actual string, and thus the string may contain
NUL bytes.  However, `php_com_olestring_to_string()` is supposed to
deal with arbitrary `OLECHAR*`s which may not be `BSTR`s, so we
introduce `php_com_bstr_to_string()` and use it for the only case where
we actually have to deal with `BSTR`s which may contain NUL bytes.

Contrary to `php_com_olestring_to_string()` we return a `zend_string`,
so we can save the re-allocation when converting to a `zval`.