### PR TITLE
Add unaccent function

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -682,6 +682,8 @@ function utf8_encode(string $data): string {}
 
 function utf8_decode(string $data): string {}
 
+function unaccent(string $str): string {}
+
 /**
  * @param resource $context
  * @return resource|false

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8890ebea8b2391a8614b844e8e1abc04a988eeb8 */
+ * Stub hash: c3cf66c57e95f2a303f47d1491644ce0c71c7f3d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -1100,6 +1100,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_utf8_encode arginfo_bin2hex
 
 #define arginfo_utf8_decode arginfo_bin2hex
+
+#define arginfo_unaccent arginfo_base64_encode
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_opendir, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
@@ -2540,6 +2542,7 @@ ZEND_FUNCTION(strpbrk);
 ZEND_FUNCTION(substr_compare);
 ZEND_FUNCTION(utf8_encode);
 ZEND_FUNCTION(utf8_decode);
+ZEND_FUNCTION(unaccent);
 ZEND_FUNCTION(opendir);
 ZEND_FUNCTION(getdir);
 ZEND_FUNCTION(closedir);
@@ -3175,6 +3178,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(substr_compare, arginfo_substr_compare)
 	ZEND_FE(utf8_encode, arginfo_utf8_encode)
 	ZEND_FE(utf8_decode, arginfo_utf8_decode)
+	ZEND_FE(unaccent, arginfo_unaccent)
 	ZEND_FE(opendir, arginfo_opendir)
 	ZEND_FE(getdir, arginfo_getdir)
 	ZEND_FALIAS(dir, getdir, arginfo_dir)

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -6139,3 +6139,131 @@ PHP_FUNCTION(utf8_decode)
 	RETURN_STR(php_utf8_decode(arg, arg_len));
 }
 /* }}} */
+
+/* {{{ proto string unaccent(string str)
+   Removes acents (diacritic sings) from string */
+PHP_FUNCTION(unaccent) {
+
+    zend_string *string;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STR(string)
+    ZEND_PARSE_PARAMETERS_END();
+
+    setlocale(LC_CTYPE,"en_US.UTF-8");
+
+    int length = ZSTR_LEN(string);
+    wchar_t *unparsed_string = emalloc(sizeof(wchar_t) * length);
+
+    /* the text string is converted to a long string that supports special characters */
+    mbstowcs(unparsed_string, ZSTR_VAL(string), length);
+
+    /* the string "aâ" has a length of 4 ('â' is a long character). The real number of characters is obtained with wcslen */
+    int length_unparsed_string = wcslen(unparsed_string);
+
+    char *unnacent = emalloc(sizeof(char) * length_unparsed_string);
+
+    for(int i=0; i<length_unparsed_string; i++) {
+        switch(unparsed_string[i]) {
+            case L'â':
+            case L'ä':
+            case L'à':
+            case L'å':
+            case L'á':
+            case L'ã':
+                unnacent[i] = 'a';
+                break;
+            case L'Ä':
+            case L'Å':
+            case L'Á':
+            case L'Â':
+            case L'À':
+                unnacent[i] = 'A';
+                break;
+            case L'é':
+            case L'ê':
+            case L'ë':
+            case L'è':
+                unnacent[i] = 'e';
+                break;
+            case L'É':
+            case L'Ê':
+            case L'Ë':
+            case L'È':
+                unnacent[i] = 'E';
+                break;
+            case L'ï':
+            case L'î':
+            case L'ì':
+            case L'í':
+            case L'ı':
+                unnacent[i] = 'i';
+                break;
+            case L'Í':
+            case L'Î':
+            case L'Ï':
+                unnacent[i] = 'I';
+                break;
+            case L'ô':
+            case L'ö':
+            case L'ò':
+            case L'ø':
+            case L'ó':
+            case L'õ':
+                unnacent[i] = 'o';
+                break;
+            case L'Ö':
+            case L'Ø':
+            case L'Ó':
+            case L'Ô':
+            case L'Ò':
+            case L'Õ':
+                unnacent[i] = 'O';
+                break;
+            case L'ü':
+            case L'û':
+            case L'ù':
+            case L'ú':
+                unnacent[i] = 'u';
+                break;
+            case L'Ü':
+            case L'Ú':
+            case L'Û':
+            case L'Ù':
+                unnacent[i] = 'U';
+                break;
+            case L'ÿ':
+            case L'ý':
+                unnacent[i] = 'y';
+                break;
+            case L'Ý':
+                unnacent[i] = 'Y';
+                break;
+            case L'ñ':
+                unnacent[i] = 'n';
+                break;
+            case L'Ñ':
+                unnacent[i] = 'N';
+                break;
+            case L'Ç':
+                unnacent[i] = 'C';
+                break;
+            case L'ç':
+                unnacent[i] = 'c';
+                break;
+            case L'Ð':
+                unnacent[i] = 'D';
+                break;
+            case L'ð':
+                unnacent[i] = 'd';
+                break;
+            default:
+                unnacent[i] = unparsed_string[i];
+        }
+    }
+
+    /* When the text string has no accents, the length of the final text string is the same. */
+    zend_string *str = zend_string_init(unnacent, length < length_unparsed_string ? length : length_unparsed_string , 0);
+    RETURN_STR(str);
+    zend_string_release(str);
+}
+/* }}} */

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -6265,5 +6265,7 @@ PHP_FUNCTION(unaccent) {
     zend_string *str = zend_string_init(unnacent, length < length_unparsed_string ? length : length_unparsed_string , 0);
     RETURN_STR(str);
     zend_string_release(str);
+	efree(unnacent);
+    efree(unparsed_string);
 }
 /* }}} */

