### PR TITLE
[RFC] Make string length for getTraceAsString() configurable

### DIFF
--- a/Zend/tests/exception_024.phpt
+++ b/Zend/tests/exception_024.phpt
@@ -1,0 +1,19 @@
+--TEST--
+zend.exception_string_param_max_len ini setting
+--INI--
+zend.exception_string_param_max_len = 23
+--FILE--
+<?php
+
+function main($arg) {
+    throw new Exception();
+}
+main('123456789012345678901234567890');
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception in %s:%d
+Stack trace:
+#0 %s(%d): main('12345678901234567890123...')
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/exception_025.phpt
+++ b/Zend/tests/exception_025.phpt
@@ -1,0 +1,41 @@
+--TEST--
+zend.exception_string_param_max_len ini setting
+--FILE--
+<?php
+
+function main($arg) {
+    echo (new Exception()), "\n";
+}
+var_dump(ini_set('zend.exception_string_param_max_len', '-1'));
+var_dump(ini_set('zend.exception_string_param_max_len', '1000001'));
+var_dump(ini_set('zend.exception_string_param_max_len', '1000000'));
+var_dump(ini_set('zend.exception_string_param_max_len', '20'));
+main('short');
+main('123456789012345678901234567890');
+var_dump(ini_set('zend.exception_string_param_max_len', '0'));
+main('short');
+main('');
+
+?>
+--EXPECTF--
+bool(false)
+bool(false)
+string(2) "15"
+string(7) "1000000"
+Exception in %s:%d
+Stack trace:
+#0 %s(10): main('short')
+#1 {main}
+Exception in %s:%d
+Stack trace:
+#0 %s(11): main('12345678901234567890...')
+#1 {main}
+string(2) "20"
+Exception in %s:%d
+Stack trace:
+#0 %s(13): main('...')
+#1 {main}
+Exception in %s:%d
+Stack trace:
+#0 %s(14): main('')
+#1 {main}

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -160,7 +160,7 @@ static ZEND_INI_MH(OnUpdateAssertions) /* {{{ */
 }
 /* }}} */
 
-static ZEND_INI_MH(OnSetThrowableStringParamMaxLen) /* {{{ */
+static ZEND_INI_MH(OnSetExceptionStringParamMaxLen) /* {{{ */
 {
 	zend_long i;
 
@@ -191,7 +191,7 @@ ZEND_INI_BEGIN()
 	STD_ZEND_INI_BOOLEAN("zend.signal_check", SIGNAL_CHECK_DEFAULT, ZEND_INI_SYSTEM, OnUpdateBool, check, zend_signal_globals_t, zend_signal_globals)
 #endif
 	STD_ZEND_INI_BOOLEAN("zend.exception_ignore_args",	"0",	ZEND_INI_ALL,		OnUpdateBool, exception_ignore_args, zend_executor_globals, executor_globals)
-	STD_ZEND_INI_ENTRY("zend.exception_string_param_max_len",	"15",	ZEND_INI_ALL,	OnSetThrowableStringParamMaxLen,	exception_string_param_max_len,		zend_executor_globals,	executor_globals)
+	STD_ZEND_INI_ENTRY("zend.exception_string_param_max_len",	"15",	ZEND_INI_ALL,	OnSetExceptionStringParamMaxLen,	exception_string_param_max_len,		zend_executor_globals,	executor_globals)
 ZEND_INI_END()
 
 ZEND_API size_t zend_vspprintf(char **pbuf, size_t max_len, const char *format, va_list ap) /* {{{ */

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -160,6 +160,20 @@ static ZEND_INI_MH(OnUpdateAssertions) /* {{{ */
 }
 /* }}} */
 
+static ZEND_INI_MH(OnSetThrowableStringParamMaxLen) /* {{{ */
+{
+	zend_long i;
+
+	ZEND_ATOL(i, ZSTR_VAL(new_value));
+	if (i >= 0 && i <= 1000000) {
+		EG(exception_string_param_max_len) = i;
+		return SUCCESS;
+	} else {
+		return FAILURE;
+	}
+}
+/* }}} */
+
 #if ZEND_DEBUG
 # define SIGNAL_CHECK_DEFAULT "1"
 #else
@@ -177,6 +191,7 @@ ZEND_INI_BEGIN()
 	STD_ZEND_INI_BOOLEAN("zend.signal_check", SIGNAL_CHECK_DEFAULT, ZEND_INI_SYSTEM, OnUpdateBool, check, zend_signal_globals_t, zend_signal_globals)
 #endif
 	STD_ZEND_INI_BOOLEAN("zend.exception_ignore_args",	"0",	ZEND_INI_ALL,		OnUpdateBool, exception_ignore_args, zend_executor_globals, executor_globals)
+	STD_ZEND_INI_ENTRY("zend.exception_string_param_max_len",	"15",	ZEND_INI_ALL,	OnSetThrowableStringParamMaxLen,	exception_string_param_max_len,		zend_executor_globals,	executor_globals)
 ZEND_INI_END()
 
 ZEND_API size_t zend_vspprintf(char **pbuf, size_t max_len, const char *format, va_list ap) /* {{{ */

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -28,7 +28,6 @@
 #include "zend_dtrace.h"
 #include "zend_smart_str.h"
 #include "zend_exceptions_arginfo.h"
