### PR TITLE
Add socketpair support to proc_open

### DIFF
--- a/ext/standard/tests/general_functions/proc_open_sockets1.inc
+++ b/ext/standard/tests/general_functions/proc_open_sockets1.inc
@@ -1,0 +1,7 @@
+<?php
+
+echo "hello";
+sleep(1);
+fwrite(STDERR, "SOME ERROR");
+sleep(1);
+echo "world";

--- a/ext/standard/tests/general_functions/proc_open_sockets1.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets1.phpt
@@ -1,0 +1,56 @@
+--TEST--
+proc_open() with output socketpairs
+--FILE--
+<?php
+
+$cmd = [
+	getenv("TEST_PHP_EXECUTABLE"),
+	__DIR__ . '/proc_open_sockets1.inc'
+];
+
+$spec = [
+	['null'],
+	['socket'],
+	['socket']
+];
+
+$proc = proc_open($cmd, $spec, $pipes);
+
+foreach ($pipes as $pipe) {
+	var_dump(stream_set_blocking($pipe, false));
+}
+
+while ($pipes) {
+	$r = $pipes;
+	$w = null;
+	$e = null;
+	
+	if (!stream_select($r, $w, $e, null, 0)) {
+		throw new Error("Select failed");
+	}
+	
+	foreach ($r as $i => $pipe) {
+		if (!is_resource($pipe) || feof($pipe)) {
+			unset($pipes[$i]);
+			continue;
+		}
+		
+		$chunk = @fread($pipe, 8192);
+		
+		if ($chunk === false) {
+			throw new Error("Failed to read: " . (error_get_last()['message'] ?? 'N/A'));
+		}
+		
+		if ($chunk !== '') {
+			echo "PIPE {$i} << {$chunk}\n";
+		}
+	}
+}
+
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+PIPE 1 << hello
+PIPE 2 << SOME ERROR
+PIPE 1 << world

--- a/ext/standard/tests/general_functions/proc_open_sockets2.inc
+++ b/ext/standard/tests/general_functions/proc_open_sockets2.inc
@@ -1,0 +1,7 @@
+<?php
+
+echo "hello";
+sleep(1);
+echo "world";
+
+echo strtoupper(trim(fgets(STDIN)));

--- a/ext/standard/tests/general_functions/proc_open_sockets2.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets2.phpt
@@ -1,0 +1,67 @@
+--TEST--
+proc_open() with IO socketpairs
+--FILE--
+<?php
+
+function poll($pipe, $read = true)
+{
+	$r = ($read == true) ? [$pipe] : null;
+	$w = ($read == false) ? [$pipe] : null;
+	$e = null;
+	
+	if (!stream_select($r, $w, $e, null, 0)) {
+		throw new \Error("Select failed");
+	}
+}
+
+function read_pipe($pipe): string
+{
+	poll($pipe);
+	
+	if (false === ($chunk = @fread($pipe, 8192))) {
+		throw new Error("Failed to read: " . (error_get_last()['message'] ?? 'N/A'));
+	}
+	
+	return $chunk;
+}
+
+function write_pipe($pipe, $data)
+{
+	poll($pipe, false);
+	
+	if (false == @fwrite($pipe, $data)) {
+		throw new Error("Failed to write: " . (error_get_last()['message'] ?? 'N/A'));
+	}
+}
+
+$cmd = [
+	getenv("TEST_PHP_EXECUTABLE"),
+	__DIR__ . '/proc_open_sockets2.inc'
+];
+
+$spec = [
+	['socket'],
+	['socket']
+];
+
+$proc = proc_open($cmd, $spec, $pipes);
+
+foreach ($pipes as $pipe) {
+	var_dump(stream_set_blocking($pipe, false));
+}
+
+printf("STDOUT << %s\n", read_pipe($pipes[1]));
+printf("STDOUT << %s\n", read_pipe($pipes[1]));
+
+write_pipe($pipes[0], 'done');
+fclose($pipes[0]);
+
+printf("STDOUT << %s\n", read_pipe($pipes[1]));
+
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+STDOUT << hello
+STDOUT << world
+STDOUT << DONE

