### PR TITLE
Add README for ext/mysqli tests

### DIFF
--- a/ext/mysqli/tests/README.md
+++ b/ext/mysqli/tests/README.md
@@ -5,7 +5,7 @@ To run the tests, a test database must be created in the MySQL command-line:
 CREATE DATABASE 'test';
 ```
 
-There are default values for `MYSQL_TEST_HOST`, `MYSQL_TEST_USER`, `MYSQL_TEST_DB` and `MYSQL_TEST_PASSWD`. If your values differ from the defaults, then environment variables must be set.
+The test suite will create the necessary tables for testing, and then delete them when testing is complete. Creating a dedicated table prior to running the tests is unnecessary. There are default values for `MYSQL_TEST_HOST`, `MYSQL_TEST_USER`, `MYSQL_TEST_DB` and `MYSQL_TEST_PASSWD`. If your values differ from the defaults, then environment variables must be set.
 
 ```bash
 # Database host

--- a/ext/mysqli/tests/README.md
+++ b/ext/mysqli/tests/README.md
@@ -1,6 +1,11 @@
 # The mysqli extension tests
 
-There are default values for `MYSQL_TEST_HOST`, `MYSQL_TEST_USER`, `MYSQL_TEST_DB` and `MYSQL_TEST_PASSWD`. If your values differ from the defaults, then the environment variables must be set.
+To run the tests, a test database must be created in the MySQL command-line:  
+```sql
+CREATE DATABASE 'test';
+```
+
+There are default values for `MYSQL_TEST_HOST`, `MYSQL_TEST_USER`, `MYSQL_TEST_DB` and `MYSQL_TEST_PASSWD`. If your values differ from the defaults, then environment variables must be set.
 
 ```bash
 # Database host

--- a/ext/mysqli/tests/README.md
+++ b/ext/mysqli/tests/README.md
@@ -1,0 +1,34 @@
+# The mysqli extension tests
+
+There are default values for `MYSQL_TEST_HOST`, `MYSQL_TEST_USER`, `MYSQL_TEST_DB` and `MYSQL_TEST_PASSWD`. If your values differ from the defaults, then the environment variables must be set.
+
+```bash
+# Database host
+# Default: localhost
+MYSQL_TEST_HOST
+
+# Database port
+MYSQL_TEST_PORT
+
+# Database user
+# Default: root
+MYSQL_TEST_USER
+
+# Database user password
+# The default password is empty (no password).
+MYSQL_TEST_PASSWD
+
+# Database name
+# Default: test
+MYSQL_TEST_DB
+
+# Storage engine to use
+MYSQL_TEST_ENGINE
+
+# Database server socket
+MYSQL_TEST_SOCKET
+```
+
+## MySQL User Permissions
+
+The MySQL user used to run the tests must have full permissions on the test database.

--- a/ext/mysqli/tests/README.md
+++ b/ext/mysqli/tests/README.md
@@ -2,7 +2,7 @@
 
 To run the tests, a test database must be created in the MySQL command-line:  
 ```sql
-CREATE DATABASE 'test';
+CREATE DATABASE test;
 ```
 
 The test suite will create the necessary tables for testing, and then delete them when testing is complete. Creating a dedicated table prior to running the tests is unnecessary. There are default values for `MYSQL_TEST_HOST`, `MYSQL_TEST_USER`, `MYSQL_TEST_DB` and `MYSQL_TEST_PASSWD`. If your values differ from the defaults, then environment variables must be set.


### PR DESCRIPTION
I created a readme file to explain what's necessary to run the ext/mysqli tests. I used the [pdo_mysql README](https://github.com/php/php-src/blob/master/ext/pdo_mysql/tests/README.md) as a rough example to write this.

I'm unsure if the statement
> The MySQL user used to run the tests must have full permissions on the test database.

is accurate with ext/mysqli. I'm guessing that the statement is correct, given that a database and test user are required to run the tests. If I'm wrong, please correct me.