### PR TITLE
added ldap_count_references()

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -711,6 +711,10 @@ PHP 8.0 UPGRADE NOTES
   . Added get_resource_id($resource) function, which returns the same value as
     (int) $resource. It provides the same functionality under a clearer API.
 
+- LDAP:
+  . Added ldap_count_references(), which returns the number of reference
+    messages in a search result.
+
 - OpenSSL:
   . Added openssl_cms_encrypt() encrypts the message in the file with the
     certificates and outputs the result to the supplied file.

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -3464,6 +3464,30 @@ PHP_FUNCTION(ldap_parse_exop)
 #endif
 /* }}} */
 
+/* {{{ proto int ldap_count_references(resource link, resource result)
+   Count the number of references in a search result */
+PHP_FUNCTION(ldap_count_references)
+{
+	zval *link, *result;
+	ldap_linkdata *ld;
+	LDAPMessage *ldap_result;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rr", &link, &result) != SUCCESS) {
+		RETURN_THROWS();
+	}
+
+	if ((ld = (ldap_linkdata *)zend_fetch_resource(Z_RES_P(link), "ldap link", le_link)) == NULL) {
+		RETURN_THROWS();
+	}
+
+	if ((ldap_result = (LDAPMessage *)zend_fetch_resource(Z_RES_P(result), "ldap result", le_result)) == NULL) {
+		RETURN_THROWS();
+	}
+
+	RETURN_LONG(ldap_count_references(ld->link, ldap_result));
+}
+/* }}} */
+
 /* {{{ proto resource ldap_first_reference(resource link, resource result)
    Return first reference */
 PHP_FUNCTION(ldap_first_reference)

--- a/ext/ldap/ldap.stub.php
+++ b/ext/ldap/ldap.stub.php
@@ -227,6 +227,12 @@ function ldap_get_option($link_identifier, int $option, &$retval = null): bool {
 function ldap_set_option($link_identifier, int $option, $newval): bool {}
 
 /**
+ * @param resource $link_identifier
+ * @param resource $result_identifier
+ */
+function ldap_count_references($link_identifier, $result_identifier): int {}
+
+/**
  * @param resource $link
  * @param resource $result
  * @return resource|false

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c9ce0e98ab386130b6332ae017808bec67b1cd07 */
+ * Stub hash: 63d7fc9e11bd2821a77f6ee709ceaf1fdcbf190e */
 
 #if defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ldap_connect, 0, 0, 0)
@@ -244,6 +244,13 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_count_references, 0, 2, IS_LONG, 0)
+	ZEND_ARG_INFO(0, link_identifier)
+	ZEND_ARG_INFO(0, result_identifier)
+ZEND_END_ARG_INFO()
+#endif
+
+#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ldap_first_reference, 0, 0, 2)
 	ZEND_ARG_INFO(0, link)
 	ZEND_ARG_INFO(0, result)
@@ -412,6 +419,9 @@ ZEND_FUNCTION(ldap_get_option);
 ZEND_FUNCTION(ldap_set_option);
 #endif
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
+ZEND_FUNCTION(ldap_count_references);
+#endif
+#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_FUNCTION(ldap_first_reference);
 #endif
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
@@ -516,6 +526,9 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 	ZEND_FE(ldap_set_option, arginfo_ldap_set_option)
+#endif
+#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
+	ZEND_FE(ldap_count_references, arginfo_ldap_count_references)
 #endif
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 	ZEND_FE(ldap_first_reference, arginfo_ldap_first_reference)

--- a/ext/ldap/tests/ldap_count_references_basic.phpt
+++ b/ext/ldap/tests/ldap_count_references_basic.phpt
@@ -1,0 +1,36 @@
+--TEST--
+ldap_count_references() - Basic ldap_count_references test
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+<?php require_once('skipifbindfailure.inc'); ?>
+--FILE--
+<?php
+require "connect.inc";
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+insert_dummy_data($link, $base);
+ldap_add($link, "cn=userref,$base", array(
+        "objectClass" => array("extensibleObject", "referral"),
+        "cn" => "userref",
+        "ref" => "cn=userA,$base",
+));
+ldap_add($link, "cn=userref2,$base", array(
+        "objectClass" => array("extensibleObject", "referral"),
+        "cn" => "userref2",
+        "ref" => "cn=userB,$base",
+));
+ldap_set_option($link, LDAP_OPT_DEREF, LDAP_DEREF_NEVER);
+$result = ldap_search($link, "$base", "(cn=*)");
+var_dump(ldap_count_references($link, $result));
+?>
+--CLEAN--
+<?php
+include "connect.inc";
+
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+// Referral can only be removed with Manage DSA IT Control
+ldap_delete($link, "cn=userref,$base", [['oid' => LDAP_CONTROL_MANAGEDSAIT, 'iscritical' => TRUE]]);
+ldap_delete($link, "cn=userref2,$base", [['oid' => LDAP_CONTROL_MANAGEDSAIT, 'iscritical' => TRUE]]);
+remove_dummy_data($link, $base);
+?>
+--EXPECTF--
+int(2)


### PR DESCRIPTION
Implemented ``ldap_count_references()`` for symmetry with ``ldap_count_entries()``. This is actually just a copy-paste.

Test:

```console
ptomulik@tea:$ LDAP_TEST_HOST=172.25.0.2 LDAP_TEST_BASE="dc=example,dc=org" LDAP_TEST_USER='cn=admin,dc=example,dc=org' LDAP_TEST_PASSWD='admin' sapi/cli/php ./run-tests.php ext/ldap/tests/ldap_count_references_basic.phpt 

=====================================================================
PHP         : /home/ptomulik/sources/php-src/sapi/cli/php 
PHP_SAPI    : cli
PHP_VERSION : 8.0.0-dev
ZEND_VERSION: 4.0.0-dev
PHP_OS      : Linux - Linux tea 5.6.0-2-amd64 #1 SMP Debian 5.6.14-2 (2020-06-09) x86_64
INI actual  : /home/ptomulik/sources/php-src
More .INIs  :   
---------------------------------------------------------------------
PHP         : /home/ptomulik/sources/php-src/sapi/phpdbg/phpdbg 
PHP_SAPI    : phpdbg
PHP_VERSION : 8.0.0-dev
ZEND_VERSION: 4.0.0-dev
PHP_OS      : Linux - Linux tea 5.6.0-2-amd64 #1 SMP Debian 5.6.14-2 (2020-06-09) x86_64
INI actual  : /home/ptomulik/sources/php-src
More .INIs  : 
---------------------------------------------------------------------
CWD         : /home/ptomulik/sources/php-src
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
Running selected tests.
PASS ldap_count_references() - Basic ldap_count_references test [ext/ldap/tests/ldap_count_references_basic.phpt] 
=====================================================================
Number of tests :    1                 1
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :    1 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    1 seconds
=====================================================================
```