--- a/ext/standard/tests/general_functions/proc_open_sockets3.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets3.phpt
@@ -1,0 +1,55 @@
+--TEST--
+proc_open() with socket and pipe
+--FILE--
+<?php
+
+function poll($pipe, $read = true)
+{
+	$r = ($read == true) ? [$pipe] : null;
+	$w = ($read == false) ? [$pipe] : null;
+	$e = null;
+	
+	if (!stream_select($r, $w, $e, null, 0)) {
+		throw new \Error("Select failed");
+	}
+}
+
+function read_pipe($pipe): string
+{
+	poll($pipe);
+	
+	if (false === ($chunk = @fread($pipe, 8192))) {
+		throw new Error("Failed to read: " . (error_get_last()['message'] ?? 'N/A'));
+	}
+	
+	return $chunk;
+}
+
+$cmd = [
+	getenv("TEST_PHP_EXECUTABLE"),
+	__DIR__ . '/proc_open_sockets2.inc'
+];
+
+$spec = [
+	['pipe', 'r'],
+	['socket']
+];
+
+$proc = proc_open($cmd, $spec, $pipes);
+
+var_dump(stream_set_blocking(pipes[1], false));
+
+printf("STDOUT << %s\n", read_pipe($pipes[1]));
+printf("STDOUT << %s\n", read_pipe($pipes[1]));
+
+fwrite($pipes[0], 'done');
+fclose($pipes[0]);
+
+printf("STDOUT << %s\n", read_pipe($pipes[1]));
+
+?>
+--EXPECTF--
+bool(true)
+STDOUT << hello
+STDOUT << world
+STDOUT << DONE

--- a/ext/standard/tests/general_functions/proc_open_sockets3.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets3.phpt
@@ -37,7 +37,7 @@ $spec = [
 
 $proc = proc_open($cmd, $spec, $pipes);
 
-var_dump(stream_set_blocking(pipes[1], false));
+var_dump(stream_set_blocking($pipes[1], false));
 
 printf("STDOUT << %s\n", read_pipe($pipes[1]));
 printf("STDOUT << %s\n", read_pipe($pipes[1]));

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -257,6 +257,11 @@ static void detect_is_seekable(php_stdio_stream_data *self) {
 
 		self->is_seekable = !(file_type == FILE_TYPE_PIPE || file_type == FILE_TYPE_CHAR);
 		self->is_pipe = file_type == FILE_TYPE_PIPE;
+
+		/* Additional check needed to distinguish between pipes and sockets. */
+		if (self->is_pipe && !GetNamedPipeInfo((HANDLE) handle, NULL, NULL, NULL, NULL)) {
+			self->is_pipe = 0;
+		}
 	}
 #endif
 }

--- a/win32/sockets.c
+++ b/win32/sockets.c
@@ -24,34 +24,33 @@
 
 #include "php.h"
 
