### PR TITLE
Improve "VirtualProtect() failed" error messages

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3545,7 +3545,7 @@ ZEND_EXT_API void zend_jit_unprotect(void)
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_READWRITE, &old)) {
 			DWORD err = GetLastError();
 			char *msg = php_win32_error_to_msg(err);
-			fprintf(stderr, "VirtualProtect() failed [%d] %s\n", err, msg);
+			fprintf(stderr, "VirtualProtect() failed [%u] %s\n", err, msg);
 			php_win32_error_msg_free(msg);
 		}
 	}
@@ -3567,7 +3567,7 @@ ZEND_EXT_API void zend_jit_protect(void)
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_EXECUTE_READ, &old)) {
 			DWORD err = GetLastError();
 			char *msg = php_win32_error_to_msg(err);
-			fprintf(stderr, "VirtualProtect() failed [%d] %s\n", err, msg);
+			fprintf(stderr, "VirtualProtect() failed [%u] %s\n", err, msg);
 			php_win32_error_msg_free(msg);
 		}
 	}
@@ -3783,7 +3783,7 @@ ZEND_EXT_API int zend_jit_startup(void *buf, size_t size, zend_bool reattached)
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_EXECUTE_READWRITE, &old)) {
 			DWORD err = GetLastError();
 			char *msg = php_win32_error_to_msg(err);
-			fprintf(stderr, "VirtualProtect() failed [%d] %s\n", err, msg);
+			fprintf(stderr, "VirtualProtect() failed [%u] %s\n", err, msg);
 			php_win32_error_msg_free(msg);
 		}
 	} else {
@@ -3792,7 +3792,7 @@ ZEND_EXT_API int zend_jit_startup(void *buf, size_t size, zend_bool reattached)
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_EXECUTE_READ, &old)) {
 			DWORD err = GetLastError();
 			char *msg = php_win32_error_to_msg(err);
-			fprintf(stderr, "VirtualProtect() failed [%d] %s\n", err, msg);
+			fprintf(stderr, "VirtualProtect() failed [%u] %s\n", err, msg);
 			php_win32_error_msg_free(msg);
 		}
 	}

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3543,7 +3543,10 @@ ZEND_EXT_API void zend_jit_unprotect(void)
 		DWORD old;
 
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_READWRITE, &old)) {
-			fprintf(stderr, "VirtualProtect() failed\n");
+			DWORD err = GetLastError();
+			char *msg = php_win32_error_to_msg(err);
+			fprintf(stderr, "VirtualProtect() failed [%d] %s\n", err, msg);
+			php_win32_error_msg_free(msg);
 		}
 	}
 #endif
@@ -3562,7 +3565,10 @@ ZEND_EXT_API void zend_jit_protect(void)
 		DWORD old;
 
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_EXECUTE_READ, &old)) {
-			fprintf(stderr, "VirtualProtect() failed\n");
+			DWORD err = GetLastError();
+			char *msg = php_win32_error_to_msg(err);
+			fprintf(stderr, "VirtualProtect() failed [%d] %s\n", err, msg);
+			php_win32_error_msg_free(msg);
 		}
 	}
 #endif
@@ -3775,13 +3781,19 @@ ZEND_EXT_API int zend_jit_startup(void *buf, size_t size, zend_bool reattached)
 		DWORD old;
 
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_EXECUTE_READWRITE, &old)) {
-			fprintf(stderr, "VirtualProtect() failed\n");
+			DWORD err = GetLastError();
+			char *msg = php_win32_error_to_msg(err);
+			fprintf(stderr, "VirtualProtect() failed [%d] %s\n", err, msg);
+			php_win32_error_msg_free(msg);
 		}
 	} else {
 		DWORD old;
 
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_EXECUTE_READ, &old)) {
-			fprintf(stderr, "VirtualProtect() failed\n");
+			DWORD err = GetLastError();
+			char *msg = php_win32_error_to_msg(err);
+			fprintf(stderr, "VirtualProtect() failed [%d] %s\n", err, msg);
+			php_win32_error_msg_free(msg);
 		}
 	}
 #endif


### PR DESCRIPTION
When `mprotect()` fails, the error message contains `errno` and the
respective `strerror()`; we add basically the same info on Windows.