### PR TITLE
refactor: class constants parsing

### DIFF
--- a/Zend/tests/assert/expect_015.phpt
+++ b/Zend/tests/assert/expect_015.phpt
@@ -164,8 +164,8 @@ Warning: assert(): assert(0 && ($a = function () {
 
 Warning: assert(): assert(0 && ($a = function &(array &$a, ?X $b = null) use($c, &$d): ?X {
     abstract class A extends B implements C, D {
-        const X = 12;
-        const Y = self::X, Z = 'aaa';
+        public const X = 12;
+        public const Y = self::X, Z = 'aaa';
         public $a = 1, $b;
         protected $c;
         private static $d = null;

--- a/Zend/tests/attributes/012_ast_export.phpt
+++ b/Zend/tests/attributes/012_ast_export.phpt
@@ -29,7 +29,7 @@ Warning: assert(): assert(0 && ($a = <<A1(1, 2, 1 + 2)>> fn() => 1)) failed in %
 Warning: assert(): assert(0 && ($a = new <<A1>> class {
     <<A1>>
     <<A2>>
-    const FOO = 'foo';
+    public const FOO = 'foo';
     <<A2>>
     public $x;
     <<A3>>

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -797,7 +797,8 @@ attributed_class_statement:
 			{ $$ = zend_ast_create(ZEND_AST_PROP_GROUP, $2, $3, NULL);
 			  $$->attr = $1; }
 	|	method_modifiers T_CONST class_const_list ';'
-			{ $$ = zend_ast_create(ZEND_AST_CLASS_CONST_GROUP, $3, NULL); $3->attr = $1; }
+			{ $$ = zend_ast_create(ZEND_AST_CLASS_CONST_GROUP, $3, NULL);
+			  $$->attr = $1; }
 	|	method_modifiers function returns_ref identifier backup_doc_comment '(' parameter_list ')'
 		return_type backup_fn_flags method_body backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_METHOD, $3 | $1 | $12, $2, $5,


### PR DESCRIPTION
As part of my work on typed class constants, I wanted to make a separate pull request for unrelated changes.

These include:
* Moving from `ast->child[0]->attr` to `ast->attr`
* Making `zend_ast_export_ex()` export class constants' visibility
* Extracting an additional `zend_compile_class_const_group()` function