-PHPAPI int socketpair(int domain, int type, int protocol, SOCKET sock[2])
+PHPAPI int socketpair_win32(int domain, int type, int protocol, SOCKET sock[2], int overlapped)
 {
 	struct sockaddr_in address;
 	SOCKET redirect;
 	int size = sizeof(address);
 
-	if(domain != AF_INET) {
+	if (domain != AF_INET) {
 		WSASetLastError(WSAENOPROTOOPT);
 		return -1;
 	}
 
-	sock[0] = sock[1] = redirect = INVALID_SOCKET;
+	sock[1] = redirect = INVALID_SOCKET;
 
-
-	sock[0]	= socket(domain, type, protocol);
+	sock[0] = socket(domain, type, protocol);
 	if (INVALID_SOCKET == sock[0]) {
 		goto error;
 	}
 
 	address.sin_addr.s_addr	= INADDR_ANY;
-	address.sin_family	= AF_INET;
-	address.sin_port	= 0;
+	address.sin_family = AF_INET;
+	address.sin_port = 0;
 
-	if (bind(sock[0], (struct sockaddr*)&address, sizeof(address)) != 0) {
+	if (bind(sock[0], (struct sockaddr *) &address, sizeof(address)) != 0) {
 		goto error;
 	}
 
-	if(getsockname(sock[0], (struct sockaddr *)&address, &size) != 0) {
+	if (getsockname(sock[0], (struct sockaddr *) &address, &size) != 0) {
 		goto error;
 	}
 
@@ -59,17 +58,22 @@ PHPAPI int socketpair(int domain, int type, int protocol, SOCKET sock[2])
 		goto error;
 	}
 
-	sock[1] = socket(domain, type, protocol);
+	if (overlapped) {
+		sock[1] = socket(domain, type, protocol);
+	} else {
+		sock[1] = WSASocket(domain, type, protocol, NULL, 0, 0);
+	}
+
 	if (INVALID_SOCKET == sock[1]) {
 		goto error;
 	}
 
 	address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-	if(connect(sock[1], (struct sockaddr*)&address, sizeof(address)) != 0) {
+	if (connect(sock[1], (struct sockaddr *) &address, sizeof(address)) != 0) {
 		goto error;
 	}
 
-	redirect = accept(sock[0],(struct sockaddr*)&address, &size);
+	redirect = accept(sock[0], (struct sockaddr *) &address, &size);
 	if (INVALID_SOCKET == redirect) {
 		goto error;
 	}
@@ -85,4 +89,9 @@ error:
 	closesocket(sock[1]);
 	WSASetLastError(WSAECONNABORTED);
 	return -1;
+}
+
+PHPAPI int socketpair(int domain, int type, int protocol, SOCKET sock[2])
+{
+	return socketpair_win32(domain, type, protocol, sock, 1);
 }

--- a/win32/sockets.h
+++ b/win32/sockets.h
@@ -22,6 +22,7 @@
 #ifndef PHP_WIN32_SOCKETS_H
 #define PHP_WIN32_SOCKETS_H
 
+PHPAPI int socketpair_win32(int domain, int type, int protocol, SOCKET sock[2], int overlapped);
 PHPAPI int socketpair(int domain, int type, int protocol, SOCKET sock[2]);
 
 #endif


### PR DESCRIPTION
Adds support for socket pairs to `proc_open()`. This is a big improvement over pipes on Windows systems because sockets do support non-blocking mode and can participate in `stream_select()`. Async PHP frameworks like ReactPHP and Amp have a hard time supporting process spawning on Windows because the created process pipes cannot be polled for events and therefore cannot be integrated with an event loop. Another common problem on Windows is that reads from process pipes will block and it is not always possible to alternate between reading data from a child processes STDOUT / STDERR as it arrives. In some cases this leads to a deadlock situation where a read blocks on one of the pipes and the child process fills the other pipes buffer without a way to drain it. Some libraries (Symfony Process Component for example) try to work around this by redirecting output to files and doing redirection in a shell.

Most of these problems can easily be solved by using a pair of connected sockets. The process calling `prop_open()` retains one of the sockets, the other one is passed to the child process as a `HANDLE` on Windows. This works only if the underlying socket does not make use of Overlapped mode, which is the default if a socket is created using `socket()`. We can make use of `WSASocket()` instead and not pass the `WSA_FLAG_OVERLAPPED` flag to create a socket that does not make use of overlapped IO. The PR uses a (slightly) modified copy of the `socketpair()` function implementation found in `win32/sockets.c` to achieve this. The change to the function could also be applied to the original implementation instead. This could be a BC break (overlapped mode dropped) but PHP does not use overlapped socket IO anywhere internally.

```php
$spec = [
    0 => ['null'],
    1 => ['socket'], // ['pipe', 'w']
    2 => ['socket'] // ['pipe', 'w']
];

$proc = proc_open(['ping', 'github.com'], $spec, $pipes);

foreach ($pipes as $pipe) {
    var_dump(stream_set_blocking($pipe, false));
}

$buffers = array_fill_keys(array_keys($pipes), '');

while ($pipes) {
    $r = $pipes;
    $w = null;
    $e = null;

    if (!stream_select($r, $w, $e, null, 0)) {
        throw new \Error("Select failed");
    }
    
    foreach ($r as $i => $pipe) {
        if (!is_resource($pipe) || feof($pipe)) {
            $line = trim($buffers[$i]);
            
            if ($line !== '') {
                echo "PIPE {$i} << {$line}\n";
            }
            
            echo "DROP pipe {$i}\n";
            unset($pipes[$i]);
            continue;
        }
        
        $chunk = @fread($pipe, 8192);
        
        if ($chunk === false) {
            throw new \Error("Failed to read: " . (error_get_last()['message'] ?? 'N/A'));
        }
        
        $buffers[$i] .= $chunk;
        
        if (false !== strpos($buffers[$i], "\n")) {
            $lines = array_map('trim', explode("\n", $buffers[$i]));
            $buffers[$i] = array_pop($lines);
            
            foreach ($lines as $line) {
                echo "PIPE {$i} << {$line}\n";
            }
        }
    }
}
```
The example demonstrates the use of socketpairs with a spawned process. It will show "realtime" data on Windows if sockets are used. If I use pipes instead it will block after the first read and then echo the remaining output once the `ping` process has finished. This approach might not work for every process but since use of sockets is an opt-in behavior ist should not break any existing code.