### PR TITLE
Fix #79749: Converting FFI instances to bool fails

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4643,7 +4643,7 @@ static HashTable *zend_fake_get_gc(zend_object *ob, zval **table, int *n) /* {{{
 }
 /* }}} */
 
-static int zend_cast_object(zend_object *obj, zval *result, int type)
+static int zend_fake_cast_object(zend_object *obj, zval *result, int type)
 {
 	switch (type) {
 		case _IS_BOOL:
@@ -4906,7 +4906,7 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_handlers.unset_dimension      = zend_fake_unset_dimension;
 	zend_ffi_handlers.get_method           = zend_ffi_get_func;
 	zend_ffi_handlers.compare              = NULL;
-	zend_ffi_handlers.cast_object          = zend_cast_object;
+	zend_ffi_handlers.cast_object          = zend_fake_cast_object;
 	zend_ffi_handlers.get_debug_info       = NULL;
 	zend_ffi_handlers.get_closure          = NULL;
 	zend_ffi_handlers.get_properties       = zend_fake_get_properties;
@@ -4985,7 +4985,7 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_cdata_free_handlers.get_method           = zend_fake_get_method;
 	zend_ffi_cdata_free_handlers.get_class_name       = zend_ffi_cdata_get_class_name;
 	zend_ffi_cdata_free_handlers.compare              = zend_ffi_cdata_compare_objects;
-	zend_ffi_cdata_free_handlers.cast_object          = zend_cast_object;
+	zend_ffi_cdata_free_handlers.cast_object          = zend_fake_cast_object;
 	zend_ffi_cdata_free_handlers.count_elements       = NULL;
 	zend_ffi_cdata_free_handlers.get_debug_info       = zend_ffi_free_get_debug_info;
 	zend_ffi_cdata_free_handlers.get_closure          = NULL;
@@ -5015,7 +5015,7 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_ctype_handlers.get_method           = zend_fake_get_method;
 	zend_ffi_ctype_handlers.get_class_name       = zend_ffi_ctype_get_class_name;
 	zend_ffi_ctype_handlers.compare              = zend_ffi_ctype_compare_objects;
-	zend_ffi_ctype_handlers.cast_object          = zend_cast_object;
+	zend_ffi_ctype_handlers.cast_object          = zend_fake_cast_object;
 	zend_ffi_ctype_handlers.count_elements       = NULL;
 	zend_ffi_ctype_handlers.get_debug_info       = zend_ffi_ctype_get_debug_info;
 	zend_ffi_ctype_handlers.get_closure          = NULL;

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -1096,6 +1096,9 @@ again:
 		}
 		convert_to_string(writeobj);
 		return SUCCESS;
+	} else if (type == _IS_BOOL) {
+		ZVAL_TRUE(writeobj);
+		return SUCCESS;
 	}
 
 	return FAILURE;
@@ -4640,9 +4643,15 @@ static HashTable *zend_fake_get_gc(zend_object *ob, zval **table, int *n) /* {{{
 }
 /* }}} */
 
-static int zend_fake_cast_object(zend_object *obj, zval *result, int type)
+static int zend_cast_object(zend_object *obj, zval *result, int type)
 {
-	return FAILURE;
+	switch (type) {
+		case _IS_BOOL:
+			ZVAL_TRUE(result);
+			return SUCCESS;
+		default:
+			return FAILURE;
+	}
 }
 
 static ZEND_COLD zend_never_inline void zend_ffi_use_after_free(void) /* {{{ */
@@ -4897,7 +4906,7 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_handlers.unset_dimension      = zend_fake_unset_dimension;
 	zend_ffi_handlers.get_method           = zend_ffi_get_func;
 	zend_ffi_handlers.compare              = NULL;
-	zend_ffi_handlers.cast_object          = zend_fake_cast_object;
+	zend_ffi_handlers.cast_object          = zend_cast_object;
 	zend_ffi_handlers.get_debug_info       = NULL;
 	zend_ffi_handlers.get_closure          = NULL;
 	zend_ffi_handlers.get_properties       = zend_fake_get_properties;
@@ -4976,7 +4985,7 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_cdata_free_handlers.get_method           = zend_fake_get_method;
 	zend_ffi_cdata_free_handlers.get_class_name       = zend_ffi_cdata_get_class_name;
 	zend_ffi_cdata_free_handlers.compare              = zend_ffi_cdata_compare_objects;
-	zend_ffi_cdata_free_handlers.cast_object          = zend_fake_cast_object;
+	zend_ffi_cdata_free_handlers.cast_object          = zend_cast_object;
 	zend_ffi_cdata_free_handlers.count_elements       = NULL;
 	zend_ffi_cdata_free_handlers.get_debug_info       = zend_ffi_free_get_debug_info;
 	zend_ffi_cdata_free_handlers.get_closure          = NULL;
@@ -5006,7 +5015,7 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_ctype_handlers.get_method           = zend_fake_get_method;
 	zend_ffi_ctype_handlers.get_class_name       = zend_ffi_ctype_get_class_name;
 	zend_ffi_ctype_handlers.compare              = zend_ffi_ctype_compare_objects;
-	zend_ffi_ctype_handlers.cast_object          = zend_fake_cast_object;
+	zend_ffi_ctype_handlers.cast_object          = zend_cast_object;
 	zend_ffi_ctype_handlers.count_elements       = NULL;
 	zend_ffi_ctype_handlers.get_debug_info       = zend_ffi_ctype_get_debug_info;
 	zend_ffi_ctype_handlers.get_closure          = NULL;

--- a/ext/ffi/tests/bug79749.phpt
+++ b/ext/ffi/tests/bug79749.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #79749 (Converting FFI instances to bool fails)
+--SKIPIF--
+<?php
+if (!extension_loaded('ffi')) die('skip ffi extension not available');
+?>
+--FILE--
+<?php
+$ffi = FFI::cdef('typedef int dummy;');
+var_dump((bool) $ffi);
+var_dump((bool) FFI::type('int'));
+var_dump((bool) FFI::new('int'));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Casting objects to bool is supposed to yield `true`.  Since the
`cast_object` handler is required now, we have to implement the
`_IS_BOOL` conversion there.