--- a/ext/standard/tests/strings/unaccent.phpt
+++ b/ext/standard/tests/strings/unaccent.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test trim() function : basic Functionality
+--FILE--
+<?php
+var_dump(unaccent("aâäàåáãAÄÅÁÂÀ"));
+var_dump(unaccent("eéêëèEÉÊËÈ"));
+var_dump(unaccent("iïîìíıIÍÎÏ"));
+var_dump(unaccent("oôöòøóõOÖØÓÔÒÕ"));
+var_dump(unaccent("uüûùúUÜÚÛÙ"));
+var_dump(unaccent("yÿýYÝ"));
+var_dump(unaccent("nñNÑ"));
+var_dump(unaccent("cçCÇ"));
+var_dump(unaccent("ðdDÐ"));
+var_dump(unaccent("var_foo"));
+var_dump(unaccent(NULL));
+var_dump(unaccent("aâäàåáãAÄÅÁÂÀeéêëèEÉÊËÈiïîìíıIÍÎÏoôöòøóõOÖØÓÔÒÕuüûùúUÜÚÛÙyÿýYÝnñNÑcçCÇðdDÐ"));
+
+
+?>
+--EXPECT--
+string(13) "aaaaaaaAAAAAA"
+string(10) "eeeeeEEEEE"
+string(10) "iiiiiiIIII"
+string(14) "oooooooOOOOOOO"
+string(10) "uuuuuUUUUU"
+string(5) "yyyYY"
+string(4) "nnNN"
+string(4) "ccCC"
+string(4) "ddDD"
+string(7) "var_foo"
+string(0) ""
+string(74) "aaaaaaaAAAAAAeeeeeEEEEEiiiiiiIIIIoooooooOOOOOOOuuuuuUUUUUyyyYYnnNNccCCddDD"


### PR DESCRIPTION
The function removes acents (diacritic sings) from string according the [extended ASCII code](https://elcodigoascii.com.ar/codigos-ascii/signo-pesos-dolar-codigo-ascii-36.html).

input | output
------------ | -------------
``unaccent("aâäàåáãAÄÅÁÂÀ")`` | aaaaaaaAAAAAA
``unaccent("eéêëèEÉÊËÈ")`` | eeeeeEEEEE
``unaccent("iïîìíıIÍÎÏ")`` | iiiiiiIIII
``unaccent("oôöòøóõOÖØÓÔÒÕ")`` | oooooooOOOOOOO
``unaccent("uüûùúUÜÚÛÙ")`` | uuuuuUUUUU
``unaccent("yÿýYÝ")`` |  yyyYY
``unaccent("nñNÑ")`` | nnNN
``unaccent("cçCÇ")`` | ccCC
``unaccent("ðdDÐ"))`` | ddDD