### PR TITLE
Track JIT successes and failures for opcache_get_status

### DIFF
--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -117,6 +117,9 @@ typedef struct _zend_jit_globals {
 	uint8_t bad_root_cache_stop[ZEND_JIT_TRACE_BAD_ROOT_SLOTS];
 	uint32_t bad_root_slot;
 
+	uint32_t function_compilation_successes;
+	uint32_t function_compilation_failures;
+
 	uint8_t  exit_counters[ZEND_JIT_TRACE_MAX_EXIT_COUNTERS];
 } zend_jit_globals;
 

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -5595,6 +5595,8 @@ static void zend_jit_trace_init_caches(void)
 	memset(JIT_G(bad_root_cache_count), 0, sizeof(JIT_G(bad_root_cache_count)));
 	memset(JIT_G(bad_root_cache_stop), 0, sizeof(JIT_G(bad_root_cache_count)));
 	JIT_G(bad_root_slot) = 0;
+	JIT_G(function_compilation_successes) = 0;
+	JIT_G(function_compilation_failures) = 0;
 
 	memset(JIT_G(exit_counters), 0, sizeof(JIT_G(exit_counters)));
 }

--- a/ext/opcache/tests/jit/opcache_get_status.phpt
+++ b/ext/opcache/tests/jit/opcache_get_status.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test JIT information in opcache_get_status
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+opcache.protect_memory=1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+var_dump(opcache_get_status()['jit'])
+
+?>
+--EXPECTF--
+array(9) {
+  ["enabled"]=>
+  bool(true)
+  ["on"]=>
+  bool(true)
+  ["kind"]=>
+  int(0)
+  ["opt_level"]=>
+  int(5)
+  ["opt_flags"]=>
+  int(6)
+  ["buffer_size"]=>
+  int(%d)
+  ["buffer_free"]=>
+  int(%d)
+  ["function_compilation_successes"]=>
+  int(1)
+  ["function_compilation_failures"]=>
+  int(0)
+}


### PR DESCRIPTION
There have been quite a few JIT benchmarks lately. It would be interesting to know how many functions actually make use of the JIT in large repositories. This PR track successes and failures and returns them in `opcache_get_status`. Naming is a little verbose, let me know if that's ok. Also, it would obviously be more useful if we knew *which* functions failed compiling but that would probably be too expensive. This PR might be too simplistic, let me know if there's something I didn't handle properly.

/ping @dstogov