### PR TITLE
Allow __halt_compiler w/o parentheses

### DIFF
--- a/Zend/tests/halt_compiler_wo_parentheses1.phpt
+++ b/Zend/tests/halt_compiler_wo_parentheses1.phpt
@@ -1,0 +1,8 @@
+--TEST--
+__HALT_COMPILER;
+--FILE--
+<?php echo 'test'; var_dump(__COMPILER_HALT_OFFSET__); __HALT_COMPILER;
+?>
+===DONE===
+--EXPECT--
+testint(71)

--- a/Zend/tests/halt_compiler_wo_parentheses2.phpt
+++ b/Zend/tests/halt_compiler_wo_parentheses2.phpt
@@ -1,0 +1,21 @@
+--TEST--
+__HALT_COMPILER; 2 files
+--FILE--
+<?php
+$text = "<?php echo 'test'; var_dump(__COMPILER_HALT_OFFSET__); __HALT_COMPILER; ?>
+hi there";
+file_put_contents(__DIR__ . '/test1.php', $text);
+$text = "<?php echo 'test2'; var_dump(__COMPILER_HALT_OFFSET__); __HALT_COMPILER; ?>
+hi there 2";
+file_put_contents(__DIR__ . '/test2.php', $text);
+include __DIR__ . '/test1.php';
+include __DIR__ . '/test2.php';
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/test1.php');
+unlink(__DIR__ . '/test2.php');
+?>
+--EXPECT--
+testint(71)
+test2int(72)


### PR DESCRIPTION
Implements language change allowing `__halt_compiler` statement to skip parentheses.
This patch implements one of the proposed changes from [Language constructs syntax changes RFC](https://wiki.php.net/rfc/language-constructs-syntax-changes#allow_to_skip_parentheses_for_compiler_halt).

In example, allows:
```php
__halt_compiler;
```