### PR TITLE
Additional test for disabled function re-declare

### DIFF
--- a/Zend/tests/bug79382_2.phpt
+++ b/Zend/tests/bug79382_2.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #79382: Cannot redeclare disabled function
+--INI--
+disable_functions=substr
+--FILE--
+<?php
+
+function substr() {
+	return 'foo';
+}
+
+var_dump(substr("bar"));
+
+?>
+--EXPECT--
+string(3) "foo"


### PR DESCRIPTION
Related to: #5473
Bug: [79382](https://bugs.php.net/bug.php?id=79382)

For disabled functions, there is currently a test:

```php
--INI--
disable_functions=strlen
--FILE--
<?php

function strlen(string $x): int {
    $len = 0;
    while (isset($x[$len])) $len++;
    return $len;
}

var_dump(strlen("foobar"));

?>
--EXPECT--
int(6)
```

This test passes, but I think PHP is still using the internal `strlen` implementation here because even if I change the user-land function declaration to return another value, the test still passes. 

This PR adds a new test that re-declares disbaled `substr` function (which has no internal optimizations). 

Thank you 🙏🏿.