### PR TITLE
ensure all files have same date in official archives

### DIFF
--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -159,7 +159,8 @@ fi
 
 # Reset the modification and access times of all files to be packaged.
 echo "makedist: Resetting the modification and access times of package files."
-find . -exec touch -c {} \;
+touch -c NEWS
+find . -exec touch -r NEWS -c {} \;
 
 cd ..
 


### PR DESCRIPTION
Trying to understand why some `arginfo.h `was newer than their `stub.php` in official archive, found this `find + touch` call which can create such issue.

Using the same time for all files seems another way to avoid the need to regenerate some files.