### PR TITLE
Make exit() unwind properly (minimal version)

### DIFF
--- a/Zend/tests/exit_exception_handler.phpt
+++ b/Zend/tests/exit_exception_handler.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Exception handler should not be invoked for exit()
+--FILE--
+<?php
+
+set_exception_handler(function($e) {
+    var_dump($e);
+});
+
+exit("Exit\n");
+
+?>
+--EXPECT--
+Exit

--- a/Zend/tests/exit_finally_1.phpt
+++ b/Zend/tests/exit_finally_1.phpt
@@ -1,0 +1,19 @@
+--TEST--
+exit() and finally (1)
+--FILE--
+<?php
+
+// TODO: In the future, we should execute the finally block.
+
+try {
+    exit("Exit\n");
+} catch (Throwable $e) {
+    echo "Not caught\n";
+} finally {
+    echo "Finally\n";
+}
+echo "Not executed\n";
+
+?>
+--EXPECT--
+Exit

--- a/Zend/tests/exit_finally_2.phpt
+++ b/Zend/tests/exit_finally_2.phpt
@@ -1,0 +1,23 @@
+--TEST--
+exit() and finally (2)
+--FILE--
+<?php
+
+// TODO: In the future, we should execute the finally block.
+
+try {
+    try {
+        exit("Exit\n");
+    } catch (Throwable $e) {
+        echo "Not caught\n";
+    } finally {
+        throw new Exception("Finally exception");
+    }
+    echo "Not executed\n";
+} catch (Exception $e) {
+    echo "Caught {$e->getMessage()}\n";
+}
+
+?>
+--EXPECT--
+Exit

--- a/Zend/tests/exit_finally_3.phpt
+++ b/Zend/tests/exit_finally_3.phpt
@@ -1,0 +1,19 @@
+--TEST--
+exit() and finally (3)
+--FILE--
+<?php
+
+// TODO: In the future, we should execute the finally block.
+
+function test() {
+    try {
+        exit("Exit\n");
+    } finally {
+        return 42;
+    }
+}
+var_dump(test());
+
+?>
+--EXPECT--
+Exit

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1621,6 +1621,11 @@ ZEND_API ZEND_COLD void zend_user_exception_handler(void) /* {{{ */
 	zval orig_user_exception_handler;
 	zval params[1], retval2;
 	zend_object *old_exception;
+
+	if (zend_is_unwind_exit(EG(exception))) {
+		return;
+	}
+
 	old_exception = EG(exception);
 	EG(exception) = NULL;
 	ZVAL_OBJ(&params[0], old_exception);
@@ -1666,8 +1671,7 @@ ZEND_API int zend_execute_scripts(int type, zval *retval, int file_count, ...) /
 					zend_user_exception_handler();
 				}
 				if (EG(exception)) {
-					zend_exception_error(EG(exception), E_ERROR);
-					ret = FAILURE;
+					ret = zend_exception_error(EG(exception), E_ERROR);
 				}
 			}
 			destroy_op_array(op_array);

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -66,7 +66,10 @@ ZEND_API zend_object *zend_throw_error_exception(zend_class_entry *exception_ce,
 extern ZEND_API void (*zend_throw_exception_hook)(zval *ex);
 
 /* show an exception using zend_error(severity,...), severity should be E_ERROR */
-ZEND_API ZEND_COLD void zend_exception_error(zend_object *exception, int severity);
+ZEND_API ZEND_COLD int zend_exception_error(zend_object *exception, int severity);
+
+ZEND_API ZEND_COLD void zend_throw_unwind_exit(void);
+ZEND_API zend_bool zend_is_unwind_exit(zend_object *ex);
 
 #include "zend_globals.h"
 

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1141,8 +1141,7 @@ ZEND_API int zend_eval_stringl_ex(const char *str, size_t str_len, zval *retval_
 
 	result = zend_eval_stringl(str, str_len, retval_ptr, string_name);
 	if (handle_exceptions && EG(exception)) {
-		zend_exception_error(EG(exception), E_ERROR);
-		result = FAILURE;
+		result = zend_exception_error(EG(exception), E_ERROR);
 	}
 	return result;
 }

--- a/ext/curl/tests/bug68937.phpt
+++ b/ext/curl/tests/bug68937.phpt
@@ -3,7 +3,6 @@ Bug # #68937 (Segfault in curl_multi_exec)
 --SKIPIF--
 <?php
 include 'skipif.inc';
-if (getenv('SKIP_ASAN')) die('skip some curl versions leak on longjmp');
 ?>
 --FILE--
 <?php

--- a/ext/curl/tests/bug68937_2.phpt
+++ b/ext/curl/tests/bug68937_2.phpt
@@ -3,7 +3,6 @@ Bug # #68937 (Segfault in curl_multi_exec)
 --SKIPIF--
 <?php
 include 'skipif.inc';
-if (getenv('SKIP_ASAN')) die('skip some curl versions leak on longjmp');
 ?>
 --FILE--
 <?php

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4484,9 +4484,10 @@ static int accel_preload(const char *config)
 					zend_user_exception_handler();
 				}
 				if (EG(exception)) {
-					zend_exception_error(EG(exception), E_ERROR);
-					CG(unclean_shutdown) = 1;
-					ret = FAILURE;
+					ret = zend_exception_error(EG(exception), E_ERROR);
+					if (ret == FAILURE) {
+						CG(unclean_shutdown) = 1;
+					}
 				}
 			}
 			destroy_op_array(op_array);

--- a/ext/session/tests/bug60634.phpt
+++ b/ext/session/tests/bug60634.phpt
@@ -40,20 +40,6 @@ session_start();
 session_write_close();
 echo "um, hi\n";
 
-/*
- * write() calls die(). This results in calling session_flush() which calls
- * write() in request shutdown. The code is inside save handler still and
- * calls save close handler.
- *
- * Because session_write_close() fails by die(), write() is called twice.
- * close() is still called at request shutdown since session is active.
- */
-
 ?>
 --EXPECT--
 write: goodbye cruel world
-
-Warning: Unknown: Cannot call session save handler in a recursive manner in Unknown on line 0
-
-Warning: Unknown: Failed to write session data using user defined save handler. (session.save_path: ) in Unknown on line 0
-close: goodbye cruel world

--- a/ext/xsl/tests/bug33853.phpt
+++ b/ext/xsl/tests/bug33853.phpt
@@ -3,7 +3,6 @@ Bug #33853 (php:function call __autoload with lowercase param)
 --SKIPIF--
 <?php
 if (!extension_loaded('xsl')) die('skip xsl not loaded');
-if (getenv('SKIP_ASAN')) die('xfail bailing out across foreign C code');
 ?>
 --FILE--
 <?php

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -1711,6 +1711,11 @@ void phpdbg_execute_ex(zend_execute_data *execute_data) /* {{{ */
 		}
 #endif
 
+		if (exception && zend_is_unwind_exit(exception)) {
+			/* Restore bailout based exit. */
+			zend_bailout();
+		}
+
 		if (PHPDBG_G(flags) & PHPDBG_PREVENT_INTERACTIVE) {
 			phpdbg_print_opline_ex(execute_data, 0);
 			goto next;


### PR DESCRIPTION
This is a minimal version of #5243. It switches exit() to throw an internal exception that is invisible to the user and only used to unwind the stack properly and perform a clean shutdown.

It does **not** execute finally block for exits, and leaves that issue for the future.