### PR TITLE
Fix bug #79783: segfault in str_replace()

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4335,7 +4335,7 @@ static void php_str_replace_common(INTERNAL_FUNCTION_PARAMETERS, int case_sensit
 		Z_PARAM_ZVAL(replace)
 		Z_PARAM_STR_OR_ARRAY_HT(subject_str, subject_ht)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_ZVAL(zcount)
+		Z_PARAM_REF(zcount)
 	ZEND_PARSE_PARAMETERS_END();
 
 	/* Make sure we're dealing with strings and do the replacement. */

--- a/ext/standard/tests/strings/bug79783.phpt
+++ b/ext/standard/tests/strings/bug79783.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #79783 (segfault in str_replace)
+--FILE--
+<?php
+
+str_replace( "", "", "", defined(1) );
+echo "fail";
+--EXPECTF--
+Fatal error: Uncaught TypeError: str_replace(): Argument #4 ($replace_count) must be a reference, bool given in %s/bug79783.php:3
+Stack trace:
+#0 %s/bug79783.php(3): str_replace('', '', '', false)
+#1 {main}
+  thrown in %s/bug79783.php on line 3


### PR DESCRIPTION
This change addresses one of two problems: that this function
crashes when passed anything but a reference as a 4th parameter.

Another problem is that it's possible to trick PHP into passing a
non-reference with defined(), but it will be addressed separately.

The solution in this change is applicable to other functions, they
will be upgraded later.