### PR TITLE
Enable most lstat_stat_* tests on Windows

### DIFF
--- a/ext/standard/tests/file/lstat_stat_error.phpt
+++ b/ext/standard/tests/file/lstat_stat_error.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test lstat() and stat() functions: error conditions
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. lstat() not available on Windows');
-}
-?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );

--- a/ext/standard/tests/file/lstat_stat_variation1.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation1.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test lstat() and stat() functions: usage variations - effects of rename() on file
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
-?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );

--- a/ext/standard/tests/file/lstat_stat_variation10.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation10.phpt
@@ -3,9 +3,6 @@ Test lstat() and stat() functions: usage variations - effects of is_dir()
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/file/lstat_stat_variation11.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation11.phpt
@@ -3,9 +3,6 @@ Test lstat() and stat() functions: usage variations - effect of is_file()
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/file/lstat_stat_variation12.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation12.phpt
@@ -3,6 +3,10 @@ Test lstat() and stat() functions: usage variations - effects of is_link()
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+if (PHP_OS_FAMILY === 'Windows') {
+    include_once __DIR__ . '/windows_links/common.inc';
+    skipIfSeCreateSymbolicLinkPrivilegeIsDisabled(__FILE__);
+}
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/file/lstat_stat_variation12.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation12.phpt
@@ -3,9 +3,6 @@ Test lstat() and stat() functions: usage variations - effects of is_link()
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-   die('skip.. lstat() not available on Windows');
-}
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/file/lstat_stat_variation13.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation13.phpt
@@ -3,9 +3,6 @@ Test lstat() and stat() functions: usage variations - file opened using w and r 
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/file/lstat_stat_variation14.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation14.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test lstat() and stat() functions: usage variations - hardlink
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-   die('skip.. lstat() not available on Windows');
-}
-?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );

--- a/ext/standard/tests/file/lstat_stat_variation15.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation15.phpt
@@ -3,9 +3,6 @@ Test lstat() and stat() functions: usage variations - effects changing permissio
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. lstat() not available on Windows');
-}
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/file/lstat_stat_variation15.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation15.phpt
@@ -3,6 +3,10 @@ Test lstat() and stat() functions: usage variations - effects changing permissio
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+if (PHP_OS_FAMILY === 'Windows') {
+    include_once __DIR__ . '/windows_links/common.inc';
+    skipIfSeCreateSymbolicLinkPrivilegeIsDisabled(__FILE__);
+}
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/file/lstat_stat_variation18.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation18.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test lstat() and stat() functions: usage variations - dir/file name stored in object
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
-?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );
@@ -85,9 +79,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -111,9 +105,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 
 -- Testing stat() on directory name stored inside an object --
@@ -141,9 +135,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -167,9 +161,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 
 --- Done ---

--- a/ext/standard/tests/file/lstat_stat_variation19.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation19.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test lstat() and stat() functions: usage variations - dir/file names in array
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
-?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );
@@ -86,9 +80,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -112,9 +106,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 array(26) {
   [0]=>
@@ -140,9 +134,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -166,9 +160,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 
 -- Testing stat() on dir name stored inside an array --
@@ -196,9 +190,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -222,9 +216,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 array(26) {
   [0]=>
@@ -250,9 +244,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -276,9 +270,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 
 --- Done ---

--- a/ext/standard/tests/file/lstat_stat_variation2.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation2.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test lstat() and stat() functions: usage variations - effects of rename() on dir
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
-?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );

--- a/ext/standard/tests/file/lstat_stat_variation20.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation20.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test lstat() and stat() functions: usage variations - link names stored in array/object
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. lstat() not available on Windows');
-}
-?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );
@@ -88,9 +82,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -114,9 +108,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 
 -- Testing stat() on link name stored inside an array --
