### PR TITLE
Fix ldap memory bugs for PHP 7.3 (fix: #79773)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ addons:
     packages:
       - locales
       - language-pack-de
+      - ldap-utils
+      - openssl
+      - slapd
       - re2c
       - libgmp-dev
       - libicu-dev
+      - libldap2-dev
       - libtidy-dev
       - libenchant-dev
       - libaspell-dev
@@ -64,6 +68,7 @@ before_script:
     - . ./travis/ext/pdo_mysql/setup.sh
     - . ./travis/ext/pgsql/setup.sh
     - . ./travis/ext/pdo_pgsql/setup.sh
+    - . ./travis/ext/ldap/setup.sh
 
 # Run PHPs run-tests.php
 script:

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -283,7 +283,8 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 	int control_iscritical = 0, rc = LDAP_SUCCESS;
 	char** ldap_attrs = NULL;
 	LDAPSortKey** sort_keys = NULL;
-	zend_string *tmpstring = NULL;
+	zend_string *tmpstring = NULL, **tmpstrings1 = NULL, **tmpstrings2 = NULL;
+	int num_tmpstrings1 = 0, num_tmpstrings2 = 0;
 
 	if ((val = zend_hash_str_find(Z_ARRVAL_P(array), "oid", sizeof("oid") - 1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Control must have an oid key");
@@ -418,6 +419,8 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 
 					num_attribs = zend_hash_num_elements(Z_ARRVAL_P(tmp));
 					ldap_attrs = safe_emalloc((num_attribs+1), sizeof(char *), 0);
+					tmpstrings1 = safe_emalloc(num_attribs, sizeof(zend_string*), 0);
+					num_tmpstrings1 = 0;
 
 					for (i = 0; i<num_attribs; i++) {
 						if ((attr = zend_hash_index_find(Z_ARRVAL_P(tmp), i)) == NULL) {
@@ -426,16 +429,13 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 							goto failure;
 						}
 
-						if (tmpstring) {
-							zend_string_release(tmpstring);
-						}
-
-						tmpstring = zval_get_string(attr);
+						tmpstrings1[num_tmpstrings1] = zval_get_string(attr);
+						++num_tmpstrings1;
 						if (EG(exception)) {
 							rc = -1;
 							goto failure;
 						}
-						ldap_attrs[i] = ZSTR_VAL(tmpstring);
+						ldap_attrs[i] = ZSTR_VAL(tmpstrings1[num_tmpstrings1-1]);
 					}
 					ldap_attrs[num_attribs] = NULL;
 
@@ -460,6 +460,10 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 
 			num_keys = zend_hash_num_elements(Z_ARRVAL_P(val));
 			sort_keys = safe_emalloc((num_keys+1), sizeof(LDAPSortKey*), 0);
+			tmpstrings1 = safe_emalloc(num_keys, sizeof(zend_string*), 0);
+			tmpstrings2 = safe_emalloc(num_keys, sizeof(zend_string*), 0);
+			num_tmpstrings1 = 0;
+			num_tmpstrings2 = 0;
 
 			for (i = 0; i<num_keys; i++) {
 				if ((sortkey = zend_hash_index_find(Z_ARRVAL_P(val), i)) == NULL) {
@@ -474,26 +478,22 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 					goto failure;
 				}
 				sort_keys[i] = emalloc(sizeof(LDAPSortKey));
-				if (tmpstring) {
-					zend_string_release(tmpstring);
-				}
-				tmpstring = zval_get_string(tmp);
+				tmpstrings1[num_tmpstrings1] = zval_get_string(tmp);
+				++num_tmpstrings1;
 				if (EG(exception)) {
 					rc = -1;
 					goto failure;
 				}
-				sort_keys[i]->attributeType = ZSTR_VAL(tmpstring);
+				sort_keys[i]->attributeType = ZSTR_VAL(tmpstrings1[num_tmpstrings1 - 1]);
 
 				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(sortkey), "oid", sizeof("oid") - 1)) != NULL) {
-					if (tmpstring) {
-						zend_string_release(tmpstring);
-					}
-					tmpstring = zval_get_string(tmp);
+					tmpstrings2[num_tmpstrings2] = zval_get_string(tmp);
+					++num_tmpstrings2;
 					if (EG(exception)) {
 						rc = -1;
 						goto failure;
 					}
-					sort_keys[i]->orderingRule = ZSTR_VAL(tmpstring);
+					sort_keys[i]->orderingRule = ZSTR_VAL(tmpstrings2[num_tmpstrings2 - 1]);
 				} else {
 					sort_keys[i]->orderingRule = NULL;
 				}
@@ -599,6 +599,24 @@ failure:
 	zend_string_release(control_oid);
 	if (tmpstring != NULL) {
 		zend_string_release(tmpstring);
+	}
+	if (tmpstrings1 != NULL) {
+		int i;
+		for (i = 0; i < num_tmpstrings1; ++i) {
+			if (tmpstrings1[i] != NULL) {
+				zend_string_release(tmpstrings1[i]);
+			}
+		}
+		efree(tmpstrings1);
+	}
+	if (tmpstrings2 != NULL) {
+		int i;
+		for (i = 0; i < num_tmpstrings2; ++i) {
+			if (tmpstrings2[i] != NULL) {
+				zend_string_release(tmpstrings2[i]);
+			}
+		}
+		efree(tmpstrings2);
 	}
 	if (control_value != NULL) {
 		ber_memfree(control_value);

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -284,7 +284,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 	char** ldap_attrs = NULL;
 	LDAPSortKey** sort_keys = NULL;
 	zend_string *tmpstring = NULL, **tmpstrings1 = NULL, **tmpstrings2 = NULL;
-	int num_tmpstrings1 = 0, num_tmpstrings2 = 0;
+	size_t num_tmpstrings1 = 0, num_tmpstrings2 = 0;
 
 	if ((val = zend_hash_str_find(Z_ARRVAL_P(array), "oid", sizeof("oid") - 1)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Control must have an oid key");
@@ -430,12 +430,12 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 						}
 
 						tmpstrings1[num_tmpstrings1] = zval_get_string(attr);
-						++num_tmpstrings1;
 						if (EG(exception)) {
 							rc = -1;
 							goto failure;
 						}
-						ldap_attrs[i] = ZSTR_VAL(tmpstrings1[num_tmpstrings1-1]);
+						ldap_attrs[i] = ZSTR_VAL(tmpstrings1[num_tmpstrings1]);
+						++num_tmpstrings1;
 					}
 					ldap_attrs[num_attribs] = NULL;
 
@@ -479,21 +479,21 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				}
 				sort_keys[i] = emalloc(sizeof(LDAPSortKey));
 				tmpstrings1[num_tmpstrings1] = zval_get_string(tmp);
-				++num_tmpstrings1;
 				if (EG(exception)) {
 					rc = -1;
 					goto failure;
 				}
-				sort_keys[i]->attributeType = ZSTR_VAL(tmpstrings1[num_tmpstrings1 - 1]);
+				sort_keys[i]->attributeType = ZSTR_VAL(tmpstrings1[num_tmpstrings1]);
+				++num_tmpstrings1;
 
 				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(sortkey), "oid", sizeof("oid") - 1)) != NULL) {
 					tmpstrings2[num_tmpstrings2] = zval_get_string(tmp);
-					++num_tmpstrings2;
 					if (EG(exception)) {
 						rc = -1;
 						goto failure;
 					}
-					sort_keys[i]->orderingRule = ZSTR_VAL(tmpstrings2[num_tmpstrings2 - 1]);
+					sort_keys[i]->orderingRule = ZSTR_VAL(tmpstrings2[num_tmpstrings2]);
+					++num_tmpstrings2;
 				} else {
 					sort_keys[i]->orderingRule = NULL;
 				}
