### PR TITLE
Fix bug #79787 : mb_strimwidth does not trim string

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfilter.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.c
@@ -1734,13 +1734,17 @@ mbfl_strimwidth(
 		mbfl_convert_filter_flush(encoder);
 		if (pc.status != 0 && mkwidth > 0) {
 			pc.width += mkwidth;
-			while (n > 0) {
-				if ((*encoder->filter_function)(*p++, encoder) < 0) {
-					break;
+			if (n > 0) {
+				while (n > 0) {
+					if ((*encoder->filter_function)(*p++, encoder) < 0) {
+						break;
+					}
+					n--;
 				}
-				n--;
+				mbfl_convert_filter_flush(encoder);
+			} else if (pc.outwidth > pc.width) {
+				pc.status++;
 			}
-			mbfl_convert_filter_flush(encoder);
 			if (pc.status != 1) {
 				pc.status = 10;
 				pc.device.pos = pc.endpos;

--- a/ext/mbstring/tests/bug79787.phpt
+++ b/ext/mbstring/tests/bug79787.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #79787 mb_strimwidth does not trim string
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
+--FILE--
+<?php
+echo mb_strimwidth("一二三", 0, 4, '.', 'UTF-8')."\n";
+echo mb_strimwidth("一二三", 0, 5, '.', 'UTF-8')."\n";
+echo mb_strimwidth("一二三", 0, 6, '.', 'UTF-8')."\n";
+echo mb_strimwidth("abcdef", 0, 4, '.', 'UTF-8')."\n";
+echo mb_strimwidth("abcdef", 0, 5, '.', 'UTF-8')."\n";
+echo mb_strimwidth("abcdef", 0, 6, '.', 'UTF-8')."\n";
+?>
+--EXPECT--
+一.
+一二.
+一二三
+abc.
+abcd.
+abcdef


### PR DESCRIPTION
When the string end with full-width character and its width is one greater than the desired trimming width，trimmaker is alse a half-width character, which will cause mb_strimwidth not to trim.

Affects all stable versions of PHP.

Original bug: https://bugs.php.net/bug.php?id=79787