### PR TITLE
Allow declare statement w/o parentheses

### DIFF
--- a/Zend/tests/declare_wo_parentheses_001.phpt
+++ b/Zend/tests/declare_wo_parentheses_001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Testing declare w/o parentheses statement with several type values
+--INI--
+precision=15
+zend.multibyte=1
+--FILE--
+<?php
+
+declare encoding = 1;
+declare encoding = 11111111111111;
+declare encoding = M_PI;
+
+print 'DONE';
+
+?>
+--EXPECTF--
+Warning: Unsupported encoding [1] in %sdeclare_wo_parentheses_001.php on line %d
+
+Warning: Unsupported encoding [11111111111111] in %sdeclare_wo_parentheses_001.php on line %d
+
+Fatal error: Encoding must be a literal in %s on line %d

--- a/Zend/tests/declare_wo_parentheses_002.phpt
+++ b/Zend/tests/declare_wo_parentheses_002.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testing declare w/o parentheses statement strict_types
+--FILE--
+<?php
+
+declare ticks = 1;
+declare strict_types = 1;
+
+function tick_handler()
+{
+    echo "tick_handler() called\n";
+}
+
+register_tick_function('tick_handler');
+
+echo (fn(string $fizz) => $fizz . "Buzz\n")('Fizz');
+
+?>
+--EXPECT--
+tick_handler() called
+FizzBuzz
+tick_handler() called

--- a/Zend/tests/declare_wo_parentheses_003.phpt
+++ b/Zend/tests/declare_wo_parentheses_003.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Testing declare w/o parentheses statement strict_types being not first statement
+--FILE--
+<?php
+
+declare ticks = 1;
+const foo = 'bar';
+declare strict_types = 1;
+
+?>
+--EXPECTF--
+Fatal error: strict_types declaration must be the very first statement in the script in %sdeclare_wo_parentheses_003.php on line 5

--- a/Zend/tests/declare_wo_parentheses_004.phpt
+++ b/Zend/tests/declare_wo_parentheses_004.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Testing multiple declare w/o parentheses in one statement
+--FILE--
+<?php
+
+declare ticks = 1, strict_types = 1;
+
+function tick_handler()
+{
+    echo "tick_handler() called\n";
+}
+
+register_tick_function('tick_handler');
+
+echo (fn(string $fizz) => $fizz . "Buzz\n")('Fizz');
+
+?>
+--EXPECT--
+tick_handler() called
+FizzBuzz
+tick_handler() called

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -362,6 +362,9 @@ top_statement:
 	|	T_USE use_declarations ';'					{ $$ = $2; $$->attr = ZEND_SYMBOL_CLASS; }
 	|	T_USE use_type use_declarations ';'			{ $$ = $3; $$->attr = $2; }
 	|	T_CONST const_list ';'						{ $$ = $2; }
+	|	T_DECLARE const_list ';'
+			{ if (!zend_handle_encoding_declaration($2)) { YYERROR; };
+			  $$ = zend_ast_create(ZEND_AST_DECLARE, $2, NULL); }
 ;
 
 use_type:


### PR DESCRIPTION
Implements language change allowing `declare` statement to skip parentheses.
This patch implements one of the proposed changes from [Language constructs syntax changes RFC](https://wiki.php.net/rfc/language-constructs-syntax-changes#allow_skip_of_parentheses_for_declare).

In example, allows:
```php
declare strict_types = 1, ticks = 1;
declare encoding = 'ISO-8859-1';
```