@@ -603,18 +603,14 @@ failure:
 	if (tmpstrings1 != NULL) {
 		int i;
 		for (i = 0; i < num_tmpstrings1; ++i) {
-			if (tmpstrings1[i] != NULL) {
-				zend_string_release(tmpstrings1[i]);
-			}
+            zend_string_release(tmpstrings1[i]);
 		}
 		efree(tmpstrings1);
 	}
 	if (tmpstrings2 != NULL) {
 		int i;
 		for (i = 0; i < num_tmpstrings2; ++i) {
-			if (tmpstrings2[i] != NULL) {
-				zend_string_release(tmpstrings2[i]);
-			}
+	        zend_string_release(tmpstrings2[i]);
 		}
 		efree(tmpstrings2);
 	}

--- a/ext/ldap/tests/connect.inc
+++ b/ext/ldap/tests/connect.inc
@@ -5,14 +5,15 @@ Default values are "localhost", "cn=Manager,dc=my-domain,dc=com", and password "
 Change the LDAP_TEST_* environment values if you want to use another configuration.
 */
 
-$host			= getenv("LDAP_TEST_HOST")	? getenv("LDAP_TEST_HOST")	: "localhost";
-$port			= getenv("LDAP_TEST_PORT")	? getenv("LDAP_TEST_PORT")	: 389;
-$base			= getenv("LDAP_TEST_BASE")	? getenv("LDAP_TEST_BASE")	: "dc=my-domain,dc=com";
-$user			= getenv("LDAP_TEST_USER")	? getenv("LDAP_TEST_USER")	: "cn=Manager,$base";
-$sasl_user		= getenv("LDAP_TEST_SASL_USER")	? getenv("LDAP_TEST_SASL_USER")	: "Manager";
-$passwd			= getenv("LDAP_TEST_PASSWD")	? getenv("LDAP_TEST_PASSWD")	: "secret";
-$protocol_version	= getenv("LDAP_TEST_OPT_PROTOCOL_VERSION")	? getenv("LDAP_TEST_OPT_PROTOCOL_VERSION")	: 3;
-$skip_on_bind_failure	= getenv("LDAP_TEST_SKIP_BIND_FAILURE") ? getenv("LDAP_TEST_SKIP_BIND_FAILURE") : true;
+$host           = getenv("LDAP_TEST_HOST")  ?: "localhost";
+$port           = getenv("LDAP_TEST_PORT")  ?: 389;
+$base           = getenv("LDAP_TEST_BASE")  ?: "dc=my-domain,dc=com";
+$user           = getenv("LDAP_TEST_USER")  ?: "cn=Manager,$base";
+$passwd         = getenv("LDAP_TEST_PASSWD")    ?: "secret";
+$sasl_user      = getenv("LDAP_TEST_SASL_USER") ?: "userA";
+$sasl_passwd    = getenv("LDAP_TEST_SASL_PASSWD")   ?: "oops";
+$protocol_version   = getenv("LDAP_TEST_OPT_PROTOCOL_VERSION")  ?: 3;
+$skip_on_bind_failure   = getenv("LDAP_TEST_SKIP_BIND_FAILURE") ?: true;
 
 function ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version) {
 	$link = ldap_connect($host, $port);

--- a/ext/ldap/tests/ldap_sasl_bind_basic.phpt
+++ b/ext/ldap/tests/ldap_sasl_bind_basic.phpt
@@ -17,11 +17,22 @@ Patrick Allaert <patrickallaert@php.net>
 <?php
 require "connect.inc";
 
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+insert_dummy_data($link, $base);
+ldap_unbind($link);
+
 $link = ldap_connect($host, $port);
 ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
-var_dump(ldap_sasl_bind($link, null, $passwd, 'DIGEST-MD5', 'realm', $sasl_user));
+var_dump(ldap_sasl_bind($link, null, $sasl_passwd, 'DIGEST-MD5', 'realm', $sasl_user));
 ?>
 ===DONE===
+--CLEAN--
+<?php
+include "connect.inc";
+
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+remove_dummy_data($link, $base);
+?>
 --EXPECT--
 bool(true)
 ===DONE===

--- a/ext/ldap/tests/ldap_sasl_bind_error.phpt
+++ b/ext/ldap/tests/ldap_sasl_bind_error.phpt
@@ -11,6 +11,10 @@ Patrick Allaert <patrickallaert@php.net>
 <?php
 require "connect.inc";
 
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+insert_dummy_data($link, $base);
+ldap_unbind($link);
+
 $link = ldap_connect($host, $port);
 ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
 
@@ -18,20 +22,27 @@ ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
 var_dump(ldap_sasl_bind());
 
 // Invalid DN
-var_dump(ldap_sasl_bind($link, "Invalid DN", $passwd, 'DIGEST-MD5', 'realm', $sasl_user));
+var_dump(ldap_sasl_bind($link, "Invalid DN", $sasl_passwd, 'DIGEST-MD5', 'realm', $sasl_user));
 
 // Invalid user
-var_dump(ldap_sasl_bind($link, null, "ThisIsNotCorrect$passwd", 'DIGEST-MD5', "realm", "invalid$sasl_user"));
+var_dump(ldap_sasl_bind($link, null, "ThisIsNotCorrect$sasl_passwd", 'DIGEST-MD5', "realm", "invalid$sasl_user"));
 
 // Invalid password
-var_dump(ldap_sasl_bind($link, null, "ThisIsNotCorrect$passwd", 'DIGEST-MD5', "realm", $sasl_user));
+var_dump(ldap_sasl_bind($link, null, "ThisIsNotCorrect$sasl_passwd", 'DIGEST-MD5', "realm", $sasl_user));
 
-var_dump(ldap_sasl_bind($link, null, $passwd, 'DIGEST-MD5', "realm", "Manager", "test"));
+var_dump(ldap_sasl_bind($link, null, $sasl_passwd, 'DIGEST-MD5', "realm", "Manager", "test"));
 
 // Invalid DN syntax
-var_dump(ldap_sasl_bind($link, "unexistingProperty=weirdValue,$user", $passwd));
+var_dump(ldap_sasl_bind($link, "unexistingProperty=weirdValue,$user", $sasl_passwd));
 ?>
 ===DONE===
+--CLEAN--
+<?php
+include "connect.inc";
+
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+remove_dummy_data($link, $base);
+?>
 --EXPECTF--
 Warning: ldap_sasl_bind() expects at least 1 parameter, 0 given in %s on line %d
 bool(false)

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -77,6 +77,8 @@ $TS \
 --with-kerberos \
 --enable-sysvmsg \
 --enable-zend-test=shared \
+--with-ldap \
+--with-ldap-sasl \
 > "$CONFIG_LOG_FILE"
 
 make "-j${MAKE_JOBS}" $MAKE_QUIET > "$MAKE_LOG_FILE"

--- a/travis/ext/ldap/setup.sh
+++ b/travis/ext/ldap/setup.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+# Create TLS certificate
+sudo mkdir -p /etc/ldap/ssl
+sudo chown -R "`id -u -n`:`id -g -n`" /etc/ldap/ssl
+
+alt_names() {
+  (
+      (
+        (hostname && hostname -a && hostname -A && hostname -f) |
+        xargs -n 1 |
+        sort -u |
+        sed -e 's/\(\S\+\)/DNS:\1/g'
+      ) && (
+        (hostname -i && hostname -I && echo "127.0.0.1 ::1") |
+        xargs -n 1 |
+        sort -u |
+        sed -e 's/\(\S\+\)/IP:\1/g'
+      )
+  ) | paste -d, -s
+}
+
+req_config() {
+  cat << EOF
+[req]
+prompt = no
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+
+[req_distinguished_name]
+countryName = US
+stateOrProvinceName = CA
+localityName = Los Angeles
+organizationName = PHP
+commonName = localhost
+
+[v3_ca]
+subjectAltName=`alt_names`
+EOF
+}
+
+openssl req -newkey rsa:4096 -x509 -nodes -days 3650 \
+  -out /etc/ldap/ssl/server.crt -keyout /etc/ldap/ssl/server.key \
+  -config <( req_config )
+
+sudo chown -R openldap:openldap /etc/ldap/ssl
+
+# Display the TLS certificate (should be world readable)
+openssl x509 -noout -text -in /etc/ldap/ssl/server.crt
+
+# Point to the certificate generated
+if ! grep -q 'TLS_CACERT \/etc\/ldap\/ssl\/server.crt' /etc/ldap/ldap.conf; then
+  sudo sed -e 's|^\s*TLS_CACERT|# TLS_CACERT|' -i /etc/ldap/ldap.conf
+  echo 'TLS_CACERT /etc/ldap/ssl/server.crt' | sudo tee -a /etc/ldap/ldap.conf
+fi
+
+# Configure LDAP protocols to serve.
+sudo sed -e 's|^\s*SLAPD_SERVICES\s*=.*$|SLAPD_SERVICES="ldap:/// ldaps:/// ldapi:///"|' -i /etc/default/slapd
+
+# Configure LDAP database.
+DBDN=`sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=config '(&(olcRootDN=*)(olcSuffix=*))' dn | grep -i '^dn:' | sed -e 's/^dn:\s*//'`;
+
+sudo ldapadd -Q -Y EXTERNAL -H ldapi:/// -f /etc/ldap/schema/ppolicy.ldif
+
+sudo service slapd restart
+
+sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// << EOF
+dn: $DBDN
+changetype: modify
+replace: olcSuffix
+olcSuffix: dc=my-domain,dc=com
+-
+replace: olcRootDN
+olcRootDN: cn=Manager,dc=my-domain,dc=com
+-
+replace: olcRootPW
+olcRootPW: secret
+
+dn: cn=config
+changetype: modify
+add: olcTLSCACertificateFile
+olcTLSCACertificateFile: /etc/ldap/ssl/server.crt
+-
+add: olcTLSCertificateFile
+olcTLSCertificateFile: /etc/ldap/ssl/server.crt
+-
+add: olcTLSCertificateKeyFile
+olcTLSCertificateKeyFile: /etc/ldap/ssl/server.key
+-
+add: olcTLSVerifyClient
+olcTLSVerifyClient: never
+-
+add: olcAuthzRegexp
+olcAuthzRegexp: uid=usera,cn=digest-md5,cn=auth cn=usera,dc=my-domain,dc=com
+-
+replace: olcLogLevel
+olcLogLevel: -1
+
+dn: cn=module{0},cn=config
+changetype: modify
+add: olcModuleLoad
+olcModuleLoad: sssvlv
+-
+add: olcModuleLoad
+olcModuleLoad: ppolicy
+-
+add: olcModuleLoad
+olcModuleLoad: dds
+EOF
+
+sudo service slapd restart
+
+sudo ldapadd -Q -Y EXTERNAL -H ldapi:/// << EOF
+dn: olcOverlay=sssvlv,$DBDN
+objectClass: olcOverlayConfig
+objectClass: olcSssVlvConfig
+olcOverlay: sssvlv
+olcSssVlvMax: 10
+olcSssVlvMaxKeys: 5
+
+dn: olcOverlay=ppolicy,$DBDN
+objectClass: olcOverlayConfig
+objectClass: olcPPolicyConfig
+olcOverlay: ppolicy
+### This would clutter our DIT and make tests to fail, while ppolicy does not
+### seem to work as we expect (it does not seem to provide expected controls)
+## olcPPolicyDefault: cn=default,ou=pwpolicies,dc=my-domain,dc=com
+## olcPPolicyHashCleartext: FALSE
+## olcPPolicyUseLockout: TRUE
+
+dn: olcOverlay=dds,$DBDN
+objectClass: olcOverlayConfig
+objectClass: olcDdsConfig
+olcOverlay: dds
+EOF
+
+sudo service slapd restart
+
+sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// << EOF
+dn: $DBDN
+changetype: modify
+add: olcDbIndex
+olcDbIndex: entryExpireTimestamp eq
+EOF
+
+sudo service slapd restart
+
+ldapadd -H ldapi:/// -D cn=Manager,dc=my-domain,dc=com -w secret <<EOF
+dn: dc=my-domain,dc=com
+objectClass: top
+objectClass: organization
+objectClass: dcObject
+dc: my-domain
+o: php ldap tests
+
+### This would clutter our DIT and make tests to fail, while ppolicy does not
+### seem to work as we expect (it does not seem to provide expected controls)
+## dn: ou=pwpolicies,dc=my-domain,dc=com
+## objectClass: top
+## objectClass: organizationalUnit
+## ou: pwpolicies
+##
+## dn: cn=default,ou=pwpolicies,dc=my-domain,dc=com
+## objectClass: top
+## objectClass: person
+## objectClass: pwdPolicy
+## cn: default
+## sn: default
+## pwdAttribute: userPassword
+## pwdMaxAge: 2592000
+## pwdExpireWarning: 3600
+## #pwdInHistory: 0
+## pwdCheckQuality: 0
+## pwdMaxFailure: 5
+## pwdLockout: TRUE
+## #pwdLockoutDuration: 0
+## #pwdGraceAuthNLimit: 0
+## #pwdFailureCountInterval: 0
+## pwdMustChange: FALSE
+## pwdMinLength: 3
+## pwdAllowUserChange: TRUE
+## pwdSafeModify: FALSE
+EOF
+
+# Verify TLS connection
+
+ldapsearch -d 255 -H ldaps://localhost -D cn=Manager,dc=my-domain,dc=com -w secret -s base -b dc=my-domain,dc=com 'objectclass=*'


### PR DESCRIPTION
This PR enables ``ext/ldap/tests`` on travis and fixes some ldap memory bugs as described in [#79773](https://bugs.php.net/bug.php?id=79773).