-#include "php_globals.h"
 
 ZEND_API zend_class_entry *zend_ce_throwable;
 ZEND_API zend_class_entry *zend_ce_exception;
@@ -483,8 +482,8 @@ static void _build_trace_args(zval *arg, smart_str *str) /* {{{ */
 			break;
 		case IS_STRING:
 			smart_str_appendc(str, '\'');
-			smart_str_append_escaped(str, Z_STRVAL_P(arg), MIN(Z_STRLEN_P(arg), PG(exception_string_param_max_len)));
-			if (Z_STRLEN_P(arg) > PG(exception_string_param_max_len)) {
+			smart_str_append_escaped(str, Z_STRVAL_P(arg), MIN(Z_STRLEN_P(arg), EG(exception_string_param_max_len)));
+			if (Z_STRLEN_P(arg) > EG(exception_string_param_max_len)) {
 				smart_str_appends(str, "...', ");
 			} else {
 				smart_str_appends(str, "', ");

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -28,6 +28,7 @@
 #include "zend_dtrace.h"
 #include "zend_smart_str.h"
 #include "zend_exceptions_arginfo.h"
+#include "php_globals.h"
 
 ZEND_API zend_class_entry *zend_ce_throwable;
 ZEND_API zend_class_entry *zend_ce_exception;
@@ -482,8 +483,8 @@ static void _build_trace_args(zval *arg, smart_str *str) /* {{{ */
 			break;
 		case IS_STRING:
 			smart_str_appendc(str, '\'');
-			smart_str_append_escaped(str, Z_STRVAL_P(arg), MIN(Z_STRLEN_P(arg), 15));
-			if (Z_STRLEN_P(arg) > 15) {
+			smart_str_append_escaped(str, Z_STRVAL_P(arg), MIN(Z_STRLEN_P(arg), PG(exception_string_param_max_len)));
+			if (Z_STRLEN_P(arg) > PG(exception_string_param_max_len)) {
 				smart_str_appends(str, "...', ");
 			} else {
 				smart_str_appends(str, "', ");

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -241,6 +241,7 @@ struct _zend_executor_globals {
 	HashTable weakrefs;
 
 	zend_bool exception_ignore_args;
+	zend_long exception_string_param_max_len;
 
 	zend_get_gc_buffer get_gc_buffer;
 

--- a/main/main.c
+++ b/main/main.c
@@ -260,22 +260,6 @@ static PHP_INI_MH(OnSetSerializePrecision)
 }
 /* }}} */
 
-/* {{{ PHP_INI_MH
- */
-static PHP_INI_MH(OnSetThrowableStringParamMaxLen)
-{
-	zend_long i;
-
-	ZEND_ATOL(i, ZSTR_VAL(new_value));
-	if (i >= 0 && i <= 1000000) {
-		PG(exception_string_param_max_len) = i;
-		return SUCCESS;
-	} else {
-		return FAILURE;
-	}
-}
-/* }}} */
-
 /* {{{ PHP_INI_MH */
 static PHP_INI_MH(OnChangeMemoryLimit)
 {
@@ -719,7 +703,6 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("register_argc_argv",	"1",		PHP_INI_PERDIR|PHP_INI_SYSTEM,	OnUpdateBool,	register_argc_argv,		php_core_globals,	core_globals)
 	STD_PHP_INI_BOOLEAN("auto_globals_jit",		"1",		PHP_INI_PERDIR|PHP_INI_SYSTEM,	OnUpdateBool,	auto_globals_jit,	php_core_globals,	core_globals)
 	STD_PHP_INI_BOOLEAN("short_open_tag",	DEFAULT_SHORT_OPEN_TAG,	PHP_INI_SYSTEM|PHP_INI_PERDIR,		OnUpdateBool,			short_tags,				zend_compiler_globals,	compiler_globals)
-	STD_PHP_INI_ENTRY("zend.exception_string_param_max_len",	"15",	PHP_INI_ALL,	OnSetThrowableStringParamMaxLen,	exception_string_param_max_len,		php_core_globals,	core_globals)
 
 	STD_PHP_INI_ENTRY("unserialize_callback_func",	NULL,	PHP_INI_ALL,		OnUpdateString,			unserialize_callback_func,	php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("serialize_precision",	"-1",	PHP_INI_ALL,		OnSetSerializePrecision,			serialize_precision,	php_core_globals,	core_globals)

--- a/main/main.c
+++ b/main/main.c
@@ -260,6 +260,21 @@ static PHP_INI_MH(OnSetSerializePrecision)
 }
 /* }}} */
 
+/* {{{ PHP_INI_MH
+ */
+static PHP_INI_MH(OnSetThrowableStringParamMaxLen)
+{
+	zend_long i;
+
+	ZEND_ATOL(i, ZSTR_VAL(new_value));
+	if (i >= 0 && i <= 1000000) {
+		PG(exception_string_param_max_len) = i;
+		return SUCCESS;
+	} else {
+		return FAILURE;
+	}
+}
+/* }}} */
 
 /* {{{ PHP_INI_MH */
 static PHP_INI_MH(OnChangeMemoryLimit)
@@ -704,6 +719,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("register_argc_argv",	"1",		PHP_INI_PERDIR|PHP_INI_SYSTEM,	OnUpdateBool,	register_argc_argv,		php_core_globals,	core_globals)
 	STD_PHP_INI_BOOLEAN("auto_globals_jit",		"1",		PHP_INI_PERDIR|PHP_INI_SYSTEM,	OnUpdateBool,	auto_globals_jit,	php_core_globals,	core_globals)
 	STD_PHP_INI_BOOLEAN("short_open_tag",	DEFAULT_SHORT_OPEN_TAG,	PHP_INI_SYSTEM|PHP_INI_PERDIR,		OnUpdateBool,			short_tags,				zend_compiler_globals,	compiler_globals)
+	STD_PHP_INI_ENTRY("zend.exception_string_param_max_len",	"15",	PHP_INI_ALL,	OnSetThrowableStringParamMaxLen,	exception_string_param_max_len,		php_core_globals,	core_globals)
 
 	STD_PHP_INI_ENTRY("unserialize_callback_func",	NULL,	PHP_INI_ALL,		OnUpdateString,			unserialize_callback_func,	php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("serialize_precision",	"-1",	PHP_INI_ALL,		OnSetSerializePrecision,			serialize_precision,	php_core_globals,	core_globals)

--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -167,8 +167,6 @@ struct _php_core_globals {
 	char *syslog_ident;
 	zend_bool have_called_openlog;
 	zend_long syslog_filter;
-
-	zend_long exception_string_param_max_len;
 };
 
 

--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -167,6 +167,8 @@ struct _php_core_globals {
 	char *syslog_ident;
 	zend_bool have_called_openlog;
 	zend_long syslog_filter;
+
+	zend_long exception_string_param_max_len;
 };
 
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -159,6 +159,11 @@
 ;   Development Value: Off
 ;   Production Value: On
 
+; zend.exception_string_param_max_len
+;   Default Value: 15
+;   Development Value: 15
+;   Production Value: 0
+
 ;;;;;;;;;;;;;;;;;;;;
 ; php.ini Options  ;
 ;;;;;;;;;;;;;;;;;;;;

--- a/php.ini-development
+++ b/php.ini-development
@@ -371,6 +371,14 @@ zend.enable_gc = On
 ; Production Value: On
 zend.exception_ignore_args = Off
 
+; Allows setting the maximum string length in an argument of a stringified stack trace
+; to a value between 0 and 1000000.
+; This has no effect when zend.exception_ignore_args is enabled.
+; Default Value: 15
+; Development Value: 15
+; Production Value: 0
+zend.exception_string_param_max_len = 15
+
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;
 ;;;;;;;;;;;;;;;;;

--- a/php.ini-production
+++ b/php.ini-production
@@ -366,12 +366,22 @@ zend.enable_gc = On
 ;zend.script_encoding =
 
 ; Allows to include or exclude arguments from stack traces generated for exceptions
-; In production, it is recommended to turn this setting on to prohibit the output 
+; In production, it is recommended to turn this setting on to prohibit the output
 ; of sensitive information in stack traces
 ; Default Value: Off
 ; Development Value: Off
 ; Production Value: On
 zend.exception_ignore_args = On
+
+; Allows setting the maximum string length in an argument of a stringified stack trace
+; to a value between 0 and 1000000.
+; This has no effect when zend.exception_ignore_args is enabled.
+; Default Value: 15
+; Development Value: 15
+; Production Value: 0
+; In production, it is recommended to set this to 0 to reduce the output
+; of sensitive information in stack traces.
+zend.exception_string_param_max_len = 0
 
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;

--- a/php.ini-production
+++ b/php.ini-production
@@ -159,6 +159,11 @@
 ;   Development Value: Off
 ;   Production Value: On
 
+; zend.exception_string_param_max_len
+;   Default Value: 15
+;   Development Value: 15
+;   Production Value: 0
+
 ;;;;;;;;;;;;;;;;;;;;
 ; php.ini Options  ;
 ;;;;;;;;;;;;;;;;;;;;

--- a/run-tests.php
+++ b/run-tests.php
@@ -343,6 +343,7 @@ function main()
         'opcache.jit_hot_side_exit=1',
         'zend.assertions=1',
         'zend.exception_ignore_args=0',
+        'zend.exception_string_param_max_len=15',
         'short_open_tag=0',
     );
 


### PR DESCRIPTION
Add a `zend.exception_string_param_max_len` ini setting.
(same suffix as `log_errors_max_len`)

Allow values between 0 and 1000000 bytes.
For example, with zend.exception_string_param_max_len=0,
"" would represent the empty string, and "..." would represent something
longer than the empty string.
Previously, this was hardcoded as exactly 15 bytes.

RFC: https://wiki.php.net/rfc/throwable_string_param_max_len
Discussion: https://externals.io/message/110717