@@ -144,9 +138,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -170,9 +164,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 array(26) {
   [0]=>
@@ -198,9 +192,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -224,9 +218,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 array(26) {
   [0]=>
@@ -252,9 +246,9 @@ array(26) {
   [10]=>
   int(%d)
   [11]=>
-  int(%d)
+  int(%i)
   [12]=>
-  int(%d)
+  int(%i)
   ["dev"]=>
   int(%d)
   ["ino"]=>
@@ -278,9 +272,9 @@ array(26) {
   ["ctime"]=>
   int(%d)
   ["blksize"]=>
-  int(%d)
+  int(%i)
   ["blocks"]=>
-  int(%d)
+  int(%i)
 }
 
 --- Done ---

--- a/ext/standard/tests/file/lstat_stat_variation22.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation22.phpt
@@ -2,11 +2,6 @@
 Test lstat() and stat() functions: usage variations - invalid filenames
 --CREDITS--
 Dave Kelsey <d_kelsey@uk.ibm.com>
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip ... not for Windows');
-}
 --CONFLICTS--
 obscure_filename
 --FILE--

--- a/ext/standard/tests/file/lstat_stat_variation22.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation22.phpt
@@ -2,6 +2,12 @@
 Test lstat() and stat() functions: usage variations - invalid filenames
 --CREDITS--
 Dave Kelsey <d_kelsey@uk.ibm.com>
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die('skip ... not for Windows');
+}
+?>
 --CONFLICTS--
 obscure_filename
 --FILE--

--- a/ext/standard/tests/file/lstat_stat_variation3.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation3.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test lstat() and stat() functions: usage variations - effects of rename() on link
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
-?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );

--- a/ext/standard/tests/file/lstat_stat_variation3.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation3.phpt
@@ -1,5 +1,12 @@
 --TEST--
 Test lstat() and stat() functions: usage variations - effects of rename() on link
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows') {
+    include_once __DIR__ . '/windows_links/common.inc';
+    skipIfSeCreateSymbolicLinkPrivilegeIsDisabled(__FILE__);
+}
+?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );

--- a/ext/standard/tests/file/lstat_stat_variation4.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation4.phpt
@@ -3,9 +3,6 @@ Test lstat() and stat() functions: usage variations - effects of touch() on file
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/file/lstat_stat_variation6.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation6.phpt
@@ -3,9 +3,6 @@ Test lstat() and stat() functions: usage variations - effects of touch() on link
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-if (!(stristr(PHP_OS, 'linux')))  {
-    die('skip.. test valid for linux only');
-}
 
 // checking for atime update whether it is enabled or disabled
 exec("mount", $mount_output);

--- a/ext/standard/tests/file/lstat_stat_variation6.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation6.phpt
@@ -4,13 +4,17 @@ Test lstat() and stat() functions: usage variations - effects of touch() on link
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 
+if (PHP_OS_FAMILY === 'Windows') {
+    include_once __DIR__ . '/windows_links/common.inc';
+    skipIfSeCreateSymbolicLinkPrivilegeIsDisabled(__FILE__);
+} else {
 // checking for atime update whether it is enabled or disabled
-exec("mount", $mount_output);
-foreach( $mount_output as $out )  {
-  if( stristr($out, "noatime") )
-     die('skip.. atime update is disabled, hence skip the test');
+    exec("mount", $mount_output);
+    foreach( $mount_output as $out )  {
+    if( stristr($out, "noatime") )
+        die('skip.. atime update is disabled, hence skip the test');
+    }
 }
-
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/file/lstat_stat_variation7.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation7.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test lstat() and stat() functions: usage variations - writing data into file
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
-?>
 --FILE--
 <?php
 /* Prototype: array lstat ( string $filename );
@@ -29,7 +23,8 @@ echo "*** Testing stat() on file after data is written in it ***\n";
 $fh = fopen($file_name,"w");
 $old_stat = stat($file_name);
 clearstatcache();
-fwrite($fh, str_repeat("Hello World", $old_stat['blksize']));
+$blksize = PHP_OS_FAMILY === 'Windows' ? 4096 : $old_stat['blksize'];
+fwrite($fh, str_repeat("Hello World", $blksize));
 $new_stat = stat($file_name);
 
 // compare self stats


### PR DESCRIPTION
Most of these have been skipped on Windows for no good reason (`lstat`
is available there as of PHP 4).  Several others would only fail,
because the `blksize` and `blocks` elements are always `-1` on Windows,
which can easily be fixed by using `%i` format specifiers instead of
`%d`.

---

The other six tests fail because PHP's `touch()` doesn't update the `ctime`, which appears to be bug.