### PR TITLE
Don't accept objects in random places in curl

### DIFF
--- a/ext/curl/tests/bug79741.phpt
+++ b/ext/curl/tests/bug79741.phpt
@@ -12,5 +12,9 @@ curl_setopt($ch, CURLOPT_POSTFIELDS, new Test);
 
 ?>
 ===DONE===
---EXPECT--
-===DONE===
+--EXPECTF--
+Fatal error: Uncaught Error: Object of class Test could not be converted to string in %s:%d
+Stack trace:
+#0 %s(%d): curl_setopt(Object(CurlHandle), %d, Object(Test))
+#1 {main}
+  thrown in %s on line %d

--- a/ext/curl/tests/curl_setopt_basic003.phpt
+++ b/ext/curl/tests/curl_setopt_basic003.phpt
@@ -39,6 +39,6 @@ var_dump( $curl_content );
 --EXPECTF--
 *** curl_setopt() call with CURLOPT_HTTPHEADER
 
-Warning: curl_setopt(): You must pass either an object or an array with the CURLOPT_HTTPHEADER argument in %s on line %d
+Warning: curl_setopt(): You must pass an array with the CURLOPT_HTTPHEADER argument in %s on line %d
 bool(false)
 bool(true)


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=79741 is another great illustration why it is such a bad idea to silently accept objects where arrays are expected. Remove this "feature" for PHP 8. Code intentionally passing an object will have to perform the hard task of adding an `(array)` cast.